### PR TITLE
Audit token inventory reads and discovery fallback metrics

### DIFF
--- a/docs/content/audit-logging.mdx
+++ b/docs/content/audit-logging.mdx
@@ -8,7 +8,7 @@ backend without having to reconstruct behavior from mixed application logs.
 
 ## Coverage
 
-Audit events cover HTTP and MCP operation invocations, other guarded runtime surfaces such as binding hooks, failed auth on protected routes, HTTP authorization denials rejected before `GuardedInvoker` runs, login and logout flows, plugin connect and disconnect flows, and API token lifecycle. Each event carries a `source` field (`http`, `mcp`, or a surface-specific value like `binding:...`) so consumers can filter by surface.
+Audit events cover HTTP and MCP operation invocations, other guarded runtime surfaces such as binding hooks, failed auth on protected routes, HTTP authorization denials rejected before `GuardedInvoker` runs, login and logout flows, plugin connect and disconnect flows, and API token inventory and lifecycle events. Each event carries a `source` field (`http`, `mcp`, or a surface-specific value like `binding:...`) so consumers can filter by surface.
 
 `gestaltd` resolves the authenticated user ID before emitting session-backed audit events, so both session requests and API-token requests produce stable `user_id` values when a user identity exists.
 
@@ -40,7 +40,7 @@ These fields are emitted when available:
 | `trace_id` | Active OpenTelemetry trace ID |
 | `span_id` | Active OpenTelemetry span ID |
 
-For platform-level events such as failed auth or API-token lifecycle, `provider` is empty because
+For platform-level events such as failed auth or API-token inventory and lifecycle, `provider` is empty because
 the event is not tied to a specific plugin.
 
 ## Event Names
@@ -58,6 +58,7 @@ Non-invocation audit events use explicit operation names:
 - `connection.manual.connect`
 - `connection.pending.select`
 - `connection.disconnect`
+- `api_token.list`
 - `operations.list`
 - `api_token.create`
 - `api_token.revoke`
@@ -82,7 +83,9 @@ rejects the request before invocation.
 | HTTP pre-invoker authorization denials | No dedicated semantic metric family | Yes | Denied workload access before invocation dispatch is audited with the attempted operation or `operations.list`. |
 | Connection auth start and completion | Yes: `gestaltd.connection.auth.*` | Yes | Covers OAuth start and completion plus manual connect completion. |
 | Connection credential refresh | Yes: `gestaltd.connection.auth.*` with `action=refresh` | No | Refresh remains metrics-only to avoid audit noise. |
-| Datastore methods | Yes: `gestaltd.datastore.*` | No | Datastore calls are internal implementation telemetry, not audit events. |
+| Credentialed HTTP catalog discovery | Yes: `gestaltd.discovery.*` with `action=list_operations` | No | Operation listing that resolves a session catalog stays metrics-only to avoid audit spam. |
+| IndexedDB operations | Yes: `gestaltd.indexeddb.*` | No | Datastore calls are internal implementation telemetry, not audit events. |
+| API token inventory read | No dedicated semantic metric family | Yes | `api_token.list` is audited because it exposes stored API-token inventory. |
 | API token lifecycle | No dedicated semantic metric family | Yes | Audit records exist for explicit token create/revoke flows and CLI token minting. |
 | Logout, pending selection, disconnect | No dedicated semantic metric family | Yes | These remain audit-only workflow events. |
 

--- a/docs/content/observability.mdx
+++ b/docs/content/observability.mdx
@@ -96,7 +96,7 @@ collectors can still split the stream by filtering on `log.type=audit`.
 
 The built-in metric surface covers Prometheus exporter metadata, inbound HTTP
 requests handled by `gestaltd`, broker operation execution, connection auth
-flows, platform auth actions, IndexedDB operations, and outbound gRPC calls
+flows, platform auth actions, credentialed HTTP catalog discovery, IndexedDB operations, and outbound gRPC calls
 from `gestaltd` to provider processes.
 
 Gestalt documents metric names using their OpenTelemetry instrument names. The
@@ -203,6 +203,36 @@ These metrics carry low-cardinality attributes: `gestalt.provider` (the auth
 provider name) and `gestalt.action` (`begin_login`, `complete_login`, or
 `validate_token`).
 
