### PR TITLE
Move mounted UI bindings onto plugins

### DIFF
--- a/docs/content/configuration.mdx
+++ b/docs/content/configuration.mdx
@@ -4,7 +4,7 @@ Gestalt is configured from a single YAML file. This page covers the key concepts
 
 ## Config file structure
 
-A Gestalt config has five top-level keys: `server` for host settings, `authorization` for shared human/workload access policy, `apps` for deployment-owned plugin/UI bindings, `providers` for host-scoped providers and web UIs, and `plugins` for executable integrations.
+A Gestalt config has four top-level keys: `server` for host settings, `authorization` for shared human/workload access policy, `providers` for host-scoped providers and web UIs, and `plugins` for executable integrations and optional plugin-backed UI mounts.
 
 ```yaml
 server:
@@ -24,9 +24,6 @@ server:
 authorization:
   policies: ...             # shared human access policies
   workloads: ...            # workload bearer-token policy
-
-apps:
-  <name>: ...               # plugin/UI binding with path + auth policy
 
 providers:
   auth: ...                 # platform login (ProviderEntry)
@@ -51,7 +48,7 @@ Gestalt has six core concepts you configure in YAML:
 - **[IndexedDB.](/providers/indexeddb)** The persistent storage layer. Stores users, sessions, tokens, and credentials through a provider that implements the IndexedDB interface.
 - **[Auth.](/providers/auth)** Platform login for the Gestalt server. Separate from connection auth, which is per-plugin and per-upstream.
 - **[Secrets.](/providers/secrets)** Resolves `secret://` references in the config at startup. Backed by environment variables, files, or cloud secret managers.
-- **[UI.](/providers/web-uis)** Public static UI bundles served under configured path prefixes. Omit `providers.ui` to run headless.
+- **[UI.](/providers/web-uis)** Public static UI bundles served under configured path prefixes, either directly from `providers.ui` or through `plugins.<name>.mountPath`. Omit `providers.ui` to run headless.
 
 ## Adding a plugin
 
@@ -67,6 +64,8 @@ plugins:
     surfaces:
       openapi:
         baseUrl: https://api.github.com
+    mountPath: /github
+    ui: github_console
 ```
 
 `source.ref` points at a published provider package. Gestalt resolves and downloads it on startup. First-party providers are published to `github.com/valon-technologies/gestalt-providers/`.

--- a/docs/content/providers/web-uis.mdx
+++ b/docs/content/providers/web-uis.mdx
@@ -1,8 +1,8 @@
 # Web UIs
 
 Web UI providers are static asset bundles. Gestalt serves each configured
-bundle either directly from `providers.ui.<name>.path` or via a top-level
-`apps.<name>.path` binding. The built-in admin UI at `/admin` remains available
+bundle either directly from `providers.ui.<name>.path` or via
+`plugins.<name>.mountPath`. The built-in admin UI at `/admin` remains available
 regardless of whether public UI bundles are configured.
 
 ## How web UI providers work
@@ -25,7 +25,7 @@ First-party UI bundles live under
 
 Use `providers.ui` as a map of UI bundles. You can either mount a bundle
 directly from `providers.ui`, or bind it to a plugin-backed app through the
-top-level `apps` block. Omit `providers.ui` entirely to run headless with no
+`plugins` block. Omit `providers.ui` entirely to run headless with no
 public UI bundles.
 
 Point at a local source bundle during development:
@@ -49,27 +49,23 @@ providers:
       source:
         path: ./customer-roadmap-review/ui/manifest.yaml
 
-apps:
+plugins:
   roadmap_review:
-    plugin: roadmap_review
+    source:
+      path: ./customer-roadmap-review/plugin/manifest.yaml
     ui: roadmap
-    path: /create-customer-roadmap-review
+    mountPath: /create-customer-roadmap-review
     authorizationPolicy: roadmap_review
 ```
 
 Or let the plugin manifest own the UI bundle and keep only the deployment binding in config:
 
 ```yaml
-providers:
-  plugins:
-    roadmap_review:
-      source:
-        path: ./customer-roadmap-review/plugin/manifest.yaml
-
-apps:
+plugins:
   roadmap_review:
-    plugin: roadmap_review
-    path: /create-customer-roadmap-review
+    source:
+      path: ./customer-roadmap-review/plugin/manifest.yaml
+    mountPath: /create-customer-roadmap-review
     authorizationPolicy: roadmap_review
 ```
 
@@ -130,6 +126,6 @@ Asset-root layout, build hooks, and release packaging now live under
 
 ## What to read next
 
-- [Configuration](/configuration): `providers.ui`, `apps`, and headless deployments
+- [Configuration](/configuration): `providers.ui`, `plugins.<name>.mountPath`, and headless deployments
 - [Client Web UI](/client/web): what the default client exposes
 - [Custom Web UIs](/custom-providers/web-uis): advanced authoring docs

--- a/docs/content/reference/config-file.mdx
+++ b/docs/content/reference/config-file.mdx
@@ -2,7 +2,7 @@ import { Tabs } from 'nextra/components'
 
 # Config File
 
-Every `gestaltd` deployment reads a single YAML config file. The top-level keys are `server` (listener, encryption, egress, and indexeddb selection), `authorization` (shared human/workload access policy), `apps` (deployment-owned bindings between plugins and web UIs), `providers` (auth, secrets, telemetry, audit, mounted UI bundles, and indexeddb), and `plugins` (executable integrations):
+Every `gestaltd` deployment reads a single YAML config file. The top-level keys are `server` (listener, encryption, egress, and indexeddb selection), `authorization` (shared human/workload access policy), `providers` (auth, secrets, telemetry, audit, mounted UI bundles, and indexeddb), and `plugins` (executable integrations and optional plugin-backed UI mounts):
 
 ```yaml
 server:
@@ -10,7 +10,6 @@ server:
 authorization:
   policies: {}
   workloads: {}
-apps: {}
 providers:
   auth: {}
   secrets: {}
@@ -494,6 +493,8 @@ plugins:
     description: Public GitHub operations
     iconFile: ./icons/github.svg
     authorizationPolicy: support_staff
+    mountPath: /github
+    ui: github_console
     source:
       ref: github.com/valon-technologies/gestalt-providers/github
       version: 1.2.3
@@ -526,6 +527,8 @@ plugins:
 | `description` | Short description of the plugin. |
 | `iconFile` | SVG icon path, resolved relative to the config directory. |
 | `authorizationPolicy` | Optional shared human access policy from `authorization.policies`. When set, host-side operation filtering and execution checks use the resolved role for this plugin. |
+| `mountPath` | Optional public path prefix for a plugin-backed mounted UI. When set, Gestalt mounts either `plugins.<name>.ui` or the plugin manifest's `spec.ui`. |
+| `ui` | Optional UI key from `providers.ui` used with `mountPath`. Omit it to mount the plugin manifest's owned `spec.ui`. |
 | `source` | **Required.** The backing provider source. See [source shape](#pluginssource) below. |
 | `config` | Provider-specific configuration passed into the provider package. |
 | `surfaces` | Typed host-side overrides for manifest-declared surfaces, such as `surfaces.openapi.baseUrl` or `surfaces.graphql.url`. |
@@ -799,37 +802,17 @@ providers:
         brandName: Acme
 ```
 
-`providers.ui` is a map of `webui` bundles. Entries may mount directly by setting `path`, or they may act as app-owned UI artifacts that are bound through the top-level `apps` block. When a plugin manifest declares `spec.ui`, an app binding may omit `ui` entirely and let Gestalt synthesize the mounted UI entry from the plugin-owned reference. The built-in admin UI remains available at `/admin`. Omit `providers.ui` entirely to run headless with no public UI bundles.
+`providers.ui` is a map of `webui` bundles. Entries may mount directly by setting `path`, or they may act as named UI bundles that `plugins.<name>.ui` binds to `plugins.<name>.mountPath`. When a plugin manifest declares `spec.ui`, `plugins.<name>.ui` may be omitted entirely and Gestalt synthesizes the mounted UI entry from the plugin-owned reference. The built-in admin UI remains available at `/admin`. Omit `providers.ui` entirely to run headless with no public UI bundles.
 
 When `authorizationPolicy` is set on a mounted UI, the referenced web UI manifest must declare `spec.routes` with non-empty `allowedRoles`, and at least one route must cover `/`.
 
 | Field | Description |
 | --- | --- |
