### PR TITLE
[codex] include linux/arm in --platform all

### DIFF
--- a/gestaltd/cmd/gestaltd/plugin.go
+++ b/gestaltd/cmd/gestaltd/plugin.go
@@ -35,7 +35,7 @@ func runProvider(args []string) error {
 	}
 }
 
-const defaultPlatforms = "darwin/amd64,darwin/arm64,linux/amd64,linux/arm64"
+const defaultPlatforms = "darwin/amd64,darwin/arm64,linux/amd64,linux/arm,linux/arm64"
 const allPlatformsValue = "all"
 const defaultReleaseOutputDir = "dist/"
 const releaseBinaryPrefix = "gestalt-plugin-"

--- a/gestaltd/cmd/gestaltd/plugin_test.go
+++ b/gestaltd/cmd/gestaltd/plugin_test.go
@@ -2033,6 +2033,42 @@ func pythonReleaseOtherPlatform() (string, string) {
 	return "linux", "amd64"
 }
 
+func TestExpandReleasePlatformValue_AllIncludesLinuxArm(t *testing.T) {
+	t.Parallel()
+
+	got, err := expandReleasePlatformValue(allPlatformsValue)
+	if err != nil {
+		t.Fatalf("expandReleasePlatformValue(%q): %v", allPlatformsValue, err)
+	}
+	if got != defaultPlatforms {
+		t.Fatalf("expandReleasePlatformValue(%q) = %q, want %q", allPlatformsValue, got, defaultPlatforms)
+	}
+
+	platforms, err := parseReleasePlatforms(got)
+	if err != nil {
+		t.Fatalf("parseReleasePlatforms(%q): %v", got, err)
+	}
+
+	for _, want := range []releasePlatform{
+		{GOOS: "darwin", GOARCH: "amd64"},
+		{GOOS: "darwin", GOARCH: "arm64"},
+		{GOOS: "linux", GOARCH: "amd64"},
+		{GOOS: "linux", GOARCH: "arm"},
+		{GOOS: "linux", GOARCH: "arm64"},
+	} {
+		found := false
+		for _, platform := range platforms {
+			if platform == want {
+				found = true
+				break
+			}
+		}
+		if !found {
+			t.Fatalf("expanded platforms = %#v, missing %+v", platforms, want)
+		}
+	}
+}
+
 func defaultReleasePlatformsForTest(t *testing.T) []releasePlatform {
 	t.Helper()
 


### PR DESCRIPTION
## Summary
- include `linux/arm` in the built-in platform set used by `--platform all`
- add a CLI regression test that verifies the expanded platform list contains `linux/arm`

## Why
`gestaltd init --platform all` only hashes the hard-coded default target set. `linux/arm` was missing from that set, so lockfiles could still retain URL-only `linux/arm` archive entries even after running `--platform all`.

## Impact
This makes `--platform all` cover the existing `linux/arm` release artifacts without hard-coding provider names or changing the broader lockfile hashing semantics.

## Validation
- `go test ./cmd/gestaltd -run 'TestExpandReleasePlatformValue_AllIncludesLinuxArm|TestRun_PluginReleaseBuildsGoSourcePluginForAllPlatforms|TestRun_PluginReleaseBuildsPythonSourcePluginForAllPlatforms' -count=1`
