### PR TITLE
[codex] Preserve plugin mount collision checks for UI overlays

### DIFF
--- a/gestaltd/internal/config/config_test.go
+++ b/gestaltd/internal/config/config_test.go
@@ -1109,6 +1109,40 @@ server:
 		}
 	})
 
+	t.Run("same-name plugin-owned ui overlay only suppresses duplicate mount checks", func(t *testing.T) {
+		t.Parallel()
+
+		path := mustWriteConfigFile(t, `
+plugins:
+  roadmap:
+    source:
+      path: ./plugin/manifest.yaml
+    mountPath: /api
+providers:
+  ui:
+    roadmap:
+      source:
+        path: ./web/roadmap/manifest.yaml
+      path: /roadmap
+  indexeddb:
+    sqlite:
+      source:
+        path: ./providers/datastore/sqlite
+server:
+  providers:
+    indexeddb: sqlite
+  encryptionKey: server-key
+`)
+
+		_, err := Load(path)
+		if err == nil {
+			t.Fatal("Load: expected error, got nil")
+		}
+		if !strings.Contains(err.Error(), `plugins.roadmap.mountPath "/api" conflicts with reserved path "/api"`) {
+			t.Fatalf("unexpected error: %v", err)
+		}
+	})
+
 	t.Run("prefix collision is rejected", func(t *testing.T) {
 		t.Parallel()
 

--- a/gestaltd/internal/config/config_validate.go
+++ b/gestaltd/internal/config/config_validate.go
@@ -674,7 +674,7 @@ func validateMountedUICollisions(cfg *Config, pluginOwnedUIRefs map[string]struc
 			continue
 		}
 		if _, ok := pluginOwnedUIRefs[name]; ok {
-			if ui := cfg.Providers.UI[name]; ui != nil && !ui.Disabled && strings.TrimSpace(ui.Path) != "" {
+			if ui := cfg.Providers.UI[name]; ui != nil && !ui.Disabled && mountedUIPathsMatch(ui.Path, entry.MountPath) {
 				continue
 			}
 		}
@@ -704,6 +704,17 @@ func validateMountedUICollisions(cfg *Config, pluginOwnedUIRefs map[string]struc
 		}
 	}
 	return nil
+}
+
+func mountedUIPathsMatch(uiPath, mountPath string) bool {
+	if strings.TrimSpace(uiPath) == "" {
+		return false
+	}
+	normalizedMountPath, err := normalizeMountedUIPath(mountPath)
+	if err != nil {
+		return false
+	}
+	return uiPath == normalizedMountPath
 }
 
 func mountedUIPathsConflict(a, b string) bool {


### PR DESCRIPTION
## Summary
- preserve plugin `mountPath` collision validation for plugin-owned same-name `providers.ui` overlays unless the overlay already carries the same normalized path
- normalize the plugin mount path before deciding whether the overlay has already represented that mount
- add a regression test covering a same-name plugin-owned overlay with its own `providers.ui.<name>.path`

## Why
PR #985 moved mounted UI bindings onto plugins, but the collision validator skipped plugin-owned mounts whenever a same-name `providers.ui` entry already had a path. That was broader than the old behavior and could suppress reserved/prefix collision checks for the plugin mount itself.

## Impact
Config loading now continues to validate plugin-owned mount prefixes even when a same-name overlay exists, unless that overlay is already representing the exact same normalized mount path.

## Validation
- `go test ./internal/config`
