### PR TITLE
server: centralize session catalog selector resolution

### DIFF
--- a/gestaltd/internal/server/catalog_resolution.go
+++ b/gestaltd/internal/server/catalog_resolution.go
@@ -1,0 +1,120 @@
+package server
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/valon-technologies/gestalt/server/core"
+	"github.com/valon-technologies/gestalt/server/core/catalog"
+	"github.com/valon-technologies/gestalt/server/internal/invocation"
+	"github.com/valon-technologies/gestalt/server/internal/principal"
+)
+
+type sessionCatalogTarget struct {
+	connection string
+	instance   string
+}
+
+func (s *Server) sessionCatalogTargets(providerName string, p *principal.Principal, requestedConnection, requestedInstance string) []sessionCatalogTarget {
+	connections := s.sessionCatalogConnections(providerName, p, requestedConnection)
+	targets := make([]sessionCatalogTarget, 0, len(connections))
+	for _, connection := range connections {
+		connection, instance := s.workloadBindingSelectors(p, providerName, connection, requestedInstance)
+		targets = append(targets, sessionCatalogTarget{
+			connection: connection,
+			instance:   instance,
+		})
+	}
+	return targets
+}
+
+func (s *Server) resolveOperationsCatalog(
+	ctx context.Context,
+	prov core.Provider,
+	providerName string,
+	resolver invocation.TokenResolver,
+	p *principal.Principal,
+	requestedConnection, requestedInstance string,
+) (*catalog.Catalog, bool, error) {
+	resolveCatalog := invocation.ResolveCatalogWithMetadata
+	strictCatalog := false
+	if requestedConnection != "" || requestedInstance != "" {
+		resolveCatalog = invocation.ResolveCatalogStrictWithMetadata
+		strictCatalog = true
+	} else if core.SupportsSessionCatalog(prov) {
+		resolveCatalog = invocation.ResolveCatalogStrictWithMetadata
+		strictCatalog = true
+	}
+
+	targets := s.sessionCatalogTargets(providerName, p, requestedConnection, requestedInstance)
+	if strictCatalog && requestedConnection == "" && requestedInstance == "" &&
+		(s.authorizer == nil || !s.authorizer.IsWorkload(p)) {
+		var firstErr error
+		for _, target := range targets {
+			cat, metadata, err := resolveCatalog(ctx, prov, providerName, resolver, p, target.connection, target.instance)
+			if err == nil {
+				return cat, metadata.SessionFailed, nil
+			}
+			if firstErr == nil {
+				firstErr = err
+			}
+		}
+		if firstErr != nil {
+			return nil, true, firstErr
+		}
+	}
+
+	target := targets[0]
+	cat, metadata, err := resolveCatalog(ctx, prov, providerName, resolver, p, target.connection, target.instance)
+	return cat, metadata.SessionFailed || err != nil, err
+}
+
+func (s *Server) resolveOperationMetadata(
+	ctx context.Context,
+	prov core.Provider,
+	providerName string,
+	resolver invocation.TokenResolver,
+	p *principal.Principal,
+	connection, instance, operationName string,
+) (catalog.CatalogOperation, string, error) {
+	opMeta, ok := invocation.CatalogOperation(prov.Catalog(), operationName)
+	if !core.SupportsSessionCatalog(prov) {
+		if !ok {
+			return catalog.CatalogOperation{}, connection, fmt.Errorf("%w: %q on provider %q", invocation.ErrOperationNotFound, operationName, providerName)
+		}
+		return opMeta, connection, nil
+	}
+
+	var firstSessionErr error
+	sessionCatalogResolved := false
+	for _, target := range s.sessionCatalogTargets(providerName, p, connection, instance) {
+		sessionCat, err := invocation.ResolveSessionCatalog(ctx, prov, providerName, resolver, p, target.connection, target.instance)
+		if err != nil {
+			if firstSessionErr == nil {
+				firstSessionErr = err
+			}
+			if connection != "" {
+				return catalog.CatalogOperation{}, connection, err
+			}
+			continue
+		}
+		sessionCatalogResolved = true
+		if sessionOp, sessionOK := invocation.CatalogOperation(sessionCat, operationName); sessionOK {
+			if connection == "" {
+				connection = target.connection
+			}
+			return sessionOp, connection, nil
+		}
+	}
+
+	if firstSessionErr != nil && !sessionCatalogResolved {
+		return catalog.CatalogOperation{}, connection, firstSessionErr
+	}
+	if instance != "" {
+		return catalog.CatalogOperation{}, connection, fmt.Errorf("%w: %q on provider %q", invocation.ErrOperationNotFound, operationName, providerName)
+	}
+	if !ok {
+		return catalog.CatalogOperation{}, connection, fmt.Errorf("%w: %q on provider %q", invocation.ErrOperationNotFound, operationName, providerName)
+	}
+	return opMeta, connection, nil
+}

