### PR TITLE
Add TypeScript SDK API docs and TypeDoc publishing

### DIFF
--- a/.github/workflows/build-typescript-sdk.yml
+++ b/.github/workflows/build-typescript-sdk.yml
@@ -1,0 +1,48 @@
+name: Build TypeScript SDK
+
+on:
+  push:
+    branches:
+      - main
+    paths:
+      - 'sdk/typescript/**'
+      - 'sdk/proto/**'
+      - '.github/workflows/build-typescript-sdk.yml'
+  pull_request:
+    paths:
+      - 'sdk/typescript/**'
+      - 'sdk/proto/**'
+      - '.github/workflows/build-typescript-sdk.yml'
+
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+jobs:
+  typescript-sdk:
+    name: TypeScript SDK Checks
+    runs-on: ubuntu-latest
+    timeout-minutes: 15
+    defaults:
+      run:
+        working-directory: sdk/typescript
+
+    steps:
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
+
+      - uses: oven-sh/setup-bun@0c5077e51419868618aeaa5fe8019c62421857d6 # v2.2.0
+        with:
+          bun-version: 1.3.11
+
+      - name: Install dependencies
+        run: bun install --frozen-lockfile
+
+      - name: Run SDK checks
+        run: bun run check
+
+      - name: Lint TSDoc comments
+        run: bun run docs:lint
+
+      - name: Build TypeDoc reference
+        run: bun run docs:build

--- a/.github/workflows/deploy-gestalt-docs.yml
+++ b/.github/workflows/deploy-gestalt-docs.yml
@@ -6,6 +6,7 @@ on:
     paths:
       - 'docs/**'
       - 'sdk/python/**'
+      - 'sdk/typescript/**'
       - '.github/workflows/deploy-gestalt-docs.yml'
   workflow_dispatch:
 
@@ -48,6 +49,20 @@ jobs:
         run: |
           rm -rf ../../docs/public/api/python
           uv run sphinx-build -W -b html -d docs/_build/deploy-doctrees docs ../../docs/public/api/python
+
+      - uses: oven-sh/setup-bun@0c5077e51419868618aeaa5fe8019c62421857d6 # v2.2.0
+        with:
+          bun-version: 1.3.11
+
+      - name: Install TypeScript SDK dependencies
+        working-directory: sdk/typescript
+        run: bun install --frozen-lockfile
+
+      - name: Build TypeScript API docs
+        working-directory: sdk/typescript
+        run: |
+          rm -rf ../../docs/public/api/typescript
+          bun run docs:build:deploy
 
       - name: Authenticate to Google Cloud
         id: gcp-auth

