### PR TITLE
Harden SDK internal-failure handling and CI permissions

### DIFF
--- a/.github/workflows/build-gestalt-cli.yml
+++ b/.github/workflows/build-gestalt-cli.yml
@@ -16,6 +16,9 @@ on:
 
   workflow_dispatch:
 
+permissions:
+  contents: read
+
 env:
   CARGO_TERM_COLOR: always
 

--- a/.github/workflows/build-gestaltd.yml
+++ b/.github/workflows/build-gestaltd.yml
@@ -8,6 +8,9 @@ on:
 
   workflow_dispatch:
 
+permissions:
+  contents: read
+
 jobs:
   lint:
     name: Go Lint & Vet

--- a/.github/workflows/build-python-sdk.yml
+++ b/.github/workflows/build-python-sdk.yml
@@ -16,6 +16,9 @@ on:
 
   workflow_dispatch:
 
+permissions:
+  contents: read
+
 jobs:
   python-sdk:
     name: Python SDK Checks

--- a/.github/workflows/build-rust-sdk.yml
+++ b/.github/workflows/build-rust-sdk.yml
@@ -16,6 +16,9 @@ on:
 
   workflow_dispatch:
 
+permissions:
+  contents: read
+
 env:
   CARGO_TERM_COLOR: always
 

--- a/.github/workflows/rust-build-matrix.yml
+++ b/.github/workflows/rust-build-matrix.yml
@@ -24,6 +24,9 @@ on:
         type: boolean
         default: true
 
+permissions:
+  contents: read
+
 env:
   CARGO_TERM_COLOR: always
 

