### PR TITLE
[codex] derive locked runtime paths from prepared installs

### DIFF
--- a/gestaltd/internal/operator/lifecycle.go
+++ b/gestaltd/internal/operator/lifecycle.go
@@ -577,6 +577,39 @@ func componentDestDir(paths initPaths, kind config.HostProviderKind, name string
 	}
 }
 
+type preparedInstall struct {
+	manifestPath   string
+	executablePath string
+	assetRootPath  string
+	manifest       *providermanifestv1.Manifest
+}
+
+func inspectPreparedInstall(destDir string) (*preparedInstall, error) {
+	manifestPath, err := providerpkg.FindManifestFile(destDir)
+	if err != nil {
+		return nil, err
+	}
+	_, manifest, err := providerpkg.ReadManifestFile(manifestPath)
+	if err != nil {
+		return nil, err
+	}
+
+	install := &preparedInstall{
+		manifestPath: manifestPath,
+		manifest:     manifest,
+	}
+	if entry := providerpkg.EntrypointForKind(manifest, ""); entry != nil {
+		if strings.TrimSpace(entry.ArtifactPath) == "" {
+			return nil, fmt.Errorf("manifest entrypoint artifact_path is required")
+		}
+		install.executablePath = filepath.Join(destDir, filepath.FromSlash(entry.ArtifactPath))
+	}
+	if manifest != nil && manifest.Spec != nil && strings.TrimSpace(manifest.Spec.AssetRoot) != "" {
+		install.assetRootPath = filepath.Join(destDir, filepath.FromSlash(manifest.Spec.AssetRoot))
+	}
+	return install, nil
+}
+
 func providerManifestKind(kind config.HostProviderKind) string {
 	switch kind {
 	case config.HostProviderKindAuth:
@@ -664,7 +697,7 @@ func lockMatchesConfig(cfg *config.Config, paths initPaths, lock *Lockfile) bool
 			continue
 		}
 		lockEntry, found := lock.Providers[name]
-		if !lockEntryMatches(paths, name, entry, lockEntry, found) {
+		if !lockEntryMatches(paths, name, entry, lockEntry, found, providerDestDir(paths, name)) {
 			return false
 		}
 	}
@@ -675,7 +708,7 @@ func lockMatchesConfig(cfg *config.Config, paths initPaths, lock *Lockfile) bool
 				continue
 			}
 			lockEntry, found := lockEntries[name]
-			if !lockEntryMatches(paths, name, entry, lockEntry, found) {
+			if !lockEntryMatches(paths, name, entry, lockEntry, found, componentDestDir(paths, collection.kind, name)) {
 				return false
 			}
 		}
@@ -685,7 +718,7 @@ func lockMatchesConfig(cfg *config.Config, paths initPaths, lock *Lockfile) bool
 			continue
 		}
 		lockEntry, found := lock.IndexedDBs[name]
-		if !lockEntryMatches(paths, name, entry, lockEntry, found) {
+		if !lockEntryMatches(paths, name, entry, lockEntry, found, indexeddbDestDir(paths, name)) {
 			return false
 		}
 	}
@@ -701,12 +734,17 @@ func lockMatchesConfig(cfg *config.Config, paths initPaths, lock *Lockfile) bool
 		if err != nil || lockEntry.Fingerprint != fingerprint {
 			return false
 		}
