### PR TITLE
Inherit selected IndexedDB for plugins without explicit bindings

### DIFF
--- a/docs/content/audit-logging.mdx
+++ b/docs/content/audit-logging.mdx
@@ -100,11 +100,21 @@ definitions.
 
 ## Routing
 
-By default, audit records follow the main telemetry log pipeline. With `providers.telemetry` set to `source: stdout` they appear in local structured logs; with `source: otlp` they export through the OTLP log pipeline.
+By default, audit records follow the main telemetry log pipeline. When the
+selected `providers.telemetry` entry uses `source: stdout` they appear in local
+structured logs; when it uses `source: otlp` they export through the OTLP log
+pipeline.
 
-If you need a dedicated audit route, configure `providers.audit` separately. Set `source: stdout` to keep audit logs on stdout even when telemetry uses a different source, `source: otlp` to export only audit records to a dedicated OTLP collector, or `source: noop` to disable audit output explicitly.
+If you need a dedicated audit route, configure `providers.audit` separately.
+Set the selected audit entry to `source: stdout` to keep audit logs on stdout
+even when telemetry uses a different source, `source: otlp` to export only
+audit records to a dedicated OTLP collector, or `source: noop` to disable
+audit output explicitly.
 
-With the default `providers.audit` source of `inherit`, you can still split audit records downstream by filtering on `log.type=audit` in your collector. See [Config File](/reference/config-file) for the config surface and [Observability](/observability) for export options.
+With the default selected audit entry using `source: inherit`, you can still
+split audit records downstream by filtering on `log.type=audit` in your
+collector. See [Config File](/reference/config-file) for the config surface and
+[Observability](/observability) for export options.
 
 ## Metrics Notes
 

--- a/docs/content/configuration.mdx
+++ b/docs/content/configuration.mdx
@@ -22,11 +22,16 @@ server:
     defaultAction: ...      # "allow" or "deny"
 
 providers:
-  auth: ...                 # platform login (ProviderEntry)
-  secrets: ...              # secret resolution (default: env)
-  telemetry: ...            # metrics and tracing (default: stdout)
-  audit: ...                # audit log routing (default: inherit)
-  ui: ...                   # web UI bundle (ProviderEntry)
+  auth:
+    <name>: ...             # named auth providers
+  secrets:
+    <name>: ...             # named secret providers (default entry: env)
+  telemetry:
+    <name>: ...             # named telemetry providers (default entry: stdout)
+  audit:
+    <name>: ...             # named audit providers (default entry: inherit)
+  ui:
+    <name>: ...             # mounted web UI bundles
   indexeddb:                # named storage providers
     <name>: ...             # each is a ProviderEntry
 
@@ -34,7 +39,7 @@ plugins:
   <name>: ...               # each is a ProviderEntry
 ```
 
-Each provider entry accepts `source` (where to load it from), `config` (provider-specific settings), `disabled`, `allowedHosts`, `connections`, and optional metadata fields. See the [Config File](/reference/config-file) reference for every field.
+Host-owned provider kinds (`auth`, `secrets`, `telemetry`, `audit`, and `indexeddb`) are named maps. `server.providers.<kind>` selects the active entry, or `default: true` can mark the fallback when the selector is omitted. Host-provider entries accept `source` (where to load it from), `config` (provider-specific settings), `default`, `disabled`, `env`, `allowedHosts`, and optional metadata fields. Plugin-only fields such as `connections`, `allowedOperations`, `indexeddb`, and `surfaces` live under top-level `plugins.<name>`. See the [Config File](/reference/config-file) reference for every field.
 
 ## Key concepts
 
@@ -174,22 +179,30 @@ MCP tool exposure is declared in the provider manifest via `spec.mcp: true`. Whe
 
 ## Secrets
 
-The `providers.secrets` entry configures how `secret://` references in the config are resolved at startup. The default is `env`, which reads secrets from environment variables:
+The `providers.secrets` map configures how `secret://` references in the config are resolved at startup. If you omit it entirely, Gestalt inserts `providers.secrets.default` with builtin `source: env`.
 
 ```yaml
 providers:
   secrets:
-    source: env
+    default:
+      default: true
+      source: env
 ```
 
 For production, use `file` (reads from a directory, works with Kubernetes volume-mounted secrets) or a cloud secret manager:
 
 ```yaml
+server:
+  providers:
+    secrets: filesystem
+
 providers:
   secrets:
-    source: file
-    config:
-      dir: /etc/gestalt-secrets
+    filesystem:
+      default: true
+      source: file
+      config:
+        dir: /etc/gestalt-secrets
 ```
 
 Cloud backends (Google Secret Manager, AWS Secrets Manager, HashiCorp Vault, Azure Key Vault) are also available. See [Secret Providers](/providers/secrets) for the full list.
@@ -218,32 +231,48 @@ The built-in admin UI at `/admin` is always available regardless of this setting
 
 ## Platform auth
 
-The `providers.auth` entry protects the web UI, HTTP API, and `/mcp` endpoint. For local development, omit it or disable it explicitly:
+The `providers.auth` map protects the web UI, HTTP API, and `/mcp` endpoint. For local development, omit it entirely. A minimal local config simply has no `providers.auth` block:
 
 ```yaml
+server:
+  providers:
+    indexeddb: main
+
 providers:
-  auth:
-    disabled: true
+  indexeddb:
+    main:
+      default: true
+      source:
+        ref: github.com/valon-technologies/gestalt-providers/indexeddb/relationaldb
+        version: 0.0.1-alpha.2
+      config:
+        dsn: sqlite://./gestalt.db
 ```
 
-For multi-user deployments, point at a published auth provider:
+For multi-user deployments, configure a named auth provider and select it with `server.providers.auth`:
 
 ```yaml
+server:
+  providers:
+    auth: corp-sso
+
 providers:
   auth:
-    source:
-      ref: github.com/valon-technologies/gestalt-providers/auth/oidc
-      version: 0.0.1-alpha.1
-    config:
-      issuerUrl: https://login.example.com
-      clientId: ${OIDC_CLIENT_ID}
-      clientSecret: secret://oidc-client-secret
+    corp-sso:
+      default: true
+      source:
+        ref: github.com/valon-technologies/gestalt-providers/auth/oidc
+        version: 0.0.1-alpha.1
+      config:
+        issuerUrl: https://login.example.com
+        clientId: ${OIDC_CLIENT_ID}
+        clientSecret: secret://oidc-client-secret
 ```
 
 | Scenario | Configuration |
 | --- | --- |
-| Local development | Omit `providers.auth` or set `providers.auth.disabled: true` |
-| Multi-user deployment | `providers.auth` with a published OIDC or Google auth provider |
+| Local development | Omit `providers.auth` |
+| Multi-user deployment | `providers.auth.<name>` plus `server.providers.auth` or a single `default: true` entry |
 | Per-user upstream access | `mode: user` on plugin connections |
 | Shared service credential | `mode: identity` on plugin connections |
 
@@ -253,7 +282,7 @@ For programmatic access, Gestalt issues API tokens prefixed with `gst_api_`. The
 
 ## Configuring storage
 
-The `providers.indexeddb` block declares storage providers. `server.providers.indexeddb` selects which one Gestalt uses:
+The `providers.indexeddb` block declares storage providers. `server.providers.indexeddb` selects which one Gestalt uses, or you can mark a single entry `default: true`:
 
 ```yaml
 server:
@@ -279,9 +308,13 @@ Gestalt ships with builtin telemetry and audit providers that work without any c
 ```yaml
 providers:
   telemetry:
-    source: stdout
+    default:
+      default: true
+      source: stdout
   audit:
-    source: inherit
+    default:
+      default: true
+      source: inherit
 ```
 
 `inherit` routes audit events through the telemetry provider. For production observability with OpenTelemetry, see [Observability](/observability).
@@ -316,7 +349,7 @@ gestaltd validate --config ./config.yaml
 
 ### Defaults and required fields
 
-Gestalt defaults `server.public.port` to `8080`, `providers.secrets` to `env`, and `providers.telemetry` to `stdout`. The required fields are `providers.indexeddb`, `server.providers.indexeddb`, and `server.encryptionKey`. Platform auth is optional.
+Gestalt defaults `server.public.port` to `8080`, `providers.secrets.default` to builtin `env`, `providers.telemetry.default` to builtin `stdout`, and `providers.audit.default` to builtin `inherit`. The required fields are `providers.indexeddb` and `server.encryptionKey`, and the active datastore must resolve from `server.providers.indexeddb`, a single `default: true` entry, or the only IndexedDB entry. A selected IndexedDB entry may not be disabled. Platform auth is optional.
 
 `server.encryptionKey` is the root deployment secret. Gestalt derives token encryption and session material from it. Changing this key invalidates all existing sessions and tokens, so treat it as a meaningful deployment event.
 
@@ -327,48 +360,53 @@ A production deployment with OIDC auth, a GitHub plugin with per-user connection
 ```yaml
 server:
   baseUrl: https://gestalt.example.com
+  providers:
+    auth: corp-sso
+    indexeddb: main
   encryptionKey: secret://gestalt-encryption-key
-  indexeddb: main
 
 providers:
   auth:
-    source:
-      ref: github.com/valon-technologies/gestalt-providers/auth/oidc
-      version: 0.0.1-alpha.1
-    config:
-      issuerUrl: https://login.example.com
-      clientId: ${OIDC_CLIENT_ID}
-      clientSecret: secret://oidc-client-secret
+    corp-sso:
+      default: true
+      source:
+        ref: github.com/valon-technologies/gestalt-providers/auth/oidc
+        version: 0.0.1-alpha.1
+      config:
+        issuerUrl: https://login.example.com
+        clientId: ${OIDC_CLIENT_ID}
+        clientSecret: secret://oidc-client-secret
 
-  indexeddbs:
+  indexeddb:
     main:
+      default: true
       source:
         ref: github.com/valon-technologies/gestalt-providers/indexeddb/relationaldb
         version: 0.0.1-alpha.2
       config:
         dsn: sqlite://./gestalt.db
 
-  plugins:
-    github:
-      displayName: GitHub
-      source:
-        ref: github.com/valon-technologies/gestalt-providers/plugins/github
-        version: 0.0.1-alpha.1
-      surfaces:
-        openapi:
-          baseUrl: https://api.github.com
-      connections:
-        api:
-          mode: user
-          auth:
-            type: bearer
-            credentials:
-              - name: token
-                label: Personal Access Token
-        mcp:
-          mode: user
-          auth:
-            type: mcp_oauth
+plugins:
+  github:
+    displayName: GitHub
+    source:
+      ref: github.com/valon-technologies/gestalt-providers/plugins/github
+      version: 0.0.1-alpha.1
+    surfaces:
+      openapi:
+        baseUrl: https://api.github.com
+    connections:
+      api:
+        mode: user
+        auth:
+          type: bearer
+          credentials:
+            - name: token
+              label: Personal Access Token
+      mcp:
+        mode: user
+        auth:
+          type: mcp_oauth
 ```
 
 ## Minimal config
@@ -380,12 +418,14 @@ server:
   public:
     port: 8080
   baseUrl: http://localhost:8080
+  providers:
+    indexeddb: main
   encryptionKey: ${GESTALT_ENCRYPTION_KEY}
-  indexeddb: main
 
 providers:
-  indexeddbs:
+  indexeddb:
     main:
+      default: true
       source:
         ref: github.com/valon-technologies/gestalt-providers/indexeddb/relationaldb
         version: 0.0.1-alpha.2

--- a/docs/content/custom-providers/auth.mdx
+++ b/docs/content/custom-providers/auth.mdx
@@ -224,18 +224,25 @@ Two optional interfaces extend the base contract.
 
 ## Config reference
 
-To use a Google auth provider in a Gestalt deployment, reference it in the `providers.auth` block:
+To use a Google auth provider in a Gestalt deployment, reference it as a named
+entry under `providers.auth` and select it with `server.providers.auth`:
 
 ```yaml
+server:
+  providers:
+    auth: google-auth
+
 providers:
   auth:
-    source:
-      path: ./google-auth/manifest.yaml
-    config:
-      clientId: ${GOOGLE_CLIENT_ID}
-      clientSecret: secret://google-client-secret
-      allowedDomains:
-        - example.com
+    google-auth:
+      default: true
+      source:
+        path: ./google-auth/manifest.yaml
+      config:
+        clientId: ${GOOGLE_CLIENT_ID}
+        clientSecret: secret://google-client-secret
+        allowedDomains:
+          - example.com
 ```
 
 `source.path` points at the auth provider's `manifest.yaml` during development. For production, use `source.ref` and `version` to reference a published release. The `config` block is passed to `Configure` at startup and validated against the config schema if one was declared in the manifest.

--- a/docs/content/custom-providers/indexeddb.mdx
+++ b/docs/content/custom-providers/indexeddb.mdx
@@ -372,15 +372,17 @@ the SDK call makes the store portable across both styles of backend.
 
 ## Config reference
 
-Reference an IndexedDB provider in the `providers.indexeddbs` section, and set `server.indexeddb` to the name of the active provider. For local development, SQLite keeps things simple with a file path:
+Reference an IndexedDB provider in the `providers.indexeddb` section, and set `server.providers.indexeddb` to the name of the active provider. For local development, SQLite keeps things simple with a file path:
 
 ```yaml
 server:
