### PR TITLE
gofmt s3 server test

### DIFF
--- a/gestaltd/internal/providerhost/s3_server_test.go
+++ b/gestaltd/internal/providerhost/s3_server_test.go
@@ -236,7 +236,7 @@ func TestS3ServerWriteObjectPropagatesProviderErrorAfterStoppingReadEarly(t *tes
 		{
 			Msg: &proto.WriteObjectRequest_Open{
 				Open: &proto.WriteObjectOpen{
-					Ref: &proto.S3ObjectRef{Bucket: "docs", Key: "plans/q4.txt"},
+					Ref:         &proto.S3ObjectRef{Bucket: "docs", Key: "plans/q4.txt"},
 					IfNoneMatch: "*",
 				},
 			},


### PR DESCRIPTION
## Summary
- apply the missing `gofmt` alignment fix in `gestaltd/internal/providerhost/s3_server_test.go`
- unblock the failing `Go Lint & Vet` job from https://github.com/valon-technologies/gestalt/actions/runs/24473317177/job/71519001829?pr=1016

## Context
This failure is separate from the docs changes in #1016. The PR job was failing on a pre-existing formatting regression in the merge-base code path:

```text
gestaltd/internal/providerhost/s3_server_test.go:239:1: File is not properly formatted (gofmt)
```

## Testing
- `cd gestaltd && go mod tidy && git diff --exit-code go.mod go.sum`
- `cd gestaltd && golangci-lint run --path-prefix=gestaltd`
