### PR TITLE
Remove legacy config path compatibility shims

### DIFF
--- a/gestaltd/internal/bootstrap/bootstrap.go
+++ b/gestaltd/internal/bootstrap/bootstrap.go
@@ -348,7 +348,7 @@ func prepareCore(ctx context.Context, cfg *config.Config, factories *FactoryRegi
 	if storeErr != nil {
 		return nil, fmt.Errorf("bootstrap: system indexeddb from resource %q: %w", selectedIndexedDBName, storeErr)
 	}
-	store = metricutil.InstrumentIndexedDB(store, cfg.Server.IndexedDB)
+	store = metricutil.InstrumentIndexedDB(store, selectedIndexedDBName)
 	svc, svcErr := coredata.New(store, enc)
 	if svcErr != nil {
 		_ = store.Close()
@@ -404,7 +404,7 @@ func prepareCore(ctx context.Context, cfg *config.Config, factories *FactoryRegi
 	deps.Egress = newEgressDeps(cfg)
 	deps.Services = svc
 	deps.IndexedDBs = hostIndexedDBs
-	deps.IndexedDBDefs = cfg.Providers.IndexedDBs
+	deps.IndexedDBDefs = cfg.Providers.IndexedDB
 	deps.IndexedDBFactory = factories.IndexedDB
 	deps.FileAPIs = hostFileAPIs
 

--- a/gestaltd/internal/bootstrap/connections.go
+++ b/gestaltd/internal/bootstrap/connections.go
@@ -19,7 +19,6 @@ type ConnectionMaps struct {
 }
 
 func BuildConnectionMaps(cfg *config.Config) (ConnectionMaps, error) {
-	cfg.SyncCompatFields()
 	maps := ConnectionMaps{
 		DefaultConnection: make(map[string]string, len(cfg.Plugins)),
 		APIConnection:     make(map[string]string, len(cfg.Plugins)),

--- a/gestaltd/internal/bootstrap/executable_plugin_test.go
+++ b/gestaltd/internal/bootstrap/executable_plugin_test.go
@@ -35,16 +35,14 @@ func TestExecutableSDKExampleProviderReceivesStartConfig(t *testing.T) {
 	manifestRoot := exampleProviderRoot(t)
 	manifest := newExecutableManifest("Example Provider", "A minimal example provider built with the public SDK")
 	cfg := &config.Config{
-		Providers: config.ProvidersConfig{
-			Plugins: map[string]*config.ProviderEntry{
-				"example": {
-					Command:              bin,
-					ResolvedManifest:     manifest,
-					ResolvedManifestPath: filepath.Join(manifestRoot, "manifest.yaml"),
-					Config: mustNode(t, map[string]any{
-						"greeting": "Hello from config",
-					}),
-				},
+		Plugins: map[string]*config.ProviderEntry{
+			"example": {
+				Command:              bin,
+				ResolvedManifest:     manifest,
+				ResolvedManifestPath: filepath.Join(manifestRoot, "manifest.yaml"),
+				Config: mustNode(t, map[string]any{
+					"greeting": "Hello from config",
+				}),
 			},
 		},
 	}
@@ -161,15 +159,13 @@ plugin = "provider"
 	t.Setenv("PATH", t.TempDir())
 
 	cfg := &config.Config{
-		Providers: config.ProvidersConfig{
-			Plugins: map[string]*config.ProviderEntry{
-				"python-source": {
-					ResolvedManifest:     manifest,
-					ResolvedManifestPath: manifestPath,
-					Config: mustNode(t, map[string]any{
-						"greeting": "Hi",
-					}),
-				},
+		Plugins: map[string]*config.ProviderEntry{
+			"python-source": {
+				ResolvedManifest:     manifest,
+				ResolvedManifestPath: manifestPath,
+				Config: mustNode(t, map[string]any{
+					"greeting": "Hi",
+				}),
 			},
 		},
 	}
@@ -252,27 +248,25 @@ paths:
 	}
 
 	cfg := &config.Config{
-		Providers: config.ProvidersConfig{
-			Plugins: map[string]*config.ProviderEntry{
-				"example": {
-					ResolvedManifestPath: manifestPath,
-					ResolvedManifest: &providermanifestv1.Manifest{
-						Kind:        providermanifestv1.KindPlugin,
-						DisplayName: "Example",
-						Description: "OpenAPI example",
-						Spec: &providermanifestv1.Spec{
-							Surfaces: &providermanifestv1.ProviderSurfaces{
-								OpenAPI: &providermanifestv1.OpenAPISurface{
-									Document: "openapi.yaml",
-									BaseURL:  manifestSrv.URL,
-								},
+		Plugins: map[string]*config.ProviderEntry{
+			"example": {
+				ResolvedManifestPath: manifestPath,
+				ResolvedManifest: &providermanifestv1.Manifest{
+					Kind:        providermanifestv1.KindPlugin,
+					DisplayName: "Example",
+					Description: "OpenAPI example",
+					Spec: &providermanifestv1.Spec{
+						Surfaces: &providermanifestv1.ProviderSurfaces{
+							OpenAPI: &providermanifestv1.OpenAPISurface{
+								Document: "openapi.yaml",
+								BaseURL:  manifestSrv.URL,
 							},
 						},
 					},
-					Surfaces: &config.ProviderSurfaceOverrides{
-						OpenAPI: &config.ProviderOpenAPISurfaceOverride{
-							BaseURL: configSrv.URL,
-						},
+				},
+				Surfaces: &config.ProviderSurfaceOverrides{
+					OpenAPI: &config.ProviderOpenAPISurfaceOverride{
+						BaseURL: configSrv.URL,
 					},
 				},
 			},
@@ -365,22 +359,20 @@ paths:
 	}
 
 	cfg := &config.Config{
-		Providers: config.ProvidersConfig{
-			Plugins: map[string]*config.ProviderEntry{
-				"notion": {
-					ResolvedManifestPath: manifestPath,
-					ResolvedManifest: &providermanifestv1.Manifest{
-						Kind:        providermanifestv1.KindPlugin,
-						DisplayName: "Notion",
-						Description: "Dual-surface provider",
-						Spec: &providermanifestv1.Spec{
-							Surfaces: &providermanifestv1.ProviderSurfaces{
-								OpenAPI: &providermanifestv1.OpenAPISurface{
-									Document: "openapi.yaml",
-								},
-								MCP: &providermanifestv1.MCPSurface{
-									URL: mcpHTTP.URL,
-								},
+		Plugins: map[string]*config.ProviderEntry{
+			"notion": {
+				ResolvedManifestPath: manifestPath,
+				ResolvedManifest: &providermanifestv1.Manifest{
+					Kind:        providermanifestv1.KindPlugin,
+					DisplayName: "Notion",
+					Description: "Dual-surface provider",
+					Spec: &providermanifestv1.Spec{
+						Surfaces: &providermanifestv1.ProviderSurfaces{
+							OpenAPI: &providermanifestv1.OpenAPISurface{
+								Document: "openapi.yaml",
+							},
+							MCP: &providermanifestv1.MCPSurface{
+								URL: mcpHTTP.URL,
 							},
 						},
 					},
@@ -455,16 +447,14 @@ func TestExecutableSDKExampleProviderAppliesConfigMetadataOverrides(t *testing.T
 	manifest := newExecutableManifest("Manifest Display", "Manifest Description")
 
 	cfg := &config.Config{
-		Providers: config.ProvidersConfig{
-			Plugins: map[string]*config.ProviderEntry{
-				"example": {
-					DisplayName:          "Config Display",
-					Description:          "Config Description",
-					IconFile:             iconPath,
-					Command:              bin,
-					ResolvedManifest:     manifest,
-					ResolvedManifestPath: filepath.Join(manifestRoot, "manifest.yaml"),
-				},
+		Plugins: map[string]*config.ProviderEntry{
+			"example": {
+				DisplayName:          "Config Display",
+				Description:          "Config Description",
+				IconFile:             iconPath,
+				Command:              bin,
+				ResolvedManifest:     manifest,
+				ResolvedManifestPath: filepath.Join(manifestRoot, "manifest.yaml"),
 			},
 		},
 	}
@@ -576,18 +566,16 @@ func TestPluginManifestOAuthWiresConnectionAuth(t *testing.T) {
 		Scopes:           []string{"read", "write"},
 	}
 	cfg := &config.Config{
-		Providers: config.ProvidersConfig{
-			Plugins: map[string]*config.ProviderEntry{
-				"echoauth": {
-					Command: bin,
-					Args:    []string{"provider"},
-					Config: mustNode(t, map[string]any{
-						"clientId":     "test-client-id",
-						"clientSecret": "test-client-secret",
-					}),
-					ResolvedManifest:     manifest,
-					ResolvedManifestPath: filepath.Join(manifestRoot, "manifest.yaml"),
-				},
+		Plugins: map[string]*config.ProviderEntry{
+			"echoauth": {
+				Command: bin,
+				Args:    []string{"provider"},
+				Config: mustNode(t, map[string]any{
+					"clientId":     "test-client-id",
+					"clientSecret": "test-client-secret",
+				}),
+				ResolvedManifest:     manifest,
+				ResolvedManifestPath: filepath.Join(manifestRoot, "manifest.yaml"),
 			},
 		},
 	}
@@ -639,14 +627,12 @@ func TestPluginManifestNoAuthSkipsConnectionAuth(t *testing.T) {
 	})
 	manifest := newExecutableManifest("Echo", "Echoes back the input parameters")
 	cfg := &config.Config{
-		Providers: config.ProvidersConfig{
-			Plugins: map[string]*config.ProviderEntry{
-				"echonoauth": {
-					Command:              bin,
-					Args:                 []string{"provider"},
-					ResolvedManifest:     manifest,
-					ResolvedManifestPath: filepath.Join(manifestRoot, "manifest.yaml"),
-				},
+		Plugins: map[string]*config.ProviderEntry{
+			"echonoauth": {
+				Command:              bin,
+				Args:                 []string{"provider"},
+				ResolvedManifest:     manifest,
+				ResolvedManifestPath: filepath.Join(manifestRoot, "manifest.yaml"),
 			},
 		},
 	}
@@ -676,29 +662,27 @@ func TestPluginManifestNamedOAuthKeepsProviderTokenMode(t *testing.T) {
 	})
 	manifest := newExecutableManifest("Echo", "Echoes back the input parameters")
 	cfg := &config.Config{
-		Providers: config.ProvidersConfig{
-			Plugins: map[string]*config.ProviderEntry{
-				"echoauth": {
-					Command:           bin,
-					Args:              []string{"provider"},
-					Source:            config.ProviderSource{Ref: "github.com/acme/plugins/test", Version: "1.0.0"},
-					DefaultConnection: "workspace",
-					Connections: map[string]*config.ConnectionDef{
-						"workspace": {
-							Auth: config.ConnectionAuthDef{
-								Type:             providermanifestv1.AuthTypeOAuth2,
-								AuthorizationURL: "https://example.com/authorize",
-								TokenURL:         "https://example.com/token",
-							},
+		Plugins: map[string]*config.ProviderEntry{
+			"echoauth": {
+				Command:           bin,
+				Args:              []string{"provider"},
+				Source:            config.ProviderSource{Ref: "github.com/acme/plugins/test", Version: "1.0.0"},
+				DefaultConnection: "workspace",
+				Connections: map[string]*config.ConnectionDef{
+					"workspace": {
+						Auth: config.ConnectionAuthDef{
+							Type:             providermanifestv1.AuthTypeOAuth2,
+							AuthorizationURL: "https://example.com/authorize",
+							TokenURL:         "https://example.com/token",
 						},
 					},
-					Config: mustNode(t, map[string]any{
-						"clientId":     "test-client-id",
-						"clientSecret": "test-client-secret",
-					}),
-					ResolvedManifest:     manifest,
-					ResolvedManifestPath: filepath.Join(manifestRoot, "manifest.yaml"),
 				},
+				Config: mustNode(t, map[string]any{
+					"clientId":     "test-client-id",
+					"clientSecret": "test-client-secret",
+				}),
+				ResolvedManifest:     manifest,
+				ResolvedManifestPath: filepath.Join(manifestRoot, "manifest.yaml"),
 			},
 		},
 	}
@@ -735,14 +719,12 @@ func TestPluginProcessEnvIsolation(t *testing.T) {
 	manifest := newExecutableManifest("Echo", "Echoes back the input parameters")
 
 	cfg := &config.Config{
-		Providers: config.ProvidersConfig{
-			Plugins: map[string]*config.ProviderEntry{
-				"echoext": {
-					Command:              bin,
-					Args:                 []string{"provider"},
-					ResolvedManifest:     manifest,
-					ResolvedManifestPath: filepath.Join(manifestRoot, "manifest.yaml"),
-				},
+		Plugins: map[string]*config.ProviderEntry{
+			"echoext": {
+				Command:              bin,
+				Args:                 []string{"provider"},
+				ResolvedManifest:     manifest,
+				ResolvedManifestPath: filepath.Join(manifestRoot, "manifest.yaml"),
 			},
 		},
 	}
@@ -801,15 +783,13 @@ func TestPluginIndexedDBBindingsExposeHostSocketEnv(t *testing.T) {
 
 	makeConfig := func(bindings []config.PluginIndexedDBBinding) *config.Config {
 		return &config.Config{
-			Providers: config.ProvidersConfig{
-				Plugins: map[string]*config.ProviderEntry{
-					"echoext": {
-						Command:              bin,
-						Args:                 []string{"provider"},
-						ResolvedManifest:     manifest,
-						ResolvedManifestPath: filepath.Join(manifestRoot, "manifest.yaml"),
-						IndexedDBs:           bindings,
-					},
+			Plugins: map[string]*config.ProviderEntry{
+				"echoext": {
+					Command:              bin,
+					Args:                 []string{"provider"},
+					ResolvedManifest:     manifest,
+					ResolvedManifestPath: filepath.Join(manifestRoot, "manifest.yaml"),
+					IndexedDBs:           bindings,
 				},
 			},
 		}
@@ -889,15 +869,13 @@ func TestPluginFileAPIBindingsExposeHostSocketEnv(t *testing.T) {
 
 	makeConfig := func(bindings []string) *config.Config {
 		return &config.Config{
-			Providers: config.ProvidersConfig{
-				Plugins: map[string]*config.ProviderEntry{
-					"echoext": {
-						Command:              bin,
-						Args:                 []string{"provider"},
-						ResolvedManifest:     manifest,
-						ResolvedManifestPath: filepath.Join(manifestRoot, "manifest.yaml"),
-						FileAPIs:             bindings,
-					},
+			Plugins: map[string]*config.ProviderEntry{
+				"echoext": {
+					Command:              bin,
+					Args:                 []string{"provider"},
+					ResolvedManifest:     manifest,
+					ResolvedManifestPath: filepath.Join(manifestRoot, "manifest.yaml"),
+					FileAPIs:             bindings,
 				},
 			},
 		}
@@ -986,10 +964,8 @@ func TestPluginIndexedDBBindingsBuildScopedConfig(t *testing.T) {
 			entry.IndexedDBSchema = schema
 		}
 		return &config.Config{
-			Providers: config.ProvidersConfig{
-				Plugins: map[string]*config.ProviderEntry{
-					"echoext": entry,
-				},
+			Plugins: map[string]*config.ProviderEntry{
+				"echoext": entry,
 			},
 		}
 	}
@@ -1171,17 +1147,15 @@ func TestPluginIndexedDBBindingsRouteObjectStoresAndTransportPrefix(t *testing.T
 		boundDB    *trackedIndexedDB
 	)
 	providers, _, err := buildProvidersStrict(context.Background(), &config.Config{
-		Providers: config.ProvidersConfig{
-			Plugins: map[string]*config.ProviderEntry{
-				"echoext": {
-					Command:              bin,
-					Args:                 []string{"provider"},
-					ResolvedManifest:     manifest,
-					ResolvedManifestPath: filepath.Join(manifestRoot, "manifest.yaml"),
-					IndexedDBSchema:      "roadmap",
-					IndexedDBs: []config.PluginIndexedDBBinding{
-						{Name: "memory", ObjectStores: []string{"tasks"}},
-					},
+		Plugins: map[string]*config.ProviderEntry{
+			"echoext": {
+				Command:              bin,
+				Args:                 []string{"provider"},
+				ResolvedManifest:     manifest,
+				ResolvedManifestPath: filepath.Join(manifestRoot, "manifest.yaml"),
+				IndexedDBSchema:      "roadmap",
+				IndexedDBs: []config.PluginIndexedDBBinding{
+					{Name: "memory", ObjectStores: []string{"tasks"}},
 				},
 			},
 		},
@@ -1269,17 +1243,15 @@ func TestPluginIndexedDBBindingsPreserveLegacyTransportPrefixedData(t *testing.T
 
 	var boundDB *trackedIndexedDB
 	providers, _, err := buildProvidersStrict(context.Background(), &config.Config{
-		Providers: config.ProvidersConfig{
-			Plugins: map[string]*config.ProviderEntry{
-				"echoext": {
-					Command:              bin,
-					Args:                 []string{"provider"},
-					ResolvedManifest:     manifest,
-					ResolvedManifestPath: filepath.Join(manifestRoot, "manifest.yaml"),
-					IndexedDBSchema:      "roadmap",
-					IndexedDBs: []config.PluginIndexedDBBinding{
-						{Name: "memory", ObjectStores: []string{"tasks"}},
-					},
+		Plugins: map[string]*config.ProviderEntry{
+			"echoext": {
+				Command:              bin,
+				Args:                 []string{"provider"},
+				ResolvedManifest:     manifest,
+				ResolvedManifestPath: filepath.Join(manifestRoot, "manifest.yaml"),
+				IndexedDBSchema:      "roadmap",
+				IndexedDBs: []config.PluginIndexedDBBinding{
+					{Name: "memory", ObjectStores: []string{"tasks"}},
 				},
 			},
 		},
@@ -1358,18 +1330,16 @@ func TestPluginIndexedDBBindingsRouteExplicitAndCatchAllStores(t *testing.T) {
 
 	boundDBs := make(map[string]*trackedIndexedDB)
 	providers, _, err := buildProvidersStrict(context.Background(), &config.Config{
-		Providers: config.ProvidersConfig{
-			Plugins: map[string]*config.ProviderEntry{
-				"echoext": {
-					Command:              bin,
-					Args:                 []string{"provider"},
-					ResolvedManifest:     manifest,
-					ResolvedManifestPath: filepath.Join(manifestRoot, "manifest.yaml"),
-					IndexedDBSchema:      "roadmap",
-					IndexedDBs: []config.PluginIndexedDBBinding{
-						{Name: "main", ObjectStores: []string{"tasks"}},
-						{Name: "archive"},
-					},
+		Plugins: map[string]*config.ProviderEntry{
+			"echoext": {
+				Command:              bin,
+				Args:                 []string{"provider"},
+				ResolvedManifest:     manifest,
+				ResolvedManifestPath: filepath.Join(manifestRoot, "manifest.yaml"),
+				IndexedDBSchema:      "roadmap",
+				IndexedDBs: []config.PluginIndexedDBBinding{
+					{Name: "main", ObjectStores: []string{"tasks"}},
+					{Name: "archive"},
 				},
 			},
 		},
@@ -1467,12 +1437,10 @@ func TestExecutablePluginRequiresManifest(t *testing.T) {
 
 	bin := buildEchoPluginBinary(t)
 	cfg := &config.Config{
-		Providers: config.ProvidersConfig{
-			Plugins: map[string]*config.ProviderEntry{
-				"echoext": {
-					Command: bin,
-					Args:    []string{"provider"},
-				},
+		Plugins: map[string]*config.ProviderEntry{
+			"echoext": {
+				Command: bin,
+				Args:    []string{"provider"},
 			},
 		},
 	}

--- a/gestaltd/internal/bootstrap/provider_build.go
+++ b/gestaltd/internal/bootstrap/provider_build.go
@@ -46,7 +46,6 @@ func buildRegistrationStore(deps Deps) mcpoauth.RegistrationStore {
 }
 
 func buildProviders(ctx context.Context, cfg *config.Config, factories *FactoryRegistry, deps Deps) (*registry.ProviderMap[core.Provider], <-chan struct{}, func() map[string]map[string]OAuthHandler, error) {
-	cfg.SyncCompatFields()
 	reg := registry.New()
 	connAuth := make(map[string]map[string]OAuthHandler)
 	var connMu sync.Mutex

--- a/gestaltd/internal/bootstrap/sandbox_test.go
+++ b/gestaltd/internal/bootstrap/sandbox_test.go
@@ -62,16 +62,14 @@ func TestSandboxedPluginCannotReadUnauthorizedFile(t *testing.T) {
 	)
 
 	cfg := &config.Config{
-		Providers: config.ProvidersConfig{
-			Plugins: map[string]*config.ProviderEntry{
-				"sandboxed": {
-					Command:              bin,
-					Args:                 []string{"provider"},
-					AllowedHosts:         []string{"localhost"},
-					HostBinary:           hostBin,
-					ResolvedManifest:     manifest,
-					ResolvedManifestPath: filepath.Join(manifestRoot, "manifest.yaml"),
-				},
+		Plugins: map[string]*config.ProviderEntry{
+			"sandboxed": {
+				Command:              bin,
+				Args:                 []string{"provider"},
+				AllowedHosts:         []string{"localhost"},
+				HostBinary:           hostBin,
+				ResolvedManifest:     manifest,
+				ResolvedManifestPath: filepath.Join(manifestRoot, "manifest.yaml"),
 			},
 		},
 	}
@@ -108,16 +106,14 @@ func TestSandboxedPluginCanCommunicateViaGRPC(t *testing.T) {
 	)
 
 	cfg := &config.Config{
-		Providers: config.ProvidersConfig{
-			Plugins: map[string]*config.ProviderEntry{
-				"sandboxed": {
-					Command:              bin,
-					Args:                 []string{"provider"},
-					AllowedHosts:         []string{"localhost"},
-					HostBinary:           hostBin,
-					ResolvedManifest:     manifest,
-					ResolvedManifestPath: filepath.Join(manifestRoot, "manifest.yaml"),
-				},
+		Plugins: map[string]*config.ProviderEntry{
+			"sandboxed": {
+				Command:              bin,
+				Args:                 []string{"provider"},
+				AllowedHosts:         []string{"localhost"},
+				HostBinary:           hostBin,
+				ResolvedManifest:     manifest,
+				ResolvedManifestPath: filepath.Join(manifestRoot, "manifest.yaml"),
 			},
 		},
 	}
@@ -157,17 +153,15 @@ func TestSandboxedSynthesizedSourcePluginCanStart(t *testing.T) {
 	}
 
 	cfg := &config.Config{
-		Providers: config.ProvidersConfig{
-			Plugins: map[string]*config.ProviderEntry{
-				"example": {
-					AllowedHosts:         []string{"localhost"},
-					HostBinary:           hostBin,
-					ResolvedManifest:     manifest,
-					ResolvedManifestPath: manifestPath,
-					Config: mustNode(t, map[string]any{
-						"greeting": "Hello from sandbox",
-					}),
-				},
+		Plugins: map[string]*config.ProviderEntry{
+			"example": {
+				AllowedHosts:         []string{"localhost"},
+				HostBinary:           hostBin,
+				ResolvedManifest:     manifest,
+				ResolvedManifestPath: manifestPath,
+				Config: mustNode(t, map[string]any{
+					"greeting": "Hello from sandbox",
+				}),
 			},
 		},
 	}
@@ -211,14 +205,12 @@ func TestSandboxDisabledByDefault(t *testing.T) {
 	)
 
 	cfg := &config.Config{
-		Providers: config.ProvidersConfig{
-			Plugins: map[string]*config.ProviderEntry{
-				"nosandbox": {
-					Command:              bin,
-					Args:                 []string{"provider"},
-					ResolvedManifest:     manifest,
-					ResolvedManifestPath: filepath.Join(manifestRoot, "manifest.yaml"),
-				},
+		Plugins: map[string]*config.ProviderEntry{
+			"nosandbox": {
+				Command:              bin,
+				Args:                 []string{"provider"},
+				ResolvedManifest:     manifest,
+				ResolvedManifestPath: filepath.Join(manifestRoot, "manifest.yaml"),
 			},
 		},
 	}
@@ -260,16 +252,14 @@ func TestSandboxedPluginHTTPProxyAllowsConfiguredHosts(t *testing.T) {
 	)
 
 	cfg := &config.Config{
-		Providers: config.ProvidersConfig{
-			Plugins: map[string]*config.ProviderEntry{
-				"proxied": {
-					Command:              bin,
-					Args:                 []string{"provider"},
-					AllowedHosts:         []string{host},
-					HostBinary:           hostBin,
-					ResolvedManifest:     manifest,
-					ResolvedManifestPath: filepath.Join(manifestRoot, "manifest.yaml"),
-				},
+		Plugins: map[string]*config.ProviderEntry{
+			"proxied": {
+				Command:              bin,
+				Args:                 []string{"provider"},
+				AllowedHosts:         []string{host},
+				HostBinary:           hostBin,
+				ResolvedManifest:     manifest,
+				ResolvedManifestPath: filepath.Join(manifestRoot, "manifest.yaml"),
 			},
 		},
 	}
@@ -318,16 +308,14 @@ func TestSandboxedPluginHTTPProxyBlocksUnconfiguredHosts(t *testing.T) {
 	)
 
 	cfg := &config.Config{
-		Providers: config.ProvidersConfig{
-			Plugins: map[string]*config.ProviderEntry{
-				"blocked": {
-					Command:              bin,
-					Args:                 []string{"provider"},
-					AllowedHosts:         []string{"not-a-real-host.example.com"},
-					HostBinary:           hostBin,
-					ResolvedManifest:     manifest,
-					ResolvedManifestPath: filepath.Join(manifestRoot, "manifest.yaml"),
-				},
+		Plugins: map[string]*config.ProviderEntry{
+			"blocked": {
+				Command:              bin,
+				Args:                 []string{"provider"},
+				AllowedHosts:         []string{"not-a-real-host.example.com"},
+				HostBinary:           hostBin,
+				ResolvedManifest:     manifest,
+				ResolvedManifestPath: filepath.Join(manifestRoot, "manifest.yaml"),
 			},
 		},
 	}

--- a/gestaltd/internal/bootstrap/validate.go
+++ b/gestaltd/internal/bootstrap/validate.go
@@ -60,7 +60,6 @@ func validateMCPCatalogs(providers *registry.ProviderMap[core.Provider]) error {
 }
 
 func buildProvidersStrict(ctx context.Context, cfg *config.Config, factories *FactoryRegistry, deps Deps) (*registry.ProviderMap[core.Provider], map[string]map[string]OAuthHandler, error) {
-	cfg.SyncCompatFields()
 	reg := registry.New()
 	connAuth := make(map[string]map[string]OAuthHandler)
 

--- a/gestaltd/internal/config/config.go
+++ b/gestaltd/internal/config/config.go
@@ -55,13 +55,6 @@ type ProvidersConfig struct {
 	UI        map[string]*UIEntry       `yaml:"ui,omitempty"`
 	IndexedDB map[string]*ProviderEntry `yaml:"indexeddb,omitempty"`
 	FileAPI   map[string]*ProviderEntry `yaml:"fileapi,omitempty"`
-
-	// Legacy aliases retained for internal call sites and tests while the
-	// canonical YAML shape is migrating to top-level plugins, indexeddb, and
-	// fileapi.
-	IndexedDBs map[string]*ProviderEntry `yaml:"-"`
-	FileAPIs   map[string]*ProviderEntry `yaml:"-"`
-	Plugins    map[string]*ProviderEntry `yaml:"-"`
 }
 
 type HostProviderKind string
@@ -294,7 +287,6 @@ type ServerConfig struct {
 	APITokenTTL   string                `yaml:"apiTokenTtl"`
 	ArtifactsDir  string                `yaml:"artifactsDir"`
 	Providers     ServerProvidersConfig `yaml:"providers,omitempty"`
-	IndexedDB     string                `yaml:"-"`
 	Egress        EgressConfig          `yaml:"egress,omitempty"`
 	Authorization AuthorizationConfig   `yaml:"authorization,omitempty"`
 }
@@ -641,9 +633,6 @@ func OverlayManagedPluginConfig(path string, cfg *Config) error {
 	if err := dec.Decode(&root); err != nil && err != io.EOF {
 		return fmt.Errorf("parsing config YAML: %w", err)
 	}
-	if err := normalizeConfigRoot(&root); err != nil {
-		return err
-	}
 	doc := documentValueNode(&root)
 	providersNode := mappingValueNode(documentValueNode(&root), "providers")
 	pluginsNode := mappingValueNode(doc, "plugins")
@@ -741,270 +730,6 @@ type configShapeUsage struct {
 	canonical bool
 }
 
-var legacyProviderEntryKeys = map[string]struct{}{
-	"source":            {},
-	"config":            {},
-	"default":           {},
-	"disabled":          {},
-	"env":               {},
-	"allowedHosts":      {},
-	"displayName":       {},
-	"description":       {},
-	"iconFile":          {},
-	"connections":       {},
-	"allowedOperations": {},
-	"indexeddb":         {},
-	"indexeddbs":        {},
-	"fileapi":           {},
-	"fileapis":          {},
-	"surfaces":          {},
-}
-
-func normalizeConfigRoot(root *yaml.Node) error {
-	doc := documentValueNode(root)
-	if doc == nil || doc.Kind == 0 {
-		return nil
-	}
-	if doc.Kind != yaml.MappingNode {
-		return fmt.Errorf("parsing config YAML: expected mapping document")
-	}
-
-	usage := configShapeUsage{}
-	providersNode := mappingValueNode(doc, "providers")
-	if err := normalizePluginsNode(doc, providersNode, &usage); err != nil {
-		return err
-	}
-	if err := normalizeProvidersNode(providersNode, &usage); err != nil {
-		return err
-	}
-	if err := normalizeServerNode(mappingValueNode(doc, "server"), &usage); err != nil {
-		return err
-	}
-	if err := normalizePluginBindings(mappingValueNode(doc, "plugins"), &usage); err != nil {
-		return err
-	}
-	return nil
-}
-
-func normalizePluginsNode(root, providersNode *yaml.Node, usage *configShapeUsage) error {
-	root = documentValueNode(root)
-	providersNode = documentValueNode(providersNode)
-	canonical := mappingValueNode(root, "plugins")
-	legacy := mappingValueNode(providersNode, "plugins")
-	if canonical != nil {
-		usage.canonical = true
-	}
-	if legacy != nil {
-		usage.legacy = true
-	}
-	if canonical != nil && legacy != nil {
-		return fmt.Errorf("config validation: plugins must be configured using top-level plugins or providers.plugins, not both")
-	}
-	if canonical == nil && legacy != nil {
-		setMappingValueNode(root, "plugins", legacy)
-		removeMappingKey(providersNode, "plugins")
-	}
-	return nil
-}
-
-func normalizeProvidersNode(providersNode *yaml.Node, usage *configShapeUsage) error {
-	providersNode = documentValueNode(providersNode)
-	if providersNode == nil {
-		return nil
-	}
-	legacyIndexedDB := mappingValueNode(providersNode, "indexeddbs")
-	canonicalIndexedDB := mappingValueNode(providersNode, "indexeddb")
-	legacyFileAPI := mappingValueNode(providersNode, "fileapis")
-	canonicalFileAPI := mappingValueNode(providersNode, "fileapi")
-	if legacyIndexedDB != nil {
-		usage.legacy = true
-	}
-	if canonicalIndexedDB != nil {
-		usage.canonical = true
-	}
-	if legacyIndexedDB != nil && canonicalIndexedDB != nil {
-		return fmt.Errorf("config validation: providers.indexeddb must be configured using indexeddb or indexeddbs, not both")
-	}
-	if canonicalIndexedDB == nil && legacyIndexedDB != nil {
-		setMappingValueNode(providersNode, "indexeddb", legacyIndexedDB)
-		removeMappingKey(providersNode, "indexeddbs")
-	}
-	if legacyFileAPI != nil {
-		usage.legacy = true
-	}
-	if canonicalFileAPI != nil {
-		usage.canonical = true
-	}
-	if legacyFileAPI != nil && canonicalFileAPI != nil {
-		return fmt.Errorf("config validation: providers.fileapi must be configured using fileapi or fileapis, not both")
-	}
-	if canonicalFileAPI == nil && legacyFileAPI != nil {
-		setMappingValueNode(providersNode, "fileapi", legacyFileAPI)
-		removeMappingKey(providersNode, "fileapis")
-	}
-
-	for _, kind := range []string{"auth", "secrets", "telemetry", "audit"} {
-		node := mappingValueNode(providersNode, kind)
-		if node == nil {
-			continue
-		}
-		if isLegacySingletonProviderNode(node) {
-			usage.legacy = true
-			setMappingValueNode(providersNode, kind, wrapLegacyProviderNode(kind, node))
-			continue
-		}
-		usage.canonical = true
-	}
-	return nil
-}
-
-func normalizeServerNode(serverNode *yaml.Node, usage *configShapeUsage) error {
-	serverNode = documentValueNode(serverNode)
-	if serverNode == nil {
-		return nil
-	}
-	providersNode := mappingValueNode(serverNode, "providers")
-	legacyIndexedDB := mappingValueNode(serverNode, "indexeddb")
-	if providersNode != nil {
-		usage.canonical = true
-	}
-	if legacyIndexedDB != nil {
-		usage.legacy = true
-	}
-	if providersNode != nil && legacyIndexedDB != nil && mappingValueNode(providersNode, "indexeddb") != nil {
-		return fmt.Errorf("config validation: server.providers.indexeddb and server.indexeddb cannot both be set")
-	}
-	if legacyIndexedDB != nil {
-		if providersNode == nil {
-			providersNode = &yaml.Node{Kind: yaml.MappingNode, Tag: "!!map"}
-			setMappingValueNode(serverNode, "providers", providersNode)
-		}
-		if mappingValueNode(providersNode, "indexeddb") == nil {
-			setMappingValueNode(providersNode, "indexeddb", legacyIndexedDB)
-		}
-		removeMappingKey(serverNode, "indexeddb")
-	}
-	return nil
-}
-
-func normalizePluginBindings(pluginsNode *yaml.Node, usage *configShapeUsage) error {
-	pluginsNode = documentValueNode(pluginsNode)
-	if pluginsNode == nil || pluginsNode.Kind != yaml.MappingNode {
-		return nil
-	}
-	for i := 0; i+1 < len(pluginsNode.Content); i += 2 {
-		entryNode := documentValueNode(pluginsNode.Content[i+1])
-		if entryNode == nil || entryNode.Kind != yaml.MappingNode {
-			continue
-		}
-		legacy := mappingValueNode(entryNode, "indexeddbs")
-		canonical := mappingValueNode(entryNode, "indexeddb")
-		if legacy != nil {
-			usage.legacy = true
-		}
-		if canonical != nil {
-			usage.canonical = true
-		}
-		if legacy != nil && canonical != nil {
-			return fmt.Errorf("config validation: plugin %q cannot set both indexeddb and indexeddbs", pluginsNode.Content[i].Value)
-		}
-		if canonical == nil && legacy != nil {
-			setMappingValueNode(entryNode, "indexeddb", legacy)
-			removeMappingKey(entryNode, "indexeddbs")
-		}
-		legacy = mappingValueNode(entryNode, "fileapis")
-		canonical = mappingValueNode(entryNode, "fileapi")
-		if legacy != nil {
-			usage.legacy = true
-		}
-		if canonical != nil {
-			usage.canonical = true
-		}
-		if legacy != nil && canonical != nil {
-			return fmt.Errorf("config validation: plugin %q cannot set both fileapi and fileapis", pluginsNode.Content[i].Value)
-		}
-		if canonical == nil && legacy != nil {
-			setMappingValueNode(entryNode, "fileapi", legacy)
-			removeMappingKey(entryNode, "fileapis")
-		}
-	}
-	return nil
-}
-
-func isLegacySingletonProviderNode(node *yaml.Node) bool {
-	node = documentValueNode(node)
-	if node == nil || node.Kind != yaml.MappingNode || len(node.Content) == 0 {
-		return false
-	}
-	for i := 0; i+1 < len(node.Content); i += 2 {
-		key := node.Content[i].Value
-		if _, ok := legacyProviderEntryKeys[key]; !ok {
-			return false
-		}
-		if !looksLikeProviderEntryMap(node.Content[i+1]) {
-			return true
-		}
-	}
-	return false
-}
-
-func looksLikeProviderEntryMap(node *yaml.Node) bool {
-	node = documentValueNode(node)
-	if node == nil || node.Kind != yaml.MappingNode {
-		return false
-	}
-	if len(node.Content) == 0 {
-		return true
-	}
-	for i := 0; i+1 < len(node.Content); i += 2 {
-		if _, ok := legacyProviderEntryKeys[node.Content[i].Value]; ok {
-			return true
-		}
-	}
-	return false
-}
-
-func wrapLegacyProviderNode(name string, node *yaml.Node) *yaml.Node {
-	return &yaml.Node{
-		Kind: yaml.MappingNode,
-		Tag:  "!!map",
-		Content: []*yaml.Node{
-			{Kind: yaml.ScalarNode, Tag: "!!str", Value: name},
-			node,
-		},
-	}
-}
-
-func setMappingValueNode(node *yaml.Node, key string, value *yaml.Node) {
-	node = documentValueNode(node)
-	if node == nil || node.Kind != yaml.MappingNode {
-		return
-	}
-	for i := 0; i+1 < len(node.Content); i += 2 {
-		if node.Content[i].Value == key {
-			node.Content[i+1] = value
-			return
-		}
-	}
-	node.Content = append(node.Content,
-		&yaml.Node{Kind: yaml.ScalarNode, Tag: "!!str", Value: key},
-		value,
-	)
-}
-
-func removeMappingKey(node *yaml.Node, key string) {
-	node = documentValueNode(node)
-	if node == nil || node.Kind != yaml.MappingNode {
-		return
-	}
-	for i := 0; i+1 < len(node.Content); i += 2 {
-		if node.Content[i].Value == key {
-			node.Content = append(node.Content[:i], node.Content[i+2:]...)
-			return
-		}
-	}
-}
-
 func loadWithLookup(path string, lookup func(string) (string, bool), allowMissing bool) (*Config, error) {
 	data, err := os.ReadFile(path)
 	if err != nil {
@@ -1019,21 +744,8 @@ func loadWithLookup(path string, lookup func(string) (string, bool), allowMissin
 		return nil, fmt.Errorf("expanding config environment variables: environment variable %q not set; use ${%s:-} to allow an empty default", firstMissing, firstMissing)
 	}
 
-	var root yaml.Node
-	normalizeDecoder := yaml.NewDecoder(strings.NewReader(resolved))
-	if err := normalizeDecoder.Decode(&root); err != nil && err != io.EOF {
-		return nil, fmt.Errorf("parsing config YAML: %w", err)
-	}
-	if err := normalizeConfigRoot(&root); err != nil {
-		return nil, err
-	}
-	normalized, err := yaml.Marshal(documentValueNode(&root))
-	if err != nil {
-		return nil, fmt.Errorf("marshaling normalized config YAML: %w", err)
-	}
-
 	var cfg Config
-	dec := yaml.NewDecoder(strings.NewReader(string(normalized)))
+	dec := yaml.NewDecoder(strings.NewReader(resolved))
 	dec.KnownFields(true)
 	if err := dec.Decode(&cfg); err != nil && err != io.EOF {
 		return nil, fmt.Errorf("parsing config YAML: %w", err)
@@ -1131,7 +843,6 @@ func overlayEnvIntoNode(node yaml.Node, lookup func(string) (string, bool), pres
 }
 
 func applyDefaults(cfg *Config) {
-	cfg.SyncCompatFields()
 	if cfg.Server.Public.Port == 0 {
 		cfg.Server.Public.Port = 8080
 	}
@@ -1143,11 +854,6 @@ func applyDefaults(cfg *Config) {
 	cfg.Providers.Audit = applyDefaultBuiltinProviderEntries(cfg.Providers.Audit, DefaultProviderInstance, "inherit")
 	cfg.Providers.IndexedDB = nonNilProviderEntryMap(cfg.Providers.IndexedDB)
 	cfg.Providers.FileAPI = nonNilProviderEntryMap(cfg.Providers.FileAPI)
-	cfg.Providers.Plugins = cfg.Plugins
-	cfg.Providers.IndexedDBs = cfg.Providers.IndexedDB
-	cfg.Providers.FileAPIs = cfg.Providers.FileAPI
-	cfg.Server.IndexedDB = cfg.Server.Providers.IndexedDB
-	cfg.SyncCompatFields()
 }
 
 func nonNilProviderEntryMap(entries map[string]*ProviderEntry) map[string]*ProviderEntry {

--- a/gestaltd/internal/config/config_test.go
+++ b/gestaltd/internal/config/config_test.go
@@ -152,7 +152,7 @@ plugins:
 	}
 }
 
-func TestLoadConfigAcceptsLegacyAndCanonicalProviderFormsWhenKeysDoNotConflict(t *testing.T) {
+func TestLoadConfigAcceptsCanonicalProviderForms(t *testing.T) {
 	t.Parallel()
 
 	path := mustWriteConfigFile(t, `
@@ -161,7 +161,7 @@ server:
     indexeddb: main
   encryptionKey: server-key
 providers:
-  indexeddbs:
+  indexeddb:
     main:
       source:
         path: ./providers/datastore/sqlite
@@ -260,12 +260,13 @@ func TestLoadConfigEnvFileFallback(t *testing.T) {
 
 	path := mustWriteConfigFile(t, `
 providers:
-  indexeddbs:
+  indexeddb:
     sqlite:
       source:
         path: ./providers/datastore/sqlite
 server:
-  indexeddb: sqlite
+  providers:
+    indexeddb: sqlite
   encryptionKey: ${TEST_ENCRYPTION}
 `)
 
@@ -293,12 +294,13 @@ func TestLoadConfigMissingEnvVariableFails(t *testing.T) {
 	portEnv := encryptionEnv + "_PORT"
 	path := mustWriteConfigFile(t, fmt.Sprintf(`
 providers:
-  indexeddbs:
+  indexeddb:
     sqlite:
       source:
         path: ./providers/datastore/sqlite
 server:
-  indexeddb: sqlite
+  providers:
+    indexeddb: sqlite
   encryptionKey: ${%s}
   public:
     port: ${%s}
@@ -334,12 +336,13 @@ func TestLoadConfigEmptyDefaultEnvSyntax(t *testing.T) {
 
 	path := mustWriteConfigFile(t, `
 providers:
-  indexeddbs:
+  indexeddb:
     sqlite:
       source:
         path: ./providers/datastore/sqlite
 server:
-  indexeddb: sqlite
+  providers:
+    indexeddb: sqlite
   encryptionKey: ${TEST_ENCRYPTION:-}
 `)
 
@@ -449,12 +452,13 @@ func TestValidateRuntime(t *testing.T) {
 			name: "missing auth provider is allowed",
 			yaml: `
 providers:
-  indexeddbs:
+  indexeddb:
     sqlite:
       source:
         path: ./providers/datastore/sqlite
 server:
-  indexeddb: sqlite
+  providers:
+    indexeddb: sqlite
   encryptionKey: server-key
 `,
 			wantErr: false,
@@ -464,7 +468,8 @@ server:
 			yaml: `
 providers:
   auth:
-    disabled: true
+    default:
+      disabled: true
 server:
   encryptionKey: server-key
 `,
@@ -474,12 +479,13 @@ server:
 			name: "missing encryption key",
 			yaml: `
 providers:
-  indexeddbs:
+  indexeddb:
     sqlite:
       source:
         path: ./providers/datastore/sqlite
 server:
-  indexeddb: sqlite
+  providers:
+    indexeddb: sqlite
 `,
 			wantErr: true,
 		},
@@ -488,13 +494,15 @@ server:
 			yaml: `
 providers:
   auth:
-    disabled: true
-  indexeddbs:
+    default:
+      disabled: true
+  indexeddb:
     sqlite:
       source:
         path: ./providers/datastore/sqlite
 server:
-  indexeddb: sqlite
+  providers:
+    indexeddb: sqlite
   encryptionKey: server-key
 `,
 			wantErr: false,
@@ -533,8 +541,7 @@ func TestLoadSucceedsWithoutRuntimeFields(t *testing.T) {
 	t.Parallel()
 
 	path := mustWriteConfigFile(t, `
-providers:
-  plugins:
+plugins:
     custom_tool:
       source:
         path: ./manifest.yaml
@@ -557,12 +564,13 @@ func TestLoadConfigUIEntries(t *testing.T) {
 
 		path := mustWriteConfigFile(t, `
 providers:
-  indexeddbs:
+  indexeddb:
     sqlite:
       source:
         path: ./providers/datastore/sqlite
 server:
-  indexeddb: sqlite
+  providers:
+    indexeddb: sqlite
   encryptionKey: server-key
 `)
 
@@ -583,12 +591,13 @@ providers:
   ui:
     roadmap:
       disabled: true
-  indexeddbs:
+  indexeddb:
     sqlite:
       source:
         path: ./providers/datastore/sqlite
 server:
-  indexeddb: sqlite
+  providers:
+    indexeddb: sqlite
   encryptionKey: server-key
 `)
 
@@ -618,12 +627,13 @@ providers:
   ui:
     roadmap:
       disabled: %s
-  indexeddbs:
+  indexeddb:
     sqlite:
       source:
         path: ./providers/datastore/sqlite
 server:
-  indexeddb: sqlite
+  providers:
+    indexeddb: sqlite
   encryptionKey: server-key
 `, variant))
 
@@ -648,12 +658,13 @@ providers:
       disabled: true
       config:
         brand_name: Acme
-  indexeddbs:
+  indexeddb:
     sqlite:
       source:
         path: ./providers/datastore/sqlite
 server:
-  indexeddb: sqlite
+  providers:
+    indexeddb: sqlite
   encryptionKey: server-key
 `)
 
@@ -673,12 +684,13 @@ providers:
       source:
         path: ./web/default/provider.yaml
       path: /create-customer-roadmap-review
-  indexeddbs:
+  indexeddb:
     sqlite:
       source:
         path: ./providers/datastore/sqlite
 server:
-  indexeddb: sqlite
+  providers:
+    indexeddb: sqlite
   encryptionKey: server-key
 `)
 
@@ -710,12 +722,13 @@ providers:
       source:
         path: ./web/roadmap/manifest.yaml
       path: /create-customer-roadmap-review/
-  indexeddbs:
+  indexeddb:
     sqlite:
       source:
         path: ./providers/datastore/sqlite
 server:
-  indexeddb: sqlite
+  providers:
+    indexeddb: sqlite
   encryptionKey: server-key
 `)
 
@@ -746,12 +759,13 @@ providers:
       source:
         path: ./web/api/manifest.yaml
       path: /api
-  indexeddbs:
+  indexeddb:
     sqlite:
       source:
         path: ./providers/datastore/sqlite
 server:
-  indexeddb: sqlite
+  providers:
+    indexeddb: sqlite
   encryptionKey: server-key
 `)
 
@@ -774,12 +788,13 @@ providers:
       source:
         path: ./web/metrics/manifest.yaml
       path: /metrics/dashboard
-  indexeddbs:
+  indexeddb:
     sqlite:
       source:
         path: ./providers/datastore/sqlite
 server:
-  indexeddb: sqlite
+  providers:
+    indexeddb: sqlite
   encryptionKey: server-key
 `)
 
@@ -806,12 +821,13 @@ providers:
       source:
         path: ./web/child/manifest.yaml
       path: /tools/admin
-  indexeddbs:
+  indexeddb:
     sqlite:
       source:
         path: ./providers/datastore/sqlite
 server:
-  indexeddb: sqlite
+  providers:
+    indexeddb: sqlite
   encryptionKey: server-key
 `)
 
@@ -834,12 +850,13 @@ providers:
       source:
         path: ./web/root/manifest.yaml
       path: /
-  indexeddbs:
+  indexeddb:
     sqlite:
       source:
         path: ./providers/datastore/sqlite
 server:
-  indexeddb: sqlite
+  providers:
+    indexeddb: sqlite
   encryptionKey: server-key
 `)
 
@@ -861,12 +878,13 @@ providers:
     roadmap:
       source: stdout
       path: /create-customer-roadmap-review
-  indexeddbs:
+  indexeddb:
     sqlite:
       source:
         path: ./providers/datastore/sqlite
 server:
-  indexeddb: sqlite
+  providers:
+    indexeddb: sqlite
   encryptionKey: server-key
 `)
 
@@ -1340,7 +1358,7 @@ providers:
 		}
 	})
 
-	t.Run("normalizes legacy fileapi collection and bindings", func(t *testing.T) {
+	t.Run("rejects legacy fileapi collection and bindings", func(t *testing.T) {
 		t.Parallel()
 
 		path := mustWriteConfigFile(t, `
@@ -1357,15 +1375,12 @@ providers:
         path: ./providers/fileapi/archive
 `)
 
-		cfg, err := Load(path)
-		if err != nil {
-			t.Fatalf("Load: %v", err)
+		_, err := Load(path)
+		if err == nil {
+			t.Fatal("Load: expected error, got nil")
 		}
-		if got := cfg.Plugins["roadmap"].FileAPIs; !reflect.DeepEqual(got, []string{"archive"}) {
-			t.Fatalf("Plugins[roadmap].FileAPIs = %v, want [archive]", got)
-		}
-		if cfg.Providers.FileAPI["archive"] == nil {
-			t.Fatal(`Providers.FileAPI["archive"] = nil`)
+		if !strings.Contains(err.Error(), `field fileapis not found`) {
+			t.Fatalf("unexpected error: %v", err)
 		}
 	})
 
@@ -1536,7 +1551,8 @@ func TestLoadAcceptsNewComponentForms(t *testing.T) {
 			yaml: `
 providers:
   telemetry:
-    source: stdout
+    default:
+      source: stdout
 `,
 		},
 		{
@@ -1553,9 +1569,10 @@ providers:
 			yaml: `
 providers:
   auth:
-    source:
-      ref: github.com/valon-technologies/gestalt-providers/auth/google
-      version: 1.0.0
+    default:
+      source:
+        ref: github.com/valon-technologies/gestalt-providers/auth/google
+        version: 1.0.0
 `,
 		},
 	}
@@ -1582,10 +1599,9 @@ func TestLoadConfigValidation(t *testing.T) {
 		{
 			name: "provider with no source or surfaces",
 			yaml: `
-providers:
-  plugins:
-    service-a:
-      displayName: Service A
+plugins:
+  service-a:
+    displayName: Service A
 `,
 		},
 		{
@@ -1597,72 +1613,53 @@ server:
 `,
 		},
 		{
-			name: "server indexeddb selector cannot use legacy and canonical keys together",
+			name: "legacy server indexeddb selector is rejected",
 			yaml: `
 server:
   indexeddb: legacy
-  providers:
-    indexeddb: canonical
 `,
 		},
 		{
-			name: "indexeddb collection cannot use legacy and canonical keys together",
+			name: "legacy indexeddb collection is rejected",
 			yaml: `
 providers:
   indexeddbs:
     legacy:
       source:
         path: ./legacy/manifest.yaml
-  indexeddb:
-    canonical:
-      source:
-        path: ./canonical/manifest.yaml
 `,
 		},
 		{
-			name: "fileapi collection cannot use legacy and canonical keys together",
+			name: "legacy fileapi collection is rejected",
 			yaml: `
 providers:
   fileapis:
     legacy:
       source:
         path: ./legacy/manifest.yaml
-  fileapi:
-    canonical:
-      source:
-        path: ./canonical/manifest.yaml
 `,
 		},
 		{
-			name: "plugins cannot use legacy and canonical keys together",
+			name: "legacy plugin collection is rejected",
 			yaml: `
 providers:
   plugins:
     legacy:
       source:
         path: ./legacy/manifest.yaml
-plugins:
-  canonical:
-    source:
-      path: ./canonical/manifest.yaml
 `,
 		},
 		{
-			name: "plugin fileapi bindings cannot use legacy and canonical keys together",
+			name: "legacy plugin fileapi bindings are rejected",
 			yaml: `
 plugins:
   roadmap:
     source:
       path: ./roadmap/manifest.yaml
-    fileapi:
-      - canonical
     fileapis:
       - legacy
 providers:
   fileapi:
-    canonical:
-      source:
-        path: ./canonical/manifest.yaml
     legacy:
       source:
         path: ./legacy/manifest.yaml
@@ -1705,8 +1702,7 @@ func TestValidConfigurations(t *testing.T) {
 		{
 			name: "managed source plugin only",
 			yaml: `
-providers:
-  plugins:
+plugins:
     custom_tool:
       source:
         ref: github.com/acme-corp/tools/widget
@@ -1716,8 +1712,7 @@ providers:
 		{
 			name: "plugin with local source",
 			yaml: `
-providers:
-  plugins:
+plugins:
     service:
       source:
         path: /usr/bin/manifest.yaml
@@ -1748,8 +1743,7 @@ func TestPluginValidation(t *testing.T) {
 		{
 			name: "integration plugin source path is valid",
 			yaml: `
-providers:
-  plugins:
+plugins:
     external:
       source:
         path: ./plugins/dummy/manifest.yaml
@@ -1758,8 +1752,7 @@ providers:
 		{
 			name: "plugin source path and ref are mutually exclusive",
 			yaml: `
-providers:
-  plugins:
+plugins:
     external:
       source:
         path: ./plugins/dummy/manifest.yaml
@@ -1771,8 +1764,7 @@ providers:
 		{
 			name: "plugin env with local source is valid",
 			yaml: `
-providers:
-  plugins:
+plugins:
     external:
       source:
         path: ./plugins/dummy/manifest.yaml
@@ -1783,8 +1775,7 @@ providers:
 		{
 			name: "plugin config with source is valid",
 			yaml: `
-providers:
-  plugins:
+plugins:
     external:
       source:
         path: ./plugins/dummy/manifest.yaml
@@ -1795,8 +1786,7 @@ providers:
 		{
 			name: "plugin source is required for external",
 			yaml: `
-providers:
-  plugins:
+plugins:
     external:
       {}
 `,
@@ -1805,8 +1795,7 @@ providers:
 		{
 			name: "plugin source path with version is rejected",
 			yaml: `
-providers:
-  plugins:
+plugins:
     external:
       source:
         path: ./plugins/dummy/manifest.yaml
@@ -1817,8 +1806,7 @@ providers:
 		{
 			name: "plugin source with version is valid",
 			yaml: `
-providers:
-  plugins:
+plugins:
     external:
       source:
         ref: github.com/acme-corp/tools/widget
@@ -1828,8 +1816,7 @@ providers:
 		{
 			name: "plugin source with base_url override is rejected",
 			yaml: `
-providers:
-  plugins:
+plugins:
     external:
       source:
         ref: github.com/acme-corp/tools/widget
@@ -1841,8 +1828,7 @@ providers:
 		{
 			name: "plugin source without version is rejected",
 			yaml: `
-providers:
-  plugins:
+plugins:
     external:
       source:
         ref: github.com/acme-corp/tools/widget
@@ -1852,8 +1838,7 @@ providers:
 		{
 			name: "non-default connection params are accepted",
 			yaml: `
-providers:
-  plugins:
+plugins:
     external:
       source:
         path: ./plugins/dummy/manifest.yaml
@@ -2072,19 +2057,21 @@ func TestLoadConfigResolvesRelativePaths(t *testing.T) {
 	if err := os.WriteFile(cfgPath, []byte(`
 providers:
   auth:
-    source:
-      path: ../auth-plugin/provider.yaml
-  indexeddbs:
+    default:
+      source:
+        path: ../auth-plugin/provider.yaml
+  indexeddb:
     sqlite:
       source:
         path: ./providers/datastore/sqlite
-  plugins:
-    service-a:
-      iconFile: ../assets/service.svg
-      source:
-        path: ../bin/manifest.yaml
+plugins:
+  service-a:
+    iconFile: ../assets/service.svg
+    source:
+      path: ../bin/manifest.yaml
 server:
-  indexeddb: sqlite
+  providers:
+    indexeddb: sqlite
 `), 0o644); err != nil {
 		t.Fatalf("WriteFile config: %v", err)
 	}
@@ -2115,19 +2102,21 @@ func TestAuthConfigMap(t *testing.T) {
 	path := mustWriteConfigFile(t, `
 providers:
   auth:
-    source:
-      ref: github.com/valon-technologies/gestalt-providers/auth/google
-      version: 1.0.0
-    config:
-      clientId: client-1
-      clientSecret: secret-1
-      redirectUrl: https://example.test/callback
-  indexeddbs:
+    default:
+      source:
+        ref: github.com/valon-technologies/gestalt-providers/auth/google
+        version: 1.0.0
+      config:
+        clientId: client-1
+        clientSecret: secret-1
+        redirectUrl: https://example.test/callback
+  indexeddb:
     sqlite:
       source:
         path: ./providers/datastore/sqlite
 server:
-  indexeddb: sqlite
+  providers:
+    indexeddb: sqlite
   encryptionKey: server-key
 `)
 
@@ -2217,8 +2206,7 @@ func TestLoad_ResolvesRelativePluginSourcePath(t *testing.T) {
 	}
 
 	cfgPath := filepath.Join(dir, "config.yaml")
-	cfg := `providers:
-  plugins:
+	cfg := `plugins:
     sample:
       source:
         path: ./my-plugin/manifest.yaml

--- a/gestaltd/internal/config/provider_selection.go
+++ b/gestaltd/internal/config/provider_selection.go
@@ -6,36 +6,6 @@ import (
 	"strings"
 )
 
-func (c *Config) SyncCompatFields() {
-	if c == nil {
-		return
-	}
-	if c.Plugins == nil && c.Providers.Plugins != nil {
-		c.Plugins = c.Providers.Plugins
-	}
-	if c.Providers.Plugins == nil && c.Plugins != nil {
-		c.Providers.Plugins = c.Plugins
-	}
-	if c.Providers.IndexedDB == nil && c.Providers.IndexedDBs != nil {
-		c.Providers.IndexedDB = c.Providers.IndexedDBs
-	}
-	if c.Providers.IndexedDBs == nil && c.Providers.IndexedDB != nil {
-		c.Providers.IndexedDBs = c.Providers.IndexedDB
-	}
-	if c.Providers.FileAPI == nil && c.Providers.FileAPIs != nil {
-		c.Providers.FileAPI = c.Providers.FileAPIs
-	}
-	if c.Providers.FileAPIs == nil && c.Providers.FileAPI != nil {
-		c.Providers.FileAPIs = c.Providers.FileAPI
-	}
-	if c.Server.Providers.IndexedDB == "" && c.Server.IndexedDB != "" {
-		c.Server.Providers.IndexedDB = c.Server.IndexedDB
-	}
-	if c.Server.IndexedDB == "" && c.Server.Providers.IndexedDB != "" {
-		c.Server.IndexedDB = c.Server.Providers.IndexedDB
-	}
-}
-
 func (s ServerProvidersConfig) Selection(kind HostProviderKind) string {
 	switch kind {
 	case HostProviderKindAuth:
@@ -57,7 +27,6 @@ func (c *Config) HostProviderEntries(kind HostProviderKind) map[string]*Provider
 	if c == nil {
 		return nil
 	}
-	c.SyncCompatFields()
 	switch kind {
 	case HostProviderKindAuth:
 		return c.Providers.Auth
@@ -75,7 +44,6 @@ func (c *Config) HostProviderEntries(kind HostProviderKind) map[string]*Provider
 }
 
 func (c *Config) SelectedHostProvider(kind HostProviderKind) (string, *ProviderEntry, error) {
-	c.SyncCompatFields()
 	return ResolveSelectedHostProvider(kind, c.Server.Providers.Selection(kind), c.HostProviderEntries(kind))
 }
 

--- a/gestaltd/internal/operator/lifecycle_source_test.go
+++ b/gestaltd/internal/operator/lifecycle_source_test.go
@@ -220,12 +220,11 @@ func writeConfigYAML(t *testing.T, dir, source, version, artifactsDir string) st
 	t.Helper()
 
 	lines := []string{
-		"providers:",
-		"  plugins:",
-		"    alpha:",
-		"      source:",
-		"        ref: " + source,
-		"        version: " + version,
+		"plugins:",
+		"  alpha:",
+		"    source:",
+		"      ref: " + source,
+		"      version: " + version,
 		"server:",
 		"  artifactsDir: " + artifactsDir,
 	}
@@ -414,13 +413,14 @@ func TestSourcePluginLoadForExecution(t *testing.T) {
 
 	artifactsDir := filepath.Join(dir, "prepared-artifacts")
 	yaml := requiredComponentConfigYAML(t, dir, filepath.Join(dir, "data.db")) + strings.Join([]string{
-		"  plugins:",
-		"    gadget:",
-		"      source:",
-		"        ref: " + source,
-		"        version: " + version,
+		"plugins:",
+		"  gadget:",
+		"    source:",
+		"      ref: " + source,
+		"      version: " + version,
 		"server:",
-		"  indexeddb: sqlite",
+		"  providers:",
+		"    indexeddb: sqlite",
 		"  artifactsDir: " + artifactsDir,
 		"  encryptionKey: aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
 	}, "\n") + "\n"
@@ -513,13 +513,14 @@ func TestSourcePluginLoadForExecution_RehydratesWhenCachedManifestVersionMismatc
 
 	artifactsDir := filepath.Join(dir, "prepared-artifacts")
 	yaml := requiredComponentConfigYAML(t, dir, filepath.Join(dir, "data.db")) + strings.Join([]string{
-		"  plugins:",
-		"    gadget:",
-		"      source:",
-		"        ref: " + source,
-		"        version: " + version,
+		"plugins:",
+		"  gadget:",
+		"    source:",
+		"      ref: " + source,
+		"      version: " + version,
 		"server:",
-		"  indexeddb: sqlite",
+		"  providers:",
+		"    indexeddb: sqlite",
 		"  artifactsDir: " + artifactsDir,
 		"  encryptionKey: aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
 	}, "\n") + "\n"
@@ -618,17 +619,20 @@ func TestSourceAuthPluginLoadForExecution(t *testing.T) {
 	configYAML := strings.Join([]string{
 		requiredIndexedDBConfigYAML(t, dir, filepath.Join(dir, "data.db")),
 		"  secrets:",
-		"    source: test-secrets",
+		"    default:",
+		"      source: test-secrets",
 		"  auth:",
-		"    source:",
-		"      ref: " + source,
-		"      version: " + version,
-		"      auth:",
-		"        token: secret://source-token",
-		"    config:",
-		"      clientId: managed-auth-client",
+		"    default:",
+		"      source:",
+		"        ref: " + source,
+		"        version: " + version,
+		"        auth:",
+		"          token: secret://source-token",
+		"      config:",
+		"        clientId: managed-auth-client",
 		"server:",
-		"  indexeddb: sqlite",
+		"  providers:",
+		"    indexeddb: sqlite",
 		"  artifactsDir: " + artifactsDir,
 		"  encryptionKey: aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
 	}, "\n") + "\n"
@@ -652,7 +656,7 @@ func TestSourceAuthPluginLoadForExecution(t *testing.T) {
 	if err != nil {
 		t.Fatalf("InitAtPath: %v", err)
 	}
-	authLockEntry := mustLockEntryByName(t, lock.Auth, "auth")
+	authLockEntry := mustLockEntryByName(t, lock.Auth, config.DefaultProviderInstance)
 	if authLockEntry.Source != source {
 		t.Fatalf("lock.Auth[auth].Source = %q, want %q", authLockEntry.Source, source)
 	}
@@ -761,7 +765,7 @@ func TestManagedIndexedDBSourcesLoadForExecutionWithMultipleBindings(t *testing.
 	artifactsDir := filepath.Join(dir, "prepared-artifacts")
 	configYAML := strings.Join([]string{
 		"providers:",
-		"  indexeddbs:",
+		"  indexeddb:",
 		"    main:",
 		"      source:",
 		"        ref: " + mainSource,
@@ -775,7 +779,8 @@ func TestManagedIndexedDBSourcesLoadForExecutionWithMultipleBindings(t *testing.
 		"      config:",
 		`        dsn: "sqlite://archive.db"`,
 		"server:",
-		"  indexeddb: main",
+		"  providers:",
+		"    indexeddb: main",
 		"  artifactsDir: " + artifactsDir,
 		"  encryptionKey: aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
 	}, "\n") + "\n"
@@ -878,7 +883,8 @@ func TestManagedFileAPISourcesLoadForExecutionWithMultipleBindings(t *testing.T)
 		"      config:",
 		`        root: "/tmp/archive"`,
 		"server:",
-		"  indexeddb: sqlite",
+		"  providers:",
+		"    indexeddb: sqlite",
 		"  artifactsDir: " + artifactsDir,
 		"  encryptionKey: aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
 	}, "\n") + "\n"
@@ -1013,19 +1019,22 @@ func TestSourceSecretsPluginBootstrapsManagedAuthSourceToken(t *testing.T) {
 	configYAML := strings.Join([]string{
 		requiredIndexedDBConfigYAML(t, dir, filepath.Join(dir, "data.db")),
 		"  secrets:",
-		"    source:",
-		"      ref: " + secretsSource,
-		"      version: " + secretsVersion,
+		"    default:",
+		"      source:",
+		"        ref: " + secretsSource,
+		"        version: " + secretsVersion,
 		"  auth:",
-		"    source:",
-		"      ref: " + authSource,
-		"      version: " + authVersion,
-		"      auth:",
-		"        token: secret://source-token",
-		"    config:",
-		"      clientId: managed-auth-client",
+		"    default:",
+		"      source:",
+		"        ref: " + authSource,
+		"        version: " + authVersion,
+		"        auth:",
+		"          token: secret://source-token",
+		"      config:",
+		"        clientId: managed-auth-client",
 		"server:",
-		"  indexeddb: sqlite",
+		"  providers:",
+		"    indexeddb: sqlite",
 		"  artifactsDir: " + artifactsDir,
 		"  encryptionKey: aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
 	}, "\n") + "\n"
@@ -1046,8 +1055,8 @@ func TestSourceSecretsPluginBootstrapsManagedAuthSourceToken(t *testing.T) {
 	if err != nil {
 		t.Fatalf("InitAtPath: %v", err)
 	}
-	secretsLockEntry := mustLockEntryByName(t, lock.Secrets, "secrets")
-	authLockEntry := mustLockEntryByName(t, lock.Auth, "auth")
+	secretsLockEntry := mustLockEntryByName(t, lock.Secrets, config.DefaultProviderInstance)
+	authLockEntry := mustLockEntryByName(t, lock.Auth, config.DefaultProviderInstance)
 	if got := len(resolver.calls); got != 2 {
 		t.Fatalf("resolver calls = %d, want 2", got)
 	}
@@ -1184,15 +1193,16 @@ func TestSourcePluginGitHubResolverEndToEnd(t *testing.T) {
 
 	artifactsDir := filepath.Join(dir, "prepared-artifacts")
 	configYAML := requiredComponentConfigYAML(t, dir, filepath.Join(dir, "data.db")) + strings.Join([]string{
-		"  plugins:",
-		"    alpha:",
-		"      source:",
-		"        ref: " + testSource,
-		"        version: " + testVersion,
-		"        auth:",
-		"          token: test-token",
+		"plugins:",
+		"  alpha:",
+		"    source:",
+		"      ref: " + testSource,
+		"      version: " + testVersion,
+		"      auth:",
+		"        token: test-token",
 		"server:",
-		"  indexeddb: sqlite",
+		"  providers:",
+		"    indexeddb: sqlite",
 		"  artifactsDir: " + artifactsDir,
 		"  encryptionKey: aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
 	}, "\n") + "\n"

--- a/gestaltd/internal/operator/lifecycle_test.go
+++ b/gestaltd/internal/operator/lifecycle_test.go
@@ -81,7 +81,7 @@ func writeStubIndexedDBManifest(t *testing.T, dir string) string {
 func requiredComponentConfigYAML(t *testing.T, dir, dbPath string) string {
 	manifestPath := writeStubIndexedDBManifest(t, dir)
 	return fmt.Sprintf(`providers:
-  indexeddbs:
+  indexeddb:
     sqlite:
       source:
         path: %s
@@ -91,7 +91,8 @@ func requiredComponentConfigYAML(t *testing.T, dir, dbPath string) string {
 }
 
 func requiredServerDatastoreYAML() string {
-	return `  indexeddb: sqlite
+	return `  providers:
+    indexeddb: sqlite
 `
 }
 
@@ -142,7 +143,7 @@ func TestLoadForExecutionAtPath_ResolvesLocalManifestPluginWithoutLockfile(t *te
 	}
 
 	cfgPath := filepath.Join(dir, "config.yaml")
-	cfg := requiredComponentConfigYAML(t, dir, filepath.Join(dir, "gestalt.db")) + `  plugins:
+	cfg := requiredComponentConfigYAML(t, dir, filepath.Join(dir, "gestalt.db")) + `plugins:
     example:
       source:
         path: ./manifest.yaml
@@ -203,7 +204,7 @@ spec:
 	}
 
 	cfgPath := filepath.Join(dir, "config.yaml")
-	cfg := requiredComponentConfigYAML(t, dir, filepath.Join(dir, "gestalt.db")) + `  plugins:
+	cfg := requiredComponentConfigYAML(t, dir, filepath.Join(dir, "gestalt.db")) + `plugins:
     notion:
       source:
         path: ./manifest.yaml
@@ -569,18 +570,20 @@ func TestLoadForExecutionAtPath_ResolvesLocalTopLevelPluginsWithoutLockfile(t *t
 	cfgPath := filepath.Join(dir, "config.yaml")
 	cfg := fmt.Sprintf(`providers:
   auth:
-    source:
-      path: ./auth-manifest.yaml
-    config:
-      clientId: local-auth-client
-  indexeddbs:
+    default:
+      source:
+        path: ./auth-manifest.yaml
+      config:
+        clientId: local-auth-client
+  indexeddb:
     sqlite:
       source:
         path: %s
       config:
         dsn: %q
 server:
-  indexeddb: sqlite
+  providers:
+    indexeddb: sqlite
   encryptionKey: aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa
 `, idbManifestPath, "sqlite://"+dbPath)
 	if err := os.WriteFile(cfgPath, []byte(cfg), 0o644); err != nil {
@@ -655,16 +658,18 @@ func TestLoadForExecutionAtPath_ResolvesLocalSourceTopLevelPluginsWithoutArtifac
 	cfgPath := filepath.Join(dir, "config.yaml")
 	cfg := fmt.Sprintf(`providers:
   auth:
-    source:
-      path: ./auth-manifest.yaml
-  indexeddbs:
+    default:
+      source:
+        path: ./auth-manifest.yaml
+  indexeddb:
     sqlite:
       source:
         path: %s
       config:
         dsn: %q
 server:
-  indexeddb: sqlite
+  providers:
+    indexeddb: sqlite
   encryptionKey: aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa
 `, idbManifestPath, "sqlite://"+dbPath)
 	if err := os.WriteFile(cfgPath, []byte(cfg), 0o644); err != nil {
@@ -726,7 +731,7 @@ func TestLoadForExecutionAtPath_GeneratesStaticCatalogForLocalSourceHybridPlugin
 	writeTestFile("manifest.yaml", manifest, 0o644)
 
 	cfgPath := filepath.Join(dir, "config.yaml")
-	cfg := requiredComponentConfigYAML(t, dir, filepath.Join(dir, "gestalt.db")) + `  plugins:
+	cfg := requiredComponentConfigYAML(t, dir, filepath.Join(dir, "gestalt.db")) + `plugins:
     example:
       source:
         path: ./manifest.yaml
@@ -896,7 +901,7 @@ def session_catalog(request: gestalt.Request) -> gestalt.Catalog:
 	}
 	writeTestFile("manifest.yaml", manifest, 0o644)
 
-	cfg := requiredComponentConfigYAML(t, dir, filepath.Join(dir, "gestalt.db")) + `  plugins:
+	cfg := requiredComponentConfigYAML(t, dir, filepath.Join(dir, "gestalt.db")) + `plugins:
     example:
       source:
         path: ./manifest.yaml
@@ -1227,7 +1232,7 @@ func TestApplyLockedPlugins_SkipsNilIntegrationPlugins(t *testing.T) {
 	}
 
 	cfgPath := filepath.Join(dir, "config.yaml")
-	cfg := requiredComponentConfigYAML(t, dir, filepath.Join(dir, "gestalt.db")) + `  plugins:
+	cfg := requiredComponentConfigYAML(t, dir, filepath.Join(dir, "gestalt.db")) + `plugins:
     example:
       source:
         path: ./manifest.yaml

--- a/gestaltd/internal/testutil/testdata/provider-go/config.yaml
+++ b/gestaltd/internal/testutil/testdata/provider-go/config.yaml
@@ -1,21 +1,20 @@
-indexeddbs:
-  main:
-    provider:
+providers:
+  indexeddb:
+    main:
       source:
         ref: github.com/valon-technologies/gestalt-providers/indexeddb/relationaldb
         version: 0.0.1-alpha.2
-    config:
-      dsn: sqlite://./example.db
-
-datastore: main
+      config:
+        dsn: sqlite://./example.db
 
 server:
+  providers:
+    indexeddb: main
   encryptionKey: dev-key-for-example-only
 
 plugins:
   example:
-    provider:
-      source:
-        path: ./plugin.yaml
+    source:
+      path: ./plugin.yaml
     config:
       greeting: "Hello from example plugin"

--- a/gestaltd/internal/testutil/testdata/provider-rust/config.yaml
+++ b/gestaltd/internal/testutil/testdata/provider-rust/config.yaml
@@ -1,21 +1,20 @@
-indexeddbs:
-  main:
-    provider:
+providers:
+  indexeddb:
+    main:
       source:
         ref: github.com/valon-technologies/gestalt-providers/indexeddb/relationaldb
         version: 0.0.1-alpha.2
-    config:
-      dsn: sqlite://./example.db
-
-datastore: main
+      config:
+        dsn: sqlite://./example.db
 
 server:
+  providers:
+    indexeddb: main
   encryptionKey: dev-key-for-example-only
 
 plugins:
   example:
-    provider:
-      source:
-        path: ./plugin.yaml
+    source:
+      path: ./plugin.yaml
     config:
       greeting: "Hello from example Rust plugin"


### PR DESCRIPTION
## Squash commit message
Remove legacy config path compatibility shims

## New interface
Go:
```go
cfg := &config.Config{
    Plugins: map[string]*config.ProviderEntry{
        "docs": {
            Source: config.ProviderSource{
                Ref:     "github.com/valon-technologies/gestalt-providers/plugins/docs",
                Version: "v0.0.1-alpha.1",
            },
            IndexedDBs: []config.PluginIndexedDBBinding{{Name: "main"}},
            FileAPIs:   []string{"archive"},
        },
    },
    Providers: config.ProvidersConfig{
        Auth: map[string]*config.ProviderEntry{
            config.DefaultProviderInstance: {
                Source: config.ProviderSource{
                    Ref:     "github.com/valon-technologies/gestalt-providers/auth/oidc",
                    Version: "v0.0.1-alpha.1",
                },
            },
        },
        Secrets: map[string]*config.ProviderEntry{
            config.DefaultProviderInstance: {
                Source: config.ProviderSource{Builtin: "env"},
            },
        },
        IndexedDB: map[string]*config.ProviderEntry{
            "main": {
                Source: config.ProviderSource{Builtin: "sqlite"},
            },
        },
        FileAPI: map[string]*config.ProviderEntry{
            "archive": {
                Source: config.ProviderSource{Path: "./providers/fileapi"},
            },
        },
    },
    Server: config.ServerConfig{
        Providers: config.ServerProvidersConfig{
            IndexedDB: "main",
        },
    },
}
```

YAML:
```yaml
providers:
  auth:
    default:
      source:
        ref: github.com/valon-technologies/gestalt-providers/auth/oidc
        version: v0.0.1-alpha.1
  secrets:
    default:
      source:
        builtin: env
  indexeddb:
    main:
      source:
        builtin: sqlite
  fileapi:
    archive:
      source:
        path: ./providers/fileapi

plugins:
  docs:
    source:
      ref: github.com/valon-technologies/gestalt-providers/plugins/docs
      version: v0.0.1-alpha.1
    indexeddb:
      - name: main
    fileapi:
      - archive

server:
  providers:
    indexeddb: main
```

## Summary
- remove loader normalization for legacy root/provider/server/plugin shapes
- drop in-memory alias syncing between old and new provider-selection fields
- require canonical config forms in bootstrap, operator lifecycle fixtures, and testdata
- convert validation coverage from legacy acceptance to legacy rejection for removed paths
- removed legacy paths include `providers.plugins`, `providers.indexeddbs`, `providers.fileapis`, singleton `providers.{auth,secrets,telemetry,audit}`, `server.indexeddb`, and plugin `fileapis`

## Validation
- `cd gestaltd && go test ./internal/config ./internal/bootstrap ./internal/providerpkg`
- `cd gestaltd && go test ./internal/operator ./internal/testutil/...`
