### PR TITLE
Fix Helm docs for nested IndexedDB provider config

### DIFF
--- a/docs/content/deploy/helm.mdx
+++ b/docs/content/deploy/helm.mdx
@@ -40,7 +40,8 @@ config:
   server:
     baseUrl: "${GESTALT_BASE_URL}"
     encryptionKey: "${GESTALT_ENCRYPTION_KEY}"
-    indexeddb: main
+    providers:
+      indexeddb: main
   providers:
     auth:
       source:
@@ -119,7 +120,8 @@ config:
       port: 9090
     baseUrl: "${GESTALT_BASE_URL}"
     encryptionKey: "${GESTALT_ENCRYPTION_KEY}"
-    indexeddb: main
+    providers:
+      indexeddb: main
   providers:
     auth:
       source:


### PR DESCRIPTION
## Summary
- update Helm chart documentation examples to use `server.providers.indexeddb`
- remove the last stale `server.indexeddb` examples from the docs

## Why
The IndexedDB config shape moved under `server.providers`, but the Helm guide still showed the pre-nesting form in two examples. This PR makes the deployment docs match the current config interface.

## Example
Before:
```yaml
server:
  indexeddb: main
```

After:
```yaml
server:
  providers:
    indexeddb: main
```