### PR TITLE
Fix plugin IndexedDB inheritance edge cases

### DIFF
--- a/gestaltd/internal/bootstrap/bootstrap_test.go
+++ b/gestaltd/internal/bootstrap/bootstrap_test.go
@@ -988,4 +988,26 @@ func TestBootstrapDisabledComponents(t *testing.T) {
 			t.Fatalf("Close: %v", err)
 		}
 	})
+
+	t.Run("disabled singleton indexeddb is rejected", func(t *testing.T) {
+		t.Parallel()
+
+		cfg := validConfig()
+		cfg.Providers.IndexedDB = map[string]*config.ProviderEntry{
+			"only": {
+				Disabled: true,
+				Source:   config.ProviderSource{Path: "stub"},
+			},
+		}
+		cfg.Server.IndexedDB = ""
+		cfg.Server.Providers.IndexedDB = ""
+
+		_, err := bootstrap.Bootstrap(ctx, cfg, validFactories())
+		if err == nil {
+			t.Fatal("Bootstrap: expected error, got nil")
+		}
+		if !strings.Contains(err.Error(), "datastore resource name is required") {
+			t.Fatalf("unexpected error: %v", err)
+		}
+	})
 }

--- a/gestaltd/internal/bootstrap/executable_plugin_test.go
+++ b/gestaltd/internal/bootstrap/executable_plugin_test.go
@@ -876,6 +876,96 @@ func TestPluginIndexedDBExposeHostSocketEnv(t *testing.T) {
 	}
 }
 
