### PR TITLE
sdk/typescript: normalize s3 body inputs

### DIFF
--- a/sdk/typescript/src/plugin.ts
+++ b/sdk/typescript/src/plugin.ts
@@ -64,6 +64,15 @@ export interface OperationDefinition<In, Out> extends OperationOptions<
   Out
 > {}
 
+type StoredOperationDefinition<In, Out> = OperationDefinition<In, Out> & {
+  id: string;
+  method: string;
+  title: string;
+  description: string;
+  allowedRoles: string[];
+  tags: string[];
+};
+
 /**
  * Session-specific catalog payload returned by a provider at runtime.
  */
@@ -94,15 +103,7 @@ export interface PluginDefinitionOptions extends RuntimeProviderOptions {
 export function operation<In, Out>(
   options: OperationOptions<In, Out>,
 ): OperationDefinition<In, Out> {
-  return {
-    ...options,
-    id: options.id.trim(),
-    method: normalizeMethod(options.method),
-    title: options.title?.trim() ?? "",
-    description: options.description?.trim() ?? "",
-    allowedRoles: normalizeAllowedRoles(options.allowedRoles),
-    tags: [...(options.tags ?? [])],
-  };
+  return normalizeOperationDefinition(options);
 }
 
 /**
@@ -137,10 +138,7 @@ export class PluginProvider extends RuntimeProvider {
   readonly connectionParams: Record<string, ConnectionParamDefinition>;
 
   private readonly sessionCatalogHandler: SessionCatalogHandler | undefined;
-  private readonly operations = new Map<
-    string,
-    OperationDefinition<any, any>
-  >();
+  private readonly operations = new Map<string, StoredOperationDefinition<any, any>>();
 
   constructor(options: PluginDefinitionOptions) {
     super(options);
@@ -150,23 +148,15 @@ export class PluginProvider extends RuntimeProvider {
     this.connectionParams = normalizeConnectionParams(options.connectionParams);
     this.sessionCatalogHandler = options.sessionCatalog;
 
-    for (const entry of options.operations) {
-      const id = entry.id.trim();
-      if (!id) {
+    for (const rawEntry of options.operations) {
+      const entry = normalizeOperationDefinition(rawEntry);
+      if (!entry.id) {
         throw new Error("operation id is required");
       }
-      if (this.operations.has(id)) {
-        throw new Error(`duplicate operation id ${JSON.stringify(id)}`);
+      if (this.operations.has(entry.id)) {
+        throw new Error(`duplicate operation id ${JSON.stringify(entry.id)}`);
       }
-      this.operations.set(id, {
-        ...entry,
-        id,
-        method: normalizeMethod(entry.method),
-        title: entry.title?.trim() ?? "",
-        description: entry.description?.trim() ?? "",
-        allowedRoles: normalizeAllowedRoles(entry.allowedRoles),
-        tags: [...(entry.tags ?? [])],
-      });
+      this.operations.set(entry.id, entry);
     }
   }
 
@@ -195,7 +185,7 @@ export class PluginProvider extends RuntimeProvider {
         (entry) => {
           const operationCatalog: CatalogOperation = {
             id: entry.id,
-            method: normalizeMethod(entry.method),
+            method: entry.method,
           };
           if (entry.title) {
             operationCatalog.title = entry.title;
@@ -364,6 +354,20 @@ function normalizeConnectionParams(
     output[key] = entry;
   }
   return output;
+}
+
+function normalizeOperationDefinition<In, Out>(
+  options: OperationOptions<In, Out>,
+): StoredOperationDefinition<In, Out> {
+  return {
+    ...options,
+    id: options.id.trim(),
+    method: normalizeMethod(options.method),
+    title: options.title?.trim() ?? "",
+    description: options.description?.trim() ?? "",
+    allowedRoles: normalizeAllowedRoles(options.allowedRoles),
+    tags: [...(options.tags ?? [])],
+  };
 }
 
 function isResponse(value: unknown): value is Response<unknown> {

--- a/sdk/typescript/src/runtime.ts
+++ b/sdk/typescript/src/runtime.ts
@@ -234,12 +234,11 @@ export async function loadProviderFromTarget(
   rawTarget?: string,
 ): Promise<LoadedProvider> {
   const config = readPackageConfig(root);
-  const targetValue =
-    rawTarget?.trim() ||
-    formatProviderTarget(
-      config.providerTarget ?? readPackageProviderTarget(root),
-    );
-  const target = parseProviderTarget(targetValue);
+  const explicitTarget = rawTarget?.trim();
+  const target = explicitTarget
+    ? parseProviderTarget(explicitTarget)
+    : config.providerTarget ?? readPackageProviderTarget(root);
+  const targetValue = explicitTarget ?? formatProviderTarget(target);
   const module = await import(resolveProviderImportUrl(root, target));
   const candidate =
     (target.exportName ? Reflect.get(module, target.exportName) : undefined) ??

--- a/sdk/typescript/src/s3.ts
+++ b/sdk/typescript/src/s3.ts
@@ -402,26 +402,8 @@ export function createS3Service(
       return create(EmptySchema, {});
     },
     async listObjects(request) {
-      const options: ListOptions = {
-        bucket: request.bucket,
-      };
-      if (request.prefix) {
-        options.prefix = request.prefix;
-      }
-      if (request.delimiter) {
-        options.delimiter = request.delimiter;
-      }
-      if (request.continuationToken) {
-        options.continuationToken = request.continuationToken;
-      }
-      if (request.startAfter) {
-        options.startAfter = request.startAfter;
-      }
-      if (request.maxKeys > 0) {
-        options.maxKeys = request.maxKeys;
-      }
       const page = await invokeS3Provider("list objects", () =>
-        provider.listObjects(options),
+        provider.listObjects(fromProtoListOptions(request)),
       );
       return create(ListObjectsResponseSchema, {
         objects: page.objects.map(toProtoObjectMeta),
@@ -431,53 +413,23 @@ export function createS3Service(
       });
     },
     async copyObject(request) {
-      const options: CopyOptions = {};
-      if (request.ifMatch) {
-        options.ifMatch = request.ifMatch;
-      }
-      if (request.ifNoneMatch) {
-        options.ifNoneMatch = request.ifNoneMatch;
-      }
       const meta = await invokeS3Provider("copy object", () =>
         provider.copyObject(
           fromProtoObjectRef(request.source),
           fromProtoObjectRef(request.destination),
-          options,
+          fromProtoCopyOptions(request),
         ),
       );
       return create(CopyObjectResponseSchema, { meta: toProtoObjectMeta(meta) });
     },
     async presignObject(request) {
-      const options: PresignOptions = {
-        method: fromProtoPresignMethod(request.method),
-        headers: cloneStringMap(request.headers),
-      };
-      if (request.expiresSeconds !== 0n) {
-        options.expiresSeconds = request.expiresSeconds;
-      }
-      if (request.contentType) {
-        options.contentType = request.contentType;
-      }
-      if (request.contentDisposition) {
-        options.contentDisposition = request.contentDisposition;
-      }
       const result = await invokeS3Provider("presign object", () =>
-        provider.presignObject(fromProtoObjectRef(request.ref), options),
+        provider.presignObject(
+          fromProtoObjectRef(request.ref),
+          fromProtoPresignOptions(request),
+        ),
       );
-      const response = {
-        url: result.url,
-        method: toProtoPresignMethod(result.method),
-        headers: cloneStringMap(result.headers),
-      } as {
-        url: string;
-        method: ProtoPresignMethod;
-        headers: Record<string, string>;
-        expiresAt?: { seconds: bigint; nanos: number };
-      };
-      if (result.expiresAt) {
-        response.expiresAt = toProtoTimestamp(result.expiresAt);
-      }
-      return create(PresignObjectResponseSchema, response);
+      return create(PresignObjectResponseSchema, toProtoPresignResult(result));
     },
   };
 }
@@ -566,14 +518,7 @@ export class S3 {
 
   async listObjects(options: ListOptions): Promise<ListPage> {
     const response = await s3Rpc(() =>
-      this.client.listObjects({
-        bucket: options.bucket,
-        prefix: options.prefix ?? "",
-        delimiter: options.delimiter ?? "",
-        continuationToken: options.continuationToken ?? "",
-        startAfter: options.startAfter ?? "",
-        maxKeys: options.maxKeys ?? 0,
-      }),
+      this.client.listObjects(toProtoListRequest(options)),
     );
     return {
       objects: response.objects.map(fromProtoObjectMeta),
@@ -589,12 +534,7 @@ export class S3 {
     options?: CopyOptions,
   ): Promise<ObjectMeta> {
     const response = await s3Rpc(() =>
-      this.client.copyObject({
-        source: toProtoObjectRef(source),
-        destination: toProtoObjectRef(destination),
-        ifMatch: options?.ifMatch ?? "",
-        ifNoneMatch: options?.ifNoneMatch ?? "",
-      }),
+      this.client.copyObject(toProtoCopyRequest(source, destination, options)),
     );
     return fromProtoObjectMeta(response.meta);
   }
@@ -602,26 +542,9 @@ export class S3 {
   async presignObject(ref: ObjectRef, options?: PresignOptions): Promise<PresignResult> {
     const requestedMethod = options?.method ?? PresignMethod.Get;
     const response = await s3Rpc(() =>
-      this.client.presignObject({
-        ref: toProtoObjectRef(ref),
-        method: toProtoPresignMethod(requestedMethod),
-        expiresSeconds: normalizeProtoInt(options?.expiresSeconds),
-        contentType: options?.contentType ?? "",
-        contentDisposition: options?.contentDisposition ?? "",
-        headers: cloneStringMap(options?.headers),
-      }),
+      this.client.presignObject(toProtoPresignRequest(ref, requestedMethod, options)),
     );
-    const result: PresignResult = {
-      url: response.url,
-      method: response.method === ProtoPresignMethod.UNSPECIFIED
-        ? requestedMethod
-        : fromProtoPresignMethod(response.method),
-      headers: cloneStringMap(response.headers),
-    };
-    if (response.expiresAt) {
-      result.expiresAt = fromProtoTimestamp(response.expiresAt);
-    }
-    return result;
+    return fromProtoPresignResult(response, requestedMethod);
   }
 }
 
@@ -1033,6 +956,74 @@ function fromProtoObjectMeta(meta: {
   return value;
 }
 
+function toProtoListRequest(options: ListOptions) {
+  return {
+    bucket: options.bucket,
+    prefix: options.prefix ?? "",
+    delimiter: options.delimiter ?? "",
+    continuationToken: options.continuationToken ?? "",
+    startAfter: options.startAfter ?? "",
+    maxKeys: options.maxKeys ?? 0,
+  };
+}
+
+function fromProtoListOptions(request: {
+  bucket?: string;
+  prefix?: string;
+  delimiter?: string;
+  continuationToken?: string;
+  startAfter?: string;
+  maxKeys?: number;
+}): ListOptions {
+  const options: ListOptions = {
+    bucket: request.bucket ?? "",
+  };
+  if (request.prefix) {
+    options.prefix = request.prefix;
+  }
+  if (request.delimiter) {
+    options.delimiter = request.delimiter;
+  }
+  if (request.continuationToken) {
+    options.continuationToken = request.continuationToken;
+  }
+  if (request.startAfter) {
+    options.startAfter = request.startAfter;
+  }
+  const maxKeys = request.maxKeys;
+  if (typeof maxKeys === "number" && maxKeys > 0) {
+    options.maxKeys = maxKeys;
+  }
+  return options;
+}
+
+function toProtoCopyRequest(
+  source: ObjectRef,
+  destination: ObjectRef,
+  options?: CopyOptions,
+) {
+  return {
+    source: toProtoObjectRef(source),
+    destination: toProtoObjectRef(destination),
+    ifMatch: options?.ifMatch ?? "",
+    ifNoneMatch: options?.ifNoneMatch ?? "",
+  };
+}
+
+function fromProtoCopyOptions(request: {
+  ifMatch?: string;
+  ifNoneMatch?: string;
+}): CopyOptions {
+  const options: CopyOptions = {};
+  if (request.ifMatch) {
+    options.ifMatch = request.ifMatch;
+  }
+  if (request.ifNoneMatch) {
+    options.ifNoneMatch = request.ifNoneMatch;
+  }
+  return options;
+}
+
 function toProtoReadOptions(options?: ReadOptions) {
   const proto: Record<string, unknown> = {
     ifMatch: options?.ifMatch ?? "",
@@ -1114,6 +1105,45 @@ function fromProtoWriteOptions(open: {
   return options;
 }
 
+function toProtoPresignRequest(
+  ref: ObjectRef,
+  requestedMethod: PresignMethod,
+  options?: PresignOptions,
+) {
+  return {
+    ref: toProtoObjectRef(ref),
+    method: toProtoPresignMethod(requestedMethod),
+    expiresSeconds: normalizeProtoInt(options?.expiresSeconds),
+    contentType: options?.contentType ?? "",
+    contentDisposition: options?.contentDisposition ?? "",
+    headers: cloneStringMap(options?.headers),
+  };
+}
+
+function fromProtoPresignOptions(request: {
+  method?: ProtoPresignMethod;
+  expiresSeconds?: bigint;
+  contentType?: string;
+  contentDisposition?: string;
+  headers?: Record<string, string>;
+}): PresignOptions {
+  const options: PresignOptions = {
+    method: fromProtoPresignMethod(request.method),
+    headers: cloneStringMap(request.headers),
+  };
+  const expiresSeconds = request.expiresSeconds;
+  if (expiresSeconds !== undefined && expiresSeconds !== 0n) {
+    options.expiresSeconds = expiresSeconds;
+  }
+  if (request.contentType) {
+    options.contentType = request.contentType;
+  }
+  if (request.contentDisposition) {
+    options.contentDisposition = request.contentDisposition;
+  }
+  return options;
+}
+
 function toProtoByteRange(range: ByteRange) {
   const proto: Record<string, unknown> = {};
   if (range.start !== undefined) {
@@ -1136,6 +1166,50 @@ function fromProtoByteRange(range: { start?: bigint; end?: bigint }): ByteRange 
   return value;
 }
 
+function toProtoPresignResult(result: PresignResult): {
+  url: string;
+  method: ProtoPresignMethod;
+  headers: Record<string, string>;
+  expiresAt?: { seconds: bigint; nanos: number };
+} {
+  const response = {
+    url: result.url,
+    method: toProtoPresignMethod(result.method),
+    headers: cloneStringMap(result.headers),
+  } as {
+    url: string;
+    method: ProtoPresignMethod;
+    headers: Record<string, string>;
+    expiresAt?: { seconds: bigint; nanos: number };
+  };
+  if (result.expiresAt) {
+    response.expiresAt = toProtoTimestamp(result.expiresAt);
+  }
+  return response;
+}
+
+function fromProtoPresignResult(
+  response: {
+    url?: string;
+    method?: ProtoPresignMethod;
+    headers?: Record<string, string>;
+    expiresAt?: { seconds?: bigint; nanos?: number };
+  },
+  requestedMethod: PresignMethod,
+): PresignResult {
+  const result: PresignResult = {
+    url: response.url ?? "",
+    method: response.method === ProtoPresignMethod.UNSPECIFIED
+      ? requestedMethod
+      : fromProtoPresignMethod(response.method),
+    headers: cloneStringMap(response.headers),
+  };
+  if (response.expiresAt) {
+    result.expiresAt = fromProtoTimestamp(response.expiresAt);
+  }
+  return result;
+}
+
 function toProtoPresignMethod(method?: PresignMethod): ProtoPresignMethod {
   switch (method ?? PresignMethod.Get) {
     case PresignMethod.Get:
@@ -1149,7 +1223,7 @@ function toProtoPresignMethod(method?: PresignMethod): ProtoPresignMethod {
   }
 }
 
-function fromProtoPresignMethod(method: ProtoPresignMethod): PresignMethod {
+function fromProtoPresignMethod(method?: ProtoPresignMethod): PresignMethod {
   switch (method) {
     case ProtoPresignMethod.PUT:
       return PresignMethod.Put;

--- a/sdk/typescript/src/s3.ts
+++ b/sdk/typescript/src/s3.ts
@@ -501,9 +501,10 @@ export class S3 {
     body?: S3BodySource,
     options?: WriteOptions,
   ): Promise<ObjectMeta> {
-    const snapshot = snapshotS3Body(body);
+    const byteBody = asS3ByteArray(body);
+    const preparedBody = byteBody ? cloneBytes(byteBody) : body;
     const response = await s3Rpc(() =>
-      this.client.writeObject(writeRequests(ref, snapshot, options)),
+      this.client.writeObject(writeRequests(ref, preparedBody, options)),
     );
     return fromProtoObjectMeta(response.meta);
   }
@@ -802,16 +803,9 @@ async function* toAsyncByteStream(body?: S3BodySource): AsyncIterable<Uint8Array
     yield* chunkBytes(textEncoder.encode(body));
     return;
   }
-  if (body instanceof Uint8Array) {
-    yield* chunkBytes(body);
-    return;
-  }
-  if (body instanceof ArrayBuffer) {
-    yield* chunkBytes(new Uint8Array(body));
-    return;
-  }
-  if (ArrayBuffer.isView(body)) {
-    yield* chunkBytes(new Uint8Array(body.buffer, body.byteOffset, body.byteLength));
+  const bytes = asS3ByteArray(body);
+  if (bytes) {
+    yield* chunkBytes(bytes);
     return;
   }
   if (body instanceof Blob) {
@@ -837,20 +831,17 @@ function* chunkBytes(bytes: Uint8Array): Iterable<Uint8Array> {
   }
 }
 
-function snapshotS3Body(body?: S3BodySource): S3BodySource | undefined {
-  if (body == null || typeof body === "string") {
+function asS3ByteArray(body?: S3BodySource): Uint8Array | undefined {
+  if (body instanceof Uint8Array) {
     return body;
   }
-  if (body instanceof Uint8Array) {
-    return cloneBytes(body);
-  }
   if (body instanceof ArrayBuffer) {
-    return body.slice(0);
+    return new Uint8Array(body);
   }
   if (ArrayBuffer.isView(body)) {
-    return new Uint8Array(body.buffer.slice(body.byteOffset, body.byteOffset + body.byteLength));
+    return new Uint8Array(body.buffer, body.byteOffset, body.byteLength);
   }
-  return body;
+  return undefined;
 }
 
 async function* readableStreamToAsyncIterable(

--- a/sdk/typescript/tests/build.test.ts
+++ b/sdk/typescript/tests/build.test.ts
@@ -198,6 +198,21 @@ test("buildProviderBinary compiles a runnable plugin provider executable", async
       expect(
         metadata.staticCatalog?.operations?.some((operation) => operation.id === "count"),
       ).toBe(true);
+      expect(
+        metadata.staticCatalog?.operations?.find((operation) => operation.id === "hello"),
+      ).toMatchObject({
+        method: "POST",
+        title: "Hello",
+        description: "Return a greeting",
+        allowedRoles: ["viewer", "admin"],
+      });
+      expect(
+        metadata.staticCatalog?.operations?.find((operation) => operation.id === "count"),
+      ).toMatchObject({
+        method: "POST",
+        title: "Count",
+        description: "Echo an integer count",
+      });
 
       await expectConnectCode(
         provider.startProvider(

--- a/sdk/typescript/tests/fixtures/basic-provider/provider.ts
+++ b/sdk/typescript/tests/fixtures/basic-provider/provider.ts
@@ -2,7 +2,6 @@ import {
   connectionParam,
   definePlugin,
   ok,
-  operation,
   s,
 } from "../../../src/index.ts";
 
@@ -35,13 +34,13 @@ export const plugin = definePlugin({
     };
   },
   operations: [
-    operation({
-      id: "hello",
-      method: "POST",
-      title: "Hello",
-      description: "Return a greeting",
+    {
+      id: "  hello  ",
+      method: " post ",
+      title: "  Hello  ",
+      description: "  Return a greeting  ",
       tags: ["fixture"],
-      allowedRoles: ["viewer", "admin"],
+      allowedRoles: ["viewer", "admin", "viewer"],
       readOnly: true,
       input: s.object({
         name: s.string({
@@ -77,12 +76,12 @@ export const plugin = definePlugin({
           accessRole: request.access.role,
         });
       },
-    }),
-    operation({
-      id: "count",
-      method: "POST",
-      title: "Count",
-      description: "Echo an integer count",
+    },
+    {
+      id: " count ",
+      method: " post ",
+      title: " Count ",
+      description: " Echo an integer count ",
       input: s.object({
         count: s.integer(),
       }),
@@ -94,6 +93,6 @@ export const plugin = definePlugin({
           count: input.count,
         });
       },
-    }),
+    },
   ],
 });

--- a/sdk/typescript/tests/plugin.test.ts
+++ b/sdk/typescript/tests/plugin.test.ts
@@ -121,33 +121,6 @@ test("plugin executes operations and exposes catalog metadata", async () => {
   });
 });
 
-test("plugin normalizes operation identifiers before storing and executing", async () => {
-  const plugin = definePlugin({
-    operations: [
-      {
-        id: "  ping  ",
-        handler() {
-          return {
-            pong: true,
-          };
-        },
-      },
-    ],
-  });
-
-  const result = await plugin.execute("ping", {}, request());
-  expect(result.status).toBe(200);
-  expect(JSON.parse(result.body)).toEqual({
-    pong: true,
-  });
-  expect(plugin.staticCatalog().operations).toEqual([
-    {
-      id: "ping",
-      method: "POST",
-    },
-  ]);
-});
-
 test("plugin rejects duplicate operation identifiers after trimming", () => {
   expect(() =>
     definePlugin({

--- a/sdk/typescript/tests/runtime.test.ts
+++ b/sdk/typescript/tests/runtime.test.ts
@@ -124,6 +124,16 @@ test("loadPluginFromTarget falls through null exports to the next plugin candida
   expect(plugin.displayName).toBe("Fixture Provider Null Export");
 });
 
+test("loadPluginFromTarget ignores whitespace-only explicit targets", async () => {
+  const plugin = await loadPluginFromTarget(
+    fixturePath("basic-provider"),
+    "   ",
+  );
+  expect(plugin.kind).toBe("integration");
+  expect(plugin.name).toBe("basic-provider");
+  expect(plugin.displayName).toBe("Fixture Provider");
+});
+
 test("runtime serves a secrets provider over unix gRPC", async () => {
   const runtimeEntry = join(import.meta.dir, "..", "src", "runtime.ts");
   const root = fixturePath("secrets-provider");


### PR DESCRIPTION
## Summary
- share one byte-backed S3 conversion primitive between the stream path and the write-time snapshot path
- snapshot mutable `Uint8Array`/`ArrayBuffer`/view inputs once in `S3.writeObject()` using the existing `S3BodySource` union
- remove duplicate byte-shape branching without changing the public S3 API

## Interfaces
Go
- No Go interface change in this slice.

YAML
```yaml
provider:
  target: ./provider.ts#plugin
```

TypeScript
```ts
const s3 = new S3();
await s3.object("docs-bucket", "payload.bin").writeBytes(new Uint8Array([1, 2, 3]));
```

## Verification
- `bun test tests/s3.transport.test.ts tests/runtime.test.ts tests/build.test.ts`
- `bun run check`

## Stack
- Stacked on top of #1069
