### PR TITLE
release: point Rust SDK release docs at docs.rs

### DIFF
--- a/.github/workflows/release-sdk.yml
+++ b/.github/workflows/release-sdk.yml
@@ -189,7 +189,8 @@ jobs:
       install-markdown: |
         - Crate: `cargo add gestalt-sdk`
         - In code, continue importing the library as `gestalt`
-        - Package docs: [crates.io/crates/gestalt-sdk](https://crates.io/crates/gestalt-sdk)
+        - API docs: [docs.rs/gestalt-sdk/latest/gestalt](https://docs.rs/gestalt-sdk/latest/gestalt/)
+        - Package page: [crates.io/crates/gestalt-sdk](https://crates.io/crates/gestalt-sdk)
 
   publish-python-sdk:
     if: ${{ startsWith(github.ref_name, 'sdk/python/v') }}


### PR DESCRIPTION
## Summary
- fix the Rust SDK GitHub release notes so the canonical API docs link points to `docs.rs`
- keep the crates.io package page as a separate link for install and registry metadata

## New interfaces
- Rust SDK release notes now render:
  - `API docs: docs.rs/gestalt-sdk/latest/gestalt`
  - `Package page: crates.io/crates/gestalt-sdk`

## Examples
```md
- API docs: [docs.rs/gestalt-sdk/latest/gestalt](https://docs.rs/gestalt-sdk/latest/gestalt/)
- Package page: [crates.io/crates/gestalt-sdk](https://crates.io/crates/gestalt-sdk)
```

## Validation
- verified the updated links are present in `.github/workflows/release-sdk.yml`
- `git diff --check`
