### PR TITLE
Add cache SDKs, source packaging, and docs

### DIFF
--- a/docs/content/custom-providers/_meta.ts
+++ b/docs/content/custom-providers/_meta.ts
@@ -1,6 +1,7 @@
 export default {
   plugins: "Plugins",
   auth: "Auth",
+  cache: "Cache",
   indexeddb: "IndexedDB",
   secrets: "Secrets",
   "web-uis": "Web UIs",

--- a/docs/content/custom-providers/cache.mdx
+++ b/docs/content/custom-providers/cache.mdx
@@ -1,0 +1,240 @@
+import { Tabs } from 'nextra/components'
+
+# Cache
+
+This page covers building custom cache providers. If you only need to bind a
+cache into a plugin, use [Providers > Cache](/providers/cache).
+
+Cache providers expose a small portable interface for cache-oriented backends
+such as Redis, Valkey, Memcached-style services, or in-memory implementations.
+The contract is intentionally narrower than IndexedDB: opaque byte values,
+relative TTLs, batch helpers, delete, and touch.
+
+## Manifest
+
+A cache provider manifest declares `kind: cache`:
+
+```yaml
+kind: cache
+source: github.com/valon-technologies/gestalt-providers/cache/redis
+version: 0.0.1
+displayName: Redis Cache
+description: Cache provider backed by Redis or Valkey.
+spec:
+  configSchemaPath: ./cache_config.json
+```
+
+## Provider interface
+
+The Cache service includes:
+
+| Method | Purpose |
+| --- | --- |
+| `Get` | Read a value by key |
+| `GetMany` | Read multiple keys in one request |
+| `Set` | Write a value with optional TTL |
+| `SetMany` | Write multiple values with one TTL policy |
+| `Delete` | Remove one key |
+| `DeleteMany` | Remove multiple keys |
+| `Touch` | Refresh TTL for an existing key |
+
+<Tabs items={['Go', 'Python', 'Rust', 'TypeScript']}>
+  <Tabs.Tab>
+    ```go
+    package rediscache
+
+    import (
+        "context"
+        "time"
+
+        gestalt "github.com/valon-technologies/gestalt/sdk/go"
+    )
+
+    type Provider struct{}
+
+    func New() *Provider { return &Provider{} }
+
+    func (p *Provider) Configure(_ context.Context, _ string, config map[string]any) error {
+        return nil
+    }
+
+    func (p *Provider) Get(ctx context.Context, key string) ([]byte, bool, error) {
+        return nil, false, nil
+    }
+
+    func (p *Provider) Set(ctx context.Context, key string, value []byte, opts gestalt.CacheSetOptions) error {
+        _ = opts.TTL
+        return nil
+    }
+
+    func (p *Provider) Delete(ctx context.Context, key string) (bool, error) {
+        return false, nil
+    }
+
+    func (p *Provider) Touch(ctx context.Context, key string, ttl time.Duration) (bool, error) {
+        return false, nil
+    }
+    ```
+  </Tabs.Tab>
+  <Tabs.Tab>
+    ```python
+    import datetime as dt
+
+    import gestalt
+
+    class RedisCache(gestalt.CacheProvider):
+        def get(self, key: str) -> bytes | None:
+            return None
+
+        def set(
+            self,
+            key: str,
+            value: bytes,
+            ttl: dt.timedelta | None = None,
+        ) -> None:
+            pass
+
+        def delete(self, key: str) -> bool:
+            return False
+
+        def touch(self, key: str, ttl: dt.timedelta) -> bool:
+            return False
+    ```
+  </Tabs.Tab>
+  <Tabs.Tab>
+    ```rust
+    #[derive(Default)]
+    struct RedisCache;
+
+    #[gestalt::async_trait]
+    impl gestalt::CacheProvider for RedisCache {
+        async fn get(&self, key: &str) -> gestalt::Result<Option<Vec<u8>>> {
+            let _ = key;
+            Ok(None)
+        }
+
+        async fn set(
+            &self,
+            key: &str,
+            value: &[u8],
+            options: gestalt::CacheSetOptions,
+        ) -> gestalt::Result<()> {
+            let _ = (key, value, options.ttl);
+            Ok(())
+        }
+
+        async fn delete(&self, key: &str) -> gestalt::Result<bool> {
+            let _ = key;
+            Ok(false)
+        }
+
+        async fn touch(&self, key: &str, ttl: std::time::Duration) -> gestalt::Result<bool> {
+            let _ = (key, ttl);
+            Ok(false)
+        }
+    }
+
+    gestalt::export_cache_provider!(constructor = RedisCache::default);
+    ```
+  </Tabs.Tab>
+  <Tabs.Tab>
+    ```ts
+    import { defineCacheProvider } from "@valon-technologies/gestalt";
+
+    export const cache = defineCacheProvider({
+      async get(key) {
+        return undefined;
+      },
+
+      async set(key, value, options) {
+        void key;
+        void value;
+        void options?.ttlMs;
+      },
+
+      async delete(key) {
+        void key;
+        return false;
+      },
+
+      async touch(key, ttlMs) {
+        void key;
+        void ttlMs;
+        return false;
+      },
+    });
+    ```
+  </Tabs.Tab>
+</Tabs>
+
+Python, Rust, and TypeScript cache providers inherit default implementations
+for `GetMany`, `SetMany`, and `DeleteMany`. Override the batch helpers only
+when the backing cache can do better than repeated single-key calls.
+
+## Plugin SDK
+
+Plugins consume bound caches through the language SDK. The host exposes a Unix
+socket for each requested cache binding.
+
+When a plugin binds exactly one cache, the host sets both:
+
+- `GESTALT_CACHE_SOCKET`
+- `GESTALT_CACHE_SOCKET_<NAME>`
+
+When a plugin binds multiple caches, only the named env vars are set.
+
+<Tabs items={['Go', 'Python', 'Rust', 'TypeScript']}>
+  <Tabs.Tab>
+    ```go
+    cache, err := gestalt.Cache("")
+    if err != nil {
+        panic(err)
+    }
+    defer cache.Close()
+
+    if err := cache.Set(ctx, "session", []byte("alpha"), gestalt.CacheSetOptions{}); err != nil {
+        panic(err)
+    }
+    ```
+  </Tabs.Tab>
+  <Tabs.Tab>
+    ```python
+    import datetime as dt
+    import gestalt
+
+    cache = gestalt.Cache("session")
+    cache.set("user:1", b"alpha", ttl=dt.timedelta(minutes=5))
+    value = cache.get("user:1")
+    cache.close()
+    ```
+  </Tabs.Tab>
+  <Tabs.Tab>
+    ```rust
+    let mut cache = gestalt::Cache::connect_named("session").await?;
+    cache
+        .set(
+            "user:1",
+            b"alpha",
+            gestalt::CacheSetOptions {
+                ttl: Some(std::time::Duration::from_secs(300)),
+            },
+        )
+        .await?;
+    ```
+  </Tabs.Tab>
+  <Tabs.Tab>
+    ```ts
+    import { Cache } from "@valon-technologies/gestalt";
+
+    const cache = new Cache("session");
+    await cache.set("user:1", new TextEncoder().encode("alpha"), { ttlMs: 300_000 });
+    const value = await cache.get("user:1");
+    ```
+  </Tabs.Tab>
+</Tabs>
+
+## Release flow
+
+Managed cache providers follow the same `gestaltd init` / lockfile / release
+flow as other source-backed provider kinds. Point a manifest at a published
+source ref, run `gestaltd init`, and package releases with `gestaltd provider release`.

--- a/docs/content/custom-providers/index.mdx
+++ b/docs/content/custom-providers/index.mdx
@@ -11,7 +11,7 @@ deployment, start with [Providers](/providers).
 ## What belongs here
 
 - Implementing executable or declarative plugin providers
-- Building custom auth, IndexedDB, secrets, and web UI providers
+- Building custom auth, cache, IndexedDB, secrets, and web UI providers
 - Testing providers from local source with `source.path`
 - Packaging releases with `gestaltd provider release`
 
@@ -35,6 +35,7 @@ providers:
   operations, declarative surfaces, and hybrid catalogs
 - [Auth](/custom-providers/auth): platform login providers and optional bearer
   token validation
+- [Cache](/custom-providers/cache): plugin-bound cache backends
 - [IndexedDB](/custom-providers/indexeddb): custom storage backends for system
   state
 - [Secrets](/custom-providers/secrets): secret managers for `secret://`

--- a/docs/content/providers/_meta.ts
+++ b/docs/content/providers/_meta.ts
@@ -1,6 +1,7 @@
 export default {
   plugins: "Plugins",
   auth: "Auth",
+  cache: "Cache",
   indexeddb: "IndexedDB",
   secrets: "Secrets",
   "web-uis": "Web UIs",

--- a/docs/content/providers/cache.mdx
+++ b/docs/content/providers/cache.mdx
@@ -1,0 +1,113 @@
+# Cache
+
+Cache providers are plugin-bound utilities for short-lived key/value state.
+They are configured under `providers.cache` and attached to plugins with
+`plugins.<name>.cache`.
+
+Unlike IndexedDB, cache providers are not selected through `server.providers`.
+They are only exposed to plugins that request them.
+
+## Configuration
+
+```yaml
+providers:
+  cache:
+    session:
+      source:
+        ref: github.com/valon-technologies/gestalt-providers/cache/redis
+        version: 0.0.1-alpha.1
+      config:
+        addr: ${VALKEY_ADDR}
+        db: 0
+
+    rate_limit:
+      source:
+        ref: github.com/valon-technologies/gestalt-providers/cache/redis
+        version: 0.0.1-alpha.1
+      config:
+        addr: ${VALKEY_ADDR}
+        db: 1
+
+plugins:
+  search:
+    source:
+      path: ./providers/search/manifest.yaml
+    cache:
+      - session
+      - rate_limit
+```
+
+## How bindings work
+
+- `plugins.<name>.cache` is a list of named cache bindings.
+- Cache names must exist under `providers.cache`.
+- Duplicate cache names are rejected during config validation.
+- With one binding, the host sets both `GESTALT_CACHE_SOCKET` and the named env var.
+- With multiple bindings, the host sets only the named env vars:
+  `GESTALT_CACHE_SOCKET_<NAME>`.
+
+For a binding named `session`, the SDK env var is:
+
+```text
+GESTALT_CACHE_SOCKET_SESSION
+```
+
+Names are normalized to uppercase with non-alphanumeric characters replaced by `_`.
+
+## SDK use
+
+Go:
+
+```go
+cache, err := gestalt.Cache("session")
+if err != nil {
+    panic(err)
+}
+defer cache.Close()
+
+value, found, err := cache.Get(ctx, "user:1")
+if err != nil {
+    panic(err)
+}
+_ = value
+_ = found
+```
+
+Python:
+
+```python
+import datetime as dt
+import gestalt
+
+cache = gestalt.Cache("session")
+cache.set("user:1", b"alpha", ttl=dt.timedelta(minutes=5))
+value = cache.get("user:1")
+cache.close()
+```
+
+Rust:
+
+```rust
+let mut cache = gestalt::Cache::connect_named("session").await?;
+let value = cache.get("user:1").await?;
+```
+
+TypeScript:
+
+```ts
+import { Cache } from "@valon-technologies/gestalt";
+
+const cache = new Cache("session");
+const value = await cache.get("user:1");
+```
+
+## First-party providers
+
+First-party cache backends can live under
+`github.com/valon-technologies/gestalt-providers/cache/...`.
+The exact package set depends on what has been published so far.
+
+## Custom implementations
+
+For manifests, SDK authoring surfaces, and release flow, see
+[Custom Providers > Cache](/custom-providers/cache).

--- a/docs/content/providers/index.mdx
+++ b/docs/content/providers/index.mdx
@@ -6,9 +6,9 @@ asIndexPage: true
 
 Gestalt loads most integration and platform surfaces as providers instead of
 compiling them into `gestaltd`. Plugins, auth backends, IndexedDB backends,
-external secret managers, and public web UIs all use the same provider model:
-you reference a package in config, the host resolves it, validates it, and
-starts it with the permissions and request context it needs.
+cache backends, external secret managers, and public web UIs all use the same
+provider model: you reference a package in config, the host resolves it,
+validates it, and starts it with the permissions and request context it needs.
 
 ## Provider kinds
 
@@ -16,6 +16,7 @@ starts it with the permissions and request context it needs.
 | --- | --- | --- |
 | `plugin` | Tool providers that expose operations over CLI, HTTP API, and MCP | `plugins.<name>` |
 | `auth` | Platform login backends | `providers.auth` |
+| `cache` | Plugin-bound cache backends | `providers.cache.<name>` |
 | `indexeddb` | Persistent state backends for users, sessions, tokens, and credentials | `providers.indexeddb.<name>` |
 | `secrets` | Secret managers that resolve `secret://` references | `providers.secrets` |
 | `webui` | Public UI bundles served under configured path prefixes | `providers.ui` |
@@ -43,6 +44,7 @@ The repository is organized by provider type:
 | --- | --- | --- |
 | Plugins | [`plugins/`](https://github.com/valon-technologies/gestalt-providers/tree/main/plugins) | `plugins.<name>` |
 | Auth | [`auth/`](https://github.com/valon-technologies/gestalt-providers/tree/main/auth) | `providers.auth` |
+| Cache | [`cache/`](https://github.com/valon-technologies/gestalt-providers/tree/main/cache) | `providers.cache.<name>` |
 | IndexedDB | [`indexeddb/`](https://github.com/valon-technologies/gestalt-providers/tree/main/indexeddb) | `providers.indexeddb.<name>` |
 | Secrets | [`secrets/`](https://github.com/valon-technologies/gestalt-providers/tree/main/secrets) | `providers.secrets` |
 | Web UI bundles | [`web/`](https://github.com/valon-technologies/gestalt-providers/tree/main/web) | `providers.ui` |
@@ -74,11 +76,21 @@ providers:
       config:
         dsn: ${DATABASE_URL}
 
+  cache:
+    session:
+      source:
+        ref: github.com/valon-technologies/gestalt-providers/cache/redis
+        version: 0.0.1-alpha.1
+      config:
+        address: ${REDIS_ADDR}
+
 plugins:
   github:
     source:
       ref: github.com/valon-technologies/gestalt-providers/plugins/github
       version: 0.0.1-alpha.1
+    cache:
+      - session
 ```
 
 Run `gestaltd init` when you want to resolve and pin published releases ahead
@@ -93,6 +105,7 @@ release workflow now lives under [Custom Providers](/custom-providers).
 
 - [Plugins](/providers/plugins): choosing and configuring plugin providers
 - [Auth](/providers/auth): platform login providers
+- [Cache](/providers/cache): plugin-bound cache backends
 - [IndexedDB](/providers/indexeddb): storage backends
 - [Secrets](/providers/secrets): built-in and external secret managers
 - [Web UIs](/providers/web-uis): public UI bundles

--- a/docs/content/reference/config-file.mdx
+++ b/docs/content/reference/config-file.mdx
@@ -218,6 +218,40 @@ Common first-party IndexedDB packages:
 | DynamoDB | `github.com/valon-technologies/gestalt-providers/indexeddb/dynamodb` | `table`, `region`, optional `endpoint` |
 | MongoDB | `github.com/valon-technologies/gestalt-providers/indexeddb/mongodb` | `uri`, optional `database` |
 
+## `providers.cache`
+
+Caches are provider-based and plugin-bound. Configure one or more named entries
+under `providers.cache`, then reference those names from `plugins.<name>.cache`.
+Unlike IndexedDB, caches are not selected through `server.providers`.
+
+```yaml
+providers:
+  cache:
+    session:
+      source:
+        ref: github.com/valon-technologies/gestalt-providers/cache/redis
+        version: 0.0.1-alpha.1
+      config:
+        address: ${REDIS_ADDR}
+        database: 0
+
+plugins:
+  github:
+    cache:
+      - session
+```
+
+First-party cache providers are published at
+`github.com/valon-technologies/gestalt-providers/cache/<name>`.
+
+| Field | Description |
+| --- | --- |
+| `source.ref` | Managed provider source address. |
+| `source.version` | Required with `source.ref`. SemVer without a leading `v`. |
+| `config` | Arbitrary provider-specific config passed through to the cache provider. |
+| `env` | Extra environment variables passed to the provider process. |
+| `allowedHosts` | Network allowlist for sandboxed provider processes. |
+
 ## `providers.secrets`
 
 The secrets manager resolves `secret://` references at startup. Two built-in sources (`env` and `file`) are selected by the `source` field. Cloud secret backends are loaded as external providers using `source.ref`, the same way auth and indexeddb providers work.

--- a/docs/content/reference/plugin-manifests.mdx
+++ b/docs/content/reference/plugin-manifests.mdx
@@ -4,7 +4,9 @@ import { Tabs } from 'nextra/components'
 
 Gestalt provider packages and release archives are described by a manifest file: `manifest.yaml`, `manifest.yml`, or `manifest.json`. YAML is the easiest format to author by hand.
 
-Providers are the umbrella concept in Gestalt. Auth providers, indexeddb providers, and plugins all use this manifest format. The `plugin` manifest kind is reserved for providers that expose callable operations.
+Providers are the umbrella concept in Gestalt. Auth providers, cache providers,
+indexeddb providers, and plugins all use this manifest format. The `plugin`
+manifest kind is reserved for providers that expose callable operations.
 
 ## Manifest Kinds
 
@@ -14,6 +16,7 @@ Every manifest defines exactly one provider kind, set by the `kind` field:
 | --- | --- |
 | `plugin` | Plugin (REST, OpenAPI, GraphQL, MCP, or executable). |
 | `auth` | Platform auth provider. |
+| `cache` | Cache backend for plugin-bound cache bindings. |
 | `indexeddb` | Persistence backend. |
 | `secrets` | Secret manager for resolving `secret://` references. |
 | `webui` | Static UI package served by `gestaltd`. |
@@ -26,7 +29,7 @@ These fields appear at the top level of every manifest regardless of kind.
 
 | Field | Type | Required | Purpose |
 | --- | --- | --- | --- |
-| `kind` | string | yes | The provider kind (`plugin`, `auth`, `indexeddb`, `secrets`, `webui`). |
+| `kind` | string | yes | The provider kind (`plugin`, `auth`, `cache`, `indexeddb`, `secrets`, `webui`). |
 | `source` | string | yes | Canonical provider source identifier. Use `github.com/<org>/<repo>/<path>`. The final path segment is the provider package name; preceding segments are used for release tags and source resolution. |
 | `version` | string | yes | Semver version. Pre-release suffixes like `-alpha.1` are allowed. |
 | `displayName` | string | no | Human-readable label shown in the UI. |

--- a/gestaltd/cmd/gestaltd/plugin.go
+++ b/gestaltd/cmd/gestaltd/plugin.go
@@ -339,10 +339,8 @@ func missingReleaseSourceBuildTargetError(kind string) error {
 	switch kind {
 	case providermanifestv1.KindPlugin:
 		return fmt.Errorf("no Go, Rust, Python, or TypeScript provider package found")
-	case providermanifestv1.KindAuth, providermanifestv1.KindIndexedDB, providermanifestv1.KindSecrets:
+	case providermanifestv1.KindAuth, providermanifestv1.KindCache, providermanifestv1.KindIndexedDB, providermanifestv1.KindSecrets:
 		return fmt.Errorf("no Go, Rust, Python, or TypeScript %s source package found", kind)
-	case providermanifestv1.KindCache:
-		return fmt.Errorf("no Go cache source package found")
 	default:
 		return fmt.Errorf("unsupported release build target kind %q", kind)
 	}

--- a/gestaltd/internal/providerpkg/go_provider.go
+++ b/gestaltd/internal/providerpkg/go_provider.go
@@ -23,7 +23,6 @@ const goReadonlyFlag = "-mod=readonly"
 
 var ErrNoGoProviderPackage = errors.New("no Go provider package found")
 var ErrNoSourceComponentPackage = errors.New("no source component package found")
-var ErrCacheSourceComponentRequiresGo = errors.New("cache source components currently require a Go package")
 var ErrGoToolUnavailable = errors.New("go tool unavailable")
 var goProviderNameSlugPattern = regexp.MustCompile(`[^A-Za-z0-9._-]+`)
 
@@ -194,13 +193,6 @@ func detectSourceComponent(root, kind, goos, goarch string) (sourceKind string, 
 		goToolUnavailable = err
 	} else if !errors.Is(err, ErrNoSourceComponentPackage) {
 		return "", "", err
-	}
-
-	if kind == providermanifestv1.KindCache {
-		if goToolUnavailable != nil {
-			return "", "", goToolUnavailable
-		}
-		return "", "", fmt.Errorf("%w: %w", ErrNoSourceComponentPackage, ErrCacheSourceComponentRequiresGo)
 	}
 
 	if _, err := detectRustPackage(root); err == nil {

--- a/gestaltd/internal/providerpkg/python_provider.go
+++ b/gestaltd/internal/providerpkg/python_provider.go
@@ -254,6 +254,7 @@ func SplitPythonProviderTarget(target string) (module string, attr string, err e
 const (
 	pythonRuntimeKindIntegration = "integration"
 	pythonRuntimeKindAuth        = "auth"
+	pythonRuntimeKindCache       = "cache"
 	pythonRuntimeKindIndexedDB   = "indexeddb"
 	pythonRuntimeKindSecrets     = "secrets"
 )
@@ -264,6 +265,8 @@ func pythonRuntimeKind(kind string) (string, error) {
 		return pythonRuntimeKindIntegration, nil
 	case providermanifestv1.KindAuth:
 		return pythonRuntimeKindAuth, nil
+	case providermanifestv1.KindCache:
+		return pythonRuntimeKindCache, nil
 	case providermanifestv1.KindIndexedDB:
 		return pythonRuntimeKindIndexedDB, nil
 	case providermanifestv1.KindSecrets:

--- a/gestaltd/internal/providerpkg/python_provider_test.go
+++ b/gestaltd/internal/providerpkg/python_provider_test.go
@@ -64,6 +64,7 @@ func TestDetectPythonComponentTarget(t *testing.T) {
 	if err := os.WriteFile(filepath.Join(root, "pyproject.toml"), []byte(`[tool.gestalt]
 plugin = "provider"
 auth = "provider:auth_provider"
+cache = "provider:cache_provider"
 indexeddb = "provider:indexeddb_provider"
 `), 0o644); err != nil {
 		t.Fatalf("WriteFile(pyproject.toml): %v", err)
@@ -75,6 +76,14 @@ indexeddb = "provider:indexeddb_provider"
 	}
 	if authTarget != "provider:auth_provider" {
 		t.Fatalf("auth target = %q, want %q", authTarget, "provider:auth_provider")
+	}
+
+	cacheTarget, err := DetectPythonComponentTarget(root, providermanifestv1.KindCache)
+	if err != nil {
+		t.Fatalf("DetectPythonComponentTarget(cache): %v", err)
+	}
+	if cacheTarget != "provider:cache_provider" {
+		t.Fatalf("cache target = %q, want %q", cacheTarget, "provider:cache_provider")
 	}
 
 	datastoreTarget, err := DetectPythonComponentTarget(root, providermanifestv1.KindIndexedDB)
@@ -166,6 +175,18 @@ func TestPythonComponentExecutionCommand_PassesRuntimeKind(t *testing.T) {
 	}
 	if got := strings.Join(args, " "); got != "-m gestalt._runtime "+root+" provider:auth_provider auth" {
 		t.Fatalf("args = %q", got)
+	}
+}
+
+func TestPythonRuntimeKind_Cache(t *testing.T) {
+	t.Parallel()
+
+	got, err := pythonRuntimeKind(providermanifestv1.KindCache)
+	if err != nil {
+		t.Fatalf("pythonRuntimeKind(cache): %v", err)
+	}
+	if got != pythonRuntimeKindCache {
+		t.Fatalf("runtime kind = %q, want %q", got, pythonRuntimeKindCache)
 	}
 }
 

--- a/gestaltd/internal/providerpkg/rust_provider.go
+++ b/gestaltd/internal/providerpkg/rust_provider.go
@@ -295,6 +295,8 @@ func rustServeFunction(kind string) (string, bool, error) {
 		return "__gestalt_serve", true, nil
 	case providermanifestv1.KindAuth:
 		return "__gestalt_serve_auth", false, nil
+	case providermanifestv1.KindCache:
+		return "__gestalt_serve_cache", false, nil
 	case providermanifestv1.KindIndexedDB:
 		return "__gestalt_serve_indexeddb", false, nil
 	case providermanifestv1.KindSecrets:
@@ -306,7 +308,7 @@ func rustServeFunction(kind string) (string, bool, error) {
 
 func rustBinaryName(kind string) string {
 	switch kind {
-	case providermanifestv1.KindAuth, providermanifestv1.KindIndexedDB, providermanifestv1.KindSecrets:
+	case providermanifestv1.KindAuth, providermanifestv1.KindCache, providermanifestv1.KindIndexedDB, providermanifestv1.KindSecrets:
 		return kind
 	default:
 		return "provider"

--- a/gestaltd/internal/providerpkg/rust_provider_test.go
+++ b/gestaltd/internal/providerpkg/rust_provider_test.go
@@ -110,6 +110,7 @@ func TestBuildRustComponentBinary_UsesKindSpecificWrapper(t *testing.T) {
 		expectedServeExport string
 	}{
 		{name: "auth", kind: "auth", expectedServeExport: "__gestalt_serve_auth"},
+		{name: "cache", kind: "cache", expectedServeExport: "__gestalt_serve_cache"},
 		{name: "indexeddb", kind: "indexeddb", expectedServeExport: "__gestalt_serve_indexeddb"},
 	}
 

--- a/gestaltd/internal/providerpkg/source_provider_test.go
+++ b/gestaltd/internal/providerpkg/source_provider_test.go
@@ -41,3 +41,23 @@ func TestDetectSourceComponent_WorkspaceCargoManifestIsMiss(t *testing.T) {
 		t.Fatalf("error = %v, want %v", err, ErrNoSourceComponentPackage)
 	}
 }
+
+func TestDetectSourceComponent_CacheFallsBackToPython(t *testing.T) {
+	t.Parallel()
+
+	root := t.TempDir()
+	mustWriteFile(t, filepath.Join(root, pythonProjectFile), []byte(`[tool.gestalt]
+cache = "provider:cache_provider"
+`), 0o644)
+
+	kind, target, err := detectSourceComponent(root, providermanifestv1.KindCache, runtime.GOOS, runtime.GOARCH)
+	if err != nil {
+		t.Fatalf("detectSourceComponent(cache): %v", err)
+	}
+	if kind != sourceProviderKindPython {
+		t.Fatalf("kind = %q, want %q", kind, sourceProviderKindPython)
+	}
+	if target != "provider:cache_provider" {
+		t.Fatalf("target = %q, want %q", target, "provider:cache_provider")
+	}
+}

--- a/gestaltd/internal/providerpkg/typescript_provider.go
+++ b/gestaltd/internal/providerpkg/typescript_provider.go
@@ -23,6 +23,7 @@ const (
 	typeScriptProviderKey  = "provider"
 	typeScriptPluginKey    = "plugin"
 	typeScriptAuthKey      = "auth"
+	typeScriptCacheKey     = "cache"
 	typeScriptIndexedDBKey = "indexeddb"
 )
 
@@ -171,6 +172,8 @@ func typeScriptComponentKind(kind string) (string, error) {
 	switch kind {
 	case providermanifestv1.KindAuth:
 		return "auth", nil
+	case providermanifestv1.KindCache:
+		return "cache", nil
 	case providermanifestv1.KindIndexedDB:
 		return "indexeddb", nil
 	case providermanifestv1.KindSecrets:
@@ -186,6 +189,8 @@ func typeScriptLegacyTargetKey(kind string) (string, bool) {
 		return typeScriptPluginKey, true
 	case "auth":
 		return typeScriptAuthKey, true
+	case "cache":
+		return typeScriptCacheKey, true
 	case "indexeddb":
 		return typeScriptIndexedDBKey, true
 	default:
@@ -313,6 +318,8 @@ func normalizeTypeScriptProviderKind(value string) string {
 		return "integration"
 	case "auth":
 		return "auth"
+	case "cache":
+		return "cache"
 	case "indexeddb":
 		return "indexeddb"
 	case "secrets":

--- a/gestaltd/internal/providerpkg/typescript_provider_test.go
+++ b/gestaltd/internal/providerpkg/typescript_provider_test.go
@@ -16,6 +16,8 @@ const (
 	typeScriptTestPluginTarget          = "plugin:./provider.ts#plugin"
 	typeScriptTestAuthModuleTarget      = "./auth.ts#auth"
 	typeScriptTestAuthTarget            = "auth:./auth.ts#auth"
+	typeScriptTestCacheModuleTarget     = "./cache.ts#cache"
+	typeScriptTestCacheTarget           = "cache:./cache.ts#cache"
 	typeScriptTestDatastoreModuleTarget = "./datastore.ts#datastore"
 	typeScriptTestDatastoreTarget       = "indexeddb:./datastore.ts#datastore"
 )
@@ -189,6 +191,11 @@ func TestDetectTypeScriptComponentTarget(t *testing.T) {
 			target: typeScriptTestAuthTarget,
 		},
 		{
+			name:   "cache",
+			kind:   providermanifestv1.KindCache,
+			target: typeScriptTestCacheTarget,
+		},
+		{
 			name:   "indexeddb",
 			kind:   providermanifestv1.KindIndexedDB,
 			target: typeScriptTestDatastoreTarget,
@@ -243,6 +250,14 @@ func TestHasSourceComponentPackage_TypeScript(t *testing.T) {
 	}
 	if !ok {
 		t.Fatal("HasSourceComponentPackage(auth) = false, want true")
+	}
+
+	ok, err = HasSourceComponentPackage(root, providermanifestv1.KindCache)
+	if err != nil {
+		t.Fatalf("HasSourceComponentPackage(cache): %v", err)
+	}
+	if ok {
+		t.Fatal("HasSourceComponentPackage(cache) = true, want false")
 	}
 
 	ok, err = HasSourceComponentPackage(root, providermanifestv1.KindIndexedDB)
@@ -320,6 +335,11 @@ func TestSourceComponentExecutionCommand_TypeScript(t *testing.T) {
 			name:   "auth",
 			kind:   providermanifestv1.KindAuth,
 			target: typeScriptTestAuthTarget,
+		},
+		{
+			name:   "cache",
+			kind:   providermanifestv1.KindCache,
+			target: typeScriptTestCacheTarget,
 		},
 		{
 			name:   "indexeddb",
@@ -403,6 +423,11 @@ func TestValidateSourceComponentRelease_TypeScript(t *testing.T) {
 			target: typeScriptTestAuthTarget,
 		},
 		{
+			name:   "cache",
+			kind:   providermanifestv1.KindCache,
+			target: typeScriptTestCacheTarget,
+		},
+		{
 			name:   "indexeddb",
 			kind:   providermanifestv1.KindIndexedDB,
 			target: typeScriptTestDatastoreTarget,
@@ -464,6 +489,12 @@ func TestBuildSourceComponentReleaseBinary_TypeScript(t *testing.T) {
 			kind:       providermanifestv1.KindAuth,
 			target:     typeScriptTestAuthTarget,
 			pluginName: "ts-auth-release",
+		},
+		{
+			name:       "cache",
+			kind:       providermanifestv1.KindCache,
+			target:     typeScriptTestCacheTarget,
+			pluginName: "ts-cache-release",
 		},
 		{
 			name:       "indexeddb",
@@ -532,7 +563,7 @@ func mustWriteTypeScriptPackageConfig(t *testing.T, root string, gestalt map[str
 	t.Helper()
 
 	var fields []string
-	for _, key := range []string{typeScriptProviderKey, typeScriptPluginKey, typeScriptAuthKey, typeScriptIndexedDBKey} {
+	for _, key := range []string{typeScriptProviderKey, typeScriptPluginKey, typeScriptAuthKey, typeScriptCacheKey, typeScriptIndexedDBKey} {
 		value, ok := gestalt[key]
 		if !ok {
 			continue
@@ -565,7 +596,7 @@ func mustWriteTypeScriptTargetModule(t *testing.T, root, target string) {
 
 func runtimeTargetModulePath(t *testing.T, target string) string {
 	t.Helper()
-	for _, prefix := range []string{"plugin:", "integration:", "auth:", "indexeddb:", "secrets:", "telemetry:"} {
+	for _, prefix := range []string{"plugin:", "integration:", "auth:", "cache:", "indexeddb:", "secrets:", "telemetry:"} {
 		if strings.HasPrefix(target, prefix) {
 			return strings.TrimPrefix(target, prefix)
 		}

--- a/sdk/python/gestalt/__init__.py
+++ b/sdk/python/gestalt/__init__.py
@@ -9,6 +9,7 @@ from ._api import (
     Subject,
     field,
 )
+from ._cache import Cache, CacheEntry, cache_socket_env
 from ._catalog import (
     Catalog,
     CatalogOperation,
@@ -38,6 +39,7 @@ from ._providers import (
     AuthProvider,
     BeginLoginRequest,
     BeginLoginResponse,
+    CacheProvider,
     Closer,
     CompleteLoginRequest,
     ExternalTokenValidator,
@@ -56,6 +58,9 @@ __all__ = [
     "AlreadyExistsError",
     "AuthProvider",
     "AuthenticatedUser",
+    "Cache",
+    "CacheEntry",
+    "CacheProvider",
     "Access",
     "BeginLoginRequest",
     "BeginLoginResponse",
@@ -96,6 +101,7 @@ __all__ = [
     "SessionCatalogProvider",
     "SessionTTLProvider",
     "WarningsProvider",
+    "cache_socket_env",
     "field",
     "indexeddb_socket_env",
     "operation",

--- a/sdk/python/gestalt/_cache.py
+++ b/sdk/python/gestalt/_cache.py
@@ -1,0 +1,126 @@
+from __future__ import annotations
+
+import datetime as _dt
+import os
+from dataclasses import dataclass
+from typing import Any, Iterable
+
+import grpc
+from google.protobuf import duration_pb2 as _duration_pb2
+
+from .gen.v1 import cache_pb2 as _pb
+from .gen.v1 import cache_pb2_grpc as _pb_grpc
+
+pb: Any = _pb
+pb_grpc: Any = _pb_grpc
+duration_pb2: Any = _duration_pb2
+
+ENV_CACHE_SOCKET = "GESTALT_CACHE_SOCKET"
+
+
+def cache_socket_env(name: str | None = None) -> str:
+    trimmed = (name or "").strip()
+    if not trimmed:
+        return ENV_CACHE_SOCKET
+    normalized = "".join(
+        ch.upper() if ch.isascii() and ch.isalnum() else "_" for ch in trimmed
+    )
+    return f"{ENV_CACHE_SOCKET}_{normalized}"
+
+
+@dataclass(frozen=True)
+class CacheEntry:
+    key: str
+    value: bytes
+
+
+class Cache:
+    def __init__(self, name: str | None = None) -> None:
+        env_name = cache_socket_env(name)
+        socket_path = os.environ.get(env_name, "")
+        if not socket_path:
+            raise RuntimeError(f"{env_name} is not set")
+        self._channel = grpc.insecure_channel(f"unix:{socket_path}")
+        self._stub = pb_grpc.CacheStub(self._channel)
+
+    def close(self) -> None:
+        self._channel.close()
+
+    def get(self, key: str) -> bytes | None:
+        resp = _grpc_call(self._stub.Get, pb.CacheGetRequest(key=key))
+        if not resp.found:
+            return None
+        return bytes(resp.value)
+
+    def get_many(self, keys: list[str]) -> dict[str, bytes]:
+        resp = _grpc_call(self._stub.GetMany, pb.CacheGetManyRequest(keys=keys))
+        out: dict[str, bytes] = {}
+        for entry in resp.entries:
+            if entry.found:
+                out[entry.key] = bytes(entry.value)
+        return out
+
+    def set(
+        self,
+        key: str,
+        value: bytes,
+        ttl: _dt.timedelta | None = None,
+    ) -> None:
+        _grpc_call(
+            self._stub.Set,
+            pb.CacheSetRequest(key=key, value=bytes(value), ttl=_duration_from_ttl(ttl)),
+        )
+
+    def set_many(
+        self,
+        entries: Iterable[CacheEntry],
+        ttl: _dt.timedelta | None = None,
+    ) -> None:
+        _grpc_call(
+            self._stub.SetMany,
+            pb.CacheSetManyRequest(
+                entries=[
+                    pb.CacheSetEntry(key=entry.key, value=bytes(entry.value))
+                    for entry in entries
+                ],
+                ttl=_duration_from_ttl(ttl),
+            ),
+        )
+
+    def delete(self, key: str) -> bool:
+        resp = _grpc_call(self._stub.Delete, pb.CacheDeleteRequest(key=key))
+        return bool(resp.deleted)
+
+    def delete_many(self, keys: list[str]) -> int:
+        resp = _grpc_call(self._stub.DeleteMany, pb.CacheDeleteManyRequest(keys=keys))
+        return int(resp.deleted)
+
+    def touch(self, key: str, ttl: _dt.timedelta) -> bool:
+        resp = _grpc_call(
+            self._stub.Touch,
+            pb.CacheTouchRequest(key=key, ttl=_duration_from_ttl(ttl)),
+        )
+        return bool(resp.touched)
+
+    def __enter__(self) -> Cache:
+        return self
+
+    def __exit__(self, *args: Any) -> None:
+        self.close()
+
+
+def _duration_from_ttl(ttl: _dt.timedelta | None) -> Any:
+    if ttl is None:
+        return None
+    if ttl.total_seconds() <= 0:
+        return None
+    duration = duration_pb2.Duration()
+    duration.FromTimedelta(ttl)
+    return duration
+
+
+def _grpc_call(method: Any, request: Any) -> Any:
+    try:
+        return method(request)
+    except grpc.RpcError:
+        raise

--- a/sdk/python/gestalt/_providers.py
+++ b/sdk/python/gestalt/_providers.py
@@ -2,6 +2,7 @@ import datetime as dt
 from enum import Enum
 from typing import Any, Callable
 
+from ._cache import CacheEntry
 from .gen.v1 import auth_pb2 as _auth_pb2
 
 AuthenticatedUser: Any = _auth_pb2.AuthenticatedUser  # ty: ignore[unresolved-attribute]
@@ -13,6 +14,7 @@ CompleteLoginRequest: Any = _auth_pb2.CompleteLoginRequest  # ty: ignore[unresol
 class ProviderKind(str, Enum):
     INTEGRATION = "integration"
     AUTH = "auth"
+    CACHE = "cache"
     SECRETS = "secrets"
     TELEMETRY = "telemetry"
 
@@ -115,3 +117,43 @@ class SecretsProvider(PluginProvider):
         _runtime.serve(self, runtime_kind=ProviderKind.SECRETS)
 
 
+class CacheProvider(PluginProvider):
+    def get(self, key: str) -> bytes | None:
+        raise NotImplementedError
+
+    def get_many(self, keys: list[str]) -> dict[str, bytes]:
+        values: dict[str, bytes] = {}
+        for key in keys:
+            value = self.get(key)
+            if value is not None:
+                values[key] = bytes(value)
+        return values
+
+    def set(self, key: str, value: bytes, ttl: dt.timedelta | None = None) -> None:
+        raise NotImplementedError
+
+    def set_many(self, entries: list[CacheEntry], ttl: dt.timedelta | None = None) -> None:
+        for entry in entries:
+            self.set(entry.key, entry.value, ttl)
+
+    def delete(self, key: str) -> bool:
+        raise NotImplementedError
+
+    def delete_many(self, keys: list[str]) -> int:
+        deleted = 0
+        seen: set[str] = set()
+        for key in keys:
+            if key in seen:
+                continue
+            seen.add(key)
+            if self.delete(key):
+                deleted += 1
+        return deleted
+
+    def touch(self, key: str, ttl: dt.timedelta) -> bool:
+        raise NotImplementedError
+
+    def serve(self) -> None:
+        from . import _runtime
+
+        _runtime.serve(self, runtime_kind=ProviderKind.CACHE)

--- a/sdk/python/gestalt/_runtime.py
+++ b/sdk/python/gestalt/_runtime.py
@@ -1,3 +1,4 @@
+import datetime as dt
 import functools
 import importlib
 import os
@@ -11,15 +12,18 @@ from http import HTTPStatus
 from typing import Any, Final, cast
 
 import grpc
+from google.protobuf import duration_pb2 as _duration_pb2
 from google.protobuf import empty_pb2 as _empty_pb2
 from google.protobuf import json_format
 
 from ._api import Access, Credential, Request, Subject
 from ._bootstrap import parse_plugin_target, read_bundled_plugin_config
+from ._cache import CacheEntry
 from ._catalog import catalog_to_proto
 from ._plugin import Plugin, _module_plugin
 from ._providers import (
     AuthProvider,
+    CacheProvider,
     Closer,
     ExternalTokenValidator,
     HealthChecker,
@@ -35,6 +39,8 @@ from ._providers import (
 from ._serialization import json_body
 from .gen.v1 import auth_pb2 as _auth_pb2
 from .gen.v1 import auth_pb2_grpc as _auth_pb2_grpc
+from .gen.v1 import cache_pb2 as _cache_pb2
+from .gen.v1 import cache_pb2_grpc as _cache_pb2_grpc
 from .gen.v1 import plugin_pb2 as _plugin_pb2
 from .gen.v1 import plugin_pb2_grpc as _plugin_pb2_grpc
 from .gen.v1 import runtime_pb2 as _runtime_pb2
@@ -43,12 +49,15 @@ from .gen.v1 import secrets_pb2 as _secrets_pb2
 from .gen.v1 import secrets_pb2_grpc as _secrets_pb2_grpc
 
 empty_pb2: Any = _empty_pb2
+duration_pb2: Any = _duration_pb2
 plugin_pb2: Any = _plugin_pb2
 plugin_pb2_grpc: Any = _plugin_pb2_grpc
 runtime_pb2: Any = _runtime_pb2
 runtime_pb2_grpc: Any = _runtime_pb2_grpc
 auth_pb2: Any = _auth_pb2
 auth_pb2_grpc: Any = _auth_pb2_grpc
+cache_pb2: Any = _cache_pb2
+cache_pb2_grpc: Any = _cache_pb2_grpc
 secrets_pb2: Any = _secrets_pb2
 secrets_pb2_grpc: Any = _secrets_pb2_grpc
 
@@ -180,11 +189,13 @@ def _load_target(args: RuntimeArgs) -> Plugin | PluginProviderAdapter | PluginPr
 
     if resolved_kind == ProviderKind.AUTH and isinstance(target, AuthProvider):
         return _auth_runtime_plugin(target)
+    if resolved_kind == ProviderKind.CACHE and isinstance(target, CacheProvider):
+        return _cache_runtime_plugin(target)
     if resolved_kind == ProviderKind.SECRETS and isinstance(target, SecretsProvider):
         return _secrets_runtime_plugin(target)
     if isinstance(target, PluginProvider):
         raise RuntimeError(
-            "providers must be wrapped in gestalt.PluginProviderAdapter unless runtime_kind is auth or secrets"
+            "providers must be wrapped in gestalt.PluginProviderAdapter unless runtime_kind is auth, cache, or secrets"
         )
     raise RuntimeError(f"{args.target} did not resolve to a supported gestalt target")
 
@@ -263,6 +274,8 @@ def _servable_target(
     kind = _normalized_runtime_kind(runtime_kind)
     if kind == ProviderKind.AUTH and isinstance(target, AuthProvider):
         return _auth_runtime_plugin(target)
+    if kind == ProviderKind.CACHE and isinstance(target, CacheProvider):
+        return _cache_runtime_plugin(target)
     if kind == ProviderKind.SECRETS and isinstance(target, SecretsProvider):
         return _secrets_runtime_plugin(target)
     raise RuntimeError("unsupported runtime target")
@@ -302,6 +315,25 @@ def _register_secrets_services(server: Any, provider: PluginProvider) -> None:
     )
     secrets_pb2_grpc.add_SecretsProviderServicer_to_server(
         _secrets_servicer(provider=provider),
+        server,
+    )
+
+
+def _cache_runtime_plugin(provider: CacheProvider) -> PluginProviderAdapter:
+    return PluginProviderAdapter(
+        kind=ProviderKind.CACHE,
+        provider=provider,
+        register_services=_register_cache_services,
+    )
+
+
+def _register_cache_services(server: Any, provider: PluginProvider) -> None:
+    runtime_pb2_grpc.add_ProviderLifecycleServicer_to_server(
+        _runtime_servicer(provider=provider, kind=ProviderKind.CACHE),
+        server,
+    )
+    cache_pb2_grpc.add_CacheServicer_to_server(
+        _cache_servicer(provider=provider),
         server,
     )
 
@@ -501,6 +533,74 @@ def _secrets_servicer(*, provider: PluginProvider) -> Any:
     return SecretsServicer()
 
 
+def _cache_servicer(*, provider: PluginProvider) -> Any:
+    cache_provider = cast(CacheProvider, provider)
+
+    class CacheServicer(cache_pb2_grpc.CacheServicer):
+        @_grpc_handler("cache get")
+        def Get(self, request: Any, _context: Any) -> Any:
+            value = cache_provider.get(request.key)
+            if value is None:
+                return cache_pb2.CacheGetResponse(found=False, value=b"")
+            return cache_pb2.CacheGetResponse(found=True, value=bytes(value))
+
+        @_grpc_handler("cache get_many")
+        def GetMany(self, request: Any, _context: Any) -> Any:
+            values = cache_provider.get_many(list(request.keys))
+            entries = []
+            for key in request.keys:
+                value = values.get(key)
+                if value is None:
+                    entries.append(cache_pb2.CacheResult(key=key, found=False, value=b""))
+                else:
+                    entries.append(
+                        cache_pb2.CacheResult(key=key, found=True, value=bytes(value))
+                    )
+            return cache_pb2.CacheGetManyResponse(entries=entries)
+
+        @_grpc_handler("cache set")
+        def Set(self, request: Any, _context: Any) -> Any:
+            cache_provider.set(
+                request.key,
+                bytes(request.value),
+                _duration_to_timedelta(request.ttl),
+            )
+            return empty_pb2.Empty()
+
+        @_grpc_handler("cache set_many")
+        def SetMany(self, request: Any, _context: Any) -> Any:
+            cache_provider.set_many(
+                [CacheEntry(key=entry.key, value=bytes(entry.value)) for entry in request.entries],
+                _duration_to_timedelta(request.ttl),
+            )
+            return empty_pb2.Empty()
+
+        @_grpc_handler("cache delete")
+        def Delete(self, request: Any, _context: Any) -> Any:
+            return cache_pb2.CacheDeleteResponse(
+                deleted=bool(cache_provider.delete(request.key))
+            )
+
+        @_grpc_handler("cache delete_many")
+        def DeleteMany(self, request: Any, _context: Any) -> Any:
+            return cache_pb2.CacheDeleteManyResponse(
+                deleted=int(cache_provider.delete_many(list(request.keys)))
+            )
+
+        @_grpc_handler("cache touch")
+        def Touch(self, request: Any, _context: Any) -> Any:
+            return cache_pb2.CacheTouchResponse(
+                touched=bool(
+                    cache_provider.touch(
+                        request.key,
+                        _duration_to_timedelta(request.ttl) or dt.timedelta(),
+                    )
+                )
+            )
+
+    return CacheServicer()
+
+
 def _plugin_request(request: Any) -> Request:
     return Request(
         token=getattr(request, "token", ""),
@@ -587,12 +687,13 @@ def _provider_kind_to_proto(kind: ProviderKind | str) -> Any:
     return {
         ProviderKind.INTEGRATION: runtime_pb2.ProviderKind.PROVIDER_KIND_INTEGRATION,
         ProviderKind.AUTH: runtime_pb2.ProviderKind.PROVIDER_KIND_AUTH,
+        ProviderKind.CACHE: runtime_pb2.ProviderKind.PROVIDER_KIND_CACHE,
         ProviderKind.SECRETS: runtime_pb2.ProviderKind.PROVIDER_KIND_SECRETS,
         ProviderKind.TELEMETRY: runtime_pb2.ProviderKind.PROVIDER_KIND_TELEMETRY,
     }.get(normalized, runtime_pb2.ProviderKind.PROVIDER_KIND_UNSPECIFIED)
 
 
-def _normalized_runtime_kind(kind: ProviderKind | str | None) -> ProviderKind:
+def _normalized_runtime_kind(kind: object | None) -> ProviderKind:
     if kind is None:
         return ProviderKind.INTEGRATION
     if isinstance(kind, ProviderKind):
@@ -603,11 +704,19 @@ def _normalized_runtime_kind(kind: ProviderKind | str | None) -> ProviderKind:
             return ProviderKind.INTEGRATION
         try:
             return ProviderKind(normalized)
-        except ValueError as error:
-            raise RuntimeError(
-                f"unsupported Python runtime kind {kind!r}"
-            ) from error
-    raise RuntimeError(f"unsupported Python runtime kind {kind!r}")
+        except ValueError:
+            return ProviderKind.INTEGRATION
+    return ProviderKind.INTEGRATION
+
+
+def _duration_to_timedelta(duration: Any) -> dt.timedelta | None:
+    if duration is None:
+        return None
+    seconds = getattr(duration, "seconds", 0)
+    nanos = getattr(duration, "nanos", 0)
+    if seconds == 0 and nanos == 0:
+        return None
+    return dt.timedelta(seconds=seconds, microseconds=nanos // 1000)
 
 
 if __name__ == "__main__":

--- a/sdk/python/tests/test_cache_transport.py
+++ b/sdk/python/tests/test_cache_transport.py
@@ -1,0 +1,107 @@
+"""Transport-backed Cache SDK tests over a real Unix socket."""
+from __future__ import annotations
+
+import datetime as dt
+import os
+import subprocess
+import tempfile
+import unittest
+
+from gestalt import Cache, CacheEntry, cache_socket_env
+
+
+def _build_harness() -> str:
+    bin_path = os.path.join(tempfile.gettempdir(), "cachetransportd")
+    src_dir = os.path.join(
+        os.path.dirname(__file__),
+        "..",
+        "..",
+        "..",
+        "gestaltd",
+        "internal",
+        "testutil",
+        "cmd",
+        "cachetransportd",
+    )
+    subprocess.check_call(
+        ["go", "build", "-o", bin_path, "."],
+        cwd=os.path.abspath(src_dir),
+        stdout=subprocess.DEVNULL,
+        stderr=subprocess.DEVNULL,
+    )
+    return bin_path
+
+
+_harness_bin: str | None = None
+_harness_proc: subprocess.Popen[bytes] | None = None
+_socket_path: str = ""
+
+
+def setUpModule() -> None:
+    global _harness_bin, _harness_proc, _socket_path
+    _harness_bin = _build_harness()
+    _socket_path = os.path.join(
+        tempfile.gettempdir(), f"py-cache-test-{os.getpid()}.sock"
+    )
+    _harness_proc = subprocess.Popen(
+        [_harness_bin, "--socket", _socket_path],
+        stdout=subprocess.PIPE,
+    )
+    assert _harness_proc.stdout is not None
+    line = _harness_proc.stdout.readline().decode().strip()
+    if line != "READY":
+        _harness_proc.kill()
+        raise RuntimeError(f"harness did not print READY, got: {line!r}")
+    os.environ["GESTALT_CACHE_SOCKET"] = _socket_path
+    os.environ[cache_socket_env("named")] = _socket_path
+    os.environ[cache_socket_env("café")] = _socket_path
+
+
+def tearDownModule() -> None:
+    if _harness_proc:
+        _harness_proc.kill()
+        _harness_proc.wait()
+    if _socket_path and os.path.exists(_socket_path):
+        os.remove(_socket_path)
+
+
+class CacheTransportTests(unittest.TestCase):
+    def test_roundtrip_batch_delete_and_touch(self) -> None:
+        client = Cache()
+        client.set("session", b"alpha")
+        self.assertEqual(client.get("session"), b"alpha")
+
+        client.set_many(
+            [
+                CacheEntry(key="a", value=b"one"),
+                CacheEntry(key="b", value=b"two"),
+            ],
+            ttl=dt.timedelta(minutes=5),
+        )
+        self.assertEqual(
+            client.get_many(["session", "a", "missing"]),
+            {
+                "session": b"alpha",
+                "a": b"one",
+            },
+        )
+        self.assertTrue(client.touch("session", dt.timedelta(minutes=1)))
+        self.assertFalse(client.touch("missing", dt.timedelta(minutes=1)))
+        self.assertEqual(client.delete_many(["a", "missing", "a"]), 1)
+        self.assertIsNone(client.get("a"))
+        self.assertTrue(client.delete("b"))
+        self.assertFalse(client.delete("b"))
+        client.close()
+
+    def test_named_socket_env_roundtrip(self) -> None:
+        client = Cache("named")
+        client.set("named-key", b"named-value")
+        self.assertEqual(client.get("named-key"), b"named-value")
+        client.close()
+
+    def test_unicode_binding_name_uses_host_normalization(self) -> None:
+        self.assertEqual(cache_socket_env("café"), "GESTALT_CACHE_SOCKET_CAF_")
+        client = Cache("café")
+        client.set("unicode-key", b"unicode-value")
+        self.assertEqual(client.get("unicode-key"), b"unicode-value")
+        client.close()

--- a/sdk/python/tests/test_runtime.py
+++ b/sdk/python/tests/test_runtime.py
@@ -7,10 +7,13 @@ from typing import Any
 from unittest import mock
 
 import grpc
+from google.protobuf import duration_pb2 as _duration_pb2
 from google.protobuf import timestamp_pb2 as _timestamp_pb2
 
 from gestalt import (
     AuthProvider,
+    CacheEntry,
+    CacheProvider,
     Catalog,
     CatalogOperation,
     ExternalTokenValidator,
@@ -26,10 +29,13 @@ from gestalt import (
     _runtime,
 )
 from gestalt.gen.v1 import auth_pb2 as _auth_pb2
+from gestalt.gen.v1 import cache_pb2 as _cache_pb2
 from gestalt.gen.v1 import plugin_pb2 as _plugin_pb2
 from gestalt.gen.v1 import runtime_pb2 as _runtime_pb2
 
 auth_pb2: Any = _auth_pb2
+cache_pb2: Any = _cache_pb2
+duration_pb2: Any = _duration_pb2
 plugin_pb2: Any = _plugin_pb2
 runtime_pb2: Any = _runtime_pb2
 timestamp_pb2: Any = _timestamp_pb2
@@ -101,6 +107,32 @@ class ParseRuntimeArgsTests(unittest.TestCase):
         with tempfile.TemporaryDirectory() as tmpdir:
             with mock.patch.object(_runtime.sys, "_MEIPASS", tmpdir, create=True):
                 self.assertIsNone(_runtime._parse_runtime_args([]))
+
+
+class RuntimeKindNormalizationTests(unittest.TestCase):
+    def test_normalized_runtime_kind_recognizes_cache(self) -> None:
+        self.assertEqual(
+            _runtime._normalized_runtime_kind("cache"),
+            ProviderKind.CACHE,
+        )
+
+    def test_normalized_runtime_kind_falls_back_to_integration_for_unknown_values(self) -> None:
+        self.assertEqual(
+            _runtime._normalized_runtime_kind("typo"),
+            ProviderKind.INTEGRATION,
+        )
+        self.assertEqual(
+            _runtime._normalized_runtime_kind(object()),
+            ProviderKind.INTEGRATION,
+        )
+
+
+class DurationConversionTests(unittest.TestCase):
+    def test_duration_to_timedelta_truncates_submicrosecond_nanos(self) -> None:
+        self.assertEqual(
+            _runtime._duration_to_timedelta(duration_pb2.Duration(nanos=5_999)),
+            dt.timedelta(microseconds=5),
+        )
 
 
 class ManifestNameTests(unittest.TestCase):
@@ -418,6 +450,194 @@ class AuthRuntimeTests(unittest.TestCase):
         unknown_context.abort.assert_called_once_with(
             grpc.StatusCode.NOT_FOUND,
             "token not recognized",
+        )
+
+
+class CacheRuntimeTests(unittest.TestCase):
+    class FallbackCacheProvider(CacheProvider):
+        def __init__(self) -> None:
+            self.values: dict[str, bytes] = {}
+
+        def get(self, key: str) -> bytes | None:
+            return self.values.get(key)
+
+        def set(
+            self,
+            key: str,
+            value: bytes,
+            ttl: dt.timedelta | None = None,
+        ) -> None:
+            self.values[key] = bytes(value)
+
+        def delete(self, key: str) -> bool:
+            return self.values.pop(key, None) is not None
+
+        def touch(self, key: str, ttl: dt.timedelta) -> bool:
+            return key in self.values
+
+    class StubCacheProvider(
+        CacheProvider,
+        MetadataProvider,
+        WarningsProvider,
+        HealthChecker,
+    ):
+        def __init__(self) -> None:
+            self.configured: list[tuple[str, dict[str, object]]] = []
+            self.values: dict[str, bytes] = {}
+
+        def configure(self, name: str, config: dict[str, Any]) -> None:
+            self.configured.append((name, dict(config)))
+
+        def metadata(self) -> ProviderMetadata:
+            return ProviderMetadata(
+                kind=ProviderKind.CACHE,
+                name="stub-cache",
+                display_name="Stub Cache",
+                description="test cache provider",
+                version="1.0.0",
+            )
+
+        def warnings(self) -> list[str]:
+            return ["set CACHE_ENV"]
+
+        def health_check(self) -> None:
+            return None
+
+        def get(self, key: str) -> bytes | None:
+            return self.values.get(key)
+
+        def set(
+            self,
+            key: str,
+            value: bytes,
+            ttl: dt.timedelta | None = None,
+        ) -> None:
+            self.values[key] = bytes(value)
+
+        def delete(self, key: str) -> bool:
+            return self.values.pop(key, None) is not None
+
+        def touch(self, key: str, ttl: dt.timedelta) -> bool:
+            return key in self.values
+
+        def set_many(
+            self,
+            entries: list[Any],
+            ttl: dt.timedelta | None = None,
+        ) -> None:
+            for entry in entries:
+                self.values[entry.key] = bytes(entry.value)
+
+        def get_many(self, keys: list[str]) -> dict[str, bytes]:
+            return {
+                key: value
+                for key in keys
+                if (value := self.values.get(key)) is not None
+            }
+
+        def delete_many(self, keys: list[str]) -> int:
+            deleted = 0
+            seen: set[str] = set()
+            for key in keys:
+                if key in seen:
+                    continue
+                seen.add(key)
+                if self.values.pop(key, None) is not None:
+                    deleted += 1
+            return deleted
+
+    def test_runtime_metadata_and_cache_servicer(self) -> None:
+        provider = self.StubCacheProvider()
+
+        runtime_servicer = _runtime._runtime_servicer(
+            provider=provider,
+            kind=ProviderKind.CACHE,
+        )
+        meta = runtime_servicer.GetProviderIdentity(mock.Mock(), mock.Mock())
+        self.assertEqual(meta.kind, runtime_pb2.ProviderKind.PROVIDER_KIND_CACHE)
+        self.assertEqual(meta.name, "stub-cache")
+        self.assertEqual(list(meta.warnings), ["set CACHE_ENV"])
+
+        cache_servicer = _runtime._cache_servicer(provider=provider)
+        cache_servicer.Set(
+            cache_pb2.CacheSetRequest(
+                key="session",
+                value=b"alpha",
+            ),
+            mock.Mock(),
+        )
+        self.assertEqual(
+            cache_servicer.Get(
+                cache_pb2.CacheGetRequest(key="session"),
+                mock.Mock(),
+            ).value,
+            b"alpha",
+        )
+
+        cache_servicer.SetMany(
+            cache_pb2.CacheSetManyRequest(
+                entries=[
+                    cache_pb2.CacheSetEntry(key="a", value=b"one"),
+                    cache_pb2.CacheSetEntry(key="b", value=b"two"),
+                ]
+            ),
+            mock.Mock(),
+        )
+        many = cache_servicer.GetMany(
+            cache_pb2.CacheGetManyRequest(keys=["session", "a", "missing"]),
+            mock.Mock(),
+        )
+        self.assertEqual(
+            [(entry.key, entry.found, bytes(entry.value)) for entry in many.entries],
+            [
+                ("session", True, b"alpha"),
+                ("a", True, b"one"),
+                ("missing", False, b""),
+            ],
+        )
+        deleted = cache_servicer.DeleteMany(
+            cache_pb2.CacheDeleteManyRequest(keys=["a", "missing", "a"]),
+            mock.Mock(),
+        )
+        self.assertEqual(deleted.deleted, 1)
+        self.assertTrue(
+            cache_servicer.Touch(
+                cache_pb2.CacheTouchRequest(key="session"),
+                mock.Mock(),
+            ).touched
+        )
+        self.assertFalse(
+            cache_servicer.Touch(
+                cache_pb2.CacheTouchRequest(key="missing"),
+                mock.Mock(),
+            ).touched
+        )
+
+    def test_cache_provider_batch_fallbacks(self) -> None:
+        provider = self.FallbackCacheProvider()
+        provider.set("session", b"alpha")
+        provider.set_many(
+            [
+                CacheEntry(key="a", value=b"one"),
+                CacheEntry(key="b", value=b"two"),
+            ],
+            ttl=dt.timedelta(minutes=5),
+        )
+
+        self.assertEqual(
+            provider.get_many(["session", "a", "missing"]),
+            {
+                "session": b"alpha",
+                "a": b"one",
+            },
+        )
+        self.assertEqual(provider.delete_many(["a", "missing", "a"]), 1)
+        self.assertEqual(
+            provider.get_many(["session", "a", "b"]),
+            {
+                "session": b"alpha",
+                "b": b"two",
+            },
         )
 
 

--- a/sdk/rust/README.md
+++ b/sdk/rust/README.md
@@ -9,9 +9,9 @@ Current scope:
 - vendored `protoc` via `protoc-bin-vendored`
 - generated protocol bindings exposed via `proto::v1`
 - typed integration-provider authoring helpers for requests, responses, catalogs, and routing
-- auth-provider and secrets-provider traits that map to the shared executable runtime protocol
-- runtime servers for the integration, auth, and secrets provider surfaces over the Unix socket exposed by `gestaltd`
-- `export_provider!`, `export_auth_provider!`, and `export_secrets_provider!` macros for source builds that let `gestaltd` synthesize the executable wrapper
+- auth-provider, cache-provider, and secrets-provider traits that map to the shared executable runtime protocol
+- runtime servers for the integration, auth, cache, and secrets provider surfaces over the Unix socket exposed by `gestaltd`
+- `export_provider!`, `export_auth_provider!`, `export_cache_provider!`, and `export_secrets_provider!` macros for source builds that let `gestaltd` synthesize the executable wrapper
 
 ## Codegen strategy
 
@@ -32,13 +32,15 @@ The crate is intentionally small:
 
 - `Provider`, `Request`, `Response`, and `ok(...)` model integration providers
 - `AuthProvider`, `BeginLoginRequest`, `BeginLoginResponse`, `CompleteLoginRequest`, and `AuthenticatedUser` model auth providers
+- `Cache`, `CacheProvider`, `CacheEntry`, and `CacheSetOptions` model cache clients and providers
 - `SecretsProvider` models secrets providers
 - `Router` and `Operation` register typed operations and derive catalog metadata from `serde` + `schemars`
 - `Catalog` types expose explicit static or session-scoped catalogs when needed
 - `RuntimeMetadata` lets any provider kind describe its runtime name/display metadata and version
-- `runtime` runs the integration, auth, or secrets gRPC servers, or writes the static catalog when `GESTALT_PLUGIN_WRITE_CATALOG` is set
+- `runtime` runs the integration, auth, cache, or secrets gRPC servers, or writes the static catalog when `GESTALT_PLUGIN_WRITE_CATALOG` is set
 - `export_provider!` exports `__gestalt_serve` and `__gestalt_write_catalog` for integration providers
 - `export_auth_provider!` exports `__gestalt_serve_auth` for auth providers
+- `export_cache_provider!` exports `__gestalt_serve_cache` for cache providers
 - `export_secrets_provider!` exports `__gestalt_serve_secrets` for secrets providers
 
 ## Package layout

--- a/sdk/rust/src/cache.rs
+++ b/sdk/rust/src/cache.rs
@@ -1,0 +1,266 @@
+use std::collections::{BTreeMap, BTreeSet};
+use std::time::Duration;
+
+use hyper_util::rt::TokioIo;
+use tokio::net::UnixStream;
+use tonic::codegen::async_trait;
+use tonic::transport::{Channel, Endpoint, Uri};
+use tower::service_fn;
+
+use crate::api::RuntimeMetadata;
+use crate::error::Result;
+use crate::generated::v1::{self as pb, cache_client::CacheClient};
+
+pub const ENV_CACHE_SOCKET: &str = "GESTALT_CACHE_SOCKET";
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct CacheEntry {
+    pub key: String,
+    pub value: Vec<u8>,
+}
+
+#[derive(Debug, Clone, Copy, Default, PartialEq, Eq)]
+pub struct CacheSetOptions {
+    pub ttl: Option<Duration>,
+}
+
+#[derive(Debug, thiserror::Error)]
+pub enum CacheError {
+    #[error("{0}")]
+    Transport(#[from] tonic::transport::Error),
+    #[error("{0}")]
+    Status(#[from] tonic::Status),
+    #[error("{0}")]
+    Env(String),
+}
+
+#[async_trait]
+pub trait CacheProvider: Send + Sync + 'static {
+    async fn configure(
+        &self,
+        _name: &str,
+        _config: serde_json::Map<String, serde_json::Value>,
+    ) -> Result<()> {
+        Ok(())
+    }
+
+    fn metadata(&self) -> Option<RuntimeMetadata> {
+        None
+    }
+
+    fn warnings(&self) -> Vec<String> {
+        Vec::new()
+    }
+
+    async fn health_check(&self) -> Result<()> {
+        Ok(())
+    }
+
+    async fn close(&self) -> Result<()> {
+        Ok(())
+    }
+
+    async fn get(&self, key: &str) -> Result<Option<Vec<u8>>>;
+
+    async fn get_many(&self, keys: &[String]) -> Result<BTreeMap<String, Vec<u8>>> {
+        let mut values = BTreeMap::new();
+        for key in keys {
+            if let Some(value) = self.get(key).await? {
+                values.insert(key.clone(), value);
+            }
+        }
+        Ok(values)
+    }
+
+    async fn set(&self, key: &str, value: &[u8], options: CacheSetOptions) -> Result<()>;
+
+    async fn set_many(&self, entries: &[CacheEntry], options: CacheSetOptions) -> Result<()> {
+        for entry in entries {
+            self.set(&entry.key, &entry.value, options).await?;
+        }
+        Ok(())
+    }
+
+    async fn delete(&self, key: &str) -> Result<bool>;
+
+    async fn delete_many(&self, keys: &[String]) -> Result<i64> {
+        let mut deleted = 0_i64;
+        let mut seen = BTreeSet::new();
+        for key in keys {
+            if !seen.insert(key.as_str()) {
+                continue;
+            }
+            if self.delete(key).await? {
+                deleted += 1;
+            }
+        }
+        Ok(deleted)
+    }
+
+    async fn touch(&self, key: &str, ttl: Duration) -> Result<bool>;
+}
+
+pub struct Cache {
+    client: CacheClient<Channel>,
+}
+
+impl Cache {
+    pub async fn connect() -> std::result::Result<Self, CacheError> {
+        Self::connect_named("").await
+    }
+
+    pub async fn connect_named(name: &str) -> std::result::Result<Self, CacheError> {
+        let env_name = cache_socket_env(name);
+        let socket_path = std::env::var(&env_name)
+            .map_err(|_| CacheError::Env(format!("{env_name} is not set")))?;
+
+        let channel = Endpoint::try_from("http://[::]:50051")?
+            .connect_with_connector(service_fn(move |_: Uri| {
+                let path = socket_path.clone();
+                async move { UnixStream::connect(path).await.map(TokioIo::new) }
+            }))
+            .await?;
+
+        Ok(Self {
+            client: CacheClient::new(channel),
+        })
+    }
+
+    pub async fn get(&mut self, key: &str) -> std::result::Result<Option<Vec<u8>>, CacheError> {
+        let response = self
+            .client
+            .get(pb::CacheGetRequest {
+                key: key.to_string(),
+            })
+            .await?
+            .into_inner();
+        if !response.found {
+            return Ok(None);
+        }
+        Ok(Some(response.value))
+    }
+
+    pub async fn get_many<S>(
+        &mut self,
+        keys: &[S],
+    ) -> std::result::Result<BTreeMap<String, Vec<u8>>, CacheError>
+    where
+        S: AsRef<str>,
+    {
+        let request_keys: Vec<String> = keys.iter().map(|key| key.as_ref().to_string()).collect();
+        let response = self
+            .client
+            .get_many(pb::CacheGetManyRequest { keys: request_keys })
+            .await?
+            .into_inner();
+        let mut values = BTreeMap::new();
+        for entry in response.entries {
+            if entry.found {
+                values.insert(entry.key, entry.value);
+            }
+        }
+        Ok(values)
+    }
+
+    pub async fn set(
+        &mut self,
+        key: &str,
+        value: &[u8],
+        options: CacheSetOptions,
+    ) -> std::result::Result<(), CacheError> {
+        self.client
+            .set(pb::CacheSetRequest {
+                key: key.to_string(),
+                value: value.to_vec(),
+                ttl: duration_to_proto(options.ttl),
+            })
+            .await?;
+        Ok(())
+    }
+
+    pub async fn set_many(
+        &mut self,
+        entries: &[CacheEntry],
+        options: CacheSetOptions,
+    ) -> std::result::Result<(), CacheError> {
+        self.client
+            .set_many(pb::CacheSetManyRequest {
+                entries: entries
+                    .iter()
+                    .map(|entry| pb::CacheSetEntry {
+                        key: entry.key.clone(),
+                        value: entry.value.clone(),
+                    })
+                    .collect(),
+                ttl: duration_to_proto(options.ttl),
+            })
+            .await?;
+        Ok(())
+    }
+
+    pub async fn delete(&mut self, key: &str) -> std::result::Result<bool, CacheError> {
+        let response = self
+            .client
+            .delete(pb::CacheDeleteRequest {
+                key: key.to_string(),
+            })
+            .await?
+            .into_inner();
+        Ok(response.deleted)
+    }
+
+    pub async fn delete_many<S>(&mut self, keys: &[S]) -> std::result::Result<i64, CacheError>
+    where
+        S: AsRef<str>,
+    {
+        let response = self
+            .client
+            .delete_many(pb::CacheDeleteManyRequest {
+                keys: keys.iter().map(|key| key.as_ref().to_string()).collect(),
+            })
+            .await?
+            .into_inner();
+        Ok(response.deleted)
+    }
+
+    pub async fn touch(
+        &mut self,
+        key: &str,
+        ttl: Duration,
+    ) -> std::result::Result<bool, CacheError> {
+        let response = self
+            .client
+            .touch(pb::CacheTouchRequest {
+                key: key.to_string(),
+                ttl: duration_to_proto(Some(ttl)),
+            })
+            .await?
+            .into_inner();
+        Ok(response.touched)
+    }
+}
+
+pub fn cache_socket_env(name: &str) -> String {
+    let trimmed = name.trim();
+    if trimmed.is_empty() {
+        return ENV_CACHE_SOCKET.to_string();
+    }
+    let mut env = String::from(ENV_CACHE_SOCKET);
+    env.push('_');
+    for ch in trimmed.chars() {
+        if ch.is_ascii_alphanumeric() {
+            env.push(ch.to_ascii_uppercase());
+        } else {
+            env.push('_');
+        }
+    }
+    env
+}
+
+fn duration_to_proto(ttl: Option<Duration>) -> Option<prost_types::Duration> {
+    let ttl = ttl.filter(|ttl| !ttl.is_zero())?;
+    Some(prost_types::Duration {
+        seconds: i64::try_from(ttl.as_secs()).unwrap_or(i64::MAX),
+        nanos: i32::try_from(ttl.subsec_nanos()).unwrap_or(i32::MAX),
+    })
+}

--- a/sdk/rust/src/cache_server.rs
+++ b/sdk/rust/src/cache_server.rs
@@ -1,0 +1,177 @@
+use std::sync::Arc;
+use std::time::Duration;
+
+use tonic::{Request as GrpcRequest, Response as GrpcResponse, Status};
+
+use crate::cache::{CacheEntry, CacheProvider, CacheSetOptions};
+use crate::generated::v1::cache_server::Cache as CacheGrpc;
+use crate::generated::v1::{
+    CacheDeleteManyRequest, CacheDeleteManyResponse, CacheDeleteRequest, CacheDeleteResponse,
+    CacheGetManyRequest, CacheGetManyResponse, CacheGetRequest, CacheGetResponse, CacheResult,
+    CacheSetManyRequest, CacheSetRequest, CacheTouchRequest, CacheTouchResponse,
+};
+use crate::rpc_status::rpc_status;
+
+#[derive(Clone)]
+pub struct CacheRpcServer<P> {
+    cache: Arc<P>,
+}
+
+impl<P> CacheRpcServer<P> {
+    pub fn new(cache: Arc<P>) -> Self {
+        Self { cache }
+    }
+}
+
+#[tonic::async_trait]
+impl<P> CacheGrpc for CacheRpcServer<P>
+where
+    P: CacheProvider,
+{
+    async fn get(
+        &self,
+        request: GrpcRequest<CacheGetRequest>,
+    ) -> std::result::Result<GrpcResponse<CacheGetResponse>, Status> {
+        let request = request.into_inner();
+        let value = self
+            .cache
+            .get(&request.key)
+            .await
+            .map_err(|error| rpc_status("get cache entry", error))?;
+        match value {
+            Some(value) => Ok(GrpcResponse::new(CacheGetResponse { found: true, value })),
+            None => Ok(GrpcResponse::new(CacheGetResponse {
+                found: false,
+                value: Vec::new(),
+            })),
+        }
+    }
+
+    async fn get_many(
+        &self,
+        request: GrpcRequest<CacheGetManyRequest>,
+    ) -> std::result::Result<GrpcResponse<CacheGetManyResponse>, Status> {
+        let request = request.into_inner();
+        let values = self
+            .cache
+            .get_many(&request.keys)
+            .await
+            .map_err(|error| rpc_status("get many cache entries", error))?;
+        let entries = request
+            .keys
+            .into_iter()
+            .map(|key| match values.get(&key) {
+                Some(value) => CacheResult {
+                    key,
+                    found: true,
+                    value: value.clone(),
+                },
+                None => CacheResult {
+                    key,
+                    found: false,
+                    value: Vec::new(),
+                },
+            })
+            .collect();
+        Ok(GrpcResponse::new(CacheGetManyResponse { entries }))
+    }
+
+    async fn set(
+        &self,
+        request: GrpcRequest<CacheSetRequest>,
+    ) -> std::result::Result<GrpcResponse<()>, Status> {
+        let request = request.into_inner();
+        self.cache
+            .set(
+                &request.key,
+                &request.value,
+                CacheSetOptions {
+                    ttl: duration_from_proto(request.ttl)?,
+                },
+            )
+            .await
+            .map_err(|error| rpc_status("set cache entry", error))?;
+        Ok(GrpcResponse::new(()))
+    }
+
+    async fn set_many(
+        &self,
+        request: GrpcRequest<CacheSetManyRequest>,
+    ) -> std::result::Result<GrpcResponse<()>, Status> {
+        let request = request.into_inner();
+        let entries: Vec<CacheEntry> = request
+            .entries
+            .into_iter()
+            .map(|entry| CacheEntry {
+                key: entry.key,
+                value: entry.value,
+            })
+            .collect();
+        self.cache
+            .set_many(
+                &entries,
+                CacheSetOptions {
+                    ttl: duration_from_proto(request.ttl)?,
+                },
+            )
+            .await
+            .map_err(|error| rpc_status("set many cache entries", error))?;
+        Ok(GrpcResponse::new(()))
+    }
+
+    async fn delete(
+        &self,
+        request: GrpcRequest<CacheDeleteRequest>,
+    ) -> std::result::Result<GrpcResponse<CacheDeleteResponse>, Status> {
+        let request = request.into_inner();
+        let deleted = self
+            .cache
+            .delete(&request.key)
+            .await
+            .map_err(|error| rpc_status("delete cache entry", error))?;
+        Ok(GrpcResponse::new(CacheDeleteResponse { deleted }))
+    }
+
+    async fn delete_many(
+        &self,
+        request: GrpcRequest<CacheDeleteManyRequest>,
+    ) -> std::result::Result<GrpcResponse<CacheDeleteManyResponse>, Status> {
+        let deleted = self
+            .cache
+            .delete_many(&request.into_inner().keys)
+            .await
+            .map_err(|error| rpc_status("delete many cache entries", error))?;
+        Ok(GrpcResponse::new(CacheDeleteManyResponse { deleted }))
+    }
+
+    async fn touch(
+        &self,
+        request: GrpcRequest<CacheTouchRequest>,
+    ) -> std::result::Result<GrpcResponse<CacheTouchResponse>, Status> {
+        let request = request.into_inner();
+        let ttl = duration_from_proto(request.ttl)?.unwrap_or_default();
+        let touched = self
+            .cache
+            .touch(&request.key, ttl)
+            .await
+            .map_err(|error| rpc_status("touch cache entry", error))?;
+        Ok(GrpcResponse::new(CacheTouchResponse { touched }))
+    }
+}
+
+fn duration_from_proto(
+    ttl: Option<prost_types::Duration>,
+) -> std::result::Result<Option<Duration>, Status> {
+    let Some(ttl) = ttl else {
+        return Ok(None);
+    };
+    if ttl.seconds < 0 {
+        return Err(Status::invalid_argument("ttl must be non-negative"));
+    }
+    if ttl.nanos < 0 || ttl.nanos >= 1_000_000_000 {
+        return Err(Status::invalid_argument("ttl nanos must be in [0, 1e9)"));
+    }
+    let seconds =
+        u64::try_from(ttl.seconds).map_err(|_| Status::invalid_argument("ttl is too large"))?;
+    Ok(Some(Duration::new(seconds, ttl.nanos as u32)))
+}

--- a/sdk/rust/src/lib.rs
+++ b/sdk/rust/src/lib.rs
@@ -3,6 +3,8 @@
 mod api;
 mod auth;
 mod auth_server;
+mod cache;
+mod cache_server;
 mod catalog;
 mod env;
 mod error;
@@ -29,6 +31,10 @@ pub mod proto {
 pub use api::{Access, Credential, Provider, Request, Response, RuntimeMetadata, Subject, ok};
 pub use auth::{
     AuthProvider, AuthenticatedUser, BeginLoginRequest, BeginLoginResponse, CompleteLoginRequest,
+};
+pub use cache::{
+    Cache, CacheEntry, CacheError, CacheProvider, CacheSetOptions, ENV_CACHE_SOCKET,
+    cache_socket_env,
 };
 pub use catalog::{Catalog, CatalogOperation};
 pub use env::{CURRENT_PROTOCOL_VERSION, ENV_PROVIDER_SOCKET};
@@ -87,6 +93,16 @@ macro_rules! export_auth_provider {
         pub fn __gestalt_serve_auth(_name: &str) -> $crate::Result<()> {
             let provider = std::sync::Arc::new($constructor());
             $crate::runtime::run_auth_provider(provider)
+        }
+    };
+}
+
+#[macro_export]
+macro_rules! export_cache_provider {
+    (constructor = $constructor:path $(,)?) => {
+        pub fn __gestalt_serve_cache(_name: &str) -> $crate::Result<()> {
+            let provider = std::sync::Arc::new($constructor());
+            $crate::runtime::run_cache_provider(provider)
         }
     };
 }

--- a/sdk/rust/src/runtime.rs
+++ b/sdk/rust/src/runtime.rs
@@ -24,18 +24,20 @@ use crate::error::{Error, Result};
 #[cfg(unix)]
 use crate::generated::v1::auth_provider_server::AuthProviderServer;
 #[cfg(unix)]
+use crate::generated::v1::cache_server::CacheServer;
+#[cfg(unix)]
 use crate::generated::v1::integration_provider_server::IntegrationProviderServer;
 #[cfg(unix)]
 use crate::generated::v1::provider_lifecycle_server::ProviderLifecycleServer;
 #[cfg(unix)]
 use crate::generated::v1::secrets_provider_server::SecretsProviderServer;
 use crate::provider_server::ProviderServer;
-#[cfg(unix)]
-use crate::{AuthProvider, SecretsProvider};
+use crate::{AuthProvider, CacheProvider, SecretsProvider};
 use crate::{Provider, Router};
 #[cfg(unix)]
 use crate::{
-    auth_server::AuthServer, runtime_server::RuntimeServer, secrets_server::SecretsServer,
+    auth_server::AuthServer, cache_server::CacheRpcServer, runtime_server::RuntimeServer,
+    secrets_server::SecretsServer,
 };
 
 fn build_runtime_and_block_on<F, Fut>(f: F) -> Result<()>
@@ -56,6 +58,10 @@ pub fn run_provider<P: Provider>(provider: Arc<P>, router: Router<P>) -> Result<
 
 pub fn run_auth_provider<P: AuthProvider>(provider: Arc<P>) -> Result<()> {
     build_runtime_and_block_on(|| serve_auth_provider(provider))
+}
+
+pub fn run_cache_provider<P: CacheProvider>(provider: Arc<P>) -> Result<()> {
+    build_runtime_and_block_on(|| serve_cache_provider(provider))
 }
 
 pub fn run_secrets_provider<P: SecretsProvider>(provider: Arc<P>) -> Result<()> {
@@ -128,6 +134,26 @@ where
 }
 
 #[cfg(unix)]
+pub async fn serve_cache_provider<P>(provider: Arc<P>) -> Result<()>
+where
+    P: CacheProvider,
+{
+    serve_unix_provider(
+        provider,
+        move |incoming, provider| {
+            Server::builder()
+                .add_service(ProviderLifecycleServer::new(RuntimeServer::for_cache(
+                    Arc::clone(&provider),
+                )))
+                .add_service(CacheServer::new(CacheRpcServer::new(Arc::clone(&provider))))
+                .serve_with_incoming_shutdown(incoming, shutdown_signal(parent_pid()))
+        },
+        |provider| async move { provider.close().await },
+    )
+    .await
+}
+
+#[cfg(unix)]
 pub async fn serve_secrets_provider<P>(provider: Arc<P>) -> Result<()>
 where
     P: SecretsProvider,
@@ -166,6 +192,16 @@ where
 pub async fn serve_auth_provider<P>(_provider: Arc<P>) -> Result<()>
 where
     P: AuthProvider,
+{
+    Err(Error::internal(
+        "unix sockets are unsupported on this platform",
+    ))
+}
+
+#[cfg(not(unix))]
+pub async fn serve_cache_provider<P>(_provider: Arc<P>) -> Result<()>
+where
+    P: CacheProvider,
 {
     Err(Error::internal(
         "unix sockets are unsupported on this platform",

--- a/sdk/rust/src/runtime_server.rs
+++ b/sdk/rust/src/runtime_server.rs
@@ -5,6 +5,7 @@ use tonic::{Request as GrpcRequest, Response as GrpcResponse, Status};
 
 use crate::api::RuntimeMetadata;
 use crate::auth::AuthProvider;
+use crate::cache::CacheProvider;
 use crate::error::Result;
 use crate::generated::v1::provider_lifecycle_server::ProviderLifecycle;
 use crate::generated::v1::{
@@ -34,6 +35,10 @@ struct ProviderRuntime<P> {
 }
 
 struct AuthRuntime<P> {
+    provider: Arc<P>,
+}
+
+struct CacheRuntime<P> {
     provider: Arc<P>,
 }
 
@@ -73,6 +78,7 @@ macro_rules! impl_runtime_hooks {
 
 impl_runtime_hooks!(ProviderRuntime, Provider);
 impl_runtime_hooks!(AuthRuntime, AuthProvider);
+impl_runtime_hooks!(CacheRuntime, CacheProvider);
 impl_runtime_hooks!(SecretsRuntime, SecretsProvider);
 
 #[derive(Clone)]
@@ -99,6 +105,16 @@ impl RuntimeServer {
         Self {
             kind: ProviderKind::Auth,
             provider: Arc::new(AuthRuntime { provider }),
+        }
+    }
+
+    pub fn for_cache<P>(provider: Arc<P>) -> Self
+    where
+        P: CacheProvider,
+    {
+        Self {
+            kind: ProviderKind::Cache,
+            provider: Arc::new(CacheRuntime { provider }),
         }
     }
 

--- a/sdk/rust/tests/cache_transport.rs
+++ b/sdk/rust/tests/cache_transport.rs
@@ -1,0 +1,259 @@
+#[allow(dead_code)]
+mod helpers;
+
+use std::collections::BTreeMap;
+use std::path::Path;
+use std::sync::{Arc, Mutex};
+use std::time::Duration;
+
+use gestalt::proto::v1::provider_lifecycle_client::ProviderLifecycleClient;
+use gestalt::proto::v1::{ConfigureProviderRequest, ProviderKind};
+use gestalt::{CacheEntry, CacheProvider, CacheSetOptions, RuntimeMetadata};
+use hyper_util::rt::tokio::TokioIo;
+use tokio::net::UnixStream;
+use tonic::transport::Endpoint;
+use tower::service_fn;
+
+#[derive(Default)]
+struct TestCacheProvider {
+    configured_name: Mutex<String>,
+    namespace: Mutex<String>,
+    entries: Mutex<BTreeMap<String, Vec<u8>>>,
+    ttl_by_key: Mutex<BTreeMap<String, Duration>>,
+}
+
+#[gestalt::async_trait]
+impl CacheProvider for TestCacheProvider {
+    async fn configure(
+        &self,
+        name: &str,
+        config: serde_json::Map<String, serde_json::Value>,
+    ) -> gestalt::Result<()> {
+        *self.configured_name.lock().expect("configured_name lock") = name.to_string();
+        *self.namespace.lock().expect("namespace lock") = config
+            .get("namespace")
+            .and_then(serde_json::Value::as_str)
+            .unwrap_or_default()
+            .to_string();
+        Ok(())
+    }
+
+    fn metadata(&self) -> Option<RuntimeMetadata> {
+        Some(RuntimeMetadata {
+            name: "cache-example".to_string(),
+            display_name: "Cache Example".to_string(),
+            description: "Test cache provider".to_string(),
+            version: "0.1.0".to_string(),
+        })
+    }
+
+    fn warnings(&self) -> Vec<String> {
+        vec!["set cache namespace".to_string()]
+    }
+
+    async fn get(&self, key: &str) -> gestalt::Result<Option<Vec<u8>>> {
+        Ok(self
+            .entries
+            .lock()
+            .expect("entries lock")
+            .get(&self.namespaced(key))
+            .cloned())
+    }
+
+    async fn set(&self, key: &str, value: &[u8], options: CacheSetOptions) -> gestalt::Result<()> {
+        let namespaced = self.namespaced(key);
+        self.entries
+            .lock()
+            .expect("entries lock")
+            .insert(namespaced.clone(), value.to_vec());
+        if let Some(ttl) = options.ttl {
+            self.ttl_by_key
+                .lock()
+                .expect("ttl_by_key lock")
+                .insert(namespaced, ttl);
+        }
+        Ok(())
+    }
+
+    async fn delete(&self, key: &str) -> gestalt::Result<bool> {
+        Ok(self
+            .entries
+            .lock()
+            .expect("entries lock")
+            .remove(&self.namespaced(key))
+            .is_some())
+    }
+
+    async fn touch(&self, key: &str, ttl: Duration) -> gestalt::Result<bool> {
+        let namespaced = self.namespaced(key);
+        let exists = self
+            .entries
+            .lock()
+            .expect("entries lock")
+            .contains_key(&namespaced);
+        if exists {
+            self.ttl_by_key
+                .lock()
+                .expect("ttl_by_key lock")
+                .insert(namespaced, ttl);
+        }
+        Ok(exists)
+    }
+}
+
+impl TestCacheProvider {
+    fn namespaced(&self, key: &str) -> String {
+        let namespace = self.namespace.lock().expect("namespace lock").clone();
+        if namespace.is_empty() {
+            return key.to_string();
+        }
+        format!("{namespace}:{key}")
+    }
+}
+
+#[tokio::test]
+async fn cache_runtime_and_client_round_trip_over_named_socket() {
+    let _env_lock = helpers::env_lock().lock().await;
+    let socket = helpers::temp_socket("gestalt-rust-cache.sock");
+    let _provider_socket = helpers::EnvGuard::set(gestalt::ENV_PROVIDER_SOCKET, socket.as_os_str());
+    let cache_env = gestalt::cache_socket_env("shared-cache");
+    let _cache_socket = helpers::EnvGuard::set(cache_env, socket.as_os_str());
+
+    let provider = Arc::new(TestCacheProvider::default());
+    let serve_provider = Arc::clone(&provider);
+    let serve_task = tokio::spawn(async move {
+        gestalt::runtime::serve_cache_provider(serve_provider)
+            .await
+            .expect("serve cache provider");
+    });
+
+    helpers::wait_for_socket(&socket).await;
+
+    let channel = connect_unix(&socket).await;
+    let mut runtime = ProviderLifecycleClient::new(channel);
+    let metadata = runtime
+        .get_provider_identity(())
+        .await
+        .expect("get provider identity")
+        .into_inner();
+    assert_eq!(
+        ProviderKind::try_from(metadata.kind)
+            .expect("valid provider kind")
+            .as_str_name(),
+        "PROVIDER_KIND_CACHE"
+    );
+    assert_eq!(metadata.name, "cache-example");
+    assert_eq!(metadata.warnings, vec!["set cache namespace"]);
+
+    runtime
+        .configure_provider(ConfigureProviderRequest {
+            name: "cache-runtime".to_string(),
+            config: Some(helpers::struct_from_json(
+                serde_json::json!({ "namespace": "tenant-a" }),
+            )),
+            protocol_version: gestalt::CURRENT_PROTOCOL_VERSION,
+        })
+        .await
+        .expect("configure provider");
+
+    let mut cache = gestalt::Cache::connect_named("shared-cache")
+        .await
+        .expect("connect cache");
+    cache
+        .set(
+            "alpha",
+            b"one",
+            CacheSetOptions {
+                ttl: Some(Duration::from_secs(60)),
+            },
+        )
+        .await
+        .expect("set alpha");
+    cache
+        .set_many(
+            &[
+                CacheEntry {
+                    key: "beta".to_string(),
+                    value: b"two".to_vec(),
+                },
+                CacheEntry {
+                    key: "gamma".to_string(),
+                    value: b"three".to_vec(),
+                },
+            ],
+            CacheSetOptions {
+                ttl: Some(Duration::from_secs(120)),
+            },
+        )
+        .await
+        .expect("set many");
+
+    assert_eq!(
+        cache.get("alpha").await.expect("get alpha"),
+        Some(b"one".to_vec())
+    );
+
+    let values = cache
+        .get_many(&["alpha", "beta", "missing"])
+        .await
+        .expect("get many");
+    assert_eq!(values.get("alpha").map(Vec::as_slice), Some(&b"one"[..]));
+    assert_eq!(values.get("beta").map(Vec::as_slice), Some(&b"two"[..]));
+    assert!(!values.contains_key("missing"));
+
+    assert!(
+        cache
+            .touch("alpha", Duration::from_secs(30))
+            .await
+            .expect("touch alpha")
+    );
+    assert!(cache.delete("alpha").await.expect("delete alpha"));
+    assert_eq!(
+        cache
+            .delete_many(&["beta", "missing", "beta"])
+            .await
+            .expect("delete many"),
+        1
+    );
+
+    assert_eq!(
+        *provider
+            .configured_name
+            .lock()
+            .expect("configured_name lock"),
+        "cache-runtime"
+    );
+    assert!(
+        provider
+            .entries
+            .lock()
+            .expect("entries lock")
+            .contains_key("tenant-a:gamma")
+    );
+    assert_eq!(
+        provider
+            .ttl_by_key
+            .lock()
+            .expect("ttl_by_key lock")
+            .get("tenant-a:alpha")
+            .copied(),
+        Some(Duration::from_secs(30))
+    );
+
+    serve_task.abort();
+    let _ = serve_task.await;
+}
+
+async fn connect_unix(path: &Path) -> tonic::transport::Channel {
+    Endpoint::try_from("http://[::]:50051")
+        .expect("endpoint")
+        .connect_with_connector(service_fn({
+            let path = path.to_path_buf();
+            move |_| {
+                let path = path.clone();
+                async move { UnixStream::connect(path).await.map(TokioIo::new) }
+            }
+        }))
+        .await
+        .expect("connect channel")
+}

--- a/sdk/rust/tests/helpers.rs
+++ b/sdk/rust/tests/helpers.rs
@@ -11,15 +11,16 @@ pub fn env_lock() -> &'static tokio::sync::Mutex<()> {
 }
 
 pub struct EnvGuard {
-    key: &'static str,
+    key: String,
     previous: Option<OsString>,
 }
 
 impl EnvGuard {
-    pub fn set(key: &'static str, value: impl AsRef<std::ffi::OsStr>) -> Self {
-        let previous = std::env::var_os(key);
+    pub fn set(key: impl Into<String>, value: impl AsRef<std::ffi::OsStr>) -> Self {
+        let key = key.into();
+        let previous = std::env::var_os(&key);
         unsafe {
-            std::env::set_var(key, value);
+            std::env::set_var(&key, value);
         }
         Self { key, previous }
     }
@@ -29,9 +30,9 @@ impl Drop for EnvGuard {
     fn drop(&mut self) {
         unsafe {
             if let Some(previous) = &self.previous {
-                std::env::set_var(self.key, previous);
+                std::env::set_var(&self.key, previous);
             } else {
-                std::env::remove_var(self.key);
+                std::env::remove_var(&self.key);
             }
         }
     }

--- a/sdk/typescript/README.md
+++ b/sdk/typescript/README.md
@@ -31,7 +31,7 @@ The target is a relative file path with an optional export suffix. The runtime
 accepts:
 
 - `gestalt.provider` as `{ "kind": "...", "target": "./file.ts#export" }`
-- `gestalt.provider` as a string like `"plugin:./provider.ts#provider"` or `"auth:./auth.ts#provider"`
+- `gestalt.provider` as a string like `"plugin:./provider.ts#provider"` or `"cache:./cache.ts#provider"`
 - legacy integration-only `gestalt.plugin`
 
 Use `"plugin"` as the kind token for executable integration providers. The
@@ -96,10 +96,15 @@ Use `ok(body)` for normal responses and `response(status, body)` when a handler
 needs to set a non-200 status. Plain objects with `status` and `body` fields
 are treated as user data.
 
-Auth providers and secrets providers use dedicated helpers:
+Auth providers, cache providers, and secrets providers use dedicated helpers:
 
 ```ts
-import { defineAuthProvider, defineSecretsProvider } from "@valon-technologies/gestalt";
+import {
+  Cache,
+  defineAuthProvider,
+  defineCacheProvider,
+  defineSecretsProvider,
+} from "@valon-technologies/gestalt";
 ```
 
 ## Runtime and build entrypoints
@@ -113,7 +118,7 @@ gestalt-ts-runtime ROOT plugin:./provider.ts#provider
 Release build:
 
 ```sh
-gestalt-ts-build ROOT auth:./auth.ts#provider OUTPUT PROVIDER_NAME GOOS GOARCH
+gestalt-ts-build ROOT cache:./cache.ts#provider OUTPUT PROVIDER_NAME GOOS GOARCH
 ```
 
 The build entrypoint compiles a standalone executable with Bun and bundles the

--- a/sdk/typescript/src/cache.ts
+++ b/sdk/typescript/src/cache.ts
@@ -1,0 +1,304 @@
+import { connect } from "node:net";
+
+import { createClient, type Client } from "@connectrpc/connect";
+import { createGrpcTransport } from "@connectrpc/connect-node";
+
+import { Cache as CacheService } from "../gen/v1/cache_pb.ts";
+import { RuntimeProvider, type RuntimeProviderOptions } from "./provider.ts";
+import type { MaybePromise } from "./api.ts";
+
+const ENV_CACHE_SOCKET = "GESTALT_CACHE_SOCKET";
+
+export interface CacheEntry {
+  key: string;
+  value: Uint8Array;
+}
+
+export interface CacheSetOptions {
+  ttlMs?: number;
+}
+
+export interface CacheProviderOptions extends RuntimeProviderOptions {
+  get: (key: string) => MaybePromise<Uint8Array | null | undefined>;
+  set: (
+    key: string,
+    value: Uint8Array,
+    options?: CacheSetOptions,
+  ) => MaybePromise<void>;
+  delete: (key: string) => MaybePromise<boolean>;
+  touch: (key: string, ttlMs: number) => MaybePromise<boolean>;
+  getMany?: (keys: string[]) => MaybePromise<Record<string, Uint8Array>>;
+  setMany?: (
+    entries: CacheEntry[],
+    options?: CacheSetOptions,
+  ) => MaybePromise<void>;
+  deleteMany?: (keys: string[]) => MaybePromise<number | bigint>;
+}
+
+export function cacheSocketEnv(name?: string): string {
+  const trimmed = name?.trim() ?? "";
+  if (!trimmed) {
+    return ENV_CACHE_SOCKET;
+  }
+  return `${ENV_CACHE_SOCKET}_${trimmed.replace(/[^A-Za-z0-9]/g, "_").toUpperCase()}`;
+}
+
+export class Cache {
+  private readonly client: Client<typeof CacheService>;
+
+  constructor(name?: string) {
+    const envName = cacheSocketEnv(name);
+    const socketPath = process.env[envName];
+    if (!socketPath) {
+      throw new Error(`cache: ${envName} is not set`);
+    }
+
+    const transport = createGrpcTransport({
+      baseUrl: "http://localhost",
+      nodeOptions: {
+        createConnection: () => connect(socketPath),
+      },
+    });
+    this.client = createClient(CacheService, transport);
+  }
+
+  async get(key: string): Promise<Uint8Array | undefined> {
+    const response = await this.client.get({
+      key,
+    });
+    if (!response.found) {
+      return undefined;
+    }
+    return cloneBytes(response.value);
+  }
+
+  async getMany(keys: string[]): Promise<Record<string, Uint8Array>> {
+    const response = await this.client.getMany({
+      keys: [...keys],
+    });
+    return entriesToRecord(response.entries);
+  }
+
+  async set(
+    key: string,
+    value: Uint8Array,
+    options?: CacheSetOptions,
+  ): Promise<void> {
+    const ttl = toProtoDuration(options?.ttlMs);
+    await this.client.set({
+      key,
+      value: cloneBytes(value),
+      ...(ttl ? { ttl } : {}),
+    });
+  }
+
+  async setMany(
+    entries: Iterable<CacheEntry>,
+    options?: CacheSetOptions,
+  ): Promise<void> {
+    const ttl = toProtoDuration(options?.ttlMs);
+    await this.client.setMany({
+      entries: cloneEntries(entries),
+      ...(ttl ? { ttl } : {}),
+    });
+  }
+
+  async delete(key: string): Promise<boolean> {
+    const response = await this.client.delete({
+      key,
+    });
+    return response.deleted;
+  }
+
+  async deleteMany(keys: string[]): Promise<number | bigint> {
+    const response = await this.client.deleteMany({
+      keys: [...keys],
+    });
+    return toJsInt(response.deleted);
+  }
+
+  async touch(key: string, ttlMs: number): Promise<boolean> {
+    const ttl = toProtoDuration(ttlMs);
+    const response = await this.client.touch({
+      key,
+      ...(ttl ? { ttl } : {}),
+    });
+    return response.touched;
+  }
+}
+
+export class CacheProvider extends RuntimeProvider {
+  readonly kind = "cache" as const;
+
+  private readonly getHandler: CacheProviderOptions["get"];
+  private readonly setHandler: CacheProviderOptions["set"];
+  private readonly deleteHandler: CacheProviderOptions["delete"];
+  private readonly touchHandler: CacheProviderOptions["touch"];
+  private readonly getManyHandler: CacheProviderOptions["getMany"];
+  private readonly setManyHandler: CacheProviderOptions["setMany"];
+  private readonly deleteManyHandler: CacheProviderOptions["deleteMany"];
+
+  constructor(options: CacheProviderOptions) {
+    super(options);
+    this.getHandler = options.get;
+    this.setHandler = options.set;
+    this.deleteHandler = options.delete;
+    this.touchHandler = options.touch;
+    this.getManyHandler = options.getMany;
+    this.setManyHandler = options.setMany;
+    this.deleteManyHandler = options.deleteMany;
+  }
+
+  async get(key: string): Promise<Uint8Array | undefined> {
+    const value = await this.getHandler(key);
+    if (value == null) {
+      return undefined;
+    }
+    return cloneBytes(value);
+  }
+
+  async getMany(keys: string[]): Promise<Record<string, Uint8Array>> {
+    if (this.getManyHandler) {
+      return cloneRecord(await this.getManyHandler([...keys]));
+    }
+    const values = createCacheRecord();
+    for (const key of keys) {
+      const value = await this.get(key);
+      if (value !== undefined) {
+        values[key] = cloneBytes(value);
+      }
+    }
+    return values;
+  }
+
+  async set(
+    key: string,
+    value: Uint8Array,
+    options?: CacheSetOptions,
+  ): Promise<void> {
+    await this.setHandler(key, cloneBytes(value), cloneSetOptions(options));
+  }
+
+  async setMany(
+    entries: Iterable<CacheEntry>,
+    options?: CacheSetOptions,
+  ): Promise<void> {
+    if (this.setManyHandler) {
+      await this.setManyHandler(cloneEntries(entries), cloneSetOptions(options));
+      return;
+    }
+    for (const entry of entries) {
+      await this.set(entry.key, entry.value, options);
+    }
+  }
+
+  async delete(key: string): Promise<boolean> {
+    return await this.deleteHandler(key);
+  }
+
+  async deleteMany(keys: string[]): Promise<number | bigint> {
+    if (this.deleteManyHandler) {
+      return await this.deleteManyHandler([...keys]);
+    }
+    let deleted = 0;
+    const seen = new Set<string>();
+    for (const key of keys) {
+      if (seen.has(key)) {
+        continue;
+      }
+      seen.add(key);
+      if (await this.delete(key)) {
+        deleted += 1;
+      }
+    }
+    return deleted;
+  }
+
+  async touch(key: string, ttlMs: number): Promise<boolean> {
+    return await this.touchHandler(key, ttlMs);
+  }
+}
+
+export function defineCacheProvider(options: CacheProviderOptions): CacheProvider {
+  return new CacheProvider(options);
+}
+
+export function isCacheProvider(value: unknown): value is CacheProvider {
+  return (
+    value instanceof CacheProvider ||
+    (typeof value === "object" &&
+      value !== null &&
+      "kind" in value &&
+      (value as { kind?: unknown }).kind === "cache" &&
+      "get" in value &&
+      "set" in value &&
+      "delete" in value &&
+      "touch" in value)
+  );
+}
+
+function cloneBytes(value: Uint8Array | ArrayBuffer): Uint8Array {
+  if (value instanceof Uint8Array) {
+    return new Uint8Array(value);
+  }
+  return new Uint8Array(value);
+}
+
+function cloneEntries(entries: Iterable<CacheEntry>): CacheEntry[] {
+  return [...entries].map((entry) => ({
+    key: entry.key,
+    value: cloneBytes(entry.value),
+  }));
+}
+
+function cloneRecord(entries: Record<string, Uint8Array>): Record<string, Uint8Array> {
+  const cloned = createCacheRecord();
+  for (const [key, value] of Object.entries(entries)) {
+    cloned[key] = cloneBytes(value);
+  }
+  return cloned;
+}
+
+function cloneSetOptions(options?: CacheSetOptions): CacheSetOptions | undefined {
+  if (!options || options.ttlMs === undefined) {
+    return undefined;
+  }
+  return {
+    ttlMs: options.ttlMs,
+  };
+}
+
+function entriesToRecord(
+  entries: ReadonlyArray<{ key: string; found: boolean; value: Uint8Array }>,
+): Record<string, Uint8Array> {
+  const values = createCacheRecord();
+  for (const entry of entries) {
+    if (!entry.found) {
+      continue;
+    }
+    values[entry.key] = cloneBytes(entry.value);
+  }
+  return values;
+}
+
+function createCacheRecord(): Record<string, Uint8Array> {
+  return Object.create(null) as Record<string, Uint8Array>;
+}
+
+function toProtoDuration(ttlMs: number | undefined): { seconds: bigint; nanos: number } | undefined {
+  if (ttlMs === undefined || !Number.isFinite(ttlMs) || ttlMs <= 0) {
+    return undefined;
+  }
+  const wholeMs = Math.trunc(ttlMs);
+  const seconds = Math.trunc(wholeMs / 1000);
+  const nanos = Math.trunc((wholeMs % 1000) * 1_000_000);
+  return {
+    seconds: BigInt(seconds),
+    nanos,
+  };
+}
+
+function toJsInt(value: bigint): number | bigint {
+  const asNumber = Number(value);
+  return Number.isSafeInteger(asNumber) ? asNumber : value;
+}

--- a/sdk/typescript/src/index.ts
+++ b/sdk/typescript/src/index.ts
@@ -41,6 +41,16 @@ export {
   type CompleteLoginRequest,
 } from "./auth.ts";
 export {
+  Cache,
+  CacheProvider,
+  cacheSocketEnv,
+  defineCacheProvider,
+  isCacheProvider,
+  type CacheEntry,
+  type CacheProviderOptions,
+  type CacheSetOptions,
+} from "./cache.ts";
+export {
   defineSecretsProvider,
   isSecretsProvider,
   type SecretsProviderOptions,
@@ -93,6 +103,7 @@ export {
   ENV_PROVIDER_SOCKET,
   ENV_WRITE_CATALOG,
   createAuthService,
+  createCacheService,
   createSecretsService,
   createProviderService,
   createRuntimeService,

--- a/sdk/typescript/src/provider.ts
+++ b/sdk/typescript/src/provider.ts
@@ -3,6 +3,7 @@ import type { MaybePromise } from "./api.ts";
 export type ProviderKind =
   | "integration"
   | "auth"
+  | "cache"
   | "secrets"
   | "telemetry";
 

--- a/sdk/typescript/src/runtime.ts
+++ b/sdk/typescript/src/runtime.ts
@@ -16,6 +16,15 @@ import {
   type ValidateExternalTokenRequest,
 } from "../gen/v1/auth_pb.ts";
 import {
+  Cache as CacheService,
+  CacheDeleteManyResponseSchema,
+  CacheDeleteResponseSchema,
+  CacheGetManyResponseSchema,
+  CacheGetResponseSchema,
+  CacheResultSchema,
+  CacheTouchResponseSchema,
+} from "../gen/v1/cache_pb.ts";
+import {
   SecretsProvider as SecretsProviderService,
   GetSecretResponseSchema,
   type GetSecretRequest,
@@ -49,6 +58,7 @@ import {
   isAuthProvider,
   type AuthenticatedUser,
 } from "./auth.ts";
+import { CacheProvider, isCacheProvider } from "./cache.ts";
 import { SecretsProvider, isSecretsProvider } from "./secrets.ts";
 import { catalogToYaml, type Catalog } from "./catalog.ts";
 import {
@@ -81,6 +91,7 @@ export type RuntimeArgs = {
 export type LoadedProvider =
   | IntegrationProvider
   | AuthProvider
+  | CacheProvider
   | SecretsProvider;
 
 export async function main(
@@ -143,6 +154,15 @@ export async function loadProviderFromTarget(
       if (!isAuthProvider(candidate)) {
         throw new Error(
           `${targetValue} did not resolve to a Gestalt auth provider`,
+        );
+      }
+      candidate.resolveName(defaultName);
+      return candidate;
+    }
+    case "cache": {
+      if (!isCacheProvider(candidate)) {
+        throw new Error(
+          `${targetValue} did not resolve to a Gestalt cache provider`,
         );
       }
       candidate.resolveName(defaultName);
@@ -245,6 +265,14 @@ export async function runBundledProvider(
       }
       loaded = provider;
       break;
+    case "cache":
+      if (!isCacheProvider(provider)) {
+        throw new Error(
+          "bundled target did not resolve to a Gestalt cache provider",
+        );
+      }
+      loaded = provider;
+      break;
     case "secrets":
       if (!isSecretsProvider(provider)) {
         throw new Error(
@@ -293,6 +321,8 @@ export async function serve(provider: LoadedProvider): Promise<void> {
         );
       } else if (isAuthProvider(provider)) {
         router.service(AuthProviderService, createAuthService(provider));
+      } else if (isCacheProvider(provider)) {
+        router.service(CacheService, createCacheService(provider));
       } else if (isSecretsProvider(provider)) {
         router.service(SecretsProviderService, createSecretsService(provider));
       }
@@ -564,6 +594,70 @@ export function createAuthService(
   };
 }
 
+export function createCacheService(
+  provider: CacheProvider,
+): Partial<ServiceImpl<typeof CacheService>> {
+  return {
+    async get(request) {
+      const value = await provider.get(request.key);
+      return create(CacheGetResponseSchema, {
+        found: value !== undefined,
+        value: value ? cloneUint8Array(value) : new Uint8Array(),
+      });
+    },
+    async getMany(request) {
+      const entries = await provider.getMany([...request.keys]);
+      return create(CacheGetManyResponseSchema, {
+        entries: request.keys.map((key) => {
+          const found = Object.hasOwn(entries, key);
+          const value = found ? entries[key] : undefined;
+          return create(CacheResultSchema, {
+            key,
+            found,
+            value: value ? cloneUint8Array(value) : new Uint8Array(),
+          });
+        }),
+      });
+    },
+    async set(request) {
+      await provider.set(
+        request.key,
+        cloneUint8Array(request.value),
+        durationToSetOptions(request.ttl),
+      );
+      return create(EmptySchema, {});
+    },
+    async setMany(request) {
+      await provider.setMany(
+        request.entries.map((entry) => ({
+          key: entry.key,
+          value: cloneUint8Array(entry.value),
+        })),
+        durationToSetOptions(request.ttl),
+      );
+      return create(EmptySchema, {});
+    },
+    async delete(request) {
+      return create(CacheDeleteResponseSchema, {
+        deleted: await provider.delete(request.key),
+      });
+    },
+    async deleteMany(request) {
+      return create(CacheDeleteManyResponseSchema, {
+        deleted: normalizeBigInt(await provider.deleteMany([...request.keys])),
+      });
+    },
+    async touch(request) {
+      return create(CacheTouchResponseSchema, {
+        touched: await provider.touch(
+          request.key,
+          durationToMs(request.ttl),
+        ),
+      });
+    },
+  };
+}
+
 export function createSecretsService(
   provider: SecretsProvider,
 ): Partial<ServiceImpl<typeof SecretsProviderService>> {
@@ -619,6 +713,8 @@ function providerKindToProto(kind: ProviderKind): ProtoProviderKind {
       return ProtoProviderKind.INTEGRATION;
     case "auth":
       return ProtoProviderKind.AUTH;
+    case "cache":
+      return ProtoProviderKind.CACHE;
     case "secrets":
       return ProtoProviderKind.SECRETS;
     case "telemetry":
@@ -698,6 +794,31 @@ function cloneUint8Array(value: Uint8Array | undefined): Uint8Array {
     return new Uint8Array();
   }
   return new Uint8Array(value);
+}
+
+function durationToMs(
+  value: { seconds: bigint; nanos: number } | undefined,
+): number {
+  if (!value) {
+    return 0;
+  }
+  const seconds = Number(value.seconds ?? 0n);
+  const nanos = Number(value.nanos ?? 0);
+  if (!Number.isFinite(seconds) || !Number.isFinite(nanos)) {
+    return 0;
+  }
+  return Math.max(0, (seconds * 1000) + Math.trunc(nanos / 1_000_000));
+}
+
+function durationToSetOptions(
+  value: { seconds: bigint; nanos: number } | undefined,
+): { ttlMs: number } | undefined {
+  if (!value) {
+    return undefined;
+  }
+  return {
+    ttlMs: durationToMs(value),
+  };
 }
 
 if (import.meta.main) {

--- a/sdk/typescript/src/target.ts
+++ b/sdk/typescript/src/target.ts
@@ -29,6 +29,7 @@ const EXTERNAL_PROVIDER_KIND_TOKENS = new Set<string>([
   "plugin",
   "integration",
   "auth",
+  "cache",
   "secrets",
   "telemetry",
 ]);
@@ -157,7 +158,7 @@ export function formatModuleTarget(target: ModuleTarget): string {
 }
 
 function parseKindPrefixedTarget(target: string): ProviderTarget | undefined {
-  const match = target.match(/^(plugin|integration|auth|secrets|telemetry):(.*)$/);
+  const match = target.match(/^(plugin|integration|auth|cache|secrets|telemetry):(.*)$/);
   if (!match) {
     return undefined;
   }

--- a/sdk/typescript/tests/build.test.ts
+++ b/sdk/typescript/tests/build.test.ts
@@ -7,8 +7,10 @@ import { EmptySchema } from "@bufbuild/protobuf/wkt";
 import { expect, test } from "bun:test";
 
 import { AuthProvider as AuthProviderService, BeginLoginRequestSchema } from "../gen/v1/auth_pb.ts";
+import { Cache as CacheService } from "../gen/v1/cache_pb.ts";
 import { ConfigureProviderRequestSchema, ProviderKind as ProtoProviderKind, ProviderLifecycle } from "../gen/v1/runtime_pb.ts";
 import { buildProviderBinary, bunTarget, parseBuildArgs } from "../src/build.ts";
+import { Cache, cacheSocketEnv } from "../src/cache.ts";
 import { CURRENT_PROTOCOL_VERSION, ENV_PROVIDER_SOCKET } from "../src/runtime.ts";
 import {
   createUnixGrpcClient,
@@ -103,7 +105,131 @@ test("buildProviderBinary compiles a runnable auth provider executable", async (
     }
     removeTempDir(tempDir);
   }
-});
+}, 15_000);
+
+test("buildProviderBinary compiles a runnable cache provider executable", async () => {
+  const { goos, goarch, executableSuffix } = hostTarget();
+  const tempDir = makeTempDir("gts-cache-");
+  const outputPath = join(tempDir, `fixture-cache${executableSuffix}`);
+  const socketPath = join(tempDir, "p.sock");
+  const previousDefaultSocket = process.env.GESTALT_CACHE_SOCKET;
+  const previousNamedSocket = process.env[cacheSocketEnv("named")];
+  let child: ChildProcess | undefined;
+  let stderr = "";
+
+  try {
+    buildProviderBinary({
+      root: fixturePath("cache-provider"),
+      target: "cache:./cache.ts#provider",
+      outputPath,
+      providerName: "fixture-cache-built",
+      goos,
+      goarch,
+    });
+
+    expect(existsSync(outputPath)).toBe(true);
+
+    child = spawn(outputPath, [], {
+      env: {
+        ...process.env,
+        [ENV_PROVIDER_SOCKET]: socketPath,
+      },
+      stdio: ["ignore", "ignore", "pipe"],
+    });
+    child.stderr?.setEncoding("utf8");
+    child.stderr?.on("data", (chunk: string) => {
+      stderr += chunk;
+    });
+
+    try {
+      await waitForPath(socketPath);
+    } catch (error) {
+      throw new Error(`${String(error)}${stderr ? `\n${stderr}` : ""}`);
+    }
+
+    const runtime = createUnixGrpcClient(ProviderLifecycle, socketPath);
+    const rawCache = createUnixGrpcClient(CacheService, socketPath);
+
+    const metadata = await runtime.getProviderIdentity(create(EmptySchema, {}));
+    expect(metadata.kind).toBe(ProtoProviderKind.CACHE);
+    expect(metadata.name).toBe("fixture-cache-built");
+
+    await runtime.configureProvider(
+      create(ConfigureProviderRequestSchema, {
+        name: "fixture-cache-built",
+        config: {
+          prefix: "binary",
+        },
+        protocolVersion: CURRENT_PROTOCOL_VERSION,
+      }),
+    );
+
+    process.env.GESTALT_CACHE_SOCKET = socketPath;
+    process.env[cacheSocketEnv("named")] = socketPath;
+
+    const encoder = new TextEncoder();
+    const decoder = new TextDecoder();
+    const cache = new Cache();
+    const namedCache = new Cache("named");
+
+    await cache.set("alpha", encoder.encode("one"), {
+      ttlMs: 1_500,
+    });
+    await namedCache.setMany([
+      { key: "beta", value: encoder.encode("two") },
+      { key: "gamma", value: encoder.encode("three") },
+      { key: "toString", value: encoder.encode("reserved") },
+      { key: "__proto__", value: encoder.encode("proto") },
+    ]);
+
+    expect(decoder.decode((await cache.get("alpha"))!)).toBe("one");
+    expect(
+      Object.fromEntries(
+        Object.entries(await namedCache.getMany(["alpha", "missing", "gamma"])).map(
+          ([key, value]) => [key, decoder.decode(value)],
+        ),
+      ),
+    ).toEqual({
+      alpha: "one",
+      gamma: "three",
+    });
+    const reserved = await namedCache.getMany(["toString", "__proto__", "missing"]);
+    expect(Object.keys(reserved).sort()).toEqual(["__proto__", "toString"]);
+    expect(decoder.decode(reserved["toString"]!)).toBe("reserved");
+    expect(decoder.decode(reserved["__proto__"]!)).toBe("proto");
+    expect(await cache.touch("gamma", 2_500)).toBe(true);
+    expect(await cache.delete("beta")).toBe(true);
+    expect(
+      await namedCache.deleteMany(["alpha", "missing", "gamma", "toString", "__proto__"]),
+    ).toBe(4);
+
+    const remaining = await rawCache.getMany({
+      keys: ["alpha", "beta", "gamma", "toString", "__proto__"],
+    });
+    expect(remaining.entries.map((entry) => entry.found)).toEqual([
+      false,
+      false,
+      false,
+      false,
+      false,
+    ]);
+  } finally {
+    if (previousDefaultSocket === undefined) {
+      delete process.env.GESTALT_CACHE_SOCKET;
+    } else {
+      process.env.GESTALT_CACHE_SOCKET = previousDefaultSocket;
+    }
+    if (previousNamedSocket === undefined) {
+      delete process.env[cacheSocketEnv("named")];
+    } else {
+      process.env[cacheSocketEnv("named")] = previousNamedSocket;
+    }
+    if (child) {
+      await stopProcess(child);
+    }
+    removeTempDir(tempDir);
+  }
+}, 15_000);
 
 async function stopProcess(child: ChildProcess): Promise<void> {
   if (child.exitCode !== null || child.signalCode !== null) {

--- a/sdk/typescript/tests/fixtures/cache-provider/cache.ts
+++ b/sdk/typescript/tests/fixtures/cache-provider/cache.ts
@@ -1,0 +1,77 @@
+import { defineCacheProvider } from "../../../src/index.ts";
+
+type CacheRecord = {
+  value: Uint8Array;
+  ttlMs: number;
+};
+
+const store = new Map<string, CacheRecord>();
+
+let configuredPrefix = "";
+
+function scopedKey(key: string): string {
+  return configuredPrefix ? `${configuredPrefix}:${key}` : key;
+}
+
+function cloneBytes(value: Uint8Array): Uint8Array {
+  return new Uint8Array(value);
+}
+
+export const provider = defineCacheProvider({
+  displayName: "Fixture Cache",
+  description: "Cache fixture used by SDK tests",
+  configure(_name, config) {
+    configuredPrefix = String(config.prefix ?? "");
+  },
+  async get(key) {
+    return store.get(scopedKey(key))?.value;
+  },
+  async getMany(keys) {
+    const entries = Object.create(null) as Record<string, Uint8Array>;
+    for (const key of keys) {
+      const record = store.get(scopedKey(key));
+      if (!record) {
+        continue;
+      }
+      entries[key] = cloneBytes(record.value);
+    }
+    return entries;
+  },
+  async set(key, value, options) {
+    store.set(scopedKey(key), {
+      value: cloneBytes(value),
+      ttlMs: Math.max(0, Math.trunc(options?.ttlMs ?? 0)),
+    });
+  },
+  async setMany(entries, options) {
+    for (const entry of entries) {
+      store.set(scopedKey(entry.key), {
+        value: cloneBytes(entry.value),
+        ttlMs: Math.max(0, Math.trunc(options?.ttlMs ?? 0)),
+      });
+    }
+  },
+  async delete(key) {
+    return store.delete(scopedKey(key));
+  },
+  async deleteMany(keys) {
+    let deleted = 0;
+    for (const key of keys) {
+      if (store.delete(scopedKey(key))) {
+        deleted += 1;
+      }
+    }
+    return deleted;
+  },
+  async touch(key, ttlMs) {
+    const existing = store.get(scopedKey(key));
+    if (!existing) {
+      return false;
+    }
+    store.set(scopedKey(key), {
+      value: cloneBytes(existing.value),
+      ttlMs: Math.max(0, Math.trunc(ttlMs)),
+    });
+    return true;
+  },
+});

--- a/sdk/typescript/tests/fixtures/cache-provider/package.json
+++ b/sdk/typescript/tests/fixtures/cache-provider/package.json
@@ -1,0 +1,10 @@
+{
+  "name": "@fixtures/cache-provider",
+  "type": "module",
+  "gestalt": {
+    "provider": {
+      "kind": "cache",
+      "target": "./cache.ts#provider"
+    }
+  }
+}

--- a/sdk/typescript/tests/runtime.test.ts
+++ b/sdk/typescript/tests/runtime.test.ts
@@ -10,6 +10,16 @@ import {
   ValidateExternalTokenRequestSchema,
 } from "../gen/v1/auth_pb.ts";
 import {
+  CacheDeleteManyRequestSchema,
+  CacheDeleteRequestSchema,
+  CacheGetManyRequestSchema,
+  CacheGetRequestSchema,
+  CacheSetEntrySchema,
+  CacheSetManyRequestSchema,
+  CacheSetRequestSchema,
+  CacheTouchRequestSchema,
+} from "../gen/v1/cache_pb.ts";
+import {
   AccessContextSchema,
   CredentialContextSchema,
   ExecuteRequestSchema,
@@ -18,8 +28,12 @@ import {
   StartProviderRequestSchema,
   SubjectContextSchema,
 } from "../gen/v1/plugin_pb.ts";
-import { ConfigureProviderRequestSchema } from "../gen/v1/runtime_pb.ts";
 import {
+  ConfigureProviderRequestSchema,
+  ProviderKind as ProtoProviderKind,
+} from "../gen/v1/runtime_pb.ts";
+import {
+  createCacheService,
   ENV_WRITE_CATALOG,
   createAuthService,
   createProviderService,
@@ -29,6 +43,7 @@ import {
   main,
   parseRuntimeArgs,
 } from "../src/runtime.ts";
+import { defineCacheProvider } from "../src/index.ts";
 import { fixturePath, makeTempDir, removeTempDir } from "./helpers.ts";
 
 test("runtime arg parsing requires root and target", () => {
@@ -208,4 +223,165 @@ test("auth provider supports runtime metadata, login flows, and token validation
     }),
   );
   expect(validated.email).toBe("api-token@example.com");
+});
+
+test("cache provider supports runtime metadata and cache operations", async () => {
+  const provider = await loadProviderFromTarget(fixturePath("cache-provider"));
+  const runtime = createRuntimeService(provider);
+  const cache = createCacheService(provider as any);
+
+  await (runtime.configureProvider as any)(
+    create(ConfigureProviderRequestSchema, {
+      name: "fixture-cache",
+      config: {
+        prefix: "runtime",
+      },
+      protocolVersion: 2,
+    }),
+  );
+
+  const metadata = await (runtime.getProviderIdentity as any)(
+    create(EmptySchema, {}),
+  );
+  expect(metadata.kind).toBe(ProtoProviderKind.CACHE);
+  expect(metadata.displayName).toBe("Fixture Cache");
+
+  const encoder = new TextEncoder();
+  const decoder = new TextDecoder();
+
+  await (cache.set as any)(
+    create(CacheSetRequestSchema, {
+      key: "alpha",
+      value: encoder.encode("one"),
+      ttl: {
+        seconds: 1n,
+        nanos: 500_000_000,
+      },
+    }),
+  );
+
+  await (cache.setMany as any)(
+    create(CacheSetManyRequestSchema, {
+      entries: [
+        create(CacheSetEntrySchema, {
+          key: "beta",
+          value: encoder.encode("two"),
+        }),
+        create(CacheSetEntrySchema, {
+          key: "gamma",
+          value: encoder.encode("three"),
+        }),
+        create(CacheSetEntrySchema, {
+          key: "toString",
+          value: encoder.encode("reserved"),
+        }),
+        create(CacheSetEntrySchema, {
+          key: "__proto__",
+          value: encoder.encode("proto"),
+        }),
+      ],
+    }),
+  );
+
+  const getAlpha = await (cache.get as any)(
+    create(CacheGetRequestSchema, {
+      key: "alpha",
+    }),
+  );
+  expect(getAlpha.found).toBe(true);
+  expect(decoder.decode(getAlpha.value)).toBe("one");
+
+  const getMany = await (cache.getMany as any)(
+    create(CacheGetManyRequestSchema, {
+      keys: ["alpha", "missing", "gamma"],
+    }),
+  );
+  expect(getMany.entries).toHaveLength(3);
+  expect(getMany.entries[0]).toMatchObject({
+    key: "alpha",
+    found: true,
+  });
+  expect(decoder.decode(getMany.entries[0].value)).toBe("one");
+  expect(getMany.entries[1]).toMatchObject({
+    key: "missing",
+    found: false,
+  });
+  expect(getMany.entries[2]).toMatchObject({
+    key: "gamma",
+    found: true,
+  });
+  const reservedMany = await (cache.getMany as any)(
+    create(CacheGetManyRequestSchema, {
+      keys: ["toString", "__proto__", "missing"],
+    }),
+  );
+  expect(reservedMany.entries).toHaveLength(3);
+  expect(reservedMany.entries[0]).toMatchObject({
+    key: "toString",
+    found: true,
+  });
+  expect(decoder.decode(reservedMany.entries[0].value)).toBe("reserved");
+  expect(reservedMany.entries[1]).toMatchObject({
+    key: "__proto__",
+    found: true,
+  });
+  expect(decoder.decode(reservedMany.entries[1].value)).toBe("proto");
+  expect(reservedMany.entries[2]).toMatchObject({
+    key: "missing",
+    found: false,
+  });
+
+  const touched = await (cache.touch as any)(
+    create(CacheTouchRequestSchema, {
+      key: "gamma",
+      ttl: {
+        seconds: 2n,
+        nanos: 0,
+      },
+    }),
+  );
+  expect(touched.touched).toBe(true);
+
+  const deleted = await (cache.delete as any)(
+    create(CacheDeleteRequestSchema, {
+      key: "beta",
+    }),
+  );
+  expect(deleted.deleted).toBe(true);
+
+  const deleteMany = await (cache.deleteMany as any)(
+    create(CacheDeleteManyRequestSchema, {
+      keys: ["alpha", "missing", "gamma", "toString", "__proto__"],
+    }),
+  );
+  expect(deleteMany.deleted).toBe(4n);
+});
+
+test("cache provider deleteMany fallback deletes each unique key once", async () => {
+  const calls: string[] = [];
+  const provider = defineCacheProvider({
+    async get() {
+      return undefined;
+    },
+    async set() {},
+    async delete(key) {
+      calls.push(key);
+      return key !== "missing";
+    },
+    async touch() {
+      return false;
+    },
+  });
+
+  expect(
+    await provider.deleteMany([
+      "alpha",
+      "alpha",
+      "missing",
+      "beta",
+      "beta",
+      "missing",
+    ]),
+  ).toBe(2);
+  expect(calls).toEqual(["alpha", "missing", "beta"]);
 });

--- a/sdk/typescript/tests/target.test.ts
+++ b/sdk/typescript/tests/target.test.ts
@@ -50,6 +50,11 @@ test("provider target parsing supports plugin defaults and kind prefixes", () =>
     modulePath: "./auth.ts",
     exportName: "provider",
   });
+  expect(parseProviderTarget("cache:./cache.ts#provider")).toEqual({
+    kind: "cache",
+    modulePath: "./cache.ts",
+    exportName: "provider",
+  });
 });
 
 test("package config reads legacy plugin targets and provider targets", () => {
@@ -82,5 +87,18 @@ test("package config reads legacy plugin targets and provider targets", () => {
   });
   expect(formatProviderTarget(readPackageProviderTarget(authRoot))).toBe(
     "auth:./auth.ts#provider",
+  );
+
+  const cacheRoot = fixturePath("cache-provider");
+  expect(readPackageConfig(cacheRoot)).toEqual({
+    name: "@fixtures/cache-provider",
+    providerTarget: {
+      kind: "cache",
+      modulePath: "./cache.ts",
+      exportName: "provider",
+    },
+  });
+  expect(formatProviderTarget(readPackageProviderTarget(cacheRoot))).toBe(
+    "cache:./cache.ts#provider",
   );
 });


### PR DESCRIPTION
## Summary

Stacked on #973.

This wires the standalone `cache` provider kind through the remaining SDK, packaging, and documentation surfaces:

- Python cache consumer/provider/runtime support
- TypeScript cache consumer/provider/runtime/build support
- Rust cache consumer/provider/runtime support
- cache source-package detection for Go, Python, Rust, and TypeScript
- cache docs, sidebar entries, and reference docs

## Go Interface

```go
type CacheProvider interface {
    Configure(ctx context.Context, name string, config map[string]any) error
    Get(ctx context.Context, key string) ([]byte, bool, error)
    Set(ctx context.Context, key string, value []byte, opts CacheSetOptions) error
    Delete(ctx context.Context, key string) (bool, error)
    Touch(ctx context.Context, key string, ttl time.Duration) (bool, error)
}
```

```go
cache, err := gestalt.Cache("session")
if err != nil {
    return err
}
defer cache.Close()

if err := cache.Set(ctx, "user:1", []byte("alpha"), gestalt.CacheSetOptions{
    TTL: 5 * time.Minute,
}); err != nil {
    return err
}
```

## YAML

```yaml
providers:
  cache:
    session:
      source:
        ref: github.com/valon-technologies/gestalt-providers/cache/redis
        version: 0.0.1-alpha.1
      config:
        address: ${REDIS_ADDR}

plugins:
  github:
    cache:
      - session
```

## Examples In This PR

Python:

```python
import datetime as dt
import gestalt

cache = gestalt.Cache("session")
cache.set("user:1", b"alpha", ttl=dt.timedelta(minutes=5))
value = cache.get("user:1")
cache.close()
```

TypeScript:

```ts
import { Cache, defineCacheProvider } from "@valon-technologies/gestalt";

export const provider = defineCacheProvider({
  async get(key) {
    return undefined;
  },
  async set(key, value, options) {
    void key;
    void value;
    void options?.ttlMs;
  },
  async delete(key) {
    void key;
    return false;
  },
  async touch(key, ttlMs) {
    void key;
    void ttlMs;
    return false;
  },
});

const cache = new Cache("session");
await cache.set("user:1", new TextEncoder().encode("alpha"), { ttlMs: 300_000 });
```

Rust:

```rust
let mut cache = gestalt::Cache::connect_named("session").await?;
cache
    .set(
        "user:1",
        b"alpha",
        gestalt::CacheSetOptions {
            ttl: Some(std::time::Duration::from_secs(300)),
        },
    )
    .await?;
```

## Verification

- `go test ./internal/providerpkg ./cmd/gestaltd ./internal/bootstrap ./internal/config`
- `.venv/bin/python -m unittest tests.test_runtime tests.test_cache_transport`
- `bunx tsc --noEmit -p tsconfig.json`
- `bun test tests/target.test.ts tests/runtime.test.ts tests/build.test.ts`
- `cargo test --manifest-path sdk/rust/Cargo.toml`
