### PR TITLE
server: centralize selector and session-catalog resolution

### DIFF
--- a/gestaltd/internal/server/handlers.go
+++ b/gestaltd/internal/server/handlers.go
@@ -453,23 +453,16 @@ func (s *Server) listOperations(w http.ResponseWriter, r *http.Request) {
 		writeError(w, http.StatusForbidden, errOperationAccess.Error())
 		return
 	}
-	requestedConnection := r.URL.Query().Get(httpConnectionParam)
-	if requestedConnection != "" {
-		var ok bool
-		requestedConnection, ok = s.resolveRequestedConnection(w, name, requestedConnection)
-		if !ok {
-			return
-		}
+	selectors, ok := s.resolveRequestedSelectors(
+		w,
+		name,
+		r.URL.Query().Get(httpConnectionParam),
+		r.URL.Query().Get(httpInstanceParam),
+	)
+	if !ok {
+		return
 	}
-	requestedInstance := r.URL.Query().Get(httpInstanceParam)
-	if requestedInstance != "" {
-		var ok bool
-		requestedInstance, ok = resolveRequestedInstance(w, requestedInstance)
-		if !ok {
-			return
-		}
-	}
-	if err := rejectWorkloadSelectors(w, p, requestedConnection, requestedInstance); err != nil {
+	if err := rejectWorkloadSelectors(w, p, selectors.Connection, selectors.Instance); err != nil {
 		s.auditHTTPEvent(r.Context(), p, name, operation, false, err)
 		return
 	}
@@ -487,27 +480,21 @@ func (s *Server) listOperations(w http.ResponseWriter, r *http.Request) {
 		discoveryConnectionMode = metricutil.NormalizeConnectionMode(prov.ConnectionMode())
 	}
 	resolveCatalog := invocation.ResolveCatalogWithMetadata
-	strictCatalog := false
-	if requestedConnection != "" || requestedInstance != "" {
+	plan := s.planSessionCatalogResolution(p, name, selectors)
+	strictCatalog := plan.requiresStrictCatalog(prov)
+	if strictCatalog {
 		resolveCatalog = invocation.ResolveCatalogStrictWithMetadata
-		strictCatalog = true
-	} else if core.SupportsSessionCatalog(prov) {
-		resolveCatalog = invocation.ResolveCatalogStrictWithMetadata
-		strictCatalog = true
 	}
 	ctx := invocation.WithAccessContext(r.Context(), s.providerAccessContext(p, name))
 	var cat *catalog.Catalog
-	if strictCatalog && requestedConnection == "" && requestedInstance == "" &&
-		(s.authorizer == nil || !s.authorizer.IsWorkload(p)) {
-		catalogConnections := s.sessionCatalogConnections(name, p, requestedConnection)
+	if strictCatalog && plan.shouldTryAllTargets(p) {
 		var firstErr error
-		for _, catalogConnection := range catalogConnections {
-			resolvedConnection, catalogInstance := s.workloadBindingSelectors(p, name, catalogConnection, requestedInstance)
+		for _, target := range plan.Targets {
 			var (
 				err      error
 				metadata invocation.CatalogResolutionMetadata
 			)
-			cat, metadata, err = resolveCatalog(ctx, prov, name, resolver, p, resolvedConnection, catalogInstance)
+			cat, metadata, err = resolveCatalog(ctx, prov, name, resolver, p, target.Connection, target.Instance)
 			if err == nil {
 				discoveryFailed = metadata.SessionFailed
 				break
@@ -526,13 +513,12 @@ func (s *Server) listOperations(w http.ResponseWriter, r *http.Request) {
 			return
 		}
 	} else {
-		catalogConnection := s.sessionCatalogConnections(name, p, requestedConnection)[0]
-		catalogConnection, catalogInstance := s.workloadBindingSelectors(p, name, catalogConnection, requestedInstance)
+		target := plan.Targets[0]
 		var (
 			err      error
 			metadata invocation.CatalogResolutionMetadata
 		)
-		cat, metadata, err = resolveCatalog(ctx, prov, name, resolver, p, catalogConnection, catalogInstance)
+		cat, metadata, err = resolveCatalog(ctx, prov, name, resolver, p, target.Connection, target.Instance)
 		discoveryFailed = metadata.SessionFailed || err != nil
 		if err != nil {
 			if recordDiscoveryMetrics {
@@ -580,23 +566,16 @@ func (s *Server) executeOperation(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	requestedConnection := r.URL.Query().Get(httpConnectionParam)
-	if requestedConnection != "" {
-		var ok bool
-		requestedConnection, ok = s.resolveRequestedConnection(w, providerName, requestedConnection)
-		if !ok {
-			return
-		}
+	querySelectors, ok := s.resolveRequestedSelectors(
+		w,
+		providerName,
+		r.URL.Query().Get(httpConnectionParam),
+		r.URL.Query().Get(httpInstanceParam),
+	)
+	if !ok {
+		return
 	}
-	requestedInstance := r.URL.Query().Get(httpInstanceParam)
-	if requestedInstance != "" {
-		var ok bool
-		requestedInstance, ok = resolveRequestedInstance(w, requestedInstance)
-		if !ok {
-			return
-		}
-	}
-	if err := rejectWorkloadSelectors(w, p, requestedConnection, requestedInstance); err != nil {
+	if err := rejectWorkloadSelectors(w, p, querySelectors.Connection, querySelectors.Instance); err != nil {
 		s.auditHTTPEvent(r.Context(), p, providerName, operationName, false, err)
 		return
 	}
@@ -623,40 +602,17 @@ func (s *Server) executeOperation(w http.ResponseWriter, r *http.Request) {
 	bodyConnection, _ := params[httpConnectionParam].(string)
 	delete(params, httpConnectionParam)
 
-	if bodyInstance != "" {
-		var ok bool
-		bodyInstance, ok = resolveRequestedInstance(w, bodyInstance)
-		if !ok {
-			return
-		}
-	}
-	if requestedInstance != "" && bodyInstance != "" && requestedInstance != bodyInstance {
-		writeError(w, http.StatusBadRequest, fmt.Sprintf("conflicting instance parameter %q in query string and JSON body", httpInstanceParam))
+	bodySelectors, ok := s.resolveRequestedSelectors(w, providerName, bodyConnection, bodyInstance)
+	if !ok {
 		return
 	}
-	instance := bodyInstance
-	if instance == "" {
-		instance = requestedInstance
-	}
-
-	if bodyConnection != "" {
-		var ok bool
-		bodyConnection, ok = s.resolveRequestedConnection(w, providerName, bodyConnection)
-		if !ok {
-			return
-		}
-	}
-	if requestedConnection != "" && bodyConnection != "" && requestedConnection != bodyConnection {
-		writeError(w, http.StatusBadRequest, fmt.Sprintf("conflicting connection parameter %q in query string and JSON body", httpConnectionParam))
-		return
-	}
-	if err := rejectWorkloadSelectors(w, p, bodyConnection, bodyInstance); err != nil {
+	if err := rejectWorkloadSelectors(w, p, bodySelectors.Connection, bodySelectors.Instance); err != nil {
 		s.auditHTTPEvent(r.Context(), p, providerName, operationName, false, err)
 		return
 	}
-	connection := bodyConnection
-	if connection == "" {
-		connection = requestedConnection
+	selectors, ok := mergeResolvedSelectors(w, querySelectors, bodySelectors)
+	if !ok {
+		return
 	}
 	ctx := r.Context()
 	ctx = invocation.WithAccessContext(ctx, access)
@@ -667,18 +623,17 @@ func (s *Server) executeOperation(w http.ResponseWriter, r *http.Request) {
 	}
 	opMeta, ok := invocation.CatalogOperation(prov.Catalog(), operationName)
 	sessionOpFound := false
+	plan := s.planSessionCatalogResolution(p, providerName, selectors)
 	if core.SupportsSessionCatalog(prov) {
 		var firstSessionErr error
 		sessionCatalogResolved := false
-		sessionConnections := s.sessionCatalogConnections(providerName, p, connection)
-		for _, sessionConnection := range sessionConnections {
-			sessionConnection, sessionInstance := s.workloadBindingSelectors(p, providerName, sessionConnection, instance)
-			sessionCat, err := invocation.ResolveSessionCatalog(ctx, prov, providerName, resolver, p, sessionConnection, sessionInstance)
+		for _, target := range plan.Targets {
+			sessionCat, err := invocation.ResolveSessionCatalog(ctx, prov, providerName, resolver, p, target.Connection, target.Instance)
 			if err != nil {
 				if firstSessionErr == nil {
 					firstSessionErr = err
 				}
-				if connection != "" {
+				if plan.ExplicitConnection {
 					s.writeInvocationError(w, r, providerName, operationName, err)
 					return
 				}
@@ -688,8 +643,8 @@ func (s *Server) executeOperation(w http.ResponseWriter, r *http.Request) {
 			if sessionOp, sessionOK := invocation.CatalogOperation(sessionCat, operationName); sessionOK {
 				opMeta, ok = sessionOp, true
 				sessionOpFound = true
-				if connection == "" {
-					connection = sessionConnection
+				if !plan.ExplicitConnection {
+					selectors.Connection = target.Connection
 				}
 				break
 			}
@@ -698,7 +653,7 @@ func (s *Server) executeOperation(w http.ResponseWriter, r *http.Request) {
 			s.writeInvocationError(w, r, providerName, operationName, firstSessionErr)
 			return
 		}
-		if instance != "" && !sessionOpFound {
+		if plan.ExplicitInstance && !sessionOpFound {
 			s.writeInvocationError(w, r, providerName, operationName, fmt.Errorf("%w: %q on provider %q", invocation.ErrOperationNotFound, operationName, providerName))
 			return
 		}
@@ -717,17 +672,17 @@ func (s *Server) executeOperation(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 	ctx = invocation.WithCatalogOperation(ctx, providerName, opMeta)
-	if connection != "" {
-		if !safeParamValue.MatchString(connection) {
+	if selectors.Connection != "" {
+		if !safeParamValue.MatchString(selectors.Connection) {
 			writeError(w, http.StatusBadRequest, "connection name contains invalid characters")
 			return
 		}
-		connection = config.ResolveConnectionAlias(connection)
-		ctx = invocation.WithConnection(ctx, connection)
+		selectors.Connection = config.ResolveConnectionAlias(selectors.Connection)
+		ctx = invocation.WithConnection(ctx, selectors.Connection)
 	}
 	ctx = invocation.WithInvocationSurface(ctx, invocation.InvocationSurfaceHTTP)
 
-	result, err := s.invoker.Invoke(ctx, p, providerName, instance, operationName, params)
+	result, err := s.invoker.Invoke(ctx, p, providerName, selectors.Instance, operationName, params)
 	if err != nil {
 		s.writeInvocationError(w, r, providerName, operationName, err)
 		return

--- a/gestaltd/internal/server/selector_resolution.go
+++ b/gestaltd/internal/server/selector_resolution.go
@@ -1,0 +1,89 @@
+package server
+
+import (
+	"fmt"
+	"net/http"
+
+	"github.com/valon-technologies/gestalt/server/core"
+	"github.com/valon-technologies/gestalt/server/internal/principal"
+)
+
+type resolvedSelectors struct {
+	Connection string
+	Instance   string
+}
+
+type sessionCatalogPlan struct {
+	ExplicitConnection bool
+	ExplicitInstance   bool
+	Targets            []resolvedSelectors
+}
+
+func (s *Server) resolveRequestedSelectors(w http.ResponseWriter, provider, requestedConnection, requestedInstance string) (resolvedSelectors, bool) {
+	if requestedConnection != "" {
+		var ok bool
+		requestedConnection, ok = s.resolveRequestedConnection(w, provider, requestedConnection)
+		if !ok {
+			return resolvedSelectors{}, false
+		}
+	}
+	if requestedInstance != "" {
+		var ok bool
+		requestedInstance, ok = resolveRequestedInstance(w, requestedInstance)
+		if !ok {
+			return resolvedSelectors{}, false
+		}
+	}
+	return resolvedSelectors{
+		Connection: requestedConnection,
+		Instance:   requestedInstance,
+	}, true
+}
+
+func mergeResolvedSelectors(w http.ResponseWriter, querySelectors, bodySelectors resolvedSelectors) (resolvedSelectors, bool) {
+	if querySelectors.Instance != "" && bodySelectors.Instance != "" && querySelectors.Instance != bodySelectors.Instance {
+		writeError(w, http.StatusBadRequest, fmt.Sprintf("conflicting instance parameter %q in query string and JSON body", httpInstanceParam))
+		return resolvedSelectors{}, false
+	}
+	if querySelectors.Connection != "" && bodySelectors.Connection != "" && querySelectors.Connection != bodySelectors.Connection {
+		writeError(w, http.StatusBadRequest, fmt.Sprintf("conflicting connection parameter %q in query string and JSON body", httpConnectionParam))
+		return resolvedSelectors{}, false
+	}
+
+	selectors := bodySelectors
+	if selectors.Instance == "" {
+		selectors.Instance = querySelectors.Instance
+	}
+	if selectors.Connection == "" {
+		selectors.Connection = querySelectors.Connection
+	}
+	return selectors, true
+}
+
+func (s *Server) planSessionCatalogResolution(p *principal.Principal, provider string, selectors resolvedSelectors) sessionCatalogPlan {
+	plan := sessionCatalogPlan{
+		ExplicitConnection: selectors.Connection != "",
+		ExplicitInstance:   selectors.Instance != "",
+	}
+	candidates := s.sessionCatalogConnections(provider, p, selectors.Connection)
+	plan.Targets = make([]resolvedSelectors, 0, len(candidates))
+	for _, candidateConnection := range candidates {
+		connection, instance := s.workloadBindingSelectors(p, provider, candidateConnection, selectors.Instance)
+		plan.Targets = append(plan.Targets, resolvedSelectors{
+			Connection: connection,
+			Instance:   instance,
+		})
+	}
+	if len(plan.Targets) == 0 {
+		plan.Targets = []resolvedSelectors{{Connection: selectors.Connection, Instance: selectors.Instance}}
+	}
+	return plan
+}
+
+func (plan sessionCatalogPlan) requiresStrictCatalog(prov core.Provider) bool {
+	return plan.ExplicitConnection || plan.ExplicitInstance || core.SupportsSessionCatalog(prov)
+}
+
+func (plan sessionCatalogPlan) shouldTryAllTargets(p *principal.Principal) bool {
+	return !plan.ExplicitConnection && !plan.ExplicitInstance && (p == nil || p.Kind != principal.KindWorkload)
+}

--- a/gestaltd/internal/server/server_test.go
+++ b/gestaltd/internal/server/server_test.go
@@ -6115,6 +6115,77 @@ func TestListOperations_UsesCatalogConnectionOverride(t *testing.T) {
 	}
 }
 
+func TestListOperations_UsesInstanceOnlySelectorWithCatalogLookupConnection(t *testing.T) {
+	t.Parallel()
+
+	sessionStub := &stubIntegrationWithSessionCatalog{
+		stubIntegrationWithOps: stubIntegrationWithOps{
+			StubIntegration: coretesting.StubIntegration{N: "sample-int", ConnMode: core.ConnectionModeUser},
+		},
+		catalogForRequestFn: func(_ context.Context, token string) (*catalog.Catalog, error) {
+			switch token {
+			case "token-a":
+				return &catalog.Catalog{
+					Name: "sample-int",
+					Operations: []catalog.CatalogOperation{
+						{ID: "run_a", Description: "Run A", Method: http.MethodGet, Transport: catalog.TransportREST},
+					},
+				}, nil
+			case "token-b":
+				return &catalog.Catalog{
+					Name: "sample-int",
+					Operations: []catalog.CatalogOperation{
+						{ID: "run_b", Description: "Run B", Method: http.MethodGet, Transport: catalog.TransportREST},
+					},
+				}, nil
+			default:
+				return nil, fmt.Errorf("unexpected token %q", token)
+			}
+		},
+	}
+
+	svc := coretesting.NewStubServices(t)
+	u := seedUser(t, svc, "anonymous@gestalt")
+	seedToken(t, svc, &core.IntegrationToken{
+		ID: "tok-a", UserID: u.ID, Integration: "sample-int",
+		Connection: "rest-conn", Instance: "team-a", AccessToken: "token-a",
+	})
+	seedToken(t, svc, &core.IntegrationToken{
+		ID: "tok-b", UserID: u.ID, Integration: "sample-int",
+		Connection: "rest-conn", Instance: "team-b", AccessToken: "token-b",
+	})
+
+	ts := newTestServer(t, func(cfg *server.Config) {
+		cfg.Providers = testutil.NewProviderRegistry(t, sessionStub)
+		cfg.DefaultConnection = map[string]string{"sample-int": "rest-conn"}
+		cfg.Services = svc
+	})
+	testutil.CloseOnCleanup(t, ts)
+
+	req, _ := http.NewRequest(http.MethodGet, ts.URL+"/api/v1/integrations/sample-int/operations?_instance=team-b", nil)
+	resp, err := http.DefaultClient.Do(req)
+	if err != nil {
+		t.Fatalf("request: %v", err)
+	}
+	defer func() { _ = resp.Body.Close() }()
+
+	if resp.StatusCode != http.StatusOK {
+		body, _ := io.ReadAll(resp.Body)
+		t.Fatalf("expected 200, got %d: %s", resp.StatusCode, body)
+	}
+
+	var ops []map[string]any
+	if err := json.NewDecoder(resp.Body).Decode(&ops); err != nil {
+		t.Fatalf("decoding response: %v", err)
+	}
+	if len(ops) != 1 {
+		t.Fatalf("expected 1 operation, got %d", len(ops))
+	}
+	if ops[0]["id"] != "run_b" {
+		t.Fatalf("expected operation run_b, got %v", ops[0]["id"])
+	}
+}
+
 func TestListOperations_UsesBrokerCatalogConnectionFallback(t *testing.T) {
 	t.Parallel()
 
@@ -6878,6 +6949,78 @@ func TestExecuteOperation_UsesInjectedInvoker(t *testing.T) {
 	}
 }
 
+func TestExecuteOperation_RejectsConflictingQueryAndBodySelectors(t *testing.T) {
+	t.Parallel()
+
+	cases := []struct {
+		name      string
+		query     string
+		body      string
+		errorText string
+	}{
+		{
+			name:      "connection",
+			query:     "_connection=workspace",
+			body:      `{"_connection":"other","foo":"bar"}`,
+			errorText: `conflicting connection parameter "_connection" in query string and JSON body`,
+		},
+		{
+			name:      "instance",
+			query:     "_instance=tenant-a",
+			body:      `{"_instance":"tenant-b","foo":"bar"}`,
+			errorText: `conflicting instance parameter "_instance" in query string and JSON body`,
+		},
+	}
+
+	for _, tc := range cases {
+		tc := tc
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+
+			called := false
+			ts := newTestServer(t, func(cfg *server.Config) {
+				cfg.Providers = testutil.NewProviderRegistry(t, &stubIntegrationWithOps{
+					StubIntegration: coretesting.StubIntegration{N: "custom-provider"},
+					ops: []core.Operation{
+						{Name: "custom-operation", Description: "Custom operation", Method: http.MethodPost},
+					},
+				})
+				cfg.Invoker = &testutil.StubInvoker{
+					InvokeFn: func(context.Context, *principal.Principal, string, string, string, map[string]any) (*core.OperationResult, error) {
+						called = true
+						return &core.OperationResult{Status: http.StatusOK, Body: `{"ok":true}`}, nil
+					},
+				}
+			})
+			testutil.CloseOnCleanup(t, ts)
+
+			req, _ := http.NewRequest(http.MethodPost, ts.URL+"/api/v1/custom-provider/custom-operation?"+tc.query, bytes.NewBufferString(tc.body))
+			req.Header.Set("Content-Type", "application/json")
+			resp, err := http.DefaultClient.Do(req)
+			if err != nil {
+				t.Fatalf("request: %v", err)
+			}
+			defer func() { _ = resp.Body.Close() }()
+
+			if resp.StatusCode != http.StatusBadRequest {
+				body, _ := io.ReadAll(resp.Body)
+				t.Fatalf("expected 400, got %d: %s", resp.StatusCode, body)
+			}
+
+			var result map[string]string
+			if err := json.NewDecoder(resp.Body).Decode(&result); err != nil {
+				t.Fatalf("decode error response: %v", err)
+			}
+			if result["error"] != tc.errorText {
+				t.Fatalf("error = %q, want %q", result["error"], tc.errorText)
+			}
+			if called {
+				t.Fatal("expected conflicting selectors to stop execution")
+			}
+		})
+	}
+}
+
 func TestExecuteOperation_WrappedProvidersPreserveOperationConnectionRouting(t *testing.T) {
 	t.Parallel()
 
@@ -7197,6 +7340,94 @@ func TestWorkloadAuthorization_ExecuteOperation_UsesBoundIdentityAndRejectsSelec
 	}
 	if selectorAudit["error"] != "workload callers may not override connection or instance bindings" {
 		t.Fatalf("unexpected selector audit error: %v", selectorAudit["error"])
+	}
+}
+
+func TestWorkloadAuthorization_ExecuteOperation_RejectsBodySelectors(t *testing.T) {
+	t.Parallel()
+
+	cases := []struct {
+		name string
+		body string
+	}{
+		{name: "instance", body: `{"_instance":"team-a"}`},
+		{name: "connection", body: `{"_connection":"workspace"}`},
+	}
+
+	for _, tc := range cases {
+		tc := tc
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+
+			workloadToken, _, err := principal.GenerateToken(principal.TokenTypeWorkload)
+			if err != nil {
+				t.Fatalf("GenerateToken: %v", err)
+			}
+
+			svc := coretesting.NewStubServices(t)
+			seedIdentityToken(t, svc, "svc", "workspace", "team-a", "identity-bound-token")
+			called := false
+
+			stub := &stubIntegrationWithOps{
+				StubIntegration: coretesting.StubIntegration{
+					N:        "svc",
+					ConnMode: core.ConnectionModeIdentity,
+					ExecuteFn: func(_ context.Context, op string, _ map[string]any, token string) (*core.OperationResult, error) {
+						called = true
+						return &core.OperationResult{Status: http.StatusOK, Body: fmt.Sprintf(`{"operation":%q,"token":%q}`, op, token)}, nil
+					},
+				},
+				ops: []core.Operation{{Name: "run", Method: http.MethodPost}},
+			}
+			providers := testutil.NewProviderRegistry(t, stub)
+			authz := mustAuthorizer(t, config.AuthorizationConfig{
+				Workloads: map[string]config.WorkloadDef{
+					"triage-bot": {
+						Token: workloadToken,
+						Providers: map[string]config.WorkloadProviderDef{
+							"svc": {
+								Connection: "workspace",
+								Instance:   "team-a",
+								Allow:      []string{"run"},
+							},
+						},
+					},
+				},
+			}, providers, nil, nil)
+
+			ts := newTestServer(t, func(cfg *server.Config) {
+				cfg.Auth = &coretesting.StubAuthProvider{N: "test"}
+				cfg.Providers = providers
+				cfg.Services = svc
+				cfg.Authorizer = authz
+			})
+			testutil.CloseOnCleanup(t, ts)
+
+			req, _ := http.NewRequest(http.MethodPost, ts.URL+"/api/v1/svc/run", bytes.NewBufferString(tc.body))
+			req.Header.Set("Authorization", "Bearer "+workloadToken)
+			req.Header.Set("Content-Type", "application/json")
+			resp, err := http.DefaultClient.Do(req)
+			if err != nil {
+				t.Fatalf("request: %v", err)
+			}
+			defer func() { _ = resp.Body.Close() }()
+
+			if resp.StatusCode != http.StatusForbidden {
+				body, _ := io.ReadAll(resp.Body)
+				t.Fatalf("expected 403, got %d: %s", resp.StatusCode, body)
+			}
+
+			var result map[string]any
+			if err := json.NewDecoder(resp.Body).Decode(&result); err != nil {
+				t.Fatalf("decode error response: %v", err)
+			}
+			if result["error"] != "workload callers may not override connection or instance bindings" {
+				t.Fatalf("unexpected error: %v", result["error"])
+			}
+			if called {
+				t.Fatal("expected body selectors to stop execution")
+			}
+		})
 	}
 }
 
@@ -8266,6 +8497,67 @@ func TestExecuteOperation_DoesNotFallbackPastConfiguredCatalogConnection(t *test
 	if resp.StatusCode != http.StatusNotFound {
 		body, _ := io.ReadAll(resp.Body)
 		t.Fatalf("expected 404, got %d: %s", resp.StatusCode, body)
+	}
+	if gotToken != "" {
+		t.Fatalf("execute token = %q, want no provider execution", gotToken)
+	}
+}
+
+func TestExecuteOperation_DoesNotFallbackPastExplicitConnectionSelector(t *testing.T) {
+	t.Parallel()
+
+	var gotToken string
+	sessionStub := &stubIntegrationWithSessionCatalog{
+		stubIntegrationWithOps: stubIntegrationWithOps{
+			StubIntegration: coretesting.StubIntegration{
+				N:        "sample-int",
+				ConnMode: core.ConnectionModeUser,
+				ExecuteFn: func(_ context.Context, op string, _ map[string]any, token string) (*core.OperationResult, error) {
+					gotToken = token
+					return &core.OperationResult{Status: http.StatusOK, Body: fmt.Sprintf(`{"operation":%q,"token":%q}`, op, token)}, nil
+				},
+			},
+		},
+		catalogForRequestFn: func(_ context.Context, token string) (*catalog.Catalog, error) {
+			switch token {
+			case "rest-token":
+				return &catalog.Catalog{
+					Name: "sample-int",
+					Operations: []catalog.CatalogOperation{
+						{ID: "run", Description: "Run", Method: http.MethodGet, Transport: catalog.TransportREST},
+					},
+				}, nil
+			default:
+				return nil, fmt.Errorf("unexpected token %q", token)
+			}
+		},
+	}
+
+	providers := testutil.NewProviderRegistry(t, sessionStub)
+	svc := coretesting.NewStubServices(t)
+	u := seedUser(t, svc, "anonymous@gestalt")
+	seedToken(t, svc, &core.IntegrationToken{
+		ID: "tok-rest", UserID: u.ID, Integration: "sample-int",
+		Connection: "rest-conn", Instance: "default", AccessToken: "rest-token",
+	})
+
+	ts := newTestServer(t, func(cfg *server.Config) {
+		cfg.Providers = providers
+		cfg.Services = svc
+		cfg.DefaultConnection = map[string]string{"sample-int": "rest-conn"}
+	})
+	testutil.CloseOnCleanup(t, ts)
+
+	req, _ := http.NewRequest(http.MethodGet, ts.URL+"/api/v1/sample-int/run?_connection=missing-conn", nil)
+	resp, err := http.DefaultClient.Do(req)
+	if err != nil {
+		t.Fatalf("request: %v", err)
+	}
+	defer func() { _ = resp.Body.Close() }()
+
+	if resp.StatusCode != http.StatusPreconditionFailed {
+		body, _ := io.ReadAll(resp.Body)
+		t.Fatalf("expected 412, got %d: %s", resp.StatusCode, body)
 	}
 	if gotToken != "" {
 		t.Fatalf("execute token = %q, want no provider execution", gotToken)


### PR DESCRIPTION
## Summary
- move server-side selector validation/merging and post-binding session-catalog target planning into `gestaltd/internal/server/selector_resolution.go`
- reuse that selector plan in both `listOperations` and `executeOperation` without collapsing their distinct list-vs-execute policies
- add HTTP coverage for instance-only selection, query/body selector conflicts, workload body-selector rejection, and explicit-selector no-fallback

## Go/HTTP interface
```http
GET /api/v1/integrations/sample-int/operations?_instance=team-b
```
This still resolves session-catalog discovery through the configured catalog/default connection while keeping `_instance` explicit.

```http
POST /api/v1/custom-provider/custom-operation?_connection=workspace
Content-Type: application/json

{"_connection":"other","foo":"bar"}
```
This still fails before provider execution with:
```json
{"error":"conflicting connection parameter \"_connection\" in query string and JSON body"}
```

```http
GET /api/v1/sample-int/run?_connection=missing-conn
```
This still does not fall back to the server default connection; the explicit selector owns the failure path.

## Rust / stdin-stdout interface
No client-side Rust surface changes are required; this PR preserves the request shapes the Rust CLI already emits and removes duplicated server branching behind them.

```rust
// Existing CLI/integration callers still rely on the same selector transport.
// Server behavior is what changed internally.
let req = serde_json::json!({"foo": "bar", "_instance": "team-b"});
```

```text
$ gestalt plugins invoke sample-int run --instance team-b
# server resolves the bound catalog/default connection for that instance-only selector
```

```text
$ printf '{"_instance":"team-a"}' | curl -X POST "$GESTALT_URL/api/v1/svc/run" \
    -H "Authorization: Bearer $WORKLOAD_TOKEN" \
    -H 'Content-Type: application/json' \
    --data-binary @-
{"error":"workload callers may not override connection or instance bindings"}
```

## Testing
- `go test ./internal/server`
