### PR TITLE
cli: centralize auth target resolution

### DIFF
--- a/gestalt/cli/src/api.rs
+++ b/gestalt/cli/src/api.rs
@@ -8,7 +8,7 @@ use std::collections::BTreeMap;
 use std::path::{Path, PathBuf};
 
 use crate::config::ConfigStore;
-use crate::credentials::CredentialStore;
+use crate::credentials::{CredentialStore, Credentials};
 use crate::http;
 
 pub const DEFAULT_URL: &str = "http://localhost:8080";
@@ -24,6 +24,17 @@ pub const AUTH_LOGIN_CALLBACK_PATH: &str = "/api/v1/auth/login/callback";
 #[serde(rename_all = "camelCase")]
 pub struct AuthInfo {
     pub login_supported: bool,
+}
+
+#[derive(Debug, Clone)]
+pub struct ConfiguredServer {
+    pub url: String,
+    pub source: String,
+}
+
+pub struct CliAuthInputs {
+    pub configured_server: Result<Option<ConfiguredServer>>,
+    pub env_api_key: Option<String>,
 }
 
 pub fn normalize_url(url: &str) -> String {
@@ -94,6 +105,18 @@ pub fn fetch_auth_info(base_url: &str) -> Result<AuthInfo> {
 
 pub fn server_auth_disabled(base_url: &str) -> Result<bool> {
     Ok(!fetch_auth_info(base_url)?.login_supported)
+}
+
+pub fn load_cli_auth_inputs(url_override: Option<&str>) -> CliAuthInputs {
+    CliAuthInputs {
+        configured_server: find_configured_url_with_source(url_override)
+            .map(|server| server.map(|(url, source)| ConfiguredServer { url, source })),
+        env_api_key: env_api_key(),
+    }
+}
+
+pub fn load_stored_credentials() -> Result<Option<Credentials>> {
+    CredentialStore::new()?.load()
 }
 
 fn find_configured_url(url_override: Option<&str>) -> Result<Option<String>> {
@@ -183,10 +206,12 @@ pub enum TokenSource {
     StoredCredentials,
 }
 
+fn env_api_key() -> Option<String> {
+    std::env::var(ENV_API_KEY).ok().filter(|v| !v.is_empty())
+}
+
 pub fn env_api_key_is_set() -> bool {
-    std::env::var(ENV_API_KEY)
-        .map(|v| !v.is_empty())
-        .unwrap_or(false)
+    env_api_key().is_some()
 }
 
 pub struct ApiClient {
@@ -198,33 +223,48 @@ pub struct ApiClient {
 
 impl ApiClient {
     pub fn from_env(url_override: Option<&str>) -> Result<Self> {
-        let (token, source, stored_credentials) =
-            if let Some(key) = std::env::var(ENV_API_KEY).ok().filter(|v| !v.is_empty()) {
-                (key, TokenSource::EnvVar, None)
-            } else {
-                let store = CredentialStore::new()?;
-                match store.load()? {
-                    Some(creds) => (
-                        creds.api_token.clone(),
-                        TokenSource::StoredCredentials,
-                        Some(creds),
-                    ),
-                    None => {
-                        bail!(
-                            "not authenticated: set {} or run 'gestalt auth login'",
-                            ENV_API_KEY
-                        )
-                    }
-                }
-            };
+        let CliAuthInputs {
+            configured_server,
+            env_api_key,
+        } = load_cli_auth_inputs(url_override);
 
-        let base_url = match resolve_url(url_override) {
-            Ok(url) => url,
-            Err(err) => match stored_credentials
+        let mut stored_credentials = None;
+        let (token, source) = if let Some(key) = env_api_key {
+            (key, TokenSource::EnvVar)
+        } else {
+            match load_stored_credentials()? {
+                Some(creds) => {
+                    let token = creds.api_token.clone();
+                    stored_credentials = Some(creds);
+                    (token, TokenSource::StoredCredentials)
+                }
+                None => {
+                    bail!(
+                        "not authenticated: set {} or run 'gestalt auth login'",
+                        ENV_API_KEY
+                    )
+                }
+            }
+        };
+
+        let mut stored_api_url = || -> Result<Option<String>> {
+            if stored_credentials.is_none() {
+                stored_credentials = load_stored_credentials()?;
+            }
+            Ok(stored_credentials
                 .as_ref()
                 .and_then(|creds| creds.api_url())
-            {
-                Some(url) => normalize_url(url),
+                .map(normalize_url))
+        };
+
+        let base_url = match configured_server {
+            Ok(Some(server)) => server.url,
+            Ok(None) => match stored_api_url()? {
+                Some(url) => url,
+                None => bail_no_url_configured()?,
+            },
+            Err(err) => match stored_api_url()? {
+                Some(url) => url,
                 None => return Err(err),
             },
         };

--- a/gestalt/cli/src/commands/auth.rs
+++ b/gestalt/cli/src/commands/auth.rs
@@ -220,12 +220,14 @@ fn build_browser_response_html(title: &str, detail: &str) -> String {
 
 pub fn logout() -> Result<()> {
     let store = CredentialStore::new()?;
-    match store.load() {
+    let api::CliAuthInputs {
+        configured_server, ..
+    } = api::load_cli_auth_inputs(None);
+    let configured_url = configured_server.ok().flatten().map(|server| server.url);
+
+    match api::load_stored_credentials() {
         Ok(Some(creds)) => {
-            let revoke_url = creds
-                .api_url()
-                .map(str::to_owned)
-                .or_else(|| api::resolve_url(None).ok());
+            let revoke_url = creds.api_url().map(str::to_owned).or(configured_url);
             if let Some(url) = revoke_url {
                 let client = ApiClient::new(&url, &creds.api_token)?;
                 if let Err(err) = client.revoke_api_token(&creds.api_token_id) {
@@ -253,15 +255,20 @@ pub fn logout() -> Result<()> {
 }
 
 pub fn status(url_override: Option<&str>, format: Format) -> Result<()> {
-    let server_config = api::describe_server_config(url_override);
-    let server_reachable = server_config.as_ref().map(|(url, _)| {
-        api::fetch_auth_info(url)
+    let api::CliAuthInputs {
+        configured_server,
+        env_api_key,
+    } = api::load_cli_auth_inputs(url_override);
+
+    let server_config = configured_server.ok().flatten();
+    let server_reachable = server_config.as_ref().map(|server| {
+        api::fetch_auth_info(&server.url)
             .ok()
             .map(|info| info.login_supported)
     });
 
-    let has_env_key = api::env_api_key_is_set();
-    let (has_stored_credentials, stored_credentials_error) = match CredentialStore::new()?.load() {
+    let has_env_key = env_api_key.is_some();
+    let (has_stored_credentials, stored_credentials_error) = match api::load_stored_credentials() {
         Ok(Some(_)) => (true, None),
         Ok(None) => (false, None),
         Err(err) => (false, Some(err.to_string())),
@@ -278,7 +285,10 @@ pub fn status(url_override: Option<&str>, format: Format) -> Result<()> {
                 "none"
             };
             let (server_url, url_source) = match &server_config {
-                Some((url, src)) => (serde_json::json!(url), serde_json::json!(src)),
+                Some(server) => (
+                    serde_json::json!(server.url),
+                    serde_json::json!(server.source),
+                ),
                 None => (serde_json::json!(null), serde_json::json!(null)),
             };
             let (reachable, login_supported) = match server_reachable {
@@ -299,9 +309,9 @@ pub fn status(url_override: Option<&str>, format: Format) -> Result<()> {
         }
         Format::Table => {
             match &server_config {
-                Some((url, source)) => {
-                    eprintln!("Server:      {}", url);
-                    eprintln!("URL source:  {}", source);
+                Some(server) => {
+                    eprintln!("Server:      {}", server.url);
+                    eprintln!("URL source:  {}", server.source);
                     match server_reachable {
                         Some(Some(login_supported)) => {
                             eprintln!("Reachable:   yes");

--- a/gestalt/cli/tests/auth_flow.rs
+++ b/gestalt/cli/tests/auth_flow.rs
@@ -142,6 +142,42 @@ fn test_auth_logout_revokes_token_using_credential_url_even_when_configured_url_
 }
 
 #[test]
+fn test_auth_logout_uses_configured_url_when_legacy_credentials_omit_api_url() {
+    let mut server = Server::new();
+    let revoke = authed_json_mock!(
+        server,
+        Method::DELETE,
+        "/api/v1/tokens/tok-123",
+        StatusCode::OK
+    )
+    .with_body(r#"{"status":"ok"}"#)
+    .create();
+
+    let home = tempfile::tempdir().unwrap();
+    write_credentials(
+        home.path(),
+        serde_json::json!({
+            "api_token": TEST_TOKEN,
+            "api_token_id": "tok-123",
+        }),
+    );
+
+    cli_command(home.path())
+        .args(["config", "set", "url", &server.url()])
+        .assert()
+        .success();
+
+    cli_command(home.path())
+        .args(["auth", "logout"])
+        .assert()
+        .success()
+        .stderr(predicate::str::contains("Logged out. Credentials removed."))
+        .stderr(predicate::str::contains("Failed to revoke stored CLI token").not());
+
+    revoke.assert();
+}
+
+#[test]
 fn test_init_skips_login_when_server_auth_is_disabled() {
     let mut server = Server::new();
     let _auth_info = json_mock!(server, Method::GET, "/api/v1/auth/info", StatusCode::OK)
@@ -192,6 +228,48 @@ fn test_auth_status_reports_auth_disabled_before_stored_credentials() {
 }
 
 #[test]
+fn test_auth_status_prefers_gestalt_url_over_project_and_global_config() {
+    let _lock = env_lock();
+    let config_root = TempDir::new().unwrap();
+    let _env = EnvGuard::new(config_root.path());
+    let workspace = TempDir::new().unwrap();
+    let repo_root = workspace.path().join("repo");
+    let nested = repo_root.join("nested");
+    let mut server = Server::new();
+    let _auth_info = json_mock!(server, Method::GET, "/api/v1/auth/info", StatusCode::OK)
+        .with_body(r#"{"loginSupported":true}"#)
+        .create();
+
+    std::fs::create_dir_all(repo_root.join(".gestalt")).unwrap();
+    std::fs::create_dir_all(&nested).unwrap();
+    std::fs::write(
+        repo_root.join(".gestalt/config.json"),
+        "{\n  \"url\": \"https://project.example.com\"\n}\n",
+    )
+    .unwrap();
+
+    cli_command(config_root.path())
+        .args(["config", "set", "url", "https://global.example.com"])
+        .assert()
+        .success();
+
+    let _cwd = CurrentDirGuard::new(&nested);
+    cli_command(config_root.path())
+        .env("GESTALT_URL", server.url())
+        .args(["auth", "status"])
+        .assert()
+        .success()
+        .stderr(predicate::str::contains(format!(
+            "Server:      {}",
+            server.url()
+        )))
+        .stderr(predicate::str::contains(
+            "URL source:  GESTALT_URL environment variable",
+        ))
+        .stderr(predicate::str::contains("Reachable:   yes"));
+}
+
+#[test]
 fn test_auth_status_reports_unreachable_server() {
     let home = tempfile::tempdir().unwrap();
     write_credentials(
@@ -212,6 +290,80 @@ fn test_auth_status_reports_unreachable_server() {
         .stderr(predicate::str::contains("Server:      http://127.0.0.1:1"))
         .stderr(predicate::str::contains("Reachable:   no"))
         .stderr(predicate::str::contains("Credentials: stored CLI token"));
+}
+
+#[test]
+fn test_auth_status_prefers_env_api_key_over_stored_credentials() {
+    let mut server = Server::new();
+    let _auth_info = json_mock!(server, Method::GET, "/api/v1/auth/info", StatusCode::OK)
+        .with_body(r#"{"loginSupported":true}"#)
+        .create();
+
+    let home = tempfile::tempdir().unwrap();
+    write_credentials(
+        home.path(),
+        serde_json::json!({
+            "api_url": server.url(),
+            "api_token": TEST_TOKEN,
+            "api_token_id": "tok-123",
+        }),
+    );
+
+    cli_command(home.path())
+        .env("GESTALT_API_KEY", "env-token")
+        .arg("--url")
+        .arg(server.url())
+        .args(["auth", "status"])
+        .assert()
+        .success()
+        .stderr(predicate::str::contains("Credentials: GESTALT_API_KEY set"))
+        .stderr(predicate::str::contains(
+            "Stored CLI credentials also exist but are being ignored.",
+        ));
+
+    let output = cli_command(home.path())
+        .env("GESTALT_API_KEY", "env-token")
+        .arg("--url")
+        .arg(server.url())
+        .args(["auth", "status", "--format", "json"])
+        .output()
+        .unwrap();
+
+    let json: serde_json::Value = serde_json::from_slice(&output.stdout).unwrap();
+    assert_eq!(json["source"], serde_json::json!("env"));
+    assert_eq!(json["envVarSet"], serde_json::json!(true));
+    assert_eq!(json["storedCredentials"], serde_json::json!(true));
+}
+
+#[test]
+fn test_auth_status_does_not_report_stored_credentials_api_url_as_configured_server() {
+    let home = tempfile::tempdir().unwrap();
+    write_credentials(
+        home.path(),
+        serde_json::json!({
+            "api_url": "https://stored.example.com",
+            "api_token": TEST_TOKEN,
+            "api_token_id": "tok-123",
+        }),
+    );
+
+    cli_command(home.path())
+        .args(["auth", "status"])
+        .assert()
+        .success()
+        .stderr(predicate::str::contains("Server:      not configured"))
+        .stderr(predicate::str::contains("Credentials: stored CLI token"))
+        .stderr(predicate::str::contains("stored.example.com").not());
+
+    let output = cli_command(home.path())
+        .args(["auth", "status", "--format", "json"])
+        .output()
+        .unwrap();
+
+    let json: serde_json::Value = serde_json::from_slice(&output.stdout).unwrap();
+    assert_eq!(json["serverUrl"], serde_json::json!(null));
+    assert_eq!(json["urlSource"], serde_json::json!(null));
+    assert_eq!(json["storedCredentials"], serde_json::json!(true));
 }
 
 #[test]

--- a/gestalt/cli/tests/config_resolution.rs
+++ b/gestalt/cli/tests/config_resolution.rs
@@ -26,6 +26,137 @@ fn test_cli_reuses_stored_credentials_api_url() {
 }
 
 #[test]
+fn test_cli_uses_stored_credentials_api_url_with_env_api_key_when_no_url_is_configured() {
+    let mut server = Server::new();
+    let _tokens = authed_json_mock!(server, Method::GET, "/api/v1/tokens", StatusCode::OK)
+        .with_body("[]")
+        .create();
+
+    let home = tempfile::tempdir().unwrap();
+    write_cli_credentials(
+        home.path(),
+        &format!(
+            r#"{{"api_url":"{}","api_token":"{}","api_token_id":"tok-123"}}"#,
+            server.url(),
+            TEST_TOKEN
+        ),
+    );
+
+    cli_command(home.path())
+        .env("GESTALT_API_KEY", TEST_TOKEN)
+        .args(["tokens", "list"])
+        .assert()
+        .success();
+}
+
+#[test]
+fn test_cli_prefers_configured_url_over_stored_credentials_with_env_api_key() {
+    let mut configured_server = Server::new();
+    let configured_tokens = authed_json_mock!(
+        configured_server,
+        Method::GET,
+        "/api/v1/tokens",
+        StatusCode::OK
+    )
+    .with_body("[]")
+    .create();
+
+    let mut stored_server = Server::new();
+    let stored_tokens =
+        authed_json_mock!(stored_server, Method::GET, "/api/v1/tokens", StatusCode::OK)
+            .expect(0)
+            .create();
+
+    let home = tempfile::tempdir().unwrap();
+    write_cli_credentials(
+        home.path(),
+        &format!(
+            r#"{{"api_url":"{}","api_token":"{}","api_token_id":"tok-123"}}"#,
+            stored_server.url(),
+            TEST_TOKEN
+        ),
+    );
+
+    cli_command(home.path())
+        .env("GESTALT_API_KEY", TEST_TOKEN)
+        .arg("--url")
+        .arg(configured_server.url())
+        .args(["tokens", "list"])
+        .assert()
+        .success();
+
+    configured_tokens.assert();
+    stored_tokens.assert();
+}
+
+#[test]
+fn test_cli_uses_stored_credentials_api_url_when_project_config_is_invalid() {
+    let _lock = env_lock();
+    let config_root = TempDir::new().unwrap();
+    let _env = EnvGuard::new(config_root.path());
+    let workspace = TempDir::new().unwrap();
+    let repo_root = workspace.path().join("repo");
+    let nested = repo_root.join("nested");
+    let mut server = Server::new();
+    let _tokens = authed_json_mock!(server, Method::GET, "/api/v1/tokens", StatusCode::OK)
+        .with_body("[]")
+        .create();
+
+    std::fs::create_dir_all(repo_root.join(".gestalt")).unwrap();
+    std::fs::create_dir_all(&nested).unwrap();
+    std::fs::write(repo_root.join(".gestalt/config.json"), "{\n  invalid\n}\n").unwrap();
+
+    write_cli_credentials(
+        config_root.path(),
+        &format!(
+            r#"{{"api_url":"{}","api_token":"{}","api_token_id":"tok-123"}}"#,
+            server.url(),
+            TEST_TOKEN
+        ),
+    );
+
+    let _cwd = CurrentDirGuard::new(&nested);
+    cli_command(config_root.path())
+        .args(["tokens", "list"])
+        .assert()
+        .success();
+}
+
+#[test]
+fn test_cli_uses_stored_credentials_api_url_with_env_api_key_when_project_config_is_invalid() {
+    let _lock = env_lock();
+    let config_root = TempDir::new().unwrap();
+    let _env = EnvGuard::new(config_root.path());
+    let workspace = TempDir::new().unwrap();
+    let repo_root = workspace.path().join("repo");
+    let nested = repo_root.join("nested");
+    let mut server = Server::new();
+    let _tokens = authed_json_mock!(server, Method::GET, "/api/v1/tokens", StatusCode::OK)
+        .with_body("[]")
+        .create();
+
+    std::fs::create_dir_all(repo_root.join(".gestalt")).unwrap();
+    std::fs::create_dir_all(&nested).unwrap();
+    std::fs::write(repo_root.join(".gestalt/config.json"), "{\n  invalid\n}\n").unwrap();
+
+    write_cli_credentials(
+        config_root.path(),
+        &format!(
+            r#"{{"api_url":"{}","api_token":"{}","api_token_id":"tok-123"}}"#,
+            server.url(),
+            TEST_TOKEN
+        ),
+    );
+
+    let _cwd = CurrentDirGuard::new(&nested);
+    cli_command(config_root.path())
+        .env("GESTALT_API_KEY", TEST_TOKEN)
+        .args(["tokens", "list"])
+        .assert()
+        .success();
+}
+
+#[test]
 fn test_cli_ignores_blank_stored_credentials_api_url() {
     let home = tempfile::tempdir().unwrap();
     write_cli_credentials(


### PR DESCRIPTION
## Summary
- centralize CLI auth target resolution around shared `load_cli_auth_inputs` and `load_stored_credentials` helpers
- keep `auth status` scoped to configured server sources while preserving stored-credential and env-key precedence
- let authenticated CLI commands reuse the stored credential `api_url` only as a fallback when configured URL resolution is missing or unreadable

## Rust interfaces
- `gestalt::api::load_cli_auth_inputs(url_override)` snapshots configured server resolution and env auth inputs without eagerly reading credentials
- `gestalt::api::load_stored_credentials()` is the single stored-credential load path for auth commands and API clients
- `ApiClient::from_env(url_override)` now falls back to the stored credential `api_url` only when configured URL resolution is missing or unreadable

## stdin/stdout interfaces
- `gestalt auth status` reports only configured server sources: `--url`, `GESTALT_URL`, project config, or global config
- `GESTALT_API_KEY=$TOKEN gestalt tokens list` can still reuse the stored credential `api_url` when no URL is configured
- `gestalt auth logout` revokes against the stored credential URL, or a configured URL when legacy credentials omit `api_url`

## Examples
```bash
GESTALT_API_KEY=$TOKEN gestalt tokens list
gestalt auth status --format json
gestalt auth logout
```

## Testing
```bash
cargo fmt --check
cargo test -p gestalt
```