### PR TITLE
[codex] fix browser auth callback flow

### DIFF
--- a/docs/content/deploy/helm.mdx
+++ b/docs/content/deploy/helm.mdx
@@ -165,7 +165,7 @@ extraEnv:
         name: gestalt-secrets
         key: oidc-client-secret
   - name: OIDC_REDIRECT_URL
-    value: "https://gestalt.example.com/api/v1/auth/login/callback"
+    value: "https://gestalt.example.com/login/callback"
   - name: DATABASE_URL
     valueFrom:
       secretKeyRef:

--- a/docs/content/reference/config-file.mdx
+++ b/docs/content/reference/config-file.mdx
@@ -138,7 +138,7 @@ providers:
           secret:
             provider: default
             name: google-client-secret
-        redirectUrl: https://gestalt.example.com/api/v1/auth/login/callback
+        redirectUrl: https://gestalt.example.com/login/callback
         allowedDomains:
           - example.com
         sessionTtl: 24h
@@ -164,7 +164,7 @@ providers:
           secret:
             provider: default
             name: oidc-client-secret
-        redirectUrl: https://gestalt.example.com/api/v1/auth/login/callback
+        redirectUrl: https://gestalt.example.com/login/callback
         allowedDomains:
           - example.com
         scopes:

--- a/docs/content/reference/http-api.mdx
+++ b/docs/content/reference/http-api.mdx
@@ -15,9 +15,10 @@ Authenticated routes accept a `session_token` cookie or an `Authorization: Beare
 | `GET` | `/health` | Basic liveness check. |
 | `GET` | `/ready` | Readiness check. Returns `503` until providers and datastore are ready. |
 | `GET` | `/admin` and `/admin/*` | Embedded admin UI shell. When `server.admin.authorizationPolicy` is set, Gestalt requires browser session auth and the configured roles before serving the shell or its assets. On split public/management deployments, configure `server.management.baseUrl` so unauthenticated management `/admin` requests can round-trip through the public login flow and return to the management listener's built-in `/admin` route. Use the same hostname as `server.baseUrl`, and keep both on `https` when the public listener uses `https`, so the session cookie can be reused across listeners. `/admin` still reads same-origin `/metrics`, which remains unauthenticated on the management listener. When `server.baseUrl` is set, the management admin UI links back to that public URL for `Client UI`; otherwise it omits that link. |
+| `GET` | `/login/callback` | Browser-facing platform auth callback page. Configure upstream IdP `redirectUrl` values to use this path. |
 | `GET` | `/api/v1/auth/info` | Returns platform auth metadata, including whether interactive login is supported. |
 | `POST` | `/api/v1/auth/login` | Starts platform login and returns an absolute browser URL. |
-| `GET` | `/api/v1/auth/login/callback` | Completes platform login. |
+| `GET` | `/api/v1/auth/login/callback` | Completes platform login for the browser callback page or CLI, and still accepts legacy direct browser redirects. |
 | `POST` | `/api/v1/auth/logout` | Clears the current platform session. |
 | `GET` | `/api/v1/auth/callback` | Completes plugin OAuth. |
 | `POST` | `/api/v1/auth/pending-connection` | Render or finalize a multi-candidate connection choice using a pending connection token. |

--- a/gestaltd/cmd/gestaltd/plugin_test.go
+++ b/gestaltd/cmd/gestaltd/plugin_test.go
@@ -720,7 +720,7 @@ func TestRun_PluginReleaseBuildsGoSourceAuthPlugin(t *testing.T) {
 	auth, err := providerhost.NewExecutableAuthProvider(context.Background(), providerhost.AuthExecConfig{
 		Command:     filepath.Join(extractDir, binaryName),
 		Name:        "auth-release",
-		CallbackURL: "https://gestalt.example.test/api/v1/auth/login/callback",
+		CallbackURL: "https://gestalt.example.test/login/callback",
 		SessionKey:  []byte("0123456789abcdef0123456789abcdef"),
 	})
 	if err != nil {
@@ -892,7 +892,7 @@ func TestRun_PluginReleaseBuildsRustSourceAuthPlugin(t *testing.T) {
 	auth, err := providerhost.NewExecutableAuthProvider(context.Background(), providerhost.AuthExecConfig{
 		Command:     filepath.Join(extractDir, binaryName),
 		Name:        "auth-release",
-		CallbackURL: "https://gestalt.example.test/api/v1/auth/login/callback",
+		CallbackURL: "https://gestalt.example.test/login/callback",
 		SessionKey:  []byte("0123456789abcdef0123456789abcdef"),
 	})
 	if err != nil {
@@ -989,7 +989,7 @@ func TestRun_PluginReleaseBuildsPythonSourceAuthPlugin(t *testing.T) {
 	auth, err := providerhost.NewExecutableAuthProvider(context.Background(), providerhost.AuthExecConfig{
 		Command:     filepath.Join(extractDir, binaryName),
 		Name:        pythonAuthReleasePluginName,
-		CallbackURL: "https://gestalt.example.test/api/v1/auth/login/callback",
+		CallbackURL: "https://gestalt.example.test/login/callback",
 		SessionKey:  []byte("0123456789abcdef0123456789abcdef"),
 	})
 	if err != nil {
@@ -1078,7 +1078,7 @@ func TestRun_PluginReleaseBuildsTypeScriptSourceAuthPlugin(t *testing.T) {
 	auth, err := providerhost.NewExecutableAuthProvider(context.Background(), providerhost.AuthExecConfig{
 		Command:     filepath.Join(extractDir, binaryName),
 		Name:        authReleasePluginName,
-		CallbackURL: "https://gestalt.example.test/api/v1/auth/login/callback",
+		CallbackURL: "https://gestalt.example.test/login/callback",
 		SessionKey:  []byte("0123456789abcdef0123456789abcdef"),
 	})
 	if err != nil {

--- a/gestaltd/cmd/gestaltd/run.go
+++ b/gestaltd/cmd/gestaltd/run.go
@@ -126,6 +126,7 @@ func runServer(env *bootstrapEnv) error {
 	if env.Config.Server.BaseURL != "" {
 		slog.Info("gestaltd base URL configured",
 			"base_url", env.Config.Server.BaseURL,
+			"browser_auth_callback", env.Config.Server.BaseURL+config.BrowserAuthCallbackPath,
 			"auth_callback", env.Config.Server.BaseURL+config.AuthCallbackPath,
 			"integration_callback", env.Config.Server.BaseURL+config.IntegrationCallbackPath,
 		)

--- a/gestaltd/internal/config/config.go
+++ b/gestaltd/internal/config/config.go
@@ -22,6 +22,7 @@ import (
 
 // Callback paths must match the routes registered in server.go.
 const (
+	BrowserAuthCallbackPath = "/login/callback"
 	AuthCallbackPath        = "/api/v1/auth/login/callback"
 	IntegrationCallbackPath = "/api/v1/auth/callback"
 )

--- a/gestaltd/internal/config/config_validate.go
+++ b/gestaltd/internal/config/config_validate.go
@@ -696,6 +696,7 @@ func validateMountedUICollisions(cfg *Config, pluginOwnedUIRefs map[string]struc
 	reserved := []string{
 		"/api",
 		"/api/v1",
+		BrowserAuthCallbackPath,
 		AuthCallbackPath,
 		IntegrationCallbackPath,
 		"/mcp",

--- a/gestaltd/internal/drivers/auth/provider/factory.go
+++ b/gestaltd/internal/drivers/auth/provider/factory.go
@@ -36,7 +36,7 @@ var Factory bootstrap.AuthFactory = func(node yaml.Node, deps bootstrap.Deps) (c
 
 	callbackURL := cfg.CallbackURL
 	if callbackURL == "" && deps.BaseURL != "" {
-		callbackURL = deps.BaseURL + config.AuthCallbackPath
+		callbackURL = deps.BaseURL + config.BrowserAuthCallbackPath
 	}
 	return providerhost.NewExecutableAuthProvider(context.Background(), providerhost.AuthExecConfig{
 		Command:      cfg.Command,

--- a/gestaltd/internal/server/handlers_auth.go
+++ b/gestaltd/internal/server/handlers_auth.go
@@ -356,8 +356,12 @@ func (s *Server) loginCallback(w http.ResponseWriter, r *http.Request) {
 	auditAllowed := false
 	auditErr := errors.New("login callback failed")
 	auditUserID := ""
+	deferredToBrowserCallback := false
 	providerName := s.authProviderName()
 	defer func() {
+		if deferredToBrowserCallback {
+			return
+		}
 		metricutil.RecordAuthMetrics(r.Context(), startedAt, providerName, "complete_login", auditErr != nil)
 		if auditUserID != "" {
 			s.auditHTTPEventWithUserID(r.Context(), auditUserID, principal.SourceSession.String(), s.authProviderName(), "auth.login.complete", auditAllowed, auditErr)
@@ -375,6 +379,11 @@ func (s *Server) loginCallback(w http.ResponseWriter, r *http.Request) {
 	if !s.authEnabled() {
 		auditErr = errors.New("auth is disabled")
 		writeError(w, http.StatusNotFound, "auth is disabled")
+		return
+	}
+	if s.shouldRedirectLegacyBrowserLoginCallback(r) {
+		deferredToBrowserCallback = true
+		http.Redirect(w, r, browserCallbackRedirectLocation(r), http.StatusFound)
 		return
 	}
 
@@ -463,8 +472,11 @@ func (s *Server) loginCallback(w http.ResponseWriter, r *http.Request) {
 	auditAllowed = true
 	auditErr = nil
 	if loginState != nil && loginState.NextPath != "" {
-		http.Redirect(w, r, loginState.NextPath, http.StatusFound)
-		return
+		if isBrowserDocumentRequest(r) {
+			http.Redirect(w, r, loginState.NextPath, http.StatusFound)
+			return
+		}
+		resp["nextPath"] = loginState.NextPath
 	}
 	writeJSON(w, http.StatusOK, resp)
 }

--- a/gestaltd/internal/server/handlers_browser_auth.go
+++ b/gestaltd/internal/server/handlers_browser_auth.go
@@ -1,0 +1,219 @@
+package server
+
+import (
+	"fmt"
+	"net/http"
+	"strings"
+
+	"github.com/valon-technologies/gestalt/server/internal/config"
+)
+
+const browserLoginCallbackHTMLTemplate = `<!doctype html>
+<html lang="en">
+<head>
+  <meta charset="utf-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1">
+  <title>Completing login...</title>
+  <style>
+    :root { color-scheme: light dark; }
+    body {
+      margin: 0;
+      font-family: ui-sans-serif, system-ui, -apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif;
+      background: #f5f5f2;
+      color: #111827;
+    }
+    main {
+      min-height: 100vh;
+      display: flex;
+      align-items: center;
+      justify-content: center;
+      padding: 24px;
+    }
+    .card {
+      width: min(420px, 100%);
+      background: rgba(255, 255, 255, 0.96);
+      border: 1px solid rgba(17, 24, 39, 0.08);
+      border-radius: 16px;
+      box-shadow: 0 12px 32px rgba(17, 24, 39, 0.08);
+      padding: 24px;
+    }
+    h1 {
+      margin: 0 0 8px;
+      font-size: 20px;
+    }
+    p {
+      margin: 0;
+      line-height: 1.5;
+      color: #4b5563;
+    }
+    .error {
+      color: #b91c1c;
+    }
+    @media (prefers-color-scheme: dark) {
+      body { background: #0f172a; color: #f8fafc; }
+      .card {
+        background: rgba(15, 23, 42, 0.94);
+        border-color: rgba(148, 163, 184, 0.18);
+        box-shadow: 0 16px 40px rgba(2, 6, 23, 0.4);
+      }
+      p { color: #cbd5e1; }
+      .error { color: #fca5a5; }
+    }
+  </style>
+</head>
+<body>
+  <main>
+    <section class="card">
+      <h1 id="title">Completing login...</h1>
+      <p id="message">Finishing authentication.</p>
+    </section>
+  </main>
+  <script>
+    (async function () {
+      const title = document.getElementById("title");
+      const message = document.getElementById("message");
+      const params = new URLSearchParams(window.location.search);
+      const code = params.get("code");
+      const rawState = params.get("state") || "";
+
+      function fail(text) {
+        title.textContent = "Login failed";
+        message.textContent = text;
+        message.className = "error";
+      }
+
+      function decodeHostState(raw) {
+        if (!raw) return raw;
+        try {
+          const base64 = raw.replace(/-/g, "+").replace(/_/g, "/");
+          const padded = base64.padEnd(Math.ceil(base64.length / 4) * 4, "=");
+          const decoded = atob(padded);
+          const bytes = Uint8Array.from(decoded, ch => ch.charCodeAt(0));
+          const payload = JSON.parse(new TextDecoder().decode(bytes));
+          if (payload && typeof payload.host_state === "string" && payload.host_state.length > 0) {
+            return payload.host_state;
+          }
+        } catch (_) {}
+        return raw;
+      }
+
+      function cliCallbackURL(hostState, authCode) {
+        if (!hostState || !hostState.startsWith("cli:")) return null;
+        const parts = hostState.split(":");
+        const port = Number(parts[1]);
+        const originalState = parts.slice(2).join(":");
+        if (!Number.isInteger(port) || port < 1 || port > 65535 || !originalState) return null;
+        const query = new URLSearchParams({ code: authCode, state: originalState });
+        return "http://127.0.0.1:" + port + "/?" + query.toString();
+      }
+
+      if (!code) {
+        fail("Missing authorization code");
+        return;
+      }
+
+      const hostState = decodeHostState(rawState);
+      const cliURL = cliCallbackURL(hostState, code);
+      if (cliURL) {
+        window.location.replace(cliURL);
+        return;
+      }
+
+      const storedState = sessionStorage.getItem("oauth_state");
+      if (!storedState || hostState !== storedState) {
+        fail("Invalid OAuth state — possible CSRF attack");
+        return;
+      }
+      sessionStorage.removeItem("oauth_state");
+
+      try {
+        const response = await fetch("__AUTH_CALLBACK_PATH__?" + params.toString(), {
+          credentials: "include",
+          headers: { "Accept": "application/json" },
+        });
+        const text = await response.text();
+        let payload = {};
+        try {
+          payload = text ? JSON.parse(text) : {};
+        } catch (_) {
+          throw new Error(text || "Login failed");
+        }
+        if (!response.ok) {
+          throw new Error(payload.error || text || "Login failed");
+        }
+        if (typeof payload.email === "string" && payload.email.length > 0) {
+          localStorage.setItem("user_email", payload.email);
+        }
+        const nextPath = typeof payload.nextPath === "string" && payload.nextPath.length > 0 ? payload.nextPath : "/";
+        window.location.replace(nextPath);
+      } catch (err) {
+        fail(err instanceof Error ? err.message : "Login failed");
+      }
+    })();
+  </script>
+</body>
+</html>
+`
+
+var browserLoginCallbackHTML = strings.ReplaceAll(
+	browserLoginCallbackHTMLTemplate,
+	"__AUTH_CALLBACK_PATH__",
+	config.AuthCallbackPath,
+)
+
+func (s *Server) browserLoginCallbackPage(w http.ResponseWriter, _ *http.Request) {
+	w.Header().Set("Content-Type", "text/html; charset=utf-8")
+	w.Header().Set("Cache-Control", "no-store")
+	_, _ = w.Write([]byte(browserLoginCallbackHTML))
+}
+
+func isBrowserDocumentRequest(r *http.Request) bool {
+	if strings.EqualFold(strings.TrimSpace(r.Header.Get("Sec-Fetch-Mode")), "navigate") {
+		return true
+	}
+	if strings.EqualFold(strings.TrimSpace(r.Header.Get("Sec-Fetch-Dest")), "document") {
+		return true
+	}
+	return strings.Contains(strings.ToLower(r.Header.Get("Accept")), "text/html")
+}
+
+func (s *Server) pendingLoginState(r *http.Request) (*loginState, bool) {
+	if s.encryptor == nil {
+		return nil, false
+	}
+	cookie, err := r.Cookie(loginStateCookieName)
+	if err != nil {
+		return nil, false
+	}
+	state, err := decodeLoginState(s.encryptor, cookie.Value, s.now())
+	if err != nil {
+		return nil, false
+	}
+	return state, true
+}
+
+func (s *Server) shouldRedirectLegacyBrowserLoginCallback(r *http.Request) bool {
+	if r.URL.Query().Get("cli") == "1" || !isBrowserDocumentRequest(r) {
+		return false
+	}
+	if pending, ok := s.pendingLoginState(r); ok && pending.NextPath != "" {
+		return false
+	}
+	return true
+}
+
+func browserCallbackRedirectLocation(r *http.Request) string {
+	target := config.BrowserAuthCallbackPath
+	if rawQuery := strings.TrimSpace(r.URL.RawQuery); rawQuery != "" {
+		target += "?" + rawQuery
+	}
+	return target
+}
+
+func browserLoginCallbackPathForBase(baseURL string) string {
+	baseURL = strings.TrimRight(baseURL, "/")
+	if baseURL == "" {
+		return config.BrowserAuthCallbackPath
+	}
+	return fmt.Sprintf("%s%s", baseURL, config.BrowserAuthCallbackPath)
+}

--- a/gestaltd/internal/server/handlers_browser_auth.go
+++ b/gestaltd/internal/server/handlers_browser_auth.go
@@ -1,7 +1,6 @@
 package server
 
 import (
-	"fmt"
 	"net/http"
 	"strings"
 
@@ -208,12 +207,4 @@ func browserCallbackRedirectLocation(r *http.Request) string {
 		target += "?" + rawQuery
 	}
 	return target
-}
-
-func browserLoginCallbackPathForBase(baseURL string) string {
-	baseURL = strings.TrimRight(baseURL, "/")
-	if baseURL == "" {
-		return config.BrowserAuthCallbackPath
-	}
-	return fmt.Sprintf("%s%s", baseURL, config.BrowserAuthCallbackPath)
 }

--- a/gestaltd/internal/server/routes.go
+++ b/gestaltd/internal/server/routes.go
@@ -6,6 +6,7 @@ import (
 
 	"github.com/go-chi/chi/v5"
 	"github.com/go-chi/chi/v5/middleware"
+	"github.com/valon-technologies/gestalt/server/internal/config"
 )
 
 func (s *Server) routes() {
@@ -45,6 +46,7 @@ const (
 func (s *Server) mountCoreRoutes(r chi.Router, exposure metricsExposure) {
 	r.Get("/health", s.healthCheck)
 	r.Get("/ready", s.readinessCheck)
+	r.Get(config.BrowserAuthCallbackPath, s.browserLoginCallbackPage)
 	switch exposure {
 	case metricsAuthenticated:
 		r.Group(func(r chi.Router) {

--- a/gestaltd/internal/server/server_test.go
+++ b/gestaltd/internal/server/server_test.go
@@ -1031,7 +1031,9 @@ func TestBuiltInAdminRoute_HumanAuthorizationSplitManagementLoginFlow(t *testing
 		t.Fatalf("parse start login redirect: %v", err)
 	}
 
-	callbackResp, err := client.Get(publicURL + "/api/v1/auth/login/callback?code=good-code&state=" + url.QueryEscape(loginURL.Query().Get("state")))
+	callbackReq, _ := http.NewRequest(http.MethodGet, publicURL+"/api/v1/auth/login/callback?code=good-code&state="+url.QueryEscape(loginURL.Query().Get("state")), nil)
+	callbackReq.Header.Set("Accept", "text/html")
+	callbackResp, err := client.Do(callbackReq)
 	if err != nil {
 		t.Fatalf("GET browser login callback: %v", err)
 	}
@@ -6105,6 +6107,54 @@ func TestLoginCallback(t *testing.T) {
 	}
 }
 
+func TestLoginCallback_BrowserNavigationRedirectsToBrowserCallbackPage(t *testing.T) {
+	t.Parallel()
+
+	ts := newTestServer(t, func(cfg *server.Config) {
+		cfg.Auth = &coretesting.StubAuthProvider{
+			N: "test",
+			HandleCallbackFn: func(_ context.Context, code string) (*core.UserIdentity, error) {
+				if code == "good-code" {
+					return &core.UserIdentity{Email: "user@example.com", DisplayName: "User"}, nil
+				}
+				return nil, fmt.Errorf("bad code")
+			},
+		}
+		cfg.Services = coretesting.NewStubServices(t)
+	})
+	testutil.CloseOnCleanup(t, ts)
+
+	jar, _ := cookiejar.New(nil)
+	client := &http.Client{
+		Jar: jar,
+		CheckRedirect: func(_ *http.Request, _ []*http.Request) error {
+			return http.ErrUseLastResponse
+		},
+	}
+
+	body := bytes.NewBufferString(`{"state":"test-state"}`)
+	loginResp, err := client.Post(ts.URL+"/api/v1/auth/login", "application/json", body)
+	if err != nil {
+		t.Fatalf("start login: %v", err)
+	}
+	_ = loginResp.Body.Close()
+
+	req, _ := http.NewRequest(http.MethodGet, ts.URL+"/api/v1/auth/login/callback?code=good-code&state=test-state", nil)
+	req.Header.Set("Accept", "text/html")
+	resp, err := client.Do(req)
+	if err != nil {
+		t.Fatalf("callback request: %v", err)
+	}
+	defer func() { _ = resp.Body.Close() }()
+
+	if resp.StatusCode != http.StatusFound {
+		t.Fatalf("expected 302, got %d", resp.StatusCode)
+	}
+	if got, want := resp.Header.Get("Location"), config.BrowserAuthCallbackPath+"?code=good-code&state=test-state"; got != want {
+		t.Fatalf("redirect location = %q, want %q", got, want)
+	}
+}
+
 func TestLoginCallbackForCLI(t *testing.T) {
 	t.Parallel()
 
@@ -6211,6 +6261,62 @@ func TestLoginCallbackForCLI(t *testing.T) {
 	}
 	if loginAudit["operation"] != "auth.login.complete" {
 		t.Fatalf("expected auth.login.complete audit operation, got %v", loginAudit["operation"])
+	}
+}
+
+func TestLoginCallback_FetchIncludesNextPath(t *testing.T) {
+	t.Parallel()
+
+	secret := []byte("0123456789abcdef0123456789abcdef")
+	auth := &stubHostIssuedSessionAuth{secret: secret}
+	jar, err := cookiejar.New(nil)
+	if err != nil {
+		t.Fatalf("cookiejar.New: %v", err)
+	}
+	client := &http.Client{
+		Jar: jar,
+		CheckRedirect: func(_ *http.Request, _ []*http.Request) error {
+			return http.ErrUseLastResponse
+		},
+	}
+
+	ts := newTestServer(t, func(cfg *server.Config) {
+		cfg.Auth = auth
+		cfg.StateSecret = secret
+		cfg.Services = coretesting.NewStubServices(t)
+	})
+	testutil.CloseOnCleanup(t, ts)
+
+	startResp, err := client.Get(ts.URL + "/api/v1/auth/login?next=" + url.QueryEscape("/sample-portal/sync?code=invite-code&state=abc123"))
+	if err != nil {
+		t.Fatalf("start browser login: %v", err)
+	}
+	defer func() { _ = startResp.Body.Close() }()
+	if startResp.StatusCode != http.StatusFound {
+		t.Fatalf("start status = %d, want %d", startResp.StatusCode, http.StatusFound)
+	}
+	loginURL, err := url.Parse(startResp.Header.Get("Location"))
+	if err != nil {
+		t.Fatalf("parse start login redirect: %v", err)
+	}
+
+	req, _ := http.NewRequest(http.MethodGet, ts.URL+"/api/v1/auth/login/callback?code=good-code&state="+url.QueryEscape(loginURL.Query().Get("state")), nil)
+	req.Header.Set("Accept", "application/json")
+	callbackResp, err := client.Do(req)
+	if err != nil {
+		t.Fatalf("fetch callback: %v", err)
+	}
+	defer func() { _ = callbackResp.Body.Close() }()
+	if callbackResp.StatusCode != http.StatusOK {
+		t.Fatalf("callback status = %d, want %d", callbackResp.StatusCode, http.StatusOK)
+	}
+
+	var result map[string]any
+	if err := json.NewDecoder(callbackResp.Body).Decode(&result); err != nil {
+		t.Fatalf("decode callback response: %v", err)
+	}
+	if got, want := result["nextPath"], "/sample-portal/sync?code=invite-code&state=abc123"; got != want {
+		t.Fatalf("nextPath = %v, want %q", got, want)
 	}
 }
 
@@ -7514,6 +7620,22 @@ func TestCallbackPathConstants(t *testing.T) {
 	_ = resp.Body.Close()
 	if resp.StatusCode == http.StatusNotFound {
 		t.Errorf("config.AuthCallbackPath %q is not a registered route (got 404)", config.AuthCallbackPath)
+	}
+
+	resp, err = http.Get(ts.URL + config.BrowserAuthCallbackPath)
+	if err != nil {
+		t.Fatalf("GET %s: %v", config.BrowserAuthCallbackPath, err)
+	}
+	body, readErr := io.ReadAll(resp.Body)
+	_ = resp.Body.Close()
+	if readErr != nil {
+		t.Fatalf("ReadAll %s: %v", config.BrowserAuthCallbackPath, readErr)
+	}
+	if resp.StatusCode == http.StatusNotFound {
+		t.Errorf("config.BrowserAuthCallbackPath %q is not a registered route (got 404)", config.BrowserAuthCallbackPath)
+	}
+	if !strings.Contains(string(body), config.AuthCallbackPath) {
+		t.Fatalf("browser callback page missing auth callback path %q", config.AuthCallbackPath)
 	}
 
 	// Integration callback: should be public and return 400 for missing params,
@@ -10161,7 +10283,9 @@ func TestBrowserLoginRedirect_RedirectsBackToNextPath(t *testing.T) {
 				t.Fatalf("login redirect state = %q, want %q", got, tc.wantState)
 			}
 
-			callbackResp, err := client.Get(ts.URL + "/api/v1/auth/login/callback?code=good-code&state=" + url.QueryEscape(loginURL.Query().Get("state")))
+			callbackReq, _ := http.NewRequest(http.MethodGet, ts.URL+"/api/v1/auth/login/callback?code=good-code&state="+url.QueryEscape(loginURL.Query().Get("state")), nil)
+			callbackReq.Header.Set("Accept", "text/html")
+			callbackResp, err := client.Do(callbackReq)
 			if err != nil {
 				t.Fatalf("browser login callback: %v", err)
 			}


### PR DESCRIPTION
## Summary
This fixes the browser login regression where users could be redirected to the raw `/api/v1/auth/login/callback` endpoint and see JSON instead of returning to the UI.

## Root Cause
Platform auth was still using the internal API callback path as the browser-facing OAuth redirect target. That worked for CLI and internal completion flows, but it bypassed the web UI's callback handling and surfaced the JSON response directly in the browser.

## What Changed
- added a public `/login/callback` browser callback bridge page
- changed the default auth provider redirect URL to use `/login/callback`
- kept `/api/v1/auth/login/callback` as the internal completion endpoint for the browser bridge and CLI
- redirected legacy direct browser hits on the API callback path over to the browser callback page
- returned `nextPath` in JSON callback responses so the browser bridge can complete login and navigate correctly
- reserved the new callback path in server config validation
- updated docs and release tests to reflect the browser callback path

## Impact
Browser logins now return to the UI instead of rendering raw callback JSON. Existing deployments that still point their IdP redirect URL at `/api/v1/auth/login/callback` remain backward-compatible for browser logins, while new/default configs now point at `/login/callback`.

## Validation
- `go test ./internal/server ./cmd/gestaltd ./internal/config`
