### PR TITLE
docs: fix SDK reference links and add Go/Rust SDK pages

### DIFF
--- a/docs/content/reference/_meta.ts
+++ b/docs/content/reference/_meta.ts
@@ -1,6 +1,8 @@
 export default {
   "config-file": "Config File",
+  "go-sdk": "Go SDK API",
   "python-sdk": "Python SDK API",
+  "rust-sdk": "Rust SDK API",
   "typescript-sdk": "TypeScript SDK",
   "plugin-manifests": "Provider Manifests",
   "http-api": "HTTP API",

--- a/docs/content/reference/go-sdk.mdx
+++ b/docs/content/reference/go-sdk.mdx
@@ -1,0 +1,46 @@
+---
+title: Go SDK API
+---
+
+# Go SDK API
+
+The Go SDK is published as the module
+`github.com/valon-technologies/gestalt/sdk/go`.
+
+Its canonical API reference is hosted on `pkg.go.dev`:
+
+- [Open the Go SDK reference on pkg.go.dev](https://pkg.go.dev/github.com/valon-technologies/gestalt/sdk/go)
+
+```go
+package example
+
+import (
+	"context"
+	"net/http"
+
+	gestalt "github.com/valon-technologies/gestalt/sdk/go"
+)
+
+type EchoProvider struct{}
+
+func (p *EchoProvider) Configure(ctx context.Context, name string, config map[string]any) error {
+	return nil
+}
+
+func New() *EchoProvider { return &EchoProvider{} }
+
+var Router = gestalt.MustRouter(
+	gestalt.Register(
+		gestalt.Operation[struct{ Message string }, struct{ Echoed string }]{
+			ID:     "echo",
+			Method: http.MethodPost,
+		},
+		func(_ *EchoProvider, _ context.Context, input struct{ Message string }, _ gestalt.Request) (gestalt.Response[struct{ Echoed string }], error) {
+			return gestalt.OK(struct{ Echoed string }{Echoed: input.Message}), nil
+		},
+	),
+)
+```
+
+`pkg.go.dev` renders the source comments directly, so package and symbol docs
+there are the primary Go reference surface.

--- a/docs/content/reference/index.mdx
+++ b/docs/content/reference/index.mdx
@@ -7,11 +7,17 @@ import { Cards } from 'nextra/components'
 # Reference
 
 <Cards>
+  <Cards.Card title="Go SDK API" href="/reference/go-sdk">
+    Source-native docs on pkg.go.dev for the Go provider SDK.
+  </Cards.Card>
   <Cards.Card title="Python SDK API" href="/reference/python-sdk">
     Authored Python interfaces plus generated reference pages.
   </Cards.Card>
   <Cards.Card title="Config File" href="/reference/config-file">
     Every YAML field, validation rules, and load semantics.
+  </Cards.Card>
+  <Cards.Card title="Rust SDK API" href="/reference/rust-sdk">
+    Crate docs on docs.rs for the Rust provider SDK.
   </Cards.Card>
   <Cards.Card title="TypeScript SDK" href="/reference/typescript-sdk">
     TypeDoc reference for the authored Bun and TypeScript SDK surface.

--- a/docs/content/reference/python-sdk.mdx
+++ b/docs/content/reference/python-sdk.mdx
@@ -26,7 +26,7 @@ def search(params: SearchInput):
 
 The generated API reference is published separately as static HTML:
 
-- [Python SDK Reference](/api/python/)
+- [Python SDK Reference](/api/python/index.html)
 
 Those pages focus on the handwritten SDK surface. Generated protobuf bindings
 under `gestalt.gen` remain available to provider code, but they are not

--- a/docs/content/reference/rust-sdk.mdx
+++ b/docs/content/reference/rust-sdk.mdx
@@ -1,0 +1,50 @@
+---
+title: Rust SDK API
+---
+
+# Rust SDK API
+
+The Rust SDK is published to crates.io as `gestalt-sdk`, while Rust code
+imports it as `gestalt`.
+
+Its canonical API reference is hosted on `docs.rs`:
+
+- [Open the Rust SDK reference on docs.rs](https://docs.rs/gestalt-sdk/latest/gestalt/)
+
+```rust
+use schemars::JsonSchema;
+use serde::{Deserialize, Serialize};
+use std::sync::Arc;
+
+#[derive(Default)]
+struct EchoProvider;
+
+#[gestalt::async_trait]
+impl gestalt::Provider for EchoProvider {}
+
+#[derive(Deserialize, JsonSchema)]
+struct EchoInput {
+    message: String,
+}
+
+#[derive(Serialize, JsonSchema)]
+struct EchoOutput {
+    echoed: String,
+}
+
+fn router() -> gestalt::Result<gestalt::Router<EchoProvider>> {
+    gestalt::Router::new().register(
+        gestalt::Operation::<EchoInput, EchoOutput>::new("echo"),
+        |_: Arc<EchoProvider>, input, _request| async move {
+            Ok::<_, gestalt::Error>(gestalt::ok(EchoOutput {
+                echoed: input.message,
+            }))
+        },
+    )
+}
+
+gestalt::export_provider!(constructor = EchoProvider::default, router = router);
+```
+
+`docs.rs` renders the crate docs, module docs, and symbol docs from the source
+and checked-in generated bindings.


### PR DESCRIPTION
## Summary
- fix the broken Python SDK reference link by pointing it at `/api/python/index.html`
- add `/reference/go-sdk` with a direct `pkg.go.dev` link and example provider code
- add `/reference/rust-sdk` with a direct `docs.rs` link and example provider code
- surface Go and Rust in the docs reference index and sidebar

## New interfaces
- `/reference/go-sdk`
- `/reference/rust-sdk`
- `/reference/python-sdk` now links to `/api/python/index.html`

## Examples
### Go
```go
var Router = gestalt.MustRouter(
	gestalt.Register(
		gestalt.Operation[struct{ Message string }, struct{ Echoed string }]{
			ID:     "echo",
			Method: http.MethodPost,
		},
		func(_ *EchoProvider, _ context.Context, input struct{ Message string }, _ gestalt.Request) (gestalt.Response[struct{ Echoed string }], error) {
			return gestalt.OK(struct{ Echoed string }{Echoed: input.Message}), nil
		},
	),
)
```

### Rust
```rust
fn router() -> gestalt::Result<gestalt::Router<EchoProvider>> {
    gestalt::Router::new().register(
        gestalt::Operation::<EchoInput, EchoOutput>::new("echo"),
        |_: Arc<EchoProvider>, input, _request| async move {
            Ok::<_, gestalt::Error>(gestalt::ok(EchoOutput {
                echoed: input.message,
            }))
        },
    )
}

gestalt::export_provider!(constructor = EchoProvider::default, router = router);
```

### Python
```md
[Python SDK Reference](/api/python/index.html)
```

## Validation
- `npm run build` in `docs`
