### PR TITLE
Audit auth failures and pre-invocation denials

### DIFF
--- a/docs/content/audit-logging.mdx
+++ b/docs/content/audit-logging.mdx
@@ -8,7 +8,7 @@ backend without having to reconstruct behavior from mixed application logs.
 
 ## Coverage
 
-Audit events cover HTTP and MCP operation invocations, other guarded runtime surfaces such as binding hooks, login and logout flows, plugin connect and disconnect flows, and API token lifecycle. Each event carries a `source` field (`http`, `mcp`, or a surface-specific value like `binding:...`) so consumers can filter by surface.
+Audit events cover HTTP and MCP operation invocations, other guarded runtime surfaces such as binding hooks, failed auth on protected routes, HTTP authorization denials rejected before `GuardedInvoker` runs, login and logout flows, plugin connect and disconnect flows, and API token lifecycle. Each event carries a `source` field (`http`, `mcp`, or a surface-specific value like `binding:...`) so consumers can filter by surface.
 
 `gestaltd` resolves the authenticated user ID before emitting session-backed audit events, so both session requests and API-token requests produce stable `user_id` values when a user identity exists.
 
@@ -31,7 +31,7 @@ These fields are emitted when available:
 
 | Field | Meaning |
 | --- | --- |
-| `auth_source` | Auth mechanism for the caller: `session`, `api_token`, or `env` |
+| `auth_source` | Auth mechanism for the caller: `session`, `api_token`, `workload_token`, or `env` |
 | `user_id` | Stable internal user ID |
 | `error` | Denial or failure reason |
 | `client_ip` | Client IP, preferring `X-Forwarded-For` |
@@ -40,15 +40,16 @@ These fields are emitted when available:
 | `trace_id` | Active OpenTelemetry trace ID |
 | `span_id` | Active OpenTelemetry span ID |
 
-For platform-level events such as API-token CRUD, `provider` is empty because
+For platform-level events such as failed auth or API-token lifecycle, `provider` is empty because
 the event is not tied to a specific plugin.
 
 ## Event Names
 
 Invocation events use the catalog operation ID in `operation`.
 
-Non-invocation HTTP audit events use explicit operation names:
+Non-invocation audit events use explicit operation names:
 
+- `auth.authenticate`
 - `auth.login.start`
 - `auth.login.complete`
 - `auth.logout`
@@ -57,9 +58,17 @@ Non-invocation HTTP audit events use explicit operation names:
 - `connection.manual.connect`
 - `connection.pending.select`
 - `connection.disconnect`
+- `operations.list`
 - `api_token.create`
 - `api_token.revoke`
 - `api_token.revoke_all`
+
+Denied requests to `/api/v1/{integration}/{operation}` that are blocked before
+`GuardedInvoker` still use the attempted catalog operation ID in `operation`,
+matching the guarded invocation audit shape. `api_token.create` is also emitted
+when the CLI login callback successfully mints a token. `auth.authenticate`
+can be emitted from both HTTP and MCP request paths when shared auth middleware
+rejects the request before invocation.
 
 ## Metrics Vs Audit
 
@@ -69,11 +78,12 @@ Non-invocation HTTP audit events use explicit operation names:
 | --- | --- | --- | --- |
 | Provider operation invocation | Yes: `gestaltd.operation.*` | Yes | Guarded invocations are both metered and audited. |
 | Platform login start and completion | Yes: `gestaltd.auth.*` | Yes | Login is both operational telemetry and a security event. |
-| Platform token validation | Yes: `gestaltd.auth.*` with `action=validate_token` | No | Request-by-request token validation is metrics-only. |
+| Platform token validation | Yes: `gestaltd.auth.*` with `action=validate_token` | Partially | Successful per-request validation is metrics-only; denied auth in shared middleware emits `auth.authenticate`. |
+| HTTP pre-invoker authorization denials | No dedicated semantic metric family | Yes | Denied workload access before invocation dispatch is audited with the attempted operation or `operations.list`. |
 | Connection auth start and completion | Yes: `gestaltd.connection.auth.*` | Yes | Covers OAuth start and completion plus manual connect completion. |
 | Connection credential refresh | Yes: `gestaltd.connection.auth.*` with `action=refresh` | No | Refresh remains metrics-only to avoid audit noise. |
 | Datastore methods | Yes: `gestaltd.datastore.*` | No | Datastore calls are internal implementation telemetry, not audit events. |
