### PR TITLE
Hide unusable integrations in API listings

### DIFF
--- a/gestaltd/internal/server/handlers.go
+++ b/gestaltd/internal/server/handlers.go
@@ -175,6 +175,10 @@ func (s *Server) listIntegrations(w http.ResponseWriter, r *http.Request) {
 				}
 				info.Connected = bindingConnected
 			}
+			info.MountedPath = s.integrationMountedPathForPrincipal(p, name, info.MountedPath)
+			if !s.integrationHasUsableSurface(p, name, prov, info) {
+				continue
+			}
 			out = append(out, info)
 			continue
 		}
@@ -208,6 +212,10 @@ func (s *Server) listIntegrations(w http.ResponseWriter, r *http.Request) {
 			authTypes = []string{}
 		}
 		info.AuthTypes = authTypes
+		info.MountedPath = s.integrationMountedPathForPrincipal(p, name, info.MountedPath)
+		if !s.integrationHasUsableSurface(p, name, prov, info) {
+			continue
+		}
 		out = append(out, info)
 	}
 	writeJSON(w, http.StatusOK, out)

--- a/gestaltd/internal/server/integration_visibility.go
+++ b/gestaltd/internal/server/integration_visibility.go
@@ -1,0 +1,97 @@
+package server
+
+import (
+	"strings"
+
+	"github.com/valon-technologies/gestalt/server/core"
+	"github.com/valon-technologies/gestalt/server/internal/invocation"
+	"github.com/valon-technologies/gestalt/server/internal/principal"
+)
+
+func (s *Server) integrationHasUsableSurface(p *principal.Principal, provider string, prov core.Provider, info integrationInfo) bool {
+	if info.MountedPath != "" {
+		return true
+	}
+	if s.integrationHasSettingsSurface(p, info) {
+		return true
+	}
+	return s.integrationHasVisibleHTTPOperations(p, provider, prov)
+}
+
+func (s *Server) integrationHasSettingsSurface(p *principal.Principal, info integrationInfo) bool {
+	if p != nil && p.Kind == principal.KindWorkload {
+		return false
+	}
+	return info.Connected || len(info.AuthTypes) > 0 || len(info.Connections) > 0
+}
+
+func (s *Server) integrationHasVisibleHTTPOperations(p *principal.Principal, provider string, prov core.Provider) bool {
+	cat := prov.Catalog()
+	if cat == nil {
+		return false
+	}
+	cat = invocation.FilterCatalogForPrincipal(cat, provider, p, s.authorizer)
+	return len(httpVisibleCatalogOperations(cat.Operations)) > 0
+}
+
+func (s *Server) integrationMountedPathForPrincipal(p *principal.Principal, provider, mountedPath string) string {
+	mountedPath = strings.TrimSpace(mountedPath)
+	if mountedPath == "" {
+		return ""
+	}
+	mounted, ok := s.mountedWebUIForProvider(provider, mountedPath)
+	if !ok || !s.mountedWebUIRootAccessible(p, mounted) {
+		return ""
+	}
+	return mountedPath
+}
+
+func (s *Server) mountedWebUIForProvider(provider, mountedPath string) (MountedWebUI, bool) {
+	for _, mounted := range s.mountedWebUIs {
+		if mounted.Handler == nil || mounted.Path != mountedPath {
+			continue
+		}
+		if mounted.PluginName == provider {
+			return mounted, true
+		}
+	}
+	for _, mounted := range s.mountedWebUIs {
+		if mounted.Handler == nil || mounted.Path != mountedPath {
+			continue
+		}
+		return mounted, true
+	}
+	return MountedWebUI{}, false
+}
+
+func (s *Server) mountedWebUIRootAccessible(p *principal.Principal, mounted MountedWebUI) bool {
+	if mounted.AuthorizationPolicy == "" {
+		return true
+	}
+	if s.authorizer == nil || p == nil || p.Kind == principal.KindWorkload {
+		return false
+	}
+
+	var (
+		access  invocation.AccessContext
+		allowed bool
+	)
+	if mounted.PluginName != "" {
+		access, allowed = s.authorizer.ResolveAccess(p, mounted.PluginName)
+	} else {
+		access, allowed = s.authorizer.ResolvePolicyAccess(p, mounted.AuthorizationPolicy)
+	}
+	if !allowed {
+		return false
+	}
+
+	route, matched := mounted.routeForRequestPath(mountedWebUIRootRequestPath(mounted))
+	return matched && len(route.AllowedRoles) > 0 && mountedWebUIRoleAllowed(access.Role, route.AllowedRoles)
+}
+
+func mountedWebUIRootRequestPath(mounted MountedWebUI) string {
+	if mounted.Path == "/" {
+		return "/"
+	}
+	return mounted.Path + "/"
+}

