### PR TITLE
gestaltd: support layered repeated --config files

### DIFF
--- a/docs/content/configuration.mdx
+++ b/docs/content/configuration.mdx
@@ -1,6 +1,6 @@
 # Configuration
 
-Gestalt is configured from a single YAML file. This page covers the key concepts and how to set up each part. The [Config File](/reference/config-file) reference documents every field and its validation rules.
+Gestalt is configured from one or more YAML files. This page covers the key concepts and how to set up each part. The [Config File](/reference/config-file) reference documents every field and its validation rules.
 
 ## Config file structure
 
@@ -379,6 +379,15 @@ When `--config` is not supplied, `gestaltd` looks for a config file in this orde
 
 If nothing is found, `gestaltd` generates a default config at `~/.gestaltd/config.yaml` with SQLite storage, no auth, a random encryption key, and an HTTPBin test plugin.
 
+When `--config` is repeated, Gestalt loads the files left-to-right and merges them with these rules:
+
+- maps deep-merge
+- later scalar values win
+- later lists replace inherited lists
+- `null` deletes inherited keys
+
+Lockfiles and default prepared-artifact paths stay rooted at the leftmost config file. Relative paths resolve from the directory of the file that declared the value, so override files can safely use their own `source.path`, `iconFile`, and `server.artifactsDir` entries.
+
 ### Environment expansion
 
 Gestalt expands `${ENV_VAR}` placeholders before YAML decoding. When a referenced variable is unset, Gestalt checks for a corresponding `ENV_VAR_FILE` variable and reads that file path instead. If neither is set, config loading fails. Use `${ENV_VAR:-}` when an explicit empty default is intentional. This is useful for container runtimes that mount secrets as files.
@@ -389,10 +398,11 @@ Structured secret refs are resolved through the named secret manager during boot
 
 ### Validation
 
-Unknown YAML fields are rejected at load time. Relative paths resolve from the config file's directory. You can check a config without starting the server:
+Unknown YAML fields are rejected at load time. When multiple config files are layered, each relative path resolves from the directory of the file that introduced it. You can check a config without starting the server:
 
 ```sh
 gestaltd validate --config ./config.yaml
+gestaltd validate --config ./deploy/base.yaml --config ./deploy/overrides/local.yaml
 ```
 
 ### Defaults and required fields

--- a/docs/content/reference/cli.mdx
+++ b/docs/content/reference/cli.mdx
@@ -9,12 +9,12 @@ import { Callout } from 'nextra/components'
 | Command | Purpose |
 | --- | --- |
 | `gestaltd` | Local-friendly startup. Generates a config if needed and serves. |
-| `gestaltd serve --config PATH` | Start the server. |
-| `gestaltd serve --locked --config PATH` | Start from lock state. Uses prepared artifacts when present and can materialize missing artifacts from the lockfile. |
+| `gestaltd serve --config PATH` | Start the server. Repeat `--config` to layer overrides. |
+| `gestaltd serve --locked --config PATH` | Start from lock state. Uses prepared artifacts when present and can materialize missing artifacts from the lockfile. Repeat `--config` to layer overrides. |
 | `gestaltd serve --artifacts-dir DIR` | Directory for prepared provider artifacts. |
-| `gestaltd init --config PATH` | Resolve published plugin sources and write lock state. |
+| `gestaltd init --config PATH` | Resolve published plugin sources and write lock state. Repeat `--config` to layer overrides. |
 | `gestaltd init --artifacts-dir DIR` | Directory for prepared provider artifacts. |
-| `gestaltd validate --config PATH` | Validate config without serving. |
+| `gestaltd validate --config PATH` | Validate config without serving. Repeat `--config` to layer overrides. |
 | `gestaltd validate --artifacts-dir DIR` | Directory for prepared provider artifacts. |
 | `gestaltd --version` | Print the server version. |
 
@@ -39,9 +39,16 @@ gestaltd
 gestaltd init --config ./config.yaml
 gestaltd serve --locked --config ./config.yaml
 gestaltd validate --config ./config.yaml
+gestaltd init --config ./base.yaml --config ./overrides/local.yaml
+gestaltd serve --locked --config ./base.yaml --config ./overrides/prod.yaml
 gestaltd provider release --version 0.0.1-alpha.1
 gestaltd provider release --version 0.0.1-alpha.1 --platform all
 gestaltd provider release --version 0.0.1-alpha.1 --platform linux/amd64,linux/arm64
 ```
+
+When repeated, `--config` files merge left-to-right. Maps deep-merge, later
+scalar values win, lists replace inherited lists, and `null` deletes inherited
+keys. Lockfiles and default artifact paths stay rooted at the leftmost config
+file.
 
 See [Configuration](/configuration) for the relationship between `init`, `serve --locked`, and `validate`.

--- a/docs/content/reference/config-file.mdx
+++ b/docs/content/reference/config-file.mdx
@@ -2,11 +2,13 @@ import { Tabs } from 'nextra/components'
 
 # Config File
 
-Every `gestaltd` deployment reads a single YAML config file. The top-level
-keys are `server` (listener, encryption, egress, and host-provider selection),
-`authorization` (shared human/workload access policy), `providers` (named
-auth, secrets, telemetry, audit, UI, indexeddb, cache, and s3 entries), and
-`plugins` (executable integrations and optional plugin-backed UI mounts):
+Every `gestaltd` deployment reads one or more YAML config files. When you pass
+multiple `--config` flags, Gestalt merges them left-to-right before validation
+and bootstrap. The top-level keys are `server` (listener, encryption, egress,
+and host-provider selection), `authorization` (shared human/workload access
+policy), `providers` (named auth, secrets, telemetry, audit, UI, indexeddb,
+cache, and s3 entries), and `plugins` (executable integrations and optional
+plugin-backed UI mounts):
 
 ```yaml
 server:
@@ -30,9 +32,62 @@ plugins: {}
 
 `${ENV_VAR}` references are expanded before YAML decoding. When a referenced variable is unset, Gestalt checks for a corresponding `ENV_VAR_FILE` variable and reads that file path instead. If neither is set, config loading fails. Use `${ENV_VAR:-}` when an explicit empty default is intentional. Unknown YAML fields are rejected.
 
-Several fields carry defaults when omitted: `server.public.port` defaults to `8080`; the runtime secrets manager defaults to builtin `env` when `providers.secrets` is omitted; `providers.telemetry.default` defaults to builtin `stdout`; and `providers.audit.default` defaults to builtin `inherit`. Relative paths resolve relative to the config file's directory. Structured secret refs are resolved during bootstrap, not during YAML parsing.
+When multiple config files are loaded, Gestalt applies these merge rules:
+
+- maps deep-merge left-to-right
+- later scalar values win
+- later lists replace inherited lists
+- `null` deletes an inherited key
+
+Relative file paths resolve relative to the config file that introduced them.
+That includes `source.path`, `iconFile`, and `server.artifactsDir`. Lockfiles
+and default artifact directories stay rooted at the leftmost config file.
+
+Several fields carry defaults when omitted: `server.public.port` defaults to `8080`; the runtime secrets manager defaults to builtin `env` when `providers.secrets` is omitted; `providers.telemetry.default` defaults to builtin `stdout`; and `providers.audit.default` defaults to builtin `inherit`. Structured secret refs are resolved during bootstrap, not during YAML parsing.
 
 `authorization` is the canonical location for shared human and workload access policy. Existing deployments may continue to use `server.authorization` as a deprecated compatibility alias; Gestalt normalizes it into the top-level block during config load and bootstrap.
+
+### Layered example
+
+Base config:
+
+```yaml
+server:
+  encryptionKey: ${GESTALT_ENCRYPTION_KEY}
+  public:
+    port: 8080
+plugins:
+  github:
+    source:
+      path: ./plugins/github/manifest.yaml
+    allowedHosts:
+      - api.github.com
+      - uploads.github.com
+```
+
+Override:
+
+```yaml
+server:
+  management:
+    port: 9090
+plugins:
+  github:
+    allowedHosts:
+      - api.github.com
+    iconFile: ./icons/github.svg
+    displayName: null
+```
+
+Run:
+
+```sh
+gestaltd validate --config ./base.yaml --config ./overrides/local.yaml
+```
+
+The resulting config keeps `server.public.port`, adds `server.management.port`,
+replaces `plugins.github.allowedHosts`, resolves `iconFile` relative to
+`./overrides/local.yaml`, and deletes the inherited `displayName`.
 
 ## `server`
 

--- a/gestaltd/cmd/gestaltd/e2e_test.go
+++ b/gestaltd/cmd/gestaltd/e2e_test.go
@@ -185,6 +185,63 @@ params:
 	}
 }
 
+func TestE2EValidateRejectsUnknownYAMLFieldInOverriddenAwayBranch(t *testing.T) {
+	t.Parallel()
+
+	cases := []struct {
+		name            string
+		baseServerExtra string
+		overrideCfg     string
+	}{
+		{
+			name: "masked branch still fails",
+			overrideCfg: `plugins:
+  example: null
+`,
+		},
+		{
+			name:            "masked branch still fails when base has unrelated missing env fixed later",
+			baseServerExtra: "  baseUrl: ${GESTALT_TEST_BASE_URL}\n",
+			overrideCfg: `server:
+  baseUrl: https://example.test
+plugins:
+  example: null
+`,
+		},
+	}
+
+	for _, tc := range cases {
+		tc := tc
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+
+			dir := t.TempDir()
+			basePath := filepath.Join(dir, "base.yaml")
+			overridePath := filepath.Join(dir, "override.yaml")
+			baseCfg := "server:\n  encryptionKey: test-key\n" + tc.baseServerExtra + authIndexedDBConfigYAML(t, dir, "local", "sqlite", filepath.Join(dir, "gestalt.db")) + `plugins:
+  example:
+    source:
+      path: /tmp/manifest.yaml
+    dispalyName: Example
+`
+			if err := os.WriteFile(basePath, []byte(baseCfg), 0o644); err != nil {
+				t.Fatalf("WriteFile base config: %v", err)
+			}
+			if err := os.WriteFile(overridePath, []byte(tc.overrideCfg), 0o644); err != nil {
+				t.Fatalf("WriteFile override config: %v", err)
+			}
+
+			out, err := exec.Command(gestaltdBin, "validate", "--config", basePath, "--config", overridePath).CombinedOutput()
+			if err == nil {
+				t.Fatalf("expected validate to fail for masked unknown field, output: %s", out)
+			}
+			if !strings.Contains(string(out), "dispalyName") || !strings.Contains(string(out), "parsing config YAML") {
+				t.Fatalf("expected output to mention dispalyName and YAML parsing, got: %s", out)
+			}
+		})
+	}
+}
+
 //nolint:paralleltest // Spawns the CLI binary; keeping it serial avoids package-level e2e flake.
 func TestE2EValidateRejectsMalformedYAML(t *testing.T) {
 	dir := t.TempDir()
@@ -272,6 +329,70 @@ func TestE2EValidateRejectsMalformedStructuredSecretRef(t *testing.T) {
 				t.Fatalf("expected output to mention %q, got: %s", tc.wantError, out)
 			}
 		})
