### PR TITLE
Handle legacy user stores without normalized_email

### DIFF
--- a/gestaltd/internal/coredata/schemas.go
+++ b/gestaltd/internal/coredata/schemas.go
@@ -24,6 +24,19 @@ var UsersSchema = indexeddb.ObjectStoreSchema{
 	},
 }
 
+var LegacyUsersSchema = indexeddb.ObjectStoreSchema{
+	Indexes: []indexeddb.IndexSchema{
+		{Name: "by_email", KeyPath: []string{"email"}, Unique: true},
+	},
+	Columns: []indexeddb.ColumnDef{
+		{Name: "id", Type: indexeddb.TypeString, PrimaryKey: true},
+		{Name: "email", Type: indexeddb.TypeString, NotNull: true, Unique: true},
+		{Name: "display_name", Type: indexeddb.TypeString},
+		{Name: "created_at", Type: indexeddb.TypeTime},
+		{Name: "updated_at", Type: indexeddb.TypeTime},
+	},
+}
+
 var IntegrationTokensSchema = indexeddb.ObjectStoreSchema{
 	Indexes: []indexeddb.IndexSchema{
 		{Name: "by_user", KeyPath: []string{"user_id"}},

--- a/gestaltd/internal/coredata/services.go
+++ b/gestaltd/internal/coredata/services.go
@@ -3,6 +3,8 @@ package coredata
 import (
 	"context"
 	"fmt"
+	"log/slog"
+	"strings"
 
 	corecrypto "github.com/valon-technologies/gestalt/server/core/crypto"
 	"github.com/valon-technologies/gestalt/server/core/indexeddb"
@@ -18,18 +20,15 @@ type Services struct {
 
 func New(ds indexeddb.IndexedDB, enc *corecrypto.AESGCMEncryptor) (*Services, error) {
 	ctx := context.Background()
-	if err := ds.CreateObjectStore(ctx, StoreUsers, UsersSchema); err != nil {
-		return nil, fmt.Errorf("create users store: %w", err)
+	users, err := initUserService(ctx, ds)
+	if err != nil {
+		return nil, err
 	}
 	if err := ds.CreateObjectStore(ctx, StoreIntegrationTokens, IntegrationTokensSchema); err != nil {
 		return nil, fmt.Errorf("create integration_tokens store: %w", err)
 	}
 	if err := ds.CreateObjectStore(ctx, StoreAPITokens, APITokensSchema); err != nil {
 		return nil, fmt.Errorf("create api_tokens store: %w", err)
-	}
-	users := NewUserService(ds)
-	if err := users.BackfillNormalizedEmails(ctx); err != nil {
-		return nil, fmt.Errorf("backfill users store: %w", err)
 	}
 	if err := ds.CreateObjectStore(ctx, StorePluginAuthorizationMemberships, PluginAuthorizationMembershipsSchema); err != nil {
 		return nil, fmt.Errorf("create plugin_authorization_memberships store: %w", err)
@@ -49,4 +48,27 @@ func (s *Services) Ping(ctx context.Context) error {
 
 func (s *Services) Close() error {
 	return s.DB.Close()
+}
+
+func initUserService(ctx context.Context, ds indexeddb.IndexedDB) (*UserService, error) {
+	if err := ds.CreateObjectStore(ctx, StoreUsers, UsersSchema); err == nil {
+		users := NewUserService(ds, true)
+		if err := users.BackfillNormalizedEmails(ctx); err != nil {
+			return nil, fmt.Errorf("backfill users store: %w", err)
+		}
+		return users, nil
+	} else if !isLegacyUsersSchemaError(err) {
+		return nil, fmt.Errorf("create users store: %w", err)
+	}
+
+	if err := ds.CreateObjectStore(ctx, StoreUsers, LegacyUsersSchema); err != nil {
+		return nil, fmt.Errorf("create users store: %w", err)
+	}
+	slog.Warn("coredata: users store missing normalized_email support; continuing in legacy compatibility mode")
+	return NewUserService(ds, false), nil
+}
+
+func isLegacyUsersSchemaError(err error) bool {
+	msg := strings.ToLower(err.Error())
+	return strings.Contains(msg, "normalized_email")
 }

--- a/gestaltd/internal/coredata/users.go
+++ b/gestaltd/internal/coredata/users.go
@@ -14,14 +14,21 @@ import (
 )
 
 type UserService struct {
-	store indexeddb.ObjectStore
+	store                indexeddb.ObjectStore
+	normalizedEmailIndex bool
 }
 
-func NewUserService(ds indexeddb.IndexedDB) *UserService {
-	return &UserService{store: ds.ObjectStore(StoreUsers)}
+func NewUserService(ds indexeddb.IndexedDB, normalizedEmailIndex bool) *UserService {
+	return &UserService{
+		store:                ds.ObjectStore(StoreUsers),
+		normalizedEmailIndex: normalizedEmailIndex,
+	}
 }
 
 func (s *UserService) BackfillNormalizedEmails(ctx context.Context) error {
+	if !s.normalizedEmailIndex {
+		return nil
+	}
 	recs, err := s.store.GetAll(ctx, nil)
 	if err != nil {
 		return fmt.Errorf("list users: %w", err)
@@ -68,12 +75,14 @@ func (s *UserService) FindOrCreateUser(ctx context.Context, email string) (*core
 
 	now := time.Now()
 	newRec := indexeddb.Record{
-		"id":               uuid.New().String(),
-		"email":            email,
-		"normalized_email": email,
-		"display_name":     "",
-		"created_at":       now,
-		"updated_at":       now,
+		"id":           uuid.New().String(),
+		"email":        email,
+		"display_name": "",
+		"created_at":   now,
+		"updated_at":   now,
+	}
+	if s.normalizedEmailIndex {
+		newRec["normalized_email"] = email
 	}
 	if err := s.store.Add(ctx, newRec); err != nil {
 		user, retryErr := s.findUserByNormalizedEmail(ctx, rawEmail, email)
@@ -95,6 +104,10 @@ func (s *UserService) FindUserByEmail(ctx context.Context, email string) (*core.
 }
 
 func (s *UserService) findUserByNormalizedEmail(ctx context.Context, rawEmail, normalizedEmail string) (*core.User, error) {
+	if !s.normalizedEmailIndex {
+		return s.findUserByNormalizedEmailLegacy(ctx, rawEmail, normalizedEmail)
+	}
+
 	recs, err := s.store.Index("by_normalized_email").GetAll(ctx, nil, normalizedEmail)
 	if err != nil {
 		return nil, fmt.Errorf("find user: %w", err)
@@ -142,6 +155,77 @@ func (s *UserService) findUserByNormalizedEmail(ctx context.Context, rawEmail, n
 		updated := cloneRecord(match)
 		updated["email"] = normalizedEmail
 		updated["normalized_email"] = normalizedEmail
+		updated["updated_at"] = time.Now()
+		if err := s.store.Put(ctx, updated); err == nil {
+			match = updated
+		}
+	}
+	return recordToUser(match), nil
+}
+
+func (s *UserService) findUserByNormalizedEmailLegacy(ctx context.Context, rawEmail, normalizedEmail string) (*core.User, error) {
+	rec, err := s.store.Index("by_email").Get(ctx, normalizedEmail)
+	if err == nil {
+		return recordToUser(rec), nil
+	}
+	if err != indexeddb.ErrNotFound {
+		return nil, fmt.Errorf("find user: %w", err)
+	}
+
+	if rawEmail != "" && rawEmail != normalizedEmail {
+		rec, err := s.store.Index("by_email").Get(ctx, rawEmail)
+		if err == nil {
+			return recordToUser(rec), nil
+		}
+		if err != indexeddb.ErrNotFound {
+			return nil, fmt.Errorf("find user: %w", err)
+		}
+	}
+
+	recs, err := s.store.GetAll(ctx, nil)
+	if err != nil {
+		return nil, fmt.Errorf("find user: %w", err)
+	}
+
+	var canonicalMatch indexeddb.Record
+	var rawMatch indexeddb.Record
+	var fallbackMatch indexeddb.Record
+	matchCount := 0
+	for _, rec := range recs {
+		email := strings.TrimSpace(recString(rec, "email"))
+		if emailutil.Normalize(email) != normalizedEmail {
+			continue
+		}
+		matchCount++
+		switch {
+		case email == normalizedEmail:
+			if preferUserRecord(rec, canonicalMatch) {
+				canonicalMatch = rec
+			}
+		case rawEmail != "" && email == rawEmail:
+			if preferUserRecord(rec, rawMatch) {
+				rawMatch = rec
+			}
+		case preferUserRecord(rec, fallbackMatch):
+			fallbackMatch = rec
+		}
+	}
+	if canonicalMatch == nil && rawMatch == nil && matchCount > 1 {
+		return nil, fmt.Errorf("find user: ambiguous case-insensitive duplicate users for %q", normalizedEmail)
+	}
+	match := canonicalMatch
+	if match == nil {
+		match = rawMatch
+	}
+	if match == nil {
+		match = fallbackMatch
+	}
+	if match == nil {
+		return nil, core.ErrNotFound
+	}
+	if matchCount == 1 && recString(match, "email") != normalizedEmail {
+		updated := cloneRecord(match)
+		updated["email"] = normalizedEmail
 		updated["updated_at"] = time.Now()
 		if err := s.store.Put(ctx, updated); err == nil {
 			match = updated


### PR DESCRIPTION
Go interface changes: none.
YAML changes: none.

This keeps the normalized-email path for fresh schemas, but falls back to a legacy users-store compatibility mode when an existing relationaldb users table does not have the new normalized_email column/index.

Example impact:
- Existing deployments with legacy users tables continue booting.
- New deployments still create and use by_normalized_email for fast lookups.