### PR TITLE
[codex] Update docs examples to match current config

### DIFF
--- a/docs/content/architecture/index.mdx
+++ b/docs/content/architecture/index.mdx
@@ -14,7 +14,7 @@ First, the YAML config file is loaded and `${ENV_VAR}` placeholders are expanded
 
 Next, Gestalt initializes the secret manager from `providers.secrets`. This is the one part of config that *cannot* use `secret://` references, because the secret manager doesn't exist yet. Credentials for the secret manager itself have to come in through `${ENV_VAR}` or `${ENV_VAR_FILE}`.
 
-Once the secret manager is ready, Gestalt resolves every `secret://` reference across the rest of the config: server settings, auth, indexeddb, telemetry, audit, and all plugin configs. The `providers.secrets.config` block is skipped to avoid a circular dependency.
+Once the secret manager is ready, Gestalt resolves every `secret://` reference across the rest of the config: server settings, auth, indexeddb, telemetry, audit, and all plugin configs. The selected secret manager's `providers.secrets.<name>.config` block is skipped to avoid a circular dependency.
 
 With secrets resolved, `server.encryptionKey` gets converted into a 32-byte AES key. A 64-character hex string is decoded directly; anything else goes through Argon2id derivation. This derived key protects all stored tokens.
 

--- a/docs/content/architecture/security-internals.mdx
+++ b/docs/content/architecture/security-internals.mdx
@@ -52,7 +52,7 @@ API tokens (`gst_api_*`) work differently: the plaintext is never stored.
 
 `secret://` resolution is a one-shot operation at startup. Gestalt resolves every reference, replaces it in memory, and never consults the secret manager again. If a secret rotates after startup, restart Gestalt to pick it up.
 
-The `providers.secrets.config` block is excluded from resolution. Use `${ENV_VAR}` or `${ENV_VAR_FILE}` for secret manager credentials.
+The selected secret manager's `providers.secrets.<name>.config` block is excluded from resolution. Use `${ENV_VAR}` or `${ENV_VAR_FILE}` for secret manager credentials.
 
 ## Key rotation
 

--- a/docs/content/audit-logging.mdx
+++ b/docs/content/audit-logging.mdx
@@ -123,11 +123,11 @@ definitions.
 
 ## Routing
 
-By default, audit records follow the main telemetry log pipeline. With `providers.telemetry` set to `source: stdout` they appear in local structured logs; with `source: otlp` they export through the OTLP log pipeline.
+By default, audit records follow the main telemetry log pipeline. With `providers.telemetry.default.source: stdout` they appear in local structured logs; with `providers.telemetry.default.source: otlp` they export through the OTLP log pipeline.
 
-If you need a dedicated audit route, configure `providers.audit` separately. Set `source: stdout` to keep audit logs on stdout even when telemetry uses a different source, `source: otlp` to export only audit records to a dedicated OTLP collector, or `source: noop` to disable audit output explicitly.
+If you need a dedicated audit route, configure `providers.audit` separately. Set `providers.audit.<name>.source: stdout` to keep audit logs on stdout even when telemetry uses a different source, `providers.audit.<name>.source: otlp` to export only audit records to a dedicated OTLP collector, or `providers.audit.<name>.source: noop` to disable audit output explicitly.
 
-With the default `providers.audit` source of `inherit`, you can still split audit records downstream by filtering on `log.type=audit` in your collector. See [Config File](/reference/config-file) for the config surface and [Observability](/observability) for export options.
+With the default `providers.audit.default.source: inherit`, you can still split audit records downstream by filtering on `log.type=audit` in your collector. See [Config File](/reference/config-file) for the config surface and [Observability](/observability) for export options.
 
 ## Metrics Notes
 

--- a/docs/content/client/web.mdx
+++ b/docs/content/client/web.mdx
@@ -30,7 +30,7 @@ When `providers.auth` points to a Google or OIDC auth provider, the web UI redir
 
 Public web UI bundles are configured through the `providers.ui` map.
 
-- Omit `ui` to run headless with no public UI bundles.
+- Omit `providers.ui` to run headless with no public UI bundles.
 - Add `ui.<name>` entries with `source` and explicit `path` fields to mount static SPAs under public URL prefixes.
 - UI bundles use the normal `/api/v1` and `/mcp` surfaces; there is no separate plugin-local browser route surface.
 

--- a/docs/content/configuration.mdx
+++ b/docs/content/configuration.mdx
@@ -4,13 +4,17 @@ Gestalt is configured from a single YAML file. This page covers the key concepts
 
 ## Config file structure
 
-A Gestalt config has four top-level keys: `server` for host settings, `authorization` for shared human/workload access policy, `providers` for host-scoped providers and web UIs, and `plugins` for executable integrations and optional plugin-backed UI mounts.
+A Gestalt config has four top-level keys: `server` for host settings and host-provider selection, `authorization` for shared human/workload access policy, `providers` for named host-scoped providers and web UIs, and `plugins` for executable integrations and optional plugin-backed UI mounts.
 
 ```yaml
 server:
   encryptionKey: ...        # required, root deployment secret
   baseUrl: ...              # public URL for OAuth callbacks
   providers:
+    auth: ...               # optional selected auth provider
+    secrets: ...            # optional selected secrets provider
+    telemetry: ...          # optional selected telemetry provider
+    audit: ...              # optional selected audit provider
     indexeddb: ...          # selected storage provider
   public:                   # public listener (default port 8080)
     host: ...
@@ -26,18 +30,25 @@ authorization:
   workloads: ...            # workload bearer-token policy
 
 providers:
-  auth: ...                 # platform login (ProviderEntry)
-  secrets: ...              # secret resolution (default: env)
-  telemetry: ...            # metrics and tracing (default: stdout)
-  audit: ...                # audit log routing (default: inherit)
-  ui: ...                   # web UI bundle (ProviderEntry)
+  auth:                     # named auth providers
+    <name>: ...            # each is a ProviderEntry
+  secrets:                  # named secret managers (default: providers.secrets.default = env)
+    <name>: ...            # each is a ProviderEntry
+  telemetry:                # named telemetry pipelines (default: providers.telemetry.default = stdout)
+    <name>: ...            # each is a ProviderEntry
+  audit:                    # named audit pipelines (default: providers.audit.default = inherit)
+    <name>: ...            # each is a ProviderEntry
+  ui:                       # named web UI bundles
+    <name>: ...             # each is a UIEntry
   indexeddb:                # named storage providers
+    <name>: ...             # each is a ProviderEntry
+  cache:                    # named cache providers
     <name>: ...             # each is a ProviderEntry
 plugins:
   <name>: ...               # each is a ProviderEntry
 ```
 
-Each provider entry accepts `source` (where to load it from), `config` (provider-specific settings), `disabled`, `allowedHosts`, `connections`, and optional metadata fields. See the [Config File](/reference/config-file) reference for every field.
+ProviderEntry-backed entries accept `source` (where to load it from), `config` (provider-specific settings), `disabled`, `allowedHosts`, and optional metadata fields. Plugin entries additionally support plugin-only fields such as `connections`, `allowedOperations`, `mountPath`, and `ui`. See the [Config File](/reference/config-file) reference for every field.
 
 ## Key concepts
 
@@ -179,12 +190,13 @@ MCP tool exposure is declared in the provider manifest via `spec.mcp: true`. Whe
 
 ## Secrets
 
-The `providers.secrets` entry configures how `secret://` references in the config are resolved at startup. The default is `env`, which reads secrets from environment variables:
+The `providers.secrets` map configures how `secret://` references in the config are resolved at startup. When omitted entirely, Gestalt synthesizes `providers.secrets.default` with builtin `env`:
 
 ```yaml
 providers:
   secrets:
-    source: env
+    default:
+      source: env
 ```
 
 For production, use `file` (reads from a directory, works with Kubernetes volume-mounted secrets) or a cloud secret manager:
@@ -192,9 +204,10 @@ For production, use `file` (reads from a directory, works with Kubernetes volume
 ```yaml
 providers:
   secrets:
-    source: file
-    config:
-      dir: /etc/gestalt-secrets
+    default:
+      source: file
+      config:
+        dir: /etc/gestalt-secrets
 ```
 
 Cloud backends (Google Secret Manager, AWS Secrets Manager, HashiCorp Vault, Azure Key Vault) are also available. See [Secret Providers](/providers/secrets) for the full list.
@@ -223,36 +236,42 @@ The built-in admin UI at `/admin` is always available regardless of this setting
 
 ## Platform auth
 
-The `providers.auth` entry protects the web UI, HTTP API, and `/mcp` endpoint. For local development, omit it or disable it explicitly:
+The `providers.auth` map protects the web UI, HTTP API, and `/mcp` endpoint. For local development, omit it or disable it explicitly:
 
 ```yaml
 providers:
   auth:
-    disabled: true
+    default:
+      disabled: true
 ```
 
 For multi-user deployments, point at a published auth provider:
 
 ```yaml
+server:
+  providers:
+    auth: oidc
+
 providers:
   auth:
-    source:
-      ref: github.com/valon-technologies/gestalt-providers/auth/oidc
-      version: 0.0.1-alpha.1
-    config:
-      issuerUrl: https://login.example.com
-      clientId: ${OIDC_CLIENT_ID}
-      clientSecret: secret://oidc-client-secret
+    oidc:
+      source:
+        ref: github.com/valon-technologies/gestalt-providers/auth/oidc
+        version: 0.0.1-alpha.1
+      config:
+        issuerUrl: https://login.example.com
+        clientId: ${OIDC_CLIENT_ID}
+        clientSecret: secret://oidc-client-secret
 ```
 
 For production OIDC providers, keep `issuerUrl` on `https://`. If you run a
 local plaintext issuer on loopback for development, add
-`allowInsecureHttp: true` under `providers.auth.config`.
+`allowInsecureHttp: true` under `providers.auth.<name>.config`.
 
 | Scenario | Configuration |
 | --- | --- |
-| Local development | Omit `providers.auth` or set `providers.auth.disabled: true` |
-| Multi-user deployment | `providers.auth` with a published OIDC or Google auth provider |
+| Local development | Omit `providers.auth` or set `providers.auth.default.disabled: true` |
+| Multi-user deployment | `providers.auth.<name>` with a published OIDC or Google auth provider |
 | Per-user upstream access | `mode: user` on plugin connections |
 | Shared service credential | `mode: identity` on plugin connections |
 
@@ -288,9 +307,11 @@ Gestalt ships with builtin telemetry and audit providers that work without any c
 ```yaml
 providers:
   telemetry:
-    source: stdout
+    default:
+      source: stdout
   audit:
-    source: inherit
+    default:
+      source: inherit
 ```
 
 `inherit` routes audit events through the telemetry provider. For production observability with OpenTelemetry, see [Observability](/observability).
@@ -325,7 +346,7 @@ gestaltd validate --config ./config.yaml
 
 ### Defaults and required fields
 
-Gestalt defaults `server.public.port` to `8080`, `providers.secrets` to `env`, and `providers.telemetry` to `stdout`. The required fields are `providers.indexeddb`, `server.providers.indexeddb`, and `server.encryptionKey`. Platform auth is optional.
+Gestalt defaults `server.public.port` to `8080`, `providers.secrets.default` to `env`, `providers.telemetry.default` to `stdout`, and `providers.audit.default` to `inherit`. The required fields are `providers.indexeddb`, `server.providers.indexeddb`, and `server.encryptionKey`. Platform auth is optional.
 
 `server.encryptionKey` is the root deployment secret. Gestalt derives token encryption and session material from it. Changing this key invalidates all existing sessions and tokens, so treat it as a meaningful deployment event.
 
@@ -338,17 +359,19 @@ server:
   baseUrl: https://gestalt.example.com
   encryptionKey: secret://gestalt-encryption-key
   providers:
+    auth: oidc
     indexeddb: main
 
 providers:
   auth:
-    source:
-      ref: github.com/valon-technologies/gestalt-providers/auth/oidc
-      version: 0.0.1-alpha.1
-    config:
-      issuerUrl: https://login.example.com
-      clientId: ${OIDC_CLIENT_ID}
-      clientSecret: secret://oidc-client-secret
+    oidc:
+      source:
+        ref: github.com/valon-technologies/gestalt-providers/auth/oidc
+        version: 0.0.1-alpha.1
+      config:
+        issuerUrl: https://login.example.com
+        clientId: ${OIDC_CLIENT_ID}
+        clientSecret: secret://oidc-client-secret
 
   indexeddb:
     main:

--- a/docs/content/custom-providers/auth.mdx
+++ b/docs/content/custom-providers/auth.mdx
@@ -224,18 +224,19 @@ Two optional interfaces extend the base contract.
 
 ## Config reference
 
-To use a Google auth provider in a Gestalt deployment, reference it in the `providers.auth` block:
+To use a Google auth provider in a Gestalt deployment, reference it as a named entry in `providers.auth`:
 
 ```yaml
 providers:
   auth:
-    source:
-      path: ./google-auth/manifest.yaml
-    config:
-      clientId: ${GOOGLE_CLIENT_ID}
-      clientSecret: secret://google-client-secret
-      allowedDomains:
-        - example.com
+    google:
+      source:
+        path: ./google-auth/manifest.yaml
+      config:
+        clientId: ${GOOGLE_CLIENT_ID}
+        clientSecret: secret://google-client-secret
+        allowedDomains:
+          - example.com
 ```
 
 `source.path` points at the auth provider's `manifest.yaml` during development. For production, use `source.ref` and `version` to reference a published release. The `config` block is passed to `Configure` at startup and validated against the config schema if one was declared in the manifest.

--- a/docs/content/custom-providers/cache.mdx
+++ b/docs/content/custom-providers/cache.mdx
@@ -16,10 +16,10 @@ A cache provider manifest declares `kind: cache`:
 
 ```yaml
 kind: cache
-source: github.com/valon-technologies/gestalt-providers/cache/redis
+source: github.com/valon-technologies/gestalt-providers/cache/valkey
 version: 0.0.1
-displayName: Redis Cache
-description: Cache provider backed by Redis or Valkey.
+displayName: Valkey Cache
+description: Cache provider backed by Valkey or Redis.
 spec:
   configSchemaPath: ./cache_config.json
 ```
@@ -41,7 +41,7 @@ The Cache service includes:
 <Tabs items={['Go', 'Python', 'Rust', 'TypeScript']}>
   <Tabs.Tab>
     ```go
-    package rediscache
+    package valkeycache
 
     import (
         "context"
@@ -82,7 +82,7 @@ The Cache service includes:
 
     import gestalt
 
-    class RedisCache(gestalt.CacheProvider):
+    class ValkeyCache(gestalt.CacheProvider):
         def get(self, key: str) -> bytes | None:
             return None
 
@@ -104,10 +104,10 @@ The Cache service includes:
   <Tabs.Tab>
     ```rust
     #[derive(Default)]
-    struct RedisCache;
+    struct ValkeyCache;
 
     #[gestalt::async_trait]
-    impl gestalt::CacheProvider for RedisCache {
+    impl gestalt::CacheProvider for ValkeyCache {
         async fn get(&self, key: &str) -> gestalt::Result<Option<Vec<u8>>> {
             let _ = key;
             Ok(None)
@@ -134,7 +134,7 @@ The Cache service includes:
         }
     }
 
-    gestalt::export_cache_provider!(constructor = RedisCache::default);
+    gestalt::export_cache_provider!(constructor = ValkeyCache::default);
     ```
   </Tabs.Tab>
   <Tabs.Tab>

--- a/docs/content/custom-providers/indexeddb.mdx
+++ b/docs/content/custom-providers/indexeddb.mdx
@@ -40,7 +40,7 @@ An IndexedDB provider manifest declares `kind: indexeddb`:
 ```yaml
 kind: indexeddb
 source: github.com/valon-technologies/gestalt-providers/indexeddb/relationaldb
-version: 0.0.1
+version: 0.0.1-alpha.2
 displayName: RelationalDB
 description: IndexedDB provider supporting PostgreSQL, MySQL, SQLite, and SQL Server.
 spec:
@@ -405,7 +405,7 @@ providers:
     main:
       source:
         ref: github.com/valon-technologies/gestalt-providers/indexeddb/relationaldb
-        version: 0.0.1
+        version: 0.0.1-alpha.2
       config:
         dsn: ${DATABASE_URL}
 ```

--- a/docs/content/custom-providers/releasing.mdx
+++ b/docs/content/custom-providers/releasing.mdx
@@ -180,7 +180,7 @@ spec:
   configSchemaPath: schemas/ui-config.schema.json
 ```
 
-`gestaltd init` prepares the released UI and records it in `gestalt.lock.json`. `gestaltd serve --locked` then serves the prepared asset root at `/`. Omit `ui` to use the pinned first-party default UI bundle, or set `ui: { disabled: true }` to disable the public UI. The built-in admin UI remains available at `/admin` regardless.
+`gestaltd init` prepares the released UI and records it in `gestalt.lock.json`. `gestaltd serve --locked` then serves the prepared asset root at whatever public path the deployment config binds for that UI bundle. Omit `providers.ui` to run headless with no public UI bundles, or set `providers.ui.<name>.disabled: true` to disable a specific mounted UI entry. The built-in admin UI remains available at `/admin` regardless.
 
 ## Build a release
 

--- a/docs/content/custom-providers/secrets.mdx
+++ b/docs/content/custom-providers/secrets.mdx
@@ -162,15 +162,16 @@ A secrets provider implements two methods: `Configure` and `GetSecret`. `Configu
 
 ## Config reference
 
-To use a secrets provider in a Gestalt deployment, reference it in the `providers.secrets` block:
+To use a secrets provider in a Gestalt deployment, reference it as a named entry in the `providers.secrets` block:
 
 ```yaml
 providers:
   secrets:
-    source:
-      path: ./google-secrets/manifest.yaml
-    config:
-      project: my-gcp-project
+    google:
+      source:
+        path: ./google-secrets/manifest.yaml
+      config:
+        project: my-gcp-project
 ```
 
 `source.path` points at the provider's `manifest.yaml` during development. For production, use `source.ref` and `version` to reference a published release:
@@ -178,11 +179,12 @@ providers:
 ```yaml
 providers:
   secrets:
-    source:
-      ref: github.com/valon-technologies/gestalt-providers/secrets/google
-      version: 0.0.1
-    config:
-      project: my-gcp-project
+    google:
+      source:
+        ref: github.com/valon-technologies/gestalt-providers/secrets/google
+        version: 0.0.1
+      config:
+        project: my-gcp-project
 ```
 
 The `config` block is passed to `Configure` at startup.
@@ -196,9 +198,10 @@ Two simple providers are built in and do not require a plugin manifest:
 ```yaml
 providers:
   secrets:
-    source: env
-    config:
-      prefix: GESTALT_
+    default:
+      source: env
+      config:
+        prefix: GESTALT_
 ```
 
 **`file`** reads secrets from files in a directory. Each secret name maps to a file in the configured directory.
@@ -206,19 +209,20 @@ providers:
 ```yaml
 providers:
   secrets:
-    source: file
-    config:
-      dir: /run/secrets
+    default:
+      source: file
+      config:
+        dir: /run/secrets
 ```
 
 ## Available providers
 
 | Provider | Source ref | Description |
 |----------|-----------|-------------|
-| AWS Secrets Manager | `github.com/valon-technologies/gestalt-providers/secrets/aws` | Config: `region` (required), `version_stage`, `endpoint` |
-| Azure Key Vault | `github.com/valon-technologies/gestalt-providers/secrets/azure` | Config: `vault_url` (required), `version` |
+| AWS Secrets Manager | `github.com/valon-technologies/gestalt-providers/secrets/aws` | Config: `region` (required), `versionStage`, `endpoint` |
+| Azure Key Vault | `github.com/valon-technologies/gestalt-providers/secrets/azure` | Config: `vaultUrl` (required), `version` |
 | Google Secret Manager | `github.com/valon-technologies/gestalt-providers/secrets/google` | Config: `project` (required), `version` |
-| HashiCorp Vault | `github.com/valon-technologies/gestalt-providers/secrets/vault` | Config: `address` (required), `token` (required), `mount_path`, `namespace` |
+| HashiCorp Vault | `github.com/valon-technologies/gestalt-providers/secrets/vault` | Config: `address` (required), `token` (required), `mountPath`, `namespace` |
 
 ## What to read next
 

--- a/docs/content/deploy/helm.mdx
+++ b/docs/content/deploy/helm.mdx
@@ -41,16 +41,18 @@ config:
     baseUrl: "${GESTALT_BASE_URL}"
     encryptionKey: "${GESTALT_ENCRYPTION_KEY}"
     providers:
+      auth: oidc
       indexeddb: main
   providers:
     auth:
-      source:
-        ref: github.com/valon-technologies/gestalt-providers/auth/oidc
-        version: 0.0.1-alpha.1
-      config:
-        issuerUrl: "${OIDC_ISSUER_URL}"
-        clientId: "${OIDC_CLIENT_ID}"
-        clientSecret: "${OIDC_CLIENT_SECRET}"
+      oidc:
+        source:
+          ref: github.com/valon-technologies/gestalt-providers/auth/oidc
+          version: 0.0.1-alpha.1
+        config:
+          issuerUrl: "${OIDC_ISSUER_URL}"
+          clientId: "${OIDC_CLIENT_ID}"
+          clientSecret: "${OIDC_CLIENT_SECRET}"
     indexeddb:
       main:
         source:
@@ -121,17 +123,19 @@ config:
     baseUrl: "${GESTALT_BASE_URL}"
     encryptionKey: "${GESTALT_ENCRYPTION_KEY}"
     providers:
+      auth: oidc
       indexeddb: main
   providers:
     auth:
-      source:
-        ref: github.com/valon-technologies/gestalt-providers/auth/oidc
-        version: 0.0.1-alpha.1
-      config:
-        issuerUrl: "${OIDC_ISSUER_URL}"
-        clientId: "${OIDC_CLIENT_ID}"
-        clientSecret: "${OIDC_CLIENT_SECRET}"
-        redirectUrl: "${OIDC_REDIRECT_URL}"
+      oidc:
+        source:
+          ref: github.com/valon-technologies/gestalt-providers/auth/oidc
+          version: 0.0.1-alpha.1
+        config:
+          issuerUrl: "${OIDC_ISSUER_URL}"
+          clientId: "${OIDC_CLIENT_ID}"
+          clientSecret: "${OIDC_CLIENT_SECRET}"
+          redirectUrl: "${OIDC_REDIRECT_URL}"
     indexeddb:
       main:
         source:
@@ -180,7 +184,7 @@ Service rather than exposing it on the public ingress.
 
 ## When to enable `pluginInit`
 
-Enable the init container when your config uses `plugins.*.source.ref`, `providers.auth.source.ref`, `providers.indexeddb.*.source.ref`, or `providers.ui.*.source.ref` and you want that state prepared before the main container starts. The init container copies the rendered config and runs:
+Enable the init container when your config uses `plugins.*.source.ref`, `providers.auth.*.source.ref`, `providers.indexeddb.*.source.ref`, or `providers.ui.*.source.ref` and you want that state prepared before the main container starts. The init container copies the rendered config and runs:
 
 `/gestaltd init --config /etc/gestalt/config.yaml`
 

--- a/docs/content/deploy/index.mdx
+++ b/docs/content/deploy/index.mdx
@@ -40,16 +40,18 @@ deploy/
   .gestaltd/ui/        # vendored UI assets (optional)
 ```
 
-The lock file is a JSON document that records every resolved provider:
+The lock file is a JSON document that records resolved plugins and host-scoped providers in separate maps:
 
 ```json
 {
   "version": 1,
-  "providers": {
-    "indexeddb/relationaldb": {
+  "indexeddbs": {
+    "main": {
+      "fingerprint": "ab12cd...",
       "source": "github.com/valon-technologies/gestalt-providers/indexeddb/relationaldb",
-      "version": "0.5.2",
-      "sha256": "ab12cd..."
+      "version": "0.0.1-alpha.2",
+      "manifest": ".gestaltd/providers/main/manifest.json",
+      "executable": ".gestaltd/providers/main/artifacts/linux/amd64/provider"
     }
   }
 }

--- a/docs/content/observability.mdx
+++ b/docs/content/observability.mdx
@@ -15,37 +15,39 @@ finished initialization, then switches to `200`.
 
 ## Default Telemetry
 
-If you omit the `providers.telemetry` block, Gestalt defaults to stdout.
+If you omit the `providers.telemetry` block, Gestalt synthesizes `providers.telemetry.default` with builtin `stdout`.
 
 ```yaml
 providers:
   telemetry:
-    source: stdout
+    default:
+      source: stdout
 ```
 
 That gives you structured logs without external collectors. The `stdout`
 source also exposes a Prometheus-compatible `/metrics` endpoint. Traces remain
-disabled unless you switch to `source: otlp` under `providers.telemetry`.
+disabled unless you switch to `providers.telemetry.<name>.source: otlp`.
 
 ## OTLP Export
 
-Set `source: otlp` under `providers.telemetry` to export traces, metrics, and
+Set `providers.telemetry.<name>.source: otlp` to export traces, metrics, and
 logs over OpenTelemetry.
 
 ```yaml
 providers:
   telemetry:
-    source: otlp
-    config:
-      endpoint: otel-collector:4317
-      protocol: grpc
-      service_name: gestaltd
-      traces:
-        sampling_ratio: 1.0
-      metrics:
-        interval: 60s
-      logs:
-        level: info
+    default:
+      source: otlp
+      config:
+        endpoint: otel-collector:4317
+        protocol: grpc
+        serviceName: gestaltd
+        traces:
+          samplingRatio: 1.0
+        metrics:
+          interval: 60s
+        logs:
+          level: info
 ```
 
 If you want traces and metrics in OTLP but need application logs to remain on
@@ -54,14 +56,15 @@ stdout for the host platform to collect, override the log exporter.
 ```yaml
 providers:
   telemetry:
-    source: otlp
-    config:
-      endpoint: otel-collector:4317
-      protocol: grpc
-      logs:
-        exporter: stdout
-        format: json
-        level: info
+    default:
+      source: otlp
+      config:
+        endpoint: otel-collector:4317
+        protocol: grpc
+        logs:
+          exporter: stdout
+          format: json
+          level: info
 ```
 
 ## Audit Routing
@@ -73,23 +76,25 @@ different route for compliance, analytics, or warehousing, configure
 ```yaml
 providers:
   telemetry:
-    source: stdout
-    config:
-      format: json
+    default:
+      source: stdout
+      config:
+        format: json
 
   audit:
-    source: otlp
-    config:
-      endpoint: audit-collector:4317
-      protocol: grpc
-      headers:
-        Authorization: Bearer ${AUDIT_OTLP_TOKEN}
+    default:
+      source: otlp
+      config:
+        endpoint: audit-collector:4317
+        protocol: grpc
+        headers:
+          Authorization: Bearer ${AUDIT_OTLP_TOKEN}
 ```
 
 That keeps application logs on stdout while exporting only audit records over
-OTLP. You can also set `providers.audit` with `source: stdout` to keep audit
-logs on stdout when telemetry is `noop`, or `source: noop` to disable audit
-output explicitly. If you leave `source: inherit` under `providers.audit`,
+OTLP. You can also set `providers.audit.<name>.source: stdout` to keep audit
+logs on stdout when telemetry is `noop`, or `providers.audit.<name>.source: noop` to disable audit
+output explicitly. If you leave `providers.audit.default.source: inherit`,
 collectors can still split the stream by filtering on `log.type=audit`.
 
 ## Emitted Metrics
@@ -113,7 +118,7 @@ as the `gestaltd_operation_duration_seconds` histogram family.
 
 | Prometheus family | Type | Meaning |
 | --- | --- | --- |
-| `target_info` | Gauge | Resource attributes including `service_name` |
+| `target_info` | Gauge | Resource attributes including `service.name` |
 
 ### Broker Operation Metrics
 
@@ -369,10 +374,10 @@ These metrics use standard OpenTelemetry gRPC client semantic attributes such as
 ## Prometheus Scrape Endpoint
 
 When telemetry metrics are enabled, Gestalt exposes a Prometheus scrape endpoint
-at `/metrics`. With `providers.telemetry` set to `source: stdout`, metrics are
-kept local and served directly. With `source: otlp`, metrics are exported over
+at `/metrics`. With `providers.telemetry.default.source: stdout`, metrics are
+kept local and served directly. With `providers.telemetry.default.source: otlp`, metrics are exported over
 OTLP and also served at `/metrics` locally unless you disable the Prometheus
-bridge. Setting `source: noop` disables Prometheus scraping entirely; `/metrics`
+bridge. Setting `providers.telemetry.default.source: noop` disables Prometheus scraping entirely; `/metrics`
 returns a clear unavailable response so the admin UI can surface that state.
 
 When Gestalt serves `/metrics` on the public listener, it is authenticated with

--- a/docs/content/providers/auth.mdx
+++ b/docs/content/providers/auth.mdx
@@ -1,7 +1,7 @@
 # Auth
 
 Auth providers handle platform login for the Gestalt server. They are separate
-from plugin connections: `providers.auth` decides how users sign in to the
+from plugin connections: `providers.auth.<name>` decides how users sign in to the
 deployment itself, while plugin connections decide how Gestalt authenticates to
 upstream APIs on behalf of callers.
 
@@ -33,14 +33,15 @@ First-party auth providers live under
 ```yaml
 providers:
   auth:
-    source:
-      ref: github.com/valon-technologies/gestalt-providers/auth/google
-      version: 0.0.1-alpha.1
-    config:
-      clientId: ${GOOGLE_CLIENT_ID}
-      clientSecret: secret://google-client-secret
-      allowedDomains:
-        - example.com
+    google:
+      source:
+        ref: github.com/valon-technologies/gestalt-providers/auth/google
+        version: 0.0.1-alpha.1
+      config:
+        clientId: ${GOOGLE_CLIENT_ID}
+        clientSecret: secret://google-client-secret
+        allowedDomains:
+          - example.com
 ```
 
 Secret references such as `secret://google-client-secret` are resolved through
@@ -51,7 +52,8 @@ To disable platform auth entirely, omit `providers.auth` or set:
 ```yaml
 providers:
   auth:
-    disabled: true
+    default:
+      disabled: true
 ```
 
 For local development, that disabled mode is the simple default: every request
@@ -62,11 +64,12 @@ is treated as the same anonymous user.
 ```yaml
 providers:
   auth:
-    source:
-      path: ./google-auth/manifest.yaml
-    config:
-      clientId: ${GOOGLE_CLIENT_ID}
-      clientSecret: secret://google-client-secret
+    google:
+      source:
+        path: ./google-auth/manifest.yaml
+      config:
+        clientId: ${GOOGLE_CLIENT_ID}
+        clientSecret: secret://google-client-secret
 ```
 
 ## Building your own auth provider

--- a/docs/content/providers/cache.mdx
+++ b/docs/content/providers/cache.mdx
@@ -17,16 +17,16 @@ providers:
         ref: github.com/valon-technologies/gestalt-providers/cache/redis
         version: 0.0.1-alpha.1
       config:
-        addr: ${VALKEY_ADDR}
-        db: 0
+        address: ${REDIS_ADDR}
+        database: 0
 
     rate_limit:
       source:
         ref: github.com/valon-technologies/gestalt-providers/cache/redis
         version: 0.0.1-alpha.1
       config:
-        addr: ${VALKEY_ADDR}
-        db: 1
+        address: ${REDIS_ADDR}
+        database: 1
 
 plugins:
   search:

--- a/docs/content/providers/cache.mdx
+++ b/docs/content/providers/cache.mdx
@@ -14,18 +14,18 @@ providers:
   cache:
     session:
       source:
-        ref: github.com/valon-technologies/gestalt-providers/cache/redis
+        ref: github.com/valon-technologies/gestalt-providers/cache/valkey
         version: 0.0.1-alpha.1
       config:
-        address: ${REDIS_ADDR}
+        address: ${VALKEY_ADDR}
         database: 0
 
     rate_limit:
       source:
-        ref: github.com/valon-technologies/gestalt-providers/cache/redis
+        ref: github.com/valon-technologies/gestalt-providers/cache/valkey
         version: 0.0.1-alpha.1
       config:
-        address: ${REDIS_ADDR}
+        address: ${VALKEY_ADDR}
         database: 1
 
 plugins:

--- a/docs/content/providers/index.mdx
+++ b/docs/content/providers/index.mdx
@@ -80,10 +80,10 @@ providers:
   cache:
     session:
       source:
-        ref: github.com/valon-technologies/gestalt-providers/cache/redis
+        ref: github.com/valon-technologies/gestalt-providers/cache/valkey
         version: 0.0.1-alpha.1
       config:
-        address: ${REDIS_ADDR}
+        address: ${VALKEY_ADDR}
 
 plugins:
   github:

--- a/docs/content/providers/index.mdx
+++ b/docs/content/providers/index.mdx
@@ -15,10 +15,10 @@ validates it, and starts it with the permissions and request context it needs.
 | Kind | Purpose | Config location |
 | --- | --- | --- |
 | `plugin` | Tool providers that expose operations over CLI, HTTP API, and MCP | `plugins.<name>` |
-| `auth` | Platform login backends | `providers.auth` |
+| `auth` | Platform login backends | `providers.auth.<name>` |
 | `cache` | Plugin-bound cache backends | `providers.cache.<name>` |
 | `indexeddb` | Persistent state backends for users, sessions, tokens, and credentials | `providers.indexeddb.<name>` |
-| `secrets` | Secret managers that resolve `secret://` references | `providers.secrets` |
+| `secrets` | Secret managers that resolve `secret://` references | `providers.secrets.<name>` |
 | `webui` | Public UI bundles served under configured path prefixes | `providers.ui` |
 
 ## How providers work
@@ -43,10 +43,10 @@ The repository is organized by provider type:
 | Type | Repository path | Typical config key |
 | --- | --- | --- |
 | Plugins | [`plugins/`](https://github.com/valon-technologies/gestalt-providers/tree/main/plugins) | `plugins.<name>` |
-| Auth | [`auth/`](https://github.com/valon-technologies/gestalt-providers/tree/main/auth) | `providers.auth` |
+| Auth | [`auth/`](https://github.com/valon-technologies/gestalt-providers/tree/main/auth) | `providers.auth.<name>` |
 | Cache | [`cache/`](https://github.com/valon-technologies/gestalt-providers/tree/main/cache) | `providers.cache.<name>` |
 | IndexedDB | [`indexeddb/`](https://github.com/valon-technologies/gestalt-providers/tree/main/indexeddb) | `providers.indexeddb.<name>` |
-| Secrets | [`secrets/`](https://github.com/valon-technologies/gestalt-providers/tree/main/secrets) | `providers.secrets` |
+| Secrets | [`secrets/`](https://github.com/valon-technologies/gestalt-providers/tree/main/secrets) | `providers.secrets.<name>` |
 | Web UI bundles | [`web/`](https://github.com/valon-technologies/gestalt-providers/tree/main/web) | `providers.ui` |
 
 ## Using providers
@@ -60,19 +60,20 @@ server:
 
 providers:
   auth:
-    source:
-      ref: github.com/valon-technologies/gestalt-providers/auth/oidc
-      version: 0.0.1-alpha.1
-    config:
-      issuerUrl: https://login.example.com
-      clientId: ${OIDC_CLIENT_ID}
-      clientSecret: secret://oidc-client-secret
+    oidc:
+      source:
+        ref: github.com/valon-technologies/gestalt-providers/auth/oidc
+        version: 0.0.1-alpha.1
+      config:
+        issuerUrl: https://login.example.com
+        clientId: ${OIDC_CLIENT_ID}
+        clientSecret: secret://oidc-client-secret
 
   indexeddb:
     main:
       source:
         ref: github.com/valon-technologies/gestalt-providers/indexeddb/relationaldb
-        version: 0.0.1-alpha.1
+        version: 0.0.1-alpha.2
       config:
         dsn: ${DATABASE_URL}
 

--- a/docs/content/providers/indexeddb.mdx
+++ b/docs/content/providers/indexeddb.mdx
@@ -50,13 +50,13 @@ providers:
     main:
       source:
         ref: github.com/valon-technologies/gestalt-providers/indexeddb/relationaldb
-        version: 0.0.1-alpha.1
+        version: 0.0.1-alpha.2
       config:
         dsn: ${SYSTEM_DATABASE_URL}
     workplaceHub:
       source:
         ref: github.com/valon-technologies/gestalt-providers/indexeddb/relationaldb
-        version: 0.0.1-alpha.1
+        version: 0.0.1-alpha.2
       config:
         dsn: ${APP_DATABASE_URL}
 
@@ -121,7 +121,7 @@ providers:
     main:
       source:
         ref: github.com/valon-technologies/gestalt-providers/indexeddb/relationaldb
-        version: 0.0.1-alpha.1
+        version: 0.0.1-alpha.2
       config:
         dsn: ${DATABASE_URL}
 ```

--- a/docs/content/providers/secrets.mdx
+++ b/docs/content/providers/secrets.mdx
@@ -24,9 +24,10 @@ Use environment variables:
 ```yaml
 providers:
   secrets:
-    source: env
-    config:
-      prefix: GESTALT_
+    default:
+      source: env
+      config:
+        prefix: GESTALT_
 ```
 
 Or use a directory of mounted files:
@@ -34,9 +35,10 @@ Or use a directory of mounted files:
 ```yaml
 providers:
   secrets:
-    source: file
-    config:
-      dir: /run/secrets
+    default:
+      source: file
+      config:
+        dir: /run/secrets
 ```
 
 ## Configuring external secret providers
@@ -44,11 +46,12 @@ providers:
 ```yaml
 providers:
   secrets:
-    source:
-      ref: github.com/valon-technologies/gestalt-providers/secrets/google
-      version: 0.0.1-alpha.1
-    config:
-      project: my-gcp-project
+    google:
+      source:
+        ref: github.com/valon-technologies/gestalt-providers/secrets/google
+        version: 0.0.1-alpha.1
+      config:
+        project: my-gcp-project
 ```
 
 The configured provider resolves each `secret://name` reference before any auth

--- a/docs/content/reference/built-in-providers.mdx
+++ b/docs/content/reference/built-in-providers.mdx
@@ -6,7 +6,7 @@ Two simple secrets providers (`env` and `file`), telemetry, and audit remain bui
 
 ## Auth Providers
 
-Auth providers handle platform login. They are configured under `providers.auth` in your config file.
+Auth providers handle platform login. They are configured under `providers.auth.<name>` in your config file.
 
 | Name | Purpose |
 | --- | --- |
@@ -17,15 +17,16 @@ Auth providers handle platform login. They are configured under `providers.auth`
 ```yaml
 providers:
   auth:
-    source:
-      ref: github.com/valon-technologies/gestalt-providers/auth/google
-      version: 1.0.0
-    config:
-      allowedDomains:
-        - example.com
+    google:
+      source:
+        ref: github.com/valon-technologies/gestalt-providers/auth/google
+        version: 0.0.1-alpha.1
+      config:
+        allowedDomains:
+          - example.com
 ```
 
-To disable platform auth entirely, omit the `providers.auth` block or set `providers: { auth: { disabled: true } }`.
+To disable platform auth entirely, omit the `providers.auth` block or set `providers.auth.default.disabled: true`.
 
 ## IndexedDB Providers
 
@@ -41,7 +42,7 @@ providers:
     main:
       source:
         ref: github.com/valon-technologies/gestalt-providers/indexeddb/relationaldb
-        version: 1.0.0
+        version: 0.0.1-alpha.2
       config:
         dsn: ${DATABASE_URL}
 ```
@@ -61,7 +62,7 @@ Two secret managers are compiled into the `gestaltd` binary and resolve `secret:
 | `env` | Resolves secrets from environment variables. Default when `providers.secrets` is omitted. |
 | `file` | Resolves secrets from files in a configured directory. Works with Kubernetes volume-mounted secrets. |
 
-For cloud backends (Google Secret Manager, AWS Secrets Manager, HashiCorp Vault, Azure Key Vault), see [Secrets Providers](/providers/secrets#available-providers). These use a `source:` config key under `providers.secrets`.
+For cloud backends (Google Secret Manager, AWS Secrets Manager, HashiCorp Vault, Azure Key Vault), see [Secrets Providers](/providers/secrets#available-providers). These use a `source:` config key under `providers.secrets.<name>`.
 
 ## Telemetry Providers (built-in)
 
@@ -81,8 +82,8 @@ Plugins (BigQuery, Jira, Slack, and others) are published separately from [`valo
 plugins:
   jira:
     source:
-      ref: github.com/valon-technologies/gestalt-providers/jira
-      version: 1.0.0
+      ref: github.com/valon-technologies/gestalt-providers/plugins/jira
+      version: 0.0.1-alpha.1
 ```
 
 ## Community and Custom Providers

--- a/docs/content/reference/config-file.mdx
+++ b/docs/content/reference/config-file.mdx
@@ -239,10 +239,10 @@ providers:
   cache:
     session:
       source:
-        ref: github.com/valon-technologies/gestalt-providers/cache/redis
+        ref: github.com/valon-technologies/gestalt-providers/cache/valkey
         version: 0.0.1-alpha.1
       config:
-        address: ${REDIS_ADDR}
+        address: ${VALKEY_ADDR}
         database: 0
 
 plugins:

--- a/docs/content/reference/config-file.mdx
+++ b/docs/content/reference/config-file.mdx
@@ -2,11 +2,11 @@ import { Tabs } from 'nextra/components'
 
 # Config File
 
-Every `gestaltd` deployment reads a single YAML config file. The top-level keys are `server` (listener, encryption, egress, and indexeddb selection), `authorization` (shared human/workload access policy), `providers` (auth, secrets, telemetry, audit, mounted UI bundles, and indexeddb), and `plugins` (executable integrations and optional plugin-backed UI mounts):
+Every `gestaltd` deployment reads a single YAML config file. The top-level keys are `server` (listener, encryption, egress, and host-provider selection), `authorization` (shared human/workload access policy), `providers` (named auth, secrets, telemetry, audit, UI, indexeddb, and cache entries), and `plugins` (executable integrations and optional plugin-backed UI mounts):
 
 ```yaml
 server:
-  # listener, encryption, egress, indexeddb selector
+  # listener, encryption, egress, host-provider selectors
 authorization:
   policies: {}
   workloads: {}
@@ -17,6 +17,7 @@ providers:
   audit: {}
   ui: {}
   indexeddb: {}
+  cache: {}
 plugins: {}
 ```
 
@@ -24,7 +25,7 @@ plugins: {}
 
 `${ENV_VAR}` references are expanded before YAML decoding. When a referenced variable is unset, Gestalt checks for a corresponding `ENV_VAR_FILE` variable and reads that file path instead. If neither is set, config loading fails. Use `${ENV_VAR:-}` when an explicit empty default is intentional. Unknown YAML fields are rejected.
 
-Several fields carry defaults when omitted: `server.public.port` defaults to `8080`, `providers.secrets.source` to `env`, and `providers.telemetry.source` to `stdout`. Relative paths resolve relative to the config file's directory. `secret://...` values are resolved during bootstrap, not during YAML parsing.
+Several fields carry defaults when omitted: `server.public.port` defaults to `8080`; `providers.secrets.default` defaults to builtin `env`; `providers.telemetry.default` defaults to builtin `stdout`; and `providers.audit.default` defaults to builtin `inherit`. Relative paths resolve relative to the config file's directory. `secret://...` values are resolved during bootstrap, not during YAML parsing.
 
 `authorization` is the canonical location for shared human and workload access policy. Existing deployments may continue to use `server.authorization` as a deprecated compatibility alias; Gestalt normalizes it into the top-level block during config load and bootstrap.
 
@@ -42,6 +43,9 @@ server:
   encryptionKey: secret://gestalt-encryption-key
   apiTokenTtl: 30d
   artifactsDir: ./state
+  providers:
+    auth: google
+    indexeddb: main
 authorization:
   policies:
     support_staff:
@@ -96,6 +100,7 @@ authorization:
 | `encryptionKey` | | **Required.** Root encryption key. Typically a `secret://` reference. |
 | `apiTokenTtl` | `30d` | Lifetime of newly issued API tokens. Go durations or day suffixes (`30d`). |
 | `artifactsDir` | config directory | Directory for prepared `init` artifacts. |
+| `providers.auth` / `providers.secrets` / `providers.telemetry` / `providers.audit` / `providers.indexeddb` | | Optional selectors for the named host-provider entries under `providers.*`. Required for IndexedDB whenever more than one enabled entry exists and recommended for other host-provider maps when more than one entry exists. |
 | `admin.authorizationPolicy` | | Shared human access policy applied to the built-in `/admin` route. |
 | `admin.allowedRoles` | `[admin]` | Roles allowed to load the built-in `/admin` route when `admin.authorizationPolicy` is set. |
 | `authorization.policies` | | Shared human access policies resolved by `subjectID` or `email`. |
@@ -105,14 +110,15 @@ When `server.management` is configured, Gestalt serves `/`, `/api/v1/*`, auth ro
 
 ## `providers.auth`
 
-Platform auth is optional. Omit the `providers.auth` block entirely to disable platform authentication, or set `providers: { auth: { disabled: true } }` explicitly. When auth is enabled, configure it with `providers.auth.source` and `providers.auth.config`. The source uses the same provider-reference shape as plugins: a `source` block plus optional `env` and `allowedHosts`.
+Platform auth is optional. Omit the `providers.auth` block entirely to disable platform authentication, or add a disabled named entry explicitly. When auth is enabled, configure one or more named entries under `providers.auth`. If more than one entry is enabled, set `server.providers.auth` to pick which one the host should use.
 
 ### `disabled`
 
 ```yaml
 providers:
   auth:
-    disabled: true
+    default:
+      disabled: true
 ```
 
 Disables platform authentication. Every request is treated as a single anonymous user. Omitting the `providers.auth` block has the same effect.
@@ -122,16 +128,17 @@ Disables platform authentication. Every request is treated as a single anonymous
 ```yaml
 providers:
   auth:
-    source:
-      ref: github.com/valon-technologies/gestalt-providers/auth/google
-      version: 0.0.1-alpha.1
-    config:
-      clientId: ${GOOGLE_CLIENT_ID}
-      clientSecret: secret://google-client-secret
-      redirectUrl: https://gestalt.example.com/api/v1/auth/login/callback
-      allowedDomains:
-        - example.com
-      sessionTtl: 24h
+    google:
+      source:
+        ref: github.com/valon-technologies/gestalt-providers/auth/google
+        version: 0.0.1-alpha.1
+      config:
+        clientId: ${GOOGLE_CLIENT_ID}
+        clientSecret: secret://google-client-secret
+        redirectUrl: https://gestalt.example.com/api/v1/auth/login/callback
+        allowedDomains:
+          - example.com
+        sessionTtl: 24h
 ```
 
 `clientId` and `clientSecret` are both required and identify your Google OAuth application. `redirectUrl` defaults to a path derived from `server.baseUrl` when omitted. `allowedDomains` restricts login to specific email domains. `sessionTtl` controls session token lifetime and defaults to `24h`.
@@ -143,26 +150,27 @@ Google checks `email_verified` on every login. Unverified accounts are rejected.
 ```yaml
 providers:
   auth:
-    source:
-      ref: github.com/valon-technologies/gestalt-providers/auth/oidc
-      version: 0.0.1-alpha.1
-    config:
-      issuerUrl: https://login.example.com
-      clientId: ${OIDC_CLIENT_ID}
-      clientSecret: secret://oidc-client-secret
-      redirectUrl: https://gestalt.example.com/api/v1/auth/login/callback
-      allowedDomains:
-        - example.com
-      scopes:
-        - openid
-        - email
-        - profile
-      sessionTtl: 24h
-      pkce: true
-      displayName: Company SSO
-      allowInsecureHttp: false
-      pkceVerifierTtl: 1h
-      pkceVerifierMaxItems: 10000
+    oidc:
+      source:
+        ref: github.com/valon-technologies/gestalt-providers/auth/oidc
+        version: 0.0.1-alpha.1
+      config:
+        issuerUrl: https://login.example.com
+        clientId: ${OIDC_CLIENT_ID}
+        clientSecret: secret://oidc-client-secret
+        redirectUrl: https://gestalt.example.com/api/v1/auth/login/callback
+        allowedDomains:
+          - example.com
+        scopes:
+          - openid
+          - email
+          - profile
+        sessionTtl: 24h
+        pkce: true
+        displayName: Company SSO
+        allowInsecureHttp: false
+        pkceVerifierTtl: 1h
+        pkceVerifierMaxItems: 10000
 ```
 
 Two fields are required: `issuerUrl` (the OIDC discovery base URL) and `clientId`. `clientSecret` may be omitted for PKCE-only public clients.
@@ -179,12 +187,15 @@ OIDC checks `email_verified` when the claim is present. Unverified accounts are 
 
 ### `providers.auth` shape
 
-Both `google` and `oidc` use the same PluginDef provider reference shape under `providers.auth`. First-party auth providers are published at `github.com/valon-technologies/gestalt-providers/auth/<name>`.
+Both `google` and `oidc` use the same ProviderEntry shape under `providers.auth.<name>`. First-party auth providers are published at `github.com/valon-technologies/gestalt-providers/auth/<name>`.
 
 | Field | Description |
 | --- | --- |
+| `disabled` | `true` disables this named auth entry. |
+| `default` | Marks this named auth entry as the default selection when `server.providers.auth` is omitted. |
 | `source.ref` | Managed provider source address. |
 | `source.version` | Required with `source.ref`. SemVer without a leading `v`. |
+| `config` | Provider-specific config passed into the auth provider. |
 | `env` | Extra environment variables passed to the provider process. |
 | `allowedHosts` | Network allowlist for sandboxed provider processes. |
 
@@ -253,14 +264,15 @@ First-party cache providers are published at
 
 ## `providers.secrets`
 
-The secrets manager resolves `secret://` references at startup. Two built-in sources (`env` and `file`) are selected by the `source` field. Cloud secret backends are loaded as external providers using `source.ref`, the same way auth and indexeddb providers work.
+The secrets manager resolves `secret://` references at startup. Configure one or more named entries under `providers.secrets`; when omitted entirely, Gestalt synthesizes `providers.secrets.default` with builtin `env`. If you configure more than one enabled entry, set `server.providers.secrets` to pick the active one.
 
 ```yaml
 providers:
   secrets:
-    source: file
-    config:
-      dir: /etc/gestalt-secrets
+    default:
+      source: file
+      config:
+        dir: /etc/gestalt-secrets
 ```
 
 | Source | Config fields | Purpose |
@@ -275,11 +287,12 @@ Cloud secret managers are external providers configured with `source.ref` instea
 ```yaml
 providers:
   secrets:
-    source:
-      ref: github.com/valon-technologies/gestalt-providers/secrets/google
-      version: 0.0.1-alpha.13
-    config:
-      project: my-gcp-project
+    gsm:
+      source:
+        ref: github.com/valon-technologies/gestalt-providers/secrets/google
+        version: 0.0.1-alpha.13
+      config:
+        project: my-gcp-project
 ```
 
 | Provider | Source ref | Config fields |
@@ -293,7 +306,7 @@ See [Secrets Providers](/providers/secrets) for the complete reference and SDK i
 
 ### Bootstrap credentials
 
-`secret://` references are resolved through the configured secret manager at startup, but the secret manager's own configuration (`providers.secrets.config`) cannot use `secret://` because it would be self-referential. Use `${ENV_VAR}` or `${ENV_VAR_FILE}` placeholders for any credentials the secret manager itself needs.
+`secret://` references are resolved through the configured secret manager at startup, but the secret manager's own configuration (`providers.secrets.<name>.config`) cannot use `secret://` because it would be self-referential. Use `${ENV_VAR}` or `${ENV_VAR_FILE}` placeholders for any credentials the secret manager itself needs.
 
 Each provider authenticates to its backing service differently. The `env` and `file` providers are built in. The remaining rows apply when using the corresponding external provider from `gestalt-providers`:
 
@@ -312,16 +325,19 @@ For local development, `env` or `file` avoids external dependencies entirely. Sw
 
 Gestalt uses [OpenTelemetry](https://opentelemetry.io) for distributed traces, metrics, and structured logs. Every HTTP request, broker invocation, and plugin gRPC call is automatically traced. See [Observability](/observability) for the emitted metric inventory and Prometheus name translation.
 
+Configure one or more named telemetry entries under `providers.telemetry`. When the block is omitted, Gestalt synthesizes `providers.telemetry.default` with builtin `stdout`. If you configure more than one enabled entry, set `server.providers.telemetry` to pick the active one.
+
 ### `stdout`
 
 ```yaml
 providers:
   telemetry:
-    source: stdout
-    config:
-      format: text
-      level: info
-      serviceName: gestaltd
+    default:
+      source: stdout
+      config:
+        format: text
+        level: info
+        serviceName: gestaltd
 ```
 
 Outputs structured logs to standard output. Traces remain disabled, but metrics are collected locally and exposed through the Prometheus-compatible `/metrics` endpoint. The built-in admin UI at `/admin` reads that same scrape surface. This is the default when `providers.telemetry` is omitted.
@@ -339,24 +355,25 @@ Outputs structured logs to standard output. Traces remain disabled, but metrics 
 ```yaml
 providers:
   telemetry:
-    source: otlp
-    config:
-      endpoint: otel-collector:4317
-      protocol: grpc
-      serviceName: gestaltd
-      insecure: false
-      headers:
-        Authorization: Bearer ${OTEL_TOKEN}
-      resourceAttributes:
-        deployment.environment: production
-        service.version: "1.0.0"
-      traces:
-        samplingRatio: 1.0
-      metrics:
-        interval: 60s
-      logs:
-        exporter: otlp
-        level: info
+    default:
+      source: otlp
+      config:
+        endpoint: otel-collector:4317
+        protocol: grpc
+        serviceName: gestaltd
+        insecure: false
+        headers:
+          Authorization: Bearer ${OTEL_TOKEN}
+        resourceAttributes:
+          deployment.environment: production
+          service.version: "1.0.0"
+        traces:
+          samplingRatio: 1.0
+        metrics:
+          interval: 60s
+        logs:
+          exporter: otlp
+          level: info
 ```
 
 Exports to any OpenTelemetry-compatible collector (Jaeger, Grafana Alloy, Datadog Agent) while still keeping local `/metrics` available by default. The built-in admin UI at `/admin` reads that same local scrape surface.
@@ -381,16 +398,17 @@ To keep system logs on stdout while still exporting traces and metrics over OTLP
 ```yaml
 providers:
   telemetry:
-    source: otlp
-    config:
-      endpoint: otel-collector:4317
-      protocol: grpc
-      metrics:
-        interval: 60s
-      logs:
-        exporter: stdout
-        format: json
-        level: info
+    default:
+      source: otlp
+      config:
+        endpoint: otel-collector:4317
+        protocol: grpc
+        metrics:
+          interval: 60s
+        logs:
+          exporter: stdout
+          format: json
+          level: info
 ```
 
 ### `noop`
@@ -398,7 +416,8 @@ providers:
 ```yaml
 providers:
   telemetry:
-    source: noop
+    default:
+      source: noop
 ```
 
 Disables all telemetry. Instrumentation points remain but produce zero overhead. This disables Prometheus scraping. `/metrics` returns a clear unavailable response, and the built-in admin UI shows that metrics are unavailable.
@@ -413,28 +432,30 @@ Disables all telemetry. Instrumentation points remain but produce zero overhead.
 
 ## `providers.audit`
 
-Audit records are emitted as structured log entries with `log.type=audit`. By default they inherit the normal telemetry log pipeline, but you can override that with a dedicated `providers.audit` block. See [Audit Logging](/audit-logging) for the event schema and coverage details, and [Observability](/observability) for export options. If you keep `providers: { audit: { source: inherit } }`, you can still route audit traffic to a dedicated backend by filtering on `log.type=audit` in your collector.
+Audit records are emitted as structured log entries with `log.type=audit`. Configure one or more named entries under `providers.audit`; when the block is omitted, Gestalt synthesizes `providers.audit.default` with builtin `inherit`. If you configure more than one enabled entry, set `server.providers.audit` to pick the active one. See [Audit Logging](/audit-logging) for the event schema and coverage details, and [Observability](/observability) for export options. If you keep `providers.audit.default.source: inherit`, you can still route audit traffic to a dedicated backend by filtering on `log.type=audit` in your collector.
 
 ### `inherit`
 
 ```yaml
 providers:
   audit:
-    source: inherit
+    default:
+      source: inherit
 ```
 
 This is the default when `providers.audit` is omitted. Audit records follow the same log route as `providers.telemetry`: when telemetry uses `stdout`, audit logs go to standard output; when telemetry uses `otlp`, audit logs export through the OTLP log pipeline; when telemetry uses `noop`, audit output is disabled unless you override it here.
 
-`providers.audit.config` is not allowed when `providers.audit.source` is `inherit`.
+`providers.audit.<name>.config` is not allowed when `providers.audit.<name>.source` is `inherit`.
 
 ### `stdout`
 
 ```yaml
 providers:
   audit:
-    source: stdout
-    config:
-      format: json
+    default:
+      source: stdout
+      config:
+        format: json
 ```
 
 Writes audit records to standard output even if the main telemetry pipeline is using a different provider.
@@ -449,16 +470,17 @@ Writes audit records to standard output even if the main telemetry pipeline is u
 ```yaml
 providers:
   audit:
-    source: otlp
-    config:
-      endpoint: audit-collector:4317
-      protocol: grpc
-      serviceName: gestaltd
-      insecure: false
-      headers:
-        Authorization: Bearer ${AUDIT_OTLP_TOKEN}
-      resourceAttributes:
-        log.stream: audit
+    default:
+      source: otlp
+      config:
+        endpoint: audit-collector:4317
+        protocol: grpc
+        serviceName: gestaltd
+        insecure: false
+        headers:
+          Authorization: Bearer ${AUDIT_OTLP_TOKEN}
+        resourceAttributes:
+          log.stream: audit
 ```
 
 Exports audit records over OTLP without changing where application logs, metrics, or traces go. Use this when you want audit records in a dedicated compliance pipeline while keeping the rest of `gestaltd` on `stdout` or a different OTLP collector.
@@ -477,10 +499,11 @@ Exports audit records over OTLP without changing where application logs, metrics
 ```yaml
 providers:
   audit:
-    source: noop
+    default:
+      source: noop
 ```
 
-Disables audit output explicitly. `providers.audit.config` is not allowed when `providers.audit.source` is `noop`.
+Disables audit output explicitly. `providers.audit.<name>.config` is not allowed when `providers.audit.<name>.source` is `noop`.
 
 ## `plugins`
 
@@ -496,7 +519,7 @@ plugins:
     mountPath: /github
     ui: github_console
     source:
-      ref: github.com/valon-technologies/gestalt-providers/github
+      ref: github.com/valon-technologies/gestalt-providers/plugins/github
       version: 1.2.3
     surfaces:
       openapi:
@@ -542,7 +565,7 @@ Every plugin uses a `source` block to declare its backing provider.
 
 ```yaml
 source:
-  ref: github.com/valon-technologies/gestalt-providers/github
+  ref: github.com/valon-technologies/gestalt-providers/plugins/github
   version: 1.2.3
 ```
 
@@ -822,7 +845,7 @@ Structural validation runs at config load time (`init`, `validate`, `serve`). Ru
 
 Each plugin uses a `source` block. Every plugin must use exactly one loading mode: local `source.path` or managed `source.ref`. `source.version` is required with `source.ref` and invalid with `source.path`.
 
-Auth providers and indexeddb entries use the same external provider shape. When `providers.auth` or `providers.indexeddb.<name>` is set, `source.ref` or `source.path` must be present. `providers.auth.config` and `providers.indexeddb.<name>.config` are only allowed when their corresponding source is set.
+Host-provider entries use the same ProviderEntry shape. When `providers.auth.<name>` or `providers.indexeddb.<name>` is set, `source.ref` or `source.path` must be present unless the entry is explicitly disabled. `providers.auth.<name>.config` and `providers.indexeddb.<name>.config` are only allowed when their corresponding source is set.
 
 Only `connections.default` may define `params` or `discovery`. All connections in a plugin must share the same mode.
 

--- a/docs/content/reference/http-api.mdx
+++ b/docs/content/reference/http-api.mdx
@@ -6,7 +6,7 @@ The HTTP API uses "integrations" in route paths (e.g. `/api/v1/integrations`) as
 
 ## Authentication model
 
-Authenticated routes accept a `session_token` cookie or an `Authorization: Bearer <token>` header. Valid bearer tokens are platform session tokens and Gestalt API tokens (`gst_api_...`).
+Authenticated routes accept a `session_token` cookie or an `Authorization: Bearer <token>` header. Valid bearer tokens include Gestalt API tokens (`gst_api_...`), workload tokens (`gst_wld_...`), and auth-provider-issued tokens when the configured platform auth provider supports direct token validation.
 
 ## Unauthenticated Routes
 

--- a/docs/content/reference/plugin-manifests.mdx
+++ b/docs/content/reference/plugin-manifests.mdx
@@ -300,7 +300,7 @@ The `spec` block for a `kind: auth` manifest describes a platform auth provider 
 
 | Field | Type | Purpose |
 | --- | --- | --- |
-| `configSchemaPath` | string | Path to a JSON/YAML schema that validates the `auth.config` block in the server config. |
+| `configSchemaPath` | string | Path to a JSON/YAML schema that validates the `providers.auth.<name>.config` block in the server config. |
 
 Auth providers require an executable entrypoint. Declare it under `entrypoint`.
 
@@ -325,7 +325,7 @@ The `spec` block for a `kind: indexeddb` manifest describes a persistence backen
 
 | Field | Type | Purpose |
 | --- | --- | --- |
-| `configSchemaPath` | string | Path to a JSON/YAML schema that validates the `datastores.<name>.config` block in the server config. |
+| `configSchemaPath` | string | Path to a JSON/YAML schema that validates the `providers.indexeddb.<name>.config` block in the server config. |
 
 IndexedDB providers require an executable entrypoint. Declare it under `entrypoint`.
 

--- a/docs/content/security.mdx
+++ b/docs/content/security.mdx
@@ -35,8 +35,9 @@ Requests are authenticated in the following order:
 
 1. Check for a `session_token` cookie
 2. Check for an `Authorization: Bearer` header with a `gst_api_` prefix (API token lookup via SHA-256 hash)
-3. Check for an `Authorization: Bearer` header with a provider-issued token
-4. If no valid credentials are found, return 401
+3. Check for an `Authorization: Bearer` header with a `gst_wld_` prefix (workload token lookup)
+4. Check for an `Authorization: Bearer` header with a provider-issued token
+5. If no valid credentials are found, return 401
 
 ## Security headers
 
@@ -89,7 +90,7 @@ Executable plugin providers run with additional OS-level isolation when `allowed
 | Setting | Impact |
 | --- | --- |
 | `server.encryptionKey` | Root deployment secret. If compromised, all stored tokens can be decrypted. Use a strong random string or 64-character hex key. Must be the same across all instances in a cluster. |
-| `providers.auth` | Omitting `providers.auth` or setting `providers: { auth: { disabled: true } }` disables all authentication. Do not use in production. |
+| `providers.auth` | Omitting `providers.auth` or setting `providers.auth.default.disabled: true` disables all authentication. Do not use in production. |
 | `server.baseUrl` | Must match the public URL exactly. OAuth callbacks are derived from it. |
 | TLS termination | Gestalt does not terminate TLS. Deploy behind a reverse proxy that handles TLS. |
 | `providers.secrets` | Use a dedicated secret manager in production. `env` is acceptable but secrets may appear in process listings. |

--- a/docs/dockerhub/gestaltd.md
+++ b/docs/dockerhub/gestaltd.md
@@ -62,20 +62,19 @@ server:
   public:
     port: 8080
   encryptionKey: ${GESTALT_ENCRYPTION_KEY}
+  providers:
+    indexeddb: main
 
-datastores:
-  main:
-    provider:
+providers:
+  indexeddb:
+    main:
       source:
         ref: github.com/valon-technologies/gestalt-providers/indexeddb/relationaldb
         version: 0.0.1-alpha.2
-    config:
-      dsn: sqlite:///data/gestalt.db
-datastore: main
+      config:
+        dsn: sqlite:///data/gestalt.db
 
 plugins: {}
-ui:
-  provider: none
 ```
 
 ## Compose example


### PR DESCRIPTION
## Summary
This updates the docs examples under `docs/` to match the current runtime and configuration model after the recent merges.

## What changed
- updated host config examples to use the current named `providers.*` maps and `server.providers.*` selectors
- fixed observability examples to use the current camelCase fields
- corrected Docker/Helm and minimal config examples to match the live schema
- fixed first-party plugin source references and lockfile examples
- aligned auth and HTTP API docs with current token handling

## Why
A number of docs snippets had drifted from the current implementation, especially around provider configuration and deployment examples. This audit brings the published examples back in line with the code.

## Validation
- `npm run typecheck` in `docs/`
- `npm run build` in `docs/` completed the Next.js build successfully
- `npm exec pagefind -- --site out --output-subdir _pagefind` in `docs/`

## Notes
- the worktree had unrelated local changes in `sdk/typescript/src/build.ts`, `sdk/typescript/src/runtime.ts`, and `thoughts/`; those were intentionally left out of this PR