### PR TITLE
Reset alpha.1 defaults and allow nested UI mounts

### DIFF
--- a/docs/content/configuration.mdx
+++ b/docs/content/configuration.mdx
@@ -293,7 +293,7 @@ providers:
     main:
       source:
         ref: github.com/valon-technologies/gestalt-providers/indexeddb/relationaldb
-        version: 0.0.1-alpha.2
+        version: 0.0.1-alpha.1
       config:
         dsn: sqlite://./gestalt.db
 ```
@@ -377,7 +377,7 @@ providers:
     main:
       source:
         ref: github.com/valon-technologies/gestalt-providers/indexeddb/relationaldb
-        version: 0.0.1-alpha.2
+        version: 0.0.1-alpha.1
       config:
         dsn: sqlite://./gestalt.db
 
@@ -422,7 +422,7 @@ providers:
     main:
       source:
         ref: github.com/valon-technologies/gestalt-providers/indexeddb/relationaldb
-        version: 0.0.1-alpha.2
+        version: 0.0.1-alpha.1
       config:
         dsn: sqlite://./gestalt.db
 ```

--- a/docs/content/custom-providers/indexeddb.mdx
+++ b/docs/content/custom-providers/indexeddb.mdx
@@ -40,7 +40,7 @@ An IndexedDB provider manifest declares `kind: indexeddb`:
 ```yaml
 kind: indexeddb
 source: github.com/valon-technologies/gestalt-providers/indexeddb/relationaldb
-version: 0.0.1-alpha.2
+version: 0.0.1-alpha.1
 displayName: RelationalDB
 description: IndexedDB provider supporting PostgreSQL, MySQL, SQLite, and SQL Server.
 spec:
@@ -405,7 +405,7 @@ providers:
     main:
       source:
         ref: github.com/valon-technologies/gestalt-providers/indexeddb/relationaldb
-        version: 0.0.1-alpha.2
+        version: 0.0.1-alpha.1
       config:
         dsn: ${DATABASE_URL}
 ```

--- a/docs/content/deploy/helm.mdx
+++ b/docs/content/deploy/helm.mdx
@@ -57,7 +57,7 @@ config:
       main:
         source:
           ref: github.com/valon-technologies/gestalt-providers/indexeddb/relationaldb
-          version: 0.0.1-alpha.2
+          version: 0.0.1-alpha.1
         config:
           dsn: "${DATABASE_URL}"
 
@@ -140,7 +140,7 @@ config:
       main:
         source:
           ref: github.com/valon-technologies/gestalt-providers/indexeddb/relationaldb
-          version: 0.0.1-alpha.2
+          version: 0.0.1-alpha.1
         config:
           dsn: "${DATABASE_URL}"
 

--- a/docs/content/deploy/index.mdx
+++ b/docs/content/deploy/index.mdx
@@ -49,7 +49,7 @@ The lock file is a JSON document that records resolved plugins and host-scoped p
     "main": {
       "fingerprint": "ab12cd...",
       "source": "github.com/valon-technologies/gestalt-providers/indexeddb/relationaldb",
-      "version": "0.0.1-alpha.2",
+      "version": "0.0.1-alpha.1",
       "manifest": ".gestaltd/providers/main/manifest.json",
       "executable": ".gestaltd/providers/main/artifacts/linux/amd64/provider"
     }

--- a/docs/content/getting-started.mdx
+++ b/docs/content/getting-started.mdx
@@ -16,7 +16,7 @@ Run `gestaltd` with no arguments:
 gestaltd
 ```
 
-When no config file exists, `gestaltd` generates one at `~/.gestaltd/config.yaml` and starts immediately with SQLite storage via the [RelationalDB](https://github.com/valon-technologies/gestalt-providers/tree/main/indexeddb/relationaldb) implementation of the [IndexedDB provider](/providers/indexeddb), no authentication, and an [HTTPBin](https://github.com/valon-technologies/gestalt-providers/tree/main/plugins/httpbin) implementation of the [plugin provider](/providers/plugins) on port 8080.
+When no config file exists, `gestaltd` generates one at `~/.gestaltd/config.yaml` and starts immediately with SQLite storage via the [RelationalDB](https://github.com/valon-technologies/gestalt-providers/tree/main/indexeddb/relationaldb) implementation of the [IndexedDB provider](/providers/indexeddb), the [default web UI](https://github.com/valon-technologies/gestalt-providers/tree/main/web/default) mounted at `/`, no authentication, and an [HTTPBin](https://github.com/valon-technologies/gestalt-providers/tree/main/plugins/httpbin) implementation of the [plugin provider](/providers/plugins) on port 8080.
 
 ```
 2026/04/10 10:00:00 INFO generated default config path=~/.gestaltd/config.yaml

