### PR TITLE
[codex] Prepare OSS SDK publishing

### DIFF
--- a/.github/workflows/release-sdk.yml
+++ b/.github/workflows/release-sdk.yml
@@ -102,10 +102,76 @@ jobs:
       - name: Run clippy
         run: cargo clippy --all-targets -- -D warnings
 
+  publish-rust-sdk:
+    if: ${{ startsWith(github.ref_name, 'sdk/rust/v') }}
+    name: Publish Rust SDK
+    needs: validate-rust-sdk
+    runs-on: ubuntu-latest
+    timeout-minutes: 15
+    permissions:
+      contents: read
+    defaults:
+      run:
+        working-directory: sdk/rust
+    steps:
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
+
+      - uses: dtolnay/rust-toolchain@29eef336d9b2848a0b548edc03f92a220660cdb8 # stable
+        with:
+          toolchain: stable
+
+      - uses: actions/cache@0057852bfaa89a56745cba8c7296529d2fc39830 # v4
+        with:
+          path: |
+            ~/.cargo/bin/
+            ~/.cargo/registry/index/
+            ~/.cargo/registry/cache/
+            ~/.cargo/git/db/
+            sdk/rust/target/
+          key: ${{ runner.os }}-cargo-rust-sdk-${{ hashFiles('sdk/rust/Cargo.toml', 'sdk/rust/Cargo.lock', 'sdk/rust/**/Cargo.toml') }}
+
+      - name: Normalize crate version from tag
+        run: |
+          python3 - <<'PY'
+          import os
+          import re
+          from pathlib import Path
+
+          path = Path("Cargo.toml")
+          data = path.read_text()
+          version = os.environ["VERSION"].removeprefix("sdk/rust/v")
+          updated, count = re.subn(
+              r'(^\[package\]\n(?:(?!^\[).*\n)*?^version = ")[^"]+(")',
+              rf"\g<1>{version}\2",
+              data,
+              count=1,
+              flags=re.MULTILINE,
+          )
+          if count != 1:
+              raise SystemExit("failed to update [package].version in Cargo.toml")
+          path.write_text(updated)
+          PY
+        env:
+          VERSION: ${{ github.ref_name }}
+
+      - name: Verify published crate contents
+        run: cargo publish --dry-run
+
+      - name: Publish crate
+        env:
+          CARGO_REGISTRY_TOKEN: ${{ secrets.CARGO_REGISTRY_TOKEN }}
+        run: |
+          if [ -z "${CARGO_REGISTRY_TOKEN}" ]; then
+            echo "CARGO_REGISTRY_TOKEN must be configured" >&2
+            exit 1
+          fi
+
+          cargo publish
+
   release-rust-sdk:
     if: ${{ startsWith(github.ref_name, 'sdk/rust/v') }}
     name: Publish Release
-    needs: validate-rust-sdk
+    needs: publish-rust-sdk
     uses: ./.github/workflows/publish-scoped-github-release.yml
     with:
       component-name: Gestalt Rust SDK
@@ -117,15 +183,21 @@ jobs:
       component-summary: |
         Rust SDK for building Gestalt executable providers, including integration, auth, and datastore surfaces, against the shared protocol bindings in this repository.
       install-markdown: |
