### PR TITLE
Clarify plugin IndexedDB configuration docs

### DIFF
--- a/docs/content/providers/indexeddb.mdx
+++ b/docs/content/providers/indexeddb.mdx
@@ -21,6 +21,65 @@ fall back to `<db>_` transport-level store prefixes. Plugins may also set
 `plugins.<name>.indexeddb.objectStores` to allowlist logical stores such as
 `tasks`.
 
+## How plugins use IndexedDB in code
+
+Executable plugins do not choose raw database DSNs or relational schemas at
+runtime. They receive one IndexedDB SDK socket from the host, and the host
+decides what that socket points to from config.
+
+- In plugin code, use `new IndexedDB()` to open the plugin's configured
+  IndexedDB connection.
+- `plugins.<name>.indexeddb.provider` selects which named
+  `providers.indexeddb` entry backs that socket.
+- `plugins.<name>.indexeddb.db` selects the plugin-visible database name used
+  for backend scoping. On schema-capable backends such as RelationalDB, that
+  becomes the backend schema name.
+- If the plugin omits `plugins.<name>.indexeddb`, it inherits the
+  host-selected IndexedDB provider and uses the plugin key as the default `db`
+  name.
+
+For example:
+
+```yaml
+server:
+  providers:
+    indexeddb: main
+
+providers:
+  indexeddb:
+    main:
+      source:
+        ref: github.com/valon-technologies/gestalt-providers/indexeddb/relationaldb
+        version: 0.0.1-alpha.1
+      config:
+        dsn: ${SYSTEM_DATABASE_URL}
+    workplaceHub:
+      source:
+        ref: github.com/valon-technologies/gestalt-providers/indexeddb/relationaldb
+        version: 0.0.1-alpha.1
+      config:
+        dsn: ${APP_DATABASE_URL}
+
+plugins:
+  workplace_hub:
+    source:
+      path: ./plugin/manifest.yaml
+    indexeddb:
+      provider: workplaceHub
+      db: workplace_hub
+```
+
+Then inside the plugin:
+
+```ts
+const db = new IndexedDB();
+```
+
+The TypeScript SDK also accepts `new IndexedDB("name")`, which looks for a
+named `GESTALT_INDEXEDDB_SOCKET_<NAME>` environment variable. Standard plugin
+config does not expose multiple IndexedDB sockets, so normal plugins should
+select provider and `db` in YAML and use `new IndexedDB()`.
+
 ## First-party IndexedDB providers
 
 First-party storage backends live under

--- a/docs/content/reference/config-file.mdx
+++ b/docs/content/reference/config-file.mdx
@@ -490,7 +490,7 @@ plugins:
 | `surfaces` | Typed host-side overrides for manifest-declared surfaces, such as `surfaces.openapi.baseUrl` or `surfaces.graphql.url`. |
 | `connections` | Named connection declarations. See [connections](#connections) below. |
 | `allowedOperations` | Allowlist with optional `alias`, `description`, and `allowedRoles` overrides per operation. |
-| `indexeddb` | Optional plugin IndexedDB config. `indexeddb.provider` selects which named `providers.indexeddb` entry to expose to the plugin; when omitted, the plugin inherits the selected/default host IndexedDB. `indexeddb.db` overrides the plugin-visible database name and defaults to the plugin key. `indexeddb.objectStores` optionally allowlists the logical object stores the plugin may use. `indexeddb.disabled: true` opts out entirely. Plugins receive one IndexedDB SDK socket via `GESTALT_INDEXEDDB_SOCKET`. |
+| `indexeddb` | Optional plugin IndexedDB config. `indexeddb.provider` selects which named `providers.indexeddb` entry backs the plugin's single IndexedDB SDK socket; when omitted, the plugin inherits the selected/default host IndexedDB. `indexeddb.db` overrides the plugin-visible database name and defaults to the plugin key. Schema-capable backends derive plugin scoping from that `db` name. `indexeddb.objectStores` optionally allowlists the logical object stores the plugin may use. `indexeddb.disabled: true` opts out entirely. Plugins then call `new IndexedDB()` (or the equivalent SDK helper) against `GESTALT_INDEXEDDB_SOCKET`; they do not choose arbitrary schemas or DSNs at runtime. |
 
 ### `plugins.*.source`
 


### PR DESCRIPTION
## Summary
- document how plugins actually consume IndexedDB from code after the plugin IndexedDB config refactor
- explain that `plugins.<name>.indexeddb.provider` and `indexeddb.db` choose the backing provider and plugin-visible database name in YAML
- clarify that standard plugin config exposes a single `GESTALT_INDEXEDDB_SOCKET`, so normal plugin code should use `new IndexedDB()` rather than selecting schemas or DSNs at runtime

## Testing
- `git diff --check`
