### PR TITLE
docs: add S3 provider and authoring documentation

### DIFF
--- a/docs/content/configuration.mdx
+++ b/docs/content/configuration.mdx
@@ -44,6 +44,8 @@ providers:
     <name>: ...             # each is a ProviderEntry
   cache:                    # named cache providers
     <name>: ...             # each is a ProviderEntry
+  s3:                       # named S3 object-store providers
+    <name>: ...             # each is a ProviderEntry
 plugins:
   <name>: ...               # each is a ProviderEntry
 ```
@@ -52,11 +54,12 @@ ProviderEntry-backed entries accept `source` (where to load it from), `config` (
 
 ## Key concepts
 
-Gestalt has six core concepts you configure in YAML:
+Gestalt has seven core concepts you configure in YAML:
 
 - **[Plugin.](/providers/plugins)** A tool backed by a provider package. Plugins expose operations that agents and users invoke over HTTP, MCP, or the CLI. Plugins can come from published packages or local source.
 - **Connection.** How Gestalt authenticates to an upstream API on behalf of a user or service. Connections handle OAuth flows, API keys, and manual credentials.
 - **[IndexedDB.](/providers/indexeddb)** The persistent storage layer. Stores users, sessions, tokens, and credentials through a provider that implements the IndexedDB interface.
+- **[S3.](/providers/s3)** Plugin-bound object storage. The provider config chooses the backend, credentials, and endpoint; plugin code chooses buckets, keys, and versions at runtime.
 - **[Auth.](/providers/auth)** Platform login for the Gestalt server. Separate from connection auth, which is per-plugin and per-upstream.
 - **[Secrets.](/providers/secrets)** Resolves structured secret refs in the config at startup. Backed by environment variables, files, or cloud secret managers.
 - **[UI.](/providers/web-uis)** Public static UI bundles served under configured path prefixes, either directly from `providers.ui` or through `plugins.<name>.mountPath`. Omit `providers.ui` to run headless.
@@ -125,6 +128,37 @@ plugins:
       - api.example.com
       - cdn.example.com
 ```
+
+## Binding S3 object stores
+
+S3 providers are plugin-only bindings. Configure named entries under
+`providers.s3`, then grant a plugin access with `plugins.<name>.s3`.
+
+```yaml
+providers:
+  s3:
+    assets:
+      source:
+        ref: github.com/valon-technologies/gestalt-providers/s3/s3
+        version: 0.0.1-alpha.1
+      config:
+        region: us-east-1
+        endpoint: https://s3.us-east-1.amazonaws.com
+        accessKeyId: ${AWS_ACCESS_KEY_ID}
+        secretAccessKey: secret://aws-secret-access-key
+
+plugins:
+  media:
+    source:
+      path: ./plugins/media/manifest.yaml
+    s3:
+      - assets
+```
+
+With one S3 binding, the SDK can use its default helper (`GESTALT_S3_SOCKET`).
+With multiple bindings, use the named helper such as `gestalt.S3("archive")`
+or `new S3("archive")`. See [S3 Providers](/providers/s3) for backend-specific
+configuration and operational notes.
 
 ## Connecting to upstream APIs
 

--- a/docs/content/custom-providers/index.mdx
+++ b/docs/content/custom-providers/index.mdx
@@ -11,7 +11,7 @@ deployment, start with [Providers](/providers).
 ## What belongs here
 
 - Implementing executable or declarative plugin providers
-- Building custom auth, cache, IndexedDB, secrets, and web UI providers
+- Building custom auth, cache, IndexedDB, S3, secrets, and web UI providers
 - Testing providers from local source with `source.path`
 - Packaging releases with `gestaltd provider release`
 
@@ -38,7 +38,10 @@ providers:
 - [Cache](/custom-providers/cache): plugin-bound cache backends
 - [IndexedDB](/custom-providers/indexeddb): custom storage backends for system
   state
-- [Secrets](/custom-providers/secrets): secret managers for structured secret refs
+- [S3](/custom-providers/s3): custom object-store backends for executable
+  plugins
+- [Secrets](/custom-providers/secrets): secret managers for structured secret
+  refs
   resolution
 - [Web UIs](/custom-providers/web-uis): public UI bundles served under
   configured path prefixes

