### PR TITLE
core: collapse declarative providers onto integration.Base

### DIFF
--- a/gestaltd/core/integration/base.go
+++ b/gestaltd/core/integration/base.go
@@ -46,16 +46,18 @@ const (
 )
 
 type Base struct {
-	IntegrationName    string
-	IntegrationDisplay string
-	IntegrationDesc    string
-	ConnMode           core.ConnectionMode
-	Auth               AuthHandler
-	BaseURL            string
-	Headers            map[string]string
-	AuthStyle          AuthStyle
-	HTTPClient         *http.Client
-	Pagination         map[string]apiexec.PaginationConfig
+	IntegrationName             string
+	IntegrationDisplay          string
+	IntegrationDesc             string
+	ConnMode                    core.ConnectionMode
+	Auth                        AuthHandler
+	BaseURL                     string
+	Headers                     map[string]string
+	AuthStyle                   AuthStyle
+	HTTPClient                  *http.Client
+	Pagination                  map[string]apiexec.PaginationConfig
+	MethodDefaultParamLocations bool
+	NoRetry                     bool
 
 	TokenParser     func(token string) (authHeader string, extraHeaders map[string]string, err error)
 	CheckResponse   apiexec.ResponseChecker

--- a/gestaltd/core/integration/egress_adapter.go
+++ b/gestaltd/core/integration/egress_adapter.go
@@ -3,6 +3,7 @@ package integration
 import (
 	"context"
 	"fmt"
+	"net/http"
 	"net/url"
 	"strings"
 
@@ -23,7 +24,7 @@ func (b *Base) executeREST(ctx context.Context, operation string, catOp *catalog
 	if strings.TrimSpace(catOp.Path) == "" {
 		return nil, fmt.Errorf("operation %q is missing path", operation)
 	}
-	bodyParams, queryParams, headerParams := partitionParams(catOp, params)
+	bodyParams, queryParams, headerParams := partitionParams(catOp, params, b.MethodDefaultParamLocations)
 
 	baseURL, headers := b.resolvedURLAndHeaders(ctx)
 	for k, v := range headerParams {
@@ -52,6 +53,7 @@ func (b *Base) executeREST(ctx context.Context, operation string, catOp *catalog
 		AuthHeader:    credential.Authorization,
 		CustomHeaders: headers,
 		CheckResponse: b.CheckResponse,
+		NoRetry:       b.NoRetry,
 	}
 
 	if pgn, ok := b.Pagination[operation]; ok {
@@ -117,14 +119,23 @@ func findCatalogOp(cat *catalog.Catalog, id string) *catalog.CatalogOperation {
 	return nil
 }
 
-func partitionParams(catOp *catalog.CatalogOperation, params map[string]any) (body map[string]any, query map[string]any, headers map[string]string) {
+func partitionParams(catOp *catalog.CatalogOperation, params map[string]any, useMethodDefault bool) (body map[string]any, query map[string]any, headers map[string]string) {
+	defaultLocation := "body"
+	if useMethodDefault {
+		defaultLocation = defaultParamLocation(catOp)
+	}
 	if catOp == nil || len(catOp.Parameters) == 0 {
+		if defaultLocation == "query" {
+			return nil, params, nil
+		}
 		return params, nil, nil
 	}
 
+	declared := make(map[string]struct{}, len(catOp.Parameters))
 	locations := make(map[string]string, len(catOp.Parameters))
 	var wireNames map[string]string
 	for _, p := range catOp.Parameters {
+		declared[p.Name] = struct{}{}
 		if p.Location != "" {
 			locations[p.Name] = p.Location
 		}
@@ -135,10 +146,6 @@ func partitionParams(catOp *catalog.CatalogOperation, params map[string]any) (bo
 			wireNames[p.Name] = p.WireName
 		}
 	}
-	if len(locations) == 0 {
-		return params, nil, nil
-	}
-
 	body = make(map[string]any)
 	query = make(map[string]any)
 	headers = make(map[string]string)
@@ -155,8 +162,31 @@ func partitionParams(catOp *catalog.CatalogOperation, params map[string]any) (bo
 		case "path":
 			body[httpKey] = v
 		default:
+			if _, ok := declared[k]; ok {
+				if useMethodDefault {
+					continue
+				}
+				body[k] = v
+				continue
+			}
+			if defaultLocation == "query" {
+				query[httpKey] = v
+				continue
+			}
 			body[k] = v
 		}
 	}
 	return body, query, headers
+}
+
+func defaultParamLocation(catOp *catalog.CatalogOperation) string {
+	if catOp == nil {
+		return "body"
+	}
+	switch strings.ToUpper(strings.TrimSpace(catOp.Method)) {
+	case http.MethodGet, http.MethodDelete:
+		return "query"
+	default:
+		return "body"
+	}
 }

--- a/gestaltd/core/integration/param_routing_test.go
+++ b/gestaltd/core/integration/param_routing_test.go
@@ -16,7 +16,7 @@ func TestPartitionParams_NilCatalogOp(t *testing.T) {
 	t.Parallel()
 
 	params := map[string]any{"name": "x", "page": 2}
-	body, query, headers := partitionParams(nil, params)
+	body, query, headers := partitionParams(nil, params, false)
 
 	if body["name"] != "x" || body["page"] != 2 {
 		t.Fatalf("body = %v, want all params", body)
@@ -33,24 +33,44 @@ func TestPartitionParams_NoLocations(t *testing.T) {
 	t.Parallel()
 
 	catOp := &catalog.CatalogOperation{
-		ID: "op1",
+		ID:     "op1",
+		Method: http.MethodGet,
 		Parameters: []catalog.CatalogParameter{
 			{Name: "name", Type: "string"},
 			{Name: "count", Type: "integer"},
 		},
 	}
-	params := map[string]any{"name": "x", "count": 5}
-	body, query, headers := partitionParams(catOp, params)
+	t.Run("declared params remain dropped in method default mode", func(t *testing.T) {
+		t.Parallel()
+		params := map[string]any{"name": "x", "count": 5}
+		body, query, headers := partitionParams(catOp, params, true)
 
-	if body["name"] != "x" || body["count"] != 5 {
-		t.Fatalf("body = %v, want all params", body)
-	}
-	if query != nil {
-		t.Fatalf("query = %v, want nil", query)
-	}
-	if headers != nil {
-		t.Fatalf("headers = %v, want nil", headers)
-	}
+		if len(body) != 0 {
+			t.Fatalf("body = %v, want no declared params", body)
+		}
+		if len(query) != 0 {
+			t.Fatalf("query = %v, want no declared params", query)
+		}
+		if len(headers) != 0 {
+			t.Fatalf("headers = %v, want no header params", headers)
+		}
+	})
+
+	t.Run("undeclared params still use method defaults", func(t *testing.T) {
+		t.Parallel()
+		params := map[string]any{"name": "x", "count": 5, "page": 2}
+		body, query, headers := partitionParams(catOp, params, true)
+
+		if len(body) != 0 {
+			t.Fatalf("body = %v, want nil", body)
+		}
+		if query["page"] != 2 || len(query) != 1 {
+			t.Fatalf("query = %v, want only undeclared params", query)
+		}
+		if len(headers) != 0 {
+			t.Fatalf("headers = %v, want nil", headers)
+		}
+	})
 }
 
 func TestPartitionParams_MixedLocations(t *testing.T) {
@@ -71,7 +91,7 @@ func TestPartitionParams_MixedLocations(t *testing.T) {
 		"x_api_key": "secret",
 		"item_id":   "abc",
 	}
-	body, query, headers := partitionParams(catOp, params)
+	body, query, headers := partitionParams(catOp, params, false)
 
 	if body["name"] != "widget" {
 		t.Fatalf("body[name] = %v, want widget", body["name"])
@@ -91,7 +111,8 @@ func TestPartitionParams_UnknownParam(t *testing.T) {
 	t.Parallel()
 
 	catOp := &catalog.CatalogOperation{
-		ID: "op1",
+		ID:     "op1",
+		Method: http.MethodGet,
 		Parameters: []catalog.CatalogParameter{
 			{Name: "page", Type: "integer", Location: "query"},
 		},
@@ -100,13 +121,13 @@ func TestPartitionParams_UnknownParam(t *testing.T) {
 		"page":    1,
 		"unknown": "extra",
 	}
-	body, query, _ := partitionParams(catOp, params)
+	_, query, _ := partitionParams(catOp, params, true)
 
 	if query["page"] != 1 {
 		t.Fatalf("query[page] = %v, want 1", query["page"])
 	}
-	if body["unknown"] != "extra" {
-		t.Fatalf("body[unknown] = %v, want extra (unknown params default to body)", body["unknown"])
+	if query["unknown"] != "extra" {
+		t.Fatalf("query[unknown] = %v, want extra (unknown GET params default to query)", query["unknown"])
 	}
 }
 

--- a/gestaltd/internal/bootstrap/bootstrap_test.go
+++ b/gestaltd/internal/bootstrap/bootstrap_test.go
@@ -2,6 +2,7 @@ package bootstrap_test
 
 import (
 	"context"
+	"encoding/base64"
 	"encoding/hex"
 	"fmt"
 	"net/http"
@@ -167,8 +168,12 @@ func TestBootstrap(t *testing.T) {
 		cases := []struct {
 			name           string
 			restConnection string
+			specAuth       *providermanifestv1.ProviderAuth
 			connections    map[string]*providermanifestv1.ManifestConnectionDef
 			tokenConn      string
+			tokenValue     string
+			wantAuth       string
+			wantAPIKey     string
 		}{
 			{
 				name: "single named connection is inferred as default",
@@ -210,6 +215,63 @@ func TestBootstrap(t *testing.T) {
 				},
 				tokenConn: "workspace",
 			},
+			{
+				name: "declarative auth mapping basic preserves derived authorization header",
+				specAuth: &providermanifestv1.ProviderAuth{
+					Type: providermanifestv1.AuthTypeManual,
+					AuthMapping: &providermanifestv1.AuthMapping{
+						Basic: &providermanifestv1.BasicAuthMapping{
+							Username: providermanifestv1.AuthValue{
+								ValueFrom: &providermanifestv1.AuthValueFrom{
+									CredentialFieldRef: &providermanifestv1.CredentialFieldRef{Name: "username"},
+								},
+							},
+							Password: providermanifestv1.AuthValue{
+								ValueFrom: &providermanifestv1.AuthValueFrom{
+									CredentialFieldRef: &providermanifestv1.CredentialFieldRef{Name: "password"},
+								},
+							},
+						},
+					},
+				},
+				connections: map[string]*providermanifestv1.ManifestConnectionDef{
+					"default": {Mode: providermanifestv1.ConnectionModeUser},
+				},
+				tokenConn:  "default",
+				tokenValue: `{"username":"alice","password":"secret"}`,
+				wantAuth:   "Basic " + base64.StdEncoding.EncodeToString([]byte("alice:secret")),
+			},
+			{
+				name: "declarative auth mapping headers preserves derived upstream header",
+				specAuth: &providermanifestv1.ProviderAuth{
+					Type: providermanifestv1.AuthTypeManual,
+					AuthMapping: &providermanifestv1.AuthMapping{
+						Headers: map[string]providermanifestv1.AuthValue{
+							"X-API-Key": {
+								ValueFrom: &providermanifestv1.AuthValueFrom{
+									CredentialFieldRef: &providermanifestv1.CredentialFieldRef{Name: "api_key"},
+								},
+							},
+						},
+					},
+				},
+				connections: map[string]*providermanifestv1.ManifestConnectionDef{
+					"default": {Mode: providermanifestv1.ConnectionModeUser},
+				},
+				tokenConn:  "default",
+				tokenValue: `{"api_key":"secret-key"}`,
+				wantAPIKey: "secret-key",
+			},
+			{
+				name:     "auth none still forwards bearer token when connection mode is user",
+				specAuth: &providermanifestv1.ProviderAuth{Type: providermanifestv1.AuthTypeNone},
+				connections: map[string]*providermanifestv1.ManifestConnectionDef{
+					"workspace": {Mode: providermanifestv1.ConnectionModeUser},
+				},
+				restConnection: "workspace",
+				tokenConn:      "workspace",
+				wantAuth:       "Bearer workspace-access-token",
+			},
 		}
 
 		for _, tc := range cases {
@@ -218,9 +280,11 @@ func TestBootstrap(t *testing.T) {
 				t.Parallel()
 
 				var authHeader atomic.Value
+				var apiKeyHeader atomic.Value
 				var requestPath atomic.Value
 				srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 					authHeader.Store(r.Header.Get("Authorization"))
+					apiKeyHeader.Store(r.Header.Get("X-API-Key"))
 					requestPath.Store(r.URL.Path)
 					w.Header().Set("Content-Type", "application/json")
 					w.WriteHeader(http.StatusOK)
@@ -233,6 +297,7 @@ func TestBootstrap(t *testing.T) {
 					"slack": {
 						ResolvedManifest: &providermanifestv1.Manifest{
 							Spec: &providermanifestv1.Spec{
+								Auth: tc.specAuth,
 								Surfaces: &providermanifestv1.ProviderSurfaces{
 									REST: &providermanifestv1.RESTSurface{
 										BaseURL:    srv.URL,
@@ -260,6 +325,9 @@ func TestBootstrap(t *testing.T) {
 					t.Fatalf("FindOrCreateUser: %v", err)
 				}
 				tokenValue := tc.tokenConn + "-access-token"
+				if tc.tokenValue != "" {
+					tokenValue = tc.tokenValue
+				}
 				if err := result.Services.Tokens.StoreToken(ctx, &core.IntegrationToken{
 					UserID:       user.ID,
 					Integration:  "slack",
@@ -287,8 +355,14 @@ func TestBootstrap(t *testing.T) {
 					t.Fatalf("path = %q, want %q", gotPath, "/users")
 				}
 				wantAuth := "Bearer " + tokenValue
+				if tc.wantAuth != "" || tc.specAuth != nil {
+					wantAuth = tc.wantAuth
+				}
 				if gotAuth, _ := authHeader.Load().(string); gotAuth != wantAuth {
 					t.Fatalf("Authorization = %q, want %q", gotAuth, wantAuth)
+				}
+				if gotAPIKey, _ := apiKeyHeader.Load().(string); gotAPIKey != tc.wantAPIKey {
+					t.Fatalf("X-API-Key = %q, want %q", gotAPIKey, tc.wantAPIKey)
 				}
 			})
 		}

--- a/gestaltd/internal/providerhost/declarative.go
+++ b/gestaltd/internal/providerhost/declarative.go
@@ -10,45 +10,43 @@ import (
 	"github.com/valon-technologies/gestalt/server/core"
 	"github.com/valon-technologies/gestalt/server/core/catalog"
 	"github.com/valon-technologies/gestalt/server/core/integration"
-	"github.com/valon-technologies/gestalt/server/internal/apiexec"
-	"github.com/valon-technologies/gestalt/server/internal/paraminterp"
 	"github.com/valon-technologies/gestalt/server/internal/provider"
 	providermanifestv1 "github.com/valon-technologies/gestalt/server/sdk/providermanifest/v1"
 )
 
 const declarativeHTTPTimeout = 30 * time.Second
 
-type DeclarativeProviderOption func(*DeclarativeProvider)
+type declarativeOptions struct {
+	displayName    string
+	description    string
+	iconSVG        string
+	connectionMode core.ConnectionMode
+}
+
+type DeclarativeProviderOption func(*declarativeOptions)
 
 func WithDeclarativeMetadataOverrides(displayName, description, iconSVG string) DeclarativeProviderOption {
-	return func(p *DeclarativeProvider) {
+	return func(opts *declarativeOptions) {
 		if displayName != "" {
-			p.catalog.DisplayName = displayName
+			opts.displayName = displayName
 		}
 		if description != "" {
-			p.catalog.Description = description
+			opts.description = description
 		}
 		if iconSVG != "" {
-			p.catalog.IconSVG = iconSVG
+			opts.iconSVG = iconSVG
 		}
 	}
 }
 
 func WithDeclarativeConnectionMode(mode core.ConnectionMode) DeclarativeProviderOption {
-	return func(p *DeclarativeProvider) {
-		p.connectionMode = mode
-	}
+	return func(opts *declarativeOptions) { opts.connectionMode = mode }
 }
 
 type DeclarativeProvider struct {
-	catalog        *catalog.Catalog
-	opsByName      map[string]*catalog.CatalogOperation
-	baseURL        string
-	auth           *providermanifestv1.ProviderAuth
-	httpClient     *http.Client
-	discovery      *providermanifestv1.ProviderDiscovery
-	connectionDefs map[string]providermanifestv1.ProviderConnectionParam
-	connectionMode core.ConnectionMode
+	*integration.Base
+	authType         providermanifestv1.AuthType
+	authorizationURL string
 }
 
 func NewDeclarativeProvider(manifest *providermanifestv1.Manifest, httpClient *http.Client, opts ...DeclarativeProviderOption) (*DeclarativeProvider, error) {
@@ -63,23 +61,107 @@ func NewDeclarativeProvider(manifest *providermanifestv1.Manifest, httpClient *h
 		httpClient = &http.Client{Timeout: declarativeHTTPTimeout}
 	}
 
-	ops := manifest.Spec.RESTOperations()
-	p := &DeclarativeProvider{
-		catalog: &catalog.Catalog{
-			Name:        manifest.Source,
-			DisplayName: manifest.DisplayName,
-			Description: manifest.Description,
-			Headers:     maps.Clone(manifest.Spec.Headers),
-			Operations:  make([]catalog.CatalogOperation, 0, len(ops)),
-		},
-		opsByName:      make(map[string]*catalog.CatalogOperation, len(ops)),
-		baseURL:        manifest.Spec.RESTBaseURL(),
-		auth:           manifest.Spec.Auth,
-		httpClient:     httpClient,
-		discovery:      manifest.Spec.Discovery,
-		connectionDefs: manifest.Spec.ConnectionParams,
+	options := declarativeOptions{}
+	for _, opt := range opts {
+		opt(&options)
 	}
+	auth := manifest.Spec.Auth
+	cat := declarativeCatalog(manifest, options)
+	authType := providermanifestv1.AuthType("")
+	authorizationURL := ""
+	base := &integration.Base{
+		IntegrationName:             cat.Name,
+		IntegrationDisplay:          cat.DisplayName,
+		IntegrationDesc:             cat.Description,
+		ConnMode:                    declarativeConnectionMode(options.connectionMode, auth),
+		BaseURL:                     manifest.Spec.RESTBaseURL(),
+		Headers:                     maps.Clone(manifest.Spec.Headers),
+		HTTPClient:                  httpClient,
+		MethodDefaultParamLocations: true,
+		ConnectionDefs:              ConnectionParamDefsFromManifest(manifest.Spec.ConnectionParams),
+		DiscoveryDef:                DiscoveryConfigFromManifest(manifest.Spec.Discovery),
+		CredentialFieldDefs:         declarativeCredentialFields(auth),
+		NoRetry:                     true,
+	}
+	if auth != nil {
+		authType = auth.Type
+		authorizationURL = auth.AuthorizationURL
+		if auth.AuthMapping != nil && (len(auth.AuthMapping.Headers) > 0 || auth.AuthMapping.Basic != nil) {
+			base.TokenParser = provider.MappedCredentialParser(auth.AuthMapping)
+		}
+	}
+	base.SetCatalog(cat)
 
+	return &DeclarativeProvider{
+		Base:             base,
+		authType:         authType,
+		authorizationURL: authorizationURL,
+	}, nil
+}
+
+func (p *DeclarativeProvider) Catalog() *catalog.Catalog {
+	return p.Base.Catalog().Clone()
+}
+
+func (p *DeclarativeProvider) Execute(ctx context.Context, operation string, params map[string]any, token string) (*core.OperationResult, error) {
+	if !declarativeHasOperation(p.Base.Catalog(), operation) {
+		return &core.OperationResult{Status: http.StatusNotFound, Body: `{"error":"unknown operation"}`}, nil
+	}
+	return p.Base.Execute(ctx, operation, params, token)
+}
+
+func (p *DeclarativeProvider) AuthTypes() []string {
+	switch p.authType {
+	case providermanifestv1.AuthTypeOAuth2:
+		return []string{"oauth"}
+	case providermanifestv1.AuthTypeBearer, providermanifestv1.AuthTypeManual:
+		return []string{"manual"}
+	case providermanifestv1.AuthTypeNone:
+		return nil
+	default:
+		return nil
+	}
+}
+
+func (p *DeclarativeProvider) AuthorizationURL(state string, scopes []string) string {
+	if p.authType != providermanifestv1.AuthTypeOAuth2 {
+		return ""
+	}
+	return p.authorizationURL
+}
+
+func (p *DeclarativeProvider) ExchangeCode(ctx context.Context, code string) (*core.TokenResponse, error) {
+	if p.authType != providermanifestv1.AuthTypeOAuth2 {
+		return nil, fmt.Errorf("provider does not support OAuth")
+	}
+	return nil, fmt.Errorf("declarative provider OAuth exchange not implemented")
+}
+
+func (p *DeclarativeProvider) RefreshToken(ctx context.Context, refreshToken string) (*core.TokenResponse, error) {
+	if p.authType != providermanifestv1.AuthTypeOAuth2 {
+		return nil, fmt.Errorf("provider does not support OAuth")
+	}
+	return nil, fmt.Errorf("declarative provider OAuth refresh not implemented")
+}
+
+func declarativeCatalog(manifest *providermanifestv1.Manifest, opts declarativeOptions) *catalog.Catalog {
+	ops := manifest.Spec.RESTOperations()
+	cat := &catalog.Catalog{
+		Name:        manifest.Source,
+		DisplayName: manifest.DisplayName,
+		Description: manifest.Description,
+		Headers:     maps.Clone(manifest.Spec.Headers),
+		Operations:  make([]catalog.CatalogOperation, 0, len(ops)),
+	}
+	if opts.displayName != "" {
+		cat.DisplayName = opts.displayName
+	}
+	if opts.description != "" {
+		cat.Description = opts.description
+	}
+	if opts.iconSVG != "" {
+		cat.IconSVG = opts.iconSVG
+	}
 	for i := range ops {
 		mop := &ops[i]
 		catOp := catalog.CatalogOperation{
@@ -100,161 +182,37 @@ func NewDeclarativeProvider(manifest *providermanifestv1.Manifest, httpClient *h
 				Required:    mp.Required,
 			})
 		}
-		p.catalog.Operations = append(p.catalog.Operations, catOp)
+		cat.Operations = append(cat.Operations, catOp)
 	}
-
-	integration.CompileSchemas(p.catalog)
-	for i := range p.catalog.Operations {
-		op := &p.catalog.Operations[i]
-		p.opsByName[op.ID] = op
-	}
-	for _, opt := range opts {
-		opt(p)
-	}
-	if p.connectionMode == "" {
-		if p.auth == nil || p.auth.Type == "" || p.auth.Type == providermanifestv1.AuthTypeNone {
-			p.connectionMode = core.ConnectionModeNone
-		} else {
-			p.connectionMode = core.ConnectionModeUser
-		}
-	}
-
-	return p, nil
+	integration.CompileSchemas(cat)
+	return cat
 }
 
-func (p *DeclarativeProvider) Name() string        { return p.catalog.Name }
-func (p *DeclarativeProvider) DisplayName() string { return p.catalog.DisplayName }
-func (p *DeclarativeProvider) Description() string { return p.catalog.Description }
-func (p *DeclarativeProvider) Catalog() *catalog.Catalog {
-	return p.catalog.Clone()
-}
-func (p *DeclarativeProvider) ConnectionMode() core.ConnectionMode { return p.connectionMode }
-
-func (p *DeclarativeProvider) Execute(ctx context.Context, operation string, params map[string]any, token string) (*core.OperationResult, error) {
-	op, ok := p.opsByName[operation]
-	if !ok {
-		return &core.OperationResult{Status: http.StatusNotFound, Body: `{"error":"unknown operation"}`}, nil
+func declarativeConnectionMode(override core.ConnectionMode, auth *providermanifestv1.ProviderAuth) core.ConnectionMode {
+	if override != "" {
+		return override
 	}
-
-	queryParams := make(map[string]any)
-	bodyParams := make(map[string]any)
-	isBodyMethod := op.Method == http.MethodPost || op.Method == http.MethodPut || op.Method == http.MethodPatch
-
-	for k, v := range params {
-		loc, declared := declarativeParamLocation(op, k)
-		if !declared {
-			if isBodyMethod {
-				loc = "body"
-			} else {
-				loc = "query"
-			}
-		}
-		switch loc {
-		case "query":
-			queryParams[k] = v
-		case "body", "path":
-			bodyParams[k] = v
-		}
+	if auth == nil || auth.Type == "" || auth.Type == providermanifestv1.AuthTypeNone {
+		return core.ConnectionModeNone
 	}
-
-	baseURL := p.baseURL
-	headers := maps.Clone(p.catalog.Headers)
-	if cp := core.ConnectionParams(ctx); cp != nil {
-		baseURL = paraminterp.Interpolate(baseURL, cp)
-		for k, v := range headers {
-			headers[k] = paraminterp.Interpolate(v, cp)
-		}
-	}
-
-	authHeader := ""
-	if p.auth != nil && p.auth.AuthMapping != nil && (len(p.auth.AuthMapping.Headers) > 0 || p.auth.AuthMapping.Basic != nil) {
-		resolvedAuth, extraHeaders, err := provider.MappedCredentialParser(p.auth.AuthMapping)(token)
-		if err != nil {
-			return nil, err
-		}
-		authHeader = resolvedAuth
-		token = ""
-		if headers == nil && len(extraHeaders) > 0 {
-			headers = make(map[string]string, len(extraHeaders))
-		}
-		for k, v := range extraHeaders {
-			headers[k] = v
-		}
-	}
-
-	req := apiexec.Request{
-		Method:        op.Method,
-		BaseURL:       baseURL,
-		Path:          op.Path,
-		Params:        bodyParams,
-		QueryParams:   queryParams,
-		CustomHeaders: headers,
-		AuthHeader:    authHeader,
-		Token:         token,
-		NoRetry:       true,
-	}
-	return apiexec.Do(ctx, p.httpClient, req)
+	return core.ConnectionModeUser
 }
 
-func declarativeParamLocation(op *catalog.CatalogOperation, name string) (string, bool) {
-	for _, param := range op.Parameters {
-		if param.Name == name {
-			return param.Location, true
-		}
-	}
-	return "", false
-}
-
-func (p *DeclarativeProvider) CredentialFields() []core.CredentialFieldDef {
-	if p.auth == nil {
+func declarativeCredentialFields(auth *providermanifestv1.ProviderAuth) []core.CredentialFieldDef {
+	if auth == nil {
 		return nil
 	}
-	return CredentialFieldsFromManifest(p.auth.Credentials)
+	return CredentialFieldsFromManifest(auth.Credentials)
 }
 
-func (p *DeclarativeProvider) AuthTypes() []string {
-	if p.auth == nil {
-		return nil
+func declarativeHasOperation(cat *catalog.Catalog, operation string) bool {
+	if cat == nil {
+		return false
 	}
-	switch p.auth.Type {
-	case providermanifestv1.AuthTypeOAuth2:
-		return []string{"oauth"}
-	case providermanifestv1.AuthTypeBearer, providermanifestv1.AuthTypeManual:
-		return []string{"manual"}
-	case providermanifestv1.AuthTypeNone:
-		return nil
-	default:
-		return nil
+	for i := range cat.Operations {
+		if cat.Operations[i].ID == operation {
+			return true
+		}
 	}
-}
-
-func (p *DeclarativeProvider) ConnectionForOperation(string) string { return "" }
-
-func (p *DeclarativeProvider) AuthorizationURL(state string, scopes []string) string {
-	if p.auth == nil || p.auth.Type != providermanifestv1.AuthTypeOAuth2 {
-		return ""
-	}
-	return p.auth.AuthorizationURL
-}
-
-func (p *DeclarativeProvider) ExchangeCode(ctx context.Context, code string) (*core.TokenResponse, error) {
-	if p.auth == nil || p.auth.Type != providermanifestv1.AuthTypeOAuth2 {
-		return nil, fmt.Errorf("provider does not support OAuth")
-	}
-	return nil, fmt.Errorf("declarative provider OAuth exchange not implemented")
-}
-
-func (p *DeclarativeProvider) RefreshToken(ctx context.Context, refreshToken string) (*core.TokenResponse, error) {
-	if p.auth == nil || p.auth.Type != providermanifestv1.AuthTypeOAuth2 {
-		return nil, fmt.Errorf("provider does not support OAuth")
-	}
-	return nil, fmt.Errorf("declarative provider OAuth refresh not implemented")
-}
-
-func (p *DeclarativeProvider) ConnectionParamDefs() map[string]core.ConnectionParamDef {
-	return ConnectionParamDefsFromManifest(p.connectionDefs)
-}
-
-func (p *DeclarativeProvider) DiscoveryConfig() *core.DiscoveryConfig {
-	return DiscoveryConfigFromManifest(p.discovery)
+	return false
 }


### PR DESCRIPTION
## Summary
- route `providerhost` declarative REST execution through `core/integration.Base` instead of the providerhost-specific executor
- preserve declarative-specific behavior by using shared executor knobs for method-default param routing and no-retry execution
- keep declarative `authMapping` and `auth: none` behavior covered at the bootstrap/invocation level
- production LOC: `+172 / -179`, net `-7`

## Go Interface
```go
base := &integration.Base{
    MethodDefaultParamLocations: true,
    NoRetry:                     true,
}
```

## YAML Interface
No manifest schema change is required. Existing declarative REST manifests keep the same YAML surface and now flow through the shared executor.

Manual auth-mapping example:
```yaml
spec:
  auth:
    type: manual
    authMapping:
      basic:
        username:
          valueFrom:
            credentialFieldRef:
              name: username
        password:
          valueFrom:
            credentialFieldRef:
              name: password
  surfaces:
    rest:
      baseUrl: https://api.example.com
      operations:
        - name: users.list
          method: GET
          path: /users
```

Explicit no-auth example with user-mode token forwarding:
```yaml
spec:
  auth:
    type: none
  connections:
    workspace:
      mode: user
  surfaces:
    rest:
      connection: workspace
      baseUrl: https://api.example.com
      operations:
        - name: users.list
          method: GET
          path: /users
```

## Verification
- `go test ./core/integration`
- `go test ./internal/bootstrap`
- `go test ./internal/plugininvocation`
- `golangci-lint run`
