### PR TITLE
Reject generic archives for executable providers in locked runtime

### DIFF
--- a/gestaltd/cmd/gestaltd/e2e_test.go
+++ b/gestaltd/cmd/gestaltd/e2e_test.go
@@ -1,6 +1,9 @@
 package main
 
 import (
+	"context"
+	"crypto/sha256"
+	"encoding/hex"
 	"encoding/json"
 	"fmt"
 	"io"
@@ -15,6 +18,9 @@ import (
 	"testing"
 	"time"
 
+	"github.com/valon-technologies/gestalt/server/internal/config"
+	"github.com/valon-technologies/gestalt/server/internal/operator"
+	"github.com/valon-technologies/gestalt/server/internal/pluginstore"
 	"github.com/valon-technologies/gestalt/server/internal/providerpkg"
 	"github.com/valon-technologies/gestalt/server/internal/testutil"
 	providermanifestv1 "github.com/valon-technologies/gestalt/server/sdk/providermanifest/v1"
@@ -415,8 +421,11 @@ func setupPrebuiltPluginDir(t *testing.T, baseDir string) string {
 	}
 
 	artifactRel := filepath.Base(binDest)
+	sum := sha256.Sum256(binData)
+	srcManifest.Source = "github.com/test/plugins/provider"
+	srcManifest.Version = "0.0.1-alpha.1"
 	srcManifest.Artifacts = []providermanifestv1.Artifact{
-		{OS: runtime.GOOS, Arch: runtime.GOARCH, Path: artifactRel},
+		{OS: runtime.GOOS, Arch: runtime.GOARCH, Path: artifactRel, SHA256: hex.EncodeToString(sum[:])},
 	}
 	srcManifest.Entrypoint = &providermanifestv1.Entrypoint{ArtifactPath: artifactRel}
 	writeManifestFile(t, providerDir, srcManifest)
@@ -504,6 +513,36 @@ providers:
     source:
       path: %s
 `, port, indexedDBManifest, uiBlock, pluginManifest)
+
+	cfgPath := filepath.Join(dir, "config.yaml")
+	if err := os.WriteFile(cfgPath, []byte(cfg), 0o644); err != nil {
+		t.Fatalf("write config: %v", err)
+	}
+	return cfgPath
+}
+
+func writeManagedSourceServeConfig(t *testing.T, dir string, port int) string {
+	t.Helper()
+
+	indexedDBDir := setupIndexedDBProviderDir(t, dir)
+	indexedDBManifest := componentProviderManifestPath(t, indexedDBDir)
+	cfg := fmt.Sprintf(`server:
+  public:
+    port: %d
+  encryptionKey: test-serve-e2e-key
+  providers:
+    indexeddb: inmem
+providers:
+  indexeddb:
+    inmem:
+      source:
+        path: %s
+plugins:
+  example:
+    source:
+      ref: github.com/test/plugins/provider
+      version: 0.0.1-alpha.1
+`, port, indexedDBManifest)
 
 	cfgPath := filepath.Join(dir, "config.yaml")
 	if err := os.WriteFile(cfgPath, []byte(cfg), 0o644); err != nil {
@@ -789,6 +828,77 @@ func TestE2EInitLocalProviders(t *testing.T) {
 	}
 	if _, ok := lock["version"]; ok {
 		t.Fatalf("expected schema-based lockfile, found legacy version field: %v", lock["version"])
+	}
+}
+
+func TestE2EServeLockedRejectsGenericArchiveForExecutablePlugin(t *testing.T) {
+	t.Parallel()
+
+	if testing.Short() {
+		t.Skip("skipping locked generic archive E2E test in short mode")
+	}
+
+	dir := t.TempDir()
+	cfgPath := writeManagedSourceServeConfig(t, dir, 0)
+	cfg, err := config.Load(cfgPath)
+	if err != nil {
+		t.Fatalf("Load(%s): %v", cfgPath, err)
+	}
+
+	fingerprint, err := operator.ProviderFingerprint("example", cfg.Plugins["example"], filepath.Dir(cfgPath))
+	if err != nil {
+		t.Fatalf("ProviderFingerprint(example): %v", err)
+	}
+
+	destDir := filepath.Join(dir, filepath.FromSlash(operator.PreparedProvidersDir), "example")
+	installed, err := pluginstore.InstallFromDir(setupPrebuiltPluginDir(t, dir), destDir)
+	if err != nil {
+		t.Fatalf("Install(prebuilt provider): %v", err)
+	}
+
+	manifestRel, err := filepath.Rel(dir, installed.ManifestPath)
+	if err != nil {
+		t.Fatalf("filepath.Rel(manifest): %v", err)
+	}
+	executableRel, err := filepath.Rel(dir, installed.ExecutablePath)
+	if err != nil {
+		t.Fatalf("filepath.Rel(executable): %v", err)
+	}
+
+	lockPath := filepath.Join(dir, "gestalt.lock.json")
+	lock := &operator.Lockfile{
+		Providers: map[string]operator.LockProviderEntry{
+			"example": {
+				Fingerprint: fingerprint,
+				Source:      cfg.Plugins["example"].SourceRef(),
+				Version:     cfg.Plugins["example"].SourceVersion(),
+				Archives: map[string]operator.LockArchive{
+					"generic": {
+						URL: "https://example.test/gestalt-plugin-provider_v0.0.1-alpha.1.tar.gz",
+					},
+				},
+				Manifest:   filepath.ToSlash(manifestRel),
+				Executable: filepath.ToSlash(executableRel),
+			},
+		},
+	}
+	if err := operator.WriteLockfile(lockPath, lock); err != nil {
+		t.Fatalf("WriteLockfile(%s): %v", lockPath, err)
+	}
+
+	ctx, cancel := context.WithTimeout(context.Background(), 3*time.Second)
+	defer cancel()
+
+	cmd := exec.CommandContext(ctx, gestaltdBin, "serve", "--locked", "--config", cfgPath)
+	out, err := cmd.CombinedOutput()
+	if ctx.Err() == context.DeadlineExceeded {
+		t.Fatalf("gestaltd serve --locked unexpectedly stayed up after forcing a generic archive\noutput: %s", out)
+	}
+	if err == nil {
+		t.Fatalf("expected gestaltd serve --locked to fail, output: %s", out)
+	}
+	if !strings.Contains(string(out), "generic release archives are not allowed") {
+		t.Fatalf("expected generic-archive policy error, got: %s", out)
 	}
 }
 

--- a/gestaltd/internal/operator/archive_policy.go
+++ b/gestaltd/internal/operator/archive_policy.go
@@ -1,0 +1,60 @@
+package operator
+
+import (
+	"fmt"
+
+	providermanifestv1 "github.com/valon-technologies/gestalt/server/sdk/providermanifest/v1"
+)
+
+func allowsGenericArchive(kind string, manifest *providermanifestv1.Manifest) bool {
+	switch kind {
+	case providermanifestv1.KindWebUI:
+		return true
+	case providermanifestv1.KindPlugin:
+		return manifest != nil && manifest.IsDeclarativeOnlyProvider()
+	default:
+		return false
+	}
+}
+
+func validateResolvedArchivePolicy(subject, kind string, manifest *providermanifestv1.Manifest, platform, currentURL string, available map[string]LockArchive) error {
+	if allowsGenericArchive(kind, manifest) || currentURL == "" {
+		return nil
+	}
+	exact, exactOK := available[platform]
+	generic, genericOK := available[platformKeyGeneric]
+	if exactOK && genericOK && exact.URL != "" && exact.URL == generic.URL && currentURL == exact.URL {
+		return unsafeGenericArchiveError(subject, platform)
+	}
+	if archive, ok := available[platform]; ok && archive.URL == currentURL {
+		return nil
+	}
+	if archive, ok := available[platformKeyGeneric]; ok && archive.URL == currentURL {
+		return unsafeGenericArchiveError(subject, platform)
+	}
+	return nil
+}
+
+func validateLockedArchivePolicy(subject, kind string, manifest *providermanifestv1.Manifest, entry LockEntry, platform, resolvedKey string) error {
+	if allowsGenericArchive(kind, manifest) {
+		return nil
+	}
+	if resolvedKey == platformKeyGeneric {
+		return unsafeGenericArchiveError(subject, platform)
+	}
+	exact, exactOK := entry.Archives[platform]
+	generic, genericOK := entry.Archives[platformKeyGeneric]
+	if exactOK && genericOK && exact.URL != "" && exact.URL == generic.URL {
+		return unsafeGenericArchiveError(subject, platform)
+	}
+	return nil
+}
+
+func unsafeGenericArchiveError(subject, platform string) error {
+	return fmt.Errorf(
+		"generic release archives are not allowed for %s on %s; publish an explicit %s archive or keep the package platform-neutral (webui or declarative/spec-only plugin package)",
+		subject,
+		platform,
+		platform,
+	)
+}

--- a/gestaltd/internal/operator/lifecycle.go
+++ b/gestaltd/internal/operator/lifecycle.go
@@ -15,6 +15,7 @@ import (
 	"slices"
 	"strconv"
 	"strings"
+	"time"
 
 	"github.com/valon-technologies/gestalt/server/internal/config"
 	"github.com/valon-technologies/gestalt/server/internal/pluginsource"
@@ -106,8 +107,9 @@ func (l *Lifecycle) InitAtPathWithPlatforms(configPath, artifactsDir string, pla
 		return lock, nil
 	}
 
+	paths := initPathsForConfigWithArtifactsDir(configPath, resolveArtifactsDir(configPath, cfg, artifactsDir))
 	tokenForSource := buildSourceTokenMap(cfg)
-	if err := downloadPlatformArchives(context.Background(), lock, platforms, tokenForSource); err != nil {
+	if err := downloadPlatformArchives(context.Background(), lock, paths, platforms, tokenForSource); err != nil {
 		return nil, err
 	}
 
@@ -707,7 +709,7 @@ func lockMatchesConfig(cfg *config.Config, paths initPaths, lock *Lockfile) bool
 			continue
 		}
 		lockEntry, found := lock.Providers[name]
-		if !lockEntryMatches(paths, name, entry, lockEntry, found, providerDestDir(paths, name)) {
+		if !lockEntryMatches(paths, providermanifestv1.KindPlugin, name, entry, lockEntry, found, providerDestDir(paths, name)) {
 			return false
 		}
 	}
@@ -718,7 +720,7 @@ func lockMatchesConfig(cfg *config.Config, paths initPaths, lock *Lockfile) bool
 				continue
 			}
 			lockEntry, found := lockEntries[name]
-			if !lockEntryMatches(paths, name, entry, lockEntry, found, componentDestDir(paths, collection.kind, name)) {
+			if !lockEntryMatches(paths, providerManifestKind(collection.kind), name, entry, lockEntry, found, componentDestDir(paths, collection.kind, name)) {
 				return false
 			}
 		}
@@ -728,7 +730,7 @@ func lockMatchesConfig(cfg *config.Config, paths initPaths, lock *Lockfile) bool
 			continue
 		}
 		lockEntry, found := lock.IndexedDBs[name]
-		if !lockEntryMatches(paths, name, entry, lockEntry, found, indexeddbDestDir(paths, name)) {
+		if !lockEntryMatches(paths, providermanifestv1.KindIndexedDB, name, entry, lockEntry, found, indexeddbDestDir(paths, name)) {
 			return false
 		}
 	}
@@ -737,7 +739,7 @@ func lockMatchesConfig(cfg *config.Config, paths initPaths, lock *Lockfile) bool
 			continue
 		}
 		lockEntry, found := lock.S3[name]
-		if !lockEntryMatches(paths, name, entry, lockEntry, found, s3DestDir(paths, name)) {
+		if !lockEntryMatches(paths, providermanifestv1.KindS3, name, entry, lockEntry, found, s3DestDir(paths, name)) {
 			return false
 		}
 	}
@@ -793,7 +795,72 @@ func NamedUIProviderFingerprint(name string, entry *config.ProviderEntry) (strin
 	return ProviderFingerprint("ui:"+name, entry, "")
 }
 
-func lockEntryMatches(paths initPaths, name string, providerEntry *config.ProviderEntry, entry LockEntry, found bool, destDir string) bool {
+func archivePolicyKind(kind string) string {
+	switch kind {
+	case providerLockKindTelemetry, providerLockKindAudit:
+		return providermanifestv1.KindPlugin
+	default:
+		return kind
+	}
+}
+
+func archivePolicySubject(kind, name string) string {
+	switch archivePolicyKind(kind) {
+	case providermanifestv1.KindPlugin:
+		return fmt.Sprintf("provider %q", name)
+	case providermanifestv1.KindWebUI:
+		return fmt.Sprintf("ui provider %q", name)
+	default:
+		return fmt.Sprintf("%s %q", kind, name)
+	}
+}
+
+func lockEntryDestDir(paths initPaths, kind, name string) string {
+	switch kind {
+	case providermanifestv1.KindPlugin:
+		return providerDestDir(paths, name)
+	case providermanifestv1.KindAuth:
+		return authDestDir(paths, name)
+	case providermanifestv1.KindSecrets:
+		return secretsDestDir(paths, name)
+	case providermanifestv1.KindCache:
+		return cacheDestDir(paths, name)
+	case providermanifestv1.KindIndexedDB:
+		return indexeddbDestDir(paths, name)
+	case providermanifestv1.KindS3:
+		return s3DestDir(paths, name)
+	case providerLockKindTelemetry:
+		return telemetryDestDir(paths, name)
+	case providerLockKindAudit:
+		return auditDestDir(paths, name)
+	case providermanifestv1.KindWebUI:
+		return uiDestDir(paths, name)
+	default:
+		return ""
+	}
+}
+
+func readLockEntryManifest(paths initPaths, entry LockEntry, destDir string) (*providermanifestv1.Manifest, error) {
+	if strings.TrimSpace(entry.Manifest) != "" {
+		manifestPath := resolveLockPath(paths.artifactsDir, entry.Manifest)
+		if _, manifest, err := providerpkg.ReadManifestFile(manifestPath); err == nil {
+			return manifest, nil
+		}
+	}
+	if destDir == "" {
+		return nil, fmt.Errorf("manifest path is unavailable")
+	}
+	install, err := inspectPreparedInstall(destDir)
+	if err != nil {
+		return nil, err
+	}
+	if install.manifest == nil {
+		return nil, fmt.Errorf("prepared install at %s is missing a manifest", destDir)
+	}
+	return install.manifest, nil
+}
+
+func lockEntryMatches(paths initPaths, kind, name string, providerEntry *config.ProviderEntry, entry LockEntry, found bool, destDir string) bool {
 	if !found {
 		return false
 	}
@@ -806,7 +873,19 @@ func lockEntryMatches(paths initPaths, name string, providerEntry *config.Provid
 	}
 	if len(entry.Archives) > 0 {
 		platform := providerpkg.CurrentPlatformString()
-		if _, _, ok := resolveArchiveForPlatform(entry, platform); !ok {
+		_, resolvedKey, ok := resolveArchiveForPlatform(entry, platform)
+		if !ok {
+			return false
+		}
+		policyKind := archivePolicyKind(kind)
+		var manifest *providermanifestv1.Manifest
+		if policyKind == providermanifestv1.KindPlugin {
+			manifest, err = readLockEntryManifest(paths, entry, destDir)
+			if err != nil {
+				return false
+			}
+		}
+		if err := validateLockedArchivePolicy(archivePolicySubject(kind, name), policyKind, manifest, entry, platform, resolvedKey); err != nil {
 			return false
 		}
 	}
@@ -874,27 +953,37 @@ func resolveArchiveForPlatform(entry LockEntry, platform string) (LockArchive, s
 // buildArchivesMap constructs the Archives map for a lock entry. It enumerates
 // all platform archives from the resolver (if supported) and records the
 // verified SHA256 for the current platform.
-func (l *Lifecycle) buildArchivesMap(ctx context.Context, src pluginsource.Source, version, currentURL, currentSHA256 string) map[string]LockArchive {
+func (l *Lifecycle) buildArchivesMap(ctx context.Context, src pluginsource.Source, version, currentURL, currentSHA256, kind, subject string, manifest *providermanifestv1.Manifest) (map[string]LockArchive, error) {
 	currentPlatform := providerpkg.CurrentPlatformString()
 	archives := map[string]LockArchive{
 		currentPlatform: {URL: currentURL, SHA256: currentSHA256},
 	}
 	enumerator, ok := l.sourceResolver.(pluginsource.PlatformEnumerator)
 	if !ok {
-		return archives
+		return archives, nil
 	}
 	platformArchives, err := enumerator.ListPlatformArchives(ctx, src, version)
 	if err != nil {
+		if !allowsGenericArchive(kind, manifest) {
+			return nil, fmt.Errorf("enumerate platform archives for %s: %w", subject, err)
+		}
 		slog.Warn("failed to enumerate platform archives; lockfile will only contain current platform", "error", err)
-		return archives
+		return archives, nil
 	}
+	available := make(map[string]LockArchive, len(platformArchives))
 	for _, pa := range platformArchives {
+		if _, exists := available[pa.Platform]; !exists {
+			available[pa.Platform] = LockArchive{URL: pa.URL}
+		}
 		if _, exists := archives[pa.Platform]; exists {
 			continue
 		}
 		archives[pa.Platform] = LockArchive{URL: pa.URL}
 	}
-	return archives
+	if err := validateResolvedArchivePolicy(subject, kind, manifest, currentPlatform, currentURL, available); err != nil {
+		return nil, err
+	}
+	return archives, nil
 }
 
 func (l *Lifecycle) writeProviderArtifacts(ctx context.Context, cfg *config.Config, paths initPaths) (map[string]LockProviderEntry, error) {
@@ -975,7 +1064,10 @@ func (l *Lifecycle) lockComponentEntryForSource(ctx context.Context, paths initP
 	if err != nil {
 		return LockEntry{}, fmt.Errorf("compute executable path for %s %q: %w", kind, name, err)
 	}
-	archives := l.buildArchivesMap(ctx, src, plugin.SourceVersion(), resolved.ResolvedURL, resolved.ArchiveSHA256)
+	archives, err := l.buildArchivesMap(ctx, src, plugin.SourceVersion(), resolved.ResolvedURL, resolved.ArchiveSHA256, kind, fmt.Sprintf("%s %q", kind, name), installed.Manifest)
+	if err != nil {
+		return LockEntry{}, err
+	}
 	return LockEntry{
 		Fingerprint: fingerprint,
 		Source:      plugin.SourceRef(),
@@ -1034,7 +1126,10 @@ func (l *Lifecycle) lockProviderEntryForSource(ctx context.Context, paths initPa
 			return LockProviderEntry{}, fmt.Errorf("compute executable path for provider %q: %w", name, err)
 		}
 	}
-	archives := l.buildArchivesMap(ctx, src, plugin.SourceVersion(), resolved.ResolvedURL, resolved.ArchiveSHA256)
+	archives, err := l.buildArchivesMap(ctx, src, plugin.SourceVersion(), resolved.ResolvedURL, resolved.ArchiveSHA256, providermanifestv1.KindPlugin, fmt.Sprintf("provider %q", name), installed.Manifest)
+	if err != nil {
+		return LockProviderEntry{}, err
+	}
 	return LockProviderEntry{
 		Fingerprint: fingerprint,
 		Source:      plugin.SourceRef(),
@@ -1095,7 +1190,10 @@ func (l *Lifecycle) writeNamedUIProviderArtifact(ctx context.Context, paths init
 	if err != nil {
 		return LockUIEntry{}, fmt.Errorf("compute asset root path for %s: %w", subject, err)
 	}
-	archives := l.buildArchivesMap(ctx, src, plugin.SourceVersion(), resolved.ResolvedURL, resolved.ArchiveSHA256)
+	archives, err := l.buildArchivesMap(ctx, src, plugin.SourceVersion(), resolved.ResolvedURL, resolved.ArchiveSHA256, providermanifestv1.KindWebUI, subject, installed.Manifest)
+	if err != nil {
+		return LockUIEntry{}, err
+	}
 	return LockUIEntry{
 		Fingerprint: fingerprint,
 		Source:      plugin.SourceRef(),
@@ -1201,6 +1299,58 @@ func (l *Lifecycle) applyLockedProviders(configPath, artifactsDir string, cfg *c
 	}
 
 	return nil
+}
+
+func installLockedPackageAtomic(packagePath, destDir string) (*pluginstore.InstalledPlugin, func() error, func() error, error) {
+	if destDir == "" {
+		return nil, nil, nil, fmt.Errorf("destination directory is required")
+	}
+	parentDir := filepath.Dir(destDir)
+	if err := os.MkdirAll(parentDir, 0o755); err != nil {
+		return nil, nil, nil, fmt.Errorf("create destination parent directory: %w", err)
+	}
+	tempDir, err := os.MkdirTemp(parentDir, filepath.Base(destDir)+".tmp-*")
+	if err != nil {
+		return nil, nil, nil, fmt.Errorf("create temp install directory: %w", err)
+	}
+	cleanupDir := tempDir
+	installed, err := pluginstore.Install(packagePath, tempDir)
+	if err != nil {
+		_ = os.RemoveAll(cleanupDir)
+		return nil, nil, nil, err
+	}
+	commit := func() error {
+		backupDir := ""
+		if _, err := os.Stat(destDir); err == nil {
+			backupDir = destDir + ".backup-" + strconv.FormatInt(time.Now().UnixNano(), 10)
+			if err := os.Rename(destDir, backupDir); err != nil {
+				return fmt.Errorf("stage existing provider cache at %s: %w", destDir, err)
+			}
+		} else if !os.IsNotExist(err) {
+			return fmt.Errorf("inspect existing provider cache at %s: %w", destDir, err)
+		}
+		if err := os.Rename(tempDir, destDir); err != nil {
+			if backupDir != "" {
+				if restoreErr := os.Rename(backupDir, destDir); restoreErr != nil {
+					return fmt.Errorf("activate prepared install at %s: %w (rollback failed: %v)", destDir, err, restoreErr)
+				}
+			}
+			return fmt.Errorf("activate prepared install at %s: %w", destDir, err)
+		}
+		if backupDir != "" {
+			if err := os.RemoveAll(backupDir); err != nil {
+				return fmt.Errorf("remove staged provider cache backup at %s: %w", backupDir, err)
+			}
+		}
+		cleanupDir = ""
+		return nil
+	}
+	return installed, func() error {
+		if cleanupDir == "" {
+			return nil
+		}
+		return os.RemoveAll(cleanupDir)
+	}, commit, nil
 }
 
 func (l *Lifecycle) resolveConfiguredPlugins(paths initPaths, lock *Lockfile, cfg *config.Config, locked bool) error {
@@ -1644,6 +1794,14 @@ func (l *Lifecycle) applyLockedProviderEntry(paths initPaths, lock *Lockfile, na
 	destDir := providerDestDir(paths, name)
 	install, err := inspectPreparedInstall(destDir)
 	needMaterialize := err != nil || !preparedManifestMatchesLock(entry, install.manifest)
+	if err == nil && !needMaterialize {
+		platform := providerpkg.CurrentPlatformString()
+		if _, resolvedKey, ok := resolveArchiveForPlatform(entry, platform); ok {
+			if policyErr := validateLockedArchivePolicy(fmt.Sprintf("provider %q", name), providermanifestv1.KindPlugin, install.manifest, entry, platform, resolvedKey); policyErr != nil {
+				return policyErr
+			}
+		}
+	}
 	if !needMaterialize && install.executablePath != "" {
 		if _, err := os.Stat(install.executablePath); err != nil {
 			needMaterialize = true
@@ -1689,6 +1847,14 @@ func (l *Lifecycle) applyLockedComponentEntry(paths initPaths, entry *LockEntry,
 
 	install, err := inspectPreparedInstall(destDir)
 	needMaterialize := err != nil || !preparedManifestMatchesLock(*entry, install.manifest)
+	if err == nil && !needMaterialize {
+		platform := providerpkg.CurrentPlatformString()
+		if _, resolvedKey, ok := resolveArchiveForPlatform(*entry, platform); ok {
+			if policyErr := validateLockedArchivePolicy(fmt.Sprintf("%s %q", kind, name), kind, install.manifest, *entry, platform, resolvedKey); policyErr != nil {
+				return policyErr
+			}
+		}
+	}
 	if !needMaterialize && install.executablePath == "" {
 		needMaterialize = true
 	}
@@ -1768,7 +1934,7 @@ func bindResolvedUIManifest(plugin *config.ProviderEntry, manifestPath string, m
 
 func (l *Lifecycle) materializeLockedProvider(ctx context.Context, paths initPaths, name string, plugin *config.ProviderEntry, entry LockProviderEntry, locked bool) error {
 	platform := providerpkg.CurrentPlatformString()
-	archive, _, ok := resolveArchiveForPlatform(entry, platform)
+	archive, resolvedKey, ok := resolveArchiveForPlatform(entry, platform)
 	if !ok || archive.URL == "" {
 		return fmt.Errorf("no archive for platform %s for provider %q; run `gestaltd init --config %s`", platform, name, paths.configPath)
 	}
@@ -1802,25 +1968,29 @@ func (l *Lifecycle) materializeLockedProvider(ctx context.Context, paths initPat
 	}
 
 	destDir := providerDestDir(paths, name)
-	if err := os.RemoveAll(destDir); err != nil {
-		return fmt.Errorf("remove stale provider cache for provider %q: %w", name, err)
-	}
-	installed, err := pluginstore.Install(download.LocalPath, destDir)
+	installed, cleanupInstall, commitInstall, err := installLockedPackageAtomic(download.LocalPath, destDir)
 	if err != nil {
 		return fmt.Errorf("install locked source provider for provider %q: %w", name, err)
 	}
+	defer func() { _ = cleanupInstall() }()
 	if installed.Manifest.Source != entry.Source {
 		return fmt.Errorf("locked source provider manifest source mismatch for provider %q: got %q, want %q", name, installed.Manifest.Source, entry.Source)
 	}
 	if installed.Manifest.Version != entry.Version {
 		return fmt.Errorf("locked source provider manifest version mismatch for provider %q: got %q, want %q", name, installed.Manifest.Version, entry.Version)
 	}
+	if err := validateLockedArchivePolicy(fmt.Sprintf("provider %q", name), providermanifestv1.KindPlugin, installed.Manifest, entry, platform, resolvedKey); err != nil {
+		return err
+	}
+	if err := commitInstall(); err != nil {
+		return fmt.Errorf("activate locked source provider for provider %q: %w", name, err)
+	}
 	return nil
 }
 
 func (l *Lifecycle) materializeLockedComponent(ctx context.Context, paths initPaths, kind, name string, plugin *config.ProviderEntry, entry LockEntry, destDir string, locked bool) error {
 	platform := providerpkg.CurrentPlatformString()
-	archive, _, ok := resolveArchiveForPlatform(entry, platform)
+	archive, resolvedKey, ok := resolveArchiveForPlatform(entry, platform)
 	if !ok || archive.URL == "" {
 		return fmt.Errorf("no archive for platform %s for %s %q; run `gestaltd init --config %s`", platform, kind, name, paths.configPath)
 	}
@@ -1856,13 +2026,11 @@ func (l *Lifecycle) materializeLockedComponent(ctx context.Context, paths initPa
 	if destDir == "" {
 		return fmt.Errorf("unsupported component %q", name)
 	}
-	if err := os.RemoveAll(destDir); err != nil {
-		return fmt.Errorf("remove stale provider cache for %s %q: %w", kind, name, err)
-	}
-	installed, err := pluginstore.Install(download.LocalPath, destDir)
+	installed, cleanupInstall, commitInstall, err := installLockedPackageAtomic(download.LocalPath, destDir)
 	if err != nil {
 		return fmt.Errorf("install locked source provider for %s %q: %w", kind, name, err)
 	}
+	defer func() { _ = cleanupInstall() }()
 	if err := validateInstalledManifestKind(kind, name, installed.Manifest); err != nil {
 		return err
 	}
@@ -1871,6 +2039,12 @@ func (l *Lifecycle) materializeLockedComponent(ctx context.Context, paths initPa
 	}
 	if installed.Manifest.Version != entry.Version {
 		return fmt.Errorf("locked source provider manifest version mismatch for %s %q: got %q, want %q", kind, name, installed.Manifest.Version, entry.Version)
+	}
+	if err := validateLockedArchivePolicy(fmt.Sprintf("%s %q", kind, name), kind, installed.Manifest, entry, platform, resolvedKey); err != nil {
+		return err
+	}
+	if err := commitInstall(); err != nil {
+		return fmt.Errorf("activate locked source provider for %s %q: %w", kind, name, err)
 	}
 	return nil
 }
@@ -1923,21 +2097,21 @@ func (l *Lifecycle) materializeLockedUIProvider(ctx context.Context, paths initP
 	return nil
 }
 
-func downloadPlatformArchives(ctx context.Context, lock *Lockfile, platforms []struct{ GOOS, GOARCH, LibC string }, tokenForSource map[string]string) error {
+func downloadPlatformArchives(ctx context.Context, lock *Lockfile, paths initPaths, platforms []struct{ GOOS, GOARCH, LibC string }, tokenForSource map[string]string) error {
 	for _, plat := range platforms {
 		platformKey := providerpkg.PlatformString(plat.GOOS, plat.GOARCH)
-		if err := hashPlatformInEntries(ctx, lock, platformKey, tokenForSource); err != nil {
+		if err := hashPlatformInEntries(ctx, lock, paths, platformKey, tokenForSource); err != nil {
 			return err
 		}
 	}
 	return nil
 }
 
-func hashPlatformInEntries(ctx context.Context, lock *Lockfile, platformKey string, tokenForSource map[string]string) error {
+func hashPlatformInEntries(ctx context.Context, lock *Lockfile, paths initPaths, platformKey string, tokenForSource map[string]string) error {
 	for _, kind := range providerLockKinds() {
 		lockEntries := lockEntriesForProviderKind(lock, kind)
 		for name, entry := range lockEntries {
-			if err := hashArchiveEntry(ctx, &entry, platformKey, tokenForSource); err != nil {
+			if err := hashArchiveEntry(ctx, kind, name, &entry, paths, platformKey, tokenForSource); err != nil {
 				return err
 			}
 			lockEntries[name] = entry
@@ -1946,13 +2120,25 @@ func hashPlatformInEntries(ctx context.Context, lock *Lockfile, platformKey stri
 	return nil
 }
 
-func hashArchiveEntry(ctx context.Context, entry *LockEntry, platformKey string, tokenForSource map[string]string) error {
+func hashArchiveEntry(ctx context.Context, kind, name string, entry *LockEntry, paths initPaths, platformKey string, tokenForSource map[string]string) error {
 	if entry.Archives == nil {
 		return nil
 	}
 	archive, resolvedKey, ok := resolveArchiveForPlatform(*entry, platformKey)
 	if !ok || archive.URL == "" || archive.SHA256 != "" {
 		return nil
+	}
+	policyKind := archivePolicyKind(kind)
+	var manifest *providermanifestv1.Manifest
+	if policyKind == providermanifestv1.KindPlugin {
+		var manifestErr error
+		manifest, manifestErr = readLockEntryManifest(paths, *entry, lockEntryDestDir(paths, kind, name))
+		if manifestErr != nil {
+			return fmt.Errorf("load manifest for %s: %w", archivePolicySubject(kind, name), manifestErr)
+		}
+	}
+	if err := validateLockedArchivePolicy(archivePolicySubject(kind, name), policyKind, manifest, *entry, platformKey, resolvedKey); err != nil {
+		return err
 	}
 	token := tokenForSource[entry.Source]
 	src, parseErr := pluginsource.Parse(entry.Source)

--- a/gestaltd/internal/operator/lifecycle_source_test.go
+++ b/gestaltd/internal/operator/lifecycle_source_test.go
@@ -1548,3 +1548,165 @@ func TestSourcePluginInitWithPlatformsPersistsExtraPlatformHash(t *testing.T) {
 		t.Fatalf("readBack extra-platform SHA256 = %q, want %q", got, hex.EncodeToString(extraArchiveSHA[:]))
 	}
 }
+
+func TestSourcePluginInitWithPlatformsRejectsGenericFallbackForExtraPlatform(t *testing.T) {
+	t.Setenv("GITHUB_TOKEN", "wrong-env-token")
+
+	dir := t.TempDir()
+
+	src := pluginsource.Source{
+		Host:  pluginsource.HostGitHub,
+		Owner: testOwner,
+		Repo:  testRepo,
+		Path:  "plugins/" + testPlugin,
+	}
+	expectedTag := src.ReleaseTag(testVersion)
+	releasePath := "/repos/" + testOwner + "/" + testRepo + "/releases/tags/" + expectedTag
+
+	currentAssetName := fmt.Sprintf("gestalt-plugin-%s_v%s_%s_%s.tar.gz", src.PluginName(), testVersion, runtime.GOOS, runtime.GOARCH)
+	genericAssetName := src.AssetName(testVersion)
+	extraPlatform := struct {
+		goos   string
+		goarch string
+	}{
+		goos:   "linux",
+		goarch: "amd64",
+	}
+	for _, candidate := range []struct {
+		goos   string
+		goarch string
+	}{
+		{goos: "linux", goarch: "amd64"},
+		{goos: "linux", goarch: "arm64"},
+		{goos: "darwin", goarch: "amd64"},
+		{goos: "darwin", goarch: "arm64"},
+	} {
+		if candidate.goos != runtime.GOOS || candidate.goarch != runtime.GOARCH {
+			extraPlatform = candidate
+			break
+		}
+	}
+
+	currentArchivePath := buildV2Archive(t, dir, testSource, testVersion, testBinary)
+	currentArchiveData, err := os.ReadFile(currentArchivePath)
+	if err != nil {
+		t.Fatalf("read current archive: %v", err)
+	}
+	genericArchiveData := []byte("generic-platform-archive")
+
+	var releaseCount atomic.Int64
+	var currentAssetCount atomic.Int64
+	var genericAssetCount atomic.Int64
+	handlerErrs := make(chan error, 4)
+	nextHandlerErr := func() error {
+		t.Helper()
+		select {
+		case err := <-handlerErrs:
+			return err
+		default:
+			return nil
+		}
+	}
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch r.URL.Path {
+		case releasePath:
+			releaseCount.Add(1)
+			if got := r.Header.Get("Authorization"); got != "token test-token" {
+				handlerErrs <- fmt.Errorf("release authorization = %q, want %q", got, "token test-token")
+				http.Error(w, "bad release authorization", http.StatusBadRequest)
+				return
+			}
+			w.Header().Set("Content-Type", "application/json")
+			resp := map[string]any{
+				"assets": []map[string]any{
+					{
+						"name":                 currentAssetName,
+						"url":                  "http://" + r.Host + "/asset-current",
+						"browser_download_url": "https://github.com/" + testOwner + "/" + testRepo + "/releases/download/" + expectedTag + "/" + currentAssetName,
+					},
+					{
+						"name":                 genericAssetName,
+						"url":                  "http://" + r.Host + "/asset-generic",
+						"browser_download_url": "https://github.com/" + testOwner + "/" + testRepo + "/releases/download/" + expectedTag + "/" + genericAssetName,
+					},
+				},
+			}
+			_ = json.NewEncoder(w).Encode(resp)
+		case "/asset-current":
+			currentAssetCount.Add(1)
+			if got := r.Header.Get("Authorization"); got != "token test-token" {
+				handlerErrs <- fmt.Errorf("current asset authorization = %q, want %q", got, "token test-token")
+				http.Error(w, "bad asset authorization", http.StatusBadRequest)
+				return
+			}
+			if got := r.Header.Get("Accept"); got != "application/octet-stream" {
+				handlerErrs <- fmt.Errorf("current asset accept = %q, want %q", got, "application/octet-stream")
+				http.Error(w, "bad asset accept", http.StatusBadRequest)
+				return
+			}
+			w.Header().Set("Content-Type", "application/octet-stream")
+			_, _ = w.Write(currentArchiveData)
+		case "/asset-generic":
+			genericAssetCount.Add(1)
+			if got := r.Header.Get("Authorization"); got != "token test-token" {
+				handlerErrs <- fmt.Errorf("generic asset authorization = %q, want %q", got, "token test-token")
+				http.Error(w, "bad asset authorization", http.StatusBadRequest)
+				return
+			}
+			if got := r.Header.Get("Accept"); got != "application/octet-stream" {
+				handlerErrs <- fmt.Errorf("generic asset accept = %q, want %q", got, "application/octet-stream")
+				http.Error(w, "bad asset accept", http.StatusBadRequest)
+				return
+			}
+			w.Header().Set("Content-Type", "application/octet-stream")
+			_, _ = w.Write(genericArchiveData)
+		default:
+			http.NotFound(w, r)
+		}
+	}))
+	defer srv.Close()
+
+	artifactsDir := filepath.Join(dir, "prepared-artifacts")
+	configYAML := requiredComponentConfigYAML(t, dir, filepath.Join(dir, "data.db")) + strings.Join([]string{
+		"plugins:",
+		"  alpha:",
+		"    source:",
+		"      ref: " + testSource,
+		"      version: " + testVersion,
+		"      auth:",
+		"        token: test-token",
+		"server:",
+		"  providers:",
+		"    indexeddb: sqlite",
+		"  artifactsDir: " + artifactsDir,
+		"  encryptionKey: aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
+	}, "\n") + "\n"
+	configPath := filepath.Join(dir, "gestalt.yaml")
+	if err := os.WriteFile(configPath, []byte(configYAML), 0o644); err != nil {
+		t.Fatalf("write config: %v", err)
+	}
+
+	resolver := &ghresolver.GitHubResolver{BaseURL: srv.URL}
+	lc := NewLifecycle(resolver)
+	_, err = lc.InitAtPathWithPlatforms(configPath, "", []struct{ GOOS, GOARCH, LibC string }{
+		{GOOS: extraPlatform.goos, GOARCH: extraPlatform.goarch},
+	})
+	if handlerErr := nextHandlerErr(); handlerErr != nil {
+		t.Fatal(handlerErr)
+	}
+	if err == nil {
+		t.Fatal("InitAtPathWithPlatforms unexpectedly succeeded with generic-only extra platform fallback")
+	}
+	if !strings.Contains(err.Error(), "generic release archives are not allowed") {
+		t.Fatalf("InitAtPathWithPlatforms error = %v, want generic archive policy rejection", err)
+	}
+	if got := currentAssetCount.Load(); got != 1 {
+		t.Fatalf("current asset request count = %d, want 1", got)
+	}
+	if got := genericAssetCount.Load(); got != 0 {
+		t.Fatalf("generic asset request count = %d, want 0", got)
+	}
+	if got := releaseCount.Load(); got < 2 {
+		t.Fatalf("release request count = %d, want at least 2", got)
+	}
+}

--- a/gestaltd/internal/operator/lifecycle_test.go
+++ b/gestaltd/internal/operator/lifecycle_test.go
@@ -934,6 +934,226 @@ func TestLoadForExecutionAtPath_ReinitializesManagedPluginOwnedUIWhenPluginLockI
 	}
 }
 
+func TestLoadForExecutionAtPath_ReinitializesManagedPluginWhenGenericArchiveLockIsStale(t *testing.T) {
+	t.Parallel()
+
+	dir := t.TempDir()
+	const pluginRef = "github.com/testowner/plugins/roadmap"
+	const version = "0.0.1-alpha.1"
+
+	pluginPkg := mustBuildManagedProviderPackage(t, dir, &providermanifestv1.Manifest{
+		Kind:        providermanifestv1.KindPlugin,
+		Source:      pluginRef,
+		Version:     version,
+		DisplayName: "Roadmap Review",
+		Entrypoint: &providermanifestv1.Entrypoint{
+			ArtifactPath: filepath.ToSlash(filepath.Join("artifacts", runtime.GOOS, runtime.GOARCH, "plugin")),
+		},
+		Spec: &providermanifestv1.Spec{
+			Auth: &providermanifestv1.ProviderAuth{Type: providermanifestv1.AuthTypeNone},
+		},
+	}, map[string]string{
+		filepath.ToSlash(filepath.Join("artifacts", runtime.GOOS, runtime.GOARCH, "plugin")): "plugin-binary-" + version,
+	}, true)
+
+	cfgPath := filepath.Join(dir, "config.yaml")
+	cfg := requiredComponentConfigYAML(t, dir, filepath.Join(dir, "gestalt.db")) + `plugins:
+  roadmap:
+    source:
+      ref: ` + pluginRef + `
+      version: ` + version + `
+server:
+` + requiredServerDatastoreYAML() + `  encryptionKey: aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa
+`
+	if err := os.WriteFile(cfgPath, []byte(cfg), 0o644); err != nil {
+		t.Fatalf("WriteFile config: %v", err)
+	}
+
+	lc := NewLifecycle(versionedSourceResolver{
+		paths: map[string]map[string]string{
+			pluginRef: {
+				version: pluginPkg,
+			},
+		},
+	})
+	if _, err := lc.InitAtPath(cfgPath); err != nil {
+		t.Fatalf("InitAtPath: %v", err)
+	}
+
+	loadedCfg, err := config.Load(cfgPath)
+	if err != nil {
+		t.Fatalf("Load: %v", err)
+	}
+	paths := initPathsForConfig(cfgPath)
+	staleLock := &Lockfile{
+		Version: LockVersion,
+		Providers: map[string]LockProviderEntry{
+			"roadmap": {
+				Fingerprint: mustFingerprint(t, "roadmap", loadedCfg.Plugins["roadmap"], paths.configDir),
+				Source:      pluginRef,
+				Version:     version,
+				Archives: map[string]LockArchive{
+					"generic": {URL: "https://example.com/roadmap.tar.gz", SHA256: "abc123"},
+				},
+			},
+		},
+	}
+	if err := WriteLockfile(filepath.Join(dir, InitLockfileName), staleLock); err != nil {
+		t.Fatalf("WriteLockfile: %v", err)
+	}
+
+	loaded, _, err := lc.LoadForExecutionAtPath(cfgPath, false)
+	if err != nil {
+		t.Fatalf("LoadForExecutionAtPath: %v", err)
+	}
+	if loaded.Plugins["roadmap"] == nil || loaded.Plugins["roadmap"].ResolvedManifest == nil {
+		t.Fatalf("ResolvedManifest = %+v", loaded.Plugins["roadmap"])
+	}
+	if loaded.Plugins["roadmap"].Command == "" {
+		t.Fatal("loaded plugin command is empty")
+	}
+
+	rewrittenLock, err := ReadLockfile(filepath.Join(dir, InitLockfileName))
+	if err != nil {
+		t.Fatalf("ReadLockfile: %v", err)
+	}
+	if _, ok := rewrittenLock.Providers["roadmap"].Archives["generic"]; ok {
+		t.Fatalf("rewritten lock still contains generic archive: %#v", rewrittenLock.Providers["roadmap"].Archives)
+	}
+	if _, ok := rewrittenLock.Providers["roadmap"].Archives[providerpkg.CurrentPlatformString()]; !ok {
+		t.Fatalf("rewritten lock missing current platform archive: %#v", rewrittenLock.Providers["roadmap"].Archives)
+	}
+}
+
+func TestLoadForExecutionAtPath_LockedManagedDeclarativePluginMaterializesBeforeGenericPolicyCheck(t *testing.T) {
+	t.Parallel()
+
+	dir := t.TempDir()
+	const pluginRef = "github.com/testowner/plugins/roadmap"
+	const oldVersion = "0.0.1-alpha.1"
+	const newVersion = "0.0.2-alpha.1"
+
+	buildExecutablePlugin := func(version string) string {
+		return mustBuildManagedProviderPackage(t, dir, &providermanifestv1.Manifest{
+			Kind:        providermanifestv1.KindPlugin,
+			Source:      pluginRef,
+			Version:     version,
+			DisplayName: "Roadmap Review",
+			Entrypoint: &providermanifestv1.Entrypoint{
+				ArtifactPath: filepath.ToSlash(filepath.Join("artifacts", runtime.GOOS, runtime.GOARCH, "plugin")),
+			},
+			Spec: &providermanifestv1.Spec{
+				Auth: &providermanifestv1.ProviderAuth{Type: providermanifestv1.AuthTypeNone},
+			},
+		}, map[string]string{
+			filepath.ToSlash(filepath.Join("artifacts", runtime.GOOS, runtime.GOARCH, "plugin")): "plugin-binary-" + version,
+		}, true)
+	}
+	buildDeclarativePlugin := func(version string) string {
+		return mustBuildManagedProviderPackage(t, dir, &providermanifestv1.Manifest{
+			Kind:        providermanifestv1.KindPlugin,
+			Source:      pluginRef,
+			Version:     version,
+			DisplayName: "Roadmap Review",
+			Spec: &providermanifestv1.Spec{
+				Auth: &providermanifestv1.ProviderAuth{Type: providermanifestv1.AuthTypeNone},
+				Surfaces: &providermanifestv1.ProviderSurfaces{
+					REST: &providermanifestv1.RESTSurface{
+						BaseURL: "https://api.example.com",
+						Operations: []providermanifestv1.ProviderOperation{
+							{
+								Name:   "ping",
+								Method: "GET",
+								Path:   "/ping",
+							},
+						},
+					},
+				},
+			},
+		}, nil, false)
+	}
+
+	oldPluginPkg := buildExecutablePlugin(oldVersion)
+	newPluginPkg := buildDeclarativePlugin(newVersion)
+	newPluginArchive, err := os.ReadFile(newPluginPkg)
+	if err != nil {
+		t.Fatalf("ReadFile new declarative package: %v", err)
+	}
+	newPluginArchiveSum := sha256.Sum256(newPluginArchive)
+	archiveServer := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		_, _ = w.Write(newPluginArchive)
+	}))
+	defer archiveServer.Close()
+
+	cfgPath := filepath.Join(dir, "config.yaml")
+	writeConfig := func(version string) {
+		cfg := requiredComponentConfigYAML(t, dir, filepath.Join(dir, "gestalt.db")) + `plugins:
+  roadmap:
+    source:
+      ref: ` + pluginRef + `
+      version: ` + version + `
+server:
+` + requiredServerDatastoreYAML() + `  encryptionKey: aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa
+`
+		if err := os.WriteFile(cfgPath, []byte(cfg), 0o644); err != nil {
+			t.Fatalf("WriteFile config: %v", err)
+		}
+	}
+	writeConfig(oldVersion)
+
+	lc := NewLifecycle(versionedSourceResolver{
+		paths: map[string]map[string]string{
+			pluginRef: {
+				oldVersion: oldPluginPkg,
+				newVersion: newPluginPkg,
+			},
+		},
+	})
+	if _, err := lc.InitAtPath(cfgPath); err != nil {
+		t.Fatalf("InitAtPath: %v", err)
+	}
+
+	writeConfig(newVersion)
+	loadedCfg, err := config.Load(cfgPath)
+	if err != nil {
+		t.Fatalf("Load: %v", err)
+	}
+	paths := initPathsForConfig(cfgPath)
+	lock := &Lockfile{
+		Version: LockVersion,
+		Providers: map[string]LockProviderEntry{
+			"roadmap": {
+				Fingerprint: mustFingerprint(t, "roadmap", loadedCfg.Plugins["roadmap"], paths.configDir),
+				Source:      pluginRef,
+				Version:     newVersion,
+				Archives: map[string]LockArchive{
+					"generic": {URL: archiveServer.URL, SHA256: hex.EncodeToString(newPluginArchiveSum[:])},
+				},
+			},
+		},
+	}
+	if err := WriteLockfile(filepath.Join(dir, InitLockfileName), lock); err != nil {
+		t.Fatalf("WriteLockfile: %v", err)
+	}
+
+	loaded, _, err := lc.LoadForExecutionAtPath(cfgPath, true)
+	if err != nil {
+		t.Fatalf("LoadForExecutionAtPath(locked=true): %v", err)
+	}
+	if loaded.Plugins["roadmap"] == nil || loaded.Plugins["roadmap"].ResolvedManifest == nil {
+		t.Fatalf("ResolvedManifest = %+v", loaded.Plugins["roadmap"])
+	}
+	if got := loaded.Plugins["roadmap"].ResolvedManifest.Version; got != newVersion {
+		t.Fatalf("ResolvedManifest.Version = %q, want %q", got, newVersion)
+	}
+	if !loaded.Plugins["roadmap"].ResolvedManifest.IsDeclarativeOnlyProvider() {
+		t.Fatalf("ResolvedManifest = %+v, want declarative-only provider", loaded.Plugins["roadmap"].ResolvedManifest)
+	}
+	if loaded.Plugins["roadmap"].Command != "" {
+		t.Fatalf("loaded plugin command = %q, want declarative plugin without executable", loaded.Plugins["roadmap"].Command)
+	}
+}
+
 func TestLoadForExecutionAtPath_UsesDerivedPreparedPathsWhenLockPathsAreStale(t *testing.T) {
 	t.Parallel()
 
@@ -1383,7 +1603,7 @@ func TestHashPlatformInEntries_HashesMountedWebUIAndProviderArchives(t *testing.
 			"session": {
 				Source: "github.com/testowner/cache/session",
 				Archives: map[string]LockArchive{
-					platformKeyGeneric: {URL: srv.URL},
+					providerpkg.CurrentPlatformString(): {URL: srv.URL},
 				},
 			},
 		},
@@ -1391,7 +1611,7 @@ func TestHashPlatformInEntries_HashesMountedWebUIAndProviderArchives(t *testing.
 			"assets": {
 				Source: "github.com/testowner/providers/s3",
 				Archives: map[string]LockArchive{
-					platformKeyGeneric: {URL: srv.URL},
+					providerpkg.CurrentPlatformString(): {URL: srv.URL},
 				},
 			},
 		},
@@ -1405,7 +1625,7 @@ func TestHashPlatformInEntries_HashesMountedWebUIAndProviderArchives(t *testing.
 		},
 	}
 
-	if err := hashPlatformInEntries(context.Background(), lock, providerpkg.CurrentPlatformString(), map[string]string{}); err != nil {
+	if err := hashPlatformInEntries(context.Background(), lock, initPaths{}, providerpkg.CurrentPlatformString(), map[string]string{}); err != nil {
 		t.Fatalf("hashPlatformInEntries: %v", err)
 	}
 
@@ -1414,10 +1634,10 @@ func TestHashPlatformInEntries_HashesMountedWebUIAndProviderArchives(t *testing.
 	if got != want {
 		t.Fatalf("webui SHA256 = %q, want %q", got, want)
 	}
-	if got := lock.Caches["session"].Archives[platformKeyGeneric].SHA256; got != want {
+	if got := lock.Caches["session"].Archives[providerpkg.CurrentPlatformString()].SHA256; got != want {
 		t.Fatalf("cache SHA256 = %q, want %q", got, want)
 	}
-	if got := lock.S3["assets"].Archives[platformKeyGeneric].SHA256; got != want {
+	if got := lock.S3["assets"].Archives[providerpkg.CurrentPlatformString()].SHA256; got != want {
 		t.Fatalf("S3 SHA256 = %q, want %q", got, want)
 	}
 }
@@ -2555,7 +2775,7 @@ func TestHashArchiveEntry_HashesFallbackArchive(t *testing.T) {
 		},
 	}
 
-	if err := hashArchiveEntry(context.Background(), &entry, "linux/amd64", nil); err != nil {
+	if err := hashArchiveEntry(context.Background(), providermanifestv1.KindWebUI, "roadmap", &entry, initPaths{}, "linux/amd64", nil); err != nil {
 		t.Fatalf("hashArchiveEntry: %v", err)
 	}
 


### PR DESCRIPTION
## Summary
This adds operator-level archive policy enforcement so executable providers can no longer silently resolve through `generic` archives. `webui` and declarative/spec-only plugin packages remain allowed to use `generic`.

## Go interface
```go
func validateResolvedArchivePolicy(subject, kind string, manifest *providermanifestv1.Manifest, platform, currentURL string, available map[string]LockArchive) error
func validateLockedArchivePolicy(subject, kind string, manifest *providermanifestv1.Manifest, entry LockEntry, platform, resolvedKey string) error
func installLockedPackageAtomic(packagePath, destDir string) (*pluginstore.InstalledPlugin, func() error, func() error, error)
```

## YAML interface
Managed source config keeps the same shape.

```yaml
plugins:
  example:
    source:
      ref: github.com/test/plugins/provider
      version: 0.0.1-alpha.1
```

## Behavior examples
- `gestaltd init --config config.yaml` now fails if the plugin above cannot prove a platform-specific release archive.
- `gestaltd serve --locked --config config.yaml` now refuses to boot if a locked executable provider resolves via `generic`.
- Failed locked installs are staged in a temp directory and only replace prepared cache entries after policy validation succeeds.
- `webui` bundles and declarative/spec-only plugin packages still allow `generic`.

## Validation
- Augmented existing CLI e2e coverage instead of adding unit tests:
```sh
cd gestaltd
go test ./cmd/gestaltd -run 'TestE2E(InitLocalProviders|ServeLockedRejectsGenericArchiveForExecutablePlugin|MountedWebUI)$' -count=1
```
- Result: passed

## Notes
The portable lock schema still does not encode portability metadata, so the strongest rejection signal happens during `init` or after reading an installed manifest during locked execution.