+	}
+}
+
+func TestE2EValidateAcceptsLayeredConfigs(t *testing.T) {
+	t.Parallel()
+
+	rootDir := t.TempDir()
+	baseDir := filepath.Join(rootDir, "base")
+	overrideDir := filepath.Join(rootDir, "overrides")
+	if err := os.MkdirAll(baseDir, 0o755); err != nil {
+		t.Fatalf("MkdirAll base: %v", err)
+	}
+	if err := os.MkdirAll(overrideDir, 0o755); err != nil {
+		t.Fatalf("MkdirAll overrides: %v", err)
+	}
+
+	indexedDBManifest := componentProviderManifestPath(t, setupIndexedDBProviderDir(t, rootDir))
+	setupPluginDir(t, overrideDir)
+
+	baseConfigPath := filepath.Join(baseDir, "base.yaml")
+	baseConfig := fmt.Sprintf(`server:
+  encryptionKey: test-key
+  providers:
+    indexeddb: sqlite
+providers:
+  indexeddb:
+    sqlite:
+      source:
+        path: %s
+      config:
+        path: %q
+plugins:
+  example:
+    source:
+      path: ./missing/manifest.yaml
+`, indexedDBManifest, filepath.Join(rootDir, "gestalt.db"))
+	if err := os.WriteFile(baseConfigPath, []byte(baseConfig), 0o644); err != nil {
+		t.Fatalf("WriteFile base config: %v", err)
+	}
+
+	overrideConfigPath := filepath.Join(overrideDir, "local.yaml")
+	overrideConfig := `plugins:
+  example:
+    source:
+      path: ./plugin-src/manifest.yaml
+`
+	if err := os.WriteFile(overrideConfigPath, []byte(overrideConfig), 0o644); err != nil {
+		t.Fatalf("WriteFile override config: %v", err)
+	}
+
+	out, err := exec.Command(gestaltdBin, "validate", "--config", baseConfigPath).CombinedOutput()
+	if err == nil {
+		t.Fatalf("expected base config validate to fail, output: %s", out)
+	}
+	if !strings.Contains(string(out), "missing/manifest.yaml") {
+		t.Fatalf("expected base config failure to mention missing manifest, got: %s", out)
+	}
+
+	out, err = exec.Command(gestaltdBin, "validate", "--config", baseConfigPath, "--config", overrideConfigPath).CombinedOutput()
+	if err != nil {
+		t.Fatalf("expected layered config validate to succeed: %v\n%s", err, out)
+	}
+	if !strings.Contains(string(out), "config ok") {
+		t.Fatalf("expected layered config output to mention success, got: %s", out)
 	}
 }
 
@@ -624,23 +745,34 @@ plugins:
 	return cfgPath
 }
 