--- a/gestaltd/internal/server/server_test.go
+++ b/gestaltd/internal/server/server_test.go
@@ -15,6 +15,7 @@ import (
 	"os"
 	"path/filepath"
 	"reflect"
+	"slices"
 	"strings"
 	"sync/atomic"
 	"testing"
@@ -3060,6 +3061,9 @@ func TestListIntegrations_IncludesMountedPath(t *testing.T) {
 	t.Parallel()
 
 	stub := &coretesting.StubIntegration{N: "github", DN: "GitHub"}
+	handler := http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.WriteHeader(http.StatusOK)
+	})
 	ts := newTestServer(t, func(cfg *server.Config) {
 		cfg.Providers = testutil.NewProviderRegistry(t, stub)
 		cfg.PluginDefs = map[string]*config.ProviderEntry{
@@ -3067,6 +3071,12 @@ func TestListIntegrations_IncludesMountedPath(t *testing.T) {
 				MountPath: "/github",
 			},
 		}
+		cfg.MountedWebUIs = []server.MountedWebUI{{
+			Name:       "github",
+			PluginName: "github",
+			Path:       "/github",
+			Handler:    handler,
+		}}
 		cfg.Services = coretesting.NewStubServices(t)
 	})
 	testutil.CloseOnCleanup(t, ts)
@@ -3100,6 +3110,170 @@ func TestListIntegrations_IncludesMountedPath(t *testing.T) {
 	}
 }
 