--- a/docs/content/custom-providers/s3.mdx
+++ b/docs/content/custom-providers/s3.mdx
@@ -6,8 +6,8 @@ This page covers building custom S3 providers. If you only need to configure
 an object store for a deployment, use [Providers > S3](/providers/s3).
 
 Gestalt's S3 provider contract models the portable S3-compatible object API:
-object metadata, streaming reads and writes, prefix listing, object copy, and
-presigning. It intentionally excludes bucket administration, IAM policy
+object metadata, streaming reads and writes, prefix listing, server-side copy,
+and presigning. It intentionally excludes bucket administration, IAM policy
 management, and other control-plane features that do not transport cleanly
 across S3-compatible backends.
 
@@ -42,84 +42,198 @@ Implement the `S3` gRPC service:
 <Tabs items={['Go', 'Python', 'Rust', 'TypeScript']}>
   <Tabs.Tab>
     ```go
-    package minio
+    package s3provider
 
     import (
     	"context"
+
     	gestalt "github.com/valon-technologies/gestalt/sdk/go"
     	proto "github.com/valon-technologies/gestalt/sdk/go/gen/v1"
+    	"google.golang.org/grpc/codes"
+    	"google.golang.org/grpc/status"
     	"google.golang.org/protobuf/types/known/emptypb"
     )
 
     type Provider struct{}
 
     func (p *Provider) Configure(_ context.Context, _ string, config map[string]any) error {
+    	_ = config
     	return nil
     }
 
     func (p *Provider) HeadObject(ctx context.Context, req *proto.HeadObjectRequest) (*proto.HeadObjectResponse, error) {
-    	return nil, nil
+    	_ = ctx
+    	_ = req
+    	return nil, status.Error(codes.Unimplemented, "todo")
     }
 
     func (p *Provider) ReadObject(req *proto.ReadObjectRequest, stream proto.S3_ReadObjectServer) error {
-    	return nil
+    	_ = req
+    	_ = stream
+    	return status.Error(codes.Unimplemented, "todo")
     }
 
     func (p *Provider) WriteObject(stream proto.S3_WriteObjectServer) error {
-    	return nil
+    	_ = stream
+    	return status.Error(codes.Unimplemented, "todo")
     }
 
     func (p *Provider) DeleteObject(context.Context, *proto.DeleteObjectRequest) (*emptypb.Empty, error) {
-    	return &emptypb.Empty{}, nil
+    	return nil, status.Error(codes.Unimplemented, "todo")
     }
 
     func (p *Provider) ListObjects(context.Context, *proto.ListObjectsRequest) (*proto.ListObjectsResponse, error) {
-    	return nil, nil
+    	return nil, status.Error(codes.Unimplemented, "todo")
     }
 
     func (p *Provider) CopyObject(context.Context, *proto.CopyObjectRequest) (*proto.CopyObjectResponse, error) {
-    	return nil, nil
+    	return nil, status.Error(codes.Unimplemented, "todo")
     }
 
     func (p *Provider) PresignObject(context.Context, *proto.PresignObjectRequest) (*proto.PresignObjectResponse, error) {
-    	return nil, nil
+    	return nil, status.Error(codes.Unimplemented, "todo")
     }
 
     func main() {
-    	_ = gestalt.ServeS3Provider(context.Background(), &Provider{})
+    	if err := gestalt.ServeS3Provider(context.Background(), &Provider{}); err != nil {
+    		panic(err)
+    	}
     }
     ```
   </Tabs.Tab>
   <Tabs.Tab>
     ```python
+    from collections.abc import Iterator
+
     import gestalt
+    from gestalt.gen.v1 import s3_pb2
 
     class MinIOS3(gestalt.S3Provider):
         def configure(self, name: str, config: dict[str, object]) -> None:
+            self.name = name
             self.endpoint = str(config["endpoint"])
 
-        def head_object(self, request: object) -> object:
-            ...
+        def HeadObject(
+            self,
+            request: s3_pb2.HeadObjectRequest,
+            context,
+        ) -> s3_pb2.HeadObjectResponse:
+            raise NotImplementedError
 
-        def read_object(self, request: object):
-            ...
+        def ReadObject(
+            self,
+            request: s3_pb2.ReadObjectRequest,
+            context,
+        ) -> Iterator[s3_pb2.ReadObjectChunk]:
+            raise NotImplementedError
 
-        def write_object(self, requests):
-            ...
+        def WriteObject(self, request_iterator, context) -> s3_pb2.WriteObjectResponse:
+            raise NotImplementedError
+
+        def DeleteObject(self, request: s3_pb2.DeleteObjectRequest, context):
+            raise NotImplementedError
+
+        def ListObjects(
+            self,
+            request: s3_pb2.ListObjectsRequest,
+            context,
+        ) -> s3_pb2.ListObjectsResponse:
+            raise NotImplementedError
+
+        def CopyObject(
+            self,
+            request: s3_pb2.CopyObjectRequest,
+            context,
+        ) -> s3_pb2.CopyObjectResponse:
+            raise NotImplementedError
+
+        def PresignObject(
+            self,
+            request: s3_pb2.PresignObjectRequest,
+            context,
+        ) -> s3_pb2.PresignObjectResponse:
+            raise NotImplementedError
+
+    if __name__ == "__main__":
+        MinIOS3().serve()
     ```
   </Tabs.Tab>
   <Tabs.Tab>
     ```rust
+    use std::pin::Pin;
+
+    use futures_core::Stream;
+    use gestalt::{self, proto::v1 as proto};
+    use tonic::{Request, Response, Status};
+
     #[derive(Default)]
     pub struct MinioS3;
 
     #[gestalt::async_trait]
     impl gestalt::S3Provider for MinioS3 {
+        async fn configure(
+            &self,
+            _name: &str,
+            _config: serde_json::Map<String, serde_json::Value>,
+        ) -> gestalt::Result<()> {
+            Ok(())
+        }
+    }
+
+    type ReadObjectStream =
+        Pin<Box<dyn Stream<Item = Result<proto::ReadObjectChunk, Status>> + Send>>;
+
+    #[gestalt::async_trait]
+    impl proto::s3_server::S3 for MinioS3 {
+        type ReadObjectStream = ReadObjectStream;
+
         async fn head_object(
             &self,
-            request: proto::HeadObjectRequest,
-        ) -> gestalt::Result<proto::HeadObjectResponse> {
-            todo!()
+            _request: Request<proto::HeadObjectRequest>,
+        ) -> Result<Response<proto::HeadObjectResponse>, Status> {
+            Err(Status::unimplemented("todo"))
+        }
+
+        async fn read_object(
+            &self,
+            _request: Request<proto::ReadObjectRequest>,
+        ) -> Result<Response<Self::ReadObjectStream>, Status> {
+            Err(Status::unimplemented("todo"))
+        }
+
+        async fn write_object(
+            &self,
+            _request: Request<tonic::Streaming<proto::WriteObjectRequest>>,
+        ) -> Result<Response<proto::WriteObjectResponse>, Status> {
+            Err(Status::unimplemented("todo"))
+        }
+
+        async fn delete_object(
+            &self,
+            _request: Request<proto::DeleteObjectRequest>,
+        ) -> Result<Response<()>, Status> {
+            Err(Status::unimplemented("todo"))
+        }
+
+        async fn list_objects(
+            &self,
+            _request: Request<proto::ListObjectsRequest>,
+        ) -> Result<Response<proto::ListObjectsResponse>, Status> {
+            Err(Status::unimplemented("todo"))
+        }
+
+        async fn copy_object(
+            &self,
+            _request: Request<proto::CopyObjectRequest>,
+        ) -> Result<Response<proto::CopyObjectResponse>, Status> {
+            Err(Status::unimplemented("todo"))
+        }
+
+        async fn presign_object(
+            &self,
+            _request: Request<proto::PresignObjectRequest>,
+        ) -> Result<Response<proto::PresignObjectResponse>, Status> {
+            Err(Status::unimplemented("todo"))
         }
     }
 
@@ -128,20 +242,76 @@ Implement the `S3` gRPC service:
   </Tabs.Tab>
   <Tabs.Tab>
     ```ts
