### PR TITLE
[codex] Update docs for standard Homebrew tap flow

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,9 +30,10 @@ Gestalt also does not replace your existing APIs. It sits between agents and ups
 
 ## Quick Start
 
-Install both binaries with Homebrew:
+Tap the Gestalt Homebrew repository and install both binaries:
 
 ```sh
+brew tap valon-technologies/gestalt
 brew install valon-technologies/gestalt/gestaltd
 brew install valon-technologies/gestalt/gestalt
 ```

--- a/docs/content/install/homebrew.mdx
+++ b/docs/content/install/homebrew.mdx
@@ -4,6 +4,12 @@ Gestalt publishes a Homebrew tap for macOS and Linux.
 
 If you need a direct-download install or a Linux-specific release artifact, see [Binary Releases](/install/binary).
 
+Tap the repository first:
+
+```sh
+brew tap valon-technologies/gestalt
+```
+
 ## Server
 
 `gestaltd` is the long-running process that manages authentication and plugins.

--- a/docs/content/install/index.mdx
+++ b/docs/content/install/index.mdx
@@ -11,6 +11,7 @@ Gestalt ships two binaries: `gestaltd` (the server) and `gestalt` (the CLI clien
 The fastest path on macOS and Linux. See [Homebrew](/install/homebrew).
 
 ```sh
+brew tap valon-technologies/gestalt
 brew install valon-technologies/gestalt/gestaltd
 brew install valon-technologies/gestalt/gestalt
 ```


### PR DESCRIPTION
## What changed
- add the standard `brew tap valon-technologies/gestalt` step to the main install docs
- update the Homebrew page and quick-start snippets to match the recreated dedicated tap

## Why
The dedicated `valon-technologies/homebrew-gestalt` repository now exists again, so Gestalt can use the normal Homebrew tap flow instead of the previous broken implicit tap behavior.

## User impact
Fresh installs can now follow the standard sequence:

```sh
brew tap valon-technologies/gestalt
brew install valon-technologies/gestalt/gestaltd
brew install valon-technologies/gestalt/gestalt
```

## Validation
- `git diff --check`
- verified the recreated tap repo is live and Homebrew resolves `valon-technologies/gestalt` from it