### PR TITLE
Add audit target fields for token and connection events

### DIFF
--- a/docs/content/audit-logging.mdx
+++ b/docs/content/audit-logging.mdx
@@ -33,6 +33,9 @@ These fields are emitted when available:
 | --- | --- |
 | `auth_source` | Auth mechanism for the caller: `session`, `api_token`, `workload_token`, or `env` |
 | `user_id` | Stable internal user ID |
+| `target_kind` | Generic kind for the object the event acted on, such as `api_token` or `connection` |
+| `target_id` | Stable identifier for the affected object when one exists |
+| `target_name` | Human-readable label for the affected object |
 | `error` | Denial or failure reason |
 | `client_ip` | Client IP, preferring `X-Forwarded-For` |
 | `remote_addr` | Immediate peer address |
@@ -42,6 +45,13 @@ These fields are emitted when available:
 
 For platform-level events such as failed auth or API-token lifecycle, `provider` is empty because
 the event is not tied to a specific plugin.
+
+Management events populate the generic target fields when they can identify a
+single object. API-token create and revoke events use `target_kind=api_token`
+with the token ID and, for creates, the token name. Connection lifecycle events
+use `target_kind=connection` with `target_id` and `target_name` derived from the
+provider, connection, and instance being changed. Bulk revocations use
+`target_kind=api_token_collection` because no single token ID applies.
 
 ## Event Names
 

