### PR TITLE
sdk/typescript: add packaged coverage for provider targets

### DIFF
--- a/sdk/typescript/src/build.ts
+++ b/sdk/typescript/src/build.ts
@@ -159,17 +159,17 @@ await runBundledProvider(candidate, ${JSON.stringify(target.kind)}, ${JSON.strin
 function defaultBundledCandidateExpression(kind: ProviderTarget["kind"]): string {
   switch (kind) {
     case "integration":
-      return "bundledModule.provider ?? bundledModule.plugin ?? bundledModule.default";
+      return 'Reflect.get(bundledModule, "provider") ?? Reflect.get(bundledModule, "plugin") ?? bundledModule.default';
     case "auth":
-      return "bundledModule.auth ?? bundledModule.provider ?? bundledModule.default";
+      return 'Reflect.get(bundledModule, "auth") ?? Reflect.get(bundledModule, "provider") ?? bundledModule.default';
     case "cache":
-      return "bundledModule.cache ?? bundledModule.provider ?? bundledModule.default";
+      return 'Reflect.get(bundledModule, "cache") ?? Reflect.get(bundledModule, "provider") ?? bundledModule.default';
     case "secrets":
-      return "bundledModule.secrets ?? bundledModule.provider ?? bundledModule.default";
+      return 'Reflect.get(bundledModule, "secrets") ?? Reflect.get(bundledModule, "provider") ?? bundledModule.default';
     case "s3":
-      return "bundledModule.s3 ?? bundledModule.provider ?? bundledModule.default";
+      return 'Reflect.get(bundledModule, "s3") ?? Reflect.get(bundledModule, "provider") ?? bundledModule.default';
     case "telemetry":
-      return "bundledModule.telemetry ?? bundledModule.provider ?? bundledModule.default";
+      return 'Reflect.get(bundledModule, "telemetry") ?? Reflect.get(bundledModule, "provider") ?? bundledModule.default';
   }
   throw new Error(`unsupported provider kind: ${kind satisfies never}`);
 }

--- a/sdk/typescript/tests/build.test.ts
+++ b/sdk/typescript/tests/build.test.ts
@@ -4,23 +4,61 @@ import { join } from "node:path";
 
 import { create } from "@bufbuild/protobuf";
 import { EmptySchema } from "@bufbuild/protobuf/wkt";
+import { Code, ConnectError } from "@connectrpc/connect";
 import { expect, test } from "bun:test";
 
 import { AuthProvider as AuthProviderService, BeginLoginRequestSchema } from "../gen/v1/auth_pb.ts";
 import { Cache as CacheService } from "../gen/v1/cache_pb.ts";
+import {
+  AccessContextSchema,
+  CredentialContextSchema,
+  ExecuteRequestSchema,
+  GetSessionCatalogRequestSchema,
+  IntegrationProvider as IntegrationProviderService,
+  RequestContextSchema,
+  StartProviderRequestSchema,
+  SubjectContextSchema,
+} from "../gen/v1/plugin_pb.ts";
+import {
+  GetSecretRequestSchema,
+  SecretsProvider as SecretsProviderService,
+} from "../gen/v1/secrets_pb.ts";
 import { S3 as S3Service } from "../gen/v1/s3_pb.ts";
 import { ConfigureProviderRequestSchema, ProviderKind as ProtoProviderKind, ProviderLifecycle } from "../gen/v1/runtime_pb.ts";
 import { buildProviderBinary, bunTarget, parseBuildArgs } from "../src/build.ts";
 import { Cache, cacheSocketEnv } from "../src/cache.ts";
 import { CURRENT_PROTOCOL_VERSION, ENV_PROVIDER_SOCKET } from "../src/runtime.ts";
 import {
+  captureChildStderr,
   createUnixGrpcClient,
   fixturePath,
   hostTarget,
   makeTempDir,
   removeTempDir,
+  stopProcess,
   waitForPath,
 } from "./helpers.ts";
+
+async function expectConnectCode(
+  promise: Promise<unknown>,
+  code: Code,
+): Promise<void> {
+  try {
+    await promise;
+    throw new Error(`expected ConnectError with code ${Code[code]}`);
+  } catch (error) {
+    expect(error).toBeInstanceOf(ConnectError);
+    expect((error as ConnectError).code).toBe(code);
+  }
+}
+
+async function waitForSocket(path: string, stderrText: () => string): Promise<void> {
+  try {
+    await waitForPath(path);
+  } catch (error) {
+    throw new Error(`${String(error)}${stderrText() ? `\n${stderrText()}` : ""}`);
+  }
+}
 
 test("build arg parsing validates required arguments", () => {
   expect(parseBuildArgs(["root", "auth:./auth.ts#provider", "out", "name", "darwin", "arm64"])).toEqual(
@@ -44,7 +82,6 @@ test("buildProviderBinary compiles a runnable auth provider executable", async (
   const outputPath = join(tempDir, `fixture-provider${executableSuffix}`);
   const socketPath = join(tempDir, "provider.sock");
   let child: ChildProcess | undefined;
-  let stderr = "";
 
   try {
     buildProviderBinary({
@@ -65,12 +102,9 @@ test("buildProviderBinary compiles a runnable auth provider executable", async (
       },
       stdio: ["ignore", "ignore", "pipe"],
     });
-    child.stderr?.setEncoding("utf8");
-    child.stderr?.on("data", (chunk: string) => {
-      stderr += chunk;
-    });
+    const stderrText = captureChildStderr(child);
 
-    await waitForPath(socketPath);
+    await waitForSocket(socketPath, stderrText);
 
     const runtime = createUnixGrpcClient(ProviderLifecycle, socketPath);
     const auth = createUnixGrpcClient(AuthProviderService, socketPath);
@@ -108,6 +142,198 @@ test("buildProviderBinary compiles a runnable auth provider executable", async (
   }
 }, 15_000);
 
+test("buildProviderBinary compiles a runnable integration provider executable for plugin and integration targets", async () => {
+  const { goos, goarch, executableSuffix } = hostTarget();
+  const tempDir = makeTempDir("gts-integration-");
+
+  try {
+    for (const [label, target] of [
+      ["plugin", "plugin:./provider.ts#plugin"],
+      ["integration", "integration:./provider.ts#plugin"],
+    ] as const) {
+      const outputPath = join(tempDir, `fixture-${label}${executableSuffix}`);
+      const socketPath = join(tempDir, `${label}.sock`);
+      let child: ChildProcess | undefined;
+
+      try {
+        buildProviderBinary({
+          root: fixturePath("basic-provider"),
+          target,
+          outputPath,
+          providerName: `fixture-${label}`,
+          goos,
+          goarch,
+        });
+
+        expect(existsSync(outputPath)).toBe(true);
+
+        child = spawn(outputPath, [], {
+          env: {
+            ...process.env,
+            [ENV_PROVIDER_SOCKET]: socketPath,
+          },
+          stdio: ["ignore", "ignore", "pipe"],
+        });
+        const stderrText = captureChildStderr(child);
+
+        await waitForSocket(socketPath, stderrText);
+
+        const runtime = createUnixGrpcClient(ProviderLifecycle, socketPath);
+        const provider = createUnixGrpcClient(
+          IntegrationProviderService,
+          socketPath,
+        );
+
+        const identity = await runtime.getProviderIdentity(create(EmptySchema, {}));
+        expect(identity.kind).toBe(ProtoProviderKind.INTEGRATION);
+        expect(identity.name).toBe(`fixture-${label}`);
+        expect(identity.minProtocolVersion).toBe(CURRENT_PROTOCOL_VERSION);
+        expect(identity.maxProtocolVersion).toBe(CURRENT_PROTOCOL_VERSION);
+
+        const metadata = await provider.getMetadata(create(EmptySchema, {}));
+        expect(metadata.name).toBe(`fixture-${label}`);
+        expect(metadata.supportsSessionCatalog).toBe(true);
+        expect(metadata.minProtocolVersion).toBe(CURRENT_PROTOCOL_VERSION);
+        expect(metadata.maxProtocolVersion).toBe(CURRENT_PROTOCOL_VERSION);
+        expect(
+          metadata.staticCatalog?.operations?.some((operation) => operation.id === "hello"),
+        ).toBe(true);
+        expect(
+          metadata.staticCatalog?.operations?.some((operation) => operation.id === "count"),
+        ).toBe(true);
+
+        await expectConnectCode(
+          provider.startProvider(
+            create(StartProviderRequestSchema, {
+              name: `fixture-${label}`,
+              config: {
+                region: "use1",
+              },
+              protocolVersion: CURRENT_PROTOCOL_VERSION + 1,
+            }),
+          ),
+          Code.FailedPrecondition,
+        );
+
+        const started = await provider.startProvider(
+          create(StartProviderRequestSchema, {
+            name: `fixture-${label}`,
+            config: {
+              region: "use1",
+            },
+            protocolVersion: CURRENT_PROTOCOL_VERSION,
+          }),
+        );
+        expect(started.protocolVersion).toBe(CURRENT_PROTOCOL_VERSION);
+
+        const result = await provider.execute(
+          create(ExecuteRequestSchema, {
+            operation: "hello",
+            params: {
+              name: "Ada",
+            },
+            token: "token-123",
+            connectionParams: {
+              region: "iad",
+            },
+            context: create(RequestContextSchema, {
+              subject: create(SubjectContextSchema, {
+                id: "user:user-123",
+                kind: "user",
+                authSource: "api_token",
+              }),
+              credential: create(CredentialContextSchema, {
+                mode: "identity",
+                subjectId: "identity:__identity__",
+              }),
+              access: create(AccessContextSchema, {
+                policy: "sample_policy",
+                role: "admin",
+              }),
+            }),
+          }),
+        );
+        expect(JSON.parse(result.body)).toEqual({
+          message: "Hello, Ada.",
+          configuredName: `fixture-${label}`,
+          region: "iad",
+          configuredRegion: "use1",
+          subjectId: "user:user-123",
+          credentialMode: "identity",
+          accessPolicy: "sample_policy",
+          accessRole: "admin",
+        });
+
+        const countResult = await provider.execute(
+          create(ExecuteRequestSchema, {
+            operation: "count",
+            params: {
+              count: 7,
+            },
+          }),
+        );
+        expect(countResult.status).toBe(200);
+        expect(JSON.parse(countResult.body)).toEqual({
+          count: 7,
+        });
+
+        const decodeError = await provider.execute(
+          create(ExecuteRequestSchema, {
+            operation: "count",
+            params: {
+              count: "oops",
+            },
+          }),
+        );
+        expect(decodeError.status).toBe(400);
+        expect(JSON.parse(decodeError.body)).toEqual({
+          error: "$.count must be an integer",
+        });
+
+        const sessionCatalog = await provider.getSessionCatalog(
+          create(GetSessionCatalogRequestSchema, {
+            token: "token-123",
+            connectionParams: {
+              scope: label,
+            },
+            context: create(RequestContextSchema, {
+              subject: create(SubjectContextSchema, {
+                id: "user:user-123",
+                kind: "user",
+              }),
+              credential: create(CredentialContextSchema, {
+                mode: "identity",
+              }),
+              access: create(AccessContextSchema, {
+                policy: "sample_policy",
+                role: "viewer",
+              }),
+            }),
+          }),
+        );
+        expect(sessionCatalog.catalog?.name).toBe("fixture-session");
+        expect(sessionCatalog.catalog?.operations).toHaveLength(1);
+        const sessionOperation = sessionCatalog.catalog?.operations?.[0];
+        expect(sessionOperation).toBeDefined();
+        expect(sessionOperation?.id).toBe("session-hello");
+        expect(sessionOperation?.allowedRoles).toEqual([
+          "viewer",
+          "admin",
+        ]);
+        expect(sessionOperation?.title).toBe(
+          `Session Hello ${label} user:user-123 identity viewer`,
+        );
+      } finally {
+        if (child) {
+          await stopProcess(child);
+        }
+      }
+    }
+  } finally {
+    removeTempDir(tempDir);
+  }
+}, 30_000);
+
 test("buildProviderBinary compiles a runnable cache provider executable", async () => {
   const { goos, goarch, executableSuffix } = hostTarget();
   const tempDir = makeTempDir("gts-cache-");
@@ -116,7 +342,6 @@ test("buildProviderBinary compiles a runnable cache provider executable", async 
   const previousDefaultSocket = process.env.GESTALT_CACHE_SOCKET;
   const previousNamedSocket = process.env[cacheSocketEnv("named")];
   let child: ChildProcess | undefined;
-  let stderr = "";
 
   try {
     buildProviderBinary({
@@ -137,16 +362,9 @@ test("buildProviderBinary compiles a runnable cache provider executable", async 
       },
       stdio: ["ignore", "ignore", "pipe"],
     });
-    child.stderr?.setEncoding("utf8");
-    child.stderr?.on("data", (chunk: string) => {
-      stderr += chunk;
-    });
+    const stderrText = captureChildStderr(child);
 
-    try {
-      await waitForPath(socketPath);
-    } catch (error) {
-      throw new Error(`${String(error)}${stderr ? `\n${stderr}` : ""}`);
-    }
+    await waitForSocket(socketPath, stderrText);
 
     const runtime = createUnixGrpcClient(ProviderLifecycle, socketPath);
     const rawCache = createUnixGrpcClient(CacheService, socketPath);
@@ -232,6 +450,93 @@ test("buildProviderBinary compiles a runnable cache provider executable", async 
   }
 }, 15_000);
 
+test("buildProviderBinary compiles a runnable secrets provider executable", async () => {
+  const { goos, goarch, executableSuffix } = hostTarget();
+  const tempDir = makeTempDir("gts-secrets-");
+  const outputPath = join(tempDir, `fixture-secrets${executableSuffix}`);
+  const socketPath = join(tempDir, "provider.sock");
+  let child: ChildProcess | undefined;
+
+  try {
+    buildProviderBinary({
+      root: fixturePath("secrets-provider"),
+      target: "secrets:./secrets.ts",
+      outputPath,
+      providerName: "fixture-secrets-built",
+      goos,
+      goarch,
+    });
+
+    expect(existsSync(outputPath)).toBe(true);
+
+    child = spawn(outputPath, [], {
+      env: {
+        ...process.env,
+        [ENV_PROVIDER_SOCKET]: socketPath,
+      },
+      stdio: ["ignore", "ignore", "pipe"],
+    });
+    const stderrText = captureChildStderr(child);
+
+    await waitForSocket(socketPath, stderrText);
+
+    const runtime = createUnixGrpcClient(ProviderLifecycle, socketPath);
+    const secrets = createUnixGrpcClient(SecretsProviderService, socketPath);
+
+    const metadata = await runtime.getProviderIdentity(create(EmptySchema, {}));
+    expect(metadata.kind).toBe(ProtoProviderKind.SECRETS);
+    expect(metadata.name).toBe("fixture-secrets-built");
+    expect(metadata.displayName).toBe("Fixture Secrets");
+    expect(metadata.minProtocolVersion).toBe(CURRENT_PROTOCOL_VERSION);
+    expect(metadata.maxProtocolVersion).toBe(CURRENT_PROTOCOL_VERSION);
+
+    await expectConnectCode(
+      runtime.configureProvider(
+        create(ConfigureProviderRequestSchema, {
+          name: "fixture-secrets-built",
+          config: {
+            scope: "binary",
+          },
+          protocolVersion: CURRENT_PROTOCOL_VERSION + 1,
+        }),
+      ),
+      Code.FailedPrecondition,
+    );
+
+    const configured = await runtime.configureProvider(
+      create(ConfigureProviderRequestSchema, {
+        name: "fixture-secrets-built",
+        config: {
+          scope: "binary",
+        },
+        protocolVersion: CURRENT_PROTOCOL_VERSION,
+      }),
+    );
+    expect(configured.protocolVersion).toBe(CURRENT_PROTOCOL_VERSION);
+
+    const secret = await secrets.getSecret(
+      create(GetSecretRequestSchema, {
+        name: "db-password",
+      }),
+    );
+    expect(secret.value).toBe("fixture-secrets-built:binary:hunter2");
+
+    await expectConnectCode(
+      secrets.getSecret(
+        create(GetSecretRequestSchema, {
+          name: "missing",
+        }),
+      ),
+      Code.NotFound,
+    );
+  } finally {
+    if (child) {
+      await stopProcess(child);
+    }
+    removeTempDir(tempDir);
+  }
+}, 15_000);
+
 test("buildProviderBinary compiles a runnable s3 provider executable", async () => {
   const { goos, goarch, executableSuffix } = hostTarget();
   const tempDir = makeTempDir("gestalt-typescript-s3-build-test-");
@@ -258,8 +563,9 @@ test("buildProviderBinary compiles a runnable s3 provider executable", async () 
       },
       stdio: ["ignore", "ignore", "pipe"],
     });
+    const stderrText = captureChildStderr(child);
 
-    await waitForPath(socketPath);
+    await waitForSocket(socketPath, stderrText);
 
     const runtime = createUnixGrpcClient(ProviderLifecycle, socketPath);
     const s3 = createUnixGrpcClient(S3Service, socketPath);
@@ -312,41 +618,3 @@ test("buildProviderBinary compiles a runnable s3 provider executable", async () 
     removeTempDir(tempDir);
   }
 });
-
-async function stopProcess(child: ChildProcess): Promise<void> {
-  if (child.exitCode !== null || child.signalCode !== null) {
-    return;
-  }
-  child.kill("SIGTERM");
-  try {
-    await waitForExit(child, 2_000);
-  } catch {
-    child.kill("SIGKILL");
-    await waitForExit(child, 2_000);
-  }
-}
-
-async function waitForExit(
-  child: ChildProcess,
-  timeoutMs: number,
-): Promise<{ code: number | null; signal: NodeJS.Signals | null }> {
-  if (child.exitCode !== null || child.signalCode !== null) {
-    return {
-      code: child.exitCode,
-      signal: child.signalCode,
-    };
-  }
-  return await new Promise((resolve, reject) => {
-    const timer = setTimeout(() => {
-      reject(new Error("timed out waiting for child process to exit"));
-    }, timeoutMs);
-    child.once("close", (code, signal) => {
-      clearTimeout(timer);
-      resolve({ code, signal });
-    });
-    child.once("error", (error) => {
-      clearTimeout(timer);
-      reject(error);
-    });
-  });
-}

--- a/sdk/typescript/tests/fixtures/basic-provider/provider.ts
+++ b/sdk/typescript/tests/fixtures/basic-provider/provider.ts
@@ -78,5 +78,22 @@ export const plugin = definePlugin({
         });
       },
     }),
+    operation({
+      id: "count",
+      method: "POST",
+      title: "Count",
+      description: "Echo an integer count",
+      input: s.object({
+        count: s.integer(),
+      }),
+      output: s.object({
+        count: s.integer(),
+      }),
+      handler(input) {
+        return ok({
+          count: input.count,
+        });
+      },
+    }),
   ],
 });

--- a/sdk/typescript/tests/fixtures/secrets-provider/package.json
+++ b/sdk/typescript/tests/fixtures/secrets-provider/package.json
@@ -1,0 +1,10 @@
+{
+  "name": "@fixtures/secrets-provider",
+  "type": "module",
+  "gestalt": {
+    "provider": {
+      "kind": "secrets",
+      "target": "./secrets.ts"
+    }
+  }
+}

--- a/sdk/typescript/tests/fixtures/secrets-provider/secrets.ts
+++ b/sdk/typescript/tests/fixtures/secrets-provider/secrets.ts
@@ -1,0 +1,26 @@
+import { Code, ConnectError } from "@connectrpc/connect";
+
+import { defineSecretsProvider } from "../../../src/index.ts";
+
+let configuredName = "";
+let configuredScope = "";
+
+const provider = defineSecretsProvider({
+  displayName: "Fixture Secrets",
+  description: "Secrets fixture used by SDK tests",
+  configure(name, config) {
+    configuredName = name;
+    configuredScope = String(config.scope ?? "");
+  },
+  async getSecret(name) {
+    if (name === "db-password") {
+      return `${configuredName}:${configuredScope || "default"}:hunter2`;
+    }
+    if (name === "api-token") {
+      return `${configuredName}:${configuredScope || "default"}:token`;
+    }
+    throw new ConnectError(`secret ${name} not found`, Code.NotFound);
+  },
+});
+
+export default provider;

--- a/sdk/typescript/tests/helpers.ts
+++ b/sdk/typescript/tests/helpers.ts
@@ -1,3 +1,4 @@
+import { type ChildProcess } from "node:child_process";
 import { existsSync, mkdtempSync, rmSync } from "node:fs";
 import { connect } from "node:net";
 import { tmpdir } from "node:os";
@@ -70,4 +71,51 @@ export function createUnixGrpcClient<T extends DescService>(service: T, socketPa
     },
   });
   return createClient(service, transport);
