### PR TITLE
cli: collapse plugin command shims without breaking aliases

### DIFF
--- a/gestalt/cli/src/cli.rs
+++ b/gestalt/cli/src/cli.rs
@@ -1,4 +1,4 @@
-use clap::{Parser, Subcommand};
+use clap::{Args, Parser, Subcommand};
 
 use crate::output::Format;
 use crate::params;
@@ -38,55 +38,19 @@ pub enum Commands {
     },
 
     /// Manage plugins
+    #[command(alias = "integrations")]
     Plugins {
         #[command(subcommand)]
         command: PluginCommands,
     },
 
     #[command(hide = true)]
-    Integrations {
-        #[command(subcommand)]
-        command: PluginCommands,
-    },
-
-    #[command(hide = true)]
     /// Execute a plugin operation
-    Invoke {
-        /// Plugin name (e.g., github, slack)
-        plugin: String,
-
-        /// Operation name segments joined by "." (e.g., "chat postMessage" or "chat.postMessage"). Omit to list available operations.
-        operation: Vec<String>,
-
-        /// Parameters as key=value or key:=json pairs
-        #[arg(short = 'p', long = "param", value_parser = params::parse_param_entry)]
-        params: Vec<params::ParamEntry>,
-
-        /// Select a named connection for this invocation
-        #[arg(long)]
-        connection: Option<String>,
-
-        /// Select a stored connection instance
-        #[arg(long)]
-        instance: Option<String>,
-
-        /// Select a sub-path from the response (e.g., "data.items")
-        #[arg(long = "select")]
-        select: Option<String>,
-
-        /// Load parameters from a JSON file (use "-" for stdin)
-        #[arg(long = "input-file")]
-        input_file: Option<String>,
-    },
+    Invoke(InvokeArgs),
 
     #[command(hide = true)]
     /// Describe a plugin operation
-    Describe {
-        /// Plugin name
-        plugin: String,
-        /// Operation name
-        operation: String,
-    },
+    Describe(DescribeArgs),
 
     /// Manage API tokens
     Tokens {
@@ -159,40 +123,46 @@ pub enum PluginCommands {
         instance: Option<String>,
     },
     /// Execute a plugin operation
-    Invoke {
-        /// Plugin name (e.g., github, slack)
-        plugin: String,
-
-        /// Operation name segments joined by "." (e.g., "chat postMessage" or "chat.postMessage"). Omit to list available operations.
-        operation: Vec<String>,
-
-        /// Parameters as key=value or key:=json pairs
-        #[arg(short = 'p', long = "param", value_parser = params::parse_param_entry)]
-        params: Vec<params::ParamEntry>,
-
-        /// Select a named connection for this invocation
-        #[arg(long)]
-        connection: Option<String>,
-
-        /// Select a stored connection instance
-        #[arg(long)]
-        instance: Option<String>,
-
-        /// Select a sub-path from the response (e.g., "data.items")
-        #[arg(long = "select")]
-        select: Option<String>,
-
-        /// Load parameters from a JSON file (use "-" for stdin)
-        #[arg(long = "input-file")]
-        input_file: Option<String>,
-    },
+    Invoke(InvokeArgs),
     /// Describe a plugin operation
-    Describe {
-        /// Plugin name
-        plugin: String,
-        /// Operation name
-        operation: String,
-    },
+    Describe(DescribeArgs),
+}
+
+#[derive(Args)]
+pub struct InvokeArgs {
+    /// Plugin name (e.g., github, slack)
+    pub plugin: String,
+
+    /// Operation name segments joined by "." (e.g., "chat postMessage" or "chat.postMessage"). Omit to list available operations.
+    pub operation: Vec<String>,
+
+    /// Parameters as key=value or key:=json pairs
+    #[arg(short = 'p', long = "param", value_parser = params::parse_param_entry)]
+    pub params: Vec<params::ParamEntry>,
+
+    /// Select a named connection for this invocation
+    #[arg(long)]
+    pub connection: Option<String>,
+
+    /// Select a stored connection instance
+    #[arg(long)]
+    pub instance: Option<String>,
+
+    /// Select a sub-path from the response (e.g., "data.items")
+    #[arg(long = "select")]
+    pub select: Option<String>,
+
+    /// Load parameters from a JSON file (use "-" for stdin)
+    #[arg(long = "input-file")]
+    pub input_file: Option<String>,
+}
+
+#[derive(Args)]
+pub struct DescribeArgs {
+    /// Plugin name
+    pub plugin: String,
+    /// Operation name
+    pub operation: String,
 }
 
 #[derive(Subcommand)]

