### PR TITLE
gestaltd: share static connection plan

### DIFF
--- a/gestaltd/internal/authorization/authorizer.go
+++ b/gestaltd/internal/authorization/authorizer.go
@@ -18,7 +18,6 @@ import (
 	"github.com/valon-technologies/gestalt/server/internal/emailutil"
 	"github.com/valon-technologies/gestalt/server/internal/principal"
 	"github.com/valon-technologies/gestalt/server/internal/registry"
-	providermanifestv1 "github.com/valon-technologies/gestalt/server/sdk/providermanifest/v1"
 )
 
 const (
@@ -816,7 +815,11 @@ func normalizeEmail(email string) string {
 
 func providerMode(provider string, pluginDefs map[string]*config.ProviderEntry, providers *registry.ProviderMap[core.Provider]) (core.ConnectionMode, bool, error) {
 	if entry, ok := pluginDefs[provider]; ok && entry != nil {
-		return pluginConnectionMode(entry), true, nil
+		plan, err := config.BuildStaticConnectionPlan(entry, entry.ManifestSpec())
+		if err != nil {
+			return "", false, err
+		}
+		return plan.ConnectionMode(), true, nil
 	}
 	if providers != nil {
 		prov, err := providers.Get(provider)
@@ -825,76 +828,4 @@ func providerMode(provider string, pluginDefs map[string]*config.ProviderEntry, 
 		}
 	}
 	return "", false, nil
-}
-
-func pluginConnectionMode(entry *config.ProviderEntry) core.ConnectionMode {
-	needUser := false
-	needIdentity := false
-
-	addMode := func(mode core.ConnectionMode) {
-		switch mode {
-		case core.ConnectionModeUser:
-			needUser = true
-		case core.ConnectionModeIdentity:
-			needIdentity = true
-		case core.ConnectionModeEither:
-			needUser = true
-			needIdentity = true
-		}
-	}
-
-	addMode(connectionModeForConnection(config.EffectivePluginConnectionDef(entry, entry.ManifestSpec())))
-
-	for name := range namedConnectionNames(entry) {
-		conn, ok := config.EffectiveNamedConnectionDef(entry, entry.ManifestSpec(), name)
-		if !ok {
-			continue
-		}
-		addMode(connectionModeForConnection(conn))
-	}
-
-	switch {
-	case needUser && needIdentity:
-		return core.ConnectionModeEither
-	case needUser:
-		return core.ConnectionModeUser
-	case needIdentity:
-		return core.ConnectionModeIdentity
-	default:
-		return core.ConnectionModeNone
-	}
-}
-
-func namedConnectionNames(entry *config.ProviderEntry) map[string]struct{} {
-	names := make(map[string]struct{})
-	if entry == nil {
-		return names
-	}
-	if spec := entry.ManifestSpec(); spec != nil {
-		for name := range spec.Connections {
-			resolved := config.ResolveConnectionAlias(name)
-			if resolved != "" && resolved != config.PluginConnectionName {
-				names[resolved] = struct{}{}
-			}
-		}
-	}
-	for name := range entry.Connections {
-		resolved := config.ResolveConnectionAlias(name)
-		if resolved != "" && resolved != config.PluginConnectionName {
-			names[resolved] = struct{}{}
-		}
-	}
-	return names
-}
-
-func connectionModeForConnection(conn config.ConnectionDef) core.ConnectionMode {
-	if conn.Mode != "" {
-		return core.ConnectionMode(conn.Mode)
-	}
-	switch conn.Auth.Type {
-	case "", providermanifestv1.AuthTypeNone:
-		return core.ConnectionModeNone
-	default:
-		return core.ConnectionModeUser
-	}
 }

--- a/gestaltd/internal/bootstrap/connections.go
+++ b/gestaltd/internal/bootstrap/connections.go
@@ -2,9 +2,7 @@ package bootstrap
 
 import (
 	"fmt"
-	"sort"
 
-	"github.com/valon-technologies/gestalt/server/core"
 	"github.com/valon-technologies/gestalt/server/internal/config"
 	"github.com/valon-technologies/gestalt/server/internal/provider"
 	providermanifestv1 "github.com/valon-technologies/gestalt/server/sdk/providermanifest/v1"
@@ -29,13 +27,13 @@ func BuildConnectionMaps(cfg *config.Config) (ConnectionMaps, error) {
 		mcpConnection := config.PluginConnectionName
 
 		if entry != nil {
-			plan, err := buildPluginConnectionPlan(entry, entry.ManifestSpec())
+			plan, err := config.BuildStaticConnectionPlan(entry, entry.ManifestSpec())
 			if err != nil {
 				return ConnectionMaps{}, fmt.Errorf("integration %q: %w", name, err)
 			}
-			defaultConnection = plan.authDefaultConnection()
-			apiConnection = plan.apiConnection()
-			mcpConnection = plan.mcpConnection()
+			defaultConnection = plan.AuthDefaultConnection()
+			apiConnection = plan.APIConnection()
+			mcpConnection = plan.MCPConnection()
 		}
 
 		maps.DefaultConnection[name] = defaultConnection
@@ -46,285 +44,19 @@ func BuildConnectionMaps(cfg *config.Config) (ConnectionMaps, error) {
 	return maps, nil
 }
 
-type pluginConnectionPlan struct {
-	manifestBacked    bool
-	pluginConnection  config.ConnectionDef
-	namedConnections  map[string]config.ConnectionDef
-	surfaces          map[config.SpecSurface]resolvedSpecSurface
-	restConnection    string
-	defaultConnection string
-}
-
-type resolvedSpecSurface struct {
-	surface        config.SpecSurface
-	url            string
-	connectionName string
-	connection     config.ConnectionDef
-}
-
-func buildPluginConnectionPlan(plugin *config.ProviderEntry, manifestPlugin *providermanifestv1.Spec) (pluginConnectionPlan, error) {
-	declaredNames := namedConnectionNames(plugin, manifestPlugin)
-	plan := pluginConnectionPlan{
-		manifestBacked:   manifestPlugin != nil && manifestPlugin.IsManifestBacked(),
-		pluginConnection: config.EffectivePluginConnectionDef(plugin, manifestPlugin),
-		namedConnections: make(map[string]config.ConnectionDef),
-		surfaces:         make(map[config.SpecSurface]resolvedSpecSurface),
-	}
-
-	for name := range declaredNames {
-		conn, ok := config.EffectiveNamedConnectionDef(plugin, manifestPlugin, name)
-		if !ok {
-			continue
-		}
-		plan.namedConnections[name] = conn
-	}
-
-	defaultConnection := resolveDefaultConnectionName(plugin, manifestPlugin)
-	if defaultConnection != "" {
-		if _, err := plan.connectionDef(defaultConnection); err != nil {
-			return pluginConnectionPlan{}, fmt.Errorf("default_connection references undeclared connection %q", defaultConnection)
-		}
-		plan.defaultConnection = defaultConnection
-	}
-
-	if manifestPlugin != nil && manifestPlugin.Surfaces != nil && manifestPlugin.Surfaces.REST != nil {
-		plan.restConnection = plan.resolveSurfaceConnectionName(manifestPlugin.Surfaces.REST.Connection)
-		if plan.restConnection != "" {
-			if _, err := plan.connectionDef(plan.restConnection); err != nil {
-				return pluginConnectionPlan{}, fmt.Errorf("rest connection references undeclared connection %q", plan.restConnection)
-			}
-		}
-	}
-
-	for _, surface := range config.OrderedSpecSurfaces {
-		url := surfaceURL(plugin, manifestPlugin, surface)
-		if url == "" {
-			continue
-		}
-		resolved := resolvedSpecSurface{
-			surface:        surface,
-			url:            url,
-			connectionName: plan.resolveSurfaceConnectionName(config.ManifestProviderSurfaceConnectionName(manifestPlugin, surface)),
-		}
-		conn, err := plan.connectionDef(resolved.connectionName)
-		if err != nil {
-			return pluginConnectionPlan{}, fmt.Errorf("%s references undeclared connection %q", surface.ConnectionField(), resolved.connectionName)
-		}
-		resolved.connection = conn
-		plan.surfaces[surface] = resolved
-	}
-
-	return plan, nil
-}
-
-func AdvertisedConnectionNames(plugin *config.ProviderEntry) ([]string, error) {
-	if plugin == nil {
-		return []string{}, nil
-	}
-	plan, err := buildPluginConnectionPlan(plugin, plugin.ManifestSpec())
-	if err != nil {
-		return nil, err
-	}
-	return plan.advertisedConnectionNames(), nil
-}
-
-func (plan pluginConnectionPlan) configuredAPISurface() (resolvedSpecSurface, bool) {
-	for _, surface := range []config.SpecSurface{config.SpecSurfaceOpenAPI, config.SpecSurfaceGraphQL} {
-		if resolved, ok := plan.resolvedSurface(surface); ok {
-			return resolved, true
-		}
-	}
-	return resolvedSpecSurface{}, false
-}
-
-func (plan pluginConnectionPlan) configuredSpecSurface() (resolvedSpecSurface, bool) {
-	if resolved, ok := plan.configuredAPISurface(); ok {
-		return resolved, true
-	}
-	return plan.resolvedSurface(config.SpecSurfaceMCP)
-}
-
-func (plan pluginConnectionPlan) resolvedSurface(surface config.SpecSurface) (resolvedSpecSurface, bool) {
-	resolved, ok := plan.surfaces[surface]
-	return resolved, ok
-}
-
-func (plan pluginConnectionPlan) authDefaultConnection() string {
-	return plan.fallbackConnection()
-}
-
-func (plan pluginConnectionPlan) apiConnection() string {
-	if resolved, ok := plan.configuredAPISurface(); ok {
-		return resolved.connectionName
-	}
-	if plan.restConnection != "" {
-		return plan.restConnection
-	}
-	return plan.fallbackConnection()
-}
-
-func (plan pluginConnectionPlan) mcpConnection() string {
-	if resolved, ok := plan.resolvedSurface(config.SpecSurfaceMCP); ok {
-		return resolved.connectionName
-	}
-	return plan.fallbackConnection()
-}
-
-func (plan pluginConnectionPlan) fallbackConnection() string {
-	if plan.defaultConnection != "" {
-		return plan.defaultConnection
-	}
-	if len(plan.namedConnections) == 0 {
-		return config.PluginConnectionName
-	}
-	if len(plan.namedConnections) == 1 {
-		for name := range plan.namedConnections {
-			return name
-		}
-	}
-	return ""
-}
-
-func (plan pluginConnectionPlan) resolveSurfaceConnectionName(raw string) string {
-	if name := config.ResolveConnectionAlias(raw); name != "" {
-		return name
-	}
-	if plan.defaultConnection != "" {
-		return plan.defaultConnection
-	}
-	if len(plan.namedConnections) == 1 {
-		for name := range plan.namedConnections {
-			return name
-		}
-	}
-	return config.PluginConnectionName
-}
-
-func (plan pluginConnectionPlan) shouldAdvertisePluginConnection() bool {
-	if !plan.manifestBacked {
-		return true
-	}
-	if len(plan.namedConnections) == 0 {
-		return true
-	}
-	if plan.defaultConnection == config.PluginConnectionName {
-		return true
-	}
-	if plan.apiConnection() == config.PluginConnectionName {
-		return true
-	}
-	if plan.mcpConnection() == config.PluginConnectionName {
-		return true
-	}
-	return false
-}
-
-func (plan pluginConnectionPlan) advertisedConnectionNames() []string {
-	names := make([]string, 0, len(plan.namedConnections))
-	for name := range plan.namedConnections {
-		names = append(names, name)
-	}
-	sort.Strings(names)
-	if !plan.shouldAdvertisePluginConnection() {
-		return names
-	}
-	return append([]string{config.PluginConnectionName}, names...)
-}
-
-func (plan pluginConnectionPlan) connectionMode() core.ConnectionMode {
-	needUser := false
-	needIdentity := false
-
-	addMode := func(mode core.ConnectionMode) {
-		switch mode {
-		case core.ConnectionModeUser:
-			needUser = true
-		case core.ConnectionModeIdentity:
-			needIdentity = true
-		case core.ConnectionModeEither:
-			needUser = true
-			needIdentity = true
-		}
-	}
-
-	addMode(connectionModeForConnection(plan.pluginConnection))
-	for name := range plan.namedConnections {
-		addMode(connectionModeForConnection(plan.namedConnections[name]))
-	}
-
-	switch {
-	case needUser && needIdentity:
-		return core.ConnectionModeEither
-	case needUser:
-		return core.ConnectionModeUser
-	case needIdentity:
-		return core.ConnectionModeIdentity
-	default:
-		return core.ConnectionModeNone
-	}
-}
-
-func connectionModeForConnection(conn config.ConnectionDef) core.ConnectionMode {
-	if conn.Mode != "" {
-		return core.ConnectionMode(conn.Mode)
-	}
-	switch conn.Auth.Type {
-	case "", providermanifestv1.AuthTypeNone:
-		return core.ConnectionModeNone
-	default:
-		return core.ConnectionModeUser
-	}
-}
-
-func (plan pluginConnectionPlan) connectionDef(name string) (config.ConnectionDef, error) {
-	if name == "" || name == config.PluginConnectionName {
-		return plan.pluginConnection, nil
-	}
-	conn, ok := plan.namedConnections[name]
-	if !ok {
-		return config.ConnectionDef{}, fmt.Errorf("undeclared connection %q", name)
-	}
-	return conn, nil
-}
-
-func resolveDefaultConnectionName(plugin *config.ProviderEntry, manifestPlugin *providermanifestv1.Spec) string {
-	if plugin != nil {
-		if name := config.ResolveConnectionAlias(plugin.DefaultConnection); name != "" {
-			return name
-		}
-	}
-	if manifestPlugin != nil {
-		if name := config.ResolveConnectionAlias(manifestPlugin.DefaultConnection); name != "" {
-			return name
-		}
-	}
-	return ""
-}
-
-func surfaceURL(plugin *config.ProviderEntry, manifestPlugin *providermanifestv1.Spec, surface config.SpecSurface) string {
-	if url := config.ProviderSurfaceURLOverride(plugin, surface); url != "" {
-		return url
-	}
-	url := config.ManifestProviderSurfaceURL(manifestPlugin, surface)
-	if url == "" {
-		return ""
-	}
-	return config.ResolveManifestRelativeSpecURL(plugin, url)
-}
-
 func buildConnectionAuthMap(name string, entry *config.ProviderEntry, manifest *providermanifestv1.Manifest, pluginConfig map[string]any, authFallback *specAuthFallback, deps Deps) (map[string]OAuthHandler, error) {
 	manifestPlugin := (*providermanifestv1.Spec)(nil)
 	if manifest != nil {
 		manifestPlugin = manifest.Spec
 	}
-	plan, err := buildPluginConnectionPlan(entry, manifestPlugin)
+	plan, err := config.BuildStaticConnectionPlan(entry, manifestPlugin)
 	if err != nil {
 		return nil, fmt.Errorf("resolve connections for %q: %w", name, err)
 	}
 
 	mcpURL := ""
-	if resolved, ok := plan.resolvedSurface(config.SpecSurfaceMCP); ok {
-		mcpURL = resolved.url
+	if resolved, ok := plan.ResolvedSurface(config.SpecSurfaceMCP); ok {
+		mcpURL = resolved.URL
 	}
 
 	specAuthForConnection := func(connectionName string) *provider.Definition {
@@ -335,14 +67,14 @@ func buildConnectionAuthMap(name string, entry *config.ProviderEntry, manifest *
 	}
 
 	handlers := make(map[string]OAuthHandler)
-	if handler, err := buildConnectionHandler(plan.pluginConnection, mcpURL, pluginConfig, specAuthForConnection(config.PluginConnectionName), deps); err != nil {
+	if handler, err := buildConnectionHandler(plan.PluginConnection(), mcpURL, pluginConfig, specAuthForConnection(config.PluginConnectionName), deps); err != nil {
 		return nil, fmt.Errorf("build plugin connection auth for %q: %w", name, err)
 	} else if handler != nil {
 		handlers[config.PluginConnectionName] = handler
 	}
 
-	for resolvedName := range plan.namedConnections {
-		conn := plan.namedConnections[resolvedName]
+	for _, resolvedName := range plan.NamedConnectionNames() {
+		conn, _ := plan.NamedConnectionDef(resolvedName)
 		handler, err := buildConnectionHandler(conn, mcpURL, pluginConfig, specAuthForConnection(resolvedName), deps)
 		if err != nil {
 			return nil, fmt.Errorf("build named connection auth for %q/%q: %w", name, resolvedName, err)
@@ -356,27 +88,6 @@ func buildConnectionAuthMap(name string, entry *config.ProviderEntry, manifest *
 		return nil, nil
 	}
 	return handlers, nil
-}
-
-func namedConnectionNames(plugin *config.ProviderEntry, manifestPlugin *providermanifestv1.Spec) map[string]struct{} {
-	names := make(map[string]struct{})
-	add := func(name string) {
-		resolved := config.ResolveConnectionAlias(name)
-		if resolved != "" && resolved != config.PluginConnectionName {
-			names[resolved] = struct{}{}
-		}
-	}
-	if manifestPlugin != nil {
-		for name := range manifestPlugin.Connections {
-			add(name)
-		}
-	}
-	if plugin != nil {
-		for name := range plugin.Connections {
-			add(name)
-		}
-	}
-	return names
 }
 
 func buildConnectionHandler(conn config.ConnectionDef, mcpURL string, pluginConfig map[string]any, specDef *provider.Definition, deps Deps) (OAuthHandler, error) {

--- a/gestaltd/internal/bootstrap/executable_plugin_test.go
+++ b/gestaltd/internal/bootstrap/executable_plugin_test.go
@@ -922,6 +922,44 @@ func TestPluginManifestNamedOAuthKeepsProviderTokenMode(t *testing.T) {
 	}
 }
 
+func TestPreparedProviderStub_UsesManifestConnectionPlanMode(t *testing.T) {
+	t.Parallel()
+
+	cfg := &config.Config{
+		Plugins: map[string]*config.ProviderEntry{
+			"echoauth": {
+				Source: config.ProviderSource{Ref: "github.com/acme/plugins/test", Version: "1.0.0"},
+				ResolvedManifest: &providermanifestv1.Manifest{
+					DisplayName: "Echo Auth",
+					Spec: &providermanifestv1.Spec{
+						ConnectionMode: providermanifestv1.ConnectionModeIdentity,
+						Connections: map[string]*providermanifestv1.ManifestConnectionDef{
+							"workspace": {
+								Mode: providermanifestv1.ConnectionModeUser,
+								Auth: &providermanifestv1.ProviderAuth{Type: providermanifestv1.AuthTypeNone},
+							},
+						},
+					},
+				},
+			},
+		},
+	}
+
+	providers, _, err := buildProvidersStrict(context.Background(), cfg, NewFactoryRegistry(), Deps{})
+	if err != nil {
+		t.Fatalf("buildProvidersStrict: %v", err)
+	}
+	defer func() { _ = CloseProviders(providers) }()
+
+	prov, err := providers.Get("echoauth")
+	if err != nil {
+		t.Fatalf("providers.Get(echoauth): %v", err)
+	}
+	if prov.ConnectionMode() != core.ConnectionModeEither {
+		t.Fatalf("ConnectionMode = %q, want %q", prov.ConnectionMode(), core.ConnectionModeEither)
+	}
+}
+
 func TestPluginProcessEnvIsolation(t *testing.T) {
 	t.Parallel()
 	bin := buildEchoPluginBinary(t)

--- a/gestaltd/internal/bootstrap/provider_build.go
+++ b/gestaltd/internal/bootstrap/provider_build.go
@@ -131,7 +131,7 @@ func buildProvider(ctx context.Context, name string, entry *config.ProviderEntry
 	case manifestPlugin.IsSpecLoaded() && manifest.Entrypoint == nil:
 		return buildSpecLoadedProvider(ctx, name, entry, manifest, pluginConfig, meta, deps, allowedOperations)
 	case manifestPlugin.IsDeclarative() && manifest.Entrypoint == nil:
-		plan, err := buildPluginConnectionPlan(entry, manifestPlugin)
+		plan, err := config.BuildStaticConnectionPlan(entry, manifestPlugin)
 		if err != nil {
 			return nil, fmt.Errorf("build declarative provider %q: %w", name, err)
 		}
@@ -139,7 +139,7 @@ func buildProvider(ctx context.Context, name string, entry *config.ProviderEntry
 			manifest,
 			nil,
 			providerhost.WithDeclarativeMetadataOverrides(meta.displayName, meta.description, meta.iconSVG),
-			providerhost.WithDeclarativeConnectionMode(plan.connectionMode()),
+			providerhost.WithDeclarativeConnectionMode(plan.ConnectionMode()),
 		)
 		if err != nil {
 			return nil, fmt.Errorf("create declarative provider %q: %w", name, err)
@@ -169,10 +169,14 @@ func buildExecutablePluginProvider(ctx context.Context, name string, entry *conf
 	if err != nil {
 		return nil, err
 	}
-	plan, err := buildPluginConnectionPlan(entry, manifestPlugin)
+	plan, err := config.BuildStaticConnectionPlan(entry, manifestPlugin)
 	if err != nil {
 		closeIfPossible(pluginProv)
 		return nil, fmt.Errorf("build executable plugin provider %q: %w", name, err)
+	}
+	mcpURL := ""
+	if resolved, ok := plan.ResolvedSurface(config.SpecSurfaceMCP); ok {
+		mcpURL = resolved.URL
 	}
 	allowedOperations := entry.AllowedOperations
 	if allowedOperations == nil && manifestPlugin != nil {
@@ -191,7 +195,7 @@ func buildExecutablePluginProvider(ctx context.Context, name string, entry *conf
 			manifest,
 			nil,
 			providerhost.WithDeclarativeMetadataOverrides(meta.displayName, meta.description, meta.iconSVG),
-			providerhost.WithDeclarativeConnectionMode(plan.connectionMode()),
+			providerhost.WithDeclarativeConnectionMode(plan.ConnectionMode()),
 		)
 		if err != nil {
 			closeIfPossible(pluginProv)
@@ -209,7 +213,7 @@ func buildExecutablePluginProvider(ctx context.Context, name string, entry *conf
 			pluginProv.Description(),
 			firstProviderIconSVG(pluginProv, apiProv),
 			composite.BoundProvider{Provider: pluginProv, Connection: config.PluginConnectionName},
-			composite.BoundProvider{Provider: apiProv, Connection: plan.apiConnection()},
+			composite.BoundProvider{Provider: apiProv, Connection: plan.APIConnection()},
 		)
 		if err != nil {
 			closeIfPossible(apiProv, pluginProv)
@@ -218,7 +222,7 @@ func buildExecutablePluginProvider(ctx context.Context, name string, entry *conf
 		return newProviderBuildResult(name, entry, manifest, pluginConfig, merged, nil, deps)
 	}
 
-	resolved, hasSpecSurface := plan.configuredSpecSurface()
+	resolved, hasSpecSurface := plan.ConfiguredSpecSurface()
 	if !hasSpecSurface {
 		restricted, err := applyAllowedOperations(name, allowedOperations, pluginProv)
 		if err != nil {
@@ -241,7 +245,7 @@ func buildExecutablePluginProvider(ctx context.Context, name string, entry *conf
 		baseURL:              config.EffectiveProviderSpecBaseURL(entry, manifestPlugin),
 		applyResponseMapping: true,
 		providerBuildOptions: func(conn config.ConnectionDef) []provider.BuildOption {
-			return mcpOAuthBuildOpts(conn, manifestPlugin, deps)
+			return mcpOAuthBuildOpts(conn, mcpURL, deps)
 		},
 	}, deps)
 	if err != nil {
@@ -254,7 +258,7 @@ func buildExecutablePluginProvider(ctx context.Context, name string, entry *conf
 		pluginProv.Description(),
 		firstProviderIconSVG(pluginProv, specProv),
 		composite.BoundProvider{Provider: pluginProv, Connection: config.PluginConnectionName},
-		composite.BoundProvider{Provider: specProv, Connection: resolved.connectionName},
+		composite.BoundProvider{Provider: specProv, Connection: resolved.ConnectionName},
 	)
 	if err != nil {
 		closeIfPossible(specProv, pluginProv)
@@ -264,7 +268,7 @@ func buildExecutablePluginProvider(ctx context.Context, name string, entry *conf
 	if specDef != nil {
 		authFallback = &specAuthFallback{
 			definition:     specDef,
-			connectionName: resolved.connectionName,
+			connectionName: resolved.ConnectionName,
 		}
 	}
 	return newProviderBuildResult(name, entry, manifest, pluginConfig, merged, authFallback, deps)
@@ -297,17 +301,21 @@ func newProviderBuildResult(name string, entry *config.ProviderEntry, manifest *
 
 func buildSpecLoadedProvider(ctx context.Context, name string, entry *config.ProviderEntry, manifest *providermanifestv1.Manifest, pluginConfig map[string]any, meta providerMetadata, deps Deps, allowedOperations map[string]*config.OperationOverride) (*ProviderBuildResult, error) {
 	mp := manifest.Spec
-	plan, err := buildPluginConnectionPlan(entry, mp)
+	plan, err := config.BuildStaticConnectionPlan(entry, mp)
 	if err != nil {
 		return nil, fmt.Errorf("build spec-loaded provider %q: %w", name, err)
 	}
-	apiResolved, hasAPI := plan.configuredAPISurface()
-	mcpResolved, hasMCP := plan.resolvedSurface(config.SpecSurfaceMCP)
+	apiResolved, hasAPI := plan.ConfiguredAPISurface()
+	mcpResolved, hasMCP := plan.ResolvedSurface(config.SpecSurfaceMCP)
+	mcpURL := ""
+	if hasMCP {
+		mcpURL = mcpResolved.URL
+	}
 	if !hasAPI && !hasMCP {
 		return nil, fmt.Errorf("build spec-loaded provider %q: no spec URL", name)
 	}
 
-	buildSpec := func(resolved resolvedSpecSurface, allowed map[string]*config.OperationOverride) (core.Provider, *provider.Definition, error) {
+	buildSpec := func(resolved config.ResolvedSpecSurface, allowed map[string]*config.OperationOverride) (core.Provider, *provider.Definition, error) {
 		return buildConfiguredSpecProvider(ctx, name, resolved, meta, specProviderConfig{
 			manifestPlugin:       mp,
 			allowedOperations:    allowed,
@@ -315,7 +323,7 @@ func buildSpecLoadedProvider(ctx context.Context, name string, entry *config.Pro
 			baseURL:              config.EffectiveProviderSpecBaseURL(entry, mp),
 			applyResponseMapping: true,
 			providerBuildOptions: func(conn config.ConnectionDef) []provider.BuildOption {
-				return mcpOAuthBuildOpts(conn, mp, deps)
+				return mcpOAuthBuildOpts(conn, mcpURL, deps)
 			},
 		}, deps)
 	}
@@ -334,7 +342,7 @@ func buildSpecLoadedProvider(ctx context.Context, name string, entry *config.Pro
 	}
 	authFallback := &specAuthFallback{
 		definition:     apiDef,
-		connectionName: apiResolved.connectionName,
+		connectionName: apiResolved.ConnectionName,
 	}
 
 	if !hasMCP {
@@ -370,10 +378,10 @@ func buildSpecLoadedProvider(ctx context.Context, name string, entry *config.Pro
 	return newProviderBuildResult(name, entry, manifest, pluginConfig, composite.New(name, apiProv, mcpUp), authFallback, deps)
 }
 
-func loadConfiguredAPIDefinition(ctx context.Context, name string, resolved resolvedSpecSurface, meta providerMetadata, cfg specProviderConfig) (*provider.Definition, error) {
+func loadConfiguredAPIDefinition(ctx context.Context, name string, resolved config.ResolvedSpecSurface, meta providerMetadata, cfg specProviderConfig) (*provider.Definition, error) {
 	def, err := loadSpecDefinition(ctx, name, resolved, cfg.allowedOperations)
 	if err != nil {
-		return nil, fmt.Errorf("load %s definition: %w", resolved.surface, err)
+		return nil, fmt.Errorf("load %s definition: %w", resolved.Surface, err)
 	}
 	if cfg.baseURL != "" {
 		def.BaseURL = cfg.baseURL
@@ -398,33 +406,33 @@ func loadConfiguredAPIDefinition(ctx context.Context, name string, resolved reso
 	return def, nil
 }
 
-func buildConfiguredSpecProvider(ctx context.Context, name string, resolved resolvedSpecSurface, meta providerMetadata, cfg specProviderConfig, deps Deps) (core.Provider, *provider.Definition, error) {
+func buildConfiguredSpecProvider(ctx context.Context, name string, resolved config.ResolvedSpecSurface, meta providerMetadata, cfg specProviderConfig, deps Deps) (core.Provider, *provider.Definition, error) {
 	var buildOpts []provider.BuildOption
 	buildOpts = append(buildOpts, provider.WithEgressCheck(deps.Egress.CheckFunc(cfg.allowedHosts)))
 	if cfg.providerBuildOptions != nil {
-		buildOpts = append(buildOpts, cfg.providerBuildOptions(resolved.connection)...)
+		buildOpts = append(buildOpts, cfg.providerBuildOptions(resolved.Connection)...)
 	}
 
-	switch resolved.surface {
+	switch resolved.Surface {
 	case config.SpecSurfaceOpenAPI, config.SpecSurfaceGraphQL:
 		def, err := loadConfiguredAPIDefinition(ctx, name, resolved, meta, cfg)
 		if err != nil {
 			return nil, nil, err
 		}
-		prov, err := provider.Build(def, resolved.connection, buildOpts...)
+		prov, err := provider.Build(def, resolved.Connection, buildOpts...)
 		if err != nil {
 			return nil, nil, err
 		}
 		return prov, def, nil
 	case config.SpecSurfaceMCP:
-		connMode := core.ConnectionMode(resolved.connection.Mode)
+		connMode := core.ConnectionMode(resolved.Connection.Mode)
 		if connMode == "" {
 			connMode = core.ConnectionModeUser
 		}
 		up, err := mcpupstream.New(
 			ctx,
 			name,
-			resolved.url,
+			resolved.URL,
 			connMode,
 			manifestHeaders(cfg.manifestPlugin),
 			deps.Egress.CheckFunc(cfg.allowedHosts),
@@ -441,18 +449,18 @@ func buildConfiguredSpecProvider(ctx context.Context, name string, resolved reso
 		}
 		return up, nil, nil
 	default:
-		return nil, nil, fmt.Errorf("unsupported spec surface %q", resolved.surface)
+		return nil, nil, fmt.Errorf("unsupported spec surface %q", resolved.Surface)
 	}
 }
 
-func loadSpecDefinition(ctx context.Context, name string, resolved resolvedSpecSurface, allowedOperations map[string]*config.OperationOverride) (*provider.Definition, error) {
-	switch resolved.surface {
+func loadSpecDefinition(ctx context.Context, name string, resolved config.ResolvedSpecSurface, allowedOperations map[string]*config.OperationOverride) (*provider.Definition, error) {
+	switch resolved.Surface {
 	case config.SpecSurfaceOpenAPI:
-		return openapi.LoadDefinition(ctx, name, resolved.url, allowedOperations)
+		return openapi.LoadDefinition(ctx, name, resolved.URL, allowedOperations)
 	case config.SpecSurfaceGraphQL:
-		return graphql.LoadDefinition(ctx, name, resolved.url, allowedOperations)
+		return graphql.LoadDefinition(ctx, name, resolved.URL, allowedOperations)
 	default:
-		return nil, fmt.Errorf("unsupported spec definition surface %q", resolved.surface)
+		return nil, fmt.Errorf("unsupported spec definition surface %q", resolved.Surface)
 	}
 }
 
@@ -854,7 +862,7 @@ func buildPluginStaticSpec(name string, entry *config.ProviderEntry, manifest *p
 	if manifest == nil || manifest.Spec == nil {
 		return providerhost.StaticProviderSpec{}, fmt.Errorf("resolved manifest is required")
 	}
-	plan, err := buildPluginConnectionPlan(entry, manifest.Spec)
+	plan, err := config.BuildStaticConnectionPlan(entry, manifest.Spec)
 	if err != nil {
 		return providerhost.StaticProviderSpec{}, err
 	}
@@ -874,8 +882,8 @@ func buildPluginStaticSpec(name string, entry *config.ProviderEntry, manifest *p
 		}
 	}
 
-	conn := config.EffectivePluginConnectionDef(entry, manifest.Spec)
-	connMode := plan.connectionMode()
+	conn := plan.PluginConnection()
+	connMode := plan.ConnectionMode()
 
 	var staticCatalog *catalog.Catalog
 	if manifestRoot := filepath.Dir(entry.ResolvedManifestPath); entry.ResolvedManifestPath != "" {
@@ -928,12 +936,12 @@ func staticAuthTypes(authType providermanifestv1.AuthType) []string {
 	}
 }
 
-func mcpOAuthBuildOpts(conn config.ConnectionDef, manifestPlugin *providermanifestv1.Spec, deps Deps) []provider.BuildOption {
-	if manifestPlugin == nil || conn.Auth.Type != providermanifestv1.AuthTypeMCPOAuth || manifestPlugin.MCPURL() == "" {
+func mcpOAuthBuildOpts(conn config.ConnectionDef, mcpURL string, deps Deps) []provider.BuildOption {
+	if conn.Auth.Type != providermanifestv1.AuthTypeMCPOAuth || mcpURL == "" {
 		return nil
 	}
 	return []provider.BuildOption{
-		provider.WithAuthHandler(buildMCPOAuthHandler(conn, manifestPlugin.MCPURL(), buildRegistrationStore(deps), deps)),
+		provider.WithAuthHandler(buildMCPOAuthHandler(conn, mcpURL, buildRegistrationStore(deps), deps)),
 	}
 }
 

--- a/gestaltd/internal/bootstrap/validate.go
+++ b/gestaltd/internal/bootstrap/validate.go
@@ -127,6 +127,10 @@ func newPreparedProviderStub(name string, entry *config.ProviderEntry) (core.Pro
 		return nil, fmt.Errorf("prepared manifest is not resolved")
 	}
 	manifest := entry.ResolvedManifest
+	plan, err := config.BuildStaticConnectionPlan(entry, entry.ManifestSpec())
+	if err != nil {
+		return nil, err
+	}
 	displayName := manifest.DisplayName
 	if displayName == "" {
 		displayName = name
@@ -139,7 +143,7 @@ func newPreparedProviderStub(name string, entry *config.ProviderEntry) (core.Pro
 		name:           name,
 		displayName:    displayName,
 		description:    description,
-		connectionMode: connectionModeFromEntry(entry),
+		connectionMode: plan.ConnectionMode(),
 	}, nil
 }
 
@@ -163,27 +167,4 @@ func (p *preparedProviderStub) Catalog() *catalog.Catalog {
 }
 func (p *preparedProviderStub) Execute(context.Context, string, map[string]any, string) (*core.OperationResult, error) {
 	return nil, fmt.Errorf("prepared validation stub cannot execute operations")
-}
-
-func connectionModeFromEntry(entry *config.ProviderEntry) core.ConnectionMode {
-	if entry == nil {
-		return core.ConnectionModeUser
-	}
-
-	plan := pluginConnectionPlan{
-		namedConnections: make(map[string]config.ConnectionDef, len(entry.Connections)),
-	}
-	if entry.ConnectionMode != "" {
-		plan.pluginConnection.Mode = entry.ConnectionMode
-	}
-	if entry.Auth != nil {
-		plan.pluginConnection.Auth = *entry.Auth
-	}
-	for name, conn := range entry.Connections {
-		if conn == nil {
-			continue
-		}
-		plan.namedConnections[name] = *conn
-	}
-	return plan.connectionMode()
 }

--- a/gestaltd/internal/config/config_validate.go
+++ b/gestaltd/internal/config/config_validate.go
@@ -831,54 +831,36 @@ func pluginOwnedUIRefs(cfg *Config) map[string]struct{} {
 	return refs
 }
 
-type inlineConnectionReference struct {
-	field    string
-	name     string
-	required bool
-	context  string
-}
-
-func manifestBackedConnectionReferences(plugin *ProviderEntry, provider *providermanifestv1.Spec) []inlineConnectionReference {
-	if provider == nil {
+func validateExecutableConnectionAuthSupport(name string, plan *StaticConnectionPlan, plugin *ProviderEntry, provider *providermanifestv1.Spec) error {
+	supportsMCPOAuth := false
+	if plan != nil {
+		_, supportsMCPOAuth = plan.ResolvedSurface(SpecSurfaceMCP)
+		if conn := plan.PluginConnection(); conn.Auth.Type == providermanifestv1.AuthTypeMCPOAuth && !supportsMCPOAuth {
+			return fmt.Errorf("config validation: integration %q plugin auth type %q requires an MCP surface", name, providermanifestv1.AuthTypeMCPOAuth)
+		}
+		for _, connName := range plan.NamedConnectionNames() {
+			conn, _ := plan.NamedConnectionDef(connName)
+			if conn.Auth.Type != providermanifestv1.AuthTypeMCPOAuth {
+				continue
+			}
+			if !supportsMCPOAuth {
+				return fmt.Errorf("config validation: integration %q connection %q auth type %q requires an MCP surface", name, connName, providermanifestv1.AuthTypeMCPOAuth)
+			}
+		}
 		return nil
 	}
 
-	defaultConnection := provider.DefaultConnection
-	if plugin != nil && plugin.DefaultConnection != "" {
-		defaultConnection = plugin.DefaultConnection
-	}
-	if defaultConnection == "" {
-		return nil
-	}
-	return []inlineConnectionReference{
-		{
-			field: "plugin.defaultConnection",
-			name:  defaultConnection,
-		},
-	}
-}
-
-func validateManifestBackedConnectionReferences(name string, plugin *ProviderEntry, provider *providermanifestv1.Spec) error {
-	return validateConnectionReferences(name, declaredManifestBackedConnections(plugin, provider), manifestBackedConnectionReferences(plugin, provider))
-}
-
-func validateManifestBackedConnectionDefaults(name string, plugin *ProviderEntry, provider *providermanifestv1.Spec) error {
-	return validateConnectionDefaults(name, "integration", len(declaredManifestBackedConnections(plugin, provider)), manifestBackedConnectionReferences(plugin, provider))
-}
-
-func validateExecutableConnectionAuthSupport(name string, plugin *ProviderEntry, provider *providermanifestv1.Spec) error {
-	supportsMCPOAuth := provider != nil && provider.MCPURL() != ""
+	supportsMCPOAuth = provider != nil && provider.MCPURL() != ""
 	if conn := EffectivePluginConnectionDef(plugin, provider); conn.Auth.Type == providermanifestv1.AuthTypeMCPOAuth && !supportsMCPOAuth {
 		return fmt.Errorf("config validation: integration %q plugin auth type %q requires an MCP surface", name, providermanifestv1.AuthTypeMCPOAuth)
 	}
 
-	declared := declaredManifestBackedConnections(plugin, provider)
-	declaredNames := make([]string, 0, len(declared))
-	for connName := range declared {
-		declaredNames = append(declaredNames, connName)
+	names := make([]string, 0, len(namedConnectionNames(plugin, provider)))
+	for connName := range namedConnectionNames(plugin, provider) {
+		names = append(names, connName)
 	}
-	sort.Strings(declaredNames)
-	for _, connName := range declaredNames {
+	sort.Strings(names)
+	for _, connName := range names {
 		conn, ok := EffectiveNamedConnectionDef(plugin, provider, connName)
 		if !ok || conn.Auth.Type != providermanifestv1.AuthTypeMCPOAuth {
 			continue
@@ -890,90 +872,40 @@ func validateExecutableConnectionAuthSupport(name string, plugin *ProviderEntry,
 	return nil
 }
 
-func validateConnectionReferences(name string, declared map[string]struct{}, refs []inlineConnectionReference) error {
-	for _, ref := range refs {
-		if ref.name == "" {
-			continue
-		}
-		resolved := ResolveConnectionAlias(ref.name)
-		if resolved == PluginConnectionName {
-			continue
-		}
-		if _, ok := declared[resolved]; ok {
-			continue
-		}
-		return fmt.Errorf("config validation: integration %q %s references undeclared connection %q", name, ref.field, ref.name)
-	}
-	return nil
-}
-
-func validateConnectionDefaults(name, subject string, declaredCount int, refs []inlineConnectionReference) error {
-	if declaredCount == 0 {
-		return nil
-	}
-	for _, ref := range refs {
-		if ref.required && ref.name == "" {
-			return fmt.Errorf("config validation: %s %q %s is required when %s", subject, name, ref.field, ref.context)
-		}
-	}
-	return nil
-}
-
-func declaredManifestBackedConnections(plugin *ProviderEntry, provider *providermanifestv1.Spec) map[string]struct{} {
-	size := 0
-	if plugin != nil {
-		size += len(plugin.Connections)
-	}
-	if provider != nil {
-		size += len(provider.Connections)
-	}
-	declared := make(map[string]struct{}, size)
-	if provider != nil {
-		for rawName := range provider.Connections {
-			addDeclaredConnection(declared, rawName)
-		}
-	}
-	if plugin != nil {
-		for rawName := range plugin.Connections {
-			addDeclaredConnection(declared, rawName)
-		}
-	}
-	return declared
-}
-
-func addDeclaredConnection(declared map[string]struct{}, rawName string) {
-	resolved := ResolveConnectionAlias(rawName)
-	if resolved == "" {
-		return
-	}
-	declared[resolved] = struct{}{}
-}
-
 func validateManifestBackedIntegration(name string, entry *ProviderEntry) error {
 	if entry == nil {
 		return nil
 	}
 	effectiveProvider := entry.ManifestSpec()
+	var plan *StaticConnectionPlan
 	if effectiveProvider != nil {
-		if err := validateManifestBackedConnectionReferences(name, entry, effectiveProvider); err != nil {
-			return err
+		resolvedPlan, err := BuildStaticConnectionPlan(entry, effectiveProvider)
+		if err != nil {
+			return fmt.Errorf("config validation: integration %q %w", name, err)
 		}
-		if err := validateManifestBackedConnectionDefaults(name, entry, effectiveProvider); err != nil {
-			return err
-		}
+		plan = &resolvedPlan
 	}
-	if err := validateExecutableConnectionAuthSupport(name, entry, effectiveProvider); err != nil {
+	if err := validateExecutableConnectionAuthSupport(name, plan, entry, effectiveProvider); err != nil {
 		return err
 	}
-	if err := validateConnectionAuthMappings(name, EffectivePluginConnectionDef(entry, effectiveProvider).Auth, "plugin"); err != nil {
+	pluginConnection := EffectivePluginConnectionDef(entry, effectiveProvider)
+	if plan != nil {
+		pluginConnection = plan.PluginConnection()
+	}
+	if err := validateConnectionAuthMappings(name, pluginConnection.Auth, "plugin"); err != nil {
 		return err
 	}
-	declared := declaredManifestBackedConnections(entry, effectiveProvider)
-	names := make([]string, 0, len(declared))
-	for connName := range declared {
-		if connName == PluginConnectionName {
-			continue
+	if plan != nil {
+		for _, connName := range plan.NamedConnectionNames() {
+			conn, _ := plan.NamedConnectionDef(connName)
+			if err := validateConnectionAuthMappings(name, conn.Auth, fmt.Sprintf("connection %q", connName)); err != nil {
+				return err
+			}
 		}
+		return nil
+	}
+	names := make([]string, 0, len(namedConnectionNames(entry, effectiveProvider)))
+	for connName := range namedConnectionNames(entry, effectiveProvider) {
 		names = append(names, connName)
 	}
 	sort.Strings(names)

--- a/gestaltd/internal/config/connection_plan.go
+++ b/gestaltd/internal/config/connection_plan.go
@@ -1,0 +1,307 @@
+package config
+
+import (
+	"fmt"
+	"sort"
+
+	"github.com/valon-technologies/gestalt/server/core"
+	providermanifestv1 "github.com/valon-technologies/gestalt/server/sdk/providermanifest/v1"
+)
+
+type StaticConnectionPlan struct {
+	manifestBacked    bool
+	pluginConnection  ConnectionDef
+	namedConnections  map[string]ConnectionDef
+	surfaces          map[SpecSurface]ResolvedSpecSurface
+	restConnection    string
+	defaultConnection string
+}
+
+type ResolvedSpecSurface struct {
+	Surface        SpecSurface
+	URL            string
+	ConnectionName string
+	Connection     ConnectionDef
+}
+
+func BuildStaticConnectionPlan(plugin *ProviderEntry, manifestPlugin *providermanifestv1.Spec) (StaticConnectionPlan, error) {
+	declaredNames := namedConnectionNames(plugin, manifestPlugin)
+	plan := StaticConnectionPlan{
+		manifestBacked:   manifestPlugin != nil && manifestPlugin.IsManifestBacked(),
+		pluginConnection: EffectivePluginConnectionDef(plugin, manifestPlugin),
+		namedConnections: make(map[string]ConnectionDef),
+		surfaces:         make(map[SpecSurface]ResolvedSpecSurface),
+	}
+
+	for name := range declaredNames {
+		conn, ok := EffectiveNamedConnectionDef(plugin, manifestPlugin, name)
+		if !ok {
+			continue
+		}
+		plan.namedConnections[name] = conn
+	}
+
+	defaultConnection := resolveDefaultConnectionName(plugin, manifestPlugin)
+	if defaultConnection != "" {
+		if _, err := plan.connectionDef(defaultConnection); err != nil {
+			return StaticConnectionPlan{}, fmt.Errorf("default_connection references undeclared connection %q", defaultConnection)
+		}
+		plan.defaultConnection = defaultConnection
+	}
+
+	if manifestPlugin != nil && manifestPlugin.Surfaces != nil && manifestPlugin.Surfaces.REST != nil {
+		plan.restConnection = plan.resolveSurfaceConnectionName(manifestPlugin.Surfaces.REST.Connection)
+		if plan.restConnection != "" {
+			if _, err := plan.connectionDef(plan.restConnection); err != nil {
+				return StaticConnectionPlan{}, fmt.Errorf("rest connection references undeclared connection %q", plan.restConnection)
+			}
+		}
+	}
+
+	for _, surface := range OrderedSpecSurfaces {
+		url := surfaceURL(plugin, manifestPlugin, surface)
+		if url == "" {
+			continue
+		}
+		resolved := ResolvedSpecSurface{
+			Surface:        surface,
+			URL:            url,
+			ConnectionName: plan.resolveSurfaceConnectionName(ManifestProviderSurfaceConnectionName(manifestPlugin, surface)),
+		}
+		conn, err := plan.connectionDef(resolved.ConnectionName)
+		if err != nil {
+			return StaticConnectionPlan{}, fmt.Errorf("%s references undeclared connection %q", surface.ConnectionField(), resolved.ConnectionName)
+		}
+		resolved.Connection = conn
+		plan.surfaces[surface] = resolved
+	}
+
+	return plan, nil
+}
+
+func (plan StaticConnectionPlan) PluginConnection() ConnectionDef {
+	return plan.pluginConnection
+}
+
+func (plan StaticConnectionPlan) NamedConnectionNames() []string {
+	names := make([]string, 0, len(plan.namedConnections))
+	for name := range plan.namedConnections {
+		names = append(names, name)
+	}
+	sort.Strings(names)
+	return names
+}
+
+func (plan StaticConnectionPlan) NamedConnectionDef(name string) (ConnectionDef, bool) {
+	conn, ok := plan.namedConnections[name]
+	return conn, ok
+}
+
+func (plan StaticConnectionPlan) LookupConnection(name string) (ConnectionDef, bool) {
+	conn, err := plan.connectionDef(ResolveConnectionAlias(name))
+	if err != nil {
+		return ConnectionDef{}, false
+	}
+	return conn, true
+}
+
+func (plan StaticConnectionPlan) ConfiguredAPISurface() (ResolvedSpecSurface, bool) {
+	for _, surface := range []SpecSurface{SpecSurfaceOpenAPI, SpecSurfaceGraphQL} {
+		if resolved, ok := plan.ResolvedSurface(surface); ok {
+			return resolved, true
+		}
+	}
+	return ResolvedSpecSurface{}, false
+}
+
+func (plan StaticConnectionPlan) ConfiguredSpecSurface() (ResolvedSpecSurface, bool) {
+	if resolved, ok := plan.ConfiguredAPISurface(); ok {
+		return resolved, true
+	}
+	return plan.ResolvedSurface(SpecSurfaceMCP)
+}
+
+func (plan StaticConnectionPlan) ResolvedSurface(surface SpecSurface) (ResolvedSpecSurface, bool) {
+	resolved, ok := plan.surfaces[surface]
+	return resolved, ok
+}
+
+func (plan StaticConnectionPlan) AuthDefaultConnection() string {
+	return plan.fallbackConnection()
+}
+
+func (plan StaticConnectionPlan) APIConnection() string {
+	if resolved, ok := plan.ConfiguredAPISurface(); ok {
+		return resolved.ConnectionName
+	}
+	if plan.restConnection != "" {
+		return plan.restConnection
+	}
+	return plan.fallbackConnection()
+}
+
+func (plan StaticConnectionPlan) MCPConnection() string {
+	if resolved, ok := plan.ResolvedSurface(SpecSurfaceMCP); ok {
+		return resolved.ConnectionName
+	}
+	return plan.fallbackConnection()
+}
+
+func (plan StaticConnectionPlan) AdvertisedConnectionNames() []string {
+	names := plan.NamedConnectionNames()
+	if !plan.shouldAdvertisePluginConnection() {
+		return names
+	}
+	return append([]string{PluginConnectionName}, names...)
+}
+
+func (plan StaticConnectionPlan) ConnectionMode() core.ConnectionMode {
+	needUser := false
+	needIdentity := false
+
+	addMode := func(mode core.ConnectionMode) {
+		switch mode {
+		case core.ConnectionModeUser:
+			needUser = true
+		case core.ConnectionModeIdentity:
+			needIdentity = true
+		case core.ConnectionModeEither:
+			needUser = true
+			needIdentity = true
+		}
+	}
+
+	addMode(connectionModeForConnection(plan.pluginConnection))
+	for _, name := range plan.NamedConnectionNames() {
+		addMode(connectionModeForConnection(plan.namedConnections[name]))
+	}
+
+	switch {
+	case needUser && needIdentity:
+		return core.ConnectionModeEither
+	case needUser:
+		return core.ConnectionModeUser
+	case needIdentity:
+		return core.ConnectionModeIdentity
+	default:
+		return core.ConnectionModeNone
+	}
+}
+
+func (plan StaticConnectionPlan) fallbackConnection() string {
+	if plan.defaultConnection != "" {
+		return plan.defaultConnection
+	}
+	if len(plan.namedConnections) == 0 {
+		return PluginConnectionName
+	}
+	if len(plan.namedConnections) == 1 {
+		for name := range plan.namedConnections {
+			return name
+		}
+	}
+	return ""
+}
+
+func (plan StaticConnectionPlan) resolveSurfaceConnectionName(raw string) string {
+	if name := ResolveConnectionAlias(raw); name != "" {
+		return name
+	}
+	if plan.defaultConnection != "" {
+		return plan.defaultConnection
+	}
+	if len(plan.namedConnections) == 1 {
+		for name := range plan.namedConnections {
+			return name
+		}
+	}
+	return PluginConnectionName
+}
+
+func (plan StaticConnectionPlan) shouldAdvertisePluginConnection() bool {
+	if !plan.manifestBacked {
+		return true
+	}
+	if len(plan.namedConnections) == 0 {
+		return true
+	}
+	if plan.defaultConnection == PluginConnectionName {
+		return true
+	}
+	if plan.APIConnection() == PluginConnectionName {
+		return true
+	}
+	if plan.MCPConnection() == PluginConnectionName {
+		return true
+	}
+	return false
+}
+
+func (plan StaticConnectionPlan) connectionDef(name string) (ConnectionDef, error) {
+	if name == "" || name == PluginConnectionName {
+		return plan.pluginConnection, nil
+	}
+	conn, ok := plan.namedConnections[name]
+	if !ok {
+		return ConnectionDef{}, fmt.Errorf("undeclared connection %q", name)
+	}
+	return conn, nil
+}
+
+func resolveDefaultConnectionName(plugin *ProviderEntry, manifestPlugin *providermanifestv1.Spec) string {
+	if plugin != nil {
+		if name := ResolveConnectionAlias(plugin.DefaultConnection); name != "" {
+			return name
+		}
+	}
+	if manifestPlugin != nil {
+		if name := ResolveConnectionAlias(manifestPlugin.DefaultConnection); name != "" {
+			return name
+		}
+	}
+	return ""
+}
+
+func surfaceURL(plugin *ProviderEntry, manifestPlugin *providermanifestv1.Spec, surface SpecSurface) string {
+	if url := ProviderSurfaceURLOverride(plugin, surface); url != "" {
+		return url
+	}
+	url := ManifestProviderSurfaceURL(manifestPlugin, surface)
+	if url == "" {
+		return ""
+	}
+	return ResolveManifestRelativeSpecURL(plugin, url)
+}
+
+func namedConnectionNames(plugin *ProviderEntry, manifestPlugin *providermanifestv1.Spec) map[string]struct{} {
+	names := make(map[string]struct{})
+	add := func(name string) {
+		resolved := ResolveConnectionAlias(name)
+		if resolved != "" && resolved != PluginConnectionName {
+			names[resolved] = struct{}{}
+		}
+	}
+	if manifestPlugin != nil {
+		for name := range manifestPlugin.Connections {
+			add(name)
+		}
+	}
+	if plugin != nil {
+		for name := range plugin.Connections {
+			add(name)
+		}
+	}
+	return names
+}
+
+func connectionModeForConnection(conn ConnectionDef) core.ConnectionMode {
+	if conn.Mode != "" {
+		return core.ConnectionMode(conn.Mode)
+	}
+	switch conn.Auth.Type {
+	case "", providermanifestv1.AuthTypeNone:
+		return core.ConnectionModeNone
+	default:
+		return core.ConnectionModeUser
+	}
+}

--- a/gestaltd/internal/operator/lifecycle_test.go
+++ b/gestaltd/internal/operator/lifecycle_test.go
@@ -506,6 +506,95 @@ spec:
 	}
 }
 
+func TestLoadForExecutionAtPath_RejectsUndeclaredManifestSurfaceConnections(t *testing.T) {
+	t.Parallel()
+
+	cases := []struct {
+		name        string
+		surfaceYAML string
+		wantErr     string
+	}{
+		{
+			name: "rest",
+			surfaceYAML: `    rest:
+      baseUrl: https://example.com
+      connection: workspace
+      operations:
+        - name: ping
+          method: GET
+          path: /ping
+`,
+			wantErr: `rest connection references undeclared connection "workspace"`,
+		},
+		{
+			name: "openapi",
+			surfaceYAML: `    openapi:
+      document: https://example.com/openapi.json
+      connection: workspace
+`,
+			wantErr: `openapi_connection references undeclared connection "workspace"`,
+		},
+		{
+			name: "graphql",
+			surfaceYAML: `    graphql:
+      url: https://example.com/graphql
+      connection: workspace
+`,
+			wantErr: `graphql_connection references undeclared connection "workspace"`,
+		},
+		{
+			name: "mcp",
+			surfaceYAML: `    mcp:
+      url: https://example.com/mcp
+      connection: workspace
+`,
+			wantErr: `mcp_connection references undeclared connection "workspace"`,
+		},
+	}
+
+	for _, tc := range cases {
+		tc := tc
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+
+			dir := t.TempDir()
+			manifestPath := filepath.Join(dir, "manifest.yaml")
+			manifest := fmt.Sprintf(`kind: plugin
+source: github.com/testowner/plugins/example
+version: 0.0.1-alpha.1
+displayName: Example
+spec:
+  auth:
+    type: none
+  surfaces:
+%s`, tc.surfaceYAML)
+			if err := os.WriteFile(manifestPath, []byte(manifest), 0o644); err != nil {
+				t.Fatalf("WriteFile manifest: %v", err)
+			}
+
+			cfgPath := filepath.Join(dir, "config.yaml")
+			cfg := requiredComponentConfigYAML(t, dir, filepath.Join(dir, "gestalt.db")) + `plugins:
+    example:
+      source:
+        path: ./manifest.yaml
+` + `server:
+` + requiredServerDatastoreYAML() + `  encryptionKey: aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa
+`
+			if err := os.WriteFile(cfgPath, []byte(cfg), 0o644); err != nil {
+				t.Fatalf("WriteFile config: %v", err)
+			}
+
+			_, _, err := NewLifecycle(nil).LoadForExecutionAtPath(cfgPath, false)
+			if err == nil {
+				t.Fatalf("LoadForExecutionAtPath: expected error containing %q", tc.wantErr)
+			}
+			if !strings.Contains(err.Error(), tc.wantErr) {
+				t.Fatalf("LoadForExecutionAtPath error = %v, want substring %q", err, tc.wantErr)
+			}
+		})
+	}
+}
+
 func TestInitAtPath_RejectsInvalidPluginInvokesShape(t *testing.T) {
 	t.Parallel()
 

--- a/gestaltd/internal/server/handlers_connect.go
+++ b/gestaltd/internal/server/handlers_connect.go
@@ -370,11 +370,11 @@ func (s *Server) effectiveConnectionAuth(integration, connection string) config.
 	if !ok || entry == nil {
 		return config.ConnectionAuthDef{}
 	}
-	manifestProvider := entry.ManifestSpec()
-	if connection == config.PluginConnectionName {
-		return config.EffectivePluginConnectionDef(entry, manifestProvider).Auth
+	plan, err := config.BuildStaticConnectionPlan(entry, entry.ManifestSpec())
+	if err != nil {
+		return config.ConnectionAuthDef{}
 	}
-	conn, ok := config.EffectiveNamedConnectionDef(entry, manifestProvider, connection)
+	conn, ok := plan.LookupConnection(connection)
 	if !ok {
 		return config.ConnectionAuthDef{}
 	}

--- a/gestaltd/internal/server/handlers_tokens.go
+++ b/gestaltd/internal/server/handlers_tokens.go
@@ -10,7 +10,6 @@ import (
 
 	"github.com/go-chi/chi/v5"
 	"github.com/valon-technologies/gestalt/server/core"
-	"github.com/valon-technologies/gestalt/server/internal/bootstrap"
 	"github.com/valon-technologies/gestalt/server/internal/config"
 	providermanifestv1 "github.com/valon-technologies/gestalt/server/sdk/providermanifest/v1"
 )
@@ -187,32 +186,19 @@ func (s *Server) connectionInfosForPlugin(integration string, plugin *config.Pro
 	if plugin == nil {
 		return []connectionDefInfo{}
 	}
-	manifestProvider := plugin.ManifestSpec()
-
-	names, err := bootstrap.AdvertisedConnectionNames(plugin)
+	plan, err := config.BuildStaticConnectionPlan(plugin, plugin.ManifestSpec())
 	if err != nil {
 		return []connectionDefInfo{}
 	}
+	names := plan.AdvertisedConnectionNames()
 	infos := make([]connectionDefInfo, 0, len(names))
 	for _, name := range names {
-		if name == config.PluginConnectionName {
-			effectivePluginConn := config.EffectivePluginConnectionDef(plugin, manifestProvider)
-			if !userFacingConnection(effectivePluginConn) {
-				continue
-			}
-			if info, ok := s.connectionInfoFromAuth(integration, config.PluginConnectionAlias, effectivePluginConn, integrationAuthTypes, defaultCredentialFields, false); ok {
-				infos = append(infos, info)
-			}
+		conn, ok := plan.LookupConnection(name)
+		if !ok || !userFacingConnection(conn) {
 			continue
 		}
-		conn, ok := config.EffectiveNamedConnectionDef(plugin, manifestProvider, name)
-		if ok {
-			if !userFacingConnection(conn) {
-				continue
-			}
-			if info, ok := s.connectionInfoFromAuth(integration, name, conn, integrationAuthTypes, defaultCredentialFields, true); ok {
-				infos = append(infos, info)
-			}
+		if info, ok := s.connectionInfoFromAuth(integration, userFacingConnectionName(name), conn, integrationAuthTypes, defaultCredentialFields, name != config.PluginConnectionName); ok {
+			infos = append(infos, info)
 		}
 	}
 


### PR DESCRIPTION
## Summary
- move manifest-backed connection selection into a shared `internal/config` planner so bootstrap runtime, resolved-structure validation, and prepared-provider validation all consume the same logic
- remove duplicated bootstrap-only branching for connection resolution and prepared-provider connection-mode aggregation
- validate undeclared `rest/openapi/graphql/mcp` surface connection refs during resolved-structure load using the same planner
- keep connection advertisement and runtime connection selection behavior unchanged while reducing the number of separate decision paths

## Go Interface Changes
- added internal config API: `BuildStaticConnectionPlan(*ProviderEntry, *providermanifestv1.Spec) (StaticConnectionPlan, error)`
- added internal config types for shared consumers: `StaticConnectionPlan` and `ResolvedSpecSurface`
- example:

```go
plan, err := config.BuildStaticConnectionPlan(entry, entry.ManifestSpec())
if err != nil {
    return err
}

apiConn := plan.APIConnection()
mode := plan.ConnectionMode()
resolved, ok := plan.ConfiguredSpecSurface()
```

## YAML Interface Changes
- none; existing connection fields are unchanged
- the same fields now validate against the shared planner during resolved-structure load
- example unchanged YAML:

```yaml
plugins:
  example:
    defaultConnection: plugin
    source:
      path: ./manifest.yaml
```

## Verification
- `cd gestaltd && go test ./internal/config ./internal/bootstrap ./internal/operator -count=1`
- `cd gestaltd && go test ./internal/server ./internal/mcp -count=1`
- `cd gestaltd && go test ./internal/... -run TestDoesNotExist -count=1`

## Test Coverage
- adds bootstrap coverage for manifest-aware prepared-provider connection mode
- adds operator execution-path coverage for undeclared `rest/openapi/graphql/mcp` surface connection refs
- adds no new unit-test-only helper suite
