### PR TITLE
config: share config secret-ref traversal

### DIFF
--- a/gestaltd/internal/bootstrap/bootstrap_test.go
+++ b/gestaltd/internal/bootstrap/bootstrap_test.go
@@ -880,6 +880,39 @@ func TestBootstrapSecretResolution(t *testing.T) {
 		}
 	})
 
+	t.Run("ignores secret refs inside secrets provider config", func(t *testing.T) {
+		t.Parallel()
+
+		factories := validFactories()
+		factories.Secrets["test-secrets"] = func(yaml.Node) (core.SecretManager, error) {
+			return &coretesting.StubSecretManager{
+				Secrets: map[string]string{"enc-key": "resolved-passphrase"},
+			}, nil
+		}
+
+		cfg := validConfig()
+		cfg.Providers.Secrets["default"] = &config.ProviderEntry{
+			Source: config.ProviderSource{Builtin: "test-secrets"},
+			Config: yaml.Node{
+				Kind: yaml.MappingNode,
+				Content: []*yaml.Node{
+					{Kind: yaml.ScalarNode, Value: "prefix", Tag: "!!str"},
+					{Kind: yaml.ScalarNode, Value: transportSecretRef("ignored-provider-secret"), Tag: "!!str"},
+				},
+			},
+		}
+		cfg.Server.EncryptionKey = config.EncodeSecretRefTransport(config.SecretRef{
+			Provider: "default",
+			Name:     "enc-key",
+		})
+
+		result, err := bootstrap.Bootstrap(ctx, cfg, factories)
+		if err != nil {
+			t.Fatalf("Bootstrap: %v", err)
+		}
+		<-result.ProvidersReady
+	})
+
 	t.Run("requires configured provider for programmatic config refs", func(t *testing.T) {
 		t.Parallel()
 

--- a/gestaltd/internal/bootstrap/secret_resolution.go
+++ b/gestaltd/internal/bootstrap/secret_resolution.go
@@ -3,11 +3,9 @@ package bootstrap
 import (
 	"errors"
 	"fmt"
-	"reflect"
 
 	"github.com/valon-technologies/gestalt/server/core"
 	"github.com/valon-technologies/gestalt/server/internal/config"
-	"gopkg.in/yaml.v3"
 )
 
 // resolveSecretRefs walks the config struct and replaces any string value
@@ -44,205 +42,12 @@ func resolveSecretRefs(cfg *config.Config, resolve func(config.SecretRef) (strin
 		return resolved, nil
 	}
 
-	if err := resolveStringFields(&cfg.Server, resolveValue); err != nil {
+	if err := config.TransformConfigStringFields(cfg, resolveValue); err != nil {
 		return err
-	}
-	if err := resolveStringFields(&cfg.Authorization, resolveValue); err != nil {
-		return err
-	}
-	for name, entry := range cfg.Plugins {
-		if entry == nil {
-			continue
-		}
-		if err := resolveStringFields(entry, resolveValue); err != nil {
-			return err
-		}
-		for _, conn := range entry.Connections {
-			if conn != nil {
-				if err := resolveStringFields(conn, resolveValue); err != nil {
-					return err
-				}
-			}
-		}
-		cfg.Plugins[name] = entry
-	}
-	for _, entries := range []map[string]*config.ProviderEntry{
-		cfg.Providers.Auth,
-		cfg.Providers.Telemetry,
-		cfg.Providers.Audit,
-		cfg.Providers.Cache,
-		cfg.Providers.S3,
-	} {
-		for _, entry := range entries {
-			if entry == nil {
-				continue
-			}
-			if err := resolveStringFields(entry, resolveValue); err != nil {
-				return err
-			}
-		}
-	}
-	for name, entry := range cfg.Providers.UI {
-		if entry == nil {
-			continue
-		}
-		if err := resolveStringFields(entry, resolveValue); err != nil {
-			return err
-		}
-		cfg.Providers.UI[name] = entry
-	}
-	// Resolve secrets provider struct fields (Source, Env, AllowedHosts, etc.)
-	// but skip their Config nodes to avoid self-referential resolution.
-	for name, entry := range cfg.Providers.Secrets {
-		if entry == nil {
-			continue
-		}
-		savedConfig := entry.Config
-		entry.Config = yaml.Node{}
-		if err := resolveStringFields(entry, resolveValue); err != nil {
-			entry.Config = savedConfig
-			return err
-		}
-		entry.Config = savedConfig
-		cfg.Providers.Secrets[name] = entry
-	}
-
-	for name, ds := range cfg.Providers.IndexedDB {
-		if ds == nil {
-			continue
-		}
-		if err := resolveStringFields(ds, resolveValue); err != nil {
-			return err
-		}
-		cfg.Providers.IndexedDB[name] = ds
 	}
 	if err := config.NormalizeCompatibility(cfg); err != nil {
 		return err
 	}
 
-	return nil
-}
-
-func resolveStringFields(ptr any, resolve func(string) (string, error)) error {
-	v := reflect.ValueOf(ptr).Elem()
-	t := v.Type()
-	for i := 0; i < t.NumField(); i++ {
-		field := v.Field(i)
-		switch field.Kind() {
-		case reflect.String:
-			if !field.CanSet() {
-				continue
-			}
-			resolved, err := resolve(field.String())
-			if err != nil {
-				return err
-			}
-			field.SetString(resolved)
-		case reflect.Struct:
-			if field.CanSet() {
-				if field.Type() == config.YAMLNodeType {
-					nodePtr := field.Addr().Interface().(*yaml.Node)
-					if err := resolveYAMLNode(nodePtr, resolve); err != nil {
-						return err
-					}
-				} else {
-					if err := resolveStringFields(field.Addr().Interface(), resolve); err != nil {
-						return err
-					}
-				}
-			}
-		case reflect.Pointer:
-			if !field.IsNil() && field.Elem().Kind() == reflect.Struct {
-				if err := resolveStringFields(field.Interface(), resolve); err != nil {
-					return err
-				}
-			}
-		case reflect.Map:
-			if field.Type().Key().Kind() != reflect.String {
-				continue
-			}
-			switch field.Type().Elem().Kind() {
-			case reflect.String:
-				for _, k := range field.MapKeys() {
-					resolved, err := resolve(field.MapIndex(k).String())
-					if err != nil {
-						return err
-					}
-					field.SetMapIndex(k, reflect.ValueOf(resolved))
-				}
-			case reflect.Struct:
-				for _, k := range field.MapKeys() {
-					current := field.MapIndex(k)
-					next := reflect.New(field.Type().Elem())
-					next.Elem().Set(current)
-					if err := resolveStringFields(next.Interface(), resolve); err != nil {
-						return err
-					}
-					field.SetMapIndex(k, next.Elem())
-				}
-			case reflect.Pointer:
-				if field.Type().Elem().Elem().Kind() != reflect.Struct {
-					continue
-				}
-				for _, k := range field.MapKeys() {
-					current := field.MapIndex(k)
-					if current.IsNil() {
-						continue
-					}
-					if err := resolveStringFields(current.Interface(), resolve); err != nil {
-						return err
-					}
-				}
-			}
-		case reflect.Slice:
-			switch field.Type().Elem().Kind() {
-			case reflect.String:
-				for j := 0; j < field.Len(); j++ {
-					elem := field.Index(j)
-					resolved, err := resolve(elem.String())
-					if err != nil {
-						return err
-					}
-					elem.SetString(resolved)
-				}
-			case reflect.Struct:
-				for j := 0; j < field.Len(); j++ {
-					if err := resolveStringFields(field.Index(j).Addr().Interface(), resolve); err != nil {
-						return err
-					}
-				}
-			}
-		}
-	}
-	return nil
-}
-
-func resolveYAMLNode(node *yaml.Node, resolve func(string) (string, error)) error {
-	if node == nil {
-		return nil
-	}
-	switch node.Kind {
-	case yaml.ScalarNode:
-		if node.Tag == "!!str" || node.Tag == "" {
-			resolved, err := resolve(node.Value)
-			if err != nil {
-				return err
-			}
-			node.Value = resolved
-		}
-	case yaml.MappingNode:
-		// Content is [key, value, key, value, ...]; only resolve values.
-		for i := 1; i < len(node.Content); i += 2 {
-			if err := resolveYAMLNode(node.Content[i], resolve); err != nil {
-				return err
-			}
-		}
-	case yaml.SequenceNode, yaml.DocumentNode:
-		for _, child := range node.Content {
-			if err := resolveYAMLNode(child, resolve); err != nil {
-				return err
-			}
-		}
-	}
 	return nil
 }

--- a/gestaltd/internal/config/secret_refs.go
+++ b/gestaltd/internal/config/secret_refs.go
@@ -21,7 +21,7 @@ type SecretRef struct {
 	Name     string `json:"name"`
 }
 
-type SecretRefVisitor func(SecretRef) error
+type ConfigStringTransformer func(string) (string, error)
 
 func IsLegacySecretRefString(value string) bool {
 	return strings.HasPrefix(strings.TrimSpace(value), legacySecretRefPrefix)
@@ -204,24 +204,29 @@ func ReferencedConfigSecretProviders(cfg *Config) (map[string]struct{}, error) {
 	if cfg == nil {
 		return providers, nil
 	}
-	visit := func(ref SecretRef) error {
-		providers[ref.Provider] = struct{}{}
-		return nil
-	}
-	if err := visitConfigSecretRefs(cfg, visit); err != nil {
+	if err := TransformConfigStringFields(cfg, func(value string) (string, error) {
+		ref, ok, err := ParseSecretRefTransport(value)
+		if err != nil {
+			return "", err
+		}
+		if ok {
+			providers[ref.Provider] = struct{}{}
+		}
+		return value, nil
+	}); err != nil {
 		return nil, err
 	}
 	return providers, nil
 }
 
-func visitConfigSecretRefs(cfg *Config, visit SecretRefVisitor) error {
+func TransformConfigStringFields(cfg *Config, transform ConfigStringTransformer) error {
 	if cfg == nil {
 		return nil
 	}
-	if err := visitSecretRefsInStruct(&cfg.Server, visit); err != nil {
+	if err := transformConfigStringFieldsInStruct(&cfg.Server, transform); err != nil {
 		return err
 	}
-	if err := visitSecretRefsInStruct(&cfg.Authorization, visit); err != nil {
+	if err := transformConfigStringFieldsInStruct(&cfg.Authorization, transform); err != nil {
 		return err
 	}
 	for _, entries := range []map[string]*ProviderEntry{
@@ -236,7 +241,7 @@ func visitConfigSecretRefs(cfg *Config, visit SecretRefVisitor) error {
 			if entry == nil {
 				continue
 			}
-			if err := visitSecretRefsInStruct(entry, visit); err != nil {
+			if err := transformConfigStringFieldsInStruct(entry, transform); err != nil {
 				return err
 			}
 		}
@@ -245,18 +250,19 @@ func visitConfigSecretRefs(cfg *Config, visit SecretRefVisitor) error {
 		if entry == nil {
 			continue
 		}
-		if err := visitSecretRefsInStruct(entry, visit); err != nil {
+		if err := transformConfigStringFieldsInStruct(entry, transform); err != nil {
 			return err
 		}
 	}
-	for _, entry := range cfg.Providers.Secrets {
+	for name, entry := range cfg.Providers.Secrets {
 		if entry == nil {
 			continue
 		}
 		savedConfig := entry.Config
 		entry.Config = yaml.Node{}
-		err := visitSecretRefsInStruct(entry, visit)
+		err := transformConfigStringFieldsInStruct(entry, transform)
 		entry.Config = savedConfig
+		cfg.Providers.Secrets[name] = entry
 		if err != nil {
 			return err
 		}
@@ -265,12 +271,12 @@ func visitConfigSecretRefs(cfg *Config, visit SecretRefVisitor) error {
 		if entry == nil {
 			continue
 		}
-		if err := visitSecretRefsInStruct(entry, visit); err != nil {
+		if err := transformConfigStringFieldsInStruct(entry, transform); err != nil {
 			return err
 		}
 		for _, conn := range entry.Connections {
 			if conn != nil {
-				if err := visitSecretRefsInStruct(conn, visit); err != nil {
+				if err := transformConfigStringFieldsInStruct(conn, transform); err != nil {
 					return err
 				}
 			}
@@ -281,9 +287,7 @@ func visitConfigSecretRefs(cfg *Config, visit SecretRefVisitor) error {
 
 var yamlNodeType = reflect.TypeOf(yaml.Node{})
 
-var YAMLNodeType = yamlNodeType
-
-func visitSecretRefsInStruct(ptr any, visit SecretRefVisitor) error {
+func transformConfigStringFieldsInStruct(ptr any, transform ConfigStringTransformer) error {
 	v := reflect.ValueOf(ptr)
 	if !v.IsValid() || v.IsNil() {
 		return nil
@@ -294,23 +298,28 @@ func visitSecretRefsInStruct(ptr any, visit SecretRefVisitor) error {
 		field := v.Field(i)
 		switch field.Kind() {
 		case reflect.String:
-			if err := visitSecretRefString(field.String(), visit); err != nil {
+			if !field.CanSet() {
+				continue
+			}
+			next, err := transform(field.String())
+			if err != nil {
 				return err
 			}
+			field.SetString(next)
 		case reflect.Struct:
 			if field.Type() == yamlNodeType {
 				nodePtr := field.Addr().Interface().(*yaml.Node)
-				if err := visitSecretRefsInYAMLNode(nodePtr, visit); err != nil {
+				if err := transformConfigStringFieldsInYAMLNode(nodePtr, transform); err != nil {
 					return err
 				}
 			} else if field.CanAddr() {
-				if err := visitSecretRefsInStruct(field.Addr().Interface(), visit); err != nil {
+				if err := transformConfigStringFieldsInStruct(field.Addr().Interface(), transform); err != nil {
 					return err
 				}
 			}
 		case reflect.Pointer:
 			if !field.IsNil() && field.Elem().Kind() == reflect.Struct {
-				if err := visitSecretRefsInStruct(field.Interface(), visit); err != nil {
+				if err := transformConfigStringFieldsInStruct(field.Interface(), transform); err != nil {
 					return err
 				}
 			}
@@ -321,18 +330,21 @@ func visitSecretRefsInStruct(ptr any, visit SecretRefVisitor) error {
 			switch field.Type().Elem().Kind() {
 			case reflect.String:
 				for _, key := range field.MapKeys() {
-					if err := visitSecretRefString(field.MapIndex(key).String(), visit); err != nil {
+					next, err := transform(field.MapIndex(key).String())
+					if err != nil {
 						return err
 					}
+					field.SetMapIndex(key, reflect.ValueOf(next))
 				}
 			case reflect.Struct:
 				for _, key := range field.MapKeys() {
 					current := field.MapIndex(key)
 					next := reflect.New(field.Type().Elem())
 					next.Elem().Set(current)
-					if err := visitSecretRefsInStruct(next.Interface(), visit); err != nil {
+					if err := transformConfigStringFieldsInStruct(next.Interface(), transform); err != nil {
 						return err
 					}
+					field.SetMapIndex(key, next.Elem())
 				}
 			case reflect.Pointer:
 				if field.Type().Elem().Elem().Kind() != reflect.Struct {
@@ -343,7 +355,7 @@ func visitSecretRefsInStruct(ptr any, visit SecretRefVisitor) error {
 					if current.IsNil() {
 						continue
 					}
-					if err := visitSecretRefsInStruct(current.Interface(), visit); err != nil {
+					if err := transformConfigStringFieldsInStruct(current.Interface(), transform); err != nil {
 						return err
 					}
 				}
@@ -352,13 +364,15 @@ func visitSecretRefsInStruct(ptr any, visit SecretRefVisitor) error {
 			switch field.Type().Elem().Kind() {
 			case reflect.String:
 				for j := 0; j < field.Len(); j++ {
-					if err := visitSecretRefString(field.Index(j).String(), visit); err != nil {
+					next, err := transform(field.Index(j).String())
+					if err != nil {
 						return err
 					}
+					field.Index(j).SetString(next)
 				}
 			case reflect.Struct:
 				for j := 0; j < field.Len(); j++ {
-					if err := visitSecretRefsInStruct(field.Index(j).Addr().Interface(), visit); err != nil {
+					if err := transformConfigStringFieldsInStruct(field.Index(j).Addr().Interface(), transform); err != nil {
 						return err
 					}
 				}
@@ -368,37 +382,28 @@ func visitSecretRefsInStruct(ptr any, visit SecretRefVisitor) error {
 	return nil
 }
 
-func visitSecretRefString(value string, visit SecretRefVisitor) error {
-	ref, ok, err := ParseSecretRefTransport(value)
-	if err != nil {
-		return err
-	}
-	if !ok {
-		return nil
-	}
-	return visit(ref)
-}
-
-func visitSecretRefsInYAMLNode(node *yaml.Node, visit SecretRefVisitor) error {
+func transformConfigStringFieldsInYAMLNode(node *yaml.Node, transform ConfigStringTransformer) error {
 	if node == nil {
 		return nil
 	}
 	switch node.Kind {
 	case yaml.ScalarNode:
 		if node.Tag == "!!str" || node.Tag == "" {
-			if err := visitSecretRefString(node.Value, visit); err != nil {
+			next, err := transform(node.Value)
+			if err != nil {
 				return err
 			}
+			node.Value = next
 		}
 	case yaml.SequenceNode, yaml.DocumentNode:
 		for _, child := range node.Content {
-			if err := visitSecretRefsInYAMLNode(child, visit); err != nil {
+			if err := transformConfigStringFieldsInYAMLNode(child, transform); err != nil {
 				return err
 			}
 		}
 	case yaml.MappingNode:
 		for i := 1; i < len(node.Content); i += 2 {
-			if err := visitSecretRefsInYAMLNode(node.Content[i], visit); err != nil {
+			if err := transformConfigStringFieldsInYAMLNode(node.Content[i], transform); err != nil {
 				return err
 			}
 		}


### PR DESCRIPTION
## Summary
This PR removes the duplicate config secret-ref tree walk that existed in both `internal/config` and `internal/bootstrap`.

Changes in this slice:
- move config-string traversal ownership into `internal/config/secret_refs.go`
- make `ReferencedConfigSecretProviders(...)` use the shared traversal primitive instead of a separate reflection walk
- delete the private bootstrap secret-resolution walker and reuse the shared config traversal instead
- add one bootstrap-level regression test proving `providers.secrets.*.config` remains outside the shared walk

This is the first standalone slice of the canonical-config phase from the reduction plan. It reduces branching without changing provider runtime semantics.

## Go Interface Changes
- None

### Go Example
```go
// No Go interface changes in this PR.
```

## YAML Interface Changes
- None

### YAML Example
```yaml
# No YAML interface changes in this PR.
```

## Verification
- `cd gestaltd && go test ./internal/config ./internal/bootstrap ./internal/operator -count=1`
- `cd gestaltd && go test ./internal/... -run TestDoesNotExist -count=1`

## Notes
- No unit-test-only suite was added.
- The new test augments existing bootstrap coverage rather than introducing a new helper-focused package.