### PR TITLE
Add identity-owned OAuth plugin connections

### DIFF
--- a/gestalt/cli/src/api.rs
+++ b/gestalt/cli/src/api.rs
@@ -338,6 +338,16 @@ impl ApiClient {
         )
     }
 
+    pub fn start_identity_oauth<T>(&self, identity: &str, body: &T) -> Result<serde_json::Value>
+    where
+        T: Serialize + ?Sized,
+    {
+        self.post(
+            &format!("/api/v1/identities/{identity}/auth/start-oauth"),
+            body,
+        )
+    }
+
     pub fn disconnect_identity_integration(
         &self,
         identity: &str,

--- a/gestalt/cli/src/commands/plugins.rs
+++ b/gestalt/cli/src/commands/plugins.rs
@@ -6,7 +6,7 @@ use crate::api::ApiClient;
 use crate::output::{self, Format};
 
 pub(crate) use connect::connect_identity;
-pub use connect::{connect, connect_with_browser_opener};
+pub use connect::{connect, connect_identity_with_browser_opener, connect_with_browser_opener};
 
 const PLUGIN_CONNECTION_NAME: &str = "_plugin";
 const PLUGIN_CONNECTION_ALIAS: &str = "plugin";

--- a/gestalt/cli/src/commands/plugins/connect.rs
+++ b/gestalt/cli/src/commands/plugins/connect.rs
@@ -283,6 +283,22 @@ pub(crate) fn connect_identity(
     connection: Option<&str>,
     instance: Option<&str>,
 ) -> Result<()> {
+    connect_identity_with_browser_opener(client, identity, name, connection, instance, |url| {
+        open::that(url).map(|_| ()).map_err(Into::into)
+    })
+}
+
+pub fn connect_identity_with_browser_opener<F>(
+    client: &ApiClient,
+    identity: &str,
+    name: &str,
+    connection: Option<&str>,
+    instance: Option<&str>,
+    open_browser: F,
+) -> Result<()>
+where
+    F: FnOnce(&str) -> Result<()>,
+{
     let integration = fetch_plugin_from_path(
         client,
         &format!("/api/v1/identities/{identity}/integrations"),
@@ -301,10 +317,7 @@ pub(crate) fn connect_identity(
             &format!("Connected {{integration}} ({{candidate}}) for identity {identity}."),
             |body| client.connect_identity_manual(identity, body),
         ),
-        ConnectMode::OAuth => bail!(
-            "identity connections do not support OAuth in the CLI yet for plugin '{}'",
-            name
-        ),
+        ConnectMode::OAuth => start_identity_oauth(client, identity, &flow, instance, open_browser),
     }
 }
 
@@ -317,18 +330,53 @@ fn start_oauth<F>(
 where
     F: FnOnce(&str) -> Result<()>,
 {
+    start_oauth_via(
+        "failed to start OAuth flow",
+        |body| client.post("/api/v1/auth/start-oauth", body),
+        flow,
+        instance,
+        open_browser,
+    )
+}
+
+fn start_identity_oauth<F>(
+    client: &ApiClient,
+    identity: &str,
+    flow: &ResolvedConnectFlow<'_>,
+    instance: Option<&str>,
+    open_browser: F,
+) -> Result<()>
+where
+    F: FnOnce(&str) -> Result<()>,
+{
+    start_oauth_via(
+        &format!("failed to start OAuth flow for identity {identity}"),
+        |body| client.start_identity_oauth(identity, body),
+        flow,
+        instance,
+        open_browser,
+    )
+}
+
+fn start_oauth_via<F, G>(
+    failure_context: &str,
+    start_request: G,
+    flow: &ResolvedConnectFlow<'_>,
+    instance: Option<&str>,
+    open_browser: F,
+) -> Result<()>
+where
+    F: FnOnce(&str) -> Result<()>,
+    G: FnOnce(&StartOAuthRequest<'_>) -> Result<serde_json::Value>,
+{
     let connection_params = prompt_connection_params(flow.connection_param_defs())?;
-    let resp = client
-        .post(
-            "/api/v1/auth/start-oauth",
-            &StartOAuthRequest {
-                integration: flow.integration_name(),
-                connection: flow.connection_name(),
-                instance,
-                connection_params: connection_params.as_ref(),
-            },
-        )
-        .context("failed to start OAuth flow")?;
+    let resp = start_request(&StartOAuthRequest {
+        integration: flow.integration_name(),
+        connection: flow.connection_name(),
+        instance,
+        connection_params: connection_params.as_ref(),
+    })
+    .with_context(|| failure_context.to_string())?;
     let url = resp["url"]
         .as_str()
         .context("response missing 'url' field")?;

--- a/gestalt/cli/tests/identities_cli.rs
+++ b/gestalt/cli/tests/identities_cli.rs
@@ -1,5 +1,7 @@
 mod support;
 
+use std::sync::{Arc, Mutex};
+
 use support::*;
 
 #[test]
@@ -382,4 +384,89 @@ fn test_cli_disconnects_identity_connection_with_connection_and_instance() {
         .stderr(predicate::str::contains(
             "Disconnected widget_metrics from identity agent-1.",
         ));
+}
+
+#[test]
+fn test_identity_connect_starts_oauth_with_connection_and_instance() {
+    let mut server = Server::new();
+    let _integrations = authed_json_mock!(
+        server,
+        Method::GET,
+        "/api/v1/identities/agent-1/integrations",
+        StatusCode::OK
+    )
+    .with_body(r#"[{"name":"acme_crm","authTypes":["oauth"],"connected":false}]"#)
+    .create();
+    let mock = authed_json_mock!(
+        server,
+        Method::POST,
+        "/api/v1/identities/agent-1/auth/start-oauth",
+        StatusCode::OK
+    )
+    .match_header(header::CONTENT_TYPE.as_str(), http::APPLICATION_JSON)
+    .match_body(Matcher::JsonString(
+        r#"{"connection":"workspace","instance":"team-a","integration":"acme_crm"}"#.to_string(),
+    ))
+    .with_body(r#"{"url":"https://example.com/oauth","state":"abc123"}"#)
+    .create();
+
+    let client = create_client(&server);
+    let result = gestalt::commands::plugins::connect_identity_with_browser_opener(
+        &client,
+        "agent-1",
+        "acme_crm",
+        Some("workspace"),
+        Some("team-a"),
+        |_| Ok(()),
+    );
+
+    mock.assert();
+    assert!(result.is_ok());
+}
+
+#[test]
+fn test_identity_connect_prefers_oauth_when_manual_also_exists() {
+    let mut server = Server::new();
+    let _integrations = authed_json_mock!(
+        server,
+        Method::GET,
+        "/api/v1/identities/agent-1/integrations",
+        StatusCode::OK
+    )
+    .with_body(r#"[{"name":"acme_crm","authTypes":["oauth","manual"],"connected":false}]"#)
+    .create();
+    let mock = authed_json_mock!(
+        server,
+        Method::POST,
+        "/api/v1/identities/agent-1/auth/start-oauth",
+        StatusCode::OK
+    )
+    .match_header(header::CONTENT_TYPE.as_str(), http::APPLICATION_JSON)
+    .match_body(Matcher::JsonString(
+        r#"{"integration":"acme_crm"}"#.to_string(),
+    ))
+    .with_body(r#"{"url":"https://example.com/oauth","state":"abc123"}"#)
+    .create();
+
+    let client = create_client(&server);
+    let opened_url = Arc::new(Mutex::new(None));
+    let opened_url_handle = Arc::clone(&opened_url);
+    let result = gestalt::commands::plugins::connect_identity_with_browser_opener(
+        &client,
+        "agent-1",
+        "acme_crm",
+        None,
+        None,
+        move |url| {
+            *opened_url_handle.lock().unwrap() = Some(url.to_string());
+            Ok(())
+        },
+    );
+
+    mock.assert();
+    assert!(result.is_ok());
+    assert_eq!(
+        opened_url.lock().unwrap().as_deref(),
+        Some("https://example.com/oauth")
+    );
 }

--- a/gestaltd/internal/authorization/authorizer.go
+++ b/gestaltd/internal/authorization/authorizer.go
@@ -951,10 +951,11 @@ func providerSupportsManagedIdentityAuth(prov core.Provider) bool {
 	if mp, ok := prov.(interface{ SupportsManualAuth() bool }); ok && mp.SupportsManualAuth() {
 		return true
 	}
-	return false
+	_, ok := prov.(core.OAuthProvider)
+	return ok
 }
 
 func managedIdentityAuthTypeSupported(authType string) bool {
 	authType = strings.ToLower(strings.TrimSpace(authType))
-	return authType == string(providermanifestv1.AuthTypeManual)
+	return authType == string(providermanifestv1.AuthTypeManual) || strings.HasPrefix(authType, "oauth")
 }

--- a/gestaltd/internal/server/authorization.go
+++ b/gestaltd/internal/server/authorization.go
@@ -12,6 +12,9 @@ import (
 )
 
 func (s *Server) allowProvider(p *principal.Principal, provider string) bool {
+	if p != nil && !principal.AllowsProviderPermission(p, provider) {
+		return false
+	}
 	if s.authorizer == nil {
 		return true
 	}
@@ -19,6 +22,9 @@ func (s *Server) allowProvider(p *principal.Principal, provider string) bool {
 }
 
 func (s *Server) allowOperation(p *principal.Principal, provider, operation string) bool {
+	if p != nil && !principal.AllowsOperationPermission(p, provider, operation) {
+		return false
+	}
 	if s.authorizer == nil {
 		return true
 	}

--- a/gestaltd/internal/server/handlers_connect.go
+++ b/gestaltd/internal/server/handlers_connect.go
@@ -7,6 +7,7 @@ import (
 	"fmt"
 	"log/slog"
 	"net/http"
+	"strings"
 	"time"
 
 	"github.com/google/uuid"
@@ -15,6 +16,7 @@ import (
 	"github.com/valon-technologies/gestalt/server/internal/discovery"
 	"github.com/valon-technologies/gestalt/server/internal/metricutil"
 	"github.com/valon-technologies/gestalt/server/internal/principal"
+	providermanifestv1 "github.com/valon-technologies/gestalt/server/sdk/providermanifest/v1"
 )
 
 var errManagedIdentityIntegrationNotFound = errors.New("managed identity integration not found")
@@ -108,14 +110,18 @@ func (s *Server) connectManual(w http.ResponseWriter, r *http.Request) {
 	}
 
 	authSource := ""
-	if p := PrincipalFromContext(r.Context()); p != nil {
-		authSource = p.AuthSource()
+	viewer := PrincipalFromContext(r.Context())
+	if viewer != nil {
+		authSource = viewer.AuthSource()
 	}
+	viewerScopes, viewerPerms := viewerCeilingForConnectionState(viewer)
 	tm := tokenMaterial{
 		OwnerKind:       core.IntegrationTokenOwnerKindUser,
 		OwnerID:         dbUserID,
 		InitiatorUserID: dbUserID,
 		AuthSource:      authSource,
+		ViewerScopes:    viewerScopes,
+		ViewerPerms:     viewerPerms,
 		Integration:     req.Integration,
 		Connection:      manualConnection,
 		Instance:        manualInstance,
@@ -246,6 +252,8 @@ type tokenMaterial struct {
 	InitiatorUserID string
 	LegacyUserID    string `json:"UserID,omitempty"`
 	AuthSource      string
+	ViewerScopes    []string                `json:"vsc,omitempty"`
+	ViewerPerms     []core.AccessPermission `json:"vpm,omitempty"`
 	Integration     string
 	Connection      string
 	Instance        string
@@ -307,10 +315,235 @@ func (s *Server) validateManagedIdentityConnectionWrite(ctx context.Context, tm 
 	if _, err := s.managedIdentityActor(ctx, tm.OwnerID, tm.InitiatorUserID, managedIdentityRoleEditor); err != nil {
 		return err
 	}
-	if !s.managedIdentityGrantPluginVisible(tm.Integration, PrincipalFromContext(ctx)) {
+	if !s.managedIdentityGrantPluginVisible(tm.Integration, s.managedIdentityConnectionViewerPrincipal(ctx, tm)) {
+		return errManagedIdentityIntegrationNotFound
+	}
+	if !s.managedIdentityConnectionVisible(tm.Integration, tm.Connection) {
 		return errManagedIdentityIntegrationNotFound
 	}
 	return nil
+}
+
+func (s *Server) managedIdentityConnectionViewerPrincipal(ctx context.Context, tm tokenMaterial) *principal.Principal {
+	initiatorUserID := strings.TrimSpace(tm.InitiatorUserID)
+	applyViewerCeiling := func(p *principal.Principal) *principal.Principal {
+		if p == nil {
+			return nil
+		}
+		if len(tm.ViewerScopes) == 0 && len(tm.ViewerPerms) == 0 {
+			return p
+		}
+		clone := *p
+		if len(tm.ViewerScopes) > 0 {
+			clone.Scopes = append([]string(nil), tm.ViewerScopes...)
+		}
+		if len(tm.ViewerPerms) > 0 {
+			clone.TokenPermissions = principal.CompilePermissions(tm.ViewerPerms)
+		}
+		return &clone
+	}
+	if initiatorUserID == "" {
+		return applyViewerCeiling(PrincipalFromContext(ctx))
+	}
+	if p := PrincipalFromContext(ctx); p != nil && p.UserID == initiatorUserID {
+		return applyViewerCeiling(p)
+	}
+	p := &principal.Principal{
+		UserID:    initiatorUserID,
+		SubjectID: principal.UserSubjectID(initiatorUserID),
+		Kind:      principal.KindUser,
+	}
+	if s.users != nil {
+		if user, err := s.users.GetUser(ctx, initiatorUserID); err == nil && user != nil {
+			p.Identity = &core.UserIdentity{
+				Email:       user.Email,
+				DisplayName: user.DisplayName,
+			}
+		}
+	}
+	return applyViewerCeiling(p)
+}
+
+func viewerCeilingForConnectionState(p *principal.Principal) ([]string, []core.AccessPermission) {
+	if p == nil {
+		return nil, nil
+	}
+	var scopes []string
+	if len(p.Scopes) > 0 {
+		scopes = append([]string(nil), p.Scopes...)
+	}
+	perms := principal.PermissionsToAccessPermissions(p.TokenPermissions)
+	if len(perms) > 0 {
+		perms = append([]core.AccessPermission(nil), perms...)
+	}
+	return scopes, perms
+}
+
+func (s *Server) managedIdentityConnectionVisible(integration, connection string) bool {
+	connection = config.ResolveConnectionAlias(strings.TrimSpace(connection))
+	if connection == "" {
+		return false
+	}
+	entry := s.pluginDefs[integration]
+	if entry == nil {
+		defaultConnection := config.ResolveConnectionAlias(s.defaultConnection[integration])
+		if defaultConnection == "" {
+			defaultConnection = config.PluginConnectionName
+		}
+		return connection == config.PluginConnectionName || connection == defaultConnection
+	}
+	names, err := s.managedIdentityAdvertisedConnectionNames(entry)
+	if err != nil {
+		return false
+	}
+	advertised := false
+	for _, name := range names {
+		if name == connection {
+			advertised = true
+			break
+		}
+	}
+	manifestProvider := entry.ManifestSpec()
+	if !advertised {
+		defaultConnection := config.ResolveConnectionAlias(s.defaultConnection[integration])
+		if manifestProvider == nil && defaultConnection != "" && connection == defaultConnection {
+			return true
+		}
+		return false
+	}
+	if connection == config.PluginConnectionName {
+		return userFacingConnection(config.EffectivePluginConnectionDef(entry, manifestProvider))
+	}
+	conn, ok := config.EffectiveNamedConnectionDef(entry, manifestProvider, connection)
+	if !ok {
+		return false
+	}
+	return userFacingConnection(conn)
+}
+
+func (s *Server) managedIdentityAdvertisedConnectionNames(entry *config.ProviderEntry) ([]string, error) {
+	if entry == nil {
+		return []string{}, nil
+	}
+	manifestProvider := entry.ManifestSpec()
+	if manifestProvider == nil {
+		plan, err := config.BuildStaticConnectionPlan(entry, nil)
+		if err != nil {
+			return nil, err
+		}
+		return plan.AdvertisedConnectionNames(), nil
+	}
+
+	names := make([]string, 0, 4)
+	seen := map[string]struct{}{}
+	add := func(name string) {
+		name = config.ResolveConnectionAlias(strings.TrimSpace(name))
+		if name == "" {
+			return
+		}
+		if _, ok := seen[name]; ok {
+			return
+		}
+		seen[name] = struct{}{}
+		names = append(names, name)
+	}
+
+	defaultConnection := s.managedIdentityExplicitDefaultConnection(entry, manifestProvider)
+	add(defaultConnection)
+	if surfaceConnection, ok := s.managedIdentityRESTConnectionName(entry, manifestProvider); ok {
+		add(surfaceConnection)
+	}
+	for _, surface := range config.OrderedSpecSurfaces {
+		if !s.managedIdentityHasConfiguredSurface(entry, manifestProvider, surface) {
+			continue
+		}
+		surfaceConnection, ok := s.managedIdentitySurfaceConnectionName(entry, manifestProvider, surface)
+		if !ok {
+			continue
+		}
+		add(surfaceConnection)
+	}
+	return names, nil
+}
+
+func (s *Server) managedIdentityExplicitDefaultConnection(entry *config.ProviderEntry, manifestProvider *providermanifestv1.Spec) string {
+	if entry != nil {
+		if name := config.ResolveConnectionAlias(strings.TrimSpace(entry.DefaultConnection)); name != "" {
+			return name
+		}
+	}
+	if manifestProvider != nil {
+		if name := config.ResolveConnectionAlias(strings.TrimSpace(manifestProvider.DefaultConnection)); name != "" {
+			return name
+		}
+	}
+	return ""
+}
+
+func (s *Server) managedIdentityRESTConnectionName(entry *config.ProviderEntry, manifestProvider *providermanifestv1.Spec) (string, bool) {
+	if (entry == nil || entry.Surfaces == nil || entry.Surfaces.REST == nil) && (manifestProvider == nil || manifestProvider.Surfaces == nil || manifestProvider.Surfaces.REST == nil) {
+		return "", false
+	}
+	defaultConnection := s.managedIdentityExplicitDefaultConnection(entry, manifestProvider)
+	if defaultConnection != "" {
+		return defaultConnection, true
+	}
+	return s.managedIdentityFallbackSurfaceConnection(entry, manifestProvider), true
+}
+
+func (s *Server) managedIdentitySurfaceConnectionName(entry *config.ProviderEntry, manifestProvider *providermanifestv1.Spec, surface config.SpecSurface) (string, bool) {
+	if !s.managedIdentityHasConfiguredSurface(entry, manifestProvider, surface) {
+		return "", false
+	}
+	if name := config.ResolveConnectionAlias(strings.TrimSpace(config.ManifestProviderSurfaceConnectionName(manifestProvider, surface))); name != "" {
+		return name, true
+	}
+	defaultConnection := s.managedIdentityExplicitDefaultConnection(entry, manifestProvider)
+	if defaultConnection != "" {
+		return defaultConnection, true
+	}
+	return s.managedIdentityFallbackSurfaceConnection(entry, manifestProvider), true
+}
+
+func (s *Server) managedIdentityFallbackSurfaceConnection(entry *config.ProviderEntry, manifestProvider *providermanifestv1.Spec) string {
+	names := managedIdentityNamedConnectionNames(entry, manifestProvider)
+	if len(names) == 1 {
+		return names[0]
+	}
+	return config.PluginConnectionName
+}
+
+func managedIdentityNamedConnectionNames(entry *config.ProviderEntry, manifestProvider *providermanifestv1.Spec) []string {
+	seen := map[string]struct{}{}
+	names := make([]string, 0)
+	if manifestProvider != nil {
+		for name := range manifestProvider.Connections {
+			if name = config.ResolveConnectionAlias(strings.TrimSpace(name)); name != "" {
+				if _, ok := seen[name]; !ok {
+					seen[name] = struct{}{}
+					names = append(names, name)
+				}
+			}
+		}
+	}
+	if entry != nil {
+		for name := range entry.Connections {
+			if name = config.ResolveConnectionAlias(strings.TrimSpace(name)); name != "" {
+				if _, ok := seen[name]; !ok {
+					seen[name] = struct{}{}
+					names = append(names, name)
+				}
+			}
+		}
+	}
+	return names
+}
+
+func (s *Server) managedIdentityHasConfiguredSurface(entry *config.ProviderEntry, manifestProvider *providermanifestv1.Spec, surface config.SpecSurface) bool {
+	if url := strings.TrimSpace(config.ProviderSurfaceURLOverride(entry, surface)); url != "" {
+		return true
+	}
+	return strings.TrimSpace(config.ManifestProviderSurfaceURL(manifestProvider, surface)) != ""
 }
 
 func (s *Server) writeManagedIdentityConnectionWriteError(w http.ResponseWriter, integration string, err error) bool {

--- a/gestaltd/internal/server/handlers_identity_integrations.go
+++ b/gestaltd/internal/server/handlers_identity_integrations.go
@@ -11,6 +11,7 @@ import (
 
 	"github.com/go-chi/chi/v5"
 	"github.com/valon-technologies/gestalt/server/core"
+	"github.com/valon-technologies/gestalt/server/internal/config"
 	"github.com/valon-technologies/gestalt/server/internal/metricutil"
 )
 
@@ -60,11 +61,19 @@ func (s *Server) listManagedIdentityIntegrations(w http.ResponseWriter, r *http.
 		if prov.ConnectionMode() == core.ConnectionModeNone {
 			info.Connected = true
 		}
-		info.Instances = append(make([]instanceInfo, 0, len(instances)), instances...)
+		visibleInstances := make([]instanceInfo, 0, len(instances))
+		for _, instance := range instances {
+			if !s.managedIdentityConnectionVisible(name, instance.Connection) {
+				continue
+			}
+			visibleInstances = append(visibleInstances, instance)
+		}
+		info.Instances = append(make([]instanceInfo, 0, len(visibleInstances)), visibleInstances...)
 		s.populateIntegrationSettings(&info, prov)
 		definedConnections := len(info.Connections) > 0
+		info.Connections = s.filterManagedIdentityConnectableConnections(name, info.Connections)
 		info.Connections = managedIdentityConnectableConnections(info.Connections)
-		info.AuthTypes = s.managedIdentitySupportedAuthTypes(name, prov, definedConnections, info.Connections, info.AuthTypes)
+		info.AuthTypes = s.managedIdentitySupportedAuthTypes(name, prov, definedConnections, info.Connections)
 		info.CredentialFields = credentialFieldInfosFromProvider(prov, info.AuthTypes)
 		if info.AuthTypes == nil {
 			info.AuthTypes = []string{}
@@ -86,22 +95,54 @@ func (s *Server) connectedIntegrationsByOwner(ctx context.Context, ownerKind, ow
 	}
 	connected := make(map[string][]instanceInfo, len(tokens))
 	for _, tok := range tokens {
+		connection := tok.Connection
+		if connection == "" {
+			connection = config.PluginConnectionName
+		}
 		connected[tok.Integration] = append(connected[tok.Integration], instanceInfo{
 			Name:       tok.Instance,
-			Connection: userFacingConnectionName(tok.Connection),
+			Connection: userFacingConnectionName(connection),
 		})
 	}
 	return connected, nil
 }
 
-func (s *Server) managedIdentitySupportedAuthTypes(integration string, prov core.Provider, definedConnections bool, connections []connectionDefInfo, authTypes []string) []string {
+func (s *Server) filterManagedIdentityConnectableConnections(integration string, connections []connectionDefInfo) []connectionDefInfo {
+	if len(connections) == 0 {
+		return nil
+	}
+	visible := make([]connectionDefInfo, 0, len(connections))
+	for _, connection := range connections {
+		if !s.managedIdentityConnectionVisible(integration, connection.Name) {
+			continue
+		}
+		visible = append(visible, connection)
+	}
+	return visible
+}
+
+func (s *Server) managedIdentitySupportedAuthTypes(integration string, prov core.Provider, definedConnections bool, connections []connectionDefInfo) []string {
 	if len(connections) > 0 {
 		return authTypesFromConnectionInfos(connections)
 	}
 	if definedConnections {
 		return nil
 	}
-	if authTypes := managedIdentityConnectableAuthTypes(authTypes); len(authTypes) > 0 {
+	entry := s.pluginDefs[integration]
+	defaultConnection := s.defaultConnection[integration]
+	if defaultConnection == "" {
+		defaultConnection = config.PluginConnectionName
+	}
+	if !s.managedIdentityConnectionVisible(integration, defaultConnection) {
+		if entry != nil {
+			return nil
+		}
+		defaultConnection = config.PluginConnectionName
+	}
+	baseAuthTypes := userFacingAuthTypes(prov.AuthTypes())
+	authTypes := connectionAuthTypes(s.effectiveConnectionAuth(integration, defaultConnection), baseAuthTypes)
+	authTypes = s.supportedConnectionAuthTypes(integration, defaultConnection, authTypes)
+	if authTypes = managedIdentityConnectableAuthTypes(authTypes); len(authTypes) > 0 {
 		return authTypes
 	}
 	if mp, ok := prov.(interface{ SupportsManualAuth() bool }); ok && mp.SupportsManualAuth() {
@@ -122,6 +163,35 @@ func authTypesFromConnectionInfos(connections []connectionDefInfo) []string {
 			}
 			out = append(out, authType)
 		}
+	}
+	return out
+}
+
+func managedIdentityConnectableAuthTypes(authTypes []string) []string {
+	if len(authTypes) == 0 {
+		return nil
+	}
+	out := make([]string, 0, len(authTypes))
+	for _, authType := range authTypes {
+		if (authType != "manual" && authType != "oauth") || authTypesContain(out, authType) {
+			continue
+		}
+		out = append(out, authType)
+	}
+	return out
+}
+
+func managedIdentityConnectableConnections(connections []connectionDefInfo) []connectionDefInfo {
+	if len(connections) == 0 {
+		return nil
+	}
+	out := make([]connectionDefInfo, 0, len(connections))
+	for _, connection := range connections {
+		connection.AuthTypes = managedIdentityConnectableAuthTypes(connection.AuthTypes)
+		if len(connection.AuthTypes) == 0 {
+			continue
+		}
+		out = append(out, connection)
 	}
 	return out
 }
@@ -221,16 +291,29 @@ func (s *Server) connectManagedIdentityManual(w http.ResponseWriter, r *http.Req
 	if viewer != nil {
 		authSource = viewer.AuthSource()
 	}
+	viewerScopes, viewerPerms := viewerCeilingForConnectionState(viewer)
 	tm := tokenMaterial{
 		OwnerKind:       core.IntegrationTokenOwnerKindManagedIdentity,
 		OwnerID:         actor.Identity.ID,
 		InitiatorUserID: actor.UserID,
 		AuthSource:      authSource,
+		ViewerScopes:    viewerScopes,
+		ViewerPerms:     viewerPerms,
 		Integration:     req.Integration,
 		Connection:      manualConnection,
 		Instance:        manualInstance,
 		AccessToken:     effectiveCredential,
 		MetadataJSON:    manualMeta,
+	}
+
+	if err := s.validateManagedIdentityConnectionWrite(r.Context(), tm); err != nil {
+		if s.writeManagedIdentityConnectionWriteError(w, req.Integration, err) {
+			auditErr = err
+			return
+		}
+		auditErr = err
+		writeError(w, http.StatusForbidden, err.Error())
+		return
 	}
 
 	result, err := s.runPostConnect(r.Context(), prov, tm)
@@ -305,7 +388,11 @@ func (s *Server) disconnectManagedIdentityIntegration(w http.ResponseWriter, r *
 
 	var matched []*core.IntegrationToken
 	for _, tok := range tokens {
-		if requestedConnection != "" && tok.Connection != requestedConnection {
+		connection := tok.Connection
+		if connection == "" {
+			connection = config.PluginConnectionName
+		}
+		if requestedConnection != "" && connection != requestedConnection {
 			continue
 		}
 		matched = append(matched, tok)
@@ -361,33 +448,4 @@ func (s *Server) disconnectManagedIdentityIntegration(w http.ResponseWriter, r *
 	auditAllowed = true
 	auditErr = nil
 	writeJSON(w, http.StatusOK, map[string]string{"status": "disconnected"})
-}
-
-func managedIdentityConnectableAuthTypes(authTypes []string) []string {
-	if len(authTypes) == 0 {
-		return nil
-	}
-	out := make([]string, 0, len(authTypes))
-	for _, authType := range authTypes {
-		if authType != "manual" || authTypesContain(out, authType) {
-			continue
-		}
-		out = append(out, authType)
-	}
-	return out
-}
-
-func managedIdentityConnectableConnections(connections []connectionDefInfo) []connectionDefInfo {
-	if len(connections) == 0 {
-		return nil
-	}
-	out := make([]connectionDefInfo, 0, len(connections))
-	for _, connection := range connections {
-		connection.AuthTypes = managedIdentityConnectableAuthTypes(connection.AuthTypes)
-		if len(connection.AuthTypes) == 0 {
-			continue
-		}
-		out = append(out, connection)
-	}
-	return out
 }

--- a/gestaltd/internal/server/handlers_oauth.go
+++ b/gestaltd/internal/server/handlers_oauth.go
@@ -3,9 +3,9 @@ package server
 import (
 	"encoding/json"
 	"errors"
+	"fmt"
 	"log/slog"
 	"net/http"
-	"net/url"
 	"strings"
 	"time"
 
@@ -22,6 +22,13 @@ type startOAuthRequest struct {
 	Instance         string            `json:"instance"`
 	Scopes           []string          `json:"scopes"`
 	ConnectionParams map[string]string `json:"connectionParams"`
+}
+
+type oauthStartTarget struct {
+	OwnerKind       string
+	OwnerID         string
+	InitiatorUserID string
+	AuthSource      string
 }
 
 func (s *Server) startIntegrationOAuth(w http.ResponseWriter, r *http.Request) {
@@ -50,41 +57,123 @@ func (s *Server) startIntegrationOAuth(w http.ResponseWriter, r *http.Request) {
 	}
 	providerName = req.Integration
 
-	prov, connection, err := s.resolveConnectionProvider(w, req.Integration, req.Connection)
+	dbUserID, err := s.resolveUserID(w, r)
 	if err != nil {
 		auditErr = err
 		return
 	}
-	metricProviderName = req.Integration
-	connectionMode = metricutil.NormalizeConnectionMode(prov.ConnectionMode())
+
+	authSource := ""
+	if p := PrincipalFromContext(r.Context()); p != nil {
+		authSource = p.AuthSource()
+	}
+	metricProviderName, connectionMode, auditTarget, err = s.startIntegrationOAuthForOwner(w, r, req, oauthStartTarget{
+		OwnerKind:       core.IntegrationTokenOwnerKindUser,
+		OwnerID:         dbUserID,
+		InitiatorUserID: dbUserID,
+		AuthSource:      authSource,
+	})
+	if err != nil {
+		auditErr = err
+		return
+	}
+	providerName = metricProviderName
+
+	auditAllowed = true
+	auditErr = nil
+}
+
+func (s *Server) startManagedIdentityOAuth(w http.ResponseWriter, r *http.Request) {
+	startedAt := time.Now()
+	auditAllowed := false
+	auditErr := errors.New("identity oauth start failed")
+	auditTarget := auditTarget{Kind: auditTargetKindConnection}
+	providerName := ""
+	metricProviderName := metricutil.UnknownAttrValue
+	connectionMode := metricutil.UnknownAttrValue
+	defer func() {
+		metricutil.RecordConnectionAuthMetrics(r.Context(), startedAt, metricProviderName, "oauth", "start", connectionMode, auditErr != nil)
+		s.auditHTTPEventWithTarget(r.Context(), PrincipalFromContext(r.Context()), providerName, "identity.connection.oauth.start", auditAllowed, auditErr, auditTarget)
+	}()
+
+	actor, ok := s.resolveManagedIdentityActor(w, r, managedIdentityRoleEditor)
+	if !ok {
+		return
+	}
+
+	var req startOAuthRequest
+	if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
+		auditErr = errors.New("invalid JSON body")
+		writeError(w, http.StatusBadRequest, "invalid JSON body")
+		return
+	}
+	providerName = req.Integration
+	if !s.managedIdentityGrantPluginVisible(req.Integration, PrincipalFromContext(r.Context())) {
+		auditErr = errors.New("integration not found")
+		writeError(w, http.StatusNotFound, "integration not found")
+		return
+	}
+
+	authSource := ""
+	if p := PrincipalFromContext(r.Context()); p != nil {
+		authSource = p.AuthSource()
+	}
+	metricProviderName, connectionMode, auditTarget, err := s.startIntegrationOAuthForOwner(w, r, req, oauthStartTarget{
+		OwnerKind:       core.IntegrationTokenOwnerKindManagedIdentity,
+		OwnerID:         actor.Identity.ID,
+		InitiatorUserID: actor.UserID,
+		AuthSource:      authSource,
+	})
+	if err != nil {
+		auditErr = err
+		return
+	}
+	providerName = metricProviderName
+	auditAllowed = true
+	auditErr = nil
+}
+
+func (s *Server) startIntegrationOAuthForOwner(w http.ResponseWriter, r *http.Request, req startOAuthRequest, target oauthStartTarget) (string, string, auditTarget, error) {
+	prov, ok := s.getProvider(w, req.Integration)
+	if !ok {
+		return metricutil.UnknownAttrValue, metricutil.UnknownAttrValue, auditTarget{Kind: auditTargetKindConnection}, errors.New("integration not found")
+	}
+	connectionMode := metricutil.NormalizeConnectionMode(prov.ConnectionMode())
+
+	connection, ok := s.resolveRequestedConnection(w, req.Integration, req.Connection)
+	if !ok {
+		return req.Integration, connectionMode, auditTarget{Kind: auditTargetKindConnection}, errors.New("invalid connection")
+	}
+	if target.OwnerKind == core.IntegrationTokenOwnerKindManagedIdentity && !s.managedIdentityConnectionVisible(req.Integration, connection) {
+		writeError(w, http.StatusNotFound, fmt.Sprintf("integration %q not found", req.Integration))
+		return req.Integration, connectionMode, auditTarget{Kind: auditTargetKindConnection}, errors.New("integration not found")
+	}
 
 	handler, ok := s.requireOAuthHandler(w, req.Integration, connection)
 	if !ok {
-		auditErr = errors.New("oauth is not configured")
-		return
+		return req.Integration, connectionMode, auditTarget{Kind: auditTargetKindConnection}, errors.New("oauth is not configured")
 	}
 
 	if s.stateCodec == nil {
-		auditErr = errors.New("oauth state encryption is not configured")
 		writeError(w, http.StatusInternalServerError, "oauth state encryption is not configured")
-		return
+		return req.Integration, connectionMode, auditTarget{Kind: auditTargetKindConnection}, errors.New("oauth state encryption is not configured")
 	}
 
-	dbUserID, instance, err := s.resolveUserConnectionSetup(w, r, req.Instance)
-	if err != nil {
-		auditErr = err
-		return
+	instance, ok := resolveRequestedInstance(w, req.Instance)
+	if !ok {
+		return req.Integration, connectionMode, auditTarget{Kind: auditTargetKindConnection}, errors.New("invalid instance")
 	}
-	auditTarget = connectionAuditTarget(req.Integration, connection, instance)
+	auditTarget := connectionAuditTarget(req.Integration, connection, instance)
 
 	connParams, ok := resolveConnectionParams(w, prov, req.ConnectionParams)
 	if !ok {
-		auditErr = errors.New("invalid connection parameters")
-		return
+		return req.Integration, connectionMode, auditTarget, errors.New("invalid connection parameters")
 	}
 
-	var authURL, verifier string
-
+	var (
+		authURL  string
+		verifier string
+	)
 	if len(connParams) > 0 {
 		rawAuthURL := handler.AuthorizationBaseURL()
 		resolvedAuthURL := paraminterp.Interpolate(rawAuthURL, connParams)
@@ -96,13 +185,19 @@ func (s *Server) startIntegrationOAuth(w http.ResponseWriter, r *http.Request) {
 		authURL, verifier = handler.StartOAuth("_", req.Scopes)
 	}
 
-	authSource := ""
-	if p := PrincipalFromContext(r.Context()); p != nil {
-		authSource = p.AuthSource()
+	legacyUserID := target.InitiatorUserID
+	if target.OwnerKind == core.IntegrationTokenOwnerKindUser {
+		legacyUserID = target.OwnerID
 	}
-	state, err := s.stateCodec.Encode(integrationOAuthState{
-		UserID:           dbUserID,
-		AuthSource:       authSource,
+	viewerScopes, viewerPerms := viewerCeilingForConnectionState(PrincipalFromContext(r.Context()))
+	encodedState, err := s.stateCodec.Encode(integrationOAuthState{
+		UserID:           legacyUserID,
+		OwnerKind:        target.OwnerKind,
+		OwnerID:          target.OwnerID,
+		InitiatorUserID:  target.InitiatorUserID,
+		AuthSource:       target.AuthSource,
+		ViewerScopes:     viewerScopes,
+		ViewerPerms:      viewerPerms,
 		Integration:      req.Integration,
 		Connection:       connection,
 		Instance:         instance,
@@ -111,21 +206,18 @@ func (s *Server) startIntegrationOAuth(w http.ResponseWriter, r *http.Request) {
 		ExpiresAt:        s.now().Add(integrationOAuthStateTTL).Unix(),
 	})
 	if err != nil {
-		auditErr = errors.New("failed to encode oauth state")
 		writeError(w, http.StatusInternalServerError, "failed to encode oauth state")
-		return
+		return req.Integration, connectionMode, auditTarget, errors.New("failed to encode oauth state")
 	}
 
-	authURL, err = setURLQueryParam(authURL, "state", state)
+	authURL, err = setURLQueryParam(authURL, "state", encodedState)
 	if err != nil {
-		auditErr = errors.New("failed to prepare oauth URL")
 		writeError(w, http.StatusInternalServerError, "failed to prepare oauth URL")
-		return
+		return req.Integration, connectionMode, auditTarget, errors.New("failed to prepare oauth URL")
 	}
 
-	auditAllowed = true
-	auditErr = nil
-	writeJSON(w, http.StatusOK, map[string]string{"url": authURL, "state": state})
+	writeJSON(w, http.StatusOK, map[string]string{"url": authURL, "state": encodedState})
+	return req.Integration, connectionMode, auditTarget, nil
 }
 
 func (s *Server) integrationOAuthCallback(w http.ResponseWriter, r *http.Request) {
@@ -195,7 +287,7 @@ func (s *Server) integrationOAuthCallback(w http.ResponseWriter, r *http.Request
 		return
 	}
 	providerName = state.Integration
-	auditUserID = state.UserID
+	auditUserID = state.InitiatorUserID
 	stateAuthSource = state.AuthSource
 	auditTarget = connectionAuditTarget(state.Integration, state.Connection, state.Instance)
 	handler, ok := s.requireOAuthHandler(w, providerName, state.Connection)
@@ -207,6 +299,62 @@ func (s *Server) integrationOAuthCallback(w http.ResponseWriter, r *http.Request
 	prov, _ := s.providers.Get(providerName)
 	if prov != nil {
 		connectionMode = metricutil.NormalizeConnectionMode(prov.ConnectionMode())
+	}
+	writeManagedIdentityCallbackError := func(err error) bool {
+		switch {
+		case errors.Is(err, core.ErrNotFound):
+			auditErr = errors.New("identity not found")
+			writeCallbackError(
+				http.StatusNotFound,
+				"identity not found",
+				providerName+" connection expired",
+				"This identity is no longer available. Start the connection again from Integrations.",
+			)
+		case errors.Is(err, errManagedIdentityAccessDenied):
+			auditErr = errManagedIdentityAccessDenied
+			writeCallbackError(
+				http.StatusForbidden,
+				"identity access denied",
+				providerName+" connection expired",
+				"You no longer have access to finish this identity connection. Start the connection again from Integrations.",
+			)
+		case errors.Is(err, errManagedIdentityIntegrationNotFound):
+			auditErr = errors.New("integration not found")
+			writeCallbackError(
+				http.StatusNotFound,
+				"integration not found",
+				providerName+" connection expired",
+				"You no longer have access to finish this identity connection. Start the connection again from Integrations.",
+			)
+		default:
+			return false
+		}
+		return true
+	}
+	if state.OwnerKind == core.IntegrationTokenOwnerKindManagedIdentity {
+		if err := s.validateManagedIdentityConnectionWrite(r.Context(), tokenMaterial{
+			OwnerKind:       state.OwnerKind,
+			OwnerID:         state.OwnerID,
+			InitiatorUserID: state.InitiatorUserID,
+			AuthSource:      state.AuthSource,
+			ViewerScopes:    append([]string(nil), state.ViewerScopes...),
+			ViewerPerms:     append([]core.AccessPermission(nil), state.ViewerPerms...),
+			Integration:     providerName,
+			Connection:      state.Connection,
+			Instance:        state.Instance,
+		}); err != nil {
+			if writeManagedIdentityCallbackError(err) {
+				return
+			}
+			auditErr = errors.New("connection setup failed")
+			writeCallbackError(
+				http.StatusInternalServerError,
+				"connection setup failed",
+				providerName+" connection failed",
+				"Gestalt could not finish saving this connection. Start the connection again from Integrations.",
+			)
+			return
+		}
 	}
 
 	var exchangeOpts []oauth.ExchangeOption
@@ -258,10 +406,12 @@ func (s *Server) integrationOAuthCallback(w http.ResponseWriter, r *http.Request
 	}
 
 	tm := tokenMaterial{
-		OwnerKind:       core.IntegrationTokenOwnerKindUser,
-		OwnerID:         state.UserID,
-		InitiatorUserID: state.UserID,
+		OwnerKind:       state.OwnerKind,
+		OwnerID:         state.OwnerID,
+		InitiatorUserID: state.InitiatorUserID,
 		AuthSource:      state.AuthSource,
+		ViewerScopes:    append([]string(nil), state.ViewerScopes...),
+		ViewerPerms:     append([]core.AccessPermission(nil), state.ViewerPerms...),
 		Integration:     providerName,
 		Connection:      state.Connection,
 		Instance:        callbackInstance,
@@ -273,6 +423,11 @@ func (s *Server) integrationOAuthCallback(w http.ResponseWriter, r *http.Request
 
 	result, err := s.runPostConnect(r.Context(), prov, tm)
 	if err != nil {
+		if state.OwnerKind == core.IntegrationTokenOwnerKindManagedIdentity {
+			if writeManagedIdentityCallbackError(err) {
+				return
+			}
+		}
 		auditErr = errors.New("connection setup failed")
 		slog.ErrorContext(r.Context(), "post_connect failed", "provider", providerName, "error", err)
 		writeCallbackError(
@@ -298,5 +453,17 @@ func (s *Server) integrationOAuthCallback(w http.ResponseWriter, r *http.Request
 	}
 	auditAllowed = true
 	auditErr = nil
-	http.Redirect(w, r, "/integrations?connected="+url.QueryEscape(providerName), http.StatusSeeOther)
+	redirectURL, err := setURLQueryParam(integrationOAuthRedirectPath(state), "connected", providerName)
+	if err != nil {
+		auditAllowed = false
+		auditErr = errors.New("failed to prepare redirect URL")
+		writeCallbackError(
+			http.StatusInternalServerError,
+			"failed to prepare redirect URL",
+			providerName+" connection failed",
+			"Gestalt saved the connection but could not redirect you back to the app.",
+		)
+		return
+	}
+	http.Redirect(w, r, redirectURL, http.StatusSeeOther)
 }

--- a/gestaltd/internal/server/oauth_state.go
+++ b/gestaltd/internal/server/oauth_state.go
@@ -5,6 +5,7 @@ import (
 	"errors"
 	"fmt"
 	"net/url"
+	"strings"
 	"time"
 
 	"github.com/valon-technologies/gestalt/server/core"
@@ -17,14 +18,19 @@ const pendingConnectionTTL = 30 * time.Minute
 var errPendingConnectionExpired = errors.New("pending connection expired")
 
 type integrationOAuthState struct {
-	UserID           string            `json:"uid"`
-	AuthSource       string            `json:"src,omitempty"`
-	Integration      string            `json:"int"`
-	Connection       string            `json:"con,omitempty"`
-	Instance         string            `json:"ins,omitempty"`
-	Verifier         string            `json:"ver,omitempty"`
-	ConnectionParams map[string]string `json:"cp,omitempty"`
-	ExpiresAt        int64             `json:"exp"`
+	UserID           string                  `json:"uid,omitempty"`
+	OwnerKind        string                  `json:"ok,omitempty"`
+	OwnerID          string                  `json:"oid,omitempty"`
+	InitiatorUserID  string                  `json:"iuid,omitempty"`
+	AuthSource       string                  `json:"src,omitempty"`
+	ViewerScopes     []string                `json:"vsc,omitempty"`
+	ViewerPerms      []core.AccessPermission `json:"vpm,omitempty"`
+	Integration      string                  `json:"int"`
+	Connection       string                  `json:"con,omitempty"`
+	Instance         string                  `json:"ins,omitempty"`
+	Verifier         string                  `json:"ver,omitempty"`
+	ConnectionParams map[string]string       `json:"cp,omitempty"`
+	ExpiresAt        int64                   `json:"exp"`
 }
 
 type integrationOAuthStateCodec struct {
@@ -65,8 +71,12 @@ func decodeEncryptedState[T any](enc *cryptoutil.AESGCMEncryptor, label, encoded
 }
 
 func validateIntegrationOAuthState(state *integrationOAuthState, now time.Time) error {
-	if state.UserID == "" {
-		return fmt.Errorf("oauth state missing user ID")
+	normalizeIntegrationOAuthState(state)
+	if state.OwnerKind == "" || state.OwnerID == "" {
+		return fmt.Errorf("oauth state missing owner")
+	}
+	if state.InitiatorUserID == "" {
+		return fmt.Errorf("oauth state missing initiator user ID")
 	}
 	if state.Integration == "" {
 		return fmt.Errorf("oauth state missing integration")
@@ -78,6 +88,34 @@ func validateIntegrationOAuthState(state *integrationOAuthState, now time.Time) 
 		return fmt.Errorf("oauth state expired")
 	}
 	return nil
+}
+
+func normalizeIntegrationOAuthState(state *integrationOAuthState) {
+	if state == nil {
+		return
+	}
+	if state.OwnerKind == "" {
+		if strings.TrimSpace(state.OwnerID) != "" {
+			state.OwnerKind = core.IntegrationTokenOwnerKindUser
+		} else if strings.TrimSpace(state.UserID) != "" {
+			state.OwnerKind = core.IntegrationTokenOwnerKindUser
+			state.OwnerID = strings.TrimSpace(state.UserID)
+		}
+	}
+	if state.OwnerID == "" && state.OwnerKind == core.IntegrationTokenOwnerKindUser {
+		state.OwnerID = strings.TrimSpace(state.UserID)
+	}
+	if state.UserID == "" && state.OwnerKind == core.IntegrationTokenOwnerKindUser {
+		state.UserID = strings.TrimSpace(state.OwnerID)
+	}
+	if state.InitiatorUserID == "" {
+		switch state.OwnerKind {
+		case core.IntegrationTokenOwnerKindUser:
+			state.InitiatorUserID = strings.TrimSpace(state.OwnerID)
+		default:
+			state.InitiatorUserID = strings.TrimSpace(state.UserID)
+		}
+	}
 }
 
 func (c *integrationOAuthStateCodec) Encode(state integrationOAuthState) (string, error) {
@@ -93,6 +131,20 @@ func (c *integrationOAuthStateCodec) Decode(encoded string, now time.Time) (*int
 		return nil, err
 	}
 	return state, nil
+}
+
+func integrationOAuthRedirectPath(state *integrationOAuthState) string {
+	if state == nil {
+		return "/integrations"
+	}
+	if state.OwnerKind == core.IntegrationTokenOwnerKindManagedIdentity && strings.TrimSpace(state.OwnerID) != "" {
+		u := &url.URL{Path: "/identities"}
+		q := u.Query()
+		q.Set("id", state.OwnerID)
+		u.RawQuery = q.Encode()
+		return u.String()
+	}
+	return "/integrations"
 }
 
 const loginStateTTL = 10 * time.Minute

--- a/gestaltd/internal/server/pending_connection.go
+++ b/gestaltd/internal/server/pending_connection.go
@@ -315,7 +315,24 @@ func (s *Server) authorizePendingConnection(w http.ResponseWriter, r *http.Reque
 	}
 	if state != nil && state.Token.OwnerKind == core.IntegrationTokenOwnerKindManagedIdentity {
 		if !authenticated {
-			writeError(w, http.StatusUnauthorized, "identity connection authorization required")
+			if err := s.authorizePendingConnectionByCookie(r, state); err != nil {
+				writeError(w, http.StatusUnauthorized, "identity connection authorization required")
+				return nil, false
+			}
+			p = s.managedIdentityConnectionViewerPrincipal(r.Context(), state.Token)
+		}
+		if _, err := s.managedIdentityActor(
+			r.Context(),
+			state.Token.OwnerID,
+			pendingConnectionInitiatorUserID(state),
+			managedIdentityRoleEditor,
+		); err != nil {
+			switch {
+			case errors.Is(err, core.ErrNotFound), errors.Is(err, errManagedIdentityAccessDenied):
+				writeError(w, http.StatusNotFound, "pending connection not found")
+			default:
+				writeError(w, http.StatusInternalServerError, "failed to validate pending connection")
+			}
 			return nil, false
 		}
 		return p, true

--- a/gestaltd/internal/server/routes_user.go
+++ b/gestaltd/internal/server/routes_user.go
@@ -39,6 +39,7 @@ func (s *Server) mountAuthenticatedRoutes(r chi.Router) {
 			r.Delete("/{identityID}/tokens/{id}", s.revokeManagedIdentityToken)
 			r.Get("/{identityID}/integrations", s.listManagedIdentityIntegrations)
 			r.Delete("/{identityID}/integrations/{name}", s.disconnectManagedIdentityIntegration)
+			r.Post("/{identityID}/auth/start-oauth", s.startManagedIdentityOAuth)
 			r.Post("/{identityID}/auth/connect-manual", s.connectManagedIdentityManual)
 		})
 	})

--- a/gestaltd/internal/server/server_test.go
+++ b/gestaltd/internal/server/server_test.go
@@ -9690,6 +9690,668 @@ func TestIntegrationOAuthCallback_InvalidState(t *testing.T) {
 	})
 }
 
+func TestManagedIdentityIntegrationOAuthCallback(t *testing.T) {
+	t.Parallel()
+
+	t.Run("connected", func(t *testing.T) {
+		t.Parallel()
+
+		svc := coretesting.NewStubServices(t)
+		admin := seedUser(t, svc, "admin@example.test")
+		editor := seedUser(t, svc, "editor@example.test")
+
+		handler := &testOAuthHandler{
+			authorizationBaseURLVal: "https://slack.com/oauth/v2/authorize",
+			exchangeCodeFn: func(_ context.Context, code string) (*core.TokenResponse, error) {
+				if code == "good-code" {
+					return &core.TokenResponse{AccessToken: "slack-token"}, nil
+				}
+				return nil, fmt.Errorf("bad code")
+			},
+		}
+
+		stub := &stubIntegrationWithAuthURL{
+			StubIntegration: coretesting.StubIntegration{N: "slack"},
+			authURL:         "https://slack.com/oauth/v2/authorize",
+		}
+		providers := testutil.NewProviderRegistry(t, stub)
+		pluginDefs := map[string]*config.ProviderEntry{
+			"slack": {AuthorizationPolicy: "slack_policy"},
+		}
+		authz := mustAuthorizer(
+			t,
+			config.AuthorizationConfig{
+				Policies: map[string]config.HumanPolicyDef{
+					"slack_policy": {
+						Members: []config.HumanPolicyMemberDef{{
+							Email: editor.Email,
+							Role:  "editor",
+						}},
+					},
+				},
+			},
+			providers,
+			pluginDefs,
+			map[string]string{"slack": testDefaultConnection},
+		)
+
+		ts := newTestServer(t, func(cfg *server.Config) {
+			cfg.Auth = &coretesting.StubAuthProvider{
+				N: "test",
+				ValidateTokenFn: func(_ context.Context, token string) (*core.UserIdentity, error) {
+					switch token {
+					case "admin-session":
+						return &core.UserIdentity{Email: admin.Email}, nil
+					case "editor-session":
+						return &core.UserIdentity{Email: editor.Email}, nil
+					default:
+						return nil, fmt.Errorf("bad token %q", token)
+					}
+				},
+			}
+			cfg.Providers = providers
+			cfg.DefaultConnection = map[string]string{"slack": testDefaultConnection}
+			cfg.ConnectionAuth = testConnectionAuth("slack", handler)
+			cfg.Services = svc
+			cfg.Authorizer = authz
+			cfg.PluginDefs = pluginDefs
+		})
+		testutil.CloseOnCleanup(t, ts)
+
+		createResp := struct {
+			ID string `json:"id"`
+		}{}
+		doJSONRequestAndDecode(t, http.MethodPost, ts.URL+"/api/v1/identities", "admin-session", `{"displayName":"OAuth Bot"}`, http.StatusCreated, &createResp)
+		doJSONRequestAndDecode(t, http.MethodPut, ts.URL+"/api/v1/identities/"+createResp.ID+"/members", "admin-session", `{"email":"editor@example.test","role":"editor"}`, http.StatusOK, nil)
+
+		startBody := bytes.NewBufferString(`{"integration":"slack"}`)
+		startReq, _ := http.NewRequest(http.MethodPost, ts.URL+"/api/v1/identities/"+createResp.ID+"/auth/start-oauth", startBody)
+		startReq.Header.Set("Content-Type", "application/json")
+		startReq.Header.Set("Authorization", "Bearer editor-session")
+		startResp, err := http.DefaultClient.Do(startReq)
+		if err != nil {
+			t.Fatalf("start request: %v", err)
+		}
+		defer func() { _ = startResp.Body.Close() }()
+		if startResp.StatusCode != http.StatusOK {
+			body, _ := io.ReadAll(startResp.Body)
+			t.Fatalf("expected 200 from identity start-oauth, got %d: %s", startResp.StatusCode, body)
+		}
+
+		var startResult map[string]string
+		if err := json.NewDecoder(startResp.Body).Decode(&startResult); err != nil {
+			t.Fatalf("decoding start response: %v", err)
+		}
+
+		noRedirect := &http.Client{
+			CheckRedirect: func(*http.Request, []*http.Request) error {
+				return http.ErrUseLastResponse
+			},
+		}
+		req, _ := http.NewRequest(http.MethodGet, ts.URL+"/api/v1/auth/callback?code=good-code&state="+url.QueryEscape(startResult["state"]), nil)
+		resp, err := noRedirect.Do(req)
+		if err != nil {
+			t.Fatalf("callback request: %v", err)
+		}
+		defer func() { _ = resp.Body.Close() }()
+
+		if resp.StatusCode != http.StatusSeeOther {
+			body, _ := io.ReadAll(resp.Body)
+			t.Fatalf("expected 303, got %d: %s", resp.StatusCode, body)
+		}
+		expectedLocation := "/identities?connected=slack&id=" + url.QueryEscape(createResp.ID)
+		if loc := resp.Header.Get("Location"); loc != expectedLocation {
+			t.Fatalf("expected redirect to %s, got %q", expectedLocation, loc)
+		}
+
+		tokens, err := svc.Tokens.ListTokensByOwner(context.Background(), core.IntegrationTokenOwnerKindManagedIdentity, createResp.ID)
+		if err != nil {
+			t.Fatalf("ListTokensByOwner: %v", err)
+		}
+		if len(tokens) != 1 {
+			t.Fatalf("expected 1 identity-owned oauth token, got %d", len(tokens))
+		}
+		if tokens[0].OwnerKind != core.IntegrationTokenOwnerKindManagedIdentity || tokens[0].OwnerID != createResp.ID {
+			t.Fatalf("stored token owner = (%q,%q), want managed_identity/%q", tokens[0].OwnerKind, tokens[0].OwnerID, createResp.ID)
+		}
+		if tokens[0].AccessToken != "slack-token" {
+			t.Fatalf("stored access token = %q, want slack-token", tokens[0].AccessToken)
+		}
+	})
+
+	t.Run("connected_uses_initiator_visibility_not_browser_session", func(t *testing.T) {
+		t.Parallel()
+
+		svc := coretesting.NewStubServices(t)
+		admin := seedUser(t, svc, "admin@example.test")
+		editor := seedUser(t, svc, "editor@example.test")
+
+		handler := &testOAuthHandler{
+			authorizationBaseURLVal: "https://slack.com/oauth/v2/authorize",
+			exchangeCodeFn: func(_ context.Context, code string) (*core.TokenResponse, error) {
+				if code == "good-code" {
+					return &core.TokenResponse{AccessToken: "slack-token"}, nil
+				}
+				return nil, fmt.Errorf("bad code")
+			},
+		}
+
+		stub := &stubIntegrationWithAuthURL{
+			StubIntegration: coretesting.StubIntegration{N: "slack"},
+			authURL:         "https://slack.com/oauth/v2/authorize",
+		}
+		providers := testutil.NewProviderRegistry(t, stub)
+		pluginDefs := map[string]*config.ProviderEntry{
+			"slack": {AuthorizationPolicy: "slack_policy"},
+		}
+		authz := mustAuthorizer(
+			t,
+			config.AuthorizationConfig{
+				Policies: map[string]config.HumanPolicyDef{
+					"slack_policy": {
+						Members: []config.HumanPolicyMemberDef{{
+							Email: editor.Email,
+							Role:  "editor",
+						}},
+					},
+				},
+			},
+			providers,
+			pluginDefs,
+			map[string]string{"slack": testDefaultConnection},
+		)
+
+		ts := newTestServer(t, func(cfg *server.Config) {
+			cfg.Auth = &coretesting.StubAuthProvider{
+				N: "test",
+				ValidateTokenFn: func(_ context.Context, token string) (*core.UserIdentity, error) {
+					switch token {
+					case "admin-session":
+						return &core.UserIdentity{Email: admin.Email}, nil
+					case "editor-session":
+						return &core.UserIdentity{Email: editor.Email}, nil
+					default:
+						return nil, fmt.Errorf("bad token %q", token)
+					}
+				},
+			}
+			cfg.Providers = providers
+			cfg.DefaultConnection = map[string]string{"slack": testDefaultConnection}
+			cfg.ConnectionAuth = testConnectionAuth("slack", handler)
+			cfg.Services = svc
+			cfg.Authorizer = authz
+			cfg.PluginDefs = pluginDefs
+		})
+		testutil.CloseOnCleanup(t, ts)
+
+		createResp := struct {
+			ID string `json:"id"`
+		}{}
+		doJSONRequestAndDecode(t, http.MethodPost, ts.URL+"/api/v1/identities", "admin-session", `{"displayName":"OAuth Bot"}`, http.StatusCreated, &createResp)
+		doJSONRequestAndDecode(t, http.MethodPut, ts.URL+"/api/v1/identities/"+createResp.ID+"/members", "admin-session", `{"email":"editor@example.test","role":"editor"}`, http.StatusOK, nil)
+
+		startReq, _ := http.NewRequest(http.MethodPost, ts.URL+"/api/v1/identities/"+createResp.ID+"/auth/start-oauth", bytes.NewBufferString(`{"integration":"slack"}`))
+		startReq.Header.Set("Content-Type", "application/json")
+		startReq.Header.Set("Authorization", "Bearer editor-session")
+		startResp, err := http.DefaultClient.Do(startReq)
+		if err != nil {
+			t.Fatalf("start request: %v", err)
+		}
+		defer func() { _ = startResp.Body.Close() }()
+		if startResp.StatusCode != http.StatusOK {
+			body, _ := io.ReadAll(startResp.Body)
+			t.Fatalf("expected 200 from identity start-oauth, got %d: %s", startResp.StatusCode, body)
+		}
+
+		var startResult map[string]string
+		if err := json.NewDecoder(startResp.Body).Decode(&startResult); err != nil {
+			t.Fatalf("decoding start response: %v", err)
+		}
+
+		noRedirect := &http.Client{
+			CheckRedirect: func(*http.Request, []*http.Request) error {
+				return http.ErrUseLastResponse
+			},
+		}
+		req, _ := http.NewRequest(http.MethodGet, ts.URL+"/api/v1/auth/callback?code=good-code&state="+url.QueryEscape(startResult["state"]), nil)
+		req.AddCookie(&http.Cookie{Name: "session_token", Value: "admin-session"})
+		resp, err := noRedirect.Do(req)
+		if err != nil {
+			t.Fatalf("callback request: %v", err)
+		}
+		defer func() { _ = resp.Body.Close() }()
+
+		if resp.StatusCode != http.StatusSeeOther {
+			body, _ := io.ReadAll(resp.Body)
+			t.Fatalf("expected 303, got %d: %s", resp.StatusCode, body)
+		}
+		expectedLocation := "/identities?connected=slack&id=" + url.QueryEscape(createResp.ID)
+		if loc := resp.Header.Get("Location"); loc != expectedLocation {
+			t.Fatalf("expected redirect to %s, got %q", expectedLocation, loc)
+		}
+	})
+
+	t.Run("start_state_preserves_api_token_viewer_ceiling", func(t *testing.T) {
+		t.Parallel()
+
+		svc := coretesting.NewStubServices(t)
+		admin := seedUser(t, svc, "admin@example.test")
+		editor := seedUser(t, svc, "editor@example.test")
+
+		handler := &testOAuthHandler{
+			authorizationBaseURLVal: "https://slack.com/oauth/v2/authorize",
+		}
+		stub := &stubIntegrationWithAuthURL{
+			StubIntegration: coretesting.StubIntegration{N: "slack"},
+			authURL:         "https://slack.com/oauth/v2/authorize",
+		}
+		providers := testutil.NewProviderRegistry(t, stub)
+		pluginDefs := map[string]*config.ProviderEntry{
+			"slack": {AuthorizationPolicy: "slack_policy"},
+		}
+		authz := mustAuthorizer(
+			t,
+			config.AuthorizationConfig{
+				Policies: map[string]config.HumanPolicyDef{
+					"slack_policy": {
+						Members: []config.HumanPolicyMemberDef{{
+							Email: editor.Email,
+							Role:  "editor",
+						}},
+					},
+				},
+			},
+			providers,
+			pluginDefs,
+			map[string]string{"slack": testDefaultConnection},
+		)
+
+		apiToken, hashed, err := principal.GenerateToken(principal.TokenTypeAPI)
+		if err != nil {
+			t.Fatalf("GenerateToken: %v", err)
+		}
+		exp := time.Now().Add(24 * time.Hour)
+		if err := svc.APITokens.StoreAPIToken(context.Background(), &core.APIToken{
+			ID:          "editor-api-token",
+			UserID:      editor.ID,
+			OwnerKind:   core.APITokenOwnerKindUser,
+			OwnerID:     editor.ID,
+			Name:        "editor-api-token",
+			HashedToken: hashed,
+			Permissions: []core.AccessPermission{{Plugin: "slack"}},
+			ExpiresAt:   &exp,
+		}); err != nil {
+			t.Fatalf("StoreAPIToken: %v", err)
+		}
+
+		ts := newTestServer(t, func(cfg *server.Config) {
+			cfg.Auth = &coretesting.StubAuthProvider{
+				N: "test",
+				ValidateTokenFn: func(_ context.Context, token string) (*core.UserIdentity, error) {
+					switch token {
+					case "admin-session":
+						return &core.UserIdentity{Email: admin.Email}, nil
+					case "editor-session":
+						return &core.UserIdentity{Email: editor.Email}, nil
+					default:
+						return nil, fmt.Errorf("bad token %q", token)
+					}
+				},
+			}
+			cfg.Providers = providers
+			cfg.DefaultConnection = map[string]string{"slack": testDefaultConnection}
+			cfg.ConnectionAuth = testConnectionAuth("slack", handler)
+			cfg.Services = svc
+			cfg.Authorizer = authz
+			cfg.PluginDefs = pluginDefs
+		})
+		testutil.CloseOnCleanup(t, ts)
+
+		createResp := struct {
+			ID string `json:"id"`
+		}{}
+		doJSONRequestAndDecode(t, http.MethodPost, ts.URL+"/api/v1/identities", "admin-session", `{"displayName":"OAuth Bot"}`, http.StatusCreated, &createResp)
+		doJSONRequestAndDecode(t, http.MethodPut, ts.URL+"/api/v1/identities/"+createResp.ID+"/members", "admin-session", `{"email":"editor@example.test","role":"editor"}`, http.StatusOK, nil)
+
+		startReq, _ := http.NewRequest(http.MethodPost, ts.URL+"/api/v1/identities/"+createResp.ID+"/auth/start-oauth", bytes.NewBufferString(`{"integration":"slack"}`))
+		startReq.Header.Set("Content-Type", "application/json")
+		startReq.Header.Set("Authorization", "Bearer "+apiToken)
+		startResp, err := http.DefaultClient.Do(startReq)
+		if err != nil {
+			t.Fatalf("start request: %v", err)
+		}
+		defer func() { _ = startResp.Body.Close() }()
+		if startResp.StatusCode != http.StatusOK {
+			body, _ := io.ReadAll(startResp.Body)
+			t.Fatalf("expected 200 from identity start-oauth, got %d: %s", startResp.StatusCode, body)
+		}
+
+		var startResult map[string]string
+		if err := json.NewDecoder(startResp.Body).Decode(&startResult); err != nil {
+			t.Fatalf("decoding start response: %v", err)
+		}
+
+		enc, err := corecrypto.NewAESGCM([]byte("0123456789abcdef0123456789abcdef"))
+		if err != nil {
+			t.Fatalf("NewAESGCM: %v", err)
+		}
+		plaintext, err := enc.DecryptURLSafe(startResult["state"])
+		if err != nil {
+			t.Fatalf("DecryptURLSafe: %v", err)
+		}
+
+		var decoded struct {
+			ViewerScopes    []string                `json:"vsc"`
+			ViewerPerms     []core.AccessPermission `json:"vpm"`
+			InitiatorUserID string                  `json:"iuid"`
+		}
+		if err := json.Unmarshal([]byte(plaintext), &decoded); err != nil {
+			t.Fatalf("Unmarshal state: %v", err)
+		}
+		if decoded.InitiatorUserID != editor.ID {
+			t.Fatalf("initiator user id = %q, want %q", decoded.InitiatorUserID, editor.ID)
+		}
+		if !reflect.DeepEqual(decoded.ViewerScopes, []string{"slack"}) {
+			t.Fatalf("viewer scopes = %+v, want [slack]", decoded.ViewerScopes)
+		}
+		if !reflect.DeepEqual(decoded.ViewerPerms, []core.AccessPermission{{Plugin: "slack"}}) {
+			t.Fatalf("viewer permissions = %+v, want [{Plugin: slack}]", decoded.ViewerPerms)
+		}
+	})
+
+	t.Run("selection_required", func(t *testing.T) {
+		t.Parallel()
+
+		const pendingSelectionPath = "/api/v1/auth/pending-connection"
+
+		discoverySrv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+			w.Header().Set("Content-Type", "application/json")
+			_, _ = io.WriteString(w, `[{"id":"site-a","name":"Site A","workspace":"alpha"},{"id":"site-b","name":"Site B","workspace":"beta"}]`)
+		}))
+		testutil.CloseOnCleanup(t, discoverySrv)
+
+		svc := coretesting.NewStubServices(t)
+		admin := seedUser(t, svc, "admin@example.test")
+		editor := seedUser(t, svc, "editor@example.test")
+
+		handler := &testOAuthHandler{
+			authorizationBaseURLVal: "https://slack.com/oauth/v2/authorize",
+			exchangeCodeFn: func(_ context.Context, code string) (*core.TokenResponse, error) {
+				if code == "good-code" {
+					return &core.TokenResponse{AccessToken: "slack-token"}, nil
+				}
+				return nil, fmt.Errorf("bad code")
+			},
+		}
+
+		stub := &stubDiscoveringProvider{
+			StubIntegration: coretesting.StubIntegration{N: "slack"},
+			discovery: &core.DiscoveryConfig{
+				URL:      discoverySrv.URL,
+				IDPath:   "id",
+				NamePath: "name",
+				Metadata: map[string]string{"workspace": "workspace"},
+			},
+		}
+		providers := testutil.NewProviderRegistry(t, stub)
+		pluginDefs := map[string]*config.ProviderEntry{
+			"slack": {AuthorizationPolicy: "slack_policy"},
+		}
+		authz := mustAuthorizer(
+			t,
+			config.AuthorizationConfig{
+				Policies: map[string]config.HumanPolicyDef{
+					"slack_policy": {
+						Members: []config.HumanPolicyMemberDef{{
+							Email: editor.Email,
+							Role:  "editor",
+						}},
+					},
+				},
+			},
+			providers,
+			pluginDefs,
+			map[string]string{"slack": testDefaultConnection},
+		)
+
+		ts := newTestServer(t, func(cfg *server.Config) {
+			cfg.Auth = &coretesting.StubAuthProvider{
+				N: "test",
+				ValidateTokenFn: func(_ context.Context, token string) (*core.UserIdentity, error) {
+					switch token {
+					case "admin-session":
+						return &core.UserIdentity{Email: admin.Email}, nil
+					case "editor-session":
+						return &core.UserIdentity{Email: editor.Email}, nil
+					default:
+						return nil, fmt.Errorf("bad token %q", token)
+					}
+				},
+			}
+			cfg.Providers = providers
+			cfg.DefaultConnection = map[string]string{"slack": testDefaultConnection}
+			cfg.ConnectionAuth = testConnectionAuth("slack", handler)
+			cfg.Services = svc
+			cfg.Authorizer = authz
+			cfg.PluginDefs = pluginDefs
+		})
+		testutil.CloseOnCleanup(t, ts)
+
+		createResp := struct {
+			ID string `json:"id"`
+		}{}
+		doJSONRequestAndDecode(t, http.MethodPost, ts.URL+"/api/v1/identities", "admin-session", `{"displayName":"OAuth Bot"}`, http.StatusCreated, &createResp)
+		doJSONRequestAndDecode(t, http.MethodPut, ts.URL+"/api/v1/identities/"+createResp.ID+"/members", "admin-session", `{"email":"editor@example.test","role":"editor"}`, http.StatusOK, nil)
+
+		startBody := bytes.NewBufferString(`{"integration":"slack"}`)
+		startReq, _ := http.NewRequest(http.MethodPost, ts.URL+"/api/v1/identities/"+createResp.ID+"/auth/start-oauth", startBody)
+		startReq.Header.Set("Content-Type", "application/json")
+		startReq.Header.Set("Authorization", "Bearer editor-session")
+		startResp, err := http.DefaultClient.Do(startReq)
+		if err != nil {
+			t.Fatalf("start request: %v", err)
+		}
+		defer func() { _ = startResp.Body.Close() }()
+
+		var startResult map[string]string
+		if err := json.NewDecoder(startResp.Body).Decode(&startResult); err != nil {
+			t.Fatalf("decoding start response: %v", err)
+		}
+
+		jar, err := cookiejar.New(nil)
+		if err != nil {
+			t.Fatalf("cookie jar: %v", err)
+		}
+		noRedirect := &http.Client{
+			Jar: jar,
+			CheckRedirect: func(*http.Request, []*http.Request) error {
+				return http.ErrUseLastResponse
+			},
+		}
+		req, _ := http.NewRequest(http.MethodGet, ts.URL+"/api/v1/auth/callback?code=good-code&state="+url.QueryEscape(startResult["state"]), nil)
+		resp, err := noRedirect.Do(req)
+		if err != nil {
+			t.Fatalf("callback request: %v", err)
+		}
+		defer func() { _ = resp.Body.Close() }()
+
+		if resp.StatusCode != http.StatusOK {
+			body, _ := io.ReadAll(resp.Body)
+			t.Fatalf("expected 200, got %d: %s", resp.StatusCode, body)
+		}
+		body, err := io.ReadAll(resp.Body)
+		if err != nil {
+			t.Fatalf("read body: %v", err)
+		}
+		text := string(body)
+		if !strings.Contains(text, "Select a slack connection") {
+			t.Fatalf("expected selection page, got %q", text)
+		}
+		selectionURL, err := url.Parse(ts.URL + pendingSelectionPath)
+		if err != nil {
+			t.Fatalf("parse selection url: %v", err)
+		}
+		cookies := jar.Cookies(selectionURL)
+		foundPendingCookie := false
+		for _, cookie := range cookies {
+			if cookie.Name == "pending_connection_state" {
+				foundPendingCookie = true
+				break
+			}
+		}
+		if !foundPendingCookie {
+			t.Fatal("expected pending connection cookie to be set on callback response")
+		}
+
+		form := url.Values{
+			"pending_token":   {extractHiddenInputValue(t, text, "pending_token")},
+			"candidate_index": {"1"},
+		}
+		selectReq, _ := http.NewRequest(http.MethodPost, ts.URL+pendingSelectionPath, strings.NewReader(form.Encode()))
+		selectReq.Header.Set("Content-Type", "application/x-www-form-urlencoded")
+		selectResp, err := noRedirect.Do(selectReq)
+		if err != nil {
+			t.Fatalf("select request: %v", err)
+		}
+		defer func() { _ = selectResp.Body.Close() }()
+
+		if selectResp.StatusCode != http.StatusOK {
+			body, _ := io.ReadAll(selectResp.Body)
+			t.Fatalf("expected 200, got %d: %s", selectResp.StatusCode, body)
+		}
+		tokens, err := svc.Tokens.ListTokensByOwner(context.Background(), core.IntegrationTokenOwnerKindManagedIdentity, createResp.ID)
+		if err != nil {
+			t.Fatalf("ListTokensByOwner: %v", err)
+		}
+		if len(tokens) != 1 {
+			t.Fatalf("expected 1 identity-owned oauth token after selection, got %d", len(tokens))
+		}
+		if !strings.Contains(tokens[0].MetadataJSON, `"workspace":"beta"`) {
+			t.Fatalf("metadata json = %q, want selected candidate metadata", tokens[0].MetadataJSON)
+		}
+	})
+
+	t.Run("rejects_hidden_identity_connection", func(t *testing.T) {
+		t.Parallel()
+
+		svc := coretesting.NewStubServices(t)
+		admin := seedUser(t, svc, "admin@example.test")
+		editor := seedUser(t, svc, "editor@example.test")
+
+		handler := &testOAuthHandler{
+			authorizationBaseURLVal: "https://slack.com/oauth/v2/authorize",
+		}
+		stub := &stubIntegrationWithAuthURL{
+			StubIntegration: coretesting.StubIntegration{N: "slack"},
+			authURL:         "https://slack.com/oauth/v2/authorize",
+		}
+		providers := testutil.NewProviderRegistry(t, stub)
+		pluginDefs := map[string]*config.ProviderEntry{
+			"slack": {
+				AuthorizationPolicy: "slack_policy",
+				ResolvedManifest: &providermanifestv1.Manifest{
+					Spec: &providermanifestv1.Spec{
+						DefaultConnection: testDefaultConnection,
+						Connections: map[string]*providermanifestv1.ManifestConnectionDef{
+							testDefaultConnection: {
+								Mode: providermanifestv1.ConnectionModeUser,
+								Auth: &providermanifestv1.ProviderAuth{Type: providermanifestv1.AuthTypeOAuth2},
+							},
+							"identity": {
+								Mode: providermanifestv1.ConnectionModeIdentity,
+								Auth: &providermanifestv1.ProviderAuth{Type: providermanifestv1.AuthTypeOAuth2},
+							},
+						},
+					},
+				},
+			},
+		}
+		authz := mustAuthorizer(
+			t,
+			config.AuthorizationConfig{
+				Policies: map[string]config.HumanPolicyDef{
+					"slack_policy": {
+						Members: []config.HumanPolicyMemberDef{{
+							Email: editor.Email,
+							Role:  "editor",
+						}},
+					},
+				},
+			},
+			providers,
+			pluginDefs,
+			map[string]string{"slack": testDefaultConnection},
+		)
+
+		ts := newTestServer(t, func(cfg *server.Config) {
+			cfg.Auth = &coretesting.StubAuthProvider{
+				N: "test",
+				ValidateTokenFn: func(_ context.Context, token string) (*core.UserIdentity, error) {
+					switch token {
+					case "admin-session":
+						return &core.UserIdentity{Email: admin.Email}, nil
+					case "editor-session":
+						return &core.UserIdentity{Email: editor.Email}, nil
+					default:
+						return nil, fmt.Errorf("bad token %q", token)
+					}
+				},
+			}
+			cfg.Providers = providers
+			cfg.DefaultConnection = map[string]string{"slack": testDefaultConnection}
+			cfg.ConnectionAuth = func() map[string]map[string]bootstrap.OAuthHandler {
+				return map[string]map[string]bootstrap.OAuthHandler{
+					"slack": {
+						testDefaultConnection: handler,
+						"identity":            handler,
+						"hidden":              handler,
+					},
+				}
+			}
+			cfg.Services = svc
+			cfg.Authorizer = authz
+			cfg.PluginDefs = pluginDefs
+		})
+		testutil.CloseOnCleanup(t, ts)
+
+		createResp := struct {
+			ID string `json:"id"`
+		}{}
+		doJSONRequestAndDecode(t, http.MethodPost, ts.URL+"/api/v1/identities", "admin-session", `{"displayName":"OAuth Bot"}`, http.StatusCreated, &createResp)
+		doJSONRequestAndDecode(t, http.MethodPut, ts.URL+"/api/v1/identities/"+createResp.ID+"/members", "admin-session", `{"email":"editor@example.test","role":"editor"}`, http.StatusOK, nil)
+
+		startBody := bytes.NewBufferString(`{"integration":"slack","connection":"identity"}`)
+		startReq, _ := http.NewRequest(http.MethodPost, ts.URL+"/api/v1/identities/"+createResp.ID+"/auth/start-oauth", startBody)
+		startReq.Header.Set("Content-Type", "application/json")
+		startReq.Header.Set("Authorization", "Bearer editor-session")
+		startResp, err := http.DefaultClient.Do(startReq)
+		if err != nil {
+			t.Fatalf("start request: %v", err)
+		}
+		defer func() { _ = startResp.Body.Close() }()
+
+		if startResp.StatusCode != http.StatusNotFound {
+			body, _ := io.ReadAll(startResp.Body)
+			t.Fatalf("expected 404 from hidden identity start-oauth, got %d: %s", startResp.StatusCode, body)
+		}
+
+		unadvertisedBody := bytes.NewBufferString(`{"integration":"slack","connection":"hidden"}`)
+		unadvertisedReq, _ := http.NewRequest(http.MethodPost, ts.URL+"/api/v1/identities/"+createResp.ID+"/auth/start-oauth", unadvertisedBody)
+		unadvertisedReq.Header.Set("Content-Type", "application/json")
+		unadvertisedReq.Header.Set("Authorization", "Bearer editor-session")
+		unadvertisedResp, err := http.DefaultClient.Do(unadvertisedReq)
+		if err != nil {
+			t.Fatalf("unadvertised start request: %v", err)
+		}
+		defer func() { _ = unadvertisedResp.Body.Close() }()
+
+		if unadvertisedResp.StatusCode != http.StatusNotFound {
+			body, _ := io.ReadAll(unadvertisedResp.Body)
+			t.Fatalf("expected 404 from unadvertised identity start-oauth, got %d: %s", unadvertisedResp.StatusCode, body)
+		}
+	})
+}
+
 func TestCreateAndListAPITokens(t *testing.T) {
 	t.Parallel()
 
@@ -10292,11 +10954,39 @@ func (s *stubIntegrationWithSessionCatalog) CallTool(ctx context.Context, name s
 	return mcpgo.NewToolResultText("passthrough:" + name), nil
 }
 
-type stubSessionCatalogWithoutManagedIdentitySupport struct {
-	stubIntegrationWithSessionCatalog
+type stubNonOAuthSessionCatalogProvider struct {
+	name                string
+	connMode            core.ConnectionMode
+	catalog             *catalog.Catalog
+	catalogForRequestFn func(context.Context, string) (*catalog.Catalog, error)
 }
 
-func (s *stubSessionCatalogWithoutManagedIdentitySupport) AuthTypes() []string { return nil }
+func (s *stubNonOAuthSessionCatalogProvider) Name() string        { return s.name }
+func (s *stubNonOAuthSessionCatalogProvider) DisplayName() string { return s.name }
+func (s *stubNonOAuthSessionCatalogProvider) Description() string { return "" }
+func (s *stubNonOAuthSessionCatalogProvider) ConnectionMode() core.ConnectionMode {
+	if s.connMode == "" {
+		return core.ConnectionModeUser
+	}
+	return s.connMode
+}
+func (s *stubNonOAuthSessionCatalogProvider) AuthTypes() []string { return nil }
+func (s *stubNonOAuthSessionCatalogProvider) ConnectionParamDefs() map[string]core.ConnectionParamDef {
+	return nil
+}
+func (s *stubNonOAuthSessionCatalogProvider) CredentialFields() []core.CredentialFieldDef { return nil }
+func (s *stubNonOAuthSessionCatalogProvider) DiscoveryConfig() *core.DiscoveryConfig      { return nil }
+func (s *stubNonOAuthSessionCatalogProvider) ConnectionForOperation(string) string        { return "" }
+func (s *stubNonOAuthSessionCatalogProvider) Catalog() *catalog.Catalog                   { return s.catalog }
+func (s *stubNonOAuthSessionCatalogProvider) Execute(context.Context, string, map[string]any, string) (*core.OperationResult, error) {
+	return nil, nil
+}
+func (s *stubNonOAuthSessionCatalogProvider) CatalogForRequest(ctx context.Context, token string) (*catalog.Catalog, error) {
+	if s.catalogForRequestFn != nil {
+		return s.catalogForRequestFn(ctx, token)
+	}
+	return s.catalog, nil
+}
 
 type stubAuthWithLoginURL struct {
 	coretesting.StubAuthProvider
@@ -10457,6 +11147,24 @@ func (s *stubOAuthIntegration) RefreshToken(ctx context.Context, token string) (
 	if s.refreshTokenFn != nil {
 		return s.refreshTokenFn(ctx, token)
 	}
+	return nil, nil
+}
+
+type stubOAuthIntegrationWithOps struct {
+	stubIntegrationWithOps
+}
+
+func (s *stubOAuthIntegrationWithOps) AuthTypes() []string { return []string{"oauth"} }
+
+func (s *stubOAuthIntegrationWithOps) AuthorizationURL(_ string, _ []string) string {
+	return "https://oauth.example/authorize"
+}
+
+func (s *stubOAuthIntegrationWithOps) ExchangeCode(context.Context, string) (*core.TokenResponse, error) {
+	return nil, nil
+}
+
+func (s *stubOAuthIntegrationWithOps) RefreshToken(context.Context, string) (*core.TokenResponse, error) {
 	return nil, nil
 }
 
@@ -14941,22 +15649,19 @@ func TestManagedIdentityGrantValidationUsesSessionCatalog(t *testing.T) {
 			AccessToken: "default-token",
 		})
 
-		sessionFallback := &stubSessionCatalogWithoutManagedIdentitySupport{
-			stubIntegrationWithSessionCatalog: stubIntegrationWithSessionCatalog{
-				stubIntegrationWithOps: stubIntegrationWithOps{
-					StubIntegration: coretesting.StubIntegration{N: "session-fallback", ConnMode: core.ConnectionModeUser},
-				},
-				catalogForRequestFn: func(_ context.Context, token string) (*catalog.Catalog, error) {
-					if token != "default-token" {
-						return nil, fmt.Errorf("missing session token")
-					}
-					return serverTestCatalog("session-fallback", []catalog.CatalogOperation{{
-						ID:        "discover",
-						Method:    http.MethodGet,
-						Path:      "/discover",
-						Transport: catalog.TransportREST,
-					}}), nil
-				},
+		sessionFallback := &stubNonOAuthSessionCatalogProvider{
+			name:     "session-fallback",
+			connMode: core.ConnectionModeUser,
+			catalogForRequestFn: func(_ context.Context, token string) (*catalog.Catalog, error) {
+				if token != "default-token" {
+					return nil, fmt.Errorf("missing session token")
+				}
+				return serverTestCatalog("session-fallback", []catalog.CatalogOperation{{
+					ID:        "discover",
+					Method:    http.MethodGet,
+					Path:      "/discover",
+					Transport: catalog.TransportREST,
+				}}), nil
 			},
 		}
 
@@ -16130,10 +16835,10 @@ func TestManagedIdentityManualConnections(t *testing.T) {
 		t.Fatalf("initial integrations = %+v, want oauth-svc listed", initialIntegrations)
 	} else {
 		if len(oauthInfo.AuthTypes) != 0 {
-			t.Fatalf("oauth-svc auth types = %+v, want none in manual-only identity surface", oauthInfo.AuthTypes)
+			t.Fatalf("oauth-svc auth types = %+v, want none without oauth handler wiring", oauthInfo.AuthTypes)
 		}
 		if len(oauthInfo.Connections) != 0 {
-			t.Fatalf("oauth-svc connections = %+v, want no connectable identity connections", oauthInfo.Connections)
+			t.Fatalf("oauth-svc connections = %+v, want no explicit connections without oauth handler wiring", oauthInfo.Connections)
 		}
 	}
 
@@ -16218,7 +16923,7 @@ func TestManagedIdentityManualConnections(t *testing.T) {
 	}
 }
 
-func TestManagedIdentityIntegrationsHideProvidersWithoutUsableManualConnection(t *testing.T) {
+func TestManagedIdentityIntegrationsHideProvidersWithoutUsableConnectionSurface(t *testing.T) {
 	t.Parallel()
 
 	svc := coretesting.NewStubServices(t)
@@ -16228,13 +16933,6 @@ func TestManagedIdentityIntegrationsHideProvidersWithoutUsableManualConnection(t
 		"hidden-svc": {
 			ResolvedManifest: &providermanifestv1.Manifest{
 				Spec: &providermanifestv1.Spec{
-					DefaultConnection: "workspace",
-					Surfaces: &providermanifestv1.ProviderSurfaces{
-						MCP: &providermanifestv1.MCPSurface{
-							Connection: "workspace",
-							URL:        "https://hidden-svc.example/mcp",
-						},
-					},
 					Connections: map[string]*providermanifestv1.ManifestConnectionDef{
 						"workspace": {
 							Mode: providermanifestv1.ConnectionModeUser,
@@ -16274,7 +16972,204 @@ func TestManagedIdentityIntegrationsHideProvidersWithoutUsableManualConnection(t
 	}
 	doJSONRequestAndDecode(t, http.MethodGet, ts.URL+"/api/v1/identities/"+createResp.ID+"/integrations", "admin-session", "", http.StatusOK, &integrations)
 	if len(integrations) != 0 {
-		t.Fatalf("integrations = %+v, want hidden-svc omitted without a usable manual surface", integrations)
+		t.Fatalf("integrations = %+v, want hidden-svc omitted without an advertised connectable surface", integrations)
+	}
+}
+
+func TestManagedIdentityManualConnectionsRejectHiddenConnectionBeforeDiscovery(t *testing.T) {
+	t.Parallel()
+
+	var discoveryCalls atomic.Int32
+	discoverySrv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		discoveryCalls.Add(1)
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = io.WriteString(w, `[{"id":"site-a","name":"Site A","workspace":"alpha"}]`)
+	}))
+	testutil.CloseOnCleanup(t, discoverySrv)
+
+	svc := coretesting.NewStubServices(t)
+	seedUser(t, svc, "admin@example.test")
+	seedUser(t, svc, "editor@example.test")
+
+	pluginDefs := map[string]*config.ProviderEntry{
+		"manual-svc": {
+			ResolvedManifest: &providermanifestv1.Manifest{
+				Spec: &providermanifestv1.Spec{
+					DefaultConnection: "workspace",
+					Surfaces: &providermanifestv1.ProviderSurfaces{
+						MCP: &providermanifestv1.MCPSurface{
+							Connection: "workspace",
+							URL:        "https://manual.example/mcp",
+						},
+					},
+					Connections: map[string]*providermanifestv1.ManifestConnectionDef{
+						"workspace": {
+							Mode: providermanifestv1.ConnectionModeUser,
+							Auth: &providermanifestv1.ProviderAuth{Type: providermanifestv1.AuthTypeManual},
+						},
+						"hidden": {
+							Mode: providermanifestv1.ConnectionModeUser,
+							Auth: &providermanifestv1.ProviderAuth{Type: providermanifestv1.AuthTypeManual},
+						},
+					},
+				},
+			},
+		},
+	}
+
+	ts := newTestServer(t, func(cfg *server.Config) {
+		cfg.Auth = &coretesting.StubAuthProvider{
+			N: "test",
+			ValidateTokenFn: func(_ context.Context, token string) (*core.UserIdentity, error) {
+				switch token {
+				case "admin-session":
+					return &core.UserIdentity{Email: "admin@example.test"}, nil
+				case "editor-session":
+					return &core.UserIdentity{Email: "editor@example.test"}, nil
+				default:
+					return nil, fmt.Errorf("unknown session %q", token)
+				}
+			},
+		}
+		cfg.Providers = testutil.NewProviderRegistry(t, &stubDiscoveringManualProvider{
+			stubManualProvider: stubManualProvider{
+				StubIntegration: coretesting.StubIntegration{N: "manual-svc"},
+			},
+			discovery: &core.DiscoveryConfig{
+				URL:      discoverySrv.URL,
+				IDPath:   "id",
+				NamePath: "name",
+				Metadata: map[string]string{"workspace": "workspace"},
+			},
+		})
+		cfg.DefaultConnection = map[string]string{"manual-svc": "workspace"}
+		cfg.PluginDefs = pluginDefs
+		cfg.Services = svc
+	})
+	testutil.CloseOnCleanup(t, ts)
+
+	createResp := struct {
+		ID string `json:"id"`
+	}{}
+	doJSONRequestAndDecode(t, http.MethodPost, ts.URL+"/api/v1/identities", "admin-session", `{"displayName":"Hidden Manual Bot"}`, http.StatusCreated, &createResp)
+	doJSONRequestAndDecode(t, http.MethodPut, ts.URL+"/api/v1/identities/"+createResp.ID+"/members", "admin-session", `{"email":"editor@example.test","role":"editor"}`, http.StatusOK, nil)
+
+	req, _ := http.NewRequest(http.MethodPost, ts.URL+"/api/v1/identities/"+createResp.ID+"/auth/connect-manual", bytes.NewBufferString(`{"integration":"manual-svc","connection":"hidden","credential":"hidden-token"}`))
+	req.Header.Set("Content-Type", "application/json")
+	req.AddCookie(&http.Cookie{Name: "session_token", Value: "editor-session"})
+	resp, err := http.DefaultClient.Do(req)
+	if err != nil {
+		t.Fatalf("hidden connection request: %v", err)
+	}
+	defer func() { _ = resp.Body.Close() }()
+	if resp.StatusCode != http.StatusNotFound {
+		body, _ := io.ReadAll(resp.Body)
+		t.Fatalf("hidden connection status = %d, want %d: %s", resp.StatusCode, http.StatusNotFound, body)
+	}
+	if calls := discoveryCalls.Load(); calls != 0 {
+		t.Fatalf("expected hidden connection rejection before discovery, got %d discovery calls", calls)
+	}
+}
+
+func TestManagedIdentityIntegrationsUseAdvertisedOAuthConnections(t *testing.T) {
+	t.Parallel()
+
+	svc := coretesting.NewStubServices(t)
+	seedUser(t, svc, "admin@example.test")
+
+	handler := &testOAuthHandler{
+		authorizationBaseURLVal: "https://slack.com/oauth/v2/authorize",
+	}
+	pluginDefs := map[string]*config.ProviderEntry{
+		"slack": {
+			ResolvedManifest: &providermanifestv1.Manifest{
+				Spec: &providermanifestv1.Spec{
+					DefaultConnection: "workspace",
+					Surfaces: &providermanifestv1.ProviderSurfaces{
+						MCP: &providermanifestv1.MCPSurface{
+							Connection: "workspace",
+							URL:        "https://slack.example/mcp",
+						},
+					},
+					Connections: map[string]*providermanifestv1.ManifestConnectionDef{
+						"workspace": {
+							Mode: providermanifestv1.ConnectionModeUser,
+							Auth: &providermanifestv1.ProviderAuth{Type: providermanifestv1.AuthTypeOAuth2},
+						},
+						"hidden": {
+							Mode: providermanifestv1.ConnectionModeUser,
+							Auth: &providermanifestv1.ProviderAuth{Type: providermanifestv1.AuthTypeOAuth2},
+						},
+					},
+				},
+			},
+		},
+	}
+
+	ts := newTestServer(t, func(cfg *server.Config) {
+		cfg.Auth = &coretesting.StubAuthProvider{
+			N: "test",
+			ValidateTokenFn: func(_ context.Context, token string) (*core.UserIdentity, error) {
+				if token != "admin-session" {
+					return nil, fmt.Errorf("unknown session %q", token)
+				}
+				return &core.UserIdentity{Email: "admin@example.test"}, nil
+			},
+		}
+		cfg.Providers = testutil.NewProviderRegistry(t, &stubIntegrationWithAuthURL{
+			StubIntegration: coretesting.StubIntegration{N: "slack"},
+			authURL:         "https://slack.com/oauth/v2/authorize",
+		})
+		cfg.DefaultConnection = map[string]string{"slack": "workspace"}
+		cfg.ConnectionAuth = func() map[string]map[string]bootstrap.OAuthHandler {
+			return map[string]map[string]bootstrap.OAuthHandler{
+				"slack": {"workspace": handler},
+			}
+		}
+		cfg.PluginDefs = pluginDefs
+		cfg.Services = svc
+	})
+	testutil.CloseOnCleanup(t, ts)
+
+	createResp := struct {
+		ID string `json:"id"`
+	}{}
+	doJSONRequestAndDecode(t, http.MethodPost, ts.URL+"/api/v1/identities", "admin-session", `{"displayName":"OAuth Visibility Bot"}`, http.StatusCreated, &createResp)
+
+	seedToken(t, svc, &core.IntegrationToken{
+		ID:          "hidden-plugin-connection",
+		OwnerKind:   core.IntegrationTokenOwnerKindManagedIdentity,
+		OwnerID:     createResp.ID,
+		Integration: "slack",
+		Connection:  "",
+		Instance:    "default",
+		AccessToken: "hidden-token",
+	})
+
+	var integrations []struct {
+		Name        string   `json:"name"`
+		Connected   bool     `json:"connected"`
+		AuthTypes   []string `json:"authTypes"`
+		Connections []struct {
+			Name      string   `json:"name"`
+			AuthTypes []string `json:"authTypes"`
+		} `json:"connections"`
+	}
+	doJSONRequestAndDecode(t, http.MethodGet, ts.URL+"/api/v1/identities/"+createResp.ID+"/integrations", "admin-session", "", http.StatusOK, &integrations)
+	if len(integrations) != 1 || integrations[0].Name != "slack" {
+		t.Fatalf("integrations = %+v, want single slack integration", integrations)
+	}
+	if !integrations[0].Connected {
+		t.Fatalf("integrations = %+v, want hidden plugin connection to count as connected", integrations)
+	}
+	if !reflect.DeepEqual(integrations[0].AuthTypes, []string{"oauth"}) {
+		t.Fatalf("top-level auth types = %+v, want [oauth]", integrations[0].AuthTypes)
+	}
+	if len(integrations[0].Connections) != 1 || integrations[0].Connections[0].Name != "workspace" {
+		t.Fatalf("connections = %+v, want single workspace connection", integrations[0].Connections)
+	}
+	if !reflect.DeepEqual(integrations[0].Connections[0].AuthTypes, []string{"oauth"}) {
+		t.Fatalf("workspace auth types = %+v, want [oauth]", integrations[0].Connections[0].AuthTypes)
 	}
 }
 
@@ -16714,7 +17609,19 @@ func TestManagedIdentityAPITokenInvocation(t *testing.T) {
 			ops: []core.Operation{{Name: "query", Method: http.MethodGet}},
 		},
 	}
-	providers := testutil.NewProviderRegistry(t, alphaStub, identityStub)
+	oauthStub := &stubOAuthIntegrationWithOps{
+		stubIntegrationWithOps: stubIntegrationWithOps{
+			StubIntegration: coretesting.StubIntegration{
+				N:        "oauth-svc",
+				ConnMode: core.ConnectionModeUser,
+				ExecuteFn: func(_ context.Context, _ string, _ map[string]any, token string) (*core.OperationResult, error) {
+					return &core.OperationResult{Status: http.StatusOK, Body: fmt.Sprintf(`{"token":%q}`, token)}, nil
+				},
+			},
+			ops: []core.Operation{{Name: "query", Method: http.MethodGet}},
+		},
+	}
+	providers := testutil.NewProviderRegistry(t, alphaStub, identityStub, oauthStub)
 	authz, err := authorization.New(config.AuthorizationConfig{}, nil, providers, nil)
 	if err != nil {
 		t.Fatalf("authorization.New: %v", err)
@@ -16742,6 +17649,7 @@ func TestManagedIdentityAPITokenInvocation(t *testing.T) {
 	doJSONRequestAndDecode(t, http.MethodPost, ts.URL+"/api/v1/identities", "admin-session", `{"displayName":"Invoke Bot"}`, http.StatusCreated, &createResp)
 	doJSONRequestAndDecode(t, http.MethodPut, ts.URL+"/api/v1/identities/"+createResp.ID+"/grants/alpha", "admin-session", `{"operations":["read"]}`, http.StatusOK, nil)
 	doJSONRequestAndDecode(t, http.MethodPut, ts.URL+"/api/v1/identities/"+createResp.ID+"/grants/identity-svc", "admin-session", `{"operations":["query"]}`, http.StatusOK, nil)
+	doJSONRequestAndDecode(t, http.MethodPut, ts.URL+"/api/v1/identities/"+createResp.ID+"/grants/oauth-svc", "admin-session", `{"operations":["query"]}`, http.StatusOK, nil)
 
 	createTokenResp := struct {
 		Token string `json:"token"`
@@ -16751,7 +17659,7 @@ func TestManagedIdentityAPITokenInvocation(t *testing.T) {
 		http.MethodPost,
 		ts.URL+"/api/v1/identities/"+createResp.ID+"/tokens",
 		"admin-session",
-		`{"name":"invoke-token","permissions":[{"plugin":"alpha","operations":["read"]},{"plugin":"identity-svc","operations":["query"]}]}`,
+		`{"name":"invoke-token","permissions":[{"plugin":"alpha","operations":["read"]},{"plugin":"identity-svc","operations":["query"]},{"plugin":"oauth-svc","operations":["query"]}]}`,
 		http.StatusCreated,
 		&createTokenResp,
 	)
@@ -16776,6 +17684,15 @@ func TestManagedIdentityAPITokenInvocation(t *testing.T) {
 		Connection:  "",
 		Instance:    "team-b",
 		AccessToken: "identity-token-b",
+	})
+	seedToken(t, svc, &core.IntegrationToken{
+		ID:          "oauth-svc-default",
+		OwnerKind:   core.IntegrationTokenOwnerKindManagedIdentity,
+		OwnerID:     createResp.ID,
+		Integration: "oauth-svc",
+		Connection:  "",
+		Instance:    "default",
+		AccessToken: "oauth-token",
 	})
 
 	integrationsReq, _ := http.NewRequest(http.MethodGet, ts.URL+"/api/v1/integrations", nil)
@@ -16805,6 +17722,9 @@ func TestManagedIdentityAPITokenInvocation(t *testing.T) {
 	}
 	if !connectedByName["identity-svc"] {
 		t.Fatalf("integrations = %+v, want identity-svc connected with stored identity token", integrations)
+	}
+	if !connectedByName["oauth-svc"] {
+		t.Fatalf("integrations = %+v, want oauth-svc connected with stored identity token", integrations)
 	}
 
 	call := func(path string) (int, string) {
@@ -16841,6 +17761,16 @@ func TestManagedIdentityAPITokenInvocation(t *testing.T) {
 	}
 	if result["token"] != "identity-token-b" {
 		t.Fatalf("identity-svc result = %+v, want token identity-token-b", result)
+	}
+	status, body = call("/api/v1/oauth-svc/query")
+	if status != http.StatusOK {
+		t.Fatalf("oauth-svc/query status = %d, want 200: %s", status, body)
+	}
+	if err := json.Unmarshal([]byte(body), &result); err != nil {
+		t.Fatalf("unmarshal oauth-svc result: %v", err)
+	}
+	if result["token"] != "oauth-token" {
+		t.Fatalf("oauth-svc result = %+v, want token oauth-token", result)
 	}
 
 	doJSONRequestAndDecode(t, http.MethodDelete, ts.URL+"/api/v1/identities/"+createResp.ID, "admin-session", "", http.StatusOK, nil)


### PR DESCRIPTION
## Summary
This PR adds the next managed-identity connection slice after PR3: identity-owned OAuth connection management.

It is intentionally stand-alone:
- managed identities can now start OAuth connection flows through the backend API and CLI
- the OAuth callback persists credentials for either a user or a managed identity using owner-aware encrypted state
- identity discovery/selection flows can still complete without a live browser session because the initiating human principal is reconstructed from encrypted state for authorization rechecks
- identity integrations listing now exposes OAuth surfaces again because they are real in this slice
- web UI work is still deferred

## Go Interfaces
New identity OAuth start route:

```text
POST /api/v1/identities/{identityID}/auth/start-oauth
```

`integrationOAuthState` is generalized from user-only to owner + initiator:

```go
type integrationOAuthState struct {
    UserID           string
    OwnerKind        string
    OwnerID          string
    InitiatorUserID  string
    AuthSource       string
    Integration      string
    Connection       string
    Instance         string
    Verifier         string
    ConnectionParams map[string]string
    ExpiresAt        int64
}
```

The OAuth callback no longer hardcodes user-owned credentials. It now rebuilds `tokenMaterial` from the decoded owner state so either a user or a managed identity can own the stored connection.

CLI identity connections now support OAuth through the existing command surface:

```text
gestalt identities connections connect <identity> <plugin> [--connection <name>] [--instance <name>]
```

If the plugin advertises OAuth, the CLI now starts the identity-scoped OAuth flow instead of failing.

## YAML Interfaces
This slice does not introduce any new YAML.

Existing provider YAML continues to work unchanged; identity-owned OAuth connections reuse the provider's existing auth and connection definitions. Example:

```yaml
providers:
  slack:
    command: ["./plugins/slack"]
    env:
      SLACK_CLIENT_ID: slack-client-id
      SLACK_CLIENT_SECRET: slack-client-secret
```

## Examples
Start an identity-owned OAuth flow over HTTP:

```http
POST /api/v1/identities/id_123/auth/start-oauth
Content-Type: application/json

{
  "integration": "slack",
  "connection": "default",
  "instance": "default"
}
```

Owner-aware OAuth state for a managed identity:

```go
integrationOAuthState{
    OwnerKind:       core.IntegrationTokenOwnerKindManagedIdentity,
    OwnerID:         identity.ID,
    InitiatorUserID: editorUserID,
    Integration:     "slack",
}
```

Use the CLI:

```bash
gestalt identities connections list id_123
gestalt identities connections connect id_123 slack
gestalt identities connections connect id_123 acme_crm --connection workspace --instance team-a
```

## Testing
- `go test ./...`
- `cargo test --manifest-path gestalt/Cargo.toml --test integration`
