### PR TITLE
Unify source.path lifecycle around prepared installs

### DIFF
--- a/docs/content/reference/cli.mdx
+++ b/docs/content/reference/cli.mdx
@@ -15,7 +15,6 @@ import { Callout } from 'nextra/components'
 | `gestaltd init --config PATH` | Resolve published plugin sources and write lock state. Repeat `--config` to layer overrides. |
 | `gestaltd init --artifacts-dir DIR` | Directory for prepared provider artifacts. |
 | `gestaltd validate --config PATH` | Validate config without serving. Repeat `--config` to layer overrides. |
-| `gestaltd validate --artifacts-dir DIR` | Directory for prepared provider artifacts. |
 | `gestaltd --version` | Print the server version. |
 
 <Callout type="warning">

--- a/gestaltd/cmd/gestaltd/e2e_test.go
+++ b/gestaltd/cmd/gestaltd/e2e_test.go
@@ -338,6 +338,102 @@ plugins:
 	}
 }
 
+func TestE2EValidateUsesScratchPreparedInstallsForLocalSourceConfigs(t *testing.T) {
+	t.Parallel()
+
+	dir := t.TempDir()
+	pluginDir := setupPluginDir(t, dir)
+	indexedDBManifest := componentProviderManifestPath(t, setupIndexedDBProviderDir(t, dir))
+
+	cfgPath := filepath.Join(dir, "config.yaml")
+	cfg := fmt.Sprintf(`server:
+  encryptionKey: test-key
+  providers:
+    indexeddb: sqlite
+providers:
+  indexeddb:
+    sqlite:
+      source:
+        path: %s
+      config:
+        path: %q
+plugins:
+  example:
+    source:
+      path: %s
+`, indexedDBManifest, filepath.Join(dir, "gestalt.db"), componentProviderManifestPath(t, pluginDir))
+	if err := os.WriteFile(cfgPath, []byte(cfg), 0o644); err != nil {
+		t.Fatalf("WriteFile config: %v", err)
+	}
+
+	out, err := exec.Command(gestaltdBin, "validate", "--config", cfgPath).CombinedOutput()
+	if err != nil {
+		t.Fatalf("expected validate to succeed: %v\n%s", err, out)
+	}
+	if !strings.Contains(string(out), "config ok") {
+		t.Fatalf("expected validate output to mention success, got: %s", out)
+	}
+	if _, err := os.Stat(filepath.Join(dir, operator.InitLockfileName)); !os.IsNotExist(err) {
+		t.Fatalf("validate should not write lockfile, got err=%v", err)
+	}
+	if _, err := os.Stat(filepath.Join(dir, ".gestaltd")); !os.IsNotExist(err) {
+		t.Fatalf("validate should not leave prepared artifacts in config dir, got err=%v", err)
+	}
+
+	providedArtifactsDir := filepath.Join(dir, "artifacts", "validate")
+	out, err = exec.Command(gestaltdBin, "validate", "--config", cfgPath, "--artifacts-dir", providedArtifactsDir).CombinedOutput()
+	if err == nil {
+		t.Fatalf("expected validate with --artifacts-dir to fail, got success:\n%s", out)
+	}
+	if _, err := os.Stat(providedArtifactsDir); !os.IsNotExist(err) {
+		t.Fatalf("validate should not mutate provided artifacts dir, got err=%v", err)
+	}
+}
+
+func TestE2EValidateRejectsInvalidPluginInvokesDependency(t *testing.T) {
+	t.Parallel()
+
+	dir := t.TempDir()
+	callerDir := setupPluginDirWithVersion(t, filepath.Join(dir, "caller"), "0.0.1-alpha.1")
+	targetDir := setupPluginDirWithVersion(t, filepath.Join(dir, "target"), "0.0.1-alpha.1")
+	indexedDBManifest := componentProviderManifestPath(t, setupIndexedDBProviderDir(t, dir))
+
+	cfgPath := filepath.Join(dir, "config.yaml")
+	cfg := fmt.Sprintf(`server:
+  encryptionKey: test-key
+  providers:
+    indexeddb: sqlite
+providers:
+  indexeddb:
+    sqlite:
+      source:
+        path: %s
+      config:
+        path: %q
+plugins:
+  caller:
+    source:
+      path: %s
+    invokes:
+      - plugin: target
+        operation: missing
+  target:
+    source:
+      path: %s
+`, indexedDBManifest, filepath.Join(dir, "gestalt.db"), componentProviderManifestPath(t, callerDir), componentProviderManifestPath(t, targetDir))
+	if err := os.WriteFile(cfgPath, []byte(cfg), 0o644); err != nil {
+		t.Fatalf("WriteFile config: %v", err)
+	}
+
+	out, err := exec.Command(gestaltdBin, "validate", "--config", cfgPath).CombinedOutput()
+	if err == nil {
+		t.Fatalf("expected validate to fail, got success:\n%s", out)
+	}
+	if !strings.Contains(string(out), `unknown effective operation`) {
+		t.Fatalf("expected validate output to mention missing invokes operation, got: %s", out)
+	}
+}
+
 func setupPluginDir(t *testing.T, baseDir string) string {
 	t.Helper()
 	return setupPluginDirWithVersion(t, baseDir, "0.0.1-alpha.1")

--- a/gestaltd/cmd/gestaltd/init.go
+++ b/gestaltd/cmd/gestaltd/init.go
@@ -47,3 +47,12 @@ func loadConfigForExecutionAtPathsWithArtifactsDir(configPaths []string, artifac
 	}
 	return cfg, nil
 }
+
+func loadConfigForValidationWithArtifactsDir(configFlags []string, artifactsDir string) ([]string, *config.Config, error) {
+	configPaths := operator.ResolveConfigPaths(configFlags)
+	cfg, err := operatorLifecycle().LoadForValidationAtPathsWithArtifactsDir(configPaths, artifactsDir)
+	if err != nil {
+		return nil, nil, err
+	}
+	return configPaths, cfg, nil
+}