--- a/gestalt/cli/src/main.rs
+++ b/gestalt/cli/src/main.rs
@@ -1,6 +1,9 @@
 use clap::{CommandFactory, Parser};
 use gestalt::api::{self, ApiClient};
-use gestalt::cli::{AuthCommands, Cli, Commands, ConfigCommands, PluginCommands, TokenCommands};
+use gestalt::cli::{
+    AuthCommands, Cli, Commands, ConfigCommands, DescribeArgs, InvokeArgs, PluginCommands,
+    TokenCommands,
+};
 use gestalt::commands;
 use gestalt::output;
 
@@ -27,32 +30,12 @@ fn run() -> anyhow::Result<()> {
             ConfigCommands::Unset { key } => commands::config::unset(&key),
             ConfigCommands::List => commands::config::list(format),
         },
-        Commands::Plugins { command } | Commands::Integrations { command } => {
-            dispatch_plugin_command(command, url, format)
+        Commands::Plugins { command } => dispatch_plugin_command(command, url, format),
+        Commands::Invoke(args) => {
+            dispatch_plugin_command(PluginCommands::Invoke(args), url, format)
         }
-        Commands::Invoke {
-            plugin,
-            operation,
-            params,
-            connection,
-            instance,
-            select,
-            input_file,
-        } => dispatch_plugin_command(
-            PluginCommands::Invoke {
-                plugin,
-                operation,
-                params,
-                connection,
-                instance,
-                select,
-                input_file,
-            },
-            url,
-            format,
-        ),
-        Commands::Describe { plugin, operation } => {
-            dispatch_plugin_command(PluginCommands::Describe { plugin, operation }, url, format)
+        Commands::Describe(args) => {
+            dispatch_plugin_command(PluginCommands::Describe(args), url, format)
         }
         Commands::Tokens { command } => {
             let client = ApiClient::from_env(url)?;
@@ -90,7 +73,7 @@ fn dispatch_plugin_command(
             connection.as_deref(),
             instance.as_deref(),
         ),
-        PluginCommands::Invoke {
+        PluginCommands::Invoke(InvokeArgs {
             plugin,
             operation,
             params,
@@ -98,7 +81,7 @@ fn dispatch_plugin_command(
             instance,
             select,
             input_file,
-        } => commands::invoke::run(
+        }) => commands::invoke::run(
             &client,
             &plugin,
             &operation,
@@ -111,7 +94,7 @@ fn dispatch_plugin_command(
             },
             format,
         ),
-        PluginCommands::Describe { plugin, operation } => {
+        PluginCommands::Describe(DescribeArgs { plugin, operation }) => {
             commands::describe::describe(&client, &plugin, &operation, format)
         }
     }

--- a/gestalt/cli/tests/integration.rs
+++ b/gestalt/cli/tests/integration.rs
@@ -429,7 +429,7 @@ fn test_error_response() {
     .create();
 
     cli_command_for_server(home.path(), &server)
-        .args(["invoke", "auth_svc", "list_items"])
+        .args(["plugins", "invoke", "auth_svc", "list_items"])
         .assert()
         .failure()
         .stderr(predicate::str::contains(
@@ -507,7 +507,7 @@ fn test_list_operations_formats_parameters() {
         )
         .create();
 
-    let output = run_cli(&server, &["invoke", "test_svc"]);
+    let output = run_cli(&server, &["plugins", "invoke", "test_svc"]);
     mock.assert();
     assert!(
         output.status.success(),
@@ -1355,14 +1355,15 @@ fn test_describe_operation() {
     .with_body(catalog_body())
     .create();
 
-    let client = create_client(&server);
-    let result =
-        gestalt::commands::describe::describe(&client, "test_svc", "do_thing", Format::Table);
-
+    let output = run_cli(&server, &["plugins", "describe", "test_svc", "do_thing"]);
+    assert!(
+        output.status.success(),
+        "stderr: {}",
+        String::from_utf8_lossy(&output.stderr)
+    );
     mock.assert();
-    assert!(result.is_ok());
 
-    // "plugins describe" subcommand reaches the same handler
+    // Legacy top-level alias still routes to the same handler.
     let mock = json_mock!(
         server,
         Method::GET,
@@ -1372,7 +1373,7 @@ fn test_describe_operation() {
     .with_body(catalog_body())
     .create();
 
-    let output = run_cli(&server, &["plugins", "describe", "test_svc", "do_thing"]);
+    let output = run_cli(&server, &["describe", "test_svc", "do_thing"]);
     assert!(
         output.status.success(),
         "stderr: {}",
@@ -1625,6 +1626,7 @@ fn test_cli_invoke_table_keeps_nested_json_inline() {
     cmd.env("GESTALT_API_KEY", TEST_TOKEN).args([
         "--url",
         &server.url(),
+        "plugins",
         "invoke",
         "test_svc",
         "do_thing",
@@ -1662,6 +1664,7 @@ fn test_cli_invoke_rejects_duplicate_scalar_params() {
     cmd.env("GESTALT_API_KEY", "test-token").args([
         "--url",
         &server.url(),
+        "plugins",
         "invoke",
         "test_svc",
         "do_thing",
@@ -1687,7 +1690,7 @@ fn test_prefix_match_shows_filtered_table() {
     .with_body(multi_operation_catalog())
     .create();
 
-    let output = run_cli(&server, &["invoke", "test_svc", "widgets"]);
+    let output = run_cli(&server, &["plugins", "invoke", "test_svc", "widgets"]);
     assert!(
         output.status.success(),
         "stderr: {}",
@@ -1707,7 +1710,10 @@ fn test_prefix_match_shows_filtered_table() {
     );
 
     // Middle-tier prefix: "widgets.bulk" filters to three-segment operations only
-    let output = run_cli(&server, &["invoke", "test_svc", "widgets", "bulk"]);
+    let output = run_cli(
+        &server,
+        &["plugins", "invoke", "test_svc", "widgets", "bulk"],
+    );
     assert!(
         output.status.success(),
         "stderr: {}",
@@ -1779,7 +1785,7 @@ fn test_space_separated_segments_invoke() {
 
     let output = run_cli(
         &server,
-        &["invoke", "test_svc", "widgets", "bulk", "create"],
+        &["plugins", "invoke", "test_svc", "widgets", "bulk", "create"],
     );
     assert!(
         output.status.success(),
@@ -1788,7 +1794,6 @@ fn test_space_separated_segments_invoke() {
     );
     deep_mock.assert();
 
-    // "plugins invoke" subcommand resolves the same way
     let subcommand_mock = authed_json_mock!(
         server,
         Method::GET,
@@ -1822,7 +1827,7 @@ fn test_no_match_returns_error() {
     .with_body(multi_operation_catalog())
     .create();
 
-    let output = run_cli(&server, &["invoke", "test_svc", "nonexistent"]);
+    let output = run_cli(&server, &["plugins", "invoke", "test_svc", "nonexistent"]);
     assert!(!output.status.success());
     let stderr = String::from_utf8_lossy(&output.stderr);
     assert!(stderr.contains("no operation matching"), "stderr: {stderr}");
@@ -1842,7 +1847,7 @@ fn test_prefix_match_with_params_warns() {
 
     let output = run_cli(
         &server,
-        &["invoke", "test_svc", "widgets", "-p", "name=foo"],
+        &["plugins", "invoke", "test_svc", "widgets", "-p", "name=foo"],
     );
     assert!(
         output.status.success(),


### PR DESCRIPTION
## Summary
- replace the separate hidden `integrations` command node with a hidden alias on `plugins`
- share the `invoke` and `describe` clap argument structs between the canonical `plugins` subcommands and the hidden top-level compatibility shims
- keep most integration coverage on the canonical `plugins` interface while retaining smoke coverage for the legacy aliases

## Rust interfaces
- `Commands::Plugins { command }` now accepts the hidden alias `integrations`
- `Commands::Invoke(InvokeArgs)` and `PluginCommands::Invoke(InvokeArgs)` share one argument struct
- `Commands::Describe(DescribeArgs)` and `PluginCommands::Describe(DescribeArgs)` share one argument struct

## stdin/stdout interfaces
```bash
gestalt integrations list
printf '{"count":42}' | gestalt invoke test_svc do_thing --input-file - --select result.id
gestalt plugins invoke test_svc widgets create -p name=foo -p color=red
gestalt describe test_svc do_thing
```

## Testing
```bash
cargo test -p gestalt
```