+}
+
+export function captureChildStderr(child: ChildProcess): () => string {
+  let stderr = "";
+  child.stderr?.setEncoding("utf8");
+  child.stderr?.on("data", (chunk: string) => {
+    stderr += chunk;
+  });
+  return () => stderr;
+}
+
+export async function stopProcess(child: ChildProcess): Promise<void> {
+  if (child.exitCode !== null || child.signalCode !== null) {
+    return;
+  }
+  child.kill("SIGTERM");
+  try {
+    await waitForExit(child, 2_000);
+  } catch {
+    child.kill("SIGKILL");
+    await waitForExit(child, 2_000);
+  }
+}
+
+async function waitForExit(
+  child: ChildProcess,
+  timeoutMs: number,
+): Promise<{ code: number | null; signal: NodeJS.Signals | null }> {
+  if (child.exitCode !== null || child.signalCode !== null) {
+    return {
+      code: child.exitCode,
+      signal: child.signalCode,
+    };
+  }
+  return await new Promise((resolve, reject) => {
+    const timer = setTimeout(() => {
+      reject(new Error("timed out waiting for child process to exit"));
+    }, timeoutMs);
+    child.once("close", (code, signal) => {
+      clearTimeout(timer);
+      resolve({ code, signal });
+    });
+    child.once("error", (error) => {
+      clearTimeout(timer);
+      reject(error);
+    });
+  });
 }

