### PR TITLE
[codex] Fix Homebrew install instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,9 +30,10 @@ Gestalt also does not replace your existing APIs. It sits between agents and ups
 
 ## Quick Start
 
-Install both binaries with Homebrew:
+Tap the repository and install both binaries with Homebrew:
 
 ```sh
+brew tap valon-technologies/gestalt https://github.com/valon-technologies/gestalt
 brew install valon-technologies/gestalt/gestaltd
 brew install valon-technologies/gestalt/gestalt
 ```

--- a/docs/content/install/homebrew.mdx
+++ b/docs/content/install/homebrew.mdx
@@ -4,6 +4,12 @@ Gestalt publishes a Homebrew tap for macOS and Linux.
 
 If you need a direct-download install or a Linux-specific release artifact, see [Binary Releases](/install/binary).
 
+Tap the main repository first. Homebrew's default `user/repo` shortcut looks for a repository named `homebrew-gestalt`, but Gestalt currently publishes its formulas from the main `gestalt` repository.
+
+```sh
+brew tap valon-technologies/gestalt https://github.com/valon-technologies/gestalt
+```
+
 ## Server
 
 `gestaltd` is the long-running process that manages authentication and plugins.

--- a/docs/content/install/index.mdx
+++ b/docs/content/install/index.mdx
@@ -11,6 +11,7 @@ Gestalt ships two binaries: `gestaltd` (the server) and `gestalt` (the CLI clien
 The fastest path on macOS and Linux. See [Homebrew](/install/homebrew).
 
 ```sh
+brew tap valon-technologies/gestalt https://github.com/valon-technologies/gestalt
 brew install valon-technologies/gestalt/gestaltd
 brew install valon-technologies/gestalt/gestalt
 ```


### PR DESCRIPTION
## What changed
- add the explicit `brew tap valon-technologies/gestalt https://github.com/valon-technologies/gestalt` step to the top-level install docs
- update the Homebrew install page to explain why the extra tap command is required
- keep the existing install commands for `gestaltd` and `gestalt` after the tap is configured

## Why
Homebrew's default `user/repo` tap shortcut assumes a repository named `homebrew-gestalt`. That repository currently does not exist, so `brew install valon-technologies/gestalt/gestalt` prompts for GitHub credentials and then fails while trying to clone a 404 tap.

## User impact
Users following the docs will get a working install path again on a fresh machine.

This is a short-term documentation fix. The cleaner long-term Homebrew setup would be either:
- restore a dedicated `valon-technologies/homebrew-gestalt` tap, or
- publish through `homebrew/core`

## Validation
- `git diff --check`
- manually verified that `https://github.com/valon-technologies/homebrew-gestalt` currently returns 404 and that the main `valon-technologies/gestalt` repo and public release assets are reachable