-func startGestaltdWithConfig(t *testing.T, cfgPath string) string {
+func startGestaltdWithConfigs(t *testing.T, cfgPaths []string, locked bool) string {
 	t.Helper()
+	if len(cfgPaths) == 0 {
+		t.Fatal("startGestaltdWithConfigs requires at least one config path")
+	}
 
 	port, holder := reservePort(t)
 	baseURL := fmt.Sprintf("http://127.0.0.1:%d", port)
 
-	cfgBytes, err := os.ReadFile(cfgPath)
+	primaryCfgPath := cfgPaths[0]
+	cfgBytes, err := os.ReadFile(primaryCfgPath)
 	if err != nil {
 		t.Fatalf("read config: %v", err)
 	}
 	cfg := strings.Replace(string(cfgBytes), "port: 0", fmt.Sprintf("port: %d", port), 1)
-	if err := os.WriteFile(cfgPath, []byte(cfg), 0o644); err != nil {
+	if err := os.WriteFile(primaryCfgPath, []byte(cfg), 0o644); err != nil {
 		t.Fatalf("write config: %v", err)
 	}
 
 	_ = holder.Close()
-	cmd := exec.Command(gestaltdBin, "serve", "--config", cfgPath)
+	args := []string{"serve"}
+	if locked {
+		args = append(args, "--locked")
+	}
+	for _, cfgPath := range cfgPaths {
+		args = append(args, "--config", cfgPath)
+	}
+	cmd := exec.Command(gestaltdBin, args...)
 	cmd.Stdout = os.Stderr
 	cmd.Stderr = os.Stderr
 	if err := cmd.Start(); err != nil {
@@ -685,6 +817,11 @@ func startGestaltdWithConfig(t *testing.T, cfgPath string) string {
 	}
 
 	return baseURL
+}
+
+func startGestaltdWithConfig(t *testing.T, cfgPath string) string {
+	t.Helper()
+	return startGestaltdWithConfigs(t, []string{cfgPath}, false)
 }
 
 func startGestaltd(t *testing.T, dir string, mountedUI *mountedUITestConfig) string {
@@ -904,6 +1041,37 @@ func TestE2EInitLocalProviders(t *testing.T) {
 	}
 }
 
+func TestE2EInitAndServeLayeredConfigs(t *testing.T) {
+	t.Parallel()
+
+	if testing.Short() {
+		t.Skip("skipping layered config E2E test in short mode")
+	}
+
+	dir := t.TempDir()
+	basePath, overridePath, lockPath, _ := writeLayeredE2EConfigs(t, dir, 0)
+
+	out, err := exec.Command(gestaltdBin, "init", "--config", basePath, "--config", overridePath).CombinedOutput()
+	if err != nil {
+		t.Fatalf("gestaltd init with layered configs failed: %v\noutput: %s", err, out)
+	}
+	if _, err := os.Stat(lockPath); err != nil {
+		t.Fatalf("expected lock file at %s: %v", lockPath, err)
+	}
+
+	baseURL := startGestaltdWithConfigs(t, []string{basePath, overridePath}, true)
+	client := &http.Client{Timeout: 2 * time.Second}
+	resp, err := client.Get(baseURL + "/api/v1/integrations")
+	if err != nil {
+		t.Fatalf("GET /api/v1/integrations: %v", err)
+	}
+	defer func() { _ = resp.Body.Close() }()
+	body, _ := io.ReadAll(resp.Body)
+	if resp.StatusCode != http.StatusUnauthorized {
+		t.Fatalf("expected /api/v1/integrations 401 with layered auth override, got %d: %s", resp.StatusCode, body)
+	}
+}
+
 func TestE2EServeLockedRejectsGenericArchiveForExecutablePlugin(t *testing.T) {
 	t.Parallel()
 
@@ -1116,6 +1284,71 @@ func TestE2EMountedWebUI(t *testing.T) {
 func writeE2EConfig(t *testing.T, dir, pluginDir string, port int) string {
 	t.Helper()
 	return writeE2EConfigWithPaths(t, dir, pluginDir, filepath.Join(dir, "gestalt.db"), "", port)
+}
+
+func writeLayeredE2EConfigs(t *testing.T, dir string, port int) (string, string, string, string) {
+	t.Helper()
+
+	deployDir := filepath.Join(dir, "deploy")
+	overrideDir := filepath.Join(deployDir, "overrides")
+	if err := os.MkdirAll(overrideDir, 0o755); err != nil {
+		t.Fatalf("MkdirAll(%s): %v", overrideDir, err)
+	}
+
+	indexedDBManifest := componentProviderManifestPath(t, setupIndexedDBProviderDir(t, dir))
+	pluginManifest := componentProviderManifestPath(t, setupPrebuiltPluginDir(t, dir))
+	authManifest := componentProviderManifestPath(t, setupAuthProviderDir(t, dir, "local"))
+
+	indexedDBRel, err := filepath.Rel(deployDir, indexedDBManifest)
+	if err != nil {
+		t.Fatalf("filepath.Rel(indexeddb): %v", err)
+	}
+	pluginRel, err := filepath.Rel(deployDir, pluginManifest)
+	if err != nil {
+		t.Fatalf("filepath.Rel(plugin): %v", err)
+	}
+	authRel, err := filepath.Rel(overrideDir, authManifest)
+	if err != nil {
+		t.Fatalf("filepath.Rel(auth): %v", err)
+	}
+
+	basePath := filepath.Join(deployDir, "base.yaml")
+	overridePath := filepath.Join(overrideDir, "local.yaml")
+	baseCfg := fmt.Sprintf(`server:
+  public:
+    port: %d
+  encryptionKey: test-layered-e2e-key
+  providers:
+    indexeddb: inmem
+providers:
+  indexeddb:
+    inmem:
+      source:
+        path: %s
+plugins:
+  example:
+    source:
+      path: %s
+`, port, filepath.ToSlash(indexedDBRel), filepath.ToSlash(pluginRel))
+	overrideCfg := fmt.Sprintf(`server:
+  providers:
+    auth: local
+  artifactsDir: ../artifacts/local
+providers:
+  auth:
+    local:
+      source:
+        path: %s
+`, filepath.ToSlash(authRel))
+
+	if err := os.WriteFile(basePath, []byte(baseCfg), 0o644); err != nil {
+		t.Fatalf("write base config: %v", err)
+	}
+	if err := os.WriteFile(overridePath, []byte(overrideCfg), 0o644); err != nil {
+		t.Fatalf("write override config: %v", err)
+	}
+
+	return basePath, overridePath, filepath.Join(deployDir, "gestalt.lock.json"), filepath.Join(deployDir, "artifacts", "local")
 }
 
 func writeE2EConfigWithPaths(t *testing.T, dir, pluginDir, dbPath, artifactsDir string, port int) string {

--- a/gestaltd/cmd/gestaltd/factories.go
+++ b/gestaltd/cmd/gestaltd/factories.go
@@ -35,8 +35,8 @@ type bootstrapEnv struct {
 	prevLogger *slog.Logger
 }
 
-func setupBootstrapWithArtifactsDir(configFlag, artifactsDir string, locked bool) (*bootstrapEnv, error) {
-	_, cfg, err := loadConfigForExecutionWithArtifactsDir(configFlag, artifactsDir, locked)
+func setupBootstrapWithArtifactsDir(configFlags []string, artifactsDir string, locked bool) (*bootstrapEnv, error) {
+	_, cfg, err := loadConfigForExecutionWithArtifactsDir(configFlags, artifactsDir, locked)
 	if err != nil {
 		return nil, err
 	}
@@ -126,25 +126,33 @@ func buildFactories() *bootstrap.FactoryRegistry {
 	return factories
 }
 
-func resolveConfigPath(flagValue string) string {
-	if flagValue != "" {
-		return flagValue
+func resolveConfigPaths(flagValues []string) []string {
+	if len(flagValues) > 0 {
+		return append([]string(nil), flagValues...)
 	}
 	if envPath := os.Getenv("GESTALT_CONFIG"); envPath != "" {
-		return envPath
+		return []string{envPath}
 	}
 	if _, err := os.Stat("config.yaml"); err == nil {
-		return "config.yaml"
+		return []string{"config.yaml"}
 	}
 	for _, p := range operator.LocalConfigPaths() {
 		if p == "" {
 			continue
 		}
 		if _, err := os.Stat(p); err == nil {
-			return p
+			return []string{p}
 		}
 	}
-	return operator.DefaultLocalConfigPath()
+	return []string{operator.DefaultLocalConfigPath()}
+}
+
+func resolvePrimaryConfigPath(flagValues []string) string {
+	configPaths := resolveConfigPaths(flagValues)
+	if len(configPaths) == 0 {
+		return ""
+	}
+	return configPaths[0]
 }
 
 const gracefulShutdownTimeout = 15 * time.Second

--- a/gestaltd/cmd/gestaltd/init.go
+++ b/gestaltd/cmd/gestaltd/init.go
@@ -15,10 +15,10 @@ func operatorLifecycle() *operator.Lifecycle {
 	})
 }
 
-func initConfigWithArtifactsDir(configFlag, artifactsDir, platformFlag string) error {
-	configPath := resolveConfigPath(configFlag)
+func initConfigWithArtifactsDir(configFlags []string, artifactsDir, platformFlag string) error {
+	configPaths := resolveConfigPaths(configFlags)
 	if platformFlag == "" {
-		_, err := operatorLifecycle().InitAtPathWithArtifactsDir(configPath, artifactsDir)
+		_, err := operatorLifecycle().InitAtPathsWithArtifactsDir(configPaths, artifactsDir)
 		return err
 	}
 
@@ -36,15 +36,15 @@ func initConfigWithArtifactsDir(configFlag, artifactsDir, platformFlag string) e
 		platArgs[i] = struct{ GOOS, GOARCH, LibC string }{p.GOOS, p.GOARCH, ""}
 	}
 
-	_, err = operatorLifecycle().InitAtPathWithPlatforms(configPath, artifactsDir, platArgs)
+	_, err = operatorLifecycle().InitAtPathsWithPlatforms(configPaths, artifactsDir, platArgs)
 	return err
 }
 
-func loadConfigForExecutionWithArtifactsDir(configFlag, artifactsDir string, locked bool) (string, *config.Config, error) {
-	configPath := resolveConfigPath(configFlag)
-	cfg, _, err := operatorLifecycle().LoadForExecutionAtPathWithArtifactsDir(configPath, artifactsDir, locked)
+func loadConfigForExecutionWithArtifactsDir(configFlags []string, artifactsDir string, locked bool) ([]string, *config.Config, error) {
+	configPaths := resolveConfigPaths(configFlags)
+	cfg, _, err := operatorLifecycle().LoadForExecutionAtPathsWithArtifactsDir(configPaths, artifactsDir, locked)
 	if err != nil {
-		return "", nil, err
+		return nil, nil, err
 	}
-	return configPath, cfg, nil
+	return configPaths, cfg, nil
 }

--- a/gestaltd/cmd/gestaltd/main_test.go
+++ b/gestaltd/cmd/gestaltd/main_test.go
@@ -18,18 +18,18 @@ func TestE2ECLIHelp(t *testing.T) {
 		{
 			name:      "root",
 			args:      []string{"--help"},
-			wantParts: []string{"gestaltd validate", "gestaltd init", "gestaltd provider <command> [flags]", "gestaltd serve", "--locked"},
+			wantParts: []string{"gestaltd validate", "gestaltd init", "gestaltd provider <command> [flags]", "gestaltd serve", "--locked", "[--config PATH]..."},
 			notWant:   []string{"gestaltd bundle", "gestaltd dev"},
 		},
 		{
 			name:      "validate",
 			args:      []string{"validate", "--help"},
-			wantParts: []string{"gestaltd validate"},
+			wantParts: []string{"gestaltd validate", "Repeated --config flags merge left-to-right."},
 		},
 		{
 			name:      "init",
 			args:      []string{"init", "--help"},
-			wantParts: []string{"gestaltd init"},
+			wantParts: []string{"gestaltd init", "When repeated, --config files merge left-to-right."},
 		},
 		{
 			name:      "provider",

--- a/gestaltd/cmd/gestaltd/run.go
+++ b/gestaltd/cmd/gestaltd/run.go
@@ -30,6 +30,17 @@ import (
 	mcpserver "github.com/mark3labs/mcp-go/server"
 )
 
+type repeatedStringFlag []string
+
+func (f *repeatedStringFlag) String() string {
+	return strings.Join(*f, ",")
+}
+
+func (f *repeatedStringFlag) Set(value string) error {
+	*f = append(*f, value)
+	return nil
+}
+
 func run(args []string) error {
 	if len(args) > 0 {
 		switch args[0] {
@@ -62,7 +73,8 @@ func runDefaultServe(args []string) error {
 func runServe(args []string) error {
 	fs := flag.NewFlagSet("gestaltd serve", flag.ContinueOnError)
 	fs.Usage = func() { printServeUsage(fs.Output()) }
-	configPath := fs.String("config", "", "path to config file")
+	var configPaths repeatedStringFlag
+	fs.Var(&configPaths, "config", "path to config file (repeat to layer overrides)")
 	artifactsDir := fs.String("artifacts-dir", "", "path to writable prepared-artifacts directory")
 	locked := fs.Bool("locked", false, "require exact lock state; do not auto-init")
 	if err := fs.Parse(args); err != nil {
@@ -72,7 +84,7 @@ func runServe(args []string) error {
 		return fmt.Errorf("unexpected arguments: %s", strings.Join(fs.Args(), " "))
 	}
 
-	env, err := setupBootstrapWithArtifactsDir(*configPath, *artifactsDir, *locked)
+	env, err := setupBootstrapWithArtifactsDir(configPaths, *artifactsDir, *locked)
 	if err != nil {
 		return err
 	}
@@ -82,7 +94,8 @@ func runServe(args []string) error {
 func runStartCommand(name string, usage func(io.Writer), args []string, locked bool, autoGenerate bool) error {
 	fs := flag.NewFlagSet(name, flag.ContinueOnError)
 	fs.Usage = func() { usage(fs.Output()) }
-	configPath := fs.String("config", "", "path to config file")
+	var configPaths repeatedStringFlag
+	fs.Var(&configPaths, "config", "path to config file (repeat to layer overrides)")
 	artifactsDir := fs.String("artifacts-dir", "", "path to writable prepared-artifacts directory")
 	if err := fs.Parse(args); err != nil {
 		return err
@@ -91,19 +104,19 @@ func runStartCommand(name string, usage func(io.Writer), args []string, locked b
 		return fmt.Errorf("unexpected arguments: %s", strings.Join(fs.Args(), " "))
 	}
 
-	if autoGenerate && *configPath == "" {
-		resolved := resolveConfigPath("")
+	if autoGenerate && len(configPaths) == 0 {
+		resolved := resolvePrimaryConfigPath(nil)
 		if _, err := os.Stat(resolved); os.IsNotExist(err) {
 			if p := operator.DefaultLocalConfigPath(); p != "" {
 				generated, genErr := operator.GenerateDefaultConfig(filepath.Dir(p))
 				if genErr == nil {
-					*configPath = generated
+					configPaths = append(configPaths, generated)
 				}
 			}
 		}
 	}
 
-	env, err := setupBootstrapWithArtifactsDir(*configPath, *artifactsDir, locked)
+	env, err := setupBootstrapWithArtifactsDir(configPaths, *artifactsDir, locked)
 	if err != nil {
 		return err
 	}
@@ -455,7 +468,8 @@ func (s mcpSurface) handler(result *bootstrap.Result, invoker invocation.Invoker
 func runInit(args []string) error {
 	fs := flag.NewFlagSet("gestaltd init", flag.ContinueOnError)
 	fs.Usage = func() { printInitUsage(fs.Output()) }
-	configPath := fs.String("config", "", "path to config file")
+	var configPaths repeatedStringFlag
+	fs.Var(&configPaths, "config", "path to config file (repeat to layer overrides)")
 	artifactsDir := fs.String("artifacts-dir", "", "path to writable prepared-artifacts directory")
 	platformFlag := fs.String("platform", "", "additional platforms to verify hashes for (comma-separated os/arch[/libc] or \"all\")")
 	if err := fs.Parse(args); err != nil {
@@ -465,13 +479,14 @@ func runInit(args []string) error {
 		return fmt.Errorf("unexpected arguments: %s", strings.Join(fs.Args(), " "))
 	}
 
-	return initConfigWithArtifactsDir(*configPath, *artifactsDir, *platformFlag)
+	return initConfigWithArtifactsDir(configPaths, *artifactsDir, *platformFlag)
 }
 
 func runValidate(args []string) error {
 	fs := flag.NewFlagSet("gestaltd validate", flag.ContinueOnError)
 	fs.Usage = func() { printValidateUsage(fs.Output()) }
-	configPath := fs.String("config", "", "path to config file")
+	var configPaths repeatedStringFlag
+	fs.Var(&configPaths, "config", "path to config file (repeat to layer overrides)")
 	artifactsDir := fs.String("artifacts-dir", "", "path to writable prepared-artifacts directory")
 	if err := fs.Parse(args); err != nil {
 		return err
@@ -480,11 +495,11 @@ func runValidate(args []string) error {
 		return fmt.Errorf("unexpected arguments: %s", strings.Join(fs.Args(), " "))
 	}
 
-	return validateConfigWithArtifactsDir(*configPath, *artifactsDir)
+	return validateConfigWithArtifactsDir(configPaths, *artifactsDir)
 }
 
-func validateConfigWithArtifactsDir(configFlag, artifactsDir string) error {
-	path, cfg, err := loadConfigForExecutionWithArtifactsDir(configFlag, artifactsDir, true)
+func validateConfigWithArtifactsDir(configFlags []string, artifactsDir string) error {
+	paths, cfg, err := loadConfigForExecutionWithArtifactsDir(configFlags, artifactsDir, true)
 	if err != nil {
 		return err
 	}
@@ -494,7 +509,7 @@ func validateConfigWithArtifactsDir(configFlag, artifactsDir string) error {
 		return err
 	}
 
-	logConfigSummary(path, cfg)
+	logConfigSummary(paths, cfg)
 	for _, w := range warnings {
 		slog.Warn(w)
 	}
@@ -502,9 +517,9 @@ func validateConfigWithArtifactsDir(configFlag, artifactsDir string) error {
 	return nil
 }
 
-func logConfigSummary(path string, cfg *config.Config) {
+func logConfigSummary(paths []string, cfg *config.Config) {
 	slog.Info("config loaded",
-		"config_file", path,
+		"config_files", paths,
 		"server_port", cfg.Server.PublicListener().Port,
 		"server_public_addr", cfg.Server.PublicAddr(),
 		"server_management_addr", maskEmpty(cfg.Server.ManagementAddr()),
@@ -561,11 +576,11 @@ func maskEmpty(s string) string {
 
 func printMainUsage(w io.Writer) {
 	writeUsageLine(w, "Usage:")
-	writeUsageLine(w, "  gestaltd [--config PATH] [--artifacts-dir PATH]")
-	writeUsageLine(w, "  gestaltd init [--config PATH] [--artifacts-dir PATH] [--platform PLATFORMS]")
-	writeUsageLine(w, "  gestaltd serve [--config PATH] [--artifacts-dir PATH] [--locked]")
+	writeUsageLine(w, "  gestaltd [--config PATH]... [--artifacts-dir PATH]")
+	writeUsageLine(w, "  gestaltd init [--config PATH]... [--artifacts-dir PATH] [--platform PLATFORMS]")
+	writeUsageLine(w, "  gestaltd serve [--config PATH]... [--artifacts-dir PATH] [--locked]")
 	writeUsageLine(w, "  gestaltd provider <command> [flags]")
-	writeUsageLine(w, "  gestaltd validate [--config PATH] [--artifacts-dir PATH]")
+	writeUsageLine(w, "  gestaltd validate [--config PATH]... [--artifacts-dir PATH]")
 	writeUsageLine(w, "")
 	writeUsageLine(w, "Commands:")
 	writeUsageLine(w, "  init        Resolve providers and plugins and write lock state")
@@ -575,23 +590,25 @@ func printMainUsage(w io.Writer) {
 	writeUsageLine(w, "  version     Print the version and exit")
 	writeUsageLine(w, "")
 	writeUsageLine(w, "Flags:")
-	writeUsageLine(w, "  --config          Path to the config file")
+	writeUsageLine(w, "  --config          Path to a config file; repeat to layer left-to-right")
 	writeUsageLine(w, "  --artifacts-dir   Path to writable prepared-artifacts directory")
 }
 
 func printServeUsage(w io.Writer) {
 	writeUsageLine(w, "Usage:")
-	writeUsageLine(w, "  gestaltd serve [--config PATH] [--artifacts-dir PATH] [--locked]")
+	writeUsageLine(w, "  gestaltd serve [--config PATH]... [--artifacts-dir PATH] [--locked]")
 	writeUsageLine(w, "")
 	writeUsageLine(w, "Start the server. Auto-inits if lock state is missing or stale.")
 	writeUsageLine(w, "For production, strongly prefer --locked so startup uses the pinned")
 	writeUsageLine(w, "lockfile state instead of resolving new artifacts or mutating state.")
 	writeUsageLine(w, "When locked, run `gestaltd init` first to prepare artifacts.")
+	writeUsageLine(w, "When repeated, --config files merge left-to-right. Maps deep-merge,")
+	writeUsageLine(w, "later scalars win, lists replace, and null deletes inherited keys.")
 }
 
 func printInitUsage(w io.Writer) {
 	writeUsageLine(w, "Usage:")
-	writeUsageLine(w, "  gestaltd init [--config PATH] [--artifacts-dir PATH] [--platform PLATFORMS]")
+	writeUsageLine(w, "  gestaltd init [--config PATH]... [--artifacts-dir PATH] [--platform PLATFORMS]")
 	writeUsageLine(w, "")
 	writeUsageLine(w, "Resolve managed plugin sources and write lock state.")
 	writeUsageLine(w, "Creates gestalt.lock.json in the config directory and prepared artifacts")
@@ -599,18 +616,20 @@ func printInitUsage(w io.Writer) {
 	writeUsageLine(w, "discovered platforms and verified SHA256 hashes for the current platform.")
 	writeUsageLine(w, "Use --platform to pre-verify hashes for additional deploy targets.")
 	writeUsageLine(w, "Use this before `gestaltd serve --locked` for production deployments.")
+	writeUsageLine(w, "When repeated, --config files merge left-to-right.")
 	writeUsageLine(w, "")
 	writeUsageLine(w, "Flags:")
-	writeUsageLine(w, "  --config          Path to the config file")
+	writeUsageLine(w, "  --config          Path to a config file; repeat to layer left-to-right")
 	writeUsageLine(w, "  --artifacts-dir   Path to writable prepared-artifacts directory")
 	writeUsageLine(w, "  --platform        Additional platforms to verify (comma-separated os/arch[/libc] or \"all\")")
 }
 
 func printValidateUsage(w io.Writer) {
 	writeUsageLine(w, "Usage:")
-	writeUsageLine(w, "  gestaltd validate [--config PATH] [--artifacts-dir PATH]")
+	writeUsageLine(w, "  gestaltd validate [--config PATH]... [--artifacts-dir PATH]")
 	writeUsageLine(w, "")
 	writeUsageLine(w, "Validate configuration without starting the server or running migrations.")
+	writeUsageLine(w, "Repeated --config flags merge left-to-right.")
 }
 
 func writeUsageLine(w io.Writer, line string) {

--- a/gestaltd/internal/config/config.go
+++ b/gestaltd/internal/config/config.go
@@ -640,15 +640,27 @@ func EffectiveNamedConnectionDef(plugin *ProviderEntry, manifestPlugin *provider
 type OperationOverride = providermanifestv1.ManifestOperationOverride
 
 func Load(path string) (*Config, error) {
-	return loadWithLookup(path, os.LookupEnv, false)
+	return LoadPaths([]string{path})
+}
+
+func LoadPaths(paths []string) (*Config, error) {
+	return loadWithLookupPaths(paths, os.LookupEnv, false)
 }
 
 func LoadWithLookup(path string, lookup func(string) (string, bool)) (*Config, error) {
-	return loadWithLookup(path, lookup, false)
+	return LoadWithLookupPaths([]string{path}, lookup)
+}
+
+func LoadWithLookupPaths(paths []string, lookup func(string) (string, bool)) (*Config, error) {
+	return loadWithLookupPaths(paths, lookup, false)
 }
 
 func LoadAllowMissingEnv(path string) (*Config, error) {
-	return loadWithLookup(path, os.LookupEnv, true)
+	return LoadAllowMissingEnvPaths([]string{path})
+}
+
+func LoadAllowMissingEnvPaths(paths []string) (*Config, error) {
+	return loadWithLookupPaths(paths, os.LookupEnv, true)
 }
 
 func NormalizeCompatibility(cfg *Config) error {
@@ -662,17 +674,12 @@ func NormalizeCompatibility(cfg *Config) error {
 }
 
 func OverlayManagedPluginConfig(path string, cfg *Config) error {
-	data, err := os.ReadFile(path)
-	if err != nil {
-		return fmt.Errorf("reading config file: %w", err)
-	}
+	return OverlayManagedPluginConfigPaths([]string{path}, cfg)
+}
 
-	var root yaml.Node
-	dec := yaml.NewDecoder(strings.NewReader(string(data)))
-	if err := dec.Decode(&root); err != nil && err != io.EOF {
-		return fmt.Errorf("parsing config YAML: %w", err)
-	}
-	if err := normalizeConfigRoot(&root); err != nil {
+func OverlayManagedPluginConfigPaths(paths []string, cfg *Config) error {
+	root, err := loadMergedConfigRoot(paths, os.LookupEnv, envMissingPreserve, "")
+	if err != nil {
 		return err
 	}
 	doc := documentValueNode(&root)
@@ -729,6 +736,14 @@ func OverlayManagedPluginConfig(path string, cfg *Config) error {
 	return nil
 }
 
+type envMissingMode int
+
+const (
+	envMissingBlank envMissingMode = iota
+	envMissingSentinel
+	envMissingPreserve
+)
+
 func overlayManagedEntryConfigNode(raw *yaml.Node, entry *ProviderEntry, subject string) error {
 	if entry == nil || !entry.HasManagedSource() || raw == nil {
 		return nil
@@ -783,34 +798,20 @@ func normalizeConfigRoot(root *yaml.Node) error {
 	return nil
 }
 
-func loadWithLookup(path string, lookup func(string) (string, bool), allowMissing bool) (*Config, error) {
-	data, err := os.ReadFile(path)
-	if err != nil {
-		return nil, fmt.Errorf("reading config file: %w", err)
-	}
-
-	var (
-		resolved                  string
-		missingEnvSentinelContext string
-	)
-	if allowMissing {
-		resolved, _, err = expandEnvVariables(string(data), lookup, false)
-	} else {
+func loadWithLookupPaths(paths []string, lookup func(string) (string, bool), allowMissing bool) (*Config, error) {
+	mode := envMissingBlank
+	missingEnvSentinelContext := ""
+	if !allowMissing {
+		mode = envMissingSentinel
+		var err error
 		missingEnvSentinelContext, err = newMissingEnvSentinelPrefix()
-		if err == nil {
-			resolved, err = expandEnvVariablesWithMissingSentinels(string(data), lookup, missingEnvSentinelContext)
+		if err != nil {
+			return nil, err
 		}
 	}
-	if err != nil {
-		return nil, err
-	}
 
-	var root yaml.Node
-	normalizeDecoder := yaml.NewDecoder(strings.NewReader(resolved))
-	if err := normalizeDecoder.Decode(&root); err != nil && err != io.EOF {
-		return nil, fmt.Errorf("parsing config YAML: %w", err)
-	}
-	if err := normalizeConfigRoot(&root); err != nil {
+	root, err := loadMergedConfigRoot(paths, lookup, mode, missingEnvSentinelContext)
+	if err != nil {
 		return nil, err
 	}
 	if err := rejectRemovedDisabledFields(&root); err != nil {
@@ -846,13 +847,256 @@ func loadWithLookup(path string, lookup func(string) (string, bool), allowMissin
 		return nil, err
 	}
 	resolveBaseURL(&cfg)
-	resolveRelativePaths(path, &cfg)
+	resolveRelativePaths(primaryConfigPath(paths), &cfg)
 
 	if err := ValidateStructure(&cfg); err != nil {
 		return nil, err
 	}
 
 	return &cfg, nil
+}
+
+func primaryConfigPath(paths []string) string {
+	if len(paths) == 0 {
+		return ""
+	}
+	return paths[0]
+}
+
+func loadMergedConfigRoot(paths []string, lookup func(string) (string, bool), mode envMissingMode, sentinelPrefix string) (yaml.Node, error) {
+	if len(paths) == 0 {
+		return yaml.Node{}, fmt.Errorf("reading config file: no config files provided")
+	}
+
+	var merged any
+	for _, path := range paths {
+		value, err := loadConfigValue(path, lookup, mode, sentinelPrefix)
+		if err != nil {
+			return yaml.Node{}, err
+		}
+		merged = mergeConfigValues(merged, value)
+	}
+
+	if merged == nil {
+		return yaml.Node{}, nil
+	}
+
+	data, err := yaml.Marshal(merged)
+	if err != nil {
+		return yaml.Node{}, fmt.Errorf("marshaling merged config YAML: %w", err)
+	}
+
+	var root yaml.Node
+	dec := yaml.NewDecoder(strings.NewReader(string(data)))
+	if err := dec.Decode(&root); err != nil && err != io.EOF {
+		return yaml.Node{}, fmt.Errorf("parsing config YAML: %w", err)
+	}
+	if err := normalizeConfigRoot(&root); err != nil {
+		return yaml.Node{}, err
+	}
+	return root, nil
+}
+
+func loadConfigValue(path string, lookup func(string) (string, bool), mode envMissingMode, sentinelPrefix string) (any, error) {
+	root, err := loadValidatedConfigRoot(path, lookup, mode, sentinelPrefix)
+	if err != nil {
+		return nil, err
+	}
+	doc := documentValueNode(&root)
+	if doc == nil || doc.Kind == 0 {
+		return nil, nil
+	}
+
+	var raw any
+	if err := doc.Decode(&raw); err != nil {
+		return nil, fmt.Errorf("parsing config YAML: %w", err)
+	}
+
+	normalized, err := normalizeConfigValue(raw)
+	if err != nil {
+		return nil, fmt.Errorf("parsing config YAML: %w", err)
+	}
+	if normalized != nil {
+		root, ok := normalized.(map[string]any)
+		if !ok {
+			return nil, fmt.Errorf("expected mapping document")
+		}
+		resolveRelativePathsInValue(path, root)
+	}
+	return normalized, nil
+}
+
+func loadValidatedConfigRoot(path string, lookup func(string) (string, bool), mode envMissingMode, sentinelPrefix string) (yaml.Node, error) {
+	data, err := os.ReadFile(path)
+	if err != nil {
+		return yaml.Node{}, fmt.Errorf("reading config file: %w", err)
+	}
+
+	resolved, err := expandConfigInput(string(data), lookup, mode, sentinelPrefix)
+	if err != nil {
+		return yaml.Node{}, err
+	}
+
+	var root yaml.Node
+	dec := yaml.NewDecoder(strings.NewReader(resolved))
+	if err := dec.Decode(&root); err != nil && err != io.EOF {
+		return yaml.Node{}, fmt.Errorf("parsing config YAML: %w", err)
+	}
+	if err := normalizeConfigRoot(&root); err != nil {
+		return yaml.Node{}, err
+	}
+	if err := rejectRemovedDisabledFields(&root); err != nil {
+		return yaml.Node{}, err
+	}
+
+	validationRoot, err := cloneConfigRoot(root)
+	if err != nil {
+		return yaml.Node{}, err
+	}
+	if err := NormalizeOpaqueSecretRefs(&validationRoot, true); err != nil {
+		return yaml.Node{}, err
+	}
+	normalizedData, err := yaml.Marshal(documentValueNode(&validationRoot))
+	if err != nil {
+		return yaml.Node{}, fmt.Errorf("marshaling config YAML: %w", err)
+	}
+	normalizedInput := string(normalizedData)
+	if mode == envMissingSentinel {
+		normalizedInput = restoreMissingEnvSentinels(normalizedInput, sentinelPrefix)
+	}
+	validationInput := normalizedInput
+	if mode == envMissingSentinel || mode == envMissingPreserve {
+		validationInput, _, err = expandEnvVariables(normalizedInput, func(string) (string, bool) {
+			return "", false
+		}, false)
+		if err != nil {
+			return yaml.Node{}, err
+		}
+	}
+	var cfg Config
+	dec = yaml.NewDecoder(strings.NewReader(validationInput))
+	dec.KnownFields(true)
+	if err := dec.Decode(&cfg); err != nil && err != io.EOF {
+		return yaml.Node{}, fmt.Errorf("parsing config YAML: %w", err)
+	}
+
+	return root, nil
+}
+
+func cloneConfigRoot(root yaml.Node) (yaml.Node, error) {
+	data, err := yaml.Marshal(documentValueNode(&root))
+	if err != nil {
+		return yaml.Node{}, fmt.Errorf("marshaling config YAML: %w", err)
+	}
+
+	var clone yaml.Node
+	dec := yaml.NewDecoder(strings.NewReader(string(data)))
+	if err := dec.Decode(&clone); err != nil && err != io.EOF {
+		return yaml.Node{}, fmt.Errorf("parsing config YAML: %w", err)
+	}
+	if err := normalizeConfigRoot(&clone); err != nil {
+		return yaml.Node{}, err
+	}
+	return clone, nil
+}
+
+func expandConfigInput(input string, lookup func(string) (string, bool), mode envMissingMode, sentinelPrefix string) (string, error) {
+	switch mode {
+	case envMissingBlank:
+		resolved, _, err := expandEnvVariables(input, lookup, false)
+		return resolved, err
+	case envMissingSentinel:
+		return expandEnvVariablesWithMissingSentinels(input, lookup, sentinelPrefix)
+	case envMissingPreserve:
+		resolved, _, err := expandEnvVariables(input, lookup, true)
+		return resolved, err
+	default:
+		return "", fmt.Errorf("unsupported env expansion mode %d", mode)
+	}
+}
+
+func normalizeConfigValue(value any) (any, error) {
+	switch current := value.(type) {
+	case nil:
+		return nil, nil
+	case map[string]any:
+		out := make(map[string]any, len(current))
+		for key, child := range current {
+			normalized, err := normalizeConfigValue(child)
+			if err != nil {
+				return nil, err
+			}
+			out[key] = normalized
+		}
+		return out, nil
+	case map[any]any:
+		out := make(map[string]any, len(current))
+		for key, child := range current {
+			keyString, ok := key.(string)
+			if !ok {
+				return nil, fmt.Errorf("expected string mapping key, got %T", key)
+			}
+			normalized, err := normalizeConfigValue(child)
+			if err != nil {
+				return nil, err
+			}
+			out[keyString] = normalized
+		}
+		return out, nil
+	case []any:
+		out := make([]any, len(current))
+		for i, child := range current {
+			normalized, err := normalizeConfigValue(child)
+			if err != nil {
+				return nil, err
+			}
+			out[i] = normalized
+		}
+		return out, nil
+	default:
+		return current, nil
+	}
+}
+
+func mergeConfigValues(base, overlay any) any {
+	if overlay == nil {
+		return cloneConfigValue(base)
+	}
+
+	baseMap, baseIsMap := base.(map[string]any)
+	overlayMap, overlayIsMap := overlay.(map[string]any)
+	if baseIsMap && overlayIsMap {
+		out := cloneConfigValue(baseMap).(map[string]any)
+		for key, value := range overlayMap {
+			if value == nil {
+				delete(out, key)
+				continue
+			}
+			out[key] = mergeConfigValues(out[key], value)
+		}
+		return out
+	}
+
+	return cloneConfigValue(overlay)
+}
+
+func cloneConfigValue(value any) any {
+	switch current := value.(type) {
+	case map[string]any:
+		out := make(map[string]any, len(current))
+		for key, child := range current {
+			out[key] = cloneConfigValue(child)
+		}
+		return out
+	case []any:
+		out := make([]any, len(current))
+		for i, child := range current {
+			out[i] = cloneConfigValue(child)
+		}
+		return out
+	default:
+		return current
+	}
 }
 
 func rejectRemovedDisabledFields(root *yaml.Node) error {
@@ -1303,6 +1547,73 @@ func resolveBaseURL(cfg *Config) {
 	cfg.Server.Management.BaseURL = strings.TrimRight(strings.TrimSpace(cfg.Server.Management.BaseURL), "/")
 }
 
+func resolveRelativePathsInValue(configPath string, root map[string]any) {
+	baseDir := filepath.Dir(configPath)
+	if absPath, err := filepath.Abs(configPath); err == nil {
+		baseDir = filepath.Dir(absPath)
+	}
+
+	if server := nestedMap(root, "server"); server != nil {
+		resolveRelativeStringField(server, "artifactsDir", baseDir)
+	}
+
+	if providers := nestedMap(root, "providers"); providers != nil {
+		for _, kind := range []string{"auth", "secrets", "telemetry", "audit", "ui", "indexeddb", "cache", "s3"} {
+			for _, entry := range mapValues(nestedMap(providers, kind)) {
+				resolveRelativePathsInEntry(entry, baseDir)
+			}
+		}
+	}
+
+	for _, entry := range mapValues(nestedMap(root, "plugins")) {
+		resolveRelativePathsInEntry(entry, baseDir)
+	}
+}
+
+func resolveRelativePathsInEntry(entry map[string]any, baseDir string) {
+	if entry == nil {
+		return
+	}
+	resolveRelativeStringField(entry, "iconFile", baseDir)
+	if source := nestedMap(entry, "source"); source != nil {
+		resolveRelativeStringField(source, "path", baseDir)
+	}
+}
+
+func resolveRelativeStringField(fields map[string]any, key, baseDir string) {
+	if fields == nil {
+		return
+	}
+	value, ok := fields[key].(string)
+	if !ok {
+		return
+	}
+	fields[key] = resolveRelativeConfigValue(baseDir, value)
+}
+
+func nestedMap(root map[string]any, key string) map[string]any {
+	if root == nil {
+		return nil
+	}
+	current, _ := root[key].(map[string]any)
+	return current
+}
+
+func mapValues(entries map[string]any) []map[string]any {
+	if len(entries) == 0 {
+		return nil
+	}
+	values := make([]map[string]any, 0, len(entries))
+	for _, entry := range entries {
+		entryMap, ok := entry.(map[string]any)
+		if !ok {
+			continue
+		}
+		values = append(values, entryMap)
+	}
+	return values
+}
+
 func resolveRelativePaths(configPath string, cfg *Config) {
 	baseDir := filepath.Dir(configPath)
 	if absPath, err := filepath.Abs(configPath); err == nil {
@@ -1346,7 +1657,14 @@ func resolveRelativePaths(configPath string, cfg *Config) {
 }
 
 func resolveRelativePath(baseDir, value string) string {
+	return resolveRelativeConfigValue(baseDir, value)
+}
+
+func resolveRelativeConfigValue(baseDir, value string) string {
 	if value == "" || filepath.IsAbs(value) {
+		return value
+	}
+	if strings.Contains(value, "${") {
 		return value
 	}
 	return filepath.Clean(filepath.Join(baseDir, value))

--- a/gestaltd/internal/operator/lifecycle.go
+++ b/gestaltd/internal/operator/lifecycle.go
@@ -87,19 +87,35 @@ func (l *Lifecycle) WithConfigSecretResolver(resolve func(context.Context, *conf
 }
 
 func (l *Lifecycle) InitAtPath(configPath string) (*Lockfile, error) {
-	lock, _, err := l.initAtPath(configPath, "")
+	lock, _, err := l.initAtPaths([]string{configPath}, "")
 	return lock, err
 }
 
 func (l *Lifecycle) InitAtPathWithArtifactsDir(configPath, artifactsDir string) (*Lockfile, error) {
-	lock, _, err := l.initAtPath(configPath, artifactsDir)
+	lock, _, err := l.initAtPaths([]string{configPath}, artifactsDir)
+	return lock, err
+}
+
+func (l *Lifecycle) InitAtPaths(configPaths []string) (*Lockfile, error) {
+	lock, _, err := l.initAtPaths(configPaths, "")
+	return lock, err
+}
+
+func (l *Lifecycle) InitAtPathsWithArtifactsDir(configPaths []string, artifactsDir string) (*Lockfile, error) {
+	lock, _, err := l.initAtPaths(configPaths, artifactsDir)
 	return lock, err
 }
 
 // InitAtPathWithPlatforms runs init and additionally downloads and hashes
 // archives for the specified extra platforms.
 func (l *Lifecycle) InitAtPathWithPlatforms(configPath, artifactsDir string, platforms []struct{ GOOS, GOARCH, LibC string }) (*Lockfile, error) {
-	lock, cfg, err := l.initAtPath(configPath, artifactsDir)
+	return l.InitAtPathsWithPlatforms([]string{configPath}, artifactsDir, platforms)
+}
+
+// InitAtPathsWithPlatforms runs init and additionally downloads and hashes
+// archives for the specified extra platforms.
+func (l *Lifecycle) InitAtPathsWithPlatforms(configPaths []string, artifactsDir string, platforms []struct{ GOOS, GOARCH, LibC string }) (*Lockfile, error) {
+	lock, cfg, err := l.initAtPaths(configPaths, artifactsDir)
 	if err != nil {
 		return nil, err
 	}
@@ -107,7 +123,8 @@ func (l *Lifecycle) InitAtPathWithPlatforms(configPath, artifactsDir string, pla
 		return lock, nil
 	}
 
-	paths := initPathsForConfigWithArtifactsDir(configPath, resolveArtifactsDir(configPath, cfg, artifactsDir))
+	configPath := primaryConfigPath(configPaths)
+	paths := initPathsForConfigsWithArtifactsDir(configPaths, resolveArtifactsDir(configPath, cfg, artifactsDir))
 	tokenForSource := buildSourceTokenMap(cfg)
 	if err := downloadPlatformArchives(context.Background(), lock, paths, platforms, tokenForSource); err != nil {
 		return nil, err
@@ -120,15 +137,16 @@ func (l *Lifecycle) InitAtPathWithPlatforms(configPath, artifactsDir string, pla
 	return lock, nil
 }
 
-func (l *Lifecycle) initAtPath(configPath, artifactsDir string) (*Lockfile, *config.Config, error) {
-	cfg, err := config.LoadAllowMissingEnv(configPath)
+func (l *Lifecycle) initAtPaths(configPaths []string, artifactsDir string) (*Lockfile, *config.Config, error) {
+	configPath := primaryConfigPath(configPaths)
+	cfg, err := config.LoadAllowMissingEnvPaths(configPaths)
 	if err != nil {
 		return nil, nil, fmt.Errorf("loading config: %v", err)
 	}
-	if err := config.OverlayManagedPluginConfig(configPath, cfg); err != nil {
+	if err := config.OverlayManagedPluginConfigPaths(configPaths, cfg); err != nil {
 		return nil, nil, fmt.Errorf("loading config: %v", err)
 	}
-	paths := initPathsForConfigWithArtifactsDir(configPath, resolveArtifactsDir(configPath, cfg, artifactsDir))
+	paths := initPathsForConfigsWithArtifactsDir(configPaths, resolveArtifactsDir(configPath, cfg, artifactsDir))
 	secretsEntries, err := l.primeSecretsProviderForConfigResolution(context.Background(), paths, cfg, nil)
 	if err != nil {
 		return nil, nil, err
@@ -207,7 +225,7 @@ func (l *Lifecycle) initAtPath(configPath, artifactsDir string) (*Lockfile, *con
 	if err := WriteLockfile(paths.lockfilePath, lock); err != nil {
 		return nil, nil, err
 	}
-	if err := l.applyLockedProviders(configPath, artifactsDir, cfg, true); err != nil {
+	if err := l.applyLockedProviders(configPaths, artifactsDir, cfg, true); err != nil {
 		return nil, nil, err
 	}
 	if err := config.ValidateResolvedStructure(cfg); err != nil {
@@ -262,19 +280,28 @@ func lockfilePathForConfig(configPath string) string {
 }
 
 func (l *Lifecycle) LoadForExecutionAtPath(configPath string, locked bool) (*config.Config, map[string]string, error) {
-	return l.LoadForExecutionAtPathWithArtifactsDir(configPath, "", locked)
+	return l.LoadForExecutionAtPaths([]string{configPath}, locked)
 }
 
 func (l *Lifecycle) LoadForExecutionAtPathWithArtifactsDir(configPath, artifactsDir string, locked bool) (*config.Config, map[string]string, error) {
-	cfg, err := config.Load(configPath)
+	return l.LoadForExecutionAtPathsWithArtifactsDir([]string{configPath}, artifactsDir, locked)
+}
+
+func (l *Lifecycle) LoadForExecutionAtPaths(configPaths []string, locked bool) (*config.Config, map[string]string, error) {
+	return l.LoadForExecutionAtPathsWithArtifactsDir(configPaths, "", locked)
+}
+
+func (l *Lifecycle) LoadForExecutionAtPathsWithArtifactsDir(configPaths []string, artifactsDir string, locked bool) (*config.Config, map[string]string, error) {
+	configPath := primaryConfigPath(configPaths)
+	cfg, err := config.LoadPaths(configPaths)
 	if err != nil {
 		return nil, nil, fmt.Errorf("loading config: %v", err)
 	}
 	if err := synthesizeLocalSourcePluginOwnedUIEntries(cfg); err != nil {
 		return nil, nil, fmt.Errorf("loading config: %v", err)
 	}
-	paths := initPathsForConfigWithArtifactsDir(configPath, resolveArtifactsDir(configPath, cfg, artifactsDir))
-	secretsLock, err := l.lockForSecretsBootstrap(configPath, artifactsDir, paths, cfg, locked)
+	paths := initPathsForConfigsWithArtifactsDir(configPaths, resolveArtifactsDir(configPath, cfg, artifactsDir))
+	secretsLock, err := l.lockForSecretsBootstrap(configPaths, artifactsDir, paths, cfg, locked)
 	if err != nil {
 		return nil, nil, err
 	}
@@ -288,7 +315,7 @@ func (l *Lifecycle) LoadForExecutionAtPathWithArtifactsDir(configPath, artifacts
 		return nil, nil, err
 	}
 
-	if err := l.applyLockedProviders(configPath, artifactsDir, cfg, locked); err != nil {
+	if err := l.applyLockedProviders(configPaths, artifactsDir, cfg, locked); err != nil {
 		return nil, nil, err
 	}
 	if err := config.ValidateResolvedStructure(cfg); err != nil {
@@ -365,7 +392,7 @@ func (l *Lifecycle) resolveSecretsProviderMetadata(ctx context.Context, name str
 	return nil
 }
 
-func (l *Lifecycle) lockForSecretsBootstrap(configPath, artifactsDir string, paths initPaths, cfg *config.Config, locked bool) (*Lockfile, error) {
+func (l *Lifecycle) lockForSecretsBootstrap(configPaths []string, artifactsDir string, paths initPaths, cfg *config.Config, locked bool) (*Lockfile, error) {
 	if cfg == nil {
 		return nil, nil
 	}
@@ -389,10 +416,10 @@ func (l *Lifecycle) lockForSecretsBootstrap(configPath, artifactsDir string, pat
 
 	lock, err := ReadLockfile(paths.lockfilePath)
 	if !locked && (err != nil || !lockMatchesConfig(cfg, paths, lock)) {
-		lock, err = l.InitAtPathWithArtifactsDir(configPath, artifactsDir)
+		lock, err = l.InitAtPathsWithArtifactsDir(configPaths, artifactsDir)
 	}
 	if err != nil {
-		return nil, fmt.Errorf("managed providers require prepared artifacts; run `gestaltd init --config %s`: %w", configPath, err)
+		return nil, fmt.Errorf("managed providers require prepared artifacts; run `gestaltd init %s`: %w", formatConfigFlags(configPaths), err)
 	}
 	return lock, nil
 }
@@ -460,7 +487,7 @@ func (l *Lifecycle) primeSecretsProviderForConfigResolution(ctx context.Context,
 				if lock != nil {
 					lockEntry, ok := lock.Secrets[name]
 					if !ok {
-						return nil, fmt.Errorf("prepared artifact for %s %q is missing or stale; run `gestaltd init --config %s`", providermanifestv1.KindSecrets, name, paths.configPath)
+						return nil, fmt.Errorf("prepared artifact for %s %q is missing or stale; run `gestaltd init %s`", providermanifestv1.KindSecrets, name, paths.configFlags)
 					}
 					if err := l.applyLockedComponentEntry(paths, &lockEntry, providermanifestv1.KindSecrets, name, provider, configMap, secretsDestDir(paths, name), false); err != nil {
 						return nil, err
@@ -512,6 +539,8 @@ func (l *Lifecycle) primeSecretsProviderForConfigResolution(ctx context.Context,
 }
 
 type initPaths struct {
+	configPaths  []string
+	configFlags  string
 	configPath   string
 	configDir    string
 	artifactsDir string
@@ -523,6 +552,24 @@ type initPaths struct {
 	auditDir     string
 	cacheDir     string
 	uiDir        string
+}
+
+func primaryConfigPath(paths []string) string {
+	if len(paths) == 0 {
+		return ""
+	}
+	return paths[0]
+}
+
+func formatConfigFlags(paths []string) string {
+	if len(paths) == 0 {
+		return ""
+	}
+	args := make([]string, 0, len(paths)*2)
+	for _, path := range paths {
+		args = append(args, "--config", path)
+	}
+	return strings.Join(args, " ")
 }
 
 type providerFingerprintInput struct {
@@ -653,10 +700,11 @@ func resolveArtifactsDir(configPath string, cfg *config.Config, override string)
 }
 
 func initPathsForConfig(configPath string) initPaths {
-	return initPathsForConfigWithArtifactsDir(configPath, "")
+	return initPathsForConfigsWithArtifactsDir([]string{configPath}, "")
 }
 
-func initPathsForConfigWithArtifactsDir(configPath, artifactsDir string) initPaths {
+func initPathsForConfigsWithArtifactsDir(configPaths []string, artifactsDir string) initPaths {
+	configPath := primaryConfigPath(configPaths)
 	configDir := filepath.Dir(configPath)
 	if artifactsDir == "" {
 		artifactsDir = configDir
@@ -664,6 +712,8 @@ func initPathsForConfigWithArtifactsDir(configPath, artifactsDir string) initPat
 		artifactsDir = filepath.Join(configDir, artifactsDir)
 	}
 	return initPaths{
+		configPaths:  append([]string(nil), configPaths...),
+		configFlags:  formatConfigFlags(configPaths),
 		configPath:   configPath,
 		configDir:    configDir,
 		artifactsDir: artifactsDir,
@@ -1351,12 +1401,13 @@ func sourceForProvider(providerEntry *config.ProviderEntry) (pluginsource.Source
 	return src, nil
 }
 
-func (l *Lifecycle) applyLockedProviders(configPath, artifactsDir string, cfg *config.Config, locked bool) error {
+func (l *Lifecycle) applyLockedProviders(configPaths []string, artifactsDir string, cfg *config.Config, locked bool) error {
 	if !configHasProviderLoading(cfg) {
 		return nil
 	}
 
-	paths := initPathsForConfigWithArtifactsDir(configPath, resolveArtifactsDir(configPath, cfg, artifactsDir))
+	configPath := primaryConfigPath(configPaths)
+	paths := initPathsForConfigsWithArtifactsDir(configPaths, resolveArtifactsDir(configPath, cfg, artifactsDir))
 	var lock *Lockfile
 	var err error
 	if configHasManagedProviderSources(cfg) {
@@ -1370,10 +1421,10 @@ func (l *Lifecycle) applyLockedProviders(configPath, artifactsDir string, cfg *c
 		}
 		if !locked && (err != nil || !lockMatchesConfig(cfg, paths, lock)) {
 			clearSynthesizedPluginOwnedUIEntries(cfg, synthesizedLockedPluginUIs)
-			lock, err = l.InitAtPathWithArtifactsDir(configPath, artifactsDir)
+			lock, err = l.InitAtPathsWithArtifactsDir(configPaths, artifactsDir)
 		}
 		if err != nil {
-			return fmt.Errorf("managed providers require prepared artifacts; run `gestaltd init --config %s`: %w", configPath, err)
+			return fmt.Errorf("managed providers require prepared artifacts; run `gestaltd init %s`: %w", formatConfigFlags(configPaths), err)
 		}
 	}
 
@@ -1743,11 +1794,11 @@ func (l *Lifecycle) applyConfiguredUIProvider(paths initPaths, lockEntry *LockUI
 	switch {
 	case provider.HasManagedSource():
 		if lockEntry == nil {
-			return "", fmt.Errorf("prepared artifact for %s is missing or stale; run `gestaltd init --config %s`", subject, paths.configPath)
+			return "", fmt.Errorf("prepared artifact for %s is missing or stale; run `gestaltd init %s`", subject, paths.configFlags)
 		}
 		fingerprint, err := NamedUIProviderFingerprint(logicalName, provider)
 		if err != nil || lockEntry.Fingerprint != fingerprint {
-			return "", fmt.Errorf("prepared artifact for %s is missing or stale; run `gestaltd init --config %s`", subject, paths.configPath)
+			return "", fmt.Errorf("prepared artifact for %s is missing or stale; run `gestaltd init %s`", subject, paths.configFlags)
 		}
 		install, err := inspectPreparedInstall(destDir)
 		needMaterialize := err != nil || !preparedManifestMatchesLock(*lockEntry, install.manifest)
@@ -1800,11 +1851,11 @@ func (l *Lifecycle) applyComponentProvider(paths initPaths, lockEntries map[stri
 	switch {
 	case provider.HasManagedSource():
 		if lockEntries == nil {
-			return fmt.Errorf("prepared artifact for %s %q is missing or stale; run `gestaltd init --config %s`", kind, name, paths.configPath)
+			return fmt.Errorf("prepared artifact for %s %q is missing or stale; run `gestaltd init %s`", kind, name, paths.configFlags)
 		}
 		lockEntry, ok := lockEntries[name]
 		if !ok {
-			return fmt.Errorf("prepared artifact for %s %q is missing or stale; run `gestaltd init --config %s`", kind, name, paths.configPath)
+			return fmt.Errorf("prepared artifact for %s %q is missing or stale; run `gestaltd init %s`", kind, name, paths.configFlags)
 		}
 		if err := l.applyLockedComponentEntry(paths, &lockEntry, kind, name, provider, configMap, destDir, locked); err != nil {
 			return err
@@ -1913,14 +1964,14 @@ func applyLocalUIManifest(plugin *config.ProviderEntry, configMap map[string]any
 func (l *Lifecycle) applyLockedProviderEntry(paths initPaths, lock *Lockfile, name string, plugin *config.ProviderEntry, configMap map[string]any, locked bool) error {
 	entry, ok := lock.Providers[name]
 	if !ok {
-		return fmt.Errorf("prepared artifact for provider %q is missing or stale; run `gestaltd init --config %s`", name, paths.configPath)
+		return fmt.Errorf("prepared artifact for provider %q is missing or stale; run `gestaltd init %s`", name, paths.configFlags)
 	}
 	fingerprint, err := ProviderFingerprint(name, plugin, paths.configDir)
 	if err != nil {
 		return fmt.Errorf("fingerprinting provider %q: %w", name, err)
 	}
 	if entry.Fingerprint != fingerprint || entry.Source != plugin.SourceRef() || entry.Version != plugin.SourceVersion() {
-		return fmt.Errorf("prepared artifact for provider %q is missing or stale; run `gestaltd init --config %s`", name, paths.configPath)
+		return fmt.Errorf("prepared artifact for provider %q is missing or stale; run `gestaltd init %s`", name, paths.configFlags)
 	}
 
 	destDir := providerDestDir(paths, name)
@@ -1953,7 +2004,7 @@ func (l *Lifecycle) applyLockedProviderEntry(paths initPaths, lock *Lockfile, na
 	}
 	if install.executablePath != "" {
 		if _, err := os.Stat(install.executablePath); err != nil {
-			return fmt.Errorf("prepared executable for provider %q not found at %s; run `gestaltd init --config %s`", name, install.executablePath, paths.configPath)
+			return fmt.Errorf("prepared executable for provider %q not found at %s; run `gestaltd init %s`", name, install.executablePath, paths.configFlags)
 		}
 		args, err := providerEntrypointArgs(install.manifest)
 		if err != nil {
@@ -1967,14 +2018,14 @@ func (l *Lifecycle) applyLockedProviderEntry(paths initPaths, lock *Lockfile, na
 
 func (l *Lifecycle) applyLockedComponentEntry(paths initPaths, entry *LockEntry, kind, name string, plugin *config.ProviderEntry, configMap map[string]any, destDir string, locked bool) error {
 	if entry == nil {
-		return fmt.Errorf("prepared artifact for %s %q is missing or stale; run `gestaltd init --config %s`", kind, name, paths.configPath)
+		return fmt.Errorf("prepared artifact for %s %q is missing or stale; run `gestaltd init %s`", kind, name, paths.configFlags)
 	}
 	fingerprint, err := ProviderFingerprint(name, plugin, paths.configDir)
 	if err != nil {
 		return fmt.Errorf("fingerprinting %s %q provider: %w", kind, name, err)
 	}
 	if entry.Fingerprint != fingerprint || entry.Source != plugin.SourceRef() || entry.Version != plugin.SourceVersion() {
-		return fmt.Errorf("prepared artifact for %s %q is missing or stale; run `gestaltd init --config %s`", kind, name, paths.configPath)
+		return fmt.Errorf("prepared artifact for %s %q is missing or stale; run `gestaltd init %s`", kind, name, paths.configFlags)
 	}
 
 	install, err := inspectPreparedInstall(destDir)
@@ -2005,13 +2056,13 @@ func (l *Lifecycle) applyLockedComponentEntry(paths initPaths, entry *LockEntry,
 		}
 	}
 	if install.executablePath == "" {
-		return fmt.Errorf("prepared executable for %s %q not found in %s; run `gestaltd init --config %s`", kind, name, destDir, paths.configPath)
+		return fmt.Errorf("prepared executable for %s %q not found in %s; run `gestaltd init %s`", kind, name, destDir, paths.configFlags)
 	}
 	if err := bindResolvedComponentManifest(kind, name, plugin, install.manifestPath, install.manifest, configMap); err != nil {
 		return err
 	}
 	if _, err := os.Stat(install.executablePath); err != nil {
-		return fmt.Errorf("prepared executable for %s %q not found at %s; run `gestaltd init --config %s`", kind, name, install.executablePath, paths.configPath)
+		return fmt.Errorf("prepared executable for %s %q not found at %s; run `gestaltd init %s`", kind, name, install.executablePath, paths.configFlags)
 	}
 	args, err := componentEntrypointArgs(install.manifest, kind)
 	if err != nil {
@@ -2068,7 +2119,7 @@ func (l *Lifecycle) materializeLockedProvider(ctx context.Context, paths initPat
 	platform := providerpkg.CurrentPlatformString()
 	archive, resolvedKey, ok := resolveArchiveForPlatform(entry, platform)
 	if !ok || archive.URL == "" {
-		return fmt.Errorf("no archive for platform %s for provider %q; run `gestaltd init --config %s`", platform, name, paths.configPath)
+		return fmt.Errorf("no archive for platform %s for provider %q; run `gestaltd init %s`", platform, name, paths.configFlags)
 	}
 	if locked && archive.SHA256 == "" {
 		return fmt.Errorf("no verified hash for platform %s for provider %q; run `gestaltd init --platform %s`", platform, name, platform)
@@ -2124,7 +2175,7 @@ func (l *Lifecycle) materializeLockedComponent(ctx context.Context, paths initPa
 	platform := providerpkg.CurrentPlatformString()
 	archive, resolvedKey, ok := resolveArchiveForPlatform(entry, platform)
 	if !ok || archive.URL == "" {
-		return fmt.Errorf("no archive for platform %s for %s %q; run `gestaltd init --config %s`", platform, kind, name, paths.configPath)
+		return fmt.Errorf("no archive for platform %s for %s %q; run `gestaltd init %s`", platform, kind, name, paths.configFlags)
 	}
 	if locked && archive.SHA256 == "" {
 		return fmt.Errorf("no verified hash for platform %s for %s %q; run `gestaltd init --platform %s`", platform, kind, name, platform)
@@ -2185,7 +2236,7 @@ func (l *Lifecycle) materializeLockedUIProvider(ctx context.Context, paths initP
 	platform := providerpkg.CurrentPlatformString()
 	archive, _, ok := resolveArchiveForPlatform(entry, platform)
 	if !ok || archive.URL == "" {
-		return fmt.Errorf("no archive for platform %s for ui provider; run `gestaltd init --config %s`", platform, paths.configPath)
+		return fmt.Errorf("no archive for platform %s for ui provider; run `gestaltd init %s`", platform, paths.configFlags)
 	}
 	if locked && archive.SHA256 == "" {
 		return fmt.Errorf("no verified hash for platform %s for ui provider; run `gestaltd init --platform %s`", platform, platform)

--- a/gestaltd/internal/operator/lifecycle_source_test.go
+++ b/gestaltd/internal/operator/lifecycle_source_test.go
@@ -754,6 +754,101 @@ func TestSourceAuthPluginLoadForExecution(t *testing.T) {
 	}
 }
 
+func TestSourceAuthPluginInitAllowsMissingEnvPlaceholderInNonStringField(t *testing.T) {
+	t.Parallel()
+
+	dir := t.TempDir()
+	source := "github.com/acme/tools/auth-widget"
+	version := "2.0.0"
+	portEnv := "GESTALT_TEST_PORT_" + strings.ToUpper(strings.ReplaceAll(t.Name(), "/", "_"))
+
+	archivePath := buildExecutableArchive(t, dir, "auth-src", source, version, providermanifestv1.KindAuth, "auth-plugin", "fake-auth-binary")
+	archiveData, err := os.ReadFile(archivePath)
+	if err != nil {
+		t.Fatalf("read archive: %v", err)
+	}
+	archiveSum := sha256.Sum256(archiveData)
+	archiveSHA := hex.EncodeToString(archiveSum[:])
+
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/octet-stream")
+		_, _ = w.Write(archiveData)
+	}))
+	defer srv.Close()
+
+	resolver := &fakeResolver{
+		archivePath: archivePath,
+		resolvedURL: srv.URL + "/plugin.tar.gz",
+		sha256:      archiveSHA,
+	}
+
+	artifactsDir := filepath.Join(dir, "prepared-artifacts")
+	configYAML := strings.Join([]string{
+		requiredIndexedDBConfigYAML(t, dir, filepath.Join(dir, "data.db")),
+		"  secrets:",
+		"    secrets:",
+		"      source: test-secrets",
+		"  auth:",
+		"    auth:",
+		"      source:",
+		"        ref: " + source,
+		"        version: " + version,
+		"        auth:",
+		"          token:",
+		"            secret:",
+		"              provider: secrets",
+		"              name: source-token",
+		"      config:",
+		"        clientId: managed-auth-client",
+		"server:",
+		"  providers:",
+		"    indexeddb: sqlite",
+		"    secrets: secrets",
+		"    auth: auth",
+		"  public:",
+		"    port: ${" + portEnv + "}",
+		"  artifactsDir: " + artifactsDir,
+		"  encryptionKey: aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
+	}, "\n") + "\n"
+
+	configPath := filepath.Join(dir, "gestalt.yaml")
+	if err := os.WriteFile(configPath, []byte(configYAML), 0o644); err != nil {
+		t.Fatalf("write config: %v", err)
+	}
+
+	factories := bootstrap.NewFactoryRegistry()
+	factories.Secrets["test-secrets"] = func(yaml.Node) (core.SecretManager, error) {
+		return &coretesting.StubSecretManager{
+			Secrets: map[string]string{"source-token": "ghp_inline_auth_source_token"},
+		}, nil
+	}
+
+	lc := NewLifecycle(resolver).WithConfigSecretResolver(func(ctx context.Context, cfg *config.Config) error {
+		return bootstrap.ResolveConfigSecrets(ctx, cfg, factories)
+	})
+	lock, err := lc.InitAtPath(configPath)
+	if err != nil {
+		t.Fatalf("InitAtPath: %v", err)
+	}
+
+	authLockEntry := mustLockEntryByName(t, lock.Auth, "auth")
+	if authLockEntry.Source != source {
+		t.Fatalf("lock.Auth[auth].Source = %q, want %q", authLockEntry.Source, source)
+	}
+	if authLockEntry.Executable == "" {
+		t.Fatal("lock.Auth.Executable is empty")
+	}
+	if resolver.lastSrc.String() != source {
+		t.Fatalf("resolver source = %q, want %q", resolver.lastSrc.String(), source)
+	}
+	if resolver.lastVersion != version {
+		t.Fatalf("resolver version = %q, want %q", resolver.lastVersion, version)
+	}
+	if resolver.lastSrc.Token != "ghp_inline_auth_source_token" {
+		t.Fatalf("resolver source token = %q, want %q", resolver.lastSrc.Token, "ghp_inline_auth_source_token")
+	}
+}
+
 func TestManagedIndexedDBSourcesLoadForExecutionWithMultipleBindings(t *testing.T) {
 	t.Parallel()
 

--- a/gestaltd/internal/operator/lifecycle_test.go
+++ b/gestaltd/internal/operator/lifecycle_test.go
@@ -2523,7 +2523,7 @@ func TestApplyLockedPlugins_SkipsNilIntegrationPlugins(t *testing.T) {
 	loaded.Plugins["missing"] = &config.ProviderEntry{}
 
 	lc := NewLifecycle(nil)
-	if err := lc.applyLockedProviders(cfgPath, "", loaded, false); err != nil {
+	if err := lc.applyLockedProviders([]string{cfgPath}, "", loaded, false); err != nil {
 		t.Fatalf("applyLockedProviders: %v", err)
 	}
 	if loaded.Plugins["example"] == nil || loaded.Plugins["example"].ResolvedManifest == nil {


### PR DESCRIPTION
## Summary
Adds Helm-style repeated `--config` support to `gestaltd` for `serve`, `init`, and `validate`.

This PR teaches the server to load multiple config files left-to-right, deep-merge maps, let later scalar values win, replace inherited lists, and treat `null` as deleting an inherited key. Relative file paths resolve from the file that declared them, while lockfiles and default artifact roots remain anchored to the leftmost config file.

## New interfaces
Go:
- `config.LoadPaths(paths []string)`
- `config.LoadWithLookupPaths(paths []string, lookup func(string) (string, bool))`
- `config.LoadAllowMissingEnvPaths(paths []string)`
- `(*Lifecycle).InitAtPaths(configPaths []string)`
- `(*Lifecycle).InitAtPathsWithArtifactsDir(configPaths []string, artifactsDir string)`
- `(*Lifecycle).InitAtPathsWithPlatforms(configPaths []string, artifactsDir string, platforms []struct{ GOOS, GOARCH, LibC string })`
- `(*Lifecycle).LoadForExecutionAtPaths(configPaths []string, locked bool)`
- `(*Lifecycle).LoadForExecutionAtPathsWithArtifactsDir(configPaths []string, artifactsDir string, locked bool)`

YAML / CLI:
- `gestaltd init --config ./deploy/base.yaml --config ./deploy/overrides/local.yaml`
- `gestaltd serve --locked --config ./deploy/base.yaml --config ./deploy/overrides/prod.yaml`
- `gestaltd validate --config ./deploy/base.yaml --config ./deploy/overrides/local.yaml`

Merge rules:
- maps deep-merge
- later scalars win
- later lists replace inherited lists
- `null` deletes inherited keys

## Examples
Go:
```go
cfg, err := config.LoadPaths([]string{"./deploy/base.yaml", "./deploy/overrides/local.yaml"})
loaded, secrets, err := lifecycle.LoadForExecutionAtPaths([]string{"./deploy/base.yaml", "./deploy/overrides/local.yaml"}, true)
lock, err := lifecycle.InitAtPathsWithPlatforms([]string{"./deploy/base.yaml", "./deploy/overrides/prod.yaml"}, "", platforms)
```

YAML:
```yaml
# base.yaml
server:
  encryptionKey: ${GESTALT_ENCRYPTION_KEY}
plugins:
  github:
    source:
      path: ./plugins/github/manifest.yaml
    allowedHosts:
      - api.github.com
      - uploads.github.com
```

```yaml
# overrides/local.yaml
server:
  management:
    port: 9090
plugins:
  github:
    allowedHosts:
      - api.github.com
    iconFile: ./icons/github.svg
    displayName: null
```

## Verification
- `go test ./cmd/gestaltd ./internal/config ./internal/operator`
- Added CLI/e2e coverage for repeated `--config` validate, init, and locked serve flows
- Updated CLI and config docs for layering semantics and relative-path behavior
