### PR TITLE
Share prepared-install staging between provider release and local prep

### DIFF
--- a/gestaltd/cmd/gestaltd/plugin.go
+++ b/gestaltd/cmd/gestaltd/plugin.go
@@ -1,14 +1,14 @@
 package main
 
 import (
-	"encoding/json"
+	"errors"
 	"flag"
 	"fmt"
 	"io"
-	"io/fs"
 	"os"
 	"path"
 	"path/filepath"
+	"runtime"
 	"strings"
 
 	"github.com/valon-technologies/gestalt/server/internal/pluginsource"
@@ -37,13 +37,16 @@ const defaultPlatforms = "darwin/amd64,darwin/arm64,linux/amd64,linux/arm,linux/
 const allPlatformsValue = "all"
 const defaultReleaseOutputDir = "dist/"
 const releaseBinaryPrefix = "gestalt-plugin-"
-const releaseOwnedUIRoot = "_owned_ui"
 const windowsOS = "windows"
 const windowsExecutableSuffix = ".exe"
 
 type releasePlatform struct {
 	GOOS   string
 	GOARCH string
+}
+
+type releaseBuildTarget struct {
+	Kind string
 }
 
 func runProviderRelease(args []string) error {
@@ -81,20 +84,17 @@ func runProviderRelease(args []string) error {
 	if err != nil {
 		return fmt.Errorf("read %s: %w", manifestPath, err)
 	}
-	if err := validateReleaseOutputDir(releaseManifest, sourceDir, *outputDir); err != nil {
-		return err
-	}
 	if err := providerpkg.RunSourceReleaseBuild(manifestPath, releaseManifest); err != nil {
 		return err
 	}
-	_, srcManifest, err := providerpkg.PrepareSourceManifest(manifestPath)
+	_, releaseManifest, err = providerpkg.ReadSourceManifestFile(manifestPath)
 	if err != nil {
-		return fmt.Errorf("prepare %s: %w", manifestPath, err)
+		return fmt.Errorf("read %s after release build: %w", manifestPath, err)
 	}
-	manifestFormat := providerpkg.ManifestFormatFromPath(manifestPath)
-	manifestFile := filepath.Base(manifestPath)
-
-	src, err := pluginsource.Parse(srcManifest.Source)
+	if err := validateReleaseOutputDir(releaseManifest, sourceDir, *outputDir); err != nil {
+		return err
+	}
+	src, err := pluginsource.Parse(releaseManifest.Source)
 	if err != nil {
 		return fmt.Errorf("invalid source in manifest: %w", err)
 	}
@@ -104,12 +104,12 @@ func runProviderRelease(args []string) error {
 		return fmt.Errorf("create output dir: %w", err)
 	}
 
-	buildKind, err := resolveReleaseBuildTarget(sourceDir, srcManifest)
+	buildTarget, err := resolveReleaseBuildTarget(sourceDir, releaseManifest)
 	if err != nil {
 		return err
 	}
 
-	buildPlatforms, err := resolveReleaseBuildPlatforms(sourceDir, srcManifest, buildKind, *platforms, platformFlagExplicit)
+	buildPlatforms, err := resolveReleaseBuildPlatforms(sourceDir, releaseManifest, buildTarget, *platforms, platformFlagExplicit)
 	if err != nil {
 		return err
 	}
@@ -117,14 +117,14 @@ func runProviderRelease(args []string) error {
 	var archivePaths []string
 	if len(buildPlatforms) > 0 {
 		for _, platform := range buildPlatforms {
-			archivePath, err := buildPlatformArchive(sourceDir, srcManifest, pluginName, *version, buildKind, platform, *outputDir, manifestFile, manifestFormat)
+			archivePath, err := buildPlatformArchive(manifestPath, pluginName, *version, buildTarget.Kind, platform, *outputDir)
 			if err != nil {
 				return fmt.Errorf("build %s: %w", providerpkg.PlatformString(platform.GOOS, platform.GOARCH), err)
 			}
 			archivePaths = append(archivePaths, archivePath)
 		}
 	} else {
-		archivePath, err := buildSourceArchive(sourceDir, srcManifest, pluginName, *version, *outputDir, manifestFile, manifestFormat)
+		archivePath, err := buildSourceArchive(manifestPath, pluginName, *version, *outputDir)
 		if err != nil {
 			return err
 		}
@@ -138,30 +138,33 @@ func runProviderRelease(args []string) error {
 	return nil
 }
 
-func resolveReleaseBuildTarget(root string, manifest *providermanifestv1.Manifest) (string, error) {
+func resolveReleaseBuildTarget(root string, manifest *providermanifestv1.Manifest) (*releaseBuildTarget, error) {
 	kind, err := providerpkg.ManifestKind(manifest)
 	if err != nil {
-		return "", err
+		return nil, err
 	}
-	hasSource, err := providerpkg.HasSourceReleaseTarget(root, kind)
+	if kind == providermanifestv1.KindWebUI {
+		return nil, nil
+	}
+	hasSource, err := detectReleaseSourceBuildTarget(root, kind)
 	if err != nil {
-		return "", fmt.Errorf("detect source %s package: %w", kind, err)
+		return nil, fmt.Errorf("detect source %s package: %w", kind, err)
 	}
 	if !hasSource {
-		if providerpkg.ReleaseRequiresBuild(manifest) {
-			return "", providerpkg.MissingSourceReleaseTargetError(kind)
+		if releaseRequiresBuildTarget(manifest) {
+			return nil, missingReleaseSourceBuildTargetError(kind)
 		}
-		return "", nil
+		return nil, nil
 	}
-	return kind, nil
+	return &releaseBuildTarget{Kind: kind}, nil
 }
 
-func resolveReleaseBuildPlatforms(root string, manifest *providermanifestv1.Manifest, buildKind, value string, explicit bool) ([]releasePlatform, error) {
-	if buildKind == "" {
+func resolveReleaseBuildPlatforms(root string, manifest *providermanifestv1.Manifest, target *releaseBuildTarget, value string, explicit bool) ([]releasePlatform, error) {
+	if target == nil {
 		return nil, nil
 	}
 
-	buildRequired := providerpkg.ReleaseRequiresBuild(manifest)
+	buildRequired := releaseRequiresBuildTarget(manifest)
 	if !buildRequired && !explicit {
 		return nil, nil
 	}
@@ -172,7 +175,7 @@ func resolveReleaseBuildPlatforms(root string, manifest *providermanifestv1.Mani
 			return nil, err
 		}
 	} else {
-		value = providerpkg.CurrentPlatformString()
+		value = currentReleasePlatform()
 	}
 	platforms, err := parseReleasePlatforms(value)
 	if err != nil {
@@ -182,21 +185,21 @@ func resolveReleaseBuildPlatforms(root string, manifest *providermanifestv1.Mani
 	builds := make([]releasePlatform, 0, len(platforms))
 	var missingSource bool
 	for _, platform := range platforms {
-		if err := providerpkg.ValidateSourceReleaseTarget(root, buildKind, platform.GOOS, platform.GOARCH); err != nil {
-			if providerpkg.IsMissingSourceReleaseTarget(err, buildKind) {
+		if err := validateReleaseBuildTarget(root, target.Kind, platform.GOOS, platform.GOARCH); err != nil {
+			if isMissingReleaseSourceBuildTarget(err, target.Kind) {
 				missingSource = true
 				continue
 			}
-			return nil, fmt.Errorf("detect source %s package for %s/%s: %w", buildKind, platform.GOOS, platform.GOARCH, err)
+			return nil, fmt.Errorf("detect source %s package for %s/%s: %w", target.Kind, platform.GOOS, platform.GOARCH, err)
 		}
 		builds = append(builds, platform)
 	}
 
 	if len(builds) == 0 {
-		return nil, providerpkg.MissingSourceReleaseTargetError(buildKind)
+		return nil, missingReleaseSourceBuildTargetError(target.Kind)
 	}
 	if missingSource {
-		return nil, providerpkg.MissingSourceReleaseTargetError(buildKind)
+		return nil, missingReleaseSourceBuildTargetError(target.Kind)
 	}
 	return builds, nil
 }
@@ -213,44 +216,31 @@ func expandReleasePlatformValue(value string) (string, error) {
 	}
 }
 
-func buildPlatformArchive(sourceDir string, srcManifest *providermanifestv1.Manifest, pluginName, version, buildKind string, platform releasePlatform, outputDir, manifestFile, manifestFormat string) (string, error) {
-	stagingDir, err := os.MkdirTemp("", "gestalt-release-*")
-	if err != nil {
-		return "", err
-	}
-	defer func() { _ = os.RemoveAll(stagingDir) }()
-
-	manifest, plat, err := prepareBuiltPackageDir(stagingDir, sourceDir, srcManifest, version, pluginName, buildKind, platform)
-	if err != nil {
-		return "", err
-	}
-	archivePath := filepath.Join(outputDir, platformArchiveName(pluginName, version, plat))
-	if err := writeReleaseManifestFile(stagingDir, manifestFile, manifestFormat, manifest); err != nil {
-		return "", err
-	}
-	if err := providerpkg.CreatePackageFromDir(stagingDir, archivePath); err != nil {
-		return "", err
-	}
-
-	_, _ = fmt.Fprintf(os.Stdout, "created %s\n", archivePath)
-	return archivePath, nil
+func buildPlatformArchive(manifestPath, pluginName, version, buildKind string, platform releasePlatform, outputDir string) (string, error) {
+	archiveName := platformArchiveName(pluginName, version, platform)
+	return createReleaseArchive(outputDir, archiveName, func(stagingDir string) error {
+		_, err := providerpkg.StagePreparedInstallDir(manifestPath, stagingDir, providerpkg.StagePreparedInstallOptions{
+			VersionOverride: version,
+			BuildKind:       buildKind,
+			PluginName:      pluginName,
+			GOOS:            platform.GOOS,
+			GOARCH:          platform.GOARCH,
+		})
+		return err
+	})
 }
 
-func createReleaseArchive(outputDir, archiveName, manifestFile, manifestFormat string, prepare func(stagingDir string) (*providermanifestv1.Manifest, error)) (string, error) {
+func createReleaseArchive(outputDir, archiveName string, prepare func(stagingDir string) error) (string, error) {
 	stagingDir, err := os.MkdirTemp("", "gestalt-release-*")
 	if err != nil {
 		return "", err
 	}
 	defer func() { _ = os.RemoveAll(stagingDir) }()
 
-	manifest, err := prepare(stagingDir)
-	if err != nil {
+	if err := prepare(stagingDir); err != nil {
 		return "", err
 	}
 	archivePath := filepath.Join(outputDir, archiveName)
-	if err := writeReleaseManifestFile(stagingDir, manifestFile, manifestFormat, manifest); err != nil {
-		return "", err
-	}
 	if err := providerpkg.CreatePackageFromDir(stagingDir, archivePath); err != nil {
 		return "", err
 	}
@@ -259,12 +249,63 @@ func createReleaseArchive(outputDir, archiveName, manifestFile, manifestFormat s
 	return archivePath, nil
 }
 
-func writeReleaseManifestFile(stagingDir, manifestFile, manifestFormat string, manifest *providermanifestv1.Manifest) error {
-	data, err := providerpkg.EncodeManifestFormat(manifest, manifestFormat)
+func releaseRequiresBuildTarget(manifest *providermanifestv1.Manifest) bool {
+	kind, err := providerpkg.ManifestKind(manifest)
 	if err != nil {
-		return fmt.Errorf("encode manifest: %w", err)
+		return false
 	}
-	return os.WriteFile(filepath.Join(stagingDir, manifestFile), data, 0644)
+	switch kind {
+	case providermanifestv1.KindPlugin:
+		return manifest.Entrypoint == nil && (manifest.Spec == nil || !manifest.Spec.IsManifestBacked())
+	case providermanifestv1.KindAuth, providermanifestv1.KindIndexedDB, providermanifestv1.KindCache, providermanifestv1.KindS3, providermanifestv1.KindSecrets:
+		return providerpkg.EntrypointForKind(manifest, kind) == nil
+	default:
+		return false
+	}
+}
+
+func detectReleaseSourceBuildTarget(root, kind string) (bool, error) {
+	switch kind {
+	case providermanifestv1.KindPlugin:
+		return providerpkg.HasSourceProviderPackage(root)
+	case providermanifestv1.KindAuth, providermanifestv1.KindIndexedDB, providermanifestv1.KindCache, providermanifestv1.KindS3, providermanifestv1.KindSecrets:
+		return providerpkg.HasSourceComponentPackage(root, kind)
+	default:
+		return false, fmt.Errorf("unsupported release build target kind %q", kind)
+	}
+}
+
+func validateReleaseBuildTarget(root, kind, goos, goarch string) error {
+	switch kind {
+	case providermanifestv1.KindPlugin:
+		return providerpkg.ValidateSourceProviderRelease(root, goos, goarch)
+	case providermanifestv1.KindAuth, providermanifestv1.KindIndexedDB, providermanifestv1.KindCache, providermanifestv1.KindS3, providermanifestv1.KindSecrets:
+		return providerpkg.ValidateSourceComponentRelease(root, kind, goos, goarch)
+	default:
+		return fmt.Errorf("unsupported release build target kind %q", kind)
+	}
+}
+
+func isMissingReleaseSourceBuildTarget(err error, kind string) bool {
+	switch kind {
+	case providermanifestv1.KindPlugin:
+		return errors.Is(err, providerpkg.ErrNoSourceProviderPackage)
+	case providermanifestv1.KindAuth, providermanifestv1.KindIndexedDB, providermanifestv1.KindCache, providermanifestv1.KindS3, providermanifestv1.KindSecrets:
+		return errors.Is(err, providerpkg.ErrNoSourceComponentPackage)
+	default:
+		return false
+	}
+}
+
+func missingReleaseSourceBuildTargetError(kind string) error {
+	switch kind {
+	case providermanifestv1.KindPlugin:
+		return fmt.Errorf("no Go, Rust, Python, or TypeScript provider package found")
+	case providermanifestv1.KindAuth, providermanifestv1.KindCache, providermanifestv1.KindIndexedDB, providermanifestv1.KindS3, providermanifestv1.KindSecrets:
+		return fmt.Errorf("no Go, Rust, Python, or TypeScript %s source package found", kind)
+	default:
+		return fmt.Errorf("unsupported release build target kind %q", kind)
+	}
 }
 
 func parseReleasePlatforms(value string) ([]releasePlatform, error) {
@@ -284,78 +325,18 @@ func parseReleasePlatforms(value string) ([]releasePlatform, error) {
 	return platforms, nil
 }
 
-func buildSourceArchive(sourceDir string, srcManifest *providermanifestv1.Manifest, pluginName, version, outputDir, manifestFile, manifestFormat string) (string, error) {
+func currentReleasePlatform() string {
+	return runtime.GOOS + "/" + runtime.GOARCH
+}
+
+func buildSourceArchive(manifestPath, pluginName, version, outputDir string) (string, error) {
 	archiveName := fmt.Sprintf("gestalt-plugin-%s_v%s.tar.gz", pluginName, version)
-	return createReleaseArchive(outputDir, archiveName, manifestFile, manifestFormat, func(stagingDir string) (*providermanifestv1.Manifest, error) {
-		manifest, err := buildSourceReleaseManifest(srcManifest, version, sourceDir)
-		if err != nil {
-			return nil, err
-		}
-		if err := copyReleasePackageFiles(manifest, sourceDir, stagingDir, true); err != nil {
-			return nil, err
-		}
-		return manifest, nil
+	return createReleaseArchive(outputDir, archiveName, func(stagingDir string) error {
+		_, err := providerpkg.StagePreparedInstallDir(manifestPath, stagingDir, providerpkg.StagePreparedInstallOptions{
+			VersionOverride: version,
+		})
+		return err
 	})
-}
-
-func prepareBuiltPackageDir(stagingDir, sourceDir string, srcManifest *providermanifestv1.Manifest, version, pluginName, buildKind string, platform releasePlatform) (*providermanifestv1.Manifest, releasePlatform, error) {
-	plat := platform
-	binaryName := releaseBinaryName(pluginName, plat.GOOS)
-	binaryPath := filepath.Join(stagingDir, binaryName)
-	if err := providerpkg.BuildSourceReleaseBinary(sourceDir, binaryPath, pluginName, buildKind, plat.GOOS, plat.GOARCH); err != nil {
-		return nil, releasePlatform{}, err
-	}
-
-	digest, err := providerpkg.FileSHA256(binaryPath)
-	if err != nil {
-		return nil, releasePlatform{}, fmt.Errorf("hash binary: %w", err)
-	}
-	manifest, err := buildReleaseManifest(srcManifest, version, binaryName, buildKind, plat, digest)
-	if err != nil {
-		return nil, releasePlatform{}, err
-	}
-	if err := copyReleasePackageFiles(manifest, sourceDir, stagingDir, false); err != nil {
-		return nil, releasePlatform{}, err
-	}
-	return manifest, plat, nil
-}
-
-func buildSourceReleaseManifest(srcManifest *providermanifestv1.Manifest, version, sourceDir string) (*providermanifestv1.Manifest, error) {
-	manifest, err := cloneManifest(srcManifest)
-	if err != nil {
-		return nil, fmt.Errorf("clone manifest: %w", err)
-	}
-	manifest.Version = version
-	manifest.Release = nil
-
-	for i, artifact := range srcManifest.Artifacts {
-		digest, err := providerpkg.FileSHA256(filepath.Join(sourceDir, filepath.FromSlash(artifact.Path)))
-		if err != nil {
-			return nil, fmt.Errorf("hash artifact %s: %w", artifact.Path, err)
-		}
-		if artifact.SHA256 != "" && artifact.SHA256 != digest {
-			return nil, fmt.Errorf("artifact %s sha256 mismatch: manifest=%s actual=%s", artifact.Path, artifact.SHA256, digest)
-		}
-		manifest.Artifacts[i].SHA256 = digest
-	}
-
-	return manifest, nil
-}
-
-func buildReleaseManifest(srcManifest *providermanifestv1.Manifest, version, binaryName, buildKind string, plat releasePlatform, digest string) (*providermanifestv1.Manifest, error) {
-	manifest, err := cloneManifest(srcManifest)
-	if err != nil {
-		return nil, fmt.Errorf("clone manifest: %w", err)
-	}
-	manifest.Version = version
-	manifest.Release = nil
-	manifest.Artifacts = []providermanifestv1.Artifact{
-		{OS: plat.GOOS, Arch: plat.GOARCH, Path: binaryName, SHA256: digest},
-	}
-
-	providerpkg.EnsureEntrypoint(manifest).ArtifactPath = binaryName
-
-	return manifest, nil
 }
 
 func platformArchiveName(pluginName, version string, plat releasePlatform) string {
@@ -391,190 +372,6 @@ func writeChecksums(dir string, archivePaths []string) error {
 	}
 	_, _ = fmt.Fprintf(os.Stdout, "created %s\n", checksumPath)
 	return nil
-}
-
-func cloneManifest(manifest *providermanifestv1.Manifest) (*providermanifestv1.Manifest, error) {
-	if manifest == nil {
-		return nil, nil
-	}
-
-	data, err := json.Marshal(manifest)
-	if err != nil {
-		return nil, err
-	}
-
-	var cloned providermanifestv1.Manifest
-	if err := json.Unmarshal(data, &cloned); err != nil {
-		return nil, err
-	}
-	return &cloned, nil
-}
-
-func copyReleaseDir(src, dst string) error {
-	return filepath.WalkDir(src, func(path string, d fs.DirEntry, err error) error {
-		if err != nil {
-			return err
-		}
-		rel, err := filepath.Rel(src, path)
-		if err != nil {
-			return err
-		}
-		target := filepath.Join(dst, rel)
-		if d.IsDir() {
-			return os.MkdirAll(target, 0o755)
-		}
-		return copyReleaseFile(path, target)
-	})
-}
-
-func copyReleaseFile(src, dst string) error {
-	in, err := os.Open(src)
-	if err != nil {
-		return err
-	}
-	defer func() { _ = in.Close() }()
-
-	info, err := in.Stat()
-	if err != nil {
-		return err
-	}
-	if err := os.MkdirAll(filepath.Dir(dst), 0755); err != nil {
-		return err
-	}
-	out, err := os.OpenFile(dst, os.O_CREATE|os.O_WRONLY|os.O_TRUNC, info.Mode())
-	if err != nil {
-		return err
-	}
-	if _, err := io.Copy(out, in); err != nil {
-		_ = out.Close()
-		return err
-	}
-	return out.Close()
-}
-
-func copyReleasePackageFiles(manifest *providermanifestv1.Manifest, sourceDir, stagingDir string, includeArtifacts bool) error {
-	if manifest == nil {
-		return nil
-	}
-	if err := stageReleaseOwnedUI(manifest, sourceDir, stagingDir); err != nil {
-		return err
-	}
-
-	copied := make(map[string]struct{})
-	copyPath := func(rel string, optional bool) error {
-		if rel == "" {
-			return nil
-		}
-
-		cleanRel, err := normalizeReleasePath(rel)
-		if err != nil {
-			return err
-		}
-		if _, seen := copied[cleanRel]; seen {
-			return nil
-		}
-		copied[cleanRel] = struct{}{}
-
-		srcPath := filepath.Join(sourceDir, filepath.FromSlash(cleanRel))
-		info, err := os.Stat(srcPath)
-		if err != nil {
-			if optional && os.IsNotExist(err) {
-				return nil
-			}
-			return fmt.Errorf("stat support path %s: %w", rel, err)
-		}
-
-		dstPath := filepath.Join(stagingDir, filepath.FromSlash(cleanRel))
-		if info.IsDir() {
-			if err := copyReleaseDir(srcPath, dstPath); err != nil {
-				return fmt.Errorf("copy support directory %s: %w", rel, err)
-			}
-			return nil
-		}
-		if err := copyReleaseFile(srcPath, dstPath); err != nil {
-			return fmt.Errorf("copy support file %s: %w", rel, err)
-		}
-		return nil
-	}
-
-	if err := copyPath(manifest.IconFile, false); err != nil {
-		return err
-	}
-	for _, ref := range providerpkg.LocalPackageReferences(manifest) {
-		if err := copyPath(ref.Path, false); err != nil {
-			return err
-		}
-	}
-	if manifest.Kind == providermanifestv1.KindPlugin && manifest.Spec != nil {
-		if err := copyPath(providerpkg.StaticCatalogFile, !providerpkg.StaticCatalogRequired(manifest)); err != nil {
-			return err
-		}
-	}
-	if manifest.Spec != nil && manifest.Spec.ConfigSchemaPath != "" {
-		if err := copyPath(manifest.Spec.ConfigSchemaPath, false); err != nil {
-			return err
-		}
-	}
-	if manifest.Spec != nil && manifest.Spec.AssetRoot != "" {
-		if err := copyPath(manifest.Spec.AssetRoot, false); err != nil {
-			return err
-		}
-	}
-	if includeArtifacts {
-		for _, artifact := range manifest.Artifacts {
-			if err := copyPath(artifact.Path, false); err != nil {
-				return err
-			}
-		}
-	}
-	return nil
-}
-
-func stageReleaseOwnedUI(manifest *providermanifestv1.Manifest, sourceDir, stagingDir string) error {
-	if manifest == nil || manifest.Kind != providermanifestv1.KindPlugin || manifest.Spec == nil || manifest.Spec.UI == nil {
-		return nil
-	}
-	ownedUI := manifest.Spec.UI
-	if strings.TrimSpace(ownedUI.Path) == "" {
-		return nil
-	}
-
-	uiManifestPath := filepath.Join(sourceDir, filepath.FromSlash(ownedUI.Path))
-	_, uiManifest, err := providerpkg.ReadSourceManifestFile(uiManifestPath)
-	if err != nil {
-		return fmt.Errorf("read owned ui manifest %s: %w", ownedUI.Path, err)
-	}
-	if err := providerpkg.RunSourceReleaseBuild(uiManifestPath, uiManifest); err != nil {
-		return fmt.Errorf("build owned ui package %s: %w", ownedUI.Path, err)
-	}
-
-	packagedManifest, err := cloneManifest(uiManifest)
-	if err != nil {
-		return fmt.Errorf("clone owned ui manifest %s: %w", ownedUI.Path, err)
-	}
-	packagedManifest.Release = nil
-
-	packagedRelPath := packagedOwnedUIManifestPath(ownedUI.Path)
-	packagedDir := filepath.Join(stagingDir, filepath.FromSlash(path.Dir(packagedRelPath)))
-	if err := copyReleasePackageFiles(packagedManifest, filepath.Dir(uiManifestPath), packagedDir, true); err != nil {
-		return fmt.Errorf("copy owned ui package %s: %w", ownedUI.Path, err)
-	}
-	if err := writeReleaseManifestFile(packagedDir, path.Base(packagedRelPath), providerpkg.ManifestFormatFromPath(uiManifestPath), packagedManifest); err != nil {
-		return fmt.Errorf("write owned ui manifest %s: %w", ownedUI.Path, err)
-	}
-
-	ownedUI.Path = packagedRelPath
-	return nil
-}
-
-func packagedOwnedUIManifestPath(rel string) string {
-	cleanRel := path.Clean(strings.ReplaceAll(rel, "\\", "/"))
-	manifestFile := path.Base(cleanRel)
-	parent := path.Base(path.Dir(cleanRel))
-	if parent == "." || parent == "/" || parent == "" {
-		return path.Join(releaseOwnedUIRoot, manifestFile)
-	}
-	return path.Join(releaseOwnedUIRoot, parent, manifestFile)
 }
 
 func validateReleaseOutputDir(manifest *providermanifestv1.Manifest, sourceDir, outputDir string) error {

--- a/gestaltd/cmd/gestaltd/plugin_test.go
+++ b/gestaltd/cmd/gestaltd/plugin_test.go
@@ -939,90 +939,117 @@ func TestRun_PluginReleaseCopiesWebUISupportFiles(t *testing.T) {
 func TestRun_PluginReleaseStagesOwnedWebUIPackage(t *testing.T) {
 	t.Parallel()
 
-	pluginDir := newSourceProviderReleaseFixtureWithOwnedUI(t, t.TempDir())
-	outputDir := t.TempDir()
-	testVersion := "0.0.3-owned-ui"
-
-	runPluginReleaseCommand(t, pluginDir,
-		"--version", testVersion,
-		"--platform", runtime.GOOS+"/"+runtime.GOARCH,
-		"--output", outputDir,
-	)
-
-	archiveName := "gestalt-plugin-release-test_v" + testVersion + "_" + runtime.GOOS + "_" + runtime.GOARCH + ".tar.gz"
-	extractDir := extractReleasedArchive(t, outputDir, archiveName)
-	manifest := readReleasedManifest(t, outputDir, archiveName)
-	if manifest.Spec == nil || manifest.Spec.UI == nil {
-		t.Fatalf("released manifest spec.ui = %+v", manifest.Spec)
-	}
-	const wantOwnedUIPath = "_owned_ui/roadmap-ui/manifest.json"
-	if got := manifest.Spec.UI.Path; got != wantOwnedUIPath {
-		t.Fatalf("spec.ui.path = %q, want %q", got, wantOwnedUIPath)
-	}
-	for _, rel := range []string{
-		wantOwnedUIPath,
-		"_owned_ui/roadmap-ui/branding/icon.svg",
-		"_owned_ui/roadmap-ui/dist/index.html",
-		"_owned_ui/roadmap-ui/dist/static/app.js",
-	} {
-		if _, err := os.Stat(filepath.Join(extractDir, filepath.FromSlash(rel))); err != nil {
-			t.Fatalf("expected %s in archive: %v", rel, err)
-		}
-	}
-	_, ownedUIManifest, err := providerpkg.ReadManifestFile(filepath.Join(extractDir, filepath.FromSlash(wantOwnedUIPath)))
-	if err != nil {
-		t.Fatalf("read owned ui manifest: %v", err)
-	}
-	if ownedUIManifest.Release != nil {
-		t.Fatalf("owned ui manifest unexpectedly retained release metadata: %+v", ownedUIManifest.Release)
-	}
-
-	configDir := t.TempDir()
-	configPath := writeManagedPluginConfigForTest(t, configDir, "roadmap", releaseTestSource, testVersion, "/create-customer-roadmap-review")
-	lc := operator.NewLifecycle(archiveSourceResolver{
-		paths: map[string]string{
-			releaseTestSource: filepath.Join(outputDir, archiveName),
+	tests := []struct {
+		name          string
+		fixture       func(*testing.T, string) string
+		wantFiles     []string
+		wantAssetRoot string
+		skipOnWin     bool
+	}{
+		{
+			name:          "prebuilt owned ui assets",
+			fixture:       newSourceProviderReleaseFixtureWithOwnedUI,
+			wantFiles:     []string{"_owned_ui/roadmap-ui/branding/icon.svg", "_owned_ui/roadmap-ui/dist/index.html", "_owned_ui/roadmap-ui/dist/static/app.js"},
+			wantAssetRoot: filepath.Join("_owned_ui", "roadmap-ui", "dist"),
 		},
-	})
-	if _, err := lc.InitAtPath(configPath); err != nil {
-		t.Fatalf("InitAtPath: %v", err)
+		{
+			name:          "built owned ui assets",
+			fixture:       newSourceProviderReleaseFixtureWithBuiltOwnedUI,
+			wantFiles:     []string{"_owned_ui/roadmap-ui/branding/icon.svg", "_owned_ui/roadmap-ui/ui/dist/index.html", "_owned_ui/roadmap-ui/ui/dist/static/app.js"},
+			wantAssetRoot: filepath.Join("_owned_ui", "roadmap-ui", "ui", "dist"),
+			skipOnWin:     true,
+		},
 	}
 
-	loaded, _, err := lc.LoadForExecutionAtPath(configPath, true)
-	if err != nil {
-		t.Fatalf("LoadForExecutionAtPath(locked=true): %v", err)
-	}
-	plugin := loaded.Plugins["roadmap"]
-	if plugin == nil || plugin.ResolvedManifest == nil {
-		t.Fatalf("ResolvedManifest = %+v", plugin)
-	}
-	if plugin.Command == "" {
-		t.Fatalf("plugin.Command = %q, want packaged executable path", plugin.Command)
-	}
-	if got := plugin.ResolvedManifest.Version; got != testVersion {
-		t.Fatalf("ResolvedManifest.Version = %q, want %q", got, testVersion)
-	}
+	for _, tc := range tests {
+		tc := tc
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			if tc.skipOnWin && runtime.GOOS == "windows" {
+				t.Skip("owned ui release-build fixture uses POSIX shell")
+			}
 
-	uiEntry := loaded.Providers.UI["roadmap"]
-	if uiEntry == nil || uiEntry.ResolvedManifest == nil {
-		t.Fatalf("Resolved plugin-owned UI = %+v", uiEntry)
-	}
-	if uiEntry.Path != "/create-customer-roadmap-review" {
-		t.Fatalf("uiEntry.Path = %q, want %q", uiEntry.Path, "/create-customer-roadmap-review")
-	}
-	if got := filepath.ToSlash(uiEntry.ResolvedManifestPath); !strings.HasSuffix(got, filepath.ToSlash(filepath.Join("_owned_ui", "roadmap-ui", providerpkg.ManifestFile))) {
-		t.Fatalf("ResolvedManifestPath = %q, want owned-ui manifest suffix", got)
-	}
-	if got := filepath.ToSlash(uiEntry.ResolvedAssetRoot); !strings.HasSuffix(got, filepath.ToSlash(filepath.Join("_owned_ui", "roadmap-ui", "dist"))) {
-		t.Fatalf("ResolvedAssetRoot = %q, want owned-ui asset root suffix", got)
-	}
+			pluginDir := tc.fixture(t, t.TempDir())
+			outputDir := t.TempDir()
+			testVersion := "0.0.3-owned-ui"
 
-	lock, err := operator.ReadLockfile(filepath.Join(configDir, operator.InitLockfileName))
-	if err != nil {
-		t.Fatalf("ReadLockfile: %v", err)
-	}
-	if len(lock.UIs) != 0 {
-		t.Fatalf("lock.UIs = %#v, want no separate UI entries for packaged owned UI", lock.UIs)
+			runPluginReleaseCommand(t, pluginDir,
+				"--version", testVersion,
+				"--platform", runtime.GOOS+"/"+runtime.GOARCH,
+				"--output", outputDir,
+			)
+
+			archiveName := "gestalt-plugin-release-test_v" + testVersion + "_" + runtime.GOOS + "_" + runtime.GOARCH + ".tar.gz"
+			extractDir := extractReleasedArchive(t, outputDir, archiveName)
+			manifest := readReleasedManifest(t, outputDir, archiveName)
+			if manifest.Spec == nil || manifest.Spec.UI == nil {
+				t.Fatalf("released manifest spec.ui = %+v", manifest.Spec)
+			}
+			const wantOwnedUIPath = "_owned_ui/roadmap-ui/manifest.json"
+			if got := manifest.Spec.UI.Path; got != wantOwnedUIPath {
+				t.Fatalf("spec.ui.path = %q, want %q", got, wantOwnedUIPath)
+			}
+			for _, rel := range append([]string{wantOwnedUIPath}, tc.wantFiles...) {
+				if _, err := os.Stat(filepath.Join(extractDir, filepath.FromSlash(rel))); err != nil {
+					t.Fatalf("expected %s in archive: %v", rel, err)
+				}
+			}
+			_, ownedUIManifest, err := providerpkg.ReadManifestFile(filepath.Join(extractDir, filepath.FromSlash(wantOwnedUIPath)))
+			if err != nil {
+				t.Fatalf("read owned ui manifest: %v", err)
+			}
+			if ownedUIManifest.Release != nil {
+				t.Fatalf("owned ui manifest unexpectedly retained release metadata: %+v", ownedUIManifest.Release)
+			}
+
+			configDir := t.TempDir()
+			configPath := writeManagedPluginConfigForTest(t, configDir, "roadmap", releaseTestSource, testVersion, "/create-customer-roadmap-review")
+			lc := operator.NewLifecycle(archiveSourceResolver{
+				paths: map[string]string{
+					releaseTestSource: filepath.Join(outputDir, archiveName),
+				},
+			})
+			if _, err := lc.InitAtPath(configPath); err != nil {
+				t.Fatalf("InitAtPath: %v", err)
+			}
+
+			loaded, _, err := lc.LoadForExecutionAtPath(configPath, true)
+			if err != nil {
+				t.Fatalf("LoadForExecutionAtPath(locked=true): %v", err)
+			}
+			plugin := loaded.Plugins["roadmap"]
+			if plugin == nil || plugin.ResolvedManifest == nil {
+				t.Fatalf("ResolvedManifest = %+v", plugin)
+			}
+			if plugin.Command == "" {
+				t.Fatalf("plugin.Command = %q, want packaged executable path", plugin.Command)
+			}
+			if got := plugin.ResolvedManifest.Version; got != testVersion {
+				t.Fatalf("ResolvedManifest.Version = %q, want %q", got, testVersion)
+			}
+
+			uiEntry := loaded.Providers.UI["roadmap"]
+			if uiEntry == nil || uiEntry.ResolvedManifest == nil {
+				t.Fatalf("Resolved plugin-owned UI = %+v", uiEntry)
+			}
+			if uiEntry.Path != "/create-customer-roadmap-review" {
+				t.Fatalf("uiEntry.Path = %q, want %q", uiEntry.Path, "/create-customer-roadmap-review")
+			}
+			if got := filepath.ToSlash(uiEntry.ResolvedManifestPath); !strings.HasSuffix(got, filepath.ToSlash(filepath.Join("_owned_ui", "roadmap-ui", providerpkg.ManifestFile))) {
+				t.Fatalf("ResolvedManifestPath = %q, want owned-ui manifest suffix", got)
+			}
+			if got := filepath.ToSlash(uiEntry.ResolvedAssetRoot); !strings.HasSuffix(got, filepath.ToSlash(tc.wantAssetRoot)) {
+				t.Fatalf("ResolvedAssetRoot = %q, want owned-ui asset root suffix %q", got, tc.wantAssetRoot)
+			}
+
+			lock, err := operator.ReadLockfile(filepath.Join(configDir, operator.InitLockfileName))
+			if err != nil {
+				t.Fatalf("ReadLockfile: %v", err)
+			}
+			if len(lock.UIs) != 0 {
+				t.Fatalf("lock.UIs = %#v, want no separate UI entries for packaged owned UI", lock.UIs)
+			}
+		})
 	}
 }
 
@@ -1661,12 +1688,6 @@ fi
 
 cwd="$2"
 shift 2
-
-if [ "$1" != "run" ]; then
-  echo "unexpected bun subcommand: $1" >&2
-  exit 1
-fi
-shift
 
 entry="$1"
 shift
@@ -2530,6 +2551,44 @@ func newSourceProviderReleaseFixtureWithOwnedUI(t *testing.T, dir string) string
 	writeTestFile(t, uiDir, releaseTestIconPath, []byte("<svg></svg>\n"), 0o644)
 	writeTestFile(t, uiDir, "dist/index.html", []byte("<html>roadmap</html>\n"), 0o644)
 	writeTestFile(t, uiDir, "dist/static/app.js", []byte("console.log('roadmap')\n"), 0o644)
+
+	manifestPath := filepath.Join(pluginDir, providerpkg.ManifestFile)
+	_, manifest, err := providerpkg.ReadSourceManifestFile(manifestPath)
+	if err != nil {
+		t.Fatalf("ReadSourceManifestFile(%s): %v", providerpkg.ManifestFile, err)
+	}
+	manifest.Spec.UI = &providermanifestv1.OwnedUIRef{Path: "../roadmap-ui/" + providerpkg.ManifestFile}
+	writeReleaseTestManifest(t, pluginDir, manifest)
+
+	return pluginDir
+}
+
+func newSourceProviderReleaseFixtureWithBuiltOwnedUI(t *testing.T, dir string) string {
+	t.Helper()
+
+	pluginDir := newSourceProviderReleaseFixture(t, dir)
+	uiDir := filepath.Join(dir, "roadmap-ui")
+	if err := os.MkdirAll(uiDir, 0o755); err != nil {
+		t.Fatalf("MkdirAll(uiDir): %v", err)
+	}
+	writeReleaseTestManifest(t, uiDir, &providermanifestv1.Manifest{
+		Kind:        providermanifestv1.KindWebUI,
+		Source:      "github.com/testowner/web/roadmap-ui",
+		Version:     "0.0.1",
+		DisplayName: "Roadmap UI",
+		IconFile:    releaseTestIconPath,
+		Release: &providermanifestv1.ReleaseMetadata{
+			Build: &providermanifestv1.ReleaseBuild{
+				Workdir: "ui",
+				Command: []string{"sh", "./build.sh"},
+			},
+		},
+		Spec: &providermanifestv1.Spec{
+			AssetRoot: "ui/dist",
+		},
+	})
+	writeTestFile(t, uiDir, releaseTestIconPath, []byte("<svg></svg>\n"), 0o644)
+	writeReleaseBuildScript(t, uiDir, filepath.Join("ui", "build.sh"), "mkdir -p dist/static\nprintf '<html>roadmap</html>\\n' > dist/index.html\nprintf 'console.log(\"roadmap\")\\n' > dist/static/app.js\n")
 
 	manifestPath := filepath.Join(pluginDir, providerpkg.ManifestFile)
 	_, manifest, err := providerpkg.ReadSourceManifestFile(manifestPath)

--- a/gestaltd/internal/providerpkg/prepared_stage.go
+++ b/gestaltd/internal/providerpkg/prepared_stage.go
@@ -1,0 +1,367 @@
+package providerpkg
+
+import (
+	"encoding/json"
+	"fmt"
+	"io"
+	"io/fs"
+	"os"
+	"path"
+	"path/filepath"
+	"strings"
+
+	"github.com/valon-technologies/gestalt/server/internal/pluginsource"
+	providermanifestv1 "github.com/valon-technologies/gestalt/server/sdk/providermanifest/v1"
+)
+
+const (
+	releaseOwnedUIRoot          = "_owned_ui"
+	preparedReleaseBinaryPrefix = "gestalt-plugin-"
+	windowsOS                   = "windows"
+	windowsExecutableSuffix     = ".exe"
+)
+
+type StagePreparedInstallOptions struct {
+	VersionOverride string
+	BuildKind       string
+	PluginName      string
+	GOOS            string
+	GOARCH          string
+}
+
+type StagedPreparedInstall struct {
+	Manifest       *providermanifestv1.Manifest
+	ManifestPath   string
+	ManifestFile   string
+	ManifestFormat string
+}
+
+// StagePreparedInstallDir stages a source manifest into its prepared-install layout.
+// It is the shared host-platform staging layer used by release packaging and local preparation.
+func StagePreparedInstallDir(manifestPath, stagingDir string, opts StagePreparedInstallOptions) (*StagedPreparedInstall, error) {
+	if strings.TrimSpace(manifestPath) == "" {
+		return nil, fmt.Errorf("manifest path is required")
+	}
+	if strings.TrimSpace(stagingDir) == "" {
+		return nil, fmt.Errorf("staging directory is required")
+	}
+
+	sourceDir := filepath.Dir(manifestPath)
+	manifestFile := filepath.Base(manifestPath)
+	manifestFormat := ManifestFormatFromPath(manifestPath)
+
+	_, _, err := ReadSourceManifestFile(manifestPath)
+	if err != nil {
+		return nil, fmt.Errorf("read %s: %w", manifestPath, err)
+	}
+	_, srcManifest, err := PrepareSourceManifest(manifestPath)
+	if err != nil {
+		return nil, fmt.Errorf("prepare %s: %w", manifestPath, err)
+	}
+
+	version := srcManifest.Version
+	if strings.TrimSpace(opts.VersionOverride) != "" {
+		version = strings.TrimSpace(opts.VersionOverride)
+	}
+	pluginName := strings.TrimSpace(opts.PluginName)
+	if pluginName == "" {
+		src, err := pluginsource.Parse(srcManifest.Source)
+		if err != nil {
+			return nil, fmt.Errorf("invalid source in manifest: %w", err)
+		}
+		pluginName = src.PluginName()
+	}
+
+	var stagedManifest *providermanifestv1.Manifest
+	switch buildKind := strings.TrimSpace(opts.BuildKind); {
+	case buildKind != "":
+		if opts.GOOS == "" || opts.GOARCH == "" {
+			return nil, fmt.Errorf("goos and goarch are required when build kind is set")
+		}
+		binaryName := stagedReleaseBinaryName(pluginName, opts.GOOS)
+		binaryPath := filepath.Join(stagingDir, binaryName)
+		if _, err := buildPreparedInstallBinary(sourceDir, binaryPath, pluginName, buildKind, opts.GOOS, opts.GOARCH); err != nil {
+			return nil, err
+		}
+		digest, err := FileSHA256(binaryPath)
+		if err != nil {
+			return nil, fmt.Errorf("hash binary: %w", err)
+		}
+		stagedManifest, err = buildPreparedInstallManifest(srcManifest, version, binaryName, opts.GOOS, opts.GOARCH, digest)
+		if err != nil {
+			return nil, err
+		}
+		if err := copyPreparedInstallSupportFiles(stagedManifest, sourceDir, stagingDir, false); err != nil {
+			return nil, err
+		}
+	default:
+		stagedManifest, err = buildPreparedInstallSourceManifest(srcManifest, version, sourceDir)
+		if err != nil {
+			return nil, err
+		}
+		if err := copyPreparedInstallSupportFiles(stagedManifest, sourceDir, stagingDir, true); err != nil {
+			return nil, err
+		}
+	}
+
+	stagedManifestPath := filepath.Join(stagingDir, manifestFile)
+	if err := writePreparedManifestFile(stagedManifestPath, manifestFormat, stagedManifest); err != nil {
+		return nil, err
+	}
+
+	return &StagedPreparedInstall{
+		Manifest:       stagedManifest,
+		ManifestPath:   stagedManifestPath,
+		ManifestFile:   manifestFile,
+		ManifestFormat: manifestFormat,
+	}, nil
+}
+
+func buildPreparedInstallBinary(root, outputPath, pluginName, kind, goos, goarch string) (string, error) {
+	switch kind {
+	case providermanifestv1.KindPlugin:
+		return BuildSourceProviderReleaseBinary(root, outputPath, pluginName, goos, goarch)
+	case providermanifestv1.KindAuth, providermanifestv1.KindIndexedDB, providermanifestv1.KindCache, providermanifestv1.KindS3, providermanifestv1.KindSecrets:
+		return BuildSourceComponentReleaseBinary(root, outputPath, kind, goos, goarch)
+	default:
+		return "", fmt.Errorf("unsupported release build target kind %q", kind)
+	}
+}
+
+func buildPreparedInstallSourceManifest(srcManifest *providermanifestv1.Manifest, version, sourceDir string) (*providermanifestv1.Manifest, error) {
+	manifest, err := cloneManifest(srcManifest)
+	if err != nil {
+		return nil, fmt.Errorf("clone manifest: %w", err)
+	}
+	manifest.Version = version
+	manifest.Release = nil
+
+	for i, artifact := range srcManifest.Artifacts {
+		digest, err := FileSHA256(filepath.Join(sourceDir, filepath.FromSlash(artifact.Path)))
+		if err != nil {
+			return nil, fmt.Errorf("hash artifact %s: %w", artifact.Path, err)
+		}
+		if artifact.SHA256 != "" && artifact.SHA256 != digest {
+			return nil, fmt.Errorf("artifact %s sha256 mismatch: manifest=%s actual=%s", artifact.Path, artifact.SHA256, digest)
+		}
+		manifest.Artifacts[i].SHA256 = digest
+	}
+
+	return manifest, nil
+}
+
+func buildPreparedInstallManifest(srcManifest *providermanifestv1.Manifest, version, binaryName, goos, goarch, digest string) (*providermanifestv1.Manifest, error) {
+	manifest, err := cloneManifest(srcManifest)
+	if err != nil {
+		return nil, fmt.Errorf("clone manifest: %w", err)
+	}
+	manifest.Version = version
+	manifest.Release = nil
+	manifest.Artifacts = []providermanifestv1.Artifact{
+		{OS: goos, Arch: goarch, Path: binaryName, SHA256: digest},
+	}
+	EnsureEntrypoint(manifest).ArtifactPath = binaryName
+	return manifest, nil
+}
+
+func writePreparedManifestFile(path, manifestFormat string, manifest *providermanifestv1.Manifest) error {
+	data, err := EncodeManifestFormat(manifest, manifestFormat)
+	if err != nil {
+		return fmt.Errorf("encode manifest: %w", err)
+	}
+	return os.WriteFile(path, data, 0o644)
+}
+
+func cloneManifest(manifest *providermanifestv1.Manifest) (*providermanifestv1.Manifest, error) {
+	if manifest == nil {
+		return nil, nil
+	}
+
+	data, err := json.Marshal(manifest)
+	if err != nil {
+		return nil, err
+	}
+
+	var cloned providermanifestv1.Manifest
+	if err := json.Unmarshal(data, &cloned); err != nil {
+		return nil, err
+	}
+	return &cloned, nil
+}
+
+func copyPreparedInstallDir(src, dst string) error {
+	return filepath.WalkDir(src, func(path string, d fs.DirEntry, err error) error {
+		if err != nil {
+			return err
+		}
+		rel, err := filepath.Rel(src, path)
+		if err != nil {
+			return err
+		}
+		target := filepath.Join(dst, rel)
+		if d.IsDir() {
+			return os.MkdirAll(target, 0o755)
+		}
+		return copyPreparedInstallFile(path, target)
+	})
+}
+
+func copyPreparedInstallFile(src, dst string) error {
+	in, err := os.Open(src)
+	if err != nil {
+		return err
+	}
+	defer func() { _ = in.Close() }()
+
+	info, err := in.Stat()
+	if err != nil {
+		return err
+	}
+	if err := os.MkdirAll(filepath.Dir(dst), 0o755); err != nil {
+		return err
+	}
+	out, err := os.OpenFile(dst, os.O_CREATE|os.O_WRONLY|os.O_TRUNC, info.Mode())
+	if err != nil {
+		return err
+	}
+	if _, err := io.Copy(out, in); err != nil {
+		_ = out.Close()
+		return err
+	}
+	return out.Close()
+}
+
+func copyPreparedInstallSupportFiles(manifest *providermanifestv1.Manifest, sourceDir, stagingDir string, includeArtifacts bool) error {
+	if manifest == nil {
+		return nil
+	}
+	if err := stagePreparedOwnedUI(manifest, sourceDir, stagingDir); err != nil {
+		return err
+	}
+
+	copied := make(map[string]struct{})
+	copyPath := func(rel string, optional bool) error {
+		if rel == "" {
+			return nil
+		}
+
+		cleanRel, err := normalizePreparedInstallPath(rel)
+		if err != nil {
+			return err
+		}
+		if _, seen := copied[cleanRel]; seen {
+			return nil
+		}
+		copied[cleanRel] = struct{}{}
+
+		srcPath := filepath.Join(sourceDir, filepath.FromSlash(cleanRel))
+		info, err := os.Stat(srcPath)
+		if err != nil {
+			if optional && os.IsNotExist(err) {
+				return nil
+			}
+			return fmt.Errorf("stat support path %s: %w", rel, err)
+		}
+
+		dstPath := filepath.Join(stagingDir, filepath.FromSlash(cleanRel))
+		if info.IsDir() {
+			if err := copyPreparedInstallDir(srcPath, dstPath); err != nil {
+				return fmt.Errorf("copy support directory %s: %w", rel, err)
+			}
+			return nil
+		}
+		if err := copyPreparedInstallFile(srcPath, dstPath); err != nil {
+			return fmt.Errorf("copy support file %s: %w", rel, err)
+		}
+		return nil
+	}
+
+	if err := copyPath(manifest.IconFile, false); err != nil {
+		return err
+	}
+	for _, ref := range LocalPackageReferences(manifest) {
+		if err := copyPath(ref.Path, false); err != nil {
+			return err
+		}
+	}
+	if manifest.Kind == providermanifestv1.KindPlugin && manifest.Spec != nil {
+		if err := copyPath(StaticCatalogFile, !StaticCatalogRequired(manifest)); err != nil {
+			return err
+		}
+	}
+	if manifest.Spec != nil && manifest.Spec.ConfigSchemaPath != "" {
+		if err := copyPath(manifest.Spec.ConfigSchemaPath, false); err != nil {
+			return err
+		}
+	}
+	if manifest.Spec != nil && manifest.Spec.AssetRoot != "" {
+		if err := copyPath(manifest.Spec.AssetRoot, false); err != nil {
+			return err
+		}
+	}
+	if includeArtifacts {
+		for _, artifact := range manifest.Artifacts {
+			if err := copyPath(artifact.Path, false); err != nil {
+				return err
+			}
+		}
+	}
+	return nil
+}
+
+func stagePreparedOwnedUI(manifest *providermanifestv1.Manifest, sourceDir, stagingDir string) error {
+	if manifest == nil || manifest.Kind != providermanifestv1.KindPlugin || manifest.Spec == nil || manifest.Spec.UI == nil {
+		return nil
+	}
+	ownedUI := manifest.Spec.UI
+	if strings.TrimSpace(ownedUI.Path) == "" {
+		return nil
+	}
+
+	uiManifestPath := filepath.Join(sourceDir, filepath.FromSlash(ownedUI.Path))
+	_, uiManifest, err := ReadSourceManifestFile(uiManifestPath)
+	if err != nil {
+		return fmt.Errorf("read owned ui manifest %s: %w", ownedUI.Path, err)
+	}
+	if err := RunSourceReleaseBuild(uiManifestPath, uiManifest); err != nil {
+		return fmt.Errorf("build owned ui package %s: %w", ownedUI.Path, err)
+	}
+	packagedRelPath := packagedOwnedUIManifestPath(ownedUI.Path)
+	packagedDir := filepath.Join(stagingDir, filepath.FromSlash(path.Dir(packagedRelPath)))
+	if _, err := StagePreparedInstallDir(uiManifestPath, packagedDir, StagePreparedInstallOptions{}); err != nil {
+		return fmt.Errorf("stage owned ui package %s: %w", ownedUI.Path, err)
+	}
+
+	ownedUI.Path = packagedRelPath
+	return nil
+}
+
+func packagedOwnedUIManifestPath(rel string) string {
+	cleanRel := path.Clean(strings.ReplaceAll(rel, "\\", "/"))
+	manifestFile := path.Base(cleanRel)
+	parent := path.Base(path.Dir(cleanRel))
+	if parent == "." || parent == "/" || parent == "" {
+		return path.Join(releaseOwnedUIRoot, manifestFile)
+	}
+	return path.Join(releaseOwnedUIRoot, parent, manifestFile)
+}
+
+func normalizePreparedInstallPath(rel string) (string, error) {
+	if rel == "" {
+		return "", nil
+	}
+
+	cleanPath := path.Clean(strings.ReplaceAll(rel, "\\", "/"))
+	if path.IsAbs(cleanPath) || cleanPath == ".." || strings.HasPrefix(cleanPath, "../") {
+		return "", fmt.Errorf("release path %q must stay within plugin root", rel)
+	}
+	return cleanPath, nil
+}
+
+func stagedReleaseBinaryName(pluginName, goos string) string {
+	binaryName := preparedReleaseBinaryPrefix + pluginName
+	if goos == windowsOS {
+		return binaryName + windowsExecutableSuffix
+	}
+	return binaryName
+}

--- a/gestaltd/internal/providerpkg/typescript_provider.go
+++ b/gestaltd/internal/providerpkg/typescript_provider.go
@@ -83,7 +83,6 @@ func typeScriptExecutionCommand(root, target string) (string, []string, func(), 
 	if sdkPath := localTypeScriptSDKPath(); sdkPath != "" {
 		return bunPath, []string{
 			"--cwd", root,
-			"run",
 			filepath.Join(sdkPath, "src", "runtime.ts"),
 			"--",
 			root,
@@ -121,7 +120,6 @@ func buildTypeScriptBinary(sourceDir, binaryPath, pluginName, target, goos, goar
 	if sdkPath := localTypeScriptSDKPath(); sdkPath != "" {
 		args = []string{
 			"--cwd", sourceDir,
-			"run",
 			filepath.Join(sdkPath, "src", "build.ts"),
 			"--",
 			sourceDir,

--- a/gestaltd/internal/providerpkg/typescript_provider_test.go
+++ b/gestaltd/internal/providerpkg/typescript_provider_test.go
@@ -339,27 +339,21 @@ func TestSourceProviderExecutionCommand_TypeScript(t *testing.T) {
 	if command != bunPath {
 		t.Fatalf("command = %q, want %q", command, bunPath)
 	}
-	if len(args) != 7 {
-		t.Fatalf("args len = %d, want 7 (%v)", len(args), args)
+	if len(args) != 6 {
+		t.Fatalf("args len = %d, want 6 (%v)", len(args), args)
 	}
 	if args[0] != "--cwd" || args[1] != root {
 		t.Fatalf("args prefix = %v, want [--cwd %s ...]", args[:2], root)
 	}
-	if args[2] != "run" {
-		t.Fatalf("args[2] = %q, want run", args[2])
+	if args[3] != "--" {
+		t.Fatalf("args[3] = %q, want --", args[3])
 	}
-	if args[4] != "--" {
-		t.Fatalf("args[4] = %q, want --", args[4])
-	}
-	if args[5] != root || args[6] != typeScriptTestPluginTarget {
-		t.Fatalf("args tail = %v, want [%s %s]", args[5:], root, typeScriptTestPluginTarget)
+	if args[4] != root || args[5] != typeScriptTestPluginTarget {
+		t.Fatalf("args tail = %v, want [%s %s]", args[4:], root, typeScriptTestPluginTarget)
 	}
 
-	entry := filepath.Base(args[3])
-	switch entry {
-	case typeScriptRuntimeBin, "runtime.ts":
-	default:
-		t.Fatalf("runtime entry = %q, want %q or local runtime.ts path", args[3], typeScriptRuntimeBin)
+	if got := filepath.Base(args[2]); got != "runtime.ts" {
+		t.Fatalf("runtime entry = %q, want local runtime.ts path", args[2])
 	}
 }
 
@@ -403,11 +397,14 @@ func TestSourceComponentExecutionCommand_TypeScript(t *testing.T) {
 			if command != bunPath {
 				t.Fatalf("command = %q, want %q", command, bunPath)
 			}
-			if len(args) != 7 {
-				t.Fatalf("args len = %d, want 7 (%v)", len(args), args)
+			if len(args) != 6 {
+				t.Fatalf("args len = %d, want 6 (%v)", len(args), args)
 			}
-			if args[5] != root || args[6] != tt.target {
-				t.Fatalf("args tail = %v, want [%s %s]", args[5:], root, tt.target)
+			if got := filepath.Base(args[2]); got != "runtime.ts" {
+				t.Fatalf("runtime entry = %q, want local runtime.ts path", args[2])
+			}
+			if args[4] != root || args[5] != tt.target {
+				t.Fatalf("args tail = %v, want [%s %s]", args[4:], root, tt.target)
 			}
 		})
 	}
@@ -696,12 +693,6 @@ fi
 
 cwd="$2"
 shift 2
-
-if [ "$1" != "run" ]; then
-  echo "unexpected bun subcommand: $1" >&2
-  exit 1
-fi
-shift
 
 entry="$1"
 shift


### PR DESCRIPTION
## Summary
This PR extracts a shared host-platform prepared-install staging helper into `internal/providerpkg` and refactors `gestaltd provider release` onto it.

It also fixes the local SDK TypeScript Bun invocation used for source catalog generation and build staging:
- `bun --cwd <root> <sdk>/src/runtime.ts -- <root> <target>`
- `bun --cwd <root> <sdk>/src/build.ts -- <root> <target> <output> <plugin> <goos> <goarch>`

This is PR 1 of the local-vs-packaged execution convergence work. It does **not** change runtime transport.

## New Interfaces
### Go
```go
staged, err := providerpkg.StagePreparedInstallDir(
    "manifest.yaml",
    stagingDir,
    providerpkg.StagePreparedInstallOptions{
        VersionOverride: "1.2.3",
    },
)
```

```go
staged, err := providerpkg.StagePreparedInstallDir(
    "manifest.yaml",
    stagingDir,
    providerpkg.StagePreparedInstallOptions{
        VersionOverride: "1.2.3",
        BuildKind:       "plugin",
        PluginName:      "release-test",
        GOOS:            "darwin",
        GOARCH:          "arm64",
    },
)
```

### CLI / Process Contract
`gestaltd provider release` keeps the same external CLI:
```bash
gestaltd provider release --version 1.2.3
gestaltd provider release --version 1.2.3 --platform darwin/arm64,linux/amd64
```

The local SDK TypeScript process contract now uses direct script execution instead of `bun run` for absolute SDK paths:
```bash
bun --cwd <root> <sdk>/src/runtime.ts -- <root> plugin:./provider.ts#provider
bun --cwd <root> <sdk>/src/build.ts -- <root> auth:./auth.ts#auth <output> auth-release darwin arm64
```

### Rust / stdin-stdout note
This slice does not change Rust APIs or introduce a stdin/stdout transport. Runtime transport remains unchanged.

## What Changed
- Added `providerpkg.StagePreparedInstallDir(...)` as the shared host-platform staging primitive.
- Moved release staging/copy/owned-UI packaging logic out of `cmd/gestaltd/plugin.go` into `internal/providerpkg`.
- Kept `release.build.command` as a once-per-release step in `runProviderRelease`, before build-target detection.
- Preserved nested owned-UI `release.build` handling during staging.
- Switched the local SDK Bun path from `bun run <abs-script.ts>` to `bun <abs-script.ts>`.

## Verification
- `go test ./cmd/gestaltd`
- `go test ./internal/providerpkg`
