### PR TITLE
Canonicalize human email identity resolution

### DIFF
--- a/gestaltd/internal/authorization/authorizer.go
+++ b/gestaltd/internal/authorization/authorizer.go
@@ -8,6 +8,7 @@ import (
 	"github.com/valon-technologies/gestalt/server/core"
 	"github.com/valon-technologies/gestalt/server/core/catalog"
 	"github.com/valon-technologies/gestalt/server/internal/config"
+	"github.com/valon-technologies/gestalt/server/internal/emailutil"
 	"github.com/valon-technologies/gestalt/server/internal/principal"
 	"github.com/valon-technologies/gestalt/server/internal/registry"
 	providermanifestv1 "github.com/valon-technologies/gestalt/server/sdk/providermanifest/v1"
@@ -344,7 +345,7 @@ func normalizeAllowedOperations(ops []string) map[string]struct{} {
 }
 
 func normalizeEmail(email string) string {
-	return strings.ToLower(strings.TrimSpace(email))
+	return emailutil.Normalize(email)
 }
 
 func providerMode(provider string, pluginDefs map[string]*config.ProviderEntry, providers *registry.ProviderMap[core.Provider]) (core.ConnectionMode, bool, error) {

--- a/gestaltd/internal/config/config_validate.go
+++ b/gestaltd/internal/config/config_validate.go
@@ -10,6 +10,7 @@ import (
 	"strconv"
 	"strings"
 
+	"github.com/valon-technologies/gestalt/server/internal/emailutil"
 	"github.com/valon-technologies/gestalt/server/internal/pluginsource"
 	"github.com/valon-technologies/gestalt/server/internal/providerenv"
 	"github.com/valon-technologies/gestalt/server/internal/providerpkg"
@@ -438,7 +439,7 @@ func validateAuthorizationPolicies(cfg *Config) error {
 		seenEmails := make(map[string]int, len(policy.Members))
 		for i, member := range policy.Members {
 			subjectID := strings.TrimSpace(member.SubjectID)
-			email := strings.ToLower(strings.TrimSpace(member.Email))
+			email := emailutil.Normalize(member.Email)
 			role := strings.TrimSpace(member.Role)
 			switch {
 			case role == "":

--- a/gestaltd/internal/coredata/records.go
+++ b/gestaltd/internal/coredata/records.go
@@ -1,0 +1,14 @@
+package coredata
+
+import "github.com/valon-technologies/gestalt/server/core/indexeddb"
+
+func cloneRecord(rec indexeddb.Record) indexeddb.Record {
+	if rec == nil {
+		return nil
+	}
+	clone := make(indexeddb.Record, len(rec))
+	for key, value := range rec {
+		clone[key] = value
+	}
+	return clone
+}

--- a/gestaltd/internal/coredata/schemas.go
+++ b/gestaltd/internal/coredata/schemas.go
@@ -11,10 +11,12 @@ const (
 var UsersSchema = indexeddb.ObjectStoreSchema{
 	Indexes: []indexeddb.IndexSchema{
 		{Name: "by_email", KeyPath: []string{"email"}, Unique: true},
+		{Name: "by_normalized_email", KeyPath: []string{"normalized_email"}},
 	},
 	Columns: []indexeddb.ColumnDef{
 		{Name: "id", Type: indexeddb.TypeString, PrimaryKey: true},
 		{Name: "email", Type: indexeddb.TypeString, NotNull: true, Unique: true},
+		{Name: "normalized_email", Type: indexeddb.TypeString},
 		{Name: "display_name", Type: indexeddb.TypeString},
 		{Name: "created_at", Type: indexeddb.TypeTime},
 		{Name: "updated_at", Type: indexeddb.TypeTime},

--- a/gestaltd/internal/coredata/services.go
+++ b/gestaltd/internal/coredata/services.go
@@ -26,8 +26,12 @@ func New(ds indexeddb.IndexedDB, enc *corecrypto.AESGCMEncryptor) (*Services, er
 	if err := ds.CreateObjectStore(ctx, StoreAPITokens, APITokensSchema); err != nil {
 		return nil, fmt.Errorf("create api_tokens store: %w", err)
 	}
+	users := NewUserService(ds)
+	if err := users.BackfillNormalizedEmails(ctx); err != nil {
+		return nil, fmt.Errorf("backfill users store: %w", err)
+	}
 	return &Services{
-		Users:     NewUserService(ds),
+		Users:     users,
 		Tokens:    NewTokenService(ds, enc),
 		APITokens: NewAPITokenService(ds),
 		DB:        ds,

--- a/gestaltd/internal/coredata/services_test.go
+++ b/gestaltd/internal/coredata/services_test.go
@@ -13,6 +13,7 @@ import (
 	"github.com/valon-technologies/gestalt/server/core/indexeddb"
 	coretesting "github.com/valon-technologies/gestalt/server/core/testing"
 	"github.com/valon-technologies/gestalt/server/internal/coredata"
+	"github.com/valon-technologies/gestalt/server/internal/emailutil"
 )
 
 const testEncryptionKey = "0123456789abcdef0123456789abcdef"
@@ -45,6 +46,128 @@ func mustCreateUser(t *testing.T, svc *coredata.Services, email string) *core.Us
 	return user
 }
 
+func seedLegacyUserRecord(t *testing.T, svc *coredata.Services, id, email string, createdAt time.Time) *core.User {
+	t.Helper()
+	ctx := context.Background()
+	rec := indexeddb.Record{
+		"id":               id,
+		"email":            email,
+		"normalized_email": emailutil.Normalize(email),
+		"display_name":     "",
+		"created_at":       createdAt,
+		"updated_at":       createdAt,
+	}
+	if err := svc.DB.ObjectStore(coredata.StoreUsers).Add(ctx, rec); err != nil {
+		t.Fatalf("seedLegacyUserRecord: %v", err)
+	}
+	return &core.User{
+		ID:          id,
+		Email:       email,
+		DisplayName: "",
+		CreatedAt:   createdAt,
+		UpdatedAt:   createdAt,
+	}
+}
+
+type countingIndexedDB struct {
+	inner        indexeddb.IndexedDB
+	mu           sync.Mutex
+	getAllCounts map[string]int
+}
+
+func newCountingIndexedDB(inner indexeddb.IndexedDB) *countingIndexedDB {
+	return &countingIndexedDB{
+		inner:        inner,
+		getAllCounts: make(map[string]int),
+	}
+}
+
+func (d *countingIndexedDB) ObjectStore(name string) indexeddb.ObjectStore {
+	return &countingObjectStore{name: name, db: d, inner: d.inner.ObjectStore(name)}
+}
+
+func (d *countingIndexedDB) CreateObjectStore(ctx context.Context, name string, schema indexeddb.ObjectStoreSchema) error {
+	return d.inner.CreateObjectStore(ctx, name, schema)
+}
+
+func (d *countingIndexedDB) DeleteObjectStore(ctx context.Context, name string) error {
+	return d.inner.DeleteObjectStore(ctx, name)
+}
+
+func (d *countingIndexedDB) Ping(ctx context.Context) error { return d.inner.Ping(ctx) }
+func (d *countingIndexedDB) Close() error                   { return d.inner.Close() }
+
+func (d *countingIndexedDB) recordGetAll(name string) {
+	d.mu.Lock()
+	defer d.mu.Unlock()
+	d.getAllCounts[name]++
+}
+
+func (d *countingIndexedDB) getAllCount(name string) int {
+	d.mu.Lock()
+	defer d.mu.Unlock()
+	return d.getAllCounts[name]
+}
+
+type countingObjectStore struct {
+	name  string
+	db    *countingIndexedDB
+	inner indexeddb.ObjectStore
+}
+
+func (o *countingObjectStore) Get(ctx context.Context, id string) (indexeddb.Record, error) {
+	return o.inner.Get(ctx, id)
+}
+
+func (o *countingObjectStore) GetKey(ctx context.Context, id string) (string, error) {
+	return o.inner.GetKey(ctx, id)
+}
+
+func (o *countingObjectStore) Add(ctx context.Context, record indexeddb.Record) error {
+	return o.inner.Add(ctx, record)
+}
+
+func (o *countingObjectStore) Put(ctx context.Context, record indexeddb.Record) error {
+	return o.inner.Put(ctx, record)
+}
+
+func (o *countingObjectStore) Delete(ctx context.Context, id string) error {
+	return o.inner.Delete(ctx, id)
+}
+
+func (o *countingObjectStore) Clear(ctx context.Context) error {
+	return o.inner.Clear(ctx)
+}
+
+func (o *countingObjectStore) GetAll(ctx context.Context, r *indexeddb.KeyRange) ([]indexeddb.Record, error) {
+	o.db.recordGetAll(o.name)
+	return o.inner.GetAll(ctx, r)
+}
+
+func (o *countingObjectStore) GetAllKeys(ctx context.Context, r *indexeddb.KeyRange) ([]string, error) {
+	return o.inner.GetAllKeys(ctx, r)
+}
+
+func (o *countingObjectStore) Count(ctx context.Context, r *indexeddb.KeyRange) (int64, error) {
+	return o.inner.Count(ctx, r)
+}
+
+func (o *countingObjectStore) DeleteRange(ctx context.Context, r indexeddb.KeyRange) (int64, error) {
+	return o.inner.DeleteRange(ctx, r)
+}
+
+func (o *countingObjectStore) Index(name string) indexeddb.Index {
+	return o.inner.Index(name)
+}
+
+func (o *countingObjectStore) OpenCursor(ctx context.Context, r *indexeddb.KeyRange, dir indexeddb.CursorDirection) (indexeddb.Cursor, error) {
+	return o.inner.OpenCursor(ctx, r, dir)
+}
+
+func (o *countingObjectStore) OpenKeyCursor(ctx context.Context, r *indexeddb.KeyRange, dir indexeddb.CursorDirection) (indexeddb.Cursor, error) {
+	return o.inner.OpenKeyCursor(ctx, r, dir)
+}
+
 func TestNew(t *testing.T) {
 	t.Parallel()
 
@@ -60,6 +183,41 @@ func TestNew(t *testing.T) {
 		}
 		if _, err := coredata.New(db, enc); err != nil {
 			t.Fatalf("second New: %v", err)
+		}
+	})
+
+	t.Run("backfills_normalized_email_for_legacy_users", func(t *testing.T) {
+		t.Parallel()
+
+		db := &coretesting.StubIndexedDB{}
+		ctx := context.Background()
+		createdAt := time.Date(2026, 1, 1, 12, 0, 0, 0, time.UTC)
+		legacy := indexeddb.Record{
+			"id":           "legacy-user",
+			"email":        "User@Example.com",
+			"display_name": "",
+			"created_at":   createdAt,
+			"updated_at":   createdAt,
+		}
+		if err := db.ObjectStore(coredata.StoreUsers).Add(ctx, legacy); err != nil {
+			t.Fatalf("seed legacy user: %v", err)
+		}
+
+		enc, err := corecrypto.NewAESGCM([]byte(testEncryptionKey))
+		if err != nil {
+			t.Fatalf("NewAESGCM: %v", err)
+		}
+		svc, err := coredata.New(db, enc)
+		if err != nil {
+			t.Fatalf("coredata.New: %v", err)
+		}
+
+		raw, err := svc.DB.ObjectStore(coredata.StoreUsers).Get(ctx, "legacy-user")
+		if err != nil {
+			t.Fatalf("Get legacy user: %v", err)
+		}
+		if got := raw["normalized_email"]; got != "user@example.com" {
+			t.Fatalf("normalized_email = %v, want %q", got, "user@example.com")
 		}
 	})
 }
@@ -115,6 +273,32 @@ func TestUserService(t *testing.T) {
 		}
 	})
 
+	t.Run("FindOrCreateUser_creates_new_without_full_table_scan", func(t *testing.T) {
+		t.Parallel()
+
+		db := newCountingIndexedDB(&coretesting.StubIndexedDB{})
+		enc, err := corecrypto.NewAESGCM([]byte(testEncryptionKey))
+		if err != nil {
+			t.Fatalf("NewAESGCM: %v", err)
+		}
+		svc, err := coredata.New(db, enc)
+		if err != nil {
+			t.Fatalf("coredata.New: %v", err)
+		}
+
+		before := db.getAllCount(coredata.StoreUsers)
+		user, err := svc.Users.FindOrCreateUser(context.Background(), "New@Example.com")
+		if err != nil {
+			t.Fatalf("FindOrCreateUser: %v", err)
+		}
+		if got := db.getAllCount(coredata.StoreUsers); got != before {
+			t.Fatalf("users GetAll count = %d, want %d", got, before)
+		}
+		if user.Email != "new@example.com" {
+			t.Fatalf("Email = %q, want %q", user.Email, "new@example.com")
+		}
+	})
+
 	t.Run("FindOrCreateUser_idempotent", func(t *testing.T) {
 		t.Parallel()
 		svc := newTestServices(t)
@@ -130,6 +314,45 @@ func TestUserService(t *testing.T) {
 		}
 		if u1.ID != u2.ID {
 			t.Errorf("not idempotent: first ID %q, second ID %q", u1.ID, u2.ID)
+		}
+	})
+
+	t.Run("FindOrCreateUser_prefers_canonical_row_over_raw_case_duplicate", func(t *testing.T) {
+		t.Parallel()
+		svc := newTestServices(t)
+		ctx := context.Background()
+
+		canonical := seedLegacyUserRecord(t, svc, "user-canonical", "user@example.com", time.Date(2026, 1, 1, 12, 0, 0, 0, time.UTC))
+		seedLegacyUserRecord(t, svc, "user-duplicate", "USER@example.com", time.Date(2026, 1, 2, 12, 0, 0, 0, time.UTC))
+
+		user, err := svc.Users.FindOrCreateUser(ctx, "USER@example.com")
+		if err != nil {
+			t.Fatalf("FindOrCreateUser: %v", err)
+		}
+		if user.ID != canonical.ID {
+			t.Fatalf("ID = %q, want canonical %q", user.ID, canonical.ID)
+		}
+		if user.Email != canonical.Email {
+			t.Fatalf("Email = %q, want canonical %q", user.Email, canonical.Email)
+		}
+	})
+
+	t.Run("FindOrCreateUser_canonicalizes_single_legacy_mixed_case_row", func(t *testing.T) {
+		t.Parallel()
+		svc := newTestServices(t)
+		ctx := context.Background()
+
+		legacy := seedLegacyUserRecord(t, svc, "user-legacy", "USER@example.com", time.Date(2026, 1, 1, 12, 0, 0, 0, time.UTC))
+
+		user, err := svc.Users.FindOrCreateUser(ctx, "USER@example.com")
+		if err != nil {
+			t.Fatalf("FindOrCreateUser: %v", err)
+		}
+		if user.ID != legacy.ID {
+			t.Fatalf("ID = %q, want legacy %q", user.ID, legacy.ID)
+		}
+		if user.Email != "user@example.com" {
+			t.Fatalf("Email = %q, want canonical %q", user.Email, "user@example.com")
 		}
 	})
 

--- a/gestaltd/internal/coredata/users.go
+++ b/gestaltd/internal/coredata/users.go
@@ -2,12 +2,15 @@ package coredata
 
 import (
 	"context"
+	"errors"
 	"fmt"
+	"strings"
 	"time"
 
 	"github.com/google/uuid"
 	"github.com/valon-technologies/gestalt/server/core"
 	"github.com/valon-technologies/gestalt/server/core/indexeddb"
+	"github.com/valon-technologies/gestalt/server/internal/emailutil"
 )
 
 type UserService struct {
@@ -16,6 +19,25 @@ type UserService struct {
 
 func NewUserService(ds indexeddb.IndexedDB) *UserService {
 	return &UserService{store: ds.ObjectStore(StoreUsers)}
+}
+
+func (s *UserService) BackfillNormalizedEmails(ctx context.Context) error {
+	recs, err := s.store.GetAll(ctx, nil)
+	if err != nil {
+		return fmt.Errorf("list users: %w", err)
+	}
+	for _, rec := range recs {
+		normalizedEmail := emailutil.Normalize(recString(rec, "email"))
+		if normalizedEmail == "" || recString(rec, "normalized_email") == normalizedEmail {
+			continue
+		}
+		updated := cloneRecord(rec)
+		updated["normalized_email"] = normalizedEmail
+		if err := s.store.Put(ctx, updated); err != nil {
+			return fmt.Errorf("backfill normalized email for user %q: %w", recString(rec, "id"), err)
+		}
+	}
+	return nil
 }
 
 func (s *UserService) GetUser(ctx context.Context, id string) (*core.User, error) {
@@ -30,29 +52,115 @@ func (s *UserService) GetUser(ctx context.Context, id string) (*core.User, error
 }
 
 func (s *UserService) FindOrCreateUser(ctx context.Context, email string) (*core.User, error) {
-	rec, err := s.store.Index("by_email").Get(ctx, email)
-	if err == nil {
-		return recordToUser(rec), nil
+	rawEmail := strings.TrimSpace(email)
+	email = emailutil.Normalize(email)
+	if email == "" {
+		return nil, fmt.Errorf("find user: email is required")
 	}
-	if err != indexeddb.ErrNotFound {
-		return nil, fmt.Errorf("find user: %w", err)
+
+	user, err := s.findUserByNormalizedEmail(ctx, rawEmail, email)
+	switch {
+	case err == nil:
+		return user, nil
+	case !errors.Is(err, core.ErrNotFound):
+		return nil, err
 	}
+
 	now := time.Now()
 	newRec := indexeddb.Record{
-		"id":           uuid.New().String(),
-		"email":        email,
-		"display_name": "",
-		"created_at":   now,
-		"updated_at":   now,
+		"id":               uuid.New().String(),
+		"email":            email,
+		"normalized_email": email,
+		"display_name":     "",
+		"created_at":       now,
+		"updated_at":       now,
 	}
 	if err := s.store.Add(ctx, newRec); err != nil {
-		rec, retryErr := s.store.Index("by_email").Get(ctx, email)
+		user, retryErr := s.findUserByNormalizedEmail(ctx, rawEmail, email)
 		if retryErr != nil {
 			return nil, fmt.Errorf("create user: %w", err)
 		}
-		return recordToUser(rec), nil
+		return user, nil
 	}
 	return recordToUser(newRec), nil
+}
+
+func (s *UserService) findUserByNormalizedEmail(ctx context.Context, rawEmail, normalizedEmail string) (*core.User, error) {
+	recs, err := s.store.Index("by_normalized_email").GetAll(ctx, nil, normalizedEmail)
+	if err != nil {
+		return nil, fmt.Errorf("find user: %w", err)
+	}
+	if len(recs) == 0 {
+		return nil, core.ErrNotFound
+	}
+
+	var canonicalMatch indexeddb.Record
+	var rawMatch indexeddb.Record
+	var fallbackMatch indexeddb.Record
+	for _, rec := range recs {
+		email := strings.TrimSpace(recString(rec, "email"))
+		switch {
+		case email == normalizedEmail:
+			if preferUserRecord(rec, canonicalMatch) {
+				canonicalMatch = rec
+			}
+		case rawEmail != "" && email == rawEmail:
+			if preferUserRecord(rec, rawMatch) {
+				rawMatch = rec
+			}
+		default:
+			if preferUserRecord(rec, fallbackMatch) {
+				fallbackMatch = rec
+			}
+		}
+	}
+	if canonicalMatch == nil && len(recs) > 1 {
+		return nil, fmt.Errorf("find user: ambiguous case-insensitive duplicate users for %q", normalizedEmail)
+	}
+	match := canonicalMatch
+	if match == nil {
+		match = rawMatch
+	}
+	if match == nil {
+		match = fallbackMatch
+	}
+	if match == nil {
+		return nil, core.ErrNotFound
+	}
+	if len(recs) == 1 && (recString(match, "email") != normalizedEmail || recString(match, "normalized_email") != normalizedEmail) {
+		// Best-effort repair for legacy mixed-case rows. Reads should not fail
+		// if the canonicalizing write cannot be completed.
+		updated := cloneRecord(match)
+		updated["email"] = normalizedEmail
+		updated["normalized_email"] = normalizedEmail
+		updated["updated_at"] = time.Now()
+		if err := s.store.Put(ctx, updated); err == nil {
+			match = updated
+		}
+	}
+	return recordToUser(match), nil
+}
+
+func preferUserRecord(candidate, current indexeddb.Record) bool {
+	if current == nil {
+		return true
+	}
+	candidateCreated := recTime(candidate, "created_at")
+	currentCreated := recTime(current, "created_at")
+	switch {
+	case candidateCreated.IsZero() && !currentCreated.IsZero():
+		return false
+	case !candidateCreated.IsZero() && currentCreated.IsZero():
+		return true
+	case !candidateCreated.Equal(currentCreated):
+		return candidateCreated.Before(currentCreated)
+	}
+	candidateID := recString(candidate, "id")
+	currentID := recString(current, "id")
+	if candidateID != currentID {
+		return candidateID < currentID
+	}
+	return recString(candidate, "email") < recString(current, "email")
 }
 
 func recordToUser(rec indexeddb.Record) *core.User {

--- a/gestaltd/internal/emailutil/email.go
+++ b/gestaltd/internal/emailutil/email.go
@@ -1,0 +1,7 @@
+package emailutil
+
+import "strings"
+
+func Normalize(email string) string {
+	return strings.ToLower(strings.TrimSpace(email))
+}

--- a/gestaltd/internal/server/server_test.go
+++ b/gestaltd/internal/server/server_test.go
@@ -24,6 +24,8 @@ import (
 	mcpserver "github.com/mark3labs/mcp-go/server"
 	"github.com/valon-technologies/gestalt/server/core"
 	"github.com/valon-technologies/gestalt/server/core/catalog"
+	corecrypto "github.com/valon-technologies/gestalt/server/core/crypto"
+	"github.com/valon-technologies/gestalt/server/core/indexeddb"
 	coreintegration "github.com/valon-technologies/gestalt/server/core/integration"
 	"github.com/valon-technologies/gestalt/server/core/session"
 	coretesting "github.com/valon-technologies/gestalt/server/core/testing"
@@ -33,6 +35,7 @@ import (
 	"github.com/valon-technologies/gestalt/server/internal/composite"
 	"github.com/valon-technologies/gestalt/server/internal/config"
 	"github.com/valon-technologies/gestalt/server/internal/coredata"
+	"github.com/valon-technologies/gestalt/server/internal/emailutil"
 	"github.com/valon-technologies/gestalt/server/internal/invocation"
 	gestaltmcp "github.com/valon-technologies/gestalt/server/internal/mcp"
 	"github.com/valon-technologies/gestalt/server/internal/oauth"
@@ -106,6 +109,48 @@ func newTestHandler(t *testing.T, opts ...func(*server.Config)) http.Handler {
 		t.Fatalf("creating server: %v", err)
 	}
 	return srv
+}
+
+type putFailingIndexedDB struct {
+	indexeddb.IndexedDB
+	failUsersPut *atomic.Bool
+}
+
+func (d *putFailingIndexedDB) ObjectStore(name string) indexeddb.ObjectStore {
+	store := d.IndexedDB.ObjectStore(name)
+	if name != coredata.StoreUsers {
+		return store
+	}
+	return &putFailingObjectStore{ObjectStore: store, failPut: d.failUsersPut}
+}
+
+type putFailingObjectStore struct {
+	indexeddb.ObjectStore
+	failPut *atomic.Bool
+}
+
+func (s *putFailingObjectStore) Put(ctx context.Context, record indexeddb.Record) error {
+	if s.failPut != nil && s.failPut.Load() {
+		return fmt.Errorf("forced users put failure")
+	}
+	return s.ObjectStore.Put(ctx, record)
+}
+
+func newTestServicesWithUsersPutFailure(t *testing.T) (*coredata.Services, *atomic.Bool) {
+	t.Helper()
+	enc, err := corecrypto.NewAESGCM([]byte("0123456789abcdef0123456789abcdef"))
+	if err != nil {
+		t.Fatalf("newTestServicesWithUsersPutFailure encryptor: %v", err)
+	}
+	failPut := &atomic.Bool{}
+	svc, err := coredata.New(&putFailingIndexedDB{
+		IndexedDB:    &coretesting.StubIndexedDB{},
+		failUsersPut: failPut,
+	}, enc)
+	if err != nil {
+		t.Fatalf("newTestServicesWithUsersPutFailure: %v", err)
+	}
+	return svc, failPut
 }
 
 func newVirtualHostClient(t *testing.T, hostAddrs map[string]string) *http.Client {
@@ -259,6 +304,29 @@ func seedUser(t *testing.T, svc *coredata.Services, email string) *core.User {
 		t.Fatalf("seedUser: %v", err)
 	}
 	return u
+}
+
+func seedLegacyUserRecord(t *testing.T, svc *coredata.Services, id, email string, createdAt time.Time) *core.User {
+	t.Helper()
+	ctx := context.Background()
+	rec := indexeddb.Record{
+		"id":               id,
+		"email":            email,
+		"normalized_email": emailutil.Normalize(email),
+		"display_name":     "",
+		"created_at":       createdAt,
+		"updated_at":       createdAt,
+	}
+	if err := svc.DB.ObjectStore(coredata.StoreUsers).Add(ctx, rec); err != nil {
+		t.Fatalf("seedLegacyUserRecord: %v", err)
+	}
+	return &core.User{
+		ID:          id,
+		Email:       email,
+		DisplayName: "",
+		CreatedAt:   createdAt,
+		UpdatedAt:   createdAt,
+	}
 }
 
 func seedIdentityToken(t *testing.T, svc *coredata.Services, integration, connection, instance, accessToken string) {
@@ -3589,7 +3657,7 @@ func TestListIntegrations_ShowsConnectedStatus(t *testing.T) {
 	t.Parallel()
 
 	svc := coretesting.NewStubServices(t)
-	u := seedUser(t, svc, "anonymous@gestalt")
+	u := seedLegacyUserRecord(t, svc, "user-a", "user@example.com", time.Date(2026, 1, 1, 12, 0, 0, 0, time.UTC))
 	seedToken(t, svc, &core.IntegrationToken{
 		ID: "tok1", UserID: u.ID, Integration: "slack",
 		Connection: "default", Instance: "default", AccessToken: "test-token",
@@ -3598,12 +3666,22 @@ func TestListIntegrations_ShowsConnectedStatus(t *testing.T) {
 	stub := &coretesting.StubIntegration{N: "slack", DN: "Slack"}
 	stub2 := &coretesting.StubIntegration{N: "github", DN: "GitHub"}
 	ts := newTestServer(t, func(cfg *server.Config) {
+		cfg.Auth = &coretesting.StubAuthProvider{
+			N: "stub",
+			ValidateTokenFn: func(_ context.Context, token string) (*core.UserIdentity, error) {
+				if token != "session-token" {
+					return nil, core.ErrNotFound
+				}
+				return &core.UserIdentity{Email: "USER@example.com"}, nil
+			},
+		}
 		cfg.Providers = testutil.NewProviderRegistry(t, stub, stub2)
 		cfg.Services = svc
 	})
 	testutil.CloseOnCleanup(t, ts)
 
 	req, _ := http.NewRequest(http.MethodGet, ts.URL+"/api/v1/integrations", nil)
+	req.AddCookie(&http.Cookie{Name: "session_token", Value: "session-token"})
 	resp, err := http.DefaultClient.Do(req)
 	if err != nil {
 		t.Fatalf("request: %v", err)
@@ -3634,6 +3712,172 @@ func TestListIntegrations_ShowsConnectedStatus(t *testing.T) {
 	}
 	if connected["github"] {
 		t.Fatal("expected github to be disconnected")
+	}
+}
+
+func TestListIntegrations_ShowsConnectedStatus_PrefersCanonicalLowercaseEmailOverExactRawDuplicate(t *testing.T) {
+	t.Parallel()
+
+	svc := coretesting.NewStubServices(t)
+	seedLegacyUserRecord(t, svc, "user-a", "user@example.com", time.Date(2026, 1, 1, 12, 0, 0, 0, time.UTC))
+	userB := seedLegacyUserRecord(t, svc, "user-b", "USER@example.com", time.Date(2026, 1, 2, 12, 0, 0, 0, time.UTC))
+	seedToken(t, svc, &core.IntegrationToken{
+		ID: "tok1", UserID: userB.ID, Integration: "slack",
+		Connection: "default", Instance: "default", AccessToken: "test-token",
+	})
+
+	stub := &coretesting.StubIntegration{N: "slack", DN: "Slack"}
+	ts := newTestServer(t, func(cfg *server.Config) {
+		cfg.Auth = &coretesting.StubAuthProvider{
+			N: "stub",
+			ValidateTokenFn: func(_ context.Context, token string) (*core.UserIdentity, error) {
+				if token != "session-token" {
+					return nil, core.ErrNotFound
+				}
+				return &core.UserIdentity{Email: "USER@example.com"}, nil
+			},
+		}
+		cfg.Providers = testutil.NewProviderRegistry(t, stub)
+		cfg.Services = svc
+	})
+	testutil.CloseOnCleanup(t, ts)
+
+	req, _ := http.NewRequest(http.MethodGet, ts.URL+"/api/v1/integrations", nil)
+	req.AddCookie(&http.Cookie{Name: "session_token", Value: "session-token"})
+	resp, err := http.DefaultClient.Do(req)
+	if err != nil {
+		t.Fatalf("request: %v", err)
+	}
+	defer func() { _ = resp.Body.Close() }()
+	if resp.StatusCode != http.StatusOK {
+		t.Fatalf("expected 200, got %d", resp.StatusCode)
+	}
+
+	var integrations []struct {
+		Name      string `json:"name"`
+		Connected bool   `json:"connected"`
+	}
+	if err := json.NewDecoder(resp.Body).Decode(&integrations); err != nil {
+		t.Fatalf("decoding: %v", err)
+	}
+	if len(integrations) != 1 {
+		t.Fatalf("expected 1 integration, got %d", len(integrations))
+	}
+	if integrations[0].Connected {
+		t.Fatal("expected canonical lowercase user to win over the exact raw-email duplicate")
+	}
+}
+
+func TestListIntegrations_ShowsConnectedStatus_AmbiguousMixedCaseDuplicatesFailClosed(t *testing.T) {
+	t.Parallel()
+
+	for _, email := range []string{"user@example.com", "USER@example.com"} {
+		email := email
+		t.Run(email, func(t *testing.T) {
+			t.Parallel()
+
+			svc := coretesting.NewStubServices(t)
+			seedLegacyUserRecord(t, svc, "user-a", "User@example.com", time.Date(2026, 1, 1, 12, 0, 0, 0, time.UTC))
+			seedLegacyUserRecord(t, svc, "user-b", "USER@example.com", time.Date(2026, 1, 2, 12, 0, 0, 0, time.UTC))
+
+			stub := &coretesting.StubIntegration{N: "slack", DN: "Slack"}
+			ts := newTestServer(t, func(cfg *server.Config) {
+				cfg.Auth = &coretesting.StubAuthProvider{
+					N: "stub",
+					ValidateTokenFn: func(_ context.Context, token string) (*core.UserIdentity, error) {
+						if token != "session-token" {
+							return nil, core.ErrNotFound
+						}
+						return &core.UserIdentity{Email: email}, nil
+					},
+				}
+				cfg.Providers = testutil.NewProviderRegistry(t, stub)
+				cfg.Services = svc
+			})
+			testutil.CloseOnCleanup(t, ts)
+
+			req, _ := http.NewRequest(http.MethodGet, ts.URL+"/api/v1/integrations", nil)
+			req.AddCookie(&http.Cookie{Name: "session_token", Value: "session-token"})
+			resp, err := http.DefaultClient.Do(req)
+			if err != nil {
+				t.Fatalf("request: %v", err)
+			}
+			defer func() { _ = resp.Body.Close() }()
+
+			if resp.StatusCode != http.StatusInternalServerError {
+				t.Fatalf("expected 500, got %d", resp.StatusCode)
+			}
+		})
+	}
+}
+
+func TestLoginCallback_LegacyMixedCaseRepairFailureStillSucceeds(t *testing.T) {
+	t.Parallel()
+
+	svc, failPut := newTestServicesWithUsersPutFailure(t)
+	existing := seedLegacyUserRecord(t, svc, "legacy-user", "User@Example.com", time.Date(2026, 1, 1, 12, 0, 0, 0, time.UTC))
+	failPut.Store(true)
+
+	var auditBuf bytes.Buffer
+	auditSink := invocation.NewSlogAuditSink(&auditBuf)
+	ts := newTestServer(t, func(cfg *server.Config) {
+		cfg.Auth = &stubAuthWithToken{
+			StubAuthProvider: coretesting.StubAuthProvider{
+				N: "test",
+				HandleCallbackFn: func(_ context.Context, code string) (*core.UserIdentity, error) {
+					if code == "good-code" {
+						return &core.UserIdentity{Email: "user@example.com", DisplayName: "User"}, nil
+					}
+					return nil, fmt.Errorf("bad code")
+				},
+			},
+		}
+		cfg.Services = svc
+		cfg.AuditSink = auditSink
+	})
+	testutil.CloseOnCleanup(t, ts)
+
+	jar, _ := cookiejar.New(nil)
+	client := &http.Client{Jar: jar}
+
+	body := bytes.NewBufferString(`{"state":"test-state"}`)
+	loginResp, err := client.Post(ts.URL+"/api/v1/auth/login", "application/json", body)
+	if err != nil {
+		t.Fatalf("start login: %v", err)
+	}
+	_ = loginResp.Body.Close()
+
+	resp, err := client.Get(ts.URL + "/api/v1/auth/login/callback?code=good-code&state=test-state")
+	if err != nil {
+		t.Fatalf("request: %v", err)
+	}
+	defer func() { _ = resp.Body.Close() }()
+
+	if resp.StatusCode != http.StatusOK {
+		t.Fatalf("expected 200, got %d", resp.StatusCode)
+	}
+
+	stored, err := svc.Users.GetUser(context.Background(), existing.ID)
+	if err != nil {
+		t.Fatalf("get user: %v", err)
+	}
+	if stored.Email != "User@Example.com" {
+		t.Fatalf("expected user email to remain unrepaired after forced put failure, got %q", stored.Email)
+	}
+
+	lines := bytes.Split(bytes.TrimSpace(auditBuf.Bytes()), []byte("\n"))
+	if len(lines) == 0 {
+		t.Fatal("expected login audit record")
+	}
+	var auditRecord map[string]any
+	if err := json.Unmarshal(lines[len(lines)-1], &auditRecord); err != nil {
+		t.Fatalf("parsing audit record: %v\nraw: %s", err, auditBuf.String())
+	}
+	if auditRecord["operation"] != "auth.login.complete" {
+		t.Fatalf("expected audit operation auth.login.complete, got %v", auditRecord["operation"])
+	}
+	if uid, ok := auditRecord["user_id"].(string); !ok || uid != existing.ID {
+		t.Fatalf("expected audit user_id %q, got %v", existing.ID, auditRecord["user_id"])
 	}
 }
 
@@ -6039,6 +6283,8 @@ func TestStartLogin_NoAuthInvalidJSON(t *testing.T) {
 func TestLoginCallback(t *testing.T) {
 	t.Parallel()
 
+	svc := coretesting.NewStubServices(t)
+	existing := seedLegacyUserRecord(t, svc, "legacy-user", "User@Example.com", time.Date(2026, 1, 1, 12, 0, 0, 0, time.UTC))
 	var auditBuf bytes.Buffer
 	auditSink := invocation.NewSlogAuditSink(&auditBuf)
 	ts := newTestServer(t, func(cfg *server.Config) {
@@ -6053,7 +6299,7 @@ func TestLoginCallback(t *testing.T) {
 				},
 			},
 		}
-		cfg.Services = coretesting.NewStubServices(t)
+		cfg.Services = svc
 		cfg.AuditSink = auditSink
 	})
 	testutil.CloseOnCleanup(t, ts)
@@ -6085,6 +6331,13 @@ func TestLoginCallback(t *testing.T) {
 	if result["email"] != "user@example.com" {
 		t.Fatalf("unexpected email: %v", result["email"])
 	}
+	stored, err := svc.Users.GetUser(context.Background(), existing.ID)
+	if err != nil {
+		t.Fatalf("get user: %v", err)
+	}
+	if stored.Email != "user@example.com" {
+		t.Fatalf("expected repaired user email %q, got %q", "user@example.com", stored.Email)
+	}
 
 	lines := bytes.Split(bytes.TrimSpace(auditBuf.Bytes()), []byte("\n"))
 	if len(lines) == 0 {
@@ -6100,8 +6353,8 @@ func TestLoginCallback(t *testing.T) {
 	if auditRecord["auth_source"] != "session" {
 		t.Fatalf("expected audit auth_source session, got %v", auditRecord["auth_source"])
 	}
-	if uid, ok := auditRecord["user_id"].(string); !ok || uid == "" {
-		t.Fatalf("expected non-empty audit user_id, got %v", auditRecord["user_id"])
+	if uid, ok := auditRecord["user_id"].(string); !ok || uid != existing.ID {
+		t.Fatalf("expected audit user_id %q, got %v", existing.ID, auditRecord["user_id"])
 	}
 }
 
@@ -6109,13 +6362,14 @@ func TestLoginCallbackForCLI(t *testing.T) {
 	t.Parallel()
 
 	svc := coretesting.NewStubServices(t)
+	u := seedUser(t, svc, "user@example.com")
 	var auditBuf bytes.Buffer
 	ts := newTestServer(t, func(cfg *server.Config) {
 		cfg.Auth = &coretesting.StubAuthProvider{
 			N: "test",
 			HandleCallbackFn: func(_ context.Context, code string) (*core.UserIdentity, error) {
 				if code == "good-code" {
-					return &core.UserIdentity{Email: "user@example.com", DisplayName: "User"}, nil
+					return &core.UserIdentity{Email: "User@Example.com", DisplayName: "User"}, nil
 				}
 				return nil, fmt.Errorf("bad code")
 			},
@@ -6159,10 +6413,6 @@ func TestLoginCallbackForCLI(t *testing.T) {
 		t.Fatalf("expected cli-token name in CLI login response, got %v", result["name"])
 	}
 
-	u, err := svc.Users.FindOrCreateUser(context.Background(), "user@example.com")
-	if err != nil {
-		t.Fatalf("find user: %v", err)
-	}
 	tokens, err := svc.APITokens.ListAPITokens(context.Background(), u.ID)
 	if err != nil {
 		t.Fatalf("list api tokens: %v", err)
@@ -6198,8 +6448,8 @@ func TestLoginCallbackForCLI(t *testing.T) {
 	if tokenAudit["auth_source"] != "session" {
 		t.Fatalf("expected token audit auth_source session, got %v", tokenAudit["auth_source"])
 	}
-	if uid, ok := tokenAudit["user_id"].(string); !ok || uid == "" {
-		t.Fatalf("expected non-empty token audit user_id, got %v", tokenAudit["user_id"])
+	if uid, ok := tokenAudit["user_id"].(string); !ok || uid != u.ID {
+		t.Fatalf("expected token audit user_id %q, got %v", u.ID, tokenAudit["user_id"])
 	}
 	if tokenAudit["allowed"] != true {
 		t.Fatalf("expected token audit allowed=true, got %v", tokenAudit["allowed"])
@@ -6211,6 +6461,9 @@ func TestLoginCallbackForCLI(t *testing.T) {
 	}
 	if loginAudit["operation"] != "auth.login.complete" {
 		t.Fatalf("expected auth.login.complete audit operation, got %v", loginAudit["operation"])
+	}
+	if uid, ok := loginAudit["user_id"].(string); !ok || uid != u.ID {
+		t.Fatalf("expected login audit user_id %q, got %v", u.ID, loginAudit["user_id"])
 	}
 }
 
@@ -6896,6 +7149,8 @@ func TestCreateAPIToken_DefaultExpiry(t *testing.T) {
 	t.Parallel()
 
 	fixedNow := time.Date(2026, 1, 15, 12, 0, 0, 0, time.UTC)
+	svc := coretesting.NewStubServices(t)
+	existing := seedUser(t, svc, "user@example.com")
 	var auditBuf bytes.Buffer
 	auditSink := invocation.NewSlogAuditSink(&auditBuf)
 	ts := newTestServer(t, func(cfg *server.Config) {
@@ -6905,12 +7160,12 @@ func TestCreateAPIToken_DefaultExpiry(t *testing.T) {
 				if token != "session-token" {
 					return nil, core.ErrNotFound
 				}
-				return &core.UserIdentity{Email: "user@example.com"}, nil
+				return &core.UserIdentity{Email: "User@Example.com"}, nil
 			},
 		}
 		cfg.Now = func() time.Time { return fixedNow }
 		cfg.AuditSink = auditSink
-		cfg.Services = coretesting.NewStubServices(t)
+		cfg.Services = svc
 	})
 	testutil.CloseOnCleanup(t, ts)
 
@@ -6954,6 +7209,17 @@ func TestCreateAPIToken_DefaultExpiry(t *testing.T) {
 		t.Fatalf("expected expiresAt %v, got %v", expected, expiresAt)
 	}
 
+	tokens, err := svc.APITokens.ListAPITokens(context.Background(), existing.ID)
+	if err != nil {
+		t.Fatalf("list api tokens: %v", err)
+	}
+	if len(tokens) != 1 {
+		t.Fatalf("expected 1 API token for canonical user, got %d", len(tokens))
+	}
+	if tokens[0].ID != tokenID {
+		t.Fatalf("expected stored token ID %q, got %q", tokenID, tokens[0].ID)
+	}
+
 	var auditRecord map[string]any
 	if err := json.Unmarshal(auditBuf.Bytes(), &auditRecord); err != nil {
 		t.Fatalf("parsing audit record: %v\nraw: %s", err, auditBuf.String())
@@ -6967,8 +7233,8 @@ func TestCreateAPIToken_DefaultExpiry(t *testing.T) {
 	if auditRecord["auth_source"] != "session" {
 		t.Fatalf("expected audit auth_source session, got %v", auditRecord["auth_source"])
 	}
-	if uid, ok := auditRecord["user_id"].(string); !ok || uid == "" {
-		t.Fatalf("expected non-empty audit user_id, got %v", auditRecord["user_id"])
+	if uid, ok := auditRecord["user_id"].(string); !ok || uid != existing.ID {
+		t.Fatalf("expected audit user_id %q, got %v", existing.ID, auditRecord["user_id"])
 	}
 	if auditRecord["allowed"] != true {
 		t.Fatalf("expected audit allowed=true, got %v", auditRecord["allowed"])


### PR DESCRIPTION
## Summary
Canonicalize human email handling at the storage boundary so mixed-case identities from auth providers resolve back to the same persisted user, and make authorization policy email validation/runtime use the same normalization rule.

## Go Interfaces
- `internal/emailutil.Normalize(email string) string`
  - Shared canonicalization helper for lowercasing and trimming human emails.
- `(*coredata.UserService).FindOrCreateUser(ctx, email)`
  - Existing signature, new behavior:
    - normalizes before lookup/create
    - repairs a single legacy mixed-case stored row on lookup
    - errors on ambiguous case-insensitive duplicates instead of silently creating another user

### Go Example
```go
user, err := services.Users.FindOrCreateUser(ctx, " User@Example.com ")
if err != nil {
    return err
}
fmt.Println(user.Email)
// Output: user@example.com
```

## YAML Interfaces
- No new YAML schema in this PR.
- Existing authorization policy member emails now normalize through the same helper during config validation and runtime matching.

### YAML Example
```yaml
authorization:
  policies:
    editors:
      members:
        - email: User@Example.com
          role: editor
```

This continues to work, and the policy email is matched using the same normalization rule as persisted users.

## Tests
Augmented existing server-level tests only:
- `TestListIntegrations_ShowsConnectedStatus`
- `TestLoginCallback`
- `TestLoginCallbackForCLI`
- `TestCreateAPIToken_DefaultExpiry`

These now prove mixed-case authenticated identities collapse onto the same stored lowercase user across normal requests, browser login, CLI login, and API-token creation.
