### PR TITLE
Add managed identity resources, grants, and CLI management

### DIFF
--- a/docs/internal/managed-agent-identities-implementation-plan.md
+++ b/docs/internal/managed-agent-identities-implementation-plan.md
@@ -1,0 +1,702 @@
+# Managed Agent Identities Implementation Plan
+
+Status: draft implementation plan with PR1 implementation underway
+Last updated: 2026-04-15
+Depends on: `docs/internal/managed-agent-identities.md`
+
+## Goal
+
+Implement runtime-managed non-human identities across:
+
+- `gestaltd` backend + HTTP API
+- CLI
+- default web client in `~/src/gestalt-providers/web/default`
+
+The implementation should be additive and preserve existing behavior for:
+
+- human users
+- static YAML workloads under `authorization.workloads`
+- the legacy deployment-wide shared `identity` credential owner
+
+## Delivery Strategy
+
+Use vertical, functionally testable PRs rather than one cross-repo mega-change.
+
+Recommended rollout:
+
+1. PR1: identity resources, memberships, grants, and initial CLI management
+2. PR2: identity API tokens, managed-identity principals, and mode-`none` invocation
+3. PR3: identity-owned upstream connections, OAuth/manual connect, and credentialed invocation
+4. PR4: web UI management surface, plus any cleanup needed after the backend/CLI rollout
+
+This keeps each PR integration-testable while still moving toward the full product.
+
+## Core Design Decisions
+
+### 1. Treat managed identities as a distinct principal kind
+
+Do not overload them as:
+
+- human users
+- static workloads
+- the fixed `identity:__identity__` owner
+
+Add a new principal kind for managed identities and add helper methods for:
+
+- human-only checks
+- non-human checks
+- identity checks
+
+### 2. Generalize permissions separately from ownership
+
+There are two different permission layers:
+
+- identity grant permissions
+- token permissions
+
+They should use the same structured representation, and effective runtime access should be their intersection.
+
+### 3. Minimize schema churn where possible
+
+For V1, prefer additive schema changes rather than renaming legacy fields in-place unless the migration path is clearly safe.
+
+Implication:
+
+- `api_tokens` should be generalized in PR2
+- `integration_tokens` can be generalized in PR3 when identity-owned credentials are added
+
+## Proposed Data Model
+
+### New store: `identities`
+
+Purpose:
+
+- identity resource metadata
+
+Fields:
+
+- `id` string PK
+- `display_name` string
+- `created_at` time
+- `updated_at` time
+
+Indexes:
+
+- `by_display_name`
+
+Notes:
+
+- Keep V1 metadata minimal.
+- No single owner field is required because the resource is workspace-owned.
+
+### New store: `identity_memberships`
+
+Purpose:
+
+- human membership on an identity
+
+Fields:
+
+- `id` string PK
+- `identity_id` string
+- `user_id` string
+- `email` string
+- `role` string
+- `created_at` time
+- `updated_at` time
+
+Indexes:
+
+- `by_identity`
+- `by_identity_user` unique on `(identity_id, user_id)`
+- optional `by_user`
+
+Notes:
+
+- Store both `user_id` and normalized `email`, matching the style used in plugin authorizations.
+- Use `FindOrCreateUser` on writes so user/email sharing stays user-backed.
+
+### New store: `identity_grants`
+
+Purpose:
+
+- plugin and operation access for an identity
+
+Fields:
+
+- `id` string PK
+- `identity_id` string
+- `plugin` string
+- `permissions_json` string
+- `created_at` time
+- `updated_at` time
+
+Indexes:
+
+- `by_identity`
+- `by_identity_plugin` unique on `(identity_id, plugin)`
+
+Notes:
+
+- One row per identity/plugin is simplest.
+- `permissions_json` stores either:
+  - plugin-wide access
+  - operation subset
+
+### Existing store changes: `api_tokens`
+
+Purpose:
+
+- support both user-owned tokens and identity-owned tokens
+
+Proposed additive fields:
+
+- `owner_kind` string
+- `owner_id` string
+- `permissions_json` string
+
+Keep existing fields temporarily for compatibility:
+
+- `user_id`
+- `scopes`
+
+Compatibility interpretation:
+
+- legacy user token:
+  - `owner_kind = "user"` if present, else implied from `user_id`
+  - `permissions_json` empty
+  - `scopes` remains plugin-wide allowlist
+- new identity token:
+  - `owner_kind = "identity"`
+  - `owner_id = <identity_id>`
+  - `permissions_json` required
+
+Indexes:
+
+- existing hash index remains
+- add `by_owner` on `(owner_kind, owner_id)`
+- keep `by_user` and `by_user_id` until all old call sites are migrated
+
+### Existing store changes: `integration_tokens` in PR3
+
+Purpose:
+
+- allow identity-owned upstream credentials
+
+Recommended additive fields:
+
+- `owner_kind` string
+- `owner_id` string
+
+Keep legacy `user_id` field during migration if needed.
+
+Indexes:
+
+- add `by_owner`
+- add `by_owner_integration`
+- add `by_owner_connection`
+- add `by_owner_lookup` unique on `(owner_kind, owner_id, integration, connection, instance)`
+
+PR3 can then switch runtime lookup over to owner-based access without breaking old records.
+
+## Shared Permission Shape
+
+Use a shared structured representation for:
+
+- identity grants
+- token permissions
+
+Proposed Go shape:
+
+```go
+type AccessPermission struct {
+    Plugin     string   `json:"plugin"`
+    Operations []string `json:"operations,omitempty"`
+}
+```
+
+Semantics:
+
+- `Operations == nil` or empty: plugin-wide
+- non-empty operations: explicit subset only
+
+Recommended helper shape at runtime:
+
+```go
+type ResolvedPluginPermission struct {
+    AllOperations bool
+    Operations    map[string]struct{}
+}
+```
+
+This avoids repeated JSON decoding and simplifies intersection logic.
+
+## Principal Model Changes
+
+### `principal.Kind`
+
+Add:
+
+```go
+const (
+    KindUser     Kind = "user"
+    KindWorkload Kind = "workload"
+    KindIdentity Kind = "identity"
+)
+```
+
+Extend `principal.Principal` with:
+
+- `IdentityID string`
+- structured token permissions for API-token-backed principals
+
+Recommended helper methods:
+
+- `IsHuman()`
+- `IsWorkload()`
+- `IsManagedIdentity()`
+- `IsNonHuman()`
+
+### Principal resolution
+
+Update `principal.Resolver` so `gst_api_...` tokens can resolve to:
+
+- user principal
+- managed identity principal
+
+Resolution rules:
+
+- owner kind `user` => existing behavior
+- owner kind `identity` => `KindIdentity`, `IdentityID`, `SubjectID = "identity:<id>"`
+
+## Authorization Model Changes
+
+The authorization layer should handle three separate concerns:
+
+1. human plugin authorization
+2. static workload allowlists and bindings
+3. managed identity grants
+
+These should not be collapsed together.
+
+### Human plugin authorization
+
+Keep existing `authorization.policies` + dynamic plugin authorizations.
+
+Add one new rule for identity management:
+
+- when listing or mutating an identity's plugin grants / connections, only expose plugins the current human is authorized for
+- when mutating an identity's operation-scoped grants, only accept operations the current human can currently invoke
+- when mutating a plugin-wide grant, only accept it if the current human can invoke every visible operation on that plugin
+
+### Static workloads
+
+Keep existing workload semantics unchanged.
+
+### Managed identities
+
+Add authorizer support for:
+
+- loading an identity's plugin grants
+- checking whether a managed identity is allowed to access a plugin
+- checking whether a managed identity is allowed to access an operation
+
+Effective runtime rule:
+
+```text
+allowed(identity token, plugin/op) =
+    identity_grant(identity, plugin/op)
+    intersect
+    token_permission(token, plugin/op)
+```
+
+## HTTP API Plan
+
+### PR1: identity core
+
+Add:
+
+- `GET /api/v1/identities`
+- `POST /api/v1/identities`
+- `GET /api/v1/identities/{identityId}`
+- `DELETE /api/v1/identities/{identityId}` maybe defer to PR2 if delete gating is easier after memberships exist
+- `GET /api/v1/identities/{identityId}/grants`
+- `PUT /api/v1/identities/{identityId}/grants/{plugin}`
+- `DELETE /api/v1/identities/{identityId}/grants/{plugin}`
+- `GET /api/v1/identities/{identityId}/tokens`
+- `POST /api/v1/identities/{identityId}/tokens`
+- `DELETE /api/v1/identities/{identityId}/tokens/{tokenId}`
+
+Suggested request body for grant upsert:
+
+```json
+{
+  "operations": ["get_forecast", "get_alerts"]
+}
+```
+
+Plugin-wide grant example:
+
+```json
+{
+  "operations": []
+}
+```
+
+Suggested token create request:
+
+```json
+{
+  "name": "automation",
+  "permissions": [
+    { "plugin": "weather", "operations": ["get_forecast"] },
+    { "plugin": "news" }
+  ]
+}
+```
+
+Suggested token create response:
+
+```json
+{
+  "id": "tok_123",
+  "name": "automation",
+  "token": "gst_api_..."
+}
+```
+
+### PR2: memberships and role enforcement
+
+Add:
+
+- `PATCH /api/v1/identities/{identityId}` or `PUT` for metadata update
+- `GET /api/v1/identities/{identityId}/members`
+- `PUT /api/v1/identities/{identityId}/members`
+- `DELETE /api/v1/identities/{identityId}/members/{userId}`
+
+Suggested membership upsert body:
+
+```json
+{
+  "email": "editor@example.com",
+  "role": "editor"
+}
+```
+
+Response bodies should include the caller's effective role for the identity to simplify CLI/UI logic.
+
+### PR3: connections
+
+Add:
+
+- `GET /api/v1/identities/{identityId}/integrations`
+- `DELETE /api/v1/identities/{identityId}/integrations/{name}`
+- `POST /api/v1/identities/{identityId}/auth/start-oauth`
+- `POST /api/v1/identities/{identityId}/auth/connect-manual`
+
+These should mirror existing user-scoped integration routes, but act on identity-owned credentials instead of human-owned credentials.
+
+## CLI Plan
+
+### Command shape
+
+Add a top-level `identities` command family.
+
+Recommended structure:
+
+```text
+gestalt identities list
+gestalt identities create --name <display-name>
+gestalt identities get <identity-id>
+gestalt identities update <identity-id> --name <display-name>
+gestalt identities delete <identity-id>
+
+gestalt identities grants list <identity-id>
+gestalt identities grants put <identity-id> <plugin> [--operation op ...]
+gestalt identities grants revoke <identity-id> <plugin>
+
+gestalt identities tokens list <identity-id>
+gestalt identities tokens create <identity-id> --name <name> --permission plugin[:op][,op] ...
+gestalt identities tokens revoke <identity-id> <token-id>
+
+gestalt identities members list <identity-id>
+gestalt identities members put <identity-id> --email <email> --role <viewer|editor|admin>
+gestalt identities members revoke <identity-id> <user-id>
+
+gestalt identities connect <identity-id> <plugin> [--connection ...] [--instance ...]
+gestalt identities disconnect <identity-id> <plugin> [--connection ...] [--instance ...]
+```
+
+Notes:
+
+- Keep existing `tokens` and `plugins` user-scoped.
+- Avoid adding identity targeting flags to existing user-scoped commands in PR1.
+- Add identity-targeted connect/disconnect in PR3 once the backend exists.
+
+### Files to change
+
+- `gestalt/cli/src/cli.rs`
+- `gestalt/cli/src/commands/mod.rs`
+- new `gestalt/cli/src/commands/identities.rs`
+- `gestalt/cli/src/api.rs`
+- `gestalt/cli/tests/integration.rs`
+
+## Default Web Client Plan
+
+### PR1 pages
+
+Add new identity-focused routes rather than overloading `/tokens` and `/integrations`.
+
+Recommended pages:
+
+- `/identities`
+- `/identities/[id]`
+- `/identities/[id]/tokens`
+- `/identities/[id]/grants`
+
+### PR2 pages
+
+- `/identities/[id]/members`
+
+### PR3 pages
+
+- `/identities/[id]/integrations`
+
+### Web API client changes
+
+Add identity-focused API helpers in:
+
+- `src/lib/api.ts`
+
+Examples:
+
+- `getIdentities()`
+- `createIdentity()`
+- `getIdentity(id)`
+- `getIdentityTokens(id)`
+- `createIdentityToken(id, ...)`
+- `getIdentityGrants(id)`
+- `putIdentityGrant(id, plugin, operations)`
+- `getIdentityMembers(id)`
+- `putIdentityMember(id, email, role)`
+- `getIdentityIntegrations(id)`
+- `startIdentityIntegrationOAuth(...)`
+
+### Reusable components
+
+Reuse from current UI where practical:
+
+- token table/create form
+- integration card/settings modal
+
+But do not try to force identity management into the existing user-only pages.
+
+### Files likely involved
+
+- `src/components/Nav.tsx`
+- `src/lib/api.ts`
+- new identity page routes under `src/app/identities/...`
+- token/grant/member/integration focused components
+- e2e specs in `e2e/*`
+
+## Test Plan
+
+The user requested:
+
+- no unit tests
+- prefer augmenting similar existing tests
+- new tests only when behavior is truly new
+
+### PR1 tests
+
+Use:
+
+- `gestaltd/cmd/gestaltd/e2e_test.go`
+- `gestalt/cli/tests/integration.rs`
+- default web client mocked e2e tests
+
+PR1 scenarios:
+
+- create identity
+- create plugin grant
+- create identity token with explicit permissions
+- invoke a `mode:none` plugin using the identity token
+- reject identity token creation with empty permissions
+- show identity list/detail/tokens/grants in UI
+
+### PR2 tests
+
+Use the same suites.
+
+PR2 scenarios:
+
+- creator seeded as admin
+- admin can share
+- viewer can list/create tokens but not revoke or mutate grants
+- editor can mutate grants and revoke tokens but not share/update/delete
+- hidden plugin config when the human no longer has authorization to manage that plugin
+
+### PR3 tests
+
+Use the same suites and extend existing similar connect-flow coverage.
+
+PR3 scenarios:
+
+- connect manual on behalf of identity
+- connect OAuth on behalf of identity
+- list identity integrations / instances
+- invoke a credentialed plugin through identity-owned credentials
+- disconnect an identity-owned integration
+
+## PR Breakdown
+
+### PR1: Identity Core
+
+Scope:
+
+- identity metadata store
+- identity grant store
+- generalized API token ownership
+- managed identity principal resolution
+- identity token permission model
+- runtime permission intersection
+- identity CRUD, grants, tokens API
+- CLI identities + identity tokens/grants
+- web identity list/detail/tokens/grants
+- mode-`none` functional coverage
+
+Definition of done:
+
+- a user can create an identity
+- grant a `mode:none` plugin
+- mint a token for that identity
+- invoke the granted operation with that token
+
+### PR2: Sharing and Management Roles
+
+Scope:
+
+- identity membership store + API
+- viewer/editor/admin enforcement
+- seeded creator admin
+- identity metadata update/delete
+- visibility filtering for plugin management
+- CLI members/admin workflows
+- web members and role-gated actions
+
+Definition of done:
+
+- two humans can share and manage the same identity according to role
+- plugin grants and connections are hidden from humans who lose plugin authorization
+
+### PR3: Identity-Owned Connections
+
+Scope:
+
+- generalized integration token ownership
+- identity-scoped integration list/connect/disconnect
+- identity OAuth/manual connect flows
+- credentialed invocation using identity-owned tokens
+- CLI identity connect/disconnect
+- web identity integrations page
+
+Definition of done:
+
+- a shared identity can own upstream OAuth/manual credentials independently of any human user and use them for invocation
+
+## Branch / PR Process
+
+The user asked for:
+
+- parallel agents/worktrees if useful
+- `gpt-5.4` + `xhigh` reviewer/worker agents
+- one squash commit per PR
+- every finished PR to be reviewed by a separate reviewer agent
+- PR descriptions to include:
+  - new Go interfaces
+  - YAML/config surface
+  - example usage
+
+Recommended working process:
+
+1. Create one branch per PR slice.
+2. Use worker agents for disjoint implementation areas:
+   - backend/API
+   - CLI
+   - default web client
+3. When a branch is functionally complete:
+   - run the relevant integration / e2e suites
+   - squash to a single commit
+   - open a PR
+4. Spawn a fresh reviewer agent on that branch.
+5. Apply reviewer feedback.
+6. Pull PR review comments, address them, and push updates.
+
+## Go Interface Examples
+
+These are planning targets, not yet locked code.
+
+```go
+type ManagedIdentity struct {
+    ID          string
+    DisplayName string
+    CreatedAt   time.Time
+    UpdatedAt   time.Time
+}
+
+type ManagedIdentityMembership struct {
+    IdentityID string
+    UserID     string
+    Email      string
+    Role       string
+}
+
+type AccessPermission struct {
+    Plugin     string
+    Operations []string
+}
+```
+
+## YAML / Config Examples
+
+Managed identities are runtime-managed, so they do not require new YAML.
+
+The relevant YAML context that remains valid is:
+
+```yaml
+server:
+  providers:
+    auth: google
+
+plugins:
+  weather:
+    source:
+      path: ./plugins/weather/manifest.yaml
+    authorizationPolicy: weather_access
+    connections:
+      default:
+        mode: user
+        auth:
+          type: manual
+```
+
+Planning note:
+
+- no new YAML is required to create managed identities
+- the semantic change is that plugin modes like `user` and `either` will eventually be usable by managed identities once PR3 lands
+
+## Open Implementation Questions
+
+These are engineering questions, not product blockers:
+
+- whether to introduce a small internal `permissions` package for shared intersection logic
+- whether identity delete should hard-delete immediately or first validate that all child cleanup succeeded transactionally
+- whether identity route responses should include explicit capabilities booleans in addition to the caller role
+- whether PR1 should include delete or defer it to PR2 when memberships/roles are present
+
+Current recommendation:
+
+- keep permissions logic internal but shared
+- fail identity delete if any child cleanup fails
+- include `role` first, add explicit booleans only if the web client needs them
+- defer update/delete to PR2 if it keeps PR1 smaller

--- a/docs/internal/managed-agent-identities.md
+++ b/docs/internal/managed-agent-identities.md
@@ -1,0 +1,346 @@
+# Managed Agent Identities
+
+Status: draft planning doc
+Last updated: 2026-04-15
+Audience: product + engineering
+
+## Summary
+
+Gestalt should support runtime-managed non-human identities that:
+
+- are persisted workspace-owned resources
+- authenticate as true non-human principals
+- own their own integration credentials
+- own their own API tokens
+- can be shared with humans using `viewer`, `editor`, and `admin` roles
+- can be granted explicit access to plugins, optionally narrowed to specific operations
+
+This is intentionally additive in V1. Existing static YAML workloads and the current deployment-wide shared `identity` owner should continue to work unchanged.
+
+## Why This Exists
+
+The current model has three separate concepts:
+
+- human users with user-owned API tokens
+- static YAML workloads under `authorization.workloads`
+- a single deployment-wide shared plugin `identity` owner
+
+That model is too rigid for agentic use cases. We need a managed resource that represents a reusable non-human actor, can be shared between humans, and can own plugin credentials independently from any single person.
+
+## Current State
+
+Today:
+
+- workload callers are static config entries, not runtime-managed resources
+- workload callers are limited to `identity` and `none` providers
+- plugin `identity` credentials are stored against one fixed internal owner (`__identity__`)
+- API tokens are user-owned
+- plugin authorization sharing exists only for human users, not for non-human identities
+- the default web client and CLI only expose user-scoped token and integration management
+
+## Target Resource Model
+
+An agent identity is a persisted workspace-owned resource with:
+
+- `id`
+- `displayName`
+- timestamps
+- human memberships
+- plugin grants
+- plugin connections / stored upstream credentials
+- API tokens
+
+Properties:
+
+- It is not a human user.
+- It is not just a relabeled user API token.
+- It is not required to have a single owner.
+- It is managed at runtime through API/CLI/web UI.
+
+## Locked Product Requirements
+
+### Identity lifecycle
+
+- Identities are runtime-managed.
+- Identities are workspace-owned resources.
+- Platform auth must be enabled for identity management.
+- V1 should coexist with:
+  - static YAML workloads
+  - the legacy deployment-wide shared `identity` credential owner
+
+### Human sharing model
+
+- Membership is user/email-based only in V1.
+- Membership roles are `viewer`, `editor`, and `admin`.
+- The creator should be seeded as an `admin`.
+
+### Identity runtime model
+
+- Identity API calls authenticate as a true non-human principal.
+- Anyone with a valid identity API token may invoke using that identity.
+- Invocation is not further constrained by the current human viewer/editor/admin memberships.
+
+### Plugin access model
+
+- Identity plugin access is explicit.
+- Even `mode: none` plugins must be explicitly granted.
+- Identity grants may be:
+  - plugin-wide
+  - operation-scoped
+- If no operations are specified for a granted plugin, the identity has plugin-wide access for that plugin.
+- If operations are specified, the identity only has access to those operations.
+
+### Token model
+
+- Identity API tokens should behave like existing `gst_api_...` tokens:
+  - one-time plaintext display at creation
+  - hashed at rest
+- Identity API tokens do not inherit full identity access automatically.
+- Token permissions must be explicitly declared.
+- Token permissions are plugin + operation granular.
+- Creating an identity token with no permissions should be rejected.
+- Effective runtime access should be the intersection of:
+  - the identity's own grants
+  - the token's declared permissions
+
+### Connection model
+
+- Identities own their own stored upstream credentials.
+- Those credentials are independent from any human user's stored credentials.
+- Identities should support the same multi-connection / multi-instance behavior users have today.
+- OAuth and manual connect should both work when performed on behalf of an identity.
+- Identity `editors` and `admins` can complete OAuth/manual connect flows on behalf of the identity.
+
+### Human authorization ceiling
+
+- When a human configures an identity's plugin access, they may only grant access to plugins that the human is themselves authorized for.
+- When a grant is operation-scoped, the selected operations must also be invokable by the configuring human.
+- A plugin-wide grant is only valid when the configuring human can invoke every visible operation on that plugin.
+- If a human later loses authorization for a plugin, the identity should keep working until explicitly changed.
+- In that case the plugin's config should be hidden from that human rather than auto-revoked.
+
+### Deletion semantics
+
+- Delete is a hard delete.
+- Deleting an identity should cascade and remove:
+  - memberships
+  - plugin grants
+  - stored integration credentials
+  - API tokens
+
+## Role And Capability Matrix
+
+This is the locked product behavior.
+
+| Capability | Viewer | Editor | Admin |
+| --- | --- | --- | --- |
+| View identity metadata | Yes | Yes | Yes |
+| View memberships | Yes | Yes | Yes |
+| View plugin grants | Yes | Yes | Yes |
+| View connections | Yes | Yes | Yes |
+| List tokens | Yes | Yes | Yes |
+| Create token | Yes | Yes | Yes |
+| Revoke token | No | Yes | Yes |
+| Connect plugin | No | Yes | Yes |
+| Disconnect plugin | No | Yes | Yes |
+| Create/update/remove plugin grants | No | Yes | Yes |
+| Rename/update identity metadata | No | No | Yes |
+| Manage sharing | No | No | Yes |
+| Delete identity | No | No | Yes |
+
+Planning note:
+
+- This doc treats plugin grant management as `editor`+`admin`, because the product direction is that `editor` can manage the operational state of the identity and was only explicitly excluded from sharing, rename/update, and delete.
+
+## Effective Access Matrix
+
+| Identity grant | Token permission | Effective result |
+| --- | --- | --- |
+| none | any | deny |
+| plugin-wide | plugin-wide | allow full plugin access |
+| plugin-wide | operation subset | allow only token subset |
+| operation subset | plugin-wide | allow only identity subset |
+| operation subset A | operation subset B | allow intersection of A and B |
+| any | empty token permissions | token creation rejected |
+
+Additional rules:
+
+- `mode: none` plugins still require an identity grant.
+- Identity grants do not auto-expand just because the identity has a connection.
+- Token permissions never exceed the identity's own grants.
+
+## Feature / Product Matrix
+
+This matrix captures the minimum V1 surface area.
+
+| Feature | Backend / Data Model | HTTP API | CLI | Default Web UI | Notes |
+| --- | --- | --- | --- | --- | --- |
+| Identity CRUD | Required | Required | Required | Required | Workspace-owned runtime resources |
+| Membership sharing | Required | Required | Required | Required | User/email-based only |
+| Viewer/editor/admin enforcement | Required | Required | Required | Required | UI should mirror server enforcement |
+| Plugin grant management | Required | Required | Required | Required | Plugin-wide or operation-scoped |
+| Visibility filtering by human auth | Required | Required | Required | Required | Hidden, not auto-revoked |
+| Identity-owned integration credentials | Required | Required | Required | Required | Independent from human credentials |
+| OAuth on behalf of identity | Required | Required | Required | Required | Editor/admin only |
+| Manual connect on behalf of identity | Required | Required | Required | Required | Editor/admin only |
+| Multi-instance connection support | Required | Required | Required | Required | Same model as users today |
+| Identity API token creation/list/revoke | Required | Required | Required | Required | Viewer can list/create only |
+| Token permission model | Required | Required | Required | Required | Plugin + operation granular |
+| True non-human principal resolution | Required | Implicit | Implicit | Implicit | Not a user alias |
+| Invocation permission intersection | Required | Implicit | Implicit | Implicit | Identity grant intersect token permission |
+| Hard delete cascade | Required | Required | Required | Required | Remove tokens, grants, memberships, creds |
+| Legacy workload coexistence | Required | N/A | N/A | N/A | Additive V1, no forced migration |
+| Docs and tests | Required | Required | Required | Required | Include user-facing docs + e2e |
+
+## Recommended API Shape
+
+Endpoint names are not locked, but V1 likely needs resource families like:
+
+- `/api/v1/identities`
+- `/api/v1/identities/{identityId}`
+- `/api/v1/identities/{identityId}/members`
+- `/api/v1/identities/{identityId}/grants`
+- `/api/v1/identities/{identityId}/tokens`
+- `/api/v1/identities/{identityId}/integrations`
+- identity-targeted connect/disconnect OAuth/manual flows
+
+Important constraint:
+
+- Existing user-scoped routes such as `/api/v1/tokens` and `/api/v1/integrations` should continue to work for human users without breaking changes.
+
+## Implementation Implications
+
+### Storage and ownership
+
+The current data model is user-centric. V1 likely needs:
+
+- a new identities store
+- a new identity memberships store
+- a new identity grants store
+- generalized credential ownership for:
+  - integration tokens
+  - API tokens
+
+The current `user_id`-only ownership model is not sufficient for managed identities.
+
+### Principal model
+
+The current principal model distinguishes users and workloads. Managed identities should be treated as a true non-human principal. The implementation can:
+
+- introduce a new principal kind
+- or generalize the existing non-human model cleanly
+
+The implementation should not keep pretending a managed identity is just the legacy fixed shared identity owner.
+
+### Permission representation
+
+The current user API token `scopes` field is plugin-only and string-based. Managed identities require structured permission data that can represent:
+
+- plugin-wide permission
+- operation subsets
+
+That likely means a new structured permissions representation for identity tokens, and possibly eventually for user tokens too.
+
+### Visibility vs runtime validity
+
+There are two separate checks:
+
+- runtime invocation validity for an identity token
+- human viewer visibility of an identity's configuration
+
+Those checks should remain separate:
+
+- identity runtime access keeps working unless explicitly changed
+- humans who lose plugin authorization should simply stop seeing that plugin in the identity management surface
+
+## Non-Goals For V1
+
+- replacing static YAML workloads
+- removing the existing deployment-wide shared `identity` owner
+- team/group-based sharing
+- auto-revocation when human permissions change
+- implicit plugin access for `mode: none`
+- identity tokens with blank permissions
+
+## Default UX Expectations
+
+### CLI
+
+The CLI should add identity-scoped management rather than force everything through the user-scoped commands.
+
+Likely families:
+
+- `gestalt identities list`
+- `gestalt identities create`
+- `gestalt identities get`
+- `gestalt identities update`
+- `gestalt identities delete`
+- `gestalt identities members ...`
+- `gestalt identities grants ...`
+- `gestalt identities tokens ...`
+- `gestalt identities connect ...`
+- `gestalt identities disconnect ...`
+
+### Default web client
+
+The default web client should gain identity management pages rather than trying to overload the current user-only:
+
+- `/integrations`
+- `/tokens`
+
+Expected V1 web surfaces:
+
+- identity list
+- identity detail
+- identity members
+- identity grants
+- identity connections
+- identity tokens
+
+The UI should hide actions the current member role cannot perform and hide plugins the current human is no longer authorized to manage.
+
+## Phased Delivery
+
+Recommended order:
+
+1. Backend data model and principal generalization
+2. Authorization and invocation enforcement
+3. Identity HTTP API
+4. CLI support
+5. Default web client support
+6. Docs and e2e / integration tests
+
+## Migration / Compatibility Strategy
+
+V1 should be additive:
+
+- keep `authorization.workloads`
+- keep the legacy shared `identity` owner
+- introduce managed identities alongside both
+
+That is the simplest migration path and avoids forcing existing deployments to rework current identity-mode plugins before the new model is stable.
+
+## Risks To Watch
+
+- overloading the existing `user_id` ownership model too far instead of introducing a clearer principal-owner abstraction
+- mixing human visibility rules with token runtime authorization
+- building plugin grants only at plugin-level and then backfilling operation scoping later
+- leaking hidden plugin config to humans who no longer have authorization to manage it
+- making CLI and web UX user-centric in a way that blocks identity management workflows
+
+## Decision Log
+
+Locked decisions captured here:
+
+- true non-human principal, not user-token aliasing
+- runtime-managed identities
+- independent identity-owned credentials
+- workspace-owned identities
+- user/email-based sharing only in V1
+- plugin grants explicit for all plugins, including `mode: none`
+- operation scoping supported at both identity-grant and token-permission layers
+- token creation rejected when permissions are empty
+- plugin-level human authorization ceiling when configuring identity access
+- no auto-revocation when human authorization later changes
+- hard-delete cascade
+- additive coexistence with legacy workloads and legacy shared identity owner

