### PR TITLE
Document dynamic plugin authorization surfaces

### DIFF
--- a/docs/content/providers/web-uis.mdx
+++ b/docs/content/providers/web-uis.mdx
@@ -118,6 +118,12 @@ The built-in admin UI is always served at `/admin`, regardless of whether
 custom UI bundles are configured. Mounted bundles own only their configured
 public prefixes.
 
+The built-in shell includes two operator views: the Prometheus metrics
+dashboard and a plugin authorization workspace at `/admin/?tab=members`.
+Plugin-backed mounted UIs inherit the owning plugin's dynamic grants when that
+plugin declares `authorizationPolicy`; direct `providers.ui.<name>.authorizationPolicy`
+bindings remain static-only.
+
 ## Building your own web UI bundle
 
 Asset-root layout, build hooks, and release packaging now live under

--- a/docs/content/reference/config-file.mdx
+++ b/docs/content/reference/config-file.mdx
@@ -98,6 +98,8 @@ authorization:
 
 `authorization.policies` configures shared human access policies. Each policy resolves a caller to exactly one role by matching either `subjectID` or `email`, then applies a `default` fallback (`allow` or `deny`) when no member matches. Plugins opt into a policy explicitly through `authorizationPolicy`.
 
+Dynamic human grants are plugin-scoped, not policy-scoped. When a plugin sets `authorizationPolicy`, operators can manage additional dynamic members for that plugin from the built-in admin UI at `/admin/?tab=members` or through `/admin/api/v1/authorization/...`. Static policy members always win over dynamic grants, and Gestalt rejects dynamic writes for users who already have static authorization on that plugin.
+
 `authorization.workloads` configures non-human workload callers. Each workload uses a dedicated bearer token with the `gst_wld_` prefix and a per-provider allowlist. In v1, workloads may bind only to `identity` or `none` providers. For `identity` providers, `connection` and `instance` resolve the exact stored identity credential the workload may use; `instance` defaults to `default` and `connection` falls back to the provider's default connection when omitted. For `none` providers, omit `connection` and `instance`.
 
 | Field | Default | Description |
@@ -117,7 +119,7 @@ authorization:
 | `authorization.policies` | | Shared human access policies resolved by `subjectID` or `email`. |
 | `authorization.workloads` | | Workload bearer tokens, per-provider allowlists, and identity credential bindings. |
 
-When `server.management` is configured, Gestalt serves `/`, `/api/v1/*`, auth routes, and `/mcp` on the public listener, while `/admin`, `/metrics`, `/health`, and `/ready` move to the management listener. The management listener is intended to be protected by deployment infrastructure such as private networking, VPN, or an internal-only reverse proxy. Gestalt does not apply its own session or API-token auth to `/metrics` on the management listener. When `server.admin.authorizationPolicy` is set, Gestalt does apply browser session auth plus role-based policy checks to `/admin`.
+When `server.management` is configured, Gestalt serves `/`, `/api/v1/*`, auth routes, and `/mcp` on the public listener, while `/admin`, `/admin/api/v1/*`, `/metrics`, `/health`, and `/ready` move to the management listener. The management listener is intended to be protected by deployment infrastructure such as private networking, VPN, or an internal-only reverse proxy. Gestalt does not apply its own session or API-token auth to `/metrics` on the management listener. When `server.admin.authorizationPolicy` is set, Gestalt does apply browser session auth plus role-based policy checks to `/admin` and `/admin/api/v1/*`.
 
 ## `providers.auth`
 
@@ -598,7 +600,7 @@ plugins:
 | `displayName` | Human-readable name shown in the UI and API. |
 | `description` | Short description of the plugin. |
 | `iconFile` | SVG icon path, resolved relative to the config directory. |
