### PR TITLE
Add safe return paths for connection callbacks

### DIFF
--- a/gestalt/cli/src/api.rs
+++ b/gestalt/cli/src/api.rs
@@ -19,6 +19,7 @@ pub const PROJECT_CONFIG_FILE: &str = ".gestalt/config.json";
 pub const AUTH_INFO_PATH: &str = "/api/v1/auth/info";
 pub const AUTH_LOGIN_PATH: &str = "/api/v1/auth/login";
 pub const AUTH_LOGIN_CALLBACK_PATH: &str = "/api/v1/auth/login/callback";
+pub const AUTH_INTEGRATION_CALLBACK_PATH: &str = "/api/v1/auth/callback";
 
 #[derive(Debug, Clone, Deserialize)]
 #[serde(rename_all = "camelCase")]
@@ -346,6 +347,16 @@ impl ApiClient {
             &format!("/api/v1/identities/{identity}/auth/start-oauth"),
             body,
         )
+    }
+
+    pub fn complete_integration_oauth_callback(
+        &self,
+        code: &str,
+        state: &str,
+    ) -> Result<serde_json::Value> {
+        let query = serde_urlencoded::to_string([("code", code), ("state", state), ("cli", "1")])
+            .context("failed to encode oauth callback query")?;
+        self.get(&format!("{AUTH_INTEGRATION_CALLBACK_PATH}?{query}"))
     }
 
     pub fn disconnect_identity_integration(

--- a/gestalt/cli/src/commands/auth.rs
+++ b/gestalt/cli/src/commands/auth.rs
@@ -194,7 +194,7 @@ where
     Ok(())
 }
 
