### PR TITLE
sdk/typescript: normalize plugin operations and target loading

### DIFF
--- a/sdk/typescript/src/plugin.ts
+++ b/sdk/typescript/src/plugin.ts
@@ -137,10 +137,7 @@ export class PluginProvider extends RuntimeProvider {
   readonly connectionParams: Record<string, ConnectionParamDefinition>;
 
   private readonly sessionCatalogHandler: SessionCatalogHandler | undefined;
-  private readonly operations = new Map<
-    string,
-    OperationDefinition<any, any>
-  >();
+  private readonly operations = new Map<string, OperationDefinition<any, any>>();
 
   constructor(options: PluginDefinitionOptions) {
     super(options);
@@ -150,23 +147,15 @@ export class PluginProvider extends RuntimeProvider {
     this.connectionParams = normalizeConnectionParams(options.connectionParams);
     this.sessionCatalogHandler = options.sessionCatalog;
 
-    for (const entry of options.operations) {
-      const id = entry.id.trim();
-      if (!id) {
+    for (const rawEntry of options.operations) {
+      const entry = operation(rawEntry);
+      if (!entry.id) {
         throw new Error("operation id is required");
       }
-      if (this.operations.has(id)) {
-        throw new Error(`duplicate operation id ${JSON.stringify(id)}`);
+      if (this.operations.has(entry.id)) {
+        throw new Error(`duplicate operation id ${JSON.stringify(entry.id)}`);
       }
-      this.operations.set(id, {
-        ...entry,
-        id,
-        method: normalizeMethod(entry.method),
-        title: entry.title?.trim() ?? "",
-        description: entry.description?.trim() ?? "",
-        allowedRoles: normalizeAllowedRoles(entry.allowedRoles),
-        tags: [...(entry.tags ?? [])],
-      });
+      this.operations.set(entry.id, entry);
     }
   }
 

--- a/sdk/typescript/src/runtime.ts
+++ b/sdk/typescript/src/runtime.ts
@@ -234,12 +234,11 @@ export async function loadProviderFromTarget(
   rawTarget?: string,
 ): Promise<LoadedProvider> {
   const config = readPackageConfig(root);
-  const targetValue =
-    rawTarget?.trim() ||
-    formatProviderTarget(
-      config.providerTarget ?? readPackageProviderTarget(root),
-    );
-  const target = parseProviderTarget(targetValue);
+  const explicitTarget = rawTarget?.trim();
+  const target = explicitTarget
+    ? parseProviderTarget(explicitTarget)
+    : config.providerTarget ?? readPackageProviderTarget(root);
+  const targetValue = explicitTarget || formatProviderTarget(target);
   const module = await import(resolveProviderImportUrl(root, target));
   const candidate =
     (target.exportName ? Reflect.get(module, target.exportName) : undefined) ??

--- a/sdk/typescript/tests/build.test.ts
+++ b/sdk/typescript/tests/build.test.ts
@@ -198,6 +198,21 @@ test("buildProviderBinary compiles a runnable plugin provider executable", async
       expect(
         metadata.staticCatalog?.operations?.some((operation) => operation.id === "count"),
       ).toBe(true);
+      expect(
+        metadata.staticCatalog?.operations?.find((operation) => operation.id === "hello"),
+      ).toMatchObject({
+        method: "POST",
+        title: "Hello",
+        description: "Return a greeting",
+        allowedRoles: ["viewer", "admin"],
+      });
+      expect(
+        metadata.staticCatalog?.operations?.find((operation) => operation.id === "count"),
+      ).toMatchObject({
+        method: "POST",
+        title: "Count",
+        description: "Echo an integer count",
+      });
 
       await expectConnectCode(
         provider.startProvider(

--- a/sdk/typescript/tests/fixtures/basic-provider/provider.ts
+++ b/sdk/typescript/tests/fixtures/basic-provider/provider.ts
@@ -2,7 +2,6 @@ import {
   connectionParam,
   definePlugin,
   ok,
-  operation,
   s,
 } from "../../../src/index.ts";
 
@@ -35,13 +34,13 @@ export const plugin = definePlugin({
     };
   },
   operations: [
-    operation({
-      id: "hello",
-      method: "POST",
-      title: "Hello",
-      description: "Return a greeting",
+    {
+      id: "  hello  ",
+      method: " post ",
+      title: "  Hello  ",
+      description: "  Return a greeting  ",
       tags: ["fixture"],
-      allowedRoles: ["viewer", "admin"],
+      allowedRoles: ["viewer", "admin", "viewer"],
       readOnly: true,
       input: s.object({
         name: s.string({
@@ -77,12 +76,12 @@ export const plugin = definePlugin({
           accessRole: request.access.role,
         });
       },
-    }),
-    operation({
-      id: "count",
-      method: "POST",
-      title: "Count",
-      description: "Echo an integer count",
+    },
+    {
+      id: " count ",
+      method: " post ",
+      title: " Count ",
+      description: " Echo an integer count ",
       input: s.object({
         count: s.integer(),
       }),
@@ -94,6 +93,6 @@ export const plugin = definePlugin({
           count: input.count,
         });
       },
-    }),
+    },
   ],
 });

--- a/sdk/typescript/tests/plugin.test.ts
+++ b/sdk/typescript/tests/plugin.test.ts
@@ -121,33 +121,6 @@ test("plugin executes operations and exposes catalog metadata", async () => {
   });
 });
 
-test("plugin normalizes operation identifiers before storing and executing", async () => {
-  const plugin = definePlugin({
-    operations: [
-      {
-        id: "  ping  ",
-        handler() {
-          return {
-            pong: true,
-          };
-        },
-      },
-    ],
-  });
-
-  const result = await plugin.execute("ping", {}, request());
-  expect(result.status).toBe(200);
-  expect(JSON.parse(result.body)).toEqual({
-    pong: true,
-  });
-  expect(plugin.staticCatalog().operations).toEqual([
-    {
-      id: "ping",
-      method: "POST",
-    },
-  ]);
-});
-
 test("plugin rejects duplicate operation identifiers after trimming", () => {
   expect(() =>
     definePlugin({

--- a/sdk/typescript/tests/runtime.test.ts
+++ b/sdk/typescript/tests/runtime.test.ts
@@ -1,5 +1,5 @@
 import { spawn, type ChildProcess } from "node:child_process";
-import { readFileSync } from "node:fs";
+import { readFileSync, writeFileSync } from "node:fs";
 import { join } from "node:path";
 
 import { create } from "@bufbuild/protobuf";
@@ -122,6 +122,59 @@ test("loadPluginFromTarget falls through null exports to the next plugin candida
   expect(plugin.kind).toBe("integration");
   expect(plugin.name).toBe("basic-provider-null-export");
   expect(plugin.displayName).toBe("Fixture Provider Null Export");
+});
+
+test("loadPluginFromTarget ignores whitespace-only explicit targets", async () => {
+  const plugin = await loadPluginFromTarget(
+    fixturePath("basic-provider"),
+    "   ",
+  );
+  expect(plugin.kind).toBe("integration");
+  expect(plugin.name).toBe("basic-provider");
+  expect(plugin.displayName).toBe("Fixture Provider");
+});
+
+test("loadProviderFromTarget formats package target in errors when explicit target is whitespace", async () => {
+  const root = makeTempDir("gestalt-typescript-runtime-target-");
+  try {
+    const indexPath = join(import.meta.dir, "..", "src", "index.ts");
+    writeFileSync(
+      join(root, "package.json"),
+      JSON.stringify({
+        name: "broken-provider",
+        gestalt: {
+          provider: {
+            kind: "auth",
+            target: "./provider.ts#missing",
+          },
+        },
+      }),
+      "utf8",
+    );
+    writeFileSync(
+      join(root, "provider.ts"),
+      `import { definePlugin } from ${JSON.stringify(indexPath)};
+
+export const plugin = definePlugin({
+  operations: [
+    {
+      id: "hello",
+      handler() {
+        return { ok: true };
+      },
+    },
+  ],
+});
+`,
+      "utf8",
+    );
+
+    await expect(loadProviderFromTarget(root, "   ")).rejects.toThrow(
+      "auth:./provider.ts#missing did not resolve to a Gestalt auth provider",
+    );
+  } finally {
+    removeTempDir(root);
+  }
 });
 
 test("runtime serves a secrets provider over unix gRPC", async () => {


### PR DESCRIPTION
## Summary

This PR removes duplicate normalization and target-loading branches from the TypeScript SDK without changing the public Go or YAML interfaces.

It keeps the same provider target shape:

```json
{
  "gestalt": {
    "provider": {
      "kind": "plugin",
      "target": "./provider.ts#plugin"
    }
  }
}
```

## Go Interface

No public Go API changed.

Example:

```go
target, err := providerpkg.DetectTypeScriptProviderTarget(root)
// unchanged: "plugin:./provider.ts#plugin"
```

## YAML Interface

No YAML shape changed.

```yaml
source: plugin:./provider.ts#plugin
config:
  region: use1
```

## TypeScript Example

```ts
import { definePlugin, ok } from "@valon-technologies/gestalt";

export const plugin = definePlugin({
  operations: [
    {
      id: "  hello  ",
      method: " post ",
      handler: async () => ok({ ok: true }),
    },
  ],
});
```

## What Changed

- normalize plugin operation metadata once in `PluginProvider` instead of through duplicated constructor and helper logic
- remove the runtime read -> format -> parse target loop when package metadata already resolved the provider target
- move operation-normalization coverage into the existing packaged plugin fixture instead of keeping separate unit-style normalization tests
- keep whitespace-only explicit targets falling back to package metadata

## Verification

- `bun test tests/plugin.test.ts tests/runtime.test.ts tests/build.test.ts tests/target.test.ts`
- `bun run check`
