### PR TITLE
Audit denied HTTP operation authorization decisions

### DIFF
--- a/gestaltd/core/audit.go
+++ b/gestaltd/core/audit.go
@@ -6,28 +6,31 @@ import (
 )
 
 type AuditEntry struct {
-	Timestamp            time.Time
-	RequestID            string
-	Source               string
-	AuthSource           string
-	UserID               string
-	SubjectID            string
-	SubjectKind          string
-	CredentialMode       string
-	CredentialSubjectID  string
-	CredentialConnection string
-	CredentialInstance   string
-	TargetID             string
-	TargetKind           string
-	TargetName           string
-	Provider             string
-	Operation            string
-	Depth                int
-	Allowed              bool
-	Error                string
-	ClientIP             string
-	RemoteAddr           string
-	UserAgent            string
+	Timestamp             time.Time
+	RequestID             string
+	Source                string
+	AuthSource            string
+	UserID                string
+	SubjectID             string
+	SubjectKind           string
+	AccessPolicy          string
+	AccessRole            string
+	AuthorizationDecision string
+	CredentialMode        string
+	CredentialSubjectID   string
+	CredentialConnection  string
+	CredentialInstance    string
+	TargetID              string
+	TargetKind            string
+	TargetName            string
+	Provider              string
+	Operation             string
+	Depth                 int
+	Allowed               bool
+	Error                 string
+	ClientIP              string
+	RemoteAddr            string
+	UserAgent             string
 }
 
 type AuditSink interface {

--- a/gestaltd/internal/invocation/audit.go
+++ b/gestaltd/internal/invocation/audit.go
@@ -67,6 +67,13 @@ func buildAuditEntry(ctx context.Context, p *principal.Principal, source, provid
 			entry.SubjectKind = string(p.Kind)
 		}
 	}
+	access := AccessContextFromContext(ctx)
+	if access.Policy != "" {
+		entry.AccessPolicy = access.Policy
+	}
+	if access.Role != "" {
+		entry.AccessRole = access.Role
+	}
 	return entry
 }
 