+### Discovery Metrics
+
+These metrics are recorded around credentialed HTTP catalog discovery, currently
+`GET /api/v1/integrations/{name}/operations` when `gestaltd` resolves a
+session catalog with stored or identity credentials.
+
+<Tabs items={['OpenTelemetry', 'Prometheus']}>
+  <Tabs.Tab>
+    | Metric | Type | Meaning |
+    | --- | --- | --- |
+    | `gestaltd.discovery.count` | Counter | Credentialed discovery attempts |
+    | `gestaltd.discovery.error_count` | Counter | Failed credentialed discovery attempts |
+    | `gestaltd.discovery.duration` | Histogram | Credentialed discovery duration |
+  </Tabs.Tab>
+  <Tabs.Tab>
+    | Metric | Type | Meaning |
+    | --- | --- | --- |
+    | `gestaltd_discovery_count_total` | Counter | Credentialed discovery attempts |
+    | `gestaltd_discovery_error_count_total` | Counter | Failed credentialed discovery attempts |
+    | `gestaltd_discovery_duration_seconds` | Histogram | Credentialed discovery duration |
+  </Tabs.Tab>
+</Tabs>
+
+These metrics carry low-cardinality attributes: `gestalt.provider` (the plugin
+key), `gestalt.action` (currently `list_operations`), and
+`gestalt.connection_mode` (the provider auth mode: `none`, `user`, `identity`,
+or `either`). `gestaltd.discovery.error_count` increments when the
+credentialed session-catalog path fails, even if `gestaltd` falls back to a
+static catalog and still serves a successful HTTP response.
+
 ### IndexedDB Metrics
 
 These metrics are recorded around every ObjectStore and Index operation on the
@@ -261,7 +291,9 @@ need actor, target, and outcome details.
 | Pre-invoker authorization denials | No dedicated semantic metric family | Yes | Denied workload access before guarded invocation dispatch is audited with the attempted operation or `operations.list`. |
 | Connection auth start and completion | Yes: `gestaltd.connection.auth.*` | Yes | Covers OAuth start and completion plus manual connect completion. |
 | Connection credential refresh | Yes: `gestaltd.connection.auth.*` with `action=refresh` | No | Refresh is system maintenance behavior, not a user-facing audit event. |
+| Credentialed HTTP catalog discovery | Yes: `gestaltd.discovery.*` with `action=list_operations` | No | Operation listing stays metrics-only even when it resolves session catalogs. |
 | IndexedDB operations | Yes: `gestaltd.indexeddb.*` | No | Audit the higher-level user action instead of low-level storage calls. |
+| API token inventory read | No dedicated semantic metric family | Yes | `api_token.list` is audited because it exposes stored API-token inventory. |
 | API token lifecycle | No dedicated semantic metric family | Yes | `api_token.create`, `api_token.revoke`, and `api_token.revoke_all` are audited. |
 | Logout, pending selection, disconnect | No dedicated semantic metric family | Yes | These are workflow and security events rather than aggregate telemetry series. |
 

