### PR TITLE
Point cache docs at cache/valkey

### DIFF
--- a/docs/content/custom-providers/cache.mdx
+++ b/docs/content/custom-providers/cache.mdx
@@ -16,10 +16,10 @@ A cache provider manifest declares `kind: cache`:
 
 ```yaml
 kind: cache
-source: github.com/valon-technologies/gestalt-providers/cache/redis
-version: 0.0.1
-displayName: Redis Cache
-description: Cache provider backed by Redis or Valkey.
+source: github.com/your-org/gestalt-providers/cache/customcache
+version: 0.0.1-alpha.1
+displayName: Custom Cache
+description: Example custom cache provider.
 spec:
   configSchemaPath: ./cache_config.json
 ```
@@ -41,7 +41,7 @@ The Cache service includes:
 <Tabs items={['Go', 'Python', 'Rust', 'TypeScript']}>
   <Tabs.Tab>
     ```go
-    package rediscache
+    package customcache
 
     import (
         "context"
@@ -82,7 +82,7 @@ The Cache service includes:
 
     import gestalt
 
-    class RedisCache(gestalt.CacheProvider):
+    class CustomCache(gestalt.CacheProvider):
         def get(self, key: str) -> bytes | None:
             return None
 
@@ -104,10 +104,10 @@ The Cache service includes:
   <Tabs.Tab>
     ```rust
     #[derive(Default)]
-    struct RedisCache;
+    struct CustomCache;
 
     #[gestalt::async_trait]
-    impl gestalt::CacheProvider for RedisCache {
+    impl gestalt::CacheProvider for CustomCache {
         async fn get(&self, key: &str) -> gestalt::Result<Option<Vec<u8>>> {
             let _ = key;
             Ok(None)
@@ -134,7 +134,7 @@ The Cache service includes:
         }
     }
 
-    gestalt::export_cache_provider!(constructor = RedisCache::default);
+    gestalt::export_cache_provider!(constructor = CustomCache::default);
     ```
   </Tabs.Tab>
   <Tabs.Tab>

--- a/docs/content/providers/cache.mdx
+++ b/docs/content/providers/cache.mdx
@@ -14,18 +14,18 @@ providers:
   cache:
     session:
       source:
-        ref: github.com/valon-technologies/gestalt-providers/cache/redis
-        version: 0.0.1-alpha.1
+        path: /path/to/local/cache-provider/manifest.yaml
       config:
-        addr: ${VALKEY_ADDR}
+        addresses:
+          - ${VALKEY_ADDR}
         db: 0
 
     rate_limit:
       source:
-        ref: github.com/valon-technologies/gestalt-providers/cache/redis
-        version: 0.0.1-alpha.1
+        path: /path/to/local/cache-provider/manifest.yaml
       config:
-        addr: ${VALKEY_ADDR}
+        addresses:
+          - ${VALKEY_ADDR}
         db: 1
 
 plugins:
@@ -35,6 +35,16 @@ plugins:
     cache:
       - session
       - rate_limit
+```
+
+Until `cache/valkey` is published as a managed package, reference it through a
+local `source.path` checkout that points at your unpublished Valkey provider
+manifest. Once a release exists, switch to:
+
+```yaml
+source:
+  ref: github.com/valon-technologies/gestalt-providers/cache/valkey
+  version: 0.0.1-alpha.1
 ```
 
 ## How bindings work
@@ -103,9 +113,9 @@ const value = await cache.get("user:1");
 
 ## First-party providers
 
-First-party cache backends can live under
-`github.com/valon-technologies/gestalt-providers/cache/...`.
-The exact package set depends on what has been published so far.
+The first-party cache backend is the Valkey provider at:
+
+- `github.com/valon-technologies/gestalt-providers/cache/valkey`
 
 ## Custom implementations
 

--- a/docs/content/providers/index.mdx
+++ b/docs/content/providers/index.mdx
@@ -79,10 +79,10 @@ providers:
   cache:
     session:
       source:
-        ref: github.com/valon-technologies/gestalt-providers/cache/redis
-        version: 0.0.1-alpha.1
+        path: /path/to/local/cache-provider/manifest.yaml
       config:
-        address: ${REDIS_ADDR}
+        addresses:
+          - ${VALKEY_ADDR}
 
 plugins:
   github:

--- a/docs/content/reference/config-file.mdx
+++ b/docs/content/reference/config-file.mdx
@@ -229,11 +229,16 @@ providers:
   cache:
     session:
       source:
-        ref: github.com/valon-technologies/gestalt-providers/cache/redis
-        version: 0.0.1-alpha.1
+        path: /path/to/local/cache-provider/manifest.yaml
       config:
-        address: ${REDIS_ADDR}
-        database: 0
+        addresses:
+          - ${VALKEY_ADDR}
+        db: 0
+        username: ${VALKEY_USERNAME}
+        password: secret://valkey-password
+        tls: false
+        dialTimeout: 5s
+        writeTimeout: 5s
 
 plugins:
   github:
@@ -241,11 +246,22 @@ plugins:
       - session
 ```
 
+Until `cache/valkey` is published as a managed package, use a local
+`source.path` entry like the example above, pointing at your unpublished Valkey
+provider manifest. After the first release is published, switch to:
+
+```yaml
+source:
+  ref: github.com/valon-technologies/gestalt-providers/cache/valkey
+  version: 0.0.1-alpha.1
+```
+
 First-party cache providers are published at
 `github.com/valon-technologies/gestalt-providers/cache/<name>`.
 
 | Field | Description |
 | --- | --- |
+| `source.path` | Local provider manifest path for an unpublished cache provider checkout. |
 | `source.ref` | Managed provider source address. |
 | `source.version` | Required with `source.ref`. SemVer without a leading `v`. |
 | `config` | Arbitrary provider-specific config passed through to the cache provider. |


### PR DESCRIPTION
## Summary

Replace the remaining placeholder `cache/redis` docs examples with the real first-party `cache/valkey` provider shape.

This PR is docs-only and depends on the provider repo rollout at `valon-technologies/gestalt-providers#105`.

## New Interfaces

### YAML

```yaml
providers:
  cache:
    session:
      source:
        path: /path/to/local/cache-provider/manifest.yaml
      config:
        addresses:
          - ${VALKEY_ADDR}
        db: 0
        username: ${VALKEY_USERNAME}
        password: secret://valkey-password
        tls: false
        dialTimeout: 5s
        writeTimeout: 5s

plugins:
  search:
    cache:
      - session
```

Once `cache/valkey` is published as a managed package, that same provider can be referenced as:

```yaml
source:
  ref: github.com/valon-technologies/gestalt-providers/cache/valkey
  version: 0.0.1-alpha.1
```

### Go

```go
cache, err := gestalt.Cache("session")
if err != nil {
    panic(err)
}
defer cache.Close()

value, found, err := cache.Get(ctx, "user:1")
if err != nil {
    panic(err)
}
_ = value
_ = found
```

## Updated Docs

- `docs/content/providers/cache.mdx`
- `docs/content/reference/config-file.mdx`
- `docs/content/custom-providers/cache.mdx`
- `docs/content/providers/index.mdx`

The docs now:

- remove the old `cache/redis` placeholder references
- use the real `cache/valkey` config shape (`addresses`, `db`, `username`, `password`, `tls`, `dialTimeout`, `writeTimeout`)
- use local `source.path` examples until the managed package is published
- keep the custom-provider manifest example generic instead of pretending to be the exact first-party Valkey manifest

## Testing

Docs-only change. I verified the docs content no longer contains `cache/redis`, `REDIS_ADDR`, or `Redis Cache` references.