--- a/sdk/typescript/tests/runtime.test.ts
+++ b/sdk/typescript/tests/runtime.test.ts
@@ -1,3 +1,4 @@
+import { spawn, type ChildProcess } from "node:child_process";
 import { readFileSync } from "node:fs";
 import { join } from "node:path";
 
@@ -30,13 +31,19 @@ import {
   SubjectContextSchema,
 } from "../gen/v1/plugin_pb.ts";
 import {
+  GetSecretRequestSchema,
+  SecretsProvider as SecretsProviderService,
+} from "../gen/v1/secrets_pb.ts";
+import {
   ConfigureProviderRequestSchema,
   ProviderKind as ProtoProviderKind,
+  ProviderLifecycle,
 } from "../gen/v1/runtime_pb.ts";
 import {
   CURRENT_PROTOCOL_VERSION,
   createCacheService,
   ENV_WRITE_CATALOG,
+  ENV_PROVIDER_SOCKET,
   createAuthService,
   createProviderService,
   createRuntimeService,
@@ -47,7 +54,15 @@ import {
 } from "../src/runtime.ts";
 import { PresignMethod, S3, defineCacheProvider, defineS3Provider } from "../src/index.ts";
 import { createS3Service } from "../src/s3.ts";
-import { fixturePath, makeTempDir, removeTempDir } from "./helpers.ts";
+import {
+  captureChildStderr,
+  createUnixGrpcClient,
+  fixturePath,
+  makeTempDir,
+  removeTempDir,
+  stopProcess,
+  waitForPath,
+} from "./helpers.ts";
 
 async function expectConnectCode(
   promise: Promise<unknown>,
@@ -92,6 +107,93 @@ test("runtime main writes a static catalog in catalog mode", async () => {
     removeTempDir(tempDir);
   }
 });
+
+test("loadProviderFromTarget resolves a secrets provider from package metadata", async () => {
+  const provider = await loadProviderFromTarget(fixturePath("secrets-provider"));
+  expect(provider.kind).toBe("secrets");
+  expect(provider.name).toBe("secrets-provider");
+  expect(provider.displayName).toBe("Fixture Secrets");
+});
+
+test("runtime serves a secrets provider over unix gRPC", async () => {
+  const runtimeEntry = join(import.meta.dir, "..", "src", "runtime.ts");
+  const root = fixturePath("secrets-provider");
+  const tempDir = makeTempDir("gestalt-typescript-runtime-");
+  const socketPath = join(tempDir, "provider.sock");
+  let child: ChildProcess | undefined;
+
+  try {
+    child = spawn(process.execPath, [runtimeEntry, root, "secrets:./secrets.ts"], {
+      env: {
+        ...process.env,
+        [ENV_PROVIDER_SOCKET]: socketPath,
+      },
+      stdio: ["ignore", "ignore", "pipe"],
+    });
+    const stderrText = captureChildStderr(child);
+
+    try {
+      await waitForPath(socketPath);
+    } catch (error) {
+      throw new Error(`${String(error)}${stderrText() ? `\n${stderrText()}` : ""}`);
+    }
+
+    const runtime = createUnixGrpcClient(ProviderLifecycle, socketPath);
+    const secrets = createUnixGrpcClient(SecretsProviderService, socketPath);
+
+    const metadata = await runtime.getProviderIdentity(create(EmptySchema, {}));
+    expect(metadata.kind).toBe(ProtoProviderKind.SECRETS);
+    expect(metadata.name).toBe("secrets-provider");
+    expect(metadata.displayName).toBe("Fixture Secrets");
+    expect(metadata.minProtocolVersion).toBe(CURRENT_PROTOCOL_VERSION);
+    expect(metadata.maxProtocolVersion).toBe(CURRENT_PROTOCOL_VERSION);
+
+    await expectConnectCode(
+      runtime.configureProvider(
+        create(ConfigureProviderRequestSchema, {
+          name: "fixture-secrets",
+          config: {
+            scope: "runtime",
+          },
+          protocolVersion: CURRENT_PROTOCOL_VERSION + 1,
+        }),
+      ),
+      Code.FailedPrecondition,
+    );
+
+    const configured = await runtime.configureProvider(
+      create(ConfigureProviderRequestSchema, {
+        name: "fixture-secrets",
+        config: {
+          scope: "runtime",
+        },
+        protocolVersion: CURRENT_PROTOCOL_VERSION,
+      }),
+    );
+    expect(configured.protocolVersion).toBe(CURRENT_PROTOCOL_VERSION);
+
+    const secret = await secrets.getSecret(
+      create(GetSecretRequestSchema, {
+        name: "db-password",
+      }),
+    );
+    expect(secret.value).toBe("fixture-secrets:runtime:hunter2");
+
+    await expectConnectCode(
+      secrets.getSecret(
+        create(GetSecretRequestSchema, {
+          name: "missing",
+        }),
+      ),
+      Code.NotFound,
+    );
+  } finally {
+    if (child) {
+      await stopProcess(child);
+    }
+    removeTempDir(tempDir);
+  }
+}, 15_000);
 
 test("integration provider service exposes metadata, configure, execute, and session catalog", async () => {
   const plugin = await loadPluginFromTarget(fixturePath("basic-provider"));


### PR DESCRIPTION
## Summary
- add a real packaged Unix-socket gRPC smoke for integration providers through both `plugin:` and `integration:` target spellings
- add secrets coverage through both the runtime entrypoint and compiled binaries
- expand the integration fixture so the compiled path proves both successful and failing integer-schema execution
- keep the existing white-box suites in place; this PR only adds product-behavior coverage

## Go Interface
No Go interface change.

Example:
```go
resp, err := client.StartProvider(ctx, &proto.StartProviderRequest{
    Name:            "example",
    Config:          cfg,
    ProtocolVersion: proto.CurrentProtocolVersion,
})
```

## YAML Shape
No YAML shape change.

Example:
```yaml
source: plugin:./provider.ts#plugin
config:
  region: use1
```

## TypeScript Coverage Examples
Runtime entrypoint over Unix gRPC:
```ts
bun run src/runtime.ts ROOT secrets:./secrets.ts
```

Packaged integration targets exercised in tests:
```text
plugin:./provider.ts#plugin
integration:./provider.ts#plugin
```

Package metadata discovery exercised in tests:
```json
{
  "gestalt": {
    "provider": {
      "kind": "secrets",
      "target": "./secrets.ts"
    }
  }
}
```

## Test Coverage
- `bun test tests/runtime.test.ts tests/build.test.ts`

## Scope Notes
- no unit-test deletions in this PR
- no runtime branch-removal refactors in this PR
- stacked on top of `#1042` because this coverage depends on the protocol-parity slice