### PR TITLE
Add plugin invokers for TypeScript, Python, and Rust SDKs

### DIFF
--- a/sdk/python/gestalt/__init__.py
+++ b/sdk/python/gestalt/__init__.py
@@ -56,6 +56,7 @@ from ._indexeddb import (
     ObjectStoreSchema,
     indexeddb_socket_env,
 )
+from ._invoker import ENV_PLUGIN_INVOKER_SOCKET, PluginInvoker
 from ._plugin import Plugin, operation, session_catalog
 from ._providers import (
     AuthenticatedUser,
@@ -122,6 +123,7 @@ __all__ = [
     "Cursor",
     "Error",
     "ENV_S3_SOCKET",
+    "ENV_PLUGIN_INVOKER_SOCKET",
     "ExternalTokenValidator",
     "HealthChecker",
     "Index",
@@ -140,6 +142,7 @@ __all__ = [
     "ObjectStoreSchema",
     "OperationAnnotations",
     "Plugin",
+    "PluginInvoker",
     "PluginProvider",
     "PluginProviderAdapter",
     "PresignMethod",

--- a/sdk/python/gestalt/_api.py
+++ b/sdk/python/gestalt/_api.py
@@ -1,11 +1,15 @@
 """Core request, response, and model helpers for authored operations."""
+from __future__ import annotations
 
 import dataclasses
 from dataclasses import MISSING
 from http import HTTPStatus
-from typing import Any, Final, Generic, TypeVar
+from typing import TYPE_CHECKING, Any, Final, Generic, TypeVar
 
 from typing_extensions import dataclass_transform
+
+if TYPE_CHECKING:
+    from ._invoker import PluginInvoker
 
 FIELD_DESCRIPTION_KEY: Final[str] = "description"
 FIELD_REQUIRED_KEY: Final[str] = "required"
@@ -50,11 +54,17 @@ class Request:
     subject: Subject = dataclasses.field(default_factory=Subject)
     credential: Credential = dataclasses.field(default_factory=Credential)
     access: Access = dataclasses.field(default_factory=Access)
+    request_handle: str = ""
 
     def connection_param(self, name: str) -> str | None:
         """Return a connection parameter by name if the host supplied it."""
 
         return self.connection_params.get(name)
+
+    def invoker(self) -> "PluginInvoker":
+        from ._invoker import PluginInvoker
+
+        return PluginInvoker(self.request_handle)
 
 
 @dataclasses.dataclass(slots=True)

--- a/sdk/python/gestalt/_invoker.py
+++ b/sdk/python/gestalt/_invoker.py
@@ -1,0 +1,75 @@
+from __future__ import annotations
+
+import os
+from typing import Any
+
+import grpc
+from google.protobuf import json_format
+from google.protobuf import struct_pb2 as _struct_pb2
+
+from ._api import Response
+from .gen.v1 import plugin_pb2 as _pb
+from .gen.v1 import plugin_pb2_grpc as _pb_grpc
+
+pb: Any = _pb
+pb_grpc: Any = _pb_grpc
+struct_pb2: Any = _struct_pb2
+
+# Matches the host-side socket name exposed by gestaltd.
+ENV_PLUGIN_INVOKER_SOCKET = "GESTALT_PLUGIN_INVOKER_SOCKET"
+
+
+class PluginInvoker:
+    def __init__(self, request_handle: str) -> None:
+        trimmed_handle = request_handle.strip()
+        if not trimmed_handle:
+            raise RuntimeError("plugin invoker: request handle is not available")
+
+        socket_path = os.environ.get(ENV_PLUGIN_INVOKER_SOCKET, "")
+        if not socket_path:
+            raise RuntimeError(f"plugin invoker: {ENV_PLUGIN_INVOKER_SOCKET} is not set")
+
+        self._channel = grpc.insecure_channel(f"unix:{socket_path}")
+        self._stub = pb_grpc.PluginInvokerStub(self._channel)
+        self._request_handle = trimmed_handle
+
+    def close(self) -> None:
+        self._channel.close()
+
+    def invoke(
+        self,
+        plugin: str,
+        operation: str,
+        params: dict[str, Any] | None = None,
+        *,
+        connection: str = "",
+        instance: str = "",
+    ) -> Response[str]:
+        request = pb.PluginInvokeRequest(
+            request_handle=self._request_handle,
+            plugin=plugin,
+            operation=operation,
+            connection=connection,
+            instance=instance,
+        )
+        message = _struct_from_dict(params)
+        if message is not None:
+            request.params.CopyFrom(message)
+
+        response = self._stub.Invoke(request)
+        return Response(status=int(response.status), body=response.body)
+
+    def __enter__(self) -> PluginInvoker:
+        return self
+
+    def __exit__(self, *args: Any) -> None:
+        self.close()
+
+
+def _struct_from_dict(values: dict[str, Any] | None) -> Any:
+    if values is None:
+        return None
+
+    message = struct_pb2.Struct()
+    json_format.ParseDict(values, message)
+    return message

--- a/sdk/python/gestalt/_runtime.py
+++ b/sdk/python/gestalt/_runtime.py
@@ -409,15 +409,7 @@ def _provider_servicer(*, plugin: Plugin) -> Any:
                         message=request.params,
                         request=request,
                     ),
-                    Request(
-                        token=request.token,
-                        connection_params=dict(request.connection_params),
-                        subject=_subject_from_proto(getattr(request, "context", None)),
-                        credential=_credential_from_proto(
-                            getattr(request, "context", None)
-                        ),
-                        access=_access_from_proto(getattr(request, "context", None)),
-                    ),
+                    _plugin_request(request),
                 )
             except Exception as error:
                 traceback.print_exception(error)
@@ -645,6 +637,7 @@ def _plugin_request(request: Any) -> Request:
         subject=_subject_from_proto(getattr(request, "context", None)),
         credential=_credential_from_proto(getattr(request, "context", None)),
         access=_access_from_proto(getattr(request, "context", None)),
+        request_handle=getattr(request, "request_handle", ""),
     )
 
 

