### PR TITLE
Emit schema-only relationaldb configs for plugin IndexedDB bindings

### DIFF
--- a/docs/content/custom-providers/indexeddb.mdx
+++ b/docs/content/custom-providers/indexeddb.mdx
@@ -231,10 +231,10 @@ You implement the [IndexedDB gRPC service](https://www.w3.org/TR/IndexedDB/#obje
 Plugins access the IndexedDB provider through the SDK. The host serves the IndexedDB interface over a gRPC socket, and the SDK wraps it into native types for each language.
 
 When a plugin binds a datastore through `plugins.<name>.indexeddb`, the host now rebuilds
-that provider with a plugin-scoped namespace before exposing it over the SDK
+that provider with a plugin-scoped schema before exposing it over the SDK
 socket. Plugins still use plain store names like `tasks` or `snapshots`; the
 host applies isolation outside the plugin. For schema-capable backends, that
-means a plugin-specific schema or namespace. For SQLite-backed relationaldb
+means a plugin-specific schema. For SQLite-backed relationaldb
 bindings, the host falls back to `<indexeddbSchema>_` table prefixes. Other
 IndexedDB providers fall back to transport-level `<indexeddbSchema>_` store
 prefixes. Plugin bindings can also declare `objectStore` allowlists so the host rejects stores
@@ -413,7 +413,7 @@ providers:
 
 `DATABASE_URL` is a connection string for your database. The RelationalDB provider accepts `postgres://`, `mysql://`, `sqlite://`, and `sqlserver://` prefixes.
 
-Object store names remain logical inside plugins. The host scopes plugin data by rebuilding schema-capable providers with a plugin-specific schema or namespace, or by applying a `<indexeddbSchema>_` prefix on backends without schema support.
+Object store names remain logical inside plugins. The host scopes plugin data by rebuilding schema-capable providers with a plugin-specific schema, or by applying a `<indexeddbSchema>_` prefix on backends without schema support.
 
 ## What to read next
 

--- a/docs/content/providers/indexeddb.mdx
+++ b/docs/content/providers/indexeddb.mdx
@@ -12,10 +12,10 @@ to one of the named entries under `providers.indexeddb`. Gestalt talks to that p
 through the IndexedDB service contract while keeping plugin state isolated with
 plugin-scoped datastore instances. By default, a plugin binding uses the plugin
 name as its IndexedDB schema; `plugins.<name>.indexeddbSchema` can
-override that namespace. Plugin bindings can also declare `objectStore`
+override that schema name. Plugin bindings can also declare `objectStore`
 allowlists so a store like `tasks` is only served through one configured
 binding. With the first-party RelationalDB provider, Postgres, MySQL, and SQL
-Server receive the namespace as `schema` / `namespace`, while SQLite falls back
+Server receive that value as `schema`, while SQLite falls back
 to `<schema>_` table prefixes because it has no schema support. Other IndexedDB
 providers fall back to `<schema>_` transport-level store prefixes.
 

--- a/docs/content/reference/config-file.mdx
+++ b/docs/content/reference/config-file.mdx
@@ -483,7 +483,7 @@ plugins:
 | `connections` | Named connection declarations. See [connections](#connections) below. |
 | `allowedOperations` | Allowlist with optional `alias`, `description`, and `allowedRoles` overrides per operation. |
 | `indexeddb` | Optional list of plugin IndexedDB bindings. The scalar shorthand `- main` is still supported; the object form accepts `name` plus optional `objectStore` allowlists to pin logical stores to a binding. A given `objectStore` may appear in at most one binding; duplicates are rejected during config validation. When any binding declares `objectStore`, one additional binding may omit it and acts as the catch-all for unassigned stores. Each binding is rebuilt as a plugin-scoped IndexedDB instance before being served to the plugin. A single binding also populates the default IndexedDB SDK env var for compatibility. |
-| `indexeddbSchema` | Optional override for the plugin IndexedDB namespace. When omitted, Gestalt uses the plugin name. RelationalDB bindings pass this through as `schema` / `namespace` on Postgres, MySQL, and SQL Server, use `<indexeddbSchema>_` table prefixes on SQLite, and other IndexedDB backends fall back to `<indexeddbSchema>_` transport-level store prefixes. |
+| `indexeddbSchema` | Optional override for the plugin IndexedDB namespace. When omitted, Gestalt uses the plugin name. RelationalDB bindings pass this through as `schema` on Postgres, MySQL, and SQL Server, use `<indexeddbSchema>_` table prefixes on SQLite, and other IndexedDB backends fall back to `<indexeddbSchema>_` transport-level store prefixes. |
 
 ### `plugins.*.source`
 

--- a/gestaltd/core/integration/restricted_test.go
+++ b/gestaltd/core/integration/restricted_test.go
@@ -58,6 +58,7 @@ func TestCatalogFilters(t *testing.T) {
 	cat := r.Catalog()
 	if cat == nil {
 		t.Fatal("Catalog() returned nil")
+		return
 	}
 	if len(cat.Operations) != 2 {
 		t.Fatalf("Catalog().Operations: got %d, want 2", len(cat.Operations))
@@ -306,6 +307,7 @@ func TestCatalogRenamesAliasedOperations(t *testing.T) {
 	cat := r.Catalog()
 	if cat == nil {
 		t.Fatal("Catalog() returned nil")
+		return
 	}
 	if len(cat.Operations) != 1 {
 		t.Fatalf("Catalog().Operations: got %d, want 1", len(cat.Operations))

--- a/gestaltd/core/testing/auth_suite.go
+++ b/gestaltd/core/testing/auth_suite.go
@@ -21,6 +21,7 @@ import (
 func RunAuthProviderTests(t *testing.T, newProvider func(t *testing.T, mockURL string) core.AuthProvider, mockServer *httptest.Server) {
 	if mockServer == nil {
 		t.Fatal("RunAuthProviderTests requires a mock server")
+		return
 	}
 	provider := newProvider(t, mockServer.URL)
 

--- a/gestaltd/internal/bootstrap/executable_plugin_test.go
+++ b/gestaltd/internal/bootstrap/executable_plugin_test.go
@@ -918,38 +918,44 @@ func TestPluginIndexedDBBindingsBuildScopedConfig(t *testing.T) {
 		"postgres": {
 			Source: config.ProviderSource{Ref: "github.com/valon-technologies/gestalt-providers/indexeddb/relationaldb"},
 			Config: mustNode(t, map[string]any{
-				"dsn":       "postgres://db.example.test/gestalt",
-				"schema":    "host_schema",
-				"namespace": "host_schema",
+				"dsn":                 "postgres://db.example.test/gestalt",
+				"schema":              "host_schema",
+				"namespace":           "host_schema_alias_should_be_removed",
+				"legacy_table_prefix": "host_legacy_should_be_replaced_",
+				"legacy_prefix":       "host_legacy_alias_should_be_removed_",
 			}),
 		},
 		"sqlite": {
 			Source: config.ProviderSource{Ref: "github.com/valon-technologies/gestalt-providers/indexeddb/relationaldb"},
 			Config: mustNode(t, map[string]any{
-				"dsn":          "sqlite://plugin-state.db",
-				"table_prefix": "host_",
-				"prefix":       "host_",
-				"schema":       "should_be_removed",
-				"namespace":    "should_be_removed",
+				"dsn":                 "sqlite://plugin-state.db",
+				"table_prefix":        "host_",
+				"prefix":              "host_",
+				"schema":              "should_be_removed",
+				"namespace":           "should_be_removed",
+				"legacy_table_prefix": "host_legacy_should_be_replaced_",
+				"legacy_prefix":       "host_legacy_alias_should_be_removed_",
 			}),
 		},
 		"local-postgres": {
 			Source: config.ProviderSource{Path: "./relationaldb/manifest.yaml"},
 			Config: mustNode(t, map[string]any{
-				"dsn":       "postgres://local.example.test/gestalt",
-				"schema":    "host_local",
-				"namespace": "host_local",
+				"dsn":                 "postgres://local.example.test/gestalt",
+				"schema":              "host_local",
+				"namespace":           "host_local_alias_should_be_removed",
+				"legacy_table_prefix": "host_local_legacy_should_be_replaced_",
+				"legacy_prefix":       "host_local_legacy_alias_should_be_removed_",
 			}),
 		},
 	}
 
 	cases := []struct {
-		name          string
-		schema        string
-		wantNamespace string
+		name       string
+		schema     string
+		wantSchema string
 	}{
-		{name: "defaults to plugin name", wantNamespace: "echoext"},
-		{name: "uses plugin override", schema: "roadmap_state", wantNamespace: "roadmap_state"},
+		{name: "defaults to plugin name", wantSchema: "echoext"},
+		{name: "uses plugin override", schema: "roadmap_state", wantSchema: "roadmap_state"},
 	}
 
 	for _, tc := range cases {
@@ -991,17 +997,17 @@ func TestPluginIndexedDBBindingsBuildScopedConfig(t *testing.T) {
 			if !ok {
 				t.Fatal("missing captured postgres indexeddb config")
 			}
-			if got := postgresCfg.Config["schema"]; got != tc.wantNamespace {
-				t.Fatalf("postgres schema = %#v, want %q", got, tc.wantNamespace)
+			if got := postgresCfg.Config["schema"]; got != tc.wantSchema {
+				t.Fatalf("postgres schema = %#v, want %q", got, tc.wantSchema)
 			}
-			if got := postgresCfg.Config["namespace"]; got != tc.wantNamespace {
-				t.Fatalf("postgres namespace = %#v, want %q", got, tc.wantNamespace)
+			if _, ok := postgresCfg.Config["namespace"]; ok {
+				t.Fatalf("postgres namespace should be removed, got %#v", postgresCfg.Config["namespace"])
 			}
 			if got := postgresCfg.Config["legacy_table_prefix"]; got != "plugin_echoext_" {
 				t.Fatalf("postgres legacy_table_prefix = %#v, want %q", got, "plugin_echoext_")
 			}
-			if got := postgresCfg.Config["legacy_prefix"]; got != "plugin_echoext_" {
-				t.Fatalf("postgres legacy_prefix = %#v, want %q", got, "plugin_echoext_")
+			if _, ok := postgresCfg.Config["legacy_prefix"]; ok {
+				t.Fatalf("postgres legacy_prefix should be removed, got %#v", postgresCfg.Config["legacy_prefix"])
 			}
 			if _, ok := postgresCfg.Config["table_prefix"]; ok {
 				t.Fatalf("postgres table_prefix should be removed, got %#v", postgresCfg.Config["table_prefix"])
@@ -1014,24 +1020,24 @@ func TestPluginIndexedDBBindingsBuildScopedConfig(t *testing.T) {
 			if !ok {
 				t.Fatal("missing captured local postgres indexeddb config")
 			}
-			if got := localPostgresCfg.Config["schema"]; got != tc.wantNamespace {
-				t.Fatalf("local postgres schema = %#v, want %q", got, tc.wantNamespace)
+			if got := localPostgresCfg.Config["schema"]; got != tc.wantSchema {
+				t.Fatalf("local postgres schema = %#v, want %q", got, tc.wantSchema)
 			}
-			if got := localPostgresCfg.Config["namespace"]; got != tc.wantNamespace {
-				t.Fatalf("local postgres namespace = %#v, want %q", got, tc.wantNamespace)
+			if _, ok := localPostgresCfg.Config["namespace"]; ok {
+				t.Fatalf("local postgres namespace should be removed, got %#v", localPostgresCfg.Config["namespace"])
 			}
 			if got := localPostgresCfg.Config["legacy_table_prefix"]; got != "plugin_echoext_" {
 				t.Fatalf("local postgres legacy_table_prefix = %#v, want %q", got, "plugin_echoext_")
 			}
-			if got := localPostgresCfg.Config["legacy_prefix"]; got != "plugin_echoext_" {
-				t.Fatalf("local postgres legacy_prefix = %#v, want %q", got, "plugin_echoext_")
+			if _, ok := localPostgresCfg.Config["legacy_prefix"]; ok {
+				t.Fatalf("local postgres legacy_prefix should be removed, got %#v", localPostgresCfg.Config["legacy_prefix"])
 			}
 
 			sqliteCfg, ok := captured["sqlite://plugin-state.db"]
 			if !ok {
 				t.Fatal("missing captured sqlite indexeddb config")
 			}
-			wantPrefix := tc.wantNamespace + "_"
+			wantPrefix := tc.wantSchema + "_"
 			if got := sqliteCfg.Config["table_prefix"]; got != wantPrefix {
 				t.Fatalf("sqlite table_prefix = %#v, want %q", got, wantPrefix)
 			}
@@ -1047,8 +1053,8 @@ func TestPluginIndexedDBBindingsBuildScopedConfig(t *testing.T) {
 			if got := sqliteCfg.Config["legacy_table_prefix"]; got != "plugin_echoext_" {
 				t.Fatalf("sqlite legacy_table_prefix = %#v, want %q", got, "plugin_echoext_")
 			}
-			if got := sqliteCfg.Config["legacy_prefix"]; got != "plugin_echoext_" {
-				t.Fatalf("sqlite legacy_prefix = %#v, want %q", got, "plugin_echoext_")
+			if _, ok := sqliteCfg.Config["legacy_prefix"]; ok {
+				t.Fatalf("sqlite legacy_prefix should be removed, got %#v", sqliteCfg.Config["legacy_prefix"])
 			}
 
 			_ = CloseProviders(providers)

--- a/gestaltd/internal/bootstrap/provider_build.go
+++ b/gestaltd/internal/bootstrap/provider_build.go
@@ -614,20 +614,19 @@ func newPluginScopedIndexedDBDef(entry *config.ProviderEntry, pluginName, schema
 
 	transportPrefix := ""
 	if pluginIndexedDBUsesScopedProviderConfig(entry, cfg) {
+		delete(cfg, "legacy_prefix")
+		delete(cfg, "namespace")
 		if legacyPrefix := legacyPluginIndexedDBPrefix(pluginName); legacyPrefix != "" {
 			cfg["legacy_table_prefix"] = legacyPrefix
-			cfg["legacy_prefix"] = legacyPrefix
 		}
 		if isSQLiteIndexedDBConfig(cfg) {
 			delete(cfg, "schema")
-			delete(cfg, "namespace")
 			cfg["table_prefix"] = schema + "_"
 			cfg["prefix"] = schema + "_"
 		} else {
 			delete(cfg, "table_prefix")
 			delete(cfg, "prefix")
 			cfg["schema"] = schema
-			cfg["namespace"] = schema
 		}
 	} else {
 		transportPrefix = schema + "_"


### PR DESCRIPTION
## Summary
- stop emitting `namespace` and `legacy_prefix` in plugin-scoped relationaldb configs
- keep emitting `schema` and `legacy_table_prefix`
- strip stale alias keys out of rebased provider configs before building plugin-scoped bindings
- update docs to describe the schema-only relationaldb interface

## Go interface
```go
type PluginIndexedDBBinding struct {
    Name         string   `yaml:"name"`
    ObjectStores []string `yaml:"objectStore"`
}

type ProviderEntry struct {
    IndexedDBs      []PluginIndexedDBBinding `yaml:"indexeddb"`
    IndexedDBSchema string                   `yaml:"indexeddbSchema"`
}
```

Generated relationaldb config for plugin-scoped bindings:
```go
map[string]any{
    "dsn":                 os.Getenv("DATABASE_URL"),
    "schema":              "github_plugin",
    "legacy_table_prefix": "plugin_github_",
}
```

## YAML interface
```yaml
server:
  providers:
    indexeddb: main

providers:
  indexeddb:
    main:
      source:
        ref: github.com/valon-technologies/gestalt-providers/indexeddb/relationaldb
        version: 0.0.1-alpha.2
      config:
        dsn: ${DATABASE_URL}

plugins:
  github:
    indexeddb:
      - name: main
        objectStore:
          - tasks
          - snapshots
    indexeddbSchema: github_plugin
```

SQLite-backed plugin bindings still receive:
```yaml
config:
  dsn: sqlite://./gestalt.db
  table_prefix: github_plugin_
  prefix: github_plugin_
  legacy_table_prefix: plugin_github_
```

## Merge order
Merge this PR before `valon-technologies/gestalt-providers#93`, because current `main` still emits the aliases that PR removes.

## Verification
- `go test ./internal/bootstrap -run 'TestPluginIndexedDBBindings(ExposeHostSocketEnv|BuildScopedConfig|RouteObjectStoresAndTransportPrefix|PreserveLegacyTransportPrefixedData|RouteExplicitAndCatchAllStores)$'`
- `git diff --check`