--- a/docs/content/providers/index.mdx
+++ b/docs/content/providers/index.mdx
@@ -75,7 +75,7 @@ providers:
     main:
       source:
         ref: github.com/valon-technologies/gestalt-providers/indexeddb/relationaldb
-        version: 0.0.1-alpha.2
+        version: 0.0.1-alpha.1
       config:
         dsn: ${DATABASE_URL}
 

--- a/docs/content/providers/indexeddb.mdx
+++ b/docs/content/providers/indexeddb.mdx
@@ -50,13 +50,13 @@ providers:
     main:
       source:
         ref: github.com/valon-technologies/gestalt-providers/indexeddb/relationaldb
-        version: 0.0.1-alpha.2
+        version: 0.0.1-alpha.1
       config:
         dsn: ${SYSTEM_DATABASE_URL}
     workplaceHub:
       source:
         ref: github.com/valon-technologies/gestalt-providers/indexeddb/relationaldb
-        version: 0.0.1-alpha.2
+        version: 0.0.1-alpha.1
       config:
         dsn: ${APP_DATABASE_URL}
 
@@ -121,7 +121,7 @@ providers:
     main:
       source:
         ref: github.com/valon-technologies/gestalt-providers/indexeddb/relationaldb
-        version: 0.0.1-alpha.2
+        version: 0.0.1-alpha.1
       config:
         dsn: ${DATABASE_URL}
 ```

--- a/docs/content/reference/built-in-providers.mdx
+++ b/docs/content/reference/built-in-providers.mdx
@@ -42,7 +42,7 @@ providers:
     main:
       source:
         ref: github.com/valon-technologies/gestalt-providers/indexeddb/relationaldb
-        version: 0.0.1-alpha.2
+        version: 0.0.1-alpha.1
       config:
         dsn: ${DATABASE_URL}
 ```

--- a/docs/content/reference/config-file.mdx
+++ b/docs/content/reference/config-file.mdx
@@ -215,7 +215,7 @@ providers:
     main:
       source:
         ref: github.com/valon-technologies/gestalt-providers/indexeddb/relationaldb
-        version: 0.0.1-alpha.2
+        version: 0.0.1-alpha.1
       config:
         dsn: ${DATABASE_URL}
 ```

--- a/docs/dockerhub/gestaltd.md
+++ b/docs/dockerhub/gestaltd.md
@@ -70,7 +70,7 @@ providers:
     main:
       source:
         ref: github.com/valon-technologies/gestalt-providers/indexeddb/relationaldb
-        version: 0.0.1-alpha.2
+        version: 0.0.1-alpha.1
       config:
         dsn: sqlite:///data/gestalt.db
 

--- a/gestaltd/cmd/gestaltd/e2e_test.go
+++ b/gestaltd/cmd/gestaltd/e2e_test.go
@@ -325,7 +325,7 @@ providers:
     %s:
       source:
         ref: github.com/valon-technologies/gestalt-providers/indexeddb/relationaldb
-        version: 0.0.1-alpha.2
+        version: 0.0.1-alpha.1
       config:
         dsn: %q
 `, serverProvidersBlock, authBlock, datastoreName, "sqlite://"+dbPath)

--- a/gestaltd/deploy/helm/gestalt/values.yaml
+++ b/gestaltd/deploy/helm/gestalt/values.yaml
@@ -98,7 +98,7 @@ config:
         # deployments with mounted persistent storage at /data.
         source:
           ref: github.com/valon-technologies/gestalt-providers/indexeddb/relationaldb
-          version: 0.0.1-alpha.2
+          version: 0.0.1-alpha.1
         config:
           dsn: "sqlite:///data/gestalt.db"
     # Add providers.ui.<name> entries when you want to mount public static UI bundles.

--- a/gestaltd/internal/config/config.go
+++ b/gestaltd/internal/config/config.go
@@ -30,9 +30,9 @@ const (
 	DefaultProviderRepo = "github.com/valon-technologies/gestalt-providers"
 
 	DefaultIndexedDBProvider = DefaultProviderRepo + "/indexeddb/relationaldb"
-	DefaultIndexedDBVersion  = "0.0.1-alpha.2"
+	DefaultIndexedDBVersion  = "0.0.1-alpha.1"
 	DefaultWebUIProvider     = DefaultProviderRepo + "/web/default"
-	DefaultWebUIVersion      = "0.0.1-alpha.5"
+	DefaultWebUIVersion      = "0.0.1-alpha.1"
 	DefaultProviderInstance  = "default"
 )
 

