### PR TITLE
Protect built-in /admin with policy-based authorization

### DIFF
--- a/docs/content/reference/config-file.mdx
+++ b/docs/content/reference/config-file.mdx
@@ -72,11 +72,15 @@ authorization:
 
 `management.host` and `management.port` bind a separate listener for operator traffic. When `management.port` is omitted, `/admin` and `/metrics` stay on the public listener, a mode best kept to local development or other trusted-network deployments. For production, prefer configuring `server.management` so the operator surface leaves the public listener entirely.
 
+`management.baseUrl` is the browser-facing absolute URL for the management listener. It is only needed when `/admin` is protected with `server.admin.authorizationPolicy` on a split public/management deployment. In that mode, unauthenticated `/admin` requests round-trip through the public listener's login flow and return to this management URL after callback. `management.baseUrl` must share a hostname with `server.baseUrl` so the session cookie can be reused across listeners. If `server.baseUrl` uses `https`, `management.baseUrl` must also use `https`.
+
 `baseUrl` derives OAuth callback URLs when explicit redirect URLs are omitted, and gives the management admin UI an absolute link back to the public client UI. When unset, the management admin UI omits the `Client UI` link rather than sending operators to a broken same-origin `/`.
 
 `encryptionKey` is the only required server field. It is the root deployment secret, used for encryption and derived session material.
 
 `apiTokenTtl` controls the lifetime of newly issued API tokens, defaulting to `30d`. It accepts Go duration strings (`1h`, `720h`) and day suffixes (`30d`). `artifactsDir` is a writable directory for prepared artifacts produced by `init` and consumed by `serve --locked` when no CLI override is supplied; it defaults to the config file's directory. See [Configuration](/configuration) for the full `init`/`serve` lifecycle.
+
+`admin.authorizationPolicy` binds the built-in `/admin` route to one shared human access policy from `authorization.policies`. `admin.allowedRoles` controls which roles may load the built-in admin UI, defaulting to `[admin]`.
 
 `authorization.policies` configures shared human access policies. Each policy resolves a caller to exactly one role by matching either `subjectID` or `email`, then applies a `default` fallback (`allow` or `deny`) when no member matches. Plugins opt into a policy explicitly through `authorizationPolicy`.
 
@@ -88,14 +92,17 @@ authorization:
 | `public.port` | `8080` | Port for the public listener. |
 | `management.host` | | Bind address for the management listener. |
 | `management.port` | | Port for the management listener. Required when `management.host` is set. |
+| `management.baseUrl` | | Browser-facing absolute URL for the management listener. Required when `server.management` and `server.admin.authorizationPolicy` are both set. |
 | `baseUrl` | | Public origin URL used for OAuth callbacks and admin UI links. |
 | `encryptionKey` | | **Required.** Root encryption key. Typically a `secret://` reference. |
 | `apiTokenTtl` | `30d` | Lifetime of newly issued API tokens. Go durations or day suffixes (`30d`). |
 | `artifactsDir` | config directory | Directory for prepared `init` artifacts. |
+| `admin.authorizationPolicy` | | Shared human access policy applied to the built-in `/admin` route. |
+| `admin.allowedRoles` | `[admin]` | Roles allowed to load the built-in `/admin` route when `admin.authorizationPolicy` is set. |
 | `authorization.policies` | | Shared human access policies resolved by `subjectID` or `email`. |
 | `authorization.workloads` | | Workload bearer tokens, per-provider allowlists, and identity credential bindings. |
 
-When `server.management` is configured, Gestalt serves `/`, `/api/v1/*`, auth routes, and `/mcp` on the public listener, while `/admin`, `/metrics`, `/health`, and `/ready` move to the management listener. The management listener is intended to be protected by deployment infrastructure such as private networking, VPN, or an internal-only reverse proxy. Gestalt does not apply its own session or API-token auth to `/metrics` on the management listener.
+When `server.management` is configured, Gestalt serves `/`, `/api/v1/*`, auth routes, and `/mcp` on the public listener, while `/admin`, `/metrics`, `/health`, and `/ready` move to the management listener. The management listener is intended to be protected by deployment infrastructure such as private networking, VPN, or an internal-only reverse proxy. Gestalt does not apply its own session or API-token auth to `/metrics` on the management listener. When `server.admin.authorizationPolicy` is set, Gestalt does apply browser session auth plus role-based policy checks to `/admin`.
 
 ## `providers.auth`
 

