### PR TITLE
[codex] authorization: treat default allow as viewer

### DIFF
--- a/gestaltd/internal/authorization/authorizer.go
+++ b/gestaltd/internal/authorization/authorizer.go
@@ -13,7 +13,10 @@ import (
 	providermanifestv1 "github.com/valon-technologies/gestalt/server/sdk/providermanifest/v1"
 )
 
-const defaultInstance = "default"
+const (
+	defaultInstance  = "default"
+	defaultHumanRole = "viewer"
+)
 
 var (
 	safeConnectionValue = regexp.MustCompile(`^[a-zA-Z0-9._-]+$`)
@@ -218,6 +221,7 @@ func (a *Authorizer) ResolvePolicyAccess(p *principal.Principal, policyName stri
 		return access, true
 	}
 	if policy.DefaultAllow {
+		access.Role = defaultHumanRole
 		return access, true
 	}
 	return access, false

--- a/gestaltd/internal/server/catalog_resolution_test.go
+++ b/gestaltd/internal/server/catalog_resolution_test.go
@@ -368,6 +368,56 @@ func TestFilterCatalogForPrincipal_HumanDefaultAllowKeepsUnannotatedOperations(t
 	}
 }
 
+func TestFilterCatalogForPrincipal_HumanDefaultAllowTreatsUnmatchedUsersAsViewer(t *testing.T) {
+	t.Parallel()
+
+	prov := &stubCatalogProvider{
+		stubProvider: stubProvider{
+			name:     "sample-api",
+			connMode: core.ConnectionModeUser,
+		},
+		cat: &catalog.Catalog{
+			Name: "sample-api",
+			Operations: []catalog.CatalogOperation{
+				{ID: "baseline_op", Method: http.MethodGet, Transport: catalog.TransportREST},
+				{ID: "viewer_op", Method: http.MethodGet, Transport: catalog.TransportREST, AllowedRoles: []string{"viewer"}},
+				{ID: "admin_op", Method: http.MethodGet, Transport: catalog.TransportREST, AllowedRoles: []string{"admin"}},
+			},
+		},
+	}
+
+	authz, err := authorization.New(config.AuthorizationConfig{
+		Policies: map[string]config.HumanPolicyDef{
+			"sample_policy": {
+				Default: "allow",
+				Members: []config.HumanPolicyMemberDef{
+					{SubjectID: principal.UserSubjectID("admin-user"), Role: "admin"},
+				},
+			},
+		},
+	}, map[string]*config.ProviderEntry{
+		"sample-api": {AuthorizationPolicy: "sample_policy"},
+	}, nil, nil)
+	if err != nil {
+		t.Fatalf("authorization.New: %v", err)
+	}
+
+	p := &principal.Principal{
+		Kind:      principal.KindUser,
+		UserID:    "viewer-user",
+		SubjectID: principal.UserSubjectID("viewer-user"),
+	}
+	filtered := invocation.FilterCatalogForPrincipal(prov.Catalog(), "sample-api", p, authz)
+	if len(filtered.Operations) != 2 {
+		t.Fatalf("expected 2 operations after default-allow filtering, got %d", len(filtered.Operations))
+	}
+	gotIDs := []string{filtered.Operations[0].ID, filtered.Operations[1].ID}
+	wantIDs := []string{"baseline_op", "viewer_op"}
+	if fmt.Sprint(gotIDs) != fmt.Sprint(wantIDs) {
+		t.Fatalf("filtered operation IDs = %#v, want %#v", gotIDs, wantIDs)
+	}
+}
+
 func TestFilterCatalogForPrincipal_HumanUnboundProviderKeepsRoleAnnotatedOperations(t *testing.T) {
 	t.Parallel()
 

--- a/gestaltd/internal/server/server_test.go
+++ b/gestaltd/internal/server/server_test.go
@@ -708,6 +708,107 @@ func TestMountedWebUIRoutes_HumanAuthorization(t *testing.T) {
 	}
 }
 
