### PR TITLE
core: centralize session operation resolution

### DIFF
--- a/gestaltd/core/integration/base.go
+++ b/gestaltd/core/integration/base.go
@@ -46,16 +46,18 @@ const (
 )
 
 type Base struct {
-	IntegrationName    string
-	IntegrationDisplay string
-	IntegrationDesc    string
-	ConnMode           core.ConnectionMode
-	Auth               AuthHandler
-	BaseURL            string
-	Headers            map[string]string
-	AuthStyle          AuthStyle
-	HTTPClient         *http.Client
-	Pagination         map[string]apiexec.PaginationConfig
+	IntegrationName             string
+	IntegrationDisplay          string
+	IntegrationDesc             string
+	ConnMode                    core.ConnectionMode
+	Auth                        AuthHandler
+	BaseURL                     string
+	Headers                     map[string]string
+	AuthStyle                   AuthStyle
+	HTTPClient                  *http.Client
+	Pagination                  map[string]apiexec.PaginationConfig
+	MethodDefaultParamLocations bool
+	NoRetry                     bool
 
 	TokenParser     func(token string) (authHeader string, extraHeaders map[string]string, err error)
 	CheckResponse   apiexec.ResponseChecker

--- a/gestaltd/core/integration/egress_adapter.go
+++ b/gestaltd/core/integration/egress_adapter.go
@@ -3,6 +3,7 @@ package integration
 import (
 	"context"
 	"fmt"
+	"net/http"
 	"net/url"
 	"strings"
 
@@ -23,7 +24,7 @@ func (b *Base) executeREST(ctx context.Context, operation string, catOp *catalog
 	if strings.TrimSpace(catOp.Path) == "" {
 		return nil, fmt.Errorf("operation %q is missing path", operation)
 	}
-	bodyParams, queryParams, headerParams := partitionParams(catOp, params)
+	bodyParams, queryParams, headerParams := partitionParams(catOp, params, b.MethodDefaultParamLocations)
 
 	baseURL, headers := b.resolvedURLAndHeaders(ctx)
 	for k, v := range headerParams {
@@ -52,6 +53,7 @@ func (b *Base) executeREST(ctx context.Context, operation string, catOp *catalog
 		AuthHeader:    credential.Authorization,
 		CustomHeaders: headers,
 		CheckResponse: b.CheckResponse,
+		NoRetry:       b.NoRetry,
 	}
 
 	if pgn, ok := b.Pagination[operation]; ok {
@@ -117,14 +119,23 @@ func findCatalogOp(cat *catalog.Catalog, id string) *catalog.CatalogOperation {
 	return nil
 }
 
-func partitionParams(catOp *catalog.CatalogOperation, params map[string]any) (body map[string]any, query map[string]any, headers map[string]string) {
+func partitionParams(catOp *catalog.CatalogOperation, params map[string]any, useMethodDefault bool) (body map[string]any, query map[string]any, headers map[string]string) {
+	defaultLocation := "body"
+	if useMethodDefault {
+		defaultLocation = defaultParamLocation(catOp)
+	}
 	if catOp == nil || len(catOp.Parameters) == 0 {
+		if defaultLocation == "query" {
+			return nil, params, nil
+		}
 		return params, nil, nil
 	}
 
+	declared := make(map[string]struct{}, len(catOp.Parameters))
 	locations := make(map[string]string, len(catOp.Parameters))
 	var wireNames map[string]string
 	for _, p := range catOp.Parameters {
+		declared[p.Name] = struct{}{}
 		if p.Location != "" {
 			locations[p.Name] = p.Location
 		}
@@ -135,10 +146,6 @@ func partitionParams(catOp *catalog.CatalogOperation, params map[string]any) (bo
 			wireNames[p.Name] = p.WireName
 		}
 	}
-	if len(locations) == 0 {
-		return params, nil, nil
-	}
-
 	body = make(map[string]any)
 	query = make(map[string]any)
 	headers = make(map[string]string)
@@ -155,8 +162,31 @@ func partitionParams(catOp *catalog.CatalogOperation, params map[string]any) (bo
 		case "path":
 			body[httpKey] = v
 		default:
+			if _, ok := declared[k]; ok {
+				if useMethodDefault {
+					continue
+				}
+				body[k] = v
+				continue
+			}
+			if defaultLocation == "query" {
+				query[httpKey] = v
+				continue
+			}
 			body[k] = v
 		}
 	}
 	return body, query, headers
+}
+
+func defaultParamLocation(catOp *catalog.CatalogOperation) string {
+	if catOp == nil {
+		return "body"
+	}
+	switch strings.ToUpper(strings.TrimSpace(catOp.Method)) {
+	case http.MethodGet, http.MethodDelete:
+		return "query"
+	default:
+		return "body"
+	}
 }

--- a/gestaltd/core/integration/param_routing_test.go
+++ b/gestaltd/core/integration/param_routing_test.go
@@ -16,7 +16,7 @@ func TestPartitionParams_NilCatalogOp(t *testing.T) {
 	t.Parallel()
 
 	params := map[string]any{"name": "x", "page": 2}
-	body, query, headers := partitionParams(nil, params)
+	body, query, headers := partitionParams(nil, params, false)
 
 	if body["name"] != "x" || body["page"] != 2 {
 		t.Fatalf("body = %v, want all params", body)
@@ -33,24 +33,44 @@ func TestPartitionParams_NoLocations(t *testing.T) {
 	t.Parallel()
 
 	catOp := &catalog.CatalogOperation{
-		ID: "op1",
+		ID:     "op1",
+		Method: http.MethodGet,
 		Parameters: []catalog.CatalogParameter{
 			{Name: "name", Type: "string"},
 			{Name: "count", Type: "integer"},
 		},
 	}
-	params := map[string]any{"name": "x", "count": 5}
-	body, query, headers := partitionParams(catOp, params)
+	t.Run("declared params remain dropped in method default mode", func(t *testing.T) {
+		t.Parallel()
+		params := map[string]any{"name": "x", "count": 5}
+		body, query, headers := partitionParams(catOp, params, true)
 
-	if body["name"] != "x" || body["count"] != 5 {
-		t.Fatalf("body = %v, want all params", body)
-	}
-	if query != nil {
-		t.Fatalf("query = %v, want nil", query)
-	}
-	if headers != nil {
-		t.Fatalf("headers = %v, want nil", headers)
-	}
+		if len(body) != 0 {
+			t.Fatalf("body = %v, want no declared params", body)
+		}
+		if len(query) != 0 {
+			t.Fatalf("query = %v, want no declared params", query)
+		}
+		if len(headers) != 0 {
+			t.Fatalf("headers = %v, want no header params", headers)
+		}
+	})
+
+	t.Run("undeclared params still use method defaults", func(t *testing.T) {
+		t.Parallel()
+		params := map[string]any{"name": "x", "count": 5, "page": 2}
+		body, query, headers := partitionParams(catOp, params, true)
+
+		if len(body) != 0 {
+			t.Fatalf("body = %v, want nil", body)
+		}
+		if query["page"] != 2 || len(query) != 1 {
+			t.Fatalf("query = %v, want only undeclared params", query)
+		}
+		if len(headers) != 0 {
+			t.Fatalf("headers = %v, want nil", headers)
+		}
+	})
 }
 
 func TestPartitionParams_MixedLocations(t *testing.T) {
@@ -71,7 +91,7 @@ func TestPartitionParams_MixedLocations(t *testing.T) {
 		"x_api_key": "secret",
 		"item_id":   "abc",
 	}
-	body, query, headers := partitionParams(catOp, params)
+	body, query, headers := partitionParams(catOp, params, false)
 
 	if body["name"] != "widget" {
 		t.Fatalf("body[name] = %v, want widget", body["name"])
@@ -91,7 +111,8 @@ func TestPartitionParams_UnknownParam(t *testing.T) {
 	t.Parallel()
 
 	catOp := &catalog.CatalogOperation{
-		ID: "op1",
+		ID:     "op1",
+		Method: http.MethodGet,
 		Parameters: []catalog.CatalogParameter{
 			{Name: "page", Type: "integer", Location: "query"},
 		},
@@ -100,13 +121,13 @@ func TestPartitionParams_UnknownParam(t *testing.T) {
 		"page":    1,
 		"unknown": "extra",
 	}
-	body, query, _ := partitionParams(catOp, params)
+	_, query, _ := partitionParams(catOp, params, true)
 
 	if query["page"] != 1 {
 		t.Fatalf("query[page] = %v, want 1", query["page"])
 	}
-	if body["unknown"] != "extra" {
-		t.Fatalf("body[unknown] = %v, want extra (unknown params default to body)", body["unknown"])
+	if query["unknown"] != "extra" {
+		t.Fatalf("query[unknown] = %v, want extra (unknown GET params default to query)", query["unknown"])
 	}
 }
 

--- a/gestaltd/internal/bootstrap/bootstrap_test.go
+++ b/gestaltd/internal/bootstrap/bootstrap_test.go
@@ -2,6 +2,7 @@ package bootstrap_test
 
 import (
 	"context"
+	"encoding/base64"
 	"encoding/hex"
 	"fmt"
 	"net/http"
@@ -167,8 +168,12 @@ func TestBootstrap(t *testing.T) {
 		cases := []struct {
 			name           string
 			restConnection string
+			specAuth       *providermanifestv1.ProviderAuth
 			connections    map[string]*providermanifestv1.ManifestConnectionDef
 			tokenConn      string
+			tokenValue     string
+			wantAuth       string
+			wantAPIKey     string
 		}{
 			{
 				name: "single named connection is inferred as default",
@@ -210,6 +215,63 @@ func TestBootstrap(t *testing.T) {
 				},
 				tokenConn: "workspace",
 			},
+			{
+				name: "declarative auth mapping basic preserves derived authorization header",
+				specAuth: &providermanifestv1.ProviderAuth{
+					Type: providermanifestv1.AuthTypeManual,
+					AuthMapping: &providermanifestv1.AuthMapping{
+						Basic: &providermanifestv1.BasicAuthMapping{
+							Username: providermanifestv1.AuthValue{
+								ValueFrom: &providermanifestv1.AuthValueFrom{
+									CredentialFieldRef: &providermanifestv1.CredentialFieldRef{Name: "username"},
+								},
+							},
+							Password: providermanifestv1.AuthValue{
+								ValueFrom: &providermanifestv1.AuthValueFrom{
+									CredentialFieldRef: &providermanifestv1.CredentialFieldRef{Name: "password"},
+								},
+							},
+						},
+					},
+				},
+				connections: map[string]*providermanifestv1.ManifestConnectionDef{
+					"default": {Mode: providermanifestv1.ConnectionModeUser},
+				},
+				tokenConn:  "default",
+				tokenValue: `{"username":"alice","password":"secret"}`,
+				wantAuth:   "Basic " + base64.StdEncoding.EncodeToString([]byte("alice:secret")),
+			},
+			{
+				name: "declarative auth mapping headers preserves derived upstream header",
+				specAuth: &providermanifestv1.ProviderAuth{
+					Type: providermanifestv1.AuthTypeManual,
+					AuthMapping: &providermanifestv1.AuthMapping{
+						Headers: map[string]providermanifestv1.AuthValue{
+							"X-API-Key": {
+								ValueFrom: &providermanifestv1.AuthValueFrom{
+									CredentialFieldRef: &providermanifestv1.CredentialFieldRef{Name: "api_key"},
+								},
+							},
+						},
+					},
+				},
+				connections: map[string]*providermanifestv1.ManifestConnectionDef{
+					"default": {Mode: providermanifestv1.ConnectionModeUser},
+				},
+				tokenConn:  "default",
+				tokenValue: `{"api_key":"secret-key"}`,
+				wantAPIKey: "secret-key",
+			},
+			{
+				name:     "auth none still forwards bearer token when connection mode is user",
+				specAuth: &providermanifestv1.ProviderAuth{Type: providermanifestv1.AuthTypeNone},
+				connections: map[string]*providermanifestv1.ManifestConnectionDef{
+					"workspace": {Mode: providermanifestv1.ConnectionModeUser},
+				},
+				restConnection: "workspace",
+				tokenConn:      "workspace",
+				wantAuth:       "Bearer workspace-access-token",
+			},
 		}
 
 		for _, tc := range cases {
@@ -218,9 +280,11 @@ func TestBootstrap(t *testing.T) {
 				t.Parallel()
 
 				var authHeader atomic.Value
+				var apiKeyHeader atomic.Value
 				var requestPath atomic.Value
 				srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 					authHeader.Store(r.Header.Get("Authorization"))
+					apiKeyHeader.Store(r.Header.Get("X-API-Key"))
 					requestPath.Store(r.URL.Path)
 					w.Header().Set("Content-Type", "application/json")
 					w.WriteHeader(http.StatusOK)
@@ -233,6 +297,7 @@ func TestBootstrap(t *testing.T) {
 					"slack": {
 						ResolvedManifest: &providermanifestv1.Manifest{
 							Spec: &providermanifestv1.Spec{
+								Auth: tc.specAuth,
 								Surfaces: &providermanifestv1.ProviderSurfaces{
 									REST: &providermanifestv1.RESTSurface{
 										BaseURL:    srv.URL,
@@ -260,6 +325,9 @@ func TestBootstrap(t *testing.T) {
 					t.Fatalf("FindOrCreateUser: %v", err)
 				}
 				tokenValue := tc.tokenConn + "-access-token"
+				if tc.tokenValue != "" {
+					tokenValue = tc.tokenValue
+				}
 				if err := result.Services.Tokens.StoreToken(ctx, &core.IntegrationToken{
 					UserID:       user.ID,
 					Integration:  "slack",
@@ -287,8 +355,14 @@ func TestBootstrap(t *testing.T) {
 					t.Fatalf("path = %q, want %q", gotPath, "/users")
 				}
 				wantAuth := "Bearer " + tokenValue
+				if tc.wantAuth != "" || tc.specAuth != nil {
+					wantAuth = tc.wantAuth
+				}
 				if gotAuth, _ := authHeader.Load().(string); gotAuth != wantAuth {
 					t.Fatalf("Authorization = %q, want %q", gotAuth, wantAuth)
+				}
+				if gotAPIKey, _ := apiKeyHeader.Load().(string); gotAPIKey != tc.wantAPIKey {
+					t.Fatalf("X-API-Key = %q, want %q", gotAPIKey, tc.wantAPIKey)
 				}
 			})
 		}

--- a/gestaltd/internal/invocation/broker.go
+++ b/gestaltd/internal/invocation/broker.go
@@ -235,7 +235,7 @@ func (b *Broker) Invoke(ctx context.Context, p *principal.Principal, providerNam
 		return fail(fmt.Errorf("%w: %s.%s", ErrAuthorizationDenied, providerName, operation))
 	}
 
-	opMeta, transport, err := b.resolveOperation(ctx, p, prov, providerName, operation, conn, instance)
+	opMeta, transport, resolvedConnection, err := b.resolveOperation(ctx, p, prov, providerName, operation, conn, instance)
 	if err != nil {
 		return fail(err)
 	}
@@ -250,6 +250,9 @@ func (b *Broker) Invoke(ctx context.Context, p *principal.Principal, providerNam
 		return fail(core.ErrMCPOnly)
 	}
 
+	if conn == "" {
+		conn = resolvedConnection
+	}
 	if conn == "" {
 		if transport == catalog.TransportMCPPassthrough {
 			conn = b.mcpConnection(providerName)
@@ -289,29 +292,16 @@ func (b *Broker) Invoke(ctx context.Context, p *principal.Principal, providerNam
 	return result, nil
 }
 
-func (b *Broker) resolveOperation(ctx context.Context, p *principal.Principal, prov core.Provider, providerName, operation, connection, instance string) (catalog.CatalogOperation, string, error) {
-	if op, ok := CatalogOperationFromContext(ctx, providerName, operation); ok {
-		return op, catalogOperationTransport(op), nil
-	}
-
-	if op, ok := CatalogOperation(providerCatalog(prov), operation); ok {
-		return op, catalogOperationTransport(op), nil
-	}
-
-	if core.SupportsSessionCatalog(prov) {
-		if connection == "" {
-			connection = b.mcpConnection(providerName)
-		}
-		cat, _, err := resolveSessionCatalog(ctx, prov, providerName, b, p, connection, instance)
-		if err != nil {
-			return catalog.CatalogOperation{}, "", err
-		}
-		if op, ok := CatalogOperation(cat, operation); ok {
-			return op, catalogOperationTransport(op), nil
+func (b *Broker) resolveOperation(ctx context.Context, p *principal.Principal, prov core.Provider, providerName, operation, connection, instance string) (catalog.CatalogOperation, string, string, error) {
+	sessionConnections := []string{connection}
+	if connection == "" {
+		sessionConnections = nil
+		if mcpConnection := b.mcpConnection(providerName); mcpConnection != "" {
+			sessionConnections = []string{mcpConnection}
 		}
 	}
 
-	return catalog.CatalogOperation{}, "", fmt.Errorf("%w: %q on provider %q", ErrOperationNotFound, operation, providerName)
+	return ResolveOperation(ctx, prov, providerName, b, p, operation, sessionConnections, instance)
 }
 
 func (b *Broker) mcpConnection(providerName string) string {

--- a/gestaltd/internal/invocation/capabilities.go
+++ b/gestaltd/internal/invocation/capabilities.go
@@ -25,7 +25,7 @@ func capabilitiesFromCatalog(name string, cat *catalog.Catalog) []core.Capabilit
 		}
 
 		method := strings.ToUpper(strings.TrimSpace(op.Method))
-		transport := catalogOperationTransport(op)
+		transport := OperationTransport(op)
 
 		caps = append(caps, core.Capability{
 			Provider:    name,
@@ -68,10 +68,10 @@ func CatalogOperationTransport(cat *catalog.Catalog, operation string) (string, 
 	if !ok {
 		return "", false
 	}
-	return catalogOperationTransport(op), true
+	return OperationTransport(op), true
 }
 
-func catalogOperationTransport(op catalog.CatalogOperation) string {
+func OperationTransport(op catalog.CatalogOperation) string {
 	transport := strings.TrimSpace(op.Transport)
 	if transport == "" && strings.TrimSpace(op.Method) != "" {
 		return catalog.TransportREST

--- a/gestaltd/internal/invocation/catalog.go
+++ b/gestaltd/internal/invocation/catalog.go
@@ -26,11 +26,6 @@ func ResolveCatalog(ctx context.Context, prov core.Provider, provName string, re
 	return cat, err
 }
 
-func ResolveCatalogStrict(ctx context.Context, prov core.Provider, provName string, resolver TokenResolver, p *principal.Principal, defaultConnection, instance string) (*catalog.Catalog, error) {
-	cat, _, err := ResolveCatalogStrictWithMetadata(ctx, prov, provName, resolver, p, defaultConnection, instance)
-	return cat, err
-}
-
 func ResolveCatalogWithMetadata(ctx context.Context, prov core.Provider, provName string, resolver TokenResolver, p *principal.Principal, defaultConnection, instance string) (*catalog.Catalog, CatalogResolutionMetadata, error) {
 	return resolveCatalog(ctx, prov, provName, resolver, p, defaultConnection, instance, false)
 }
@@ -39,9 +34,30 @@ func ResolveCatalogStrictWithMetadata(ctx context.Context, prov core.Provider, p
 	return resolveCatalog(ctx, prov, provName, resolver, p, defaultConnection, instance, true)
 }
 
-func ResolveSessionCatalog(ctx context.Context, prov core.Provider, provName string, resolver TokenResolver, p *principal.Principal, connection, instance string) (*catalog.Catalog, error) {
-	cat, _, err := resolveSessionCatalog(ctx, prov, provName, resolver, p, connection, instance)
-	return cat, err
+func ResolveOperation(ctx context.Context, prov core.Provider, provName string, resolver TokenResolver, p *principal.Principal, operation string, sessionConnections []string, instance string) (catalog.CatalogOperation, string, string, error) {
+	if op, ok := CatalogOperationFromContext(ctx, provName, operation); ok {
+		return op, OperationTransport(op), "", nil
+	}
+
+	staticOp, staticOK := CatalogOperation(providerCatalog(prov), operation)
+	if !core.SupportsSessionCatalog(prov) {
+		if staticOK {
+			return staticOp, OperationTransport(staticOp), "", nil
+		}
+		return catalog.CatalogOperation{}, "", "", fmt.Errorf("%w: %q on provider %q", ErrOperationNotFound, operation, provName)
+	}
+
+	sessionOp, sessionConnection, sessionFound, err := resolveSessionOperation(ctx, prov, provName, resolver, p, operation, sessionConnections, instance)
+	if err != nil {
+		return catalog.CatalogOperation{}, "", "", err
+	}
+	if sessionFound {
+		return sessionOp, OperationTransport(sessionOp), sessionConnection, nil
+	}
+	if instance == "" && staticOK {
+		return staticOp, OperationTransport(staticOp), "", nil
+	}
+	return catalog.CatalogOperation{}, "", "", fmt.Errorf("%w: %q on provider %q", ErrOperationNotFound, operation, provName)
 }
 
 func resolveCatalog(ctx context.Context, prov core.Provider, provName string, resolver TokenResolver, p *principal.Principal, defaultConnection, instance string, strictSession bool) (*catalog.Catalog, CatalogResolutionMetadata, error) {
@@ -89,6 +105,37 @@ func resolveSessionCatalog(ctx context.Context, prov core.Provider, provName str
 	}
 	cat, _, err := core.CatalogForRequest(ctx, prov, token)
 	return cat, true, err
+}
+
+func resolveSessionOperation(ctx context.Context, prov core.Provider, provName string, resolver TokenResolver, p *principal.Principal, operation string, connections []string, instance string) (catalog.CatalogOperation, string, bool, error) {
+	if len(connections) == 0 {
+		connections = []string{""}
+	}
+
+	var (
+		firstErr error
+		resolved bool
+	)
+	for _, connection := range connections {
+		cat, attempted, err := resolveSessionCatalog(ctx, prov, provName, resolver, p, connection, instance)
+		if err != nil {
+			if firstErr == nil {
+				firstErr = err
+			}
+			continue
+		}
+		if !attempted || cat == nil {
+			continue
+		}
+		resolved = true
+		if op, ok := CatalogOperation(cat, operation); ok {
+			return op, connection, true, nil
+		}
+	}
+	if firstErr != nil && !resolved {
+		return catalog.CatalogOperation{}, "", false, firstErr
+	}
+	return catalog.CatalogOperation{}, "", false, nil
 }
 
 func mergeCatalogs(provName string, staticCat, sessionCat *catalog.Catalog) (*catalog.Catalog, error) {

--- a/gestaltd/internal/mcp/binding_test.go
+++ b/gestaltd/internal/mcp/binding_test.go
@@ -2443,6 +2443,76 @@ func TestNewServer_SessionHydratedRESTToolUsesHydrationConnection(t *testing.T) 
 	if seenToken != "catalog-token" {
 		t.Fatalf("execute token = %q, want %q", seenToken, "catalog-token")
 	}
+
+	t.Run("broker resolution uses session metadata before static collision", func(t *testing.T) {
+		t.Parallel()
+
+		seenToken = ""
+		usedDirectTool := false
+		collisionProv := &directCallerProvider{
+			StubIntegration: coretesting.StubIntegration{
+				N:        "sampledb",
+				ConnMode: core.ConnectionModeUser,
+				ExecuteFn: func(_ context.Context, _ string, _ map[string]any, token string) (*core.OperationResult, error) {
+					seenToken = token
+					return &core.OperationResult{Status: http.StatusOK, Body: `{"ok":true}`}, nil
+				},
+			},
+			cat: &catalog.Catalog{
+				Name: "sampledb",
+				Operations: []catalog.CatalogOperation{
+					{ID: "run_query", Description: "static query", Transport: catalog.TransportMCPPassthrough},
+				},
+			},
+			sessionCatalogFn: func(_ context.Context, token string) (*catalog.Catalog, error) {
+				switch token {
+				case "catalog-token":
+					return &catalog.Catalog{
+						Name: "sampledb",
+						Operations: []catalog.CatalogOperation{
+							{ID: "run_query", Description: "session query", Method: http.MethodGet, Transport: catalog.TransportREST},
+						},
+					}, nil
+				case "rest-token":
+					return &catalog.Catalog{Name: "sampledb"}, nil
+				default:
+					return nil, fmt.Errorf("unexpected token %q", token)
+				}
+			},
+			callFn: func(_ context.Context, _ string, _ map[string]any) (*mcpgo.CallToolResult, error) {
+				usedDirectTool = true
+				return mcpgo.NewToolResultText("static"), nil
+			},
+		}
+
+		collisionProviders := testutil.NewProviderRegistry(t, collisionProv)
+		collisionBroker := invocation.NewBroker(
+			collisionProviders,
+			ds.Users,
+			ds.Tokens,
+			invocation.WithConnectionMapper(invocation.ConnectionMap(map[string]string{"sampledb": "rest-conn"})),
+			invocation.WithMCPConnectionMapper(invocation.ConnectionMap(map[string]string{"sampledb": "catalog-conn"})),
+		)
+		collisionServer := gestaltmcp.NewServer(gestaltmcp.Config{
+			Invoker:       collisionBroker,
+			TokenResolver: collisionBroker,
+			Providers:     collisionProviders,
+			MCPConnection: map[string]string{"sampledb": "catalog-conn"},
+		})
+
+		result := callToolForSession(t, collisionServer, ctxWithPrincipal(userID), newTestSessionWithTools(), "sampledb_run_query", map[string]any{
+			"sql": "select 1",
+		})
+		if result.IsError {
+			t.Fatalf("expected success result, got %+v", result)
+		}
+		if usedDirectTool {
+			t.Fatal("expected session REST metadata to beat static MCP collision")
+		}
+		if seenToken != "catalog-token" {
+			t.Fatalf("execute token = %q, want %q", seenToken, "catalog-token")
+		}
+	})
 }
 
 func TestNewServer_HumanCallToolUsesNormalizedRequestedInstanceWithoutOverwritingDefaultTools(t *testing.T) {

--- a/gestaltd/internal/providerhost/declarative.go
+++ b/gestaltd/internal/providerhost/declarative.go
@@ -10,45 +10,43 @@ import (
 	"github.com/valon-technologies/gestalt/server/core"
 	"github.com/valon-technologies/gestalt/server/core/catalog"
 	"github.com/valon-technologies/gestalt/server/core/integration"
-	"github.com/valon-technologies/gestalt/server/internal/apiexec"
-	"github.com/valon-technologies/gestalt/server/internal/paraminterp"
 	"github.com/valon-technologies/gestalt/server/internal/provider"
 	providermanifestv1 "github.com/valon-technologies/gestalt/server/sdk/providermanifest/v1"
 )
 
 const declarativeHTTPTimeout = 30 * time.Second
 
-type DeclarativeProviderOption func(*DeclarativeProvider)
+type declarativeOptions struct {
+	displayName    string
+	description    string
+	iconSVG        string
+	connectionMode core.ConnectionMode
+}
+
+type DeclarativeProviderOption func(*declarativeOptions)
 
 func WithDeclarativeMetadataOverrides(displayName, description, iconSVG string) DeclarativeProviderOption {
-	return func(p *DeclarativeProvider) {
+	return func(opts *declarativeOptions) {
 		if displayName != "" {
-			p.catalog.DisplayName = displayName
+			opts.displayName = displayName
 		}
 		if description != "" {
-			p.catalog.Description = description
+			opts.description = description
 		}
 		if iconSVG != "" {
-			p.catalog.IconSVG = iconSVG
+			opts.iconSVG = iconSVG
 		}
 	}
 }
 
 func WithDeclarativeConnectionMode(mode core.ConnectionMode) DeclarativeProviderOption {
-	return func(p *DeclarativeProvider) {
-		p.connectionMode = mode
-	}
+	return func(opts *declarativeOptions) { opts.connectionMode = mode }
 }
 
 type DeclarativeProvider struct {
-	catalog        *catalog.Catalog
-	opsByName      map[string]*catalog.CatalogOperation
-	baseURL        string
-	auth           *providermanifestv1.ProviderAuth
-	httpClient     *http.Client
-	discovery      *providermanifestv1.ProviderDiscovery
-	connectionDefs map[string]providermanifestv1.ProviderConnectionParam
-	connectionMode core.ConnectionMode
+	*integration.Base
+	authType         providermanifestv1.AuthType
+	authorizationURL string
 }
 
 func NewDeclarativeProvider(manifest *providermanifestv1.Manifest, httpClient *http.Client, opts ...DeclarativeProviderOption) (*DeclarativeProvider, error) {
@@ -63,23 +61,107 @@ func NewDeclarativeProvider(manifest *providermanifestv1.Manifest, httpClient *h
 		httpClient = &http.Client{Timeout: declarativeHTTPTimeout}
 	}
 
-	ops := manifest.Spec.RESTOperations()
-	p := &DeclarativeProvider{
-		catalog: &catalog.Catalog{
-			Name:        manifest.Source,
-			DisplayName: manifest.DisplayName,
-			Description: manifest.Description,
-			Headers:     maps.Clone(manifest.Spec.Headers),
-			Operations:  make([]catalog.CatalogOperation, 0, len(ops)),
-		},
-		opsByName:      make(map[string]*catalog.CatalogOperation, len(ops)),
-		baseURL:        manifest.Spec.RESTBaseURL(),
-		auth:           manifest.Spec.Auth,
-		httpClient:     httpClient,
-		discovery:      manifest.Spec.Discovery,
-		connectionDefs: manifest.Spec.ConnectionParams,
+	options := declarativeOptions{}
+	for _, opt := range opts {
+		opt(&options)
 	}
+	auth := manifest.Spec.Auth
+	cat := declarativeCatalog(manifest, options)
+	authType := providermanifestv1.AuthType("")
+	authorizationURL := ""
+	base := &integration.Base{
+		IntegrationName:             cat.Name,
+		IntegrationDisplay:          cat.DisplayName,
+		IntegrationDesc:             cat.Description,
+		ConnMode:                    declarativeConnectionMode(options.connectionMode, auth),
+		BaseURL:                     manifest.Spec.RESTBaseURL(),
+		Headers:                     maps.Clone(manifest.Spec.Headers),
+		HTTPClient:                  httpClient,
+		MethodDefaultParamLocations: true,
+		ConnectionDefs:              ConnectionParamDefsFromManifest(manifest.Spec.ConnectionParams),
+		DiscoveryDef:                DiscoveryConfigFromManifest(manifest.Spec.Discovery),
+		CredentialFieldDefs:         declarativeCredentialFields(auth),
+		NoRetry:                     true,
+	}
+	if auth != nil {
+		authType = auth.Type
+		authorizationURL = auth.AuthorizationURL
+		if auth.AuthMapping != nil && (len(auth.AuthMapping.Headers) > 0 || auth.AuthMapping.Basic != nil) {
+			base.TokenParser = provider.MappedCredentialParser(auth.AuthMapping)
+		}
+	}
+	base.SetCatalog(cat)
 
+	return &DeclarativeProvider{
+		Base:             base,
+		authType:         authType,
+		authorizationURL: authorizationURL,
+	}, nil
+}
+
+func (p *DeclarativeProvider) Catalog() *catalog.Catalog {
+	return p.Base.Catalog().Clone()
+}
+
+func (p *DeclarativeProvider) Execute(ctx context.Context, operation string, params map[string]any, token string) (*core.OperationResult, error) {
+	if !declarativeHasOperation(p.Base.Catalog(), operation) {
+		return &core.OperationResult{Status: http.StatusNotFound, Body: `{"error":"unknown operation"}`}, nil
+	}
+	return p.Base.Execute(ctx, operation, params, token)
+}
+
+func (p *DeclarativeProvider) AuthTypes() []string {
+	switch p.authType {
+	case providermanifestv1.AuthTypeOAuth2:
+		return []string{"oauth"}
+	case providermanifestv1.AuthTypeBearer, providermanifestv1.AuthTypeManual:
+		return []string{"manual"}
+	case providermanifestv1.AuthTypeNone:
+		return nil
+	default:
+		return nil
+	}
+}
+
+func (p *DeclarativeProvider) AuthorizationURL(state string, scopes []string) string {
+	if p.authType != providermanifestv1.AuthTypeOAuth2 {
+		return ""
+	}
+	return p.authorizationURL
+}
+
+func (p *DeclarativeProvider) ExchangeCode(ctx context.Context, code string) (*core.TokenResponse, error) {
+	if p.authType != providermanifestv1.AuthTypeOAuth2 {
+		return nil, fmt.Errorf("provider does not support OAuth")
+	}
+	return nil, fmt.Errorf("declarative provider OAuth exchange not implemented")
+}
+
+func (p *DeclarativeProvider) RefreshToken(ctx context.Context, refreshToken string) (*core.TokenResponse, error) {
+	if p.authType != providermanifestv1.AuthTypeOAuth2 {
+		return nil, fmt.Errorf("provider does not support OAuth")
+	}
+	return nil, fmt.Errorf("declarative provider OAuth refresh not implemented")
+}
+
+func declarativeCatalog(manifest *providermanifestv1.Manifest, opts declarativeOptions) *catalog.Catalog {
+	ops := manifest.Spec.RESTOperations()
+	cat := &catalog.Catalog{
+		Name:        manifest.Source,
+		DisplayName: manifest.DisplayName,
+		Description: manifest.Description,
+		Headers:     maps.Clone(manifest.Spec.Headers),
+		Operations:  make([]catalog.CatalogOperation, 0, len(ops)),
+	}
+	if opts.displayName != "" {
+		cat.DisplayName = opts.displayName
+	}
+	if opts.description != "" {
+		cat.Description = opts.description
+	}
+	if opts.iconSVG != "" {
+		cat.IconSVG = opts.iconSVG
+	}
 	for i := range ops {
 		mop := &ops[i]
 		catOp := catalog.CatalogOperation{
@@ -100,161 +182,37 @@ func NewDeclarativeProvider(manifest *providermanifestv1.Manifest, httpClient *h
 				Required:    mp.Required,
 			})
 		}
-		p.catalog.Operations = append(p.catalog.Operations, catOp)
+		cat.Operations = append(cat.Operations, catOp)
 	}
-
-	integration.CompileSchemas(p.catalog)
-	for i := range p.catalog.Operations {
-		op := &p.catalog.Operations[i]
-		p.opsByName[op.ID] = op
-	}
-	for _, opt := range opts {
-		opt(p)
-	}
-	if p.connectionMode == "" {
-		if p.auth == nil || p.auth.Type == "" || p.auth.Type == providermanifestv1.AuthTypeNone {
-			p.connectionMode = core.ConnectionModeNone
-		} else {
-			p.connectionMode = core.ConnectionModeUser
-		}
-	}
-
-	return p, nil
+	integration.CompileSchemas(cat)
+	return cat
 }
 
-func (p *DeclarativeProvider) Name() string        { return p.catalog.Name }
-func (p *DeclarativeProvider) DisplayName() string { return p.catalog.DisplayName }
-func (p *DeclarativeProvider) Description() string { return p.catalog.Description }
-func (p *DeclarativeProvider) Catalog() *catalog.Catalog {
-	return p.catalog.Clone()
-}
-func (p *DeclarativeProvider) ConnectionMode() core.ConnectionMode { return p.connectionMode }
-
-func (p *DeclarativeProvider) Execute(ctx context.Context, operation string, params map[string]any, token string) (*core.OperationResult, error) {
-	op, ok := p.opsByName[operation]
-	if !ok {
-		return &core.OperationResult{Status: http.StatusNotFound, Body: `{"error":"unknown operation"}`}, nil
+func declarativeConnectionMode(override core.ConnectionMode, auth *providermanifestv1.ProviderAuth) core.ConnectionMode {
+	if override != "" {
+		return override
 	}
-
-	queryParams := make(map[string]any)
-	bodyParams := make(map[string]any)
-	isBodyMethod := op.Method == http.MethodPost || op.Method == http.MethodPut || op.Method == http.MethodPatch
-
-	for k, v := range params {
-		loc, declared := declarativeParamLocation(op, k)
-		if !declared {
-			if isBodyMethod {
-				loc = "body"
-			} else {
-				loc = "query"
-			}
-		}
-		switch loc {
-		case "query":
-			queryParams[k] = v
-		case "body", "path":
-			bodyParams[k] = v
-		}
+	if auth == nil || auth.Type == "" || auth.Type == providermanifestv1.AuthTypeNone {
+		return core.ConnectionModeNone
 	}
-
-	baseURL := p.baseURL
-	headers := maps.Clone(p.catalog.Headers)
-	if cp := core.ConnectionParams(ctx); cp != nil {
-		baseURL = paraminterp.Interpolate(baseURL, cp)
-		for k, v := range headers {
-			headers[k] = paraminterp.Interpolate(v, cp)
-		}
-	}
-
-	authHeader := ""
-	if p.auth != nil && p.auth.AuthMapping != nil && (len(p.auth.AuthMapping.Headers) > 0 || p.auth.AuthMapping.Basic != nil) {
-		resolvedAuth, extraHeaders, err := provider.MappedCredentialParser(p.auth.AuthMapping)(token)
-		if err != nil {
-			return nil, err
-		}
-		authHeader = resolvedAuth
-		token = ""
-		if headers == nil && len(extraHeaders) > 0 {
-			headers = make(map[string]string, len(extraHeaders))
-		}
-		for k, v := range extraHeaders {
-			headers[k] = v
-		}
-	}
-
-	req := apiexec.Request{
-		Method:        op.Method,
-		BaseURL:       baseURL,
-		Path:          op.Path,
-		Params:        bodyParams,
-		QueryParams:   queryParams,
-		CustomHeaders: headers,
-		AuthHeader:    authHeader,
-		Token:         token,
-		NoRetry:       true,
-	}
-	return apiexec.Do(ctx, p.httpClient, req)
+	return core.ConnectionModeUser
 }
 
-func declarativeParamLocation(op *catalog.CatalogOperation, name string) (string, bool) {
-	for _, param := range op.Parameters {
-		if param.Name == name {
-			return param.Location, true
-		}
-	}
-	return "", false
-}
-
-func (p *DeclarativeProvider) CredentialFields() []core.CredentialFieldDef {
-	if p.auth == nil {
+func declarativeCredentialFields(auth *providermanifestv1.ProviderAuth) []core.CredentialFieldDef {
+	if auth == nil {
 		return nil
 	}
-	return CredentialFieldsFromManifest(p.auth.Credentials)
+	return CredentialFieldsFromManifest(auth.Credentials)
 }
 
-func (p *DeclarativeProvider) AuthTypes() []string {
-	if p.auth == nil {
-		return nil
+func declarativeHasOperation(cat *catalog.Catalog, operation string) bool {
+	if cat == nil {
+		return false
 	}
-	switch p.auth.Type {
-	case providermanifestv1.AuthTypeOAuth2:
-		return []string{"oauth"}
-	case providermanifestv1.AuthTypeBearer, providermanifestv1.AuthTypeManual:
-		return []string{"manual"}
-	case providermanifestv1.AuthTypeNone:
-		return nil
-	default:
-		return nil
+	for i := range cat.Operations {
+		if cat.Operations[i].ID == operation {
+			return true
+		}
 	}
-}
-
-func (p *DeclarativeProvider) ConnectionForOperation(string) string { return "" }
-
-func (p *DeclarativeProvider) AuthorizationURL(state string, scopes []string) string {
-	if p.auth == nil || p.auth.Type != providermanifestv1.AuthTypeOAuth2 {
-		return ""
-	}
-	return p.auth.AuthorizationURL
-}
-
-func (p *DeclarativeProvider) ExchangeCode(ctx context.Context, code string) (*core.TokenResponse, error) {
-	if p.auth == nil || p.auth.Type != providermanifestv1.AuthTypeOAuth2 {
-		return nil, fmt.Errorf("provider does not support OAuth")
-	}
-	return nil, fmt.Errorf("declarative provider OAuth exchange not implemented")
-}
-
-func (p *DeclarativeProvider) RefreshToken(ctx context.Context, refreshToken string) (*core.TokenResponse, error) {
-	if p.auth == nil || p.auth.Type != providermanifestv1.AuthTypeOAuth2 {
-		return nil, fmt.Errorf("provider does not support OAuth")
-	}
-	return nil, fmt.Errorf("declarative provider OAuth refresh not implemented")
-}
-
-func (p *DeclarativeProvider) ConnectionParamDefs() map[string]core.ConnectionParamDef {
-	return ConnectionParamDefsFromManifest(p.connectionDefs)
-}
-
-func (p *DeclarativeProvider) DiscoveryConfig() *core.DiscoveryConfig {
-	return DiscoveryConfigFromManifest(p.discovery)
+	return false
 }

--- a/gestaltd/internal/server/authorization.go
+++ b/gestaltd/internal/server/authorization.go
@@ -52,12 +52,15 @@ func rejectWorkloadSelectors(w http.ResponseWriter, p *principal.Principal, conn
 }
 
 func (s *Server) workloadBindingSelectors(p *principal.Principal, provider, connection, instance string) (string, string) {
+	resolveConnection := func(connection string) string {
+		return s.sessionCatalogConnections(provider, nil, connection)[0]
+	}
 	if p == nil || p.Kind != principal.KindWorkload {
-		return s.catalogLookupConnection(provider, connection), instance
+		return resolveConnection(connection), instance
 	}
 	binding, ok := s.workloadBinding(p, provider)
 	if !ok {
-		return s.catalogLookupConnection(provider, connection), instance
+		return resolveConnection(connection), instance
 	}
 	if connection == "" {
 		connection = binding.Connection
@@ -65,7 +68,7 @@ func (s *Server) workloadBindingSelectors(p *principal.Principal, provider, conn
 	if instance == "" {
 		instance = binding.Instance
 	}
-	return s.catalogLookupConnection(provider, connection), instance
+	return resolveConnection(connection), instance
 }
 
 func (s *Server) workloadBindingConnected(ctx context.Context, binding authorization.CredentialBinding, provider string) (bool, error) {

--- a/gestaltd/internal/server/handlers.go
+++ b/gestaltd/internal/server/handlers.go
@@ -496,51 +496,13 @@ func (s *Server) listOperations(w http.ResponseWriter, r *http.Request) {
 		strictCatalog = true
 	}
 	ctx := invocation.WithAccessContext(r.Context(), s.providerAccessContext(p, name))
-	var cat *catalog.Catalog
-	if strictCatalog && requestedConnection == "" && requestedInstance == "" &&
-		(s.authorizer == nil || !s.authorizer.IsWorkload(p)) {
-		catalogConnections := s.sessionCatalogConnections(name, p, requestedConnection)
-		var firstErr error
-		for _, catalogConnection := range catalogConnections {
-			resolvedConnection, catalogInstance := s.workloadBindingSelectors(p, name, catalogConnection, requestedInstance)
-			var (
-				err      error
-				metadata invocation.CatalogResolutionMetadata
-			)
-			cat, metadata, err = resolveCatalog(ctx, prov, name, resolver, p, resolvedConnection, catalogInstance)
-			if err == nil {
-				discoveryFailed = metadata.SessionFailed
-				break
-			}
-			if firstErr == nil {
-				firstErr = err
-			}
-			cat = nil
+	cat, discoveryFailed, err := s.resolveCatalogForRequest(ctx, prov, name, resolver, p, requestedConnection, requestedInstance, strictCatalog, resolveCatalog)
+	if err != nil {
+		if recordDiscoveryMetrics {
+			metricutil.RecordDiscoveryMetrics(r.Context(), discoveryStartedAt, name, "list_operations", discoveryConnectionMode, discoveryFailed)
 		}
-		if cat == nil && firstErr != nil {
-			discoveryFailed = true
-			if recordDiscoveryMetrics {
-				metricutil.RecordDiscoveryMetrics(r.Context(), discoveryStartedAt, name, "list_operations", discoveryConnectionMode, discoveryFailed)
-			}
-			s.writeInvocationError(w, r, name, "", firstErr)
-			return
-		}
-	} else {
-		catalogConnection := s.sessionCatalogConnections(name, p, requestedConnection)[0]
-		catalogConnection, catalogInstance := s.workloadBindingSelectors(p, name, catalogConnection, requestedInstance)
-		var (
-			err      error
-			metadata invocation.CatalogResolutionMetadata
-		)
-		cat, metadata, err = resolveCatalog(ctx, prov, name, resolver, p, catalogConnection, catalogInstance)
-		discoveryFailed = metadata.SessionFailed || err != nil
-		if err != nil {
-			if recordDiscoveryMetrics {
-				metricutil.RecordDiscoveryMetrics(r.Context(), discoveryStartedAt, name, "list_operations", discoveryConnectionMode, discoveryFailed)
-			}
-			s.writeInvocationError(w, r, name, "", err)
-			return
-		}
+		s.writeInvocationError(w, r, name, "", err)
+		return
 	}
 	if recordDiscoveryMetrics {
 		metricutil.RecordDiscoveryMetrics(r.Context(), discoveryStartedAt, name, "list_operations", discoveryConnectionMode, discoveryFailed)
@@ -665,46 +627,10 @@ func (s *Server) executeOperation(w http.ResponseWriter, r *http.Request) {
 	if tr, ok := s.invoker.(invocation.TokenResolver); ok {
 		resolver = tr
 	}
-	opMeta, ok := invocation.CatalogOperation(prov.Catalog(), operationName)
-	sessionOpFound := false
-	if core.SupportsSessionCatalog(prov) {
-		var firstSessionErr error
-		sessionCatalogResolved := false
-		sessionConnections := s.sessionCatalogConnections(providerName, p, connection)
-		for _, sessionConnection := range sessionConnections {
-			sessionConnection, sessionInstance := s.workloadBindingSelectors(p, providerName, sessionConnection, instance)
-			sessionCat, err := invocation.ResolveSessionCatalog(ctx, prov, providerName, resolver, p, sessionConnection, sessionInstance)
-			if err != nil {
-				if firstSessionErr == nil {
-					firstSessionErr = err
-				}
-				if connection != "" {
-					s.writeInvocationError(w, r, providerName, operationName, err)
-					return
-				}
-				continue
-			}
-			sessionCatalogResolved = true
-			if sessionOp, sessionOK := invocation.CatalogOperation(sessionCat, operationName); sessionOK {
-				opMeta, ok = sessionOp, true
-				sessionOpFound = true
-				if connection == "" {
-					connection = sessionConnection
-				}
-				break
-			}
-		}
-		if firstSessionErr != nil && !sessionCatalogResolved {
-			s.writeInvocationError(w, r, providerName, operationName, firstSessionErr)
-			return
-		}
-		if instance != "" && !sessionOpFound {
-			s.writeInvocationError(w, r, providerName, operationName, fmt.Errorf("%w: %q on provider %q", invocation.ErrOperationNotFound, operationName, providerName))
-			return
-		}
-	}
-	if !ok {
-		s.writeInvocationError(w, r, providerName, operationName, fmt.Errorf("%w: %q on provider %q", invocation.ErrOperationNotFound, operationName, providerName))
+	boundSessionConnections, sessionInstance := s.boundSessionCatalogConnections(providerName, p, connection, instance)
+	opMeta, _, resolvedConnection, err := invocation.ResolveOperation(ctx, prov, providerName, resolver, p, operationName, boundSessionConnections, sessionInstance)
+	if err != nil {
+		s.writeInvocationError(w, r, providerName, operationName, err)
 		return
 	}
 	if s.authorizer != nil && !s.authorizer.AllowCatalogOperation(p, providerName, opMeta) {
@@ -717,6 +643,9 @@ func (s *Server) executeOperation(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 	ctx = invocation.WithCatalogOperation(ctx, providerName, opMeta)
+	if connection == "" {
+		connection = resolvedConnection
+	}
 	if connection != "" {
 		if !safeParamValue.MatchString(connection) {
 			writeError(w, http.StatusBadRequest, "connection name contains invalid characters")
@@ -787,21 +716,6 @@ func (s *Server) writeInvocationError(w http.ResponseWriter, r *http.Request, pr
 	}
 }
 
-func (s *Server) catalogLookupConnection(providerName, explicit string) string {
-	if explicit != "" {
-		return config.ResolveConnectionAlias(explicit)
-	}
-	if conn := s.catalogConnection[providerName]; conn != "" {
-		return conn
-	}
-	if broker, ok := s.invoker.(interface{ MCPConnection(string) string }); ok {
-		if conn := broker.MCPConnection(providerName); conn != "" {
-			return conn
-		}
-	}
-	return s.defaultConnection[providerName]
-}
-
 func (s *Server) sessionCatalogConnections(providerName string, p *principal.Principal, explicit string) []string {
 	if explicit != "" {
 		return []string{config.ResolveConnectionAlias(explicit)}
@@ -811,7 +725,13 @@ func (s *Server) sessionCatalogConnections(providerName string, p *principal.Pri
 	}
 
 	connections := make([]string, 0, 2)
-	if conn := s.catalogLookupConnection(providerName, ""); conn != "" {
+	if conn := s.catalogConnection[providerName]; conn != "" {
+		connections = append(connections, conn)
+	} else if broker, ok := s.invoker.(interface{ MCPConnection(string) string }); ok {
+		if conn := broker.MCPConnection(providerName); conn != "" {
+			connections = append(connections, conn)
+		}
+	} else if conn := s.defaultConnection[providerName]; conn != "" {
 		connections = append(connections, conn)
 	}
 	if conn := s.defaultConnection[providerName]; conn != "" && (len(connections) == 0 || connections[0] != conn) && s.catalogConnection[providerName] == "" {
@@ -823,24 +743,47 @@ func (s *Server) sessionCatalogConnections(providerName string, p *principal.Pri
 	return connections
 }
 
+func (s *Server) boundSessionCatalogConnections(providerName string, p *principal.Principal, explicit, instance string) ([]string, string) {
+	connections := s.sessionCatalogConnections(providerName, p, explicit)
+	boundConnections := make([]string, 0, len(connections))
+	boundInstance := instance
+	for _, connection := range connections {
+		connection, boundInstance = s.workloadBindingSelectors(p, providerName, connection, instance)
+		boundConnections = append(boundConnections, connection)
+	}
+	return boundConnections, boundInstance
+}
+
+func (s *Server) resolveCatalogForRequest(ctx context.Context, prov core.Provider, providerName string, resolver invocation.TokenResolver, p *principal.Principal, requestedConnection, requestedInstance string, strict bool, resolveCatalog func(context.Context, core.Provider, string, invocation.TokenResolver, *principal.Principal, string, string) (*catalog.Catalog, invocation.CatalogResolutionMetadata, error)) (*catalog.Catalog, bool, error) {
+	connections, instance := s.boundSessionCatalogConnections(providerName, p, requestedConnection, requestedInstance)
+	if !strict || requestedConnection != "" || requestedInstance != "" || (s.authorizer != nil && s.authorizer.IsWorkload(p)) {
+		cat, metadata, err := resolveCatalog(ctx, prov, providerName, resolver, p, connections[0], instance)
+		return cat, metadata.SessionFailed || err != nil, err
+	}
+
+	var firstErr error
+	for _, connection := range connections {
+		cat, metadata, err := resolveCatalog(ctx, prov, providerName, resolver, p, connection, instance)
+		if err == nil {
+			return cat, metadata.SessionFailed, nil
+		}
+		if firstErr == nil {
+			firstErr = err
+		}
+	}
+	return nil, firstErr != nil, firstErr
+}
+
 func httpVisibleCatalogOperations(ops []catalog.CatalogOperation) []catalog.CatalogOperation {
 	filtered := make([]catalog.CatalogOperation, 0, len(ops))
 	for i := range ops {
 		op := ops[i]
-		if catalogOperationTransport(op) == catalog.TransportMCPPassthrough {
+		if invocation.OperationTransport(op) == catalog.TransportMCPPassthrough {
 			continue
 		}
 		filtered = append(filtered, op)
 	}
 	return filtered
-}
-
-func catalogOperationTransport(op catalog.CatalogOperation) string {
-	transport := strings.TrimSpace(op.Transport)
-	if transport == "" && strings.TrimSpace(op.Method) != "" {
-		return catalog.TransportREST
-	}
-	return transport
 }
 
 func safeOperationErrorMessage(err error) (string, bool) {

--- a/gestaltd/internal/server/server_test.go
+++ b/gestaltd/internal/server/server_test.go
@@ -5875,11 +5875,12 @@ func TestDisconnectIntegration_NotConnected(t *testing.T) {
 	if err != nil {
 		t.Fatalf("request: %v", err)
 	}
-	defer func() { _ = resp.Body.Close() }()
 
 	if resp.StatusCode != http.StatusNotFound {
+		_ = resp.Body.Close()
 		t.Fatalf("expected 404, got %d", resp.StatusCode)
 	}
+	_ = resp.Body.Close()
 }
 
 func TestListOperations(t *testing.T) {
@@ -7014,6 +7015,47 @@ func TestExecuteOperation_UnknownOperation(t *testing.T) {
 	if resp.StatusCode != http.StatusNotFound {
 		t.Fatalf("expected 404, got %d", resp.StatusCode)
 	}
+
+	sessionStub := &stubIntegrationWithSessionCatalog{
+		stubIntegrationWithOps: stubIntegrationWithOps{
+			StubIntegration: coretesting.StubIntegration{N: "sample-int", ConnMode: core.ConnectionModeUser},
+		},
+		catalog: serverTestCatalog("sample-int", []catalog.CatalogOperation{
+			{ID: "run", Description: "Run", Method: http.MethodGet, Transport: catalog.TransportREST},
+		}),
+		catalogForRequestFn: func(_ context.Context, token string) (*catalog.Catalog, error) {
+			if token != "tok-team-a" {
+				return nil, fmt.Errorf("unexpected token %q", token)
+			}
+			return &catalog.Catalog{Name: "sample-int"}, nil
+		},
+	}
+
+	svc := coretesting.NewStubServices(t)
+	u := seedUser(t, svc, "anonymous@gestalt")
+	seedToken(t, svc, &core.IntegrationToken{
+		ID: "tok-team-a", UserID: u.ID, Integration: "sample-int",
+		Connection: testCatalogConnection, Instance: "team-a", AccessToken: "tok-team-a",
+	})
+
+	ts = newTestServer(t, func(cfg *server.Config) {
+		cfg.Providers = testutil.NewProviderRegistry(t, sessionStub)
+		cfg.CatalogConnection = map[string]string{"sample-int": testCatalogConnection}
+		cfg.Services = svc
+	})
+	testutil.CloseOnCleanup(t, ts)
+
+	req, _ = http.NewRequest(http.MethodGet, ts.URL+"/api/v1/sample-int/run?_instance=team-a", nil)
+	resp, err = http.DefaultClient.Do(req)
+	if err != nil {
+		t.Fatalf("session request: %v", err)
+	}
+	defer func() { _ = resp.Body.Close() }()
+
+	if resp.StatusCode != http.StatusNotFound {
+		body, _ := io.ReadAll(resp.Body)
+		t.Fatalf("expected 404 for missing session operation, got %d: %s", resp.StatusCode, body)
+	}
 }
 
 func TestExecuteOperation_NoStoredToken(t *testing.T) {
@@ -7951,14 +7993,32 @@ func TestExecuteOperation_UsesFallbackSessionCatalogConnectionAfterEarlierError(
 	if err != nil {
 		t.Fatalf("request: %v", err)
 	}
-	defer func() { _ = resp.Body.Close() }()
 
 	if resp.StatusCode != http.StatusOK {
 		body, _ := io.ReadAll(resp.Body)
+		_ = resp.Body.Close()
 		t.Fatalf("expected 200, got %d: %s", resp.StatusCode, body)
 	}
 	if gotToken != "rest-token" {
+		_ = resp.Body.Close()
 		t.Fatalf("execute token = %q, want %q", gotToken, "rest-token")
+	}
+	_ = resp.Body.Close()
+
+	gotToken = ""
+	req, _ = http.NewRequest(http.MethodGet, ts.URL+"/api/v1/sample-int/run?_connection=mcp-conn", nil)
+	resp, err = http.DefaultClient.Do(req)
+	if err != nil {
+		t.Fatalf("explicit request: %v", err)
+	}
+	defer func() { _ = resp.Body.Close() }()
+
+	if resp.StatusCode != http.StatusPreconditionFailed {
+		body, _ := io.ReadAll(resp.Body)
+		t.Fatalf("expected 412 for explicit session catalog failure, got %d: %s", resp.StatusCode, body)
+	}
+	if gotToken != "" {
+		t.Fatalf("execute token = %q, want no provider execution", gotToken)
 	}
 }
 


### PR DESCRIPTION
## Summary
- centralize static-vs-session operation lookup in `internal/invocation` so broker and HTTP execute share the same resolution path
- collapse the `listOperations` catalog-selection branching into a smaller request helper while preserving catalog-connection ordering and fail-closed behavior
- keep production LOC net reductive for this slice: non-test `+127 / -144`, net `-17`

## Go Interface
```go
op, transport, connection, err := invocation.ResolveOperation(
    ctx,
    prov,
    providerName,
    resolver,
    principal,
    "run",
    []string{"catalog", "default"},
    "tenant-a",
)
```

The returned `connection` is the session-catalog candidate that actually exposed the operation, so HTTP execution and broker execution stay pinned to the same resolved connection.

## YAML Interface
No manifest schema change is required. Existing plugin YAML that pins a default connection keeps the same surface; this PR only routes session-catalog lookup and execution through one shared path.

```yaml
apiVersion: gestalt.valon/v1
kind: plugin
metadata:
  name: sample-int
spec:
  defaultConnection: workspace
  surfaces:
    rest:
      connection: workspace
      operations:
        - name: run
          method: GET
          path: /run
```

That same manifest still works with HTTP selector overrides like `?_connection=workspace&_instance=tenant-a`; the resolved session-catalog connection is now reused by both the server handler and the broker.

## Verification
- `go test ./internal/invocation ./internal/server ./internal/mcp`
- `golangci-lint run`
