### PR TITLE
docs: fix canonical Go and Rust SDK references

### DIFF
--- a/sdk/go/doc.go
+++ b/sdk/go/doc.go
@@ -40,9 +40,10 @@
 //		gestalt.Register(myOperation, (*MyProvider).myHandler),
 //	)
 //
-// Source-provider flows derive the executable catalog name from manifest.yaml. Use
-// [MustNamedRouter] only when you need an explicit catalog name outside that
-// manifest-backed flow.
+// Source-provider flows derive the executable catalog name from manifest.yaml.
+// Use [Router.WithName] only when you need an explicit catalog name outside
+// that manifest-backed flow.
 //
-// See `/docs/content/providers/plugins.mdx` for the full typed authoring flow.
+// See https://gestaltd.ai/custom-providers/plugins for the full typed
+// authoring flow.
 package gestalt

--- a/sdk/rust/README.md
+++ b/sdk/rust/README.md
@@ -70,11 +70,15 @@ Current scope:
 
 ## Codegen strategy
 
-Bindings are checked into [`src/generated`](src/generated) so crate consumers do
-not need a protobuf toolchain when building `gestalt-sdk`.
+Bindings are checked into
+[`src/generated`](https://github.com/valon-technologies/gestalt/tree/main/sdk/rust/src/generated)
+so crate consumers do not need a protobuf toolchain when building
+`gestalt-sdk`.
 
 Maintainers regenerate them from the shared proto definitions in
-[`sdk/proto`](../proto) with a helper binary under `tools/rust-sdk-codegen/`,
+[`sdk/proto`](https://github.com/valon-technologies/gestalt/tree/main/sdk/proto)
+with a helper binary under
+[`tools/rust-sdk-codegen`](https://github.com/valon-technologies/gestalt/tree/main/tools/rust-sdk-codegen),
 which uses a vendored `protoc`.
 
 To regenerate the bindings:


### PR DESCRIPTION
## Summary
- fix the `pkg.go.dev` landing docs so they no longer reference the nonexistent `MustNamedRouter` symbol
- replace the repo-relative provider-authoring pointer in `sdk/go/doc.go` with the public docs URL
- replace the `docs.rs`-broken relative README links in `sdk/rust/README.md` with absolute GitHub URLs

## New interfaces
- `sdk/go/doc.go` now directs readers to `Router.WithName`
- `sdk/go/doc.go` now links to `https://gestaltd.ai/custom-providers/plugins`
- `sdk/rust/README.md` now links to:
  - `sdk/rust/src/generated`
  - `sdk/proto`
  - `tools/rust-sdk-codegen`

## Examples
### Go
```go
// Source-provider flows derive the executable catalog name from manifest.yaml.
// Use [Router.WithName] only when you need an explicit catalog name outside
// that manifest-backed flow.
```

### Rust
```md
[`src/generated`](https://github.com/valon-technologies/gestalt/tree/main/sdk/rust/src/generated)
[`sdk/proto`](https://github.com/valon-technologies/gestalt/tree/main/sdk/proto)
[`tools/rust-sdk-codegen`](https://github.com/valon-technologies/gestalt/tree/main/tools/rust-sdk-codegen)
```

## Validation
- `cargo doc --no-deps` in `sdk/rust`
- verified the broken `MustNamedRouter` and repo-relative README links are gone from source
