### PR TITLE
[codex] write provider lock schema and preserve legacy lock reads

### DIFF
--- a/gestaltd/cmd/gestaltd/e2e_test.go
+++ b/gestaltd/cmd/gestaltd/e2e_test.go
@@ -781,9 +781,14 @@ func TestE2EInitLocalProviders(t *testing.T) {
 	if err := json.Unmarshal(lockData, &lock); err != nil {
 		t.Fatalf("invalid lock file JSON: %v", err)
 	}
-	version, _ := lock["version"].(float64)
-	if version < 1 {
-		t.Fatalf("expected lock version >= 1, got %v", lock["version"])
+	if got, _ := lock["schema"].(string); got != "gestaltd-provider-lock" {
+		t.Fatalf("expected provider lock schema, got %v", lock["schema"])
+	}
+	if got, _ := lock["schemaVersion"].(float64); got < 1 {
+		t.Fatalf("expected schemaVersion >= 1, got %v", lock["schemaVersion"])
+	}
+	if _, ok := lock["version"]; ok {
+		t.Fatalf("expected schema-based lockfile, found legacy version field: %v", lock["version"])
 	}
 }
 

--- a/gestaltd/internal/operator/lifecycle.go
+++ b/gestaltd/internal/operator/lifecycle.go
@@ -137,17 +137,7 @@ func (l *Lifecycle) initAtPath(configPath, artifactsDir string) (*Lockfile, *con
 		return nil, nil, fmt.Errorf("creating providers dir: %w", err)
 	}
 
-	lock := &Lockfile{
-		Version:    LockVersion,
-		Providers:  make(map[string]LockProviderEntry),
-		Auth:       make(map[string]LockEntry),
-		IndexedDBs: make(map[string]LockEntry),
-		Caches:     make(map[string]LockEntry),
-		Secrets:    make(map[string]LockEntry),
-		Telemetry:  make(map[string]LockEntry),
-		Audit:      make(map[string]LockEntry),
-		UIs:        make(map[string]LockUIEntry),
-	}
+	lock := newLockfile()
 
 	resolvedProviders, err := l.writeProviderArtifacts(context.Background(), cfg, paths)
 	if err != nil {
@@ -641,48 +631,39 @@ func ReadLockfile(path string) (*Lockfile, error) {
 	if err != nil {
 		return nil, err
 	}
-	var version struct {
-		Version int `json:"version"`
+	var header struct {
+		Schema        string `json:"schema"`
+		SchemaVersion int    `json:"schemaVersion"`
+		Version       int    `json:"version"`
 	}
-	if err := json.Unmarshal(data, &version); err != nil {
+	if err := json.Unmarshal(data, &header); err != nil {
 		return nil, fmt.Errorf("parsing lockfile %s: %w", path, err)
 	}
-	if version.Version != LockVersion {
-		return nil, fmt.Errorf("unsupported lockfile version %d; run `gestaltd init` to upgrade", version.Version)
+
+	if header.Schema != "" {
+		var lock providerLockfile
+		if err := json.Unmarshal(data, &lock); err != nil {
+			return nil, fmt.Errorf("parsing lockfile %s: %w", path, err)
+		}
+		if err := validateProviderLockfile(&lock); err != nil {
+			return nil, err
+		}
+		return lock.toLockfile(), nil
 	}
+
+	if header.Version != LockVersion {
+		return nil, fmt.Errorf("unsupported lockfile version %d; run `gestaltd init` to upgrade", header.Version)
+	}
+
 	var lock Lockfile
 	if err := json.Unmarshal(data, &lock); err != nil {
 		return nil, fmt.Errorf("parsing lockfile %s: %w", path, err)
 	}
-	if lock.Providers == nil {
-		lock.Providers = make(map[string]LockProviderEntry)
-	}
-	if lock.Auth == nil {
-		lock.Auth = make(map[string]LockEntry)
-	}
-	if lock.Secrets == nil {
-		lock.Secrets = make(map[string]LockEntry)
-	}
-	if lock.Caches == nil {
-		lock.Caches = make(map[string]LockEntry)
-	}
-	if lock.Telemetry == nil {
-		lock.Telemetry = make(map[string]LockEntry)
-	}
-	if lock.Audit == nil {
-		lock.Audit = make(map[string]LockEntry)
-	}
-	if lock.IndexedDBs == nil {
-		lock.IndexedDBs = make(map[string]LockEntry)
-	}
-	if lock.UIs == nil {
-		lock.UIs = make(map[string]LockUIEntry)
-	}
-	return &lock, nil
+	return normalizeLockfile(&lock), nil
 }
 
 func WriteLockfile(path string, lock *Lockfile) error {
-	if err := writeJSONFile(path, lock); err != nil {
+	if err := writeJSONFile(path, providerLockfileFromLockfile(lock)); err != nil {
 		return fmt.Errorf("writing lockfile: %w", err)
 	}
 	return nil
@@ -1892,31 +1873,14 @@ func downloadPlatformArchives(ctx context.Context, lock *Lockfile, platforms []s
 }
 
 func hashPlatformInEntries(ctx context.Context, lock *Lockfile, platformKey string, tokenForSource map[string]string) error {
-	for name, entry := range lock.Providers {
-		if err := hashArchiveEntry(ctx, &entry, platformKey, tokenForSource); err != nil {
-			return err
-		}
-		lock.Providers[name] = entry
-	}
-	for _, lockEntries := range []map[string]LockEntry{lock.Auth, lock.Secrets, lock.Telemetry, lock.Audit} {
+	for _, kind := range providerLockKinds() {
+		lockEntries := lockEntriesForProviderKind(lock, kind)
 		for name, entry := range lockEntries {
 			if err := hashArchiveEntry(ctx, &entry, platformKey, tokenForSource); err != nil {
 				return err
 			}
 			lockEntries[name] = entry
 		}
-	}
-	for name, entry := range lock.IndexedDBs {
-		if err := hashArchiveEntry(ctx, &entry, platformKey, tokenForSource); err != nil {
-			return err
-		}
-		lock.IndexedDBs[name] = entry
-	}
-	for name, entry := range lock.UIs {
-		if err := hashArchiveEntry(ctx, &entry, platformKey, tokenForSource); err != nil {
-			return err
-		}
-		lock.UIs[name] = entry
 	}
 	return nil
 }

--- a/gestaltd/internal/operator/lifecycle_source_test.go
+++ b/gestaltd/internal/operator/lifecycle_source_test.go
@@ -344,12 +344,12 @@ func TestSourcePluginEndToEnd(t *testing.T) {
 	if err != nil {
 		t.Fatalf("read lockfile: %v", err)
 	}
-	var written Lockfile
+	var written providerLockfile
 	if err := json.Unmarshal(lockData, &written); err != nil {
 		t.Fatalf("parse lockfile: %v", err)
 	}
-	if written.Version != LockVersion {
-		t.Errorf("written lockfile version = %d, want %d", written.Version, LockVersion)
+	if written.Schema != providerLockSchemaName {
+		t.Errorf("written lockfile schema = %q, want %q", written.Schema, providerLockSchemaName)
 	}
 
 	readBack, err := ReadLockfile(lockPath)
@@ -476,8 +476,12 @@ func TestSourcePluginLoadForExecution(t *testing.T) {
 	if _, err := os.Stat(executablePath); err != nil {
 		t.Fatalf("executable not rehydrated at %s: %v", executablePath, err)
 	}
-	if cfg.Plugins["gadget"].Command != executablePath {
-		t.Fatalf("plugin command = %q, want %q", cfg.Plugins["gadget"].Command, executablePath)
+	install, err := inspectPreparedInstall(pluginRoot)
+	if err != nil {
+		t.Fatalf("inspectPreparedInstall(%s): %v", pluginRoot, err)
+	}
+	if cfg.Plugins["gadget"].Command != install.executablePath {
+		t.Fatalf("plugin command = %q, want %q", cfg.Plugins["gadget"].Command, install.executablePath)
 	}
 }
 
@@ -539,8 +543,14 @@ func TestSourcePluginLoadForExecution_RehydratesWhenCachedManifestVersionMismatc
 	if err != nil {
 		t.Fatalf("ReadLockfile: %v", err)
 	}
-	entry := lock.Providers["gadget"]
-	manifestPath := resolveLockPath(artifactsDir, entry.Manifest)
+	if _, ok := lock.Providers["gadget"]; !ok {
+		t.Fatal(`lock.Providers["gadget"] not found`)
+	}
+	install, err := inspectPreparedInstall(filepath.Join(artifactsDir, ".gestaltd", "providers", "gadget"))
+	if err != nil {
+		t.Fatalf("inspectPreparedInstall: %v", err)
+	}
+	manifestPath := install.manifestPath
 
 	_, staleManifest, err := providerpkg.ReadManifestFile(manifestPath)
 	if err != nil {
@@ -914,6 +924,21 @@ func TestManagedCacheSourcesLoadForExecutionWithMultipleBindings(t *testing.T) {
 	if _, ok := lock.Caches["rate_limit"]; !ok {
 		t.Fatal(`lock.Caches["rate_limit"] not found`)
 	}
+	lockPath := filepath.Join(dir, InitLockfileName)
+	lockData, err := os.ReadFile(lockPath)
+	if err != nil {
+		t.Fatalf("ReadFile lockfile: %v", err)
+	}
+	var diskLock providerLockfile
+	if err := json.Unmarshal(lockData, &diskLock); err != nil {
+		t.Fatalf("Unmarshal lockfile: %v", err)
+	}
+	if _, ok := diskLock.Providers.Cache["session"]; !ok {
+		t.Fatal(`disk lock cache["session"] not found`)
+	}
+	if _, ok := diskLock.Providers.Cache["rate_limit"]; !ok {
+		t.Fatal(`disk lock cache["rate_limit"] not found`)
+	}
 
 	callsBefore := len(resolver.calls)
 	cfg, _, err := lc.LoadForExecutionAtPath(configPath, true)
@@ -1263,6 +1288,30 @@ func TestSourcePluginGitHubResolverEndToEnd(t *testing.T) {
 
 	configDir := filepath.Dir(configPath)
 	lockPath := filepath.Join(configDir, InitLockfileName)
+	lockData, err := os.ReadFile(lockPath)
+	if err != nil {
+		t.Fatalf("ReadFile lockfile: %v", err)
+	}
+	if !strings.Contains(string(lockData), `"schema": "gestaltd-provider-lock"`) {
+		t.Fatalf("lockfile = %s, want provider lock schema", lockData)
+	}
+	if strings.Contains(string(lockData), `"version": 7`) {
+		t.Fatalf("lockfile = %s, want schema-based versioning", lockData)
+	}
+	if strings.Contains(string(lockData), `"manifest"`) || strings.Contains(string(lockData), `"executable"`) {
+		t.Fatalf("lockfile = %s, want portable entries only", lockData)
+	}
+	var diskLock providerLockfile
+	if err := json.Unmarshal(lockData, &diskLock); err != nil {
+		t.Fatalf("Unmarshal lockfile: %v", err)
+	}
+	diskEntry, ok := diskLock.Providers.Plugin["alpha"]
+	if !ok {
+		t.Fatal(`disk lock providers.plugin["alpha"] not found`)
+	}
+	if diskEntry.Source != testSource || diskEntry.Version != testVersion {
+		t.Fatalf("disk lock plugin entry = %#v", diskEntry)
+	}
 	readBack, err := ReadLockfile(lockPath)
 	if err != nil {
 		t.Fatalf("ReadLockfile: %v", err)
@@ -1317,5 +1366,185 @@ func TestSourcePluginGitHubResolverEndToEnd(t *testing.T) {
 	}
 	if cfg.Plugins["alpha"].Command != executablePath {
 		t.Errorf("plugin command = %q, want %q", cfg.Plugins["alpha"].Command, executablePath)
+	}
+}
+
+func TestSourcePluginInitWithPlatformsPersistsExtraPlatformHash(t *testing.T) {
+	t.Setenv("GITHUB_TOKEN", "wrong-env-token")
+
+	dir := t.TempDir()
+
+	src := pluginsource.Source{
+		Host:  pluginsource.HostGitHub,
+		Owner: testOwner,
+		Repo:  testRepo,
+		Path:  "plugins/" + testPlugin,
+	}
+	expectedTag := src.ReleaseTag(testVersion)
+	releasePath := "/repos/" + testOwner + "/" + testRepo + "/releases/tags/" + expectedTag
+
+	currentAssetName := fmt.Sprintf("gestalt-plugin-%s_v%s_%s_%s.tar.gz", src.PluginName(), testVersion, runtime.GOOS, runtime.GOARCH)
+	extraPlatform := struct {
+		goos   string
+		goarch string
+	}{
+		goos:   "linux",
+		goarch: "amd64",
+	}
+	for _, candidate := range []struct {
+		goos   string
+		goarch string
+	}{
+		{goos: "linux", goarch: "amd64"},
+		{goos: "linux", goarch: "arm64"},
+		{goos: "darwin", goarch: "amd64"},
+		{goos: "darwin", goarch: "arm64"},
+	} {
+		if candidate.goos != runtime.GOOS || candidate.goarch != runtime.GOARCH {
+			extraPlatform = candidate
+			break
+		}
+	}
+	extraPlatformKey := providerpkg.PlatformString(extraPlatform.goos, extraPlatform.goarch)
+	extraAssetName := fmt.Sprintf("gestalt-plugin-%s_v%s_%s_%s.tar.gz", src.PluginName(), testVersion, extraPlatform.goos, extraPlatform.goarch)
+
+	currentArchivePath := buildV2Archive(t, dir, testSource, testVersion, testBinary)
+	currentArchiveData, err := os.ReadFile(currentArchivePath)
+	if err != nil {
+		t.Fatalf("read current archive: %v", err)
+	}
+	extraArchiveData := []byte("extra-platform-archive")
+	extraArchiveSHA := sha256.Sum256(extraArchiveData)
+
+	var releaseCount atomic.Int64
+	var currentAssetCount atomic.Int64
+	var extraAssetCount atomic.Int64
+	handlerErrs := make(chan error, 4)
+	nextHandlerErr := func() error {
+		t.Helper()
+		select {
+		case err := <-handlerErrs:
+			return err
+		default:
+			return nil
+		}
+	}
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch r.URL.Path {
+		case releasePath:
+			releaseCount.Add(1)
+			if got := r.Header.Get("Authorization"); got != "token test-token" {
+				handlerErrs <- fmt.Errorf("release authorization = %q, want %q", got, "token test-token")
+				http.Error(w, "bad release authorization", http.StatusBadRequest)
+				return
+			}
+			w.Header().Set("Content-Type", "application/json")
+			resp := map[string]any{
+				"assets": []map[string]any{
+					{
+						"name":                 currentAssetName,
+						"url":                  "http://" + r.Host + "/asset-current",
+						"browser_download_url": "https://github.com/" + testOwner + "/" + testRepo + "/releases/download/" + expectedTag + "/" + currentAssetName,
+					},
+					{
+						"name":                 extraAssetName,
+						"url":                  "http://" + r.Host + "/asset-extra",
+						"browser_download_url": "https://github.com/" + testOwner + "/" + testRepo + "/releases/download/" + expectedTag + "/" + extraAssetName,
+					},
+				},
+			}
+			_ = json.NewEncoder(w).Encode(resp)
+		case "/asset-current":
+			currentAssetCount.Add(1)
+			if got := r.Header.Get("Authorization"); got != "token test-token" {
+				handlerErrs <- fmt.Errorf("current asset authorization = %q, want %q", got, "token test-token")
+				http.Error(w, "bad asset authorization", http.StatusBadRequest)
+				return
+			}
+			if got := r.Header.Get("Accept"); got != "application/octet-stream" {
+				handlerErrs <- fmt.Errorf("current asset accept = %q, want %q", got, "application/octet-stream")
+				http.Error(w, "bad asset accept", http.StatusBadRequest)
+				return
+			}
+			w.Header().Set("Content-Type", "application/octet-stream")
+			_, _ = w.Write(currentArchiveData)
+		case "/asset-extra":
+			extraAssetCount.Add(1)
+			if got := r.Header.Get("Authorization"); got != "token test-token" {
+				handlerErrs <- fmt.Errorf("extra asset authorization = %q, want %q", got, "token test-token")
+				http.Error(w, "bad asset authorization", http.StatusBadRequest)
+				return
+			}
+			if got := r.Header.Get("Accept"); got != "application/octet-stream" {
+				handlerErrs <- fmt.Errorf("extra asset accept = %q, want %q", got, "application/octet-stream")
+				http.Error(w, "bad asset accept", http.StatusBadRequest)
+				return
+			}
+			w.Header().Set("Content-Type", "application/octet-stream")
+			_, _ = w.Write(extraArchiveData)
+		default:
+			http.NotFound(w, r)
+		}
+	}))
+	defer srv.Close()
+
+	artifactsDir := filepath.Join(dir, "prepared-artifacts")
+	configYAML := requiredComponentConfigYAML(t, dir, filepath.Join(dir, "data.db")) + strings.Join([]string{
+		"plugins:",
+		"  alpha:",
+		"    source:",
+		"      ref: " + testSource,
+		"      version: " + testVersion,
+		"      auth:",
+		"        token: test-token",
+		"server:",
+		"  providers:",
+		"    indexeddb: sqlite",
+		"  artifactsDir: " + artifactsDir,
+		"  encryptionKey: aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
+	}, "\n") + "\n"
+	configPath := filepath.Join(dir, "gestalt.yaml")
+	if err := os.WriteFile(configPath, []byte(configYAML), 0o644); err != nil {
+		t.Fatalf("write config: %v", err)
+	}
+
+	resolver := &ghresolver.GitHubResolver{BaseURL: srv.URL}
+	lc := NewLifecycle(resolver)
+	lock, err := lc.InitAtPathWithPlatforms(configPath, "", []struct{ GOOS, GOARCH, LibC string }{
+		{GOOS: extraPlatform.goos, GOARCH: extraPlatform.goarch},
+	})
+	if err != nil {
+		if handlerErr := nextHandlerErr(); handlerErr != nil {
+			t.Fatal(handlerErr)
+		}
+		t.Fatalf("InitAtPathWithPlatforms: %v", err)
+	}
+	if handlerErr := nextHandlerErr(); handlerErr != nil {
+		t.Fatal(handlerErr)
+	}
+	if got := currentAssetCount.Load(); got != 1 {
+		t.Fatalf("current asset request count = %d, want 1", got)
+	}
+	if got := extraAssetCount.Load(); got != 1 {
+		t.Fatalf("extra asset request count = %d, want 1", got)
+	}
+	if got := releaseCount.Load(); got < 2 {
+		t.Fatalf("release request count = %d, want at least 2", got)
+	}
+
+	entry, ok := lock.Providers["alpha"]
+	if !ok {
+		t.Fatal(`lock.Providers["alpha"] not found`)
+	}
+	if got := entry.Archives[extraPlatformKey].SHA256; got != hex.EncodeToString(extraArchiveSHA[:]) {
+		t.Fatalf("lock extra-platform SHA256 = %q, want %q", got, hex.EncodeToString(extraArchiveSHA[:]))
+	}
+
+	readBack, err := ReadLockfile(filepath.Join(dir, InitLockfileName))
+	if err != nil {
+		t.Fatalf("ReadLockfile: %v", err)
+	}
+	if got := readBack.Providers["alpha"].Archives[extraPlatformKey].SHA256; got != hex.EncodeToString(extraArchiveSHA[:]) {
+		t.Fatalf("readBack extra-platform SHA256 = %q, want %q", got, hex.EncodeToString(extraArchiveSHA[:]))
 	}
 }

--- a/gestaltd/internal/operator/lifecycle_test.go
+++ b/gestaltd/internal/operator/lifecycle_test.go
@@ -1040,8 +1040,9 @@ server:
 	uiEntry.Manifest = "stale/ui/manifest.json"
 	uiEntry.AssetRoot = "stale/ui/assets"
 	lock.UIs["roadmap"] = uiEntry
-	if err := WriteLockfile(filepath.Join(dir, InitLockfileName), lock); err != nil {
-		t.Fatalf("WriteLockfile: %v", err)
+	lockPath := filepath.Join(dir, InitLockfileName)
+	if err := writeJSONFile(lockPath, lock); err != nil {
+		t.Fatalf("writeJSONFile: %v", err)
 	}
 
 	for _, locked := range []bool{false, true} {
@@ -1075,7 +1076,7 @@ server:
 		}
 	}
 
-	rewrittenLock, err := ReadLockfile(filepath.Join(dir, InitLockfileName))
+	rewrittenLock, err := ReadLockfile(lockPath)
 	if err != nil {
 		t.Fatalf("ReadLockfile: %v", err)
 	}
@@ -1087,6 +1088,13 @@ server:
 	}
 	if got := rewrittenLock.UIs["roadmap"].AssetRoot; got != "stale/ui/assets" {
 		t.Fatalf("lock.UIs[roadmap].AssetRoot = %q, want stale path preserved", got)
+	}
+	rewrittenData, err := os.ReadFile(lockPath)
+	if err != nil {
+		t.Fatalf("ReadFile: %v", err)
+	}
+	if !strings.Contains(string(rewrittenData), "stale/provider/manifest.json") || !strings.Contains(string(rewrittenData), "stale/ui/assets") {
+		t.Fatalf("lockfile was unexpectedly rewritten: %s", rewrittenData)
 	}
 }
 
@@ -1360,7 +1368,7 @@ func TestLockProviderEntryForSource_RejectsManifestWithoutProviderKind(t *testin
 	}
 }
 
-func TestHashPlatformInEntries_HashesMountedWebUIArchives(t *testing.T) {
+func TestHashPlatformInEntries_HashesMountedWebUIAndCacheArchives(t *testing.T) {
 	t.Parallel()
 
 	archiveBytes := []byte("mounted-web-ui-archive")
@@ -1371,6 +1379,14 @@ func TestHashPlatformInEntries_HashesMountedWebUIArchives(t *testing.T) {
 	defer srv.Close()
 
 	lock := &Lockfile{
+		Caches: map[string]LockEntry{
+			"session": {
+				Source: "github.com/testowner/cache/session",
+				Archives: map[string]LockArchive{
+					platformKeyGeneric: {URL: srv.URL},
+				},
+			},
+		},
 		UIs: map[string]LockUIEntry{
 			"roadmap": {
 				Source: "github.com/testowner/web/roadmap",
@@ -1388,7 +1404,10 @@ func TestHashPlatformInEntries_HashesMountedWebUIArchives(t *testing.T) {
 	got := lock.UIs["roadmap"].Archives[platformKeyGeneric].SHA256
 	want := hex.EncodeToString(sum[:])
 	if got != want {
-		t.Fatalf("SHA256 = %q, want %q", got, want)
+		t.Fatalf("webui SHA256 = %q, want %q", got, want)
+	}
+	if got := lock.Caches["session"].Archives[platformKeyGeneric].SHA256; got != want {
+		t.Fatalf("cache SHA256 = %q, want %q", got, want)
 	}
 }
 
@@ -2180,12 +2199,8 @@ func TestReadLockfile_RejectsUnsupportedVersion(t *testing.T) {
 
 	dir := t.TempDir()
 	lockPath := filepath.Join(dir, InitLockfileName)
-	lock := &Lockfile{
-		Version:   999,
-		Providers: make(map[string]LockProviderEntry),
-	}
-	if err := WriteLockfile(lockPath, lock); err != nil {
-		t.Fatalf("WriteLockfile: %v", err)
+	if err := os.WriteFile(lockPath, []byte(`{"version":999,"providers":{}}`), 0o644); err != nil {
+		t.Fatalf("WriteFile: %v", err)
 	}
 
 	_, err := ReadLockfile(lockPath)
@@ -2376,6 +2391,20 @@ func TestReadWriteLockfile_RoundTrip(t *testing.T) {
 		t.Fatalf("WriteLockfile: %v", err)
 	}
 
+	lockData, err := os.ReadFile(lockPath)
+	if err != nil {
+		t.Fatalf("ReadFile: %v", err)
+	}
+	if !strings.Contains(string(lockData), `"schema": "gestaltd-provider-lock"`) {
+		t.Fatalf("lockfile = %s, want provider lock schema", lockData)
+	}
+	if strings.Contains(string(lockData), `"version": 7`) {
+		t.Fatalf("lockfile = %s, want schema-based versioning", lockData)
+	}
+	if strings.Contains(string(lockData), `"manifest"`) || strings.Contains(string(lockData), `"executable"`) || strings.Contains(string(lockData), `"assetRoot"`) {
+		t.Fatalf("lockfile = %s, want portable entries only", lockData)
+	}
+
 	got, err := ReadLockfile(lockPath)
 	if err != nil {
 		t.Fatalf("ReadLockfile: %v", err)
@@ -2392,11 +2421,14 @@ func TestReadWriteLockfile_RoundTrip(t *testing.T) {
 	if got.IndexedDBs["main"].Fingerprint != want.IndexedDBs["main"].Fingerprint {
 		t.Fatal("indexeddb fingerprint mismatch")
 	}
-	if got.IndexedDBs["archive"].Executable != want.IndexedDBs["archive"].Executable {
-		t.Fatal("indexeddb executable mismatch")
+	if got.IndexedDBs["archive"].Executable != "" {
+		t.Fatal("indexeddb executable should not round-trip from portable lock schema")
 	}
 	if got.UIs["roadmap"].Source != want.UIs["roadmap"].Source || got.UIs["roadmap"].Version != want.UIs["roadmap"].Version {
 		t.Fatal("ui lock entry mismatch")
+	}
+	if got.Providers["example"].Manifest != "" || got.UIs["roadmap"].AssetRoot != "" {
+		t.Fatal("portable lock schema should not populate local path fields on read")
 	}
 }
 

--- a/gestaltd/internal/operator/lockschema.go
+++ b/gestaltd/internal/operator/lockschema.go
@@ -1,0 +1,208 @@
+package operator
+
+import (
+	"fmt"
+	"maps"
+
+	providermanifestv1 "github.com/valon-technologies/gestalt/server/sdk/providermanifest/v1"
+)
+
+const (
+	providerLockSchemaName    = "gestaltd-provider-lock"
+	providerLockSchemaVersion = 1
+	providerLockRevision      = 0
+	providerLockKindTelemetry = "telemetry"
+	providerLockKindAudit     = "audit"
+)
+
+type providerLockfile struct {
+	Schema        string              `json:"schema"`
+	SchemaVersion int                 `json:"schemaVersion"`
+	Revision      int                 `json:"revision"`
+	Providers     providerLockBuckets `json:"providers"`
+}
+
+type providerLockBuckets struct {
+	Plugin    map[string]portableLockEntry `json:"plugin,omitempty"`
+	Auth      map[string]portableLockEntry `json:"auth,omitempty"`
+	IndexedDB map[string]portableLockEntry `json:"indexeddb,omitempty"`
+	Cache     map[string]portableLockEntry `json:"cache,omitempty"`
+	Secrets   map[string]portableLockEntry `json:"secrets,omitempty"`
+	Telemetry map[string]portableLockEntry `json:"telemetry,omitempty"`
+	Audit     map[string]portableLockEntry `json:"audit,omitempty"`
+	WebUI     map[string]portableLockEntry `json:"webui,omitempty"`
+}
+
+type portableLockEntry struct {
+	Fingerprint string                 `json:"fingerprint"`
+	Source      string                 `json:"source,omitempty"`
+	Version     string                 `json:"version,omitempty"`
+	Archives    map[string]LockArchive `json:"archives,omitempty"`
+}
+
+func newLockfile() *Lockfile {
+	return &Lockfile{
+		Version:    LockVersion,
+		Providers:  make(map[string]LockProviderEntry),
+		Auth:       make(map[string]LockEntry),
+		IndexedDBs: make(map[string]LockEntry),
+		Caches:     make(map[string]LockEntry),
+		Secrets:    make(map[string]LockEntry),
+		Telemetry:  make(map[string]LockEntry),
+		Audit:      make(map[string]LockEntry),
+		UIs:        make(map[string]LockUIEntry),
+	}
+}
+
+func normalizeLockfile(lock *Lockfile) *Lockfile {
+	if lock == nil {
+		return newLockfile()
+	}
+	if lock.Version == 0 {
+		lock.Version = LockVersion
+	}
+	if lock.Providers == nil {
+		lock.Providers = make(map[string]LockProviderEntry)
+	}
+	if lock.Auth == nil {
+		lock.Auth = make(map[string]LockEntry)
+	}
+	if lock.Secrets == nil {
+		lock.Secrets = make(map[string]LockEntry)
+	}
+	if lock.Caches == nil {
+		lock.Caches = make(map[string]LockEntry)
+	}
+	if lock.Telemetry == nil {
+		lock.Telemetry = make(map[string]LockEntry)
+	}
+	if lock.Audit == nil {
+		lock.Audit = make(map[string]LockEntry)
+	}
+	if lock.IndexedDBs == nil {
+		lock.IndexedDBs = make(map[string]LockEntry)
+	}
+	if lock.UIs == nil {
+		lock.UIs = make(map[string]LockUIEntry)
+	}
+	return lock
+}
+
+func providerLockKinds() []string {
+	return []string{
+		providermanifestv1.KindPlugin,
+		providermanifestv1.KindAuth,
+		providermanifestv1.KindIndexedDB,
+		providermanifestv1.KindCache,
+		providermanifestv1.KindSecrets,
+		providerLockKindTelemetry,
+		providerLockKindAudit,
+		providermanifestv1.KindWebUI,
+	}
+}
+
+func lockEntriesForProviderKind(lock *Lockfile, kind string) map[string]LockEntry {
+	if lock == nil {
+		return nil
+	}
+	switch kind {
+	case providermanifestv1.KindPlugin:
+		return lock.Providers
+	case providermanifestv1.KindAuth:
+		return lock.Auth
+	case providermanifestv1.KindIndexedDB:
+		return lock.IndexedDBs
+	case providermanifestv1.KindCache:
+		return lock.Caches
+	case providermanifestv1.KindSecrets:
+		return lock.Secrets
+	case providerLockKindTelemetry:
+		return lock.Telemetry
+	case providerLockKindAudit:
+		return lock.Audit
+	case providermanifestv1.KindWebUI:
+		return lock.UIs
+	default:
+		return nil
+	}
+}
+
+func providerLockfileFromLockfile(lock *Lockfile) *providerLockfile {
+	lock = normalizeLockfile(lock)
+	return &providerLockfile{
+		Schema:        providerLockSchemaName,
+		SchemaVersion: providerLockSchemaVersion,
+		Revision:      providerLockRevision,
+		Providers: providerLockBuckets{
+			Plugin:    portableEntriesFromLockEntries(lock.Providers),
+			Auth:      portableEntriesFromLockEntries(lock.Auth),
+			IndexedDB: portableEntriesFromLockEntries(lock.IndexedDBs),
+			Cache:     portableEntriesFromLockEntries(lock.Caches),
+			Secrets:   portableEntriesFromLockEntries(lock.Secrets),
+			Telemetry: portableEntriesFromLockEntries(lock.Telemetry),
+			Audit:     portableEntriesFromLockEntries(lock.Audit),
+			WebUI:     portableEntriesFromLockEntries(lock.UIs),
+		},
+	}
+}
+
+func (lock *providerLockfile) toLockfile() *Lockfile {
+	runtimeLock := newLockfile()
+	if lock == nil {
+		return runtimeLock
+	}
+	runtimeLock.Providers = lockEntriesFromPortableEntries(lock.Providers.Plugin)
+	runtimeLock.Auth = lockEntriesFromPortableEntries(lock.Providers.Auth)
+	runtimeLock.IndexedDBs = lockEntriesFromPortableEntries(lock.Providers.IndexedDB)
+	runtimeLock.Caches = lockEntriesFromPortableEntries(lock.Providers.Cache)
+	runtimeLock.Secrets = lockEntriesFromPortableEntries(lock.Providers.Secrets)
+	runtimeLock.Telemetry = lockEntriesFromPortableEntries(lock.Providers.Telemetry)
+	runtimeLock.Audit = lockEntriesFromPortableEntries(lock.Providers.Audit)
+	runtimeLock.UIs = lockEntriesFromPortableEntries(lock.Providers.WebUI)
+	return runtimeLock
+}
+
+func validateProviderLockfile(lock *providerLockfile) error {
+	if lock == nil {
+		return fmt.Errorf("unsupported lockfile schema; run `gestaltd init` to upgrade")
+	}
+	if lock.Schema != providerLockSchemaName {
+		return fmt.Errorf("unsupported lockfile schema %q; run `gestaltd init` to upgrade", lock.Schema)
+	}
+	if lock.SchemaVersion != providerLockSchemaVersion {
+		return fmt.Errorf("unsupported lockfile schema version %d; run `gestaltd init` to upgrade", lock.SchemaVersion)
+	}
+	return nil
+}
+
+func portableEntriesFromLockEntries(entries map[string]LockEntry) map[string]portableLockEntry {
+	if len(entries) == 0 {
+		return nil
+	}
+	portable := make(map[string]portableLockEntry, len(entries))
+	for name, entry := range entries {
+		portable[name] = portableLockEntry{
+			Fingerprint: entry.Fingerprint,
+			Source:      entry.Source,
+			Version:     entry.Version,
+			Archives:    maps.Clone(entry.Archives),
+		}
+	}
+	return portable
+}
+
+func lockEntriesFromPortableEntries(entries map[string]portableLockEntry) map[string]LockEntry {
+	if len(entries) == 0 {
+		return make(map[string]LockEntry)
+	}
+	runtimeEntries := make(map[string]LockEntry, len(entries))
+	for name, entry := range entries {
+		runtimeEntries[name] = LockEntry{
+			Fingerprint: entry.Fingerprint,
+			Source:      entry.Source,
+			Version:     entry.Version,
+			Archives:    maps.Clone(entry.Archives),
+		}
+	}
+	return runtimeEntries
+}


### PR DESCRIPTION
## Summary
This PR switches `gestalt.lock.json` writes to the portable provider lock schema while keeping the existing runtime `Lockfile`/`LockEntry` model in memory.

`ReadLockfile` now accepts both the new schema and legacy `version: 7` files, and `init --platform ...` now hashes every provider kind through a shared traversal, including `cache`.

## Go Interface
New internal disk schema:

```go
type providerLockfile struct {
    Schema        string
    SchemaVersion int
    Revision      int
    Providers     providerLockBuckets
}

type providerLockBuckets struct {
    Plugin    map[string]portableLockEntry
    Auth      map[string]portableLockEntry
    IndexedDB map[string]portableLockEntry
    Cache     map[string]portableLockEntry
    Secrets   map[string]portableLockEntry
    Telemetry map[string]portableLockEntry
    Audit     map[string]portableLockEntry
    WebUI     map[string]portableLockEntry
}
```

Read/write behavior now looks like this:

```go
ReadLockfile(path)  // accepts either legacy {"version":7,...} or new provider schema
WriteLockfile(path, lock) // always emits the provider lock schema
```

## YAML Interface
No config YAML changes in this PR.
Existing managed provider configs continue to work unchanged.

Example YAML:

```yaml
plugins:
  alpha:
    source:
      ref: github.com/testowner/testrepo/plugins/testplugin
      version: 1.0.0
providers:
  indexeddb:
    sqlite:
      source:
        path: ./indexeddb-manifest.yaml
      config:
        path: ./gestalt.db
  cache:
    session:
      source:
        ref: github.com/acme/providers/cache-session
        version: 1.0.0
server:
  providers:
    indexeddb: sqlite
  encryptionKey: aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa
```

## Lockfile Example
`gestaltd init` now writes a provider-centric lockfile like this:

```json
{
  "schema": "gestaltd-provider-lock",
  "schemaVersion": 1,
  "revision": 0,
  "providers": {
    "plugin": {
      "alpha": {
        "fingerprint": "...",
        "source": "github.com/testowner/testrepo/plugins/testplugin",
        "version": "1.0.0",
        "archives": {
          "darwin/arm64": {"url": "https://example.com/current.tar.gz", "sha256": "..."},
          "linux/amd64": {"url": "https://example.com/linux-amd64.tar.gz", "sha256": "..."}
        }
      }
    },
    "cache": {
      "session": {
        "fingerprint": "...",
        "source": "github.com/acme/providers/cache-session",
        "version": "1.0.0",
        "archives": {
          "generic": {"url": "https://example.com/cache-session.tar.gz", "sha256": "..."}
        }
      }
    }
  }
}
```

## Examples
- `gestaltd init --config ./gestalt.yaml` now writes the schema-based provider lockfile above.
- `gestaltd init --config ./gestalt.yaml --platform linux/amd64` keeps the same YAML config, adds extra-platform SHA256s through the shared provider traversal, and writes them under `providers.<kind>.<name>.archives["linux/amd64"].sha256`.
- `gestaltd serve --locked` can still boot from an older `version: 7` lockfile during migration because `ReadLockfile` translates it into the current in-memory runtime model.

## Validation
```sh
go test ./internal/operator -count=1
go test ./cmd/gestaltd -count=1
```
