### PR TITLE
Propagate allowedRoles overrides for local plugins

### DIFF
--- a/gestaltd/core/integration/restricted.go
+++ b/gestaltd/core/integration/restricted.go
@@ -17,6 +17,7 @@ type Restricted struct {
 	reverseAlias map[string]string
 	allowedInner map[string]struct{}
 	descriptions map[string]string
+	allowedRoles map[string][]string
 }
 
 // RestrictedOption configures a Restricted provider.
@@ -25,6 +26,11 @@ type RestrictedOption func(*Restricted)
 // WithDescriptions sets description overrides keyed by exposed operation name.
 func WithDescriptions(descs map[string]string) RestrictedOption {
 	return func(r *Restricted) { r.descriptions = descs }
+}
+
+// WithAllowedRoles sets allowedRoles overrides keyed by exposed operation name.
+func WithAllowedRoles(roles map[string][]string) RestrictedOption {
+	return func(r *Restricted) { r.allowedRoles = roles }
 }
 
 // Compile-time interface checks.
@@ -138,6 +144,9 @@ func (r *Restricted) filterCatalog(cat *catalog.Catalog) *catalog.Catalog {
 			}
 			if desc, ok := r.descriptions[op.ID]; ok {
 				op.Description = desc
+			}
+			if roles, ok := r.allowedRoles[op.ID]; ok {
+				op.AllowedRoles = append([]string(nil), roles...)
 			}
 			filtered.Operations = append(filtered.Operations, op)
 		}

--- a/gestaltd/core/integration/restricted_test.go
+++ b/gestaltd/core/integration/restricted_test.go
@@ -86,6 +86,37 @@ func TestCatalogFilters(t *testing.T) {
 	}
 }
 
+func TestCatalogFiltersCanOverrideAllowedRoles(t *testing.T) {
+	t.Parallel()
+
+	inner := &stubWithOps{
+		StubIntegration: coretesting.StubIntegration{N: "test_provider"},
+		ops:             sampleOps(),
+	}
+
+	r := coreintegration.NewRestricted(
+		inner,
+		map[string]string{"list_channels": "", "send_message": ""},
+		coreintegration.WithAllowedRoles(map[string][]string{
+			"list_channels": {"admin"},
+		}),
+	)
+
+	cat := r.Catalog()
+	if cat == nil {
+		t.Fatal("Catalog() returned nil")
+	}
+	if len(cat.Operations) != 2 {
+		t.Fatalf("Catalog().Operations: got %d, want 2", len(cat.Operations))
+	}
+	if got := cat.Operations[0].AllowedRoles; len(got) != 1 || got[0] != "admin" {
+		t.Fatalf("list_channels AllowedRoles = %#v, want [admin]", got)
+	}
+	if got := cat.Operations[1].AllowedRoles; len(got) != 0 {
+		t.Fatalf("send_message AllowedRoles = %#v, want empty", got)
+	}
+}
+
 func TestCatalogPreservesOrder(t *testing.T) {
 	t.Parallel()
 

--- a/gestaltd/internal/operationexposure/policy.go
+++ b/gestaltd/internal/operationexposure/policy.go
@@ -17,6 +17,7 @@ type Policy struct {
 	exposedToOriginal map[string]string
 	originalToExposed map[string]string
 	descriptions      map[string]string
+	allowedRoles      map[string][]string
 }
 
 func New(allowed map[string]*config.OperationOverride) (*Policy, error) {
@@ -50,6 +51,12 @@ func New(allowed map[string]*config.OperationOverride) (*Policy, error) {
 				policy.descriptions = make(map[string]string)
 			}
 			policy.descriptions[exposed] = override.Description
+		}
+		if override != nil && override.AllowedRoles != nil {
+			if policy.allowedRoles == nil {
+				policy.allowedRoles = make(map[string][]string)
+			}
+			policy.allowedRoles[exposed] = append([]string(nil), override.AllowedRoles...)
 		}
 	}
 
@@ -102,6 +109,9 @@ func (p *Policy) Wrap(prov core.Provider) core.Provider {
 	if len(p.descriptions) > 0 {
 		opts = append(opts, coreintegration.WithDescriptions(p.DescriptionOverrides()))
 	}
+	if len(p.allowedRoles) > 0 {
+		opts = append(opts, coreintegration.WithAllowedRoles(p.AllowedRoles()))
+	}
 	return coreintegration.NewRestricted(prov, p.RestrictedMap(), opts...)
 }
 
