### PR TITLE
Support structured secret refs and remove disabled config entries

### DIFF
--- a/docs/content/architecture/index.mdx
+++ b/docs/content/architecture/index.mdx
@@ -12,9 +12,9 @@ When `gestaltd serve` starts, it goes through a specific sequence that matters w
 
 First, the YAML config file is loaded and `${ENV_VAR}` placeholders are expanded. If a variable isn't set, Gestalt checks for a corresponding `_FILE` variable and reads that file instead (this is how Docker secrets work). If neither exists, config loading fails. Use `${ENV_VAR:-}` when an explicit empty default is intentional. Unknown fields are rejected.
 
-Next, Gestalt initializes the secret manager from `providers.secrets`. This is the one part of config that *cannot* use `secret://` references, because the secret manager doesn't exist yet. Credentials for the secret manager itself have to come in through `${ENV_VAR}` or `${ENV_VAR_FILE}`.
+Next, Gestalt initializes the secret managers from `providers.secrets`. The secret manager config blocks themselves *cannot* use structured secret refs, because the secret managers do not exist yet. Credentials for `providers.secrets.<name>.config` have to come in through `${ENV_VAR}` or `${ENV_VAR_FILE}`.
 
-Once the secret manager is ready, Gestalt resolves every `secret://` reference across the rest of the config: server settings, auth, indexeddb, telemetry, audit, and all plugin configs. The selected secret manager's `providers.secrets.<name>.config` block is skipped to avoid a circular dependency.
+Once the secret managers are ready, Gestalt resolves every structured secret ref across the rest of the config: server settings, auth, indexeddb, telemetry, audit, cache, and all plugin configs. Every ref names its provider explicitly, and each `providers.secrets.<name>.config` block is skipped to avoid a circular dependency.
 
 With secrets resolved, `server.encryptionKey` gets converted into a 32-byte AES key. A 64-character hex string is decoded directly; anything else goes through Argon2id derivation. This derived key protects all stored tokens.
 

--- a/docs/content/architecture/security-internals.mdx
+++ b/docs/content/architecture/security-internals.mdx
@@ -50,7 +50,7 @@ API tokens (`gst_api_*`) work differently: the plaintext is never stored.
 
 ## Secret resolution
 
-`secret://` resolution is a one-shot operation at startup. Gestalt resolves every reference, replaces it in memory, and never consults the secret manager again. If a secret rotates after startup, restart Gestalt to pick it up.
+Structured secret resolution is a one-shot operation at startup. Gestalt resolves every reference, replaces it in memory, and never consults the secret manager again. If a secret rotates after startup, restart Gestalt to pick it up.
 
 The selected secret manager's `providers.secrets.<name>.config` block is excluded from resolution. Use `${ENV_VAR}` or `${ENV_VAR_FILE}` for secret manager credentials.
 

--- a/docs/content/client/web.mdx
+++ b/docs/content/client/web.mdx
@@ -24,7 +24,7 @@ Create and revoke API tokens for programmatic access. Each token shows its name,
 
 ## Authentication
 
-When `providers.auth` points to a Google or OIDC auth provider, the web UI redirects to your identity provider for login. With `providers.auth` disabled, every request is anonymous.
+When `providers.auth` points to a Google or OIDC auth provider, the web UI redirects to your identity provider for login. When `providers.auth` is omitted, every request is anonymous.
 
 ## Custom UI bundles
 

--- a/docs/content/configuration.mdx
+++ b/docs/content/configuration.mdx
@@ -32,7 +32,7 @@ authorization:
 providers:
   auth:                     # named auth providers
     <name>: ...            # each is a ProviderEntry
-  secrets:                  # named secret managers (default: providers.secrets.default = env)
+  secrets:                  # named secret managers
     <name>: ...            # each is a ProviderEntry
   telemetry:                # named telemetry pipelines (default: providers.telemetry.default = stdout)
     <name>: ...            # each is a ProviderEntry
@@ -48,7 +48,7 @@ plugins:
   <name>: ...               # each is a ProviderEntry
 ```
 
-ProviderEntry-backed entries accept `source` (where to load it from), `config` (provider-specific settings), `disabled`, `allowedHosts`, and optional metadata fields. Plugin entries additionally support plugin-only fields such as `connections`, `allowedOperations`, `mountPath`, and `ui`. See the [Config File](/reference/config-file) reference for every field.
+ProviderEntry-backed entries accept `source` (where to load it from), `config` (provider-specific settings), `allowedHosts`, and optional metadata fields. Plugin entries additionally support plugin-only fields such as `connections`, `allowedOperations`, `mountPath`, and `ui`. See the [Config File](/reference/config-file) reference for every field.
 
 ## Key concepts
 
@@ -58,7 +58,7 @@ Gestalt has six core concepts you configure in YAML:
 - **Connection.** How Gestalt authenticates to an upstream API on behalf of a user or service. Connections handle OAuth flows, API keys, and manual credentials.
 - **[IndexedDB.](/providers/indexeddb)** The persistent storage layer. Stores users, sessions, tokens, and credentials through a provider that implements the IndexedDB interface.
 - **[Auth.](/providers/auth)** Platform login for the Gestalt server. Separate from connection auth, which is per-plugin and per-upstream.
-- **[Secrets.](/providers/secrets)** Resolves `secret://` references in the config at startup. Backed by environment variables, files, or cloud secret managers.
+- **[Secrets.](/providers/secrets)** Resolves structured secret refs in the config at startup. Backed by environment variables, files, or cloud secret managers.
 - **[UI.](/providers/web-uis)** Public static UI bundles served under configured path prefixes, either directly from `providers.ui` or through `plugins.<name>.mountPath`. Omit `providers.ui` to run headless.
 
 ## Adding a plugin
@@ -173,7 +173,10 @@ plugins:
       version: 0.0.1
     config:
       clientId: ${GITHUB_CLIENT_ID}
-      clientSecret: secret://github-client-secret
+      clientSecret:
+        secret:
+          provider: default
+          name: github-client-secret
 ```
 
 Not all providers need this. Some providers (like Slack) use OAuth flows that do not require operator-provided app credentials. Check the provider's documentation or config schema for required fields.
@@ -190,7 +193,17 @@ MCP tool exposure is declared in the provider manifest via `spec.mcp: true`. Whe
 
 ## Secrets
 
-The `providers.secrets` map configures how `secret://` references in the config are resolved at startup. When omitted entirely, Gestalt synthesizes `providers.secrets.default` with builtin `env`:
+The `providers.secrets` map configures named secret managers. Each config secret ref names one of those providers explicitly:
+
+```yaml
+server:
+  encryptionKey:
+    secret:
+      provider: default
+      name: gestalt-encryption-key
+```
+
+When `providers.secrets` is omitted entirely, the runtime secrets manager defaults to builtin `env`, but structured refs still require an explicit named provider entry:
 
 ```yaml
 providers:
@@ -236,14 +249,7 @@ The built-in admin UI at `/admin` is always available regardless of this setting
 
 ## Platform auth
 
-The `providers.auth` map protects the web UI, HTTP API, and `/mcp` endpoint. For local development, omit it or disable it explicitly:
-
-```yaml
-providers:
-  auth:
-    default:
-      disabled: true
-```
+The `providers.auth` map protects the web UI, HTTP API, and `/mcp` endpoint. For local development, omit it:
 
 For multi-user deployments, point at a published auth provider:
 
@@ -261,7 +267,10 @@ providers:
       config:
         issuerUrl: https://login.example.com
         clientId: ${OIDC_CLIENT_ID}
-        clientSecret: secret://oidc-client-secret
+        clientSecret:
+          secret:
+            provider: default
+            name: oidc-client-secret
 ```
 
 For production OIDC providers, keep `issuerUrl` on `https://`. If you run a
@@ -270,7 +279,7 @@ local plaintext issuer on loopback for development, add
 
 | Scenario | Configuration |
 | --- | --- |
-| Local development | Omit `providers.auth` or set `providers.auth.default.disabled: true` |
+| Local development | Omit `providers.auth` |
 | Multi-user deployment | `providers.auth.<name>` with a published OIDC or Google auth provider |
 | Per-user upstream access | `mode: user` on plugin connections |
 | Shared service credential | `mode: identity` on plugin connections |
@@ -334,7 +343,7 @@ Gestalt expands `${ENV_VAR}` placeholders before YAML decoding. When a reference
 
 ### Secret resolution
 
-Values prefixed with `secret://` are resolved through the configured secret manager during bootstrap, not during YAML parsing. This lets you reference secrets from Vault, AWS Secrets Manager, Google Secret Manager, or Azure Key Vault without embedding them in the config file.
+Structured secret refs are resolved through the named secret manager during bootstrap, not during YAML parsing. This lets you reference secrets from Vault, AWS Secrets Manager, Google Secret Manager, or Azure Key Vault without embedding them in the config file.
 
 ### Validation
 
@@ -346,7 +355,7 @@ gestaltd validate --config ./config.yaml
 
 ### Defaults and required fields
 
-Gestalt defaults `server.public.port` to `8080`, `providers.secrets.default` to `env`, `providers.telemetry.default` to `stdout`, and `providers.audit.default` to `inherit`. The required fields are `providers.indexeddb`, `server.providers.indexeddb`, and `server.encryptionKey`. Platform auth is optional.
+Gestalt defaults `server.public.port` to `8080`, the runtime secrets manager to builtin `env` when `providers.secrets` is omitted, `providers.telemetry.default` to `stdout`, and `providers.audit.default` to `inherit`. The required fields are `providers.indexeddb`, `server.providers.indexeddb`, and `server.encryptionKey`. Platform auth is optional.
 
 `server.encryptionKey` is the root deployment secret. Gestalt derives token encryption and session material from it. Changing this key invalidates all existing sessions and tokens, so treat it as a meaningful deployment event.
 
@@ -357,12 +366,22 @@ A production deployment with OIDC auth, a GitHub plugin with per-user connection
 ```yaml
 server:
   baseUrl: https://gestalt.example.com
-  encryptionKey: secret://gestalt-encryption-key
+  encryptionKey:
+    secret:
+      provider: default
+      name: gestalt-encryption-key
   providers:
     auth: oidc
+    secrets: default
     indexeddb: main
 
 providers:
+  secrets:
+    default:
+      source: file
+      config:
+        dir: /etc/gestalt-secrets
+
   auth:
     oidc:
       source:
@@ -371,7 +390,10 @@ providers:
       config:
         issuerUrl: https://login.example.com
         clientId: ${OIDC_CLIENT_ID}
-        clientSecret: secret://oidc-client-secret
+        clientSecret:
+          secret:
+            provider: default
+            name: oidc-client-secret
 
   indexeddb:
     main:

--- a/docs/content/custom-providers/auth.mdx
+++ b/docs/content/custom-providers/auth.mdx
@@ -234,17 +234,20 @@ providers:
         path: ./google-auth/manifest.yaml
       config:
         clientId: ${GOOGLE_CLIENT_ID}
-        clientSecret: secret://google-client-secret
+        clientSecret:
+          secret:
+            provider: default
+            name: google-client-secret
         allowedDomains:
           - example.com
 ```
 
 `source.path` points at the auth provider's `manifest.yaml` during development. For production, use `source.ref` and `version` to reference a published release. The `config` block is passed to `Configure` at startup and validated against the config schema if one was declared in the manifest.
 
-Secret references like `secret://google-client-secret` are resolved through the configured secret manager before reaching the provider. Environment variable placeholders like `${GOOGLE_CLIENT_ID}` are expanded during config loading. See [Configuration](/configuration) for details on both.
+Structured secret refs like `clientSecret.secret.provider: default` are resolved through the configured secret manager before reaching the provider. Environment variable placeholders like `${GOOGLE_CLIENT_ID}` are expanded during config loading. See [Configuration](/configuration) for details on both.
 
 ## What to read next
 
-- [Secrets](/providers/secrets): configuring the secret manager that resolves `secret://` references
+- [Secrets](/providers/secrets): configuring the secret manager that resolves structured secret refs
 - [Releasing](/custom-providers/releasing): packaging and publishing provider releases
 - [Built-in Providers](/reference/built-in-providers): first-party auth provider reference

--- a/docs/content/custom-providers/index.mdx
+++ b/docs/content/custom-providers/index.mdx
@@ -38,7 +38,7 @@ providers:
 - [Cache](/custom-providers/cache): plugin-bound cache backends
 - [IndexedDB](/custom-providers/indexeddb): custom storage backends for system
   state
-- [Secrets](/custom-providers/secrets): secret managers for `secret://`
+- [Secrets](/custom-providers/secrets): secret managers for structured secret refs
   resolution
 - [Web UIs](/custom-providers/web-uis): public UI bundles served under
   configured path prefixes

--- a/docs/content/custom-providers/releasing.mdx
+++ b/docs/content/custom-providers/releasing.mdx
@@ -180,7 +180,7 @@ spec:
   configSchemaPath: schemas/ui-config.schema.json
 ```
 
-`gestaltd init` prepares the released UI and records it in `gestalt.lock.json`. `gestaltd serve --locked` then serves the prepared asset root at whatever public path the deployment config binds for that UI bundle. Omit `providers.ui` to run headless with no public UI bundles, or set `providers.ui.<name>.disabled: true` to disable a specific mounted UI entry. The built-in admin UI remains available at `/admin` regardless.
+`gestaltd init` prepares the released UI and records it in `gestalt.lock.json`. `gestaltd serve --locked` then serves the prepared asset root at whatever public path the deployment config binds for that UI bundle. Omit `providers.ui` to run headless with no public UI bundles. The built-in admin UI remains available at `/admin` regardless.
 
 ## Build a release
 

--- a/docs/content/custom-providers/secrets.mdx
+++ b/docs/content/custom-providers/secrets.mdx
@@ -6,7 +6,7 @@ This page covers building custom secrets providers. If you only need to
 configure secret resolution for a deployment, use
 [Providers > Secrets](/providers/secrets).
 
-Secrets providers resolve named secrets at server startup. When the Gestalt config references `secret://my-secret`, the secrets provider fetches the value from whatever backend it wraps (a cloud key vault, a file on disk, an environment variable, etc.) and injects it into the config before any other component starts.
+Secrets providers resolve named secrets at server startup. When the Gestalt config references a structured secret ref, the secrets provider fetches the value from whatever backend it wraps (a cloud key vault, a file on disk, an environment variable, etc.) and injects it into the config before any other component starts.
 
 The built-in `env` and `file` providers cover local development. For production deployments that store secrets in a cloud vault, use an external secrets provider.
 
@@ -226,6 +226,6 @@ providers:
 
 ## What to read next
 
-- [Configuration](/configuration): how `secret://` references are used across the server config
+- [Configuration](/configuration): how structured secret refs are used across the server config
 - [Releasing](/custom-providers/releasing): packaging and publishing provider releases
 - [Built-in Providers](/reference/built-in-providers): full reference for `env` and `file` providers

--- a/docs/content/deploy/docker.mdx
+++ b/docs/content/deploy/docker.mdx
@@ -86,7 +86,7 @@ docker run --rm \
   valontechnologies/gestaltd:latest
 ```
 
-For production, use a dedicated secret manager with `secret://` references. See
+For production, use a dedicated secret manager with structured secret refs. See
 [Configuration](/configuration) for details.
 
 ## Health endpoints

--- a/docs/content/deploy/helm.mdx
+++ b/docs/content/deploy/helm.mdx
@@ -18,7 +18,7 @@ matching `extraEnv` entries.
 
 The default chart profile is intentionally minimal:
 
-- platform auth disabled
+- platform auth omitted
 - SQLite on a PVC mounted at `/data`
 - a static dev-only `server.encryptionKey`
 - one replica

