### PR TITLE
Refactor plugin IndexedDB config to one provider/db object

### DIFF
--- a/docs/content/custom-providers/indexeddb.mdx
+++ b/docs/content/custom-providers/indexeddb.mdx
@@ -230,15 +230,14 @@ You implement the [IndexedDB gRPC service](https://www.w3.org/TR/IndexedDB/#obje
 
 Plugins access the IndexedDB provider through the SDK. The host serves the IndexedDB interface over a gRPC socket, and the SDK wraps it into native types for each language.
 
-When a plugin binds a datastore through `plugins.<name>.indexeddb`, the host now rebuilds
-that provider with a plugin-scoped schema before exposing it over the SDK
-socket. Plugins still use plain store names like `tasks` or `snapshots`; the
-host applies isolation outside the plugin. For schema-capable backends, that
-means a plugin-specific schema. For SQLite-backed relationaldb
-bindings, the host falls back to `<indexeddbSchema>_` table prefixes. Other
-IndexedDB providers fall back to transport-level `<indexeddbSchema>_` store
-prefixes. Plugin bindings can also declare `objectStore` allowlists so the host rejects stores
-that were assigned to a different binding.
+When a plugin binds a datastore through `plugins.<name>.indexeddb`, the host
+rebuilds that provider with plugin-scoped storage before exposing it over the
+SDK socket. Plugins still use plain store names like `tasks` or `snapshots`;
+the host applies isolation outside the plugin. For schema-capable backends,
+that means a plugin-specific schema. For SQLite-backed relationaldb bindings,
+the host falls back to `<db>_` table prefixes. Other IndexedDB providers fall
+back to transport-level `<db>_` store prefixes. `plugins.<name>.indexeddb.objectStores`
+can also allowlist logical stores so the host rejects stores outside that set.
 
 <Tabs items={['Go', 'Python', 'Rust', 'TypeScript']}>
   <Tabs.Tab>
@@ -413,7 +412,7 @@ providers:
 
 `DATABASE_URL` is a connection string for your database. The RelationalDB provider accepts `postgres://`, `mysql://`, `sqlite://`, and `sqlserver://` prefixes.
 
-Object store names remain logical inside plugins. The host scopes plugin data by rebuilding schema-capable providers with a plugin-specific schema, or by applying a `<indexeddbSchema>_` prefix on backends without schema support.
+Object store names remain logical inside plugins. The host scopes plugin data by rebuilding schema-capable providers with a plugin-specific schema, or by applying a `<db>_` prefix on backends without schema support.
 
 ## What to read next
 

--- a/docs/content/providers/indexeddb.mdx
+++ b/docs/content/providers/indexeddb.mdx
@@ -10,14 +10,16 @@ contract can map cleanly to relational, document, or key-value backends.
 The active datastore is selected by `server.providers.indexeddb`, which points
 to one of the named entries under `providers.indexeddb`. Gestalt talks to that provider
 through the IndexedDB service contract while keeping plugin state isolated with
-plugin-scoped datastore instances. By default, a plugin binding uses the plugin
-name as its IndexedDB schema; `plugins.<name>.indexeddbSchema` can
-override that schema name. Plugin bindings can also declare `objectStore`
-allowlists so a store like `tasks` is only served through one configured
-binding. With the first-party RelationalDB provider, Postgres, MySQL, and SQL
-Server receive that value as `schema`, while SQLite falls back
-to `<schema>_` table prefixes because it has no schema support. Other IndexedDB
-providers fall back to `<schema>_` transport-level store prefixes.
+plugin-scoped datastore instances. Plugins may override that host selection
+with `plugins.<name>.indexeddb.provider`; otherwise they inherit the
+selected/default host IndexedDB. `plugins.<name>.indexeddb.db` defaults to the
+plugin key and controls the plugin-visible database name used for backend
+scoping. With the first-party RelationalDB provider, Postgres, MySQL, and SQL
+Server receive that value as `schema`, while SQLite falls back to `<db>_`
+table prefixes because it has no schema support. Other IndexedDB providers
+fall back to `<db>_` transport-level store prefixes. Plugins may also set
+`plugins.<name>.indexeddb.objectStores` to allowlist logical stores such as
+`tasks`.
 
 ## First-party IndexedDB providers
 

--- a/docs/content/reference/config-file.mdx
+++ b/docs/content/reference/config-file.mdx
@@ -460,11 +460,11 @@ plugins:
       openapi:
         baseUrl: https://api.github.com
     indexeddb:
-      - name: main
-        objectStore:
-          - tasks
-          - snapshots
-    indexeddbSchema: github_plugin
+      provider: main
+      db: github_plugin
+      objectStores:
+        - tasks
+        - snapshots
     connections:
       default:
         mode: user
@@ -490,8 +490,7 @@ plugins:
 | `surfaces` | Typed host-side overrides for manifest-declared surfaces, such as `surfaces.openapi.baseUrl` or `surfaces.graphql.url`. |
 | `connections` | Named connection declarations. See [connections](#connections) below. |
 | `allowedOperations` | Allowlist with optional `alias`, `description`, and `allowedRoles` overrides per operation. |
-| `indexeddb` | Optional list of plugin IndexedDB bindings. The scalar shorthand `- main` is still supported; the object form accepts `name` plus optional `objectStore` allowlists to pin logical stores to a binding. A given `objectStore` may appear in at most one binding; duplicates are rejected during config validation. When any binding declares `objectStore`, one additional binding may omit it and acts as the catch-all for unassigned stores. Each binding is rebuilt as a plugin-scoped IndexedDB instance before being served to the plugin. A single binding also populates the default IndexedDB SDK env var for compatibility. |
-| `indexeddbSchema` | Optional override for the plugin IndexedDB namespace. When omitted, Gestalt uses the plugin name. RelationalDB bindings pass this through as `schema` on Postgres, MySQL, and SQL Server, use `<indexeddbSchema>_` table prefixes on SQLite, and other IndexedDB backends fall back to `<indexeddbSchema>_` transport-level store prefixes. |
+| `indexeddb` | Optional plugin IndexedDB config. `indexeddb.provider` selects which named `providers.indexeddb` entry to expose to the plugin; when omitted, the plugin inherits the selected/default host IndexedDB. `indexeddb.db` overrides the plugin-visible database name and defaults to the plugin key. `indexeddb.objectStores` optionally allowlists the logical object stores the plugin may use. `indexeddb.disabled: true` opts out entirely. Plugins receive one IndexedDB SDK socket via `GESTALT_INDEXEDDB_SOCKET`. |
 
 ### `plugins.*.source`
 

--- a/gestaltd/internal/bootstrap/bootstrap.go
+++ b/gestaltd/internal/bootstrap/bootstrap.go
@@ -120,14 +120,15 @@ func (m providerMetadata) descriptionOr(v string) string {
 }
 
 type Deps struct {
-	EncryptionKey    []byte
-	BaseURL          string
-	SecretManager    core.SecretManager
-	Services         *coredata.Services
-	IndexedDBs       map[string]indexeddb.IndexedDB
-	IndexedDBDefs    map[string]*config.ProviderEntry
-	IndexedDBFactory IndexedDBFactory
-	Egress           EgressDeps
+	EncryptionKey         []byte
+	BaseURL               string
+	SecretManager         core.SecretManager
+	Services              *coredata.Services
+	SelectedIndexedDBName string
+	IndexedDBs            map[string]indexeddb.IndexedDB
+	IndexedDBDefs         map[string]*config.ProviderEntry
+	IndexedDBFactory      IndexedDBFactory
+	Egress                EgressDeps
 }
 
 type AuthFactory func(node yaml.Node, deps Deps) (core.AuthProvider, error)
@@ -358,6 +359,7 @@ func prepareCore(ctx context.Context, cfg *config.Config, factories *FactoryRegi
 	deps.Egress = newEgressDeps(cfg)
 	deps.Services = svc
 	deps.IndexedDBs = hostIndexedDBs
+	deps.SelectedIndexedDBName = selectedIndexedDBName
 	deps.IndexedDBDefs = cfg.Providers.IndexedDBs
 	deps.IndexedDBFactory = factories.IndexedDB
 

--- a/gestaltd/internal/bootstrap/executable_plugin_test.go
+++ b/gestaltd/internal/bootstrap/executable_plugin_test.go
@@ -787,7 +787,7 @@ func TestPluginProcessEnvIsolation(t *testing.T) {
 	}
 }
 
-func TestPluginIndexedDBBindingsExposeHostSocketEnv(t *testing.T) {
+func TestPluginIndexedDBExposeHostSocketEnv(t *testing.T) {
 	t.Parallel()
 
 	bin := buildEchoPluginBinary(t)
@@ -799,7 +799,7 @@ func TestPluginIndexedDBBindingsExposeHostSocketEnv(t *testing.T) {
 	})
 	manifest := newExecutableManifest("Echo", "Echoes back the input parameters")
 
-	makeConfig := func(bindings []config.PluginIndexedDBBinding) *config.Config {
+	makeConfig := func(indexedDB *config.PluginIndexedDBConfig) *config.Config {
 		return &config.Config{
 			Providers: config.ProvidersConfig{
 				Plugins: map[string]*config.ProviderEntry{
@@ -808,14 +808,14 @@ func TestPluginIndexedDBBindingsExposeHostSocketEnv(t *testing.T) {
 						Args:                 []string{"provider"},
 						ResolvedManifest:     manifest,
 						ResolvedManifestPath: filepath.Join(manifestRoot, "manifest.yaml"),
-						IndexedDBs:           bindings,
+						IndexedDB:            indexedDB,
 					},
 				},
 			},
 		}
 	}
 
-	indexedDBBindings := map[string]*config.ProviderEntry{
+	indexedDBDefs := map[string]*config.ProviderEntry{
 		"main": {
 			Config: mustNode(t, map[string]any{"dsn": "postgres://main.example.test/gestalt"}),
 		},
@@ -824,10 +824,11 @@ func TestPluginIndexedDBBindingsExposeHostSocketEnv(t *testing.T) {
 		},
 	}
 
-	checkEnv := func(t *testing.T, bindings []config.PluginIndexedDBBinding, envName string) bool {
+	checkEnv := func(t *testing.T, indexedDB *config.PluginIndexedDBConfig, envName string) bool {
 		t.Helper()
-		providers, _, err := buildProvidersStrict(context.Background(), makeConfig(bindings), NewFactoryRegistry(), Deps{
-			IndexedDBDefs: indexedDBBindings,
+		providers, _, err := buildProvidersStrict(context.Background(), makeConfig(indexedDB), NewFactoryRegistry(), Deps{
+			SelectedIndexedDBName: "main",
+			IndexedDBDefs:         indexedDBDefs,
 			IndexedDBFactory: func(yaml.Node) (indexeddb.IndexedDB, error) {
 				return &coretesting.StubIndexedDB{}, nil
 			},
@@ -855,27 +856,27 @@ func TestPluginIndexedDBBindingsExposeHostSocketEnv(t *testing.T) {
 		return env.Found && env.Value != ""
 	}
 
-	if got := checkEnv(t, nil, providerhost.DefaultIndexedDBSocketEnv); got {
-		t.Fatal("default IndexedDB env should not be set without plugin indexeddb bindings")
+	if got := checkEnv(t, nil, providerhost.DefaultIndexedDBSocketEnv); !got {
+		t.Fatal("default IndexedDB env should be set when plugin omits indexeddb and inherits the host selection")
 	}
-	if got := checkEnv(t, []config.PluginIndexedDBBinding{{Name: "main"}}, providerhost.DefaultIndexedDBSocketEnv); !got {
-		t.Fatal("default IndexedDB env should be set with a single plugin indexeddb binding")
+	if got := checkEnv(t, &config.PluginIndexedDBConfig{}, providerhost.DefaultIndexedDBSocketEnv); !got {
+		t.Fatal("default IndexedDB env should be set when plugin indexeddb is explicitly empty")
 	}
-	if got := checkEnv(t, []config.PluginIndexedDBBinding{{Name: "main"}}, providerhost.IndexedDBSocketEnv("main")); !got {
-		t.Fatal("named IndexedDB env should be set with a single plugin indexeddb binding")
+	if got := checkEnv(t, &config.PluginIndexedDBConfig{Provider: "archive"}, providerhost.DefaultIndexedDBSocketEnv); !got {
+		t.Fatal("default IndexedDB env should be set when plugin explicitly selects one indexeddb provider")
 	}
-	if got := checkEnv(t, []config.PluginIndexedDBBinding{{Name: "main"}, {Name: "archive"}}, providerhost.DefaultIndexedDBSocketEnv); got {
-		t.Fatal("default IndexedDB env should not be set with multiple plugin indexeddb bindings")
+	if got := checkEnv(t, nil, providerhost.IndexedDBSocketEnv("main")); got {
+		t.Fatal("named IndexedDB env should not be set for inherited plugin indexeddb access")
 	}
-	if got := checkEnv(t, []config.PluginIndexedDBBinding{{Name: "main"}, {Name: "archive"}}, providerhost.IndexedDBSocketEnv("main")); !got {
-		t.Fatal(`named IndexedDB env for "main" should be set with multiple plugin indexeddb bindings`)
+	if got := checkEnv(t, &config.PluginIndexedDBConfig{Provider: "archive"}, providerhost.IndexedDBSocketEnv("archive")); got {
+		t.Fatal("named IndexedDB env should not be set when plugins expose a single indexeddb socket")
 	}
-	if got := checkEnv(t, []config.PluginIndexedDBBinding{{Name: "main"}, {Name: "archive"}}, providerhost.IndexedDBSocketEnv("archive")); !got {
-		t.Fatal(`named IndexedDB env for "archive" should be set with multiple plugin indexeddb bindings`)
+	if got := checkEnv(t, &config.PluginIndexedDBConfig{Disabled: true}, providerhost.DefaultIndexedDBSocketEnv); got {
+		t.Fatal("default IndexedDB env should not be set when plugin indexeddb is disabled")
 	}
 }
 
-func TestPluginIndexedDBBindingsBuildScopedConfig(t *testing.T) {
+func TestPluginIndexedDBBuildScopedConfig(t *testing.T) {
 	t.Parallel()
 
 	bin := buildEchoPluginBinary(t)
@@ -891,31 +892,24 @@ func TestPluginIndexedDBBindingsBuildScopedConfig(t *testing.T) {
 		Config map[string]any `yaml:"config"`
 	}
 
-	makeConfig := func(schema string) *config.Config {
-		entry := &config.ProviderEntry{
-			Command:              bin,
-			Args:                 []string{"provider"},
-			ResolvedManifest:     manifest,
-			ResolvedManifestPath: filepath.Join(manifestRoot, "manifest.yaml"),
-			IndexedDBs: []config.PluginIndexedDBBinding{
-				{Name: "postgres"},
-				{Name: "sqlite"},
-				{Name: "local-postgres"},
-			},
-		}
-		if schema != "" {
-			entry.IndexedDBSchema = schema
-		}
+	makeConfig := func(indexedDB *config.PluginIndexedDBConfig, legacyDB string) *config.Config {
 		return &config.Config{
 			Providers: config.ProvidersConfig{
 				Plugins: map[string]*config.ProviderEntry{
-					"echoext": entry,
+					"echoext": {
+						Command:              bin,
+						Args:                 []string{"provider"},
+						ResolvedManifest:     manifest,
+						ResolvedManifestPath: filepath.Join(manifestRoot, "manifest.yaml"),
+						IndexedDB:            indexedDB,
+						IndexedDBSchema:      legacyDB,
+					},
 				},
 			},
 		}
 	}
 
-	bindingDefs := map[string]*config.ProviderEntry{
+	indexedDBDefs := map[string]*config.ProviderEntry{
 		"postgres": {
 			Source: config.ProviderSource{Ref: "github.com/valon-technologies/gestalt-providers/indexeddb/relationaldb"},
 			Config: mustNode(t, map[string]any{
@@ -952,11 +946,38 @@ func TestPluginIndexedDBBindingsBuildScopedConfig(t *testing.T) {
 
 	cases := []struct {
 		name       string
-		schema     string
-		wantSchema string
+		indexedDB  *config.PluginIndexedDBConfig
+		legacyDB   string
+		wantDSN    string
+		wantDB     string
+		wantSQLite bool
 	}{
-		{name: "defaults to plugin name", wantSchema: "echoext"},
-		{name: "uses plugin override", schema: "roadmap_state", wantSchema: "roadmap_state"},
+		{
+			name:      "defaults db to plugin name for postgres",
+			indexedDB: &config.PluginIndexedDBConfig{Provider: "postgres"},
+			wantDSN:   "postgres://db.example.test/gestalt",
+			wantDB:    "echoext",
+		},
+		{
+			name:      "uses db override for postgres",
+			indexedDB: &config.PluginIndexedDBConfig{Provider: "postgres", DB: "roadmap_state"},
+			wantDSN:   "postgres://db.example.test/gestalt",
+			wantDB:    "roadmap_state",
+		},
+		{
+			name:       "uses db override for sqlite table prefixes",
+			indexedDB:  &config.PluginIndexedDBConfig{Provider: "sqlite", DB: "roadmap_state"},
+			wantDSN:    "sqlite://plugin-state.db",
+			wantDB:     "roadmap_state",
+			wantSQLite: true,
+		},
+		{
+			name:      "accepts legacy indexeddbSchema alias",
+			indexedDB: &config.PluginIndexedDBConfig{Provider: "local-postgres"},
+			legacyDB:  "legacy_state",
+			wantDSN:   "postgres://local.example.test/gestalt",
+			wantDB:    "legacy_state",
+		},
 	}
 
 	for _, tc := range cases {
@@ -966,8 +987,9 @@ func TestPluginIndexedDBBindingsBuildScopedConfig(t *testing.T) {
 
 			var closeCount atomic.Int32
 			captured := make(map[string]capturedIndexedDBConfig)
-			providers, _, err := buildProvidersStrict(context.Background(), makeConfig(tc.schema), NewFactoryRegistry(), Deps{
-				IndexedDBDefs: bindingDefs,
+			providers, _, err := buildProvidersStrict(context.Background(), makeConfig(tc.indexedDB, tc.legacyDB), NewFactoryRegistry(), Deps{
+				SelectedIndexedDBName: "postgres",
+				IndexedDBDefs:         indexedDBDefs,
 				IndexedDBFactory: func(node yaml.Node) (indexeddb.IndexedDB, error) {
 					var decoded capturedIndexedDBConfig
 					if err := node.Decode(&decoded); err != nil {
@@ -990,84 +1012,52 @@ func TestPluginIndexedDBBindingsBuildScopedConfig(t *testing.T) {
 				}
 			})
 
-			if got := closeCount.Load(); got != 0 {
-				t.Fatalf("closeCount before provider shutdown = %d, want 0", got)
-			}
-
-			postgresCfg, ok := captured["postgres://db.example.test/gestalt"]
+			cfg, ok := captured[tc.wantDSN]
 			if !ok {
-				t.Fatal("missing captured postgres indexeddb config")
+				t.Fatalf("missing captured indexeddb config for %q", tc.wantDSN)
 			}
-			if got := postgresCfg.Config["schema"]; got != tc.wantSchema {
-				t.Fatalf("postgres schema = %#v, want %q", got, tc.wantSchema)
+			if tc.wantSQLite {
+				wantPrefix := tc.wantDB + "_"
+				if got := cfg.Config["table_prefix"]; got != wantPrefix {
+					t.Fatalf("sqlite table_prefix = %#v, want %q", got, wantPrefix)
+				}
+				if got := cfg.Config["prefix"]; got != wantPrefix {
+					t.Fatalf("sqlite prefix = %#v, want %q", got, wantPrefix)
+				}
+				if _, ok := cfg.Config["schema"]; ok {
+					t.Fatalf("sqlite schema should be removed, got %#v", cfg.Config["schema"])
+				}
+			} else {
+				if got := cfg.Config["schema"]; got != tc.wantDB {
+					t.Fatalf("schema = %#v, want %q", got, tc.wantDB)
+				}
+				if _, ok := cfg.Config["table_prefix"]; ok {
+					t.Fatalf("table_prefix should be removed, got %#v", cfg.Config["table_prefix"])
+				}
+				if _, ok := cfg.Config["prefix"]; ok {
+					t.Fatalf("prefix should be removed, got %#v", cfg.Config["prefix"])
+				}
 			}
-			if _, ok := postgresCfg.Config["namespace"]; ok {
-				t.Fatalf("postgres namespace should be removed, got %#v", postgresCfg.Config["namespace"])
+			if _, ok := cfg.Config["namespace"]; ok {
+				t.Fatalf("namespace should be removed, got %#v", cfg.Config["namespace"])
 			}
-			if _, ok := postgresCfg.Config["legacy_table_prefix"]; ok {
-				t.Fatalf("postgres legacy_table_prefix should be removed, got %#v", postgresCfg.Config["legacy_table_prefix"])
+			if _, ok := cfg.Config["legacy_table_prefix"]; ok {
+				t.Fatalf("legacy_table_prefix should be removed, got %#v", cfg.Config["legacy_table_prefix"])
 			}
-			if _, ok := postgresCfg.Config["legacy_prefix"]; ok {
-				t.Fatalf("postgres legacy_prefix should be removed, got %#v", postgresCfg.Config["legacy_prefix"])
-			}
-			if _, ok := postgresCfg.Config["table_prefix"]; ok {
-				t.Fatalf("postgres table_prefix should be removed, got %#v", postgresCfg.Config["table_prefix"])
-			}
-			if _, ok := postgresCfg.Config["prefix"]; ok {
-				t.Fatalf("postgres prefix should be removed, got %#v", postgresCfg.Config["prefix"])
-			}
-
-			localPostgresCfg, ok := captured["postgres://local.example.test/gestalt"]
-			if !ok {
-				t.Fatal("missing captured local postgres indexeddb config")
-			}
-			if got := localPostgresCfg.Config["schema"]; got != tc.wantSchema {
-				t.Fatalf("local postgres schema = %#v, want %q", got, tc.wantSchema)
-			}
-			if _, ok := localPostgresCfg.Config["namespace"]; ok {
-				t.Fatalf("local postgres namespace should be removed, got %#v", localPostgresCfg.Config["namespace"])
-			}
-			if _, ok := localPostgresCfg.Config["legacy_table_prefix"]; ok {
-				t.Fatalf("local postgres legacy_table_prefix should be removed, got %#v", localPostgresCfg.Config["legacy_table_prefix"])
-			}
-			if _, ok := localPostgresCfg.Config["legacy_prefix"]; ok {
-				t.Fatalf("local postgres legacy_prefix should be removed, got %#v", localPostgresCfg.Config["legacy_prefix"])
-			}
-
-			sqliteCfg, ok := captured["sqlite://plugin-state.db"]
-			if !ok {
-				t.Fatal("missing captured sqlite indexeddb config")
-			}
-			wantPrefix := tc.wantSchema + "_"
-			if got := sqliteCfg.Config["table_prefix"]; got != wantPrefix {
-				t.Fatalf("sqlite table_prefix = %#v, want %q", got, wantPrefix)
-			}
-			if got := sqliteCfg.Config["prefix"]; got != wantPrefix {
-				t.Fatalf("sqlite prefix = %#v, want %q", got, wantPrefix)
-			}
-			if _, ok := sqliteCfg.Config["schema"]; ok {
-				t.Fatalf("sqlite schema should be removed, got %#v", sqliteCfg.Config["schema"])
-			}
-			if _, ok := sqliteCfg.Config["namespace"]; ok {
-				t.Fatalf("sqlite namespace should be removed, got %#v", sqliteCfg.Config["namespace"])
-			}
-			if _, ok := sqliteCfg.Config["legacy_table_prefix"]; ok {
-				t.Fatalf("sqlite legacy_table_prefix should be removed, got %#v", sqliteCfg.Config["legacy_table_prefix"])
-			}
-			if _, ok := sqliteCfg.Config["legacy_prefix"]; ok {
-				t.Fatalf("sqlite legacy_prefix should be removed, got %#v", sqliteCfg.Config["legacy_prefix"])
+			if _, ok := cfg.Config["legacy_prefix"]; ok {
+				t.Fatalf("legacy_prefix should be removed, got %#v", cfg.Config["legacy_prefix"])
 			}
 
 			_ = CloseProviders(providers)
 			providers = nil
-			if got := closeCount.Load(); got != 3 {
-				t.Fatalf("closeCount after provider shutdown = %d, want 3", got)
+			if got := closeCount.Load(); got != 1 {
+				t.Fatalf("closeCount after provider shutdown = %d, want 1", got)
 			}
 		})
 	}
 }
 
-func TestPluginIndexedDBBindingsRouteObjectStoresAndTransportPrefix(t *testing.T) {
+func TestPluginIndexedDBRouteObjectStoresAndTransportPrefix(t *testing.T) {
 	t.Parallel()
 
 	bin := buildEchoPluginBinary(t)
@@ -1099,14 +1089,16 @@ func TestPluginIndexedDBBindingsRouteObjectStoresAndTransportPrefix(t *testing.T
 					Args:                 []string{"provider"},
 					ResolvedManifest:     manifest,
 					ResolvedManifestPath: filepath.Join(manifestRoot, "manifest.yaml"),
-					IndexedDBSchema:      "roadmap",
-					IndexedDBs: []config.PluginIndexedDBBinding{
-						{Name: "memory", ObjectStores: []string{"tasks"}},
+					IndexedDB: &config.PluginIndexedDBConfig{
+						Provider:     "memory",
+						DB:           "roadmap",
+						ObjectStores: []string{"tasks"},
 					},
 				},
 			},
 		},
 	}, NewFactoryRegistry(), Deps{
+		SelectedIndexedDBName: "memory",
 		IndexedDBDefs: map[string]*config.ProviderEntry{
 			"memory": {
 				Source: config.ProviderSource{Path: "./providers/datastore/memory"},
@@ -1168,7 +1160,7 @@ func TestPluginIndexedDBBindingsRouteObjectStoresAndTransportPrefix(t *testing.T
 	}
 }
 
-func TestPluginIndexedDBBindingsRouteExplicitAndCatchAllStores(t *testing.T) {
+func TestPluginIndexedDBProviderOverrideUsesExplicitHostIndexedDB(t *testing.T) {
 	t.Parallel()
 
 	bin := buildEchoPluginBinary(t)
@@ -1179,7 +1171,6 @@ func TestPluginIndexedDBBindingsRouteExplicitAndCatchAllStores(t *testing.T) {
 				ID:     "indexeddb_roundtrip",
 				Method: http.MethodPost,
 				Parameters: []catalog.CatalogParameter{
-					{Name: "binding", Type: "string"},
 					{Name: "store", Type: "string", Required: true},
 					{Name: "id", Type: "string", Required: true},
 					{Name: "value", Type: "string", Required: true},
@@ -1198,15 +1189,15 @@ func TestPluginIndexedDBBindingsRouteExplicitAndCatchAllStores(t *testing.T) {
 					Args:                 []string{"provider"},
 					ResolvedManifest:     manifest,
 					ResolvedManifestPath: filepath.Join(manifestRoot, "manifest.yaml"),
-					IndexedDBSchema:      "roadmap",
-					IndexedDBs: []config.PluginIndexedDBBinding{
-						{Name: "main", ObjectStores: []string{"tasks"}},
-						{Name: "archive"},
+					IndexedDB: &config.PluginIndexedDBConfig{
+						Provider: "archive",
+						DB:       "roadmap",
 					},
 				},
 			},
 		},
 	}, NewFactoryRegistry(), Deps{
+		SelectedIndexedDBName: "main",
 		IndexedDBDefs: map[string]*config.ProviderEntry{
 			"main": {
 				Source: config.ProviderSource{Path: "./providers/datastore/main"},
@@ -1240,46 +1231,29 @@ func TestPluginIndexedDBBindingsRouteExplicitAndCatchAllStores(t *testing.T) {
 		t.Fatalf("providers.Get: %v", err)
 	}
 
-	if _, err := prov.Execute(context.Background(), "indexeddb_roundtrip", map[string]any{
-		"binding": "main",
-		"store":   "tasks",
-		"id":      "task-1",
-		"value":   "ship-it",
-	}, ""); err != nil {
-		t.Fatalf("Execute main tasks roundtrip: %v", err)
+	result, err := prov.Execute(context.Background(), "indexeddb_roundtrip", map[string]any{
+		"store": "events",
+		"id":    "evt-1",
+		"value": "stored",
+	}, "")
+	if err != nil {
+		t.Fatalf("Execute indexeddb_roundtrip: %v", err)
 	}
-	if _, err := boundDBs["main"].ObjectStore("roadmap_tasks").Get(context.Background(), "task-1"); err != nil {
-		t.Fatalf("main binding should own tasks store: %v", err)
+	var record map[string]any
+	if err := json.Unmarshal([]byte(result.Body), &record); err != nil {
+		t.Fatalf("unmarshal record: %v", err)
 	}
-
-	if _, err := prov.Execute(context.Background(), "indexeddb_roundtrip", map[string]any{
-		"binding": "main",
-		"store":   "events",
-		"id":      "evt-main",
-		"value":   "blocked",
-	}, ""); err == nil {
-		t.Fatal("main binding should reject stores outside its explicit objectStore allowlist")
+	if got := record["value"]; got != "stored" {
+		t.Fatalf("record value = %#v, want %q", got, "stored")
 	}
-
-	if _, err := prov.Execute(context.Background(), "indexeddb_roundtrip", map[string]any{
-		"binding": "archive",
-		"store":   "events",
-		"id":      "evt-1",
-		"value":   "stored",
-	}, ""); err != nil {
-		t.Fatalf("Execute archive events roundtrip: %v", err)
+	if len(boundDBs) != 1 {
+		t.Fatalf("boundDBs = %d, want 1 explicit provider build", len(boundDBs))
+	}
+	if _, ok := boundDBs["main"]; ok {
+		t.Fatal("main indexeddb should not be rebuilt when plugin explicitly selects archive")
 	}
 	if _, err := boundDBs["archive"].ObjectStore("roadmap_events").Get(context.Background(), "evt-1"); err != nil {
-		t.Fatalf("archive binding should act as catch-all for unassigned stores: %v", err)
-	}
-
-	if _, err := prov.Execute(context.Background(), "indexeddb_roundtrip", map[string]any{
-		"binding": "archive",
-		"store":   "tasks",
-		"id":      "task-archive",
-		"value":   "blocked",
-	}, ""); err == nil {
-		t.Fatal("archive catch-all binding should reject stores explicitly assigned to another binding")
+		t.Fatalf("archive backing store should contain event: %v", err)
 	}
 }
 

--- a/gestaltd/internal/bootstrap/plugin_indexeddb.go
+++ b/gestaltd/internal/bootstrap/plugin_indexeddb.go
@@ -7,83 +7,41 @@ import (
 )
 
 type pluginIndexedDBTransportOptions struct {
-	StorePrefix   string
-	AllowedStores []string
-	DeniedStores  []string
+	StorePrefix string
 }
 
 func newPluginIndexedDBTransport(ds indexeddb.IndexedDB, opts pluginIndexedDBTransportOptions) indexeddb.IndexedDB {
 	if ds == nil {
 		return nil
 	}
-	if opts.StorePrefix == "" && len(opts.AllowedStores) == 0 && len(opts.DeniedStores) == 0 {
+	if opts.StorePrefix == "" {
 		return ds
 	}
-	allowed := make(map[string]struct{}, len(opts.AllowedStores))
-	for _, store := range opts.AllowedStores {
-		allowed[store] = struct{}{}
-	}
-	if len(allowed) == 0 {
-		allowed = nil
-	}
-	denied := make(map[string]struct{}, len(opts.DeniedStores))
-	for _, store := range opts.DeniedStores {
-		denied[store] = struct{}{}
-	}
-	if len(denied) == 0 {
-		denied = nil
-	}
 	return &pluginIndexedDBTransport{
-		inner:   ds,
-		prefix:  opts.StorePrefix,
-		allowed: allowed,
-		denied:  denied,
+		inner:  ds,
+		prefix: opts.StorePrefix,
 	}
 }
 
 type pluginIndexedDBTransport struct {
-	inner   indexeddb.IndexedDB
-	prefix  string
-	allowed map[string]struct{}
-	denied  map[string]struct{}
+	inner  indexeddb.IndexedDB
+	prefix string
 }
 
-func (d *pluginIndexedDBTransport) translateStore(name string) (string, error) {
-	if len(d.allowed) > 0 {
-		if _, ok := d.allowed[name]; !ok {
-			return "", indexeddb.ErrNotFound
-		}
-	}
-	if len(d.denied) > 0 {
-		if _, ok := d.denied[name]; ok {
-			return "", indexeddb.ErrNotFound
-		}
-	}
-	return d.prefix + name, nil
+func (d *pluginIndexedDBTransport) translateStore(name string) string {
+	return d.prefix + name
 }
 
 func (d *pluginIndexedDBTransport) ObjectStore(name string) indexeddb.ObjectStore {
-	storeName, err := d.translateStore(name)
-	if err != nil {
-		return missingObjectStore{}
-	}
-	return d.inner.ObjectStore(storeName)
+	return d.inner.ObjectStore(d.translateStore(name))
 }
 
 func (d *pluginIndexedDBTransport) CreateObjectStore(ctx context.Context, name string, schema indexeddb.ObjectStoreSchema) error {
-	storeName, err := d.translateStore(name)
-	if err != nil {
-		return err
-	}
-	return d.inner.CreateObjectStore(ctx, storeName, schema)
+	return d.inner.CreateObjectStore(ctx, d.translateStore(name), schema)
 }
 
 func (d *pluginIndexedDBTransport) DeleteObjectStore(ctx context.Context, name string) error {
-	storeName, err := d.translateStore(name)
-	if err != nil {
-		return err
-	}
-	return d.inner.DeleteObjectStore(ctx, storeName)
+	return d.inner.DeleteObjectStore(ctx, d.translateStore(name))
 }
 
 func (d *pluginIndexedDBTransport) Ping(ctx context.Context) error {
@@ -92,92 +50,4 @@ func (d *pluginIndexedDBTransport) Ping(ctx context.Context) error {
 
 func (d *pluginIndexedDBTransport) Close() error {
 	return d.inner.Close()
-}
-
-type missingObjectStore struct{}
-
-func (missingObjectStore) Get(context.Context, string) (indexeddb.Record, error) {
-	return nil, indexeddb.ErrNotFound
-}
-
-func (missingObjectStore) GetKey(context.Context, string) (string, error) {
-	return "", indexeddb.ErrNotFound
-}
-
-func (missingObjectStore) Add(context.Context, indexeddb.Record) error {
-	return indexeddb.ErrNotFound
-}
-
-func (missingObjectStore) Put(context.Context, indexeddb.Record) error {
-	return indexeddb.ErrNotFound
-}
-
-func (missingObjectStore) Delete(context.Context, string) error {
-	return indexeddb.ErrNotFound
-}
-
-func (missingObjectStore) Clear(context.Context) error {
-	return indexeddb.ErrNotFound
-}
-
-func (missingObjectStore) GetAll(context.Context, *indexeddb.KeyRange) ([]indexeddb.Record, error) {
-	return nil, indexeddb.ErrNotFound
-}
-
-func (missingObjectStore) GetAllKeys(context.Context, *indexeddb.KeyRange) ([]string, error) {
-	return nil, indexeddb.ErrNotFound
-}
-
-func (missingObjectStore) Count(context.Context, *indexeddb.KeyRange) (int64, error) {
-	return 0, indexeddb.ErrNotFound
-}
-
-func (missingObjectStore) DeleteRange(context.Context, indexeddb.KeyRange) (int64, error) {
-	return 0, indexeddb.ErrNotFound
-}
-
-func (missingObjectStore) Index(string) indexeddb.Index {
-	return missingIndex{}
-}
-
-func (missingObjectStore) OpenCursor(context.Context, *indexeddb.KeyRange, indexeddb.CursorDirection) (indexeddb.Cursor, error) {
-	return nil, indexeddb.ErrNotFound
-}
-
-func (missingObjectStore) OpenKeyCursor(context.Context, *indexeddb.KeyRange, indexeddb.CursorDirection) (indexeddb.Cursor, error) {
-	return nil, indexeddb.ErrNotFound
-}
-
-type missingIndex struct{}
-
-func (missingIndex) Get(context.Context, ...any) (indexeddb.Record, error) {
-	return nil, indexeddb.ErrNotFound
-}
-
-func (missingIndex) GetKey(context.Context, ...any) (string, error) {
-	return "", indexeddb.ErrNotFound
-}
-
-func (missingIndex) GetAll(context.Context, *indexeddb.KeyRange, ...any) ([]indexeddb.Record, error) {
-	return nil, indexeddb.ErrNotFound
-}
-
-func (missingIndex) GetAllKeys(context.Context, *indexeddb.KeyRange, ...any) ([]string, error) {
-	return nil, indexeddb.ErrNotFound
-}
-
-func (missingIndex) Count(context.Context, *indexeddb.KeyRange, ...any) (int64, error) {
-	return 0, indexeddb.ErrNotFound
-}
-
-func (missingIndex) Delete(context.Context, ...any) (int64, error) {
-	return 0, indexeddb.ErrNotFound
-}
-
-func (missingIndex) OpenCursor(context.Context, *indexeddb.KeyRange, indexeddb.CursorDirection, ...any) (indexeddb.Cursor, error) {
-	return nil, indexeddb.ErrNotFound
-}
-
-func (missingIndex) OpenKeyCursor(context.Context, *indexeddb.KeyRange, indexeddb.CursorDirection, ...any) (indexeddb.Cursor, error) {
-	return nil, indexeddb.ErrNotFound
 }

--- a/gestaltd/internal/bootstrap/provider_build.go
+++ b/gestaltd/internal/bootstrap/provider_build.go
@@ -508,8 +508,12 @@ func buildPluginProvider(ctx context.Context, name string, entry *config.Provide
 		DefaultAction: deps.Egress.DefaultAction,
 		HostBinary:    entry.HostBinary,
 	}
-	if len(entry.IndexedDBs) > 0 {
-		hostServices, indexedDBCleanup, err := buildPluginIndexedDBHostServices(name, entry, deps)
+	effectiveIndexedDB, err := config.ResolveEffectivePluginIndexedDB(name, entry, deps.SelectedIndexedDBName, deps.IndexedDBDefs)
+	if err != nil {
+		return nil, err
+	}
+	if effectiveIndexedDB.Enabled {
+		hostServices, indexedDBCleanup, err := buildPluginIndexedDBHostServices(name, effectiveIndexedDB, deps)
 		if err != nil {
 			return nil, err
 		}
@@ -525,81 +529,49 @@ func buildPluginProvider(ctx context.Context, name string, entry *config.Provide
 	return prov, nil
 }
 
-func buildPluginIndexedDBHostServices(pluginName string, entry *config.ProviderEntry, deps Deps) ([]providerhost.HostService, func(), error) {
+func buildPluginIndexedDBHostServices(pluginName string, effective config.EffectivePluginIndexedDB, deps Deps) ([]providerhost.HostService, func(), error) {
 	if deps.IndexedDBFactory == nil || len(deps.IndexedDBDefs) == 0 {
 		return nil, nil, fmt.Errorf("indexeddb host services are not available")
 	}
 
-	effectiveSchema := effectivePluginIndexedDBSchema(pluginName, entry)
-	explicitStores := make(map[string]struct{})
-	for _, binding := range entry.IndexedDBs {
-		for _, store := range binding.ObjectStores {
-			explicitStores[store] = struct{}{}
-		}
-	}
-	reservedStores := make([]string, 0, len(explicitStores))
-	for store := range explicitStores {
-		reservedStores = append(reservedStores, store)
-	}
-	hostServices := make([]providerhost.HostService, 0, len(entry.IndexedDBs)+1)
-	boundStores := make([]indexeddb.IndexedDB, 0, len(entry.IndexedDBs))
-	for _, binding := range entry.IndexedDBs {
-		var deniedStores []string
-		if len(binding.ObjectStores) == 0 && len(reservedStores) > 0 {
-			deniedStores = reservedStores
-		}
-		ds, err := buildPluginScopedIndexedDB(binding, effectiveSchema, deniedStores, deps)
-		if err != nil {
-			_ = closeIndexedDBs(boundStores...)
-			return nil, nil, err
-		}
-		boundStores = append(boundStores, ds)
-		hostServices = append(hostServices, providerhost.HostService{
-			EnvVar: providerhost.IndexedDBSocketEnv(binding.Name),
-			Register: func(ds indexeddb.IndexedDB) func(*grpc.Server) {
-				return func(srv *grpc.Server) {
-					proto.RegisterIndexedDBServer(srv, providerhost.NewIndexedDBServer(ds, pluginName))
-				}
-			}(ds),
-		})
-	}
-	if len(boundStores) == 1 {
-		ds := boundStores[0]
-		hostServices = append(hostServices, providerhost.HostService{
-			EnvVar: providerhost.DefaultIndexedDBSocketEnv,
-			Register: func(srv *grpc.Server) {
-				proto.RegisterIndexedDBServer(srv, providerhost.NewIndexedDBServer(ds, pluginName))
-			},
-		})
+	ds, err := buildPluginScopedIndexedDB(effective, deps)
+	if err != nil {
+		return nil, nil, err
 	}
 
+	hostServices := []providerhost.HostService{{
+		EnvVar: providerhost.DefaultIndexedDBSocketEnv,
+		Register: func(srv *grpc.Server) {
+			proto.RegisterIndexedDBServer(srv, providerhost.NewIndexedDBServer(ds, pluginName, providerhost.IndexedDBServerOptions{
+				AllowedStores: effective.ObjectStores,
+			}))
+		},
+	}}
 	return hostServices, func() {
-		_ = closeIndexedDBs(boundStores...)
+		_ = closeIndexedDBs(ds)
 	}, nil
 }
 
-func buildPluginScopedIndexedDB(binding config.PluginIndexedDBBinding, schema string, deniedStores []string, deps Deps) (indexeddb.IndexedDB, error) {
-	def, ok := deps.IndexedDBDefs[binding.Name]
+func buildPluginScopedIndexedDB(effective config.EffectivePluginIndexedDB, deps Deps) (indexeddb.IndexedDB, error) {
+	def, ok := deps.IndexedDBDefs[effective.ProviderName]
 	if !ok || def == nil {
-		return nil, fmt.Errorf("indexeddb %q is not available", binding.Name)
+		return nil, fmt.Errorf("indexeddb %q is not available", effective.ProviderName)
 	}
-	scopedDef, transportPrefix, err := newPluginScopedIndexedDBDef(def, schema)
+	scopedDef, transportPrefix, err := newPluginScopedIndexedDBDef(def, effective.DB)
 	if err != nil {
-		return nil, fmt.Errorf("indexeddb %q: %w", binding.Name, err)
+		return nil, fmt.Errorf("indexeddb %q: %w", effective.ProviderName, err)
 	}
 	ds, err := buildIndexedDB(scopedDef, &FactoryRegistry{IndexedDB: deps.IndexedDBFactory})
 	if err != nil {
-		return nil, fmt.Errorf("indexeddb %q: %w", binding.Name, err)
+		return nil, fmt.Errorf("indexeddb %q: %w", effective.ProviderName, err)
 	}
 	ds = newPluginIndexedDBTransport(ds, pluginIndexedDBTransportOptions{
-		StorePrefix:   transportPrefix,
-		AllowedStores: binding.ObjectStores,
-		DeniedStores:  deniedStores,
+		StorePrefix: transportPrefix,
 	})
-	return metricutil.InstrumentIndexedDB(ds, binding.Name), nil
+	return metricutil.InstrumentIndexedDB(ds, effective.ProviderName), nil
 }
 
-func newPluginScopedIndexedDBDef(entry *config.ProviderEntry, schema string) (*config.ProviderEntry, string, error) {
+func newPluginScopedIndexedDBDef(entry *config.ProviderEntry, db string) (*config.ProviderEntry, string, error) {
 	if entry == nil {
 		return nil, "", fmt.Errorf("datastore provider is required")
 	}
@@ -618,15 +590,15 @@ func newPluginScopedIndexedDBDef(entry *config.ProviderEntry, schema string) (*c
 		delete(cfg, "namespace")
 		if isSQLiteIndexedDBConfig(cfg) {
 			delete(cfg, "schema")
-			cfg["table_prefix"] = schema + "_"
-			cfg["prefix"] = schema + "_"
+			cfg["table_prefix"] = db + "_"
+			cfg["prefix"] = db + "_"
 		} else {
 			delete(cfg, "table_prefix")
 			delete(cfg, "prefix")
-			cfg["schema"] = schema
+			cfg["schema"] = db
 		}
 	} else {
-		transportPrefix = schema + "_"
+		transportPrefix = db + "_"
 	}
 
 	configNode, err := mapToYAMLNode(cfg)
@@ -696,13 +668,6 @@ func mapToYAMLNode(value map[string]any) (yaml.Node, error) {
 		return *out.Content[0], nil
 	}
 	return out, nil
-}
-
-func effectivePluginIndexedDBSchema(pluginName string, entry *config.ProviderEntry) string {
-	if entry != nil && strings.TrimSpace(entry.IndexedDBSchema) != "" {
-		return strings.TrimSpace(entry.IndexedDBSchema)
-	}
-	return pluginName
 }
 
 func chainCleanup(cleanups ...func()) func() {

--- a/gestaltd/internal/config/config.go
+++ b/gestaltd/internal/config/config.go
@@ -139,8 +139,8 @@ type ProviderEntry struct {
 	// Plugin-specific config fields (parsed from YAML, only valid on plugin entries)
 	Connections       map[string]*ConnectionDef     `yaml:"connections,omitempty"`
 	AllowedOperations map[string]*OperationOverride `yaml:"allowedOperations,omitempty"`
-	IndexedDBs        []PluginIndexedDBBinding      `yaml:"indexeddb,omitempty"`
-	IndexedDBSchema   string                        `yaml:"indexeddbSchema,omitempty"`
+	IndexedDB         *PluginIndexedDBConfig        `yaml:"indexeddb,omitempty"`
+	IndexedDBSchema   string                        `yaml:"indexeddbSchema,omitempty"` // Legacy alias for IndexedDB.DB.
 	Surfaces          *ProviderSurfaceOverrides     `yaml:"surfaces,omitempty"`
 
 	// Runtime-resolved fields (populated during init/bootstrap, not from YAML)
@@ -167,18 +167,48 @@ type ProviderSurfaceOverrides struct {
 	MCP     *ProviderMCPSurfaceOverride     `yaml:"mcp,omitempty"`
 }
 
-type PluginIndexedDBBinding struct {
+type PluginIndexedDBConfig struct {
+	Disabled     bool     `yaml:"disabled,omitempty"`
+	Provider     string   `yaml:"provider,omitempty"`
+	DB           string   `yaml:"db,omitempty"`
+	ObjectStores []string `yaml:"objectStores,omitempty"`
+}
+
+type legacyPluginIndexedDBBinding struct {
 	Name         string   `yaml:"name,omitempty"`
 	ObjectStores []string `yaml:"objectStore,omitempty"`
 }
 
-func (b *PluginIndexedDBBinding) UnmarshalYAML(value *yaml.Node) error {
-	if value.Kind == yaml.ScalarNode {
-		b.Name = strings.TrimSpace(value.Value)
+func (c *PluginIndexedDBConfig) UnmarshalYAML(value *yaml.Node) error {
+	switch value.Kind {
+	case yaml.ScalarNode:
+		c.Provider = strings.TrimSpace(value.Value)
 		return nil
+	case yaml.SequenceNode:
+		switch len(value.Content) {
+		case 0:
+			c.Disabled = true
+			return nil
+		case 1:
+			item := value.Content[0]
+			if item.Kind == yaml.ScalarNode {
+				c.Provider = strings.TrimSpace(item.Value)
+				return nil
+			}
+			var binding legacyPluginIndexedDBBinding
+			if err := item.Decode(&binding); err != nil {
+				return err
+			}
+			c.Provider = strings.TrimSpace(binding.Name)
+			c.ObjectStores = slices.Clone(binding.ObjectStores)
+			return nil
+		default:
+			return fmt.Errorf("plugin indexeddb legacy list supports at most one entry")
+		}
+	default:
+		type raw PluginIndexedDBConfig
+		return value.Decode((*raw)(c))
 	}
-	type raw PluginIndexedDBBinding
-	return value.Decode((*raw)(b))
 }
 
 type ProviderRESTSurfaceOverride struct {

--- a/gestaltd/internal/config/config_test.go
+++ b/gestaltd/internal/config/config_test.go
@@ -146,9 +146,9 @@ plugins:
 	if indexedDBName != "archive" || indexedDBEntry == nil {
 		t.Fatalf("SelectedIndexedDBProvider = (%q, %#v), want archive", indexedDBName, indexedDBEntry)
 	}
-	wantBindings := []PluginIndexedDBBinding{{Name: "archive"}}
-	if got := cfg.Plugins["service-a"].IndexedDBs; !reflect.DeepEqual(got, wantBindings) {
-		t.Fatalf("Plugins[service-a].IndexedDBs = %v, want %v", got, wantBindings)
+	wantIndexedDB := &PluginIndexedDBConfig{Provider: "archive"}
+	if got := cfg.Plugins["service-a"].IndexedDB; !reflect.DeepEqual(got, wantIndexedDB) {
+		t.Fatalf("Plugins[service-a].IndexedDB = %#v, want %#v", got, wantIndexedDB)
 	}
 }
 
@@ -1087,7 +1087,7 @@ server:
 func TestLoadConfigPluginIndexedDBBindings(t *testing.T) {
 	t.Parallel()
 
-	t.Run("plugin accepts indexeddb bindings", func(t *testing.T) {
+	t.Run("plugin accepts indexeddb config object", func(t *testing.T) {
 		t.Parallel()
 
 		path := mustWriteConfigFile(t, `
@@ -1096,8 +1096,11 @@ plugins:
     source:
       path: ./plugin/manifest.yaml
     indexeddb:
-      - sqlite
-      - archive
+      provider: archive
+      db: roadmap_review
+      objectStores:
+        - tasks
+        - snapshots
 providers:
   indexeddb:
     sqlite:
@@ -1116,17 +1119,18 @@ server:
 		if err != nil {
 			t.Fatalf("Load: %v", err)
 		}
-		want := []PluginIndexedDBBinding{
-			{Name: "sqlite"},
-			{Name: "archive"},
+		want := &PluginIndexedDBConfig{
+			Provider:     "archive",
+			DB:           "roadmap_review",
+			ObjectStores: []string{"tasks", "snapshots"},
 		}
-		got := cfg.Plugins["roadmap"].IndexedDBs
+		got := cfg.Plugins["roadmap"].IndexedDB
 		if !reflect.DeepEqual(got, want) {
-			t.Fatalf("Plugins[roadmap].IndexedDBs = %v, want %v", got, want)
+			t.Fatalf("Plugins[roadmap].IndexedDB = %#v, want %#v", got, want)
 		}
 	})
 
-	t.Run("loads plugin indexeddb object store routing", func(t *testing.T) {
+	t.Run("plugin accepts legacy single-entry indexeddb list", func(t *testing.T) {
 		t.Parallel()
 
 		path := mustWriteConfigFile(t, `
@@ -1139,17 +1143,11 @@ plugins:
         objectStore:
           - tasks
           - snapshots
-      - name: archive
-        objectStore:
-          - events
 providers:
   indexeddb:
     sqlite:
       source:
         path: ./providers/datastore/sqlite
-    archive:
-      source:
-        path: ./providers/datastore/archive
 server:
   providers:
     indexeddb: sqlite
@@ -1160,13 +1158,43 @@ server:
 		if err != nil {
 			t.Fatalf("Load: %v", err)
 		}
-		got := cfg.Plugins["roadmap"].IndexedDBs
-		want := []PluginIndexedDBBinding{
-			{Name: "sqlite", ObjectStores: []string{"tasks", "snapshots"}},
-			{Name: "archive", ObjectStores: []string{"events"}},
+		got := cfg.Plugins["roadmap"].IndexedDB
+		want := &PluginIndexedDBConfig{
+			Provider:     "sqlite",
+			ObjectStores: []string{"tasks", "snapshots"},
 		}
 		if !reflect.DeepEqual(got, want) {
-			t.Fatalf("Plugins[roadmap].IndexedDBs = %#v, want %#v", got, want)
+			t.Fatalf("Plugins[roadmap].IndexedDB = %#v, want %#v", got, want)
+		}
+	})
+
+	t.Run("plugin accepts legacy empty indexeddb list as disabled", func(t *testing.T) {
+		t.Parallel()
+
+		path := mustWriteConfigFile(t, `
+plugins:
+  roadmap:
+    source:
+      path: ./plugin/manifest.yaml
+    indexeddb: []
+providers:
+  indexeddb:
+    sqlite:
+      source:
+        path: ./providers/datastore/sqlite
+server:
+  providers:
+    indexeddb: sqlite
+  encryptionKey: server-key
+`)
+
+		cfg, err := Load(path)
+		if err != nil {
+			t.Fatalf("Load: %v", err)
+		}
+		want := &PluginIndexedDBConfig{Disabled: true}
+		if got := cfg.Plugins["roadmap"].IndexedDB; !reflect.DeepEqual(got, want) {
+			t.Fatalf("Plugins[roadmap].IndexedDB = %#v, want %#v", got, want)
 		}
 	})
 
@@ -1259,8 +1287,9 @@ server:
 		if err != nil {
 			t.Fatalf("Load: %v", err)
 		}
-		if got := cfg.Plugins["datadog"].IndexedDBSchema; got != "plugin_data" {
-			t.Fatalf("Plugins[datadog].IndexedDBSchema = %q, want %q", got, "plugin_data")
+		want := &PluginIndexedDBConfig{DB: "plugin_data"}
+		if got := cfg.Plugins["datadog"].IndexedDB; !reflect.DeepEqual(got, want) {
+			t.Fatalf("Plugins[datadog].IndexedDB = %#v, want %#v", got, want)
 		}
 	})
 
@@ -1326,7 +1355,7 @@ server:
 		}
 	})
 
-	t.Run("rejects unknown indexeddb binding names", func(t *testing.T) {
+	t.Run("rejects unknown indexeddb provider names", func(t *testing.T) {
 		t.Parallel()
 
 		path := mustWriteConfigFile(t, `
@@ -1335,8 +1364,7 @@ plugins:
     source:
       path: ./plugin/manifest.yaml
     indexeddb:
-      - sqlite
-      - missing
+      provider: missing
 providers:
   indexeddb:
     sqlite:
@@ -1352,12 +1380,12 @@ server:
 		if err == nil {
 			t.Fatal("Load: expected error, got nil")
 		}
-		if !strings.Contains(err.Error(), `plugin "roadmap" indexeddb[1] references unknown indexeddb "missing"`) {
+		if !strings.Contains(err.Error(), `plugins.roadmap.indexeddb.provider references unknown indexeddb "missing"`) {
 			t.Fatalf("unexpected error: %v", err)
 		}
 	})
 
-	t.Run("rejects indexeddb bindings that normalize to the same env var", func(t *testing.T) {
+	t.Run("rejects disabled indexeddb mixed with provider override", func(t *testing.T) {
 		t.Parallel()
 
 		path := mustWriteConfigFile(t, `
@@ -1366,16 +1394,13 @@ plugins:
     source:
       path: ./plugin/manifest.yaml
     indexeddb:
-      - main-db
-      - main_db
+      disabled: true
+      provider: main-db
 providers:
   indexeddb:
     main-db:
       source:
         path: ./providers/datastore/main-db
-    main_db:
-      source:
-        path: ./providers/datastore/main_db
 server:
   providers:
     indexeddb: main-db
@@ -1386,12 +1411,12 @@ server:
 		if err == nil {
 			t.Fatal("Load: expected error, got nil")
 		}
-		if !strings.Contains(err.Error(), `plugin "roadmap" indexeddb[1] "main_db" conflicts with "main-db" after IndexedDB env normalization (GESTALT_INDEXEDDB_SOCKET_MAIN_DB)`) {
+		if !strings.Contains(err.Error(), `plugins.roadmap.indexeddb.disabled may not be combined with indexeddb.provider`) {
 			t.Fatalf("unexpected error: %v", err)
 		}
 	})
 
-	t.Run("rejects duplicate indexeddb object stores across bindings", func(t *testing.T) {
+	t.Run("rejects duplicate indexeddb object stores", func(t *testing.T) {
 		t.Parallel()
 
 		path := mustWriteConfigFile(t, `
@@ -1400,12 +1425,41 @@ plugins:
     source:
       path: ./plugin/manifest.yaml
     indexeddb:
-      - name: main
-        objectStore:
-          - tasks
-      - name: archive
-        objectStore:
-          - tasks
+      provider: main
+      objectStores:
+        - tasks
+        - tasks
+providers:
+  indexeddb:
+    main:
+      source:
+        path: ./providers/datastore/main
+server:
+  providers:
+    indexeddb: main
+  encryptionKey: server-key
+`)
+
+		_, err := Load(path)
+		if err == nil {
+			t.Fatal("Load: expected error, got nil")
+		}
+		if !strings.Contains(err.Error(), `plugins.roadmap.indexeddb.objectStores[1] duplicates "tasks"`) {
+			t.Fatalf("unexpected error: %v", err)
+		}
+	})
+
+	t.Run("rejects legacy multi-entry indexeddb lists", func(t *testing.T) {
+		t.Parallel()
+
+		path := mustWriteConfigFile(t, `
+plugins:
+  roadmap:
+    source:
+      path: ./plugin/manifest.yaml
+    indexeddb:
+      - main
+      - archive
 providers:
   indexeddb:
     main:
@@ -1424,87 +1478,7 @@ server:
 		if err == nil {
 			t.Fatal("Load: expected error, got nil")
 		}
-		if !strings.Contains(err.Error(), `plugin "roadmap" indexeddb[1].objectStore[0] "tasks" duplicates indexeddb "main"`) {
-			t.Fatalf("unexpected error: %v", err)
-		}
-	})
-
-	t.Run("loads mixed explicit and catch-all indexeddb bindings", func(t *testing.T) {
-		t.Parallel()
-
-		path := mustWriteConfigFile(t, `
-plugins:
-  roadmap:
-    source:
-      path: ./plugin/manifest.yaml
-    indexeddb:
-      - name: main
-        objectStore:
-          - tasks
-      - name: archive
-providers:
-  indexeddb:
-    main:
-      source:
-        path: ./providers/datastore/main
-    archive:
-      source:
-        path: ./providers/datastore/archive
-server:
-  providers:
-    indexeddb: main
-  encryptionKey: server-key
-`)
-
-		cfg, err := Load(path)
-		if err != nil {
-			t.Fatalf("Load: %v", err)
-		}
-		want := []PluginIndexedDBBinding{
-			{Name: "main", ObjectStores: []string{"tasks"}},
-			{Name: "archive"},
-		}
-		if got := cfg.Plugins["roadmap"].IndexedDBs; !reflect.DeepEqual(got, want) {
-			t.Fatalf("Plugins[roadmap].IndexedDBs = %#v, want %#v", got, want)
-		}
-	})
-
-	t.Run("rejects multiple catch-all indexeddb bindings when allowlists are used", func(t *testing.T) {
-		t.Parallel()
-
-		path := mustWriteConfigFile(t, `
-plugins:
-  roadmap:
-    source:
-      path: ./plugin/manifest.yaml
-    indexeddb:
-      - name: main
-        objectStore:
-          - tasks
-      - name: archive
-      - name: backup
-providers:
-  indexeddb:
-    main:
-      source:
-        path: ./providers/datastore/main
-    archive:
-      source:
-        path: ./providers/datastore/archive
-    backup:
-      source:
-        path: ./providers/datastore/backup
-server:
-  providers:
-    indexeddb: main
-  encryptionKey: server-key
-`)
-
-		_, err := Load(path)
-		if err == nil {
-			t.Fatal("Load: expected error, got nil")
-		}
-		if !strings.Contains(err.Error(), `plugin "roadmap" indexeddb may declare at most one unrestricted binding when objectStore allowlists are used`) {
+		if !strings.Contains(err.Error(), `plugin indexeddb legacy list supports at most one entry`) {
 			t.Fatalf("unexpected error: %v", err)
 		}
 	})

--- a/gestaltd/internal/config/config_validate.go
+++ b/gestaltd/internal/config/config_validate.go
@@ -292,10 +292,26 @@ func validatePlugin(cfg *Config, name string, entry *ProviderEntry) error {
 		return fmt.Errorf("config validation: plugins.%s.default is not supported on plugins", name)
 	}
 	entry.IndexedDBSchema = strings.TrimSpace(entry.IndexedDBSchema)
+	if entry.IndexedDB != nil {
+		entry.IndexedDB.Provider = strings.TrimSpace(entry.IndexedDB.Provider)
+		entry.IndexedDB.DB = strings.TrimSpace(entry.IndexedDB.DB)
+		for i, store := range entry.IndexedDB.ObjectStores {
+			entry.IndexedDB.ObjectStores[i] = strings.TrimSpace(store)
+		}
+	}
+	if entry.IndexedDBSchema != "" {
+		if entry.IndexedDB == nil {
+			entry.IndexedDB = &PluginIndexedDBConfig{}
+		}
+		if entry.IndexedDB.DB != "" {
+			return fmt.Errorf("config validation: plugins.%s may not set both indexeddb.db and indexeddbSchema", name)
+		}
+		entry.IndexedDB.DB = entry.IndexedDBSchema
+	}
 	if err := validateProviderEntrySource("plugin", name, entry); err != nil {
 		return err
 	}
-	if err := validatePluginIndexedDBBindings(cfg, name, entry); err != nil {
+	if err := validatePluginIndexedDBConfig(cfg, name, entry); err != nil {
 		return err
 	}
 	if err := validateAuthorizationPolicyReference(cfg, "plugin", name, entry.AuthorizationPolicy); err != nil {
@@ -326,7 +342,7 @@ func validatePluginOnlyProviderFields(subject string, entry *ProviderEntry) erro
 	if entry == nil {
 		return nil
 	}
-	if len(entry.IndexedDBs) > 0 {
+	if entry.IndexedDB != nil {
 		return fmt.Errorf("config validation: %s.indexeddb is only supported on plugins.*", subject)
 	}
 	if strings.TrimSpace(entry.IndexedDBSchema) != "" {
@@ -469,80 +485,40 @@ func validateAbsoluteBaseURL(label, raw string) (*url.URL, error) {
 	return parsed, nil
 }
 
-func validatePluginIndexedDBBindings(cfg *Config, name string, entry *ProviderEntry) error {
+func validatePluginIndexedDBConfig(cfg *Config, name string, entry *ProviderEntry) error {
 	if entry == nil {
 		return nil
 	}
-	seen := make(map[string]struct{}, len(entry.IndexedDBs))
-	envNames := make(map[string]string, len(entry.IndexedDBs))
-	objectStores := make(map[string]string)
-	restrictedBindingCount := 0
-	unrestrictedBindingCount := 0
-	for i := range entry.IndexedDBs {
-		binding := &entry.IndexedDBs[i]
-		binding.Name = strings.TrimSpace(binding.Name)
-		if binding.Name == "" {
-			return fmt.Errorf("config validation: plugin %q indexeddb[%d] is required", name, i)
-		}
-		if _, exists := seen[binding.Name]; exists {
-			return fmt.Errorf("config validation: plugin %q indexeddb[%d] duplicates %q", name, i, binding.Name)
-		}
-		if _, ok := cfg.Providers.IndexedDB[binding.Name]; !ok {
-			return fmt.Errorf("config validation: plugin %q indexeddb[%d] references unknown indexeddb %q", name, i, binding.Name)
-		}
-		envName := indexedDBSocketEnv(binding.Name)
-		if otherBinding, exists := envNames[envName]; exists {
-			return fmt.Errorf("config validation: plugin %q indexeddb[%d] %q conflicts with %q after IndexedDB env normalization (%s)", name, i, binding.Name, otherBinding, envName)
-		}
-		seenStores := make(map[string]struct{}, len(binding.ObjectStores))
-		if len(binding.ObjectStores) > 0 {
-			restrictedBindingCount++
-		} else {
-			unrestrictedBindingCount++
-		}
-		for j, store := range binding.ObjectStores {
-			store = strings.TrimSpace(store)
-			if store == "" {
-				return fmt.Errorf("config validation: plugin %q indexeddb[%d].objectStore[%d] is required", name, i, j)
-			}
-			if _, exists := seenStores[store]; exists {
-				return fmt.Errorf("config validation: plugin %q indexeddb[%d].objectStore[%d] duplicates %q", name, i, j, store)
-			}
-			if otherBinding, exists := objectStores[store]; exists {
-				return fmt.Errorf("config validation: plugin %q indexeddb[%d].objectStore[%d] %q duplicates indexeddb %q", name, i, j, store, otherBinding)
-			}
-			seenStores[store] = struct{}{}
-			objectStores[store] = binding.Name
-			binding.ObjectStores[j] = store
-		}
-		seen[binding.Name] = struct{}{}
-		envNames[envName] = binding.Name
+	if entry.IndexedDB == nil {
+		return nil
 	}
-	if restrictedBindingCount > 0 && unrestrictedBindingCount > 1 {
-		return fmt.Errorf("config validation: plugin %q indexeddb may declare at most one unrestricted binding when objectStore allowlists are used", name)
+	indexedDB := entry.IndexedDB
+	if indexedDB.Disabled {
+		switch {
+		case indexedDB.Provider != "":
+			return fmt.Errorf("config validation: plugins.%s.indexeddb.disabled may not be combined with indexeddb.provider", name)
+		case indexedDB.DB != "":
+			return fmt.Errorf("config validation: plugins.%s.indexeddb.disabled may not be combined with indexeddb.db", name)
+		case len(indexedDB.ObjectStores) > 0:
+			return fmt.Errorf("config validation: plugins.%s.indexeddb.disabled may not be combined with indexeddb.objectStores", name)
+		default:
+			return nil
+		}
+	}
+	seenStores := make(map[string]struct{}, len(indexedDB.ObjectStores))
+	for i, store := range indexedDB.ObjectStores {
+		if store == "" {
+			return fmt.Errorf("config validation: plugins.%s.indexeddb.objectStores[%d] is required", name, i)
+		}
+		if _, exists := seenStores[store]; exists {
+			return fmt.Errorf("config validation: plugins.%s.indexeddb.objectStores[%d] duplicates %q", name, i, store)
+		}
+		seenStores[store] = struct{}{}
+	}
+	if _, err := cfg.EffectivePluginIndexedDB(name, entry); err != nil {
+		return err
 	}
 	return nil
-}
-
-func indexedDBSocketEnv(name string) string {
-	name = strings.TrimSpace(name)
-	if name == "" {
-		return "GESTALT_INDEXEDDB_SOCKET"
-	}
-	var b strings.Builder
-	b.WriteString("GESTALT_INDEXEDDB_SOCKET")
-	b.WriteByte('_')
-	for _, r := range name {
-		switch {
-		case r >= 'a' && r <= 'z':
-			b.WriteRune(r - ('a' - 'A'))
-		case r >= 'A' && r <= 'Z', r >= '0' && r <= '9':
-			b.WriteRune(r)
-		default:
-			b.WriteByte('_')
-		}
-	}
-	return b.String()
 }
 
 func normalizeMountedUIPaths(cfg *Config, appUIRefs map[string]struct{}) error {

--- a/gestaltd/internal/config/provider_selection.go
+++ b/gestaltd/internal/config/provider_selection.go
@@ -2,6 +2,7 @@ package config
 
 import (
 	"fmt"
+	"slices"
 	"sort"
 	"strings"
 )
@@ -91,6 +92,71 @@ func (c *Config) SelectedAuditProvider() (string, *ProviderEntry, error) {
 
 func (c *Config) SelectedIndexedDBProvider() (string, *ProviderEntry, error) {
 	return c.SelectedHostProvider(HostProviderKindIndexedDB)
+}
+
+type EffectivePluginIndexedDB struct {
+	Enabled      bool
+	ProviderName string
+	Provider     *ProviderEntry
+	DB           string
+	ObjectStores []string
+}
+
+func (c *Config) EffectivePluginIndexedDB(pluginName string, entry *ProviderEntry) (EffectivePluginIndexedDB, error) {
+	c.SyncCompatFields()
+	selectedName, _, err := c.SelectedIndexedDBProvider()
+	if err != nil {
+		return EffectivePluginIndexedDB{}, err
+	}
+	return ResolveEffectivePluginIndexedDB(pluginName, entry, selectedName, c.Providers.IndexedDB)
+}
+
+func ResolveEffectivePluginIndexedDB(pluginName string, entry *ProviderEntry, selectedName string, entries map[string]*ProviderEntry) (EffectivePluginIndexedDB, error) {
+	if entry == nil {
+		return EffectivePluginIndexedDB{}, nil
+	}
+	if entry.IndexedDB != nil && entry.IndexedDB.Disabled {
+		return EffectivePluginIndexedDB{}, nil
+	}
+
+	providerName := ""
+	if entry.IndexedDB != nil {
+		providerName = strings.TrimSpace(entry.IndexedDB.Provider)
+	}
+	if providerName == "" {
+		providerName = strings.TrimSpace(selectedName)
+	}
+	if providerName == "" {
+		return EffectivePluginIndexedDB{}, nil
+	}
+
+	provider, ok := entries[providerName]
+	if !ok || provider == nil {
+		return EffectivePluginIndexedDB{}, fmt.Errorf("config validation: plugins.%s.indexeddb.provider references unknown indexeddb %q", pluginName, providerName)
+	}
+	if provider.Disabled {
+		return EffectivePluginIndexedDB{}, fmt.Errorf("config validation: plugins.%s.indexeddb.provider references disabled indexeddb %q", pluginName, providerName)
+	}
+
+	dbName := pluginName
+	if entry.IndexedDB != nil && strings.TrimSpace(entry.IndexedDB.DB) != "" {
+		dbName = strings.TrimSpace(entry.IndexedDB.DB)
+	} else if legacyDB := strings.TrimSpace(entry.IndexedDBSchema); legacyDB != "" {
+		dbName = legacyDB
+	}
+
+	var objectStores []string
+	if entry.IndexedDB != nil {
+		objectStores = slices.Clone(entry.IndexedDB.ObjectStores)
+	}
+
+	return EffectivePluginIndexedDB{
+		Enabled:      true,
+		ProviderName: providerName,
+		Provider:     provider,
+		DB:           dbName,
+		ObjectStores: objectStores,
+	}, nil
 }
 
 func ResolveSelectedHostProvider(kind HostProviderKind, explicit string, entries map[string]*ProviderEntry) (string, *ProviderEntry, error) {

--- a/gestaltd/internal/providerhost/cursor_test.go
+++ b/gestaltd/internal/providerhost/cursor_test.go
@@ -42,7 +42,7 @@ func newCursorTestDB(t *testing.T) (*coretesting.StubIndexedDB, indexeddb.Indexe
 	}
 
 	conn := newBufconnConn(t, func(srv *grpc.Server) {
-		proto.RegisterIndexedDBServer(srv, NewIndexedDBServer(stub, ""))
+		proto.RegisterIndexedDBServer(srv, NewIndexedDBServer(stub, "", IndexedDBServerOptions{}))
 	})
 	remote := &remoteIndexedDB{
 		client: proto.NewIndexedDBClient(conn),
@@ -91,7 +91,7 @@ func TestCursor_EmptyCursor(t *testing.T) {
 	_ = stub.CreateObjectStore(ctx, "empty", indexeddb.ObjectStoreSchema{})
 
 	conn := newBufconnConn(t, func(srv *grpc.Server) {
-		proto.RegisterIndexedDBServer(srv, NewIndexedDBServer(stub, ""))
+		proto.RegisterIndexedDBServer(srv, NewIndexedDBServer(stub, "", IndexedDBServerOptions{}))
 	})
 	remote := &remoteIndexedDB{client: proto.NewIndexedDBClient(conn)}
 
@@ -564,7 +564,7 @@ func TestCursor_IndexContinueToKeyRoundTrip(t *testing.T) {
 	}
 
 	conn := newBufconnConn(t, func(srv *grpc.Server) {
-		proto.RegisterIndexedDBServer(srv, NewIndexedDBServer(stub, ""))
+		proto.RegisterIndexedDBServer(srv, NewIndexedDBServer(stub, "", IndexedDBServerOptions{}))
 	})
 	remote := &remoteIndexedDB{client: proto.NewIndexedDBClient(conn)}
 
@@ -619,7 +619,7 @@ func TestCursor_EmptyResultSetDoneOnly(t *testing.T) {
 	_ = stub.CreateObjectStore(ctx, "empty", indexeddb.ObjectStoreSchema{})
 
 	conn := newBufconnConn(t, func(srv *grpc.Server) {
-		proto.RegisterIndexedDBServer(srv, NewIndexedDBServer(stub, ""))
+		proto.RegisterIndexedDBServer(srv, NewIndexedDBServer(stub, "", IndexedDBServerOptions{}))
 	})
 	remote := &remoteIndexedDB{client: proto.NewIndexedDBClient(conn)}
 

--- a/gestaltd/internal/providerhost/indexeddb_server.go
+++ b/gestaltd/internal/providerhost/indexeddb_server.go
@@ -16,16 +16,29 @@ import (
 
 type indexedDBServer struct {
 	proto.UnimplementedIndexedDBServer
-	ds     indexeddb.IndexedDB
-	db     string
-	plugin string
+	ds      indexeddb.IndexedDB
+	db      string
+	plugin  string
+	allowed map[string]struct{}
 }
 
-func NewIndexedDBServer(ds indexeddb.IndexedDB, pluginName string) proto.IndexedDBServer {
+type IndexedDBServerOptions struct {
+	AllowedStores []string
+}
+
+func NewIndexedDBServer(ds indexeddb.IndexedDB, pluginName string, opts IndexedDBServerOptions) proto.IndexedDBServer {
+	allowed := make(map[string]struct{}, len(opts.AllowedStores))
+	for _, store := range opts.AllowedStores {
+		allowed[store] = struct{}{}
+	}
+	if len(allowed) == 0 {
+		allowed = nil
+	}
 	return &indexedDBServer{
-		ds:     ds,
-		db:     metricutil.IndexedDBName(ds),
-		plugin: pluginName,
+		ds:      ds,
+		db:      metricutil.IndexedDBName(ds),
+		plugin:  pluginName,
+		allowed: allowed,
 	}
 }
 
@@ -33,7 +46,20 @@ func (s *indexedDBServer) storeName(name string) string {
 	return name
 }
 
-func (s *indexedDBServer) objectStore(name string) indexeddb.ObjectStore {
+func (s *indexedDBServer) ensureAllowedStore(name string) error {
+	if len(s.allowed) == 0 {
+		return nil
+	}
+	if _, ok := s.allowed[name]; ok {
+		return nil
+	}
+	return indexeddb.ErrNotFound
+}
+
+func (s *indexedDBServer) objectStore(name string) (indexeddb.ObjectStore, error) {
+	if err := s.ensureAllowedStore(name); err != nil {
+		return nil, err
+	}
 	return metricutil.InstrumentObjectStore(
 		metricutil.UnwrapIndexedDB(s.ds).ObjectStore(s.storeName(name)),
 		metricutil.IndexedDBMetricLabels{
@@ -41,10 +67,13 @@ func (s *indexedDBServer) objectStore(name string) indexeddb.ObjectStore {
 			Plugin:      s.plugin,
 			ObjectStore: name,
 		},
-	)
+	), nil
 }
 
 func (s *indexedDBServer) CreateObjectStore(ctx context.Context, req *proto.CreateObjectStoreRequest) (*emptypb.Empty, error) {
+	if err := s.ensureAllowedStore(req.GetName()); err != nil {
+		return nil, indexeddbToGRPCErr(err)
+	}
 	schema := protoToSchema(req.GetSchema())
 	if err := s.ds.CreateObjectStore(ctx, s.storeName(req.GetName()), schema); err != nil {
 		return nil, indexeddbToGRPCErr(err)
@@ -53,6 +82,9 @@ func (s *indexedDBServer) CreateObjectStore(ctx context.Context, req *proto.Crea
 }
 
 func (s *indexedDBServer) DeleteObjectStore(ctx context.Context, req *proto.DeleteObjectStoreRequest) (*emptypb.Empty, error) {
+	if err := s.ensureAllowedStore(req.GetName()); err != nil {
+		return nil, indexeddbToGRPCErr(err)
+	}
 	if err := s.ds.DeleteObjectStore(ctx, s.storeName(req.GetName())); err != nil {
 		return nil, indexeddbToGRPCErr(err)
 	}
@@ -60,7 +92,11 @@ func (s *indexedDBServer) DeleteObjectStore(ctx context.Context, req *proto.Dele
 }
 
 func (s *indexedDBServer) Get(ctx context.Context, req *proto.ObjectStoreRequest) (*proto.RecordResponse, error) {
-	rec, err := s.objectStore(req.GetStore()).Get(ctx, req.GetId())
+	store, err := s.objectStore(req.GetStore())
+	if err != nil {
+		return nil, indexeddbToGRPCErr(err)
+	}
+	rec, err := store.Get(ctx, req.GetId())
 	if err != nil {
 		return nil, indexeddbToGRPCErr(err)
 	}
@@ -68,7 +104,11 @@ func (s *indexedDBServer) Get(ctx context.Context, req *proto.ObjectStoreRequest
 }
 
 func (s *indexedDBServer) GetKey(ctx context.Context, req *proto.ObjectStoreRequest) (*proto.KeyResponse, error) {
-	key, err := s.objectStore(req.GetStore()).GetKey(ctx, req.GetId())
+	store, err := s.objectStore(req.GetStore())
+	if err != nil {
+		return nil, indexeddbToGRPCErr(err)
+	}
+	key, err := store.GetKey(ctx, req.GetId())
 	if err != nil {
 		return nil, indexeddbToGRPCErr(err)
 	}
@@ -80,7 +120,11 @@ func (s *indexedDBServer) Add(ctx context.Context, req *proto.RecordRequest) (*e
 	if err != nil {
 		return nil, status.Errorf(codes.InvalidArgument, "unmarshal record: %v", err)
 	}
-	if err := s.objectStore(req.GetStore()).Add(ctx, record); err != nil {
+	store, err := s.objectStore(req.GetStore())
+	if err != nil {
+		return nil, indexeddbToGRPCErr(err)
+	}
+	if err := store.Add(ctx, record); err != nil {
 		return nil, indexeddbToGRPCErr(err)
 	}
 	return &emptypb.Empty{}, nil
@@ -91,21 +135,33 @@ func (s *indexedDBServer) Put(ctx context.Context, req *proto.RecordRequest) (*e
 	if err != nil {
 		return nil, status.Errorf(codes.InvalidArgument, "unmarshal record: %v", err)
 	}
-	if err := s.objectStore(req.GetStore()).Put(ctx, record); err != nil {
+	store, err := s.objectStore(req.GetStore())
+	if err != nil {
+		return nil, indexeddbToGRPCErr(err)
+	}
+	if err := store.Put(ctx, record); err != nil {
 		return nil, indexeddbToGRPCErr(err)
 	}
 	return &emptypb.Empty{}, nil
 }
 
 func (s *indexedDBServer) Delete(ctx context.Context, req *proto.ObjectStoreRequest) (*emptypb.Empty, error) {
-	if err := s.objectStore(req.GetStore()).Delete(ctx, req.GetId()); err != nil {
+	store, err := s.objectStore(req.GetStore())
+	if err != nil {
+		return nil, indexeddbToGRPCErr(err)
+	}
+	if err := store.Delete(ctx, req.GetId()); err != nil {
 		return nil, indexeddbToGRPCErr(err)
 	}
 	return &emptypb.Empty{}, nil
 }
 
 func (s *indexedDBServer) Clear(ctx context.Context, req *proto.ObjectStoreNameRequest) (*emptypb.Empty, error) {
-	if err := s.objectStore(req.GetStore()).Clear(ctx); err != nil {
+	store, err := s.objectStore(req.GetStore())
+	if err != nil {
+		return nil, indexeddbToGRPCErr(err)
+	}
+	if err := store.Clear(ctx); err != nil {
 		return nil, indexeddbToGRPCErr(err)
 	}
 	return &emptypb.Empty{}, nil
@@ -116,7 +172,11 @@ func (s *indexedDBServer) GetAll(ctx context.Context, req *proto.ObjectStoreRang
 	if err != nil {
 		return nil, status.Errorf(codes.InvalidArgument, "unmarshal key range: %v", err)
 	}
-	recs, err := s.objectStore(req.GetStore()).GetAll(ctx, keyRange)
+	store, err := s.objectStore(req.GetStore())
+	if err != nil {
+		return nil, indexeddbToGRPCErr(err)
+	}
+	recs, err := store.GetAll(ctx, keyRange)
 	if err != nil {
 		return nil, indexeddbToGRPCErr(err)
 	}
@@ -128,7 +188,11 @@ func (s *indexedDBServer) GetAllKeys(ctx context.Context, req *proto.ObjectStore
 	if err != nil {
 		return nil, status.Errorf(codes.InvalidArgument, "unmarshal key range: %v", err)
 	}
-	keys, err := s.objectStore(req.GetStore()).GetAllKeys(ctx, keyRange)
+	store, err := s.objectStore(req.GetStore())
+	if err != nil {
+		return nil, indexeddbToGRPCErr(err)
+	}
+	keys, err := store.GetAllKeys(ctx, keyRange)
 	if err != nil {
 		return nil, indexeddbToGRPCErr(err)
 	}
@@ -140,7 +204,11 @@ func (s *indexedDBServer) Count(ctx context.Context, req *proto.ObjectStoreRange
 	if err != nil {
 		return nil, status.Errorf(codes.InvalidArgument, "unmarshal key range: %v", err)
 	}
-	count, err := s.objectStore(req.GetStore()).Count(ctx, keyRange)
+	store, err := s.objectStore(req.GetStore())
+	if err != nil {
+		return nil, indexeddbToGRPCErr(err)
+	}
+	count, err := store.Count(ctx, keyRange)
 	if err != nil {
 		return nil, indexeddbToGRPCErr(err)
 	}
@@ -155,7 +223,11 @@ func (s *indexedDBServer) DeleteRange(ctx context.Context, req *proto.ObjectStor
 	if kr == nil {
 		return nil, status.Error(codes.InvalidArgument, "key range is required for DeleteRange")
 	}
-	deleted, err := s.objectStore(req.GetStore()).DeleteRange(ctx, *kr)
+	store, err := s.objectStore(req.GetStore())
+	if err != nil {
+		return nil, indexeddbToGRPCErr(err)
+	}
+	deleted, err := store.DeleteRange(ctx, *kr)
 	if err != nil {
 		return nil, indexeddbToGRPCErr(err)
 	}
@@ -167,7 +239,11 @@ func (s *indexedDBServer) IndexGet(ctx context.Context, req *proto.IndexQueryReq
 	if err != nil {
 		return nil, status.Errorf(codes.InvalidArgument, "unmarshal index values: %v", err)
 	}
-	rec, err := s.objectStore(req.GetStore()).Index(req.GetIndex()).Get(ctx, values...)
+	store, err := s.objectStore(req.GetStore())
+	if err != nil {
+		return nil, indexeddbToGRPCErr(err)
+	}
+	rec, err := store.Index(req.GetIndex()).Get(ctx, values...)
 	if err != nil {
 		return nil, indexeddbToGRPCErr(err)
 	}
@@ -179,7 +255,11 @@ func (s *indexedDBServer) IndexGetKey(ctx context.Context, req *proto.IndexQuery
 	if err != nil {
 		return nil, status.Errorf(codes.InvalidArgument, "unmarshal index values: %v", err)
 	}
-	key, err := s.objectStore(req.GetStore()).Index(req.GetIndex()).GetKey(ctx, values...)
+	store, err := s.objectStore(req.GetStore())
+	if err != nil {
+		return nil, indexeddbToGRPCErr(err)
+	}
+	key, err := store.Index(req.GetIndex()).GetKey(ctx, values...)
 	if err != nil {
 		return nil, indexeddbToGRPCErr(err)
 	}
@@ -195,7 +275,11 @@ func (s *indexedDBServer) IndexGetAll(ctx context.Context, req *proto.IndexQuery
 	if err != nil {
 		return nil, status.Errorf(codes.InvalidArgument, "unmarshal index values: %v", err)
 	}
-	recs, err := s.objectStore(req.GetStore()).Index(req.GetIndex()).GetAll(ctx, keyRange, values...)
+	store, err := s.objectStore(req.GetStore())
+	if err != nil {
+		return nil, indexeddbToGRPCErr(err)
+	}
+	recs, err := store.Index(req.GetIndex()).GetAll(ctx, keyRange, values...)
 	if err != nil {
 		return nil, indexeddbToGRPCErr(err)
 	}
@@ -211,7 +295,11 @@ func (s *indexedDBServer) IndexGetAllKeys(ctx context.Context, req *proto.IndexQ
 	if err != nil {
 		return nil, status.Errorf(codes.InvalidArgument, "unmarshal index values: %v", err)
 	}
-	keys, err := s.objectStore(req.GetStore()).Index(req.GetIndex()).GetAllKeys(ctx, keyRange, values...)
+	store, err := s.objectStore(req.GetStore())
+	if err != nil {
+		return nil, indexeddbToGRPCErr(err)
+	}
+	keys, err := store.Index(req.GetIndex()).GetAllKeys(ctx, keyRange, values...)
 	if err != nil {
 		return nil, indexeddbToGRPCErr(err)
 	}
@@ -227,7 +315,11 @@ func (s *indexedDBServer) IndexCount(ctx context.Context, req *proto.IndexQueryR
 	if err != nil {
 		return nil, status.Errorf(codes.InvalidArgument, "unmarshal index values: %v", err)
 	}
-	count, err := s.objectStore(req.GetStore()).Index(req.GetIndex()).Count(ctx, keyRange, values...)
+	store, err := s.objectStore(req.GetStore())
+	if err != nil {
+		return nil, indexeddbToGRPCErr(err)
+	}
+	count, err := store.Index(req.GetIndex()).Count(ctx, keyRange, values...)
 	if err != nil {
 		return nil, indexeddbToGRPCErr(err)
 	}
@@ -239,7 +331,11 @@ func (s *indexedDBServer) IndexDelete(ctx context.Context, req *proto.IndexQuery
 	if err != nil {
 		return nil, status.Errorf(codes.InvalidArgument, "unmarshal index values: %v", err)
 	}
-	deleted, err := s.objectStore(req.GetStore()).Index(req.GetIndex()).Delete(ctx, values...)
+	store, err := s.objectStore(req.GetStore())
+	if err != nil {
+		return nil, indexeddbToGRPCErr(err)
+	}
+	deleted, err := store.Index(req.GetIndex()).Delete(ctx, values...)
 	if err != nil {
 		return nil, indexeddbToGRPCErr(err)
 	}
@@ -277,7 +373,10 @@ func (s *indexedDBServer) OpenCursor(stream proto.IndexedDB_OpenCursorServer) er
 	ctx := stream.Context()
 
 	var cursor indexeddb.Cursor
-	store := s.objectStore(openReq.GetStore())
+	store, err := s.objectStore(openReq.GetStore())
+	if err != nil {
+		return indexeddbToGRPCErr(err)
+	}
 
 	if openReq.GetIndex() != "" {
 		values, vErr := protoValuesToAny(openReq.GetValues())

--- a/gestaltd/internal/providerhost/indexeddb_server_test.go
+++ b/gestaltd/internal/providerhost/indexeddb_server_test.go
@@ -16,7 +16,7 @@ func TestIndexedDBServerUsesStoreNamesAsProvided(t *testing.T) {
 	t.Parallel()
 
 	db := &coretesting.StubIndexedDB{}
-	srv := NewIndexedDBServer(db, "roadmap")
+	srv := NewIndexedDBServer(db, "roadmap", IndexedDBServerOptions{})
 	ctx := context.Background()
 	record, err := gestalt.RecordToProto(map[string]any{"id": "snap-1"})
 	if err != nil {
@@ -42,7 +42,7 @@ func TestIndexedDBServerRecordsPluginMetricAttributes(t *testing.T) {
 	ctx := metricutil.WithMeterProvider(context.Background(), metrics.Provider)
 
 	db := metricutil.InstrumentIndexedDB(&coretesting.StubIndexedDB{}, "system")
-	srv := NewIndexedDBServer(db, "roadmap")
+	srv := NewIndexedDBServer(db, "roadmap", IndexedDBServerOptions{})
 	if err := metricutil.UnwrapIndexedDB(db).CreateObjectStore(ctx, "snapshots", indexeddb.ObjectStoreSchema{
 		Indexes: []indexeddb.IndexSchema{{Name: "by_type", KeyPath: []string{"type"}}},
 	}); err != nil {
@@ -93,4 +93,30 @@ func TestIndexedDBServerRecordsPluginMetricAttributes(t *testing.T) {
 	metrictest.RequireInt64Sum(t, rm, "gestaltd.indexeddb.count", 1, indexAttrs)
 	metrictest.RequireInt64SumOmitsAttr(t, rm, "gestaltd.indexeddb.count", indexAttrs, "gestalt.store")
 	metrictest.RequireFloat64Histogram(t, rm, "gestaltd.indexeddb.duration", indexAttrs)
+}
+
+func TestIndexedDBServerRejectsStoresOutsideAllowlist(t *testing.T) {
+	t.Parallel()
+
+	db := &coretesting.StubIndexedDB{}
+	srv := NewIndexedDBServer(db, "roadmap", IndexedDBServerOptions{
+		AllowedStores: []string{"tasks"},
+	})
+	ctx := context.Background()
+	record, err := gestalt.RecordToProto(map[string]any{"id": "evt-1"})
+	if err != nil {
+		t.Fatalf("RecordToProto: %v", err)
+	}
+
+	if _, err := srv.(*indexedDBServer).Put(ctx, &proto.RecordRequest{
+		Store:  "events",
+		Record: record,
+	}); err == nil {
+		t.Fatal("Put should reject stores outside the configured allowlist")
+	}
+	if _, err := srv.(*indexedDBServer).CreateObjectStore(ctx, &proto.CreateObjectStoreRequest{
+		Name: "events",
+	}); err == nil {
+		t.Fatal("CreateObjectStore should reject stores outside the configured allowlist")
+	}
 }

--- a/gestaltd/internal/testutil/indexeddbtransport/server.go
+++ b/gestaltd/internal/testutil/indexeddbtransport/server.go
@@ -29,7 +29,7 @@ func Start(socketPath string) (*Server, error) {
 	}
 	stub := &coretesting.StubIndexedDB{}
 	srv := grpc.NewServer()
-	proto.RegisterIndexedDBServer(srv, providerhost.NewIndexedDBServer(stub, ""))
+	proto.RegisterIndexedDBServer(srv, providerhost.NewIndexedDBServer(stub, "", providerhost.IndexedDBServerOptions{}))
 	go func() { _ = srv.Serve(lis) }()
 	return &Server{srv: srv, lis: lis, Socket: socketPath}, nil
 }


### PR DESCRIPTION
## Summary

This refactors plugin IndexedDB config from a list of bindings plus `indexeddbSchema` into one canonical object:

```yaml
plugins:
  roadmap:
    indexeddb:
      provider: main
      db: roadmap_state
      objectStores:
        - tasks
```

The runtime now resolves one effective plugin IndexedDB, exposes one SDK socket via `GESTALT_INDEXEDDB_SOCKET`, and scopes storage from `indexeddb.db` instead of the old multi-binding model.

## YAML Interface

Canonical plugin config:

```yaml
plugins:
  roadmap:
    indexeddb:
      provider: main
      db: roadmap_state
      objectStores:
        - tasks
        - snapshots
```

Inherited host default:

```yaml
server:
  providers:
    indexeddb: main

plugins:
  roadmap:
    indexeddb: {}
```

Explicit opt-out:

```yaml
plugins:
  roadmap:
    indexeddb:
      disabled: true
```

Legacy migration examples still accepted:

```yaml
plugins:
  roadmap:
    indexeddb: []
```

```yaml
plugins:
  roadmap:
    indexeddb:
      - main
```

## Go Interface

```go
type PluginIndexedDBConfig struct {
    Disabled     bool     `yaml:"disabled,omitempty"`
    Provider     string   `yaml:"provider,omitempty"`
    DB           string   `yaml:"db,omitempty"`
    ObjectStores []string `yaml:"objectStores,omitempty"`
}

type ProviderEntry struct {
    IndexedDB *PluginIndexedDBConfig `yaml:"indexeddb,omitempty"`
}
```

## Behavior Changes

- plugins can declare exactly one IndexedDB provider
- omitted or empty plugin IndexedDB config inherits the selected/default host IndexedDB
- `indexeddb.db` defaults to the plugin key and drives provider-side schema/prefix scoping
- `indexeddb.objectStores` is enforced as a host-side allowlist
- plugins no longer receive named IndexedDB socket env vars; they get one socket via `GESTALT_INDEXEDDB_SOCKET`
- legacy `indexeddbSchema` is treated as a compatibility alias for `indexeddb.db`
- legacy multi-entry plugin IndexedDB lists are now rejected with a targeted migration error

## Verification

- `go test ./internal/config ./internal/bootstrap ./internal/providerhost`
- `go test ./...`
- `go build ./...`
- `golangci-lint run ./...`