--- a/docs/content/reference/_meta.ts
+++ b/docs/content/reference/_meta.ts
@@ -1,6 +1,7 @@
 export default {
   "config-file": "Config File",
   "python-sdk": "Python SDK API",
+  "typescript-sdk": "TypeScript SDK",
   "plugin-manifests": "Provider Manifests",
   "http-api": "HTTP API",
   cli: "Server CLI",

--- a/docs/content/reference/index.mdx
+++ b/docs/content/reference/index.mdx
@@ -13,6 +13,9 @@ import { Cards } from 'nextra/components'
   <Cards.Card title="Config File" href="/reference/config-file">
     Every YAML field, validation rules, and load semantics.
   </Cards.Card>
+  <Cards.Card title="TypeScript SDK" href="/reference/typescript-sdk">
+    TypeDoc reference for the authored Bun and TypeScript SDK surface.
+  </Cards.Card>
   <Cards.Card title="Provider Manifests" href="/reference/plugin-manifests">
     Manifest schema for provider packages and UI bundles.
   </Cards.Card>

--- a/docs/content/reference/typescript-sdk.mdx
+++ b/docs/content/reference/typescript-sdk.mdx
@@ -1,0 +1,32 @@
+# TypeScript SDK
+
+The TypeScript SDK reference is generated from the authored public surface in
+`sdk/typescript/src`. It covers the root package exports from
+`@valon-technologies/gestalt` together with the `build`, `runtime`, `schema`,
+and `target` entrypoints used by Bun-based providers.
+
+[Open the TypeScript API reference](/api/typescript/index.html)
+
+```ts
+import { defineIntegrationProvider, ok, operation, s } from "@valon-technologies/gestalt";
+
+export const provider = defineIntegrationProvider({
+  displayName: "Example Provider",
+  operations: [
+    operation({
+      id: "hello",
+      input: s.object({ name: s.string({ default: "World" }) }),
+      output: s.object({ message: s.string() }),
+      async handler(input) {
+        return ok({ message: `Hello, ${input.name}` });
+      },
+    }),
+  ],
+});
+```
+
+```ts
+import { parseRuntimeArgs, serve } from "@valon-technologies/gestalt/runtime";
+
+const args = parseRuntimeArgs(process.argv.slice(2));
+```

--- a/sdk/typescript/bun.lock
+++ b/sdk/typescript/bun.lock
@@ -12,6 +12,10 @@
       },
       "devDependencies": {
         "@types/bun": "1.3.2",
+        "@typescript-eslint/parser": "8.46.1",
+        "eslint": "9.38.0",
+        "eslint-plugin-tsdoc": "0.4.0",
+        "typedoc": "0.28.14",
         "typescript": "5.9.3",
       },
       "peerDependencies": {
@@ -26,20 +30,312 @@
 
     "@connectrpc/connect-node": ["@connectrpc/connect-node@2.1.0", "", { "peerDependencies": { "@bufbuild/protobuf": "^2.7.0", "@connectrpc/connect": "2.1.0" } }, "sha512-6akCXZSX5uWHLR654ne9Tnq7AnPUkLS65NvgsI5885xBkcuVy2APBd8sA4sLqaplUt84cVEr6LhjEFNx6W1KtQ=="],
 
+    "@eslint-community/eslint-utils": ["@eslint-community/eslint-utils@4.9.1", "", { "dependencies": { "eslint-visitor-keys": "^3.4.3" }, "peerDependencies": { "eslint": "^6.0.0 || ^7.0.0 || >=8.0.0" } }, "sha512-phrYmNiYppR7znFEdqgfWHXR6NCkZEK7hwWDHZUjit/2/U0r6XvkDl0SYnoM51Hq7FhCGdLDT6zxCCOY1hexsQ=="],
+
+    "@eslint-community/regexpp": ["@eslint-community/regexpp@4.12.2", "", {}, "sha512-EriSTlt5OC9/7SXkRSCAhfSxxoSUgBm33OH+IkwbdpgoqsSsUg7y3uh+IICI/Qg4BBWr3U2i39RpmycbxMq4ew=="],
+
+    "@eslint/config-array": ["@eslint/config-array@0.21.2", "", { "dependencies": { "@eslint/object-schema": "^2.1.7", "debug": "^4.3.1", "minimatch": "^3.1.5" } }, "sha512-nJl2KGTlrf9GjLimgIru+V/mzgSK0ABCDQRvxw5BjURL7WfH5uoWmizbH7QB6MmnMBd8cIC9uceWnezL1VZWWw=="],
+
+    "@eslint/config-helpers": ["@eslint/config-helpers@0.4.2", "", { "dependencies": { "@eslint/core": "^0.17.0" } }, "sha512-gBrxN88gOIf3R7ja5K9slwNayVcZgK6SOUORm2uBzTeIEfeVaIhOpCtTox3P6R7o2jLFwLFTLnC7kU/RGcYEgw=="],
+
+    "@eslint/core": ["@eslint/core@0.16.0", "", { "dependencies": { "@types/json-schema": "^7.0.15" } }, "sha512-nmC8/totwobIiFcGkDza3GIKfAw1+hLiYVrh3I1nIomQ8PEr5cxg34jnkmGawul/ep52wGRAcyeDCNtWKSOj4Q=="],
+
+    "@eslint/eslintrc": ["@eslint/eslintrc@3.3.5", "", { "dependencies": { "ajv": "^6.14.0", "debug": "^4.3.2", "espree": "^10.0.1", "globals": "^14.0.0", "ignore": "^5.2.0", "import-fresh": "^3.2.1", "js-yaml": "^4.1.1", "minimatch": "^3.1.5", "strip-json-comments": "^3.1.1" } }, "sha512-4IlJx0X0qftVsN5E+/vGujTRIFtwuLbNsVUe7TO6zYPDR1O6nFwvwhIKEKSrl6dZchmYBITazxKoUYOjdtjlRg=="],
+
+    "@eslint/js": ["@eslint/js@9.38.0", "", {}, "sha512-UZ1VpFvXf9J06YG9xQBdnzU+kthors6KjhMAl6f4gH4usHyh31rUf2DLGInT8RFYIReYXNSydgPY0V2LuWgl7A=="],
+
+    "@eslint/object-schema": ["@eslint/object-schema@2.1.7", "", {}, "sha512-VtAOaymWVfZcmZbp6E2mympDIHvyjXs/12LqWYjVw6qjrfF+VK+fyG33kChz3nnK+SU5/NeHOqrTEHS8sXO3OA=="],
+
+    "@eslint/plugin-kit": ["@eslint/plugin-kit@0.4.1", "", { "dependencies": { "@eslint/core": "^0.17.0", "levn": "^0.4.1" } }, "sha512-43/qtrDUokr7LJqoF2c3+RInu/t4zfrpYdoSDfYyhg52rwLV6TnOvdG4fXm7IkSB3wErkcmJS9iEhjVtOSEjjA=="],
+
+    "@gerrit0/mini-shiki": ["@gerrit0/mini-shiki@3.23.0", "", { "dependencies": { "@shikijs/engine-oniguruma": "^3.23.0", "@shikijs/langs": "^3.23.0", "@shikijs/themes": "^3.23.0", "@shikijs/types": "^3.23.0", "@shikijs/vscode-textmate": "^10.0.2" } }, "sha512-bEMORlG0cqdjVyCEuU0cDQbORWX+kYCeo0kV1lbxF5bt4r7SID2l9bqsxJEM0zndaxpOUT7riCyIVEuqq/Ynxg=="],
+
+    "@humanfs/core": ["@humanfs/core@0.19.1", "", {}, "sha512-5DyQ4+1JEUzejeK1JGICcideyfUbGixgS9jNgex5nqkW+cY7WZhxBigmieN5Qnw9ZosSNVC9KQKyb+GUaGyKUA=="],
+
+    "@humanfs/node": ["@humanfs/node@0.16.7", "", { "dependencies": { "@humanfs/core": "^0.19.1", "@humanwhocodes/retry": "^0.4.0" } }, "sha512-/zUx+yOsIrG4Y43Eh2peDeKCxlRt/gET6aHfaKpuq267qXdYDFViVHfMaLyygZOnl0kGWxFIgsBy8QFuTLUXEQ=="],
+
+    "@humanwhocodes/module-importer": ["@humanwhocodes/module-importer@1.0.1", "", {}, "sha512-bxveV4V8v5Yb4ncFTT3rPSgZBOpCkjfK0y4oVVVJwIuDVBRMDXrPyXRL988i5ap9m9bnyEEjWfm5WkBmtffLfA=="],
+
+    "@humanwhocodes/retry": ["@humanwhocodes/retry@0.4.3", "", {}, "sha512-bV0Tgo9K4hfPCek+aMAn81RppFKv2ySDQeMoSZuvTASywNTnVJCArCZE2FWqpvIatKu7VMRLWlR1EazvVhDyhQ=="],
+
+    "@microsoft/tsdoc": ["@microsoft/tsdoc@0.15.1", "", {}, "sha512-4aErSrCR/On/e5G2hDP0wjooqDdauzEbIq8hIkIe5pXV0rtWJZvdCEKL0ykZxex+IxIwBp0eGeV48hQN07dXtw=="],
+
+    "@microsoft/tsdoc-config": ["@microsoft/tsdoc-config@0.17.1", "", { "dependencies": { "@microsoft/tsdoc": "0.15.1", "ajv": "~8.12.0", "jju": "~1.4.0", "resolve": "~1.22.2" } }, "sha512-UtjIFe0C6oYgTnad4q1QP4qXwLhe6tIpNTRStJ2RZEPIkqQPREAwE5spzVxsdn9UaEMUqhh0AqSx3X4nWAKXWw=="],
+
+    "@nodelib/fs.scandir": ["@nodelib/fs.scandir@2.1.5", "", { "dependencies": { "@nodelib/fs.stat": "2.0.5", "run-parallel": "^1.1.9" } }, "sha512-vq24Bq3ym5HEQm2NKCr3yXDwjc7vTsEThRDnkp2DK9p1uqLR+DHurm/NOTo0KG7HYHU7eppKZj3MyqYuMBf62g=="],
+
+    "@nodelib/fs.stat": ["@nodelib/fs.stat@2.0.5", "", {}, "sha512-RkhPPp2zrqDAQA/2jNhnztcPAlv64XdhIp7a7454A5ovI7Bukxgt7MX7udwAu3zg1DcpPU0rz3VV1SeaqvY4+A=="],
+
+    "@nodelib/fs.walk": ["@nodelib/fs.walk@1.2.8", "", { "dependencies": { "@nodelib/fs.scandir": "2.1.5", "fastq": "^1.6.0" } }, "sha512-oGB+UxlgWcgQkgwo8GcEGwemoTFt3FIO9ababBmaGwXIoBKZ+GTy0pP185beGg7Llih/NSHSV2XAs1lnznocSg=="],
+
+    "@shikijs/engine-oniguruma": ["@shikijs/engine-oniguruma@3.23.0", "", { "dependencies": { "@shikijs/types": "3.23.0", "@shikijs/vscode-textmate": "^10.0.2" } }, "sha512-1nWINwKXxKKLqPibT5f4pAFLej9oZzQTsby8942OTlsJzOBZ0MWKiwzMsd+jhzu8YPCHAswGnnN1YtQfirL35g=="],
+
+    "@shikijs/langs": ["@shikijs/langs@3.23.0", "", { "dependencies": { "@shikijs/types": "3.23.0" } }, "sha512-2Ep4W3Re5aB1/62RSYQInK9mM3HsLeB91cHqznAJMuylqjzNVAVCMnNWRHFtcNHXsoNRayP9z1qj4Sq3nMqYXg=="],
+
+    "@shikijs/themes": ["@shikijs/themes@3.23.0", "", { "dependencies": { "@shikijs/types": "3.23.0" } }, "sha512-5qySYa1ZgAT18HR/ypENL9cUSGOeI2x+4IvYJu4JgVJdizn6kG4ia5Q1jDEOi7gTbN4RbuYtmHh0W3eccOrjMA=="],
+
+    "@shikijs/types": ["@shikijs/types@3.23.0", "", { "dependencies": { "@shikijs/vscode-textmate": "^10.0.2", "@types/hast": "^3.0.4" } }, "sha512-3JZ5HXOZfYjsYSk0yPwBrkupyYSLpAE26Qc0HLghhZNGTZg/SKxXIIgoxOpmmeQP0RRSDJTk1/vPfw9tbw+jSQ=="],
+
+    "@shikijs/vscode-textmate": ["@shikijs/vscode-textmate@10.0.2", "", {}, "sha512-83yeghZ2xxin3Nj8z1NMd/NCuca+gsYXswywDy5bHvwlWL8tpTQmzGeUuHd9FC3E/SBEMvzJRwWEOz5gGes9Qg=="],
+
     "@types/bun": ["@types/bun@1.3.2", "", { "dependencies": { "bun-types": "1.3.2" } }, "sha512-t15P7k5UIgHKkxwnMNkJbWlh/617rkDGEdSsDbu+qNHTaz9SKf7aC8fiIlUdD5RPpH6GEkP0cK7WlvmrEBRtWg=="],
+
+    "@types/estree": ["@types/estree@1.0.8", "", {}, "sha512-dWHzHa2WqEXI/O1E9OjrocMTKJl2mSrEolh1Iomrv6U+JuNwaHXsXx9bLu5gG7BUWFIN0skIQJQ/L1rIex4X6w=="],
+
+    "@types/hast": ["@types/hast@3.0.4", "", { "dependencies": { "@types/unist": "*" } }, "sha512-WPs+bbQw5aCj+x6laNGWLH3wviHtoCv/P3+otBhbOhJgG8qtpdAMlTCxLtsTWA7LH1Oh/bFCHsBn0TPS5m30EQ=="],
+
+    "@types/json-schema": ["@types/json-schema@7.0.15", "", {}, "sha512-5+fP8P8MFNC+AyZCDxrB2pkZFPGzqQWUzpSeuuVLvm8VMcorNYavBqoFcxK8bQz4Qsbn4oUEEem4wDLfcysGHA=="],
 
     "@types/node": ["@types/node@25.5.2", "", { "dependencies": { "undici-types": "~7.18.0" } }, "sha512-tO4ZIRKNC+MDWV4qKVZe3Ql/woTnmHDr5JD8UI5hn2pwBrHEwOEMZK7WlNb5RKB6EoJ02gwmQS9OrjuFnZYdpg=="],
 
     "@types/react": ["@types/react@19.2.14", "", { "dependencies": { "csstype": "^3.2.2" } }, "sha512-ilcTH/UniCkMdtexkoCN0bI7pMcJDvmQFPvuPvmEaYA/NSfFTAgdUSLAoVjaRJm7+6PvcM+q1zYOwS4wTYMF9w=="],
 
+    "@types/unist": ["@types/unist@3.0.3", "", {}, "sha512-ko/gIFJRv177XgZsZcBwnqJN5x/Gien8qNOn0D5bQU/zAzVf9Zt3BlcUiLqhV9y4ARk0GbT3tnUiPNgnTXzc/Q=="],
+
+    "@typescript-eslint/parser": ["@typescript-eslint/parser@8.46.1", "", { "dependencies": { "@typescript-eslint/scope-manager": "8.46.1", "@typescript-eslint/types": "8.46.1", "@typescript-eslint/typescript-estree": "8.46.1", "@typescript-eslint/visitor-keys": "8.46.1", "debug": "^4.3.4" }, "peerDependencies": { "eslint": "^8.57.0 || ^9.0.0", "typescript": ">=4.8.4 <6.0.0" } }, "sha512-6JSSaBZmsKvEkbRUkf7Zj7dru/8ZCrJxAqArcLaVMee5907JdtEbKGsZ7zNiIm/UAkpGUkaSMZEXShnN2D1HZA=="],
+
+    "@typescript-eslint/project-service": ["@typescript-eslint/project-service@8.46.1", "", { "dependencies": { "@typescript-eslint/tsconfig-utils": "^8.46.1", "@typescript-eslint/types": "^8.46.1", "debug": "^4.3.4" }, "peerDependencies": { "typescript": ">=4.8.4 <6.0.0" } }, "sha512-FOIaFVMHzRskXr5J4Jp8lFVV0gz5ngv3RHmn+E4HYxSJ3DgDzU7fVI1/M7Ijh1zf6S7HIoaIOtln1H5y8V+9Zg=="],
+
+    "@typescript-eslint/scope-manager": ["@typescript-eslint/scope-manager@8.46.1", "", { "dependencies": { "@typescript-eslint/types": "8.46.1", "@typescript-eslint/visitor-keys": "8.46.1" } }, "sha512-weL9Gg3/5F0pVQKiF8eOXFZp8emqWzZsOJuWRUNtHT+UNV2xSJegmpCNQHy37aEQIbToTq7RHKhWvOsmbM680A=="],
+
+    "@typescript-eslint/tsconfig-utils": ["@typescript-eslint/tsconfig-utils@8.46.1", "", { "peerDependencies": { "typescript": ">=4.8.4 <6.0.0" } }, "sha512-X88+J/CwFvlJB+mK09VFqx5FE4H5cXD+H/Bdza2aEWkSb8hnWIQorNcscRl4IEo1Cz9VI/+/r/jnGWkbWPx54g=="],
+
+    "@typescript-eslint/types": ["@typescript-eslint/types@8.46.1", "", {}, "sha512-C+soprGBHwWBdkDpbaRC4paGBrkIXxVlNohadL5o0kfhsXqOC6GYH2S/Obmig+I0HTDl8wMaRySwrfrXVP8/pQ=="],
+
+    "@typescript-eslint/typescript-estree": ["@typescript-eslint/typescript-estree@8.46.1", "", { "dependencies": { "@typescript-eslint/project-service": "8.46.1", "@typescript-eslint/tsconfig-utils": "8.46.1", "@typescript-eslint/types": "8.46.1", "@typescript-eslint/visitor-keys": "8.46.1", "debug": "^4.3.4", "fast-glob": "^3.3.2", "is-glob": "^4.0.3", "minimatch": "^9.0.4", "semver": "^7.6.0", "ts-api-utils": "^2.1.0" }, "peerDependencies": { "typescript": ">=4.8.4 <6.0.0" } }, "sha512-uIifjT4s8cQKFQ8ZBXXyoUODtRoAd7F7+G8MKmtzj17+1UbdzFl52AzRyZRyKqPHhgzvXunnSckVu36flGy8cg=="],
+
+    "@typescript-eslint/visitor-keys": ["@typescript-eslint/visitor-keys@8.46.1", "", { "dependencies": { "@typescript-eslint/types": "8.46.1", "eslint-visitor-keys": "^4.2.1" } }, "sha512-ptkmIf2iDkNUjdeu2bQqhFPV1m6qTnFFjg7PPDjxKWaMaP0Z6I9l30Jr3g5QqbZGdw8YdYvLp+XnqnWWZOg/NA=="],
+
+    "acorn": ["acorn@8.16.0", "", { "bin": { "acorn": "bin/acorn" } }, "sha512-UVJyE9MttOsBQIDKw1skb9nAwQuR5wuGD3+82K6JgJlm/Y+KI92oNsMNGZCYdDsVtRHSak0pcV5Dno5+4jh9sw=="],
+
+    "acorn-jsx": ["acorn-jsx@5.3.2", "", { "peerDependencies": { "acorn": "^6.0.0 || ^7.0.0 || ^8.0.0" } }, "sha512-rq9s+JNhf0IChjtDXxllJ7g41oZk5SlXtp0LHwyA5cejwn7vKmKp4pPri6YEePv2PU65sAsegbXtIinmDFDXgQ=="],
+
+    "ajv": ["ajv@6.14.0", "", { "dependencies": { "fast-deep-equal": "^3.1.1", "fast-json-stable-stringify": "^2.0.0", "json-schema-traverse": "^0.4.1", "uri-js": "^4.2.2" } }, "sha512-IWrosm/yrn43eiKqkfkHis7QioDleaXQHdDVPKg0FSwwd/DuvyX79TZnFOnYpB7dcsFAMmtFztZuXPDvSePkFw=="],
+
+    "ansi-styles": ["ansi-styles@4.3.0", "", { "dependencies": { "color-convert": "^2.0.1" } }, "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg=="],
+
+    "argparse": ["argparse@2.0.1", "", {}, "sha512-8+9WqebbFzpX9OR+Wa6O29asIogeRMzcGtAINdpMHHyAg10f05aSFVBbcEqGf/PXw1EjAZ+q2/bEBg3DvurK3Q=="],
+
+    "balanced-match": ["balanced-match@1.0.2", "", {}, "sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw=="],
+
+    "brace-expansion": ["brace-expansion@1.1.14", "", { "dependencies": { "balanced-match": "^1.0.0", "concat-map": "0.0.1" } }, "sha512-MWPGfDxnyzKU7rNOW9SP/c50vi3xrmrua/+6hfPbCS2ABNWfx24vPidzvC7krjU/RTo235sV776ymlsMtGKj8g=="],
+
+    "braces": ["braces@3.0.3", "", { "dependencies": { "fill-range": "^7.1.1" } }, "sha512-yQbXgO/OSZVD2IsiLlro+7Hf6Q18EJrKSEsdoMzKePKXct3gvD8oLcOQdIzGupr5Fj+EDe8gO/lxc1BzfMpxvA=="],
+
     "bun-types": ["bun-types@1.3.2", "", { "dependencies": { "@types/node": "*" }, "peerDependencies": { "@types/react": "^19" } }, "sha512-i/Gln4tbzKNuxP70OWhJRZz1MRfvqExowP7U6JKoI8cntFrtxg7RJK3jvz7wQW54UuvNC8tbKHHri5fy74FVqg=="],
+
+    "callsites": ["callsites@3.1.0", "", {}, "sha512-P8BjAsXvZS+VIDUI11hHCQEv74YT67YUi5JJFNWIqL235sBmjX4+qx9Muvls5ivyNENctx46xQLQ3aTuE7ssaQ=="],
+
+    "chalk": ["chalk@4.1.2", "", { "dependencies": { "ansi-styles": "^4.1.0", "supports-color": "^7.1.0" } }, "sha512-oKnbhFyRIXpUuez8iBMmyEa4nbj4IOQyuhc/wy9kY7/WVPcwIO9VA668Pu8RkO7+0G76SLROeyw9CpQ061i4mA=="],
+
+    "color-convert": ["color-convert@2.0.1", "", { "dependencies": { "color-name": "~1.1.4" } }, "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ=="],
+
+    "color-name": ["color-name@1.1.4", "", {}, "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA=="],
+
+    "concat-map": ["concat-map@0.0.1", "", {}, "sha512-/Srv4dswyQNBfohGpz9o6Yb3Gz3SrUDqBH5rTuhGR7ahtlbYKnVxw2bCFMRljaA7EXHaXZ8wsHdodFvbkhKmqg=="],
+
+    "cross-spawn": ["cross-spawn@7.0.6", "", { "dependencies": { "path-key": "^3.1.0", "shebang-command": "^2.0.0", "which": "^2.0.1" } }, "sha512-uV2QOWP2nWzsy2aMp8aRibhi9dlzF5Hgh5SHaB9OiTGEyDTiJJyx0uy51QXdyWbtAHNua4XJzUKca3OzKUd3vA=="],
 
     "csstype": ["csstype@3.2.3", "", {}, "sha512-z1HGKcYy2xA8AGQfwrn0PAy+PB7X/GSj3UVJW9qKyn43xWa+gl5nXmU4qqLMRzWVLFC8KusUX8T/0kCiOYpAIQ=="],
 
+    "debug": ["debug@4.4.3", "", { "dependencies": { "ms": "^2.1.3" } }, "sha512-RGwwWnwQvkVfavKVt22FGLw+xYSdzARwm0ru6DhTVA3umU5hZc28V3kO4stgYryrTlLpuvgI9GiijltAjNbcqA=="],
+
+    "deep-is": ["deep-is@0.1.4", "", {}, "sha512-oIPzksmTg4/MriiaYGO+okXDT7ztn/w3Eptv/+gSIdMdKsJo0u4CfYNFJPy+4SKMuCqGw2wxnA+URMg3t8a/bQ=="],
+
+    "entities": ["entities@4.5.0", "", {}, "sha512-V0hjH4dGPh9Ao5p0MoRY6BVqtwCjhz6vI5LT8AJ55H+4g9/4vbHx1I54fS0XuclLhDHArPQCiMjDxjaL8fPxhw=="],
+
+    "es-errors": ["es-errors@1.3.0", "", {}, "sha512-Zf5H2Kxt2xjTvbJvP2ZWLEICxA6j+hAmMzIlypy4xcBg1vKVnx89Wy0GbS+kf5cwCVFFzdCFh2XSCFNULS6csw=="],
+
+    "escape-string-regexp": ["escape-string-regexp@4.0.0", "", {}, "sha512-TtpcNJ3XAzx3Gq8sWRzJaVajRs0uVxA2YAkdb1jm2YkPz4G6egUFAyA3n5vtEIZefPk5Wa4UXbKuS5fKkJWdgA=="],
+
+    "eslint": ["eslint@9.38.0", "", { "dependencies": { "@eslint-community/eslint-utils": "^4.8.0", "@eslint-community/regexpp": "^4.12.1", "@eslint/config-array": "^0.21.1", "@eslint/config-helpers": "^0.4.1", "@eslint/core": "^0.16.0", "@eslint/eslintrc": "^3.3.1", "@eslint/js": "9.38.0", "@eslint/plugin-kit": "^0.4.0", "@humanfs/node": "^0.16.6", "@humanwhocodes/module-importer": "^1.0.1", "@humanwhocodes/retry": "^0.4.2", "@types/estree": "^1.0.6", "ajv": "^6.12.4", "chalk": "^4.0.0", "cross-spawn": "^7.0.6", "debug": "^4.3.2", "escape-string-regexp": "^4.0.0", "eslint-scope": "^8.4.0", "eslint-visitor-keys": "^4.2.1", "espree": "^10.4.0", "esquery": "^1.5.0", "esutils": "^2.0.2", "fast-deep-equal": "^3.1.3", "file-entry-cache": "^8.0.0", "find-up": "^5.0.0", "glob-parent": "^6.0.2", "ignore": "^5.2.0", "imurmurhash": "^0.1.4", "is-glob": "^4.0.0", "json-stable-stringify-without-jsonify": "^1.0.1", "lodash.merge": "^4.6.2", "minimatch": "^3.1.2", "natural-compare": "^1.4.0", "optionator": "^0.9.3" }, "peerDependencies": { "jiti": "*" }, "optionalPeers": ["jiti"], "bin": { "eslint": "bin/eslint.js" } }, "sha512-t5aPOpmtJcZcz5UJyY2GbvpDlsK5E8JqRqoKtfiKE3cNh437KIqfJr3A3AKf5k64NPx6d0G3dno6XDY05PqPtw=="],
+
+    "eslint-plugin-tsdoc": ["eslint-plugin-tsdoc@0.4.0", "", { "dependencies": { "@microsoft/tsdoc": "0.15.1", "@microsoft/tsdoc-config": "0.17.1" } }, "sha512-MT/8b4aKLdDClnS8mP3R/JNjg29i0Oyqd/0ym6NnQf+gfKbJJ4ZcSh2Bs1H0YiUMTBwww5JwXGTWot/RwyJ7aQ=="],
+
+    "eslint-scope": ["eslint-scope@8.4.0", "", { "dependencies": { "esrecurse": "^4.3.0", "estraverse": "^5.2.0" } }, "sha512-sNXOfKCn74rt8RICKMvJS7XKV/Xk9kA7DyJr8mJik3S7Cwgy3qlkkmyS2uQB3jiJg6VNdZd/pDBJu0nvG2NlTg=="],
+
+    "eslint-visitor-keys": ["eslint-visitor-keys@4.2.1", "", {}, "sha512-Uhdk5sfqcee/9H/rCOJikYz67o0a2Tw2hGRPOG2Y1R2dg7brRe1uG0yaNQDHu+TO/uQPF/5eCapvYSmHUjt7JQ=="],
+
+    "espree": ["espree@10.4.0", "", { "dependencies": { "acorn": "^8.15.0", "acorn-jsx": "^5.3.2", "eslint-visitor-keys": "^4.2.1" } }, "sha512-j6PAQ2uUr79PZhBjP5C5fhl8e39FmRnOjsD5lGnWrFU8i2G776tBK7+nP8KuQUTTyAZUwfQqXAgrVH5MbH9CYQ=="],
+
+    "esquery": ["esquery@1.7.0", "", { "dependencies": { "estraverse": "^5.1.0" } }, "sha512-Ap6G0WQwcU/LHsvLwON1fAQX9Zp0A2Y6Y/cJBl9r/JbW90Zyg4/zbG6zzKa2OTALELarYHmKu0GhpM5EO+7T0g=="],
+
+    "esrecurse": ["esrecurse@4.3.0", "", { "dependencies": { "estraverse": "^5.2.0" } }, "sha512-KmfKL3b6G+RXvP8N1vr3Tq1kL/oCFgn2NYXEtqP8/L3pKapUA4G8cFVaoF3SU323CD4XypR/ffioHmkti6/Tag=="],
+
+    "estraverse": ["estraverse@5.3.0", "", {}, "sha512-MMdARuVEQziNTeJD8DgMqmhwR11BRQ/cBP+pLtYdSTnf3MIO8fFeiINEbX36ZdNlfU/7A9f3gUw49B3oQsvwBA=="],
+
+    "esutils": ["esutils@2.0.3", "", {}, "sha512-kVscqXk4OCp68SZ0dkgEKVi6/8ij300KBWTJq32P/dYeWTSwK41WyTxalN1eRmA5Z9UU/LX9D7FWSmV9SAYx6g=="],
+
+    "fast-deep-equal": ["fast-deep-equal@3.1.3", "", {}, "sha512-f3qQ9oQy9j2AhBe/H9VC91wLmKBCCU/gDOnKNAYG5hswO7BLKj09Hc5HYNz9cGI++xlpDCIgDaitVs03ATR84Q=="],
+
+    "fast-glob": ["fast-glob@3.3.3", "", { "dependencies": { "@nodelib/fs.stat": "^2.0.2", "@nodelib/fs.walk": "^1.2.3", "glob-parent": "^5.1.2", "merge2": "^1.3.0", "micromatch": "^4.0.8" } }, "sha512-7MptL8U0cqcFdzIzwOTHoilX9x5BrNqye7Z/LuC7kCMRio1EMSyqRK3BEAUD7sXRq4iT4AzTVuZdhgQ2TCvYLg=="],
+
+    "fast-json-stable-stringify": ["fast-json-stable-stringify@2.1.0", "", {}, "sha512-lhd/wF+Lk98HZoTCtlVraHtfh5XYijIjalXck7saUtuanSDyLMxnHhSXEDJqHxD7msR8D0uCmqlkwjCV8xvwHw=="],
+
+    "fast-levenshtein": ["fast-levenshtein@2.0.6", "", {}, "sha512-DCXu6Ifhqcks7TZKY3Hxp3y6qphY5SJZmrWMDrKcERSOXWQdMhU9Ig/PYrzyw/ul9jOIyh0N4M0tbC5hodg8dw=="],
+
+    "fastq": ["fastq@1.20.1", "", { "dependencies": { "reusify": "^1.0.4" } }, "sha512-GGToxJ/w1x32s/D2EKND7kTil4n8OVk/9mycTc4VDza13lOvpUZTGX3mFSCtV9ksdGBVzvsyAVLM6mHFThxXxw=="],
+
+    "file-entry-cache": ["file-entry-cache@8.0.0", "", { "dependencies": { "flat-cache": "^4.0.0" } }, "sha512-XXTUwCvisa5oacNGRP9SfNtYBNAMi+RPwBFmblZEF7N7swHYQS6/Zfk7SRwx4D5j3CH211YNRco1DEMNVfZCnQ=="],
+
+    "fill-range": ["fill-range@7.1.1", "", { "dependencies": { "to-regex-range": "^5.0.1" } }, "sha512-YsGpe3WHLK8ZYi4tWDg2Jy3ebRz2rXowDxnld4bkQB00cc/1Zw9AWnC0i9ztDJitivtQvaI9KaLyKrc+hBW0yg=="],
+
+    "find-up": ["find-up@5.0.0", "", { "dependencies": { "locate-path": "^6.0.0", "path-exists": "^4.0.0" } }, "sha512-78/PXT1wlLLDgTzDs7sjq9hzz0vXD+zn+7wypEe4fXQxCmdmqfGsEPQxmiCSQI3ajFV91bVSsvNtrJRiW6nGng=="],
+
+    "flat-cache": ["flat-cache@4.0.1", "", { "dependencies": { "flatted": "^3.2.9", "keyv": "^4.5.4" } }, "sha512-f7ccFPK3SXFHpx15UIGyRJ/FJQctuKZ0zVuN3frBo4HnK3cay9VEW0R6yPYFHC0AgqhukPzKjq22t5DmAyqGyw=="],
+
+    "flatted": ["flatted@3.4.2", "", {}, "sha512-PjDse7RzhcPkIJwy5t7KPWQSZ9cAbzQXcafsetQoD7sOJRQlGikNbx7yZp2OotDnJyrDcbyRq3Ttb18iYOqkxA=="],
+
+    "function-bind": ["function-bind@1.1.2", "", {}, "sha512-7XHNxH7qX9xG5mIwxkhumTox/MIRNcOgDrxWsMt2pAr23WHp6MrRlN7FBSFpCpr+oVO0F744iUgR82nJMfG2SA=="],
+
+    "glob-parent": ["glob-parent@6.0.2", "", { "dependencies": { "is-glob": "^4.0.3" } }, "sha512-XxwI8EOhVQgWp6iDL+3b0r86f4d6AX6zSU55HfB4ydCEuXLXc5FcYeOu+nnGftS4TEju/11rt4KJPTMgbfmv4A=="],
+
+    "globals": ["globals@14.0.0", "", {}, "sha512-oahGvuMGQlPw/ivIYBjVSrWAfWLBeku5tpPE2fOPLi+WHffIWbuh2tCjhyQhTBPMf5E9jDEH4FOmTYgYwbKwtQ=="],
+
+    "has-flag": ["has-flag@4.0.0", "", {}, "sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ=="],
+
+    "hasown": ["hasown@2.0.2", "", { "dependencies": { "function-bind": "^1.1.2" } }, "sha512-0hJU9SCPvmMzIBdZFqNPXWa6dqh7WdH0cII9y+CyS8rG3nL48Bclra9HmKhVVUHyPWNH5Y7xDwAB7bfgSjkUMQ=="],
+
+    "ignore": ["ignore@5.3.2", "", {}, "sha512-hsBTNUqQTDwkWtcdYI2i06Y/nUBEsNEDJKjWdigLvegy8kDuJAS8uRlpkkcQpyEXL0Z/pjDy5HBmMjRCJ2gq+g=="],
+
+    "import-fresh": ["import-fresh@3.3.1", "", { "dependencies": { "parent-module": "^1.0.0", "resolve-from": "^4.0.0" } }, "sha512-TR3KfrTZTYLPB6jUjfx6MF9WcWrHL9su5TObK4ZkYgBdWKPOFoSoQIdEuTuR82pmtxH2spWG9h6etwfr1pLBqQ=="],
+
+    "imurmurhash": ["imurmurhash@0.1.4", "", {}, "sha512-JmXMZ6wuvDmLiHEml9ykzqO6lwFbof0GG4IkcGaENdCRDDmMVnny7s5HsIgHCbaq0w2MyPhDqkhTUgS2LU2PHA=="],
+
+    "is-core-module": ["is-core-module@2.16.1", "", { "dependencies": { "hasown": "^2.0.2" } }, "sha512-UfoeMA6fIJ8wTYFEUjelnaGI67v6+N7qXJEvQuIGa99l4xsCruSYOVSQ0uPANn4dAzm8lkYPaKLrrijLq7x23w=="],
+
+    "is-extglob": ["is-extglob@2.1.1", "", {}, "sha512-SbKbANkN603Vi4jEZv49LeVJMn4yGwsbzZworEoyEiutsN3nJYdbO36zfhGJ6QEDpOZIFkDtnq5JRxmvl3jsoQ=="],
+
+    "is-glob": ["is-glob@4.0.3", "", { "dependencies": { "is-extglob": "^2.1.1" } }, "sha512-xelSayHH36ZgE7ZWhli7pW34hNbNl8Ojv5KVmkJD4hBdD3th8Tfk9vYasLM+mXWOZhFkgZfxhLSnrwRr4elSSg=="],
+
+    "is-number": ["is-number@7.0.0", "", {}, "sha512-41Cifkg6e8TylSpdtTpeLVMqvSBEVzTttHvERD741+pnZ8ANv0004MRL43QKPDlK9cGvNp6NZWZUBlbGXYxxng=="],
+
+    "isexe": ["isexe@2.0.0", "", {}, "sha512-RHxMLp9lnKHGHRng9QFhRCMbYAcVpn69smSGcq3f36xjgVVWThj4qqLbTLlq7Ssj8B+fIQ1EuCEGI2lKsyQeIw=="],
+
+    "jju": ["jju@1.4.0", "", {}, "sha512-8wb9Yw966OSxApiCt0K3yNJL8pnNeIv+OEq2YMidz4FKP6nonSRoOXc80iXY4JaN2FC11B9qsNmDsm+ZOfMROA=="],
+
+    "js-yaml": ["js-yaml@4.1.1", "", { "dependencies": { "argparse": "^2.0.1" }, "bin": { "js-yaml": "bin/js-yaml.js" } }, "sha512-qQKT4zQxXl8lLwBtHMWwaTcGfFOZviOJet3Oy/xmGk2gZH677CJM9EvtfdSkgWcATZhj/55JZ0rmy3myCT5lsA=="],
+
+    "json-buffer": ["json-buffer@3.0.1", "", {}, "sha512-4bV5BfR2mqfQTJm+V5tPPdf+ZpuhiIvTuAB5g8kcrXOZpTT/QwwVRWBywX1ozr6lEuPdbHxwaJlm9G6mI2sfSQ=="],
+
+    "json-schema-traverse": ["json-schema-traverse@0.4.1", "", {}, "sha512-xbbCH5dCYU5T8LcEhhuh7HJ88HXuW3qsI3Y0zOZFKfZEHcpWiHU/Jxzk629Brsab/mMiHQti9wMP+845RPe3Vg=="],
+
+    "json-stable-stringify-without-jsonify": ["json-stable-stringify-without-jsonify@1.0.1", "", {}, "sha512-Bdboy+l7tA3OGW6FjyFHWkP5LuByj1Tk33Ljyq0axyzdk9//JSi2u3fP1QSmd1KNwq6VOKYGlAu87CisVir6Pw=="],
+
+    "keyv": ["keyv@4.5.4", "", { "dependencies": { "json-buffer": "3.0.1" } }, "sha512-oxVHkHR/EJf2CNXnWxRLW6mg7JyCCUcG0DtEGmL2ctUo1PNTin1PUil+r/+4r5MpVgC/fn1kjsx7mjSujKqIpw=="],
+
+    "levn": ["levn@0.4.1", "", { "dependencies": { "prelude-ls": "^1.2.1", "type-check": "~0.4.0" } }, "sha512-+bT2uH4E5LGE7h/n3evcS/sQlJXCpIp6ym8OWJ5eV6+67Dsql/LaaT7qJBAt2rzfoa/5QBGBhxDix1dMt2kQKQ=="],
+
+    "linkify-it": ["linkify-it@5.0.0", "", { "dependencies": { "uc.micro": "^2.0.0" } }, "sha512-5aHCbzQRADcdP+ATqnDuhhJ/MRIqDkZX5pyjFHRRysS8vZ5AbqGEoFIb6pYHPZ+L/OC2Lc+xT8uHVVR5CAK/wQ=="],
+
+    "locate-path": ["locate-path@6.0.0", "", { "dependencies": { "p-locate": "^5.0.0" } }, "sha512-iPZK6eYjbxRu3uB4/WZ3EsEIMJFMqAoopl3R+zuq0UjcAm/MO6KCweDgPfP3elTztoKP3KtnVHxTn2NHBSDVUw=="],
+
+    "lodash.merge": ["lodash.merge@4.6.2", "", {}, "sha512-0KpjqXRVvrYyCsX1swR/XTK0va6VQkQM6MNo7PqW77ByjAhoARA8EfrP1N4+KlKj8YS0ZUCtRT/YUuhyYDujIQ=="],
+
+    "lunr": ["lunr@2.3.9", "", {}, "sha512-zTU3DaZaF3Rt9rhN3uBMGQD3dD2/vFQqnvZCDv4dl5iOzq2IZQqTxu90r4E5J+nP70J3ilqVCrbho2eWaeW8Ow=="],
+
+    "markdown-it": ["markdown-it@14.1.1", "", { "dependencies": { "argparse": "^2.0.1", "entities": "^4.4.0", "linkify-it": "^5.0.0", "mdurl": "^2.0.0", "punycode.js": "^2.3.1", "uc.micro": "^2.1.0" }, "bin": { "markdown-it": "bin/markdown-it.mjs" } }, "sha512-BuU2qnTti9YKgK5N+IeMubp14ZUKUUw7yeJbkjtosvHiP0AZ5c8IAgEMk79D0eC8F23r4Ac/q8cAIFdm2FtyoA=="],
+
+    "mdurl": ["mdurl@2.0.0", "", {}, "sha512-Lf+9+2r+Tdp5wXDXC4PcIBjTDtq4UKjCPMQhKIuzpJNW0b96kVqSwW0bT7FhRSfmAiFYgP+SCRvdrDozfh0U5w=="],
+
+    "merge2": ["merge2@1.4.1", "", {}, "sha512-8q7VEgMJW4J8tcfVPy8g09NcQwZdbwFEqhe/WZkoIzjn/3TGDwtOCYtXGxA3O8tPzpczCCDgv+P2P5y00ZJOOg=="],
+
+    "micromatch": ["micromatch@4.0.8", "", { "dependencies": { "braces": "^3.0.3", "picomatch": "^2.3.1" } }, "sha512-PXwfBhYu0hBCPw8Dn0E+WDYb7af3dSLVWKi3HGv84IdF4TyFoC0ysxFd0Goxw7nSv4T/PzEJQxsYsEiFCKo2BA=="],
+
+    "minimatch": ["minimatch@3.1.5", "", { "dependencies": { "brace-expansion": "^1.1.7" } }, "sha512-VgjWUsnnT6n+NUk6eZq77zeFdpW2LWDzP6zFGrCbHXiYNul5Dzqk2HHQ5uFH2DNW5Xbp8+jVzaeNt94ssEEl4w=="],
+
+    "ms": ["ms@2.1.3", "", {}, "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA=="],
+
+    "natural-compare": ["natural-compare@1.4.0", "", {}, "sha512-OWND8ei3VtNC9h7V60qff3SVobHr996CTwgxubgyQYEpg290h9J0buyECNNJexkFm5sOajh5G116RYA1c8ZMSw=="],
+
+    "optionator": ["optionator@0.9.4", "", { "dependencies": { "deep-is": "^0.1.3", "fast-levenshtein": "^2.0.6", "levn": "^0.4.1", "prelude-ls": "^1.2.1", "type-check": "^0.4.0", "word-wrap": "^1.2.5" } }, "sha512-6IpQ7mKUxRcZNLIObR0hz7lxsapSSIYNZJwXPGeF0mTVqGKFIXj1DQcMoT22S3ROcLyY/rz0PWaWZ9ayWmad9g=="],
+
+    "p-limit": ["p-limit@3.1.0", "", { "dependencies": { "yocto-queue": "^0.1.0" } }, "sha512-TYOanM3wGwNGsZN2cVTYPArw454xnXj5qmWF1bEoAc4+cU/ol7GVh7odevjp1FNHduHc3KZMcFduxU5Xc6uJRQ=="],
+
+    "p-locate": ["p-locate@5.0.0", "", { "dependencies": { "p-limit": "^3.0.2" } }, "sha512-LaNjtRWUBY++zB5nE/NwcaoMylSPk+S+ZHNB1TzdbMJMny6dynpAGt7X/tl/QYq3TIeE6nxHppbo2LGymrG5Pw=="],
+
+    "parent-module": ["parent-module@1.0.1", "", { "dependencies": { "callsites": "^3.0.0" } }, "sha512-GQ2EWRpQV8/o+Aw8YqtfZZPfNRWZYkbidE9k5rpl/hC3vtHHBfGm2Ifi6qWV+coDGkrUKZAxE3Lot5kcsRlh+g=="],
+
+    "path-exists": ["path-exists@4.0.0", "", {}, "sha512-ak9Qy5Q7jYb2Wwcey5Fpvg2KoAc/ZIhLSLOSBmRmygPsGwkVVt0fZa0qrtMz+m6tJTAHfZQ8FnmB4MG4LWy7/w=="],
+
+    "path-key": ["path-key@3.1.1", "", {}, "sha512-ojmeN0qd+y0jszEtoY48r0Peq5dwMEkIlCOu6Q5f41lfkswXuKtYrhgoTpLnyIcHm24Uhqx+5Tqm2InSwLhE6Q=="],
+
+    "path-parse": ["path-parse@1.0.7", "", {}, "sha512-LDJzPVEEEPR+y48z93A0Ed0yXb8pAByGWo/k5YYdYgpY2/2EsOsksJrq7lOHxryrVOn1ejG6oAp8ahvOIQD8sw=="],
+
+    "picomatch": ["picomatch@2.3.2", "", {}, "sha512-V7+vQEJ06Z+c5tSye8S+nHUfI51xoXIXjHQ99cQtKUkQqqO1kO/KCJUfZXuB47h/YBlDhah2H3hdUGXn8ie0oA=="],
+
+    "prelude-ls": ["prelude-ls@1.2.1", "", {}, "sha512-vkcDPrRZo1QZLbn5RLGPpg/WmIQ65qoWWhcGKf/b5eplkkarX0m9z8ppCat4mlOqUsWpyNuYgO3VRyrYHSzX5g=="],
+
+    "punycode": ["punycode@2.3.1", "", {}, "sha512-vYt7UD1U9Wg6138shLtLOvdAu+8DsC/ilFtEVHcH+wydcSpNE20AfSOduf6MkRFahL5FY7X1oU7nKVZFtfq8Fg=="],
+
+    "punycode.js": ["punycode.js@2.3.1", "", {}, "sha512-uxFIHU0YlHYhDQtV4R9J6a52SLx28BCjT+4ieh7IGbgwVJWO+km431c4yRlREUAsAmt/uMjQUyQHNEPf0M39CA=="],
+
+    "queue-microtask": ["queue-microtask@1.2.3", "", {}, "sha512-NuaNSa6flKT5JaSYQzJok04JzTL1CA6aGhv5rfLW3PgqA+M2ChpZQnAC8h8i4ZFkBS8X5RqkDBHA7r4hej3K9A=="],
+
+    "require-from-string": ["require-from-string@2.0.2", "", {}, "sha512-Xf0nWe6RseziFMu+Ap9biiUbmplq6S9/p+7w7YXP/JBHhrUDDUhwa+vANyubuqfZWTveU//DYVGsDG7RKL/vEw=="],
+
+    "resolve": ["resolve@1.22.12", "", { "dependencies": { "es-errors": "^1.3.0", "is-core-module": "^2.16.1", "path-parse": "^1.0.7", "supports-preserve-symlinks-flag": "^1.0.0" }, "bin": { "resolve": "bin/resolve" } }, "sha512-TyeJ1zif53BPfHootBGwPRYT1RUt6oGWsaQr8UyZW/eAm9bKoijtvruSDEmZHm92CwS9nj7/fWttqPCgzep8CA=="],
+
+    "resolve-from": ["resolve-from@4.0.0", "", {}, "sha512-pb/MYmXstAkysRFx8piNI1tGFNQIFA3vkE3Gq4EuA1dF6gHp/+vgZqsCGJapvy8N3Q+4o7FwvquPJcnZ7RYy4g=="],
+
+    "reusify": ["reusify@1.1.0", "", {}, "sha512-g6QUff04oZpHs0eG5p83rFLhHeV00ug/Yf9nZM6fLeUrPguBTkTQOdpAWWspMh55TZfVQDPaN3NQJfbVRAxdIw=="],
+
+    "run-parallel": ["run-parallel@1.2.0", "", { "dependencies": { "queue-microtask": "^1.2.2" } }, "sha512-5l4VyZR86LZ/lDxZTR6jqL8AFE2S0IFLMP26AbjsLVADxHdhB/c0GUsH+y39UfCi3dzz8OlQuPmnaJOMoDHQBA=="],
+
+    "semver": ["semver@7.7.4", "", { "bin": { "semver": "bin/semver.js" } }, "sha512-vFKC2IEtQnVhpT78h1Yp8wzwrf8CM+MzKMHGJZfBtzhZNycRFnXsHk6E5TxIkkMsgNS7mdX3AGB7x2QM2di4lA=="],
+
+    "shebang-command": ["shebang-command@2.0.0", "", { "dependencies": { "shebang-regex": "^3.0.0" } }, "sha512-kHxr2zZpYtdmrN1qDjrrX/Z1rR1kG8Dx+gkpK1G4eXmvXswmcE1hTWBWYUzlraYw1/yZp6YuDY77YtvbN0dmDA=="],
+
+    "shebang-regex": ["shebang-regex@3.0.0", "", {}, "sha512-7++dFhtcx3353uBaq8DDR4NuxBetBzC7ZQOhmTQInHEd6bSrXdiEyzCvG07Z44UYdLShWUyXt5M/yhz8ekcb1A=="],
+
+    "strip-json-comments": ["strip-json-comments@3.1.1", "", {}, "sha512-6fPc+R4ihwqP6N/aIv2f1gMH8lOVtWQHoqC4yK6oSDVVocumAsfCqjkXnqiYMhmMwS/mEHLp7Vehlt3ql6lEig=="],
+
+    "supports-color": ["supports-color@7.2.0", "", { "dependencies": { "has-flag": "^4.0.0" } }, "sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw=="],
+
+    "supports-preserve-symlinks-flag": ["supports-preserve-symlinks-flag@1.0.0", "", {}, "sha512-ot0WnXS9fgdkgIcePe6RHNk1WA8+muPa6cSjeR3V8K27q9BB1rTE3R1p7Hv0z1ZyAc8s6Vvv8DIyWf681MAt0w=="],
+
+    "to-regex-range": ["to-regex-range@5.0.1", "", { "dependencies": { "is-number": "^7.0.0" } }, "sha512-65P7iz6X5yEr1cwcgvQxbbIw7Uk3gOy5dIdtZ4rDveLqhrdJP+Li/Hx6tyK0NEb+2GCyneCMJiGqrADCSNk8sQ=="],
+
+    "ts-api-utils": ["ts-api-utils@2.5.0", "", { "peerDependencies": { "typescript": ">=4.8.4" } }, "sha512-OJ/ibxhPlqrMM0UiNHJ/0CKQkoKF243/AEmplt3qpRgkW8VG7IfOS41h7V8TjITqdByHzrjcS/2si+y4lIh8NA=="],
+
+    "type-check": ["type-check@0.4.0", "", { "dependencies": { "prelude-ls": "^1.2.1" } }, "sha512-XleUoc9uwGXqjWwXaUTZAmzMcFZ5858QA2vvx1Ur5xIcixXIP+8LnFDgRplU30us6teqdlskFfu+ae4K79Ooew=="],
+
+    "typedoc": ["typedoc@0.28.14", "", { "dependencies": { "@gerrit0/mini-shiki": "^3.12.0", "lunr": "^2.3.9", "markdown-it": "^14.1.0", "minimatch": "^9.0.5", "yaml": "^2.8.1" }, "peerDependencies": { "typescript": "5.0.x || 5.1.x || 5.2.x || 5.3.x || 5.4.x || 5.5.x || 5.6.x || 5.7.x || 5.8.x || 5.9.x" }, "bin": { "typedoc": "bin/typedoc" } }, "sha512-ftJYPvpVfQvFzpkoSfHLkJybdA/geDJ8BGQt/ZnkkhnBYoYW6lBgPQXu6vqLxO4X75dA55hX8Af847H5KXlEFA=="],
+
     "typescript": ["typescript@5.9.3", "", { "bin": { "tsc": "bin/tsc", "tsserver": "bin/tsserver" } }, "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw=="],
+
+    "uc.micro": ["uc.micro@2.1.0", "", {}, "sha512-ARDJmphmdvUk6Glw7y9DQ2bFkKBHwQHLi2lsaH6PPmz/Ka9sFOBsBluozhDltWmnv9u/cF6Rt87znRTPV+yp/A=="],
 
     "undici-types": ["undici-types@7.18.2", "", {}, "sha512-AsuCzffGHJybSaRrmr5eHr81mwJU3kjw6M+uprWvCXiNeN9SOGwQ3Jn8jb8m3Z6izVgknn1R0FTCEAP2QrLY/w=="],
 
+    "uri-js": ["uri-js@4.4.1", "", { "dependencies": { "punycode": "^2.1.0" } }, "sha512-7rKUyy33Q1yc98pQ1DAmLtwX109F7TIfWlW1Ydo8Wl1ii1SeHieeh0HHfPeL2fMXK6z0s8ecKs9frCuLJvndBg=="],
+
+    "which": ["which@2.0.2", "", { "dependencies": { "isexe": "^2.0.0" }, "bin": { "node-which": "./bin/node-which" } }, "sha512-BLI3Tl1TW3Pvl70l3yq3Y64i+awpwXqsGBYWkkqMtnbXgrMD+yj7rhW0kuEDxzJaYXGjEW5ogapKNMEKNMjibA=="],
+
+    "word-wrap": ["word-wrap@1.2.5", "", {}, "sha512-BN22B5eaMMI9UMtjrGd5g5eCYPpCPDUy0FJXbYsaT5zYxjFOckS53SQDE3pWkVoWpHXVb3BrYcEN4Twa55B5cA=="],
+
     "yaml": ["yaml@2.8.1", "", { "bin": { "yaml": "bin.mjs" } }, "sha512-lcYcMxX2PO9XMGvAJkJ3OsNMw+/7FKes7/hgerGUYWIoWu5j/+YQqcZr5JnPZWzOsEBgMbSbiSTn/dv/69Mkpw=="],
+
+    "yocto-queue": ["yocto-queue@0.1.0", "", {}, "sha512-rVksvsnNCdJ/ohGc6xgPwyN8eheCxsiLM8mxuE/t/mOVqJewPuO1miLpTHQiRgTKCLexL4MeAFVagts7HmNZ2Q=="],
+
+    "@eslint-community/eslint-utils/eslint-visitor-keys": ["eslint-visitor-keys@3.4.3", "", {}, "sha512-wpc+LXeiyiisxPlEkUzU6svyS1frIO3Mgxj1fdy7Pm8Ygzguax2N3Fa/D/ag1WqbOprdI+uY6wMUl8/a2G+iag=="],
+
+    "@eslint/config-helpers/@eslint/core": ["@eslint/core@0.17.0", "", { "dependencies": { "@types/json-schema": "^7.0.15" } }, "sha512-yL/sLrpmtDaFEiUj1osRP4TI2MDz1AddJL+jZ7KSqvBuliN4xqYY54IfdN8qD8Toa6g1iloph1fxQNkjOxrrpQ=="],
+
+    "@eslint/plugin-kit/@eslint/core": ["@eslint/core@0.17.0", "", { "dependencies": { "@types/json-schema": "^7.0.15" } }, "sha512-yL/sLrpmtDaFEiUj1osRP4TI2MDz1AddJL+jZ7KSqvBuliN4xqYY54IfdN8qD8Toa6g1iloph1fxQNkjOxrrpQ=="],
+
+    "@microsoft/tsdoc-config/ajv": ["ajv@8.12.0", "", { "dependencies": { "fast-deep-equal": "^3.1.1", "json-schema-traverse": "^1.0.0", "require-from-string": "^2.0.2", "uri-js": "^4.2.2" } }, "sha512-sRu1kpcO9yLtYxBKvqfTeh9KzZEwO3STyX1HT+4CaDzC6HpTGYhIhPIzj9XuKU7KYDwnaeh5hcOwjy1QuJzBPA=="],
+
+    "@typescript-eslint/typescript-estree/minimatch": ["minimatch@9.0.9", "", { "dependencies": { "brace-expansion": "^2.0.2" } }, "sha512-OBwBN9AL4dqmETlpS2zasx+vTeWclWzkblfZk7KTA5j3jeOONz/tRCnZomUyvNg83wL5Zv9Ss6HMJXAgL8R2Yg=="],
+
+    "fast-glob/glob-parent": ["glob-parent@5.1.2", "", { "dependencies": { "is-glob": "^4.0.1" } }, "sha512-AOIgSQCepiJYwP3ARnGx+5VnTu2HBYdzbGP45eLw1vr3zB3vZLeyed1sC9hnbcOc9/SrMyM5RPQrkGz4aS9Zow=="],
+
+    "typedoc/minimatch": ["minimatch@9.0.9", "", { "dependencies": { "brace-expansion": "^2.0.2" } }, "sha512-OBwBN9AL4dqmETlpS2zasx+vTeWclWzkblfZk7KTA5j3jeOONz/tRCnZomUyvNg83wL5Zv9Ss6HMJXAgL8R2Yg=="],
+
+    "@microsoft/tsdoc-config/ajv/json-schema-traverse": ["json-schema-traverse@1.0.0", "", {}, "sha512-NM8/P9n3XjXhIZn1lLhkFaACTOURQXjWhV4BA/RnOv8xvgqtqpAX9IO4mRQxSx1Rlo4tqzeqb0sOlruaOy3dug=="],
+
+    "@typescript-eslint/typescript-estree/minimatch/brace-expansion": ["brace-expansion@2.1.0", "", { "dependencies": { "balanced-match": "^1.0.0" } }, "sha512-TN1kCZAgdgweJhWWpgKYrQaMNHcDULHkWwQIspdtjV4Y5aurRdZpjAqn6yX3FPqTA9ngHCc4hJxMAMgGfve85w=="],
+
+    "typedoc/minimatch/brace-expansion": ["brace-expansion@2.1.0", "", { "dependencies": { "balanced-match": "^1.0.0" } }, "sha512-TN1kCZAgdgweJhWWpgKYrQaMNHcDULHkWwQIspdtjV4Y5aurRdZpjAqn6yX3FPqTA9ngHCc4hJxMAMgGfve85w=="],
   }
 }