-  indexeddb: main
+  providers:
+    indexeddb: main
 
 providers:
-  indexeddbs:
+  indexeddb:
     main:
+      default: true
       source:
         path: ./relationaldb/manifest.yaml
       config:
@@ -390,9 +392,14 @@ providers:
 For production, use `source.ref` and `version` to reference a published release:
 
 ```yaml
+server:
+  providers:
+    indexeddb: main
+
 providers:
-  indexeddbs:
+  indexeddb:
     main:
+      default: true
       source:
         ref: github.com/valon-technologies/gestalt-providers/indexeddb/relationaldb
         version: 0.0.1

--- a/docs/content/custom-providers/plugins.mdx
+++ b/docs/content/custom-providers/plugins.mdx
@@ -6,7 +6,7 @@ This page covers building custom plugin providers. If you only need to
 configure a published plugin in a Gestalt deployment, use
 [Providers > Plugins](/providers/plugins).
 
-Plugins are one provider kind. Their manifests use a top-level `spec:` block, and deployments reference them under `providers.plugins`. A plugin can define operations as executable code (handled by the provider process), as passthrough surfaces (REST, OpenAPI, GraphQL, or MCP endpoints forwarded by the host), or both.
+Plugins are one provider kind. Their manifests use a top-level `spec:` block, and deployments reference them under top-level `plugins`. A plugin can define operations as executable code (handled by the provider process), as passthrough surfaces (REST, OpenAPI, GraphQL, or MCP endpoints forwarded by the host), or both.
 
 The examples on this page use a Slack plugin as the running example, since it demonstrates most plugin features: OAuth connections, REST passthrough surfaces, executable operations, and MCP.
 
@@ -515,11 +515,10 @@ spec:
 You configure a declarative plugin the same way as any other. Point the config at the manifest, and the declared operations appear in the catalog:
 
 ```yaml
-providers:
-  plugins:
-    slack-readonly:
-      source:
-        path: ./slack-readonly/manifest.yaml
+plugins:
+  slack-readonly:
+    source:
+      path: ./slack-readonly/manifest.yaml
 ```
 
 ```sh
@@ -644,13 +643,12 @@ A Slack plugin could use this to check which Slack workspace the caller is conne
 Point a local config at the source plugin. Gestalt synthesizes the executable wrapper and materializes the catalog automatically:
 
 ```yaml
-providers:
-  plugins:
-    slack:
-      source:
-        path: ./slack/manifest.yaml
-      allowedHosts:
-        - slack.com
+plugins:
+  slack:
+    source:
+      path: ./slack/manifest.yaml
+    allowedHosts:
+      - slack.com
 ```
 
 Start the server and invoke an operation:

--- a/docs/content/custom-providers/releasing.mdx
+++ b/docs/content/custom-providers/releasing.mdx
@@ -217,11 +217,10 @@ binaries during release.
 Use `source.path` to point at the source tree directly. Gestalt synthesizes the executable wrapper and materializes the catalog automatically:
 
 ```yaml
-providers:
-  plugins:
-    my-plugin:
-      source:
-        path: ./plugins/my-plugin/manifest.yaml
+plugins:
+  my-plugin:
+    source:
+      path: ./plugins/my-plugin/manifest.yaml
 ```
 
 UI bundles work the same way:
@@ -240,12 +239,11 @@ providers:
 Reference a published release by source and version:
 
 ```yaml
-providers:
-  plugins:
-    my-plugin:
-      source:
-        ref: github.com/your-org/your-plugins/my-plugin
-        version: 0.0.1-alpha.1
+plugins:
+  my-plugin:
+    source:
+      ref: github.com/your-org/your-plugins/my-plugin
+      version: 0.0.1-alpha.1
 ```
 
 UI bundles use the same pattern under `providers.ui.<name>`:

--- a/docs/content/custom-providers/secrets.mdx
+++ b/docs/content/custom-providers/secrets.mdx
@@ -162,27 +162,40 @@ A secrets provider implements two methods: `Configure` and `GetSecret`. `Configu
 
 ## Config reference
 
-To use a secrets provider in a Gestalt deployment, reference it in the `providers.secrets` block:
+To use a secrets provider in a Gestalt deployment, reference it as a named
+entry under `providers.secrets` and select it with `server.providers.secrets`:
 
 ```yaml
+server:
+  providers:
+    secrets: google-secrets
+
 providers:
   secrets:
-    source:
-      path: ./google-secrets/manifest.yaml
-    config:
-      project: my-gcp-project
+    google-secrets:
+      default: true
+      source:
+        path: ./google-secrets/manifest.yaml
+      config:
+        project: my-gcp-project
 ```
 
 `source.path` points at the provider's `manifest.yaml` during development. For production, use `source.ref` and `version` to reference a published release:
 
 ```yaml
+server:
+  providers:
+    secrets: google-secrets
+
 providers:
   secrets:
-    source:
-      ref: github.com/valon-technologies/gestalt-providers/secrets/google
-      version: 0.0.1
-    config:
-      project: my-gcp-project
+    google-secrets:
+      default: true
+      source:
+        ref: github.com/valon-technologies/gestalt-providers/secrets/google
+        version: 0.0.1
+      config:
+        project: my-gcp-project
 ```
 
 The `config` block is passed to `Configure` at startup.
@@ -196,29 +209,37 @@ Two simple providers are built in and do not require a plugin manifest:
 ```yaml
 providers:
   secrets:
-    source: env
-    config:
-      prefix: GESTALT_
+    default:
+      default: true
+      source: env
+      config:
+        prefix: GESTALT_
 ```
 
 **`file`** reads secrets from files in a directory. Each secret name maps to a file in the configured directory.
 
 ```yaml
+server:
+  providers:
+    secrets: filesystem
+
 providers:
   secrets:
-    source: file
-    config:
-      dir: /run/secrets
+    filesystem:
+      default: true
+      source: file
+      config:
+        dir: /run/secrets
 ```
 
 ## Available providers
 
 | Provider | Source ref | Description |
 |----------|-----------|-------------|
-| AWS Secrets Manager | `github.com/valon-technologies/gestalt-providers/secrets/aws` | Config: `region` (required), `version_stage`, `endpoint` |
-| Azure Key Vault | `github.com/valon-technologies/gestalt-providers/secrets/azure` | Config: `vault_url` (required), `version` |
+| AWS Secrets Manager | `github.com/valon-technologies/gestalt-providers/secrets/aws` | Config: `region` (required), `versionStage`, `endpoint` |
+| Azure Key Vault | `github.com/valon-technologies/gestalt-providers/secrets/azure` | Config: `vaultUrl` (required), `version` |
 | Google Secret Manager | `github.com/valon-technologies/gestalt-providers/secrets/google` | Config: `project` (required), `version` |
-| HashiCorp Vault | `github.com/valon-technologies/gestalt-providers/secrets/vault` | Config: `address` (required), `token` (required), `mount_path`, `namespace` |
+| HashiCorp Vault | `github.com/valon-technologies/gestalt-providers/secrets/vault` | Config: `address` (required), `token` (required), `mountPath`, `namespace` |
 
 ## What to read next
 

--- a/docs/content/deploy/helm.mdx
+++ b/docs/content/deploy/helm.mdx
@@ -40,18 +40,23 @@ config:
   server:
     baseUrl: "${GESTALT_BASE_URL}"
     encryptionKey: "${GESTALT_ENCRYPTION_KEY}"
-    indexeddb: main
+    providers:
+      auth: corp-sso
+      indexeddb: main
   providers:
     auth:
-      source:
-        ref: github.com/valon-technologies/gestalt-providers/auth/oidc
-        version: 0.0.1-alpha.1
-      config:
-        issuerUrl: "${OIDC_ISSUER_URL}"
-        clientId: "${OIDC_CLIENT_ID}"
-        clientSecret: "${OIDC_CLIENT_SECRET}"
-    indexeddbs:
+      corp-sso:
+        default: true
+        source:
+          ref: github.com/valon-technologies/gestalt-providers/auth/oidc
+          version: 0.0.1-alpha.1
+        config:
+          issuerUrl: "${OIDC_ISSUER_URL}"
+          clientId: "${OIDC_CLIENT_ID}"
+          clientSecret: "${OIDC_CLIENT_SECRET}"
+    indexeddb:
       main:
+        default: true
         source:
           ref: github.com/valon-technologies/gestalt-providers/indexeddb/relationaldb
           version: 0.0.1-alpha.2
@@ -119,19 +124,24 @@ config:
       port: 9090
     baseUrl: "${GESTALT_BASE_URL}"
     encryptionKey: "${GESTALT_ENCRYPTION_KEY}"
-    indexeddb: main
+    providers:
+      auth: corp-sso
+      indexeddb: main
   providers:
     auth:
-      source:
-        ref: github.com/valon-technologies/gestalt-providers/auth/oidc
-        version: 0.0.1-alpha.1
-      config:
-        issuerUrl: "${OIDC_ISSUER_URL}"
-        clientId: "${OIDC_CLIENT_ID}"
-        clientSecret: "${OIDC_CLIENT_SECRET}"
-        redirectUrl: "${OIDC_REDIRECT_URL}"
-    indexeddbs:
+      corp-sso:
+        default: true
+        source:
+          ref: github.com/valon-technologies/gestalt-providers/auth/oidc
+          version: 0.0.1-alpha.1
+        config:
+          issuerUrl: "${OIDC_ISSUER_URL}"
+          clientId: "${OIDC_CLIENT_ID}"
+          clientSecret: "${OIDC_CLIENT_SECRET}"
+          redirectUrl: "${OIDC_REDIRECT_URL}"
+    indexeddb:
       main:
+        default: true
         source:
           ref: github.com/valon-technologies/gestalt-providers/indexeddb/relationaldb
           version: 0.0.1-alpha.2
@@ -178,7 +188,7 @@ Service rather than exposing it on the public ingress.
 
 ## When to enable `pluginInit`
 
-Enable the init container when your config uses `providers.plugins.*.source.ref`, `providers.auth.source.ref`, `providers.indexeddbs.*.source.ref`, or `providers.ui.*.source.ref` and you want that state prepared before the main container starts. The init container copies the rendered config and runs:
+Enable the init container when your config uses `plugins.*.source.ref`, `providers.auth.*.source.ref`, `providers.indexeddb.*.source.ref`, or `providers.ui.*.source.ref` and you want that state prepared before the main container starts. The init container copies the rendered config and runs:
 
 `/gestaltd init --config /etc/gestalt/config.yaml`
 

--- a/docs/content/observability.mdx
+++ b/docs/content/observability.mdx
@@ -15,12 +15,15 @@ finished initialization, then switches to `200`.
 
 ## Default Telemetry
 
-If you omit the `providers.telemetry` block, Gestalt defaults to stdout.
+If you omit the `providers.telemetry` block, Gestalt inserts a builtin
+`providers.telemetry.default` entry with `source: stdout`.
 
 ```yaml
 providers:
   telemetry:
-    source: stdout
+    default:
+      default: true
+      source: stdout
 ```
 
 That gives you structured logs without external collectors. The `stdout`
@@ -29,39 +32,51 @@ disabled unless you switch to `source: otlp` under `providers.telemetry`.
 
 ## OTLP Export
 
-Set `source: otlp` under `providers.telemetry` to export traces, metrics, and
-logs over OpenTelemetry.
+Set `source: otlp` under the selected `providers.telemetry` entry to export
+traces, metrics, and logs over OpenTelemetry.
 
 ```yaml
+server:
+  providers:
+    telemetry: observability
+
 providers:
   telemetry:
-    source: otlp
-    config:
-      endpoint: otel-collector:4317
-      protocol: grpc
-      service_name: gestaltd
-      traces:
-        sampling_ratio: 1.0
-      metrics:
-        interval: 60s
-      logs:
-        level: info
+    observability:
+      default: true
+      source: otlp
+      config:
+        endpoint: otel-collector:4317
+        protocol: grpc
+        serviceName: gestaltd
+        traces:
+          samplingRatio: 1.0
+        metrics:
+          interval: 60s
+        logs:
+          level: info
 ```
 
 If you want traces and metrics in OTLP but need application logs to remain on
 stdout for the host platform to collect, override the log exporter.
 
 ```yaml
+server:
+  providers:
+    telemetry: observability
+
 providers:
   telemetry:
-    source: otlp
-    config:
-      endpoint: otel-collector:4317
-      protocol: grpc
-      logs:
-        exporter: stdout
-        format: json
-        level: info
+    observability:
+      default: true
+      source: otlp
+      config:
+        endpoint: otel-collector:4317
+        protocol: grpc
+        logs:
+          exporter: stdout
+          format: json
+          level: info
 ```
 
 ## Audit Routing
@@ -71,26 +86,36 @@ different route for compliance, analytics, or warehousing, configure
 `providers.audit` separately.
 
 ```yaml
+server:
+  providers:
+    telemetry: default
+    audit: compliance
+
 providers:
   telemetry:
-    source: stdout
-    config:
-      format: json
+    default:
+      default: true
+      source: stdout
+      config:
+        format: json
 
   audit:
-    source: otlp
-    config:
-      endpoint: audit-collector:4317
-      protocol: grpc
-      headers:
-        Authorization: Bearer ${AUDIT_OTLP_TOKEN}
+    compliance:
+      default: true
+      source: otlp
+      config:
+        endpoint: audit-collector:4317
+        protocol: grpc
+        headers:
+          Authorization: Bearer ${AUDIT_OTLP_TOKEN}
 ```
 
 That keeps application logs on stdout while exporting only audit records over
-OTLP. You can also set `providers.audit` with `source: stdout` to keep audit
-logs on stdout when telemetry is `noop`, or `source: noop` to disable audit
-output explicitly. If you leave `source: inherit` under `providers.audit`,
-collectors can still split the stream by filtering on `log.type=audit`.
+OTLP. You can also set the selected `providers.audit` entry to `source: stdout`
+to keep audit logs on stdout when telemetry is `noop`, or `source: noop` to
+disable audit output explicitly. If the selected audit entry uses
+`source: inherit`, collectors can still split the stream by filtering on
+`log.type=audit`.
 
 ## Emitted Metrics
 
@@ -206,9 +231,10 @@ provider name) and `gestalt.action` (`begin_login`, `complete_login`, or
 ### IndexedDB Metrics
 
 These metrics are recorded around every ObjectStore and Index operation on the
-system IndexedDB instance. The instrumentation is applied once at the interface
-level in bootstrap, so both core services (tokens, users, API tokens) and
-plugin host traffic are covered.
+instrumented IndexedDB instances Gestalt builds at bootstrap. That includes the
+active system datastore and any additional enabled host IndexedDB providers
+that are bound into plugins, so both core services (tokens, users, API tokens)
+and plugin host traffic are covered.
 
 <Tabs items={['OpenTelemetry', 'Prometheus']}>
   <Tabs.Tab>
@@ -336,11 +362,13 @@ These metrics use standard OpenTelemetry gRPC client semantic attributes such as
 ## Prometheus Scrape Endpoint
 
 When telemetry metrics are enabled, Gestalt exposes a Prometheus scrape endpoint
-at `/metrics`. With `providers.telemetry` set to `source: stdout`, metrics are
-kept local and served directly. With `source: otlp`, metrics are exported over
-OTLP and also served at `/metrics` locally unless you disable the Prometheus
-bridge. Setting `source: noop` disables Prometheus scraping entirely; `/metrics`
-returns a clear unavailable response so the admin UI can surface that state.
+at `/metrics`. When the selected `providers.telemetry` entry uses
+`source: stdout`, metrics are kept local and served directly. When it uses
+`source: otlp`, metrics are exported over OTLP and also served at `/metrics`
+locally unless you disable the Prometheus bridge. Setting the selected
+telemetry entry to `source: noop` disables Prometheus scraping entirely;
+`/metrics` returns a clear unavailable response so the admin UI can surface
+that state.
 
 When Gestalt serves `/metrics` on the public listener, it is authenticated with
 the same session or bearer-token middleware as the rest of the HTTP API. When

--- a/docs/content/providers/auth.mdx
+++ b/docs/content/providers/auth.mdx
@@ -1,16 +1,16 @@
 # Auth
 
 Auth providers handle platform login for the Gestalt server. They are separate
-from plugin connections: `providers.auth` decides how users sign in to the
-deployment itself, while plugin connections decide how Gestalt authenticates to
-upstream APIs on behalf of callers.
+from plugin connections: named entries under `providers.auth` decide how users
+sign in to the deployment itself, while plugin connections decide how Gestalt
+authenticates to upstream APIs on behalf of callers.
 
 ## How auth providers work
 
-When a request arrives without a valid session, Gestalt asks the configured
-auth provider to begin login, redirects the user to the identity provider, and
-then calls the provider again to complete the callback. After that, Gestalt
-issues and stores its own session.
+When a request arrives without a valid session, Gestalt asks the selected auth
+provider to begin login, redirects the user to the identity provider, and then
+calls the provider again to complete the callback. After that, Gestalt issues
+and stores its own session.
 
 Some auth providers also support:
 
@@ -31,42 +31,53 @@ First-party auth providers live under
 ## Configuring `providers.auth`
 
 ```yaml
+server:
+  providers:
+    auth: workspace-google
+
 providers:
   auth:
-    source:
-      ref: github.com/valon-technologies/gestalt-providers/auth/google
-      version: 0.0.1-alpha.1
-    config:
-      clientId: ${GOOGLE_CLIENT_ID}
-      clientSecret: secret://google-client-secret
-      allowedDomains:
-        - example.com
+    workspace-google:
+      default: true
+      source:
+        ref: github.com/valon-technologies/gestalt-providers/auth/google
+        version: 0.0.1-alpha.1
+      config:
+        clientId: ${GOOGLE_CLIENT_ID}
+        clientSecret: secret://google-client-secret
+        allowedDomains:
+          - example.com
 ```
 
 Secret references such as `secret://google-client-secret` are resolved through
-`providers.secrets` before the auth provider receives its config.
+the selected `providers.secrets` entry before the auth provider receives its
+config.
 
-To disable platform auth entirely, omit `providers.auth` or set:
+Use `server.providers.auth` when you have more than one auth entry. If there is
+only one auth entry, Gestalt selects it automatically; otherwise mark one entry
+`default: true`.
 
-```yaml
-providers:
-  auth:
-    disabled: true
-```
+To disable platform auth entirely, omit `providers.auth`.
 
-For local development, that disabled mode is the simple default: every request
+For local development, that no-auth mode is the simple default: every request
 is treated as the same anonymous user.
 
 ## Local source during development
 
 ```yaml
+server:
+  providers:
+    auth: local-auth
+
 providers:
   auth:
-    source:
-      path: ./google-auth/manifest.yaml
-    config:
-      clientId: ${GOOGLE_CLIENT_ID}
-      clientSecret: secret://google-client-secret
+    local-auth:
+      default: true
+      source:
+        path: ./google-auth/manifest.yaml
+      config:
+        clientId: ${GOOGLE_CLIENT_ID}
+        clientSecret: secret://google-client-secret
 ```
 
 ## Building your own auth provider

--- a/docs/content/providers/index.mdx
+++ b/docs/content/providers/index.mdx
@@ -14,11 +14,11 @@ starts it with the permissions and request context it needs.
 
 | Kind | Purpose | Config location |
 | --- | --- | --- |
-| `plugin` | Tool providers that expose operations over CLI, HTTP API, and MCP | `providers.plugins.<name>` |
-| `auth` | Platform login backends | `providers.auth` |
-| `indexeddb` | Persistent state backends for users, sessions, tokens, and credentials | `providers.indexeddbs.<name>` |
-| `secrets` | Secret managers that resolve `secret://` references | `providers.secrets` |
-| `webui` | Public UI bundles served under configured path prefixes | `providers.ui` |
+| `plugin` | Tool providers that expose operations over CLI, HTTP API, and MCP | `plugins.<name>` |
+| `auth` | Platform login backends | `providers.auth.<name>` |
+| `indexeddb` | Persistent state backends for users, sessions, tokens, and credentials | `providers.indexeddb.<name>` |
+| `secrets` | Secret managers that resolve `secret://` references | `providers.secrets.<name>` |
+| `webui` | Public UI bundles served under configured path prefixes | `providers.ui.<name>` |
 
 ## How providers work
 
@@ -41,11 +41,11 @@ The repository is organized by provider type:
 
 | Type | Repository path | Typical config key |
 | --- | --- | --- |