--- a/sdk/python/tests/test_plugin_invoker_transport.py
+++ b/sdk/python/tests/test_plugin_invoker_transport.py
@@ -1,0 +1,147 @@
+"""Transport-backed PluginInvoker SDK tests over a real Unix socket."""
+from __future__ import annotations
+
+import json
+import os
+import tempfile
+import unittest
+from concurrent import futures
+from typing import Any
+
+import grpc
+from google.protobuf import json_format
+
+from gestalt import ENV_PLUGIN_INVOKER_SOCKET, PluginInvoker, Request
+from gestalt.gen.v1 import plugin_pb2 as _plugin_pb2
+from gestalt.gen.v1 import plugin_pb2_grpc as _plugin_pb2_grpc
+
+plugin_pb2: Any = _plugin_pb2
+plugin_pb2_grpc: Any = _plugin_pb2_grpc
+
+_server: grpc.Server | None = None
+_socket_path: str = ""
+_previous_socket_env: str | None = None
+
+
+class _PluginInvokerServicer(plugin_pb2_grpc.PluginInvokerServicer):
+    def Invoke(self, request, context):
+        if request.operation == "plain_text":
+            return plugin_pb2.OperationResult(
+                status=200,
+                body="plain response",
+            )
+
+        params = (
+            json_format.MessageToDict(
+                request.params,
+                preserving_proto_field_name=True,
+            )
+            if request.HasField("params")
+            else {}
+        )
+        return plugin_pb2.OperationResult(
+            status=200,
+            body=json.dumps(
+                {
+                    "request_handle": request.request_handle,
+                    "plugin": request.plugin,
+                    "operation": request.operation,
+                    "params": params,
+                    "params_present": request.HasField("params"),
+                    "connection": request.connection,
+                    "instance": request.instance,
+                }
+            ),
+        )
+
+
+def setUpModule() -> None:
+    global _server, _socket_path, _previous_socket_env
+    _socket_path = os.path.join(
+        tempfile.gettempdir(), f"py-plugin-invoker-test-{os.getpid()}.sock"
+    )
+    if os.path.exists(_socket_path):
+        os.remove(_socket_path)
+
+    _server = grpc.server(futures.ThreadPoolExecutor(max_workers=1))
+    plugin_pb2_grpc.add_PluginInvokerServicer_to_server(
+        _PluginInvokerServicer(),
+        _server,
+    )
+    _server.add_insecure_port(f"unix:{_socket_path}")
+    _server.start()
+    _previous_socket_env = os.environ.get(ENV_PLUGIN_INVOKER_SOCKET)
+    os.environ[ENV_PLUGIN_INVOKER_SOCKET] = _socket_path
+
+
+def tearDownModule() -> None:
+    if _previous_socket_env is None:
+        os.environ.pop(ENV_PLUGIN_INVOKER_SOCKET, None)
+    else:
+        os.environ[ENV_PLUGIN_INVOKER_SOCKET] = _previous_socket_env
+    if _server is not None:
+        _server.stop(grace=0).wait()
+    if _socket_path and os.path.exists(_socket_path):
+        os.remove(_socket_path)
+
+
+class PluginInvokerTransportTests(unittest.TestCase):
+    def test_request_helper_roundtrip(self) -> None:
+        request = Request(request_handle="req-123")
+
+        with request.invoker() as client:
+            response = client.invoke(
+                "github",
+                "get_issue",
+                {"repo": "valon-technologies/gestalt", "issue_number": 1026},
+                connection="work",
+                instance="prod",
+            )
+
+        self.assertEqual(response.status, 200)
+        self.assertEqual(
+            json.loads(response.body),
+            {
+                "request_handle": "req-123",
+                "plugin": "github",
+                "operation": "get_issue",
+                "params": {
+                    "repo": "valon-technologies/gestalt",
+                    "issue_number": 1026.0,
+                },
+                "params_present": True,
+                "connection": "work",
+                "instance": "prod",
+            },
+        )
+
+    def test_request_handle_constructor_roundtrip(self) -> None:
+        with PluginInvoker("req-456") as client:
+            response = client.invoke("slack", "plain_text")
+
+        self.assertEqual(response.status, 200)
+        self.assertEqual(response.body, "plain response")
+
+    def test_empty_dict_params_are_preserved_as_present(self) -> None:
+        with PluginInvoker("req-789") as client:
+            response = client.invoke("github", "get_issue", {})
+
+        self.assertEqual(response.status, 200)
+        self.assertEqual(
+            json.loads(response.body),
+            {
+                "request_handle": "req-789",
+                "plugin": "github",
+                "operation": "get_issue",
+                "params": {},
+                "params_present": True,
+                "connection": "",
+                "instance": "",
+            },
+        )
+
+    def test_whitespace_only_request_handle_is_rejected(self) -> None:
+        with self.assertRaisesRegex(
+            RuntimeError, "plugin invoker: request handle is not available"
+        ):
+            PluginInvoker("   ")

--- a/sdk/python/tests/test_runtime.py
+++ b/sdk/python/tests/test_runtime.py
@@ -213,6 +213,7 @@ class RequestTests(unittest.TestCase):
         self.assertEqual(request.subject.id, "")
         self.assertEqual(request.credential.mode, "")
         self.assertEqual(request.access.role, "")
+        self.assertEqual(request.request_handle, "")
 
 
 class MainEntrypointTests(unittest.TestCase):