@@ -131,6 +141,18 @@ func (p *Policy) DescriptionOverrides() map[string]string {
 		descriptions[exposed] = description
 	}
 	return descriptions
+}
+
+func (p *Policy) AllowedRoles() map[string][]string {
+	if len(p.allowedRoles) == 0 {
+		return nil
+	}
+
+	roles := make(map[string][]string, len(p.allowedRoles))
+	for exposed, allowed := range p.allowedRoles {
+		roles[exposed] = append([]string(nil), allowed...)
+	}
+	return roles
 }
 
 func (p *Policy) ApplyOperations(ops []core.Operation) []core.Operation {
@@ -172,6 +194,9 @@ func (p *Policy) ApplyCatalog(cat *catalog.Catalog) *catalog.Catalog {
 		op.ID = exposed
 		if description, ok := p.descriptions[exposed]; ok {
 			op.Description = description
+		}
+		if roles, ok := p.allowedRoles[exposed]; ok {
+			op.AllowedRoles = append([]string(nil), roles...)
 		}
 		filtered.Operations = append(filtered.Operations, op)
 	}

--- a/gestaltd/internal/operationexposure/policy_test.go
+++ b/gestaltd/internal/operationexposure/policy_test.go
@@ -37,7 +37,7 @@ func TestPolicyValidateAndApply(t *testing.T) {
 	t.Parallel()
 
 	policy, err := New(map[string]*config.OperationOverride{
-		"list_items": {Alias: "items", Description: "Custom description"},
+		"list_items": {Alias: "items", Description: "Custom description", AllowedRoles: []string{"admin"}},
 		"get_item":   nil,
 	})
 	if err != nil {
@@ -76,5 +76,8 @@ func TestPolicyValidateAndApply(t *testing.T) {
 	}
 	if filteredCat.Operations[0].ID != "items" || filteredCat.Operations[0].Description != "Custom description" {
 		t.Fatalf("first catalog operation = %+v", filteredCat.Operations[0])
+	}
+	if got := filteredCat.Operations[0].AllowedRoles; len(got) != 1 || got[0] != "admin" {
+		t.Fatalf("first catalog AllowedRoles = %#v, want [admin]", got)
 	}
 }


### PR DESCRIPTION
## Summary
This fixes a host authorization bug for local executable plugins.

`plugins.<name>.allowedOperations.<op>.allowedRoles` already propagates into catalog metadata for OpenAPI and GraphQL providers, but it was not propagating for local executable plugins. That meant policy-bound mounted apps could resolve a human caller as `admin` and still reject the operation at catalog authorization time because the runtime catalog entry still had an empty `allowedRoles` list.

## Behavior Before
Given config like:

```yaml
plugins:
  workplaceHub:
    source:
      path: ./workplace-hub/plugin/manifest.yaml
    authorizationPolicy: workplaceHub
    allowedOperations:
      nyc_desks_get_desks_state:
        allowedRoles:
          - admin
```

OpenAPI / GraphQL providers would expose `nyc_desks_get_desks_state` with `allowedRoles: [admin]`, but a local executable plugin would still expose that operation with no catalog `allowedRoles`.

Under a `default: deny` human policy, `AllowCatalogOperation(...)` would then reject the call even for an explicit admin member.

## Fix
The local-plugin `allowedOperations` wrapper now preserves `AllowedRoles` overrides when it filters and aliases catalogs.

Go interface change in the restricted wrapper:

```go
type RestrictedOption func(*Restricted)

func WithAllowedRoles(roles map[string][]string) RestrictedOption
```

The operation-exposure policy now uses that option when `allowedOperations` includes role overrides, and also preserves those roles in `ApplyCatalog(...)`.

## Validation
- `go test ./core/integration ./internal/operationexposure`
- `git diff --check`

## Why this matters
This is the bug currently blocking the mounted Workplace Hub NYC desks path on `valon.tools`:
- request resolves to `access_policy=workplaceHub`, `access_role=admin`
- host deny point is `authorization_decision=catalog_role_denied`
- the local plugin runtime catalog was dropping the configured `allowedRoles` override for `nyc_desks_get_desks_state`