--- a/docs/content/reference/http-api.mdx
+++ b/docs/content/reference/http-api.mdx
@@ -14,7 +14,7 @@ Authenticated routes accept a `session_token` cookie or an `Authorization: Beare
 | --- | --- | --- |
 | `GET` | `/health` | Basic liveness check. |
 | `GET` | `/ready` | Readiness check. Returns `503` until providers and datastore are ready. |
-| `GET` | `/admin` and `/admin/*` | Embedded admin UI shell. On the management listener it reads same-origin `/metrics` without Gestalt auth, so access control is expected to come from your network or reverse proxy. When `server.baseUrl` is set, the management admin UI links back to that public URL for `Client UI`; otherwise it omits that link. |
+| `GET` | `/admin` and `/admin/*` | Embedded admin UI shell. When `server.admin.authorizationPolicy` is set, Gestalt requires browser session auth and the configured roles before serving the shell or its assets. On split public/management deployments, configure `server.management.baseUrl` so unauthenticated management `/admin` requests can round-trip through the public login flow and return to the management listener. Use the same hostname as `server.baseUrl`, and keep both on `https` when the public listener uses `https`, so the session cookie can be reused across listeners. `/admin` still reads same-origin `/metrics`, which remains unauthenticated on the management listener. When `server.baseUrl` is set, the management admin UI links back to that public URL for `Client UI`; otherwise it omits that link. |
 | `GET` | `/api/v1/auth/info` | Returns platform auth metadata, including whether interactive login is supported. |
 | `POST` | `/api/v1/auth/login` | Starts platform login and returns an absolute browser URL. |
 | `GET` | `/api/v1/auth/login/callback` | Completes platform login. |

--- a/docs/dockerhub/gestaltd.md
+++ b/docs/dockerhub/gestaltd.md
@@ -126,8 +126,15 @@ for the full config model and `secret://` reference support.
 
 The built-in admin UI is served at `/admin`. If you configure
 `server.management`, health and admin endpoints move to the management
-listener. See the [deployment documentation](https://gestaltd.ai/deploy) for
-the recommended split-listener production pattern.
+listener. If you also set `server.admin.authorizationPolicy`, Gestalt applies
+browser session auth and role checks to `/admin`; on split
+public/management deployments, set `server.management.baseUrl` so login can
+return the browser to the management listener after callback. Use the same
+hostname as `server.baseUrl`, and keep it on `https` whenever
+`server.baseUrl` is `https`, so the session cookie is reusable across both
+listeners. See the
+[deployment documentation](https://gestaltd.ai/deploy) for the recommended
+split-listener production pattern.
 
 ## SQLite and `/data`
 

--- a/gestaltd/cmd/gestaltd/run.go
+++ b/gestaltd/cmd/gestaltd/run.go
@@ -160,6 +160,7 @@ func runServer(env *bootstrapEnv) error {
 		PluginDefs:        env.Config.Plugins,
 		Authorizer:        result.Authorizer,
 		PublicBaseURL:     env.Config.Server.BaseURL,
+		ManagementBaseURL: env.Config.Server.ManagementBaseURL(),
 		SecureCookies:     strings.HasPrefix(env.Config.Server.BaseURL, "https://"),
 		StateSecret:       crypto.DeriveKey(env.Config.Server.EncryptionKey),
 		APITokenTTL:       apiTokenTTL,
@@ -170,7 +171,11 @@ func runServer(env *bootstrapEnv) error {
 		PrometheusMetrics: env.Result.Telemetry.PrometheusHandler(),
 		MCPHandler:        mcpHandler,
 		MountedWebUIs:     mountedWebUIs,
-		AdminUI:           publicAdminUI,
+		Admin: server.AdminRouteConfig{
+			AuthorizationPolicy: env.Config.Server.Admin.AuthorizationPolicy,
+			AllowedRoles:        append([]string(nil), env.Config.Server.Admin.AllowedRoles...),
+		},
+		AdminUI: publicAdminUI,
 	}
 
 	publicProfile := server.RouteProfileAll
@@ -205,10 +210,17 @@ func runServer(env *bootstrapEnv) error {
 	}}
 
 	if managementAddr := env.Config.Server.ManagementAddr(); managementAddr != "" {
-		slog.Warn(
-			"management listener serves /admin and /metrics without Gestalt auth; protect server.management with private networking or an internal reverse proxy",
-			"addr", managementAddr,
-		)
+		if env.Config.Server.Admin.AuthorizationPolicy != "" {
+			slog.Warn(
+				"management listener serves /metrics without Gestalt auth; /admin requires Gestalt session auth and server.admin policy access",
+				"addr", managementAddr,
+			)
+		} else {
+			slog.Warn(
+				"management listener serves /admin and /metrics without Gestalt auth; protect server.management with private networking or an internal reverse proxy",
+				"addr", managementAddr,
+			)
+		}
 
 		managementConfig := baseServerConfig
 		managementConfig.RouteProfile = server.RouteProfileManagement

--- a/gestaltd/internal/config/config.go
+++ b/gestaltd/internal/config/config.go
@@ -13,6 +13,7 @@ import (
 	"strings"
 	"time"
 
+	"github.com/valon-technologies/gestalt/server/internal/providerpkg"
 	providermanifestv1 "github.com/valon-technologies/gestalt/server/sdk/providermanifest/v1"
 	"gopkg.in/yaml.v3"
 )
@@ -291,17 +292,28 @@ type ListenerConfig struct {
 	Port int    `yaml:"port"`
 }
 
+type ManagementListenerConfig struct {
+	ListenerConfig `yaml:",inline"`
+	BaseURL        string `yaml:"baseUrl,omitempty"`
+}
+
+type AdminConfig struct {
+	AuthorizationPolicy string   `yaml:"authorizationPolicy,omitempty"`
+	AllowedRoles        []string `yaml:"allowedRoles,omitempty"`
+}
+
 type ServerConfig struct {
-	Public        ListenerConfig        `yaml:"public"`
-	Management    ListenerConfig        `yaml:"management"`
-	BaseURL       string                `yaml:"baseUrl"`
-	EncryptionKey string                `yaml:"encryptionKey"`
-	APITokenTTL   string                `yaml:"apiTokenTtl"`
-	ArtifactsDir  string                `yaml:"artifactsDir"`
-	Providers     ServerProvidersConfig `yaml:"providers,omitempty"`
-	IndexedDB     string                `yaml:"-"`
-	Egress        EgressConfig          `yaml:"egress,omitempty"`
-	Authorization AuthorizationConfig   `yaml:"authorization,omitempty"`
+	Public        ListenerConfig           `yaml:"public"`
+	Management    ManagementListenerConfig `yaml:"management"`
+	BaseURL       string                   `yaml:"baseUrl"`
+	EncryptionKey string                   `yaml:"encryptionKey"`
+	APITokenTTL   string                   `yaml:"apiTokenTtl"`
+	ArtifactsDir  string                   `yaml:"artifactsDir"`
+	Providers     ServerProvidersConfig    `yaml:"providers,omitempty"`
+	IndexedDB     string                   `yaml:"-"`
+	Egress        EgressConfig             `yaml:"egress,omitempty"`
+	Authorization AuthorizationConfig      `yaml:"authorization,omitempty"`
+	Admin         AdminConfig              `yaml:"admin,omitempty"`
 }
 
 func (s ServerConfig) PublicListener() ListenerConfig {
@@ -324,7 +336,7 @@ func (s ServerConfig) ManagementListener() (ListenerConfig, bool) {
 	if s.Management.Port == 0 {
 		return ListenerConfig{}, false
 	}
-	return s.Management, true
+	return s.Management.ListenerConfig, true
 }
 
 func (s ServerConfig) ManagementAddr() string {
@@ -333,6 +345,10 @@ func (s ServerConfig) ManagementAddr() string {
 		return ""
 	}
 	return net.JoinHostPort(listener.Host, strconv.Itoa(listener.Port))
+}
+
+func (s ServerConfig) ManagementBaseURL() string {
+	return strings.TrimRight(strings.TrimSpace(s.Management.BaseURL), "/")
 }
 
 // ConnectionDef owns authentication and connection parameters for a named
@@ -633,6 +649,9 @@ func LoadAllowMissingEnv(path string) (*Config, error) {
 
 func NormalizeCompatibility(cfg *Config) error {
 	if err := normalizeAuthorizationConfig(cfg); err != nil {
+		return err
+	}
+	if err := normalizeAdminConfig(cfg); err != nil {
 		return err
 	}
 	return applyAppBindings(cfg)
@@ -1197,6 +1216,34 @@ func normalizedAuthorizationConfig(cfg AuthorizationConfig) AuthorizationConfig 
 	return cfg
 }
 
+func normalizeAdminConfig(cfg *Config) error {
+	if cfg == nil {
+		return nil
+	}
+	admin := cfg.Server.Admin
+	admin.AuthorizationPolicy = strings.TrimSpace(admin.AuthorizationPolicy)
+	if len(admin.AllowedRoles) == 0 {
+		if admin.AuthorizationPolicy != "" {
+			admin.AllowedRoles = []string{"admin"}
+		} else {
+			admin.AllowedRoles = nil
+		}
+		cfg.Server.Admin = admin
+		return nil
+	}
+
+	roles, err := providerpkg.NormalizeWebUIAllowedRoles("server.admin.allowedRoles", admin.AllowedRoles)
+	if err != nil {
+		if admin.AuthorizationPolicy == "" {
+			return fmt.Errorf("normalize admin config: server.admin.allowedRoles requires server.admin.authorizationPolicy")
+		}
+		return fmt.Errorf("normalize admin config: %w", err)
+	}
+	admin.AllowedRoles = roles
+	cfg.Server.Admin = admin
+	return nil
+}
+
 func normalizedHumanPolicyDef(policy HumanPolicyDef) HumanPolicyDef {
 	if len(policy.Members) == 0 {
 		policy.Members = nil
@@ -1302,11 +1349,8 @@ func applyAppBindings(cfg *Config) error {
 }
 
 func resolveBaseURL(cfg *Config) {
-	base := strings.TrimRight(cfg.Server.BaseURL, "/")
-	if base == "" {
-		return
-	}
-	cfg.Server.BaseURL = base
+	cfg.Server.BaseURL = strings.TrimRight(strings.TrimSpace(cfg.Server.BaseURL), "/")
+	cfg.Server.Management.BaseURL = strings.TrimRight(strings.TrimSpace(cfg.Server.Management.BaseURL), "/")
 }
 
 func resolveRelativePaths(configPath string, cfg *Config) {

--- a/gestaltd/internal/config/config_test.go
+++ b/gestaltd/internal/config/config_test.go
@@ -529,6 +529,210 @@ server:
 	}
 }
 
+func TestLoadConfigAdminBaseURLValidation(t *testing.T) {
+	t.Parallel()
+
+	t.Run("invalid baseUrl is allowed when built-in admin auth is unset", func(t *testing.T) {
+		t.Parallel()
+
+		path := mustWriteConfigFile(t, `
+server:
+  baseUrl: not a url
+  encryptionKey: server-key
+providers:
+  auth:
+    disabled: true
+  indexeddbs:
+    sqlite:
+      source:
+        path: ./providers/datastore/sqlite
+`)
+
+		if _, err := Load(path); err != nil {
+			t.Fatalf("Load: %v", err)
+		}
+	})
+
+	t.Run("invalid management.baseUrl is allowed when built-in admin auth is unset", func(t *testing.T) {
+		t.Parallel()
+
+		path := mustWriteConfigFile(t, `
+server:
+  encryptionKey: server-key
+  management:
+    host: 127.0.0.1
+    port: 9090
+    baseUrl: not a url
+providers:
+  auth:
+    disabled: true
+  indexeddbs:
+    sqlite:
+      source:
+        path: ./providers/datastore/sqlite
+`)
+
+		if _, err := Load(path); err != nil {
+			t.Fatalf("Load: %v", err)
+		}
+	})
+
+	t.Run("invalid baseUrl is rejected for split built-in admin auth", func(t *testing.T) {
+		t.Parallel()
+
+		path := mustWriteConfigFile(t, `
+server:
+  baseUrl: not a url
+  encryptionKey: server-key
+  providers:
+    auth: sample
+    indexeddb: sqlite
+  management:
+    host: 127.0.0.1
+    port: 9090
+    baseUrl: https://gestalt.example.test:9090
+  admin:
+    authorizationPolicy: admin_policy
+providers:
+  auth:
+    sample:
+      source:
+        path: ./providers/auth/sample
+  indexeddbs:
+    sqlite:
+      source:
+        path: ./providers/datastore/sqlite
+authorization:
+  policies:
+    admin_policy:
+      default: deny
+`)
+
+		_, err := Load(path)
+		if err == nil {
+			t.Fatal("Load: expected error, got nil")
+		}
+		if !strings.Contains(err.Error(), "server.baseUrl must be an absolute URL") {
+			t.Fatalf("unexpected error: %v", err)
+		}
+	})
+
+	t.Run("invalid management.baseUrl is rejected for split built-in admin auth", func(t *testing.T) {
+		t.Parallel()
+
+		path := mustWriteConfigFile(t, `
+server:
+  baseUrl: https://gestalt.example.test
+  encryptionKey: server-key
+  providers:
+    auth: sample
+    indexeddb: sqlite
+  management:
+    host: 127.0.0.1
+    port: 9090
+    baseUrl: not a url
+  admin:
+    authorizationPolicy: admin_policy
+providers:
+  auth:
+    sample:
+      source:
+        path: ./providers/auth/sample
+  indexeddbs:
+    sqlite:
+      source:
+        path: ./providers/datastore/sqlite
+authorization:
+  policies:
+    admin_policy:
+      default: deny
+`)
+
+		_, err := Load(path)
+		if err == nil {
+			t.Fatal("Load: expected error, got nil")
+		}
+		if !strings.Contains(err.Error(), "server.management.baseUrl must be an absolute URL") {
+			t.Fatalf("unexpected error: %v", err)
+		}
+	})
+
+	t.Run("management.baseUrl without management listener is rejected for built-in admin auth", func(t *testing.T) {
+		t.Parallel()
+
+		path := mustWriteConfigFile(t, `
+server:
+  baseUrl: https://gestalt.example.test
+  encryptionKey: server-key
+  providers:
+    auth: sample
+    indexeddb: sqlite
+  management:
+    baseUrl: https://gestalt.example.test:9090
+  admin:
+    authorizationPolicy: admin_policy
+providers:
+  auth:
+    sample:
+      source:
+        path: ./providers/auth/sample
+  indexeddbs:
+    sqlite:
+      source:
+        path: ./providers/datastore/sqlite
+authorization:
+  policies:
+    admin_policy:
+      default: deny
+`)
+
+		_, err := Load(path)
+		if err == nil {
+			t.Fatal("Load: expected error, got nil")
+		}
+		if !strings.Contains(err.Error(), "server.management.baseUrl requires server.management.host/server.management.port when server.admin.authorizationPolicy is set") {
+			t.Fatalf("unexpected error: %v", err)
+		}
+	})
+
+	t.Run("blank admin allowedRoles entry is rejected", func(t *testing.T) {
+		t.Parallel()
+
+		path := mustWriteConfigFile(t, `
+server:
+  encryptionKey: server-key
+  providers:
+    auth: sample
+    indexeddb: sqlite
+  admin:
+    authorizationPolicy: admin_policy
+    allowedRoles:
+      - ""
+providers:
+  auth:
+    sample:
+      source:
+        path: ./providers/auth/sample
+  indexeddbs:
+    sqlite:
+      source:
+        path: ./providers/datastore/sqlite
+authorization:
+  policies:
+    admin_policy:
+      default: deny
+`)
+
+		_, err := Load(path)
+		if err == nil {
+			t.Fatal("Load: expected error, got nil")
+		}
+		if !strings.Contains(err.Error(), "server.admin.allowedRoles[0] is required") {
+			t.Fatalf("unexpected error: %v", err)
+		}
+	})
+}
+
 func TestLoadSucceedsWithoutRuntimeFields(t *testing.T) {
 	t.Parallel()
 

--- a/gestaltd/internal/config/config_validate.go
+++ b/gestaltd/internal/config/config_validate.go
@@ -4,6 +4,7 @@ import (
 	"fmt"
 	"maps"
 	"net"
+	"net/url"
 	"slices"
 	"sort"
 	"strconv"
@@ -30,6 +31,9 @@ func ValidateStructure(cfg *Config) error {
 		return err
 	}
 	if err := validateServerListeners(cfg.Server); err != nil {
+		return err
+	}
+	if err := validateAdminConfig(cfg); err != nil {
 		return err
 	}
 	if cfg.Server.APITokenTTL != "" {
@@ -387,6 +391,82 @@ func validateAuthorizationPolicyReference(cfg *Config, kind, name, policy string
 		return fmt.Errorf("config validation: %s %q authorizationPolicy references unknown policy %q", kind, name, policy)
 	}
 	return nil
+}
+
+func validateAdminConfig(cfg *Config) error {
+	if cfg == nil {
+		return nil
+	}
+	admin := cfg.Server.Admin
+	policy := strings.TrimSpace(admin.AuthorizationPolicy)
+	if policy == "" {
+		if len(admin.AllowedRoles) > 0 {
+			return fmt.Errorf("config validation: server.admin.allowedRoles requires server.admin.authorizationPolicy")
+		}
+	} else {
+		_, authProvider, err := cfg.SelectedAuthProvider()
+		if err != nil {
+			return err
+		}
+		if authProvider == nil || authProvider.Disabled {
+			return fmt.Errorf("config validation: server.admin.authorizationPolicy requires providers.auth to be configured and enabled")
+		}
+		if err := validateAuthorizationPolicyReference(cfg, "server.admin", "/admin", policy); err != nil {
+			return err
+		}
+		if len(admin.AllowedRoles) == 0 {
+			return fmt.Errorf("config validation: server.admin.allowedRoles must not be empty when server.admin.authorizationPolicy is set")
+		}
+	}
+
+	_, hasManagement := cfg.Server.ManagementListener()
+	if !hasManagement {
+		if policy != "" && strings.TrimSpace(cfg.Server.ManagementBaseURL()) != "" {
+			return fmt.Errorf("config validation: server.management.baseUrl requires server.management.host/server.management.port when server.admin.authorizationPolicy is set")
+		}
+		return nil
+	}
+	if policy == "" {
+		return nil
+	}
+
+	publicURL, err := validateAbsoluteBaseURL("server.baseUrl", cfg.Server.BaseURL)
+	if err != nil {
+		return err
+	}
+	managementURL, err := validateAbsoluteBaseURL("server.management.baseUrl", cfg.Server.ManagementBaseURL())
+	if err != nil {
+		return err
+	}
+
+	if publicURL == nil {
+		return fmt.Errorf("config validation: server.admin.authorizationPolicy on a split management listener requires server.baseUrl")
+	}
+	if managementURL == nil {
+		return fmt.Errorf("config validation: server.admin.authorizationPolicy on a split management listener requires server.management.baseUrl")
+	}
+	if publicURL.Hostname() != managementURL.Hostname() {
+		return fmt.Errorf("config validation: server.baseUrl and server.management.baseUrl must use the same hostname when server.admin.authorizationPolicy is enabled on a split management listener")
+	}
+	if strings.EqualFold(publicURL.Scheme, "https") && !strings.EqualFold(managementURL.Scheme, "https") {
+		return fmt.Errorf("config validation: server.management.baseUrl must use https when server.baseUrl uses https and server.admin.authorizationPolicy is enabled on a split management listener")
+	}
+	return nil
+}
+
+func validateAbsoluteBaseURL(label, raw string) (*url.URL, error) {
+	raw = strings.TrimSpace(raw)
+	if raw == "" {
+		return nil, nil
+	}
+	parsed, err := url.Parse(raw)
+	if err != nil || !parsed.IsAbs() || parsed.Host == "" {
+		return nil, fmt.Errorf("config validation: %s must be an absolute URL", label)
+	}
+	if parsed.RawQuery != "" || parsed.Fragment != "" {
+		return nil, fmt.Errorf("config validation: %s may not include query or fragment", label)
+	}
+	return parsed, nil
 }
 
 func validatePluginIndexedDBBindings(cfg *Config, name string, entry *ProviderEntry) error {

--- a/gestaltd/internal/server/handlers_auth.go
+++ b/gestaltd/internal/server/handlers_auth.go
@@ -8,6 +8,7 @@ import (
 	"log/slog"
 	"net/http"
 	"net/url"
+	stdpath "path"
 	"strings"
 	"time"
 
@@ -105,7 +106,7 @@ func (s *Server) startBrowserLogin(w http.ResponseWriter, r *http.Request) {
 		s.auditHTTPEvent(r.Context(), nil, s.authProviderName(), "auth.login.start", auditAllowed, auditErr)
 	}()
 
-	nextPath, err := resolveLoginRedirectPath(r.URL.Query().Get("next"))
+	nextPath, err := resolveLoginRedirectPath(r.URL.Query().Get("next"), s.allowedLoginRedirectBaseURLs())
 	if err != nil {
 		auditErr = err
 		writeError(w, http.StatusBadRequest, err.Error())
@@ -160,7 +161,14 @@ func (s *Server) beginLogin(w http.ResponseWriter, r *http.Request, state, nextP
 	return loginURL, nil
 }
 
-func resolveLoginRedirectPath(raw string) (string, error) {
+func (s *Server) allowedLoginRedirectBaseURLs() []string {
+	if s.routeProfile != RouteProfilePublic || s.managementBaseURL == "" || s.adminRoute.AuthorizationPolicy == "" {
+		return nil
+	}
+	return []string{strings.TrimRight(s.managementBaseURL, "/") + "/admin"}
+}
+
+func resolveLoginRedirectPath(raw string, allowedBaseURLs []string) (string, error) {
 	raw = strings.TrimSpace(raw)
 	if raw == "" {
 		return "/", nil
@@ -169,7 +177,16 @@ func resolveLoginRedirectPath(raw string) (string, error) {
 	if err != nil {
 		return "", errBadLoginRedirectPath
 	}
-	if parsed.IsAbs() || parsed.Host != "" || !strings.HasPrefix(raw, "/") || strings.HasPrefix(raw, "//") {
+	if parsed.IsAbs() || parsed.Host != "" {
+		for _, base := range allowedBaseURLs {
+			if absoluteLoginRedirectAllowed(raw, base) {
+				parsed.Fragment = ""
+				return parsed.String(), nil
+			}
+		}
+		return "", errBadLoginRedirectPath
+	}
+	if !strings.HasPrefix(raw, "/") || strings.HasPrefix(raw, "//") {
 		return "", errBadLoginRedirectPath
 	}
 	parsed.Fragment = ""
@@ -177,6 +194,57 @@ func resolveLoginRedirectPath(raw string) (string, error) {
 		parsed.Path = "/"
 	}
 	return parsed.RequestURI(), nil
+}
+
+func absoluteLoginRedirectAllowed(raw, allowedBase string) bool {
+	base, err := url.Parse(strings.TrimSpace(allowedBase))
+	if err != nil || !base.IsAbs() || base.Host == "" {
+		return false
+	}
+	next, err := url.Parse(raw)
+	if err != nil || !next.IsAbs() || next.Host == "" {
+		return false
+	}
+	if next.Scheme != base.Scheme || next.Host != base.Host {
+		return false
+	}
+	basePath, ok := normalizedAbsoluteRedirectPath(base)
+	if !ok {
+		return false
+	}
+	nextPath, ok := normalizedAbsoluteRedirectPath(next)
+	if !ok {
+		return false
+	}
+	switch {
+	case basePath == "":
+		return strings.HasPrefix(nextPath, "/")
+	case nextPath == basePath:
+		return true
+	case strings.HasPrefix(nextPath, basePath+"/"):
+		return true
+	default:
+		return false
+	}
+}
+
+func normalizedAbsoluteRedirectPath(u *url.URL) (string, bool) {
+	path := u.EscapedPath()
+	if path == "" {
+		return "/", true
+	}
+	decoded, err := url.PathUnescape(path)
+	if err != nil {
+		return "", false
+	}
+	path = stdpath.Clean(decoded)
+	if path == "." {
+		path = "/"
+	}
+	if !strings.HasPrefix(path, "/") {
+		path = "/" + path
+	}
+	return path, true
 }
 
 func browserLoginStateForNextPath(nextPath string) string {

--- a/gestaltd/internal/server/mounted_ui.go
+++ b/gestaltd/internal/server/mounted_ui.go
@@ -21,6 +21,76 @@ type mountedWebUINavigationPathResolver interface {
 	NavigationPathForRequest(string) (string, bool)
 }
 
+type protectedUILoginRedirect func(http.ResponseWriter, *http.Request) error
+
+func normalizeAdminRouteConfig(admin AdminRouteConfig) (AdminRouteConfig, error) {
+	admin.AuthorizationPolicy = strings.TrimSpace(admin.AuthorizationPolicy)
+	if admin.AuthorizationPolicy == "" {
+		if len(admin.AllowedRoles) > 0 {
+			return AdminRouteConfig{}, fmt.Errorf("admin allowedRoles requires AuthorizationPolicy")
+		}
+		admin.AllowedRoles = nil
+		return admin, nil
+	}
+	if len(admin.AllowedRoles) == 0 {
+		admin.AllowedRoles = []string{"admin"}
+		return admin, nil
+	}
+
+	roles, err := providerpkg.NormalizeWebUIAllowedRoles("admin allowedRoles", admin.AllowedRoles)
+	if err != nil {
+		return AdminRouteConfig{}, err
+	}
+	admin.AllowedRoles = roles
+	return admin, nil
+}
+
+func validateAdminRouteRuntime(admin AdminRouteConfig, noAuth bool, publicBaseURL, managementBaseURL string, routeProfile RouteProfile) error {
+	if admin.AuthorizationPolicy == "" {
+		return nil
+	}
+	if noAuth {
+		return fmt.Errorf("admin authorization requires auth to be enabled")
+	}
+	if routeProfile == RouteProfileAll {
+		if strings.TrimSpace(managementBaseURL) != "" {
+			return fmt.Errorf("ManagementBaseURL requires RouteProfilePublic or RouteProfileManagement for admin authorization")
+		}
+		return nil
+	}
+
+	publicURL, err := parseAbsoluteBaseURL("PublicBaseURL", publicBaseURL)
+	if err != nil {
+		return err
+	}
+	managementURL, err := parseAbsoluteBaseURL("ManagementBaseURL", managementBaseURL)
+	if err != nil {
+		return err
+	}
+	if publicURL.Hostname() != managementURL.Hostname() {
+		return fmt.Errorf("PublicBaseURL and ManagementBaseURL must use the same hostname for admin authorization")
+	}
+	if strings.EqualFold(publicURL.Scheme, "https") && !strings.EqualFold(managementURL.Scheme, "https") {
+		return fmt.Errorf("ManagementBaseURL must use https when PublicBaseURL uses https for admin authorization")
+	}
+	return nil
+}
+
+func parseAbsoluteBaseURL(label, raw string) (*url.URL, error) {
+	raw = strings.TrimSpace(raw)
+	if raw == "" {
+		return nil, fmt.Errorf("%s is required", label)
+	}
+	parsed, err := url.Parse(raw)
+	if err != nil || !parsed.IsAbs() || parsed.Host == "" {
+		return nil, fmt.Errorf("%s must be an absolute URL", label)
+	}
+	if parsed.RawQuery != "" || parsed.Fragment != "" {
+		return nil, fmt.Errorf("%s may not include query or fragment", label)
+	}
+	return parsed, nil
+}
+
 func normalizeMountedWebUIs(mounted []MountedWebUI) ([]MountedWebUI, error) {
 	if len(mounted) == 0 {
 		return nil, nil
@@ -120,12 +190,38 @@ func (s *Server) mountedWebUIHandler(mounted MountedWebUI) http.Handler {
 	if mounted.Path != "/" {
 		inner = http.StripPrefix(mounted.Path, inner)
 	}
+	return s.protectedUIHandler(mounted, inner, s.redirectMountedWebUILogin)
+}
+
+func (s *Server) adminUIHandler() http.Handler {
+	if s.adminUI == nil {
+		return http.NotFoundHandler()
+	}
+	mounted := s.adminMountedWebUI()
+	inner := http.StripPrefix(mounted.Path, mounted.Handler)
+	return s.protectedUIHandler(mounted, inner, s.redirectAdminUILogin)
+}
+
+func (s *Server) adminMountedWebUI() MountedWebUI {
+	return MountedWebUI{
+		Name:                "builtin_admin",
+		Path:                "/admin",
+		AuthorizationPolicy: s.adminRoute.AuthorizationPolicy,
+		Routes: []MountedWebUIRoute{{
+			Path:         "/*",
+			AllowedRoles: append([]string(nil), s.adminRoute.AllowedRoles...),
+		}},
+		Handler: s.adminUI,
+	}
+}
+
+func (s *Server) protectedUIHandler(mounted MountedWebUI, inner http.Handler, redirectLogin protectedUILoginRedirect) http.Handler {
 	if mounted.AuthorizationPolicy == "" {
 		return inner
 	}
 
 	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		ctx, ok := s.authorizeMountedWebUIRequest(w, r, mounted)
+		ctx, ok := s.authorizeProtectedUIRequest(w, r, mounted, redirectLogin)
 		if !ok {
 			return
 		}
@@ -133,7 +229,7 @@ func (s *Server) mountedWebUIHandler(mounted MountedWebUI) http.Handler {
 	})
 }
 
-func (s *Server) authorizeMountedWebUIRequest(w http.ResponseWriter, r *http.Request, mounted MountedWebUI) (context.Context, bool) {
+func (s *Server) authorizeProtectedUIRequest(w http.ResponseWriter, r *http.Request, mounted MountedWebUI, redirectLogin protectedUILoginRedirect) (context.Context, bool) {
 	if s.authorizer == nil {
 		writeError(w, http.StatusInternalServerError, "app authorization is unavailable")
 		return nil, false
@@ -145,7 +241,11 @@ func (s *Server) authorizeMountedWebUIRequest(w http.ResponseWriter, r *http.Req
 		return nil, false
 	}
 	if !authenticated {
-		s.redirectMountedWebUILogin(w, r)
+		if redirectLogin != nil {
+			if err := redirectLogin(w, r); err != nil {
+				writeError(w, http.StatusInternalServerError, err.Error())
+			}
+		}
 		return nil, false
 	}
 	if p != nil && p.Kind == principal.KindWorkload {
@@ -196,9 +296,26 @@ func (s *Server) resolveMountedWebUIPrincipal(r *http.Request) (*principal.Princ
 	}
 }
 
-func (s *Server) redirectMountedWebUILogin(w http.ResponseWriter, r *http.Request) {
+func (s *Server) redirectMountedWebUILogin(w http.ResponseWriter, r *http.Request) error {
 	target := browserLoginPath + "?next=" + url.QueryEscape(r.URL.RequestURI())
 	http.Redirect(w, r, target, http.StatusFound)
+	return nil
+}
+
+func (s *Server) redirectAdminUILogin(w http.ResponseWriter, r *http.Request) error {
+	if s.routeProfile != RouteProfileManagement {
+		return s.redirectMountedWebUILogin(w, r)
+	}
+	if s.publicBaseURL == "" {
+		return fmt.Errorf("admin login redirect requires server.baseUrl")
+	}
+	if s.managementBaseURL == "" {
+		return fmt.Errorf("admin login redirect requires server.management.baseUrl")
+	}
+
+	target := s.publicBaseURL + browserLoginPath + "?next=" + url.QueryEscape(s.managementBaseURL+r.URL.RequestURI())
+	http.Redirect(w, r, target, http.StatusFound)
+	return nil
 }
 
 func (m MountedWebUI) routeForRequestPath(requestPath string) (MountedWebUIRoute, bool) {

--- a/gestaltd/internal/server/routes.go
+++ b/gestaltd/internal/server/routes.go
@@ -74,7 +74,7 @@ func (s *Server) mountAdminUIRoutes(r chi.Router) {
 	r.Get("/admin", func(w http.ResponseWriter, r *http.Request) {
 		redirectPreservingQuery(w, r, "/admin/", http.StatusMovedPermanently)
 	})
-	r.Handle("/admin/*", http.StripPrefix("/admin", s.adminUI))
+	r.Handle("/admin/*", s.adminUIHandler())
 }
 
 func (s *Server) mountMountedWebUIRoutes(r chi.Router) {

--- a/gestaltd/internal/server/server.go
+++ b/gestaltd/internal/server/server.go
@@ -48,6 +48,11 @@ type MountedWebUI struct {
 	Handler             http.Handler
 }
 
+type AdminRouteConfig struct {
+	AuthorizationPolicy string
+	AllowedRoles        []string
+}
+
 type Server struct {
 	router             chi.Router
 	handler            http.Handler
@@ -67,6 +72,7 @@ type Server struct {
 	noAuth             bool
 	anonymousPrincipal *principal.Principal
 	publicBaseURL      string
+	managementBaseURL  string
 	secureCookies      bool
 	encryptor          *cryptoutil.AESGCMEncryptor
 	sessionIssuer      []byte
@@ -77,6 +83,7 @@ type Server struct {
 	prometheusMetrics  http.Handler
 	mcpHandler         http.Handler
 	mountedWebUIs      []MountedWebUI
+	adminRoute         AdminRouteConfig
 	adminUI            http.Handler
 	routeProfile       RouteProfile
 }
@@ -93,6 +100,7 @@ type Config struct {
 	PluginDefs        map[string]*config.ProviderEntry
 	Authorizer        *authorization.Authorizer
 	PublicBaseURL     string
+	ManagementBaseURL string
 	SecureCookies     bool
 	StateSecret       []byte
 	APITokenTTL       time.Duration
@@ -101,6 +109,7 @@ type Config struct {
 	PrometheusMetrics http.Handler
 	MCPHandler        http.Handler
 	MountedWebUIs     []MountedWebUI
+	Admin             AdminRouteConfig
 	AdminUI           http.Handler
 	RouteProfile      RouteProfile
 	MeterProvider     metric.MeterProvider
@@ -130,6 +139,13 @@ func New(cfg Config) (*Server, error) {
 	now := cfg.Now
 	if now == nil {
 		now = time.Now
+	}
+	adminRoute, err := normalizeAdminRouteConfig(cfg.Admin)
+	if err != nil {
+		return nil, fmt.Errorf("normalize admin route: %w", err)
+	}
+	if err := validateAdminRouteRuntime(adminRoute, noAuth, cfg.PublicBaseURL, cfg.ManagementBaseURL, cfg.RouteProfile); err != nil {
+		return nil, fmt.Errorf("validate admin route: %w", err)
 	}
 	mountedWebUIs, err := normalizeMountedWebUIs(cfg.MountedWebUIs)
 	if err != nil {
@@ -164,6 +180,7 @@ func New(cfg Config) (*Server, error) {
 		authorizer:        cfg.Authorizer,
 		noAuth:            noAuth,
 		publicBaseURL:     strings.TrimRight(cfg.PublicBaseURL, "/"),
+		managementBaseURL: strings.TrimRight(cfg.ManagementBaseURL, "/"),
 		secureCookies:     cfg.SecureCookies,
 		encryptor:         encryptor,
 		sessionIssuer:     cfg.StateSecret,
@@ -174,6 +191,7 @@ func New(cfg Config) (*Server, error) {
 		prometheusMetrics: cfg.PrometheusMetrics,
 		mcpHandler:        cfg.MCPHandler,
 		mountedWebUIs:     mountedWebUIs,
+		adminRoute:        adminRoute,
 		adminUI:           cfg.AdminUI,
 		routeProfile:      cfg.RouteProfile,
 	}

--- a/gestaltd/internal/server/server_test.go
+++ b/gestaltd/internal/server/server_test.go
@@ -3,9 +3,11 @@ package server_test
 import (
 	"bytes"
 	"context"
+	"crypto/tls"
 	"encoding/json"
 	"fmt"
 	"io"
+	"net"
 	"net/http"
 	"net/http/cookiejar"
 	"net/http/httptest"
@@ -46,6 +48,16 @@ import (
 )
 
 func newTestServer(t *testing.T, opts ...func(*server.Config)) *httptest.Server {
+	t.Helper()
+	return newTestHTTPServer(t, httptest.NewServer, opts...)
+}
+
+func newTestHTTPServer(t *testing.T, start func(http.Handler) *httptest.Server, opts ...func(*server.Config)) *httptest.Server {
+	t.Helper()
+	return start(newTestHandler(t, opts...))
+}
+
+func newTestHandler(t *testing.T, opts ...func(*server.Config)) http.Handler {
 	t.Helper()
 	cfg := server.Config{
 		Auth:     &coretesting.StubAuthProvider{N: "none"},
@@ -93,7 +105,31 @@ func newTestServer(t *testing.T, opts ...func(*server.Config)) *httptest.Server 
 	if err != nil {
 		t.Fatalf("creating server: %v", err)
 	}
-	return httptest.NewServer(srv)
+	return srv
+}
+
+func newVirtualHostClient(t *testing.T, hostAddrs map[string]string) *http.Client {
+	t.Helper()
+	jar, err := cookiejar.New(nil)
+	if err != nil {
+		t.Fatalf("cookiejar.New: %v", err)
+	}
+	dialer := &net.Dialer{}
+	return &http.Client{
+		Jar: jar,
+		Transport: &http.Transport{
+			TLSClientConfig: &tls.Config{InsecureSkipVerify: true},
+			DialContext: func(ctx context.Context, network, addr string) (net.Conn, error) {
+				if actual, ok := hostAddrs[addr]; ok {
+					addr = actual
+				}
+				return dialer.DialContext(ctx, network, addr)
+			},
+		},
+		CheckRedirect: func(_ *http.Request, _ []*http.Request) error {
+			return http.ErrUseLastResponse
+		},
+	}
 }
 
 func extractHiddenInputValue(t *testing.T, html, name string) string {
@@ -272,6 +308,90 @@ func TestNewServerRequiresStateSecretWithAuth(t *testing.T) {
 	}
 	if !strings.Contains(err.Error(), "state secret is required") {
 		t.Fatalf("unexpected error: %v", err)
+	}
+}
+
+func TestNewServerAdminAuthorizationRequiresValidSplitBaseURLs(t *testing.T) {
+	t.Parallel()
+
+	makeConfig := func() server.Config {
+		svc := coretesting.NewStubServices(t)
+		reg := registry.New()
+		return server.Config{
+			Auth:      &coretesting.StubAuthProvider{N: "google"},
+			Services:  svc,
+			Providers: &reg.Providers,
+			Invoker:   invocation.NewBroker(&reg.Providers, svc.Users, svc.Tokens),
+			StateSecret: []byte(
+				"0123456789abcdef0123456789abcdef",
+			),
+			Admin: server.AdminRouteConfig{
+				AuthorizationPolicy: "admin_policy",
+			},
+		}
+	}
+
+	tests := []struct {
+		name              string
+		routeProfile      server.RouteProfile
+		publicBaseURL     string
+		managementBaseURL string
+		admin             server.AdminRouteConfig
+		want              string
+	}{
+		{
+			name:              "route profile all rejects management base url",
+			routeProfile:      server.RouteProfileAll,
+			publicBaseURL:     "https://gestalt.example.test",
+			managementBaseURL: "https://gestalt.example.test:9090",
+			admin:             server.AdminRouteConfig{AuthorizationPolicy: "admin_policy"},
+			want:              "ManagementBaseURL requires RouteProfilePublic or RouteProfileManagement",
+		},
+		{
+			name:              "route profile public rejects mismatched management hostname",
+			routeProfile:      server.RouteProfilePublic,
+			publicBaseURL:     "https://gestalt.example.test",
+			managementBaseURL: "https://evil.example.test:9090",
+			admin:             server.AdminRouteConfig{AuthorizationPolicy: "admin_policy"},
+			want:              "PublicBaseURL and ManagementBaseURL must use the same hostname",
+		},
+		{
+			name:              "route profile public rejects insecure management url",
+			routeProfile:      server.RouteProfilePublic,
+			publicBaseURL:     "https://gestalt.example.test",
+			managementBaseURL: "http://gestalt.example.test:9090",
+			admin:             server.AdminRouteConfig{AuthorizationPolicy: "admin_policy"},
+			want:              "ManagementBaseURL must use https when PublicBaseURL uses https",
+		},
+		{
+			name:         "blank allowed role is rejected",
+			routeProfile: server.RouteProfileAll,
+			admin: server.AdminRouteConfig{
+				AuthorizationPolicy: "admin_policy",
+				AllowedRoles:        []string{""},
+			},
+			want: "admin allowedRoles[0] is required",
+		},
+	}
+
+	for _, tc := range tests {
+		tc := tc
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+
+			cfg := makeConfig()
+			cfg.RouteProfile = tc.routeProfile
+			cfg.PublicBaseURL = tc.publicBaseURL
+			cfg.ManagementBaseURL = tc.managementBaseURL
+			if tc.admin.AuthorizationPolicy != "" || tc.admin.AllowedRoles != nil {
+				cfg.Admin = tc.admin
+			}
+
+			_, err := server.New(cfg)
+			if err == nil || !strings.Contains(err.Error(), tc.want) {
+				t.Fatalf("server.New error = %v, want substring %q", err, tc.want)
+			}
+		})
 	}
 }
 
@@ -517,6 +637,358 @@ func TestMountedWebUIRoutes_HumanAuthorization(t *testing.T) {
 	}
 	if !strings.Contains(string(body), "protected-sample") {
 		t.Fatalf("asset body = %q, want protected sample asset", body)
+	}
+}
+
+func TestBuiltInAdminRoute_HumanAuthorization(t *testing.T) {
+	t.Parallel()
+
+	dir := t.TempDir()
+	if err := os.WriteFile(filepath.Join(dir, "index.html"), []byte("<html>protected-admin-shell</html>"), 0o644); err != nil {
+		t.Fatalf("WriteFile index.html: %v", err)
+	}
+	if err := os.WriteFile(filepath.Join(dir, "theme.css"), []byte("body{background:#eee;}"), 0o644); err != nil {
+		t.Fatalf("WriteFile theme.css: %v", err)
+	}
+	handler, err := testutilWebUIHandler(dir)
+	if err != nil {
+		t.Fatalf("webui handler: %v", err)
+	}
+
+	svc := coretesting.NewStubServices(t)
+	viewer := seedUser(t, svc, "viewer@example.test")
+	admin := seedUser(t, svc, "admin@example.test")
+	authz := mustAuthorizer(t, config.AuthorizationConfig{
+		Policies: map[string]config.HumanPolicyDef{
+			"admin_policy": {
+				Default: "deny",
+				Members: []config.HumanPolicyMemberDef{
+					{SubjectID: principal.UserSubjectID(viewer.ID), Role: "viewer"},
+					{SubjectID: principal.UserSubjectID(admin.ID), Role: "admin"},
+				},
+			},
+		},
+	}, nil, nil, nil)
+
+	ts := newTestServer(t, func(cfg *server.Config) {
+		cfg.Auth = &coretesting.StubAuthProvider{
+			N: "test",
+			ValidateTokenFn: func(_ context.Context, token string) (*core.UserIdentity, error) {
+				switch token {
+				case "viewer-session":
+					return &core.UserIdentity{Email: "viewer@example.test"}, nil
+				case "admin-session":
+					return &core.UserIdentity{Email: "admin@example.test"}, nil
+				default:
+					return nil, fmt.Errorf("invalid token")
+				}
+			},
+		}
+		cfg.Services = svc
+		cfg.Authorizer = authz
+		cfg.Admin = server.AdminRouteConfig{
+			AuthorizationPolicy: "admin_policy",
+			AllowedRoles:        []string{"admin"},
+		}
+		cfg.AdminUI = handler
+	})
+	testutil.CloseOnCleanup(t, ts)
+
+	noRedirect := &http.Client{CheckRedirect: func(_ *http.Request, _ []*http.Request) error {
+		return http.ErrUseLastResponse
+	}}
+
+	resp, err := noRedirect.Get(ts.URL + "/admin/?tab=members")
+	if err != nil {
+		t.Fatalf("GET protected admin without auth: %v", err)
+	}
+	defer func() { _ = resp.Body.Close() }()
+	if resp.StatusCode != http.StatusFound {
+		t.Fatalf("status = %d, want %d", resp.StatusCode, http.StatusFound)
+	}
+	if got, want := resp.Header.Get("Location"), "/api/v1/auth/login?next=%2Fadmin%2F%3Ftab%3Dmembers"; got != want {
+		t.Fatalf("Location = %q, want %q", got, want)
+	}
+
+	req, _ := http.NewRequest(http.MethodGet, ts.URL+"/admin/", nil)
+	req.AddCookie(&http.Cookie{Name: "session_token", Value: "viewer-session"})
+	resp, err = http.DefaultClient.Do(req)
+	if err != nil {
+		t.Fatalf("GET protected admin with viewer session: %v", err)
+	}
+	defer func() { _ = resp.Body.Close() }()
+	if resp.StatusCode != http.StatusForbidden {
+		t.Fatalf("viewer admin status = %d, want %d", resp.StatusCode, http.StatusForbidden)
+	}
+
+	req, _ = http.NewRequest(http.MethodGet, ts.URL+"/admin/", nil)
+	req.AddCookie(&http.Cookie{Name: "session_token", Value: "admin-session"})
+	resp, err = http.DefaultClient.Do(req)
+	if err != nil {
+		t.Fatalf("GET protected admin with admin session: %v", err)
+	}
+	body, err := io.ReadAll(resp.Body)
+	_ = resp.Body.Close()
+	if err != nil {
+		t.Fatalf("ReadAll protected admin: %v", err)
+	}
+	if resp.StatusCode != http.StatusOK {
+		t.Fatalf("admin status = %d, want 200", resp.StatusCode)
+	}
+	if !strings.Contains(string(body), "protected-admin-shell") {
+		t.Fatalf("body = %q, want protected admin shell", body)
+	}
+
+	req, _ = http.NewRequest(http.MethodGet, ts.URL+"/admin/theme.css", nil)
+	req.AddCookie(&http.Cookie{Name: "session_token", Value: "admin-session"})
+	resp, err = http.DefaultClient.Do(req)
+	if err != nil {
+		t.Fatalf("GET protected admin asset: %v", err)
+	}
+	body, err = io.ReadAll(resp.Body)
+	_ = resp.Body.Close()
+	if err != nil {
+		t.Fatalf("ReadAll protected admin asset: %v", err)
+	}
+	if resp.StatusCode != http.StatusOK {
+		t.Fatalf("admin asset status = %d, want 200", resp.StatusCode)
+	}
+	if !strings.Contains(string(body), "background") {
+		t.Fatalf("admin asset body = %q, want stylesheet", body)
+	}
+}
+
+func TestBuiltInAdminRoute_HumanAuthorizationOnManagementProfile(t *testing.T) {
+	t.Parallel()
+
+	dir := t.TempDir()
+	if err := os.WriteFile(filepath.Join(dir, "index.html"), []byte("<html>protected-admin-shell</html>"), 0o644); err != nil {
+		t.Fatalf("WriteFile index.html: %v", err)
+	}
+	handler, err := testutilWebUIHandler(dir)
+	if err != nil {
+		t.Fatalf("webui handler: %v", err)
+	}
+
+	svc := coretesting.NewStubServices(t)
+	viewer := seedUser(t, svc, "viewer@example.test")
+	admin := seedUser(t, svc, "admin@example.test")
+	authz := mustAuthorizer(t, config.AuthorizationConfig{
+		Policies: map[string]config.HumanPolicyDef{
+			"admin_policy": {
+				Default: "deny",
+				Members: []config.HumanPolicyMemberDef{
+					{SubjectID: principal.UserSubjectID(viewer.ID), Role: "viewer"},
+					{SubjectID: principal.UserSubjectID(admin.ID), Role: "admin"},
+				},
+			},
+		},
+	}, nil, nil, nil)
+
+	ts := newTestServer(t, func(cfg *server.Config) {
+		cfg.Auth = &coretesting.StubAuthProvider{
+			N: "test",
+			ValidateTokenFn: func(_ context.Context, token string) (*core.UserIdentity, error) {
+				switch token {
+				case "viewer-session":
+					return &core.UserIdentity{Email: "viewer@example.test"}, nil
+				case "admin-session":
+					return &core.UserIdentity{Email: "admin@example.test"}, nil
+				default:
+					return nil, fmt.Errorf("invalid token")
+				}
+			},
+		}
+		cfg.Services = svc
+		cfg.Authorizer = authz
+		cfg.RouteProfile = server.RouteProfileManagement
+		cfg.PublicBaseURL = "https://gestalt.example.test"
+		cfg.ManagementBaseURL = "https://gestalt.example.test:9090"
+		cfg.Admin = server.AdminRouteConfig{
+			AuthorizationPolicy: "admin_policy",
+			AllowedRoles:        []string{"admin"},
+		}
+		cfg.AdminUI = handler
+	})
+	testutil.CloseOnCleanup(t, ts)
+
+	noRedirect := &http.Client{CheckRedirect: func(_ *http.Request, _ []*http.Request) error {
+		return http.ErrUseLastResponse
+	}}
+
+	resp, err := noRedirect.Get(ts.URL + "/admin/?tab=members")
+	if err != nil {
+		t.Fatalf("GET protected management admin without auth: %v", err)
+	}
+	defer func() { _ = resp.Body.Close() }()
+	if resp.StatusCode != http.StatusFound {
+		t.Fatalf("status = %d, want %d", resp.StatusCode, http.StatusFound)
+	}
+	if got, want := resp.Header.Get("Location"), "https://gestalt.example.test/api/v1/auth/login?next=https%3A%2F%2Fgestalt.example.test%3A9090%2Fadmin%2F%3Ftab%3Dmembers"; got != want {
+		t.Fatalf("Location = %q, want %q", got, want)
+	}
+
+	req, _ := http.NewRequest(http.MethodGet, ts.URL+"/admin/", nil)
+	req.AddCookie(&http.Cookie{Name: "session_token", Value: "viewer-session"})
+	resp, err = http.DefaultClient.Do(req)
+	if err != nil {
+		t.Fatalf("GET protected management admin with viewer session: %v", err)
+	}
+	defer func() { _ = resp.Body.Close() }()
+	if resp.StatusCode != http.StatusForbidden {
+		t.Fatalf("viewer management admin status = %d, want %d", resp.StatusCode, http.StatusForbidden)
+	}
+
+	req, _ = http.NewRequest(http.MethodGet, ts.URL+"/admin/", nil)
+	req.AddCookie(&http.Cookie{Name: "session_token", Value: "admin-session"})
+	resp, err = http.DefaultClient.Do(req)
+	if err != nil {
+		t.Fatalf("GET protected management admin with admin session: %v", err)
+	}
+	body, err := io.ReadAll(resp.Body)
+	_ = resp.Body.Close()
+	if err != nil {
+		t.Fatalf("ReadAll protected management admin: %v", err)
+	}
+	if resp.StatusCode != http.StatusOK {
+		t.Fatalf("management admin status = %d, want 200", resp.StatusCode)
+	}
+	if !strings.Contains(string(body), "protected-admin-shell") {
+		t.Fatalf("body = %q, want protected admin shell", body)
+	}
+}
+
+func TestBuiltInAdminRoute_HumanAuthorizationSplitManagementLoginFlow(t *testing.T) {
+	t.Parallel()
+
+	dir := t.TempDir()
+	if err := os.WriteFile(filepath.Join(dir, "index.html"), []byte("<html>protected-admin-shell</html>"), 0o644); err != nil {
+		t.Fatalf("WriteFile index.html: %v", err)
+	}
+	handler, err := testutilWebUIHandler(dir)
+	if err != nil {
+		t.Fatalf("webui handler: %v", err)
+	}
+
+	secret := []byte("0123456789abcdef0123456789abcdef")
+	auth := &stubHostIssuedSessionAuth{secret: secret}
+	svc := coretesting.NewStubServices(t)
+	authz := mustAuthorizer(t, config.AuthorizationConfig{
+		Policies: map[string]config.HumanPolicyDef{
+			"admin_policy": {
+				Default: "deny",
+				Members: []config.HumanPolicyMemberDef{
+					{Email: "host@example.com", Role: "admin"},
+				},
+			},
+		},
+	}, nil, nil, nil)
+
+	publicListener, err := net.Listen("tcp", "127.0.0.1:0")
+	if err != nil {
+		t.Fatalf("listen public: %v", err)
+	}
+	managementListener, err := net.Listen("tcp", "127.0.0.1:0")
+	if err != nil {
+		_ = publicListener.Close()
+		t.Fatalf("listen management: %v", err)
+	}
+	publicPort := publicListener.Addr().(*net.TCPAddr).Port
+	managementPort := managementListener.Addr().(*net.TCPAddr).Port
+	publicURL := fmt.Sprintf("https://gestalt.example.test:%d", publicPort)
+	managementURL := fmt.Sprintf("https://gestalt.example.test:%d", managementPort)
+
+	publicTS := httptest.NewUnstartedServer(newTestHandler(t, func(cfg *server.Config) {
+		cfg.Auth = auth
+		cfg.StateSecret = secret
+		cfg.Services = svc
+		cfg.Authorizer = authz
+		cfg.PublicBaseURL = publicURL
+		cfg.ManagementBaseURL = managementURL
+		cfg.RouteProfile = server.RouteProfilePublic
+		cfg.Admin = server.AdminRouteConfig{
+			AuthorizationPolicy: "admin_policy",
+		}
+	}))
+	publicTS.Listener = publicListener
+	publicTS.StartTLS()
+	testutil.CloseOnCleanup(t, publicTS)
+
+	managementTS := httptest.NewUnstartedServer(newTestHandler(t, func(cfg *server.Config) {
+		cfg.Auth = auth
+		cfg.StateSecret = secret
+		cfg.Services = svc
+		cfg.Authorizer = authz
+		cfg.PublicBaseURL = publicURL
+		cfg.ManagementBaseURL = managementURL
+		cfg.RouteProfile = server.RouteProfileManagement
+		cfg.Admin = server.AdminRouteConfig{
+			AuthorizationPolicy: "admin_policy",
+		}
+		cfg.AdminUI = handler
+	}))
+	managementTS.Listener = managementListener
+	managementTS.StartTLS()
+	testutil.CloseOnCleanup(t, managementTS)
+
+	client := newVirtualHostClient(t, map[string]string{
+		fmt.Sprintf("gestalt.example.test:%d", publicPort):     publicTS.Listener.Addr().String(),
+		fmt.Sprintf("gestalt.example.test:%d", managementPort): managementTS.Listener.Addr().String(),
+	})
+
+	adminResp, err := client.Get(managementURL + "/admin/?tab=members")
+	if err != nil {
+		t.Fatalf("GET protected management admin without auth: %v", err)
+	}
+	defer func() { _ = adminResp.Body.Close() }()
+	if adminResp.StatusCode != http.StatusFound {
+		t.Fatalf("initial admin status = %d, want %d", adminResp.StatusCode, http.StatusFound)
+	}
+
+	loginStartURL := adminResp.Header.Get("Location")
+	if got, want := loginStartURL, publicURL+"/api/v1/auth/login?next="+url.QueryEscape(managementURL+"/admin/?tab=members"); got != want {
+		t.Fatalf("initial admin redirect = %q, want %q", got, want)
+	}
+
+	loginStartResp, err := client.Get(loginStartURL)
+	if err != nil {
+		t.Fatalf("GET browser login start: %v", err)
+	}
+	defer func() { _ = loginStartResp.Body.Close() }()
+	if loginStartResp.StatusCode != http.StatusFound {
+		t.Fatalf("login start status = %d, want %d", loginStartResp.StatusCode, http.StatusFound)
+	}
+	loginURL, err := url.Parse(loginStartResp.Header.Get("Location"))
+	if err != nil {
+		t.Fatalf("parse start login redirect: %v", err)
+	}
+
+	callbackResp, err := client.Get(publicURL + "/api/v1/auth/login/callback?code=good-code&state=" + url.QueryEscape(loginURL.Query().Get("state")))
+	if err != nil {
+		t.Fatalf("GET browser login callback: %v", err)
+	}
+	defer func() { _ = callbackResp.Body.Close() }()
+	if callbackResp.StatusCode != http.StatusFound {
+		t.Fatalf("callback status = %d, want %d", callbackResp.StatusCode, http.StatusFound)
+	}
+	if got, want := callbackResp.Header.Get("Location"), managementURL+"/admin/?tab=members"; got != want {
+		t.Fatalf("callback redirect = %q, want %q", got, want)
+	}
+
+	finalResp, err := client.Get(callbackResp.Header.Get("Location"))
+	if err != nil {
+		t.Fatalf("GET management admin after login: %v", err)
+	}
+	body, err := io.ReadAll(finalResp.Body)
+	_ = finalResp.Body.Close()
+	if err != nil {
+		t.Fatalf("ReadAll protected management admin after login: %v", err)
+	}
+	if finalResp.StatusCode != http.StatusOK {
+		t.Fatalf("final admin status = %d, want 200", finalResp.StatusCode)
+	}
+	if !strings.Contains(string(body), "protected-admin-shell") {
+		t.Fatalf("body = %q, want protected admin shell", body)
 	}
 }
 
@@ -9291,65 +9763,154 @@ func TestLoginCallback_HostIssuesSessionWhenProviderDoesNot(t *testing.T) {
 func TestBrowserLoginRedirect_RedirectsBackToNextPath(t *testing.T) {
 	t.Parallel()
 
-	secret := []byte("0123456789abcdef0123456789abcdef")
-	auth := &stubHostIssuedSessionAuth{secret: secret}
-	jar, err := cookiejar.New(nil)
-	if err != nil {
-		t.Fatalf("cookiejar.New: %v", err)
-	}
-	client := &http.Client{
-		Jar: jar,
-		CheckRedirect: func(_ *http.Request, _ []*http.Request) error {
-			return http.ErrUseLastResponse
+	tests := []struct {
+		name              string
+		next              string
+		publicBaseURL     string
+		managementBaseURL string
+		enableAdminAuth   bool
+		routeProfile      server.RouteProfile
+		wantStartStatus   int
+		wantState         string
+		wantRedirect      string
+	}{
+		{
+			name:            "relative next path",
+			next:            "/sample-portal/admin?tab=members",
+			wantStartStatus: http.StatusFound,
+			wantState:       "/sample-portal/admin",
+			wantRedirect:    "/sample-portal/admin?tab=members",
+		},
+		{
+			name:              "trusted absolute management next path",
+			next:              "https://gestalt.example.test:9090/admin?tab=members",
+			publicBaseURL:     "https://gestalt.example.test",
+			managementBaseURL: "https://gestalt.example.test:9090",
+			enableAdminAuth:   true,
+			routeProfile:      server.RouteProfilePublic,
+			wantStartStatus:   http.StatusFound,
+			wantState:         "/admin",
+			wantRedirect:      "https://gestalt.example.test:9090/admin?tab=members",
+		},
+		{
+			name:              "rejects absolute management next path when admin auth is disabled",
+			next:              "https://gestalt.example.test:9090/admin?tab=members",
+			publicBaseURL:     "https://gestalt.example.test",
+			managementBaseURL: "https://gestalt.example.test:9090",
+			routeProfile:      server.RouteProfilePublic,
+			wantStartStatus:   http.StatusBadRequest,
+		},
+		{
+			name:              "rejects untrusted absolute next path",
+			next:              "https://evil.example.test/admin?tab=members",
+			publicBaseURL:     "https://gestalt.example.test",
+			managementBaseURL: "https://gestalt.example.test:9090",
+			enableAdminAuth:   true,
+			routeProfile:      server.RouteProfilePublic,
+			wantStartStatus:   http.StatusBadRequest,
+		},
+		{
+			name:              "rejects absolute management next path outside admin",
+			next:              "https://gestalt.example.test:9090/metrics",
+			publicBaseURL:     "https://gestalt.example.test",
+			managementBaseURL: "https://gestalt.example.test:9090",
+			enableAdminAuth:   true,
+			routeProfile:      server.RouteProfilePublic,
+			wantStartStatus:   http.StatusBadRequest,
+		},
+		{
+			name:              "rejects absolute management next path with admin traversal",
+			next:              "https://gestalt.example.test:9090/admin/%2e%2e/metrics",
+			publicBaseURL:     "https://gestalt.example.test",
+			managementBaseURL: "https://gestalt.example.test:9090",
+			enableAdminAuth:   true,
+			routeProfile:      server.RouteProfilePublic,
+			wantStartStatus:   http.StatusBadRequest,
 		},
 	}
 
-	ts := newTestServer(t, func(cfg *server.Config) {
-		cfg.Auth = auth
-		cfg.StateSecret = secret
-		cfg.Services = coretesting.NewStubServices(t)
-	})
-	testutil.CloseOnCleanup(t, ts)
+	for _, tc := range tests {
+		tc := tc
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
 
-	startResp, err := client.Get(ts.URL + "/api/v1/auth/login?next=%2Fsample-portal%2Fadmin%3Ftab%3Dmembers")
-	if err != nil {
-		t.Fatalf("start browser login: %v", err)
-	}
-	defer func() { _ = startResp.Body.Close() }()
-	if startResp.StatusCode != http.StatusFound {
-		t.Fatalf("start status = %d, want %d", startResp.StatusCode, http.StatusFound)
-	}
-	loginURL, err := url.Parse(startResp.Header.Get("Location"))
-	if err != nil {
-		t.Fatalf("parse start login redirect: %v", err)
-	}
-	if got := loginURL.Host; got != "idp.example.test" {
-		t.Fatalf("login redirect host = %q, want %q", got, "idp.example.test")
-	}
-	if got := loginURL.Query().Get("state"); got != "/sample-portal/admin" {
-		t.Fatalf("login redirect state = %q, want %q", got, "/sample-portal/admin")
-	}
+			secret := []byte("0123456789abcdef0123456789abcdef")
+			auth := &stubHostIssuedSessionAuth{secret: secret}
+			jar, err := cookiejar.New(nil)
+			if err != nil {
+				t.Fatalf("cookiejar.New: %v", err)
+			}
+			client := &http.Client{
+				Jar: jar,
+				CheckRedirect: func(_ *http.Request, _ []*http.Request) error {
+					return http.ErrUseLastResponse
+				},
+			}
 
-	callbackResp, err := client.Get(ts.URL + "/api/v1/auth/login/callback?code=good-code&state=" + url.QueryEscape(loginURL.Query().Get("state")))
-	if err != nil {
-		t.Fatalf("browser login callback: %v", err)
-	}
-	defer func() { _ = callbackResp.Body.Close() }()
-	if callbackResp.StatusCode != http.StatusFound {
-		t.Fatalf("callback status = %d, want %d", callbackResp.StatusCode, http.StatusFound)
-	}
-	if got, want := callbackResp.Header.Get("Location"), "/sample-portal/admin?tab=members"; got != want {
-		t.Fatalf("callback redirect = %q, want %q", got, want)
-	}
+			ts := newTestServer(t, func(cfg *server.Config) {
+				cfg.Auth = auth
+				cfg.StateSecret = secret
+				cfg.Services = coretesting.NewStubServices(t)
+				cfg.PublicBaseURL = tc.publicBaseURL
+				cfg.ManagementBaseURL = tc.managementBaseURL
+				cfg.RouteProfile = tc.routeProfile
+				if tc.enableAdminAuth {
+					cfg.Admin = server.AdminRouteConfig{AuthorizationPolicy: "admin_policy"}
+				}
+			})
+			testutil.CloseOnCleanup(t, ts)
 
-	foundSession := false
-	for _, cookie := range jar.Cookies(callbackResp.Request.URL) {
-		if cookie.Name == "session_token" && cookie.Value != "" {
-			foundSession = true
-		}
-	}
-	if !foundSession {
-		t.Fatal("expected session cookie after browser login callback")
+			startResp, err := client.Get(ts.URL + "/api/v1/auth/login?next=" + url.QueryEscape(tc.next))
+			if err != nil {
+				t.Fatalf("start browser login: %v", err)
+			}
+			defer func() { _ = startResp.Body.Close() }()
+			if startResp.StatusCode != tc.wantStartStatus {
+				t.Fatalf("start status = %d, want %d", startResp.StatusCode, tc.wantStartStatus)
+			}
+			if tc.wantStartStatus != http.StatusFound {
+				body, readErr := io.ReadAll(startResp.Body)
+				if readErr != nil {
+					t.Fatalf("ReadAll start error body: %v", readErr)
+				}
+				if !strings.Contains(string(body), "invalid next path") {
+					t.Fatalf("start error body = %q, want %q", body, "invalid next path")
+				}
+				return
+			}
+			loginURL, err := url.Parse(startResp.Header.Get("Location"))
+			if err != nil {
+				t.Fatalf("parse start login redirect: %v", err)
+			}
+			if got := loginURL.Host; got != "idp.example.test" {
+				t.Fatalf("login redirect host = %q, want %q", got, "idp.example.test")
+			}
+			if got := loginURL.Query().Get("state"); got != tc.wantState {
+				t.Fatalf("login redirect state = %q, want %q", got, tc.wantState)
+			}
+
+			callbackResp, err := client.Get(ts.URL + "/api/v1/auth/login/callback?code=good-code&state=" + url.QueryEscape(loginURL.Query().Get("state")))
+			if err != nil {
+				t.Fatalf("browser login callback: %v", err)
+			}
+			defer func() { _ = callbackResp.Body.Close() }()
+			if callbackResp.StatusCode != http.StatusFound {
+				t.Fatalf("callback status = %d, want %d", callbackResp.StatusCode, http.StatusFound)
+			}
+			if got := callbackResp.Header.Get("Location"); got != tc.wantRedirect {
+				t.Fatalf("callback redirect = %q, want %q", got, tc.wantRedirect)
+			}
+
+			foundSession := false
+			for _, cookie := range jar.Cookies(callbackResp.Request.URL) {
+				if cookie.Name == "session_token" && cookie.Value != "" {
+					foundSession = true
+				}
+			}
+			if !foundSession {
+				t.Fatal("expected session cookie after browser login callback")
+			}
+		})
 	}
 }
 


### PR DESCRIPTION
## Plan

Protect the built-in `/admin` route with the same shared human authorization primitives introduced for mounted UIs, and make split public/management browser login round-trips work safely for the built-in admin UI.

This PR does four things:
- adds a first-class config surface for built-in admin authorization
- enforces that authorization on `/admin` HTML and static assets
- supports public-login -> management-`/admin` redirects for split listeners
- validates both YAML and direct Go construction so unsafe or broken redirect configs are rejected

## YAML interface

```yaml
server:
  baseUrl: https://gestalt.example.test
  management:
    host: 0.0.0.0
    port: 9090
    baseUrl: https://gestalt.example.test:9090
  admin:
    authorizationPolicy: admin_policy
    allowedRoles:
      - admin

authorization:
  policies:
    admin_policy:
      default: deny
      members:
        - email: ops@example.com
          role: admin
        - email: eng-manager@example.com
          role: admin
```

New YAML surface:
- `server.admin.authorizationPolicy`
- `server.admin.allowedRoles`
- `server.management.baseUrl`

Notes:
- `server.admin.allowedRoles` defaults to `[admin]` when `server.admin.authorizationPolicy` is set.
- `server.management.baseUrl` is required for split public/management deployments that protect built-in `/admin`.
- `server.baseUrl` and `server.management.baseUrl` must use the same hostname, and management must stay on `https` when the public listener uses `https`.

## Go interface

```go
srv, err := server.New(server.Config{
    Auth:              authProvider,
    Services:          services,
    Providers:         providers,
    Invoker:           invoker,
    StateSecret:       stateSecret,
    RouteProfile:      server.RouteProfileManagement,
    PublicBaseURL:     "https://gestalt.example.test",
    ManagementBaseURL: "https://gestalt.example.test:9090",
    Admin: server.AdminRouteConfig{
        AuthorizationPolicy: "admin_policy",
        AllowedRoles:        []string{"admin"},
    },
    AdminUI: adminHandler,
})
```

New Go surface:
- `config.AdminConfig`
- `config.ManagementListenerConfig.BaseURL`
- `server.Config.ManagementBaseURL`
- `server.Config.Admin`
- `server.AdminRouteConfig`

## Examples

Same-origin built-in admin auth:

```yaml
server:
  admin:
    authorizationPolicy: admin_policy
```

Split public/management built-in admin auth:

```yaml
server:
  baseUrl: https://gestalt.example.test
  management:
    host: 0.0.0.0
    port: 9090
    baseUrl: https://gestalt.example.test:9090
  admin:
    authorizationPolicy: admin_policy
    allowedRoles: [admin]
```

Direct Go split-public login allowlist:

```go
server.Config{
    RouteProfile:      server.RouteProfilePublic,
    PublicBaseURL:     "https://gestalt.example.test",
    ManagementBaseURL: "https://gestalt.example.test:9090",
    Admin: server.AdminRouteConfig{AuthorizationPolicy: "admin_policy"},
}
```

## Behavior changes

- `/admin` now reuses the mounted-UI authorization wrapper instead of bypassing policy enforcement.
- Protected built-in admin assets such as `/admin/theme.css` are gated the same way as `/admin/`.
- On management listeners, unauthenticated `/admin` requests redirect to the public login endpoint and return to the management listener after callback.
- Browser login only trusts absolute `next=` targets for built-in admin when they match the configured management base URL on the split public listener.
- Direct Go construction now rejects split-admin configurations that are invalid in YAML as well.

## Testing

Augmented existing server-level coverage instead of adding standalone unit-test files:
- same-origin built-in `/admin` auth flow
- management-profile `/admin` redirect behavior
- end-to-end split public/management browser login round-trip with real cookie behavior
- browser-login absolute `next=` acceptance and rejection cases
- `server.New(...)` validation coverage for invalid split-admin Go configs

Commands run:
- `go test ./internal/server`
- `go test ./internal/config`
- `go test ./cmd/gestaltd`