-        - Crate name: `gestalt`
-        - Crates.io publishing is not enabled for this release yet.
-        - Consume the crate source from `sdk/rust` at tag `${tag}` until registry publishing is added.
+        - Crate: `cargo add gestalt-sdk`
+        - In code, continue importing the library as `gestalt`
+        - Package docs: [crates.io/crates/gestalt-sdk](https://crates.io/crates/gestalt-sdk)
 
   publish-python-sdk:
     if: ${{ startsWith(github.ref_name, 'sdk/python/v') }}
     name: Publish Python SDK
     runs-on: ubuntu-latest
     timeout-minutes: 15
+    environment:
+      name: pypi
+      url: https://pypi.org/p/gestalt-sdk
+    permissions:
+      contents: read
+      id-token: write
     env:
       UV_PYTHON: "3.14"
     defaults:
@@ -154,29 +226,18 @@ jobs:
           uv run --with "$wheel" --no-project python -c "import gestalt"
 
       - name: Publish distributions
-        env:
-          GESTALT_PYTHON_PUBLISH_URL: ${{ secrets.GESTALT_PYTHON_PUBLISH_URL }}
-          UV_PUBLISH_TOKEN: ${{ secrets.GESTALT_PYTHON_PUBLISH_TOKEN }}
-          UV_PUBLISH_USERNAME: ${{ secrets.GESTALT_PYTHON_PUBLISH_USERNAME }}
-          UV_PUBLISH_PASSWORD: ${{ secrets.GESTALT_PYTHON_PUBLISH_PASSWORD }}
-        run: |
-          if [ -z "${GESTALT_PYTHON_PUBLISH_URL}" ]; then
-            echo "GESTALT_PYTHON_PUBLISH_URL must be configured" >&2
-            exit 1
-          fi
-
-          if [ -z "${UV_PUBLISH_TOKEN}" ] && { [ -z "${UV_PUBLISH_USERNAME}" ] || [ -z "${UV_PUBLISH_PASSWORD}" ]; }; then
-            echo "configure GESTALT_PYTHON_PUBLISH_TOKEN or GESTALT_PYTHON_PUBLISH_USERNAME and GESTALT_PYTHON_PUBLISH_PASSWORD" >&2
-            exit 1
-          fi
-
-          uv publish --publish-url "${GESTALT_PYTHON_PUBLISH_URL}"
+        uses: pypa/gh-action-pypi-publish@release/v1
+        with:
+          packages-dir: sdk/python/dist/
 
   publish-typescript-sdk:
     if: ${{ startsWith(github.ref_name, 'sdk/typescript/v') }}
     name: Publish TypeScript SDK
     runs-on: ubuntu-latest
     timeout-minutes: 15
+    permissions:
+      contents: read
+      id-token: write
     defaults:
       run:
         working-directory: sdk/typescript
@@ -187,12 +248,32 @@ jobs:
         with:
           bun-version: 1.3.11
 
+      - uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4
+        with:
+          node-version: '24'
+          registry-url: 'https://registry.npmjs.org'
+
       - name: Install dependencies
         run: bun install --frozen-lockfile
 
-      - name: Normalize package version from tag
+      - name: Determine publish metadata from tag
+        id: version
         env:
           VERSION: ${{ github.ref_name }}
+        run: |
+          version="${VERSION#sdk/typescript/v}"
+          tag=latest
+          case "$version" in
+            *-alpha.*) tag=alpha ;;
+            *-beta.*) tag=beta ;;
+            *-rc.*) tag=rc ;;
+          esac
+          echo "version=${version}" >> "$GITHUB_OUTPUT"
+          echo "tag=${tag}" >> "$GITHUB_OUTPUT"
+
+      - name: Normalize package version from tag
+        env:
+          VERSION: ${{ steps.version.outputs.version }}
         run: |
           python3 - <<'PY'
           import json
@@ -201,64 +282,15 @@ jobs:
 
           path = Path("package.json")
           data = json.loads(path.read_text())
-          data["version"] = os.environ["VERSION"].removeprefix("sdk/typescript/v")
+          data["version"] = os.environ["VERSION"]
           path.write_text(json.dumps(data, indent=2) + "\n")
           PY
 
       - name: Run SDK checks
         run: bun run check
 