--- a/gestaltd/cmd/gestaltd/plugin_test.go
+++ b/gestaltd/cmd/gestaltd/plugin_test.go
@@ -2080,12 +2080,29 @@ server:
 func writeStubIndexedDBManifestForTest(t *testing.T, dir string) string {
 	t.Helper()
 
+	artifactPath := filepath.ToSlash(filepath.Join("artifacts", runtime.GOOS, runtime.GOARCH, "indexeddb"))
+	artifactFullPath := filepath.Join(dir, filepath.FromSlash(artifactPath))
+	if err := os.MkdirAll(filepath.Dir(artifactFullPath), 0o755); err != nil {
+		t.Fatalf("mkdir indexeddb artifact dir: %v", err)
+	}
+	artifactContent := []byte("indexeddb-stub-binary")
+	if err := os.WriteFile(artifactFullPath, artifactContent, 0o755); err != nil {
+		t.Fatalf("write indexeddb artifact: %v", err)
+	}
+	artifactSum := sha256.Sum256(artifactContent)
 	manifestPath := filepath.Join(dir, "indexeddb-manifest.yaml")
 	data, err := providerpkg.EncodeSourceManifestFormat(&providermanifestv1.Manifest{
-		Source:  "github.com/test/providers/indexeddb-stub",
-		Version: "0.0.1-alpha.1",
-		Kind:    providermanifestv1.KindIndexedDB,
-		Spec:    &providermanifestv1.Spec{},
+		Source:     "github.com/test/providers/indexeddb-stub",
+		Version:    "0.0.1-alpha.1",
+		Kind:       providermanifestv1.KindIndexedDB,
+		Entrypoint: &providermanifestv1.Entrypoint{ArtifactPath: artifactPath},
+		Artifacts: []providermanifestv1.Artifact{{
+			OS:     runtime.GOOS,
+			Arch:   runtime.GOARCH,
+			Path:   artifactPath,
+			SHA256: hex.EncodeToString(artifactSum[:]),
+		}},
+		Spec: &providermanifestv1.Spec{},
 	}, providerpkg.ManifestFormatYAML)
 	if err != nil {
 		t.Fatalf("encode indexeddb manifest: %v", err)

--- a/gestaltd/cmd/gestaltd/run.go
+++ b/gestaltd/cmd/gestaltd/run.go
@@ -473,7 +473,6 @@ func runValidate(args []string) error {
 	fs.Usage = func() { printValidateUsage(fs.Output()) }
 	var configPaths repeatedStringFlag
 	fs.Var(&configPaths, "config", "path to config file (repeat to layer overrides)")
-	artifactsDir := fs.String("artifacts-dir", "", "path to writable prepared-artifacts directory")
 	if err := fs.Parse(args); err != nil {
 		return err
 	}
@@ -481,12 +480,17 @@ func runValidate(args []string) error {
 		return fmt.Errorf("unexpected arguments: %s", strings.Join(fs.Args(), " "))
 	}
 
-	return validateConfigWithArtifactsDir(configPaths, *artifactsDir)
+	return validateConfig(configPaths)
 }
 
-func validateConfigWithArtifactsDir(configFlags []string, artifactsDir string) error {
-	configPaths := operator.ResolveConfigPaths(configFlags)
-	cfg, err := loadConfigForExecutionAtPathsWithArtifactsDir(configPaths, artifactsDir, true)
+func validateConfig(configFlags []string) error {
+	scratchDir, err := os.MkdirTemp("", "gestaltd-validate-*")
+	if err != nil {
+		return fmt.Errorf("create validation scratch dir: %w", err)
+	}
+	defer func() { _ = os.RemoveAll(scratchDir) }()
+
+	paths, cfg, err := loadConfigForValidationWithArtifactsDir(configFlags, scratchDir)
 	if err != nil {
 		return err
 	}
@@ -496,7 +500,7 @@ func validateConfigWithArtifactsDir(configFlags []string, artifactsDir string) e
 		return err
 	}
 
-	logConfigSummary(configPaths, cfg)
+	logConfigSummary(paths, cfg)
 	for _, w := range warnings {
 		slog.Warn(w)
 	}
@@ -567,7 +571,7 @@ func printMainUsage(w io.Writer) {
 	writeUsageLine(w, "  gestaltd init [--config PATH]... [--artifacts-dir PATH] [--platform PLATFORMS]")
 	writeUsageLine(w, "  gestaltd serve [--config PATH]... [--artifacts-dir PATH] [--locked]")
 	writeUsageLine(w, "  gestaltd provider <command> [flags]")
-	writeUsageLine(w, "  gestaltd validate [--config PATH]... [--artifacts-dir PATH]")
+	writeUsageLine(w, "  gestaltd validate [--config PATH]...")
 	writeUsageLine(w, "")
 	writeUsageLine(w, "Commands:")
 	writeUsageLine(w, "  init        Resolve providers and plugins and write lock state")
@@ -578,7 +582,7 @@ func printMainUsage(w io.Writer) {
 	writeUsageLine(w, "")
 	writeUsageLine(w, "Flags:")
 	writeUsageLine(w, "  --config          Path to a config file; repeat to layer left-to-right")
-	writeUsageLine(w, "  --artifacts-dir   Path to writable prepared-artifacts directory")
+	writeUsageLine(w, "  --artifacts-dir   Path to writable prepared-artifacts directory for init/serve")
 }
 
 func printServeUsage(w io.Writer) {
@@ -613,9 +617,10 @@ func printInitUsage(w io.Writer) {
 
 func printValidateUsage(w io.Writer) {
 	writeUsageLine(w, "Usage:")
-	writeUsageLine(w, "  gestaltd validate [--config PATH]... [--artifacts-dir PATH]")
+	writeUsageLine(w, "  gestaltd validate [--config PATH]...")
 	writeUsageLine(w, "")
 	writeUsageLine(w, "Validate configuration without starting the server or running migrations.")
+	writeUsageLine(w, "Validation always stages source-backed providers in a temporary scratch dir.")
 	writeUsageLine(w, "Repeated --config flags merge left-to-right.")
 }
 

--- a/gestaltd/internal/operator/lifecycle.go
+++ b/gestaltd/internal/operator/lifecycle.go
@@ -12,6 +12,7 @@ import (
 	"net/http"
 	"os"
 	"path/filepath"
+	"runtime"
 	"slices"
 	"strconv"
 	"strings"
@@ -150,82 +151,11 @@ func (l *Lifecycle) initAtPaths(configPaths []string, artifactsDir string) (*Loc
 		return nil, nil, fmt.Errorf("loading config: %v", err)
 	}
 	paths := initPathsForConfigsWithArtifactsDir(configPaths, resolveArtifactsDir(configPath, cfg, artifactsDir))
-	secretsEntries, err := l.primeSecretsProviderForConfigResolution(context.Background(), paths, cfg, nil)
+	lock, err := l.prepareRuntimeLockFromLoadedConfig(context.Background(), paths, cfg)
 	if err != nil {
 		return nil, nil, err
 	}
-	if err := l.resolveConfigSecrets(context.Background(), cfg); err != nil {
-		return nil, nil, err
-	}
-	if err := os.MkdirAll(paths.providersDir, 0o755); err != nil {
-		return nil, nil, fmt.Errorf("creating providers dir: %w", err)
-	}
-
-	lock := newLockfile()
-
-	resolvedProviders, err := l.writeProviderArtifacts(context.Background(), cfg, paths)
-	if err != nil {
-		return nil, nil, err
-	}
-	for name := range resolvedProviders {
-		lock.Providers[name] = resolvedProviders[name]
-	}
-	for _, collection := range hostProviderCollections(cfg) {
-		for name, entry := range collection.entries {
-			if entry == nil || !entry.HasManagedSource() {
-				continue
-			}
-			if collection.kind == config.HostProviderKindSecrets {
-				if _, alreadyPrepared := secretsEntries[name]; alreadyPrepared {
-					continue
-				}
-			}
-			destDir := componentDestDir(paths, collection.kind, name)
-			lockEntry, err := l.writeComponentArtifact(context.Background(), paths, providerManifestKind(collection.kind), name, destDir, entry, entry.Config)
-			if err != nil {
-				return nil, nil, err
-			}
-			lockEntriesForKind(lock, collection.kind)[name] = lockEntry
-		}
-	}
-	if err := l.resolveConfiguredPlugins(paths, lock, cfg, true); err != nil {
-		return nil, nil, err
-	}
-	if err := synthesizePluginOwnedUIEntries(cfg); err != nil {
-		return nil, nil, err
-	}
-	for name, lockEntry := range secretsEntries {
-		lock.Secrets[name] = lockEntry
-	}
-	for name, def := range cfg.Providers.IndexedDB {
-		if def != nil && def.HasManagedSource() {
-			entry, err := l.writeComponentArtifact(context.Background(), paths, providermanifestv1.KindIndexedDB, name, indexeddbDestDir(paths, name), def, def.Config)
-			if err != nil {
-				return nil, nil, err
-			}
-			lock.IndexedDBs[name] = entry
-		}
-	}
-	for name, def := range cfg.Providers.S3 {
-		if def != nil && def.HasManagedSource() {
-			entry, err := l.writeComponentArtifact(context.Background(), paths, providermanifestv1.KindS3, name, s3DestDir(paths, name), def, def.Config)
-			if err != nil {
-				return nil, nil, err
-			}
-			lock.S3[name] = entry
-		}
-	}
-	for name, entry := range cfg.Providers.UI {
-		if entry != nil && entry.HasManagedSource() {
-			uiEntry, err := l.writeNamedUIProviderArtifact(context.Background(), paths, name, &entry.ProviderEntry, uiDestDir(paths, name), "ui "+strconv.Quote(name))
-			if err != nil {
-				return nil, nil, err
-			}
-			lock.UIs[name] = uiEntry
-		}
-	}
-
-	if err := l.applyLockedProviders(configPaths, artifactsDir, cfg, true, lock); err != nil {
+	if err := l.applyPreparedProviders(paths, lock, cfg, true); err != nil {
 		return nil, nil, err
 	}
 	if err := config.ValidateResolvedStructure(cfg); err != nil {
@@ -241,6 +171,92 @@ func (l *Lifecycle) initAtPaths(configPaths []string, artifactsDir string) (*Loc
 	slog.Info("prepared locked artifacts", "providers", len(lock.Providers), "auth", len(lock.Auth), "indexeddbs", len(lock.IndexedDBs), "cache", len(lock.Caches), "s3", len(lock.S3), "secrets", len(lock.Secrets), "telemetry", len(lock.Telemetry), "audit", len(lock.Audit), "uis", len(lock.UIs))
 	slog.Info("wrote lockfile", "path", paths.lockfilePath)
 	return lock, cfg, nil
+}
+
+func (l *Lifecycle) prepareRuntimeLockFromLoadedConfig(ctx context.Context, paths initPaths, cfg *config.Config) (*Lockfile, error) {
+	secretsEntries, err := l.primeSecretsProviderForConfigResolution(ctx, paths, cfg, nil)
+	if err != nil {
+		return nil, err
+	}
+	if err := l.resolveConfigSecrets(ctx, cfg); err != nil {
+		return nil, err
+	}
+	if err := os.MkdirAll(paths.providersDir, 0o755); err != nil {
+		return nil, fmt.Errorf("creating providers dir: %w", err)
+	}
+
+	lock := newLockfile()
+	resolvedProviders, err := l.writeProviderArtifacts(ctx, cfg, paths)
+	if err != nil {
+		return nil, err
+	}
+	for name := range resolvedProviders {
+		lock.Providers[name] = resolvedProviders[name]
+	}
+	for _, collection := range hostProviderCollections(cfg) {
+		for name, entry := range collection.entries {
+			if entry == nil || !sourceBacked(entry) {
+				continue
+			}
+			if collection.kind == config.HostProviderKindSecrets {
+				if _, alreadyPrepared := secretsEntries[name]; alreadyPrepared {
+					continue
+				}
+			}
+			destDir := componentDestDir(paths, collection.kind, name)
+			lockEntry, err := l.writeComponentArtifact(ctx, paths, providerManifestKind(collection.kind), name, destDir, entry, entry.Config)
+			if err != nil {
+				return nil, err
+			}
+			lockEntriesForKind(lock, collection.kind)[name] = lockEntry
+		}
+	}
+	if err := l.resolveConfiguredPlugins(paths, lock, cfg, true); err != nil {
+		return nil, err
+	}
+	existingUIEntries := make(map[string]struct{}, len(cfg.Providers.UI))
+	for name := range cfg.Providers.UI {
+		existingUIEntries[name] = struct{}{}
+	}
+	if err := synthesizePluginOwnedUIEntries(cfg); err != nil {
+		return nil, err
+	}
+	for name, lockEntry := range secretsEntries {
+		lock.Secrets[name] = lockEntry
+	}
+	for name, def := range cfg.Providers.IndexedDB {
+		if sourceBacked(def) {
+			entry, err := l.writeComponentArtifact(ctx, paths, providermanifestv1.KindIndexedDB, name, indexeddbDestDir(paths, name), def, def.Config)
+			if err != nil {
+				return nil, err
+			}
+			lock.IndexedDBs[name] = entry
+		}
+	}
+	for name, def := range cfg.Providers.S3 {
+		if sourceBacked(def) {
+			entry, err := l.writeComponentArtifact(ctx, paths, providermanifestv1.KindS3, name, s3DestDir(paths, name), def, def.Config)
+			if err != nil {
+				return nil, err
+			}
+			lock.S3[name] = entry
+		}
+	}
+	for name, entry := range cfg.Providers.UI {
+		if entry != nil && sourceBacked(&entry.ProviderEntry) {
+			if _, existed := existingUIEntries[name]; !existed && entry.HasLocalSource() {
+				if plugin := cfg.Plugins[name]; plugin != nil && strings.TrimSpace(plugin.UI) == "" && strings.TrimSpace(plugin.MountPath) != "" {
+					continue
+				}
+			}
+			uiEntry, err := l.writeNamedUIProviderArtifact(ctx, paths, name, &entry.ProviderEntry, uiDestDir(paths, name), "ui "+strconv.Quote(name))
+			if err != nil {
+				return nil, err
+			}
+			lock.UIs[name] = uiEntry
+		}
+	}
+	return lock, nil
 }
 
 func buildSourceTokenMap(cfg *config.Config) map[string]string {
@@ -303,11 +319,8 @@ func (l *Lifecycle) LoadForExecutionAtPathsWithArtifactsDir(configPaths []string
 	if err != nil {
 		return nil, nil, fmt.Errorf("loading config: %v", err)
 	}
-	if err := synthesizeLocalSourcePluginOwnedUIEntries(cfg); err != nil {
-		return nil, nil, fmt.Errorf("loading config: %v", err)
-	}
 	paths := initPathsForConfigsWithArtifactsDir(configPaths, resolveArtifactsDir(configPath, cfg, artifactsDir))
-	secretsLock, err := l.lockForSecretsBootstrap(configPaths, artifactsDir, paths, cfg, locked)
+	secretsLock, secretsValidated, err := l.lockForSecretsBootstrap(configPaths, artifactsDir, paths, cfg, locked)
 	if err != nil {
 		return nil, nil, err
 	}
@@ -321,16 +334,45 @@ func (l *Lifecycle) LoadForExecutionAtPathsWithArtifactsDir(configPaths []string
 		return nil, nil, err
 	}
 
-	if err := l.applyLockedProviders(configPaths, artifactsDir, cfg, locked, nil); err != nil {
+	dependenciesValidated, err := l.applyLockedProviders(configPaths, artifactsDir, cfg, locked, secretsLock)
+	if err != nil {
 		return nil, nil, err
 	}
 	if err := config.ValidateResolvedStructure(cfg); err != nil {
 		return nil, nil, err
 	}
-	if err := plugininvocation.ValidateDependencies(context.Background(), cfg); err != nil {
-		return nil, nil, err
+	if !secretsValidated && !dependenciesValidated {
+		if err := plugininvocation.ValidateDependencies(context.Background(), cfg); err != nil {
+			return nil, nil, err
+		}
 	}
 	return cfg, nil, nil
+}
+
+func (l *Lifecycle) LoadForValidationAtPathsWithArtifactsDir(configPaths []string, artifactsDir string) (*config.Config, error) {
+	configPath := primaryConfigPath(configPaths)
+	cfg, err := config.LoadPaths(configPaths)
+	if err != nil {
+		return nil, fmt.Errorf("loading config: %v", err)
+	}
+	paths := initPathsForConfigsWithArtifactsDir(configPaths, resolveArtifactsDir(configPath, cfg, artifactsDir))
+	lock, err := l.prepareRuntimeLockFromLoadedConfig(context.Background(), paths, cfg)
+	if err != nil {
+		return nil, err
+	}
+	if err := config.ValidateRuntime(cfg); err != nil {
+		return nil, err
+	}
+	if err := l.applyPreparedProviders(paths, lock, cfg, true); err != nil {
+		return nil, err
+	}
+	if err := config.ValidateResolvedStructure(cfg); err != nil {
+		return nil, err
+	}
+	if err := plugininvocation.ValidateDependencies(context.Background(), cfg); err != nil {
+		return nil, err
+	}
+	return cfg, nil
 }
 
 func (l *Lifecycle) resolveConfigSecrets(ctx context.Context, cfg *config.Config) error {
@@ -358,36 +400,80 @@ func referencedConfigSecretsProviders(cfg *config.Config) (map[string]*config.Pr
 	return entries, nil
 }
 
-func (l *Lifecycle) lockForSecretsBootstrap(configPaths []string, artifactsDir string, paths initPaths, cfg *config.Config, locked bool) (*Lockfile, error) {
-	if cfg == nil {
+func secretsProviderMetadataDependencies(name string, provider *config.ProviderEntry) (map[string]struct{}, error) {
+	if provider == nil {
 		return nil, nil
 	}
-	referenced, err := referencedConfigSecretsProviders(cfg)
+	tmp := &config.Config{
+		Providers: config.ProvidersConfig{
+			Secrets: map[string]*config.ProviderEntry{
+				name: provider,
+			},
+		},
+	}
+	deps, err := config.ReferencedConfigSecretProviders(tmp)
 	if err != nil {
 		return nil, err
 	}
-	needsManagedSecrets := false
+	delete(deps, name)
+	if len(deps) == 0 {
+		return nil, nil
+	}
+	return deps, nil
+}
+
+func (l *Lifecycle) resolveSecretsProviderMetadata(ctx context.Context, name string, provider *config.ProviderEntry, available map[string]*config.ProviderEntry) error {
+	if l.configSecretResolver == nil || provider == nil {
+		return nil
+	}
+	secrets := make(map[string]*config.ProviderEntry, len(available)+1)
+	for availableName, entry := range available {
+		secrets[availableName] = entry
+	}
+	secrets[name] = provider
+	tmp := &config.Config{
+		Providers: config.ProvidersConfig{
+			Secrets: secrets,
+		},
+	}
+	if err := l.configSecretResolver(ctx, tmp); err != nil {
+		return fmt.Errorf("resolve metadata for %s %q: %w", providermanifestv1.KindSecrets, name, err)
+	}
+	return nil
+}
+
+func (l *Lifecycle) lockForSecretsBootstrap(configPaths []string, artifactsDir string, paths initPaths, cfg *config.Config, locked bool) (*Lockfile, bool, error) {
+	if cfg == nil {
+		return nil, false, nil
+	}
+	referenced, err := referencedConfigSecretsProviders(cfg)
+	if err != nil {
+		return nil, false, err
+	}
+	needsPreparedSecrets := false
 	for _, provider := range referenced {
-		if provider != nil && provider.HasManagedSource() {
-			needsManagedSecrets = true
+		if sourceBacked(provider) {
+			needsPreparedSecrets = true
 			break
 		}
 	}
-	if !needsManagedSecrets {
-		return nil, nil
+	if !needsPreparedSecrets {
+		return nil, false, nil
 	}
-	if !configHasManagedProviderSources(cfg) {
-		return nil, nil
+	if !configHasProviderLoading(cfg) {
+		return nil, false, nil
 	}
 
 	lock, err := ReadLockfile(paths.lockfilePath)
-	if !locked && (err != nil || !lockMatchesConfig(cfg, paths, lock)) {
+	validatedDuringInit := false
+	if !locked && (err != nil || !lockMatchesConfig(cfg, paths, lock) || configHasLocalProviderSources(cfg)) {
 		lock, err = l.InitAtPathsWithArtifactsDir(configPaths, artifactsDir)
+		validatedDuringInit = err == nil
 	}
 	if err != nil {
-		return nil, fmt.Errorf("managed providers require prepared artifacts; run `gestaltd init %s`: %w", formatConfigFlags(configPaths), err)
+		return nil, false, fmt.Errorf("source-backed providers require prepared artifacts; run `gestaltd init %s`: %w", formatConfigFlags(configPaths), err)
 	}
-	return lock, nil
+	return lock, validatedDuringInit, nil
 }
 
 func (l *Lifecycle) primeSecretsProviderForConfigResolution(ctx context.Context, paths initPaths, cfg *config.Config, lock *Lockfile) (map[string]LockEntry, error) {
@@ -405,18 +491,10 @@ func (l *Lifecycle) primeSecretsProviderForConfigResolution(ctx context.Context,
 		if provider == nil {
 			continue
 		}
-		tmp := &config.Config{
-			Providers: config.ProvidersConfig{
-				Secrets: map[string]*config.ProviderEntry{
-					name: provider,
-				},
-			},
-		}
-		deps, err := config.ReferencedConfigSecretProviders(tmp)
+		deps, err := secretsProviderMetadataDependencies(name, provider)
 		if err != nil {
 			return nil, err
 		}
-		delete(deps, name)
 		dependencies[name] = deps
 		if provider.Source.IsBuiltin() {
 			available[name] = provider
@@ -448,28 +526,15 @@ func (l *Lifecycle) primeSecretsProviderForConfigResolution(ctx context.Context,
 			if !ready {
 				continue
 			}
-			if l.configSecretResolver != nil {
-				secrets := make(map[string]*config.ProviderEntry, len(available)+1)
-				for availableName, entry := range available {
-					secrets[availableName] = entry
-				}
-				secrets[name] = provider
-				tmp := &config.Config{
-					Providers: config.ProvidersConfig{
-						Secrets: secrets,
-					},
-				}
-				if err := l.configSecretResolver(ctx, tmp); err != nil {
-					return nil, fmt.Errorf("resolve metadata for %s %q: %w", providermanifestv1.KindSecrets, name, err)
-				}
+			if err := l.resolveSecretsProviderMetadata(ctx, name, provider, available); err != nil {
+				return nil, err
 			}
 			configMap, err := config.NodeToMap(provider.Config)
 			if err != nil {
 				return nil, fmt.Errorf("decode provider config for %s %q: %w", providermanifestv1.KindSecrets, name, err)
 			}
 
-			switch {
-			case provider.HasManagedSource():
+			if sourceBacked(provider) {
 				if lock != nil {
 					lockEntry, ok := lock.Secrets[name]
 					if !ok {
@@ -487,10 +552,6 @@ func (l *Lifecycle) primeSecretsProviderForConfigResolution(ctx context.Context,
 						return nil, err
 					}
 					prepared[name] = entry
-				}
-			case provider.HasLocalSource():
-				if err := applyLocalComponentManifest(providermanifestv1.KindSecrets, name, provider, configMap); err != nil {
-					return nil, err
 				}
 			}
 
@@ -562,6 +623,11 @@ type providerFingerprintInput struct {
 	Name    string `json:"name"`
 	Source  string `json:"source,omitempty"`
 	Version string `json:"version,omitempty"`
+	Path    string `json:"path,omitempty"`
+}
+
+func sourceBacked(entry *config.ProviderEntry) bool {
+	return entry != nil && (entry.HasManagedSource() || entry.HasLocalSource())
 }
 
 func hostProviderCollections(cfg *config.Config) []struct {
@@ -604,60 +670,60 @@ func lockEntriesForKind(lock *Lockfile, kind config.HostProviderKind) map[string
 
 func configHasProviderLoading(cfg *config.Config) bool {
 	for _, entry := range cfg.Plugins {
-		if entry.HasManagedSource() || entry.HasLocalSource() {
+		if sourceBacked(entry) {
 			return true
 		}
 	}
 	for _, collection := range hostProviderCollections(cfg) {
 		for _, entry := range collection.entries {
-			if entry != nil && (entry.HasManagedSource() || entry.HasLocalSource()) {
+			if sourceBacked(entry) {
 				return true
 			}
 		}
 	}
 	for _, entry := range cfg.Providers.UI {
-		if entry != nil && (entry.HasManagedSource() || entry.HasLocalSource()) {
+		if entry != nil && sourceBacked(&entry.ProviderEntry) {
 			return true
 		}
 	}
 	for _, def := range cfg.Providers.IndexedDB {
-		if def != nil && (def.HasManagedSource() || def.HasLocalSource()) {
+		if sourceBacked(def) {
 			return true
 		}
 	}
 	for _, def := range cfg.Providers.S3 {
-		if def != nil && (def.HasManagedSource() || def.HasLocalSource()) {
+		if sourceBacked(def) {
 			return true
 		}
 	}
 	return false
 }
 
-func configHasManagedProviderSources(cfg *config.Config) bool {
+func configHasLocalProviderSources(cfg *config.Config) bool {
 	for _, entry := range cfg.Plugins {
-		if entry.HasManagedSource() {
+		if entry.HasLocalSource() {
 			return true
 		}
 	}
 	for _, collection := range hostProviderCollections(cfg) {
 		for _, entry := range collection.entries {
-			if entry != nil && entry.HasManagedSource() {
+			if entry != nil && entry.HasLocalSource() {
 				return true
 			}
 		}
 	}
 	for _, entry := range cfg.Providers.UI {
-		if entry != nil && entry.HasManagedSource() {
+		if entry != nil && entry.HasLocalSource() {
 			return true
 		}
 	}
 	for _, def := range cfg.Providers.IndexedDB {
-		if def != nil && def.HasManagedSource() {
+		if def != nil && def.HasLocalSource() {
 			return true
 		}
 	}
 	for _, def := range cfg.Providers.S3 {
-		if def != nil && def.HasManagedSource() {
+		if def != nil && def.HasLocalSource() {
 			return true
 		}
 	}
@@ -876,7 +942,7 @@ func lockMatchesConfig(cfg *config.Config, paths initPaths, lock *Lockfile) bool
 		return false
 	}
 	for name, entry := range cfg.Plugins {
-		if !entry.HasManagedSource() {
+		if !sourceBacked(entry) {
 			continue
 		}
 		lockEntry, found := lock.Providers[name]
@@ -887,7 +953,7 @@ func lockMatchesConfig(cfg *config.Config, paths initPaths, lock *Lockfile) bool
 	for _, collection := range hostProviderCollections(cfg) {
 		lockEntries := lockEntriesForKind(lock, collection.kind)
 		for name, entry := range collection.entries {
-			if entry == nil || !entry.HasManagedSource() {
+			if entry == nil || !sourceBacked(entry) {
 				continue
 			}
 			lockEntry, found := lockEntries[name]
@@ -897,7 +963,7 @@ func lockMatchesConfig(cfg *config.Config, paths initPaths, lock *Lockfile) bool
 		}
 	}
 	for name, entry := range cfg.Providers.IndexedDB {
-		if entry == nil || !entry.HasManagedSource() {
+		if !sourceBacked(entry) {
 			continue
 		}
 		lockEntry, found := lock.IndexedDBs[name]
@@ -906,7 +972,7 @@ func lockMatchesConfig(cfg *config.Config, paths initPaths, lock *Lockfile) bool
 		}
 	}
 	for name, entry := range cfg.Providers.S3 {
-		if entry == nil || !entry.HasManagedSource() {
+		if !sourceBacked(entry) {
 			continue
 		}
 		lockEntry, found := lock.S3[name]
@@ -915,7 +981,7 @@ func lockMatchesConfig(cfg *config.Config, paths initPaths, lock *Lockfile) bool
 		}
 	}
 	for name, entry := range cfg.Providers.UI {
-		if entry == nil || !entry.HasManagedSource() {
+		if entry == nil || !sourceBacked(&entry.ProviderEntry) {
 			continue
 		}
 		lockEntry, ok := lock.UIs[name]
@@ -952,6 +1018,9 @@ func ProviderFingerprint(name string, entry *config.ProviderEntry, configDir str
 		Name:    name,
 		Source:  entry.SourceRef(),
 		Version: entry.SourceVersion(),
+	}
+	if entry.HasLocalSource() {
+		input.Path = entry.SourcePath()
 	}
 
 	payload, err := json.Marshal(input)
@@ -1157,6 +1226,133 @@ func (l *Lifecycle) buildArchivesMap(ctx context.Context, src pluginsource.Sourc
 	return archives, nil
 }
 
+func prepareLocalSourceInstall(kind, name, manifestPath, destDir string) (*preparedInstall, error) {
+	if strings.TrimSpace(manifestPath) == "" {
+		return nil, fmt.Errorf("manifest path for %s %q is required", kind, name)
+	}
+	if _, err := os.Stat(manifestPath); err != nil {
+		return nil, fmt.Errorf("manifest for %s %q not found at %s: %w", kind, name, manifestPath, err)
+	}
+	parentDir := filepath.Dir(destDir)
+	if err := os.MkdirAll(parentDir, 0o755); err != nil {
+		return nil, fmt.Errorf("create destination parent directory: %w", err)
+	}
+	tempDir, err := os.MkdirTemp(parentDir, filepath.Base(destDir)+".tmp-*")
+	if err != nil {
+		return nil, fmt.Errorf("create temp install directory: %w", err)
+	}
+	cleanupDir := tempDir
+	defer func() {
+		if cleanupDir != "" {
+			_ = os.RemoveAll(cleanupDir)
+		}
+	}()
+
+	stageKind := kind
+	if stageKind == providerLockKindTelemetry || stageKind == providerLockKindAudit {
+		stageKind = providermanifestv1.KindPlugin
+	}
+	if _, err := providerpkg.StageSourcePreparedInstallDir(manifestPath, tempDir, providerpkg.StageSourcePreparedInstallOptions{
+		Kind:       stageKind,
+		PluginName: name,
+		GOOS:       runtime.GOOS,
+		GOARCH:     runtime.GOARCH,
+	}); err != nil {
+		return nil, fmt.Errorf("prepare manifest for %s %q: %w", kind, name, err)
+	}
+
+	backupDir := ""
+	if _, err := os.Stat(destDir); err == nil {
+		backupDir = destDir + ".backup-" + strconv.FormatInt(time.Now().UnixNano(), 10)
+		if err := os.Rename(destDir, backupDir); err != nil {
+			return nil, fmt.Errorf("stage existing provider cache at %s: %w", destDir, err)
+		}
+	} else if !os.IsNotExist(err) {
+		return nil, fmt.Errorf("inspect existing provider cache at %s: %w", destDir, err)
+	}
+	if err := os.Rename(tempDir, destDir); err != nil {
+		if backupDir != "" {
+			if restoreErr := os.Rename(backupDir, destDir); restoreErr != nil {
+				return nil, fmt.Errorf("activate prepared install at %s: %w (rollback failed: %v)", destDir, err, restoreErr)
+			}
+		}
+		return nil, fmt.Errorf("activate prepared install at %s: %w", destDir, err)
+	}
+	cleanupDir = ""
+	if backupDir != "" {
+		if err := os.RemoveAll(backupDir); err != nil {
+			return nil, fmt.Errorf("remove staged provider cache backup at %s: %w", backupDir, err)
+		}
+	}
+	install, err := inspectPreparedInstall(destDir)
+	if err != nil {
+		return nil, fmt.Errorf("inspect prepared install for %s %q: %w", kind, name, err)
+	}
+	return install, nil
+}
+
+func relativePreparedPath(artifactsDir, path string) (string, error) {
+	if strings.TrimSpace(path) == "" {
+		return "", nil
+	}
+	rel, err := filepath.Rel(artifactsDir, path)
+	if err != nil {
+		return "", err
+	}
+	return filepath.ToSlash(rel), nil
+}
+
+func pathWithinRoot(root, target string) bool {
+	if strings.TrimSpace(root) == "" || strings.TrimSpace(target) == "" {
+		return false
+	}
+	rel, err := filepath.Rel(root, target)
+	if err != nil {
+		return false
+	}
+	return rel == "." || (rel != ".." && !strings.HasPrefix(rel, ".."+string(os.PathSeparator)))
+}
+
+func localLockEntryFromPreparedInstall(paths initPaths, kind, name string, plugin *config.ProviderEntry, install *preparedInstall) (LockEntry, error) {
+	fingerprint, err := ProviderFingerprint(name, plugin, paths.configDir)
+	if err != nil {
+		return LockEntry{}, fmt.Errorf("fingerprinting %s %q provider: %w", kind, name, err)
+	}
+	manifestPath, err := relativePreparedPath(paths.artifactsDir, install.manifestPath)
+	if err != nil {
+		return LockEntry{}, fmt.Errorf("compute manifest path for %s %q: %w", kind, name, err)
+	}
+	executablePath, err := relativePreparedPath(paths.artifactsDir, install.executablePath)
+	if err != nil {
+		return LockEntry{}, fmt.Errorf("compute executable path for %s %q: %w", kind, name, err)
+	}
+	return LockEntry{
+		Fingerprint: fingerprint,
+		Manifest:    manifestPath,
+		Executable:  executablePath,
+	}, nil
+}
+
+func localUILockEntryFromPreparedInstall(paths initPaths, name string, plugin *config.ProviderEntry, install *preparedInstall) (LockUIEntry, error) {
+	fingerprint, err := NamedUIProviderFingerprint(name, plugin)
+	if err != nil {
+		return LockUIEntry{}, fmt.Errorf("fingerprinting ui %q: %w", name, err)
+	}
+	manifestPath, err := relativePreparedPath(paths.artifactsDir, install.manifestPath)
+	if err != nil {
+		return LockUIEntry{}, fmt.Errorf("compute manifest path for ui %q: %w", name, err)
+	}
+	assetRoot, err := relativePreparedPath(paths.artifactsDir, install.assetRootPath)
+	if err != nil {
+		return LockUIEntry{}, fmt.Errorf("compute asset root path for ui %q: %w", name, err)
+	}
+	return LockUIEntry{
+		Fingerprint: fingerprint,
+		Manifest:    manifestPath,
+		AssetRoot:   assetRoot,
+	}, nil
+}
+
 func (l *Lifecycle) writeProviderArtifacts(ctx context.Context, cfg *config.Config, paths initPaths) (map[string]LockProviderEntry, error) {
 	written := make(map[string]LockProviderEntry)
 	for name, entry := range cfg.Plugins {
@@ -1167,7 +1363,7 @@ func (l *Lifecycle) writeProviderArtifacts(ctx context.Context, cfg *config.Conf
 		if err != nil {
 			return nil, fmt.Errorf("decode provider config for provider %q: %w", name, err)
 		}
-		if !entry.HasManagedSource() {
+		if !sourceBacked(entry) {
 			continue
 		}
 		lockEntry, err := l.lockProviderEntryForSource(ctx, paths, name, entry, configMap)
@@ -1189,6 +1385,20 @@ func (l *Lifecycle) writeComponentArtifact(ctx context.Context, paths initPaths,
 }
 
 func (l *Lifecycle) lockComponentEntryForSource(ctx context.Context, paths initPaths, kind, name, destDir string, plugin *config.ProviderEntry, configMap map[string]any) (LockEntry, error) {
+	if plugin != nil && plugin.HasLocalSource() {
+		install, err := prepareLocalSourceInstall(kind, name, plugin.SourcePath(), destDir)
+		if err != nil {
+			return LockEntry{}, err
+		}
+		if err := validateInstalledManifestKind(kind, name, install.manifest); err != nil {
+			return LockEntry{}, err
+		}
+		if err := providerpkg.ValidateConfigForManifest(install.manifestPath, install.manifest, kind, configMap); err != nil {
+			return LockEntry{}, fmt.Errorf("provider config validation for %s %q: %w", kind, name, err)
+		}
+		return localLockEntryFromPreparedInstall(paths, kind, name, plugin, install)
+	}
+
 	src, err := sourceForProvider(plugin)
 	if err != nil {
 		return LockEntry{}, fmt.Errorf("%s %q source.ref %q: %w", kind, name, plugin.SourceRef(), err)
@@ -1250,6 +1460,20 @@ func (l *Lifecycle) lockComponentEntryForSource(ctx context.Context, paths initP
 }
 
 func (l *Lifecycle) lockProviderEntryForSource(ctx context.Context, paths initPaths, name string, plugin *config.ProviderEntry, configMap map[string]any) (LockProviderEntry, error) {
+	if plugin != nil && plugin.HasLocalSource() {
+		install, err := prepareLocalSourceInstall(providermanifestv1.KindPlugin, name, plugin.SourcePath(), providerDestDir(paths, name))
+		if err != nil {
+			return LockProviderEntry{}, err
+		}
+		if err := validateInstalledManifestKind(providermanifestv1.KindPlugin, name, install.manifest); err != nil {
+			return LockProviderEntry{}, err
+		}
+		if err := providerpkg.ValidateConfigForManifest(install.manifestPath, install.manifest, providermanifestv1.KindPlugin, configMap); err != nil {
+			return LockProviderEntry{}, fmt.Errorf("provider config validation for provider %q: %w", name, err)
+		}
+		return localLockEntryFromPreparedInstall(paths, providermanifestv1.KindPlugin, name, plugin, install)
+	}
+
 	src, err := sourceForProvider(plugin)
 	if err != nil {
 		return LockProviderEntry{}, fmt.Errorf("provider %q source.ref %q: %w", name, plugin.SourceRef(), err)
@@ -1312,8 +1536,8 @@ func (l *Lifecycle) lockProviderEntryForSource(ctx context.Context, paths initPa
 }
 
 func (l *Lifecycle) writeNamedUIProviderArtifact(ctx context.Context, paths initPaths, name string, plugin *config.ProviderEntry, destDir string, subject string) (LockUIEntry, error) {
-	if plugin == nil || !plugin.HasManagedSource() {
-		return LockUIEntry{}, fmt.Errorf("%s requires managed source", subject)
+	if plugin == nil || !sourceBacked(plugin) {
+		return LockUIEntry{}, fmt.Errorf("%s requires source configuration", subject)
 	}
 	configMap, err := config.NodeToMap(plugin.Config)
 	if err != nil {
@@ -1322,6 +1546,24 @@ func (l *Lifecycle) writeNamedUIProviderArtifact(ctx context.Context, paths init
 	fingerprint, err := NamedUIProviderFingerprint(name, plugin)
 	if err != nil {
 		return LockUIEntry{}, fmt.Errorf("fingerprinting %s: %w", subject, err)
+	}
+	if plugin.HasLocalSource() {
+		install, err := prepareLocalSourceInstall(providermanifestv1.KindWebUI, name, plugin.SourcePath(), destDir)
+		if err != nil {
+			return LockUIEntry{}, err
+		}
+		if err := validateInstalledManifestKind(providermanifestv1.KindWebUI, subject, install.manifest); err != nil {
+			return LockUIEntry{}, err
+		}
+		if err := providerpkg.ValidateConfigForManifest(install.manifestPath, install.manifest, providermanifestv1.KindWebUI, configMap); err != nil {
+			return LockUIEntry{}, fmt.Errorf("provider config validation for %s: %w", subject, err)
+		}
+		entry, err := localUILockEntryFromPreparedInstall(paths, name, plugin, install)
+		if err != nil {
+			return LockUIEntry{}, err
+		}
+		entry.Fingerprint = fingerprint
+		return entry, nil
 	}
 
 	src, err := sourceForProvider(plugin)
@@ -1387,45 +1629,22 @@ func sourceForProvider(providerEntry *config.ProviderEntry) (pluginsource.Source
 	return src, nil
 }
 
-func (l *Lifecycle) applyLockedProviders(configPaths []string, artifactsDir string, cfg *config.Config, locked bool, preparedLock *Lockfile) error {
+func (l *Lifecycle) applyPreparedProviders(paths initPaths, lock *Lockfile, cfg *config.Config, locked bool) error {
 	if !configHasProviderLoading(cfg) {
 		return nil
 	}
 
-	configPath := primaryConfigPath(configPaths)
-	paths := initPathsForConfigsWithArtifactsDir(configPaths, resolveArtifactsDir(configPath, cfg, artifactsDir))
-	var lock *Lockfile
-	var err error
-	if configHasManagedProviderSources(cfg) {
-		var synthesizedLockedPluginUIs map[string]struct{}
-		lock = preparedLock
-		if lock == nil {
-			lock, err = ReadLockfile(paths.lockfilePath)
-			if err == nil {
-				synthesizedLockedPluginUIs, err = synthesizeLockedSourcePluginOwnedUIEntries(cfg, paths, lock)
-				if err != nil {
-					clearSynthesizedPluginOwnedUIEntries(cfg, synthesizedLockedPluginUIs)
-				}
-			}
-			if !locked && (err != nil || !lockMatchesConfig(cfg, paths, lock)) {
-				clearSynthesizedPluginOwnedUIEntries(cfg, synthesizedLockedPluginUIs)
-				lock, err = l.InitAtPathsWithArtifactsDir(configPaths, artifactsDir)
-			}
-		} else {
-			synthesizedLockedPluginUIs, err = synthesizeLockedSourcePluginOwnedUIEntries(cfg, paths, lock)
-			if err != nil {
-				clearSynthesizedPluginOwnedUIEntries(cfg, synthesizedLockedPluginUIs)
-			}
-		}
-		if err != nil {
-			return fmt.Errorf("managed providers require prepared artifacts; run `gestaltd init %s`: %w", formatConfigFlags(configPaths), err)
-		}
+	synthesizedPluginUIs, err := synthesizeLockedSourcePluginOwnedUIEntries(cfg, paths, lock)
+	if err != nil {
+		return err
 	}
 
 	if err := l.resolveConfiguredPlugins(paths, lock, cfg, locked); err != nil {
+		clearSynthesizedPluginOwnedUIEntries(cfg, synthesizedPluginUIs)
 		return err
 	}
 	if err := synthesizePluginOwnedUIEntries(cfg); err != nil {
+		clearSynthesizedPluginOwnedUIEntries(cfg, synthesizedPluginUIs)
 		return err
 	}
 	for _, collection := range hostProviderCollections(cfg) {
@@ -1435,6 +1654,7 @@ func (l *Lifecycle) applyLockedProviders(configPaths []string, artifactsDir stri
 				continue
 			}
 			if err := l.applyComponentProvider(paths, lockEntries, providerManifestKind(collection.kind), name, entry, entry.Config, &entry.Config, componentDestDir(paths, collection.kind, name), locked); err != nil {
+				clearSynthesizedPluginOwnedUIEntries(cfg, synthesizedPluginUIs)
 				return err
 			}
 		}
@@ -1446,6 +1666,7 @@ func (l *Lifecycle) applyLockedProviders(configPaths []string, artifactsDir stri
 	for name, def := range cfg.Providers.IndexedDB {
 		if def != nil {
 			if err := l.applyComponentProvider(paths, indexedDBLocks, providermanifestv1.KindIndexedDB, name, def, def.Config, &def.Config, indexeddbDestDir(paths, name), locked); err != nil {
+				clearSynthesizedPluginOwnedUIEntries(cfg, synthesizedPluginUIs)
 				return err
 			}
 		}
@@ -1457,6 +1678,7 @@ func (l *Lifecycle) applyLockedProviders(configPaths []string, artifactsDir stri
 	for name, def := range cfg.Providers.S3 {
 		if def != nil {
 			if err := l.applyComponentProvider(paths, s3Locks, providermanifestv1.KindS3, name, def, def.Config, &def.Config, s3DestDir(paths, name), locked); err != nil {
+				clearSynthesizedPluginOwnedUIEntries(cfg, synthesizedPluginUIs)
 				return err
 			}
 		}
@@ -1473,12 +1695,39 @@ func (l *Lifecycle) applyLockedProviders(configPaths []string, artifactsDir stri
 		}
 		resolvedAssetRoot, err := l.applyConfiguredUIProvider(paths, lockEntry, &entry.ProviderEntry, name, "ui "+strconv.Quote(name), uiDestDir(paths, name), locked)
 		if err != nil {
+			clearSynthesizedPluginOwnedUIEntries(cfg, synthesizedPluginUIs)
 			return err
 		}
 		entry.ResolvedAssetRoot = resolvedAssetRoot
 	}
 
 	return nil
+}
+
+func (l *Lifecycle) applyLockedProviders(configPaths []string, artifactsDir string, cfg *config.Config, locked bool, bootstrapLock *Lockfile) (bool, error) {
+	if !configHasProviderLoading(cfg) {
+		return false, nil
+	}
+
+	configPath := primaryConfigPath(configPaths)
+	paths := initPathsForConfigsWithArtifactsDir(configPaths, resolveArtifactsDir(configPath, cfg, artifactsDir))
+	lock := bootstrapLock
+	var err error
+	validatedDuringInit := false
+	if lock == nil {
+		lock, err = ReadLockfile(paths.lockfilePath)
+	}
+	if !locked && (err != nil || !lockMatchesConfig(cfg, paths, lock) || (bootstrapLock == nil && configHasLocalProviderSources(cfg))) {
+		lock, err = l.InitAtPathsWithArtifactsDir(configPaths, artifactsDir)
+		validatedDuringInit = err == nil
+	}
+	if err != nil {
+		return false, fmt.Errorf("source-backed providers require prepared artifacts; run `gestaltd init %s`: %w", formatConfigFlags(configPaths), err)
+	}
+	if err := l.applyPreparedProviders(paths, lock, cfg, locked); err != nil {
+		return false, err
+	}
+	return validatedDuringInit, nil
 }
 
 func installLockedPackageAtomic(packagePath, destDir string) (*pluginstore.InstalledPlugin, func() error, func() error, error) {
@@ -1543,12 +1792,8 @@ func (l *Lifecycle) resolveConfiguredPlugins(paths initPaths, lock *Lockfile, cf
 			return fmt.Errorf("decode provider config for provider %q: %w", name, err)
 		}
 		switch {
-		case entry.HasManagedSource():
+		case sourceBacked(entry):
 			if err := l.applyLockedProviderEntry(paths, lock, name, entry, configMap, locked); err != nil {
-				return err
-			}
-		case entry.HasLocalSource():
-			if err := applyLocalProviderManifest(name, entry, configMap); err != nil {
 				return err
 			}
 		default:
@@ -1606,54 +1851,6 @@ func synthesizePluginOwnedUIEntries(cfg *config.Config) error {
 	return nil
 }
 
-func synthesizeLocalSourcePluginOwnedUIEntries(cfg *config.Config) error {
-	if cfg == nil || len(cfg.Plugins) == 0 {
-		return nil
-	}
-	if cfg.Providers.UI == nil {
-		cfg.Providers.UI = map[string]*config.UIEntry{}
-	}
-	pluginNames := slices.Sorted(maps.Keys(cfg.Plugins))
-	for _, pluginName := range pluginNames {
-		plugin := cfg.Plugins[pluginName]
-		if plugin == nil || strings.TrimSpace(plugin.UI) != "" || strings.TrimSpace(plugin.MountPath) == "" || !plugin.HasLocalSource() {
-			continue
-		}
-		manifestPath := plugin.SourcePath()
-		if manifestPath == "" {
-			continue
-		}
-		_, manifest, err := providerpkg.ReadSourceManifestFile(manifestPath)
-		if err != nil {
-			return fmt.Errorf("prepare manifest for provider %q: %w", pluginName, err)
-		}
-		if manifest == nil || manifest.Spec == nil || manifest.Spec.UI == nil {
-			continue
-		}
-		entry, err := ownedUIEntryFromManifest(manifestPath, manifest.Version, manifest.Spec.UI)
-		if err != nil {
-			return fmt.Errorf("plugin %q ui: %w", pluginName, err)
-		}
-		entry.Path = strings.TrimSpace(plugin.MountPath)
-		entry.AuthorizationPolicy = strings.TrimSpace(plugin.AuthorizationPolicy)
-		entry.OwnerPlugin = pluginName
-		if existing := cfg.Providers.UI[pluginName]; existing != nil {
-			if err := validateSynthesizedPluginUIEntry(pluginName, existing, entry); err != nil {
-				return err
-			}
-			if existing.Source.Auth == nil && entry.Source.Auth != nil {
-				existing.Source.Auth = entry.Source.Auth
-			}
-			existing.Path = cmp.Or(existing.Path, entry.Path)
-			existing.AuthorizationPolicy = cmp.Or(existing.AuthorizationPolicy, entry.AuthorizationPolicy)
-			existing.OwnerPlugin = cmp.Or(existing.OwnerPlugin, entry.OwnerPlugin)
-			continue
-		}
-		cfg.Providers.UI[pluginName] = entry
-	}
-	return nil
-}
-
 func synthesizeLockedSourcePluginOwnedUIEntries(cfg *config.Config, paths initPaths, lock *Lockfile) (map[string]struct{}, error) {
 	added := map[string]struct{}{}
 	if cfg == nil || len(cfg.Plugins) == 0 || lock == nil {
@@ -1665,7 +1862,7 @@ func synthesizeLockedSourcePluginOwnedUIEntries(cfg *config.Config, paths initPa
 	pluginNames := slices.Sorted(maps.Keys(cfg.Plugins))
 	for _, pluginName := range pluginNames {
 		plugin := cfg.Plugins[pluginName]
-		if plugin == nil || strings.TrimSpace(plugin.UI) != "" || strings.TrimSpace(plugin.MountPath) == "" || !plugin.HasManagedSource() {
+		if plugin == nil || strings.TrimSpace(plugin.UI) != "" || strings.TrimSpace(plugin.MountPath) == "" || !sourceBacked(plugin) {
 			continue
 		}
 		lockEntry, ok := lock.Providers[pluginName]
@@ -1771,7 +1968,7 @@ func validateSynthesizedPluginUIEntry(pluginName string, existing, expected *con
 	if currentAuth != "" && currentAuth != expectedAuth {
 		return fmt.Errorf("config validation: plugins.%s owned ui conflicts with providers.ui.%s.source.auth.token", pluginName, pluginName)
 	}
-	if current := strings.TrimSpace(existing.Source.Path); current != "" && current != expected.Source.Path {
+	if current := strings.TrimSpace(existing.Source.Path); current != "" && !equivalentProviderManifestPath(current, expected.Source.Path) {
 		return fmt.Errorf("config validation: plugins.%s owned ui conflicts with providers.ui.%s.source.path", pluginName, pluginName)
 	}
 	if current := strings.TrimSpace(existing.Path); current != "" && current != expected.Path {
@@ -1786,6 +1983,26 @@ func validateSynthesizedPluginUIEntry(pluginName string, existing, expected *con
 	return nil
 }
 
+func equivalentProviderManifestPath(current, expected string) bool {
+	current = strings.TrimSpace(current)
+	expected = strings.TrimSpace(expected)
+	if current == expected {
+		return true
+	}
+	if current == "" || expected == "" {
+		return false
+	}
+	_, currentManifest, currentErr := providerpkg.ReadManifestFile(current)
+	_, expectedManifest, expectedErr := providerpkg.ReadManifestFile(expected)
+	if currentErr != nil || expectedErr != nil {
+		return false
+	}
+	return currentManifest != nil && expectedManifest != nil &&
+		currentManifest.Kind == expectedManifest.Kind &&
+		currentManifest.Source == expectedManifest.Source &&
+		currentManifest.Version == expectedManifest.Version
+}
+
 func (l *Lifecycle) applyConfiguredUIProvider(paths initPaths, lockEntry *LockUIEntry, provider *config.ProviderEntry, logicalName, subject, destDir string, locked bool) (string, error) {
 	if provider == nil {
 		return "", nil
@@ -1795,8 +2012,11 @@ func (l *Lifecycle) applyConfiguredUIProvider(paths initPaths, lockEntry *LockUI
 		return "", fmt.Errorf("decode %s config: %w", subject, err)
 	}
 	switch {
-	case provider.HasManagedSource():
+	case sourceBacked(provider):
 		if lockEntry == nil {
+			if provider.HasLocalSource() && pathWithinRoot(filepath.Join(paths.artifactsDir, ".gestaltd"), provider.SourcePath()) {
+				return bindPathBackedUIManifest(provider, configMap)
+			}
 			return "", fmt.Errorf("prepared artifact for %s is missing or stale; run `gestaltd init %s`", subject, paths.configFlags)
 		}
 		fingerprint, err := NamedUIProviderFingerprint(logicalName, provider)
@@ -1814,6 +2034,9 @@ func (l *Lifecycle) applyConfiguredUIProvider(paths initPaths, lockEntry *LockUI
 			}
 		}
 		if needMaterialize {
+			if len(lockEntry.Archives) == 0 {
+				return "", fmt.Errorf("prepared artifact for %s is missing or stale; run `gestaltd init %s`", subject, paths.configFlags)
+			}
 			if err := l.materializeLockedUIProvider(context.Background(), paths, provider, *lockEntry, destDir, locked); err != nil {
 				return "", err
 			}
@@ -1832,12 +2055,6 @@ func (l *Lifecycle) applyConfiguredUIProvider(paths initPaths, lockEntry *LockUI
 			return "", err
 		}
 		return install.assetRootPath, nil
-	case provider.HasLocalSource():
-		var resolvedAssetRoot string
-		if err := applyLocalUIManifest(provider, configMap, &resolvedAssetRoot); err != nil {
-			return "", err
-		}
-		return resolvedAssetRoot, nil
 	default:
 		return "", nil
 	}
@@ -1852,7 +2069,7 @@ func (l *Lifecycle) applyComponentProvider(paths initPaths, lockEntries map[stri
 		return fmt.Errorf("decode provider config for %s %q: %w", kind, name, err)
 	}
 	switch {
-	case provider.HasManagedSource():
+	case sourceBacked(provider):
 		if lockEntries == nil {
 			return fmt.Errorf("prepared artifact for %s %q is missing or stale; run `gestaltd init %s`", kind, name, paths.configFlags)
 		}
@@ -1861,10 +2078,6 @@ func (l *Lifecycle) applyComponentProvider(paths initPaths, lockEntries map[stri
 			return fmt.Errorf("prepared artifact for %s %q is missing or stale; run `gestaltd init %s`", kind, name, paths.configFlags)
 		}
 		if err := l.applyLockedComponentEntry(paths, &lockEntry, kind, name, provider, configMap, destDir, locked); err != nil {
-			return err
-		}
-	case provider.HasLocalSource():
-		if err := applyLocalComponentManifest(kind, name, provider, configMap); err != nil {
 			return err
 		}
 	default:
@@ -1876,91 +2089,6 @@ func (l *Lifecycle) applyComponentProvider(paths initPaths, lockEntries map[stri
 		return err
 	}
 	*targetNode = node
-	return nil
-}
-
-func applyLocalProviderManifest(name string, plugin *config.ProviderEntry, configMap map[string]any) error {
-	if plugin == nil || !plugin.HasLocalSource() {
-		return nil
-	}
-
-	manifestPath := plugin.SourcePath()
-	if _, err := os.Stat(manifestPath); err != nil {
-		return fmt.Errorf("manifest for provider %q not found at %s: %w", name, manifestPath, err)
-	}
-
-	_, manifest, err := providerpkg.PrepareSourceManifest(manifestPath)
-	if err != nil {
-		return fmt.Errorf("prepare manifest for provider %q: %w", name, err)
-	}
-	if err := bindResolvedProviderManifest(name, plugin, manifestPath, manifest, configMap); err != nil {
-		return err
-	}
-	if plugin.Command != "" {
-		return nil
-	}
-	if entry := providerpkg.EntrypointForKind(plugin.ResolvedManifest, providermanifestv1.KindPlugin); entry != nil {
-		candidate := filepath.Join(filepath.Dir(manifestPath), filepath.FromSlash(entry.ArtifactPath))
-		if _, err := os.Stat(candidate); err == nil {
-			plugin.Command = candidate
-			plugin.Args = append([]string(nil), entry.Args...)
-		}
-	}
-	return nil
-}
-
-func applyLocalComponentManifest(kind, name string, plugin *config.ProviderEntry, configMap map[string]any) error {
-	if plugin == nil || !plugin.HasLocalSource() {
-		return nil
-	}
-
-	manifestPath := plugin.SourcePath()
-	if _, err := os.Stat(manifestPath); err != nil {
-		return fmt.Errorf("manifest for %s %q not found at %s: %w", kind, name, manifestPath, err)
-	}
-
-	_, manifest, err := providerpkg.ReadSourceManifestFile(manifestPath)
-	if err != nil {
-		return fmt.Errorf("prepare manifest for %s %q: %w", kind, name, err)
-	}
-	if err := bindResolvedComponentManifest(kind, name, plugin, manifestPath, manifest, configMap); err != nil {
-		return err
-	}
-	if plugin.Command != "" {
-		return nil
-	}
-	if entry := providerpkg.EntrypointForKind(plugin.ResolvedManifest, kind); entry != nil {
-		candidate := filepath.Join(filepath.Dir(manifestPath), filepath.FromSlash(entry.ArtifactPath))
-		if _, err := os.Stat(candidate); err == nil {
-			plugin.Command = candidate
-			plugin.Args = append([]string(nil), entry.Args...)
-		}
-	}
-	return nil
-}
-
-func applyLocalUIManifest(plugin *config.ProviderEntry, configMap map[string]any, resolvedAssetRoot *string) error {
-	if plugin == nil || !plugin.HasLocalSource() {
-		return nil
-	}
-
-	manifestPath := plugin.SourcePath()
-	if _, err := os.Stat(manifestPath); err != nil {
-		return fmt.Errorf("manifest for ui provider not found at %s: %w", manifestPath, err)
-	}
-
-	_, manifest, err := providerpkg.ReadSourceManifestFile(manifestPath)
-	if err != nil {
-		return fmt.Errorf("prepare manifest for ui provider: %w", err)
-	}
-	if err := bindResolvedUIManifest(plugin, manifestPath, manifest, configMap); err != nil {
-		return err
-	}
-	assetRoot := filepath.Join(filepath.Dir(manifestPath), filepath.FromSlash(manifest.Spec.AssetRoot))
-	if _, err := os.Stat(assetRoot); err != nil {
-		return fmt.Errorf("ui provider asset root not found at %s: %w", assetRoot, err)
-	}
-	*resolvedAssetRoot = assetRoot
 	return nil
 }
 
@@ -1994,6 +2122,9 @@ func (l *Lifecycle) applyLockedProviderEntry(paths initPaths, lock *Lockfile, na
 		}
 	}
 	if needMaterialize {
+		if len(entry.Archives) == 0 {
+			return fmt.Errorf("prepared artifact for provider %q is missing or stale; run `gestaltd init %s`", name, paths.configFlags)
+		}
 		if err := l.materializeLockedProvider(context.Background(), paths, name, plugin, entry, locked); err != nil {
 			return err
 		}
@@ -2050,6 +2181,9 @@ func (l *Lifecycle) applyLockedComponentEntry(paths initPaths, entry *LockEntry,
 		}
 	}
 	if needMaterialize {
+		if len(entry.Archives) == 0 {
+			return fmt.Errorf("prepared artifact for %s %q is missing or stale; run `gestaltd init %s`", kind, name, paths.configFlags)
+		}
 		if err := l.materializeLockedComponent(context.Background(), paths, kind, name, plugin, *entry, destDir, locked); err != nil {
 			return err
 		}
@@ -2116,6 +2250,28 @@ func bindResolvedUIManifest(plugin *config.ProviderEntry, manifestPath string, m
 	plugin.ResolvedManifestPath = manifestPath
 	plugin.ResolvedManifest = manifest
 	return nil
+}
+
+func bindPathBackedUIManifest(plugin *config.ProviderEntry, configMap map[string]any) (string, error) {
+	manifestPath := plugin.SourcePath()
+	if strings.TrimSpace(manifestPath) == "" {
+		return "", fmt.Errorf("resolved ui manifest path is required")
+	}
+	if _, err := os.Stat(manifestPath); err != nil {
+		return "", fmt.Errorf("ui provider manifest not found at %s: %w", manifestPath, err)
+	}
+	_, manifest, err := providerpkg.ReadManifestFile(manifestPath)
+	if err != nil {
+		return "", fmt.Errorf("prepare manifest for ui provider: %w", err)
+	}
+	if err := bindResolvedUIManifest(plugin, manifestPath, manifest, configMap); err != nil {
+		return "", err
+	}
+	assetRoot := filepath.Join(filepath.Dir(manifestPath), filepath.FromSlash(manifest.Spec.AssetRoot))
+	if _, err := os.Stat(assetRoot); err != nil {
+		return "", fmt.Errorf("ui provider asset root not found at %s: %w", assetRoot, err)
+	}
+	return assetRoot, nil
 }
 
 func (l *Lifecycle) materializeLockedProvider(ctx context.Context, paths initPaths, name string, plugin *config.ProviderEntry, entry LockProviderEntry, locked bool) error {

--- a/gestaltd/internal/operator/lifecycle_source_test.go
+++ b/gestaltd/internal/operator/lifecycle_source_test.go
@@ -1409,9 +1409,9 @@ func TestSourceSecretsPluginBootstrapsManagedAuthSourceToken(t *testing.T) {
 		t.Fatalf("auth resolver token = %q, want %q", resolver.calls[1].src.Token, "ghp_inline_auth_source_token")
 	}
 
-	secretsRoot := filepath.Join(artifactsDir, ".gestaltd", "secrets")
+	secretsRoot := filepath.Join(artifactsDir, ".gestaltd", "secrets", "secrets")
 	if err := os.RemoveAll(secretsRoot); err != nil {
-		t.Fatalf("RemoveAll secrets root: %v", err)
+		t.Fatalf("RemoveAll secrets provider root: %v", err)
 	}
 	authRoot := filepath.Join(artifactsDir, ".gestaltd", "auth")
 	if err := os.RemoveAll(authRoot); err != nil {
@@ -1457,6 +1457,131 @@ func TestSourceSecretsPluginBootstrapsManagedAuthSourceToken(t *testing.T) {
 	authExecutablePath := resolveLockPath(artifactsDir, authLockEntry.Executable)
 	if authProvider.Command != authExecutablePath {
 		t.Fatalf("auth provider command = %q, want %q", authProvider.Command, authExecutablePath)
+	}
+}
+
+func TestLoadForExecutionAtPath_UnlockedBootstrapInitPreparesOnce(t *testing.T) {
+	t.Parallel()
+
+	dir := t.TempDir()
+	bootstrapSource := "github.com/acme/tools/bootstrap-secrets"
+	bootstrapVersion := "0.1.0"
+	authSource := "github.com/acme/tools/auth-widget"
+	authVersion := "2.0.0"
+	bootstrapArtifact := filepath.ToSlash(filepath.Join("artifacts", runtime.GOOS, runtime.GOARCH, "bootstrap-secrets"))
+	bootstrapManifestPath := filepath.Join(dir, "bootstrap-secrets-manifest.yaml")
+	bootstrapManifest, err := providerpkg.EncodeSourceManifestFormat(&providermanifestv1.Manifest{
+		Kind:    providermanifestv1.KindSecrets,
+		Source:  bootstrapSource,
+		Version: bootstrapVersion,
+		Spec:    &providermanifestv1.Spec{},
+		Artifacts: []providermanifestv1.Artifact{
+			{OS: runtime.GOOS, Arch: runtime.GOARCH, Path: bootstrapArtifact},
+		},
+		Entrypoint: &providermanifestv1.Entrypoint{ArtifactPath: bootstrapArtifact},
+	}, providerpkg.ManifestFormatYAML)
+	if err != nil {
+		t.Fatalf("EncodeSourceManifestFormat bootstrap: %v", err)
+	}
+	if err := os.WriteFile(bootstrapManifestPath, bootstrapManifest, 0o644); err != nil {
+		t.Fatalf("write bootstrap manifest: %v", err)
+	}
+	bootstrapBinaryData, err := os.ReadFile(buildGoSourceSecretsBinary(t))
+	if err != nil {
+		t.Fatalf("read bootstrap binary: %v", err)
+	}
+	bootstrapBinaryPath := filepath.Join(dir, filepath.FromSlash(bootstrapArtifact))
+	if err := os.MkdirAll(filepath.Dir(bootstrapBinaryPath), 0o755); err != nil {
+		t.Fatalf("MkdirAll bootstrap artifact: %v", err)
+	}
+	if err := os.WriteFile(bootstrapBinaryPath, bootstrapBinaryData, 0o755); err != nil {
+		t.Fatalf("write bootstrap artifact: %v", err)
+	}
+
+	authArchivePath := buildExecutableArchive(
+		t,
+		dir,
+		"auth-src",
+		authSource,
+		authVersion,
+		providermanifestv1.KindAuth,
+		"auth-plugin",
+		"fake-auth-binary",
+	)
+	authArchiveData, err := os.ReadFile(authArchivePath)
+	if err != nil {
+		t.Fatalf("read auth archive: %v", err)
+	}
+	authArchiveSum := sha256.Sum256(authArchiveData)
+	resolver := &fakeResolver{
+		archivePath: authArchivePath,
+		resolvedURL: "https://example.test/auth.tar.gz",
+		sha256:      hex.EncodeToString(authArchiveSum[:]),
+	}
+
+	artifactsDir := filepath.Join(dir, "prepared-artifacts")
+	configYAML := strings.Join([]string{
+		requiredIndexedDBConfigYAML(t, dir, filepath.Join(dir, "data.db")),
+		"  secrets:",
+		"    bootstrap:",
+		"      source:",
+		"        path: ./bootstrap-secrets-manifest.yaml",
+		"  auth:",
+		"    auth:",
+		"      source:",
+		"        ref: " + authSource,
+		"        version: " + authVersion,
+		"        auth:",
+		"          token:",
+		"            secret:",
+		"              provider: bootstrap",
+		"              name: source-token",
+		"      config:",
+		"        clientId: managed-auth-client",
+		"server:",
+		"  providers:",
+		"    indexeddb: sqlite",
+		"    secrets: bootstrap",
+		"    auth: auth",
+		"  artifactsDir: " + artifactsDir,
+		"  encryptionKey: aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
+	}, "\n") + "\n"
+
+	configPath := filepath.Join(dir, "gestalt.yaml")
+	if err := os.WriteFile(configPath, []byte(configYAML), 0o644); err != nil {
+		t.Fatalf("write config: %v", err)
+	}
+
+	factories := bootstrap.NewFactoryRegistry()
+	factories.Secrets["provider"] = secretsprovider.Factory
+
+	lc := NewLifecycle(resolver).WithConfigSecretResolver(func(ctx context.Context, cfg *config.Config) error {
+		return bootstrap.ResolveConfigSecrets(ctx, cfg, factories)
+	})
+
+	cfg, _, err := lc.LoadForExecutionAtPath(configPath, false)
+	if err != nil {
+		t.Fatalf("LoadForExecutionAtPath(locked=false): %v", err)
+	}
+	if got := resolver.calls; got != 1 {
+		t.Fatalf("resolver calls = %d, want 1", got)
+	}
+	if resolver.lastSrc.String() != authSource {
+		t.Fatalf("resolver source = %q, want %q", resolver.lastSrc.String(), authSource)
+	}
+	if resolver.lastVersion != authVersion {
+		t.Fatalf("resolver version = %q, want %q", resolver.lastVersion, authVersion)
+	}
+	if resolver.lastSrc.Token != "ghp_inline_auth_source_token" {
+		t.Fatalf("resolver token = %q, want %q", resolver.lastSrc.Token, "ghp_inline_auth_source_token")
+	}
+
+	authProvider := mustSelectedHostProviderEntry(t, cfg, config.HostProviderKindAuth)
+	if authProvider == nil || authProvider.Source.Auth == nil {
+		t.Fatalf("auth provider source auth = %#v", authProvider)
+	}
+	if authProvider.Source.Auth.Token != "ghp_inline_auth_source_token" {
+		t.Fatalf("resolved auth source token = %q, want %q", authProvider.Source.Auth.Token, "ghp_inline_auth_source_token")
 	}
 }
 

--- a/gestaltd/internal/operator/lifecycle_test.go
+++ b/gestaltd/internal/operator/lifecycle_test.go
@@ -2,6 +2,7 @@ package operator
 
 import (
 	"archive/tar"
+	"cmp"
 	"compress/gzip"
 	"context"
 	"crypto/sha256"
@@ -139,12 +140,27 @@ func decodeNodeMap(t *testing.T, node any) map[string]any {
 
 func writeStubIndexedDBManifest(t *testing.T, dir string) string {
 	t.Helper()
-	manifestPath := filepath.Join(dir, "indexeddb-manifest.yaml")
+	providerDir := filepath.Join(dir, "indexeddb-stub")
+	manifestPath := filepath.Join(providerDir, "indexeddb-manifest.yaml")
+	artifactRel := filepath.ToSlash(filepath.Join("artifacts", runtime.GOOS, runtime.GOARCH, "indexeddb"))
+	artifactPath := filepath.Join(providerDir, filepath.FromSlash(artifactRel))
+	if err := os.MkdirAll(filepath.Dir(artifactPath), 0o755); err != nil {
+		t.Fatalf("mkdir indexeddb artifact dir: %v", err)
+	}
+	if err := os.WriteFile(artifactPath, []byte("stub-indexeddb"), 0o755); err != nil {
+		t.Fatalf("write indexeddb artifact: %v", err)
+	}
 	data, err := providerpkg.EncodeSourceManifestFormat(&providermanifestv1.Manifest{
 		Source:  "github.com/test/providers/indexeddb-stub",
 		Version: "0.0.1-alpha.1",
 		Kind:    providermanifestv1.KindIndexedDB,
 		Spec:    &providermanifestv1.Spec{},
+		Artifacts: []providermanifestv1.Artifact{{
+			OS:   runtime.GOOS,
+			Arch: runtime.GOARCH,
+			Path: artifactRel,
+		}},
+		Entrypoint: &providermanifestv1.Entrypoint{ArtifactPath: artifactRel},
 	}, providerpkg.ManifestFormatYAML)
 	if err != nil {
 		t.Fatalf("encode indexeddb manifest: %v", err)
@@ -180,12 +196,29 @@ func writeLocalExecutablePlugin(t *testing.T, dir, name string, operations ...st
 	if err := os.MkdirAll(root, 0o755); err != nil {
 		t.Fatalf("MkdirAll(%s): %v", root, err)
 	}
+	artifactPath := filepath.ToSlash(filepath.Join("artifacts", runtime.GOOS, runtime.GOARCH, "plugin"))
+	artifactFullPath := filepath.Join(root, filepath.FromSlash(artifactPath))
+	if err := os.MkdirAll(filepath.Dir(artifactFullPath), 0o755); err != nil {
+		t.Fatalf("MkdirAll(%s): %v", filepath.Dir(artifactFullPath), err)
+	}
+	artifactContent := []byte(name + "-binary")
+	if err := os.WriteFile(artifactFullPath, artifactContent, 0o755); err != nil {
+		t.Fatalf("WriteFile(%s): %v", artifactFullPath, err)
+	}
+	artifactSum := sha256.Sum256(artifactContent)
 	manifestPath := filepath.Join(root, "manifest.yaml")
 	manifest, err := providerpkg.EncodeSourceManifestFormat(&providermanifestv1.Manifest{
 		Kind:        providermanifestv1.KindPlugin,
 		Source:      "github.com/test/plugins/" + name,
 		Version:     "0.0.1-alpha.1",
 		DisplayName: testDisplayName(name),
+		Entrypoint:  &providermanifestv1.Entrypoint{ArtifactPath: artifactPath},
+		Artifacts: []providermanifestv1.Artifact{{
+			OS:     runtime.GOOS,
+			Arch:   runtime.GOARCH,
+			Path:   artifactPath,
+			SHA256: hex.EncodeToString(artifactSum[:]),
+		}},
 		Spec: &providermanifestv1.Spec{
 			Auth: &providermanifestv1.ProviderAuth{Type: providermanifestv1.AuthTypeNone},
 		},
@@ -389,6 +422,14 @@ func TestLoadForExecutionAtPath_ResolvesLocalManifestPluginWithoutLockfile(t *te
 
 	dir := t.TempDir()
 	manifestPath := filepath.Join(dir, "manifest.yaml")
+	artifactRel := filepath.ToSlash(filepath.Join("artifacts", runtime.GOOS, runtime.GOARCH, "provider"))
+	artifactPath := filepath.Join(dir, filepath.FromSlash(artifactRel))
+	if err := os.MkdirAll(filepath.Dir(artifactPath), 0o755); err != nil {
+		t.Fatalf("MkdirAll artifact dir: %v", err)
+	}
+	if err := os.WriteFile(artifactPath, []byte("local-provider"), 0o755); err != nil {
+		t.Fatalf("WriteFile artifact: %v", err)
+	}
 	manifest, err := providerpkg.EncodeSourceManifestFormat(&providermanifestv1.Manifest{
 		Source:      "github.com/testowner/plugins/local-provider",
 		Version:     "0.0.1-alpha.1",
@@ -397,6 +438,12 @@ func TestLoadForExecutionAtPath_ResolvesLocalManifestPluginWithoutLockfile(t *te
 		Kind:        providermanifestv1.KindPlugin, Spec: &providermanifestv1.Spec{
 			Auth: &providermanifestv1.ProviderAuth{Type: providermanifestv1.AuthTypeNone},
 		},
+		Artifacts: []providermanifestv1.Artifact{{
+			OS:   runtime.GOOS,
+			Arch: runtime.GOARCH,
+			Path: artifactRel,
+		}},
+		Entrypoint: &providermanifestv1.Entrypoint{ArtifactPath: artifactRel},
 	}, providerpkg.ManifestFormatYAML)
 	if err != nil {
 		t.Fatalf("EncodeManifest: %v", err)
@@ -436,11 +483,14 @@ func TestLoadForExecutionAtPath_ResolvesLocalManifestPluginWithoutLockfile(t *te
 	if intg == nil || intg.ResolvedManifest == nil {
 		t.Fatalf("ResolvedManifest = %+v", intg)
 	}
-	if intg.ResolvedManifestPath != manifestPath {
-		t.Fatalf("ResolvedManifestPath = %q, want %q", intg.ResolvedManifestPath, manifestPath)
+	if !strings.HasSuffix(filepath.ToSlash(intg.ResolvedManifestPath), filepath.ToSlash(filepath.Join(".gestaltd", "providers", "example", "manifest.yaml"))) {
+		t.Fatalf("ResolvedManifestPath = %q", intg.ResolvedManifestPath)
 	}
-	if _, err := os.Stat(filepath.Join(dir, InitLockfileName)); !os.IsNotExist(err) {
-		t.Fatalf("lockfile should not be created, got err=%v", err)
+	if intg.Command == "" {
+		t.Fatal("Command = empty, want prepared executable path")
+	}
+	if _, err := os.Stat(filepath.Join(dir, InitLockfileName)); err != nil {
+		t.Fatalf("expected lockfile to be created: %v", err)
 	}
 }
 
@@ -501,8 +551,8 @@ spec:
 	if got := conn.Auth.Type; got != providermanifestv1.AuthTypeMCPOAuth {
 		t.Fatalf("MCP auth type = %q, want %q", got, providermanifestv1.AuthTypeMCPOAuth)
 	}
-	if _, err := os.Stat(filepath.Join(dir, InitLockfileName)); !os.IsNotExist(err) {
-		t.Fatalf("lockfile should not be created, got err=%v", err)
+	if _, err := os.Stat(filepath.Join(dir, InitLockfileName)); err != nil {
+		t.Fatalf("expected lockfile to be created: %v", err)
 	}
 }
 
@@ -1038,6 +1088,7 @@ func TestLoadForExecutionAtPath_ResolvesLocalMountedWebUIWithoutLockfile(t *test
 		wantPath     string
 		wantPolicy   string
 		ownedUIPath  string
+		uiManifest   string
 		wantErr      string
 	}{
 		{
@@ -1137,6 +1188,29 @@ plugins:
 			ownedUIPath: "../webui/manifest.yaml",
 		},
 		{
+			name: "plugin owned ui via plugin mount with noncanonical manifest filename",
+			uiConfigYAML: `plugins:
+    roadmap:
+      source:
+        path: ./plugin/manifest.yaml
+      mountPath: /create-customer-roadmap-review
+      authorizationPolicy: roadmap_policy
+`,
+			extraYAML: `authorization:
+  policies:
+    roadmap_policy:
+      default: deny
+      members:
+        - email: viewer@example.test
+          role: viewer
+`,
+			uiKey:       "roadmap",
+			wantPath:    "/create-customer-roadmap-review",
+			wantPolicy:  "roadmap_policy",
+			ownedUIPath: "../webui/ui-manifest.yaml",
+			uiManifest:  "ui-manifest.yaml",
+		},
+		{
 			name: "plugin owned ui with same-name ui overlay",
 			uiConfigYAML: `  ui:
     roadmap:
@@ -1193,7 +1267,8 @@ plugins:
 			if err := os.WriteFile(filepath.Join(webUIDir, "dist", "index.html"), []byte("<html>roadmap</html>"), 0o644); err != nil {
 				t.Fatalf("WriteFile index.html: %v", err)
 			}
-			manifestPath := filepath.Join(webUIDir, "manifest.yaml")
+			manifestName := cmp.Or(tc.uiManifest, "manifest.yaml")
+			manifestPath := filepath.Join(webUIDir, manifestName)
 			spec := &providermanifestv1.Spec{AssetRoot: "dist"}
 			if tc.wantPolicy != "" {
 				spec.Routes = []providermanifestv1.WebUIRoute{
@@ -1218,6 +1293,14 @@ plugins:
 				if err := os.MkdirAll(filepath.Dir(pluginManifestPath), 0o755); err != nil {
 					t.Fatalf("MkdirAll plugin dir: %v", err)
 				}
+				pluginArtifactRel := filepath.ToSlash(filepath.Join("artifacts", runtime.GOOS, runtime.GOARCH, "plugin"))
+				pluginArtifactPath := filepath.Join(dir, "plugin", filepath.FromSlash(pluginArtifactRel))
+				if err := os.MkdirAll(filepath.Dir(pluginArtifactPath), 0o755); err != nil {
+					t.Fatalf("MkdirAll plugin artifact dir: %v", err)
+				}
+				if err := os.WriteFile(pluginArtifactPath, []byte("roadmap-plugin"), 0o755); err != nil {
+					t.Fatalf("WriteFile plugin artifact: %v", err)
+				}
 				pluginSpec := &providermanifestv1.Spec{
 					Auth: &providermanifestv1.ProviderAuth{Type: providermanifestv1.AuthTypeNone},
 				}
@@ -1230,6 +1313,12 @@ plugins:
 					DisplayName: "Roadmap Plugin",
 					Kind:        providermanifestv1.KindPlugin,
 					Spec:        pluginSpec,
+					Artifacts: []providermanifestv1.Artifact{{
+						OS:   runtime.GOOS,
+						Arch: runtime.GOARCH,
+						Path: pluginArtifactRel,
+					}},
+					Entrypoint: &providermanifestv1.Entrypoint{ArtifactPath: pluginArtifactRel},
 				}, providerpkg.ManifestFormatYAML)
 				if err != nil {
 					t.Fatalf("EncodePluginManifest: %v", err)
@@ -1272,12 +1361,17 @@ plugins:
 			if entry.ResolvedManifest == nil {
 				t.Fatal("ResolvedManifest = nil")
 			}
-			if got := entry.ResolvedManifestPath; got != manifestPath {
-				t.Fatalf("ResolvedManifestPath = %q, want %q", got, manifestPath)
+			gotManifestPath := filepath.ToSlash(entry.ResolvedManifestPath)
+			wantUIManifest := filepath.ToSlash(filepath.Join(".gestaltd", "ui", tc.uiKey, "manifest.yaml"))
+			wantOwnedManifest := filepath.ToSlash(filepath.Join(".gestaltd", "providers", "roadmap", "_owned_ui", "webui", "manifest.yaml"))
+			if !strings.HasSuffix(gotManifestPath, wantUIManifest) && !strings.HasSuffix(gotManifestPath, wantOwnedManifest) {
+				t.Fatalf("ResolvedManifestPath = %q", gotManifestPath)
 			}
-			wantAssetRoot := filepath.Join(webUIDir, "dist")
-			if got := entry.ResolvedAssetRoot; got != wantAssetRoot {
-				t.Fatalf("ResolvedAssetRoot = %q, want %q", got, wantAssetRoot)
+			gotAssetRoot := filepath.ToSlash(entry.ResolvedAssetRoot)
+			wantUIAssetRoot := filepath.ToSlash(filepath.Join(".gestaltd", "ui", tc.uiKey, "dist"))
+			wantOwnedAssetRoot := filepath.ToSlash(filepath.Join(".gestaltd", "providers", "roadmap", "_owned_ui", "webui", "dist"))
+			if !strings.HasSuffix(gotAssetRoot, wantUIAssetRoot) && !strings.HasSuffix(gotAssetRoot, wantOwnedAssetRoot) {
+				t.Fatalf("ResolvedAssetRoot = %q", gotAssetRoot)
 			}
 			if got := entry.Path; got != tc.wantPath {
 				t.Fatalf("Path = %q, want %q", got, tc.wantPath)
@@ -1299,10 +1393,67 @@ plugins:
 					t.Fatalf("Plugin AuthorizationPolicy = %q, want %q", got, tc.wantPolicy)
 				}
 			}
-			if _, err := os.Stat(filepath.Join(dir, InitLockfileName)); !os.IsNotExist(err) {
-				t.Fatalf("lockfile should not be created, got err=%v", err)
+			if _, err := os.Stat(filepath.Join(dir, InitLockfileName)); err != nil {
+				t.Fatalf("expected lockfile to be created: %v", err)
 			}
 		})
+	}
+}
+
+func TestLoadForExecutionAtPath_RejectsLockedExplicitLocalUIWithoutPreparedUILockEntry(t *testing.T) {
+	t.Parallel()
+
+	dir := t.TempDir()
+	webUIDir := filepath.Join(dir, "webui")
+	if err := os.MkdirAll(filepath.Join(webUIDir, "dist"), 0o755); err != nil {
+		t.Fatalf("MkdirAll webui dist: %v", err)
+	}
+	if err := os.WriteFile(filepath.Join(webUIDir, "dist", "index.html"), []byte("<html>roadmap</html>"), 0o644); err != nil {
+		t.Fatalf("WriteFile index.html: %v", err)
+	}
+	manifest, err := providerpkg.EncodeSourceManifestFormat(&providermanifestv1.Manifest{
+		Kind:        providermanifestv1.KindWebUI,
+		Source:      "github.com/testowner/web/roadmap",
+		Version:     "0.0.1-alpha.1",
+		DisplayName: "Roadmap UI",
+		Spec:        &providermanifestv1.Spec{AssetRoot: "dist"},
+	}, providerpkg.ManifestFormatYAML)
+	if err != nil {
+		t.Fatalf("EncodeManifest: %v", err)
+	}
+	if err := os.WriteFile(filepath.Join(webUIDir, "manifest.yaml"), manifest, 0o644); err != nil {
+		t.Fatalf("WriteFile manifest: %v", err)
+	}
+
+	cfgPath := filepath.Join(dir, "config.yaml")
+	cfg := requiredComponentConfigYAML(t, dir, filepath.Join(dir, "gestalt.db")) + `  ui:
+    roadmap:
+      source:
+        path: ./webui/manifest.yaml
+      path: /create-customer-roadmap-review
+server:
+` + requiredServerDatastoreYAML() + `  encryptionKey: aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa
+`
+	if err := os.WriteFile(cfgPath, []byte(cfg), 0o644); err != nil {
+		t.Fatalf("WriteFile config: %v", err)
+	}
+
+	lc := NewLifecycle(nil)
+	if _, err := lc.InitAtPath(cfgPath); err != nil {
+		t.Fatalf("InitAtPath: %v", err)
+	}
+	lockPath := filepath.Join(dir, InitLockfileName)
+	lock, err := ReadLockfile(lockPath)
+	if err != nil {
+		t.Fatalf("ReadLockfile: %v", err)
+	}
+	delete(lock.UIs, "roadmap")
+	if err := WriteLockfile(lockPath, lock); err != nil {
+		t.Fatalf("WriteLockfile: %v", err)
+	}
+
+	if _, _, err := lc.LoadForExecutionAtPath(cfgPath, true); err == nil || !strings.Contains(err.Error(), `prepared artifact for ui "roadmap" is missing or stale`) {
+		t.Fatalf("LoadForExecutionAtPath locked error = %v, want missing prepared artifact", err)
 	}
 }
 
@@ -1842,7 +1993,8 @@ server:
 			},
 		},
 	})
-	if _, err := lc.InitAtPath(cfgPath); err != nil {
+	initialLock, err := lc.InitAtPath(cfgPath)
+	if err != nil {
 		t.Fatalf("InitAtPath: %v", err)
 	}
 
@@ -1852,16 +2004,14 @@ server:
 		t.Fatalf("Load: %v", err)
 	}
 	paths := initPathsForConfig(cfgPath)
-	lock := &Lockfile{
-		Version: LockVersion,
-		Providers: map[string]LockProviderEntry{
-			"roadmap": {
-				Fingerprint: mustFingerprint(t, "roadmap", loadedCfg.Plugins["roadmap"], paths.configDir),
-				Source:      pluginRef,
-				Version:     newVersion,
-				Archives: map[string]LockArchive{
-					"generic": {URL: archiveServer.URL, SHA256: hex.EncodeToString(newPluginArchiveSum[:])},
-				},
+	lock := normalizeLockfile(initialLock)
+	lock.Providers = map[string]LockProviderEntry{
+		"roadmap": {
+			Fingerprint: mustFingerprint(t, "roadmap", loadedCfg.Plugins["roadmap"], paths.configDir),
+			Source:      pluginRef,
+			Version:     newVersion,
+			Archives: map[string]LockArchive{
+				"generic": {URL: archiveServer.URL, SHA256: hex.EncodeToString(newPluginArchiveSum[:])},
 			},
 		},
 	}
@@ -2581,23 +2731,23 @@ server:
 	if authEntry == nil || authEntry.ResolvedManifest == nil {
 		t.Fatalf("auth resolved manifest = %+v", authEntry)
 	}
-	if authEntry.Command != authExecutablePath {
-		t.Fatalf("auth command = %q, want %q", authEntry.Command, authExecutablePath)
+	if !strings.HasSuffix(filepath.ToSlash(authEntry.Command), filepath.ToSlash(filepath.Join(".gestaltd", "auth", "auth", filepath.FromSlash(authArtifact)))) {
+		t.Fatalf("auth command = %q", authEntry.Command)
 	}
 	if got := authEntry.Args; len(got) != 1 || got[0] != "serve-auth" {
 		t.Fatalf("auth args = %v, want [serve-auth]", got)
 	}
 	authCfg := decodeNodeMap(t, authEntry.Config)
-	if authCfg["command"] != authExecutablePath {
-		t.Fatalf("auth config command = %v, want %q", authCfg["command"], authExecutablePath)
+	if authCfg["command"] != authEntry.Command {
+		t.Fatalf("auth config command = %v, want %q", authCfg["command"], authEntry.Command)
 	}
 	authPluginCfg, ok := authCfg["config"].(map[string]any)
 	if !ok || authPluginCfg["clientId"] != "local-auth-client" {
 		t.Fatalf("auth nested config = %#v", authCfg["config"])
 	}
 
-	if _, err := os.Stat(filepath.Join(dir, InitLockfileName)); !os.IsNotExist(err) {
-		t.Fatalf("lockfile should not be created, got err=%v", err)
+	if _, err := os.Stat(filepath.Join(dir, InitLockfileName)); err != nil {
+		t.Fatalf("expected lockfile to be created: %v", err)
 	}
 }
 
@@ -2668,17 +2818,20 @@ server:
 	if authEntry == nil || authEntry.ResolvedManifest == nil {
 		t.Fatalf("auth resolved manifest = %+v", authEntry)
 	}
-	if authEntry.Command != "" {
-		t.Fatalf("auth command = %q, want empty", authEntry.Command)
+	if authEntry.Command == "" {
+		t.Fatal("auth command = empty, want prepared executable path")
 	}
 	authCfg := decodeNodeMap(t, authEntry.Config)
-	if authCfg["manifestPath"] != authManifestPath {
-		t.Fatalf("auth manifest_path = %v, want %q", authCfg["manifestPath"], authManifestPath)
+	manifestPathValue, _ := authCfg["manifestPath"].(string)
+	if !strings.HasSuffix(filepath.ToSlash(manifestPathValue), filepath.ToSlash(filepath.Join(".gestaltd", "auth", "auth", "manifest.yaml"))) {
+		t.Fatalf("auth manifest_path = %v", authCfg["manifestPath"])
 	}
-	if authCfg["command"] != "" {
-		t.Fatalf("auth config command = %v, want empty", authCfg["command"])
+	if authCfg["command"] == "" {
+		t.Fatalf("auth config command = %v, want prepared executable path", authCfg["command"])
 	}
-
+	if _, err := os.Stat(filepath.Join(dir, InitLockfileName)); err != nil {
+		t.Fatalf("expected lockfile to be created: %v", err)
+	}
 }
 
 func TestLoadForExecutionAtPath_GeneratesStaticCatalogForLocalSourceHybridPlugin(t *testing.T) {
@@ -2739,12 +2892,14 @@ func TestLoadForExecutionAtPath_GeneratesStaticCatalogForLocalSourceHybridPlugin
 	if !strings.Contains(string(catalogData), "generated_op") {
 		t.Fatalf("unexpected catalog contents: %s", catalogData)
 	}
-	if _, err := os.Stat(filepath.Join(dir, InitLockfileName)); !os.IsNotExist(err) {
-		t.Fatalf("lockfile should not be created, got err=%v", err)
+	if _, err := os.Stat(filepath.Join(dir, InitLockfileName)); err != nil {
+		t.Fatalf("expected lockfile to be created: %v", err)
 	}
 }
 
 func TestLoadForExecutionAtPath_GeneratesStaticCatalogForLocalPythonSourcePlugin(t *testing.T) {
+	t.Parallel()
+
 	if runtime.GOOS == "windows" {
 		t.Skip("local Python source plugin fixture is POSIX-only")
 	}
@@ -2753,6 +2908,13 @@ func TestLoadForExecutionAtPath_GeneratesStaticCatalogForLocalPythonSourcePlugin
 	python3Path, err := exec.LookPath("python3")
 	if err != nil {
 		t.Skipf("python3 not found: %v", err)
+	}
+	if runtime.GOOS == "darwin" {
+		for _, tool := range []string{"arch", "lipo", "install_name_tool"} {
+			if _, err := exec.LookPath(tool); err != nil {
+				t.Skipf("%s not found: %v", tool, err)
+			}
+		}
 	}
 	writeTestFile := func(rel string, data []byte, mode os.FileMode) {
 		t.Helper()
@@ -2869,6 +3031,8 @@ def session_catalog(request: gestalt.Request) -> gestalt.Catalog:
     )
 `), 0o644)
 	createLocalPythonSDKVenv(t, python3Path, filepath.Join(dir, ".venv"), localPythonSDKPath(t))
+	artifactRel := filepath.ToSlash(filepath.Join("artifacts", runtime.GOOS, runtime.GOARCH, "provider"))
+	writeTestFile(artifactRel, []byte("python-provider"), 0o755)
 
 	manifest, err := providerpkg.EncodeSourceManifestFormat(&providermanifestv1.Manifest{
 		Source:      "github.com/testowner/plugins/local-python-provider",
@@ -2877,6 +3041,12 @@ def session_catalog(request: gestalt.Request) -> gestalt.Catalog:
 		Kind:        providermanifestv1.KindPlugin, Spec: &providermanifestv1.Spec{
 			Auth: &providermanifestv1.ProviderAuth{Type: providermanifestv1.AuthTypeNone},
 		},
+		Artifacts: []providermanifestv1.Artifact{{
+			OS:   runtime.GOOS,
+			Arch: runtime.GOARCH,
+			Path: artifactRel,
+		}},
+		Entrypoint: &providermanifestv1.Entrypoint{ArtifactPath: artifactRel},
 	}, providerpkg.ManifestFormatYAML)
 	if err != nil {
 		t.Fatalf("EncodeManifestFormat: %v", err)
@@ -2945,7 +3115,6 @@ print(json.dumps({
     "zero_body": json.loads(zero_body),
 }, sort_keys=True))
 `), 0o644)
-	t.Setenv("PATH", t.TempDir())
 
 	lc := NewLifecycle(nil)
 	loaded, _, err := lc.LoadForExecutionAtPath(filepath.Join(dir, "config.yaml"), false)
@@ -3141,8 +3310,8 @@ print(json.dumps({
 		t.Fatalf("zero_status = %v, want 0", body["zero_status"])
 	}
 
-	if _, err := os.Stat(filepath.Join(dir, InitLockfileName)); !os.IsNotExist(err) {
-		t.Fatalf("lockfile should not be created, got err=%v", err)
+	if _, err := os.Stat(filepath.Join(dir, InitLockfileName)); err != nil {
+		t.Fatalf("expected lockfile to be created: %v", err)
 	}
 }
 
@@ -3195,6 +3364,14 @@ func TestApplyLockedPlugins_SkipsNilIntegrationPlugins(t *testing.T) {
 
 	dir := t.TempDir()
 	manifestPath := filepath.Join(dir, "manifest.yaml")
+	artifactRel := filepath.ToSlash(filepath.Join("artifacts", runtime.GOOS, runtime.GOARCH, "provider"))
+	artifactPath := filepath.Join(dir, filepath.FromSlash(artifactRel))
+	if err := os.MkdirAll(filepath.Dir(artifactPath), 0o755); err != nil {
+		t.Fatalf("MkdirAll artifact dir: %v", err)
+	}
+	if err := os.WriteFile(artifactPath, []byte("local-provider"), 0o755); err != nil {
+		t.Fatalf("WriteFile artifact: %v", err)
+	}
 	manifest, err := providerpkg.EncodeSourceManifestFormat(&providermanifestv1.Manifest{
 		Source:      "github.com/testowner/plugins/local-provider",
 		Version:     "0.0.1-alpha.1",
@@ -3202,6 +3379,12 @@ func TestApplyLockedPlugins_SkipsNilIntegrationPlugins(t *testing.T) {
 		Kind:        providermanifestv1.KindPlugin, Spec: &providermanifestv1.Spec{
 			Auth: &providermanifestv1.ProviderAuth{Type: providermanifestv1.AuthTypeNone},
 		},
+		Artifacts: []providermanifestv1.Artifact{{
+			OS:   runtime.GOOS,
+			Arch: runtime.GOARCH,
+			Path: artifactRel,
+		}},
+		Entrypoint: &providermanifestv1.Entrypoint{ArtifactPath: artifactRel},
 	}, providerpkg.ManifestFormatYAML)
 	if err != nil {
 		t.Fatalf("EncodeManifest: %v", err)
@@ -3232,7 +3415,7 @@ func TestApplyLockedPlugins_SkipsNilIntegrationPlugins(t *testing.T) {
 	loaded.Plugins["missing"] = &config.ProviderEntry{}
 
 	lc := NewLifecycle(nil)
-	if err := lc.applyLockedProviders([]string{cfgPath}, "", loaded, false, nil); err != nil {
+	if _, err := lc.applyLockedProviders([]string{cfgPath}, "", loaded, false, nil); err != nil {
 		t.Fatalf("applyLockedProviders: %v", err)
 	}
 	if loaded.Plugins["example"] == nil || loaded.Plugins["example"].ResolvedManifest == nil {

--- a/gestaltd/internal/providerpkg/prepared_stage.go
+++ b/gestaltd/internal/providerpkg/prepared_stage.go
@@ -2,6 +2,7 @@ package providerpkg
 
 import (
 	"encoding/json"
+	"errors"
 	"fmt"
 	"io"
 	"io/fs"
@@ -29,11 +30,55 @@ type StagePreparedInstallOptions struct {
 	GOARCH          string
 }
 
+type StageSourcePreparedInstallOptions struct {
+	Kind       string
+	PluginName string
+	GOOS       string
+	GOARCH     string
+}
+
 type StagedPreparedInstall struct {
 	Manifest       *providermanifestv1.Manifest
 	ManifestPath   string
 	ManifestFile   string
 	ManifestFormat string
+}
+
+// StageSourcePreparedInstallDir stages a source tree into its prepared-install layout.
+// It runs any source release build hook, determines whether a host-platform executable
+// build is needed, and then delegates to StagePreparedInstallDir for the final layout.
+func StageSourcePreparedInstallDir(manifestPath, stagingDir string, opts StageSourcePreparedInstallOptions) (*StagedPreparedInstall, error) {
+	if strings.TrimSpace(manifestPath) == "" {
+		return nil, fmt.Errorf("manifest path is required")
+	}
+	_, manifest, err := ReadSourceManifestFile(manifestPath)
+	if err != nil {
+		return nil, fmt.Errorf("read %s: %w", manifestPath, err)
+	}
+	if err := RunSourceReleaseBuild(manifestPath, manifest); err != nil {
+		return nil, err
+	}
+	_, manifest, err = ReadSourceManifestFile(manifestPath)
+	if err != nil {
+		return nil, fmt.Errorf("read %s after release build: %w", manifestPath, err)
+	}
+	kind := strings.TrimSpace(opts.Kind)
+	if kind == "" {
+		kind, err = ManifestKind(manifest)
+		if err != nil {
+			return nil, err
+		}
+	}
+	buildKind, err := resolvePreparedInstallBuildKind(filepath.Dir(manifestPath), manifest, kind)
+	if err != nil {
+		return nil, err
+	}
+	return StagePreparedInstallDir(manifestPath, stagingDir, StagePreparedInstallOptions{
+		BuildKind:  buildKind,
+		PluginName: opts.PluginName,
+		GOOS:       opts.GOOS,
+		GOARCH:     opts.GOARCH,
+	})
 }
 
 // StagePreparedInstallDir stages a source manifest into its prepared-install layout.
@@ -47,8 +92,8 @@ func StagePreparedInstallDir(manifestPath, stagingDir string, opts StagePrepared
 	}
 
 	sourceDir := filepath.Dir(manifestPath)
-	manifestFile := filepath.Base(manifestPath)
 	manifestFormat := ManifestFormatFromPath(manifestPath)
+	manifestFile := preparedManifestFileName(manifestFormat)
 
 	_, _, err := ReadSourceManifestFile(manifestPath)
 	if err != nil {
@@ -115,6 +160,111 @@ func StagePreparedInstallDir(manifestPath, stagingDir string, opts StagePrepared
 		ManifestFile:   manifestFile,
 		ManifestFormat: manifestFormat,
 	}, nil
+}
+
+func preparedManifestFileName(format string) string {
+	switch format {
+	case ManifestFormatYAML:
+		return "manifest.yaml"
+	default:
+		return ManifestFile
+	}
+}
+
+func resolvePreparedInstallBuildKind(root string, manifest *providermanifestv1.Manifest, kind string) (string, error) {
+	kind = strings.TrimSpace(kind)
+	if kind == "" {
+		var err error
+		kind, err = ManifestKind(manifest)
+		if err != nil {
+			return "", err
+		}
+	}
+	if kind == providermanifestv1.KindWebUI {
+		return "", nil
+	}
+
+	if buildKind, err := resolvePreparedInstallBuildTarget(root, kind); err == nil {
+		return buildKind, nil
+	} else if !isMissingPreparedInstallBuildTarget(err, kind) {
+		return "", err
+	}
+
+	entry := EntrypointForKind(manifest, kind)
+	if artifactExistsForEntrypoint(root, entry) {
+		return "", nil
+	}
+
+	if preparedInstallRequiresBuild(manifest, kind) {
+		return "", missingPreparedInstallBuildTargetError(kind)
+	}
+	return "", nil
+}
+
+func preparedInstallRequiresBuild(manifest *providermanifestv1.Manifest, kind string) bool {
+	switch kind {
+	case providermanifestv1.KindPlugin:
+		return manifest != nil && manifest.Entrypoint == nil && (manifest.Spec == nil || !manifest.Spec.IsManifestBacked())
+	case providermanifestv1.KindAuth, providermanifestv1.KindIndexedDB, providermanifestv1.KindCache, providermanifestv1.KindS3, providermanifestv1.KindSecrets:
+		return EntrypointForKind(manifest, kind) == nil
+	default:
+		return false
+	}
+}
+
+func resolvePreparedInstallBuildTarget(root, kind string) (string, error) {
+	switch kind {
+	case providermanifestv1.KindPlugin:
+		ok, err := HasSourceProviderPackage(root)
+		if err != nil {
+			return "", err
+		}
+		if !ok {
+			return "", ErrNoSourceProviderPackage
+		}
+		return kind, nil
+	case providermanifestv1.KindAuth, providermanifestv1.KindIndexedDB, providermanifestv1.KindCache, providermanifestv1.KindS3, providermanifestv1.KindSecrets:
+		ok, err := HasSourceComponentPackage(root, kind)
+		if err != nil {
+			return "", err
+		}
+		if !ok {
+			return "", ErrNoSourceComponentPackage
+		}
+		return kind, nil
+	default:
+		return "", fmt.Errorf("unsupported release build target kind %q", kind)
+	}
+}
+
+func isMissingPreparedInstallBuildTarget(err error, kind string) bool {
+	switch kind {
+	case providermanifestv1.KindPlugin:
+		return errors.Is(err, ErrNoSourceProviderPackage)
+	case providermanifestv1.KindAuth, providermanifestv1.KindIndexedDB, providermanifestv1.KindCache, providermanifestv1.KindS3, providermanifestv1.KindSecrets:
+		return errors.Is(err, ErrNoSourceComponentPackage)
+	default:
+		return false
+	}
+}
+
+func missingPreparedInstallBuildTargetError(kind string) error {
+	switch kind {
+	case providermanifestv1.KindPlugin:
+		return ErrNoSourceProviderPackage
+	case providermanifestv1.KindAuth, providermanifestv1.KindIndexedDB, providermanifestv1.KindCache, providermanifestv1.KindS3, providermanifestv1.KindSecrets:
+		return ErrNoSourceComponentPackage
+	default:
+		return fmt.Errorf("unsupported release build target kind %q", kind)
+	}
+}
+
+func artifactExistsForEntrypoint(root string, entry *providermanifestv1.Entrypoint) bool {
+	if entry == nil || strings.TrimSpace(entry.ArtifactPath) == "" {
+		return false
+	}
+	_, err := os.Stat(filepath.Join(root, filepath.FromSlash(entry.ArtifactPath)))
+	return err == nil
 }
 
 func buildPreparedInstallBinary(root, outputPath, pluginName, kind, goos, goarch string) (string, error) {
@@ -326,24 +476,31 @@ func stagePreparedOwnedUI(manifest *providermanifestv1.Manifest, sourceDir, stag
 	if err := RunSourceReleaseBuild(uiManifestPath, uiManifest); err != nil {
 		return fmt.Errorf("build owned ui package %s: %w", ownedUI.Path, err)
 	}
-	packagedRelPath := packagedOwnedUIManifestPath(ownedUI.Path)
-	packagedDir := filepath.Join(stagingDir, filepath.FromSlash(path.Dir(packagedRelPath)))
-	if _, err := StagePreparedInstallDir(uiManifestPath, packagedDir, StagePreparedInstallOptions{}); err != nil {
+	packagedDir := filepath.Join(stagingDir, filepath.FromSlash(packagedOwnedUIDir(ownedUI.Path)))
+	staged, err := StagePreparedInstallDir(uiManifestPath, packagedDir, StagePreparedInstallOptions{})
+	if err != nil {
 		return fmt.Errorf("stage owned ui package %s: %w", ownedUI.Path, err)
+	}
+	packagedRelPath, err := filepath.Rel(stagingDir, staged.ManifestPath)
+	if err != nil {
+		return fmt.Errorf("resolve staged owned ui manifest %s: %w", ownedUI.Path, err)
+	}
+	packagedRelPath, err = normalizePreparedInstallPath(filepath.ToSlash(packagedRelPath))
+	if err != nil {
+		return fmt.Errorf("normalize staged owned ui manifest %s: %w", ownedUI.Path, err)
 	}
 
 	ownedUI.Path = packagedRelPath
 	return nil
 }
 
-func packagedOwnedUIManifestPath(rel string) string {
+func packagedOwnedUIDir(rel string) string {
 	cleanRel := path.Clean(strings.ReplaceAll(rel, "\\", "/"))
-	manifestFile := path.Base(cleanRel)
 	parent := path.Base(path.Dir(cleanRel))
 	if parent == "." || parent == "/" || parent == "" {
-		return path.Join(releaseOwnedUIRoot, manifestFile)
+		return releaseOwnedUIRoot
 	}
-	return path.Join(releaseOwnedUIRoot, parent, manifestFile)
+	return path.Join(releaseOwnedUIRoot, parent)
 }
 
 func normalizePreparedInstallPath(rel string) (string, error) {

--- a/gestaltd/internal/providerpkg/prepared_stage_test.go
+++ b/gestaltd/internal/providerpkg/prepared_stage_test.go
@@ -1,0 +1,63 @@
+package providerpkg
+
+import (
+	"os"
+	"path/filepath"
+	"runtime"
+	"testing"
+
+	"github.com/valon-technologies/gestalt/server/internal/testutil"
+	providermanifestv1 "github.com/valon-technologies/gestalt/server/sdk/providermanifest/v1"
+)
+
+func TestStageSourcePreparedInstallDir_BuildsHostBinaryWhenSourcePackageExists(t *testing.T) {
+	t.Parallel()
+
+	root := t.TempDir()
+	testutil.CopyExampleProviderPlugin(t, root)
+
+	staleArtifactPath := filepath.ToSlash(filepath.Join("artifacts", runtime.GOOS, runtime.GOARCH, "provider"))
+	mustWriteFile(t, filepath.Join(root, filepath.FromSlash(staleArtifactPath)), []byte("stale-binary"), 0o755)
+	manifestPath := mustWriteManifestData(t, root, "manifest.yaml", mustManifestYAML(t, &providermanifestv1.Manifest{
+		Kind:        providermanifestv1.KindPlugin,
+		Source:      "github.com/test/plugins/provider",
+		Version:     "0.0.1-alpha.1",
+		DisplayName: "Example Provider",
+		Spec:        &providermanifestv1.Spec{},
+		Artifacts: []providermanifestv1.Artifact{{
+			OS:   runtime.GOOS,
+			Arch: runtime.GOARCH,
+			Path: staleArtifactPath,
+		}},
+		Entrypoint: &providermanifestv1.Entrypoint{ArtifactPath: staleArtifactPath},
+	}))
+
+	stagingDir := filepath.Join(t.TempDir(), "prepared")
+	staged, err := StageSourcePreparedInstallDir(manifestPath, stagingDir, StageSourcePreparedInstallOptions{
+		Kind:       providermanifestv1.KindPlugin,
+		PluginName: "prepared-stage-test",
+		GOOS:       runtime.GOOS,
+		GOARCH:     runtime.GOARCH,
+	})
+	if err != nil {
+		t.Fatalf("StageSourcePreparedInstallDir: %v", err)
+	}
+
+	wantBinary := stagedReleaseBinaryName("prepared-stage-test", runtime.GOOS)
+	if staged.Manifest == nil || staged.Manifest.Entrypoint == nil || staged.Manifest.Entrypoint.ArtifactPath != wantBinary {
+		var entrypoint any
+		if staged.Manifest != nil {
+			entrypoint = staged.Manifest.Entrypoint
+		}
+		t.Fatalf("staged manifest entrypoint = %#v, want artifact path %q", entrypoint, wantBinary)
+	}
+
+	stagedBinaryPath := filepath.Join(stagingDir, wantBinary)
+	data, err := os.ReadFile(stagedBinaryPath)
+	if err != nil {
+		t.Fatalf("ReadFile(%s): %v", stagedBinaryPath, err)
+	}
+	if string(data) == "stale-binary" {
+		t.Fatalf("staged binary reused stale checked-in artifact")
+	}
+}


### PR DESCRIPTION
## Summary
This PR makes local `source.path` execution use the same prepared-install lifecycle boundary as packaged execution.

Source-backed plugins, auth/indexeddb/cache/s3/secrets providers, and mounted UIs now prepare into `.gestaltd/...` before runtime binding. `validate` prepares in scratch space, `init` writes the lock/artifacts boundary, and locked execution consumes only prepared installs.

## Go Interfaces
- Added `(*Lifecycle).LoadForValidationAtPathsWithArtifactsDir(configPaths, artifactsDir)`.
- Refactored `init`, `validate`, and execution preparation through shared `prepareRuntimeLockFromLoadedConfig(...)`.
- Added shared source staging via `providerpkg.StageSourcePreparedInstallDir(...)`.

## YAML Interfaces
```yaml
plugins:
  example:
    source:
      path: ./manifest.yaml

providers:
  auth:
    local:
      source:
        path: ./auth-manifest.yaml

  ui:
    roadmap:
      source:
        path: ./webui/manifest.yaml
      path: /roadmap
```

## CLI Examples
```bash
gestaltd validate --config config.yaml
gestaltd init --config config.yaml
gestaltd serve --config config.yaml --locked
```

## Behavior Changes
- Local `source.path` entries now stage into prepared installs under `.gestaltd/...` and runtime binds only those prepared installs.
- `validate` always uses a scratch prepared-install directory and does not mutate `gestalt.lock.json` or a caller-supplied `--artifacts-dir`.
- Unlocked `serve` refreshes local source-backed entries before execution.
- Locked execution requires prepared installs for local source-backed entries, including explicit mounted UIs.
- Non-canonical owned UI manifest filenames now normalize correctly when staged.
- When a source package is buildable, staging prefers rebuilding it instead of silently reusing a checked-in entrypoint artifact.

## Rust / Executable Transport
- Rust, Go, Python, and TypeScript source plugins now converge on the same prepared executable lifecycle before execution.
- This PR does **not** introduce a new stdin/stdout protocol. Runtime still uses the existing prepared executable contract after `init` / `validate` preparation.

## End-to-End Flow Examples
- `gestaltd validate --config config.yaml`
  - prepares local source plugins in scratch space
  - validates them end-to-end
  - leaves no `gestalt.lock.json` behind
- `gestaltd init --config config.yaml`
  - writes prepared installs plus `gestalt.lock.json`
- `gestaltd serve --config config.yaml --locked`
  - consumes only prepared installs from the lock/artifacts boundary

## Verification
- `go test ./internal/providerpkg`
- `go test ./internal/operator`
- `go test ./cmd/gestaltd`
- isolated rerun: `go test ./internal/operator -run '^TestLoadForExecutionAtPath_GeneratesStaticCatalogForLocalPythonSourcePlugin$'`