-| API token lifecycle | No dedicated semantic metric family | Yes | Audit records exist for create and revoke flows. |
+| API token lifecycle | No dedicated semantic metric family | Yes | Audit records exist for explicit token create/revoke flows and CLI token minting. |
 | Logout, pending selection, disconnect | No dedicated semantic metric family | Yes | These remain audit-only workflow events. |
 
 See [Observability](/observability) for the metric families and attribute

--- a/docs/content/observability.mdx
+++ b/docs/content/observability.mdx
@@ -253,7 +253,8 @@ need actor, target, and outcome details.
 | --- | --- | --- | --- |
 | Provider operation invocation | Yes: `gestaltd.operation.*` | Yes | Every guarded HTTP and MCP invocation is audited. |
 | Platform login start and completion | Yes: `gestaltd.auth.*` | Yes | `begin_login` and `complete_login` are both operational and security events. |
-| Platform token validation | Yes: `gestaltd.auth.*` with `action=validate_token` | No | Per-request auth checks stay metrics-only to avoid audit noise. |
+| Platform token validation | Yes: `gestaltd.auth.*` with `action=validate_token` | Partially | Successful per-request validation is metrics-only; shared-middleware denials emit `auth.authenticate`. |
+| Pre-invoker authorization denials | No dedicated semantic metric family | Yes | Denied workload access before guarded invocation dispatch is audited with the attempted operation or `operations.list`. |
 | Connection auth start and completion | Yes: `gestaltd.connection.auth.*` | Yes | Covers OAuth start and completion plus manual connect completion. |
 | Connection credential refresh | Yes: `gestaltd.connection.auth.*` with `action=refresh` | No | Refresh is system maintenance behavior, not a user-facing audit event. |
 | IndexedDB operations | Yes: `gestaltd.indexeddb.*` | No | Audit the higher-level user action instead of low-level storage calls. |