--- a/gestalt/cli/src/api.rs
+++ b/gestalt/cli/src/api.rs
@@ -265,6 +265,20 @@ impl ApiClient {
         self.send_json(Method::POST, path, body)
     }
 
+    pub fn put<T>(&self, path: &str, body: &T) -> Result<serde_json::Value>
+    where
+        T: Serialize + ?Sized,
+    {
+        self.send_json(Method::PUT, path, body)
+    }
+
+    pub fn patch<T>(&self, path: &str, body: &T) -> Result<serde_json::Value>
+    where
+        T: Serialize + ?Sized,
+    {
+        self.send_json(Method::PATCH, path, body)
+    }
+
     pub fn post_form<T>(&self, path: &str, body: &T) -> Result<String>
     where
         T: Serialize + ?Sized,

--- a/gestalt/cli/src/cli.rs
+++ b/gestalt/cli/src/cli.rs
@@ -57,6 +57,12 @@ pub enum Commands {
         #[command(subcommand)]
         command: TokenCommands,
     },
+
+    /// Manage workspace-owned identities
+    Identities {
+        #[command(subcommand)]
+        command: IdentityCommands,
+    },
 }
 
 #[derive(Subcommand)]
@@ -180,4 +186,123 @@ pub enum TokenCommands {
         /// Token ID to revoke
         id: String,
     },
+}
+
+#[derive(Subcommand)]
+pub enum IdentityCommands {
+    /// List identities you can access
+    List,
+    /// Create a new identity
+    Create {
+        /// Display name for the identity
+        #[arg(long = "name")]
+        display_name: String,
+    },
+    /// Show one identity
+    Get {
+        /// Identity ID
+        id: String,
+    },
+    /// Update an identity's display name
+    Update {
+        /// Identity ID
+        id: String,
+        /// New display name
+        #[arg(long = "name")]
+        display_name: String,
+    },
+    /// Delete an identity
+    Delete {
+        /// Identity ID
+        id: String,
+    },
+    /// Manage identity members
+    Members {
+        #[command(subcommand)]
+        command: IdentityMemberCommands,
+    },
+    /// Manage identity grants
+    Grants {
+        #[command(subcommand)]
+        command: IdentityGrantCommands,
+    },
+}
+
+#[derive(Subcommand)]
+pub enum IdentityMemberCommands {
+    /// List members for an identity
+    List {
+        /// Identity ID
+        identity: String,
+    },
+    /// Add a member to an identity
+    Add {
+        /// Identity ID
+        identity: String,
+        /// User email
+        email: String,
+        /// Membership role
+        #[arg(long, value_enum)]
+        role: IdentityRole,
+    },
+    /// Update a member's role on an identity
+    Update {
+        /// Identity ID
+        identity: String,
+        /// User email
+        email: String,
+        /// Membership role
+        #[arg(long, value_enum)]
+        role: IdentityRole,
+    },
+    /// Remove a member from an identity
+    Remove {
+        /// Identity ID
+        identity: String,
+        /// User email
+        email: String,
+    },
+}
+
+#[derive(Subcommand)]
+pub enum IdentityGrantCommands {
+    /// List grants for an identity
+    List {
+        /// Identity ID
+        identity: String,
+    },
+    /// Set or replace a plugin grant for an identity
+    Set {
+        /// Identity ID
+        identity: String,
+        /// Plugin name
+        plugin: String,
+        /// Restrict the grant to specific operations
+        #[arg(long = "operation")]
+        operations: Vec<String>,
+    },
+    /// Remove a plugin grant from an identity
+    Revoke {
+        /// Identity ID
+        identity: String,
+        /// Plugin name
+        plugin: String,
+    },
+}
+
+#[derive(clap::ValueEnum, Clone, Copy, Debug, PartialEq, Eq)]
+pub enum IdentityRole {
+    Viewer,
+    Editor,
+    Admin,
+}
+
+impl IdentityRole {
+    pub fn as_str(self) -> &'static str {
+        match self {
+            Self::Viewer => "viewer",
+            Self::Editor => "editor",
+            Self::Admin => "admin",
+        }
+    }
 }

--- a/gestalt/cli/src/commands/identities.rs
+++ b/gestalt/cli/src/commands/identities.rs
@@ -1,0 +1,301 @@
+use anyhow::{Context, Result};
+use serde_json::json;
+
+use crate::api::ApiClient;
+use crate::output::{self, Format};
+
+pub fn list(client: &ApiClient, format: Format) -> Result<()> {
+    let resp = client
+        .get("/api/v1/identities")
+        .context("failed to list identities")?;
+    print_identities(&resp, format);
+    Ok(())
+}
+
+pub fn get(client: &ApiClient, id: &str, format: Format) -> Result<()> {
+    let resp = client
+        .get(&format!("/api/v1/identities/{id}"))
+        .with_context(|| format!("failed to get identity {id}"))?;
+    print_identity(&resp, format);
+    Ok(())
+}
+
+pub fn create(client: &ApiClient, display_name: &str, format: Format) -> Result<()> {
+    let resp = client
+        .post(
+            "/api/v1/identities",
+            &json!({
+                "displayName": display_name,
+            }),
+        )
+        .context("failed to create identity")?;
+    print_identity(&resp, format);
+    Ok(())
+}
+
+pub fn update(client: &ApiClient, id: &str, display_name: &str, format: Format) -> Result<()> {
+    let resp = client
+        .patch(
+            &format!("/api/v1/identities/{id}"),
+            &json!({
+                "displayName": display_name,
+            }),
+        )
+        .with_context(|| format!("failed to update identity {id}"))?;
+    print_identity(&resp, format);
+    Ok(())
+}
+
+pub fn delete(client: &ApiClient, id: &str, format: Format) -> Result<()> {
+    let resp = client
+        .delete(&format!("/api/v1/identities/{id}"))
+        .with_context(|| format!("failed to delete identity {id}"))?;
+    match format {
+        Format::Json => output::print_json(&resp),
+        Format::Table => output::print_success(&format!("Identity {id} deleted.")),
+    }
+    Ok(())
+}
+
+pub fn list_members(client: &ApiClient, identity: &str, format: Format) -> Result<()> {
+    let resp = client
+        .get(&format!("/api/v1/identities/{identity}/members"))
+        .with_context(|| format!("failed to list members for identity {identity}"))?;
+    print_members(&resp, format);
+    Ok(())
+}
+
+pub fn upsert_member(
+    client: &ApiClient,
+    identity: &str,
+    email: &str,
+    role: &str,
+    format: Format,
+) -> Result<()> {
+    let resp = client
+        .put(
+            &format!("/api/v1/identities/{identity}/members"),
+            &json!({
+                "email": email,
+                "role": role,
+            }),
+        )
+        .with_context(|| format!("failed to update member {email} on identity {identity}"))?;
+    print_member(&resp, format);
+    Ok(())
+}
+
+pub fn remove_member(
+    client: &ApiClient,
+    identity: &str,
+    email: &str,
+    format: Format,
+) -> Result<()> {
+    let encoded_email = encode_path_segment(email);
+    let resp = client
+        .delete(&format!(
+            "/api/v1/identities/{identity}/members/{encoded_email}"
+        ))
+        .with_context(|| format!("failed to remove member {email} from identity {identity}"))?;
+    match format {
+        Format::Json => output::print_json(&resp),
+        Format::Table => {
+            output::print_success(&format!("Removed member {email} from identity {identity}."))
+        }
+    }
+    Ok(())
+}
+
+pub fn list_grants(client: &ApiClient, identity: &str, format: Format) -> Result<()> {
+    let resp = client
+        .get(&format!("/api/v1/identities/{identity}/grants"))
+        .with_context(|| format!("failed to list grants for identity {identity}"))?;
+    print_grants(&resp, format);
+    Ok(())
+}
+
+pub fn set_grant(
+    client: &ApiClient,
+    identity: &str,
+    plugin: &str,
+    operations: &[String],
+    format: Format,
+) -> Result<()> {
+    let resp = client
+        .put(
+            &format!("/api/v1/identities/{identity}/grants/{plugin}"),
+            &json!({
+                "operations": operations,
+            }),
+        )
+        .with_context(|| {
+            format!("failed to set grant for plugin {plugin} on identity {identity}")
+        })?;
+    print_grant(&resp, format);
+    Ok(())
+}
+
+pub fn revoke_grant(
+    client: &ApiClient,
+    identity: &str,
+    plugin: &str,
+    format: Format,
+) -> Result<()> {
+    let resp = client
+        .delete(&format!("/api/v1/identities/{identity}/grants/{plugin}"))
+        .with_context(|| {
+            format!("failed to revoke grant for plugin {plugin} on identity {identity}")
+        })?;
+    match format {
+        Format::Json => output::print_json(&resp),
+        Format::Table => output::print_success(&format!(
+            "Revoked plugin {plugin} from identity {identity}."
+        )),
+    }
+    Ok(())
+}
+
+fn print_identity(value: &serde_json::Value, format: Format) {
+    match format {
+        Format::Json => output::print_json(value),
+        Format::Table => {
+            let row = vec![vec![
+                value["id"].as_str().unwrap_or("-").to_string(),
+                value["displayName"].as_str().unwrap_or("-").to_string(),
+                value["role"].as_str().unwrap_or("-").to_string(),
+                value["createdAt"].as_str().unwrap_or("-").to_string(),
+                value["updatedAt"].as_str().unwrap_or("-").to_string(),
+            ]];
+            output::print_table(&["ID", "Name", "Role", "Created", "Updated"], &row);
+        }
+    }
+}
+
+fn print_identities(value: &serde_json::Value, format: Format) {
+    match format {
+        Format::Json => output::print_json(value),
+        Format::Table => {
+            let items = value.as_array().unwrap_or(&Vec::new()).clone();
+            let rows: Vec<Vec<String>> = items
+                .iter()
+                .map(|item| {
+                    vec![
+                        item["id"].as_str().unwrap_or("-").to_string(),
+                        item["displayName"].as_str().unwrap_or("-").to_string(),
+                        item["role"].as_str().unwrap_or("-").to_string(),
+                        item["createdAt"].as_str().unwrap_or("-").to_string(),
+                        item["updatedAt"].as_str().unwrap_or("-").to_string(),
+                    ]
+                })
+                .collect();
+            output::print_table(&["ID", "Name", "Role", "Created", "Updated"], &rows);
+        }
+    }
+}
+
+fn print_member(value: &serde_json::Value, format: Format) {
+    match format {
+        Format::Json => output::print_json(value),
+        Format::Table => {
+            let row = vec![vec![
+                value["userId"].as_str().unwrap_or("-").to_string(),
+                value["email"].as_str().unwrap_or("-").to_string(),
+                value["role"].as_str().unwrap_or("-").to_string(),
+                value["createdAt"].as_str().unwrap_or("-").to_string(),
+                value["updatedAt"].as_str().unwrap_or("-").to_string(),
+            ]];
+            output::print_table(&["User ID", "Email", "Role", "Created", "Updated"], &row);
+        }
+    }
+}
+
+fn print_members(value: &serde_json::Value, format: Format) {
+    match format {
+        Format::Json => output::print_json(value),
+        Format::Table => {
+            let items = value.as_array().unwrap_or(&Vec::new()).clone();
+            let rows: Vec<Vec<String>> = items
+                .iter()
+                .map(|item| {
+                    vec![
+                        item["userId"].as_str().unwrap_or("-").to_string(),
+                        item["email"].as_str().unwrap_or("-").to_string(),
+                        item["role"].as_str().unwrap_or("-").to_string(),
+                        item["createdAt"].as_str().unwrap_or("-").to_string(),
+                        item["updatedAt"].as_str().unwrap_or("-").to_string(),
+                    ]
+                })
+                .collect();
+            output::print_table(&["User ID", "Email", "Role", "Created", "Updated"], &rows);
+        }
+    }
+}
+
+fn print_grant(value: &serde_json::Value, format: Format) {
+    match format {
+        Format::Json => output::print_json(value),
+        Format::Table => {
+            let operations = render_operations_cell(value.get("operations"));
+            let row = vec![vec![
+                value["plugin"].as_str().unwrap_or("-").to_string(),
+                operations,
+                value["createdAt"].as_str().unwrap_or("-").to_string(),
+                value["updatedAt"].as_str().unwrap_or("-").to_string(),
+            ]];
+            output::print_table(&["Plugin", "Operations", "Created", "Updated"], &row);
+        }
+    }
+}
+
+fn print_grants(value: &serde_json::Value, format: Format) {
+    match format {
+        Format::Json => output::print_json(value),
+        Format::Table => {
+            let items = value.as_array().unwrap_or(&Vec::new()).clone();
+            let rows: Vec<Vec<String>> = items
+                .iter()
+                .map(|item| {
+                    let operations = render_operations_cell(item.get("operations"));
+                    vec![
+                        item["plugin"].as_str().unwrap_or("-").to_string(),
+                        operations,
+                        item["createdAt"].as_str().unwrap_or("-").to_string(),
+                        item["updatedAt"].as_str().unwrap_or("-").to_string(),
+                    ]
+                })
+                .collect();
+            output::print_table(&["Plugin", "Operations", "Created", "Updated"], &rows);
+        }
+    }
+}
+
+fn render_operations_cell(operations: Option<&serde_json::Value>) -> String {
+    match operations.and_then(|value| value.as_array()) {
+        None => "all".to_string(),
+        Some(ops) if ops.is_empty() => "all".to_string(),
+        Some(ops) => {
+            let joined = ops
+                .iter()
+                .filter_map(|op| op.as_str())
+                .collect::<Vec<_>>()
+                .join(",");
+            if joined.is_empty() {
+                "-".to_string()
+            } else {
+                joined
+            }
+        }
+    }
+}
+
+fn encode_path_segment(value: &str) -> String {
+    let mut url = url::Url::parse("https://managed-identities.invalid/").expect("static URL");
+    {
+        let mut segments = url
+            .path_segments_mut()
+            .expect("static URL should support path segments");
+        segments.pop_if_empty();
+        segments.push(value);
+    }
+    url.path().trim_start_matches('/').to_string()
+}

--- a/gestalt/cli/src/commands/mod.rs
+++ b/gestalt/cli/src/commands/mod.rs
@@ -1,6 +1,7 @@
 pub mod auth;
 pub mod config;
 pub mod describe;
+pub mod identities;
 pub mod init;
 pub mod invoke;
 pub mod plugins;

--- a/gestalt/cli/src/main.rs
+++ b/gestalt/cli/src/main.rs
@@ -1,8 +1,8 @@
 use clap::{CommandFactory, Parser};
 use gestalt::api::{self, ApiClient};
 use gestalt::cli::{
-    AuthCommands, Cli, Commands, ConfigCommands, DescribeArgs, InvokeArgs, PluginCommands,
-    TokenCommands,
+    AuthCommands, Cli, Commands, ConfigCommands, DescribeArgs, IdentityCommands,
+    IdentityGrantCommands, IdentityMemberCommands, InvokeArgs, PluginCommands, TokenCommands,
 };
 use gestalt::commands;
 use gestalt::output;
@@ -45,6 +45,65 @@ fn run() -> anyhow::Result<()> {
                 }
                 TokenCommands::List => commands::tokens::list(&client, format),
                 TokenCommands::Revoke { id } => commands::tokens::revoke(&client, &id, format),
+            }
+        }
+        Commands::Identities { command } => {
+            let client = ApiClient::from_env(url)?;
+            match command {
+                IdentityCommands::List => commands::identities::list(&client, format),
+                IdentityCommands::Create { display_name } => {
+                    commands::identities::create(&client, &display_name, format)
+                }
+                IdentityCommands::Get { id } => commands::identities::get(&client, &id, format),
+                IdentityCommands::Update { id, display_name } => {
+                    commands::identities::update(&client, &id, &display_name, format)
+                }
+                IdentityCommands::Delete { id } => {
+                    commands::identities::delete(&client, &id, format)
+                }
+                IdentityCommands::Members { command } => match command {
+                    IdentityMemberCommands::List { identity } => {
+                        commands::identities::list_members(&client, &identity, format)
+                    }
+                    IdentityMemberCommands::Add {
+                        identity,
+                        email,
+                        role,
+                    }
+                    | IdentityMemberCommands::Update {
+                        identity,
+                        email,
+                        role,
+                    } => commands::identities::upsert_member(
+                        &client,
+                        &identity,
+                        &email,
+                        role.as_str(),
+                        format,
+                    ),
+                    IdentityMemberCommands::Remove { identity, email } => {
+                        commands::identities::remove_member(&client, &identity, &email, format)
+                    }
+                },
+                IdentityCommands::Grants { command } => match command {
+                    IdentityGrantCommands::List { identity } => {
+                        commands::identities::list_grants(&client, &identity, format)
+                    }
+                    IdentityGrantCommands::Set {
+                        identity,
+                        plugin,
+                        operations,
+                    } => commands::identities::set_grant(
+                        &client,
+                        &identity,
+                        &plugin,
+                        &operations,
+                        format,
+                    ),
+                    IdentityGrantCommands::Revoke { identity, plugin } => {
+                        commands::identities::revoke_grant(&client, &identity, &plugin, format)
+                    }
+                },
             }
         }
     }

