### PR TITLE
core: hydrate sparse session catalogs at the provider boundary

### DIFF
--- a/gestaltd/core/provider_capabilities.go
+++ b/gestaltd/core/provider_capabilities.go
@@ -1,10 +1,7 @@
 package core
 
 import (
-	"context"
 	"errors"
-
-	"github.com/valon-technologies/gestalt/server/core/catalog"
 )
 
 var ErrSessionCatalogUnavailable = errors.New("session catalog unavailable")
@@ -12,13 +9,4 @@ var ErrSessionCatalogUnavailable = errors.New("session catalog unavailable")
 func SupportsSessionCatalog(prov Provider) bool {
 	_, ok := prov.(SessionCatalogProvider)
 	return ok
-}
-
-func CatalogForRequest(ctx context.Context, prov Provider, token string) (*catalog.Catalog, bool, error) {
-	scp, ok := prov.(SessionCatalogProvider)
-	if !ok {
-		return nil, false, nil
-	}
-	cat, err := scp.CatalogForRequest(ctx, token)
-	return cat, true, err
 }

--- a/gestaltd/internal/composite/provider.go
+++ b/gestaltd/internal/composite/provider.go
@@ -49,14 +49,11 @@ func (p *Provider) Name() string        { return p.name }
 func (p *Provider) DisplayName() string { return p.api.DisplayName() }
 func (p *Provider) Description() string { return p.api.Description() }
 func (p *Provider) ConnectionMode() core.ConnectionMode {
-	return stricterConnectionMode(p.api.ConnectionMode(), p.mcpConnectionMode())
-}
-
-func (p *Provider) mcpConnectionMode() core.ConnectionMode {
+	mcpMode := core.ConnectionModeNone
 	if cm, ok := p.mcp.(interface{ ConnectionMode() core.ConnectionMode }); ok {
-		return cm.ConnectionMode()
+		mcpMode = cm.ConnectionMode()
 	}
-	return core.ConnectionModeNone
+	return stricterConnectionMode(p.api.ConnectionMode(), mcpMode)
 }
 
 var connectionModeRank = map[core.ConnectionMode]int{
@@ -84,7 +81,7 @@ func (p *Provider) CatalogForRequest(ctx context.Context, token string) (*catalo
 	if err != nil || cat == nil {
 		return cat, err
 	}
-	return tagMCPCatalog(cat), nil
+	return tagCatalog(cat, catalog.TransportMCPPassthrough), nil
 }
 
 func (p *Provider) ConnectionForOperation(operation string) string {
@@ -151,10 +148,10 @@ func (p *Provider) buildCatalog() *catalog.Catalog {
 		return nil
 	}
 	if apiCat == nil {
-		return tagMCPCatalog(mcpCat)
+		return tagCatalog(mcpCat, catalog.TransportMCPPassthrough)
 	}
 	if mcpCat == nil {
-		return tagRESTCatalog(apiCat)
+		return tagCatalog(apiCat, catalog.TransportREST)
 	}
 
 	merged := &catalog.Catalog{
@@ -183,12 +180,4 @@ func tagCatalog(src *catalog.Catalog, transport string) *catalog.Catalog {
 		out.Operations[i].Transport = transport
 	}
 	return out
-}
-
-func tagRESTCatalog(src *catalog.Catalog) *catalog.Catalog {
-	return tagCatalog(src, catalog.TransportREST)
-}
-
-func tagMCPCatalog(src *catalog.Catalog) *catalog.Catalog {
-	return tagCatalog(src, catalog.TransportMCPPassthrough)
 }

--- a/gestaltd/internal/invocation/catalog.go
+++ b/gestaltd/internal/invocation/catalog.go
@@ -77,7 +77,8 @@ func ResolveOperation(ctx context.Context, prov core.Provider, provName string, 
 }
 
 func resolveSessionCatalog(ctx context.Context, prov core.Provider, provName string, resolver TokenResolver, p *principal.Principal, connection, instance string) (*catalog.Catalog, bool, error) {
-	if !core.SupportsSessionCatalog(prov) || (prov.ConnectionMode() != core.ConnectionModeNone && (resolver == nil || p == nil)) {
+	scp, ok := prov.(core.SessionCatalogProvider)
+	if !ok || (prov.ConnectionMode() != core.ConnectionModeNone && (resolver == nil || p == nil)) {
 		return nil, false, nil
 	}
 	token := ""
@@ -90,10 +91,9 @@ func resolveSessionCatalog(ctx context.Context, prov core.Provider, provName str
 	} else {
 		ctx = WithCredentialContext(ctx, CredentialContext{Mode: core.ConnectionModeNone})
 	}
-	cat, _, err := core.CatalogForRequest(ctx, prov, token)
+	cat, err := scp.CatalogForRequest(ctx, token)
 	return cat, true, err
 }
-
 func resolveSessionOperation(ctx context.Context, prov core.Provider, provName string, resolver TokenResolver, p *principal.Principal, operation string, connections []string, instance string) (catalog.CatalogOperation, string, bool, error) {
 	if len(connections) == 0 {
 		connections = []string{""}

--- a/gestaltd/internal/mcp/session_tools.go
+++ b/gestaltd/internal/mcp/session_tools.go
@@ -59,14 +59,15 @@ func hydrateSessionToolsForInstance(ctx context.Context, cfg Config, providerNam
 		if err != nil {
 			continue
 		}
-		if !core.SupportsSessionCatalog(prov) {
+		scp, ok := prov.(core.SessionCatalogProvider)
+		if !ok {
 			continue
 		}
 		sessionCtx, token, connection, err := resolveSessionToken(ctx, cfg, provName, prov, instance)
 		if err != nil {
 			continue
 		}
-		cat, _, err := core.CatalogForRequest(sessionCtx, prov, token)
+		cat, err := scp.CatalogForRequest(sessionCtx, token)
 		if err != nil {
 			continue
 		}

--- a/gestaltd/internal/providerhost/provider_client.go
+++ b/gestaltd/internal/providerhost/provider_client.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"fmt"
 	"io"
+	"maps"
 	"strings"
 	"time"
 
@@ -11,6 +12,7 @@ import (
 	proto "github.com/valon-technologies/gestalt/sdk/go/gen/v1"
 	"github.com/valon-technologies/gestalt/server/core"
 	"github.com/valon-technologies/gestalt/server/core/catalog"
+	coreintegration "github.com/valon-technologies/gestalt/server/core/integration"
 	"github.com/valon-technologies/gestalt/server/internal/invocation"
 	"github.com/valon-technologies/gestalt/server/internal/principal"
 	"google.golang.org/grpc/codes"
@@ -206,7 +208,9 @@ func (p *remoteProviderBase) sessionCatalog(ctx context.Context, token string) (
 	if err != nil {
 		return nil, err
 	}
-	return p.decorateCatalog(cat), nil
+	cat = p.decorateCatalog(cat)
+	coreintegration.CompileSchemas(cat)
+	return cat, nil
 }
 
 type remoteProviderWithSessionCatalog struct{ *remoteProviderBase }
@@ -220,6 +224,25 @@ func (p *remoteProviderBase) decorateCatalog(cat *catalog.Catalog) *catalog.Cata
 		return nil
 	}
 	decorated := cat.Clone()
+	if p.catalog != nil {
+		decorated.BaseURL = p.catalog.BaseURL
+		decorated.AuthStyle = p.catalog.AuthStyle
+		if len(p.catalog.Headers) > 0 {
+			headers := maps.Clone(p.catalog.Headers)
+			maps.Copy(headers, decorated.Headers)
+			decorated.Headers = headers
+		}
+		for i := range decorated.Operations {
+			staticOp, ok := invocation.CatalogOperation(p.catalog, decorated.Operations[i].ID)
+			if !ok {
+				continue
+			}
+			if decorated.Operations[i].Transport == "" && decorated.Operations[i].Path == "" && decorated.Operations[i].Query == "" {
+				decorated.Operations[i].Transport = staticOp.Transport
+			}
+			decorated.Operations[i] = invocation.MergeCatalogOperation(staticOp, decorated.Operations[i])
+		}
+	}
 	if decorated.Name == "" {
 		decorated.Name = p.name
 	}

--- a/gestaltd/internal/providerhost/provider_server.go
+++ b/gestaltd/internal/providerhost/provider_server.go
@@ -50,14 +50,15 @@ func (s *ProviderServer) Execute(ctx context.Context, req *proto.ExecuteRequest)
 }
 
 func (s *ProviderServer) GetSessionCatalog(ctx context.Context, req *proto.GetSessionCatalogRequest) (*proto.GetSessionCatalogResponse, error) {
-	if !core.SupportsSessionCatalog(s.provider) {
+	scp, ok := s.provider.(core.SessionCatalogProvider)
+	if !ok {
 		return nil, status.Error(codes.Unimplemented, "provider does not support session catalogs")
 	}
 	ctx = applyRequestContext(ctx, req.GetContext())
 	if len(req.GetConnectionParams()) > 0 {
 		ctx = core.WithConnectionParams(ctx, req.GetConnectionParams())
 	}
-	cat, _, err := core.CatalogForRequest(ctx, s.provider, req.GetToken())
+	cat, err := scp.CatalogForRequest(ctx, req.GetToken())
 	if err != nil {
 		return nil, status.Errorf(codes.Unknown, "session catalog: %v", err)
 	}

--- a/gestaltd/internal/providerhost/provider_test.go
+++ b/gestaltd/internal/providerhost/provider_test.go
@@ -11,6 +11,7 @@ import (
 	proto "github.com/valon-technologies/gestalt/sdk/go/gen/v1"
 	"github.com/valon-technologies/gestalt/server/core"
 	"github.com/valon-technologies/gestalt/server/core/catalog"
+	coreintegration "github.com/valon-technologies/gestalt/server/core/integration"
 	"github.com/valon-technologies/gestalt/server/internal/invocation"
 	"github.com/valon-technologies/gestalt/server/internal/principal"
 )
@@ -61,15 +62,57 @@ func (p *roundTripProvider) Execute(ctx context.Context, operation string, param
 	}, nil
 }
 
-func (p *roundTripProvider) Catalog() *catalog.Catalog {
-	return &catalog.Catalog{
+func roundTripOperation(allowedRoles ...string) catalog.CatalogOperation {
+	return catalog.CatalogOperation{
+		ID:           "echo",
+		ProviderID:   "queries",
+		Method:       http.MethodPost,
+		Path:         "/v1/queries/{queryId}",
+		Query:        "view=full",
+		Title:        "Echo",
+		Description:  "Echo input",
+		AllowedRoles: append([]string(nil), allowedRoles...),
+		Transport:    catalog.TransportREST,
+		Parameters: []catalog.CatalogParameter{
+			{Name: "message", Type: "string", Description: "message", Required: true},
+			{Name: "query_id", WireName: "queryId", Type: "string", Location: "path", Description: "query id", Required: true},
+		},
+	}
+}
+
+func roundTripPluginOperation(allowedRoles ...string) catalog.CatalogOperation {
+	return catalog.CatalogOperation{
+		ID:           "plugin_echo",
+		Method:       http.MethodPost,
+		Description:  "Plugin echo",
+		AllowedRoles: append([]string(nil), allowedRoles...),
+		Parameters: []catalog.CatalogParameter{
+			{Name: "message", Type: "string", Description: "message", Required: true},
+		},
+	}
+}
+
+func roundTripStaticCatalog() *catalog.Catalog {
+	cat := &catalog.Catalog{
 		Name:        "roundtrip",
 		DisplayName: "Round Trip",
 		Description: "test provider",
+		BaseURL:     "https://roundtrip.example.com",
+		AuthStyle:   "bearer",
+		Headers: map[string]string{
+			"X-Env": "test",
+		},
 		Operations: []catalog.CatalogOperation{
-			{ID: "echo", Method: http.MethodPost, AllowedRoles: []string{"admin"}},
+			roundTripOperation("admin"),
+			roundTripPluginOperation("admin"),
 		},
 	}
+	coreintegration.CompileSchemas(cat)
+	return cat
+}
+
+func (p *roundTripProvider) Catalog() *catalog.Catalog {
+	return roundTripStaticCatalog()
 }
 
 func (p *roundTripProvider) CatalogForRequest(ctx context.Context, token string) (*catalog.Catalog, error) {
@@ -97,7 +140,21 @@ func (p *roundTripProvider) CatalogForRequest(ctx context.Context, token string)
 		DisplayName: fmt.Sprintf("%s|%s|%s|%s|%s|%s|%s|%s|%s", token, subjectID, subjectKind, displayName, identityPresent, authSource, credential.Mode, access.Policy, access.Role),
 		Description: "session catalog",
 		Operations: []catalog.CatalogOperation{
-			{ID: "echo", Method: http.MethodPost, AllowedRoles: []string{"viewer"}},
+			{
+				ID:           "echo",
+				AllowedRoles: []string{"viewer"},
+				Parameters: []catalog.CatalogParameter{
+					{Name: "message", Type: "string", Description: "message", Required: true},
+					{Name: "query_id", Type: "string", Description: "query id", Required: true},
+				},
+			},
+			{
+				ID:           "plugin_echo",
+				AllowedRoles: []string{"viewer"},
+				Parameters: []catalog.CatalogParameter{
+					{Name: "message", Type: "string", Description: "message", Required: true},
+				},
+			},
 		},
 	}, nil
 }
@@ -118,15 +175,8 @@ func roundTripStaticSpec() StaticProviderSpec {
 		DisplayName:    "Round Trip",
 		Description:    "test provider",
 		ConnectionMode: core.ConnectionModeEither,
-		Catalog: &catalog.Catalog{
-			Name:        "roundtrip",
-			DisplayName: "Round Trip",
-			Description: "test provider",
-			Operations: []catalog.CatalogOperation{
-				{ID: "echo", Method: http.MethodPost, AllowedRoles: []string{"admin"}},
-			},
-		},
-		AuthTypes: []string{"manual"},
+		Catalog:        roundTripStaticCatalog(),
+		AuthTypes:      []string{"manual"},
 		ConnectionParams: map[string]core.ConnectionParamDef{
 			"tenant":  {Required: true, Description: "Tenant slug"},
 			"team_id": {From: "token_response", Field: "team_id"},
@@ -184,7 +234,7 @@ func TestRemoteProviderRoundTrip(t *testing.T) {
 	if got := prov.AuthTypes(); len(got) != 1 || got[0] != "manual" {
 		t.Fatalf("unexpected auth types: %#v", got)
 	}
-	if cat := prov.Catalog(); cat == nil || len(cat.Operations) != 1 || cat.Operations[0].ID != "echo" {
+	if cat := prov.Catalog(); cat == nil || len(cat.Operations) != 2 || cat.Operations[0].ID != "echo" {
 		t.Fatalf("unexpected Catalog result: %+v", cat)
 	}
 
@@ -260,8 +310,40 @@ func TestRemoteProviderRoundTrip(t *testing.T) {
 			if sessionCat.Name != "roundtrip-session" || sessionCat.DisplayName != tc.wantSessionCatalog {
 				t.Fatalf("unexpected session catalog: %+v", sessionCat)
 			}
-			if got := sessionCat.Operations[0].AllowedRoles; len(got) != 1 || got[0] != "viewer" {
+			if sessionCat.BaseURL != "https://roundtrip.example.com" || sessionCat.AuthStyle != "bearer" {
+				t.Fatalf("unexpected session catalog transport metadata: %+v", sessionCat)
+			}
+			if got := sessionCat.Headers["X-Env"]; got != "test" {
+				t.Fatalf("unexpected session catalog headers: %+v", sessionCat.Headers)
+			}
+			if len(sessionCat.Operations) != 2 {
+				t.Fatalf("unexpected session catalog operations: %+v", sessionCat.Operations)
+			}
+			opsByID := map[string]catalog.CatalogOperation{}
+			for _, op := range sessionCat.Operations {
+				opsByID[op.ID] = op
+			}
+			echoOp := opsByID["echo"]
+			if got := echoOp.AllowedRoles; len(got) != 1 || got[0] != "viewer" {
 				t.Fatalf("unexpected session catalog allowedRoles: %#v", got)
+			}
+			if echoOp.Transport != catalog.TransportREST {
+				t.Fatalf("unexpected session catalog operation identifiers: %+v", echoOp)
+			}
+			if echoOp.Path != "/v1/queries/{queryId}" || echoOp.Query != "view=full" {
+				t.Fatalf("unexpected session catalog request metadata: %+v", echoOp)
+			}
+			if len(echoOp.InputSchema) == 0 {
+				t.Fatalf("expected synthesized input schema, got %+v", echoOp)
+			}
+			if len(echoOp.Parameters) != 2 {
+				t.Fatalf("unexpected session catalog parameters: %+v", echoOp.Parameters)
+			}
+			if echoOp.Parameters[1].WireName != "queryId" || echoOp.Parameters[1].Location != "path" {
+				t.Fatalf("unexpected session catalog path parameter metadata: %+v", echoOp.Parameters[1])
+			}
+			if pluginOp := opsByID["plugin_echo"]; pluginOp.Transport != catalog.TransportPlugin {
+				t.Fatalf("expected plugin session operation to preserve plugin transport, got %+v", pluginOp)
 			}
 		})
 	}


### PR DESCRIPTION
## Summary
Narrow this slice back to the actual providerhost boundary bug.

Instead of teaching `core` and higher layers a broader sparse-catalog merge abstraction, this branch now:
- removes the `core.CatalogForRequest` helper
- keeps providerhost server responses raw
- hydrates missing static REST metadata on the remote provider client after the session catalog crosses the RPC boundary
- leaves higher-layer catalog/session resolution semantics unchanged

Diff vs `codex/core-session-catalog-merge`:
- non-test: `+39 / -40`, net `-1`
- test: `+97 / -15`, net `+82`

## Go Interface
Session-catalog callers now use the session-provider primitive directly instead of the removed helper:

```go
scp, ok := prov.(core.SessionCatalogProvider)
if !ok {
    return nil, false, nil
}
cat, err := scp.CatalogForRequest(ctx, token)
```

Remote providerhost clients hydrate sparse catalogs after deserialization and before schema compilation:

```go
cat = p.decorateCatalog(cat)
coreintegration.CompileSchemas(cat)
```

## YAML Surface
No new YAML keys were added.

Static REST metadata still comes from the existing manifest surface:

```yaml
spec:
  surfaces:
    rest:
      baseUrl: https://roundtrip.example.com
      operations:
        - name: echo
          method: POST
          path: /v1/queries/{queryId}
          parameters:
            - name: query_id
              wireName: queryId
              in: path
```

Sparse session catalogs can keep returning only dynamic/session-owned fields:

```yaml
name: roundtrip-session
operations:
  - id: echo
    allowedRoles: [viewer]
    parameters:
      - name: query_id
        type: string
```

## What Changed
- deleted `core.CatalogForRequest`
- changed `internal/invocation`, `internal/mcp`, and `internal/providerhost/server` to use `core.SessionCatalogProvider` directly
- changed `internal/providerhost/provider_client.go` to restore missing `baseUrl`, `authStyle`, `headers`, transport, path/query, and parameter wire metadata from the decorated static catalog after the RPC round-trip
- kept the existing higher-layer merge behavior in `internal/invocation`
- kept only the providerhost round-trip coverage for the sparse-catalog behavior; reverted broader follow-on tests that were not necessary for this boundary fix

## Tests
Augmented the existing providerhost round-trip suite instead of introducing a new standalone suite.

Coverage now pins:
- sparse remote session catalogs keep dynamic name/display/allowed-role data
- static REST metadata is restored on the remote client
- synthesized input schema survives the providerhost round-trip
- plugin transport survives sparse session collisions

## Verification
```bash
go test ./internal/providerhost ./internal/invocation ./internal/mcp ./internal/server ./internal/bootstrap
golangci-lint run ./internal/providerhost/... ./internal/invocation/... ./internal/mcp/... ./internal/server/... ./internal/bootstrap/... ./core/...
```
