### PR TITLE
Let plugins declare owned app UIs

### DIFF
--- a/docs/content/providers/web-uis.mdx
+++ b/docs/content/providers/web-uis.mdx
@@ -57,6 +57,35 @@ apps:
     authorizationPolicy: roadmap_review
 ```
 
+Or let the plugin manifest own the UI bundle and keep only the deployment binding in config:
+
+```yaml
+providers:
+  plugins:
+    roadmap_review:
+      source:
+        path: ./customer-roadmap-review/plugin/manifest.yaml
+
+apps:
+  roadmap_review:
+    plugin: roadmap_review
+    path: /create-customer-roadmap-review
+    authorizationPolicy: roadmap_review
+```
+
+With a plugin manifest like:
+
+```yaml
+kind: plugin
+source: github.com/acme/plugins/roadmap-review
+version: 1.0.0
+spec:
+  auth:
+    type: none
+  ui:
+    path: ../ui/manifest.yaml
+```
+
 Reference a published bundle in production:
 
 ```yaml

--- a/docs/content/reference/config-file.mdx
+++ b/docs/content/reference/config-file.mdx
@@ -752,7 +752,7 @@ providers:
         brandName: Acme
 ```
 
-`providers.ui` is a map of `webui` bundles. Entries may mount directly by setting `path`, or they may act as app-owned UI artifacts that are bound through the top-level `apps` block. The built-in admin UI remains available at `/admin`. Omit `providers.ui` entirely to run headless with no public UI bundles.
+`providers.ui` is a map of `webui` bundles. Entries may mount directly by setting `path`, or they may act as app-owned UI artifacts that are bound through the top-level `apps` block. When a plugin manifest declares `spec.ui`, an app binding may omit `ui` entirely and let Gestalt synthesize the mounted UI entry from the plugin-owned reference. The built-in admin UI remains available at `/admin`. Omit `providers.ui` entirely to run headless with no public UI bundles.
 
 When `authorizationPolicy` is set on a mounted UI, the referenced web UI manifest must declare `spec.routes` with non-empty `allowedRoles`, and at least one route must cover `/`.
 
@@ -770,17 +770,16 @@ When `authorizationPolicy` is set on a mounted UI, the referenced web UI manifes
 apps:
   roadmap_review:
     plugin: roadmap_review
-    ui: roadmap_review_ui
     path: /create-customer-roadmap-review
     authorizationPolicy: support_staff
 ```
 
-`apps` is a deployment-owned binding layer for plugin-backed mounted apps. Each entry references an existing `plugins.<name>` entry and an existing `providers.ui.<name>` bundle, then supplies the public path and optional shared human authorization policy for both surfaces.
+`apps` is a deployment-owned binding layer for plugin-backed mounted apps. Each entry references an existing `plugins.<name>` entry, then supplies the public path and optional shared human authorization policy for both surfaces. The UI bundle may either be named explicitly through `apps.<name>.ui`, or omitted when the referenced plugin manifest declares an owned UI through `spec.ui`.
 
 | Field | Description |
 | --- | --- |
 | `plugin` | Required plugin key from `plugins`. |
-| `ui` | Required UI key from `providers.ui`. |
+| `ui` | Optional UI key from `providers.ui`. Omit it when the plugin manifest declares `spec.ui`. |
 | `path` | Required public mount path for the app-owned UI bundle. |
 | `authorizationPolicy` | Optional shared policy from `authorization.policies` applied to both the mounted UI and referenced plugin. |
 | `disabled` | `true` to disable the app binding without removing the underlying plugin or UI entries. |
@@ -799,7 +798,7 @@ Only `connections.default` may define `params` or `discovery`. All connections i
 
 Each `providers.ui.<name>` entry must use exactly one mode: `disabled: true`, or a source mapping with exactly one loading mode: local `providers.ui.<name>.source.path` or managed `providers.ui.<name>.source.ref`. `providers.ui.<name>.source.version` is required with `providers.ui.<name>.source.ref` and invalid with `providers.ui.<name>.source.path`. `providers.ui.<name>.config` is only allowed when `providers.ui.<name>.source` is set.
 
-Each enabled `apps.<name>` entry must reference an existing enabled plugin and an existing enabled UI bundle. A given plugin or UI may be bound by at most one enabled app entry. `apps.<name>.path` must use the same path rules as a directly mounted UI, and `apps.<name>.authorizationPolicy` must reference `authorization.policies` when set.
+Each enabled `apps.<name>` entry must reference an existing enabled plugin. When `apps.<name>.ui` is set, it must reference an existing enabled UI bundle. When `apps.<name>.ui` is omitted, the referenced plugin manifest must declare `spec.ui`. A given plugin or UI may be bound by at most one enabled app entry. `apps.<name>.path` must use the same path rules as a directly mounted UI, and `apps.<name>.authorizationPolicy` must reference `authorization.policies` when set.
 
 Mounted UI bundles are served on the public listener only. The built-in admin UI remains at `/admin`.
 