@@ -260,6 +261,7 @@ class MainEntrypointTests(unittest.TestCase):
                 "credential_subject_id": request.credential.subject_id,
                 "access_policy": request.access.policy,
                 "access_role": request.access.role,
+                "request_handle": request.request_handle,
             }
 
         @plugin.session_catalog
@@ -310,6 +312,7 @@ class MainEntrypointTests(unittest.TestCase):
             plugin_pb2.ExecuteRequest(
                 operation="whoami",
                 token="secret-token",
+                request_handle="opaque-request-handle",
                 context=plugin_pb2.RequestContext(
                     subject=plugin_pb2.SubjectContext(
                         id="user:user-123",
@@ -371,6 +374,7 @@ class MainEntrypointTests(unittest.TestCase):
                 "credential_subject_id": "identity:__identity__",
                 "access_policy": "sample_policy",
                 "access_role": "admin",
+                "request_handle": "opaque-request-handle",
             },
         )
         catalog = response.catalog

--- a/sdk/rust/src/api.rs
+++ b/sdk/rust/src/api.rs
@@ -39,12 +39,23 @@ pub struct Request {
     pub subject: Subject,
     pub credential: Credential,
     pub access: Access,
+    pub request_handle: String,
 }
 
 impl Request {
     /// Returns one resolved connection parameter by name.
     pub fn connection_param(&self, name: &str) -> Option<&str> {
         self.connection_params.get(name).map(String::as_str)
+    }
+
+    pub fn request_handle(&self) -> &str {
+        &self.request_handle
+    }
+
+    pub async fn invoker(
+        &self,
+    ) -> std::result::Result<crate::PluginInvoker, crate::PluginInvokerError> {
+        crate::PluginInvoker::connect(self.request_handle()).await
     }
 }
 

--- a/sdk/rust/src/invoker.rs
+++ b/sdk/rust/src/invoker.rs
@@ -1,0 +1,150 @@
+use hyper_util::rt::TokioIo;
+use serde::Serialize;
+use tokio::net::UnixStream;
+use tonic::transport::{Channel, Endpoint, Uri};
+use tower::service_fn;
+
+use crate::OperationResult;
+use crate::generated::v1::{
+    self as pb, plugin_invoker_client::PluginInvokerClient as ProtoPluginInvokerClient,
+};
+
+pub const ENV_PLUGIN_INVOKER_SOCKET: &str = "GESTALT_PLUGIN_INVOKER_SOCKET";
+
+#[derive(Debug, thiserror::Error)]
+pub enum PluginInvokerError {
+    #[error("plugin invoker: request handle is not available")]
+    MissingRequestHandle,
+    #[error("{0}")]
+    Transport(#[from] tonic::transport::Error),
+    #[error("{0}")]
+    Status(#[from] tonic::Status),
+    #[error("{0}")]
+    Env(String),
+    #[error("{0}")]
+    Json(#[from] serde_json::Error),
+    #[error("{0}")]
+    Protocol(String),
+}
+
+#[derive(Clone, Debug, Default, Eq, PartialEq)]
+pub struct InvokeOptions {
+    pub connection: String,
+    pub instance: String,
+}
+
+pub struct PluginInvoker {
+    client: ProtoPluginInvokerClient<Channel>,
+    request_handle: String,
+}
+
+impl PluginInvoker {
+    pub async fn connect(
+        request_handle: impl AsRef<str>,
+    ) -> std::result::Result<Self, PluginInvokerError> {
+        let request_handle = request_handle.as_ref().trim().to_owned();
+        if request_handle.is_empty() {
+            return Err(PluginInvokerError::MissingRequestHandle);
+        }
+
+        let socket_path = std::env::var(ENV_PLUGIN_INVOKER_SOCKET).map_err(|_| {
+            PluginInvokerError::Env(format!("{ENV_PLUGIN_INVOKER_SOCKET} is not set"))
+        })?;
+
+        let channel = Endpoint::try_from("http://[::]:50051")?
+            .connect_with_connector(service_fn(move |_: Uri| {
+                let path = socket_path.clone();
+                async move { UnixStream::connect(path).await.map(TokioIo::new) }
+            }))
+            .await?;
+
+        Ok(Self {
+            client: ProtoPluginInvokerClient::new(channel),
+            request_handle,
+        })
+    }
+
+    pub async fn invoke<P>(
+        &mut self,
+        plugin: &str,
+        operation: &str,
+        params: P,
+        options: Option<InvokeOptions>,
+    ) -> std::result::Result<OperationResult, PluginInvokerError>
+    where
+        P: Serialize,
+    {
+        let response = self
+            .client
+            .invoke(pb::PluginInvokeRequest {
+                request_handle: self.request_handle.clone(),
+                plugin: plugin.to_string(),
+                operation: operation.to_string(),
+                params: Some(json_to_struct(serde_json::to_value(params)?)?),
+                connection: options
+                    .as_ref()
+                    .map(|opts| opts.connection.clone())
+                    .unwrap_or_default(),
+                instance: options
+                    .as_ref()
+                    .map(|opts| opts.instance.clone())
+                    .unwrap_or_default(),
+            })
+            .await?
+            .into_inner();
+
+        let status = u16::try_from(response.status).map_err(|_| {
+            PluginInvokerError::Protocol(format!(
+                "plugin invoker: invalid response status {}",
+                response.status
+            ))
+        })?;
+
+        Ok(OperationResult {
+            status,
+            body: response.body,
+        })
+    }
+}
+
+fn json_to_struct(
+    value: serde_json::Value,
+) -> std::result::Result<prost_types::Struct, PluginInvokerError> {
+    let serde_json::Value::Object(fields) = value else {
+        if value.is_null() {
+            return Ok(prost_types::Struct::default());
+        }
+        return Err(PluginInvokerError::Protocol(
+            "plugin invoker: params must serialize to a JSON object".to_string(),
+        ));
+    };
+
+    Ok(prost_types::Struct {
+        fields: fields
+            .into_iter()
+            .map(|(key, value)| (key, json_value_to_prost(value)))
+            .collect(),
+    })
+}
+
+fn json_value_to_prost(value: serde_json::Value) -> prost_types::Value {
+    use prost_types::value::Kind;
+
+    let kind = match value {
+        serde_json::Value::Null => Kind::NullValue(0),
+        serde_json::Value::Bool(boolean) => Kind::BoolValue(boolean),
+        serde_json::Value::Number(number) => Kind::NumberValue(number.as_f64().unwrap_or_default()),
+        serde_json::Value::String(string) => Kind::StringValue(string),
+        serde_json::Value::Array(items) => Kind::ListValue(prost_types::ListValue {
+            values: items.into_iter().map(json_value_to_prost).collect(),
+        }),
+        serde_json::Value::Object(fields) => Kind::StructValue(prost_types::Struct {
+            fields: fields
+                .into_iter()
+                .map(|(key, value)| (key, json_value_to_prost(value)))
+                .collect(),
+        }),
+    };
+
+    prost_types::Value { kind: Some(kind) }
+}

--- a/sdk/rust/src/lib.rs
+++ b/sdk/rust/src/lib.rs
@@ -12,6 +12,7 @@ mod error;
 mod generated;
 /// IndexedDB-style datastore client and provider helpers.
 pub mod indexeddb;
+mod invoker;
 mod provider_server;
 mod router;
 mod rpc_status;
@@ -40,6 +41,7 @@ pub use catalog::{Catalog, CatalogOperation};
 pub use env::{CURRENT_PROTOCOL_VERSION, ENV_PROVIDER_SOCKET};
 pub use error::{Error, Result};
 pub use indexeddb::{Cursor, CursorDirection, IndexedDB, IndexedDBError};
+pub use invoker::{ENV_PLUGIN_INVOKER_SOCKET, InvokeOptions, PluginInvoker, PluginInvokerError};
 #[doc(hidden)]
 pub use provider_server::{OperationResult, ProviderServer};
 pub use router::{Operation, Router};

--- a/sdk/rust/src/provider_server.rs
+++ b/sdk/rust/src/provider_server.rs
@@ -114,6 +114,7 @@ where
                     subject: request_subject(request.context.as_ref()),
                     credential: request_credential(request.context.as_ref()),
                     access: request_access(request.context.as_ref()),
+                    request_handle: request.request_handle,
                 },
             )
             .await;
@@ -141,6 +142,7 @@ where
             subject: request_subject(request.context.as_ref()),
             credential: request_credential(request.context.as_ref()),
             access: request_access(request.context.as_ref()),
+            request_handle: String::new(),
         };
         let catalog = self
             .provider

--- a/sdk/rust/tests/plugin_invoker_transport.rs
+++ b/sdk/rust/tests/plugin_invoker_transport.rs
@@ -1,0 +1,209 @@
+#[allow(dead_code)]
+mod helpers;
+
+use std::path::Path;
+use std::sync::{Arc, Mutex};
+
+use gestalt::proto::v1::plugin_invoker_server::{
+    PluginInvoker as ProtoPluginInvoker, PluginInvokerServer,
+};
+use gestalt::proto::v1::{OperationResult, PluginInvokeRequest};
+use gestalt::{ENV_PLUGIN_INVOKER_SOCKET, InvokeOptions, PluginInvoker, Request};
+use prost_types::Struct;
+use tokio::net::UnixListener;
+use tokio_stream::wrappers::UnixListenerStream;
+use tonic::codegen::async_trait;
+use tonic::transport::Server;
+use tonic::{Request as GrpcRequest, Response as GrpcResponse, Status};
+
+#[derive(Clone, Debug, Default, PartialEq)]
+struct SeenRequest {
+    request_handle: String,
+    plugin: String,
+    operation: String,
+    params: Option<Struct>,
+    connection: String,
+    instance: String,
+}
+
+#[derive(Clone, Default)]
+struct TestPluginInvokerServer {
+    seen: Arc<Mutex<Vec<SeenRequest>>>,
+}
+
+#[async_trait]
+impl ProtoPluginInvoker for TestPluginInvokerServer {
+    async fn invoke(
+        &self,
+        request: GrpcRequest<PluginInvokeRequest>,
+    ) -> std::result::Result<GrpcResponse<OperationResult>, Status> {
+        let request = request.into_inner();
+        self.seen.lock().expect("lock seen").push(SeenRequest {
+            request_handle: request.request_handle.clone(),
+            plugin: request.plugin.clone(),
+            operation: request.operation.clone(),
+            params: request.params.clone(),
+            connection: request.connection.clone(),
+            instance: request.instance.clone(),
+        });
+
+        Ok(GrpcResponse::new(OperationResult {
+            status: 207,
+            body: serde_json::json!({
+                "request_handle": request.request_handle,
+                "plugin": request.plugin,
+                "operation": request.operation,
+                "params": request.params.map(struct_to_json).unwrap_or_else(|| serde_json::json!({})),
+                "connection": request.connection,
+                "instance": request.instance,
+            })
+            .to_string(),
+        }))
+    }
+}
+
+#[tokio::test]
+async fn plugin_invoker_connects_over_unix_socket_and_sends_request_handle() {
+    let _env_lock = helpers::env_lock().lock().await;
+    let socket = helpers::temp_socket("gestalt-rust-plugin-invoker.sock");
+    let _socket_guard = helpers::EnvGuard::set(ENV_PLUGIN_INVOKER_SOCKET, socket.as_os_str());
+
+    let server = TestPluginInvokerServer::default();
+    let serve_server = server.clone();
+    let serve_socket = socket.clone();
+    let serve_task = tokio::spawn(async move {
+        serve_plugin_invoker(serve_server, &serve_socket)
+            .await
+            .expect("serve plugin invoker");
+    });
+
+    helpers::wait_for_socket(&socket).await;
+
+    let mut invoker = PluginInvoker::connect("handle-123")
+        .await
+        .expect("connect invoker");
+    let response = invoker
+        .invoke(
+            "github",
+            "get_issue",
+            serde_json::json!({ "issue": 42, "labels": ["bug"] }),
+            Some(InvokeOptions {
+                connection: "work".to_string(),
+                instance: "secondary".to_string(),
+            }),
+        )
+        .await
+        .expect("invoke nested operation");
+
+    assert_eq!(response.status, 207);
+    assert_eq!(
+        serde_json::from_str::<serde_json::Value>(&response.body).expect("parse response"),
+        serde_json::json!({
+            "request_handle": "handle-123",
+            "plugin": "github",
+            "operation": "get_issue",
+            "params": { "issue": 42.0, "labels": ["bug"] },
+            "connection": "work",
+            "instance": "secondary",
+        })
+    );
+
+    let seen = server.seen.lock().expect("lock seen").clone();
+    assert_eq!(seen.len(), 1);
+    assert_eq!(
+        seen[0],
+        SeenRequest {
+            request_handle: "handle-123".to_string(),
+            plugin: "github".to_string(),
+            operation: "get_issue".to_string(),
+            params: Some(helpers::struct_from_json(
+                serde_json::json!({ "issue": 42, "labels": ["bug"] }),
+            )),
+            connection: "work".to_string(),
+            instance: "secondary".to_string(),
+        }
+    );
+
+    serve_task.abort();
+    let _ = serve_task.await;
+}
+
+#[tokio::test]
+async fn request_invoker_uses_embedded_request_handle() {
+    let _env_lock = helpers::env_lock().lock().await;
+    let socket = helpers::temp_socket("gestalt-rust-request-invoker.sock");
+    let _socket_guard = helpers::EnvGuard::set(ENV_PLUGIN_INVOKER_SOCKET, socket.as_os_str());
+
+    let server = TestPluginInvokerServer::default();
+    let serve_server = server.clone();
+    let serve_socket = socket.clone();
+    let serve_task = tokio::spawn(async move {
+        serve_plugin_invoker(serve_server, &serve_socket)
+            .await
+            .expect("serve plugin invoker");
+    });
+
+    helpers::wait_for_socket(&socket).await;
+
+    let request = Request {
+        request_handle: "handle-embedded".to_string(),
+        ..Request::default()
+    };
+    let mut invoker = request.invoker().await.expect("request invoker");
+    let response = invoker
+        .invoke("linear", "search_issues", serde_json::json!({}), None)
+        .await
+        .expect("invoke nested operation");
+
+    assert_eq!(response.status, 207);
+
+    let seen = server.seen.lock().expect("lock seen").clone();
+    assert_eq!(seen.len(), 1);
+    assert_eq!(seen[0].request_handle, "handle-embedded");
+    assert_eq!(seen[0].plugin, "linear");
+    assert_eq!(seen[0].operation, "search_issues");
+    assert_eq!(seen[0].connection, "");
+    assert_eq!(seen[0].instance, "");
+
+    serve_task.abort();
+    let _ = serve_task.await;
+}
+
+async fn serve_plugin_invoker(
+    server: TestPluginInvokerServer,
+    socket: &Path,
+) -> std::result::Result<(), tonic::transport::Error> {
+    let _ = std::fs::remove_file(socket);
+    let listener = UnixListener::bind(socket).expect("bind unix listener");
+
+    Server::builder()
+        .add_service(PluginInvokerServer::new(server))
+        .serve_with_incoming(UnixListenerStream::new(listener))
+        .await
+}
+
+fn struct_to_json(value: Struct) -> serde_json::Value {
+    serde_json::Value::Object(
+        value
+            .fields
+            .into_iter()
+            .map(|(key, value)| (key, prost_to_json(value)))
+            .collect(),
+    )
+}
+
+fn prost_to_json(value: prost_types::Value) -> serde_json::Value {
+    use prost_types::value::Kind;
+
+    match value.kind {
+        Some(Kind::NullValue(_)) => serde_json::Value::Null,
+        Some(Kind::BoolValue(boolean)) => serde_json::Value::Bool(boolean),
+        Some(Kind::NumberValue(number)) => serde_json::json!(number),
+        Some(Kind::StringValue(string)) => serde_json::Value::String(string),
+        Some(Kind::StructValue(object)) => struct_to_json(object),
+        Some(Kind::ListValue(list)) => {
+            serde_json::Value::Array(list.values.into_iter().map(prost_to_json).collect())
+        }
+        None => serde_json::Value::Null,
+    }
+}

--- a/sdk/rust/tests/router.rs
+++ b/sdk/rust/tests/router.rs
@@ -259,6 +259,7 @@ async fn execute_handles_success_decode_errors_handler_errors_and_panics() {
             token: "tok".to_owned(),
             connection_params: BTreeMap::from([("api_key".to_owned(), "secret".to_owned())]),
             invocation_id: String::new(),
+            request_handle: "handle-123".to_owned(),
             context: Some(RequestContext {
                 subject: Some(SubjectContext {
                     id: "user:user-123".to_owned(),
@@ -271,7 +272,6 @@ async fn execute_handles_success_decode_errors_handler_errors_and_panics() {
                 }),
                 access: None,
             }),
-            ..ExecuteRequest::default()
         }))
         .await
         .expect("execute greet")