-    import { defineS3Provider } from "@valon-technologies/gestalt";
+    import { PresignMethod, defineS3Provider } from "@valon-technologies/gestalt";
 
     export const provider = defineS3Provider({
       async configure(name, config) {
-        this.endpoint = String(config.endpoint);
+        void name;
+        void config.endpoint;
       },
 
-      async headObject(request) {
-        return {};
+      async headObject(ref) {
+        return {
+          ref,
+          etag: "",
+          size: 0n,
+          contentType: "",
+          lastModified: new Date(),
+          metadata: {},
+          storageClass: "",
+        };
+      },
+
+      async readObject(ref) {
+        return {
+          meta: await this.headObject(ref),
+          body: new Uint8Array(),
+        };
+      },
+
+      async writeObject(ref, body, options) {
+        void body;
+        void options;
+        return await this.headObject(ref);
+      },
+
+      async deleteObject(ref) {
+        void ref;
+      },
+
+      async listObjects(options) {
+        void options;
+        return {
+          objects: [],
+          commonPrefixes: [],
+          nextContinuationToken: "",
+          hasMore: false,
+        };
+      },
+
+      async copyObject(source, destination, options) {
+        void source;
+        void options;
+        return await this.headObject(destination);
+      },
+
+      async presignObject(ref, options) {
+        return {
+          url: `https://example.invalid/${ref.bucket}/${encodeURIComponent(ref.key)}`,
+          method: options?.method ?? PresignMethod.Get,
+          headers: { ...(options?.headers ?? {}) },
+          expiresAt: new Date(Date.now() + 60_000),
+        };
       },
     });
     ```
   </Tabs.Tab>
 </Tabs>
+
+Python S3 providers implement the generated `HeadObject`, `ReadObject`,
+`WriteObject`, `DeleteObject`, `ListObjects`, `CopyObject`, and
+`PresignObject` methods from `gestalt.gen.v1.s3_pb2_grpc.S3Servicer`.
+`gestalt.S3Provider` adds the runtime lifecycle wiring and `serve()` helper.
 
 ## Plugin SDK
 
@@ -168,17 +338,44 @@ _ = body
 
 The same contract exists across Go, Python, Rust, and TypeScript:
 
-- connect to the default binding with `S3()` / `new S3()` / `S3.connect()`
+- connect to the default binding with `S3()` / `new S3()` /
+  `S3::connect().await`
 - connect to a named binding with `S3("archive")` or its language equivalent
-- operate on object handles with `stat`, `bytes` / `text` / `json`, `write`, `delete`, and `presign`
+- operate on object handles with `stat`, `bytes` / `text` / `json`, `write`,
+  `delete`, and `presign`
+
+## Deploying the provider
+
+Custom S3 providers are wired into Gestalt the same way as first-party ones:
+
+```yaml
+providers:
+  s3:
+    assets:
+      source:
+        path: ./providers/s3/custom/manifest.yaml
+      config:
+        endpoint: http://127.0.0.1:9000
+        region: us-east-1
+
+plugins:
+  media:
+    source:
+      path: ./plugins/media/manifest.yaml
+    s3:
+      - assets
+```
 
 ## Implementation notes
 
 - Treat object references as `{bucket, key, version_id}` values, not filesystem paths.
 - Keep reads and writes streaming. Do not require the caller to buffer the full object in memory.
 - Preserve backend metadata that fits the portable model: `etag`, `size`, `content_type`, `last_modified`, `metadata`, and `storage_class`.
-- Use `FailedPrecondition` for conditional-write failures and `NotFound` for missing objects so SDK error mapping stays portable.
-- Prefer implementing multipart upload and backend retries internally instead of extending the public gRPC surface unless the caller truly needs those controls.
+- `CopyObject` conditionals apply to the source object, not the destination object.
+- Map missing objects to `NotFound`, conditional failures to `FailedPrecondition`, and invalid ranges to `OutOfRange` so SDK error mapping stays portable.
+- `PresignObject` should return only caller-required headers. Do not leak transport-generated headers such as `Host`.
+- Implement multipart upload and multipart copy internally when the backend needs them, or reject above the single-request S3 limit explicitly. Do not silently rely on backend-specific `PutObject` / `CopyObject` failures.
+- Plugin-scoped presigning is disabled by the host transport because signed URLs would expose the internal namespace prefix used to isolate plugin data.
 
 ## What to read next
 

--- a/docs/content/providers/index.mdx
+++ b/docs/content/providers/index.mdx
@@ -6,9 +6,10 @@ asIndexPage: true
 
 Gestalt loads most integration and platform surfaces as providers instead of
 compiling them into `gestaltd`. Plugins, auth backends, IndexedDB backends,
-cache backends, external secret managers, and public web UIs all use the same
-provider model: you reference a package in config, the host resolves it,
-validates it, and starts it with the permissions and request context it needs.
+cache backends, S3 object stores, external secret managers, and public web UIs
+all use the same provider model: you reference a package in config, the host
+resolves it, validates it, and starts it with the permissions and request
+context it needs.
 
 ## Provider kinds
 

--- a/docs/content/providers/s3.mdx
+++ b/docs/content/providers/s3.mdx
@@ -1,17 +1,29 @@
+import { Tabs } from 'nextra/components'
+
 # S3
 
-S3 providers expose portable object storage to plugins. Gestalt models the
-de facto S3-compatible object API rather than a filesystem API, so one plugin
-surface can work against AWS S3, MinIO, Cloudflare R2, GCS interoperability
-mode, and other compatible backends.
+S3 providers expose portable object storage to executable plugins. Gestalt
+models the de facto S3-compatible object API rather than a filesystem API, so
+the same plugin code can target AWS S3, MinIO, GCS XML interoperability mode,
+Cloudflare R2, and other compatible backends.
 
 ## How S3 providers work
 
-Each named entry under `providers.s3` starts one S3 provider process. Plugins
-opt into those bindings with `plugins.<name>.s3`. When a plugin is
-bound to one S3 provider, the host sets the default SDK socket env var
-(`GESTALT_S3_SOCKET`). With multiple bindings, the host sets only named env
-vars such as `GESTALT_S3_SOCKET_ARCHIVE`.
+Configure one or more named entries under `providers.s3`, then bind them into
+executable plugins with `plugins.<name>.s3`. The host starts one provider
+process per enabled named entry and only exposes the bindings each plugin is
+granted.
+
+When a plugin binds exactly one S3 provider, Gestalt sets both:
+
+- `GESTALT_S3_SOCKET`
+- `GESTALT_S3_SOCKET_<NAME>`
+
+When a plugin binds multiple S3 providers, only the named env vars are set.
+
+Plugins still work with ordinary `{bucket, key, version_id}` references. The
+host keeps plugin data isolated with an internal namespace prefix, so plugins
+do not need to invent their own storage prefix scheme.
 
 The portable contract covers:
 
@@ -25,70 +37,159 @@ The portable contract covers:
 | `CopyObject` | `CopyObject` |
 | `PresignObject` | presigned `GET` / `PUT` / `DELETE` / `HEAD` |
 
-## Configuring an S3 provider
+## Configuring the first-party S3 provider
+
+The first-party package lives at
+`github.com/valon-technologies/gestalt-providers/s3/s3`:
 
 ```yaml
 providers:
   s3:
     assets:
       source:
-        path: ./providers/s3/minio/manifest.yaml
+        ref: github.com/valon-technologies/gestalt-providers/s3/s3
+        version: 0.0.1-alpha.1
       config:
-        endpoint: http://127.0.0.1:9000
         region: us-east-1
-        accessKeyId: ${MINIO_ROOT_USER}
-        secretAccessKey: secret://minio-root-password
+        endpoint: https://s3.us-east-1.amazonaws.com
+        forcePathStyle: false
+        accessKeyId: ${AWS_ACCESS_KEY_ID}
+        secretAccessKey: secret://aws-secret-access-key
 
-  plugins:
-    media:
-      source:
-        path: ./plugins/media/manifest.yaml
-      s3:
-        - assets
+plugins:
+  media:
+    source:
+      path: ./plugins/media/manifest.yaml
+    s3:
+      - assets
 ```
 
-The shape of `config` is provider-specific. Gestalt passes the selected
-`providers.s3.<name>.config` block through to that provider unchanged.
+The first-party provider accepts these config fields:
+
+- `region`: signing region for the backend.
+- `endpoint`: optional base URL for S3-compatible services such as MinIO or
+  GCS XML interoperability.
+- `forcePathStyle`: toggles path-style versus virtual-host-style requests.
+- `accessKeyId`: optional static HMAC access key.
+- `secretAccessKey`: optional static HMAC secret key.
+- `sessionToken`: optional session token for temporary credentials.
+
+If static credentials are omitted, the provider falls back to the AWS SDK
+default credential chain.
+
+GCS XML interoperability uses the same provider with a different endpoint and
+HMAC credentials:
+
+```yaml
+providers:
+  s3:
+    archive:
+      source:
+        ref: github.com/valon-technologies/gestalt-providers/s3/s3
+        version: 0.0.1-alpha.1
+      config:
+        region: auto
+        endpoint: https://storage.googleapis.com
+        forcePathStyle: true
+        accessKeyId: ${GCS_HMAC_ACCESS_KEY}
+        secretAccessKey: secret://gcs-hmac-secret
+```
 
 ## Using S3 from a plugin
 
-The SDK presents object handles rather than raw gRPC stubs:
+The SDK exposes an S3 client plus object-handle helpers in every supported
+language.
 
-```go
-ctx := context.Background()
+<Tabs items={['Go', 'Python', 'Rust', 'TypeScript']}>
+  <Tabs.Tab>
+    ```go
+    ctx := context.Background()
 
-s3, err := gestalt.S3()
-if err != nil {
-	log.Fatal(err)
-}
-defer s3.Close()
+    s3, err := gestalt.S3()
+    if err != nil {
+    	log.Fatal(err)
+    }
+    defer s3.Close()
 
-avatar := s3.Object("uploads", "avatars/user-123.png")
+    avatar := s3.Object("uploads", "avatars/user-123.png")
+    if _, err := avatar.WriteBytes(ctx, pngBytes, &gestalt.WriteOptions{
+    	ContentType: "image/png",
+    }); err != nil {
+    	log.Fatal(err)
+    }
 
-if _, err := avatar.WriteBytes(ctx, pngBytes, &gestalt.WriteOptions{
-	ContentType: "image/png",
-}); err != nil {
-	log.Fatal(err)
-}
+    body, err := avatar.Bytes(ctx, nil)
+    if err != nil {
+    	log.Fatal(err)
+    }
+    _ = body
+    ```
+  </Tabs.Tab>
+  <Tabs.Tab>
+    ```python
+    import gestalt
 
-url, err := avatar.Presign(ctx, &gestalt.PresignOptions{
-	Method:  gestalt.PresignMethodGet,
-	Expires: 15 * time.Minute,
-})
-if err != nil {
-	log.Fatal(err)
-}
-fmt.Println(url.URL)
-```
+    s3 = gestalt.S3()
+    avatar = s3.object("uploads", "avatars/user-123.png")
+    avatar.write_bytes(
+        png_bytes,
+        gestalt.WriteOptions(content_type="image/png"),
+    )
+    body = avatar.bytes()
+    s3.close()
+    ```
+  </Tabs.Tab>
+  <Tabs.Tab>
+    ```rust
+    let s3 = gestalt::S3::connect().await?;
+    let mut avatar = s3.object("uploads", "avatars/user-123.png");
 
-Use `gestalt.S3("archive")` when a plugin binds multiple named S3 providers.
+    avatar
+        .write_bytes(
+            &png_bytes,
+            Some(gestalt::WriteOptions {
+                content_type: "image/png".to_string(),
+                ..Default::default()
+            }),
+        )
+        .await?;
+
+    let body = avatar.bytes(None).await?;
+    ```
+  </Tabs.Tab>
+  <Tabs.Tab>
+    ```ts
+    import { S3 } from "@valon-technologies/gestalt";
+
+    const s3 = new S3();
+    const avatar = s3.object("uploads", "avatars/user-123.png");
+
+    await avatar.write(pngBytes, { contentType: "image/png" });
+    const body = await avatar.bytes();
+    ```
+  </Tabs.Tab>
+</Tabs>
+
+Use the named helpers when a plugin binds more than one S3 provider: Go and
+Python use `gestalt.S3("archive")`, Rust uses
+`gestalt::S3::connect_named("archive")`, and TypeScript uses
+`new S3("archive")`.
 
 ## Operational notes
 
-- Gestalt does not use S3 providers for its own system state. They are plugin-only bindings.
-- Named S3 bindings are isolated at the process and socket level; plugins only see the bindings explicitly granted in config.
-- Plugin-scoped presigning is not available. Signed URLs expose the provider-internal key namespace used to isolate plugin data.
-- `gestaltd init` can prepare published S3 provider packages the same way it prepares auth, indexeddb, and secrets providers.
+- Gestalt does not use S3 providers for its own system state. They are
+  plugin-only bindings.
+- The first-party provider preserves the portable object identity
+  `{bucket, key, version_id}`. Buckets are chosen by the caller, not fixed in
+  provider config.
+- Plugin-scoped presigning is not available through the SDK transport. Signed
+  URLs would expose the provider-internal namespace prefix that the host uses
+  to isolate plugin data.
+- The first-party provider currently rejects writes and copies above the
+  single-request S3 limit instead of exposing multipart controls through the
+  public contract.
+- `gestaltd init` can prepare published S3 provider packages the same way it
+  prepares auth, indexeddb, cache, and secrets providers.
 
 ## Building your own S3 provider
 

--- a/docs/content/reference/built-in-providers.mdx
+++ b/docs/content/reference/built-in-providers.mdx
@@ -1,6 +1,11 @@
 # First-Party Providers
 
-Gestalt does not compile auth or datastore providers into the `gestaltd` binary. Both are loaded at startup as external provider processes through the same runtime model that also powers plugins. The first-party implementations are published from [`valon-technologies/gestalt-providers`](https://github.com/valon-technologies/gestalt-providers) and maintained alongside the server.
+Gestalt does not compile auth, IndexedDB, or S3 providers into the `gestaltd`
+binary. They are loaded at startup as external provider processes through the
+same runtime model that also powers plugins. The first-party implementations
+are published from
+[`valon-technologies/gestalt-providers`](https://github.com/valon-technologies/gestalt-providers)
+and maintained alongside the server.
 
 Two simple secrets providers (`env` and `file`), telemetry, and audit remain built into the binary. Cloud secret backends (Google Secret Manager, AWS Secrets Manager, HashiCorp Vault, Azure Key Vault) are available as external providers from [`valon-technologies/gestalt-providers`](https://github.com/valon-technologies/gestalt-providers). See [Secrets Providers](/providers/secrets) for the full list and configuration.
 
@@ -52,6 +57,43 @@ providers:
 | `relationaldb` | SQL-backed IndexedDB provider for PostgreSQL, MySQL, SQLite, and SQL Server. |
 | `dynamodb` | Amazon DynamoDB-backed IndexedDB provider for managed key-value and document storage. |
 | `mongodb` | MongoDB-backed IndexedDB provider for document-oriented storage. |
+
+## S3 Providers
+
+S3 providers expose portable object storage to executable plugins. They are
+configured under named entries in `providers.s3`, then bound into plugins with
+`plugins.<name>.s3`.
+
+```yaml
+providers:
+  s3:
+    assets:
+      source:
+        ref: github.com/valon-technologies/gestalt-providers/s3/s3
+        version: 0.0.1-alpha.1
+      config:
+        region: us-east-1
+        endpoint: https://s3.us-east-1.amazonaws.com
+        forcePathStyle: false
+        accessKeyId: ${AWS_ACCESS_KEY_ID}
+        secretAccessKey: secret://aws-secret-access-key
+
+plugins:
+  media:
+    source:
+      path: ./plugins/media/manifest.yaml
+    s3:
+      - assets
+```
+
+| Name | Purpose |
+| --- | --- |
+| `s3` | Portable S3-compatible object store provider for AWS S3, MinIO, GCS XML interoperability, and similar backends. |
+
+If `accessKeyId` and `secretAccessKey` are omitted, the first-party provider
+falls back to the AWS SDK default credential chain. `sessionToken`, custom
+`endpoint`, and `forcePathStyle` are available for temporary credentials and
+non-AWS S3-compatible backends.
 
 ## Secret Managers
 

--- a/docs/content/reference/config-file.mdx
+++ b/docs/content/reference/config-file.mdx
@@ -2,8 +2,11 @@ import { Tabs } from 'nextra/components'
 
 # Config File
 
-Every `gestaltd` deployment reads a single YAML config file. The top-level keys are `server` (listener, encryption, egress, and host-provider selection), `authorization` (shared human/workload access policy), `providers` (named auth, secrets, telemetry, audit, UI, indexeddb, and cache entries), and `plugins` (executable integrations and optional plugin-backed UI mounts):
-S3-compatible object stores are also configured under `providers.s3`.
+Every `gestaltd` deployment reads a single YAML config file. The top-level
+keys are `server` (listener, encryption, egress, and host-provider selection),
+`authorization` (shared human/workload access policy), `providers` (named
+auth, secrets, telemetry, audit, UI, indexeddb, cache, and s3 entries), and
+`plugins` (executable integrations and optional plugin-backed UI mounts):
 
 ```yaml
 server:
@@ -603,6 +606,9 @@ plugins:
 | `indexeddb` | Optional plugin IndexedDB config. `indexeddb.provider` selects which named `providers.indexeddb` entry backs the plugin's single IndexedDB SDK socket; when omitted, the plugin inherits the selected/default host IndexedDB. `indexeddb.db` overrides the plugin-visible database name and defaults to the plugin key. Schema-capable backends derive plugin scoping from that `db` name. `indexeddb.objectStores` optionally allowlists the logical object stores the plugin may use. Plugins then call `new IndexedDB()` (or the equivalent SDK helper) against `GESTALT_INDEXEDDB_SOCKET`; they do not choose arbitrary schemas or DSNs at runtime. |
 | `s3` | Optional list of named `providers.s3` bindings exposed to the executable plugin through the SDK transport. A single binding also populates the default S3 SDK env var for compatibility. |
 
+S3 bindings are exposed as `GESTALT_S3_SOCKET_<NAME>`. When exactly one S3
+binding is configured, Gestalt also sets `GESTALT_S3_SOCKET`.
+
 ### `plugins.*.source`
 
 Every plugin uses a `source` block to declare its backing provider.
@@ -888,13 +894,22 @@ Structural validation runs at config load time (`init`, `validate`, `serve`). Ru
 
 Each plugin uses a `source` block. Every plugin must use exactly one loading mode: local `source.path` or managed `source.ref`. `source.version` is required with `source.ref` and invalid with `source.path`.
 
-Host-provider entries use the same ProviderEntry shape. When `providers.auth.<name>` or `providers.indexeddb.<name>` is set, `source.ref` or `source.path` must be present. `providers.auth.<name>.config` and `providers.indexeddb.<name>.config` are only allowed when their corresponding source is set.
+Host-provider entries use the same ProviderEntry shape. When
+`providers.auth.<name>`, `providers.cache.<name>`,
+`providers.indexeddb.<name>`, or `providers.s3.<name>` is set, `source.ref` or
+`source.path` must be present.
+`providers.auth.<name>.config`, `providers.cache.<name>.config`,
+`providers.indexeddb.<name>.config`, and `providers.s3.<name>.config` are only
+allowed when their corresponding source is set.
 
 Only `connections.default` may define `params` or `discovery`. All connections in a plugin must share the same mode.
 
 Each `providers.ui.<name>` entry must use exactly one loading mode: local `providers.ui.<name>.source.path` or managed `providers.ui.<name>.source.ref`. `providers.ui.<name>.source.version` is required with `providers.ui.<name>.source.ref` and invalid with `providers.ui.<name>.source.path`. `providers.ui.<name>.config` is only allowed when `providers.ui.<name>.source` is set.
 
 Each `plugins.<name>` entry may set `mountPath` to publish a plugin-backed UI. When `plugins.<name>.ui` is set, it must reference an existing UI bundle. When `plugins.<name>.ui` is omitted and `plugins.<name>.mountPath` is set, the plugin manifest must declare `spec.ui`. A given UI may be bound by at most one plugin entry. `plugins.<name>.mountPath` must use the same path rules as a directly mounted UI.
+
+Each name in `plugins.<name>.s3` must reference an existing enabled
+`providers.s3.<name>` entry.
 
 Mounted UI bundles are served on the public listener only. The built-in admin UI remains at `/admin`.
 


### PR DESCRIPTION
## Summary
- add and tighten the core S3 docs across provider, config, and built-in-provider references
- document how to configure `providers.s3` and bind it into executable plugins with `plugins.<name>.s3`
- update the advanced custom-provider docs so the Go, Python, Rust, and TypeScript S3 provider examples match the shipped SDK/runtime entrypoints and current S3 behavior

## Highlights
- adds operator-facing guidance for the first-party provider at `github.com/valon-technologies/gestalt-providers/s3/s3`
- documents plugin SDK usage, named socket bindings, and the current presign limitation for plugin-scoped S3 bindings
- adds custom-provider implementation notes for source preconditions, range/error mapping, presign headers, and large-object behavior

## Validation
- `cd docs && npm ci`
- `cd docs && npm run build`
