### PR TITLE
docs: replace remaining secret:// examples in S3 docs

### DIFF
--- a/docs/content/configuration.mdx
+++ b/docs/content/configuration.mdx
@@ -145,7 +145,10 @@ providers:
         region: us-east-1
         endpoint: https://s3.us-east-1.amazonaws.com
         accessKeyId: ${AWS_ACCESS_KEY_ID}
-        secretAccessKey: secret://aws-secret-access-key
+        secretAccessKey:
+          secret:
+            provider: default
+            name: aws-secret-access-key
 
 plugins:
   media:

--- a/docs/content/providers/index.mdx
+++ b/docs/content/providers/index.mdx
@@ -99,7 +99,10 @@ providers:
         endpoint: http://127.0.0.1:9000
         region: us-east-1
         accessKeyId: ${MINIO_ROOT_USER}
-        secretAccessKey: secret://minio-root-password
+        secretAccessKey:
+          secret:
+            provider: default
+            name: minio-root-password
 
 plugins:
   github:

--- a/docs/content/providers/s3.mdx
+++ b/docs/content/providers/s3.mdx
@@ -54,7 +54,10 @@ providers:
         endpoint: https://s3.us-east-1.amazonaws.com
         forcePathStyle: false
         accessKeyId: ${AWS_ACCESS_KEY_ID}
-        secretAccessKey: secret://aws-secret-access-key
+        secretAccessKey:
+          secret:
+            provider: default
+            name: aws-secret-access-key
 
 plugins:
   media:
@@ -92,7 +95,10 @@ providers:
         endpoint: https://storage.googleapis.com
         forcePathStyle: true
         accessKeyId: ${GCS_HMAC_ACCESS_KEY}
-        secretAccessKey: secret://gcs-hmac-secret
+        secretAccessKey:
+          secret:
+            provider: default
+            name: gcs-hmac-secret
 ```
 
 ## Using S3 from a plugin

--- a/docs/content/reference/built-in-providers.mdx
+++ b/docs/content/reference/built-in-providers.mdx
@@ -76,7 +76,10 @@ providers:
         endpoint: https://s3.us-east-1.amazonaws.com
         forcePathStyle: false
         accessKeyId: ${AWS_ACCESS_KEY_ID}
-        secretAccessKey: secret://aws-secret-access-key
+        secretAccessKey:
+          secret:
+            provider: default
+            name: aws-secret-access-key
 
 plugins:
   media:

--- a/docs/content/reference/config-file.mdx
+++ b/docs/content/reference/config-file.mdx
@@ -284,7 +284,10 @@ providers:
         endpoint: http://127.0.0.1:9000
         region: us-east-1
         accessKeyId: ${MINIO_ROOT_USER}
-        secretAccessKey: secret://minio-root-password
+        secretAccessKey:
+          secret:
+            provider: default
+            name: minio-root-password
 plugins:
   media:
     source:


### PR DESCRIPTION
## Summary
This updates the remaining S3-oriented docs examples on `main` that still showed legacy `secret://...` config values.

## YAML Interface
```yaml
secretAccessKey:
  secret:
    provider: default
    name: aws-secret-access-key
```

## Go Interface
- none; docs-only follow-up

## Examples Updated
```yaml
providers:
  s3:
    assets:
      config:
        accessKeyId: ${AWS_ACCESS_KEY_ID}
        secretAccessKey:
          secret:
            provider: default
            name: aws-secret-access-key
```

## Validation
- `rg -n "secret://" docs docs/dockerhub/gestaltd.md` returns no hits in this worktree
- `npm run build` in `docs/` still fails in this shell because `next` is not installed (`sh: next: command not found`)
