### PR TITLE
[codex] Fix deploy parent page behavior

### DIFF
--- a/docs/content/deploy/index.mdx
+++ b/docs/content/deploy/index.mdx
@@ -1,8 +1,8 @@
-import { Callout } from 'nextra/components'
-
 ---
 asIndexPage: true
 ---
+
+import { Callout } from 'nextra/components'
 
 # Deploy
 


### PR DESCRIPTION
## What changed
- moved the frontmatter in `docs/content/deploy/index.mdx` above the MDX import
- preserved `asIndexPage: true` so Nextra treats `/deploy` as the parent page itself

## Why
`deploy/index.mdx` had an `import` before the frontmatter, so Nextra did not apply `asIndexPage: true`. That caused `/deploy` to render as a folder with a separate child index page instead of the parent page.

## Impact
- `/deploy` now behaves as the actual parent page
- the sidebar links to `/deploy` directly while still showing the `Docker` and `Helm` child pages underneath

## Validation
- `npx next build`
- verified generated output now renders `Deploy` as `href="/deploy"` instead of a folder-only `data-href="/deploy"`