--- a/sdk/rust/tests/transport.rs
+++ b/sdk/rust/tests/transport.rs
@@ -84,6 +84,7 @@ struct Output {
     subject_id: String,
     credential_mode: String,
     access_role: String,
+    request_handle: String,
 }
 
 #[tokio::test]
@@ -97,11 +98,16 @@ async fn serves_provider_requests_over_unix_socket() {
             Operation::<Input, Output>::new("greet"),
             |provider: Arc<TestProvider>, input: Input, request: Request| async move {
                 let greeting = provider.greeting.lock().expect("lock greeting").clone();
+                let subject_id = request.subject.id.clone();
+                let credential_mode = request.credential.mode.clone();
+                let access_role = request.access.role.clone();
+                let request_handle = request.request_handle().to_string();
                 Ok::<Response<Output>, std::convert::Infallible>(ok(Output {
                     message: format!("{greeting}, {}!", input.name),
-                    subject_id: request.subject.id,
-                    credential_mode: request.credential.mode,
-                    access_role: request.access.role,
+                    subject_id,
+                    credential_mode,
+                    access_role,
+                    request_handle,
                 }))
             },
         )
@@ -185,6 +191,7 @@ async fn serves_provider_requests_over_unix_socket() {
             token: String::new(),
             connection_params: Default::default(),
             invocation_id: String::new(),
+            request_handle: "handle-123".to_string(),
             context: Some(RequestContext {
                 subject: Some(SubjectContext {
                     id: "user:user-123".to_string(),
@@ -200,7 +207,6 @@ async fn serves_provider_requests_over_unix_socket() {
                     role: "admin".to_string(),
                 }),
             }),
-            ..ExecuteRequest::default()
         })
         .await
         .expect("execute")
