### PR TITLE
core: centralize provider capability plumbing

### DIFF
--- a/gestaltd/core/integration/base.go
+++ b/gestaltd/core/integration/base.go
@@ -16,10 +16,7 @@ import (
 )
 
 var (
-	_ core.OAuthProvider           = (*Base)(nil)
-	_ core.ManualProvider          = (*Base)(nil)
-	_ core.ConnectionParamProvider = (*Base)(nil)
-	_ core.DiscoveryConfigProvider = (*Base)(nil)
+	_ core.OAuthProvider = (*Base)(nil)
 )
 
 type manualChecker interface{ IsManual() bool }
@@ -85,14 +82,6 @@ func (b *Base) ConnectionMode() core.ConnectionMode {
 	return b.ConnMode
 }
 
-func (b *Base) SupportsManualAuth() bool {
-	if b.ManualAuthEnabled {
-		return true
-	}
-	mc, ok := b.Auth.(manualChecker)
-	return ok && mc.IsManual()
-}
-
 func (b *Base) AuthTypes() []string {
 	mc, ok := b.Auth.(manualChecker)
 	manualOnly := ok && mc.IsManual()
@@ -116,6 +105,8 @@ func (b *Base) CredentialFields() []core.CredentialFieldDef {
 func (b *Base) DiscoveryConfig() *core.DiscoveryConfig {
 	return b.DiscoveryDef
 }
+
+func (b *Base) ConnectionForOperation(string) string { return "" }
 
 func (b *Base) SetCatalog(c *catalog.Catalog) { b.catalog = c }
 

--- a/gestaltd/core/integration/restricted.go
+++ b/gestaltd/core/integration/restricted.go
@@ -35,11 +35,15 @@ func WithAllowedRoles(roles map[string][]string) RestrictedOption {
 
 // Compile-time interface checks.
 var (
-	_ core.Provider       = (*Restricted)(nil)
-	_ core.ManualProvider = (*Restricted)(nil)
-	_ core.AuthTypeLister = (*Restricted)(nil)
-	_ core.OAuthProvider  = (*restrictedOAuth)(nil)
-	_ core.ManualProvider = (*restrictedOAuth)(nil)
+	_ core.Provider                    = (*Restricted)(nil)
+	_ core.ManualProvider              = (*Restricted)(nil)
+	_ core.AuthTypeLister              = (*Restricted)(nil)
+	_ core.OperationConnectionProvider = (*Restricted)(nil)
+	_ core.ConnectionParamProvider     = (*Restricted)(nil)
+	_ core.CredentialFieldsProvider    = (*Restricted)(nil)
+	_ core.DiscoveryConfigProvider     = (*Restricted)(nil)
+	_ core.OAuthProvider               = (*restrictedOAuth)(nil)
+	_ core.ManualProvider              = (*restrictedOAuth)(nil)
 )
 
 // NewRestricted returns a Provider that gates operations to the allowed set.
@@ -119,10 +123,7 @@ func (r *Restricted) Execute(ctx context.Context, operation string, params map[s
 }
 
 func (r *Restricted) SupportsManualAuth() bool {
-	if mp, ok := r.inner.(core.ManualProvider); ok {
-		return mp.SupportsManualAuth()
-	}
-	return false
+	return core.SupportsManualAuth(r.inner)
 }
 
 func (r *Restricted) Catalog() *catalog.Catalog {
@@ -209,22 +210,28 @@ func (r *restrictedOAuth) CatalogForRequest(ctx context.Context, token string) (
 }
 
 func (r *Restricted) AuthTypes() []string {
-	if atl, ok := r.inner.(core.AuthTypeLister); ok {
-		return atl.AuthTypes()
-	}
-	return nil
+	return core.AuthTypes(r.inner)
 }
 
 func (r *Restricted) ConnectionParamDefs() map[string]core.ConnectionParamDef {
-	if cpp, ok := r.inner.(core.ConnectionParamProvider); ok {
-		return cpp.ConnectionParamDefs()
-	}
-	return nil
+	return core.ConnectionParamDefs(r.inner)
 }
 
 func (r *Restricted) CredentialFields() []core.CredentialFieldDef {
-	if cfp, ok := r.inner.(core.CredentialFieldsProvider); ok {
-		return cfp.CredentialFields()
+	return core.CredentialFields(r.inner)
+}
+
+func (r *Restricted) DiscoveryConfig() *core.DiscoveryConfig {
+	return core.DiscoveryConfigFor(r.inner)
+}
+
+func (r *Restricted) ConnectionForOperation(operation string) string {
+	if _, ok := r.allowed[operation]; !ok {
+		return ""
 	}
-	return nil
+	innerOperation := operation
+	if alias, ok := r.aliases[operation]; ok {
+		innerOperation = alias
+	}
+	return core.OperationConnection(r.inner, innerOperation)
 }

--- a/gestaltd/core/integration/restricted.go
+++ b/gestaltd/core/integration/restricted.go
@@ -35,15 +35,8 @@ func WithAllowedRoles(roles map[string][]string) RestrictedOption {
 
 // Compile-time interface checks.
 var (
-	_ core.Provider                    = (*Restricted)(nil)
-	_ core.ManualProvider              = (*Restricted)(nil)
-	_ core.AuthTypeLister              = (*Restricted)(nil)
-	_ core.OperationConnectionProvider = (*Restricted)(nil)
-	_ core.ConnectionParamProvider     = (*Restricted)(nil)
-	_ core.CredentialFieldsProvider    = (*Restricted)(nil)
-	_ core.DiscoveryConfigProvider     = (*Restricted)(nil)
-	_ core.OAuthProvider               = (*restrictedOAuth)(nil)
-	_ core.ManualProvider              = (*restrictedOAuth)(nil)
+	_ core.Provider      = (*Restricted)(nil)
+	_ core.OAuthProvider = (*restrictedOAuth)(nil)
 )
 
 // NewRestricted returns a Provider that gates operations to the allowed set.
@@ -120,10 +113,6 @@ func (r *Restricted) Execute(ctx context.Context, operation string, params map[s
 		innerName = alias
 	}
 	return r.inner.Execute(ctx, innerName, params, token)
-}
-
-func (r *Restricted) SupportsManualAuth() bool {
-	return core.SupportsManualAuth(r.inner)
 }
 
 func (r *Restricted) Catalog() *catalog.Catalog {
@@ -210,19 +199,19 @@ func (r *restrictedOAuth) CatalogForRequest(ctx context.Context, token string) (
 }
 
 func (r *Restricted) AuthTypes() []string {
-	return core.AuthTypes(r.inner)
+	return r.inner.AuthTypes()
 }
 
 func (r *Restricted) ConnectionParamDefs() map[string]core.ConnectionParamDef {
-	return core.ConnectionParamDefs(r.inner)
+	return r.inner.ConnectionParamDefs()
 }
 
 func (r *Restricted) CredentialFields() []core.CredentialFieldDef {
-	return core.CredentialFields(r.inner)
+	return r.inner.CredentialFields()
 }
 
 func (r *Restricted) DiscoveryConfig() *core.DiscoveryConfig {
-	return core.DiscoveryConfigFor(r.inner)
+	return r.inner.DiscoveryConfig()
 }
 
 func (r *Restricted) ConnectionForOperation(operation string) string {
@@ -233,5 +222,5 @@ func (r *Restricted) ConnectionForOperation(operation string) string {
 	if alias, ok := r.aliases[operation]; ok {
 		innerOperation = alias
 	}
-	return core.OperationConnection(r.inner, innerOperation)
+	return r.inner.ConnectionForOperation(innerOperation)
 }

--- a/gestaltd/core/provider.go
+++ b/gestaltd/core/provider.go
@@ -20,6 +20,11 @@ type Provider interface {
 	DisplayName() string
 	Description() string
 	ConnectionMode() ConnectionMode
+	AuthTypes() []string
+	ConnectionParamDefs() map[string]ConnectionParamDef
+	CredentialFields() []CredentialFieldDef
+	DiscoveryConfig() *DiscoveryConfig
+	ConnectionForOperation(operation string) string
 	Catalog() *catalog.Catalog
 	Execute(ctx context.Context, operation string, params map[string]any, token string) (*OperationResult, error)
 }
@@ -31,23 +36,11 @@ type OAuthProvider interface {
 	RefreshToken(ctx context.Context, refreshToken string) (*TokenResponse, error)
 }
 
-type ManualProvider interface {
-	Provider
-	SupportsManualAuth() bool
-}
-
 // SessionCatalogProvider is an optional interface for providers whose MCP tool
 // surface depends on request-scoped authentication and must be resolved after a
 // user is connected.
 type SessionCatalogProvider interface {
 	CatalogForRequest(ctx context.Context, token string) (*catalog.Catalog, error)
-}
-
-// OperationConnectionProvider is an optional interface for providers whose
-// operations should default to different stored connections. This is used by
-// composite providers that route different operations to different backends.
-type OperationConnectionProvider interface {
-	ConnectionForOperation(operation string) string
 }
 
 type ConnectionParamDef struct {
@@ -58,22 +51,10 @@ type ConnectionParamDef struct {
 	Field       string // JSON field name for token_response extraction
 }
 
-type ConnectionParamProvider interface {
-	ConnectionParamDefs() map[string]ConnectionParamDef
-}
-
 type CredentialFieldDef struct {
 	Name        string
 	Label       string
 	Description string
-}
-
-type CredentialFieldsProvider interface {
-	CredentialFields() []CredentialFieldDef
-}
-
-type AuthTypeLister interface {
-	AuthTypes() []string
 }
 
 type DiscoveryCandidate struct {
@@ -88,8 +69,4 @@ type DiscoveryConfig struct {
 	IDPath    string
 	NamePath  string
 	Metadata  map[string]string
-}
-
-type DiscoveryConfigProvider interface {
-	DiscoveryConfig() *DiscoveryConfig
 }

--- a/gestaltd/core/provider_capabilities.go
+++ b/gestaltd/core/provider_capabilities.go
@@ -1,0 +1,81 @@
+package core
+
+import (
+	"context"
+
+	"github.com/valon-technologies/gestalt/server/core/catalog"
+)
+
+func SupportsManualAuth(prov Provider) bool {
+	mp, ok := prov.(ManualProvider)
+	return ok && mp.SupportsManualAuth()
+}
+
+func SupportsOAuth(prov Provider) bool {
+	_, ok := prov.(OAuthProvider)
+	return ok
+}
+
+func SupportsSessionCatalog(prov Provider) bool {
+	_, ok := prov.(SessionCatalogProvider)
+	return ok
+}
+
+func CatalogForRequest(ctx context.Context, prov Provider, token string) (*catalog.Catalog, bool, error) {
+	scp, ok := prov.(SessionCatalogProvider)
+	if !ok {
+		return nil, false, nil
+	}
+	cat, err := scp.CatalogForRequest(ctx, token)
+	return cat, true, err
+}
+
+func OperationConnection(prov Provider, operation string) string {
+	ocp, ok := prov.(OperationConnectionProvider)
+	if !ok {
+		return ""
+	}
+	return ocp.ConnectionForOperation(operation)
+}
+
+func ConnectionParamDefs(prov Provider) map[string]ConnectionParamDef {
+	cpp, ok := prov.(ConnectionParamProvider)
+	if !ok {
+		return nil
+	}
+	return cpp.ConnectionParamDefs()
+}
+
+func HasConnectionParamDefs(prov Provider) bool {
+	_, ok := prov.(ConnectionParamProvider)
+	return ok
+}
+
+func CredentialFields(prov Provider) []CredentialFieldDef {
+	cfp, ok := prov.(CredentialFieldsProvider)
+	if !ok {
+		return nil
+	}
+	return cfp.CredentialFields()
+}
+
+func AuthTypes(prov Provider) []string {
+	atl, ok := prov.(AuthTypeLister)
+	if !ok {
+		return nil
+	}
+	return atl.AuthTypes()
+}
+
+func HasAuthTypes(prov Provider) bool {
+	_, ok := prov.(AuthTypeLister)
+	return ok
+}
+
+func DiscoveryConfigFor(prov Provider) *DiscoveryConfig {
+	dcp, ok := prov.(DiscoveryConfigProvider)
+	if !ok {
+		return nil
+	}
+	return dcp.DiscoveryConfig()
+}

--- a/gestaltd/core/provider_capabilities.go
+++ b/gestaltd/core/provider_capabilities.go
@@ -6,16 +6,6 @@ import (
 	"github.com/valon-technologies/gestalt/server/core/catalog"
 )
 
-func SupportsManualAuth(prov Provider) bool {
-	mp, ok := prov.(ManualProvider)
-	return ok && mp.SupportsManualAuth()
-}
-
-func SupportsOAuth(prov Provider) bool {
-	_, ok := prov.(OAuthProvider)
-	return ok
-}
-
 func SupportsSessionCatalog(prov Provider) bool {
 	_, ok := prov.(SessionCatalogProvider)
 	return ok
@@ -28,54 +18,4 @@ func CatalogForRequest(ctx context.Context, prov Provider, token string) (*catal
 	}
 	cat, err := scp.CatalogForRequest(ctx, token)
 	return cat, true, err
-}
-
-func OperationConnection(prov Provider, operation string) string {
-	ocp, ok := prov.(OperationConnectionProvider)
-	if !ok {
-		return ""
-	}
-	return ocp.ConnectionForOperation(operation)
-}
-
-func ConnectionParamDefs(prov Provider) map[string]ConnectionParamDef {
-	cpp, ok := prov.(ConnectionParamProvider)
-	if !ok {
-		return nil
-	}
-	return cpp.ConnectionParamDefs()
-}
-
-func HasConnectionParamDefs(prov Provider) bool {
-	_, ok := prov.(ConnectionParamProvider)
-	return ok
-}
-
-func CredentialFields(prov Provider) []CredentialFieldDef {
-	cfp, ok := prov.(CredentialFieldsProvider)
-	if !ok {
-		return nil
-	}
-	return cfp.CredentialFields()
-}
-
-func AuthTypes(prov Provider) []string {
-	atl, ok := prov.(AuthTypeLister)
-	if !ok {
-		return nil
-	}
-	return atl.AuthTypes()
-}
-
-func HasAuthTypes(prov Provider) bool {
-	_, ok := prov.(AuthTypeLister)
-	return ok
-}
-
-func DiscoveryConfigFor(prov Provider) *DiscoveryConfig {
-	dcp, ok := prov.(DiscoveryConfigProvider)
-	if !ok {
-		return nil
-	}
-	return dcp.DiscoveryConfig()
 }

--- a/gestaltd/core/testing/stubs.go
+++ b/gestaltd/core/testing/stubs.go
@@ -75,14 +75,14 @@ func (s *StubIntegration) ConnectionMode() core.ConnectionMode {
 	}
 	return s.ConnMode
 }
-func (s *StubIntegration) AuthTypes() []string                           { return nil }
+func (s *StubIntegration) AuthTypes() []string { return nil }
 func (s *StubIntegration) ConnectionParamDefs() map[string]core.ConnectionParamDef {
 	return nil
 }
 func (s *StubIntegration) CredentialFields() []core.CredentialFieldDef { return nil }
 func (s *StubIntegration) DiscoveryConfig() *core.DiscoveryConfig      { return nil }
 func (s *StubIntegration) ConnectionForOperation(string) string        { return "" }
-func (s *StubIntegration) AuthorizationURL(string, []string) string { return "" }
+func (s *StubIntegration) AuthorizationURL(string, []string) string    { return "" }
 func (s *StubIntegration) ExchangeCode(ctx context.Context, code string) (*core.TokenResponse, error) {
 	if s.ExchangeCodeFn != nil {
 		return s.ExchangeCodeFn(ctx, code)

--- a/gestaltd/core/testing/stubs.go
+++ b/gestaltd/core/testing/stubs.go
@@ -75,6 +75,13 @@ func (s *StubIntegration) ConnectionMode() core.ConnectionMode {
 	}
 	return s.ConnMode
 }
+func (s *StubIntegration) AuthTypes() []string                           { return nil }
+func (s *StubIntegration) ConnectionParamDefs() map[string]core.ConnectionParamDef {
+	return nil
+}
+func (s *StubIntegration) CredentialFields() []core.CredentialFieldDef { return nil }
+func (s *StubIntegration) DiscoveryConfig() *core.DiscoveryConfig      { return nil }
+func (s *StubIntegration) ConnectionForOperation(string) string        { return "" }
 func (s *StubIntegration) AuthorizationURL(string, []string) string { return "" }
 func (s *StubIntegration) ExchangeCode(ctx context.Context, code string) (*core.TokenResponse, error) {
 	if s.ExchangeCodeFn != nil {

--- a/gestaltd/internal/bootstrap/validate.go
+++ b/gestaltd/internal/bootstrap/validate.go
@@ -142,6 +142,13 @@ func (p *preparedProviderStub) Name() string                        { return p.n
 func (p *preparedProviderStub) DisplayName() string                 { return p.displayName }
 func (p *preparedProviderStub) Description() string                 { return p.description }
 func (p *preparedProviderStub) ConnectionMode() core.ConnectionMode { return p.connectionMode }
+func (p *preparedProviderStub) AuthTypes() []string                 { return nil }
+func (p *preparedProviderStub) ConnectionParamDefs() map[string]core.ConnectionParamDef {
+	return nil
+}
+func (p *preparedProviderStub) CredentialFields() []core.CredentialFieldDef { return nil }
+func (p *preparedProviderStub) DiscoveryConfig() *core.DiscoveryConfig      { return nil }
+func (p *preparedProviderStub) ConnectionForOperation(string) string        { return "" }
 func (p *preparedProviderStub) Catalog() *catalog.Catalog {
 	return &catalog.Catalog{
 		Name:        p.name,

--- a/gestaltd/internal/composite/merged.go
+++ b/gestaltd/internal/composite/merged.go
@@ -25,8 +25,7 @@ type BoundProvider struct {
 }
 
 var (
-	_ core.Provider                    = (*MergedProvider)(nil)
-	_ core.OperationConnectionProvider = (*MergedProvider)(nil)
+	_ core.Provider = (*MergedProvider)(nil)
 )
 
 func NewMergedWithConnections(name, displayName, desc, iconSVG string, providers ...BoundProvider) (*MergedProvider, error) {
@@ -77,6 +76,12 @@ func (m *MergedProvider) Name() string                        { return m.catalog
 func (m *MergedProvider) DisplayName() string                 { return m.catalog.DisplayName }
 func (m *MergedProvider) Description() string                 { return m.catalog.Description }
 func (m *MergedProvider) ConnectionMode() core.ConnectionMode { return m.connMode }
+func (m *MergedProvider) AuthTypes() []string                 { return nil }
+func (m *MergedProvider) ConnectionParamDefs() map[string]core.ConnectionParamDef {
+	return nil
+}
+func (m *MergedProvider) CredentialFields() []core.CredentialFieldDef { return nil }
+func (m *MergedProvider) DiscoveryConfig() *core.DiscoveryConfig      { return nil }
 func (m *MergedProvider) ConnectionForOperation(op string) string {
 	return m.opConn[op]
 }

--- a/gestaltd/internal/composite/merged_test.go
+++ b/gestaltd/internal/composite/merged_test.go
@@ -22,6 +22,13 @@ func (p *fakeProvider) Name() string                        { return p.name }
 func (p *fakeProvider) DisplayName() string                 { return p.name }
 func (p *fakeProvider) Description() string                 { return "" }
 func (p *fakeProvider) ConnectionMode() core.ConnectionMode { return p.connMode }
+func (p *fakeProvider) AuthTypes() []string                 { return nil }
+func (p *fakeProvider) ConnectionParamDefs() map[string]core.ConnectionParamDef {
+	return nil
+}
+func (p *fakeProvider) CredentialFields() []core.CredentialFieldDef { return nil }
+func (p *fakeProvider) DiscoveryConfig() *core.DiscoveryConfig      { return nil }
+func (p *fakeProvider) ConnectionForOperation(string) string        { return "" }
 func (p *fakeProvider) Catalog() *catalog.Catalog {
 	cat := &catalog.Catalog{
 		Name:       p.name,

--- a/gestaltd/internal/composite/provider.go
+++ b/gestaltd/internal/composite/provider.go
@@ -27,13 +27,8 @@ type Provider struct {
 }
 
 var (
-	_ core.Provider                    = (*Provider)(nil)
-	_ core.SessionCatalogProvider      = (*Provider)(nil)
-	_ core.OperationConnectionProvider = (*Provider)(nil)
-	_ core.AuthTypeLister              = (*Provider)(nil)
-	_ core.ConnectionParamProvider     = (*Provider)(nil)
-	_ core.CredentialFieldsProvider    = (*Provider)(nil)
-	_ core.DiscoveryConfigProvider     = (*Provider)(nil)
+	_ core.Provider               = (*Provider)(nil)
+	_ core.SessionCatalogProvider = (*Provider)(nil)
 )
 
 // New creates a composite provider. If the API provider implements
@@ -93,7 +88,7 @@ func (p *Provider) CatalogForRequest(ctx context.Context, token string) (*catalo
 }
 
 func (p *Provider) ConnectionForOperation(operation string) string {
-	return core.OperationConnection(p.api, operation)
+	return p.api.ConnectionForOperation(operation)
 }
 
 func (p *Provider) CallTool(ctx context.Context, name string, args map[string]any) (*mcpgo.CallToolResult, error) {
@@ -102,27 +97,20 @@ func (p *Provider) CallTool(ctx context.Context, name string, args map[string]an
 
 func (p *Provider) Inner() core.Provider { return p.api }
 
-// SupportsManualAuth delegates to the API provider only. The MCP
-// upstream's manual-auth support is irrelevant — the server uses this
-// to decide whether to block the OAuth connection flow.
-func (p *Provider) SupportsManualAuth() bool {
-	return core.SupportsManualAuth(p.api)
-}
-
 func (p *Provider) AuthTypes() []string {
-	return core.AuthTypes(p.api)
+	return p.api.AuthTypes()
 }
 
 func (p *Provider) ConnectionParamDefs() map[string]core.ConnectionParamDef {
-	return core.ConnectionParamDefs(p.api)
+	return p.api.ConnectionParamDefs()
 }
 
 func (p *Provider) CredentialFields() []core.CredentialFieldDef {
-	return core.CredentialFields(p.api)
+	return p.api.CredentialFields()
 }
 
 func (p *Provider) DiscoveryConfig() *core.DiscoveryConfig {
-	return core.DiscoveryConfigFor(p.api)
+	return p.api.DiscoveryConfig()
 }
 
 func (p *Provider) Close() error {

--- a/gestaltd/internal/composite/provider.go
+++ b/gestaltd/internal/composite/provider.go
@@ -27,9 +27,13 @@ type Provider struct {
 }
 
 var (
-	_ core.Provider               = (*Provider)(nil)
-	_ core.SessionCatalogProvider = (*Provider)(nil)
-	_ core.AuthTypeLister         = (*Provider)(nil)
+	_ core.Provider                    = (*Provider)(nil)
+	_ core.SessionCatalogProvider      = (*Provider)(nil)
+	_ core.OperationConnectionProvider = (*Provider)(nil)
+	_ core.AuthTypeLister              = (*Provider)(nil)
+	_ core.ConnectionParamProvider     = (*Provider)(nil)
+	_ core.CredentialFieldsProvider    = (*Provider)(nil)
+	_ core.DiscoveryConfigProvider     = (*Provider)(nil)
 )
 
 // New creates a composite provider. If the API provider implements
@@ -88,6 +92,10 @@ func (p *Provider) CatalogForRequest(ctx context.Context, token string) (*catalo
 	return tagMCPCatalog(cat), nil
 }
 
+func (p *Provider) ConnectionForOperation(operation string) string {
+	return core.OperationConnection(p.api, operation)
+}
+
 func (p *Provider) CallTool(ctx context.Context, name string, args map[string]any) (*mcpgo.CallToolResult, error) {
 	return p.mcp.CallTool(ctx, name, args)
 }
@@ -98,17 +106,23 @@ func (p *Provider) Inner() core.Provider { return p.api }
 // upstream's manual-auth support is irrelevant — the server uses this
 // to decide whether to block the OAuth connection flow.
 func (p *Provider) SupportsManualAuth() bool {
-	if mp, ok := p.api.(core.ManualProvider); ok {
-		return mp.SupportsManualAuth()
-	}
-	return false
+	return core.SupportsManualAuth(p.api)
 }
 
 func (p *Provider) AuthTypes() []string {
-	if atl, ok := p.api.(core.AuthTypeLister); ok {
-		return atl.AuthTypes()
-	}
-	return nil
+	return core.AuthTypes(p.api)
+}
+
+func (p *Provider) ConnectionParamDefs() map[string]core.ConnectionParamDef {
+	return core.ConnectionParamDefs(p.api)
+}
+
+func (p *Provider) CredentialFields() []core.CredentialFieldDef {
+	return core.CredentialFields(p.api)
+}
+
+func (p *Provider) DiscoveryConfig() *core.DiscoveryConfig {
+	return core.DiscoveryConfigFor(p.api)
 }
 
 func (p *Provider) Close() error {

--- a/gestaltd/internal/invocation/broker.go
+++ b/gestaltd/internal/invocation/broker.go
@@ -253,8 +253,8 @@ func (b *Broker) Invoke(ctx context.Context, p *principal.Principal, providerNam
 	if conn == "" {
 		if transport == catalog.TransportMCPPassthrough {
 			conn = b.mcpConnection(providerName)
-		} else if ocp, ok := prov.(core.OperationConnectionProvider); ok {
-			conn = ocp.ConnectionForOperation(operation)
+		} else {
+			conn = core.OperationConnection(prov, operation)
 		}
 	}
 	if conn == "" && b.connMapper != nil {
@@ -298,7 +298,7 @@ func (b *Broker) resolveOperation(ctx context.Context, p *principal.Principal, p
 		return op, catalogOperationTransport(op), nil
 	}
 
-	if _, ok := prov.(core.SessionCatalogProvider); ok {
+	if core.SupportsSessionCatalog(prov) {
 		if connection == "" {
 			connection = b.mcpConnection(providerName)
 		}

--- a/gestaltd/internal/invocation/broker.go
+++ b/gestaltd/internal/invocation/broker.go
@@ -254,7 +254,7 @@ func (b *Broker) Invoke(ctx context.Context, p *principal.Principal, providerNam
 		if transport == catalog.TransportMCPPassthrough {
 			conn = b.mcpConnection(providerName)
 		} else {
-			conn = core.OperationConnection(prov, operation)
+			conn = prov.ConnectionForOperation(operation)
 		}
 	}
 	if conn == "" && b.connMapper != nil {

--- a/gestaltd/internal/invocation/catalog.go
+++ b/gestaltd/internal/invocation/catalog.go
@@ -63,8 +63,7 @@ func resolveCatalog(ctx context.Context, prov core.Provider, provName string, re
 }
 
 func resolveSessionCatalog(ctx context.Context, prov core.Provider, provName string, resolver TokenResolver, p *principal.Principal, connection, instance string) (*catalog.Catalog, bool, error) {
-	scp, ok := prov.(core.SessionCatalogProvider)
-	if !ok {
+	if !core.SupportsSessionCatalog(prov) {
 		return nil, false, nil
 	}
 	if prov.ConnectionMode() == core.ConnectionModeNone {
@@ -73,11 +72,11 @@ func resolveSessionCatalog(ctx context.Context, prov core.Provider, provName str
 			if err != nil {
 				return nil, true, err
 			}
-			cat, err := scp.CatalogForRequest(enrichedCtx, token)
+			cat, _, err := core.CatalogForRequest(enrichedCtx, prov, token)
 			return cat, true, err
 		}
 		ctx = WithCredentialContext(ctx, CredentialContext{Mode: core.ConnectionModeNone})
-		cat, err := scp.CatalogForRequest(ctx, "")
+		cat, _, err := core.CatalogForRequest(ctx, prov, "")
 		return cat, true, err
 	}
 	if resolver == nil || p == nil {
@@ -88,7 +87,7 @@ func resolveSessionCatalog(ctx context.Context, prov core.Provider, provName str
 	if err != nil {
 		return nil, true, err
 	}
-	cat, err := scp.CatalogForRequest(ctx, token)
+	cat, _, err := core.CatalogForRequest(ctx, prov, token)
 	return cat, true, err
 }
 

--- a/gestaltd/internal/mcp/authorization.go
+++ b/gestaltd/internal/mcp/authorization.go
@@ -83,7 +83,7 @@ func catalogOperationForTool(ctx context.Context, cfg Config, providerName, oper
 	if op, _, ok := sessionCatalogOperationFromContext(ctx, providerName, operation, ""); ok {
 		return op, true
 	}
-	if _, sessionCapable := prov.(core.SessionCatalogProvider); sessionCapable &&
+	if core.SupportsSessionCatalog(prov) &&
 		sessionProviderHydrationAttemptedFromContext(ctx, providerName, "") &&
 		!sessionProviderHydratedFromContext(ctx, providerName, "") {
 		return catalog.CatalogOperation{}, false
@@ -91,7 +91,7 @@ func catalogOperationForTool(ctx context.Context, cfg Config, providerName, oper
 	if op, ok := invocation.CatalogOperation(prov.Catalog(), operation); ok && catalogOperationProjectedToMCP(cfg, providerName, op) {
 		return op, true
 	}
-	if _, ok := prov.(core.SessionCatalogProvider); !ok {
+	if !core.SupportsSessionCatalog(prov) {
 		return catalog.CatalogOperation{}, false
 	}
 	return catalog.CatalogOperation{}, false

--- a/gestaltd/internal/mcp/binding.go
+++ b/gestaltd/internal/mcp/binding.go
@@ -60,7 +60,7 @@ func NewServer(cfg Config) *mcpserver.MCPServer {
 			continue
 		}
 
-		if _, ok := prov.(core.SessionCatalogProvider); ok {
+		if core.SupportsSessionCatalog(prov) {
 			dynamicProviders = append(dynamicProviders, provName)
 		}
 

--- a/gestaltd/internal/mcp/composite_test.go
+++ b/gestaltd/internal/mcp/composite_test.go
@@ -34,11 +34,17 @@ func (u *stubMCPUpstream) Description() string { return "" }
 func (u *stubMCPUpstream) ConnectionMode() core.ConnectionMode {
 	return core.ConnectionModeNone
 }
+func (u *stubMCPUpstream) AuthTypes() []string                 { return nil }
+func (u *stubMCPUpstream) ConnectionParamDefs() map[string]core.ConnectionParamDef {
+	return nil
+}
+func (u *stubMCPUpstream) CredentialFields() []core.CredentialFieldDef { return nil }
+func (u *stubMCPUpstream) DiscoveryConfig() *core.DiscoveryConfig      { return nil }
+func (u *stubMCPUpstream) ConnectionForOperation(string) string        { return "" }
 func (u *stubMCPUpstream) Catalog() *catalog.Catalog { return u.cat }
 func (u *stubMCPUpstream) CatalogForRequest(_ context.Context, _ string) (*catalog.Catalog, error) {
 	return u.cat, nil
 }
-func (u *stubMCPUpstream) SupportsManualAuth() bool { return true }
 func (u *stubMCPUpstream) Close() error             { return nil }
 func (u *stubMCPUpstream) Execute(context.Context, string, map[string]any, string) (*core.OperationResult, error) {
 	return nil, core.ErrMCPOnly

--- a/gestaltd/internal/mcp/composite_test.go
+++ b/gestaltd/internal/mcp/composite_test.go
@@ -34,18 +34,18 @@ func (u *stubMCPUpstream) Description() string { return "" }
 func (u *stubMCPUpstream) ConnectionMode() core.ConnectionMode {
 	return core.ConnectionModeNone
 }
-func (u *stubMCPUpstream) AuthTypes() []string                 { return nil }
+func (u *stubMCPUpstream) AuthTypes() []string { return nil }
 func (u *stubMCPUpstream) ConnectionParamDefs() map[string]core.ConnectionParamDef {
 	return nil
 }
 func (u *stubMCPUpstream) CredentialFields() []core.CredentialFieldDef { return nil }
 func (u *stubMCPUpstream) DiscoveryConfig() *core.DiscoveryConfig      { return nil }
 func (u *stubMCPUpstream) ConnectionForOperation(string) string        { return "" }
-func (u *stubMCPUpstream) Catalog() *catalog.Catalog { return u.cat }
+func (u *stubMCPUpstream) Catalog() *catalog.Catalog                   { return u.cat }
 func (u *stubMCPUpstream) CatalogForRequest(_ context.Context, _ string) (*catalog.Catalog, error) {
 	return u.cat, nil
 }
-func (u *stubMCPUpstream) Close() error             { return nil }
+func (u *stubMCPUpstream) Close() error { return nil }
 func (u *stubMCPUpstream) Execute(context.Context, string, map[string]any, string) (*core.OperationResult, error) {
 	return nil, core.ErrMCPOnly
 }

--- a/gestaltd/internal/mcp/handlers.go
+++ b/gestaltd/internal/mcp/handlers.go
@@ -47,7 +47,7 @@ func makeHandler(cfg Config, provName, opName, connection string) mcpserver.Tool
 				ctx = invocation.WithConnection(ctx, sessionConnection)
 			}
 		} else if prov, err := cfg.Providers.Get(provName); err == nil {
-			if _, sessionCapable := prov.(core.SessionCatalogProvider); sessionCapable {
+			if core.SupportsSessionCatalog(prov) {
 				if instance != "" || (sessionProviderHydrationAttemptedFromContext(ctx, provName, "") && !sessionProviderHydratedFromContext(ctx, provName, "")) {
 					return mcpgo.NewToolResultError("requested instance is unavailable for this tool"), nil
 				}

--- a/gestaltd/internal/mcp/session_tools.go
+++ b/gestaltd/internal/mcp/session_tools.go
@@ -64,8 +64,7 @@ func hydrateSessionToolsForInstance(ctx context.Context, cfg Config, providerNam
 			continue
 		}
 
-		scp, ok := prov.(core.SessionCatalogProvider)
-		if !ok {
+		if !core.SupportsSessionCatalog(prov) {
 			continue
 		}
 
@@ -74,7 +73,7 @@ func hydrateSessionToolsForInstance(ctx context.Context, cfg Config, providerNam
 			continue
 		}
 
-		cat, err := scp.CatalogForRequest(sessionCtx, token)
+		cat, _, err := core.CatalogForRequest(sessionCtx, prov, token)
 		if err != nil {
 			continue
 		}

--- a/gestaltd/internal/mcpupstream/upstream.go
+++ b/gestaltd/internal/mcpupstream/upstream.go
@@ -105,6 +105,13 @@ func (u *Upstream) Name() string                        { return u.name }
 func (u *Upstream) DisplayName() string                 { return u.display }
 func (u *Upstream) Description() string                 { return u.desc }
 func (u *Upstream) ConnectionMode() core.ConnectionMode { return u.connMode }
+func (u *Upstream) AuthTypes() []string                 { return nil }
+func (u *Upstream) ConnectionParamDefs() map[string]core.ConnectionParamDef {
+	return nil
+}
+func (u *Upstream) CredentialFields() []core.CredentialFieldDef { return nil }
+func (u *Upstream) DiscoveryConfig() *core.DiscoveryConfig      { return nil }
+func (u *Upstream) ConnectionForOperation(string) string        { return "" }
 func (u *Upstream) Catalog() *catalog.Catalog           { return u.decorateCatalog(u.cat) }
 
 func (u *Upstream) SetDisplayName(s string) { u.display = s }

--- a/gestaltd/internal/mcpupstream/upstream.go
+++ b/gestaltd/internal/mcpupstream/upstream.go
@@ -112,7 +112,7 @@ func (u *Upstream) ConnectionParamDefs() map[string]core.ConnectionParamDef {
 func (u *Upstream) CredentialFields() []core.CredentialFieldDef { return nil }
 func (u *Upstream) DiscoveryConfig() *core.DiscoveryConfig      { return nil }
 func (u *Upstream) ConnectionForOperation(string) string        { return "" }
-func (u *Upstream) Catalog() *catalog.Catalog           { return u.decorateCatalog(u.cat) }
+func (u *Upstream) Catalog() *catalog.Catalog                   { return u.decorateCatalog(u.cat) }
 
 func (u *Upstream) SetDisplayName(s string) { u.display = s }
 func (u *Upstream) SetDescription(s string) { u.desc = s }

--- a/gestaltd/internal/mcpupstream/upstream_test.go
+++ b/gestaltd/internal/mcpupstream/upstream_test.go
@@ -272,8 +272,8 @@ func TestUpstream_ProviderMetadata(t *testing.T) {
 	if u.ConnectionMode() != core.ConnectionModeUser {
 		t.Fatalf("ConnectionMode = %q", u.ConnectionMode())
 	}
-	if _, ok := any(u).(core.ManualProvider); ok {
-		t.Fatal("expected pure MCP upstream not to implement ManualProvider")
+	if got := u.AuthTypes(); len(got) != 0 {
+		t.Fatalf("AuthTypes = %#v, want nil/empty", got)
 	}
 }
 

--- a/gestaltd/internal/provider/build_test.go
+++ b/gestaltd/internal/provider/build_test.go
@@ -638,12 +638,7 @@ func TestBuildConnectionParams(t *testing.T) {
 		t.Fatalf("Build: %v", err)
 	}
 
-	cpp, ok := prov.(core.ConnectionParamProvider)
-	if !ok {
-		t.Fatal("provider does not implement ConnectionParamProvider")
-	}
-
-	defs := cpp.ConnectionParamDefs()
+	defs := prov.ConnectionParamDefs()
 	if len(defs) != 2 {
 		t.Fatalf("expected 2 connection params, got %d", len(defs))
 	}
@@ -932,12 +927,7 @@ func TestBuildCredentialFields(t *testing.T) {
 		t.Fatalf("Build: %v", err)
 	}
 
-	cfp, ok := prov.(core.CredentialFieldsProvider)
-	if !ok {
-		t.Fatal("provider does not implement CredentialFieldsProvider")
-	}
-
-	fields := cfp.CredentialFields()
+	fields := prov.CredentialFields()
 	if len(fields) != 2 {
 		t.Fatalf("got %d credential fields, want 2", len(fields))
 	}
@@ -975,12 +965,7 @@ func TestBuildCredentialFieldsFromConfig(t *testing.T) {
 		t.Fatalf("Build: %v", err)
 	}
 
-	cfp, ok := prov.(core.CredentialFieldsProvider)
-	if !ok {
-		t.Fatal("provider does not implement CredentialFieldsProvider")
-	}
-
-	fields := cfp.CredentialFields()
+	fields := prov.CredentialFields()
 	if len(fields) != 1 {
 		t.Fatalf("got %d credential fields, want 1", len(fields))
 	}

--- a/gestaltd/internal/providerhost/declarative.go
+++ b/gestaltd/internal/providerhost/declarative.go
@@ -205,13 +205,6 @@ func declarativeParamLocation(op *catalog.CatalogOperation, name string) (string
 	return "", false
 }
 
-func (p *DeclarativeProvider) SupportsManualAuth() bool {
-	if p.auth == nil {
-		return false
-	}
-	return p.auth.Type == providermanifestv1.AuthTypeManual || p.auth.Type == providermanifestv1.AuthTypeBearer
-}
-
 func (p *DeclarativeProvider) CredentialFields() []core.CredentialFieldDef {
 	if p.auth == nil {
 		return nil
@@ -234,6 +227,8 @@ func (p *DeclarativeProvider) AuthTypes() []string {
 		return nil
 	}
 }
+
+func (p *DeclarativeProvider) ConnectionForOperation(string) string { return "" }
 
 func (p *DeclarativeProvider) AuthorizationURL(state string, scopes []string) string {
 	if p.auth == nil || p.auth.Type != providermanifestv1.AuthTypeOAuth2 {

--- a/gestaltd/internal/providerhost/provider_client.go
+++ b/gestaltd/internal/providerhost/provider_client.go
@@ -150,15 +150,6 @@ func (p *remoteProviderBase) Execute(ctx context.Context, operation string, para
 	}, nil
 }
 
-func (p *remoteProviderBase) SupportsManualAuth() bool {
-	for _, authType := range p.authTypes {
-		if authType == "manual" {
-			return true
-		}
-	}
-	return false
-}
-
 func (p *remoteProviderBase) Catalog() *catalog.Catalog {
 	return p.decorateCatalog(p.catalog)
 }
@@ -178,6 +169,8 @@ func (p *remoteProviderBase) CredentialFields() []core.CredentialFieldDef {
 func (p *remoteProviderBase) DiscoveryConfig() *core.DiscoveryConfig {
 	return p.discovery
 }
+
+func (p *remoteProviderBase) ConnectionForOperation(string) string { return "" }
 
 func (p *remoteProviderBase) sessionCatalog(ctx context.Context, token string) (*catalog.Catalog, error) {
 	resp, err := p.client.GetSessionCatalog(ctx, &proto.GetSessionCatalogRequest{

--- a/gestaltd/internal/providerhost/provider_server.go
+++ b/gestaltd/internal/providerhost/provider_server.go
@@ -24,7 +24,7 @@ func NewProviderServer(provider core.Provider) *ProviderServer {
 
 func (s *ProviderServer) GetMetadata(_ context.Context, _ *emptypb.Empty) (*proto.ProviderMetadata, error) {
 	return &proto.ProviderMetadata{
-		SupportsSessionCatalog: supportsSessionCatalog(s.provider),
+		SupportsSessionCatalog: core.SupportsSessionCatalog(s.provider),
 	}, nil
 }
 
@@ -47,24 +47,18 @@ func (s *ProviderServer) Execute(ctx context.Context, req *proto.ExecuteRequest)
 }
 
 func (s *ProviderServer) GetSessionCatalog(ctx context.Context, req *proto.GetSessionCatalogRequest) (*proto.GetSessionCatalogResponse, error) {
-	scp, ok := s.provider.(core.SessionCatalogProvider)
-	if !ok {
+	if !core.SupportsSessionCatalog(s.provider) {
 		return nil, status.Error(codes.Unimplemented, "provider does not support session catalogs")
 	}
 	ctx = applyRequestContext(ctx, req.GetContext())
 	if len(req.GetConnectionParams()) > 0 {
 		ctx = core.WithConnectionParams(ctx, req.GetConnectionParams())
 	}
-	cat, err := scp.CatalogForRequest(ctx, req.GetToken())
+	cat, _, err := core.CatalogForRequest(ctx, s.provider, req.GetToken())
 	if err != nil {
 		return nil, status.Errorf(codes.Unknown, "session catalog: %v", err)
 	}
 	return &proto.GetSessionCatalogResponse{Catalog: catalogToProto(cat)}, nil
-}
-
-func supportsSessionCatalog(prov core.Provider) bool {
-	_, ok := prov.(core.SessionCatalogProvider)
-	return ok
 }
 
 func applyRequestContext(ctx context.Context, reqCtx *proto.RequestContext) context.Context {

--- a/gestaltd/internal/providerhost/provider_test.go
+++ b/gestaltd/internal/providerhost/provider_test.go
@@ -23,6 +23,16 @@ func (p *roundTripProvider) Name() string                        { return "round
 func (p *roundTripProvider) DisplayName() string                 { return "Round Trip" }
 func (p *roundTripProvider) Description() string                 { return "test provider" }
 func (p *roundTripProvider) ConnectionMode() core.ConnectionMode { return core.ConnectionModeEither }
+func (p *roundTripProvider) AuthTypes() []string                 { return []string{"manual"} }
+func (p *roundTripProvider) ConnectionParamDefs() map[string]core.ConnectionParamDef {
+	return map[string]core.ConnectionParamDef{
+		"tenant":  {Required: true, Description: "Tenant slug"},
+		"team_id": {From: "token_response", Field: "team_id"},
+	}
+}
+func (p *roundTripProvider) CredentialFields() []core.CredentialFieldDef { return nil }
+func (p *roundTripProvider) DiscoveryConfig() *core.DiscoveryConfig      { return nil }
+func (p *roundTripProvider) ConnectionForOperation(string) string        { return "" }
 
 func (p *roundTripProvider) Execute(ctx context.Context, operation string, params map[string]any, token string) (*core.OperationResult, error) {
 	subjectID := ""
@@ -167,17 +177,11 @@ func TestRemoteProviderRoundTrip(t *testing.T) {
 		t.Fatalf("unexpected connection mode: %q", prov.ConnectionMode())
 	}
 
-	if _, ok := prov.(core.ManualProvider); !ok {
-		t.Fatal("expected remote provider to implement ManualProvider")
-	}
 	if _, ok := prov.(core.SessionCatalogProvider); !ok {
 		t.Fatal("expected remote provider to implement SessionCatalogProvider")
 	}
-	if _, ok := prov.(core.ConnectionParamProvider); !ok {
-		t.Fatal("expected remote provider to implement ConnectionParamProvider")
-	}
-	if _, ok := prov.(core.AuthTypeLister); !ok {
-		t.Fatal("expected remote provider to implement AuthTypeLister")
+	if got := prov.AuthTypes(); len(got) != 1 || got[0] != "manual" {
+		t.Fatalf("unexpected auth types: %#v", got)
 	}
 	if cat := prov.Catalog(); cat == nil || len(cat.Operations) != 1 || cat.Operations[0].ID != "echo" {
 		t.Fatalf("unexpected Catalog result: %+v", cat)
@@ -261,8 +265,7 @@ func TestRemoteProviderRoundTrip(t *testing.T) {
 		})
 	}
 
-	cpp := prov.(core.ConnectionParamProvider)
-	if defs := cpp.ConnectionParamDefs(); defs["tenant"].Description != "Tenant slug" || defs["team_id"].Field != "team_id" {
+	if defs := prov.ConnectionParamDefs(); defs["tenant"].Description != "Tenant slug" || defs["team_id"].Field != "team_id" {
 		t.Fatalf("unexpected connection param defs: %+v", defs)
 	}
 }
@@ -322,12 +325,8 @@ func TestRemoteProviderManualAuthOnly(t *testing.T) {
 		t.Fatalf("NewRemoteProvider: %v", err)
 	}
 
-	mp, ok := prov.(core.ManualProvider)
-	if !ok {
-		t.Fatal("expected remote provider to implement core.ManualProvider")
-	}
-	if !mp.SupportsManualAuth() {
-		t.Fatal("expected SupportsManualAuth() == true")
+	if got := prov.AuthTypes(); len(got) != 1 || got[0] != "manual" {
+		t.Fatalf("AuthTypes = %#v, want [manual]", got)
 	}
 	cat := prov.Catalog()
 	if cat == nil || len(cat.Operations) != 1 {

--- a/gestaltd/internal/server/catalog_resolution_test.go
+++ b/gestaltd/internal/server/catalog_resolution_test.go
@@ -28,6 +28,13 @@ func (s *stubProvider) Name() string                        { return s.name }
 func (s *stubProvider) DisplayName() string                 { return s.displayName }
 func (s *stubProvider) Description() string                 { return s.description }
 func (s *stubProvider) ConnectionMode() core.ConnectionMode { return s.connMode }
+func (s *stubProvider) AuthTypes() []string                 { return nil }
+func (s *stubProvider) ConnectionParamDefs() map[string]core.ConnectionParamDef {
+	return nil
+}
+func (s *stubProvider) CredentialFields() []core.CredentialFieldDef { return nil }
+func (s *stubProvider) DiscoveryConfig() *core.DiscoveryConfig      { return nil }
+func (s *stubProvider) ConnectionForOperation(string) string        { return "" }
 func (s *stubProvider) Catalog() *catalog.Catalog           { return nil }
 func (s *stubProvider) Execute(context.Context, string, map[string]any, string) (*core.OperationResult, error) {
 	return nil, nil

--- a/gestaltd/internal/server/catalog_resolution_test.go
+++ b/gestaltd/internal/server/catalog_resolution_test.go
@@ -35,7 +35,7 @@ func (s *stubProvider) ConnectionParamDefs() map[string]core.ConnectionParamDef 
 func (s *stubProvider) CredentialFields() []core.CredentialFieldDef { return nil }
 func (s *stubProvider) DiscoveryConfig() *core.DiscoveryConfig      { return nil }
 func (s *stubProvider) ConnectionForOperation(string) string        { return "" }
-func (s *stubProvider) Catalog() *catalog.Catalog           { return nil }
+func (s *stubProvider) Catalog() *catalog.Catalog                   { return nil }
 func (s *stubProvider) Execute(context.Context, string, map[string]any, string) (*core.OperationResult, error) {
 	return nil, nil
 }

--- a/gestaltd/internal/server/handlers.go
+++ b/gestaltd/internal/server/handlers.go
@@ -188,7 +188,7 @@ func (s *Server) listIntegrations(w http.ResponseWriter, r *http.Request) {
 		info.Connected = len(instances) > 0
 		info.Instances = append(make([]instanceInfo, 0, len(instances)), instances...)
 		info.CredentialFields = credentialFieldInfosFromProvider(prov)
-		for name, def := range core.ConnectionParamDefs(prov) {
+		for name, def := range prov.ConnectionParamDefs() {
 			if def.From == "" {
 				info.ConnectionParams[name] = connectionParamInfo{
 					Required:    def.Required,
@@ -201,7 +201,9 @@ func (s *Server) listIntegrations(w http.ResponseWriter, r *http.Request) {
 		if len(authTypes) == 0 {
 			authTypes = authTypesFromConnections(info.Connections)
 			if len(authTypes) == 0 {
-				authTypes = fallbackAuthTypesForProvider(prov)
+				if _, ok := prov.(core.OAuthProvider); ok {
+					authTypes = []string{"oauth"}
+				}
 			}
 			info.Connections = s.integrationConnectionInfos(name, authTypes, info.CredentialFields)
 		}
@@ -429,12 +431,7 @@ func resolveRequestedInstance(w http.ResponseWriter, requested string) (string, 
 }
 
 func resolveConnectionParams(w http.ResponseWriter, prov core.Provider, provided map[string]string) (map[string]string, bool) {
-	if !core.HasConnectionParamDefs(prov) {
-		return nil, true
-	}
-
-	defs := core.ConnectionParamDefs(prov)
-	connParams, err := validateConnectionParams(defs, provided)
+	connParams, err := validateConnectionParams(prov.ConnectionParamDefs(), provided)
 	if err != nil {
 		writeError(w, http.StatusBadRequest, err.Error())
 		return nil, false

--- a/gestaltd/internal/server/handlers.go
+++ b/gestaltd/internal/server/handlers.go
@@ -188,15 +188,12 @@ func (s *Server) listIntegrations(w http.ResponseWriter, r *http.Request) {
 		info.Connected = len(instances) > 0
 		info.Instances = append(make([]instanceInfo, 0, len(instances)), instances...)
 		info.CredentialFields = credentialFieldInfosFromProvider(prov)
-		if cpp, ok := prov.(core.ConnectionParamProvider); ok {
-			defs := cpp.ConnectionParamDefs()
-			for name, def := range defs {
-				if def.From == "" {
-					info.ConnectionParams[name] = connectionParamInfo{
-						Required:    def.Required,
-						Description: def.Description,
-						Default:     def.Default,
-					}
+		for name, def := range core.ConnectionParamDefs(prov) {
+			if def.From == "" {
+				info.ConnectionParams[name] = connectionParamInfo{
+					Required:    def.Required,
+					Description: def.Description,
+					Default:     def.Default,
 				}
 			}
 		}
@@ -432,12 +429,12 @@ func resolveRequestedInstance(w http.ResponseWriter, requested string) (string, 
 }
 
 func resolveConnectionParams(w http.ResponseWriter, prov core.Provider, provided map[string]string) (map[string]string, bool) {
-	cpp, ok := prov.(core.ConnectionParamProvider)
-	if !ok {
+	if !core.HasConnectionParamDefs(prov) {
 		return nil, true
 	}
 
-	connParams, err := validateConnectionParams(cpp.ConnectionParamDefs(), provided)
+	defs := core.ConnectionParamDefs(prov)
+	connParams, err := validateConnectionParams(defs, provided)
 	if err != nil {
 		writeError(w, http.StatusBadRequest, err.Error())
 		return nil, false
@@ -487,7 +484,7 @@ func (s *Server) listOperations(w http.ResponseWriter, r *http.Request) {
 	discoveryStartedAt := time.Time{}
 	discoveryConnectionMode := ""
 	discoveryFailed := false
-	if _, ok := prov.(core.SessionCatalogProvider); ok && resolver != nil && p != nil && prov.ConnectionMode() != core.ConnectionModeNone {
+	if core.SupportsSessionCatalog(prov) && resolver != nil && p != nil && prov.ConnectionMode() != core.ConnectionModeNone {
 		recordDiscoveryMetrics = true
 		discoveryStartedAt = time.Now()
 		discoveryConnectionMode = metricutil.NormalizeConnectionMode(prov.ConnectionMode())
@@ -497,7 +494,7 @@ func (s *Server) listOperations(w http.ResponseWriter, r *http.Request) {
 	if requestedConnection != "" || requestedInstance != "" {
 		resolveCatalog = invocation.ResolveCatalogStrictWithMetadata
 		strictCatalog = true
-	} else if _, ok := prov.(core.SessionCatalogProvider); ok {
+	} else if core.SupportsSessionCatalog(prov) {
 		resolveCatalog = invocation.ResolveCatalogStrictWithMetadata
 		strictCatalog = true
 	}
@@ -685,7 +682,7 @@ func (s *Server) executeOperation(w http.ResponseWriter, r *http.Request) {
 	}
 	opMeta, ok := invocation.CatalogOperation(prov.Catalog(), operationName)
 	sessionOpFound := false
-	if _, sessionCapable := prov.(core.SessionCatalogProvider); sessionCapable {
+	if core.SupportsSessionCatalog(prov) {
 		var firstSessionErr error
 		sessionCatalogResolved := false
 		sessionConnections := make([]string, 0, 2)

--- a/gestaltd/internal/server/handlers_connect.go
+++ b/gestaltd/internal/server/handlers_connect.go
@@ -178,7 +178,7 @@ func buildConnectionMetadata(prov core.Provider, userParams map[string]string, t
 		metadata[k] = v
 	}
 
-	if defs := core.ConnectionParamDefs(prov); tokenResp != nil && tokenResp.Extra != nil {
+	if defs := prov.ConnectionParamDefs(); tokenResp != nil && tokenResp.Extra != nil {
 		for name, def := range defs {
 			if def.From == "token_response" {
 				field := def.Field
@@ -298,7 +298,7 @@ func mergeMetadataJSON(existing string, extra map[string]string) (string, error)
 }
 
 func (s *Server) runPostConnect(ctx context.Context, prov core.Provider, tm tokenMaterial) (*postConnectResult, error) {
-	if cfg := core.DiscoveryConfigFor(prov); cfg != nil {
+	if cfg := prov.DiscoveryConfig(); cfg != nil {
 		client := &http.Client{
 			Timeout:   30 * time.Second,
 			Transport: &bearerTransport{token: tm.AccessToken, base: http.DefaultTransport},
@@ -348,7 +348,7 @@ func manualConnectionAllowed(prov core.Provider, auth config.ConnectionAuthDef) 
 	if authTypesContain(connectionAuthTypes(auth, nil), "manual") {
 		return true
 	}
-	return providerSupportsManualAuth(prov)
+	return authTypesContain(userFacingAuthTypes(prov.AuthTypes()), "manual")
 }
 
 func discoveryCandidateInfos(candidates []core.DiscoveryCandidate) []discoveryCandidateInfo {

--- a/gestaltd/internal/server/handlers_connect.go
+++ b/gestaltd/internal/server/handlers_connect.go
@@ -145,9 +145,6 @@ func (s *Server) connectManual(w http.ResponseWriter, r *http.Request) {
 }
 
 func validateConnectionParams(defs map[string]core.ConnectionParamDef, provided map[string]string) (map[string]string, error) {
-	if len(defs) == 0 {
-		return nil, nil
-	}
 	for key := range provided {
 		if _, ok := defs[key]; !ok {
 			return nil, fmt.Errorf("unknown connection parameter: %s", key)
@@ -181,8 +178,8 @@ func buildConnectionMetadata(prov core.Provider, userParams map[string]string, t
 		metadata[k] = v
 	}
 
-	if cpp, ok := prov.(core.ConnectionParamProvider); ok && tokenResp != nil && tokenResp.Extra != nil {
-		for name, def := range cpp.ConnectionParamDefs() {
+	if defs := core.ConnectionParamDefs(prov); tokenResp != nil && tokenResp.Extra != nil {
+		for name, def := range defs {
 			if def.From == "token_response" {
 				field := def.Field
 				if field == "" {
@@ -301,46 +298,44 @@ func mergeMetadataJSON(existing string, extra map[string]string) (string, error)
 }
 
 func (s *Server) runPostConnect(ctx context.Context, prov core.Provider, tm tokenMaterial) (*postConnectResult, error) {
-	if dcp, ok := prov.(core.DiscoveryConfigProvider); ok {
-		if cfg := dcp.DiscoveryConfig(); cfg != nil {
-			client := &http.Client{
-				Timeout:   30 * time.Second,
-				Transport: &bearerTransport{token: tm.AccessToken, base: http.DefaultTransport},
-			}
-			candidates, err := discovery.Run(ctx, cfg, client)
-			if err != nil {
-				return nil, fmt.Errorf("discovery: %w", err)
-			}
-			if len(candidates) == 0 {
-				return nil, fmt.Errorf("no resources discovered")
-			}
-			if len(candidates) == 1 {
-				if err := validateDiscoveryMetadata(candidates[0].Metadata); err != nil {
-					return nil, err
-				}
-				merged, err := mergeMetadataJSON(tm.MetadataJSON, candidates[0].Metadata)
-				if err != nil {
-					return nil, err
-				}
-				tm.MetadataJSON = merged
-				if _, err := s.storeTokenFromMaterial(ctx, tm); err != nil {
-					return nil, err
-				}
-				return &postConnectResult{Status: "connected", Integration: tm.Integration}, nil
-			}
-
-			pendingToken, err := s.encodePendingConnectionToken(tm, candidates)
-			if err != nil {
-				return nil, fmt.Errorf("encode pending connection: %w", err)
-			}
-			return &postConnectResult{
-				Status:       "selection_required",
-				Integration:  tm.Integration,
-				SelectionURL: pendingConnectionPath,
-				PendingToken: pendingToken,
-				Candidates:   discoveryCandidateInfos(candidates),
-			}, nil
+	if cfg := core.DiscoveryConfigFor(prov); cfg != nil {
+		client := &http.Client{
+			Timeout:   30 * time.Second,
+			Transport: &bearerTransport{token: tm.AccessToken, base: http.DefaultTransport},
 		}
+		candidates, err := discovery.Run(ctx, cfg, client)
+		if err != nil {
+			return nil, fmt.Errorf("discovery: %w", err)
+		}
+		if len(candidates) == 0 {
+			return nil, fmt.Errorf("no resources discovered")
+		}
+		if len(candidates) == 1 {
+			if err := validateDiscoveryMetadata(candidates[0].Metadata); err != nil {
+				return nil, err
+			}
+			merged, err := mergeMetadataJSON(tm.MetadataJSON, candidates[0].Metadata)
+			if err != nil {
+				return nil, err
+			}
+			tm.MetadataJSON = merged
+			if _, err := s.storeTokenFromMaterial(ctx, tm); err != nil {
+				return nil, err
+			}
+			return &postConnectResult{Status: "connected", Integration: tm.Integration}, nil
+		}
+
+		pendingToken, err := s.encodePendingConnectionToken(tm, candidates)
+		if err != nil {
+			return nil, fmt.Errorf("encode pending connection: %w", err)
+		}
+		return &postConnectResult{
+			Status:       "selection_required",
+			Integration:  tm.Integration,
+			SelectionURL: pendingConnectionPath,
+			PendingToken: pendingToken,
+			Candidates:   discoveryCandidateInfos(candidates),
+		}, nil
 	}
 
 	if _, err := s.storeTokenFromMaterial(ctx, tm); err != nil {

--- a/gestaltd/internal/server/handlers_tokens.go
+++ b/gestaltd/internal/server/handlers_tokens.go
@@ -227,19 +227,17 @@ func userFacingConnectionName(name string) string {
 }
 
 func providerSupportsManualAuth(prov core.Provider) bool {
-	mp, ok := prov.(core.ManualProvider)
-	return ok && mp.SupportsManualAuth()
+	return core.SupportsManualAuth(prov)
 }
 
 func providerSupportsOAuth(prov core.Provider) bool {
-	_, ok := prov.(core.OAuthProvider)
-	return ok
+	return core.SupportsOAuth(prov)
 }
 
 func integrationAuthTypesForProvider(prov core.Provider) []string {
 	var authTypes []string
-	if atl, ok := prov.(core.AuthTypeLister); ok {
-		authTypes = atl.AuthTypes()
+	if core.HasAuthTypes(prov) {
+		authTypes = core.AuthTypes(prov)
 	} else if providerSupportsManualAuth(prov) {
 		authTypes = []string{"manual"}
 	} else if providerSupportsOAuth(prov) {
@@ -249,9 +247,8 @@ func integrationAuthTypesForProvider(prov core.Provider) []string {
 }
 
 func credentialFieldInfosFromProvider(prov core.Provider) []credentialFieldInfo {
-	cfp, ok := prov.(core.CredentialFieldsProvider)
-	if ok {
-		if fields := credentialFieldInfos(cfp.CredentialFields(), func(field core.CredentialFieldDef) credentialFieldInfo {
+	if fields := core.CredentialFields(prov); len(fields) > 0 {
+		if fields := credentialFieldInfos(fields, func(field core.CredentialFieldDef) credentialFieldInfo {
 			return credentialFieldInfo{
 				Name:        field.Name,
 				Label:       field.Label,

--- a/gestaltd/internal/server/handlers_tokens.go
+++ b/gestaltd/internal/server/handlers_tokens.go
@@ -226,28 +226,12 @@ func userFacingConnectionName(name string) string {
 	return name
 }
 
-func providerSupportsManualAuth(prov core.Provider) bool {
-	return core.SupportsManualAuth(prov)
-}
-
-func providerSupportsOAuth(prov core.Provider) bool {
-	return core.SupportsOAuth(prov)
-}
-
 func integrationAuthTypesForProvider(prov core.Provider) []string {
-	var authTypes []string
-	if core.HasAuthTypes(prov) {
-		authTypes = core.AuthTypes(prov)
-	} else if providerSupportsManualAuth(prov) {
-		authTypes = []string{"manual"}
-	} else if providerSupportsOAuth(prov) {
-		authTypes = []string{"oauth"}
-	}
-	return userFacingAuthTypes(authTypes)
+	return userFacingAuthTypes(prov.AuthTypes())
 }
 
 func credentialFieldInfosFromProvider(prov core.Provider) []credentialFieldInfo {
-	if fields := core.CredentialFields(prov); len(fields) > 0 {
+	if fields := prov.CredentialFields(); len(fields) > 0 {
 		if fields := credentialFieldInfos(fields, func(field core.CredentialFieldDef) credentialFieldInfo {
 			return credentialFieldInfo{
 				Name:        field.Name,
@@ -258,7 +242,7 @@ func credentialFieldInfosFromProvider(prov core.Provider) []credentialFieldInfo 
 			return fields
 		}
 	}
-	if providerSupportsManualAuth(prov) {
+	if authTypesContain(userFacingAuthTypes(prov.AuthTypes()), "manual") {
 		return defaultManualCredentialFieldInfos()
 	}
 	return []credentialFieldInfo{}
@@ -350,16 +334,6 @@ func authTypesFromConnections(connections []connectionDefInfo) []string {
 		combined = append(combined, connection.AuthTypes...)
 	}
 	return userFacingAuthTypes(combined)
-}
-
-func fallbackAuthTypesForProvider(prov core.Provider) []string {
-	if providerSupportsManualAuth(prov) {
-		return []string{"manual"}
-	}
-	if providerSupportsOAuth(prov) {
-		return []string{"oauth"}
-	}
-	return nil
 }
 
 func connectionDisplayName(name, configured string) string {

--- a/gestaltd/internal/server/metrics_test.go
+++ b/gestaltd/internal/server/metrics_test.go
@@ -30,13 +30,19 @@ func (p *manualMetricsProvider) Name() string                        { return p.
 func (p *manualMetricsProvider) DisplayName() string                 { return p.name }
 func (p *manualMetricsProvider) Description() string                 { return "" }
 func (p *manualMetricsProvider) ConnectionMode() core.ConnectionMode { return core.ConnectionModeUser }
+func (p *manualMetricsProvider) AuthTypes() []string                 { return []string{"manual"} }
+func (p *manualMetricsProvider) ConnectionParamDefs() map[string]core.ConnectionParamDef {
+	return nil
+}
+func (p *manualMetricsProvider) CredentialFields() []core.CredentialFieldDef { return nil }
+func (p *manualMetricsProvider) DiscoveryConfig() *core.DiscoveryConfig      { return nil }
+func (p *manualMetricsProvider) ConnectionForOperation(string) string        { return "" }
 func (p *manualMetricsProvider) Catalog() *catalog.Catalog {
 	return serverTestCatalogFromOperations(p.name, nil)
 }
 func (p *manualMetricsProvider) Execute(context.Context, string, map[string]any, string) (*core.OperationResult, error) {
 	return &core.OperationResult{Status: http.StatusOK, Body: `{}`}, nil
 }
-func (p *manualMetricsProvider) SupportsManualAuth() bool { return true }
 
 type metricsHostIssuedSessionAuth struct {
 	secret []byte

--- a/gestaltd/internal/server/server_test.go
+++ b/gestaltd/internal/server/server_test.go
@@ -9717,8 +9717,8 @@ func (s *stubIntegrationWithSessionCatalog) CatalogForRequest(ctx context.Contex
 	return s.catalog, nil
 }
 
-func (s *stubIntegrationWithSessionCatalog) AuthTypes() []string      { return []string{"manual"} }
-func (s *stubIntegrationWithSessionCatalog) Close() error             { return nil }
+func (s *stubIntegrationWithSessionCatalog) AuthTypes() []string { return []string{"manual"} }
+func (s *stubIntegrationWithSessionCatalog) Close() error        { return nil }
 func (s *stubIntegrationWithSessionCatalog) CallTool(ctx context.Context, name string, args map[string]any) (*mcpgo.CallToolResult, error) {
 	if s.callFn != nil {
 		return s.callFn(ctx, name, args)

--- a/gestaltd/internal/server/server_test.go
+++ b/gestaltd/internal/server/server_test.go
@@ -4483,6 +4483,108 @@ func TestListIntegrations_ManualProvidersWithoutDeclaredCredentialsExposeGeneric
 	}
 }
 
+func TestListIntegrations_CompositeProvidersExposeAPIConnectionMetadata(t *testing.T) {
+	t.Parallel()
+
+	apiProv := &stubManualProviderWithCapabilities{
+		stubManualProvider: stubManualProvider{
+			StubIntegration: coretesting.StubIntegration{N: "docs", DN: "Docs"},
+		},
+		credentialFields: []core.CredentialFieldDef{
+			{Name: "api_key", Label: "API Key", Description: "Docs API key"},
+		},
+		connectionParams: map[string]core.ConnectionParamDef{
+			"tenant": {
+				Required:    true,
+				Description: "Tenant slug",
+				Default:     "acme",
+			},
+		},
+	}
+	prov := composite.New("docs", apiProv, &stubIntegrationWithSessionCatalog{
+		stubIntegrationWithOps: stubIntegrationWithOps{
+			StubIntegration: coretesting.StubIntegration{N: "docs-mcp", ConnMode: core.ConnectionModeNone},
+		},
+	})
+
+	ts := newTestServer(t, func(cfg *server.Config) {
+		cfg.Providers = testutil.NewProviderRegistry(t, prov)
+		cfg.PluginDefs = map[string]*config.ProviderEntry{
+			"docs": {},
+		}
+		cfg.Services = coretesting.NewStubServices(t)
+	})
+	testutil.CloseOnCleanup(t, ts)
+
+	req, _ := http.NewRequest(http.MethodGet, ts.URL+"/api/v1/integrations", nil)
+	resp, err := http.DefaultClient.Do(req)
+	if err != nil {
+		t.Fatalf("request: %v", err)
+	}
+	defer func() { _ = resp.Body.Close() }()
+
+	if resp.StatusCode != http.StatusOK {
+		t.Fatalf("expected 200, got %d", resp.StatusCode)
+	}
+
+	type credentialField struct {
+		Name        string `json:"name"`
+		Label       string `json:"label"`
+		Description string `json:"description"`
+	}
+	type connectionParam struct {
+		Required    bool   `json:"required"`
+		Description string `json:"description"`
+		Default     string `json:"default"`
+	}
+	var integrations []struct {
+		Name             string                     `json:"name"`
+		AuthTypes        []string                   `json:"authTypes"`
+		CredentialFields []credentialField          `json:"credentialFields"`
+		ConnectionParams map[string]connectionParam `json:"connectionParams"`
+		Connections      []struct {
+			Name             string            `json:"name"`
+			AuthTypes        []string          `json:"authTypes"`
+			CredentialFields []credentialField `json:"credentialFields"`
+		} `json:"connections"`
+	}
+	if err := json.NewDecoder(resp.Body).Decode(&integrations); err != nil {
+		t.Fatalf("decoding: %v", err)
+	}
+	if len(integrations) != 1 {
+		t.Fatalf("expected 1 integration, got %d", len(integrations))
+	}
+
+	wantFields := []credentialField{{Name: "api_key", Label: "API Key", Description: "Docs API key"}}
+	if !reflect.DeepEqual(integrations[0].AuthTypes, []string{"manual"}) {
+		t.Fatalf("auth types = %v, want [manual]", integrations[0].AuthTypes)
+	}
+	if !reflect.DeepEqual(integrations[0].CredentialFields, wantFields) {
+		t.Fatalf("credential fields = %+v, want %+v", integrations[0].CredentialFields, wantFields)
+	}
+	if !reflect.DeepEqual(integrations[0].ConnectionParams, map[string]connectionParam{
+		"tenant": {
+			Required:    true,
+			Description: "Tenant slug",
+			Default:     "acme",
+		},
+	}) {
+		t.Fatalf("connection params = %+v", integrations[0].ConnectionParams)
+	}
+	if len(integrations[0].Connections) != 1 {
+		t.Fatalf("connections = %+v, want one default connection", integrations[0].Connections)
+	}
+	if integrations[0].Connections[0].Name != config.PluginConnectionAlias {
+		t.Fatalf("connection name = %q, want %q", integrations[0].Connections[0].Name, config.PluginConnectionAlias)
+	}
+	if !reflect.DeepEqual(integrations[0].Connections[0].AuthTypes, []string{"manual"}) {
+		t.Fatalf("connection auth types = %v, want [manual]", integrations[0].Connections[0].AuthTypes)
+	}
+	if !reflect.DeepEqual(integrations[0].Connections[0].CredentialFields, wantFields) {
+		t.Fatalf("connection credential fields = %+v, want %+v", integrations[0].Connections[0].CredentialFields, wantFields)
+	}
+}
+
 func TestListIntegrations_ConnectionInfosUseResolvedConnectionDefs(t *testing.T) {
 	t.Parallel()
 
@@ -6702,6 +6804,97 @@ func TestExecuteOperation_UsesInjectedInvoker(t *testing.T) {
 	}
 	if _, ok := gotParams["_connection"]; ok {
 		t.Fatalf("expected _connection to be stripped from params, got %v", gotParams)
+	}
+}
+
+func TestExecuteOperation_WrappedProvidersPreserveOperationConnectionRouting(t *testing.T) {
+	t.Parallel()
+
+	svc := coretesting.NewStubServices(t)
+	user, err := svc.Users.FindOrCreateUser(context.Background(), "wrapped@test.local")
+	if err != nil {
+		t.Fatalf("FindOrCreateUser: %v", err)
+	}
+	seedToken(t, svc, &core.IntegrationToken{
+		ID:          "svc-workspace-default",
+		UserID:      user.ID,
+		Integration: "svc",
+		Connection:  "workspace",
+		Instance:    "default",
+		AccessToken: "workspace-token",
+	})
+
+	backend := &stubIntegrationWithOps{
+		StubIntegration: coretesting.StubIntegration{
+			N: "search-backend",
+			ExecuteFn: func(_ context.Context, op string, _ map[string]any, token string) (*core.OperationResult, error) {
+				return &core.OperationResult{
+					Status: http.StatusOK,
+					Body:   fmt.Sprintf(`{"operation":%q,"token":%q}`, op, token),
+				}, nil
+			},
+		},
+		ops: []core.Operation{
+			{Name: "search", Description: "Search", Method: http.MethodGet},
+		},
+	}
+	merged, err := composite.NewMergedWithConnections("svc-api", "Svc API", "", "",
+		composite.BoundProvider{Provider: backend, Connection: "workspace"},
+	)
+	if err != nil {
+		t.Fatalf("NewMergedWithConnections: %v", err)
+	}
+	apiProv := coreintegration.NewRestricted(merged, map[string]string{"find": "search"})
+	prov := composite.New("svc", apiProv, &stubIntegrationWithSessionCatalog{
+		stubIntegrationWithOps: stubIntegrationWithOps{
+			StubIntegration: coretesting.StubIntegration{N: "svc-mcp", ConnMode: core.ConnectionModeNone},
+		},
+	})
+	if got := core.OperationConnection(apiProv, "find"); got != "workspace" {
+		t.Fatalf("restricted op connection = %q, want workspace", got)
+	}
+	if got := core.OperationConnection(prov, "find"); got != "workspace" {
+		t.Fatalf("composite op connection = %q, want workspace", got)
+	}
+
+	ts := newTestServer(t, func(cfg *server.Config) {
+		cfg.Auth = &coretesting.StubAuthProvider{
+			N: "stub",
+			ValidateTokenFn: func(_ context.Context, token string) (*core.UserIdentity, error) {
+				if token != "user-token" {
+					return nil, fmt.Errorf("bad token")
+				}
+				return &core.UserIdentity{Email: "wrapped@test.local"}, nil
+			},
+		}
+		cfg.Providers = testutil.NewProviderRegistry(t, prov)
+		cfg.CatalogConnection = map[string]string{"svc": "workspace"}
+		cfg.Services = svc
+	})
+	testutil.CloseOnCleanup(t, ts)
+
+	req, _ := http.NewRequest(http.MethodGet, ts.URL+"/api/v1/svc/find", nil)
+	req.Header.Set("Authorization", "Bearer user-token")
+	resp, err := http.DefaultClient.Do(req)
+	if err != nil {
+		t.Fatalf("request: %v", err)
+	}
+	defer func() { _ = resp.Body.Close() }()
+
+	if resp.StatusCode != http.StatusOK {
+		body, _ := io.ReadAll(resp.Body)
+		t.Fatalf("expected 200, got %d: %s", resp.StatusCode, body)
+	}
+
+	var body map[string]string
+	if err := json.NewDecoder(resp.Body).Decode(&body); err != nil {
+		t.Fatalf("decoding: %v", err)
+	}
+	if body["operation"] != "search" {
+		t.Fatalf("operation = %q, want search", body["operation"])
+	}
+	if body["token"] != "workspace-token" {
+		t.Fatalf("token = %q, want workspace-token", body["token"])
 	}
 }
 
@@ -10526,6 +10719,25 @@ func (s *stubDiscoveringProvider) DiscoveryConfig() *core.DiscoveryConfig {
 	return s.discovery
 }
 
+type stubManualProviderWithCapabilities struct {
+	stubManualProvider
+	credentialFields []core.CredentialFieldDef
+	connectionParams map[string]core.ConnectionParamDef
+	discovery        *core.DiscoveryConfig
+}
+
+func (s *stubManualProviderWithCapabilities) CredentialFields() []core.CredentialFieldDef {
+	return s.credentialFields
+}
+
+func (s *stubManualProviderWithCapabilities) ConnectionParamDefs() map[string]core.ConnectionParamDef {
+	return s.connectionParams
+}
+
+func (s *stubManualProviderWithCapabilities) DiscoveryConfig() *core.DiscoveryConfig {
+	return s.discovery
+}
+
 type stubDualAuthProvider struct {
 	coretesting.StubIntegration
 }
@@ -10838,6 +11050,204 @@ func TestConnectManual(t *testing.T) {
 		}
 		if metadata["workspace"] != "beta" {
 			t.Fatalf("expected workspace metadata beta, got %q", metadata["workspace"])
+		}
+	})
+}
+
+func TestConnectManual_CompositeProviderPreservesDiscoveryAndConnectionMetadata(t *testing.T) {
+	t.Parallel()
+
+	discoverySrv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = io.WriteString(w, `[{"id":"site-a","name":"Site A","workspace":"alpha"}]`)
+	}))
+	testutil.CloseOnCleanup(t, discoverySrv)
+
+	svc := coretesting.NewStubServices(t)
+	apiProv := &stubManualProviderWithCapabilities{
+		stubManualProvider: stubManualProvider{
+			StubIntegration: coretesting.StubIntegration{N: "manual-svc"},
+		},
+		connectionParams: map[string]core.ConnectionParamDef{
+			"tenant": {
+				Required:    true,
+				Description: "Tenant slug",
+			},
+		},
+		discovery: &core.DiscoveryConfig{
+			URL:      discoverySrv.URL,
+			IDPath:   "id",
+			NamePath: "name",
+			Metadata: map[string]string{"workspace": "workspace"},
+		},
+	}
+	prov := composite.New("manual-svc", apiProv, &stubIntegrationWithSessionCatalog{
+		stubIntegrationWithOps: stubIntegrationWithOps{
+			StubIntegration: coretesting.StubIntegration{N: "manual-svc-mcp", ConnMode: core.ConnectionModeNone},
+		},
+	})
+
+	ts := newTestServer(t, func(cfg *server.Config) {
+		cfg.Providers = testutil.NewProviderRegistry(t, prov)
+		cfg.DefaultConnection = map[string]string{"manual-svc": config.PluginConnectionName}
+		cfg.PluginDefs = map[string]*config.ProviderEntry{
+			"manual-svc": {},
+		}
+		cfg.Services = svc
+	})
+	testutil.CloseOnCleanup(t, ts)
+
+	body := bytes.NewBufferString(`{"integration":"manual-svc","credential":"my-api-key","connectionParams":{"tenant":"acme"}}`)
+	req, _ := http.NewRequest(http.MethodPost, ts.URL+"/api/v1/auth/connect-manual", body)
+	req.Header.Set("Content-Type", "application/json")
+	resp, err := http.DefaultClient.Do(req)
+	if err != nil {
+		t.Fatalf("request: %v", err)
+	}
+	defer func() { _ = resp.Body.Close() }()
+
+	if resp.StatusCode != http.StatusOK {
+		t.Fatalf("expected 200, got %d", resp.StatusCode)
+	}
+
+	var result map[string]string
+	if err := json.NewDecoder(resp.Body).Decode(&result); err != nil {
+		t.Fatalf("decoding: %v", err)
+	}
+	if result["status"] != "connected" {
+		t.Fatalf("expected connected, got %q", result["status"])
+	}
+
+	u, _ := svc.Users.FindOrCreateUser(context.Background(), "anonymous@gestalt")
+	tokens, _ := svc.Tokens.ListTokens(context.Background(), u.ID)
+	if len(tokens) != 1 {
+		t.Fatalf("expected 1 stored token, got %d", len(tokens))
+	}
+
+	var metadata map[string]string
+	if err := json.Unmarshal([]byte(tokens[0].MetadataJSON), &metadata); err != nil {
+		t.Fatalf("unmarshal metadata: %v", err)
+	}
+	if !reflect.DeepEqual(metadata, map[string]string{
+		"tenant":    "acme",
+		"workspace": "alpha",
+	}) {
+		t.Fatalf("metadata = %+v", metadata)
+	}
+}
+
+func TestConnectManual_RestrictedProviderPreservesValidationAndDiscovery(t *testing.T) {
+	t.Parallel()
+
+	t.Run("rejects unknown connection params when provider exposes none", func(t *testing.T) {
+		t.Parallel()
+
+		prov := coreintegration.NewRestricted(&stubManualProviderWithCapabilities{
+			stubManualProvider: stubManualProvider{
+				StubIntegration: coretesting.StubIntegration{N: "manual-svc"},
+			},
+			connectionParams: map[string]core.ConnectionParamDef{},
+		}, map[string]string{})
+
+		ts := newTestServer(t, func(cfg *server.Config) {
+			cfg.Providers = testutil.NewProviderRegistry(t, prov)
+			cfg.DefaultConnection = map[string]string{"manual-svc": config.PluginConnectionName}
+			cfg.PluginDefs = map[string]*config.ProviderEntry{
+				"manual-svc": {},
+			}
+			cfg.Services = coretesting.NewStubServices(t)
+		})
+		testutil.CloseOnCleanup(t, ts)
+
+		body := bytes.NewBufferString(`{"integration":"manual-svc","credential":"my-api-key","connectionParams":{"unknown":"nope"}}`)
+		req, _ := http.NewRequest(http.MethodPost, ts.URL+"/api/v1/auth/connect-manual", body)
+		req.Header.Set("Content-Type", "application/json")
+		resp, err := http.DefaultClient.Do(req)
+		if err != nil {
+			t.Fatalf("request: %v", err)
+		}
+		defer func() { _ = resp.Body.Close() }()
+
+		if resp.StatusCode != http.StatusBadRequest {
+			body, _ := io.ReadAll(resp.Body)
+			t.Fatalf("expected 400, got %d: %s", resp.StatusCode, body)
+		}
+	})
+
+	t.Run("preserves discovery and connection metadata", func(t *testing.T) {
+		t.Parallel()
+
+		discoverySrv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+			w.Header().Set("Content-Type", "application/json")
+			_, _ = io.WriteString(w, `[{"id":"site-a","name":"Site A","workspace":"alpha"}]`)
+		}))
+		testutil.CloseOnCleanup(t, discoverySrv)
+
+		svc := coretesting.NewStubServices(t)
+		prov := coreintegration.NewRestricted(&stubManualProviderWithCapabilities{
+			stubManualProvider: stubManualProvider{
+				StubIntegration: coretesting.StubIntegration{N: "manual-svc"},
+			},
+			connectionParams: map[string]core.ConnectionParamDef{
+				"tenant": {
+					Required:    true,
+					Description: "Tenant slug",
+				},
+			},
+			discovery: &core.DiscoveryConfig{
+				URL:      discoverySrv.URL,
+				IDPath:   "id",
+				NamePath: "name",
+				Metadata: map[string]string{"workspace": "workspace"},
+			},
+		}, map[string]string{})
+
+		ts := newTestServer(t, func(cfg *server.Config) {
+			cfg.Providers = testutil.NewProviderRegistry(t, prov)
+			cfg.DefaultConnection = map[string]string{"manual-svc": config.PluginConnectionName}
+			cfg.PluginDefs = map[string]*config.ProviderEntry{
+				"manual-svc": {},
+			}
+			cfg.Services = svc
+		})
+		testutil.CloseOnCleanup(t, ts)
+
+		body := bytes.NewBufferString(`{"integration":"manual-svc","credential":"my-api-key","connectionParams":{"tenant":"acme"}}`)
+		req, _ := http.NewRequest(http.MethodPost, ts.URL+"/api/v1/auth/connect-manual", body)
+		req.Header.Set("Content-Type", "application/json")
+		resp, err := http.DefaultClient.Do(req)
+		if err != nil {
+			t.Fatalf("request: %v", err)
+		}
+		defer func() { _ = resp.Body.Close() }()
+
+		if resp.StatusCode != http.StatusOK {
+			t.Fatalf("expected 200, got %d", resp.StatusCode)
+		}
+
+		var result map[string]string
+		if err := json.NewDecoder(resp.Body).Decode(&result); err != nil {
+			t.Fatalf("decoding: %v", err)
+		}
+		if result["status"] != "connected" {
+			t.Fatalf("expected connected, got %q", result["status"])
+		}
+
+		u, _ := svc.Users.FindOrCreateUser(context.Background(), "anonymous@gestalt")
+		tokens, _ := svc.Tokens.ListTokens(context.Background(), u.ID)
+		if len(tokens) != 1 {
+			t.Fatalf("expected 1 stored token, got %d", len(tokens))
+		}
+
+		var metadata map[string]string
+		if err := json.Unmarshal([]byte(tokens[0].MetadataJSON), &metadata); err != nil {
+			t.Fatalf("unmarshal metadata: %v", err)
+		}
+		if !reflect.DeepEqual(metadata, map[string]string{
+			"tenant":    "acme",
+			"workspace": "alpha",
+		}) {
+			t.Fatalf("metadata = %+v", metadata)
 		}
 	})
 }

--- a/gestaltd/internal/server/server_test.go
+++ b/gestaltd/internal/server/server_test.go
@@ -4483,108 +4483,6 @@ func TestListIntegrations_ManualProvidersWithoutDeclaredCredentialsExposeGeneric
 	}
 }
 
-func TestListIntegrations_CompositeProvidersExposeAPIConnectionMetadata(t *testing.T) {
-	t.Parallel()
-
-	apiProv := &stubManualProviderWithCapabilities{
-		stubManualProvider: stubManualProvider{
-			StubIntegration: coretesting.StubIntegration{N: "docs", DN: "Docs"},
-		},
-		credentialFields: []core.CredentialFieldDef{
-			{Name: "api_key", Label: "API Key", Description: "Docs API key"},
-		},
-		connectionParams: map[string]core.ConnectionParamDef{
-			"tenant": {
-				Required:    true,
-				Description: "Tenant slug",
-				Default:     "acme",
-			},
-		},
-	}
-	prov := composite.New("docs", apiProv, &stubIntegrationWithSessionCatalog{
-		stubIntegrationWithOps: stubIntegrationWithOps{
-			StubIntegration: coretesting.StubIntegration{N: "docs-mcp", ConnMode: core.ConnectionModeNone},
-		},
-	})
-
-	ts := newTestServer(t, func(cfg *server.Config) {
-		cfg.Providers = testutil.NewProviderRegistry(t, prov)
-		cfg.PluginDefs = map[string]*config.ProviderEntry{
-			"docs": {},
-		}
-		cfg.Services = coretesting.NewStubServices(t)
-	})
-	testutil.CloseOnCleanup(t, ts)
-
-	req, _ := http.NewRequest(http.MethodGet, ts.URL+"/api/v1/integrations", nil)
-	resp, err := http.DefaultClient.Do(req)
-	if err != nil {
-		t.Fatalf("request: %v", err)
-	}
-	defer func() { _ = resp.Body.Close() }()
-
-	if resp.StatusCode != http.StatusOK {
-		t.Fatalf("expected 200, got %d", resp.StatusCode)
-	}
-
-	type credentialField struct {
-		Name        string `json:"name"`
-		Label       string `json:"label"`
-		Description string `json:"description"`
-	}
-	type connectionParam struct {
-		Required    bool   `json:"required"`
-		Description string `json:"description"`
-		Default     string `json:"default"`
-	}
-	var integrations []struct {
-		Name             string                     `json:"name"`
-		AuthTypes        []string                   `json:"authTypes"`
-		CredentialFields []credentialField          `json:"credentialFields"`
-		ConnectionParams map[string]connectionParam `json:"connectionParams"`
-		Connections      []struct {
-			Name             string            `json:"name"`
-			AuthTypes        []string          `json:"authTypes"`
-			CredentialFields []credentialField `json:"credentialFields"`
-		} `json:"connections"`
-	}
-	if err := json.NewDecoder(resp.Body).Decode(&integrations); err != nil {
-		t.Fatalf("decoding: %v", err)
-	}
-	if len(integrations) != 1 {
-		t.Fatalf("expected 1 integration, got %d", len(integrations))
-	}
-
-	wantFields := []credentialField{{Name: "api_key", Label: "API Key", Description: "Docs API key"}}
-	if !reflect.DeepEqual(integrations[0].AuthTypes, []string{"manual"}) {
-		t.Fatalf("auth types = %v, want [manual]", integrations[0].AuthTypes)
-	}
-	if !reflect.DeepEqual(integrations[0].CredentialFields, wantFields) {
-		t.Fatalf("credential fields = %+v, want %+v", integrations[0].CredentialFields, wantFields)
-	}
-	if !reflect.DeepEqual(integrations[0].ConnectionParams, map[string]connectionParam{
-		"tenant": {
-			Required:    true,
-			Description: "Tenant slug",
-			Default:     "acme",
-		},
-	}) {
-		t.Fatalf("connection params = %+v", integrations[0].ConnectionParams)
-	}
-	if len(integrations[0].Connections) != 1 {
-		t.Fatalf("connections = %+v, want one default connection", integrations[0].Connections)
-	}
-	if integrations[0].Connections[0].Name != config.PluginConnectionAlias {
-		t.Fatalf("connection name = %q, want %q", integrations[0].Connections[0].Name, config.PluginConnectionAlias)
-	}
-	if !reflect.DeepEqual(integrations[0].Connections[0].AuthTypes, []string{"manual"}) {
-		t.Fatalf("connection auth types = %v, want [manual]", integrations[0].Connections[0].AuthTypes)
-	}
-	if !reflect.DeepEqual(integrations[0].Connections[0].CredentialFields, wantFields) {
-		t.Fatalf("connection credential fields = %+v, want %+v", integrations[0].Connections[0].CredentialFields, wantFields)
-	}
-}
-
 func TestListIntegrations_ConnectionInfosUseResolvedConnectionDefs(t *testing.T) {
 	t.Parallel()
 
@@ -4824,6 +4722,108 @@ func TestListIntegrations_ConnectionInfosUseResolvedConnectionDefs(t *testing.T)
 		}
 		if !reflect.DeepEqual(integrations[0].Connections[0].AuthTypes, []string{"manual"}) {
 			t.Fatalf("expected default authTypes [manual], got %+v", integrations[0].Connections[0].AuthTypes)
+		}
+	})
+
+	t.Run("composite wrappers preserve API metadata", func(t *testing.T) {
+		t.Parallel()
+
+		apiProv := &stubManualProviderWithCapabilities{
+			stubManualProvider: stubManualProvider{
+				StubIntegration: coretesting.StubIntegration{N: "docs", DN: "Docs"},
+			},
+			credentialFields: []core.CredentialFieldDef{
+				{Name: "api_key", Label: "API Key", Description: "Docs API key"},
+			},
+			connectionParams: map[string]core.ConnectionParamDef{
+				"tenant": {
+					Required:    true,
+					Description: "Tenant slug",
+					Default:     "acme",
+				},
+			},
+		}
+		prov := composite.New("docs", apiProv, &stubIntegrationWithSessionCatalog{
+			stubIntegrationWithOps: stubIntegrationWithOps{
+				StubIntegration: coretesting.StubIntegration{N: "docs-mcp", ConnMode: core.ConnectionModeNone},
+			},
+		})
+
+		ts := newTestServer(t, func(cfg *server.Config) {
+			cfg.Providers = testutil.NewProviderRegistry(t, prov)
+			cfg.PluginDefs = map[string]*config.ProviderEntry{
+				"docs": {},
+			}
+			cfg.Services = coretesting.NewStubServices(t)
+		})
+		testutil.CloseOnCleanup(t, ts)
+
+		req, _ := http.NewRequest(http.MethodGet, ts.URL+"/api/v1/integrations", nil)
+		resp, err := http.DefaultClient.Do(req)
+		if err != nil {
+			t.Fatalf("request: %v", err)
+		}
+		defer func() { _ = resp.Body.Close() }()
+
+		if resp.StatusCode != http.StatusOK {
+			t.Fatalf("expected 200, got %d", resp.StatusCode)
+		}
+
+		type credentialField struct {
+			Name        string `json:"name"`
+			Label       string `json:"label"`
+			Description string `json:"description"`
+		}
+		type connectionParam struct {
+			Required    bool   `json:"required"`
+			Description string `json:"description"`
+			Default     string `json:"default"`
+		}
+		var integrations []struct {
+			Name             string                     `json:"name"`
+			AuthTypes        []string                   `json:"authTypes"`
+			CredentialFields []credentialField          `json:"credentialFields"`
+			ConnectionParams map[string]connectionParam `json:"connectionParams"`
+			Connections      []struct {
+				Name             string            `json:"name"`
+				AuthTypes        []string          `json:"authTypes"`
+				CredentialFields []credentialField `json:"credentialFields"`
+			} `json:"connections"`
+		}
+		if err := json.NewDecoder(resp.Body).Decode(&integrations); err != nil {
+			t.Fatalf("decoding: %v", err)
+		}
+		if len(integrations) != 1 {
+			t.Fatalf("expected 1 integration, got %d", len(integrations))
+		}
+
+		wantFields := []credentialField{{Name: "api_key", Label: "API Key", Description: "Docs API key"}}
+		if !reflect.DeepEqual(integrations[0].AuthTypes, []string{"manual"}) {
+			t.Fatalf("auth types = %v, want [manual]", integrations[0].AuthTypes)
+		}
+		if !reflect.DeepEqual(integrations[0].CredentialFields, wantFields) {
+			t.Fatalf("credential fields = %+v, want %+v", integrations[0].CredentialFields, wantFields)
+		}
+		if !reflect.DeepEqual(integrations[0].ConnectionParams, map[string]connectionParam{
+			"tenant": {
+				Required:    true,
+				Description: "Tenant slug",
+				Default:     "acme",
+			},
+		}) {
+			t.Fatalf("connection params = %+v", integrations[0].ConnectionParams)
+		}
+		if len(integrations[0].Connections) != 1 {
+			t.Fatalf("connections = %+v, want one default connection", integrations[0].Connections)
+		}
+		if integrations[0].Connections[0].Name != config.PluginConnectionAlias {
+			t.Fatalf("connection name = %q, want %q", integrations[0].Connections[0].Name, config.PluginConnectionAlias)
+		}
+		if !reflect.DeepEqual(integrations[0].Connections[0].AuthTypes, []string{"manual"}) {
+			t.Fatalf("connection auth types = %v, want [manual]", integrations[0].Connections[0].AuthTypes)
+		}
+		if !reflect.DeepEqual(integrations[0].Connections[0].CredentialFields, wantFields) {
+			t.Fatalf("connection credential fields = %+v, want %+v", integrations[0].Connections[0].CredentialFields, wantFields)
 		}
 	})
 
@@ -11052,92 +11052,6 @@ func TestConnectManual(t *testing.T) {
 			t.Fatalf("expected workspace metadata beta, got %q", metadata["workspace"])
 		}
 	})
-}
-
-func TestConnectManual_CompositeProviderPreservesDiscoveryAndConnectionMetadata(t *testing.T) {
-	t.Parallel()
-
-	discoverySrv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
-		w.Header().Set("Content-Type", "application/json")
-		_, _ = io.WriteString(w, `[{"id":"site-a","name":"Site A","workspace":"alpha"}]`)
-	}))
-	testutil.CloseOnCleanup(t, discoverySrv)
-
-	svc := coretesting.NewStubServices(t)
-	apiProv := &stubManualProviderWithCapabilities{
-		stubManualProvider: stubManualProvider{
-			StubIntegration: coretesting.StubIntegration{N: "manual-svc"},
-		},
-		connectionParams: map[string]core.ConnectionParamDef{
-			"tenant": {
-				Required:    true,
-				Description: "Tenant slug",
-			},
-		},
-		discovery: &core.DiscoveryConfig{
-			URL:      discoverySrv.URL,
-			IDPath:   "id",
-			NamePath: "name",
-			Metadata: map[string]string{"workspace": "workspace"},
-		},
-	}
-	prov := composite.New("manual-svc", apiProv, &stubIntegrationWithSessionCatalog{
-		stubIntegrationWithOps: stubIntegrationWithOps{
-			StubIntegration: coretesting.StubIntegration{N: "manual-svc-mcp", ConnMode: core.ConnectionModeNone},
-		},
-	})
-
-	ts := newTestServer(t, func(cfg *server.Config) {
-		cfg.Providers = testutil.NewProviderRegistry(t, prov)
-		cfg.DefaultConnection = map[string]string{"manual-svc": config.PluginConnectionName}
-		cfg.PluginDefs = map[string]*config.ProviderEntry{
-			"manual-svc": {},
-		}
-		cfg.Services = svc
-	})
-	testutil.CloseOnCleanup(t, ts)
-
-	body := bytes.NewBufferString(`{"integration":"manual-svc","credential":"my-api-key","connectionParams":{"tenant":"acme"}}`)
-	req, _ := http.NewRequest(http.MethodPost, ts.URL+"/api/v1/auth/connect-manual", body)
-	req.Header.Set("Content-Type", "application/json")
-	resp, err := http.DefaultClient.Do(req)
-	if err != nil {
-		t.Fatalf("request: %v", err)
-	}
-	defer func() { _ = resp.Body.Close() }()
-
-	if resp.StatusCode != http.StatusOK {
-		t.Fatalf("expected 200, got %d", resp.StatusCode)
-	}
-
-	var result map[string]string
-	if err := json.NewDecoder(resp.Body).Decode(&result); err != nil {
-		t.Fatalf("decoding: %v", err)
-	}
-	if result["status"] != "connected" {
-		t.Fatalf("expected connected, got %q", result["status"])
-	}
-
-	u, _ := svc.Users.FindOrCreateUser(context.Background(), "anonymous@gestalt")
-	tokens, _ := svc.Tokens.ListTokens(context.Background(), u.ID)
-	if len(tokens) != 1 {
-		t.Fatalf("expected 1 stored token, got %d", len(tokens))
-	}
-
-	var metadata map[string]string
-	if err := json.Unmarshal([]byte(tokens[0].MetadataJSON), &metadata); err != nil {
-		t.Fatalf("unmarshal metadata: %v", err)
-	}
-	if !reflect.DeepEqual(metadata, map[string]string{
-		"tenant":    "acme",
-		"workspace": "alpha",
-	}) {
-		t.Fatalf("metadata = %+v", metadata)
-	}
-}
-
-func TestConnectManual_RestrictedProviderPreservesValidationAndDiscovery(t *testing.T) {
-	t.Parallel()
 
 	t.Run("rejects unknown connection params when provider exposes none", func(t *testing.T) {
 		t.Parallel()
@@ -11174,7 +11088,89 @@ func TestConnectManual_RestrictedProviderPreservesValidationAndDiscovery(t *test
 		}
 	})
 
-	t.Run("preserves discovery and connection metadata", func(t *testing.T) {
+	t.Run("composite wrappers preserve discovery and connection metadata", func(t *testing.T) {
+		t.Parallel()
+
+		discoverySrv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+			w.Header().Set("Content-Type", "application/json")
+			_, _ = io.WriteString(w, `[{"id":"site-a","name":"Site A","workspace":"alpha"}]`)
+		}))
+		testutil.CloseOnCleanup(t, discoverySrv)
+
+		svc := coretesting.NewStubServices(t)
+		apiProv := &stubManualProviderWithCapabilities{
+			stubManualProvider: stubManualProvider{
+				StubIntegration: coretesting.StubIntegration{N: "manual-svc"},
+			},
+			connectionParams: map[string]core.ConnectionParamDef{
+				"tenant": {
+					Required:    true,
+					Description: "Tenant slug",
+				},
+			},
+			discovery: &core.DiscoveryConfig{
+				URL:      discoverySrv.URL,
+				IDPath:   "id",
+				NamePath: "name",
+				Metadata: map[string]string{"workspace": "workspace"},
+			},
+		}
+		prov := composite.New("manual-svc", apiProv, &stubIntegrationWithSessionCatalog{
+			stubIntegrationWithOps: stubIntegrationWithOps{
+				StubIntegration: coretesting.StubIntegration{N: "manual-svc-mcp", ConnMode: core.ConnectionModeNone},
+			},
+		})
+
+		ts := newTestServer(t, func(cfg *server.Config) {
+			cfg.Providers = testutil.NewProviderRegistry(t, prov)
+			cfg.DefaultConnection = map[string]string{"manual-svc": config.PluginConnectionName}
+			cfg.PluginDefs = map[string]*config.ProviderEntry{
+				"manual-svc": {},
+			}
+			cfg.Services = svc
+		})
+		testutil.CloseOnCleanup(t, ts)
+
+		body := bytes.NewBufferString(`{"integration":"manual-svc","credential":"my-api-key","connectionParams":{"tenant":"acme"}}`)
+		req, _ := http.NewRequest(http.MethodPost, ts.URL+"/api/v1/auth/connect-manual", body)
+		req.Header.Set("Content-Type", "application/json")
+		resp, err := http.DefaultClient.Do(req)
+		if err != nil {
+			t.Fatalf("request: %v", err)
+		}
+		defer func() { _ = resp.Body.Close() }()
+
+		if resp.StatusCode != http.StatusOK {
+			t.Fatalf("expected 200, got %d", resp.StatusCode)
+		}
+
+		var result map[string]string
+		if err := json.NewDecoder(resp.Body).Decode(&result); err != nil {
+			t.Fatalf("decoding: %v", err)
+		}
+		if result["status"] != "connected" {
+			t.Fatalf("expected connected, got %q", result["status"])
+		}
+
+		u, _ := svc.Users.FindOrCreateUser(context.Background(), "anonymous@gestalt")
+		tokens, _ := svc.Tokens.ListTokens(context.Background(), u.ID)
+		if len(tokens) != 1 {
+			t.Fatalf("expected 1 stored token, got %d", len(tokens))
+		}
+
+		var metadata map[string]string
+		if err := json.Unmarshal([]byte(tokens[0].MetadataJSON), &metadata); err != nil {
+			t.Fatalf("unmarshal metadata: %v", err)
+		}
+		if !reflect.DeepEqual(metadata, map[string]string{
+			"tenant":    "acme",
+			"workspace": "alpha",
+		}) {
+			t.Fatalf("metadata = %+v", metadata)
+		}
+	})
+
+	t.Run("restricted wrappers preserve discovery and connection metadata", func(t *testing.T) {
 		t.Parallel()
 
 		discoverySrv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {

--- a/gestaltd/internal/server/server_test.go
+++ b/gestaltd/internal/server/server_test.go
@@ -6850,10 +6850,10 @@ func TestExecuteOperation_WrappedProvidersPreserveOperationConnectionRouting(t *
 			StubIntegration: coretesting.StubIntegration{N: "svc-mcp", ConnMode: core.ConnectionModeNone},
 		},
 	})
-	if got := core.OperationConnection(apiProv, "find"); got != "workspace" {
+	if got := apiProv.ConnectionForOperation("find"); got != "workspace" {
 		t.Fatalf("restricted op connection = %q, want workspace", got)
 	}
-	if got := core.OperationConnection(prov, "find"); got != "workspace" {
+	if got := prov.ConnectionForOperation("find"); got != "workspace" {
 		t.Fatalf("composite op connection = %q, want workspace", got)
 	}
 
@@ -9717,7 +9717,7 @@ func (s *stubIntegrationWithSessionCatalog) CatalogForRequest(ctx context.Contex
 	return s.catalog, nil
 }
 
-func (s *stubIntegrationWithSessionCatalog) SupportsManualAuth() bool { return true }
+func (s *stubIntegrationWithSessionCatalog) AuthTypes() []string      { return []string{"manual"} }
 func (s *stubIntegrationWithSessionCatalog) Close() error             { return nil }
 func (s *stubIntegrationWithSessionCatalog) CallTool(ctx context.Context, name string, args map[string]any) (*mcpgo.CallToolResult, error) {
 	if s.callFn != nil {
@@ -9900,6 +9900,13 @@ func (s *stubNonOAuthProvider) Name() string                        { return s.n
 func (s *stubNonOAuthProvider) DisplayName() string                 { return s.name }
 func (s *stubNonOAuthProvider) Description() string                 { return "" }
 func (s *stubNonOAuthProvider) ConnectionMode() core.ConnectionMode { return core.ConnectionModeUser }
+func (s *stubNonOAuthProvider) AuthTypes() []string                 { return nil }
+func (s *stubNonOAuthProvider) ConnectionParamDefs() map[string]core.ConnectionParamDef {
+	return nil
+}
+func (s *stubNonOAuthProvider) CredentialFields() []core.CredentialFieldDef { return nil }
+func (s *stubNonOAuthProvider) DiscoveryConfig() *core.DiscoveryConfig      { return nil }
+func (s *stubNonOAuthProvider) ConnectionForOperation(string) string        { return "" }
 func (s *stubNonOAuthProvider) Catalog() *catalog.Catalog {
 	if s.catalog != nil {
 		return s.catalog
@@ -10693,7 +10700,7 @@ type stubManualProvider struct {
 	coretesting.StubIntegration
 }
 
-func (s *stubManualProvider) SupportsManualAuth() bool { return true }
+func (s *stubManualProvider) AuthTypes() []string { return []string{"manual"} }
 
 type stubNilAuthTypesProvider struct {
 	coretesting.StubIntegration
@@ -10742,8 +10749,7 @@ type stubDualAuthProvider struct {
 	coretesting.StubIntegration
 }
 
-func (s *stubDualAuthProvider) SupportsManualAuth() bool { return true }
-func (s *stubDualAuthProvider) AuthTypes() []string      { return []string{"oauth", "manual"} }
+func (s *stubDualAuthProvider) AuthTypes() []string { return []string{"oauth", "manual"} }
 func (s *stubDualAuthProvider) CredentialFields() []core.CredentialFieldDef {
 	return []core.CredentialFieldDef{{Name: "api_token", Label: "API Token"}}
 }

--- a/gestaltd/internal/testplugins/echo/main.go
+++ b/gestaltd/internal/testplugins/echo/main.go
@@ -46,6 +46,13 @@ func (p *echoProvider) Name() string                        { return "echo" }
 func (p *echoProvider) DisplayName() string                 { return "Echo" }
 func (p *echoProvider) Description() string                 { return "Echoes back the input parameters" }
 func (p *echoProvider) ConnectionMode() core.ConnectionMode { return core.ConnectionModeNone }
+func (p *echoProvider) AuthTypes() []string                 { return nil }
+func (p *echoProvider) ConnectionParamDefs() map[string]core.ConnectionParamDef {
+	return nil
+}
+func (p *echoProvider) CredentialFields() []core.CredentialFieldDef { return nil }
+func (p *echoProvider) DiscoveryConfig() *core.DiscoveryConfig      { return nil }
+func (p *echoProvider) ConnectionForOperation(string) string        { return "" }
 func (p *echoProvider) Catalog() *catalog.Catalog {
 	return &catalog.Catalog{
 		Name:        p.Name(),

--- a/gestaltd/internal/testplugins/echo/proxy_provider.go
+++ b/gestaltd/internal/testplugins/echo/proxy_provider.go
@@ -26,6 +26,19 @@ func (p *proxyProvider) Name() string                        { return p.inner.Na
 func (p *proxyProvider) DisplayName() string                 { return p.inner.DisplayName() }
 func (p *proxyProvider) Description() string                 { return p.inner.Description() }
 func (p *proxyProvider) ConnectionMode() core.ConnectionMode { return p.inner.ConnectionMode() }
+func (p *proxyProvider) AuthTypes() []string                 { return p.inner.AuthTypes() }
+func (p *proxyProvider) ConnectionParamDefs() map[string]core.ConnectionParamDef {
+	return p.inner.ConnectionParamDefs()
+}
+func (p *proxyProvider) CredentialFields() []core.CredentialFieldDef {
+	return p.inner.CredentialFields()
+}
+func (p *proxyProvider) DiscoveryConfig() *core.DiscoveryConfig {
+	return p.inner.DiscoveryConfig()
+}
+func (p *proxyProvider) ConnectionForOperation(operation string) string {
+	return p.inner.ConnectionForOperation(operation)
+}
 func (p *proxyProvider) Catalog() *catalog.Catalog {
 	var cat *catalog.Catalog
 	if inner := p.inner.Catalog(); inner != nil {


### PR DESCRIPTION
## Summary
This PR removes repeated wrapper-specific branching by centralizing provider capability lookup in `gestaltd/core` and by making wrapper providers preserve the capability interfaces they already logically expose.

It specifically:
- adds shared capability helpers for session catalogs, operation-level connection routing, auth types, credential fields, connection params, and discovery config
- makes `composite.Provider` preserve REST-side capability interfaces instead of forcing callers to rediscover them through ad hoc type assertions
- makes `integration.Restricted` preserve operation routing, connection metadata, and discovery behavior while still enforcing aliasing/allowed-operation boundaries
- replaces repeated optional-interface branching in server, invocation, MCP, and providerhost codepaths with the shared helpers
- adds server-level behavior coverage for composite and restricted wrappers instead of adding new low-value unit tests

## Go Interface
New helper surface in Go:
```go
if core.SupportsSessionCatalog(prov) {
    cat, _, err := core.CatalogForRequest(ctx, prov, token)
    _ = cat
    _ = err
}

conn := core.OperationConnection(prov, "find")
fields := core.CredentialFields(prov)
params := core.ConnectionParamDefs(prov)
if core.HasConnectionParamDefs(prov) {
    // validate request-supplied connection params
}
```

Wrapper-preserved capabilities in Go:
- `composite.Provider`
  - `OperationConnectionProvider`
  - `ConnectionParamProvider`
  - `CredentialFieldsProvider`
  - `DiscoveryConfigProvider`
- `integration.Restricted`
  - `OperationConnectionProvider` with alias translation
  - `ConnectionParamProvider`
  - `CredentialFieldsProvider`
  - `DiscoveryConfigProvider`

## YAML Interface
There is no schema change in YAML. The point of this PR is that existing `params`, `discovery`, and `allowed_operations` config now survives wrapper layers without more special-casing.

Example preserved YAML:
```yaml
connections:
  default:
    mode: user
    auth:
      type: oauth2
    params:
      workspace_id:
        required: true
        from: discovery
    discovery:
      url: https://api.example.com/workspaces
      idPath: id
      namePath: name
      metadata:
        workspace_id: id
allowed_operations:
  find: search
```

This PR ensures the Go wrapper path still exposes the same connection metadata/discovery behavior implied by that YAML, including the aliased `find -> search` operation route.

## Examples
Go wrapper example:
```go
prov := composite.New("docs", apiProv, mcpUp)
if core.SupportsSessionCatalog(prov) {
    cat, _, _ := core.CatalogForRequest(ctx, prov, token)
    _ = cat
}
conn := core.OperationConnection(prov, "find")
```

YAML behavior example:
```yaml
connections:
  default:
    params:
      tenant:
        required: true
        description: Tenant slug
    discovery:
      url: https://api.example.com/sites
      idPath: id
      namePath: name
      metadata:
        workspace: workspace
allowed_operations:
  find: search
```

With this PR, the wrapped provider still:
- lists `tenant` as a connection parameter
- preserves discovery after connect
- routes aliased `find` through the operation-specific stored connection for `search`

## Verification
Functional/integration coverage added or exercised:
- `go test ./core/... ./internal/composite ./internal/invocation ./internal/mcp ./internal/providerhost ./internal/server`
- new server-level coverage for:
  - composite integration metadata exposure
  - composite manual-connect discovery + connection metadata
  - restricted manual-connect validation + discovery forwarding
  - restricted/composite operation-connection routing end to end
