### PR TITLE
[codex] Fix cache SDK follow-ups

### DIFF
--- a/sdk/python/gestalt/_runtime.py
+++ b/sdk/python/gestalt/_runtime.py
@@ -704,9 +704,9 @@ def _normalized_runtime_kind(kind: object | None) -> ProviderKind:
             return ProviderKind.INTEGRATION
         try:
             return ProviderKind(normalized)
-        except ValueError:
-            return ProviderKind.INTEGRATION
-    return ProviderKind.INTEGRATION
+        except ValueError as exc:
+            raise ValueError(f"unsupported runtime kind: {kind!r}") from exc
+    raise TypeError(f"unsupported runtime kind: {kind!r}")
 
 
 def _duration_to_timedelta(duration: Any) -> dt.timedelta | None:

--- a/sdk/python/tests/test_runtime.py
+++ b/sdk/python/tests/test_runtime.py
@@ -116,15 +116,19 @@ class RuntimeKindNormalizationTests(unittest.TestCase):
             ProviderKind.CACHE,
         )
 
-    def test_normalized_runtime_kind_falls_back_to_integration_for_unknown_values(self) -> None:
+    def test_normalized_runtime_kind_defaults_none_to_integration(self) -> None:
         self.assertEqual(
-            _runtime._normalized_runtime_kind("typo"),
+            _runtime._normalized_runtime_kind(None),
             ProviderKind.INTEGRATION,
         )
-        self.assertEqual(
-            _runtime._normalized_runtime_kind(object()),
-            ProviderKind.INTEGRATION,
-        )
+
+    def test_normalized_runtime_kind_rejects_unknown_values(self) -> None:
+        with self.assertRaisesRegex(ValueError, "unsupported runtime kind"):
+            _runtime._normalized_runtime_kind("typo")
+
+    def test_normalized_runtime_kind_rejects_unsupported_types(self) -> None:
+        with self.assertRaisesRegex(TypeError, "unsupported runtime kind"):
+            _runtime._normalized_runtime_kind(object())
 
 
 class DurationConversionTests(unittest.TestCase):

--- a/sdk/typescript/src/cache.ts
+++ b/sdk/typescript/src/cache.ts
@@ -40,7 +40,7 @@ export function cacheSocketEnv(name?: string): string {
   if (!trimmed) {
     return ENV_CACHE_SOCKET;
   }
-  return `${ENV_CACHE_SOCKET}_${trimmed.replace(/[^A-Za-z0-9]/g, "_").toUpperCase()}`;
+  return `${ENV_CACHE_SOCKET}_${trimmed.replace(/[^A-Za-z0-9]/gu, "_").toUpperCase()}`;
 }
 
 export class Cache {

--- a/sdk/typescript/tests/cache.test.ts
+++ b/sdk/typescript/tests/cache.test.ts
@@ -1,0 +1,23 @@
+import { expect, test } from "bun:test";
+
+import { Cache, cacheSocketEnv } from "../src/cache.ts";
+
+test("cache socket env normalizes unicode bindings by code point", () => {
+  expect(cacheSocketEnv("café")).toBe("GESTALT_CACHE_SOCKET_CAF_");
+  expect(cacheSocketEnv("😀")).toBe("GESTALT_CACHE_SOCKET__");
+});
+
+test("Cache resolves emoji binding env names with host-compatible normalization", () => {
+  const envName = cacheSocketEnv("😀");
+  const previous = process.env[envName];
+  process.env[envName] = "/tmp/gestalt-cache.sock";
+  try {
+    expect(() => new Cache("😀")).not.toThrow();
+  } finally {
+    if (previous === undefined) {
+      delete process.env[envName];
+    } else {
+      process.env[envName] = previous;
+    }
+  }
+});


### PR DESCRIPTION
## Summary
- reject unsupported Python `runtime_kind` values instead of silently coercing them to `integration`
- normalize TypeScript cache socket env names by Unicode code point so supplementary-plane names match host-side normalization
- add focused regression tests for both cases

## Why
These are follow-up fixes for review findings on the cache SDK PR.

The Python runtime path was accepting typoed or otherwise unsupported runtime kinds and then failing later with a misleading provider-shape error. The TypeScript cache env helper normalized UTF-16 code units instead of Unicode scalars, which broke named cache lookup for bindings like `"😀"` even when the host had exported the correct socket env var.

## Impact
- misconfigured Python source builds now fail fast with a direct `unsupported runtime kind` error
- named cache bindings with supplementary-plane Unicode characters now resolve correctly in the TypeScript SDK

## Validation
- `uv run python -m unittest tests.test_runtime` in `sdk/python`
- `bun test tests/cache.test.ts` in `sdk/typescript`