### PR TITLE
Hide app-backed plugins from integration surfaces

### DIFF
--- a/docs/content/reference/config-file.mdx
+++ b/docs/content/reference/config-file.mdx
@@ -777,6 +777,8 @@ apps:
 
 `apps` is a deployment-owned binding layer for plugin-backed mounted apps. Each entry references an existing `plugins.<name>` entry and an existing `providers.ui.<name>` bundle, then supplies the public path and optional shared human authorization policy for both surfaces.
 
+Plugins bound through `apps` are treated as mounted applications rather than generic integrations. They do not appear in `/api/v1/integrations` or on the default Plugins page.
+
 | Field | Description |
 | --- | --- |
 | `plugin` | Required plugin key from `plugins`. |

--- a/gestaltd/internal/config/config.go
+++ b/gestaltd/internal/config/config.go
@@ -157,6 +157,7 @@ type ProviderEntry struct {
 	Discovery            *providermanifestv1.ProviderDiscovery `yaml:"-"`
 	ResolvedAssetRoot    string                                `yaml:"-"`
 	MCPToolPrefix        string                                `yaml:"-"`
+	AppBinding           string                                `yaml:"-"`
 }
 
 type ProviderSurfaceOverrides struct {
@@ -1276,15 +1277,18 @@ func applyAppBindings(cfg *Config) error {
 		if plugin.Disabled {
 			return fmt.Errorf("config validation: apps.%s.plugin references disabled plugin %q", appName, app.Plugin)
 		}
+		if current := strings.TrimSpace(plugin.AuthorizationPolicy); current != "" && current != app.AuthorizationPolicy {
+			return fmt.Errorf("config validation: apps.%s.plugin %q conflicts with plugins.%s.authorizationPolicy", appName, app.Plugin, app.Plugin)
+		}
+		plugin.AuthorizationPolicy = app.AuthorizationPolicy
+		plugin.AppBinding = appName
+		seenPlugins[app.Plugin] = appName
 		ui := cfg.Providers.UI[app.UI]
 		if ui == nil {
 			return fmt.Errorf("config validation: apps.%s.ui references unknown ui %q", appName, app.UI)
 		}
 		if ui.Disabled {
 			return fmt.Errorf("config validation: apps.%s.ui references disabled ui %q", appName, app.UI)
-		}
-		if current := strings.TrimSpace(plugin.AuthorizationPolicy); current != "" && current != app.AuthorizationPolicy {
-			return fmt.Errorf("config validation: apps.%s.plugin %q conflicts with plugins.%s.authorizationPolicy", appName, app.Plugin, app.Plugin)
 		}
 		if current := strings.TrimSpace(ui.AuthorizationPolicy); current != "" && current != app.AuthorizationPolicy {
 			return fmt.Errorf("config validation: apps.%s.ui %q conflicts with providers.ui.%s.authorizationPolicy", appName, app.UI, app.UI)

--- a/gestaltd/internal/server/handlers.go
+++ b/gestaltd/internal/server/handlers.go
@@ -139,6 +139,9 @@ func (s *Server) listIntegrations(w http.ResponseWriter, r *http.Request) {
 	names := s.providers.List()
 	out := make([]integrationInfo, 0, len(names))
 	for _, name := range names {
+		if s.isAppBackedPlugin(name) {
+			continue
+		}
 		if !s.allowProvider(p, name) {
 			continue
 		}
@@ -208,6 +211,14 @@ func (s *Server) listIntegrations(w http.ResponseWriter, r *http.Request) {
 	writeJSON(w, http.StatusOK, out)
 }
 
+func (s *Server) isAppBackedPlugin(name string) bool {
+	if s == nil || s.pluginDefs == nil {
+		return false
+	}
+	entry := s.pluginDefs[name]
+	return entry != nil && strings.TrimSpace(entry.AppBinding) != ""
+}
+
 func (s *Server) userConnectedIntegrations(r *http.Request) (map[string][]instanceInfo, error) {
 	user := UserFromContext(r.Context())
 	if user == nil || user.Email == "" {
@@ -252,7 +263,7 @@ func (s *Server) disconnectIntegration(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	if _, ok := s.getProvider(w, name); !ok {
+	if _, ok := s.getAuthorizedUserFacingProvider(w, r, name); !ok {
 		auditErr = errors.New("integration not found")
 		return
 	}
@@ -357,6 +368,26 @@ func (s *Server) getProvider(w http.ResponseWriter, name string) (core.Provider,
 	return prov, true
 }
 
+func (s *Server) getUserFacingProvider(w http.ResponseWriter, name string) (core.Provider, bool) {
+	if s.isAppBackedPlugin(name) {
+		writeError(w, http.StatusNotFound, fmt.Sprintf("integration %q not found", name))
+		return nil, false
+	}
+	return s.getProvider(w, name)
+}
+
+func (s *Server) getAuthorizedUserFacingProvider(w http.ResponseWriter, r *http.Request, name string) (core.Provider, bool) {
+	prov, ok := s.getUserFacingProvider(w, name)
+	if !ok {
+		return nil, false
+	}
+	if !s.allowProvider(PrincipalFromContext(r.Context()), name) {
+		writeError(w, http.StatusForbidden, "provider access denied")
+		return nil, false
+	}
+	return prov, true
+}
+
 func queryParamValue(r *http.Request, names ...string) string {
 	for _, name := range names {
 		if value := r.URL.Query().Get(name); value != "" {
@@ -431,7 +462,7 @@ func (s *Server) listOperations(w http.ResponseWriter, r *http.Request) {
 	const operation = "operations.list"
 
 	name := chi.URLParam(r, "name")
-	prov, ok := s.getProvider(w, name)
+	prov, ok := s.getUserFacingProvider(w, name)
 	if !ok {
 		return
 	}

--- a/gestaltd/internal/server/handlers_connect.go
+++ b/gestaltd/internal/server/handlers_connect.go
@@ -57,7 +57,7 @@ func (s *Server) connectManual(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	prov, ok := s.getProvider(w, req.Integration)
+	prov, ok := s.getAuthorizedUserFacingProvider(w, r, req.Integration)
 	if !ok {
 		auditErr = errors.New("integration not found")
 		return

--- a/gestaltd/internal/server/handlers_oauth.go
+++ b/gestaltd/internal/server/handlers_oauth.go
@@ -49,7 +49,7 @@ func (s *Server) startIntegrationOAuth(w http.ResponseWriter, r *http.Request) {
 	}
 	providerName = req.Integration
 
-	prov, ok := s.getProvider(w, req.Integration)
+	prov, ok := s.getAuthorizedUserFacingProvider(w, r, req.Integration)
 	if !ok {
 		auditErr = errors.New("integration not found")
 		return

--- a/gestaltd/internal/server/server_test.go
+++ b/gestaltd/internal/server/server_test.go
@@ -1653,9 +1653,13 @@ func TestListIntegrations(t *testing.T) {
 	t.Parallel()
 
 	stub := &coretesting.StubIntegration{N: "slack", DN: "Slack", Desc: "Team messaging"}
+	appStub := &coretesting.StubIntegration{N: "roadmap_review", DN: "Roadmap Review", Desc: "Mounted internal app"}
 	ts := newTestServer(t, func(cfg *server.Config) {
-		cfg.Providers = testutil.NewProviderRegistry(t, stub)
+		cfg.Providers = testutil.NewProviderRegistry(t, stub, appStub)
 		cfg.Services = coretesting.NewStubServices(t)
+		cfg.PluginDefs = map[string]*config.ProviderEntry{
+			"roadmap_review": {AppBinding: "roadmap_review"},
+		}
 	})
 	testutil.CloseOnCleanup(t, ts)
 
@@ -3300,9 +3304,13 @@ func TestDisconnectIntegration_NotConnected(t *testing.T) {
 	t.Parallel()
 
 	stub := &coretesting.StubIntegration{N: "slack", DN: "Slack"}
+	appStub := &coretesting.StubIntegration{N: "roadmap_review", DN: "Roadmap Review"}
 	ts := newTestServer(t, func(cfg *server.Config) {
-		cfg.Providers = testutil.NewProviderRegistry(t, stub)
+		cfg.Providers = testutil.NewProviderRegistry(t, stub, appStub)
 		cfg.Services = coretesting.NewStubServices(t)
+		cfg.PluginDefs = map[string]*config.ProviderEntry{
+			"roadmap_review": {AppBinding: "roadmap_review"},
+		}
 	})
 	testutil.CloseOnCleanup(t, ts)
 
@@ -3315,6 +3323,17 @@ func TestDisconnectIntegration_NotConnected(t *testing.T) {
 
 	if resp.StatusCode != http.StatusNotFound {
 		t.Fatalf("expected 404, got %d", resp.StatusCode)
+	}
+
+	reqHidden, _ := http.NewRequest(http.MethodDelete, ts.URL+"/api/v1/integrations/roadmap_review", nil)
+	respHidden, err := http.DefaultClient.Do(reqHidden)
+	if err != nil {
+		t.Fatalf("hidden request: %v", err)
+	}
+	defer func() { _ = respHidden.Body.Close() }()
+
+	if respHidden.StatusCode != http.StatusNotFound {
+		t.Fatalf("expected hidden app-backed integration to return 404, got %d", respHidden.StatusCode)
 	}
 }
 
@@ -3971,6 +3990,10 @@ func TestExecuteOperation_HumanAuthorizationUsesSessionMetadataOnCollision(t *te
 func TestListOperations_NotFound(t *testing.T) {
 	t.Parallel()
 	ts := newTestServer(t, func(cfg *server.Config) {
+		cfg.Providers = testutil.NewProviderRegistry(t, &coretesting.StubIntegration{N: "roadmap_review", DN: "Roadmap Review"})
+		cfg.PluginDefs = map[string]*config.ProviderEntry{
+			"roadmap_review": {AppBinding: "roadmap_review"},
+		}
 	})
 	testutil.CloseOnCleanup(t, ts)
 
@@ -3983,6 +4006,17 @@ func TestListOperations_NotFound(t *testing.T) {
 
 	if resp.StatusCode != http.StatusNotFound {
 		t.Fatalf("expected 404, got %d", resp.StatusCode)
+	}
+
+	reqHidden, _ := http.NewRequest(http.MethodGet, ts.URL+"/api/v1/integrations/roadmap_review/operations", nil)
+	respHidden, err := http.DefaultClient.Do(reqHidden)
+	if err != nil {
+		t.Fatalf("hidden request: %v", err)
+	}
+	defer func() { _ = respHidden.Body.Close() }()
+
+	if respHidden.StatusCode != http.StatusNotFound {
+		t.Fatalf("expected hidden app-backed integration to return 404, got %d", respHidden.StatusCode)
 	}
 }
 
@@ -5729,54 +5763,97 @@ func TestLoginCallbackWithStatefulHandler(t *testing.T) {
 func TestStartIntegrationOAuth(t *testing.T) {
 	t.Parallel()
 
-	stub := &stubIntegrationWithAuthURL{
-		StubIntegration: coretesting.StubIntegration{N: "slack"},
-		authURL:         "https://slack.com/oauth/v2/authorize",
-	}
+	t.Run("app backed integration is hidden", func(t *testing.T) {
+		t.Parallel()
 
-	handler := &testOAuthHandler{
-		authorizationBaseURLVal: "https://slack.com/oauth/v2/authorize",
-	}
+		stub := &stubIntegrationWithAuthURL{
+			StubIntegration: coretesting.StubIntegration{N: "slack"},
+			authURL:         "https://slack.com/oauth/v2/authorize",
+		}
 
-	ts := newTestServer(t, func(cfg *server.Config) {
-		cfg.Providers = testutil.NewProviderRegistry(t, stub)
-		cfg.DefaultConnection = map[string]string{"slack": testDefaultConnection}
-		cfg.ConnectionAuth = testConnectionAuth("slack", handler)
-		cfg.Services = coretesting.NewStubServices(t)
+		handler := &testOAuthHandler{
+			authorizationBaseURLVal: "https://slack.com/oauth/v2/authorize",
+		}
+
+		ts := newTestServer(t, func(cfg *server.Config) {
+			cfg.Providers = testutil.NewProviderRegistry(t, stub)
+			cfg.DefaultConnection = map[string]string{"slack": testDefaultConnection}
+			cfg.ConnectionAuth = testConnectionAuth("slack", handler)
+			cfg.PluginDefs = map[string]*config.ProviderEntry{
+				"slack": {AppBinding: "sample_app"},
+			}
+			cfg.Services = coretesting.NewStubServices(t)
+		})
+		testutil.CloseOnCleanup(t, ts)
+
+		body := bytes.NewBufferString(`{"integration":"slack","scopes":["channels:read"]}`)
+		req, _ := http.NewRequest(http.MethodPost, ts.URL+"/api/v1/auth/start-oauth", body)
+		req.Header.Set("Authorization", "Bearer ignored")
+		req.Header.Set("Content-Type", "application/json")
+		resp, err := http.DefaultClient.Do(req)
+		if err != nil {
+			t.Fatalf("request: %v", err)
+		}
+		defer func() { _ = resp.Body.Close() }()
+
+		if resp.StatusCode != http.StatusNotFound {
+			t.Fatalf("expected 404, got %d", resp.StatusCode)
+		}
 	})
-	testutil.CloseOnCleanup(t, ts)
 
-	body := bytes.NewBufferString(`{"integration":"slack","scopes":["channels:read"]}`)
-	req, _ := http.NewRequest(http.MethodPost, ts.URL+"/api/v1/auth/start-oauth", body)
-	req.Header.Set("Authorization", "Bearer ignored")
-	req.Header.Set("Content-Type", "application/json")
-	resp, err := http.DefaultClient.Do(req)
-	if err != nil {
-		t.Fatalf("request: %v", err)
-	}
-	defer func() { _ = resp.Body.Close() }()
+	t.Run("user facing integration returns an oauth url", func(t *testing.T) {
+		t.Parallel()
 
-	if resp.StatusCode != http.StatusOK {
-		t.Fatalf("expected 200, got %d", resp.StatusCode)
-	}
+		stub := &stubIntegrationWithAuthURL{
+			StubIntegration: coretesting.StubIntegration{N: "slack"},
+			authURL:         "https://slack.com/oauth/v2/authorize",
+		}
 
-	var result map[string]string
-	if err := json.NewDecoder(resp.Body).Decode(&result); err != nil {
-		t.Fatalf("decoding: %v", err)
-	}
-	if result["url"] == "" {
-		t.Fatal("expected non-empty url")
-	}
-	if result["state"] == "" {
-		t.Fatal("expected non-empty state")
-	}
-	parsedURL, err := url.Parse(result["url"])
-	if err != nil {
-		t.Fatalf("parse auth URL: %v", err)
-	}
-	if parsedURL.Query().Get("state") != result["state"] {
-		t.Fatal("expected auth URL state to match returned state")
-	}
+		handler := &testOAuthHandler{
+			authorizationBaseURLVal: "https://slack.com/oauth/v2/authorize",
+		}
+
+		ts := newTestServer(t, func(cfg *server.Config) {
+			cfg.Providers = testutil.NewProviderRegistry(t, stub)
+			cfg.DefaultConnection = map[string]string{"slack": testDefaultConnection}
+			cfg.ConnectionAuth = testConnectionAuth("slack", handler)
+			cfg.Services = coretesting.NewStubServices(t)
+		})
+		testutil.CloseOnCleanup(t, ts)
+
+		body := bytes.NewBufferString(`{"integration":"slack","scopes":["channels:read"]}`)
+		req, _ := http.NewRequest(http.MethodPost, ts.URL+"/api/v1/auth/start-oauth", body)
+		req.Header.Set("Authorization", "Bearer ignored")
+		req.Header.Set("Content-Type", "application/json")
+		resp, err := http.DefaultClient.Do(req)
+		if err != nil {
+			t.Fatalf("request: %v", err)
+		}
+		defer func() { _ = resp.Body.Close() }()
+
+		if resp.StatusCode != http.StatusOK {
+			t.Fatalf("expected 200, got %d", resp.StatusCode)
+		}
+
+		var result map[string]string
+		if err := json.NewDecoder(resp.Body).Decode(&result); err != nil {
+			t.Fatalf("decoding: %v", err)
+		}
+		if result["url"] == "" {
+			t.Fatal("expected non-empty url")
+		}
+		if result["state"] == "" {
+			t.Fatal("expected non-empty state")
+		}
+		parsedURL, err := url.Parse(result["url"])
+		if err != nil {
+			t.Fatalf("parse auth URL: %v", err)
+		}
+		if parsedURL.Query().Get("state") != result["state"] {
+			t.Fatal("expected auth URL state to match returned state")
+		}
+	})
+
 }
 
 func TestIntegrationOAuthCallback(t *testing.T) {
@@ -7645,6 +7722,35 @@ func TestConnectManual(t *testing.T) {
 
 	const pendingSelectionPath = "/api/v1/auth/pending-connection"
 
+	t.Run("app backed integration is hidden", func(t *testing.T) {
+		t.Parallel()
+
+		ts := newTestServer(t, func(cfg *server.Config) {
+			cfg.Providers = testutil.NewProviderRegistry(t, &stubManualProvider{
+				StubIntegration: coretesting.StubIntegration{N: "manual-svc"},
+			})
+			cfg.DefaultConnection = map[string]string{"manual-svc": config.PluginConnectionName}
+			cfg.PluginDefs = map[string]*config.ProviderEntry{
+				"manual-svc": {AppBinding: "sample_app"},
+			}
+			cfg.Services = coretesting.NewStubServices(t)
+		})
+		testutil.CloseOnCleanup(t, ts)
+
+		body := bytes.NewBufferString(`{"integration":"manual-svc","credential":"my-api-key"}`)
+		req, _ := http.NewRequest(http.MethodPost, ts.URL+"/api/v1/auth/connect-manual", body)
+		req.Header.Set("Content-Type", "application/json")
+		resp, err := http.DefaultClient.Do(req)
+		if err != nil {
+			t.Fatalf("request: %v", err)
+		}
+		defer func() { _ = resp.Body.Close() }()
+
+		if resp.StatusCode != http.StatusNotFound {
+			t.Fatalf("expected 404, got %d", resp.StatusCode)
+		}
+	})
+
 	t.Run("connected", func(t *testing.T) {
 		t.Parallel()
 
@@ -7919,6 +8025,7 @@ func TestConnectManual(t *testing.T) {
 			t.Fatalf("expected workspace metadata beta, got %q", metadata["workspace"])
 		}
 	})
+
 }
 
 func TestConnectManual_OAuthProviderRejected(t *testing.T) {


### PR DESCRIPTION
## Summary
- treat plugins bound through top-level `apps` as app-backed surfaces instead of generic integrations in the default integration UX
- hide app-backed plugins from `/api/v1/integrations`
- return `404` for app-backed plugins on the generic integration-management routes while leaving mounted app access and direct invocation intact

## Public Interfaces
This PR does not add a new YAML knob beyond the existing top-level `apps` binding. The behavior is triggered when a plugin is mounted as an app:

```yaml
apps:
  customer_roadmap_review:
    plugin: roadmap_review
    path: /create-customer-roadmap-review
```

Internal Go/runtime marker used by the server:
```go
entry := &config.ProviderEntry{AppBinding: "customer_roadmap_review"}
```

Once `AppBinding` is set, Gestalt omits the plugin from:
```text
GET /api/v1/integrations
```

and returns `404` on the generic integration-management routes:
```text
GET    /api/v1/integrations/{name}/operations
DELETE /api/v1/integrations/{name}
POST   /api/v1/auth/start-oauth
POST   /api/v1/auth/connect-manual
```

Mounted app access still flows through the app UI path and normal plugin invocation routes such as:
```text
GET  /create-customer-roadmap-review/...
POST /api/v1/customer_roadmap_review/<operation>
```

## Example Deployment
```yaml
apps:
  customer_roadmap_review:
    plugin: customer_roadmap_review
    path: /create-customer-roadmap-review
    authorizationPolicy: roadmap_review
```

With that binding in place, the plugin stops appearing in the generic integrations page and generic connection-management endpoints.

## Testing
- `go test ./internal/server -run 'TestListIntegrations$|TestDisconnectIntegration_NotConnected|TestListOperations_NotFound|TestStartIntegrationOAuth|TestIntegrationOAuthCallback|TestConnectManual' -count=1`
- `go test ./cmd/gestaltd -run 'TestE2EMountedWebUI|TestE2EServeAndHealthCheck|TestE2EValidateRejectsUnknownYAMLField' -count=1`