-      - name: Configure registry auth
-        env:
-          GESTALT_TYPESCRIPT_PUBLISH_URL: ${{ secrets.GESTALT_TYPESCRIPT_PUBLISH_URL }}
-          GESTALT_TYPESCRIPT_PUBLISH_TOKEN: ${{ secrets.GESTALT_TYPESCRIPT_PUBLISH_TOKEN }}
-          GESTALT_TYPESCRIPT_PUBLISH_USERNAME: ${{ secrets.GESTALT_TYPESCRIPT_PUBLISH_USERNAME }}
-          GESTALT_TYPESCRIPT_PUBLISH_PASSWORD: ${{ secrets.GESTALT_TYPESCRIPT_PUBLISH_PASSWORD }}
-        run: |
-          if [ -z "${GESTALT_TYPESCRIPT_PUBLISH_URL}" ]; then
-            echo "GESTALT_TYPESCRIPT_PUBLISH_URL must be configured" >&2
-            exit 1
-          fi
-
-          if [ -z "${GESTALT_TYPESCRIPT_PUBLISH_TOKEN}" ] && { [ -z "${GESTALT_TYPESCRIPT_PUBLISH_USERNAME}" ] || [ -z "${GESTALT_TYPESCRIPT_PUBLISH_PASSWORD}" ]; }; then
-            echo "configure GESTALT_TYPESCRIPT_PUBLISH_TOKEN or GESTALT_TYPESCRIPT_PUBLISH_USERNAME and GESTALT_TYPESCRIPT_PUBLISH_PASSWORD" >&2
-            exit 1
-          fi
-
-          registry_host="$(python3 - <<'PY'
-          import os
-          from urllib.parse import urlparse
-
-          url = urlparse(os.environ["GESTALT_TYPESCRIPT_PUBLISH_URL"])
-          path = url.path or "/"
-          if not path.endswith("/"):
-            path += "/"
-          print(f"//{url.netloc}{path}")
-          PY
-          )"
-
-          userconfig="$RUNNER_TEMP/.npmrc"
-          {
-            printf "registry=%s\n" "$GESTALT_TYPESCRIPT_PUBLISH_URL"
-            printf "always-auth=true\n"
-            if [ -n "${GESTALT_TYPESCRIPT_PUBLISH_TOKEN}" ]; then
-              printf "%s:_authToken=%s\n" "$registry_host" "$GESTALT_TYPESCRIPT_PUBLISH_TOKEN"
-            else
-              password_b64="$(printf '%s' "$GESTALT_TYPESCRIPT_PUBLISH_PASSWORD" | base64 | tr -d '\n')"
-              printf "%s:username=%s\n" "$registry_host" "$GESTALT_TYPESCRIPT_PUBLISH_USERNAME"
-              printf "%s:_password=%s\n" "$registry_host" "$password_b64"
-              printf "%s:email=%s\n" "$registry_host" "github-actions[bot]@users.noreply.github.com"
-            fi
-          } > "$userconfig"
-
-          echo "NPM_CONFIG_USERCONFIG=$userconfig" >> "$GITHUB_ENV"
-
       - name: Dry-run publish
-        env:
-          GESTALT_TYPESCRIPT_PUBLISH_URL: ${{ secrets.GESTALT_TYPESCRIPT_PUBLISH_URL }}
-        run: bun publish --dry-run --registry "${GESTALT_TYPESCRIPT_PUBLISH_URL}"
+        run: npm publish --dry-run --access public --tag "${{ steps.version.outputs.tag }}"
 
       - name: Publish package
-        env:
-          GESTALT_TYPESCRIPT_PUBLISH_URL: ${{ secrets.GESTALT_TYPESCRIPT_PUBLISH_URL }}
-        run: bun publish --registry "${GESTALT_TYPESCRIPT_PUBLISH_URL}"
+        run: npm publish --access public --tag "${{ steps.version.outputs.tag }}"

--- a/sdk/python/pyproject.toml
+++ b/sdk/python/pyproject.toml
@@ -3,7 +3,7 @@ requires = ["setuptools==82.0.1"]
 build-backend = "setuptools.build_meta"
 
 [project]
-name = "gestalt"
+name = "gestalt-sdk"
 version = "0.0.1a1"
 description = "Python SDK for Gestalt executable providers"
 requires-python = ">=3.10"

--- a/sdk/python/uv.lock
+++ b/sdk/python/uv.lock
@@ -33,7 +33,7 @@ wheels = [
 ]
 
 [[package]]