-fn send_browser_response(
+pub(crate) fn send_browser_response(
     stream: &std::net::TcpStream,
     title: &str,
     detail: &str,
@@ -209,7 +209,7 @@ fn send_browser_response(
     )
 }
 
-fn build_browser_response_html(title: &str, detail: &str) -> String {
+pub(crate) fn build_browser_response_html(title: &str, detail: &str) -> String {
     let data = serde_json::json!({
         "detail": detail,
         "title": title,
@@ -361,7 +361,7 @@ pub fn status(url_override: Option<&str>, format: Format) -> Result<()> {
     Ok(())
 }
 
-fn random_hex_string() -> String {
+pub(crate) fn random_hex_string() -> String {
     let mut buf = [0u8; 16];
     getrandom::fill(&mut buf).expect("failed to generate random bytes");
     buf.iter().map(|b| format!("{b:02x}")).collect()

--- a/gestalt/cli/src/commands/plugins.rs
+++ b/gestalt/cli/src/commands/plugins.rs
@@ -6,7 +6,10 @@ use crate::api::ApiClient;
 use crate::output::{self, Format};
 
 pub(crate) use connect::connect_identity;
-pub use connect::{connect, connect_identity_with_browser_opener, connect_with_browser_opener};
+pub use connect::{
+    connect, connect_identity_with_browser_opener, connect_identity_with_browser_opener_and_wait,
+    connect_with_browser_opener, connect_with_browser_opener_and_wait,
+};
 
 const PLUGIN_CONNECTION_NAME: &str = "_plugin";
 const PLUGIN_CONNECTION_ALIAS: &str = "plugin";

--- a/gestalt/cli/src/commands/plugins/connect.rs
+++ b/gestalt/cli/src/commands/plugins/connect.rs
@@ -1,9 +1,13 @@
 use std::collections::BTreeMap;
+use std::io::{BufRead, BufReader};
+use std::net::TcpListener;
+use std::time::Duration;
 
 use anyhow::{Context, Result, bail};
 use serde::{Deserialize, Serialize};
 
 use crate::api::ApiClient;
+use crate::commands::auth::{random_hex_string, send_browser_response};
 use crate::interactive::{InputPrompt, PromptOption, prompt_input, prompt_select};
 use crate::output;
 
@@ -87,6 +91,10 @@ struct StartOAuthRequest<'a> {
     connection: Option<&'a str>,
     #[serde(skip_serializing_if = "Option::is_none")]
     instance: Option<&'a str>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    callback_port: Option<u16>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    callback_state: Option<&'a str>,
     #[serde(skip_serializing_if = "Option::is_none")]
     connection_params: Option<&'a BTreeMap<String, String>>,
 }
@@ -267,13 +275,7 @@ pub fn connect_with_browser_opener<F>(
 where
     F: FnOnce(&str) -> Result<()>,
 {
-    let integration = fetch_plugin(client, name)?;
-    let flow = ResolvedConnectFlow::resolve(&integration, connection)?;
-
-    match flow.mode {
-        ConnectMode::OAuth => start_oauth(client, &flow, instance, open_browser),
-        ConnectMode::Manual => connect_manual(client, &flow, instance),
-    }
+    connect_with_browser_opener_and_wait(client, name, connection, instance, open_browser)
 }
 
 pub(crate) fn connect_identity(
@@ -283,12 +285,47 @@ pub(crate) fn connect_identity(
     connection: Option<&str>,
     instance: Option<&str>,
 ) -> Result<()> {
-    connect_identity_with_browser_opener(client, identity, name, connection, instance, |url| {
-        open::that(url).map(|_| ()).map_err(Into::into)
-    })
+    connect_identity_with_browser_opener_and_wait(
+        client,
+        identity,
+        name,
+        connection,
+        instance,
+        |url| open::that(url).map(|_| ()).map_err(Into::into),
+    )
 }
 
-pub fn connect_identity_with_browser_opener<F>(
+pub fn connect_with_browser_opener_and_wait<F>(
+    client: &ApiClient,
+    name: &str,
+    connection: Option<&str>,
+    instance: Option<&str>,
+    open_browser: F,
+) -> Result<()>
+where
+    F: FnOnce(&str) -> Result<()>,
+{
+    let integration = fetch_plugin(client, name)?;
+    let flow = ResolvedConnectFlow::resolve(&integration, connection)?;
+
+    match flow.mode {
+        ConnectMode::OAuth => complete_oauth(
+            client,
+            &flow,
+            instance,
+            OAuthCompletionMessages {
+                failure_context: "failed to start OAuth flow".to_string(),
+                success_template: "Connected {integration}.".to_string(),
+                selection_success_template: "Connected {integration} ({candidate})".to_string(),
+            },
+            |body| client.post("/api/v1/auth/start-oauth", body),
+            open_browser,
+        ),
+        ConnectMode::Manual => connect_manual(client, &flow, instance),
+    }
+}
+
+pub fn connect_identity_with_browser_opener_and_wait<F>(
     client: &ApiClient,
     identity: &str,
     name: &str,
@@ -317,78 +354,254 @@ where
             &format!("Connected {{integration}} ({{candidate}}) for identity {identity}."),
             |body| client.connect_identity_manual(identity, body),
         ),
-        ConnectMode::OAuth => start_identity_oauth(client, identity, &flow, instance, open_browser),
+        ConnectMode::OAuth => complete_oauth(
+            client,
+            &flow,
+            instance,
+            OAuthCompletionMessages {
+                failure_context: format!("failed to start OAuth flow for identity {identity}"),
+                success_template: format!("Connected {{integration}} for identity {identity}."),
+                selection_success_template: format!(
+                    "Connected {{integration}} ({{candidate}}) for identity {identity}."
+                ),
+            },
+            |body| client.start_identity_oauth(identity, body),
+            open_browser,
+        ),
     }
 }
 
-fn start_oauth<F>(
-    client: &ApiClient,
-    flow: &ResolvedConnectFlow<'_>,
-    instance: Option<&str>,
-    open_browser: F,
-) -> Result<()>
-where
-    F: FnOnce(&str) -> Result<()>,
-{
-    start_oauth_via(
-        "failed to start OAuth flow",
-        |body| client.post("/api/v1/auth/start-oauth", body),
-        flow,
-        instance,
-        open_browser,
-    )
-}
-
-fn start_identity_oauth<F>(
+pub fn connect_identity_with_browser_opener<F>(
     client: &ApiClient,
     identity: &str,
-    flow: &ResolvedConnectFlow<'_>,
+    name: &str,
+    connection: Option<&str>,
     instance: Option<&str>,
     open_browser: F,
 ) -> Result<()>
 where
     F: FnOnce(&str) -> Result<()>,
 {
-    start_oauth_via(
-        &format!("failed to start OAuth flow for identity {identity}"),
-        |body| client.start_identity_oauth(identity, body),
-        flow,
+    connect_identity_with_browser_opener_and_wait(
+        client,
+        identity,
+        name,
+        connection,
         instance,
         open_browser,
     )
 }
 
-fn start_oauth_via<F, G>(
-    failure_context: &str,
-    start_request: G,
+struct OAuthCompletionMessages {
+    failure_context: String,
+    success_template: String,
+    selection_success_template: String,
+}
+
+fn complete_oauth<F, G>(
+    client: &ApiClient,
     flow: &ResolvedConnectFlow<'_>,
     instance: Option<&str>,
+    messages: OAuthCompletionMessages,
+    start_request: G,
     open_browser: F,
 ) -> Result<()>
 where
     F: FnOnce(&str) -> Result<()>,
     G: FnOnce(&StartOAuthRequest<'_>) -> Result<serde_json::Value>,
 {
+    let listener =
+        TcpListener::bind("127.0.0.1:0").context("failed to bind OAuth callback listener")?;
+    let callback_port = listener.local_addr()?.port();
+    let callback_state = random_hex_string();
     let connection_params = prompt_connection_params(flow.connection_param_defs())?;
     let resp = start_request(&StartOAuthRequest {
         integration: flow.integration_name(),
         connection: flow.connection_name(),
         instance,
+        callback_port: Some(callback_port),
+        callback_state: Some(&callback_state),
         connection_params: connection_params.as_ref(),
     })
-    .with_context(|| failure_context.to_string())?;
+    .with_context(|| messages.failure_context.clone())?;
     let url = resp["url"]
         .as_str()
         .context("response missing 'url' field")?;
 
+    let (tx, rx) = std::sync::mpsc::channel();
+    std::thread::spawn(move || {
+        let _ = tx.send(listener.accept());
+    });
+
     eprintln!("Opening browser to connect {}...", flow.integration_name());
     eprintln!("If the browser doesn't open, visit: {}", url);
-
     if open_browser(url).is_err() {
         eprintln!("Could not open browser automatically.");
     }
 
-    Ok(())
+    eprintln!(
+        "Waiting for OAuth callback on http://127.0.0.1:{}/ ...",
+        callback_port
+    );
+
+    let (stream, _) = rx
+        .recv_timeout(Duration::from_secs(300))
+        .map_err(|_| anyhow::anyhow!("timed out waiting for OAuth callback after 5 minutes"))?
+        .context("failed to accept OAuth callback")?;
+
+    let callback = parse_oauth_callback_request(&stream, &callback_state)?;
+    let callback_value = match client
+        .complete_integration_oauth_callback(&callback.code, &callback.state)
+    {
+        Ok(value) => value,
+        Err(err) => {
+            let _ = send_browser_response(
+                &stream,
+                "Connection failed",
+                "The CLI could not finish exchanging the OAuth callback. Check the terminal for details.",
+            );
+            return Err(err).context("failed to exchange OAuth callback");
+        }
+    };
+    let callback_response: ConnectManualResponse = match serde_json::from_value(callback_value) {
+        Ok(response) => response,
+        Err(err) => {
+            let _ = send_browser_response(
+                &stream,
+                "Connection failed",
+                "The CLI received an invalid OAuth completion response. Check the terminal for details.",
+            );
+            return Err(err).context("failed to parse OAuth callback response");
+        }
+    };
+
+    match callback_response.status.as_str() {
+        "connected" => {
+            let _ =
+                send_browser_response(&stream, "Connection successful", "You can close this tab.");
+            output::print_success(&render_connect_success(
+                &messages.success_template,
+                callback_response
+                    .integration
+                    .as_deref()
+                    .unwrap_or(flow.integration_name()),
+                None,
+            ));
+            Ok(())
+        }
+        "selection_required" => {
+            let integration = callback_response
+                .integration
+                .as_deref()
+                .unwrap_or(flow.integration_name());
+            let selection_result = complete_pending_selection_with_message(
+                client,
+                integration,
+                callback_response.selection_url.as_deref(),
+                callback_response.pending_token.as_deref(),
+                &callback_response.candidates,
+                &messages.selection_success_template,
+            );
+            match selection_result {
+                Ok(()) => {
+                    let _ = send_browser_response(
+                        &stream,
+                        "Connection successful",
+                        "You can close this tab.",
+                    );
+                    Ok(())
+                }
+                Err(err) => {
+                    let _ = send_browser_response(
+                        &stream,
+                        "Connection failed",
+                        "The CLI could not finish selecting the connected account. Check the terminal for details.",
+                    );
+                    Err(err)
+                }
+            }
+        }
+        other => {
+            let _ = send_browser_response(
+                &stream,
+                "Connection failed",
+                "The OAuth flow returned an unexpected result. Check the terminal for details.",
+            );
+            bail!("unexpected OAuth callback response status '{}'", other)
+        }
+    }
+}
+
+struct OAuthCallbackRequest {
+    code: String,
+    state: String,
+}
+
+fn parse_oauth_callback_request(
+    stream: &std::net::TcpStream,
+    expected_callback_state: &str,
+) -> Result<OAuthCallbackRequest> {
+    let browser_error = |detail: &str| {
+        let _ = send_browser_response(stream, "Connection failed", detail);
+    };
+    let mut reader = BufReader::new(stream);
+    let mut request_line = String::new();
+    if let Err(err) = BufRead::read_line(&mut reader, &mut request_line) {
+        browser_error(
+            "The CLI could not read the OAuth callback request. Check the terminal for details.",
+        );
+        return Err(err).context("failed to read OAuth callback request");
+    }
+
+    let callback_params = match request_line
+        .split_whitespace()
+        .nth(1)
+        .and_then(|path| url::Url::parse(&format!("http://localhost{}", path)).ok())
+    {
+        Some(params) => params,
+        None => {
+            browser_error(
+                "The CLI received an invalid OAuth callback request. Check the terminal for details.",
+            );
+            bail!("failed to parse OAuth callback request");
+        }
+    };
+    let cli_state = callback_params
+        .query_pairs()
+        .find(|(key, _)| key == "cli_state")
+        .map(|(_, value)| value.into_owned());
+    if cli_state.as_deref() != Some(expected_callback_state) {
+        browser_error("The callback state did not match. Check the terminal for details.");
+        bail!("OAuth callback state mismatch - possible CSRF attack");
+    }
+
+    let code = match callback_params
+        .query_pairs()
+        .find(|(key, _)| key == "code")
+        .map(|(_, value)| value.into_owned())
+    {
+        Some(code) => code,
+        None => {
+            browser_error(
+                "The OAuth provider did not return an authorization code. Check the terminal for details.",
+            );
+            bail!("callback did not contain an authorization code");
+        }
+    };
+    let state = match callback_params
+        .query_pairs()
+        .find(|(key, _)| key == "state")
+        .map(|(_, value)| value.into_owned())
+    {
+        Some(state) => state,
+        None => {
+            browser_error(
+                "The OAuth provider did not return state. Check the terminal for details.",
+            );
+            bail!("callback did not contain OAuth state");
+        }
+    };
+    Ok(OAuthCallbackRequest { code, state })
 }
 
 fn connect_manual(

--- a/gestalt/cli/tests/identities_cli.rs
+++ b/gestalt/cli/tests/identities_cli.rs
@@ -1,7 +1,5 @@
 mod support;
 
-use std::sync::{Arc, Mutex};
-
 use support::*;
 
 #[test]
@@ -388,85 +386,107 @@ fn test_cli_disconnects_identity_connection_with_connection_and_instance() {
 
 #[test]
 fn test_identity_connect_starts_oauth_with_connection_and_instance() {
-    let mut server = Server::new();
-    let _integrations = authed_json_mock!(
-        server,
-        Method::GET,
-        "/api/v1/identities/agent-1/integrations",
-        StatusCode::OK
-    )
-    .with_body(r#"[{"name":"acme_crm","authTypes":["oauth"],"connected":false}]"#)
-    .create();
-    let mock = authed_json_mock!(
-        server,
-        Method::POST,
-        "/api/v1/identities/agent-1/auth/start-oauth",
-        StatusCode::OK
-    )
-    .match_header(header::CONTENT_TYPE.as_str(), http::APPLICATION_JSON)
-    .match_body(Matcher::JsonString(
-        r#"{"connection":"workspace","instance":"team-a","integration":"acme_crm"}"#.to_string(),
-    ))
-    .with_body(r#"{"url":"https://example.com/oauth","state":"abc123"}"#)
-    .create();
-
-    let client = create_client(&server);
-    let result = gestalt::commands::plugins::connect_identity_with_browser_opener(
+    let server = spawn_oauth_connect_server(OAuthConnectServerConfig {
+        integrations_path: "/api/v1/identities/agent-1/integrations",
+        start_path: "/api/v1/identities/agent-1/auth/start-oauth",
+        integration_name: "acme_crm",
+        integrations_response: None,
+        selection_required: false,
+    });
+    let client = gestalt::api::ApiClient::new(&server.base_url, TEST_TOKEN).unwrap();
+    let result = gestalt::commands::plugins::connect_identity_with_browser_opener_and_wait(
         &client,
         "agent-1",
         "acme_crm",
         Some("workspace"),
         Some("team-a"),
-        |_| Ok(()),
+        |url| {
+            let url = url.to_string();
+            std::thread::spawn(move || {
+                let _ = reqwest::blocking::get(&url);
+            });
+            Ok(())
+        },
     );
 
-    mock.assert();
     assert!(result.is_ok());
+    server.handle.join().unwrap();
+    let body = server.state.lock().unwrap().start_body.clone().unwrap();
+    assert_eq!(body["integration"], "acme_crm");
+    assert_eq!(body["connection"], "workspace");
+    assert_eq!(body["instance"], "team-a");
 }
 
 #[test]
 fn test_identity_connect_prefers_oauth_when_manual_also_exists() {
-    let mut server = Server::new();
-    let _integrations = authed_json_mock!(
-        server,
-        Method::GET,
-        "/api/v1/identities/agent-1/integrations",
-        StatusCode::OK
-    )
-    .with_body(r#"[{"name":"acme_crm","authTypes":["oauth","manual"],"connected":false}]"#)
-    .create();
-    let mock = authed_json_mock!(
-        server,
-        Method::POST,
-        "/api/v1/identities/agent-1/auth/start-oauth",
-        StatusCode::OK
-    )
-    .match_header(header::CONTENT_TYPE.as_str(), http::APPLICATION_JSON)
-    .match_body(Matcher::JsonString(
-        r#"{"integration":"acme_crm"}"#.to_string(),
-    ))
-    .with_body(r#"{"url":"https://example.com/oauth","state":"abc123"}"#)
-    .create();
-
-    let client = create_client(&server);
-    let opened_url = Arc::new(Mutex::new(None));
-    let opened_url_handle = Arc::clone(&opened_url);
-    let result = gestalt::commands::plugins::connect_identity_with_browser_opener(
+    let server = spawn_oauth_connect_server(OAuthConnectServerConfig {
+        integrations_path: "/api/v1/identities/agent-1/integrations",
+        start_path: "/api/v1/identities/agent-1/auth/start-oauth",
+        integration_name: "acme_crm",
+        integrations_response: Some(
+            r#"[{"name":"acme_crm","authTypes":["oauth","manual"],"connected":false}]"#,
+        ),
+        selection_required: false,
+    });
+    let client = gestalt::api::ApiClient::new(&server.base_url, TEST_TOKEN).unwrap();
+    let result = gestalt::commands::plugins::connect_identity_with_browser_opener_and_wait(
         &client,
         "agent-1",
         "acme_crm",
         None,
         None,
-        move |url| {
-            *opened_url_handle.lock().unwrap() = Some(url.to_string());
+        |url| {
+            let url = url.to_string();
+            std::thread::spawn(move || {
+                let _ = reqwest::blocking::get(&url);
+            });
             Ok(())
         },
     );
 
-    mock.assert();
     assert!(result.is_ok());
-    assert_eq!(
-        opened_url.lock().unwrap().as_deref(),
-        Some("https://example.com/oauth")
+    server.handle.join().unwrap();
+    let body = server.state.lock().unwrap().start_body.clone().unwrap();
+    let object = body.as_object().unwrap();
+    assert_eq!(body["integration"], "acme_crm");
+    assert!(!object.contains_key("connection"));
+    assert!(!object.contains_key("instance"));
+}
+
+#[test]
+fn test_identity_connect_completes_oauth_via_local_callback() {
+    let server = spawn_oauth_connect_server(OAuthConnectServerConfig {
+        integrations_path: "/api/v1/identities/agent-1/integrations",
+        start_path: "/api/v1/identities/agent-1/auth/start-oauth",
+        integration_name: "acme_crm",
+        integrations_response: None,
+        selection_required: false,
+    });
+    let client = gestalt::api::ApiClient::new(&server.base_url, TEST_TOKEN).unwrap();
+
+    let result = gestalt::commands::plugins::connect_identity_with_browser_opener_and_wait(
+        &client,
+        "agent-1",
+        "acme_crm",
+        None,
+        None,
+        |url| {
+            let url = url.to_string();
+            std::thread::spawn(move || {
+                let _ = reqwest::blocking::get(&url);
+            });
+            Ok(())
+        },
     );
+
+    assert!(result.is_ok());
+    server.handle.join().unwrap();
+    let html = server
+        .state
+        .lock()
+        .unwrap()
+        .browser_response_html
+        .clone()
+        .unwrap_or_default();
+    assert!(html.contains("Connection successful"));
 }

--- a/gestalt/cli/tests/plugins_connect.rs
+++ b/gestalt/cli/tests/plugins_connect.rs
@@ -1,7 +1,5 @@
 mod support;
 
-use std::sync::{Arc, Mutex};
-
 use support::*;
 
 #[test]
@@ -24,148 +22,213 @@ fn test_list_plugins() {
 
 #[test]
 fn test_connect_includes_connection_and_instance() {
-    let mut server = Server::new();
-    let _integrations =
-        authed_json_mock!(server, Method::GET, "/api/v1/integrations", StatusCode::OK)
-            .with_body(r#"[{"name":"acme_crm","authTypes":["oauth"],"connected":false}]"#)
-            .create();
-    let mock = authed_json_mock!(
-        server,
-        Method::POST,
-        "/api/v1/auth/start-oauth",
-        StatusCode::OK
-    )
-    .match_header(header::CONTENT_TYPE.as_str(), http::APPLICATION_JSON)
-    .match_body(Matcher::JsonString(
-        r#"{"connection":"workspace","instance":"team-a","integration":"acme_crm"}"#.to_string(),
-    ))
-    .with_body(r#"{"url":"https://example.com/oauth","state":"abc123"}"#)
-    .create();
-
-    let client = create_client(&server);
-    let result = gestalt::commands::plugins::connect_with_browser_opener(
+    let server = spawn_oauth_connect_server(OAuthConnectServerConfig {
+        integrations_path: "/api/v1/integrations",
+        start_path: "/api/v1/auth/start-oauth",
+        integration_name: "acme_crm",
+        integrations_response: None,
+        selection_required: false,
+    });
+    let client = gestalt::api::ApiClient::new(&server.base_url, TEST_TOKEN).unwrap();
+    let result = gestalt::commands::plugins::connect_with_browser_opener_and_wait(
         &client,
         "acme_crm",
         Some("workspace"),
         Some("team-a"),
-        |_| Ok(()),
-    );
-
-    mock.assert();
-    assert!(result.is_ok());
-}
-
-#[test]
-fn test_connect_prefers_oauth_when_manual_also_exists_and_omits_null_connection_and_instance() {
-    let mut server = Server::new();
-    let _integrations =
-        authed_json_mock!(server, Method::GET, "/api/v1/integrations", StatusCode::OK)
-            .with_body(r#"[{"name":"acme_crm","authTypes":["oauth","manual"],"connected":false}]"#)
-            .create();
-    let mock = authed_json_mock!(
-        server,
-        Method::POST,
-        "/api/v1/auth/start-oauth",
-        StatusCode::OK
-    )
-    .match_header(header::CONTENT_TYPE.as_str(), http::APPLICATION_JSON)
-    .match_body(Matcher::JsonString(
-        r#"{"integration":"acme_crm"}"#.to_string(),
-    ))
-    .with_body(r#"{"url":"https://example.com/oauth","state":"abc123"}"#)
-    .create();
-
-    let client = create_client(&server);
-    let opened_url = Arc::new(Mutex::new(None));
-    let opened_url_handle = Arc::clone(&opened_url);
-    let result = gestalt::commands::plugins::connect_with_browser_opener(
-        &client,
-        "acme_crm",
-        None,
-        None,
-        move |url| {
-            *opened_url_handle.lock().unwrap() = Some(url.to_string());
+        |url| {
+            let url = url.to_string();
+            std::thread::spawn(move || {
+                let _ = reqwest::blocking::get(&url);
+            });
             Ok(())
         },
     );
 
-    mock.assert();
     assert!(result.is_ok());
-    assert_eq!(
-        opened_url.lock().unwrap().as_deref(),
-        Some("https://example.com/oauth")
+    server.handle.join().unwrap();
+    let body = server.state.lock().unwrap().start_body.clone().unwrap();
+    assert_eq!(body["integration"], "acme_crm");
+    assert_eq!(body["connection"], "workspace");
+    assert_eq!(body["instance"], "team-a");
+    assert!(body["callbackPort"].as_u64().unwrap() > 0);
+    assert!(!body["callbackState"].as_str().unwrap().is_empty());
+}
+
+#[test]
+fn test_connect_prefers_oauth_when_manual_also_exists_and_omits_null_connection_and_instance() {
+    let server = spawn_oauth_connect_server(OAuthConnectServerConfig {
+        integrations_path: "/api/v1/integrations",
+        start_path: "/api/v1/auth/start-oauth",
+        integration_name: "acme_crm",
+        integrations_response: Some(
+            r#"[{"name":"acme_crm","authTypes":["oauth","manual"],"connected":false}]"#,
+        ),
+        selection_required: false,
+    });
+    let client = gestalt::api::ApiClient::new(&server.base_url, TEST_TOKEN).unwrap();
+    let result = gestalt::commands::plugins::connect_with_browser_opener_and_wait(
+        &client,
+        "acme_crm",
+        None,
+        None,
+        |url| {
+            let url = url.to_string();
+            std::thread::spawn(move || {
+                let _ = reqwest::blocking::get(&url);
+            });
+            Ok(())
+        },
     );
+
+    assert!(result.is_ok());
+    server.handle.join().unwrap();
+    let body = server.state.lock().unwrap().start_body.clone().unwrap();
+    let object = body.as_object().unwrap();
+    assert_eq!(body["integration"], "acme_crm");
+    assert!(!object.contains_key("connection"));
+    assert!(!object.contains_key("instance"));
 }
 
 #[test]
 fn test_connect_uses_defined_plugin_connection_name_on_the_wire() {
-    let mut server = Server::new();
-    let _integrations = authed_json_mock!(server, Method::GET, "/api/v1/integrations", StatusCode::OK)
-        .with_body(
+    let server = spawn_oauth_connect_server(OAuthConnectServerConfig {
+        integrations_path: "/api/v1/integrations",
+        start_path: "/api/v1/auth/start-oauth",
+        integration_name: "acme_crm",
+        integrations_response: Some(
             r#"[{
                 "name":"acme_crm",
                 "authTypes":["oauth"],
                 "connections":[{"name":"_plugin","displayName":"Plugin OAuth","authTypes":["oauth"]}]
             }]"#,
-        )
-        .create();
-    let mock = authed_json_mock!(
-        server,
-        Method::POST,
-        "/api/v1/auth/start-oauth",
-        StatusCode::OK
-    )
-    .match_header(header::CONTENT_TYPE.as_str(), http::APPLICATION_JSON)
-    .match_body(Matcher::JsonString(
-        r#"{"connection":"_plugin","integration":"acme_crm"}"#.to_string(),
-    ))
-    .with_body(r#"{"url":"https://example.com/oauth","state":"abc123"}"#)
-    .create();
-
-    let client = create_client(&server);
-    let result = gestalt::commands::plugins::connect_with_browser_opener(
+        ),
+        selection_required: false,
+    });
+    let client = gestalt::api::ApiClient::new(&server.base_url, TEST_TOKEN).unwrap();
+    let result = gestalt::commands::plugins::connect_with_browser_opener_and_wait(
         &client,
         "acme_crm",
         Some("plugin"),
         None,
-        |_| Ok(()),
+        |url| {
+            let url = url.to_string();
+            std::thread::spawn(move || {
+                let _ = reqwest::blocking::get(&url);
+            });
+            Ok(())
+        },
     );
 
-    mock.assert();
     assert!(result.is_ok());
+    server.handle.join().unwrap();
+    let body = server.state.lock().unwrap().start_body.clone().unwrap();
+    assert_eq!(body["integration"], "acme_crm");
+    assert_eq!(body["connection"], "_plugin");
 }
 
 #[test]
 fn test_connect_preserves_requested_plugin_connection_when_no_definitions_exist() {
-    let mut server = Server::new();
-    let _integrations =
-        authed_json_mock!(server, Method::GET, "/api/v1/integrations", StatusCode::OK)
-            .with_body(r#"[{"name":"acme_crm","authTypes":["oauth"],"connected":false}]"#)
-            .create();
-    let mock = authed_json_mock!(
-        server,
-        Method::POST,
-        "/api/v1/auth/start-oauth",
-        StatusCode::OK
-    )
-    .match_header(header::CONTENT_TYPE.as_str(), http::APPLICATION_JSON)
-    .match_body(Matcher::JsonString(
-        r#"{"connection":"plugin","integration":"acme_crm"}"#.to_string(),
-    ))
-    .with_body(r#"{"url":"https://example.com/oauth","state":"abc123"}"#)
-    .create();
-
-    let client = create_client(&server);
-    let result = gestalt::commands::plugins::connect_with_browser_opener(
+    let server = spawn_oauth_connect_server(OAuthConnectServerConfig {
+        integrations_path: "/api/v1/integrations",
+        start_path: "/api/v1/auth/start-oauth",
+        integration_name: "acme_crm",
+        integrations_response: None,
+        selection_required: false,
+    });
+    let client = gestalt::api::ApiClient::new(&server.base_url, TEST_TOKEN).unwrap();
+    let result = gestalt::commands::plugins::connect_with_browser_opener_and_wait(
         &client,
         "acme_crm",
         Some("plugin"),
         None,
-        |_| Ok(()),
+        |url| {
+            let url = url.to_string();
+            std::thread::spawn(move || {
+                let _ = reqwest::blocking::get(&url);
+            });
+            Ok(())
+        },
     );
 
-    mock.assert();
     assert!(result.is_ok());
+    server.handle.join().unwrap();
+    let body = server.state.lock().unwrap().start_body.clone().unwrap();
+    assert_eq!(body["integration"], "acme_crm");
+    assert_eq!(body["connection"], "plugin");
+}
+
+#[test]
+fn test_connect_completes_oauth_via_local_callback() {
+    let server = spawn_oauth_connect_server(OAuthConnectServerConfig {
+        integrations_path: "/api/v1/integrations",
+        start_path: "/api/v1/auth/start-oauth",
+        integration_name: "acme_crm",
+        integrations_response: None,
+        selection_required: false,
+    });
+    let client = gestalt::api::ApiClient::new(&server.base_url, TEST_TOKEN).unwrap();
+
+    let result = gestalt::commands::plugins::connect_with_browser_opener_and_wait(
+        &client,
+        "acme_crm",
+        None,
+        None,
+        |url| {
+            let url = url.to_string();
+            std::thread::spawn(move || {
+                let _ = reqwest::blocking::get(&url);
+            });
+            Ok(())
+        },
+    );
+
+    assert!(result.is_ok());
+    server.handle.join().unwrap();
+    let html = server
+        .state
+        .lock()
+        .unwrap()
+        .browser_response_html
+        .clone()
+        .unwrap_or_default();
+    assert!(html.contains("Connection successful"));
+}
+
+#[test]
+fn test_connect_completes_oauth_selection_required_in_terminal() {
+    let server = spawn_oauth_connect_server(OAuthConnectServerConfig {
+        integrations_path: "/api/v1/integrations",
+        start_path: "/api/v1/auth/start-oauth",
+        integration_name: "acme_crm",
+        integrations_response: None,
+        selection_required: true,
+    });
+    let client = gestalt::api::ApiClient::new(&server.base_url, TEST_TOKEN).unwrap();
+
+    let result = gestalt::commands::plugins::connect_with_browser_opener_and_wait(
+        &client,
+        "acme_crm",
+        None,
+        None,
+        |url| {
+            let url = url.to_string();
+            std::thread::spawn(move || {
+                let _ = reqwest::blocking::get(&url);
+            });
+            Ok(())
+        },
+    );
+
+    assert!(result.is_ok());
+    server.handle.join().unwrap();
+    let html = server
+        .state
+        .lock()
+        .unwrap()
+        .browser_response_html
+        .clone()
+        .unwrap_or_default();
+    assert!(html.contains("Connection successful"));
 }
 
 #[test]
@@ -349,87 +412,85 @@ fn test_manual_connect_prompts_for_connection_and_finishes_candidate_selection()
 
 #[test]
 fn test_connection_selection_uses_selected_connection_auth_type() {
-    let mut server = Server::new();
-    let _integrations =
-        authed_json_mock!(server, Method::GET, "/api/v1/integrations", StatusCode::OK)
-            .with_body(
-                r#"[{
-                    "name":"manual-svc",
-                    "displayName":"Manual Service",
-                    "authTypes":["manual"],
-                    "connections":[
-                        {"name":"workspace","displayName":"Workspace OAuth","authTypes":["oauth"]},
-                        {"name":"apikey","displayName":"API Key","authTypes":["manual"],"credentialFields":[{"name":"token","label":"Token"}]}
-                    ]
-                }]"#,
-            )
-            .create();
-    let _oauth = authed_json_mock!(
-        server,
-        Method::POST,
-        "/api/v1/auth/start-oauth",
-        StatusCode::OK
-    )
-    .match_header(header::CONTENT_TYPE.as_str(), http::APPLICATION_JSON)
-    .match_body(Matcher::JsonString(
-        r#"{"connection":"workspace","integration":"manual-svc"}"#.to_string(),
-    ))
-    .with_body(r#"{"url":"https://example.com/oauth","state":"abc123"}"#)
-    .create();
+    let server = spawn_oauth_connect_server(OAuthConnectServerConfig {
+        integrations_path: "/api/v1/integrations",
+        start_path: "/api/v1/auth/start-oauth",
+        integration_name: "manual-svc",
+        integrations_response: Some(
+            r#"[{
+                "name":"manual-svc",
+                "displayName":"Manual Service",
+                "authTypes":["manual"],
+                "connections":[
+                    {"name":"workspace","displayName":"Workspace OAuth","authTypes":["oauth"]},
+                    {"name":"apikey","displayName":"API Key","authTypes":["manual"],"credentialFields":[{"name":"token","label":"Token"}]}
+                ]
+            }]"#,
+        ),
+        selection_required: false,
+    });
+    let client = gestalt::api::ApiClient::new(&server.base_url, TEST_TOKEN).unwrap();
+    let result = gestalt::commands::plugins::connect_with_browser_opener_and_wait(
+        &client,
+        "manual-svc",
+        Some("workspace"),
+        None,
+        |url| {
+            let url = url.to_string();
+            std::thread::spawn(move || {
+                let _ = reqwest::blocking::get(&url);
+            });
+            Ok(())
+        },
+    );
 
-    let home = tempfile::tempdir().unwrap();
-    cli_command_for_server(home.path(), &server)
-        .args(["plugins", "connect", "manual-svc"])
-        .write_stdin("1\n")
-        .assert()
-        .success()
-        .stderr(predicate::str::contains(
-            "Select a Manual Service connection:",
-        ))
-        .stderr(predicate::str::contains("Workspace OAuth"))
-        .stderr(predicate::str::contains(
-            "Opening browser to connect manual-svc...",
-        ));
+    assert!(result.is_ok());
+    server.handle.join().unwrap();
+    let body = server.state.lock().unwrap().start_body.clone().unwrap();
+    assert_eq!(body["integration"], "manual-svc");
+    assert_eq!(body["connection"], "workspace");
 }
 
 #[test]
 fn test_connect_auto_selects_single_connection_and_uses_its_auth_type() {
-    let mut server = Server::new();
-    let _integrations =
-        authed_json_mock!(server, Method::GET, "/api/v1/integrations", StatusCode::OK)
-            .with_body(
-                r#"[{
-                    "name":"single-svc",
-                    "displayName":"Single Service",
-                    "authTypes":["manual"],
-                    "connections":[
-                        {"name":"workspace","displayName":"Workspace OAuth","authTypes":["oauth"]}
-                    ]
-                }]"#,
-            )
-            .create();
-    let _oauth = authed_json_mock!(
-        server,
-        Method::POST,
-        "/api/v1/auth/start-oauth",
-        StatusCode::OK
-    )
-    .match_header(header::CONTENT_TYPE.as_str(), http::APPLICATION_JSON)
-    .match_body(Matcher::JsonString(
-        r#"{"connection":"workspace","integration":"single-svc"}"#.to_string(),
-    ))
-    .with_body(r#"{"url":"https://example.com/oauth","state":"abc123"}"#)
-    .create();
+    let server = spawn_oauth_connect_server(OAuthConnectServerConfig {
+        integrations_path: "/api/v1/integrations",
+        start_path: "/api/v1/auth/start-oauth",
+        integration_name: "single-svc",
+        integrations_response: Some(
+            r#"[{
+                "name":"single-svc",
+                "displayName":"Single Service",
+                "authTypes":["manual"],
+                "connections":[
+                    {"name":"workspace","displayName":"Workspace OAuth","authTypes":["oauth"]}
+                ]
+            }]"#,
+        ),
+        selection_required: false,
+    });
+    let client = gestalt::api::ApiClient::new(&server.base_url, TEST_TOKEN).unwrap();
+    let result = gestalt::commands::plugins::connect_with_browser_opener_and_wait(
+        &client,
+        "single-svc",
+        None,
+        None,
+        |url| {
+            let url = url.to_string();
+            std::thread::spawn(move || {
+                let _ = reqwest::blocking::get(&url);
+            });
+            Ok(())
+        },
+    );
 
-    let home = tempfile::tempdir().unwrap();
-    cli_command_for_server(home.path(), &server)
-        .args(["plugins", "connect", "single-svc"])
-        .assert()
-        .success()
-        .stderr(predicate::str::contains("Select a Single Service connection:").not())
-        .stderr(predicate::str::contains(
-            "Opening browser to connect single-svc...",
-        ));
+    assert!(result.is_ok());
+    server.handle.join().unwrap();
+    let body = server.state.lock().unwrap().start_body.clone().unwrap();
+    assert_eq!(body["integration"], "single-svc");
+    assert_eq!(body["connection"], "workspace");
+    assert!(body["callbackPort"].as_u64().unwrap() > 0);
+    assert!(!body["callbackState"].as_str().unwrap().is_empty());
 }
 
 #[test]

--- a/gestalt/cli/tests/support/mod.rs
+++ b/gestalt/cli/tests/support/mod.rs
@@ -116,12 +116,46 @@ pub(crate) struct LoginFlowState {
 struct HttpRequest {
     method: Method,
     target: String,
+    headers: Vec<(String, String)>,
     body: Vec<u8>,
 }
 
 pub(crate) struct LoginServer {
     pub(crate) base_url: String,
     pub(crate) state: Arc<Mutex<LoginFlowState>>,
+    pub(crate) handle: std::thread::JoinHandle<()>,
+}
+
+pub(crate) struct OAuthConnectServerConfig<'a> {
+    pub(crate) integrations_path: &'a str,
+    pub(crate) start_path: &'a str,
+    pub(crate) integration_name: &'a str,
+    pub(crate) integrations_response: Option<&'a str>,
+    pub(crate) selection_required: bool,
+}
+
+#[derive(Clone)]
+struct OAuthConnectHandlerConfig {
+    browser_url: String,
+    integrations_path: String,
+    start_path: String,
+    integration_name: String,
+    integrations_response: Option<String>,
+    selection_required: bool,
+}
+
+#[derive(Default)]
+pub(crate) struct OAuthConnectFlowState {
+    pub(crate) callback_port: Option<u16>,
+    pub(crate) callback_state: Option<String>,
+    pub(crate) oauth_state: Option<String>,
+    pub(crate) browser_response_html: Option<String>,
+    pub(crate) start_body: Option<serde_json::Value>,
+}
+
+pub(crate) struct OAuthConnectServer {
+    pub(crate) base_url: String,
+    pub(crate) state: Arc<Mutex<OAuthConnectFlowState>>,
     pub(crate) handle: std::thread::JoinHandle<()>,
 }
 
@@ -146,6 +180,47 @@ pub(crate) fn spawn_login_server() -> LoginServer {
         }
     });
     LoginServer {
+        base_url,
+        state,
+        handle,
+    }
+}
+
+pub(crate) fn spawn_oauth_connect_server(
+    config: OAuthConnectServerConfig<'_>,
+) -> OAuthConnectServer {
+    let listener = TcpListener::bind("127.0.0.1:0").unwrap();
+    let base_url = format!("http://{}", listener.local_addr().unwrap());
+    let handler_config = OAuthConnectHandlerConfig {
+        browser_url: format!("{base_url}/browser-oauth"),
+        integrations_path: config.integrations_path.to_string(),
+        start_path: config.start_path.to_string(),
+        integration_name: config.integration_name.to_string(),
+        integrations_response: config.integrations_response.map(str::to_string),
+        selection_required: config.selection_required,
+    };
+    let state = Arc::new(Mutex::new(OAuthConnectFlowState::default()));
+    let server_state = Arc::clone(&state);
+    let expected_request_count = if handler_config.selection_required {
+        5
+    } else {
+        4
+    };
+    let handle = std::thread::spawn(move || {
+        let mut workers = Vec::new();
+        for _ in 0..expected_request_count {
+            let (stream, _) = listener.accept().unwrap();
+            let state = Arc::clone(&server_state);
+            let handler_config = handler_config.clone();
+            workers.push(std::thread::spawn(move || {
+                handle_oauth_connect_request(stream, state, &handler_config);
+            }));
+        }
+        for worker in workers {
+            worker.join().unwrap();
+        }
+    });
+    OAuthConnectServer {
         base_url,
         state,
         handle,
@@ -222,17 +297,144 @@ fn handle_login_request(
     }
 }
 
+fn handle_oauth_connect_request(
+    mut stream: TcpStream,
+    state: Arc<Mutex<OAuthConnectFlowState>>,
+    config: &OAuthConnectHandlerConfig,
+) {
+    let request = read_http_request(&mut stream);
+    match request.target.as_str() {
+        target if request.method == Method::GET && target == config.integrations_path => {
+            let body = config.integrations_response.clone().unwrap_or_else(|| {
+                format!(
+                    r#"[{{"name":"{}","authTypes":["oauth"],"connected":false}}]"#,
+                    config.integration_name
+                )
+            });
+            write_http_response(&mut stream, StatusCode::OK, http::APPLICATION_JSON, &body);
+        }
+        target if request.method == Method::POST && target == config.start_path => {
+            let body: serde_json::Value = serde_json::from_slice(&request.body).unwrap();
+            let mut state = state.lock().unwrap();
+            state.callback_port = Some(body["callbackPort"].as_u64().unwrap() as u16);
+            state.callback_state = Some(body["callbackState"].as_str().unwrap().to_string());
+            state.oauth_state = Some("oauth-state".to_string());
+            state.start_body = Some(body.clone());
+            write_http_response(
+                &mut stream,
+                StatusCode::OK,
+                http::APPLICATION_JSON,
+                &format!(
+                    r#"{{"url":"{}","state":"oauth-state"}}"#,
+                    config.browser_url
+                ),
+            );
+        }
+        "/browser-oauth" if request.method == Method::GET => {
+            let (callback_port, callback_state, oauth_state) = {
+                let state = state.lock().unwrap();
+                (
+                    state.callback_port.expect("missing callback port"),
+                    state
+                        .callback_state
+                        .clone()
+                        .expect("missing callback state"),
+                    state.oauth_state.clone().expect("missing oauth state"),
+                )
+            };
+            let callback_url = format!(
+                "http://127.0.0.1:{callback_port}/?code=test-code&state={oauth_state}&cli_state={callback_state}"
+            );
+            let html = reqwest::blocking::get(callback_url)
+                .unwrap()
+                .text()
+                .unwrap();
+            state.lock().unwrap().browser_response_html = Some(html);
+            write_http_response(&mut stream, StatusCode::OK, http::TEXT_PLAIN, "ok");
+        }
+        target if request.method == Method::GET && target.starts_with("/api/v1/auth/callback?") => {
+            let url = url::Url::parse(&format!("http://localhost{target}")).unwrap();
+            let params = url
+                .query_pairs()
+                .collect::<std::collections::HashMap<_, _>>();
+            let oauth_state = state.lock().unwrap().oauth_state.clone().unwrap();
+            assert_eq!(params.get("code").map(|v| v.as_ref()), Some("test-code"));
+            assert_eq!(params.get("cli").map(|v| v.as_ref()), Some("1"));
+            assert_eq!(
+                params.get("state").map(|v| v.as_ref()),
+                Some(oauth_state.as_str())
+            );
+            if config.selection_required {
+                write_http_response(
+                    &mut stream,
+                    StatusCode::OK,
+                    http::APPLICATION_JSON,
+                    &format!(
+                        r#"{{
+                            "status":"selection_required",
+                            "integration":"{}",
+                            "selectionUrl":"/api/v1/auth/pending-connection",
+                            "pendingToken":"pending-123",
+                            "candidates":[
+                                {{"id":"site-a","name":"Site A"}}
+                            ]
+                        }}"#,
+                        config.integration_name
+                    ),
+                );
+                return;
+            }
+            write_http_response(
+                &mut stream,
+                StatusCode::OK,
+                http::APPLICATION_JSON,
+                &format!(
+                    r#"{{"status":"connected","integration":"{}"}}"#,
+                    config.integration_name
+                ),
+            );
+        }
+        "/api/v1/auth/pending-connection" if request.method == Method::POST => {
+            assert!(
+                config.selection_required,
+                "unexpected pending-connection request"
+            );
+            let expected_bearer = test_bearer();
+            assert_eq!(
+                request_auth_header(&request).as_deref(),
+                Some(expected_bearer.as_str()),
+                "expected bearer auth on pending selection request"
+            );
+            assert_eq!(
+                String::from_utf8(request.body).unwrap(),
+                "pending_token=pending-123&candidate_index=0"
+            );
+            write_http_response(
+                &mut stream,
+                StatusCode::OK,
+                http::TEXT_HTML,
+                "<html>ok</html>",
+            );
+        }
+        _ => panic!("unexpected request: {} {}", request.method, request.target),
+    }
+}
+
 fn read_http_request(stream: &mut TcpStream) -> HttpRequest {
     let mut reader = BufReader::new(stream.try_clone().unwrap());
     let mut request_line = String::new();
     reader.read_line(&mut request_line).unwrap();
 
     let mut content_length = 0usize;
+    let mut headers = Vec::new();
     loop {
         let mut line = String::new();
         reader.read_line(&mut line).unwrap();
         if line == "\r\n" {
             break;
+        }
+        if let Some((name, value)) = line.split_once(':') {
+            headers.push((name.trim().to_string(), value.trim().to_string()));
         }
         if let Some((name, value)) = line.split_once(':')
             && name.eq_ignore_ascii_case(header::CONTENT_LENGTH.as_str())
@@ -248,8 +450,17 @@ fn read_http_request(stream: &mut TcpStream) -> HttpRequest {
     HttpRequest {
         method: Method::from_bytes(parts.next().unwrap().as_bytes()).unwrap(),
         target: parts.next().unwrap().to_string(),
+        headers,
         body,
     }
+}
+
+fn request_auth_header(request: &HttpRequest) -> Option<String> {
+    request
+        .headers
+        .iter()
+        .find(|(name, _)| name.eq_ignore_ascii_case(header::AUTHORIZATION.as_str()))
+        .map(|(_, value)| value.clone())
 }
 
 fn write_http_response(stream: &mut TcpStream, status: StatusCode, content_type: &str, body: &str) {

--- a/gestaltd/internal/server/handlers_connect.go
+++ b/gestaltd/internal/server/handlers_connect.go
@@ -25,6 +25,7 @@ type connectManualRequest struct {
 	Integration      string            `json:"integration"`
 	Connection       string            `json:"connection"`
 	Instance         string            `json:"instance"`
+	ReturnPath       string            `json:"returnPath"`
 	Credential       string            `json:"credential"`
 	Credentials      map[string]string `json:"credentials"`
 	ConnectionParams map[string]string `json:"connectionParams"`
@@ -59,6 +60,12 @@ func (s *Server) connectManual(w http.ResponseWriter, r *http.Request) {
 	if req.Integration == "" {
 		auditErr = errors.New("integration is required")
 		writeError(w, http.StatusBadRequest, "integration is required")
+		return
+	}
+	returnPath, err := normalizeReturnPath(req.ReturnPath)
+	if err != nil {
+		auditErr = err
+		writeError(w, http.StatusBadRequest, err.Error())
 		return
 	}
 
@@ -129,7 +136,7 @@ func (s *Server) connectManual(w http.ResponseWriter, r *http.Request) {
 		MetadataJSON:    manualMeta,
 	}
 
-	result, err := s.runPostConnect(r.Context(), prov, tm)
+	result, err := s.runPostConnect(r.Context(), prov, tm, returnPath)
 	if err != nil {
 		auditErr = errors.New("connection setup failed")
 		slog.ErrorContext(r.Context(), "post_connect failed", "provider", req.Integration, "error", err)
@@ -586,7 +593,7 @@ func mergeMetadataJSON(existing string, extra map[string]string) (string, error)
 	return string(b), nil
 }
 
-func (s *Server) runPostConnect(ctx context.Context, prov core.Provider, tm tokenMaterial) (*postConnectResult, error) {
+func (s *Server) runPostConnect(ctx context.Context, prov core.Provider, tm tokenMaterial, returnPath string) (*postConnectResult, error) {
 	if cfg := prov.DiscoveryConfig(); cfg != nil {
 		client := &http.Client{
 			Timeout:   30 * time.Second,
@@ -614,7 +621,7 @@ func (s *Server) runPostConnect(ctx context.Context, prov core.Provider, tm toke
 			return &postConnectResult{Status: "connected", Integration: tm.Integration}, nil
 		}
 
-		pendingToken, err := s.encodePendingConnectionToken(tm, candidates)
+		pendingToken, err := s.encodePendingConnectionToken(tm, candidates, returnPath)
 		if err != nil {
 			return nil, fmt.Errorf("encode pending connection: %w", err)
 		}

--- a/gestaltd/internal/server/handlers_identity_integrations.go
+++ b/gestaltd/internal/server/handlers_identity_integrations.go
@@ -226,6 +226,17 @@ func (s *Server) connectManagedIdentityManual(w http.ResponseWriter, r *http.Req
 		writeError(w, http.StatusBadRequest, "integration is required")
 		return
 	}
+	returnPath, err := normalizeReturnPath(req.ReturnPath)
+	if err != nil {
+		auditErr = err
+		writeError(w, http.StatusBadRequest, err.Error())
+		return
+	}
+	if err := validateManagedIdentityReturnPath(returnPath, core.IntegrationTokenOwnerKindManagedIdentity, actor.Identity.ID); err != nil {
+		auditErr = err
+		writeError(w, http.StatusBadRequest, err.Error())
+		return
+	}
 
 	viewer := PrincipalFromContext(r.Context())
 	if !s.managedIdentityGrantPluginVisible(req.Integration, viewer) {
@@ -316,7 +327,7 @@ func (s *Server) connectManagedIdentityManual(w http.ResponseWriter, r *http.Req
 		return
 	}
 
-	result, err := s.runPostConnect(r.Context(), prov, tm)
+	result, err := s.runPostConnect(r.Context(), prov, tm, returnPath)
 	if err != nil {
 		if s.writeManagedIdentityConnectionWriteError(w, req.Integration, err) {
 			auditErr = err

--- a/gestaltd/internal/server/handlers_oauth.go
+++ b/gestaltd/internal/server/handlers_oauth.go
@@ -1,11 +1,13 @@
 package server
 
 import (
+	"crypto/sha256"
 	"encoding/json"
 	"errors"
 	"fmt"
 	"log/slog"
 	"net/http"
+	"net/url"
 	"strings"
 	"time"
 
@@ -21,6 +23,9 @@ type startOAuthRequest struct {
 	Connection       string            `json:"connection"`
 	Instance         string            `json:"instance"`
 	Scopes           []string          `json:"scopes"`
+	ReturnPath       string            `json:"returnPath"`
+	CallbackPort     int               `json:"callbackPort,omitempty"`
+	CallbackState    string            `json:"callbackState,omitempty"`
 	ConnectionParams map[string]string `json:"connectionParams"`
 }
 
@@ -29,6 +34,120 @@ type oauthStartTarget struct {
 	OwnerID         string
 	InitiatorUserID string
 	AuthSource      string
+}
+
+const (
+	oauthCallbackPath      = "/api/v1/auth/callback"
+	oauthStateCookieBase   = "oauth_state"
+	oauthStateCookiePrefix = "oauth_state_"
+	oauthCLIRelayPageHTML  = `<!doctype html>
+<html lang="en">
+<head>
+  <meta charset="utf-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1">
+  <meta name="color-scheme" content="light dark">
+  <title>Continue Connection</title>
+</head>
+<body>
+  <main>
+    <h1 id="title"></h1>
+    <p id="detail"></p>
+    <p><a id="link" href="">Continue in the CLI</a></p>
+  </main>
+  <script>
+    const data = __DATA__;
+    document.getElementById("title").textContent = data.title;
+    document.getElementById("detail").textContent = data.detail;
+    document.getElementById("link").href = data.targetURL;
+    window.location.replace(data.targetURL);
+  </script>
+</body>
+</html>
+`
+)
+
+func oauthStateCookieName(encodedState string) string {
+	if encodedState == "" {
+		return oauthStateCookieBase
+	}
+	sum := sha256.Sum256([]byte(encodedState))
+	return oauthStateCookiePrefix + fmt.Sprintf("%x", sum[:8])
+}
+
+func (s *Server) setOAuthStateCookie(w http.ResponseWriter, encodedState string) {
+	if encodedState == "" {
+		return
+	}
+	http.SetCookie(w, &http.Cookie{
+		Name:     oauthStateCookieName(encodedState),
+		Value:    encodedState,
+		Path:     oauthCallbackPath,
+		MaxAge:   int(integrationOAuthStateTTL.Seconds()),
+		HttpOnly: true,
+		Secure:   s.secureCookies,
+		SameSite: http.SameSiteLaxMode,
+	})
+}
+
+func (s *Server) clearOAuthStateCookie(w http.ResponseWriter, encodedState string) {
+	http.SetCookie(w, &http.Cookie{
+		Name:     oauthStateCookieName(encodedState),
+		Value:    "",
+		Path:     oauthCallbackPath,
+		MaxAge:   -1,
+		HttpOnly: true,
+		Secure:   s.secureCookies,
+		SameSite: http.SameSiteLaxMode,
+	})
+}
+
+func (s *Server) validateOAuthStateCookie(r *http.Request, encodedState string) error {
+	cookie, err := r.Cookie(oauthStateCookieName(encodedState))
+	if err != nil {
+		return fmt.Errorf("missing oauth state cookie")
+	}
+	if cookie.Value != encodedState {
+		return fmt.Errorf("oauth state mismatch")
+	}
+	return nil
+}
+
+func writeOAuthCLIRelayPage(w http.ResponseWriter, targetURL, integration string) {
+	data := map[string]string{
+		"title":     "Continue " + integration + " connection",
+		"detail":    "Returning this OAuth callback to the Gestalt CLI. You can close this tab if nothing happens automatically.",
+		"targetURL": targetURL,
+	}
+	payload, err := json.Marshal(data)
+	if err != nil {
+		writeError(w, http.StatusInternalServerError, "failed to render cli oauth relay page")
+		return
+	}
+	html := strings.Replace(oauthCLIRelayPageHTML, "__DATA__", string(payload), 1)
+	w.Header().Set("Cache-Control", "no-store")
+	w.Header().Set("Content-Type", "text/html; charset=utf-8")
+	w.WriteHeader(http.StatusOK)
+	_, _ = w.Write([]byte(html))
+}
+
+func buildOAuthCLIRelayURL(state *integrationOAuthState, code, encodedState string) (string, error) {
+	if state == nil {
+		return "", fmt.Errorf("missing oauth state")
+	}
+	if state.CallbackPort <= 0 || state.CallbackPort > maxPort || strings.TrimSpace(state.CallbackState) == "" {
+		return "", fmt.Errorf("oauth state missing callback binding")
+	}
+	target := &url.URL{
+		Scheme: "http",
+		Host:   fmt.Sprintf("127.0.0.1:%d", state.CallbackPort),
+		Path:   "/",
+	}
+	query := target.Query()
+	query.Set("code", code)
+	query.Set("state", encodedState)
+	query.Set("cli_state", state.CallbackState)
+	target.RawQuery = query.Encode()
+	return target.String(), nil
 }
 
 func (s *Server) startIntegrationOAuth(w http.ResponseWriter, r *http.Request) {
@@ -134,6 +253,23 @@ func (s *Server) startManagedIdentityOAuth(w http.ResponseWriter, r *http.Reques
 }
 
 func (s *Server) startIntegrationOAuthForOwner(w http.ResponseWriter, r *http.Request, req startOAuthRequest, target oauthStartTarget) (string, string, auditTarget, error) {
+	returnPath, err := normalizeReturnPath(req.ReturnPath)
+	if err != nil {
+		writeError(w, http.StatusBadRequest, err.Error())
+		return metricutil.UnknownAttrValue, metricutil.UnknownAttrValue, auditTarget{Kind: auditTargetKindConnection}, err
+	}
+	switch {
+	case req.CallbackPort == 0 && strings.TrimSpace(req.CallbackState) == "":
+	case req.CallbackPort <= 0 || req.CallbackPort > maxPort || strings.TrimSpace(req.CallbackState) == "":
+		err := errors.New("callbackPort and callbackState must be provided together")
+		writeError(w, http.StatusBadRequest, err.Error())
+		return metricutil.UnknownAttrValue, metricutil.UnknownAttrValue, auditTarget{Kind: auditTargetKindConnection}, err
+	}
+	if err := validateManagedIdentityReturnPath(returnPath, target.OwnerKind, target.OwnerID); err != nil {
+		writeError(w, http.StatusBadRequest, err.Error())
+		return metricutil.UnknownAttrValue, metricutil.UnknownAttrValue, auditTarget{Kind: auditTargetKindConnection}, err
+	}
+
 	prov, ok := s.getProvider(w, req.Integration)
 	if !ok {
 		return metricutil.UnknownAttrValue, metricutil.UnknownAttrValue, auditTarget{Kind: auditTargetKindConnection}, errors.New("integration not found")
@@ -201,6 +337,9 @@ func (s *Server) startIntegrationOAuthForOwner(w http.ResponseWriter, r *http.Re
 		Integration:      req.Integration,
 		Connection:       connection,
 		Instance:         instance,
+		ReturnPath:       returnPath,
+		CallbackPort:     req.CallbackPort,
+		CallbackState:    strings.TrimSpace(req.CallbackState),
 		Verifier:         verifier,
 		ConnectionParams: connParams,
 		ExpiresAt:        s.now().Add(integrationOAuthStateTTL).Unix(),
@@ -216,6 +355,7 @@ func (s *Server) startIntegrationOAuthForOwner(w http.ResponseWriter, r *http.Re
 		return req.Integration, connectionMode, auditTarget, errors.New("failed to prepare oauth URL")
 	}
 
+	s.setOAuthStateCookie(w, encodedState)
 	writeJSON(w, http.StatusOK, map[string]string{"url": authURL, "state": encodedState})
 	return req.Integration, connectionMode, auditTarget, nil
 }
@@ -229,7 +369,11 @@ func (s *Server) integrationOAuthCallback(w http.ResponseWriter, r *http.Request
 	stateAuthSource := ""
 	providerName := ""
 	connectionMode := metricutil.UnknownAttrValue
+	recordCompletion := true
 	defer func() {
+		if !recordCompletion {
+			return
+		}
 		metricutil.RecordConnectionAuthMetrics(r.Context(), startedAt, providerName, "oauth", "complete", connectionMode, auditErr != nil)
 		if auditUserID != "" {
 			s.auditHTTPEventWithUserIDAndTarget(r.Context(), auditUserID, stateAuthSource, providerName, "connection.oauth.complete", auditAllowed, auditErr, auditTarget)
@@ -253,6 +397,7 @@ func (s *Server) integrationOAuthCallback(w http.ResponseWriter, r *http.Request
 
 	code := r.URL.Query().Get("code")
 	encodedState := r.URL.Query().Get("state")
+	cliFinalize := r.URL.Query().Get("cli") == "1"
 	if code == "" || encodedState == "" {
 		auditErr = errors.New("missing code or state parameter")
 		writeCallbackError(
@@ -274,6 +419,7 @@ func (s *Server) integrationOAuthCallback(w http.ResponseWriter, r *http.Request
 		)
 		return
 	}
+	s.clearOAuthStateCookie(w, encodedState)
 
 	state, err := s.stateCodec.Decode(encodedState, s.now())
 	if err != nil {
@@ -290,6 +436,95 @@ func (s *Server) integrationOAuthCallback(w http.ResponseWriter, r *http.Request
 	auditUserID = state.InitiatorUserID
 	stateAuthSource = state.AuthSource
 	auditTarget = connectionAuditTarget(state.Integration, state.Connection, state.Instance)
+	if cliFinalize {
+		if state.CallbackPort == 0 || strings.TrimSpace(state.CallbackState) == "" {
+			auditErr = errors.New("oauth callback is not configured for CLI finalization")
+			writeCallbackError(
+				http.StatusBadRequest,
+				"oauth callback is not configured for CLI finalization",
+				providerName+" connection failed",
+				"This connection attempt cannot be completed by the CLI. Start the connection again from the CLI.",
+			)
+			return
+		}
+		if !s.noAuth {
+			p, err := s.resolveRequestPrincipalWithUserID(r)
+			switch {
+			case err == nil && p != nil:
+				if p.UserID != state.InitiatorUserID {
+					auditErr = errors.New("oauth callback initiator mismatch")
+					writeCallbackError(
+						http.StatusForbidden,
+						"oauth callback initiator mismatch",
+						providerName+" connection expired",
+						"You no longer have access to finish this connection from the CLI. Start the connection again.",
+					)
+					return
+				}
+				r = r.WithContext(principal.WithPrincipal(r.Context(), p))
+			case err == nil:
+				auditErr = errors.New("missing authorization")
+				writeCallbackError(
+					http.StatusUnauthorized,
+					"missing authorization",
+					providerName+" connection failed",
+					"The CLI must authenticate before it can finish this connection.",
+				)
+				return
+			case errors.Is(err, errInvalidAuthorizationHeader):
+				auditErr = errInvalidAuthorizationHeader
+				writeCallbackError(
+					http.StatusUnauthorized,
+					"invalid authorization header format",
+					providerName+" connection failed",
+					"The CLI sent an invalid authorization header while finishing this connection.",
+				)
+				return
+			case errors.Is(err, principal.ErrInvalidToken):
+				auditErr = principal.ErrInvalidToken
+				writeCallbackError(
+					http.StatusUnauthorized,
+					"invalid token",
+					providerName+" connection failed",
+					"The CLI credentials are no longer valid. Log in again and restart the connection.",
+				)
+				return
+			default:
+				auditErr = errors.New("token validation failed")
+				writeCallbackError(
+					http.StatusInternalServerError,
+					"token validation failed",
+					providerName+" connection failed",
+					"Gestalt could not validate the CLI credentials for this connection. Try again.",
+				)
+				return
+			}
+		}
+	} else if state.CallbackPort != 0 {
+		relayURL, err := buildOAuthCLIRelayURL(state, code, encodedState)
+		if err != nil {
+			auditErr = errors.New("failed to prepare cli callback relay")
+			writeCallbackError(
+				http.StatusInternalServerError,
+				"failed to prepare cli callback relay",
+				providerName+" connection failed",
+				"Gestalt could not return this OAuth callback to the CLI. Start the connection again from the CLI.",
+			)
+			return
+		}
+		recordCompletion = false
+		writeOAuthCLIRelayPage(w, relayURL, providerName)
+		return
+	} else if err := s.validateOAuthStateCookie(r, encodedState); err != nil {
+		auditErr = errors.New("invalid or expired oauth state")
+		writeCallbackError(
+			http.StatusBadRequest,
+			"invalid or expired oauth state",
+			"Connection expired",
+			"This connection attempt is no longer valid. Start a new connection from Integrations.",
+		)
+		return
+	}
 	handler, ok := s.requireOAuthHandler(w, providerName, state.Connection)
 	if !ok {
 		auditErr = errors.New("oauth is not configured")
@@ -421,7 +656,7 @@ func (s *Server) integrationOAuthCallback(w http.ResponseWriter, r *http.Request
 		MetadataJSON:    metadata,
 	}
 
-	result, err := s.runPostConnect(r.Context(), prov, tm)
+	result, err := s.runPostConnect(r.Context(), prov, tm, state.ReturnPath)
 	if err != nil {
 		if state.OwnerKind == core.IntegrationTokenOwnerKindManagedIdentity {
 			if writeManagedIdentityCallbackError(err) {
@@ -448,14 +683,31 @@ func (s *Server) integrationOAuthCallback(w http.ResponseWriter, r *http.Request
 		}
 		auditAllowed = true
 		auditErr = nil
+		if cliFinalize {
+			writeJSON(w, http.StatusOK, map[string]any{
+				"status":       "selection_required",
+				"integration":  providerName,
+				"selectionUrl": pendingConnectionPath,
+				"pendingToken": result.PendingToken,
+				"candidates":   state.Candidates,
+			})
+			return
+		}
 		s.writePendingConnectionSelectionPage(w, state, result.PendingToken)
 		return
 	}
-	auditAllowed = true
-	auditErr = nil
-	redirectURL, err := setURLQueryParam(integrationOAuthRedirectPath(state), "connected", providerName)
+	if cliFinalize {
+		auditAllowed = true
+		auditErr = nil
+		writeJSON(w, http.StatusOK, map[string]any{
+			"status":      "connected",
+			"integration": providerName,
+		})
+		return
+	}
+	redirectPath := integrationOAuthRedirectPath(state)
+	redirectURL, err := setURLQueryParam(redirectPath, "connected", providerName)
 	if err != nil {
-		auditAllowed = false
 		auditErr = errors.New("failed to prepare redirect URL")
 		writeCallbackError(
 			http.StatusInternalServerError,
@@ -465,5 +717,7 @@ func (s *Server) integrationOAuthCallback(w http.ResponseWriter, r *http.Request
 		)
 		return
 	}
+	auditAllowed = true
+	auditErr = nil
 	http.Redirect(w, r, redirectURL, http.StatusSeeOther)
 }

--- a/gestaltd/internal/server/metrics_test.go
+++ b/gestaltd/internal/server/metrics_test.go
@@ -119,7 +119,12 @@ func TestConnectionAuthMetrics(t *testing.T) {
 		body := bytes.NewBufferString(`{"integration":"` + providerName + `"}`)
 		startReq, _ := http.NewRequest(http.MethodPost, oauthServer.URL+"/api/v1/auth/start-oauth", body)
 		startReq.Header.Set("Content-Type", "application/json")
-		startResp, err := http.DefaultClient.Do(startReq)
+		jar, err := cookiejar.New(nil)
+		if err != nil {
+			t.Fatalf("cookie jar: %v", err)
+		}
+		startClient := &http.Client{Jar: jar}
+		startResp, err := startClient.Do(startReq)
 		if err != nil {
 			t.Fatalf("start oauth request: %v", err)
 		}
@@ -135,6 +140,7 @@ func TestConnectionAuthMetrics(t *testing.T) {
 		}
 
 		noRedirect := &http.Client{
+			Jar:           jar,
 			CheckRedirect: func(*http.Request, []*http.Request) error { return http.ErrUseLastResponse },
 		}
 		req, _ := http.NewRequest(http.MethodGet, oauthServer.URL+"/api/v1/auth/callback?code="+url.QueryEscape(code)+"&state="+url.QueryEscape(startResult["state"]), nil)

--- a/gestaltd/internal/server/oauth_state.go
+++ b/gestaltd/internal/server/oauth_state.go
@@ -5,6 +5,8 @@ import (
 	"errors"
 	"fmt"
 	"net/url"
+	"path"
+	"strconv"
 	"strings"
 	"time"
 
@@ -28,6 +30,9 @@ type integrationOAuthState struct {
 	Integration      string                  `json:"int"`
 	Connection       string                  `json:"con,omitempty"`
 	Instance         string                  `json:"ins,omitempty"`
+	ReturnPath       string                  `json:"ret,omitempty"`
+	CallbackPort     int                     `json:"cbp,omitempty"`
+	CallbackState    string                  `json:"cbs,omitempty"`
 	Verifier         string                  `json:"ver,omitempty"`
 	ConnectionParams map[string]string       `json:"cp,omitempty"`
 	ExpiresAt        int64                   `json:"exp"`
@@ -80,6 +85,17 @@ func validateIntegrationOAuthState(state *integrationOAuthState, now time.Time) 
 	}
 	if state.Integration == "" {
 		return fmt.Errorf("oauth state missing integration")
+	}
+	if _, err := normalizeReturnPath(state.ReturnPath); err != nil {
+		return err
+	}
+	if err := validateManagedIdentityReturnPath(state.ReturnPath, state.OwnerKind, state.OwnerID); err != nil {
+		return err
+	}
+	switch {
+	case state.CallbackPort == 0 && state.CallbackState == "":
+	case state.CallbackPort <= 0 || state.CallbackPort > maxPort || strings.TrimSpace(state.CallbackState) == "":
+		return fmt.Errorf("oauth state missing callback binding")
 	}
 	if state.ExpiresAt == 0 {
 		return fmt.Errorf("oauth state missing expiration")
@@ -137,6 +153,9 @@ func integrationOAuthRedirectPath(state *integrationOAuthState) string {
 	if state == nil {
 		return "/integrations"
 	}
+	if state.ReturnPath != "" {
+		return state.ReturnPath
+	}
 	if state.OwnerKind == core.IntegrationTokenOwnerKindManagedIdentity && strings.TrimSpace(state.OwnerID) != "" {
 		u := &url.URL{Path: "/identities"}
 		q := u.Query()
@@ -160,6 +179,7 @@ type pendingConnectionState struct {
 	Token      tokenMaterial             `json:"tok"`
 	BindingKey string                    `json:"bind"`
 	Candidates []core.DiscoveryCandidate `json:"cand"`
+	ReturnPath string                    `json:"ret,omitempty"`
 	ExpiresAt  int64                     `json:"exp"`
 }
 
@@ -209,6 +229,12 @@ func validatePendingConnectionState(state *pendingConnectionState, now time.Time
 	}
 	if len(state.Candidates) == 0 {
 		return fmt.Errorf("pending connection missing candidates")
+	}
+	if _, err := normalizeReturnPath(state.ReturnPath); err != nil {
+		return err
+	}
+	if err := validateManagedIdentityReturnPath(state.ReturnPath, state.Token.OwnerKind, state.Token.OwnerID); err != nil {
+		return err
 	}
 	if state.ExpiresAt == 0 {
 		return fmt.Errorf("pending connection missing expiration")
@@ -267,4 +293,113 @@ func setURLQueryParam(rawURL, key, value string) (string, error) {
 	q.Set(key, value)
 	u.RawQuery = q.Encode()
 	return u.String(), nil
+}
+
+func normalizeReturnPath(raw string) (string, error) {
+	raw = strings.TrimSpace(raw)
+	if raw == "" {
+		return "", nil
+	}
+	if containsASCIIControl(raw) || containsInvalidPercentEscape(raw) || containsEncodedASCIIControl(raw) {
+		return "", fmt.Errorf("invalid returnPath")
+	}
+	if strings.Contains(raw, `\`) || strings.Contains(strings.ToLower(raw), "%5c") {
+		return "", fmt.Errorf("invalid returnPath")
+	}
+	if strings.HasPrefix(raw, "//") {
+		return "", fmt.Errorf("invalid returnPath")
+	}
+	u, err := url.Parse(raw)
+	if err != nil {
+		return "", fmt.Errorf("invalid returnPath")
+	}
+	if u.IsAbs() || u.Host != "" || !strings.HasPrefix(u.Path, "/") || strings.HasPrefix(u.Path, "//") {
+		return "", fmt.Errorf("invalid returnPath")
+	}
+	u.Path = path.Clean(u.Path)
+	u.RawPath = ""
+	return u.String(), nil
+}
+
+func validateManagedIdentityReturnPath(raw, ownerKind, ownerID string) error {
+	if raw == "" || ownerKind != core.IntegrationTokenOwnerKindManagedIdentity {
+		return nil
+	}
+	ownerID = strings.TrimSpace(ownerID)
+	if ownerID == "" {
+		return nil
+	}
+	u, err := url.Parse(raw)
+	if err != nil {
+		return fmt.Errorf("invalid returnPath")
+	}
+	targetID, err := managedIdentityTargetIDFromReturnPath(u)
+	if err != nil {
+		return err
+	}
+	if targetID != "" && targetID != ownerID {
+		return fmt.Errorf("invalid returnPath")
+	}
+	return nil
+}
+
+func managedIdentityTargetIDFromReturnPath(u *url.URL) (string, error) {
+	if u == nil {
+		return "", nil
+	}
+	trimmedPath := strings.Trim(strings.TrimSpace(u.Path), "/")
+	if trimmedPath == "identities" {
+		return strings.TrimSpace(u.Query().Get("id")), nil
+	}
+	segments := strings.Split(trimmedPath, "/")
+	if len(segments) >= 2 && segments[0] == "identities" {
+		id, err := url.PathUnescape(segments[1])
+		if err != nil {
+			return "", fmt.Errorf("invalid returnPath")
+		}
+		return strings.TrimSpace(id), nil
+	}
+	return "", nil
+}
+
+func containsASCIIControl(s string) bool {
+	for _, r := range s {
+		if r < 0x20 || r == 0x7f {
+			return true
+		}
+	}
+	return false
+}
+
+func containsInvalidPercentEscape(s string) bool {
+	for i := 0; i < len(s); i++ {
+		if s[i] != '%' {
+			continue
+		}
+		if i+2 >= len(s) || !isHexDigit(s[i+1]) || !isHexDigit(s[i+2]) {
+			return true
+		}
+		i += 2
+	}
+	return false
+}
+
+func containsEncodedASCIIControl(s string) bool {
+	for i := 0; i+2 < len(s); i++ {
+		if s[i] != '%' {
+			continue
+		}
+		v, err := strconv.ParseUint(s[i+1:i+3], 16, 8)
+		if err != nil {
+			continue
+		}
+		if v < 0x20 || v == 0x7f {
+			return true
+		}
+	}
+	return false
+}
+
+func isHexDigit(b byte) bool {
+	return ('0' <= b && b <= '9') || ('a' <= b && b <= 'f') || ('A' <= b && b <= 'F')
 }

--- a/gestaltd/internal/server/pending_connection.go
+++ b/gestaltd/internal/server/pending_connection.go
@@ -141,7 +141,7 @@ func writePendingConnectionPage(w http.ResponseWriter, status int, view pendingC
 	_, _ = w.Write(buf.Bytes())
 }
 
-func (s *Server) encodePendingConnectionToken(tm tokenMaterial, candidates []core.DiscoveryCandidate) (string, error) {
+func (s *Server) encodePendingConnectionToken(tm tokenMaterial, candidates []core.DiscoveryCandidate, returnPath string) (string, error) {
 	if s.encryptor == nil {
 		return "", fmt.Errorf("pending connection encryption is not configured")
 	}
@@ -149,6 +149,7 @@ func (s *Server) encodePendingConnectionToken(tm tokenMaterial, candidates []cor
 		Token:      tm,
 		BindingKey: uuid.NewString(),
 		Candidates: candidates,
+		ReturnPath: returnPath,
 		ExpiresAt:  s.now().Add(pendingConnectionTTL).Unix(),
 	})
 }
@@ -232,7 +233,7 @@ func (s *Server) writePendingConnectionSelectionPage(w http.ResponseWriter, stat
 
 func (s *Server) writePendingConnectionSuccessPage(w http.ResponseWriter, integration, linkURL string) {
 	s.clearPendingConnectionCookie(w)
-	linkLabel := "Open integrations"
+	linkLabel := "Open app"
 	if linkURL == "" {
 		linkURL = "/integrations"
 	}
@@ -542,7 +543,13 @@ func pendingConnectionInitiatorUserID(state *pendingConnectionState) string {
 }
 
 func pendingConnectionRedirectPath(state *pendingConnectionState) string {
-	if state != nil && state.Token.OwnerKind == core.IntegrationTokenOwnerKindManagedIdentity && strings.TrimSpace(state.Token.OwnerID) != "" {
+	if state == nil {
+		return "/integrations"
+	}
+	if state.ReturnPath != "" {
+		return state.ReturnPath
+	}
+	if state.Token.OwnerKind == core.IntegrationTokenOwnerKindManagedIdentity && strings.TrimSpace(state.Token.OwnerID) != "" {
 		return "/identities?id=" + url.QueryEscape(state.Token.OwnerID)
 	}
 	return "/integrations"

--- a/gestaltd/internal/server/server_test.go
+++ b/gestaltd/internal/server/server_test.go
@@ -3,6 +3,7 @@ package server_test
 import (
 	"bytes"
 	"context"
+	"crypto/sha256"
 	"crypto/tls"
 	"encoding/json"
 	"errors"
@@ -9398,11 +9399,16 @@ func TestIntegrationOAuthCallback(t *testing.T) {
 		})
 		testutil.CloseOnCleanup(t, ts)
 
-		startBody := bytes.NewBufferString(`{"integration":"slack"}`)
+		startBody := bytes.NewBufferString(`{"integration":"slack","returnPath":"/workspace/connections?tab=oauth"}`)
 		startReq, _ := http.NewRequest(http.MethodPost, ts.URL+"/api/v1/auth/start-oauth", startBody)
 		startReq.Header.Set("Content-Type", "application/json")
 		startReq.Header.Set("Authorization", "Bearer session-token")
-		startResp, err := http.DefaultClient.Do(startReq)
+		jar, err := cookiejar.New(nil)
+		if err != nil {
+			t.Fatalf("cookie jar: %v", err)
+		}
+		startClient := &http.Client{Jar: jar}
+		startResp, err := startClient.Do(startReq)
 		if err != nil {
 			t.Fatalf("start request: %v", err)
 		}
@@ -9416,8 +9422,17 @@ func TestIntegrationOAuthCallback(t *testing.T) {
 		if err := json.NewDecoder(startResp.Body).Decode(&startResult); err != nil {
 			t.Fatalf("decoding start response: %v", err)
 		}
+		callbackURL, err := url.Parse(ts.URL + "/api/v1/auth/callback")
+		if err != nil {
+			t.Fatalf("callback url: %v", err)
+		}
+		stateCookieName := oauthStateCookieNameForTest(startResult["state"])
+		if !cookieJarHasCookie(jar, callbackURL, stateCookieName) {
+			t.Fatalf("expected oauth state cookie %q to be set before callback", stateCookieName)
+		}
 
 		noRedirect := &http.Client{
+			Jar: jar,
 			CheckRedirect: func(*http.Request, []*http.Request) error {
 				return http.ErrUseLastResponse
 			},
@@ -9433,8 +9448,11 @@ func TestIntegrationOAuthCallback(t *testing.T) {
 			t.Fatalf("expected 303, got %d", resp.StatusCode)
 		}
 		loc := resp.Header.Get("Location")
-		if loc != "/integrations?connected=slack" {
-			t.Fatalf("expected redirect to /integrations?connected=slack, got %q", loc)
+		if loc != "/workspace/connections?connected=slack&tab=oauth" {
+			t.Fatalf("expected redirect to /workspace/connections?connected=slack&tab=oauth, got %q", loc)
+		}
+		if cookieJarHasCookie(jar, callbackURL, stateCookieName) {
+			t.Fatalf("expected oauth state cookie %q to be cleared after callback", stateCookieName)
 		}
 		u, _ := svc.Users.FindOrCreateUser(context.Background(), "user@example.com")
 		tokens, _ := svc.Tokens.ListTokens(context.Background(), u.ID)
@@ -9474,6 +9492,121 @@ func TestIntegrationOAuthCallback(t *testing.T) {
 		}
 		if auditRecord["target_name"] != "default/default" {
 			t.Fatalf("expected audit target_name default/default, got %v", auditRecord["target_name"])
+		}
+	})
+
+	t.Run("rejects_invalid_return_path", func(t *testing.T) {
+		t.Parallel()
+
+		for _, returnPath := range []string{
+			"///evil.com",
+			`/workspace\connections`,
+			"/%5cevil.com",
+			"/%0d%0aevil.com",
+			"/workspace?tab=%09oauth",
+			"/workspace?tab=%zz",
+		} {
+			t.Run(returnPath, func(t *testing.T) {
+				t.Parallel()
+
+				ts := newTestServer(t, func(cfg *server.Config) {
+					cfg.Providers = testutil.NewProviderRegistry(t, &stubManualProvider{
+						StubIntegration: coretesting.StubIntegration{N: "manual-svc"},
+					})
+					cfg.DefaultConnection = map[string]string{"manual-svc": config.PluginConnectionName}
+				})
+				testutil.CloseOnCleanup(t, ts)
+
+				body := bytes.NewBufferString(fmt.Sprintf(`{"integration":"manual-svc","credential":"my-api-key","returnPath":%q}`, returnPath))
+				req, _ := http.NewRequest(http.MethodPost, ts.URL+"/api/v1/auth/connect-manual", body)
+				req.Header.Set("Content-Type", "application/json")
+				resp, err := http.DefaultClient.Do(req)
+				if err != nil {
+					t.Fatalf("request: %v", err)
+				}
+				defer func() { _ = resp.Body.Close() }()
+
+				if resp.StatusCode != http.StatusBadRequest {
+					t.Fatalf("expected 400, got %d", resp.StatusCode)
+				}
+				bodyBytes, err := io.ReadAll(resp.Body)
+				if err != nil {
+					t.Fatalf("read body: %v", err)
+				}
+				if !strings.Contains(string(bodyBytes), "invalid returnPath") {
+					t.Fatalf("expected invalid returnPath error, got %q", string(bodyBytes))
+				}
+			})
+		}
+	})
+
+	t.Run("rejects_missing_oauth_state_cookie", func(t *testing.T) {
+		t.Parallel()
+
+		svc := coretesting.NewStubServices(t)
+		handler := &testOAuthHandler{
+			authorizationBaseURLVal: "https://slack.com/oauth/v2/authorize",
+			exchangeCodeFn: func(_ context.Context, code string) (*core.TokenResponse, error) {
+				if code == "good-code" {
+					return &core.TokenResponse{AccessToken: "slack-token"}, nil
+				}
+				return nil, fmt.Errorf("bad code")
+			},
+		}
+		stub := &stubIntegrationWithAuthURL{
+			StubIntegration: coretesting.StubIntegration{N: "slack"},
+			authURL:         "https://slack.com/oauth/v2/authorize",
+		}
+
+		ts := newTestServer(t, func(cfg *server.Config) {
+			cfg.Auth = &coretesting.StubAuthProvider{
+				N: "test",
+				ValidateTokenFn: func(_ context.Context, token string) (*core.UserIdentity, error) {
+					if token != "session-token" {
+						return nil, fmt.Errorf("bad token")
+					}
+					return &core.UserIdentity{Email: "user@example.com"}, nil
+				},
+			}
+			cfg.Providers = testutil.NewProviderRegistry(t, stub)
+			cfg.DefaultConnection = map[string]string{"slack": testDefaultConnection}
+			cfg.ConnectionAuth = testConnectionAuth("slack", handler)
+			cfg.Services = svc
+		})
+		testutil.CloseOnCleanup(t, ts)
+
+		startReq, _ := http.NewRequest(http.MethodPost, ts.URL+"/api/v1/auth/start-oauth", bytes.NewBufferString(`{"integration":"slack"}`))
+		startReq.Header.Set("Content-Type", "application/json")
+		startReq.Header.Set("Authorization", "Bearer session-token")
+		startResp, err := http.DefaultClient.Do(startReq)
+		if err != nil {
+			t.Fatalf("start request: %v", err)
+		}
+		defer func() { _ = startResp.Body.Close() }()
+		if startResp.StatusCode != http.StatusOK {
+			t.Fatalf("expected 200 from start-oauth, got %d", startResp.StatusCode)
+		}
+
+		var startResult map[string]string
+		if err := json.NewDecoder(startResp.Body).Decode(&startResult); err != nil {
+			t.Fatalf("decoding start response: %v", err)
+		}
+
+		req, _ := http.NewRequest(http.MethodGet, ts.URL+"/api/v1/auth/callback?code=good-code&state="+url.QueryEscape(startResult["state"]), nil)
+		resp, err := http.DefaultClient.Do(req)
+		if err != nil {
+			t.Fatalf("callback request: %v", err)
+		}
+		defer func() { _ = resp.Body.Close() }()
+		if resp.StatusCode != http.StatusBadRequest {
+			t.Fatalf("expected 400, got %d", resp.StatusCode)
+		}
+		body, err := io.ReadAll(resp.Body)
+		if err != nil {
+			t.Fatalf("read body: %v", err)
+		}
+		if !strings.Contains(string(body), "invalid or expired oauth state") {
+			t.Fatalf("expected invalid oauth state error, got %q", string(body))
 		}
 	})
 
@@ -9524,11 +9657,16 @@ func TestIntegrationOAuthCallback(t *testing.T) {
 		})
 		testutil.CloseOnCleanup(t, ts)
 
-		startBody := bytes.NewBufferString(`{"integration":"slack"}`)
+		startBody := bytes.NewBufferString(`{"integration":"slack","returnPath":"/workspace/select?source=oauth"}`)
 		startReq, _ := http.NewRequest(http.MethodPost, ts.URL+"/api/v1/auth/start-oauth", startBody)
 		startReq.Header.Set("Content-Type", "application/json")
 		startReq.Header.Set("Authorization", "Bearer cli-api-token")
-		startResp, err := http.DefaultClient.Do(startReq)
+		jar, err := cookiejar.New(nil)
+		if err != nil {
+			t.Fatalf("cookie jar: %v", err)
+		}
+		startClient := &http.Client{Jar: jar}
+		startResp, err := startClient.Do(startReq)
 		if err != nil {
 			t.Fatalf("start request: %v", err)
 		}
@@ -9539,10 +9677,6 @@ func TestIntegrationOAuthCallback(t *testing.T) {
 			t.Fatalf("decoding start response: %v", err)
 		}
 
-		jar, err := cookiejar.New(nil)
-		if err != nil {
-			t.Fatalf("cookie jar: %v", err)
-		}
 		noRedirect := &http.Client{
 			Jar: jar,
 			CheckRedirect: func(*http.Request, []*http.Request) error {
@@ -9620,6 +9754,207 @@ func TestIntegrationOAuthCallback(t *testing.T) {
 			t.Fatalf("stored token integration = %q, want %q", stored.Integration, "slack")
 		}
 	})
+
+	t.Run("allows_multiple_browser_flows_in_parallel", func(t *testing.T) {
+		t.Parallel()
+
+		svc := coretesting.NewStubServices(t)
+		handler := &testOAuthHandler{
+			authorizationBaseURLVal: "https://slack.com/oauth/v2/authorize",
+			exchangeCodeFn: func(_ context.Context, code string) (*core.TokenResponse, error) {
+				if code == "good-code" {
+					return &core.TokenResponse{AccessToken: "slack-token"}, nil
+				}
+				return nil, fmt.Errorf("bad code")
+			},
+		}
+		stub := &stubIntegrationWithAuthURL{
+			StubIntegration: coretesting.StubIntegration{N: "slack"},
+			authURL:         "https://slack.com/oauth/v2/authorize",
+		}
+
+		ts := newTestServer(t, func(cfg *server.Config) {
+			cfg.Auth = &coretesting.StubAuthProvider{
+				N: "test",
+				ValidateTokenFn: func(_ context.Context, token string) (*core.UserIdentity, error) {
+					if token != "session-token" {
+						return nil, fmt.Errorf("bad token")
+					}
+					return &core.UserIdentity{Email: "user@example.com"}, nil
+				},
+			}
+			cfg.Providers = testutil.NewProviderRegistry(t, stub)
+			cfg.DefaultConnection = map[string]string{"slack": testDefaultConnection}
+			cfg.ConnectionAuth = testConnectionAuth("slack", handler)
+			cfg.Services = svc
+		})
+		testutil.CloseOnCleanup(t, ts)
+
+		jar, err := cookiejar.New(nil)
+		if err != nil {
+			t.Fatalf("cookie jar: %v", err)
+		}
+		startClient := &http.Client{Jar: jar}
+		startFlow := func() string {
+			startReq, _ := http.NewRequest(http.MethodPost, ts.URL+"/api/v1/auth/start-oauth", bytes.NewBufferString(`{"integration":"slack"}`))
+			startReq.Header.Set("Content-Type", "application/json")
+			startReq.Header.Set("Authorization", "Bearer session-token")
+			startResp, err := startClient.Do(startReq)
+			if err != nil {
+				t.Fatalf("start request: %v", err)
+			}
+			defer func() { _ = startResp.Body.Close() }()
+			if startResp.StatusCode != http.StatusOK {
+				t.Fatalf("expected 200 from start-oauth, got %d", startResp.StatusCode)
+			}
+			var startResult map[string]string
+			if err := json.NewDecoder(startResp.Body).Decode(&startResult); err != nil {
+				t.Fatalf("decoding start response: %v", err)
+			}
+			return startResult["state"]
+		}
+
+		firstState := startFlow()
+		secondState := startFlow()
+
+		noRedirect := &http.Client{
+			Jar: jar,
+			CheckRedirect: func(*http.Request, []*http.Request) error {
+				return http.ErrUseLastResponse
+			},
+		}
+		for _, encodedState := range []string{firstState, secondState} {
+			req, _ := http.NewRequest(http.MethodGet, ts.URL+"/api/v1/auth/callback?code=good-code&state="+url.QueryEscape(encodedState), nil)
+			resp, err := noRedirect.Do(req)
+			if err != nil {
+				t.Fatalf("callback request: %v", err)
+			}
+			defer func() { _ = resp.Body.Close() }()
+			if resp.StatusCode != http.StatusSeeOther {
+				t.Fatalf("expected 303 for state %q, got %d", encodedState, resp.StatusCode)
+			}
+		}
+	})
+
+	t.Run("cli_relay_and_finalize", func(t *testing.T) {
+		t.Parallel()
+
+		svc := coretesting.NewStubServices(t)
+		handler := &testOAuthHandler{
+			authorizationBaseURLVal: "https://slack.com/oauth/v2/authorize",
+			exchangeCodeFn: func(_ context.Context, code string) (*core.TokenResponse, error) {
+				if code == "good-code" {
+					return &core.TokenResponse{AccessToken: "slack-token"}, nil
+				}
+				return nil, fmt.Errorf("bad code")
+			},
+		}
+		stub := &stubIntegrationWithAuthURL{
+			StubIntegration: coretesting.StubIntegration{N: "slack"},
+			authURL:         "https://slack.com/oauth/v2/authorize",
+		}
+
+		ts := newTestServer(t, func(cfg *server.Config) {
+			cfg.Auth = &coretesting.StubAuthProvider{
+				N: "test",
+				ValidateTokenFn: func(_ context.Context, token string) (*core.UserIdentity, error) {
+					if token != "cli-api-token" {
+						return nil, fmt.Errorf("bad token")
+					}
+					return &core.UserIdentity{Email: "cli@test.local"}, nil
+				},
+			}
+			cfg.Providers = testutil.NewProviderRegistry(t, stub)
+			cfg.DefaultConnection = map[string]string{"slack": testDefaultConnection}
+			cfg.ConnectionAuth = testConnectionAuth("slack", handler)
+			cfg.Services = svc
+		})
+		testutil.CloseOnCleanup(t, ts)
+
+		startReq, _ := http.NewRequest(http.MethodPost, ts.URL+"/api/v1/auth/start-oauth", bytes.NewBufferString(`{"integration":"slack","callbackPort":43123,"callbackState":"cli-state"}`))
+		startReq.Header.Set("Content-Type", "application/json")
+		startReq.Header.Set("Authorization", "Bearer cli-api-token")
+		startResp, err := http.DefaultClient.Do(startReq)
+		if err != nil {
+			t.Fatalf("start request: %v", err)
+		}
+		defer func() { _ = startResp.Body.Close() }()
+		if startResp.StatusCode != http.StatusOK {
+			t.Fatalf("expected 200 from start-oauth, got %d", startResp.StatusCode)
+		}
+
+		var startResult map[string]string
+		if err := json.NewDecoder(startResp.Body).Decode(&startResult); err != nil {
+			t.Fatalf("decoding start response: %v", err)
+		}
+
+		relayReq, _ := http.NewRequest(http.MethodGet, ts.URL+"/api/v1/auth/callback?code=good-code&state="+url.QueryEscape(startResult["state"]), nil)
+		relayResp, err := http.DefaultClient.Do(relayReq)
+		if err != nil {
+			t.Fatalf("relay request: %v", err)
+		}
+		defer func() { _ = relayResp.Body.Close() }()
+		if relayResp.StatusCode != http.StatusOK {
+			body, _ := io.ReadAll(relayResp.Body)
+			t.Fatalf("expected 200 relay response, got %d: %s", relayResp.StatusCode, body)
+		}
+		relayBody, err := io.ReadAll(relayResp.Body)
+		if err != nil {
+			t.Fatalf("read relay body: %v", err)
+		}
+		relayText := string(relayBody)
+		if !strings.Contains(relayText, "127.0.0.1:43123") || !strings.Contains(relayText, "cli_state") {
+			t.Fatalf("expected relay page to target localhost callback, got %q", relayText)
+		}
+		u, _ := svc.Users.FindOrCreateUser(context.Background(), "cli@test.local")
+		tokens, _ := svc.Tokens.ListTokens(context.Background(), u.ID)
+		if len(tokens) != 0 {
+			t.Fatalf("expected no token to be stored before cli finalization, got %d", len(tokens))
+		}
+
+		finalizeReq, _ := http.NewRequest(http.MethodGet, ts.URL+"/api/v1/auth/callback?code=good-code&state="+url.QueryEscape(startResult["state"])+"&cli=1", nil)
+		finalizeReq.Header.Set("Authorization", "Bearer cli-api-token")
+		finalizeResp, err := http.DefaultClient.Do(finalizeReq)
+		if err != nil {
+			t.Fatalf("finalize request: %v", err)
+		}
+		defer func() { _ = finalizeResp.Body.Close() }()
+		if finalizeResp.StatusCode != http.StatusOK {
+			body, _ := io.ReadAll(finalizeResp.Body)
+			t.Fatalf("expected 200 finalization response, got %d: %s", finalizeResp.StatusCode, body)
+		}
+		var finalizeResult map[string]string
+		if err := json.NewDecoder(finalizeResp.Body).Decode(&finalizeResult); err != nil {
+			t.Fatalf("decode finalization response: %v", err)
+		}
+		if finalizeResult["status"] != "connected" || finalizeResult["integration"] != "slack" {
+			t.Fatalf("unexpected finalization response: %+v", finalizeResult)
+		}
+		tokens, _ = svc.Tokens.ListTokens(context.Background(), u.ID)
+		if len(tokens) != 1 {
+			t.Fatalf("expected token to be stored after cli finalization, got %d", len(tokens))
+		}
+	})
+}
+
+func cookieJarHasCookie(jar http.CookieJar, target *url.URL, name string) bool {
+	if jar == nil || target == nil || name == "" {
+		return false
+	}
+	for _, cookie := range jar.Cookies(target) {
+		if cookie.Name == name {
+			return true
+		}
+	}
+	return false
+}
+
+func oauthStateCookieNameForTest(encodedState string) string {
+	if encodedState == "" {
+		return "oauth_state"
+	}
+	sum := sha256.Sum256([]byte(encodedState))
+	return "oauth_state_" + fmt.Sprintf("%x", sum[:8])
 }
 
 func TestIntegrationOAuthCallback_InvalidState(t *testing.T) {
@@ -9764,11 +10099,16 @@ func TestManagedIdentityIntegrationOAuthCallback(t *testing.T) {
 		doJSONRequestAndDecode(t, http.MethodPost, ts.URL+"/api/v1/identities", "admin-session", `{"displayName":"OAuth Bot"}`, http.StatusCreated, &createResp)
 		doJSONRequestAndDecode(t, http.MethodPut, ts.URL+"/api/v1/identities/"+createResp.ID+"/members", "admin-session", `{"email":"editor@example.test","role":"editor"}`, http.StatusOK, nil)
 
-		startBody := bytes.NewBufferString(`{"integration":"slack"}`)
+		startBody := bytes.NewBufferString(fmt.Sprintf(`{"integration":"slack","returnPath":"/identities/%s"}`, createResp.ID))
 		startReq, _ := http.NewRequest(http.MethodPost, ts.URL+"/api/v1/identities/"+createResp.ID+"/auth/start-oauth", startBody)
 		startReq.Header.Set("Content-Type", "application/json")
 		startReq.Header.Set("Authorization", "Bearer editor-session")
-		startResp, err := http.DefaultClient.Do(startReq)
+		jar, err := cookiejar.New(nil)
+		if err != nil {
+			t.Fatalf("cookie jar: %v", err)
+		}
+		startClient := &http.Client{Jar: jar}
+		startResp, err := startClient.Do(startReq)
 		if err != nil {
 			t.Fatalf("start request: %v", err)
 		}
@@ -9784,6 +10124,7 @@ func TestManagedIdentityIntegrationOAuthCallback(t *testing.T) {
 		}
 
 		noRedirect := &http.Client{
+			Jar: jar,
 			CheckRedirect: func(*http.Request, []*http.Request) error {
 				return http.ErrUseLastResponse
 			},
@@ -9799,7 +10140,7 @@ func TestManagedIdentityIntegrationOAuthCallback(t *testing.T) {
 			body, _ := io.ReadAll(resp.Body)
 			t.Fatalf("expected 303, got %d: %s", resp.StatusCode, body)
 		}
-		expectedLocation := "/identities?connected=slack&id=" + url.QueryEscape(createResp.ID)
+		expectedLocation := "/identities/" + url.PathEscape(createResp.ID) + "?connected=slack"
 		if loc := resp.Header.Get("Location"); loc != expectedLocation {
 			t.Fatalf("expected redirect to %s, got %q", expectedLocation, loc)
 		}
@@ -9893,7 +10234,12 @@ func TestManagedIdentityIntegrationOAuthCallback(t *testing.T) {
 		startReq, _ := http.NewRequest(http.MethodPost, ts.URL+"/api/v1/identities/"+createResp.ID+"/auth/start-oauth", bytes.NewBufferString(`{"integration":"slack"}`))
 		startReq.Header.Set("Content-Type", "application/json")
 		startReq.Header.Set("Authorization", "Bearer editor-session")
-		startResp, err := http.DefaultClient.Do(startReq)
+		jar, err := cookiejar.New(nil)
+		if err != nil {
+			t.Fatalf("cookie jar: %v", err)
+		}
+		startClient := &http.Client{Jar: jar}
+		startResp, err := startClient.Do(startReq)
 		if err != nil {
 			t.Fatalf("start request: %v", err)
 		}
@@ -9909,6 +10255,7 @@ func TestManagedIdentityIntegrationOAuthCallback(t *testing.T) {
 		}
 
 		noRedirect := &http.Client{
+			Jar: jar,
 			CheckRedirect: func(*http.Request, []*http.Request) error {
 				return http.ErrUseLastResponse
 			},
@@ -10059,6 +10406,89 @@ func TestManagedIdentityIntegrationOAuthCallback(t *testing.T) {
 		}
 	})
 
+	t.Run("rejects mismatched identity returnPath", func(t *testing.T) {
+		t.Parallel()
+
+		svc := coretesting.NewStubServices(t)
+		admin := seedUser(t, svc, "admin@example.test")
+		editor := seedUser(t, svc, "editor@example.test")
+
+		stub := &stubIntegrationWithAuthURL{
+			StubIntegration: coretesting.StubIntegration{N: "slack"},
+			authURL:         "https://slack.com/oauth/v2/authorize",
+		}
+		providers := testutil.NewProviderRegistry(t, stub)
+		pluginDefs := map[string]*config.ProviderEntry{
+			"slack": {AuthorizationPolicy: "slack_policy"},
+		}
+		authz := mustAuthorizer(
+			t,
+			config.AuthorizationConfig{
+				Policies: map[string]config.HumanPolicyDef{
+					"slack_policy": {
+						Members: []config.HumanPolicyMemberDef{{
+							Email: editor.Email,
+							Role:  "editor",
+						}},
+					},
+				},
+			},
+			providers,
+			pluginDefs,
+			map[string]string{"slack": testDefaultConnection},
+		)
+
+		ts := newTestServer(t, func(cfg *server.Config) {
+			cfg.Auth = &coretesting.StubAuthProvider{
+				N: "test",
+				ValidateTokenFn: func(_ context.Context, token string) (*core.UserIdentity, error) {
+					switch token {
+					case "admin-session":
+						return &core.UserIdentity{Email: admin.Email}, nil
+					case "editor-session":
+						return &core.UserIdentity{Email: editor.Email}, nil
+					default:
+						return nil, fmt.Errorf("bad token %q", token)
+					}
+				},
+			}
+			cfg.Providers = providers
+			cfg.DefaultConnection = map[string]string{"slack": testDefaultConnection}
+			cfg.Services = svc
+			cfg.Authorizer = authz
+			cfg.PluginDefs = pluginDefs
+		})
+		testutil.CloseOnCleanup(t, ts)
+
+		createResp := struct {
+			ID string `json:"id"`
+		}{}
+		doJSONRequestAndDecode(t, http.MethodPost, ts.URL+"/api/v1/identities", "admin-session", `{"displayName":"OAuth Bot"}`, http.StatusCreated, &createResp)
+		doJSONRequestAndDecode(t, http.MethodPut, ts.URL+"/api/v1/identities/"+createResp.ID+"/members", "admin-session", `{"email":"editor@example.test","role":"editor"}`, http.StatusOK, nil)
+
+		for _, returnPath := range []string{
+			"/identities/other-identity",
+			"/workspace/../identities/other-identity",
+			"/identities//other-identity",
+		} {
+			t.Run(returnPath, func(t *testing.T) {
+				t.Parallel()
+				startReq, _ := http.NewRequest(http.MethodPost, ts.URL+"/api/v1/identities/"+createResp.ID+"/auth/start-oauth", bytes.NewBufferString(fmt.Sprintf(`{"integration":"slack","returnPath":%q}`, returnPath)))
+				startReq.Header.Set("Content-Type", "application/json")
+				startReq.Header.Set("Authorization", "Bearer editor-session")
+				startResp, err := http.DefaultClient.Do(startReq)
+				if err != nil {
+					t.Fatalf("start request: %v", err)
+				}
+				defer func() { _ = startResp.Body.Close() }()
+				if startResp.StatusCode != http.StatusBadRequest {
+					body, _ := io.ReadAll(startResp.Body)
+					t.Fatalf("expected 400 from mismatched identity start-oauth, got %d: %s", startResp.StatusCode, body)
+				}
+			})
+		}
+	})
+
 	t.Run("selection_required", func(t *testing.T) {
 		t.Parallel()
 
@@ -10143,11 +10573,16 @@ func TestManagedIdentityIntegrationOAuthCallback(t *testing.T) {
 		doJSONRequestAndDecode(t, http.MethodPost, ts.URL+"/api/v1/identities", "admin-session", `{"displayName":"OAuth Bot"}`, http.StatusCreated, &createResp)
 		doJSONRequestAndDecode(t, http.MethodPut, ts.URL+"/api/v1/identities/"+createResp.ID+"/members", "admin-session", `{"email":"editor@example.test","role":"editor"}`, http.StatusOK, nil)
 
-		startBody := bytes.NewBufferString(`{"integration":"slack"}`)
+		startBody := bytes.NewBufferString(fmt.Sprintf(`{"integration":"slack","returnPath":"/identities/%s"}`, createResp.ID))
 		startReq, _ := http.NewRequest(http.MethodPost, ts.URL+"/api/v1/identities/"+createResp.ID+"/auth/start-oauth", startBody)
 		startReq.Header.Set("Content-Type", "application/json")
 		startReq.Header.Set("Authorization", "Bearer editor-session")
-		startResp, err := http.DefaultClient.Do(startReq)
+		jar, err := cookiejar.New(nil)
+		if err != nil {
+			t.Fatalf("cookie jar: %v", err)
+		}
+		startClient := &http.Client{Jar: jar}
+		startResp, err := startClient.Do(startReq)
 		if err != nil {
 			t.Fatalf("start request: %v", err)
 		}
@@ -10158,10 +10593,6 @@ func TestManagedIdentityIntegrationOAuthCallback(t *testing.T) {
 			t.Fatalf("decoding start response: %v", err)
 		}
 
-		jar, err := cookiejar.New(nil)
-		if err != nil {
-			t.Fatalf("cookie jar: %v", err)
-		}
 		noRedirect := &http.Client{
 			Jar: jar,
 			CheckRedirect: func(*http.Request, []*http.Request) error {
@@ -10218,6 +10649,13 @@ func TestManagedIdentityIntegrationOAuthCallback(t *testing.T) {
 		if selectResp.StatusCode != http.StatusOK {
 			body, _ := io.ReadAll(selectResp.Body)
 			t.Fatalf("expected 200, got %d: %s", selectResp.StatusCode, body)
+		}
+		successBody, err := io.ReadAll(selectResp.Body)
+		if err != nil {
+			t.Fatalf("read selection success body: %v", err)
+		}
+		if !strings.Contains(string(successBody), fmt.Sprintf(`/identities/%s?connected=slack`, createResp.ID)) {
+			t.Fatalf("expected success page link to identity detail, got %q", string(successBody))
 		}
 		tokens, err := svc.Tokens.ListTokensByOwner(context.Background(), core.IntegrationTokenOwnerKindManagedIdentity, createResp.ID)
 		if err != nil {
@@ -11073,7 +11511,12 @@ func TestIntegrationOAuthCallback_PKCEUsesVerifier(t *testing.T) {
 	startBody := bytes.NewBufferString(`{"integration":"gitlab"}`)
 	startReq, _ := http.NewRequest(http.MethodPost, ts.URL+"/api/v1/auth/start-oauth", startBody)
 	startReq.Header.Set("Content-Type", "application/json")
-	startResp, err := http.DefaultClient.Do(startReq)
+	jar, err := cookiejar.New(nil)
+	if err != nil {
+		t.Fatalf("cookie jar: %v", err)
+	}
+	startClient := &http.Client{Jar: jar}
+	startResp, err := startClient.Do(startReq)
 	if err != nil {
 		t.Fatalf("start request: %v", err)
 	}
@@ -11089,6 +11532,7 @@ func TestIntegrationOAuthCallback_PKCEUsesVerifier(t *testing.T) {
 	}
 
 	noRedirect := &http.Client{
+		Jar: jar,
 		CheckRedirect: func(*http.Request, []*http.Request) error {
 			return http.ErrUseLastResponse
 		},
@@ -12117,7 +12561,7 @@ func TestConnectManual(t *testing.T) {
 			},
 		}
 
-		connectBody := bytes.NewBufferString(`{"integration":"manual-svc","credential":"my-api-key"}`)
+		connectBody := bytes.NewBufferString(`{"integration":"manual-svc","credential":"my-api-key","returnPath":"/workspace/manual?tab=select"}`)
 		connectReq, _ := http.NewRequest(http.MethodPost, ts.URL+"/api/v1/auth/connect-manual", connectBody)
 		connectReq.Header.Set("Content-Type", "application/json")
 		connectReq.Header.Set("Authorization", "Bearer same-user-token")
@@ -12283,8 +12727,8 @@ func TestConnectManual(t *testing.T) {
 		if selectResp.StatusCode != http.StatusSeeOther {
 			t.Fatalf("expected 303, got %d", selectResp.StatusCode)
 		}
-		if loc := selectResp.Header.Get("Location"); loc != "/integrations?connected=manual-svc" {
-			t.Fatalf("expected redirect to /integrations?connected=manual-svc, got %q", loc)
+		if loc := selectResp.Header.Get("Location"); loc != "/workspace/manual?connected=manual-svc&tab=select" {
+			t.Fatalf("expected redirect to /workspace/manual?connected=manual-svc&tab=select, got %q", loc)
 		}
 		u, _ := svc.Users.FindOrCreateUser(context.Background(), "same@test.local")
 		tokens, _ := svc.Tokens.ListTokens(context.Background(), u.ID)
@@ -12911,7 +13355,12 @@ func TestOAuthCallback_UsesStateConnection(t *testing.T) {
 	startReq, _ := http.NewRequest(http.MethodPost, ts.URL+"/api/v1/auth/start-oauth", startBody)
 	startReq.Header.Set("X-Dev-User-Email", "dev@example.com")
 	startReq.Header.Set("Content-Type", "application/json")
-	startResp, err := http.DefaultClient.Do(startReq)
+	jar, err := cookiejar.New(nil)
+	if err != nil {
+		t.Fatalf("cookie jar: %v", err)
+	}
+	startClient := &http.Client{Jar: jar}
+	startResp, err := startClient.Do(startReq)
 	if err != nil {
 		t.Fatalf("start request: %v", err)
 	}
@@ -12925,6 +13374,7 @@ func TestOAuthCallback_UsesStateConnection(t *testing.T) {
 	}
 
 	noRedirect := &http.Client{
+		Jar: jar,
 		CheckRedirect: func(*http.Request, []*http.Request) error {
 			return http.ErrUseLastResponse
 		},
@@ -16855,6 +17305,19 @@ func TestManagedIdentityManualConnections(t *testing.T) {
 		t.Fatalf("viewer connect status = %d, want %d: %s", connectDeniedResp.StatusCode, http.StatusForbidden, body)
 	}
 
+	req, _ = http.NewRequest(http.MethodPost, ts.URL+"/api/v1/identities/"+createResp.ID+"/auth/connect-manual", bytes.NewBufferString(`{"integration":"manual-svc","credential":"editor-token","returnPath":"/identities/other-identity"}`))
+	req.Header.Set("Content-Type", "application/json")
+	req.AddCookie(&http.Cookie{Name: "session_token", Value: "editor-session"})
+	invalidReturnPathResp, err := http.DefaultClient.Do(req)
+	if err != nil {
+		t.Fatalf("invalid returnPath connect request: %v", err)
+	}
+	defer func() { _ = invalidReturnPathResp.Body.Close() }()
+	if invalidReturnPathResp.StatusCode != http.StatusBadRequest {
+		body, _ := io.ReadAll(invalidReturnPathResp.Body)
+		t.Fatalf("invalid returnPath connect status = %d, want %d: %s", invalidReturnPathResp.StatusCode, http.StatusBadRequest, body)
+	}
+
 	connectResp := struct {
 		Status      string `json:"status"`
 		Integration string `json:"integration"`
@@ -17251,7 +17714,7 @@ func TestManagedIdentityManualConnectionSelectionRequired(t *testing.T) {
 		},
 	}
 
-	connectReq, _ := http.NewRequest(http.MethodPost, ts.URL+"/api/v1/identities/"+createResp.ID+"/auth/connect-manual", bytes.NewBufferString(`{"integration":"manual-svc","credential":"identity-token"}`))
+	connectReq, _ := http.NewRequest(http.MethodPost, ts.URL+"/api/v1/identities/"+createResp.ID+"/auth/connect-manual", bytes.NewBufferString(fmt.Sprintf(`{"integration":"manual-svc","credential":"identity-token","returnPath":"/identities/%s"}`, createResp.ID)))
 	connectReq.Header.Set("Content-Type", "application/json")
 	connectReq.AddCookie(&http.Cookie{Name: "session_token", Value: "editor-session"})
 	connectResp, err := noRedirect.Do(connectReq)
@@ -17328,8 +17791,8 @@ func TestManagedIdentityManualConnectionSelectionRequired(t *testing.T) {
 		body, _ := io.ReadAll(selectResp.Body)
 		t.Fatalf("selection status = %d, want %d: %s", selectResp.StatusCode, http.StatusSeeOther, body)
 	}
-	if location := selectResp.Header.Get("Location"); location != fmt.Sprintf("/identities?connected=manual-svc&id=%s", createResp.ID) {
-		t.Fatalf("selection redirect = %q, want identity redirect", location)
+	if location := selectResp.Header.Get("Location"); location != fmt.Sprintf("/identities/%s?connected=manual-svc", createResp.ID) {
+		t.Fatalf("selection redirect = %q, want identity detail redirect", location)
 	}
 
 	tokens, err := svc.Tokens.ListTokensByOwner(context.Background(), core.IntegrationTokenOwnerKindManagedIdentity, createResp.ID)


### PR DESCRIPTION
## Summary
This PR adds the small backend cleanup needed before the default web client can manage managed-identity connections cleanly.

It is intentionally stand-alone:
- OAuth and manual connection starts can now carry an optional in-app `returnPath`
- the encrypted OAuth callback state and pending-selection state both preserve that path
- final success redirects use the caller-provided path with `connected=<plugin>` appended
- existing callers that do not provide `returnPath` keep the current `/integrations` fallback

## Go Interfaces
New optional request field on both user and managed-identity OAuth start routes:

```go
type startOAuthRequest struct {
    Integration string
    Connection  string
    Instance    string
    Scopes      []string
    ReturnPath  string
    ConnectionParams map[string]string
}
```

New optional request field on both user and managed-identity manual connect routes:

```go
type connectManualRequest struct {
    Integration string
    Connection  string
    Instance    string
    ReturnPath  string
    Credential  string
    Credentials map[string]string
    ConnectionParams map[string]string
}
```

Encrypted callback and pending-selection state now preserve the safe app return path:

```go
type integrationOAuthState struct {
    OwnerKind      string
    OwnerID        string
    InitiatorUserID string
    Integration    string
    Connection     string
    Instance       string
    ReturnPath     string
    // ...
}

type pendingConnectionState struct {
    Token      tokenMaterial
    BindingKey string
    Candidates []core.DiscoveryCandidate
    ReturnPath string
    ExpiresAt  int64
}
```

Behavioral interface change:
- OAuth callback success now redirects to `returnPath` with `connected=<plugin>` when present
- pending-selection success now links back to `returnPath` with `connected=<plugin>` when present
- invalid non-relative `returnPath` values are rejected with `400`

## YAML Interfaces
This slice does not introduce any new YAML.

Existing provider auth and connection definitions continue to work unchanged. Example:

```yaml
providers:
  slack:
    command: ["./plugins/slack"]
    env:
      SLACK_CLIENT_ID: slack-client-id
      SLACK_CLIENT_SECRET: slack-client-secret
```

## Examples
User OAuth start with a custom return target:

```http
POST /api/v1/auth/start-oauth
Content-Type: application/json

{
  "integration": "slack",
  "returnPath": "/workspace/connections?tab=oauth"
}
```

Managed-identity OAuth start with a detail-page return target:

```http
POST /api/v1/identities/id_123/auth/start-oauth
Content-Type: application/json

{
  "integration": "slack",
  "returnPath": "/identities/id_123"
}
```

Managed-identity manual connect with a detail-page return target:

```http
POST /api/v1/identities/id_123/auth/connect-manual
Content-Type: application/json

{
  "integration": "slack",
  "credential": "token",
  "returnPath": "/identities/id_123"
}
```

## Testing
- `go test ./internal/server -run 'TestIntegrationOAuthCallback|TestManagedIdentityIntegrationOAuthCallback|TestManagedIdentityManualConnections' -count=1`
- `go test ./...`