-		manifestPath := resolveLockPath(paths.artifactsDir, lockEntry.Manifest)
-		if _, err := os.Stat(manifestPath); err != nil {
+		install, err := inspectPreparedInstall(uiDestDir(paths, name))
+		if err != nil {
 			return false
 		}
-		assetRootPath := resolveLockPath(paths.artifactsDir, lockEntry.AssetRoot)
-		if _, err := os.Stat(assetRootPath); err != nil {
+		if !preparedManifestMatchesLock(lockEntry, install.manifest) {
+			return false
+		}
+		if install.assetRootPath == "" {
+			return false
+		}
+		if _, err := os.Stat(install.assetRootPath); err != nil {
 			return false
 		}
 	}
@@ -736,7 +774,7 @@ func NamedUIProviderFingerprint(name string, entry *config.ProviderEntry) (strin
 	return ProviderFingerprint("ui:"+name, entry, "")
 }
 
-func lockEntryMatches(paths initPaths, name string, providerEntry *config.ProviderEntry, entry LockEntry, found bool) bool {
+func lockEntryMatches(paths initPaths, name string, providerEntry *config.ProviderEntry, entry LockEntry, found bool, destDir string) bool {
 	if !found {
 		return false
 	}
@@ -753,13 +791,15 @@ func lockEntryMatches(paths initPaths, name string, providerEntry *config.Provid
 			return false
 		}
 	}
-	manifestPath := resolveLockPath(paths.artifactsDir, entry.Manifest)
-	if _, err := os.Stat(manifestPath); err != nil {
+	install, err := inspectPreparedInstall(destDir)
+	if err != nil {
 		return false
 	}
-	if entry.Executable != "" {
-		executablePath := resolveLockPath(paths.artifactsDir, entry.Executable)
-		if _, err := os.Stat(executablePath); err != nil {
+	if !preparedManifestMatchesLock(entry, install.manifest) {
+		return false
+	}
+	if install.executablePath != "" {
+		if _, err := os.Stat(install.executablePath); err != nil {
 			return false
 		}
 	}
@@ -1253,18 +1293,20 @@ func synthesizeLockedSourcePluginOwnedUIEntries(cfg *config.Config, paths initPa
 			continue
 		}
 		lockEntry, ok := lock.Providers[pluginName]
-		if !ok || strings.TrimSpace(lockEntry.Manifest) == "" {
+		if !ok {
 			continue
 		}
-		manifestPath := resolveLockPath(paths.artifactsDir, lockEntry.Manifest)
-		_, manifest, err := providerpkg.ReadManifestFile(manifestPath)
+		install, err := inspectPreparedInstall(providerDestDir(paths, pluginName))
 		if err != nil {
 			return added, fmt.Errorf("prepare manifest for provider %q: %w", pluginName, err)
 		}
-		if manifest == nil || manifest.Spec == nil || manifest.Spec.UI == nil {
+		if !preparedManifestMatchesLock(lockEntry, install.manifest) {
+			return added, fmt.Errorf("prepared manifest for provider %q is missing or stale", pluginName)
+		}
+		if install.manifest == nil || install.manifest.Spec == nil || install.manifest.Spec.UI == nil {
 			continue
 		}
-		entry, err := ownedUIEntryFromManifest(manifestPath, manifest.Version, manifest.Spec.UI)
+		entry, err := ownedUIEntryFromManifest(install.manifestPath, install.manifest.Version, install.manifest.Spec.UI)
 		if err != nil {
 			return added, fmt.Errorf("plugin %q ui: %w", pluginName, err)
 		}
@@ -1383,23 +1425,13 @@ func (l *Lifecycle) applyConfiguredUIProvider(paths initPaths, lockEntry *LockUI
 		if err != nil || lockEntry.Fingerprint != fingerprint {
 			return "", fmt.Errorf("prepared artifact for %s is missing or stale; run `gestaltd init --config %s`", subject, paths.configPath)
 		}
-		manifestPath := resolveLockPath(paths.artifactsDir, lockEntry.Manifest)
-		assetRootPath := resolveLockPath(paths.artifactsDir, lockEntry.AssetRoot)
-		needMaterialize := false
-		if _, err := os.Stat(manifestPath); err != nil {
+		install, err := inspectPreparedInstall(destDir)
+		needMaterialize := err != nil || !preparedManifestMatchesLock(*lockEntry, install.manifest)
+		if !needMaterialize && install.assetRootPath == "" {
 			needMaterialize = true
 		}
 		if !needMaterialize {
-			if _, err := os.Stat(assetRootPath); err != nil {
-				needMaterialize = true
-			}
-		}
-		if !needMaterialize {
-			_, manifest, err := providerpkg.ReadManifestFile(manifestPath)
-			if err != nil {
-				return "", fmt.Errorf("read prepared manifest for %s: %w", subject, err)
-			}
-			if !preparedManifestMatchesLock(*lockEntry, manifest) {
+			if _, err := os.Stat(install.assetRootPath); err != nil {
 				needMaterialize = true
 			}
 		}
@@ -1407,21 +1439,21 @@ func (l *Lifecycle) applyConfiguredUIProvider(paths initPaths, lockEntry *LockUI
 			if err := l.materializeLockedUIProvider(context.Background(), paths, provider, *lockEntry, destDir, locked); err != nil {
 				return "", err
 			}
+			install, err = inspectPreparedInstall(destDir)
+			if err != nil {
+				return "", fmt.Errorf("read prepared manifest for %s: %w", subject, err)
+			}
 		}
-		if _, err := os.Stat(manifestPath); err != nil {
-			return "", fmt.Errorf("prepared manifest for %s not found at %s", subject, manifestPath)
+		if install.assetRootPath == "" {
+			return "", fmt.Errorf("prepared asset root for %s not found in %s", subject, destDir)
 		}
-		if _, err := os.Stat(assetRootPath); err != nil {
-			return "", fmt.Errorf("prepared asset root for %s not found at %s", subject, assetRootPath)
+		if _, err := os.Stat(install.assetRootPath); err != nil {
+			return "", fmt.Errorf("prepared asset root for %s not found at %s", subject, install.assetRootPath)
 		}
-		_, manifest, err := providerpkg.ReadManifestFile(manifestPath)
-		if err != nil {
-			return "", fmt.Errorf("read prepared manifest for %s: %w", subject, err)
-		}
-		if err := bindResolvedUIManifest(provider, manifestPath, manifest, configMap); err != nil {
+		if err := bindResolvedUIManifest(provider, install.manifestPath, install.manifest, configMap); err != nil {
 			return "", err
 		}
-		return assetRootPath, nil
+		return install.assetRootPath, nil
 	case provider.HasLocalSource():
 		var resolvedAssetRoot string
 		if err := applyLocalUIManifest(provider, configMap, &resolvedAssetRoot); err != nil {
@@ -1567,23 +1599,11 @@ func (l *Lifecycle) applyLockedProviderEntry(paths initPaths, lock *Lockfile, na
 		return fmt.Errorf("prepared artifact for provider %q is missing or stale; run `gestaltd init --config %s`", name, paths.configPath)
 	}
 
-	manifestPath := resolveLockPath(paths.artifactsDir, entry.Manifest)
-	executablePath := resolveLockPath(paths.artifactsDir, entry.Executable)
-	needMaterialize := false
-	if _, err := os.Stat(manifestPath); err != nil {
-		needMaterialize = true
-	}
-	if !needMaterialize && entry.Executable != "" {
-		if _, err := os.Stat(executablePath); err != nil {
-			needMaterialize = true
-		}
-	}
-	if !needMaterialize {
-		_, manifest, err := providerpkg.ReadManifestFile(manifestPath)
-		if err != nil {
-			return fmt.Errorf("read prepared manifest for provider %q: %w", name, err)
-		}
-		if !preparedManifestMatchesLock(entry, manifest) {
+	destDir := providerDestDir(paths, name)
+	install, err := inspectPreparedInstall(destDir)
+	needMaterialize := err != nil || !preparedManifestMatchesLock(entry, install.manifest)
+	if !needMaterialize && install.executablePath != "" {
+		if _, err := os.Stat(install.executablePath); err != nil {
 			needMaterialize = true
 		}
 	}
@@ -1591,27 +1611,23 @@ func (l *Lifecycle) applyLockedProviderEntry(paths initPaths, lock *Lockfile, na
 		if err := l.materializeLockedProvider(context.Background(), paths, name, plugin, entry, locked); err != nil {
 			return err
 		}
+		install, err = inspectPreparedInstall(destDir)
+		if err != nil {
+			return fmt.Errorf("read prepared manifest for provider %q: %w", name, err)
+		}
 	}
-	if _, err := os.Stat(manifestPath); err != nil {
-		return fmt.Errorf("prepared manifest for provider %q not found at %s; run `gestaltd init --config %s`", name, manifestPath, paths.configPath)
-	}
-
-	_, manifest, err := providerpkg.ReadManifestFile(manifestPath)
-	if err != nil {
-		return fmt.Errorf("read prepared manifest for provider %q: %w", name, err)
-	}
-	if err := bindResolvedProviderManifest(name, plugin, manifestPath, manifest, configMap); err != nil {
+	if err := bindResolvedProviderManifest(name, plugin, install.manifestPath, install.manifest, configMap); err != nil {
 		return err
 	}
-	if entry.Executable != "" {
-		if _, err := os.Stat(executablePath); err != nil {
-			return fmt.Errorf("prepared executable for provider %q not found at %s; run `gestaltd init --config %s`", name, executablePath, paths.configPath)
+	if install.executablePath != "" {
+		if _, err := os.Stat(install.executablePath); err != nil {
+			return fmt.Errorf("prepared executable for provider %q not found at %s; run `gestaltd init --config %s`", name, install.executablePath, paths.configPath)
 		}
-		args, err := providerEntrypointArgs(manifest)
+		args, err := providerEntrypointArgs(install.manifest)
 		if err != nil {
 			return fmt.Errorf("resolve entrypoint for provider %q: %w", name, err)
 		}
-		plugin.Command = executablePath
+		plugin.Command = install.executablePath
 		plugin.Args = append([]string(nil), args...)
 	}
 	return nil
@@ -1629,23 +1645,13 @@ func (l *Lifecycle) applyLockedComponentEntry(paths initPaths, entry *LockEntry,
 		return fmt.Errorf("prepared artifact for %s %q is missing or stale; run `gestaltd init --config %s`", kind, name, paths.configPath)
 	}
 
-	manifestPath := resolveLockPath(paths.artifactsDir, entry.Manifest)
-	executablePath := resolveLockPath(paths.artifactsDir, entry.Executable)
-	needMaterialize := false
-	if _, err := os.Stat(manifestPath); err != nil {
+	install, err := inspectPreparedInstall(destDir)
+	needMaterialize := err != nil || !preparedManifestMatchesLock(*entry, install.manifest)
+	if !needMaterialize && install.executablePath == "" {
 		needMaterialize = true
 	}
 	if !needMaterialize {
-		if _, err := os.Stat(executablePath); err != nil {
-			needMaterialize = true
-		}
-	}
-	if !needMaterialize {
-		_, manifest, err := providerpkg.ReadManifestFile(manifestPath)
-		if err != nil {
-			return fmt.Errorf("read prepared manifest for %s %q: %w", kind, name, err)
-		}
-		if !preparedManifestMatchesLock(*entry, manifest) {
+		if _, err := os.Stat(install.executablePath); err != nil {
 			needMaterialize = true
 		}
 	}
@@ -1653,26 +1659,25 @@ func (l *Lifecycle) applyLockedComponentEntry(paths initPaths, entry *LockEntry,
 		if err := l.materializeLockedComponent(context.Background(), paths, kind, name, plugin, *entry, destDir, locked); err != nil {
 			return err
 		}
+		install, err = inspectPreparedInstall(destDir)
+		if err != nil {
+			return fmt.Errorf("read prepared manifest for %s %q: %w", kind, name, err)
+		}
 	}
-	if _, err := os.Stat(manifestPath); err != nil {
-		return fmt.Errorf("prepared manifest for %s %q not found at %s; run `gestaltd init --config %s`", kind, name, manifestPath, paths.configPath)
+	if install.executablePath == "" {
+		return fmt.Errorf("prepared executable for %s %q not found in %s; run `gestaltd init --config %s`", kind, name, destDir, paths.configPath)
 	}
-
-	_, manifest, err := providerpkg.ReadManifestFile(manifestPath)
-	if err != nil {
-		return fmt.Errorf("read prepared manifest for %s %q: %w", kind, name, err)
-	}
-	if err := bindResolvedComponentManifest(kind, name, plugin, manifestPath, manifest, configMap); err != nil {
+	if err := bindResolvedComponentManifest(kind, name, plugin, install.manifestPath, install.manifest, configMap); err != nil {
 		return err
 	}
-	if _, err := os.Stat(executablePath); err != nil {
-		return fmt.Errorf("prepared executable for %s %q not found at %s; run `gestaltd init --config %s`", kind, name, executablePath, paths.configPath)
+	if _, err := os.Stat(install.executablePath); err != nil {
+		return fmt.Errorf("prepared executable for %s %q not found at %s; run `gestaltd init --config %s`", kind, name, install.executablePath, paths.configPath)
 	}
-	args, err := componentEntrypointArgs(manifest, kind)
+	args, err := componentEntrypointArgs(install.manifest, kind)
 	if err != nil {
 		return fmt.Errorf("resolve entrypoint for %s %q: %w", kind, name, err)
 	}
-	plugin.Command = executablePath
+	plugin.Command = install.executablePath
 	plugin.Args = append([]string(nil), args...)
 	return nil
 }

--- a/gestaltd/internal/operator/lifecycle_test.go
+++ b/gestaltd/internal/operator/lifecycle_test.go
@@ -647,6 +647,9 @@ plugins:
 		t.Fatalf("InitAtPath: %v", err)
 	}
 	delete(lock.UIs, "roadmap")
+	pluginLock := lock.Providers["roadmap"]
+	pluginLock.Manifest = ""
+	lock.Providers["roadmap"] = pluginLock
 	if err := WriteLockfile(filepath.Join(dir, InitLockfileName), lock); err != nil {
 		t.Fatalf("WriteLockfile: %v", err)
 	}
@@ -773,27 +776,43 @@ func TestLoadForExecutionAtPath_ResolvesManagedPluginOwnedUIFromManagedPath(t *t
 		t.Fatalf("InitAtPath: %v", err)
 	}
 
-	loaded, _, err := lc.LoadForExecutionAtPath(cfgPath, false)
+	lock, err := ReadLockfile(filepath.Join(dir, InitLockfileName))
 	if err != nil {
-		t.Fatalf("LoadForExecutionAtPath: %v", err)
+		t.Fatalf("ReadLockfile: %v", err)
 	}
-	entry := loaded.Providers.UI["roadmap"]
-	if entry == nil || entry.ResolvedManifest == nil {
-		t.Fatalf("Resolved plugin-owned UI = %+v", entry)
+	pluginLock := lock.Providers["roadmap"]
+	pluginLock.Manifest = ""
+	lock.Providers["roadmap"] = pluginLock
+	if err := WriteLockfile(filepath.Join(dir, InitLockfileName), lock); err != nil {
+		t.Fatalf("WriteLockfile: %v", err)
 	}
-	if entry.Path != "/create-customer-roadmap-review" {
-		t.Fatalf("entry.Path = %q", entry.Path)
-	}
-	if got, want := filepath.ToSlash(entry.ResolvedManifestPath), filepath.ToSlash(filepath.Join("_owned_ui", "roadmap-ui", providerpkg.ManifestFile)); !strings.HasSuffix(got, want) {
-		t.Fatalf("ResolvedManifestPath = %q, want suffix %q", got, want)
-	}
-	if got, want := filepath.ToSlash(entry.ResolvedAssetRoot), filepath.ToSlash(filepath.Join("_owned_ui", "roadmap-ui", "dist")); !strings.HasSuffix(got, want) {
-		t.Fatalf("ResolvedAssetRoot = %q, want suffix %q", got, want)
+
+	for _, locked := range []bool{false, true} {
+		loaded, _, err := lc.LoadForExecutionAtPath(cfgPath, locked)
+		if err != nil {
+			t.Fatalf("LoadForExecutionAtPath(locked=%t): %v", locked, err)
+		}
+		entry := loaded.Providers.UI["roadmap"]
+		if entry == nil || entry.ResolvedManifest == nil {
+			t.Fatalf("Resolved plugin-owned UI = %+v", entry)
+		}
+		if entry.Path != "/create-customer-roadmap-review" {
+			t.Fatalf("entry.Path = %q, want %q", entry.Path, "/create-customer-roadmap-review")
+		}
+		if got, want := filepath.ToSlash(entry.ResolvedManifestPath), filepath.ToSlash(filepath.Join("_owned_ui", "roadmap-ui", providerpkg.ManifestFile)); !strings.HasSuffix(got, want) {
+			t.Fatalf("ResolvedManifestPath = %q, want suffix %q", got, want)
+		}
+		if got, want := filepath.ToSlash(entry.ResolvedAssetRoot), filepath.ToSlash(filepath.Join("_owned_ui", "roadmap-ui", "dist")); !strings.HasSuffix(got, want) {
+			t.Fatalf("ResolvedAssetRoot = %q, want suffix %q", got, want)
+		}
 	}
 
 	rewrittenLock, err := ReadLockfile(filepath.Join(dir, InitLockfileName))
 	if err != nil {
 		t.Fatalf("ReadLockfile: %v", err)
+	}
+	if got := rewrittenLock.Providers["roadmap"].Manifest; got != "" {
+		t.Fatalf("lock.Providers[roadmap].Manifest = %q, want stale value preserved", got)
 	}
 	if len(rewrittenLock.UIs) != 0 {
 		t.Fatalf("lock.UIs = %#v, want no separate UI entries for in-package owned UI", rewrittenLock.UIs)
@@ -912,6 +931,162 @@ func TestLoadForExecutionAtPath_ReinitializesManagedPluginOwnedUIWhenPluginLockI
 	}
 	if got := lockEntry.Version; got != newVersion {
 		t.Fatalf("lock.UIs[roadmap].Version = %q, want %q", got, newVersion)
+	}
+}
+
+func TestLoadForExecutionAtPath_UsesDerivedPreparedPathsWhenLockPathsAreStale(t *testing.T) {
+	t.Parallel()
+
+	dir := t.TempDir()
+	const pluginRef = "github.com/testowner/plugins/example"
+	const indexedDBRef = "github.com/testowner/indexeddb/main"
+	const webUIRef = "github.com/testowner/web/roadmap"
+	const version = "0.0.1-alpha.1"
+
+	pluginPkg := mustBuildManagedProviderPackage(t, dir, &providermanifestv1.Manifest{
+		Kind:        providermanifestv1.KindPlugin,
+		Source:      pluginRef,
+		Version:     version,
+		DisplayName: "Example Plugin",
+		Entrypoint: &providermanifestv1.Entrypoint{
+			ArtifactPath: filepath.ToSlash(filepath.Join("artifacts", runtime.GOOS, runtime.GOARCH, "plugin")),
+			Args:         []string{"serve-plugin"},
+		},
+		Spec: &providermanifestv1.Spec{
+			Auth: &providermanifestv1.ProviderAuth{Type: providermanifestv1.AuthTypeNone},
+		},
+	}, map[string]string{
+		filepath.ToSlash(filepath.Join("artifacts", runtime.GOOS, runtime.GOARCH, "plugin")): "plugin-binary",
+	}, true)
+
+	indexedDBPkg := mustBuildManagedProviderPackage(t, dir, &providermanifestv1.Manifest{
+		Kind:        providermanifestv1.KindIndexedDB,
+		Source:      indexedDBRef,
+		Version:     version,
+		DisplayName: "Main IndexedDB",
+		Entrypoint: &providermanifestv1.Entrypoint{
+			ArtifactPath: filepath.ToSlash(filepath.Join("artifacts", runtime.GOOS, runtime.GOARCH, "indexeddb")),
+			Args:         []string{"serve-indexeddb"},
+		},
+		Spec: &providermanifestv1.Spec{},
+	}, map[string]string{
+		filepath.ToSlash(filepath.Join("artifacts", runtime.GOOS, runtime.GOARCH, "indexeddb")): "indexeddb-binary",
+	}, false)
+
+	webUIPkg := mustBuildManagedProviderPackage(t, dir, &providermanifestv1.Manifest{
+		Kind:        providermanifestv1.KindWebUI,
+		Source:      webUIRef,
+		Version:     version,
+		DisplayName: "Roadmap UI",
+		Spec: &providermanifestv1.Spec{
+			AssetRoot: "dist",
+		},
+	}, map[string]string{
+		"dist/index.html": "<html>roadmap</html>",
+	}, false)
+
+	cfgPath := filepath.Join(dir, "config.yaml")
+	cfg := fmt.Sprintf(`providers:
+  indexeddb:
+    main:
+      source:
+        ref: %s
+        version: %s
+      config:
+        path: %q
+  ui:
+    roadmap:
+      source:
+        ref: %s
+        version: %s
+      path: /roadmap
+plugins:
+  example:
+    source:
+      ref: %s
+      version: %s
+server:
+  providers:
+    indexeddb: main
+  encryptionKey: aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa
+`, indexedDBRef, version, filepath.Join(dir, "gestalt.db"), webUIRef, version, pluginRef, version)
+	if err := os.WriteFile(cfgPath, []byte(cfg), 0o644); err != nil {
+		t.Fatalf("WriteFile config: %v", err)
+	}
+
+	lc := NewLifecycle(mappedSourceResolver{paths: map[string]string{
+		pluginRef:    pluginPkg,
+		indexedDBRef: indexedDBPkg,
+		webUIRef:     webUIPkg,
+	}})
+	lock, err := lc.InitAtPath(cfgPath)
+	if err != nil {
+		t.Fatalf("InitAtPath: %v", err)
+	}
+
+	lock.Providers["example"] = LockProviderEntry{
+		Fingerprint: lock.Providers["example"].Fingerprint,
+		Source:      lock.Providers["example"].Source,
+		Version:     lock.Providers["example"].Version,
+		Archives:    lock.Providers["example"].Archives,
+		Manifest:    "stale/provider/manifest.json",
+		Executable:  "stale/provider/executable",
+	}
+	indexedDBEntry := lock.IndexedDBs["main"]
+	indexedDBEntry.Manifest = "stale/indexeddb/manifest.json"
+	indexedDBEntry.Executable = "stale/indexeddb/executable"
+	lock.IndexedDBs["main"] = indexedDBEntry
+	uiEntry := lock.UIs["roadmap"]
+	uiEntry.Manifest = "stale/ui/manifest.json"
+	uiEntry.AssetRoot = "stale/ui/assets"
+	lock.UIs["roadmap"] = uiEntry
+	if err := WriteLockfile(filepath.Join(dir, InitLockfileName), lock); err != nil {
+		t.Fatalf("WriteLockfile: %v", err)
+	}
+
+	for _, locked := range []bool{false, true} {
+		loaded, _, err := lc.LoadForExecutionAtPath(cfgPath, locked)
+		if err != nil {
+			t.Fatalf("LoadForExecutionAtPath(locked=%t): %v", locked, err)
+		}
+
+		plugin := loaded.Plugins["example"]
+		if plugin == nil || plugin.ResolvedManifest == nil {
+			t.Fatalf("Plugins[example] = %+v", plugin)
+		}
+		if got := plugin.Command; strings.Contains(got, "stale/provider/executable") {
+			t.Fatalf("plugin.Command = %q, want derived prepared path", got)
+		}
+
+		indexedDB := mustSelectedHostProviderEntry(t, loaded, config.HostProviderKindIndexedDB)
+		if indexedDB == nil || indexedDB.ResolvedManifest == nil {
+			t.Fatalf("SelectedHostProvider(indexeddb) = %+v", indexedDB)
+		}
+		if got := indexedDB.Command; strings.Contains(got, "stale/indexeddb/executable") {
+			t.Fatalf("indexeddb.Command = %q, want derived prepared path", got)
+		}
+
+		ui := loaded.Providers.UI["roadmap"]
+		if ui == nil || ui.ResolvedManifest == nil {
+			t.Fatalf("Providers.UI[roadmap] = %+v", ui)
+		}
+		if got := ui.ResolvedAssetRoot; strings.Contains(got, "stale/ui/assets") {
+			t.Fatalf("ResolvedAssetRoot = %q, want derived prepared path", got)
+		}
+	}
+
+	rewrittenLock, err := ReadLockfile(filepath.Join(dir, InitLockfileName))
+	if err != nil {
+		t.Fatalf("ReadLockfile: %v", err)
+	}
+	if got := rewrittenLock.Providers["example"].Manifest; got != "stale/provider/manifest.json" {
+		t.Fatalf("lock.Providers[example].Manifest = %q, want stale path preserved", got)
+	}
+	if got := rewrittenLock.IndexedDBs["main"].Executable; got != "stale/indexeddb/executable" {
+		t.Fatalf("lock.IndexedDBs[main].Executable = %q, want stale path preserved", got)
+	}
+	if got := rewrittenLock.UIs["roadmap"].AssetRoot; got != "stale/ui/assets" {
+		t.Fatalf("lock.UIs[roadmap].AssetRoot = %q, want stale path preserved", got)
 	}
 }
 


### PR DESCRIPTION
## Summary
This PR stops locked runtime startup from trusting `gestalt.lock.json` path fields for prepared artifacts.

Instead, `gestaltd` now derives prepared manifest, executable, and asset-root locations from the deterministic install directories under `.gestaltd/...` and validates or re-materializes from there.

This PR also removes the remaining plugin-owned mounted UI dependency on `lock.Providers[plugin].Manifest`: managed plugins with `mountPath` plus `spec.ui` now read the prepared plugin manifest from the deterministic plugin install directory.

This keeps the current on-disk lockfile schema unchanged, but makes runtime behavior resilient to stale `manifest`, `executable`, and `assetRoot` values in the lockfile.

## Go Interface
New internal interface:

```go
type preparedInstall struct {
    manifestPath   string
    executablePath string
    assetRootPath  string
    manifest       *providermanifestv1.Manifest
}

func inspectPreparedInstall(destDir string) (*preparedInstall, error)
```

Runtime callers updated to use derived prepared-install paths instead of lockfile path fields:

```go
applyLockedProviderEntry(...)
applyLockedComponentEntry(...)
applyConfiguredUIProvider(...)
lockMatchesConfig(...)
synthesizeLockedSourcePluginOwnedUIEntries(...)
```

## YAML Interface
No YAML or config shape changes in this PR.
Existing managed provider configs continue to work unchanged.

Example YAML that now benefits from the runtime derivation behavior:

```yaml
providers:
  indexeddb:
    main:
      source:
        ref: github.com/testowner/indexeddb/main
        version: 0.0.1-alpha.1
      config:
        path: ./gestalt.db
  ui:
    roadmap:
      source:
        ref: github.com/testowner/web/roadmap
        version: 0.0.1-alpha.1
      path: /roadmap
plugins:
  example:
    source:
      ref: github.com/testowner/plugins/example
      version: 0.0.1-alpha.1
      mountPath: /roadmap
server:
  providers:
    indexeddb: main
  encryptionKey: aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa
```

## Behavior Examples
Before this PR, locked startup could fail or trigger unnecessary re-init if the lockfile contained stale path fields like:

```json
{
  "manifest": "stale/provider/manifest.json",
  "executable": "stale/provider/executable",
  "assetRoot": "stale/ui/assets"
}
```

With this PR:

- `serve --locked` and `LoadForExecutionAtPath(..., locked)` derive the actual prepared locations from the deterministic install roots for managed providers and explicit managed `providers.ui` entries.
- managed plugins with `mountPath` plus `spec.ui` synthesize their mounted UI from the prepared plugin manifest under `.gestaltd/providers/<plugin>/...` instead of trusting `lock.Providers[plugin].Manifest`.

## Validation
Integration-style coverage added by extending lifecycle behavior tests, plus full operator package verification:

```sh
go test ./internal/operator -count=1
```