-| Plugins | [`plugins/`](https://github.com/valon-technologies/gestalt-providers/tree/main/plugins) | `providers.plugins.<name>` |
-| Auth | [`auth/`](https://github.com/valon-technologies/gestalt-providers/tree/main/auth) | `providers.auth` |
-| IndexedDB | [`indexeddb/`](https://github.com/valon-technologies/gestalt-providers/tree/main/indexeddb) | `providers.indexeddbs.<name>` |
-| Secrets | [`secrets/`](https://github.com/valon-technologies/gestalt-providers/tree/main/secrets) | `providers.secrets` |
-| Web UI bundles | [`web/`](https://github.com/valon-technologies/gestalt-providers/tree/main/web) | `providers.ui` |
+| Plugins | [`plugins/`](https://github.com/valon-technologies/gestalt-providers/tree/main/plugins) | `plugins.<name>` |
+| Auth | [`auth/`](https://github.com/valon-technologies/gestalt-providers/tree/main/auth) | `providers.auth.<name>` |
+| IndexedDB | [`indexeddb/`](https://github.com/valon-technologies/gestalt-providers/tree/main/indexeddb) | `providers.indexeddb.<name>` |
+| Secrets | [`secrets/`](https://github.com/valon-technologies/gestalt-providers/tree/main/secrets) | `providers.secrets.<name>` |
+| Web UI bundles | [`web/`](https://github.com/valon-technologies/gestalt-providers/tree/main/web) | `providers.ui.<name>` |
 
 ## Using providers
 
@@ -53,31 +53,36 @@ Reference the package you want to run, then initialize or start the server:
 
 ```yaml
 server:
-  indexeddb: main
+  providers:
+    auth: corp-sso
+    indexeddb: main
 
 providers:
   auth:
-    source:
-      ref: github.com/valon-technologies/gestalt-providers/auth/oidc
-      version: 0.0.1-alpha.1
-    config:
-      issuerUrl: https://login.example.com
-      clientId: ${OIDC_CLIENT_ID}
-      clientSecret: secret://oidc-client-secret
+    corp-sso:
+      default: true
+      source:
+        ref: github.com/valon-technologies/gestalt-providers/auth/oidc
+        version: 0.0.1-alpha.1
+      config:
+        issuerUrl: https://login.example.com
+        clientId: ${OIDC_CLIENT_ID}
+        clientSecret: secret://oidc-client-secret
 
-  indexeddbs:
+  indexeddb:
     main:
+      default: true
       source:
         ref: github.com/valon-technologies/gestalt-providers/indexeddb/relationaldb
         version: 0.0.1-alpha.1
       config:
         dsn: ${DATABASE_URL}
 
-  plugins:
-    github:
-      source:
-        ref: github.com/valon-technologies/gestalt-providers/plugins/github
-        version: 0.0.1-alpha.1
+plugins:
+  github:
+    source:
+      ref: github.com/valon-technologies/gestalt-providers/plugins/github
+      version: 0.0.1-alpha.1
 ```
 
 Run `gestaltd init` when you want to resolve and pin published releases ahead

--- a/docs/content/providers/indexeddb.mdx
+++ b/docs/content/providers/indexeddb.mdx
@@ -7,9 +7,13 @@ contract can map cleanly to relational, document, or key-value backends.
 
 ## How IndexedDB providers work
 
-The active datastore is selected by `server.indexeddb`, which points to one of
-the named entries under `providers.indexeddbs`. Gestalt talks to that provider
-through the IndexedDB service contract while keeping plugin state namespaced so
+The active datastore is selected by `server.providers.indexeddb`, by a single
+`default: true` entry under `providers.indexeddb`, or by the only
+`providers.indexeddb` entry when there is exactly one. Disabled IndexedDB
+entries may stay in the config for later reuse, but Gestalt will not select
+them as the active datastore or expose them to plugins. Gestalt talks to the
+active datastore and any enabled plugin-bound host IndexedDB providers through
+the IndexedDB service contract while keeping plugin state namespaced so
 plugins cannot read or overwrite each other's records directly.
 
 ## First-party IndexedDB providers
@@ -29,11 +33,13 @@ For local development, SQLite keeps setup simple:
 
 ```yaml
 server:
-  indexeddb: main
+  providers:
+    indexeddb: main
 
 providers:
-  indexeddbs:
+  indexeddb:
     main:
+      default: true
       source:
         path: ./relationaldb/manifest.yaml
       config:
@@ -44,10 +50,11 @@ For production, reference a published release:
 
 ```yaml
 server:
-  indexeddb: main
+  providers:
+    indexeddb: main
 
 providers:
-  indexeddbs:
+  indexeddb:
     main:
       source:
         ref: github.com/valon-technologies/gestalt-providers/indexeddb/relationaldb
@@ -63,7 +70,7 @@ Other first-party IndexedDB providers use their own config blocks:
 
 ```yaml
 providers:
-  indexeddbs:
+  indexeddb:
     main:
       source:
         ref: github.com/valon-technologies/gestalt-providers/indexeddb/dynamodb
@@ -76,7 +83,7 @@ providers:
 
 ```yaml
 providers:
-  indexeddbs:
+  indexeddb:
     main:
       source:
         ref: github.com/valon-technologies/gestalt-providers/indexeddb/mongodb
@@ -88,11 +95,18 @@ providers:
 
 ## Operational notes
 
-- Gestalt needs exactly one active datastore selected by `server.indexeddb`.
+- Gestalt needs exactly one active datastore selected by
+  `server.providers.indexeddb`, resolved from a single `default: true`
+  `providers.indexeddb` entry, or inferred from the only
+  `providers.indexeddb` entry.
 - Published datastore packages can be prepared with `gestaltd init` just like
   other provider types.
 - Plugins still go through the host's request and auth model; they do not talk
   to the datastore provider directly.
+- When a plugin omits `plugins.<name>.indexeddb`, Gestalt exposes the
+  selected/default host IndexedDB to that plugin automatically. An explicit
+  `plugins.<name>.indexeddb` list overrides that inheritance, and
+  `plugins.<name>.indexeddb: []` disables inherited IndexedDB access.
 
 ## Building your own datastore provider
 

--- a/docs/content/providers/plugins.mdx
+++ b/docs/content/providers/plugins.mdx
@@ -1,7 +1,7 @@
 # Plugins
 
 Plugin providers are the packages that expose tools through Gestalt. Operators
-configure them under `providers.plugins`, while the host takes care of catalog
+configure them under top-level `plugins`, while the host takes care of catalog
 loading, token storage, connection management, HTTP routing, and MCP exposure.
 
 ## How plugin providers work
@@ -38,28 +38,55 @@ their package layouts.
 ## Configuring a plugin provider
 
 ```yaml
+server:
+  providers:
+    indexeddb: main
+
 providers:
-  plugins:
-    github:
-      displayName: GitHub
+  indexeddb:
+    main:
+      default: true
       source:
-        ref: github.com/valon-technologies/gestalt-providers/plugins/github
-        version: 0.0.1-alpha.1
-      config:
-        apiBaseUrl: https://api.github.com
-        clientId: ${GITHUB_CLIENT_ID}
-        clientSecret: secret://github-client-secret
+        path: ./providers/indexeddb/relationaldb/manifest.yaml
+
+plugins:
+  github:
+    displayName: GitHub
+    source:
+      ref: github.com/valon-technologies/gestalt-providers/plugins/github
+      version: 0.0.1-alpha.1
+    config:
+      apiBaseUrl: https://api.github.com
+      clientId: ${GITHUB_CLIENT_ID}
+      clientSecret: secret://github-client-secret
 ```
 
 During local development, point at a source manifest instead:
 
 ```yaml
-providers:
-  plugins:
-    support:
-      source:
-        path: ./plugins/support/manifest.yaml
+plugins:
+  support:
+    source:
+      path: ./plugins/support/manifest.yaml
 ```
+
+## IndexedDB bindings
+
+Plugins that use the IndexedDB SDK can bind one or more named host datastores:
+
+```yaml
+plugins:
+  roadmap:
+    source:
+      path: ./plugins/roadmap/manifest.yaml
+    indexeddb:
+      - archive
+```
+
+When `plugins.<name>.indexeddb` is omitted, Gestalt inherits the
+selected/default host IndexedDB for that plugin. An explicit `indexeddb` list
+overrides that inheritance, and `indexeddb: []` disables inherited IndexedDB
+access entirely for that plugin.
 
 ## Connections and credentials
 
@@ -82,28 +109,26 @@ the plugin's `config` block when the provider requires them.
 Use `allowedOperations` to publish only a subset of a large plugin catalog:
 
 ```yaml
-providers:
-  plugins:
-    support:
-      source:
-        ref: github.com/acme/providers/support
-        version: 2.4.0
-      allowedOperations:
-        tickets.list:
-          alias: list_tickets
-        tickets.get:
-          alias: get_ticket
+plugins:
+  support:
+    source:
+      ref: github.com/acme/providers/support
+      version: 2.4.0
+    allowedOperations:
+      tickets.list:
+        alias: list_tickets
+      tickets.get:
+        alias: get_ticket
 ```
 
 Use `allowedHosts` when a plugin needs explicit outbound access:
 
 ```yaml
-providers:
-  plugins:
-    github:
-      allowedHosts:
-        - api.github.com
-        - "*.github.com"
+plugins:
+  github:
+    allowedHosts:
+      - api.github.com
+      - "*.github.com"
 ```
 
 ## Building your own plugin

--- a/docs/content/providers/secrets.mdx
+++ b/docs/content/providers/secrets.mdx
@@ -19,36 +19,53 @@ Cloud or vault-backed secret managers are external providers published from
 
 ## Configuring built-in providers
 
+If you omit `providers.secrets` entirely, Gestalt inserts a builtin `default`
+entry with `source: env`.
+
 Use environment variables:
 
 ```yaml
 providers:
   secrets:
-    source: env
-    config:
-      prefix: GESTALT_
+    default:
+      default: true
+      source: env
+      config:
+        prefix: GESTALT_
 ```
 
 Or use a directory of mounted files:
 
 ```yaml
+server:
+  providers:
+    secrets: filesystem
+
 providers:
   secrets:
-    source: file
-    config:
-      dir: /run/secrets
+    filesystem:
+      default: true
+      source: file
+      config:
+        dir: /run/secrets
 ```
 
 ## Configuring external secret providers
 
 ```yaml
+server:
+  providers:
+    secrets: google
+
 providers:
   secrets:
-    source:
-      ref: github.com/valon-technologies/gestalt-providers/secrets/google
-      version: 0.0.1-alpha.1
-    config:
-      project: my-gcp-project
+    google:
+      default: true
+      source:
+        ref: github.com/valon-technologies/gestalt-providers/secrets/google
+        version: 0.0.1-alpha.1
+      config:
+        project: my-gcp-project
 ```
 
 The configured provider resolves each `secret://name` reference before any auth

--- a/docs/content/reference/built-in-providers.mdx
+++ b/docs/content/reference/built-in-providers.mdx
@@ -6,7 +6,7 @@ Two simple secrets providers (`env` and `file`), telemetry, and audit remain bui
 
 ## Auth Providers
 
-Auth providers handle platform login. They are configured under `providers.auth` in your config file.
+Auth providers handle platform login. They are configured under named entries in `providers.auth`, and `server.providers.auth` selects the active one when more than one is present.
 
 | Name | Purpose |
 | --- | --- |
@@ -15,29 +15,37 @@ Auth providers handle platform login. They are configured under `providers.auth`
 | `oidc` | Generic OpenID Connect. Works with Okta, Auth0, Azure AD, Keycloak, and others. |
 
 ```yaml
+server:
+  providers:
+    auth: workspace-google
+
 providers:
   auth:
-    source:
-      ref: github.com/valon-technologies/gestalt-providers/auth/google
-      version: 1.0.0
-    config:
-      allowedDomains:
-        - example.com
+    workspace-google:
+      default: true
+      source:
+        ref: github.com/valon-technologies/gestalt-providers/auth/google
+        version: 1.0.0
+      config:
+        allowedDomains:
+          - example.com
 ```
 
-To disable platform auth entirely, omit the `providers.auth` block or set `providers: { auth: { disabled: true } }`.
+To disable platform auth entirely, omit the `providers.auth` block.
 
 ## IndexedDB Providers
 
-Datastore providers back the persistent state layer. They are configured under named entries in `providers.indexeddbs`, and `server.indexeddb` selects which one the host uses. Gestalt does not compile datastore drivers into the binary; it starts the configured external datastore provider process at runtime.
+Datastore providers back the persistent state layer. They are configured under named entries in `providers.indexeddb`, and `server.providers.indexeddb` selects which one the host uses. Gestalt does not compile datastore drivers into the binary; it starts the configured external datastore provider process at runtime.
 
 ```yaml
 server:
-  indexeddb: main
+  providers:
+    indexeddb: main
 
 providers:
-  indexeddbs:
+  indexeddb:
     main:
+      default: true
       source:
         ref: github.com/valon-technologies/gestalt-providers/indexeddb/relationaldb
         version: 1.0.0
@@ -60,7 +68,7 @@ Two secret managers are compiled into the `gestaltd` binary and resolve `secret:
 | `env` | Resolves secrets from environment variables. Default when `providers.secrets` is omitted. |
 | `file` | Resolves secrets from files in a configured directory. Works with Kubernetes volume-mounted secrets. |
 
-For cloud backends (Google Secret Manager, AWS Secrets Manager, HashiCorp Vault, Azure Key Vault), see [Secrets Providers](/providers/secrets#available-providers). These use a `source:` config key under `providers.secrets`.
+For cloud backends (Google Secret Manager, AWS Secrets Manager, HashiCorp Vault, Azure Key Vault), see [Secrets Providers](/providers/secrets#available-providers). These use named entries under `providers.secrets`.
 
 ## Telemetry Providers (built-in)
 
@@ -68,21 +76,20 @@ Telemetry providers are compiled into the binary.
 
 | Name | Purpose |
 | --- | --- |
-| `stdout` | Outputs structured logs to standard output. Traces stay disabled, and metrics are exposed locally through the built-in Prometheus bridge. Default when `telemetry` is omitted. |
+| `stdout` | Outputs structured logs to standard output. Traces stay disabled, and metrics are exposed locally through the built-in Prometheus bridge. Default when `providers.telemetry` is omitted. |
 | `otlp` | Exports traces, metrics, and logs via OpenTelemetry Protocol. |
 | `noop` | Disables all telemetry collection. |
 
 ## Plugins
 
-Plugins (BigQuery, Jira, Slack, and others) are published separately from [`valon-technologies/gestalt-providers`](https://github.com/valon-technologies/gestalt-providers). They are configured under `providers.plugins`:
+Plugins (BigQuery, Jira, Slack, and others) are published separately from [`valon-technologies/gestalt-providers`](https://github.com/valon-technologies/gestalt-providers). They are configured under top-level `plugins`:
 
 ```yaml
-providers:
-  plugins:
-    jira:
-      source:
-        ref: github.com/valon-technologies/gestalt-providers/jira
-        version: 1.0.0
+plugins:
+  jira:
+    source:
+      ref: github.com/valon-technologies/gestalt-providers/plugins/jira
+      version: 1.0.0
 ```
 
 ## Community and Custom Providers

--- a/docs/content/reference/config-file.mdx
+++ b/docs/content/reference/config-file.mdx
@@ -2,21 +2,33 @@ import { Tabs } from 'nextra/components'
 
 # Config File
 
-Every `gestaltd` deployment reads a single YAML config file. The top-level keys are `server` (listener, encryption, egress, and indexeddb selection), `authorization` (shared human/workload access policy), `providers` (auth, secrets, telemetry, audit, mounted UI bundles, and indexeddbs), and `plugins` (executable integrations):
+Every `gestaltd` deployment reads a single YAML config file. The canonical
+top-level keys are `server` (listener, encryption, egress, and host provider
+selection), `authorization` (shared human and workload access policy),
+`providers` (auth, secrets, telemetry, audit, mounted UI bundles, and
+indexeddb), and `plugins` (executable integrations):
 
 ```yaml
 server:
-  # listener, encryption, egress, indexeddb selector
+  # listener, encryption, egress, host provider selection
+  providers:
+    indexeddb: main
 authorization:
   policies: {}
   workloads: {}
 providers:
-  auth: {}
-  secrets: {}
-  telemetry: {}
-  audit: {}
-  ui: {}
-  indexeddb: {}
+  auth:
+    <name>: {}
+  secrets:
+    <name>: {}
+  telemetry:
+    <name>: {}
+  audit:
+    <name>: {}
+  ui:
+    <name>: {}
+  indexeddb:
+    <name>: {}
 plugins: {}
 ```
 
@@ -24,7 +36,7 @@ plugins: {}
 
 `${ENV_VAR}` references are expanded before YAML decoding. When a referenced variable is unset, Gestalt checks for a corresponding `ENV_VAR_FILE` variable and reads that file path instead. If neither is set, config loading fails. Use `${ENV_VAR:-}` when an explicit empty default is intentional. Unknown YAML fields are rejected.
 
-Several fields carry defaults when omitted: `server.public.port` defaults to `8080`, `providers.secrets.source` to `env`, and `providers.telemetry.source` to `stdout`. Relative paths resolve relative to the config file's directory. `secret://...` values are resolved during bootstrap, not during YAML parsing.
+Several fields carry defaults when omitted: `server.public.port` defaults to `8080`, `providers.secrets.default` defaults to builtin `env`, `providers.telemetry.default` defaults to builtin `stdout`, and `providers.audit.default` defaults to builtin `inherit`. Relative paths resolve relative to the config file's directory. `secret://...` values are resolved during bootstrap, not during YAML parsing.
 
 `authorization` is the canonical location for shared human and workload access policy. Existing deployments may continue to use `server.authorization` as a deprecated compatibility alias; Gestalt normalizes it into the top-level block during config load and bootstrap.
 
@@ -39,6 +51,12 @@ server:
     host: 127.0.0.1
     port: 9090
   baseUrl: https://gestalt.example.com
+  providers:
+    auth: corp-sso
+    secrets: vault
+    telemetry: observability
+    audit: compliance
+    indexeddb: main
   encryptionKey: secret://gestalt-encryption-key
   apiTokenTtl: 30d
   artifactsDir: ./state
@@ -88,6 +106,11 @@ authorization:
 | `management.host` | | Bind address for the management listener. |
 | `management.port` | | Port for the management listener. Required when `management.host` is set. |
 | `baseUrl` | | Public origin URL used for OAuth callbacks and admin UI links. |
+| `providers.auth` | | Named `providers.auth` entry the host uses for platform login. |
+| `providers.secrets` | | Named `providers.secrets` entry the host uses for config secret resolution. |
+| `providers.telemetry` | | Named `providers.telemetry` entry the host uses for logs, traces, and metrics. |
+| `providers.audit` | | Named `providers.audit` entry the host uses for audit output. |
+| `providers.indexeddb` | | Named `providers.indexeddb` entry the host uses for system storage. |
 | `encryptionKey` | | **Required.** Root encryption key. Typically a `secret://` reference. |
 | `apiTokenTtl` | `30d` | Lifetime of newly issued API tokens. Go durations or day suffixes (`30d`). |
 | `artifactsDir` | config directory | Directory for prepared `init` artifacts. |
@@ -98,33 +121,51 @@ When `server.management` is configured, Gestalt serves `/`, `/api/v1/*`, auth ro
 
 ## `providers.auth`
 
-Platform auth is optional. Omit the `providers.auth` block entirely to disable platform authentication, or set `providers: { auth: { disabled: true } }` explicitly. When auth is enabled, configure it with `providers.auth.source` and `providers.auth.config`. The source uses the same provider-reference shape as plugins: a `source` block plus optional `env` and `allowedHosts`.
+Platform auth is optional. Omit `providers.auth` entirely to disable platform authentication. When auth is enabled, configure one or more named entries under `providers.auth`, then select the active one with `server.providers.auth` or by marking exactly one entry `default: true`. If exactly one auth entry exists, Gestalt selects it automatically.
 
-### `disabled`
+Auth entries use the same provider-reference shape as plugins: a `source` block plus optional `env` and `allowedHosts`.
 
 ```yaml
+server:
+  providers:
+    auth: corp-sso
+
 providers:
   auth:
-    disabled: true
+    corp-sso:
+      default: true
+      source:
+        ref: github.com/valon-technologies/gestalt-providers/auth/oidc
+        version: 0.0.1-alpha.1
+      config:
+        issuerUrl: https://login.example.com
+        clientId: ${OIDC_CLIENT_ID}
+        clientSecret: secret://oidc-client-secret
 ```
 
-Disables platform authentication. Every request is treated as a single anonymous user. Omitting the `providers.auth` block has the same effect.
+If `providers.auth` is omitted, every request is treated as anonymous.
 
 ### `google`
 
 ```yaml
+server:
+  providers:
+    auth: workspace-google
+
 providers:
   auth:
-    source:
-      ref: github.com/valon-technologies/gestalt-providers/auth/google
-      version: 0.0.1-alpha.1
-    config:
-      clientId: ${GOOGLE_CLIENT_ID}
-      clientSecret: secret://google-client-secret
-      redirectUrl: https://gestalt.example.com/api/v1/auth/login/callback
-      allowedDomains:
-        - example.com
-      sessionTtl: 24h
+    workspace-google:
+      default: true
+      source:
+        ref: github.com/valon-technologies/gestalt-providers/auth/google
+        version: 0.0.1-alpha.1
+      config:
+        clientId: ${GOOGLE_CLIENT_ID}
+        clientSecret: secret://google-client-secret
+        redirectUrl: https://gestalt.example.com/api/v1/auth/login/callback
+        allowedDomains:
+          - example.com
+        sessionTtl: 24h
 ```
 
 `clientId` and `clientSecret` are both required and identify your Google OAuth application. `redirectUrl` defaults to a path derived from `server.baseUrl` when omitted. `allowedDomains` restricts login to specific email domains. `sessionTtl` controls session token lifetime and defaults to `24h`.
@@ -134,25 +175,31 @@ Google checks `email_verified` on every login. Unverified accounts are rejected.
 ### `oidc`
 
 ```yaml
+server:
+  providers:
+    auth: corp-sso
+
 providers:
   auth:
-    source:
-      ref: github.com/valon-technologies/gestalt-providers/auth/oidc
-      version: 0.0.1-alpha.1
-    config:
-      issuerUrl: https://login.example.com
-      clientId: ${OIDC_CLIENT_ID}
-      clientSecret: secret://oidc-client-secret
-      redirectUrl: https://gestalt.example.com/api/v1/auth/login/callback
-      allowedDomains:
-        - example.com
-      scopes:
-        - openid
-        - email
-        - profile
-      sessionTtl: 24h
-      pkce: true
-      displayName: Company SSO
+    corp-sso:
+      default: true
+      source:
+        ref: github.com/valon-technologies/gestalt-providers/auth/oidc
+        version: 0.0.1-alpha.1
+      config:
+        issuerUrl: https://login.example.com
+        clientId: ${OIDC_CLIENT_ID}
+        clientSecret: secret://oidc-client-secret
+        redirectUrl: https://gestalt.example.com/api/v1/auth/login/callback
+        allowedDomains:
+          - example.com
+        scopes:
+          - openid
+          - email
+          - profile
+        sessionTtl: 24h
+        pkce: true
+        displayName: Company SSO
 ```
 
 Two fields are required: `issuerUrl` (the OIDC discovery base URL) and `clientId`. `clientSecret` may be omitted for PKCE-only public clients.
@@ -165,18 +212,22 @@ OIDC checks `email_verified` when the claim is present. Unverified accounts are 
 
 ### `providers.auth` shape
 
-Both `google` and `oidc` use the same PluginDef provider reference shape under `providers.auth`. First-party auth providers are published at `github.com/valon-technologies/gestalt-providers/auth/<name>`.
+Both `google` and `oidc` use the same provider-entry shape under `providers.auth.<name>`. First-party auth providers are published at `github.com/valon-technologies/gestalt-providers/auth/<name>`.
 
 | Field | Description |
 | --- | --- |
+| `default` | Marks this entry as the fallback when `server.providers.auth` is omitted. At most one auth entry may set it. |
+| `disabled` | Disables this named auth entry without deleting it from the file. |
 | `source.ref` | Managed provider source address. |
 | `source.version` | Required with `source.ref`. SemVer without a leading `v`. |
+| `source.path` | Local provider manifest path for development or custom auth providers. |
 | `env` | Extra environment variables passed to the provider process. |
 | `allowedHosts` | Network allowlist for sandboxed provider processes. |
+| `config` | Provider-specific config passed through to the auth provider. |
 
 ## `providers.indexeddb`
 
-Indexed databases are provider-based. Configure one or more named entries under `providers.indexeddb`, then set `server.providers.indexeddb` to the name the host should use for system storage. First-party indexeddb providers are published at `github.com/valon-technologies/gestalt-providers/indexeddb/<name>`.
+Indexed databases are provider-based. Configure one or more named entries under `providers.indexeddb`, then select the host datastore with `server.providers.indexeddb` or mark one entry `default: true`. If exactly one IndexedDB entry exists, Gestalt selects it automatically. Disabled IndexedDB entries may stay in the config, but Gestalt will not select them as the active datastore or expose them to plugins. First-party indexeddb providers are published at `github.com/valon-technologies/gestalt-providers/indexeddb/<name>`.
 
 ```yaml
 server:
@@ -186,6 +237,7 @@ server:
 providers:
   indexeddb:
     main:
+      default: true
       source:
         ref: github.com/valon-technologies/gestalt-providers/indexeddb/relationaldb
         version: 0.0.1-alpha.2
@@ -194,6 +246,8 @@ providers:
 ```
 
 The exact config fields depend on the selected external indexeddb provider package. Gestalt itself does not have a built-in indexeddb driver matrix; it loads the configured provider process and passes the selected `providers.indexeddb.<name>.config` block through to that provider.
+
+Plugins can request specific IndexedDB bindings with `plugins.<name>.indexeddb`. When a plugin omits that field, Gestalt now inherits the selected/default host IndexedDB for that plugin automatically. Set `indexeddb: []` to disable that inheritance for a plugin.
 
 Common first-party IndexedDB packages:
 
@@ -205,14 +259,22 @@ Common first-party IndexedDB packages:
 
 ## `providers.secrets`
 
-The secrets manager resolves `secret://` references at startup. Two built-in sources (`env` and `file`) are selected by the `source` field. Cloud secret backends are loaded as external providers using `source.ref`, the same way auth and indexeddb providers work.
+The secrets manager resolves `secret://` references at startup. Configure one or more named entries under `providers.secrets`, then select the active one with `server.providers.secrets` or by marking exactly one entry `default: true`. If `providers.secrets` is omitted entirely, Gestalt inserts a builtin `default` entry with `source: env`.
+
+Two built-in sources (`env` and `file`) use a scalar `source` value. Cloud secret backends are loaded as external providers using `source.ref`, the same way auth and indexeddb providers work.
 
 ```yaml
+server:
+  providers:
+    secrets: filesystem
+
 providers:
   secrets:
-    source: file
-    config:
-      dir: /etc/gestalt-secrets
+    filesystem:
+      default: true
+      source: file
+      config:
+        dir: /etc/gestalt-secrets
 ```
 
 | Source | Config fields | Purpose |
@@ -225,13 +287,19 @@ providers:
 Cloud secret managers are external providers configured with `source.ref` instead of a string `source`:
 
 ```yaml
+server:
+  providers:
+    secrets: google
+
 providers:
   secrets:
-    source:
-      ref: github.com/valon-technologies/gestalt-providers/secrets/google
-      version: 0.0.1-alpha.13
-    config:
-      project: my-gcp-project
+    google:
+      default: true
+      source:
+        ref: github.com/valon-technologies/gestalt-providers/secrets/google
+        version: 0.0.1-alpha.13
+      config:
+        project: my-gcp-project
 ```
 
 | Provider | Source ref | Config fields |
@@ -245,7 +313,7 @@ See [Secrets Providers](/providers/secrets) for the complete reference and SDK i
 
 ### Bootstrap credentials
 
-`secret://` references are resolved through the configured secret manager at startup, but the secret manager's own configuration (`providers.secrets.config`) cannot use `secret://` because it would be self-referential. Use `${ENV_VAR}` or `${ENV_VAR_FILE}` placeholders for any credentials the secret manager itself needs.
+`secret://` references are resolved through the configured secret manager at startup, but the secret manager's own configuration (`providers.secrets.<name>.config`) cannot use `secret://` because it would be self-referential. Use `${ENV_VAR}` or `${ENV_VAR_FILE}` placeholders for any credentials the secret manager itself needs.
 
 Each provider authenticates to its backing service differently. The `env` and `file` providers are built in. The remaining rows apply when using the corresponding external provider from `gestalt-providers`:
 
@@ -264,16 +332,24 @@ For local development, `env` or `file` avoids external dependencies entirely. Sw
 
 Gestalt uses [OpenTelemetry](https://opentelemetry.io) for distributed traces, metrics, and structured logs. Every HTTP request, broker invocation, and plugin gRPC call is automatically traced. See [Observability](/observability) for the emitted metric inventory and Prometheus name translation.
 
+Configure one or more named entries under `providers.telemetry`, then select the active one with `server.providers.telemetry` or by marking exactly one entry `default: true`. If `providers.telemetry` is omitted entirely, Gestalt inserts a builtin `default` entry with `source: stdout`.
+
 ### `stdout`
 
 ```yaml
+server:
+  providers:
+    telemetry: local
+
 providers:
   telemetry:
-    source: stdout
-    config:
-      format: text
-      level: info
-      serviceName: gestaltd
+    local:
+      default: true
+      source: stdout
+      config:
+        format: text
+        level: info
+        serviceName: gestaltd
 ```
 
 Outputs structured logs to standard output. Traces remain disabled, but metrics are collected locally and exposed through the Prometheus-compatible `/metrics` endpoint. The built-in admin UI at `/admin` reads that same scrape surface. This is the default when `providers.telemetry` is omitted.
@@ -289,26 +365,32 @@ Outputs structured logs to standard output. Traces remain disabled, but metrics 
 ### `otlp`
 
 ```yaml
+server:
+  providers:
+    telemetry: observability
+
 providers:
   telemetry:
-    source: otlp
-    config:
-      endpoint: otel-collector:4317
-      protocol: grpc
-      serviceName: gestaltd
-      insecure: false
-      headers:
-        Authorization: Bearer ${OTEL_TOKEN}
-      resourceAttributes:
-        deployment.environment: production
-        service.version: "1.0.0"
-      traces:
-        samplingRatio: 1.0
-      metrics:
-        interval: 60s
-      logs:
-        exporter: otlp
-        level: info
+    observability:
+      default: true
+      source: otlp
+      config:
+        endpoint: otel-collector:4317
+        protocol: grpc
+        serviceName: gestaltd
+        insecure: false
+        headers:
+          Authorization: Bearer ${OTEL_TOKEN}
+        resourceAttributes:
+          deployment.environment: production
+          service.version: "1.0.0"
+        traces:
+          samplingRatio: 1.0
+        metrics:
+          interval: 60s
+        logs:
+          exporter: otlp
+          level: info
 ```
 
 Exports to any OpenTelemetry-compatible collector (Jaeger, Grafana Alloy, Datadog Agent) while still keeping local `/metrics` available by default. The built-in admin UI at `/admin` reads that same local scrape surface.
@@ -331,26 +413,37 @@ Exports to any OpenTelemetry-compatible collector (Jaeger, Grafana Alloy, Datado
 To keep system logs on stdout while still exporting traces and metrics over OTLP:
 
 ```yaml
+server:
+  providers:
+    telemetry: observability
+
 providers:
   telemetry:
-    source: otlp
-    config:
-      endpoint: otel-collector:4317
-      protocol: grpc
-      metrics:
-        interval: 60s
-      logs:
-        exporter: stdout
-        format: json
-        level: info
+    observability:
+      source: otlp
+      config:
+        endpoint: otel-collector:4317
+        protocol: grpc
+        metrics:
+          interval: 60s
+        logs:
+          exporter: stdout
+          format: json
+          level: info
 ```
 
 ### `noop`
 
 ```yaml
+server:
+  providers:
+    telemetry: disabled
+
 providers:
   telemetry:
-    source: noop
+    disabled:
+      default: true
+      source: noop
 ```
 
 Disables all telemetry. Instrumentation points remain but produce zero overhead. This disables Prometheus scraping. `/metrics` returns a clear unavailable response, and the built-in admin UI shows that metrics are unavailable.
@@ -365,28 +458,42 @@ Disables all telemetry. Instrumentation points remain but produce zero overhead.
 
 ## `providers.audit`
 
-Audit records are emitted as structured log entries with `log.type=audit`. By default they inherit the normal telemetry log pipeline, but you can override that with a dedicated `providers.audit` block. See [Audit Logging](/audit-logging) for the event schema and coverage details, and [Observability](/observability) for export options. If you keep `providers: { audit: { source: inherit } }`, you can still route audit traffic to a dedicated backend by filtering on `log.type=audit` in your collector.
+Audit records are emitted as structured log entries with `log.type=audit`. Configure one or more named entries under `providers.audit`, then select the active one with `server.providers.audit` or by marking exactly one entry `default: true`. If `providers.audit` is omitted entirely, Gestalt inserts a builtin `default` entry with `source: inherit`.
+
+By default audit output inherits the normal telemetry log pipeline, but you can override that with a dedicated audit entry. See [Audit Logging](/audit-logging) for the event schema and coverage details, and [Observability](/observability) for export options. If you keep `source: inherit`, you can still route audit traffic to a dedicated backend by filtering on `log.type=audit` in your collector.
 
 ### `inherit`
 
 ```yaml
+server:
+  providers:
+    audit: default
+
 providers:
   audit:
-    source: inherit
+    default:
+      default: true
+      source: inherit
 ```
 
 This is the default when `providers.audit` is omitted. Audit records follow the same log route as `providers.telemetry`: when telemetry uses `stdout`, audit logs go to standard output; when telemetry uses `otlp`, audit logs export through the OTLP log pipeline; when telemetry uses `noop`, audit output is disabled unless you override it here.
 
-`providers.audit.config` is not allowed when `providers.audit.source` is `inherit`.
+`providers.audit.<name>.config` is not allowed when that entry uses `source: inherit`.
 
 ### `stdout`
 
 ```yaml
+server:
+  providers:
+    audit: compliance
+
 providers:
   audit:
-    source: stdout
-    config:
-      format: json
+    compliance:
+      default: true
+      source: stdout
+      config:
+        format: json
 ```
 
 Writes audit records to standard output even if the main telemetry pipeline is using a different provider.
@@ -399,18 +506,24 @@ Writes audit records to standard output even if the main telemetry pipeline is u
 ### `otlp`
 
 ```yaml
+server:
+  providers:
+    audit: compliance
+
 providers:
   audit:
-    source: otlp
-    config:
-      endpoint: audit-collector:4317
-      protocol: grpc
-      serviceName: gestaltd
-      insecure: false
-      headers:
-        Authorization: Bearer ${AUDIT_OTLP_TOKEN}
-      resourceAttributes:
-        log.stream: audit
+    compliance:
+      default: true
+      source: otlp
+      config:
+        endpoint: audit-collector:4317
+        protocol: grpc
+        serviceName: gestaltd
+        insecure: false
+        headers:
+          Authorization: Bearer ${AUDIT_OTLP_TOKEN}
+        resourceAttributes:
+          log.stream: audit
 ```
 
 Exports audit records over OTLP without changing where application logs, metrics, or traces go. Use this when you want audit records in a dedicated compliance pipeline while keeping the rest of `gestaltd` on `stdout` or a different OTLP collector.
@@ -427,16 +540,22 @@ Exports audit records over OTLP without changing where application logs, metrics
 ### `noop`
 
 ```yaml
+server:
+  providers:
+    audit: disabled
+
 providers:
   audit:
-    source: noop
+    disabled:
+      default: true
+      source: noop
 ```
 
-Disables audit output explicitly. `providers.audit.config` is not allowed when `providers.audit.source` is `noop`.
+Disables audit output explicitly. `providers.audit.<name>.config` is not allowed when that entry uses `source: noop`.
 
 ## `plugins`
 
-Each entry in the `plugins` map is a named plugin backed by an executable provider package. The provider package is the source of truth for operations and transport details. Server config selects the provider, passes provider-specific config, and declares connection policy. The HTTP API route paths still use "integrations" (e.g. `/api/v1/integrations`) as stable code surface, but the CLI and config both use `plugins` as the canonical term.
+Each entry in the top-level `plugins` map is a named plugin backed by an executable provider package. The provider package is the source of truth for operations and transport details. Server config loads the plugin, passes provider-specific config, and declares connection policy. The HTTP API route paths still use "integrations" (e.g. `/api/v1/integrations`) as stable code surface, but the CLI and config both use `plugins` as the canonical term.
 
 ```yaml
 plugins:
@@ -446,8 +565,10 @@ plugins:
     iconFile: ./icons/github.svg
     authorizationPolicy: support_staff
     source:
-      ref: github.com/valon-technologies/gestalt-providers/github
+      ref: github.com/valon-technologies/gestalt-providers/plugins/github
       version: 1.2.3
+    indexeddb:
+      - archive
     surfaces:
       openapi:
         baseUrl: https://api.github.com
@@ -476,7 +597,7 @@ plugins:
 | `surfaces` | Typed host-side overrides for manifest-declared surfaces, such as `surfaces.openapi.baseUrl` or `surfaces.graphql.url`. |
 | `connections` | Named connection declarations. See [connections](#connections) below. |
 | `allowedOperations` | Allowlist with optional `alias`, `description`, and `allowedRoles` overrides per operation. |
-| `indexeddbs` | Optional list of named `providers.indexeddb` bindings exposed to the executable plugin through the SDK transport. Store names are automatically prefixed per plugin. A single binding also populates the default IndexedDB SDK env var for compatibility. |
+| `indexeddb` | Optional list of named `providers.indexeddb` bindings exposed to the executable plugin through the SDK transport. When omitted, the plugin inherits the selected/default host IndexedDB. Set `indexeddb: []` to disable inheritance. A single effective binding also populates the default IndexedDB SDK env var for compatibility. |
 
 ### `plugins.*.source`
 
@@ -484,7 +605,7 @@ Every plugin uses a `source` block to declare its backing provider.
 
 ```yaml
 source:
-  ref: github.com/valon-technologies/gestalt-providers/github
+  ref: github.com/valon-technologies/gestalt-providers/plugins/github
   version: 1.2.3
 ```
 
@@ -763,7 +884,9 @@ Structural validation runs at config load time (`init`, `validate`, `serve`). Ru
 
 Each plugin uses a `source` block. Every plugin must use exactly one loading mode: local `source.path` or managed `source.ref`. `source.version` is required with `source.ref` and invalid with `source.path`.
 
-Auth providers and indexeddb entries use the same external provider shape. When `providers.auth` or `providers.indexeddb.<name>` is set, `source.ref` or `source.path` must be present. `providers.auth.config` and `providers.indexeddb.<name>.config` are only allowed when their corresponding source is set.
+Host provider maps (`providers.auth`, `providers.secrets`, `providers.telemetry`, `providers.audit`, and `providers.indexeddb`) use named entries. `server.providers.<kind>` may select an entry explicitly. When the selector is omitted, Gestalt uses exactly one `default: true` entry, or the only entry if there is just one.
+
+Auth providers and indexeddb entries use the same external provider shape. When `providers.auth.<name>` or `providers.indexeddb.<name>` is set, `source.ref` or `source.path` must be present. `providers.auth.<name>.config` and `providers.indexeddb.<name>.config` are only allowed when their corresponding source is set.
 
 Only `connections.default` may define `params` or `discovery`. All connections in a plugin must share the same mode.
 
@@ -779,4 +902,4 @@ Server listener ports must be greater than zero. When `server.management` is con
 
 ### Runtime
 
-`server.providers.indexeddb`, `providers.indexeddb`, and `server.encryptionKey` are required at `serve` time. `providers.auth` is optional.
+`providers.indexeddb` and `server.encryptionKey` are required at `serve` time. The active datastore must resolve from `server.providers.indexeddb`, a single `default: true` `providers.indexeddb` entry, or the only `providers.indexeddb` entry, and that selected datastore may not be disabled. `providers.auth` is optional.

--- a/docs/content/reference/plugin-manifests.mdx
+++ b/docs/content/reference/plugin-manifests.mdx
@@ -338,7 +338,7 @@ The `artifacts` array lists platform-specific binaries included in the package.
 | `path` | string | yes | Path to the binary inside the package. |
 | `sha256` | string | no | SHA-256 hex digest for integrity verification. |
 
-Declarative-only plugin packages do not require `artifacts`. Pure executable source manifests used with `plugins.*.provider.source.path` or `gestaltd provider release` may omit them.
+Declarative-only plugin packages do not require `artifacts`. Pure executable source manifests used with `plugins.*.source.path` or `gestaltd provider release` may omit them.
 
 ## Full Example
 

--- a/docs/content/security.mdx
+++ b/docs/content/security.mdx
@@ -63,14 +63,14 @@ server:
     defaultAction: deny
 
 providers:
-  plugins:
-    my-plugin:
-      source:
-        ref: github.com/acme/plugins/my-plugin
-        version: 1.0.0
-      allowedHosts:
-        - "api.example.com"
-        - "*.slack.com"
+plugins:
+  my-plugin:
+    source:
+      ref: github.com/acme/plugins/my-plugin
+      version: 1.0.0
+    allowedHosts:
+      - "api.example.com"
+      - "*.slack.com"
 ```
 
 Wildcards are supported (`*.example.com` matches `api.example.com`). The same check applies uniformly to REST, GraphQL, and MCP providers.
@@ -90,11 +90,11 @@ Executable plugin providers run with additional OS-level isolation when `allowed
 | Setting | Impact |
 | --- | --- |
 | `server.encryptionKey` | Root deployment secret. If compromised, all stored tokens can be decrypted. Use a strong random string or 64-character hex key. Must be the same across all instances in a cluster. |
-| `providers.auth` | Omitting `providers.auth` or setting `providers: { auth: { disabled: true } }` disables all authentication. Do not use in production. |
+| `providers.auth` | Omitting `providers.auth` disables all authentication. Do not use in production. |
 | `server.baseUrl` | Must match the public URL exactly. OAuth callbacks are derived from it. |
 | TLS termination | Gestalt does not terminate TLS. Deploy behind a reverse proxy that handles TLS. |
 | `providers.secrets` | Use a dedicated secret manager in production. `env` is acceptable but secrets may appear in process listings. |
-| `providers.indexeddbs` and `server.indexeddb` | Use a production-grade datastore provider for multi-replica deployments. SQLite is single-writer and not suitable for multi-replica deployments. |
+| `providers.indexeddb` and `server.providers.indexeddb` | Use a production-grade datastore provider for multi-replica deployments. SQLite is single-writer and not suitable for multi-replica deployments. |
 
 ## Known limitations
 

--- a/docs/content/troubleshooting.mdx
+++ b/docs/content/troubleshooting.mdx
@@ -16,7 +16,7 @@ When `/ready` returns `503`, the server has not finished initialization. Readine
 
 ## Operation invocation
 
-A "provider not found" error means the plugin key in the request does not match any entry in `providers.plugins`. Verify the spelling and confirm the plugin loaded without errors at startup.
+A "provider not found" error means the plugin key in the request does not match any entry in top-level `plugins`. Verify the spelling and confirm the plugin loaded without errors at startup.
 
 An "operation not found" error means the operation ID does not exist in the plugin's catalog. Check that the operation is exposed and that `allowedOperations`, if set, includes it.
 

--- a/gestaltd/internal/bootstrap/bootstrap.go
+++ b/gestaltd/internal/bootstrap/bootstrap.go
@@ -120,12 +120,13 @@ func (m providerMetadata) descriptionOr(v string) string {
 }
 
 type Deps struct {
-	EncryptionKey []byte
-	BaseURL       string
-	SecretManager core.SecretManager
-	Services      *coredata.Services
-	IndexedDBs    map[string]indexeddb.IndexedDB
-	Egress        EgressDeps
+	EncryptionKey         []byte
+	BaseURL               string
+	SecretManager         core.SecretManager
+	Services              *coredata.Services
+	SelectedIndexedDBName string
+	IndexedDBs            map[string]indexeddb.IndexedDB
+	Egress                EgressDeps
 }
 
 type AuthFactory func(node yaml.Node, deps Deps) (core.AuthProvider, error)
@@ -312,6 +313,9 @@ func prepareCore(ctx context.Context, cfg *config.Config, factories *FactoryRegi
 	if selectedIndexedDBName == "" || def == nil {
 		return nil, fmt.Errorf("bootstrap: datastore resource name is required")
 	}
+	if def.Disabled {
+		return nil, fmt.Errorf("bootstrap: indexeddb resource %q is disabled", selectedIndexedDBName)
+	}
 	enc, encErr := crypto.NewAESGCM(encKey)
 	if encErr != nil {
 		return nil, fmt.Errorf("bootstrap: create encryptor: %w", encErr)
@@ -320,7 +324,7 @@ func prepareCore(ctx context.Context, cfg *config.Config, factories *FactoryRegi
 	if storeErr != nil {
 		return nil, fmt.Errorf("bootstrap: system indexeddb from resource %q: %w", selectedIndexedDBName, storeErr)
 	}
-	store = metricutil.InstrumentIndexedDB(store, cfg.Server.IndexedDB)
+	store = metricutil.InstrumentIndexedDB(store, selectedIndexedDBName)
 	svc, svcErr := coredata.New(store, enc)
 	if svcErr != nil {
 		_ = store.Close()
@@ -329,7 +333,7 @@ func prepareCore(ctx context.Context, cfg *config.Config, factories *FactoryRegi
 	hostIndexedDBs := map[string]indexeddb.IndexedDB{selectedIndexedDBName: store}
 	var extraIndexedDBs []indexeddb.IndexedDB
 	for name, entry := range cfg.Providers.IndexedDB {
-		if name == selectedIndexedDBName {
+		if name == selectedIndexedDBName || entry == nil || entry.Disabled {
 			continue
 		}
 		ds, err := buildIndexedDB(entry, factories)
@@ -355,6 +359,7 @@ func prepareCore(ctx context.Context, cfg *config.Config, factories *FactoryRegi
 
 	deps.Egress = newEgressDeps(cfg)
 	deps.Services = svc
+	deps.SelectedIndexedDBName = selectedIndexedDBName
 	deps.IndexedDBs = hostIndexedDBs
 
 	closeSM = false

--- a/gestaltd/internal/bootstrap/executable_plugin_test.go
+++ b/gestaltd/internal/bootstrap/executable_plugin_test.go
@@ -820,11 +820,12 @@ func TestPluginIndexedDBBindingsExposeHostSocketEnv(t *testing.T) {
 		"archive": &coretesting.StubIndexedDB{},
 	}
 
-	checkEnv := func(t *testing.T, bindings []string, envName string) bool {
+	checkEnv := func(t *testing.T, bindings []string, selectedIndexedDBName, envName string) bool {
 		t.Helper()
 		providers, _, err := buildProvidersStrict(context.Background(), makeConfig(bindings), NewFactoryRegistry(), Deps{
-			Services:   services,
-			IndexedDBs: indexedDBBindings,
+			Services:              services,
+			SelectedIndexedDBName: selectedIndexedDBName,
+			IndexedDBs:            indexedDBBindings,
 		})
 		if err != nil {
 			t.Fatalf("buildProvidersStrict: %v", err)
@@ -849,22 +850,34 @@ func TestPluginIndexedDBBindingsExposeHostSocketEnv(t *testing.T) {
 		return env.Found && env.Value != ""
 	}
 
-	if got := checkEnv(t, nil, providerhost.DefaultIndexedDBSocketEnv); got {
-		t.Fatal("default IndexedDB env should not be set without plugin indexeddb bindings")
+	if got := checkEnv(t, nil, "main", providerhost.DefaultIndexedDBSocketEnv); !got {
+		t.Fatal("default IndexedDB env should inherit the selected host indexeddb when plugin bindings are omitted")
 	}
-	if got := checkEnv(t, []string{"main"}, providerhost.DefaultIndexedDBSocketEnv); !got {
+	if got := checkEnv(t, nil, "main", providerhost.IndexedDBSocketEnv("main")); !got {
+		t.Fatal("named IndexedDB env should inherit the selected host indexeddb when plugin bindings are omitted")
+	}
+	if got := checkEnv(t, nil, "main", providerhost.IndexedDBSocketEnv("archive")); got {
+		t.Fatal(`named IndexedDB env for "archive" should not be set when plugin bindings are omitted and the selected host indexeddb is "main"`)
+	}
+	if got := checkEnv(t, []string{}, "main", providerhost.DefaultIndexedDBSocketEnv); got {
+		t.Fatal("default IndexedDB env should not be set when an explicit empty plugin indexeddb list disables inheritance")
+	}
+	if got := checkEnv(t, []string{}, "main", providerhost.IndexedDBSocketEnv("main")); got {
+		t.Fatal(`named IndexedDB env for "main" should not be set when an explicit empty plugin indexeddb list disables inheritance`)
+	}
+	if got := checkEnv(t, []string{"main"}, "archive", providerhost.DefaultIndexedDBSocketEnv); !got {
 		t.Fatal("default IndexedDB env should be set with a single plugin indexeddb binding")
 	}
-	if got := checkEnv(t, []string{"main"}, providerhost.IndexedDBSocketEnv("main")); !got {
+	if got := checkEnv(t, []string{"main"}, "archive", providerhost.IndexedDBSocketEnv("main")); !got {
 		t.Fatal("named IndexedDB env should be set with a single plugin indexeddb binding")
 	}
-	if got := checkEnv(t, []string{"main", "archive"}, providerhost.DefaultIndexedDBSocketEnv); got {
+	if got := checkEnv(t, []string{"main", "archive"}, "main", providerhost.DefaultIndexedDBSocketEnv); got {
 		t.Fatal("default IndexedDB env should not be set with multiple plugin indexeddb bindings")
 	}
-	if got := checkEnv(t, []string{"main", "archive"}, providerhost.IndexedDBSocketEnv("main")); !got {
+	if got := checkEnv(t, []string{"main", "archive"}, "main", providerhost.IndexedDBSocketEnv("main")); !got {
 		t.Fatal(`named IndexedDB env for "main" should be set with multiple plugin indexeddb bindings`)
 	}
-	if got := checkEnv(t, []string{"main", "archive"}, providerhost.IndexedDBSocketEnv("archive")); !got {
+	if got := checkEnv(t, []string{"main", "archive"}, "main", providerhost.IndexedDBSocketEnv("archive")); !got {
 		t.Fatal(`named IndexedDB env for "archive" should be set with multiple plugin indexeddb bindings`)
 	}
 }

--- a/gestaltd/internal/bootstrap/provider_build.go
+++ b/gestaltd/internal/bootstrap/provider_build.go
@@ -507,12 +507,13 @@ func buildPluginProvider(ctx context.Context, name string, entry *config.Provide
 		HostBinary:    entry.HostBinary,
 		Cleanup:       cleanup,
 	}
-	if len(entry.IndexedDBs) > 0 {
+	indexedDBBindings := config.ResolveEffectivePluginIndexedDBBindings(entry, deps.SelectedIndexedDBName)
+	if len(indexedDBBindings) > 0 {
 		if len(deps.IndexedDBs) == 0 {
 			return nil, fmt.Errorf("indexeddb host services are not available")
 		}
-		execCfg.HostServices = make([]providerhost.HostService, 0, len(entry.IndexedDBs)+1)
-		for _, binding := range entry.IndexedDBs {
+		execCfg.HostServices = make([]providerhost.HostService, 0, len(indexedDBBindings)+1)
+		for _, binding := range indexedDBBindings {
 			ds, ok := deps.IndexedDBs[binding]
 			if !ok || ds == nil {
 				return nil, fmt.Errorf("indexeddb %q is not available", binding)
@@ -526,8 +527,8 @@ func buildPluginProvider(ctx context.Context, name string, entry *config.Provide
 				}(ds),
 			})
 		}
-		if len(entry.IndexedDBs) == 1 {
-			ds := deps.IndexedDBs[entry.IndexedDBs[0]]
+		if len(indexedDBBindings) == 1 {
+			ds := deps.IndexedDBs[indexedDBBindings[0]]
 			execCfg.HostServices = append(execCfg.HostServices, providerhost.HostService{
 				EnvVar: providerhost.DefaultIndexedDBSocketEnv,
 				Register: func(srv *grpc.Server) {

--- a/gestaltd/internal/config/config_test.go
+++ b/gestaltd/internal/config/config_test.go
@@ -131,6 +131,9 @@ plugins:
       path: /tmp/manifest.yaml
     indexeddb:
       - archive
+  service-b:
+    source:
+      path: /tmp/manifest-b.yaml
 `)
 
 	cfg, err := Load(path)
@@ -148,6 +151,16 @@ plugins:
 	}
 	if got := cfg.Plugins["service-a"].IndexedDBs; !reflect.DeepEqual(got, []string{"archive"}) {
 		t.Fatalf("Plugins[service-a].IndexedDBs = %v, want [archive]", got)
+	}
+	if got := cfg.Plugins["service-b"].IndexedDBs; got != nil {
+		t.Fatalf("Plugins[service-b].IndexedDBs = %v, want nil", got)
+	}
+	serviceBIndexedDBs, err := cfg.EffectivePluginIndexedDBBindings(cfg.Plugins["service-b"])
+	if err != nil {
+		t.Fatalf("EffectivePluginIndexedDBBindings(service-b): %v", err)
+	}
+	if want := []string{"archive"}; !reflect.DeepEqual(serviceBIndexedDBs, want) {
+		t.Fatalf("EffectivePluginIndexedDBBindings(service-b) = %v, want %v", serviceBIndexedDBs, want)
 	}
 }
 
@@ -497,6 +510,20 @@ server:
   encryptionKey: server-key
 `,
 			wantErr: false,
+		},
+		{
+			name: "selected datastore cannot be disabled",
+			yaml: `
+providers:
+  indexeddb:
+    sqlite:
+      disabled: true
+      source:
+        path: ./providers/datastore/sqlite
+server:
+  encryptionKey: server-key
+`,
+			wantErr: true,
 		},
 	}
 
@@ -918,6 +945,86 @@ server:
 		}
 	})
 
+	t.Run("plugin inherits selected indexeddb when binding is omitted", func(t *testing.T) {
+		t.Parallel()
+
+		path := mustWriteConfigFile(t, `
+plugins:
+  roadmap:
+    source:
+      path: ./plugin/manifest.yaml
+providers:
+  indexeddb:
+    sqlite:
+      source:
+        path: ./providers/datastore/sqlite
+    archive:
+      source:
+        path: ./providers/datastore/archive
+server:
+  providers:
+    indexeddb: archive
+  encryptionKey: server-key
+`)
+
+		cfg, err := Load(path)
+		if err != nil {
+			t.Fatalf("Load: %v", err)
+		}
+		if got := cfg.Plugins["roadmap"].IndexedDBs; got != nil {
+			t.Fatalf("Plugins[roadmap].IndexedDBs = %v, want nil", got)
+		}
+		bindings, err := cfg.EffectivePluginIndexedDBBindings(cfg.Plugins["roadmap"])
+		if err != nil {
+			t.Fatalf("EffectivePluginIndexedDBBindings: %v", err)
+		}
+		if want := []string{"archive"}; !reflect.DeepEqual(bindings, want) {
+			t.Fatalf("EffectivePluginIndexedDBBindings = %v, want %v", bindings, want)
+		}
+	})
+
+	t.Run("plugin explicit empty indexeddb disables inheritance", func(t *testing.T) {
+		t.Parallel()
+
+		path := mustWriteConfigFile(t, `
+plugins:
+  roadmap:
+    source:
+      path: ./plugin/manifest.yaml
+    indexeddb: []
+providers:
+  indexeddb:
+    sqlite:
+      source:
+        path: ./providers/datastore/sqlite
+    archive:
+      source:
+        path: ./providers/datastore/archive
+server:
+  providers:
+    indexeddb: archive
+  encryptionKey: server-key
+`)
+
+		cfg, err := Load(path)
+		if err != nil {
+			t.Fatalf("Load: %v", err)
+		}
+		if cfg.Plugins["roadmap"].IndexedDBs == nil {
+			t.Fatal("Plugins[roadmap].IndexedDBs = nil, want explicit empty slice")
+		}
+		if got := cfg.Plugins["roadmap"].IndexedDBs; len(got) != 0 {
+			t.Fatalf("Plugins[roadmap].IndexedDBs = %v, want []", got)
+		}
+		bindings, err := cfg.EffectivePluginIndexedDBBindings(cfg.Plugins["roadmap"])
+		if err != nil {
+			t.Fatalf("EffectivePluginIndexedDBBindings: %v", err)
+		}
+		if len(bindings) != 0 {
+			t.Fatalf("EffectivePluginIndexedDBBindings = %v, want []", bindings)
+		}
+	})
+
 	t.Run("rejects indexeddb bindings outside plugins", func(t *testing.T) {
 		t.Parallel()
 
@@ -930,6 +1037,36 @@ providers:
       path: /app
       indexeddb:
         - sqlite
+  indexeddb:
+    sqlite:
+      source:
+        path: ./providers/datastore/sqlite
+server:
+  providers:
+    indexeddb: sqlite
+  encryptionKey: server-key
+`)
+
+		_, err := Load(path)
+		if err == nil {
+			t.Fatal("Load: expected error, got nil")
+		}
+		if !strings.Contains(err.Error(), `ui.root.indexeddb is only supported on plugins.*`) {
+			t.Fatalf("unexpected error: %v", err)
+		}
+	})
+
+	t.Run("rejects explicit empty indexeddb outside plugins", func(t *testing.T) {
+		t.Parallel()
+
+		path := mustWriteConfigFile(t, `
+providers:
+  ui:
+    root:
+      source:
+        path: ./web/root/manifest.yaml
+      path: /app
+      indexeddb: []
   indexeddb:
     sqlite:
       source:
@@ -1042,6 +1179,64 @@ server:
 			t.Fatal("Load: expected error, got nil")
 		}
 		if !strings.Contains(err.Error(), `plugin "roadmap" indexeddb[1] references unknown indexeddb "missing"`) {
+			t.Fatalf("unexpected error: %v", err)
+		}
+	})
+
+	t.Run("allows disabled indexeddb entries that are not selected or bound", func(t *testing.T) {
+		t.Parallel()
+
+		path := mustWriteConfigFile(t, `
+providers:
+  indexeddb:
+    main:
+      source:
+        path: ./providers/datastore/main
+    archive:
+      disabled: true
+      source:
+        path: ./providers/datastore/archive
+server:
+  providers:
+    indexeddb: main
+  encryptionKey: server-key
+`)
+
+		if _, err := Load(path); err != nil {
+			t.Fatalf("Load: %v", err)
+		}
+	})
+
+	t.Run("rejects plugin bindings to disabled indexeddb entries", func(t *testing.T) {
+		t.Parallel()
+
+		path := mustWriteConfigFile(t, `
+plugins:
+  roadmap:
+    source:
+      path: ./plugin/manifest.yaml
+    indexeddb:
+      - archive
+providers:
+  indexeddb:
+    main:
+      source:
+        path: ./providers/datastore/main
+    archive:
+      disabled: true
+      source:
+        path: ./providers/datastore/archive
+server:
+  providers:
+    indexeddb: main
+  encryptionKey: server-key
+`)
+
+		_, err := Load(path)
+		if err == nil {
+			t.Fatal("Load: expected error, got nil")
+		}
+		if !strings.Contains(err.Error(), `plugin "roadmap" indexeddb[0] references disabled indexeddb "archive"`) {
 			t.Fatalf("unexpected error: %v", err)
 		}
 	})

--- a/gestaltd/internal/config/config_validate.go
+++ b/gestaltd/internal/config/config_validate.go
@@ -261,12 +261,15 @@ func ValidateResolvedStructure(cfg *Config) error {
 // ValidateRuntime checks runtime-only requirements: encryption key plus the
 // required top-level datastore provider.
 func ValidateRuntime(cfg *Config) error {
-	name, _, err := cfg.SelectedIndexedDBProvider()
+	name, entry, err := cfg.SelectedIndexedDBProvider()
 	if err != nil {
 		return err
 	}
 	if name == "" {
 		return fmt.Errorf("config validation: server.providers.indexeddb is required (set server.providers.indexeddb or mark one providers.indexeddb entry default: true)")
+	}
+	if entry != nil && entry.Disabled {
+		return fmt.Errorf("config validation: selected indexeddb %q is disabled", name)
 	}
 	if cfg.Server.EncryptionKey == "" {
 		return fmt.Errorf("config validation: server.encryption_key is required")
@@ -315,14 +318,14 @@ func validatePluginOnlyProviderFields(subject string, entry *ProviderEntry) erro
 	if entry == nil {
 		return nil
 	}
-	if len(entry.IndexedDBs) > 0 {
+	if entry.IndexedDBs != nil {
 		return fmt.Errorf("config validation: %s.indexeddb is only supported on plugins.*", subject)
 	}
 	if entry.Surfaces != nil {
 		return fmt.Errorf("config validation: %s.surfaces is only supported on plugins.*", subject)
 	}
 	if entry.AuthorizationPolicy != "" && !strings.HasPrefix(subject, "ui.") {
-		return fmt.Errorf("config validation: %s.authorizationPolicy is only supported on providers.plugins.* and providers.ui.*", subject)
+		return fmt.Errorf("config validation: %s.authorizationPolicy is only supported on plugins.* and providers.ui.*", subject)
 	}
 	return nil
 }
@@ -383,9 +386,14 @@ func validatePluginIndexedDBBindings(cfg *Config, name string, entry *ProviderEn
 	if entry == nil {
 		return nil
 	}
-	seen := make(map[string]struct{}, len(entry.IndexedDBs))
-	envNames := make(map[string]string, len(entry.IndexedDBs))
-	for i, binding := range entry.IndexedDBs {
+	bindings, err := cfg.EffectivePluginIndexedDBBindings(entry)
+	if err != nil {
+		return err
+	}
+	explicitBindings := entry.IndexedDBs != nil
+	seen := make(map[string]struct{}, len(bindings))
+	envNames := make(map[string]string, len(bindings))
+	for i, binding := range bindings {
 		binding = strings.TrimSpace(binding)
 		if binding == "" {
 			return fmt.Errorf("config validation: plugin %q indexeddb[%d] is required", name, i)
@@ -396,13 +404,18 @@ func validatePluginIndexedDBBindings(cfg *Config, name string, entry *ProviderEn
 		if _, ok := cfg.Providers.IndexedDB[binding]; !ok {
 			return fmt.Errorf("config validation: plugin %q indexeddb[%d] references unknown indexeddb %q", name, i, binding)
 		}
+		if cfg.Providers.IndexedDB[binding].Disabled {
+			return fmt.Errorf("config validation: plugin %q indexeddb[%d] references disabled indexeddb %q", name, i, binding)
+		}
 		envName := indexedDBSocketEnv(binding)
 		if otherBinding, exists := envNames[envName]; exists {
 			return fmt.Errorf("config validation: plugin %q indexeddb[%d] %q conflicts with %q after IndexedDB env normalization (%s)", name, i, binding, otherBinding, envName)
 		}
 		seen[binding] = struct{}{}
 		envNames[envName] = binding
-		entry.IndexedDBs[i] = binding
+		if explicitBindings {
+			entry.IndexedDBs[i] = binding
+		}
 	}
 	return nil
 }

--- a/gestaltd/internal/config/provider_selection.go
+++ b/gestaltd/internal/config/provider_selection.go
@@ -93,6 +93,33 @@ func (c *Config) SelectedIndexedDBProvider() (string, *ProviderEntry, error) {
 	return c.SelectedHostProvider(HostProviderKindIndexedDB)
 }
 
+func (c *Config) EffectivePluginIndexedDBBindings(plugin *ProviderEntry) ([]string, error) {
+	c.SyncCompatFields()
+	selectedName, _, err := c.SelectedIndexedDBProvider()
+	if err != nil {
+		return nil, err
+	}
+	return ResolveEffectivePluginIndexedDBBindings(plugin, selectedName), nil
+}
+
+func ResolveEffectivePluginIndexedDBBindings(plugin *ProviderEntry, selectedName string) []string {
+	if plugin == nil {
+		return nil
+	}
+	if plugin.IndexedDBs != nil {
+		bindings := make([]string, len(plugin.IndexedDBs))
+		for i, binding := range plugin.IndexedDBs {
+			bindings[i] = strings.TrimSpace(binding)
+		}
+		return bindings
+	}
+	selectedName = strings.TrimSpace(selectedName)
+	if selectedName == "" {
+		return nil
+	}
+	return []string{selectedName}
+}
+
 func ResolveSelectedHostProvider(kind HostProviderKind, explicit string, entries map[string]*ProviderEntry) (string, *ProviderEntry, error) {
 	if len(entries) == 0 {
 		return "", nil, nil


### PR DESCRIPTION
## Summary
- make plugins inherit the selected/default host IndexedDB when `plugins.<name>.indexeddb` is omitted
- keep explicit plugin bindings authoritative, including `indexeddb: []` as an explicit opt-out
- align config validation and executable plugin runtime wiring around one effective-binding resolution path
- update the existing similar config/bootstrap docs and tests to reflect the shipped behavior

## Public Interface

### YAML

```yaml
server:
  providers:
    indexeddb: main

providers:
  indexeddb:
    main:
      default: true
      source:
        path: ./providers/indexeddb/main/manifest.yaml
    archive:
      source:
        path: ./providers/indexeddb/archive/manifest.yaml

plugins:
  roadmap:
    source:
      path: ./plugins/roadmap/manifest.yaml
  reports:
    source:
      path: ./plugins/reports/manifest.yaml
    indexeddb:
      - archive
  stateless:
    source:
      path: ./plugins/stateless/manifest.yaml
    indexeddb: []
```

Behavior:
- omitted `plugins.<name>.indexeddb` inherits the selected/default host IndexedDB
- explicit named bindings override inheritance
- `indexeddb: []` disables inherited IndexedDB access for that plugin

### Go

```go
type Deps struct {
    SelectedIndexedDBName string
    IndexedDBs            map[string]indexeddb.IndexedDB
}

func (c *Config) EffectivePluginIndexedDBBindings(plugin *ProviderEntry) ([]string, error)
func ResolveEffectivePluginIndexedDBBindings(plugin *ProviderEntry, selectedName string) []string
```

Usage examples:

```go
bindings, err := cfg.EffectivePluginIndexedDBBindings(cfg.Plugins["roadmap"])
// bindings == []string{"main"}

bindings = config.ResolveEffectivePluginIndexedDBBindings(cfg.Plugins["reports"], "main")
// bindings == []string{"archive"}

bindings = config.ResolveEffectivePluginIndexedDBBindings(cfg.Plugins["stateless"], "main")
// bindings == []string{}
```

## Notes
- executable plugins still receive both `GESTALT_INDEXEDDB_SOCKET` and the named socket env var when their effective IndexedDB binding set has size 1
- this PR stays intentionally IndexedDB-specific in public behavior; it does not introduce a generic plugin host-provider binding model for auth/secrets/telemetry/audit

## Verification
- `go test ./internal/config ./internal/bootstrap ./cmd/gestaltd`
- `golangci-lint run ./internal/config ./internal/bootstrap ./cmd/gestaltd`
- `go test ./...`
- `go build ./...`
