### PR TITLE
cli: honor invoke method and selector catalog contracts

### DIFF
--- a/gestalt/cli/src/catalog.rs
+++ b/gestalt/cli/src/catalog.rs
@@ -3,6 +3,12 @@ use serde::{Deserialize, Serialize};
 
 use crate::api::ApiClient;
 
+#[derive(Debug, Clone, Copy, Default)]
+pub struct CatalogSelectors<'a> {
+    pub connection: Option<&'a str>,
+    pub instance: Option<&'a str>,
+}
+
 pub enum ResolvedOperation<'a> {
     All(&'a [CatalogOperation]),
     Exact(&'a CatalogOperation),
@@ -107,8 +113,43 @@ fn is_valid_operation_query(query: &str) -> bool {
     })
 }
 
+pub(crate) fn selector_query_pairs(selectors: CatalogSelectors<'_>) -> Vec<(String, String)> {
+    let mut params = Vec::new();
+    if let Some(connection) = selectors.connection {
+        params.push(("_connection".to_string(), connection.to_string()));
+    }
+    if let Some(instance) = selectors.instance {
+        params.push(("_instance".to_string(), instance.to_string()));
+    }
+    params
+}
+
+pub(crate) fn append_query_pairs(
+    path: &str,
+    params: impl IntoIterator<Item = (String, String)>,
+) -> Result<String> {
+    let params: Vec<_> = params.into_iter().collect();
+    if params.is_empty() {
+        return Ok(path.to_string());
+    }
+
+    let query = serde_urlencoded::to_string(&params).context("failed to encode query")?;
+    Ok(format!("{path}?{query}"))
+}
+
 pub fn fetch_catalog(client: &ApiClient, plugin: &str) -> Result<OperationsCatalog> {
-    let path = format!("/api/v1/integrations/{}/operations", plugin);
+    fetch_catalog_with_selectors(client, plugin, CatalogSelectors::default())
+}
+
+pub fn fetch_catalog_with_selectors(
+    client: &ApiClient,
+    plugin: &str,
+    selectors: CatalogSelectors<'_>,
+) -> Result<OperationsCatalog> {
+    let path = append_query_pairs(
+        &format!("/api/v1/integrations/{}/operations", plugin),
+        selector_query_pairs(selectors),
+    )?;
     let resp = client.get(&path)?;
     let operations: Vec<CatalogOperation> =
         serde_json::from_value(resp).context("failed to parse operations response")?;

--- a/gestalt/cli/src/commands/invoke.rs
+++ b/gestalt/cli/src/commands/invoke.rs
@@ -1,13 +1,16 @@
 use anyhow::{Context, Result};
+use reqwest::Method;
+use std::collections::BTreeMap;
 
 use crate::api::ApiClient;
 use crate::catalog::{
-    self, CatalogOperation, CatalogParameter, OperationsCatalog, ResolvedOperation,
+    self, CatalogOperation, CatalogParameter, CatalogSelectors, OperationsCatalog,
+    ResolvedOperation,
 };
 use crate::output::{self, Format};
 use crate::params::{self, ParamEntry};
 
-#[derive(Default)]
+#[derive(Default, Clone, Copy)]
 pub struct InvokeOptions<'a> {
     pub connection: Option<&'a str>,
     pub instance: Option<&'a str>,
@@ -23,7 +26,7 @@ pub fn run(
     options: InvokeOptions<'_>,
     format: Format,
 ) -> Result<()> {
-    let cat = catalog::fetch_catalog(client, plugin)?;
+    let cat = fetch_catalog_for_invoke(client, plugin, options)?;
     let query = segments.join(".");
 
     match cat.resolve(&query)? {
@@ -55,12 +58,12 @@ pub fn invoke(
     options: InvokeOptions<'_>,
     format: Format,
 ) -> Result<()> {
-    let cat = catalog::fetch_catalog(client, plugin)?;
+    let cat = fetch_catalog_for_invoke(client, plugin, options)?;
     execute(client, &cat, plugin, operation, params, options, format)
 }
 
 pub fn list_operations(client: &ApiClient, plugin: &str, format: Format) -> Result<()> {
-    let cat = catalog::fetch_catalog(client, plugin)?;
+    let cat = catalog::fetch_catalog_with_selectors(client, plugin, CatalogSelectors::default())?;
     display_operations(cat.operations(), format)
 }
 
@@ -80,47 +83,36 @@ fn execute(
         param_map = params::merge_params(file_map, param_map);
     }
 
-    if let Some(connection) = options.connection {
-        param_map.insert(
-            "_connection".to_string(),
-            serde_json::Value::String(connection.to_string()),
-        );
-    }
-    if let Some(instance) = options.instance {
-        param_map.insert(
-            "_instance".to_string(),
-            serde_json::Value::String(instance.to_string()),
-        );
-    }
+    let request_method = request_method(
+        cat.find_operation(operation),
+        &param_map,
+        options.connection.is_some() || options.instance.is_some(),
+    );
 
     let path = format!("/api/v1/{}/{}", plugin, operation);
-    let resp = (if param_map.is_empty() {
-        client.get(&path)
-    } else {
-        client.post(&path, &serde_json::Value::Object(param_map))
-    })
-    .map_err(|err| {
-        let message = err.to_string();
-        if !message.contains("no token stored for integration") {
-            return err;
+    let resp = match request_method {
+        Method::GET => {
+            let query_path = operation_query_path(&path, &param_map, options)?;
+            client.get(&query_path)
         }
-
-        let mut connect_command = format!("gestalt plugins connect {}", plugin);
-        if let Some(connection) = options.connection {
-            connect_command.push_str(" --connection ");
-            connect_command.push_str(connection);
+        Method::POST => {
+            if let Some(connection) = options.connection {
+                param_map.insert(
+                    "_connection".to_string(),
+                    serde_json::Value::String(connection.to_string()),
+                );
+            }
+            if let Some(instance) = options.instance {
+                param_map.insert(
+                    "_instance".to_string(),
+                    serde_json::Value::String(instance.to_string()),
+                );
+            }
+            client.post(&path, &serde_json::Value::Object(param_map))
         }
-        if let Some(instance) = options.instance {
-            connect_command.push_str(" --instance ");
-            connect_command.push_str(instance);
-        }
-
-        anyhow::anyhow!(
-            "plugin {:?} is not connected. Connect it first with `{}`",
-            plugin,
-            connect_command,
-        )
-    })
+        _ => unreachable!("unsupported method already rejected"),
+    }
+    .map_err(|err| rewrite_connect_error(err, plugin, options))
     .with_context(|| format!("failed to invoke {}.{}", plugin, operation))?;
 
     let output_value = match options.select {
@@ -134,6 +126,106 @@ fn execute(
     }
 
     Ok(())
+}
+
+fn catalog_selectors(options: InvokeOptions<'_>) -> CatalogSelectors<'_> {
+    CatalogSelectors {
+        connection: options.connection,
+        instance: options.instance,
+    }
+}
+
+fn fetch_catalog_for_invoke(
+    client: &ApiClient,
+    plugin: &str,
+    options: InvokeOptions<'_>,
+) -> Result<OperationsCatalog> {
+    catalog::fetch_catalog_with_selectors(client, plugin, catalog_selectors(options))
+        .map_err(|err| rewrite_connect_error(err, plugin, options))
+        .with_context(|| format!("failed to load catalog for plugin '{}'", plugin))
+}
+
+fn request_method(
+    operation: Option<&CatalogOperation>,
+    params: &serde_json::Map<String, serde_json::Value>,
+    has_selectors: bool,
+) -> Method {
+    let Some(operation) = operation else {
+        return if !params.is_empty() || has_selectors {
+            Method::POST
+        } else {
+            Method::GET
+        };
+    };
+
+    let method = operation.method.trim();
+    if method.is_empty() {
+        return if !params.is_empty() || has_selectors {
+            Method::POST
+        } else {
+            Method::GET
+        };
+    }
+
+    if method.eq_ignore_ascii_case("GET") && params.values().all(query_value_is_safe) {
+        Method::GET
+    } else {
+        Method::POST
+    }
+}
+
+fn operation_query_path(
+    path: &str,
+    params: &serde_json::Map<String, serde_json::Value>,
+    options: InvokeOptions<'_>,
+) -> Result<String> {
+    let mut query_pairs = catalog::selector_query_pairs(catalog_selectors(options));
+    let mut sorted_params = BTreeMap::new();
+    for (key, value) in params {
+        let encoded = query_value(value)
+            .with_context(|| format!("failed to encode query parameter '{}'", key))?;
+        sorted_params.insert(key.clone(), encoded);
+    }
+    query_pairs.extend(sorted_params);
+    catalog::append_query_pairs(path, query_pairs)
+}
+
+fn query_value_is_safe(value: &serde_json::Value) -> bool {
+    matches!(value, serde_json::Value::String(_))
+}
+
+fn query_value(value: &serde_json::Value) -> Result<String> {
+    match value {
+        serde_json::Value::String(value) => Ok(value.clone()),
+        _ => serde_json::to_string(value).context("failed to encode query parameter"),
+    }
+}
+
+fn rewrite_connect_error(
+    err: anyhow::Error,
+    plugin: &str,
+    options: InvokeOptions<'_>,
+) -> anyhow::Error {
+    let message = err.to_string();
+    if !message.contains("no token stored for integration") {
+        return err;
+    }
+
+    let mut connect_command = format!("gestalt plugins connect {}", plugin);
+    if let Some(connection) = options.connection {
+        connect_command.push_str(" --connection ");
+        connect_command.push_str(connection);
+    }
+    if let Some(instance) = options.instance {
+        connect_command.push_str(" --instance ");
+        connect_command.push_str(instance);
+    }
+
+    anyhow::anyhow!(
+        "plugin {:?} is not connected. Connect it first with `{}`",
+        plugin,
+        connect_command,
+    )
 }
 
 fn display_operations<'a>(

--- a/gestalt/cli/tests/invoke_contract.rs
+++ b/gestalt/cli/tests/invoke_contract.rs
@@ -59,6 +59,38 @@ fn test_invoke_precondition_error_suggests_connect_command() {
 }
 
 #[test]
+fn test_selector_scoped_catalog_precondition_error_suggests_connect_command() {
+    let mut server = Server::new();
+    let home = TempDir::new().unwrap();
+
+    let _catalog_mock = authed_json_mock!(
+        server,
+        Method::GET,
+        "/api/v1/integrations/auth_svc/operations?_connection=workspace&_instance=team-a",
+        StatusCode::PRECONDITION_FAILED
+    )
+    .with_body(r#"{"error":"no token stored for integration \"auth_svc\" instance \"team-a\""}"#)
+    .create();
+
+    cli_command_for_server(home.path(), &server)
+        .args([
+            "plugins",
+            "invoke",
+            "auth_svc",
+            "list_items",
+            "--connection",
+            "workspace",
+            "--instance",
+            "team-a",
+        ])
+        .assert()
+        .failure()
+        .stderr(predicate::str::contains(
+            "failed to load catalog for plugin 'auth_svc': plugin \"auth_svc\" is not connected. Connect it first with `gestalt plugins connect auth_svc --connection workspace --instance team-a`",
+        ));
+}
+
+#[test]
 fn test_list_operations_formats_parameters() {
     let mut server = Server::new();
     let mock = authed_json_mock!(
@@ -145,6 +177,43 @@ fn test_list_operations_json_format() {
 }
 
 #[test]
+fn test_invoke_lists_selector_scoped_catalog() {
+    let mut server = Server::new();
+    let scoped_catalog = authed_json_mock!(
+        server,
+        Method::GET,
+        "/api/v1/integrations/test_svc/operations?_connection=workspace&_instance=team-a",
+        StatusCode::OK
+    )
+    .with_body(r#"[{"id":"scoped.run","description":"Scoped op","method":"GET","parameters":[]}]"#)
+    .create();
+
+    let output = run_cli(
+        &server,
+        &[
+            "plugins",
+            "invoke",
+            "test_svc",
+            "--connection",
+            "workspace",
+            "--instance",
+            "team-a",
+        ],
+    );
+    assert!(
+        output.status.success(),
+        "stderr: {}",
+        String::from_utf8_lossy(&output.stderr)
+    );
+    assert!(
+        String::from_utf8_lossy(&output.stdout).contains("scoped.run"),
+        "stdout: {}",
+        String::from_utf8_lossy(&output.stdout)
+    );
+    scoped_catalog.assert();
+}
+
+#[test]
 fn test_list_operations_empty_parameters() {
     let mut server = Server::new();
     let mock = authed_json_mock!(
@@ -172,7 +241,7 @@ fn test_invoke_with_connection_and_instance() {
     let _catalog_mock = json_mock!(
         server,
         Method::GET,
-        "/api/v1/integrations/test_svc/operations",
+        "/api/v1/integrations/test_svc/operations?_connection=workspace&_instance=team-a",
         StatusCode::OK
     )
     .with_body(catalog_body())
@@ -216,7 +285,7 @@ fn test_invoke_with_connection_and_instance() {
     let _secondary_catalog_mock = authed_json_mock!(
         server,
         Method::GET,
-        "/api/v1/integrations/other_svc/operations",
+        "/api/v1/integrations/other_svc/operations?_connection=workspace&_instance=team-a",
         StatusCode::OK
     )
     .with_body(single_operation_catalog("check_status"))
@@ -317,8 +386,6 @@ fn test_describe_operation() {
 fn test_cli_invoke_merges_file_params_and_selects_output() {
     let mut server = Server::new();
     let home = TempDir::new().unwrap();
-    let input_file = home.path().join("input.json");
-    std::fs::write(&input_file, r#"{"count":1,"name":"from-file"}"#).unwrap();
 
     let _catalog_mock = authed_json_mock!(
         server,
@@ -361,11 +428,14 @@ fn test_cli_invoke_merges_file_params_and_selects_output() {
         "-p",
         "tags=two",
         "--input-file",
-        input_file.to_str().unwrap(),
+        "-",
         "--select",
         "result.id",
     ]);
-    cmd.assert().success().stdout("\"1\"\n");
+    cmd.write_stdin(r#"{"count":1,"name":"from-file"}"#)
+        .assert()
+        .success()
+        .stdout("\"1\"\n");
 
     invoke_mock.assert();
 }
@@ -385,10 +455,12 @@ fn test_cli_invoke_table_keeps_nested_json_inline() {
 
     let invoke_mock = authed_json_mock!(
         server,
-        Method::GET,
+        Method::POST,
         "/api/v1/test_svc/do_thing",
         StatusCode::OK
     )
+    .match_header(header::CONTENT_TYPE.as_str(), http::APPLICATION_JSON)
+    .match_body(Matcher::JsonString("{}".to_string()))
     .with_body(
         r#"{
                 "id":"abc123",
@@ -421,6 +493,164 @@ fn test_cli_invoke_table_keeps_nested_json_inline() {
         .stdout(predicate::str::contains(
             r#"[{"id":"j1","state":"done"},{"id":"j2","state":"running"}]"#,
         ));
+
+    invoke_mock.assert();
+}
+
+#[test]
+fn test_cli_invoke_uses_get_query_for_get_operations_with_params_and_selectors() {
+    let mut server = Server::new();
+    let _catalog_mock = authed_json_mock!(
+        server,
+        Method::GET,
+        "/api/v1/integrations/test_svc/operations?_connection=workspace&_instance=team-a",
+        StatusCode::OK
+    )
+    .with_body(
+        r#"[{
+            "id":"list_items",
+            "description":"List items",
+            "method":"GET",
+            "parameters":[
+                {"name":"filter","type":"string","location":"query"},
+                {"name":"cursor","type":"string","location":"query"}
+            ]
+        }]"#,
+    )
+    .create();
+
+    let invoke_mock = authed_json_mock!(
+        server,
+        Method::GET,
+        "/api/v1/test_svc/list_items?_connection=workspace&_instance=team-a&cursor=next-page&filter=open",
+        StatusCode::OK
+    )
+    .with_body(r#"{"items":[]}"#)
+    .create();
+
+    let output = run_cli(
+        &server,
+        &[
+            "plugins",
+            "invoke",
+            "test_svc",
+            "list_items",
+            "--connection",
+            "workspace",
+            "--instance",
+            "team-a",
+            "-p",
+            "filter=open",
+            "-p",
+            "cursor=next-page",
+        ],
+    );
+    assert!(
+        output.status.success(),
+        "stderr: {}",
+        String::from_utf8_lossy(&output.stderr)
+    );
+
+    invoke_mock.assert();
+}
+
+#[test]
+fn test_cli_invoke_posts_typed_get_operation_params_as_json() {
+    let mut server = Server::new();
+    let _catalog_mock = authed_json_mock!(
+        server,
+        Method::GET,
+        "/api/v1/integrations/test_svc/operations?_connection=workspace&_instance=team-a",
+        StatusCode::OK
+    )
+    .with_body(
+        r#"[{
+            "id":"list_items",
+            "description":"List items",
+            "method":"GET",
+            "parameters":[
+                {"name":"limit","type":"integer","location":"query"}
+            ]
+        }]"#,
+    )
+    .create();
+
+    let invoke_mock = authed_json_mock!(
+        server,
+        Method::POST,
+        "/api/v1/test_svc/list_items",
+        StatusCode::OK
+    )
+    .match_header(header::CONTENT_TYPE.as_str(), http::APPLICATION_JSON)
+    .match_body(Matcher::JsonString(
+        r#"{"_connection":"workspace","_instance":"team-a","limit":10}"#.to_string(),
+    ))
+    .with_body(r#"{"items":[]}"#)
+    .create();
+
+    let output = run_cli(
+        &server,
+        &[
+            "plugins",
+            "invoke",
+            "test_svc",
+            "list_items",
+            "--connection",
+            "workspace",
+            "--instance",
+            "team-a",
+            "-p",
+            "limit:=10",
+        ],
+    );
+    assert!(
+        output.status.success(),
+        "stderr: {}",
+        String::from_utf8_lossy(&output.stderr)
+    );
+
+    invoke_mock.assert();
+}
+
+#[test]
+fn test_cli_invoke_uses_post_transport_for_non_get_catalog_methods() {
+    let mut server = Server::new();
+    let _catalog_mock = authed_json_mock!(
+        server,
+        Method::GET,
+        "/api/v1/integrations/test_svc/operations",
+        StatusCode::OK
+    )
+    .with_body(
+        r#"[{
+            "id":"widgets.remove",
+            "description":"Remove widget",
+            "method":"DELETE",
+            "parameters":[]
+        }]"#,
+    )
+    .create();
+
+    let invoke_mock = authed_json_mock!(
+        server,
+        Method::POST,
+        "/api/v1/test_svc/widgets.remove",
+        StatusCode::OK
+    )
+    .match_header(header::CONTENT_TYPE.as_str(), http::APPLICATION_JSON)
+    .match_body(Matcher::JsonString("{}".to_string()))
+    .with_body(r#"{"ok":true}"#)
+    .create();
+
+    let output = run_cli(
+        &server,
+        &["plugins", "invoke", "test_svc", "widgets.remove"],
+    );
+    assert!(
+        output.status.success(),
+        "stderr: {}",
+        String::from_utf8_lossy(&output.stderr)
+    );
 
     invoke_mock.assert();
 }
@@ -552,10 +782,12 @@ fn test_space_separated_segments_invoke() {
 
     let deep_mock = authed_json_mock!(
         server,
-        Method::GET,
+        Method::POST,
         "/api/v1/test_svc/widgets.bulk.create",
         StatusCode::OK
     )
+    .match_header(header::CONTENT_TYPE.as_str(), http::APPLICATION_JSON)
+    .match_body(Matcher::JsonString("{}".to_string()))
     .with_body(r#"{"ok": true}"#)
     .create();
 
@@ -572,10 +804,12 @@ fn test_space_separated_segments_invoke() {
 
     let subcommand_mock = authed_json_mock!(
         server,
-        Method::GET,
+        Method::POST,
         "/api/v1/test_svc/widgets.delete",
         StatusCode::OK
     )
+    .match_header(header::CONTENT_TYPE.as_str(), http::APPLICATION_JSON)
+    .match_body(Matcher::JsonString("{}".to_string()))
     .with_body(r#"{"ok": true}"#)
     .create();
 


### PR DESCRIPTION
## Summary
- scope CLI operation discovery by `_connection` / `_instance` so `plugins invoke` resolves against the same catalog the server uses
- honor the catalog operation method instead of the old `params.is_empty()` heuristic when choosing GET vs POST
- keep the invoke contract tests focused on wire behavior by updating the existing suite and adding only the missing selector and GET-query coverage

## Rust interfaces
- `gestalt::catalog::fetch_catalog_with_selectors(client, plugin, CatalogSelectors { .. })` scopes operation discovery by selector
- `gestalt::commands::invoke::run(...)` now chooses GET or POST from the catalog operation method, with the old heuristic used only as a fallback when the catalog omits `method`
- `gestalt::catalog::append_query_pairs(...)` is the shared query encoder for selector-scoped discovery and GET invocation paths

## stdin/stdout interfaces
- `gestalt plugins invoke PLUGIN --connection NAME --instance ID` now lists the selector-scoped catalog instead of always using the default catalog
- `gestalt plugins invoke PLUGIN OP -p key=value` now sends query params for catalog `GET` operations and JSON bodies for catalog `POST` operations
- `printf '{"count":1}' | gestalt plugins invoke test_svc do_thing --input-file - --select result.id` still merges stdin JSON and prints the selected value

## Examples
```bash
gestalt plugins invoke slack chat.postMessage --connection workspace --instance team-a -p channel=C123 -p text=hello
gestalt plugins invoke github search.repositories --connection workspace -p q=gestalt -p per_page:=10
printf '{"count":1}' | gestalt plugins invoke test_svc do_thing --input-file - --select result.id
```

## Testing
```bash
cargo fmt --check
cargo test -p gestalt
```