--- a/docs/content/deploy/index.mdx
+++ b/docs/content/deploy/index.mdx
@@ -12,7 +12,7 @@ The server image `valontechnologies/gestaltd:latest` is published for `linux/amd
 
 **Database.** SQLite works for single-instance deployments. For multi-replica or horizontally scaled deployments, use a networked datastore provider such as the first-party `indexeddb/relationaldb`, `indexeddb/dynamodb`, or `indexeddb/mongodb` packages. See [IndexedDB](/providers/indexeddb) for the provider model.
 
-**Secrets.** Use `file` or a cloud secret manager instead of `env` in production. `file` is built in and works with Kubernetes volume-mounted secrets. Cloud backends (Google Secret Manager, AWS Secrets Manager, HashiCorp Vault, Azure Key Vault) are available as external providers from [`gestalt-providers`](https://github.com/valon-technologies/gestalt-providers). Gestalt config supports `secret://` references that are resolved at boot time through the configured secrets provider. See [Secrets Providers](/providers/secrets) for setup details.
+**Secrets.** Use `file` or a cloud secret manager instead of `env` in production. `file` is built in and works with Kubernetes volume-mounted secrets. Cloud backends (Google Secret Manager, AWS Secrets Manager, HashiCorp Vault, Azure Key Vault) are available as external providers from [`gestalt-providers`](https://github.com/valon-technologies/gestalt-providers). Gestalt config supports structured secret refs that are resolved at boot time through the configured secrets provider. See [Secrets Providers](/providers/secrets) for setup details.
 
 **TLS.** Gestalt does not terminate TLS. Deploy behind a reverse proxy or load balancer that handles TLS termination. Set `server.baseUrl` to the public HTTPS URL so that OAuth callback URLs are derived correctly.
 

--- a/docs/content/providers/auth.mdx
+++ b/docs/content/providers/auth.mdx
@@ -39,25 +39,22 @@ providers:
         version: 0.0.1-alpha.1
       config:
         clientId: ${GOOGLE_CLIENT_ID}
-        clientSecret: secret://google-client-secret
+        clientSecret:
+          secret:
+            provider: default
+            name: google-client-secret
         allowedDomains:
           - example.com
 ```
 
-Secret references such as `secret://google-client-secret` are resolved through
-`providers.secrets` before the auth provider receives its config.
+Structured secret refs such as `clientSecret.secret.provider: default` are
+resolved through `providers.secrets` before the auth provider receives its
+config.
 
-To disable platform auth entirely, omit `providers.auth` or set:
+To disable platform auth entirely, omit `providers.auth`.
 
-```yaml
-providers:
-  auth:
-    default:
-      disabled: true
-```
-
-For local development, that disabled mode is the simple default: every request
-is treated as the same anonymous user.
+For local development, omission is the simple default: every request is treated
+as the same anonymous user.
 
 ## Local source during development
 
@@ -69,7 +66,10 @@ providers:
         path: ./google-auth/manifest.yaml
       config:
         clientId: ${GOOGLE_CLIENT_ID}
-        clientSecret: secret://google-client-secret
+        clientSecret:
+          secret:
+            provider: default
+            name: google-client-secret
 ```
 
 ## Building your own auth provider

--- a/docs/content/providers/index.mdx
+++ b/docs/content/providers/index.mdx
@@ -19,7 +19,7 @@ validates it, and starts it with the permissions and request context it needs.
 | `cache` | Plugin-bound cache backends | `providers.cache.<name>` |
 | `indexeddb` | Persistent state backends for users, sessions, tokens, and credentials | `providers.indexeddb.<name>` |
 | `s3` | S3-compatible object stores mounted into plugins | `providers.s3.<name>` |
-| `secrets` | Secret managers that resolve `secret://` references | `providers.secrets.<name>` |
+| `secrets` | Secret managers that resolve structured secret refs | `providers.secrets.<name>` |
 | `webui` | Public UI bundles served under configured path prefixes | `providers.ui` |
 
 ## How providers work
@@ -69,7 +69,10 @@ providers:
       config:
         issuerUrl: https://login.example.com
         clientId: ${OIDC_CLIENT_ID}
-        clientSecret: secret://oidc-client-secret
+        clientSecret:
+          secret:
+            provider: default
+            name: oidc-client-secret
 
   indexeddb:
     main:

--- a/docs/content/providers/plugins.mdx
+++ b/docs/content/providers/plugins.mdx
@@ -47,7 +47,10 @@ plugins:
     config:
       apiBaseUrl: https://api.github.com
       clientId: ${GITHUB_CLIENT_ID}
-      clientSecret: secret://github-client-secret
+      clientSecret:
+        secret:
+          provider: default
+          name: github-client-secret
 ```
 
 During local development, point at a source manifest instead:

--- a/docs/content/providers/secrets.mdx
+++ b/docs/content/providers/secrets.mdx
@@ -1,6 +1,6 @@
 # Secrets
 
-Secrets providers resolve `secret://` references before the rest of the server
+Secrets providers resolve structured secret refs before the rest of the server
 starts. That lets provider config, OAuth app secrets, DSNs, and other sensitive
 values stay out of the main YAML file while still being injected into the final
 runtime config.
@@ -28,6 +28,12 @@ providers:
       source: env
       config:
         prefix: GESTALT_
+
+server:
+  encryptionKey:
+    secret:
+      provider: default
+      name: GESTALT_ENCRYPTION_KEY
 ```
 
 Or use a directory of mounted files:
@@ -54,7 +60,7 @@ providers:
         project: my-gcp-project
 ```
 
-The configured provider resolves each `secret://name` reference before any auth
+The configured provider resolves each structured secret ref before any auth
 provider, plugin provider, or datastore provider receives its config.
 
 ## First-party external secret providers
@@ -75,6 +81,6 @@ Implementation details for custom secrets providers now live under
 
 ## What to read next
 
-- [Configuration](/configuration): using `secret://` across the server config
+- [Configuration](/configuration): using structured secret refs across the server config
 - [Built-in Providers](/reference/built-in-providers): built-in `env` and `file`
 - [Custom Secrets Providers](/custom-providers/secrets): advanced authoring docs

--- a/docs/content/reference/built-in-providers.mdx
+++ b/docs/content/reference/built-in-providers.mdx
@@ -26,7 +26,7 @@ providers:
           - example.com
 ```
 
-To disable platform auth entirely, omit the `providers.auth` block or set `providers.auth.default.disabled: true`.
+To disable platform auth entirely, omit the `providers.auth` block.
 
 ## IndexedDB Providers
 
@@ -55,7 +55,7 @@ providers:
 
 ## Secret Managers
 
-Two secret managers are compiled into the `gestaltd` binary and resolve `secret://` references during bootstrap. Cloud secret backends are available as external providers published from [`valon-technologies/gestalt-providers`](https://github.com/valon-technologies/gestalt-providers).
+Two secret managers are compiled into the `gestaltd` binary and resolve structured secret refs during bootstrap. Cloud secret backends are available as external providers published from [`valon-technologies/gestalt-providers`](https://github.com/valon-technologies/gestalt-providers).
 
 | Name | Purpose |
 | --- | --- |

--- a/docs/content/reference/config-file.mdx
+++ b/docs/content/reference/config-file.mdx
@@ -27,7 +27,7 @@ plugins: {}
 
 `${ENV_VAR}` references are expanded before YAML decoding. When a referenced variable is unset, Gestalt checks for a corresponding `ENV_VAR_FILE` variable and reads that file path instead. If neither is set, config loading fails. Use `${ENV_VAR:-}` when an explicit empty default is intentional. Unknown YAML fields are rejected.
 
-Several fields carry defaults when omitted: `server.public.port` defaults to `8080`; `providers.secrets.default` defaults to builtin `env`; `providers.telemetry.default` defaults to builtin `stdout`; and `providers.audit.default` defaults to builtin `inherit`. Relative paths resolve relative to the config file's directory. `secret://...` values are resolved during bootstrap, not during YAML parsing.
+Several fields carry defaults when omitted: `server.public.port` defaults to `8080`; the runtime secrets manager defaults to builtin `env` when `providers.secrets` is omitted; `providers.telemetry.default` defaults to builtin `stdout`; and `providers.audit.default` defaults to builtin `inherit`. Relative paths resolve relative to the config file's directory. Structured secret refs are resolved during bootstrap, not during YAML parsing.
 
 `authorization` is the canonical location for shared human and workload access policy. Existing deployments may continue to use `server.authorization` as a deprecated compatibility alias; Gestalt normalizes it into the top-level block during config load and bootstrap.
 
@@ -42,7 +42,10 @@ server:
     host: 127.0.0.1
     port: 9090
   baseUrl: https://gestalt.example.com
-  encryptionKey: secret://gestalt-encryption-key
+  encryptionKey:
+    secret:
+      provider: default
+      name: gestalt-encryption-key
   apiTokenTtl: 30d
   artifactsDir: ./state
   providers:
@@ -60,7 +63,10 @@ authorization:
   workloads:
     triage-bot:
       displayName: Triage Bot
-      token: secret://triage-bot-token
+      token:
+        secret:
+          provider: default
+          name: triage-bot-token
       providers:
         github:
           connection: default
@@ -99,10 +105,10 @@ authorization:
 | `management.port` | | Port for the management listener. Required when `management.host` is set. |
 | `management.baseUrl` | | Browser-facing absolute URL for the management listener. Required for protected built-in `/admin` on split public/management deployments. |
 | `baseUrl` | | Public origin URL used for OAuth callbacks and admin UI links. |
-| `encryptionKey` | | **Required.** Root encryption key. Typically a `secret://` reference. |
+| `encryptionKey` | | **Required.** Root encryption key. Typically a structured secret ref. |
 | `apiTokenTtl` | `30d` | Lifetime of newly issued API tokens. Go durations or day suffixes (`30d`). |
 | `artifactsDir` | config directory | Directory for prepared `init` artifacts. |
-| `providers.auth` / `providers.secrets` / `providers.telemetry` / `providers.audit` / `providers.indexeddb` | | Optional selectors for the named host-provider entries under `providers.*`. Required for IndexedDB whenever more than one enabled entry exists and recommended for other host-provider maps when more than one entry exists. |
+| `providers.auth` / `providers.secrets` / `providers.telemetry` / `providers.audit` / `providers.indexeddb` | | Optional selectors for the named host-provider entries under `providers.*`. Required for IndexedDB whenever more than one entry exists and recommended for other host-provider maps when more than one entry exists. |
 | `admin.authorizationPolicy` | | Shared human access policy applied to the built-in `/admin` route. |
 | `admin.allowedRoles` | `[admin]` | Roles allowed to load the built-in `/admin` route when `admin.authorizationPolicy` is set. |
 | `authorization.policies` | | Shared human access policies resolved by `subjectID` or `email`. |
@@ -112,18 +118,7 @@ When `server.management` is configured, Gestalt serves `/`, `/api/v1/*`, auth ro
 
 ## `providers.auth`
 
-Platform auth is optional. Omit the `providers.auth` block entirely to disable platform authentication, or add a disabled named entry explicitly. When auth is enabled, configure one or more named entries under `providers.auth`. If more than one entry is enabled, set `server.providers.auth` to pick which one the host should use.
-
-### `disabled`
-
-```yaml
-providers:
-  auth:
-    default:
-      disabled: true
-```
-
-Disables platform authentication. Every request is treated as a single anonymous user. Omitting the `providers.auth` block has the same effect.
+Platform auth is optional. Omit the `providers.auth` block entirely to disable platform authentication. When auth is enabled, configure one or more named entries under `providers.auth`. If more than one entry exists, set `server.providers.auth` to pick which one the host should use.
 
 ### `google`
 
@@ -136,7 +131,10 @@ providers:
         version: 0.0.1-alpha.1
       config:
         clientId: ${GOOGLE_CLIENT_ID}
-        clientSecret: secret://google-client-secret
+        clientSecret:
+          secret:
+            provider: default
+            name: google-client-secret
         redirectUrl: https://gestalt.example.com/api/v1/auth/login/callback
         allowedDomains:
           - example.com
@@ -159,7 +157,10 @@ providers:
       config:
         issuerUrl: https://login.example.com
         clientId: ${OIDC_CLIENT_ID}
-        clientSecret: secret://oidc-client-secret
+        clientSecret:
+          secret:
+            provider: default
+            name: oidc-client-secret
         redirectUrl: https://gestalt.example.com/api/v1/auth/login/callback
         allowedDomains:
           - example.com
@@ -193,7 +194,6 @@ Both `google` and `oidc` use the same ProviderEntry shape under `providers.auth.
 
 | Field | Description |
 | --- | --- |
-| `disabled` | `true` disables this named auth entry. |
 | `default` | Marks this named auth entry as the default selection when `server.providers.auth` is omitted. |
 | `source.ref` | Managed provider source address. |
 | `source.version` | Required with `source.ref`. SemVer without a leading `v`. |
@@ -298,7 +298,16 @@ other S3-compatible backends without changing application code.
 
 ## `providers.secrets`
 
-The secrets manager resolves `secret://` references at startup. Configure one or more named entries under `providers.secrets`; when omitted entirely, Gestalt synthesizes `providers.secrets.default` with builtin `env`. If you configure more than one enabled entry, set `server.providers.secrets` to pick the active one.
+Structured secret refs name the provider explicitly:
+
+```yaml
+encryptionKey:
+  secret:
+    provider: default
+    name: gestalt-encryption-key
+```
+
+Configure one or more named entries under `providers.secrets`. Every config secret ref uses `secret.provider` to choose one of those named entries. When `providers.secrets` is omitted entirely, the runtime secrets manager defaults to builtin `env`, but structured refs still require an explicit named provider entry. `server.providers.secrets` continues to select the runtime host secrets provider when one is needed outside config resolution.
 
 ```yaml
 providers:
@@ -340,7 +349,7 @@ See [Secrets Providers](/providers/secrets) for the complete reference and SDK i
 
 ### Bootstrap credentials
 
-`secret://` references are resolved through the configured secret manager at startup, but the secret manager's own configuration (`providers.secrets.<name>.config`) cannot use `secret://` because it would be self-referential. Use `${ENV_VAR}` or `${ENV_VAR_FILE}` placeholders for any credentials the secret manager itself needs.
+Structured secret refs are resolved through the named secret manager at startup, but the secret manager's own configuration (`providers.secrets.<name>.config`) cannot use secret refs because it would be self-referential. Use `${ENV_VAR}` or `${ENV_VAR_FILE}` placeholders for any credentials the secret manager itself needs.
 
 Each provider authenticates to its backing service differently. The `env` and `file` providers are built in. The remaining rows apply when using the corresponding external provider from `gestalt-providers`:
 
@@ -359,7 +368,7 @@ For local development, `env` or `file` avoids external dependencies entirely. Sw
 
 Gestalt uses [OpenTelemetry](https://opentelemetry.io) for distributed traces, metrics, and structured logs. Every HTTP request, broker invocation, and plugin gRPC call is automatically traced. See [Observability](/observability) for the emitted metric inventory and Prometheus name translation.
 
-Configure one or more named telemetry entries under `providers.telemetry`. When the block is omitted, Gestalt synthesizes `providers.telemetry.default` with builtin `stdout`. If you configure more than one enabled entry, set `server.providers.telemetry` to pick the active one.
+Configure one or more named telemetry entries under `providers.telemetry`. When the block is omitted, Gestalt synthesizes `providers.telemetry.default` with builtin `stdout`. If you configure more than one entry, set `server.providers.telemetry` to pick the active one.
 
 ### `stdout`
 
@@ -466,7 +475,7 @@ Disables all telemetry. Instrumentation points remain but produce zero overhead.
 
 ## `providers.audit`
 
-Audit records are emitted as structured log entries with `log.type=audit`. Configure one or more named entries under `providers.audit`; when the block is omitted, Gestalt synthesizes `providers.audit.default` with builtin `inherit`. If you configure more than one enabled entry, set `server.providers.audit` to pick the active one. See [Audit Logging](/audit-logging) for the event schema and coverage details, and [Observability](/observability) for export options. If you keep `providers.audit.default.source: inherit`, you can still route audit traffic to a dedicated backend by filtering on `log.type=audit` in your collector.
+Audit records are emitted as structured log entries with `log.type=audit`. Configure one or more named entries under `providers.audit`; when the block is omitted, Gestalt synthesizes `providers.audit.default` with builtin `inherit`. If you configure more than one entry, set `server.providers.audit` to pick the active one. See [Audit Logging](/audit-logging) for the event schema and coverage details, and [Observability](/observability) for export options. If you keep `providers.audit.default.source: inherit`, you can still route audit traffic to a dedicated backend by filtering on `log.type=audit` in your collector.
 
 ### `inherit`
 
@@ -591,7 +600,7 @@ plugins:
 | `surfaces` | Typed host-side overrides for manifest-declared surfaces, such as `surfaces.openapi.baseUrl` or `surfaces.graphql.url`. |
 | `connections` | Named connection declarations. See [connections](#connections) below. |
 | `allowedOperations` | Allowlist with optional `alias`, `description`, and `allowedRoles` overrides per operation. |
-| `indexeddb` | Optional plugin IndexedDB config. `indexeddb.provider` selects which named `providers.indexeddb` entry backs the plugin's single IndexedDB SDK socket; when omitted, the plugin inherits the selected/default host IndexedDB. `indexeddb.db` overrides the plugin-visible database name and defaults to the plugin key. Schema-capable backends derive plugin scoping from that `db` name. `indexeddb.objectStores` optionally allowlists the logical object stores the plugin may use. `indexeddb.disabled: true` opts out entirely. Plugins then call `new IndexedDB()` (or the equivalent SDK helper) against `GESTALT_INDEXEDDB_SOCKET`; they do not choose arbitrary schemas or DSNs at runtime. |
+| `indexeddb` | Optional plugin IndexedDB config. `indexeddb.provider` selects which named `providers.indexeddb` entry backs the plugin's single IndexedDB SDK socket; when omitted, the plugin inherits the selected/default host IndexedDB. `indexeddb.db` overrides the plugin-visible database name and defaults to the plugin key. Schema-capable backends derive plugin scoping from that `db` name. `indexeddb.objectStores` optionally allowlists the logical object stores the plugin may use. Plugins then call `new IndexedDB()` (or the equivalent SDK helper) against `GESTALT_INDEXEDDB_SOCKET`; they do not choose arbitrary schemas or DSNs at runtime. |
 | `s3` | Optional list of named `providers.s3` bindings exposed to the executable plugin through the SDK transport. A single binding also populates the default S3 SDK env var for compatibility. |
 
 ### `plugins.*.source`
@@ -868,7 +877,6 @@ When `authorizationPolicy` is set on a mounted UI, the referenced web UI manifes
 | --- | --- |
 | `path` | Direct mount prefix for this UI when not bound through `plugins.<name>.mountPath`. |
 | `authorizationPolicy` | Direct policy binding for this UI when not bound through `plugins.<name>.mountPath`. |
-| `disabled` | `true` to disable an individual mounted UI entry. |
 | `source` | A source mapping with `source.path` or `source.ref`. |
 | `config` | Optional UI-provider config validated against the bundle schema when present. |
 
@@ -880,13 +888,13 @@ Structural validation runs at config load time (`init`, `validate`, `serve`). Ru
 
 Each plugin uses a `source` block. Every plugin must use exactly one loading mode: local `source.path` or managed `source.ref`. `source.version` is required with `source.ref` and invalid with `source.path`.
 
-Host-provider entries use the same ProviderEntry shape. When `providers.auth.<name>` or `providers.indexeddb.<name>` is set, `source.ref` or `source.path` must be present unless the entry is explicitly disabled. `providers.auth.<name>.config` and `providers.indexeddb.<name>.config` are only allowed when their corresponding source is set.
+Host-provider entries use the same ProviderEntry shape. When `providers.auth.<name>` or `providers.indexeddb.<name>` is set, `source.ref` or `source.path` must be present. `providers.auth.<name>.config` and `providers.indexeddb.<name>.config` are only allowed when their corresponding source is set.
 
 Only `connections.default` may define `params` or `discovery`. All connections in a plugin must share the same mode.
 
-Each `providers.ui.<name>` entry must use exactly one mode: `disabled: true`, or a source mapping with exactly one loading mode: local `providers.ui.<name>.source.path` or managed `providers.ui.<name>.source.ref`. `providers.ui.<name>.source.version` is required with `providers.ui.<name>.source.ref` and invalid with `providers.ui.<name>.source.path`. `providers.ui.<name>.config` is only allowed when `providers.ui.<name>.source` is set.
+Each `providers.ui.<name>` entry must use exactly one loading mode: local `providers.ui.<name>.source.path` or managed `providers.ui.<name>.source.ref`. `providers.ui.<name>.source.version` is required with `providers.ui.<name>.source.ref` and invalid with `providers.ui.<name>.source.path`. `providers.ui.<name>.config` is only allowed when `providers.ui.<name>.source` is set.
 
-Each enabled `plugins.<name>` entry may set `mountPath` to publish a plugin-backed UI. When `plugins.<name>.ui` is set, it must reference an existing enabled UI bundle. When `plugins.<name>.ui` is omitted and `plugins.<name>.mountPath` is set, the plugin manifest must declare `spec.ui`. A given UI may be bound by at most one enabled plugin entry. `plugins.<name>.mountPath` must use the same path rules as a directly mounted UI.
+Each `plugins.<name>` entry may set `mountPath` to publish a plugin-backed UI. When `plugins.<name>.ui` is set, it must reference an existing UI bundle. When `plugins.<name>.ui` is omitted and `plugins.<name>.mountPath` is set, the plugin manifest must declare `spec.ui`. A given UI may be bound by at most one plugin entry. `plugins.<name>.mountPath` must use the same path rules as a directly mounted UI.
 
 Mounted UI bundles are served on the public listener only. The built-in admin UI remains at `/admin`.
 

--- a/docs/content/reference/plugin-manifests.mdx
+++ b/docs/content/reference/plugin-manifests.mdx
@@ -20,7 +20,7 @@ Every manifest defines exactly one provider kind, set by the `kind` field:
 | `cache` | Cache backend for plugin-bound cache bindings. |
 | `indexeddb` | Persistence backend. |
 | `s3` | S3-compatible object store backend. |
-| `secrets` | Secret manager for resolving `secret://` references. |
+| `secrets` | Secret manager for resolving structured secret refs. |
 | `webui` | Static UI package served by `gestaltd`. |
 
 The `kind` field is required. Kind-specific configuration goes under the `spec` block.
@@ -115,7 +115,10 @@ spec:
     ref: github.com/acme/web/roadmap-review
     version: 1.0.0
     auth:
-      token: secret://roadmap-review-ui-source-token
+      token:
+        secret:
+          provider: default
+          name: roadmap-review-ui-source-token
 ```
 
 ### Connections

--- a/docs/content/security.mdx
+++ b/docs/content/security.mdx
@@ -9,7 +9,7 @@ Gestalt sits between callers and upstream APIs. It authenticates users, stores e
 | Internet to Gestalt | User requests | Platform auth (session or API token) |
 | Gestalt to upstream APIs | OAuth tokens, API keys | Credential encryption, TLS, egress host allowlist |
 | Gestalt to providers | Config, operation requests, access tokens | Process isolation, Unix socket, scoped capabilities |
-| Operator to Gestalt | Config, encryption key, secrets | Secret manager, env var expansion, `secret://` refs |
+| Operator to Gestalt | Config, encryption key, secrets | Secret manager, env var expansion, structured secret refs |
 
 ## Encryption at rest
 
@@ -90,7 +90,7 @@ Executable plugin providers run with additional OS-level isolation when `allowed
 | Setting | Impact |
 | --- | --- |
 | `server.encryptionKey` | Root deployment secret. If compromised, all stored tokens can be decrypted. Use a strong random string or 64-character hex key. Must be the same across all instances in a cluster. |
-| `providers.auth` | Omitting `providers.auth` or setting `providers.auth.default.disabled: true` disables all authentication. Do not use in production. |
+| `providers.auth` | Omitting `providers.auth` disables all authentication. Do not use in production. |
 | `server.baseUrl` | Must match the public URL exactly. OAuth callbacks are derived from it. |
 | TLS termination | Gestalt does not terminate TLS. Deploy behind a reverse proxy that handles TLS. |
 | `providers.secrets` | Use a dedicated secret manager in production. `env` is acceptable but secrets may appear in process listings. |

--- a/docs/content/troubleshooting.mdx
+++ b/docs/content/troubleshooting.mdx
@@ -6,7 +6,7 @@ import { Tabs } from 'nextra/components'
 
 When `gestaltd serve --locked` reports that prepared artifacts are missing or stale, the lock state has drifted from the current config. Run `gestaltd init --config ./config.yaml` to re-resolve and re-prepare all references, then start the server again with `gestaltd serve --locked --config ./config.yaml`.
 
-The validation error `server.encryptionKey is required` means the config is missing its root deployment secret. Set `server.encryptionKey` to a `secret://` reference or other secret-backed value. The encryption key is used for token encryption and derived session material, so the server refuses to start without it.
+The validation error `server.encryptionKey is required` means the config is missing its root deployment secret. Set `server.encryptionKey` to a structured secret ref or other secret-backed value. The encryption key is used for token encryption and derived session material, so the server refuses to start without it.
 
 Set `server.encryptionKey` for every real deployment. Gestalt derives token and session encryption from it regardless of which auth and datastore providers you use.
 

--- a/docs/dockerhub/gestaltd.md
+++ b/docs/dockerhub/gestaltd.md
@@ -116,7 +116,7 @@ Gestalt expands `${VAR}` placeholders in the config before YAML decoding. The
 image also supports the `*_FILE` convention: if `VAR` is not set but `VAR_FILE`
 is, `${VAR}` resolves to the contents of that file. This works well with
 Docker secrets. See the [configuration documentation](https://gestaltd.ai/configuration)
-for the full config model and `secret://` reference support.
+for the full config model and structured secret-ref support.
 
 ## Health endpoints
 

--- a/gestaltd/cmd/gestaltd/e2e_test.go
+++ b/gestaltd/cmd/gestaltd/e2e_test.go
@@ -196,6 +196,79 @@ func TestE2EValidateRejectsMalformedYAML(t *testing.T) {
 	}
 }
 
+func TestE2EValidateRejectsLegacyConfigSecretSyntax(t *testing.T) {
+	t.Parallel()
+
+	dir := t.TempDir()
+	cfgPath := filepath.Join(dir, "config.yaml")
+	cfg := `server:
+  encryptionKey: secret://enc-key
+`
+	if err := os.WriteFile(cfgPath, []byte(cfg), 0o644); err != nil {
+		t.Fatalf("WriteFile config: %v", err)
+	}
+
+	out, err := exec.Command(gestaltdBin, "validate", "--config", cfgPath).CombinedOutput()
+	if err == nil {
+		t.Fatalf("expected validate to fail for legacy secret syntax, output: %s", out)
+	}
+	if !strings.Contains(string(out), "legacy secret:// syntax") {
+		t.Fatalf("expected output to mention legacy secret syntax, got: %s", out)
+	}
+}
+
+func TestE2EValidateRejectsMalformedStructuredSecretRef(t *testing.T) {
+	t.Parallel()
+
+	cases := []struct {
+		name      string
+		cfg       string
+		wantError string
+	}{
+		{
+			name: "missing provider",
+			cfg: `server:
+  encryptionKey:
+    secret:
+      name: enc-key
+`,
+			wantError: "secret.provider is required",
+		},
+		{
+			name: "extra key",
+			cfg: `server:
+  encryptionKey:
+    secret:
+      provider: env
+      name: enc-key
+      from: somewhere
+`,
+			wantError: "secret.from is not supported",
+		},
+	}
+
+	for _, tc := range cases {
+		tc := tc
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+
+			dir := t.TempDir()
+			cfgPath := filepath.Join(dir, "config.yaml")
+			if err := os.WriteFile(cfgPath, []byte(tc.cfg), 0o644); err != nil {
+				t.Fatalf("WriteFile config: %v", err)
+			}
+
+			out, err := exec.Command(gestaltdBin, "validate", "--config", cfgPath).CombinedOutput()
+			if err == nil {
+				t.Fatalf("expected validate to fail for malformed structured secret ref, output: %s", out)
+			}
+			if !strings.Contains(string(out), tc.wantError) {
+				t.Fatalf("expected output to mention %q, got: %s", tc.wantError, out)
+			}
+		})
+	}
+}
+
 func setupPluginDir(t *testing.T, baseDir string) string {
 	t.Helper()
 	return setupPluginDirWithVersion(t, baseDir, "0.0.1-alpha.1")

--- a/gestaltd/cmd/gestaltd/run.go
+++ b/gestaltd/cmd/gestaltd/run.go
@@ -335,7 +335,7 @@ func resolveMountedWebUIHandlers(cfg *config.Config) ([]server.MountedWebUI, err
 	mounted := make([]server.MountedWebUI, 0, len(names))
 	for _, name := range names {
 		entry := cfg.Providers.UI[name]
-		if entry == nil || entry.Disabled {
+		if entry == nil {
 			continue
 		}
 		if entry.ResolvedAssetRoot == "" {
@@ -491,7 +491,7 @@ func logConfigSummary(path string, cfg *config.Config) {
 		"server_base_url", maskEmpty(cfg.Server.BaseURL),
 		"server_encryption", maskSecret(cfg.Server.EncryptionKey),
 		"auth_provider", selectedProviderLabel(cfg.SelectedAuthProvider()),
-		"secrets_provider", selectedProviderLabel(cfg.SelectedSecretsProvider()),
+		"runtime_secrets_provider", selectedProviderLabel(cfg.SelectedSecretsProvider()),
 		"telemetry_provider", selectedProviderLabel(cfg.SelectedTelemetryProvider()),
 	)
 

--- a/gestaltd/internal/bootstrap/bootstrap.go
+++ b/gestaltd/internal/bootstrap/bootstrap.go
@@ -269,33 +269,94 @@ type preparedCore struct {
 	Deps            Deps
 }
 
-func prepareSecretManager(ctx context.Context, cfg *config.Config, factories *FactoryRegistry) (core.SecretManager, error) {
-	sm, err := buildSecretManager(cfg, factories)
+type configSecretManagers struct {
+	ctx       context.Context
+	cfg       *config.Config
+	factories *FactoryRegistry
+	managers  map[string]core.SecretManager
+}
+
+func newConfigSecretManagers(ctx context.Context, cfg *config.Config, factories *FactoryRegistry) (*configSecretManagers, error) {
+	referenced, err := config.ReferencedConfigSecretProviders(cfg)
 	if err != nil {
 		return nil, err
 	}
-	if err := resolveSecretRefs(ctx, cfg, sm); err != nil {
-		_ = closeSecretManager(sm)
+	if len(referenced) == 0 {
+		return nil, nil
+	}
+	return &configSecretManagers{
+		ctx:       ctx,
+		cfg:       cfg,
+		factories: factories,
+		managers:  make(map[string]core.SecretManager, len(referenced)),
+	}, nil
+}
+
+func (r *configSecretManagers) resolve(ref config.SecretRef) (string, error) {
+	sm, err := r.manager(ref.Provider)
+	if err != nil {
+		return "", err
+	}
+	value, err := sm.GetSecret(r.ctx, ref.Name)
+	if err != nil {
+		return "", fmt.Errorf("provider %q: %w", ref.Provider, err)
+	}
+	return value, nil
+}
+
+func (r *configSecretManagers) manager(name string) (core.SecretManager, error) {
+	if sm, ok := r.managers[name]; ok {
+		return sm, nil
+	}
+	entry := r.cfg.Providers.Secrets[name]
+	if entry == nil {
+		return nil, fmt.Errorf("config validation: secret refs reference unknown secrets provider %q", name)
+	}
+	sm, err := buildNamedSecretManager(name, entry, r.factories)
+	if err != nil {
 		return nil, err
 	}
+	r.managers[name] = sm
 	return sm, nil
 }
 
-// ResolveConfigSecrets resolves secret:// references in config using the
-// configured secrets provider, then closes the temporary secret manager.
-func ResolveConfigSecrets(ctx context.Context, cfg *config.Config, factories *FactoryRegistry) error {
-	sm, err := prepareSecretManager(ctx, cfg, factories)
+func (r *configSecretManagers) Close() error {
+	if r == nil {
+		return nil
+	}
+	var errs []error
+	for _, sm := range r.managers {
+		errs = append(errs, closeSecretManager(sm))
+	}
+	return errors.Join(errs...)
+}
+
+func resolveConfigSecrets(ctx context.Context, cfg *config.Config, factories *FactoryRegistry) error {
+	resolver, err := newConfigSecretManagers(ctx, cfg, factories)
 	if err != nil {
 		return err
 	}
-	return closeSecretManager(sm)
+	if resolver == nil {
+		return nil
+	}
+	defer func() { _ = resolver.Close() }()
+	return resolveSecretRefs(cfg, resolver.resolve)
+}
+
+// ResolveConfigSecrets resolves structured config secret refs using their
+// referenced secrets providers, then closes the temporary secret managers.
+func ResolveConfigSecrets(ctx context.Context, cfg *config.Config, factories *FactoryRegistry) error {
+	return resolveConfigSecrets(ctx, cfg, factories)
 }
 
 func prepareCore(ctx context.Context, cfg *config.Config, factories *FactoryRegistry, requireEncryptionKey bool) (*preparedCore, error) {
 	if err := config.NormalizeCompatibility(cfg); err != nil {
 		return nil, err
 	}
-	sm, err := prepareSecretManager(ctx, cfg, factories)
+	if err := resolveConfigSecrets(ctx, cfg, factories); err != nil {
+		return nil, err
+	}
+	sm, err := buildRuntimeSecretManager(cfg, factories)
 	if err != nil {
 		return nil, err
 	}
@@ -357,7 +418,7 @@ func prepareCore(ctx context.Context, cfg *config.Config, factories *FactoryRegi
 	hostIndexedDBs := map[string]indexeddb.IndexedDB{selectedIndexedDBName: store}
 	var extraIndexedDBs []indexeddb.IndexedDB
 	for name, entry := range cfg.Providers.IndexedDB {
-		if name == selectedIndexedDBName {
+		if name == selectedIndexedDBName || entry == nil {
 			continue
 		}
 		ds, err := buildIndexedDB(entry, factories)
@@ -384,7 +445,7 @@ func prepareCore(ctx context.Context, cfg *config.Config, factories *FactoryRegi
 	hostS3s := make(map[string]s3store.Client, len(cfg.Providers.S3))
 	var extraS3s []s3store.Client
 	for name, entry := range cfg.Providers.S3 {
-		if entry == nil || entry.Disabled {
+		if entry == nil {
 			continue
 		}
 		client, err := buildS3(name, entry, factories)
@@ -522,13 +583,6 @@ func buildTelemetry(cfg *config.Config, factories *FactoryRegistry) (core.Teleme
 	if err != nil {
 		return nil, err
 	}
-	if tel != nil && tel.Disabled {
-		factory, ok := factories.Telemetry["noop"]
-		if !ok {
-			return nil, fmt.Errorf("bootstrap: noop telemetry factory is not registered")
-		}
-		return factory(tel.Config)
-	}
 	if tel != nil && !tel.Source.IsBuiltin() {
 		return nil, fmt.Errorf("bootstrap: provider-based telemetry providers are not yet supported")
 	}
@@ -553,9 +607,6 @@ func buildAuditSink(ctx context.Context, cfg *config.Config, factories *FactoryR
 	_, audit, err := cfg.SelectedAuditProvider()
 	if err != nil {
 		return nil, nil, err
-	}
-	if audit != nil && audit.Disabled {
-		return invocation.NewLoggerAuditSink(slog.New(slog.DiscardHandler)), nil, nil
 	}
 	if audit != nil && !audit.Source.IsBuiltin() {
 		return nil, nil, fmt.Errorf("bootstrap: provider-based audit providers are not yet supported")
@@ -582,23 +633,21 @@ func buildAuditSink(ctx context.Context, cfg *config.Config, factories *FactoryR
 	return sink, closeFn, nil
 }
 
-type disabledSecretManager struct{}
-
-var errSecretsDisabled = fmt.Errorf("%w: secrets provider is disabled", core.ErrSecretNotFound)
-
-func (disabledSecretManager) GetSecret(_ context.Context, _ string) (string, error) {
-	return "", errSecretsDisabled
-}
-
-func buildSecretManager(cfg *config.Config, factories *FactoryRegistry) (core.SecretManager, error) {
-	_, secrets, err := cfg.SelectedSecretsProvider()
+func buildRuntimeSecretManager(cfg *config.Config, factories *FactoryRegistry) (core.SecretManager, error) {
+	name, secrets, err := cfg.SelectedSecretsProvider()
 	if err != nil {
 		return nil, err
 	}
-	if secrets != nil && secrets.Disabled {
-		return disabledSecretManager{}, nil
+	return buildNamedSecretManager(name, secrets, factories)
+}
+
+func buildNamedSecretManager(name string, secrets *config.ProviderEntry, factories *FactoryRegistry) (core.SecretManager, error) {
+	logicalName := name
+	if logicalName == "" {
+		logicalName = "secrets"
 	}
-	if secrets != nil && !secrets.Source.IsBuiltin() {
+
+	if secrets != nil && (secrets.Source.IsManaged() || secrets.Source.IsLocal()) {
 		factory, ok := factories.Secrets["provider"]
 		if !ok {
 			return nil, fmt.Errorf("bootstrap: secrets provider factory is not registered")
@@ -606,34 +655,43 @@ func buildSecretManager(cfg *config.Config, factories *FactoryRegistry) (core.Se
 		node := secrets.Config
 		if !config.IsComponentRuntimeConfigNode(node) {
 			var err error
-			node, err = config.BuildComponentRuntimeConfigNode("secrets", "secrets", secrets, secrets.Config)
+			node, err = config.BuildComponentRuntimeConfigNode(logicalName, "secrets", secrets, secrets.Config)
 			if err != nil {
-				return nil, fmt.Errorf("bootstrap: secrets provider: %w", err)
+				return nil, fmt.Errorf("bootstrap: secrets provider %q: %w", logicalName, err)
 			}
 		}
 		sm, err := factory(node)
 		if err != nil {
-			return nil, fmt.Errorf("bootstrap: secrets provider: %w", err)
+			return nil, fmt.Errorf("bootstrap: secrets provider %q: %w", logicalName, err)
 		}
 		return sm, nil
 	}
 
-	name := ""
+	builtinName := ""
 	var configNode yaml.Node
 	if secrets != nil {
-		name = secrets.Source.Builtin
+		builtinName = secrets.Source.Builtin
 		configNode = secrets.Config
+		if builtinName == "" {
+			return nil, fmt.Errorf("bootstrap: secrets provider %q has no source", logicalName)
+		}
 	}
-	if name == "" {
-		name = "env"
+	if builtinName == "" {
+		builtinName = "env"
 	}
-	factory, ok := factories.Secrets[name]
+	factory, ok := factories.Secrets[builtinName]
 	if !ok {
-		return nil, fmt.Errorf("bootstrap: unknown secrets provider %q", name)
+		if secrets != nil {
+			return nil, fmt.Errorf("bootstrap: secrets provider %q references unknown builtin %q", logicalName, builtinName)
+		}
+		return nil, fmt.Errorf("bootstrap: unknown secrets provider %q", builtinName)
 	}
 	sm, err := factory(configNode)
 	if err != nil {
-		return nil, fmt.Errorf("bootstrap: secrets provider %q: %w", name, err)
+		if secrets != nil {
+			return nil, fmt.Errorf("bootstrap: secrets provider %q: %w", logicalName, err)
+		}
+		return nil, fmt.Errorf("bootstrap: secrets provider %q: %w", builtinName, err)
 	}
 	return sm, nil
 }
@@ -659,7 +717,7 @@ func buildAuth(cfg *config.Config, factories *FactoryRegistry, deps Deps) (core.
 	if err != nil {
 		return nil, err
 	}
-	if authEntry == nil || authEntry.Disabled {
+	if authEntry == nil {
 		return nil, nil
 	}
 	if factories.Auth == nil {

--- a/gestaltd/internal/bootstrap/bootstrap_test.go
+++ b/gestaltd/internal/bootstrap/bootstrap_test.go
@@ -115,6 +115,13 @@ func validFactories() *bootstrap.FactoryRegistry {
 	return f
 }
 
+func transportSecretRef(name string) string {
+	return config.EncodeSecretRefTransport(config.SecretRef{
+		Provider: "default",
+		Name:     name,
+	})
+}
+
 func TestBootstrap(t *testing.T) {
 	t.Parallel()
 	ctx := context.Background()
@@ -623,7 +630,7 @@ func TestBootstrapSecretResolution(t *testing.T) {
 	t.Parallel()
 	ctx := context.Background()
 
-	t.Run("resolves secret:// in encryption key", func(t *testing.T) {
+	t.Run("resolves config secret ref in encryption key", func(t *testing.T) {
 		t.Parallel()
 
 		var receivedKey []byte
@@ -639,7 +646,7 @@ func TestBootstrapSecretResolution(t *testing.T) {
 		}
 
 		cfg := validConfig()
-		cfg.Server.EncryptionKey = "secret://enc-key"
+		cfg.Server.EncryptionKey = transportSecretRef("enc-key")
 
 		result, err := bootstrap.Bootstrap(ctx, cfg, factories)
 		if err != nil {
@@ -671,7 +678,7 @@ func TestBootstrapSecretResolution(t *testing.T) {
 		t.Parallel()
 
 		cfg := validConfig()
-		cfg.Server.EncryptionKey = "secret://missing-key"
+		cfg.Server.EncryptionKey = transportSecretRef("missing-key")
 
 		_, err := bootstrap.Bootstrap(ctx, cfg, validFactories())
 		if err == nil {
@@ -693,7 +700,7 @@ func TestBootstrapSecretResolution(t *testing.T) {
 		}
 
 		cfg := validConfig()
-		cfg.Server.EncryptionKey = "secret://empty-secret"
+		cfg.Server.EncryptionKey = transportSecretRef("empty-secret")
 
 		_, err := bootstrap.Bootstrap(ctx, cfg, factories)
 		if err == nil {
@@ -704,7 +711,7 @@ func TestBootstrapSecretResolution(t *testing.T) {
 		}
 	})
 
-	t.Run("resolves secret:// in yaml.Node auth config", func(t *testing.T) {
+	t.Run("resolves config secret ref in yaml.Node auth config", func(t *testing.T) {
 		t.Parallel()
 
 		factories := validFactories()
@@ -725,7 +732,7 @@ func TestBootstrapSecretResolution(t *testing.T) {
 			Kind: yaml.MappingNode,
 			Content: []*yaml.Node{
 				{Kind: yaml.ScalarNode, Value: "clientSecret", Tag: "!!str"},
-				{Kind: yaml.ScalarNode, Value: "secret://auth-secret", Tag: "!!str"},
+				{Kind: yaml.ScalarNode, Value: transportSecretRef("auth-secret"), Tag: "!!str"},
 			},
 		}
 
@@ -750,7 +757,7 @@ func TestBootstrapSecretResolution(t *testing.T) {
 		}
 	})
 
-	t.Run("resolves secret:// in yaml.Node indexeddb config", func(t *testing.T) {
+	t.Run("resolves config secret ref in yaml.Node indexeddb config", func(t *testing.T) {
 		t.Parallel()
 
 		factories := validFactories()
@@ -772,7 +779,7 @@ func TestBootstrapSecretResolution(t *testing.T) {
 			Kind: yaml.MappingNode,
 			Content: []*yaml.Node{
 				{Kind: yaml.ScalarNode, Value: "dsn", Tag: "!!str"},
-				{Kind: yaml.ScalarNode, Value: "secret://indexeddb-dsn", Tag: "!!str"},
+				{Kind: yaml.ScalarNode, Value: transportSecretRef("indexeddb-dsn"), Tag: "!!str"},
 			},
 		}
 		cfg.Providers.IndexedDB["test"] = ds
@@ -795,7 +802,54 @@ func TestBootstrapSecretResolution(t *testing.T) {
 		}
 	})
 
-	t.Run("resolves secret:// in workload tokens", func(t *testing.T) {
+	t.Run("resolves config secret ref in yaml.Node s3 config", func(t *testing.T) {
+		t.Parallel()
+
+		factories := validFactories()
+		factories.Secrets["test-secrets"] = func(yaml.Node) (core.SecretManager, error) {
+			return &coretesting.StubSecretManager{
+				Secrets: map[string]string{"s3-token": "resolved-s3-token"},
+			}, nil
+		}
+
+		var receivedNode yaml.Node
+		factories.S3 = func(node yaml.Node) (s3store.Client, error) {
+			receivedNode = node
+			return &coretesting.StubS3{}, nil
+		}
+
+		cfg := validConfig()
+		cfg.Providers.S3 = map[string]*config.ProviderEntry{
+			"assets": {
+				Source: config.ProviderSource{Path: "stub"},
+				Config: yaml.Node{
+					Kind: yaml.MappingNode,
+					Content: []*yaml.Node{
+						{Kind: yaml.ScalarNode, Value: "token", Tag: "!!str"},
+						{Kind: yaml.ScalarNode, Value: transportSecretRef("s3-token"), Tag: "!!str"},
+					},
+				},
+			},
+		}
+
+		result, err := bootstrap.Bootstrap(ctx, cfg, factories)
+		if err != nil {
+			t.Fatalf("Bootstrap: %v", err)
+		}
+		<-result.ProvidersReady
+
+		var decoded struct {
+			Config map[string]string `yaml:"config"`
+		}
+		if err := receivedNode.Decode(&decoded); err != nil {
+			t.Fatalf("decode: %v", err)
+		}
+		if decoded.Config["token"] != "resolved-s3-token" {
+			t.Errorf("token: got %q, want %q", decoded.Config["token"], "resolved-s3-token")
+		}
+	})
+
+	t.Run("resolves config secret ref in workload tokens", func(t *testing.T) {
 		t.Parallel()
 
 		tests := []struct {
@@ -835,7 +889,7 @@ func TestBootstrapSecretResolution(t *testing.T) {
 				tc.apply(cfg, config.AuthorizationConfig{
 					Workloads: map[string]config.WorkloadDef{
 						"triage-bot": {
-							Token: "secret://workload-token",
+							Token: transportSecretRef("workload-token"),
 							Providers: map[string]config.WorkloadProviderDef{
 								"weather": {Allow: []string{"forecast"}},
 							},
@@ -859,29 +913,55 @@ func TestBootstrapSecretResolution(t *testing.T) {
 		}
 	})
 
-	t.Run("skips secret resolution for disabled mounted webuis", func(t *testing.T) {
+	t.Run("requires configured provider for programmatic config refs", func(t *testing.T) {
 		t.Parallel()
 
 		cfg := validConfig()
-		cfg.Providers.UI = map[string]*config.UIEntry{
-			"roadmap": {
-				ProviderEntry: config.ProviderEntry{
-					Disabled: true,
-					Source: config.ProviderSource{
-						Ref:     "github.com/testowner/web/roadmap",
-						Version: "0.0.1-alpha.1",
-						Auth:    &config.SourceAuthDef{Token: "secret://disabled-webui-token"},
-					},
-				},
-				Path: "/create-customer-roadmap-review",
-			},
+		delete(cfg.Providers.Secrets, "default")
+		cfg.Server.EncryptionKey = config.EncodeSecretRefTransport(config.SecretRef{
+			Provider: "env",
+			Name:     "GESTALT_ENCRYPTION_KEY",
+		})
+
+		_, err := bootstrap.Bootstrap(ctx, cfg, validFactories())
+		if err == nil {
+			t.Fatal("expected error, got nil")
+		}
+		if !strings.Contains(err.Error(), `unknown secrets provider "env"`) {
+			t.Fatalf("expected unknown provider error, got %v", err)
+		}
+	})
+
+	t.Run("configured secrets provider without source errors with config key", func(t *testing.T) {
+		t.Parallel()
+
+		cfg := validConfig()
+		cfg.Providers.Secrets["default"] = &config.ProviderEntry{}
+
+		_, err := bootstrap.Bootstrap(ctx, cfg, validFactories())
+		if err == nil {
+			t.Fatal("expected error, got nil")
+		}
+		if !strings.Contains(err.Error(), `secrets provider "default" has no source`) {
+			t.Fatalf("expected missing source error, got %v", err)
+		}
+	})
+
+	t.Run("configured builtin secrets provider errors keep config key", func(t *testing.T) {
+		t.Parallel()
+
+		cfg := validConfig()
+		cfg.Providers.Secrets["default"] = &config.ProviderEntry{
+			Source: config.ProviderSource{Builtin: "missing-builtin"},
 		}
 
-		result, err := bootstrap.Bootstrap(ctx, cfg, validFactories())
-		if err != nil {
-			t.Fatalf("Bootstrap: %v", err)
+		_, err := bootstrap.Bootstrap(ctx, cfg, validFactories())
+		if err == nil {
+			t.Fatal("expected error, got nil")
 		}
-		<-result.ProvidersReady
+		if !strings.Contains(err.Error(), `secrets provider "default" references unknown builtin "missing-builtin"`) {
+			t.Fatalf("expected config-key builtin error, got %v", err)
+		}
 	})
 
 	t.Run("passes top-level provider selection to auth factory", func(t *testing.T) {
@@ -1038,99 +1118,4 @@ func TestBootstrapWorkloadAuthorizationRejectsEitherProvider(t *testing.T) {
 			}
 		})
 	}
-}
-
-func TestBootstrapDisabledComponents(t *testing.T) {
-	t.Parallel()
-	ctx := context.Background()
-
-	t.Run("disabled telemetry uses noop", func(t *testing.T) {
-		t.Parallel()
-
-		cfg := validConfig()
-		cfg.Providers.Telemetry = map[string]*config.ProviderEntry{"default": {Disabled: true}}
-
-		factories := validFactories()
-		factories.Telemetry["noop"] = telemetrynoop.Factory
-
-		result, err := bootstrap.Bootstrap(ctx, cfg, factories)
-		if err != nil {
-			t.Fatalf("Bootstrap: %v", err)
-		}
-		<-result.ProvidersReady
-		if result.Telemetry == nil {
-			t.Fatal("Telemetry is nil")
-		}
-		if err := result.Close(context.Background()); err != nil {
-			t.Fatalf("Close: %v", err)
-		}
-	})
-
-	t.Run("disabled secrets returns not found", func(t *testing.T) {
-		t.Parallel()
-
-		cfg := validConfig()
-		cfg.Providers.Secrets = map[string]*config.ProviderEntry{"default": {Disabled: true}}
-
-		result, err := bootstrap.Bootstrap(ctx, cfg, validFactories())
-		if err != nil {
-			t.Fatalf("Bootstrap: %v", err)
-		}
-		<-result.ProvidersReady
-		if result.SecretManager == nil {
-			t.Fatal("SecretManager is nil")
-		}
-		_, getErr := result.SecretManager.GetSecret(ctx, "any-key")
-		if getErr == nil {
-			t.Fatal("expected error from disabled secret manager")
-		}
-		if !strings.Contains(getErr.Error(), "disabled") {
-			t.Fatalf("error should mention disabled: %v", getErr)
-		}
-		if err := result.Close(context.Background()); err != nil {
-			t.Fatalf("Close: %v", err)
-		}
-	})
-
-	t.Run("disabled singleton indexeddb is rejected", func(t *testing.T) {
-		t.Parallel()
-
-		cfg := validConfig()
-		cfg.Providers.IndexedDB = map[string]*config.ProviderEntry{
-			"only": {
-				Disabled: true,
-				Source:   config.ProviderSource{Path: "stub"},
-			},
-		}
-		cfg.Server.Providers.IndexedDB = ""
-
-		_, err := bootstrap.Bootstrap(ctx, cfg, validFactories())
-		if err == nil {
-			t.Fatal("Bootstrap: expected error, got nil")
-		}
-		if !strings.Contains(err.Error(), "datastore resource name is required") {
-			t.Fatalf("unexpected error: %v", err)
-		}
-	})
-
-	t.Run("disabled s3 is skipped", func(t *testing.T) {
-		t.Parallel()
-
-		cfg := validConfig()
-		cfg.Providers.S3 = map[string]*config.ProviderEntry{
-			"assets": {Disabled: true},
-		}
-
-		result, err := bootstrap.Bootstrap(ctx, cfg, validFactories())
-		if err != nil {
-			t.Fatalf("Bootstrap: %v", err)
-		}
-		<-result.ProvidersReady
-		if got := len(result.ExtraS3s); got != 0 {
-			t.Fatalf("ExtraS3s = %d, want 0", got)
-		}
-		if err := result.Close(context.Background()); err != nil {
-			t.Fatalf("Close: %v", err)
-		}
-	})
 }

--- a/gestaltd/internal/bootstrap/executable_plugin_test.go
+++ b/gestaltd/internal/bootstrap/executable_plugin_test.go
@@ -11,6 +11,7 @@ import (
 	"runtime"
 	"slices"
 	"strconv"
+	"strings"
 	"sync/atomic"
 	"testing"
 
@@ -854,9 +855,6 @@ func TestPluginIndexedDBExposeHostSocketEnv(t *testing.T) {
 	if got := checkEnv(t, &config.PluginIndexedDBConfig{Provider: "archive"}, providerhost.IndexedDBSocketEnv("archive")); got {
 		t.Fatal("named IndexedDB env should not be set when plugins expose a single indexeddb socket")
 	}
-	if got := checkEnv(t, &config.PluginIndexedDBConfig{Disabled: true}, providerhost.DefaultIndexedDBSocketEnv); got {
-		t.Fatal("default IndexedDB env should not be set when plugin indexeddb is disabled")
-	}
 }
 
 func TestPluginCacheBindingsExposeHostSocketEnv(t *testing.T) {
@@ -940,6 +938,48 @@ func TestPluginCacheBindingsExposeHostSocketEnv(t *testing.T) {
 	}
 	if got := checkEnv(t, []string{"session", "rate_limit"}, providerhost.CacheSocketEnv("rate_limit")); !got {
 		t.Fatal(`named cache env for "rate_limit" should be set with multiple plugin cache bindings`)
+	}
+}
+
+func TestPluginCacheBindingsRejectUnknownCaches(t *testing.T) {
+	t.Parallel()
+
+	bin := buildEchoPluginBinary(t)
+	manifestRoot := writeStaticCatalog(t, &catalog.Catalog{
+		Name: "echoext",
+		Operations: []catalog.CatalogOperation{
+			{ID: "read_env", Method: http.MethodGet, Parameters: []catalog.CatalogParameter{{Name: "name", Type: "string", Required: true}}},
+		},
+	})
+	manifest := newExecutableManifest("Echo", "Echoes back the input parameters")
+
+	cfg := &config.Config{
+		Plugins: map[string]*config.ProviderEntry{
+			"echoext": {
+				Command:              bin,
+				Args:                 []string{"provider"},
+				ResolvedManifest:     manifest,
+				ResolvedManifestPath: filepath.Join(manifestRoot, "manifest.yaml"),
+				Cache:                []string{"missing"},
+			},
+		},
+	}
+
+	_, _, err := buildProvidersStrict(context.Background(), cfg, NewFactoryRegistry(), Deps{
+		CacheDefs: map[string]*config.ProviderEntry{
+			"session": {
+				Config: mustNode(t, map[string]any{"namespace": "session"}),
+			},
+		},
+		CacheFactory: func(yaml.Node) (corecache.Cache, error) {
+			return coretesting.NewStubCache(), nil
+		},
+	})
+	if err == nil {
+		t.Fatal("buildProvidersStrict: expected error, got nil")
+	}
+	if !strings.Contains(err.Error(), `cache "missing" is not available`) {
+		t.Fatalf("unexpected error: %v", err)
 	}
 }
 

--- a/gestaltd/internal/bootstrap/secret_resolution.go
+++ b/gestaltd/internal/bootstrap/secret_resolution.go
@@ -1,60 +1,65 @@
 package bootstrap
 
 import (
-	"context"
+	"errors"
 	"fmt"
 	"reflect"
-	"strings"
 
 	"github.com/valon-technologies/gestalt/server/core"
 	"github.com/valon-technologies/gestalt/server/internal/config"
 	"gopkg.in/yaml.v3"
 )
 
-const secretPrefix = "secret://"
-
-var yamlNodeType = reflect.TypeOf(yaml.Node{})
-
 // resolveSecretRefs walks the config struct and replaces any string value
-// starting with "secret://" with the resolved secret value. The
-// SecretsConfig.Config node is skipped to avoid self-referential resolution,
-// but secrets.provider metadata is still resolved after the secret manager has
-// been prepared so managed source auth can use secret-backed credentials.
-func resolveSecretRefs(ctx context.Context, cfg *config.Config, sm core.SecretManager) error {
-	resolve := func(val string) (string, error) {
-		name, ok := strings.CutPrefix(val, secretPrefix)
+// containing internal structured secret refs with resolved secret values. The
+// providers.secrets.<name>.config subtree is skipped to avoid self-referential
+// resolution, but the remaining secrets-provider metadata still resolves so
+// managed source auth can use secret-backed credentials.
+func resolveSecretRefs(cfg *config.Config, resolve func(config.SecretRef) (string, error)) error {
+	resolveValue := func(val string) (string, error) {
+		ref, ok, err := config.ParseSecretRefTransport(val)
+		if err != nil {
+			return "", err
+		}
 		if !ok {
+			if config.IsLegacySecretRefString(val) {
+				return "", fmt.Errorf("legacy secret:// syntax should have been rejected during config load")
+			}
 			return val, nil
 		}
-		resolved, err := sm.GetSecret(ctx, name)
+		resolved, err := resolve(ref)
 		if err != nil {
-			return "", &core.SecretResolutionError{Name: name, Err: err}
+			var secretErr *core.SecretResolutionError
+			if errors.As(err, &secretErr) {
+				return "", err
+			}
+			return "", &core.SecretResolutionError{
+				Name: ref.Name,
+				Err:  err,
+			}
 		}
 		if resolved == "" {
-			return "", &core.SecretResolutionError{
-				Name: name,
-				Err:  fmt.Errorf("resolved to empty value"),
-			}
+			return "", &core.SecretResolutionError{Name: ref.Name, Err: fmt.Errorf("resolved to empty value")}
 		}
 		return resolved, nil
 	}
 
-	if err := resolveStringFields(&cfg.Server, resolve); err != nil {
+	if err := resolveStringFields(&cfg.Server, resolveValue); err != nil {
 		return err
 	}
-	if err := resolveStringFields(&cfg.Authorization, resolve); err != nil {
+	if err := resolveStringFields(&cfg.Authorization, resolveValue); err != nil {
 		return err
 	}
 	for name, entry := range cfg.Plugins {
 		if entry == nil {
 			continue
 		}
-		if err := resolveStringFields(entry, resolve); err != nil {
+		if err := resolveStringFields(entry, resolveValue); err != nil {
 			return err
 		}
 		for _, conn := range entry.Connections {
 			if conn != nil {
-				if err := resolveStringFields(conn, resolve); err != nil {
+				if err := resolveStringFields(conn, resolveValue); err != nil {
 					return err
 				}
 			}
@@ -65,20 +70,23 @@ func resolveSecretRefs(ctx context.Context, cfg *config.Config, sm core.SecretMa
 		cfg.Providers.Auth,
 		cfg.Providers.Telemetry,
 		cfg.Providers.Audit,
+		cfg.Providers.Cache,
+		cfg.Providers.S3,
 	} {
 		for _, entry := range entries {
-			if entry != nil {
-				if err := resolveStringFields(entry, resolve); err != nil {
-					return err
-				}
+			if entry == nil {
+				continue
+			}
+			if err := resolveStringFields(entry, resolveValue); err != nil {
+				return err
 			}
 		}
 	}
 	for name, entry := range cfg.Providers.UI {
-		if entry == nil || entry.Disabled {
+		if entry == nil {
 			continue
 		}
-		if err := resolveStringFields(entry, resolve); err != nil {
+		if err := resolveStringFields(entry, resolveValue); err != nil {
 			return err
 		}
 		cfg.Providers.UI[name] = entry
@@ -91,7 +99,7 @@ func resolveSecretRefs(ctx context.Context, cfg *config.Config, sm core.SecretMa
 		}
 		savedConfig := entry.Config
 		entry.Config = yaml.Node{}
-		if err := resolveStringFields(entry, resolve); err != nil {
+		if err := resolveStringFields(entry, resolveValue); err != nil {
 			entry.Config = savedConfig
 			return err
 		}
@@ -103,7 +111,7 @@ func resolveSecretRefs(ctx context.Context, cfg *config.Config, sm core.SecretMa
 		if ds == nil {
 			continue
 		}
-		if err := resolveStringFields(ds, resolve); err != nil {
+		if err := resolveStringFields(ds, resolveValue); err != nil {
 			return err
 		}
 		cfg.Providers.IndexedDB[name] = ds
@@ -132,7 +140,7 @@ func resolveStringFields(ptr any, resolve func(string) (string, error)) error {
 			field.SetString(resolved)
 		case reflect.Struct:
 			if field.CanSet() {
-				if field.Type() == yamlNodeType {
+				if field.Type() == config.YAMLNodeType {
 					nodePtr := field.Addr().Interface().(*yaml.Node)
 					if err := resolveYAMLNode(nodePtr, resolve); err != nil {
 						return err

--- a/gestaltd/internal/config/config.go
+++ b/gestaltd/internal/config/config.go
@@ -120,7 +120,6 @@ type ProviderEntry struct {
 	Source       ProviderSource    `yaml:"source"`
 	Config       yaml.Node         `yaml:"config,omitempty"`
 	Default      bool              `yaml:"default,omitempty"`
-	Disabled     bool              `yaml:"disabled,omitempty"`
 	Env          map[string]string `yaml:"env,omitempty"`
 	AllowedHosts []string          `yaml:"allowedHosts,omitempty"`
 	DisplayName  string            `yaml:"displayName,omitempty"`
@@ -164,7 +163,6 @@ type ProviderSurfaceOverrides struct {
 }
 
 type PluginIndexedDBConfig struct {
-	Disabled     bool     `yaml:"disabled,omitempty"`
 	Provider     string   `yaml:"provider,omitempty"`
 	DB           string   `yaml:"db,omitempty"`
 	ObjectStores []string `yaml:"objectStores,omitempty"`
@@ -178,6 +176,11 @@ func (c *PluginIndexedDBConfig) UnmarshalYAML(value *yaml.Node) error {
 	case yaml.SequenceNode:
 		return fmt.Errorf("plugin indexeddb must be a mapping or scalar provider name")
 	default:
+		for i := 0; i+1 < len(value.Content); i += 2 {
+			if key := value.Content[i]; key != nil && key.Value == "disabled" {
+				return fmt.Errorf("field disabled not found in type config.raw")
+			}
+		}
 		type raw PluginIndexedDBConfig
 		return value.Decode((*raw)(c))
 	}
@@ -707,7 +710,7 @@ func OverlayManagedPluginConfig(path string, cfg *Config) error {
 	}
 	s3Node := mappingValueNode(providersNode, "s3")
 	for name, entry := range cfg.Providers.S3 {
-		if entry == nil || entry.Disabled || !entry.HasManagedSource() {
+		if entry == nil || !entry.HasManagedSource() {
 			continue
 		}
 		if err := overlayManagedEntryConfigNode(mappingValueNode(s3Node, name), entry, "s3 "+strconv.Quote(name)); err != nil {
@@ -737,6 +740,10 @@ func overlayManagedEntryConfigNode(raw *yaml.Node, entry *ProviderEntry, subject
 	node, err := overlayEnvIntoNode(*configNode, os.LookupEnv, true)
 	if err != nil {
 		return fmt.Errorf("expanding managed provider config for %s: %w", subject, err)
+	}
+	allowSecretRefs := !strings.HasPrefix(subject, "secrets ")
+	if err := NormalizeOpaqueSecretRefs(&node, allowSecretRefs); err != nil {
+		return err
 	}
 	entry.Config = node
 	return nil
@@ -776,48 +783,6 @@ func normalizeConfigRoot(root *yaml.Node) error {
 	return nil
 }
 
-func cloneConfigRoot(node *yaml.Node) (*yaml.Node, error) {
-	data, err := yaml.Marshal(documentValueNode(node))
-	if err != nil {
-		return nil, fmt.Errorf("marshaling normalized config YAML: %w", err)
-	}
-	var out yaml.Node
-	dec := yaml.NewDecoder(strings.NewReader(string(data)))
-	if err := dec.Decode(&out); err != nil && err != io.EOF {
-		return nil, fmt.Errorf("parsing config YAML: %w", err)
-	}
-	return &out, nil
-}
-
-func removeDisabledS3Entries(root *yaml.Node) {
-	providersNode := mappingValueNode(root, "providers")
-	s3Node := documentValueNode(mappingValueNode(providersNode, "s3"))
-	if s3Node == nil || s3Node.Kind != yaml.MappingNode {
-		return
-	}
-	filtered := s3Node.Content[:0]
-	for i := 0; i+1 < len(s3Node.Content); i += 2 {
-		keyNode := s3Node.Content[i]
-		entryNode := s3Node.Content[i+1]
-		if providerEntryDisabled(entryNode) {
-			continue
-		}
-		filtered = append(filtered, keyNode, entryNode)
-	}
-	s3Node.Content = filtered
-}
-
-func providerEntryDisabled(node *yaml.Node) bool {
-	disabledNode := mappingValueNode(node, "disabled")
-	if disabledNode == nil {
-		return false
-	}
-	var disabled bool
-	if err := disabledNode.Decode(&disabled); err != nil {
-		return false
-	}
-	return disabled
-}
 func loadWithLookup(path string, lookup func(string) (string, bool), allowMissing bool) (*Config, error) {
 	data, err := os.ReadFile(path)
 	if err != nil {
@@ -848,13 +813,14 @@ func loadWithLookup(path string, lookup func(string) (string, bool), allowMissin
 	if err := normalizeConfigRoot(&root); err != nil {
 		return nil, err
 	}
+	if err := rejectRemovedDisabledFields(&root); err != nil {
+		return nil, err
+	}
+	if err := NormalizeConfigSecretRefs(&root); err != nil {
+		return nil, err
+	}
 	if !allowMissing {
-		validationRoot, err := cloneConfigRoot(&root)
-		if err != nil {
-			return nil, err
-		}
-		removeDisabledS3Entries(validationRoot)
-		firstMissing := firstMissingEnvSentinel(validationRoot, missingEnvSentinelContext)
+		firstMissing := firstMissingEnvSentinel(&root, missingEnvSentinelContext)
 		if firstMissing != "" {
 			return nil, fmt.Errorf("expanding config environment variables: environment variable %q not set; use ${%s:-} to allow an empty default", firstMissing, firstMissing)
 		}
@@ -889,6 +855,42 @@ func loadWithLookup(path string, lookup func(string) (string, bool), allowMissin
 	return &cfg, nil
 }
 
+func rejectRemovedDisabledFields(root *yaml.Node) error {
+	if err := rejectRemovedDisabledEntryFields(mappingValueNode(root, "plugins"), "plugins"); err != nil {
+		return err
+	}
+	providersNode := mappingValueNode(root, "providers")
+	for _, section := range []string{"auth", "secrets", "telemetry", "audit", "indexeddb", "cache", "s3", "ui"} {
+		if err := rejectRemovedDisabledEntryFields(mappingValueNode(providersNode, section), "providers."+section); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+func rejectRemovedDisabledEntryFields(node *yaml.Node, prefix string) error {
+	node = documentValueNode(node)
+	if node == nil || node.Kind != yaml.MappingNode {
+		return nil
+	}
+	for i := 0; i+1 < len(node.Content); i += 2 {
+		keyNode := node.Content[i]
+		entryNode := node.Content[i+1]
+		if keyNode == nil || entryNode == nil {
+			continue
+		}
+		if mappingValueNode(entryNode, "disabled") != nil {
+			return fmt.Errorf("parsing config YAML: %s.%s.disabled: field disabled not found; omit the entry instead", prefix, keyNode.Value)
+		}
+		if prefix == "plugins" {
+			if indexedDBNode := mappingValueNode(entryNode, "indexeddb"); indexedDBNode != nil && mappingValueNode(indexedDBNode, "disabled") != nil {
+				return fmt.Errorf("parsing config YAML: %s.%s.indexeddb.disabled: field disabled not found; omit indexeddb to inherit the host provider", prefix, keyNode.Value)
+			}
+		}
+	}
+	return nil
+}
+
 const (
 	missingEnvSentinelPrefix = "__GESTALT_MISSING_ENV_"
 	missingEnvSentinelSuffix = "__"
@@ -917,12 +919,12 @@ func firstMissingEnvSentinelInString(value, sentinelPrefix string) string {
 	for start := 0; start < len(value); {
 		idx := strings.Index(value[start:], sentinelPrefix)
 		if idx < 0 {
-			return ""
+			break
 		}
 		idx += start + len(sentinelPrefix)
 		end := strings.Index(value[idx:], missingEnvSentinelSuffix)
 		if end < 0 {
-			return ""
+			break
 		}
 		decoded, err := base64.RawURLEncoding.DecodeString(value[idx : idx+end])
 		if err == nil {
@@ -930,7 +932,14 @@ func firstMissingEnvSentinelInString(value, sentinelPrefix string) string {
 		}
 		start = idx + end + len(missingEnvSentinelSuffix)
 	}
-	return ""
+	ref, ok, err := ParseSecretRefTransport(value)
+	if err != nil || !ok {
+		return ""
+	}
+	if name := firstMissingEnvSentinelInString(ref.Provider, sentinelPrefix); name != "" {
+		return name
+	}
+	return firstMissingEnvSentinelInString(ref.Name, sentinelPrefix)
 }
 
 func restoreMissingEnvSentinels(input, sentinelPrefix string) string {
@@ -1126,7 +1135,7 @@ func applyDefaultBuiltinProviderEntries(entries map[string]*ProviderEntry, defau
 		}
 	}
 	for _, entry := range entries {
-		if entry == nil || entry.Disabled || entry.Source.IsBuiltin() || entry.Source.IsManaged() || entry.Source.IsLocal() {
+		if entry == nil || entry.Source.IsBuiltin() || entry.Source.IsManaged() || entry.Source.IsLocal() {
 			continue
 		}
 		entry.Source.Builtin = builtin
@@ -1247,9 +1256,6 @@ func applyPluginMountBindings(cfg *Config) error {
 		if plugin == nil {
 			return fmt.Errorf("config validation: plugins.%s is required", pluginName)
 		}
-		if plugin.Disabled {
-			continue
-		}
 		plugin.UI = strings.TrimSpace(plugin.UI)
 		plugin.MountPath = strings.TrimSpace(plugin.MountPath)
 		plugin.AuthorizationPolicy = strings.TrimSpace(plugin.AuthorizationPolicy)
@@ -1277,9 +1283,6 @@ func applyPluginMountBindings(cfg *Config) error {
 		ui := cfg.Providers.UI[plugin.UI]
 		if ui == nil {
 			return fmt.Errorf("config validation: plugins.%s.ui references unknown ui %q", pluginName, plugin.UI)
-		}
-		if ui.Disabled {
-			return fmt.Errorf("config validation: plugins.%s.ui references disabled ui %q", pluginName, plugin.UI)
 		}
 		if current := strings.TrimSpace(ui.AuthorizationPolicy); current != "" && current != plugin.AuthorizationPolicy {
 			return fmt.Errorf("config validation: plugins.%s.ui %q conflicts with providers.ui.%s.authorizationPolicy", pluginName, plugin.UI, plugin.UI)

--- a/gestaltd/internal/config/config_test.go
+++ b/gestaltd/internal/config/config_test.go
@@ -330,6 +330,42 @@ server:
 	}
 }
 
+func TestLoadConfigStructuredSecretRefMissingEnvVariableFails(t *testing.T) {
+	t.Parallel()
+
+	providerEnv := "GESTALT_TEST_SECRET_PROVIDER_" + strings.ToUpper(strings.ReplaceAll(t.Name(), "/", "_"))
+	path := mustWriteConfigFile(t, fmt.Sprintf(`
+providers:
+  indexeddb:
+    sqlite:
+      source:
+        path: ./providers/datastore/sqlite
+  secrets:
+    default:
+      source: env
+server:
+  providers:
+    indexeddb: sqlite
+  encryptionKey:
+    secret:
+      provider: ${%s}
+      name: enc-key
+`, providerEnv))
+
+	_, err := LoadWithLookup(path, func(string) (string, bool) {
+		return "", false
+	})
+	if err == nil {
+		t.Fatal("LoadWithLookup: expected error, got nil")
+	}
+	if !strings.Contains(err.Error(), fmt.Sprintf(`environment variable %q not set`, providerEnv)) {
+		t.Fatalf("expected missing env error, got: %v", err)
+	}
+	if !strings.Contains(err.Error(), fmt.Sprintf("${%s:-}", providerEnv)) {
+		t.Fatalf("expected empty-default hint, got: %v", err)
+	}
+}
+
 func TestLoadConfigEmptyDefaultEnvSyntax(t *testing.T) {
 	t.Parallel()
 
@@ -556,10 +592,6 @@ server:
 		{
 			name: "missing datastore",
 			yaml: `
-providers:
-  auth:
-    auth:
-      disabled: true
 server:
   encryptionKey: server-key
 `,
@@ -580,12 +612,9 @@ server:
 			wantErr: true,
 		},
 		{
-			name: "auth disabled is allowed",
+			name: "omitted auth is allowed",
 			yaml: `
 providers:
-  auth:
-    auth:
-      disabled: true
   indexeddb:
     sqlite:
       source:
@@ -596,20 +625,6 @@ server:
   encryptionKey: server-key
 `,
 			wantErr: false,
-		},
-		{
-			name: "disabled singleton datastore is rejected",
-			yaml: `
-providers:
-  indexeddb:
-    only:
-      disabled: true
-      source:
-        path: ./providers/datastore/sqlite
-server:
-  encryptionKey: server-key
-`,
-			wantErr: true,
 		},
 	}
 
@@ -631,10 +646,10 @@ server:
 			if err != nil {
 				t.Fatalf("ValidateRuntime: %v", err)
 			}
-			if tc.name == "auth disabled is allowed" {
+			if tc.name == "omitted auth is allowed" {
 				_, auth := mustSelectedProvider(t, cfg, HostProviderKindAuth)
-				if auth == nil || !auth.Disabled {
-					t.Fatalf("SelectedAuthProvider = %#v, want disabled auth entry", auth)
+				if auth != nil {
+					t.Fatalf("SelectedAuthProvider = %#v, want nil", auth)
 				}
 			}
 		})
@@ -652,9 +667,6 @@ server:
   baseUrl: not a url
   encryptionKey: server-key
 providers:
-  auth:
-    auth:
-      disabled: true
   indexeddb:
     sqlite:
       source:
@@ -677,9 +689,6 @@ server:
     port: 9090
     baseUrl: not a url
 providers:
-  auth:
-    auth:
-      disabled: true
   indexeddb:
     sqlite:
       source:
@@ -894,7 +903,7 @@ server:
 		}
 	})
 
-	t.Run("ui entry can be disabled", func(t *testing.T) {
+	t.Run("ui entry rejects disabled field", func(t *testing.T) {
 		t.Parallel()
 
 		path := mustWriteConfigFile(t, `
@@ -912,20 +921,16 @@ server:
   encryptionKey: server-key
 `)
 
-		cfg, err := Load(path)
-		if err != nil {
-			t.Fatalf("Load: %v", err)
+		_, err := Load(path)
+		if err == nil {
+			t.Fatal("Load: expected error, got nil")
 		}
-		entry := cfg.Providers.UI["roadmap"]
-		if entry == nil {
-			t.Fatal(`Providers.UI["roadmap"] = nil`)
-		}
-		if !entry.Disabled {
-			t.Fatal(`Providers.UI["roadmap"].Disabled = false, want true`)
+		if !strings.Contains(err.Error(), `field disabled not found`) {
+			t.Fatalf("unexpected error: %v", err)
 		}
 	})
 
-	t.Run("disabled field accepts all YAML boolean variants", func(t *testing.T) {
+	t.Run("ui disabled field rejects YAML boolean variants", func(t *testing.T) {
 		t.Parallel()
 
 		for _, variant := range []string{"true", "True", "TRUE"} {
@@ -948,18 +953,18 @@ server:
   encryptionKey: server-key
 `, variant))
 
-				cfg, err := Load(path)
-				if err != nil {
-					t.Fatalf("Load: %v", err)
+				_, err := Load(path)
+				if err == nil {
+					t.Fatal("Load: expected error, got nil")
 				}
-				if !cfg.Providers.UI["roadmap"].Disabled {
-					t.Fatalf(`Providers.UI["roadmap"].Disabled = false with disabled: %s, want true`, variant)
+				if !strings.Contains(err.Error(), `field disabled not found`) {
+					t.Fatalf("disabled: %s unexpected error: %v", variant, err)
 				}
 			})
 		}
 	})
 
-	t.Run("ui config is accepted when disabled", func(t *testing.T) {
+	t.Run("ui config is rejected when disabled field is present", func(t *testing.T) {
 		t.Parallel()
 
 		path := mustWriteConfigFile(t, `
@@ -980,8 +985,11 @@ server:
 `)
 
 		_, err := Load(path)
-		if err != nil {
-			t.Fatalf("Load: %v", err)
+		if err == nil {
+			t.Fatal("Load: expected error, got nil")
+		}
+		if !strings.Contains(err.Error(), `field disabled not found`) {
+			t.Fatalf("unexpected error: %v", err)
 		}
 	})
 
@@ -1142,6 +1150,42 @@ server:
 		}
 	})
 
+	t.Run("nested mounted ui provider paths are allowed", func(t *testing.T) {
+		t.Parallel()
+
+		path := mustWriteConfigFile(t, `
+providers:
+  ui:
+    docs:
+      source:
+        path: ./web/docs/manifest.yaml
+      path: /docs
+    admin:
+      source:
+        path: ./web/docs-admin/manifest.yaml
+      path: /docs/admin
+  indexeddb:
+    sqlite:
+      source:
+        path: ./providers/datastore/sqlite
+server:
+  providers:
+    indexeddb: sqlite
+  encryptionKey: server-key
+`)
+
+		cfg, err := Load(path)
+		if err != nil {
+			t.Fatalf("Load: %v", err)
+		}
+		if got := cfg.Providers.UI["docs"].Path; got != "/docs" {
+			t.Fatalf(`Providers.UI["docs"].Path = %q, want %q`, got, "/docs")
+		}
+		if got := cfg.Providers.UI["admin"].Path; got != "/docs/admin" {
+			t.Fatalf(`Providers.UI["admin"].Path = %q, want %q`, got, "/docs/admin")
+		}
+	})
+
 	t.Run("reserved path is rejected", func(t *testing.T) {
 		t.Parallel()
 
@@ -1267,39 +1311,37 @@ server:
 		}
 	})
 
-	t.Run("nested ui paths are accepted", func(t *testing.T) {
+	t.Run("plugin mount path prefix collision with mounted ui is rejected", func(t *testing.T) {
 		t.Parallel()
 
 		path := mustWriteConfigFile(t, `
 providers:
   ui:
-    parent:
+    docs:
       source:
-        path: ./web/parent/manifest.yaml
+        path: ./web/docs/manifest.yaml
       path: /tools
-    child:
-      source:
-        path: ./web/child/manifest.yaml
-      path: /tools/admin
   indexeddb:
     sqlite:
       source:
         path: ./providers/datastore/sqlite
+plugins:
+  admin:
+    source:
+      path: ./plugin/manifest.yaml
+    mountPath: /tools/admin
 server:
   providers:
     indexeddb: sqlite
   encryptionKey: server-key
 `)
 
-		cfg, err := Load(path)
-		if err != nil {
-			t.Fatalf("Load: %v", err)
+		_, err := Load(path)
+		if err == nil {
+			t.Fatal("Load: expected error, got nil")
 		}
-		if got := cfg.Providers.UI["parent"].Path; got != "/tools" {
-			t.Fatalf(`Providers.UI["parent"].Path = %q, want %q`, got, "/tools")
-		}
-		if got := cfg.Providers.UI["child"].Path; got != "/tools/admin" {
-			t.Fatalf(`Providers.UI["child"].Path = %q, want %q`, got, "/tools/admin")
+		if !strings.Contains(err.Error(), `ui.docs.path "/tools" conflicts with plugins.admin.mountPath "/tools/admin"`) {
+			t.Fatalf("unexpected error: %v", err)
 		}
 	})
 
@@ -1440,7 +1482,7 @@ server:
 		}
 	})
 
-	t.Run("plugin accepts explicit disabled indexeddb config", func(t *testing.T) {
+	t.Run("plugin rejects disabled indexeddb config", func(t *testing.T) {
 		t.Parallel()
 
 		path := mustWriteConfigFile(t, `
@@ -1461,13 +1503,12 @@ server:
   encryptionKey: server-key
 `)
 
-		cfg, err := Load(path)
-		if err != nil {
-			t.Fatalf("Load: %v", err)
+		_, err := Load(path)
+		if err == nil {
+			t.Fatal("Load: expected error, got nil")
 		}
-		want := &PluginIndexedDBConfig{Disabled: true}
-		if got := cfg.Plugins["roadmap"].IndexedDB; !reflect.DeepEqual(got, want) {
-			t.Fatalf("Plugins[roadmap].IndexedDB = %#v, want %#v", got, want)
+		if !strings.Contains(err.Error(), `field disabled not found`) {
+			t.Fatalf("unexpected error: %v", err)
 		}
 	})
 
@@ -1765,37 +1806,12 @@ server:
 				wantIndexedDB: true,
 			},
 			{
-				name: "empty object with disabled-only host indexeddb",
+				name: "omitted indexeddb with no host indexeddb definitions",
 				body: `
 plugins:
   roadmap:
     source:
       path: ./plugin/manifest.yaml
-    indexeddb: {}
-providers:
-  indexeddb:
-    only:
-      disabled: true
-      source:
-        path: ./providers/datastore/sqlite
-server:
-  encryptionKey: server-key
-`,
-				wantIndexedDB: true,
-			},
-			{
-				name: "omitted indexeddb with disabled-only host indexeddb",
-				body: `
-plugins:
-  roadmap:
-    source:
-      path: ./plugin/manifest.yaml
-providers:
-  indexeddb:
-    only:
-      disabled: true
-      source:
-        path: ./providers/datastore/sqlite
 server:
   encryptionKey: server-key
 `,
@@ -1821,7 +1837,7 @@ server:
 		}
 	})
 
-	t.Run("rejects disabled indexeddb mixed with provider override", func(t *testing.T) {
+	t.Run("rejects indexeddb disabled field", func(t *testing.T) {
 		t.Parallel()
 
 		path := mustWriteConfigFile(t, `
@@ -1847,7 +1863,7 @@ server:
 		if err == nil {
 			t.Fatal("Load: expected error, got nil")
 		}
-		if !strings.Contains(err.Error(), `plugins.roadmap.indexeddb.disabled may not be combined with indexeddb.provider`) {
+		if !strings.Contains(err.Error(), `field disabled not found`) {
 			t.Fatalf("unexpected error: %v", err)
 		}
 	})
@@ -1953,7 +1969,7 @@ server:
 		}
 	})
 
-	t.Run("rejects disabled s3 binding names", func(t *testing.T) {
+	t.Run("rejects s3 disabled field", func(t *testing.T) {
 		t.Parallel()
 
 		path := mustWriteConfigFile(t, `
@@ -1981,7 +1997,40 @@ server:
 		if err == nil {
 			t.Fatal("Load: expected error, got nil")
 		}
-		if !strings.Contains(err.Error(), `plugin "roadmap" s3[0] references disabled s3 "assets"`) {
+		if !strings.Contains(err.Error(), `field disabled not found`) {
+			t.Fatalf("unexpected error: %v", err)
+		}
+	})
+
+	t.Run("rejects cache disabled field", func(t *testing.T) {
+		t.Parallel()
+
+		path := mustWriteConfigFile(t, `
+plugins:
+  roadmap:
+    source:
+      path: ./plugin/manifest.yaml
+    cache:
+      - session
+providers:
+  cache:
+    session:
+      disabled: true
+  indexeddb:
+    sqlite:
+      source:
+        path: ./providers/datastore/sqlite
+server:
+  providers:
+    indexeddb: sqlite
+  encryptionKey: server-key
+`)
+
+		_, err := Load(path)
+		if err == nil {
+			t.Fatal("Load: expected error, got nil")
+		}
+		if !strings.Contains(err.Error(), `field disabled not found`) {
 			t.Fatalf("unexpected error: %v", err)
 		}
 	})
@@ -2015,6 +2064,19 @@ providers:
 `,
 			wantErr: `field builtin not found`,
 		},
+		{
+			name: "disabled field wins over missing env",
+			yaml: `
+providers:
+  ui:
+    roadmap:
+      disabled: true
+      source:
+        path: ${MISSING_UI_PATH}
+      path: /roadmap
+`,
+			wantErr: `field disabled not found`,
+		},
 	}
 
 	for _, tc := range cases {
@@ -2046,29 +2108,6 @@ providers:
   telemetry:
     primary:
       source: stdout
-`,
-		},
-		{
-			name: "disabled true",
-			yaml: `
-providers:
-  ui:
-    roadmap:
-      disabled: true
-`,
-		},
-		{
-			name: "disabled s3 entry",
-			yaml: `
-providers:
-  s3:
-    assets:
-      disabled: true
-      source:
-        ref: github.com/valon-technologies/gestalt-providers/s3/compatible
-        version: 1.0.0
-      config:
-        bucket: ${MISSING_S3_BUCKET}
 `,
 		},
 		{
@@ -2515,20 +2554,20 @@ func TestValidateStructure_PluginValidationDirect(t *testing.T) {
 			wantErr: `source.path or source.ref is required`,
 		},
 		{
-			name: "auth config accepted when auth disabled",
+			name: "auth config requires source",
 			cfg: &Config{
 				Providers: ProvidersConfig{
-					Auth: singletonProviderEntry(&ProviderEntry{Config: yaml.Node{Kind: yaml.MappingNode}, Disabled: true}),
+					Auth: singletonProviderEntry(&ProviderEntry{Config: yaml.Node{Kind: yaml.MappingNode}}),
 				},
 			},
+			wantErr: `source.path or source.ref is required`,
 		},
 		{
-			name: "disabled s3 entry skips source validation",
+			name: "s3 entry validates source",
 			cfg: &Config{
 				Providers: ProvidersConfig{
 					S3: map[string]*ProviderEntry{
 						"assets": {
-							Disabled: true,
 							Source: ProviderSource{
 								Ref: "not-a-valid-ref",
 							},
@@ -2536,6 +2575,7 @@ func TestValidateStructure_PluginValidationDirect(t *testing.T) {
 					},
 				},
 			},
+			wantErr: `source.ref`,
 		},
 		{
 			name: "plugin auth rejects mcp oauth early",

--- a/gestaltd/internal/config/config_validate.go
+++ b/gestaltd/internal/config/config_validate.go
@@ -69,9 +69,6 @@ func ValidateStructure(cfg *Config) error {
 		if err := validatePluginOnlyProviderFields("ui."+name, &entry.ProviderEntry); err != nil {
 			return err
 		}
-		if entry.Disabled {
-			continue
-		}
 		if entry.Source.IsBuiltin() {
 			return fmt.Errorf("config validation: ui %q does not support builtin providers; use a provider source reference", name)
 		}
@@ -102,6 +99,9 @@ func ValidateStructure(cfg *Config) error {
 	if err := validateS3Config(cfg); err != nil {
 		return err
 	}
+	if err := validateConfigSecretRefs(cfg); err != nil {
+		return err
+	}
 
 	// Validate plugins
 	for name, entry := range cfg.Plugins {
@@ -129,15 +129,12 @@ func validateHostProviderEntries(kind HostProviderKind, entries map[string]*Prov
 				return err
 			}
 		case HostProviderKindSecrets, HostProviderKindTelemetry:
-			if !entry.Disabled && !entry.Source.IsBuiltin() {
+			if !entry.Source.IsBuiltin() {
 				if err := validateProviderEntrySource(string(kind), name, entry); err != nil {
 					return err
 				}
 			}
 		case HostProviderKindAudit:
-			if entry.Disabled {
-				continue
-			}
 			if entry.Source.IsBuiltin() {
 				if err := validateBuiltinAudit(entry); err != nil {
 					return err
@@ -216,7 +213,7 @@ func validateProviderEntrySource(kind, name string, entry *ProviderEntry) error 
 	if src.IsManaged() {
 		modeCount++
 	}
-	if modeCount == 0 && !entry.Disabled {
+	if modeCount == 0 {
 		return fmt.Errorf("config validation: %s %q source.path or source.ref is required", kind, name)
 	}
 	if modeCount > 1 {
@@ -247,6 +244,20 @@ func validateProviderEntrySource(kind, name string, entry *ProviderEntry) error 
 	return nil
 }
 
+func validateConfigSecretRefs(cfg *Config) error {
+	referenced, err := ReferencedConfigSecretProviders(cfg)
+	if err != nil {
+		return fmt.Errorf("config validation: %w", err)
+	}
+	for name := range referenced {
+		entry, ok := cfg.Providers.Secrets[name]
+		if !ok || entry == nil {
+			return fmt.Errorf("config validation: secret refs reference unknown secrets provider %q", name)
+		}
+	}
+	return nil
+}
+
 // ValidateResolvedStructure checks integration fields whose support depends on
 // resolved managed plugin manifests.
 func ValidateResolvedStructure(cfg *Config) error {
@@ -257,7 +268,7 @@ func ValidateResolvedStructure(cfg *Config) error {
 		if err := validateManifestBackedIntegration(name, entry); err != nil {
 			return err
 		}
-		if entry.Disabled || strings.TrimSpace(entry.MountPath) == "" || strings.TrimSpace(entry.UI) != "" {
+		if strings.TrimSpace(entry.MountPath) == "" || strings.TrimSpace(entry.UI) != "" {
 			continue
 		}
 		if entry.ResolvedManifest == nil || entry.ManifestSpec() == nil || entry.ManifestSpec().UI == nil {
@@ -268,7 +279,7 @@ func ValidateResolvedStructure(cfg *Config) error {
 		if entry == nil {
 			return fmt.Errorf("config validation: ui %q requires a source", name)
 		}
-		if entry.Disabled || entry.AuthorizationPolicy == "" {
+		if entry.AuthorizationPolicy == "" {
 			continue
 		}
 		if entry.ResolvedManifest == nil || entry.ManifestSpec() == nil {
@@ -378,9 +389,6 @@ func validateS3Config(cfg *Config) error {
 		if err := validatePluginOnlyProviderFields("providers.s3."+name, entry); err != nil {
 			return err
 		}
-		if entry.Disabled {
-			continue
-		}
 		if err := validateProviderEntrySource("s3", name, entry); err != nil {
 			return err
 		}
@@ -483,8 +491,8 @@ func validateAdminConfig(cfg *Config) error {
 		if err != nil {
 			return err
 		}
-		if authProvider == nil || authProvider.Disabled {
-			return fmt.Errorf("config validation: server.admin.authorizationPolicy requires providers.auth to be configured and enabled")
+		if authProvider == nil {
+			return fmt.Errorf("config validation: server.admin.authorizationPolicy requires providers.auth to be configured")
 		}
 		if err := validateAuthorizationPolicyReference(cfg, "server.admin", "/admin", policy); err != nil {
 			return err
@@ -552,18 +560,6 @@ func validatePluginIndexedDBConfig(cfg *Config, name string, entry *ProviderEntr
 		return nil
 	}
 	indexedDB := entry.IndexedDB
-	if indexedDB.Disabled {
-		switch {
-		case indexedDB.Provider != "":
-			return fmt.Errorf("config validation: plugins.%s.indexeddb.disabled may not be combined with indexeddb.provider", name)
-		case indexedDB.DB != "":
-			return fmt.Errorf("config validation: plugins.%s.indexeddb.disabled may not be combined with indexeddb.db", name)
-		case len(indexedDB.ObjectStores) > 0:
-			return fmt.Errorf("config validation: plugins.%s.indexeddb.disabled may not be combined with indexeddb.objectStores", name)
-		default:
-			return nil
-		}
-	}
 	seenStores := make(map[string]struct{}, len(indexedDB.ObjectStores))
 	for i, store := range indexedDB.ObjectStores {
 		if store == "" {
@@ -598,9 +594,6 @@ func validatePluginS3Bindings(cfg *Config, name string, entry *ProviderEntry) er
 		if !ok || boundEntry == nil {
 			return fmt.Errorf("config validation: plugin %q s3[%d] references unknown s3 %q", name, i, binding)
 		}
-		if boundEntry.Disabled {
-			return fmt.Errorf("config validation: plugin %q s3[%d] references disabled s3 %q", name, i, binding)
-		}
 		envName := providerenv.S3SocketEnv(binding)
 		if otherBinding, exists := envNames[envName]; exists {
 			return fmt.Errorf("config validation: plugin %q s3[%d] %q conflicts with %q after S3 env normalization (%s)", name, i, binding, otherBinding, envName)
@@ -626,7 +619,8 @@ func validatePluginCacheBindings(cfg *Config, name string, entry *ProviderEntry)
 		if _, exists := seen[binding]; exists {
 			return fmt.Errorf("config validation: plugin %q cache[%d] duplicates %q", name, i, binding)
 		}
-		if _, ok := cfg.Providers.Cache[binding]; !ok {
+		boundEntry, ok := cfg.Providers.Cache[binding]
+		if !ok || boundEntry == nil {
 			return fmt.Errorf("config validation: plugin %q cache[%d] references unknown cache %q", name, i, binding)
 		}
 		envName := cacheSocketEnv(binding)
@@ -662,7 +656,7 @@ func cacheSocketEnv(name string) string {
 }
 func normalizeMountedUIPaths(cfg *Config, pluginOwnedUIRefs map[string]struct{}) error {
 	for name, entry := range cfg.Providers.UI {
-		if entry == nil || entry.Disabled {
+		if entry == nil {
 			continue
 		}
 		if strings.TrimSpace(entry.Path) == "" {
@@ -719,7 +713,7 @@ func validateMountedUICollisions(cfg *Config, pluginOwnedUIRefs map[string]struc
 	names := slices.Sorted(maps.Keys(cfg.Providers.UI))
 	for _, name := range names {
 		entry := cfg.Providers.UI[name]
-		if entry == nil || entry.Disabled || strings.TrimSpace(entry.Path) == "" {
+		if entry == nil || strings.TrimSpace(entry.Path) == "" {
 			continue
 		}
 		subjects = append(subjects, mountedPathSubject{
@@ -731,11 +725,11 @@ func validateMountedUICollisions(cfg *Config, pluginOwnedUIRefs map[string]struc
 	pluginNames := slices.Sorted(maps.Keys(cfg.Plugins))
 	for _, name := range pluginNames {
 		entry := cfg.Plugins[name]
-		if entry == nil || entry.Disabled || strings.TrimSpace(entry.UI) != "" || strings.TrimSpace(entry.MountPath) == "" {
+		if entry == nil || strings.TrimSpace(entry.UI) != "" || strings.TrimSpace(entry.MountPath) == "" {
 			continue
 		}
 		if _, ok := pluginOwnedUIRefs[name]; ok {
-			if ui := cfg.Providers.UI[name]; ui != nil && !ui.Disabled && mountedUIPathsMatch(ui.Path, entry.MountPath) {
+			if ui := cfg.Providers.UI[name]; ui != nil && mountedUIPathsMatch(ui.Path, entry.MountPath) {
 				continue
 			}
 		}
@@ -793,7 +787,7 @@ func mountedUIPathsMatch(uiPath, mountPath string) bool {
 func pluginOwnedUIRefs(cfg *Config) map[string]struct{} {
 	refs := make(map[string]struct{}, len(cfg.Plugins))
 	for name, entry := range cfg.Plugins {
-		if entry == nil || entry.Disabled || strings.TrimSpace(entry.UI) != "" || strings.TrimSpace(entry.MountPath) == "" {
+		if entry == nil || strings.TrimSpace(entry.UI) != "" || strings.TrimSpace(entry.MountPath) == "" {
 			continue
 		}
 		refs[name] = struct{}{}

--- a/gestaltd/internal/config/provider_selection.go
+++ b/gestaltd/internal/config/provider_selection.go
@@ -69,14 +69,7 @@ func (c *Config) SelectedAuditProvider() (string, *ProviderEntry, error) {
 }
 
 func (c *Config) SelectedIndexedDBProvider() (string, *ProviderEntry, error) {
-	name, entry, err := ResolveSelectedHostProvider(HostProviderKindIndexedDB, c.Server.Providers.Selection(HostProviderKindIndexedDB), c.HostProviderEntries(HostProviderKindIndexedDB))
-	if err != nil {
-		return "", nil, err
-	}
-	if strings.TrimSpace(c.Server.Providers.IndexedDB) == "" && entry != nil && entry.Disabled {
-		return "", nil, nil
-	}
-	return name, entry, nil
+	return ResolveSelectedHostProvider(HostProviderKindIndexedDB, c.Server.Providers.Selection(HostProviderKindIndexedDB), c.HostProviderEntries(HostProviderKindIndexedDB))
 }
 
 type EffectivePluginIndexedDB struct {
@@ -99,9 +92,6 @@ func ResolveEffectivePluginIndexedDB(pluginName string, entry *ProviderEntry, se
 	if entry == nil {
 		return EffectivePluginIndexedDB{}, nil
 	}
-	if entry.IndexedDB != nil && entry.IndexedDB.Disabled {
-		return EffectivePluginIndexedDB{}, nil
-	}
 
 	providerName := ""
 	if entry.IndexedDB != nil {
@@ -120,9 +110,6 @@ func ResolveEffectivePluginIndexedDB(pluginName string, entry *ProviderEntry, se
 	provider, ok := entries[providerName]
 	if !ok || provider == nil {
 		return EffectivePluginIndexedDB{}, fmt.Errorf("config validation: plugins.%s.indexeddb.provider references unknown indexeddb %q", pluginName, providerName)
-	}
-	if provider.Disabled {
-		return EffectivePluginIndexedDB{}, fmt.Errorf("config validation: plugins.%s.indexeddb.provider references disabled indexeddb %q", pluginName, providerName)
 	}
 
 	dbName := pluginName
@@ -154,49 +141,33 @@ func ResolveSelectedHostProvider(kind HostProviderKind, explicit string, entries
 		if !ok || entry == nil {
 			return "", nil, fmt.Errorf("config validation: server.providers.%s references unknown provider %q", kind, explicit)
 		}
-		if entry.Disabled {
-			return "", nil, fmt.Errorf("config validation: server.providers.%s references disabled provider %q", kind, explicit)
-		}
 		return explicit, entry, nil
 	}
 
-	allNames := make([]string, 0, len(entries))
-	enabledNames := make([]string, 0, len(entries))
+	names := make([]string, 0, len(entries))
 	defaultNames := make([]string, 0, len(entries))
 	for name, entry := range entries {
 		if entry == nil {
 			continue
 		}
-		allNames = append(allNames, name)
+		names = append(names, name)
 		if entry.Default {
 			defaultNames = append(defaultNames, name)
 		}
-		if entry.Disabled {
-			continue
-		}
-		enabledNames = append(enabledNames, name)
 	}
 
 	switch {
 	case len(defaultNames) == 1:
 		name := defaultNames[0]
-		if entries[name].Disabled {
-			return "", nil, fmt.Errorf("config validation: providers.%s.%s cannot be both default and disabled", kind, name)
-		}
 		return name, entries[name], nil
 	case len(defaultNames) > 1:
 		sort.Strings(defaultNames)
 		return "", nil, fmt.Errorf("config validation: providers.%s declares multiple defaults: %s", kind, strings.Join(defaultNames, ", "))
-	case len(enabledNames) == 1:
-		name := enabledNames[0]
+	case len(names) == 1:
+		name := names[0]
 		return name, entries[name], nil
-	case len(allNames) == 1:
-		name := allNames[0]
-		return name, entries[name], nil
-	case len(enabledNames) == 0:
-		return "", nil, nil
 	default:
-		sort.Strings(enabledNames)
-		return "", nil, fmt.Errorf("config validation: providers.%s has multiple enabled providers but no selection or default: %s", kind, strings.Join(enabledNames, ", "))
+		sort.Strings(names)
+		return "", nil, fmt.Errorf("config validation: providers.%s has multiple providers but no selection or default: %s", kind, strings.Join(names, ", "))
 	}
 }

--- a/gestaltd/internal/config/secret_refs.go
+++ b/gestaltd/internal/config/secret_refs.go
@@ -1,0 +1,407 @@
+package config
+
+import (
+	"encoding/base64"
+	"encoding/json"
+	"fmt"
+	"reflect"
+	"slices"
+	"strings"
+
+	"gopkg.in/yaml.v3"
+)
+
+const (
+	legacySecretRefPrefix    = "secret://"
+	secretRefTransportPrefix = "__GESTALT_SECRET_REF__:"
+)
+
+type SecretRef struct {
+	Provider string `json:"provider"`
+	Name     string `json:"name"`
+}
+
+type SecretRefVisitor func(SecretRef) error
+
+func IsLegacySecretRefString(value string) bool {
+	return strings.HasPrefix(strings.TrimSpace(value), legacySecretRefPrefix)
+}
+
+func EncodeSecretRefTransport(ref SecretRef) string {
+	payload, err := json.Marshal(ref)
+	if err != nil {
+		panic(fmt.Sprintf("marshal secret ref transport: %v", err))
+	}
+	return secretRefTransportPrefix + base64.RawURLEncoding.EncodeToString(payload)
+}
+
+func ParseSecretRefTransport(value string) (SecretRef, bool, error) {
+	if !strings.HasPrefix(value, secretRefTransportPrefix) {
+		return SecretRef{}, false, nil
+	}
+	payload := strings.TrimPrefix(value, secretRefTransportPrefix)
+	decoded, err := base64.RawURLEncoding.DecodeString(payload)
+	if err != nil {
+		return SecretRef{}, true, fmt.Errorf("decoding internal secret ref: %w", err)
+	}
+	var ref SecretRef
+	if err := json.Unmarshal(decoded, &ref); err != nil {
+		return SecretRef{}, true, fmt.Errorf("parsing internal secret ref: %w", err)
+	}
+	if strings.TrimSpace(ref.Provider) == "" || strings.TrimSpace(ref.Name) == "" {
+		return SecretRef{}, true, fmt.Errorf("internal secret ref is incomplete")
+	}
+	return ref, true, nil
+}
+
+func NormalizeConfigSecretRefs(root *yaml.Node) error {
+	return normalizeSecretRefsNode(documentValueNode(root), nil, true)
+}
+
+func NormalizeOpaqueSecretRefs(node *yaml.Node, allowSecretRefs bool) error {
+	return normalizeSecretRefsNode(documentValueNode(node), nil, allowSecretRefs)
+}
+
+func normalizeSecretRefsNode(node *yaml.Node, path []string, allowSecretRefs bool) error {
+	if node == nil {
+		return nil
+	}
+	switch node.Kind {
+	case yaml.DocumentNode:
+		for _, child := range node.Content {
+			if err := normalizeSecretRefsNode(child, path, allowSecretRefs); err != nil {
+				return err
+			}
+		}
+		return nil
+	case yaml.ScalarNode:
+		if node.Tag == "!!str" || node.Tag == "" {
+			value := strings.TrimSpace(node.Value)
+			switch {
+			case strings.HasPrefix(value, secretRefTransportPrefix):
+				return fmt.Errorf("parsing config YAML: %s uses reserved internal secret ref syntax", formatSecretRefPath(path))
+			case strings.HasPrefix(value, legacySecretRefPrefix):
+				return fmt.Errorf("parsing config YAML: %s uses legacy secret:// syntax; use secret.provider and secret.name", formatSecretRefPath(path))
+			}
+		}
+		return nil
+	case yaml.SequenceNode:
+		for i, child := range node.Content {
+			childPath := appendPath(path, fmt.Sprintf("[%d]", i))
+			if err := normalizeSecretRefsNode(child, childPath, allowSecretRefs); err != nil {
+				return err
+			}
+		}
+		return nil
+	case yaml.MappingNode:
+		if candidate, ok := decodeStructuredSecretRef(node); ok {
+			if !allowSecretRefs {
+				return fmt.Errorf("parsing config YAML: %s does not allow secret refs", formatSecretRefPath(path))
+			}
+			ref, err := validateStructuredSecretRef(candidate, path)
+			if err != nil {
+				return err
+			}
+			*node = yaml.Node{
+				Kind:  yaml.ScalarNode,
+				Tag:   "!!str",
+				Value: EncodeSecretRefTransport(ref),
+			}
+			return nil
+		}
+		for i := 0; i+1 < len(node.Content); i += 2 {
+			keyNode := node.Content[i]
+			valueNode := node.Content[i+1]
+			if keyNode == nil {
+				continue
+			}
+			key := keyNode.Value
+			childPath := appendPath(path, key)
+			childAllowRefs := allowSecretRefs
+			if isSecretsProviderConfigPath(childPath) {
+				childAllowRefs = false
+			}
+			if err := normalizeSecretRefsNode(valueNode, childPath, childAllowRefs); err != nil {
+				return err
+			}
+		}
+		return nil
+	default:
+		return nil
+	}
+}
+
+func decodeStructuredSecretRef(node *yaml.Node) (*yaml.Node, bool) {
+	if node == nil || node.Kind != yaml.MappingNode || len(node.Content) != 2 {
+		return nil, false
+	}
+	key := node.Content[0]
+	if key == nil || key.Value != "secret" {
+		return nil, false
+	}
+	return node.Content[1], true
+}
+
+func validateStructuredSecretRef(secretNode *yaml.Node, path []string) (SecretRef, error) {
+	if secretNode == nil || secretNode.Kind != yaml.MappingNode {
+		return SecretRef{}, fmt.Errorf("parsing config YAML: %s.secret must be a mapping with provider and name", formatSecretRefPath(path))
+	}
+	raw := map[string]string{}
+	for i := 0; i+1 < len(secretNode.Content); i += 2 {
+		keyNode := secretNode.Content[i]
+		valueNode := secretNode.Content[i+1]
+		if keyNode == nil || valueNode == nil {
+			continue
+		}
+		key := keyNode.Value
+		switch key {
+		case "provider", "name":
+		default:
+			return SecretRef{}, fmt.Errorf("parsing config YAML: %s.secret.%s is not supported", formatSecretRefPath(path), key)
+		}
+		if valueNode.Kind != yaml.ScalarNode || (valueNode.Tag != "" && valueNode.Tag != "!!str") {
+			return SecretRef{}, fmt.Errorf("parsing config YAML: %s.secret.%s must be a string", formatSecretRefPath(path), key)
+		}
+		raw[key] = strings.TrimSpace(valueNode.Value)
+	}
+	if raw["provider"] == "" {
+		return SecretRef{}, fmt.Errorf("parsing config YAML: %s.secret.provider is required", formatSecretRefPath(path))
+	}
+	if raw["name"] == "" {
+		return SecretRef{}, fmt.Errorf("parsing config YAML: %s.secret.name is required", formatSecretRefPath(path))
+	}
+	return SecretRef{Provider: raw["provider"], Name: raw["name"]}, nil
+}
+
+func formatSecretRefPath(path []string) string {
+	if len(path) == 0 {
+		return "config"
+	}
+	var b strings.Builder
+	for i, segment := range path {
+		if strings.HasPrefix(segment, "[") {
+			b.WriteString(segment)
+			continue
+		}
+		if i > 0 {
+			b.WriteByte('.')
+		}
+		b.WriteString(segment)
+	}
+	return b.String()
+}
+
+func appendPath(path []string, segment string) []string {
+	return append(slices.Clone(path), segment)
+}
+
+func isSecretsProviderConfigPath(path []string) bool {
+	return len(path) >= 4 && path[0] == "providers" && path[1] == "secrets" && path[3] == "config"
+}
+
+func ReferencedConfigSecretProviders(cfg *Config) (map[string]struct{}, error) {
+	providers := map[string]struct{}{}
+	if cfg == nil {
+		return providers, nil
+	}
+	visit := func(ref SecretRef) error {
+		providers[ref.Provider] = struct{}{}
+		return nil
+	}
+	if err := visitConfigSecretRefs(cfg, visit); err != nil {
+		return nil, err
+	}
+	return providers, nil
+}
+
+func visitConfigSecretRefs(cfg *Config, visit SecretRefVisitor) error {
+	if cfg == nil {
+		return nil
+	}
+	if err := visitSecretRefsInStruct(&cfg.Server, visit); err != nil {
+		return err
+	}
+	if err := visitSecretRefsInStruct(&cfg.Authorization, visit); err != nil {
+		return err
+	}
+	for _, entries := range []map[string]*ProviderEntry{
+		cfg.Providers.Auth,
+		cfg.Providers.Telemetry,
+		cfg.Providers.Audit,
+		cfg.Providers.IndexedDB,
+		cfg.Providers.Cache,
+		cfg.Providers.S3,
+	} {
+		for _, entry := range entries {
+			if entry == nil {
+				continue
+			}
+			if err := visitSecretRefsInStruct(entry, visit); err != nil {
+				return err
+			}
+		}
+	}
+	for _, entry := range cfg.Providers.UI {
+		if entry == nil {
+			continue
+		}
+		if err := visitSecretRefsInStruct(entry, visit); err != nil {
+			return err
+		}
+	}
+	for _, entry := range cfg.Providers.Secrets {
+		if entry == nil {
+			continue
+		}
+		savedConfig := entry.Config
+		entry.Config = yaml.Node{}
+		err := visitSecretRefsInStruct(entry, visit)
+		entry.Config = savedConfig
+		if err != nil {
+			return err
+		}
+	}
+	for _, entry := range cfg.Plugins {
+		if entry == nil {
+			continue
+		}
+		if err := visitSecretRefsInStruct(entry, visit); err != nil {
+			return err
+		}
+		for _, conn := range entry.Connections {
+			if conn != nil {
+				if err := visitSecretRefsInStruct(conn, visit); err != nil {
+					return err
+				}
+			}
+		}
+	}
+	return nil
+}
+
+var yamlNodeType = reflect.TypeOf(yaml.Node{})
+
+var YAMLNodeType = yamlNodeType
+
+func visitSecretRefsInStruct(ptr any, visit SecretRefVisitor) error {
+	v := reflect.ValueOf(ptr)
+	if !v.IsValid() || v.IsNil() {
+		return nil
+	}
+	v = v.Elem()
+	t := v.Type()
+	for i := 0; i < t.NumField(); i++ {
+		field := v.Field(i)
+		switch field.Kind() {
+		case reflect.String:
+			if err := visitSecretRefString(field.String(), visit); err != nil {
+				return err
+			}
+		case reflect.Struct:
+			if field.Type() == yamlNodeType {
+				nodePtr := field.Addr().Interface().(*yaml.Node)
+				if err := visitSecretRefsInYAMLNode(nodePtr, visit); err != nil {
+					return err
+				}
+			} else if field.CanAddr() {
+				if err := visitSecretRefsInStruct(field.Addr().Interface(), visit); err != nil {
+					return err
+				}
+			}
+		case reflect.Pointer:
+			if !field.IsNil() && field.Elem().Kind() == reflect.Struct {
+				if err := visitSecretRefsInStruct(field.Interface(), visit); err != nil {
+					return err
+				}
+			}
+		case reflect.Map:
+			if field.Type().Key().Kind() != reflect.String {
+				continue
+			}
+			switch field.Type().Elem().Kind() {
+			case reflect.String:
+				for _, key := range field.MapKeys() {
+					if err := visitSecretRefString(field.MapIndex(key).String(), visit); err != nil {
+						return err
+					}
+				}
+			case reflect.Struct:
+				for _, key := range field.MapKeys() {
+					current := field.MapIndex(key)
+					next := reflect.New(field.Type().Elem())
+					next.Elem().Set(current)
+					if err := visitSecretRefsInStruct(next.Interface(), visit); err != nil {
+						return err
+					}
+				}
+			case reflect.Pointer:
+				if field.Type().Elem().Elem().Kind() != reflect.Struct {
+					continue
+				}
+				for _, key := range field.MapKeys() {
+					current := field.MapIndex(key)
+					if current.IsNil() {
+						continue
+					}
+					if err := visitSecretRefsInStruct(current.Interface(), visit); err != nil {
+						return err
+					}
+				}
+			}
+		case reflect.Slice:
+			switch field.Type().Elem().Kind() {
+			case reflect.String:
+				for j := 0; j < field.Len(); j++ {
+					if err := visitSecretRefString(field.Index(j).String(), visit); err != nil {
+						return err
+					}
+				}
+			case reflect.Struct:
+				for j := 0; j < field.Len(); j++ {
+					if err := visitSecretRefsInStruct(field.Index(j).Addr().Interface(), visit); err != nil {
+						return err
+					}
+				}
+			}
+		}
+	}
+	return nil
+}
+
+func visitSecretRefString(value string, visit SecretRefVisitor) error {
+	ref, ok, err := ParseSecretRefTransport(value)
+	if err != nil {
+		return err
+	}
+	if !ok {
+		return nil
+	}
+	return visit(ref)
+}
+
+func visitSecretRefsInYAMLNode(node *yaml.Node, visit SecretRefVisitor) error {
+	if node == nil {
+		return nil
+	}
+	switch node.Kind {
+	case yaml.ScalarNode:
+		if node.Tag == "!!str" || node.Tag == "" {
+			if err := visitSecretRefString(node.Value, visit); err != nil {
+				return err
+			}
+		}
+	case yaml.SequenceNode, yaml.DocumentNode:
+		for _, child := range node.Content {
+			if err := visitSecretRefsInYAMLNode(child, visit); err != nil {
+				return err
+			}
+		}
+	case yaml.MappingNode:
+		for i := 1; i < len(node.Content); i += 2 {
+			if err := visitSecretRefsInYAMLNode(node.Content[i], visit); err != nil {
+				return err
+			}
+		}
+	}
+	return nil
+}

--- a/gestaltd/internal/operator/lifecycle.go
+++ b/gestaltd/internal/operator/lifecycle.go
@@ -184,7 +184,7 @@ func (l *Lifecycle) initAtPath(configPath, artifactsDir string) (*Lockfile, *con
 		}
 	}
 	for name, def := range cfg.Providers.S3 {
-		if def != nil && !def.Disabled && def.HasManagedSource() {
+		if def != nil && def.HasManagedSource() {
 			entry, err := l.writeComponentArtifact(context.Background(), paths, providermanifestv1.KindS3, name, s3DestDir(paths, name), def, def.Config)
 			if err != nil {
 				return nil, nil, err
@@ -193,7 +193,7 @@ func (l *Lifecycle) initAtPath(configPath, artifactsDir string) (*Lockfile, *con
 		}
 	}
 	for name, entry := range cfg.Providers.UI {
-		if entry != nil && !entry.Disabled && entry.HasManagedSource() {
+		if entry != nil && entry.HasManagedSource() {
 			uiEntry, err := l.writeNamedUIProviderArtifact(context.Background(), paths, name, &entry.ProviderEntry, uiDestDir(paths, name), "ui "+strconv.Quote(name))
 			if err != nil {
 				return nil, nil, err
@@ -237,12 +237,12 @@ func buildSourceTokenMap(cfg *config.Config) map[string]string {
 		}
 	}
 	for _, def := range cfg.Providers.S3 {
-		if def != nil && !def.Disabled && def.Source.Auth != nil {
+		if def != nil && def.Source.Auth != nil {
 			tokens[def.SourceRef()] = def.Source.Auth.Token
 		}
 	}
 	for _, entry := range cfg.Providers.UI {
-		if entry != nil && !entry.Disabled && entry.Source.Auth != nil {
+		if entry != nil && entry.Source.Auth != nil {
 			tokens[entry.SourceRef()] = entry.Source.Auth.Token
 		}
 	}
@@ -306,15 +306,79 @@ func (l *Lifecycle) resolveConfigSecrets(ctx context.Context, cfg *config.Config
 	return config.ValidateStructure(cfg)
 }
 
+func referencedConfigSecretsProviders(cfg *config.Config) (map[string]*config.ProviderEntry, error) {
+	referenced, err := config.ReferencedConfigSecretProviders(cfg)
+	if err != nil {
+		return nil, err
+	}
+	if len(referenced) == 0 {
+		return nil, nil
+	}
+	entries := make(map[string]*config.ProviderEntry, len(referenced))
+	for name := range referenced {
+		entries[name] = cfg.Providers.Secrets[name]
+	}
+	return entries, nil
+}
+
+func secretsProviderMetadataDependencies(name string, provider *config.ProviderEntry) (map[string]struct{}, error) {
+	if provider == nil {
+		return nil, nil
+	}
+	tmp := &config.Config{
+		Providers: config.ProvidersConfig{
+			Secrets: map[string]*config.ProviderEntry{
+				name: provider,
+			},
+		},
+	}
+	deps, err := config.ReferencedConfigSecretProviders(tmp)
+	if err != nil {
+		return nil, err
+	}
+	delete(deps, name)
+	if len(deps) == 0 {
+		return nil, nil
+	}
+	return deps, nil
+}
+
+func (l *Lifecycle) resolveSecretsProviderMetadata(ctx context.Context, name string, provider *config.ProviderEntry, available map[string]*config.ProviderEntry) error {
+	if l.configSecretResolver == nil || provider == nil {
+		return nil
+	}
+	secrets := make(map[string]*config.ProviderEntry, len(available)+1)
+	for availableName, entry := range available {
+		secrets[availableName] = entry
+	}
+	secrets[name] = provider
+	tmp := &config.Config{
+		Providers: config.ProvidersConfig{
+			Secrets: secrets,
+		},
+	}
+	if err := l.configSecretResolver(ctx, tmp); err != nil {
+		return fmt.Errorf("resolve metadata for %s %q: %w", providermanifestv1.KindSecrets, name, err)
+	}
+	return nil
+}
+
 func (l *Lifecycle) lockForSecretsBootstrap(configPath, artifactsDir string, paths initPaths, cfg *config.Config, locked bool) (*Lockfile, error) {
 	if cfg == nil {
 		return nil, nil
 	}
-	_, provider, err := cfg.SelectedSecretsProvider()
+	referenced, err := referencedConfigSecretsProviders(cfg)
 	if err != nil {
 		return nil, err
 	}
-	if provider == nil || !provider.HasManagedSource() {
+	needsManagedSecrets := false
+	for _, provider := range referenced {
+		if provider != nil && provider.HasManagedSource() {
+			needsManagedSecrets = true
+			break
+		}
+	}
+	if !needsManagedSecrets {
 		return nil, nil
 	}
 	if !configHasManagedProviderSources(cfg) {
@@ -335,43 +399,114 @@ func (l *Lifecycle) primeSecretsProviderForConfigResolution(ctx context.Context,
 	if cfg == nil {
 		return nil, nil
 	}
-	name, provider, err := cfg.SelectedSecretsProvider()
-	if err != nil || provider == nil {
+	referenced, err := referencedConfigSecretsProviders(cfg)
+	if err != nil {
 		return nil, err
 	}
-
-	configMap, err := config.NodeToMap(provider.Config)
-	if err != nil {
-		return nil, fmt.Errorf("decode provider config for %s %q: %w", providermanifestv1.KindSecrets, name, err)
-	}
-
-	switch {
-	case provider.HasManagedSource():
-		if lock != nil {
-			lockEntry, ok := lock.Secrets[name]
-			if !ok {
-				return nil, fmt.Errorf("prepared artifact for %s %q is missing or stale; run `gestaltd init --config %s`", providermanifestv1.KindSecrets, name, paths.configPath)
-			}
-			if err := l.applyLockedComponentEntry(paths, &lockEntry, providermanifestv1.KindSecrets, name, provider, configMap, secretsDestDir(paths, name), false); err != nil {
-				return nil, err
-			}
-			return nil, nil
+	available := make(map[string]*config.ProviderEntry, len(referenced))
+	pending := make(map[string]*config.ProviderEntry, len(referenced))
+	dependencies := make(map[string]map[string]struct{}, len(referenced))
+	for name, provider := range referenced {
+		if provider == nil {
+			continue
 		}
-		entry, err := l.writeComponentArtifact(ctx, paths, providermanifestv1.KindSecrets, name, secretsDestDir(paths, name), provider, provider.Config)
+		deps, err := secretsProviderMetadataDependencies(name, provider)
 		if err != nil {
 			return nil, err
 		}
-		if err := l.applyLockedComponentEntry(paths, &entry, providermanifestv1.KindSecrets, name, provider, configMap, secretsDestDir(paths, name), false); err != nil {
-			return nil, err
+		dependencies[name] = deps
+		if provider.Source.IsBuiltin() {
+			available[name] = provider
+			continue
 		}
-		return map[string]LockEntry{name: entry}, nil
-	case provider.HasLocalSource():
-		if err := applyLocalComponentManifest(providermanifestv1.KindSecrets, name, provider, configMap); err != nil {
-			return nil, err
-		}
+		pending[name] = provider
 	}
+	prepared := make(map[string]LockEntry)
+	for len(pending) > 0 {
+		progress := false
+		names := make([]string, 0, len(pending))
+		for name := range pending {
+			names = append(names, name)
+		}
+		slices.Sort(names)
+		for _, name := range names {
+			provider := pending[name]
+			ready := true
+			for dep := range dependencies[name] {
+				depProvider := referenced[dep]
+				if depProvider == nil {
+					return nil, fmt.Errorf("config validation: secret refs reference unknown secrets provider %q", dep)
+				}
+				if _, ok := available[dep]; !ok {
+					ready = false
+					break
+				}
+			}
+			if !ready {
+				continue
+			}
+			if err := l.resolveSecretsProviderMetadata(ctx, name, provider, available); err != nil {
+				return nil, err
+			}
+			configMap, err := config.NodeToMap(provider.Config)
+			if err != nil {
+				return nil, fmt.Errorf("decode provider config for %s %q: %w", providermanifestv1.KindSecrets, name, err)
+			}
 
-	return nil, nil
+			switch {
+			case provider.HasManagedSource():
+				if lock != nil {
+					lockEntry, ok := lock.Secrets[name]
+					if !ok {
+						return nil, fmt.Errorf("prepared artifact for %s %q is missing or stale; run `gestaltd init --config %s`", providermanifestv1.KindSecrets, name, paths.configPath)
+					}
+					if err := l.applyLockedComponentEntry(paths, &lockEntry, providermanifestv1.KindSecrets, name, provider, configMap, secretsDestDir(paths, name), false); err != nil {
+						return nil, err
+					}
+				} else {
+					entry, err := l.writeComponentArtifact(ctx, paths, providermanifestv1.KindSecrets, name, secretsDestDir(paths, name), provider, provider.Config)
+					if err != nil {
+						return nil, err
+					}
+					if err := l.applyLockedComponentEntry(paths, &entry, providermanifestv1.KindSecrets, name, provider, configMap, secretsDestDir(paths, name), false); err != nil {
+						return nil, err
+					}
+					prepared[name] = entry
+				}
+			case provider.HasLocalSource():
+				if err := applyLocalComponentManifest(providermanifestv1.KindSecrets, name, provider, configMap); err != nil {
+					return nil, err
+				}
+			}
+
+			available[name] = provider
+			delete(pending, name)
+			progress = true
+		}
+		if progress {
+			continue
+		}
+		blocked := make([]string, 0, len(pending))
+		for _, name := range names {
+			deps := make([]string, 0, len(dependencies[name]))
+			for dep := range dependencies[name] {
+				if _, ok := available[dep]; !ok {
+					deps = append(deps, dep)
+				}
+			}
+			slices.Sort(deps)
+			if len(deps) == 0 {
+				blocked = append(blocked, name)
+				continue
+			}
+			blocked = append(blocked, fmt.Sprintf("%s -> %s", name, strings.Join(deps, ", ")))
+		}
+		return nil, fmt.Errorf("bootstrap %s providers for config resolution: unresolved dependencies: %s", providermanifestv1.KindSecrets, strings.Join(blocked, "; "))
+	}
+	if len(prepared) == 0 {
+		return nil, nil
+	}
+	return prepared, nil
 }
 
 type initPaths struct {
@@ -446,7 +581,7 @@ func configHasProviderLoading(cfg *config.Config) bool {
 		}
 	}
 	for _, entry := range cfg.Providers.UI {
-		if entry != nil && !entry.Disabled && (entry.HasManagedSource() || entry.HasLocalSource()) {
+		if entry != nil && (entry.HasManagedSource() || entry.HasLocalSource()) {
 			return true
 		}
 	}
@@ -456,7 +591,7 @@ func configHasProviderLoading(cfg *config.Config) bool {
 		}
 	}
 	for _, def := range cfg.Providers.S3 {
-		if def != nil && !def.Disabled && (def.HasManagedSource() || def.HasLocalSource()) {
+		if def != nil && (def.HasManagedSource() || def.HasLocalSource()) {
 			return true
 		}
 	}
@@ -477,7 +612,7 @@ func configHasManagedProviderSources(cfg *config.Config) bool {
 		}
 	}
 	for _, entry := range cfg.Providers.UI {
-		if entry != nil && !entry.Disabled && entry.HasManagedSource() {
+		if entry != nil && entry.HasManagedSource() {
 			return true
 		}
 	}
@@ -487,7 +622,7 @@ func configHasManagedProviderSources(cfg *config.Config) bool {
 		}
 	}
 	for _, def := range cfg.Providers.S3 {
-		if def != nil && !def.Disabled && def.HasManagedSource() {
+		if def != nil && def.HasManagedSource() {
 			return true
 		}
 	}
@@ -733,7 +868,7 @@ func lockMatchesConfig(cfg *config.Config, paths initPaths, lock *Lockfile) bool
 		}
 	}
 	for name, entry := range cfg.Providers.S3 {
-		if entry == nil || entry.Disabled || !entry.HasManagedSource() {
+		if entry == nil || !entry.HasManagedSource() {
 			continue
 		}
 		lockEntry, found := lock.S3[name]
@@ -742,7 +877,7 @@ func lockMatchesConfig(cfg *config.Config, paths initPaths, lock *Lockfile) bool
 		}
 	}
 	for name, entry := range cfg.Providers.UI {
-		if entry == nil || entry.Disabled || !entry.HasManagedSource() {
+		if entry == nil || !entry.HasManagedSource() {
 			continue
 		}
 		lockEntry, ok := lock.UIs[name]
@@ -1177,14 +1312,14 @@ func (l *Lifecycle) applyLockedProviders(configPath, artifactsDir string, cfg *c
 		s3Locks = lock.S3
 	}
 	for name, def := range cfg.Providers.S3 {
-		if def != nil && !def.Disabled {
+		if def != nil {
 			if err := l.applyComponentProvider(paths, s3Locks, providermanifestv1.KindS3, name, def, def.Config, &def.Config, s3DestDir(paths, name), locked); err != nil {
 				return err
 			}
 		}
 	}
 	for name, entry := range cfg.Providers.UI {
-		if entry == nil || entry.Disabled {
+		if entry == nil {
 			continue
 		}
 		var lockEntry *LockUIEntry
@@ -1244,7 +1379,7 @@ func synthesizePluginOwnedUIEntries(cfg *config.Config) error {
 	pluginNames := slices.Sorted(maps.Keys(cfg.Plugins))
 	for _, pluginName := range pluginNames {
 		plugin := cfg.Plugins[pluginName]
-		if plugin == nil || plugin.Disabled || strings.TrimSpace(plugin.UI) != "" || strings.TrimSpace(plugin.MountPath) == "" {
+		if plugin == nil || strings.TrimSpace(plugin.UI) != "" || strings.TrimSpace(plugin.MountPath) == "" {
 			continue
 		}
 		manifestSpec := plugin.ManifestSpec()
@@ -1284,7 +1419,7 @@ func synthesizeLocalSourcePluginOwnedUIEntries(cfg *config.Config) error {
 	pluginNames := slices.Sorted(maps.Keys(cfg.Plugins))
 	for _, pluginName := range pluginNames {
 		plugin := cfg.Plugins[pluginName]
-		if plugin == nil || plugin.Disabled || strings.TrimSpace(plugin.UI) != "" || strings.TrimSpace(plugin.MountPath) == "" || !plugin.HasLocalSource() {
+		if plugin == nil || strings.TrimSpace(plugin.UI) != "" || strings.TrimSpace(plugin.MountPath) == "" || !plugin.HasLocalSource() {
 			continue
 		}
 		manifestPath := plugin.SourcePath()
@@ -1331,7 +1466,7 @@ func synthesizeLockedSourcePluginOwnedUIEntries(cfg *config.Config, paths initPa
 	pluginNames := slices.Sorted(maps.Keys(cfg.Plugins))
 	for _, pluginName := range pluginNames {
 		plugin := cfg.Plugins[pluginName]
-		if plugin == nil || plugin.Disabled || strings.TrimSpace(plugin.UI) != "" || strings.TrimSpace(plugin.MountPath) == "" || !plugin.HasManagedSource() {
+		if plugin == nil || strings.TrimSpace(plugin.UI) != "" || strings.TrimSpace(plugin.MountPath) == "" || !plugin.HasManagedSource() {
 			continue
 		}
 		lockEntry, ok := lock.Providers[pluginName]
@@ -1417,9 +1552,6 @@ func ownedUIEntryFromManifest(manifestPath, manifestVersion string, ownedUI *pro
 func validateSynthesizedPluginUIEntry(pluginName string, existing, expected *config.UIEntry) error {
 	if existing == nil || expected == nil {
 		return nil
-	}
-	if existing.Disabled {
-		return fmt.Errorf("config validation: plugins.%s owned ui conflicts with disabled providers.ui.%s", pluginName, pluginName)
 	}
 	if current := strings.TrimSpace(existing.Source.Ref); current != "" && current != expected.Source.Ref {
 		return fmt.Errorf("config validation: plugins.%s owned ui conflicts with providers.ui.%s.source.ref", pluginName, pluginName)

--- a/gestaltd/internal/operator/lifecycle_source_test.go
+++ b/gestaltd/internal/operator/lifecycle_source_test.go
@@ -47,9 +47,10 @@ type fakeResolver struct {
 }
 
 type fakeResolverResult struct {
-	archivePath string
-	resolvedURL string
-	sha256      string
+	archivePath      string
+	resolvedURL      string
+	sha256           string
+	platformArchives []pluginsource.PlatformArchive
 }
 
 type fakeResolverCall struct {
@@ -87,6 +88,14 @@ func (f *fakeMultiResolver) Resolve(_ context.Context, src pluginsource.Source, 
 		ArchiveSHA256: result.sha256,
 		ResolvedURL:   result.resolvedURL,
 	}, nil
+}
+
+func (f *fakeMultiResolver) ListPlatformArchives(_ context.Context, src pluginsource.Source, _ string) ([]pluginsource.PlatformArchive, error) {
+	result, ok := f.results[src.String()]
+	if !ok {
+		return nil, fmt.Errorf("unexpected source %q", src.String())
+	}
+	return append([]pluginsource.PlatformArchive(nil), result.platformArchives...), nil
 }
 
 func sha256hex(data string) string {
@@ -350,6 +359,12 @@ func TestSourcePluginEndToEnd(t *testing.T) {
 	}
 	if written.Schema != providerLockSchemaName {
 		t.Errorf("written lockfile schema = %q, want %q", written.Schema, providerLockSchemaName)
+	}
+	if written.SchemaVersion != providerLockSchemaVersion {
+		t.Errorf("written lockfile schemaVersion = %d, want %d", written.SchemaVersion, providerLockSchemaVersion)
+	}
+	if _, ok := written.Providers.Plugin["alpha"]; !ok {
+		t.Fatalf(`written.Providers.Plugin["alpha"] not found`)
 	}
 
 	readBack, err := ReadLockfile(lockPath)
@@ -637,7 +652,10 @@ func TestSourceAuthPluginLoadForExecution(t *testing.T) {
 		"        ref: " + source,
 		"        version: " + version,
 		"        auth:",
-		"          token: secret://source-token",
+		"          token:",
+		"            secret:",
+		"              provider: secrets",
+		"              name: source-token",
 		"      config:",
 		"        clientId: managed-auth-client",
 		"server:",
@@ -883,6 +901,11 @@ func TestManagedCacheSourcesLoadForExecutionWithMultipleBindings(t *testing.T) {
 	indexedDBManifestPath := writeStubIndexedDBManifest(t, dir)
 	configYAML := strings.Join([]string{
 		"providers:",
+		"  secrets:",
+		"    session:",
+		"      source: session-secrets",
+		"    rate_limit:",
+		"      source: rate-limit-secrets",
 		"  indexeddb:",
 		"    main:",
 		"      source:",
@@ -894,13 +917,24 @@ func TestManagedCacheSourcesLoadForExecutionWithMultipleBindings(t *testing.T) {
 		"      source:",
 		"        ref: " + sessionSource,
 		"        version: " + version,
+		"      config:",
+		"        password:",
+		"          secret:",
+		"            provider: session",
+		"            name: session-cache-password",
 		"    rate_limit:",
 		"      source:",
 		"        ref: " + rateLimitSource,
 		"        version: " + version,
+		"      config:",
+		"        password:",
+		"          secret:",
+		"            provider: rate_limit",
+		"            name: rate-limit-cache-password",
 		"server:",
 		"  providers:",
 		"    indexeddb: main",
+		"    secrets: session",
 		"  artifactsDir: " + artifactsDir,
 		"  encryptionKey: aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
 	}, "\n") + "\n"
@@ -910,7 +944,21 @@ func TestManagedCacheSourcesLoadForExecutionWithMultipleBindings(t *testing.T) {
 		t.Fatalf("write config: %v", err)
 	}
 
-	lc := NewLifecycle(resolver)
+	factories := bootstrap.NewFactoryRegistry()
+	factories.Secrets["session-secrets"] = func(yaml.Node) (core.SecretManager, error) {
+		return &coretesting.StubSecretManager{
+			Secrets: map[string]string{"session-cache-password": "resolved-session-cache-password"},
+		}, nil
+	}
+	factories.Secrets["rate-limit-secrets"] = func(yaml.Node) (core.SecretManager, error) {
+		return &coretesting.StubSecretManager{
+			Secrets: map[string]string{"rate-limit-cache-password": "resolved-rate-limit-cache-password"},
+		}, nil
+	}
+
+	lc := NewLifecycle(resolver).WithConfigSecretResolver(func(ctx context.Context, cfg *config.Config) error {
+		return bootstrap.ResolveConfigSecrets(ctx, cfg, factories)
+	})
 	lock, err := lc.InitAtPath(configPath)
 	if err != nil {
 		t.Fatalf("InitAtPath: %v", err)
@@ -949,6 +997,10 @@ func TestManagedCacheSourcesLoadForExecutionWithMultipleBindings(t *testing.T) {
 		t.Fatalf("resolver called during locked load: got %d calls, want %d", len(resolver.calls), callsBefore)
 	}
 
+	wantPasswords := map[string]string{
+		"session":    "resolved-session-cache-password",
+		"rate_limit": "resolved-rate-limit-cache-password",
+	}
 	for _, name := range []string{"session", "rate_limit"} {
 		entry := cfg.Providers.Cache[name]
 		if entry == nil {
@@ -961,6 +1013,119 @@ func TestManagedCacheSourcesLoadForExecutionWithMultipleBindings(t *testing.T) {
 		if entry.Command != wantCommand {
 			t.Fatalf("cfg.Providers.Cache[%q].Command = %q, want %q", name, entry.Command, wantCommand)
 		}
+		runtimeCfg, err := config.NodeToMap(entry.Config)
+		if err != nil {
+			t.Fatalf("NodeToMap(cache %q config): %v", name, err)
+		}
+		configMap, ok := runtimeCfg["config"].(map[string]any)
+		if !ok {
+			t.Fatalf("cache %q runtime config = %#v", name, runtimeCfg["config"])
+		}
+		if got := configMap["password"]; got != wantPasswords[name] {
+			t.Fatalf("cache %q password = %#v, want %q", name, got, wantPasswords[name])
+		}
+	}
+}
+
+func TestManagedCacheSourcesInitAtPathWithPlatformsHashesExtraPlatformArchives(t *testing.T) {
+	t.Parallel()
+
+	dir := t.TempDir()
+	cacheSource := "github.com/acme/tools/cache-session"
+	version := "1.0.0"
+
+	cacheArchivePath := buildExecutableArchive(
+		t,
+		dir,
+		"cache-src",
+		cacheSource,
+		version,
+		providermanifestv1.KindCache,
+		"cache-plugin",
+		"fake-cache-binary",
+	)
+	cacheArchiveData, err := os.ReadFile(cacheArchivePath)
+	if err != nil {
+		t.Fatalf("read cache archive: %v", err)
+	}
+	cacheArchiveSum := sha256.Sum256(cacheArchiveData)
+
+	extraPlatform := struct{ GOOS, GOARCH, LibC string }{GOOS: "linux", GOARCH: "amd64"}
+	if runtime.GOOS == extraPlatform.GOOS && runtime.GOARCH == extraPlatform.GOARCH {
+		extraPlatform = struct{ GOOS, GOARCH, LibC string }{GOOS: "darwin", GOARCH: "arm64"}
+	}
+	extraPlatformKey := providerpkg.PlatformString(extraPlatform.GOOS, extraPlatform.GOARCH)
+	extraArchiveData := []byte("fake-cache-extra-platform-archive")
+	extraArchiveSum := sha256.Sum256(extraArchiveData)
+
+	var extraAssetCount atomic.Int64
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch r.URL.Path {
+		case "/cache-extra.tar.gz":
+			extraAssetCount.Add(1)
+			w.Header().Set("Content-Type", "application/octet-stream")
+			_, _ = w.Write(extraArchiveData)
+		default:
+			http.NotFound(w, r)
+		}
+	}))
+	defer srv.Close()
+
+	resolver := &fakeMultiResolver{
+		results: map[string]fakeResolverResult{
+			cacheSource: {
+				archivePath: cacheArchivePath,
+				resolvedURL: srv.URL + "/cache-current.tar.gz",
+				sha256:      hex.EncodeToString(cacheArchiveSum[:]),
+				platformArchives: []pluginsource.PlatformArchive{
+					{Platform: extraPlatformKey, URL: srv.URL + "/cache-extra.tar.gz"},
+				},
+			},
+		},
+	}
+
+	artifactsDir := filepath.Join(dir, "prepared-artifacts")
+	configYAML := requiredComponentConfigYAML(t, dir, filepath.Join(dir, "gestalt.db")) + strings.Join([]string{
+		"  cache:",
+		"    session:",
+		"      source:",
+		"        ref: " + cacheSource,
+		"        version: " + version,
+		"server:",
+		"  providers:",
+		"    indexeddb: sqlite",
+		"  artifactsDir: " + artifactsDir,
+		"  encryptionKey: aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
+	}, "\n") + "\n"
+
+	configPath := filepath.Join(dir, "gestalt.yaml")
+	if err := os.WriteFile(configPath, []byte(configYAML), 0o644); err != nil {
+		t.Fatalf("write config: %v", err)
+	}
+
+	lc := NewLifecycle(resolver)
+	lock, err := lc.InitAtPathWithPlatforms(configPath, "", []struct{ GOOS, GOARCH, LibC string }{extraPlatform})
+	if err != nil {
+		t.Fatalf("InitAtPathWithPlatforms: %v", err)
+	}
+	if got := extraAssetCount.Load(); got != 1 {
+		t.Fatalf("extra asset request count = %d, want 1", got)
+	}
+
+	entry, ok := lock.Caches["session"]
+	if !ok {
+		t.Fatal(`lock.Caches["session"] not found`)
+	}
+	if got := entry.Archives[extraPlatformKey].SHA256; got != hex.EncodeToString(extraArchiveSum[:]) {
+		t.Fatalf("lock extra-platform SHA256 = %q, want %q", got, hex.EncodeToString(extraArchiveSum[:]))
+	}
+
+	readBack, err := ReadLockfile(filepath.Join(dir, InitLockfileName))
+	if err != nil {
+		t.Fatalf("ReadLockfile: %v", err)
+	}
+	if got := readBack.Caches["session"].Archives[extraPlatformKey].SHA256; got != hex.EncodeToString(extraArchiveSum[:]) {
+		t.Fatalf("readBack extra-platform SHA256 = %q, want %q", got, hex.EncodeToString(extraArchiveSum[:]))
 	}
 }
 
@@ -968,10 +1133,42 @@ func TestSourceSecretsPluginBootstrapsManagedAuthSourceToken(t *testing.T) {
 	t.Parallel()
 
 	dir := t.TempDir()
+	secretsSourceToken := "ghp_inline_auth_source_token"
+	bootstrapSource := "github.com/acme/tools/bootstrap-secrets"
+	bootstrapVersion := "0.1.0"
 	secretsSource := "github.com/acme/tools/secrets-widget"
 	secretsVersion := "1.0.0"
 	authSource := "github.com/acme/tools/auth-widget"
 	authVersion := "2.0.0"
+	bootstrapArtifact := filepath.ToSlash(filepath.Join("artifacts", runtime.GOOS, runtime.GOARCH, "bootstrap-secrets"))
+	bootstrapManifestPath := filepath.Join(dir, "bootstrap-secrets-manifest.yaml")
+	bootstrapManifest, err := providerpkg.EncodeSourceManifestFormat(&providermanifestv1.Manifest{
+		Kind:    providermanifestv1.KindSecrets,
+		Source:  bootstrapSource,
+		Version: bootstrapVersion,
+		Spec:    &providermanifestv1.Spec{},
+		Artifacts: []providermanifestv1.Artifact{
+			{OS: runtime.GOOS, Arch: runtime.GOARCH, Path: bootstrapArtifact},
+		},
+		Entrypoint: &providermanifestv1.Entrypoint{ArtifactPath: bootstrapArtifact},
+	}, providerpkg.ManifestFormatYAML)
+	if err != nil {
+		t.Fatalf("EncodeSourceManifestFormat bootstrap: %v", err)
+	}
+	if err := os.WriteFile(bootstrapManifestPath, bootstrapManifest, 0o644); err != nil {
+		t.Fatalf("write bootstrap manifest: %v", err)
+	}
+	bootstrapBinaryData, err := os.ReadFile(buildGoSourceSecretsBinary(t))
+	if err != nil {
+		t.Fatalf("read bootstrap binary: %v", err)
+	}
+	bootstrapBinaryPath := filepath.Join(dir, filepath.FromSlash(bootstrapArtifact))
+	if err := os.MkdirAll(filepath.Dir(bootstrapBinaryPath), 0o755); err != nil {
+		t.Fatalf("MkdirAll bootstrap artifact: %v", err)
+	}
+	if err := os.WriteFile(bootstrapBinaryPath, bootstrapBinaryData, 0o755); err != nil {
+		t.Fatalf("write bootstrap artifact: %v", err)
+	}
 
 	secretsArchivePath := buildExecutableArchiveFromBinaryPath(
 		t,
@@ -1011,8 +1208,8 @@ func TestSourceSecretsPluginBootstrapsManagedAuthSourceToken(t *testing.T) {
 		switch r.URL.Path {
 		case "/secrets.tar.gz":
 			secretsDownloads.Add(1)
-			if got := r.Header.Get("Authorization"); got != "" {
-				http.Error(w, "unexpected auth header for secrets download", http.StatusUnauthorized)
+			if got := r.Header.Get("Authorization"); got != "token "+secretsSourceToken {
+				http.Error(w, "bad auth header for secrets download", http.StatusUnauthorized)
 				return
 			}
 			w.Header().Set("Content-Type", "application/octet-stream")
@@ -1050,17 +1247,28 @@ func TestSourceSecretsPluginBootstrapsManagedAuthSourceToken(t *testing.T) {
 	configYAML := strings.Join([]string{
 		requiredIndexedDBConfigYAML(t, dir, filepath.Join(dir, "data.db")),
 		"  secrets:",
+		"    bootstrap:",
+		"      source:",
+		"        path: ./bootstrap-secrets-manifest.yaml",
 		"    secrets:",
 		"      source:",
 		"        ref: " + secretsSource,
 		"        version: " + secretsVersion,
+		"        auth:",
+		"          token:",
+		"            secret:",
+		"              provider: bootstrap",
+		"              name: source-token",
 		"  auth:",
 		"    auth:",
 		"      source:",
 		"        ref: " + authSource,
 		"        version: " + authVersion,
 		"        auth:",
-		"          token: secret://source-token",
+		"          token:",
+		"            secret:",
+		"              provider: secrets",
+		"              name: source-token",
 		"      config:",
 		"        clientId: managed-auth-client",
 		"server:",
@@ -1096,8 +1304,8 @@ func TestSourceSecretsPluginBootstrapsManagedAuthSourceToken(t *testing.T) {
 	if resolver.calls[0].src.String() != secretsSource {
 		t.Fatalf("first resolver source = %q, want %q", resolver.calls[0].src.String(), secretsSource)
 	}
-	if resolver.calls[0].src.Token != "" {
-		t.Fatalf("secrets resolver token = %q, want empty", resolver.calls[0].src.Token)
+	if resolver.calls[0].src.Token != secretsSourceToken {
+		t.Fatalf("secrets resolver token = %q, want %q", resolver.calls[0].src.Token, secretsSourceToken)
 	}
 	if resolver.calls[1].src.String() != authSource {
 		t.Fatalf("second resolver source = %q, want %q", resolver.calls[1].src.String(), authSource)
@@ -1141,6 +1349,12 @@ func TestSourceSecretsPluginBootstrapsManagedAuthSourceToken(t *testing.T) {
 	secretsProvider := mustSelectedHostProviderEntry(t, cfg, config.HostProviderKindSecrets)
 	if secretsProvider == nil {
 		t.Fatal("secrets provider is nil after load")
+	}
+	if secretsProvider.Source.Auth == nil {
+		t.Fatalf("secrets provider source auth = %#v", secretsProvider)
+	}
+	if secretsProvider.Source.Auth.Token != secretsSourceToken {
+		t.Fatalf("resolved secrets source token = %q, want %q", secretsProvider.Source.Auth.Token, secretsSourceToken)
 	}
 	if secretsProvider.Command != secretsExecutablePath {
 		t.Fatalf("secrets provider command = %q, want %q", secretsProvider.Command, secretsExecutablePath)

--- a/gestaltd/internal/operator/lifecycle_test.go
+++ b/gestaltd/internal/operator/lifecycle_test.go
@@ -350,7 +350,7 @@ plugins:
 			wantPolicy: "roadmap_policy",
 		},
 		{
-			name: "disabled explicit plugin mount does not suppress ui path validation",
+			name: "disabled explicit plugin mount is rejected",
 			uiConfigYAML: `  ui:
     roadmap:
       source:
@@ -369,10 +369,10 @@ plugins:
       authorizationPolicy: roadmap_policy
 `,
 			uiKey:   "roadmap",
-			wantErr: "config validation: ui.roadmap.path: path is required",
+			wantErr: "field disabled not found",
 		},
 		{
-			name: "disabled plugin does not suppress matching ui path validation",
+			name: "disabled plugin is rejected",
 			uiConfigYAML: `  ui:
     roadmap:
       source:
@@ -384,7 +384,7 @@ plugins:
         path: ./plugin/manifest.yaml
       mountPath: /create-customer-roadmap-review
 `,
-			wantErr: "config validation: ui.roadmap.path: path is required",
+			wantErr: "field disabled not found",
 		},
 		{
 			name: "plugin owned ui via plugin mount",
@@ -435,7 +435,7 @@ plugins:
 			ownedUIPath: "../webui/manifest.yaml",
 		},
 		{
-			name: "disabled same-name ui overlay is rejected",
+			name: "disabled same-name ui overlay is rejected at parse time",
 			uiConfigYAML: `  ui:
     roadmap:
       disabled: true
@@ -447,7 +447,7 @@ plugins:
         path: ./plugin/manifest.yaml
       mountPath: /create-customer-roadmap-review
 `,
-			wantErr:     "config validation: plugins.roadmap owned ui conflicts with disabled providers.ui.roadmap",
+			wantErr:     "field disabled not found",
 			ownedUIPath: "../webui/manifest.yaml",
 		},
 	}
@@ -1172,7 +1172,7 @@ server:
 	}
 }
 
-func TestLoadForExecutionAtPath_SkipsDisabledLocalMountedWebUIWithoutLockfile(t *testing.T) {
+func TestLoadForExecutionAtPath_RejectsDisabledLocalMountedWebUIWithoutLockfile(t *testing.T) {
 	t.Parallel()
 
 	dir := t.TempDir()
@@ -1191,27 +1191,16 @@ func TestLoadForExecutionAtPath_SkipsDisabledLocalMountedWebUIWithoutLockfile(t 
 	}
 
 	lc := NewLifecycle(nil)
-	loaded, _, err := lc.LoadForExecutionAtPath(cfgPath, false)
-	if err != nil {
-		t.Fatalf("LoadForExecutionAtPath: %v", err)
+	_, _, err := lc.LoadForExecutionAtPath(cfgPath, false)
+	if err == nil {
+		t.Fatal("LoadForExecutionAtPath: expected error, got nil")
 	}
-
-	entry := loaded.Providers.UI["roadmap"]
-	if entry == nil {
-		t.Fatal(`Providers.UI["roadmap"] = nil`)
-	}
-	if entry.ResolvedManifest != nil {
-		t.Fatalf("ResolvedManifest = %#v, want nil", entry.ResolvedManifest)
-	}
-	if entry.ResolvedAssetRoot != "" {
-		t.Fatalf("ResolvedAssetRoot = %q, want empty", entry.ResolvedAssetRoot)
-	}
-	if _, err := os.Stat(filepath.Join(dir, InitLockfileName)); !os.IsNotExist(err) {
-		t.Fatalf("lockfile should not be created, got err=%v", err)
+	if !strings.Contains(err.Error(), "field disabled not found") {
+		t.Fatalf("LoadForExecutionAtPath error = %v, want substring %q", err, "field disabled not found")
 	}
 }
 
-func TestInitAtPath_SkipsDisabledManagedMountedWebUI(t *testing.T) {
+func TestInitAtPath_RejectsDisabledManagedMountedWebUI(t *testing.T) {
 	t.Parallel()
 
 	dir := t.TempDir()
@@ -1222,6 +1211,11 @@ func TestInitAtPath_SkipsDisabledManagedMountedWebUI(t *testing.T) {
       source:
         ref: github.com/testowner/web/roadmap
         version: 0.0.1-alpha.1
+        auth:
+          token:
+            secret:
+              provider: missing
+              name: disabled-webui-token
       path: /create-customer-roadmap-review
 ` + `server:
 ` + requiredServerDatastoreYAML() + `  encryptionKey: aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa
@@ -1231,12 +1225,182 @@ func TestInitAtPath_SkipsDisabledManagedMountedWebUI(t *testing.T) {
 	}
 
 	lc := NewLifecycle(nil)
-	lock, err := lc.InitAtPath(cfgPath)
-	if err != nil {
-		t.Fatalf("InitAtPath: %v", err)
+	_, err := lc.InitAtPath(cfgPath)
+	if err == nil {
+		t.Fatal("InitAtPath: expected error, got nil")
 	}
-	if len(lock.UIs) != 0 {
-		t.Fatalf("UIs = %#v, want empty", lock.UIs)
+	if !strings.Contains(err.Error(), "field disabled not found") {
+		t.Fatalf("InitAtPath error = %v, want substring %q", err, "field disabled not found")
+	}
+}
+
+func TestInitAtPath_RejectsDisabledManagedHostProvidersWithStructuredSecretRefs(t *testing.T) {
+	t.Parallel()
+
+	dir := t.TempDir()
+	cfgPath := filepath.Join(dir, "config.yaml")
+	manifestPath := writeStubIndexedDBManifest(t, dir)
+	cfg := `providers:
+  indexeddb:
+    sqlite:
+      source:
+        path: ` + manifestPath + `
+      config:
+        path: "` + filepath.Join(dir, "gestalt.db") + `"
+    disabled:
+      disabled: true
+      config:
+        path:
+          secret:
+            provider: missing
+            name: disabled-indexeddb-path
+  auth:
+    disabled:
+      disabled: true
+      config:
+        clientSecret:
+          secret:
+            provider: missing
+            name: disabled-auth-token
+  telemetry:
+    disabled:
+      disabled: true
+      config:
+        endpoint:
+          secret:
+            provider: missing
+            name: disabled-telemetry-endpoint
+  audit:
+    disabled:
+      disabled: true
+      config:
+        endpoint:
+          secret:
+            provider: missing
+            name: disabled-audit-endpoint
+  secrets:
+    disabled:
+      disabled: true
+      displayName:
+        secret:
+          provider: missing
+          name: disabled-secrets-token
+  cache:
+    disabled:
+      disabled: true
+      config:
+        password:
+          secret:
+            provider: missing
+            name: disabled-cache-password
+` + `server:
+` + requiredServerDatastoreYAML() + `  encryptionKey: aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa
+`
+	if err := os.WriteFile(cfgPath, []byte(cfg), 0o644); err != nil {
+		t.Fatalf("WriteFile config: %v", err)
+	}
+
+	lc := NewLifecycle(nil)
+	_, err := lc.InitAtPath(cfgPath)
+	if err == nil {
+		t.Fatal("InitAtPath: expected error, got nil")
+	}
+	if !strings.Contains(err.Error(), "field disabled not found") {
+		t.Fatalf("InitAtPath error = %v, want substring %q", err, "field disabled not found")
+	}
+}
+
+func TestLoadForExecutionAtPath_RejectsDisabledManagedHostProvidersWithoutLockfile(t *testing.T) {
+	t.Parallel()
+
+	dir := t.TempDir()
+	cfgPath := filepath.Join(dir, "config.yaml")
+	manifestPath := writeStubIndexedDBManifest(t, dir)
+	cfg := `providers:
+  indexeddb:
+    sqlite:
+      source:
+        path: ` + manifestPath + `
+      config:
+        path: "` + filepath.Join(dir, "gestalt.db") + `"
+    disabled:
+      disabled: true
+      source:
+        ref: github.com/testowner/indexeddb/disabled
+        version: 0.0.1-alpha.1
+      config:
+        path:
+          secret:
+            provider: missing
+            name: disabled-indexeddb-path
+  auth:
+    disabled:
+      disabled: true
+      source:
+        ref: github.com/testowner/auth/disabled
+        version: 0.0.1-alpha.1
+      config:
+        clientSecret:
+          secret:
+            provider: missing
+            name: disabled-auth-token
+  telemetry:
+    disabled:
+      disabled: true
+      source:
+        ref: github.com/testowner/plugins/telemetry-disabled
+        version: 0.0.1-alpha.1
+      config:
+        endpoint:
+          secret:
+            provider: missing
+            name: disabled-telemetry-endpoint
+  audit:
+    disabled:
+      disabled: true
+      source:
+        ref: github.com/testowner/plugins/audit-disabled
+        version: 0.0.1-alpha.1
+      config:
+        endpoint:
+          secret:
+            provider: missing
+            name: disabled-audit-endpoint
+  secrets:
+    disabled:
+      disabled: true
+      source:
+        ref: github.com/testowner/secrets/disabled
+        version: 0.0.1-alpha.1
+      displayName:
+        secret:
+          provider: missing
+          name: disabled-secrets-token
+  cache:
+    disabled:
+      disabled: true
+      source:
+        ref: github.com/testowner/cache/disabled
+        version: 0.0.1-alpha.1
+      config:
+        password:
+          secret:
+            provider: missing
+            name: disabled-cache-password
+` + `server:
+` + requiredServerDatastoreYAML() + `  encryptionKey: aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa
+`
+	if err := os.WriteFile(cfgPath, []byte(cfg), 0o644); err != nil {
+		t.Fatalf("WriteFile config: %v", err)
+	}
+
+	lc := NewLifecycle(nil)
+	_, _, err := lc.LoadForExecutionAtPath(cfgPath, false)
+	if err == nil {
+		t.Fatal("LoadForExecutionAtPath: expected error, got nil")
+	}
+	if !strings.Contains(err.Error(), "field disabled not found") {
+		t.Fatalf("LoadForExecutionAtPath error = %v, want substring %q", err, "field disabled not found")
 	}
 }
 


### PR DESCRIPTION
## Summary

This replaces config-wide `secret://...` strings with explicit structured secret refs and removes `disabled` config support for providers, plugins, mounted UIs, and plugin IndexedDB config.

YAML:

```yaml
server:
  providers:
    secrets: runtime
    indexeddb: main

  encryptionKey:
    secret:
      provider: runtime
      name: gestalt-encryption-key

providers:
  secrets:
    runtime:
      source: env

  indexeddb:
    main:
      source:
        ref: github.com/valon-technologies/gestalt-providers/indexeddb/sqlite
        version: 0.0.1-alpha.1
      config:
        path: /data/gestalt.db

  auth:
    oidc:
      source:
        ref: github.com/valon-technologies/gestalt-providers/auth/oidc
        version: 0.0.1-alpha.1
      config:
        clientId: ${OIDC_CLIENT_ID}
        clientSecret:
          secret:
            provider: runtime
            name: oidc-client-secret

  ui:
    roadmap:
      source:
        ref: github.com/acme/web/roadmap
        version: 1.2.3
      path: /roadmap
```

Removed syntax:

```yaml
providers:
  auth:
    default:
      disabled: true
```

Disable auth or mounted UI by omission instead.

Go:

```go
type SecretRef struct {
    Provider string `json:"provider"`
    Name     string `json:"name"`
}

var YAMLNodeType = reflect.TypeOf(yaml.Node{})

func ReferencedConfigSecretProviders(cfg *Config) (map[string]struct{}, error)
func ResolveConfigSecrets(ctx context.Context, cfg *config.Config, factories *FactoryRegistry) error
```

Examples:
- `clientSecret.secret.provider` and `clientSecret.secret.name` now define config secret sources explicitly.
- config load rejects legacy `secret://...` during parsing.
- config-time resolution can use multiple named `providers.secrets.*` entries in one config.
- runtime `server.providers.secrets` still governs the single runtime `SecretManager`.
- `disabled` is no longer supported on providers, plugins, UI entries, or plugin IndexedDB config; omit the entry instead.

## Implementation

- adds raw-YAML structured secret-ref normalization and validation before typed decode
- runs the same normalization through managed provider config overlay paths so `init` and `serve` agree
- resolves config secret refs through a temporary per-provider secret-manager cache with success/failure cleanup
- updates operator init/load flows to prepare every referenced managed secrets provider needed for config resolution
- extends config-time traversal to `providers.cache`
- preserves runtime `server.providers.secrets` selection as the singular runtime secret manager
- removes `disabled` branches from config selection, validation, bootstrap, init/load flows, and docs
- rejects removed `disabled` fields during raw YAML load before missing-env validation
- updates docs/examples to omission-based auth/UI disablement and structured secret refs

## Validation

```sh
cd gestaltd
go test ./internal/config ./internal/bootstrap ./internal/operator ./cmd/gestaltd
golangci-lint run
```

Sanity grep:

```sh
rg -n "\\bDisabled\\b|disabled:" gestaltd docs/content docs/dockerhub -g'*.go' -g'*.mdx' -g'*.md'
```

The remaining grep hits are intentional rejection tests.
