### PR TITLE
[codex] Remove legacy server.authorization config

### DIFF
--- a/docs/content/reference/config-file.mdx
+++ b/docs/content/reference/config-file.mdx
@@ -45,7 +45,7 @@ and default artifact directories stay rooted at the leftmost config file.
 
 Several fields carry defaults when omitted: `server.public.port` defaults to `8080`; the runtime secrets manager defaults to builtin `env` when `providers.secrets` is omitted; `providers.telemetry.default` defaults to builtin `stdout`; and `providers.audit.default` defaults to builtin `inherit`. Structured secret refs are resolved during bootstrap, not during YAML parsing.
 
-`authorization` is the canonical location for shared human and workload access policy. Existing deployments may continue to use `server.authorization` as a deprecated compatibility alias; Gestalt normalizes it into the top-level block during config load and bootstrap.
+`authorization` configures shared human and workload access policy at the top level.
 
 ### Layered example
 

--- a/gestaltd/internal/bootstrap/bootstrap_test.go
+++ b/gestaltd/internal/bootstrap/bootstrap_test.go
@@ -161,36 +161,6 @@ func TestBootstrap(t *testing.T) {
 		t.Fatal("expected shared invoker and capability lister to be the same instance")
 	}
 
-	t.Run("normalizes equivalent top level and legacy authorization shapes", func(t *testing.T) {
-		t.Parallel()
-
-		cfg := validConfig()
-		cfg.Authorization = config.AuthorizationConfig{
-			Policies: map[string]config.HumanPolicyDef{
-				"roadmap": {
-					Default: "deny",
-				},
-			},
-		}
-		cfg.Server.Authorization = config.AuthorizationConfig{
-			Policies: map[string]config.HumanPolicyDef{
-				"roadmap": {
-					Default: "deny",
-					Members: []config.HumanPolicyMemberDef{},
-				},
-			},
-		}
-
-		result, err := bootstrap.Bootstrap(ctx, cfg, validFactories())
-		if err != nil {
-			t.Fatalf("Bootstrap: %v", err)
-		}
-		<-result.ProvidersReady
-		if result.Authorizer == nil {
-			t.Fatal("Authorizer is nil")
-		}
-	})
-
 	t.Run("invoker uses resolved REST connections", func(t *testing.T) {
 		t.Parallel()
 
@@ -852,64 +822,39 @@ func TestBootstrapSecretResolution(t *testing.T) {
 	t.Run("resolves config secret ref in workload tokens", func(t *testing.T) {
 		t.Parallel()
 
-		tests := []struct {
-			name  string
-			apply func(*config.Config, config.AuthorizationConfig)
-		}{
-			{
-				name: "top level authorization",
-				apply: func(cfg *config.Config, authz config.AuthorizationConfig) {
-					cfg.Authorization = authz
-				},
-			},
-			{
-				name: "legacy server authorization",
-				apply: func(cfg *config.Config, authz config.AuthorizationConfig) {
-					cfg.Server.Authorization = authz
+		factories := validFactories()
+		factories.Secrets["test-secrets"] = func(yaml.Node) (core.SecretManager, error) {
+			return &coretesting.StubSecretManager{
+				Secrets: map[string]string{"workload-token": "gst_wld_resolved-workload-token"},
+			}, nil
+		}
+		factories.Builtins = []core.Provider{
+			&coretesting.StubIntegration{N: "weather", ConnMode: core.ConnectionModeNone},
+		}
+
+		cfg := validConfig()
+		cfg.Authorization = config.AuthorizationConfig{
+			Workloads: map[string]config.WorkloadDef{
+				"triage-bot": {
+					Token: transportSecretRef("workload-token"),
+					Providers: map[string]config.WorkloadProviderDef{
+						"weather": {Allow: []string{"forecast"}},
+					},
 				},
 			},
 		}
 
-		for _, tc := range tests {
-			tc := tc
-			t.Run(tc.name, func(t *testing.T) {
-				t.Parallel()
+		result, err := bootstrap.Bootstrap(ctx, cfg, factories)
+		if err != nil {
+			t.Fatalf("Bootstrap: %v", err)
+		}
+		<-result.ProvidersReady
 
-				factories := validFactories()
-				factories.Secrets["test-secrets"] = func(yaml.Node) (core.SecretManager, error) {
-					return &coretesting.StubSecretManager{
-						Secrets: map[string]string{"workload-token": "gst_wld_resolved-workload-token"},
-					}, nil
-				}
-				factories.Builtins = []core.Provider{
-					&coretesting.StubIntegration{N: "weather", ConnMode: core.ConnectionModeNone},
-				}
-
-				cfg := validConfig()
-				tc.apply(cfg, config.AuthorizationConfig{
-					Workloads: map[string]config.WorkloadDef{
-						"triage-bot": {
-							Token: transportSecretRef("workload-token"),
-							Providers: map[string]config.WorkloadProviderDef{
-								"weather": {Allow: []string{"forecast"}},
-							},
-						},
-					},
-				})
-
-				result, err := bootstrap.Bootstrap(ctx, cfg, factories)
-				if err != nil {
-					t.Fatalf("Bootstrap: %v", err)
-				}
-				<-result.ProvidersReady
-
-				if result.Authorizer == nil {
-					t.Fatal("Authorizer is nil")
-				}
-				if _, ok := result.Authorizer.ResolveWorkloadToken("gst_wld_resolved-workload-token"); !ok {
-					t.Fatal("expected resolved workload token to authenticate")
-				}
-			})
+		if result.Authorizer == nil {
+			t.Fatal("Authorizer is nil")
+		}
+		if _, ok := result.Authorizer.ResolveWorkloadToken("gst_wld_resolved-workload-token"); !ok {
+			t.Fatal("expected resolved workload token to authenticate")
 		}
 	})
 
@@ -1069,53 +1014,28 @@ func TestBootstrapSecretResolution(t *testing.T) {
 func TestBootstrapWorkloadAuthorizationRejectsEitherProvider(t *testing.T) {
 	t.Parallel()
 
-	tests := []struct {
-		name  string
-		apply func(*config.Config, config.AuthorizationConfig)
-	}{
-		{
-			name: "top level authorization",
-			apply: func(cfg *config.Config, authz config.AuthorizationConfig) {
-				cfg.Authorization = authz
-			},
-		},
-		{
-			name: "legacy server authorization",
-			apply: func(cfg *config.Config, authz config.AuthorizationConfig) {
-				cfg.Server.Authorization = authz
+	cfg := validConfig()
+	cfg.Authorization = config.AuthorizationConfig{
+		Workloads: map[string]config.WorkloadDef{
+			"triage-bot": {
+				Token: "gst_wld_triage-bot-token",
+				Providers: map[string]config.WorkloadProviderDef{
+					"svc": {Allow: []string{"run"}},
+				},
 			},
 		},
 	}
 
-	for _, tc := range tests {
-		tc := tc
-		t.Run(tc.name, func(t *testing.T) {
-			t.Parallel()
+	factories := validFactories()
+	factories.Builtins = []core.Provider{
+		&coretesting.StubIntegration{N: "svc", ConnMode: core.ConnectionModeEither},
+	}
 
-			cfg := validConfig()
-			tc.apply(cfg, config.AuthorizationConfig{
-				Workloads: map[string]config.WorkloadDef{
-					"triage-bot": {
-						Token: "gst_wld_triage-bot-token",
-						Providers: map[string]config.WorkloadProviderDef{
-							"svc": {Allow: []string{"run"}},
-						},
-					},
-				},
-			})
-
-			factories := validFactories()
-			factories.Builtins = []core.Provider{
-				&coretesting.StubIntegration{N: "svc", ConnMode: core.ConnectionModeEither},
-			}
-
-			_, err := bootstrap.Bootstrap(context.Background(), cfg, factories)
-			if err == nil {
-				t.Fatal("expected error, got nil")
-			}
-			if !strings.Contains(err.Error(), `unsupported connection mode "either"`) {
-				t.Fatalf("unexpected error: %v", err)
-			}
-		})
+	_, err := bootstrap.Bootstrap(context.Background(), cfg, factories)
+	if err == nil {
+		t.Fatal("expected error, got nil")
+	}
+	if !strings.Contains(err.Error(), `unsupported connection mode "either"`) {
+		t.Fatalf("unexpected error: %v", err)
 	}
 }

--- a/gestaltd/internal/config/config.go
+++ b/gestaltd/internal/config/config.go
@@ -9,7 +9,6 @@ import (
 	"net"
 	"os"
 	"path/filepath"
-	"reflect"
 	"slices"
 	"strconv"
 	"strings"
@@ -316,7 +315,6 @@ type ServerConfig struct {
 	ArtifactsDir  string                   `yaml:"artifactsDir"`
 	Providers     ServerProvidersConfig    `yaml:"providers,omitempty"`
 	Egress        EgressConfig             `yaml:"egress,omitempty"`
-	Authorization AuthorizationConfig      `yaml:"authorization,omitempty"`
 	Admin         AdminConfig              `yaml:"admin,omitempty"`
 }
 
@@ -1392,27 +1390,7 @@ func normalizeAuthorizationConfig(cfg *Config) error {
 		return nil
 	}
 	cfg.Authorization = normalizedAuthorizationConfig(cfg.Authorization)
-	cfg.Server.Authorization = normalizedAuthorizationConfig(cfg.Server.Authorization)
-	topLevelSet := hasAuthorizationConfig(cfg.Authorization)
-	legacySet := hasAuthorizationConfig(cfg.Server.Authorization)
-	switch {
-	case topLevelSet && legacySet:
-		if !reflect.DeepEqual(cfg.Authorization, cfg.Server.Authorization) {
-			return fmt.Errorf("config validation: authorization and server.authorization may not both be set with different values")
-		}
-	case topLevelSet:
-		cfg.Server.Authorization = cfg.Authorization
-	case legacySet:
-		cfg.Authorization = cfg.Server.Authorization
-	default:
-		cfg.Authorization = AuthorizationConfig{}
-		cfg.Server.Authorization = AuthorizationConfig{}
-	}
 	return nil
-}
-
-func hasAuthorizationConfig(cfg AuthorizationConfig) bool {
-	return len(cfg.Policies) > 0 || len(cfg.Workloads) > 0
 }
 
 func normalizedAuthorizationConfig(cfg AuthorizationConfig) AuthorizationConfig {

--- a/gestaltd/internal/config/config_test.go
+++ b/gestaltd/internal/config/config_test.go
@@ -515,13 +515,11 @@ func TestValidateStructureRejectsDuplicateAuthorizationPolicyMembers(t *testing.
 			t.Parallel()
 
 			cfg := &Config{
-				Server: ServerConfig{
-					Authorization: AuthorizationConfig{
-						Policies: map[string]HumanPolicyDef{
-							"roadmap": {
-								Default: "deny",
-								Members: tc.members,
-							},
+				Authorization: AuthorizationConfig{
+					Policies: map[string]HumanPolicyDef{
+						"roadmap": {
+							Default: "deny",
+							Members: tc.members,
 						},
 					},
 				},
@@ -2100,6 +2098,7 @@ func TestLoadAcceptsNewComponentForms(t *testing.T) {
 	cases := []struct {
 		name string
 		yaml string
+		want string
 	}{
 		{
 			name: "builtin string",
@@ -2141,6 +2140,7 @@ func TestLoadConfigValidation(t *testing.T) {
 	cases := []struct {
 		name string
 		yaml string
+		want string
 	}{
 		{
 			name: "provider with no source or surfaces",
@@ -2172,6 +2172,17 @@ providers:
         path: ./two/manifest.yaml
 `,
 		},
+		{
+			name: "legacy server authorization is rejected",
+			yaml: `
+server:
+  authorization:
+    policies:
+      sample_policy:
+        default: deny
+`,
+			want: `field authorization not found in type config.ServerConfig`,
+		},
 	}
 
 	for _, tc := range cases {
@@ -2181,6 +2192,9 @@ providers:
 			_, err := Load(path)
 			if err == nil {
 				t.Fatal("Load: expected error, got nil")
+			}
+			if tc.want != "" && !strings.Contains(err.Error(), tc.want) {
+				t.Fatalf("Load error = %v, want substring %q", err, tc.want)
 			}
 		})
 	}

--- a/gestaltd/internal/operator/lifecycle_test.go
+++ b/gestaltd/internal/operator/lifecycle_test.go
@@ -1648,74 +1648,50 @@ func TestInitAtPath_RejectsPolicyBoundManagedMountedWebUIWithoutExplicitRouteCov
 			want: "must declare a route covering /",
 		},
 	}
-	authBlocks := []struct {
-		name string
-		yaml string
-	}{
-		{
-			name: "top level authorization",
-			yaml: `authorization:
-  policies:
-    sample_policy:
-      default: deny
-      members:
-        - email: viewer@example.test
-          role: viewer
-`,
-		},
-		{
-			name: "legacy server authorization",
-			yaml: `  authorization:
-    policies:
-      sample_policy:
-        default: deny
-        members:
-          - email: viewer@example.test
-            role: viewer
-`,
-		},
-	}
-
 	for _, tc := range tests {
 		tc := tc
-		for _, authBlock := range authBlocks {
-			authBlock := authBlock
-			t.Run(tc.name+"/"+authBlock.name, func(t *testing.T) {
-				t.Parallel()
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
 
-				dir := t.TempDir()
-				pkgPath := mustBuildManagedProviderPackage(t, dir, &providermanifestv1.Manifest{
-					Kind:        providermanifestv1.KindWebUI,
-					Source:      "github.com/testowner/web/sample-portal",
-					Version:     "0.0.1-alpha.1",
-					DisplayName: "Sample Portal",
-					Spec:        tc.spec,
-				}, map[string]string{
-					"dist/index.html": "<html>sample portal</html>",
-				}, false)
+			dir := t.TempDir()
+			pkgPath := mustBuildManagedProviderPackage(t, dir, &providermanifestv1.Manifest{
+				Kind:        providermanifestv1.KindWebUI,
+				Source:      "github.com/testowner/web/sample-portal",
+				Version:     "0.0.1-alpha.1",
+				DisplayName: "Sample Portal",
+				Spec:        tc.spec,
+			}, map[string]string{
+				"dist/index.html": "<html>sample portal</html>",
+			}, false)
 
-				cfgPath := filepath.Join(dir, "config.yaml")
-				cfg := requiredComponentConfigYAML(t, dir, filepath.Join(dir, "gestalt.db")) + `  ui:
+			cfgPath := filepath.Join(dir, "config.yaml")
+			cfg := requiredComponentConfigYAML(t, dir, filepath.Join(dir, "gestalt.db")) + `  ui:
     sample_portal:
       source:
         ref: github.com/testowner/web/sample-portal
         version: 0.0.1-alpha.1
       path: /sample-portal
       authorizationPolicy: sample_policy
+authorization:
+  policies:
+    sample_policy:
+      default: deny
+      members:
+        - email: viewer@example.test
+          role: viewer
 ` + `server:
 ` + requiredServerDatastoreYAML() + `  encryptionKey: aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa
-` + authBlock.yaml
-				if err := os.WriteFile(cfgPath, []byte(cfg), 0o644); err != nil {
-					t.Fatalf("WriteFile config: %v", err)
-				}
+`
+			if err := os.WriteFile(cfgPath, []byte(cfg), 0o644); err != nil {
+				t.Fatalf("WriteFile config: %v", err)
+			}
 
-				lc := NewLifecycle(staticSourceResolver{localPath: pkgPath})
-				_, err := lc.InitAtPath(cfgPath)
-				if err == nil || !strings.Contains(err.Error(), tc.want) {
-					t.Fatalf("InitAtPath error = %v, want substring %q", err, tc.want)
-				}
-			})
-		}
+			lc := NewLifecycle(staticSourceResolver{localPath: pkgPath})
+			_, err := lc.InitAtPath(cfgPath)
+			if err == nil || !strings.Contains(err.Error(), tc.want) {
+				t.Fatalf("InitAtPath error = %v, want substring %q", err, tc.want)
+			}
+		})
 	}
 }
 


### PR DESCRIPTION
## Summary
Remove the deprecated `server.authorization` config path and require top-level `authorization` exclusively.

## What Changed
- removed `ServerConfig.Authorization` from config parsing
- removed compatibility normalization that mirrored `server.authorization` into top-level `authorization`
- updated bootstrap and operator tests to cover only top-level authorization inputs
- added a config load test that explicitly rejects `server.authorization` as an unknown field
- updated the config reference docs to describe `authorization` as top-level only

## Why
The legacy alias was kept only for backwards compatibility. This follow-up intentionally removes that deprecated surface after the earlier authorization migration work landed.

## Impact
This is a breaking change for any deployment still using `server.authorization`; those configs must move to top-level `authorization`.

## Validation
- `go test ./internal/config ./internal/bootstrap ./internal/operator` (from `gestaltd/`)