--- a/gestalt/cli/tests/identities_cli.rs
+++ b/gestalt/cli/tests/identities_cli.rs
@@ -1,0 +1,188 @@
+mod support;
+
+use support::*;
+
+#[test]
+fn test_cli_lists_identities() {
+    let mut server = Server::new();
+    let _identities = authed_json_mock!(server, Method::GET, "/api/v1/identities", StatusCode::OK)
+        .with_body(
+            r#"[{"id":"id-1","displayName":"Release Bot","role":"admin","createdAt":"2026-04-15T00:00:00Z","updatedAt":"2026-04-15T00:00:00Z"}]"#,
+        )
+        .create();
+
+    let home = tempfile::tempdir().unwrap();
+    cli_command(home.path())
+        .env("GESTALT_API_KEY", TEST_TOKEN)
+        .arg("--url")
+        .arg(server.url())
+        .args(["identities", "list"])
+        .assert()
+        .success()
+        .stdout(predicate::str::contains("Release Bot"))
+        .stdout(predicate::str::contains("admin"));
+}
+
+#[test]
+fn test_cli_creates_identity() {
+    let mut server = Server::new();
+    let _create =
+        authed_json_mock!(server, Method::POST, "/api/v1/identities", StatusCode::CREATED)
+            .match_header(header::CONTENT_TYPE.as_str(), http::APPLICATION_JSON)
+            .match_body(Matcher::JsonString(
+                r#"{"displayName":"Release Bot"}"#.to_string(),
+            ))
+            .with_body(
+                r#"{"id":"id-1","displayName":"Release Bot","role":"admin","createdAt":"2026-04-15T00:00:00Z","updatedAt":"2026-04-15T00:00:00Z"}"#,
+            )
+            .create();
+
+    let home = tempfile::tempdir().unwrap();
+    cli_command(home.path())
+        .env("GESTALT_API_KEY", TEST_TOKEN)
+        .arg("--url")
+        .arg(server.url())
+        .args([
+            "--format",
+            "json",
+            "identities",
+            "create",
+            "--name",
+            "Release Bot",
+        ])
+        .assert()
+        .success()
+        .stdout(predicate::str::contains(r#""displayName": "Release Bot""#))
+        .stdout(predicate::str::contains(r#""role": "admin""#));
+}
+
+#[test]
+fn test_cli_adds_identity_member() {
+    let mut server = Server::new();
+    let _member = authed_json_mock!(
+        server,
+        Method::PUT,
+        "/api/v1/identities/id-1/members",
+        StatusCode::OK
+    )
+    .match_header(header::CONTENT_TYPE.as_str(), http::APPLICATION_JSON)
+    .match_body(Matcher::JsonString(
+        r#"{"email":"viewer@example.test","role":"viewer"}"#.to_string(),
+    ))
+    .with_body(
+        r#"{"userId":"user-2","email":"viewer@example.test","role":"viewer","createdAt":"2026-04-15T00:00:00Z","updatedAt":"2026-04-15T00:00:00Z"}"#,
+    )
+    .create();
+
+    let home = tempfile::tempdir().unwrap();
+    cli_command(home.path())
+        .env("GESTALT_API_KEY", TEST_TOKEN)
+        .arg("--url")
+        .arg(server.url())
+        .args([
+            "--format",
+            "json",
+            "identities",
+            "members",
+            "add",
+            "id-1",
+            "viewer@example.test",
+            "--role",
+            "viewer",
+        ])
+        .assert()
+        .success()
+        .stdout(predicate::str::contains(
+            r#""email": "viewer@example.test""#,
+        ))
+        .stdout(predicate::str::contains(r#""role": "viewer""#));
+}
+
+#[test]
+fn test_cli_removes_identity_member_with_path_segment_encoding() {
+    let mut server = Server::new();
+    let _remove = authed_json_mock!(
+        server,
+        Method::DELETE,
+        "/api/v1/identities/id-1/members/space%20cadet",
+        StatusCode::OK
+    )
+    .with_body(r#"{"status":"deleted"}"#)
+    .create();
+
+    let home = tempfile::tempdir().unwrap();
+    cli_command(home.path())
+        .env("GESTALT_API_KEY", TEST_TOKEN)
+        .arg("--url")
+        .arg(server.url())
+        .args(["identities", "members", "remove", "id-1", "space cadet"])
+        .assert()
+        .success()
+        .stderr(predicate::str::contains(
+            "Removed member space cadet from identity id-1.",
+        ));
+}
+
+#[test]
+fn test_cli_sets_identity_grant() {
+    let mut server = Server::new();
+    let _grant = authed_json_mock!(
+        server,
+        Method::PUT,
+        "/api/v1/identities/id-1/grants/github",
+        StatusCode::OK
+    )
+    .match_header(header::CONTENT_TYPE.as_str(), http::APPLICATION_JSON)
+    .match_body(Matcher::JsonString(
+        r#"{"operations":["issues.list","pulls.list"]}"#.to_string(),
+    ))
+    .with_body(
+        r#"{"plugin":"github","operations":["issues.list","pulls.list"],"createdAt":"2026-04-15T00:00:00Z","updatedAt":"2026-04-15T00:00:00Z"}"#,
+    )
+    .create();
+
+    let home = tempfile::tempdir().unwrap();
+    cli_command(home.path())
+        .env("GESTALT_API_KEY", TEST_TOKEN)
+        .arg("--url")
+        .arg(server.url())
+        .args([
+            "--format",
+            "json",
+            "identities",
+            "grants",
+            "set",
+            "id-1",
+            "github",
+            "--operation",
+            "issues.list",
+            "--operation",
+            "pulls.list",
+        ])
+        .assert()
+        .success()
+        .stdout(predicate::str::contains(r#""plugin": "github""#))
+        .stdout(predicate::str::contains(r#""issues.list""#))
+        .stdout(predicate::str::contains(r#""pulls.list""#));
+}
+
+#[test]
+fn test_cli_lists_explicit_empty_grant_operations_as_plugin_wide_access() {
+    let mut server = Server::new();
+    let _grants = authed_json_mock!(server, Method::GET, "/api/v1/identities/id-1/grants", StatusCode::OK)
+        .with_body(
+            r#"[{"plugin":"github","operations":[],"createdAt":"2026-04-15T00:00:00Z","updatedAt":"2026-04-15T00:00:00Z"}]"#,
+        )
+        .create();
+
+    let home = tempfile::tempdir().unwrap();
+    cli_command(home.path())
+        .env("GESTALT_API_KEY", TEST_TOKEN)
+        .arg("--url")
+        .arg(server.url())
+        .args(["identities", "grants", "list", "id-1"])
+        .assert()
+        .success()
+        .stdout(predicate::str::contains("github"))
+        .stdout(predicate::str::contains("all"));
+}

--- a/gestaltd/core/types.go
+++ b/gestaltd/core/types.go
@@ -41,6 +41,32 @@ type APIToken struct {
 	UpdatedAt   time.Time
 }
 
+type ManagedIdentity struct {
+	ID          string
+	DisplayName string
+	CreatedAt   time.Time
+	UpdatedAt   time.Time
+}
+
+type ManagedIdentityMembership struct {
+	ID         string
+	IdentityID string
+	UserID     string
+	Email      string
+	Role       string
+	CreatedAt  time.Time
+	UpdatedAt  time.Time
+}
+
+type ManagedIdentityGrant struct {
+	ID         string
+	IdentityID string
+	Plugin     string
+	Operations []string
+	CreatedAt  time.Time
+	UpdatedAt  time.Time
+}
+
 type UserIdentity struct {
 	Email       string
 	DisplayName string

--- a/gestaltd/internal/coredata/managed_identities.go
+++ b/gestaltd/internal/coredata/managed_identities.go
@@ -1,0 +1,112 @@
+package coredata
+
+import (
+	"context"
+	"fmt"
+	"time"
+
+	"github.com/google/uuid"
+	"github.com/valon-technologies/gestalt/server/core"
+	"github.com/valon-technologies/gestalt/server/core/indexeddb"
+)
+
+type ManagedIdentityService struct {
+	store indexeddb.ObjectStore
+}
+
+func NewManagedIdentityService(ds indexeddb.IndexedDB) *ManagedIdentityService {
+	return &ManagedIdentityService{store: ds.ObjectStore(StoreManagedIdentities)}
+}
+
+func (s *ManagedIdentityService) CreateIdentity(ctx context.Context, identity *core.ManagedIdentity) error {
+	if identity.ID == "" {
+		identity.ID = uuid.NewString()
+	}
+	now := time.Now()
+	if identity.CreatedAt.IsZero() {
+		identity.CreatedAt = now
+	}
+	if identity.UpdatedAt.IsZero() {
+		identity.UpdatedAt = identity.CreatedAt
+	}
+	if err := s.store.Add(ctx, indexeddb.Record{
+		"id":           identity.ID,
+		"display_name": identity.DisplayName,
+		"created_at":   identity.CreatedAt,
+		"updated_at":   identity.UpdatedAt,
+	}); err != nil {
+		return fmt.Errorf("create managed identity: %w", err)
+	}
+	return nil
+}
+
+func (s *ManagedIdentityService) GetIdentity(ctx context.Context, id string) (*core.ManagedIdentity, error) {
+	rec, err := s.store.Get(ctx, id)
+	if err != nil {
+		if err == indexeddb.ErrNotFound {
+			return nil, core.ErrNotFound
+		}
+		return nil, fmt.Errorf("get managed identity: %w", err)
+	}
+	return recordToManagedIdentity(rec), nil
+}
+
+func (s *ManagedIdentityService) UpdateIdentity(ctx context.Context, identity *core.ManagedIdentity) error {
+	if identity == nil || identity.ID == "" {
+		return fmt.Errorf("update managed identity: id is required")
+	}
+	existing, err := s.GetIdentity(ctx, identity.ID)
+	if err != nil {
+		return err
+	}
+	identity.CreatedAt = existing.CreatedAt
+	if identity.UpdatedAt.IsZero() {
+		identity.UpdatedAt = time.Now()
+	}
+	if err := s.store.Put(ctx, indexeddb.Record{
+		"id":           identity.ID,
+		"display_name": identity.DisplayName,
+		"created_at":   identity.CreatedAt,
+		"updated_at":   identity.UpdatedAt,
+	}); err != nil {
+		return fmt.Errorf("update managed identity: %w", err)
+	}
+	return nil
+}
+
+func (s *ManagedIdentityService) DeleteIdentity(ctx context.Context, id string) error {
+	if _, err := s.GetIdentity(ctx, id); err != nil {
+		return err
+	}
+	if err := s.store.Delete(ctx, id); err != nil {
+		return fmt.Errorf("delete managed identity: %w", err)
+	}
+	return nil
+}
+
+func (s *ManagedIdentityService) ListIdentitiesByIDs(ctx context.Context, ids []string) ([]*core.ManagedIdentity, error) {
+	out := make([]*core.ManagedIdentity, 0, len(ids))
+	for _, id := range ids {
+		if id == "" {
+			continue
+		}
+		identity, err := s.GetIdentity(ctx, id)
+		if err != nil {
+			if err == core.ErrNotFound {
+				continue
+			}
+			return nil, err
+		}
+		out = append(out, identity)
+	}
+	return out, nil
+}
+
+func recordToManagedIdentity(rec indexeddb.Record) *core.ManagedIdentity {
+	return &core.ManagedIdentity{
+		ID:          recString(rec, "id"),
+		DisplayName: recString(rec, "display_name"),
+		CreatedAt:   recTime(rec, "created_at"),
+		UpdatedAt:   recTime(rec, "updated_at"),
+	}
+}

--- a/gestaltd/internal/coredata/managed_identity_grants.go
+++ b/gestaltd/internal/coredata/managed_identity_grants.go
@@ -1,0 +1,153 @@
+package coredata
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"time"
+
+	"github.com/google/uuid"
+	"github.com/valon-technologies/gestalt/server/core"
+	"github.com/valon-technologies/gestalt/server/core/indexeddb"
+)
+
+type ManagedIdentityGrantService struct {
+	store indexeddb.ObjectStore
+}
+
+func NewManagedIdentityGrantService(ds indexeddb.IndexedDB) *ManagedIdentityGrantService {
+	return &ManagedIdentityGrantService{store: ds.ObjectStore(StoreManagedIdentityGrants)}
+}
+
+func (s *ManagedIdentityGrantService) UpsertGrant(ctx context.Context, grant *core.ManagedIdentityGrant) (*core.ManagedIdentityGrant, error) {
+	if grant == nil || grant.IdentityID == "" || grant.Plugin == "" {
+		return nil, fmt.Errorf("upsert managed identity grant: identity_id and plugin are required")
+	}
+
+	now := time.Now()
+	rec, err := s.store.Index("by_identity_plugin").Get(ctx, grant.IdentityID, grant.Plugin)
+	switch {
+	case err == nil:
+		existing, err := recordToManagedIdentityGrant(rec)
+		if err != nil {
+			return nil, fmt.Errorf("update managed identity grant: %w", err)
+		}
+		existing.Operations = append([]string(nil), grant.Operations...)
+		existing.UpdatedAt = now
+		record, err := managedIdentityGrantRecord(existing)
+		if err != nil {
+			return nil, fmt.Errorf("update managed identity grant: %w", err)
+		}
+		if err := s.store.Put(ctx, record); err != nil {
+			return nil, fmt.Errorf("update managed identity grant: %w", err)
+		}
+		return existing, nil
+	case err != nil && err != indexeddb.ErrNotFound:
+		return nil, fmt.Errorf("lookup managed identity grant: %w", err)
+	}
+
+	if grant.ID == "" {
+		grant.ID = uuid.NewString()
+	}
+	grant.CreatedAt = now
+	grant.UpdatedAt = now
+	record, err := managedIdentityGrantRecord(grant)
+	if err != nil {
+		return nil, fmt.Errorf("create managed identity grant: %w", err)
+	}
+	if err := s.store.Add(ctx, record); err != nil {
+		return nil, fmt.Errorf("create managed identity grant: %w", err)
+	}
+	return grant, nil
+}
+
+func (s *ManagedIdentityGrantService) GetGrant(ctx context.Context, identityID, plugin string) (*core.ManagedIdentityGrant, error) {
+	rec, err := s.store.Index("by_identity_plugin").Get(ctx, identityID, plugin)
+	if err != nil {
+		if err == indexeddb.ErrNotFound {
+			return nil, core.ErrNotFound
+		}
+		return nil, fmt.Errorf("get managed identity grant: %w", err)
+	}
+	grant, err := recordToManagedIdentityGrant(rec)
+	if err != nil {
+		return nil, fmt.Errorf("get managed identity grant: %w", err)
+	}
+	return grant, nil
+}
+
+func (s *ManagedIdentityGrantService) ListGrantsByIdentity(ctx context.Context, identityID string) ([]*core.ManagedIdentityGrant, error) {
+	recs, err := s.store.Index("by_identity").GetAll(ctx, nil, identityID)
+	if err != nil {
+		return nil, fmt.Errorf("list managed identity grants: %w", err)
+	}
+	out := make([]*core.ManagedIdentityGrant, 0, len(recs))
+	for _, rec := range recs {
+		grant, err := recordToManagedIdentityGrant(rec)
+		if err != nil {
+			return nil, fmt.Errorf("list managed identity grants: %w", err)
+		}
+		out = append(out, grant)
+	}
+	return out, nil
+}
+
+func (s *ManagedIdentityGrantService) DeleteGrant(ctx context.Context, identityID, plugin string) error {
+	deleted, err := s.store.Index("by_identity_plugin").Delete(ctx, identityID, plugin)
+	if err != nil {
+		return fmt.Errorf("delete managed identity grant: %w", err)
+	}
+	if deleted == 0 {
+		return core.ErrNotFound
+	}
+	return nil
+}
+
+func (s *ManagedIdentityGrantService) RestoreGrant(ctx context.Context, grant *core.ManagedIdentityGrant) error {
+	if grant == nil || grant.ID == "" || grant.IdentityID == "" || grant.Plugin == "" {
+		return fmt.Errorf("restore managed identity grant: id, identity_id, and plugin are required")
+	}
+	record, err := managedIdentityGrantRecord(grant)
+	if err != nil {
+		return fmt.Errorf("restore managed identity grant: %w", err)
+	}
+	if err := s.store.Put(ctx, record); err != nil {
+		return fmt.Errorf("restore managed identity grant: %w", err)
+	}
+	return nil
+}
+
+func managedIdentityGrantRecord(grant *core.ManagedIdentityGrant) (indexeddb.Record, error) {
+	operationsJSON := ""
+	if len(grant.Operations) > 0 {
+		b, err := json.Marshal(grant.Operations)
+		if err != nil {
+			return nil, fmt.Errorf("marshal managed identity grant operations: %w", err)
+		}
+		operationsJSON = string(b)
+	}
+	return indexeddb.Record{
+		"id":              grant.ID,
+		"identity_id":     grant.IdentityID,
+		"plugin":          grant.Plugin,
+		"operations_json": operationsJSON,
+		"created_at":      grant.CreatedAt,
+		"updated_at":      grant.UpdatedAt,
+	}, nil
+}
+
+func recordToManagedIdentityGrant(rec indexeddb.Record) (*core.ManagedIdentityGrant, error) {
+	grant := &core.ManagedIdentityGrant{
+		ID:         recString(rec, "id"),
+		IdentityID: recString(rec, "identity_id"),
+		Plugin:     recString(rec, "plugin"),
+		CreatedAt:  recTime(rec, "created_at"),
+		UpdatedAt:  recTime(rec, "updated_at"),
+	}
+	if raw := recString(rec, "operations_json"); raw != "" {
+		if err := json.Unmarshal([]byte(raw), &grant.Operations); err != nil {
+			return nil, fmt.Errorf("decode managed identity grant operations: %w", err)
+		}
+	}
+	return grant, nil
+}

--- a/gestaltd/internal/coredata/managed_identity_memberships.go
+++ b/gestaltd/internal/coredata/managed_identity_memberships.go
@@ -1,0 +1,131 @@
+package coredata
+
+import (
+	"context"
+	"fmt"
+	"time"
+
+	"github.com/google/uuid"
+	"github.com/valon-technologies/gestalt/server/core"
+	"github.com/valon-technologies/gestalt/server/core/indexeddb"
+)
+
+type ManagedIdentityMembershipService struct {
+	store indexeddb.ObjectStore
+}
+
+func NewManagedIdentityMembershipService(ds indexeddb.IndexedDB) *ManagedIdentityMembershipService {
+	return &ManagedIdentityMembershipService{store: ds.ObjectStore(StoreManagedIdentityMemberships)}
+}
+
+func (s *ManagedIdentityMembershipService) UpsertMembership(ctx context.Context, membership *core.ManagedIdentityMembership) (*core.ManagedIdentityMembership, error) {
+	if membership == nil || membership.IdentityID == "" || membership.UserID == "" {
+		return nil, fmt.Errorf("upsert managed identity membership: identity_id and user_id are required")
+	}
+
+	now := time.Now()
+	rec, err := s.store.Index("by_identity_user").Get(ctx, membership.IdentityID, membership.UserID)
+	switch {
+	case err == nil:
+		existing := recordToManagedIdentityMembership(rec)
+		existing.Email = membership.Email
+		existing.Role = membership.Role
+		existing.UpdatedAt = now
+		if err := s.store.Put(ctx, managedIdentityMembershipRecord(existing)); err != nil {
+			return nil, fmt.Errorf("update managed identity membership: %w", err)
+		}
+		return existing, nil
+	case err != nil && err != indexeddb.ErrNotFound:
+		return nil, fmt.Errorf("lookup managed identity membership: %w", err)
+	}
+
+	if membership.ID == "" {
+		membership.ID = uuid.NewString()
+	}
+	membership.CreatedAt = now
+	membership.UpdatedAt = now
+	if err := s.store.Add(ctx, managedIdentityMembershipRecord(membership)); err != nil {
+		return nil, fmt.Errorf("create managed identity membership: %w", err)
+	}
+	return membership, nil
+}
+
+func (s *ManagedIdentityMembershipService) GetMembership(ctx context.Context, identityID, userID string) (*core.ManagedIdentityMembership, error) {
+	rec, err := s.store.Index("by_identity_user").Get(ctx, identityID, userID)
+	if err != nil {
+		if err == indexeddb.ErrNotFound {
+			return nil, core.ErrNotFound
+		}
+		return nil, fmt.Errorf("get managed identity membership: %w", err)
+	}
+	return recordToManagedIdentityMembership(rec), nil
+}
+
+func (s *ManagedIdentityMembershipService) ListMembershipsByIdentity(ctx context.Context, identityID string) ([]*core.ManagedIdentityMembership, error) {
+	recs, err := s.store.Index("by_identity").GetAll(ctx, nil, identityID)
+	if err != nil {
+		return nil, fmt.Errorf("list managed identity memberships by identity: %w", err)
+	}
+	out := make([]*core.ManagedIdentityMembership, 0, len(recs))
+	for _, rec := range recs {
+		out = append(out, recordToManagedIdentityMembership(rec))
+	}
+	return out, nil
+}
+
+func (s *ManagedIdentityMembershipService) ListMembershipsByUser(ctx context.Context, userID string) ([]*core.ManagedIdentityMembership, error) {
+	recs, err := s.store.Index("by_user").GetAll(ctx, nil, userID)
+	if err != nil {
+		return nil, fmt.Errorf("list managed identity memberships by user: %w", err)
+	}
+	out := make([]*core.ManagedIdentityMembership, 0, len(recs))
+	for _, rec := range recs {
+		out = append(out, recordToManagedIdentityMembership(rec))
+	}
+	return out, nil
+}
+
+func (s *ManagedIdentityMembershipService) DeleteMembership(ctx context.Context, identityID, userID string) error {
+	deleted, err := s.store.Index("by_identity_user").Delete(ctx, identityID, userID)
+	if err != nil {
+		return fmt.Errorf("delete managed identity membership: %w", err)
+	}
+	if deleted == 0 {
+		return core.ErrNotFound
+	}
+	return nil
+}
+
+func (s *ManagedIdentityMembershipService) RestoreMembership(ctx context.Context, membership *core.ManagedIdentityMembership) error {
+	if membership == nil || membership.ID == "" || membership.IdentityID == "" || membership.UserID == "" {
+		return fmt.Errorf("restore managed identity membership: id, identity_id, and user_id are required")
+	}
+	if err := s.store.Put(ctx, managedIdentityMembershipRecord(membership)); err != nil {
+		return fmt.Errorf("restore managed identity membership: %w", err)
+	}
+	return nil
+}
+
+func managedIdentityMembershipRecord(membership *core.ManagedIdentityMembership) indexeddb.Record {
+	return indexeddb.Record{
+		"id":          membership.ID,
+		"identity_id": membership.IdentityID,
+		"user_id":     membership.UserID,
+		"email":       membership.Email,
+		"role":        membership.Role,
+		"created_at":  membership.CreatedAt,
+		"updated_at":  membership.UpdatedAt,
+	}
+}
+
+func recordToManagedIdentityMembership(rec indexeddb.Record) *core.ManagedIdentityMembership {
+	return &core.ManagedIdentityMembership{
+		ID:         recString(rec, "id"),
+		IdentityID: recString(rec, "identity_id"),
+		UserID:     recString(rec, "user_id"),
+		Email:      recString(rec, "email"),
+		Role:       recString(rec, "role"),
+		CreatedAt:  recTime(rec, "created_at"),
+		UpdatedAt:  recTime(rec, "updated_at"),
+	}
+}

--- a/gestaltd/internal/coredata/schemas.go
+++ b/gestaltd/internal/coredata/schemas.go
@@ -6,6 +6,9 @@ const (
 	StoreUsers                          = "users"
 	StoreIntegrationTokens              = "integration_tokens"
 	StoreAPITokens                      = "api_tokens"
+	StoreManagedIdentities              = "managed_identities"
+	StoreManagedIdentityMemberships     = "managed_identity_memberships"
+	StoreManagedIdentityGrants          = "managed_identity_grants"
 	StorePluginAuthorizationMemberships = "plugin_authorization_memberships"
 	StoreAdminAuthorizationMemberships  = "admin_authorization_memberships"
 )
@@ -63,6 +66,47 @@ var APITokensSchema = indexeddb.ObjectStoreSchema{
 		{Name: "hashed_token", Type: indexeddb.TypeString, NotNull: true, Unique: true},
 		{Name: "scopes", Type: indexeddb.TypeString},
 		{Name: "expires_at", Type: indexeddb.TypeTime},
+		{Name: "created_at", Type: indexeddb.TypeTime},
+		{Name: "updated_at", Type: indexeddb.TypeTime},
+	},
+}
+
+var ManagedIdentitiesSchema = indexeddb.ObjectStoreSchema{
+	Columns: []indexeddb.ColumnDef{
+		{Name: "id", Type: indexeddb.TypeString, PrimaryKey: true},
+		{Name: "display_name", Type: indexeddb.TypeString, NotNull: true},
+		{Name: "created_at", Type: indexeddb.TypeTime},
+		{Name: "updated_at", Type: indexeddb.TypeTime},
+	},
+}
+
+var ManagedIdentityMembershipsSchema = indexeddb.ObjectStoreSchema{
+	Indexes: []indexeddb.IndexSchema{
+		{Name: "by_identity", KeyPath: []string{"identity_id"}},
+		{Name: "by_user", KeyPath: []string{"user_id"}},
+		{Name: "by_identity_user", KeyPath: []string{"identity_id", "user_id"}, Unique: true},
+	},
+	Columns: []indexeddb.ColumnDef{
+		{Name: "id", Type: indexeddb.TypeString, PrimaryKey: true},
+		{Name: "identity_id", Type: indexeddb.TypeString, NotNull: true},
+		{Name: "user_id", Type: indexeddb.TypeString, NotNull: true},
+		{Name: "email", Type: indexeddb.TypeString, NotNull: true},
+		{Name: "role", Type: indexeddb.TypeString, NotNull: true},
+		{Name: "created_at", Type: indexeddb.TypeTime},
+		{Name: "updated_at", Type: indexeddb.TypeTime},
+	},
+}
+
+var ManagedIdentityGrantsSchema = indexeddb.ObjectStoreSchema{
+	Indexes: []indexeddb.IndexSchema{
+		{Name: "by_identity", KeyPath: []string{"identity_id"}},
+		{Name: "by_identity_plugin", KeyPath: []string{"identity_id", "plugin"}, Unique: true},
+	},
+	Columns: []indexeddb.ColumnDef{
+		{Name: "id", Type: indexeddb.TypeString, PrimaryKey: true},
+		{Name: "identity_id", Type: indexeddb.TypeString, NotNull: true},
+		{Name: "plugin", Type: indexeddb.TypeString, NotNull: true},
+		{Name: "operations_json", Type: indexeddb.TypeString},
 		{Name: "created_at", Type: indexeddb.TypeTime},
 		{Name: "updated_at", Type: indexeddb.TypeTime},
 	},

--- a/gestaltd/internal/coredata/services.go
+++ b/gestaltd/internal/coredata/services.go
@@ -12,6 +12,9 @@ type Services struct {
 	Users                *UserService
 	Tokens               *TokenService
 	APITokens            *APITokenService
+	ManagedIdentities    *ManagedIdentityService
+	IdentityMemberships  *ManagedIdentityMembershipService
+	IdentityGrants       *ManagedIdentityGrantService
 	PluginAuthorizations *PluginAuthorizationService
 	AdminAuthorizations  *AdminAuthorizationService
 	DB                   indexeddb.IndexedDB
@@ -28,6 +31,15 @@ func New(ds indexeddb.IndexedDB, enc *corecrypto.AESGCMEncryptor) (*Services, er
 	if err := ds.CreateObjectStore(ctx, StoreAPITokens, APITokensSchema); err != nil {
 		return nil, fmt.Errorf("create api_tokens store: %w", err)
 	}
+	if err := ds.CreateObjectStore(ctx, StoreManagedIdentities, ManagedIdentitiesSchema); err != nil {
+		return nil, fmt.Errorf("create managed_identities store: %w", err)
+	}
+	if err := ds.CreateObjectStore(ctx, StoreManagedIdentityMemberships, ManagedIdentityMembershipsSchema); err != nil {
+		return nil, fmt.Errorf("create managed_identity_memberships store: %w", err)
+	}
+	if err := ds.CreateObjectStore(ctx, StoreManagedIdentityGrants, ManagedIdentityGrantsSchema); err != nil {
+		return nil, fmt.Errorf("create managed_identity_grants store: %w", err)
+	}
 	users := NewUserService(ds)
 	if err := users.BackfillNormalizedEmails(ctx); err != nil {
 		return nil, fmt.Errorf("backfill users store: %w", err)
@@ -42,6 +54,9 @@ func New(ds indexeddb.IndexedDB, enc *corecrypto.AESGCMEncryptor) (*Services, er
 		Users:                users,
 		Tokens:               NewTokenService(ds, enc),
 		APITokens:            NewAPITokenService(ds),
+		ManagedIdentities:    NewManagedIdentityService(ds),
+		IdentityMemberships:  NewManagedIdentityMembershipService(ds),
+		IdentityGrants:       NewManagedIdentityGrantService(ds),
 		PluginAuthorizations: NewPluginAuthorizationService(ds),
 		AdminAuthorizations:  NewAdminAuthorizationService(ds),
 		DB:                   ds,

--- a/gestaltd/internal/server/audit.go
+++ b/gestaltd/internal/server/audit.go
@@ -12,12 +12,15 @@ import (
 )
 
 const (
-	auditTargetKindAPIToken             = "api_token"
-	auditTargetKindAPITokenCollection   = "api_token_collection"
-	auditTargetKindConnection           = "connection"
-	auditDecisionProviderAccessDenied   = "provider_access_denied"
-	auditDecisionOperationBindingDenied = "operation_binding_denied"
-	auditDecisionCatalogRoleDenied      = "catalog_role_denied"
+	auditTargetKindAPIToken              = "api_token"
+	auditTargetKindAPITokenCollection    = "api_token_collection"
+	auditTargetKindConnection            = "connection"
+	auditTargetKindManagedIdentity       = "managed_identity"
+	auditTargetKindManagedIdentityMember = "managed_identity_member"
+	auditTargetKindManagedIdentityGrant  = "managed_identity_grant"
+	auditDecisionProviderAccessDenied    = "provider_access_denied"
+	auditDecisionOperationBindingDenied  = "operation_binding_denied"
+	auditDecisionCatalogRoleDenied       = "catalog_role_denied"
 )
 
 type auditTarget struct {
@@ -164,6 +167,30 @@ func connectionAuditTarget(provider, connection, instance string) auditTarget {
 		ID:   strings.Join(idParts, "/"),
 		Kind: auditTargetKindConnection,
 		Name: connection + "/" + instance,
+	}
+}
+
+func managedIdentityAuditTarget(id, name string) auditTarget {
+	return auditTarget{
+		ID:   strings.TrimSpace(id),
+		Kind: auditTargetKindManagedIdentity,
+		Name: strings.TrimSpace(name),
+	}
+}
+
+func managedIdentityMemberAuditTarget(identityID, email string) auditTarget {
+	return auditTarget{
+		ID:   strings.TrimSpace(identityID),
+		Kind: auditTargetKindManagedIdentityMember,
+		Name: strings.TrimSpace(email),
+	}
+}
+
+func managedIdentityGrantAuditTarget(identityID, plugin string) auditTarget {
+	return auditTarget{
+		ID:   strings.TrimSpace(identityID),
+		Kind: auditTargetKindManagedIdentityGrant,
+		Name: strings.TrimSpace(plugin),
 	}
 }
 

--- a/gestaltd/internal/server/handlers_identities.go
+++ b/gestaltd/internal/server/handlers_identities.go
@@ -1,0 +1,1270 @@
+package server
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"io"
+	"net/http"
+	"net/url"
+	"slices"
+	"sort"
+	"strings"
+	"time"
+
+	"github.com/go-chi/chi/v5"
+	"github.com/google/uuid"
+	"github.com/valon-technologies/gestalt/server/core"
+	"github.com/valon-technologies/gestalt/server/core/catalog"
+	"github.com/valon-technologies/gestalt/server/internal/config"
+	"github.com/valon-technologies/gestalt/server/internal/emailutil"
+	"github.com/valon-technologies/gestalt/server/internal/invocation"
+	"github.com/valon-technologies/gestalt/server/internal/principal"
+)
+
+const (
+	managedIdentityRoleViewer = "viewer"
+	managedIdentityRoleEditor = "editor"
+	managedIdentityRoleAdmin  = "admin"
+)
+
+var managedIdentityRoleRank = map[string]int{
+	managedIdentityRoleViewer: 1,
+	managedIdentityRoleEditor: 2,
+	managedIdentityRoleAdmin:  3,
+}
+
+type managedIdentityInfo struct {
+	ID          string    `json:"id"`
+	DisplayName string    `json:"displayName"`
+	Role        string    `json:"role"`
+	CreatedAt   time.Time `json:"createdAt"`
+	UpdatedAt   time.Time `json:"updatedAt"`
+}
+
+type managedIdentityMemberInfo struct {
+	UserID    string    `json:"userId"`
+	Email     string    `json:"email"`
+	Role      string    `json:"role"`
+	CreatedAt time.Time `json:"createdAt"`
+	UpdatedAt time.Time `json:"updatedAt"`
+}
+
+type managedIdentityGrantInfo struct {
+	Plugin     string    `json:"plugin"`
+	Operations []string  `json:"operations"`
+	CreatedAt  time.Time `json:"createdAt"`
+	UpdatedAt  time.Time `json:"updatedAt"`
+}
+
+type createManagedIdentityRequest struct {
+	DisplayName string `json:"displayName"`
+}
+
+type updateManagedIdentityRequest struct {
+	DisplayName string `json:"displayName"`
+}
+
+type putManagedIdentityMemberRequest struct {
+	Email string `json:"email"`
+	Role  string `json:"role"`
+}
+
+type putManagedIdentityGrantRequest struct {
+	Operations []string `json:"operations"`
+}
+
+type managedIdentityActor struct {
+	UserID     string
+	Identity   *core.ManagedIdentity
+	Membership *core.ManagedIdentityMembership
+}
+
+func (s *Server) listManagedIdentities(w http.ResponseWriter, r *http.Request) {
+	userID, _, ok := s.resolveManagedIdentityUser(w, r)
+	if !ok {
+		return
+	}
+
+	memberships, err := s.identityMemberships.ListMembershipsByUser(r.Context(), userID)
+	if err != nil {
+		writeError(w, http.StatusInternalServerError, "failed to list identities")
+		return
+	}
+
+	identityIDs := make([]string, 0, len(memberships))
+	roleByIdentityID := make(map[string]string, len(memberships))
+	for _, membership := range memberships {
+		identityIDs = append(identityIDs, membership.IdentityID)
+		roleByIdentityID[membership.IdentityID] = membership.Role
+	}
+
+	identities, err := s.managedIdentities.ListIdentitiesByIDs(r.Context(), identityIDs)
+	if err != nil {
+		writeError(w, http.StatusInternalServerError, "failed to list identities")
+		return
+	}
+
+	out := make([]managedIdentityInfo, 0, len(identities))
+	for _, identity := range identities {
+		out = append(out, managedIdentityInfo{
+			ID:          identity.ID,
+			DisplayName: identity.DisplayName,
+			Role:        roleByIdentityID[identity.ID],
+			CreatedAt:   identity.CreatedAt,
+			UpdatedAt:   identity.UpdatedAt,
+		})
+	}
+	sort.Slice(out, func(i, j int) bool {
+		if out[i].DisplayName != out[j].DisplayName {
+			return out[i].DisplayName < out[j].DisplayName
+		}
+		return out[i].ID < out[j].ID
+	})
+
+	writeJSON(w, http.StatusOK, out)
+}
+
+func (s *Server) createManagedIdentity(w http.ResponseWriter, r *http.Request) {
+	auditAllowed := false
+	auditErr := errors.New("identity create failed")
+	auditTarget := managedIdentityAuditTarget("", "")
+	defer func() {
+		s.auditHTTPEventWithTarget(r.Context(), PrincipalFromContext(r.Context()), "", "identity.create", auditAllowed, auditErr, auditTarget)
+	}()
+
+	userID, user, ok := s.resolveManagedIdentityUser(w, r)
+	if !ok {
+		return
+	}
+
+	var req createManagedIdentityRequest
+	if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
+		writeError(w, http.StatusBadRequest, "invalid JSON body")
+		return
+	}
+	req.DisplayName = strings.TrimSpace(req.DisplayName)
+	if req.DisplayName == "" {
+		auditErr = errors.New("displayName is required")
+		writeError(w, http.StatusBadRequest, "displayName is required")
+		return
+	}
+	auditTarget = managedIdentityAuditTarget("", req.DisplayName)
+
+	s.managedIdentityMu.Lock()
+	defer s.managedIdentityMu.Unlock()
+
+	now := s.nowUTCSecond()
+	identity := &core.ManagedIdentity{
+		ID:          uuid.NewString(),
+		DisplayName: req.DisplayName,
+		CreatedAt:   now,
+		UpdatedAt:   now,
+	}
+	if err := s.managedIdentities.CreateIdentity(r.Context(), identity); err != nil {
+		auditErr = errors.New("failed to create identity")
+		writeError(w, http.StatusInternalServerError, "failed to create identity")
+		return
+	}
+	membership, err := s.identityMemberships.UpsertMembership(r.Context(), &core.ManagedIdentityMembership{
+		IdentityID: identity.ID,
+		UserID:     userID,
+		Email:      user.Email,
+		Role:       managedIdentityRoleAdmin,
+	})
+	if err != nil {
+		membership = &core.ManagedIdentityMembership{
+			ID:         uuid.NewString(),
+			IdentityID: identity.ID,
+			UserID:     userID,
+			Email:      user.Email,
+			Role:       managedIdentityRoleAdmin,
+			CreatedAt:  now,
+			UpdatedAt:  now,
+		}
+		membership, err = s.recoverManagedIdentityCreateMembership(r.Context(), identity, membership, err)
+		if err != nil {
+			auditErr = err
+			writeError(w, http.StatusInternalServerError, "failed to create identity membership")
+			return
+		}
+	}
+	auditAllowed = true
+	auditErr = nil
+	auditTarget = managedIdentityAuditTarget(identity.ID, identity.DisplayName)
+
+	writeJSON(w, http.StatusCreated, managedIdentityInfo{
+		ID:          identity.ID,
+		DisplayName: identity.DisplayName,
+		Role:        membership.Role,
+		CreatedAt:   identity.CreatedAt,
+		UpdatedAt:   identity.UpdatedAt,
+	})
+}
+
+func (s *Server) getManagedIdentity(w http.ResponseWriter, r *http.Request) {
+	actor, ok := s.resolveManagedIdentityActor(w, r, managedIdentityRoleViewer)
+	if !ok {
+		return
+	}
+
+	writeJSON(w, http.StatusOK, managedIdentityInfo{
+		ID:          actor.Identity.ID,
+		DisplayName: actor.Identity.DisplayName,
+		Role:        actor.Membership.Role,
+		CreatedAt:   actor.Identity.CreatedAt,
+		UpdatedAt:   actor.Identity.UpdatedAt,
+	})
+}
+
+func (s *Server) routeManagedIdentityOrExecuteIdentitiesOperation(
+	w http.ResponseWriter,
+	r *http.Request,
+	identityHandler func(http.ResponseWriter, *http.Request),
+) {
+	identityID := strings.TrimSpace(chi.URLParam(r, "identityID"))
+	if identityID == "" {
+		identityHandler(w, r)
+		return
+	}
+	if s.managedIdentities != nil {
+		if _, err := s.managedIdentities.GetIdentity(r.Context(), identityID); err == nil {
+			identityHandler(w, r)
+			return
+		} else if !errors.Is(err, core.ErrNotFound) {
+			writeError(w, http.StatusInternalServerError, "failed to resolve identity")
+			return
+		}
+	}
+	if s.identitiesProviderHasOperation(r.Context(), identityID, r.Method, PrincipalFromContext(r.Context())) {
+		s.executeIdentitiesOperation(w, r)
+		return
+	}
+	identityHandler(w, r)
+}
+
+func (s *Server) getManagedIdentityOrExecuteIdentitiesOperation(w http.ResponseWriter, r *http.Request) {
+	s.routeManagedIdentityOrExecuteIdentitiesOperation(w, r, s.getManagedIdentity)
+}
+
+func (s *Server) updateManagedIdentityOrExecuteIdentitiesOperation(w http.ResponseWriter, r *http.Request) {
+	s.routeManagedIdentityOrExecuteIdentitiesOperation(w, r, s.updateManagedIdentity)
+}
+
+func (s *Server) deleteManagedIdentityOrExecuteIdentitiesOperation(w http.ResponseWriter, r *http.Request) {
+	s.routeManagedIdentityOrExecuteIdentitiesOperation(w, r, s.deleteManagedIdentity)
+}
+
+func (s *Server) executeIdentitiesOperation(w http.ResponseWriter, r *http.Request) {
+	operation := strings.TrimSpace(chi.URLParam(r, "identityID"))
+	routeCtx := chi.RouteContext(r.Context())
+	if routeCtx == nil {
+		routeCtx = chi.NewRouteContext()
+	} else {
+		cloned := chi.NewRouteContext()
+		*cloned = *routeCtx
+		routeCtx = cloned
+	}
+	routeCtx.URLParams.Add("integration", "identities")
+	routeCtx.URLParams.Add("operation", operation)
+	r = r.WithContext(context.WithValue(r.Context(), chi.RouteCtxKey, routeCtx))
+	s.executeOperation(w, r)
+}
+
+func (s *Server) identitiesProviderHasOperation(ctx context.Context, operation, method string, p *principal.Principal) bool {
+	prov, err := s.providers.Get("identities")
+	if err != nil {
+		return false
+	}
+	var resolver invocation.TokenResolver
+	if tr, ok := s.invoker.(invocation.TokenResolver); ok {
+		resolver = tr
+	}
+	ctx = invocation.WithAccessContext(ctx, s.providerAccessContext(p, "identities"))
+	targets, err := s.managedIdentityGrantCatalogTargets(ctx, "identities", p)
+	if err != nil {
+		return false
+	}
+	for _, target := range targets {
+		cat, err := s.managedIdentityGrantCatalogForConnection(ctx, prov, "identities", resolver, p, target.connection, target.instance)
+		if err != nil || cat == nil {
+			continue
+		}
+		for i := range cat.Operations {
+			op := cat.Operations[i]
+			if op.ID != operation {
+				continue
+			}
+			if strings.TrimSpace(op.Method) == "" || strings.EqualFold(op.Method, method) {
+				return true
+			}
+		}
+	}
+	return false
+}
+
+func (s *Server) updateManagedIdentity(w http.ResponseWriter, r *http.Request) {
+	auditAllowed := false
+	auditErr := errors.New("identity update failed")
+	auditTarget := managedIdentityAuditTarget(chi.URLParam(r, "identityID"), "")
+	defer func() {
+		s.auditHTTPEventWithTarget(r.Context(), PrincipalFromContext(r.Context()), "", "identity.update", auditAllowed, auditErr, auditTarget)
+	}()
+
+	var req updateManagedIdentityRequest
+	if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
+		writeError(w, http.StatusBadRequest, "invalid JSON body")
+		return
+	}
+	req.DisplayName = strings.TrimSpace(req.DisplayName)
+	if req.DisplayName == "" {
+		auditErr = errors.New("displayName is required")
+		writeError(w, http.StatusBadRequest, "displayName is required")
+		return
+	}
+
+	s.managedIdentityMu.Lock()
+	defer s.managedIdentityMu.Unlock()
+
+	actor, ok := s.resolveManagedIdentityActor(w, r, managedIdentityRoleAdmin)
+	if !ok {
+		return
+	}
+	auditTarget = managedIdentityAuditTarget(actor.Identity.ID, actor.Identity.DisplayName)
+
+	actor.Identity.DisplayName = req.DisplayName
+	actor.Identity.UpdatedAt = s.nowUTCSecond()
+	if err := s.managedIdentities.UpdateIdentity(r.Context(), actor.Identity); err != nil {
+		auditErr = errors.New("failed to update identity")
+		writeError(w, http.StatusInternalServerError, "failed to update identity")
+		return
+	}
+	auditAllowed = true
+	auditErr = nil
+	auditTarget = managedIdentityAuditTarget(actor.Identity.ID, actor.Identity.DisplayName)
+
+	writeJSON(w, http.StatusOK, managedIdentityInfo{
+		ID:          actor.Identity.ID,
+		DisplayName: actor.Identity.DisplayName,
+		Role:        actor.Membership.Role,
+		CreatedAt:   actor.Identity.CreatedAt,
+		UpdatedAt:   actor.Identity.UpdatedAt,
+	})
+}
+
+func (s *Server) deleteManagedIdentity(w http.ResponseWriter, r *http.Request) {
+	auditAllowed := false
+	auditErr := errors.New("identity delete failed")
+	auditTarget := managedIdentityAuditTarget(chi.URLParam(r, "identityID"), "")
+	defer func() {
+		s.auditHTTPEventWithTarget(r.Context(), PrincipalFromContext(r.Context()), "", "identity.delete", auditAllowed, auditErr, auditTarget)
+	}()
+
+	s.managedIdentityMu.Lock()
+	defer s.managedIdentityMu.Unlock()
+
+	actor, ok := s.resolveManagedIdentityActor(w, r, managedIdentityRoleAdmin)
+	if !ok {
+		return
+	}
+	auditTarget = managedIdentityAuditTarget(actor.Identity.ID, actor.Identity.DisplayName)
+
+	snapshot, err := s.loadManagedIdentityDeleteSnapshot(r.Context(), actor.Identity.ID)
+	if err != nil {
+		auditErr = errors.New("failed to load identity delete snapshot")
+		writeError(w, http.StatusInternalServerError, "failed to delete identity")
+		return
+	}
+
+	if err := s.deleteManagedIdentityChildren(r.Context(), snapshot, actor.UserID); err != nil {
+		auditErr = fmt.Errorf("failed to delete identity children: %w", err)
+		writeError(w, http.StatusInternalServerError, "failed to delete identity")
+		return
+	}
+
+	if err := s.managedIdentities.DeleteIdentity(r.Context(), actor.Identity.ID); err != nil {
+		if restoreErr := s.restoreManagedIdentityChildren(r.Context(), snapshot, actor.UserID); restoreErr != nil {
+			auditErr = fmt.Errorf("failed to delete identity and restore children: %w", restoreErr)
+			writeError(w, http.StatusInternalServerError, "failed to delete identity")
+			return
+		}
+		auditErr = errors.New("failed to delete identity")
+		writeError(w, http.StatusInternalServerError, "failed to delete identity")
+		return
+	}
+
+	auditAllowed = true
+	auditErr = nil
+
+	writeJSON(w, http.StatusOK, map[string]any{"status": "deleted"})
+}
+
+func (s *Server) listManagedIdentityMembers(w http.ResponseWriter, r *http.Request) {
+	actor, ok := s.resolveManagedIdentityActor(w, r, managedIdentityRoleViewer)
+	if !ok {
+		return
+	}
+
+	memberships, err := s.identityMemberships.ListMembershipsByIdentity(r.Context(), actor.Identity.ID)
+	if err != nil {
+		writeError(w, http.StatusInternalServerError, "failed to list identity members")
+		return
+	}
+
+	out := make([]managedIdentityMemberInfo, 0, len(memberships))
+	for _, membership := range memberships {
+		out = append(out, managedIdentityMemberInfo{
+			UserID:    membership.UserID,
+			Email:     membership.Email,
+			Role:      membership.Role,
+			CreatedAt: membership.CreatedAt,
+			UpdatedAt: membership.UpdatedAt,
+		})
+	}
+	sort.Slice(out, func(i, j int) bool {
+		if managedIdentityRoleRank[out[i].Role] != managedIdentityRoleRank[out[j].Role] {
+			return managedIdentityRoleRank[out[i].Role] > managedIdentityRoleRank[out[j].Role]
+		}
+		if out[i].Email != out[j].Email {
+			return out[i].Email < out[j].Email
+		}
+		return out[i].UserID < out[j].UserID
+	})
+
+	writeJSON(w, http.StatusOK, out)
+}
+
+func (s *Server) putManagedIdentityMember(w http.ResponseWriter, r *http.Request) {
+	auditAllowed := false
+	auditErr := errors.New("identity member update failed")
+	auditTarget := managedIdentityMemberAuditTarget(chi.URLParam(r, "identityID"), "")
+	defer func() {
+		s.auditHTTPEventWithTarget(r.Context(), PrincipalFromContext(r.Context()), "", "identity.member.put", auditAllowed, auditErr, auditTarget)
+	}()
+
+	var req putManagedIdentityMemberRequest
+	if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
+		writeError(w, http.StatusBadRequest, "invalid JSON body")
+		return
+	}
+	role := normalizeManagedIdentityRole(req.Role)
+	if role == "" {
+		auditErr = errors.New("invalid role")
+		writeError(w, http.StatusBadRequest, "role must be viewer, editor, or admin")
+		return
+	}
+	email := emailutil.Normalize(req.Email)
+	if email == "" {
+		auditErr = errors.New("email is required")
+		writeError(w, http.StatusBadRequest, "email is required")
+		return
+	}
+
+	s.managedIdentityMu.Lock()
+	defer s.managedIdentityMu.Unlock()
+
+	actor, ok := s.resolveManagedIdentityActor(w, r, managedIdentityRoleAdmin)
+	if !ok {
+		return
+	}
+	auditTarget = managedIdentityMemberAuditTarget(actor.Identity.ID, email)
+
+	user, err := s.users.FindOrCreateUser(r.Context(), email)
+	if err != nil {
+		auditErr = errors.New("failed to resolve user")
+		writeError(w, http.StatusInternalServerError, "failed to resolve user")
+		return
+	}
+
+	existing, err := s.identityMemberships.GetMembership(r.Context(), actor.Identity.ID, user.ID)
+	if err != nil && !errors.Is(err, core.ErrNotFound) {
+		auditErr = errors.New("failed to resolve existing membership")
+		writeError(w, http.StatusInternalServerError, "failed to resolve existing membership")
+		return
+	}
+	if existing != nil && existing.Role == managedIdentityRoleAdmin && role != managedIdentityRoleAdmin {
+		if !s.ensureManagedIdentityHasAnotherAdmin(w, r, actor.Identity.ID, user.ID) {
+			return
+		}
+	}
+
+	membership, err := s.identityMemberships.UpsertMembership(r.Context(), &core.ManagedIdentityMembership{
+		IdentityID: actor.Identity.ID,
+		UserID:     user.ID,
+		Email:      user.Email,
+		Role:       role,
+	})
+	if err != nil {
+		auditErr = errors.New("failed to persist identity member")
+		writeError(w, http.StatusInternalServerError, "failed to persist identity member")
+		return
+	}
+	auditAllowed = true
+	auditErr = nil
+	auditTarget = managedIdentityMemberAuditTarget(actor.Identity.ID, membership.Email)
+
+	writeJSON(w, http.StatusOK, managedIdentityMemberInfo{
+		UserID:    membership.UserID,
+		Email:     membership.Email,
+		Role:      membership.Role,
+		CreatedAt: membership.CreatedAt,
+		UpdatedAt: membership.UpdatedAt,
+	})
+}
+
+func (s *Server) deleteManagedIdentityMember(w http.ResponseWriter, r *http.Request) {
+	auditAllowed := false
+	auditErr := errors.New("identity member delete failed")
+	auditTarget := managedIdentityMemberAuditTarget(chi.URLParam(r, "identityID"), "")
+	defer func() {
+		s.auditHTTPEventWithTarget(r.Context(), PrincipalFromContext(r.Context()), "", "identity.member.delete", auditAllowed, auditErr, auditTarget)
+	}()
+
+	rawEmail, err := url.PathUnescape(strings.TrimSpace(chi.URLParam(r, "email")))
+	if err != nil {
+		auditErr = errors.New("invalid email path")
+		writeError(w, http.StatusBadRequest, "invalid email path")
+		return
+	}
+	email := emailutil.Normalize(rawEmail)
+	if email == "" {
+		auditErr = errors.New("email is required")
+		writeError(w, http.StatusBadRequest, "email is required")
+		return
+	}
+
+	s.managedIdentityMu.Lock()
+	defer s.managedIdentityMu.Unlock()
+
+	actor, ok := s.resolveManagedIdentityActor(w, r, managedIdentityRoleAdmin)
+	if !ok {
+		return
+	}
+	auditTarget = managedIdentityMemberAuditTarget(actor.Identity.ID, email)
+
+	user, err := s.users.FindUserByEmail(r.Context(), email)
+	if err != nil {
+		if errors.Is(err, core.ErrNotFound) {
+			auditErr = errors.New("identity member not found")
+			writeError(w, http.StatusNotFound, "identity member not found")
+			return
+		}
+		auditErr = errors.New("failed to resolve identity member")
+		writeError(w, http.StatusInternalServerError, "failed to resolve identity member")
+		return
+	}
+
+	membership, err := s.identityMemberships.GetMembership(r.Context(), actor.Identity.ID, user.ID)
+	if err != nil {
+		if errors.Is(err, core.ErrNotFound) {
+			auditErr = errors.New("identity member not found")
+			writeError(w, http.StatusNotFound, "identity member not found")
+			return
+		}
+		auditErr = errors.New("failed to resolve identity member")
+		writeError(w, http.StatusInternalServerError, "failed to resolve identity member")
+		return
+	}
+	if membership.Role == managedIdentityRoleAdmin && !s.ensureManagedIdentityHasAnotherAdmin(w, r, actor.Identity.ID, membership.UserID) {
+		return
+	}
+	if err := s.identityMemberships.DeleteMembership(r.Context(), actor.Identity.ID, membership.UserID); err != nil {
+		auditErr = errors.New("failed to delete identity member")
+		writeError(w, http.StatusInternalServerError, "failed to delete identity member")
+		return
+	}
+	auditAllowed = true
+	auditErr = nil
+	auditTarget = managedIdentityMemberAuditTarget(actor.Identity.ID, membership.Email)
+
+	writeJSON(w, http.StatusOK, map[string]string{"status": "deleted"})
+}
+
+func (s *Server) listManagedIdentityGrants(w http.ResponseWriter, r *http.Request) {
+	actor, ok := s.resolveManagedIdentityActor(w, r, managedIdentityRoleViewer)
+	if !ok {
+		return
+	}
+
+	grants, err := s.identityGrants.ListGrantsByIdentity(r.Context(), actor.Identity.ID)
+	if err != nil {
+		writeError(w, http.StatusInternalServerError, "failed to list identity grants")
+		return
+	}
+
+	p := PrincipalFromContext(r.Context())
+	out := make([]managedIdentityGrantInfo, 0, len(grants))
+	for _, grant := range grants {
+		if !s.managedIdentityGrantVisibleToActor(grant.Plugin, p, actor.Membership.Role) {
+			continue
+		}
+		out = append(out, managedIdentityGrantInfo{
+			Plugin:     grant.Plugin,
+			Operations: managedIdentityGrantOperationsResponse(grant.Operations),
+			CreatedAt:  grant.CreatedAt,
+			UpdatedAt:  grant.UpdatedAt,
+		})
+	}
+	sort.Slice(out, func(i, j int) bool { return out[i].Plugin < out[j].Plugin })
+
+	writeJSON(w, http.StatusOK, out)
+}
+
+func (s *Server) putManagedIdentityGrant(w http.ResponseWriter, r *http.Request) {
+	auditAllowed := false
+	auditErr := errors.New("identity grant update failed")
+	auditTarget := managedIdentityGrantAuditTarget(chi.URLParam(r, "identityID"), chi.URLParam(r, "plugin"))
+	defer func() {
+		s.auditHTTPEventWithTarget(r.Context(), PrincipalFromContext(r.Context()), "", "identity.grant.put", auditAllowed, auditErr, auditTarget)
+	}()
+
+	plugin := strings.TrimSpace(chi.URLParam(r, "plugin"))
+
+	s.managedIdentityMu.Lock()
+	_, ok := s.resolveManagedIdentityActor(w, r, managedIdentityRoleEditor)
+	s.managedIdentityMu.Unlock()
+	if !ok {
+		return
+	}
+
+	var req putManagedIdentityGrantRequest
+	if err := json.NewDecoder(r.Body).Decode(&req); err != nil && !errors.Is(err, io.EOF) {
+		auditErr = errors.New("invalid JSON body")
+		writeError(w, http.StatusBadRequest, "invalid JSON body")
+		return
+	}
+
+	p := PrincipalFromContext(r.Context())
+	if !s.managedIdentityGrantPluginVisible(plugin, p) {
+		auditErr = errors.New("plugin not found")
+		writeError(w, http.StatusNotFound, "plugin not found")
+		return
+	}
+	operations := normalizeManagedIdentityOperations(req.Operations)
+	if len(req.Operations) > 0 && len(operations) == 0 {
+		auditErr = errors.New("operations must contain at least one non-blank operation")
+		writeError(w, http.StatusBadRequest, "operations must contain at least one non-blank operation")
+		return
+	}
+	if err := s.validateManagedIdentityGrantOperations(r.Context(), plugin, operations, p); err != nil {
+		auditErr = err
+		writeError(w, http.StatusBadRequest, err.Error())
+		return
+	}
+
+	s.managedIdentityMu.Lock()
+	defer s.managedIdentityMu.Unlock()
+
+	actor, ok := s.resolveManagedIdentityActor(w, r, managedIdentityRoleEditor)
+	if !ok {
+		return
+	}
+	if !s.managedIdentityGrantPluginVisible(plugin, p) {
+		auditErr = errors.New("plugin not found")
+		writeError(w, http.StatusNotFound, "plugin not found")
+		return
+	}
+	auditTarget = managedIdentityGrantAuditTarget(actor.Identity.ID, plugin)
+
+	grant, err := s.identityGrants.UpsertGrant(r.Context(), &core.ManagedIdentityGrant{
+		IdentityID: actor.Identity.ID,
+		Plugin:     plugin,
+		Operations: operations,
+	})
+	if err != nil {
+		auditErr = errors.New("failed to persist identity grant")
+		writeError(w, http.StatusInternalServerError, "failed to persist identity grant")
+		return
+	}
+	auditAllowed = true
+	auditErr = nil
+
+	writeJSON(w, http.StatusOK, managedIdentityGrantInfo{
+		Plugin:     grant.Plugin,
+		Operations: managedIdentityGrantOperationsResponse(grant.Operations),
+		CreatedAt:  grant.CreatedAt,
+		UpdatedAt:  grant.UpdatedAt,
+	})
+}
+
+func managedIdentityGrantOperationsResponse(operations []string) []string {
+	if len(operations) == 0 {
+		return []string{}
+	}
+	return append([]string(nil), operations...)
+}
+
+func (s *Server) deleteManagedIdentityGrant(w http.ResponseWriter, r *http.Request) {
+	auditAllowed := false
+	auditErr := errors.New("identity grant delete failed")
+	auditTarget := managedIdentityGrantAuditTarget(chi.URLParam(r, "identityID"), chi.URLParam(r, "plugin"))
+	defer func() {
+		s.auditHTTPEventWithTarget(r.Context(), PrincipalFromContext(r.Context()), "", "identity.grant.delete", auditAllowed, auditErr, auditTarget)
+	}()
+
+	plugin := strings.TrimSpace(chi.URLParam(r, "plugin"))
+
+	s.managedIdentityMu.Lock()
+	defer s.managedIdentityMu.Unlock()
+
+	actor, ok := s.resolveManagedIdentityActor(w, r, managedIdentityRoleEditor)
+	if !ok {
+		return
+	}
+	if _, err := s.providers.Get(plugin); err != nil {
+		if _, grantErr := s.identityGrants.GetGrant(r.Context(), actor.Identity.ID, plugin); grantErr != nil {
+			if errors.Is(grantErr, core.ErrNotFound) {
+				auditErr = errors.New("identity grant not found")
+				writeError(w, http.StatusNotFound, "identity grant not found")
+				return
+			}
+			auditErr = errors.New("failed to resolve identity grant")
+			writeError(w, http.StatusInternalServerError, "failed to resolve identity grant")
+			return
+		}
+	} else if !s.allowProvider(PrincipalFromContext(r.Context()), plugin) {
+		auditErr = errors.New("plugin not found")
+		writeError(w, http.StatusNotFound, "plugin not found")
+		return
+	}
+	auditTarget = managedIdentityGrantAuditTarget(actor.Identity.ID, plugin)
+	if err := s.identityGrants.DeleteGrant(r.Context(), actor.Identity.ID, plugin); err != nil {
+		if errors.Is(err, core.ErrNotFound) {
+			auditErr = errors.New("identity grant not found")
+			writeError(w, http.StatusNotFound, "identity grant not found")
+			return
+		}
+		auditErr = errors.New("failed to delete identity grant")
+		writeError(w, http.StatusInternalServerError, "failed to delete identity grant")
+		return
+	}
+	auditAllowed = true
+	auditErr = nil
+
+	writeJSON(w, http.StatusOK, map[string]string{"status": "deleted"})
+}
+
+func (s *Server) resolveManagedIdentityUser(w http.ResponseWriter, r *http.Request) (string, *core.User, bool) {
+	if !s.ensureManagedIdentityRoutesAvailable(w) {
+		return "", nil, false
+	}
+	userID, err := s.resolveUserID(w, r)
+	if err != nil {
+		return "", nil, false
+	}
+	user, err := s.users.GetUser(r.Context(), userID)
+	if err != nil {
+		writeError(w, http.StatusInternalServerError, "failed to resolve user")
+		return "", nil, false
+	}
+	return userID, user, true
+}
+
+func (s *Server) resolveManagedIdentityActor(w http.ResponseWriter, r *http.Request, requiredRole string) (*managedIdentityActor, bool) {
+	userID, _, ok := s.resolveManagedIdentityUser(w, r)
+	if !ok {
+		return nil, false
+	}
+
+	identityID := strings.TrimSpace(chi.URLParam(r, "identityID"))
+	if identityID == "" {
+		writeError(w, http.StatusBadRequest, "identityID is required")
+		return nil, false
+	}
+	identity, err := s.managedIdentities.GetIdentity(r.Context(), identityID)
+	if err != nil {
+		if errors.Is(err, core.ErrNotFound) {
+			writeError(w, http.StatusNotFound, "identity not found")
+			return nil, false
+		}
+		writeError(w, http.StatusInternalServerError, "failed to resolve identity")
+		return nil, false
+	}
+	membership, err := s.identityMemberships.GetMembership(r.Context(), identityID, userID)
+	if err != nil {
+		if errors.Is(err, core.ErrNotFound) {
+			writeError(w, http.StatusNotFound, "identity not found")
+			return nil, false
+		}
+		writeError(w, http.StatusInternalServerError, "failed to resolve identity membership")
+		return nil, false
+	}
+	if !managedIdentityRoleAllows(membership.Role, requiredRole) {
+		writeError(w, http.StatusForbidden, "identity access denied")
+		return nil, false
+	}
+	return &managedIdentityActor{
+		UserID:     userID,
+		Identity:   identity,
+		Membership: membership,
+	}, true
+}
+
+func (s *Server) ensureManagedIdentityRoutesAvailable(w http.ResponseWriter) bool {
+	if s.noAuth {
+		writeError(w, http.StatusServiceUnavailable, "managed identities require auth to be enabled")
+		return false
+	}
+	if s.managedIdentities == nil || s.identityMemberships == nil || s.identityGrants == nil {
+		writeError(w, http.StatusServiceUnavailable, "managed identities are unavailable")
+		return false
+	}
+	return true
+}
+
+func (s *Server) ensureManagedIdentityHasAnotherAdmin(w http.ResponseWriter, r *http.Request, identityID, excludedUserID string) bool {
+	memberships, err := s.identityMemberships.ListMembershipsByIdentity(r.Context(), identityID)
+	if err != nil {
+		writeError(w, http.StatusInternalServerError, "failed to resolve identity admins")
+		return false
+	}
+	for _, membership := range memberships {
+		if membership.UserID == excludedUserID {
+			continue
+		}
+		if membership.Role == managedIdentityRoleAdmin {
+			return true
+		}
+	}
+	writeError(w, http.StatusConflict, "identity must retain at least one admin")
+	return false
+}
+
+type managedIdentityDeleteSnapshot struct {
+	Grants      []*core.ManagedIdentityGrant
+	Memberships []*core.ManagedIdentityMembership
+}
+
+func (s *Server) loadManagedIdentityDeleteSnapshot(ctx context.Context, identityID string) (*managedIdentityDeleteSnapshot, error) {
+	grants, err := s.identityGrants.ListGrantsByIdentity(ctx, identityID)
+	if err != nil {
+		return nil, err
+	}
+	memberships, err := s.identityMemberships.ListMembershipsByIdentity(ctx, identityID)
+	if err != nil {
+		return nil, err
+	}
+	return &managedIdentityDeleteSnapshot{
+		Grants:      cloneManagedIdentityGrants(grants),
+		Memberships: cloneManagedIdentityMemberships(memberships),
+	}, nil
+}
+
+func (s *Server) deleteManagedIdentityChildren(ctx context.Context, snapshot *managedIdentityDeleteSnapshot, actorUserID string) error {
+	deleted := &managedIdentityDeleteSnapshot{}
+
+	for _, grant := range snapshot.Grants {
+		if err := s.identityGrants.DeleteGrant(ctx, grant.IdentityID, grant.Plugin); err != nil {
+			if restoreErr := s.restoreManagedIdentityChildren(ctx, deleted, actorUserID); restoreErr != nil {
+				return fmt.Errorf("delete managed identity grant: %w (restore deleted children: %v)", err, restoreErr)
+			}
+			return err
+		}
+		deleted.Grants = append(deleted.Grants, cloneManagedIdentityGrant(grant))
+	}
+
+	for _, membership := range managedIdentityDeleteMembershipOrder(snapshot.Memberships, actorUserID) {
+		if err := s.identityMemberships.DeleteMembership(ctx, membership.IdentityID, membership.UserID); err != nil {
+			if restoreErr := s.restoreManagedIdentityChildren(ctx, deleted, actorUserID); restoreErr != nil {
+				return fmt.Errorf("delete managed identity membership: %w (restore deleted children: %v)", err, restoreErr)
+			}
+			return err
+		}
+		deleted.Memberships = append(deleted.Memberships, cloneManagedIdentityMembership(membership))
+	}
+
+	return nil
+}
+
+func (s *Server) restoreManagedIdentityChildren(ctx context.Context, snapshot *managedIdentityDeleteSnapshot, actorUserID string) error {
+	if snapshot == nil {
+		return nil
+	}
+	failedMemberships := s.restoreManagedIdentityMemberships(ctx, managedIdentityRestoreMembershipOrder(snapshot.Memberships, actorUserID))
+	if len(failedMemberships) > 0 {
+		failedMemberships = s.restoreManagedIdentityMemberships(ctx, failedMemberships)
+	}
+	failedGrants := s.restoreManagedIdentityGrants(ctx, snapshot.Grants)
+	if len(failedGrants) > 0 {
+		failedGrants = s.restoreManagedIdentityGrants(ctx, failedGrants)
+	}
+
+	var restoreErr error
+	for _, membership := range failedMemberships {
+		restoreErr = errors.Join(restoreErr, fmt.Errorf("restore managed identity membership %s: failed after retry", membership.UserID))
+	}
+	for _, grant := range failedGrants {
+		restoreErr = errors.Join(restoreErr, fmt.Errorf("restore managed identity grant %s: failed after retry", grant.Plugin))
+	}
+	return restoreErr
+}
+
+func managedIdentityDeleteMembershipOrder(memberships []*core.ManagedIdentityMembership, actorUserID string) []*core.ManagedIdentityMembership {
+	if len(memberships) == 0 {
+		return nil
+	}
+	ordered := cloneManagedIdentityMemberships(memberships)
+	sort.SliceStable(ordered, func(i, j int) bool {
+		if ordered[i].UserID == actorUserID {
+			return false
+		}
+		if ordered[j].UserID == actorUserID {
+			return true
+		}
+		return ordered[i].UserID < ordered[j].UserID
+	})
+	return ordered
+}
+
+func managedIdentityRestoreMembershipOrder(memberships []*core.ManagedIdentityMembership, actorUserID string) []*core.ManagedIdentityMembership {
+	if len(memberships) == 0 {
+		return nil
+	}
+	ordered := cloneManagedIdentityMemberships(memberships)
+	sort.SliceStable(ordered, func(i, j int) bool {
+		if ordered[i].UserID == actorUserID {
+			return true
+		}
+		if ordered[j].UserID == actorUserID {
+			return false
+		}
+		return ordered[i].UserID < ordered[j].UserID
+	})
+	return ordered
+}
+
+func (s *Server) restoreManagedIdentityMemberships(ctx context.Context, memberships []*core.ManagedIdentityMembership) []*core.ManagedIdentityMembership {
+	if len(memberships) == 0 {
+		return nil
+	}
+	failed := make([]*core.ManagedIdentityMembership, 0)
+	for _, membership := range memberships {
+		if err := s.identityMemberships.RestoreMembership(ctx, cloneManagedIdentityMembership(membership)); err != nil {
+			failed = append(failed, cloneManagedIdentityMembership(membership))
+		}
+	}
+	return failed
+}
+
+func (s *Server) restoreManagedIdentityGrants(ctx context.Context, grants []*core.ManagedIdentityGrant) []*core.ManagedIdentityGrant {
+	if len(grants) == 0 {
+		return nil
+	}
+	failed := make([]*core.ManagedIdentityGrant, 0)
+	for _, grant := range grants {
+		if err := s.identityGrants.RestoreGrant(ctx, cloneManagedIdentityGrant(grant)); err != nil {
+			failed = append(failed, cloneManagedIdentityGrant(grant))
+		}
+	}
+	return failed
+}
+
+func cloneManagedIdentityGrants(grants []*core.ManagedIdentityGrant) []*core.ManagedIdentityGrant {
+	if len(grants) == 0 {
+		return nil
+	}
+	cloned := make([]*core.ManagedIdentityGrant, 0, len(grants))
+	for _, grant := range grants {
+		cloned = append(cloned, cloneManagedIdentityGrant(grant))
+	}
+	return cloned
+}
+
+func cloneManagedIdentityGrant(grant *core.ManagedIdentityGrant) *core.ManagedIdentityGrant {
+	if grant == nil {
+		return nil
+	}
+	clone := *grant
+	clone.Operations = append([]string(nil), grant.Operations...)
+	return &clone
+}
+
+func cloneManagedIdentityMemberships(memberships []*core.ManagedIdentityMembership) []*core.ManagedIdentityMembership {
+	if len(memberships) == 0 {
+		return nil
+	}
+	cloned := make([]*core.ManagedIdentityMembership, 0, len(memberships))
+	for _, membership := range memberships {
+		cloned = append(cloned, cloneManagedIdentityMembership(membership))
+	}
+	return cloned
+}
+
+func cloneManagedIdentityMembership(membership *core.ManagedIdentityMembership) *core.ManagedIdentityMembership {
+	if membership == nil {
+		return nil
+	}
+	clone := *membership
+	return &clone
+}
+
+func (s *Server) recoverManagedIdentityCreateMembership(ctx context.Context, identity *core.ManagedIdentity, membership *core.ManagedIdentityMembership, createErr error) (*core.ManagedIdentityMembership, error) {
+	if membership == nil {
+		return nil, fmt.Errorf("failed to create identity membership: %w", createErr)
+	}
+	if err := s.identityMemberships.RestoreMembership(ctx, cloneManagedIdentityMembership(membership)); err == nil {
+		return membership, nil
+	} else {
+		restoreErr := err
+		if deleteErr := s.managedIdentities.DeleteIdentity(ctx, identity.ID); deleteErr == nil {
+			return nil, fmt.Errorf("failed to create identity membership: %w", createErr)
+		} else {
+			if err := s.identityMemberships.RestoreMembership(ctx, cloneManagedIdentityMembership(membership)); err == nil {
+				return membership, nil
+			}
+			return nil, fmt.Errorf("failed to create identity membership and roll back identity: %w", errors.Join(createErr, restoreErr, deleteErr))
+		}
+	}
+}
+
+func (s *Server) managedIdentityGrantPluginVisible(plugin string, p *principal.Principal) bool {
+	if _, err := s.providers.Get(plugin); err != nil {
+		return false
+	}
+	return s.allowProvider(p, plugin)
+}
+
+func (s *Server) managedIdentityGrantVisibleToActor(plugin string, p *principal.Principal, role string) bool {
+	if _, err := s.providers.Get(plugin); err != nil {
+		return errors.Is(err, core.ErrNotFound) && managedIdentityRoleAllows(role, managedIdentityRoleEditor)
+	}
+	return s.allowProvider(p, plugin)
+}
+
+func (s *Server) managedIdentityGrantCatalog(ctx context.Context, plugin string, p *principal.Principal) (*catalog.Catalog, error) {
+	prov, err := s.providers.Get(plugin)
+	if err != nil {
+		return nil, err
+	}
+	var resolver invocation.TokenResolver
+	if tr, ok := s.invoker.(invocation.TokenResolver); ok {
+		resolver = tr
+	}
+	ctx = invocation.WithAccessContext(ctx, s.providerAccessContext(p, plugin))
+	targets, err := s.managedIdentityGrantCatalogTargets(ctx, plugin, p)
+	if err != nil {
+		return nil, err
+	}
+	var firstErr error
+	for _, target := range targets {
+		cat, err := s.managedIdentityGrantCatalogForConnection(ctx, prov, plugin, resolver, p, target.connection, target.instance)
+		if err == nil && cat != nil {
+			return cat, nil
+		}
+		if err != nil && firstErr == nil {
+			firstErr = err
+		}
+	}
+	return nil, firstErr
+}
+
+type managedIdentityGrantCatalogTarget struct {
+	connection string
+	instance   string
+}
+
+func (s *Server) managedIdentityGrantCatalogTargets(ctx context.Context, plugin string, p *principal.Principal) ([]managedIdentityGrantCatalogTarget, error) {
+	targets := make([]managedIdentityGrantCatalogTarget, 0, 4)
+	seen := map[string]struct{}{}
+	addTarget := func(connection, instance string) {
+		connection = config.ResolveConnectionAlias(strings.TrimSpace(connection))
+		instance = strings.TrimSpace(instance)
+		key := connection + "\x00" + instance
+		if _, ok := seen[key]; ok {
+			return
+		}
+		seen[key] = struct{}{}
+		targets = append(targets, managedIdentityGrantCatalogTarget{
+			connection: connection,
+			instance:   instance,
+		})
+	}
+
+	for _, connection := range s.sessionCatalogConnections(plugin, p, "") {
+		connection, instance := s.workloadBindingSelectors(p, plugin, connection, "")
+		addTarget(connection, instance)
+	}
+	if p == nil || p.Kind == principal.KindWorkload || strings.TrimSpace(p.UserID) == "" {
+		if len(targets) == 0 {
+			addTarget("", "")
+		}
+		return targets, nil
+	}
+
+	tokens, err := s.tokens.ListTokensForIntegration(ctx, p.UserID, plugin)
+	if err != nil {
+		return nil, fmt.Errorf("list integration tokens for grant validation: %w", err)
+	}
+	byConnection := make(map[string][]*core.IntegrationToken, len(tokens))
+	for _, token := range tokens {
+		byConnection[token.Connection] = append(byConnection[token.Connection], token)
+	}
+	connections := make([]string, 0, len(byConnection))
+	for connection := range byConnection {
+		connections = append(connections, connection)
+	}
+	sort.Strings(connections)
+	for _, connection := range connections {
+		connectionTokens := byConnection[connection]
+		if len(connectionTokens) <= 1 {
+			addTarget(connection, "")
+			continue
+		}
+		sort.Slice(connectionTokens, func(i, j int) bool {
+			return connectionTokens[i].Instance < connectionTokens[j].Instance
+		})
+		for _, token := range connectionTokens {
+			addTarget(connection, token.Instance)
+		}
+	}
+	if len(targets) == 0 {
+		addTarget("", "")
+	}
+	return targets, nil
+}
+
+func (s *Server) managedIdentityGrantCatalogForConnection(
+	ctx context.Context,
+	prov core.Provider,
+	plugin string,
+	resolver invocation.TokenResolver,
+	p *principal.Principal,
+	connection string,
+	instance string,
+) (*catalog.Catalog, error) {
+	cat, attempted, err := s.managedIdentityGrantSessionCatalog(ctx, prov, plugin, resolver, p, connection, instance)
+	if err != nil {
+		return nil, err
+	}
+	if attempted && cat != nil {
+		return cat, nil
+	}
+	cat, _, err = invocation.ResolveCatalogStrictWithMetadata(ctx, prov, plugin, resolver, p, connection, instance)
+	return cat, err
+}
+
+func (s *Server) managedIdentityGrantSessionCatalog(
+	ctx context.Context,
+	prov core.Provider,
+	plugin string,
+	resolver invocation.TokenResolver,
+	p *principal.Principal,
+	connection string,
+	instance string,
+) (*catalog.Catalog, bool, error) {
+	if !core.SupportsSessionCatalog(prov) {
+		return nil, false, nil
+	}
+	if prov.ConnectionMode() == core.ConnectionModeNone {
+		if resolver != nil && p != nil {
+			enrichedCtx, token, err := resolver.ResolveToken(ctx, p, plugin, connection, instance)
+			if err != nil {
+				return nil, true, err
+			}
+			cat, _, err := core.CatalogForRequest(enrichedCtx, prov, token)
+			return cat, true, err
+		}
+		ctx = invocation.WithCredentialContext(ctx, invocation.CredentialContext{Mode: core.ConnectionModeNone})
+		cat, _, err := core.CatalogForRequest(ctx, prov, "")
+		return cat, true, err
+	}
+	if resolver == nil || p == nil {
+		return nil, false, nil
+	}
+
+	enrichedCtx, token, err := resolver.ResolveToken(ctx, p, plugin, connection, instance)
+	if err != nil {
+		return nil, true, err
+	}
+	cat, _, err := core.CatalogForRequest(enrichedCtx, prov, token)
+	return cat, true, err
+}
+
+func (s *Server) validateManagedIdentityGrantOperations(ctx context.Context, plugin string, operations []string, p *principal.Principal) error {
+	cat, err := s.managedIdentityGrantCatalog(ctx, plugin, p)
+	if err != nil || cat == nil {
+		return fmt.Errorf("plugin %q does not expose operations for validation", plugin)
+	}
+	visible := grantableCatalogOperations(cat.Operations)
+	if len(visible) == 0 {
+		return fmt.Errorf("plugin %q does not expose operations for validation", plugin)
+	}
+	known := make(map[string]struct{}, len(visible))
+	for i := range visible {
+		known[visible[i].ID] = struct{}{}
+	}
+	allowedVisible := visible
+	if s.authorizer != nil {
+		filtered := invocation.FilterCatalogForPrincipal(cat, plugin, p, s.authorizer)
+		allowedVisible = grantableCatalogOperations(filtered.Operations)
+	}
+	allowed := make(map[string]struct{}, len(allowedVisible))
+	for i := range allowedVisible {
+		allowed[allowedVisible[i].ID] = struct{}{}
+	}
+	if len(operations) == 0 {
+		for operation := range known {
+			if _, ok := allowed[operation]; !ok {
+				return fmt.Errorf("plugin-wide access is not authorized for plugin %q", plugin)
+			}
+		}
+		return nil
+	}
+	for _, operation := range operations {
+		if _, ok := known[operation]; !ok {
+			return fmt.Errorf("unknown operation %q for plugin %q", operation, plugin)
+		}
+		if _, ok := allowed[operation]; !ok {
+			return fmt.Errorf("operation %q is not authorized for plugin %q", operation, plugin)
+		}
+	}
+	return nil
+}
+
+func grantableCatalogOperations(ops []catalog.CatalogOperation) []catalog.CatalogOperation {
+	filtered := make([]catalog.CatalogOperation, 0, len(ops))
+	for i := range ops {
+		if strings.TrimSpace(ops[i].ID) == "" {
+			continue
+		}
+		filtered = append(filtered, ops[i])
+	}
+	return filtered
+}
+
+func normalizeManagedIdentityRole(role string) string {
+	role = strings.TrimSpace(strings.ToLower(role))
+	if _, ok := managedIdentityRoleRank[role]; !ok {
+		return ""
+	}
+	return role
+}
+
+func managedIdentityRoleAllows(actualRole, requiredRole string) bool {
+	if requiredRole == "" {
+		return true
+	}
+	actualRank := managedIdentityRoleRank[normalizeManagedIdentityRole(actualRole)]
+	requiredRank := managedIdentityRoleRank[normalizeManagedIdentityRole(requiredRole)]
+	return actualRank >= requiredRank
+}
+
+func normalizeManagedIdentityOperations(operations []string) []string {
+	if len(operations) == 0 {
+		return nil
+	}
+	out := make([]string, 0, len(operations))
+	for _, operation := range operations {
+		operation = strings.TrimSpace(operation)
+		if operation == "" || slices.Contains(out, operation) {
+			continue
+		}
+		out = append(out, operation)
+	}
+	sort.Strings(out)
+	if len(out) == 0 {
+		return nil
+	}
+	return out
+}

--- a/gestaltd/internal/server/routes_user.go
+++ b/gestaltd/internal/server/routes_user.go
@@ -20,5 +20,20 @@ func (s *Server) mountAuthenticatedRoutes(r chi.Router) {
 		r.Get("/tokens", s.listAPITokens)
 		r.Delete("/tokens", s.revokeAllAPITokens)
 		r.Delete("/tokens/{id}", s.revokeAPIToken)
+
+		r.Route("/identities", func(r chi.Router) {
+			r.Get("/", s.listManagedIdentities)
+			r.Post("/", s.createManagedIdentity)
+			r.Get("/{identityID}", s.getManagedIdentityOrExecuteIdentitiesOperation)
+			r.Post("/{identityID}", s.executeIdentitiesOperation)
+			r.Patch("/{identityID}", s.updateManagedIdentityOrExecuteIdentitiesOperation)
+			r.Delete("/{identityID}", s.deleteManagedIdentityOrExecuteIdentitiesOperation)
+			r.Get("/{identityID}/members", s.listManagedIdentityMembers)
+			r.Put("/{identityID}/members", s.putManagedIdentityMember)
+			r.Delete("/{identityID}/members/{email}", s.deleteManagedIdentityMember)
+			r.Get("/{identityID}/grants", s.listManagedIdentityGrants)
+			r.Put("/{identityID}/grants/{plugin}", s.putManagedIdentityGrant)
+			r.Delete("/{identityID}/grants/{plugin}", s.deleteManagedIdentityGrant)
+		})
 	})
 }

--- a/gestaltd/internal/server/server.go
+++ b/gestaltd/internal/server/server.go
@@ -4,6 +4,7 @@ import (
 	"fmt"
 	"net/http"
 	"strings"
+	"sync"
 	"time"
 
 	"github.com/go-chi/chi/v5"
@@ -63,8 +64,12 @@ type Server struct {
 	users                *coredata.UserService
 	tokens               *coredata.TokenService
 	apiTokens            *coredata.APITokenService
+	managedIdentities    *coredata.ManagedIdentityService
+	identityMemberships  *coredata.ManagedIdentityMembershipService
+	identityGrants       *coredata.ManagedIdentityGrantService
 	pluginAuthorizations *coredata.PluginAuthorizationService
 	adminAuthorizations  *coredata.AdminAuthorizationService
+	managedIdentityMu    sync.Mutex
 	providers            *registry.ProviderMap[core.Provider]
 	resolver             *principal.Resolver
 	invoker              invocation.Invoker
@@ -159,6 +164,9 @@ func New(cfg Config) (*Server, error) {
 	users := cfg.Services.Users
 	tokens := cfg.Services.Tokens
 	apiTokens := cfg.Services.APITokens
+	managedIdentities := cfg.Services.ManagedIdentities
+	identityMemberships := cfg.Services.IdentityMemberships
+	identityGrants := cfg.Services.IdentityGrants
 	pluginAuthorizations := cfg.Services.PluginAuthorizations
 	adminAuthorizations := cfg.Services.AdminAuthorizations
 	resolver := principal.NewResolver(cfg.Auth, users, apiTokens, cfg.Authorizer)
@@ -176,6 +184,9 @@ func New(cfg Config) (*Server, error) {
 		users:                users,
 		tokens:               tokens,
 		apiTokens:            apiTokens,
+		managedIdentities:    managedIdentities,
+		identityMemberships:  identityMemberships,
+		identityGrants:       identityGrants,
 		pluginAuthorizations: pluginAuthorizations,
 		adminAuthorizations:  adminAuthorizations,
 		providers:            cfg.Providers,

--- a/gestaltd/internal/server/server_test.go
+++ b/gestaltd/internal/server/server_test.go
@@ -5,6 +5,7 @@ import (
 	"context"
 	"crypto/tls"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"io"
 	"net"
@@ -139,6 +140,157 @@ func (s *putFailingObjectStore) Put(ctx context.Context, record indexeddb.Record
 	return s.ObjectStore.Put(ctx, record)
 }
 
+type addFailingIndexedDB struct {
+	indexeddb.IndexedDB
+	failStoreAdds    map[string]*atomic.Bool
+	failStorePuts    map[string]*deleteFailureRule
+	failStoreDeletes map[string]*deleteFailureRule
+}
+
+func (d *addFailingIndexedDB) ObjectStore(name string) indexeddb.ObjectStore {
+	store := d.IndexedDB.ObjectStore(name)
+	failAdd := d.failStoreAdds[name]
+	failPut := d.failStorePuts[name]
+	failDelete := d.failStoreDeletes[name]
+	if failAdd == nil && failPut == nil && failDelete == nil {
+		return store
+	}
+	return &addFailingObjectStore{
+		ObjectStore: store,
+		storeName:   name,
+		failAdd:     failAdd,
+		failPut:     failPut,
+		failDelete:  failDelete,
+	}
+}
+
+type addFailingObjectStore struct {
+	indexeddb.ObjectStore
+	storeName  string
+	failAdd    *atomic.Bool
+	failPut    *deleteFailureRule
+	failDelete *deleteFailureRule
+}
+
+func (s *addFailingObjectStore) Add(ctx context.Context, record indexeddb.Record) error {
+	if s.failAdd != nil && s.failAdd.Load() {
+		return fmt.Errorf("forced add failure")
+	}
+	return s.ObjectStore.Add(ctx, record)
+}
+
+func (s *addFailingObjectStore) Put(ctx context.Context, record indexeddb.Record) error {
+	if s.failPut.shouldFail() {
+		return fmt.Errorf("forced %s put failure", s.storeName)
+	}
+	return s.ObjectStore.Put(ctx, record)
+}
+
+func (s *addFailingObjectStore) Delete(ctx context.Context, id string) error {
+	if s.failDelete.shouldFail() {
+		return fmt.Errorf("forced %s delete failure", s.storeName)
+	}
+	return s.ObjectStore.Delete(ctx, id)
+}
+
+type deleteFailingIndexedDB struct {
+	indexeddb.IndexedDB
+	failStoreDeletes map[string]*deleteFailureRule
+	failIndexDeletes map[string]*deleteFailureRule
+	failStorePuts    map[string]*deleteFailureRule
+}
+
+func (d *deleteFailingIndexedDB) ObjectStore(name string) indexeddb.ObjectStore {
+	store := d.IndexedDB.ObjectStore(name)
+	return &deleteFailingObjectStore{
+		ObjectStore:      store,
+		storeName:        name,
+		failDelete:       d.failStoreDeletes[name],
+		failIndexDeletes: d.failIndexDeletes,
+		failPut:          d.failStorePuts[name],
+	}
+}
+
+type deleteFailingObjectStore struct {
+	indexeddb.ObjectStore
+	storeName        string
+	failDelete       *deleteFailureRule
+	failIndexDeletes map[string]*deleteFailureRule
+	failPut          *deleteFailureRule
+}
+
+func (s *deleteFailingObjectStore) Delete(ctx context.Context, id string) error {
+	if s.failDelete.shouldFail() {
+		return fmt.Errorf("forced %s delete failure", s.storeName)
+	}
+	return s.ObjectStore.Delete(ctx, id)
+}
+
+func (s *deleteFailingObjectStore) Put(ctx context.Context, record indexeddb.Record) error {
+	if s.failPut.shouldFail() {
+		return fmt.Errorf("forced %s put failure", s.storeName)
+	}
+	return s.ObjectStore.Put(ctx, record)
+}
+
+func (s *deleteFailingObjectStore) Index(name string) indexeddb.Index {
+	idx := s.ObjectStore.Index(name)
+	failDelete := s.failIndexDeletes[s.storeName+"/"+name]
+	if failDelete == nil {
+		return idx
+	}
+	return &deleteFailingIndex{Index: idx, name: s.storeName + "/" + name, failDelete: failDelete}
+}
+
+type deleteFailingIndex struct {
+	indexeddb.Index
+	name       string
+	failDelete *deleteFailureRule
+}
+
+func (i *deleteFailingIndex) Delete(ctx context.Context, values ...any) (int64, error) {
+	if i.failDelete.shouldFail() {
+		return 0, fmt.Errorf("forced %s delete failure", i.name)
+	}
+	return i.Index.Delete(ctx, values...)
+}
+
+type deleteFailureRule struct {
+	failAfter int64
+	enabled   atomic.Bool
+	calls     atomic.Int64
+}
+
+func newDeleteFailureRule(failAfter int64) *deleteFailureRule {
+	if failAfter < 1 {
+		failAfter = 1
+	}
+	return &deleteFailureRule{failAfter: failAfter}
+}
+
+func (r *deleteFailureRule) Enable() {
+	if r == nil {
+		return
+	}
+	r.calls.Store(0)
+	r.enabled.Store(true)
+}
+
+func (r *deleteFailureRule) Disable() {
+	if r == nil {
+		return
+	}
+	r.enabled.Store(false)
+	r.calls.Store(0)
+}
+
+func (r *deleteFailureRule) shouldFail() bool {
+	if r == nil || !r.enabled.Load() {
+		return false
+	}
+	return r.calls.Add(1) == r.failAfter
+}
+
 func newTestServicesWithUsersPutFailure(t *testing.T) (*coredata.Services, *atomic.Bool) {
 	t.Helper()
 	enc, err := corecrypto.NewAESGCM([]byte("0123456789abcdef0123456789abcdef"))
@@ -194,6 +346,118 @@ func newTestServicesWithAdminAuthorizationPutFailure(t *testing.T) (*coredata.Se
 		t.Fatalf("newTestServicesWithAdminAuthorizationPutFailure: %v", err)
 	}
 	return svc, failPut
+}
+
+func newTestServicesWithManagedIdentityMembershipAddFailure(t *testing.T) (*coredata.Services, *atomic.Bool, *deleteFailureRule, *deleteFailureRule, indexeddb.IndexedDB) {
+	t.Helper()
+	enc, err := corecrypto.NewAESGCM([]byte("0123456789abcdef0123456789abcdef"))
+	if err != nil {
+		t.Fatalf("newTestServicesWithManagedIdentityMembershipAddFailure encryptor: %v", err)
+	}
+	failAdd := &atomic.Bool{}
+	failPut := newDeleteFailureRule(1)
+	failDelete := newDeleteFailureRule(1)
+	db := &addFailingIndexedDB{
+		IndexedDB: &coretesting.StubIndexedDB{},
+		failStoreAdds: map[string]*atomic.Bool{
+			coredata.StoreManagedIdentityMemberships: failAdd,
+		},
+		failStorePuts: map[string]*deleteFailureRule{
+			coredata.StoreManagedIdentityMemberships: failPut,
+		},
+		failStoreDeletes: map[string]*deleteFailureRule{
+			coredata.StoreManagedIdentities: failDelete,
+		},
+	}
+	svc, err := coredata.New(db, enc)
+	if err != nil {
+		t.Fatalf("newTestServicesWithManagedIdentityMembershipAddFailure: %v", err)
+	}
+	return svc, failAdd, failPut, failDelete, db
+}
+
+func newTestServicesWithManagedIdentityGrantDeleteFailure(t *testing.T, failAfter int64) (*coredata.Services, *deleteFailureRule) {
+	t.Helper()
+
+	key, err := corecrypto.NewAESGCM([]byte("0123456789abcdef0123456789abcdef"))
+	if err != nil {
+		t.Fatalf("newTestServicesWithManagedIdentityGrantDeleteFailure encryptor: %v", err)
+	}
+	failDelete := newDeleteFailureRule(failAfter)
+	svc, err := coredata.New(&deleteFailingIndexedDB{
+		IndexedDB: &coretesting.StubIndexedDB{},
+		failIndexDeletes: map[string]*deleteFailureRule{
+			coredata.StoreManagedIdentityGrants + "/by_identity_plugin": failDelete,
+		},
+	}, key)
+	if err != nil {
+		t.Fatalf("newTestServicesWithManagedIdentityGrantDeleteFailure: %v", err)
+	}
+	return svc, failDelete
+}
+
+func newTestServicesWithManagedIdentityMembershipDeleteFailure(t *testing.T, failAfter int64) (*coredata.Services, *deleteFailureRule) {
+	t.Helper()
+
+	key, err := corecrypto.NewAESGCM([]byte("0123456789abcdef0123456789abcdef"))
+	if err != nil {
+		t.Fatalf("newTestServicesWithManagedIdentityMembershipDeleteFailure encryptor: %v", err)
+	}
+	failDelete := newDeleteFailureRule(failAfter)
+	svc, err := coredata.New(&deleteFailingIndexedDB{
+		IndexedDB: &coretesting.StubIndexedDB{},
+		failIndexDeletes: map[string]*deleteFailureRule{
+			coredata.StoreManagedIdentityMemberships + "/by_identity_user": failDelete,
+		},
+	}, key)
+	if err != nil {
+		t.Fatalf("newTestServicesWithManagedIdentityMembershipDeleteFailure: %v", err)
+	}
+	return svc, failDelete
+}
+
+func newTestServicesWithManagedIdentityDeleteFailure(t *testing.T) (*coredata.Services, *deleteFailureRule) {
+	t.Helper()
+
+	key, err := corecrypto.NewAESGCM([]byte("0123456789abcdef0123456789abcdef"))
+	if err != nil {
+		t.Fatalf("newTestServicesWithManagedIdentityDeleteFailure encryptor: %v", err)
+	}
+	failDelete := newDeleteFailureRule(1)
+	svc, err := coredata.New(&deleteFailingIndexedDB{
+		IndexedDB: &coretesting.StubIndexedDB{},
+		failStoreDeletes: map[string]*deleteFailureRule{
+			coredata.StoreManagedIdentities: failDelete,
+		},
+	}, key)
+	if err != nil {
+		t.Fatalf("newTestServicesWithManagedIdentityDeleteFailure: %v", err)
+	}
+	return svc, failDelete
+}
+
+func newTestServicesWithManagedIdentityDeleteAndMembershipRestoreFailure(t *testing.T, membershipRestoreFailAfter int64) (*coredata.Services, *deleteFailureRule, *deleteFailureRule) {
+	t.Helper()
+
+	key, err := corecrypto.NewAESGCM([]byte("0123456789abcdef0123456789abcdef"))
+	if err != nil {
+		t.Fatalf("newTestServicesWithManagedIdentityDeleteAndMembershipRestoreFailure encryptor: %v", err)
+	}
+	deleteFail := newDeleteFailureRule(1)
+	membershipRestoreFail := newDeleteFailureRule(membershipRestoreFailAfter)
+	svc, err := coredata.New(&deleteFailingIndexedDB{
+		IndexedDB: &coretesting.StubIndexedDB{},
+		failStoreDeletes: map[string]*deleteFailureRule{
+			coredata.StoreManagedIdentities: deleteFail,
+		},
+		failStorePuts: map[string]*deleteFailureRule{
+			coredata.StoreManagedIdentityMemberships: membershipRestoreFail,
+		},
+	}, key)
+	if err != nil {
+		t.Fatalf("newTestServicesWithManagedIdentityDeleteAndMembershipRestoreFailure: %v", err)
+	}
+	return svc, deleteFail, membershipRestoreFail
 }
 
 func newVirtualHostClient(t *testing.T, hostAddrs map[string]string) *http.Client {
@@ -13367,5 +13631,1518 @@ func TestCreateAPIToken_InvalidScope(t *testing.T) {
 	defer func() { _ = resp.Body.Close() }()
 	if resp.StatusCode != http.StatusBadRequest {
 		t.Fatalf("expected 400, got %d", resp.StatusCode)
+	}
+}
+
+func TestManagedIdentityCRUDAndMemberships(t *testing.T) {
+	t.Parallel()
+
+	svc := coretesting.NewStubServices(t)
+	admin := seedUser(t, svc, "admin@example.test")
+	seedUser(t, svc, "viewer@example.test")
+
+	ts := newTestServer(t, func(cfg *server.Config) {
+		cfg.Auth = &coretesting.StubAuthProvider{
+			N: "test",
+			ValidateTokenFn: func(_ context.Context, token string) (*core.UserIdentity, error) {
+				switch token {
+				case "admin-session":
+					return &core.UserIdentity{Email: "admin@example.test"}, nil
+				case "viewer-session":
+					return &core.UserIdentity{Email: "viewer@example.test"}, nil
+				default:
+					return nil, fmt.Errorf("unknown session %q", token)
+				}
+			},
+		}
+		cfg.Services = svc
+	})
+	testutil.CloseOnCleanup(t, ts)
+
+	createResp := struct {
+		ID          string `json:"id"`
+		DisplayName string `json:"displayName"`
+		Role        string `json:"role"`
+	}{}
+	doJSONRequestAndDecode(t, http.MethodPost, ts.URL+"/api/v1/identities", "admin-session", `{"displayName":"Release Bot"}`, http.StatusCreated, &createResp)
+	if createResp.Role != "admin" {
+		t.Fatalf("create role = %q, want admin", createResp.Role)
+	}
+	if createResp.DisplayName != "Release Bot" {
+		t.Fatalf("displayName = %q, want %q", createResp.DisplayName, "Release Bot")
+	}
+	createdIdentity, err := svc.ManagedIdentities.GetIdentity(context.Background(), createResp.ID)
+	if err != nil {
+		t.Fatalf("GetIdentity after create: %v", err)
+	}
+
+	var listResp []struct {
+		ID          string `json:"id"`
+		DisplayName string `json:"displayName"`
+		Role        string `json:"role"`
+	}
+	doJSONRequestAndDecode(t, http.MethodGet, ts.URL+"/api/v1/identities", "admin-session", "", http.StatusOK, &listResp)
+	if len(listResp) != 1 || listResp[0].ID != createResp.ID || listResp[0].Role != "admin" {
+		t.Fatalf("list response = %+v, want single admin identity %q", listResp, createResp.ID)
+	}
+
+	memberResp := struct {
+		UserID string `json:"userId"`
+		Email  string `json:"email"`
+		Role   string `json:"role"`
+	}{}
+	doJSONRequestAndDecode(t, http.MethodPut, ts.URL+"/api/v1/identities/"+createResp.ID+"/members", "admin-session", `{"email":"viewer@example.test","role":"viewer"}`, http.StatusOK, &memberResp)
+	if memberResp.Role != "viewer" || memberResp.Email != "viewer@example.test" {
+		t.Fatalf("member response = %+v, want viewer@example.test viewer", memberResp)
+	}
+
+	var viewerList []struct {
+		ID          string `json:"id"`
+		DisplayName string `json:"displayName"`
+		Role        string `json:"role"`
+	}
+	doJSONRequestAndDecode(t, http.MethodGet, ts.URL+"/api/v1/identities", "viewer-session", "", http.StatusOK, &viewerList)
+	if len(viewerList) != 1 || viewerList[0].Role != "viewer" {
+		t.Fatalf("viewer list response = %+v, want single viewer identity", viewerList)
+	}
+
+	reqBody := bytes.NewBufferString(`{"displayName":"Nope"}`)
+	req, _ := http.NewRequest(http.MethodPatch, ts.URL+"/api/v1/identities/"+createResp.ID, reqBody)
+	req.Header.Set("Content-Type", "application/json")
+	req.AddCookie(&http.Cookie{Name: "session_token", Value: "viewer-session"})
+	resp, err := http.DefaultClient.Do(req)
+	if err != nil {
+		t.Fatalf("viewer patch request: %v", err)
+	}
+	defer func() { _ = resp.Body.Close() }()
+	if resp.StatusCode != http.StatusForbidden {
+		t.Fatalf("viewer patch status = %d, want %d", resp.StatusCode, http.StatusForbidden)
+	}
+
+	updateResp := struct {
+		DisplayName string `json:"displayName"`
+	}{}
+	doJSONRequestAndDecode(t, http.MethodPatch, ts.URL+"/api/v1/identities/"+createResp.ID, "admin-session", `{"displayName":"Release Automation"}`, http.StatusOK, &updateResp)
+	if updateResp.DisplayName != "Release Automation" {
+		t.Fatalf("updated displayName = %q, want %q", updateResp.DisplayName, "Release Automation")
+	}
+	updatedIdentity, err := svc.ManagedIdentities.GetIdentity(context.Background(), createResp.ID)
+	if err != nil {
+		t.Fatalf("GetIdentity after update: %v", err)
+	}
+	if !updatedIdentity.CreatedAt.Equal(createdIdentity.CreatedAt) {
+		t.Fatalf("createdAt changed across update: got %v want %v", updatedIdentity.CreatedAt, createdIdentity.CreatedAt)
+	}
+
+	req, _ = http.NewRequest(http.MethodDelete, ts.URL+"/api/v1/identities/"+createResp.ID+"/members/"+admin.Email, nil)
+	req.AddCookie(&http.Cookie{Name: "session_token", Value: "admin-session"})
+	resp, err = http.DefaultClient.Do(req)
+	if err != nil {
+		t.Fatalf("delete admin membership request: %v", err)
+	}
+	defer func() { _ = resp.Body.Close() }()
+	if resp.StatusCode != http.StatusConflict {
+		t.Fatalf("delete last admin status = %d, want %d", resp.StatusCode, http.StatusConflict)
+	}
+
+	doJSONRequestAndDecode(t, http.MethodDelete, ts.URL+"/api/v1/identities/"+createResp.ID, "admin-session", "", http.StatusOK, nil)
+
+	req, _ = http.NewRequest(http.MethodGet, ts.URL+"/api/v1/identities/"+createResp.ID, nil)
+	req.AddCookie(&http.Cookie{Name: "session_token", Value: "admin-session"})
+	resp, err = http.DefaultClient.Do(req)
+	if err != nil {
+		t.Fatalf("get deleted identity request: %v", err)
+	}
+	defer func() { _ = resp.Body.Close() }()
+	if resp.StatusCode != http.StatusNotFound {
+		t.Fatalf("get deleted identity status = %d, want %d", resp.StatusCode, http.StatusNotFound)
+	}
+}
+
+func TestManagedIdentityCreateRecoversWhenMembershipCreateFails(t *testing.T) {
+	t.Parallel()
+
+	t.Run("restores membership via put fallback", func(t *testing.T) {
+		t.Parallel()
+
+		svc, failAdd, _, _, db := newTestServicesWithManagedIdentityMembershipAddFailure(t)
+		seedUser(t, svc, "admin@example.test")
+		ts := newTestServer(t, func(cfg *server.Config) {
+			cfg.Auth = &coretesting.StubAuthProvider{
+				N: "test",
+				ValidateTokenFn: func(_ context.Context, token string) (*core.UserIdentity, error) {
+					switch token {
+					case "admin-session":
+						return &core.UserIdentity{Email: "admin@example.test"}, nil
+					default:
+						return nil, fmt.Errorf("unknown session %q", token)
+					}
+				},
+			}
+			cfg.Services = svc
+		})
+		testutil.CloseOnCleanup(t, ts)
+
+		failAdd.Store(true)
+
+		createResp := struct {
+			ID string `json:"id"`
+		}{}
+		doJSONRequestAndDecode(t, http.MethodPost, ts.URL+"/api/v1/identities", "admin-session", `{"displayName":"Recovered Bot"}`, http.StatusCreated, &createResp)
+
+		identityCount, err := db.ObjectStore(coredata.StoreManagedIdentities).Count(context.Background(), nil)
+		if err != nil {
+			t.Fatalf("Count managed identities: %v", err)
+		}
+		if identityCount != 1 {
+			t.Fatalf("managed identity count = %d, want 1", identityCount)
+		}
+		membershipCount, err := db.ObjectStore(coredata.StoreManagedIdentityMemberships).Count(context.Background(), nil)
+		if err != nil {
+			t.Fatalf("Count managed identity memberships: %v", err)
+		}
+		if membershipCount != 1 {
+			t.Fatalf("managed identity membership count = %d, want 1", membershipCount)
+		}
+		if createResp.ID == "" {
+			t.Fatal("expected created identity id")
+		}
+	})
+
+	t.Run("retries membership restore after rollback delete failure", func(t *testing.T) {
+		t.Parallel()
+
+		svc, failAdd, failPut, failDelete, db := newTestServicesWithManagedIdentityMembershipAddFailure(t)
+		seedUser(t, svc, "admin@example.test")
+		ts := newTestServer(t, func(cfg *server.Config) {
+			cfg.Auth = &coretesting.StubAuthProvider{
+				N: "test",
+				ValidateTokenFn: func(_ context.Context, token string) (*core.UserIdentity, error) {
+					switch token {
+					case "admin-session":
+						return &core.UserIdentity{Email: "admin@example.test"}, nil
+					default:
+						return nil, fmt.Errorf("unknown session %q", token)
+					}
+				},
+			}
+			cfg.Services = svc
+		})
+		testutil.CloseOnCleanup(t, ts)
+
+		failAdd.Store(true)
+		failPut.Enable()
+		failDelete.Enable()
+
+		createResp := struct {
+			ID string `json:"id"`
+		}{}
+		doJSONRequestAndDecode(t, http.MethodPost, ts.URL+"/api/v1/identities", "admin-session", `{"displayName":"Retried Bot"}`, http.StatusCreated, &createResp)
+
+		identityCount, err := db.ObjectStore(coredata.StoreManagedIdentities).Count(context.Background(), nil)
+		if err != nil {
+			t.Fatalf("Count managed identities: %v", err)
+		}
+		if identityCount != 1 {
+			t.Fatalf("managed identity count = %d, want 1", identityCount)
+		}
+		membershipCount, err := db.ObjectStore(coredata.StoreManagedIdentityMemberships).Count(context.Background(), nil)
+		if err != nil {
+			t.Fatalf("Count managed identity memberships: %v", err)
+		}
+		if membershipCount != 1 {
+			t.Fatalf("managed identity membership count = %d, want 1", membershipCount)
+		}
+		if createResp.ID == "" {
+			t.Fatal("expected created identity id")
+		}
+	})
+}
+
+func TestManagedIdentityGrantsRespectActorAuthorization(t *testing.T) {
+	t.Parallel()
+
+	svc := coretesting.NewStubServices(t)
+	admin := seedUser(t, svc, "admin@example.test")
+	seedUser(t, svc, "viewer@example.test")
+
+	alpha := &stubIntegrationWithOps{
+		StubIntegration: coretesting.StubIntegration{N: "alpha", ConnMode: core.ConnectionModeNone},
+		ops:             []core.Operation{{Name: "read", Method: http.MethodGet}},
+	}
+	beta := &stubIntegrationWithOps{
+		StubIntegration: coretesting.StubIntegration{N: "beta", ConnMode: core.ConnectionModeNone},
+		ops:             []core.Operation{{Name: "read", Method: http.MethodGet}},
+	}
+	gamma := &stubIntegrationWithOps{
+		StubIntegration: coretesting.StubIntegration{N: "gamma", ConnMode: core.ConnectionModeNone},
+		ops:             []core.Operation{{Name: "read", Method: http.MethodGet}},
+	}
+	alphaCatalog := &stubIntegrationWithCatalog{
+		StubIntegration: alpha.StubIntegration,
+		catalog: serverTestCatalog("alpha", []catalog.CatalogOperation{
+			{ID: "read", Method: http.MethodGet, Path: "/read", Transport: catalog.TransportREST, AllowedRoles: []string{"viewer"}},
+			{ID: "write", Method: http.MethodPost, Path: "/write", Transport: catalog.TransportREST, AllowedRoles: []string{"admin"}},
+		}),
+	}
+	gammaCatalog := &stubIntegrationWithCatalog{
+		StubIntegration: gamma.StubIntegration,
+		catalog: serverTestCatalog("gamma", []catalog.CatalogOperation{
+			{ID: "read", Method: http.MethodGet, Path: "/read", Transport: catalog.TransportREST, AllowedRoles: []string{"viewer"}},
+		}),
+	}
+	providers := testutil.NewProviderRegistry(t, alphaCatalog, beta, gammaCatalog)
+	pluginDefs := map[string]*config.ProviderEntry{
+		"alpha": {AuthorizationPolicy: "alpha_policy"},
+		"beta":  {AuthorizationPolicy: "beta_policy"},
+		"gamma": {AuthorizationPolicy: "gamma_policy"},
+	}
+	authz := mustAuthorizer(t, config.AuthorizationConfig{
+		Policies: map[string]config.HumanPolicyDef{
+			"alpha_policy": {
+				Members: []config.HumanPolicyMemberDef{
+					{SubjectID: principal.UserSubjectID(admin.ID), Role: "viewer"},
+				},
+			},
+			"beta_policy": {},
+			"gamma_policy": {
+				Members: []config.HumanPolicyMemberDef{
+					{SubjectID: principal.UserSubjectID(admin.ID), Role: "viewer"},
+				},
+			},
+		},
+	}, providers, pluginDefs, nil)
+
+	ts := newTestServer(t, func(cfg *server.Config) {
+		cfg.Auth = &coretesting.StubAuthProvider{
+			N: "test",
+			ValidateTokenFn: func(_ context.Context, token string) (*core.UserIdentity, error) {
+				switch token {
+				case "admin-session":
+					return &core.UserIdentity{Email: "admin@example.test"}, nil
+				case "viewer-session":
+					return &core.UserIdentity{Email: "viewer@example.test"}, nil
+				default:
+					return nil, fmt.Errorf("unknown session %q", token)
+				}
+			},
+		}
+		cfg.Services = svc
+		cfg.Providers = providers
+		cfg.PluginDefs = pluginDefs
+		cfg.Authorizer = authz
+	})
+	testutil.CloseOnCleanup(t, ts)
+
+	createResp := struct {
+		ID string `json:"id"`
+	}{}
+	doJSONRequestAndDecode(t, http.MethodPost, ts.URL+"/api/v1/identities", "admin-session", `{"displayName":"Grant Bot"}`, http.StatusCreated, &createResp)
+	doJSONRequestAndDecode(t, http.MethodPut, ts.URL+"/api/v1/identities/"+createResp.ID+"/members", "admin-session", `{"email":"viewer@example.test","role":"viewer"}`, http.StatusOK, nil)
+
+	grantResp := struct {
+		Plugin     string   `json:"plugin"`
+		Operations []string `json:"operations"`
+	}{}
+	doJSONRequestAndDecode(t, http.MethodPut, ts.URL+"/api/v1/identities/"+createResp.ID+"/grants/alpha", "admin-session", `{"operations":["read","read"]}`, http.StatusOK, &grantResp)
+	if grantResp.Plugin != "alpha" || !reflect.DeepEqual(grantResp.Operations, []string{"read"}) {
+		t.Fatalf("grant response = %+v, want alpha [read]", grantResp)
+	}
+
+	var (
+		req  *http.Request
+		resp *http.Response
+		err  error
+	)
+	req, _ = http.NewRequest(http.MethodPut, ts.URL+"/api/v1/identities/"+createResp.ID+"/grants/alpha", bytes.NewBufferString(`{"operations":[" ",""]}`))
+	req.Header.Set("Content-Type", "application/json")
+	req.AddCookie(&http.Cookie{Name: "session_token", Value: "admin-session"})
+	resp, err = http.DefaultClient.Do(req)
+	if err != nil {
+		t.Fatalf("blank alpha grant request: %v", err)
+	}
+	defer func() { _ = resp.Body.Close() }()
+	if resp.StatusCode != http.StatusBadRequest {
+		t.Fatalf("blank alpha grant status = %d, want %d", resp.StatusCode, http.StatusBadRequest)
+	}
+
+	req, _ = http.NewRequest(http.MethodPut, ts.URL+"/api/v1/identities/"+createResp.ID+"/grants/alpha", bytes.NewBufferString(`{"operations":["missing.op"]}`))
+	req.Header.Set("Content-Type", "application/json")
+	req.AddCookie(&http.Cookie{Name: "session_token", Value: "admin-session"})
+	resp, err = http.DefaultClient.Do(req)
+	if err != nil {
+		t.Fatalf("invalid alpha grant request: %v", err)
+	}
+	defer func() { _ = resp.Body.Close() }()
+	if resp.StatusCode != http.StatusBadRequest {
+		t.Fatalf("invalid alpha grant status = %d, want %d", resp.StatusCode, http.StatusBadRequest)
+	}
+
+	req, _ = http.NewRequest(http.MethodPut, ts.URL+"/api/v1/identities/"+createResp.ID+"/grants/alpha", bytes.NewBufferString(`{"operations":["write"]}`))
+	req.Header.Set("Content-Type", "application/json")
+	req.AddCookie(&http.Cookie{Name: "session_token", Value: "admin-session"})
+	resp, err = http.DefaultClient.Do(req)
+	if err != nil {
+		t.Fatalf("unauthorized alpha grant request: %v", err)
+	}
+	defer func() { _ = resp.Body.Close() }()
+	if resp.StatusCode != http.StatusBadRequest {
+		t.Fatalf("unauthorized alpha grant status = %d, want %d", resp.StatusCode, http.StatusBadRequest)
+	}
+
+	req, _ = http.NewRequest(http.MethodPut, ts.URL+"/api/v1/identities/"+createResp.ID+"/grants/alpha", bytes.NewBufferString(`{}`))
+	req.Header.Set("Content-Type", "application/json")
+	req.AddCookie(&http.Cookie{Name: "session_token", Value: "admin-session"})
+	resp, err = http.DefaultClient.Do(req)
+	if err != nil {
+		t.Fatalf("plugin-wide alpha grant request: %v", err)
+	}
+	defer func() { _ = resp.Body.Close() }()
+	if resp.StatusCode != http.StatusBadRequest {
+		t.Fatalf("plugin-wide alpha grant status = %d, want %d", resp.StatusCode, http.StatusBadRequest)
+	}
+
+	doJSONRequestAndDecode(t, http.MethodPut, ts.URL+"/api/v1/identities/"+createResp.ID+"/grants/gamma", "admin-session", `{}`, http.StatusOK, &grantResp)
+	if grantResp.Plugin != "gamma" || !reflect.DeepEqual(grantResp.Operations, []string{}) {
+		t.Fatalf("plugin-wide grant response = %+v, want gamma []", grantResp)
+	}
+
+	req, _ = http.NewRequest(http.MethodPut, ts.URL+"/api/v1/identities/"+createResp.ID+"/grants/beta", bytes.NewBufferString(`{"operations":["read"]}`))
+	req.Header.Set("Content-Type", "application/json")
+	req.AddCookie(&http.Cookie{Name: "session_token", Value: "admin-session"})
+	resp, err = http.DefaultClient.Do(req)
+	if err != nil {
+		t.Fatalf("beta grant request: %v", err)
+	}
+	defer func() { _ = resp.Body.Close() }()
+	if resp.StatusCode != http.StatusNotFound {
+		t.Fatalf("beta grant status = %d, want %d", resp.StatusCode, http.StatusNotFound)
+	}
+
+	var adminGrantList []struct {
+		Plugin     string   `json:"plugin"`
+		Operations []string `json:"operations"`
+	}
+	doJSONRequestAndDecode(t, http.MethodGet, ts.URL+"/api/v1/identities/"+createResp.ID+"/grants", "admin-session", "", http.StatusOK, &adminGrantList)
+	if len(adminGrantList) != 2 || adminGrantList[0].Plugin != "alpha" || adminGrantList[1].Plugin != "gamma" {
+		t.Fatalf("admin grant list = %+v, want alpha and gamma grants", adminGrantList)
+	}
+	if !reflect.DeepEqual(adminGrantList[0].Operations, []string{"read"}) {
+		t.Fatalf("alpha grant operations = %+v, want [read]", adminGrantList[0].Operations)
+	}
+	if !reflect.DeepEqual(adminGrantList[1].Operations, []string{}) {
+		t.Fatalf("gamma grant operations = %+v, want []", adminGrantList[1].Operations)
+	}
+
+	var viewerGrantList []struct {
+		Plugin string `json:"plugin"`
+	}
+	doJSONRequestAndDecode(t, http.MethodGet, ts.URL+"/api/v1/identities/"+createResp.ID+"/grants", "viewer-session", "", http.StatusOK, &viewerGrantList)
+	if len(viewerGrantList) != 0 {
+		t.Fatalf("viewer grant list = %+v, want hidden grants", viewerGrantList)
+	}
+
+	t.Run("removed providers remain deletable", func(t *testing.T) {
+		t.Parallel()
+
+		svc := coretesting.NewStubServices(t)
+		seedUser(t, svc, "admin@example.test")
+		viewer := seedUser(t, svc, "viewer@example.test")
+
+		ts := newTestServer(t, func(cfg *server.Config) {
+			cfg.Auth = &coretesting.StubAuthProvider{
+				N: "test",
+				ValidateTokenFn: func(_ context.Context, token string) (*core.UserIdentity, error) {
+					switch token {
+					case "admin-session":
+						return &core.UserIdentity{Email: "admin@example.test"}, nil
+					case "viewer-session":
+						return &core.UserIdentity{Email: "viewer@example.test"}, nil
+					default:
+						return nil, fmt.Errorf("unknown session %q", token)
+					}
+				},
+			}
+			cfg.Services = svc
+		})
+		testutil.CloseOnCleanup(t, ts)
+
+		createResp := struct {
+			ID string `json:"id"`
+		}{}
+		doJSONRequestAndDecode(t, http.MethodPost, ts.URL+"/api/v1/identities", "admin-session", `{"displayName":"Removed Provider Bot"}`, http.StatusCreated, &createResp)
+		if _, err := svc.IdentityGrants.UpsertGrant(context.Background(), &core.ManagedIdentityGrant{
+			IdentityID: createResp.ID,
+			Plugin:     "removed-plugin",
+		}); err != nil {
+			t.Fatalf("UpsertGrant: %v", err)
+		}
+		if _, err := svc.IdentityMemberships.UpsertMembership(context.Background(), &core.ManagedIdentityMembership{
+			IdentityID: createResp.ID,
+			UserID:     viewer.ID,
+			Email:      viewer.Email,
+			Role:       "viewer",
+		}); err != nil {
+			t.Fatalf("UpsertMembership: %v", err)
+		}
+
+		var grants []struct {
+			Plugin string `json:"plugin"`
+		}
+		doJSONRequestAndDecode(t, http.MethodGet, ts.URL+"/api/v1/identities/"+createResp.ID+"/grants", "admin-session", "", http.StatusOK, &grants)
+		if len(grants) != 1 || grants[0].Plugin != "removed-plugin" {
+			t.Fatalf("removed-provider grant list = %+v, want single removed-plugin grant", grants)
+		}
+
+		var viewerGrants []struct {
+			Plugin string `json:"plugin"`
+		}
+		doJSONRequestAndDecode(t, http.MethodGet, ts.URL+"/api/v1/identities/"+createResp.ID+"/grants", "viewer-session", "", http.StatusOK, &viewerGrants)
+		if len(viewerGrants) != 0 {
+			t.Fatalf("viewer removed-provider grant list = %+v, want hidden grant", viewerGrants)
+		}
+
+		doJSONRequestAndDecode(t, http.MethodDelete, ts.URL+"/api/v1/identities/"+createResp.ID+"/grants/removed-plugin", "admin-session", "", http.StatusOK, nil)
+
+		if _, err := svc.IdentityGrants.GetGrant(context.Background(), createResp.ID, "removed-plugin"); !errors.Is(err, core.ErrNotFound) {
+			t.Fatalf("GetGrant after delete error = %v, want not found", err)
+		}
+	})
+
+	t.Run("malformed stored grants fail closed", func(t *testing.T) {
+		t.Parallel()
+
+		svc := coretesting.NewStubServices(t)
+		seedUser(t, svc, "admin@example.test")
+
+		ts := newTestServer(t, func(cfg *server.Config) {
+			cfg.Auth = &coretesting.StubAuthProvider{
+				N: "test",
+				ValidateTokenFn: func(_ context.Context, token string) (*core.UserIdentity, error) {
+					if token != "admin-session" {
+						return nil, fmt.Errorf("unknown session %q", token)
+					}
+					return &core.UserIdentity{Email: "admin@example.test"}, nil
+				},
+			}
+			cfg.Services = svc
+		})
+		testutil.CloseOnCleanup(t, ts)
+
+		createResp := struct {
+			ID string `json:"id"`
+		}{}
+		doJSONRequestAndDecode(t, http.MethodPost, ts.URL+"/api/v1/identities", "admin-session", `{"displayName":"Malformed Grant Bot"}`, http.StatusCreated, &createResp)
+
+		if err := svc.DB.ObjectStore(coredata.StoreManagedIdentityGrants).Add(context.Background(), indexeddb.Record{
+			"id":              "bad-grant",
+			"identity_id":     createResp.ID,
+			"plugin":          "alpha",
+			"operations_json": "{not-json",
+			"created_at":      time.Now(),
+			"updated_at":      time.Now(),
+		}); err != nil {
+			t.Fatalf("Add malformed grant: %v", err)
+		}
+
+		req, _ := http.NewRequest(http.MethodGet, ts.URL+"/api/v1/identities/"+createResp.ID+"/grants", nil)
+		req.AddCookie(&http.Cookie{Name: "session_token", Value: "admin-session"})
+		resp, err := http.DefaultClient.Do(req)
+		if err != nil {
+			t.Fatalf("GET malformed grants: %v", err)
+		}
+		defer func() { _ = resp.Body.Close() }()
+		if resp.StatusCode != http.StatusInternalServerError {
+			body, _ := io.ReadAll(resp.Body)
+			t.Fatalf("malformed grants status = %d, want %d: %s", resp.StatusCode, http.StatusInternalServerError, body)
+		}
+	})
+}
+
+func TestManagedIdentityGrantValidationUsesSessionCatalog(t *testing.T) {
+	t.Parallel()
+
+	t.Run("uses request catalog when provider catalog is empty", func(t *testing.T) {
+		t.Parallel()
+
+		svc := coretesting.NewStubServices(t)
+		seedUser(t, svc, "admin@example.test")
+
+		sessionOnly := &stubIntegrationWithSessionCatalog{
+			stubIntegrationWithOps: stubIntegrationWithOps{
+				StubIntegration: coretesting.StubIntegration{N: "session-only", ConnMode: core.ConnectionModeNone},
+			},
+			catalogForRequestFn: func(context.Context, string) (*catalog.Catalog, error) {
+				return serverTestCatalog("session-only", []catalog.CatalogOperation{{
+					ID:        "discover",
+					Method:    http.MethodGet,
+					Path:      "/discover",
+					Transport: catalog.TransportREST,
+				}}), nil
+			},
+		}
+
+		ts := newTestServer(t, func(cfg *server.Config) {
+			cfg.Auth = &coretesting.StubAuthProvider{
+				N: "test",
+				ValidateTokenFn: func(_ context.Context, token string) (*core.UserIdentity, error) {
+					switch token {
+					case "admin-session":
+						return &core.UserIdentity{Email: "admin@example.test"}, nil
+					default:
+						return nil, fmt.Errorf("unknown session %q", token)
+					}
+				},
+			}
+			cfg.Services = svc
+			cfg.Providers = testutil.NewProviderRegistry(t, sessionOnly)
+		})
+		testutil.CloseOnCleanup(t, ts)
+
+		createResp := struct {
+			ID string `json:"id"`
+		}{}
+		doJSONRequestAndDecode(t, http.MethodPost, ts.URL+"/api/v1/identities", "admin-session", `{"displayName":"Session Catalog Bot"}`, http.StatusCreated, &createResp)
+
+		grantResp := struct {
+			Plugin     string   `json:"plugin"`
+			Operations []string `json:"operations"`
+		}{}
+		doJSONRequestAndDecode(t, http.MethodPut, ts.URL+"/api/v1/identities/"+createResp.ID+"/grants/session-only", "admin-session", `{"operations":["discover"]}`, http.StatusOK, &grantResp)
+		if grantResp.Plugin != "session-only" || !reflect.DeepEqual(grantResp.Operations, []string{"discover"}) {
+			t.Fatalf("grant response = %+v, want session-only [discover]", grantResp)
+		}
+	})
+
+	t.Run("falls back across session catalog connections", func(t *testing.T) {
+		t.Parallel()
+
+		svc := coretesting.NewStubServices(t)
+		admin := seedUser(t, svc, "admin@example.test")
+		seedToken(t, svc, &core.IntegrationToken{
+			ID:          "tok-default",
+			UserID:      admin.ID,
+			Integration: "session-fallback",
+			Connection:  "default",
+			Instance:    "default",
+			AccessToken: "default-token",
+		})
+
+		sessionFallback := &stubIntegrationWithSessionCatalog{
+			stubIntegrationWithOps: stubIntegrationWithOps{
+				StubIntegration: coretesting.StubIntegration{N: "session-fallback", ConnMode: core.ConnectionModeUser},
+			},
+			catalogForRequestFn: func(_ context.Context, token string) (*catalog.Catalog, error) {
+				if token != "default-token" {
+					return nil, fmt.Errorf("missing session token")
+				}
+				return serverTestCatalog("session-fallback", []catalog.CatalogOperation{{
+					ID:        "discover",
+					Method:    http.MethodGet,
+					Path:      "/discover",
+					Transport: catalog.TransportREST,
+				}}), nil
+			},
+		}
+
+		ts := newTestServer(t, func(cfg *server.Config) {
+			cfg.Auth = &coretesting.StubAuthProvider{
+				N: "test",
+				ValidateTokenFn: func(_ context.Context, token string) (*core.UserIdentity, error) {
+					switch token {
+					case "admin-session":
+						return &core.UserIdentity{Email: "admin@example.test"}, nil
+					default:
+						return nil, fmt.Errorf("unknown session %q", token)
+					}
+				},
+			}
+			cfg.Services = svc
+			cfg.Providers = testutil.NewProviderRegistry(t, sessionFallback)
+			cfg.DefaultConnection = map[string]string{"session-fallback": "default"}
+			cfg.Invoker = invocation.NewBroker(
+				cfg.Providers,
+				svc.Users,
+				svc.Tokens,
+				invocation.WithMCPConnectionMapper(invocation.ConnectionMap(map[string]string{"session-fallback": "catalog"})),
+			)
+		})
+		testutil.CloseOnCleanup(t, ts)
+
+		createResp := struct {
+			ID string `json:"id"`
+		}{}
+		doJSONRequestAndDecode(t, http.MethodPost, ts.URL+"/api/v1/identities", "admin-session", `{"displayName":"Session Fallback Bot"}`, http.StatusCreated, &createResp)
+
+		grantResp := struct {
+			Plugin     string   `json:"plugin"`
+			Operations []string `json:"operations"`
+		}{}
+		doJSONRequestAndDecode(t, http.MethodPut, ts.URL+"/api/v1/identities/"+createResp.ID+"/grants/session-fallback", "admin-session", `{"operations":["discover"]}`, http.StatusOK, &grantResp)
+		if grantResp.Plugin != "session-fallback" || !reflect.DeepEqual(grantResp.Operations, []string{"discover"}) {
+			t.Fatalf("grant response = %+v, want session-fallback [discover]", grantResp)
+		}
+	})
+
+	t.Run("rejects static-only operations when session catalog narrows visibility", func(t *testing.T) {
+		t.Parallel()
+
+		svc := coretesting.NewStubServices(t)
+		seedUser(t, svc, "admin@example.test")
+
+		mixedCatalog := &stubIntegrationWithSessionCatalog{
+			stubIntegrationWithOps: stubIntegrationWithOps{
+				StubIntegration: coretesting.StubIntegration{N: "mixed-catalog", ConnMode: core.ConnectionModeNone},
+			},
+			catalog: serverTestCatalog("mixed-catalog", []catalog.CatalogOperation{{
+				ID:        "static-only",
+				Method:    http.MethodPost,
+				Path:      "/static-only",
+				Transport: catalog.TransportREST,
+			}}),
+			catalogForRequestFn: func(context.Context, string) (*catalog.Catalog, error) {
+				return serverTestCatalog("mixed-catalog", []catalog.CatalogOperation{{
+					ID:        "session-only",
+					Method:    http.MethodGet,
+					Path:      "/session-only",
+					Transport: catalog.TransportREST,
+				}}), nil
+			},
+		}
+
+		ts := newTestServer(t, func(cfg *server.Config) {
+			cfg.Auth = &coretesting.StubAuthProvider{
+				N: "test",
+				ValidateTokenFn: func(_ context.Context, token string) (*core.UserIdentity, error) {
+					switch token {
+					case "admin-session":
+						return &core.UserIdentity{Email: "admin@example.test"}, nil
+					default:
+						return nil, fmt.Errorf("unknown session %q", token)
+					}
+				},
+			}
+			cfg.Services = svc
+			cfg.Providers = testutil.NewProviderRegistry(t, mixedCatalog)
+		})
+		testutil.CloseOnCleanup(t, ts)
+
+		createResp := struct {
+			ID string `json:"id"`
+		}{}
+		doJSONRequestAndDecode(t, http.MethodPost, ts.URL+"/api/v1/identities", "admin-session", `{"displayName":"Mixed Catalog Bot"}`, http.StatusCreated, &createResp)
+
+		req, err := http.NewRequest(http.MethodPut, ts.URL+"/api/v1/identities/"+createResp.ID+"/grants/mixed-catalog", strings.NewReader(`{"operations":["static-only"]}`))
+		if err != nil {
+			t.Fatalf("new request: %v", err)
+		}
+		req.Header.Set("Content-Type", "application/json")
+		req.AddCookie(&http.Cookie{Name: "session_token", Value: "admin-session"})
+		resp, err := http.DefaultClient.Do(req)
+		if err != nil {
+			t.Fatalf("grant static-only request: %v", err)
+		}
+		defer func() { _ = resp.Body.Close() }()
+		if resp.StatusCode != http.StatusBadRequest {
+			body, _ := io.ReadAll(resp.Body)
+			t.Fatalf("grant static-only status = %d, want %d: %s", resp.StatusCode, http.StatusBadRequest, body)
+		}
+
+		grantResp := struct {
+			Plugin     string   `json:"plugin"`
+			Operations []string `json:"operations"`
+		}{}
+		doJSONRequestAndDecode(t, http.MethodPut, ts.URL+"/api/v1/identities/"+createResp.ID+"/grants/mixed-catalog", "admin-session", `{"operations":["session-only"]}`, http.StatusOK, &grantResp)
+		if grantResp.Plugin != "mixed-catalog" || !reflect.DeepEqual(grantResp.Operations, []string{"session-only"}) {
+			t.Fatalf("grant response = %+v, want mixed-catalog [session-only]", grantResp)
+		}
+	})
+
+	t.Run("falls back to static catalog when request catalog is absent", func(t *testing.T) {
+		t.Parallel()
+
+		svc := coretesting.NewStubServices(t)
+		seedUser(t, svc, "admin@example.test")
+
+		optionalSessionCatalog := &stubIntegrationWithSessionCatalog{
+			stubIntegrationWithOps: stubIntegrationWithOps{
+				StubIntegration: coretesting.StubIntegration{N: "optional-session", ConnMode: core.ConnectionModeNone},
+			},
+			catalog: serverTestCatalog("optional-session", []catalog.CatalogOperation{{
+				ID:        "static-op",
+				Method:    http.MethodGet,
+				Path:      "/static-op",
+				Transport: catalog.TransportREST,
+			}}),
+			catalogForRequestFn: func(context.Context, string) (*catalog.Catalog, error) {
+				return nil, nil
+			},
+		}
+
+		ts := newTestServer(t, func(cfg *server.Config) {
+			cfg.Auth = &coretesting.StubAuthProvider{
+				N: "test",
+				ValidateTokenFn: func(_ context.Context, token string) (*core.UserIdentity, error) {
+					switch token {
+					case "admin-session":
+						return &core.UserIdentity{Email: "admin@example.test"}, nil
+					default:
+						return nil, fmt.Errorf("unknown session %q", token)
+					}
+				},
+			}
+			cfg.Services = svc
+			cfg.Providers = testutil.NewProviderRegistry(t, optionalSessionCatalog)
+		})
+		testutil.CloseOnCleanup(t, ts)
+
+		createResp := struct {
+			ID string `json:"id"`
+		}{}
+		doJSONRequestAndDecode(t, http.MethodPost, ts.URL+"/api/v1/identities", "admin-session", `{"displayName":"Optional Session Bot"}`, http.StatusCreated, &createResp)
+
+		grantResp := struct {
+			Plugin     string   `json:"plugin"`
+			Operations []string `json:"operations"`
+		}{}
+		doJSONRequestAndDecode(t, http.MethodPut, ts.URL+"/api/v1/identities/"+createResp.ID+"/grants/optional-session", "admin-session", `{"operations":["static-op"]}`, http.StatusOK, &grantResp)
+		if grantResp.Plugin != "optional-session" || !reflect.DeepEqual(grantResp.Operations, []string{"static-op"}) {
+			t.Fatalf("grant response = %+v, want optional-session [static-op]", grantResp)
+		}
+	})
+
+	t.Run("probes stored named connections and instances", func(t *testing.T) {
+		t.Parallel()
+
+		svc := coretesting.NewStubServices(t)
+		admin := seedUser(t, svc, "admin@example.test")
+		seedToken(t, svc, &core.IntegrationToken{
+			ID:          "tok-team-a-primary",
+			UserID:      admin.ID,
+			Integration: "team-catalog",
+			Connection:  "team-a",
+			Instance:    "primary",
+			AccessToken: "team-a-primary-token",
+		})
+		seedToken(t, svc, &core.IntegrationToken{
+			ID:          "tok-team-a-secondary",
+			UserID:      admin.ID,
+			Integration: "team-catalog",
+			Connection:  "team-a",
+			Instance:    "secondary",
+			AccessToken: "team-a-secondary-token",
+		})
+
+		teamCatalog := &stubIntegrationWithSessionCatalog{
+			stubIntegrationWithOps: stubIntegrationWithOps{
+				StubIntegration: coretesting.StubIntegration{N: "team-catalog", ConnMode: core.ConnectionModeUser},
+			},
+			catalogForRequestFn: func(_ context.Context, token string) (*catalog.Catalog, error) {
+				switch token {
+				case "team-a-primary-token", "team-a-secondary-token":
+					return serverTestCatalog("team-catalog", []catalog.CatalogOperation{{
+						ID:        "discover",
+						Method:    http.MethodGet,
+						Path:      "/discover",
+						Transport: catalog.TransportREST,
+					}}), nil
+				default:
+					return nil, fmt.Errorf("unexpected session token %q", token)
+				}
+			},
+		}
+
+		ts := newTestServer(t, func(cfg *server.Config) {
+			cfg.Auth = &coretesting.StubAuthProvider{
+				N: "test",
+				ValidateTokenFn: func(_ context.Context, token string) (*core.UserIdentity, error) {
+					switch token {
+					case "admin-session":
+						return &core.UserIdentity{Email: "admin@example.test"}, nil
+					default:
+						return nil, fmt.Errorf("unknown session %q", token)
+					}
+				},
+			}
+			cfg.Services = svc
+			cfg.Providers = testutil.NewProviderRegistry(t, teamCatalog)
+			cfg.Invoker = invocation.NewBroker(cfg.Providers, svc.Users, svc.Tokens)
+		})
+		testutil.CloseOnCleanup(t, ts)
+
+		createResp := struct {
+			ID string `json:"id"`
+		}{}
+		doJSONRequestAndDecode(t, http.MethodPost, ts.URL+"/api/v1/identities", "admin-session", `{"displayName":"Team Catalog Bot"}`, http.StatusCreated, &createResp)
+
+		grantResp := struct {
+			Plugin     string   `json:"plugin"`
+			Operations []string `json:"operations"`
+		}{}
+		doJSONRequestAndDecode(t, http.MethodPut, ts.URL+"/api/v1/identities/"+createResp.ID+"/grants/team-catalog", "admin-session", `{"operations":["discover"]}`, http.StatusOK, &grantResp)
+		if grantResp.Plugin != "team-catalog" || !reflect.DeepEqual(grantResp.Operations, []string{"discover"}) {
+			t.Fatalf("grant response = %+v, want team-catalog [discover]", grantResp)
+		}
+	})
+
+	t.Run("allows mcp-passthrough-only operations", func(t *testing.T) {
+		t.Parallel()
+
+		svc := coretesting.NewStubServices(t)
+		seedUser(t, svc, "admin@example.test")
+
+		mcpOnly := &stubIntegrationWithCatalog{
+			StubIntegration: coretesting.StubIntegration{N: "mcp-only", ConnMode: core.ConnectionModeNone},
+			catalog: serverTestCatalog("mcp-only", []catalog.CatalogOperation{{
+				ID:        "discover",
+				Transport: catalog.TransportMCPPassthrough,
+			}}),
+		}
+
+		ts := newTestServer(t, func(cfg *server.Config) {
+			cfg.Auth = &coretesting.StubAuthProvider{
+				N: "test",
+				ValidateTokenFn: func(_ context.Context, token string) (*core.UserIdentity, error) {
+					if token != "admin-session" {
+						return nil, fmt.Errorf("unknown session %q", token)
+					}
+					return &core.UserIdentity{Email: "admin@example.test"}, nil
+				},
+			}
+			cfg.Services = svc
+			cfg.Providers = testutil.NewProviderRegistry(t, mcpOnly)
+		})
+		testutil.CloseOnCleanup(t, ts)
+
+		createResp := struct {
+			ID string `json:"id"`
+		}{}
+		doJSONRequestAndDecode(t, http.MethodPost, ts.URL+"/api/v1/identities", "admin-session", `{"displayName":"MCP Grant Bot"}`, http.StatusCreated, &createResp)
+
+		grantResp := struct {
+			Plugin     string   `json:"plugin"`
+			Operations []string `json:"operations"`
+		}{}
+		doJSONRequestAndDecode(t, http.MethodPut, ts.URL+"/api/v1/identities/"+createResp.ID+"/grants/mcp-only", "admin-session", `{"operations":["discover"]}`, http.StatusOK, &grantResp)
+		if grantResp.Plugin != "mcp-only" || !reflect.DeepEqual(grantResp.Operations, []string{"discover"}) {
+			t.Fatalf("grant response = %+v, want mcp-only [discover]", grantResp)
+		}
+	})
+}
+
+func TestManagedIdentityDeleteFailuresPreserveRetryPath(t *testing.T) {
+	t.Parallel()
+
+	newServer := func(t *testing.T, svc *coredata.Services) (*httptest.Server, *core.User) {
+		t.Helper()
+
+		admin := seedUser(t, svc, "admin@example.test")
+		ts := newTestServer(t, func(cfg *server.Config) {
+			cfg.Auth = &coretesting.StubAuthProvider{
+				N: "test",
+				ValidateTokenFn: func(_ context.Context, token string) (*core.UserIdentity, error) {
+					switch token {
+					case "admin-session":
+						return &core.UserIdentity{Email: "admin@example.test"}, nil
+					default:
+						return nil, fmt.Errorf("unknown session %q", token)
+					}
+				},
+			}
+			cfg.Services = svc
+		})
+		return ts, admin
+	}
+
+	t.Run("grant delete failure restores prior grants", func(t *testing.T) {
+		t.Parallel()
+
+		svc, failDelete := newTestServicesWithManagedIdentityGrantDeleteFailure(t, 2)
+		ts, _ := newServer(t, svc)
+		testutil.CloseOnCleanup(t, ts)
+
+		createResp := struct {
+			ID string `json:"id"`
+		}{}
+		doJSONRequestAndDecode(t, http.MethodPost, ts.URL+"/api/v1/identities", "admin-session", `{"displayName":"Grant Retry Bot"}`, http.StatusCreated, &createResp)
+		if _, err := svc.IdentityGrants.UpsertGrant(context.Background(), &core.ManagedIdentityGrant{
+			IdentityID: createResp.ID,
+			Plugin:     "alpha",
+		}); err != nil {
+			t.Fatalf("UpsertGrant alpha: %v", err)
+		}
+		if _, err := svc.IdentityGrants.UpsertGrant(context.Background(), &core.ManagedIdentityGrant{
+			IdentityID: createResp.ID,
+			Plugin:     "beta",
+		}); err != nil {
+			t.Fatalf("UpsertGrant beta: %v", err)
+		}
+
+		failDelete.Enable()
+		req, _ := http.NewRequest(http.MethodDelete, ts.URL+"/api/v1/identities/"+createResp.ID, nil)
+		req.AddCookie(&http.Cookie{Name: "session_token", Value: "admin-session"})
+		resp, err := http.DefaultClient.Do(req)
+		if err != nil {
+			t.Fatalf("delete request: %v", err)
+		}
+		defer func() { _ = resp.Body.Close() }()
+		if resp.StatusCode != http.StatusInternalServerError {
+			body, _ := io.ReadAll(resp.Body)
+			t.Fatalf("delete status = %d, want %d: %s", resp.StatusCode, http.StatusInternalServerError, body)
+		}
+
+		failDelete.Disable()
+		doJSONRequestAndDecode(t, http.MethodGet, ts.URL+"/api/v1/identities/"+createResp.ID, "admin-session", "", http.StatusOK, nil)
+
+		grants, err := svc.IdentityGrants.ListGrantsByIdentity(context.Background(), createResp.ID)
+		if err != nil {
+			t.Fatalf("ListGrantsByIdentity: %v", err)
+		}
+		if len(grants) != 2 {
+			t.Fatalf("grant count = %d, want 2", len(grants))
+		}
+	})
+
+	t.Run("membership delete failure restores deleted grants and members", func(t *testing.T) {
+		t.Parallel()
+
+		svc, failDelete := newTestServicesWithManagedIdentityMembershipDeleteFailure(t, 2)
+		ts, admin := newServer(t, svc)
+		testutil.CloseOnCleanup(t, ts)
+
+		viewer := seedUser(t, svc, "viewer@example.test")
+
+		createResp := struct {
+			ID string `json:"id"`
+		}{}
+		doJSONRequestAndDecode(t, http.MethodPost, ts.URL+"/api/v1/identities", "admin-session", `{"displayName":"Member Retry Bot"}`, http.StatusCreated, &createResp)
+		originalGrant, err := svc.IdentityGrants.UpsertGrant(context.Background(), &core.ManagedIdentityGrant{
+			IdentityID: createResp.ID,
+			Plugin:     "alpha",
+		})
+		if err != nil {
+			t.Fatalf("UpsertGrant: %v", err)
+		}
+		originalViewerMembership, err := svc.IdentityMemberships.UpsertMembership(context.Background(), &core.ManagedIdentityMembership{
+			IdentityID: createResp.ID,
+			UserID:     viewer.ID,
+			Email:      viewer.Email,
+			Role:       "viewer",
+		})
+		if err != nil {
+			t.Fatalf("UpsertMembership viewer: %v", err)
+		}
+
+		failDelete.Enable()
+		req, _ := http.NewRequest(http.MethodDelete, ts.URL+"/api/v1/identities/"+createResp.ID, nil)
+		req.AddCookie(&http.Cookie{Name: "session_token", Value: "admin-session"})
+		resp, err := http.DefaultClient.Do(req)
+		if err != nil {
+			t.Fatalf("delete request: %v", err)
+		}
+		defer func() { _ = resp.Body.Close() }()
+		if resp.StatusCode != http.StatusInternalServerError {
+			body, _ := io.ReadAll(resp.Body)
+			t.Fatalf("delete status = %d, want %d: %s", resp.StatusCode, http.StatusInternalServerError, body)
+		}
+
+		failDelete.Disable()
+		doJSONRequestAndDecode(t, http.MethodGet, ts.URL+"/api/v1/identities/"+createResp.ID, "admin-session", "", http.StatusOK, nil)
+
+		grants, err := svc.IdentityGrants.ListGrantsByIdentity(context.Background(), createResp.ID)
+		if err != nil {
+			t.Fatalf("ListGrantsByIdentity: %v", err)
+		}
+		if len(grants) != 1 || grants[0].Plugin != "alpha" {
+			t.Fatalf("grants = %+v, want single alpha grant", grants)
+		}
+		restoredGrant, err := svc.IdentityGrants.GetGrant(context.Background(), createResp.ID, "alpha")
+		if err != nil {
+			t.Fatalf("GetGrant alpha: %v", err)
+		}
+		if restoredGrant.ID != originalGrant.ID || !restoredGrant.CreatedAt.Equal(originalGrant.CreatedAt) || !restoredGrant.UpdatedAt.Equal(originalGrant.UpdatedAt) {
+			t.Fatalf("restored grant = %+v, want original metadata %+v", restoredGrant, originalGrant)
+		}
+		memberships, err := svc.IdentityMemberships.ListMembershipsByIdentity(context.Background(), createResp.ID)
+		if err != nil {
+			t.Fatalf("ListMembershipsByIdentity: %v", err)
+		}
+		if len(memberships) != 2 {
+			t.Fatalf("membership count = %d, want 2", len(memberships))
+		}
+		if _, err := svc.IdentityMemberships.GetMembership(context.Background(), createResp.ID, admin.ID); err != nil {
+			t.Fatalf("GetMembership admin: %v", err)
+		}
+		restoredViewerMembership, err := svc.IdentityMemberships.GetMembership(context.Background(), createResp.ID, viewer.ID)
+		if err != nil {
+			t.Fatalf("GetMembership viewer: %v", err)
+		}
+		if restoredViewerMembership.ID != originalViewerMembership.ID || !restoredViewerMembership.CreatedAt.Equal(originalViewerMembership.CreatedAt) || !restoredViewerMembership.UpdatedAt.Equal(originalViewerMembership.UpdatedAt) {
+			t.Fatalf("restored viewer membership = %+v, want original metadata %+v", restoredViewerMembership, originalViewerMembership)
+		}
+	})
+
+	t.Run("identity delete failure restores all child state", func(t *testing.T) {
+		t.Parallel()
+
+		svc, failDelete := newTestServicesWithManagedIdentityDeleteFailure(t)
+		ts, admin := newServer(t, svc)
+		testutil.CloseOnCleanup(t, ts)
+
+		viewer := seedUser(t, svc, "delete-viewer@example.test")
+
+		createResp := struct {
+			ID string `json:"id"`
+		}{}
+		doJSONRequestAndDecode(t, http.MethodPost, ts.URL+"/api/v1/identities", "admin-session", `{"displayName":"Delete Retry Bot"}`, http.StatusCreated, &createResp)
+		originalGrant, err := svc.IdentityGrants.UpsertGrant(context.Background(), &core.ManagedIdentityGrant{
+			IdentityID: createResp.ID,
+			Plugin:     "alpha",
+		})
+		if err != nil {
+			t.Fatalf("UpsertGrant: %v", err)
+		}
+		originalViewerMembership, err := svc.IdentityMemberships.UpsertMembership(context.Background(), &core.ManagedIdentityMembership{
+			IdentityID: createResp.ID,
+			UserID:     viewer.ID,
+			Email:      viewer.Email,
+			Role:       "viewer",
+		})
+		if err != nil {
+			t.Fatalf("UpsertMembership viewer: %v", err)
+		}
+
+		failDelete.Enable()
+		req, _ := http.NewRequest(http.MethodDelete, ts.URL+"/api/v1/identities/"+createResp.ID, nil)
+		req.AddCookie(&http.Cookie{Name: "session_token", Value: "admin-session"})
+		resp, err := http.DefaultClient.Do(req)
+		if err != nil {
+			t.Fatalf("delete request: %v", err)
+		}
+		defer func() { _ = resp.Body.Close() }()
+		if resp.StatusCode != http.StatusInternalServerError {
+			body, _ := io.ReadAll(resp.Body)
+			t.Fatalf("delete status = %d, want %d: %s", resp.StatusCode, http.StatusInternalServerError, body)
+		}
+
+		failDelete.Disable()
+		doJSONRequestAndDecode(t, http.MethodGet, ts.URL+"/api/v1/identities/"+createResp.ID, "admin-session", "", http.StatusOK, nil)
+
+		grants, err := svc.IdentityGrants.ListGrantsByIdentity(context.Background(), createResp.ID)
+		if err != nil {
+			t.Fatalf("ListGrantsByIdentity: %v", err)
+		}
+		if len(grants) != 1 || grants[0].Plugin != "alpha" {
+			t.Fatalf("grants after failed parent delete = %+v, want single alpha grant", grants)
+		}
+		restoredGrant, err := svc.IdentityGrants.GetGrant(context.Background(), createResp.ID, "alpha")
+		if err != nil {
+			t.Fatalf("GetGrant alpha: %v", err)
+		}
+		if restoredGrant.ID != originalGrant.ID || !restoredGrant.CreatedAt.Equal(originalGrant.CreatedAt) || !restoredGrant.UpdatedAt.Equal(originalGrant.UpdatedAt) {
+			t.Fatalf("restored grant = %+v, want original metadata %+v", restoredGrant, originalGrant)
+		}
+		memberships, err := svc.IdentityMemberships.ListMembershipsByIdentity(context.Background(), createResp.ID)
+		if err != nil {
+			t.Fatalf("ListMembershipsByIdentity: %v", err)
+		}
+		if len(memberships) != 2 {
+			t.Fatalf("membership count after failed parent delete = %d, want 2", len(memberships))
+		}
+		if _, err := svc.IdentityMemberships.GetMembership(context.Background(), createResp.ID, admin.ID); err != nil {
+			t.Fatalf("GetMembership admin: %v", err)
+		}
+		restoredViewerMembership, err := svc.IdentityMemberships.GetMembership(context.Background(), createResp.ID, viewer.ID)
+		if err != nil {
+			t.Fatalf("GetMembership viewer: %v", err)
+		}
+		if restoredViewerMembership.ID != originalViewerMembership.ID || !restoredViewerMembership.CreatedAt.Equal(originalViewerMembership.CreatedAt) || !restoredViewerMembership.UpdatedAt.Equal(originalViewerMembership.UpdatedAt) {
+			t.Fatalf("restored viewer membership = %+v, want original metadata %+v", restoredViewerMembership, originalViewerMembership)
+		}
+
+		doJSONRequestAndDecode(t, http.MethodDelete, ts.URL+"/api/v1/identities/"+createResp.ID, "admin-session", "", http.StatusOK, nil)
+	})
+
+	t.Run("identity delete failure retries later restore failure and preserves child state", func(t *testing.T) {
+		t.Parallel()
+
+		svc, deleteFail, membershipRestoreFail := newTestServicesWithManagedIdentityDeleteAndMembershipRestoreFailure(t, 2)
+		ts, _ := newServer(t, svc)
+		testutil.CloseOnCleanup(t, ts)
+
+		viewer := seedUser(t, svc, "restore-viewer@example.test")
+
+		createResp := struct {
+			ID string `json:"id"`
+		}{}
+		doJSONRequestAndDecode(t, http.MethodPost, ts.URL+"/api/v1/identities", "admin-session", `{"displayName":"Restore Retry Bot"}`, http.StatusCreated, &createResp)
+		originalGrant, err := svc.IdentityGrants.UpsertGrant(context.Background(), &core.ManagedIdentityGrant{
+			IdentityID: createResp.ID,
+			Plugin:     "alpha",
+		})
+		if err != nil {
+			t.Fatalf("UpsertGrant: %v", err)
+		}
+		if _, err := svc.IdentityMemberships.UpsertMembership(context.Background(), &core.ManagedIdentityMembership{
+			IdentityID: createResp.ID,
+			UserID:     viewer.ID,
+			Email:      viewer.Email,
+			Role:       "viewer",
+		}); err != nil {
+			t.Fatalf("UpsertMembership viewer: %v", err)
+		}
+
+		deleteFail.Enable()
+		membershipRestoreFail.Enable()
+		req, _ := http.NewRequest(http.MethodDelete, ts.URL+"/api/v1/identities/"+createResp.ID, nil)
+		req.AddCookie(&http.Cookie{Name: "session_token", Value: "admin-session"})
+		resp, err := http.DefaultClient.Do(req)
+		if err != nil {
+			t.Fatalf("delete request: %v", err)
+		}
+		defer func() { _ = resp.Body.Close() }()
+		if resp.StatusCode != http.StatusInternalServerError {
+			body, _ := io.ReadAll(resp.Body)
+			t.Fatalf("delete status = %d, want %d: %s", resp.StatusCode, http.StatusInternalServerError, body)
+		}
+
+		deleteFail.Disable()
+		membershipRestoreFail.Disable()
+		doJSONRequestAndDecode(t, http.MethodGet, ts.URL+"/api/v1/identities/"+createResp.ID, "admin-session", "", http.StatusOK, nil)
+		restoredGrant, err := svc.IdentityGrants.GetGrant(context.Background(), createResp.ID, "alpha")
+		if err != nil {
+			t.Fatalf("GetGrant alpha: %v", err)
+		}
+		if restoredGrant.ID != originalGrant.ID || !restoredGrant.CreatedAt.Equal(originalGrant.CreatedAt) || !restoredGrant.UpdatedAt.Equal(originalGrant.UpdatedAt) {
+			t.Fatalf("restored grant = %+v, want original metadata %+v", restoredGrant, originalGrant)
+		}
+		memberships, err := svc.IdentityMemberships.ListMembershipsByIdentity(context.Background(), createResp.ID)
+		if err != nil {
+			t.Fatalf("ListMembershipsByIdentity: %v", err)
+		}
+		if len(memberships) != 2 {
+			t.Fatalf("membership count after restore retry = %d, want 2", len(memberships))
+		}
+		if _, err := svc.IdentityMemberships.GetMembership(context.Background(), createResp.ID, viewer.ID); err != nil {
+			t.Fatalf("GetMembership viewer after restore retry: %v", err)
+		}
+	})
+}
+
+func TestManagedIdentityRoutesRequireConfiguredAuth(t *testing.T) {
+	t.Parallel()
+
+	ts := newTestServer(t, func(cfg *server.Config) {
+		cfg.Services = coretesting.NewStubServices(t)
+	})
+	testutil.CloseOnCleanup(t, ts)
+
+	req, _ := http.NewRequest(http.MethodGet, ts.URL+"/api/v1/identities", nil)
+	resp, err := http.DefaultClient.Do(req)
+	if err != nil {
+		t.Fatalf("request: %v", err)
+	}
+	defer func() { _ = resp.Body.Close() }()
+	if resp.StatusCode != http.StatusServiceUnavailable {
+		t.Fatalf("status = %d, want %d", resp.StatusCode, http.StatusServiceUnavailable)
+	}
+}
+
+func TestServerAllowsProviderNamedIdentities(t *testing.T) {
+	t.Parallel()
+
+	svc := coretesting.NewStubServices(t)
+	seedUser(t, svc, "admin@example.test")
+	getOnlyOperation := "00000000-0000-0000-0000-000000000044"
+	patchOperation := "11111111-1111-1111-1111-111111111111"
+	deleteOperation := "22222222-2222-2222-2222-222222222222"
+	missingIdentityID := "33333333-3333-3333-3333-333333333333"
+
+	providers := testutil.NewProviderRegistry(t, &stubIntegrationWithOps{
+		StubIntegration: coretesting.StubIntegration{
+			N:        "identities",
+			ConnMode: core.ConnectionModeNone,
+			ExecuteFn: func(_ context.Context, operation string, _ map[string]any, _ string) (*core.OperationResult, error) {
+				return &core.OperationResult{Status: http.StatusOK, Body: fmt.Sprintf(`{"operation":%q}`, operation)}, nil
+			},
+		},
+		ops: []core.Operation{
+			{Name: "read", Method: http.MethodGet},
+			{Name: "write", Method: http.MethodPost},
+			{Name: getOnlyOperation, Method: http.MethodGet},
+			{Name: patchOperation, Method: http.MethodPatch},
+			{Name: deleteOperation, Method: http.MethodDelete},
+		},
+	})
+
+	ts := newTestServer(t, func(cfg *server.Config) {
+		cfg.Auth = &coretesting.StubAuthProvider{
+			N: "test",
+			ValidateTokenFn: func(_ context.Context, token string) (*core.UserIdentity, error) {
+				if token != "admin-session" {
+					return nil, fmt.Errorf("unknown session %q", token)
+				}
+				return &core.UserIdentity{Email: "admin@example.test"}, nil
+			},
+		}
+		cfg.Services = svc
+		cfg.Providers = providers
+	})
+	testutil.CloseOnCleanup(t, ts)
+
+	createResp := struct {
+		ID string `json:"id"`
+	}{}
+	doJSONRequestAndDecode(t, http.MethodPost, ts.URL+"/api/v1/identities", "admin-session", `{"displayName":"Named Provider Bot"}`, http.StatusCreated, &createResp)
+
+	readReq, _ := http.NewRequest(http.MethodGet, ts.URL+"/api/v1/identities/read", nil)
+	readReq.AddCookie(&http.Cookie{Name: "session_token", Value: "admin-session"})
+	readResp, err := http.DefaultClient.Do(readReq)
+	if err != nil {
+		t.Fatalf("GET identities/read: %v", err)
+	}
+	defer func() { _ = readResp.Body.Close() }()
+	if readResp.StatusCode != http.StatusOK {
+		body, _ := io.ReadAll(readResp.Body)
+		t.Fatalf("GET identities/read status = %d, want %d: %s", readResp.StatusCode, http.StatusOK, body)
+	}
+
+	writeReq, _ := http.NewRequest(http.MethodPost, ts.URL+"/api/v1/identities/write", bytes.NewBufferString(`{}`))
+	writeReq.Header.Set("Content-Type", "application/json")
+	writeReq.AddCookie(&http.Cookie{Name: "session_token", Value: "admin-session"})
+	writeResp, err := http.DefaultClient.Do(writeReq)
+	if err != nil {
+		t.Fatalf("POST identities/write: %v", err)
+	}
+	defer func() { _ = writeResp.Body.Close() }()
+	if writeResp.StatusCode != http.StatusOK {
+		body, _ := io.ReadAll(writeResp.Body)
+		t.Fatalf("POST identities/write status = %d, want %d: %s", writeResp.StatusCode, http.StatusOK, body)
+	}
+
+	patchReq, _ := http.NewRequest(http.MethodPatch, ts.URL+"/api/v1/identities/"+patchOperation, nil)
+	patchReq.AddCookie(&http.Cookie{Name: "session_token", Value: "admin-session"})
+	patchResp, err := http.DefaultClient.Do(patchReq)
+	if err != nil {
+		t.Fatalf("PATCH identities/%s: %v", patchOperation, err)
+	}
+	defer func() { _ = patchResp.Body.Close() }()
+	if patchResp.StatusCode != http.StatusOK {
+		body, _ := io.ReadAll(patchResp.Body)
+		t.Fatalf("PATCH identities/%s status = %d, want %d: %s", patchOperation, patchResp.StatusCode, http.StatusOK, body)
+	}
+
+	deleteReq, _ := http.NewRequest(http.MethodDelete, ts.URL+"/api/v1/identities/"+deleteOperation, nil)
+	deleteReq.AddCookie(&http.Cookie{Name: "session_token", Value: "admin-session"})
+	deleteResp, err := http.DefaultClient.Do(deleteReq)
+	if err != nil {
+		t.Fatalf("DELETE identities/%s: %v", deleteOperation, err)
+	}
+	defer func() { _ = deleteResp.Body.Close() }()
+	if deleteResp.StatusCode != http.StatusOK {
+		body, _ := io.ReadAll(deleteResp.Body)
+		t.Fatalf("DELETE identities/%s status = %d, want %d: %s", deleteOperation, deleteResp.StatusCode, http.StatusOK, body)
+	}
+
+	getOnlyReq, _ := http.NewRequest(http.MethodGet, ts.URL+"/api/v1/identities/"+getOnlyOperation, nil)
+	getOnlyReq.AddCookie(&http.Cookie{Name: "session_token", Value: "admin-session"})
+	getOnlyResp, err := http.DefaultClient.Do(getOnlyReq)
+	if err != nil {
+		t.Fatalf("GET identities/%s: %v", getOnlyOperation, err)
+	}
+	defer func() { _ = getOnlyResp.Body.Close() }()
+	if getOnlyResp.StatusCode != http.StatusOK {
+		body, _ := io.ReadAll(getOnlyResp.Body)
+		t.Fatalf("GET identities/%s status = %d, want %d: %s", getOnlyOperation, getOnlyResp.StatusCode, http.StatusOK, body)
+	}
+
+	getOnlyPatchReq, _ := http.NewRequest(http.MethodPatch, ts.URL+"/api/v1/identities/"+getOnlyOperation, bytes.NewBufferString(`{"displayName":"Still Missing"}`))
+	getOnlyPatchReq.Header.Set("Content-Type", "application/json")
+	getOnlyPatchReq.AddCookie(&http.Cookie{Name: "session_token", Value: "admin-session"})
+	getOnlyPatchResp, err := http.DefaultClient.Do(getOnlyPatchReq)
+	if err != nil {
+		t.Fatalf("PATCH identities/%s: %v", getOnlyOperation, err)
+	}
+	defer func() { _ = getOnlyPatchResp.Body.Close() }()
+	if getOnlyPatchResp.StatusCode != http.StatusNotFound {
+		body, _ := io.ReadAll(getOnlyPatchResp.Body)
+		t.Fatalf("PATCH identities/%s status = %d, want %d: %s", getOnlyOperation, getOnlyPatchResp.StatusCode, http.StatusNotFound, body)
+	}
+
+	missingGetReq, _ := http.NewRequest(http.MethodGet, ts.URL+"/api/v1/identities/"+missingIdentityID, nil)
+	missingGetReq.AddCookie(&http.Cookie{Name: "session_token", Value: "admin-session"})
+	missingGetResp, err := http.DefaultClient.Do(missingGetReq)
+	if err != nil {
+		t.Fatalf("GET identities/%s: %v", missingIdentityID, err)
+	}
+	defer func() { _ = missingGetResp.Body.Close() }()
+	if missingGetResp.StatusCode != http.StatusNotFound {
+		body, _ := io.ReadAll(missingGetResp.Body)
+		t.Fatalf("GET identities/%s status = %d, want %d: %s", missingIdentityID, missingGetResp.StatusCode, http.StatusNotFound, body)
+	}
+
+	missingDeleteReq, _ := http.NewRequest(http.MethodDelete, ts.URL+"/api/v1/identities/"+missingIdentityID, nil)
+	missingDeleteReq.AddCookie(&http.Cookie{Name: "session_token", Value: "admin-session"})
+	missingDeleteResp, err := http.DefaultClient.Do(missingDeleteReq)
+	if err != nil {
+		t.Fatalf("DELETE identities/%s: %v", missingIdentityID, err)
+	}
+	defer func() { _ = missingDeleteResp.Body.Close() }()
+	if missingDeleteResp.StatusCode != http.StatusNotFound {
+		body, _ := io.ReadAll(missingDeleteResp.Body)
+		t.Fatalf("DELETE identities/%s status = %d, want %d: %s", missingIdentityID, missingDeleteResp.StatusCode, http.StatusNotFound, body)
+	}
+
+	getResp := struct {
+		ID string `json:"id"`
+	}{}
+	doJSONRequestAndDecode(t, http.MethodGet, ts.URL+"/api/v1/identities/"+createResp.ID, "admin-session", "", http.StatusOK, &getResp)
+	if getResp.ID != createResp.ID {
+		t.Fatalf("get identity response = %+v, want id %q", getResp, createResp.ID)
+	}
+}
+
+func TestServerAllowsProviderNamedIdentitiesWhenManagedIdentityStoresUnavailable(t *testing.T) {
+	t.Parallel()
+
+	svc := coretesting.NewStubServices(t)
+	svc.ManagedIdentities = nil
+	svc.IdentityMemberships = nil
+	svc.IdentityGrants = nil
+
+	providers := testutil.NewProviderRegistry(t, &stubIntegrationWithOps{
+		StubIntegration: coretesting.StubIntegration{
+			N:        "identities",
+			ConnMode: core.ConnectionModeNone,
+			ExecuteFn: func(_ context.Context, operation string, _ map[string]any, _ string) (*core.OperationResult, error) {
+				return &core.OperationResult{Status: http.StatusOK, Body: fmt.Sprintf(`{"operation":%q}`, operation)}, nil
+			},
+		},
+		ops: []core.Operation{{Name: "read", Method: http.MethodGet}},
+	})
+
+	ts := newTestServer(t, func(cfg *server.Config) {
+		cfg.Auth = &coretesting.StubAuthProvider{
+			N: "test",
+			ValidateTokenFn: func(_ context.Context, token string) (*core.UserIdentity, error) {
+				if token != "admin-session" {
+					return nil, fmt.Errorf("unknown session %q", token)
+				}
+				return &core.UserIdentity{Email: "admin@example.test"}, nil
+			},
+		}
+		cfg.Services = svc
+		cfg.Providers = providers
+	})
+	testutil.CloseOnCleanup(t, ts)
+
+	readReq, _ := http.NewRequest(http.MethodGet, ts.URL+"/api/v1/identities/read", nil)
+	readReq.AddCookie(&http.Cookie{Name: "session_token", Value: "admin-session"})
+	readResp, err := http.DefaultClient.Do(readReq)
+	if err != nil {
+		t.Fatalf("GET identities/read: %v", err)
+	}
+	defer func() { _ = readResp.Body.Close() }()
+	if readResp.StatusCode != http.StatusOK {
+		body, _ := io.ReadAll(readResp.Body)
+		t.Fatalf("GET identities/read status = %d, want %d: %s", readResp.StatusCode, http.StatusOK, body)
+	}
+
+	missingReq, _ := http.NewRequest(http.MethodGet, ts.URL+"/api/v1/identities/33333333-3333-3333-3333-333333333333", nil)
+	missingReq.AddCookie(&http.Cookie{Name: "session_token", Value: "admin-session"})
+	missingResp, err := http.DefaultClient.Do(missingReq)
+	if err != nil {
+		t.Fatalf("GET missing identity UUID: %v", err)
+	}
+	defer func() { _ = missingResp.Body.Close() }()
+	if missingResp.StatusCode != http.StatusServiceUnavailable {
+		body, _ := io.ReadAll(missingResp.Body)
+		t.Fatalf("GET missing identity UUID status = %d, want %d: %s", missingResp.StatusCode, http.StatusServiceUnavailable, body)
+	}
+}
+
+func TestDeleteManagedIdentityMemberDecodesEscapedEmailPath(t *testing.T) {
+	t.Parallel()
+
+	svc := coretesting.NewStubServices(t)
+	seedUser(t, svc, "admin@example.test")
+	member := seedUser(t, svc, "editor/alias@example.test")
+
+	ts := newTestServer(t, func(cfg *server.Config) {
+		cfg.Auth = &coretesting.StubAuthProvider{
+			N: "test",
+			ValidateTokenFn: func(_ context.Context, token string) (*core.UserIdentity, error) {
+				if token != "admin-session" {
+					return nil, fmt.Errorf("unknown session %q", token)
+				}
+				return &core.UserIdentity{Email: "admin@example.test"}, nil
+			},
+		}
+		cfg.Services = svc
+	})
+	testutil.CloseOnCleanup(t, ts)
+
+	createResp := struct {
+		ID string `json:"id"`
+	}{}
+	doJSONRequestAndDecode(t, http.MethodPost, ts.URL+"/api/v1/identities", "admin-session", `{"displayName":"Escaped Email Bot"}`, http.StatusCreated, &createResp)
+	doJSONRequestAndDecode(
+		t,
+		http.MethodPut,
+		ts.URL+"/api/v1/identities/"+createResp.ID+"/members",
+		"admin-session",
+		`{"email":"editor/alias@example.test","role":"viewer"}`,
+		http.StatusOK,
+		nil,
+	)
+
+	doJSONRequestAndDecode(
+		t,
+		http.MethodDelete,
+		ts.URL+"/api/v1/identities/"+createResp.ID+"/members/"+url.PathEscape(member.Email),
+		"admin-session",
+		"",
+		http.StatusOK,
+		nil,
+	)
+
+	members, err := svc.IdentityMemberships.ListMembershipsByIdentity(context.Background(), createResp.ID)
+	if err != nil {
+		t.Fatalf("ListMembershipsByIdentity: %v", err)
+	}
+	if len(members) != 1 || members[0].UserID == member.ID {
+		t.Fatalf("members after delete = %+v, expected only the admin membership to remain", members)
+	}
+}
+
+func doJSONRequestAndDecode(t *testing.T, method, url, sessionToken, body string, wantStatus int, dst any) {
+	t.Helper()
+
+	var reqBody io.Reader
+	if body != "" {
+		reqBody = bytes.NewBufferString(body)
+	}
+	req, _ := http.NewRequest(method, url, reqBody)
+	if body != "" {
+		req.Header.Set("Content-Type", "application/json")
+	}
+	if sessionToken != "" {
+		req.AddCookie(&http.Cookie{Name: "session_token", Value: sessionToken})
+	}
+
+	resp, err := http.DefaultClient.Do(req)
+	if err != nil {
+		t.Fatalf("%s %s: %v", method, url, err)
+	}
+	defer func() { _ = resp.Body.Close() }()
+	if resp.StatusCode != wantStatus {
+		payload, _ := io.ReadAll(resp.Body)
+		t.Fatalf("%s %s status = %d, want %d: %s", method, url, resp.StatusCode, wantStatus, strings.TrimSpace(string(payload)))
+	}
+	if dst == nil {
+		return
+	}
+	if err := json.NewDecoder(resp.Body).Decode(dst); err != nil {
+		t.Fatalf("%s %s decode: %v", method, url, err)
 	}
 }


### PR DESCRIPTION
## Summary

This lands the first managed-identity vertical slice:
- persisted managed identities, memberships, and plugin grants in `gestaltd`
- authenticated HTTP routes under `/api/v1/identities/...`
- initial `gestalt identities ...` CLI commands
- audit coverage and route validation for the new management surface
- internal product and implementation docs for the full rollout

## New Go Interfaces

```go
type ManagedIdentity struct {
    ID          string
    DisplayName string
    CreatedAt   time.Time
    UpdatedAt   time.Time
}

type ManagedIdentityMembership struct {
    ID         string
    IdentityID string
    UserID     string
    Email      string
    Role       string // viewer | editor | admin
    CreatedAt  time.Time
    UpdatedAt  time.Time
}

type ManagedIdentityGrant struct {
    ID         string
    IdentityID string
    Plugin     string
    Operations []string // empty means plugin-wide access
    CreatedAt  time.Time
    UpdatedAt  time.Time
}
```

## New HTTP Routes

```text
GET    /api/v1/identities
POST   /api/v1/identities
GET    /api/v1/identities/{identityID}
PATCH  /api/v1/identities/{identityID}
DELETE /api/v1/identities/{identityID}

GET    /api/v1/identities/{identityID}/members
PUT    /api/v1/identities/{identityID}/members
DELETE /api/v1/identities/{identityID}/members/{email}

GET    /api/v1/identities/{identityID}/grants
PUT    /api/v1/identities/{identityID}/grants/{plugin}
DELETE /api/v1/identities/{identityID}/grants/{plugin}
```

## CLI Examples

```bash
gestalt identities create --name "release-bot"
gestalt identities list
gestalt identities get <identity-id>
gestalt identities update <identity-id> --name "release-automation"
gestalt identities delete <identity-id>

gestalt identities members add <identity-id> alice@example.com --role viewer
gestalt identities members update <identity-id> alice@example.com --role admin
gestalt identities members remove <identity-id> alice@example.com

gestalt identities grants set <identity-id> github --operation issues.list --operation pulls.list
gestalt identities grants revoke <identity-id> github
```

## YAML Context

```yaml
server:
  providers:
    auth: google

plugins:
  weather:
    source:
      path: ./plugins/weather/manifest.yaml
    authorizationPolicy: weather_access
    connections:
      default:
        mode: user
        auth:
          type: manual
```

Managed identities are runtime-managed, so this PR does not add new YAML to create an identity. The existing plugin authorization YAML still defines the ceiling for which plugins a human can grant to an identity.

## Additional Hardening

- identity lifecycle/admin mutations are serialized in-process to protect the “must retain at least one admin” invariant
- create/delete ordering avoids orphaning identities without reachable admins
- grant operations are validated against the plugin’s known catalog operations
- the provider name `identities` is reserved so the new route subtree cannot be shadowed
- all identity create/update/delete/member/grant mutations emit audit events

## Testing

- `go test ./...`
- `cargo test --manifest-path gestalt/Cargo.toml --test integration`