-| `path` | Direct mount prefix for this UI when not bound through `apps`. |
-| `authorizationPolicy` | Direct policy binding for this UI when not bound through `apps`. |
+| `path` | Direct mount prefix for this UI when not bound through `plugins.<name>.mountPath`. |
+| `authorizationPolicy` | Direct policy binding for this UI when not bound through `plugins.<name>.mountPath`. |
 | `disabled` | `true` to disable an individual mounted UI entry. |
 | `source` | A source mapping with `source.path` or `source.ref`. |
 | `config` | Optional UI-provider config validated against the bundle schema when present. |
-
-## `apps`
-
-```yaml
-apps:
-  roadmap_review:
-    plugin: roadmap_review
-    path: /create-customer-roadmap-review
-    authorizationPolicy: support_staff
-```
-
-`apps` is a deployment-owned binding layer for plugin-backed mounted apps. Each entry references an existing `plugins.<name>` entry, then supplies the public path and optional shared human authorization policy for both surfaces. The UI bundle may either be named explicitly through `apps.<name>.ui`, or omitted when the referenced plugin manifest declares an owned UI through `spec.ui`.
-
-| Field | Description |
-| --- | --- |
-| `plugin` | Required plugin key from `plugins`. |
-| `ui` | Optional UI key from `providers.ui`. Omit it when the plugin manifest declares `spec.ui`. |
-| `path` | Required public mount path for the app-owned UI bundle. |
-| `authorizationPolicy` | Optional shared policy from `authorization.policies` applied to both the mounted UI and referenced plugin. |
-| `disabled` | `true` to disable the app binding without removing the underlying plugin or UI entries. |
 
 ## Validation rules
 
@@ -845,7 +828,7 @@ Only `connections.default` may define `params` or `discovery`. All connections i
 
 Each `providers.ui.<name>` entry must use exactly one mode: `disabled: true`, or a source mapping with exactly one loading mode: local `providers.ui.<name>.source.path` or managed `providers.ui.<name>.source.ref`. `providers.ui.<name>.source.version` is required with `providers.ui.<name>.source.ref` and invalid with `providers.ui.<name>.source.path`. `providers.ui.<name>.config` is only allowed when `providers.ui.<name>.source` is set.
 
-Each enabled `apps.<name>` entry must reference an existing enabled plugin. When `apps.<name>.ui` is set, it must reference an existing enabled UI bundle. When `apps.<name>.ui` is omitted, the referenced plugin manifest must declare `spec.ui`. A given plugin or UI may be bound by at most one enabled app entry. `apps.<name>.path` must use the same path rules as a directly mounted UI, and `apps.<name>.authorizationPolicy` must reference `authorization.policies` when set.
+Each enabled `plugins.<name>` entry may set `mountPath` to publish a plugin-backed UI. When `plugins.<name>.ui` is set, it must reference an existing enabled UI bundle. When `plugins.<name>.ui` is omitted and `plugins.<name>.mountPath` is set, the plugin manifest must declare `spec.ui`. A given UI may be bound by at most one enabled plugin entry. `plugins.<name>.mountPath` must use the same path rules as a directly mounted UI.
 
 Mounted UI bundles are served on the public listener only. The built-in admin UI remains at `/admin`.
 

