### PR TITLE
cli: remove duplicate invoke and describe entrypoints

### DIFF
--- a/gestalt/cli/src/cli.rs
+++ b/gestalt/cli/src/cli.rs
@@ -44,14 +44,6 @@ pub enum Commands {
         command: PluginCommands,
     },
 
-    #[command(hide = true)]
-    /// Execute a plugin operation
-    Invoke(InvokeArgs),
-
-    #[command(hide = true)]
-    /// Describe a plugin operation
-    Describe(DescribeArgs),
-
     /// Manage API tokens
     Tokens {
         #[command(subcommand)]

--- a/gestalt/cli/src/main.rs
+++ b/gestalt/cli/src/main.rs
@@ -1,9 +1,6 @@
 use clap::{CommandFactory, Parser};
 use gestalt::api::{self, ApiClient};
-use gestalt::cli::{
-    AuthCommands, Cli, Commands, ConfigCommands, DescribeArgs, InvokeArgs, PluginCommands,
-    TokenCommands,
-};
+use gestalt::cli::{AuthCommands, Cli, Commands, ConfigCommands, PluginCommands, TokenCommands};
 use gestalt::commands;
 use gestalt::output;
 
@@ -31,12 +28,6 @@ fn run() -> anyhow::Result<()> {
             ConfigCommands::List => commands::config::list(format),
         },
         Commands::Plugins { command } => dispatch_plugin_command(command, url, format),
-        Commands::Invoke(args) => {
-            dispatch_plugin_command(PluginCommands::Invoke(args), url, format)
-        }
-        Commands::Describe(args) => {
-            dispatch_plugin_command(PluginCommands::Describe(args), url, format)
-        }
         Commands::Tokens { command } => {
             let client = ApiClient::from_env(url)?;
             match command {
@@ -73,7 +64,7 @@ fn dispatch_plugin_command(
             connection.as_deref(),
             instance.as_deref(),
         ),
-        PluginCommands::Invoke(InvokeArgs {
+        PluginCommands::Invoke(gestalt::cli::InvokeArgs {
             plugin,
             operation,
             params,
@@ -94,7 +85,7 @@ fn dispatch_plugin_command(
             },
             format,
         ),
-        PluginCommands::Describe(DescribeArgs { plugin, operation }) => {
+        PluginCommands::Describe(gestalt::cli::DescribeArgs { plugin, operation }) => {
             commands::describe::describe(&client, &plugin, &operation, format)
         }
     }

--- a/gestalt/cli/tests/invoke_contract.rs
+++ b/gestalt/cli/tests/invoke_contract.rs
@@ -304,7 +304,10 @@ fn test_describe_operation() {
     .with_body(catalog_body())
     .create();
 
-    let output = run_cli(&server, &["describe", "test_svc", "do_thing"]);
+    let output = run_cli(
+        &server,
+        &["integrations", "describe", "test_svc", "do_thing"],
+    );
     assert!(
         output.status.success(),
         "stderr: {}",
@@ -533,6 +536,7 @@ fn test_space_separated_segments_invoke() {
     let output = run_cli(
         &server,
         &[
+            "integrations",
             "invoke",
             "test_svc",
             "widgets",

--- a/gestaltd/cmd/gestaltd/e2e_test.go
+++ b/gestaltd/cmd/gestaltd/e2e_test.go
@@ -1386,7 +1386,7 @@ func TestE2ECLIToServer(t *testing.T) {
 	t.Run("invoke echo operation", func(t *testing.T) {
 		t.Parallel()
 
-		cmd := exec.Command(gestaltCLIBin, "invoke", "example", "echo",
+		cmd := exec.Command(gestaltCLIBin, "plugins", "invoke", "example", "echo",
 			"--format", "json",
 			"--url", baseURL,
 			"-p", "message=hello-e2e",
@@ -1404,7 +1404,7 @@ func TestE2ECLIToServer(t *testing.T) {
 	t.Run("describe operation", func(t *testing.T) {
 		t.Parallel()
 
-		cmd := exec.Command(gestaltCLIBin, "describe", "example", "echo",
+		cmd := exec.Command(gestaltCLIBin, "plugins", "describe", "example", "echo",
 			"--format", "json",
 			"--url", baseURL,
 		)


### PR DESCRIPTION
## Summary
- remove the hidden top-level `invoke` and `describe` command variants so plugin operations route only through `plugins`
- trim the extra dispatch branches in `main.rs` that rebuilt `PluginCommands` just to hand them back to the plugin dispatcher
- keep the retained `integrations` alias covered with one smoke test while dropping redundant hidden-entrypoint coverage

## Rust interfaces
- `gestalt::cli::Commands` now exposes plugin operation entrypoints only through `Commands::Plugins { command: PluginCommands }`
- `main.rs` no longer reconstructs `PluginCommands::Invoke` or `PluginCommands::Describe` from hidden top-level variants
- the invoke contract tests now exercise only the public plugin command surface while preserving the explicit `integrations` alias smoke

## stdin/stdout interfaces
- `gestalt plugins invoke ...` remains the supported way to execute plugin operations
- `gestalt plugins describe ...` remains the supported way to inspect operation contracts
- `gestalt integrations list` still works as the retained alias for `gestalt plugins list`

## Examples
```bash
gestalt plugins invoke github search.repositories -p q=gestalt
gestalt plugins describe slack chat.postMessage
gestalt integrations list
```

## Testing
```bash
cargo fmt --check
cargo test -p gestalt
```