--- a/docs/content/reference/plugin-manifests.mdx
+++ b/docs/content/reference/plugin-manifests.mdx
@@ -67,6 +67,51 @@ The `spec` block for a `kind: plugin` manifest describes a plugin. It supports d
 | `surfaces` | Surfaces | Spec-loaded and declarative REST surfaces. See [Surfaces](#surfaces). |
 | `defaultConnection` | string | Name of the connection to use when none is specified. |
 | `requires` | string[] | Provider source identifiers that this provider depends on. Gestalt ensures the listed providers are available before starting this provider. |
+| `ui` | OwnedUIRef | Optional owned web UI reference for app-backed plugins. |
+
+### Owned UI
+
+Plugins that back mounted apps may declare their UI artifact in the plugin manifest. Deployment config still chooses whether to mount the app, which public path to use, and which authorization policy to bind. The manifest only says which UI bundle belongs to the plugin.
+
+`spec.ui` supports two mutually exclusive forms:
+
+| Field | Type | Purpose |
+| --- | --- | --- |
+| `path` | string | Relative path to a co-packaged `kind: webui` manifest. Source releases may point at sibling UI packages; `gestaltd provider release` rewrites them into the archive automatically. |
+| `ref` | string | Managed provider source ref for the owned UI bundle. |
+| `version` | string | Optional version for `ref`. Defaults to the plugin manifest version when omitted. |
+| `auth.token` | string | Optional source token used when resolving a private managed `ref`. Only valid with `ref`. |
+
+When a deployment defines `apps.<name>` with `plugin: <plugin>` and omits `apps.<name>.ui`, Gestalt synthesizes the mounted UI binding from this block.
+
+Source-manifest example:
+
+```yaml
+kind: plugin
+source: github.com/acme/plugins/roadmap-review
+version: 1.0.0
+spec:
+  auth:
+    type: none
+  ui:
+    path: ../ui/manifest.yaml
+```
+
+Published-manifest example:
+
+```yaml
+kind: plugin
+source: github.com/acme/plugins/roadmap-review
+version: 1.0.0
+spec:
+  auth:
+    type: none
+  ui:
+    ref: github.com/acme/web/roadmap-review
+    version: 1.0.0
+    auth:
+      token: secret://roadmap-review-ui-source-token
+```
 
 ### Connections
 

--- a/gestaltd/cmd/gestaltd/plugin.go
+++ b/gestaltd/cmd/gestaltd/plugin.go
@@ -39,6 +39,7 @@ const defaultPlatforms = "darwin/amd64,darwin/arm64,linux/amd64,linux/arm64"
 const allPlatformsValue = "all"
 const defaultReleaseOutputDir = "dist/"
 const releaseBinaryPrefix = "gestalt-plugin-"
+const releaseOwnedUIRoot = "_owned_ui"
 const windowsOS = "windows"
 const windowsExecutableSuffix = ".exe"
 
@@ -392,11 +393,11 @@ func prepareBuiltPackageDir(stagingDir, sourceDir string, srcManifest *providerm
 	if err != nil {
 		return nil, releasePlatform{}, fmt.Errorf("hash binary: %w", err)
 	}
-	if err := copyReleasePackageFiles(srcManifest, sourceDir, stagingDir, false); err != nil {
-		return nil, releasePlatform{}, err
-	}
 	manifest, err := buildReleaseManifest(srcManifest, version, binaryName, buildKind, plat, digest)
 	if err != nil {
+		return nil, releasePlatform{}, err
+	}
+	if err := copyReleasePackageFiles(manifest, sourceDir, stagingDir, false); err != nil {
 		return nil, releasePlatform{}, err
 	}
 	return manifest, plat, nil
@@ -538,6 +539,9 @@ func copyReleasePackageFiles(manifest *providermanifestv1.Manifest, sourceDir, s
 	if manifest == nil {
 		return nil
 	}
+	if err := stageReleaseOwnedUI(manifest, sourceDir, stagingDir); err != nil {
+		return err
+	}
 
 	copied := make(map[string]struct{})
 	copyPath := func(rel string, optional bool) error {
@@ -607,6 +611,53 @@ func copyReleasePackageFiles(manifest *providermanifestv1.Manifest, sourceDir, s
 		}
 	}
 	return nil
+}
+
+func stageReleaseOwnedUI(manifest *providermanifestv1.Manifest, sourceDir, stagingDir string) error {
+	if manifest == nil || manifest.Kind != providermanifestv1.KindPlugin || manifest.Spec == nil || manifest.Spec.UI == nil {
+		return nil
+	}
+	ownedUI := manifest.Spec.UI
+	if strings.TrimSpace(ownedUI.Path) == "" {
+		return nil
+	}
+
+	uiManifestPath := filepath.Join(sourceDir, filepath.FromSlash(ownedUI.Path))
+	_, uiManifest, err := providerpkg.ReadSourceManifestFile(uiManifestPath)
+	if err != nil {
+		return fmt.Errorf("read owned ui manifest %s: %w", ownedUI.Path, err)
+	}
+	if err := providerpkg.RunSourceReleaseBuild(uiManifestPath, uiManifest); err != nil {
+		return fmt.Errorf("build owned ui package %s: %w", ownedUI.Path, err)
+	}
+
+	packagedManifest, err := cloneManifest(uiManifest)
+	if err != nil {
+		return fmt.Errorf("clone owned ui manifest %s: %w", ownedUI.Path, err)
+	}
+	packagedManifest.Release = nil
+
+	packagedRelPath := packagedOwnedUIManifestPath(ownedUI.Path)
+	packagedDir := filepath.Join(stagingDir, filepath.FromSlash(path.Dir(packagedRelPath)))
+	if err := copyReleasePackageFiles(packagedManifest, filepath.Dir(uiManifestPath), packagedDir, true); err != nil {
+		return fmt.Errorf("copy owned ui package %s: %w", ownedUI.Path, err)
+	}
+	if err := writeReleaseManifestFile(packagedDir, path.Base(packagedRelPath), providerpkg.ManifestFormatFromPath(uiManifestPath), packagedManifest); err != nil {
+		return fmt.Errorf("write owned ui manifest %s: %w", ownedUI.Path, err)
+	}
+
+	ownedUI.Path = packagedRelPath
+	return nil
+}
+
+func packagedOwnedUIManifestPath(rel string) string {
+	cleanRel := path.Clean(strings.ReplaceAll(rel, "\\", "/"))
+	manifestFile := path.Base(cleanRel)
+	parent := path.Base(path.Dir(cleanRel))
+	if parent == "." || parent == "/" || parent == "" {
+		return path.Join(releaseOwnedUIRoot, manifestFile)
+	}
+	return path.Join(releaseOwnedUIRoot, parent, manifestFile)
 }
 
 func validateReleaseOutputDir(manifest *providermanifestv1.Manifest, sourceDir, outputDir string) error {

--- a/gestaltd/cmd/gestaltd/plugin_test.go
+++ b/gestaltd/cmd/gestaltd/plugin_test.go
@@ -1181,6 +1181,48 @@ func TestRun_PluginReleaseCopiesWebUISupportFiles(t *testing.T) {
 	}
 }
 
+func TestRun_PluginReleaseStagesOwnedWebUIPackage(t *testing.T) {
+	t.Parallel()
+
+	pluginDir := newSourceProviderReleaseFixtureWithOwnedUI(t, t.TempDir())
+	outputDir := t.TempDir()
+	testVersion := "0.0.3-owned-ui"
+
+	runPluginReleaseCommand(t, pluginDir,
+		"--version", testVersion,
+		"--platform", runtime.GOOS+"/"+runtime.GOARCH,
+		"--output", outputDir,
+	)
+
+	archiveName := "gestalt-plugin-release-test_v" + testVersion + "_" + runtime.GOOS + "_" + runtime.GOARCH + ".tar.gz"
+	extractDir := extractReleasedArchive(t, outputDir, archiveName)
+	manifest := readReleasedManifest(t, outputDir, archiveName)
+	if manifest.Spec == nil || manifest.Spec.UI == nil {
+		t.Fatalf("released manifest spec.ui = %+v", manifest.Spec)
+	}
+	const wantOwnedUIPath = "_owned_ui/roadmap-ui/manifest.json"
+	if got := manifest.Spec.UI.Path; got != wantOwnedUIPath {
+		t.Fatalf("spec.ui.path = %q, want %q", got, wantOwnedUIPath)
+	}
+	for _, rel := range []string{
+		wantOwnedUIPath,
+		"_owned_ui/roadmap-ui/branding/icon.svg",
+		"_owned_ui/roadmap-ui/dist/index.html",
+		"_owned_ui/roadmap-ui/dist/static/app.js",
+	} {
+		if _, err := os.Stat(filepath.Join(extractDir, filepath.FromSlash(rel))); err != nil {
+			t.Fatalf("expected %s in archive: %v", rel, err)
+		}
+	}
+	_, ownedUIManifest, err := providerpkg.ReadManifestFile(filepath.Join(extractDir, filepath.FromSlash(wantOwnedUIPath)))
+	if err != nil {
+		t.Fatalf("read owned ui manifest: %v", err)
+	}
+	if ownedUIManifest.Release != nil {
+		t.Fatalf("owned ui manifest unexpectedly retained release metadata: %+v", ownedUIManifest.Release)
+	}
+}
+
 func TestRun_ProviderReleaseBuildsProviderSupportFilesBeforePackaging(t *testing.T) {
 	t.Parallel()
 
@@ -2502,6 +2544,39 @@ func newBuiltWebUIReleaseFixture(t *testing.T, dir string) string {
 	})
 	writeTestFile(t, pluginDir, releaseTestIconPath, []byte("<svg></svg>\n"), 0644)
 	writeReleaseBuildScript(t, pluginDir, filepath.Join("ui", "build.sh"), "mkdir -p out/static\nprintf '<html></html>\\n' > out/index.html\nprintf 'console.log(\"ok\")\\n' > out/static/app.js\n")
+	return pluginDir
+}
+
+func newSourceProviderReleaseFixtureWithOwnedUI(t *testing.T, dir string) string {
+	t.Helper()
+
+	pluginDir := newSourceProviderReleaseFixture(t, dir)
+	uiDir := filepath.Join(dir, "roadmap-ui")
+	if err := os.MkdirAll(uiDir, 0o755); err != nil {
+		t.Fatalf("MkdirAll(uiDir): %v", err)
+	}
+	writeReleaseTestManifest(t, uiDir, &providermanifestv1.Manifest{
+		Kind:        providermanifestv1.KindWebUI,
+		Source:      "github.com/testowner/web/roadmap-ui",
+		Version:     "0.0.1",
+		DisplayName: "Roadmap UI",
+		IconFile:    releaseTestIconPath,
+		Spec: &providermanifestv1.Spec{
+			AssetRoot: "dist",
+		},
+	})
+	writeTestFile(t, uiDir, releaseTestIconPath, []byte("<svg></svg>\n"), 0o644)
+	writeTestFile(t, uiDir, "dist/index.html", []byte("<html>roadmap</html>\n"), 0o644)
+	writeTestFile(t, uiDir, "dist/static/app.js", []byte("console.log('roadmap')\n"), 0o644)
+
+	manifestPath := filepath.Join(pluginDir, providerpkg.ManifestFile)
+	_, manifest, err := providerpkg.ReadSourceManifestFile(manifestPath)
+	if err != nil {
+		t.Fatalf("ReadSourceManifestFile(%s): %v", providerpkg.ManifestFile, err)
+	}
+	manifest.Spec.UI = &providermanifestv1.OwnedUIRef{Path: "../roadmap-ui/" + providerpkg.ManifestFile}
+	writeReleaseTestManifest(t, pluginDir, manifest)
+
 	return pluginDir
 }
 

--- a/gestaltd/internal/config/config.go
+++ b/gestaltd/internal/config/config.go
@@ -1225,8 +1225,7 @@ func applyAppBindings(cfg *Config) error {
 		return nil
 	}
 
-	appNames := mapsKeys(cfg.Apps)
-	slices.Sort(appNames)
+	appNames := slices.Sorted(maps.Keys(cfg.Apps))
 	seenPlugins := make(map[string]string, len(appNames))
 	seenUIs := make(map[string]string, len(appNames))
 	for _, appName := range appNames {
@@ -1248,9 +1247,6 @@ func applyAppBindings(cfg *Config) error {
 		if app.Plugin == "" {
 			return fmt.Errorf("config validation: apps.%s.plugin is required", appName)
 		}
-		if app.UI == "" {
-			return fmt.Errorf("config validation: apps.%s.ui is required", appName)
-		}
 		if app.Path == "" {
 			return fmt.Errorf("config validation: apps.%s.path is required", appName)
 		}
@@ -1265,16 +1261,24 @@ func applyAppBindings(cfg *Config) error {
 		if prev, exists := seenPlugins[app.Plugin]; exists && prev != appName {
 			return fmt.Errorf("config validation: apps.%s.plugin %q duplicates apps.%s", appName, app.Plugin, prev)
 		}
-		if prev, exists := seenUIs[app.UI]; exists && prev != appName {
-			return fmt.Errorf("config validation: apps.%s.ui %q duplicates apps.%s", appName, app.UI, prev)
-		}
-
 		plugin := cfg.Plugins[app.Plugin]
 		if plugin == nil {
 			return fmt.Errorf("config validation: apps.%s.plugin references unknown plugin %q", appName, app.Plugin)
 		}
 		if plugin.Disabled {
 			return fmt.Errorf("config validation: apps.%s.plugin references disabled plugin %q", appName, app.Plugin)
+		}
+		if current := strings.TrimSpace(plugin.AuthorizationPolicy); current != "" && current != app.AuthorizationPolicy {
+			return fmt.Errorf("config validation: apps.%s.plugin %q conflicts with plugins.%s.authorizationPolicy", appName, app.Plugin, app.Plugin)
+		}
+		plugin.AuthorizationPolicy = app.AuthorizationPolicy
+		seenPlugins[app.Plugin] = appName
+
+		if app.UI == "" {
+			continue
+		}
+		if prev, exists := seenUIs[app.UI]; exists && prev != appName {
+			return fmt.Errorf("config validation: apps.%s.ui %q duplicates apps.%s", appName, app.UI, prev)
 		}
 		ui := cfg.Providers.UI[app.UI]
 		if ui == nil {
@@ -1283,20 +1287,14 @@ func applyAppBindings(cfg *Config) error {
 		if ui.Disabled {
 			return fmt.Errorf("config validation: apps.%s.ui references disabled ui %q", appName, app.UI)
 		}
-		if current := strings.TrimSpace(plugin.AuthorizationPolicy); current != "" && current != app.AuthorizationPolicy {
-			return fmt.Errorf("config validation: apps.%s.plugin %q conflicts with plugins.%s.authorizationPolicy", appName, app.Plugin, app.Plugin)
-		}
 		if current := strings.TrimSpace(ui.AuthorizationPolicy); current != "" && current != app.AuthorizationPolicy {
 			return fmt.Errorf("config validation: apps.%s.ui %q conflicts with providers.ui.%s.authorizationPolicy", appName, app.UI, app.UI)
 		}
 		if current := strings.TrimSpace(ui.Path); current != "" && current != app.Path {
 			return fmt.Errorf("config validation: apps.%s.ui %q conflicts with providers.ui.%s.path", appName, app.UI, app.UI)
 		}
-
-		plugin.AuthorizationPolicy = app.AuthorizationPolicy
 		ui.AuthorizationPolicy = app.AuthorizationPolicy
 		ui.Path = app.Path
-		seenPlugins[app.Plugin] = appName
 		seenUIs[app.UI] = appName
 	}
 

--- a/gestaltd/internal/config/config_validate.go
+++ b/gestaltd/internal/config/config_validate.go
@@ -2,7 +2,9 @@ package config
 
 import (
 	"fmt"
+	"maps"
 	"net"
+	"slices"
 	"sort"
 	"strconv"
 	"strings"
@@ -512,37 +514,53 @@ func validateMountedUICollisions(cfg *Config) error {
 		"/health",
 		"/ready",
 	}
-	names := mapsKeys(cfg.Providers.UI)
-	sort.Strings(names)
-	for i, name := range names {
+	type mountedPathSubject struct {
+		label string
+		path  string
+	}
+	subjects := make([]mountedPathSubject, 0, len(cfg.Providers.UI)+len(cfg.Apps))
+	names := slices.Sorted(maps.Keys(cfg.Providers.UI))
+	for _, name := range names {
 		entry := cfg.Providers.UI[name]
 		if entry == nil || entry.Disabled || strings.TrimSpace(entry.Path) == "" {
 			continue
 		}
-		if entry.Path == "/" {
-			for _, otherName := range names[i+1:] {
-				other := cfg.Providers.UI[otherName]
-				if other == nil || other.Disabled {
-					continue
-				}
-				if other.Path == "/" {
-					return fmt.Errorf("config validation: ui.%s.path %q conflicts with ui.%s.path %q", name, entry.Path, otherName, other.Path)
+		subjects = append(subjects, mountedPathSubject{
+			label: "ui." + name + ".path",
+			path:  entry.Path,
+		})
+	}
+	appNames := slices.Sorted(maps.Keys(cfg.Apps))
+	for _, name := range appNames {
+		app := cfg.Apps[name]
+		if app == nil || app.Disabled || strings.TrimSpace(app.UI) != "" || strings.TrimSpace(app.Path) == "" {
+			continue
+		}
+		if ui := cfg.Providers.UI[name]; ui != nil && !ui.Disabled && strings.TrimSpace(ui.Path) != "" {
+			continue
+		}
+		subjects = append(subjects, mountedPathSubject{
+			label: "apps." + name + ".path",
+			path:  app.Path,
+		})
+	}
+	for i, subject := range subjects {
+		if subject.path == "/" {
+			for _, other := range subjects[i+1:] {
+				if other.path == "/" {
+					return fmt.Errorf("config validation: %s %q conflicts with %s %q", subject.label, subject.path, other.label, other.path)
 				}
 			}
 			continue
 		}
 		for _, reservedPath := range reserved {
-			if mountedUIPathsConflict(entry.Path, reservedPath) {
-				return fmt.Errorf("config validation: ui.%s.path %q conflicts with reserved path %q", name, entry.Path, reservedPath)
+			if mountedUIPathsConflict(subject.path, reservedPath) {
+				return fmt.Errorf("config validation: %s %q conflicts with reserved path %q", subject.label, subject.path, reservedPath)
 			}
 		}
-		for _, otherName := range names[i+1:] {
-			other := cfg.Providers.UI[otherName]
-			if other == nil || other.Disabled || strings.TrimSpace(other.Path) == "" {
-				continue
-			}
-			if mountedUIPathsConflict(entry.Path, other.Path) {
-				return fmt.Errorf("config validation: ui.%s.path %q conflicts with ui.%s.path %q", name, entry.Path, otherName, other.Path)
+		for _, other := range subjects[i+1:] {
+			if mountedUIPathsConflict(subject.path, other.path) {
+				return fmt.Errorf("config validation: %s %q conflicts with %s %q", subject.label, subject.path, other.label, other.path)
 			}
 		}
 	}
@@ -558,23 +576,17 @@ func mountedUIPathsConflict(a, b string) bool {
 
 func appReferencedUIs(cfg *Config) map[string]struct{} {
 	refs := make(map[string]struct{}, len(cfg.Apps))
-	for _, app := range cfg.Apps {
+	for name, app := range cfg.Apps {
 		if app == nil || app.Disabled {
 			continue
 		}
 		if ui := strings.TrimSpace(app.UI); ui != "" {
 			refs[ui] = struct{}{}
+			continue
 		}
+		refs[name] = struct{}{}
 	}
 	return refs
-}
-
-func mapsKeys[V any](m map[string]V) []string {
-	keys := make([]string, 0, len(m))
-	for k := range m {
-		keys = append(keys, k)
-	}
-	return keys
 }
 
 type inlineConnectionReference struct {

--- a/gestaltd/internal/operator/lifecycle.go
+++ b/gestaltd/internal/operator/lifecycle.go
@@ -8,10 +8,13 @@ import (
 	"encoding/json"
 	"fmt"
 	"log/slog"
+	"maps"
 	"net/http"
 	"os"
 	"path/filepath"
+	"slices"
 	"strconv"
+	"strings"
 
 	"github.com/valon-technologies/gestalt/server/internal/config"
 	"github.com/valon-technologies/gestalt/server/internal/pluginsource"
@@ -168,6 +171,12 @@ func (l *Lifecycle) initAtPath(configPath, artifactsDir string) (*Lockfile, *con
 			lockEntriesForKind(lock, collection.kind)[name] = lockEntry
 		}
 	}
+	if err := l.resolveConfiguredPlugins(paths, lock, cfg, true); err != nil {
+		return nil, nil, err
+	}
+	if err := synthesizeAppOwnedUIEntries(cfg); err != nil {
+		return nil, nil, err
+	}
 	for name, lockEntry := range secretsEntries {
 		lock.Secrets[name] = lockEntry
 	}
@@ -249,6 +258,9 @@ func (l *Lifecycle) LoadForExecutionAtPath(configPath string, locked bool) (*con
 func (l *Lifecycle) LoadForExecutionAtPathWithArtifactsDir(configPath, artifactsDir string, locked bool) (*config.Config, map[string]string, error) {
 	cfg, err := config.Load(configPath)
 	if err != nil {
+		return nil, nil, fmt.Errorf("loading config: %v", err)
+	}
+	if err := synthesizeLocalSourceAppOwnedUIEntries(cfg); err != nil {
 		return nil, nil, fmt.Errorf("loading config: %v", err)
 	}
 	paths := initPathsForConfigWithArtifactsDir(configPath, resolveArtifactsDir(configPath, cfg, artifactsDir))
@@ -1025,8 +1037,16 @@ func (l *Lifecycle) applyLockedProviders(configPath, artifactsDir string, cfg *c
 	var lock *Lockfile
 	var err error
 	if configHasManagedProviderSources(cfg) {
+		var synthesizedLockedAppUIs map[string]struct{}
 		lock, err = ReadLockfile(paths.lockfilePath)
+		if err == nil {
+			synthesizedLockedAppUIs, err = synthesizeLockedSourceAppOwnedUIEntries(cfg, paths, lock)
+			if err != nil {
+				clearSynthesizedAppOwnedUIEntries(cfg, synthesizedLockedAppUIs)
+			}
+		}
 		if !locked && (err != nil || !lockMatchesConfig(cfg, paths, lock)) {
+			clearSynthesizedAppOwnedUIEntries(cfg, synthesizedLockedAppUIs)
 			lock, err = l.InitAtPathWithArtifactsDir(configPath, artifactsDir)
 		}
 		if err != nil {
@@ -1034,31 +1054,11 @@ func (l *Lifecycle) applyLockedProviders(configPath, artifactsDir string, cfg *c
 		}
 	}
 
-	for name, entry := range cfg.Plugins {
-		if entry == nil {
-			continue
-		}
-		configMap, err := config.NodeToMap(entry.Config)
-		if err != nil {
-			return fmt.Errorf("decode provider config for provider %q: %w", name, err)
-		}
-		switch {
-		case entry.HasManagedSource():
-			if err := l.applyLockedProviderEntry(paths, lock, name, entry, configMap, locked); err != nil {
-				return err
-			}
-		case entry.HasLocalSource():
-			if err := applyLocalProviderManifest(name, entry, configMap); err != nil {
-				return err
-			}
-		default:
-			continue
-		}
-		if manifest := entry.ResolvedManifest; manifest != nil {
-			entry.DisplayName = cmp.Or(entry.DisplayName, manifest.DisplayName)
-			entry.Description = cmp.Or(entry.Description, manifest.Description)
-		}
-		entry.IconFile = cmp.Or(entry.IconFile, entry.ResolvedIconFile)
+	if err := l.resolveConfiguredPlugins(paths, lock, cfg, locked); err != nil {
+		return err
+	}
+	if err := synthesizeAppOwnedUIEntries(cfg); err != nil {
+		return err
 	}
 	for _, collection := range hostProviderCollections(cfg) {
 		lockEntries := lockEntriesForKind(lock, collection.kind)
@@ -1099,6 +1099,266 @@ func (l *Lifecycle) applyLockedProviders(configPath, artifactsDir string, cfg *c
 		entry.ResolvedAssetRoot = resolvedAssetRoot
 	}
 
+	return nil
+}
+
+func (l *Lifecycle) resolveConfiguredPlugins(paths initPaths, lock *Lockfile, cfg *config.Config, locked bool) error {
+	for name, entry := range cfg.Plugins {
+		if entry == nil {
+			continue
+		}
+		configMap, err := config.NodeToMap(entry.Config)
+		if err != nil {
+			return fmt.Errorf("decode provider config for provider %q: %w", name, err)
+		}
+		switch {
+		case entry.HasManagedSource():
+			if err := l.applyLockedProviderEntry(paths, lock, name, entry, configMap, locked); err != nil {
+				return err
+			}
+		case entry.HasLocalSource():
+			if err := applyLocalProviderManifest(name, entry, configMap); err != nil {
+				return err
+			}
+		default:
+			continue
+		}
+		if manifest := entry.ResolvedManifest; manifest != nil {
+			entry.DisplayName = cmp.Or(entry.DisplayName, manifest.DisplayName)
+			entry.Description = cmp.Or(entry.Description, manifest.Description)
+		}
+		entry.IconFile = cmp.Or(entry.IconFile, entry.ResolvedIconFile)
+	}
+	return nil
+}
+
+func synthesizeAppOwnedUIEntries(cfg *config.Config) error {
+	if cfg == nil || len(cfg.Apps) == 0 {
+		return nil
+	}
+	if cfg.Providers.UI == nil {
+		cfg.Providers.UI = map[string]*config.UIEntry{}
+	}
+
+	appNames := slices.Sorted(maps.Keys(cfg.Apps))
+	for _, appName := range appNames {
+		app := cfg.Apps[appName]
+		if app == nil || app.Disabled || strings.TrimSpace(app.UI) != "" {
+			continue
+		}
+		pluginName := strings.TrimSpace(app.Plugin)
+		plugin := cfg.Plugins[pluginName]
+		if plugin == nil {
+			return fmt.Errorf("config validation: apps.%s.plugin references unknown plugin %q", appName, pluginName)
+		}
+		manifestSpec := plugin.ManifestSpec()
+		if manifestSpec == nil || manifestSpec.UI == nil {
+			return fmt.Errorf("app %q plugin %q does not declare spec.ui", appName, pluginName)
+		}
+		ownedUI := manifestSpec.UI
+		entry, err := ownedUIEntryForPlugin(plugin, ownedUI)
+		if err != nil {
+			return fmt.Errorf("app %q plugin %q ui: %w", appName, pluginName, err)
+		}
+		entry.Path = strings.TrimSpace(app.Path)
+		entry.AuthorizationPolicy = strings.TrimSpace(app.AuthorizationPolicy)
+		if existing := cfg.Providers.UI[appName]; existing != nil {
+			if err := validateSynthesizedAppUIEntry(appName, existing, entry); err != nil {
+				return err
+			}
+			if existing.Source.Auth == nil && entry.Source.Auth != nil {
+				existing.Source.Auth = entry.Source.Auth
+			}
+			existing.Path = cmp.Or(existing.Path, entry.Path)
+			existing.AuthorizationPolicy = cmp.Or(existing.AuthorizationPolicy, entry.AuthorizationPolicy)
+			continue
+		}
+		cfg.Providers.UI[appName] = entry
+	}
+	return nil
+}
+
+func synthesizeLocalSourceAppOwnedUIEntries(cfg *config.Config) error {
+	if cfg == nil || len(cfg.Apps) == 0 {
+		return nil
+	}
+	if cfg.Providers.UI == nil {
+		cfg.Providers.UI = map[string]*config.UIEntry{}
+	}
+	appNames := slices.Sorted(maps.Keys(cfg.Apps))
+	for _, appName := range appNames {
+		app := cfg.Apps[appName]
+		if app == nil || app.Disabled || strings.TrimSpace(app.UI) != "" {
+			continue
+		}
+		pluginName := strings.TrimSpace(app.Plugin)
+		plugin := cfg.Plugins[pluginName]
+		if plugin == nil || !plugin.HasLocalSource() {
+			continue
+		}
+		manifestPath := plugin.SourcePath()
+		if manifestPath == "" {
+			continue
+		}
+		_, manifest, err := providerpkg.ReadSourceManifestFile(manifestPath)
+		if err != nil {
+			return fmt.Errorf("prepare manifest for provider %q: %w", pluginName, err)
+		}
+		if manifest == nil || manifest.Spec == nil || manifest.Spec.UI == nil {
+			continue
+		}
+		entry, err := ownedUIEntryFromManifest(manifestPath, manifest.Version, manifest.Spec.UI)
+		if err != nil {
+			return fmt.Errorf("app %q plugin %q ui: %w", appName, pluginName, err)
+		}
+		entry.Path = strings.TrimSpace(app.Path)
+		entry.AuthorizationPolicy = strings.TrimSpace(app.AuthorizationPolicy)
+		if existing := cfg.Providers.UI[appName]; existing != nil {
+			if err := validateSynthesizedAppUIEntry(appName, existing, entry); err != nil {
+				return err
+			}
+			if existing.Source.Auth == nil && entry.Source.Auth != nil {
+				existing.Source.Auth = entry.Source.Auth
+			}
+			existing.Path = cmp.Or(existing.Path, entry.Path)
+			existing.AuthorizationPolicy = cmp.Or(existing.AuthorizationPolicy, entry.AuthorizationPolicy)
+			continue
+		}
+		cfg.Providers.UI[appName] = entry
+	}
+	return nil
+}
+
+func synthesizeLockedSourceAppOwnedUIEntries(cfg *config.Config, paths initPaths, lock *Lockfile) (map[string]struct{}, error) {
+	added := map[string]struct{}{}
+	if cfg == nil || len(cfg.Apps) == 0 || lock == nil {
+		return added, nil
+	}
+	if cfg.Providers.UI == nil {
+		cfg.Providers.UI = map[string]*config.UIEntry{}
+	}
+	appNames := slices.Sorted(maps.Keys(cfg.Apps))
+	for _, appName := range appNames {
+		app := cfg.Apps[appName]
+		if app == nil || app.Disabled || strings.TrimSpace(app.UI) != "" {
+			continue
+		}
+		pluginName := strings.TrimSpace(app.Plugin)
+		plugin := cfg.Plugins[pluginName]
+		if plugin == nil || !plugin.HasManagedSource() {
+			continue
+		}
+		lockEntry, ok := lock.Providers[pluginName]
+		if !ok || strings.TrimSpace(lockEntry.Manifest) == "" {
+			continue
+		}
+		manifestPath := resolveLockPath(paths.artifactsDir, lockEntry.Manifest)
+		_, manifest, err := providerpkg.ReadManifestFile(manifestPath)
+		if err != nil {
+			return added, fmt.Errorf("prepare manifest for provider %q: %w", pluginName, err)
+		}
+		if manifest == nil || manifest.Spec == nil || manifest.Spec.UI == nil {
+			continue
+		}
+		entry, err := ownedUIEntryFromManifest(manifestPath, manifest.Version, manifest.Spec.UI)
+		if err != nil {
+			return added, fmt.Errorf("app %q plugin %q ui: %w", appName, pluginName, err)
+		}
+		entry.Path = strings.TrimSpace(app.Path)
+		entry.AuthorizationPolicy = strings.TrimSpace(app.AuthorizationPolicy)
+		if existing := cfg.Providers.UI[appName]; existing != nil {
+			if err := validateSynthesizedAppUIEntry(appName, existing, entry); err != nil {
+				return added, err
+			}
+			if existing.Source.Auth == nil && entry.Source.Auth != nil {
+				existing.Source.Auth = entry.Source.Auth
+			}
+			existing.Path = cmp.Or(existing.Path, entry.Path)
+			existing.AuthorizationPolicy = cmp.Or(existing.AuthorizationPolicy, entry.AuthorizationPolicy)
+			continue
+		}
+		cfg.Providers.UI[appName] = entry
+		added[appName] = struct{}{}
+	}
+	return added, nil
+}
+
+func clearSynthesizedAppOwnedUIEntries(cfg *config.Config, added map[string]struct{}) {
+	if cfg == nil || len(added) == 0 || cfg.Providers.UI == nil {
+		return
+	}
+	for name := range added {
+		delete(cfg.Providers.UI, name)
+	}
+}
+
+func ownedUIEntryForPlugin(plugin *config.ProviderEntry, ownedUI *providermanifestv1.OwnedUIRef) (*config.UIEntry, error) {
+	if plugin == nil || ownedUI == nil {
+		return nil, fmt.Errorf("owned ui definition is required")
+	}
+	manifestVersion := plugin.SourceVersion()
+	if plugin.ResolvedManifest != nil {
+		manifestVersion = cmp.Or(plugin.ResolvedManifest.Version, manifestVersion)
+	}
+	return ownedUIEntryFromManifest(plugin.ResolvedManifestPath, manifestVersion, ownedUI)
+}
+
+func ownedUIEntryFromManifest(manifestPath, manifestVersion string, ownedUI *providermanifestv1.OwnedUIRef) (*config.UIEntry, error) {
+	if ownedUI == nil {
+		return nil, fmt.Errorf("owned ui definition is required")
+	}
+	entry := &config.UIEntry{}
+	switch {
+	case strings.TrimSpace(ownedUI.Ref) != "":
+		entry.Source.Ref = strings.TrimSpace(ownedUI.Ref)
+		entry.Source.Version = cmp.Or(strings.TrimSpace(ownedUI.Version), manifestVersion)
+		if ownedUI.Auth != nil {
+			entry.Source.Auth = &config.SourceAuthDef{Token: strings.TrimSpace(ownedUI.Auth.Token)}
+		}
+	case strings.TrimSpace(ownedUI.Path) != "":
+		if strings.TrimSpace(manifestPath) == "" {
+			return nil, fmt.Errorf("resolved plugin manifest path is required for spec.ui.path")
+		}
+		entry.Source.Path = filepath.Clean(filepath.Join(filepath.Dir(manifestPath), filepath.FromSlash(ownedUI.Path)))
+	default:
+		return nil, fmt.Errorf("spec.ui.path or spec.ui.ref is required")
+	}
+	return entry, nil
+}
+
+func validateSynthesizedAppUIEntry(appName string, existing, expected *config.UIEntry) error {
+	if existing == nil || expected == nil {
+		return nil
+	}
+	if existing.Disabled {
+		return fmt.Errorf("config validation: apps.%s owned ui conflicts with disabled providers.ui.%s", appName, appName)
+	}
+	if current := strings.TrimSpace(existing.Source.Ref); current != "" && current != expected.Source.Ref {
+		return fmt.Errorf("config validation: apps.%s owned ui conflicts with providers.ui.%s.source.ref", appName, appName)
+	}
+	if current := strings.TrimSpace(existing.Source.Version); current != "" && current != expected.Source.Version {
+		return fmt.Errorf("config validation: apps.%s owned ui conflicts with providers.ui.%s.source.version", appName, appName)
+	}
+	currentAuth := ""
+	if existing.Source.Auth != nil {
+		currentAuth = strings.TrimSpace(existing.Source.Auth.Token)
+	}
+	expectedAuth := ""
+	if expected.Source.Auth != nil {
+		expectedAuth = strings.TrimSpace(expected.Source.Auth.Token)
+	}
+	if currentAuth != "" && currentAuth != expectedAuth {
+		return fmt.Errorf("config validation: apps.%s owned ui conflicts with providers.ui.%s.source.auth.token", appName, appName)
+	}
+	if current := strings.TrimSpace(existing.Source.Path); current != "" && current != expected.Source.Path {
+		return fmt.Errorf("config validation: apps.%s owned ui conflicts with providers.ui.%s.source.path", appName, appName)
+	}
+	if current := strings.TrimSpace(existing.Path); current != "" && current != expected.Path {
+		return fmt.Errorf("config validation: apps.%s.path %q conflicts with providers.ui.%s.path", appName, expected.Path, appName)
+	}
+	if current := strings.TrimSpace(existing.AuthorizationPolicy); current != "" && current != expected.AuthorizationPolicy {
+		return fmt.Errorf("config validation: apps.%s.authorizationPolicy conflicts with providers.ui.%s.authorizationPolicy", appName, appName)
+	}
 	return nil
 }
 

--- a/gestaltd/internal/operator/lifecycle_test.go
+++ b/gestaltd/internal/operator/lifecycle_test.go
@@ -1,6 +1,8 @@
 package operator
 
 import (
+	"archive/tar"
+	"compress/gzip"
 	"context"
 	"crypto/sha256"
 	"encoding/hex"
@@ -31,6 +33,63 @@ type staticSourceResolver struct {
 func (r staticSourceResolver) Resolve(context.Context, pluginsource.Source, string) (*pluginsource.ResolvedPackage, error) {
 	return &pluginsource.ResolvedPackage{
 		LocalPath: r.localPath,
+		Cleanup:   func() {},
+	}, nil
+}
+
+type mappedSourceResolver struct {
+	paths map[string]string
+}
+
+func (r mappedSourceResolver) Resolve(_ context.Context, src pluginsource.Source, _ string) (*pluginsource.ResolvedPackage, error) {
+	localPath, ok := r.paths[src.String()]
+	if !ok {
+		return nil, fmt.Errorf("no test package for %s", src.String())
+	}
+	return &pluginsource.ResolvedPackage{
+		LocalPath: localPath,
+		Cleanup:   func() {},
+	}, nil
+}
+
+type authMappedSourceResolver struct {
+	paths  map[string]string
+	tokens map[string]string
+}
+
+func (r authMappedSourceResolver) Resolve(_ context.Context, src pluginsource.Source, _ string) (*pluginsource.ResolvedPackage, error) {
+	if wantToken, ok := r.tokens[src.String()]; ok && src.Token != wantToken {
+		return nil, fmt.Errorf("source %s token = %q, want %q", src.String(), src.Token, wantToken)
+	}
+	localPath, ok := r.paths[src.String()]
+	if !ok {
+		return nil, fmt.Errorf("no test package for %s", src.String())
+	}
+	return &pluginsource.ResolvedPackage{
+		LocalPath: localPath,
+		Cleanup:   func() {},
+	}, nil
+}
+
+type versionedSourceResolver struct {
+	paths  map[string]map[string]string
+	tokens map[string]string
+}
+
+func (r versionedSourceResolver) Resolve(_ context.Context, src pluginsource.Source, version string) (*pluginsource.ResolvedPackage, error) {
+	if wantToken, ok := r.tokens[src.String()]; ok && src.Token != wantToken {
+		return nil, fmt.Errorf("source %s token = %q, want %q", src.String(), src.Token, wantToken)
+	}
+	versions, ok := r.paths[src.String()]
+	if !ok {
+		return nil, fmt.Errorf("no test package for %s", src.String())
+	}
+	localPath, ok := versions[version]
+	if !ok {
+		return nil, fmt.Errorf("no test package for %s version %s", src.String(), version)
+	}
+	return &pluginsource.ResolvedPackage{
+		LocalPath: localPath,
 		Cleanup:   func() {},
 	}, nil
 }
@@ -246,8 +305,10 @@ func TestLoadForExecutionAtPath_ResolvesLocalMountedWebUIWithoutLockfile(t *test
 		name         string
 		uiConfigYAML string
 		extraYAML    string
+		uiKey        string
 		wantPath     string
 		wantPolicy   string
+		ownedUIPath  string
 		wantErr      string
 	}{
 		{
@@ -258,6 +319,7 @@ func TestLoadForExecutionAtPath_ResolvesLocalMountedWebUIWithoutLockfile(t *test
         path: ./webui/manifest.yaml
       path: /create-customer-roadmap-review
 `,
+			uiKey:    "roadmap",
 			wantPath: "/create-customer-roadmap-review",
 		},
 		{
@@ -285,11 +347,12 @@ authorization:
         - email: viewer@example.test
           role: viewer
 `,
+			uiKey:      "roadmap",
 			wantPath:   "/create-customer-roadmap-review",
 			wantPolicy: "roadmap_policy",
 		},
 		{
-			name: "disabled app binding does not suppress ui path validation",
+			name: "disabled explicit app binding does not suppress ui path validation",
 			uiConfigYAML: `  ui:
     roadmap:
       source:
@@ -303,6 +366,7 @@ authorization:
       source:
         path: ./plugin/manifest.yaml
 `,
+			uiKey: "roadmap",
 			extraYAML: `apps:
   roadmap_review:
     disabled: true
@@ -312,6 +376,98 @@ authorization:
     authorizationPolicy: roadmap_policy
 `,
 			wantErr: "config validation: ui.roadmap.path: path is required",
+		},
+		{
+			name: "disabled app does not suppress matching ui path validation",
+			uiConfigYAML: `  ui:
+    roadmap_review:
+      source:
+        path: ./webui/manifest.yaml
+  plugins:
+    roadmap:
+      source:
+        path: ./plugin/manifest.yaml
+`,
+			extraYAML: `apps:
+  roadmap_review:
+    disabled: true
+    plugin: roadmap
+`,
+			wantErr: "config validation: ui.roadmap_review.path: path is required",
+		},
+		{
+			name: "plugin owned ui via app binding",
+			uiConfigYAML: `  plugins:
+    roadmap:
+      source:
+        path: ./plugin/manifest.yaml
+`,
+			extraYAML: `apps:
+  roadmap_review:
+    plugin: roadmap
+    path: /create-customer-roadmap-review
+    authorizationPolicy: roadmap_policy
+authorization:
+  policies:
+    roadmap_policy:
+      default: deny
+      members:
+        - email: viewer@example.test
+          role: viewer
+`,
+			uiKey:       "roadmap_review",
+			wantPath:    "/create-customer-roadmap-review",
+			wantPolicy:  "roadmap_policy",
+			ownedUIPath: "../webui/manifest.yaml",
+		},
+		{
+			name: "plugin owned ui with same-name ui overlay",
+			uiConfigYAML: `  ui:
+    roadmap_review:
+      source:
+        path: ./webui/manifest.yaml
+  plugins:
+    roadmap:
+      source:
+        path: ./plugin/manifest.yaml
+`,
+			extraYAML: `apps:
+  roadmap_review:
+    plugin: roadmap
+    path: /create-customer-roadmap-review
+    authorizationPolicy: roadmap_policy
+authorization:
+  policies:
+    roadmap_policy:
+      default: deny
+      members:
+        - email: viewer@example.test
+          role: viewer
+`,
+			uiKey:       "roadmap_review",
+			wantPath:    "/create-customer-roadmap-review",
+			wantPolicy:  "roadmap_policy",
+			ownedUIPath: "../webui/manifest.yaml",
+		},
+		{
+			name: "disabled same-name ui overlay is rejected",
+			uiConfigYAML: `  ui:
+    roadmap_review:
+      disabled: true
+      source:
+        path: ./webui/manifest.yaml
+  plugins:
+    roadmap:
+      source:
+        path: ./plugin/manifest.yaml
+`,
+			extraYAML: `apps:
+  roadmap_review:
+    plugin: roadmap
+    path: /create-customer-roadmap-review
+`,
+			wantErr:     "config validation: apps.roadmap_review owned ui conflicts with disabled providers.ui.roadmap_review",
+			ownedUIPath: "../webui/manifest.yaml",
 		},
 	}
 
@@ -348,19 +504,23 @@ authorization:
 			if err := os.WriteFile(manifestPath, manifest, 0o644); err != nil {
 				t.Fatalf("WriteFile manifest: %v", err)
 			}
-			if tc.extraYAML != "" {
+			if tc.extraYAML != "" || tc.ownedUIPath != "" {
 				pluginManifestPath := filepath.Join(dir, "plugin", "manifest.yaml")
 				if err := os.MkdirAll(filepath.Dir(pluginManifestPath), 0o755); err != nil {
 					t.Fatalf("MkdirAll plugin dir: %v", err)
+				}
+				pluginSpec := &providermanifestv1.Spec{
+					Auth: &providermanifestv1.ProviderAuth{Type: providermanifestv1.AuthTypeNone},
+				}
+				if tc.ownedUIPath != "" {
+					pluginSpec.UI = &providermanifestv1.OwnedUIRef{Path: tc.ownedUIPath}
 				}
 				pluginManifest, err := providerpkg.EncodeSourceManifestFormat(&providermanifestv1.Manifest{
 					Source:      "github.com/testowner/plugins/roadmap",
 					Version:     "0.0.1-alpha.1",
 					DisplayName: "Roadmap Plugin",
 					Kind:        providermanifestv1.KindPlugin,
-					Spec: &providermanifestv1.Spec{
-						Auth: &providermanifestv1.ProviderAuth{Type: providermanifestv1.AuthTypeNone},
-					},
+					Spec:        pluginSpec,
 				}, providerpkg.ManifestFormatYAML)
 				if err != nil {
 					t.Fatalf("EncodePluginManifest: %v", err)
@@ -396,9 +556,9 @@ authorization:
 				t.Fatalf("LoadForExecutionAtPath: %v", err)
 			}
 
-			entry := loaded.Providers.UI["roadmap"]
+			entry := loaded.Providers.UI[tc.uiKey]
 			if entry == nil {
-				t.Fatal(`Providers.UI["roadmap"] = nil`)
+				t.Fatalf(`Providers.UI[%q] = nil`, tc.uiKey)
 			}
 			if entry.ResolvedManifest == nil {
 				t.Fatal("ResolvedManifest = nil")
@@ -429,6 +589,434 @@ authorization:
 				t.Fatalf("lockfile should not be created, got err=%v", err)
 			}
 		})
+	}
+}
+
+func TestLoadForExecutionAtPath_ReinitializesManagedPluginOwnedUIWhenUILockEntryIsMissing(t *testing.T) {
+	t.Parallel()
+
+	dir := t.TempDir()
+	const pluginRef = "github.com/testowner/plugins/roadmap"
+	const webUIRef = "github.com/testowner/web/roadmap-review"
+	const version = "0.0.1-alpha.1"
+
+	webUIPkg := mustBuildManagedProviderPackage(t, dir, &providermanifestv1.Manifest{
+		Kind:        providermanifestv1.KindWebUI,
+		Source:      webUIRef,
+		Version:     version,
+		DisplayName: "Roadmap Review UI",
+		Spec: &providermanifestv1.Spec{
+			AssetRoot: "dist",
+		},
+	}, map[string]string{
+		"dist/index.html": "<html>roadmap review</html>",
+	}, false)
+
+	pluginPkg := mustBuildManagedProviderPackage(t, dir, &providermanifestv1.Manifest{
+		Kind:        providermanifestv1.KindPlugin,
+		Source:      pluginRef,
+		Version:     version,
+		DisplayName: "Roadmap Review",
+		Entrypoint: &providermanifestv1.Entrypoint{
+			ArtifactPath: filepath.ToSlash(filepath.Join("artifacts", runtime.GOOS, runtime.GOARCH, "plugin")),
+		},
+		Spec: &providermanifestv1.Spec{
+			Auth: &providermanifestv1.ProviderAuth{Type: providermanifestv1.AuthTypeNone},
+			UI: &providermanifestv1.OwnedUIRef{
+				Ref:     webUIRef,
+				Version: version,
+				Auth:    &providermanifestv1.SourceAuth{Token: "owned-ui-token"},
+			},
+		},
+	}, map[string]string{
+		filepath.ToSlash(filepath.Join("artifacts", runtime.GOOS, runtime.GOARCH, "plugin")): "plugin-binary",
+	}, true)
+
+	cfgPath := filepath.Join(dir, "config.yaml")
+	cfg := requiredComponentConfigYAML(t, dir, filepath.Join(dir, "gestalt.db")) + `  ui:
+    roadmap_review:
+      source:
+        ref: ` + webUIRef + `
+        version: ` + version + `
+      path: /create-customer-roadmap-review
+  plugins:
+    roadmap:
+      source:
+        ref: ` + pluginRef + `
+        version: ` + version + `
+` + `server:
+` + requiredServerDatastoreYAML() + `  encryptionKey: aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa
+apps:
+  roadmap_review:
+    plugin: roadmap
+    path: /create-customer-roadmap-review
+`
+	if err := os.WriteFile(cfgPath, []byte(cfg), 0o644); err != nil {
+		t.Fatalf("WriteFile config: %v", err)
+	}
+
+	lc := NewLifecycle(authMappedSourceResolver{
+		paths: map[string]string{
+			pluginRef: pluginPkg,
+			webUIRef:  webUIPkg,
+		},
+		tokens: map[string]string{
+			webUIRef: "owned-ui-token",
+		},
+	})
+	lock, err := lc.InitAtPath(cfgPath)
+	if err != nil {
+		t.Fatalf("InitAtPath: %v", err)
+	}
+	delete(lock.UIs, "roadmap_review")
+	if err := WriteLockfile(filepath.Join(dir, InitLockfileName), lock); err != nil {
+		t.Fatalf("WriteLockfile: %v", err)
+	}
+
+	loaded, _, err := lc.LoadForExecutionAtPath(cfgPath, false)
+	if err != nil {
+		t.Fatalf("LoadForExecutionAtPath: %v", err)
+	}
+	entry := loaded.Providers.UI["roadmap_review"]
+	if entry == nil || entry.ResolvedManifest == nil {
+		t.Fatalf("Resolved app-owned UI = %+v", entry)
+	}
+	if entry.Path != "/create-customer-roadmap-review" {
+		t.Fatalf("entry.Path = %q", entry.Path)
+	}
+
+	rewrittenLock, err := ReadLockfile(filepath.Join(dir, InitLockfileName))
+	if err != nil {
+		t.Fatalf("ReadLockfile: %v", err)
+	}
+	if _, ok := rewrittenLock.UIs["roadmap_review"]; !ok {
+		t.Fatalf("lock.UIs = %#v, want roadmap_review entry restored", rewrittenLock.UIs)
+	}
+}
+
+func TestLoadForExecutionAtPath_ResolvesManagedPluginOwnedUIFromManagedPath(t *testing.T) {
+	t.Parallel()
+
+	dir := t.TempDir()
+	const pluginRef = "github.com/testowner/plugins/roadmap"
+	const version = "0.0.1-alpha.1"
+
+	pkgDir := filepath.Join(dir, "roadmap-plugin-pkg")
+	if err := os.MkdirAll(pkgDir, 0o755); err != nil {
+		t.Fatalf("MkdirAll package dir: %v", err)
+	}
+
+	artifactPath := filepath.ToSlash(filepath.Join("artifacts", runtime.GOOS, runtime.GOARCH, "plugin"))
+	artifactContent := []byte("plugin-binary")
+	artifactFullPath := filepath.Join(pkgDir, filepath.FromSlash(artifactPath))
+	if err := os.MkdirAll(filepath.Dir(artifactFullPath), 0o755); err != nil {
+		t.Fatalf("MkdirAll artifact dir: %v", err)
+	}
+	if err := os.WriteFile(artifactFullPath, artifactContent, 0o755); err != nil {
+		t.Fatalf("WriteFile artifact: %v", err)
+	}
+
+	ownedUIManifestPath := filepath.ToSlash(filepath.Join("_owned_ui", "roadmap-ui", providerpkg.ManifestFile))
+	ownedUIManifestBytes, err := providerpkg.EncodeManifest(&providermanifestv1.Manifest{
+		Kind:        providermanifestv1.KindWebUI,
+		Source:      "github.com/testowner/web/roadmap-review",
+		Version:     version,
+		DisplayName: "Roadmap Review UI",
+		Spec: &providermanifestv1.Spec{
+			AssetRoot: "dist",
+		},
+	})
+	if err != nil {
+		t.Fatalf("Encode owned UI manifest: %v", err)
+	}
+	if err := os.MkdirAll(filepath.Join(pkgDir, "_owned_ui", "roadmap-ui", "dist"), 0o755); err != nil {
+		t.Fatalf("MkdirAll owned UI dist: %v", err)
+	}
+	if err := os.WriteFile(filepath.Join(pkgDir, filepath.FromSlash(ownedUIManifestPath)), ownedUIManifestBytes, 0o644); err != nil {
+		t.Fatalf("WriteFile owned UI manifest: %v", err)
+	}
+	if err := os.WriteFile(filepath.Join(pkgDir, "_owned_ui", "roadmap-ui", "dist", "index.html"), []byte("<html>roadmap review</html>"), 0o644); err != nil {
+		t.Fatalf("WriteFile owned UI index: %v", err)
+	}
+
+	sum := sha256.Sum256(artifactContent)
+	pluginManifestBytes, err := providerpkg.EncodeManifest(&providermanifestv1.Manifest{
+		Kind:        providermanifestv1.KindPlugin,
+		Source:      pluginRef,
+		Version:     version,
+		DisplayName: "Roadmap Review",
+		Entrypoint: &providermanifestv1.Entrypoint{
+			ArtifactPath: artifactPath,
+		},
+		Artifacts: []providermanifestv1.Artifact{{
+			OS:     runtime.GOOS,
+			Arch:   runtime.GOARCH,
+			Path:   artifactPath,
+			SHA256: hex.EncodeToString(sum[:]),
+		}},
+		Spec: &providermanifestv1.Spec{
+			Auth: &providermanifestv1.ProviderAuth{Type: providermanifestv1.AuthTypeNone},
+			UI: &providermanifestv1.OwnedUIRef{
+				Path: ownedUIManifestPath,
+			},
+		},
+	})
+	if err != nil {
+		t.Fatalf("Encode plugin manifest: %v", err)
+	}
+	if err := os.WriteFile(filepath.Join(pkgDir, providerpkg.ManifestFile), pluginManifestBytes, 0o644); err != nil {
+		t.Fatalf("WriteFile plugin manifest: %v", err)
+	}
+	if err := os.WriteFile(filepath.Join(pkgDir, "catalog.yaml"), []byte("name: roadmap\noperations:\n  - id: ping\n    method: GET\n"), 0o644); err != nil {
+		t.Fatalf("WriteFile catalog: %v", err)
+	}
+
+	pkgPath := filepath.Join(dir, "roadmap-plugin-pkg.tar.gz")
+	if err := providerpkg.CreatePackageFromDir(pkgDir, pkgPath); err != nil {
+		t.Fatalf("CreatePackageFromDir: %v", err)
+	}
+
+	cfgPath := filepath.Join(dir, "config.yaml")
+	cfg := requiredComponentConfigYAML(t, dir, filepath.Join(dir, "gestalt.db")) + `  plugins:
+    roadmap:
+      source:
+        ref: ` + pluginRef + `
+        version: ` + version + `
+` + `server:
+` + requiredServerDatastoreYAML() + `  encryptionKey: aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa
+apps:
+  roadmap_review:
+    plugin: roadmap
+    path: /create-customer-roadmap-review
+`
+	if err := os.WriteFile(cfgPath, []byte(cfg), 0o644); err != nil {
+		t.Fatalf("WriteFile config: %v", err)
+	}
+
+	lc := NewLifecycle(mappedSourceResolver{paths: map[string]string{pluginRef: pkgPath}})
+	if _, err := lc.InitAtPath(cfgPath); err != nil {
+		t.Fatalf("InitAtPath: %v", err)
+	}
+
+	loaded, _, err := lc.LoadForExecutionAtPath(cfgPath, false)
+	if err != nil {
+		t.Fatalf("LoadForExecutionAtPath: %v", err)
+	}
+	entry := loaded.Providers.UI["roadmap_review"]
+	if entry == nil || entry.ResolvedManifest == nil {
+		t.Fatalf("Resolved app-owned UI = %+v", entry)
+	}
+	if entry.Path != "/create-customer-roadmap-review" {
+		t.Fatalf("entry.Path = %q", entry.Path)
+	}
+	if got, want := filepath.ToSlash(entry.ResolvedManifestPath), filepath.ToSlash(filepath.Join("_owned_ui", "roadmap-ui", providerpkg.ManifestFile)); !strings.HasSuffix(got, want) {
+		t.Fatalf("ResolvedManifestPath = %q, want suffix %q", got, want)
+	}
+	if got, want := filepath.ToSlash(entry.ResolvedAssetRoot), filepath.ToSlash(filepath.Join("_owned_ui", "roadmap-ui", "dist")); !strings.HasSuffix(got, want) {
+		t.Fatalf("ResolvedAssetRoot = %q, want suffix %q", got, want)
+	}
+
+	rewrittenLock, err := ReadLockfile(filepath.Join(dir, InitLockfileName))
+	if err != nil {
+		t.Fatalf("ReadLockfile: %v", err)
+	}
+	if len(rewrittenLock.UIs) != 0 {
+		t.Fatalf("lock.UIs = %#v, want no separate UI entries for in-package owned UI", rewrittenLock.UIs)
+	}
+}
+
+func TestLoadForExecutionAtPath_ReinitializesManagedPluginOwnedUIWhenPluginLockIsStale(t *testing.T) {
+	t.Parallel()
+
+	dir := t.TempDir()
+	const pluginRef = "github.com/testowner/plugins/roadmap"
+	const webUIRef = "github.com/testowner/web/roadmap-review"
+	const oldVersion = "0.0.1-alpha.1"
+	const newVersion = "0.0.2-alpha.1"
+
+	buildWebUIPackage := func(version string) string {
+		return mustBuildManagedProviderPackage(t, dir, &providermanifestv1.Manifest{
+			Kind:        providermanifestv1.KindWebUI,
+			Source:      webUIRef,
+			Version:     version,
+			DisplayName: "Roadmap Review UI",
+			Spec: &providermanifestv1.Spec{
+				AssetRoot: "dist",
+			},
+		}, map[string]string{
+			"dist/index.html": "<html>roadmap review " + version + "</html>",
+		}, false)
+	}
+	buildPluginPackage := func(version string) string {
+		return mustBuildManagedProviderPackage(t, dir, &providermanifestv1.Manifest{
+			Kind:        providermanifestv1.KindPlugin,
+			Source:      pluginRef,
+			Version:     version,
+			DisplayName: "Roadmap Review",
+			Entrypoint: &providermanifestv1.Entrypoint{
+				ArtifactPath: filepath.ToSlash(filepath.Join("artifacts", runtime.GOOS, runtime.GOARCH, "plugin")),
+			},
+			Spec: &providermanifestv1.Spec{
+				Auth: &providermanifestv1.ProviderAuth{Type: providermanifestv1.AuthTypeNone},
+				UI: &providermanifestv1.OwnedUIRef{
+					Ref:     webUIRef,
+					Version: version,
+					Auth:    &providermanifestv1.SourceAuth{Token: "owned-ui-token"},
+				},
+			},
+		}, map[string]string{
+			filepath.ToSlash(filepath.Join("artifacts", runtime.GOOS, runtime.GOARCH, "plugin")): "plugin-binary-" + version,
+		}, true)
+	}
+
+	oldWebUIPkg := buildWebUIPackage(oldVersion)
+	oldPluginPkg := buildPluginPackage(oldVersion)
+	newWebUIPkg := buildWebUIPackage(newVersion)
+	newPluginPkg := buildPluginPackage(newVersion)
+
+	cfgPath := filepath.Join(dir, "config.yaml")
+	writeConfig := func(version string) {
+		cfg := requiredComponentConfigYAML(t, dir, filepath.Join(dir, "gestalt.db")) + `  plugins:
+    roadmap:
+      source:
+        ref: ` + pluginRef + `
+        version: ` + version + `
+` + `server:
+` + requiredServerDatastoreYAML() + `  encryptionKey: aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa
+apps:
+  roadmap_review:
+    plugin: roadmap
+    path: /create-customer-roadmap-review
+`
+		if err := os.WriteFile(cfgPath, []byte(cfg), 0o644); err != nil {
+			t.Fatalf("WriteFile config: %v", err)
+		}
+	}
+	writeConfig(oldVersion)
+
+	lc := NewLifecycle(versionedSourceResolver{
+		paths: map[string]map[string]string{
+			pluginRef: {
+				oldVersion: oldPluginPkg,
+				newVersion: newPluginPkg,
+			},
+			webUIRef: {
+				oldVersion: oldWebUIPkg,
+				newVersion: newWebUIPkg,
+			},
+		},
+		tokens: map[string]string{
+			webUIRef: "owned-ui-token",
+		},
+	})
+	if _, err := lc.InitAtPath(cfgPath); err != nil {
+		t.Fatalf("InitAtPath: %v", err)
+	}
+
+	writeConfig(newVersion)
+
+	loaded, _, err := lc.LoadForExecutionAtPath(cfgPath, false)
+	if err != nil {
+		t.Fatalf("LoadForExecutionAtPath: %v", err)
+	}
+	entry := loaded.Providers.UI["roadmap_review"]
+	if entry == nil || entry.ResolvedManifest == nil {
+		t.Fatalf("Resolved app-owned UI = %+v", entry)
+	}
+	if got := entry.ResolvedManifest.Version; got != newVersion {
+		t.Fatalf("ResolvedManifest.Version = %q, want %q", got, newVersion)
+	}
+	if entry.Path != "/create-customer-roadmap-review" {
+		t.Fatalf("entry.Path = %q", entry.Path)
+	}
+
+	rewrittenLock, err := ReadLockfile(filepath.Join(dir, InitLockfileName))
+	if err != nil {
+		t.Fatalf("ReadLockfile: %v", err)
+	}
+	lockEntry, ok := rewrittenLock.UIs["roadmap_review"]
+	if !ok {
+		t.Fatalf("lock.UIs = %#v, want roadmap_review entry restored", rewrittenLock.UIs)
+	}
+	if got := lockEntry.Version; got != newVersion {
+		t.Fatalf("lock.UIs[roadmap_review].Version = %q, want %q", got, newVersion)
+	}
+}
+
+func TestInitAtPath_RejectsManagedPluginOwnedUIPathOutsidePackage(t *testing.T) {
+	t.Parallel()
+
+	dir := t.TempDir()
+	const pluginRef = "github.com/testowner/plugins/roadmap"
+	const version = "0.0.1-alpha.1"
+
+	pkgDir := filepath.Join(dir, "roadmap-managed-pkg")
+	if err := os.MkdirAll(pkgDir, 0o755); err != nil {
+		t.Fatalf("MkdirAll package dir: %v", err)
+	}
+	artifactPath := filepath.ToSlash(filepath.Join("artifacts", runtime.GOOS, runtime.GOARCH, "plugin"))
+	artifactContent := []byte("plugin-binary")
+	artifactFullPath := filepath.Join(pkgDir, filepath.FromSlash(artifactPath))
+	if err := os.MkdirAll(filepath.Dir(artifactFullPath), 0o755); err != nil {
+		t.Fatalf("MkdirAll artifact dir: %v", err)
+	}
+	if err := os.WriteFile(artifactFullPath, artifactContent, 0o755); err != nil {
+		t.Fatalf("WriteFile artifact: %v", err)
+	}
+	sum := sha256.Sum256(artifactContent)
+	manifestBytes, err := json.Marshal(&providermanifestv1.Manifest{
+		Kind:        providermanifestv1.KindPlugin,
+		Source:      pluginRef,
+		Version:     version,
+		DisplayName: "Roadmap Review",
+		Entrypoint: &providermanifestv1.Entrypoint{
+			ArtifactPath: artifactPath,
+		},
+		Artifacts: []providermanifestv1.Artifact{{
+			OS:     runtime.GOOS,
+			Arch:   runtime.GOARCH,
+			Path:   artifactPath,
+			SHA256: hex.EncodeToString(sum[:]),
+		}},
+		Spec: &providermanifestv1.Spec{
+			Auth: &providermanifestv1.ProviderAuth{Type: providermanifestv1.AuthTypeNone},
+			UI: &providermanifestv1.OwnedUIRef{
+				Path: "../owned-ui/manifest.json",
+			},
+		},
+	})
+	if err != nil {
+		t.Fatalf("Marshal manifest: %v", err)
+	}
+	if err := os.WriteFile(filepath.Join(pkgDir, providerpkg.ManifestFile), manifestBytes, 0o644); err != nil {
+		t.Fatalf("WriteFile manifest: %v", err)
+	}
+	pkgPath := filepath.Join(dir, "roadmap-managed-pkg.tar.gz")
+	mustCreateLifecycleArchive(t, pkgPath,
+		lifecycleArchiveFile{name: providerpkg.ManifestFile, data: manifestBytes, mode: 0o644},
+		lifecycleArchiveFile{name: artifactPath, data: artifactContent, mode: 0o755},
+	)
+
+	cfgPath := filepath.Join(dir, "config.yaml")
+	cfg := requiredComponentConfigYAML(t, dir, filepath.Join(dir, "gestalt.db")) + `  plugins:
+    roadmap:
+      source:
+        ref: ` + pluginRef + `
+        version: ` + version + `
+server:
+` + requiredServerDatastoreYAML() + `  encryptionKey: aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa
+apps:
+  roadmap_review:
+    plugin: roadmap
+    path: /create-customer-roadmap-review
+`
+	if err := os.WriteFile(cfgPath, []byte(cfg), 0o644); err != nil {
+		t.Fatalf("WriteFile config: %v", err)
+	}
+
+	lc := NewLifecycle(mappedSourceResolver{paths: map[string]string{pluginRef: pkgPath}})
+	if _, err := lc.InitAtPath(cfgPath); err == nil || !strings.Contains(err.Error(), "spec.ui.path must stay within the package") {
+		t.Fatalf("InitAtPath error = %v, want substring %q", err, "spec.ui.path must stay within the package")
 	}
 }
 
@@ -1534,6 +2122,50 @@ func mustBuildManagedProviderPackage(t *testing.T, dir string, manifest *provide
 		t.Fatalf("CreatePackageFromDir: %v", err)
 	}
 	return pkgPath
+}
+
+type lifecycleArchiveFile struct {
+	name string
+	data []byte
+	mode int64
+}
+
+func mustCreateLifecycleArchive(t *testing.T, archivePath string, files ...lifecycleArchiveFile) {
+	t.Helper()
+
+	out, err := os.Create(archivePath)
+	if err != nil {
+		t.Fatalf("Create(%q): %v", archivePath, err)
+	}
+	defer func() {
+		if err := out.Close(); err != nil {
+			t.Fatalf("close archive: %v", err)
+		}
+	}()
+
+	gzw := gzip.NewWriter(out)
+	defer func() {
+		if err := gzw.Close(); err != nil {
+			t.Fatalf("close gzip: %v", err)
+		}
+	}()
+
+	tw := tar.NewWriter(gzw)
+	defer func() {
+		if err := tw.Close(); err != nil {
+			t.Fatalf("close tar: %v", err)
+		}
+	}()
+
+	for _, file := range files {
+		hdr := &tar.Header{Name: file.name, Mode: file.mode, Size: int64(len(file.data))}
+		if err := tw.WriteHeader(hdr); err != nil {
+			t.Fatalf("WriteHeader(%q): %v", file.name, err)
+		}
+		if _, err := tw.Write(file.data); err != nil {
+			t.Fatalf("Write(%q): %v", file.name, err)
+		}
+	}
 }
 
 func TestReadWriteLockfile_RoundTrip(t *testing.T) {

--- a/gestaltd/internal/providerpkg/manifest.go
+++ b/gestaltd/internal/providerpkg/manifest.go
@@ -177,6 +177,9 @@ func validateManifest(manifest *providermanifestv1.Manifest, sourceMode bool) er
 		if err := validateExecutableProviderMetadata(spec); err != nil {
 			return err
 		}
+		if err := validateOwnedUIRef(spec.UI, sourceMode); err != nil {
+			return err
+		}
 		if spec != nil && spec.IsDeclarative() {
 			if err := validateDeclarativeProvider(spec); err != nil {
 				return err
@@ -219,6 +222,72 @@ func validateManifest(manifest *providermanifestv1.Manifest, sourceMode bool) er
 		return fmt.Errorf("unsupported manifest kind %q", kind)
 	}
 
+	return nil
+}
+
+func validateOwnedUIRef(ref *providermanifestv1.OwnedUIRef, sourceMode bool) error {
+	if ref == nil {
+		return nil
+	}
+	pathValue := strings.TrimSpace(ref.Path)
+	refValue := strings.TrimSpace(ref.Ref)
+	versionValue := strings.TrimSpace(ref.Version)
+	var authValue *providermanifestv1.SourceAuth
+	if ref.Auth != nil {
+		token := strings.TrimSpace(ref.Auth.Token)
+		if token == "" {
+			return fmt.Errorf("spec.ui.auth.token is required when spec.ui.auth is set")
+		}
+		authValue = &providermanifestv1.SourceAuth{Token: token}
+	}
+	modeCount := 0
+	if pathValue != "" {
+		modeCount++
+	}
+	if refValue != "" {
+		modeCount++
+	}
+	switch modeCount {
+	case 0:
+		return fmt.Errorf("spec.ui.path or spec.ui.ref is required when spec.ui is set")
+	case 2:
+		return fmt.Errorf("spec.ui.path and spec.ui.ref are mutually exclusive")
+	}
+	if pathValue != "" {
+		if authValue != nil {
+			return fmt.Errorf("spec.ui.auth is only valid with spec.ui.ref")
+		}
+		if !sourceMode {
+			if err := validateRelativePackagePath(pathValue, "spec.ui.path"); err != nil {
+				return err
+			}
+			ref.Path = pathValue
+		} else {
+			if filepath.IsAbs(pathValue) {
+				return fmt.Errorf("spec.ui.path must be relative")
+			}
+			cleaned := path.Clean(filepath.ToSlash(pathValue))
+			if cleaned == "." || cleaned == "" {
+				return fmt.Errorf("spec.ui.path must not be empty")
+			}
+			ref.Path = cleaned
+		}
+		if versionValue != "" {
+			return fmt.Errorf("spec.ui.version is only valid with spec.ui.ref")
+		}
+		return nil
+	}
+	if _, err := pluginsource.Parse(refValue); err != nil {
+		return fmt.Errorf("spec.ui.ref: %w", err)
+	}
+	if versionValue != "" {
+		if err := pluginsource.ValidateVersion(versionValue); err != nil {
+			return fmt.Errorf("spec.ui.version: %w", err)
+		}
+	}
+	ref.Ref = refValue
+	ref.Version = versionValue
+	ref.Auth = authValue
 	return nil
 }
 

--- a/gestaltd/sdk/providermanifest/v1/types.go
+++ b/gestaltd/sdk/providermanifest/v1/types.go
@@ -55,10 +55,22 @@ type Spec struct {
 	ResponseMapping   *ManifestResponseMapping              `json:"responseMapping,omitempty" yaml:"responseMapping,omitempty"`
 	Pagination        *ManifestPaginationConfig             `json:"pagination,omitempty" yaml:"pagination,omitempty"`
 	Requires          []string                              `json:"requires,omitempty" yaml:"requires,omitempty"`
+	UI                *OwnedUIRef                           `json:"ui,omitempty" yaml:"ui,omitempty"`
 
 	// WebUI-specific fields
 	AssetRoot string       `json:"assetRoot,omitempty" yaml:"assetRoot,omitempty"`
 	Routes    []WebUIRoute `json:"routes,omitempty" yaml:"routes,omitempty"`
+}
+
+type OwnedUIRef struct {
+	Ref     string      `json:"ref,omitempty" yaml:"ref,omitempty"`
+	Version string      `json:"version,omitempty" yaml:"version,omitempty"`
+	Path    string      `json:"path,omitempty" yaml:"path,omitempty"`
+	Auth    *SourceAuth `json:"auth,omitempty" yaml:"auth,omitempty"`
+}
+
+type SourceAuth struct {
+	Token string `json:"token,omitempty" yaml:"token,omitempty"`
 }
 
 func (s *Spec) IsDeclarative() bool {


### PR DESCRIPTION
## Summary
- add public plugin-manifest support for declaring an owned web UI through `spec.ui`
- synthesize the mounted UI entry from the bound app during local load, `init`, and locked execution
- stage owned UI bundles during `gestaltd plugin release`, preserve same-name `providers.ui.<app>` overlays, and reject managed `spec.ui.path` values that escape the packaged root

## Public Interfaces
YAML plugin manifest, source-path form:
```yaml
kind: plugin
source: github.com/acme/plugins/customer-roadmap-review
version: 0.0.1-alpha.1
spec:
  auth:
    type: none
  ui:
    path: ../ui/manifest.yaml
```

YAML plugin manifest, managed-ref form:
```yaml
kind: plugin
source: github.com/acme/plugins/customer-roadmap-review
version: 0.0.1-alpha.1
spec:
  ui:
    ref: github.com/acme/web/customer-roadmap-review
    version: 0.0.1-alpha.1
    auth:
      token: ${UI_TOKEN}
```

Go SDK shape:
```go
manifest.Spec.UI = &providermanifestv1.OwnedUIRef{
    Path: "../ui/manifest.yaml",
}
```

```go
manifest.Spec.UI = &providermanifestv1.OwnedUIRef{
    Ref:     "github.com/acme/web/customer-roadmap-review",
    Version: "0.0.1-alpha.1",
    Auth:    &providermanifestv1.SourceAuth{Token: "${UI_TOKEN}"},
}
```

## Example Deployment
Bind the plugin-owned UI into a mounted app through top-level `apps`:
```yaml
apps:
  customer_roadmap_review:
    plugin: roadmap_review
    path: /create-customer-roadmap-review
```

Optional same-name overlay when the deployment needs to override path or policy without redefining the owned source:
```yaml
providers:
  ui:
    customer_roadmap_review:
      path: /create-customer-roadmap-review
      authorizationPolicy: roadmap_review
```

## Testing
- `go test ./internal/operator -run 'TestLoadForExecutionAtPath_ResolvesLocalMountedWebUIWithoutLockfile|TestLoadForExecutionAtPath_ReinitializesManagedPluginOwnedUIWhenUILockEntryIsMissing|TestLoadForExecutionAtPath_ResolvesManagedPluginOwnedUIFromManagedPath|TestLoadForExecutionAtPath_ReinitializesManagedPluginOwnedUIWhenPluginLockIsStale|TestInitAtPath_RejectsManagedPluginOwnedUIPathOutsidePackage|TestLoadForExecutionAtPath_SkipsDisabledLocalMountedWebUIWithoutLockfile|TestInitAtPath_SkipsDisabledManagedMountedWebUI|TestInitAtPath_RejectsPolicyBoundManagedMountedWebUIWithoutExplicitRouteCoverage' -count=1`
- `go test ./cmd/gestaltd -run 'TestRun_PluginReleaseCopiesCompiledSupportFiles|TestRun_PluginReleaseStagesOwnedWebUIPackage|TestRun_ProviderReleaseBuildsWebUIAssetsBeforePackaging|TestE2EMountedWebUI|TestE2EServeAndHealthCheck' -count=1`