+func TestListIntegrations_HumanAuthorizationFiltersByMountedUIAccessAndVisibleOperations(t *testing.T) {
+	t.Parallel()
+
+	svc := coretesting.NewStubServices(t)
+	viewer := seedUser(t, svc, "viewer@example.test")
+	policyMembers := []config.HumanPolicyMemberDef{
+		{SubjectID: principal.UserSubjectID(viewer.ID), Role: "viewer"},
+	}
+
+	opsVisibleProvider := &stubNonOAuthProvider{
+		name: "ops-visible",
+		catalog: serverTestCatalog("ops-visible", []catalog.CatalogOperation{{
+			ID:           "list",
+			Method:       http.MethodGet,
+			Path:         "/list",
+			Transport:    catalog.TransportREST,
+			AllowedRoles: []string{"viewer"},
+		}}),
+	}
+	settingsVisibleProvider := &stubIntegrationWithCatalog{
+		StubIntegration: coretesting.StubIntegration{N: "settings-visible", DN: "Settings Visible"},
+		catalog: serverTestCatalog("settings-visible", []catalog.CatalogOperation{{
+			ID:           "sync",
+			Method:       http.MethodPost,
+			Transport:    catalog.TransportMCPPassthrough,
+			AllowedRoles: []string{"viewer"},
+		}}),
+	}
+	uiVisibleProvider := &stubNonOAuthProvider{
+		name: "ui-visible",
+		catalog: serverTestCatalog("ui-visible", []catalog.CatalogOperation{{
+			ID:           "sync",
+			Method:       http.MethodPost,
+			Transport:    catalog.TransportMCPPassthrough,
+			AllowedRoles: []string{"viewer"},
+		}}),
+	}
+	hiddenProvider := &stubNonOAuthProvider{
+		name: "hidden",
+		catalog: serverTestCatalog("hidden", []catalog.CatalogOperation{{
+			ID:           "sync",
+			Method:       http.MethodPost,
+			Transport:    catalog.TransportMCPPassthrough,
+			AllowedRoles: []string{"viewer"},
+		}}),
+	}
+	providers := testutil.NewProviderRegistry(t, opsVisibleProvider, settingsVisibleProvider, uiVisibleProvider, hiddenProvider)
+	pluginDefs := map[string]*config.ProviderEntry{
+		"ops-visible":      {MountPath: "/ops-visible", AuthorizationPolicy: "sample_policy"},
+		"settings-visible": {MountPath: "/settings-visible", AuthorizationPolicy: "sample_policy"},
+		"ui-visible":       {MountPath: "/ui-visible", AuthorizationPolicy: "sample_policy"},
+		"hidden":           {MountPath: "/hidden", AuthorizationPolicy: "sample_policy"},
+	}
+	authz := mustAuthorizer(t, config.AuthorizationConfig{
+		Policies: map[string]config.HumanPolicyDef{
+			"sample_policy": {
+				Default: "deny",
+				Members: policyMembers,
+			},
+		},
+	}, providers, pluginDefs, nil)
+
+	handler := http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.WriteHeader(http.StatusOK)
+	})
+	ts := newTestServer(t, func(cfg *server.Config) {
+		cfg.Auth = &coretesting.StubAuthProvider{
+			N: "test",
+			ValidateTokenFn: func(_ context.Context, token string) (*core.UserIdentity, error) {
+				if token != "viewer-session" {
+					return nil, fmt.Errorf("invalid token")
+				}
+				return &core.UserIdentity{Email: "viewer@example.test"}, nil
+			},
+		}
+		cfg.Providers = providers
+		cfg.PluginDefs = pluginDefs
+		cfg.Services = svc
+		cfg.Authorizer = authz
+		cfg.MountedWebUIs = []server.MountedWebUI{
+			{
+				Name:                "ops-visible",
+				PluginName:          "ops-visible",
+				Path:                "/ops-visible",
+				AuthorizationPolicy: "sample_policy",
+				Routes: []server.MountedWebUIRoute{
+					{Path: "/*", AllowedRoles: []string{"admin"}},
+				},
+				Handler: handler,
+			},
+			{
+				Name:                "settings-visible",
+				PluginName:          "settings-visible",
+				Path:                "/settings-visible",
+				AuthorizationPolicy: "sample_policy",
+				Routes: []server.MountedWebUIRoute{
+					{Path: "/*", AllowedRoles: []string{"admin"}},
+				},
+				Handler: handler,
+			},
+			{
+				Name:                "ui-visible",
+				PluginName:          "ui-visible",
+				Path:                "/ui-visible",
+				AuthorizationPolicy: "sample_policy",
+				Routes: []server.MountedWebUIRoute{
+					{Path: "/*", AllowedRoles: []string{"viewer"}},
+				},
+				Handler: handler,
+			},
+			{
+				Name:                "hidden",
+				PluginName:          "hidden",
+				Path:                "/hidden",
+				AuthorizationPolicy: "sample_policy",
+				Routes: []server.MountedWebUIRoute{
+					{Path: "/*", AllowedRoles: []string{"admin"}},
+				},
+				Handler: handler,
+			},
+		}
+	})
+	testutil.CloseOnCleanup(t, ts)
+
+	req, _ := http.NewRequest(http.MethodGet, ts.URL+"/api/v1/integrations", nil)
+	req.Header.Set("Authorization", "Bearer viewer-session")
+	resp, err := http.DefaultClient.Do(req)
+	if err != nil {
+		t.Fatalf("request: %v", err)
+	}
+	defer func() { _ = resp.Body.Close() }()
+
+	if resp.StatusCode != http.StatusOK {
+		body, _ := io.ReadAll(resp.Body)
+		t.Fatalf("expected 200, got %d: %s", resp.StatusCode, body)
+	}
+
+	var integrations []struct {
+		Name        string `json:"name"`
+		MountedPath string `json:"mountedPath"`
+	}
+	if err := json.NewDecoder(resp.Body).Decode(&integrations); err != nil {
+		t.Fatalf("decoding: %v", err)
+	}
+
+	got := make(map[string]string, len(integrations))
+	for _, integration := range integrations {
+		got[integration.Name] = integration.MountedPath
+	}
+
+	if !reflect.DeepEqual(sortedKeys(got), []string{"ops-visible", "settings-visible", "ui-visible"}) {
+		t.Fatalf("integration names = %v, want %v", sortedKeys(got), []string{"ops-visible", "settings-visible", "ui-visible"})
+	}
+	if got["ops-visible"] != "" {
+		t.Fatalf("ops-visible mounted path = %q, want empty", got["ops-visible"])
+	}
+	if got["settings-visible"] != "" {
+		t.Fatalf("settings-visible mounted path = %q, want empty", got["settings-visible"])
+	}
+	if got["ui-visible"] != "/ui-visible" {
+		t.Fatalf("ui-visible mounted path = %q, want /ui-visible", got["ui-visible"])
+	}
+}
+
 func TestWorkloadAuthorization_ListIntegrationsFiltersAndHidesConnectionAffordances(t *testing.T) {
 	t.Parallel()
 
@@ -3119,18 +3293,27 @@ func TestWorkloadAuthorization_ListIntegrationsFiltersAndHidesConnectionAffordan
 		StubIntegration: coretesting.StubIntegration{N: "weather", DN: "Weather", ConnMode: core.ConnectionModeNone},
 		ops:             []core.Operation{{Name: "forecast", Method: http.MethodGet}},
 	}
