### PR TITLE
sdk/typescript: prefer plugin-only provider targets

### DIFF
--- a/docs/content/custom-providers/plugins.mdx
+++ b/docs/content/custom-providers/plugins.mdx
@@ -192,7 +192,7 @@ The manifest is the source of truth for display name, description, the connectio
       "gestalt": {
         "provider": {
           "kind": "plugin",
-          "target": "./provider.ts#provider"
+          "target": "./provider.ts#plugin"
         }
       }
     }
@@ -350,9 +350,9 @@ The following example defines a `conversations.getMessage` operation that fetche
   </Tabs.Tab>
   <Tabs.Tab>
     ```typescript
-    import { defineIntegrationProvider, ok, operation, s } from "@valon-technologies/gestalt";
+    import { definePlugin, ok, operation, s } from "@valon-technologies/gestalt";
 
-    export const provider = defineIntegrationProvider({
+    export const plugin = definePlugin({
       operations: [
         operation({
           id: "conversations.getMessage",
@@ -378,7 +378,7 @@ The following example defines a `conversations.getMessage` operation that fetche
 
     The `package.json` field `gestalt.provider` points Gestalt at the provider
     module and optional export. Use a string target such as
-    `./provider.ts#provider` for plugin providers, or an object with `kind` and
+    `./provider.ts#plugin` for plugin providers, or an object with `kind` and
     `target` for auth and datastore providers.
   </Tabs.Tab>
 </Tabs>
@@ -618,7 +618,7 @@ A Slack plugin could use this to check which Slack workspace the caller is conne
     Export a `sessionCatalog` function from your plugin provider definition:
 
     ```typescript
-    export const provider = defineIntegrationProvider({
+    export const plugin = definePlugin({
       sessionCatalog(request) {
         return {
           name: "slack-session",

--- a/docs/content/custom-providers/releasing.mdx
+++ b/docs/content/custom-providers/releasing.mdx
@@ -114,7 +114,7 @@ packaging.
       "gestalt": {
         "provider": {
           "kind": "plugin",
-          "target": "./provider.ts#provider"
+          "target": "./provider.ts#plugin"
         }
       }
     }

--- a/docs/content/reference/plugin-manifests.mdx
+++ b/docs/content/reference/plugin-manifests.mdx
@@ -654,7 +654,7 @@ for the end-to-end authoring flow.
       "gestalt": {
         "provider": {
           "kind": "plugin",
-          "target": "./provider.ts#provider"
+          "target": "./provider.ts#plugin"
         }
       }
     }

--- a/docs/content/reference/typescript-sdk.mdx
+++ b/docs/content/reference/typescript-sdk.mdx
@@ -8,9 +8,9 @@ and `target` entrypoints used by Bun-based providers.
 [Open the TypeScript API reference](/api/typescript/index.html)
 
 ```ts
-import { defineIntegrationProvider, ok, operation, s } from "@valon-technologies/gestalt";
+import { definePlugin, ok, operation, s } from "@valon-technologies/gestalt";
 