--- a/gestaltd/internal/server/audit.go
+++ b/gestaltd/internal/server/audit.go
@@ -3,6 +3,8 @@ package server
 import (
 	"context"
 	"fmt"
+	"net/http"
+	"strings"
 
 	"github.com/valon-technologies/gestalt/server/internal/invocation"
 	"github.com/valon-technologies/gestalt/server/internal/principal"
@@ -45,12 +47,19 @@ func (s *Server) resolvePrincipalUserID(ctx context.Context, p *principal.Princi
 	return &clone, nil
 }
 
-func (s *Server) auditHTTPEvent(ctx context.Context, p *principal.Principal, provider, operation string, allowed bool, err error) {
+func auditSourceForRequest(r *http.Request) string {
+	if r != nil && strings.HasPrefix(r.URL.Path, "/mcp") {
+		return "mcp"
+	}
+	return "http"
+}
+
+func (s *Server) auditEvent(ctx context.Context, p *principal.Principal, source, provider, operation string, allowed bool, err error) {
 	if s.auditSink == nil {
 		return
 	}
 
-	ctx, entry := invocation.BuildAuditEntry(ctx, p, "http", provider, operation)
+	ctx, entry := invocation.BuildAuditEntry(ctx, p, source, provider, operation)
 	entry.Allowed = allowed
 	if err != nil {
 		entry.Error = err.Error()
@@ -58,12 +67,26 @@ func (s *Server) auditHTTPEvent(ctx context.Context, p *principal.Principal, pro
 	s.auditSink.Log(ctx, entry)
 }
 
-func (s *Server) auditHTTPEventWithUserID(ctx context.Context, userID, authSource, provider, operation string, allowed bool, err error) {
+func (s *Server) auditEventWithAuthSource(ctx context.Context, authSource, source, provider, operation string, allowed bool, err error) {
 	if s.auditSink == nil {
 		return
 	}
 
-	ctx, entry := invocation.BuildAuditEntry(ctx, nil, "http", provider, operation)
+	ctx, entry := invocation.BuildAuditEntry(ctx, nil, source, provider, operation)
+	entry.AuthSource = authSource
+	entry.Allowed = allowed
+	if err != nil {
+		entry.Error = err.Error()
+	}
+	s.auditSink.Log(ctx, entry)
+}
+
+func (s *Server) auditEventWithUserID(ctx context.Context, userID, authSource, source, provider, operation string, allowed bool, err error) {
+	if s.auditSink == nil {
+		return
+	}
+
+	ctx, entry := invocation.BuildAuditEntry(ctx, nil, source, provider, operation)
 	entry.UserID = userID
 	entry.AuthSource = authSource
 	entry.SubjectID = principal.UserSubjectID(userID)
@@ -73,4 +96,16 @@ func (s *Server) auditHTTPEventWithUserID(ctx context.Context, userID, authSourc
 		entry.Error = err.Error()
 	}
 	s.auditSink.Log(ctx, entry)
+}
+
+func (s *Server) auditHTTPEvent(ctx context.Context, p *principal.Principal, provider, operation string, allowed bool, err error) {
+	s.auditEvent(ctx, p, "http", provider, operation, allowed, err)
+}
+
+func (s *Server) auditRequestEventWithAuthSource(r *http.Request, authSource, provider, operation string, allowed bool, err error) {
+	s.auditEventWithAuthSource(r.Context(), authSource, auditSourceForRequest(r), provider, operation, allowed, err)
+}
+
+func (s *Server) auditHTTPEventWithUserID(ctx context.Context, userID, authSource, provider, operation string, allowed bool, err error) {
+	s.auditEventWithUserID(ctx, userID, authSource, "http", provider, operation, allowed, err)
 }

--- a/gestaltd/internal/server/audit_metadata_test.go
+++ b/gestaltd/internal/server/audit_metadata_test.go
@@ -4,6 +4,7 @@ import (
 	"bytes"
 	"context"
 	"encoding/json"
+	"fmt"
 	"io"
 	"net/http"
 	"net/http/httptest"
@@ -178,6 +179,128 @@ func TestAuditMetadata_FallbackToRemoteAddr(t *testing.T) {
 	}
 	if record["user_agent"] != "fallback-agent/2.0" {
 		t.Errorf("expected user_agent=fallback-agent/2.0, got %v", record["user_agent"])
+	}
+}
+
+func TestAuditMetadata_AuthMiddlewareFailures(t *testing.T) {
+	t.Parallel()
+
+	testCases := []struct {
+		name           string
+		method         string
+		path           string
+		body           string
+		authHeader     string
+		withMCPHandler bool
+		wantSource     string
+		wantError      string
+		wantAuthSource string
+	}{
+		{
+			name:       "missing_http_auth",
+			method:     http.MethodGet,
+			path:       "/api/v1/integrations",
+			wantSource: "http",
+			wantError:  "missing authorization",
+		},
+		{
+			name:           "missing_mcp_auth",
+			method:         http.MethodPost,
+			path:           "/mcp",
+			body:           `{"jsonrpc":"2.0","id":1,"method":"initialize","params":{}}`,
+			withMCPHandler: true,
+			wantSource:     "mcp",
+			wantError:      "missing authorization",
+		},
+		{
+			name:           "invalid_session_bearer",
+			method:         http.MethodPost,
+			path:           "/mcp",
+			body:           `{"jsonrpc":"2.0","id":1,"method":"initialize","params":{}}`,
+			authHeader:     "Bearer invalid-session-token",
+			withMCPHandler: true,
+			wantSource:     "mcp",
+			wantError:      "invalid token",
+			wantAuthSource: "session",
+		},
+	}
+
+	for _, tc := range testCases {
+		tc := tc
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+
+			var auditBuf bytes.Buffer
+			auditSink := invocation.NewSlogAuditSink(&auditBuf)
+
+			ts := newTestServer(t, func(cfg *server.Config) {
+				cfg.Auth = &coretesting.StubAuthProvider{
+					N: "stub",
+					ValidateTokenFn: func(_ context.Context, _ string) (*core.UserIdentity, error) {
+						return nil, fmt.Errorf("invalid token")
+					},
+				}
+				cfg.AuditSink = auditSink
+				cfg.Services = coretesting.NewStubServices(t)
+				if tc.withMCPHandler {
+					cfg.MCPHandler = http.HandlerFunc(func(http.ResponseWriter, *http.Request) {
+						t.Fatal("unexpected MCP handler invocation")
+					})
+				}
+			})
+			t.Cleanup(ts.Close)
+
+			var body io.Reader
+			if tc.body != "" {
+				body = bytes.NewBufferString(tc.body)
+			}
+			req, _ := http.NewRequest(tc.method, ts.URL+tc.path, body)
+			if tc.body != "" {
+				req.Header.Set("Content-Type", "application/json")
+			}
+			if tc.authHeader != "" {
+				req.Header.Set("Authorization", tc.authHeader)
+			}
+
+			resp, err := http.DefaultClient.Do(req)
+			if err != nil {
+				t.Fatalf("request: %v", err)
+			}
+			defer func() { _ = resp.Body.Close() }()
+			_, _ = io.ReadAll(resp.Body)
+
+			if resp.StatusCode != http.StatusUnauthorized {
+				t.Fatalf("expected 401, got %d", resp.StatusCode)
+			}
+
+			var record map[string]any
+			if err := json.Unmarshal(bytes.TrimSpace(auditBuf.Bytes()), &record); err != nil {
+				t.Fatalf("failed to parse audit JSON: %v\nraw: %s", err, auditBuf.String())
+			}
+
+			if record["source"] != tc.wantSource {
+				t.Fatalf("expected source %q, got %v", tc.wantSource, record["source"])
+			}
+			if record["operation"] != "auth.authenticate" {
+				t.Fatalf("expected operation auth.authenticate, got %v", record["operation"])
+			}
+			if record["allowed"] != false {
+				t.Fatalf("expected allowed=false, got %v", record["allowed"])
+			}
+			if record["error"] != tc.wantError {
+				t.Fatalf("expected error %q, got %v", tc.wantError, record["error"])
+			}
+			if record["provider"] != "" {
+				t.Fatalf("expected empty provider, got %v", record["provider"])
+			}
+			if tc.wantAuthSource == "" {
+				if authSource, ok := record["auth_source"]; ok && authSource != "" {
+					t.Fatalf("expected empty auth_source, got %v", authSource)
+				}
+			} else if record["auth_source"] != tc.wantAuthSource {
+				t.Fatalf("expected auth_source %q, got %v", tc.wantAuthSource, record["auth_source"])
+			}
+		})
 	}
 }
 

--- a/gestaltd/internal/server/authorization.go
+++ b/gestaltd/internal/server/authorization.go
@@ -31,15 +31,15 @@ func (s *Server) workloadBinding(p *principal.Principal, provider string) (autho
 	return s.authorizer.Binding(p, provider)
 }
 
-func rejectWorkloadSelectors(w http.ResponseWriter, p *principal.Principal, connection, instance string) bool {
+func rejectWorkloadSelectors(w http.ResponseWriter, p *principal.Principal, connection, instance string) error {
 	if p == nil || p.Kind != principal.KindWorkload {
-		return false
+		return nil
 	}
 	if connection == "" && instance == "" {
-		return false
+		return nil
 	}
-	writeError(w, http.StatusForbidden, "workload callers may not override connection or instance bindings")
-	return true
+	writeError(w, http.StatusForbidden, errWorkloadSelector.Error())
+	return errWorkloadSelector
 }
 
 func (s *Server) workloadBindingSelectors(p *principal.Principal, provider, connection, instance string) (string, string) {

--- a/gestaltd/internal/server/handlers.go
+++ b/gestaltd/internal/server/handlers.go
@@ -41,6 +41,8 @@ var (
 	errNotAuthenticated  = errors.New("not authenticated")
 	errResolveUser       = errors.New("failed to resolve user")
 	errWorkloadForbidden = errors.New("workload callers are not allowed on this route")
+	errOperationAccess   = errors.New("operation access denied")
+	errWorkloadSelector  = errors.New("workload callers may not override connection or instance bindings")
 )
 
 var (
@@ -426,6 +428,8 @@ func resolveConnectionParams(w http.ResponseWriter, prov core.Provider, provided
 }
 
 func (s *Server) listOperations(w http.ResponseWriter, r *http.Request) {
+	const operation = "operations.list"
+
 	name := chi.URLParam(r, "name")
 	prov, ok := s.getProvider(w, name)
 	if !ok {
@@ -433,7 +437,8 @@ func (s *Server) listOperations(w http.ResponseWriter, r *http.Request) {
 	}
 	p := PrincipalFromContext(r.Context())
 	if !s.allowProvider(p, name) {
-		writeError(w, http.StatusForbidden, "operation access denied")
+		s.auditHTTPEvent(r.Context(), p, name, operation, false, errOperationAccess)
+		writeError(w, http.StatusForbidden, errOperationAccess.Error())
 		return
 	}
 	requestedConnection := r.URL.Query().Get(httpConnectionParam)
@@ -452,7 +457,8 @@ func (s *Server) listOperations(w http.ResponseWriter, r *http.Request) {
 			return
 		}
 	}
-	if rejectWorkloadSelectors(w, p, requestedConnection, requestedInstance) {
+	if err := rejectWorkloadSelectors(w, p, requestedConnection, requestedInstance); err != nil {
+		s.auditHTTPEvent(r.Context(), p, name, operation, false, err)
 		return
 	}
 	var resolver invocation.TokenResolver
@@ -486,7 +492,8 @@ func (s *Server) executeOperation(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 	if !s.allowProvider(p, providerName) || !s.allowOperation(p, providerName, operationName) {
-		writeError(w, http.StatusForbidden, "operation access denied")
+		s.auditHTTPEvent(r.Context(), p, providerName, operationName, false, errOperationAccess)
+		writeError(w, http.StatusForbidden, errOperationAccess.Error())
 		return
 	}
 
@@ -506,7 +513,8 @@ func (s *Server) executeOperation(w http.ResponseWriter, r *http.Request) {
 			return
 		}
 	}
-	if rejectWorkloadSelectors(w, p, requestedConnection, requestedInstance) {
+	if err := rejectWorkloadSelectors(w, p, requestedConnection, requestedInstance); err != nil {
+		s.auditHTTPEvent(r.Context(), p, providerName, operationName, false, err)
 		return
 	}
 
@@ -559,7 +567,8 @@ func (s *Server) executeOperation(w http.ResponseWriter, r *http.Request) {
 		writeError(w, http.StatusBadRequest, fmt.Sprintf("conflicting connection parameter %q in query string and JSON body", httpConnectionParam))
 		return
 	}
-	if rejectWorkloadSelectors(w, p, bodyConnection, bodyInstance) {
+	if err := rejectWorkloadSelectors(w, p, bodyConnection, bodyInstance); err != nil {
+		s.auditHTTPEvent(r.Context(), p, providerName, operationName, false, err)
 		return
 	}
 	connection := bodyConnection

--- a/gestaltd/internal/server/handlers_auth.go
+++ b/gestaltd/internal/server/handlers_auth.go
@@ -281,6 +281,7 @@ func (s *Server) loginCallback(w http.ResponseWriter, r *http.Request) {
 			writeError(w, http.StatusInternalServerError, "failed to issue CLI API token")
 			return
 		}
+		s.auditHTTPEventWithUserID(r.Context(), dbUser.ID, principal.SourceSession.String(), "", "api_token.create", true, nil)
 		auditAllowed = true
 		auditErr = nil
 		writeJSON(w, http.StatusOK, createTokenResponse{

--- a/gestaltd/internal/server/middleware.go
+++ b/gestaltd/internal/server/middleware.go
@@ -103,6 +103,30 @@ func requestBearerToken(r *http.Request) (string, error) {
 	return bearer, nil
 }
 
+func requestedAuthSource(r *http.Request) string {
+	header := r.Header.Get("Authorization")
+	if header != "" {
+		bearer := strings.TrimPrefix(header, core.BearerScheme)
+		if bearer == header {
+			return ""
+		}
+		if typ, ok := principal.ParseTokenType(bearer); ok {
+			switch typ {
+			case principal.TokenTypeAPI:
+				return principal.SourceAPIToken.String()
+			case principal.TokenTypeWorkload:
+				return principal.SourceWorkloadToken.String()
+			}
+		}
+		return principal.SourceSession.String()
+	}
+
+	if c, err := r.Cookie(sessionCookieName); err == nil && c.Value != "" {
+		return principal.SourceSession.String()
+	}
+	return ""
+}
+
 func (s *Server) resolveRequestPrincipal(r *http.Request) (*principal.Principal, error) {
 	var lastErr error
 
@@ -166,19 +190,24 @@ func (s *Server) authMiddleware(next http.Handler) http.Handler {
 			return
 		}
 
+		authSource := requestedAuthSource(r)
 		switch {
 		case err == nil:
+			s.auditRequestEventWithAuthSource(r, authSource, "", "auth.authenticate", false, errors.New("missing authorization"))
 			writeError(w, http.StatusUnauthorized, "missing authorization")
 			return
 		case errors.Is(err, errInvalidAuthorizationHeader):
+			s.auditRequestEventWithAuthSource(r, authSource, "", "auth.authenticate", false, errInvalidAuthorizationHeader)
 			writeError(w, http.StatusUnauthorized, "invalid authorization header format")
 			return
 		case errors.Is(err, principal.ErrInvalidToken):
 			slog.InfoContext(r.Context(), "auth: invalid token", "remote_addr", r.RemoteAddr)
+			s.auditRequestEventWithAuthSource(r, authSource, "", "auth.authenticate", false, principal.ErrInvalidToken)
 			writeError(w, http.StatusUnauthorized, "invalid token")
 			return
 		default:
 			slog.ErrorContext(r.Context(), "auth: token validation failed", "remote_addr", r.RemoteAddr, "error", err)
+			s.auditRequestEventWithAuthSource(r, authSource, "", "auth.authenticate", false, errors.New("token validation failed"))
 			writeError(w, http.StatusInternalServerError, "token validation failed")
 			return
 		}

--- a/gestaltd/internal/server/server_test.go
+++ b/gestaltd/internal/server/server_test.go
@@ -1178,11 +1178,13 @@ func TestWorkloadAuthorization_ListOperationsFiltersAndRejectsSelectors(t *testi
 		},
 	}, providers, nil, nil)
 
+	var auditBuf bytes.Buffer
 	ts := newTestServer(t, func(cfg *server.Config) {
 		cfg.Auth = &coretesting.StubAuthProvider{N: "test"}
 		cfg.Providers = providers
 		cfg.Services = coretesting.NewStubServices(t)
 		cfg.Authorizer = authz
+		cfg.AuditSink = invocation.NewSlogAuditSink(&auditBuf)
 	})
 	testutil.CloseOnCleanup(t, ts)
 
@@ -1219,6 +1221,33 @@ func TestWorkloadAuthorization_ListOperationsFiltersAndRejectsSelectors(t *testi
 	if resp.StatusCode != http.StatusForbidden {
 		body, _ := io.ReadAll(resp.Body)
 		t.Fatalf("expected 403, got %d: %s", resp.StatusCode, body)
+	}
+
+	lines := bytes.Split(bytes.TrimSpace(auditBuf.Bytes()), []byte("\n"))
+	if len(lines) == 0 {
+		t.Fatal("expected list operations denial audit record")
+	}
+	var auditRecord map[string]any
+	if err := json.Unmarshal(lines[len(lines)-1], &auditRecord); err != nil {
+		t.Fatalf("parsing list operations audit record: %v\nraw: %s", err, auditBuf.String())
+	}
+	if auditRecord["provider"] != "svc" {
+		t.Fatalf("expected audit provider svc, got %v", auditRecord["provider"])
+	}
+	if auditRecord["operation"] != "operations.list" {
+		t.Fatalf("expected audit operation operations.list, got %v", auditRecord["operation"])
+	}
+	if auditRecord["allowed"] != false {
+		t.Fatalf("expected denied audit record, got %v", auditRecord["allowed"])
+	}
+	if auditRecord["auth_source"] != "workload_token" {
+		t.Fatalf("expected workload auth_source, got %v", auditRecord["auth_source"])
+	}
+	if auditRecord["subject_id"] != "workload:triage-bot" {
+		t.Fatalf("expected workload subject_id, got %v", auditRecord["subject_id"])
+	}
+	if auditRecord["error"] != "workload callers may not override connection or instance bindings" {
+		t.Fatalf("unexpected audit error: %v", auditRecord["error"])
 	}
 
 	svc := coretesting.NewStubServices(t)
@@ -3195,11 +3224,13 @@ func TestWorkloadAuthorization_ExecuteOperation_UsesBoundIdentityAndRejectsSelec
 		},
 	}, providers, nil, nil)
 
+	var auditBuf bytes.Buffer
 	ts := newTestServer(t, func(cfg *server.Config) {
 		cfg.Auth = &coretesting.StubAuthProvider{N: "test"}
 		cfg.Providers = providers
 		cfg.Services = svc
 		cfg.Authorizer = authz
+		cfg.AuditSink = invocation.NewSlogAuditSink(&auditBuf)
 	})
 	testutil.CloseOnCleanup(t, ts)
 
@@ -3244,6 +3275,51 @@ func TestWorkloadAuthorization_ExecuteOperation_UsesBoundIdentityAndRejectsSelec
 	if resp.StatusCode != http.StatusForbidden {
 		body, _ := io.ReadAll(resp.Body)
 		t.Fatalf("expected 403 for selector override, got %d: %s", resp.StatusCode, body)
+	}
+
+	lines := bytes.Split(bytes.TrimSpace(auditBuf.Bytes()), []byte("\n"))
+	if len(lines) < 2 {
+		t.Fatalf("expected denial audit records, got %d", len(lines))
+	}
+
+	var accessDeniedAudit map[string]any
+	if err := json.Unmarshal(lines[len(lines)-2], &accessDeniedAudit); err != nil {
+		t.Fatalf("parsing denied operation audit record: %v\nraw: %s", err, auditBuf.String())
+	}
+	if accessDeniedAudit["provider"] != "svc" {
+		t.Fatalf("expected denied operation provider svc, got %v", accessDeniedAudit["provider"])
+	}
+	if accessDeniedAudit["operation"] != "admin" {
+		t.Fatalf("expected denied operation admin, got %v", accessDeniedAudit["operation"])
+	}
+	if accessDeniedAudit["allowed"] != false {
+		t.Fatalf("expected denied operation audit allowed=false, got %v", accessDeniedAudit["allowed"])
+	}
+	if accessDeniedAudit["error"] != "operation access denied" {
+		t.Fatalf("unexpected denied operation error: %v", accessDeniedAudit["error"])
+	}
+
+	var selectorAudit map[string]any
+	if err := json.Unmarshal(lines[len(lines)-1], &selectorAudit); err != nil {
+		t.Fatalf("parsing selector denial audit record: %v\nraw: %s", err, auditBuf.String())
+	}
+	if selectorAudit["provider"] != "svc" {
+		t.Fatalf("expected selector audit provider svc, got %v", selectorAudit["provider"])
+	}
+	if selectorAudit["operation"] != "run" {
+		t.Fatalf("expected selector audit operation run, got %v", selectorAudit["operation"])
+	}
+	if selectorAudit["allowed"] != false {
+		t.Fatalf("expected selector audit allowed=false, got %v", selectorAudit["allowed"])
+	}
+	if selectorAudit["auth_source"] != "workload_token" {
+		t.Fatalf("expected selector audit auth_source workload_token, got %v", selectorAudit["auth_source"])
+	}
+	if selectorAudit["subject_id"] != "workload:triage-bot" {
+		t.Fatalf("expected selector audit subject_id workload:triage-bot, got %v", selectorAudit["subject_id"])
+	}
+	if selectorAudit["error"] != "workload callers may not override connection or instance bindings" {
+		t.Fatalf("unexpected selector audit error: %v", selectorAudit["error"])
 	}
 }
 
@@ -3762,6 +3838,7 @@ func TestLoginCallbackForCLI(t *testing.T) {
 	t.Parallel()
 
 	svc := coretesting.NewStubServices(t)
+	var auditBuf bytes.Buffer
 	ts := newTestServer(t, func(cfg *server.Config) {
 		cfg.Auth = &coretesting.StubAuthProvider{
 			N: "test",
@@ -3773,6 +3850,7 @@ func TestLoginCallbackForCLI(t *testing.T) {
 			},
 		}
 		cfg.Services = svc
+		cfg.AuditSink = invocation.NewSlogAuditSink(&auditBuf)
 	})
 	testutil.CloseOnCleanup(t, ts)
 
@@ -3829,6 +3907,39 @@ func TestLoginCallbackForCLI(t *testing.T) {
 		if cookie.Name == "session_token" {
 			t.Fatalf("did not expect session cookie for CLI login, got %q", cookie.Value)
 		}
+	}
+
+	lines := bytes.Split(bytes.TrimSpace(auditBuf.Bytes()), []byte("\n"))
+	if len(lines) < 2 {
+		t.Fatalf("expected CLI login callback to emit token and login audit records, got %d", len(lines))
+	}
+
+	var tokenAudit map[string]any
+	if err := json.Unmarshal(lines[len(lines)-2], &tokenAudit); err != nil {
+		t.Fatalf("parsing token audit record: %v\nraw: %s", err, auditBuf.String())
+	}
+	if tokenAudit["operation"] != "api_token.create" {
+		t.Fatalf("expected api_token.create audit operation, got %v", tokenAudit["operation"])
+	}
+	if tokenAudit["source"] != "http" {
+		t.Fatalf("expected token audit source http, got %v", tokenAudit["source"])
+	}
+	if tokenAudit["auth_source"] != "session" {
+		t.Fatalf("expected token audit auth_source session, got %v", tokenAudit["auth_source"])
+	}
+	if uid, ok := tokenAudit["user_id"].(string); !ok || uid == "" {
+		t.Fatalf("expected non-empty token audit user_id, got %v", tokenAudit["user_id"])
+	}
+	if tokenAudit["allowed"] != true {
+		t.Fatalf("expected token audit allowed=true, got %v", tokenAudit["allowed"])
+	}
+
+	var loginAudit map[string]any
+	if err := json.Unmarshal(lines[len(lines)-1], &loginAudit); err != nil {
+		t.Fatalf("parsing login audit record: %v\nraw: %s", err, auditBuf.String())
+	}
+	if loginAudit["operation"] != "auth.login.complete" {
+		t.Fatalf("expected auth.login.complete audit operation, got %v", loginAudit["operation"])
 	}
 }
 


### PR DESCRIPTION
## Summary
- audit shared auth-middleware denials as `auth.authenticate` on both HTTP and MCP request paths
- audit workload authorization denials that happen before `GuardedInvoker`, including denied `operations.list` and denied direct operation dispatch
- emit `api_token.create` when the CLI login callback mints a token
- align the audit and observability docs with the new boundary, including `workload_token`

## Go interfaces
- No exported Go API changes.
- Newly emitted audit operations:
  - `auth.authenticate`
  - `operations.list`
  - attempted catalog operation IDs on pre-invoker denials
  - `api_token.create` on CLI login token minting

## YAML interfaces
- No YAML config changes.

Example YAML:
```yaml
authorization:
  workloads:
    triage-bot:
      providers:
        github:
          connection: default
          allow:
            - issues_list
```

## Examples
Audit events:
```json
{"source":"mcp","auth_source":"api_token","operation":"auth.authenticate","allowed":false}
{"source":"http","auth_source":"workload_token","provider":"github","operation":"operations.list","allowed":false}
{"source":"http","operation":"api_token.create","allowed":true}
```

## Validation
```sh
go test ./internal/server -run 'TestAuditMetadata_AuthMiddlewareFailures|TestWorkloadAuthorization_ListOperationsFiltersAndRejectsSelectors|TestWorkloadAuthorization_ExecuteOperation_UsesBoundIdentityAndRejectsSelectors|TestLoginCallbackForCLI|TestCreateAPIToken_ExpiresAtAndAudit|TestCreateAPIToken_AuditResolveUserFailure|TestMCPEndpoint_WorkloadAuthorizationAndAudit|TestIntegrationOAuthCallback'
```