### PR TITLE
docs: document OIDC HTTPS and PKCE cache config

### DIFF
--- a/docs/content/configuration.mdx
+++ b/docs/content/configuration.mdx
@@ -246,6 +246,10 @@ providers:
       clientSecret: secret://oidc-client-secret
 ```
 
+For production OIDC providers, keep `issuerUrl` on `https://`. If you run a
+local plaintext issuer on loopback for development, add
+`allowInsecureHttp: true` under `providers.auth.config`.
+
 | Scenario | Configuration |
 | --- | --- |
 | Local development | Omit `providers.auth` or set `providers.auth.disabled: true` |

--- a/docs/content/reference/config-file.mdx
+++ b/docs/content/reference/config-file.mdx
@@ -161,6 +161,9 @@ providers:
       sessionTtl: 24h
       pkce: true
       displayName: Company SSO
+      allowInsecureHttp: false
+      pkceVerifierTtl: 1h
+      pkceVerifierMaxItems: 10000
 ```
 
 Two fields are required: `issuerUrl` (the OIDC discovery base URL) and `clientId`. `clientSecret` may be omitted for PKCE-only public clients.
@@ -168,6 +171,10 @@ Two fields are required: `issuerUrl` (the OIDC discovery base URL) and `clientId
 `redirectUrl` defaults to a path derived from `server.baseUrl`. `allowedDomains` restricts login by email domain. `scopes` defaults to `openid`, `email`, and `profile`.
 
 `sessionTtl` controls session token lifetime and defaults to `24h`. Set `pkce` to `true` to enable Proof Key for Code Exchange. `displayName` controls the label shown in the login UI, defaulting to `SSO`.
+
+`issuerUrl` and all discovered OIDC endpoints must use `https://` by default. Set `allowInsecureHttp: true` only for local loopback development against issuers such as `http://127.0.0.1:8080` or `http://localhost:8080`. Non-loopback `http://` endpoints are always rejected.
+
+`pkceVerifierTtl` and `pkceVerifierMaxItems` are optional PKCE cache controls. They default to `1h` and `10000` in-flight login attempts, and both must be greater than zero when set.
 
 OIDC checks `email_verified` when the claim is present. Unverified accounts are rejected.
 


### PR DESCRIPTION
## Summary
- document that OIDC issuer discovery now requires `https` by default
- add the loopback-only `allowInsecureHttp` escape hatch to the OIDC config reference
- document the optional `pkceVerifierTtl` and `pkceVerifierMaxItems` cache controls
- clarify the normal production path versus local loopback development in the main configuration guide

## Go Interface
```go
type config struct {
    IssuerURL            string        `yaml:"issuerUrl"`
    ClientID             string        `yaml:"clientId"`
    ClientSecret         string        `yaml:"clientSecret"`
    RedirectURL          string        `yaml:"redirectUrl"`
    AllowedDomains       []string      `yaml:"allowedDomains"`
    Scopes               []string      `yaml:"scopes"`
    SessionTTL           time.Duration `yaml:"sessionTtl"`
    PKCE                 bool          `yaml:"pkce"`
    DisplayName          string        `yaml:"displayName"`
    AllowInsecureHTTP    bool          `yaml:"allowInsecureHttp"`
    PKCEVerifierTTL      time.Duration `yaml:"pkceVerifierTtl"`
    PKCEVerifierMaxItems int           `yaml:"pkceVerifierMaxItems"`
}
```

## YAML Interface
```yaml
providers:
  auth:
    source:
      ref: github.com/valon-technologies/gestalt-providers/auth/oidc
      version: 0.0.1-alpha.1
    config:
      issuerUrl: https://login.example.com
      clientId: ${OIDC_CLIENT_ID}
      clientSecret: secret://oidc-client-secret
      pkce: true
      allowInsecureHttp: false
      pkceVerifierTtl: 1h
      pkceVerifierMaxItems: 10000
```

## Examples
```yaml
# Production OIDC
providers:
  auth:
    source:
      ref: github.com/valon-technologies/gestalt-providers/auth/oidc
      version: 0.0.1-alpha.1
    config:
      issuerUrl: https://login.example.com
      clientId: ${OIDC_CLIENT_ID}
      clientSecret: secret://oidc-client-secret
```

```yaml
# Local loopback OIDC development
providers:
  auth:
    source:
      ref: github.com/valon-technologies/gestalt-providers/auth/oidc
      version: 0.0.1-alpha.1
    config:
      issuerUrl: http://127.0.0.1:8080/realms/dev
      clientId: ${OIDC_CLIENT_ID}
      clientSecret: secret://oidc-client-secret
      allowInsecureHttp: true
```

## Validation
- `git diff --check`