--- a/gestaltd/internal/config/config_test.go
+++ b/gestaltd/internal/config/config_test.go
@@ -1267,7 +1267,7 @@ server:
 		}
 	})
 
-	t.Run("prefix collision is rejected", func(t *testing.T) {
+	t.Run("nested ui paths are accepted", func(t *testing.T) {
 		t.Parallel()
 
 		path := mustWriteConfigFile(t, `
@@ -1291,12 +1291,15 @@ server:
   encryptionKey: server-key
 `)
 
-		_, err := Load(path)
-		if err == nil {
-			t.Fatal("Load: expected error, got nil")
+		cfg, err := Load(path)
+		if err != nil {
+			t.Fatalf("Load: %v", err)
 		}
-		if !strings.Contains(err.Error(), `ui.`) || !strings.Contains(err.Error(), `"/tools"`) || !strings.Contains(err.Error(), `"/tools/admin"`) {
-			t.Fatalf("unexpected error: %v", err)
+		if got := cfg.Providers.UI["parent"].Path; got != "/tools" {
+			t.Fatalf(`Providers.UI["parent"].Path = %q, want %q`, got, "/tools")
+		}
+		if got := cfg.Providers.UI["child"].Path; got != "/tools/admin" {
+			t.Fatalf(`Providers.UI["child"].Path = %q, want %q`, got, "/tools/admin")
 		}
 	})
 

--- a/gestaltd/internal/config/config_validate.go
+++ b/gestaltd/internal/config/config_validate.go
@@ -711,8 +711,9 @@ func validateMountedUICollisions(cfg *Config, pluginOwnedUIRefs map[string]struc
 		"/ready",
 	}
 	type mountedPathSubject struct {
-		label string
-		path  string
+		label           string
+		path            string
+		allowNestedPath bool
 	}
 	subjects := make([]mountedPathSubject, 0, len(cfg.Providers.UI)+len(cfg.Plugins))
 	names := slices.Sorted(maps.Keys(cfg.Providers.UI))
@@ -722,8 +723,9 @@ func validateMountedUICollisions(cfg *Config, pluginOwnedUIRefs map[string]struc
 			continue
 		}
 		subjects = append(subjects, mountedPathSubject{
-			label: "ui." + name + ".path",
-			path:  entry.Path,
+			label:           "ui." + name + ".path",
+			path:            entry.Path,
+			allowNestedPath: true,
 		})
 	}
 	pluginNames := slices.Sorted(maps.Keys(cfg.Plugins))
@@ -757,12 +759,24 @@ func validateMountedUICollisions(cfg *Config, pluginOwnedUIRefs map[string]struc
 			}
 		}
 		for _, other := range subjects[i+1:] {
-			if mountedUIPathsConflict(subject.path, other.path) {
+			if subject.path == other.path {
 				return fmt.Errorf("config validation: %s %q conflicts with %s %q", subject.label, subject.path, other.label, other.path)
+			}
+			if !subject.allowNestedPath || !other.allowNestedPath {
+				if mountedUIPathsConflict(subject.path, other.path) {
+					return fmt.Errorf("config validation: %s %q conflicts with %s %q", subject.label, subject.path, other.label, other.path)
+				}
 			}
 		}
 	}
 	return nil
+}
+
+func mountedUIPathsConflict(a, b string) bool {
+	if a == b {
+		return true
+	}
+	return strings.HasPrefix(a, b+"/") || strings.HasPrefix(b, a+"/")
 }
 
 func mountedUIPathsMatch(uiPath, mountPath string) bool {
@@ -774,13 +788,6 @@ func mountedUIPathsMatch(uiPath, mountPath string) bool {
 		return false
 	}
 	return uiPath == normalizedMountPath
-}
-
-func mountedUIPathsConflict(a, b string) bool {
-	if a == b {
-		return true
-	}
-	return strings.HasPrefix(a, b+"/") || strings.HasPrefix(b, a+"/")
 }
 
 func pluginOwnedUIRefs(cfg *Config) map[string]struct{} {

--- a/gestaltd/internal/server/server_test.go
+++ b/gestaltd/internal/server/server_test.go
@@ -505,6 +505,74 @@ func TestMountedWebUIRoutes(t *testing.T) {
 	}
 }
 
+func TestMountedWebUIRoutes_PrefersNestedMount(t *testing.T) {
+	t.Parallel()
+
+	parentDir := t.TempDir()
+	if err := os.WriteFile(filepath.Join(parentDir, "index.html"), []byte("<html>parent-shell</html>"), 0o644); err != nil {
+		t.Fatalf("WriteFile parent index.html: %v", err)
+	}
+	childDir := t.TempDir()
+	if err := os.WriteFile(filepath.Join(childDir, "index.html"), []byte("<html>child-shell</html>"), 0o644); err != nil {
+		t.Fatalf("WriteFile child index.html: %v", err)
+	}
+
+	parentHandler, err := testutilWebUIHandler(parentDir)
+	if err != nil {
+		t.Fatalf("parent webui handler: %v", err)
+	}
+	childHandler, err := testutilWebUIHandler(childDir)
+	if err != nil {
+		t.Fatalf("child webui handler: %v", err)
+	}
+
+	ts := newTestServer(t, func(cfg *server.Config) {
+		cfg.MountedWebUIs = []server.MountedWebUI{
+			{
+				Path:    "/workplace-hub",
+				Handler: parentHandler,
+			},
+			{
+				Path:    "/workplace-hub/nyc-badges",
+				Handler: childHandler,
+			},
+		}
+	})
+	testutil.CloseOnCleanup(t, ts)
+
+	resp, err := http.Get(ts.URL + "/workplace-hub/nyc-badges/new-hire")
+	if err != nil {
+		t.Fatalf("GET nested mounted UI: %v", err)
+	}
+	body, err := io.ReadAll(resp.Body)
+	_ = resp.Body.Close()
+	if err != nil {
+		t.Fatalf("ReadAll nested mounted UI: %v", err)
+	}
+	if resp.StatusCode != http.StatusOK {
+		t.Fatalf("status = %d, want 200", resp.StatusCode)
+	}
+	if !strings.Contains(string(body), "child-shell") {
+		t.Fatalf("body = %q, want child shell", body)
+	}
+
+	resp, err = http.Get(ts.URL + "/workplace-hub/admin")
+	if err != nil {
+		t.Fatalf("GET parent mounted UI: %v", err)
+	}
+	body, err = io.ReadAll(resp.Body)
+	_ = resp.Body.Close()
+	if err != nil {
+		t.Fatalf("ReadAll parent mounted UI: %v", err)
+	}
+	if resp.StatusCode != http.StatusOK {
+		t.Fatalf("status = %d, want 200", resp.StatusCode)
+	}
+	if !strings.Contains(string(body), "parent-shell") {
+		t.Fatalf("body = %q, want parent shell", body)
+	}
+}
+
 func TestMountedWebUIRoutes_HumanAuthorization(t *testing.T) {
 	t.Parallel()
 

--- a/gestaltd/internal/testutil/testdata/provider-go/config.yaml
+++ b/gestaltd/internal/testutil/testdata/provider-go/config.yaml
@@ -8,7 +8,7 @@ providers:
     main:
       source:
         ref: github.com/valon-technologies/gestalt-providers/indexeddb/relationaldb
-        version: 0.0.1-alpha.2
+        version: 0.0.1-alpha.1
       config:
         dsn: sqlite://./example.db
 

--- a/gestaltd/internal/testutil/testdata/provider-rust/config.yaml
+++ b/gestaltd/internal/testutil/testdata/provider-rust/config.yaml
@@ -8,7 +8,7 @@ providers:
     main:
       source:
         ref: github.com/valon-technologies/gestalt-providers/indexeddb/relationaldb
-        version: 0.0.1-alpha.2
+        version: 0.0.1-alpha.1
       config:
         dsn: sqlite://./example.db
 

--- a/sdk/rust/Cargo.toml
+++ b/sdk/rust/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "gestalt"
-version = "0.0.1-alpha.2"
+version = "0.0.1-alpha.1"
 edition = "2024"
 rust-version = "1.85"
 license = "Apache-2.0"


### PR DESCRIPTION
## Summary
- pin the default managed indexeddb and web UI providers back to `0.0.1-alpha.1`
- reset remaining alpha.2 docs/tests/sdk references to alpha.1
- allow nested `providers.ui` mount paths so current valon-tools config can regenerate a lockfile

## Testing
- go test ./internal/config ./internal/operator ./cmd/gestaltd ./internal/server
- cargo test