+	mcpOnlyProvider := &stubIntegrationWithCatalog{
+		StubIntegration: coretesting.StubIntegration{N: "mcp-only", DN: "MCP Only", ConnMode: core.ConnectionModeNone},
+		catalog: serverTestCatalog("mcp-only", []catalog.CatalogOperation{{
+			ID:        "inspect",
+			Method:    http.MethodPost,
+			Transport: catalog.TransportMCPPassthrough,
+		}}),
+	}
 	secretProvider := &stubIntegrationWithOps{
 		StubIntegration: coretesting.StubIntegration{N: "secret", DN: "Secret", ConnMode: core.ConnectionModeNone},
 		ops:             []core.Operation{{Name: "peek", Method: http.MethodGet}},
 	}
-	providers := testutil.NewProviderRegistry(t, svcProvider, weatherProvider, secretProvider)
+	providers := testutil.NewProviderRegistry(t, svcProvider, weatherProvider, mcpOnlyProvider, secretProvider)
 	authz := mustAuthorizer(t, config.AuthorizationConfig{
 		Workloads: map[string]config.WorkloadDef{
 			"triage-bot": {
 				Token: workloadToken,
 				Providers: map[string]config.WorkloadProviderDef{
-					"svc":     {Allow: []string{"run"}},
-					"weather": {Allow: []string{"forecast"}},
+					"svc":      {Allow: []string{"run"}},
+					"weather":  {Allow: []string{"forecast"}},
+					"mcp-only": {Allow: []string{"inspect"}},
 				},
 			},
 		},
@@ -3201,6 +3384,9 @@ func TestWorkloadAuthorization_ListIntegrationsFiltersAndHidesConnectionAffordan
 	}
 	if _, ok := got["secret"]; ok {
 		t.Fatalf("unauthorized integration was visible: %+v", integrations)
+	}
+	if _, ok := got["mcp-only"]; ok {
+		t.Fatalf("mcp-only integration should not be visible over HTTP: %+v", integrations)
 	}
 	if !got["svc"].Connected {
 		t.Fatalf("expected bound identity integration to be connected, got %+v", got["svc"])
@@ -3453,7 +3639,10 @@ func TestListIntegrations_AuthTypes(t *testing.T) {
 	manualStub := &stubManualProvider{
 		StubIntegration: coretesting.StubIntegration{N: "manual-svc", DN: "Manual Service"},
 	}
-	mcpStub := &stubNonOAuthProvider{name: "clickhouse"}
+	mcpStub := &stubNonOAuthProvider{
+		name: "clickhouse",
+		ops:  []core.Operation{{Name: "query", Method: http.MethodGet}},
+	}
 	ts := newTestServer(t, func(cfg *server.Config) {
 		cfg.Providers = testutil.NewProviderRegistry(t, oauthStub, manualStub, mcpStub)
 		cfg.Services = coretesting.NewStubServices(t)
@@ -3967,6 +4156,7 @@ func TestListIntegrations_ConnectionInfosUseResolvedConnectionDefs(t *testing.T)
 				Ref:     "github.com/acme/plugins/clickhouse",
 				Version: "1.0.0",
 			},
+			MountPath: "/clickhouse",
 			ResolvedManifest: &providermanifestv1.Manifest{
 				Spec: &providermanifestv1.Spec{
 					Surfaces: &providermanifestv1.ProviderSurfaces{
@@ -3984,6 +4174,14 @@ func TestListIntegrations_ConnectionInfosUseResolvedConnectionDefs(t *testing.T)
 				"clickhouse": plugin,
 			}
 			cfg.Services = coretesting.NewStubServices(t)
+			cfg.MountedWebUIs = []server.MountedWebUI{{
+				Name:       "clickhouse",
+				PluginName: "clickhouse",
+				Path:       "/clickhouse",
+				Handler: http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+					w.WriteHeader(http.StatusOK)
+				}),
+			}}
 		})
 		testutil.CloseOnCleanup(t, ts)
 
@@ -8921,9 +9119,10 @@ func (s *stubOAuthIntegration) RefreshToken(ctx context.Context, token string) (
 
 // stubNonOAuthProvider implements core.Provider but NOT core.OAuthProvider.
 type stubNonOAuthProvider struct {
-	name   string
-	ops    []core.Operation
-	execFn func(context.Context, string, map[string]any, string) (*core.OperationResult, error)
+	name    string
+	ops     []core.Operation
+	catalog *catalog.Catalog
+	execFn  func(context.Context, string, map[string]any, string) (*core.OperationResult, error)
 }
 
 func (s *stubNonOAuthProvider) Name() string                        { return s.name }
@@ -8931,6 +9130,9 @@ func (s *stubNonOAuthProvider) DisplayName() string                 { return s.n
 func (s *stubNonOAuthProvider) Description() string                 { return "" }
 func (s *stubNonOAuthProvider) ConnectionMode() core.ConnectionMode { return core.ConnectionModeUser }
 func (s *stubNonOAuthProvider) Catalog() *catalog.Catalog {
+	if s.catalog != nil {
+		return s.catalog
+	}
 	return serverTestCatalogFromOperations(s.name, s.ops)
 }
 func (s *stubNonOAuthProvider) Execute(ctx context.Context, op string, params map[string]any, token string) (*core.OperationResult, error) {
@@ -8967,6 +9169,24 @@ func serverTestCatalogFromOperations(name string, ops []core.Operation) *catalog
 	}
 	coreintegration.CompileSchemas(cat)
 	return cat
+}
+
+func serverTestCatalog(name string, ops []catalog.CatalogOperation) *catalog.Catalog {
+	cat := &catalog.Catalog{
+		Name:       name,
+		Operations: append([]catalog.CatalogOperation(nil), ops...),
+	}
+	coreintegration.CompileSchemas(cat)
+	return cat
+}
+
+func sortedKeys[V any](m map[string]V) []string {
+	keys := make([]string, 0, len(m))
+	for key := range m {
+		keys = append(keys, key)
+	}
+	slices.Sort(keys)
+	return keys
 }
 
 func TestExecuteOperation_RefreshesExpiredToken(t *testing.T) {


### PR DESCRIPTION
## Summary
Move integration visibility into `gestaltd` core so `/api/v1/integrations` only returns plugins with at least one usable surface for the current principal.

This replaces the client-side workaround in `web/default` with the server as the source of truth.

## Go Interface
New server helpers:
```go
func (s *Server) integrationHasUsableSurface(p *principal.Principal, provider string, prov core.Provider, info integrationInfo) bool
func (s *Server) integrationMountedPathForPrincipal(p *principal.Principal, provider, mountedPath string) string
```

Updated behavior:
```go
// GET /api/v1/integrations
// - omits integrations with no usable surface for the caller
// - omits mountedPath when the mounted UI root is not reachable for the caller
```

Example outcome for a human caller:
```json
[
  {
    "name": "ui-visible",
    "mountedPath": "/ui-visible"
  },
  {
    "name": "ops-visible"
  }
]
```

## YAML Interface
No config schema changes.

Existing plugin config continues to drive the decision:
```yaml
plugins:
  examplePlugin:
    mountPath: /example
    authorizationPolicy: example_policy
```

Example effect:
- if the caller can load `/example/`, `mountedPath` stays present
- if the caller cannot load `/example/` but still has visible HTTP operations or settings/connect affordances, the integration remains without `mountedPath`
- if the caller has none of those surfaces, the integration is omitted

## Tests
- adds list-integrations coverage for mounted UI access vs visible operations
- updates workload list-integrations coverage so MCP-only providers are not returned over HTTP
