### PR TITLE
gestaltd: add dynamic built-in admin memberships

### DIFF
--- a/gestaltd/internal/authorization/authorizer.go
+++ b/gestaltd/internal/authorization/authorizer.go
@@ -2,6 +2,7 @@ package authorization
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"log/slog"
 	"regexp"
@@ -78,6 +79,8 @@ type dynamicGrant struct {
 type dynamicSnapshot struct {
 	byPluginUserID map[string]map[string]dynamicGrant
 	byPluginEmail  map[string]map[string]dynamicGrant
+	adminByUserID  map[string]dynamicGrant
+	adminByEmail   map[string]dynamicGrant
 }
 
 type Authorizer struct {
@@ -86,6 +89,7 @@ type Authorizer struct {
 	policies             map[string]*HumanPolicy
 	providerPolicies     map[string]string
 	dynamicService       *coredata.PluginAuthorizationService
+	adminDynamicService  *coredata.AdminAuthorizationService
 	dynamicReloadEvery   time.Duration
 	dynamic              atomic.Pointer[dynamicSnapshot]
 	lifecycleMu          sync.Mutex
@@ -190,8 +194,15 @@ func New(cfg config.AuthorizationConfig, pluginDefs map[string]*config.ProviderE
 	return a, nil
 }
 
+func (a *Authorizer) SetAdminAuthorizationService(svc *coredata.AdminAuthorizationService) {
+	if a == nil {
+		return
+	}
+	a.adminDynamicService = svc
+}
+
 func (a *Authorizer) Start(ctx context.Context) error {
-	if a == nil || a.dynamicService == nil {
+	if a == nil || !a.hasDynamicSources() {
 		return nil
 	}
 
@@ -242,50 +253,42 @@ func (a *Authorizer) Close() error {
 	return nil
 }
 
-func (a *Authorizer) HasDynamicAuthorizations() bool {
+func (a *Authorizer) HasDynamicPluginAuthorizations() bool {
 	return a != nil && a.dynamicService != nil
 }
 
+func (a *Authorizer) HasDynamicAdminAuthorizations() bool {
+	return a != nil && a.adminDynamicService != nil
+}
+
 func (a *Authorizer) ReloadDynamic(ctx context.Context) error {
-	if a == nil || a.dynamicService == nil {
+	if a == nil || !a.hasDynamicSources() {
 		return nil
 	}
 
-	grants, err := a.dynamicService.ListPluginAuthorizations(ctx)
-	if err != nil {
-		return fmt.Errorf("reload dynamic authorizations: %w", err)
-	}
+	previous := a.dynamic.Load()
 	snapshot := emptyDynamicSnapshot()
-	for _, grant := range grants {
-		if grant == nil {
-			continue
+	var reloadErr error
+	if a.dynamicService != nil {
+		grants, err := a.dynamicService.ListPluginAuthorizations(ctx)
+		if err != nil {
+			copyPluginDynamicSnapshot(snapshot, previous)
+			reloadErr = errors.Join(reloadErr, fmt.Errorf("reload dynamic authorizations: %w", err))
+		} else {
+			loadPluginDynamicSnapshot(snapshot, grants)
 		}
-		plugin := strings.TrimSpace(grant.Plugin)
-		userID := strings.TrimSpace(grant.UserID)
-		email := normalizeEmail(grant.Email)
-		role := strings.TrimSpace(grant.Role)
-		if plugin == "" || role == "" {
-			continue
-		}
-		if userID != "" {
-			byUserID := snapshot.byPluginUserID[plugin]
-			if byUserID == nil {
-				byUserID = map[string]dynamicGrant{}
-				snapshot.byPluginUserID[plugin] = byUserID
-			}
-			byUserID[userID] = dynamicGrant{UserID: userID, Email: email, Role: role}
-		}
-		if email != "" {
-			byEmail := snapshot.byPluginEmail[plugin]
-			if byEmail == nil {
-				byEmail = map[string]dynamicGrant{}
-				snapshot.byPluginEmail[plugin] = byEmail
-			}
-			byEmail[email] = dynamicGrant{UserID: userID, Email: email, Role: role}
+	}
+	if a.adminDynamicService != nil {
+		grants, err := a.adminDynamicService.ListAdminAuthorizations(ctx)
+		if err != nil {
+			copyAdminDynamicSnapshot(snapshot, previous)
+			reloadErr = errors.Join(reloadErr, fmt.Errorf("reload admin authorizations: %w", err))
+		} else {
+			loadAdminDynamicSnapshot(snapshot, grants)
 		}
 	}
 	a.dynamic.Store(snapshot)
-	return nil
+	return reloadErr
 }
 
 func (a *Authorizer) pollLoop(ctx context.Context, done chan struct{}) {
@@ -392,11 +395,11 @@ func (a *Authorizer) PolicyNameForProvider(provider string) string {
 	return strings.TrimSpace(a.providerPolicies[provider])
 }
 
-func (a *Authorizer) StaticRoleForProviderIdentity(provider, subjectID, userID, email string) (AccessContext, bool) {
+func (a *Authorizer) StaticRoleForPolicyIdentity(policyName, subjectID, userID, email string) (AccessContext, bool) {
 	if a == nil {
 		return AccessContext{}, false
 	}
-	policyName := a.PolicyNameForProvider(provider)
+	policyName = strings.TrimSpace(policyName)
 	if policyName == "" {
 		return AccessContext{}, false
 	}
@@ -412,17 +415,25 @@ func (a *Authorizer) StaticRoleForProviderIdentity(provider, subjectID, userID, 
 	return access, false
 }
 
-func (a *Authorizer) StaticMembersForProvider(provider string) (string, []StaticHumanMember, bool) {
+func (a *Authorizer) StaticRoleForProviderIdentity(provider, subjectID, userID, email string) (AccessContext, bool) {
 	if a == nil {
-		return "", nil, false
+		return AccessContext{}, false
 	}
 	policyName := a.PolicyNameForProvider(provider)
+	return a.StaticRoleForPolicyIdentity(policyName, subjectID, userID, email)
+}
+
+func (a *Authorizer) StaticMembersForPolicy(policyName string) ([]StaticHumanMember, bool) {
+	if a == nil {
+		return nil, false
+	}
+	policyName = strings.TrimSpace(policyName)
 	if policyName == "" {
-		return "", nil, false
+		return nil, false
 	}
 	policy := a.policies[policyName]
 	if policy == nil {
-		return policyName, nil, false
+		return nil, false
 	}
 	members := make([]StaticHumanMember, 0, len(policy.RolesBySubjectID)+len(policy.RolesByEmail))
 	for subjectID, role := range policy.RolesBySubjectID {
@@ -436,6 +447,21 @@ func (a *Authorizer) StaticMembersForProvider(provider string) (string, []Static
 			Email: email,
 			Role:  role,
 		})
+	}
+	return members, true
+}
+
+func (a *Authorizer) StaticMembersForProvider(provider string) (string, []StaticHumanMember, bool) {
+	if a == nil {
+		return "", nil, false
+	}
+	policyName := a.PolicyNameForProvider(provider)
+	if policyName == "" {
+		return "", nil, false
+	}
+	members, ok := a.StaticMembersForPolicy(policyName)
+	if !ok {
+		return policyName, nil, false
 	}
 	return policyName, members, true
 }
@@ -456,6 +482,37 @@ func (a *Authorizer) ResolvePolicyAccess(p *principal.Principal, policyName stri
 	}
 	access := AccessContext{Policy: policyName}
 	if role, ok := policy.roleForPrincipal(p); ok {
+		access.Role = role
+		return access, true
+	}
+	if policy.DefaultAllow {
+		access.Role = defaultHumanRole
+		return access, true
+	}
+	return access, false
+}
+
+func (a *Authorizer) ResolveAdminAccess(p *principal.Principal, policyName string) (AccessContext, bool) {
+	if a == nil {
+		return AccessContext{}, true
+	}
+	policyName = strings.TrimSpace(policyName)
+	if policyName == "" {
+		return AccessContext{}, true
+	}
+	if a.IsWorkload(p) {
+		return AccessContext{Policy: policyName}, false
+	}
+	policy := a.policies[policyName]
+	if policy == nil {
+		return AccessContext{}, false
+	}
+	access := AccessContext{Policy: policyName}
+	if role, ok := policy.roleForPrincipal(p); ok {
+		access.Role = role
+		return access, true
+	}
+	if role, ok := a.dynamicAdminRoleForPrincipal(p); ok {
 		access.Role = role
 		return access, true
 	}
@@ -626,10 +683,130 @@ func (a *Authorizer) dynamicRoleForPrincipal(provider string, p *principal.Princ
 	return "", false
 }
 
+func (a *Authorizer) dynamicAdminRoleForPrincipal(p *principal.Principal) (string, bool) {
+	if a == nil || p == nil {
+		return "", false
+	}
+	snapshot := a.dynamic.Load()
+	if snapshot == nil {
+		return "", false
+	}
+	if p.UserID != "" {
+		if grant, ok := snapshot.adminByUserID[p.UserID]; ok {
+			return grant.Role, true
+		}
+	}
+	email := ""
+	if p.Identity != nil {
+		email = p.Identity.Email
+	}
+	if email = normalizeEmail(email); email != "" {
+		if grant, ok := snapshot.adminByEmail[email]; ok {
+			return grant.Role, true
+		}
+	}
+	return "", false
+}
+
+func (a *Authorizer) hasDynamicSources() bool {
+	return a != nil && (a.dynamicService != nil || a.adminDynamicService != nil)
+}
+
+func loadPluginDynamicSnapshot(snapshot *dynamicSnapshot, grants []*coredata.PluginAuthorizationMembership) {
+	if snapshot == nil {
+		return
+	}
+	for _, grant := range grants {
+		if grant == nil {
+			continue
+		}
+		plugin := strings.TrimSpace(grant.Plugin)
+		userID := strings.TrimSpace(grant.UserID)
+		email := normalizeEmail(grant.Email)
+		role := strings.TrimSpace(grant.Role)
+		if plugin == "" || role == "" {
+			continue
+		}
+		if userID != "" {
+			byUserID := snapshot.byPluginUserID[plugin]
+			if byUserID == nil {
+				byUserID = map[string]dynamicGrant{}
+				snapshot.byPluginUserID[plugin] = byUserID
+			}
+			byUserID[userID] = dynamicGrant{UserID: userID, Email: email, Role: role}
+		}
+		if email != "" {
+			byEmail := snapshot.byPluginEmail[plugin]
+			if byEmail == nil {
+				byEmail = map[string]dynamicGrant{}
+				snapshot.byPluginEmail[plugin] = byEmail
+			}
+			byEmail[email] = dynamicGrant{UserID: userID, Email: email, Role: role}
+		}
+	}
+}
+
+func loadAdminDynamicSnapshot(snapshot *dynamicSnapshot, grants []*coredata.AdminAuthorizationMembership) {
+	if snapshot == nil {
+		return
+	}
+	for _, grant := range grants {
+		if grant == nil {
+			continue
+		}
+		userID := strings.TrimSpace(grant.UserID)
+		email := normalizeEmail(grant.Email)
+		role := strings.TrimSpace(grant.Role)
+		if role == "" {
+			continue
+		}
+		if userID != "" {
+			snapshot.adminByUserID[userID] = dynamicGrant{UserID: userID, Email: email, Role: role}
+		}
+		if email != "" {
+			snapshot.adminByEmail[email] = dynamicGrant{UserID: userID, Email: email, Role: role}
+		}
+	}
+}
+
+func copyPluginDynamicSnapshot(dst, src *dynamicSnapshot) {
+	if dst == nil || src == nil {
+		return
+	}
+	for plugin, byUserID := range src.byPluginUserID {
+		cloned := make(map[string]dynamicGrant, len(byUserID))
+		for userID, grant := range byUserID {
+			cloned[userID] = grant
+		}
+		dst.byPluginUserID[plugin] = cloned
+	}
+	for plugin, byEmail := range src.byPluginEmail {
+		cloned := make(map[string]dynamicGrant, len(byEmail))
+		for email, grant := range byEmail {
+			cloned[email] = grant
+		}
+		dst.byPluginEmail[plugin] = cloned
+	}
+}
+
+func copyAdminDynamicSnapshot(dst, src *dynamicSnapshot) {
+	if dst == nil || src == nil {
+		return
+	}
+	for userID, grant := range src.adminByUserID {
+		dst.adminByUserID[userID] = grant
+	}
+	for email, grant := range src.adminByEmail {
+		dst.adminByEmail[email] = grant
+	}
+}
+
 func emptyDynamicSnapshot() *dynamicSnapshot {
 	return &dynamicSnapshot{
 		byPluginUserID: map[string]map[string]dynamicGrant{},
 		byPluginEmail:  map[string]map[string]dynamicGrant{},
+		adminByUserID:  map[string]dynamicGrant{},
+		adminByEmail:   map[string]dynamicGrant{},
 	}
 }
 

--- a/gestaltd/internal/bootstrap/bootstrap.go
+++ b/gestaltd/internal/bootstrap/bootstrap.go
@@ -546,6 +546,7 @@ func Bootstrap(ctx context.Context, cfg *config.Config, factories *FactoryRegist
 	if err != nil {
 		return nil, err
 	}
+	authz.SetAdminAuthorizationService(prepared.Services.AdminAuthorizations)
 	sharedInvoker := invocation.NewBroker(providers, prepared.Services.Users, prepared.Services.Tokens,
 		invocation.WithAuthorizer(authz),
 		invocation.WithConnectionMapper(invocation.ConnectionMap(connMaps.APIConnection)),

--- a/gestaltd/internal/coredata/admin_authorizations.go
+++ b/gestaltd/internal/coredata/admin_authorizations.go
@@ -1,0 +1,114 @@
+package coredata
+
+import (
+	"context"
+	"fmt"
+	"strings"
+	"time"
+
+	"github.com/valon-technologies/gestalt/server/core"
+	"github.com/valon-technologies/gestalt/server/core/indexeddb"
+	"github.com/valon-technologies/gestalt/server/internal/emailutil"
+)
+
+type AdminAuthorizationMembership struct {
+	ID        string
+	UserID    string
+	Email     string
+	Role      string
+	CreatedAt time.Time
+	UpdatedAt time.Time
+}
+
+type AdminAuthorizationService struct {
+	store indexeddb.ObjectStore
+}
+
+func NewAdminAuthorizationService(ds indexeddb.IndexedDB) *AdminAuthorizationService {
+	return &AdminAuthorizationService{store: ds.ObjectStore(StoreAdminAuthorizationMemberships)}
+}
+
+func (s *AdminAuthorizationService) ListAdminAuthorizations(ctx context.Context) ([]*AdminAuthorizationMembership, error) {
+	recs, err := s.store.GetAll(ctx, nil)
+	if err != nil {
+		return nil, fmt.Errorf("list admin authorizations: %w", err)
+	}
+	out := make([]*AdminAuthorizationMembership, len(recs))
+	for i, rec := range recs {
+		out[i] = recordToAdminAuthorizationMembership(rec)
+	}
+	return out, nil
+}
+
+func (s *AdminAuthorizationService) UpsertAdminAuthorization(ctx context.Context, membership *AdminAuthorizationMembership) (*AdminAuthorizationMembership, error) {
+	if membership == nil {
+		return nil, fmt.Errorf("upsert admin authorization: membership is required")
+	}
+
+	userID := strings.TrimSpace(membership.UserID)
+	email := emailutil.Normalize(membership.Email)
+	role := strings.TrimSpace(membership.Role)
+	switch {
+	case userID == "":
+		return nil, fmt.Errorf("upsert admin authorization: userID is required")
+	case email == "":
+		return nil, fmt.Errorf("upsert admin authorization: email is required")
+	case role == "":
+		return nil, fmt.Errorf("upsert admin authorization: role is required")
+	}
+
+	id := adminAuthorizationRecordID(userID)
+	now := time.Now()
+	createdAt := now
+	if existing, err := s.store.Get(ctx, id); err == nil {
+		createdAt = recTime(existing, "created_at")
+	} else if err != indexeddb.ErrNotFound {
+		return nil, fmt.Errorf("upsert admin authorization: %w", err)
+	}
+
+	rec := indexeddb.Record{
+		"id":         id,
+		"user_id":    userID,
+		"email":      email,
+		"role":       role,
+		"created_at": createdAt,
+		"updated_at": now,
+	}
+	if createdAt.IsZero() {
+		rec["created_at"] = now
+	}
+
+	if err := s.store.Put(ctx, rec); err != nil {
+		return nil, fmt.Errorf("upsert admin authorization: %w", err)
+	}
+	return recordToAdminAuthorizationMembership(rec), nil
+}
+
+func (s *AdminAuthorizationService) DeleteAdminAuthorization(ctx context.Context, userID string) error {
+	userID = strings.TrimSpace(userID)
+	if userID == "" {
+		return fmt.Errorf("delete admin authorization: userID is required")
+	}
+	if err := s.store.Delete(ctx, adminAuthorizationRecordID(userID)); err != nil {
+		if err == indexeddb.ErrNotFound {
+			return core.ErrNotFound
+		}
+		return fmt.Errorf("delete admin authorization: %w", err)
+	}
+	return nil
+}
+
+func adminAuthorizationRecordID(userID string) string {
+	return userID
+}
+
+func recordToAdminAuthorizationMembership(rec indexeddb.Record) *AdminAuthorizationMembership {
+	return &AdminAuthorizationMembership{
+		ID:        recString(rec, "id"),
+		UserID:    recString(rec, "user_id"),
+		Email:     recString(rec, "email"),
+		Role:      recString(rec, "role"),
+		CreatedAt: recTime(rec, "created_at"),
+		UpdatedAt: recTime(rec, "updated_at"),
+	}
+}

--- a/gestaltd/internal/coredata/schemas.go
+++ b/gestaltd/internal/coredata/schemas.go
@@ -7,6 +7,7 @@ const (
 	StoreIntegrationTokens              = "integration_tokens"
 	StoreAPITokens                      = "api_tokens"
 	StorePluginAuthorizationMemberships = "plugin_authorization_memberships"
+	StoreAdminAuthorizationMemberships  = "admin_authorization_memberships"
 )
 
 var UsersSchema = indexeddb.ObjectStoreSchema{
@@ -75,6 +76,20 @@ var PluginAuthorizationMembershipsSchema = indexeddb.ObjectStoreSchema{
 	Columns: []indexeddb.ColumnDef{
 		{Name: "id", Type: indexeddb.TypeString, PrimaryKey: true},
 		{Name: "plugin", Type: indexeddb.TypeString, NotNull: true},
+		{Name: "user_id", Type: indexeddb.TypeString, NotNull: true},
+		{Name: "email", Type: indexeddb.TypeString, NotNull: true},
+		{Name: "role", Type: indexeddb.TypeString, NotNull: true},
+		{Name: "created_at", Type: indexeddb.TypeTime},
+		{Name: "updated_at", Type: indexeddb.TypeTime},
+	},
+}
+
+var AdminAuthorizationMembershipsSchema = indexeddb.ObjectStoreSchema{
+	Indexes: []indexeddb.IndexSchema{
+		{Name: "by_user", KeyPath: []string{"user_id"}, Unique: true},
+	},
+	Columns: []indexeddb.ColumnDef{
+		{Name: "id", Type: indexeddb.TypeString, PrimaryKey: true},
 		{Name: "user_id", Type: indexeddb.TypeString, NotNull: true},
 		{Name: "email", Type: indexeddb.TypeString, NotNull: true},
 		{Name: "role", Type: indexeddb.TypeString, NotNull: true},

--- a/gestaltd/internal/coredata/services.go
+++ b/gestaltd/internal/coredata/services.go
@@ -13,6 +13,7 @@ type Services struct {
 	Tokens               *TokenService
 	APITokens            *APITokenService
 	PluginAuthorizations *PluginAuthorizationService
+	AdminAuthorizations  *AdminAuthorizationService
 	DB                   indexeddb.IndexedDB
 }
 
@@ -34,11 +35,15 @@ func New(ds indexeddb.IndexedDB, enc *corecrypto.AESGCMEncryptor) (*Services, er
 	if err := ds.CreateObjectStore(ctx, StorePluginAuthorizationMemberships, PluginAuthorizationMembershipsSchema); err != nil {
 		return nil, fmt.Errorf("create plugin_authorization_memberships store: %w", err)
 	}
+	if err := ds.CreateObjectStore(ctx, StoreAdminAuthorizationMemberships, AdminAuthorizationMembershipsSchema); err != nil {
+		return nil, fmt.Errorf("create admin_authorization_memberships store: %w", err)
+	}
 	return &Services{
 		Users:                users,
 		Tokens:               NewTokenService(ds, enc),
 		APITokens:            NewAPITokenService(ds),
 		PluginAuthorizations: NewPluginAuthorizationService(ds),
+		AdminAuthorizations:  NewAdminAuthorizationService(ds),
 		DB:                   ds,
 	}, nil
 }

--- a/gestaltd/internal/server/handlers_admin_authorization.go
+++ b/gestaltd/internal/server/handlers_admin_authorization.go
@@ -11,6 +11,7 @@ import (
 
 	"github.com/go-chi/chi/v5"
 	"github.com/valon-technologies/gestalt/server/core"
+	"github.com/valon-technologies/gestalt/server/internal/authorization"
 	"github.com/valon-technologies/gestalt/server/internal/config"
 	"github.com/valon-technologies/gestalt/server/internal/coredata"
 	"github.com/valon-technologies/gestalt/server/internal/emailutil"
@@ -43,6 +44,9 @@ type putAdminAuthorizationMemberRequest struct {
 }
 
 func (s *Server) mountAdminAuthorizationRoutes(r chi.Router) {
+	r.Get("/authorization/admins/members", s.listAdminAuthorizationAdminMembers)
+	r.Put("/authorization/admins/members", s.putAdminAuthorizationAdminMember)
+	r.Delete("/authorization/admins/members/{userID}", s.deleteAdminAuthorizationAdminMember)
 	r.Get("/authorization/plugins", s.listAdminAuthorizationPlugins)
 	r.Get("/authorization/plugins/{plugin}/members", s.listAdminAuthorizationPluginMembers)
 	r.Put("/authorization/plugins/{plugin}/members", s.putAdminAuthorizationPluginMember)
@@ -74,7 +78,7 @@ func (s *Server) adminAPIAuthMiddleware(next http.Handler) http.Handler {
 			return
 		}
 
-		access, allowed := s.authorizer.ResolvePolicyAccess(p, s.adminRoute.AuthorizationPolicy)
+		access, allowed := s.authorizer.ResolveAdminAccess(p, s.adminRoute.AuthorizationPolicy)
 		if !allowed || !mountedWebUIRoleAllowed(access.Role, s.adminRoute.AllowedRoles) {
 			writeError(w, http.StatusForbidden, "admin access denied")
 			return
@@ -242,6 +246,124 @@ func (s *Server) deleteAdminAuthorizationPluginMember(w http.ResponseWriter, r *
 	})
 }
 
+func (s *Server) listAdminAuthorizationAdminMembers(w http.ResponseWriter, r *http.Request) {
+	if !s.ensureAdminDynamicAdminAvailable(w) {
+		return
+	}
+
+	rows, err := s.adminAuthorizationAdminRows(r.Context())
+	if err != nil {
+		writeError(w, http.StatusInternalServerError, "failed to list admin members")
+		return
+	}
+	writeJSON(w, http.StatusOK, rows)
+}
+
+func (s *Server) putAdminAuthorizationAdminMember(w http.ResponseWriter, r *http.Request) {
+	if !s.ensureAdminDynamicAdminAvailable(w) {
+		return
+	}
+	if !s.ensureAdminAuthorizationWriteAccess(w, r) {
+		return
+	}
+
+	var req putAdminAuthorizationMemberRequest
+	if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
+		writeError(w, http.StatusBadRequest, "invalid JSON body")
+		return
+	}
+	if emailutil.Normalize(req.Email) == "" {
+		writeError(w, http.StatusBadRequest, "email is required")
+		return
+	}
+	if strings.TrimSpace(req.Role) == "" {
+		writeError(w, http.StatusBadRequest, "role is required")
+		return
+	}
+	user, err := s.users.FindOrCreateUser(r.Context(), req.Email)
+	if err != nil {
+		writeError(w, http.StatusInternalServerError, "failed to resolve user")
+		return
+	}
+	if access, ok := s.authorizer.StaticRoleForPolicyIdentity(s.adminRoute.AuthorizationPolicy, principal.UserSubjectID(user.ID), user.ID, user.Email); ok && access.Role != "" {
+		writeError(w, http.StatusConflict, "user already has static admin authorization")
+		return
+	}
+
+	membership, err := s.adminAuthorizations.UpsertAdminAuthorization(r.Context(), &coredata.AdminAuthorizationMembership{
+		UserID: user.ID,
+		Email:  user.Email,
+		Role:   req.Role,
+	})
+	if err != nil {
+		writeError(w, http.StatusInternalServerError, "failed to persist admin member")
+		return
+	}
+
+	row := adminAuthorizationMemberRow{
+		Role:          membership.Role,
+		Source:        "dynamic",
+		Effective:     true,
+		Mutable:       true,
+		SelectorKind:  "user_id",
+		SelectorValue: membership.UserID,
+		UserID:        membership.UserID,
+		Email:         membership.Email,
+	}
+	if err := s.reloadDynamicAuthorizations(r.Context()); err != nil {
+		writeJSON(w, http.StatusAccepted, map[string]any{
+			"status":     "persisted_pending_reload",
+			"persisted":  true,
+			"reloaded":   false,
+			"membership": row,
+		})
+		return
+	}
+	writeJSON(w, http.StatusOK, map[string]any{
+		"status":     "ok",
+		"persisted":  true,
+		"reloaded":   true,
+		"membership": row,
+	})
+}
+
+func (s *Server) deleteAdminAuthorizationAdminMember(w http.ResponseWriter, r *http.Request) {
+	if !s.ensureAdminDynamicAdminAvailable(w) {
+		return
+	}
+	if !s.ensureAdminAuthorizationWriteAccess(w, r) {
+		return
+	}
+	userID := strings.TrimSpace(chi.URLParam(r, "userID"))
+	if userID == "" {
+		writeError(w, http.StatusBadRequest, "userID is required")
+		return
+	}
+
+	if err := s.adminAuthorizations.DeleteAdminAuthorization(r.Context(), userID); err != nil {
+		if errors.Is(err, core.ErrNotFound) {
+			writeError(w, http.StatusNotFound, "admin member not found")
+			return
+		}
+		writeError(w, http.StatusInternalServerError, "failed to delete admin member")
+		return
+	}
+
+	if err := s.reloadDynamicAuthorizations(r.Context()); err != nil {
+		writeJSON(w, http.StatusAccepted, map[string]any{
+			"status":    "persisted_pending_reload",
+			"persisted": true,
+			"reloaded":  false,
+		})
+		return
+	}
+	writeJSON(w, http.StatusOK, map[string]any{
+		"status":    "deleted",
+		"persisted": true,
+		"reloaded":  true,
+	})
+}
+
 func (s *Server) adminAuthorizationPluginEntry(plugin string) (string, *config.ProviderEntry, error) {
 	plugin = strings.TrimSpace(plugin)
 	if plugin == "" {
@@ -271,7 +393,7 @@ func (s *Server) writeAdminAuthorizationPluginError(w http.ResponseWriter, err e
 }
 
 func (s *Server) adminAuthorizationMemberRows(ctx context.Context, plugin string) ([]adminAuthorizationMemberRow, error) {
-	if s.pluginAuthorizations == nil || s.authorizer == nil || !s.authorizer.HasDynamicAuthorizations() {
+	if s.pluginAuthorizations == nil || s.authorizer == nil || !s.authorizer.HasDynamicPluginAuthorizations() {
 		return nil, errAdminAuthorizationUnavailable
 	}
 	staticRows, err := s.adminAuthorizationStaticRows(ctx, plugin)
@@ -338,11 +460,90 @@ func (s *Server) adminAuthorizationMemberRows(ctx context.Context, plugin string
 	return rows, nil
 }
 
+func (s *Server) adminAuthorizationAdminRows(ctx context.Context) ([]adminAuthorizationMemberRow, error) {
+	if s.adminAuthorizations == nil || s.authorizer == nil || !s.authorizer.HasDynamicAdminAuthorizations() {
+		return nil, errAdminAuthorizationUnavailable
+	}
+	staticRows, err := s.adminAuthorizationStaticAdminRows(ctx)
+	if err != nil {
+		return nil, err
+	}
+	dynamicMemberships, err := s.adminAuthorizations.ListAdminAuthorizations(ctx)
+	if err != nil {
+		return nil, err
+	}
+
+	staticByUserID := make(map[string]string, len(staticRows))
+	staticByEmail := make(map[string]string, len(staticRows))
+	rows := make([]adminAuthorizationMemberRow, 0, len(staticRows)+len(dynamicMemberships))
+	for i := range staticRows {
+		row := &staticRows[i]
+		rows = append(rows, *row)
+		key := row.adminAuthorizationRowKey()
+		if row.UserID != "" {
+			staticByUserID[row.UserID] = key
+		}
+		if email := normalizedRowEmail(*row); email != "" {
+			staticByEmail[email] = key
+		}
+	}
+
+	for _, membership := range dynamicMemberships {
+		if membership == nil {
+			continue
+		}
+		row := adminAuthorizationMemberRow{
+			Role:          membership.Role,
+			Source:        "dynamic",
+			Effective:     true,
+			Mutable:       true,
+			SelectorKind:  "user_id",
+			SelectorValue: membership.UserID,
+			UserID:        membership.UserID,
+			Email:         membership.Email,
+		}
+		if shadow, ok := staticByUserID[row.UserID]; ok {
+			row.Effective = false
+			row.ShadowedBy = shadow
+		} else if shadow, ok := staticByEmail[normalizedRowEmail(row)]; ok {
+			row.Effective = false
+			row.ShadowedBy = shadow
+		}
+		rows = append(rows, row)
+	}
+
+	sort.Slice(rows, func(i, j int) bool {
+		if rows[i].Source != rows[j].Source {
+			return rows[i].Source < rows[j].Source
+		}
+		if rows[i].SelectorKind != rows[j].SelectorKind {
+			return rows[i].SelectorKind < rows[j].SelectorKind
+		}
+		if rows[i].SelectorValue != rows[j].SelectorValue {
+			return rows[i].SelectorValue < rows[j].SelectorValue
+		}
+		return rows[i].Role < rows[j].Role
+	})
+	return rows, nil
+}
+
 func (s *Server) adminAuthorizationStaticRows(ctx context.Context, plugin string) ([]adminAuthorizationMemberRow, error) {
 	_, members, ok := s.authorizer.StaticMembersForProvider(plugin)
 	if !ok {
 		return nil, nil
 	}
+	return s.adminAuthorizationRowsFromStaticMembers(ctx, plugin, members)
+}
+
+func (s *Server) adminAuthorizationStaticAdminRows(ctx context.Context) ([]adminAuthorizationMemberRow, error) {
+	members, ok := s.authorizer.StaticMembersForPolicy(s.adminRoute.AuthorizationPolicy)
+	if !ok {
+		return nil, nil
+	}
+	return s.adminAuthorizationRowsFromStaticMembers(ctx, "", members)
+}
+
+func (s *Server) adminAuthorizationRowsFromStaticMembers(ctx context.Context, plugin string, members []authorization.StaticHumanMember) ([]adminAuthorizationMemberRow, error) {
 	rows := make([]adminAuthorizationMemberRow, 0, len(members))
 	for _, member := range members {
 		row := adminAuthorizationMemberRow{
@@ -434,9 +635,50 @@ var (
 )
 
 func (s *Server) ensureAdminDynamicAuthorizationAvailable(w http.ResponseWriter) bool {
-	if s.pluginAuthorizations == nil || s.authorizer == nil || !s.authorizer.HasDynamicAuthorizations() {
+	if s.pluginAuthorizations == nil || s.authorizer == nil || !s.authorizer.HasDynamicPluginAuthorizations() {
 		writeError(w, http.StatusServiceUnavailable, "dynamic authorization is unavailable")
 		return false
 	}
 	return true
+}
+
+func (s *Server) ensureAdminDynamicAdminAvailable(w http.ResponseWriter) bool {
+	if strings.TrimSpace(s.adminRoute.AuthorizationPolicy) == "" {
+		writeError(w, http.StatusServiceUnavailable, "dynamic admin authorization is unavailable")
+		return false
+	}
+	if s.adminAuthorizations == nil || s.authorizer == nil || !s.authorizer.HasDynamicAdminAuthorizations() {
+		writeError(w, http.StatusServiceUnavailable, "dynamic admin authorization is unavailable")
+		return false
+	}
+	members, ok := s.authorizer.StaticMembersForPolicy(s.adminRoute.AuthorizationPolicy)
+	if !ok || len(members) == 0 {
+		writeError(w, http.StatusServiceUnavailable, "dynamic admin authorization requires at least one static admin member")
+		return false
+	}
+	hasSeedAdmin := false
+	for _, member := range members {
+		if s.adminRoleCanMutate(member.Role) {
+			hasSeedAdmin = true
+			break
+		}
+	}
+	if !hasSeedAdmin {
+		writeError(w, http.StatusServiceUnavailable, "dynamic admin authorization requires at least one static admin member")
+		return false
+	}
+	return true
+}
+
+func (s *Server) ensureAdminAuthorizationWriteAccess(w http.ResponseWriter, r *http.Request) bool {
+	access := invocation.AccessContextFromContext(r.Context())
+	if !s.adminRoleCanMutate(access.Role) {
+		writeError(w, http.StatusForbidden, "admin membership changes require an allowed admin role")
+		return false
+	}
+	return true
+}
+
+func (s *Server) adminRoleCanMutate(role string) bool {
+	return mountedWebUIRoleAllowed(strings.TrimSpace(role), s.adminRoute.AllowedRoles)
 }

--- a/gestaltd/internal/server/mounted_ui.go
+++ b/gestaltd/internal/server/mounted_ui.go
@@ -207,6 +207,7 @@ func (s *Server) adminMountedWebUI() MountedWebUI {
 		Name:                "builtin_admin",
 		Path:                "/admin",
 		AuthorizationPolicy: s.adminRoute.AuthorizationPolicy,
+		builtInAdmin:        true,
 		Routes: []MountedWebUIRoute{{
 			Path:         "/*",
 			AllowedRoles: append([]string(nil), s.adminRoute.AllowedRoles...),
@@ -257,9 +258,12 @@ func (s *Server) authorizeProtectedUIRequest(w http.ResponseWriter, r *http.Requ
 		access  invocation.AccessContext
 		allowed bool
 	)
-	if mounted.PluginName != "" {
+	switch {
+	case mounted.PluginName != "":
 		access, allowed = s.authorizer.ResolveAccess(p, mounted.PluginName)
-	} else {
+	case mounted.builtInAdmin:
+		access, allowed = s.authorizer.ResolveAdminAccess(p, mounted.AuthorizationPolicy)
+	default:
 		access, allowed = s.authorizer.ResolvePolicyAccess(p, mounted.AuthorizationPolicy)
 	}
 	if !allowed {

--- a/gestaltd/internal/server/server.go
+++ b/gestaltd/internal/server/server.go
@@ -47,6 +47,7 @@ type MountedWebUI struct {
 	AuthorizationPolicy string
 	Routes              []MountedWebUIRoute
 	Handler             http.Handler
+	builtInAdmin        bool
 }
 
 type AdminRouteConfig struct {
@@ -63,6 +64,7 @@ type Server struct {
 	tokens               *coredata.TokenService
 	apiTokens            *coredata.APITokenService
 	pluginAuthorizations *coredata.PluginAuthorizationService
+	adminAuthorizations  *coredata.AdminAuthorizationService
 	providers            *registry.ProviderMap[core.Provider]
 	resolver             *principal.Resolver
 	invoker              invocation.Invoker
@@ -158,6 +160,7 @@ func New(cfg Config) (*Server, error) {
 	tokens := cfg.Services.Tokens
 	apiTokens := cfg.Services.APITokens
 	pluginAuthorizations := cfg.Services.PluginAuthorizations
+	adminAuthorizations := cfg.Services.AdminAuthorizations
 	resolver := principal.NewResolver(cfg.Auth, users, apiTokens, cfg.Authorizer)
 
 	router := chi.NewRouter()
@@ -174,6 +177,7 @@ func New(cfg Config) (*Server, error) {
 		tokens:               tokens,
 		apiTokens:            apiTokens,
 		pluginAuthorizations: pluginAuthorizations,
+		adminAuthorizations:  adminAuthorizations,
 		providers:            cfg.Providers,
 		resolver:             resolver,
 		invoker:              cfg.Invoker,

--- a/gestaltd/internal/server/server_test.go
+++ b/gestaltd/internal/server/server_test.go
@@ -177,6 +177,25 @@ func newTestServicesWithPluginAuthorizationPutFailure(t *testing.T) (*coredata.S
 	return svc, failPut
 }
 
+func newTestServicesWithAdminAuthorizationPutFailure(t *testing.T) (*coredata.Services, *atomic.Bool) {
+	t.Helper()
+	enc, err := corecrypto.NewAESGCM([]byte("0123456789abcdef0123456789abcdef"))
+	if err != nil {
+		t.Fatalf("newTestServicesWithAdminAuthorizationPutFailure encryptor: %v", err)
+	}
+	failPut := &atomic.Bool{}
+	svc, err := coredata.New(&putFailingIndexedDB{
+		IndexedDB: &coretesting.StubIndexedDB{},
+		failStorePuts: map[string]*atomic.Bool{
+			coredata.StoreAdminAuthorizationMemberships: failPut,
+		},
+	}, enc)
+	if err != nil {
+		t.Fatalf("newTestServicesWithAdminAuthorizationPutFailure: %v", err)
+	}
+	return svc, failPut
+}
+
 func newVirtualHostClient(t *testing.T, hostAddrs map[string]string) *http.Client {
 	t.Helper()
 	jar, err := cookiejar.New(nil)
@@ -392,6 +411,26 @@ func mustAuthorizer(t *testing.T, cfg config.AuthorizationConfig, providers *reg
 		t.Fatalf("authorization.New: %v", err)
 	}
 	return authz
+}
+
+func seedDynamicAdminMembership(t *testing.T, svc *coredata.Services, authz *authorization.Authorizer, email, role string) *core.User {
+	t.Helper()
+	authz.SetAdminAuthorizationService(svc.AdminAuthorizations)
+	user, err := svc.Users.FindOrCreateUser(context.Background(), email)
+	if err != nil {
+		t.Fatalf("FindOrCreateUser dynamic admin: %v", err)
+	}
+	if _, err := svc.AdminAuthorizations.UpsertAdminAuthorization(context.Background(), &coredata.AdminAuthorizationMembership{
+		UserID: user.ID,
+		Email:  user.Email,
+		Role:   role,
+	}); err != nil {
+		t.Fatalf("UpsertAdminAuthorization: %v", err)
+	}
+	if err := authz.ReloadDynamic(context.Background()); err != nil {
+		t.Fatalf("ReloadDynamic: %v", err)
+	}
+	return user
 }
 
 func seedToken(t *testing.T, svc *coredata.Services, tok *core.IntegrationToken) {
@@ -1060,6 +1099,7 @@ func TestBuiltInAdminRoute_HumanAuthorization(t *testing.T) {
 			},
 		},
 	}, nil, nil, nil)
+	seedDynamicAdminMembership(t, svc, authz, "dynamic-admin@example.test", "admin")
 
 	ts := newTestServer(t, func(cfg *server.Config) {
 		cfg.Auth = &coretesting.StubAuthProvider{
@@ -1070,6 +1110,8 @@ func TestBuiltInAdminRoute_HumanAuthorization(t *testing.T) {
 					return &core.UserIdentity{Email: "viewer@example.test"}, nil
 				case "admin-session":
 					return &core.UserIdentity{Email: "admin@example.test"}, nil
+				case "dynamic-admin-session":
+					return &core.UserIdentity{Email: "dynamic-admin@example.test"}, nil
 				default:
 					return nil, fmt.Errorf("invalid token")
 				}
@@ -1113,12 +1155,30 @@ func TestBuiltInAdminRoute_HumanAuthorization(t *testing.T) {
 	}
 
 	req, _ = http.NewRequest(http.MethodGet, ts.URL+"/admin/", nil)
+	req.AddCookie(&http.Cookie{Name: "session_token", Value: "dynamic-admin-session"})
+	resp, err = http.DefaultClient.Do(req)
+	if err != nil {
+		t.Fatalf("GET protected admin with dynamic admin session: %v", err)
+	}
+	body, err := io.ReadAll(resp.Body)
+	_ = resp.Body.Close()
+	if err != nil {
+		t.Fatalf("ReadAll protected admin dynamic admin: %v", err)
+	}
+	if resp.StatusCode != http.StatusOK {
+		t.Fatalf("dynamic admin status = %d, want 200", resp.StatusCode)
+	}
+	if !strings.Contains(string(body), "protected-admin-shell") {
+		t.Fatalf("dynamic admin body = %q, want protected admin shell", body)
+	}
+
+	req, _ = http.NewRequest(http.MethodGet, ts.URL+"/admin/", nil)
 	req.AddCookie(&http.Cookie{Name: "session_token", Value: "admin-session"})
 	resp, err = http.DefaultClient.Do(req)
 	if err != nil {
 		t.Fatalf("GET protected admin with admin session: %v", err)
 	}
-	body, err := io.ReadAll(resp.Body)
+	body, err = io.ReadAll(resp.Body)
 	_ = resp.Body.Close()
 	if err != nil {
 		t.Fatalf("ReadAll protected admin: %v", err)
@@ -1175,6 +1235,7 @@ func TestBuiltInAdminRoute_HumanAuthorizationOnManagementProfile(t *testing.T) {
 			},
 		},
 	}, nil, nil, nil)
+	seedDynamicAdminMembership(t, svc, authz, "dynamic-admin@example.test", "admin")
 
 	ts := newTestServer(t, func(cfg *server.Config) {
 		cfg.Auth = &coretesting.StubAuthProvider{
@@ -1185,6 +1246,8 @@ func TestBuiltInAdminRoute_HumanAuthorizationOnManagementProfile(t *testing.T) {
 					return &core.UserIdentity{Email: "viewer@example.test"}, nil
 				case "admin-session":
 					return &core.UserIdentity{Email: "admin@example.test"}, nil
+				case "dynamic-admin-session":
+					return &core.UserIdentity{Email: "dynamic-admin@example.test"}, nil
 				default:
 					return nil, fmt.Errorf("invalid token")
 				}
@@ -1231,12 +1294,30 @@ func TestBuiltInAdminRoute_HumanAuthorizationOnManagementProfile(t *testing.T) {
 	}
 
 	req, _ = http.NewRequest(http.MethodGet, ts.URL+"/admin/", nil)
+	req.AddCookie(&http.Cookie{Name: "session_token", Value: "dynamic-admin-session"})
+	resp, err = http.DefaultClient.Do(req)
+	if err != nil {
+		t.Fatalf("GET protected management admin with dynamic admin session: %v", err)
+	}
+	body, err := io.ReadAll(resp.Body)
+	_ = resp.Body.Close()
+	if err != nil {
+		t.Fatalf("ReadAll protected management admin dynamic admin: %v", err)
+	}
+	if resp.StatusCode != http.StatusOK {
+		t.Fatalf("management dynamic admin status = %d, want 200", resp.StatusCode)
+	}
+	if !strings.Contains(string(body), "protected-admin-shell") {
+		t.Fatalf("body = %q, want protected admin shell", body)
+	}
+
+	req, _ = http.NewRequest(http.MethodGet, ts.URL+"/admin/", nil)
 	req.AddCookie(&http.Cookie{Name: "session_token", Value: "admin-session"})
 	resp, err = http.DefaultClient.Do(req)
 	if err != nil {
 		t.Fatalf("GET protected management admin with admin session: %v", err)
 	}
-	body, err := io.ReadAll(resp.Body)
+	body, err = io.ReadAll(resp.Body)
 	_ = resp.Body.Close()
 	if err != nil {
 		t.Fatalf("ReadAll protected management admin: %v", err)
@@ -1442,6 +1523,7 @@ func TestAdminAPI_HumanAuthorization(t *testing.T) {
 	}, nil, map[string]*config.ProviderEntry{
 		"sample_plugin": {AuthorizationPolicy: "sample_policy"},
 	}, nil)
+	seedDynamicAdminMembership(t, svc, authz, "dynamic-admin@example.test", "admin")
 
 	ts := newTestServer(t, func(cfg *server.Config) {
 		cfg.Auth = &coretesting.StubAuthProvider{
@@ -1452,6 +1534,8 @@ func TestAdminAPI_HumanAuthorization(t *testing.T) {
 					return &core.UserIdentity{Email: "viewer@example.test"}, nil
 				case "admin-session":
 					return &core.UserIdentity{Email: "admin@example.test"}, nil
+				case "dynamic-admin-session":
+					return &core.UserIdentity{Email: "dynamic-admin@example.test"}, nil
 				default:
 					return nil, fmt.Errorf("invalid token")
 				}
@@ -1491,6 +1575,18 @@ func TestAdminAPI_HumanAuthorization(t *testing.T) {
 	defer func() { _ = resp.Body.Close() }()
 	if resp.StatusCode != http.StatusForbidden {
 		t.Fatalf("viewer admin api status = %d, want %d", resp.StatusCode, http.StatusForbidden)
+	}
+
+	req, _ = http.NewRequest(http.MethodGet, ts.URL+"/admin/api/v1/authorization/admins/members", nil)
+	req.AddCookie(&http.Cookie{Name: "session_token", Value: "dynamic-admin-session"})
+	resp, err = http.DefaultClient.Do(req)
+	if err != nil {
+		t.Fatalf("GET admin members api with dynamic admin session: %v", err)
+	}
+	defer func() { _ = resp.Body.Close() }()
+	if resp.StatusCode != http.StatusOK {
+		body, _ := io.ReadAll(resp.Body)
+		t.Fatalf("dynamic admin api status = %d, want 200: %s", resp.StatusCode, body)
 	}
 
 	req, _ = http.NewRequest(http.MethodGet, ts.URL+"/admin/api/v1/authorization/plugins", nil)
@@ -1562,15 +1658,20 @@ func TestAdminAPI_HumanAuthorizationOnManagementProfile(t *testing.T) {
 	}, nil, map[string]*config.ProviderEntry{
 		"sample_plugin": {AuthorizationPolicy: "sample_policy"},
 	}, nil)
+	seedDynamicAdminMembership(t, svc, authz, "dynamic-admin@example.test", "admin")
 
 	ts := newTestServer(t, func(cfg *server.Config) {
 		cfg.Auth = &coretesting.StubAuthProvider{
 			N: "test",
 			ValidateTokenFn: func(_ context.Context, token string) (*core.UserIdentity, error) {
-				if token != "admin-session" {
+				switch token {
+				case "admin-session":
+					return &core.UserIdentity{Email: "admin@example.test"}, nil
+				case "dynamic-admin-session":
+					return &core.UserIdentity{Email: "dynamic-admin@example.test"}, nil
+				default:
 					return nil, fmt.Errorf("invalid token")
 				}
-				return &core.UserIdentity{Email: "admin@example.test"}, nil
 			},
 		}
 		cfg.Services = svc
@@ -1591,9 +1692,21 @@ func TestAdminAPI_HumanAuthorizationOnManagementProfile(t *testing.T) {
 	})
 	testutil.CloseOnCleanup(t, ts)
 
-	req, _ := http.NewRequest(http.MethodGet, ts.URL+"/admin/api/v1/authorization/plugins", nil)
-	req.AddCookie(&http.Cookie{Name: "session_token", Value: "admin-session"})
+	req, _ := http.NewRequest(http.MethodGet, ts.URL+"/admin/api/v1/authorization/admins/members", nil)
+	req.AddCookie(&http.Cookie{Name: "session_token", Value: "dynamic-admin-session"})
 	resp, err := http.DefaultClient.Do(req)
+	if err != nil {
+		t.Fatalf("GET management admin members api with dynamic admin session: %v", err)
+	}
+	defer func() { _ = resp.Body.Close() }()
+	if resp.StatusCode != http.StatusOK {
+		body, _ := io.ReadAll(resp.Body)
+		t.Fatalf("management dynamic admin api status = %d, want 200: %s", resp.StatusCode, body)
+	}
+
+	req, _ = http.NewRequest(http.MethodGet, ts.URL+"/admin/api/v1/authorization/plugins", nil)
+	req.AddCookie(&http.Cookie{Name: "session_token", Value: "admin-session"})
+	resp, err = http.DefaultClient.Do(req)
 	if err != nil {
 		t.Fatalf("GET management admin api with admin session: %v", err)
 	}
@@ -1805,6 +1918,229 @@ func TestAdminAPI_PluginAuthorizationCRUD(t *testing.T) {
 	}
 }
 
+func TestAdminAPI_AdminAuthorizationCRUD(t *testing.T) {
+	t.Parallel()
+
+	svc := coretesting.NewStubServices(t)
+	seedUser(t, svc, "static-admin@example.test")
+	const adminRole = "owner"
+	authz := mustAuthorizer(t, config.AuthorizationConfig{
+		Policies: map[string]config.HumanPolicyDef{
+			"admin_policy": {
+				Default: "deny",
+				Members: []config.HumanPolicyMemberDef{
+					{Email: "static-admin@example.test", Role: adminRole},
+				},
+			},
+		},
+	}, nil, nil, nil)
+	authz.SetAdminAuthorizationService(svc.AdminAuthorizations)
+	if err := authz.ReloadDynamic(context.Background()); err != nil {
+		t.Fatalf("ReloadDynamic: %v", err)
+	}
+
+	ts := newTestServer(t, func(cfg *server.Config) {
+		cfg.Auth = &coretesting.StubAuthProvider{
+			N: "test",
+			ValidateTokenFn: func(_ context.Context, token string) (*core.UserIdentity, error) {
+				if token != "admin-session" {
+					return nil, fmt.Errorf("invalid token")
+				}
+				return &core.UserIdentity{Email: "static-admin@example.test"}, nil
+			},
+		}
+		cfg.Services = svc
+		cfg.Authorizer = authz
+		cfg.Admin = server.AdminRouteConfig{
+			AuthorizationPolicy: "admin_policy",
+			AllowedRoles:        []string{adminRole},
+		}
+		cfg.AdminUI = http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+			_, _ = w.Write([]byte("admin"))
+		})
+	})
+	testutil.CloseOnCleanup(t, ts)
+
+	req, _ := http.NewRequest(http.MethodGet, ts.URL+"/admin/api/v1/authorization/admins/members", nil)
+	req.AddCookie(&http.Cookie{Name: "session_token", Value: "admin-session"})
+	resp, err := http.DefaultClient.Do(req)
+	if err != nil {
+		t.Fatalf("GET admin members: %v", err)
+	}
+	defer func() { _ = resp.Body.Close() }()
+	if resp.StatusCode != http.StatusOK {
+		body, _ := io.ReadAll(resp.Body)
+		t.Fatalf("admin members status = %d, want 200: %s", resp.StatusCode, body)
+	}
+
+	var members []map[string]any
+	if err := json.NewDecoder(resp.Body).Decode(&members); err != nil {
+		t.Fatalf("decoding admin members: %v", err)
+	}
+	if len(members) != 1 || members[0]["source"] != "static" {
+		t.Fatalf("admin members = %+v, want one static row", members)
+	}
+
+	body := bytes.NewBufferString(`{"email":"dynamic-admin@example.test","role":"owner"}`)
+	req, _ = http.NewRequest(http.MethodPut, ts.URL+"/admin/api/v1/authorization/admins/members", body)
+	req.Header.Set("Content-Type", "application/json")
+	req.AddCookie(&http.Cookie{Name: "session_token", Value: "admin-session"})
+	resp, err = http.DefaultClient.Do(req)
+	if err != nil {
+		t.Fatalf("PUT admin member: %v", err)
+	}
+	defer func() { _ = resp.Body.Close() }()
+	if resp.StatusCode != http.StatusOK {
+		respBody, _ := io.ReadAll(resp.Body)
+		t.Fatalf("put admin member status = %d, want 200: %s", resp.StatusCode, respBody)
+	}
+
+	req, _ = http.NewRequest(http.MethodGet, ts.URL+"/admin/api/v1/authorization/admins/members", nil)
+	req.AddCookie(&http.Cookie{Name: "session_token", Value: "admin-session"})
+	resp, err = http.DefaultClient.Do(req)
+	if err != nil {
+		t.Fatalf("GET admin members after put: %v", err)
+	}
+	defer func() { _ = resp.Body.Close() }()
+	if resp.StatusCode != http.StatusOK {
+		t.Fatalf("admin members after put status = %d, want 200", resp.StatusCode)
+	}
+	members = nil
+	if err := json.NewDecoder(resp.Body).Decode(&members); err != nil {
+		t.Fatalf("decoding admin members after put: %v", err)
+	}
+	if len(members) != 2 {
+		t.Fatalf("expected 2 merged admin members, got %d (%+v)", len(members), members)
+	}
+
+	body = bytes.NewBufferString(`{"email":"static-admin@example.test","role":"owner"}`)
+	req, _ = http.NewRequest(http.MethodPut, ts.URL+"/admin/api/v1/authorization/admins/members", body)
+	req.Header.Set("Content-Type", "application/json")
+	req.AddCookie(&http.Cookie{Name: "session_token", Value: "admin-session"})
+	resp, err = http.DefaultClient.Do(req)
+	if err != nil {
+		t.Fatalf("PUT static admin conflict: %v", err)
+	}
+	defer func() { _ = resp.Body.Close() }()
+	if resp.StatusCode != http.StatusConflict {
+		respBody, _ := io.ReadAll(resp.Body)
+		t.Fatalf("put static admin conflict status = %d, want 409: %s", resp.StatusCode, respBody)
+	}
+
+	user, err := svc.Users.FindUserByEmail(context.Background(), "dynamic-admin@example.test")
+	if err != nil {
+		t.Fatalf("find dynamic admin user: %v", err)
+	}
+	req, _ = http.NewRequest(http.MethodDelete, ts.URL+"/admin/api/v1/authorization/admins/members/"+url.PathEscape(user.ID), nil)
+	req.AddCookie(&http.Cookie{Name: "session_token", Value: "admin-session"})
+	resp, err = http.DefaultClient.Do(req)
+	if err != nil {
+		t.Fatalf("DELETE admin member: %v", err)
+	}
+	defer func() { _ = resp.Body.Close() }()
+	if resp.StatusCode != http.StatusOK {
+		respBody, _ := io.ReadAll(resp.Body)
+		t.Fatalf("delete admin member status = %d, want 200: %s", resp.StatusCode, respBody)
+	}
+
+	req, _ = http.NewRequest(http.MethodGet, ts.URL+"/admin/api/v1/authorization/admins/members", nil)
+	req.AddCookie(&http.Cookie{Name: "session_token", Value: "admin-session"})
+	resp, err = http.DefaultClient.Do(req)
+	if err != nil {
+		t.Fatalf("GET admin members after delete: %v", err)
+	}
+	defer func() { _ = resp.Body.Close() }()
+	if resp.StatusCode != http.StatusOK {
+		t.Fatalf("admin members after delete status = %d, want 200", resp.StatusCode)
+	}
+	members = nil
+	if err := json.NewDecoder(resp.Body).Decode(&members); err != nil {
+		t.Fatalf("decoding admin members after delete: %v", err)
+	}
+	if len(members) != 1 || members[0]["source"] != "static" {
+		t.Fatalf("admin members after delete = %+v, want only static row", members)
+	}
+}
+
+func TestAdminAPI_AdminAuthorizationWriteUsesAllowedAdminRoles(t *testing.T) {
+	t.Parallel()
+
+	svc := coretesting.NewStubServices(t)
+	seedUser(t, svc, "static-admin@example.test")
+	seedUser(t, svc, "viewer@example.test")
+	const adminRole = "ops-admin"
+	authz := mustAuthorizer(t, config.AuthorizationConfig{
+		Policies: map[string]config.HumanPolicyDef{
+			"admin_policy": {
+				Default: "deny",
+				Members: []config.HumanPolicyMemberDef{
+					{Email: "static-admin@example.test", Role: adminRole},
+				},
+			},
+		},
+	}, nil, nil, nil)
+	authz.SetAdminAuthorizationService(svc.AdminAuthorizations)
+	if err := authz.ReloadDynamic(context.Background()); err != nil {
+		t.Fatalf("ReloadDynamic: %v", err)
+	}
+
+	ts := newTestServer(t, func(cfg *server.Config) {
+		cfg.Auth = &coretesting.StubAuthProvider{
+			N: "test",
+			ValidateTokenFn: func(_ context.Context, token string) (*core.UserIdentity, error) {
+				switch token {
+				case "ops-admin-session":
+					return &core.UserIdentity{Email: "static-admin@example.test"}, nil
+				case "viewer-session":
+					return &core.UserIdentity{Email: "viewer@example.test"}, nil
+				default:
+					return nil, fmt.Errorf("invalid token")
+				}
+			},
+		}
+		cfg.Services = svc
+		cfg.Authorizer = authz
+		cfg.Admin = server.AdminRouteConfig{
+			AuthorizationPolicy: "admin_policy",
+			AllowedRoles:        []string{adminRole},
+		}
+		cfg.AdminUI = http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+			_, _ = w.Write([]byte("admin"))
+		})
+	})
+	testutil.CloseOnCleanup(t, ts)
+
+	body := bytes.NewBufferString(`{"email":"viewer@example.test","role":"ops-admin"}`)
+	req, _ := http.NewRequest(http.MethodPut, ts.URL+"/admin/api/v1/authorization/admins/members", body)
+	req.Header.Set("Content-Type", "application/json")
+	req.AddCookie(&http.Cookie{Name: "session_token", Value: "ops-admin-session"})
+	resp, err := http.DefaultClient.Do(req)
+	if err != nil {
+		t.Fatalf("ops-admin PUT admin member: %v", err)
+	}
+	defer func() { _ = resp.Body.Close() }()
+	if resp.StatusCode != http.StatusOK {
+		respBody, _ := io.ReadAll(resp.Body)
+		t.Fatalf("ops-admin put admin member status = %d, want 200: %s", resp.StatusCode, respBody)
+	}
+
+	user, err := svc.Users.FindUserByEmail(context.Background(), "viewer@example.test")
+	if err != nil {
+		t.Fatalf("find dynamic admin user: %v", err)
+	}
+	req, _ = http.NewRequest(http.MethodDelete, ts.URL+"/admin/api/v1/authorization/admins/members/"+url.PathEscape(user.ID), nil)
+	req.AddCookie(&http.Cookie{Name: "session_token", Value: "ops-admin-session"})
+	resp, err = http.DefaultClient.Do(req)
+	if err != nil {
+		t.Fatalf("ops-admin DELETE admin member: %v", err)
+	}
+	defer func() { _ = resp.Body.Close() }()
+	if resp.StatusCode != http.StatusOK {
+		respBody, _ := io.ReadAll(resp.Body)
+		t.Fatalf("ops-admin delete admin member status = %d, want 200: %s", resp.StatusCode, respBody)
+	}
+}
+
 func TestAdminAPI_PluginAuthorizationUnavailable(t *testing.T) {
 	t.Parallel()
 
@@ -1840,6 +2176,97 @@ func TestAdminAPI_PluginAuthorizationUnavailable(t *testing.T) {
 	if resp.StatusCode != http.StatusServiceUnavailable {
 		t.Fatalf("members status = %d, want 503", resp.StatusCode)
 	}
+}
+
+func TestAdminAPI_AdminAuthorizationUnavailable(t *testing.T) {
+	t.Parallel()
+
+	t.Run("admin policy unset", func(t *testing.T) {
+		t.Parallel()
+
+		svc := coretesting.NewStubServices(t)
+		authz := mustAuthorizer(t, config.AuthorizationConfig{}, nil, nil, nil)
+		authz.SetAdminAuthorizationService(svc.AdminAuthorizations)
+		if err := authz.ReloadDynamic(context.Background()); err != nil {
+			t.Fatalf("ReloadDynamic: %v", err)
+		}
+
+		ts := newTestServer(t, func(cfg *server.Config) {
+			cfg.Auth = &coretesting.StubAuthProvider{
+				N: "test",
+				ValidateTokenFn: func(_ context.Context, token string) (*core.UserIdentity, error) {
+					if token != "admin-session" {
+						return nil, fmt.Errorf("invalid token")
+					}
+					return &core.UserIdentity{Email: "admin@example.test"}, nil
+				},
+			}
+			cfg.Services = svc
+			cfg.Authorizer = authz
+			cfg.AdminUI = http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+				_, _ = w.Write([]byte("admin"))
+			})
+		})
+		testutil.CloseOnCleanup(t, ts)
+
+		req, _ := http.NewRequest(http.MethodGet, ts.URL+"/admin/api/v1/authorization/admins/members", nil)
+		req.AddCookie(&http.Cookie{Name: "session_token", Value: "admin-session"})
+		resp, err := http.DefaultClient.Do(req)
+		if err != nil {
+			t.Fatalf("GET admin members with admin policy unset: %v", err)
+		}
+		defer func() { _ = resp.Body.Close() }()
+		if resp.StatusCode != http.StatusServiceUnavailable {
+			body, _ := io.ReadAll(resp.Body)
+			t.Fatalf("status = %d, want 503: %s", resp.StatusCode, body)
+		}
+	})
+
+	t.Run("static seed missing", func(t *testing.T) {
+		t.Parallel()
+
+		svc := coretesting.NewStubServices(t)
+		authz := mustAuthorizer(t, config.AuthorizationConfig{
+			Policies: map[string]config.HumanPolicyDef{
+				"admin_policy": {Default: "deny"},
+			},
+		}, nil, nil, nil)
+		seedDynamicAdminMembership(t, svc, authz, "admin@example.test", "admin")
+
+		ts := newTestServer(t, func(cfg *server.Config) {
+			cfg.Auth = &coretesting.StubAuthProvider{
+				N: "test",
+				ValidateTokenFn: func(_ context.Context, token string) (*core.UserIdentity, error) {
+					if token != "admin-session" {
+						return nil, fmt.Errorf("invalid token")
+					}
+					return &core.UserIdentity{Email: "admin@example.test"}, nil
+				},
+			}
+			cfg.Services = svc
+			cfg.Authorizer = authz
+			cfg.Admin = server.AdminRouteConfig{
+				AuthorizationPolicy: "admin_policy",
+				AllowedRoles:        []string{"admin"},
+			}
+			cfg.AdminUI = http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+				_, _ = w.Write([]byte("admin"))
+			})
+		})
+		testutil.CloseOnCleanup(t, ts)
+
+		req, _ := http.NewRequest(http.MethodGet, ts.URL+"/admin/api/v1/authorization/admins/members", nil)
+		req.AddCookie(&http.Cookie{Name: "session_token", Value: "admin-session"})
+		resp, err := http.DefaultClient.Do(req)
+		if err != nil {
+			t.Fatalf("GET admin members without static seed: %v", err)
+		}
+		defer func() { _ = resp.Body.Close() }()
+		if resp.StatusCode != http.StatusServiceUnavailable {
+			body, _ := io.ReadAll(resp.Body)
+			t.Fatalf("status = %d, want 503: %s", resp.StatusCode, body)
+		}
+	})
 }
 
 func TestAdminAPI_PluginAuthorizationPutFailureReturnsServerError(t *testing.T) {
@@ -1881,6 +2308,64 @@ func TestAdminAPI_PluginAuthorizationPutFailureReturnsServerError(t *testing.T) 
 	if resp.StatusCode != http.StatusInternalServerError {
 		respBody, _ := io.ReadAll(resp.Body)
 		t.Fatalf("put dynamic member status = %d, want 500: %s", resp.StatusCode, respBody)
+	}
+}
+
+func TestAdminAPI_AdminAuthorizationPutFailureReturnsServerError(t *testing.T) {
+	t.Parallel()
+
+	svc, failPut := newTestServicesWithAdminAuthorizationPutFailure(t)
+	seedUser(t, svc, "static-admin@example.test")
+	authz := mustAuthorizer(t, config.AuthorizationConfig{
+		Policies: map[string]config.HumanPolicyDef{
+			"admin_policy": {
+				Default: "deny",
+				Members: []config.HumanPolicyMemberDef{
+					{Email: "static-admin@example.test", Role: "admin"},
+				},
+			},
+		},
+	}, nil, nil, nil)
+	authz.SetAdminAuthorizationService(svc.AdminAuthorizations)
+	if err := authz.ReloadDynamic(context.Background()); err != nil {
+		t.Fatalf("ReloadDynamic: %v", err)
+	}
+	failPut.Store(true)
+
+	ts := newTestServer(t, func(cfg *server.Config) {
+		cfg.Auth = &coretesting.StubAuthProvider{
+			N: "test",
+			ValidateTokenFn: func(_ context.Context, token string) (*core.UserIdentity, error) {
+				if token != "admin-session" {
+					return nil, fmt.Errorf("invalid token")
+				}
+				return &core.UserIdentity{Email: "static-admin@example.test"}, nil
+			},
+		}
+		cfg.Services = svc
+		cfg.Authorizer = authz
+		cfg.Admin = server.AdminRouteConfig{
+			AuthorizationPolicy: "admin_policy",
+			AllowedRoles:        []string{"admin"},
+		}
+		cfg.AdminUI = http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+			_, _ = w.Write([]byte("admin"))
+		})
+	})
+	testutil.CloseOnCleanup(t, ts)
+
+	body := bytes.NewBufferString(`{"email":"dynamic-admin@example.test","role":"admin"}`)
+	req, _ := http.NewRequest(http.MethodPut, ts.URL+"/admin/api/v1/authorization/admins/members", body)
+	req.Header.Set("Content-Type", "application/json")
+	req.AddCookie(&http.Cookie{Name: "session_token", Value: "admin-session"})
+	resp, err := http.DefaultClient.Do(req)
+	if err != nil {
+		t.Fatalf("PUT admin member: %v", err)
+	}
+	defer func() { _ = resp.Body.Close() }()
+	if resp.StatusCode != http.StatusInternalServerError {
+		respBody, _ := io.ReadAll(resp.Body)
+		t.Fatalf("put admin member status = %d, want 500: %s", resp.StatusCode, respBody)
 	}
 }
 
@@ -1977,6 +2462,76 @@ func TestMountedWebUIAuthorizationPolicyRequiresExplicitRouteCoverage(t *testing
 				t.Fatalf("server.New error = %v, want substring %q", err, tc.want)
 			}
 		})
+	}
+}
+
+func TestMountedWebUIAuthorizationPolicyNamedBuiltinAdminDoesNotUseAdminResolver(t *testing.T) {
+	t.Parallel()
+
+	dir := t.TempDir()
+	if err := os.WriteFile(filepath.Join(dir, "index.html"), []byte("<html>custom-builtin-admin-name</html>"), 0o644); err != nil {
+		t.Fatalf("WriteFile index.html: %v", err)
+	}
+	handler, err := testutilWebUIHandler(dir)
+	if err != nil {
+		t.Fatalf("webui handler: %v", err)
+	}
+
+	svc := coretesting.NewStubServices(t)
+	seedUser(t, svc, "static-admin@example.test")
+	authz := mustAuthorizer(t, config.AuthorizationConfig{
+		Policies: map[string]config.HumanPolicyDef{
+			"admin_policy": {
+				Default: "deny",
+				Members: []config.HumanPolicyMemberDef{
+					{Email: "static-admin@example.test", Role: "admin"},
+				},
+			},
+			"sample_policy": {
+				Default: "deny",
+			},
+		},
+	}, nil, nil, nil)
+	seedDynamicAdminMembership(t, svc, authz, "dynamic-admin@example.test", "admin")
+
+	ts := newTestServer(t, func(cfg *server.Config) {
+		cfg.Auth = &coretesting.StubAuthProvider{
+			N: "test",
+			ValidateTokenFn: func(_ context.Context, token string) (*core.UserIdentity, error) {
+				if token != "dynamic-admin-session" {
+					return nil, fmt.Errorf("invalid token")
+				}
+				return &core.UserIdentity{Email: "dynamic-admin@example.test"}, nil
+			},
+		}
+		cfg.Services = svc
+		cfg.Authorizer = authz
+		cfg.Admin = server.AdminRouteConfig{
+			AuthorizationPolicy: "admin_policy",
+			AllowedRoles:        []string{"admin"},
+		}
+		cfg.MountedWebUIs = []server.MountedWebUI{{
+			Name:                "builtin_admin",
+			Path:                "/sample-portal",
+			AuthorizationPolicy: "sample_policy",
+			Routes: []server.MountedWebUIRoute{
+				{Path: "/*", AllowedRoles: []string{"admin"}},
+			},
+			Handler: handler,
+		}}
+	})
+	testutil.CloseOnCleanup(t, ts)
+
+	req, _ := http.NewRequest(http.MethodGet, ts.URL+"/sample-portal/", nil)
+	req.AddCookie(&http.Cookie{Name: "session_token", Value: "dynamic-admin-session"})
+	resp, err := http.DefaultClient.Do(req)
+	if err != nil {
+		t.Fatalf("GET custom builtin_admin-named mounted ui: %v", err)
+	}
+	defer func() { _ = resp.Body.Close() }()
+	if resp.StatusCode != http.StatusForbidden {
+		body, _ := io.ReadAll(resp.Body)
+		t.Fatalf("status = %d, want 403: %s", resp.StatusCode, body)
 	}
 }
 


### PR DESCRIPTION
## Summary
- add dynamic built-in admin memberships in coredata and the authorizer snapshot/poller
- switch built-in `/admin` and `/admin/api/v1/*` to resolve admin access through merged static + dynamic admin memberships
- add `/admin/api/v1/authorization/admins/members` CRUD with server-level coverage extended from the existing plugin authorization/admin route tests

## Go interfaces
```go
type AdminAuthorizationMembership struct {
    ID        string
    UserID    string
    Email     string
    Role      string
    CreatedAt time.Time
    UpdatedAt time.Time
}

type AdminAuthorizationService struct { /* ... */ }

func NewAdminAuthorizationService(ds indexeddb.IndexedDB) *AdminAuthorizationService
func (s *AdminAuthorizationService) ListAdminAuthorizations(ctx context.Context) ([]*AdminAuthorizationMembership, error)
func (s *AdminAuthorizationService) UpsertAdminAuthorization(ctx context.Context, membership *AdminAuthorizationMembership) (*AdminAuthorizationMembership, error)
func (s *AdminAuthorizationService) DeleteAdminAuthorization(ctx context.Context, userID string) error

func (a *Authorizer) SetAdminAuthorizationService(svc *coredata.AdminAuthorizationService)
func (a *Authorizer) HasDynamicAdminAuthorizations() bool
func (a *Authorizer) StaticMembersForPolicy(policyName string) ([]StaticHumanMember, bool)
func (a *Authorizer) StaticRoleForPolicyIdentity(policyName, subjectID, userID, email string) (AccessContext, bool)
func (a *Authorizer) ResolveAdminAccess(p *principal.Principal, policyName string) (AccessContext, bool)
```

## YAML interface
```yaml
server:
  admin:
    authorizationPolicy: gestaltAdmin
    allowedRoles:
      - admin

authorization:
  policies:
    gestaltAdmin:
      default: deny
      members:
        - email: hugh@valon.com
          role: admin
```

## HTTP examples
```sh
curl https://gestalt.example.com/admin/api/v1/authorization/admins/members

curl -X PUT https://gestalt.example.com/admin/api/v1/authorization/admins/members \
  -H 'Content-Type: application/json' \
  -d '{"email":"ops@valon.com","role":"admin"}'

curl -X DELETE https://gestalt.example.com/admin/api/v1/authorization/admins/members/usr_123
```

## Behavior examples
- static admin membership still wins over dynamic admin membership
- built-in `/admin` and `/admin/api/v1/*` now honor dynamic admin grants when `server.admin.authorizationPolicy` is configured
- dynamic admin management stays unavailable unless `server.admin.authorizationPolicy` is set and the configured admin policy still has at least one static seed admin

## Verification
- `go test ./internal/server -run 'Test(BuiltInAdminRoute_HumanAuthorization|BuiltInAdminRoute_HumanAuthorizationOnManagementProfile|BuiltInAdminRoute_HumanAuthorizationSplitManagementLoginFlow|AdminAPI_HumanAuthorization|AdminAPI_HumanAuthorizationOnManagementProfile|AdminAPI_HumanAuthorization_UserResolutionFailure|AdminAPI_PluginAuthorizationCRUD|AdminAPI_PluginAuthorizationUnavailable|AdminAPI_AdminAuthorizationCRUD|AdminAPI_AdminAuthorizationUnavailable)$'`
- `go test ./internal/server`
- `go test ./internal/bootstrap ./cmd/gestaltd -run '^$'`
- `go test ./... -run '^$'`