--- a/sdk/typescript/docs/entrypoints/@valon-technologies/gestalt/index.ts
+++ b/sdk/typescript/docs/entrypoints/@valon-technologies/gestalt/index.ts
@@ -1,0 +1,25 @@
+/**
+ * Public API surface for `@valon-technologies/gestalt`.
+ *
+ * @example
+ * ```ts
+ * import { defineIntegrationProvider, ok, operation, s } from "@valon-technologies/gestalt";
+ *
+ * export const provider = defineIntegrationProvider({
+ *   displayName: "Example Provider",
+ *   operations: [
+ *     operation({
+ *       id: "hello",
+ *       input: s.object({ name: s.string({ default: "World" }) }),
+ *       output: s.object({ message: s.string() }),
+ *       async handler(input) {
+ *         return ok({ message: `Hello, ${input.name}` });
+ *       },
+ *     }),
+ *   ],
+ * });
+ * ```
+ *
+ * @module
+ */
+export * from "../../../../src/index.ts";

--- a/sdk/typescript/docs/entrypoints/build/index.ts
+++ b/sdk/typescript/docs/entrypoints/build/index.ts
@@ -1,0 +1,6 @@
+/**
+ * Build-time helpers for producing Gestalt provider binaries.
+ *
+ * @module
+ */
+export * from "../../../src/build.ts";