+func TestMountedWebUIRoutes_HumanAuthorization_DefaultAllowTreatsAuthenticatedUsersAsViewer(t *testing.T) {
+	t.Parallel()
+
+	dir := t.TempDir()
+	if err := os.WriteFile(filepath.Join(dir, "index.html"), []byte("<html>protected-sample-shell</html>"), 0o644); err != nil {
+		t.Fatalf("WriteFile index.html: %v", err)
+	}
+	handler, err := testutilWebUIHandler(dir)
+	if err != nil {
+		t.Fatalf("webui handler: %v", err)
+	}
+
+	authz := mustAuthorizer(t, config.AuthorizationConfig{
+		Policies: map[string]config.HumanPolicyDef{
+			"sample_policy": {
+				Default: "allow",
+				Members: []config.HumanPolicyMemberDef{
+					{Email: "admin@example.test", Role: "admin"},
+				},
+			},
+		},
+	}, nil, map[string]*config.ProviderEntry{
+		"sample_portal": {AuthorizationPolicy: "sample_policy"},
+	}, nil)
+
+	ts := newTestServer(t, func(cfg *server.Config) {
+		cfg.Auth = &coretesting.StubAuthProvider{
+			N: "test",
+			ValidateTokenFn: func(_ context.Context, token string) (*core.UserIdentity, error) {
+				switch token {
+				case "viewer-session":
+					return &core.UserIdentity{Email: "viewer@example.test"}, nil
+				case "admin-session":
+					return &core.UserIdentity{Email: "admin@example.test"}, nil
+				default:
+					return nil, fmt.Errorf("invalid token")
+				}
+			},
+		}
+		cfg.Authorizer = authz
+		cfg.MountedWebUIs = []server.MountedWebUI{{
+			Name:                "sample_portal",
+			Path:                "/sample-portal",
+			AuthorizationPolicy: "sample_policy",
+			Routes: []server.MountedWebUIRoute{
+				{Path: "/admin/*", AllowedRoles: []string{"admin"}},
+				{Path: "/*", AllowedRoles: []string{"viewer", "admin"}},
+			},
+			Handler: handler,
+		}}
+	})
+	testutil.CloseOnCleanup(t, ts)
+
+	req, _ := http.NewRequest(http.MethodGet, ts.URL+"/sample-portal/sync", nil)
+	req.AddCookie(&http.Cookie{Name: "session_token", Value: "viewer-session"})
+	resp, err := http.DefaultClient.Do(req)
+	if err != nil {
+		t.Fatalf("GET default-allow mounted sync with viewer session: %v", err)
+	}
+	body, err := io.ReadAll(resp.Body)
+	_ = resp.Body.Close()
+	if err != nil {
+		t.Fatalf("ReadAll default-allow mounted sync: %v", err)
+	}
+	if resp.StatusCode != http.StatusOK {
+		t.Fatalf("default-allow viewer status = %d, want %d", resp.StatusCode, http.StatusOK)
+	}
+	if !strings.Contains(string(body), "protected-sample-shell") {
+		t.Fatalf("body = %q, want protected sample shell", body)
+	}
+
+	req, _ = http.NewRequest(http.MethodGet, ts.URL+"/sample-portal/admin", nil)
+	req.AddCookie(&http.Cookie{Name: "session_token", Value: "viewer-session"})
+	resp, err = http.DefaultClient.Do(req)
+	if err != nil {
+		t.Fatalf("GET default-allow mounted admin with viewer session: %v", err)
+	}
+	defer func() { _ = resp.Body.Close() }()
+	if resp.StatusCode != http.StatusForbidden {
+		t.Fatalf("default-allow viewer admin status = %d, want %d", resp.StatusCode, http.StatusForbidden)
+	}
+
+	req, _ = http.NewRequest(http.MethodGet, ts.URL+"/sample-portal/admin", nil)
+	req.AddCookie(&http.Cookie{Name: "session_token", Value: "admin-session"})
+	resp, err = http.DefaultClient.Do(req)
+	if err != nil {
+		t.Fatalf("GET default-allow mounted admin with admin session: %v", err)
+	}
+	body, err = io.ReadAll(resp.Body)
+	_ = resp.Body.Close()
+	if err != nil {
+		t.Fatalf("ReadAll default-allow mounted admin: %v", err)
+	}
+	if resp.StatusCode != http.StatusOK {
+		t.Fatalf("default-allow admin status = %d, want %d", resp.StatusCode, http.StatusOK)
+	}
+	if !strings.Contains(string(body), "protected-sample-shell") {
+		t.Fatalf("admin body = %q, want protected sample shell", body)
+	}
+}
+
 func TestBuiltInAdminRoute_HumanAuthorization(t *testing.T) {
 	t.Parallel()
 
@@ -5120,6 +5221,140 @@ func TestHumanAuthorization_ExecuteOperation_UsesResolvedRoleAndRejectsDisallowe
 				Members: []config.HumanPolicyMemberDef{
 					{Email: "viewer-user@test.local", Role: "viewer"},
 					{SubjectID: principal.UserSubjectID(viewer.ID), Role: "viewer"},
+				},
+			},
+		},
+	}, nil, pluginDefs, nil)
+
+	var auditBuf bytes.Buffer
+	ts := newTestServer(t, func(cfg *server.Config) {
+		cfg.Auth = &coretesting.StubAuthProvider{N: "test"}
+		cfg.Providers = testutil.NewProviderRegistry(t, stub)
+		cfg.Services = svc
+		cfg.Authorizer = authz
+		cfg.PluginDefs = pluginDefs
+		cfg.AuditSink = invocation.NewSlogAuditSink(&auditBuf)
+	})
+	testutil.CloseOnCleanup(t, ts)
+
+	req, _ := http.NewRequest(http.MethodGet, ts.URL+"/api/v1/svc/run", nil)
+	req.Header.Set("Authorization", "Bearer "+plaintext)
+	resp, err := http.DefaultClient.Do(req)
+	if err != nil {
+		t.Fatalf("request: %v", err)
+	}
+	defer func() { _ = resp.Body.Close() }()
+	if resp.StatusCode != http.StatusOK {
+		body, _ := io.ReadAll(resp.Body)
+		t.Fatalf("expected 200, got %d: %s", resp.StatusCode, body)
+	}
+	var result map[string]any
+	if err := json.NewDecoder(resp.Body).Decode(&result); err != nil {
+		t.Fatalf("decoding: %v", err)
+	}
+	if result["policy"] != "sample_policy" || result["role"] != "viewer" {
+		t.Fatalf("unexpected access context in execute response: %+v", result)
+	}
+
+	req, _ = http.NewRequest(http.MethodGet, ts.URL+"/api/v1/svc/admin", nil)
+	req.Header.Set("Authorization", "Bearer "+plaintext)
+	resp, err = http.DefaultClient.Do(req)
+	if err != nil {
+		t.Fatalf("admin request: %v", err)
+	}
+	defer func() { _ = resp.Body.Close() }()
+	if resp.StatusCode != http.StatusForbidden {
+		body, _ := io.ReadAll(resp.Body)
+		t.Fatalf("expected 403, got %d: %s", resp.StatusCode, body)
+	}
+
+	lines := bytes.Split(bytes.TrimSpace(auditBuf.Bytes()), []byte("\n"))
+	if len(lines) == 0 {
+		t.Fatal("expected denial audit record")
+	}
+
+	var deniedAudit map[string]any
+	if err := json.Unmarshal(lines[len(lines)-1], &deniedAudit); err != nil {
+		t.Fatalf("parsing denied audit record: %v\nraw: %s", err, auditBuf.String())
+	}
+	if deniedAudit["provider"] != "svc" {
+		t.Fatalf("expected denied audit provider svc, got %v", deniedAudit["provider"])
+	}
+	if deniedAudit["operation"] != "admin" {
+		t.Fatalf("expected denied audit operation admin, got %v", deniedAudit["operation"])
+	}
+	if deniedAudit["allowed"] != false {
+		t.Fatalf("expected denied audit allowed=false, got %v", deniedAudit["allowed"])
+	}
+	if deniedAudit["auth_source"] != "api_token" {
+		t.Fatalf("expected denied audit auth_source api_token, got %v", deniedAudit["auth_source"])
+	}
+	if deniedAudit["subject_id"] != principal.UserSubjectID(viewer.ID) {
+		t.Fatalf("expected denied audit subject_id %q, got %v", principal.UserSubjectID(viewer.ID), deniedAudit["subject_id"])
+	}
+	if deniedAudit["access_policy"] != "sample_policy" {
+		t.Fatalf("expected denied audit access_policy sample_policy, got %v", deniedAudit["access_policy"])
+	}
+	if deniedAudit["access_role"] != "viewer" {
+		t.Fatalf("expected denied audit access_role viewer, got %v", deniedAudit["access_role"])
+	}
+	if deniedAudit["authorization_decision"] != "catalog_role_denied" {
+		t.Fatalf("expected denied audit authorization_decision catalog_role_denied, got %v", deniedAudit["authorization_decision"])
+	}
+	if deniedAudit["error"] != "operation access denied" {
+		t.Fatalf("expected denied audit error operation access denied, got %v", deniedAudit["error"])
+	}
+}
+
+func TestHumanAuthorization_ExecuteOperation_DefaultAllowTreatsAuthenticatedUsersAsViewer(t *testing.T) {
+	t.Parallel()
+
+	plaintext, hashed, err := principal.GenerateToken(principal.TokenTypeAPI)
+	if err != nil {
+		t.Fatalf("GenerateToken: %v", err)
+	}
+
+	svc := coretesting.NewStubServices(t)
+	seedAPIToken(t, svc, plaintext, hashed, "viewer-user")
+	viewer := seedUser(t, svc, "viewer-user@test.local")
+
+	stub := &stubIntegrationWithSessionCatalog{
+		stubIntegrationWithOps: stubIntegrationWithOps{
+			StubIntegration: coretesting.StubIntegration{
+				N:        "svc",
+				ConnMode: core.ConnectionModeNone,
+				ExecuteFn: func(ctx context.Context, op string, _ map[string]any, _ string) (*core.OperationResult, error) {
+					access := invocation.AccessContextFromContext(ctx)
+					body, err := json.Marshal(map[string]string{
+						"operation": op,
+						"policy":    access.Policy,
+						"role":      access.Role,
+					})
+					if err != nil {
+						return nil, err
+					}
+					return &core.OperationResult{Status: http.StatusOK, Body: string(body)}, nil
+				},
+			},
+		},
+		catalog: &catalog.Catalog{
+			Name: "svc",
+			Operations: []catalog.CatalogOperation{
+				{ID: "run", Method: http.MethodGet, Transport: catalog.TransportREST, AllowedRoles: []string{"viewer"}},
+				{ID: "admin", Method: http.MethodGet, Transport: catalog.TransportREST, AllowedRoles: []string{"admin"}},
+			},
+		},
+	}
+
+	pluginDefs := map[string]*config.ProviderEntry{
+		"svc": {AuthorizationPolicy: "sample_policy"},
+	}
+	authz := mustAuthorizer(t, config.AuthorizationConfig{
+		Policies: map[string]config.HumanPolicyDef{
+			"sample_policy": {
+				Default: "allow",
+				Members: []config.HumanPolicyMemberDef{
+					{Email: "admin-user@test.local", Role: "admin"},
 				},
 			},
 		},


### PR DESCRIPTION
## What changed
`default: allow` now resolves unmatched authenticated human users as `viewer` instead of returning an empty role.

This updates the shared authorization semantics used by mounted web UIs and role-annotated provider operations, and adds regression coverage for catalog filtering, mounted UI routing, and operation execution.

## Why
`/ci-workqueue` and any other policy-bound UI/operation that requires `viewer|editor|admin` was still denying unmatched logged-in users under `default: allow`, because `gestaltd` treated them as allowed-with-no-role.

In practice that meant `default: allow` did not behave like "all authenticated users can access viewer-level routes and operations".

## Impact
Authenticated users who match a human policy with `default: allow` now receive `viewer` access by default.

Admin/editor explicit grants still behave the same, and admin-only routes/operations remain denied to default viewers.

## Validation
- `go test ./internal/server -run 'TestFilterCatalogForPrincipal_HumanDefaultAllow(KeepsUnannotatedOperations|TreatsUnmatchedUsersAsViewer)|TestMountedWebUIRoutes_HumanAuthorization(_DefaultAllowTreatsAuthenticatedUsersAsViewer)?|TestHumanAuthorization_ExecuteOperation_(UsesResolvedRoleAndRejectsDisallowedOperations|DefaultAllowTreatsAuthenticatedUsersAsViewer)$'`
- `go test ./internal/mcp -run 'TestNewServer_HumanSessionCatalogReceivesAccessContext$'`

## Root cause
The authorizer returned `allowed=true` for `default: allow`, but left `AccessContext.Role` empty. Downstream UI/operation checks interpret an empty role as unauthorized when `allowedRoles` is declared.