### PR TITLE
Add dynamic plugin authorization backend and admin API

### DIFF
--- a/gestaltd/cmd/gestaltd/run.go
+++ b/gestaltd/cmd/gestaltd/run.go
@@ -177,6 +177,9 @@ func runServer(env *bootstrapEnv) error {
 		},
 		AdminUI: publicAdminUI,
 	}
+	if err := result.Start(env.Ctx); err != nil {
+		return err
+	}
 
 	publicProfile := server.RouteProfileAll
 	if env.Config.Server.ManagementAddr() != "" {
@@ -271,10 +274,6 @@ func runServer(env *bootstrapEnv) error {
 		return nil
 	}
 
-	if err := result.Start(env.Ctx); err != nil {
-		return err
-	}
-
 	mcpInner, err := mcpSurface.handler(result, mcpInvoker)
 	if err != nil {
 		return err
@@ -326,6 +325,19 @@ func resolveUIHandlers(cfg *config.Config) ([]server.MountedWebUI, http.Handler,
 }
 
 func resolveMountedWebUIHandlers(cfg *config.Config) ([]server.MountedWebUI, error) {
+	uiOwners := make(map[string]string, len(cfg.Plugins))
+	for pluginName, entry := range cfg.Plugins {
+		if entry == nil || strings.TrimSpace(entry.MountPath) == "" {
+			continue
+		}
+		switch uiName := strings.TrimSpace(entry.UI); {
+		case uiName != "":
+			uiOwners[uiName] = pluginName
+		case cfg.Providers.UI[pluginName] != nil:
+			uiOwners[pluginName] = pluginName
+		}
+	}
+
 	names := make([]string, 0, len(cfg.Providers.UI))
 	for name := range cfg.Providers.UI {
 		names = append(names, name)
@@ -358,6 +370,7 @@ func resolveMountedWebUIHandlers(cfg *config.Config) ([]server.MountedWebUI, err
 		mounted = append(mounted, server.MountedWebUI{
 			Name:                name,
 			Path:                entry.Path,
+			PluginName:          uiOwners[name],
 			AuthorizationPolicy: entry.AuthorizationPolicy,
 			Routes:              routes,
 			Handler:             handler,

--- a/gestaltd/cmd/gestaltd/run_test.go
+++ b/gestaltd/cmd/gestaltd/run_test.go
@@ -1,0 +1,93 @@
+package main
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/valon-technologies/gestalt/server/internal/config"
+)
+
+func TestResolveMountedWebUIHandlers_PreservesPluginOwnership(t *testing.T) {
+	t.Parallel()
+
+	newAssetRoot := func(t *testing.T) string {
+		t.Helper()
+		dir := t.TempDir()
+		if err := os.WriteFile(filepath.Join(dir, "index.html"), []byte("<html>ui</html>"), 0o644); err != nil {
+			t.Fatalf("WriteFile index.html: %v", err)
+		}
+		return dir
+	}
+
+	t.Run("explicit plugin ui binding", func(t *testing.T) {
+		t.Parallel()
+
+		cfg := &config.Config{
+			Providers: config.ProvidersConfig{
+				UI: map[string]*config.UIEntry{
+					"roadmap": {
+						ProviderEntry: config.ProviderEntry{
+							ResolvedAssetRoot:   newAssetRoot(t),
+							AuthorizationPolicy: "roadmap_policy",
+						},
+						Path: "/roadmap",
+					},
+				},
+			},
+			Plugins: map[string]*config.ProviderEntry{
+				"roadmap_plugin": {
+					UI:                  "roadmap",
+					MountPath:           "/roadmap",
+					AuthorizationPolicy: "roadmap_policy",
+				},
+			},
+		}
+
+		mounted, err := resolveMountedWebUIHandlers(cfg)
+		if err != nil {
+			t.Fatalf("resolveMountedWebUIHandlers: %v", err)
+		}
+		if len(mounted) != 1 {
+			t.Fatalf("len(mounted) = %d, want 1", len(mounted))
+		}
+		if got := mounted[0].PluginName; got != "roadmap_plugin" {
+			t.Fatalf("mounted[0].PluginName = %q, want %q", got, "roadmap_plugin")
+		}
+	})
+
+	t.Run("synthesized plugin owned ui", func(t *testing.T) {
+		t.Parallel()
+
+		cfg := &config.Config{
+			Providers: config.ProvidersConfig{
+				UI: map[string]*config.UIEntry{
+					"roadmap": {
+						ProviderEntry: config.ProviderEntry{
+							ResolvedAssetRoot:   newAssetRoot(t),
+							AuthorizationPolicy: "roadmap_policy",
+						},
+						Path: "/roadmap",
+					},
+				},
+			},
+			Plugins: map[string]*config.ProviderEntry{
+				"roadmap": {
+					MountPath:           "/roadmap",
+					AuthorizationPolicy: "roadmap_policy",
+				},
+			},
+		}
+
+		mounted, err := resolveMountedWebUIHandlers(cfg)
+		if err != nil {
+			t.Fatalf("resolveMountedWebUIHandlers: %v", err)
+		}
+		if len(mounted) != 1 {
+			t.Fatalf("len(mounted) = %d, want 1", len(mounted))
+		}
+		if got := mounted[0].PluginName; got != "roadmap" {
+			t.Fatalf("mounted[0].PluginName = %q, want %q", got, "roadmap")
+		}
+	})
+}

--- a/gestaltd/internal/authorization/authorizer.go
+++ b/gestaltd/internal/authorization/authorizer.go
@@ -1,13 +1,19 @@
 package authorization
 
 import (
+	"context"
 	"fmt"
+	"log/slog"
 	"regexp"
 	"strings"
+	"sync"
+	"sync/atomic"
+	"time"
 
 	"github.com/valon-technologies/gestalt/server/core"
 	"github.com/valon-technologies/gestalt/server/core/catalog"
 	"github.com/valon-technologies/gestalt/server/internal/config"
+	"github.com/valon-technologies/gestalt/server/internal/coredata"
 	"github.com/valon-technologies/gestalt/server/internal/emailutil"
 	"github.com/valon-technologies/gestalt/server/internal/principal"
 	"github.com/valon-technologies/gestalt/server/internal/registry"
@@ -18,6 +24,8 @@ const (
 	defaultInstance  = "default"
 	defaultHumanRole = "viewer"
 )
+
+const defaultDynamicReloadInterval = 5 * time.Second
 
 var (
 	safeConnectionValue = regexp.MustCompile(`^[a-zA-Z0-9._-]+$`)
@@ -55,20 +63,52 @@ type HumanPolicy struct {
 	RolesByEmail     map[string]string
 }
 
+type StaticHumanMember struct {
+	SubjectID string
+	Email     string
+	Role      string
+}
+
+type dynamicGrant struct {
+	UserID string
+	Email  string
+	Role   string
+}
+
+type dynamicSnapshot struct {
+	byPluginUserID map[string]map[string]dynamicGrant
+	byPluginEmail  map[string]map[string]dynamicGrant
+}
+
 type Authorizer struct {
 	workloadsByHash      map[string]*Workload
 	workloadsBySubjectID map[string]*Workload
 	policies             map[string]*HumanPolicy
 	providerPolicies     map[string]string
+	dynamicService       *coredata.PluginAuthorizationService
+	dynamicReloadEvery   time.Duration
+	dynamic              atomic.Pointer[dynamicSnapshot]
+	lifecycleMu          sync.Mutex
+	started              bool
+	closed               bool
+	pollCancel           context.CancelFunc
+	pollDone             chan struct{}
 }
 
-func New(cfg config.AuthorizationConfig, pluginDefs map[string]*config.ProviderEntry, providers *registry.ProviderMap[core.Provider], defaultConnections map[string]string) (*Authorizer, error) {
+func New(cfg config.AuthorizationConfig, pluginDefs map[string]*config.ProviderEntry, providers *registry.ProviderMap[core.Provider], defaultConnections map[string]string, dynamicServices ...*coredata.PluginAuthorizationService) (*Authorizer, error) {
+	var dynamicService *coredata.PluginAuthorizationService
+	if len(dynamicServices) > 0 {
+		dynamicService = dynamicServices[0]
+	}
 	a := &Authorizer{
 		workloadsByHash:      map[string]*Workload{},
 		workloadsBySubjectID: map[string]*Workload{},
 		policies:             map[string]*HumanPolicy{},
 		providerPolicies:     map[string]string{},
+		dynamicService:       dynamicService,
+		dynamicReloadEvery:   defaultDynamicReloadInterval,
 	}
+	a.dynamic.Store(emptyDynamicSnapshot())
 
 	for policyID, def := range cfg.Policies {
 		policy := &HumanPolicy{
@@ -150,6 +190,121 @@ func New(cfg config.AuthorizationConfig, pluginDefs map[string]*config.ProviderE
 	return a, nil
 }
 
+func (a *Authorizer) Start(ctx context.Context) error {
+	if a == nil || a.dynamicService == nil {
+		return nil
+	}
+
+	a.lifecycleMu.Lock()
+	defer a.lifecycleMu.Unlock()
+	if a.closed {
+		return fmt.Errorf("authorizer already closed")
+	}
+	if a.started {
+		return nil
+	}
+	if err := a.ReloadDynamic(ctx); err != nil {
+		return err
+	}
+
+	pollCtx, cancel := context.WithCancel(ctx)
+	done := make(chan struct{})
+	a.pollCancel = cancel
+	a.pollDone = done
+	a.started = true
+	go a.pollLoop(pollCtx, done)
+	return nil
+}
+
+func (a *Authorizer) Close() error {
+	if a == nil {
+		return nil
+	}
+
+	a.lifecycleMu.Lock()
+	if a.closed {
+		a.lifecycleMu.Unlock()
+		return nil
+	}
+	cancel := a.pollCancel
+	done := a.pollDone
+	a.pollCancel = nil
+	a.pollDone = nil
+	a.closed = true
+	a.lifecycleMu.Unlock()
+
+	if cancel != nil {
+		cancel()
+	}
+	if done != nil {
+		<-done
+	}
+	return nil
+}
+
+func (a *Authorizer) HasDynamicAuthorizations() bool {
+	return a != nil && a.dynamicService != nil
+}
+
+func (a *Authorizer) ReloadDynamic(ctx context.Context) error {
+	if a == nil || a.dynamicService == nil {
+		return nil
+	}
+
+	grants, err := a.dynamicService.ListPluginAuthorizations(ctx)
+	if err != nil {
+		return fmt.Errorf("reload dynamic authorizations: %w", err)
+	}
+	snapshot := emptyDynamicSnapshot()
+	for _, grant := range grants {
+		if grant == nil {
+			continue
+		}
+		plugin := strings.TrimSpace(grant.Plugin)
+		userID := strings.TrimSpace(grant.UserID)
+		email := normalizeEmail(grant.Email)
+		role := strings.TrimSpace(grant.Role)
+		if plugin == "" || role == "" {
+			continue
+		}
+		if userID != "" {
+			byUserID := snapshot.byPluginUserID[plugin]
+			if byUserID == nil {
+				byUserID = map[string]dynamicGrant{}
+				snapshot.byPluginUserID[plugin] = byUserID
+			}
+			byUserID[userID] = dynamicGrant{UserID: userID, Email: email, Role: role}
+		}
+		if email != "" {
+			byEmail := snapshot.byPluginEmail[plugin]
+			if byEmail == nil {
+				byEmail = map[string]dynamicGrant{}
+				snapshot.byPluginEmail[plugin] = byEmail
+			}
+			byEmail[email] = dynamicGrant{UserID: userID, Email: email, Role: role}
+		}
+	}
+	a.dynamic.Store(snapshot)
+	return nil
+}
+
+func (a *Authorizer) pollLoop(ctx context.Context, done chan struct{}) {
+	defer close(done)
+	ticker := time.NewTicker(a.dynamicReloadEvery)
+	defer ticker.Stop()
+
+	for {
+		select {
+		case <-ctx.Done():
+			return
+		case <-ticker.C:
+			if err := a.ReloadDynamic(ctx); err != nil {
+				slog.WarnContext(ctx, "authorization: dynamic reload failed", "error", err)
+			}
+		}
+	}
+}
+
 func (a *Authorizer) ResolveWorkloadToken(token string) (*principal.ResolvedWorkload, bool) {
 	if a == nil {
 		return nil, false
@@ -198,8 +353,91 @@ func (a *Authorizer) Binding(p *principal.Principal, provider string) (Credentia
 }
 
 func (a *Authorizer) ResolveAccess(p *principal.Principal, provider string) (AccessContext, bool) {
+	if a == nil {
+		return AccessContext{}, true
+	}
 	policyName := strings.TrimSpace(a.providerPolicies[provider])
-	return a.ResolvePolicyAccess(p, policyName)
+	if policyName == "" {
+		return AccessContext{}, true
+	}
+	if a.IsWorkload(p) {
+		return a.ResolvePolicyAccess(p, policyName)
+	}
+
+	policy := a.policies[policyName]
+	if policy == nil {
+		return AccessContext{}, false
+	}
+
+	access := AccessContext{Policy: policyName}
+	if role, ok := policy.roleForPrincipal(p); ok {
+		access.Role = role
+		return access, true
+	}
+	if role, ok := a.dynamicRoleForPrincipal(provider, p); ok {
+		access.Role = role
+		return access, true
+	}
+	if policy.DefaultAllow {
+		access.Role = defaultHumanRole
+		return access, true
+	}
+	return access, false
+}
+
+func (a *Authorizer) PolicyNameForProvider(provider string) string {
+	if a == nil {
+		return ""
+	}
+	return strings.TrimSpace(a.providerPolicies[provider])
+}
+
+func (a *Authorizer) StaticRoleForProviderIdentity(provider, subjectID, userID, email string) (AccessContext, bool) {
+	if a == nil {
+		return AccessContext{}, false
+	}
+	policyName := a.PolicyNameForProvider(provider)
+	if policyName == "" {
+		return AccessContext{}, false
+	}
+	policy := a.policies[policyName]
+	if policy == nil {
+		return AccessContext{}, false
+	}
+	access := AccessContext{Policy: policyName}
+	if role, ok := policy.staticRoleForIdentity(subjectID, userID, email); ok {
+		access.Role = role
+		return access, true
+	}
+	return access, false
+}
+
+func (a *Authorizer) StaticMembersForProvider(provider string) (string, []StaticHumanMember, bool) {
+	if a == nil {
+		return "", nil, false
+	}
+	policyName := a.PolicyNameForProvider(provider)
+	if policyName == "" {
+		return "", nil, false
+	}
+	policy := a.policies[policyName]
+	if policy == nil {
+		return policyName, nil, false
+	}
+	members := make([]StaticHumanMember, 0, len(policy.RolesBySubjectID)+len(policy.RolesByEmail))
+	for subjectID, role := range policy.RolesBySubjectID {
+		members = append(members, StaticHumanMember{
+			SubjectID: subjectID,
+			Role:      role,
+		})
+	}
+	for email, role := range policy.RolesByEmail {
+		members = append(members, StaticHumanMember{
+			Email: email,
+			Role:  role,
+		})
+	}
+	return policyName, members, true
 }
 
 func (a *Authorizer) ResolvePolicyAccess(p *principal.Principal, policyName string) (AccessContext, bool) {
@@ -270,18 +508,29 @@ func (p *HumanPolicy) roleForPrincipal(pr *principal.Principal) (string, bool) {
 	if p == nil || pr == nil {
 		return "", false
 	}
-	if pr.SubjectID != "" {
-		if role, ok := p.RolesBySubjectID[pr.SubjectID]; ok {
-			return role, true
-		}
-	}
-	if pr.UserID != "" {
-		if role, ok := p.RolesBySubjectID[principal.UserSubjectID(pr.UserID)]; ok {
-			return role, true
-		}
-	}
+	email := ""
 	if pr.Identity != nil {
-		if role, ok := p.RolesByEmail[normalizeEmail(pr.Identity.Email)]; ok {
+		email = pr.Identity.Email
+	}
+	return p.staticRoleForIdentity(pr.SubjectID, pr.UserID, email)
+}
+
+func (p *HumanPolicy) staticRoleForIdentity(subjectID, userID, email string) (string, bool) {
+	if p == nil {
+		return "", false
+	}
+	if subjectID = strings.TrimSpace(subjectID); subjectID != "" {
+		if role, ok := p.RolesBySubjectID[subjectID]; ok {
+			return role, true
+		}
+	}
+	if userID = strings.TrimSpace(userID); userID != "" {
+		if role, ok := p.RolesBySubjectID[principal.UserSubjectID(userID)]; ok {
+			return role, true
+		}
+	}
+	if email = normalizeEmail(email); email != "" {
+		if role, ok := p.RolesByEmail[email]; ok {
 			return role, true
 		}
 	}
@@ -346,6 +595,42 @@ func normalizeAllowedOperations(ops []string) map[string]struct{} {
 		allowed[name] = struct{}{}
 	}
 	return allowed
+}
+
+func (a *Authorizer) dynamicRoleForPrincipal(provider string, p *principal.Principal) (string, bool) {
+	if a == nil || p == nil {
+		return "", false
+	}
+	snapshot := a.dynamic.Load()
+	if snapshot == nil {
+		return "", false
+	}
+	if p.UserID != "" {
+		if byUserID := snapshot.byPluginUserID[provider]; byUserID != nil {
+			if grant, ok := byUserID[p.UserID]; ok {
+				return grant.Role, true
+			}
+		}
+	}
+	email := ""
+	if p.Identity != nil {
+		email = p.Identity.Email
+	}
+	if email = normalizeEmail(email); email != "" {
+		if byEmail := snapshot.byPluginEmail[provider]; byEmail != nil {
+			if grant, ok := byEmail[email]; ok {
+				return grant.Role, true
+			}
+		}
+	}
+	return "", false
+}
+
+func emptyDynamicSnapshot() *dynamicSnapshot {
+	return &dynamicSnapshot{
+		byPluginUserID: map[string]map[string]dynamicGrant{},
+		byPluginEmail:  map[string]map[string]dynamicGrant{},
+	}
 }
 
 func normalizeEmail(email string) string {

--- a/gestaltd/internal/bootstrap/bootstrap.go
+++ b/gestaltd/internal/bootstrap/bootstrap.go
@@ -192,6 +192,11 @@ func (r *Result) Start(ctx context.Context) error {
 	if r.closed {
 		return fmt.Errorf("bootstrap result already closed")
 	}
+	if r.Authorizer != nil {
+		if err := r.Authorizer.Start(ctx); err != nil {
+			return err
+		}
+	}
 	return nil
 }
 
@@ -208,6 +213,7 @@ func (r *Result) Close(ctx context.Context) error {
 
 	var errs []error
 	errs = append(errs,
+		r.Authorizer.Close(),
 		closeAuth(r.Auth),
 		CloseProviders(r.Providers),
 		r.Services.Close(),
@@ -536,7 +542,7 @@ func Bootstrap(ctx context.Context, cfg *config.Config, factories *FactoryRegist
 	if err != nil {
 		return nil, err
 	}
-	authz, err := authorization.New(cfg.Authorization, cfg.Plugins, providers, connMaps.DefaultConnection)
+	authz, err := authorization.New(cfg.Authorization, cfg.Plugins, providers, connMaps.DefaultConnection, prepared.Services.PluginAuthorizations)
 	if err != nil {
 		return nil, err
 	}

--- a/gestaltd/internal/coredata/plugin_authorizations.go
+++ b/gestaltd/internal/coredata/plugin_authorizations.go
@@ -1,0 +1,137 @@
+package coredata
+
+import (
+	"context"
+	"fmt"
+	"strings"
+	"time"
+
+	"github.com/valon-technologies/gestalt/server/core"
+	"github.com/valon-technologies/gestalt/server/core/indexeddb"
+	"github.com/valon-technologies/gestalt/server/internal/emailutil"
+)
+
+type PluginAuthorizationMembership struct {
+	ID        string
+	Plugin    string
+	UserID    string
+	Email     string
+	Role      string
+	CreatedAt time.Time
+	UpdatedAt time.Time
+}
+
+type PluginAuthorizationService struct {
+	store indexeddb.ObjectStore
+}
+
+func NewPluginAuthorizationService(ds indexeddb.IndexedDB) *PluginAuthorizationService {
+	return &PluginAuthorizationService{store: ds.ObjectStore(StorePluginAuthorizationMemberships)}
+}
+
+func (s *PluginAuthorizationService) ListPluginAuthorizations(ctx context.Context) ([]*PluginAuthorizationMembership, error) {
+	recs, err := s.store.GetAll(ctx, nil)
+	if err != nil {
+		return nil, fmt.Errorf("list plugin authorizations: %w", err)
+	}
+	out := make([]*PluginAuthorizationMembership, len(recs))
+	for i, rec := range recs {
+		out[i] = recordToPluginAuthorizationMembership(rec)
+	}
+	return out, nil
+}
+
+func (s *PluginAuthorizationService) ListPluginAuthorizationsByPlugin(ctx context.Context, plugin string) ([]*PluginAuthorizationMembership, error) {
+	plugin = strings.TrimSpace(plugin)
+	if plugin == "" {
+		return nil, fmt.Errorf("list plugin authorizations: plugin is required")
+	}
+	recs, err := s.store.Index("by_plugin").GetAll(ctx, nil, plugin)
+	if err != nil {
+		return nil, fmt.Errorf("list plugin authorizations by plugin: %w", err)
+	}
+	out := make([]*PluginAuthorizationMembership, len(recs))
+	for i, rec := range recs {
+		out[i] = recordToPluginAuthorizationMembership(rec)
+	}
+	return out, nil
+}
+
+func (s *PluginAuthorizationService) UpsertPluginAuthorization(ctx context.Context, membership *PluginAuthorizationMembership) (*PluginAuthorizationMembership, error) {
+	if membership == nil {
+		return nil, fmt.Errorf("upsert plugin authorization: membership is required")
+	}
+
+	plugin := strings.TrimSpace(membership.Plugin)
+	userID := strings.TrimSpace(membership.UserID)
+	email := emailutil.Normalize(membership.Email)
+	role := strings.TrimSpace(membership.Role)
+	switch {
+	case plugin == "":
+		return nil, fmt.Errorf("upsert plugin authorization: plugin is required")
+	case userID == "":
+		return nil, fmt.Errorf("upsert plugin authorization: userID is required")
+	case email == "":
+		return nil, fmt.Errorf("upsert plugin authorization: email is required")
+	case role == "":
+		return nil, fmt.Errorf("upsert plugin authorization: role is required")
+	}
+
+	id := pluginAuthorizationRecordID(plugin, userID)
+	now := time.Now()
+	createdAt := now
+	if existing, err := s.store.Get(ctx, id); err == nil {
+		createdAt = recTime(existing, "created_at")
+	} else if err != indexeddb.ErrNotFound {
+		return nil, fmt.Errorf("upsert plugin authorization: %w", err)
+	}
+
+	rec := indexeddb.Record{
+		"id":         id,
+		"plugin":     plugin,
+		"user_id":    userID,
+		"email":      email,
+		"role":       role,
+		"created_at": createdAt,
+		"updated_at": now,
+	}
+	if createdAt.IsZero() {
+		rec["created_at"] = now
+	}
+
+	if err := s.store.Put(ctx, rec); err != nil {
+		return nil, fmt.Errorf("upsert plugin authorization: %w", err)
+	}
+	return recordToPluginAuthorizationMembership(rec), nil
+}
+
+func (s *PluginAuthorizationService) DeletePluginAuthorization(ctx context.Context, plugin, userID string) error {
+	plugin = strings.TrimSpace(plugin)
+	userID = strings.TrimSpace(userID)
+	if plugin == "" || userID == "" {
+		return fmt.Errorf("delete plugin authorization: plugin and userID are required")
+	}
+	if err := s.store.Delete(ctx, pluginAuthorizationRecordID(plugin, userID)); err != nil {
+		if err == indexeddb.ErrNotFound {
+			return core.ErrNotFound
+		}
+		return fmt.Errorf("delete plugin authorization: %w", err)
+	}
+	return nil
+}
+
+func pluginAuthorizationRecordID(plugin, userID string) string {
+	return plugin + "\x00" + userID
+}
+
+func recordToPluginAuthorizationMembership(rec indexeddb.Record) *PluginAuthorizationMembership {
+	return &PluginAuthorizationMembership{
+		ID:        recString(rec, "id"),
+		Plugin:    recString(rec, "plugin"),
+		UserID:    recString(rec, "user_id"),
+		Email:     recString(rec, "email"),
+		Role:      recString(rec, "role"),
+		CreatedAt: recTime(rec, "created_at"),
+		UpdatedAt: recTime(rec, "updated_at"),
+	}
+}

--- a/gestaltd/internal/coredata/schemas.go
+++ b/gestaltd/internal/coredata/schemas.go
@@ -3,9 +3,10 @@ package coredata
 import "github.com/valon-technologies/gestalt/server/core/indexeddb"
 
 const (
-	StoreUsers             = "users"
-	StoreIntegrationTokens = "integration_tokens"
-	StoreAPITokens         = "api_tokens"
+	StoreUsers                          = "users"
+	StoreIntegrationTokens              = "integration_tokens"
+	StoreAPITokens                      = "api_tokens"
+	StorePluginAuthorizationMemberships = "plugin_authorization_memberships"
 )
 
 var UsersSchema = indexeddb.ObjectStoreSchema{
@@ -61,6 +62,22 @@ var APITokensSchema = indexeddb.ObjectStoreSchema{
 		{Name: "hashed_token", Type: indexeddb.TypeString, NotNull: true, Unique: true},
 		{Name: "scopes", Type: indexeddb.TypeString},
 		{Name: "expires_at", Type: indexeddb.TypeTime},
+		{Name: "created_at", Type: indexeddb.TypeTime},
+		{Name: "updated_at", Type: indexeddb.TypeTime},
+	},
+}
+
+var PluginAuthorizationMembershipsSchema = indexeddb.ObjectStoreSchema{
+	Indexes: []indexeddb.IndexSchema{
+		{Name: "by_plugin", KeyPath: []string{"plugin"}},
+		{Name: "by_plugin_user", KeyPath: []string{"plugin", "user_id"}, Unique: true},
+	},
+	Columns: []indexeddb.ColumnDef{
+		{Name: "id", Type: indexeddb.TypeString, PrimaryKey: true},
+		{Name: "plugin", Type: indexeddb.TypeString, NotNull: true},
+		{Name: "user_id", Type: indexeddb.TypeString, NotNull: true},
+		{Name: "email", Type: indexeddb.TypeString, NotNull: true},
+		{Name: "role", Type: indexeddb.TypeString, NotNull: true},
 		{Name: "created_at", Type: indexeddb.TypeTime},
 		{Name: "updated_at", Type: indexeddb.TypeTime},
 	},

--- a/gestaltd/internal/coredata/services.go
+++ b/gestaltd/internal/coredata/services.go
@@ -9,10 +9,11 @@ import (
 )
 
 type Services struct {
-	Users     *UserService
-	Tokens    *TokenService
-	APITokens *APITokenService
-	DB        indexeddb.IndexedDB
+	Users                *UserService
+	Tokens               *TokenService
+	APITokens            *APITokenService
+	PluginAuthorizations *PluginAuthorizationService
+	DB                   indexeddb.IndexedDB
 }
 
 func New(ds indexeddb.IndexedDB, enc *corecrypto.AESGCMEncryptor) (*Services, error) {
@@ -30,11 +31,15 @@ func New(ds indexeddb.IndexedDB, enc *corecrypto.AESGCMEncryptor) (*Services, er
 	if err := users.BackfillNormalizedEmails(ctx); err != nil {
 		return nil, fmt.Errorf("backfill users store: %w", err)
 	}
+	if err := ds.CreateObjectStore(ctx, StorePluginAuthorizationMemberships, PluginAuthorizationMembershipsSchema); err != nil {
+		return nil, fmt.Errorf("create plugin_authorization_memberships store: %w", err)
+	}
 	return &Services{
-		Users:     users,
-		Tokens:    NewTokenService(ds, enc),
-		APITokens: NewAPITokenService(ds),
-		DB:        ds,
+		Users:                users,
+		Tokens:               NewTokenService(ds, enc),
+		APITokens:            NewAPITokenService(ds),
+		PluginAuthorizations: NewPluginAuthorizationService(ds),
+		DB:                   ds,
 	}, nil
 }
 

--- a/gestaltd/internal/coredata/users.go
+++ b/gestaltd/internal/coredata/users.go
@@ -85,6 +85,15 @@ func (s *UserService) FindOrCreateUser(ctx context.Context, email string) (*core
 	return recordToUser(newRec), nil
 }
 
+func (s *UserService) FindUserByEmail(ctx context.Context, email string) (*core.User, error) {
+	rawEmail := strings.TrimSpace(email)
+	email = emailutil.Normalize(email)
+	if email == "" {
+		return nil, fmt.Errorf("find user: email is required")
+	}
+	return s.findUserByNormalizedEmail(ctx, rawEmail, email)
+}
+
 func (s *UserService) findUserByNormalizedEmail(ctx context.Context, rawEmail, normalizedEmail string) (*core.User, error) {
 	recs, err := s.store.Index("by_normalized_email").GetAll(ctx, nil, normalizedEmail)
 	if err != nil {

--- a/gestaltd/internal/mcp/binding_test.go
+++ b/gestaltd/internal/mcp/binding_test.go
@@ -1488,6 +1488,75 @@ func TestNewServer_HumanListToolsDoesNotLeakAcrossStatelessSessions(t *testing.T
 	}
 }
 
+func TestNewServer_HumanListToolsFiltersRoleRestrictedTools_DynamicGrant(t *testing.T) {
+	t.Parallel()
+
+	staticCat := &catalog.Catalog{
+		Name: "sampledb",
+		Operations: []catalog.CatalogOperation{
+			{
+				ID:           "run_query",
+				Description:  "run a query",
+				Transport:    catalog.TransportMCPPassthrough,
+				AllowedRoles: []string{"viewer", "admin"},
+			},
+			{
+				ID:           "delete_table",
+				Description:  "delete a table",
+				Transport:    catalog.TransportMCPPassthrough,
+				AllowedRoles: []string{"admin"},
+			},
+			{
+				ID:          "export_results",
+				Description: "export results",
+				Transport:   catalog.TransportMCPPassthrough,
+			},
+		},
+	}
+
+	prov := &directCallerProvider{
+		StubIntegration: coretesting.StubIntegration{N: "sampledb", ConnMode: core.ConnectionModeNone},
+		cat:             staticCat,
+	}
+
+	providers := testutil.NewProviderRegistry(t, prov)
+	ds, userID := stubServicesWithToken(t, "sampledb")
+	authz, err := authorization.New(config.AuthorizationConfig{
+		Policies: map[string]config.HumanPolicyDef{
+			"sample_policy": {Default: "deny"},
+		},
+	}, map[string]*config.ProviderEntry{
+		"sampledb": {AuthorizationPolicy: "sample_policy"},
+	}, providers, map[string]string{}, ds.PluginAuthorizations)
+	if err != nil {
+		t.Fatalf("authorization.New: %v", err)
+	}
+	if _, err := ds.PluginAuthorizations.UpsertPluginAuthorization(context.Background(), &coredata.PluginAuthorizationMembership{
+		Plugin: "sampledb",
+		UserID: userID,
+		Email:  "test@example.com",
+		Role:   "viewer",
+	}); err != nil {
+		t.Fatalf("UpsertPluginAuthorization: %v", err)
+	}
+	if err := authz.ReloadDynamic(context.Background()); err != nil {
+		t.Fatalf("ReloadDynamic: %v", err)
+	}
+
+	broker := invocation.NewBroker(providers, ds.Users, ds.Tokens, invocation.WithAuthorizer(authz))
+	srv := gestaltmcp.NewServer(gestaltmcp.Config{
+		Invoker:       broker,
+		TokenResolver: broker,
+		Providers:     providers,
+		Authorizer:    authz,
+	})
+
+	viewerResult := listToolsForSession(t, srv, ctxWithPrincipal(userID), newTestSessionWithTools())
+	if len(viewerResult.Tools) != 1 || viewerResult.Tools[0].Name != "sampledb_run_query" {
+		t.Fatalf("viewer tool names = %+v, want only sampledb_run_query", viewerResult.Tools)
+	}
+}
+
 func TestNewServer_HumanListToolsHidesInternalInstanceMarkers(t *testing.T) {
 	t.Parallel()
 

--- a/gestaltd/internal/server/handlers_admin_authorization.go
+++ b/gestaltd/internal/server/handlers_admin_authorization.go
@@ -1,0 +1,442 @@
+package server
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"net/http"
+	"sort"
+	"strings"
+	"time"
+
+	"github.com/go-chi/chi/v5"
+	"github.com/valon-technologies/gestalt/server/core"
+	"github.com/valon-technologies/gestalt/server/internal/config"
+	"github.com/valon-technologies/gestalt/server/internal/coredata"
+	"github.com/valon-technologies/gestalt/server/internal/emailutil"
+	"github.com/valon-technologies/gestalt/server/internal/invocation"
+	"github.com/valon-technologies/gestalt/server/internal/principal"
+)
+
+type adminAuthorizationPluginInfo struct {
+	Name                string `json:"name"`
+	AuthorizationPolicy string `json:"authorizationPolicy"`
+	MountedUIPath       string `json:"mountedUiPath,omitempty"`
+}
+
+type adminAuthorizationMemberRow struct {
+	Plugin        string `json:"plugin"`
+	Role          string `json:"role"`
+	Source        string `json:"source"`
+	Effective     bool   `json:"effective"`
+	Mutable       bool   `json:"mutable"`
+	SelectorKind  string `json:"selectorKind"`
+	SelectorValue string `json:"selectorValue"`
+	UserID        string `json:"userId,omitempty"`
+	Email         string `json:"email,omitempty"`
+	ShadowedBy    string `json:"shadowedBy,omitempty"`
+}
+
+type putAdminAuthorizationMemberRequest struct {
+	Email string `json:"email"`
+	Role  string `json:"role"`
+}
+
+func (s *Server) mountAdminAuthorizationRoutes(r chi.Router) {
+	r.Get("/authorization/plugins", s.listAdminAuthorizationPlugins)
+	r.Get("/authorization/plugins/{plugin}/members", s.listAdminAuthorizationPluginMembers)
+	r.Put("/authorization/plugins/{plugin}/members", s.putAdminAuthorizationPluginMember)
+	r.Delete("/authorization/plugins/{plugin}/members/{userID}", s.deleteAdminAuthorizationPluginMember)
+}
+
+func (s *Server) adminAPIAuthMiddleware(next http.Handler) http.Handler {
+	if s.adminRoute.AuthorizationPolicy == "" {
+		return next
+	}
+
+	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if s.authorizer == nil {
+			writeError(w, http.StatusInternalServerError, "admin authorization is unavailable")
+			return
+		}
+
+		p, authenticated, err := s.resolveMountedWebUIPrincipal(r)
+		if err != nil {
+			writeError(w, http.StatusInternalServerError, "failed to resolve user")
+			return
+		}
+		if !authenticated {
+			writeError(w, http.StatusUnauthorized, "missing authorization")
+			return
+		}
+		if p.Kind == principal.KindWorkload {
+			writeError(w, http.StatusForbidden, "workload callers are not allowed on this route")
+			return
+		}
+
+		access, allowed := s.authorizer.ResolvePolicyAccess(p, s.adminRoute.AuthorizationPolicy)
+		if !allowed || !mountedWebUIRoleAllowed(access.Role, s.adminRoute.AllowedRoles) {
+			writeError(w, http.StatusForbidden, "admin access denied")
+			return
+		}
+
+		ctx := r.Context()
+		if p != nil {
+			ctx = principal.WithPrincipal(ctx, p)
+		}
+		if access.Policy != "" || access.Role != "" {
+			ctx = invocation.WithAccessContext(ctx, access)
+		}
+		next.ServeHTTP(w, r.WithContext(ctx))
+	})
+}
+
+func (s *Server) listAdminAuthorizationPlugins(w http.ResponseWriter, r *http.Request) {
+	names := make([]string, 0, len(s.pluginDefs))
+	for name, entry := range s.pluginDefs {
+		if entry == nil || strings.TrimSpace(entry.AuthorizationPolicy) == "" {
+			continue
+		}
+		names = append(names, name)
+	}
+	sort.Strings(names)
+
+	out := make([]adminAuthorizationPluginInfo, 0, len(names))
+	for _, name := range names {
+		entry := s.pluginDefs[name]
+		out = append(out, adminAuthorizationPluginInfo{
+			Name:                name,
+			AuthorizationPolicy: strings.TrimSpace(entry.AuthorizationPolicy),
+			MountedUIPath:       strings.TrimSpace(entry.MountPath),
+		})
+	}
+	writeJSON(w, http.StatusOK, out)
+}
+
+func (s *Server) listAdminAuthorizationPluginMembers(w http.ResponseWriter, r *http.Request) {
+	plugin, _, err := s.adminAuthorizationPluginEntry(chi.URLParam(r, "plugin"))
+	if err != nil {
+		s.writeAdminAuthorizationPluginError(w, err)
+		return
+	}
+	if !s.ensureAdminDynamicAuthorizationAvailable(w) {
+		return
+	}
+
+	rows, err := s.adminAuthorizationMemberRows(r.Context(), plugin)
+	if err != nil {
+		writeError(w, http.StatusInternalServerError, "failed to list authorization members")
+		return
+	}
+	writeJSON(w, http.StatusOK, rows)
+}
+
+func (s *Server) putAdminAuthorizationPluginMember(w http.ResponseWriter, r *http.Request) {
+	plugin, _, err := s.adminAuthorizationPluginEntry(chi.URLParam(r, "plugin"))
+	if err != nil {
+		s.writeAdminAuthorizationPluginError(w, err)
+		return
+	}
+	if !s.ensureAdminDynamicAuthorizationAvailable(w) {
+		return
+	}
+
+	var req putAdminAuthorizationMemberRequest
+	if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
+		writeError(w, http.StatusBadRequest, "invalid JSON body")
+		return
+	}
+	if emailutil.Normalize(req.Email) == "" {
+		writeError(w, http.StatusBadRequest, "email is required")
+		return
+	}
+	if strings.TrimSpace(req.Role) == "" {
+		writeError(w, http.StatusBadRequest, "role is required")
+		return
+	}
+	user, err := s.users.FindOrCreateUser(r.Context(), req.Email)
+	if err != nil {
+		writeError(w, http.StatusInternalServerError, "failed to resolve user")
+		return
+	}
+	if access, ok := s.authorizer.StaticRoleForProviderIdentity(plugin, principal.UserSubjectID(user.ID), user.ID, user.Email); ok && access.Role != "" {
+		writeError(w, http.StatusConflict, "user already has static authorization for this plugin")
+		return
+	}
+
+	membership, err := s.pluginAuthorizations.UpsertPluginAuthorization(r.Context(), &coredata.PluginAuthorizationMembership{
+		Plugin: plugin,
+		UserID: user.ID,
+		Email:  user.Email,
+		Role:   req.Role,
+	})
+	if err != nil {
+		writeError(w, http.StatusInternalServerError, "failed to persist authorization member")
+		return
+	}
+
+	row := adminAuthorizationMemberRow{
+		Plugin:        membership.Plugin,
+		Role:          membership.Role,
+		Source:        "dynamic",
+		Effective:     true,
+		Mutable:       true,
+		SelectorKind:  "user_id",
+		SelectorValue: membership.UserID,
+		UserID:        membership.UserID,
+		Email:         membership.Email,
+	}
+	if err := s.reloadDynamicAuthorizations(r.Context()); err != nil {
+		writeJSON(w, http.StatusAccepted, map[string]any{
+			"status":     "persisted_pending_reload",
+			"persisted":  true,
+			"reloaded":   false,
+			"membership": row,
+		})
+		return
+	}
+	writeJSON(w, http.StatusOK, map[string]any{
+		"status":     "ok",
+		"persisted":  true,
+		"reloaded":   true,
+		"membership": row,
+	})
+}
+
+func (s *Server) deleteAdminAuthorizationPluginMember(w http.ResponseWriter, r *http.Request) {
+	plugin, _, err := s.adminAuthorizationPluginEntry(chi.URLParam(r, "plugin"))
+	if err != nil {
+		s.writeAdminAuthorizationPluginError(w, err)
+		return
+	}
+	if !s.ensureAdminDynamicAuthorizationAvailable(w) {
+		return
+	}
+	userID := strings.TrimSpace(chi.URLParam(r, "userID"))
+	if userID == "" {
+		writeError(w, http.StatusBadRequest, "userID is required")
+		return
+	}
+
+	if err := s.pluginAuthorizations.DeletePluginAuthorization(r.Context(), plugin, userID); err != nil {
+		if errors.Is(err, core.ErrNotFound) {
+			writeError(w, http.StatusNotFound, "authorization member not found")
+			return
+		}
+		writeError(w, http.StatusInternalServerError, "failed to delete authorization member")
+		return
+	}
+
+	if err := s.reloadDynamicAuthorizations(r.Context()); err != nil {
+		writeJSON(w, http.StatusAccepted, map[string]any{
+			"status":    "persisted_pending_reload",
+			"persisted": true,
+			"reloaded":  false,
+		})
+		return
+	}
+	writeJSON(w, http.StatusOK, map[string]any{
+		"status":    "deleted",
+		"persisted": true,
+		"reloaded":  true,
+	})
+}
+
+func (s *Server) adminAuthorizationPluginEntry(plugin string) (string, *config.ProviderEntry, error) {
+	plugin = strings.TrimSpace(plugin)
+	if plugin == "" {
+		return "", nil, errAdminAuthorizationPluginMissing
+	}
+	entry := s.pluginDefs[plugin]
+	if entry == nil {
+		return "", nil, errAdminAuthorizationPluginUnknown
+	}
+	if strings.TrimSpace(entry.AuthorizationPolicy) == "" {
+		return "", nil, errAdminAuthorizationPluginUnbound
+	}
+	return plugin, entry, nil
+}
+
+func (s *Server) writeAdminAuthorizationPluginError(w http.ResponseWriter, err error) {
+	switch err {
+	case errAdminAuthorizationPluginMissing:
+		writeError(w, http.StatusBadRequest, "plugin is required")
+	case errAdminAuthorizationPluginUnknown:
+		writeError(w, http.StatusNotFound, "plugin not found")
+	case errAdminAuthorizationPluginUnbound:
+		writeError(w, http.StatusBadRequest, "plugin does not declare authorizationPolicy")
+	default:
+		writeError(w, http.StatusInternalServerError, "plugin authorization failed")
+	}
+}
+
+func (s *Server) adminAuthorizationMemberRows(ctx context.Context, plugin string) ([]adminAuthorizationMemberRow, error) {
+	if s.pluginAuthorizations == nil || s.authorizer == nil || !s.authorizer.HasDynamicAuthorizations() {
+		return nil, errAdminAuthorizationUnavailable
+	}
+	staticRows, err := s.adminAuthorizationStaticRows(ctx, plugin)
+	if err != nil {
+		return nil, err
+	}
+	dynamicMemberships, err := s.pluginAuthorizations.ListPluginAuthorizationsByPlugin(ctx, plugin)
+	if err != nil {
+		return nil, err
+	}
+
+	staticByUserID := make(map[string]string, len(staticRows))
+	staticByEmail := make(map[string]string, len(staticRows))
+	rows := make([]adminAuthorizationMemberRow, 0, len(staticRows)+len(dynamicMemberships))
+	for i := range staticRows {
+		row := &staticRows[i]
+		rows = append(rows, *row)
+		key := row.adminAuthorizationRowKey()
+		if row.UserID != "" {
+			staticByUserID[row.UserID] = key
+		}
+		if email := normalizedRowEmail(*row); email != "" {
+			staticByEmail[email] = key
+		}
+	}
+
+	for _, membership := range dynamicMemberships {
+		if membership == nil {
+			continue
+		}
+		row := adminAuthorizationMemberRow{
+			Plugin:        membership.Plugin,
+			Role:          membership.Role,
+			Source:        "dynamic",
+			Effective:     true,
+			Mutable:       true,
+			SelectorKind:  "user_id",
+			SelectorValue: membership.UserID,
+			UserID:        membership.UserID,
+			Email:         membership.Email,
+		}
+		if shadow, ok := staticByUserID[row.UserID]; ok {
+			row.Effective = false
+			row.ShadowedBy = shadow
+		} else if shadow, ok := staticByEmail[normalizedRowEmail(row)]; ok {
+			row.Effective = false
+			row.ShadowedBy = shadow
+		}
+		rows = append(rows, row)
+	}
+
+	sort.Slice(rows, func(i, j int) bool {
+		if rows[i].Source != rows[j].Source {
+			return rows[i].Source < rows[j].Source
+		}
+		if rows[i].SelectorKind != rows[j].SelectorKind {
+			return rows[i].SelectorKind < rows[j].SelectorKind
+		}
+		if rows[i].SelectorValue != rows[j].SelectorValue {
+			return rows[i].SelectorValue < rows[j].SelectorValue
+		}
+		return rows[i].Role < rows[j].Role
+	})
+	return rows, nil
+}
+
+func (s *Server) adminAuthorizationStaticRows(ctx context.Context, plugin string) ([]adminAuthorizationMemberRow, error) {
+	_, members, ok := s.authorizer.StaticMembersForProvider(plugin)
+	if !ok {
+		return nil, nil
+	}
+	rows := make([]adminAuthorizationMemberRow, 0, len(members))
+	for _, member := range members {
+		row := adminAuthorizationMemberRow{
+			Plugin:    plugin,
+			Role:      member.Role,
+			Source:    "static",
+			Effective: true,
+			Mutable:   false,
+		}
+		switch {
+		case member.Email != "":
+			row.SelectorKind = "email"
+			row.SelectorValue = member.Email
+			user, err := s.users.FindUserByEmail(ctx, member.Email)
+			switch {
+			case err == nil:
+				row.UserID = user.ID
+				row.Email = user.Email
+			case errors.Is(err, core.ErrNotFound):
+				row.Email = member.Email
+			case err != nil:
+				return nil, err
+			}
+		case strings.HasPrefix(member.SubjectID, string(principal.KindUser)+":"):
+			userID := strings.TrimPrefix(member.SubjectID, string(principal.KindUser)+":")
+			row.SelectorKind = "user_id"
+			row.SelectorValue = userID
+			row.UserID = userID
+			user, err := s.users.GetUser(ctx, userID)
+			switch {
+			case err == nil:
+				row.Email = user.Email
+			case errors.Is(err, core.ErrNotFound):
+			case err != nil:
+				return nil, err
+			}
+		default:
+			row.SelectorKind = "subject_id"
+			row.SelectorValue = member.SubjectID
+		}
+		rows = append(rows, row)
+	}
+	return rows, nil
+}
+
+func (s *Server) reloadDynamicAuthorizations(ctx context.Context) error {
+	if s.authorizer == nil {
+		return nil
+	}
+
+	var lastErr error
+	for i := 0; i < 3; i++ {
+		if err := s.authorizer.ReloadDynamic(ctx); err == nil {
+			return nil
+		} else {
+			lastErr = err
+		}
+		if i == 2 {
+			break
+		}
+		select {
+		case <-ctx.Done():
+			return ctx.Err()
+		case <-time.After(time.Duration(i+1) * 50 * time.Millisecond):
+		}
+	}
+	return lastErr
+}
+
+func (r adminAuthorizationMemberRow) adminAuthorizationRowKey() string {
+	return r.Source + ":" + r.SelectorKind + ":" + r.SelectorValue
+}
+
+func normalizedRowEmail(row adminAuthorizationMemberRow) string {
+	if row.Email != "" {
+		return strings.ToLower(strings.TrimSpace(row.Email))
+	}
+	if row.SelectorKind == "email" {
+		return strings.ToLower(strings.TrimSpace(row.SelectorValue))
+	}
+	return ""
+}
+
+var (
+	errAdminAuthorizationPluginMissing = errors.New("plugin is required")
+	errAdminAuthorizationPluginUnknown = errors.New("plugin not found")
+	errAdminAuthorizationPluginUnbound = errors.New("plugin does not declare authorizationPolicy")
+	errAdminAuthorizationUnavailable   = errors.New("dynamic authorization is unavailable")
+)
+
+func (s *Server) ensureAdminDynamicAuthorizationAvailable(w http.ResponseWriter) bool {
+	if s.pluginAuthorizations == nil || s.authorizer == nil || !s.authorizer.HasDynamicAuthorizations() {
+		writeError(w, http.StatusServiceUnavailable, "dynamic authorization is unavailable")
+		return false
+	}
+	return true
+}

--- a/gestaltd/internal/server/mounted_ui.go
+++ b/gestaltd/internal/server/mounted_ui.go
@@ -253,7 +253,15 @@ func (s *Server) authorizeProtectedUIRequest(w http.ResponseWriter, r *http.Requ
 		return nil, false
 	}
 
-	access, allowed := s.authorizer.ResolvePolicyAccess(p, mounted.AuthorizationPolicy)
+	var (
+		access  invocation.AccessContext
+		allowed bool
+	)
+	if mounted.PluginName != "" {
+		access, allowed = s.authorizer.ResolveAccess(p, mounted.PluginName)
+	} else {
+		access, allowed = s.authorizer.ResolvePolicyAccess(p, mounted.AuthorizationPolicy)
+	}
 	if !allowed {
 		writeError(w, http.StatusForbidden, "app access denied")
 		return nil, false

--- a/gestaltd/internal/server/routes.go
+++ b/gestaltd/internal/server/routes.go
@@ -24,12 +24,14 @@ func (s *Server) routes() {
 	case RouteProfileManagement:
 		s.mountCoreRoutes(r, metricsUnauthenticated)
 		s.mountManagementRootRedirect(r)
+		s.mountAdminAPIRoutes(r)
 		s.mountAdminUIRoutes(r)
 	default:
 		s.mountCoreRoutes(r, metricsAuthenticated)
 		s.mountMCPRoutes(r)
 		s.mountAPIRoutes(r)
 		s.mountMountedWebUIRoutes(r)
+		s.mountAdminAPIRoutes(r)
 		s.mountAdminUIRoutes(r)
 	}
 }
@@ -77,6 +79,16 @@ func (s *Server) mountAdminUIRoutes(r chi.Router) {
 	r.Handle("/admin/*", s.adminUIHandler())
 }
 
+func (s *Server) mountAdminAPIRoutes(r chi.Router) {
+	r.Route("/admin/api/v1", func(r chi.Router) {
+		r.Use(middleware.Timeout(60 * time.Second))
+		if s.adminRoute.AuthorizationPolicy != "" {
+			r.Use(s.adminAPIAuthMiddleware)
+		}
+		s.mountAdminAuthorizationRoutes(r)
+	})
+}
+
 func (s *Server) mountMountedWebUIRoutes(r chi.Router) {
 	var rootHandler http.Handler
 	for _, mounted := range s.mountedWebUIs {
@@ -109,6 +121,8 @@ func redirectPreservingQuery(w http.ResponseWriter, r *http.Request, target stri
 func (s *Server) mountManagementHiddenRoutes(r chi.Router) {
 	notFound := http.NotFoundHandler()
 	r.Handle("/metrics", notFound)
+	r.Handle("/admin/api/v1", notFound)
+	r.Handle("/admin/api/v1/*", notFound)
 	r.Handle("/admin", notFound)
 	r.Handle("/admin/*", notFound)
 }

--- a/gestaltd/internal/server/server.go
+++ b/gestaltd/internal/server/server.go
@@ -43,6 +43,7 @@ type MountedWebUIRoute struct {
 type MountedWebUI struct {
 	Name                string
 	Path                string
+	PluginName          string
 	AuthorizationPolicy string
 	Routes              []MountedWebUIRoute
 	Handler             http.Handler
@@ -54,38 +55,39 @@ type AdminRouteConfig struct {
 }
 
 type Server struct {
-	router             chi.Router
-	handler            http.Handler
-	auth               core.AuthProvider
-	auditSink          core.AuditSink
-	users              *coredata.UserService
-	tokens             *coredata.TokenService
-	apiTokens          *coredata.APITokenService
-	providers          *registry.ProviderMap[core.Provider]
-	resolver           *principal.Resolver
-	invoker            invocation.Invoker
-	defaultConnection  map[string]string
-	catalogConnection  map[string]string
-	connectionAuth     func() map[string]map[string]bootstrap.OAuthHandler
-	pluginDefs         map[string]*config.ProviderEntry
-	authorizer         *authorization.Authorizer
-	noAuth             bool
-	anonymousPrincipal *principal.Principal
-	publicBaseURL      string
-	managementBaseURL  string
-	secureCookies      bool
-	encryptor          *cryptoutil.AESGCMEncryptor
-	sessionIssuer      []byte
-	stateCodec         *integrationOAuthStateCodec
-	apiTokenTTL        time.Duration
-	now                func() time.Time
-	readiness          ReadinessChecker
-	prometheusMetrics  http.Handler
-	mcpHandler         http.Handler
-	mountedWebUIs      []MountedWebUI
-	adminRoute         AdminRouteConfig
-	adminUI            http.Handler
-	routeProfile       RouteProfile
+	router               chi.Router
+	handler              http.Handler
+	auth                 core.AuthProvider
+	auditSink            core.AuditSink
+	users                *coredata.UserService
+	tokens               *coredata.TokenService
+	apiTokens            *coredata.APITokenService
+	pluginAuthorizations *coredata.PluginAuthorizationService
+	providers            *registry.ProviderMap[core.Provider]
+	resolver             *principal.Resolver
+	invoker              invocation.Invoker
+	defaultConnection    map[string]string
+	catalogConnection    map[string]string
+	connectionAuth       func() map[string]map[string]bootstrap.OAuthHandler
+	pluginDefs           map[string]*config.ProviderEntry
+	authorizer           *authorization.Authorizer
+	noAuth               bool
+	anonymousPrincipal   *principal.Principal
+	publicBaseURL        string
+	managementBaseURL    string
+	secureCookies        bool
+	encryptor            *cryptoutil.AESGCMEncryptor
+	sessionIssuer        []byte
+	stateCodec           *integrationOAuthStateCodec
+	apiTokenTTL          time.Duration
+	now                  func() time.Time
+	readiness            ReadinessChecker
+	prometheusMetrics    http.Handler
+	mcpHandler           http.Handler
+	mountedWebUIs        []MountedWebUI
+	adminRoute           AdminRouteConfig
+	adminUI              http.Handler
+	routeProfile         RouteProfile
 }
 
 type Config struct {
@@ -155,6 +157,7 @@ func New(cfg Config) (*Server, error) {
 	users := cfg.Services.Users
 	tokens := cfg.Services.Tokens
 	apiTokens := cfg.Services.APITokens
+	pluginAuthorizations := cfg.Services.PluginAuthorizations
 	resolver := principal.NewResolver(cfg.Auth, users, apiTokens, cfg.Authorizer)
 
 	router := chi.NewRouter()
@@ -163,37 +166,38 @@ func New(cfg Config) (*Server, error) {
 		otelOptions = append(otelOptions, otelhttp.WithMeterProvider(cfg.MeterProvider))
 	}
 	s := &Server{
-		router:            router,
-		handler:           withRequestMeterProvider(otelhttp.NewHandler(router, "gestaltd", otelOptions...), cfg.MeterProvider),
-		auth:              cfg.Auth,
-		auditSink:         cfg.AuditSink,
-		users:             users,
-		tokens:            tokens,
-		apiTokens:         apiTokens,
-		providers:         cfg.Providers,
-		resolver:          resolver,
-		invoker:           cfg.Invoker,
-		defaultConnection: cfg.DefaultConnection,
-		catalogConnection: cfg.CatalogConnection,
-		connectionAuth:    cfg.ConnectionAuth,
-		pluginDefs:        cfg.PluginDefs,
-		authorizer:        cfg.Authorizer,
-		noAuth:            noAuth,
-		publicBaseURL:     strings.TrimRight(cfg.PublicBaseURL, "/"),
-		managementBaseURL: strings.TrimRight(cfg.ManagementBaseURL, "/"),
-		secureCookies:     cfg.SecureCookies,
-		encryptor:         encryptor,
-		sessionIssuer:     cfg.StateSecret,
-		stateCodec:        stateCodec,
-		apiTokenTTL:       cfg.APITokenTTL,
-		now:               now,
-		readiness:         cfg.Readiness,
-		prometheusMetrics: cfg.PrometheusMetrics,
-		mcpHandler:        cfg.MCPHandler,
-		mountedWebUIs:     mountedWebUIs,
-		adminRoute:        adminRoute,
-		adminUI:           cfg.AdminUI,
-		routeProfile:      cfg.RouteProfile,
+		router:               router,
+		handler:              withRequestMeterProvider(otelhttp.NewHandler(router, "gestaltd", otelOptions...), cfg.MeterProvider),
+		auth:                 cfg.Auth,
+		auditSink:            cfg.AuditSink,
+		users:                users,
+		tokens:               tokens,
+		apiTokens:            apiTokens,
+		pluginAuthorizations: pluginAuthorizations,
+		providers:            cfg.Providers,
+		resolver:             resolver,
+		invoker:              cfg.Invoker,
+		defaultConnection:    cfg.DefaultConnection,
+		catalogConnection:    cfg.CatalogConnection,
+		connectionAuth:       cfg.ConnectionAuth,
+		pluginDefs:           cfg.PluginDefs,
+		authorizer:           cfg.Authorizer,
+		noAuth:               noAuth,
+		publicBaseURL:        strings.TrimRight(cfg.PublicBaseURL, "/"),
+		managementBaseURL:    strings.TrimRight(cfg.ManagementBaseURL, "/"),
+		secureCookies:        cfg.SecureCookies,
+		encryptor:            encryptor,
+		sessionIssuer:        cfg.StateSecret,
+		stateCodec:           stateCodec,
+		apiTokenTTL:          cfg.APITokenTTL,
+		now:                  now,
+		readiness:            cfg.Readiness,
+		prometheusMetrics:    cfg.PrometheusMetrics,
+		mcpHandler:           cfg.MCPHandler,
+		mountedWebUIs:        mountedWebUIs,
+		adminRoute:           adminRoute,
+		adminUI:              cfg.AdminUI,
+		routeProfile:         cfg.RouteProfile,
 	}
 	if noAuth {
 		s.anonymousPrincipal = resolver.ResolveEmail(anonymousEmail)

--- a/gestaltd/internal/server/server_test.go
+++ b/gestaltd/internal/server/server_test.go
@@ -113,15 +113,16 @@ func newTestHandler(t *testing.T, opts ...func(*server.Config)) http.Handler {
 
 type putFailingIndexedDB struct {
 	indexeddb.IndexedDB
-	failUsersPut *atomic.Bool
+	failStorePuts map[string]*atomic.Bool
 }
 
 func (d *putFailingIndexedDB) ObjectStore(name string) indexeddb.ObjectStore {
 	store := d.IndexedDB.ObjectStore(name)
-	if name != coredata.StoreUsers {
+	failPut := d.failStorePuts[name]
+	if failPut == nil {
 		return store
 	}
-	return &putFailingObjectStore{ObjectStore: store, failPut: d.failUsersPut}
+	return &putFailingObjectStore{ObjectStore: store, failPut: failPut}
 }
 
 type putFailingObjectStore struct {
@@ -144,11 +145,32 @@ func newTestServicesWithUsersPutFailure(t *testing.T) (*coredata.Services, *atom
 	}
 	failPut := &atomic.Bool{}
 	svc, err := coredata.New(&putFailingIndexedDB{
-		IndexedDB:    &coretesting.StubIndexedDB{},
-		failUsersPut: failPut,
+		IndexedDB: &coretesting.StubIndexedDB{},
+		failStorePuts: map[string]*atomic.Bool{
+			coredata.StoreUsers: failPut,
+		},
 	}, enc)
 	if err != nil {
 		t.Fatalf("newTestServicesWithUsersPutFailure: %v", err)
+	}
+	return svc, failPut
+}
+
+func newTestServicesWithPluginAuthorizationPutFailure(t *testing.T) (*coredata.Services, *atomic.Bool) {
+	t.Helper()
+	enc, err := corecrypto.NewAESGCM([]byte("0123456789abcdef0123456789abcdef"))
+	if err != nil {
+		t.Fatalf("newTestServicesWithPluginAuthorizationPutFailure encryptor: %v", err)
+	}
+	failPut := &atomic.Bool{}
+	svc, err := coredata.New(&putFailingIndexedDB{
+		IndexedDB: &coretesting.StubIndexedDB{},
+		failStorePuts: map[string]*atomic.Bool{
+			coredata.StorePluginAuthorizationMemberships: failPut,
+		},
+	}, enc)
+	if err != nil {
+		t.Fatalf("newTestServicesWithPluginAuthorizationPutFailure: %v", err)
 	}
 	return svc, failPut
 }
@@ -327,6 +349,26 @@ func seedLegacyUserRecord(t *testing.T, svc *coredata.Services, id, email string
 		CreatedAt:   createdAt,
 		UpdatedAt:   createdAt,
 	}
+}
+
+func seedPluginAuthorization(t *testing.T, svc *coredata.Services, authz *authorization.Authorizer, plugin, email, role string) *core.User {
+	t.Helper()
+	ctx := context.Background()
+	user := seedUser(t, svc, email)
+	if _, err := svc.PluginAuthorizations.UpsertPluginAuthorization(ctx, &coredata.PluginAuthorizationMembership{
+		Plugin: plugin,
+		UserID: user.ID,
+		Email:  user.Email,
+		Role:   role,
+	}); err != nil {
+		t.Fatalf("seedPluginAuthorization: %v", err)
+	}
+	if authz != nil {
+		if err := authz.ReloadDynamic(ctx); err != nil {
+			t.Fatalf("seedPluginAuthorization reload: %v", err)
+		}
+	}
+	return user
 }
 
 func seedIdentityToken(t *testing.T, svc *coredata.Services, integration, connection, instance, accessToken string) {
@@ -877,6 +919,116 @@ func TestMountedWebUIRoutes_HumanAuthorization_DefaultAllowTreatsAuthenticatedUs
 	}
 }
 
+func TestMountedWebUIRoutes_HumanAuthorization_DynamicGrant(t *testing.T) {
+	t.Parallel()
+
+	dir := t.TempDir()
+	if err := os.WriteFile(filepath.Join(dir, "index.html"), []byte("<html>protected-sample-shell</html>"), 0o644); err != nil {
+		t.Fatalf("WriteFile index.html: %v", err)
+	}
+	handler, err := testutilWebUIHandler(dir)
+	if err != nil {
+		t.Fatalf("webui handler: %v", err)
+	}
+
+	svc := coretesting.NewStubServices(t)
+	adminUser := seedUser(t, svc, "admin@example.test")
+	authz, err := authorization.New(config.AuthorizationConfig{
+		Policies: map[string]config.HumanPolicyDef{
+			"sample_policy": {
+				Default: "deny",
+				Members: []config.HumanPolicyMemberDef{
+					{SubjectID: principal.UserSubjectID(adminUser.ID), Role: "admin"},
+				},
+			},
+		},
+	}, map[string]*config.ProviderEntry{
+		"sample_portal": {AuthorizationPolicy: "sample_policy"},
+	}, nil, nil, svc.PluginAuthorizations)
+	if err != nil {
+		t.Fatalf("authorization.New: %v", err)
+	}
+	seedPluginAuthorization(t, svc, authz, "sample_portal", "viewer@example.test", "viewer")
+	seedPluginAuthorization(t, svc, authz, "sample_portal", "admin@example.test", "viewer")
+
+	ts := newTestServer(t, func(cfg *server.Config) {
+		cfg.Auth = &coretesting.StubAuthProvider{
+			N: "test",
+			ValidateTokenFn: func(_ context.Context, token string) (*core.UserIdentity, error) {
+				switch token {
+				case "viewer-session":
+					return &core.UserIdentity{Email: "viewer@example.test"}, nil
+				case "admin-session":
+					return &core.UserIdentity{Email: "admin@example.test"}, nil
+				default:
+					return nil, fmt.Errorf("invalid token")
+				}
+			},
+		}
+		cfg.Services = svc
+		cfg.Authorizer = authz
+		cfg.MountedWebUIs = []server.MountedWebUI{{
+			Name:                "sample_portal",
+			Path:                "/sample-portal",
+			PluginName:          "sample_portal",
+			AuthorizationPolicy: "sample_policy",
+			Routes: []server.MountedWebUIRoute{
+				{Path: "/admin/*", AllowedRoles: []string{"admin"}},
+				{Path: "/*", AllowedRoles: []string{"viewer", "admin"}},
+			},
+			Handler: handler,
+		}}
+	})
+	testutil.CloseOnCleanup(t, ts)
+
+	req, _ := http.NewRequest(http.MethodGet, ts.URL+"/sample-portal/sync", nil)
+	req.AddCookie(&http.Cookie{Name: "session_token", Value: "viewer-session"})
+	resp, err := http.DefaultClient.Do(req)
+	if err != nil {
+		t.Fatalf("GET dynamic mounted sync with viewer session: %v", err)
+	}
+	body, err := io.ReadAll(resp.Body)
+	_ = resp.Body.Close()
+	if err != nil {
+		t.Fatalf("ReadAll dynamic mounted sync: %v", err)
+	}
+	if resp.StatusCode != http.StatusOK {
+		t.Fatalf("dynamic viewer status = %d, want 200", resp.StatusCode)
+	}
+	if !strings.Contains(string(body), "protected-sample-shell") {
+		t.Fatalf("body = %q, want protected sample shell", body)
+	}
+
+	req, _ = http.NewRequest(http.MethodGet, ts.URL+"/sample-portal/admin", nil)
+	req.AddCookie(&http.Cookie{Name: "session_token", Value: "viewer-session"})
+	resp, err = http.DefaultClient.Do(req)
+	if err != nil {
+		t.Fatalf("GET dynamic mounted admin with viewer session: %v", err)
+	}
+	defer func() { _ = resp.Body.Close() }()
+	if resp.StatusCode != http.StatusForbidden {
+		t.Fatalf("dynamic viewer admin status = %d, want %d", resp.StatusCode, http.StatusForbidden)
+	}
+
+	req, _ = http.NewRequest(http.MethodGet, ts.URL+"/sample-portal/admin", nil)
+	req.AddCookie(&http.Cookie{Name: "session_token", Value: "admin-session"})
+	resp, err = http.DefaultClient.Do(req)
+	if err != nil {
+		t.Fatalf("GET dynamic mounted admin with admin session: %v", err)
+	}
+	body, err = io.ReadAll(resp.Body)
+	_ = resp.Body.Close()
+	if err != nil {
+		t.Fatalf("ReadAll dynamic mounted admin: %v", err)
+	}
+	if resp.StatusCode != http.StatusOK {
+		t.Fatalf("static-over-dynamic admin status = %d, want 200", resp.StatusCode)
+	}
+	if !strings.Contains(string(body), "protected-sample-shell") {
+		t.Fatalf("body = %q, want protected sample shell", body)
+	}
+}
+
 func TestBuiltInAdminRoute_HumanAuthorization(t *testing.T) {
 	t.Parallel()
 
@@ -1226,6 +1378,468 @@ func TestBuiltInAdminRoute_HumanAuthorizationSplitManagementLoginFlow(t *testing
 	}
 	if !strings.Contains(string(body), "protected-admin-shell") {
 		t.Fatalf("body = %q, want protected admin shell", body)
+	}
+}
+
+func TestAdminAPI_HumanAuthorization(t *testing.T) {
+	t.Parallel()
+
+	svc := coretesting.NewStubServices(t)
+	viewer := seedUser(t, svc, "viewer@example.test")
+	admin := seedUser(t, svc, "admin@example.test")
+	authz := mustAuthorizer(t, config.AuthorizationConfig{
+		Policies: map[string]config.HumanPolicyDef{
+			"admin_policy": {
+				Default: "deny",
+				Members: []config.HumanPolicyMemberDef{
+					{SubjectID: principal.UserSubjectID(viewer.ID), Role: "viewer"},
+					{SubjectID: principal.UserSubjectID(admin.ID), Role: "admin"},
+				},
+			},
+			"sample_policy": {Default: "deny"},
+		},
+	}, nil, map[string]*config.ProviderEntry{
+		"sample_plugin": {AuthorizationPolicy: "sample_policy"},
+	}, nil)
+
+	ts := newTestServer(t, func(cfg *server.Config) {
+		cfg.Auth = &coretesting.StubAuthProvider{
+			N: "test",
+			ValidateTokenFn: func(_ context.Context, token string) (*core.UserIdentity, error) {
+				switch token {
+				case "viewer-session":
+					return &core.UserIdentity{Email: "viewer@example.test"}, nil
+				case "admin-session":
+					return &core.UserIdentity{Email: "admin@example.test"}, nil
+				default:
+					return nil, fmt.Errorf("invalid token")
+				}
+			},
+		}
+		cfg.Services = svc
+		cfg.Authorizer = authz
+		cfg.PluginDefs = map[string]*config.ProviderEntry{
+			"sample_plugin": {AuthorizationPolicy: "sample_policy"},
+		}
+		cfg.Admin = server.AdminRouteConfig{
+			AuthorizationPolicy: "admin_policy",
+			AllowedRoles:        []string{"admin"},
+		}
+		cfg.AdminUI = http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+			_, _ = w.Write([]byte("admin"))
+		})
+	})
+	testutil.CloseOnCleanup(t, ts)
+
+	req, _ := http.NewRequest(http.MethodGet, ts.URL+"/admin/api/v1/authorization/plugins", nil)
+	resp, err := http.DefaultClient.Do(req)
+	if err != nil {
+		t.Fatalf("GET admin api without auth: %v", err)
+	}
+	defer func() { _ = resp.Body.Close() }()
+	if resp.StatusCode != http.StatusUnauthorized {
+		t.Fatalf("unauthenticated admin api status = %d, want %d", resp.StatusCode, http.StatusUnauthorized)
+	}
+
+	req, _ = http.NewRequest(http.MethodGet, ts.URL+"/admin/api/v1/authorization/plugins", nil)
+	req.AddCookie(&http.Cookie{Name: "session_token", Value: "viewer-session"})
+	resp, err = http.DefaultClient.Do(req)
+	if err != nil {
+		t.Fatalf("GET admin api with viewer session: %v", err)
+	}
+	defer func() { _ = resp.Body.Close() }()
+	if resp.StatusCode != http.StatusForbidden {
+		t.Fatalf("viewer admin api status = %d, want %d", resp.StatusCode, http.StatusForbidden)
+	}
+
+	req, _ = http.NewRequest(http.MethodGet, ts.URL+"/admin/api/v1/authorization/plugins", nil)
+	req.AddCookie(&http.Cookie{Name: "session_token", Value: "admin-session"})
+	resp, err = http.DefaultClient.Do(req)
+	if err != nil {
+		t.Fatalf("GET admin api with admin session: %v", err)
+	}
+	defer func() { _ = resp.Body.Close() }()
+	if resp.StatusCode != http.StatusOK {
+		body, _ := io.ReadAll(resp.Body)
+		t.Fatalf("admin api status = %d, want 200: %s", resp.StatusCode, body)
+	}
+
+	var plugins []map[string]any
+	if err := json.NewDecoder(resp.Body).Decode(&plugins); err != nil {
+		t.Fatalf("decoding plugins: %v", err)
+	}
+	if len(plugins) != 1 || plugins[0]["name"] != "sample_plugin" {
+		t.Fatalf("plugins = %+v, want sample_plugin", plugins)
+	}
+}
+
+func TestAdminAPI_RoutesMountedWithoutAdminUI(t *testing.T) {
+	t.Parallel()
+
+	ts := newTestServer(t, func(cfg *server.Config) {
+		cfg.PluginDefs = map[string]*config.ProviderEntry{
+			"sample_plugin": {AuthorizationPolicy: "sample_policy"},
+		}
+		cfg.AdminUI = nil
+	})
+	testutil.CloseOnCleanup(t, ts)
+
+	resp, err := http.Get(ts.URL + "/admin/api/v1/authorization/plugins")
+	if err != nil {
+		t.Fatalf("GET admin api without admin ui: %v", err)
+	}
+	defer func() { _ = resp.Body.Close() }()
+	if resp.StatusCode != http.StatusOK {
+		body, _ := io.ReadAll(resp.Body)
+		t.Fatalf("admin api without admin ui status = %d, want 200: %s", resp.StatusCode, body)
+	}
+
+	var plugins []map[string]any
+	if err := json.NewDecoder(resp.Body).Decode(&plugins); err != nil {
+		t.Fatalf("decoding plugins: %v", err)
+	}
+	if len(plugins) != 1 || plugins[0]["name"] != "sample_plugin" {
+		t.Fatalf("plugins = %+v, want sample_plugin", plugins)
+	}
+}
+
+func TestAdminAPI_HumanAuthorizationOnManagementProfile(t *testing.T) {
+	t.Parallel()
+
+	svc := coretesting.NewStubServices(t)
+	admin := seedUser(t, svc, "admin@example.test")
+	authz := mustAuthorizer(t, config.AuthorizationConfig{
+		Policies: map[string]config.HumanPolicyDef{
+			"admin_policy": {
+				Default: "deny",
+				Members: []config.HumanPolicyMemberDef{
+					{SubjectID: principal.UserSubjectID(admin.ID), Role: "admin"},
+				},
+			},
+			"sample_policy": {Default: "deny"},
+		},
+	}, nil, map[string]*config.ProviderEntry{
+		"sample_plugin": {AuthorizationPolicy: "sample_policy"},
+	}, nil)
+
+	ts := newTestServer(t, func(cfg *server.Config) {
+		cfg.Auth = &coretesting.StubAuthProvider{
+			N: "test",
+			ValidateTokenFn: func(_ context.Context, token string) (*core.UserIdentity, error) {
+				if token != "admin-session" {
+					return nil, fmt.Errorf("invalid token")
+				}
+				return &core.UserIdentity{Email: "admin@example.test"}, nil
+			},
+		}
+		cfg.Services = svc
+		cfg.Authorizer = authz
+		cfg.PluginDefs = map[string]*config.ProviderEntry{
+			"sample_plugin": {AuthorizationPolicy: "sample_policy"},
+		}
+		cfg.RouteProfile = server.RouteProfileManagement
+		cfg.PublicBaseURL = "https://gestalt.example.test"
+		cfg.ManagementBaseURL = "https://gestalt.example.test:9090"
+		cfg.Admin = server.AdminRouteConfig{
+			AuthorizationPolicy: "admin_policy",
+			AllowedRoles:        []string{"admin"},
+		}
+		cfg.AdminUI = http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+			_, _ = w.Write([]byte("admin"))
+		})
+	})
+	testutil.CloseOnCleanup(t, ts)
+
+	req, _ := http.NewRequest(http.MethodGet, ts.URL+"/admin/api/v1/authorization/plugins", nil)
+	req.AddCookie(&http.Cookie{Name: "session_token", Value: "admin-session"})
+	resp, err := http.DefaultClient.Do(req)
+	if err != nil {
+		t.Fatalf("GET management admin api with admin session: %v", err)
+	}
+	defer func() { _ = resp.Body.Close() }()
+	if resp.StatusCode != http.StatusOK {
+		body, _ := io.ReadAll(resp.Body)
+		t.Fatalf("management admin api status = %d, want 200: %s", resp.StatusCode, body)
+	}
+}
+
+func TestAdminAPI_HumanAuthorization_UserResolutionFailure(t *testing.T) {
+	t.Parallel()
+
+	svc := coretesting.NewStubServices(t)
+	admin := seedUser(t, svc, "admin@example.test")
+	authz := mustAuthorizer(t, config.AuthorizationConfig{
+		Policies: map[string]config.HumanPolicyDef{
+			"admin_policy": {
+				Default: "deny",
+				Members: []config.HumanPolicyMemberDef{
+					{SubjectID: principal.UserSubjectID(admin.ID), Role: "admin"},
+				},
+			},
+			"sample_policy": {Default: "deny"},
+		},
+	}, nil, map[string]*config.ProviderEntry{
+		"sample_plugin": {AuthorizationPolicy: "sample_policy"},
+	}, nil)
+
+	ts := newTestServer(t, func(cfg *server.Config) {
+		cfg.Auth = &coretesting.StubAuthProvider{
+			N: "test",
+			ValidateTokenFn: func(_ context.Context, token string) (*core.UserIdentity, error) {
+				if token != "admin-session" {
+					return nil, fmt.Errorf("invalid token")
+				}
+				return &core.UserIdentity{Email: "admin@example.test"}, nil
+			},
+		}
+		cfg.Services = svc
+		cfg.Authorizer = authz
+		cfg.PluginDefs = map[string]*config.ProviderEntry{
+			"sample_plugin": {AuthorizationPolicy: "sample_policy"},
+		}
+		cfg.Admin = server.AdminRouteConfig{
+			AuthorizationPolicy: "admin_policy",
+			AllowedRoles:        []string{"admin"},
+		}
+		cfg.AdminUI = http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+			_, _ = w.Write([]byte("admin"))
+		})
+	})
+	testutil.CloseOnCleanup(t, ts)
+
+	stubDB := svc.DB.(*coretesting.StubIndexedDB)
+	stubDB.Err = fmt.Errorf("database unavailable")
+	defer func() { stubDB.Err = nil }()
+
+	req, _ := http.NewRequest(http.MethodGet, ts.URL+"/admin/api/v1/authorization/plugins", nil)
+	req.AddCookie(&http.Cookie{Name: "session_token", Value: "admin-session"})
+	resp, err := http.DefaultClient.Do(req)
+	if err != nil {
+		t.Fatalf("GET admin api with failed user resolution: %v", err)
+	}
+	defer func() { _ = resp.Body.Close() }()
+	if resp.StatusCode != http.StatusInternalServerError {
+		body, _ := io.ReadAll(resp.Body)
+		t.Fatalf("admin api user-resolution failure status = %d, want 500: %s", resp.StatusCode, body)
+	}
+}
+
+func TestAdminAPIRoutes_HiddenOnPublicProfile(t *testing.T) {
+	t.Parallel()
+
+	ts := newTestServer(t, func(cfg *server.Config) {
+		cfg.RouteProfile = server.RouteProfilePublic
+		cfg.PluginDefs = map[string]*config.ProviderEntry{
+			"sample_plugin": {AuthorizationPolicy: "sample_policy"},
+		}
+		cfg.AdminUI = http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+			_, _ = w.Write([]byte("admin"))
+		})
+	})
+	testutil.CloseOnCleanup(t, ts)
+
+	resp, err := http.Get(ts.URL + "/admin/api/v1/authorization/plugins")
+	if err != nil {
+		t.Fatalf("GET public admin api: %v", err)
+	}
+	defer func() { _ = resp.Body.Close() }()
+	if resp.StatusCode != http.StatusNotFound {
+		t.Fatalf("public admin api status = %d, want %d", resp.StatusCode, http.StatusNotFound)
+	}
+}
+
+func TestAdminAPI_PluginAuthorizationCRUD(t *testing.T) {
+	t.Parallel()
+
+	svc := coretesting.NewStubServices(t)
+	authz, err := authorization.New(config.AuthorizationConfig{
+		Policies: map[string]config.HumanPolicyDef{
+			"sample_policy": {
+				Default: "deny",
+				Members: []config.HumanPolicyMemberDef{
+					{Email: "static@example.test", Role: "admin"},
+				},
+			},
+		},
+	}, map[string]*config.ProviderEntry{
+		"sample_plugin": {AuthorizationPolicy: "sample_policy", MountPath: "/sample"},
+	}, nil, nil, svc.PluginAuthorizations)
+	if err != nil {
+		t.Fatalf("authorization.New: %v", err)
+	}
+
+	ts := newTestServer(t, func(cfg *server.Config) {
+		cfg.Services = svc
+		cfg.Authorizer = authz
+		cfg.PluginDefs = map[string]*config.ProviderEntry{
+			"sample_plugin": {AuthorizationPolicy: "sample_policy", MountPath: "/sample"},
+		}
+		cfg.AdminUI = http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+			_, _ = w.Write([]byte("admin"))
+		})
+	})
+	testutil.CloseOnCleanup(t, ts)
+
+	resp, err := http.Get(ts.URL + "/admin/api/v1/authorization/plugins")
+	if err != nil {
+		t.Fatalf("GET plugins: %v", err)
+	}
+	defer func() { _ = resp.Body.Close() }()
+	if resp.StatusCode != http.StatusOK {
+		t.Fatalf("plugins status = %d, want 200", resp.StatusCode)
+	}
+
+	body := bytes.NewBufferString(`{"email":"dynamic@example.test","role":"viewer"}`)
+	req, _ := http.NewRequest(http.MethodPut, ts.URL+"/admin/api/v1/authorization/plugins/sample_plugin/members", body)
+	req.Header.Set("Content-Type", "application/json")
+	resp, err = http.DefaultClient.Do(req)
+	if err != nil {
+		t.Fatalf("PUT dynamic member: %v", err)
+	}
+	defer func() { _ = resp.Body.Close() }()
+	if resp.StatusCode != http.StatusOK {
+		respBody, _ := io.ReadAll(resp.Body)
+		t.Fatalf("put dynamic member status = %d, want 200: %s", resp.StatusCode, respBody)
+	}
+
+	resp, err = http.Get(ts.URL + "/admin/api/v1/authorization/plugins/sample_plugin/members")
+	if err != nil {
+		t.Fatalf("GET members: %v", err)
+	}
+	defer func() { _ = resp.Body.Close() }()
+	if resp.StatusCode != http.StatusOK {
+		t.Fatalf("members status = %d, want 200", resp.StatusCode)
+	}
+
+	var members []map[string]any
+	if err := json.NewDecoder(resp.Body).Decode(&members); err != nil {
+		t.Fatalf("decoding members: %v", err)
+	}
+	if len(members) != 2 {
+		t.Fatalf("expected 2 merged members, got %d (%+v)", len(members), members)
+	}
+
+	body = bytes.NewBufferString(`{"email":"static@example.test","role":"viewer"}`)
+	req, _ = http.NewRequest(http.MethodPut, ts.URL+"/admin/api/v1/authorization/plugins/sample_plugin/members", body)
+	req.Header.Set("Content-Type", "application/json")
+	resp, err = http.DefaultClient.Do(req)
+	if err != nil {
+		t.Fatalf("PUT static-conflict member: %v", err)
+	}
+	defer func() { _ = resp.Body.Close() }()
+	if resp.StatusCode != http.StatusConflict {
+		respBody, _ := io.ReadAll(resp.Body)
+		t.Fatalf("put static-conflict status = %d, want 409: %s", resp.StatusCode, respBody)
+	}
+
+	user, err := svc.Users.FindUserByEmail(context.Background(), "dynamic@example.test")
+	if err != nil {
+		t.Fatalf("find dynamic user: %v", err)
+	}
+	req, _ = http.NewRequest(http.MethodDelete, ts.URL+"/admin/api/v1/authorization/plugins/sample_plugin/members/"+url.PathEscape(user.ID), nil)
+	resp, err = http.DefaultClient.Do(req)
+	if err != nil {
+		t.Fatalf("DELETE dynamic member: %v", err)
+	}
+	defer func() { _ = resp.Body.Close() }()
+	if resp.StatusCode != http.StatusOK {
+		respBody, _ := io.ReadAll(resp.Body)
+		t.Fatalf("delete dynamic member status = %d, want 200: %s", resp.StatusCode, respBody)
+	}
+
+	resp, err = http.Get(ts.URL + "/admin/api/v1/authorization/plugins/sample_plugin/members")
+	if err != nil {
+		t.Fatalf("GET members after delete: %v", err)
+	}
+	defer func() { _ = resp.Body.Close() }()
+	if resp.StatusCode != http.StatusOK {
+		t.Fatalf("members after delete status = %d, want 200", resp.StatusCode)
+	}
+	members = nil
+	if err := json.NewDecoder(resp.Body).Decode(&members); err != nil {
+		t.Fatalf("decoding members after delete: %v", err)
+	}
+	if len(members) != 1 || members[0]["source"] != "static" {
+		t.Fatalf("members after delete = %+v, want only static row", members)
+	}
+}
+
+func TestAdminAPI_PluginAuthorizationUnavailable(t *testing.T) {
+	t.Parallel()
+
+	svc := coretesting.NewStubServices(t)
+	authz, err := authorization.New(config.AuthorizationConfig{
+		Policies: map[string]config.HumanPolicyDef{
+			"sample_policy": {Default: "deny"},
+		},
+	}, map[string]*config.ProviderEntry{
+		"sample_plugin": {AuthorizationPolicy: "sample_policy", MountPath: "/sample"},
+	}, nil, nil)
+	if err != nil {
+		t.Fatalf("authorization.New: %v", err)
+	}
+
+	ts := newTestServer(t, func(cfg *server.Config) {
+		cfg.Services = svc
+		cfg.Authorizer = authz
+		cfg.PluginDefs = map[string]*config.ProviderEntry{
+			"sample_plugin": {AuthorizationPolicy: "sample_policy", MountPath: "/sample"},
+		}
+		cfg.AdminUI = http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+			_, _ = w.Write([]byte("admin"))
+		})
+	})
+	testutil.CloseOnCleanup(t, ts)
+
+	resp, err := http.Get(ts.URL + "/admin/api/v1/authorization/plugins/sample_plugin/members")
+	if err != nil {
+		t.Fatalf("GET members: %v", err)
+	}
+	defer func() { _ = resp.Body.Close() }()
+	if resp.StatusCode != http.StatusServiceUnavailable {
+		t.Fatalf("members status = %d, want 503", resp.StatusCode)
+	}
+}
+
+func TestAdminAPI_PluginAuthorizationPutFailureReturnsServerError(t *testing.T) {
+	t.Parallel()
+
+	svc, failPut := newTestServicesWithPluginAuthorizationPutFailure(t)
+	authz, err := authorization.New(config.AuthorizationConfig{
+		Policies: map[string]config.HumanPolicyDef{
+			"sample_policy": {Default: "deny"},
+		},
+	}, map[string]*config.ProviderEntry{
+		"sample_plugin": {AuthorizationPolicy: "sample_policy", MountPath: "/sample"},
+	}, nil, nil, svc.PluginAuthorizations)
+	if err != nil {
+		t.Fatalf("authorization.New: %v", err)
+	}
+	failPut.Store(true)
+
+	ts := newTestServer(t, func(cfg *server.Config) {
+		cfg.Services = svc
+		cfg.Authorizer = authz
+		cfg.PluginDefs = map[string]*config.ProviderEntry{
+			"sample_plugin": {AuthorizationPolicy: "sample_policy", MountPath: "/sample"},
+		}
+		cfg.AdminUI = http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+			_, _ = w.Write([]byte("admin"))
+		})
+	})
+	testutil.CloseOnCleanup(t, ts)
+
+	body := bytes.NewBufferString(`{"email":"dynamic@example.test","role":"viewer"}`)
+	req, _ := http.NewRequest(http.MethodPut, ts.URL+"/admin/api/v1/authorization/plugins/sample_plugin/members", body)
+	req.Header.Set("Content-Type", "application/json")
+	resp, err := http.DefaultClient.Do(req)
+	if err != nil {
+		t.Fatalf("PUT dynamic member: %v", err)
+	}
+	defer func() { _ = resp.Body.Close() }()
+	if resp.StatusCode != http.StatusInternalServerError {
+		respBody, _ := io.ReadAll(resp.Body)
+		t.Fatalf("put dynamic member status = %d, want 500: %s", resp.StatusCode, respBody)
 	}
 }
 
@@ -4747,6 +5361,97 @@ func TestListOperations_HumanAuthorizationFiltersMergedCatalog(t *testing.T) {
 	}
 }
 
+func TestListOperations_HumanAuthorizationFiltersMergedCatalog_DynamicGrant(t *testing.T) {
+	t.Parallel()
+
+	plaintext, hashed, err := principal.GenerateToken(principal.TokenTypeAPI)
+	if err != nil {
+		t.Fatalf("GenerateToken: %v", err)
+	}
+
+	svc := coretesting.NewStubServices(t)
+	seedAPIToken(t, svc, plaintext, hashed, "viewer-user")
+	viewer := seedUser(t, svc, "viewer-user@test.local")
+	seedToken(t, svc, &core.IntegrationToken{
+		ID: "tok-cat-human", UserID: viewer.ID, Integration: "test-int",
+		Connection: testCatalogConnection, Instance: "default", AccessToken: testCatalogToken,
+	})
+
+	var gotAccess invocation.AccessContext
+	stub := &stubIntegrationWithSessionCatalog{
+		stubIntegrationWithOps: stubIntegrationWithOps{
+			StubIntegration: coretesting.StubIntegration{N: "test-int", ConnMode: core.ConnectionModeUser},
+		},
+		catalog: &catalog.Catalog{
+			Name: "test-int",
+			Operations: []catalog.CatalogOperation{
+				{ID: "public_static", Description: "Visible to anyone with app access", Method: http.MethodGet, Transport: catalog.TransportREST},
+				{ID: "admin_static", Description: "Admin only", Method: http.MethodGet, Transport: catalog.TransportREST, AllowedRoles: []string{"admin"}},
+			},
+		},
+		catalogForRequestFn: func(ctx context.Context, token string) (*catalog.Catalog, error) {
+			if token != testCatalogToken {
+				return nil, fmt.Errorf("unexpected token %q", token)
+			}
+			gotAccess = invocation.AccessContextFromContext(ctx)
+			return &catalog.Catalog{
+				Name: "test-int",
+				Operations: []catalog.CatalogOperation{
+					{ID: "viewer_session", Description: "Viewer session op", Method: http.MethodPost, Transport: catalog.TransportREST, AllowedRoles: []string{"viewer"}},
+					{ID: "admin_session", Description: "Admin session op", Method: http.MethodPost, Transport: catalog.TransportREST, AllowedRoles: []string{"admin"}},
+				},
+			}, nil
+		},
+	}
+
+	pluginDefs := map[string]*config.ProviderEntry{
+		"test-int": {AuthorizationPolicy: "sample_policy"},
+	}
+	authz, err := authorization.New(config.AuthorizationConfig{
+		Policies: map[string]config.HumanPolicyDef{
+			"sample_policy": {Default: "deny"},
+		},
+	}, pluginDefs, nil, nil, svc.PluginAuthorizations)
+	if err != nil {
+		t.Fatalf("authorization.New: %v", err)
+	}
+	seedPluginAuthorization(t, svc, authz, "test-int", "viewer-user@test.local", "viewer")
+
+	ts := newTestServer(t, func(cfg *server.Config) {
+		cfg.Auth = &coretesting.StubAuthProvider{N: "test"}
+		cfg.Providers = testutil.NewProviderRegistry(t, stub)
+		cfg.CatalogConnection = map[string]string{"test-int": testCatalogConnection}
+		cfg.Services = svc
+		cfg.Authorizer = authz
+		cfg.PluginDefs = pluginDefs
+	})
+	testutil.CloseOnCleanup(t, ts)
+
+	req, _ := http.NewRequest(http.MethodGet, ts.URL+"/api/v1/integrations/test-int/operations", nil)
+	req.Header.Set("Authorization", "Bearer "+plaintext)
+	resp, err := http.DefaultClient.Do(req)
+	if err != nil {
+		t.Fatalf("request: %v", err)
+	}
+	defer func() { _ = resp.Body.Close() }()
+
+	if resp.StatusCode != http.StatusOK {
+		body, _ := io.ReadAll(resp.Body)
+		t.Fatalf("expected 200, got %d: %s", resp.StatusCode, body)
+	}
+
+	var ops []map[string]any
+	if err := json.NewDecoder(resp.Body).Decode(&ops); err != nil {
+		t.Fatalf("decoding response: %v", err)
+	}
+	if len(ops) != 1 || ops[0]["id"] != "viewer_session" {
+		t.Fatalf("unexpected filtered operations: %+v", ops)
+	}
+	if gotAccess.Policy != "sample_policy" || gotAccess.Role != "viewer" {
+		t.Fatalf("unexpected access context propagated to session catalog: %+v", gotAccess)
+	}
+}
+
 func TestExecuteOperation_HumanAuthorizationUsesCatalogRoles(t *testing.T) {
 	t.Parallel()
 
@@ -5603,6 +6308,139 @@ func TestHumanAuthorization_ExecuteOperation_DefaultAllowTreatsAuthenticatedUser
 			},
 		},
 	}, nil, pluginDefs, nil)
+
+	var auditBuf bytes.Buffer
+	ts := newTestServer(t, func(cfg *server.Config) {
+		cfg.Auth = &coretesting.StubAuthProvider{N: "test"}
+		cfg.Providers = testutil.NewProviderRegistry(t, stub)
+		cfg.Services = svc
+		cfg.Authorizer = authz
+		cfg.PluginDefs = pluginDefs
+		cfg.AuditSink = invocation.NewSlogAuditSink(&auditBuf)
+	})
+	testutil.CloseOnCleanup(t, ts)
+
+	req, _ := http.NewRequest(http.MethodGet, ts.URL+"/api/v1/svc/run", nil)
+	req.Header.Set("Authorization", "Bearer "+plaintext)
+	resp, err := http.DefaultClient.Do(req)
+	if err != nil {
+		t.Fatalf("request: %v", err)
+	}
+	defer func() { _ = resp.Body.Close() }()
+	if resp.StatusCode != http.StatusOK {
+		body, _ := io.ReadAll(resp.Body)
+		t.Fatalf("expected 200, got %d: %s", resp.StatusCode, body)
+	}
+	var result map[string]any
+	if err := json.NewDecoder(resp.Body).Decode(&result); err != nil {
+		t.Fatalf("decoding: %v", err)
+	}
+	if result["policy"] != "sample_policy" || result["role"] != "viewer" {
+		t.Fatalf("unexpected access context in execute response: %+v", result)
+	}
+
+	req, _ = http.NewRequest(http.MethodGet, ts.URL+"/api/v1/svc/admin", nil)
+	req.Header.Set("Authorization", "Bearer "+plaintext)
+	resp, err = http.DefaultClient.Do(req)
+	if err != nil {
+		t.Fatalf("admin request: %v", err)
+	}
+	defer func() { _ = resp.Body.Close() }()
+	if resp.StatusCode != http.StatusForbidden {
+		body, _ := io.ReadAll(resp.Body)
+		t.Fatalf("expected 403, got %d: %s", resp.StatusCode, body)
+	}
+
+	lines := bytes.Split(bytes.TrimSpace(auditBuf.Bytes()), []byte("\n"))
+	if len(lines) == 0 {
+		t.Fatal("expected denial audit record")
+	}
+
+	var deniedAudit map[string]any
+	if err := json.Unmarshal(lines[len(lines)-1], &deniedAudit); err != nil {
+		t.Fatalf("parsing denied audit record: %v\nraw: %s", err, auditBuf.String())
+	}
+	if deniedAudit["provider"] != "svc" {
+		t.Fatalf("expected denied audit provider svc, got %v", deniedAudit["provider"])
+	}
+	if deniedAudit["operation"] != "admin" {
+		t.Fatalf("expected denied audit operation admin, got %v", deniedAudit["operation"])
+	}
+	if deniedAudit["allowed"] != false {
+		t.Fatalf("expected denied audit allowed=false, got %v", deniedAudit["allowed"])
+	}
+	if deniedAudit["auth_source"] != "api_token" {
+		t.Fatalf("expected denied audit auth_source api_token, got %v", deniedAudit["auth_source"])
+	}
+	if deniedAudit["subject_id"] != principal.UserSubjectID(viewer.ID) {
+		t.Fatalf("expected denied audit subject_id %q, got %v", principal.UserSubjectID(viewer.ID), deniedAudit["subject_id"])
+	}
+	if deniedAudit["access_policy"] != "sample_policy" {
+		t.Fatalf("expected denied audit access_policy sample_policy, got %v", deniedAudit["access_policy"])
+	}
+	if deniedAudit["access_role"] != "viewer" {
+		t.Fatalf("expected denied audit access_role viewer, got %v", deniedAudit["access_role"])
+	}
+	if deniedAudit["authorization_decision"] != "catalog_role_denied" {
+		t.Fatalf("expected denied audit authorization_decision catalog_role_denied, got %v", deniedAudit["authorization_decision"])
+	}
+	if deniedAudit["error"] != "operation access denied" {
+		t.Fatalf("expected denied audit error operation access denied, got %v", deniedAudit["error"])
+	}
+}
+
+func TestHumanAuthorization_ExecuteOperation_UsesResolvedRoleAndRejectsDisallowedOperations_DynamicGrant(t *testing.T) {
+	t.Parallel()
+
+	plaintext, hashed, err := principal.GenerateToken(principal.TokenTypeAPI)
+	if err != nil {
+		t.Fatalf("GenerateToken: %v", err)
+	}
+
+	svc := coretesting.NewStubServices(t)
+	seedAPIToken(t, svc, plaintext, hashed, "viewer-user")
+	viewer := seedUser(t, svc, "viewer-user@test.local")
+
+	stub := &stubIntegrationWithSessionCatalog{
+		stubIntegrationWithOps: stubIntegrationWithOps{
+			StubIntegration: coretesting.StubIntegration{
+				N:        "svc",
+				ConnMode: core.ConnectionModeNone,
+				ExecuteFn: func(ctx context.Context, op string, _ map[string]any, _ string) (*core.OperationResult, error) {
+					access := invocation.AccessContextFromContext(ctx)
+					body, err := json.Marshal(map[string]string{
+						"operation": op,
+						"policy":    access.Policy,
+						"role":      access.Role,
+					})
+					if err != nil {
+						return nil, err
+					}
+					return &core.OperationResult{Status: http.StatusOK, Body: string(body)}, nil
+				},
+			},
+		},
+		catalog: &catalog.Catalog{
+			Name: "svc",
+			Operations: []catalog.CatalogOperation{
+				{ID: "run", Method: http.MethodGet, Transport: catalog.TransportREST, AllowedRoles: []string{"viewer"}},
+				{ID: "admin", Method: http.MethodGet, Transport: catalog.TransportREST, AllowedRoles: []string{"admin"}},
+			},
+		},
+	}
+
+	pluginDefs := map[string]*config.ProviderEntry{
+		"svc": {AuthorizationPolicy: "sample_policy"},
+	}
+	authz, err := authorization.New(config.AuthorizationConfig{
+		Policies: map[string]config.HumanPolicyDef{
+			"sample_policy": {Default: "deny"},
+		},
+	}, pluginDefs, nil, nil, svc.PluginAuthorizations)
+	if err != nil {
+		t.Fatalf("authorization.New: %v", err)
+	}
+	seedPluginAuthorization(t, svc, authz, "svc", "viewer-user@test.local", "viewer")
 
 	var auditBuf bytes.Buffer
 	ts := newTestServer(t, func(cfg *server.Config) {


### PR DESCRIPTION
## Summary
Add the dynamic plugin-authorization backend, provider/plugin-aware mounted UI authorization, and the management/admin API for reading and mutating dynamic human grants.

## Go Interfaces
- `internal/coredata.PluginAuthorizationService`
  - Persists dynamic plugin grants in `plugin_authorization_memberships`.
- `internal/coredata.PluginAuthorizationMembership`
  - Fields: `plugin`, `user_id`, `email`, `role`, `created_at`, `updated_at`.
- `authorization.New(..., dynamicServices ...*coredata.PluginAuthorizationService)`
  - Existing constructor now optionally wires dynamic grants into the authorizer.
- `(*authorization.Authorizer).Start(ctx)`, `ReloadDynamic(ctx)`, `Close()`
  - Start/load/stop the immutable dynamic snapshot.
- `(*authorization.Authorizer).HasDynamicAuthorizations() bool`
  - Reports whether the authorizer is actually wired to the dynamic membership store.
- `server.MountedWebUI.PluginName`
  - Preserves plugin ownership so plugin-backed UIs authorize through plugin/provider resolution.
- New admin API routes:
  - `GET /admin/api/v1/authorization/plugins`
  - `GET /admin/api/v1/authorization/plugins/{plugin}/members`
  - `PUT /admin/api/v1/authorization/plugins/{plugin}/members`
  - `DELETE /admin/api/v1/authorization/plugins/{plugin}/members/{userID}`

### Go Examples
```go
_, err := services.PluginAuthorizations.UpsertPluginAuthorization(ctx, &coredata.PluginAuthorizationMembership{
    Plugin: "sample_plugin",
    UserID: user.ID,
    Email:  user.Email,
    Role:   "viewer",
})
if err != nil {
    return err
}
if err := authorizer.ReloadDynamic(ctx); err != nil {
    return err
}
```

```bash
curl -X PUT /admin/api/v1/authorization/plugins/sample_plugin/members \
  -H 'Content-Type: application/json' \
  -d '{"email":"viewer@example.test","role":"viewer"}'
```

## YAML Interfaces
- No new YAML schema in this PR.
- Dynamic grants only apply to plugins that already declare `plugins.<name>.authorizationPolicy`.
- Plugin-backed mounted UIs continue to use the existing `plugins.<name>.ui` / `plugins.<name>.mountPath` / `plugins.<name>.authorizationPolicy` config, but runtime auth now preserves plugin ownership so dynamic grants apply there too.

### YAML Example
```yaml
plugins:
  sample_plugin:
    source:
      path: ./plugin/manifest.yaml
    authorizationPolicy: sample_policy
    mountPath: /sample
    ui: sample_ui

authorization:
  policies:
    sample_policy:
      default: deny
      members:
        - email: admin@example.test
          role: admin
```

With that config, static members still win, and additional human access can now be managed dynamically via `/admin/api/v1/authorization/plugins/sample_plugin/members`.

## Behavior Notes
- Static policy membership still takes precedence over dynamic grants.
- The admin API rejects dynamic writes for users who already have static authorization for that plugin.
- `/admin/api` mirrors built-in `/admin` auth semantics:
  - open when `server.admin.authorizationPolicy` is unset
  - protected when it is set
  - JSON `401/403` instead of browser redirects
- If the dynamic authorization store is not wired into the authorizer, `/admin/api/v1/authorization/plugins/{plugin}/members` returns `503` instead of accepting ineffective dynamic grants.
- Failed dynamic membership persistence returns `500` so callers do not mistake backend write failures for request validation problems.
- Public-profile servers hide `/admin/api/v1/*` with `404`.

## Tests
Augmented existing server and MCP authorization tests for:
- dynamic human grants on HTTP list/execute paths
- dynamic grants on mounted plugin UIs
- dynamic grants on MCP tool filtering
- admin API auth parity, management/public routing, and CRUD behavior
- explicit and synthesized plugin UI ownership preservation in `resolveMountedWebUIHandlers`
- unavailable dynamic-store and membership-store failure handling on the admin API