--- a/gestaltd/internal/server/handlers.go
+++ b/gestaltd/internal/server/handlers.go
@@ -430,6 +430,28 @@ func resolveRequestedInstance(w http.ResponseWriter, requested string) (string, 
 	return instance, true
 }
 
+func (s *Server) resolveExplicitSelectors(w http.ResponseWriter, r *http.Request, integration string) (string, string, bool) {
+	requestedConnection := r.URL.Query().Get(httpConnectionParam)
+	if requestedConnection != "" {
+		var ok bool
+		requestedConnection, ok = s.resolveRequestedConnection(w, integration, requestedConnection)
+		if !ok {
+			return "", "", false
+		}
+	}
+
+	requestedInstance := r.URL.Query().Get(httpInstanceParam)
+	if requestedInstance != "" {
+		var ok bool
+		requestedInstance, ok = resolveRequestedInstance(w, requestedInstance)
+		if !ok {
+			return "", "", false
+		}
+	}
+
+	return requestedConnection, requestedInstance, true
+}
+
 func resolveConnectionParams(w http.ResponseWriter, prov core.Provider, provided map[string]string) (map[string]string, bool) {
 	connParams, err := validateConnectionParams(prov.ConnectionParamDefs(), provided)
 	if err != nil {
@@ -453,21 +475,9 @@ func (s *Server) listOperations(w http.ResponseWriter, r *http.Request) {
 		writeError(w, http.StatusForbidden, errOperationAccess.Error())
 		return
 	}
-	requestedConnection := r.URL.Query().Get(httpConnectionParam)
-	if requestedConnection != "" {
-		var ok bool
-		requestedConnection, ok = s.resolveRequestedConnection(w, name, requestedConnection)
-		if !ok {
-			return
-		}
-	}
-	requestedInstance := r.URL.Query().Get(httpInstanceParam)
-	if requestedInstance != "" {
-		var ok bool
-		requestedInstance, ok = resolveRequestedInstance(w, requestedInstance)
-		if !ok {
-			return
-		}
+	requestedConnection, requestedInstance, ok := s.resolveExplicitSelectors(w, r, name)
+	if !ok {
+		return
 	}
 	if err := rejectWorkloadSelectors(w, p, requestedConnection, requestedInstance); err != nil {
 		s.auditHTTPEvent(r.Context(), p, name, operation, false, err)
@@ -486,61 +496,14 @@ func (s *Server) listOperations(w http.ResponseWriter, r *http.Request) {
 		discoveryStartedAt = time.Now()
 		discoveryConnectionMode = metricutil.NormalizeConnectionMode(prov.ConnectionMode())
 	}
-	resolveCatalog := invocation.ResolveCatalogWithMetadata
-	strictCatalog := false
-	if requestedConnection != "" || requestedInstance != "" {
-		resolveCatalog = invocation.ResolveCatalogStrictWithMetadata
-		strictCatalog = true
-	} else if core.SupportsSessionCatalog(prov) {
-		resolveCatalog = invocation.ResolveCatalogStrictWithMetadata
-		strictCatalog = true
-	}
 	ctx := invocation.WithAccessContext(r.Context(), s.providerAccessContext(p, name))
-	var cat *catalog.Catalog
-	if strictCatalog && requestedConnection == "" && requestedInstance == "" &&
-		(s.authorizer == nil || !s.authorizer.IsWorkload(p)) {
-		catalogConnections := s.sessionCatalogConnections(name, p, requestedConnection)
-		var firstErr error
-		for _, catalogConnection := range catalogConnections {
-			resolvedConnection, catalogInstance := s.workloadBindingSelectors(p, name, catalogConnection, requestedInstance)
-			var (
-				err      error
-				metadata invocation.CatalogResolutionMetadata
-			)
-			cat, metadata, err = resolveCatalog(ctx, prov, name, resolver, p, resolvedConnection, catalogInstance)
-			if err == nil {
-				discoveryFailed = metadata.SessionFailed
-				break
-			}
-			if firstErr == nil {
-				firstErr = err
-			}
-			cat = nil
+	cat, discoveryFailed, err := s.resolveOperationsCatalog(ctx, prov, name, resolver, p, requestedConnection, requestedInstance)
+	if err != nil {
+		if recordDiscoveryMetrics {
+			metricutil.RecordDiscoveryMetrics(r.Context(), discoveryStartedAt, name, "list_operations", discoveryConnectionMode, discoveryFailed)
 		}
-		if cat == nil && firstErr != nil {
-			discoveryFailed = true
-			if recordDiscoveryMetrics {
-				metricutil.RecordDiscoveryMetrics(r.Context(), discoveryStartedAt, name, "list_operations", discoveryConnectionMode, discoveryFailed)
-			}
-			s.writeInvocationError(w, r, name, "", firstErr)
-			return
-		}
-	} else {
-		catalogConnection := s.sessionCatalogConnections(name, p, requestedConnection)[0]
-		catalogConnection, catalogInstance := s.workloadBindingSelectors(p, name, catalogConnection, requestedInstance)
-		var (
-			err      error
-			metadata invocation.CatalogResolutionMetadata
-		)
-		cat, metadata, err = resolveCatalog(ctx, prov, name, resolver, p, catalogConnection, catalogInstance)
-		discoveryFailed = metadata.SessionFailed || err != nil
-		if err != nil {
-			if recordDiscoveryMetrics {
-				metricutil.RecordDiscoveryMetrics(r.Context(), discoveryStartedAt, name, "list_operations", discoveryConnectionMode, discoveryFailed)
-			}
-			s.writeInvocationError(w, r, name, "", err)
-			return
-		}
+		s.writeInvocationError(w, r, name, "", err)
+		return
 	}
 	if recordDiscoveryMetrics {
 		metricutil.RecordDiscoveryMetrics(r.Context(), discoveryStartedAt, name, "list_operations", discoveryConnectionMode, discoveryFailed)
@@ -580,21 +543,9 @@ func (s *Server) executeOperation(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	requestedConnection := r.URL.Query().Get(httpConnectionParam)
-	if requestedConnection != "" {
-		var ok bool
-		requestedConnection, ok = s.resolveRequestedConnection(w, providerName, requestedConnection)
-		if !ok {
-			return
-		}
-	}
-	requestedInstance := r.URL.Query().Get(httpInstanceParam)
-	if requestedInstance != "" {
-		var ok bool
-		requestedInstance, ok = resolveRequestedInstance(w, requestedInstance)
-		if !ok {
-			return
-		}
+	requestedConnection, requestedInstance, ok := s.resolveExplicitSelectors(w, r, providerName)
+	if !ok {
+		return
 	}
 	if err := rejectWorkloadSelectors(w, p, requestedConnection, requestedInstance); err != nil {
 		s.auditHTTPEvent(r.Context(), p, providerName, operationName, false, err)
@@ -665,46 +616,9 @@ func (s *Server) executeOperation(w http.ResponseWriter, r *http.Request) {
 	if tr, ok := s.invoker.(invocation.TokenResolver); ok {
 		resolver = tr
 	}
-	opMeta, ok := invocation.CatalogOperation(prov.Catalog(), operationName)
-	sessionOpFound := false
-	if core.SupportsSessionCatalog(prov) {
-		var firstSessionErr error
-		sessionCatalogResolved := false
-		sessionConnections := s.sessionCatalogConnections(providerName, p, connection)
-		for _, sessionConnection := range sessionConnections {
-			sessionConnection, sessionInstance := s.workloadBindingSelectors(p, providerName, sessionConnection, instance)
-			sessionCat, err := invocation.ResolveSessionCatalog(ctx, prov, providerName, resolver, p, sessionConnection, sessionInstance)
-			if err != nil {
-				if firstSessionErr == nil {
-					firstSessionErr = err
-				}
-				if connection != "" {
-					s.writeInvocationError(w, r, providerName, operationName, err)
-					return
-				}
-				continue
-			}
-			sessionCatalogResolved = true
-			if sessionOp, sessionOK := invocation.CatalogOperation(sessionCat, operationName); sessionOK {
-				opMeta, ok = sessionOp, true
-				sessionOpFound = true
-				if connection == "" {
-					connection = sessionConnection
-				}
-				break
-			}
-		}
-		if firstSessionErr != nil && !sessionCatalogResolved {
-			s.writeInvocationError(w, r, providerName, operationName, firstSessionErr)
-			return
-		}
-		if instance != "" && !sessionOpFound {
-			s.writeInvocationError(w, r, providerName, operationName, fmt.Errorf("%w: %q on provider %q", invocation.ErrOperationNotFound, operationName, providerName))
-			return
-		}
-	}
-	if !ok {
-		s.writeInvocationError(w, r, providerName, operationName, fmt.Errorf("%w: %q on provider %q", invocation.ErrOperationNotFound, operationName, providerName))
+	opMeta, connection, err := s.resolveOperationMetadata(ctx, prov, providerName, resolver, p, connection, instance, operationName)
+	if err != nil {
+		s.writeInvocationError(w, r, providerName, operationName, err)
 		return
 	}
 	if s.authorizer != nil && !s.authorizer.AllowCatalogOperation(p, providerName, opMeta) {

--- a/gestaltd/internal/server/server_test.go
+++ b/gestaltd/internal/server/server_test.go
@@ -8037,6 +8037,178 @@ func TestExecuteOperation_PinsSessionCatalogConnectionIntoExecution(t *testing.T
 	}
 }
 
+func TestExecuteOperation_UsesBodyInstanceForSessionCatalogResolution(t *testing.T) {
+	t.Parallel()
+
+	var gotToken string
+	var gotParams map[string]any
+	sessionStub := &stubIntegrationWithSessionCatalog{
+		stubIntegrationWithOps: stubIntegrationWithOps{
+			StubIntegration: coretesting.StubIntegration{
+				N:        "sample-int",
+				ConnMode: core.ConnectionModeUser,
+				ExecuteFn: func(_ context.Context, op string, params map[string]any, token string) (*core.OperationResult, error) {
+					gotToken = token
+					gotParams = params
+					return &core.OperationResult{Status: http.StatusOK, Body: fmt.Sprintf(`{"operation":%q,"token":%q}`, op, token)}, nil
+				},
+			},
+		},
+		catalogForRequestFn: func(_ context.Context, token string) (*catalog.Catalog, error) {
+			switch token {
+			case "tenant-token":
+				return &catalog.Catalog{
+					Name: "sample-int",
+					Operations: []catalog.CatalogOperation{
+						{ID: "run", Description: "Run", Method: http.MethodPost, Transport: catalog.TransportREST},
+					},
+				}, nil
+			default:
+				return nil, fmt.Errorf("unexpected token %q", token)
+			}
+		},
+	}
+
+	svc := coretesting.NewStubServices(t)
+	u := seedUser(t, svc, "anonymous@gestalt")
+	seedToken(t, svc, &core.IntegrationToken{
+		ID: "tok-tenant", UserID: u.ID, Integration: "sample-int",
+		Connection: "catalog-conn", Instance: "tenant-a", AccessToken: "tenant-token",
+	})
+
+	ts := newTestServer(t, func(cfg *server.Config) {
+		cfg.Providers = testutil.NewProviderRegistry(t, sessionStub)
+		cfg.Services = svc
+		cfg.CatalogConnection = map[string]string{"sample-int": "catalog-conn"}
+	})
+	testutil.CloseOnCleanup(t, ts)
+
+	req, _ := http.NewRequest(http.MethodPost, ts.URL+"/api/v1/sample-int/run", bytes.NewBufferString(`{"_instance":"tenant-a","foo":"bar"}`))
+	req.Header.Set("Content-Type", "application/json")
+	resp, err := http.DefaultClient.Do(req)
+	if err != nil {
+		t.Fatalf("request: %v", err)
+	}
+	defer func() { _ = resp.Body.Close() }()
+
+	if resp.StatusCode != http.StatusOK {
+		body, _ := io.ReadAll(resp.Body)
+		t.Fatalf("expected 200, got %d: %s", resp.StatusCode, body)
+	}
+	if gotToken != "tenant-token" {
+		t.Fatalf("execute token = %q, want %q", gotToken, "tenant-token")
+	}
+	if gotParams["foo"] != "bar" {
+		t.Fatalf("expected foo=bar, got %v", gotParams["foo"])
+	}
+	if _, ok := gotParams["_instance"]; ok {
+		t.Fatalf("expected _instance to be stripped from params, got %v", gotParams["_instance"])
+	}
+}
+
+func TestExecuteOperation_IgnoresLegacySelectorParams(t *testing.T) {
+	t.Parallel()
+
+	var gotToken string
+	var gotParams map[string]any
+	sessionStub := &stubIntegrationWithSessionCatalog{
+		stubIntegrationWithOps: stubIntegrationWithOps{
+			StubIntegration: coretesting.StubIntegration{
+				N:        "sample-int",
+				ConnMode: core.ConnectionModeUser,
+				ExecuteFn: func(_ context.Context, op string, params map[string]any, token string) (*core.OperationResult, error) {
+					gotToken = token
+					gotParams = params
+					return &core.OperationResult{Status: http.StatusOK, Body: fmt.Sprintf(`{"operation":%q,"token":%q}`, op, token)}, nil
+				},
+			},
+		},
+		catalogForRequestFn: func(_ context.Context, token string) (*catalog.Catalog, error) {
+			switch token {
+			case "catalog-token", "alt-token":
+				return &catalog.Catalog{
+					Name: "sample-int",
+					Operations: []catalog.CatalogOperation{
+						{ID: "run", Description: "Run", Method: http.MethodGet, Transport: catalog.TransportREST},
+					},
+				}, nil
+			default:
+				return nil, fmt.Errorf("unexpected token %q", token)
+			}
+		},
+	}
+
+	svc := coretesting.NewStubServices(t)
+	u := seedUser(t, svc, "anonymous@gestalt")
+	seedToken(t, svc, &core.IntegrationToken{
+		ID: "tok-catalog", UserID: u.ID, Integration: "sample-int",
+		Connection: "catalog-conn", Instance: "default", AccessToken: "catalog-token",
+	})
+	seedToken(t, svc, &core.IntegrationToken{
+		ID: "tok-alt", UserID: u.ID, Integration: "sample-int",
+		Connection: "alt-conn", Instance: "tenant-a", AccessToken: "alt-token",
+	})
+
+	ts := newTestServer(t, func(cfg *server.Config) {
+		cfg.Providers = testutil.NewProviderRegistry(t, sessionStub)
+		cfg.Services = svc
+		cfg.CatalogConnection = map[string]string{"sample-int": "catalog-conn"}
+	})
+	testutil.CloseOnCleanup(t, ts)
+
+	req, _ := http.NewRequest(http.MethodGet, ts.URL+"/api/v1/sample-int/run?connection=alt-conn&instance=tenant-a&foo=bar", nil)
+	resp, err := http.DefaultClient.Do(req)
+	if err != nil {
+		t.Fatalf("request: %v", err)
+	}
+	defer func() { _ = resp.Body.Close() }()
+
+	if resp.StatusCode != http.StatusOK {
+		body, _ := io.ReadAll(resp.Body)
+		t.Fatalf("expected 200, got %d: %s", resp.StatusCode, body)
+	}
+	if gotToken != "catalog-token" {
+		t.Fatalf("execute token = %q, want %q", gotToken, "catalog-token")
+	}
+	if gotParams["connection"] != "alt-conn" {
+		t.Fatalf("expected legacy connection param to pass through, got %v", gotParams["connection"])
+	}
+	if gotParams["instance"] != "tenant-a" {
+		t.Fatalf("expected legacy instance param to pass through, got %v", gotParams["instance"])
+	}
+	if gotParams["foo"] != "bar" {
+		t.Fatalf("expected foo=bar, got %v", gotParams["foo"])
+	}
+
+	gotToken = ""
+	gotParams = nil
+
+	req, _ = http.NewRequest(http.MethodPost, ts.URL+"/api/v1/sample-int/run?connection=alt-conn&instance=tenant-a", bytes.NewBufferString(`{"foo":"bar"}`))
+	req.Header.Set("Content-Type", "application/json")
+	resp, err = http.DefaultClient.Do(req)
+	if err != nil {
+		t.Fatalf("post request: %v", err)
+	}
+	defer func(body io.ReadCloser) { _ = body.Close() }(resp.Body)
+
+	if resp.StatusCode != http.StatusOK {
+		body, _ := io.ReadAll(resp.Body)
+		t.Fatalf("expected 200 for POST, got %d: %s", resp.StatusCode, body)
+	}
+	if gotToken != "catalog-token" {
+		t.Fatalf("post execute token = %q, want %q", gotToken, "catalog-token")
+	}
+	if gotParams["foo"] != "bar" {
+		t.Fatalf("expected post foo=bar, got %v", gotParams["foo"])
+	}
+	if _, ok := gotParams["connection"]; ok {
+		t.Fatalf("expected post legacy connection query param to be ignored, got %v", gotParams["connection"])
+	}
+	if _, ok := gotParams["instance"]; ok {
+		t.Fatalf("expected post legacy instance query param to be ignored, got %v", gotParams["instance"])
+	}
+}
+
 func TestExecuteOperation_UsesConfiguredCatalogConnectionWhenInvokerIsWrapped(t *testing.T) {
 	t.Parallel()
 


### PR DESCRIPTION
## Summary
This trims duplicated selector/session-catalog branching in the server without changing product behavior.

Changes:
- extract shared explicit `_connection` / `_instance` parsing for operation list and execute routes
- extract shared session-catalog target and operation-metadata resolution
- add HTTP contract coverage that legacy `connection` / `instance` query params do not act as selectors on either GET or POST execute paths

## Rust Interface
This PR does not change a public Rust API surface.

Server-side selector behavior remains:
- only `_connection` and `_instance` are treated as explicit selectors
- legacy `connection` and `instance` do not participate in server-side session-catalog selection

HTTP examples:
```http
GET /api/v1/integrations/sample-int/operations?_connection=catalog-conn&_instance=tenant-a
GET /api/v1/sample-int/run?_connection=catalog-conn&_instance=tenant-a
```

## stdin/stdout Interface
This PR does not change the CLI stdin/stdout surface.

Existing selector-aware CLI flows continue to map to the same transport contracts.

Examples:
```bash
gestalt plugins describe sample-int --connection catalog-conn --instance tenant-a

echo '{"foo":"bar"}' | gestalt plugins invoke sample-int run \
  --connection catalog-conn \
  --instance tenant-a \
  --input-file -
```

## Contract Examples
Explicit selectors still select the catalog/credential target:
```bash
curl "$GESTALTD/api/v1/sample-int/run?_connection=catalog-conn&_instance=tenant-a"
```

Legacy query params are ignored as selectors:
```bash
curl "$GESTALTD/api/v1/sample-int/run?connection=alt-conn&instance=tenant-a&foo=bar"
```
That request still executes against the default/catalog-selected credential target; `connection` and `instance` are not treated as selectors.

## Verification
```bash
cd gestaltd
go test ./internal/server
go test ./cmd/gestaltd -run TestDoesNotExist
```