### PR TITLE
gestaltd: validate plugin invokes dependencies during init and validate

### DIFF
--- a/gestaltd/internal/bootstrap/bootstrap_test.go
+++ b/gestaltd/internal/bootstrap/bootstrap_test.go
@@ -419,6 +419,28 @@ func TestValidate(t *testing.T) {
 			t.Fatalf("Validate: %v", err)
 		}
 	})
+
+	t.Run("rejects invalid plugin invokes dependency", func(t *testing.T) {
+		t.Parallel()
+
+		cfg := validConfig()
+		cfg.Plugins = map[string]*config.ProviderEntry{
+			"caller": {
+				ResolvedManifest: &providermanifestv1.Manifest{
+					Entrypoint: &providermanifestv1.Entrypoint{ArtifactPath: "caller"},
+					Spec:       &providermanifestv1.Spec{},
+				},
+				Invokes: []config.PluginInvocationDependency{
+					{Plugin: "missing", Operation: "ping"},
+				},
+			},
+		}
+
+		_, err := bootstrap.Validate(context.Background(), cfg, validFactories())
+		if err == nil || !strings.Contains(err.Error(), `plugins.caller.invokes[0] references unknown plugin "missing"`) {
+			t.Fatalf("Validate error = %v, want unknown plugin invokes error", err)
+		}
+	})
 }
 
 func TestBootstrapNoIntegrations(t *testing.T) {

--- a/gestaltd/internal/bootstrap/connections.go
+++ b/gestaltd/internal/bootstrap/connections.go
@@ -2,9 +2,7 @@ package bootstrap
 
 import (
 	"fmt"
-	"path/filepath"
 	"sort"
-	"strings"
 
 	"github.com/valon-technologies/gestalt/server/core"
 	"github.com/valon-technologies/gestalt/server/internal/config"
@@ -311,24 +309,7 @@ func surfaceURL(plugin *config.ProviderEntry, manifestPlugin *providermanifestv1
 	if url == "" {
 		return ""
 	}
-	return resolveManifestRelativeSpecURL(plugin, url)
-}
-
-func resolveManifestRelativeSpecURL(plugin *config.ProviderEntry, raw string) string {
-	if plugin == nil || plugin.ResolvedManifestPath == "" || raw == "" {
-		return raw
-	}
-	if filepath.IsAbs(raw) || strings.HasPrefix(raw, "http://") || strings.HasPrefix(raw, "https://") {
-		return raw
-	}
-	if strings.HasPrefix(raw, "file://") {
-		path := strings.TrimPrefix(raw, "file://")
-		if filepath.IsAbs(path) {
-			return raw
-		}
-		return "file://" + filepath.Clean(filepath.Join(filepath.Dir(plugin.ResolvedManifestPath), path))
-	}
-	return filepath.Clean(filepath.Join(filepath.Dir(plugin.ResolvedManifestPath), raw))
+	return config.ResolveManifestRelativeSpecURL(plugin, url)
 }
 
 func buildConnectionAuthMap(name string, entry *config.ProviderEntry, manifest *providermanifestv1.Manifest, pluginConfig map[string]any, authFallback *specAuthFallback, deps Deps) (map[string]OAuthHandler, error) {

--- a/gestaltd/internal/bootstrap/executable_plugin_test.go
+++ b/gestaltd/internal/bootstrap/executable_plugin_test.go
@@ -311,6 +311,83 @@ paths:
 	}
 }
 
+func TestHybridExecutableProviderAppliesAllowedOperationsToStaticAndOpenAPICatalogs(t *testing.T) {
+	t.Parallel()
+
+	bin := buildEchoPluginBinary(t)
+	manifestRoot := writeStaticCatalog(t, &catalog.Catalog{
+		Name: "hybrid",
+		Operations: []catalog.CatalogOperation{
+			{ID: "echo", Method: http.MethodPost, Parameters: []catalog.CatalogParameter{{Name: "message", Type: "string", Required: true}}},
+		},
+	})
+	openapiDoc := `openapi: "3.1.0"
+info:
+  title: Hybrid
+  version: "1.0.0"
+paths:
+  /status:
+    get:
+      operationId: status
+      responses:
+        "200":
+          description: OK
+`
+	if err := os.WriteFile(filepath.Join(manifestRoot, "openapi.yaml"), []byte(openapiDoc), 0o644); err != nil {
+		t.Fatalf("WriteFile(openapi.yaml): %v", err)
+	}
+
+	manifest := newExecutableManifest("Hybrid", "Hybrid provider")
+	manifest.Entrypoint = &providermanifestv1.Entrypoint{ArtifactPath: "ignored-for-command-mode"}
+	manifest.Spec.Surfaces = &providermanifestv1.ProviderSurfaces{
+		OpenAPI: &providermanifestv1.OpenAPISurface{Document: "openapi.yaml"},
+	}
+	manifestPath := filepath.Join(manifestRoot, "manifest.yaml")
+
+	cfg := &config.Config{
+		Plugins: map[string]*config.ProviderEntry{
+			"hybrid": {
+				Command:              bin,
+				Args:                 []string{"provider"},
+				ResolvedManifest:     manifest,
+				ResolvedManifestPath: manifestPath,
+				AllowedOperations: map[string]*config.OperationOverride{
+					"echo":   {Alias: "renamed_echo"},
+					"status": {Alias: "renamed_status"},
+				},
+			},
+		},
+	}
+
+	factories := NewFactoryRegistry()
+	providers, _, err := buildProvidersStrict(context.Background(), cfg, factories, Deps{})
+	if err != nil {
+		t.Fatalf("buildProvidersStrict: %v", err)
+	}
+	defer func() { _ = CloseProviders(providers) }()
+
+	prov, err := providers.Get("hybrid")
+	if err != nil {
+		t.Fatalf("providers.Get(hybrid): %v", err)
+	}
+	cat := prov.Catalog()
+	if cat == nil {
+		t.Fatal("Catalog() = nil")
+	}
+
+	hasOperation := func(id string) bool {
+		return slices.ContainsFunc(cat.Operations, func(op catalog.CatalogOperation) bool {
+			return op.ID == id
+		})
+	}
+	if !hasOperation("renamed_echo") || !hasOperation("renamed_status") {
+		t.Fatalf("catalog operations = %+v, want renamed static and OpenAPI operations", cat.Operations)
+	}
+	if hasOperation("echo") || hasOperation("status") {
+		t.Fatalf("catalog operations = %+v, want original operation ids hidden", cat.Operations)
+	}
+}
+
 func TestSpecLoadedDualSurfaceProviderBuildsMCPOperations(t *testing.T) {
 	t.Parallel()
 

--- a/gestaltd/internal/bootstrap/provider_build.go
+++ b/gestaltd/internal/bootstrap/provider_build.go
@@ -177,8 +177,15 @@ func buildExecutablePluginProvider(ctx context.Context, name string, entry *conf
 	if allowedOperations == nil && manifestPlugin != nil {
 		allowedOperations = maps.Clone(manifestPlugin.AllowedOperations)
 	}
+	staticAllowedOperations := operationexposure.MatchingAllowedOperations(allowedOperations, pluginProv.Catalog())
 
 	if manifestPlugin.IsDeclarative() {
+		filteredPluginProv, err := applyAllowedOperations(name, staticAllowedOperations, pluginProv)
+		if err != nil {
+			closeIfPossible(pluginProv)
+			return nil, err
+		}
+		pluginProv = filteredPluginProv
 		declarative, err := providerhost.NewDeclarativeProvider(
 			manifest,
 			nil,
@@ -189,7 +196,8 @@ func buildExecutablePluginProvider(ctx context.Context, name string, entry *conf
 			closeIfPossible(pluginProv)
 			return nil, fmt.Errorf("create declarative provider %q: %w", name, err)
 		}
-		apiProv, err := applyAllowedOperations(name, allowedOperations, declarative)
+		apiAllowedOperations := operationexposure.MatchingAllowedOperations(allowedOperations, declarative.Catalog())
+		apiProv, err := applyAllowedOperations(name, apiAllowedOperations, declarative)
 		if err != nil {
 			closeIfPossible(apiProv, pluginProv)
 			return nil, err
@@ -218,6 +226,12 @@ func buildExecutablePluginProvider(ctx context.Context, name string, entry *conf
 		}
 		return newProviderBuildResult(name, entry, manifest, pluginConfig, restricted, nil, deps)
 	}
+	filteredPluginProv, err := applyAllowedOperations(name, staticAllowedOperations, pluginProv)
+	if err != nil {
+		closeIfPossible(pluginProv)
+		return nil, err
+	}
+	pluginProv = filteredPluginProv
 
 	specProv, specDef, err := buildConfiguredSpecProvider(ctx, name, resolved, meta, specProviderConfig{
 		manifestPlugin:       manifestPlugin,
@@ -337,7 +351,7 @@ func buildSpecLoadedProvider(ctx context.Context, name string, entry *config.Pro
 		return nil, fmt.Errorf("build spec-loaded provider %q: unexpected mcp provider type %T", name, mcpProv)
 	}
 
-	filtered := matchingAllowedOperations(allowedOperations, mcpUp.Catalog())
+	filtered := operationexposure.MatchingAllowedOperations(allowedOperations, mcpUp.Catalog())
 	if len(filtered) > 0 {
 		filterable, ok := any(mcpUp).(interface {
 			FilterOperations(map[string]*config.OperationOverride) error
@@ -1082,26 +1096,6 @@ func firstProviderIconSVG(providers ...core.Provider) string {
 		}
 	}
 	return ""
-}
-
-func matchingAllowedOperations(allowed map[string]*config.OperationOverride, cat *catalog.Catalog) map[string]*config.OperationOverride {
-	if len(allowed) == 0 || cat == nil || len(cat.Operations) == 0 {
-		return nil
-	}
-	available := make(map[string]struct{}, len(cat.Operations))
-	for i := range cat.Operations {
-		available[cat.Operations[i].ID] = struct{}{}
-	}
-	filtered := make(map[string]*config.OperationOverride)
-	for name, override := range allowed {
-		if _, ok := available[name]; ok {
-			filtered[name] = override
-		}
-	}
-	if len(filtered) == 0 {
-		return nil
-	}
-	return filtered
 }
 
 func buildOAuthHandlerFromAuth(auth *config.ConnectionAuthDef, pluginConfig map[string]any, deps Deps) (OAuthHandler, error) {

--- a/gestaltd/internal/bootstrap/validate.go
+++ b/gestaltd/internal/bootstrap/validate.go
@@ -11,6 +11,7 @@ import (
 	"github.com/valon-technologies/gestalt/server/core/catalog"
 	"github.com/valon-technologies/gestalt/server/internal/config"
 	"github.com/valon-technologies/gestalt/server/internal/metricutil"
+	"github.com/valon-technologies/gestalt/server/internal/plugininvocation"
 	"github.com/valon-technologies/gestalt/server/internal/registry"
 )
 
@@ -18,6 +19,10 @@ import (
 // starting the server or running migrations. Unlike Bootstrap, provider
 // validation is strict: any provider construction failure is returned.
 func Validate(ctx context.Context, cfg *config.Config, factories *FactoryRegistry) ([]string, error) {
+	if err := plugininvocation.ValidateDependencies(ctx, cfg); err != nil {
+		return nil, err
+	}
+
 	prepared, err := prepareCore(ctx, cfg, factories, false)
 	if err != nil {
 		return nil, err

--- a/gestaltd/internal/config/config.go
+++ b/gestaltd/internal/config/config.go
@@ -132,6 +132,7 @@ type ProviderEntry struct {
 	UI                string                        `yaml:"ui,omitempty"`
 	Connections       map[string]*ConnectionDef     `yaml:"connections,omitempty"`
 	AllowedOperations map[string]*OperationOverride `yaml:"allowedOperations,omitempty"`
+	Invokes           []PluginInvocationDependency  `yaml:"invokes,omitempty"`
 	IndexedDB         *PluginIndexedDBConfig        `yaml:"indexeddb,omitempty"`
 	Cache             []string                      `yaml:"cache,omitempty"`
 	S3                []string                      `yaml:"s3,omitempty"`
@@ -636,6 +637,11 @@ func EffectiveNamedConnectionDef(plugin *ProviderEntry, manifestPlugin *provider
 
 // OperationOverride holds optional alias and description for an allowed operation.
 type OperationOverride = providermanifestv1.ManifestOperationOverride
+
+type PluginInvocationDependency struct {
+	Plugin    string `yaml:"plugin,omitempty"`
+	Operation string `yaml:"operation,omitempty"`
+}
 
 func Load(path string) (*Config, error) {
 	return LoadPaths([]string{path})

--- a/gestaltd/internal/config/config_validate.go
+++ b/gestaltd/internal/config/config_validate.go
@@ -325,6 +325,22 @@ func validatePlugin(cfg *Config, name string, entry *ProviderEntry) error {
 			entry.IndexedDB.ObjectStores[i] = strings.TrimSpace(store)
 		}
 	}
+	seenInvokes := make(map[string]int, len(entry.Invokes))
+	for i := range entry.Invokes {
+		entry.Invokes[i].Plugin = strings.TrimSpace(entry.Invokes[i].Plugin)
+		entry.Invokes[i].Operation = strings.TrimSpace(entry.Invokes[i].Operation)
+		switch {
+		case entry.Invokes[i].Plugin == "":
+			return fmt.Errorf("config validation: plugins.%s.invokes[%d].plugin is required", name, i)
+		case entry.Invokes[i].Operation == "":
+			return fmt.Errorf("config validation: plugins.%s.invokes[%d].operation is required", name, i)
+		}
+		key := entry.Invokes[i].Plugin + "\x00" + entry.Invokes[i].Operation
+		if prev, ok := seenInvokes[key]; ok {
+			return fmt.Errorf("config validation: plugins.%s.invokes[%d] duplicates invokes[%d]", name, i, prev)
+		}
+		seenInvokes[key] = i
+	}
 	if entry.UI != "" && entry.MountPath == "" {
 		return fmt.Errorf("config validation: plugins.%s.ui requires plugins.%s.mountPath", name, name)
 	}
@@ -415,6 +431,9 @@ func validatePluginOnlyProviderFields(subject string, entry *ProviderEntry) erro
 	}
 	if len(entry.S3) > 0 {
 		return fmt.Errorf("config validation: %s.s3 is only supported on plugins.*", subject)
+	}
+	if len(entry.Invokes) > 0 {
+		return fmt.Errorf("config validation: %s.invokes is only supported on plugins.*", subject)
 	}
 	if entry.Surfaces != nil {
 		return fmt.Errorf("config validation: %s.surfaces is only supported on plugins.*", subject)

--- a/gestaltd/internal/config/surfaces.go
+++ b/gestaltd/internal/config/surfaces.go
@@ -1,6 +1,7 @@
 package config
 
 import (
+	"path/filepath"
 	"strings"
 
 	providermanifestv1 "github.com/valon-technologies/gestalt/server/sdk/providermanifest/v1"
@@ -93,4 +94,21 @@ func EffectiveProviderSpecBaseURL(entry *ProviderEntry, provider *providermanife
 		return ""
 	}
 	return provider.SpecBaseURL()
+}
+
+func ResolveManifestRelativeSpecURL(entry *ProviderEntry, raw string) string {
+	if entry == nil || entry.ResolvedManifestPath == "" || raw == "" {
+		return raw
+	}
+	if filepath.IsAbs(raw) || strings.HasPrefix(raw, "http://") || strings.HasPrefix(raw, "https://") {
+		return raw
+	}
+	if strings.HasPrefix(raw, "file://") {
+		path := strings.TrimPrefix(raw, "file://")
+		if filepath.IsAbs(path) {
+			return raw
+		}
+		return "file://" + filepath.Clean(filepath.Join(filepath.Dir(entry.ResolvedManifestPath), path))
+	}
+	return filepath.Clean(filepath.Join(filepath.Dir(entry.ResolvedManifestPath), raw))
 }

--- a/gestaltd/internal/operationexposure/policy.go
+++ b/gestaltd/internal/operationexposure/policy.go
@@ -202,3 +202,26 @@ func (p *Policy) ApplyCatalog(cat *catalog.Catalog) *catalog.Catalog {
 	}
 	return filtered
 }
+
+// MatchingAllowedOperations returns the subset of allowed operations that are
+// present in the provided catalog. It returns nil when either input is empty or
+// when no allowed operations match the catalog.
+func MatchingAllowedOperations(allowed map[string]*config.OperationOverride, cat *catalog.Catalog) map[string]*config.OperationOverride {
+	if len(allowed) == 0 || cat == nil || len(cat.Operations) == 0 {
+		return nil
+	}
+	available := make(map[string]struct{}, len(cat.Operations))
+	for i := range cat.Operations {
+		available[cat.Operations[i].ID] = struct{}{}
+	}
+	filtered := make(map[string]*config.OperationOverride)
+	for name, override := range allowed {
+		if _, ok := available[name]; ok {
+			filtered[name] = override
+		}
+	}
+	if len(filtered) == 0 {
+		return nil
+	}
+	return filtered
+}

--- a/gestaltd/internal/operator/lifecycle.go
+++ b/gestaltd/internal/operator/lifecycle.go
@@ -18,6 +18,7 @@ import (
 	"time"
 
 	"github.com/valon-technologies/gestalt/server/internal/config"
+	"github.com/valon-technologies/gestalt/server/internal/plugininvocation"
 	"github.com/valon-technologies/gestalt/server/internal/pluginsource"
 	ghresolver "github.com/valon-technologies/gestalt/server/internal/pluginsource/github"
 	"github.com/valon-technologies/gestalt/server/internal/pluginstore"
@@ -222,13 +223,16 @@ func (l *Lifecycle) initAtPaths(configPaths []string, artifactsDir string) (*Loc
 		}
 	}
 
-	if err := WriteLockfile(paths.lockfilePath, lock); err != nil {
-		return nil, nil, err
-	}
-	if err := l.applyLockedProviders(configPaths, artifactsDir, cfg, true); err != nil {
+	if err := l.applyLockedProviders(configPaths, artifactsDir, cfg, true, lock); err != nil {
 		return nil, nil, err
 	}
 	if err := config.ValidateResolvedStructure(cfg); err != nil {
+		return nil, nil, err
+	}
+	if err := plugininvocation.ValidateDependencies(context.Background(), cfg); err != nil {
+		return nil, nil, err
+	}
+	if err := WriteLockfile(paths.lockfilePath, lock); err != nil {
 		return nil, nil, err
 	}
 
@@ -315,13 +319,15 @@ func (l *Lifecycle) LoadForExecutionAtPathsWithArtifactsDir(configPaths []string
 		return nil, nil, err
 	}
 
-	if err := l.applyLockedProviders(configPaths, artifactsDir, cfg, locked); err != nil {
+	if err := l.applyLockedProviders(configPaths, artifactsDir, cfg, locked, nil); err != nil {
 		return nil, nil, err
 	}
 	if err := config.ValidateResolvedStructure(cfg); err != nil {
 		return nil, nil, err
 	}
-
+	if err := plugininvocation.ValidateDependencies(context.Background(), cfg); err != nil {
+		return nil, nil, err
+	}
 	return cfg, nil, nil
 }
 
@@ -1401,7 +1407,7 @@ func sourceForProvider(providerEntry *config.ProviderEntry) (pluginsource.Source
 	return src, nil
 }
 
-func (l *Lifecycle) applyLockedProviders(configPaths []string, artifactsDir string, cfg *config.Config, locked bool) error {
+func (l *Lifecycle) applyLockedProviders(configPaths []string, artifactsDir string, cfg *config.Config, locked bool, preparedLock *Lockfile) error {
 	if !configHasProviderLoading(cfg) {
 		return nil
 	}
@@ -1412,16 +1418,24 @@ func (l *Lifecycle) applyLockedProviders(configPaths []string, artifactsDir stri
 	var err error
 	if configHasManagedProviderSources(cfg) {
 		var synthesizedLockedPluginUIs map[string]struct{}
-		lock, err = ReadLockfile(paths.lockfilePath)
-		if err == nil {
+		lock = preparedLock
+		if lock == nil {
+			lock, err = ReadLockfile(paths.lockfilePath)
+			if err == nil {
+				synthesizedLockedPluginUIs, err = synthesizeLockedSourcePluginOwnedUIEntries(cfg, paths, lock)
+				if err != nil {
+					clearSynthesizedPluginOwnedUIEntries(cfg, synthesizedLockedPluginUIs)
+				}
+			}
+			if !locked && (err != nil || !lockMatchesConfig(cfg, paths, lock)) {
+				clearSynthesizedPluginOwnedUIEntries(cfg, synthesizedLockedPluginUIs)
+				lock, err = l.InitAtPathsWithArtifactsDir(configPaths, artifactsDir)
+			}
+		} else {
 			synthesizedLockedPluginUIs, err = synthesizeLockedSourcePluginOwnedUIEntries(cfg, paths, lock)
 			if err != nil {
 				clearSynthesizedPluginOwnedUIEntries(cfg, synthesizedLockedPluginUIs)
 			}
-		}
-		if !locked && (err != nil || !lockMatchesConfig(cfg, paths, lock)) {
-			clearSynthesizedPluginOwnedUIEntries(cfg, synthesizedLockedPluginUIs)
-			lock, err = l.InitAtPathsWithArtifactsDir(configPaths, artifactsDir)
 		}
 		if err != nil {
 			return fmt.Errorf("managed providers require prepared artifacts; run `gestaltd init %s`: %w", formatConfigFlags(configPaths), err)

--- a/gestaltd/internal/operator/lifecycle_test.go
+++ b/gestaltd/internal/operator/lifecycle_test.go
@@ -16,7 +16,9 @@ import (
 	"regexp"
 	"runtime"
 	"strings"
+	"sync/atomic"
 	"testing"
+	"unicode"
 
 	"github.com/valon-technologies/gestalt/server/internal/config"
 	"github.com/valon-technologies/gestalt/server/internal/pluginsource"
@@ -74,6 +76,22 @@ func (r authMappedSourceResolver) Resolve(_ context.Context, src pluginsource.So
 type versionedSourceResolver struct {
 	paths  map[string]map[string]string
 	tokens map[string]string
+}
+
+func testDisplayName(name string) string {
+	parts := strings.Fields(strings.ReplaceAll(name, "-", " "))
+	for i, part := range parts {
+		runes := []rune(part)
+		if len(runes) == 0 {
+			continue
+		}
+		runes[0] = unicode.ToUpper(runes[0])
+		for j := 1; j < len(runes); j++ {
+			runes[j] = unicode.ToLower(runes[j])
+		}
+		parts[i] = string(runes)
+	}
+	return strings.Join(parts, " ")
 }
 
 func (r versionedSourceResolver) Resolve(_ context.Context, src pluginsource.Source, version string) (*pluginsource.ResolvedPackage, error) {
@@ -153,6 +171,195 @@ func requiredServerDatastoreYAML() string {
 	return `  providers:
     indexeddb: sqlite
 `
+}
+
+func writeLocalExecutablePlugin(t *testing.T, dir, name string, operations ...string) string {
+	t.Helper()
+
+	root := filepath.Join(dir, name)
+	if err := os.MkdirAll(root, 0o755); err != nil {
+		t.Fatalf("MkdirAll(%s): %v", root, err)
+	}
+	manifestPath := filepath.Join(root, "manifest.yaml")
+	manifest, err := providerpkg.EncodeSourceManifestFormat(&providermanifestv1.Manifest{
+		Kind:        providermanifestv1.KindPlugin,
+		Source:      "github.com/test/plugins/" + name,
+		Version:     "0.0.1-alpha.1",
+		DisplayName: testDisplayName(name),
+		Spec: &providermanifestv1.Spec{
+			Auth: &providermanifestv1.ProviderAuth{Type: providermanifestv1.AuthTypeNone},
+		},
+	}, providerpkg.ManifestFormatYAML)
+	if err != nil {
+		t.Fatalf("EncodeSourceManifestFormat(%s): %v", name, err)
+	}
+	if err := os.WriteFile(manifestPath, manifest, 0o644); err != nil {
+		t.Fatalf("WriteFile(%s): %v", manifestPath, err)
+	}
+
+	var builder strings.Builder
+	builder.WriteString("name: " + name + "\noperations:\n")
+	for _, operation := range operations {
+		builder.WriteString("  - id: " + operation + "\n")
+		builder.WriteString("    method: GET\n")
+	}
+	if err := os.WriteFile(filepath.Join(root, "catalog.yaml"), []byte(builder.String()), 0o644); err != nil {
+		t.Fatalf("WriteFile(catalog.yaml): %v", err)
+	}
+	return manifestPath
+}
+
+func writeLocalMCPSpecPlugin(t *testing.T, dir, name string) string {
+	t.Helper()
+
+	root := filepath.Join(dir, name)
+	if err := os.MkdirAll(root, 0o755); err != nil {
+		t.Fatalf("MkdirAll(%s): %v", root, err)
+	}
+	manifestPath := filepath.Join(root, "manifest.yaml")
+	manifest, err := providerpkg.EncodeSourceManifestFormat(&providermanifestv1.Manifest{
+		Kind:        providermanifestv1.KindPlugin,
+		Source:      "github.com/test/plugins/" + name,
+		Version:     "0.0.1-alpha.1",
+		DisplayName: testDisplayName(name),
+		Spec: &providermanifestv1.Spec{
+			Surfaces: &providermanifestv1.ProviderSurfaces{
+				MCP: &providermanifestv1.MCPSurface{URL: "https://mcp.example.test"},
+			},
+		},
+	}, providerpkg.ManifestFormatYAML)
+	if err != nil {
+		t.Fatalf("EncodeSourceManifestFormat(%s): %v", name, err)
+	}
+	if err := os.WriteFile(manifestPath, manifest, 0o644); err != nil {
+		t.Fatalf("WriteFile(%s): %v", manifestPath, err)
+	}
+	return manifestPath
+}
+
+func writeLocalOpenAPIAndMCPSpecPlugin(t *testing.T, dir, name string) string {
+	t.Helper()
+
+	root := filepath.Join(dir, name)
+	if err := os.MkdirAll(root, 0o755); err != nil {
+		t.Fatalf("MkdirAll(%s): %v", root, err)
+	}
+
+	openAPIPath := filepath.Join(root, "openapi.yaml")
+	openAPIDoc := `openapi: "3.1.0"
+info:
+  title: Hybrid
+  version: "1.0.0"
+paths:
+  /status:
+    get:
+      operationId: status
+      responses:
+        "200":
+          description: OK
+`
+	if err := os.WriteFile(openAPIPath, []byte(openAPIDoc), 0o644); err != nil {
+		t.Fatalf("WriteFile(%s): %v", openAPIPath, err)
+	}
+
+	manifestPath := filepath.Join(root, "manifest.yaml")
+	manifest, err := providerpkg.EncodeSourceManifestFormat(&providermanifestv1.Manifest{
+		Kind:        providermanifestv1.KindPlugin,
+		Source:      "github.com/test/plugins/" + name,
+		Version:     "0.0.1-alpha.1",
+		DisplayName: testDisplayName(name),
+		Spec: &providermanifestv1.Spec{
+			Surfaces: &providermanifestv1.ProviderSurfaces{
+				OpenAPI: &providermanifestv1.OpenAPISurface{Document: "openapi.yaml"},
+				MCP:     &providermanifestv1.MCPSurface{URL: "https://mcp.example.test"},
+			},
+		},
+	}, providerpkg.ManifestFormatYAML)
+	if err != nil {
+		t.Fatalf("EncodeSourceManifestFormat(%s): %v", name, err)
+	}
+	if err := os.WriteFile(manifestPath, manifest, 0o644); err != nil {
+		t.Fatalf("WriteFile(%s): %v", manifestPath, err)
+	}
+	return manifestPath
+}
+
+func writeLocalExecutableOpenAPIPlugin(t *testing.T, dir, name string, staticOperations, openAPIOperations []string) string {
+	t.Helper()
+
+	root := filepath.Join(dir, name)
+	if err := os.MkdirAll(root, 0o755); err != nil {
+		t.Fatalf("MkdirAll(%s): %v", root, err)
+	}
+
+	var openAPI strings.Builder
+	openAPI.WriteString(`openapi: "3.1.0"
+info:
+  title: Hybrid
+  version: "1.0.0"
+paths:
+`)
+	for _, operation := range openAPIOperations {
+		openAPI.WriteString("  /" + operation + ":\n")
+		openAPI.WriteString("    get:\n")
+		openAPI.WriteString("      operationId: " + operation + "\n")
+		openAPI.WriteString("      responses:\n")
+		openAPI.WriteString("        \"200\":\n")
+		openAPI.WriteString("          description: OK\n")
+	}
+	openAPIPath := filepath.Join(root, "openapi.yaml")
+	if err := os.WriteFile(openAPIPath, []byte(openAPI.String()), 0o644); err != nil {
+		t.Fatalf("WriteFile(%s): %v", openAPIPath, err)
+	}
+
+	artifactPath := filepath.ToSlash(filepath.Join("artifacts", runtime.GOOS, runtime.GOARCH, "plugin"))
+	artifactFullPath := filepath.Join(root, filepath.FromSlash(artifactPath))
+	if err := os.MkdirAll(filepath.Dir(artifactFullPath), 0o755); err != nil {
+		t.Fatalf("MkdirAll(%s): %v", filepath.Dir(artifactFullPath), err)
+	}
+	artifactContent := []byte(name + "-binary")
+	if err := os.WriteFile(artifactFullPath, artifactContent, 0o755); err != nil {
+		t.Fatalf("WriteFile(%s): %v", artifactFullPath, err)
+	}
+	artifactSum := sha256.Sum256(artifactContent)
+
+	manifestPath := filepath.Join(root, "manifest.yaml")
+	manifest, err := providerpkg.EncodeSourceManifestFormat(&providermanifestv1.Manifest{
+		Kind:        providermanifestv1.KindPlugin,
+		Source:      "github.com/test/plugins/" + name,
+		Version:     "0.0.1-alpha.1",
+		DisplayName: testDisplayName(name),
+		Entrypoint:  &providermanifestv1.Entrypoint{ArtifactPath: artifactPath},
+		Artifacts: []providermanifestv1.Artifact{{
+			OS:     runtime.GOOS,
+			Arch:   runtime.GOARCH,
+			Path:   artifactPath,
+			SHA256: hex.EncodeToString(artifactSum[:]),
+		}},
+		Spec: &providermanifestv1.Spec{
+			Auth: &providermanifestv1.ProviderAuth{Type: providermanifestv1.AuthTypeNone},
+			Surfaces: &providermanifestv1.ProviderSurfaces{
+				OpenAPI: &providermanifestv1.OpenAPISurface{Document: "openapi.yaml"},
+			},
+		},
+	}, providerpkg.ManifestFormatYAML)
+	if err != nil {
+		t.Fatalf("EncodeSourceManifestFormat(%s): %v", name, err)
+	}
+	if err := os.WriteFile(manifestPath, manifest, 0o644); err != nil {
+		t.Fatalf("WriteFile(%s): %v", manifestPath, err)
+	}
+
+	var catalogBuilder strings.Builder
+	catalogBuilder.WriteString("name: " + name + "\noperations:\n")
+	for _, operation := range staticOperations {
+		catalogBuilder.WriteString("  - id: " + operation + "\n")
+		catalogBuilder.WriteString("    method: GET\n")
+	}
+	if err := os.WriteFile(filepath.Join(root, "catalog.yaml"), []byte(catalogBuilder.String()), 0o644); err != nil {
+		t.Fatalf("WriteFile(catalog.yaml): %v", err)
+	}
+	return manifestPath
 }
 
 func requiredIndexedDBConfigYAML(t *testing.T, dir, dbPath string) string {
@@ -296,6 +503,438 @@ spec:
 	}
 	if _, err := os.Stat(filepath.Join(dir, InitLockfileName)); !os.IsNotExist(err) {
 		t.Fatalf("lockfile should not be created, got err=%v", err)
+	}
+}
+
+func TestInitAtPath_RejectsInvalidPluginInvokesShape(t *testing.T) {
+	t.Parallel()
+
+	cases := []struct {
+		name string
+		body string
+		want string
+	}{
+		{
+			name: "missing plugin",
+			body: `plugins:
+    caller:
+      source:
+        path: ./caller/manifest.yaml
+      invokes:
+        - operation: ping
+`,
+			want: `plugins.caller.invokes[0].plugin is required`,
+		},
+		{
+			name: "missing operation",
+			body: `plugins:
+    caller:
+      source:
+        path: ./caller/manifest.yaml
+      invokes:
+        - plugin: target
+`,
+			want: `plugins.caller.invokes[0].operation is required`,
+		},
+		{
+			name: "duplicate dependency",
+			body: `plugins:
+    caller:
+      source:
+        path: ./caller/manifest.yaml
+      invokes:
+        - plugin: target
+          operation: ping
+        - plugin: target
+          operation: ping
+`,
+			want: `plugins.caller.invokes[1] duplicates invokes[0]`,
+		},
+		{
+			name: "non plugin provider",
+			body: `  cache:
+    shared:
+      source:
+        path: ./cache-manifest.yaml
+      invokes:
+        - plugin: target
+          operation: ping
+`,
+			want: `providers.cache.shared.invokes is only supported on plugins.*`,
+		},
+	}
+
+	for _, tc := range cases {
+		tc := tc
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+
+			caseDir := t.TempDir()
+			cfgPath := filepath.Join(caseDir, "config.yaml")
+			cfg := requiredComponentConfigYAML(t, caseDir, filepath.Join(caseDir, "gestalt.db")) + tc.body + `server:
+` + requiredServerDatastoreYAML() + `  encryptionKey: aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa
+`
+			if err := os.WriteFile(cfgPath, []byte(cfg), 0o644); err != nil {
+				t.Fatalf("WriteFile config: %v", err)
+			}
+
+			_, err := NewLifecycle(nil).InitAtPath(cfgPath)
+			if err == nil || !strings.Contains(err.Error(), tc.want) {
+				t.Fatalf("InitAtPath error = %v, want substring %q", err, tc.want)
+			}
+		})
+	}
+}
+
+func TestInitAtPath_AllowsInvokesAgainstEffectiveAlias(t *testing.T) {
+	t.Parallel()
+
+	dir := t.TempDir()
+	callerManifestPath := writeLocalExecutablePlugin(t, dir, "caller", "invoke")
+	targetManifestPath := writeLocalExecutablePlugin(t, dir, "target", "ping")
+
+	cfgPath := filepath.Join(dir, "config.yaml")
+	cfg := requiredComponentConfigYAML(t, dir, filepath.Join(dir, "gestalt.db")) + fmt.Sprintf(`plugins:
+    caller:
+      source:
+        path: %q
+      invokes:
+        - plugin: target
+          operation: renamed_ping
+    target:
+      source:
+        path: %q
+      allowedOperations:
+        ping:
+          alias: renamed_ping
+server:
+`, callerManifestPath, targetManifestPath) + requiredServerDatastoreYAML() + `  encryptionKey: aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa
+`
+	if err := os.WriteFile(cfgPath, []byte(cfg), 0o644); err != nil {
+		t.Fatalf("WriteFile config: %v", err)
+	}
+
+	if _, err := NewLifecycle(nil).InitAtPath(cfgPath); err != nil {
+		t.Fatalf("InitAtPath: %v", err)
+	}
+}
+
+func TestInitAtPath_RejectsHybridExecutableStaticOperationByOriginalNameAfterAlias(t *testing.T) {
+	t.Parallel()
+
+	dir := t.TempDir()
+	callerManifestPath := writeLocalExecutablePlugin(t, dir, "caller", "invoke")
+	targetManifestPath := writeLocalExecutableOpenAPIPlugin(t, dir, "target", []string{"ping"}, []string{"status"})
+
+	cfgPath := filepath.Join(dir, "config.yaml")
+	cfg := requiredComponentConfigYAML(t, dir, filepath.Join(dir, "gestalt.db")) + fmt.Sprintf(`plugins:
+    caller:
+      source:
+        path: %q
+      invokes:
+        - plugin: target
+          operation: ping
+    target:
+      source:
+        path: %q
+      allowedOperations:
+        ping:
+          alias: renamed_ping
+        status:
+          alias: renamed_status
+server:
+`, callerManifestPath, targetManifestPath) + requiredServerDatastoreYAML() + `  encryptionKey: aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa
+`
+	if err := os.WriteFile(cfgPath, []byte(cfg), 0o644); err != nil {
+		t.Fatalf("WriteFile config: %v", err)
+	}
+
+	_, err := NewLifecycle(nil).InitAtPath(cfgPath)
+	if err == nil || !strings.Contains(err.Error(), `unknown effective operation "ping" on plugin "target"`) {
+		t.Fatalf("InitAtPath error = %v, want unknown operation error", err)
+	}
+}
+
+func TestInitAtPath_AllowsManagedPluginInvokesOnFirstInit(t *testing.T) {
+	t.Parallel()
+
+	dir := t.TempDir()
+	const callerRef = "github.com/testowner/plugins/caller"
+	const targetRef = "github.com/testowner/plugins/target"
+	const version = "0.0.1-alpha.1"
+
+	callerPkg := mustBuildManagedProviderPackage(t, dir, &providermanifestv1.Manifest{
+		Kind:        providermanifestv1.KindPlugin,
+		Source:      callerRef,
+		Version:     version,
+		DisplayName: "Caller",
+		Entrypoint: &providermanifestv1.Entrypoint{
+			ArtifactPath: filepath.ToSlash(filepath.Join("artifacts", runtime.GOOS, runtime.GOARCH, "plugin")),
+		},
+		Spec: &providermanifestv1.Spec{
+			Auth: &providermanifestv1.ProviderAuth{Type: providermanifestv1.AuthTypeNone},
+		},
+	}, map[string]string{
+		filepath.ToSlash(filepath.Join("artifacts", runtime.GOOS, runtime.GOARCH, "plugin")): "caller-binary",
+	}, true)
+
+	targetPkg := mustBuildManagedProviderPackage(t, dir, &providermanifestv1.Manifest{
+		Kind:        providermanifestv1.KindPlugin,
+		Source:      targetRef,
+		Version:     version,
+		DisplayName: "Target",
+		Entrypoint: &providermanifestv1.Entrypoint{
+			ArtifactPath: filepath.ToSlash(filepath.Join("artifacts", runtime.GOOS, runtime.GOARCH, "plugin")),
+		},
+		Spec: &providermanifestv1.Spec{
+			Auth: &providermanifestv1.ProviderAuth{Type: providermanifestv1.AuthTypeNone},
+		},
+	}, map[string]string{
+		filepath.ToSlash(filepath.Join("artifacts", runtime.GOOS, runtime.GOARCH, "plugin")): "target-binary",
+	}, true)
+
+	cfgPath := filepath.Join(dir, "config.yaml")
+	cfg := requiredComponentConfigYAML(t, dir, filepath.Join(dir, "gestalt.db")) + fmt.Sprintf(`plugins:
+    caller:
+      source:
+        ref: %s
+        version: %s
+      invokes:
+        - plugin: target
+          operation: ping
+    target:
+      source:
+        ref: %s
+        version: %s
+server:
+`, callerRef, version, targetRef, version) + requiredServerDatastoreYAML() + `  encryptionKey: aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa
+`
+	if err := os.WriteFile(cfgPath, []byte(cfg), 0o644); err != nil {
+		t.Fatalf("WriteFile config: %v", err)
+	}
+
+	lc := NewLifecycle(mappedSourceResolver{paths: map[string]string{
+		callerRef: callerPkg,
+		targetRef: targetPkg,
+	}})
+	lock, err := lc.InitAtPath(cfgPath)
+	if err != nil {
+		t.Fatalf("InitAtPath: %v", err)
+	}
+	if lock.Providers["caller"].Executable == "" || lock.Providers["target"].Executable == "" {
+		t.Fatalf("prepared plugin executables = %#v", lock.Providers)
+	}
+}
+
+func TestInitAtPath_RejectsSessionCatalogOnlyInvokesTarget(t *testing.T) {
+	t.Parallel()
+
+	dir := t.TempDir()
+	callerManifestPath := writeLocalExecutablePlugin(t, dir, "caller", "invoke")
+	targetManifestPath := writeLocalMCPSpecPlugin(t, dir, "target")
+
+	cfgPath := filepath.Join(dir, "config.yaml")
+	cfg := requiredComponentConfigYAML(t, dir, filepath.Join(dir, "gestalt.db")) + fmt.Sprintf(`plugins:
+    caller:
+      source:
+        path: %q
+      invokes:
+        - plugin: target
+          operation: private_search
+    target:
+      source:
+        path: %q
+server:
+`, callerManifestPath, targetManifestPath) + requiredServerDatastoreYAML() + `  encryptionKey: aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa
+`
+	if err := os.WriteFile(cfgPath, []byte(cfg), 0o644); err != nil {
+		t.Fatalf("WriteFile config: %v", err)
+	}
+
+	_, err := NewLifecycle(nil).InitAtPath(cfgPath)
+	if err == nil || !strings.Contains(err.Error(), `session-catalog-only operation "private_search" on plugin "target"`) {
+		t.Fatalf("InitAtPath error = %v, want session catalog invokes error", err)
+	}
+}
+
+func TestInitAtPath_DoesNotWriteLockfileWhenInvokesValidationFails(t *testing.T) {
+	t.Parallel()
+
+	dir := t.TempDir()
+	callerManifestPath := writeLocalExecutablePlugin(t, dir, "caller", "invoke")
+	targetManifestPath := writeLocalExecutablePlugin(t, dir, "target", "ping")
+
+	cfgPath := filepath.Join(dir, "config.yaml")
+	cfg := requiredComponentConfigYAML(t, dir, filepath.Join(dir, "gestalt.db")) + fmt.Sprintf(`plugins:
+    caller:
+      source:
+        path: %q
+      invokes:
+        - plugin: target
+          operation: missing
+    target:
+      source:
+        path: %q
+server:
+`, callerManifestPath, targetManifestPath) + requiredServerDatastoreYAML() + `  encryptionKey: aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa
+`
+	if err := os.WriteFile(cfgPath, []byte(cfg), 0o644); err != nil {
+		t.Fatalf("WriteFile config: %v", err)
+	}
+
+	_, err := NewLifecycle(nil).InitAtPath(cfgPath)
+	if err == nil || !strings.Contains(err.Error(), `unknown effective operation "missing" on plugin "target"`) {
+		t.Fatalf("InitAtPath error = %v, want unknown operation error", err)
+	}
+	if _, statErr := os.Stat(filepath.Join(dir, InitLockfileName)); !os.IsNotExist(statErr) {
+		t.Fatalf("lockfile should not be written on invokes validation failure, got stat error %v", statErr)
+	}
+}
+
+func TestInitAtPath_RejectsHybridMCPTypoAsUnknownOperation(t *testing.T) {
+	t.Parallel()
+
+	dir := t.TempDir()
+	callerManifestPath := writeLocalExecutablePlugin(t, dir, "caller", "invoke")
+	targetManifestPath := writeLocalOpenAPIAndMCPSpecPlugin(t, dir, "target")
+
+	cfgPath := filepath.Join(dir, "config.yaml")
+	cfg := requiredComponentConfigYAML(t, dir, filepath.Join(dir, "gestalt.db")) + fmt.Sprintf(`plugins:
+    caller:
+      source:
+        path: %q
+      invokes:
+        - plugin: target
+          operation: private_search
+    target:
+      source:
+        path: %q
+server:
+`, callerManifestPath, targetManifestPath) + requiredServerDatastoreYAML() + `  encryptionKey: aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa
+`
+	if err := os.WriteFile(cfgPath, []byte(cfg), 0o644); err != nil {
+		t.Fatalf("WriteFile config: %v", err)
+	}
+
+	_, err := NewLifecycle(nil).InitAtPath(cfgPath)
+	if err == nil || !strings.Contains(err.Error(), `unknown effective operation "private_search" on plugin "target"`) {
+		t.Fatalf("InitAtPath error = %v, want unknown operation error", err)
+	}
+	if strings.Contains(err.Error(), "session-catalog-only operation") {
+		t.Fatalf("InitAtPath error = %v, want unknown operation classification", err)
+	}
+}
+
+func TestLoadForExecutionAtPath_RejectsInvalidPluginInvokesDependency(t *testing.T) {
+	t.Parallel()
+
+	dir := t.TempDir()
+	callerManifestPath := writeLocalExecutablePlugin(t, dir, "caller", "invoke")
+	targetManifestPath := writeLocalExecutablePlugin(t, dir, "target", "ping")
+
+	cfgPath := filepath.Join(dir, "config.yaml")
+	cfg := requiredComponentConfigYAML(t, dir, filepath.Join(dir, "gestalt.db")) + fmt.Sprintf(`plugins:
+    caller:
+      source:
+        path: %q
+      invokes:
+        - plugin: target
+          operation: missing
+    target:
+      source:
+        path: %q
+server:
+`, callerManifestPath, targetManifestPath) + requiredServerDatastoreYAML() + `  encryptionKey: aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa
+`
+	if err := os.WriteFile(cfgPath, []byte(cfg), 0o644); err != nil {
+		t.Fatalf("WriteFile config: %v", err)
+	}
+
+	_, _, err := NewLifecycle(nil).LoadForExecutionAtPath(cfgPath, false)
+	if err == nil || !strings.Contains(err.Error(), `unknown effective operation "missing" on plugin "target"`) {
+		t.Fatalf("LoadForExecutionAtPath error = %v, want unknown operation error", err)
+	}
+}
+
+func TestLoadForExecutionAtPath_CachesInvokesTargetCatalogResolution(t *testing.T) {
+	t.Parallel()
+
+	var docHits atomic.Int32
+	docSrv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		docHits.Add(1)
+		w.Header().Set("Content-Type", "application/yaml")
+		_, _ = w.Write([]byte(`openapi: "3.1.0"
+info:
+  title: Remote Target
+  version: "1.0.0"
+paths:
+  /status:
+    get:
+      operationId: status
+      responses:
+        "200":
+          description: OK
+  /ping:
+    get:
+      operationId: ping
+      responses:
+        "200":
+          description: OK
+`))
+	}))
+	t.Cleanup(docSrv.Close)
+
+	dir := t.TempDir()
+	callerManifestPath := writeLocalExecutablePlugin(t, dir, "caller", "invoke")
+
+	targetRoot := filepath.Join(dir, "target")
+	if err := os.MkdirAll(targetRoot, 0o755); err != nil {
+		t.Fatalf("MkdirAll(%s): %v", targetRoot, err)
+	}
+	targetManifestPath := filepath.Join(targetRoot, "manifest.yaml")
+	targetManifest, err := providerpkg.EncodeSourceManifestFormat(&providermanifestv1.Manifest{
+		Kind:        providermanifestv1.KindPlugin,
+		Source:      "github.com/test/plugins/target",
+		Version:     "0.0.1-alpha.1",
+		DisplayName: "Target",
+		Spec: &providermanifestv1.Spec{
+			Surfaces: &providermanifestv1.ProviderSurfaces{
+				OpenAPI: &providermanifestv1.OpenAPISurface{Document: docSrv.URL},
+			},
+		},
+	}, providerpkg.ManifestFormatYAML)
+	if err != nil {
+		t.Fatalf("EncodeSourceManifestFormat(target): %v", err)
+	}
+	if err := os.WriteFile(targetManifestPath, targetManifest, 0o644); err != nil {
+		t.Fatalf("WriteFile(%s): %v", targetManifestPath, err)
+	}
+
+	cfgPath := filepath.Join(dir, "config.yaml")
+	cfg := requiredComponentConfigYAML(t, dir, filepath.Join(dir, "gestalt.db")) + fmt.Sprintf(`plugins:
+    caller:
+      source:
+        path: %q
+      invokes:
+        - plugin: target
+          operation: status
+        - plugin: target
+          operation: ping
+    target:
+      source:
+        path: %q
+server:
+`, callerManifestPath, targetManifestPath) + requiredServerDatastoreYAML() + `  encryptionKey: aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa
+`
+	if err := os.WriteFile(cfgPath, []byte(cfg), 0o644); err != nil {
+		t.Fatalf("WriteFile config: %v", err)
+	}
+
+	if _, _, err := NewLifecycle(nil).LoadForExecutionAtPath(cfgPath, false); err != nil {
+		t.Fatalf("LoadForExecutionAtPath: %v", err)
+	}
+	if got := docHits.Load(); got != 1 {
+		t.Fatalf("OpenAPI document hits = %d, want 1", got)
 	}
 }
 
@@ -2499,7 +3138,7 @@ func TestApplyLockedPlugins_SkipsNilIntegrationPlugins(t *testing.T) {
 	loaded.Plugins["missing"] = &config.ProviderEntry{}
 
 	lc := NewLifecycle(nil)
-	if err := lc.applyLockedProviders([]string{cfgPath}, "", loaded, false); err != nil {
+	if err := lc.applyLockedProviders([]string{cfgPath}, "", loaded, false, nil); err != nil {
 		t.Fatalf("applyLockedProviders: %v", err)
 	}
 	if loaded.Plugins["example"] == nil || loaded.Plugins["example"].ResolvedManifest == nil {

--- a/gestaltd/internal/plugininvocation/validation.go
+++ b/gestaltd/internal/plugininvocation/validation.go
@@ -1,0 +1,317 @@
+package plugininvocation
+
+import (
+	"context"
+	"fmt"
+	"path/filepath"
+
+	"github.com/valon-technologies/gestalt/server/core/catalog"
+	"github.com/valon-technologies/gestalt/server/internal/config"
+	"github.com/valon-technologies/gestalt/server/internal/graphql"
+	"github.com/valon-technologies/gestalt/server/internal/openapi"
+	"github.com/valon-technologies/gestalt/server/internal/operationexposure"
+	"github.com/valon-technologies/gestalt/server/internal/provider"
+	"github.com/valon-technologies/gestalt/server/internal/providerhost"
+	"github.com/valon-technologies/gestalt/server/internal/providerpkg"
+	providermanifestv1 "github.com/valon-technologies/gestalt/server/sdk/providermanifest/v1"
+)
+
+type resolvedDependencyCatalog struct {
+	catalog     *catalog.Catalog
+	sessionOnly bool
+	err         error
+}
+
+func ValidateDependencies(ctx context.Context, cfg *config.Config) error {
+	if cfg == nil {
+		return nil
+	}
+	targetCatalogs := make(map[string]resolvedDependencyCatalog, len(cfg.Plugins))
+	for callerName, callerEntry := range cfg.Plugins {
+		if callerEntry == nil || len(callerEntry.Invokes) == 0 {
+			continue
+		}
+		if !isExecutablePlugin(callerEntry) {
+			return fmt.Errorf("config validation: plugins.%s.invokes is only supported on executable plugins", callerName)
+		}
+		for i, dependency := range callerEntry.Invokes {
+			targetEntry, ok := cfg.Plugins[dependency.Plugin]
+			if !ok || targetEntry == nil {
+				return fmt.Errorf("config validation: plugins.%s.invokes[%d] references unknown plugin %q", callerName, i, dependency.Plugin)
+			}
+			resolved, ok := targetCatalogs[dependency.Plugin]
+			if !ok {
+				resolved.catalog, resolved.sessionOnly, resolved.err = resolveStaticCatalog(ctx, dependency.Plugin, targetEntry)
+				targetCatalogs[dependency.Plugin] = resolved
+			}
+			if resolved.err != nil {
+				return fmt.Errorf("config validation: plugins.%s.invokes[%d]: %w", callerName, i, resolved.err)
+			}
+			if hasCatalogOperation(resolved.catalog, dependency.Operation) {
+				continue
+			}
+			if resolved.sessionOnly {
+				return fmt.Errorf("config validation: plugins.%s.invokes[%d] references session-catalog-only operation %q on plugin %q, which is unsupported during init/validate", callerName, i, dependency.Operation, dependency.Plugin)
+			}
+			return fmt.Errorf("config validation: plugins.%s.invokes[%d] references unknown effective operation %q on plugin %q", callerName, i, dependency.Operation, dependency.Plugin)
+		}
+	}
+	return nil
+}
+
+func isExecutablePlugin(entry *config.ProviderEntry) bool {
+	if entry == nil {
+		return false
+	}
+	manifest := entry.ResolvedManifest
+	spec := entry.ManifestSpec()
+	if manifest == nil || spec == nil {
+		return false
+	}
+	if spec.IsSpecLoaded() && manifest.Entrypoint == nil {
+		return false
+	}
+	if spec.IsDeclarative() && manifest.Entrypoint == nil {
+		return false
+	}
+	return true
+}
+
+func resolveStaticCatalog(ctx context.Context, name string, entry *config.ProviderEntry) (*catalog.Catalog, bool, error) {
+	manifest := entry.ResolvedManifest
+	spec := entry.ManifestSpec()
+	if manifest == nil || spec == nil {
+		return nil, false, fmt.Errorf("plugin %q does not have a resolved manifest", name)
+	}
+	allowed := effectiveAllowedOperations(entry, spec)
+	switch {
+	case spec.IsSpecLoaded() && manifest.Entrypoint == nil:
+		return resolveSpecLoadedCatalog(ctx, name, entry, spec, allowed)
+	case spec.IsDeclarative() && manifest.Entrypoint == nil:
+		return resolveDeclarativeCatalog(name, manifest, allowed)
+	default:
+		return resolveExecutableCatalog(ctx, name, entry, manifest, spec, allowed)
+	}
+}
+
+func resolveSpecLoadedCatalog(ctx context.Context, name string, entry *config.ProviderEntry, spec *providermanifestv1.Spec, allowed map[string]*config.OperationOverride) (*catalog.Catalog, bool, error) {
+	apiCatalog, err := loadConfiguredAPICatalog(ctx, name, entry, spec, allowed)
+	if err != nil {
+		return nil, false, err
+	}
+	_, hasMCP := resolvedSurfaceURL(entry, spec, config.SpecSurfaceMCP)
+	return apiCatalog, hasMCP && apiCatalog == nil, nil
+}
+
+func resolveDeclarativeCatalog(name string, manifest *providermanifestv1.Manifest, allowed map[string]*config.OperationOverride) (*catalog.Catalog, bool, error) {
+	rawCatalog, err := loadDeclarativeCatalog(name, manifest)
+	if err != nil {
+		return nil, false, err
+	}
+	filtered, err := applyOperationExposure(rawCatalog, allowed)
+	if err != nil {
+		return nil, false, fmt.Errorf("plugin %q declarative catalog: %w", name, err)
+	}
+	return filtered, false, nil
+}
+
+func loadDeclarativeCatalog(name string, manifest *providermanifestv1.Manifest) (*catalog.Catalog, error) {
+	prov, err := providerhost.NewDeclarativeProvider(manifest, nil)
+	if err != nil {
+		return nil, fmt.Errorf("plugin %q declarative catalog: %w", name, err)
+	}
+	return prov.Catalog(), nil
+}
+
+func resolveExecutableCatalog(ctx context.Context, name string, entry *config.ProviderEntry, manifest *providermanifestv1.Manifest, spec *providermanifestv1.Spec, allowed map[string]*config.OperationOverride) (*catalog.Catalog, bool, error) {
+	pluginCatalog, err := readStaticCatalog(name, entry, manifest)
+	if err != nil {
+		return nil, false, err
+	}
+
+	if !spec.IsManifestBacked() {
+		filtered, err := applyOperationExposure(pluginCatalog, allowed)
+		if err != nil {
+			return nil, false, fmt.Errorf("plugin %q static catalog: %w", name, err)
+		}
+		return filtered, false, nil
+	}
+
+	filteredPluginCatalog, err := applyOperationExposure(pluginCatalog, operationexposure.MatchingAllowedOperations(allowed, pluginCatalog))
+	if err != nil {
+		return nil, false, fmt.Errorf("plugin %q static catalog: %w", name, err)
+	}
+
+	if spec.IsDeclarative() {
+		apiCatalog, err := loadDeclarativeCatalog(name, manifest)
+		if err != nil {
+			return nil, false, err
+		}
+		if err := validateAllowedOperationCoverage(name, allowed, pluginCatalog, apiCatalog); err != nil {
+			return nil, false, err
+		}
+		filteredAPICatalog, err := applyOperationExposure(apiCatalog, operationexposure.MatchingAllowedOperations(allowed, apiCatalog))
+		if err != nil {
+			return nil, false, err
+		}
+		merged, err := mergeCatalogs(name, filteredPluginCatalog, filteredAPICatalog)
+		if err != nil {
+			return nil, false, err
+		}
+		return merged, false, nil
+	}
+
+	apiCatalog, err := loadConfiguredAPICatalog(ctx, name, entry, spec, nil)
+	if err != nil {
+		return nil, false, err
+	}
+	if err := validateAllowedOperationCoverage(name, allowed, pluginCatalog, apiCatalog); err != nil {
+		return nil, false, err
+	}
+	filteredAPICatalog, err := applyOperationExposure(apiCatalog, operationexposure.MatchingAllowedOperations(allowed, apiCatalog))
+	if err != nil {
+		return nil, false, fmt.Errorf("plugin %q API catalog: %w", name, err)
+	}
+	_, hasMCP := resolvedSurfaceURL(entry, spec, config.SpecSurfaceMCP)
+	merged, err := mergeCatalogs(name, filteredPluginCatalog, filteredAPICatalog)
+	if err != nil {
+		return nil, false, err
+	}
+	return merged, hasMCP && merged == nil, nil
+}
+
+func readStaticCatalog(name string, entry *config.ProviderEntry, manifest *providermanifestv1.Manifest) (*catalog.Catalog, error) {
+	if entry == nil || entry.ResolvedManifestPath == "" {
+		if providerpkg.StaticCatalogRequired(manifest) {
+			return nil, fmt.Errorf("plugin %q requires %s", name, providerpkg.StaticCatalogFile)
+		}
+		return nil, nil
+	}
+	cat, err := providerpkg.ReadStaticCatalog(filepath.Dir(entry.ResolvedManifestPath), name)
+	if err != nil {
+		return nil, fmt.Errorf("plugin %q static catalog: %w", name, err)
+	}
+	if cat == nil && providerpkg.StaticCatalogRequired(manifest) {
+		return nil, fmt.Errorf("plugin %q requires %s", name, providerpkg.StaticCatalogFile)
+	}
+	return cat, nil
+}
+
+func loadConfiguredAPICatalog(ctx context.Context, name string, entry *config.ProviderEntry, spec *providermanifestv1.Spec, allowed map[string]*config.OperationOverride) (*catalog.Catalog, error) {
+	for _, surface := range []config.SpecSurface{config.SpecSurfaceOpenAPI, config.SpecSurfaceGraphQL} {
+		url, ok := resolvedSurfaceURL(entry, spec, surface)
+		if !ok {
+			continue
+		}
+		var (
+			def *provider.Definition
+			err error
+		)
+		switch surface {
+		case config.SpecSurfaceOpenAPI:
+			def, err = openapi.LoadDefinition(ctx, name, url, allowed)
+		case config.SpecSurfaceGraphQL:
+			def, err = graphql.LoadDefinition(ctx, name, url, allowed)
+		}
+		if err != nil {
+			return nil, fmt.Errorf("plugin %q %s catalog: %w", name, surface, err)
+		}
+		return provider.CatalogFromDefinition(def), nil
+	}
+	return nil, nil
+}
+
+func resolvedSurfaceURL(entry *config.ProviderEntry, spec *providermanifestv1.Spec, surface config.SpecSurface) (string, bool) {
+	if url := config.ProviderSurfaceURLOverride(entry, surface); url != "" {
+		return url, true
+	}
+	url := config.ManifestProviderSurfaceURL(spec, surface)
+	if url == "" {
+		return "", false
+	}
+	return config.ResolveManifestRelativeSpecURL(entry, url), true
+}
+
+func applyOperationExposure(cat *catalog.Catalog, allowed map[string]*config.OperationOverride) (*catalog.Catalog, error) {
+	if cat == nil {
+		return nil, nil
+	}
+	policy, err := operationexposure.New(allowed)
+	if err != nil {
+		return nil, err
+	}
+	if policy == nil {
+		return cat.Clone(), nil
+	}
+	if err := policy.ValidateCatalog(cat); err != nil {
+		return nil, err
+	}
+	return policy.ApplyCatalog(cat), nil
+}
+
+func validateAllowedOperationCoverage(name string, allowed map[string]*config.OperationOverride, catalogs ...*catalog.Catalog) error {
+	if len(allowed) == 0 {
+		return nil
+	}
+	available := make(map[string]struct{})
+	for _, cat := range catalogs {
+		if cat == nil {
+			continue
+		}
+		for i := range cat.Operations {
+			available[cat.Operations[i].ID] = struct{}{}
+		}
+	}
+	for operation := range allowed {
+		if _, ok := available[operation]; !ok {
+			return fmt.Errorf("plugin %q effective catalog: allowedOperations contains unknown operation %q", name, operation)
+		}
+	}
+	return nil
+}
+
+func mergeCatalogs(name string, first, second *catalog.Catalog) (*catalog.Catalog, error) {
+	switch {
+	case first == nil && second == nil:
+		return nil, nil
+	case first == nil:
+		return second.Clone(), nil
+	case second == nil:
+		return first.Clone(), nil
+	}
+
+	merged := first.Clone()
+	seen := make(map[string]struct{}, len(merged.Operations))
+	for i := range merged.Operations {
+		seen[merged.Operations[i].ID] = struct{}{}
+	}
+	for i := range second.Operations {
+		if _, ok := seen[second.Operations[i].ID]; ok {
+			return nil, fmt.Errorf("plugin %q exposes duplicate operation %q across static and API catalogs", name, second.Operations[i].ID)
+		}
+		merged.Operations = append(merged.Operations, second.Operations[i])
+	}
+	return merged, nil
+}
+
+func hasCatalogOperation(cat *catalog.Catalog, operation string) bool {
+	if cat == nil {
+		return false
+	}
+	for i := range cat.Operations {
+		if cat.Operations[i].ID == operation {
+			return true
+		}
+	}
+	return false
+}
+
+func effectiveAllowedOperations(entry *config.ProviderEntry, spec *providermanifestv1.Spec) map[string]*config.OperationOverride {
+	if entry != nil && entry.AllowedOperations != nil {
+		return entry.AllowedOperations
+	}
+	if spec == nil {
+		return nil
+	}
+	return spec.AllowedOperations
+}


### PR DESCRIPTION
## Summary
Add `plugins.<name>.invokes` to `config.yaml` and validate those dependencies against statically resolvable effective catalogs during both `gestaltd init` and `gestaltd validate`.

This PR covers:
- YAML schema and structural validation for `plugins.<name>.invokes`
- shared Go validation helper reused by lifecycle init/load and bootstrap validate
- effective-operation resolution through `allowedOperations` aliasing/filtering
- explicit rejection of session-catalog-only targets during init/validate
- regression coverage in the existing lifecycle/bootstrap test suites

## YAML Interface
```yaml
plugins:
  caller:
    source:
      path: ./caller/manifest.yaml
    invokes:
      - plugin: target
        operation: renamed_ping

  target:
    source:
      path: ./target/manifest.yaml
    allowedOperations:
      ping:
        alias: renamed_ping
```

Example behavior:
- `caller -> target.renamed_ping` is valid
- `caller -> target.ping` fails, because `renamed_ping` is the effective exposed operation id
- `caller -> target.private_search` fails during `init` / `validate` if `target` only exposes that operation via a session catalog

## Go Interface
```go
func ValidateDependencies(ctx context.Context, cfg *config.Config) error
```

Example use:
```go
if err := plugininvocation.ValidateDependencies(ctx, cfg); err != nil {
    return err
}
```

Wired in here:
- `operator.Lifecycle.initAtPath(...)`
- `operator.Lifecycle.LoadForExecutionAtPathWithArtifactsDir(...)`
- `bootstrap.Validate(...)`

## Tests
Augmented existing suites only:
- `go test ./internal/config`
- `go test ./internal/bootstrap`
- `go test ./internal/operator`
