### PR TITLE
sdk: enforce startup protocol-version parity

### DIFF
--- a/sdk/go/auth_transport_test.go
+++ b/sdk/go/auth_transport_test.go
@@ -118,6 +118,12 @@ func TestAuthProviderRoundTrip(t *testing.T) {
 	if meta.GetVersion() != "1.0" {
 		t.Fatalf("version = %q, want %q", meta.GetVersion(), "1.0")
 	}
+	if meta.GetMinProtocolVersion() != proto.CurrentProtocolVersion {
+		t.Fatalf("min_protocol_version = %d, want %d", meta.GetMinProtocolVersion(), proto.CurrentProtocolVersion)
+	}
+	if meta.GetMaxProtocolVersion() != proto.CurrentProtocolVersion {
+		t.Fatalf("max_protocol_version = %d, want %d", meta.GetMaxProtocolVersion(), proto.CurrentProtocolVersion)
+	}
 	found := false
 	for _, w := range meta.GetWarnings() {
 		if w == "battery low" {
@@ -130,13 +136,16 @@ func TestAuthProviderRoundTrip(t *testing.T) {
 	}
 
 	cfg, _ := structpb.NewStruct(map[string]any{"clientId": "abc"})
-	_, err = runtimeClient.ConfigureProvider(rpcCtx, &proto.ConfigureProviderRequest{
+	configuredResp, err := runtimeClient.ConfigureProvider(rpcCtx, &proto.ConfigureProviderRequest{
 		Name:            "my-auth",
 		Config:          cfg,
 		ProtocolVersion: proto.CurrentProtocolVersion,
 	})
 	if err != nil {
 		t.Fatalf("ConfigureProvider: %v", err)
+	}
+	if configuredResp.GetProtocolVersion() != proto.CurrentProtocolVersion {
+		t.Fatalf("configured protocol_version = %d, want %d", configuredResp.GetProtocolVersion(), proto.CurrentProtocolVersion)
 	}
 	if len(provider.configured) != 1 {
 		t.Fatalf("configured calls = %d, want 1", len(provider.configured))
@@ -146,6 +155,21 @@ func TestAuthProviderRoundTrip(t *testing.T) {
 	}
 	if provider.configured[0].config["clientId"] != "abc" {
 		t.Fatalf("configured config[clientId] = %v, want %q", provider.configured[0].config["clientId"], "abc")
+	}
+
+	_, err = runtimeClient.ConfigureProvider(rpcCtx, &proto.ConfigureProviderRequest{
+		Name:            "my-auth",
+		Config:          cfg,
+		ProtocolVersion: proto.CurrentProtocolVersion + 1,
+	})
+	if err == nil {
+		t.Fatal("ConfigureProvider should fail for mismatched protocol version")
+	}
+	if s, ok := status.FromError(err); !ok || s.Code() != codes.FailedPrecondition {
+		t.Fatalf("ConfigureProvider code = %v, want FAILED_PRECONDITION", err)
+	}
+	if len(provider.configured) != 1 {
+		t.Fatalf("configured calls = %d after mismatch, want 1", len(provider.configured))
 	}
 
 	health, err := runtimeClient.HealthCheck(rpcCtx, &emptypb.Empty{})
@@ -175,7 +199,7 @@ func TestAuthProviderRoundTrip(t *testing.T) {
 	completeResp, err := authClient.CompleteLogin(rpcCtx, &proto.CompleteLoginRequest{
 		Query:         map[string]string{"code": "auth-code"},
 		ProviderState: []byte("state-data"),
-		CallbackUrl: "https://app.example.test/callback",
+		CallbackUrl:   "https://app.example.test/callback",
 	})
 	if err != nil {
 		t.Fatalf("CompleteLogin: %v", err)

--- a/sdk/go/protocol_version.go
+++ b/sdk/go/protocol_version.go
@@ -1,0 +1,19 @@
+package gestalt
+
+import (
+	proto "github.com/valon-technologies/gestalt/sdk/go/gen/v1"
+	"google.golang.org/grpc/codes"
+	"google.golang.org/grpc/status"
+)
+
+func validateProtocolVersion(version int32) error {
+	if version == proto.CurrentProtocolVersion {
+		return nil
+	}
+	return status.Errorf(
+		codes.FailedPrecondition,
+		"host requested protocol version %d, provider requires %d",
+		version,
+		proto.CurrentProtocolVersion,
+	)
+}

--- a/sdk/go/provider_server.go
+++ b/sdk/go/provider_server.go
@@ -46,6 +46,9 @@ func (s *ProviderServer) StartProvider(ctx context.Context, req *proto.StartProv
 	if req == nil {
 		return nil, status.Error(codes.InvalidArgument, "request is required")
 	}
+	if err := validateProtocolVersion(req.GetProtocolVersion()); err != nil {
+		return nil, err
+	}
 	config := req.GetConfig().AsMap()
 	if config == nil {
 		config = map[string]any{}
@@ -62,6 +65,8 @@ func (s *ProviderServer) GetMetadata(_ context.Context, _ *emptypb.Empty) (*prot
 	_, ok := s.sessionCat()
 	return &proto.ProviderMetadata{
 		SupportsSessionCatalog: ok,
+		MinProtocolVersion:     proto.CurrentProtocolVersion,
+		MaxProtocolVersion:     proto.CurrentProtocolVersion,
 	}, nil
 }
 

--- a/sdk/go/runtime_server.go
+++ b/sdk/go/runtime_server.go
@@ -49,13 +49,8 @@ func (s *runtimeServer) ConfigureProvider(ctx context.Context, req *proto.Config
 	if req == nil {
 		return nil, status.Error(codes.InvalidArgument, "request is required")
 	}
-	if req.GetProtocolVersion() != proto.CurrentProtocolVersion {
-		return nil, status.Errorf(
-			codes.FailedPrecondition,
-			"host requested protocol version %d, provider requires %d",
-			req.GetProtocolVersion(),
-			proto.CurrentProtocolVersion,
-		)
+	if err := validateProtocolVersion(req.GetProtocolVersion()); err != nil {
+		return nil, err
 	}
 	config := req.GetConfig().AsMap()
 	if config == nil {

--- a/sdk/go/serve_test.go
+++ b/sdk/go/serve_test.go
@@ -9,6 +9,8 @@ import (
 
 	gestalt "github.com/valon-technologies/gestalt/sdk/go"
 	proto "github.com/valon-technologies/gestalt/sdk/go/gen/v1"
+	"google.golang.org/grpc/codes"
+	"google.golang.org/grpc/status"
 	protoutil "google.golang.org/protobuf/proto"
 	"google.golang.org/protobuf/types/known/emptypb"
 	"google.golang.org/protobuf/types/known/structpb"
@@ -134,6 +136,12 @@ func TestProviderServerGetMetadata(t *testing.T) {
 		if meta.GetSupportsSessionCatalog() {
 			t.Fatal("SupportsSessionCatalog = true, want false")
 		}
+		if meta.GetMinProtocolVersion() != proto.CurrentProtocolVersion {
+			t.Fatalf("MinProtocolVersion = %d, want %d", meta.GetMinProtocolVersion(), proto.CurrentProtocolVersion)
+		}
+		if meta.GetMaxProtocolVersion() != proto.CurrentProtocolVersion {
+			t.Fatalf("MaxProtocolVersion = %d, want %d", meta.GetMaxProtocolVersion(), proto.CurrentProtocolVersion)
+		}
 	})
 
 	t.Run("session catalog provider", func(t *testing.T) {
@@ -151,6 +159,12 @@ func TestProviderServerGetMetadata(t *testing.T) {
 		}
 		if !meta.GetSupportsSessionCatalog() {
 			t.Fatal("SupportsSessionCatalog = false, want true")
+		}
+		if meta.GetMinProtocolVersion() != proto.CurrentProtocolVersion {
+			t.Fatalf("MinProtocolVersion = %d, want %d", meta.GetMinProtocolVersion(), proto.CurrentProtocolVersion)
+		}
+		if meta.GetMaxProtocolVersion() != proto.CurrentProtocolVersion {
+			t.Fatalf("MaxProtocolVersion = %d, want %d", meta.GetMaxProtocolVersion(), proto.CurrentProtocolVersion)
 		}
 	})
 }
@@ -336,26 +350,52 @@ func TestProviderServerExecute(t *testing.T) {
 func TestProviderServerStartProvider(t *testing.T) {
 	t.Parallel()
 
-	prov := &startableStubProvider{}
-	client := newIntegrationProviderClient(t, prov, startableStubRouter)
-	ctx := context.Background()
+	t.Run("accepts matching protocol version", func(t *testing.T) {
+		prov := &startableStubProvider{}
+		client := newIntegrationProviderClient(t, prov, startableStubRouter)
+		ctx := context.Background()
 
-	cfg, _ := structpb.NewStruct(map[string]any{"key": "val"})
-	resp, err := client.StartProvider(ctx, &proto.StartProviderRequest{
-		Name:            "my-instance",
-		Config:          cfg,
-		ProtocolVersion: proto.CurrentProtocolVersion,
+		cfg, _ := structpb.NewStruct(map[string]any{"key": "val"})
+		resp, err := client.StartProvider(ctx, &proto.StartProviderRequest{
+			Name:            "my-instance",
+			Config:          cfg,
+			ProtocolVersion: proto.CurrentProtocolVersion,
+		})
+		if err != nil {
+			t.Fatalf("StartProvider: %v", err)
+		}
+		if resp.GetProtocolVersion() != proto.CurrentProtocolVersion {
+			t.Errorf("ProtocolVersion = %d, want %d", resp.GetProtocolVersion(), proto.CurrentProtocolVersion)
+		}
+		if prov.name != "my-instance" {
+			t.Errorf("name = %q, want %q", prov.name, "my-instance")
+		}
+		if prov.config["key"] != "val" {
+			t.Errorf("config[key] = %v, want %q", prov.config["key"], "val")
+		}
 	})
-	if err != nil {
-		t.Fatalf("StartProvider: %v", err)
-	}
-	if resp.GetProtocolVersion() != proto.CurrentProtocolVersion {
-		t.Errorf("ProtocolVersion = %d, want %d", resp.GetProtocolVersion(), proto.CurrentProtocolVersion)
-	}
-	if prov.name != "my-instance" {
-		t.Errorf("name = %q, want %q", prov.name, "my-instance")
-	}
-	if prov.config["key"] != "val" {
-		t.Errorf("config[key] = %v, want %q", prov.config["key"], "val")
-	}
+
+	t.Run("rejects mismatched protocol version", func(t *testing.T) {
+		prov := &startableStubProvider{}
+		client := newIntegrationProviderClient(t, prov, startableStubRouter)
+		ctx := context.Background()
+
+		_, err := client.StartProvider(ctx, &proto.StartProviderRequest{
+			Name:            "my-instance",
+			Config:          &structpb.Struct{},
+			ProtocolVersion: proto.CurrentProtocolVersion + 1,
+		})
+		if err == nil {
+			t.Fatal("StartProvider should fail for mismatched protocol version")
+		}
+		if code := status.Code(err); code != codes.FailedPrecondition {
+			t.Fatalf("StartProvider code = %v, want %v", code, codes.FailedPrecondition)
+		}
+		if prov.name != "" {
+			t.Fatalf("provider configured name = %q, want empty", prov.name)
+		}
+		if prov.config != nil {
+			t.Fatalf("provider config = %#v, want nil", prov.config)
+		}
+	})
 }

--- a/sdk/python/gestalt/_runtime.py
+++ b/sdk/python/gestalt/_runtime.py
@@ -100,6 +100,19 @@ def _grpc_handler(label: str):
     return decorator
 
 
+def _abort_if_protocol_version_mismatch(
+    protocol_version: int,
+    context: Any,
+) -> bool:
+    if protocol_version == CURRENT_PROTOCOL_VERSION:
+        return False
+    context.abort(
+        grpc.StatusCode.FAILED_PRECONDITION,
+        f"host requested protocol version {protocol_version}, provider requires {CURRENT_PROTOCOL_VERSION}",
+    )
+    return True
+
+
 def serve(
     target: Plugin | PluginProviderAdapter | PluginProvider,
     *,
@@ -371,7 +384,10 @@ def _provider_servicer(*, plugin: Plugin) -> Any:
                 max_protocol_version=CURRENT_PROTOCOL_VERSION,
             )
 
-        def StartProvider(self, request: Any, _context: Any) -> Any:
+        @_grpc_handler("configure provider")
+        def StartProvider(self, request: Any, context: Any) -> Any:
+            if _abort_if_protocol_version_mismatch(request.protocol_version, context):
+                return None
             plugin.configure_provider(
                 request.name,
                 _message_to_dict(
@@ -455,11 +471,8 @@ def _runtime_servicer(*, provider: PluginProvider, kind: ProviderKind) -> Any:
 
         @_grpc_handler("configure provider")
         def ConfigureProvider(self, request: Any, context: Any) -> Any:
-            if request.protocol_version != CURRENT_PROTOCOL_VERSION:
-                return context.abort(
-                    grpc.StatusCode.FAILED_PRECONDITION,
-                    f"host requested protocol version {request.protocol_version}, provider requires {CURRENT_PROTOCOL_VERSION}",
-                )
+            if _abort_if_protocol_version_mismatch(request.protocol_version, context):
+                return None
             config = _message_to_dict(
                 field_name="config",
                 message=request.config,

--- a/sdk/python/tests/test_runtime.py
+++ b/sdk/python/tests/test_runtime.py
@@ -8,6 +8,7 @@ from unittest import mock
 
 import grpc
 from google.protobuf import duration_pb2 as _duration_pb2
+from google.protobuf import json_format
 from google.protobuf import timestamp_pb2 as _timestamp_pb2
 
 from gestalt import (
@@ -51,6 +52,24 @@ def _ts(epoch_seconds: int) -> Any:
     ts = timestamp_pb2.Timestamp()
     ts.FromDatetime(dt.datetime.fromtimestamp(epoch_seconds, tz=UTC))
     return ts
+
+
+class AbortCalled(RuntimeError):
+    pass
+
+
+class AbortContext:
+    def __init__(self) -> None:
+        self._code: grpc.StatusCode | None = None
+        self.details: str | None = None
+
+    def abort(self, code: grpc.StatusCode, details: str) -> None:
+        self._code = code
+        self.details = details
+        raise AbortCalled(details)
+
+    def code(self) -> grpc.StatusCode | None:
+        return self._code
 
 
 class ParseRuntimeArgsTests(unittest.TestCase):
@@ -225,6 +244,11 @@ class MainEntrypointTests(unittest.TestCase):
 
     def test_provider_servicer_reports_and_serves_session_catalogs(self) -> None:
         plugin = Plugin("source-name")
+        configured: list[tuple[str, dict[str, Any]]] = []
+
+        @plugin.configure
+        def configure(name: str, config: dict[str, Any]) -> None:
+            configured.append((name, dict(config)))
 
         @plugin.operation
         def whoami(request: Request) -> dict[str, str]:
@@ -257,6 +281,31 @@ class MainEntrypointTests(unittest.TestCase):
 
         servicer = _runtime._provider_servicer(plugin=plugin)
         metadata = servicer.GetMetadata(mock.Mock(), mock.Mock())
+        bad_context = AbortContext()
+        with self.assertRaisesRegex(
+            AbortCalled,
+            "host requested protocol version",
+        ):
+            servicer.StartProvider(
+                plugin_pb2.StartProviderRequest(
+                    name="source-instance",
+                    protocol_version=_runtime.CURRENT_PROTOCOL_VERSION + 1,
+                ),
+                bad_context,
+            )
+        self.assertEqual(bad_context.code(), grpc.StatusCode.FAILED_PRECONDITION)
+        self.assertEqual(
+            bad_context.details,
+            f"host requested protocol version {_runtime.CURRENT_PROTOCOL_VERSION + 1}, provider requires {_runtime.CURRENT_PROTOCOL_VERSION}",
+        )
+        self.assertEqual(configured, [])
+
+        start_request = plugin_pb2.StartProviderRequest(
+            name="source-instance",
+            protocol_version=_runtime.CURRENT_PROTOCOL_VERSION,
+        )
+        json_format.ParseDict({"region": "use1"}, start_request.config)
+        start_response = servicer.StartProvider(start_request, mock.Mock())
         execute_response = servicer.Execute(
             plugin_pb2.ExecuteRequest(
                 operation="whoami",
@@ -296,6 +345,22 @@ class MainEntrypointTests(unittest.TestCase):
         )
 
         self.assertTrue(metadata.supports_session_catalog)
+        self.assertEqual(
+            metadata.min_protocol_version,
+            _runtime.CURRENT_PROTOCOL_VERSION,
+        )
+        self.assertEqual(
+            metadata.max_protocol_version,
+            _runtime.CURRENT_PROTOCOL_VERSION,
+        )
+        self.assertEqual(
+            start_response.protocol_version,
+            _runtime.CURRENT_PROTOCOL_VERSION,
+        )
+        self.assertEqual(
+            configured,
+            [("source-instance", {"region": "use1"})],
+        )
         self.assertEqual(
             json.loads(execute_response.body),
             {
@@ -402,10 +467,57 @@ class AuthRuntimeTests(unittest.TestCase):
             provider=provider,
             kind=ProviderKind.AUTH,
         )
+        bad_context = AbortContext()
+        with self.assertRaisesRegex(
+            AbortCalled,
+            "host requested protocol version",
+        ):
+            runtime_servicer.ConfigureProvider(
+                runtime_pb2.ConfigureProviderRequest(
+                    name="fixture-auth",
+                    protocol_version=_runtime.CURRENT_PROTOCOL_VERSION + 1,
+                ),
+                bad_context,
+            )
+        self.assertEqual(bad_context.code(), grpc.StatusCode.FAILED_PRECONDITION)
+        self.assertEqual(
+            bad_context.details,
+            f"host requested protocol version {_runtime.CURRENT_PROTOCOL_VERSION + 1}, provider requires {_runtime.CURRENT_PROTOCOL_VERSION}",
+        )
+        self.assertEqual(provider.configured, [])
+
+        configure_request = runtime_pb2.ConfigureProviderRequest(
+            name="fixture-auth",
+            protocol_version=_runtime.CURRENT_PROTOCOL_VERSION,
+        )
+        json_format.ParseDict(
+            {"issuer": "https://login.example.test"},
+            configure_request.config,
+        )
+        configure_response = runtime_servicer.ConfigureProvider(
+            configure_request,
+            mock.Mock(),
+        )
         meta = runtime_servicer.GetProviderIdentity(mock.Mock(), mock.Mock())
         self.assertEqual(meta.kind, runtime_pb2.ProviderKind.PROVIDER_KIND_AUTH)
         self.assertEqual(meta.name, "stub-auth")
         self.assertEqual(list(meta.warnings), ["set AUTH_ENV"])
+        self.assertEqual(
+            meta.min_protocol_version,
+            _runtime.CURRENT_PROTOCOL_VERSION,
+        )
+        self.assertEqual(
+            meta.max_protocol_version,
+            _runtime.CURRENT_PROTOCOL_VERSION,
+        )
+        self.assertEqual(
+            configure_response.protocol_version,
+            _runtime.CURRENT_PROTOCOL_VERSION,
+        )
+        self.assertEqual(
+            provider.configured,
+            [("fixture-auth", {"issuer": "https://login.example.test"})],
+        )
 
         auth_servicer = _runtime._auth_servicer(provider=provider)
         login = auth_servicer.BeginLogin(

--- a/sdk/rust/src/provider_server.rs
+++ b/sdk/rust/src/provider_server.rs
@@ -14,7 +14,7 @@ use crate::generated::v1::{
     OperationResult as ProtoOperationResult, PostConnectRequest, PostConnectResponse,
     ProviderMetadata, StartProviderRequest, StartProviderResponse,
 };
-use crate::rpc_status::rpc_status;
+use crate::rpc_status::{require_protocol_version, rpc_status};
 use crate::{Provider, Router};
 
 #[derive(Clone)]
@@ -86,6 +86,7 @@ where
         request: GrpcRequest<StartProviderRequest>,
     ) -> std::result::Result<GrpcResponse<StartProviderResponse>, Status> {
         let request = request.into_inner();
+        require_protocol_version(request.protocol_version, CURRENT_PROTOCOL_VERSION)?;
         self.provider
             .configure(&request.name, object_map(request.config))
             .await

--- a/sdk/rust/src/rpc_status.rs
+++ b/sdk/rust/src/rpc_status.rs
@@ -21,6 +21,15 @@ pub(crate) fn rpc_status(operation: &str, error: Error) -> Status {
     }
 }
 
+pub(crate) fn require_protocol_version(version: i32, current: i32) -> Result<(), Status> {
+    if version == current {
+        return Ok(());
+    }
+    Err(Status::failed_precondition(format!(
+        "host requested protocol version {version}, provider requires {current}"
+    )))
+}
+
 #[cfg(test)]
 mod tests {
     use tonic::Code;
@@ -39,5 +48,15 @@ mod tests {
         let status = rpc_status("get cache entry", Error::bad_request("bad key"));
         assert_eq!(status.code(), Code::InvalidArgument);
         assert_eq!(status.message(), "bad key");
+    }
+
+    #[test]
+    fn require_protocol_version_rejects_mismatch() {
+        let status = require_protocol_version(3, 2).expect_err("protocol mismatch");
+        assert_eq!(status.code(), Code::FailedPrecondition);
+        assert_eq!(
+            status.message(),
+            "host requested protocol version 3, provider requires 2"
+        );
     }
 }

--- a/sdk/rust/src/runtime_server.rs
+++ b/sdk/rust/src/runtime_server.rs
@@ -12,7 +12,7 @@ use crate::generated::v1::{
     ConfigureProviderRequest, ConfigureProviderResponse, HealthCheckResponse, ProviderIdentity,
     ProviderKind,
 };
-use crate::rpc_status::{rpc_error_message, rpc_status};
+use crate::rpc_status::{require_protocol_version, rpc_error_message, rpc_status};
 use crate::secrets::SecretsProvider;
 use crate::{CURRENT_PROTOCOL_VERSION, Provider, S3Provider};
 
@@ -169,12 +169,7 @@ impl ProviderLifecycle for RuntimeServer {
         request: GrpcRequest<ConfigureProviderRequest>,
     ) -> std::result::Result<GrpcResponse<ConfigureProviderResponse>, Status> {
         let request = request.into_inner();
-        if request.protocol_version != CURRENT_PROTOCOL_VERSION {
-            return Err(Status::failed_precondition(format!(
-                "host requested protocol version {}, provider requires {}",
-                request.protocol_version, CURRENT_PROTOCOL_VERSION
-            )));
-        }
+        require_protocol_version(request.protocol_version, CURRENT_PROTOCOL_VERSION)?;
         let config = crate::catalog::object_map(request.config);
         self.provider
             .configure(&request.name, config)

--- a/sdk/rust/tests/cache_transport.rs
+++ b/sdk/rust/tests/cache_transport.rs
@@ -11,6 +11,7 @@ use gestalt::proto::v1::{ConfigureProviderRequest, ProviderKind};
 use gestalt::{CacheEntry, CacheProvider, CacheSetOptions, RuntimeMetadata};
 use hyper_util::rt::tokio::TokioIo;
 use tokio::net::UnixStream;
+use tonic::Code;
 use tonic::transport::Endpoint;
 use tower::service_fn;
 
@@ -144,8 +145,37 @@ async fn cache_runtime_and_client_round_trip_over_named_socket() {
     );
     assert_eq!(metadata.name, "cache-example");
     assert_eq!(metadata.warnings, vec!["set cache namespace"]);
+    assert_eq!(
+        metadata.min_protocol_version,
+        gestalt::CURRENT_PROTOCOL_VERSION
+    );
+    assert_eq!(
+        metadata.max_protocol_version,
+        gestalt::CURRENT_PROTOCOL_VERSION
+    );
 
-    runtime
+    let err = runtime
+        .configure_provider(ConfigureProviderRequest {
+            name: "cache-runtime".to_string(),
+            config: Some(helpers::struct_from_json(
+                serde_json::json!({ "namespace": "tenant-a" }),
+            )),
+            protocol_version: gestalt::CURRENT_PROTOCOL_VERSION + 1,
+        })
+        .await
+        .expect_err("configure provider should reject mismatched protocol version");
+    assert_eq!(err.code(), Code::FailedPrecondition);
+    assert_eq!(
+        provider
+            .configured_name
+            .lock()
+            .expect("configured_name lock")
+            .as_str(),
+        "",
+        "provider should not be configured on protocol mismatch"
+    );
+
+    let configured = runtime
         .configure_provider(ConfigureProviderRequest {
             name: "cache-runtime".to_string(),
             config: Some(helpers::struct_from_json(
@@ -154,7 +184,12 @@ async fn cache_runtime_and_client_round_trip_over_named_socket() {
             protocol_version: gestalt::CURRENT_PROTOCOL_VERSION,
         })
         .await
-        .expect("configure provider");
+        .expect("configure provider")
+        .into_inner();
+    assert_eq!(
+        configured.protocol_version,
+        gestalt::CURRENT_PROTOCOL_VERSION
+    );
 
     let mut cache = gestalt::Cache::connect_named("shared-cache")
         .await

--- a/sdk/rust/tests/transport.rs
+++ b/sdk/rust/tests/transport.rs
@@ -146,6 +146,23 @@ async fn serves_provider_requests_over_unix_socket() {
         gestalt::CURRENT_PROTOCOL_VERSION
     );
 
+    let err = client
+        .start_provider(StartProviderRequest {
+            name: "example".to_string(),
+            config: Some(helpers::struct_from_json(
+                serde_json::json!({ "greeting": "Hi" }),
+            )),
+            protocol_version: gestalt::CURRENT_PROTOCOL_VERSION + 1,
+        })
+        .await
+        .expect_err("start provider should reject mismatched protocol version");
+    assert_eq!(err.code(), Code::FailedPrecondition);
+    assert_eq!(
+        provider.greeting.lock().expect("lock greeting").as_str(),
+        "",
+        "provider should not be configured on protocol mismatch"
+    );
+
     let started = client
         .start_provider(StartProviderRequest {
             name: "example".to_string(),

--- a/sdk/typescript/src/build.ts
+++ b/sdk/typescript/src/build.ts
@@ -159,17 +159,17 @@ await runBundledProvider(candidate, ${JSON.stringify(target.kind)}, ${JSON.strin
 function defaultBundledCandidateExpression(kind: ProviderTarget["kind"]): string {
   switch (kind) {
     case "integration":
-      return "bundledModule.provider ?? bundledModule.plugin ?? bundledModule.default";
+      return 'Reflect.get(bundledModule, "provider") ?? Reflect.get(bundledModule, "plugin") ?? bundledModule.default';
     case "auth":
-      return "bundledModule.auth ?? bundledModule.provider ?? bundledModule.default";
+      return 'Reflect.get(bundledModule, "auth") ?? Reflect.get(bundledModule, "provider") ?? bundledModule.default';
     case "cache":
-      return "bundledModule.cache ?? bundledModule.provider ?? bundledModule.default";
+      return 'Reflect.get(bundledModule, "cache") ?? Reflect.get(bundledModule, "provider") ?? bundledModule.default';
     case "secrets":
-      return "bundledModule.secrets ?? bundledModule.provider ?? bundledModule.default";
+      return 'Reflect.get(bundledModule, "secrets") ?? Reflect.get(bundledModule, "provider") ?? bundledModule.default';
     case "s3":
-      return "bundledModule.s3 ?? bundledModule.provider ?? bundledModule.default";
+      return 'Reflect.get(bundledModule, "s3") ?? Reflect.get(bundledModule, "provider") ?? bundledModule.default';
     case "telemetry":
-      return "bundledModule.telemetry ?? bundledModule.provider ?? bundledModule.default";
+      return 'Reflect.get(bundledModule, "telemetry") ?? Reflect.get(bundledModule, "provider") ?? bundledModule.default';
   }
   throw new Error(`unsupported provider kind: ${kind satisfies never}`);
 }

--- a/sdk/typescript/src/runtime.ts
+++ b/sdk/typescript/src/runtime.ts
@@ -118,6 +118,16 @@ export type LoadedProvider =
   | SecretsProvider
   | S3Provider;
 
+function assertProtocolVersion(protocolVersion: number): void {
+  if (protocolVersion === CURRENT_PROTOCOL_VERSION) {
+    return;
+  }
+  throw new ConnectError(
+    `host requested protocol version ${protocolVersion}, provider requires ${CURRENT_PROTOCOL_VERSION}`,
+    Code.FailedPrecondition,
+  );
+}
+
 /**
  * CLI entrypoint that loads a provider from source and starts serving it.
  */
@@ -462,12 +472,7 @@ export function createRuntimeService(
       });
     },
     async configureProvider(request: ConfigureProviderRequest) {
-      if (request.protocolVersion !== CURRENT_PROTOCOL_VERSION) {
-        throw new ConnectError(
-          `host requested protocol version ${request.protocolVersion}, provider requires ${CURRENT_PROTOCOL_VERSION}`,
-          Code.FailedPrecondition,
-        );
-      }
+      assertProtocolVersion(request.protocolVersion);
       try {
         await provider.configureProvider(
           request.name,
@@ -536,6 +541,7 @@ export function createProviderService(
       });
     },
     async startProvider(request: StartProviderRequest) {
+      assertProtocolVersion(request.protocolVersion);
       try {
         await provider.configureProvider(
           request.name,

--- a/sdk/typescript/tests/build.test.ts
+++ b/sdk/typescript/tests/build.test.ts
@@ -4,23 +4,61 @@ import { join } from "node:path";
 
 import { create } from "@bufbuild/protobuf";
 import { EmptySchema } from "@bufbuild/protobuf/wkt";
+import { Code, ConnectError } from "@connectrpc/connect";
 import { expect, test } from "bun:test";
 
 import { AuthProvider as AuthProviderService, BeginLoginRequestSchema } from "../gen/v1/auth_pb.ts";
 import { Cache as CacheService } from "../gen/v1/cache_pb.ts";
+import {
+  AccessContextSchema,
+  CredentialContextSchema,
+  ExecuteRequestSchema,
+  GetSessionCatalogRequestSchema,
+  IntegrationProvider as IntegrationProviderService,
+  RequestContextSchema,
+  StartProviderRequestSchema,
+  SubjectContextSchema,
+} from "../gen/v1/plugin_pb.ts";
+import {
+  GetSecretRequestSchema,
+  SecretsProvider as SecretsProviderService,
+} from "../gen/v1/secrets_pb.ts";
 import { S3 as S3Service } from "../gen/v1/s3_pb.ts";
 import { ConfigureProviderRequestSchema, ProviderKind as ProtoProviderKind, ProviderLifecycle } from "../gen/v1/runtime_pb.ts";
 import { buildProviderBinary, bunTarget, parseBuildArgs } from "../src/build.ts";
 import { Cache, cacheSocketEnv } from "../src/cache.ts";
 import { CURRENT_PROTOCOL_VERSION, ENV_PROVIDER_SOCKET } from "../src/runtime.ts";
 import {
+  captureChildStderr,
   createUnixGrpcClient,
   fixturePath,
   hostTarget,
   makeTempDir,
   removeTempDir,
+  stopProcess,
   waitForPath,
 } from "./helpers.ts";
+
+async function expectConnectCode(
+  promise: Promise<unknown>,
+  code: Code,
+): Promise<void> {
+  try {
+    await promise;
+    throw new Error(`expected ConnectError with code ${Code[code]}`);
+  } catch (error) {
+    expect(error).toBeInstanceOf(ConnectError);
+    expect((error as ConnectError).code).toBe(code);
+  }
+}
+
+async function waitForSocket(path: string, stderrText: () => string): Promise<void> {
+  try {
+    await waitForPath(path);
+  } catch (error) {
+    throw new Error(`${String(error)}${stderrText() ? `\n${stderrText()}` : ""}`);
+  }
+}
 
 test("build arg parsing validates required arguments", () => {
   expect(parseBuildArgs(["root", "auth:./auth.ts#provider", "out", "name", "darwin", "arm64"])).toEqual(
@@ -44,7 +82,6 @@ test("buildProviderBinary compiles a runnable auth provider executable", async (
   const outputPath = join(tempDir, `fixture-provider${executableSuffix}`);
   const socketPath = join(tempDir, "provider.sock");
   let child: ChildProcess | undefined;
-  let stderr = "";
 
   try {
     buildProviderBinary({
@@ -65,12 +102,9 @@ test("buildProviderBinary compiles a runnable auth provider executable", async (
       },
       stdio: ["ignore", "ignore", "pipe"],
     });
-    child.stderr?.setEncoding("utf8");
-    child.stderr?.on("data", (chunk: string) => {
-      stderr += chunk;
-    });
+    const stderrText = captureChildStderr(child);
 
-    await waitForPath(socketPath);
+    await waitForSocket(socketPath, stderrText);
 
     const runtime = createUnixGrpcClient(ProviderLifecycle, socketPath);
     const auth = createUnixGrpcClient(AuthProviderService, socketPath);
@@ -108,6 +142,198 @@ test("buildProviderBinary compiles a runnable auth provider executable", async (
   }
 }, 15_000);
 
+test("buildProviderBinary compiles a runnable integration provider executable for plugin and integration targets", async () => {
+  const { goos, goarch, executableSuffix } = hostTarget();
+  const tempDir = makeTempDir("gts-integration-");
+
+  try {
+    for (const [label, target] of [
+      ["plugin", "plugin:./provider.ts#plugin"],
+      ["integration", "integration:./provider.ts#plugin"],
+    ] as const) {
+      const outputPath = join(tempDir, `fixture-${label}${executableSuffix}`);
+      const socketPath = join(tempDir, `${label}.sock`);
+      let child: ChildProcess | undefined;
+
+      try {
+        buildProviderBinary({
+          root: fixturePath("basic-provider"),
+          target,
+          outputPath,
+          providerName: `fixture-${label}`,
+          goos,
+          goarch,
+        });
+
+        expect(existsSync(outputPath)).toBe(true);
+
+        child = spawn(outputPath, [], {
+          env: {
+            ...process.env,
+            [ENV_PROVIDER_SOCKET]: socketPath,
+          },
+          stdio: ["ignore", "ignore", "pipe"],
+        });
+        const stderrText = captureChildStderr(child);
+
+        await waitForSocket(socketPath, stderrText);
+
+        const runtime = createUnixGrpcClient(ProviderLifecycle, socketPath);
+        const provider = createUnixGrpcClient(
+          IntegrationProviderService,
+          socketPath,
+        );
+
+        const identity = await runtime.getProviderIdentity(create(EmptySchema, {}));
+        expect(identity.kind).toBe(ProtoProviderKind.INTEGRATION);
+        expect(identity.name).toBe(`fixture-${label}`);
+        expect(identity.minProtocolVersion).toBe(CURRENT_PROTOCOL_VERSION);
+        expect(identity.maxProtocolVersion).toBe(CURRENT_PROTOCOL_VERSION);
+
+        const metadata = await provider.getMetadata(create(EmptySchema, {}));
+        expect(metadata.name).toBe(`fixture-${label}`);
+        expect(metadata.supportsSessionCatalog).toBe(true);
+        expect(metadata.minProtocolVersion).toBe(CURRENT_PROTOCOL_VERSION);
+        expect(metadata.maxProtocolVersion).toBe(CURRENT_PROTOCOL_VERSION);
+        expect(
+          metadata.staticCatalog?.operations?.some((operation) => operation.id === "hello"),
+        ).toBe(true);
+        expect(
+          metadata.staticCatalog?.operations?.some((operation) => operation.id === "count"),
+        ).toBe(true);
+
+        await expectConnectCode(
+          provider.startProvider(
+            create(StartProviderRequestSchema, {
+              name: `fixture-${label}`,
+              config: {
+                region: "use1",
+              },
+              protocolVersion: CURRENT_PROTOCOL_VERSION + 1,
+            }),
+          ),
+          Code.FailedPrecondition,
+        );
+
+        const started = await provider.startProvider(
+          create(StartProviderRequestSchema, {
+            name: `fixture-${label}`,
+            config: {
+              region: "use1",
+            },
+            protocolVersion: CURRENT_PROTOCOL_VERSION,
+          }),
+        );
+        expect(started.protocolVersion).toBe(CURRENT_PROTOCOL_VERSION);
+
+        const result = await provider.execute(
+          create(ExecuteRequestSchema, {
+            operation: "hello",
+            params: {
+              name: "Ada",
+            },
+            token: "token-123",
+            connectionParams: {
+              region: "iad",
+            },
+            context: create(RequestContextSchema, {
+              subject: create(SubjectContextSchema, {
+                id: "user:user-123",
+                kind: "user",
+                authSource: "api_token",
+              }),
+              credential: create(CredentialContextSchema, {
+                mode: "identity",
+                subjectId: "identity:__identity__",
+              }),
+              access: create(AccessContextSchema, {
+                policy: "sample_policy",
+                role: "admin",
+              }),
+            }),
+          }),
+        );
+        expect(JSON.parse(result.body)).toEqual({
+          message: "Hello, Ada.",
+          configuredName: `fixture-${label}`,
+          region: "iad",
+          configuredRegion: "use1",
+          subjectId: "user:user-123",
+          credentialMode: "identity",
+          accessPolicy: "sample_policy",
+          accessRole: "admin",
+        });
+
+        const countResult = await provider.execute(
+          create(ExecuteRequestSchema, {
+            operation: "count",
+            params: {
+              count: 7,
+            },
+          }),
+        );
+        expect(countResult.status).toBe(200);
+        expect(JSON.parse(countResult.body)).toEqual({
+          count: 7,
+        });
+
+        const decodeError = await provider.execute(
+          create(ExecuteRequestSchema, {
+            operation: "count",
+            params: {
+              count: "oops",
+            },
+          }),
+        );
+        expect(decodeError.status).toBe(400);
+        expect(JSON.parse(decodeError.body)).toEqual({
+          error: "$.count must be an integer",
+        });
+
+        const sessionCatalog = await provider.getSessionCatalog(
+          create(GetSessionCatalogRequestSchema, {
+            token: "token-123",
+            connectionParams: {
+              scope: label,
+            },
+            context: create(RequestContextSchema, {
+              subject: create(SubjectContextSchema, {
+                id: "user:user-123",
+                kind: "user",
+              }),
+              credential: create(CredentialContextSchema, {
+                mode: "identity",
+              }),
+              access: create(AccessContextSchema, {
+                policy: "sample_policy",
+                role: "viewer",
+              }),
+            }),
+          }),
+        );
+        expect(sessionCatalog.catalog?.name).toBe("fixture-session");
+        expect(sessionCatalog.catalog?.operations).toHaveLength(1);
+        const sessionOperation = sessionCatalog.catalog?.operations?.[0];
+        expect(sessionOperation).toBeDefined();
+        expect(sessionOperation?.id).toBe("session-hello");
+        expect(sessionOperation?.allowedRoles).toEqual([
+          "viewer",
+          "admin",
+        ]);
+        expect(sessionOperation?.title).toBe(
+          `Session Hello ${label} user:user-123 identity viewer`,
+        );
+      } finally {
+        if (child) {
+          await stopProcess(child);
+        }
+      }
+    }
+  } finally {
+    removeTempDir(tempDir);
+  }
+}, 30_000);
+
 test("buildProviderBinary compiles a runnable cache provider executable", async () => {
   const { goos, goarch, executableSuffix } = hostTarget();
   const tempDir = makeTempDir("gts-cache-");
@@ -116,7 +342,6 @@ test("buildProviderBinary compiles a runnable cache provider executable", async 
   const previousDefaultSocket = process.env.GESTALT_CACHE_SOCKET;
   const previousNamedSocket = process.env[cacheSocketEnv("named")];
   let child: ChildProcess | undefined;
-  let stderr = "";
 
   try {
     buildProviderBinary({
@@ -137,16 +362,9 @@ test("buildProviderBinary compiles a runnable cache provider executable", async 
       },
       stdio: ["ignore", "ignore", "pipe"],
     });
-    child.stderr?.setEncoding("utf8");
-    child.stderr?.on("data", (chunk: string) => {
-      stderr += chunk;
-    });
+    const stderrText = captureChildStderr(child);
 
-    try {
-      await waitForPath(socketPath);
-    } catch (error) {
-      throw new Error(`${String(error)}${stderr ? `\n${stderr}` : ""}`);
-    }
+    await waitForSocket(socketPath, stderrText);
 
     const runtime = createUnixGrpcClient(ProviderLifecycle, socketPath);
     const rawCache = createUnixGrpcClient(CacheService, socketPath);
@@ -232,6 +450,93 @@ test("buildProviderBinary compiles a runnable cache provider executable", async 
   }
 }, 15_000);
 
+test("buildProviderBinary compiles a runnable secrets provider executable", async () => {
+  const { goos, goarch, executableSuffix } = hostTarget();
+  const tempDir = makeTempDir("gts-secrets-");
+  const outputPath = join(tempDir, `fixture-secrets${executableSuffix}`);
+  const socketPath = join(tempDir, "provider.sock");
+  let child: ChildProcess | undefined;
+
+  try {
+    buildProviderBinary({
+      root: fixturePath("secrets-provider"),
+      target: "secrets:./secrets.ts",
+      outputPath,
+      providerName: "fixture-secrets-built",
+      goos,
+      goarch,
+    });
+
+    expect(existsSync(outputPath)).toBe(true);
+
+    child = spawn(outputPath, [], {
+      env: {
+        ...process.env,
+        [ENV_PROVIDER_SOCKET]: socketPath,
+      },
+      stdio: ["ignore", "ignore", "pipe"],
+    });
+    const stderrText = captureChildStderr(child);
+
+    await waitForSocket(socketPath, stderrText);
+
+    const runtime = createUnixGrpcClient(ProviderLifecycle, socketPath);
+    const secrets = createUnixGrpcClient(SecretsProviderService, socketPath);
+
+    const metadata = await runtime.getProviderIdentity(create(EmptySchema, {}));
+    expect(metadata.kind).toBe(ProtoProviderKind.SECRETS);
+    expect(metadata.name).toBe("fixture-secrets-built");
+    expect(metadata.displayName).toBe("Fixture Secrets");
+    expect(metadata.minProtocolVersion).toBe(CURRENT_PROTOCOL_VERSION);
+    expect(metadata.maxProtocolVersion).toBe(CURRENT_PROTOCOL_VERSION);
+
+    await expectConnectCode(
+      runtime.configureProvider(
+        create(ConfigureProviderRequestSchema, {
+          name: "fixture-secrets-built",
+          config: {
+            scope: "binary",
+          },
+          protocolVersion: CURRENT_PROTOCOL_VERSION + 1,
+        }),
+      ),
+      Code.FailedPrecondition,
+    );
+
+    const configured = await runtime.configureProvider(
+      create(ConfigureProviderRequestSchema, {
+        name: "fixture-secrets-built",
+        config: {
+          scope: "binary",
+        },
+        protocolVersion: CURRENT_PROTOCOL_VERSION,
+      }),
+    );
+    expect(configured.protocolVersion).toBe(CURRENT_PROTOCOL_VERSION);
+
+    const secret = await secrets.getSecret(
+      create(GetSecretRequestSchema, {
+        name: "db-password",
+      }),
+    );
+    expect(secret.value).toBe("fixture-secrets-built:binary:hunter2");
+
+    await expectConnectCode(
+      secrets.getSecret(
+        create(GetSecretRequestSchema, {
+          name: "missing",
+        }),
+      ),
+      Code.NotFound,
+    );
+  } finally {
+    if (child) {
+      await stopProcess(child);
+    }
+    removeTempDir(tempDir);
+  }
+}, 15_000);
+
 test("buildProviderBinary compiles a runnable s3 provider executable", async () => {
   const { goos, goarch, executableSuffix } = hostTarget();
   const tempDir = makeTempDir("gestalt-typescript-s3-build-test-");
@@ -258,8 +563,9 @@ test("buildProviderBinary compiles a runnable s3 provider executable", async () 
       },
       stdio: ["ignore", "ignore", "pipe"],
     });
+    const stderrText = captureChildStderr(child);
 
-    await waitForPath(socketPath);
+    await waitForSocket(socketPath, stderrText);
 
     const runtime = createUnixGrpcClient(ProviderLifecycle, socketPath);
     const s3 = createUnixGrpcClient(S3Service, socketPath);
@@ -312,41 +618,3 @@ test("buildProviderBinary compiles a runnable s3 provider executable", async () 
     removeTempDir(tempDir);
   }
 });
-
-async function stopProcess(child: ChildProcess): Promise<void> {
-  if (child.exitCode !== null || child.signalCode !== null) {
-    return;
-  }
-  child.kill("SIGTERM");
-  try {
-    await waitForExit(child, 2_000);
-  } catch {
-    child.kill("SIGKILL");
-    await waitForExit(child, 2_000);
-  }
-}
-
-async function waitForExit(
-  child: ChildProcess,
-  timeoutMs: number,
-): Promise<{ code: number | null; signal: NodeJS.Signals | null }> {
-  if (child.exitCode !== null || child.signalCode !== null) {
-    return {
-      code: child.exitCode,
-      signal: child.signalCode,
-    };
-  }
-  return await new Promise((resolve, reject) => {
-    const timer = setTimeout(() => {
-      reject(new Error("timed out waiting for child process to exit"));
-    }, timeoutMs);
-    child.once("close", (code, signal) => {
-      clearTimeout(timer);
-      resolve({ code, signal });
-    });
-    child.once("error", (error) => {
-      clearTimeout(timer);
-      reject(error);
-    });
-  });
-}

--- a/sdk/typescript/tests/fixtures/basic-provider/provider.ts
+++ b/sdk/typescript/tests/fixtures/basic-provider/provider.ts
@@ -78,5 +78,22 @@ export const plugin = definePlugin({
         });
       },
     }),
+    operation({
+      id: "count",
+      method: "POST",
+      title: "Count",
+      description: "Echo an integer count",
+      input: s.object({
+        count: s.integer(),
+      }),
+      output: s.object({
+        count: s.integer(),
+      }),
+      handler(input) {
+        return ok({
+          count: input.count,
+        });
+      },
+    }),
   ],
 });

--- a/sdk/typescript/tests/fixtures/secrets-provider/package.json
+++ b/sdk/typescript/tests/fixtures/secrets-provider/package.json
@@ -1,0 +1,10 @@
+{
+  "name": "@fixtures/secrets-provider",
+  "type": "module",
+  "gestalt": {
+    "provider": {
+      "kind": "secrets",
+      "target": "./secrets.ts"
+    }
+  }
+}

--- a/sdk/typescript/tests/fixtures/secrets-provider/secrets.ts
+++ b/sdk/typescript/tests/fixtures/secrets-provider/secrets.ts
@@ -1,0 +1,26 @@
+import { Code, ConnectError } from "@connectrpc/connect";
+
+import { defineSecretsProvider } from "../../../src/index.ts";
+
+let configuredName = "";
+let configuredScope = "";
+
+const provider = defineSecretsProvider({
+  displayName: "Fixture Secrets",
+  description: "Secrets fixture used by SDK tests",
+  configure(name, config) {
+    configuredName = name;
+    configuredScope = String(config.scope ?? "");
+  },
+  async getSecret(name) {
+    if (name === "db-password") {
+      return `${configuredName}:${configuredScope || "default"}:hunter2`;
+    }
+    if (name === "api-token") {
+      return `${configuredName}:${configuredScope || "default"}:token`;
+    }
+    throw new ConnectError(`secret ${name} not found`, Code.NotFound);
+  },
+});
+
+export default provider;

--- a/sdk/typescript/tests/helpers.ts
+++ b/sdk/typescript/tests/helpers.ts
@@ -1,3 +1,4 @@
+import { type ChildProcess } from "node:child_process";
 import { existsSync, mkdtempSync, rmSync } from "node:fs";
 import { connect } from "node:net";
 import { tmpdir } from "node:os";
@@ -70,4 +71,51 @@ export function createUnixGrpcClient<T extends DescService>(service: T, socketPa
     },
   });
   return createClient(service, transport);
+}
+
+export function captureChildStderr(child: ChildProcess): () => string {
+  let stderr = "";
+  child.stderr?.setEncoding("utf8");
+  child.stderr?.on("data", (chunk: string) => {
+    stderr += chunk;
+  });
+  return () => stderr;
+}
+
+export async function stopProcess(child: ChildProcess): Promise<void> {
+  if (child.exitCode !== null || child.signalCode !== null) {
+    return;
+  }
+  child.kill("SIGTERM");
+  try {
+    await waitForExit(child, 2_000);
+  } catch {
+    child.kill("SIGKILL");
+    await waitForExit(child, 2_000);
+  }
+}
+
+async function waitForExit(
+  child: ChildProcess,
+  timeoutMs: number,
+): Promise<{ code: number | null; signal: NodeJS.Signals | null }> {
+  if (child.exitCode !== null || child.signalCode !== null) {
+    return {
+      code: child.exitCode,
+      signal: child.signalCode,
+    };
+  }
+  return await new Promise((resolve, reject) => {
+    const timer = setTimeout(() => {
+      reject(new Error("timed out waiting for child process to exit"));
+    }, timeoutMs);
+    child.once("close", (code, signal) => {
+      clearTimeout(timer);
+      resolve({ code, signal });
+    });
+    child.once("error", (error) => {
+      clearTimeout(timer);
+      reject(error);
+    });
+  });
 }

--- a/sdk/typescript/tests/runtime.test.ts
+++ b/sdk/typescript/tests/runtime.test.ts
@@ -1,3 +1,4 @@
+import { spawn, type ChildProcess } from "node:child_process";
 import { readFileSync } from "node:fs";
 import { join } from "node:path";
 
@@ -30,13 +31,19 @@ import {
   SubjectContextSchema,
 } from "../gen/v1/plugin_pb.ts";
 import {
+  GetSecretRequestSchema,
+  SecretsProvider as SecretsProviderService,
+} from "../gen/v1/secrets_pb.ts";
+import {
   ConfigureProviderRequestSchema,
   ProviderKind as ProtoProviderKind,
+  ProviderLifecycle,
 } from "../gen/v1/runtime_pb.ts";
 import {
   CURRENT_PROTOCOL_VERSION,
   createCacheService,
   ENV_WRITE_CATALOG,
+  ENV_PROVIDER_SOCKET,
   createAuthService,
   createProviderService,
   createRuntimeService,
@@ -47,7 +54,15 @@ import {
 } from "../src/runtime.ts";
 import { PresignMethod, S3, defineCacheProvider, defineS3Provider } from "../src/index.ts";
 import { createS3Service } from "../src/s3.ts";
-import { fixturePath, makeTempDir, removeTempDir } from "./helpers.ts";
+import {
+  captureChildStderr,
+  createUnixGrpcClient,
+  fixturePath,
+  makeTempDir,
+  removeTempDir,
+  stopProcess,
+  waitForPath,
+} from "./helpers.ts";
 
 async function expectConnectCode(
   promise: Promise<unknown>,
@@ -92,6 +107,93 @@ test("runtime main writes a static catalog in catalog mode", async () => {
     removeTempDir(tempDir);
   }
 });
+
+test("loadProviderFromTarget resolves a secrets provider from package metadata", async () => {
+  const provider = await loadProviderFromTarget(fixturePath("secrets-provider"));
+  expect(provider.kind).toBe("secrets");
+  expect(provider.name).toBe("secrets-provider");
+  expect(provider.displayName).toBe("Fixture Secrets");
+});
+
+test("runtime serves a secrets provider over unix gRPC", async () => {
+  const runtimeEntry = join(import.meta.dir, "..", "src", "runtime.ts");
+  const root = fixturePath("secrets-provider");
+  const tempDir = makeTempDir("gestalt-typescript-runtime-");
+  const socketPath = join(tempDir, "provider.sock");
+  let child: ChildProcess | undefined;
+
+  try {
+    child = spawn(process.execPath, [runtimeEntry, root, "secrets:./secrets.ts"], {
+      env: {
+        ...process.env,
+        [ENV_PROVIDER_SOCKET]: socketPath,
+      },
+      stdio: ["ignore", "ignore", "pipe"],
+    });
+    const stderrText = captureChildStderr(child);
+
+    try {
+      await waitForPath(socketPath);
+    } catch (error) {
+      throw new Error(`${String(error)}${stderrText() ? `\n${stderrText()}` : ""}`);
+    }
+
+    const runtime = createUnixGrpcClient(ProviderLifecycle, socketPath);
+    const secrets = createUnixGrpcClient(SecretsProviderService, socketPath);
+
+    const metadata = await runtime.getProviderIdentity(create(EmptySchema, {}));
+    expect(metadata.kind).toBe(ProtoProviderKind.SECRETS);
+    expect(metadata.name).toBe("secrets-provider");
+    expect(metadata.displayName).toBe("Fixture Secrets");
+    expect(metadata.minProtocolVersion).toBe(CURRENT_PROTOCOL_VERSION);
+    expect(metadata.maxProtocolVersion).toBe(CURRENT_PROTOCOL_VERSION);
+
+    await expectConnectCode(
+      runtime.configureProvider(
+        create(ConfigureProviderRequestSchema, {
+          name: "fixture-secrets",
+          config: {
+            scope: "runtime",
+          },
+          protocolVersion: CURRENT_PROTOCOL_VERSION + 1,
+        }),
+      ),
+      Code.FailedPrecondition,
+    );
+
+    const configured = await runtime.configureProvider(
+      create(ConfigureProviderRequestSchema, {
+        name: "fixture-secrets",
+        config: {
+          scope: "runtime",
+        },
+        protocolVersion: CURRENT_PROTOCOL_VERSION,
+      }),
+    );
+    expect(configured.protocolVersion).toBe(CURRENT_PROTOCOL_VERSION);
+
+    const secret = await secrets.getSecret(
+      create(GetSecretRequestSchema, {
+        name: "db-password",
+      }),
+    );
+    expect(secret.value).toBe("fixture-secrets:runtime:hunter2");
+
+    await expectConnectCode(
+      secrets.getSecret(
+        create(GetSecretRequestSchema, {
+          name: "missing",
+        }),
+      ),
+      Code.NotFound,
+    );
+  } finally {
+    if (child) {
+      await stopProcess(child);
+    }
+    removeTempDir(tempDir);
+  }
+}, 15_000);
 
 test("integration provider service exposes metadata, configure, execute, and session catalog", async () => {
   const plugin = await loadPluginFromTarget(fixturePath("basic-provider"));

--- a/sdk/typescript/tests/runtime.test.ts
+++ b/sdk/typescript/tests/runtime.test.ts
@@ -3,6 +3,7 @@ import { join } from "node:path";
 
 import { create } from "@bufbuild/protobuf";
 import { EmptySchema } from "@bufbuild/protobuf/wkt";
+import { Code, ConnectError } from "@connectrpc/connect";
 import { expect, test } from "bun:test";
 
 import {
@@ -33,6 +34,7 @@ import {
   ProviderKind as ProtoProviderKind,
 } from "../gen/v1/runtime_pb.ts";
 import {
+  CURRENT_PROTOCOL_VERSION,
   createCacheService,
   ENV_WRITE_CATALOG,
   createAuthService,
@@ -46,6 +48,19 @@ import {
 import { PresignMethod, S3, defineCacheProvider, defineS3Provider } from "../src/index.ts";
 import { createS3Service } from "../src/s3.ts";
 import { fixturePath, makeTempDir, removeTempDir } from "./helpers.ts";
+
+async function expectConnectCode(
+  promise: Promise<unknown>,
+  code: Code,
+): Promise<void> {
+  try {
+    await promise;
+    throw new Error(`expected ConnectError with code ${Code[code]}`);
+  } catch (error) {
+    expect(error).toBeInstanceOf(ConnectError);
+    expect((error as ConnectError).code).toBe(code);
+  }
+}
 
 test("runtime arg parsing requires root and target", () => {
   expect(parseRuntimeArgs(["root", "plugin:./provider.ts#plugin"])).toEqual({
@@ -85,6 +100,8 @@ test("integration provider service exposes metadata, configure, execute, and ses
   const metadata = await (service.getMetadata as any)();
   expect(metadata.name).toBe("basic-provider");
   expect(metadata.supportsSessionCatalog).toBe(true);
+  expect(metadata.minProtocolVersion).toBe(CURRENT_PROTOCOL_VERSION);
+  expect(metadata.maxProtocolVersion).toBe(CURRENT_PROTOCOL_VERSION);
   expect(
     metadata.staticCatalog?.operations?.some((op: any) => op.id === "hello"),
   ).toBe(true);
@@ -93,14 +110,46 @@ test("integration provider service exposes metadata, configure, execute, and ses
       ?.allowedRoles,
   ).toEqual(["viewer", "admin"]);
 
-  await (service.startProvider as any)(
+  await expectConnectCode(
+    (service.startProvider as any)(
+      create(StartProviderRequestSchema, {
+        name: "configured-provider",
+        config: {
+          region: "use1",
+        },
+        protocolVersion: CURRENT_PROTOCOL_VERSION + 1,
+      }),
+    ),
+    Code.FailedPrecondition,
+  );
+
+  const unconfiguredResult = await (service.execute as any)(
+    create(ExecuteRequestSchema, {
+      operation: "hello",
+      params: {
+        name: "Ada",
+      },
+      token: "token-123",
+      connectionParams: {
+        region: "iad",
+      },
+    }),
+  );
+  expect(JSON.parse(unconfiguredResult.body)).toMatchObject({
+    configuredName: "",
+    configuredRegion: "",
+  });
+
+  const started = await (service.startProvider as any)(
     create(StartProviderRequestSchema, {
       name: "configured-provider",
       config: {
         region: "use1",
       },
+      protocolVersion: CURRENT_PROTOCOL_VERSION,
     }),
   );
+  expect(started.protocolVersion).toBe(CURRENT_PROTOCOL_VERSION);
 
   const result = await (service.execute as any)(
     create(ExecuteRequestSchema, {
@@ -179,21 +228,48 @@ test("auth provider supports runtime metadata, login flows, and token validation
   const runtime = createRuntimeService(provider);
   const auth = createAuthService(provider as any);
 
-  await (runtime.configureProvider as any)(
+  await expectConnectCode(
+    (runtime.configureProvider as any)(
+      create(ConfigureProviderRequestSchema, {
+        name: "fixture-auth",
+        config: {
+          issuer: "https://login.example.test",
+        },
+        protocolVersion: CURRENT_PROTOCOL_VERSION + 1,
+      }),
+    ),
+    Code.FailedPrecondition,
+  );
+
+  const defaultBegin = await (auth.beginLogin as any)(
+    create((await import("../gen/v1/auth_pb.ts")).BeginLoginRequestSchema, {
+      callbackUrl: "https://app.example.test/callback",
+      hostState: "host-state",
+      scopes: ["openid"],
+    }),
+  );
+  expect(defaultBegin.authorizationUrl).toContain(
+    "https://issuer.example.test/authorize",
+  );
+
+  const configuredAuth = await (runtime.configureProvider as any)(
     create(ConfigureProviderRequestSchema, {
       name: "fixture-auth",
       config: {
         issuer: "https://login.example.test",
       },
-      protocolVersion: 2,
+      protocolVersion: CURRENT_PROTOCOL_VERSION,
     }),
   );
+  expect(configuredAuth.protocolVersion).toBe(CURRENT_PROTOCOL_VERSION);
 
   const metadata = await (runtime.getProviderIdentity as any)(
     create(EmptySchema, {}),
   );
   expect(metadata.kind).toBe(2);
   expect(metadata.displayName).toBe("Fixture Auth");
+  expect(metadata.minProtocolVersion).toBe(CURRENT_PROTOCOL_VERSION);
+  expect(metadata.maxProtocolVersion).toBe(CURRENT_PROTOCOL_VERSION);
 
   const begin = await (auth.beginLogin as any)(
     create((await import("../gen/v1/auth_pb.ts")).BeginLoginRequestSchema, {
@@ -231,21 +307,24 @@ test("cache provider supports runtime metadata and cache operations", async () =
   const runtime = createRuntimeService(provider);
   const cache = createCacheService(provider as any);
 
-  await (runtime.configureProvider as any)(
+  const configuredCache = await (runtime.configureProvider as any)(
     create(ConfigureProviderRequestSchema, {
       name: "fixture-cache",
       config: {
         prefix: "runtime",
       },
-      protocolVersion: 2,
+      protocolVersion: CURRENT_PROTOCOL_VERSION,
     }),
   );
+  expect(configuredCache.protocolVersion).toBe(CURRENT_PROTOCOL_VERSION);
 
   const metadata = await (runtime.getProviderIdentity as any)(
     create(EmptySchema, {}),
   );
   expect(metadata.kind).toBe(ProtoProviderKind.CACHE);
   expect(metadata.displayName).toBe("Fixture Cache");
+  expect(metadata.minProtocolVersion).toBe(CURRENT_PROTOCOL_VERSION);
+  expect(metadata.maxProtocolVersion).toBe(CURRENT_PROTOCOL_VERSION);
 
   const encoder = new TextEncoder();
   const decoder = new TextDecoder();
@@ -392,19 +471,22 @@ test("s3 provider target resolves and serves runtime metadata plus object operat
   const runtime = createRuntimeService(provider);
   const s3 = createS3Service(provider as any);
 
-  await (runtime.configureProvider as any)(
+  const configuredS3 = await (runtime.configureProvider as any)(
     create(ConfigureProviderRequestSchema, {
       name: "fixture-s3",
       config: {},
-      protocolVersion: 2,
+      protocolVersion: CURRENT_PROTOCOL_VERSION,
     }),
   );
+  expect(configuredS3.protocolVersion).toBe(CURRENT_PROTOCOL_VERSION);
 
   const metadata = await (runtime.getProviderIdentity as any)(
     create(EmptySchema, {}),
   );
   expect(metadata.kind).toBe(ProtoProviderKind.S3);
   expect(metadata.displayName).toBe("Fixture S3");
+  expect(metadata.minProtocolVersion).toBe(CURRENT_PROTOCOL_VERSION);
+  expect(metadata.maxProtocolVersion).toBe(CURRENT_PROTOCOL_VERSION);
 
   const written = await (s3.writeObject as any)(
     (async function* () {


### PR DESCRIPTION
## Summary
- reject protocol-version mismatches on both startup paths across the Go, Python, Rust, and TypeScript SDK runtimes
- align Go integration-provider metadata with the same advertised protocol window as the other SDKs
- prove rejected startup requests do not mutate provider configuration state before returning `FAILED_PRECONDITION`

## Go Interface
No Go interface change.

Example:
```go
resp, err := client.StartProvider(ctx, &proto.StartProviderRequest{
    Name:            "example",
    Config:          cfg,
    ProtocolVersion: proto.CurrentProtocolVersion,
})
// matching versions still configure the provider and return the current protocol version
```

Mismatch example:
```go
_, err := client.StartProvider(ctx, &proto.StartProviderRequest{
    Name:            "example",
    Config:          cfg,
    ProtocolVersion: proto.CurrentProtocolVersion + 1,
})
// now returns FAILED_PRECONDITION and leaves provider state unchanged
```

## YAML Shape
No YAML shape change.

Example:
```yaml
source: plugin:./provider.ts#plugin
config:
  region: use1
```

The runtime contract change is behavioral only: startup now rejects mismatched protocol versions consistently on both lifecycle paths.

## Test Coverage
- `go test ./...` in `sdk/go`
- `python3 -m unittest tests.test_runtime` in `sdk/python`
- `bun install --frozen-lockfile && bun test tests/runtime.test.ts` in `sdk/typescript`
- `cargo test --manifest-path sdk/rust/Cargo.toml --test transport --test cache_transport --lib`

## Scope Notes
- no unit-test deletions in this PR
- no telemetry, `PostConnect`, or provider-kind removals in this PR
- this is the contract-alignment gate before broader SDK branch-removal work