### PR TITLE
core: centralize connection setup request resolution

### DIFF
--- a/gestaltd/internal/server/handlers.go
+++ b/gestaltd/internal/server/handlers.go
@@ -183,34 +183,10 @@ func (s *Server) listIntegrations(w http.ResponseWriter, r *http.Request) {
 			continue
 		}
 
-		authTypes := integrationAuthTypesForProvider(prov)
 		instances := connected[name]
 		info.Connected = len(instances) > 0
 		info.Instances = append(make([]instanceInfo, 0, len(instances)), instances...)
-		info.CredentialFields = credentialFieldInfosFromProvider(prov)
-		for name, def := range prov.ConnectionParamDefs() {
-			if def.From == "" {
-				info.ConnectionParams[name] = connectionParamInfo{
-					Required:    def.Required,
-					Description: def.Description,
-					Default:     def.Default,
-				}
-			}
-		}
-		info.Connections = s.integrationConnectionInfos(name, authTypes, info.CredentialFields)
-		if len(authTypes) == 0 {
-			authTypes = authTypesFromConnections(info.Connections)
-			if len(authTypes) == 0 {
-				if _, ok := prov.(core.OAuthProvider); ok {
-					authTypes = []string{"oauth"}
-				}
-			}
-			info.Connections = s.integrationConnectionInfos(name, authTypes, info.CredentialFields)
-		}
-		if authTypes == nil {
-			authTypes = []string{}
-		}
-		info.AuthTypes = authTypes
+		s.populateIntegrationSettings(&info, prov)
 		info.MountedPath = s.integrationMountedPathForPrincipal(p, name, info.MountedPath)
 		if !s.integrationHasUsableSurface(p, name, prov, info) {
 			continue

--- a/gestaltd/internal/server/handlers_connect.go
+++ b/gestaltd/internal/server/handlers_connect.go
@@ -58,19 +58,13 @@ func (s *Server) connectManual(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	prov, ok := s.getProvider(w, req.Integration)
-	if !ok {
-		auditErr = errors.New("integration not found")
+	prov, manualConnection, err := s.resolveConnectionProvider(w, req.Integration, req.Connection)
+	if err != nil {
+		auditErr = err
 		return
 	}
 	metricProviderName = req.Integration
 	connectionMode = metricutil.NormalizeConnectionMode(prov.ConnectionMode())
-
-	manualConnection, ok := s.resolveRequestedConnection(w, req.Integration, req.Connection)
-	if !ok {
-		auditErr = errors.New("invalid connection")
-		return
-	}
 
 	auth := s.effectiveConnectionAuth(req.Integration, manualConnection)
 	if !manualConnectionAllowed(prov, auth) {
@@ -79,15 +73,9 @@ func (s *Server) connectManual(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	dbUserID, err := s.resolveUserID(w, r)
+	dbUserID, manualInstance, err := s.resolveUserConnectionSetup(w, r, req.Instance)
 	if err != nil {
 		auditErr = err
-		return
-	}
-
-	manualInstance, ok := resolveRequestedInstance(w, req.Instance)
-	if !ok {
-		auditErr = errors.New("invalid instance")
 		return
 	}
 	auditTarget = connectionAuditTarget(req.Integration, manualConnection, manualInstance)
@@ -142,6 +130,30 @@ func (s *Server) connectManual(w http.ResponseWriter, r *http.Request) {
 	auditAllowed = true
 	auditErr = nil
 	writeJSON(w, http.StatusOK, result)
+}
+
+func (s *Server) resolveConnectionProvider(w http.ResponseWriter, integration, requestedConnection string) (core.Provider, string, error) {
+	prov, ok := s.getProvider(w, integration)
+	if !ok {
+		return nil, "", errors.New("integration not found")
+	}
+	connection, ok := s.resolveRequestedConnection(w, integration, requestedConnection)
+	if !ok {
+		return nil, "", errors.New("invalid connection")
+	}
+	return prov, connection, nil
+}
+
+func (s *Server) resolveUserConnectionSetup(w http.ResponseWriter, r *http.Request, requestedInstance string) (string, string, error) {
+	userID, err := s.resolveUserID(w, r)
+	if err != nil {
+		return "", "", err
+	}
+	instance, ok := resolveRequestedInstance(w, requestedInstance)
+	if !ok {
+		return "", "", errors.New("invalid instance")
+	}
+	return userID, instance, nil
 }
 
 func validateConnectionParams(defs map[string]core.ConnectionParamDef, provided map[string]string) (map[string]string, error) {

--- a/gestaltd/internal/server/handlers_oauth.go
+++ b/gestaltd/internal/server/handlers_oauth.go
@@ -50,19 +50,13 @@ func (s *Server) startIntegrationOAuth(w http.ResponseWriter, r *http.Request) {
 	}
 	providerName = req.Integration
 
-	prov, ok := s.getProvider(w, req.Integration)
-	if !ok {
-		auditErr = errors.New("integration not found")
+	prov, connection, err := s.resolveConnectionProvider(w, req.Integration, req.Connection)
+	if err != nil {
+		auditErr = err
 		return
 	}
 	metricProviderName = req.Integration
 	connectionMode = metricutil.NormalizeConnectionMode(prov.ConnectionMode())
-
-	connection, ok := s.resolveRequestedConnection(w, req.Integration, req.Connection)
-	if !ok {
-		auditErr = errors.New("invalid connection")
-		return
-	}
 
 	handler, ok := s.requireOAuthHandler(w, req.Integration, connection)
 	if !ok {
@@ -76,15 +70,9 @@ func (s *Server) startIntegrationOAuth(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	dbUserID, err := s.resolveUserID(w, r)
+	dbUserID, instance, err := s.resolveUserConnectionSetup(w, r, req.Instance)
 	if err != nil {
 		auditErr = err
-		return
-	}
-
-	instance, ok := resolveRequestedInstance(w, req.Instance)
-	if !ok {
-		auditErr = errors.New("invalid instance")
 		return
 	}
 	auditTarget = connectionAuditTarget(req.Integration, connection, instance)
@@ -95,10 +83,7 @@ func (s *Server) startIntegrationOAuth(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	var (
-		authURL  string
-		verifier string
-	)
+	var authURL, verifier string
 
 	if len(connParams) > 0 {
 		rawAuthURL := handler.AuthorizationBaseURL()

--- a/gestaltd/internal/server/handlers_tokens.go
+++ b/gestaltd/internal/server/handlers_tokens.go
@@ -174,14 +174,6 @@ func (s *Server) revokeAllAPITokens(w http.ResponseWriter, r *http.Request) {
 	writeJSON(w, http.StatusOK, map[string]any{"status": "revoked", "count": count})
 }
 
-func (s *Server) integrationConnectionInfos(name string, integrationAuthTypes []string, defaultCredentialFields []credentialFieldInfo) []connectionDefInfo {
-	entry, ok := s.pluginDefs[name]
-	if !ok || entry == nil {
-		return nil
-	}
-	return s.connectionInfosForPlugin(name, entry, integrationAuthTypes, defaultCredentialFields)
-}
-
 func (s *Server) connectionInfosForPlugin(integration string, plugin *config.ProviderEntry, integrationAuthTypes []string, defaultCredentialFields []credentialFieldInfo) []connectionDefInfo {
 	if plugin == nil {
 		return []connectionDefInfo{}
@@ -212,11 +204,18 @@ func userFacingConnectionName(name string) string {
 	return name
 }
 
-func integrationAuthTypesForProvider(prov core.Provider) []string {
-	return userFacingAuthTypes(prov.AuthTypes())
+func (s *Server) populateIntegrationSettings(info *integrationInfo, prov core.Provider) {
+	authTypes := userFacingAuthTypes(prov.AuthTypes())
+	info.ConnectionParams = connectionParamInfosFromProvider(prov)
+	info.CredentialFields = credentialFieldInfosFromProvider(prov, authTypes)
+	info.Connections = s.connectionInfosForPlugin(info.Name, s.pluginDefs[info.Name], authTypes, info.CredentialFields)
+	info.AuthTypes = resolvedIntegrationAuthTypes(prov, authTypes, info.Connections)
+	if len(authTypes) == 0 && len(info.AuthTypes) > 0 {
+		info.Connections = s.connectionInfosForPlugin(info.Name, s.pluginDefs[info.Name], info.AuthTypes, info.CredentialFields)
+	}
 }
 
-func credentialFieldInfosFromProvider(prov core.Provider) []credentialFieldInfo {
+func credentialFieldInfosFromProvider(prov core.Provider, authTypes []string) []credentialFieldInfo {
 	if fields := prov.CredentialFields(); len(fields) > 0 {
 		if fields := credentialFieldInfos(fields, func(field core.CredentialFieldDef) credentialFieldInfo {
 			return credentialFieldInfo{
@@ -228,10 +227,25 @@ func credentialFieldInfosFromProvider(prov core.Provider) []credentialFieldInfo 
 			return fields
 		}
 	}
-	if authTypesContain(userFacingAuthTypes(prov.AuthTypes()), "manual") {
+	if authTypesContain(authTypes, "manual") {
 		return defaultManualCredentialFieldInfos()
 	}
 	return []credentialFieldInfo{}
+}
+
+func connectionParamInfosFromProvider(prov core.Provider) map[string]connectionParamInfo {
+	infos := map[string]connectionParamInfo{}
+	for name, def := range prov.ConnectionParamDefs() {
+		if def.From != "" {
+			continue
+		}
+		infos[name] = connectionParamInfo{
+			Required:    def.Required,
+			Description: def.Description,
+			Default:     def.Default,
+		}
+	}
+	return infos
 }
 
 func credentialFieldInfos[T any](fields []T, mapField func(T) credentialFieldInfo) []credentialFieldInfo {
@@ -314,19 +328,28 @@ func removeAuthType(authTypes []string, drop string) []string {
 	return filtered
 }
 
-func authTypesFromConnections(connections []connectionDefInfo) []string {
-	combined := make([]string, 0, 2)
-	for _, connection := range connections {
-		combined = append(combined, connection.AuthTypes...)
-	}
-	return userFacingAuthTypes(combined)
-}
-
 func connectionDisplayName(name, configured string) string {
 	if strings.TrimSpace(configured) != "" {
 		return configured
 	}
 	return userFacingConnectionName(name)
+}
+
+func resolvedIntegrationAuthTypes(prov core.Provider, authTypes []string, connections []connectionDefInfo) []string {
+	if len(authTypes) > 0 {
+		return authTypes
+	}
+	combined := make([]string, 0, 2)
+	for _, connection := range connections {
+		combined = append(combined, connection.AuthTypes...)
+	}
+	if authTypes = userFacingAuthTypes(combined); len(authTypes) > 0 {
+		return authTypes
+	}
+	if _, ok := prov.(core.OAuthProvider); ok {
+		return []string{"oauth"}
+	}
+	return []string{}
 }
 
 func connectionAuthTypes(auth config.ConnectionAuthDef, integrationAuthTypes []string) []string {

--- a/gestaltd/internal/server/server_test.go
+++ b/gestaltd/internal/server/server_test.go
@@ -8968,6 +8968,38 @@ func TestStartIntegrationOAuth(t *testing.T) {
 	if auditRecord["target_name"] != "default/default" {
 		t.Fatalf("expected audit target_name default/default, got %v", auditRecord["target_name"])
 	}
+
+	var invalidAuditBuf bytes.Buffer
+	invalidTS := newTestServer(t, func(cfg *server.Config) {
+		cfg.Providers = testutil.NewProviderRegistry(t, stub)
+		cfg.DefaultConnection = map[string]string{"slack": testDefaultConnection}
+		cfg.ConnectionAuth = testConnectionAuth("slack", handler)
+		cfg.AuditSink = invocation.NewSlogAuditSink(&invalidAuditBuf)
+		cfg.Services = coretesting.NewStubServices(t)
+	})
+	testutil.CloseOnCleanup(t, invalidTS)
+
+	invalidBody := bytes.NewBufferString(`{"integration":"slack","connectionParams":{"unknown":"nope"}}`)
+	invalidReq, _ := http.NewRequest(http.MethodPost, invalidTS.URL+"/api/v1/auth/start-oauth", invalidBody)
+	invalidReq.Header.Set("Content-Type", "application/json")
+	invalidResp, err := http.DefaultClient.Do(invalidReq)
+	if err != nil {
+		t.Fatalf("invalid request: %v", err)
+	}
+	defer func() { _ = invalidResp.Body.Close() }()
+
+	if invalidResp.StatusCode != http.StatusBadRequest {
+		body, _ := io.ReadAll(invalidResp.Body)
+		t.Fatalf("expected 400, got %d: %s", invalidResp.StatusCode, body)
+	}
+
+	var invalidAuditRecord map[string]any
+	if err := json.Unmarshal(invalidAuditBuf.Bytes(), &invalidAuditRecord); err != nil {
+		t.Fatalf("parsing invalid audit record: %v\nraw: %s", err, invalidAuditBuf.String())
+	}
+	if invalidAuditRecord["target_id"] != "slack/default/default" {
+		t.Fatalf("expected invalid audit target_id slack/default/default, got %v", invalidAuditRecord["target_id"])
+	}
 }
 
 func TestIntegrationOAuthCallback(t *testing.T) {
@@ -11203,6 +11235,51 @@ func TestConnectManual(t *testing.T) {
 	t.Run("rejects unknown connection params when provider exposes none", func(t *testing.T) {
 		t.Parallel()
 
+		var auditBuf bytes.Buffer
+		prov := coreintegration.NewRestricted(&stubManualProviderWithCapabilities{
+			stubManualProvider: stubManualProvider{
+				StubIntegration: coretesting.StubIntegration{N: "manual-svc"},
+			},
+			connectionParams: map[string]core.ConnectionParamDef{},
+		}, map[string]string{})
+
+		ts := newTestServer(t, func(cfg *server.Config) {
+			cfg.Providers = testutil.NewProviderRegistry(t, prov)
+			cfg.DefaultConnection = map[string]string{"manual-svc": config.PluginConnectionName}
+			cfg.PluginDefs = map[string]*config.ProviderEntry{
+				"manual-svc": {},
+			}
+			cfg.AuditSink = invocation.NewSlogAuditSink(&auditBuf)
+			cfg.Services = coretesting.NewStubServices(t)
+		})
+		testutil.CloseOnCleanup(t, ts)
+
+		body := bytes.NewBufferString(`{"integration":"manual-svc","credential":"my-api-key","connectionParams":{"unknown":"nope"}}`)
+		req, _ := http.NewRequest(http.MethodPost, ts.URL+"/api/v1/auth/connect-manual", body)
+		req.Header.Set("Content-Type", "application/json")
+		resp, err := http.DefaultClient.Do(req)
+		if err != nil {
+			t.Fatalf("request: %v", err)
+		}
+		defer func() { _ = resp.Body.Close() }()
+
+		if resp.StatusCode != http.StatusBadRequest {
+			body, _ := io.ReadAll(resp.Body)
+			t.Fatalf("expected 400, got %d: %s", resp.StatusCode, body)
+		}
+
+		var auditRecord map[string]any
+		if err := json.Unmarshal(auditBuf.Bytes(), &auditRecord); err != nil {
+			t.Fatalf("parsing audit record: %v\nraw: %s", err, auditBuf.String())
+		}
+		if auditRecord["target_id"] != "manual-svc/plugin/default" {
+			t.Fatalf("expected audit target_id manual-svc/plugin/default, got %v", auditRecord["target_id"])
+		}
+	})
+
+	t.Run("credential validation still wins before connection params", func(t *testing.T) {
+		t.Parallel()
+
 		prov := coreintegration.NewRestricted(&stubManualProviderWithCapabilities{
 			stubManualProvider: stubManualProvider{
 				StubIntegration: coretesting.StubIntegration{N: "manual-svc"},
@@ -11220,7 +11297,7 @@ func TestConnectManual(t *testing.T) {
 		})
 		testutil.CloseOnCleanup(t, ts)
 
-		body := bytes.NewBufferString(`{"integration":"manual-svc","credential":"my-api-key","connectionParams":{"unknown":"nope"}}`)
+		body := bytes.NewBufferString(`{"integration":"manual-svc","connectionParams":{"unknown":"nope"}}`)
 		req, _ := http.NewRequest(http.MethodPost, ts.URL+"/api/v1/auth/connect-manual", body)
 		req.Header.Set("Content-Type", "application/json")
 		resp, err := http.DefaultClient.Do(req)
@@ -11232,6 +11309,14 @@ func TestConnectManual(t *testing.T) {
 		if resp.StatusCode != http.StatusBadRequest {
 			body, _ := io.ReadAll(resp.Body)
 			t.Fatalf("expected 400, got %d: %s", resp.StatusCode, body)
+		}
+
+		var result map[string]string
+		if err := json.NewDecoder(resp.Body).Decode(&result); err != nil {
+			t.Fatalf("decoding: %v", err)
+		}
+		if result["error"] != "credential is required" {
+			t.Fatalf("expected credential validation error, got %q", result["error"])
 		}
 	})
 


### PR DESCRIPTION
## Summary
- centralize the shared provider/connection lookup used by manual connect and OAuth start
- centralize the shared user and instance resolution after the route-specific auth checks
- keep connection-param validation in the route so audit target attribution and manual credential precedence stay unchanged

## Non-test LOC
- non-test: `+33 / -36`, net `-3`

## Go Interface
```go
prov, connection, err := s.resolveConnectionProvider(w, integration, requestedConnection)
userID, instance, err := s.resolveUserConnectionSetup(w, r, requestedInstance)
```

## YAML Example
```yaml
plugins:
  slack:
    default_connection: workspace
    connection_params:
      tenant:
        required: true
    connections:
      workspace:
        auth:
          type: oauth2
      api:
        auth:
          type: manual
          credentials:
            - name: api_key
```

## Verification
- `go test ./internal/server`
- `go test ./internal/server -run 'Test(StartIntegrationOAuth|ConnectManual(|_CompositeProviderPreservesDiscoveryAndConnectionMetadata|_RestrictedProviderPreservesValidationAndDiscovery|_OAuthProviderRejected|_MissingFields|_UnknownIntegration|_MultiCredential)|StartOAuth_(ManualProviderRejected|MultiConnection_SelectsByConnectionName|MultiConnectionWithoutDefaultRequiresExplicitConnection|MissingConnection_FailsCleanly))$'`
- `golangci-lint run ./internal/server`
