### PR TITLE
CLI: scope catalogs and honor catalog methods

### DIFF
--- a/gestalt/cli/src/api.rs
+++ b/gestalt/cli/src/api.rs
@@ -258,6 +258,26 @@ impl ApiClient {
         self.send(Method::GET, path)
     }
 
+    pub fn get_with_query<T>(&self, path: &str, query: &T) -> Result<serde_json::Value>
+    where
+        T: Serialize + ?Sized,
+    {
+        let encoded =
+            serde_urlencoded::to_string(query).context("failed to encode query parameters")?;
+        let url = if encoded.is_empty() {
+            format!("{}{}", self.base_url, path)
+        } else {
+            format!("{}{}?{}", self.base_url, path, encoded)
+        };
+        let resp = self
+            .client
+            .request(Method::GET, &url)
+            .bearer_auth(&self.token)
+            .send()
+            .map_err(|e| self.wrap_send_error(e, &url))?;
+        self.handle_response(resp)
+    }
+
     pub fn post<T>(&self, path: &str, body: &T) -> Result<serde_json::Value>
     where
         T: Serialize + ?Sized,

--- a/gestalt/cli/src/catalog.rs
+++ b/gestalt/cli/src/catalog.rs
@@ -3,6 +3,12 @@ use serde::{Deserialize, Serialize};
 
 use crate::api::ApiClient;
 
+#[derive(Debug, Clone, Copy, Default)]
+pub struct CatalogSelectors<'a> {
+    pub connection: Option<&'a str>,
+    pub instance: Option<&'a str>,
+}
+
 pub enum ResolvedOperation<'a> {
     All(&'a [CatalogOperation]),
     Exact(&'a CatalogOperation),
@@ -107,9 +113,20 @@ fn is_valid_operation_query(query: &str) -> bool {
     })
 }
 