--- a/docs/content/reference/plugin-manifests.mdx
+++ b/docs/content/reference/plugin-manifests.mdx
@@ -70,7 +70,7 @@ The `spec` block for a `kind: plugin` manifest describes a plugin. It supports d
 | `surfaces` | Surfaces | Spec-loaded and declarative REST surfaces. See [Surfaces](#surfaces). |
 | `defaultConnection` | string | Name of the connection to use when none is specified. |
 | `requires` | string[] | Provider source identifiers that this provider depends on. Gestalt ensures the listed providers are available before starting this provider. |
-| `ui` | OwnedUIRef | Optional owned web UI reference for app-backed plugins. |
+| `ui` | OwnedUIRef | Optional owned web UI reference for plugins that publish a mounted UI. |
 
 ### Owned UI
 
@@ -85,7 +85,7 @@ Plugins that back mounted apps may declare their UI artifact in the plugin manif
 | `version` | string | Optional version for `ref`. Defaults to the plugin manifest version when omitted. |
 | `auth.token` | string | Optional source token used when resolving a private managed `ref`. Only valid with `ref`. |
 
-When a deployment defines `apps.<name>` with `plugin: <plugin>` and omits `apps.<name>.ui`, Gestalt synthesizes the mounted UI binding from this block.
+When a deployment sets `plugins.<name>.mountPath` and omits `plugins.<name>.ui`, Gestalt synthesizes the mounted UI binding from this block.
 
 Source-manifest example:
 

--- a/gestaltd/internal/config/config.go
+++ b/gestaltd/internal/config/config.go
@@ -44,17 +44,8 @@ const PluginConnectionAlias = "plugin"
 type Config struct {
 	Server        ServerConfig              `yaml:"server"`
 	Authorization AuthorizationConfig       `yaml:"authorization,omitempty"`
-	Apps          map[string]*AppEntry      `yaml:"apps,omitempty"`
 	Providers     ProvidersConfig           `yaml:"providers"`
 	Plugins       map[string]*ProviderEntry `yaml:"plugins,omitempty"`
-}
-
-type AppEntry struct {
-	Plugin              string `yaml:"plugin"`
-	UI                  string `yaml:"ui"`
-	Path                string `yaml:"path,omitempty"`
-	AuthorizationPolicy string `yaml:"authorizationPolicy,omitempty"`
-	Disabled            bool   `yaml:"disabled,omitempty"`
 }
 
 type ProvidersConfig struct {
@@ -134,6 +125,8 @@ type ProviderEntry struct {
 	AuthorizationPolicy string `yaml:"authorizationPolicy,omitempty"`
 
 	// Plugin-specific config fields (parsed from YAML, only valid on plugin entries)
+	MountPath         string                        `yaml:"mountPath,omitempty"`
+	UI                string                        `yaml:"ui,omitempty"`
 	Connections       map[string]*ConnectionDef     `yaml:"connections,omitempty"`
 	AllowedOperations map[string]*OperationOverride `yaml:"allowedOperations,omitempty"`
 	IndexedDB         *PluginIndexedDBConfig        `yaml:"indexeddb,omitempty"`
@@ -656,7 +649,7 @@ func NormalizeCompatibility(cfg *Config) error {
 	if err := normalizeAdminConfig(cfg); err != nil {
 		return err
 	}
-	return applyAppBindings(cfg)
+	return applyPluginMountBindings(cfg)
 }
 
 func OverlayManagedPluginConfig(path string, cfg *Config) error {
@@ -1040,82 +1033,61 @@ func normalizedWorkloadDef(workload WorkloadDef) WorkloadDef {
 	return workload
 }
 
-func applyAppBindings(cfg *Config) error {
-	if cfg == nil || len(cfg.Apps) == 0 {
+func applyPluginMountBindings(cfg *Config) error {
+	if cfg == nil || len(cfg.Plugins) == 0 {
 		return nil
 	}
 
-	appNames := slices.Sorted(maps.Keys(cfg.Apps))
-	seenPlugins := make(map[string]string, len(appNames))
-	seenUIs := make(map[string]string, len(appNames))
-	for _, appName := range appNames {
-		app := cfg.Apps[appName]
-		if app == nil {
-			return fmt.Errorf("config validation: apps.%s is required", appName)
-		}
-		if app.Disabled {
-			continue
-		}
-		if strings.TrimSpace(appName) == "" {
-			return fmt.Errorf("config validation: apps keys must be non-empty")
-		}
-		app.Plugin = strings.TrimSpace(app.Plugin)
-		app.UI = strings.TrimSpace(app.UI)
-		app.Path = strings.TrimSpace(app.Path)
-		app.AuthorizationPolicy = strings.TrimSpace(app.AuthorizationPolicy)
-
-		if app.Plugin == "" {
-			return fmt.Errorf("config validation: apps.%s.plugin is required", appName)
-		}
-		if app.Path == "" {
-			return fmt.Errorf("config validation: apps.%s.path is required", appName)
-		}
-		normalizedPath, err := normalizeMountedUIPath(app.Path)
-		if err != nil {
-			return fmt.Errorf("config validation: apps.%s.path: %w", appName, err)
-		}
-		app.Path = normalizedPath
-		if err := validateAuthorizationPolicyReference(cfg, "app", appName, app.AuthorizationPolicy); err != nil {
-			return err
-		}
-		if prev, exists := seenPlugins[app.Plugin]; exists && prev != appName {
-			return fmt.Errorf("config validation: apps.%s.plugin %q duplicates apps.%s", appName, app.Plugin, prev)
-		}
-		plugin := cfg.Plugins[app.Plugin]
+	pluginNames := slices.Sorted(maps.Keys(cfg.Plugins))
+	seenUIs := make(map[string]string, len(pluginNames))
+	for _, pluginName := range pluginNames {
+		plugin := cfg.Plugins[pluginName]
 		if plugin == nil {
-			return fmt.Errorf("config validation: apps.%s.plugin references unknown plugin %q", appName, app.Plugin)
+			return fmt.Errorf("config validation: plugins.%s is required", pluginName)
 		}
 		if plugin.Disabled {
-			return fmt.Errorf("config validation: apps.%s.plugin references disabled plugin %q", appName, app.Plugin)
-		}
-		if current := strings.TrimSpace(plugin.AuthorizationPolicy); current != "" && current != app.AuthorizationPolicy {
-			return fmt.Errorf("config validation: apps.%s.plugin %q conflicts with plugins.%s.authorizationPolicy", appName, app.Plugin, app.Plugin)
-		}
-		plugin.AuthorizationPolicy = app.AuthorizationPolicy
-		seenPlugins[app.Plugin] = appName
-
-		if app.UI == "" {
 			continue
 		}
-		if prev, exists := seenUIs[app.UI]; exists && prev != appName {
-			return fmt.Errorf("config validation: apps.%s.ui %q duplicates apps.%s", appName, app.UI, prev)
+		plugin.UI = strings.TrimSpace(plugin.UI)
+		plugin.MountPath = strings.TrimSpace(plugin.MountPath)
+		plugin.AuthorizationPolicy = strings.TrimSpace(plugin.AuthorizationPolicy)
+
+		if plugin.MountPath == "" {
+			if plugin.UI != "" {
+				return fmt.Errorf("config validation: plugins.%s.ui requires plugins.%s.mountPath", pluginName, pluginName)
+			}
+			continue
 		}
-		ui := cfg.Providers.UI[app.UI]
+		normalizedPath, err := normalizeMountedUIPath(plugin.MountPath)
+		if err != nil {
+			return fmt.Errorf("config validation: plugins.%s.mountPath: %w", pluginName, err)
+		}
+		plugin.MountPath = normalizedPath
+		if err := validateAuthorizationPolicyReference(cfg, "plugin", pluginName, plugin.AuthorizationPolicy); err != nil {
+			return err
+		}
+		if plugin.UI == "" {
+			continue
+		}
+		if prev, exists := seenUIs[plugin.UI]; exists && prev != pluginName {
+			return fmt.Errorf("config validation: plugins.%s.ui %q duplicates plugins.%s", pluginName, plugin.UI, prev)
+		}
+		ui := cfg.Providers.UI[plugin.UI]
 		if ui == nil {
-			return fmt.Errorf("config validation: apps.%s.ui references unknown ui %q", appName, app.UI)
+			return fmt.Errorf("config validation: plugins.%s.ui references unknown ui %q", pluginName, plugin.UI)
 		}
 		if ui.Disabled {
-			return fmt.Errorf("config validation: apps.%s.ui references disabled ui %q", appName, app.UI)
+			return fmt.Errorf("config validation: plugins.%s.ui references disabled ui %q", pluginName, plugin.UI)
 		}
-		if current := strings.TrimSpace(ui.AuthorizationPolicy); current != "" && current != app.AuthorizationPolicy {
-			return fmt.Errorf("config validation: apps.%s.ui %q conflicts with providers.ui.%s.authorizationPolicy", appName, app.UI, app.UI)
+		if current := strings.TrimSpace(ui.AuthorizationPolicy); current != "" && current != plugin.AuthorizationPolicy {
+			return fmt.Errorf("config validation: plugins.%s.ui %q conflicts with providers.ui.%s.authorizationPolicy", pluginName, plugin.UI, plugin.UI)
 		}
-		if current := strings.TrimSpace(ui.Path); current != "" && current != app.Path {
-			return fmt.Errorf("config validation: apps.%s.ui %q conflicts with providers.ui.%s.path", appName, app.UI, app.UI)
+		if current := strings.TrimSpace(ui.Path); current != "" && current != plugin.MountPath {
+			return fmt.Errorf("config validation: plugins.%s.ui %q conflicts with providers.ui.%s.path", pluginName, plugin.UI, plugin.UI)
 		}
-		ui.AuthorizationPolicy = app.AuthorizationPolicy
-		ui.Path = app.Path
-		seenUIs[app.UI] = appName
+		ui.AuthorizationPolicy = plugin.AuthorizationPolicy
+		ui.Path = plugin.MountPath
+		seenUIs[plugin.UI] = pluginName
 	}
 
 	return nil

--- a/gestaltd/internal/config/config_test.go
+++ b/gestaltd/internal/config/config_test.go
@@ -969,6 +969,55 @@ server:
 		}
 	})
 
+	t.Run("plugin mount path binds an explicit ui entry", func(t *testing.T) {
+		t.Parallel()
+
+		path := mustWriteConfigFile(t, `
+providers:
+  ui:
+    roadmap:
+      source:
+        path: ./web/roadmap/manifest.yaml
+  indexeddb:
+    sqlite:
+      source:
+        path: ./providers/datastore/sqlite
+plugins:
+  roadmap:
+    source:
+      path: ./plugin/manifest.yaml
+    ui: roadmap
+    mountPath: /create-customer-roadmap-review/
+    authorizationPolicy: roadmap_policy
+authorization:
+  policies:
+    roadmap_policy:
+      default: deny
+      members:
+        - email: viewer@example.test
+          role: viewer
+server:
+  providers:
+    indexeddb: sqlite
+  encryptionKey: server-key
+`)
+
+		cfg, err := Load(path)
+		if err != nil {
+			t.Fatalf("Load: %v", err)
+		}
+		entry := cfg.Providers.UI["roadmap"]
+		if entry == nil {
+			t.Fatal(`Providers.UI["roadmap"] = nil`)
+		}
+		if got := entry.Path; got != "/create-customer-roadmap-review" {
+			t.Fatalf(`Providers.UI["roadmap"].Path = %q, want %q`, got, "/create-customer-roadmap-review")
+		}
+		if got := entry.AuthorizationPolicy; got != "roadmap_policy" {
+			t.Fatalf(`Providers.UI["roadmap"].AuthorizationPolicy = %q, want %q`, got, "roadmap_policy")
+		}
+	})
+
 	t.Run("reserved path is rejected", func(t *testing.T) {
 		t.Parallel()
 
@@ -1023,6 +1072,39 @@ server:
 			t.Fatal("Load: expected error, got nil")
 		}
 		if !strings.Contains(err.Error(), `ui.metrics.path "/metrics/dashboard" conflicts with reserved path "/metrics"`) {
+			t.Fatalf("unexpected error: %v", err)
+		}
+	})
+
+	t.Run("plugin-owned ui overlay still validates reserved mount paths", func(t *testing.T) {
+		t.Parallel()
+
+		path := mustWriteConfigFile(t, `
+plugins:
+  roadmap:
+    source:
+      path: ./plugin/manifest.yaml
+    mountPath: /api
+providers:
+  ui:
+    roadmap:
+      source:
+        path: ./web/roadmap/manifest.yaml
+  indexeddb:
+    sqlite:
+      source:
+        path: ./providers/datastore/sqlite
+server:
+  providers:
+    indexeddb: sqlite
+  encryptionKey: server-key
+`)
+
+		_, err := Load(path)
+		if err == nil {
+			t.Fatal("Load: expected error, got nil")
+		}
+		if !strings.Contains(err.Error(), `plugins.roadmap.mountPath "/api" conflicts with reserved path "/api"`) {
 			t.Fatalf("unexpected error: %v", err)
 		}
 	})
@@ -1352,6 +1434,36 @@ server:
 			t.Fatal("Load: expected error, got nil")
 		}
 		if !strings.Contains(err.Error(), `ui.root.surfaces is only supported on plugins.*`) {
+			t.Fatalf("unexpected error: %v", err)
+		}
+	})
+
+	t.Run("rejects plugin mount fields outside plugins", func(t *testing.T) {
+		t.Parallel()
+
+		path := mustWriteConfigFile(t, `
+providers:
+  ui:
+    root:
+      source:
+        path: ./web/root/manifest.yaml
+      path: /app
+      mountPath: /also-app
+  indexeddb:
+    sqlite:
+      source:
+        path: ./providers/datastore/sqlite
+server:
+  providers:
+    indexeddb: sqlite
+  encryptionKey: server-key
+`)
+
+		_, err := Load(path)
+		if err == nil {
+			t.Fatal("Load: expected error, got nil")
+		}
+		if !strings.Contains(err.Error(), `ui.root.mountPath is only supported on plugins.*`) {
 			t.Fatalf("unexpected error: %v", err)
 		}
 	})

--- a/gestaltd/internal/config/config_validate.go
+++ b/gestaltd/internal/config/config_validate.go
@@ -23,8 +23,8 @@ func ValidateStructure(cfg *Config) error {
 	if err := NormalizeCompatibility(cfg); err != nil {
 		return err
 	}
-	appUIRefs := appReferencedUIs(cfg)
-	if err := normalizeMountedUIPaths(cfg, appUIRefs); err != nil {
+	pluginOwnedUIRefs := pluginOwnedUIRefs(cfg)
+	if err := normalizeMountedUIPaths(cfg, pluginOwnedUIRefs); err != nil {
 		return err
 	}
 	if err := validateAuthorizationPolicies(cfg); err != nil {
@@ -81,13 +81,13 @@ func ValidateStructure(cfg *Config) error {
 			return err
 		}
 		if entry.Path == "" {
-			if _, ok := appUIRefs[name]; ok {
+			if _, ok := pluginOwnedUIRefs[name]; ok {
 				continue
 			}
 			return fmt.Errorf("config validation: ui.%s.path is required", name)
 		}
 	}
-	if err := validateMountedUICollisions(cfg); err != nil {
+	if err := validateMountedUICollisions(cfg, pluginOwnedUIRefs); err != nil {
 		return err
 	}
 
@@ -253,6 +253,12 @@ func ValidateResolvedStructure(cfg *Config) error {
 		if err := validateManifestBackedIntegration(name, entry); err != nil {
 			return err
 		}
+		if entry.Disabled || strings.TrimSpace(entry.MountPath) == "" || strings.TrimSpace(entry.UI) != "" {
+			continue
+		}
+		if entry.ResolvedManifest == nil || entry.ManifestSpec() == nil || entry.ManifestSpec().UI == nil {
+			return fmt.Errorf("config validation: plugins.%s.mountPath requires plugins.%s.ui or plugin spec.ui", name, name)
+		}
 	}
 	for name, entry := range cfg.Providers.UI {
 		if entry == nil {
@@ -294,12 +300,17 @@ func validatePlugin(cfg *Config, name string, entry *ProviderEntry) error {
 	if entry.Default {
 		return fmt.Errorf("config validation: plugins.%s.default is not supported on plugins", name)
 	}
+	entry.MountPath = strings.TrimSpace(entry.MountPath)
+	entry.UI = strings.TrimSpace(entry.UI)
 	if entry.IndexedDB != nil {
 		entry.IndexedDB.Provider = strings.TrimSpace(entry.IndexedDB.Provider)
 		entry.IndexedDB.DB = strings.TrimSpace(entry.IndexedDB.DB)
 		for i, store := range entry.IndexedDB.ObjectStores {
 			entry.IndexedDB.ObjectStores[i] = strings.TrimSpace(store)
 		}
+	}
+	if entry.UI != "" && entry.MountPath == "" {
+		return fmt.Errorf("config validation: plugins.%s.ui requires plugins.%s.mountPath", name, name)
 	}
 	if err := validateProviderEntrySource("plugin", name, entry); err != nil {
 		return err
@@ -355,6 +366,12 @@ func validateCacheConfig(cfg *Config) error {
 func validatePluginOnlyProviderFields(subject string, entry *ProviderEntry) error {
 	if entry == nil {
 		return nil
+	}
+	if strings.TrimSpace(entry.MountPath) != "" {
+		return fmt.Errorf("config validation: %s.mountPath is only supported on plugins.*", subject)
+	}
+	if strings.TrimSpace(entry.UI) != "" {
+		return fmt.Errorf("config validation: %s.ui is only supported on plugins.*", subject)
 	}
 	if entry.IndexedDB != nil {
 		return fmt.Errorf("config validation: %s.indexeddb is only supported on plugins.*", subject)
@@ -584,15 +601,16 @@ func cacheSocketEnv(name string) string {
 	return b.String()
 }
 
-func normalizeMountedUIPaths(cfg *Config, appUIRefs map[string]struct{}) error {
+func normalizeMountedUIPaths(cfg *Config, pluginOwnedUIRefs map[string]struct{}) error {
 	for name, entry := range cfg.Providers.UI {
 		if entry == nil || entry.Disabled {
 			continue
 		}
 		if strings.TrimSpace(entry.Path) == "" {
-			if _, ok := appUIRefs[name]; ok {
+			if _, ok := pluginOwnedUIRefs[name]; ok {
 				continue
 			}
+			return fmt.Errorf("config validation: ui.%s.path: path is required", name)
 		}
 		normalized, err := normalizeMountedUIPath(entry.Path)
 		if err != nil {
@@ -621,7 +639,7 @@ func normalizeMountedUIPath(path string) (string, error) {
 	return path, nil
 }
 
-func validateMountedUICollisions(cfg *Config) error {
+func validateMountedUICollisions(cfg *Config, pluginOwnedUIRefs map[string]struct{}) error {
 	reserved := []string{
 		"/api",
 		"/api/v1",
@@ -637,7 +655,7 @@ func validateMountedUICollisions(cfg *Config) error {
 		label string
 		path  string
 	}
-	subjects := make([]mountedPathSubject, 0, len(cfg.Providers.UI)+len(cfg.Apps))
+	subjects := make([]mountedPathSubject, 0, len(cfg.Providers.UI)+len(cfg.Plugins))
 	names := slices.Sorted(maps.Keys(cfg.Providers.UI))
 	for _, name := range names {
 		entry := cfg.Providers.UI[name]
@@ -649,18 +667,20 @@ func validateMountedUICollisions(cfg *Config) error {
 			path:  entry.Path,
 		})
 	}
-	appNames := slices.Sorted(maps.Keys(cfg.Apps))
-	for _, name := range appNames {
-		app := cfg.Apps[name]
-		if app == nil || app.Disabled || strings.TrimSpace(app.UI) != "" || strings.TrimSpace(app.Path) == "" {
+	pluginNames := slices.Sorted(maps.Keys(cfg.Plugins))
+	for _, name := range pluginNames {
+		entry := cfg.Plugins[name]
+		if entry == nil || entry.Disabled || strings.TrimSpace(entry.UI) != "" || strings.TrimSpace(entry.MountPath) == "" {
 			continue
 		}
-		if ui := cfg.Providers.UI[name]; ui != nil && !ui.Disabled && strings.TrimSpace(ui.Path) != "" {
-			continue
+		if _, ok := pluginOwnedUIRefs[name]; ok {
+			if ui := cfg.Providers.UI[name]; ui != nil && !ui.Disabled && strings.TrimSpace(ui.Path) != "" {
+				continue
+			}
 		}
 		subjects = append(subjects, mountedPathSubject{
-			label: "apps." + name + ".path",
-			path:  app.Path,
+			label: "plugins." + name + ".mountPath",
+			path:  entry.MountPath,
 		})
 	}
 	for i, subject := range subjects {
@@ -693,14 +713,10 @@ func mountedUIPathsConflict(a, b string) bool {
 	return strings.HasPrefix(a, b+"/") || strings.HasPrefix(b, a+"/")
 }
 
-func appReferencedUIs(cfg *Config) map[string]struct{} {
-	refs := make(map[string]struct{}, len(cfg.Apps))
-	for name, app := range cfg.Apps {
-		if app == nil || app.Disabled {
-			continue
-		}
-		if ui := strings.TrimSpace(app.UI); ui != "" {
-			refs[ui] = struct{}{}
+func pluginOwnedUIRefs(cfg *Config) map[string]struct{} {
+	refs := make(map[string]struct{}, len(cfg.Plugins))
+	for name, entry := range cfg.Plugins {
+		if entry == nil || entry.Disabled || strings.TrimSpace(entry.UI) != "" || strings.TrimSpace(entry.MountPath) == "" {
 			continue
 		}
 		refs[name] = struct{}{}

--- a/gestaltd/internal/operator/lifecycle.go
+++ b/gestaltd/internal/operator/lifecycle.go
@@ -177,7 +177,7 @@ func (l *Lifecycle) initAtPath(configPath, artifactsDir string) (*Lockfile, *con
 	if err := l.resolveConfiguredPlugins(paths, lock, cfg, true); err != nil {
 		return nil, nil, err
 	}
-	if err := synthesizeAppOwnedUIEntries(cfg); err != nil {
+	if err := synthesizePluginOwnedUIEntries(cfg); err != nil {
 		return nil, nil, err
 	}
 	for name, lockEntry := range secretsEntries {
@@ -263,7 +263,7 @@ func (l *Lifecycle) LoadForExecutionAtPathWithArtifactsDir(configPath, artifacts
 	if err != nil {
 		return nil, nil, fmt.Errorf("loading config: %v", err)
 	}
-	if err := synthesizeLocalSourceAppOwnedUIEntries(cfg); err != nil {
+	if err := synthesizeLocalSourcePluginOwnedUIEntries(cfg); err != nil {
 		return nil, nil, fmt.Errorf("loading config: %v", err)
 	}
 	paths := initPathsForConfigWithArtifactsDir(configPath, resolveArtifactsDir(configPath, cfg, artifactsDir))
@@ -1056,16 +1056,16 @@ func (l *Lifecycle) applyLockedProviders(configPath, artifactsDir string, cfg *c
 	var lock *Lockfile
 	var err error
 	if configHasManagedProviderSources(cfg) {
-		var synthesizedLockedAppUIs map[string]struct{}
+		var synthesizedLockedPluginUIs map[string]struct{}
 		lock, err = ReadLockfile(paths.lockfilePath)
 		if err == nil {
-			synthesizedLockedAppUIs, err = synthesizeLockedSourceAppOwnedUIEntries(cfg, paths, lock)
+			synthesizedLockedPluginUIs, err = synthesizeLockedSourcePluginOwnedUIEntries(cfg, paths, lock)
 			if err != nil {
-				clearSynthesizedAppOwnedUIEntries(cfg, synthesizedLockedAppUIs)
+				clearSynthesizedPluginOwnedUIEntries(cfg, synthesizedLockedPluginUIs)
 			}
 		}
 		if !locked && (err != nil || !lockMatchesConfig(cfg, paths, lock)) {
-			clearSynthesizedAppOwnedUIEntries(cfg, synthesizedLockedAppUIs)
+			clearSynthesizedPluginOwnedUIEntries(cfg, synthesizedLockedPluginUIs)
 			lock, err = l.InitAtPathWithArtifactsDir(configPath, artifactsDir)
 		}
 		if err != nil {
@@ -1076,7 +1076,7 @@ func (l *Lifecycle) applyLockedProviders(configPath, artifactsDir string, cfg *c
 	if err := l.resolveConfiguredPlugins(paths, lock, cfg, locked); err != nil {
 		return err
 	}
-	if err := synthesizeAppOwnedUIEntries(cfg); err != nil {
+	if err := synthesizePluginOwnedUIEntries(cfg); err != nil {
 		return err
 	}
 	for _, collection := range hostProviderCollections(cfg) {
@@ -1151,38 +1151,33 @@ func (l *Lifecycle) resolveConfiguredPlugins(paths initPaths, lock *Lockfile, cf
 	return nil
 }
 
-func synthesizeAppOwnedUIEntries(cfg *config.Config) error {
-	if cfg == nil || len(cfg.Apps) == 0 {
+func synthesizePluginOwnedUIEntries(cfg *config.Config) error {
+	if cfg == nil || len(cfg.Plugins) == 0 {
 		return nil
 	}
 	if cfg.Providers.UI == nil {
 		cfg.Providers.UI = map[string]*config.UIEntry{}
 	}
 
-	appNames := slices.Sorted(maps.Keys(cfg.Apps))
-	for _, appName := range appNames {
-		app := cfg.Apps[appName]
-		if app == nil || app.Disabled || strings.TrimSpace(app.UI) != "" {
-			continue
-		}
-		pluginName := strings.TrimSpace(app.Plugin)
+	pluginNames := slices.Sorted(maps.Keys(cfg.Plugins))
+	for _, pluginName := range pluginNames {
 		plugin := cfg.Plugins[pluginName]
-		if plugin == nil {
-			return fmt.Errorf("config validation: apps.%s.plugin references unknown plugin %q", appName, pluginName)
+		if plugin == nil || plugin.Disabled || strings.TrimSpace(plugin.UI) != "" || strings.TrimSpace(plugin.MountPath) == "" {
+			continue
 		}
 		manifestSpec := plugin.ManifestSpec()
 		if manifestSpec == nil || manifestSpec.UI == nil {
-			return fmt.Errorf("app %q plugin %q does not declare spec.ui", appName, pluginName)
+			return fmt.Errorf("plugin %q mountPath requires spec.ui or plugins.%s.ui", pluginName, pluginName)
 		}
 		ownedUI := manifestSpec.UI
 		entry, err := ownedUIEntryForPlugin(plugin, ownedUI)
 		if err != nil {
-			return fmt.Errorf("app %q plugin %q ui: %w", appName, pluginName, err)
+			return fmt.Errorf("plugin %q ui: %w", pluginName, err)
 		}
-		entry.Path = strings.TrimSpace(app.Path)
-		entry.AuthorizationPolicy = strings.TrimSpace(app.AuthorizationPolicy)
-		if existing := cfg.Providers.UI[appName]; existing != nil {
-			if err := validateSynthesizedAppUIEntry(appName, existing, entry); err != nil {
+		entry.Path = strings.TrimSpace(plugin.MountPath)
+		entry.AuthorizationPolicy = strings.TrimSpace(plugin.AuthorizationPolicy)
+		if existing := cfg.Providers.UI[pluginName]; existing != nil {
+			if err := validateSynthesizedPluginUIEntry(pluginName, existing, entry); err != nil {
 				return err
 			}
 			if existing.Source.Auth == nil && entry.Source.Auth != nil {
@@ -1192,27 +1187,22 @@ func synthesizeAppOwnedUIEntries(cfg *config.Config) error {
 			existing.AuthorizationPolicy = cmp.Or(existing.AuthorizationPolicy, entry.AuthorizationPolicy)
 			continue
 		}
-		cfg.Providers.UI[appName] = entry
+		cfg.Providers.UI[pluginName] = entry
 	}
 	return nil
 }
 
-func synthesizeLocalSourceAppOwnedUIEntries(cfg *config.Config) error {
-	if cfg == nil || len(cfg.Apps) == 0 {
+func synthesizeLocalSourcePluginOwnedUIEntries(cfg *config.Config) error {
+	if cfg == nil || len(cfg.Plugins) == 0 {
 		return nil
 	}
 	if cfg.Providers.UI == nil {
 		cfg.Providers.UI = map[string]*config.UIEntry{}
 	}
-	appNames := slices.Sorted(maps.Keys(cfg.Apps))
-	for _, appName := range appNames {
-		app := cfg.Apps[appName]
-		if app == nil || app.Disabled || strings.TrimSpace(app.UI) != "" {
-			continue
-		}
-		pluginName := strings.TrimSpace(app.Plugin)
+	pluginNames := slices.Sorted(maps.Keys(cfg.Plugins))
+	for _, pluginName := range pluginNames {
 		plugin := cfg.Plugins[pluginName]
-		if plugin == nil || !plugin.HasLocalSource() {
+		if plugin == nil || plugin.Disabled || strings.TrimSpace(plugin.UI) != "" || strings.TrimSpace(plugin.MountPath) == "" || !plugin.HasLocalSource() {
 			continue
 		}
 		manifestPath := plugin.SourcePath()
@@ -1228,12 +1218,12 @@ func synthesizeLocalSourceAppOwnedUIEntries(cfg *config.Config) error {
 		}
 		entry, err := ownedUIEntryFromManifest(manifestPath, manifest.Version, manifest.Spec.UI)
 		if err != nil {
-			return fmt.Errorf("app %q plugin %q ui: %w", appName, pluginName, err)
+			return fmt.Errorf("plugin %q ui: %w", pluginName, err)
 		}
-		entry.Path = strings.TrimSpace(app.Path)
-		entry.AuthorizationPolicy = strings.TrimSpace(app.AuthorizationPolicy)
-		if existing := cfg.Providers.UI[appName]; existing != nil {
-			if err := validateSynthesizedAppUIEntry(appName, existing, entry); err != nil {
+		entry.Path = strings.TrimSpace(plugin.MountPath)
+		entry.AuthorizationPolicy = strings.TrimSpace(plugin.AuthorizationPolicy)
+		if existing := cfg.Providers.UI[pluginName]; existing != nil {
+			if err := validateSynthesizedPluginUIEntry(pluginName, existing, entry); err != nil {
 				return err
 			}
 			if existing.Source.Auth == nil && entry.Source.Auth != nil {
@@ -1243,28 +1233,23 @@ func synthesizeLocalSourceAppOwnedUIEntries(cfg *config.Config) error {
 			existing.AuthorizationPolicy = cmp.Or(existing.AuthorizationPolicy, entry.AuthorizationPolicy)
 			continue
 		}
-		cfg.Providers.UI[appName] = entry
+		cfg.Providers.UI[pluginName] = entry
 	}
 	return nil
 }
 
-func synthesizeLockedSourceAppOwnedUIEntries(cfg *config.Config, paths initPaths, lock *Lockfile) (map[string]struct{}, error) {
+func synthesizeLockedSourcePluginOwnedUIEntries(cfg *config.Config, paths initPaths, lock *Lockfile) (map[string]struct{}, error) {
 	added := map[string]struct{}{}
-	if cfg == nil || len(cfg.Apps) == 0 || lock == nil {
+	if cfg == nil || len(cfg.Plugins) == 0 || lock == nil {
 		return added, nil
 	}
 	if cfg.Providers.UI == nil {
 		cfg.Providers.UI = map[string]*config.UIEntry{}
 	}
-	appNames := slices.Sorted(maps.Keys(cfg.Apps))
-	for _, appName := range appNames {
-		app := cfg.Apps[appName]
-		if app == nil || app.Disabled || strings.TrimSpace(app.UI) != "" {
-			continue
-		}
-		pluginName := strings.TrimSpace(app.Plugin)
+	pluginNames := slices.Sorted(maps.Keys(cfg.Plugins))
+	for _, pluginName := range pluginNames {
 		plugin := cfg.Plugins[pluginName]
-		if plugin == nil || !plugin.HasManagedSource() {
+		if plugin == nil || plugin.Disabled || strings.TrimSpace(plugin.UI) != "" || strings.TrimSpace(plugin.MountPath) == "" || !plugin.HasManagedSource() {
 			continue
 		}
 		lockEntry, ok := lock.Providers[pluginName]
@@ -1281,12 +1266,12 @@ func synthesizeLockedSourceAppOwnedUIEntries(cfg *config.Config, paths initPaths
 		}
 		entry, err := ownedUIEntryFromManifest(manifestPath, manifest.Version, manifest.Spec.UI)
 		if err != nil {
-			return added, fmt.Errorf("app %q plugin %q ui: %w", appName, pluginName, err)
+			return added, fmt.Errorf("plugin %q ui: %w", pluginName, err)
 		}
-		entry.Path = strings.TrimSpace(app.Path)
-		entry.AuthorizationPolicy = strings.TrimSpace(app.AuthorizationPolicy)
-		if existing := cfg.Providers.UI[appName]; existing != nil {
-			if err := validateSynthesizedAppUIEntry(appName, existing, entry); err != nil {
+		entry.Path = strings.TrimSpace(plugin.MountPath)
+		entry.AuthorizationPolicy = strings.TrimSpace(plugin.AuthorizationPolicy)
+		if existing := cfg.Providers.UI[pluginName]; existing != nil {
+			if err := validateSynthesizedPluginUIEntry(pluginName, existing, entry); err != nil {
 				return added, err
 			}
 			if existing.Source.Auth == nil && entry.Source.Auth != nil {
@@ -1296,13 +1281,13 @@ func synthesizeLockedSourceAppOwnedUIEntries(cfg *config.Config, paths initPaths
 			existing.AuthorizationPolicy = cmp.Or(existing.AuthorizationPolicy, entry.AuthorizationPolicy)
 			continue
 		}
-		cfg.Providers.UI[appName] = entry
-		added[appName] = struct{}{}
+		cfg.Providers.UI[pluginName] = entry
+		added[pluginName] = struct{}{}
 	}
 	return added, nil
 }
 
-func clearSynthesizedAppOwnedUIEntries(cfg *config.Config, added map[string]struct{}) {
+func clearSynthesizedPluginOwnedUIEntries(cfg *config.Config, added map[string]struct{}) {
 	if cfg == nil || len(added) == 0 || cfg.Providers.UI == nil {
 		return
 	}
@@ -1345,18 +1330,18 @@ func ownedUIEntryFromManifest(manifestPath, manifestVersion string, ownedUI *pro
 	return entry, nil
 }
 
-func validateSynthesizedAppUIEntry(appName string, existing, expected *config.UIEntry) error {
+func validateSynthesizedPluginUIEntry(pluginName string, existing, expected *config.UIEntry) error {
 	if existing == nil || expected == nil {
 		return nil
 	}
 	if existing.Disabled {
-		return fmt.Errorf("config validation: apps.%s owned ui conflicts with disabled providers.ui.%s", appName, appName)
+		return fmt.Errorf("config validation: plugins.%s owned ui conflicts with disabled providers.ui.%s", pluginName, pluginName)
 	}
 	if current := strings.TrimSpace(existing.Source.Ref); current != "" && current != expected.Source.Ref {
-		return fmt.Errorf("config validation: apps.%s owned ui conflicts with providers.ui.%s.source.ref", appName, appName)
+		return fmt.Errorf("config validation: plugins.%s owned ui conflicts with providers.ui.%s.source.ref", pluginName, pluginName)
 	}
 	if current := strings.TrimSpace(existing.Source.Version); current != "" && current != expected.Source.Version {
-		return fmt.Errorf("config validation: apps.%s owned ui conflicts with providers.ui.%s.source.version", appName, appName)
+		return fmt.Errorf("config validation: plugins.%s owned ui conflicts with providers.ui.%s.source.version", pluginName, pluginName)
 	}
 	currentAuth := ""
 	if existing.Source.Auth != nil {
@@ -1367,16 +1352,16 @@ func validateSynthesizedAppUIEntry(appName string, existing, expected *config.UI
 		expectedAuth = strings.TrimSpace(expected.Source.Auth.Token)
 	}
 	if currentAuth != "" && currentAuth != expectedAuth {
-		return fmt.Errorf("config validation: apps.%s owned ui conflicts with providers.ui.%s.source.auth.token", appName, appName)
+		return fmt.Errorf("config validation: plugins.%s owned ui conflicts with providers.ui.%s.source.auth.token", pluginName, pluginName)
 	}
 	if current := strings.TrimSpace(existing.Source.Path); current != "" && current != expected.Source.Path {
-		return fmt.Errorf("config validation: apps.%s owned ui conflicts with providers.ui.%s.source.path", appName, appName)
+		return fmt.Errorf("config validation: plugins.%s owned ui conflicts with providers.ui.%s.source.path", pluginName, pluginName)
 	}
 	if current := strings.TrimSpace(existing.Path); current != "" && current != expected.Path {
-		return fmt.Errorf("config validation: apps.%s.path %q conflicts with providers.ui.%s.path", appName, expected.Path, appName)
+		return fmt.Errorf("config validation: plugins.%s.mountPath %q conflicts with providers.ui.%s.path", pluginName, expected.Path, pluginName)
 	}
 	if current := strings.TrimSpace(existing.AuthorizationPolicy); current != "" && current != expected.AuthorizationPolicy {
-		return fmt.Errorf("config validation: apps.%s.authorizationPolicy conflicts with providers.ui.%s.authorizationPolicy", appName, appName)
+		return fmt.Errorf("config validation: plugins.%s.authorizationPolicy conflicts with providers.ui.%s.authorizationPolicy", pluginName, pluginName)
 	}
 	return nil
 }

--- a/gestaltd/internal/operator/lifecycle_test.go
+++ b/gestaltd/internal/operator/lifecycle_test.go
@@ -324,7 +324,7 @@ func TestLoadForExecutionAtPath_ResolvesLocalMountedWebUIWithoutLockfile(t *test
 			wantPath: "/create-customer-roadmap-review",
 		},
 		{
-			name: "app bound mounted ui",
+			name: "plugin mount binds explicit ui",
 			uiConfigYAML: `  ui:
     roadmap:
       source:
@@ -333,14 +333,11 @@ plugins:
     roadmap:
       source:
         path: ./plugin/manifest.yaml
+      ui: roadmap
+      mountPath: /create-customer-roadmap-review
+      authorizationPolicy: roadmap_policy
 `,
-			extraYAML: `apps:
-  roadmap_review:
-    plugin: roadmap
-    ui: roadmap
-    path: /create-customer-roadmap-review
-    authorizationPolicy: roadmap_policy
-authorization:
+			extraYAML: `authorization:
   policies:
     roadmap_policy:
       default: deny
@@ -353,7 +350,7 @@ authorization:
 			wantPolicy: "roadmap_policy",
 		},
 		{
-			name: "disabled explicit app binding does not suppress ui path validation",
+			name: "disabled explicit plugin mount does not suppress ui path validation",
 			uiConfigYAML: `  ui:
     roadmap:
       source:
@@ -364,51 +361,41 @@ authorization:
       path: /console
 plugins:
     roadmap:
+      disabled: true
       source:
         path: ./plugin/manifest.yaml
+      ui: roadmap
+      mountPath: /create-customer-roadmap-review
+      authorizationPolicy: roadmap_policy
 `,
-			uiKey: "roadmap",
-			extraYAML: `apps:
-  roadmap_review:
-    disabled: true
-    plugin: roadmap
-    ui: roadmap
-    path: /create-customer-roadmap-review
-    authorizationPolicy: roadmap_policy
-`,
+			uiKey:   "roadmap",
 			wantErr: "config validation: ui.roadmap.path: path is required",
 		},
 		{
-			name: "disabled app does not suppress matching ui path validation",
+			name: "disabled plugin does not suppress matching ui path validation",
 			uiConfigYAML: `  ui:
-    roadmap_review:
+    roadmap:
       source:
         path: ./webui/manifest.yaml
 plugins:
     roadmap:
+      disabled: true
       source:
         path: ./plugin/manifest.yaml
+      mountPath: /create-customer-roadmap-review
 `,
-			extraYAML: `apps:
-  roadmap_review:
-    disabled: true
-    plugin: roadmap
-`,
-			wantErr: "config validation: ui.roadmap_review.path: path is required",
+			wantErr: "config validation: ui.roadmap.path: path is required",
 		},
 		{
-			name: "plugin owned ui via app binding",
+			name: "plugin owned ui via plugin mount",
 			uiConfigYAML: `plugins:
     roadmap:
       source:
         path: ./plugin/manifest.yaml
+      mountPath: /create-customer-roadmap-review
+      authorizationPolicy: roadmap_policy
 `,
-			extraYAML: `apps:
-  roadmap_review:
-    plugin: roadmap
-    path: /create-customer-roadmap-review
-    authorizationPolicy: roadmap_policy
-authorization:
+			extraYAML: `authorization:
   policies:
     roadmap_policy:
       default: deny
@@ -416,7 +403,7 @@ authorization:
         - email: viewer@example.test
           role: viewer
 `,
-			uiKey:       "roadmap_review",
+			uiKey:       "roadmap",
 			wantPath:    "/create-customer-roadmap-review",
 			wantPolicy:  "roadmap_policy",
 			ownedUIPath: "../webui/manifest.yaml",
@@ -424,20 +411,17 @@ authorization:
 		{
 			name: "plugin owned ui with same-name ui overlay",
 			uiConfigYAML: `  ui:
-    roadmap_review:
+    roadmap:
       source:
         path: ./webui/manifest.yaml
 plugins:
     roadmap:
       source:
         path: ./plugin/manifest.yaml
+      mountPath: /create-customer-roadmap-review
+      authorizationPolicy: roadmap_policy
 `,
-			extraYAML: `apps:
-  roadmap_review:
-    plugin: roadmap
-    path: /create-customer-roadmap-review
-    authorizationPolicy: roadmap_policy
-authorization:
+			extraYAML: `authorization:
   policies:
     roadmap_policy:
       default: deny
@@ -445,7 +429,7 @@ authorization:
         - email: viewer@example.test
           role: viewer
 `,
-			uiKey:       "roadmap_review",
+			uiKey:       "roadmap",
 			wantPath:    "/create-customer-roadmap-review",
 			wantPolicy:  "roadmap_policy",
 			ownedUIPath: "../webui/manifest.yaml",
@@ -453,7 +437,7 @@ authorization:
 		{
 			name: "disabled same-name ui overlay is rejected",
 			uiConfigYAML: `  ui:
-    roadmap_review:
+    roadmap:
       disabled: true
       source:
         path: ./webui/manifest.yaml
@@ -461,13 +445,9 @@ plugins:
     roadmap:
       source:
         path: ./plugin/manifest.yaml
+      mountPath: /create-customer-roadmap-review
 `,
-			extraYAML: `apps:
-  roadmap_review:
-    plugin: roadmap
-    path: /create-customer-roadmap-review
-`,
-			wantErr:     "config validation: apps.roadmap_review owned ui conflicts with disabled providers.ui.roadmap_review",
+			wantErr:     "config validation: plugins.roadmap owned ui conflicts with disabled providers.ui.roadmap",
 			ownedUIPath: "../webui/manifest.yaml",
 		},
 	}
@@ -635,7 +615,7 @@ func TestLoadForExecutionAtPath_ReinitializesManagedPluginOwnedUIWhenUILockEntry
 
 	cfgPath := filepath.Join(dir, "config.yaml")
 	cfg := requiredComponentConfigYAML(t, dir, filepath.Join(dir, "gestalt.db")) + `  ui:
-    roadmap_review:
+    roadmap:
       source:
         ref: ` + webUIRef + `
         version: ` + version + `
@@ -645,12 +625,9 @@ plugins:
       source:
         ref: ` + pluginRef + `
         version: ` + version + `
+      mountPath: /create-customer-roadmap-review
 ` + `server:
 ` + requiredServerDatastoreYAML() + `  encryptionKey: aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa
-apps:
-  roadmap_review:
-    plugin: roadmap
-    path: /create-customer-roadmap-review
 `
 	if err := os.WriteFile(cfgPath, []byte(cfg), 0o644); err != nil {
 		t.Fatalf("WriteFile config: %v", err)
@@ -669,7 +646,7 @@ apps:
 	if err != nil {
 		t.Fatalf("InitAtPath: %v", err)
 	}
-	delete(lock.UIs, "roadmap_review")
+	delete(lock.UIs, "roadmap")
 	if err := WriteLockfile(filepath.Join(dir, InitLockfileName), lock); err != nil {
 		t.Fatalf("WriteLockfile: %v", err)
 	}
@@ -678,9 +655,9 @@ apps:
 	if err != nil {
 		t.Fatalf("LoadForExecutionAtPath: %v", err)
 	}
-	entry := loaded.Providers.UI["roadmap_review"]
+	entry := loaded.Providers.UI["roadmap"]
 	if entry == nil || entry.ResolvedManifest == nil {
-		t.Fatalf("Resolved app-owned UI = %+v", entry)
+		t.Fatalf("Resolved plugin-owned UI = %+v", entry)
 	}
 	if entry.Path != "/create-customer-roadmap-review" {
 		t.Fatalf("entry.Path = %q", entry.Path)
@@ -690,8 +667,8 @@ apps:
 	if err != nil {
 		t.Fatalf("ReadLockfile: %v", err)
 	}
-	if _, ok := rewrittenLock.UIs["roadmap_review"]; !ok {
-		t.Fatalf("lock.UIs = %#v, want roadmap_review entry restored", rewrittenLock.UIs)
+	if _, ok := rewrittenLock.UIs["roadmap"]; !ok {
+		t.Fatalf("lock.UIs = %#v, want roadmap entry restored", rewrittenLock.UIs)
 	}
 }
 
@@ -783,12 +760,9 @@ func TestLoadForExecutionAtPath_ResolvesManagedPluginOwnedUIFromManagedPath(t *t
       source:
         ref: ` + pluginRef + `
         version: ` + version + `
+      mountPath: /create-customer-roadmap-review
 ` + `server:
 ` + requiredServerDatastoreYAML() + `  encryptionKey: aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa
-apps:
-  roadmap_review:
-    plugin: roadmap
-    path: /create-customer-roadmap-review
 `
 	if err := os.WriteFile(cfgPath, []byte(cfg), 0o644); err != nil {
 		t.Fatalf("WriteFile config: %v", err)
@@ -803,9 +777,9 @@ apps:
 	if err != nil {
 		t.Fatalf("LoadForExecutionAtPath: %v", err)
 	}
-	entry := loaded.Providers.UI["roadmap_review"]
+	entry := loaded.Providers.UI["roadmap"]
 	if entry == nil || entry.ResolvedManifest == nil {
-		t.Fatalf("Resolved app-owned UI = %+v", entry)
+		t.Fatalf("Resolved plugin-owned UI = %+v", entry)
 	}
 	if entry.Path != "/create-customer-roadmap-review" {
 		t.Fatalf("entry.Path = %q", entry.Path)
@@ -882,12 +856,9 @@ func TestLoadForExecutionAtPath_ReinitializesManagedPluginOwnedUIWhenPluginLockI
       source:
         ref: ` + pluginRef + `
         version: ` + version + `
+      mountPath: /create-customer-roadmap-review
 ` + `server:
 ` + requiredServerDatastoreYAML() + `  encryptionKey: aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa
-apps:
-  roadmap_review:
-    plugin: roadmap
-    path: /create-customer-roadmap-review
 `
 		if err := os.WriteFile(cfgPath, []byte(cfg), 0o644); err != nil {
 			t.Fatalf("WriteFile config: %v", err)
@@ -920,9 +891,9 @@ apps:
 	if err != nil {
 		t.Fatalf("LoadForExecutionAtPath: %v", err)
 	}
-	entry := loaded.Providers.UI["roadmap_review"]
+	entry := loaded.Providers.UI["roadmap"]
 	if entry == nil || entry.ResolvedManifest == nil {
-		t.Fatalf("Resolved app-owned UI = %+v", entry)
+		t.Fatalf("Resolved plugin-owned UI = %+v", entry)
 	}
 	if got := entry.ResolvedManifest.Version; got != newVersion {
 		t.Fatalf("ResolvedManifest.Version = %q, want %q", got, newVersion)
@@ -935,12 +906,12 @@ apps:
 	if err != nil {
 		t.Fatalf("ReadLockfile: %v", err)
 	}
-	lockEntry, ok := rewrittenLock.UIs["roadmap_review"]
+	lockEntry, ok := rewrittenLock.UIs["roadmap"]
 	if !ok {
-		t.Fatalf("lock.UIs = %#v, want roadmap_review entry restored", rewrittenLock.UIs)
+		t.Fatalf("lock.UIs = %#v, want roadmap entry restored", rewrittenLock.UIs)
 	}
 	if got := lockEntry.Version; got != newVersion {
-		t.Fatalf("lock.UIs[roadmap_review].Version = %q, want %q", got, newVersion)
+		t.Fatalf("lock.UIs[roadmap].Version = %q, want %q", got, newVersion)
 	}
 }
 
@@ -1004,12 +975,9 @@ func TestInitAtPath_RejectsManagedPluginOwnedUIPathOutsidePackage(t *testing.T) 
       source:
         ref: ` + pluginRef + `
         version: ` + version + `
+      mountPath: /create-customer-roadmap-review
 server:
 ` + requiredServerDatastoreYAML() + `  encryptionKey: aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa
-apps:
-  roadmap_review:
-    plugin: roadmap
-    path: /create-customer-roadmap-review
 `
 	if err := os.WriteFile(cfgPath, []byte(cfg), 0o644); err != nil {
 		t.Fatalf("WriteFile config: %v", err)


### PR DESCRIPTION
## Summary

This removes the top-level `apps` binding layer and makes plugins own mounted UI configuration directly.

The new interface is:

### Go

```go
type ProviderEntry struct {
    AuthorizationPolicy string `yaml:"authorizationPolicy,omitempty"`
    MountPath           string `yaml:"mountPath,omitempty"`
    UI                  string `yaml:"ui,omitempty"`
    // ... existing plugin fields
}
```

### YAML

Explicit UI binding:

```yaml
plugins:
  workplace_hub:
    source:
      path: ./workplace-hub/plugin/manifest.yaml
    ui: workplace_hub
    mountPath: /workplace-hub
    authorizationPolicy: workplace_hub
```

Manifest-owned UI binding:

```yaml
plugins:
  workplace_hub:
    source:
      path: ./workplace-hub/plugin/manifest.yaml
    mountPath: /workplace-hub
    authorizationPolicy: workplace_hub
```

`providers.ui` still supports direct mounts, and it can still supply named UI bundles when `plugins.<name>.ui` points at one.

## Implementation

- removes `apps` from config parsing and validation
- adds `plugins.<name>.mountPath` and optional `plugins.<name>.ui`
- updates config normalization so plugin mount bindings flow into resolved UI mounts
- updates lifecycle synthesis for manifest-owned plugin UIs
- updates config/operator tests to use the new interface
- updates docs and reference pages to describe the new model

## Validation

- `go test ./internal/config ./internal/operator`
- `go test ./...`
- `git diff --check`