@@ -209,7 +215,7 @@ async fn serves_provider_requests_over_unix_socket() {
     assert_eq!(response.status, 200);
     assert_eq!(
         response.body,
-        r#"{"message":"Hi, Rust!","subject_id":"user:user-123","credential_mode":"identity","access_role":"admin"}"#
+        r#"{"message":"Hi, Rust!","subject_id":"user:user-123","credential_mode":"identity","access_role":"admin","request_handle":"handle-123"}"#
     );
 
     let session_catalog = client

--- a/sdk/typescript/src/api.ts
+++ b/sdk/typescript/src/api.ts
@@ -35,6 +35,7 @@ export interface Request {
   subject: Subject;
   credential: Credential;
   access: Access;
+  requestHandle: string;
 }
 
 /**
@@ -98,6 +99,7 @@ export function request(
   subject: Partial<Subject> = {},
   credential: Partial<Credential> = {},
   access: Partial<Access> = {},
+  requestHandle = "",
 ): Request {
   return {
     token,
@@ -120,6 +122,7 @@ export function request(
       policy: access.policy ?? "",
       role: access.role ?? "",
     },
+    requestHandle,
   };
 }
 

--- a/sdk/typescript/src/index.ts
+++ b/sdk/typescript/src/index.ts
@@ -61,6 +61,11 @@ export {
   parseBuildArgs,
 } from "./build.ts";
 export {
+  ENV_PLUGIN_INVOKER_SOCKET,
+  PluginInvoker,
+  type PluginInvokeOptions,
+} from "./invoker.ts";
+export {
   defineAuthProvider,
   isAuthProvider,
   type AuthenticatedUser,

--- a/sdk/typescript/src/invoker.ts
+++ b/sdk/typescript/src/invoker.ts
@@ -1,0 +1,99 @@
+import { connect } from "node:net";
+
+import type { JsonObject, JsonValue } from "@bufbuild/protobuf";
+import { createClient, type Client } from "@connectrpc/connect";
+import { createGrpcTransport } from "@connectrpc/connect-node";
+
+import { PluginInvoker as PluginInvokerService } from "../gen/v1/plugin_pb.ts";
+import type { OperationResult, Request } from "./api.ts";
+
+export const ENV_PLUGIN_INVOKER_SOCKET = "GESTALT_PLUGIN_INVOKER_SOCKET";
+
+export interface PluginInvokeOptions {
+  connection?: string;
+  instance?: string;
+}
+
+export class PluginInvoker {
+  private readonly client: Client<typeof PluginInvokerService>;
+  private readonly requestHandle: string;
+
+  constructor(request: Request);
+  constructor(requestHandle: string);
+  constructor(requestOrHandle: Request | string) {
+    const socketPath = process.env[ENV_PLUGIN_INVOKER_SOCKET];
+    if (!socketPath) {
+      throw new Error(`plugin invoker: ${ENV_PLUGIN_INVOKER_SOCKET} is not set`);
+    }
+
+    this.requestHandle = normalizeRequestHandle(requestOrHandle);
+    const transport = createGrpcTransport({
+      baseUrl: "http://localhost",
+      nodeOptions: {
+        createConnection: () => connect(socketPath),
+      },
+    });
+    this.client = createClient(PluginInvokerService, transport);
+  }
+
+  async invoke(
+    plugin: string,
+    operation: string,
+    params: Record<string, unknown> = {},
+    options?: PluginInvokeOptions,
+  ): Promise<OperationResult> {
+    const response = await this.client.invoke({
+      requestHandle: this.requestHandle,
+      plugin,
+      operation,
+      params: toJsonObject(params),
+      connection: options?.connection ?? "",
+      instance: options?.instance ?? "",
+    });
+    return {
+      status: response.status,
+      body: response.body,
+    };
+  }
+}
+
+function normalizeRequestHandle(requestOrHandle: Request | string): string {
+  const requestHandle =
+    typeof requestOrHandle === "string"
+      ? requestOrHandle
+      : requestOrHandle.requestHandle;
+  const trimmed = requestHandle.trim();
+  if (!trimmed) {
+    throw new Error("plugin invoker: request handle is required");
+  }
+  return trimmed;
+}
+
+function toJsonObject(params: Record<string, unknown>): JsonObject {
+  const output: JsonObject = {};
+  for (const [key, value] of Object.entries(params ?? {})) {
+    if (value === undefined) {
+      continue;
+    }
+    output[key] = toJsonValue(value);
+  }
+  return output;
+}
+
+function toJsonValue(value: unknown): JsonValue {
+  if (
+    value === null ||
+    typeof value === "string" ||
+    typeof value === "number" ||
+    typeof value === "boolean"
+  ) {
+    return value;
+  }
+  if (Array.isArray(value)) {
+    return value.map((entry) => toJsonValue(entry));
+  }
+  if (typeof value === "object") {
+    return toJsonObject(value as Record<string, unknown>);
+  }
+  throw new Error("plugin invoker: params must be JSON-serializable");
+}

--- a/sdk/typescript/src/runtime.ts
+++ b/sdk/typescript/src/runtime.ts
@@ -529,6 +529,7 @@ export function createProviderService(
             request.token,
             request.connectionParams,
             request.context,
+            request.requestHandle,
           ),
         ),
       );
@@ -739,6 +740,7 @@ function providerRequest(
   token: string,
   connectionParams: Record<string, string>,
   requestContext?: ProtoRequestContext,
+  requestHandle = "",
 ): Request {
   const subject = requestContext?.subject;
   const credential = requestContext?.credential;
@@ -764,6 +766,7 @@ function providerRequest(
       policy: access?.policy ?? "",
       role: access?.role ?? "",
     },
+    requestHandle,
   };
 }
 

--- a/sdk/typescript/tests/build.test.ts
+++ b/sdk/typescript/tests/build.test.ts
@@ -259,6 +259,7 @@ test("buildProviderBinary compiles a runnable plugin provider executable", async
         credentialMode: "identity",
         accessPolicy: "sample_policy",
         accessRole: "admin",
+        requestHandle: "",
       });
 
       const countResult = await provider.execute(

--- a/sdk/typescript/tests/fixtures/basic-provider/provider.ts
+++ b/sdk/typescript/tests/fixtures/basic-provider/provider.ts
@@ -63,6 +63,7 @@ export const plugin = definePlugin({
         credentialMode: s.string(),
         accessPolicy: s.string(),
         accessRole: s.string(),
+        requestHandle: s.string(),
       }),
       handler(input, request) {
         const region = connectionParam(request, "region") ?? "";
@@ -75,6 +76,7 @@ export const plugin = definePlugin({
           credentialMode: request.credential.mode,
           accessPolicy: request.access.policy,
           accessRole: request.access.role,
+          requestHandle: request.requestHandle,
         });
       },
     }),

--- a/sdk/typescript/tests/invoker.transport.test.ts
+++ b/sdk/typescript/tests/invoker.transport.test.ts
@@ -1,0 +1,164 @@
+import { mkdtempSync } from "node:fs";
+import { createServer } from "node:http2";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+
+import { create } from "@bufbuild/protobuf";
+import { type ServiceImpl } from "@connectrpc/connect";
+import { connectNodeAdapter } from "@connectrpc/connect-node";
+import { expect, test } from "bun:test";
+
+import {
+  OperationResultSchema,
+  PluginInvoker as PluginInvokerService,
+} from "../gen/v1/plugin_pb.ts";
+import {
+  ENV_PLUGIN_INVOKER_SOCKET,
+  PluginInvoker,
+  request,
+} from "../src/index.ts";
+import { removeTempDir } from "./helpers.ts";
+
+test("PluginInvoker forwards request handles from strings and Request objects", async () => {
+  const tempDir = mkdtempSync(join(tmpdir(), "gts-plugin-invoker-"));
+  const socketPath = join(tempDir, "plugin-invoker.sock");
+  const previousSocket = process.env[ENV_PLUGIN_INVOKER_SOCKET];
+  const calls: Array<{
+    requestHandle: string;
+    plugin: string;
+    operation: string;
+    params: Record<string, unknown>;
+    connection: string;
+    instance: string;
+  }> = [];
+
+  const handler = connectNodeAdapter({
+    grpc: true,
+    grpcWeb: false,
+    connect: false,
+    routes(router) {
+      router.service(
+        PluginInvokerService,
+        {
+          async invoke(input) {
+            const params = Object.fromEntries(Object.entries(input.params ?? {}));
+            calls.push({
+              requestHandle: input.requestHandle,
+              plugin: input.plugin,
+              operation: input.operation,
+              params,
+              connection: input.connection,
+              instance: input.instance,
+            });
+            return create(OperationResultSchema, {
+              status: 207,
+              body: JSON.stringify({
+                requestHandle: input.requestHandle,
+                plugin: input.plugin,
+                operation: input.operation,
+                params,
+                connection: input.connection,
+                instance: input.instance,
+              }),
+            });
+          },
+        } satisfies Partial<ServiceImpl<typeof PluginInvokerService>>,
+      );
+    },
+  });
+  const server = createServer(handler);
+
+  try {
+    await new Promise<void>((resolve, reject) => {
+      server.once("error", reject);
+      server.listen(socketPath, () => {
+        server.off("error", reject);
+        resolve();
+      });
+    });
+
+    process.env[ENV_PLUGIN_INVOKER_SOCKET] = socketPath;
+
+    const fromHandle = new PluginInvoker("request-handle-123");
+    const first = await fromHandle.invoke(
+      "github",
+      "get_issue",
+      {
+        issue_number: 42,
+      },
+      {
+        connection: "work",
+        instance: "secondary",
+      },
+    );
+
+    expect(first.status).toBe(207);
+    expect(JSON.parse(first.body)).toEqual({
+      requestHandle: "request-handle-123",
+      plugin: "github",
+      operation: "get_issue",
+      params: {
+        issue_number: 42,
+      },
+      connection: "work",
+      instance: "secondary",
+    });
+
+    const fromRequest = new PluginInvoker(
+      request("tok", {}, {}, {}, {}, "request-handle-456"),
+    );
+    const second = await fromRequest.invoke("slack", "post_message", {
+      channel: "eng",
+      text: "hello",
+    });
+
+    expect(second.status).toBe(207);
+    expect(JSON.parse(second.body)).toEqual({
+      requestHandle: "request-handle-456",
+      plugin: "slack",
+      operation: "post_message",
+      params: {
+        channel: "eng",
+        text: "hello",
+      },
+      connection: "",
+      instance: "",
+    });
+
+    expect(calls).toEqual([
+      {
+        requestHandle: "request-handle-123",
+        plugin: "github",
+        operation: "get_issue",
+        params: {
+          issue_number: 42,
+        },
+        connection: "work",
+        instance: "secondary",
+      },
+      {
+        requestHandle: "request-handle-456",
+        plugin: "slack",
+        operation: "post_message",
+        params: {
+          channel: "eng",
+          text: "hello",
+        },
+        connection: "",
+        instance: "",
+      },
+    ]);
+  } finally {
+    if (previousSocket === undefined) {
+      delete process.env[ENV_PLUGIN_INVOKER_SOCKET];
+    } else {
+      process.env[ENV_PLUGIN_INVOKER_SOCKET] = previousSocket;
+    }
+    if (server.listening) {
+      await new Promise<void>((resolve) => {
+        server.close(() => resolve());
+      });
+    }
+    removeTempDir(tempDir);
+  }
+});

--- a/sdk/typescript/tests/plugin.test.ts
+++ b/sdk/typescript/tests/plugin.test.ts
@@ -61,6 +61,9 @@ test("plugin executes operations and exposes catalog metadata", async () => {
     "iad",
   );
   expect(connectionParam(request(), "missing")).toBeUndefined();
+  expect(request("", {}, {}, {}, {}, "request-handle-123").requestHandle).toBe(
+    "request-handle-123",
+  );
 
   const invalid = await plugin.execute("sum", { a: "bad" }, request());
   expect(invalid.status).toBe(400);

--- a/sdk/typescript/tests/runtime.test.ts
+++ b/sdk/typescript/tests/runtime.test.ts
@@ -287,6 +287,7 @@ test("integration provider service exposes metadata, configure, execute, and ses
           role: "admin",
         }),
       }),
+      requestHandle: "request-handle-123",
     }),
   );
   expect(JSON.parse(result.body)).toEqual({
@@ -298,6 +299,7 @@ test("integration provider service exposes metadata, configure, execute, and ses
     credentialMode: "identity",
     accessPolicy: "sample_policy",
     accessRole: "admin",
+    requestHandle: "request-handle-123",
   });
 
   const sessionCatalog = await (service.getSessionCatalog as any)(


### PR DESCRIPTION
## Summary

This rounds out plugin-to-plugin invocation for the remaining executable SDKs by wiring host-issued request handles through each runtime and adding request-scoped `PluginInvoker` clients for TypeScript, Python, and Rust.

## YAML Interface

```yaml
plugins:
  p:
    invokes:
      - plugin: q
        operation: create_ticket
```

## Go Interface

```go
func createTicket(_ *Provider, ctx context.Context, in Input, req gestalt.Request) (gestalt.Response[Output], error) {
    invoker, err := req.Invoker()
    if err != nil {
        return gestalt.Response[Output]{}, err
    }
    defer invoker.Close()

    result, err := invoker.Invoke(ctx, "q", "create_ticket", map[string]any{
        "title": in.Title,
    }, &gestalt.InvokeOptions{Connection: "work"})
    if err != nil {
        return gestalt.Response[Output]{}, err
    }

    return gestalt.OK(Output{Status: result.Status}), nil
}
```

## New SDK Interfaces

### TypeScript

```ts
import { PluginInvoker } from "@valon-technologies/gestalt";

const invoker = new PluginInvoker(request);
const result = await invoker.invoke("q", "create_ticket", {
  title: input.title,
}, { connection: "work", instance: "prod" });
```

### Python

```py
import json

with request.invoker() as invoker:
    result = invoker.invoke(
        "q",
        "create_ticket",
        {"title": input.title},
        connection="work",
        instance="prod",
    )
    payload = json.loads(result.body)
```

### Rust

```rust
let mut invoker = request.invoker().await?;
let result = invoker
    .invoke(
        "q",
        "create_ticket",
        serde_json::json!({ "title": input.title }),
        Some(gestalt::InvokeOptions {
            connection: "work".to_string(),
            instance: "prod".to_string(),
        }),
    )
    .await?;
```

## What Changed

- Added request-handle plumbing to the TypeScript, Python, and Rust executable runtimes.
- Added host `PluginInvoker` clients to all three SDKs.
- Added request-scoped accessors:
  - TypeScript: `new PluginInvoker(request | requestHandle)`
  - Python: `Request.invoker()`
  - Rust: `Request::invoker().await`
- Preserved raw operation-result bodies across the SDKs instead of forcing JSON decode in the Python client.
- Extended runtime/transport coverage for all three SDKs.

## Testing

- `bun test && bun run typecheck` in `sdk/typescript`
- `python3 -m unittest discover -s tests` in `sdk/python`
- `cargo test` in `sdk/rust`
