### PR TITLE
cli: pin plugin connect selection contracts

### DIFF
--- a/gestalt/cli/src/commands/plugins/connect.rs
+++ b/gestalt/cli/src/commands/plugins/connect.rs
@@ -463,7 +463,7 @@ fn resolve_connection<'a>(
         )));
     }
 
-    let options: Vec<PromptOption> = integration
+    let prompt_options: Vec<PromptOption> = integration
         .connections
         .iter()
         .map(|connection| PromptOption {
@@ -476,7 +476,7 @@ fn resolve_connection<'a>(
         .collect();
     let idx = prompt_select(
         &format!("Select a {} connection:", integration.display_name()),
-        &options,
+        &prompt_options,
     )?;
 
     Ok(Some(ResolvedConnection::from_definition(
@@ -589,7 +589,7 @@ impl IntegrationInfo {
     fn available_connections(&self) -> String {
         self.connections
             .iter()
-            .map(ConnectionDefInfo::display_name)
+            .map(|connection| ConnectionName::new(&connection.name).display().to_string())
             .collect::<Vec<_>>()
             .join(", ")
     }

--- a/gestalt/cli/tests/plugins_connect.rs
+++ b/gestalt/cli/tests/plugins_connect.rs
@@ -393,6 +393,73 @@ fn test_connection_selection_uses_selected_connection_auth_type() {
 }
 
 #[test]
+fn test_connect_auto_selects_single_connection_and_uses_its_auth_type() {
+    let mut server = Server::new();
+    let _integrations =
+        authed_json_mock!(server, Method::GET, "/api/v1/integrations", StatusCode::OK)
+            .with_body(
+                r#"[{
+                    "name":"single-svc",
+                    "displayName":"Single Service",
+                    "authTypes":["manual"],
+                    "connections":[
+                        {"name":"workspace","displayName":"Workspace OAuth","authTypes":["oauth"]}
+                    ]
+                }]"#,
+            )
+            .create();
+    let _oauth = authed_json_mock!(
+        server,
+        Method::POST,
+        "/api/v1/auth/start-oauth",
+        StatusCode::OK
+    )
+    .match_header(header::CONTENT_TYPE.as_str(), http::APPLICATION_JSON)
+    .match_body(Matcher::JsonString(
+        r#"{"connection":"workspace","integration":"single-svc"}"#.to_string(),
+    ))
+    .with_body(r#"{"url":"https://example.com/oauth","state":"abc123"}"#)
+    .create();
+
+    let home = tempfile::tempdir().unwrap();
+    cli_command_for_server(home.path(), &server)
+        .args(["plugins", "connect", "single-svc"])
+        .assert()
+        .success()
+        .stderr(predicate::str::contains("Select a Single Service connection:").not())
+        .stderr(predicate::str::contains(
+            "Opening browser to connect single-svc...",
+        ));
+}
+
+#[test]
+fn test_connect_unknown_connection_lists_normalized_available_names() {
+    let mut server = Server::new();
+    let _integrations =
+        authed_json_mock!(server, Method::GET, "/api/v1/integrations", StatusCode::OK)
+            .with_body(
+                r#"[{
+                    "name":"manual-svc",
+                    "connections":[
+                        {"name":"_plugin","displayName":"Plugin OAuth","authTypes":["oauth"]},
+                        {"name":"workspace","displayName":"Workspace OAuth","authTypes":["manual"]}
+                    ]
+                }]"#,
+            )
+            .create();
+
+    let home = tempfile::tempdir().unwrap();
+    cli_command_for_server(home.path(), &server)
+        .args(["plugins", "connect", "manual-svc", "--connection", "bogus"])
+        .assert()
+        .failure()
+        .stderr(predicate::str::contains("unknown connection 'bogus'"))
+        .stderr(predicate::str::contains(
+            "available connections: plugin, workspace",
+        ));
+}
+
+#[test]
 fn test_manual_connect_uses_credentials_object_for_multi_field_auth() {
     let mut server = Server::new();
     let _integrations =


### PR DESCRIPTION
## Summary
Keep plugin connect behavior simple and pinned without introducing new control-flow abstractions.

Changes:
- keep existing connection-selection flow and prompt ownership intact
- normalize unknown-connection errors to list selector names, not display labels
- add product-level coverage for single-connection auth override and normalized unknown-connection errors

Non-test LOC against `main`:
- `+3 / -3` net `0`

## Rust Interface
No public Rust API change.

The existing CLI internals stay intact:
```rust
let connection = resolve_connection(integration, requested_connection)?;
```

Behavioral contract tightened:
- a sole advertised connection still auto-selects and contributes its auth type
- an unknown `--connection` now reports normalized selector names in the available-connections error

## stdin/stdout Interface
The CLI surface stays the same.

Examples:
```bash
gestalt plugins connect single-svc
gestalt plugins connect manual-svc --connection bogus
```

Expected error output:
```text
$ gestalt plugins connect manual-svc --connection bogus
Error: unknown connection 'bogus' for plugin 'manual-svc'; available connections: plugin, workspace
```

## Verification
```bash
cd gestalt
cargo fmt --check
cargo test -p gestalt
```