--- a/sdk/typescript/docs/entrypoints/runtime/index.ts
+++ b/sdk/typescript/docs/entrypoints/runtime/index.ts
@@ -1,0 +1,6 @@
+/**
+ * Runtime helpers for loading and serving Gestalt providers.
+ *
+ * @module
+ */
+export * from "../../../src/runtime.ts";

--- a/sdk/typescript/docs/entrypoints/schema/index.ts
+++ b/sdk/typescript/docs/entrypoints/schema/index.ts
@@ -1,0 +1,6 @@
+/**
+ * Schema builders for operation inputs, outputs, and catalog metadata.
+ *
+ * @module
+ */
+export * from "../../../src/schema.ts";

--- a/sdk/typescript/docs/entrypoints/target/index.ts
+++ b/sdk/typescript/docs/entrypoints/target/index.ts
@@ -1,0 +1,6 @@
+/**
+ * Utilities for parsing plugin and provider targets.
+ *
+ * @module
+ */
+export * from "../../../src/target.ts";

--- a/sdk/typescript/eslint.config.mjs
+++ b/sdk/typescript/eslint.config.mjs
@@ -1,0 +1,21 @@
+import tsParser from "@typescript-eslint/parser";
+import tsdoc from "eslint-plugin-tsdoc";
+
+export default [
+  {
+    files: ["src/**/*.ts", "docs/entrypoints/**/*.ts"],
+    languageOptions: {
+      parser: tsParser,
+      parserOptions: {
+        ecmaVersion: "latest",
+        sourceType: "module",
+      },
+    },
+    plugins: {
+      tsdoc,
+    },
+    rules: {
+      "tsdoc/syntax": "error",
+    },
+  },
+];