-export const provider = defineIntegrationProvider({
+export const plugin = definePlugin({
   displayName: "Example Provider",
   operations: [
     operation({

--- a/gestaltd/internal/providerpkg/typescript_provider.go
+++ b/gestaltd/internal/providerpkg/typescript_provider.go
@@ -72,20 +72,7 @@ func detectTypeScriptTarget(root, expectedKind string, missingErr error) (string
 			return formatTypeScriptRuntimeTarget(kind, target), nil
 		}
 	}
-
-	key, ok := typeScriptLegacyTargetKey(expectedKind)
-	if !ok {
-		return "", missingErr
-	}
-	target, ok := config.Gestalt[key].(string)
-	target = strings.TrimSpace(target)
-	if !ok || target == "" {
-		return "", missingErr
-	}
-	if _, _, err := SplitTypeScriptProviderTarget(target); err != nil {
-		return "", fmt.Errorf("%s gestalt.%s: %w", typeScriptProjectFile, key, err)
-	}
-	return formatTypeScriptRuntimeTarget(expectedKind, target), nil
+	return "", missingErr
 }
 
 func typeScriptExecutionCommand(root, target string) (string, []string, func(), error) {
@@ -186,23 +173,6 @@ func typeScriptComponentKind(kind string) (string, error) {
 	}
 }
 
-func typeScriptLegacyTargetKey(kind string) (string, bool) {
-	switch kind {
-	case "integration":
-		return typeScriptPluginKey, true
-	case "auth":
-		return typeScriptAuthKey, true
-	case "cache":
-		return typeScriptCacheKey, true
-	case "indexeddb":
-		return typeScriptIndexedDBKey, true
-	case "s3":
-		return typeScriptS3Key, true
-	default:
-		return "", false
-	}
-}
-
 func DetectBunExecutable() (string, error) {
 	for _, candidate := range bunExecutableCandidates() {
 		if candidate == "" {
@@ -297,6 +267,12 @@ func parseTypeScriptProviderString(raw string) (kind string, target string, err 
 		return prefix, rest, nil
 	}
 	if _, _, err := SplitTypeScriptProviderTarget(trimmed); err != nil {
+		if prefix, _, found := strings.Cut(trimmed, ":"); found {
+			prefix = strings.TrimSpace(prefix)
+			if prefix != "" && !strings.HasPrefix(prefix, ".") && !strings.HasPrefix(prefix, "/") {
+				return "", "", fmt.Errorf("unsupported provider kind %q", prefix)
+			}
+		}
 		return "", "", err
 	}
 	return "integration", trimmed, nil
@@ -319,7 +295,7 @@ func parseTypeScriptKindPrefixedTarget(raw string) (kind string, target string, 
 
 func normalizeTypeScriptProviderKind(value string) string {
 	switch strings.TrimSpace(strings.ToLower(value)) {
-	case "", "plugin", "integration":
+	case "", "plugin":
 		return "integration"
 	case "auth":
 		return "auth"

--- a/gestaltd/internal/providerpkg/typescript_provider_test.go
+++ b/gestaltd/internal/providerpkg/typescript_provider_test.go
@@ -103,11 +103,6 @@ func TestDetectTypeScriptProviderTarget(t *testing.T) {
 			target: typeScriptTestPluginTarget,
 			want:   typeScriptTestPluginTarget,
 		},
-		{
-			name:   "legacy integration prefix",
-			target: "integration:./provider.ts#plugin",
-			want:   typeScriptTestPluginTarget,
-		},
 	}
 
 	for _, tt := range tests {
@@ -133,13 +128,13 @@ func TestDetectTypeScriptProviderTarget_InvalidTarget(t *testing.T) {
 	t.Parallel()
 
 	root := t.TempDir()
-	mustWriteFile(t, filepath.Join(root, typeScriptProjectFile), []byte(`{"name":"ts-release","gestalt":{"plugin":"provider.ts"}}`), 0o644)
+	mustWriteFile(t, filepath.Join(root, typeScriptProjectFile), []byte(`{"name":"ts-release","gestalt":{"provider":"provider.ts"}}`), 0o644)
 
 	_, err := DetectTypeScriptProviderTarget(root)
 	if err == nil {
 		t.Fatal("expected invalid TypeScript provider target error")
 	}
-	if want := "package.json gestalt.plugin"; !containsString(err.Error(), want) {
+	if want := "package.json gestalt.provider"; !containsString(err.Error(), want) {
 		t.Fatalf("error = %q, want mention of %q", err, want)
 	}
 }
@@ -159,6 +154,49 @@ func TestDetectTypeScriptProviderTarget_RejectsEmptyKindPrefix(t *testing.T) {
 	}
 	if want := "package.json gestalt.provider"; !containsString(err.Error(), want) {
 		t.Fatalf("error = %q, want mention of %q", err, want)
+	}
+}
+
+func TestDetectTypeScriptProviderTarget_RejectsLegacyIntegrationPrefix(t *testing.T) {
+	t.Parallel()
+
+	root := t.TempDir()
+	mustWriteTypeScriptPackageConfig(t, root, map[string]string{
+		typeScriptProviderKey: "integration:./provider.ts#plugin",
+	})
+	mustWriteTypeScriptTargetModule(t, root, typeScriptTestPluginTarget)
+
+	_, err := DetectTypeScriptProviderTarget(root)
+	if err == nil {
+		t.Fatal("expected unsupported TypeScript provider kind error")
+	}
+	if want := `unsupported provider kind "integration"`; !containsString(err.Error(), want) {
+		t.Fatalf("error = %q, want mention of %q", err, want)
+	}
+}
+
+func TestDetectTypeScriptProviderTarget_ObjectConfig(t *testing.T) {
+	t.Parallel()
+
+	root := t.TempDir()
+	mustWriteFile(t, filepath.Join(root, typeScriptProjectFile), []byte(`{
+  "name": "ts-release",
+  "version": "0.0.1",
+  "gestalt": {
+    "provider": {
+      "kind": "plugin",
+      "target": "./provider.ts#plugin"
+    }
+  }
+}`), 0o644)
+	mustWriteTypeScriptTargetModule(t, root, typeScriptTestPluginTarget)
+
+	got, err := DetectTypeScriptProviderTarget(root)
+	if err != nil {
+		t.Fatalf("DetectTypeScriptProviderTarget: %v", err)
+	}
+	if got != typeScriptTestPluginTarget {
+		t.Fatalf("target = %q, want %q", got, typeScriptTestPluginTarget)
 	}
 }
 
@@ -226,14 +264,14 @@ func TestDetectTypeScriptComponentTarget_InvalidTarget(t *testing.T) {
 
 	root := t.TempDir()
 	mustWriteTypeScriptPackageConfig(t, root, map[string]string{
-		typeScriptAuthKey: "auth.ts",
+		typeScriptProviderKey: "auth:auth.ts",
 	})
 
 	_, err := DetectTypeScriptComponentTarget(root, providermanifestv1.KindAuth)
 	if err == nil {
 		t.Fatal("expected invalid TypeScript auth target error")
 	}
-	if want := "package.json gestalt.auth"; !containsString(err.Error(), want) {
+	if want := "package.json gestalt.provider"; !containsString(err.Error(), want) {
 		t.Fatalf("error = %q, want mention of %q", err, want)
 	}
 }
@@ -596,7 +634,7 @@ func mustWriteTypeScriptTargetModule(t *testing.T, root, target string) {
 
 func runtimeTargetModulePath(t *testing.T, target string) string {
 	t.Helper()
-	for _, prefix := range []string{"plugin:", "integration:", "auth:", "cache:", "indexeddb:", "secrets:", "telemetry:"} {
+	for _, prefix := range []string{"plugin:", "auth:", "cache:", "indexeddb:", "secrets:", "telemetry:"} {
 		if strings.HasPrefix(target, prefix) {
 			return strings.TrimPrefix(target, prefix)
 		}

--- a/sdk/typescript/README.md
+++ b/sdk/typescript/README.md
@@ -21,7 +21,7 @@ property in `package.json`:
   "gestalt": {
     "provider": {
       "kind": "plugin",
-      "target": "./provider.ts#provider"
+      "target": "./provider.ts#plugin"
     }
   }
 }
@@ -31,11 +31,9 @@ The target is a relative file path with an optional export suffix. The runtime
 accepts:
 
 - `gestalt.provider` as `{ "kind": "...", "target": "./file.ts#export" }`
-- `gestalt.provider` as a string like `"plugin:./provider.ts#provider"` or `"cache:./cache.ts#provider"`
-- legacy integration-only `gestalt.plugin`
+- `gestalt.provider` as a string like `"plugin:./provider.ts#plugin"` or `"cache:./cache.ts#provider"`
 
-Use `"plugin"` as the kind token for executable integration providers. The
-older `"integration"` spelling is still accepted for compatibility.
+Use `"plugin"` as the kind token for executable plugin providers.
 
 If the export suffix is omitted, the runtime looks for `provider`, then
 `plugin`, then the default export.
@@ -46,14 +44,14 @@ Use explicit runtime schemas to define plugin operation inputs and outputs:
 
 ```ts
 import {
-  defineIntegrationProvider,
+  definePlugin,
   ok,
   operation,
   response,
   s,
 } from "@valon-technologies/gestalt";
 
-export const provider = defineIntegrationProvider({
+export const plugin = definePlugin({
   displayName: "Example Provider",
   description: "A provider implemented with the Gestalt TypeScript SDK",
   configure(name, config) {
@@ -112,7 +110,7 @@ import {
 Source-mode runtime:
 
 ```sh
-gestalt-ts-runtime ROOT plugin:./provider.ts#provider
+gestalt-ts-runtime ROOT plugin:./provider.ts#plugin
 ```
 
 Release build:

--- a/sdk/typescript/docs/entrypoints/@valon-technologies/gestalt/index.ts
+++ b/sdk/typescript/docs/entrypoints/@valon-technologies/gestalt/index.ts
@@ -3,9 +3,9 @@
  *
  * @example
  * ```ts
- * import { defineIntegrationProvider, ok, operation, s } from "@valon-technologies/gestalt";
+ * import { definePlugin, ok, operation, s } from "@valon-technologies/gestalt";
  *
- * export const provider = defineIntegrationProvider({
+ * export const plugin = definePlugin({
  *   displayName: "Example Provider",
  *   operations: [
  *     operation({

--- a/sdk/typescript/src/build.ts
+++ b/sdk/typescript/src/build.ts
@@ -3,6 +3,7 @@ import { existsSync, mkdtempSync, rmSync, writeFileSync } from "node:fs";
 import { homedir, tmpdir } from "node:os";
 import { join, resolve } from "node:path";
 
+import { defaultProviderExportNames } from "./provider-kind.ts";
 import { parseProviderTarget, resolveProviderModulePath, type ProviderTarget } from "./target.ts";
 
 /**
@@ -81,7 +82,7 @@ export function buildProviderBinary(args: BuildArgs): void {
 }
 
 /**
- * Backwards-compatible alias for integration provider builds.
+ * Plugin-specific alias for provider builds.
  */
 export const buildPluginBinary = buildProviderBinary;
 
@@ -157,21 +158,9 @@ await runBundledProvider(candidate, ${JSON.stringify(target.kind)}, ${JSON.strin
 }
 
 function defaultBundledCandidateExpression(kind: ProviderTarget["kind"]): string {
-  switch (kind) {
-    case "integration":
-      return 'Reflect.get(bundledModule, "provider") ?? Reflect.get(bundledModule, "plugin") ?? bundledModule.default';
-    case "auth":
-      return 'Reflect.get(bundledModule, "auth") ?? Reflect.get(bundledModule, "provider") ?? bundledModule.default';
-    case "cache":
-      return 'Reflect.get(bundledModule, "cache") ?? Reflect.get(bundledModule, "provider") ?? bundledModule.default';
-    case "secrets":
-      return 'Reflect.get(bundledModule, "secrets") ?? Reflect.get(bundledModule, "provider") ?? bundledModule.default';
-    case "s3":
-      return 'Reflect.get(bundledModule, "s3") ?? Reflect.get(bundledModule, "provider") ?? bundledModule.default';
-    case "telemetry":
-      return 'Reflect.get(bundledModule, "telemetry") ?? Reflect.get(bundledModule, "provider") ?? bundledModule.default';
-  }
-  throw new Error(`unsupported provider kind: ${kind satisfies never}`);
+  return [...defaultProviderExportNames(kind), "default"]
+    .map((exportName) => `Reflect.get(bundledModule, ${JSON.stringify(exportName)})`)
+    .join(" ?? ");
 }
 
 function resolveBunExecutable(): string {

--- a/sdk/typescript/src/index.ts
+++ b/sdk/typescript/src/index.ts
@@ -6,9 +6,9 @@
  *
  * @example
  * ```ts
- * import { defineIntegrationProvider, ok, operation, s } from "@valon-technologies/gestalt";
+ * import { definePlugin, ok, operation, s } from "@valon-technologies/gestalt";
  *
- * export const provider = defineIntegrationProvider({
+ * export const plugin = definePlugin({
  *   displayName: "Example Provider",
  *   operations: [
  *     operation({
@@ -89,13 +89,11 @@ export {
   Plugin,
   connectionModeToProtoValue,
   connectionParamToProto,
-  defineIntegrationProvider,
   definePlugin,
-  isIntegrationProvider,
+  isPluginProvider,
   operation,
   type ConnectionMode,
   type ConnectionParamDefinition,
-  type IntegrationProviderOptions,
   type OperationDefinition,
   type OperationOptions,
   type PluginDefinitionOptions,

--- a/sdk/typescript/src/plugin.ts
+++ b/sdk/typescript/src/plugin.ts
@@ -19,7 +19,7 @@ import { RuntimeProvider, type RuntimeProviderOptions } from "./provider.ts";
 import type { Schema } from "./schema.ts";
 
 /**
- * How an integration provider expects to authenticate or connect.
+ * How a plugin provider expects to authenticate or connect.
  */
 export type ConnectionMode =
   | "unspecified"
@@ -57,7 +57,7 @@ export interface OperationOptions<In, Out> {
 }
 
 /**
- * Normalized integration operation definition.
+ * Normalized plugin operation definition.
  */
 export interface OperationDefinition<In, Out> extends OperationOptions<
   In,
@@ -77,7 +77,7 @@ export type SessionCatalogHandler = (
 ) => MaybePromise<SessionCatalog | null | undefined>;
 
 /**
- * Runtime hooks required to implement an integration provider.
+ * Runtime hooks required to implement a plugin provider.
  */
 export interface PluginDefinitionOptions extends RuntimeProviderOptions {
   connectionMode?: ConnectionMode;
@@ -89,12 +89,7 @@ export interface PluginDefinitionOptions extends RuntimeProviderOptions {
 }
 
 /**
- * Alias for integration providers to mirror the Go and Python SDKs.
- */
-export type IntegrationProviderOptions = PluginDefinitionOptions;
-
-/**
- * Normalizes an integration operation definition.
+ * Normalizes a plugin operation definition.
  */
 export function operation<In, Out>(
   options: OperationOptions<In, Out>,
@@ -111,13 +106,13 @@ export function operation<In, Out>(
 }
 
 /**
- * Integration provider implementation consumed by the Gestalt runtime.
+ * Plugin provider implementation consumed by the Gestalt runtime.
  *
  * @example
  * ```ts
- * import { defineIntegrationProvider, ok, operation, s } from "@valon-technologies/gestalt";
+ * import { definePlugin, ok, operation, s } from "@valon-technologies/gestalt";
  *
- * export const provider = defineIntegrationProvider({
+ * export const plugin = definePlugin({
  *   displayName: "Example Provider",
  *   operations: [
  *     operation({
@@ -134,7 +129,7 @@ export function operation<In, Out>(
  * });
  * ```
  */
-export class IntegrationProvider extends RuntimeProvider {
+export class PluginProvider extends RuntimeProvider {
   readonly kind = "integration" as const;
   readonly iconSvg: string;
   readonly connectionMode: ConnectionMode;
@@ -315,36 +310,27 @@ export class IntegrationProvider extends RuntimeProvider {
 }
 
 /**
- * Backwards-compatible alias for the integration provider class.
+ * Plugin provider implementation consumed by the Gestalt runtime.
  */
-export const Plugin = IntegrationProvider;
+export const Plugin = PluginProvider;
 
 /**
- * Creates an integration provider.
- */
-export function defineIntegrationProvider(
-  options: PluginDefinitionOptions,
-): IntegrationProvider {
-  return new IntegrationProvider(options);
-}
-
-/**
- * Backwards-compatible alias for {@link defineIntegrationProvider}.
+ * Creates a plugin provider.
  */
 export function definePlugin(
   options: PluginDefinitionOptions,
-): IntegrationProvider {
-  return new IntegrationProvider(options);
+): PluginProvider {
+  return new PluginProvider(options);
 }
 
 /**
- * Runtime type guard for integration providers loaded from user modules.
+ * Runtime type guard for plugin providers loaded from user modules.
  */
-export function isIntegrationProvider(
+export function isPluginProvider(
   value: unknown,
-): value is IntegrationProvider {
+): value is PluginProvider {
   return (
-    value instanceof IntegrationProvider ||
+    value instanceof PluginProvider ||
     (typeof value === "object" &&
       value !== null &&
       "kind" in value &&

--- a/sdk/typescript/src/provider-kind.ts
+++ b/sdk/typescript/src/provider-kind.ts
@@ -1,0 +1,101 @@
+import type { ProviderKind } from "./provider.ts";
+
+type ProviderKindDefinition = {
+  readonly tokens: readonly string[];
+  readonly formatToken: string;
+  readonly defaultExportNames: readonly string[];
+  readonly label: string;
+};
+
+const PROVIDER_KIND_DEFINITIONS = {
+  integration: {
+    tokens: ["plugin"],
+    formatToken: "plugin",
+    defaultExportNames: ["provider", "plugin"],
+    label: "plugin provider",
+  },
+  auth: {
+    tokens: ["auth"],
+    formatToken: "auth",
+    defaultExportNames: ["auth", "provider"],
+    label: "auth provider",
+  },
+  cache: {
+    tokens: ["cache"],
+    formatToken: "cache",
+    defaultExportNames: ["cache", "provider"],
+    label: "cache provider",
+  },
+  secrets: {
+    tokens: ["secrets"],
+    formatToken: "secrets",
+    defaultExportNames: ["secrets", "provider"],
+    label: "secrets provider",
+  },
+  s3: {
+    tokens: ["s3"],
+    formatToken: "s3",
+    defaultExportNames: ["s3", "provider"],
+    label: "s3 provider",
+  },
+  telemetry: {
+    tokens: ["telemetry"],
+    formatToken: "telemetry",
+    defaultExportNames: ["telemetry", "provider"],
+    label: "telemetry provider",
+  },
+} satisfies Record<ProviderKind, ProviderKindDefinition>;
+
+const EXTERNAL_PROVIDER_KIND_TOKEN_SET = new Set<string>(
+  Object.values(PROVIDER_KIND_DEFINITIONS).flatMap(
+    (definition) => definition.tokens,
+  ),
+);
+
+const EXTERNAL_PROVIDER_KIND_MAP = new Map<string, ProviderKind>(
+  Object.entries(PROVIDER_KIND_DEFINITIONS).flatMap(([kind, definition]) =>
+    definition.tokens.map(
+      (token) => [token, kind as ProviderKind] as const,
+    ),
+  ),
+);
+
+export function isExternalProviderKindToken(value: string): boolean {
+  return EXTERNAL_PROVIDER_KIND_TOKEN_SET.has(value.trim().toLowerCase());
+}
+
+export function parseExternalProviderKind(value: string): ProviderKind {
+  const normalized = value.trim().toLowerCase();
+  const kind = EXTERNAL_PROVIDER_KIND_MAP.get(normalized);
+  if (!kind) {
+    throw new Error(`unsupported provider kind ${JSON.stringify(value)}`);
+  }
+  return kind;
+}
+
+export function formatExternalProviderKind(kind: ProviderKind): string {
+  return PROVIDER_KIND_DEFINITIONS[kind].formatToken;
+}
+
+export function providerKindLabel(kind: ProviderKind): string {
+  return PROVIDER_KIND_DEFINITIONS[kind].label;
+}
+
+export function defaultProviderExportNames(
+  kind: ProviderKind,
+): readonly string[] {
+  return PROVIDER_KIND_DEFINITIONS[kind].defaultExportNames;
+}
+
+export function resolveDefaultProviderExport(
+  module: Record<string, unknown>,
+  kind: ProviderKind,
+): unknown {
+  for (const exportName of defaultProviderExportNames(kind)) {
+    const candidate = Reflect.get(module, exportName);
+    if (candidate !== undefined && candidate !== null) {
+      return candidate;
+    }
+  }
+  return Reflect.get(module, "default");
+}

--- a/sdk/typescript/src/runtime.ts
+++ b/sdk/typescript/src/runtime.ts
@@ -4,7 +4,12 @@ import { dirname, resolve } from "node:path";
 
 import { create } from "@bufbuild/protobuf";
 import { EmptySchema } from "@bufbuild/protobuf/wkt";
-import { Code, ConnectError, type ServiceImpl } from "@connectrpc/connect";
+import {
+  Code,
+  ConnectError,
+  type ConnectRouter,
+  type ServiceImpl,
+} from "@connectrpc/connect";
 import { connectNodeAdapter } from "@connectrpc/connect-node";
 
 import {
@@ -63,11 +68,15 @@ import { CacheProvider, isCacheProvider } from "./cache.ts";
 import { SecretsProvider, isSecretsProvider } from "./secrets.ts";
 import { catalogToYaml, type Catalog } from "./catalog.ts";
 import {
-  IntegrationProvider,
+  PluginProvider,
   connectionModeToProtoValue,
   connectionParamToProto,
-  isIntegrationProvider,
+  isPluginProvider,
 } from "./plugin.ts";
+import {
+  providerKindLabel,
+  resolveDefaultProviderExport,
+} from "./provider-kind.ts";
 import { type ProviderKind, slugName } from "./provider.ts";
 import { S3Provider, createS3Service, isS3Provider } from "./s3.ts";
 import {
@@ -112,11 +121,69 @@ export type RuntimeArgs = {
  * Provider implementations supported by the runtime host.
  */
 export type LoadedProvider =
-  | IntegrationProvider
+  | PluginProvider
   | AuthProvider
   | CacheProvider
   | SecretsProvider
   | S3Provider;
+
+type ProviderRuntimeEntry = {
+  isProvider: (value: unknown) => value is LoadedProvider;
+  protoKind: ProtoProviderKind;
+  registerService: (router: ConnectRouter, provider: LoadedProvider) => void;
+};
+
+const PROVIDER_RUNTIME_ENTRIES: Partial<
+  Record<ProviderKind, ProviderRuntimeEntry>
+> = {
+  integration: {
+    isProvider: isPluginProvider as (value: unknown) => value is LoadedProvider,
+    protoKind: ProtoProviderKind.INTEGRATION,
+    registerService(router, provider) {
+      router.service(
+        IntegrationProviderService,
+        createProviderService(provider as PluginProvider),
+      );
+    },
+  },
+  auth: {
+    isProvider: isAuthProvider as (value: unknown) => value is LoadedProvider,
+    protoKind: ProtoProviderKind.AUTH,
+    registerService(router, provider) {
+      router.service(
+        AuthProviderService,
+        createAuthService(provider as AuthProvider),
+      );
+    },
+  },
+  cache: {
+    isProvider: isCacheProvider as (value: unknown) => value is LoadedProvider,
+    protoKind: ProtoProviderKind.CACHE,
+    registerService(router, provider) {
+      router.service(
+        CacheService,
+        createCacheService(provider as CacheProvider),
+      );
+    },
+  },
+  secrets: {
+    isProvider: isSecretsProvider as (value: unknown) => value is LoadedProvider,
+    protoKind: ProtoProviderKind.SECRETS,
+    registerService(router, provider) {
+      router.service(
+        SecretsProviderService,
+        createSecretsService(provider as SecretsProvider),
+      );
+    },
+  },
+  s3: {
+    isProvider: isS3Provider as (value: unknown) => value is LoadedProvider,
+    protoKind: ProtoProviderKind.S3,
+    registerService(router, provider) {
+      router.service(S3Service, createS3Service(provider as S3Provider));
+    },
+  },
+};
 
 function assertProtocolVersion(protocolVersion: number): void {
   if (protocolVersion === CURRENT_PROTOCOL_VERSION) {
@@ -175,73 +242,27 @@ export async function loadProviderFromTarget(
   const target = parseProviderTarget(targetValue);
   const module = await import(resolveProviderImportUrl(root, target));
   const candidate =
-    (target.exportName ? module[target.exportName] : undefined) ??
-    defaultProviderExport(module, target.kind);
+    (target.exportName ? Reflect.get(module, target.exportName) : undefined) ??
+    resolveDefaultProviderExport(module, target.kind);
 
   const defaultName =
     slugName(config.name ?? "") ||
     slugName(dirname(resolve(root, target.modulePath)));
-  switch (target.kind) {
-    case "integration": {
-      if (!isIntegrationProvider(candidate)) {
-        throw new Error(
-          `${targetValue} did not resolve to a Gestalt integration provider`,
-        );
-      }
-      candidate.resolveName(defaultName);
-      return candidate;
-    }
-    case "auth": {
-      if (!isAuthProvider(candidate)) {
-        throw new Error(
-          `${targetValue} did not resolve to a Gestalt auth provider`,
-        );
-      }
-      candidate.resolveName(defaultName);
-      return candidate;
-    }
-    case "cache": {
-      if (!isCacheProvider(candidate)) {
-        throw new Error(
-          `${targetValue} did not resolve to a Gestalt cache provider`,
-        );
-      }
-      candidate.resolveName(defaultName);
-      return candidate;
-    }
-    case "secrets": {
-      if (!isSecretsProvider(candidate)) {
-        throw new Error(
-          `${targetValue} did not resolve to a Gestalt secrets provider`,
-        );
-      }
-      candidate.resolveName(defaultName);
-      return candidate;
-    }
-    case "s3": {
-      if (!isS3Provider(candidate)) {
-        throw new Error(`${targetValue} did not resolve to a Gestalt s3 provider`);
-      }
-      candidate.resolveName(defaultName);
-      return candidate;
-    }
-    default:
-      throw new Error(
-        `TypeScript SDK does not yet support provider kind ${JSON.stringify(target.kind)}`,
-      );
-  }
+  const provider = resolveLoadedProvider(candidate, target.kind, targetValue);
+  provider.resolveName(defaultName);
+  return provider;
 }
 
 /**
- * Loads an integration provider from a package root and optional target.
+ * Loads a plugin provider from a package root and optional target.
  */
 export async function loadPluginFromTarget(
   root: string,
   rawTarget?: string,
-): Promise<IntegrationProvider> {
+): Promise<PluginProvider> {
   const provider = await loadProviderFromTarget(root, rawTarget);
-  if (!isIntegrationProvider(provider)) {
-    throw new Error("target did not resolve to an integration provider");
+  if (!isPluginProvider(provider)) {
+    throw new Error("target did not resolve to a plugin provider");
   }
   return provider;
 }
@@ -264,9 +285,9 @@ export async function runLoadedProvider(
 
   const catalogPath = process.env[ENV_WRITE_CATALOG];
   if (catalogPath) {
-    if (!isIntegrationProvider(provider)) {
+    if (!isPluginProvider(provider)) {
       throw new Error(
-        "static catalog generation is only supported for integration providers",
+        "static catalog generation is only supported for plugin providers",
       );
     }
     writeFileSync(catalogPath, pluginCatalogYaml(provider), "utf8");
@@ -277,10 +298,10 @@ export async function runLoadedProvider(
 }
 
 /**
- * Runs an integration provider that has already been loaded into memory.
+ * Runs a plugin provider that has already been loaded into memory.
  */
 export async function runLoadedPlugin(
-  plugin: IntegrationProvider,
+  plugin: PluginProvider,
   options: {
     root?: string;
     pluginName?: string;
@@ -307,59 +328,13 @@ export async function runBundledProvider(
   kind: ProviderKind,
   providerName: string,
 ): Promise<void> {
-  let loaded: LoadedProvider;
-  switch (kind) {
-    case "integration":
-      if (!isIntegrationProvider(provider)) {
-        throw new Error(
-          "bundled target did not resolve to a Gestalt integration provider",
-        );
-      }
-      loaded = provider;
-      break;
-    case "auth":
-      if (!isAuthProvider(provider)) {
-        throw new Error(
-          "bundled target did not resolve to a Gestalt auth provider",
-        );
-      }
-      loaded = provider;
-      break;
-    case "cache":
-      if (!isCacheProvider(provider)) {
-        throw new Error(
-          "bundled target did not resolve to a Gestalt cache provider",
-        );
-      }
-      loaded = provider;
-      break;
-    case "secrets":
-      if (!isSecretsProvider(provider)) {
-        throw new Error(
-          "bundled target did not resolve to a Gestalt secrets provider",
-        );
-      }
-      loaded = provider;
-      break;
-    case "s3":
-      if (!isS3Provider(provider)) {
-        throw new Error("bundled target did not resolve to a Gestalt s3 provider");
-      }
-      loaded = provider;
-      break;
-    default:
-      throw new Error(
-        `TypeScript SDK does not yet support provider kind ${JSON.stringify(kind)}`,
-      );
-  }
-  loaded.name = slugName(providerName);
-  await runLoadedProvider(loaded, {
+  await runLoadedProvider(resolveLoadedProvider(provider, kind, "bundled target"), {
     providerName,
   });
 }
 
 /**
- * Runs a bundled integration provider export.
+ * Runs a bundled plugin provider export.
  */
 export async function runBundledPlugin(
   plugin: unknown,
@@ -386,20 +361,7 @@ export async function serve(provider: LoadedProvider): Promise<void> {
     connect: false,
     routes(router) {
       router.service(ProviderLifecycle, createRuntimeService(provider));
-      if (isIntegrationProvider(provider)) {
-        router.service(
-          IntegrationProviderService,
-          createProviderService(provider),
-        );
-      } else if (isAuthProvider(provider)) {
-        router.service(AuthProviderService, createAuthService(provider));
-      } else if (isCacheProvider(provider)) {
-        router.service(CacheService, createCacheService(provider));
-      } else if (isS3Provider(provider)) {
-        router.service(S3Service, createS3Service(provider));
-      } else if (isSecretsProvider(provider)) {
-        router.service(SecretsProviderService, createSecretsService(provider));
-      }
+      registerProviderService(router, provider);
     },
   });
 
@@ -461,7 +423,7 @@ export function createRuntimeService(
   return {
     async getProviderIdentity() {
       return create(ProviderIdentitySchema, {
-        kind: providerKindToProto(provider.kind),
+        kind: providerRuntimeEntry(provider.kind).protoKind,
         name: provider.name,
         displayName: provider.displayName,
         description: provider.description,
@@ -510,12 +472,12 @@ export function createRuntimeService(
 }
 
 /**
- * Adapts an integration provider to the shared protocol service implementation.
+ * Adapts a plugin provider to the shared protocol service implementation.
  *
  * @internal
  */
 export function createProviderService(
-  provider: IntegrationProvider,
+  provider: PluginProvider,
 ): Partial<ServiceImpl<typeof IntegrationProviderService>> {
   return {
     getMetadata() {
@@ -767,9 +729,9 @@ export function createSecretsService(
 }
 
 /**
- * Serializes an integration provider's static catalog as YAML.
+ * Serializes a plugin provider's static catalog as YAML.
  */
-export function pluginCatalogYaml(plugin: IntegrationProvider): string {
+export function pluginCatalogYaml(plugin: PluginProvider): string {
   return catalogToYaml(plugin.staticCatalog());
 }
 
@@ -805,40 +767,37 @@ function providerRequest(
   };
 }
 
-function providerKindToProto(kind: ProviderKind): ProtoProviderKind {
-  switch (kind) {
-    case "integration":
-      return ProtoProviderKind.INTEGRATION;
-    case "auth":
-      return ProtoProviderKind.AUTH;
-    case "cache":
-      return ProtoProviderKind.CACHE;
-    case "secrets":
-      return ProtoProviderKind.SECRETS;
-    case "s3":
-      return ProtoProviderKind.S3;
-    case "telemetry":
-      return ProtoProviderKind.TELEMETRY;
-    default:
-      return ProtoProviderKind.UNSPECIFIED;
+function providerRuntimeEntry(
+  kind: ProviderKind,
+): ProviderRuntimeEntry {
+  const entry = PROVIDER_RUNTIME_ENTRIES[kind];
+  if (!entry) {
+    throw new Error(
+      `TypeScript SDK does not yet support provider kind ${JSON.stringify(kind)}`,
+    );
   }
+  return entry;
 }
 
-function defaultProviderExport(module: Record<string, unknown>, kind: ProviderKind): unknown {
-  switch (kind) {
-    case "integration":
-      return module.provider ?? module.plugin ?? module.default;
-    case "auth":
-      return module.auth ?? module.provider ?? module.default;
-    case "cache":
-      return module.cache ?? module.provider ?? module.default;
-    case "secrets":
-      return module.secrets ?? module.provider ?? module.default;
-    case "s3":
-      return module.s3 ?? module.provider ?? module.default;
-    case "telemetry":
-      return module.telemetry ?? module.provider ?? module.default;
+function resolveLoadedProvider(
+  candidate: unknown,
+  kind: ProviderKind,
+  source: string,
+): LoadedProvider {
+  const entry = providerRuntimeEntry(kind);
+  if (!entry.isProvider(candidate)) {
+    throw new Error(
+      `${source} did not resolve to a Gestalt ${providerKindLabel(kind)}`,
+    );
   }
+  return candidate;
+}
+
+function registerProviderService(
+  router: ConnectRouter,
+  provider: LoadedProvider,
+): void {
+  providerRuntimeEntry(provider.kind).registerService(router, provider);
 }
 
 function objectFromUnknown(value: unknown): Record<string, unknown> {

--- a/sdk/typescript/src/target.ts
+++ b/sdk/typescript/src/target.ts
@@ -2,6 +2,11 @@ import { readFileSync } from "node:fs";
 import { isAbsolute, normalize, resolve } from "node:path";
 import { pathToFileURL } from "node:url";
 
+import {
+  formatExternalProviderKind,
+  isExternalProviderKindToken,
+  parseExternalProviderKind,
+} from "./provider-kind.ts";
 import { slugName, type ProviderKind } from "./provider.ts";
 
 /**
@@ -26,16 +31,6 @@ export type PackageConfig = {
   name?: string;
   providerTarget?: ProviderTarget;
 };
-
-const EXTERNAL_PROVIDER_KIND_TOKENS = new Set<string>([
-  "plugin",
-  "integration",
-  "auth",
-  "cache",
-  "secrets",
-  "s3",
-  "telemetry",
-]);
 
 /**
  * Parses a relative module target in the form `./file.ts#namedExport`.
@@ -81,7 +76,7 @@ export function parseProviderTarget(
     };
   }
 
-  const kind = parseProviderKind(target.kind ?? "integration");
+  const kind = parseExternalProviderKind(target.kind ?? "plugin");
   if (!target.target || typeof target.target !== "string") {
     throw new Error("gestalt.provider.target is required");
   }
@@ -92,7 +87,7 @@ export function parseProviderTarget(
 }
 
 /**
- * Backwards-compatible alias for integration-only package targets.
+ * Parses a plugin module target in the form `./file.ts#namedExport`.
  */
 export const parsePluginTarget = parseModuleTarget;
 
@@ -110,11 +105,6 @@ export function readPackageConfig(root: string): PackageConfig {
     providerTarget = parseProviderTarget(gestalt.provider);
   } else if (isProviderConfigObject(gestalt.provider)) {
     providerTarget = parseProviderTarget(gestalt.provider);
-  } else if (typeof gestalt.plugin === "string") {
-    providerTarget = {
-      kind: "integration",
-      ...parseModuleTarget(gestalt.plugin, "gestalt.plugin"),
-    };
   }
 
   const config: PackageConfig = {};
@@ -133,18 +123,18 @@ export function readPackageConfig(root: string): PackageConfig {
 export function readPackageProviderTarget(root: string): ProviderTarget {
   const config = readPackageConfig(root);
   if (!config.providerTarget) {
-    throw new Error("package.json gestalt.provider or gestalt.plugin is required");
+    throw new Error("package.json gestalt.provider is required");
   }
   return config.providerTarget;
 }
 
 /**
- * Reads the integration-provider target from `package.json`.
+ * Reads the plugin-provider target from `package.json`.
  */
 export function readPackagePluginTarget(root: string): string {
   const target = readPackageProviderTarget(root);
   if (target.kind !== "integration") {
-    throw new Error(`package.json provider kind ${JSON.stringify(target.kind)} is not an integration provider`);
+    throw new Error(`package.json provider kind ${JSON.stringify(target.kind)} is not a plugin provider`);
   }
   return formatModuleTarget(target);
 }
@@ -158,7 +148,7 @@ export function defaultProviderName(root: string): string {
 }
 
 /**
- * Backwards-compatible alias for integration providers.
+ * Computes a default plugin slug from the package name.
  */
 export const defaultPluginName = defaultProviderName;
 
@@ -174,7 +164,7 @@ export function resolveProviderModulePath(root: string, target: ProviderTarget |
 }
 
 /**
- * Backwards-compatible alias for integration providers.
+ * Resolves a plugin target to an absolute file path.
  */
 export const resolvePluginModulePath = resolveProviderModulePath;
 
@@ -186,7 +176,7 @@ export function resolveProviderImportUrl(root: string, target: ProviderTarget | 
 }
 
 /**
- * Backwards-compatible alias for integration providers.
+ * Resolves a plugin target to an importable file URL.
  */
 export const resolvePluginImportUrl = resolveProviderImportUrl;
 
@@ -205,32 +195,25 @@ export function formatModuleTarget(target: ModuleTarget): string {
 }
 
 function parseKindPrefixedTarget(target: string): ProviderTarget | undefined {
-  const match = target.match(/^(plugin|integration|auth|cache|secrets|s3|telemetry):(.*)$/);
-  if (!match) {
+  const separator = target.indexOf(":");
+  if (separator < 0) {
+    return undefined;
+  }
+  const kindToken = target.slice(0, separator);
+  if (!kindToken || !isExternalProviderKindToken(kindToken)) {
+    if (kindToken && !kindToken.startsWith(".") && !kindToken.startsWith("/")) {
+      parseExternalProviderKind(kindToken);
+    }
     return undefined;
   }
   return {
-    kind: parseProviderKind(match[1]!),
-    ...parseModuleTarget(match[2]!, "provider target"),
+    kind: parseExternalProviderKind(kindToken),
+    ...parseModuleTarget(target.slice(separator + 1), "provider target"),
   };
 }
 
-function parseProviderKind(value: string): ProviderKind {
-  const normalized = value.trim().toLowerCase();
-  if (!EXTERNAL_PROVIDER_KIND_TOKENS.has(normalized)) {
-    throw new Error(`unsupported provider kind ${JSON.stringify(value)}`);
-  }
-  if (normalized === "plugin") {
-    return "integration";
-  }
-  return normalized as ProviderKind;
-}
-
 function formatProviderKind(kind: ProviderKind): string {
-  if (kind === "integration") {
-    return "plugin";
-  }
-  return kind;
+  return formatExternalProviderKind(kind);
 }
 
 function isProviderConfigObject(value: unknown): value is { kind?: string; target?: string } {

--- a/sdk/typescript/tests/build.test.ts
+++ b/sdk/typescript/tests/build.test.ts
@@ -54,7 +54,7 @@ async function expectConnectCode(
 
 async function waitForSocket(path: string, stderrText: () => string): Promise<void> {
   try {
-    await waitForPath(path);
+    await waitForPath(path, 15_000);
   } catch (error) {
     throw new Error(`${String(error)}${stderrText() ? `\n${stderrText()}` : ""}`);
   }
@@ -142,197 +142,317 @@ test("buildProviderBinary compiles a runnable auth provider executable", async (
   }
 }, 15_000);
 
-test("buildProviderBinary compiles a runnable integration provider executable for plugin and integration targets", async () => {
+test("buildProviderBinary compiles a runnable plugin provider executable", async () => {
   const { goos, goarch, executableSuffix } = hostTarget();
   const tempDir = makeTempDir("gts-integration-");
 
   try {
-    for (const [label, target] of [
-      ["plugin", "plugin:./provider.ts#plugin"],
-      ["integration", "integration:./provider.ts#plugin"],
-    ] as const) {
-      const outputPath = join(tempDir, `fixture-${label}${executableSuffix}`);
-      const socketPath = join(tempDir, `${label}.sock`);
-      let child: ChildProcess | undefined;
+    const label = "plugin";
+    const outputPath = join(tempDir, `fixture-${label}${executableSuffix}`);
+    const socketPath = join(tempDir, `${label}.sock`);
+    let child: ChildProcess | undefined;
 
-      try {
-        buildProviderBinary({
-          root: fixturePath("basic-provider"),
-          target,
-          outputPath,
-          providerName: `fixture-${label}`,
-          goos,
-          goarch,
-        });
+    try {
+      buildProviderBinary({
+        root: fixturePath("basic-provider"),
+        target: "plugin:./provider.ts#plugin",
+        outputPath,
+        providerName: `fixture-${label}`,
+        goos,
+        goarch,
+      });
 
-        expect(existsSync(outputPath)).toBe(true);
+      expect(existsSync(outputPath)).toBe(true);
 
-        child = spawn(outputPath, [], {
-          env: {
-            ...process.env,
-            [ENV_PROVIDER_SOCKET]: socketPath,
-          },
-          stdio: ["ignore", "ignore", "pipe"],
-        });
-        const stderrText = captureChildStderr(child);
+      child = spawn(outputPath, [], {
+        env: {
+          ...process.env,
+          [ENV_PROVIDER_SOCKET]: socketPath,
+        },
+        stdio: ["ignore", "ignore", "pipe"],
+      });
+      const stderrText = captureChildStderr(child);
 
-        await waitForSocket(socketPath, stderrText);
+      await waitForSocket(socketPath, stderrText);
 
-        const runtime = createUnixGrpcClient(ProviderLifecycle, socketPath);
-        const provider = createUnixGrpcClient(
-          IntegrationProviderService,
-          socketPath,
-        );
+      const runtime = createUnixGrpcClient(ProviderLifecycle, socketPath);
+      const provider = createUnixGrpcClient(
+        IntegrationProviderService,
+        socketPath,
+      );
 
-        const identity = await runtime.getProviderIdentity(create(EmptySchema, {}));
-        expect(identity.kind).toBe(ProtoProviderKind.INTEGRATION);
-        expect(identity.name).toBe(`fixture-${label}`);
-        expect(identity.minProtocolVersion).toBe(CURRENT_PROTOCOL_VERSION);
-        expect(identity.maxProtocolVersion).toBe(CURRENT_PROTOCOL_VERSION);
+      const identity = await runtime.getProviderIdentity(create(EmptySchema, {}));
+      expect(identity.kind).toBe(ProtoProviderKind.INTEGRATION);
+      expect(identity.name).toBe(`fixture-${label}`);
+      expect(identity.minProtocolVersion).toBe(CURRENT_PROTOCOL_VERSION);
+      expect(identity.maxProtocolVersion).toBe(CURRENT_PROTOCOL_VERSION);
 
-        const metadata = await provider.getMetadata(create(EmptySchema, {}));
-        expect(metadata.name).toBe(`fixture-${label}`);
-        expect(metadata.supportsSessionCatalog).toBe(true);
-        expect(metadata.minProtocolVersion).toBe(CURRENT_PROTOCOL_VERSION);
-        expect(metadata.maxProtocolVersion).toBe(CURRENT_PROTOCOL_VERSION);
-        expect(
-          metadata.staticCatalog?.operations?.some((operation) => operation.id === "hello"),
-        ).toBe(true);
-        expect(
-          metadata.staticCatalog?.operations?.some((operation) => operation.id === "count"),
-        ).toBe(true);
+      const metadata = await provider.getMetadata(create(EmptySchema, {}));
+      expect(metadata.name).toBe(`fixture-${label}`);
+      expect(metadata.supportsSessionCatalog).toBe(true);
+      expect(metadata.minProtocolVersion).toBe(CURRENT_PROTOCOL_VERSION);
+      expect(metadata.maxProtocolVersion).toBe(CURRENT_PROTOCOL_VERSION);
+      expect(
+        metadata.staticCatalog?.operations?.some((operation) => operation.id === "hello"),
+      ).toBe(true);
+      expect(
+        metadata.staticCatalog?.operations?.some((operation) => operation.id === "count"),
+      ).toBe(true);
 
-        await expectConnectCode(
-          provider.startProvider(
-            create(StartProviderRequestSchema, {
-              name: `fixture-${label}`,
-              config: {
-                region: "use1",
-              },
-              protocolVersion: CURRENT_PROTOCOL_VERSION + 1,
-            }),
-          ),
-          Code.FailedPrecondition,
-        );
-
-        const started = await provider.startProvider(
+      await expectConnectCode(
+        provider.startProvider(
           create(StartProviderRequestSchema, {
             name: `fixture-${label}`,
             config: {
               region: "use1",
             },
-            protocolVersion: CURRENT_PROTOCOL_VERSION,
+            protocolVersion: CURRENT_PROTOCOL_VERSION + 1,
           }),
-        );
-        expect(started.protocolVersion).toBe(CURRENT_PROTOCOL_VERSION);
+        ),
+        Code.FailedPrecondition,
+      );
 
-        const result = await provider.execute(
-          create(ExecuteRequestSchema, {
-            operation: "hello",
-            params: {
-              name: "Ada",
-            },
-            token: "token-123",
-            connectionParams: {
-              region: "iad",
-            },
-            context: create(RequestContextSchema, {
-              subject: create(SubjectContextSchema, {
-                id: "user:user-123",
-                kind: "user",
-                authSource: "api_token",
-              }),
-              credential: create(CredentialContextSchema, {
-                mode: "identity",
-                subjectId: "identity:__identity__",
-              }),
-              access: create(AccessContextSchema, {
-                policy: "sample_policy",
-                role: "admin",
-              }),
+      const started = await provider.startProvider(
+        create(StartProviderRequestSchema, {
+          name: `fixture-${label}`,
+          config: {
+            region: "use1",
+          },
+          protocolVersion: CURRENT_PROTOCOL_VERSION,
+        }),
+      );
+      expect(started.protocolVersion).toBe(CURRENT_PROTOCOL_VERSION);
+
+      const result = await provider.execute(
+        create(ExecuteRequestSchema, {
+          operation: "hello",
+          params: {
+            name: "Ada",
+          },
+          token: "token-123",
+          connectionParams: {
+            region: "iad",
+          },
+          context: create(RequestContextSchema, {
+            subject: create(SubjectContextSchema, {
+              id: "user:user-123",
+              kind: "user",
+              authSource: "api_token",
+            }),
+            credential: create(CredentialContextSchema, {
+              mode: "identity",
+              subjectId: "identity:__identity__",
+            }),
+            access: create(AccessContextSchema, {
+              policy: "sample_policy",
+              role: "admin",
             }),
           }),
-        );
-        expect(JSON.parse(result.body)).toEqual({
-          message: "Hello, Ada.",
-          configuredName: `fixture-${label}`,
-          region: "iad",
-          configuredRegion: "use1",
-          subjectId: "user:user-123",
-          credentialMode: "identity",
-          accessPolicy: "sample_policy",
-          accessRole: "admin",
-        });
+        }),
+      );
+      expect(JSON.parse(result.body)).toEqual({
+        message: "Hello, Ada.",
+        configuredName: `fixture-${label}`,
+        region: "iad",
+        configuredRegion: "use1",
+        subjectId: "user:user-123",
+        credentialMode: "identity",
+        accessPolicy: "sample_policy",
+        accessRole: "admin",
+      });
 
-        const countResult = await provider.execute(
-          create(ExecuteRequestSchema, {
-            operation: "count",
-            params: {
-              count: 7,
-            },
-          }),
-        );
-        expect(countResult.status).toBe(200);
-        expect(JSON.parse(countResult.body)).toEqual({
-          count: 7,
-        });
+      const countResult = await provider.execute(
+        create(ExecuteRequestSchema, {
+          operation: "count",
+          params: {
+            count: 7,
+          },
+        }),
+      );
+      expect(countResult.status).toBe(200);
+      expect(JSON.parse(countResult.body)).toEqual({
+        count: 7,
+      });
 
-        const decodeError = await provider.execute(
-          create(ExecuteRequestSchema, {
-            operation: "count",
-            params: {
-              count: "oops",
-            },
-          }),
-        );
-        expect(decodeError.status).toBe(400);
-        expect(JSON.parse(decodeError.body)).toEqual({
-          error: "$.count must be an integer",
-        });
+      const decodeError = await provider.execute(
+        create(ExecuteRequestSchema, {
+          operation: "count",
+          params: {
+            count: "oops",
+          },
+        }),
+      );
+      expect(decodeError.status).toBe(400);
+      expect(JSON.parse(decodeError.body)).toEqual({
+        error: "$.count must be an integer",
+      });
 
-        const sessionCatalog = await provider.getSessionCatalog(
-          create(GetSessionCatalogRequestSchema, {
-            token: "token-123",
-            connectionParams: {
-              scope: label,
-            },
-            context: create(RequestContextSchema, {
-              subject: create(SubjectContextSchema, {
-                id: "user:user-123",
-                kind: "user",
-              }),
-              credential: create(CredentialContextSchema, {
-                mode: "identity",
-              }),
-              access: create(AccessContextSchema, {
-                policy: "sample_policy",
-                role: "viewer",
-              }),
+      const sessionCatalog = await provider.getSessionCatalog(
+        create(GetSessionCatalogRequestSchema, {
+          token: "token-123",
+          connectionParams: {
+            scope: label,
+          },
+          context: create(RequestContextSchema, {
+            subject: create(SubjectContextSchema, {
+              id: "user:user-123",
+              kind: "user",
+            }),
+            credential: create(CredentialContextSchema, {
+              mode: "identity",
+            }),
+            access: create(AccessContextSchema, {
+              policy: "sample_policy",
+              role: "viewer",
             }),
           }),
-        );
-        expect(sessionCatalog.catalog?.name).toBe("fixture-session");
-        expect(sessionCatalog.catalog?.operations).toHaveLength(1);
-        const sessionOperation = sessionCatalog.catalog?.operations?.[0];
-        expect(sessionOperation).toBeDefined();
-        expect(sessionOperation?.id).toBe("session-hello");
-        expect(sessionOperation?.allowedRoles).toEqual([
-          "viewer",
-          "admin",
-        ]);
-        expect(sessionOperation?.title).toBe(
-          `Session Hello ${label} user:user-123 identity viewer`,
-        );
-      } finally {
-        if (child) {
-          await stopProcess(child);
-        }
+        }),
+      );
+      expect(sessionCatalog.catalog?.name).toBe("fixture-session");
+      expect(sessionCatalog.catalog?.operations).toHaveLength(1);
+      const sessionOperation = sessionCatalog.catalog?.operations?.[0];
+      expect(sessionOperation).toBeDefined();
+      expect(sessionOperation?.id).toBe("session-hello");
+      expect(sessionOperation?.allowedRoles).toEqual([
+        "viewer",
+        "admin",
+      ]);
+      expect(sessionOperation?.title).toBe(
+        `Session Hello ${label} user:user-123 identity viewer`,
+      );
+    } finally {
+      if (child) {
+        await stopProcess(child);
       }
     }
   } finally {
     removeTempDir(tempDir);
   }
 }, 30_000);
+
+test("buildProviderBinary compiles a plugin provider executable without an explicit export name", async () => {
+  const { goos, goarch, executableSuffix } = hostTarget();
+  const tempDir = makeTempDir("gts-integration-fallback-");
+  const outputPath = join(tempDir, `fixture-fallback${executableSuffix}`);
+  const socketPath = join(tempDir, "provider.sock");
+  let child: ChildProcess | undefined;
+
+  try {
+    buildProviderBinary({
+      root: fixturePath("basic-provider-default-export"),
+      target: "plugin:./provider.ts",
+      outputPath,
+      providerName: "fixture-fallback",
+      goos,
+      goarch,
+    });
+
+    expect(existsSync(outputPath)).toBe(true);
+
+    child = spawn(outputPath, [], {
+      env: {
+        ...process.env,
+        [ENV_PROVIDER_SOCKET]: socketPath,
+      },
+      stdio: ["ignore", "ignore", "pipe"],
+    });
+    const stderrText = captureChildStderr(child);
+
+    await waitForSocket(socketPath, stderrText);
+
+    const runtime = createUnixGrpcClient(ProviderLifecycle, socketPath);
+    const provider = createUnixGrpcClient(
+      IntegrationProviderService,
+      socketPath,
+    );
+
+    const identity = await runtime.getProviderIdentity(create(EmptySchema, {}));
+    expect(identity.kind).toBe(ProtoProviderKind.INTEGRATION);
+    expect(identity.name).toBe("fixture-fallback");
+
+    const metadata = await provider.getMetadata(create(EmptySchema, {}));
+    expect(metadata.name).toBe("fixture-fallback");
+    expect(
+      metadata.staticCatalog?.operations?.map((operation) => operation.id),
+    ).toEqual(["hello"]);
+
+    const result = await provider.execute(
+      create(ExecuteRequestSchema, {
+        operation: "hello",
+        params: {
+          name: "Ada",
+        },
+      }),
+    );
+    expect(JSON.parse(result.body)).toEqual({
+      message: "Hello, Ada.",
+    });
+  } finally {
+    if (child) {
+      await stopProcess(child);
+    }
+    removeTempDir(tempDir);
+  }
+}, 15_000);
+
+test("buildProviderBinary falls through null exports to the next plugin candidate", async () => {
+  const { goos, goarch, executableSuffix } = hostTarget();
+  const tempDir = makeTempDir("gts-integration-null-export-");
+  const outputPath = join(tempDir, `fixture-null-export${executableSuffix}`);
+  const socketPath = join(tempDir, "provider.sock");
+  let child: ChildProcess | undefined;
+
+  try {
+    buildProviderBinary({
+      root: fixturePath("basic-provider-null-export"),
+      target: "plugin:./provider.ts",
+      outputPath,
+      providerName: "fixture-null-export",
+      goos,
+      goarch,
+    });
+
+    expect(existsSync(outputPath)).toBe(true);
+
+    child = spawn(outputPath, [], {
+      env: {
+        ...process.env,
+        [ENV_PROVIDER_SOCKET]: socketPath,
+      },
+      stdio: ["ignore", "ignore", "pipe"],
+    });
+    const stderrText = captureChildStderr(child);
+
+    await waitForSocket(socketPath, stderrText);
+
+    const runtime = createUnixGrpcClient(ProviderLifecycle, socketPath);
+    const provider = createUnixGrpcClient(
+      IntegrationProviderService,
+      socketPath,
+    );
+
+    const identity = await runtime.getProviderIdentity(create(EmptySchema, {}));
+    expect(identity.kind).toBe(ProtoProviderKind.INTEGRATION);
+    expect(identity.name).toBe("fixture-null-export");
+
+    const result = await provider.execute(
+      create(ExecuteRequestSchema, {
+        operation: "hello",
+        params: {
+          name: "Ada",
+        },
+      }),
+    );
+    expect(JSON.parse(result.body)).toEqual({
+      message: "Hello, Ada.",
+    });
+  } finally {
+    if (child) {
+      await stopProcess(child);
+    }
+    removeTempDir(tempDir);
+  }
+}, 15_000);
 
 test("buildProviderBinary compiles a runnable cache provider executable", async () => {
   const { goos, goarch, executableSuffix } = hostTarget();
@@ -617,4 +737,4 @@ test("buildProviderBinary compiles a runnable s3 provider executable", async () 
     }
     removeTempDir(tempDir);
   }
-});
+}, 15_000);

--- a/sdk/typescript/tests/fixtures/basic-provider-default-export/package.json
+++ b/sdk/typescript/tests/fixtures/basic-provider-default-export/package.json
@@ -1,0 +1,4 @@
+{
+  "name": "@fixtures/basic-provider-default-export",
+  "type": "module"
+}

--- a/sdk/typescript/tests/fixtures/basic-provider-default-export/provider.ts
+++ b/sdk/typescript/tests/fixtures/basic-provider-default-export/provider.ts
@@ -1,0 +1,26 @@
+import { definePlugin, ok, operation, s } from "../../../src/index.ts";
+
+const provider = definePlugin({
+  displayName: "Fixture Provider Default Export",
+  operations: [
+    operation({
+      id: "hello",
+      method: "POST",
+      input: s.object({
+        name: s.string({
+          default: "World",
+        }),
+      }),
+      output: s.object({
+        message: s.string(),
+      }),
+      handler(input) {
+        return ok({
+          message: `Hello, ${input.name}.`,
+        });
+      },
+    }),
+  ],
+});
+
+export default provider;

--- a/sdk/typescript/tests/fixtures/basic-provider-null-export/package.json
+++ b/sdk/typescript/tests/fixtures/basic-provider-null-export/package.json
@@ -1,10 +1,10 @@
 {
-  "name": "@fixtures/basic-provider",
+  "name": "@fixtures/basic-provider-null-export",
   "type": "module",
   "gestalt": {
     "provider": {
       "kind": "plugin",
-      "target": "./provider.ts#plugin"
+      "target": "./provider.ts"
     }
   }
 }

--- a/sdk/typescript/tests/fixtures/basic-provider-null-export/provider.ts
+++ b/sdk/typescript/tests/fixtures/basic-provider-null-export/provider.ts
@@ -1,0 +1,26 @@
+import { definePlugin, ok, operation, s } from "../../../src/index.ts";
+
+export const provider = null;
+
+export const plugin = definePlugin({
+  displayName: "Fixture Provider Null Export",
+  operations: [
+    operation({
+      id: "hello",
+      method: "POST",
+      input: s.object({
+        name: s.string({
+          default: "World",
+        }),
+      }),
+      output: s.object({
+        message: s.string(),
+      }),
+      handler(input) {
+        return ok({
+          message: `Hello, ${input.name}.`,
+        });
+      },
+    }),
+  ],
+});

--- a/sdk/typescript/tests/runtime.test.ts
+++ b/sdk/typescript/tests/runtime.test.ts
@@ -115,6 +115,15 @@ test("loadProviderFromTarget resolves a secrets provider from package metadata",
   expect(provider.displayName).toBe("Fixture Secrets");
 });
 
+test("loadPluginFromTarget falls through null exports to the next plugin candidate", async () => {
+  const plugin = await loadPluginFromTarget(
+    fixturePath("basic-provider-null-export"),
+  );
+  expect(plugin.kind).toBe("integration");
+  expect(plugin.name).toBe("basic-provider-null-export");
+  expect(plugin.displayName).toBe("Fixture Provider Null Export");
+});
+
 test("runtime serves a secrets provider over unix gRPC", async () => {
   const runtimeEntry = join(import.meta.dir, "..", "src", "runtime.ts");
   const root = fixturePath("secrets-provider");

--- a/sdk/typescript/tests/target.test.ts
+++ b/sdk/typescript/tests/target.test.ts
@@ -40,7 +40,7 @@ test("provider target parsing supports plugin defaults and kind prefixes", () =>
     modulePath: "./provider.ts",
     exportName: "plugin",
   });
-  expect(parseProviderTarget("integration:./provider.ts#plugin")).toEqual({
+  expect(parseProviderTarget({ target: "./provider.ts#plugin" })).toEqual({
     kind: "integration",
     modulePath: "./provider.ts",
     exportName: "plugin",
@@ -55,9 +55,12 @@ test("provider target parsing supports plugin defaults and kind prefixes", () =>
     modulePath: "./cache.ts",
     exportName: "provider",
   });
+  expect(() => parseProviderTarget("integration:./provider.ts#plugin")).toThrow(
+    'unsupported provider kind "integration"',
+  );
 });
 
-test("package config reads legacy plugin targets and provider targets", () => {
+test("package config reads provider targets", () => {
   const pluginRoot = fixturePath("basic-provider");
   expect(readPackageConfig(pluginRoot)).toEqual({
     name: "@fixtures/basic-provider",


### PR DESCRIPTION
## Summary

This PR removes the TypeScript SDK's public `integration` compatibility aliases and makes `plugin` the only public executable-provider spelling.

It also aligns TypeScript SDK parsing, Go host-side detection, docs, and tests around the same package metadata:

```json
{
  "gestalt": {
    "provider": {
      "kind": "plugin",
      "target": "./provider.ts#plugin"
    }
  }
}
```

Accepted string form remains:

```json
{
  "gestalt": {
    "provider": "plugin:./provider.ts#plugin"
  }
}
```

## Go Interface

No public Go API changed.

Go host-side detection now normalizes the plugin target consistently and rejects stale `integration:` config:

```go
target, err := providerpkg.DetectTypeScriptProviderTarget(root)
// returns: "plugin:./provider.ts#plugin"
```

## YAML Interface

```yaml
source: plugin:./provider.ts#plugin
config:
  region: use1
```

## TypeScript Example

```ts
import { definePlugin, ok, operation } from "@valon-technologies/gestalt";

export const plugin = definePlugin({
  operations: [
    operation({
      id: "ping",
      handler: async () => ok({ ok: true }),
    }),
  ],
});
```

## What Changed

- removed public alias support for `integration:` targets and `gestalt.plugin`
- removed `defineIntegrationProvider`, `IntegrationProviderOptions`, and `isIntegrationProvider`
- kept `plugin` as the only public executable-provider token
- preserved object-form `gestalt.provider` without an explicit `kind` by defaulting it to `plugin`
- made Bun-side parsing and Go host-side detection reject stale `integration:` config consistently
- collapsed duplicated packaged plugin/integration build coverage into plugin-only coverage
- kept packaged fallback-export coverage for `plugin:./provider.ts`

## Verification

- `bun run check` in `sdk/typescript`
- `go test ./internal/providerpkg` in `gestaltd`
