### PR TITLE
Mount web/default at / in default managed config

### DIFF
--- a/gestaltd/internal/config/config.go
+++ b/gestaltd/internal/config/config.go
@@ -29,6 +29,8 @@ const (
 
 	DefaultIndexedDBProvider = DefaultProviderRepo + "/indexeddb/relationaldb"
 	DefaultIndexedDBVersion  = "0.0.1-alpha.2"
+	DefaultWebUIProvider     = DefaultProviderRepo + "/web/default"
+	DefaultWebUIVersion      = "0.0.1-alpha.5"
 	DefaultProviderInstance  = "default"
 )
 

--- a/gestaltd/internal/operator/localconfig.go
+++ b/gestaltd/internal/operator/localconfig.go
@@ -74,6 +74,12 @@ providers:
         version: %s
       config:
         dsn: %q
+  ui:
+    root:
+      source:
+        ref: %s
+        version: %s
+      path: /
   secrets:
     env:
       source: env
@@ -85,7 +91,7 @@ plugins:
       version: %s
     allowedHosts:
       - httpbin.org
-`, encryptionKey, config.DefaultIndexedDBProvider, config.DefaultIndexedDBVersion, "sqlite://"+dbPath, defaultHTTPBinProvider, defaultHTTPBinVersion)
+`, encryptionKey, config.DefaultIndexedDBProvider, config.DefaultIndexedDBVersion, "sqlite://"+dbPath, config.DefaultWebUIProvider, config.DefaultWebUIVersion, defaultHTTPBinProvider, defaultHTTPBinVersion)
 }
 
 func defaultLocalSourceConfig(providersDir, dbPath, encryptionKey string) string {

--- a/gestaltd/internal/operator/localconfig_test.go
+++ b/gestaltd/internal/operator/localconfig_test.go
@@ -1,0 +1,70 @@
+package operator
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/valon-technologies/gestalt/server/internal/config"
+)
+
+func TestDefaultManagedConfigIncludesRootWebUI(t *testing.T) {
+	t.Parallel()
+
+	dir := t.TempDir()
+	dbPath := filepath.Join(dir, "gestalt.db")
+	configPath := filepath.Join(dir, "config.yaml")
+
+	if err := os.WriteFile(configPath, []byte(defaultManagedConfig(dbPath, "server-key")), 0o600); err != nil {
+		t.Fatalf("WriteFile: %v", err)
+	}
+
+	cfg, err := config.Load(configPath)
+	if err != nil {
+		t.Fatalf("Load: %v", err)
+	}
+
+	rootUI := cfg.Providers.UI["root"]
+	if rootUI == nil {
+		t.Fatal(`Providers.UI["root"] = nil`)
+	}
+	if got := rootUI.SourceRef(); got != config.DefaultWebUIProvider {
+		t.Fatalf(`Providers.UI["root"].Source.Ref = %q, want %q`, got, config.DefaultWebUIProvider)
+	}
+	if got := rootUI.SourceVersion(); got != config.DefaultWebUIVersion {
+		t.Fatalf(`Providers.UI["root"].Source.Version = %q, want %q`, got, config.DefaultWebUIVersion)
+	}
+	if got := rootUI.Path; got != "/" {
+		t.Fatalf(`Providers.UI["root"].Path = %q, want %q`, got, "/")
+	}
+}
+
+func TestDefaultLocalSourceConfigIncludesRootWebUI(t *testing.T) {
+	t.Parallel()
+
+	dir := t.TempDir()
+	providersDir := filepath.Join(dir, "providers")
+	dbPath := filepath.Join(dir, "gestalt.db")
+	configPath := filepath.Join(dir, "config.yaml")
+
+	if err := os.WriteFile(configPath, []byte(defaultLocalSourceConfig(providersDir, dbPath, "server-key")), 0o600); err != nil {
+		t.Fatalf("WriteFile: %v", err)
+	}
+
+	cfg, err := config.Load(configPath)
+	if err != nil {
+		t.Fatalf("Load: %v", err)
+	}
+
+	rootUI := cfg.Providers.UI["root"]
+	if rootUI == nil {
+		t.Fatal(`Providers.UI["root"] = nil`)
+	}
+	wantPath := filepath.Join(providersDir, "web", "default", "manifest.yaml")
+	if got := rootUI.SourcePath(); got != wantPath {
+		t.Fatalf(`Providers.UI["root"].Source.Path = %q, want %q`, got, wantPath)
+	}
+	if got := rootUI.Path; got != "/" {
+		t.Fatalf(`Providers.UI["root"].Path = %q, want %q`, got, "/")
+	}
+}


### PR DESCRIPTION
## Summary
- add a default managed UI mount at `/` for `github.com/valon-technologies/gestalt-providers/web/default`
- point the managed default at `0.0.1-alpha.5`
- add operator tests covering both managed and local-source default config generation

## Testing
- `go test ./internal/operator ./internal/config`