--- a/sdk/typescript/package.json
+++ b/sdk/typescript/package.json
@@ -29,6 +29,10 @@
   },
   "scripts": {
     "build:proto": "buf generate --template ../proto/buf.typescript.gen.yaml ../proto",
+    "docs:lint": "eslint --max-warnings=0 \"src/**/*.ts\" \"docs/entrypoints/**/*.ts\"",
+    "docs:build": "typedoc --options typedoc.json --out docs/_build/html",
+    "docs:build:deploy": "typedoc --options typedoc.json --out ../../docs/public/api/typescript",
+    "docs:check": "bun run docs:lint && bun run docs:build",
     "typecheck": "tsc --noEmit",
     "test": "bun test",
     "check": "bun test && tsc --noEmit"
@@ -40,7 +44,11 @@
     "yaml": "2.8.1"
   },
   "devDependencies": {
+    "@typescript-eslint/parser": "8.46.1",
     "@types/bun": "1.3.2",
+    "eslint": "9.38.0",
+    "eslint-plugin-tsdoc": "0.4.0",
+    "typedoc": "0.28.14",
     "typescript": "5.9.3"
   },
   "peerDependencies": {

--- a/sdk/typescript/src/api.ts
+++ b/sdk/typescript/src/api.ts
@@ -1,3 +1,6 @@
+/**
+ * Common request and response types shared across authored Gestalt providers.
+ */
 export interface Subject {
   id: string;
   kind: string;
@@ -5,6 +8,9 @@ export interface Subject {
   authSource: string;
 }
 
+/**
+ * Describes the credential Gestalt used to authorize the current request.
+ */
 export interface Credential {
   mode: string;
   subjectId: string;
@@ -12,11 +18,17 @@ export interface Credential {
   instance: string;
 }
 
+/**
+ * Describes the access policy and effective role for the current request.
+ */
 export interface Access {
   policy: string;
   role: string;
 }
 
+/**
+ * Request metadata forwarded to provider handlers by the Gestalt runtime.
+ */
 export interface Request {
   token: string;
   connectionParams: Record<string, string>;
@@ -25,21 +37,36 @@ export interface Request {
   access: Access;
 }
 
+/**
+ * Internal discriminator used by {@link response} and {@link ok}.
+ */
 export const responseBrand: unique symbol = Symbol("gestalt.response");
 
+/**
+ * Explicit handler response with an optional HTTP status override.
+ */
 export interface Response<T> {
   readonly [responseBrand]: true;
   status?: number;
   body: T;
 }
 
+/**
+ * Serialized operation result returned by the protocol runtime.
+ */
 export interface OperationResult {
   status: number;
   body: string;
 }
 
+/**
+ * Value or promise-like return accepted by provider handlers.
+ */
 export type MaybePromise<T> = T | Promise<T>;
 
+/**
+ * Wraps a handler result with an explicit status code.
+ */
 export function response<T>(status: number, body: T): Response<T> {
   return {
     [responseBrand]: true,
@@ -48,10 +75,23 @@ export function response<T>(status: number, body: T): Response<T> {
   };
 }
 
+/**
+ * Wraps a handler result with the default `200` status code.
+ */
 export function ok<T>(body: T): Response<T> {
   return response(200, body);
 }
 
+/**
+ * Creates a request object for local testing or direct provider invocation.
+ *
+ * @example
+ * ```ts
+ * import { request } from "@valon-technologies/gestalt";
+ *
+ * const input = request("token", { region: "us-east-1" }, { id: "usr_123" });
+ * ```
+ */
 export function request(
   token = "",
   connectionParams: Record<string, string> = {},
@@ -83,6 +123,9 @@ export function request(
   };
 }
 
+/**
+ * Looks up a single connection parameter from a request.
+ */
 export function connectionParam(
   input: Request | undefined,
   name: string,
@@ -90,6 +133,9 @@ export function connectionParam(
   return input?.connectionParams[name];
 }
 
+/**
+ * Normalizes unknown thrown values into a readable error message.
+ */
 export function errorMessage(error: unknown): string {
   if (error instanceof Error && error.message) {
     return error.message;

--- a/sdk/typescript/src/auth.ts
+++ b/sdk/typescript/src/auth.ts
@@ -1,6 +1,9 @@
 import { RuntimeProvider, type RuntimeProviderOptions } from "./provider.ts";
 import type { MaybePromise } from "./api.ts";
 
+/**
+ * Identity payload returned by an auth provider after a successful login.
+ */
 export interface AuthenticatedUser {
   subject: string;
   email?: string;
@@ -10,6 +13,9 @@ export interface AuthenticatedUser {
   claims?: Record<string, string>;
 }
 
+/**
+ * Input passed to an auth provider's `beginLogin` handler.
+ */
 export interface BeginLoginRequest {
   callbackUrl: string;
   hostState: string;
@@ -17,21 +23,33 @@ export interface BeginLoginRequest {
   options: Record<string, string>;
 }
 
+/**
+ * Response returned by an auth provider's `beginLogin` handler.
+ */
 export interface BeginLoginResponse {
   authorizationUrl: string;
   providerState?: Uint8Array;
 }
 
+/**
+ * Callback payload passed to an auth provider's `completeLogin` handler.
+ */
 export interface CompleteLoginRequest {
   query: Record<string, string>;
   providerState: Uint8Array;
   callbackUrl: string;
 }
 
+/**
+ * Session TTL hints exposed by an auth provider.
+ */
 export interface AuthSessionSettings {
   sessionTtlSeconds: number | bigint;
 }
 
+/**
+ * Runtime hooks required to implement a Gestalt auth provider.
+ */
 export interface AuthProviderOptions extends RuntimeProviderOptions {
   beginLogin: (
     request: BeginLoginRequest,
@@ -45,6 +63,9 @@ export interface AuthProviderOptions extends RuntimeProviderOptions {
   sessionSettings?: () => MaybePromise<AuthSessionSettings>;
 }
 
+/**
+ * Auth provider implementation consumed by the Gestalt runtime.
+ */
 export class AuthProvider extends RuntimeProvider {
   readonly kind = "auth" as const;
 
@@ -86,10 +107,33 @@ export class AuthProvider extends RuntimeProvider {
   }
 }
 
+/**
+ * Creates an auth provider with the standard Gestalt runtime contract.
+ *
+ * @example
+ * ```ts
+ * import { defineAuthProvider } from "@valon-technologies/gestalt";
+ *
+ * export const auth = defineAuthProvider({
+ *   displayName: "Example Auth",
+ *   async beginLogin(request) {
+ *     return {
+ *       authorizationUrl: new URL("/login", request.callbackUrl).toString(),
+ *     };
+ *   },
+ *   async completeLogin() {
+ *     return { subject: "usr_123", email: "user@example.com" };
+ *   },
+ * });
+ * ```
+ */
 export function defineAuthProvider(options: AuthProviderOptions): AuthProvider {
   return new AuthProvider(options);
 }
 
+/**
+ * Runtime type guard for auth providers loaded from user modules.
+ */
 export function isAuthProvider(value: unknown): value is AuthProvider {
   return (
     value instanceof AuthProvider ||

--- a/sdk/typescript/src/build.ts
+++ b/sdk/typescript/src/build.ts
@@ -5,9 +5,15 @@ import { join, resolve } from "node:path";
 
 import { parseProviderTarget, resolveProviderModulePath, type ProviderTarget } from "./target.ts";
 
+/**
+ * Command-line usage for the bundled build entrypoint.
+ */
 export const USAGE =
   "usage: bun run build.ts ROOT PROVIDER_TARGET OUTPUT PROVIDER_NAME GOOS GOARCH";
 
+/**
+ * Parsed arguments for the build entrypoint.
+ */
 export type BuildArgs = {
   root: string;
   target: string;
@@ -17,6 +23,9 @@ export type BuildArgs = {
   goarch: string;
 };
 
+/**
+ * CLI entrypoint that compiles a provider into a standalone Bun executable.
+ */
 export async function main(argv: string[] = process.argv.slice(2)): Promise<number> {
   const args = parseBuildArgs(argv);
   if (!args) {
@@ -27,6 +36,9 @@ export async function main(argv: string[] = process.argv.slice(2)): Promise<numb
   return 0;
 }
 
+/**
+ * Parses `gestalt-ts-build` CLI arguments.
+ */
 export function parseBuildArgs(argv: string[]): BuildArgs | undefined {
   if (argv.length !== 6) {
     return undefined;
@@ -41,6 +53,9 @@ export function parseBuildArgs(argv: string[]): BuildArgs | undefined {
   };
 }
 
+/**
+ * Bundles a provider into a standalone executable for the requested target.
+ */
 export function buildProviderBinary(args: BuildArgs): void {
   const root = resolve(args.root);
   const outputPath = resolve(args.outputPath);
@@ -65,8 +80,14 @@ export function buildProviderBinary(args: BuildArgs): void {
   }
 }
 
+/**
+ * Backwards-compatible alias for integration provider builds.
+ */
 export const buildPluginBinary = buildProviderBinary;
 
+/**
+ * Constructs the Bun command used to compile a provider binary.
+ */
 export function bunBuildCommand(
   wrapperPath: string,
   outputPath: string,
@@ -87,6 +108,9 @@ export function bunBuildCommand(
   };
 }
 
+/**
+ * Maps a Go-style `GOOS` / `GOARCH` target into Bun's compile target format.
+ */
 export function bunTarget(goos: string, goarch: string): string {
   const key = `${goos}/${goarch}`;
   switch (key) {

--- a/sdk/typescript/src/cache.ts
+++ b/sdk/typescript/src/cache.ts
@@ -9,15 +9,24 @@ import type { MaybePromise } from "./api.ts";
 
 const ENV_CACHE_SOCKET = "GESTALT_CACHE_SOCKET";
 
+/**
+ * Single cache entry used by batch cache APIs.
+ */
 export interface CacheEntry {
   key: string;
   value: Uint8Array;
 }
 
+/**
+ * Optional TTL applied when setting cache values.
+ */
 export interface CacheSetOptions {
   ttlMs?: number;
 }
 
+/**
+ * Runtime hooks required to implement a Gestalt cache provider.
+ */
 export interface CacheProviderOptions extends RuntimeProviderOptions {
   get: (key: string) => MaybePromise<Uint8Array | null | undefined>;
   set: (
@@ -35,6 +44,9 @@ export interface CacheProviderOptions extends RuntimeProviderOptions {
   deleteMany?: (keys: string[]) => MaybePromise<number | bigint>;
 }
 
+/**
+ * Returns the environment variable name used to discover a cache socket.
+ */
 export function cacheSocketEnv(name?: string): string {
   const trimmed = name?.trim() ?? "";
   if (!trimmed) {
@@ -43,6 +55,17 @@ export function cacheSocketEnv(name?: string): string {
   return `${ENV_CACHE_SOCKET}_${trimmed.replace(/[^A-Za-z0-9]/gu, "_").toUpperCase()}`;
 }
 
+/**
+ * Client for invoking a host-provided cache over the Gestalt transport.
+ *
+ * @example
+ * ```ts
+ * import { Cache } from "@valon-technologies/gestalt";
+ *
+ * const cache = new Cache();
+ * await cache.set("session", new TextEncoder().encode("hello"));
+ * ```
+ */
 export class Cache {
   private readonly client: Client<typeof CacheService>;
 
@@ -127,6 +150,9 @@ export class Cache {
   }
 }
 
+/**
+ * Cache provider implementation consumed by the Gestalt runtime.
+ */
 export class CacheProvider extends RuntimeProvider {
   readonly kind = "cache" as const;
 
@@ -219,10 +245,16 @@ export class CacheProvider extends RuntimeProvider {
   }
 }
 
+/**
+ * Creates a cache provider from standard CRUD handlers.
+ */
 export function defineCacheProvider(options: CacheProviderOptions): CacheProvider {
   return new CacheProvider(options);
 }
 
+/**
+ * Runtime type guard for cache providers loaded from user modules.
+ */
 export function isCacheProvider(value: unknown): value is CacheProvider {
   return (
     value instanceof CacheProvider ||

--- a/sdk/typescript/src/catalog.ts
+++ b/sdk/typescript/src/catalog.ts
@@ -4,6 +4,9 @@ import YAML from "yaml";
 
 import type { Schema } from "./schema.ts";
 
+/**
+ * Query-style parameter metadata derived from a Gestalt schema.
+ */
 export interface CatalogParameter {
   name: string;
   type: string;
@@ -12,6 +15,9 @@ export interface CatalogParameter {
   default?: unknown;
 }
 
+/**
+ * JSON-schema-like description used in provider catalogs.
+ */
 export interface CatalogSchema {
   type: string;
   description?: string;
@@ -21,6 +27,9 @@ export interface CatalogSchema {
   items?: CatalogSchema;
 }
 
+/**
+ * Static operation metadata emitted by a provider catalog.
+ */
 export interface CatalogOperation {
   id: string;
   method: string;
@@ -35,6 +44,9 @@ export interface CatalogOperation {
   allowedRoles?: string[];
 }
 
+/**
+ * Static provider catalog emitted to the Gestalt host.
+ */
 export interface Catalog {
   name?: string;
   displayName?: string;
@@ -43,6 +55,9 @@ export interface Catalog {
   operations: CatalogOperation[];
 }
 
+/**
+ * Extracts top-level parameter metadata from an object schema.
+ */
 export function schemaToParameters(
   schema: Schema<unknown> | undefined,
 ): CatalogParameter[] {
@@ -67,6 +82,9 @@ export function schemaToParameters(
   });
 }
 
+/**
+ * Converts a runtime schema into catalog-friendly metadata.
+ */
 export function schemaToCatalogSchema(
   schema: Schema<unknown> | undefined,
 ): CatalogSchema | undefined {
@@ -102,6 +120,9 @@ export function schemaToCatalogSchema(
   return output;
 }
 
+/**
+ * Serializes a catalog to JSON for host consumption.
+ */
 export function catalogToJson(
   catalog: Catalog | Record<string, unknown> | null | undefined,
 ): string {
@@ -111,12 +132,18 @@ export function catalogToJson(
   return JSON.stringify(toCatalogJsonObject(catalog));
 }
 
+/**
+ * Serializes a catalog to YAML for release artifacts.
+ */
 export function catalogToYaml(
   catalog: Catalog | Record<string, unknown>,
 ): string {
   return YAML.stringify(toCatalogJsonObject(catalog));
 }
 
+/**
+ * Writes a catalog to disk as YAML.
+ */
 export function writeCatalogYaml(
   path: string,
   catalog: Catalog | Record<string, unknown>,

--- a/sdk/typescript/src/index.ts
+++ b/sdk/typescript/src/index.ts
@@ -1,3 +1,33 @@
+/**
+ * @packageDocumentation
+ *
+ * Authored TypeScript APIs for building Gestalt providers, helper CLIs, and
+ * runtime adapters.
+ *
+ * @example
+ * ```ts
+ * import { defineIntegrationProvider, ok, operation, s } from "@valon-technologies/gestalt";
+ *
+ * export const provider = defineIntegrationProvider({
+ *   displayName: "Example Provider",
+ *   operations: [
+ *     operation({
+ *       id: "hello",
+ *       input: s.object({ name: s.string({ default: "World" }) }),
+ *       output: s.object({ message: s.string() }),
+ *       async handler(input) {
+ *         return ok({ message: `Hello, ${input.name}` });
+ *       },
+ *     }),
+ *   ],
+ * });
+ * ```
+ *
+ * @example
+ * ```ts
+ * import { parseRuntimeArgs, serve } from "@valon-technologies/gestalt/runtime";
+ * ```
+ */
 export {
   connectionParam,
   ok,
@@ -124,6 +154,7 @@ export {
   formatModuleTarget,
   formatProviderTarget,
   parseModuleTarget,
+  parsePluginTarget,
   parseProviderTarget,
   readPackageConfig,
   readPackagePluginTarget,

--- a/sdk/typescript/src/indexeddb.ts
+++ b/sdk/typescript/src/indexeddb.ts
@@ -7,6 +7,9 @@ import {
 
 const ENV_INDEXEDDB_SOCKET = "GESTALT_INDEXEDDB_SOCKET";
 
+/**
+ * Returns the environment variable name used to discover an IndexedDB socket.
+ */
 export function indexedDBSocketEnv(name?: string): string {
   const trimmed = name?.trim() ?? "";
   if (!trimmed) return ENV_INDEXEDDB_SOCKET;
@@ -64,6 +67,9 @@ class AsyncQueue<T> implements AsyncIterable<T> {
   }
 }
 
+/**
+ * Cursor iteration direction.
+ */
 export enum CursorDirection {
   Next = 0,
   NextUnique = 1,
@@ -78,11 +84,17 @@ const CURSOR_DIRECTION_TO_PROTO: { [K in CursorDirection]: ProtoCursorDirection 
   [CursorDirection.PrevUnique]: ProtoCursorDirection.CURSOR_PREV_UNIQUE,
 };
 
+/**
+ * Options for opening a cursor over an object store or index.
+ */
 export interface OpenCursorOptions {
   range?: KeyRange;
   direction?: CursorDirection;
 }
 
+/**
+ * Streaming cursor over an object store or secondary index.
+ */
 export class Cursor {
   private sendQueue: AsyncQueue<any>;
   private responseIterator: AsyncIterator<any>;
@@ -103,6 +115,11 @@ export class Cursor {
     this._indexCursor = indexCursor;
   }
 
+  /**
+   * Opens a low-level cursor stream for object-store and index helpers.
+   *
+   * @internal
+   */
   static async open(
     client: Client<typeof IndexedDBService>,
     store: string,
@@ -135,22 +152,37 @@ export class Cursor {
     return cursor;
   }
 
+  /**
+   * Current cursor key.
+   */
   get key(): unknown {
     return this._key;
   }
 
+  /**
+   * Current primary key for the pointed record.
+   */
   get primaryKey(): string {
     return this._primaryKey;
   }
 
+  /**
+   * Current record value.
+   */
   get value(): Record | undefined {
     return this._value;
   }
 
+  /**
+   * Whether the cursor has reached the end of the stream.
+   */
   get done(): boolean {
     return this._done;
   }
 
+  /**
+   * Advances the cursor to the next entry.
+   */
   async continue(): Promise<boolean> {
     this.sendQueue.push({
       msg: { case: "command" as const, value: { command: { case: "next" as const, value: true } } },
@@ -158,6 +190,9 @@ export class Cursor {
     return this.pull();
   }
 
+  /**
+   * Advances the cursor to a specific key.
+   */
   async continueToKey(key: unknown): Promise<boolean> {
     this.sendQueue.push({
       msg: {
@@ -173,6 +208,9 @@ export class Cursor {
     return this.pull();
   }
 
+  /**
+   * Advances the cursor by `count` entries.
+   */
   async advance(count: number): Promise<boolean> {
     this.sendQueue.push({
       msg: {
@@ -183,6 +221,9 @@ export class Cursor {
     return this.pull();
   }
 
+  /**
+   * Deletes the current entry.
+   */
   async delete(): Promise<void> {
     if (this._done) throw new NotFoundError("cursor is exhausted");
     this.sendQueue.push({
@@ -194,6 +235,9 @@ export class Cursor {
     await this.recvMutationAck();
   }
 
+  /**
+   * Updates the current entry with a replacement record.
+   */
   async update(record: Record): Promise<void> {
     if (this._done) throw new NotFoundError("cursor is exhausted");
     this.sendQueue.push({
@@ -205,6 +249,9 @@ export class Cursor {
     await this.recvMutationAck();
   }
 
+  /**
+   * Closes the cursor stream.
+   */
   close(): void {
     this.sendQueue.push({
       msg: {
@@ -310,6 +357,9 @@ export class Cursor {
   }
 }
 
+/**
+ * Error returned when an IndexedDB record cannot be found.
+ */
 export class NotFoundError extends Error {
   constructor(message?: string) {
     super(message ?? "not found");
@@ -317,6 +367,9 @@ export class NotFoundError extends Error {
   }
 }
 
+/**
+ * Error returned when a write conflicts with an existing unique value.
+ */
 export class AlreadyExistsError extends Error {
   constructor(message?: string) {
     super(message ?? "already exists");
@@ -324,8 +377,14 @@ export class AlreadyExistsError extends Error {
   }
 }
 
+/**
+ * Plain object record stored in IndexedDB.
+ */
 export type Record = { [key: string]: unknown };
 
+/**
+ * Key range used to filter object store and index operations.
+ */
 export interface KeyRange {
   lower?: unknown;
   upper?: unknown;
@@ -333,12 +392,18 @@ export interface KeyRange {
   upperOpen?: boolean;
 }
 
+/**
+ * Secondary index definition for an object store.
+ */
 export interface IndexSchema {
   name: string;
   keyPath: string[];
   unique?: boolean;
 }
 
+/**
+ * Column type metadata used by the datastore schema.
+ */
 export enum ColumnType {
   String = 0,
   Int = 1,
@@ -349,6 +414,9 @@ export enum ColumnType {
   JSON = 6,
 }
 
+/**
+ * Column definition for an object store schema.
+ */
 export interface ColumnSchema {
   name: string;
   type?: ColumnType;
@@ -357,11 +425,25 @@ export interface ColumnSchema {
   unique?: boolean;
 }
 
+/**
+ * Object store schema used during store creation.
+ */
 export interface ObjectStoreSchema {
   indexes?: IndexSchema[];
   columns?: ColumnSchema[];
 }
 
+/**
+ * Client for invoking a host-provided IndexedDB service over the Gestalt transport.
+ *
+ * @example
+ * ```ts
+ * import { IndexedDB } from "@valon-technologies/gestalt";
+ *
+ * const db = new IndexedDB();
+ * const todos = db.objectStore("todos");
+ * ```
+ */
 export class IndexedDB {
   private client: Client<typeof IndexedDBService>;
 
@@ -378,6 +460,9 @@ export class IndexedDB {
     this.client = createClient(IndexedDBService, transport);
   }
 
+  /**
+   * Creates an object store.
+   */
   async createObjectStore(name: string, schema?: ObjectStoreSchema): Promise<void> {
     await this.client.createObjectStore({
       name,
@@ -398,47 +483,80 @@ export class IndexedDB {
     });
   }
 
+  /**
+   * Deletes an object store.
+   */
   async deleteObjectStore(name: string): Promise<void> {
     await this.client.deleteObjectStore({ name });
   }
 
+  /**
+   * Returns a client bound to a single object store.
+   */
   objectStore(name: string): ObjectStore {
     return new ObjectStore(this.client, name);
   }
 }
 
+/**
+ * Object store client used for primary-key operations.
+ */
 export class ObjectStore {
+  /**
+   * @internal
+   */
   constructor(
     private client: Client<typeof IndexedDBService>,
     private store: string,
   ) {}
 
+  /**
+   * Reads a record by primary key.
+   */
   async get(id: string): Promise<Record> {
     const resp = await rpc(() => this.client.get({ store: this.store, id }));
     return fromProtoRecord(resp.record);
   }
 
+  /**
+   * Reads the generated primary key for a record.
+   */
   async getKey(id: string): Promise<string> {
     const resp = await rpc(() => this.client.getKey({ store: this.store, id }));
     return resp.key;
   }
 
+  /**
+   * Inserts a new record and fails if it already exists.
+   */
   async add(record: Record): Promise<void> {
     await rpc(() => this.client.add({ store: this.store, record: toProtoRecord(record) }));
   }
 
+  /**
+   * Inserts or replaces a record.
+   */
   async put(record: Record): Promise<void> {
     await rpc(() => this.client.put({ store: this.store, record: toProtoRecord(record) }));
   }
 
+  /**
+   * Deletes a record by primary key.
+   */
   async delete(id: string): Promise<void> {
     await rpc(() => this.client.delete({ store: this.store, id }));
   }
 
+  /**
+   * Removes all records from the object store.
+   */
   async clear(): Promise<void> {
     await this.client.clear({ store: this.store });
   }
 
+  /**
+   * Reads all records in the object store or within a key range.
+   */
   async getAll(keyRange?: KeyRange): Promise<Record[]> {
     const resp = await this.client.getAll({
       store: this.store,
@@ -447,6 +565,9 @@ export class ObjectStore {
     return resp.records.map((r) => fromProtoRecord(r));
   }
 
+  /**
+   * Reads all primary keys in the object store or within a key range.
+   */
   async getAllKeys(keyRange?: KeyRange): Promise<string[]> {
     const resp = await this.client.getAllKeys({
       store: this.store,
@@ -455,6 +576,9 @@ export class ObjectStore {
     return resp.keys;
   }
 
+  /**
+   * Counts records in the object store or within a key range.
+   */
   async count(keyRange?: KeyRange): Promise<number> {
     const resp = await this.client.count({
       store: this.store,
@@ -463,6 +587,9 @@ export class ObjectStore {
     return Number(resp.count);
   }
 
+  /**
+   * Deletes records within a key range.
+   */
   async deleteRange(keyRange: KeyRange): Promise<number> {
     const resp = await this.client.deleteRange({
       store: this.store,
@@ -471,26 +598,44 @@ export class ObjectStore {
     return Number(resp.deleted);
   }
 
+  /**
+   * Opens a cursor over the object store.
+   */
   async openCursor(options?: OpenCursorOptions): Promise<Cursor | null> {
     return Cursor.open(this.client, this.store, options);
   }
 
+  /**
+   * Opens a key-only cursor over the object store.
+   */
   async openKeyCursor(options?: OpenCursorOptions): Promise<Cursor | null> {
     return Cursor.open(this.client, this.store, { ...options, keysOnly: true });
   }
 
+  /**
+   * Returns a client bound to a secondary index.
+   */
   index(name: string): Index {
     return new Index(this.client, this.store, name);
   }
 }
 
+/**
+ * Secondary-index client used for lookup and cursor operations.
+ */
 export class Index {
+  /**
+   * @internal
+   */
   constructor(
     private client: Client<typeof IndexedDBService>,
     private store: string,
     private indexName: string,
   ) {}
 
+  /**
+   * Reads the first record matching the supplied index values.
+   */
   async get(...values: unknown[]): Promise<Record> {
     const resp = await rpc(() =>
       this.client.indexGet({
@@ -502,6 +647,9 @@ export class Index {
     return fromProtoRecord(resp.record);
   }
 
+  /**
+   * Reads the primary key for the first matching index entry.
+   */
   async getKey(...values: unknown[]): Promise<string> {
     const resp = await rpc(() =>
       this.client.indexGetKey({
@@ -513,6 +661,9 @@ export class Index {
     return resp.key;
   }
 
+  /**
+   * Reads all records matching the supplied index values and optional range.
+   */
   async getAll(keyRange?: KeyRange, ...values: unknown[]): Promise<Record[]> {
     const resp = await this.client.indexGetAll({
       store: this.store,
@@ -523,6 +674,9 @@ export class Index {
     return resp.records.map((r) => fromProtoRecord(r));
   }
 
+  /**
+   * Reads all primary keys matching the supplied index values and optional range.
+   */
   async getAllKeys(keyRange?: KeyRange, ...values: unknown[]): Promise<string[]> {
     const resp = await this.client.indexGetAllKeys({
       store: this.store,
@@ -533,6 +687,9 @@ export class Index {
     return resp.keys;
   }
 
+  /**
+   * Counts records matching the supplied index values and optional range.
+   */
   async count(keyRange?: KeyRange, ...values: unknown[]): Promise<number> {
     const resp = await this.client.indexCount({
       store: this.store,
@@ -543,6 +700,9 @@ export class Index {
     return Number(resp.count);
   }
 
+  /**
+   * Deletes records matching the supplied index values.
+   */
   async delete(...values: unknown[]): Promise<number> {
     const resp = await this.client.indexDelete({
       store: this.store,
@@ -552,6 +712,9 @@ export class Index {
     return Number(resp.deleted);
   }
 
+  /**
+   * Opens a cursor over the index.
+   */
   async openCursor(options?: OpenCursorOptions, ...values: unknown[]): Promise<Cursor | null> {
     return Cursor.open(this.client, this.store, {
       ...options,
@@ -560,6 +723,9 @@ export class Index {
     });
   }
 
+  /**
+   * Opens a key-only cursor over the index.
+   */
   async openKeyCursor(options?: OpenCursorOptions, ...values: unknown[]): Promise<Cursor | null> {
     return Cursor.open(this.client, this.store, {
       ...options,

--- a/sdk/typescript/src/plugin.ts
+++ b/sdk/typescript/src/plugin.ts
@@ -18,6 +18,9 @@ import {
 import { RuntimeProvider, type RuntimeProviderOptions } from "./provider.ts";
 import type { Schema } from "./schema.ts";
 
+/**
+ * How an integration provider expects to authenticate or connect.
+ */
 export type ConnectionMode =
   | "unspecified"
   | "none"
@@ -25,6 +28,9 @@ export type ConnectionMode =
   | "identity"
   | "either";
 
+/**
+ * Metadata for a single connection parameter exposed by a provider.
+ */
 export interface ConnectionParamDefinition {
   required?: boolean;
   description?: string;
@@ -33,6 +39,9 @@ export interface ConnectionParamDefinition {
   field?: string;
 }
 
+/**
+ * Operation definition accepted by {@link operation} and {@link definePlugin}.
+ */
 export interface OperationOptions<In, Out> {
   id: string;
   method?: string;
@@ -47,16 +56,29 @@ export interface OperationOptions<In, Out> {
   handler: (input: In, request: Request) => MaybePromise<Out | Response<Out>>;
 }
 
+/**
+ * Normalized integration operation definition.
+ */
 export interface OperationDefinition<In, Out> extends OperationOptions<
   In,
   Out
 > {}
 
+/**
+ * Session-specific catalog payload returned by a provider at runtime.
+ */
 export type SessionCatalog = Catalog | Record<string, unknown>;
+
+/**
+ * Callback used to resolve a catalog for an authenticated request context.
+ */
 export type SessionCatalogHandler = (
   request: Request,
 ) => MaybePromise<SessionCatalog | null | undefined>;
 
+/**
+ * Runtime hooks required to implement an integration provider.
+ */
 export interface PluginDefinitionOptions extends RuntimeProviderOptions {
   connectionMode?: ConnectionMode;
   authTypes?: string[];
@@ -66,8 +88,14 @@ export interface PluginDefinitionOptions extends RuntimeProviderOptions {
   sessionCatalog?: SessionCatalogHandler;
 }
 
+/**
+ * Alias for integration providers to mirror the Go and Python SDKs.
+ */
 export type IntegrationProviderOptions = PluginDefinitionOptions;
 
+/**
+ * Normalizes an integration operation definition.
+ */
 export function operation<In, Out>(
   options: OperationOptions<In, Out>,
 ): OperationDefinition<In, Out> {
@@ -82,6 +110,30 @@ export function operation<In, Out>(
   };
 }
 
+/**
+ * Integration provider implementation consumed by the Gestalt runtime.
+ *
+ * @example
+ * ```ts
+ * import { defineIntegrationProvider, ok, operation, s } from "@valon-technologies/gestalt";
+ *
+ * export const provider = defineIntegrationProvider({
+ *   displayName: "Example Provider",
+ *   operations: [
+ *     operation({
+ *       id: "ping",
+ *       method: "GET",
+ *       readOnly: true,
+ *       input: s.object({ name: s.string({ default: "World" }) }),
+ *       output: s.object({ message: s.string() }),
+ *       async handler(input) {
+ *         return ok({ message: `Hello, ${input.name}` });
+ *       },
+ *     }),
+ *   ],
+ * });
+ * ```
+ */
 export class IntegrationProvider extends RuntimeProvider {
   readonly kind = "integration" as const;
   readonly iconSvg: string;
@@ -123,16 +175,25 @@ export class IntegrationProvider extends RuntimeProvider {
     }
   }
 
+  /**
+   * Reports whether the provider exposes a session-specific catalog.
+   */
   supportsSessionCatalog(): boolean {
     return this.sessionCatalogHandler !== undefined;
   }
 
+  /**
+   * Resolves a catalog for the current request context, if configured.
+   */
   async catalogForRequest(
     request: Request,
   ): Promise<SessionCatalog | null | undefined> {
     return await this.sessionCatalogHandler?.(request);
   }
 
+  /**
+   * Returns the static catalog emitted during provider startup.
+   */
   staticCatalog(): Catalog {
     const catalog: Catalog = {
       operations: [...this.operations.values()].map<CatalogOperation>(
@@ -197,14 +258,23 @@ export class IntegrationProvider extends RuntimeProvider {
     return catalog;
   }
 
+  /**
+   * Writes the provider's static catalog to disk as YAML.
+   */
   writeCatalog(path: string): void {
     writeCatalogYaml(path, this.staticCatalog());
   }
 
+  /**
+   * Returns the static catalog serialized as JSON.
+   */
   catalogJson(): string {
     return catalogToJson(this.staticCatalog());
   }
 
+  /**
+   * Executes an operation against validated input and request metadata.
+   */
   async execute(
     operationId: string,
     params: Record<string, unknown>,
@@ -244,20 +314,32 @@ export class IntegrationProvider extends RuntimeProvider {
   }
 }
 
+/**
+ * Backwards-compatible alias for the integration provider class.
+ */
 export const Plugin = IntegrationProvider;
 
+/**
+ * Creates an integration provider.
+ */
 export function defineIntegrationProvider(
   options: PluginDefinitionOptions,
 ): IntegrationProvider {
   return new IntegrationProvider(options);
 }
 
+/**
+ * Backwards-compatible alias for {@link defineIntegrationProvider}.
+ */
 export function definePlugin(
   options: PluginDefinitionOptions,
 ): IntegrationProvider {
   return new IntegrationProvider(options);
 }
 
+/**
+ * Runtime type guard for integration providers loaded from user modules.
+ */
 export function isIntegrationProvider(
   value: unknown,
 ): value is IntegrationProvider {
@@ -353,6 +435,9 @@ function errorResult(status: number, message: string): OperationResult {
   };
 }
 
+/**
+ * Converts a connection mode into the shared protocol enum value.
+ */
 export function connectionModeToProtoValue(mode: ConnectionMode): number {
   switch (mode) {
     case "none":
@@ -369,6 +454,9 @@ export function connectionModeToProtoValue(mode: ConnectionMode): number {
   }
 }
 
+/**
+ * Converts a connection parameter definition into protocol wire metadata.
+ */
 export function connectionParamToProto(value: ConnectionParamDefinition): {
   required?: boolean;
   description?: string;

--- a/sdk/typescript/src/provider.ts
+++ b/sdk/typescript/src/provider.ts
@@ -1,5 +1,8 @@
 import type { MaybePromise } from "./api.ts";
 
+/**
+ * Provider kinds supported by the TypeScript SDK runtime.
+ */
 export type ProviderKind =
   | "integration"
   | "auth"
@@ -8,6 +11,9 @@ export type ProviderKind =
   | "s3"
   | "telemetry";
 
+/**
+ * Runtime metadata reported to the Gestalt host during startup.
+ */
 export type ProviderMetadata = {
   kind?: ProviderKind;
   name?: string;
@@ -16,17 +22,32 @@ export type ProviderMetadata = {
   version?: string;
 };
 
+/**
+ * Optional configuration hook invoked after the host starts the provider.
+ */
 export type ConfigureHandler = (
   name: string,
   config: Record<string, unknown>,
 ) => MaybePromise<void>;
 
+/**
+ * Optional readiness probe invoked by the Gestalt host.
+ */
 export type HealthCheckHandler = () => MaybePromise<void>;
 
+/**
+ * Optional callback that returns non-fatal runtime warnings.
+ */
 export type WarningsHandler = () => MaybePromise<string[]>;
 
+/**
+ * Optional shutdown hook invoked when the provider process exits.
+ */
 export type CloseHandler = () => MaybePromise<void>;
 
+/**
+ * Shared runtime metadata and lifecycle hooks for authored providers.
+ */
 export interface RuntimeProviderOptions {
   name?: string;
   displayName?: string;
@@ -38,6 +59,9 @@ export interface RuntimeProviderOptions {
   close?: CloseHandler;
 }
 
+/**
+ * Base class shared by all TypeScript SDK provider implementations.
+ */
 export abstract class RuntimeProvider {
   abstract readonly kind: ProviderKind;
 
@@ -116,6 +140,9 @@ export abstract class RuntimeProvider {
   }
 }
 
+/**
+ * Runtime type guard for values that implement the provider base contract.
+ */
 export function isRuntimeProvider(value: unknown): value is RuntimeProvider {
   return (
     value instanceof RuntimeProvider ||
@@ -127,6 +154,9 @@ export function isRuntimeProvider(value: unknown): value is RuntimeProvider {
   );
 }
 
+/**
+ * Normalizes package and provider names into Gestalt's slug format.
+ */
 export function slugName(value: string): string {
   const normalized = value.trim().replace(/^@[^/]+\//, "");
   return normalized.replace(/[^A-Za-z0-9._-]+/g, "-").replace(/^-+|-+$/g, "");

--- a/sdk/typescript/src/runtime.ts
+++ b/sdk/typescript/src/runtime.ts
@@ -79,17 +79,38 @@ import {
   resolveProviderImportUrl,
 } from "./target.ts";
 
+/**
+ * Environment variable containing the Unix socket path for a running provider.
+ */
 export const ENV_PROVIDER_SOCKET = "GESTALT_PLUGIN_SOCKET";
+/**
+ * Environment variable containing the parent process ID supplied by the host.
+ */
 export const ENV_PROVIDER_PARENT_PID = "GESTALT_PLUGIN_PARENT_PID";
+/**
+ * Environment variable used to request static catalog generation.
+ */
 export const ENV_WRITE_CATALOG = "GESTALT_PLUGIN_WRITE_CATALOG";
+/**
+ * Protocol version currently implemented by the TypeScript runtime.
+ */
 export const CURRENT_PROTOCOL_VERSION = 2;
+/**
+ * Command-line usage for the runtime entrypoint.
+ */
 export const USAGE = "usage: bun run runtime.ts ROOT PROVIDER_TARGET";
 
+/**
+ * Parsed arguments for the runtime entrypoint.
+ */
 export type RuntimeArgs = {
   root: string;
   target: string;
 };
 
+/**
+ * Provider implementations supported by the runtime host.
+ */
 export type LoadedProvider =
   | IntegrationProvider
   | AuthProvider
@@ -97,6 +118,9 @@ export type LoadedProvider =
   | SecretsProvider
   | S3Provider;
 
+/**
+ * CLI entrypoint that loads a provider from source and starts serving it.
+ */
 export async function main(
   argv: string[] = process.argv.slice(2),
 ): Promise<number> {
@@ -112,6 +136,9 @@ export async function main(
   return 0;
 }
 
+/**
+ * Parses `gestalt-ts-runtime` CLI arguments.
+ */
 export function parseRuntimeArgs(argv: string[]): RuntimeArgs | undefined {
   if (argv.length !== 2) {
     return undefined;
@@ -122,6 +149,9 @@ export function parseRuntimeArgs(argv: string[]): RuntimeArgs | undefined {
   };
 }
 
+/**
+ * Loads any supported provider kind from a package root and optional target.
+ */
 export async function loadProviderFromTarget(
   root: string,
   rawTarget?: string,
@@ -192,6 +222,9 @@ export async function loadProviderFromTarget(
   }
 }
 
+/**
+ * Loads an integration provider from a package root and optional target.
+ */
 export async function loadPluginFromTarget(
   root: string,
   rawTarget?: string,
@@ -203,6 +236,9 @@ export async function loadPluginFromTarget(
   return provider;
 }
 
+/**
+ * Runs a provider that has already been loaded into memory.
+ */
 export async function runLoadedProvider(
   provider: LoadedProvider,
   options: {
@@ -230,6 +266,9 @@ export async function runLoadedProvider(
   await serve(provider);
 }
 
+/**
+ * Runs an integration provider that has already been loaded into memory.
+ */
 export async function runLoadedPlugin(
   plugin: IntegrationProvider,
   options: {
@@ -250,6 +289,9 @@ export async function runLoadedPlugin(
   await runLoadedProvider(plugin, runtimeOptions);
 }
 
+/**
+ * Runs a bundled provider export after validating its provider kind.
+ */
 export async function runBundledProvider(
   provider: unknown,
   kind: ProviderKind,
@@ -306,6 +348,9 @@ export async function runBundledProvider(
   });
 }
 
+/**
+ * Runs a bundled integration provider export.
+ */
 export async function runBundledPlugin(
   plugin: unknown,
   pluginName: string,
@@ -313,6 +358,9 @@ export async function runBundledPlugin(
   await runBundledProvider(plugin, "integration", pluginName);
 }
 
+/**
+ * Starts serving a provider over the Gestalt Unix socket transport.
+ */
 export async function serve(provider: LoadedProvider): Promise<void> {
   const socketPath = process.env[ENV_PROVIDER_SOCKET];
   if (!socketPath) {
@@ -392,6 +440,11 @@ export async function serve(provider: LoadedProvider): Promise<void> {
   }
 }
 
+/**
+ * Adapts the provider lifecycle service used during startup and health checks.
+ *
+ * @internal
+ */
 export function createRuntimeService(
   provider: LoadedProvider,
 ): Partial<ServiceImpl<typeof ProviderLifecycle>> {
@@ -451,6 +504,11 @@ export function createRuntimeService(
   };
 }
 
+/**
+ * Adapts an integration provider to the shared protocol service implementation.
+ *
+ * @internal
+ */
 export function createProviderService(
   provider: IntegrationProvider,
 ): Partial<ServiceImpl<typeof IntegrationProviderService>> {
@@ -542,6 +600,11 @@ export function createProviderService(
   };
 }
 
+/**
+ * Adapts an auth provider to the shared protocol service implementation.
+ *
+ * @internal
+ */
 export function createAuthService(
   provider: AuthProvider,
 ): Partial<ServiceImpl<typeof AuthProviderService>> {
@@ -610,6 +673,11 @@ export function createAuthService(
   };
 }
 
+/**
+ * Adapts a cache provider to the shared protocol service implementation.
+ *
+ * @internal
+ */
 export function createCacheService(
   provider: CacheProvider,
 ): Partial<ServiceImpl<typeof CacheService>> {
@@ -674,6 +742,11 @@ export function createCacheService(
   };
 }
 
+/**
+ * Adapts a secrets provider to the shared protocol service implementation.
+ *
+ * @internal
+ */
 export function createSecretsService(
   provider: SecretsProvider,
 ): Partial<ServiceImpl<typeof SecretsProviderService>> {
@@ -687,6 +760,9 @@ export function createSecretsService(
   };
 }
 
+/**
+ * Serializes an integration provider's static catalog as YAML.
+ */
 export function pluginCatalogYaml(plugin: IntegrationProvider): string {
   return catalogToYaml(plugin.staticCatalog());
 }

--- a/sdk/typescript/src/s3.ts
+++ b/sdk/typescript/src/s3.ts
@@ -28,12 +28,18 @@ const ENV_S3_SOCKET = "GESTALT_S3_SOCKET";
 const WRITE_CHUNK_SIZE = 64 * 1024;
 const textEncoder = new TextEncoder();
 
+/**
+ * Returns the environment variable name used to discover an S3 socket.
+ */
 export function s3SocketEnv(name?: string): string {
   const trimmed = name?.trim() ?? "";
   if (!trimmed) return ENV_S3_SOCKET;
   return `${ENV_S3_SOCKET}_${trimmed.replace(/[^A-Za-z0-9]/g, "_").toUpperCase()}`;
 }
 
+/**
+ * Error returned when an object reference does not exist.
+ */
 export class S3NotFoundError extends Error {
   constructor(message?: string) {
     super(message ?? "s3: not found");
@@ -41,6 +47,9 @@ export class S3NotFoundError extends Error {
   }
 }
 
+/**
+ * Error returned when conditional read or write preconditions fail.
+ */
 export class S3PreconditionFailedError extends Error {
   constructor(message?: string) {
     super(message ?? "s3: precondition failed");
@@ -48,6 +57,9 @@ export class S3PreconditionFailedError extends Error {
   }
 }
 
+/**
+ * Error returned when the requested byte range is invalid.
+ */
 export class S3InvalidRangeError extends Error {
   constructor(message?: string) {
     super(message ?? "s3: invalid range");
@@ -55,12 +67,18 @@ export class S3InvalidRangeError extends Error {
   }
 }
 
+/**
+ * Identifies a concrete object or object version.
+ */
 export interface ObjectRef {
   bucket: string;
   key: string;
   versionId?: string;
 }
 
+/**
+ * Metadata returned for an S3 object.
+ */
 export interface ObjectMeta {
   ref: ObjectRef;
   etag: string;
@@ -71,11 +89,17 @@ export interface ObjectMeta {
   storageClass: string;
 }
 
+/**
+ * Byte range for partial object reads.
+ */
 export interface ByteRange {
   start?: number | bigint;
   end?: number | bigint;
 }
 
+/**
+ * Conditional and range options for reads.
+ */
 export interface ReadOptions {
   range?: ByteRange;
   ifMatch?: string;
@@ -84,6 +108,9 @@ export interface ReadOptions {
   ifUnmodifiedSince?: Date;
 }
 
+/**
+ * Optional headers and conditions for writes.
+ */
 export interface WriteOptions {
   contentType?: string;
   cacheControl?: string;
@@ -95,6 +122,9 @@ export interface WriteOptions {
   ifNoneMatch?: string;
 }
 
+/**
+ * Listing options for object pagination and prefix filtering.
+ */
 export interface ListOptions {
   bucket: string;
   prefix?: string;
@@ -104,6 +134,9 @@ export interface ListOptions {
   maxKeys?: number;
 }
 
+/**
+ * Single page of results returned by {@link S3.listObjects}.
+ */
 export interface ListPage {
   objects: ObjectMeta[];
   commonPrefixes: string[];
@@ -111,11 +144,17 @@ export interface ListPage {
   hasMore: boolean;
 }
 
+/**
+ * Conditional options for server-side copy operations.
+ */
 export interface CopyOptions {
   ifMatch?: string;
   ifNoneMatch?: string;
 }
 
+/**
+ * Supported presign methods.
+ */
 export enum PresignMethod {
   Get = "GET",
   Put = "PUT",
@@ -123,6 +162,9 @@ export enum PresignMethod {
   Head = "HEAD",
 }
 
+/**
+ * Options used when generating a presigned URL.
+ */
 export interface PresignOptions {
   method?: PresignMethod;
   expiresSeconds?: number | bigint;
@@ -131,6 +173,9 @@ export interface PresignOptions {
   headers?: Record<string, string>;
 }
 
+/**
+ * Result returned by {@link S3.presignObject} or {@link S3Object.presign}.
+ */
 export interface PresignResult {
   url: string;
   method: PresignMethod;
@@ -138,6 +183,9 @@ export interface PresignResult {
   headers: Record<string, string>;
 }
 
+/**
+ * Accepted write body sources for the S3 client.
+ */
 export type S3BodySource =
   | string
   | Uint8Array
@@ -149,16 +197,25 @@ export type S3BodySource =
   | null
   | undefined;
 
+/**
+ * Streaming read result returned by the S3 client.
+ */
 export interface ReadResult {
   meta: ObjectMeta;
   stream: AsyncIterable<Uint8Array>;
 }
 
+/**
+ * Result returned by an authored S3 provider implementation.
+ */
 export interface ProviderReadResult {
   meta: ObjectMeta;
   body?: S3BodySource;
 }
 
+/**
+ * Runtime hooks required to implement a Gestalt S3 provider.
+ */
 export interface S3ProviderOptions extends RuntimeProviderOptions {
   headObject: (ref: ObjectRef) => MaybePromise<ObjectMeta>;
   readObject: (ref: ObjectRef, options?: ReadOptions) => MaybePromise<ProviderReadResult>;
@@ -180,6 +237,9 @@ export interface S3ProviderOptions extends RuntimeProviderOptions {
   ) => MaybePromise<PresignResult>;
 }
 
+/**
+ * S3 provider implementation consumed by the Gestalt runtime.
+ */
 export class S3Provider extends RuntimeProvider {
   readonly kind = "s3" as const;
 
@@ -239,10 +299,16 @@ export class S3Provider extends RuntimeProvider {
   }
 }
 
+/**
+ * Creates an S3 provider from standard object storage handlers.
+ */
 export function defineS3Provider(options: S3ProviderOptions): S3Provider {
   return new S3Provider(options);
 }
 
+/**
+ * Runtime type guard for S3 providers loaded from user modules.
+ */
 export function isS3Provider(value: unknown): value is S3Provider {
   return (
     value instanceof S3Provider ||
@@ -260,6 +326,11 @@ export function isS3Provider(value: unknown): value is S3Provider {
   );
 }
 
+/**
+ * Adapts an authored S3 provider to the shared protocol service implementation.
+ *
+ * @internal
+ */
 export function createS3Service(
   provider: S3Provider,
 ): Partial<ServiceImpl<typeof S3Service>> {
@@ -411,6 +482,17 @@ export function createS3Service(
   };
 }
 
+/**
+ * Client for invoking a host-provided S3 service over the Gestalt transport.
+ *
+ * @example
+ * ```ts
+ * import { S3 } from "@valon-technologies/gestalt";
+ *
+ * const s3 = new S3();
+ * await s3.object("example-bucket", "hello.json").writeJSON({ ok: true });
+ * ```
+ */
 export class S3 {
   private readonly client: Client<typeof S3Service>;
 
@@ -543,16 +625,25 @@ export class S3 {
   }
 }
 
+/**
+ * Convenience wrapper for working with a single S3 object reference.
+ */
 export class S3Object {
   constructor(
     private readonly client: S3,
     readonly ref: ObjectRef,
   ) {}
 
+  /**
+   * Loads object metadata without downloading the object body.
+   */
   async stat(): Promise<ObjectMeta> {
     return await this.client.headObject(this.ref);
   }
 
+  /**
+   * Returns `true` when the referenced object exists.
+   */
   async exists(): Promise<boolean> {
     try {
       await this.stat();
@@ -565,40 +656,67 @@ export class S3Object {
     }
   }
 
+  /**
+   * Reads an object and returns its metadata and byte stream.
+   */
   async read(options?: ReadOptions): Promise<ReadResult> {
     return await this.client.readObject(this.ref, options);
   }
 
+  /**
+   * Reads only the object byte stream.
+   */
   async stream(options?: ReadOptions): Promise<AsyncIterable<Uint8Array>> {
     const result = await this.read(options);
     return result.stream;
   }
 
+  /**
+   * Reads an object into memory as bytes.
+   */
   async bytes(options?: ReadOptions): Promise<Uint8Array> {
     const result = await this.read(options);
     return await collectBytes(result.stream);
   }
 
+  /**
+   * Reads an object into memory as a string.
+   */
   async text(options?: ReadOptions, encoding = "utf-8"): Promise<string> {
     return new TextDecoder(encoding).decode(await this.bytes(options));
   }
 
+  /**
+   * Reads and parses an object as JSON.
+   */
   async json<T = unknown>(options?: ReadOptions): Promise<T> {
     return JSON.parse(await this.text(options)) as T;
   }
 
+  /**
+   * Writes an object body to storage.
+   */
   async write(body?: S3BodySource, options?: WriteOptions): Promise<ObjectMeta> {
     return await this.client.writeObject(this.ref, body, options);
   }
 
+  /**
+   * Writes binary content to storage.
+   */
   async writeBytes(body: Uint8Array | ArrayBuffer | ArrayBufferView): Promise<ObjectMeta> {
     return await this.write(body);
   }
 
+  /**
+   * Writes string content to storage.
+   */
   async writeString(body: string, options?: WriteOptions): Promise<ObjectMeta> {
     return await this.write(body, options);
   }
 
+  /**
+   * Writes JSON content using `application/json` by default.
+   */
   async writeJSON(value: unknown, options: WriteOptions = {}): Promise<ObjectMeta> {
     return await this.write(JSON.stringify(value), {
       ...options,
@@ -606,10 +724,16 @@ export class S3Object {
     });
   }
 
+  /**
+   * Deletes the referenced object.
+   */
   async delete(): Promise<void> {
     await this.client.deleteObject(this.ref);
   }
 
+  /**
+   * Generates a presigned URL for the referenced object.
+   */
   async presign(options?: PresignOptions): Promise<PresignResult> {
     return await this.client.presignObject(this.ref, options);
   }

--- a/sdk/typescript/src/schema.ts
+++ b/sdk/typescript/src/schema.ts
@@ -1,5 +1,11 @@
+/**
+ * Catalog schema kinds supported by the TypeScript SDK.
+ */
 export type CatalogType = "string" | "integer" | "number" | "boolean" | "object" | "array";
 
+/**
+ * Runtime schema that validates operation input and output values.
+ */
 export interface Schema<T> {
   readonly catalogType: CatalogType;
   readonly description: string;
@@ -10,10 +16,16 @@ export interface Schema<T> {
   parse(value: unknown, path?: string): T;
 }
 
+/**
+ * Extracts the TypeScript type represented by a {@link Schema}.
+ */
 export type InferSchema<TSchema extends Schema<unknown>> = TSchema extends Schema<infer T>
   ? T
   : never;
 
+/**
+ * Shared options supported by all schema builders.
+ */
 export interface SchemaOptions<T> {
   description?: string;
   required?: boolean;
@@ -53,6 +65,9 @@ function withMeta<T>(
   };
 }
 
+/**
+ * Creates a string schema.
+ */
 export function string(options?: SchemaOptions<string>): Schema<string> {
   return withMeta(
     "string",
@@ -66,6 +81,9 @@ export function string(options?: SchemaOptions<string>): Schema<string> {
   );
 }
 
+/**
+ * Creates an integer schema.
+ */
 export function integer(options?: SchemaOptions<number>): Schema<number> {
   return withMeta(
     "integer",
@@ -85,6 +103,9 @@ export function integer(options?: SchemaOptions<number>): Schema<number> {
   );
 }
 
+/**
+ * Creates a floating-point or integer number schema.
+ */
 export function number(options?: SchemaOptions<number>): Schema<number> {
   return withMeta(
     "number",
@@ -107,6 +128,9 @@ export function number(options?: SchemaOptions<number>): Schema<number> {
   );
 }
 
+/**
+ * Creates a boolean schema that accepts `true` / `false` and `1` / `0`.
+ */
 export function boolean(options?: SchemaOptions<boolean>): Schema<boolean> {
   return withMeta(
     "boolean",
@@ -129,6 +153,9 @@ export function boolean(options?: SchemaOptions<boolean>): Schema<boolean> {
   );
 }
 
+/**
+ * Creates an array schema for repeated values.
+ */
 export function array<T>(item: Schema<T>, options?: SchemaOptions<T[]>): Schema<T[]> {
   const base = withMeta<T[]>(
     "array",
@@ -147,6 +174,19 @@ export function array<T>(item: Schema<T>, options?: SchemaOptions<T[]>): Schema<
   };
 }
 
+/**
+ * Creates an object schema from a field map.
+ *
+ * @example
+ * ```ts
+ * import { s } from "@valon-technologies/gestalt";
+ *
+ * const input = s.object({
+ *   name: s.string(),
+ *   excited: s.optional(s.boolean()),
+ * });
+ * ```
+ */
 export function object<T extends Record<string, unknown>>(
   fields: { [K in keyof T]: Schema<T[K]> },
   options?: SchemaOptions<T>,
@@ -176,6 +216,9 @@ export function object<T extends Record<string, unknown>>(
   };
 }
 
+/**
+ * Marks another schema as optional while preserving its metadata.
+ */
 export function optional<T>(schema: Schema<T>): Schema<T | undefined> {
   const wrapped: Schema<T | undefined> = {
     catalogType: schema.catalogType,
@@ -201,6 +244,9 @@ export function optional<T>(schema: Schema<T>): Schema<T | undefined> {
   };
 }
 
+/**
+ * Namespace-style schema builder helpers.
+ */
 export const s = {
   string,
   integer,

--- a/sdk/typescript/src/secrets.ts
+++ b/sdk/typescript/src/secrets.ts
@@ -1,10 +1,16 @@
 import { RuntimeProvider, type RuntimeProviderOptions } from "./provider.ts";
 import type { MaybePromise } from "./api.ts";
 
+/**
+ * Runtime hooks required to implement a Gestalt secrets provider.
+ */
 export interface SecretsProviderOptions extends RuntimeProviderOptions {
   getSecret: (name: string) => MaybePromise<string>;
 }
 
+/**
+ * Secrets provider implementation consumed by the Gestalt runtime.
+ */
 export class SecretsProvider extends RuntimeProvider {
   readonly kind = "secrets" as const;
 
@@ -20,10 +26,16 @@ export class SecretsProvider extends RuntimeProvider {
   }
 }
 
+/**
+ * Creates a secrets provider from a simple `getSecret` implementation.
+ */
 export function defineSecretsProvider(options: SecretsProviderOptions): SecretsProvider {
   return new SecretsProvider(options);
 }
 
+/**
+ * Runtime type guard for secrets providers loaded from user modules.
+ */
 export function isSecretsProvider(value: unknown): value is SecretsProvider {
   return (
     value instanceof SecretsProvider ||

--- a/sdk/typescript/src/target.ts
+++ b/sdk/typescript/src/target.ts
@@ -4,26 +4,28 @@ import { pathToFileURL } from "node:url";
 
 import { slugName, type ProviderKind } from "./provider.ts";
 
+/**
+ * Relative module target with an optional named export.
+ */
 export type ModuleTarget = {
   modulePath: string;
   exportName?: string;
 };
 
+/**
+ * Provider target with an explicit Gestalt provider kind.
+ */
 export type ProviderTarget = ModuleTarget & {
   kind: ProviderKind;
 };
 
+/**
+ * Gestalt-specific package metadata read from `package.json`.
+ */
 export type PackageConfig = {
   name?: string;
   providerTarget?: ProviderTarget;
 };
-
-type PackageProviderConfig =
-  | string
-  | {
-      kind?: string;
-      target?: string;
-    };
 
 const EXTERNAL_PROVIDER_KIND_TOKENS = new Set<string>([
   "plugin",
@@ -35,6 +37,9 @@ const EXTERNAL_PROVIDER_KIND_TOKENS = new Set<string>([
   "telemetry",
 ]);
 
+/**
+ * Parses a relative module target in the form `./file.ts#namedExport`.
+ */
 export function parseModuleTarget(target: string, label = "gestalt provider target"): ModuleTarget {
   const [modulePathRaw, exportNameRaw] = target.split("#", 2);
   const modulePath = modulePathRaw?.trim() ?? "";
@@ -59,7 +64,12 @@ export function parseModuleTarget(target: string, label = "gestalt provider targ
   return parsed;
 }
 
-export function parseProviderTarget(target: string | PackageProviderConfig): ProviderTarget {
+/**
+ * Parses either a string or object-form provider target from `package.json`.
+ */
+export function parseProviderTarget(
+  target: string | { kind?: string; target?: string },
+): ProviderTarget {
   if (typeof target === "string") {
     const prefixed = parseKindPrefixedTarget(target);
     if (prefixed) {
@@ -81,8 +91,14 @@ export function parseProviderTarget(target: string | PackageProviderConfig): Pro
   };
 }
 
+/**
+ * Backwards-compatible alias for integration-only package targets.
+ */
 export const parsePluginTarget = parseModuleTarget;
 
+/**
+ * Reads the Gestalt-specific provider metadata from a package directory.
+ */
 export function readPackageConfig(root: string): PackageConfig {
   const packagePath = resolve(root, "package.json");
   const raw = JSON.parse(readFileSync(packagePath, "utf8")) as Record<string, unknown>;
@@ -111,6 +127,9 @@ export function readPackageConfig(root: string): PackageConfig {
   return config;
 }
 
+/**
+ * Reads and validates the configured provider target from `package.json`.
+ */
 export function readPackageProviderTarget(root: string): ProviderTarget {
   const config = readPackageConfig(root);
   if (!config.providerTarget) {
@@ -119,6 +138,9 @@ export function readPackageProviderTarget(root: string): ProviderTarget {
   return config.providerTarget;
 }
 
+/**
+ * Reads the integration-provider target from `package.json`.
+ */
 export function readPackagePluginTarget(root: string): string {
   const target = readPackageProviderTarget(root);
   if (target.kind !== "integration") {
@@ -127,13 +149,22 @@ export function readPackagePluginTarget(root: string): string {
   return formatModuleTarget(target);
 }
 
+/**
+ * Computes a default provider slug from the package name.
+ */
 export function defaultProviderName(root: string): string {
   const config = readPackageConfig(root);
   return slugName(config.name ?? "");
 }
 
+/**
+ * Backwards-compatible alias for integration providers.
+ */
 export const defaultPluginName = defaultProviderName;
 
+/**
+ * Resolves a provider target to an absolute file path.
+ */
 export function resolveProviderModulePath(root: string, target: ProviderTarget | ModuleTarget): string {
   const absolute = resolve(root, target.modulePath);
   if (!isAbsolute(absolute)) {
@@ -142,18 +173,33 @@ export function resolveProviderModulePath(root: string, target: ProviderTarget |
   return normalize(absolute);
 }
 
+/**
+ * Backwards-compatible alias for integration providers.
+ */
 export const resolvePluginModulePath = resolveProviderModulePath;
 
+/**
+ * Resolves a provider target to an importable file URL.
+ */
 export function resolveProviderImportUrl(root: string, target: ProviderTarget | ModuleTarget): string {
   return pathToFileURL(resolveProviderModulePath(root, target)).href;
 }
 
+/**
+ * Backwards-compatible alias for integration providers.
+ */
 export const resolvePluginImportUrl = resolveProviderImportUrl;
 
+/**
+ * Formats a provider target using the public `kind:./path#export` syntax.
+ */
 export function formatProviderTarget(target: ProviderTarget): string {
   return `${formatProviderKind(target.kind)}:${formatModuleTarget(target)}`;
 }
 
+/**
+ * Formats a module target using the public `./path#export` syntax.
+ */
 export function formatModuleTarget(target: ModuleTarget): string {
   return `${target.modulePath}${target.exportName ? `#${target.exportName}` : ""}`;
 }

--- a/sdk/typescript/tsconfig.json
+++ b/sdk/typescript/tsconfig.json
@@ -15,6 +15,7 @@
     ]
   },
   "include": [
+    "docs/entrypoints/**/*.ts",
     "src/**/*.ts",
     "tests/**/*.ts",
     "gen/**/*.ts"

--- a/sdk/typescript/tsdoc.json
+++ b/sdk/typescript/tsdoc.json
@@ -1,0 +1,9 @@
+{
+  "$schema": "https://developer.microsoft.com/json-schemas/tsdoc/v0/tsdoc.schema.json",
+  "tagDefinitions": [
+    {
+      "tagName": "@module",
+      "syntaxKind": "block"
+    }
+  ]
+}

--- a/sdk/typescript/typedoc.json
+++ b/sdk/typescript/typedoc.json
@@ -1,0 +1,24 @@
+{
+  "$schema": "https://typedoc.org/schema.json",
+  "entryPoints": [
+    "docs/entrypoints/@valon-technologies/gestalt",
+    "docs/entrypoints/build",
+    "docs/entrypoints/runtime",
+    "docs/entrypoints/schema",
+    "docs/entrypoints/target"
+  ],
+  "displayBasePath": "docs/entrypoints",
+  "tsconfig": "tsconfig.json",
+  "readme": "README.md",
+  "excludePrivate": true,
+  "excludeProtected": true,
+  "excludeInternal": true,
+  "sort": [
+    "source-order"
+  ],
+  "treatWarningsAsErrors": true,
+  "validation": {
+    "notExported": false,
+    "invalidLink": true
+  }
+}


### PR DESCRIPTION
## Summary

This adds the stand-alone TypeScript SDK docs slice for `@valon-technologies/gestalt`.

New interfaces:
- Source-native TSDoc across the authored public TypeScript SDK surface in `sdk/typescript/src`, centered on provider authoring, request/response helpers, schema/catalog builders, and the Cache / IndexedDB / S3 clients.
- `sdk/typescript/typedoc.json` and `sdk/typescript/eslint.config.mjs` for generated TypeDoc HTML and TSDoc syntax validation.
- `.github/workflows/build-typescript-sdk.yml` to run the existing Bun SDK checks plus docs lint/build.
- `.github/workflows/deploy-gestalt-docs.yml` now generates static TypeScript API HTML into `docs/public/api/typescript` before the docs Docker build.
- `docs/content/reference/typescript-sdk.mdx` and reference nav updates so the docs site can reach the published TypeScript API reference.

Examples:

```ts
import { defineIntegrationProvider, ok, operation, s } from "@valon-technologies/gestalt";

export const provider = defineIntegrationProvider({
  displayName: "Example Provider",
  operations: [
    operation({
      id: "hello",
      input: s.object({ name: s.string({ default: "World" }) }),
      output: s.object({ message: s.string() }),
      async handler(input) {
        return ok({ message: `Hello, ${input.name}` });
      },
    }),
  ],
});
```

```ts
import { Cache, IndexedDB, S3 } from "@valon-technologies/gestalt";
import { parseRuntimeArgs } from "@valon-technologies/gestalt/runtime";

const cache = new Cache();
const db = new IndexedDB();
const s3 = new S3();
const args = parseRuntimeArgs(process.argv.slice(2));
```

## Validation

- `cd sdk/typescript && bun install`
- `cd sdk/typescript && bun run docs:check`
- `cd sdk/typescript && bun run check`
- `cd sdk/typescript && rm -rf ../../docs/public/api/typescript && bun run docs:build:deploy`
- `cd docs && npm ci`
- `cd docs && npm run build`