--- a/gestaltd/core/integration/restricted_test.go
+++ b/gestaltd/core/integration/restricted_test.go
@@ -58,6 +58,7 @@ func TestCatalogFilters(t *testing.T) {
 	cat := r.Catalog()
 	if cat == nil {
 		t.Fatal("Catalog() returned nil")
+		return
 	}
 	if len(cat.Operations) != 2 {
 		t.Fatalf("Catalog().Operations: got %d, want 2", len(cat.Operations))
@@ -306,6 +307,7 @@ func TestCatalogRenamesAliasedOperations(t *testing.T) {
 	cat := r.Catalog()
 	if cat == nil {
 		t.Fatal("Catalog() returned nil")
+		return
 	}
 	if len(cat.Operations) != 1 {
 		t.Fatalf("Catalog().Operations: got %d, want 1", len(cat.Operations))

--- a/gestaltd/core/testing/auth_suite.go
+++ b/gestaltd/core/testing/auth_suite.go
@@ -21,6 +21,7 @@ import (
 func RunAuthProviderTests(t *testing.T, newProvider func(t *testing.T, mockURL string) core.AuthProvider, mockServer *httptest.Server) {
 	if mockServer == nil {
 		t.Fatal("RunAuthProviderTests requires a mock server")
+		return
 	}
 	provider := newProvider(t, mockServer.URL)
 
@@ -52,6 +53,7 @@ func RunAuthProviderTests(t *testing.T, newProvider func(t *testing.T, mockURL s
 		}
 		if identity == nil {
 			t.Fatal("HandleCallback returned nil identity")
+			return
 		}
 		if identity.Email == "" {
 			t.Error("identity.Email is empty")
@@ -72,6 +74,7 @@ func RunAuthProviderTests(t *testing.T, newProvider func(t *testing.T, mockURL s
 		}
 		if identity == nil {
 			t.Fatal("ValidateToken returned nil identity")
+			return
 		}
 		if identity.Email == "" {
 			t.Error("identity.Email is empty")

--- a/gestaltd/core/testing/integration_suite.go
+++ b/gestaltd/core/testing/integration_suite.go
@@ -23,6 +23,7 @@ import (
 func RunIntegrationTests(t *testing.T, newIntegration func(t *testing.T, mockURL string) core.OAuthProvider, mockServer *httptest.Server) {
 	if mockServer == nil {
 		t.Fatal("RunIntegrationTests requires a mock server")
+		return
 	}
 	integration := newIntegration(t, mockServer.URL)
 
@@ -63,6 +64,7 @@ func RunIntegrationTests(t *testing.T, newIntegration func(t *testing.T, mockURL
 		}
 		if resp == nil {
 			t.Fatal("ExchangeCode returned nil")
+			return
 		}
 		if resp.AccessToken == "" {
 			t.Error("AccessToken is empty")

--- a/gestaltd/internal/bootstrap/executable_plugin_test.go
+++ b/gestaltd/internal/bootstrap/executable_plugin_test.go
@@ -489,6 +489,7 @@ func TestExecutableSDKExampleProviderAppliesConfigMetadataOverrides(t *testing.T
 	cat := prov.Catalog()
 	if cat == nil {
 		t.Fatal("expected non-nil catalog")
+		return
 	}
 	if cat.DisplayName != "Config Display" {
 		t.Fatalf("catalog DisplayName = %q, want %q", cat.DisplayName, "Config Display")

--- a/gestaltd/internal/composite/merged_test.go
+++ b/gestaltd/internal/composite/merged_test.go
@@ -138,6 +138,7 @@ func TestMergedCatalogIncludesConstructorMetadata(t *testing.T) {
 	cat := merged.Catalog()
 	if cat == nil {
 		t.Fatal("expected non-nil catalog")
+		return
 	}
 	if cat.DisplayName != "Override" {
 		t.Fatalf("DisplayName = %q, want %q", cat.DisplayName, "Override")

--- a/gestaltd/internal/invocation/broker.go
+++ b/gestaltd/internal/invocation/broker.go
@@ -302,7 +302,7 @@ func (b *Broker) resolveOperation(ctx context.Context, p *principal.Principal, p
 		if connection == "" {
 			connection = b.mcpConnection(providerName)
 		}
-		cat, err := resolveSessionCatalog(ctx, prov, providerName, b, p, connection, instance)
+		cat, _, err := resolveSessionCatalog(ctx, prov, providerName, b, p, connection, instance)
 		if err != nil {
 			return catalog.CatalogOperation{}, "", err
 		}

--- a/gestaltd/internal/invocation/catalog.go
+++ b/gestaltd/internal/invocation/catalog.go
@@ -16,57 +16,80 @@ type TokenResolver interface {
 	ResolveToken(ctx context.Context, p *principal.Principal, providerName, connection, instance string) (context.Context, string, error)
 }
 
+type CatalogResolutionMetadata struct {
+	SessionAttempted bool
+	SessionFailed    bool
+}
+
 func ResolveCatalog(ctx context.Context, prov core.Provider, provName string, resolver TokenResolver, p *principal.Principal, defaultConnection, instance string) (*catalog.Catalog, error) {
-	return resolveCatalog(ctx, prov, provName, resolver, p, defaultConnection, instance, false)
+	cat, _, err := ResolveCatalogWithMetadata(ctx, prov, provName, resolver, p, defaultConnection, instance)
+	return cat, err
 }
 
 func ResolveCatalogStrict(ctx context.Context, prov core.Provider, provName string, resolver TokenResolver, p *principal.Principal, defaultConnection, instance string) (*catalog.Catalog, error) {
+	cat, _, err := ResolveCatalogStrictWithMetadata(ctx, prov, provName, resolver, p, defaultConnection, instance)
+	return cat, err
+}
+
+func ResolveCatalogWithMetadata(ctx context.Context, prov core.Provider, provName string, resolver TokenResolver, p *principal.Principal, defaultConnection, instance string) (*catalog.Catalog, CatalogResolutionMetadata, error) {
+	return resolveCatalog(ctx, prov, provName, resolver, p, defaultConnection, instance, false)
+}
+
+func ResolveCatalogStrictWithMetadata(ctx context.Context, prov core.Provider, provName string, resolver TokenResolver, p *principal.Principal, defaultConnection, instance string) (*catalog.Catalog, CatalogResolutionMetadata, error) {
 	return resolveCatalog(ctx, prov, provName, resolver, p, defaultConnection, instance, true)
 }
 
 func ResolveSessionCatalog(ctx context.Context, prov core.Provider, provName string, resolver TokenResolver, p *principal.Principal, connection, instance string) (*catalog.Catalog, error) {
-	return resolveSessionCatalog(ctx, prov, provName, resolver, p, connection, instance)
+	cat, _, err := resolveSessionCatalog(ctx, prov, provName, resolver, p, connection, instance)
+	return cat, err
 }
 
-func resolveCatalog(ctx context.Context, prov core.Provider, provName string, resolver TokenResolver, p *principal.Principal, defaultConnection, instance string, strictSession bool) (*catalog.Catalog, error) {
+func resolveCatalog(ctx context.Context, prov core.Provider, provName string, resolver TokenResolver, p *principal.Principal, defaultConnection, instance string, strictSession bool) (*catalog.Catalog, CatalogResolutionMetadata, error) {
+	meta := CatalogResolutionMetadata{}
 	staticCat := prov.Catalog()
 
-	sessionCat, err := resolveSessionCatalog(ctx, prov, provName, resolver, p, defaultConnection, instance)
+	sessionCat, attempted, err := resolveSessionCatalog(ctx, prov, provName, resolver, p, defaultConnection, instance)
+	meta.SessionAttempted = attempted
 	if err != nil {
+		meta.SessionFailed = true
 		if strictSession || staticCat == nil {
-			return nil, err
+			return nil, meta, err
 		}
 		slog.WarnContext(ctx, "catalog session resolution failed", "provider", provName, "error", err)
 	}
 
-	return mergeCatalogs(provName, staticCat, sessionCat)
+	merged, err := mergeCatalogs(provName, staticCat, sessionCat)
+	return merged, meta, err
 }
 
-func resolveSessionCatalog(ctx context.Context, prov core.Provider, provName string, resolver TokenResolver, p *principal.Principal, connection, instance string) (*catalog.Catalog, error) {
+func resolveSessionCatalog(ctx context.Context, prov core.Provider, provName string, resolver TokenResolver, p *principal.Principal, connection, instance string) (*catalog.Catalog, bool, error) {
 	scp, ok := prov.(core.SessionCatalogProvider)
 	if !ok {
-		return nil, nil
+		return nil, false, nil
 	}
 	if prov.ConnectionMode() == core.ConnectionModeNone {
 		if resolver != nil && p != nil {
 			enrichedCtx, token, err := resolver.ResolveToken(ctx, p, provName, connection, instance)
 			if err != nil {
-				return nil, err
+				return nil, true, err
 			}
-			return scp.CatalogForRequest(enrichedCtx, token)
+			cat, err := scp.CatalogForRequest(enrichedCtx, token)
+			return cat, true, err
 		}
 		ctx = WithCredentialContext(ctx, CredentialContext{Mode: core.ConnectionModeNone})
-		return scp.CatalogForRequest(ctx, "")
+		cat, err := scp.CatalogForRequest(ctx, "")
+		return cat, true, err
 	}
 	if resolver == nil || p == nil {
-		return nil, nil
+		return nil, false, nil
 	}
 
 	ctx, token, err := resolver.ResolveToken(ctx, p, provName, connection, instance)
 	if err != nil {
-		return nil, err
+		return nil, true, err
 	}
-	return scp.CatalogForRequest(ctx, token)
+	cat, err := scp.CatalogForRequest(ctx, token)
+	return cat, true, err
 }
 
 func mergeCatalogs(provName string, staticCat, sessionCat *catalog.Catalog) (*catalog.Catalog, error) {

--- a/gestaltd/internal/mcpupstream/upstream_test.go
+++ b/gestaltd/internal/mcpupstream/upstream_test.go
@@ -104,6 +104,7 @@ func TestUpstream_DiscoverTools(t *testing.T) {
 	cat := u.Catalog()
 	if cat == nil {
 		t.Fatal("expected non-nil catalog")
+		return
 	}
 	if len(cat.Operations) != 2 {
 		t.Fatalf("expected 2 catalog operations, got %d", len(cat.Operations))
@@ -580,6 +581,7 @@ func TestUpstream_DiscoverToolsPreservesOutputSchema(t *testing.T) {
 	cat := u.Catalog()
 	if cat == nil {
 		t.Fatal("expected non-nil catalog")
+		return
 	}
 	if len(cat.Operations) != 1 {
 		t.Fatalf("expected 1 catalog operation, got %d", len(cat.Operations))

--- a/gestaltd/internal/metricutil/semantic_metrics.go
+++ b/gestaltd/internal/metricutil/semantic_metrics.go
@@ -51,6 +51,7 @@ func newCounterMetrics(meter metric.Meter, prefix, desc string) counterMetrics {
 var (
 	authMetricsCache           MeterCache[counterMetrics]
 	connectionAuthMetricsCache MeterCache[counterMetrics]
+	discoveryMetricsCache      MeterCache[counterMetrics]
 	indexedDBMetricsCache      MeterCache[counterMetrics]
 )
 
@@ -71,6 +72,17 @@ func RecordConnectionAuthMetrics(ctx context.Context, startedAt time.Time, provi
 	recordCounterMetrics(ctx, metrics, startedAt, failed,
 		attrProvider.String(AttrValue(provider)),
 		attrType.String(AttrValue(authType)),
+		attrAction.String(AttrValue(action)),
+		attrConnectionMode.String(AttrValue(connectionMode)),
+	)
+}
+
+func RecordDiscoveryMetrics(ctx context.Context, startedAt time.Time, provider string, action string, connectionMode string, failed bool) {
+	metrics := discoveryMetricsCache.Load(ctx, meterName, func(meter metric.Meter) counterMetrics {
+		return newCounterMetrics(meter, "gestaltd.discovery", "gestaltd credentialed discovery actions")
+	})
+	recordCounterMetrics(ctx, metrics, startedAt, failed,
+		attrProvider.String(AttrValue(provider)),
 		attrAction.String(AttrValue(action)),
 		attrConnectionMode.String(AttrValue(connectionMode)),
 	)

--- a/gestaltd/internal/server/catalog_resolution_test.go
+++ b/gestaltd/internal/server/catalog_resolution_test.go
@@ -502,9 +502,15 @@ func TestResolveCatalog_TokenResolutionFailure_NonFatal(t *testing.T) {
 	resolver := &stubTokenResolver{err: fmt.Errorf("token expired")}
 	p := &principal.Principal{UserID: "u1"}
 
-	cat, err := invocation.ResolveCatalog(context.Background(), prov, "auth-api", resolver, p, "default", "")
+	cat, metadata, err := invocation.ResolveCatalogWithMetadata(context.Background(), prov, "auth-api", resolver, p, "default", "")
 	if err != nil {
 		t.Fatalf("expected no error on token failure, got: %v", err)
+	}
+	if !metadata.SessionAttempted {
+		t.Fatal("expected session resolution attempt to be reported")
+	}
+	if !metadata.SessionFailed {
+		t.Fatal("expected session resolution failure to be reported")
 	}
 	if len(cat.Operations) != 1 {
 		t.Fatalf("expected 1 operation (static only), got %d", len(cat.Operations))

--- a/gestaltd/internal/server/handlers.go
+++ b/gestaltd/internal/server/handlers.go
@@ -19,6 +19,7 @@ import (
 	"github.com/valon-technologies/gestalt/server/internal/bootstrap"
 	"github.com/valon-technologies/gestalt/server/internal/config"
 	"github.com/valon-technologies/gestalt/server/internal/invocation"
+	"github.com/valon-technologies/gestalt/server/internal/metricutil"
 	"github.com/valon-technologies/gestalt/server/internal/principal"
 
 	"google.golang.org/grpc/codes"
@@ -465,13 +466,22 @@ func (s *Server) listOperations(w http.ResponseWriter, r *http.Request) {
 	if tr, ok := s.invoker.(invocation.TokenResolver); ok {
 		resolver = tr
 	}
-	resolveCatalog := invocation.ResolveCatalog
+	recordDiscoveryMetrics := false
+	discoveryStartedAt := time.Time{}
+	discoveryConnectionMode := ""
+	discoveryFailed := false
+	if _, ok := prov.(core.SessionCatalogProvider); ok && resolver != nil && p != nil && prov.ConnectionMode() != core.ConnectionModeNone {
+		recordDiscoveryMetrics = true
+		discoveryStartedAt = time.Now()
+		discoveryConnectionMode = metricutil.NormalizeConnectionMode(prov.ConnectionMode())
+	}
+	resolveCatalog := invocation.ResolveCatalogWithMetadata
 	strictCatalog := false
 	if requestedConnection != "" || requestedInstance != "" {
-		resolveCatalog = invocation.ResolveCatalogStrict
+		resolveCatalog = invocation.ResolveCatalogStrictWithMetadata
 		strictCatalog = true
 	} else if _, ok := prov.(core.SessionCatalogProvider); ok {
-		resolveCatalog = invocation.ResolveCatalogStrict
+		resolveCatalog = invocation.ResolveCatalogStrictWithMetadata
 		strictCatalog = true
 	}
 	ctx := invocation.WithAccessContext(r.Context(), s.providerAccessContext(p, name))
@@ -491,9 +501,13 @@ func (s *Server) listOperations(w http.ResponseWriter, r *http.Request) {
 		var firstErr error
 		for _, catalogConnection := range catalogConnections {
 			resolvedConnection, catalogInstance := s.workloadBindingSelectors(p, name, catalogConnection, requestedInstance)
-			var err error
-			cat, err = resolveCatalog(ctx, prov, name, resolver, p, resolvedConnection, catalogInstance)
+			var (
+				err      error
+				metadata invocation.CatalogResolutionMetadata
+			)
+			cat, metadata, err = resolveCatalog(ctx, prov, name, resolver, p, resolvedConnection, catalogInstance)
 			if err == nil {
+				discoveryFailed = metadata.SessionFailed
 				break
 			}
 			if firstErr == nil {
@@ -502,6 +516,10 @@ func (s *Server) listOperations(w http.ResponseWriter, r *http.Request) {
 			cat = nil
 		}
 		if cat == nil && firstErr != nil {
+			discoveryFailed = true
+			if recordDiscoveryMetrics {
+				metricutil.RecordDiscoveryMetrics(r.Context(), discoveryStartedAt, name, "list_operations", discoveryConnectionMode, discoveryFailed)
+			}
 			s.writeInvocationError(w, r, name, "", firstErr)
 			return
 		}
@@ -511,12 +529,22 @@ func (s *Server) listOperations(w http.ResponseWriter, r *http.Request) {
 			catalogConnection = s.catalogLookupConnection(name, requestedConnection)
 		}
 		catalogConnection, catalogInstance := s.workloadBindingSelectors(p, name, catalogConnection, requestedInstance)
-		var err error
-		cat, err = resolveCatalog(ctx, prov, name, resolver, p, catalogConnection, catalogInstance)
+		var (
+			err      error
+			metadata invocation.CatalogResolutionMetadata
+		)
+		cat, metadata, err = resolveCatalog(ctx, prov, name, resolver, p, catalogConnection, catalogInstance)
+		discoveryFailed = metadata.SessionFailed || err != nil
 		if err != nil {
+			if recordDiscoveryMetrics {
+				metricutil.RecordDiscoveryMetrics(r.Context(), discoveryStartedAt, name, "list_operations", discoveryConnectionMode, discoveryFailed)
+			}
 			s.writeInvocationError(w, r, name, "", err)
 			return
 		}
+	}
+	if recordDiscoveryMetrics {
+		metricutil.RecordDiscoveryMetrics(r.Context(), discoveryStartedAt, name, "list_operations", discoveryConnectionMode, discoveryFailed)
 	}
 	cat = invocation.FilterCatalogForPrincipal(cat, name, p, s.authorizer)
 	ops := httpVisibleCatalogOperations(cat.Operations)

--- a/gestaltd/internal/server/handlers_tokens.go
+++ b/gestaltd/internal/server/handlers_tokens.go
@@ -89,13 +89,21 @@ type apiTokenInfo struct {
 }
 
 func (s *Server) listAPITokens(w http.ResponseWriter, r *http.Request) {
+	auditAllowed := false
+	auditErr := errors.New("api token list failed")
+	defer func() {
+		s.auditHTTPEvent(r.Context(), PrincipalFromContext(r.Context()), "", "api_token.list", auditAllowed, auditErr)
+	}()
+
 	userID, err := s.resolveUserID(w, r)
 	if err != nil {
+		auditErr = err
 		return
 	}
 
 	tokens, err := s.apiTokens.ListAPITokens(r.Context(), userID)
 	if err != nil {
+		auditErr = errors.New("failed to list tokens")
 		writeError(w, http.StatusInternalServerError, "failed to list tokens")
 		return
 	}
@@ -104,6 +112,8 @@ func (s *Server) listAPITokens(w http.ResponseWriter, r *http.Request) {
 	for _, t := range tokens {
 		out = append(out, apiTokenInfoFromCore(t))
 	}
+	auditAllowed = true
+	auditErr = nil
 	writeJSON(w, http.StatusOK, out)
 }
 

--- a/gestaltd/internal/server/metrics_test.go
+++ b/gestaltd/internal/server/metrics_test.go
@@ -502,8 +502,22 @@ func TestPlatformAuthMetrics(t *testing.T) {
 	if tokensResp.StatusCode != http.StatusOK {
 		t.Fatalf("list tokens status = %d, want %d", tokensResp.StatusCode, http.StatusOK)
 	}
-	if got := bytes.TrimSpace(auditBuf.Bytes()); len(got) != 0 {
-		t.Fatalf("validate-token and datastore read should not emit audit logs, got: %s", got)
+	lines := bytes.Split(bytes.TrimSpace(auditBuf.Bytes()), []byte("\n"))
+	if len(lines) != 1 {
+		t.Fatalf("expected exactly one audit record for api token inventory read, got %d\nraw: %s", len(lines), auditBuf.String())
+	}
+	var auditRecord map[string]any
+	if err := json.Unmarshal(lines[0], &auditRecord); err != nil {
+		t.Fatalf("parse audit record: %v\nraw: %s", err, auditBuf.String())
+	}
+	if auditRecord["operation"] != "api_token.list" {
+		t.Fatalf("expected audit operation api_token.list, got %v", auditRecord["operation"])
+	}
+	if auditRecord["auth_source"] != "session" {
+		t.Fatalf("expected audit auth_source session, got %v", auditRecord["auth_source"])
+	}
+	if auditRecord["allowed"] != true {
+		t.Fatalf("expected audit allowed=true, got %v", auditRecord["allowed"])
 	}
 
 	rm := metrictest.CollectMetrics(t, metrics.Reader)
@@ -548,4 +562,127 @@ func TestHTTPMiddlewareMetricsUseConfiguredMeterProvider(t *testing.T) {
 	if !hasMetricWithPrefix(rm, "http.server.") {
 		t.Fatalf("expected otelhttp metrics in configured meter provider, got %+v", rm.ScopeMetrics)
 	}
+}
+
+func TestHTTPDiscoveryMetrics(t *testing.T) {
+	t.Parallel()
+
+	metrics := metrictest.NewManualMeterProvider(t)
+	const providerName = "metrics-session-catalog"
+
+	prov := &stubIntegrationWithSessionCatalog{
+		stubIntegrationWithOps: stubIntegrationWithOps{
+			StubIntegration: coretesting.StubIntegration{N: providerName, ConnMode: core.ConnectionModeIdentity},
+		},
+		catalogForRequestFn: func(_ context.Context, token string) (*catalog.Catalog, error) {
+			if token != "identity-token" {
+				t.Fatalf("catalog token = %q, want %q", token, "identity-token")
+			}
+			return &catalog.Catalog{
+				Name: providerName,
+				Operations: []catalog.CatalogOperation{
+					{ID: "list_projects", Description: "List projects", Method: http.MethodGet, Transport: catalog.TransportREST},
+				},
+			}, nil
+		},
+	}
+
+	svc := coretesting.NewStubServices(t)
+	seedIdentityToken(t, svc, providerName, testDefaultConnection, "default", "identity-token")
+	ts := newTestServer(t, func(cfg *server.Config) {
+		cfg.MeterProvider = metrics.Provider
+		cfg.Auth = &coretesting.StubAuthProvider{
+			N: "stub",
+			ValidateTokenFn: func(_ context.Context, token string) (*core.UserIdentity, error) {
+				if token != "session-token" {
+					return nil, core.ErrNotFound
+				}
+				return &core.UserIdentity{Email: "user@example.com"}, nil
+			},
+		}
+		cfg.Providers = testutil.NewProviderRegistry(t, prov)
+		cfg.DefaultConnection = map[string]string{providerName: testDefaultConnection}
+		cfg.Services = svc
+	})
+	testutil.CloseOnCleanup(t, ts)
+
+	req, _ := http.NewRequest(http.MethodGet, ts.URL+"/api/v1/integrations/"+providerName+"/operations", nil)
+	req.AddCookie(&http.Cookie{Name: "session_token", Value: "session-token"})
+	resp, err := http.DefaultClient.Do(req)
+	if err != nil {
+		t.Fatalf("list operations request: %v", err)
+	}
+	defer func() { _ = resp.Body.Close() }()
+	if resp.StatusCode != http.StatusOK {
+		t.Fatalf("list operations status = %d, want %d", resp.StatusCode, http.StatusOK)
+	}
+
+	rm := metrictest.CollectMetrics(t, metrics.Reader)
+	attrs := map[string]string{
+		"gestalt.provider":        providerName,
+		"gestalt.action":          "list_operations",
+		"gestalt.connection_mode": "identity",
+	}
+	metrictest.RequireInt64Sum(t, rm, "gestaltd.discovery.count", 1, attrs)
+	metrictest.RequireNoInt64Sum(t, rm, "gestaltd.discovery.error_count", attrs)
+	metrictest.RequireFloat64Histogram(t, rm, "gestaltd.discovery.duration", attrs)
+}
+
+func TestHTTPDiscoveryMetrics_FailureRecordsErrorCount(t *testing.T) {
+	t.Parallel()
+
+	metrics := metrictest.NewManualMeterProvider(t)
+	const providerName = "metrics-session-catalog-error"
+
+	prov := &stubIntegrationWithSessionCatalog{
+		stubIntegrationWithOps: stubIntegrationWithOps{
+			StubIntegration: coretesting.StubIntegration{N: providerName, ConnMode: core.ConnectionModeIdentity},
+		},
+		catalogForRequestFn: func(_ context.Context, token string) (*catalog.Catalog, error) {
+			if token != "identity-token" {
+				t.Fatalf("catalog token = %q, want %q", token, "identity-token")
+			}
+			return nil, context.DeadlineExceeded
+		},
+	}
+
+	svc := coretesting.NewStubServices(t)
+	seedIdentityToken(t, svc, providerName, testDefaultConnection, "default", "identity-token")
+	ts := newTestServer(t, func(cfg *server.Config) {
+		cfg.MeterProvider = metrics.Provider
+		cfg.Auth = &coretesting.StubAuthProvider{
+			N: "stub",
+			ValidateTokenFn: func(_ context.Context, token string) (*core.UserIdentity, error) {
+				if token != "session-token" {
+					return nil, core.ErrNotFound
+				}
+				return &core.UserIdentity{Email: "user@example.com"}, nil
+			},
+		}
+		cfg.Providers = testutil.NewProviderRegistry(t, prov)
+		cfg.DefaultConnection = map[string]string{providerName: testDefaultConnection}
+		cfg.Services = svc
+	})
+	testutil.CloseOnCleanup(t, ts)
+
+	req, _ := http.NewRequest(http.MethodGet, ts.URL+"/api/v1/integrations/"+providerName+"/operations", nil)
+	req.AddCookie(&http.Cookie{Name: "session_token", Value: "session-token"})
+	resp, err := http.DefaultClient.Do(req)
+	if err != nil {
+		t.Fatalf("list operations request: %v", err)
+	}
+	defer func() { _ = resp.Body.Close() }()
+	if resp.StatusCode != http.StatusBadGateway {
+		t.Fatalf("list operations status = %d, want %d", resp.StatusCode, http.StatusBadGateway)
+	}
+
+	rm := metrictest.CollectMetrics(t, metrics.Reader)
+	attrs := map[string]string{
+		"gestalt.provider":        providerName,
+		"gestalt.action":          "list_operations",
+		"gestalt.connection_mode": "identity",
+	}
+	metrictest.RequireInt64Sum(t, rm, "gestaltd.discovery.count", 1, attrs)
+	metrictest.RequireInt64Sum(t, rm, "gestaltd.discovery.error_count", 1, attrs)
+	metrictest.RequireFloat64Histogram(t, rm, "gestaltd.discovery.duration", attrs)
 }


### PR DESCRIPTION
## Summary
- audit `GET /api/v1/tokens` as `api_token.list`
- add `gestaltd.discovery.*` telemetry for credentialed HTTP catalog discovery on `list_operations`
- count credentialed session-catalog failures in discovery telemetry even when `gestaltd` falls back to a static catalog
- document the new discovery telemetry semantics in the observability and audit docs

## Go interfaces
- `invocation.CatalogResolutionMetadata`
- `invocation.ResolveCatalogWithMetadata(...)`
- `invocation.ResolveCatalogStrictWithMetadata(...)`

## YAML interfaces
- No YAML config changes.

Example YAML:
```yaml
providers:
  telemetry:
    source: otlp
```

## Examples
Go:
```go
cat, meta, err := invocation.ResolveCatalogWithMetadata(ctx, prov, "github", resolver, p, "default", "")
if meta.SessionFailed {
    // credentialed discovery failed before static fallback
}
```

Audit and telemetry:
```json
{"operation":"api_token.list","allowed":true}
```

```text
gestaltd.discovery.count{gestalt.provider=github,gestalt.action=list_operations,gestalt.connection_mode=identity}
gestaltd.discovery.error_count{gestalt.provider=github,gestalt.action=list_operations,gestalt.connection_mode=identity}
```

## Validation
```sh
go test ./internal/server -run 'TestCreateAndListAPITokens|TestPlatformAuthMetrics|TestHTTPDiscoveryMetrics|TestResolveCatalog_TokenResolutionFailure_NonFatal'
```