-| `authorizationPolicy` | Optional shared human access policy from `authorization.policies`. When set, host-side operation filtering and execution checks use the resolved role for this plugin. |
+| `authorizationPolicy` | Optional shared human access policy from `authorization.policies`. When set, host-side operation filtering and execution checks use the resolved role for this plugin, and the built-in admin UI / admin API can manage plugin-scoped dynamic grants for additional human members. Static policy members still take precedence. |
 | `mountPath` | Optional public path prefix for a plugin-backed mounted UI. When set, Gestalt mounts either `plugins.<name>.ui` or the plugin manifest's `spec.ui`. |
 | `ui` | Optional UI key from `providers.ui` used with `mountPath`. Omit it to mount the plugin manifest's owned `spec.ui`. |
 | `source` | **Required.** The backing provider source. See [source shape](#pluginssource) below. |
@@ -879,6 +881,8 @@ providers:
 ```
 
 `providers.ui` is a map of `webui` bundles. Entries may mount directly by setting `path`, or they may act as named UI bundles that `plugins.<name>.ui` binds to `plugins.<name>.mountPath`. When a plugin manifest declares `spec.ui`, `plugins.<name>.ui` may be omitted entirely and Gestalt synthesizes the mounted UI entry from the plugin-owned reference. The built-in admin UI remains available at `/admin`. Omit `providers.ui` entirely to run headless with no public UI bundles.
+
+Plugin-backed mounted UIs inherit the owning plugin's dynamic authorization grants when that plugin sets `authorizationPolicy`. Direct `providers.ui.<name>.authorizationPolicy` bindings remain static-only.
 
 When `authorizationPolicy` is set on a mounted UI, the referenced web UI manifest must declare `spec.routes` with non-empty `allowedRoles`, and at least one route must cover `/`.
 

--- a/docs/content/reference/http-api.mdx
+++ b/docs/content/reference/http-api.mdx
@@ -1,6 +1,6 @@
 # HTTP API
 
-`gestaltd` exposes a REST API and an optional MCP endpoint. When `server.management` is not configured, every route below is served from the public listener. When `server.management` is configured, `/admin`, `/metrics`, `/health`, and `/ready` move to the management listener and return `404` on the public listener. Prefer the split-listener setup for production so the operator surface does not share the public listener.
+`gestaltd` exposes a REST API and an optional MCP endpoint. When `server.management` is not configured, every route below is served from the public listener. When `server.management` is configured, `/admin`, `/admin/api/v1/*`, `/metrics`, `/health`, and `/ready` move to the management listener and return `404` on the public listener. Prefer the split-listener setup for production so the operator surface does not share the public listener.
 
 The HTTP API uses "integrations" in route paths (e.g. `/api/v1/integrations`) as a stable code surface. The CLI and config both use "plugins" as the canonical term. See [Config File](/reference/config-file#providersplugins) for context.
 
@@ -14,7 +14,7 @@ Authenticated routes accept a `session_token` cookie or an `Authorization: Beare
 | --- | --- | --- |
 | `GET` | `/health` | Basic liveness check. |
 | `GET` | `/ready` | Readiness check. Returns `503` until providers and datastore are ready. |
-| `GET` | `/admin` and `/admin/*` | Embedded admin UI shell. When `server.admin.authorizationPolicy` is set, Gestalt requires browser session auth and the configured roles before serving the shell or its assets. On split public/management deployments, configure `server.management.baseUrl` so unauthenticated management `/admin` requests can round-trip through the public login flow and return to the management listener's built-in `/admin` route. Use the same hostname as `server.baseUrl`, and keep both on `https` when the public listener uses `https`, so the session cookie can be reused across listeners. `/admin` still reads same-origin `/metrics`, which remains unauthenticated on the management listener. When `server.baseUrl` is set, the management admin UI links back to that public URL for `Client UI`; otherwise it omits that link. |
+| `GET` | `/admin` and `/admin/*` | Embedded admin UI shell. The built-in shell now includes a Prometheus dashboard and a plugin authorization workspace at `?tab=members`. When `server.admin.authorizationPolicy` is set, Gestalt requires browser session auth and the configured roles before serving the shell or its assets. On split public/management deployments, configure `server.management.baseUrl` so unauthenticated management `/admin` requests can round-trip through the public login flow and return to the management listener's built-in `/admin` route. Use the same hostname as `server.baseUrl`, and keep both on `https` when the public listener uses `https`, so the session cookie can be reused across listeners. `/admin` still reads same-origin `/metrics`, which remains unauthenticated on the management listener. When `server.baseUrl` is set, the management admin UI links back to that public URL for `Client UI`; otherwise it omits that link. |
 | `GET` | `/api/v1/auth/info` | Returns platform auth metadata, including whether interactive login is supported. |
 | `POST` | `/api/v1/auth/login` | Starts platform login and returns an absolute browser URL. |
 | `GET` | `/api/v1/auth/login/callback` | Completes platform login. |
@@ -54,6 +54,14 @@ Authenticated routes accept a `session_token` cookie or an `Authorization: Beare
 | Method | Path | Purpose |
 | --- | --- | --- |
 | `GET` | `/metrics` | Prometheus scrape endpoint for emitted metrics. Requires Gestalt auth only when served on the public listener. The recommended production pattern is to move it to `server.management` and protect that listener at the network or proxy layer. |
+| `GET` | `/admin/api/v1/authorization/plugins` | List plugins that declare `authorizationPolicy`, including the bound policy name and mounted UI path when present. |
+| `GET` | `/admin/api/v1/authorization/plugins/{plugin}/members` | List merged static and dynamic human membership rows for one plugin. Rows include `source`, `effective`, `mutable`, and selector metadata. |
+| `PUT` | `/admin/api/v1/authorization/plugins/{plugin}/members` | Upsert one dynamic human membership row for a plugin by email and role. Rejects users who already have static authorization on that plugin. |
+| `DELETE` | `/admin/api/v1/authorization/plugins/{plugin}/members/{userID}` | Remove one dynamic human membership row for a plugin. Static rows are read-only and cannot be deleted through the API. |
+
+`/admin/api/v1/...` mirrors the built-in `/admin` protection model: when `server.admin.authorizationPolicy` is unset, the routes are open wherever `/admin` is open; when it is set, they require the same browser session and role checks as `/admin`, but return JSON `401`/`403` instead of browser redirects.
+
+`PUT` and `DELETE` may return `202 Accepted` with `status: "persisted_pending_reload"` when the dynamic grant was written successfully but the local in-memory authorization snapshot has not reloaded yet. In that case, retry access checks only after the local snapshot converges.
 
 ## MCP
 
@@ -93,4 +101,9 @@ curl 'http://localhost:8080/api/v1/slack/chat.postMessage?_connection=mcp&_insta
 curl -X POST http://localhost:8080/api/v1/slack/chat.postMessage \
   -H 'Content-Type: application/json' \
   -d '{"_connection": "mcp", "channel": "C123", "text": "hello"}'
+
+# Add a dynamic plugin member from the management/admin surface
+curl -X PUT http://localhost:9090/admin/api/v1/authorization/plugins/sample_plugin/members \
+  -H 'Content-Type: application/json' \
+  -d '{"email":"viewer@example.test","role":"viewer"}'
 ```

--- a/docs/dockerhub/gestaltd.md
+++ b/docs/dockerhub/gestaltd.md
@@ -136,6 +136,12 @@ listeners. See the
 [deployment documentation](https://gestaltd.ai/deploy) for the recommended
 split-listener production pattern.
 
+The built-in `/admin` shell now includes both the Prometheus metrics dashboard
+and a plugin authorization workspace. For any plugin that already declares
+`authorizationPolicy`, operators can open `/admin/?tab=members&plugin=<name>`
+to inspect merged static/dynamic rows and manage dynamic grants. Static policy
+members remain authoritative.
+
 ## SQLite and `/data`
 
 SQLite works for local development, demos, and single-instance deployments.

--- a/gestaltd/cmd/gestaltd/run.go
+++ b/gestaltd/cmd/gestaltd/run.go
@@ -291,7 +291,8 @@ func runServer(env *bootstrapEnv) error {
 }
 
 const (
-	adminUIDirEnv = "GESTALTD_ADMIN_UI_DIR"
+	adminUIDirEnv    = "GESTALTD_ADMIN_UI_DIR"
+	adminUILoginPath = "/api/v1/auth/login"
 )
 
 func resolveUIHandlers(cfg *config.Config) ([]server.MountedWebUI, http.Handler, http.Handler, error) {
@@ -309,13 +310,19 @@ func resolveUIHandlers(cfg *config.Config) ([]server.MountedWebUI, http.Handler,
 	}
 	publicAdminUI, err := resolveAdminUIHandler(adminui.Options{
 		BrandHref: publicBrandHref,
+		LoginBase: adminUILoginPath,
 	})
 	if err != nil {
 		return nil, nil, nil, err
 	}
 
+	managementLoginBase := adminUILoginPath
+	if baseURL := strings.TrimRight(cfg.Server.BaseURL, "/"); baseURL != "" {
+		managementLoginBase = baseURL + adminUILoginPath
+	}
 	managementAdminUI, err := resolveAdminUIHandler(adminui.Options{
 		BrandHref: "/admin/",
+		LoginBase: managementLoginBase,
 	})
 	if err != nil {
 		return nil, nil, nil, err

--- a/gestaltd/internal/adminui/adminui.go
+++ b/gestaltd/internal/adminui/adminui.go
@@ -7,6 +7,7 @@ import (
 	"io/fs"
 	"net/http"
 	"os"
+	"strconv"
 	"strings"
 
 	"github.com/valon-technologies/gestalt/server/internal/staticui"
@@ -17,6 +18,7 @@ var assets embed.FS
 
 type Options struct {
 	BrandHref string
+	LoginBase string
 }
 
 func EmbeddedHandler(opts Options) http.Handler {
@@ -57,6 +59,7 @@ func renderIndexHTML(indexHTML []byte, opts Options) []byte {
 	)
 
 	replaced = strings.Replace(replaced, `<a href="/">Client UI</a>`, "", 1)
+	replaced = strings.Replace(replaced, `__GESTALT_ADMIN_LOGIN_BASE__`, strconv.Quote(normalized.LoginBase), 1)
 	return []byte(replaced)
 }
 
@@ -64,6 +67,10 @@ func normalizeOptions(opts Options) Options {
 	opts.BrandHref = strings.TrimSpace(opts.BrandHref)
 	if opts.BrandHref == "" {
 		opts.BrandHref = "/"
+	}
+	opts.LoginBase = strings.TrimSpace(opts.LoginBase)
+	if opts.LoginBase == "" {
+		opts.LoginBase = "/api/v1/auth/login"
 	}
 	return opts
 }

--- a/gestaltd/internal/adminui/out/index.html
+++ b/gestaltd/internal/adminui/out/index.html
@@ -19,6 +19,10 @@
         window.__gestaltTheme = { get: function() { return theme; }, set: function(t) { theme = t; localStorage.setItem('gestalt-admin-theme', t); apply(); } };
       })();
     </script>
+    <script>
+      window.__gestaltAdminShell = window.__gestaltAdminShell || {};
+      window.__gestaltAdminShell.loginBase = __GESTALT_ADMIN_LOGIN_BASE__;
+    </script>
     <link rel="stylesheet" href="./theme.css" />
     <style>
       @font-face {
@@ -257,6 +261,218 @@
         max-width: 380px;
       }
 
+      .tab-nav {
+        display: flex;
+        gap: 10px;
+        margin-top: 20px;
+        flex-wrap: wrap;
+      }
+
+      .tab-btn,
+      .action-btn,
+      .danger-btn {
+        appearance: none;
+        -webkit-appearance: none;
+        border: 1px solid rgba(var(--alpha-dark), 0.12);
+        border-radius: 999px;
+        background: #FFFFFF;
+        color: rgba(var(--alpha-dark), 0.78);
+        font: inherit;
+        font-size: 0.875rem;
+        line-height: 1;
+        padding: 10px 14px;
+        cursor: pointer;
+        transition: border-color 150ms, background-color 150ms, color 150ms, transform 150ms;
+      }
+
+      .tab-btn:hover,
+      .action-btn:hover,
+      .danger-btn:hover {
+        border-color: rgba(var(--alpha-dark), 0.22);
+        color: rgba(var(--alpha-dark), 0.92);
+      }
+
+      .tab-btn.is-active {
+        background: linear-gradient(135deg, var(--brand) 0%, color-mix(in srgb, var(--brand) 72%, #f4debb) 100%);
+        border-color: transparent;
+        color: #fffaf2;
+        box-shadow: 0 10px 24px rgba(122, 79, 16, 0.16);
+      }
+
+      .action-btn {
+        border-radius: 10px;
+        background: linear-gradient(135deg, var(--brand) 0%, color-mix(in srgb, var(--brand) 70%, #f2d7b3) 100%);
+        border-color: transparent;
+        color: #fffaf2;
+        padding: 11px 16px;
+        font-weight: 600;
+      }
+
+      .action-btn.secondary {
+        background: color-mix(in srgb, hsl(var(--surface-raised)) 76%, transparent);
+        border-color: rgba(var(--alpha-dark), 0.12);
+        color: rgba(var(--alpha-dark), 0.78);
+        box-shadow: none;
+      }
+
+      .danger-btn {
+        border-radius: 10px;
+        background: transparent;
+        color: var(--danger);
+        border-color: color-mix(in srgb, var(--danger) 30%, transparent);
+        padding: 8px 12px;
+      }
+
+      .tab-btn:disabled,
+      .action-btn:disabled,
+      .danger-btn:disabled {
+        cursor: not-allowed;
+        opacity: 0.5;
+        transform: none;
+      }
+
+      .tab-panel[hidden] {
+        display: none !important;
+      }
+
+      .auth-grid {
+        display: grid;
+        gap: 16px;
+        margin-top: 20px;
+        grid-template-columns: minmax(280px, 340px) minmax(0, 1fr);
+      }
+
+      .auth-form {
+        display: grid;
+        gap: 14px;
+        margin-top: 18px;
+      }
+
+      .text-input {
+        width: 100%;
+        border: 1px solid rgba(var(--alpha-dark), 0.12);
+        border-radius: 10px;
+        background: #FFFFFF;
+        color: rgba(var(--alpha-dark), 1);
+        font: inherit;
+        font-size: 0.9375rem;
+        padding: 11px 12px;
+        transition: border-color 150ms, box-shadow 150ms;
+      }
+
+      .text-input:focus {
+        outline: none;
+        border-color: rgba(var(--alpha-dark), 0.32);
+        box-shadow: 0 0 0 3px rgba(var(--alpha-dark), 0.06);
+      }
+
+      .dark .text-input,
+      .dark .tab-btn,
+      .dark .action-btn.secondary,
+      .dark .danger-btn {
+        background: hsl(var(--surface) / 1);
+        color: hsl(var(--foreground) / 1);
+      }
+
+      .auth-form-copy {
+        margin-top: 8px;
+      }
+
+      .inline-note {
+        margin-top: 0;
+      }
+
+      .member-table-wrap {
+        overflow-x: auto;
+        margin-top: 18px;
+      }
+
+      .member-table {
+        width: 100%;
+        border-collapse: collapse;
+        min-width: 680px;
+      }
+
+      .member-table th,
+      .member-table td {
+        padding: 14px 12px;
+        border-top: 1px solid rgba(var(--alpha-dark), 0.08);
+        text-align: left;
+        vertical-align: top;
+      }
+
+      .member-table th {
+        font-size: 0.75rem;
+        letter-spacing: 0.12em;
+        text-transform: uppercase;
+        color: rgba(var(--alpha-dark), 0.48);
+        font-weight: 600;
+      }
+
+      .principal-value {
+        font-weight: 600;
+      }
+
+      .principal-meta {
+        margin-top: 4px;
+        font-size: 0.8125rem;
+        color: rgba(var(--alpha-dark), 0.58);
+      }
+
+      .pill-row {
+        display: flex;
+        flex-wrap: wrap;
+        gap: 8px;
+      }
+
+      .pill {
+        display: inline-flex;
+        align-items: center;
+        gap: 6px;
+        padding: 5px 10px;
+        border-radius: 999px;
+        font-size: 0.75rem;
+        letter-spacing: 0.04em;
+        text-transform: uppercase;
+        border: 1px solid rgba(var(--alpha-dark), 0.1);
+        background: color-mix(in srgb, hsl(var(--surface-raised)) 72%, transparent);
+        color: rgba(var(--alpha-dark), 0.72);
+      }
+
+      .pill.source-static {
+        background: color-mix(in srgb, var(--brand-soft) 32%, transparent);
+      }
+
+      .pill.source-dynamic {
+        background: color-mix(in srgb, var(--success) 16%, transparent);
+      }
+
+      .pill.state-shadowed {
+        background: color-mix(in srgb, var(--danger) 14%, transparent);
+        color: var(--danger);
+      }
+
+      .pill.state-effective {
+        background: color-mix(in srgb, var(--success) 16%, transparent);
+        color: var(--success);
+      }
+
+      .pill.locked {
+        background: color-mix(in srgb, hsl(var(--surface-raised)) 82%, transparent);
+      }
+
+      .empty-state {
+        padding: 20px;
+        border: 1px dashed hsl(var(--border) / 1);
+        border-radius: 12px;
+        background: color-mix(in srgb, hsl(var(--surface-raised)) 40%, transparent);
+      }
+
+      .subtle-copy {
+        font-size: 0.875rem;
+        color: rgba(var(--alpha-dark), 0.6);
+      }
+
       .metric-value {
         margin-top: 14px;
         font-size: 1.875rem;
@@ -377,6 +593,10 @@
         .panel-grid {
           grid-template-columns: repeat(2, minmax(0, 1fr));
         }
+
+        .auth-grid {
+          grid-template-columns: minmax(0, 1fr);
+        }
       }
 
       @media (max-width: 640px) {
@@ -419,104 +639,204 @@
     <main class="shell">
       <section class="card hero animate-fade-in-up">
         <span class="label-text">Admin</span>
-        <h1>Prometheus metrics</h1>
+        <h1>Control surface</h1>
         <p>
-          The embedded admin UI reuses the client workspace theme and derives a
-          few lightweight views directly from the same-origin
-          <code>/metrics</code> scrape, with browser-local chart history for
-          quick operator debugging.
+          Inspect live Prometheus telemetry and manage plugin-scoped human
+          authorization from the same protected surface. Static policy members
+          remain authoritative; dynamic grants only extend access where the
+          plugin already declares an authorization policy.
         </p>
       </section>
 
-      <section class="status animate-fade-in-up" style="animation-delay:40ms" id="status">Loading metrics...</section>
+      <nav class="tab-nav animate-fade-in-up" style="animation-delay:40ms" aria-label="Admin views">
+        <button id="tab-overview" class="tab-btn" type="button" data-tab="overview" aria-selected="true">Overview</button>
+        <button id="tab-authorization" class="tab-btn" type="button" data-tab="authorization" aria-selected="false">Authorization</button>
+      </nav>
 
-      <section class="summary-grid animate-fade-in-up" style="animation-delay:60ms">
-        <article class="card summary-card">
-          <span class="label-text">Total requests</span>
-          <div class="metric-value" id="summary-requests">--</div>
-          <p class="metric-note">Cumulative invocations for this process.</p>
-        </article>
-        <article class="card summary-card">
-          <span class="label-text">Errors</span>
-          <div class="metric-value" id="summary-errors">--</div>
-          <p class="metric-note">Cumulative failed invocations.</p>
-        </article>
-        <article class="card summary-card">
-          <span class="label-text">Avg latency</span>
-          <div class="metric-value" id="summary-avg-latency">--</div>
-          <p class="metric-note">Computed from histogram sum and count.</p>
-        </article>
-        <article class="card summary-card">
-          <span class="label-text">P95 latency</span>
-          <div class="metric-value" id="summary-p95-latency">--</div>
-          <p class="metric-note">Estimated from current buckets.</p>
-        </article>
+      <section id="panel-overview" class="tab-panel" data-tab-panel="overview">
+        <section class="status animate-fade-in-up" style="animation-delay:60ms" id="metrics-status">Loading metrics...</section>
+
+        <section class="summary-grid animate-fade-in-up" style="animation-delay:80ms">
+          <article class="card summary-card">
+            <span class="label-text">Total requests</span>
+            <div class="metric-value" id="summary-requests">--</div>
+            <p class="metric-note">Cumulative invocations for this process.</p>
+          </article>
+          <article class="card summary-card">
+            <span class="label-text">Errors</span>
+            <div class="metric-value" id="summary-errors">--</div>
+            <p class="metric-note">Cumulative failed invocations.</p>
+          </article>
+          <article class="card summary-card">
+            <span class="label-text">Avg latency</span>
+            <div class="metric-value" id="summary-avg-latency">--</div>
+            <p class="metric-note">Computed from histogram sum and count.</p>
+          </article>
+          <article class="card summary-card">
+            <span class="label-text">P95 latency</span>
+            <div class="metric-value" id="summary-p95-latency">--</div>
+            <p class="metric-note">Estimated from current buckets.</p>
+          </article>
+        </section>
+
+        <section class="card controls animate-fade-in-up" style="animation-delay:100ms">
+          <div class="control-cluster">
+            <label class="control-group" for="time-window-select">
+              <span class="label-text">Time window</span>
+              <select class="control-select" id="time-window-select">
+                <option value="15m">15 min</option>
+                <option value="1h">1 hour</option>
+                <option value="6h">6 hours</option>
+                <option value="24h">24 hours</option>
+                <option value="all">All</option>
+              </select>
+            </label>
+
+            <label class="control-group" for="refresh-interval-select">
+              <span class="label-text">Refresh cadence</span>
+              <select class="control-select" id="refresh-interval-select">
+                <option value="2000">2 seconds (Live)</option>
+                <option value="5000" selected>5 seconds</option>
+                <option value="15000">15 seconds</option>
+                <option value="30000">30 seconds</option>
+                <option value="60000">1 minute</option>
+                <option value="0">Paused</option>
+              </select>
+            </label>
+          </div>
+
+          <p class="metric-note controls-note">
+            Filters the browser's current chart history from same-origin
+            <code>/metrics</code> scrapes. Provider totals stay cumulative.
+          </p>
+        </section>
+
+        <section class="panel-grid animate-fade-in-up" style="animation-delay:120ms">
+          <article class="card panel-card">
+            <span class="label-text">Recent activity</span>
+            <h2>Requests and failures</h2>
+            <div class="chart" id="activity-chart" data-chart-state="empty"></div>
+            <p class="metric-note chart-caption">
+              Derived from consecutive same-origin <code>/metrics</code> scrapes
+              captured in this browser session.
+            </p>
+          </article>
+
+          <article class="card panel-card">
+            <span class="label-text">Latency</span>
+            <h2>Average and p95</h2>
+            <div class="chart" id="latency-chart" data-chart-state="empty"></div>
+            <p class="metric-note chart-caption">
+              Estimated from the current Prometheus histogram totals for this process.
+            </p>
+          </article>
+
+          <article class="card panel-card panel-wide">
+            <span class="label-text">Current distribution</span>
+            <h2>Top providers</h2>
+            <div class="chart" id="provider-chart" data-chart-state="empty"></div>
+            <div class="bar-list" id="provider-bars"></div>
+            <p class="metric-note chart-caption">
+              Based on the latest same-origin <code>/metrics</code> scrape for
+              this process.
+            </p>
+          </article>
+        </section>
       </section>
 
-      <section class="card controls animate-fade-in-up" style="animation-delay:80ms">
-        <div class="control-cluster">
-          <label class="control-group" for="time-window-select">
-            <span class="label-text">Time window</span>
-            <select class="control-select" id="time-window-select">
-              <option value="15m">15 min</option>
-              <option value="1h">1 hour</option>
-              <option value="6h">6 hours</option>
-              <option value="24h">24 hours</option>
-              <option value="all">All</option>
-            </select>
-          </label>
+      <section id="panel-authorization" class="tab-panel" data-tab-panel="authorization" hidden>
+        <section class="status animate-fade-in-up" style="animation-delay:60ms" id="auth-status">Loading authorization plugins...</section>
 
-          <label class="control-group" for="refresh-interval-select">
-            <span class="label-text">Refresh cadence</span>
-            <select class="control-select" id="refresh-interval-select">
-              <option value="2000">2 seconds (Live)</option>
-              <option value="5000" selected>5 seconds</option>
-              <option value="15000">15 seconds</option>
-              <option value="30000">30 seconds</option>
-              <option value="60000">1 minute</option>
-              <option value="0">Paused</option>
-            </select>
-          </label>
-        </div>
+        <section class="card controls animate-fade-in-up" style="animation-delay:80ms">
+          <div class="control-cluster">
+            <label class="control-group" for="authorization-plugin-select">
+              <span class="label-text">Plugin</span>
+              <select class="control-select" id="authorization-plugin-select"></select>
+            </label>
 
-        <p class="metric-note controls-note">
-          Filters the browser's current chart history from same-origin
-          <code>/metrics</code> scrapes. Provider totals stay cumulative.
-        </p>
-      </section>
+            <button class="action-btn secondary" type="button" id="authorization-refresh-button">Refresh</button>
+          </div>
 
-      <section class="panel-grid animate-fade-in-up" style="animation-delay:100ms">
-        <article class="card panel-card">
-          <span class="label-text">Recent activity</span>
-          <h2>Requests and failures</h2>
-          <div class="chart" id="activity-chart" data-chart-state="empty"></div>
-          <p class="metric-note chart-caption">
-            Derived from consecutive same-origin <code>/metrics</code> scrapes
-            captured in this browser session.
+          <p class="metric-note controls-note">
+            Dynamic grants are plugin-scoped and evaluated only after static
+            policy members. Writes are blocked for users who already have
+            static authorization on the selected plugin.
           </p>
-        </article>
+        </section>
 
-        <article class="card panel-card">
-          <span class="label-text">Latency</span>
-          <h2>Average and p95</h2>
-          <div class="chart" id="latency-chart" data-chart-state="empty"></div>
-          <p class="metric-note chart-caption">
-            Estimated from the current Prometheus histogram totals for this process.
-          </p>
-        </article>
+        <section class="summary-grid animate-fade-in-up" style="animation-delay:100ms">
+          <article class="card summary-card">
+            <span class="label-text">Effective rows</span>
+            <div class="metric-value" id="authorization-effective-count">--</div>
+            <p class="metric-note">Rows that currently contribute to access decisions.</p>
+          </article>
+          <article class="card summary-card">
+            <span class="label-text">Static rows</span>
+            <div class="metric-value" id="authorization-static-count">--</div>
+            <p class="metric-note">Config-defined members that remain authoritative.</p>
+          </article>
+          <article class="card summary-card">
+            <span class="label-text">Dynamic rows</span>
+            <div class="metric-value" id="authorization-dynamic-count">--</div>
+            <p class="metric-note">Persisted plugin grants from the admin API.</p>
+          </article>
+          <article class="card summary-card">
+            <span class="label-text">Shadowed grants</span>
+            <div class="metric-value" id="authorization-shadowed-count">--</div>
+            <p class="metric-note">Dynamic rows hidden by a static membership match.</p>
+          </article>
+        </section>
 
-        <article class="card panel-card panel-wide">
-          <span class="label-text">Current distribution</span>
-          <h2>Top providers</h2>
-          <div class="chart" id="provider-chart" data-chart-state="empty"></div>
-          <div class="bar-list" id="provider-bars"></div>
-          <p class="metric-note chart-caption">
-            Based on the latest same-origin <code>/metrics</code> scrape for
-            this process.
-          </p>
-        </article>
+        <section class="auth-grid animate-fade-in-up" style="animation-delay:120ms">
+          <article class="card panel-card">
+            <span class="label-text">Authorization rules</span>
+            <h2>Add or update a dynamic member</h2>
+            <p class="metric-note auth-form-copy">
+              Roles are stored as opaque strings and checked against the
+              plugin's existing <code>allowedRoles</code> rules.
+            </p>
+
+            <form id="authorization-form" class="auth-form">
+              <label class="control-group" for="authorization-email-input">
+                <span class="label-text">Email</span>
+                <input class="text-input" id="authorization-email-input" name="email" type="email" autocomplete="email" placeholder="viewer@example.test" />
+              </label>
+
+              <label class="control-group" for="authorization-role-input">
+                <span class="label-text">Role</span>
+                <input class="text-input" id="authorization-role-input" name="role" list="authorization-role-options" placeholder="viewer" />
+              </label>
+
+              <button class="action-btn" type="submit" id="authorization-submit-button">Save dynamic grant</button>
+            </form>
+
+            <p class="metric-note inline-note" id="authorization-form-note">
+              Pick a plugin, then add a new dynamic member or update an existing dynamic role.
+            </p>
+          </article>
+
+          <article class="card panel-card">
+            <span class="label-text">Effective access</span>
+            <h2>Plugin members</h2>
+            <div class="member-table-wrap">
+              <table class="member-table">
+                <thead>
+                  <tr>
+                    <th scope="col">Principal</th>
+                    <th scope="col">Role</th>
+                    <th scope="col">Source</th>
+                    <th scope="col">State</th>
+                    <th scope="col">Actions</th>
+                  </tr>
+                </thead>
+                <tbody id="authorization-members-body"></tbody>
+              </table>
+            </div>
+          </article>
+        </section>
       </section>
     </main>
+    <datalist id="authorization-role-options"></datalist>
     <script src="./echarts.min.js"></script>
     <script>
       (function () {
@@ -565,19 +885,161 @@
         let selectedWindowKey = "1h";
         let refreshIntervalMs = DEFAULT_REFRESH_INTERVAL_MS;
         let refreshTimer = null;
+        let activeTabKey = "overview";
+        let authPlugins = [];
+        let authMembers = [];
+        let authLoaded = false;
+        let authLoading = false;
+        let authSaving = false;
+        let authDeletingUserID = "";
+        let authPendingReload = false;
+        let selectedPluginName = "";
+        let authMembersRequestToken = 0;
 
         function byId(id) {
           return document.getElementById(id);
         }
 
-        function setStatus(message, kind) {
-          var el = byId("status");
+        function setMetricsStatus(message, kind) {
+          var el = byId("metrics-status");
           el.className = kind ? "status " + kind : "status";
           if (kind === "ok" && refreshIntervalMs === 2000) {
             el.innerHTML = '<span class="live-dot"></span>' + message.replace(/^Last refreshed/, "Live \u00b7");
           } else {
             el.textContent = message;
           }
+        }
+
+        function setAuthStatus(message, kind) {
+          var el = byId("auth-status");
+          el.className = kind ? "status " + kind : "status";
+          el.textContent = message;
+        }
+
+        function clearAuthPendingReload() {
+          authPendingReload = false;
+        }
+
+        function markAuthPendingReload(message) {
+          authPendingReload = true;
+          setAuthStatus(message, "error");
+        }
+
+        function normalizeTabKey(value) {
+          return value === "authorization" || value === "members" ? "authorization" : "overview";
+        }
+
+        function normalizePluginName(value) {
+          return typeof value === "string" ? value.trim() : "";
+        }
+
+        function updateURLState() {
+          const url = new URL(window.location.href);
+          url.searchParams.set("tab", activeTabKey === "authorization" ? "members" : "overview");
+          if (selectedPluginName) {
+            url.searchParams.set("plugin", selectedPluginName);
+          } else {
+            url.searchParams.delete("plugin");
+          }
+          window.history.replaceState(null, "", url.toString());
+        }
+
+        function applyActiveTab() {
+          ["overview", "authorization"].forEach(function (key) {
+            const button = byId("tab-" + key);
+            const panel = byId("panel-" + key);
+            const active = key === activeTabKey;
+            if (button) {
+              button.classList.toggle("is-active", active);
+              button.setAttribute("aria-selected", active ? "true" : "false");
+            }
+            if (panel) {
+              panel.hidden = !active;
+            }
+          });
+          if (activeTabKey === "authorization" && !authLoaded && !authLoading) {
+            loadAuthorizationPlugins();
+          }
+        }
+
+        function setActiveTab(nextKey) {
+          activeTabKey = normalizeTabKey(nextKey);
+          updateURLState();
+          applyActiveTab();
+        }
+
+        function bindTabs() {
+          ["overview", "authorization"].forEach(function (key) {
+            const button = byId("tab-" + key);
+            if (!button) return;
+            button.addEventListener("click", function () {
+              if (activeTabKey === key) return;
+              setActiveTab(key);
+            });
+          });
+
+          const url = new URL(window.location.href);
+          activeTabKey = normalizeTabKey(url.searchParams.get("tab"));
+          selectedPluginName = normalizePluginName(url.searchParams.get("plugin"));
+          applyActiveTab();
+        }
+
+        function adminLoginURL() {
+          const configured = window.__gestaltAdminShell && typeof window.__gestaltAdminShell.loginBase === "string"
+            ? window.__gestaltAdminShell.loginBase.trim()
+            : "";
+          const loginBase = configured || "/api/v1/auth/login";
+          const absoluteBase = /^[a-zA-Z][a-zA-Z\d+\-.]*:/.test(loginBase);
+          const loginURL = new URL(loginBase, window.location.href);
+          loginURL.searchParams.set("next", absoluteBase ? window.location.href : window.location.pathname + window.location.search);
+          return loginURL.toString();
+        }
+
+        function handleUnauthorizedResponse() {
+          try {
+            window.localStorage.removeItem("user_email");
+          } catch {}
+          window.location.replace(adminLoginURL());
+        }
+
+        async function fetchJSON(path, options) {
+          const response = await fetch(path, Object.assign(
+            {
+              credentials: "include",
+              headers: { Accept: "application/json" },
+            },
+            options || {},
+          ));
+
+          if (response.status === 401) {
+            handleUnauthorizedResponse();
+            throw new Error("Authentication required");
+          }
+
+          const contentType = (response.headers.get("content-type") || "").toLowerCase();
+          const raw = await response.text();
+          let payload = null;
+          if (raw) {
+            if (contentType.includes("application/json")) {
+              payload = JSON.parse(raw);
+            } else {
+              try {
+                payload = JSON.parse(raw);
+              } catch {}
+            }
+          }
+
+          if (!response.ok) {
+            const message = payload && payload.error
+              ? payload.error
+              : raw.trim() || `Request failed (${response.status})`;
+            const error = new Error(message);
+            error.status = response.status;
+            error.payload = payload;
+            throw error;
+          }
+
+          return { status: response.status, payload: payload };
         }
 
         function formatCount(value) {
@@ -675,6 +1137,340 @@
           });
 
           syncControlState();
+        }
+
+        function normalizedEmail(value) {
+          return String(value || "").trim().toLowerCase();
+        }
+
+        function authStaticEmails() {
+          const emails = new Set();
+          authMembers.forEach(function (row) {
+            if (!row || row.source !== "static") return;
+            const email = normalizedEmail(row.email || (row.selectorKind === "email" ? row.selectorValue : ""));
+            if (email) {
+              emails.add(email);
+            }
+          });
+          return emails;
+        }
+
+        function authRoleSuggestions() {
+          const values = new Set();
+          authMembers.forEach(function (row) {
+            if (row && typeof row.role === "string" && row.role.trim()) {
+              values.add(row.role.trim());
+            }
+          });
+          const current = String(byId("authorization-role-input").value || "").trim();
+          if (current) {
+            values.add(current);
+          }
+          return Array.from(values).sort();
+        }
+
+        function principalLabel(row) {
+          if (!row) return "Unknown";
+          if (row.email) return row.email;
+          if (row.selectorKind === "email") return row.selectorValue;
+          return row.selectorValue || "Unknown";
+        }
+
+        function principalMeta(row) {
+          if (!row) return "";
+          if (row.selectorKind === "user_id") return row.userId ? `user_id:${row.userId}` : "user_id";
+          if (row.selectorKind === "email") return row.userId ? `email match · user_id:${row.userId}` : "email selector";
+          if (row.selectorKind === "subject_id") return "subjectID-only static member";
+          return row.selectorKind || "";
+        }
+
+        function renderAuthorizationMembers() {
+          const body = byId("authorization-members-body");
+          const roleOptions = byId("authorization-role-options");
+          roleOptions.textContent = "";
+          authRoleSuggestions().forEach(function (role) {
+            const option = document.createElement("option");
+            option.value = role;
+            roleOptions.appendChild(option);
+          });
+
+          body.textContent = "";
+          if (!selectedPluginName) {
+            const row = document.createElement("tr");
+            row.innerHTML = '<td colspan="5"><div class="empty-state"><p class="metric-note">No plugin authorization policies are configured yet.</p></div></td>';
+            body.appendChild(row);
+            return;
+          }
+          if (authMembers.length === 0) {
+            const row = document.createElement("tr");
+            row.innerHTML = '<td colspan="5"><div class="empty-state"><p class="metric-note">No members found for the selected plugin.</p></div></td>';
+            body.appendChild(row);
+            return;
+          }
+
+          authMembers.forEach(function (row) {
+            const tr = document.createElement("tr");
+            const sourceClass = row.source === "static" ? "source-static" : "source-dynamic";
+            const stateClass = row.effective ? "state-effective" : "state-shadowed";
+            const stateLabel = row.effective ? "Effective" : "Shadowed";
+            const mutableLabel = row.mutable ? "Mutable" : "Locked";
+            const actionDisabled = !row.mutable || !row.userId || authDeletingUserID === row.userId;
+            tr.innerHTML =
+              '<td><div class="principal-value"></div><div class="principal-meta"></div></td>' +
+              '<td><code></code></td>' +
+              '<td><div class="pill-row"><span class="pill ' + sourceClass + '"></span><span class="pill ' + (row.mutable ? "" : "locked") + '"></span></div></td>' +
+              '<td><div class="pill-row"><span class="pill ' + stateClass + '"></span></div><div class="principal-meta state-copy"></div></td>' +
+              '<td><button class="danger-btn" type="button">Remove</button></td>';
+            tr.querySelector(".principal-value").textContent = principalLabel(row);
+            tr.querySelector(".principal-meta").textContent = principalMeta(row);
+            tr.querySelector("code").textContent = row.role || "";
+            const pills = tr.querySelectorAll(".pill");
+            pills[0].textContent = row.source || "";
+            pills[1].textContent = mutableLabel;
+            pills[2].textContent = stateLabel;
+            if (!row.effective && row.shadowedBy) {
+              tr.querySelector(".state-copy").textContent = "Hidden by " + row.shadowedBy;
+            }
+            const button = tr.querySelector("button");
+            if (actionDisabled) {
+              button.disabled = true;
+            }
+            if (row.mutable && row.userId) {
+              button.dataset.userId = row.userId;
+            }
+            if (!row.mutable) {
+              button.textContent = "Static";
+            } else if (authDeletingUserID === row.userId) {
+              button.textContent = "Removing...";
+            }
+            body.appendChild(tr);
+          });
+        }
+
+        function renderAuthorizationSummary() {
+          const effective = authMembers.filter(function (row) { return row && row.effective; }).length;
+          const staticCount = authMembers.filter(function (row) { return row && row.source === "static"; }).length;
+          const dynamicCount = authMembers.filter(function (row) { return row && row.source === "dynamic"; }).length;
+          const shadowedCount = authMembers.filter(function (row) { return row && row.source === "dynamic" && !row.effective; }).length;
+          byId("authorization-effective-count").textContent = formatCount(effective);
+          byId("authorization-static-count").textContent = formatCount(staticCount);
+          byId("authorization-dynamic-count").textContent = formatCount(dynamicCount);
+          byId("authorization-shadowed-count").textContent = formatCount(shadowedCount);
+        }
+
+        function updateAuthorizationFormState() {
+          const emailInput = byId("authorization-email-input");
+          const roleInput = byId("authorization-role-input");
+          const submitButton = byId("authorization-submit-button");
+          const formNote = byId("authorization-form-note");
+          const pluginSelect = byId("authorization-plugin-select");
+          const hasPlugin = !!selectedPluginName;
+          pluginSelect.disabled = authLoading || authSaving;
+          emailInput.disabled = !hasPlugin || authLoading || authSaving;
+          roleInput.disabled = !hasPlugin || authLoading || authSaving;
+
+          const email = normalizedEmail(emailInput.value);
+          const role = String(roleInput.value || "").trim();
+          const staticConflict = email && authStaticEmails().has(email);
+          submitButton.disabled = !hasPlugin || !email || !role || staticConflict || authLoading || authSaving;
+          submitButton.textContent = authSaving ? "Saving..." : "Save dynamic grant";
+
+          if (!hasPlugin) {
+            formNote.textContent = "Pick a plugin with an authorization policy to manage members.";
+          } else if (staticConflict) {
+            formNote.textContent = "This user already has static authorization on the selected plugin and cannot receive a dynamic grant.";
+          } else {
+            formNote.textContent = "Static rows remain read-only. Dynamic rows can be added, updated, or removed here.";
+          }
+        }
+
+        function renderAuthorizationPluginSelect() {
+          const select = byId("authorization-plugin-select");
+          select.textContent = "";
+          if (authPlugins.length === 0) {
+            const option = document.createElement("option");
+            option.value = "";
+            option.textContent = "No authorized plugins";
+            select.appendChild(option);
+            select.disabled = true;
+            return;
+          }
+
+          authPlugins.forEach(function (plugin) {
+            const option = document.createElement("option");
+            option.value = plugin.name;
+            option.textContent = plugin.name;
+            select.appendChild(option);
+          });
+          select.disabled = authLoading || authSaving;
+          if (!selectedPluginName || !authPlugins.some(function (plugin) { return plugin.name === selectedPluginName; })) {
+            selectedPluginName = authPlugins[0].name;
+          }
+          select.value = selectedPluginName;
+        }
+
+        function renderAuthorization() {
+          renderAuthorizationPluginSelect();
+          renderAuthorizationSummary();
+          renderAuthorizationMembers();
+          updateAuthorizationFormState();
+        }
+
+        async function loadAuthorizationMembers() {
+          authMembersRequestToken += 1;
+          const requestToken = authMembersRequestToken;
+          if (!selectedPluginName) {
+            authLoading = false;
+            authMembers = [];
+            renderAuthorization();
+            return;
+          }
+
+          authLoading = true;
+          renderAuthorization();
+          setAuthStatus("Loading plugin members...", "");
+          const plugin = selectedPluginName;
+          try {
+            const result = await fetchJSON("/admin/api/v1/authorization/plugins/" + encodeURIComponent(plugin) + "/members");
+            if (requestToken !== authMembersRequestToken || plugin !== selectedPluginName) return;
+            authMembers = Array.isArray(result.payload) ? result.payload : [];
+            setAuthStatus("Loaded " + authMembers.length + " rows for " + plugin + ".", "ok");
+          } catch (error) {
+            if (requestToken !== authMembersRequestToken || plugin !== selectedPluginName) return;
+            authMembers = [];
+            setAuthStatus(error instanceof Error ? error.message : "Failed to load plugin members.", "error");
+          } finally {
+            if (requestToken === authMembersRequestToken) {
+              authLoading = false;
+              renderAuthorization();
+            }
+          }
+        }
+
+        async function loadAuthorizationPlugins() {
+          authLoading = true;
+          renderAuthorization();
+          setAuthStatus("Loading authorization plugins...", "");
+          try {
+            const result = await fetchJSON("/admin/api/v1/authorization/plugins");
+            authPlugins = Array.isArray(result.payload) ? result.payload : [];
+            authLoaded = true;
+            renderAuthorizationPluginSelect();
+            updateURLState();
+            if (authPlugins.length === 0) {
+              authMembers = [];
+              setAuthStatus("No plugins currently expose dynamic authorization management.", "");
+              authLoading = false;
+              renderAuthorization();
+              return;
+            }
+            await loadAuthorizationMembers();
+          } catch (error) {
+            authPlugins = [];
+            authMembers = [];
+            authLoaded = true;
+            authLoading = false;
+            renderAuthorization();
+            setAuthStatus(error instanceof Error ? error.message : "Failed to load authorization plugins.", "error");
+          }
+        }
+
+        function bindAuthorizationControls() {
+          byId("authorization-plugin-select").addEventListener("change", function (event) {
+            const target = event.target;
+            if (!target || typeof target.value !== "string") return;
+            clearAuthPendingReload();
+            selectedPluginName = normalizePluginName(target.value);
+            updateURLState();
+            loadAuthorizationMembers();
+          });
+
+          byId("authorization-refresh-button").addEventListener("click", function () {
+            if (authLoading || authSaving) return;
+            clearAuthPendingReload();
+            loadAuthorizationPlugins();
+          });
+
+          byId("authorization-email-input").addEventListener("input", updateAuthorizationFormState);
+          byId("authorization-role-input").addEventListener("input", updateAuthorizationFormState);
+
+          byId("authorization-form").addEventListener("submit", async function (event) {
+            event.preventDefault();
+            if (!selectedPluginName || authSaving) return;
+
+            const emailInput = byId("authorization-email-input");
+            const roleInput = byId("authorization-role-input");
+            const email = String(emailInput.value || "").trim();
+            const role = String(roleInput.value || "").trim();
+            if (!email || !role) {
+              updateAuthorizationFormState();
+              return;
+            }
+
+            authSaving = true;
+            updateAuthorizationFormState();
+            setAuthStatus("Saving dynamic grant...", "");
+            try {
+              const result = await fetchJSON(
+                "/admin/api/v1/authorization/plugins/" + encodeURIComponent(selectedPluginName) + "/members",
+                {
+                  method: "PUT",
+                  headers: {
+                    Accept: "application/json",
+                    "Content-Type": "application/json",
+                  },
+                  body: JSON.stringify({ email: email, role: role }),
+                },
+              );
+              emailInput.value = "";
+              if (result.payload && result.payload.membership && result.payload.membership.role) {
+                roleInput.value = result.payload.membership.role;
+              }
+              if (result.payload && result.payload.reloaded === false) {
+                markAuthPendingReload("Dynamic grant persisted. Use Refresh after the local authorization snapshot converges to inspect the updated access state.");
+              } else {
+                clearAuthPendingReload();
+                setAuthStatus("Dynamic grant saved.", "ok");
+                await loadAuthorizationMembers();
+              }
+            } catch (error) {
+              setAuthStatus(error instanceof Error ? error.message : "Failed to save dynamic grant.", "error");
+            } finally {
+              authSaving = false;
+              updateAuthorizationFormState();
+            }
+          });
+
+          byId("authorization-members-body").addEventListener("click", async function (event) {
+            const target = event.target;
+            if (!(target instanceof HTMLButtonElement)) return;
+            const userID = normalizePluginName(target.dataset.userId);
+            if (!userID || !selectedPluginName || authDeletingUserID || target.disabled) return;
+
+            authDeletingUserID = userID;
+            renderAuthorization();
+            setAuthStatus("Removing dynamic grant...", "");
+            try {
+              const result = await fetchJSON(
+                "/admin/api/v1/authorization/plugins/" + encodeURIComponent(selectedPluginName) + "/members/" + encodeURIComponent(userID),
+                {
+                  method: "DELETE",
+                },
+              );
+              if (result.payload && result.payload.reloaded === false) {
+                markAuthPendingReload("Dynamic grant removed from storage. Use Refresh after the local authorization snapshot converges to inspect the updated access state.");
+              } else {
+                clearAuthPendingReload();
+                setAuthStatus("Dynamic grant removed.", "ok");
+                await loadAuthorizationMembers();
+              }
+            } catch (error) {
+              setAuthStatus(error instanceof Error ? error.message : "Failed to remove dynamic grant.", "error");
+            } finally {
+              authDeletingUserID = "";
+              renderAuthorization();
+            }
+          });
         }
 
         function parseLabels(raw) {
@@ -1135,10 +1931,7 @@
             });
 
             if (response.status === 401) {
-              try {
-                window.localStorage.removeItem("user_email");
-              } catch {}
-              window.location.replace("/login");
+              handleUnauthorizedResponse();
               return;
             }
 
@@ -1160,18 +1953,21 @@
             byId("summary-avg-latency").textContent = formatDuration(snapshot.avgLatencySeconds);
             byId("summary-p95-latency").textContent = formatDuration(snapshot.p95LatencySeconds);
             renderCharts(snapshot);
-            setStatus(`Last refreshed ${new Date().toLocaleTimeString()}`, "ok");
+            setMetricsStatus(`Last refreshed ${new Date().toLocaleTimeString()}`, "ok");
           } catch (error) {
             const message =
               error instanceof Error ? error.message : "Failed to load Prometheus metrics";
             latestSnapshot = null;
             clearDashboard(message);
-            setStatus(message, "error");
+            setMetricsStatus(message, "error");
           }
         }
 
+        bindTabs();
         bindControls();
+        bindAuthorizationControls();
         clearDashboard("Loading metrics...");
+        renderAuthorization();
         refresh();
         scheduleRefreshTimer();
         window.addEventListener("resize", function () {

--- a/gestaltd/internal/server/server_test.go
+++ b/gestaltd/internal/server/server_test.go
@@ -29,6 +29,7 @@ import (
 	coreintegration "github.com/valon-technologies/gestalt/server/core/integration"
 	"github.com/valon-technologies/gestalt/server/core/session"
 	coretesting "github.com/valon-technologies/gestalt/server/core/testing"
+	"github.com/valon-technologies/gestalt/server/internal/adminui"
 	"github.com/valon-technologies/gestalt/server/internal/apiexec"
 	"github.com/valon-technologies/gestalt/server/internal/authorization"
 	"github.com/valon-technologies/gestalt/server/internal/bootstrap"
@@ -1378,6 +1379,45 @@ func TestBuiltInAdminRoute_HumanAuthorizationSplitManagementLoginFlow(t *testing
 	}
 	if !strings.Contains(string(body), "protected-admin-shell") {
 		t.Fatalf("body = %q, want protected admin shell", body)
+	}
+}
+
+func TestBuiltInAdminRoute_EmbeddedAdminUIIncludesAuthorizationWorkspace(t *testing.T) {
+	t.Parallel()
+
+	ts := newTestServer(t, func(cfg *server.Config) {
+		cfg.AdminUI = adminui.EmbeddedHandler(adminui.Options{BrandHref: "/"})
+	})
+	testutil.CloseOnCleanup(t, ts)
+
+	resp, err := http.Get(ts.URL + "/admin/?tab=members")
+	if err != nil {
+		t.Fatalf("GET embedded admin ui: %v", err)
+	}
+	body, err := io.ReadAll(resp.Body)
+	_ = resp.Body.Close()
+	if err != nil {
+		t.Fatalf("ReadAll embedded admin ui: %v", err)
+	}
+	if resp.StatusCode != http.StatusOK {
+		t.Fatalf("embedded admin ui status = %d, want 200", resp.StatusCode)
+	}
+
+	text := string(body)
+	for _, want := range []string{
+		"Control surface",
+		"Authorization rules",
+		`data-tab="authorization"`,
+		`data-tab-panel="authorization"`,
+		"/admin/api/v1/authorization/plugins",
+		`window.__gestaltAdminShell.loginBase = "/api/v1/auth/login"`,
+		"Save dynamic grant",
+		"window.history.replaceState",
+		"Prometheus telemetry",
+	} {
+		if !strings.Contains(text, want) {
+			t.Fatalf("embedded admin ui body missing %q", want)
+		}
 	}
 }
 


### PR DESCRIPTION
## Summary
Document the dynamic plugin-authorization feature across the config reference, HTTP API reference, built-in admin UI docs, and Docker/operator docs.

## Go Interfaces
- No new Go interfaces are introduced in this PR.
- This PR documents the Go/API surfaces shipped in the previous slices:
  - `adminui.Options.LoginBase`
  - `GET /admin/api/v1/authorization/plugins`
  - `GET /admin/api/v1/authorization/plugins/{plugin}/members`
  - `PUT /admin/api/v1/authorization/plugins/{plugin}/members`
  - `DELETE /admin/api/v1/authorization/plugins/{plugin}/members/{userID}`
  - built-in admin query-state: `/admin/?tab=members&plugin=sample_plugin`

### Go Examples
```go
handler := adminui.EmbeddedHandler(adminui.Options{
    BrandHref: "/admin/",
    LoginBase: "https://gestalt.example.test/api/v1/auth/login",
})
_ = handler
```

```text
PUT /admin/api/v1/authorization/plugins/sample_plugin/members
```

## YAML Interfaces
- No new YAML schema is introduced in this PR.
- This PR documents that dynamic grants apply only to plugins that already declare `plugins.<name>.authorizationPolicy`, while direct `providers.ui.<name>.authorizationPolicy` bindings remain static-only.

### YAML Example
```yaml
plugins:
  sample_plugin:
    source:
      path: ./plugin/manifest.yaml
    authorizationPolicy: sample_policy
    mountPath: /sample
    ui: sample_ui

authorization:
  policies:
    sample_policy:
      default: deny
      members:
        - email: admin@example.test
          role: admin
```

With that config, operators can manage plugin-scoped dynamic grants from `/admin/?tab=members&plugin=sample_plugin` or through `/admin/api/v1/authorization/plugins/sample_plugin/members`.

## Docs Updated
- Config reference
- HTTP API reference
- Web UI provider docs
- Docker image/operator docs