### PR TITLE
Fix SDK release blockers

### DIFF
--- a/.github/workflows/release-sdk.yml
+++ b/.github/workflows/release-sdk.yml
@@ -155,7 +155,7 @@ jobs:
           VERSION: ${{ github.ref_name }}
 
       - name: Verify published crate contents
-        run: cargo publish --dry-run
+        run: cargo publish --dry-run --allow-dirty
 
       - name: Publish crate
         env:
@@ -166,7 +166,7 @@ jobs:
             exit 1
           fi
 
-          cargo publish
+          cargo publish --allow-dirty
 
   release-rust-sdk:
     if: ${{ startsWith(github.ref_name, 'sdk/rust/v') }}

--- a/gestaltd/internal/providerhost/s3_server.go
+++ b/gestaltd/internal/providerhost/s3_server.go
@@ -117,6 +117,10 @@ func (s *s3Server) WriteObject(stream proto.S3_WriteObjectServer) error {
 	meta, err := s.client.WriteObject(stream.Context(), s.namespacedWriteRequest(open, pr))
 	if err != nil {
 		_ = pr.CloseWithError(err)
+		select {
+		case <-done:
+		case <-stream.Context().Done():
+		}
 		return s3ToGRPCErr(err)
 	}
 	meta, err = s.requireOwnedMetaNamespace(meta)

--- a/gestaltd/internal/providerhost/s3_server_test.go
+++ b/gestaltd/internal/providerhost/s3_server_test.go
@@ -224,6 +224,41 @@ func TestS3ServerWriteObjectReturnsWhenProviderStopsReadingEarly(t *testing.T) {
 	}
 }
 
+func TestS3ServerWriteObjectPropagatesProviderErrorAfterStoppingReadEarly(t *testing.T) {
+	t.Parallel()
+
+	srv := NewS3Server(funcS3Client{
+		writeObject: func(_ context.Context, req s3store.WriteRequest) (s3store.ObjectMeta, error) {
+			return s3store.ObjectMeta{}, s3store.ErrPreconditionFailed
+		},
+	}, "roadmap")
+	stream := newStubS3WriteObjectServer(context.Background(), []*proto.WriteObjectRequest{
+		{
+			Msg: &proto.WriteObjectRequest_Open{
+				Open: &proto.WriteObjectOpen{
+					Ref: &proto.S3ObjectRef{Bucket: "docs", Key: "plans/q4.txt"},
+					IfNoneMatch: "*",
+				},
+			},
+		},
+		{Msg: &proto.WriteObjectRequest_Data{Data: []byte("payload")}},
+	})
+
+	done := make(chan error, 1)
+	go func() {
+		done <- srv.WriteObject(stream)
+	}()
+
+	select {
+	case err := <-done:
+		if status.Code(err) != codes.FailedPrecondition {
+			t.Fatalf("WriteObject error = %v, want codes.FailedPrecondition", err)
+		}
+	case <-time.After(2 * time.Second):
+		t.Fatal("WriteObject hung when provider returned an early precondition error")
+	}
+}
+
 func TestS3ServerWriteObjectPropagatesRecvErrorObservedDuringSendAndClose(t *testing.T) {
 	t.Parallel()
 


### PR DESCRIPTION
## Summary
- allow the Rust release workflow to publish after rewriting `Cargo.toml` from the release tag
- make the provider-host S3 write handler wait for its read loop to stop before returning backend write errors
- add a regression test covering early precondition failures during S3 writes

## Validation
- `env GOWORK=off go test . -run 'TestS3ServerWriteObject' -count=1` in `gestaltd/internal/providerhost`
- `env GOWORK=off go test . -run TestS3Transport_ErrorMapping -count=50` in `sdk/go`
- `env GOWORK=off go test ./...` in `sdk/go`