-pub fn fetch_catalog(client: &ApiClient, plugin: &str) -> Result<OperationsCatalog> {
+pub fn fetch_catalog(
+    client: &ApiClient,
+    plugin: &str,
+    selectors: CatalogSelectors<'_>,
+) -> Result<OperationsCatalog> {
     let path = format!("/api/v1/integrations/{}/operations", plugin);
-    let resp = client.get(&path)?;
+    let query: Vec<(&str, &str)> = [
+        ("_connection", selectors.connection),
+        ("_instance", selectors.instance),
+    ]
+    .into_iter()
+    .filter_map(|(key, value)| value.map(|v| (key, v)))
+    .collect();
+    let resp = client.get_with_query(&path, &query)?;
     let operations: Vec<CatalogOperation> =
         serde_json::from_value(resp).context("failed to parse operations response")?;
     Ok(OperationsCatalog { operations })

--- a/gestalt/cli/src/cli.rs
+++ b/gestalt/cli/src/cli.rs
@@ -86,6 +86,12 @@ pub enum Commands {
         plugin: String,
         /// Operation name
         operation: String,
+        /// Select a named connection when loading the operation contract
+        #[arg(long)]
+        connection: Option<String>,
+        /// Select a stored connection instance when loading the operation contract
+        #[arg(long)]
+        instance: Option<String>,
     },
 
     /// Manage API tokens
@@ -192,6 +198,12 @@ pub enum PluginCommands {
         plugin: String,
         /// Operation name
         operation: String,
+        /// Select a named connection when loading the operation contract
+        #[arg(long)]
+        connection: Option<String>,
+        /// Select a stored connection instance when loading the operation contract
+        #[arg(long)]
+        instance: Option<String>,
     },
 }
 

--- a/gestalt/cli/src/commands/describe.rs
+++ b/gestalt/cli/src/commands/describe.rs
@@ -1,11 +1,30 @@
 use anyhow::{Result, bail};
 
 use crate::api::ApiClient;
-use crate::catalog;
+use crate::catalog::{self, CatalogSelectors};
 use crate::output::{self, Format};
 
-pub fn describe(client: &ApiClient, plugin: &str, operation: &str, format: Format) -> Result<()> {
-    let cat = catalog::fetch_catalog(client, plugin)?;
+#[derive(Default)]
+pub struct DescribeOptions<'a> {
+    pub connection: Option<&'a str>,
+    pub instance: Option<&'a str>,
+}
+
+pub fn describe(
+    client: &ApiClient,
+    plugin: &str,
+    operation: &str,
+    options: DescribeOptions<'_>,
+    format: Format,
+) -> Result<()> {
+    let cat = catalog::fetch_catalog(
+        client,
+        plugin,
+        CatalogSelectors {
+            connection: options.connection,
+            instance: options.instance,
+        },
+    )?;
 
     let op = match cat.find_operation(operation) {
         Some(op) => op,

--- a/gestalt/cli/src/commands/invoke.rs
+++ b/gestalt/cli/src/commands/invoke.rs
@@ -1,8 +1,10 @@
 use anyhow::{Context, Result};
+use reqwest::Method;
 
 use crate::api::ApiClient;
 use crate::catalog::{
-    self, CatalogOperation, CatalogParameter, OperationsCatalog, ResolvedOperation,
+    self, CatalogOperation, CatalogParameter, CatalogSelectors, OperationsCatalog,
+    ResolvedOperation,
 };
 use crate::output::{self, Format};
 use crate::params::{self, ParamEntry};
@@ -23,7 +25,14 @@ pub fn run(
     options: InvokeOptions<'_>,
     format: Format,
 ) -> Result<()> {
-    let cat = catalog::fetch_catalog(client, plugin)?;
+    let cat = catalog::fetch_catalog(
+        client,
+        plugin,
+        CatalogSelectors {
+            connection: options.connection,
+            instance: options.instance,
+        },
+    )?;
     let query = segments.join(".");
 
     match cat.resolve(&query)? {
@@ -31,9 +40,7 @@ pub fn run(
             warn_ignored_params(params, "no operation specified");
             display_operations(ops, format)
         }
-        ResolvedOperation::Exact(_) => {
-            execute(client, &cat, plugin, &query, params, options, format)
-        }
+        ResolvedOperation::Exact(op) => execute(client, &cat, op, plugin, params, options, format),
         ResolvedOperation::Prefix(matches) => {
             let n = matches.len();
             let reason = format!(
@@ -55,25 +62,35 @@ pub fn invoke(
     options: InvokeOptions<'_>,
     format: Format,
 ) -> Result<()> {
-    let cat = catalog::fetch_catalog(client, plugin)?;
-    execute(client, &cat, plugin, operation, params, options, format)
+    let cat = catalog::fetch_catalog(
+        client,
+        plugin,
+        CatalogSelectors {
+            connection: options.connection,
+            instance: options.instance,
+        },
+    )?;
+    let op = cat
+        .find_operation(operation)
+        .ok_or_else(|| anyhow::anyhow!("operation '{}' not found", operation))?;
+    execute(client, &cat, op, plugin, params, options, format)
 }
 
 pub fn list_operations(client: &ApiClient, plugin: &str, format: Format) -> Result<()> {
-    let cat = catalog::fetch_catalog(client, plugin)?;
+    let cat = catalog::fetch_catalog(client, plugin, CatalogSelectors::default())?;
     display_operations(cat.operations(), format)
 }
 
 fn execute(
     client: &ApiClient,
     cat: &OperationsCatalog,
+    op: &CatalogOperation,
     plugin: &str,
-    operation: &str,
     params: &[ParamEntry],
     options: InvokeOptions<'_>,
     format: Format,
 ) -> Result<()> {
-    let mut param_map = params::assemble_params(params, Some(cat), operation)?;
+    let mut param_map = params::assemble_params(params, Some(cat), &op.id)?;
 
     if let Some(file_path) = options.input_file {
         let file_map = params::load_input_file(file_path)?;
@@ -93,12 +110,13 @@ fn execute(
         );
     }
 
-    let path = format!("/api/v1/{}/{}", plugin, operation);
-    let resp = (if param_map.is_empty() {
-        client.get(&path)
-    } else {
-        client.post(&path, &serde_json::Value::Object(param_map))
-    })
+    let path = format!("/api/v1/{}/{}", plugin, op.id);
+    let method = resolve_invocation_method(op, param_map.is_empty())?;
+    let resp = match method {
+        Method::GET => client.get_with_query(&path, &build_query_pairs(&param_map)?),
+        Method::POST => client.post(&path, &serde_json::Value::Object(param_map)),
+        _ => unreachable!("only GET and POST are supported"),
+    }
     .map_err(|err| {
         let message = err.to_string();
         if !message.contains("no token stored for integration") {
@@ -121,7 +139,7 @@ fn execute(
             connect_command,
         )
     })
-    .with_context(|| format!("failed to invoke {}.{}", plugin, operation))?;
+    .with_context(|| format!("failed to invoke {}.{}", plugin, op.id))?;
 
     let output_value = match options.select {
         Some(sel_path) => output::select_path(&resp, sel_path)?,
@@ -134,6 +152,74 @@ fn execute(
     }
 
     Ok(())
+}
+
+fn resolve_invocation_method(op: &CatalogOperation, params_empty: bool) -> Result<Method> {
+    let method = op.method.trim();
+    if method.eq_ignore_ascii_case("GET") {
+        return Ok(Method::GET);
+    }
+    if method.eq_ignore_ascii_case("POST") {
+        return Ok(Method::POST);
+    }
+    if method.is_empty() {
+        // Compatibility fallback for older catalogs that omit method metadata.
+        return Ok(if params_empty {
+            Method::GET
+        } else {
+            Method::POST
+        });
+    }
+    anyhow::bail!(
+        "unsupported operation method '{}' for '{}'; expected GET or POST",
+        op.method,
+        op.id
+    );
+}
+
+fn build_query_pairs(
+    params: &serde_json::Map<String, serde_json::Value>,
+) -> Result<Vec<(String, String)>> {
+    let mut query = Vec::new();
+    for (key, value) in params {
+        append_query_pairs(&mut query, key, value)?;
+    }
+    Ok(query)
+}
+
+fn append_query_pairs(
+    query: &mut Vec<(String, String)>,
+    key: &str,
+    value: &serde_json::Value,
+) -> Result<()> {
+    match value {
+        serde_json::Value::Array(items) => {
+            for item in items {
+                query.push((key.to_string(), query_value(key, item)?));
+            }
+        }
+        _ => query.push((key.to_string(), query_value(key, value)?)),
+    }
+    Ok(())
+}
+
+fn query_value(key: &str, value: &serde_json::Value) -> Result<String> {
+    match value {
+        serde_json::Value::String(s) => Ok(s.clone()),
+        serde_json::Value::Bool(_) | serde_json::Value::Number(_) => Ok(value.to_string()),
+        serde_json::Value::Null => anyhow::bail!(
+            "GET query parameter '{}' cannot be null; omit it or use POST",
+            key
+        ),
+        serde_json::Value::Array(_) => anyhow::bail!(
+            "GET query parameter '{}' must be a scalar or flat array of scalars",
+            key
+        ),
+        serde_json::Value::Object(_) => anyhow::bail!(
+            "GET query parameter '{}' cannot be an object; use POST for structured input",
+            key
+        ),
+    }
 }
 
 fn display_operations<'a>(

--- a/gestalt/cli/src/main.rs
+++ b/gestalt/cli/src/main.rs
@@ -51,9 +51,21 @@ fn run() -> anyhow::Result<()> {
             url,
             format,
         ),
-        Commands::Describe { plugin, operation } => {
-            dispatch_plugin_command(PluginCommands::Describe { plugin, operation }, url, format)
-        }
+        Commands::Describe {
+            plugin,
+            operation,
+            connection,
+            instance,
+        } => dispatch_plugin_command(
+            PluginCommands::Describe {
+                plugin,
+                operation,
+                connection,
+                instance,
+            },
+            url,
+            format,
+        ),
         Commands::Tokens { command } => {
             let client = ApiClient::from_env(url)?;
             match command {
@@ -111,9 +123,21 @@ fn dispatch_plugin_command(
             },
             format,
         ),
-        PluginCommands::Describe { plugin, operation } => {
-            commands::describe::describe(&client, &plugin, &operation, format)
-        }
+        PluginCommands::Describe {
+            plugin,
+            operation,
+            connection,
+            instance,
+        } => commands::describe::describe(
+            &client,
+            &plugin,
+            &operation,
+            commands::describe::DescribeOptions {
+                connection: connection.as_deref(),
+                instance: instance.as_deref(),
+            },
+            format,
+        ),
     }
 }
 

--- a/gestalt/cli/tests/integration.rs
+++ b/gestalt/cli/tests/integration.rs
@@ -471,6 +471,30 @@ fn test_connection_error_shows_actionable_message() {
 }
 
 #[test]
+fn test_success_response_normalization_handles_no_content_and_empty_body() {
+    let mut server = Server::new();
+    let no_content = authed_json_mock!(
+        server,
+        Method::GET,
+        "/api/v1/no-content",
+        StatusCode::NO_CONTENT
+    )
+    .create();
+    let empty_body = authed_json_mock!(server, Method::GET, "/api/v1/empty-body", StatusCode::OK)
+        .with_body("")
+        .create();
+
+    let client = create_client(&server);
+    let no_content_resp = client.get("/api/v1/no-content").unwrap();
+    let empty_body_resp = client.get("/api/v1/empty-body").unwrap();
+
+    no_content.assert();
+    empty_body.assert();
+    assert_eq!(no_content_resp, serde_json::json!({"status":"ok"}));
+    assert_eq!(empty_body_resp, serde_json::json!({}));
+}
+
+#[test]
 fn test_list_operations_formats_parameters() {
     let mut server = Server::new();
     let mock = authed_json_mock!(
@@ -1256,7 +1280,7 @@ fn test_invoke_with_connection_and_instance() {
     let _catalog_mock = json_mock!(
         server,
         Method::GET,
-        "/api/v1/integrations/test_svc/operations",
+        "/api/v1/integrations/test_svc/operations?_connection=workspace&_instance=team-a",
         StatusCode::OK
     )
     .with_body(catalog_body())
@@ -1300,7 +1324,7 @@ fn test_invoke_with_connection_and_instance() {
     let _secondary_catalog_mock = authed_json_mock!(
         server,
         Method::GET,
-        "/api/v1/integrations/other_svc/operations",
+        "/api/v1/integrations/other_svc/operations?_connection=workspace&_instance=team-a",
         StatusCode::OK
     )
     .with_body(single_operation_catalog("check_status"))
@@ -1356,8 +1380,13 @@ fn test_describe_operation() {
     .create();
 
     let client = create_client(&server);
-    let result =
-        gestalt::commands::describe::describe(&client, "test_svc", "do_thing", Format::Table);
+    let result = gestalt::commands::describe::describe(
+        &client,
+        "test_svc",
+        "do_thing",
+        gestalt::commands::describe::DescribeOptions::default(),
+        Format::Table,
+    );
 
     mock.assert();
     assert!(result.is_ok());
@@ -1378,6 +1407,40 @@ fn test_describe_operation() {
         "stderr: {}",
         String::from_utf8_lossy(&output.stderr)
     );
+    mock.assert();
+}
+
+#[test]
+fn test_cli_describe_operation_scopes_catalog_by_connection_and_instance() {
+    let mut server = Server::new();
+    let mock = authed_json_mock!(
+        server,
+        Method::GET,
+        "/api/v1/integrations/test_svc/operations?_connection=workspace&_instance=team-a",
+        StatusCode::OK
+    )
+    .with_body(catalog_body())
+    .create();
+
+    let home = tempfile::tempdir().unwrap();
+    cli_command_for_server(home.path(), &server)
+        .args([
+            "plugins",
+            "describe",
+            "test_svc",
+            "do_thing",
+            "--connection",
+            "workspace",
+            "--instance",
+            "team-a",
+            "--format",
+            "json",
+        ])
+        .assert()
+        .success()
+        .stdout(predicate::str::contains("\"id\": \"do_thing\""))
+        .stdout(predicate::str::contains("\"method\": \"POST\""));
+
     mock.assert();
 }
 
@@ -1592,6 +1655,459 @@ fn test_cli_invoke_merges_file_params_and_selects_output() {
 }
 
 #[test]
+fn test_cli_invoke_get_uses_query_params_and_scoped_catalog() {
+    let mut server = Server::new();
+    let home = TempDir::new().unwrap();
+    let _catalog_mock = authed_json_mock!(
+        server,
+        Method::GET,
+        "/api/v1/integrations/test_svc/operations?_connection=workspace&_instance=team-a",
+        StatusCode::OK
+    )
+    .with_body(
+        r#"[{
+            "id":"search",
+            "description":"Search items",
+            "method":"GET",
+            "parameters":[{"name":"query","type":"string","location":"query","required":true}]
+        }]"#,
+    )
+    .create();
+
+    let invoke_mock = authed_json_mock!(
+        server,
+        Method::GET,
+        "/api/v1/test_svc/search",
+        StatusCode::OK
+    )
+    .match_query(Matcher::AllOf(vec![
+        Matcher::UrlEncoded("query".into(), "hello".into()),
+        Matcher::UrlEncoded("_connection".into(), "workspace".into()),
+        Matcher::UrlEncoded("_instance".into(), "team-a".into()),
+    ]))
+    .with_body(r#"{"ok":true}"#)
+    .create();
+
+    cli_command_for_server(home.path(), &server)
+        .args([
+            "plugins",
+            "invoke",
+            "test_svc",
+            "search",
+            "--connection",
+            "workspace",
+            "--instance",
+            "team-a",
+            "-p",
+            "query=hello",
+        ])
+        .assert()
+        .success()
+        .stdout(predicate::str::contains("ok"));
+
+    invoke_mock.assert();
+}
+
+#[test]
+fn test_cli_invoke_get_supports_typed_scalar_query_params() {
+    let mut server = Server::new();
+    let home = TempDir::new().unwrap();
+    let _catalog_mock = authed_json_mock!(
+        server,
+        Method::GET,
+        "/api/v1/integrations/test_svc/operations",
+        StatusCode::OK
+    )
+    .with_body(
+        r#"[{
+            "id":"search",
+            "description":"Search items",
+            "method":"GET",
+            "parameters":[
+                {"name":"limit","type":"integer","location":"query"},
+                {"name":"exact","type":"boolean","location":"query"}
+            ]
+        }]"#,
+    )
+    .create();
+
+    let invoke_mock = authed_json_mock!(
+        server,
+        Method::GET,
+        "/api/v1/test_svc/search",
+        StatusCode::OK
+    )
+    .match_query(Matcher::AllOf(vec![
+        Matcher::UrlEncoded("limit".into(), "10".into()),
+        Matcher::UrlEncoded("exact".into(), "true".into()),
+    ]))
+    .with_body(r#"{"ok":true}"#)
+    .create();
+
+    cli_command_for_server(home.path(), &server)
+        .args([
+            "plugins",
+            "invoke",
+            "test_svc",
+            "search",
+            "-p",
+            "limit:=10",
+            "-p",
+            "exact:=true",
+        ])
+        .assert()
+        .success()
+        .stdout(predicate::str::contains("ok"));
+
+    invoke_mock.assert();
+}
+
+#[test]
+fn test_cli_invoke_get_without_query_params_uses_get_transport() {
+    let mut server = Server::new();
+    let home = TempDir::new().unwrap();
+    let _catalog_mock = authed_json_mock!(
+        server,
+        Method::GET,
+        "/api/v1/integrations/test_svc/operations",
+        StatusCode::OK
+    )
+    .with_body(
+        r#"[{
+            "id":"list_items",
+            "description":"List items",
+            "method":"GET",
+            "parameters":[]
+        }]"#,
+    )
+    .create();
+
+    let invoke_mock = authed_json_mock!(
+        server,
+        Method::GET,
+        "/api/v1/test_svc/list_items",
+        StatusCode::OK
+    )
+    .with_body(r#"{"items":[]}"#)
+    .create();
+
+    cli_command_for_server(home.path(), &server)
+        .args(["plugins", "invoke", "test_svc", "list_items"])
+        .assert()
+        .success()
+        .stdout(predicate::str::contains("items"));
+
+    invoke_mock.assert();
+}
+
+#[test]
+fn test_cli_invoke_get_without_business_params_keeps_selectors() {
+    let mut server = Server::new();
+    let home = TempDir::new().unwrap();
+    let _catalog_mock = authed_json_mock!(
+        server,
+        Method::GET,
+        "/api/v1/integrations/test_svc/operations?_connection=workspace&_instance=team-a",
+        StatusCode::OK
+    )
+    .with_body(
+        r#"[{
+            "id":"list_items",
+            "description":"List items",
+            "method":"GET",
+            "parameters":[]
+        }]"#,
+    )
+    .create();
+
+    let invoke_mock = authed_json_mock!(
+        server,
+        Method::GET,
+        "/api/v1/test_svc/list_items",
+        StatusCode::OK
+    )
+    .match_query(Matcher::AllOf(vec![
+        Matcher::UrlEncoded("_connection".into(), "workspace".into()),
+        Matcher::UrlEncoded("_instance".into(), "team-a".into()),
+    ]))
+    .with_body(r#"{"items":[]}"#)
+    .create();
+
+    cli_command_for_server(home.path(), &server)
+        .args([
+            "plugins",
+            "invoke",
+            "test_svc",
+            "list_items",
+            "--connection",
+            "workspace",
+            "--instance",
+            "team-a",
+        ])
+        .assert()
+        .success()
+        .stdout(predicate::str::contains("items"));
+
+    invoke_mock.assert();
+}
+
+#[test]
+fn test_cli_invoke_legacy_catalog_without_method_uses_post_when_params_present() {
+    let mut server = Server::new();
+    let home = TempDir::new().unwrap();
+    let _catalog_mock = authed_json_mock!(
+        server,
+        Method::GET,
+        "/api/v1/integrations/test_svc/operations",
+        StatusCode::OK
+    )
+    .with_body(
+        r#"[{
+            "id":"do_thing",
+            "description":"Does a thing",
+            "parameters":[{"name":"name","type":"string","required":true}]
+        }]"#,
+    )
+    .create();
+
+    let invoke_mock = authed_json_mock!(
+        server,
+        Method::POST,
+        "/api/v1/test_svc/do_thing",
+        StatusCode::OK
+    )
+    .match_header(header::CONTENT_TYPE.as_str(), http::APPLICATION_JSON)
+    .match_body(Matcher::JsonString(r#"{"name":"legacy"}"#.to_string()))
+    .with_body(r#"{"ok":true}"#)
+    .create();
+
+    cli_command_for_server(home.path(), &server)
+        .args([
+            "plugins",
+            "invoke",
+            "test_svc",
+            "do_thing",
+            "-p",
+            "name=legacy",
+        ])
+        .assert()
+        .success()
+        .stdout(predicate::str::contains("ok"));
+
+    invoke_mock.assert();
+}
+
+#[test]
+fn test_cli_invoke_get_rejects_structured_query_values() {
+    let mut server = Server::new();
+    let home = TempDir::new().unwrap();
+    let _catalog_mock = authed_json_mock!(
+        server,
+        Method::GET,
+        "/api/v1/integrations/test_svc/operations",
+        StatusCode::OK
+    )
+    .with_body(
+        r#"[{
+            "id":"search",
+            "description":"Search items",
+            "method":"GET",
+            "parameters":[{"name":"filter","type":"object","location":"query"}]
+        }]"#,
+    )
+    .create();
+
+    cli_command_for_server(home.path(), &server)
+        .args([
+            "plugins",
+            "invoke",
+            "test_svc",
+            "search",
+            "-p",
+            "filter:={\"status\":\"open\"}",
+        ])
+        .assert()
+        .failure()
+        .stderr(predicate::str::contains(
+            "GET query parameter 'filter' cannot be an object",
+        ));
+}
+
+#[test]
+fn test_cli_invoke_legacy_catalog_without_method_uses_get_when_params_absent() {
+    let mut server = Server::new();
+    let home = TempDir::new().unwrap();
+    let _catalog_mock = authed_json_mock!(
+        server,
+        Method::GET,
+        "/api/v1/integrations/test_svc/operations",
+        StatusCode::OK
+    )
+    .with_body(single_operation_catalog("list_items"))
+    .create();
+
+    let invoke_mock = authed_json_mock!(
+        server,
+        Method::GET,
+        "/api/v1/test_svc/list_items",
+        StatusCode::OK
+    )
+    .with_body(r#"{"items":[]}"#)
+    .create();
+
+    cli_command_for_server(home.path(), &server)
+        .args(["plugins", "invoke", "test_svc", "list_items"])
+        .assert()
+        .success()
+        .stdout(predicate::str::contains("items"));
+
+    invoke_mock.assert();
+}
+
+#[test]
+fn test_cli_invoke_reads_input_file_from_stdin() {
+    let mut server = Server::new();
+    let home = TempDir::new().unwrap();
+    let _catalog_mock = authed_json_mock!(
+        server,
+        Method::GET,
+        "/api/v1/integrations/test_svc/operations",
+        StatusCode::OK
+    )
+    .with_body(catalog_body())
+    .create();
+
+    let invoke_mock = authed_json_mock!(
+        server,
+        Method::POST,
+        "/api/v1/test_svc/do_thing",
+        StatusCode::OK
+    )
+    .match_header(header::CONTENT_TYPE.as_str(), http::APPLICATION_JSON)
+    .match_body(Matcher::JsonString(
+        r#"{"count":7,"name":"stdin-name"}"#.to_string(),
+    ))
+    .with_body(r#"{"ok":true}"#)
+    .create();
+
+    cli_command_for_server(home.path(), &server)
+        .args([
+            "plugins",
+            "invoke",
+            "test_svc",
+            "do_thing",
+            "--input-file",
+            "-",
+        ])
+        .write_stdin("{\"count\":7,\"name\":\"stdin-name\"}")
+        .assert()
+        .success()
+        .stdout(predicate::str::contains("ok"));
+
+    invoke_mock.assert();
+}
+
+#[test]
+fn test_cli_invoke_rejects_invalid_json_from_stdin_input_file() {
+    let mut server = Server::new();
+    let home = TempDir::new().unwrap();
+    let _catalog_mock = authed_json_mock!(
+        server,
+        Method::GET,
+        "/api/v1/integrations/test_svc/operations",
+        StatusCode::OK
+    )
+    .with_body(catalog_body())
+    .create();
+
+    cli_command_for_server(home.path(), &server)
+        .args([
+            "plugins",
+            "invoke",
+            "test_svc",
+            "do_thing",
+            "--input-file",
+            "-",
+        ])
+        .write_stdin("{not-json")
+        .assert()
+        .failure()
+        .stderr(predicate::str::contains(
+            "failed to parse input file as JSON",
+        ));
+}
+
+#[test]
+fn test_cli_invoke_rejects_non_object_json_from_stdin_input_file() {
+    let mut server = Server::new();
+    let home = TempDir::new().unwrap();
+    let _catalog_mock = authed_json_mock!(
+        server,
+        Method::GET,
+        "/api/v1/integrations/test_svc/operations",
+        StatusCode::OK
+    )
+    .with_body(catalog_body())
+    .create();
+
+    cli_command_for_server(home.path(), &server)
+        .args([
+            "plugins",
+            "invoke",
+            "test_svc",
+            "do_thing",
+            "--input-file",
+            "-",
+        ])
+        .write_stdin("[1,2,3]")
+        .assert()
+        .failure()
+        .stderr(predicate::str::contains(
+            "input file must contain a JSON object",
+        ));
+}
+
+#[test]
+fn test_cli_invoke_invalid_select_path_fails() {
+    let mut server = Server::new();
+    let home = TempDir::new().unwrap();
+    let _catalog_mock = authed_json_mock!(
+        server,
+        Method::GET,
+        "/api/v1/integrations/test_svc/operations",
+        StatusCode::OK
+    )
+    .with_body(catalog_body())
+    .create();
+
+    let invoke_mock = authed_json_mock!(
+        server,
+        Method::POST,
+        "/api/v1/test_svc/do_thing",
+        StatusCode::OK
+    )
+    .with_body(r#"{"result":{"id":"1"}}"#)
+    .create();
+
+    cli_command_for_server(home.path(), &server)
+        .args([
+            "plugins",
+            "invoke",
+            "test_svc",
+            "do_thing",
+            "--select",
+            "result.missing",
+        ])
+        .assert()
+        .failure()
+        .stderr(predicate::str::contains(
+            "key 'missing' not found in response",
+        ));
+
+    invoke_mock.assert();
+}
+
+#[test]
 fn test_cli_invoke_table_keeps_nested_json_inline() {
     let mut server = Server::new();
     let home = TempDir::new().unwrap();
@@ -1606,7 +2122,7 @@ fn test_cli_invoke_table_keeps_nested_json_inline() {
 
     let invoke_mock = authed_json_mock!(
         server,
-        Method::GET,
+        Method::POST,
         "/api/v1/test_svc/do_thing",
         StatusCode::OK
     )
@@ -1727,6 +2243,36 @@ fn test_prefix_match_shows_filtered_table() {
 }
 
 #[test]
+fn test_prefix_match_scopes_catalog_by_connection_and_instance() {
+    let mut server = Server::new();
+    let _catalog_mock = authed_json_mock!(
+        server,
+        Method::GET,
+        "/api/v1/integrations/test_svc/operations?_connection=workspace&_instance=team-a",
+        StatusCode::OK
+    )
+    .with_body(multi_operation_catalog())
+    .create();
+
+    let home = TempDir::new().unwrap();
+    cli_command_for_server(home.path(), &server)
+        .args([
+            "plugins",
+            "invoke",
+            "test_svc",
+            "widgets",
+            "--connection",
+            "workspace",
+            "--instance",
+            "team-a",
+        ])
+        .assert()
+        .success()
+        .stdout(predicate::str::contains("widgets.create"))
+        .stdout(predicate::str::contains("widgets.bulk.create"));
+}
+
+#[test]
 fn test_space_separated_segments_invoke() {
     let mut server = Server::new();
     let _catalog_mock = authed_json_mock!(
@@ -1770,7 +2316,7 @@ fn test_space_separated_segments_invoke() {
     // Three segments join to "widgets.bulk.create"
     let deep_mock = authed_json_mock!(
         server,
-        Method::GET,
+        Method::POST,
         "/api/v1/test_svc/widgets.bulk.create",
         StatusCode::OK
     )
@@ -1791,7 +2337,7 @@ fn test_space_separated_segments_invoke() {
     // "plugins invoke" subcommand resolves the same way
     let subcommand_mock = authed_json_mock!(
         server,
-        Method::GET,
+        Method::POST,
         "/api/v1/test_svc/widgets.delete",
         StatusCode::OK
     )


### PR DESCRIPTION
## Summary
This PR makes the CLI load selector-scoped operation catalogs and invoke operations using the catalog-declared HTTP method instead of the old `params-empty => GET / params-present => POST` heuristic.

It also collapses GET transport onto a single primitive and adds transport-level integration coverage for:
- selector-scoped catalog fetches
- explicit GET invocations with query params
- explicit GET invocations with no params
- legacy catalogs with no `method` falling back to `GET`/`POST`
- `--input-file -` stdin JSON handling
- invalid `--select`
- 204 / empty-body response normalization

## Rust interface
```rust
use gestalt::catalog::{fetch_catalog, CatalogSelectors};
use gestalt::commands::describe::{describe, DescribeOptions};
use gestalt::commands::invoke::{run, InvokeOptions};

let catalog = fetch_catalog(
    &client,
    "test_svc",
    CatalogSelectors {
        connection: Some("workspace"),
        instance: Some("team-a"),
    },
)?;

describe(
    &client,
    "test_svc",
    "do_thing",
    DescribeOptions {
        connection: Some("workspace"),
        instance: Some("team-a"),
    },
    gestalt::output::Format::Json,
)?;

run(
    &client,
    "test_svc",
    &["search".to_string()],
    &[],
    InvokeOptions {
        connection: Some("workspace"),
        instance: Some("team-a"),
        select: None,
        input_file: None,
    },
    gestalt::output::Format::Json,
)?;
```

New transport helper used by both selector-scoped catalog fetches and GET invocations:
```rust
let resp = client.get_with_query(
    "/api/v1/integrations/test_svc/operations",
    &[("_connection", "workspace"), ("_instance", "team-a")],
)?;
```

## stdin/stdout examples
```sh
# Describe against a selector-scoped catalog
 gestaltd plugins describe test_svc do_thing --connection workspace --instance team-a --format json

# Invoke a catalog-declared GET operation with query params
 gestalt plugins invoke test_svc search --connection workspace --instance team-a -p query=hello

# Invoke with stdin-fed JSON params
 printf '{"count":7,"name":"stdin-name"}' | gestalt plugins invoke test_svc do_thing --input-file -
```

## Testing
```sh
cargo test -p gestalt
```