### PR TITLE
Drop legacy plugin IndexedDB fallback wiring

### DIFF
--- a/gestaltd/internal/bootstrap/executable_plugin_test.go
+++ b/gestaltd/internal/bootstrap/executable_plugin_test.go
@@ -1003,8 +1003,8 @@ func TestPluginIndexedDBBindingsBuildScopedConfig(t *testing.T) {
 			if _, ok := postgresCfg.Config["namespace"]; ok {
 				t.Fatalf("postgres namespace should be removed, got %#v", postgresCfg.Config["namespace"])
 			}
-			if got := postgresCfg.Config["legacy_table_prefix"]; got != "plugin_echoext_" {
-				t.Fatalf("postgres legacy_table_prefix = %#v, want %q", got, "plugin_echoext_")
+			if _, ok := postgresCfg.Config["legacy_table_prefix"]; ok {
+				t.Fatalf("postgres legacy_table_prefix should be removed, got %#v", postgresCfg.Config["legacy_table_prefix"])
 			}
 			if _, ok := postgresCfg.Config["legacy_prefix"]; ok {
 				t.Fatalf("postgres legacy_prefix should be removed, got %#v", postgresCfg.Config["legacy_prefix"])
@@ -1026,8 +1026,8 @@ func TestPluginIndexedDBBindingsBuildScopedConfig(t *testing.T) {
 			if _, ok := localPostgresCfg.Config["namespace"]; ok {
 				t.Fatalf("local postgres namespace should be removed, got %#v", localPostgresCfg.Config["namespace"])
 			}
-			if got := localPostgresCfg.Config["legacy_table_prefix"]; got != "plugin_echoext_" {
-				t.Fatalf("local postgres legacy_table_prefix = %#v, want %q", got, "plugin_echoext_")
+			if _, ok := localPostgresCfg.Config["legacy_table_prefix"]; ok {
+				t.Fatalf("local postgres legacy_table_prefix should be removed, got %#v", localPostgresCfg.Config["legacy_table_prefix"])
 			}
 			if _, ok := localPostgresCfg.Config["legacy_prefix"]; ok {
 				t.Fatalf("local postgres legacy_prefix should be removed, got %#v", localPostgresCfg.Config["legacy_prefix"])
@@ -1050,8 +1050,8 @@ func TestPluginIndexedDBBindingsBuildScopedConfig(t *testing.T) {
 			if _, ok := sqliteCfg.Config["namespace"]; ok {
 				t.Fatalf("sqlite namespace should be removed, got %#v", sqliteCfg.Config["namespace"])
 			}
-			if got := sqliteCfg.Config["legacy_table_prefix"]; got != "plugin_echoext_" {
-				t.Fatalf("sqlite legacy_table_prefix = %#v, want %q", got, "plugin_echoext_")
+			if _, ok := sqliteCfg.Config["legacy_table_prefix"]; ok {
+				t.Fatalf("sqlite legacy_table_prefix should be removed, got %#v", sqliteCfg.Config["legacy_table_prefix"])
 			}
 			if _, ok := sqliteCfg.Config["legacy_prefix"]; ok {
 				t.Fatalf("sqlite legacy_prefix should be removed, got %#v", sqliteCfg.Config["legacy_prefix"])
@@ -1164,94 +1164,6 @@ func TestPluginIndexedDBBindingsRouteObjectStoresAndTransportPrefix(t *testing.T
 	providers = nil
 	if got := closeCount.Load(); got != 1 {
 		t.Fatalf("closeCount after provider shutdown = %d, want 1", got)
-	}
-}
-
-func TestPluginIndexedDBBindingsPreserveLegacyTransportPrefixedData(t *testing.T) {
-	t.Parallel()
-
-	bin := buildEchoPluginBinary(t)
-	manifestRoot := writeStaticCatalog(t, &catalog.Catalog{
-		Name: "echoext",
-		Operations: []catalog.CatalogOperation{
-			{
-				ID:     "indexeddb_roundtrip",
-				Method: http.MethodPost,
-				Parameters: []catalog.CatalogParameter{
-					{Name: "store", Type: "string", Required: true},
-					{Name: "id", Type: "string", Required: true},
-					{Name: "value", Type: "string", Required: true},
-				},
-			},
-		},
-	})
-	manifest := newExecutableManifest("Echo", "Echoes back the input parameters")
-
-	var boundDB *trackedIndexedDB
-	providers, _, err := buildProvidersStrict(context.Background(), &config.Config{
-		Providers: config.ProvidersConfig{
-			Plugins: map[string]*config.ProviderEntry{
-				"echoext": {
-					Command:              bin,
-					Args:                 []string{"provider"},
-					ResolvedManifest:     manifest,
-					ResolvedManifestPath: filepath.Join(manifestRoot, "manifest.yaml"),
-					IndexedDBSchema:      "roadmap",
-					IndexedDBs: []config.PluginIndexedDBBinding{
-						{Name: "memory", ObjectStores: []string{"tasks"}},
-					},
-				},
-			},
-		},
-	}, NewFactoryRegistry(), Deps{
-		IndexedDBDefs: map[string]*config.ProviderEntry{
-			"memory": {
-				Source: config.ProviderSource{Path: "./providers/datastore/memory"},
-				Config: mustNode(t, map[string]any{"bucket": "plugin-state"}),
-			},
-		},
-		IndexedDBFactory: func(yaml.Node) (indexeddb.IndexedDB, error) {
-			boundDB = &trackedIndexedDB{
-				StubIndexedDB: coretesting.StubIndexedDB{},
-			}
-			return boundDB, nil
-		},
-	})
-	if err != nil {
-		t.Fatalf("buildProvidersStrict: %v", err)
-	}
-	t.Cleanup(func() { _ = CloseProviders(providers) })
-
-	if err := boundDB.CreateObjectStore(context.Background(), "plugin_echoext_tasks", indexeddb.ObjectStoreSchema{}); err != nil {
-		t.Fatalf("CreateObjectStore legacy tasks: %v", err)
-	}
-	if err := boundDB.ObjectStore("plugin_echoext_tasks").Put(context.Background(), indexeddb.Record{
-		"id":    "legacy-task",
-		"value": "already-there",
-	}); err != nil {
-		t.Fatalf("Put legacy task: %v", err)
-	}
-
-	prov, err := providers.Get("echoext")
-	if err != nil {
-		t.Fatalf("providers.Get: %v", err)
-	}
-	if _, err := prov.Execute(context.Background(), "indexeddb_roundtrip", map[string]any{
-		"store": "tasks",
-		"id":    "task-1",
-		"value": "ship-it",
-	}, ""); err != nil {
-		t.Fatalf("Execute indexeddb_roundtrip: %v", err)
-	}
-
-	if _, err := boundDB.ObjectStore("plugin_echoext_tasks").Get(context.Background(), "task-1"); err != nil {
-		t.Fatalf("legacy backing store should receive new writes: %v", err)
-	}
-	if _, err := boundDB.ObjectStore("plugin_echoext_tasks").Get(context.Background(), "legacy-task"); err != nil {
-		t.Fatalf("legacy backing store should keep old rows: %v", err)
-	}
-	if _, err := boundDB.ObjectStore("roadmap_tasks").Get(context.Background(), "task-1"); err == nil {
-		t.Fatal("new transport-prefixed store should remain unused while only legacy data exists")
 	}
 }
 

--- a/gestaltd/internal/bootstrap/plugin_indexeddb.go
+++ b/gestaltd/internal/bootstrap/plugin_indexeddb.go
@@ -2,23 +2,21 @@ package bootstrap
 
 import (
 	"context"
-	"errors"
 
 	"github.com/valon-technologies/gestalt/server/core/indexeddb"
 )
 
 type pluginIndexedDBTransportOptions struct {
-	StorePrefix       string
-	LegacyStorePrefix string
-	AllowedStores     []string
-	DeniedStores      []string
+	StorePrefix   string
+	AllowedStores []string
+	DeniedStores  []string
 }
 
 func newPluginIndexedDBTransport(ds indexeddb.IndexedDB, opts pluginIndexedDBTransportOptions) indexeddb.IndexedDB {
 	if ds == nil {
 		return nil
 	}
-	if opts.StorePrefix == "" && opts.LegacyStorePrefix == "" && len(opts.AllowedStores) == 0 && len(opts.DeniedStores) == 0 {
+	if opts.StorePrefix == "" && len(opts.AllowedStores) == 0 && len(opts.DeniedStores) == 0 {
 		return ds
 	}
 	allowed := make(map[string]struct{}, len(opts.AllowedStores))
@@ -36,74 +34,54 @@ func newPluginIndexedDBTransport(ds indexeddb.IndexedDB, opts pluginIndexedDBTra
 		denied = nil
 	}
 	return &pluginIndexedDBTransport{
-		inner:        ds,
-		prefix:       opts.StorePrefix,
-		legacyPrefix: opts.LegacyStorePrefix,
-		allowed:      allowed,
-		denied:       denied,
+		inner:   ds,
+		prefix:  opts.StorePrefix,
+		allowed: allowed,
+		denied:  denied,
 	}
 }
 
 type pluginIndexedDBTransport struct {
-	inner        indexeddb.IndexedDB
-	prefix       string
-	legacyPrefix string
-	allowed      map[string]struct{}
-	denied       map[string]struct{}
+	inner   indexeddb.IndexedDB
+	prefix  string
+	allowed map[string]struct{}
+	denied  map[string]struct{}
 }
 
-func (d *pluginIndexedDBTransport) translateStore(name string) (string, string, error) {
+func (d *pluginIndexedDBTransport) translateStore(name string) (string, error) {
 	if len(d.allowed) > 0 {
 		if _, ok := d.allowed[name]; !ok {
-			return "", "", indexeddb.ErrNotFound
+			return "", indexeddb.ErrNotFound
 		}
 	}
 	if len(d.denied) > 0 {
 		if _, ok := d.denied[name]; ok {
-			return "", "", indexeddb.ErrNotFound
+			return "", indexeddb.ErrNotFound
 		}
 	}
-	return d.prefix + name, d.legacyPrefix + name, nil
+	return d.prefix + name, nil
 }
 
 func (d *pluginIndexedDBTransport) ObjectStore(name string) indexeddb.ObjectStore {
-	primary, legacy, err := d.translateStore(name)
+	storeName, err := d.translateStore(name)
 	if err != nil {
 		return missingObjectStore{}
 	}
-	return &pluginIndexedDBObjectStore{
-		inner:   d.inner,
-		primary: primary,
-		legacy:  legacy,
-	}
+	return d.inner.ObjectStore(storeName)
 }
 
 func (d *pluginIndexedDBTransport) CreateObjectStore(ctx context.Context, name string, schema indexeddb.ObjectStoreSchema) error {
-	primary, legacy, err := d.translateStore(name)
+	storeName, err := d.translateStore(name)
 	if err != nil {
 		return err
-	}
-	storeName, exists, err := resolveActiveStoreName(ctx, d.inner, primary, legacy)
-	if err != nil {
-		return err
-	}
-	if !exists {
-		storeName = primary
 	}
 	return d.inner.CreateObjectStore(ctx, storeName, schema)
 }
 
 func (d *pluginIndexedDBTransport) DeleteObjectStore(ctx context.Context, name string) error {
-	primary, legacy, err := d.translateStore(name)
+	storeName, err := d.translateStore(name)
 	if err != nil {
 		return err
-	}
-	storeName, exists, err := resolveActiveStoreName(ctx, d.inner, primary, legacy)
-	if err != nil {
-		return err
-	}
-	if !exists {
-		storeName = primary
 	}
 	return d.inner.DeleteObjectStore(ctx, storeName)
 }
@@ -114,237 +92,6 @@ func (d *pluginIndexedDBTransport) Ping(ctx context.Context) error {
 
 func (d *pluginIndexedDBTransport) Close() error {
 	return d.inner.Close()
-}
-
-type pluginIndexedDBObjectStore struct {
-	inner   indexeddb.IndexedDB
-	primary string
-	legacy  string
-}
-
-func (s *pluginIndexedDBObjectStore) resolve(ctx context.Context) (indexeddb.ObjectStore, error) {
-	storeName, _, err := resolveActiveStoreName(ctx, s.inner, s.primary, s.legacy)
-	if err != nil {
-		return nil, err
-	}
-	return s.inner.ObjectStore(storeName), nil
-}
-
-func (s *pluginIndexedDBObjectStore) Get(ctx context.Context, id string) (indexeddb.Record, error) {
-	store, err := s.resolve(ctx)
-	if err != nil {
-		return nil, err
-	}
-	return store.Get(ctx, id)
-}
-
-func (s *pluginIndexedDBObjectStore) GetKey(ctx context.Context, id string) (string, error) {
-	store, err := s.resolve(ctx)
-	if err != nil {
-		return "", err
-	}
-	return store.GetKey(ctx, id)
-}
-
-func (s *pluginIndexedDBObjectStore) Add(ctx context.Context, record indexeddb.Record) error {
-	store, err := s.resolve(ctx)
-	if err != nil {
-		return err
-	}
-	return store.Add(ctx, record)
-}
-
-func (s *pluginIndexedDBObjectStore) Put(ctx context.Context, record indexeddb.Record) error {
-	store, err := s.resolve(ctx)
-	if err != nil {
-		return err
-	}
-	return store.Put(ctx, record)
-}
-
-func (s *pluginIndexedDBObjectStore) Delete(ctx context.Context, id string) error {
-	store, err := s.resolve(ctx)
-	if err != nil {
-		return err
-	}
-	return store.Delete(ctx, id)
-}
-
-func (s *pluginIndexedDBObjectStore) Clear(ctx context.Context) error {
-	store, err := s.resolve(ctx)
-	if err != nil {
-		return err
-	}
-	return store.Clear(ctx)
-}
-
-func (s *pluginIndexedDBObjectStore) GetAll(ctx context.Context, r *indexeddb.KeyRange) ([]indexeddb.Record, error) {
-	store, err := s.resolve(ctx)
-	if err != nil {
-		return nil, err
-	}
-	return store.GetAll(ctx, r)
-}
-
-func (s *pluginIndexedDBObjectStore) GetAllKeys(ctx context.Context, r *indexeddb.KeyRange) ([]string, error) {
-	store, err := s.resolve(ctx)
-	if err != nil {
-		return nil, err
-	}
-	return store.GetAllKeys(ctx, r)
-}
-
-func (s *pluginIndexedDBObjectStore) Count(ctx context.Context, r *indexeddb.KeyRange) (int64, error) {
-	store, err := s.resolve(ctx)
-	if err != nil {
-		return 0, err
-	}
-	return store.Count(ctx, r)
-}
-
-func (s *pluginIndexedDBObjectStore) DeleteRange(ctx context.Context, r indexeddb.KeyRange) (int64, error) {
-	store, err := s.resolve(ctx)
-	if err != nil {
-		return 0, err
-	}
-	return store.DeleteRange(ctx, r)
-}
-
-func (s *pluginIndexedDBObjectStore) Index(name string) indexeddb.Index {
-	return &pluginIndexedDBIndex{
-		store: s,
-		name:  name,
-	}
-}
-
-func (s *pluginIndexedDBObjectStore) OpenCursor(ctx context.Context, r *indexeddb.KeyRange, dir indexeddb.CursorDirection) (indexeddb.Cursor, error) {
-	store, err := s.resolve(ctx)
-	if err != nil {
-		return nil, err
-	}
-	return store.OpenCursor(ctx, r, dir)
-}
-
-func (s *pluginIndexedDBObjectStore) OpenKeyCursor(ctx context.Context, r *indexeddb.KeyRange, dir indexeddb.CursorDirection) (indexeddb.Cursor, error) {
-	store, err := s.resolve(ctx)
-	if err != nil {
-		return nil, err
-	}
-	return store.OpenKeyCursor(ctx, r, dir)
-}
-
-type pluginIndexedDBIndex struct {
-	store *pluginIndexedDBObjectStore
-	name  string
-}
-
-func (i *pluginIndexedDBIndex) resolve(ctx context.Context) (indexeddb.Index, error) {
-	store, err := i.store.resolve(ctx)
-	if err != nil {
-		return nil, err
-	}
-	return store.Index(i.name), nil
-}
-
-func (i *pluginIndexedDBIndex) Get(ctx context.Context, values ...any) (indexeddb.Record, error) {
-	index, err := i.resolve(ctx)
-	if err != nil {
-		return nil, err
-	}
-	return index.Get(ctx, values...)
-}
-
-func (i *pluginIndexedDBIndex) GetKey(ctx context.Context, values ...any) (string, error) {
-	index, err := i.resolve(ctx)
-	if err != nil {
-		return "", err
-	}
-	return index.GetKey(ctx, values...)
-}
-
-func (i *pluginIndexedDBIndex) GetAll(ctx context.Context, r *indexeddb.KeyRange, values ...any) ([]indexeddb.Record, error) {
-	index, err := i.resolve(ctx)
-	if err != nil {
-		return nil, err
-	}
-	return index.GetAll(ctx, r, values...)
-}
-
-func (i *pluginIndexedDBIndex) GetAllKeys(ctx context.Context, r *indexeddb.KeyRange, values ...any) ([]string, error) {
-	index, err := i.resolve(ctx)
-	if err != nil {
-		return nil, err
-	}
-	return index.GetAllKeys(ctx, r, values...)
-}
-
-func (i *pluginIndexedDBIndex) Count(ctx context.Context, r *indexeddb.KeyRange, values ...any) (int64, error) {
-	index, err := i.resolve(ctx)
-	if err != nil {
-		return 0, err
-	}
-	return index.Count(ctx, r, values...)
-}
-
-func (i *pluginIndexedDBIndex) Delete(ctx context.Context, values ...any) (int64, error) {
-	index, err := i.resolve(ctx)
-	if err != nil {
-		return 0, err
-	}
-	return index.Delete(ctx, values...)
-}
-
-func (i *pluginIndexedDBIndex) OpenCursor(ctx context.Context, r *indexeddb.KeyRange, dir indexeddb.CursorDirection, values ...any) (indexeddb.Cursor, error) {
-	index, err := i.resolve(ctx)
-	if err != nil {
-		return nil, err
-	}
-	return index.OpenCursor(ctx, r, dir, values...)
-}
-
-func (i *pluginIndexedDBIndex) OpenKeyCursor(ctx context.Context, r *indexeddb.KeyRange, dir indexeddb.CursorDirection, values ...any) (indexeddb.Cursor, error) {
-	index, err := i.resolve(ctx)
-	if err != nil {
-		return nil, err
-	}
-	return index.OpenKeyCursor(ctx, r, dir, values...)
-}
-
-func resolveActiveStoreName(ctx context.Context, db indexeddb.IndexedDB, primary, legacy string) (string, bool, error) {
-	if exists, err := storeExists(ctx, db, primary); err != nil {
-		return "", false, err
-	} else if exists {
-		return primary, true, nil
-	}
-	if legacy != "" && legacy != primary {
-		if exists, err := storeExists(ctx, db, legacy); err != nil {
-			return "", false, err
-		} else if exists {
-			return legacy, true, nil
-		}
-	}
-	return primary, false, nil
-}
-
-func storeExists(ctx context.Context, db indexeddb.IndexedDB, storeName string) (bool, error) {
-	if storeName == "" {
-		return false, nil
-	}
-	type objectStoreExistenceChecker interface {
-		HasObjectStore(name string) bool
-	}
-	if checker, ok := db.(objectStoreExistenceChecker); ok {
-		return checker.HasObjectStore(storeName), nil
-	}
-	_, err := db.ObjectStore(storeName).Count(ctx, nil)
-	switch {
-	case err == nil:
-		return true, nil
-	case errors.Is(err, indexeddb.ErrNotFound):
-		return false, nil
-	default:
-		return false, err
-	}
 }
 
 type missingObjectStore struct{}

--- a/gestaltd/internal/bootstrap/provider_build.go
+++ b/gestaltd/internal/bootstrap/provider_build.go
@@ -592,10 +592,9 @@ func buildPluginScopedIndexedDB(pluginName string, binding config.PluginIndexedD
 		return nil, fmt.Errorf("indexeddb %q: %w", binding.Name, err)
 	}
 	ds = newPluginIndexedDBTransport(ds, pluginIndexedDBTransportOptions{
-		StorePrefix:       transportPrefix,
-		LegacyStorePrefix: legacyPluginIndexedDBPrefix(pluginName),
-		AllowedStores:     binding.ObjectStores,
-		DeniedStores:      deniedStores,
+		StorePrefix:   transportPrefix,
+		AllowedStores: binding.ObjectStores,
+		DeniedStores:  deniedStores,
 	})
 	return metricutil.InstrumentIndexedDB(ds, binding.Name), nil
 }
@@ -614,11 +613,9 @@ func newPluginScopedIndexedDBDef(entry *config.ProviderEntry, pluginName, schema
 
 	transportPrefix := ""
 	if pluginIndexedDBUsesScopedProviderConfig(entry, cfg) {
+		delete(cfg, "legacy_table_prefix")
 		delete(cfg, "legacy_prefix")
 		delete(cfg, "namespace")
-		if legacyPrefix := legacyPluginIndexedDBPrefix(pluginName); legacyPrefix != "" {
-			cfg["legacy_table_prefix"] = legacyPrefix
-		}
 		if isSQLiteIndexedDBConfig(cfg) {
 			delete(cfg, "schema")
 			cfg["table_prefix"] = schema + "_"
@@ -665,14 +662,6 @@ func isRelationalIndexedDBEntry(entry *config.ProviderEntry) bool {
 			strings.HasSuffix(path, "/relationaldb/manifest.yaml")
 	}
 	return false
-}
-
-func legacyPluginIndexedDBPrefix(pluginName string) string {
-	pluginName = strings.TrimSpace(pluginName)
-	if pluginName == "" {
-		return ""
-	}
-	return "plugin_" + pluginName + "_"
 }
 
 func isSQLiteIndexedDBConfig(cfg map[string]any) bool {

--- a/gestaltd/internal/bootstrap/provider_build.go
+++ b/gestaltd/internal/bootstrap/provider_build.go
@@ -548,7 +548,7 @@ func buildPluginIndexedDBHostServices(pluginName string, entry *config.ProviderE
 		if len(binding.ObjectStores) == 0 && len(reservedStores) > 0 {
 			deniedStores = reservedStores
 		}
-		ds, err := buildPluginScopedIndexedDB(pluginName, binding, effectiveSchema, deniedStores, deps)
+		ds, err := buildPluginScopedIndexedDB(binding, effectiveSchema, deniedStores, deps)
 		if err != nil {
 			_ = closeIndexedDBs(boundStores...)
 			return nil, nil, err
@@ -578,12 +578,12 @@ func buildPluginIndexedDBHostServices(pluginName string, entry *config.ProviderE
 	}, nil
 }
 
-func buildPluginScopedIndexedDB(pluginName string, binding config.PluginIndexedDBBinding, schema string, deniedStores []string, deps Deps) (indexeddb.IndexedDB, error) {
+func buildPluginScopedIndexedDB(binding config.PluginIndexedDBBinding, schema string, deniedStores []string, deps Deps) (indexeddb.IndexedDB, error) {
 	def, ok := deps.IndexedDBDefs[binding.Name]
 	if !ok || def == nil {
 		return nil, fmt.Errorf("indexeddb %q is not available", binding.Name)
 	}
-	scopedDef, transportPrefix, err := newPluginScopedIndexedDBDef(def, pluginName, schema)
+	scopedDef, transportPrefix, err := newPluginScopedIndexedDBDef(def, schema)
 	if err != nil {
 		return nil, fmt.Errorf("indexeddb %q: %w", binding.Name, err)
 	}
@@ -599,7 +599,7 @@ func buildPluginScopedIndexedDB(pluginName string, binding config.PluginIndexedD
 	return metricutil.InstrumentIndexedDB(ds, binding.Name), nil
 }
 
-func newPluginScopedIndexedDBDef(entry *config.ProviderEntry, pluginName, schema string) (*config.ProviderEntry, string, error) {
+func newPluginScopedIndexedDBDef(entry *config.ProviderEntry, schema string) (*config.ProviderEntry, string, error) {
 	if entry == nil {
 		return nil, "", fmt.Errorf("datastore provider is required")
 	}


### PR DESCRIPTION
## Summary
- remove plugin IndexedDB transport fallback to legacy `plugin_<plugin>_<store>` stores
- stop emitting `legacy_table_prefix` for plugin-scoped relationaldb bindings
- keep stripping stale `legacy_table_prefix`, `legacy_prefix`, and `namespace` keys from rebased scoped configs
- remove the legacy transport fallback bootstrap test and keep the current routing coverage

## New Interfaces
Go:
```go
config.ProviderEntry{
    IndexedDBSchema: "roadmap",
    IndexedDBs: []config.PluginIndexedDBBinding{
        {Name: "state", ObjectStores: []string{"tasks"}},
    },
}
```

YAML:
```yaml
plugins:
  echoext:
    indexeddbSchema: roadmap
    indexeddb:
      - name: state
        objectStore:
          - tasks

providers:
  indexeddb:
    state:
      source: github.com/valon-technologies/gestalt-providers/indexeddb/relationaldb
      dsn: postgres://db.example.test/gestalt
      schema: roadmap
```

SQLite fallback:
```yaml
providers:
  indexeddb:
    state:
      source: github.com/valon-technologies/gestalt-providers/indexeddb/relationaldb
      dsn: file:/var/lib/gestalt/plugins.sqlite
      table_prefix: roadmap_
```

## Verification
- `go test ./internal/bootstrap ./internal/config`
- `git diff --check`

## Merge Order
- merge this PR before `valon-technologies/gestalt-providers` because current `main` still emits `legacy_table_prefix`