@@ -112,6 +119,15 @@ func (s *SlogAuditSink) Log(ctx context.Context, entry core.AuditEntry) {
 	}
 	if entry.SubjectKind != "" {
 		attrs = append(attrs, slog.String("subject_kind", entry.SubjectKind))
+	}
+	if entry.AccessPolicy != "" {
+		attrs = append(attrs, slog.String("access_policy", entry.AccessPolicy))
+	}
+	if entry.AccessRole != "" {
+		attrs = append(attrs, slog.String("access_role", entry.AccessRole))
+	}
+	if entry.AuthorizationDecision != "" {
+		attrs = append(attrs, slog.String("authorization_decision", entry.AuthorizationDecision))
 	}
 	if entry.CredentialMode != "" {
 		attrs = append(attrs, slog.String("credential_mode", entry.CredentialMode))

--- a/gestaltd/internal/server/audit.go
+++ b/gestaltd/internal/server/audit.go
@@ -12,15 +12,24 @@ import (
 )
 
 const (
-	auditTargetKindAPIToken           = "api_token"
-	auditTargetKindAPITokenCollection = "api_token_collection"
-	auditTargetKindConnection         = "connection"
+	auditTargetKindAPIToken             = "api_token"
+	auditTargetKindAPITokenCollection   = "api_token_collection"
+	auditTargetKindConnection           = "connection"
+	auditDecisionProviderAccessDenied   = "provider_access_denied"
+	auditDecisionOperationBindingDenied = "operation_binding_denied"
+	auditDecisionCatalogRoleDenied      = "catalog_role_denied"
 )
 
 type auditTarget struct {
 	ID   string
 	Kind string
 	Name string
+}
+
+type auditAuthorization struct {
+	Policy   string
+	Role     string
+	Decision string
 }
 
 func (s *Server) resolvePrincipalUserID(ctx context.Context, p *principal.Principal) (*principal.Principal, error) {
@@ -73,7 +82,7 @@ func (s *Server) auditEventWithTarget(ctx context.Context, p *principal.Principa
 	}
 
 	ctx, entry := invocation.BuildAuditEntry(ctx, p, source, provider, operation)
-	populateAuditEntry(&entry, allowed, err, target)
+	populateAuditEntry(&entry, allowed, err, target, auditAuthorization{})
 	s.auditSink.Log(ctx, entry)
 }
 
@@ -84,7 +93,7 @@ func (s *Server) auditEventWithAuthSource(ctx context.Context, authSource, sourc
 
 	ctx, entry := invocation.BuildAuditEntry(ctx, nil, source, provider, operation)
 	entry.AuthSource = authSource
-	populateAuditEntry(&entry, allowed, err, auditTarget{})
+	populateAuditEntry(&entry, allowed, err, auditTarget{}, auditAuthorization{})
 	s.auditSink.Log(ctx, entry)
 }
 
@@ -98,14 +107,23 @@ func (s *Server) auditEventWithUserIDAndTarget(ctx context.Context, userID, auth
 	entry.AuthSource = authSource
 	entry.SubjectID = principal.UserSubjectID(userID)
 	entry.SubjectKind = string(principal.KindUser)
-	populateAuditEntry(&entry, allowed, err, target)
+	populateAuditEntry(&entry, allowed, err, target, auditAuthorization{})
 	s.auditSink.Log(ctx, entry)
 }
 
-func populateAuditEntry(entry *core.AuditEntry, allowed bool, err error, target auditTarget) {
+func populateAuditEntry(entry *core.AuditEntry, allowed bool, err error, target auditTarget, authz auditAuthorization) {
 	entry.Allowed = allowed
 	if err != nil {
 		entry.Error = err.Error()
+	}
+	if authz.Policy != "" {
+		entry.AccessPolicy = authz.Policy
+	}
+	if authz.Role != "" {
+		entry.AccessRole = authz.Role
+	}
+	if authz.Decision != "" {
+		entry.AuthorizationDecision = authz.Decision
 	}
 	if target.ID != "" {
 		entry.TargetID = target.ID
@@ -163,6 +181,16 @@ func (s *Server) auditHTTPEvent(ctx context.Context, p *principal.Principal, pro
 
 func (s *Server) auditHTTPEventWithTarget(ctx context.Context, p *principal.Principal, provider, operation string, allowed bool, err error, target auditTarget) {
 	s.auditEventWithTarget(ctx, p, "http", provider, operation, allowed, err, target)
+}
+
+func (s *Server) auditHTTPAuthorizationEvent(ctx context.Context, p *principal.Principal, provider, operation string, allowed bool, err error, authz auditAuthorization) {
+	if s.auditSink == nil {
+		return
+	}
+
+	ctx, entry := invocation.BuildAuditEntry(ctx, p, "http", provider, operation)
+	populateAuditEntry(&entry, allowed, err, auditTarget{}, authz)
+	s.auditSink.Log(ctx, entry)
 }
 
 func (s *Server) auditRequestEventWithAuthSource(r *http.Request, authSource, provider, operation string, allowed bool, err error) {

--- a/gestaltd/internal/server/handlers.go
+++ b/gestaltd/internal/server/handlers.go
@@ -568,8 +568,20 @@ func (s *Server) executeOperation(w http.ResponseWriter, r *http.Request) {
 	if !ok {
 		return
 	}
-	if !s.allowProvider(p, providerName) || !s.allowOperation(p, providerName, operationName) {
-		s.auditHTTPEvent(r.Context(), p, providerName, operationName, false, errOperationAccess)
+	access := s.providerAccessContext(p, providerName)
+	providerAllowed := s.allowProvider(p, providerName)
+	operationAllowed := s.allowOperation(p, providerName, operationName)
+	if !providerAllowed || !operationAllowed {
+		authz := auditAuthorization{
+			Policy: access.Policy,
+			Role:   access.Role,
+		}
+		if !providerAllowed {
+			authz.Decision = auditDecisionProviderAccessDenied
+		} else {
+			authz.Decision = auditDecisionOperationBindingDenied
+		}
+		s.auditHTTPAuthorizationEvent(r.Context(), p, providerName, operationName, false, errOperationAccess, authz)
 		writeError(w, http.StatusForbidden, errOperationAccess.Error())
 		return
 	}
@@ -653,7 +665,7 @@ func (s *Server) executeOperation(w http.ResponseWriter, r *http.Request) {
 		connection = requestedConnection
 	}
 	ctx := r.Context()
-	ctx = invocation.WithAccessContext(ctx, s.providerAccessContext(p, providerName))
+	ctx = invocation.WithAccessContext(ctx, access)
 
 	var resolver invocation.TokenResolver
 	if tr, ok := s.invoker.(invocation.TokenResolver); ok {
@@ -731,6 +743,11 @@ func (s *Server) executeOperation(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 	if s.authorizer != nil && !s.authorizer.AllowCatalogOperation(p, providerName, opMeta) {
+		s.auditHTTPAuthorizationEvent(ctx, p, providerName, operationName, false, errOperationAccess, auditAuthorization{
+			Policy:   access.Policy,
+			Role:     access.Role,
+			Decision: auditDecisionCatalogRoleDenied,
+		})
 		writeError(w, http.StatusForbidden, "operation access denied")
 		return
 	}

--- a/gestaltd/internal/server/server_test.go
+++ b/gestaltd/internal/server/server_test.go
@@ -4930,6 +4930,9 @@ func TestWorkloadAuthorization_ExecuteOperation_UsesBoundIdentityAndRejectsSelec
 	if accessDeniedAudit["error"] != "operation access denied" {
 		t.Fatalf("unexpected denied operation error: %v", accessDeniedAudit["error"])
 	}
+	if accessDeniedAudit["authorization_decision"] != "operation_binding_denied" {
+		t.Fatalf("expected denied operation authorization_decision operation_binding_denied, got %v", accessDeniedAudit["authorization_decision"])
+	}
 
 	var selectorAudit map[string]any
 	if err := json.Unmarshal(lines[len(lines)-1], &selectorAudit); err != nil {
@@ -5010,12 +5013,14 @@ func TestHumanAuthorization_ExecuteOperation_UsesResolvedRoleAndRejectsDisallowe
 		},
 	}, nil, pluginDefs, nil)
 
+	var auditBuf bytes.Buffer
 	ts := newTestServer(t, func(cfg *server.Config) {
 		cfg.Auth = &coretesting.StubAuthProvider{N: "test"}
 		cfg.Providers = testutil.NewProviderRegistry(t, stub)
 		cfg.Services = svc
 		cfg.Authorizer = authz
 		cfg.PluginDefs = pluginDefs
+		cfg.AuditSink = invocation.NewSlogAuditSink(&auditBuf)
 	})
 	testutil.CloseOnCleanup(t, ts)
 
@@ -5048,6 +5053,43 @@ func TestHumanAuthorization_ExecuteOperation_UsesResolvedRoleAndRejectsDisallowe
 	if resp.StatusCode != http.StatusForbidden {
 		body, _ := io.ReadAll(resp.Body)
 		t.Fatalf("expected 403, got %d: %s", resp.StatusCode, body)
+	}
+
+	lines := bytes.Split(bytes.TrimSpace(auditBuf.Bytes()), []byte("\n"))
+	if len(lines) == 0 {
+		t.Fatal("expected denial audit record")
+	}
+
+	var deniedAudit map[string]any
+	if err := json.Unmarshal(lines[len(lines)-1], &deniedAudit); err != nil {
+		t.Fatalf("parsing denied audit record: %v\nraw: %s", err, auditBuf.String())
+	}
+	if deniedAudit["provider"] != "svc" {
+		t.Fatalf("expected denied audit provider svc, got %v", deniedAudit["provider"])
+	}
+	if deniedAudit["operation"] != "admin" {
+		t.Fatalf("expected denied audit operation admin, got %v", deniedAudit["operation"])
+	}
+	if deniedAudit["allowed"] != false {
+		t.Fatalf("expected denied audit allowed=false, got %v", deniedAudit["allowed"])
+	}
+	if deniedAudit["auth_source"] != "api_token" {
+		t.Fatalf("expected denied audit auth_source api_token, got %v", deniedAudit["auth_source"])
+	}
+	if deniedAudit["subject_id"] != principal.UserSubjectID(viewer.ID) {
+		t.Fatalf("expected denied audit subject_id %q, got %v", principal.UserSubjectID(viewer.ID), deniedAudit["subject_id"])
+	}
+	if deniedAudit["access_policy"] != "sample_policy" {
+		t.Fatalf("expected denied audit access_policy sample_policy, got %v", deniedAudit["access_policy"])
+	}
+	if deniedAudit["access_role"] != "viewer" {
+		t.Fatalf("expected denied audit access_role viewer, got %v", deniedAudit["access_role"])
+	}
+	if deniedAudit["authorization_decision"] != "catalog_role_denied" {
+		t.Fatalf("expected denied audit authorization_decision catalog_role_denied, got %v", deniedAudit["authorization_decision"])
+	}
+	if deniedAudit["error"] != "operation access denied" {
+		t.Fatalf("expected denied audit error operation access denied, got %v", deniedAudit["error"])
 	}
 }
 


### PR DESCRIPTION
## Summary
- add access policy, access role, and authorization decision fields to audit entries
- emit an HTTP audit record when `executeOperation` denies a request at the catalog-role gate
- extend existing server authorization tests to cover both operation-binding denial and catalog-role denial audit output

## Test plan
- `go test ./internal/server -run 'TestWorkloadAuthorization_ExecuteOperation_UsesBoundIdentityAndRejectsSelectors|TestHumanAuthorization_ExecuteOperation_UsesResolvedRoleAndRejectsDisallowedOperations'`
- `go test ./internal/server`
- `git diff --check`