-name = "gestalt"
+name = "gestalt-sdk"
 version = "0.0.1a1"
 source = { editable = "." }
 dependencies = [
@@ -65,7 +65,7 @@ requires-dist = [
 dev = [
     { name = "pytest", specifier = ">=9.0.3" },
     { name = "ruff", specifier = "==0.15.9" },
-    { name = "ty", specifier = "==0.0.29" },
+    { name = "ty", specifier = "==0.0.31" },
     { name = "vulture", specifier = "==2.16.0" },
 ]
 
@@ -424,26 +424,26 @@ wheels = [
 
 [[package]]
 name = "ty"
-version = "0.0.29"
+version = "0.0.31"
 source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/47/d5/853561de49fae38c519e905b2d8da9c531219608f1fccc47a0fc2c896980/ty-0.0.29.tar.gz", hash = "sha256:e7936cca2f691eeda631876c92809688dbbab68687c3473f526cd83b6a9228d8", size = 5469221 }
+sdist = { url = "https://files.pythonhosted.org/packages/31/cc/5ea5d3a72216c8c2bf77d83066dd4f3553532d0aacc03d4a8397dd9845e1/ty-0.0.31.tar.gz", hash = "sha256:4a4094292d9671caf3b510c7edf36991acd9c962bb5d97205374ffed9f541c45", size = 5516619 }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/03/b7/911f9962115acfa24e3b2ec9d4992dd994c38e8769e1b1d7680bb4d28a51/ty-0.0.29-py3-none-linux_armv6l.whl", hash = "sha256:b8a40955f7660d3eaceb0d964affc81b790c0765e7052921a5f861ff8a471c30", size = 10568206 },
-    { url = "https://files.pythonhosted.org/packages/fe/c3/fcae2167d4c77a97269f92f11d1b43b03617f81de1283d5d05b43432110c/ty-0.0.29-py3-none-macosx_10_12_x86_64.whl", hash = "sha256:6b6849adae15b00bbe2d3c5b078967dcb62eba37d38936b8eeb4c81a82d2e3b8", size = 10442530 },
-    { url = "https://files.pythonhosted.org/packages/97/33/5a6bfa240cfcb9c36046ae2459fa9ea23238d20130d8656ff5ac4d6c012a/ty-0.0.29-py3-none-macosx_11_0_arm64.whl", hash = "sha256:dcdd9b17209788152f7b7ea815eda07989152325052fe690013537cc7904ce49", size = 9915735 },
-    { url = "https://files.pythonhosted.org/packages/b3/1e/318f45fae232118e81a6306c30f50de42c509c412128d5bd231eab699ffb/ty-0.0.29-py3-none-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:9d8ed4789bae78ffaf94462c0d25589a734cab0366b86f2bbcb1bb90e1a7a169", size = 10419748 },
-    { url = "https://files.pythonhosted.org/packages/a9/a8/5687872e2ab5a0f7dd4fd8456eac31e9381ad4dc74961f6f29965ad4dd91/ty-0.0.29-py3-none-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:91ec374b8565e0ad0900011c24641ebbef2da51adbd4fb69ff3280c8a7eceb02", size = 10394738 },
-    { url = "https://files.pythonhosted.org/packages/de/68/015d118097eeb95e6a44c4abce4c0a28b7b9dfb3085b7f0ee48e4f099633/ty-0.0.29-py3-none-manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:298a8d5faa2502d3810bbbb47a030b9455495b9921594206043c785dd61548cf", size = 10910613 },
-    { url = "https://files.pythonhosted.org/packages/1c/01/47ce3c6c53e0670eadbe80756b167bf80ed6681d1ba57cfde2e8065a13d1/ty-0.0.29-py3-none-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:3c8fba1a3524c6109d1e020d92301c79d41bf442fa8d335b9fa366239339cb70", size = 11475750 },
-    { url = "https://files.pythonhosted.org/packages/c4/cf/e361845b1081c9264ad5b7c963231bab03f2666865a9f2a115c4233f2137/ty-0.0.29-py3-none-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:4c48adf88a70d264128c39ee922ed14a947817fced1e93c08c1a89c9244edcde", size = 11190055 },
-    { url = "https://files.pythonhosted.org/packages/79/12/0fb0857e9a62cb11586e9a712103877bbf717f5fb570d16634408cfdefee/ty-0.0.29-py3-none-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:2ce0a7a0e96bc7b42518cd3a1a6a6298ef64ff40ca4614355c1aa807059b5c6f", size = 11020539 },
-    { url = "https://files.pythonhosted.org/packages/20/36/5a26753802083f80cd125db6c4348ad42b3c982ec36e718e0bf4c18f75e5/ty-0.0.29-py3-none-musllinux_1_2_aarch64.whl", hash = "sha256:a6ac86a05b4a3731d45365ab97780acc7b8146fa62fccb3cbe94fe6546c67a97", size = 10396399 },
-    { url = "https://files.pythonhosted.org/packages/00/e6/b4e75b5752239ab3ab400f19faef4dbef81d05aab5d3419fda0c062a3765/ty-0.0.29-py3-none-musllinux_1_2_armv7l.whl", hash = "sha256:6bbbf53141af0f3150bf288d716263f1a3550054e4b3551ca866d38192ba9891", size = 10421461 },
-    { url = "https://files.pythonhosted.org/packages/c0/21/1084b5b609f9abed62070ec0b31c283a403832a6310c8bbc208bd45ee1e6/ty-0.0.29-py3-none-musllinux_1_2_i686.whl", hash = "sha256:1c9e06b770c1d0ff5efc51e34312390db31d53fcf3088163f413030b42b74f84", size = 10599187 },
-    { url = "https://files.pythonhosted.org/packages/ab/a1/ce19a2ca717bbcc1ee11378aba52ef70b6ce5b87245162a729d9fdc2360f/ty-0.0.29-py3-none-musllinux_1_2_x86_64.whl", hash = "sha256:0307fe37e3f000ef1a4ae230bbaf511508a78d24a5e51b40902a21b09d5e6037", size = 11121198 },
-    { url = "https://files.pythonhosted.org/packages/6b/6b/f1430b279af704321566ce7ec2725d3d8258c2f815ebd93e474c64cd4543/ty-0.0.29-py3-none-win32.whl", hash = "sha256:7a2a898217960a825f8bc0087e1fdbaf379606175e98f9807187221d53a4a8ed", size = 9995331 },
-    { url = "https://files.pythonhosted.org/packages/d2/ef/3ef01c17785ff9a69378465c7d0faccd48a07b163554db0995e5d65a5a23/ty-0.0.29-py3-none-win_amd64.whl", hash = "sha256:fc1294200226b91615acbf34e0a9ad81caf98c081e9c6a912a31b0a7b603bc3f", size = 11023644 },
-    { url = "https://files.pythonhosted.org/packages/2c/55/87280a994d6a2d2647c65e12abbc997ed49835794366153c04c4d9304d76/ty-0.0.29-py3-none-win_arm64.whl", hash = "sha256:f9794bbd1bb3ce13f78c191d0c89ae4c63f52c12b6daa0c6fe220b90d019d12c", size = 10428165 },
+    { url = "https://files.pythonhosted.org/packages/b0/10/ea805cbbd75d5d50792551a2b383de8521eeab0c44f38c73e12819ced65e/ty-0.0.31-py3-none-linux_armv6l.whl", hash = "sha256:761651dc17ad7bc0abfc1b04b3f0e84df263ed435d34f29760b3da739ab02d35", size = 10834749 },
+    { url = "https://files.pythonhosted.org/packages/d9/4c/fabf951850401d24d36b21bced088a366c6827e1c37dab4523afff84c4b2/ty-0.0.31-py3-none-macosx_10_12_x86_64.whl", hash = "sha256:c529922395a07231c27488f0290651e05d27d149f7e0aa807678f1f7e9c58a5e", size = 10626012 },
+    { url = "https://files.pythonhosted.org/packages/04/b0/4a5aff88d2544f19514a59c8f693d63144aa7307fe2ee5df608333ab5460/ty-0.0.31-py3-none-macosx_11_0_arm64.whl", hash = "sha256:5f345df2b87d747859e72c2cbc9be607ea1bbc8bc93dd32fa3d03ea091cb4fee", size = 10075790 },
+    { url = "https://files.pythonhosted.org/packages/d5/73/9d4dcad12cd4e85274014f2c0510ef93f590b2a1e5148de3a9f276098dad/ty-0.0.31-py3-none-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:d4b207eddcfbafd376132689d3435b14efcb531289cb59cd961c6a611133bd54", size = 10590286 },
+    { url = "https://files.pythonhosted.org/packages/47/45/fe40adde18692359ded174ae7ddbfac056e876eb0f43b65be74fde7f6072/ty-0.0.31-py3-none-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:663778b220f357067488ce68bfc52335ccbd161549776f70dcbde6bbde82f77a", size = 10623824 },
+    { url = "https://files.pythonhosted.org/packages/2e/e8/0ffa2e09b548e6daa9ebc368d68b767dc2405ca4cbeadb7ede0e2cb21059/ty-0.0.31-py3-none-manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:3506cfe87dfade0fb2960dd4fffd4fd8089003587b3445c0a1a295c9d83764fb", size = 11156864 },
+    { url = "https://files.pythonhosted.org/packages/08/e9/fd44c2075115d569593ee9473d7e2a38b750fd7e783421c95eb528c15df5/ty-0.0.31-py3-none-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:8b3f3d8492f08e81916026354c1d1599e9ddfa1241804141a74d5662fc710085", size = 11696401 },
+    { url = "https://files.pythonhosted.org/packages/4e/50/35aad8eadf964d23e2a4faa5b38a206aa85c78833c8ce335dddd2c34ba63/ty-0.0.31-py3-none-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:a97de32ee6a619393a4c495e056a1c547de7877510f3152e61345c71d774d2d0", size = 11374903 },
+    { url = "https://files.pythonhosted.org/packages/c8/37/01eccd25d23f5aaa7f7ff1a87b5b215469f6b202cf689a1812b71c1e7f6b/ty-0.0.31-py3-none-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:c906354ce441e342646582bc9b8f48a676f79f3d061e25de15ff870e015ca14e", size = 11206624 },
+    { url = "https://files.pythonhosted.org/packages/f4/70/baad2914cb097453f127a221f8addb2b41926098059cd773c75e6a662fc4/ty-0.0.31-py3-none-musllinux_1_2_aarch64.whl", hash = "sha256:275bb7c82afcbf89fe2dbef1b2692f2bc98451f1ee2c8eb809ddd91317822388", size = 10575089 },
+    { url = "https://files.pythonhosted.org/packages/83/12/bae3a7bba2e785eb72ce00f9da70eedcb8c5e8299efecbd16e6e436abd82/ty-0.0.31-py3-none-musllinux_1_2_armv7l.whl", hash = "sha256:405da247027c6efd1e264886b6ac4a86ab3a4f09200b02e33630efe85f119e53", size = 10642315 },
+    { url = "https://files.pythonhosted.org/packages/93/9e/cad04d5d839bc60355cea98c7e09d724ea65f47184def0fae8b90dc54591/ty-0.0.31-py3-none-musllinux_1_2_i686.whl", hash = "sha256:54d9835608eed196853d6643f645c50ce83bcc7fe546cdb3e210c1bcf7c58c09", size = 10834473 },
+    { url = "https://files.pythonhosted.org/packages/e3/ba/84112d280182d37690d3d2b4018b2667e42bc281585e607015635310016a/ty-0.0.31-py3-none-musllinux_1_2_x86_64.whl", hash = "sha256:5ee11be9b07e8c0c6b455ff075a0abe4f194de9476f57624db98eec9df618355", size = 11315785 },
+    { url = "https://files.pythonhosted.org/packages/50/9f/ac42dc223d7e0950e97a1854567a8b3e7fe09ad7375adbf91bfb43290482/ty-0.0.31-py3-none-win32.whl", hash = "sha256:7286587aacf3eef0956062d6492b893b02f82b0f22c5e230008e13ff0d216a8b", size = 10187657 },
+    { url = "https://files.pythonhosted.org/packages/75/3e/57ba7ea7ecb2f4751644ba91756e2be70e33ef5952c0c41a256a0e4c2437/ty-0.0.31-py3-none-win_amd64.whl", hash = "sha256:81134e25d2a2562ab372f24de8f9bd05034d27d30377a5d7540f259791c6234c", size = 11205258 },
+    { url = "https://files.pythonhosted.org/packages/88/39/bca669095ccf0a400af941fdf741578d4c2d6719f1b7f10e6dbec10aa862/ty-0.0.31-py3-none-win_arm64.whl", hash = "sha256:e9cb15fad26545c6a608f40f227af3a5513cb376998ca6feddd47ca7d93ffafa", size = 10590392 },
 ]
 
 [[package]]

--- a/sdk/rust/Cargo.toml
+++ b/sdk/rust/Cargo.toml
@@ -1,5 +1,5 @@
 [package]
-name = "gestalt"
+name = "gestalt-sdk"
 version = "0.0.1-alpha.1"
 edition = "2024"
 rust-version = "1.85"
@@ -9,6 +9,9 @@ readme = "README.md"
 repository = "https://github.com/valon-technologies/gestalt"
 keywords = ["gestalt", "grpc", "protobuf", "sdk"]
 categories = ["api-bindings", "development-tools"]
+
+[lib]
+name = "gestalt"
 
 [dependencies]
 libc = "0.2"

--- a/sdk/typescript/package.json
+++ b/sdk/typescript/package.json
@@ -3,6 +3,10 @@
   "version": "0.0.1-alpha.1",
   "description": "TypeScript SDK for Gestalt executable providers",
   "type": "module",
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/valon-technologies/gestalt.git"
+  },
   "exports": {
     ".": "./src/index.ts",
     "./build": "./src/build.ts",
@@ -11,8 +15,8 @@
     "./target": "./src/target.ts"
   },
   "bin": {
-    "gestalt-ts-build": "./src/build.ts",
-    "gestalt-ts-runtime": "./src/runtime.ts"
+    "gestalt-ts-build": "src/build.ts",
+    "gestalt-ts-runtime": "src/runtime.ts"
   },
   "files": [
     "src",
@@ -20,6 +24,9 @@
     "README.md",
     "tsconfig.json"
   ],
+  "publishConfig": {
+    "access": "public"
+  },
   "scripts": {
     "build:proto": "buf generate --template ../proto/buf.typescript.gen.yaml ../proto",
     "typecheck": "tsc --noEmit",


### PR DESCRIPTION
## What changed

This keeps the SDK publishing PR narrow and only changes the pieces needed to publish the open source SDKs publicly.

- publish the Python SDK to PyPI as `gestalt-sdk` while keeping `import gestalt`
- refresh `sdk/python/uv.lock` for the renamed Python package so CI stays frozen and reproducible
- publish the Rust SDK to crates.io as `gestalt-sdk` while keeping `use gestalt::...`
- add crates.io publishing to the Rust SDK release workflow
- switch Python publishing from repo secrets to PyPI Trusted Publishing
- switch TypeScript publishing from token-based `bun publish` to OIDC-based `npm publish`
- add the npm metadata required for trusted publishing and first public scoped publish

## Why it changed

The repo was already tag-driven for SDK releases, but the public registry path was incomplete:

- Python used the taken name `gestalt`
- Rust used the taken name `gestalt` and did not publish to crates.io
- TypeScript was still set up for token-based publishing instead of npm trusted publishing
- renaming the Python package without refreshing the lockfile broke frozen CI

## Follow-up configuration required

Before the workflows will succeed in GitHub Actions:

- configure PyPI Trusted Publishing for package `gestalt-sdk`, workflow `release-sdk.yml`, environment `pypi`
- configure npm Trusted Publishing for `@valon-technologies/gestalt`
- add `CARGO_REGISTRY_TOKEN` as a repository secret

## Validation

- parsed `sdk/python/pyproject.toml`
- parsed `sdk/rust/Cargo.toml`
- parsed `sdk/typescript/package.json`
- ran `cargo test` in `sdk/rust`
- ran `uv sync --frozen --group dev` in `sdk/python`
- ran Ruff, ty, vulture, and unit tests in `sdk/python`