--- a/gestaltd/internal/operator/lifecycle_test.go
+++ b/gestaltd/internal/operator/lifecycle_test.go
@@ -2358,8 +2358,8 @@ print(json.dumps({
 	if body["explode_status"] != float64(http.StatusInternalServerError) {
 		t.Fatalf("explode_status = %v, want %d", body["explode_status"], http.StatusInternalServerError)
 	}
-	if explodePayload["error"] != "boom" {
-		t.Fatalf("explode error = %v, want boom", explodePayload["error"])
+	if explodePayload["error"] != "internal error" {
+		t.Fatalf("explode error = %v, want internal error", explodePayload["error"])
 	}
 	listPayload, ok := body["list_body"].(map[string]any)
 	if !ok {

--- a/sdk/go/errors.go
+++ b/sdk/go/errors.go
@@ -17,6 +17,7 @@ const (
 	unknownOperationMessage   = "unknown operation"
 	routerNilMessage          = "router is nil"
 	nilResultMessage          = "provider returned nil result"
+	internalErrorMessage      = "internal error"
 	internalErrorBodyFallback = `{"error":"internal error"}`
 )
 
@@ -59,7 +60,7 @@ func operationResultFromError(err error) *OperationResult {
 		return nil
 	}
 	status := http.StatusInternalServerError
-	message := err.Error()
+	message := internalErrorMessage
 	var opErr *operationError
 	if errors.As(err, &opErr) {
 		if opErr.status != 0 {
@@ -69,19 +70,20 @@ func operationResultFromError(err error) *OperationResult {
 		if message == "" {
 			message = opErr.Error()
 		}
+	} else {
+		fmt.Fprintf(os.Stderr, "internal error in Gestalt operation: %v\n", err)
 	}
 	return operationResult(status, message)
 }
 
 func recoveredOperationResult(operation string, recovered any) *OperationResult {
-	message := fmt.Sprint(recovered)
 	if operation == "" {
 		fmt.Fprintf(os.Stderr, "panic in Gestalt operation: %v\n", recovered)
 	} else {
 		fmt.Fprintf(os.Stderr, "panic in Gestalt operation %q: %v\n", operation, recovered)
 	}
 	_, _ = os.Stderr.Write(debug.Stack())
-	return operationResult(http.StatusInternalServerError, message)
+	return operationResult(http.StatusInternalServerError, internalErrorMessage)
 }
 
 func protectedOperationResult(operation string, fn func() (*OperationResult, error)) (result *OperationResult) {

--- a/sdk/go/errors_test.go
+++ b/sdk/go/errors_test.go
@@ -1,0 +1,41 @@
+package gestalt
+
+import (
+	"errors"
+	"io"
+	"os"
+	"strings"
+	"testing"
+)
+
+func TestOperationResultFromErrorLogsSanitizedInternalErrors(t *testing.T) {
+	reader, writer, err := os.Pipe()
+	if err != nil {
+		t.Fatalf("os.Pipe: %v", err)
+	}
+	defer func() { _ = reader.Close() }()
+
+	oldStderr := os.Stderr
+	os.Stderr = writer
+	defer func() {
+		os.Stderr = oldStderr
+	}()
+
+	result := operationResultFromError(errors.New("boom"))
+
+	_ = writer.Close()
+	output, err := io.ReadAll(reader)
+	if err != nil {
+		t.Fatalf("io.ReadAll: %v", err)
+	}
+
+	if result.Status != 500 {
+		t.Fatalf("status = %d, want 500", result.Status)
+	}
+	if result.Body != `{"error":"internal error"}` {
+		t.Fatalf("body = %q, want %q", result.Body, `{"error":"internal error"}`)
+	}
+	if !strings.Contains(string(output), "internal error in Gestalt operation: boom") {
+		t.Fatalf("stderr = %q, want log containing %q", string(output), "internal error in Gestalt operation: boom")
+	}
+}

--- a/sdk/go/router_test.go
+++ b/sdk/go/router_test.go
@@ -216,8 +216,8 @@ func TestRouterOperationExecution(t *testing.T) {
 	if result.Status != http.StatusInternalServerError {
 		t.Fatalf("plain_error status = %d, want %d", result.Status, http.StatusInternalServerError)
 	}
-	if result.Body != `{"error":"boom"}` {
-		t.Fatalf("plain_error body = %q, want %q", result.Body, `{"error":"boom"}`)
+	if result.Body != `{"error":"internal error"}` {
+		t.Fatalf("plain_error body = %q, want %q", result.Body, `{"error":"internal error"}`)
 	}
 
 	var nilRouter *gestalt.Router[execProvider]

--- a/sdk/go/serve_test.go
+++ b/sdk/go/serve_test.go
@@ -294,7 +294,7 @@ func TestProviderServerExecute(t *testing.T) {
 			name:       "handler error",
 			router:     errorRouter,
 			wantStatus: http.StatusInternalServerError,
-			wantBody:   `{"error":"boom"}`,
+			wantBody:   `{"error":"internal error"}`,
 			request: &proto.ExecuteRequest{
 				Operation: "error_op",
 			},
@@ -303,7 +303,7 @@ func TestProviderServerExecute(t *testing.T) {
 			name:       "panic",
 			router:     panicRouter,
 			wantStatus: http.StatusInternalServerError,
-			wantBody:   `{"error":"boom"}`,
+			wantBody:   `{"error":"internal error"}`,
 			request: &proto.ExecuteRequest{
 				Operation: "panic_op",
 			},

--- a/sdk/python/gestalt/_operations.py
+++ b/sdk/python/gestalt/_operations.py
@@ -10,6 +10,8 @@ from typing import Any, Union, get_args, get_origin, get_type_hints
 from ._api import Error, Request, Response
 from ._serialization import json_body
 
+INTERNAL_ERROR_MESSAGE = "internal error"
+
 
 @dataclass(frozen=True, slots=True)
 class OperationDefinition:
@@ -94,7 +96,7 @@ def execute_operation(
         return _error_result(error.status, error.message)
     except Exception as error:
         traceback.print_exception(error)
-        return _error_result(HTTPStatus.INTERNAL_SERVER_ERROR, str(error))
+        return _error_result(HTTPStatus.INTERNAL_SERVER_ERROR, INTERNAL_ERROR_MESSAGE)
 
 
 def decode_input(input_type: Any, params: dict[str, Any]) -> Any:

--- a/sdk/python/gestalt/_runtime.py
+++ b/sdk/python/gestalt/_runtime.py
@@ -20,6 +20,7 @@ from ._api import Access, Credential, Request, Subject
 from ._bootstrap import parse_plugin_target, read_bundled_plugin_config
 from ._cache import CacheEntry
 from ._catalog import catalog_to_proto
+from ._operations import INTERNAL_ERROR_MESSAGE
 from ._plugin import Plugin, _module_plugin
 from ._providers import (
     AuthProvider,
@@ -405,7 +406,7 @@ def _provider_servicer(*, plugin: Plugin) -> Any:
             except Exception as error:
                 traceback.print_exception(error)
                 status = HTTPStatus.INTERNAL_SERVER_ERROR
-                body = json_body({"error": str(error)})
+                body = json_body({"error": INTERNAL_ERROR_MESSAGE})
                 return plugin_pb2.OperationResult(status=status, body=body)
             return plugin_pb2.OperationResult(status=result.status, body=result.body)
 

--- a/sdk/python/tests/test_plugin.py
+++ b/sdk/python/tests/test_plugin.py
@@ -152,7 +152,7 @@ class PluginOperationTests(unittest.TestCase):
 
         result = plugin.execute("broken", {}, Request())
         self.assertEqual(result.status, 500)
-        self.assertIn("something broke", json.loads(result.body)["error"])
+        self.assertEqual(json.loads(result.body), {"error": "internal error"})
 
         result = plugin.execute("missing", {}, Request())
         self.assertEqual(result.status, 404)

--- a/sdk/python/tests/test_runtime.py
+++ b/sdk/python/tests/test_runtime.py
@@ -316,6 +316,22 @@ class MainEntrypointTests(unittest.TestCase):
         self.assertEqual(catalog.operations[0].method, "POST")
         self.assertEqual(list(catalog.operations[0].allowed_roles), ["viewer", "admin"])
 
+    def test_provider_servicer_sanitizes_unhandled_execute_exceptions(self) -> None:
+        plugin = Plugin("source-name")
+
+        @plugin.operation
+        def broken() -> None:
+            raise RuntimeError("sensitive details")
+
+        servicer = _runtime._provider_servicer(plugin=plugin)
+        execute_response = servicer.Execute(
+            plugin_pb2.ExecuteRequest(operation="broken"),
+            mock.Mock(),
+        )
+
+        self.assertEqual(execute_response.status, 500)
+        self.assertEqual(json.loads(execute_response.body), {"error": "internal error"})
+
     def test_provider_servicer_rejects_missing_session_catalog_support(self) -> None:
         plugin = Plugin("source-name")
         servicer = _runtime._provider_servicer(plugin=plugin)

--- a/sdk/rust/src/error.rs
+++ b/sdk/rust/src/error.rs
@@ -3,12 +3,14 @@
 pub struct Error {
     status: Option<u16>,
     message: String,
+    expose_message: bool,
 }
 
 pub(crate) const HTTP_BAD_REQUEST: u16 = 400;
 pub(crate) const HTTP_NOT_FOUND: u16 = 404;
 pub(crate) const HTTP_INTERNAL_SERVER_ERROR: u16 = 500;
 pub(crate) const HTTP_NOT_IMPLEMENTED: u16 = 501;
+pub(crate) const INTERNAL_ERROR_MESSAGE: &str = "internal error";
 
 pub type Result<T> = std::result::Result<T, Error>;
 
@@ -17,6 +19,7 @@ impl Error {
         Self {
             status: None,
             message: message.into(),
+            expose_message: true,
         }
     }
 
@@ -24,6 +27,7 @@ impl Error {
         Self {
             status: Some(status),
             message: message.into(),
+            expose_message: true,
         }
     }
 
@@ -50,22 +54,34 @@ impl Error {
     pub fn message(&self) -> &str {
         &self.message
     }
+
+    pub(crate) fn expose_message(&self) -> bool {
+        self.expose_message
+    }
+
+    pub(crate) fn hidden_internal(message: impl Into<String>) -> Self {
+        Self {
+            status: Some(HTTP_INTERNAL_SERVER_ERROR),
+            message: message.into(),
+            expose_message: false,
+        }
+    }
 }
 
 impl From<serde_json::Error> for Error {
     fn from(value: serde_json::Error) -> Self {
-        Self::internal(value.to_string())
+        Self::hidden_internal(value.to_string())
     }
 }
 
 impl From<std::io::Error> for Error {
     fn from(value: std::io::Error) -> Self {
-        Self::internal(value.to_string())
+        Self::hidden_internal(value.to_string())
     }
 }
 
 impl From<tonic::transport::Error> for Error {
     fn from(value: tonic::transport::Error) -> Self {
-        Self::internal(value.to_string())
+        Self::hidden_internal(value.to_string())
     }
 }

--- a/sdk/rust/src/provider_server.rs
+++ b/sdk/rust/src/provider_server.rs
@@ -7,13 +7,14 @@ use tonic::{Request as GrpcRequest, Response as GrpcResponse, Status};
 use crate::api::{Access, Credential, Request, Response, Subject};
 use crate::catalog::object_map;
 use crate::env::CURRENT_PROTOCOL_VERSION;
-use crate::error::Error;
+use crate::error::{Error, HTTP_INTERNAL_SERVER_ERROR, INTERNAL_ERROR_MESSAGE};
 use crate::generated::v1::integration_provider_server::IntegrationProvider;
 use crate::generated::v1::{
     ExecuteRequest, GetSessionCatalogRequest, GetSessionCatalogResponse,
     OperationResult as ProtoOperationResult, PostConnectRequest, PostConnectResponse,
     ProviderMetadata, StartProviderRequest, StartProviderResponse,
 };
+use crate::rpc_status::rpc_status;
 use crate::{Provider, Router};
 
 #[derive(Clone)]
@@ -33,12 +34,20 @@ impl OperationResult {
         let status = response.status.unwrap_or(200);
         match serde_json::to_string(&response.body) {
             Ok(body) => Self { status, body },
-            Err(error) => Self::error(500, error.to_string()),
+            Err(error) => {
+                eprintln!("internal error in Gestalt operation response: {error}");
+                Self::error(HTTP_INTERNAL_SERVER_ERROR, INTERNAL_ERROR_MESSAGE)
+            }
         }
     }
 
     pub fn from_error(error: Error) -> Self {
-        Self::error(error.status().unwrap_or(500), error.message().to_owned())
+        let status = error.status().unwrap_or(HTTP_INTERNAL_SERVER_ERROR);
+        if !error.expose_message() {
+            eprintln!("internal error in Gestalt operation: {}", error.message());
+            return Self::error(HTTP_INTERNAL_SERVER_ERROR, INTERNAL_ERROR_MESSAGE);
+        }
+        Self::error(status, error.message().to_owned())
     }
 
     pub fn error(status: u16, message: impl Into<String>) -> Self {
@@ -80,7 +89,7 @@ where
         self.provider
             .configure(&request.name, object_map(request.config))
             .await
-            .map_err(|error| Status::unknown(format!("configure provider: {}", error.message())))?;
+            .map_err(|error| rpc_status("configure provider", error))?;
 
         Ok(GrpcResponse::new(StartProviderResponse {
             protocol_version: CURRENT_PROTOCOL_VERSION,
@@ -136,7 +145,7 @@ where
             .provider
             .catalog_for_request(&request)
             .await
-            .map_err(|error| Status::unknown(format!("session catalog: {}", error.message())))?;
+            .map_err(|error| rpc_status("session catalog", error))?;
 
         Ok(GrpcResponse::new(GetSessionCatalogResponse { catalog }))
     }

--- a/sdk/rust/src/router.rs
+++ b/sdk/rust/src/router.rs
@@ -12,7 +12,7 @@ use serde_json::Value;
 
 use crate::api::{IntoResponse, Request};
 use crate::catalog::{Catalog, CatalogOperation, schema_json, schema_parameters};
-use crate::error::{Error, Result};
+use crate::error::{Error, INTERNAL_ERROR_MESSAGE, Result};
 use crate::provider_server::OperationResult;
 
 #[derive(Clone, Debug)]
@@ -253,18 +253,21 @@ fn is_empty_object(value: &Value) -> bool {
 
 fn join_error_message(error: tokio::task::JoinError) -> String {
     if error.is_panic() {
-        return panic_message(error.try_into_panic().expect("panic payload"));
+        let payload = error.try_into_panic().expect("panic payload");
+        log_panic_payload(payload);
+    } else {
+        eprintln!("internal error in Gestalt operation task: {error}");
     }
-    error.to_string()
+    INTERNAL_ERROR_MESSAGE.to_owned()
 }
 
-fn panic_message(payload: Box<dyn Any + Send + 'static>) -> String {
+fn log_panic_payload(payload: Box<dyn Any + Send + 'static>) {
     if let Some(text) = payload.downcast_ref::<&'static str>() {
-        (*text).to_owned()
+        eprintln!("panic in Gestalt operation: {}", text);
     } else if let Some(text) = payload.downcast_ref::<String>() {
-        text.clone()
+        eprintln!("panic in Gestalt operation: {}", text);
     } else {
-        "panic in Gestalt operation".to_owned()
+        eprintln!("panic in Gestalt operation");
     }
 }
 

--- a/sdk/rust/src/rpc_status.rs
+++ b/sdk/rust/src/rpc_status.rs
@@ -1,12 +1,43 @@
 use tonic::Status;
 
 use crate::Error;
+use crate::error::INTERNAL_ERROR_MESSAGE;
+
+pub(crate) fn rpc_error_message(operation: &str, error: &Error) -> String {
+    if !error.expose_message() {
+        eprintln!("internal error in Gestalt {operation}: {}", error.message());
+        return INTERNAL_ERROR_MESSAGE.to_owned();
+    }
+    error.message().to_owned()
+}
 
 pub(crate) fn rpc_status(operation: &str, error: Error) -> Status {
+    let message = rpc_error_message(operation, &error);
     match error.status() {
-        Some(400) => Status::invalid_argument(error.message().to_owned()),
-        Some(404) => Status::not_found(error.message().to_owned()),
-        Some(501) => Status::unimplemented(error.message().to_owned()),
-        _ => Status::unknown(format!("{operation}: {}", error.message())),
+        Some(400) => Status::invalid_argument(message),
+        Some(404) => Status::not_found(message),
+        Some(501) => Status::unimplemented(message),
+        _ => Status::unknown(format!("{operation}: {message}")),
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use tonic::Code;
+
+    use super::*;
+
+    #[test]
+    fn rpc_status_sanitizes_hidden_internal_errors() {
+        let status = rpc_status("get cache entry", Error::hidden_internal("disk exploded"));
+        assert_eq!(status.code(), Code::Unknown);
+        assert_eq!(status.message(), "get cache entry: internal error");
+    }
+
+    #[test]
+    fn rpc_status_preserves_explicit_errors() {
+        let status = rpc_status("get cache entry", Error::bad_request("bad key"));
+        assert_eq!(status.code(), Code::InvalidArgument);
+        assert_eq!(status.message(), "bad key");
     }
 }

--- a/sdk/rust/src/runtime_server.rs
+++ b/sdk/rust/src/runtime_server.rs
@@ -12,6 +12,7 @@ use crate::generated::v1::{
     ConfigureProviderRequest, ConfigureProviderResponse, HealthCheckResponse, ProviderIdentity,
     ProviderKind,
 };
+use crate::rpc_status::{rpc_error_message, rpc_status};
 use crate::secrets::SecretsProvider;
 use crate::{CURRENT_PROTOCOL_VERSION, Provider, S3Provider};
 
@@ -178,7 +179,7 @@ impl ProviderLifecycle for RuntimeServer {
         self.provider
             .configure(&request.name, config)
             .await
-            .map_err(|error| Status::unknown(format!("configure provider: {}", error.message())))?;
+            .map_err(|error| rpc_status("configure provider", error))?;
         Ok(GrpcResponse::new(ConfigureProviderResponse {
             protocol_version: CURRENT_PROTOCOL_VERSION,
         }))
@@ -195,8 +196,66 @@ impl ProviderLifecycle for RuntimeServer {
             })),
             Err(error) => Ok(GrpcResponse::new(HealthCheckResponse {
                 ready: false,
-                message: error.message().to_owned(),
+                message: rpc_error_message("health check", &error),
             })),
         }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use std::sync::Arc;
+
+    use tonic::Code;
+    use tonic::Request as GrpcRequest;
+
+    use super::*;
+    use crate::error::INTERNAL_ERROR_MESSAGE;
+
+    #[derive(Default)]
+    struct HiddenRuntimeProvider;
+
+    #[tonic::async_trait]
+    impl Provider for HiddenRuntimeProvider {
+        async fn configure(
+            &self,
+            _name: &str,
+            _config: serde_json::Map<String, serde_json::Value>,
+        ) -> Result<()> {
+            Err(std::io::Error::other("disk exploded").into())
+        }
+
+        async fn health_check(&self) -> Result<()> {
+            Err(std::io::Error::other("health failed").into())
+        }
+    }
+
+    #[tokio::test]
+    async fn configure_provider_sanitizes_hidden_internal_errors() {
+        let server = RuntimeServer::for_provider(Arc::new(HiddenRuntimeProvider));
+
+        let error = server
+            .configure_provider(GrpcRequest::new(ConfigureProviderRequest {
+                name: "broken".to_owned(),
+                config: None,
+                protocol_version: CURRENT_PROTOCOL_VERSION,
+            }))
+            .await
+            .expect_err("configure provider should fail");
+        assert_eq!(error.code(), Code::Unknown);
+        assert_eq!(error.message(), "configure provider: internal error");
+    }
+
+    #[tokio::test]
+    async fn health_check_sanitizes_hidden_internal_errors() {
+        let server = RuntimeServer::for_provider(Arc::new(HiddenRuntimeProvider));
+
+        let response = server
+            .health_check(GrpcRequest::new(()))
+            .await
+            .expect("health check response")
+            .into_inner();
+        assert!(!response.ready);
+        assert_eq!(response.message, INTERNAL_ERROR_MESSAGE);
     }
 }

--- a/sdk/rust/tests/router.rs
+++ b/sdk/rust/tests/router.rs
@@ -150,12 +150,61 @@ async fn fail(
     Err(gestalt::Error::internal("boom"))
 }
 
+async fn implicit_internal(
+    _provider: Arc<ErrorTestProvider>,
+    _input: EmptyInput,
+    _request: gestalt::Request,
+) -> gestalt::Result<gestalt::Response<GreetOutput>> {
+    Err(std::io::Error::other("disk exploded").into())
+}
+
+async fn not_found(
+    _provider: Arc<ErrorTestProvider>,
+    _input: EmptyInput,
+    _request: gestalt::Request,
+) -> gestalt::Result<gestalt::Response<GreetOutput>> {
+    Err(gestalt::Error::not_found("record not found"))
+}
+
+async fn explicit_500(
+    _provider: Arc<ErrorTestProvider>,
+    _input: EmptyInput,
+    _request: gestalt::Request,
+) -> gestalt::Result<gestalt::Response<GreetOutput>> {
+    Err(gestalt::Error::with_status(500, "service unavailable"))
+}
+
 async fn panic_op(
     _provider: Arc<ErrorTestProvider>,
     _input: EmptyInput,
     _request: gestalt::Request,
 ) -> gestalt::Result<gestalt::Response<GreetOutput>> {
     panic!("boom")
+}
+
+#[derive(Default)]
+struct HiddenLifecycleProvider;
+
+#[async_trait]
+impl gestalt::Provider for HiddenLifecycleProvider {
+    async fn configure(
+        &self,
+        _name: &str,
+        _config: JsonMap<String, JsonValue>,
+    ) -> gestalt::Result<()> {
+        Err(std::io::Error::other("disk exploded").into())
+    }
+
+    fn supports_session_catalog(&self) -> bool {
+        true
+    }
+
+    async fn catalog_for_request(
+        &self,
+        _request: &gestalt::Request,
+    ) -> gestalt::Result<Option<gestalt::Catalog>> {
+        Err(std::io::Error::other("catalog exploded").into())
+    }
 }
 
 fn error_test_router() -> gestalt::Result<gestalt::Router<ErrorTestProvider>> {
@@ -170,6 +219,18 @@ fn error_test_router() -> gestalt::Result<gestalt::Router<ErrorTestProvider>> {
         .register(
             gestalt::Operation::<EmptyInput, GreetOutput>::new("error"),
             fail,
+        )?
+        .register(
+            gestalt::Operation::<EmptyInput, GreetOutput>::new("implicit_error"),
+            implicit_internal,
+        )?
+        .register(
+            gestalt::Operation::<EmptyInput, GreetOutput>::new("not_found"),
+            not_found,
+        )?
+        .register(
+            gestalt::Operation::<EmptyInput, GreetOutput>::new("explicit_500"),
+            explicit_500,
         )?
         .register(
             gestalt::Operation::<EmptyInput, GreetOutput>::new("panic"),
@@ -255,6 +316,39 @@ async fn execute_handles_success_decode_errors_handler_errors_and_panics() {
     assert_eq!(handler_error.status, 500);
     assert_eq!(handler_error.body, r#"{"error":"boom"}"#);
 
+    let implicit_handler_error = server
+        .execute(GrpcRequest::new(ExecuteRequest {
+            operation: "implicit_error".to_owned(),
+            ..ExecuteRequest::default()
+        }))
+        .await
+        .expect("execute implicit_error")
+        .into_inner();
+    assert_eq!(implicit_handler_error.status, 500);
+    assert_eq!(implicit_handler_error.body, r#"{"error":"internal error"}"#);
+
+    let not_found = server
+        .execute(GrpcRequest::new(ExecuteRequest {
+            operation: "not_found".to_owned(),
+            ..ExecuteRequest::default()
+        }))
+        .await
+        .expect("execute not_found")
+        .into_inner();
+    assert_eq!(not_found.status, 404);
+    assert_eq!(not_found.body, r#"{"error":"record not found"}"#);
+
+    let explicit_500 = server
+        .execute(GrpcRequest::new(ExecuteRequest {
+            operation: "explicit_500".to_owned(),
+            ..ExecuteRequest::default()
+        }))
+        .await
+        .expect("execute explicit_500")
+        .into_inner();
+    assert_eq!(explicit_500.status, 500);
+    assert_eq!(explicit_500.body, r#"{"error":"service unavailable"}"#);
+
     let panic = server
         .execute(GrpcRequest::new(ExecuteRequest {
             operation: "panic".to_owned(),
@@ -264,5 +358,36 @@ async fn execute_handles_success_decode_errors_handler_errors_and_panics() {
         .expect("execute panic")
         .into_inner();
     assert_eq!(panic.status, 500);
-    assert_eq!(panic.body, r#"{"error":"boom"}"#);
+    assert_eq!(panic.body, r#"{"error":"internal error"}"#);
+}
+
+#[tokio::test]
+async fn lifecycle_rpcs_sanitize_hidden_internal_errors() {
+    let server = gestalt::ProviderServer::new(
+        Arc::new(HiddenLifecycleProvider),
+        gestalt::Router::<HiddenLifecycleProvider>::new(),
+    );
+
+    let configure_error = server
+        .start_provider(GrpcRequest::new(StartProviderRequest {
+            name: "broken".to_owned(),
+            config: None,
+            protocol_version: gestalt::CURRENT_PROTOCOL_VERSION,
+        }))
+        .await
+        .expect_err("start provider should fail");
+    assert_eq!(configure_error.code(), tonic::Code::Unknown);
+    assert_eq!(
+        configure_error.message(),
+        "configure provider: internal error"
+    );
+
+    let catalog_error = server
+        .get_session_catalog(GrpcRequest::new(
+            gestalt::proto::v1::GetSessionCatalogRequest::default(),
+        ))
+        .await
+        .expect_err("get session catalog should fail");
+    assert_eq!(catalog_error.code(), tonic::Code::Unknown);
+    assert_eq!(catalog_error.message(), "session catalog: internal error");
 }


### PR DESCRIPTION
## Summary
- sanitize unhandled SDK failures so raw panic and exception text is no longer returned to callers
- keep explicit caller-facing errors unchanged, including explicit Rust `500` errors
- add explicit read-only `contents` permissions to the build workflows
- align the operator lifecycle test with the sanitized Python error contract

Note: the Homebrew/private-release change was removed from this PR because `valon-technologies/gestalt` is still private as of April 15, 2026, so anonymous release URLs would break tap installs.

## Old vs New Internal-Failure Behavior
Go handler returning a plain internal error:

```go
fmt.Println("about to explode")
return gestalt.Response[any]{}, fmt.Errorf("boom")
```

- old stdout/stderr: `about to explode`
- old caller response: `{"error":"boom"}`
- new stdout/stderr: `about to explode`
- new caller response: `{"error":"internal error"}`

Go handler panicking:

```go
fmt.Println("about to panic")
panic("boom")
```

- old caller response: `{"error":"boom"}`
- new caller response: `{"error":"internal error"}`
- stderr still logs the real failure, for example:

```text
panic in Gestalt operation "panic_op": boom
<stack trace>
```

Python source-plugin operation:

```python
print("about to explode")
raise RuntimeError("boom")
```

- old stdout: `about to explode`
- old caller response: `{"error":"boom"}`
- new stdout: `about to explode`
- new caller response: `{"error":"internal error"}`
- stderr still shows the traceback

Explicit caller-facing errors still pass through unchanged:

```go
return gestalt.Response[any]{}, gestalt.Error(http.StatusBadRequest, "invalid input")
```

- old caller response: `{"error":"invalid input"}`
- new caller response: `{"error":"invalid input"}`

The same rule now holds in Rust for explicit `500` errors such as `Error::internal("boom")`; only implicit internal failures sourced from panics and runtime/serialization/transport errors are sanitized.

## Go Interfaces
These remain the same:

```go
type Provider interface {
    Configure(ctx context.Context, name string, config map[string]any) error
}

type Request struct {
    Token            string
    ConnectionParams map[string]string
    Subject          Subject
    Credential       Credential
    Access           Access
}

type Response[T any] struct {
    Status int
    Body   T
}

type Operation[In any, Out any] struct {
    ID           string
    Method       string
    Title        string
    Description  string
    AllowedRoles []string
    Tags         []string
    ReadOnly     bool
    Visible      *bool
}

func Register[P any, In any, Out any](
    op Operation[In, Out],
    handler func(*P, context.Context, In, Request) (Response[Out], error),
) Registration[P]
```

## Verification
- `go test ./...` in `gestaltd`
- `go test ./...` in `sdk/go`
- `cargo test` in `sdk/rust`
- `uv run python -m unittest discover -s tests` in `sdk/python`
