### PR TITLE
config: make canonicalization boundary explicit

### DIFF
--- a/gestaltd/internal/bootstrap/bootstrap.go
+++ b/gestaltd/internal/bootstrap/bootstrap.go
@@ -338,6 +338,9 @@ func (r *configSecretManagers) Close() error {
 }
 
 func resolveConfigSecrets(ctx context.Context, cfg *config.Config, factories *FactoryRegistry) error {
+	if err := config.CanonicalizeStructure(cfg); err != nil {
+		return err
+	}
 	resolver, err := newConfigSecretManagers(ctx, cfg, factories)
 	if err != nil {
 		return err
@@ -356,9 +359,6 @@ func ResolveConfigSecrets(ctx context.Context, cfg *config.Config, factories *Fa
 }
 
 func prepareCore(ctx context.Context, cfg *config.Config, factories *FactoryRegistry, requireEncryptionKey bool) (*preparedCore, error) {
-	if err := config.NormalizeCompatibility(cfg); err != nil {
-		return nil, err
-	}
 	if err := resolveConfigSecrets(ctx, cfg, factories); err != nil {
 		return nil, err
 	}

--- a/gestaltd/internal/bootstrap/secret_resolution.go
+++ b/gestaltd/internal/bootstrap/secret_resolution.go
@@ -45,7 +45,7 @@ func resolveSecretRefs(cfg *config.Config, resolve func(config.SecretRef) (strin
 	if err := config.TransformConfigStringFields(cfg, resolveValue); err != nil {
 		return err
 	}
-	if err := config.NormalizeCompatibility(cfg); err != nil {
+	if err := config.CanonicalizeStructure(cfg); err != nil {
 		return err
 	}
 

--- a/gestaltd/internal/config/config.go
+++ b/gestaltd/internal/config/config.go
@@ -848,13 +848,13 @@ func loadWithLookupPaths(paths []string, lookup func(string) (string, bool), all
 	}
 
 	applyDefaults(&cfg)
-	if err := NormalizeCompatibility(&cfg); err != nil {
+	if err := CanonicalizeStructure(&cfg); err != nil {
 		return nil, err
 	}
 	resolveBaseURL(&cfg)
 	resolveRelativePaths(primaryConfigPath(paths), &cfg)
 
-	if err := ValidateStructure(&cfg); err != nil {
+	if err := ValidateCanonicalStructure(&cfg); err != nil {
 		return nil, err
 	}
 

--- a/gestaltd/internal/config/config_validate.go
+++ b/gestaltd/internal/config/config_validate.go
@@ -22,6 +22,15 @@ import (
 // Called by Load (and therefore by init, validate, and serve). Does not require
 // runtime secrets like encryption_key.
 func ValidateStructure(cfg *Config) error {
+	if err := CanonicalizeStructure(cfg); err != nil {
+		return err
+	}
+	return ValidateCanonicalStructure(cfg)
+}
+
+// CanonicalizeStructure applies the config-shape normalization required before
+// structural validation or bootstrap consumers operate on the config.
+func CanonicalizeStructure(cfg *Config) error {
 	if err := NormalizeCompatibility(cfg); err != nil {
 		return err
 	}
@@ -29,6 +38,13 @@ func ValidateStructure(cfg *Config) error {
 	if err := normalizeMountedUIPaths(cfg, pluginOwnedUIRefs); err != nil {
 		return err
 	}
+	return nil
+}
+
+// ValidateCanonicalStructure checks config shape assuming canonicalization has
+// already run on the config.
+func ValidateCanonicalStructure(cfg *Config) error {
+	pluginOwnedUIRefs := pluginOwnedUIRefs(cfg)
 	if err := validateAuthorizationPolicies(cfg); err != nil {
 		return err
 	}

--- a/gestaltd/internal/operator/lifecycle.go
+++ b/gestaltd/internal/operator/lifecycle.go
@@ -82,6 +82,8 @@ func NewLifecycle(sourceResolver pluginsource.Resolver) *Lifecycle {
 	return &Lifecycle{sourceResolver: sourceResolver}
 }
 
+// WithConfigSecretResolver installs a resolver that may mutate cfg in place and
+// must leave it in canonicalized form for subsequent structural validation.
 func (l *Lifecycle) WithConfigSecretResolver(resolve func(context.Context, *config.Config) error) *Lifecycle {
 	l.configSecretResolver = resolve
 	return l
@@ -338,7 +340,7 @@ func (l *Lifecycle) resolveConfigSecrets(ctx context.Context, cfg *config.Config
 	if err := l.configSecretResolver(ctx, cfg); err != nil {
 		return fmt.Errorf("resolving config secrets: %w", err)
 	}
-	return config.ValidateStructure(cfg)
+	return config.ValidateCanonicalStructure(cfg)
 }
 
 func referencedConfigSecretsProviders(cfg *config.Config) (map[string]*config.ProviderEntry, error) {


### PR DESCRIPTION
## Summary
This PR makes the config canonicalization boundary explicit so already-canonical paths stop re-entering compatibility normalization during validation.

Changes in this slice:
- add `CanonicalizeStructure(...)` and `ValidateCanonicalStructure(...)` in `internal/config`
- make the load path canonicalize once, then validate the canonical shape
- make bootstrap config-secret resolution own canonicalization before provider discovery and after secret replacement
- make operator secret-resolution validation consume the canonical-only validator instead of re-entering `ValidateStructure(...)`

This is the next standalone slice in the canonical-config phase. It does not change runtime interfaces; it makes the normalization contract explicit and removes redundant canonicalization passes from already-canonical flows.

## Go Interface Changes
- None

### Go Example
```go
// No Go interface changes in this PR.
```

## YAML Interface Changes
- None

### YAML Example
```yaml
# No YAML interface changes in this PR.
```

## Verification
- `cd gestaltd && go test ./internal/config ./internal/bootstrap ./internal/operator -count=1`
- `cd gestaltd && go test ./internal/... -run TestDoesNotExist -count=1`

## Notes
- No unit tests were added.
- Existing load/bootstrap/operator suites cover the changed call paths.