+func TestPluginIndexedDBInheritsHostSelectionAndDefaultDBName(t *testing.T) {
+	t.Parallel()
+
+	bin := buildEchoPluginBinary(t)
+	manifestRoot := writeStaticCatalog(t, &catalog.Catalog{
+		Name: "echoext",
+		Operations: []catalog.CatalogOperation{
+			{
+				ID:     "indexeddb_roundtrip",
+				Method: http.MethodPost,
+				Parameters: []catalog.CatalogParameter{
+					{Name: "store", Type: "string", Required: true},
+					{Name: "id", Type: "string", Required: true},
+					{Name: "value", Type: "string", Required: true},
+				},
+			},
+		},
+	})
+	manifest := newExecutableManifest("Echo", "Echoes back the input parameters")
+
+	cases := []struct {
+		name      string
+		indexedDB *config.PluginIndexedDBConfig
+	}{
+		{name: "omitted indexeddb inherits host selection"},
+		{name: "empty indexeddb inherits host selection", indexedDB: &config.PluginIndexedDBConfig{}},
+		{name: "objectStores-only indexeddb inherits host selection", indexedDB: &config.PluginIndexedDBConfig{ObjectStores: []string{"tasks"}}},
+	}
+
+	for _, tc := range cases {
+		tc := tc
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+
+			boundDB := &trackedIndexedDB{StubIndexedDB: coretesting.StubIndexedDB{}}
+			providers, _, err := buildProvidersStrict(context.Background(), &config.Config{
+				Providers: config.ProvidersConfig{
+					Plugins: map[string]*config.ProviderEntry{
+						"echoext": {
+							Command:              bin,
+							Args:                 []string{"provider"},
+							ResolvedManifest:     manifest,
+							ResolvedManifestPath: filepath.Join(manifestRoot, "manifest.yaml"),
+							IndexedDB:            tc.indexedDB,
+						},
+					},
+				},
+			}, NewFactoryRegistry(), Deps{
+				SelectedIndexedDBName: "memory",
+				IndexedDBDefs: map[string]*config.ProviderEntry{
+					"memory": {
+						Source: config.ProviderSource{Path: "./providers/datastore/memory"},
+						Config: mustNode(t, map[string]any{"bucket": "plugin-state"}),
+					},
+				},
+				IndexedDBFactory: func(yaml.Node) (indexeddb.IndexedDB, error) {
+					return boundDB, nil
+				},
+			})
+			if err != nil {
+				t.Fatalf("buildProvidersStrict: %v", err)
+			}
+			t.Cleanup(func() { _ = CloseProviders(providers) })
+
+			prov, err := providers.Get("echoext")
+			if err != nil {
+				t.Fatalf("providers.Get: %v", err)
+			}
+			result, err := prov.Execute(context.Background(), "indexeddb_roundtrip", map[string]any{
+				"store": "tasks",
+				"id":    "task-1",
+				"value": "ship-it",
+			}, "")
+			if err != nil {
+				t.Fatalf("Execute indexeddb_roundtrip: %v", err)
+			}
+			var record map[string]any
+			if err := json.Unmarshal([]byte(result.Body), &record); err != nil {
+				t.Fatalf("unmarshal record: %v", err)
+			}
+			if got := record["value"]; got != "ship-it" {
+				t.Fatalf("record value = %#v, want %q", got, "ship-it")
+			}
+			if _, err := boundDB.ObjectStore("echoext_tasks").Get(context.Background(), "task-1"); err != nil {
+				t.Fatalf("inherited host indexeddb should use plugin-name default db prefix: %v", err)
+			}
+		})
+	}
+}
+
 func TestPluginIndexedDBBuildScopedConfig(t *testing.T) {
 	t.Parallel()
 

--- a/gestaltd/internal/config/config_test.go
+++ b/gestaltd/internal/config/config_test.go
@@ -499,6 +499,20 @@ server:
 `,
 			wantErr: false,
 		},
+		{
+			name: "disabled singleton datastore is rejected",
+			yaml: `
+providers:
+  indexeddb:
+    only:
+      disabled: true
+      source:
+        path: ./providers/datastore/sqlite
+server:
+  encryptionKey: server-key
+`,
+			wantErr: true,
+		},
 	}
 
 	for _, tc := range cases {
@@ -1382,6 +1396,138 @@ server:
 		}
 		if !strings.Contains(err.Error(), `plugins.roadmap.indexeddb.provider references unknown indexeddb "missing"`) {
 			t.Fatalf("unexpected error: %v", err)
+		}
+	})
+
+	t.Run("rejects explicit indexeddb object without provider or inherited host indexeddb", func(t *testing.T) {
+		t.Parallel()
+
+		cases := []struct {
+			name string
+			body string
+		}{
+			{
+				name: "db override",
+				body: `
+plugins:
+  roadmap:
+    source:
+      path: ./plugin/manifest.yaml
+    indexeddb:
+      db: roadmap_state
+server:
+  encryptionKey: server-key
+`,
+			},
+			{
+				name: "objectStores only",
+				body: `
+plugins:
+  roadmap:
+    source:
+      path: ./plugin/manifest.yaml
+    indexeddb:
+      objectStores:
+        - tasks
+server:
+  encryptionKey: server-key
+`,
+			},
+		}
+
+		for _, tc := range cases {
+			tc := tc
+			t.Run(tc.name, func(t *testing.T) {
+				t.Parallel()
+
+				path := mustWriteConfigFile(t, tc.body)
+
+				_, err := Load(path)
+				if err == nil {
+					t.Fatal("Load: expected error, got nil")
+				}
+				if !strings.Contains(err.Error(), `plugins.roadmap.indexeddb requires indexeddb.provider or an available selected/default host indexeddb`) {
+					t.Fatalf("unexpected error: %v", err)
+				}
+			})
+		}
+	})
+
+	t.Run("accepts empty indexeddb object without inherited host indexeddb", func(t *testing.T) {
+		t.Parallel()
+
+		cases := []struct {
+			name          string
+			body          string
+			wantIndexedDB bool
+		}{
+			{
+				name: "empty object with no host indexeddb definitions",
+				body: `
+plugins:
+  roadmap:
+    source:
+      path: ./plugin/manifest.yaml
+    indexeddb: {}
+server:
+  encryptionKey: server-key
+`,
+				wantIndexedDB: true,
+			},
+			{
+				name: "empty object with disabled-only host indexeddb",
+				body: `
+plugins:
+  roadmap:
+    source:
+      path: ./plugin/manifest.yaml
+    indexeddb: {}
+providers:
+  indexeddb:
+    only:
+      disabled: true
+      source:
+        path: ./providers/datastore/sqlite
+server:
+  encryptionKey: server-key
+`,
+				wantIndexedDB: true,
+			},
+			{
+				name: "omitted indexeddb with disabled-only host indexeddb",
+				body: `
+plugins:
+  roadmap:
+    source:
+      path: ./plugin/manifest.yaml
+providers:
+  indexeddb:
+    only:
+      disabled: true
+      source:
+        path: ./providers/datastore/sqlite
+server:
+  encryptionKey: server-key
+`,
+				wantIndexedDB: false,
+			},
+		}
+
+		for _, tc := range cases {
+			tc := tc
+			t.Run(tc.name, func(t *testing.T) {
+				t.Parallel()
+
+				path := mustWriteConfigFile(t, tc.body)
+
+				cfg, err := Load(path)
+				if err != nil {
+					t.Fatalf("Load: %v", err)
+				}
+				if got := cfg.Plugins["roadmap"].IndexedDB != nil; got != tc.wantIndexedDB {
+					t.Fatalf("IndexedDB presence = %v, want %v", got, tc.wantIndexedDB)
+				}
+			})
 		}
 	})
 

--- a/gestaltd/internal/config/provider_selection.go
+++ b/gestaltd/internal/config/provider_selection.go
@@ -91,7 +91,15 @@ func (c *Config) SelectedAuditProvider() (string, *ProviderEntry, error) {
 }
 
 func (c *Config) SelectedIndexedDBProvider() (string, *ProviderEntry, error) {
-	return c.SelectedHostProvider(HostProviderKindIndexedDB)
+	c.SyncCompatFields()
+	name, entry, err := ResolveSelectedHostProvider(HostProviderKindIndexedDB, c.Server.Providers.Selection(HostProviderKindIndexedDB), c.HostProviderEntries(HostProviderKindIndexedDB))
+	if err != nil {
+		return "", nil, err
+	}
+	if strings.TrimSpace(c.Server.Providers.IndexedDB) == "" && entry != nil && entry.Disabled {
+		return "", nil, nil
+	}
+	return name, entry, nil
 }
 
 type EffectivePluginIndexedDB struct {
@@ -127,6 +135,9 @@ func ResolveEffectivePluginIndexedDB(pluginName string, entry *ProviderEntry, se
 		providerName = strings.TrimSpace(selectedName)
 	}
 	if providerName == "" {
+		if entry.IndexedDB != nil && (strings.TrimSpace(entry.IndexedDB.DB) != "" || len(entry.IndexedDB.ObjectStores) > 0) {
+			return EffectivePluginIndexedDB{}, fmt.Errorf("config validation: plugins.%s.indexeddb requires indexeddb.provider or an available selected/default host indexeddb", pluginName)
+		}
 		return EffectivePluginIndexedDB{}, nil
 	}
 

--- a/gestaltd/internal/providerhost/indexeddb_server_test.go
+++ b/gestaltd/internal/providerhost/indexeddb_server_test.go
@@ -2,6 +2,7 @@ package providerhost
 
 import (
 	"context"
+	"errors"
 	"testing"
 
 	gestalt "github.com/valon-technologies/gestalt/sdk/go"
@@ -10,6 +11,7 @@ import (
 	coretesting "github.com/valon-technologies/gestalt/server/core/testing"
 	"github.com/valon-technologies/gestalt/server/internal/metricutil"
 	"github.com/valon-technologies/gestalt/server/internal/testutil/metrictest"
+	"google.golang.org/grpc"
 )
 
 func TestIndexedDBServerUsesStoreNamesAsProvided(t *testing.T) {
@@ -99,13 +101,31 @@ func TestIndexedDBServerRejectsStoresOutsideAllowlist(t *testing.T) {
 	t.Parallel()
 
 	db := &coretesting.StubIndexedDB{}
+	ctx := context.Background()
+	schema := indexeddb.ObjectStoreSchema{
+		Indexes: []indexeddb.IndexSchema{{Name: "by_type", KeyPath: []string{"type"}}},
+	}
+	if err := db.CreateObjectStore(ctx, "events", schema); err != nil {
+		t.Fatalf("CreateObjectStore events: %v", err)
+	}
+	if err := db.ObjectStore("events").Put(ctx, indexeddb.Record{"id": "evt-1", "type": "daily"}); err != nil {
+		t.Fatalf("seed events record: %v", err)
+	}
+
 	srv := NewIndexedDBServer(db, "roadmap", IndexedDBServerOptions{
 		AllowedStores: []string{"tasks"},
 	})
-	ctx := context.Background()
 	record, err := gestalt.RecordToProto(map[string]any{"id": "evt-1"})
 	if err != nil {
 		t.Fatalf("RecordToProto: %v", err)
+	}
+	indexValue, err := gestalt.TypedValueFromAny("daily")
+	if err != nil {
+		t.Fatalf("TypedValueFromAny: %v", err)
+	}
+	eventsRange, err := keyRangeToProto(indexeddb.Only("evt-1"))
+	if err != nil {
+		t.Fatalf("keyRangeToProto: %v", err)
 	}
 
 	if _, err := srv.(*indexedDBServer).Put(ctx, &proto.RecordRequest{
@@ -118,5 +138,50 @@ func TestIndexedDBServerRejectsStoresOutsideAllowlist(t *testing.T) {
 		Name: "events",
 	}); err == nil {
 		t.Fatal("CreateObjectStore should reject stores outside the configured allowlist")
+	}
+	if _, err := srv.(*indexedDBServer).DeleteObjectStore(ctx, &proto.DeleteObjectStoreRequest{
+		Name: "events",
+	}); err == nil {
+		t.Fatal("DeleteObjectStore should reject stores outside the configured allowlist")
+	}
+	if _, err := srv.(*indexedDBServer).Get(ctx, &proto.ObjectStoreRequest{
+		Store: "events",
+		Id:    "evt-1",
+	}); err == nil {
+		t.Fatal("Get should reject stores outside the configured allowlist")
+	}
+	if _, err := srv.(*indexedDBServer).DeleteRange(ctx, &proto.ObjectStoreRangeRequest{
+		Store: "events",
+		Range: eventsRange,
+	}); err == nil {
+		t.Fatal("DeleteRange should reject stores outside the configured allowlist")
+	}
+	if _, err := srv.(*indexedDBServer).IndexGet(ctx, &proto.IndexQueryRequest{
+		Store:  "events",
+		Index:  "by_type",
+		Values: []*proto.TypedValue{indexValue},
+	}); err == nil {
+		t.Fatal("IndexGet should reject stores outside the configured allowlist")
+	}
+
+	conn := newBufconnConn(t, func(server *grpc.Server) {
+		proto.RegisterIndexedDBServer(server, srv)
+	})
+	remote := &remoteIndexedDB{client: proto.NewIndexedDBClient(conn)}
+
+	if _, err := remote.ObjectStore("events").Get(ctx, "evt-1"); !errors.Is(err, indexeddb.ErrNotFound) {
+		t.Fatalf("remote Get error = %v, want indexeddb.ErrNotFound", err)
+	}
+	if _, err := remote.ObjectStore("events").DeleteRange(ctx, *indexeddb.Only("evt-1")); !errors.Is(err, indexeddb.ErrNotFound) {
+		t.Fatalf("remote DeleteRange error = %v, want indexeddb.ErrNotFound", err)
+	}
+	if _, err := remote.ObjectStore("events").Index("by_type").Get(ctx, "daily"); !errors.Is(err, indexeddb.ErrNotFound) {
+		t.Fatalf("remote IndexGet error = %v, want indexeddb.ErrNotFound", err)
+	}
+	if cursor, err := remote.ObjectStore("events").OpenCursor(ctx, nil, indexeddb.CursorNext); !errors.Is(err, indexeddb.ErrNotFound) {
+		if cursor != nil {
+			_ = cursor.Close()
+		}
+		t.Fatalf("remote OpenCursor error = %v, want indexeddb.ErrNotFound", err)
 	}
 }


### PR DESCRIPTION
## Summary

This follow-up keeps the new single plugin IndexedDB interface and fixes the remaining inheritance and disabled-selection edge cases.

## YAML Interface

Canonical plugin config:

```yaml
plugins:
  roadmap:
    indexeddb:
      provider: main
      db: roadmap_state
      objectStores:
        - tasks
```

Inherited host selection:

```yaml
server:
  providers:
    indexeddb: main

plugins:
  roadmap:
    indexeddb: {}
```

Object-store-only inheritance:

```yaml
plugins:
  roadmap:
    indexeddb:
      objectStores:
        - tasks
```

## Go Interface

```go
type PluginIndexedDBConfig struct {
    Disabled     bool     `yaml:"disabled,omitempty"`
    Provider     string   `yaml:"provider,omitempty"`
    DB           string   `yaml:"db,omitempty"`
    ObjectStores []string `yaml:"objectStores,omitempty"`
}

type ProviderEntry struct {
    IndexedDB *PluginIndexedDBConfig `yaml:"indexeddb,omitempty"`
}
```

## Behavior Changes

- omitted `indexeddb` and `indexeddb: {}` now behave equivalently when no host IndexedDB is available, including disabled-only host IndexedDB definitions
- explicit `indexeddb.db` or `indexeddb.objectStores` without a resolvable provider now fails validation instead of silently degrading to no IndexedDB
- disabled-only host IndexedDB entries no longer count as an available implicitly selected datastore for runtime/bootstrap
- providerhost allowlist coverage now exercises destructive/query paths beyond the original `Put` and `CreateObjectStore` checks

## Verification

- `go test ./internal/config ./internal/bootstrap ./internal/providerhost`
- `go test ./...`
- `go build ./...`
- `golangci-lint run ./...`