--- a/gestaltd/core/audit.go
+++ b/gestaltd/core/audit.go
@@ -17,6 +17,9 @@ type AuditEntry struct {
 	CredentialSubjectID  string
 	CredentialConnection string
 	CredentialInstance   string
+	TargetID             string
+	TargetKind           string
+	TargetName           string
 	Provider             string
 	Operation            string
 	Depth                int

--- a/gestaltd/core/integration/restricted_test.go
+++ b/gestaltd/core/integration/restricted_test.go
@@ -58,6 +58,7 @@ func TestCatalogFilters(t *testing.T) {
 	cat := r.Catalog()
 	if cat == nil {
 		t.Fatal("Catalog() returned nil")
+		return
 	}
 	if len(cat.Operations) != 2 {
 		t.Fatalf("Catalog().Operations: got %d, want 2", len(cat.Operations))
@@ -306,6 +307,7 @@ func TestCatalogRenamesAliasedOperations(t *testing.T) {
 	cat := r.Catalog()
 	if cat == nil {
 		t.Fatal("Catalog() returned nil")
+		return
 	}
 	if len(cat.Operations) != 1 {
 		t.Fatalf("Catalog().Operations: got %d, want 1", len(cat.Operations))

--- a/gestaltd/core/testing/auth_suite.go
+++ b/gestaltd/core/testing/auth_suite.go
@@ -21,6 +21,7 @@ import (
 func RunAuthProviderTests(t *testing.T, newProvider func(t *testing.T, mockURL string) core.AuthProvider, mockServer *httptest.Server) {
 	if mockServer == nil {
 		t.Fatal("RunAuthProviderTests requires a mock server")
+		return
 	}
 	provider := newProvider(t, mockServer.URL)
 
@@ -52,6 +53,7 @@ func RunAuthProviderTests(t *testing.T, newProvider func(t *testing.T, mockURL s
 		}
 		if identity == nil {
 			t.Fatal("HandleCallback returned nil identity")
+			return
 		}
 		if identity.Email == "" {
 			t.Error("identity.Email is empty")
@@ -72,6 +74,7 @@ func RunAuthProviderTests(t *testing.T, newProvider func(t *testing.T, mockURL s
 		}
 		if identity == nil {
 			t.Fatal("ValidateToken returned nil identity")
+			return
 		}
 		if identity.Email == "" {
 			t.Error("identity.Email is empty")

--- a/gestaltd/core/testing/integration_suite.go
+++ b/gestaltd/core/testing/integration_suite.go
@@ -23,6 +23,7 @@ import (
 func RunIntegrationTests(t *testing.T, newIntegration func(t *testing.T, mockURL string) core.OAuthProvider, mockServer *httptest.Server) {
 	if mockServer == nil {
 		t.Fatal("RunIntegrationTests requires a mock server")
+		return
 	}
 	integration := newIntegration(t, mockServer.URL)
 
@@ -63,6 +64,7 @@ func RunIntegrationTests(t *testing.T, newIntegration func(t *testing.T, mockURL
 		}
 		if resp == nil {
 			t.Fatal("ExchangeCode returned nil")
+			return
 		}
 		if resp.AccessToken == "" {
 			t.Error("AccessToken is empty")

--- a/gestaltd/internal/bootstrap/executable_plugin_test.go
+++ b/gestaltd/internal/bootstrap/executable_plugin_test.go
@@ -489,6 +489,7 @@ func TestExecutableSDKExampleProviderAppliesConfigMetadataOverrides(t *testing.T
 	cat := prov.Catalog()
 	if cat == nil {
 		t.Fatal("expected non-nil catalog")
+		return
 	}
 	if cat.DisplayName != "Config Display" {
 		t.Fatalf("catalog DisplayName = %q, want %q", cat.DisplayName, "Config Display")

--- a/gestaltd/internal/composite/merged_test.go
+++ b/gestaltd/internal/composite/merged_test.go
@@ -138,6 +138,7 @@ func TestMergedCatalogIncludesConstructorMetadata(t *testing.T) {
 	cat := merged.Catalog()
 	if cat == nil {
 		t.Fatal("expected non-nil catalog")
+		return
 	}
 	if cat.DisplayName != "Override" {
 		t.Fatalf("DisplayName = %q, want %q", cat.DisplayName, "Override")

--- a/gestaltd/internal/invocation/audit.go
+++ b/gestaltd/internal/invocation/audit.go
@@ -125,6 +125,15 @@ func (s *SlogAuditSink) Log(ctx context.Context, entry core.AuditEntry) {
 	if entry.CredentialInstance != "" {
 		attrs = append(attrs, slog.String("credential_instance", entry.CredentialInstance))
 	}
+	if entry.TargetID != "" {
+		attrs = append(attrs, slog.String("target_id", entry.TargetID))
+	}
+	if entry.TargetKind != "" {
+		attrs = append(attrs, slog.String("target_kind", entry.TargetKind))
+	}
+	if entry.TargetName != "" {
+		attrs = append(attrs, slog.String("target_name", entry.TargetName))
+	}
 
 	if entry.Error != "" {
 		attrs = append(attrs, slog.String("error", entry.Error))

--- a/gestaltd/internal/mcpupstream/upstream_test.go
+++ b/gestaltd/internal/mcpupstream/upstream_test.go
@@ -104,6 +104,7 @@ func TestUpstream_DiscoverTools(t *testing.T) {
 	cat := u.Catalog()
 	if cat == nil {
 		t.Fatal("expected non-nil catalog")
+		return
 	}
 	if len(cat.Operations) != 2 {
 		t.Fatalf("expected 2 catalog operations, got %d", len(cat.Operations))
@@ -580,6 +581,7 @@ func TestUpstream_DiscoverToolsPreservesOutputSchema(t *testing.T) {
 	cat := u.Catalog()
 	if cat == nil {
 		t.Fatal("expected non-nil catalog")
+		return
 	}
 	if len(cat.Operations) != 1 {
 		t.Fatalf("expected 1 catalog operation, got %d", len(cat.Operations))

--- a/gestaltd/internal/server/audit.go
+++ b/gestaltd/internal/server/audit.go
@@ -6,9 +6,22 @@ import (
 	"net/http"
 	"strings"
 
+	"github.com/valon-technologies/gestalt/server/core"
 	"github.com/valon-technologies/gestalt/server/internal/invocation"
 	"github.com/valon-technologies/gestalt/server/internal/principal"
 )
+
+const (
+	auditTargetKindAPIToken           = "api_token"
+	auditTargetKindAPITokenCollection = "api_token_collection"
+	auditTargetKindConnection         = "connection"
+)
+
+type auditTarget struct {
+	ID   string
+	Kind string
+	Name string
+}
 
 func (s *Server) resolvePrincipalUserID(ctx context.Context, p *principal.Principal) (*principal.Principal, error) {
 	if p == nil {
@@ -54,16 +67,13 @@ func auditSourceForRequest(r *http.Request) string {
 	return "http"
 }
 
-func (s *Server) auditEvent(ctx context.Context, p *principal.Principal, source, provider, operation string, allowed bool, err error) {
+func (s *Server) auditEventWithTarget(ctx context.Context, p *principal.Principal, source, provider, operation string, allowed bool, err error, target auditTarget) {
 	if s.auditSink == nil {
 		return
 	}
 
 	ctx, entry := invocation.BuildAuditEntry(ctx, p, source, provider, operation)
-	entry.Allowed = allowed
-	if err != nil {
-		entry.Error = err.Error()
-	}
+	populateAuditEntry(&entry, allowed, err, target)
 	s.auditSink.Log(ctx, entry)
 }
 
@@ -74,14 +84,11 @@ func (s *Server) auditEventWithAuthSource(ctx context.Context, authSource, sourc
 
 	ctx, entry := invocation.BuildAuditEntry(ctx, nil, source, provider, operation)
 	entry.AuthSource = authSource
-	entry.Allowed = allowed
-	if err != nil {
-		entry.Error = err.Error()
-	}
+	populateAuditEntry(&entry, allowed, err, auditTarget{})
 	s.auditSink.Log(ctx, entry)
 }
 
-func (s *Server) auditEventWithUserID(ctx context.Context, userID, authSource, source, provider, operation string, allowed bool, err error) {
+func (s *Server) auditEventWithUserIDAndTarget(ctx context.Context, userID, authSource, source, provider, operation string, allowed bool, err error, target auditTarget) {
 	if s.auditSink == nil {
 		return
 	}
@@ -91,15 +98,71 @@ func (s *Server) auditEventWithUserID(ctx context.Context, userID, authSource, s
 	entry.AuthSource = authSource
 	entry.SubjectID = principal.UserSubjectID(userID)
 	entry.SubjectKind = string(principal.KindUser)
+	populateAuditEntry(&entry, allowed, err, target)
+	s.auditSink.Log(ctx, entry)
+}
+
+func populateAuditEntry(entry *core.AuditEntry, allowed bool, err error, target auditTarget) {
 	entry.Allowed = allowed
 	if err != nil {
 		entry.Error = err.Error()
 	}
-	s.auditSink.Log(ctx, entry)
+	if target.ID != "" {
+		entry.TargetID = target.ID
+	}
+	if target.Kind != "" {
+		entry.TargetKind = target.Kind
+	}
+	if target.Name != "" {
+		entry.TargetName = target.Name
+	}
+}
+
+func apiTokenAuditTarget(id, name string) auditTarget {
+	return auditTarget{
+		ID:   id,
+		Kind: auditTargetKindAPIToken,
+		Name: name,
+	}
+}
+
+func apiTokenCollectionAuditTarget() auditTarget {
+	return auditTarget{Kind: auditTargetKindAPITokenCollection}
+}
+
+func connectionAuditTarget(provider, connection, instance string) auditTarget {
+	connection = auditConnectionName(connection)
+	if instance == "" {
+		instance = defaultTokenInstance
+	}
+
+	idParts := []string{}
+	if provider != "" {
+		idParts = append(idParts, provider)
+	}
+	idParts = append(idParts, connection, instance)
+
+	return auditTarget{
+		ID:   strings.Join(idParts, "/"),
+		Kind: auditTargetKindConnection,
+		Name: connection + "/" + instance,
+	}
+}
+
+func auditConnectionName(connection string) string {
+	connection = userFacingConnectionName(connection)
+	if connection == "" {
+		return "default"
+	}
+	return connection
 }
 
 func (s *Server) auditHTTPEvent(ctx context.Context, p *principal.Principal, provider, operation string, allowed bool, err error) {
-	s.auditEvent(ctx, p, "http", provider, operation, allowed, err)
+	s.auditHTTPEventWithTarget(ctx, p, provider, operation, allowed, err, auditTarget{})
+}
+
+func (s *Server) auditHTTPEventWithTarget(ctx context.Context, p *principal.Principal, provider, operation string, allowed bool, err error, target auditTarget) {
+	s.auditEventWithTarget(ctx, p, "http", provider, operation, allowed, err, target)
 }
 
 func (s *Server) auditRequestEventWithAuthSource(r *http.Request, authSource, provider, operation string, allowed bool, err error) {
@@ -107,5 +170,9 @@ func (s *Server) auditRequestEventWithAuthSource(r *http.Request, authSource, pr
 }
 
 func (s *Server) auditHTTPEventWithUserID(ctx context.Context, userID, authSource, provider, operation string, allowed bool, err error) {
-	s.auditEventWithUserID(ctx, userID, authSource, "http", provider, operation, allowed, err)
+	s.auditHTTPEventWithUserIDAndTarget(ctx, userID, authSource, provider, operation, allowed, err, auditTarget{})
+}
+
+func (s *Server) auditHTTPEventWithUserIDAndTarget(ctx context.Context, userID, authSource, provider, operation string, allowed bool, err error, target auditTarget) {
+	s.auditEventWithUserIDAndTarget(ctx, userID, authSource, "http", provider, operation, allowed, err, target)
 }

--- a/gestaltd/internal/server/handlers.go
+++ b/gestaltd/internal/server/handlers.go
@@ -242,8 +242,9 @@ func (s *Server) disconnectIntegration(w http.ResponseWriter, r *http.Request) {
 	name := chi.URLParam(r, "name")
 	auditAllowed := false
 	auditErr := errors.New("connection disconnect failed")
+	auditTarget := auditTarget{}
 	defer func() {
-		s.auditHTTPEvent(r.Context(), PrincipalFromContext(r.Context()), name, "connection.disconnect", auditAllowed, auditErr)
+		s.auditHTTPEventWithTarget(r.Context(), PrincipalFromContext(r.Context()), name, "connection.disconnect", auditAllowed, auditErr, auditTarget)
 	}()
 
 	userID, err := s.resolveUserID(w, r)
@@ -274,6 +275,9 @@ func (s *Server) disconnectIntegration(w http.ResponseWriter, r *http.Request) {
 			auditErr = errors.New("invalid connection parameter")
 			return
 		}
+	}
+	if requestedConnection != "" && requestedInstance != "" {
+		auditTarget = connectionAuditTarget(name, requestedConnection, requestedInstance)
 	}
 
 	tokens, err := s.tokens.ListTokensForIntegration(r.Context(), userID, name)
@@ -327,6 +331,7 @@ func (s *Server) disconnectIntegration(w http.ResponseWriter, r *http.Request) {
 	}
 
 	tokenID := matched[0].ID
+	auditTarget = connectionAuditTarget(name, matched[0].Connection, matched[0].Instance)
 	if tokenID == "" {
 		auditErr = errors.New("connection token is missing an ID")
 		writeError(w, http.StatusNotFound, fmt.Sprintf("no connection found for integration %q", name))

--- a/gestaltd/internal/server/handlers_connect.go
+++ b/gestaltd/internal/server/handlers_connect.go
@@ -30,12 +30,13 @@ func (s *Server) connectManual(w http.ResponseWriter, r *http.Request) {
 	startedAt := time.Now()
 	auditAllowed := false
 	auditErr := errors.New("manual connection failed")
+	auditTarget := auditTarget{Kind: auditTargetKindConnection}
 	providerName := ""
 	metricProviderName := metricutil.UnknownAttrValue
 	connectionMode := metricutil.UnknownAttrValue
 	defer func() {
 		metricutil.RecordConnectionAuthMetrics(r.Context(), startedAt, metricProviderName, "manual", "complete", connectionMode, auditErr != nil)
-		s.auditHTTPEvent(r.Context(), PrincipalFromContext(r.Context()), providerName, "connection.manual.connect", auditAllowed, auditErr)
+		s.auditHTTPEventWithTarget(r.Context(), PrincipalFromContext(r.Context()), providerName, "connection.manual.connect", auditAllowed, auditErr, auditTarget)
 	}()
 	if p := PrincipalFromContext(r.Context()); p != nil && p.Kind == principal.KindWorkload {
 		auditErr = errWorkloadForbidden
@@ -89,6 +90,7 @@ func (s *Server) connectManual(w http.ResponseWriter, r *http.Request) {
 		auditErr = errors.New("invalid instance")
 		return
 	}
+	auditTarget = connectionAuditTarget(req.Integration, manualConnection, manualInstance)
 
 	effectiveCredential, credErr := buildEffectiveManualCredential(req, auth)
 	if credErr != nil {

--- a/gestaltd/internal/server/handlers_oauth.go
+++ b/gestaltd/internal/server/handlers_oauth.go
@@ -28,12 +28,13 @@ func (s *Server) startIntegrationOAuth(w http.ResponseWriter, r *http.Request) {
 	startedAt := time.Now()
 	auditAllowed := false
 	auditErr := errors.New("oauth start failed")
+	auditTarget := auditTarget{Kind: auditTargetKindConnection}
 	providerName := ""
 	metricProviderName := metricutil.UnknownAttrValue
 	connectionMode := metricutil.UnknownAttrValue
 	defer func() {
 		metricutil.RecordConnectionAuthMetrics(r.Context(), startedAt, metricProviderName, "oauth", "start", connectionMode, auditErr != nil)
-		s.auditHTTPEvent(r.Context(), PrincipalFromContext(r.Context()), providerName, "connection.oauth.start", auditAllowed, auditErr)
+		s.auditHTTPEventWithTarget(r.Context(), PrincipalFromContext(r.Context()), providerName, "connection.oauth.start", auditAllowed, auditErr, auditTarget)
 	}()
 	if p := PrincipalFromContext(r.Context()); p != nil && p.Kind == principal.KindWorkload {
 		auditErr = errWorkloadForbidden
@@ -86,6 +87,7 @@ func (s *Server) startIntegrationOAuth(w http.ResponseWriter, r *http.Request) {
 		auditErr = errors.New("invalid instance")
 		return
 	}
+	auditTarget = connectionAuditTarget(req.Integration, connection, instance)
 
 	connParams, ok := resolveConnectionParams(w, prov, req.ConnectionParams)
 	if !ok {
@@ -146,16 +148,17 @@ func (s *Server) integrationOAuthCallback(w http.ResponseWriter, r *http.Request
 	auditAllowed := false
 	auditErr := errors.New("oauth callback failed")
 	auditUserID := ""
+	auditTarget := auditTarget{Kind: auditTargetKindConnection}
 	stateAuthSource := ""
 	providerName := ""
 	connectionMode := metricutil.UnknownAttrValue
 	defer func() {
 		metricutil.RecordConnectionAuthMetrics(r.Context(), startedAt, providerName, "oauth", "complete", connectionMode, auditErr != nil)
 		if auditUserID != "" {
-			s.auditHTTPEventWithUserID(r.Context(), auditUserID, stateAuthSource, providerName, "connection.oauth.complete", auditAllowed, auditErr)
+			s.auditHTTPEventWithUserIDAndTarget(r.Context(), auditUserID, stateAuthSource, providerName, "connection.oauth.complete", auditAllowed, auditErr, auditTarget)
 			return
 		}
-		s.auditHTTPEvent(r.Context(), nil, providerName, "connection.oauth.complete", auditAllowed, auditErr)
+		s.auditHTTPEventWithTarget(r.Context(), nil, providerName, "connection.oauth.complete", auditAllowed, auditErr, auditTarget)
 	}()
 
 	writeCallbackError := func(status int, apiMessage, title, pageMessage string) {
@@ -209,6 +212,7 @@ func (s *Server) integrationOAuthCallback(w http.ResponseWriter, r *http.Request
 	providerName = state.Integration
 	auditUserID = state.UserID
 	stateAuthSource = state.AuthSource
+	auditTarget = connectionAuditTarget(state.Integration, state.Connection, state.Instance)
 	handler, ok := s.requireOAuthHandler(w, providerName, state.Connection)
 	if !ok {
 		auditErr = errors.New("oauth is not configured")

--- a/gestaltd/internal/server/handlers_tokens.go
+++ b/gestaltd/internal/server/handlers_tokens.go
@@ -30,8 +30,9 @@ type createTokenResponse struct {
 func (s *Server) createAPIToken(w http.ResponseWriter, r *http.Request) {
 	auditAllowed := false
 	auditErr := errors.New("api token creation failed")
+	auditTarget := auditTarget{}
 	defer func() {
-		s.auditHTTPEvent(r.Context(), PrincipalFromContext(r.Context()), "", "api_token.create", auditAllowed, auditErr)
+		s.auditHTTPEventWithTarget(r.Context(), PrincipalFromContext(r.Context()), "", "api_token.create", auditAllowed, auditErr, auditTarget)
 	}()
 
 	userID, err := s.resolveUserID(w, r)
@@ -52,6 +53,7 @@ func (s *Server) createAPIToken(w http.ResponseWriter, r *http.Request) {
 		writeError(w, http.StatusBadRequest, "name is required")
 		return
 	}
+	auditTarget = apiTokenAuditTarget("", req.Name)
 
 	if req.Scopes != "" {
 		for _, scope := range strings.Fields(req.Scopes) {
@@ -69,6 +71,7 @@ func (s *Server) createAPIToken(w http.ResponseWriter, r *http.Request) {
 		writeError(w, http.StatusInternalServerError, "failed to generate token")
 		return
 	}
+	auditTarget = apiTokenAuditTarget(apiToken.ID, apiToken.Name)
 
 	auditAllowed = true
 	auditErr = nil
@@ -110,8 +113,10 @@ func (s *Server) listAPITokens(w http.ResponseWriter, r *http.Request) {
 func (s *Server) revokeAPIToken(w http.ResponseWriter, r *http.Request) {
 	auditAllowed := false
 	auditErr := errors.New("api token revoke failed")
+	id := chi.URLParam(r, "id")
+	auditTarget := apiTokenAuditTarget(id, "")
 	defer func() {
-		s.auditHTTPEvent(r.Context(), PrincipalFromContext(r.Context()), "", "api_token.revoke", auditAllowed, auditErr)
+		s.auditHTTPEventWithTarget(r.Context(), PrincipalFromContext(r.Context()), "", "api_token.revoke", auditAllowed, auditErr, auditTarget)
 	}()
 
 	userID, err := s.resolveUserID(w, r)
@@ -120,7 +125,6 @@ func (s *Server) revokeAPIToken(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	id := chi.URLParam(r, "id")
 	if err := s.apiTokens.RevokeAPIToken(r.Context(), userID, id); err != nil {
 		if errors.Is(err, core.ErrNotFound) {
 			auditErr = errors.New("token not found")
@@ -139,8 +143,9 @@ func (s *Server) revokeAPIToken(w http.ResponseWriter, r *http.Request) {
 func (s *Server) revokeAllAPITokens(w http.ResponseWriter, r *http.Request) {
 	auditAllowed := false
 	auditErr := errors.New("api token revoke all failed")
+	auditTarget := apiTokenCollectionAuditTarget()
 	defer func() {
-		s.auditHTTPEvent(r.Context(), PrincipalFromContext(r.Context()), "", "api_token.revoke_all", auditAllowed, auditErr)
+		s.auditHTTPEventWithTarget(r.Context(), PrincipalFromContext(r.Context()), "", "api_token.revoke_all", auditAllowed, auditErr, auditTarget)
 	}()
 
 	userID, err := s.resolveUserID(w, r)

--- a/gestaltd/internal/server/pending_connection.go
+++ b/gestaltd/internal/server/pending_connection.go
@@ -318,13 +318,14 @@ func (s *Server) selectPendingConnection(w http.ResponseWriter, r *http.Request)
 	auditErr := errors.New("pending connection selection failed")
 	auditUserID := ""
 	auditAuthSource := ""
+	auditTarget := auditTarget{Kind: auditTargetKindConnection}
 	providerName := ""
 	defer func() {
 		if auditUserID != "" {
-			s.auditHTTPEventWithUserID(r.Context(), auditUserID, auditAuthSource, providerName, "connection.pending.select", auditAllowed, auditErr)
+			s.auditHTTPEventWithUserIDAndTarget(r.Context(), auditUserID, auditAuthSource, providerName, "connection.pending.select", auditAllowed, auditErr, auditTarget)
 			return
 		}
-		s.auditHTTPEvent(r.Context(), PrincipalFromContext(r.Context()), providerName, "connection.pending.select", auditAllowed, auditErr)
+		s.auditHTTPEventWithTarget(r.Context(), PrincipalFromContext(r.Context()), providerName, "connection.pending.select", auditAllowed, auditErr, auditTarget)
 	}()
 
 	if err := r.ParseForm(); err != nil {
@@ -353,6 +354,7 @@ func (s *Server) selectPendingConnection(w http.ResponseWriter, r *http.Request)
 		return
 	}
 	providerName = state.Token.Integration
+	auditTarget = connectionAuditTarget(state.Token.Integration, state.Token.Connection, state.Token.Instance)
 	if !s.authorizePendingConnection(w, r, state) {
 		auditErr = errors.New("pending connection authorization required")
 		return

--- a/gestaltd/internal/server/server_test.go
+++ b/gestaltd/internal/server/server_test.go
@@ -3217,6 +3217,7 @@ func TestDisconnectIntegration(t *testing.T) {
 
 		svc := coretesting.NewStubServices(t)
 		u := seedUser(t, svc, "anonymous@gestalt")
+		var auditBuf bytes.Buffer
 		seedToken(t, svc, &core.IntegrationToken{
 			ID: "tok-b", UserID: u.ID, Integration: "notion",
 			Connection: "mcp", Instance: "MCP OAuth", AccessToken: "test-token",
@@ -3228,6 +3229,7 @@ func TestDisconnectIntegration(t *testing.T) {
 
 		ts := newTestServer(t, func(cfg *server.Config) {
 			cfg.Providers = testutil.NewProviderRegistry(t, &coretesting.StubIntegration{N: "notion", DN: "Notion"})
+			cfg.AuditSink = invocation.NewSlogAuditSink(&auditBuf)
 			cfg.Services = svc
 		})
 		testutil.CloseOnCleanup(t, ts)
@@ -3253,6 +3255,20 @@ func TestDisconnectIntegration(t *testing.T) {
 		if tokens[0].Connection != "default" || tokens[0].Instance != "default" {
 			t.Fatalf("unexpected remaining token %+v", tokens[0])
 		}
+
+		var auditRecord map[string]any
+		if err := json.Unmarshal(auditBuf.Bytes(), &auditRecord); err != nil {
+			t.Fatalf("parsing audit record: %v\nraw: %s", err, auditBuf.String())
+		}
+		if auditRecord["target_kind"] != "connection" {
+			t.Fatalf("expected audit target_kind connection, got %v", auditRecord["target_kind"])
+		}
+		if auditRecord["target_id"] != "notion/mcp/MCP OAuth" {
+			t.Fatalf("expected audit target_id notion/mcp/MCP OAuth, got %v", auditRecord["target_id"])
+		}
+		if auditRecord["target_name"] != "mcp/MCP OAuth" {
+			t.Fatalf("expected audit target_name mcp/MCP OAuth, got %v", auditRecord["target_name"])
+		}
 	})
 
 	t.Run("ambiguous error uses canonical hint", func(t *testing.T) {
@@ -3260,6 +3276,7 @@ func TestDisconnectIntegration(t *testing.T) {
 
 		svc := coretesting.NewStubServices(t)
 		u := seedUser(t, svc, "anonymous@gestalt")
+		var auditBuf bytes.Buffer
 		seedToken(t, svc, &core.IntegrationToken{
 			ID: "tok-a", UserID: u.ID, Integration: "slack",
 			Connection: "workspace", Instance: "team-a", AccessToken: "test-token",
@@ -3271,6 +3288,7 @@ func TestDisconnectIntegration(t *testing.T) {
 
 		ts := newTestServer(t, func(cfg *server.Config) {
 			cfg.Providers = testutil.NewProviderRegistry(t, &coretesting.StubIntegration{N: "slack", DN: "Slack"})
+			cfg.AuditSink = invocation.NewSlogAuditSink(&auditBuf)
 			cfg.Services = svc
 		})
 		testutil.CloseOnCleanup(t, ts)
@@ -3292,6 +3310,20 @@ func TestDisconnectIntegration(t *testing.T) {
 		}
 		if !strings.Contains(result["error"], "?_instance=NAME") {
 			t.Fatalf("expected canonical parameter hint, got %q", result["error"])
+		}
+
+		var auditRecord map[string]any
+		if err := json.Unmarshal(auditBuf.Bytes(), &auditRecord); err != nil {
+			t.Fatalf("parsing audit record: %v\nraw: %s", err, auditBuf.String())
+		}
+		if auditRecord["target_kind"] != nil {
+			t.Fatalf("expected no audit target_kind for ambiguous disconnect, got %v", auditRecord["target_kind"])
+		}
+		if auditRecord["target_id"] != nil {
+			t.Fatalf("expected no audit target_id for ambiguous disconnect, got %v", auditRecord["target_id"])
+		}
+		if auditRecord["target_name"] != nil {
+			t.Fatalf("expected no audit target_name for ambiguous disconnect, got %v", auditRecord["target_name"])
 		}
 	})
 }
@@ -5729,6 +5761,7 @@ func TestLoginCallbackWithStatefulHandler(t *testing.T) {
 func TestStartIntegrationOAuth(t *testing.T) {
 	t.Parallel()
 
+	var auditBuf bytes.Buffer
 	stub := &stubIntegrationWithAuthURL{
 		StubIntegration: coretesting.StubIntegration{N: "slack"},
 		authURL:         "https://slack.com/oauth/v2/authorize",
@@ -5742,6 +5775,7 @@ func TestStartIntegrationOAuth(t *testing.T) {
 		cfg.Providers = testutil.NewProviderRegistry(t, stub)
 		cfg.DefaultConnection = map[string]string{"slack": testDefaultConnection}
 		cfg.ConnectionAuth = testConnectionAuth("slack", handler)
+		cfg.AuditSink = invocation.NewSlogAuditSink(&auditBuf)
 		cfg.Services = coretesting.NewStubServices(t)
 	})
 	testutil.CloseOnCleanup(t, ts)
@@ -5776,6 +5810,20 @@ func TestStartIntegrationOAuth(t *testing.T) {
 	}
 	if parsedURL.Query().Get("state") != result["state"] {
 		t.Fatal("expected auth URL state to match returned state")
+	}
+
+	var auditRecord map[string]any
+	if err := json.Unmarshal(auditBuf.Bytes(), &auditRecord); err != nil {
+		t.Fatalf("parsing audit record: %v\nraw: %s", err, auditBuf.String())
+	}
+	if auditRecord["target_kind"] != "connection" {
+		t.Fatalf("expected audit target_kind connection, got %v", auditRecord["target_kind"])
+	}
+	if auditRecord["target_id"] != "slack/default/default" {
+		t.Fatalf("expected audit target_id slack/default/default, got %v", auditRecord["target_id"])
+	}
+	if auditRecord["target_name"] != "default/default" {
+		t.Fatalf("expected audit target_name default/default, got %v", auditRecord["target_name"])
 	}
 }
 
@@ -5890,6 +5938,15 @@ func TestIntegrationOAuthCallback(t *testing.T) {
 		}
 		if uid, ok := auditRecord["user_id"].(string); !ok || uid == "" {
 			t.Fatalf("expected non-empty audit user_id, got %v", auditRecord["user_id"])
+		}
+		if auditRecord["target_kind"] != "connection" {
+			t.Fatalf("expected audit target_kind connection, got %v", auditRecord["target_kind"])
+		}
+		if auditRecord["target_id"] != "slack/default/default" {
+			t.Fatalf("expected audit target_id slack/default/default, got %v", auditRecord["target_id"])
+		}
+		if auditRecord["target_name"] != "default/default" {
+			t.Fatalf("expected audit target_name default/default, got %v", auditRecord["target_name"])
 		}
 	})
 
@@ -6144,6 +6201,7 @@ func TestRevokeAPIToken(t *testing.T) {
 
 	svc := coretesting.NewStubServices(t)
 	u := seedUser(t, svc, "anonymous@gestalt")
+	var auditBuf bytes.Buffer
 	ctx := context.Background()
 	exp := time.Now().Add(24 * time.Hour)
 	_ = svc.APITokens.StoreAPIToken(ctx, &core.APIToken{
@@ -6151,6 +6209,7 @@ func TestRevokeAPIToken(t *testing.T) {
 	})
 
 	ts := newTestServer(t, func(cfg *server.Config) {
+		cfg.AuditSink = invocation.NewSlogAuditSink(&auditBuf)
 		cfg.Services = svc
 	})
 	testutil.CloseOnCleanup(t, ts)
@@ -6172,6 +6231,17 @@ func TestRevokeAPIToken(t *testing.T) {
 	}
 	if result["status"] != "revoked" {
 		t.Fatalf("expected revoked, got %q", result["status"])
+	}
+
+	var auditRecord map[string]any
+	if err := json.Unmarshal(auditBuf.Bytes(), &auditRecord); err != nil {
+		t.Fatalf("parsing audit record: %v\nraw: %s", err, auditBuf.String())
+	}
+	if auditRecord["target_kind"] != "api_token" {
+		t.Fatalf("expected audit target_kind api_token, got %v", auditRecord["target_kind"])
+	}
+	if auditRecord["target_id"] != "tok-123" {
+		t.Fatalf("expected audit target_id tok-123, got %v", auditRecord["target_id"])
 	}
 }
 
@@ -6237,6 +6307,10 @@ func TestCreateAPIToken_DefaultExpiry(t *testing.T) {
 	if err := json.NewDecoder(resp.Body).Decode(&result); err != nil {
 		t.Fatalf("decoding: %v", err)
 	}
+	tokenID, ok := result["id"].(string)
+	if !ok || tokenID == "" {
+		t.Fatalf("expected non-empty id in response, got %v", result["id"])
+	}
 	expiresAtRaw, ok := result["expiresAt"]
 	if !ok || expiresAtRaw == nil {
 		t.Fatal("expected expiresAt in response, got nil")
@@ -6272,6 +6346,15 @@ func TestCreateAPIToken_DefaultExpiry(t *testing.T) {
 	}
 	if auditRecord["allowed"] != true {
 		t.Fatalf("expected audit allowed=true, got %v", auditRecord["allowed"])
+	}
+	if auditRecord["target_kind"] != "api_token" {
+		t.Fatalf("expected audit target_kind api_token, got %v", auditRecord["target_kind"])
+	}
+	if auditRecord["target_id"] != tokenID {
+		t.Fatalf("expected audit target_id %q, got %v", tokenID, auditRecord["target_id"])
+	}
+	if auditRecord["target_name"] != "expiry-test" {
+		t.Fatalf("expected audit target_name expiry-test, got %v", auditRecord["target_name"])
 	}
 }
 
@@ -6383,6 +6466,7 @@ func TestRevokeAllAPITokens(t *testing.T) {
 
 	svc := coretesting.NewStubServices(t)
 	u := seedUser(t, svc, "anonymous@gestalt")
+	var auditBuf bytes.Buffer
 	ctx := context.Background()
 	exp := time.Now().Add(24 * time.Hour)
 	for i, name := range []string{"tok-a", "tok-b", "tok-c"} {
@@ -6393,6 +6477,7 @@ func TestRevokeAllAPITokens(t *testing.T) {
 	}
 
 	ts := newTestServer(t, func(cfg *server.Config) {
+		cfg.AuditSink = invocation.NewSlogAuditSink(&auditBuf)
 		cfg.Services = svc
 	})
 	testutil.CloseOnCleanup(t, ts)
@@ -6417,6 +6502,14 @@ func TestRevokeAllAPITokens(t *testing.T) {
 	}
 	if count, ok := result["count"].(float64); !ok || count != 3 {
 		t.Fatalf("expected count 3, got %v", result["count"])
+	}
+
+	var auditRecord map[string]any
+	if err := json.Unmarshal(auditBuf.Bytes(), &auditRecord); err != nil {
+		t.Fatalf("parsing audit record: %v\nraw: %s", err, auditBuf.String())
+	}
+	if auditRecord["target_kind"] != "api_token_collection" {
+		t.Fatalf("expected audit target_kind api_token_collection, got %v", auditRecord["target_kind"])
 	}
 }
 
@@ -7648,12 +7741,14 @@ func TestConnectManual(t *testing.T) {
 	t.Run("connected", func(t *testing.T) {
 		t.Parallel()
 
+		var auditBuf bytes.Buffer
 		svc := coretesting.NewStubServices(t)
 		ts := newTestServer(t, func(cfg *server.Config) {
 			cfg.Providers = testutil.NewProviderRegistry(t, &stubManualProvider{
 				StubIntegration: coretesting.StubIntegration{N: "manual-svc"},
 			})
 			cfg.DefaultConnection = map[string]string{"manual-svc": config.PluginConnectionName}
+			cfg.AuditSink = invocation.NewSlogAuditSink(&auditBuf)
 			cfg.Services = svc
 		})
 		testutil.CloseOnCleanup(t, ts)
@@ -7690,6 +7785,20 @@ func TestConnectManual(t *testing.T) {
 		}
 		if stored.AccessToken != "my-api-key" {
 			t.Fatalf("expected credential my-api-key, got %q", stored.AccessToken)
+		}
+
+		var auditRecord map[string]any
+		if err := json.Unmarshal(auditBuf.Bytes(), &auditRecord); err != nil {
+			t.Fatalf("parsing audit record: %v\nraw: %s", err, auditBuf.String())
+		}
+		if auditRecord["target_kind"] != "connection" {
+			t.Fatalf("expected audit target_kind connection, got %v", auditRecord["target_kind"])
+		}
+		if auditRecord["target_id"] != "manual-svc/plugin/default" {
+			t.Fatalf("expected audit target_id manual-svc/plugin/default, got %v", auditRecord["target_id"])
+		}
+		if auditRecord["target_name"] != "plugin/default" {
+			t.Fatalf("expected audit target_name plugin/default, got %v", auditRecord["target_name"])
 		}
 	})
 
@@ -7848,6 +7957,15 @@ func TestConnectManual(t *testing.T) {
 		}
 		if userID, ok := noAuthAudit["user_id"]; ok && userID != "" {
 			t.Fatalf("expected unauthenticated denied selection to omit user_id, got %v", userID)
+		}
+		if noAuthAudit["target_kind"] != "connection" {
+			t.Fatalf("expected pending connection target_kind connection, got %v", noAuthAudit["target_kind"])
+		}
+		if noAuthAudit["target_id"] != "manual-svc/plugin/default" {
+			t.Fatalf("expected pending connection target_id manual-svc/plugin/default, got %v", noAuthAudit["target_id"])
+		}
+		if noAuthAudit["target_name"] != "plugin/default" {
+			t.Fatalf("expected pending connection target_name plugin/default, got %v", noAuthAudit["target_name"])
 		}
 
 		mismatchForm := url.Values{


### PR DESCRIPTION
## Summary
- add generic audit target fields to `core.AuditEntry`
- backfill target identity across API-token lifecycle events and connection management flows
- keep ambiguous disconnect failures from fabricating a specific connection target
- document the new target fields in the audit logging guide

## Go interfaces
- `core.AuditEntry` adds:
  - `TargetKind string`
  - `TargetID string`
  - `TargetName string`

## YAML interfaces
- No YAML config changes.

Example YAML:
```yaml
providers:
  audit:
    source: stdout
```

## Examples
Audit events:
```json
{"operation":"connection.disconnect","target_kind":"connection","target_id":"slack/workspace/team-a","target_name":"workspace/team-a"}
{"operation":"api_token.revoke","target_kind":"api_token","target_id":"tok_123","target_name":"ci-bot"}
{"operation":"api_token.revoke_all","target_kind":"api_token_collection"}
```

## Validation
```sh
go test ./internal/server -run 'TestStartIntegrationOAuth|TestIntegrationOAuthCallback|TestRevokeAPIToken|TestCreateAPIToken_DefaultExpiry|TestRevokeAllAPITokens|TestDisconnectIntegration|TestConnectManual'
```