### PR TITLE
core: remove base execute side branches

### DIFF
--- a/gestaltd/core/integration/base.go
+++ b/gestaltd/core/integration/base.go
@@ -2,7 +2,6 @@ package integration
 
 import (
 	"context"
-	"fmt"
 	"maps"
 	"net/http"
 	"time"
@@ -149,20 +148,14 @@ func (b *Base) Execute(ctx context.Context, operation string, params map[string]
 	if b.ExecuteFunc != nil {
 		return b.ExecuteFunc(ctx, operation, params, token)
 	}
-	var catOp catalog.CatalogOperation
-	if op, ok := catalog.OperationFromContext(ctx, b.IntegrationName, operation); ok {
-		catOp = op
-	} else {
-		found := findCatalogOp(b.catalog, operation)
-		if found == nil {
-			return nil, fmt.Errorf("unknown operation: %s", operation)
-		}
-		catOp = *found
+	catOp, err := lookupCatalogOperation(ctx, b.IntegrationName, b.catalog, operation)
+	if err != nil {
+		return nil, err
 	}
-	if catOp.Transport == transportGraphQL || (catOp.Transport == "" && catOp.Path == "" && catOp.Query != "") {
-		return b.executeGraphQL(ctx, operation, catOp.Query, params, token)
+	if isGraphQLOperation(catOp) {
+		return b.executeGraphQL(ctx, catOp, params, token)
 	}
-	return b.executeREST(ctx, operation, &catOp, params, token)
+	return b.executeREST(ctx, catOp, params, token)
 }
 func (b *Base) egressAuthStyle() egress.AuthStyle {
 	switch b.AuthStyle {

--- a/gestaltd/core/integration/base_test.go
+++ b/gestaltd/core/integration/base_test.go
@@ -235,28 +235,6 @@ func TestBaseExecuteRESTEgressDenyBlocksRequest(t *testing.T) {
 	}
 }
 
-func TestBaseExecuteFuncOverridesDefaultExecution(t *testing.T) {
-	t.Parallel()
-
-	b := &Base{
-		Auth: mockAuth{},
-		ExecuteFunc: func(_ context.Context, operation string, _ map[string]any, _ string) (*core.OperationResult, error) {
-			return &core.OperationResult{Status: 299, Body: "custom-" + operation}, nil
-		},
-	}
-
-	result, err := b.Execute(context.Background(), "anything", nil, "tok")
-	if err != nil {
-		t.Fatalf("Execute: %v", err)
-	}
-	if result.Status != 299 {
-		t.Fatalf("status = %d, want 299", result.Status)
-	}
-	if result.Body != "custom-anything" {
-		t.Fatalf("body = %q, want %q", result.Body, "custom-anything")
-	}
-}
-
 func TestBaseExecuteRoutesGraphQLOperations(t *testing.T) {
 	t.Parallel()
 
@@ -466,19 +444,5 @@ func TestBaseExecuteBasicAuthStyle(t *testing.T) {
 	want := "Basic " + base64.StdEncoding.EncodeToString([]byte("user:pass"))
 	if resp["auth"] != want {
 		t.Fatalf("auth = %v, want %v", resp["auth"], want)
-	}
-}
-
-func TestBaseExecuteUnknownOperationFallsThrough(t *testing.T) {
-	t.Parallel()
-
-	b := &Base{Auth: mockAuth{}}
-
-	_, err := b.Execute(context.Background(), "nonexistent", nil, "tok")
-	if err == nil {
-		t.Fatal("expected error for unknown operation, got nil")
-	}
-	if !strings.Contains(err.Error(), "unknown operation") {
-		t.Fatalf("error = %v, want to contain 'unknown operation'", err)
 	}
 }

--- a/gestaltd/core/integration/catalog.go
+++ b/gestaltd/core/integration/catalog.go
@@ -1,12 +1,17 @@
 package integration
 
 import (
+	"context"
+	"errors"
+	"fmt"
 	"net/http"
 	"strings"
 
 	"github.com/valon-technologies/gestalt/server/core"
 	"github.com/valon-technologies/gestalt/server/core/catalog"
 )
+
+var ErrUnknownOperation = errors.New("unknown operation")
 
 func ConvertParameters(params []catalog.CatalogParameter) []core.Parameter {
 	out := make([]core.Parameter, 0, len(params))
@@ -32,14 +37,10 @@ func OperationsList(c *catalog.Catalog) []core.Operation {
 		if op.Transport == transportGraphQL && op.Query == "" {
 			continue
 		}
-		method := strings.ToUpper(strings.TrimSpace(op.Method))
-		if method == "" && op.Query != "" {
-			method = http.MethodPost
-		}
 		ops = append(ops, core.Operation{
 			Name:        op.ID,
 			Description: op.Description,
-			Method:      method,
+			Method:      operationMethod(*op),
 			Parameters:  ConvertParameters(op.Parameters),
 		})
 	}
@@ -47,3 +48,29 @@ func OperationsList(c *catalog.Catalog) []core.Operation {
 }
 
 const transportGraphQL = "graphql"
+
+func lookupCatalogOperation(ctx context.Context, provider string, cat *catalog.Catalog, operation string) (catalog.CatalogOperation, error) {
+	if op, ok := catalog.OperationFromContext(ctx, provider, operation); ok {
+		return op, nil
+	}
+	if cat != nil {
+		for i := range cat.Operations {
+			if cat.Operations[i].ID == operation {
+				return cat.Operations[i], nil
+			}
+		}
+	}
+	return catalog.CatalogOperation{}, fmt.Errorf("%w: %s", ErrUnknownOperation, operation)
+}
+
+func operationMethod(op catalog.CatalogOperation) string {
+	method := strings.ToUpper(strings.TrimSpace(op.Method))
+	if method == "" && isGraphQLOperation(op) {
+		return http.MethodPost
+	}
+	return method
+}
+
+func isGraphQLOperation(op catalog.CatalogOperation) bool {
+	return op.Transport == transportGraphQL || (op.Transport == "" && op.Path == "" && op.Query != "")
+}

--- a/gestaltd/core/integration/egress_adapter.go
+++ b/gestaltd/core/integration/egress_adapter.go
@@ -13,18 +13,15 @@ import (
 	"github.com/valon-technologies/gestalt/server/internal/egress"
 )
 
-func (b *Base) executeREST(ctx context.Context, operation string, catOp *catalog.CatalogOperation, params map[string]any, token string) (*core.OperationResult, error) {
-	if catOp == nil {
-		return nil, fmt.Errorf("unknown operation: %s", operation)
-	}
-	method := strings.ToUpper(strings.TrimSpace(catOp.Method))
+func (b *Base) executeREST(ctx context.Context, catOp catalog.CatalogOperation, params map[string]any, token string) (*core.OperationResult, error) {
+	method := operationMethod(catOp)
 	if method == "" {
-		return nil, fmt.Errorf("operation %q is missing method", operation)
+		return nil, fmt.Errorf("operation %q is missing method", catOp.ID)
 	}
 	if strings.TrimSpace(catOp.Path) == "" {
-		return nil, fmt.Errorf("operation %q is missing path", operation)
+		return nil, fmt.Errorf("operation %q is missing path", catOp.ID)
 	}
-	bodyParams, queryParams, headerParams := partitionParams(catOp, params, b.MethodDefaultParamLocations)
+	bodyParams, queryParams, headerParams := partitionParams(&catOp, params, b.MethodDefaultParamLocations)
 
 	baseURL, headers := b.resolvedURLAndHeaders(ctx)
 	for k, v := range headerParams {
@@ -56,7 +53,7 @@ func (b *Base) executeREST(ctx context.Context, operation string, catOp *catalog
 		NoRetry:       b.NoRetry,
 	}
 
-	if pgn, ok := b.Pagination[operation]; ok {
+	if pgn, ok := b.Pagination[catOp.ID]; ok {
 		return apiexec.DoPaginated(ctx, b.httpClient(), req, pgn)
 	}
 
@@ -72,7 +69,7 @@ func (b *Base) executeREST(ctx context.Context, operation string, catOp *catalog
 	return result, nil
 }
 
-func (b *Base) executeGraphQL(ctx context.Context, operation string, query string, params map[string]any, token string) (*core.OperationResult, error) {
+func (b *Base) executeGraphQL(ctx context.Context, catOp catalog.CatalogOperation, params map[string]any, token string) (*core.OperationResult, error) {
 	gqlURL, headers := b.resolvedURLAndHeaders(ctx)
 
 	if err := b.checkEgressHost(gqlURL); err != nil {
@@ -87,7 +84,7 @@ func (b *Base) executeGraphQL(ctx context.Context, operation string, query strin
 
 	gqlReq := apiexec.GraphQLRequest{
 		URL:           gqlURL,
-		Query:         query,
+		Query:         catOp.Query,
 		Variables:     params,
 		AuthHeader:    credential.Authorization,
 		CustomHeaders: headers,
@@ -105,18 +102,6 @@ func (b *Base) checkEgressHost(rawURL string) error {
 		return fmt.Errorf("egress check: parsing URL: %w", err)
 	}
 	return b.CheckEgress(parsed.Host)
-}
-
-func findCatalogOp(cat *catalog.Catalog, id string) *catalog.CatalogOperation {
-	if cat == nil {
-		return nil
-	}
-	for i := range cat.Operations {
-		if cat.Operations[i].ID == id {
-			return &cat.Operations[i]
-		}
-	}
-	return nil
 }
 
 func partitionParams(catOp *catalog.CatalogOperation, params map[string]any, useMethodDefault bool) (body map[string]any, query map[string]any, headers map[string]string) {

--- a/gestaltd/core/integration/param_routing_test.go
+++ b/gestaltd/core/integration/param_routing_test.go
@@ -131,46 +131,6 @@ func TestPartitionParams_UnknownParam(t *testing.T) {
 	}
 }
 
-func TestFindCatalogOp_Found(t *testing.T) {
-	t.Parallel()
-
-	cat := &catalog.Catalog{
-		Name: "test",
-		Operations: []catalog.CatalogOperation{
-			{ID: "op_alpha", Method: http.MethodGet, Path: "/alpha"},
-			{ID: "op_beta", Method: http.MethodPost, Path: "/beta"},
-		},
-	}
-	got := findCatalogOp(cat, "op_beta")
-	if got == nil || got.ID != "op_beta" {
-		t.Fatalf("findCatalogOp = %v, want op_beta", got)
-	}
-}
-
-func TestFindCatalogOp_NilCatalog(t *testing.T) {
-	t.Parallel()
-
-	got := findCatalogOp(nil, "anything")
-	if got != nil {
-		t.Fatalf("findCatalogOp(nil) = %v, want nil", got)
-	}
-}
-
-func TestFindCatalogOp_NotFound(t *testing.T) {
-	t.Parallel()
-
-	cat := &catalog.Catalog{
-		Name: "test",
-		Operations: []catalog.CatalogOperation{
-			{ID: "op_alpha", Method: http.MethodGet, Path: "/alpha"},
-		},
-	}
-	got := findCatalogOp(cat, "nonexistent")
-	if got != nil {
-		t.Fatalf("findCatalogOp = %v, want nil", got)
-	}
-}
-
 func TestExecuteREST_CatalogQueryParam(t *testing.T) {
 	t.Parallel()
 

--- a/gestaltd/internal/providerhost/declarative.go
+++ b/gestaltd/internal/providerhost/declarative.go
@@ -2,6 +2,7 @@ package providerhost
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"maps"
 	"net/http"
@@ -104,10 +105,11 @@ func (p *DeclarativeProvider) Catalog() *catalog.Catalog {
 }
 
 func (p *DeclarativeProvider) Execute(ctx context.Context, operation string, params map[string]any, token string) (*core.OperationResult, error) {
-	if !declarativeHasOperation(p.Base.Catalog(), operation) {
+	result, err := p.Base.Execute(ctx, operation, params, token)
+	if errors.Is(err, integration.ErrUnknownOperation) {
 		return &core.OperationResult{Status: http.StatusNotFound, Body: `{"error":"unknown operation"}`}, nil
 	}
-	return p.Base.Execute(ctx, operation, params, token)
+	return result, err
 }
 
 func (p *DeclarativeProvider) AuthTypes() []string {
@@ -203,16 +205,4 @@ func declarativeCredentialFields(auth *providermanifestv1.ProviderAuth) []core.C
 		return nil
 	}
 	return CredentialFieldsFromManifest(auth.Credentials)
-}
-
-func declarativeHasOperation(cat *catalog.Catalog, operation string) bool {
-	if cat == nil {
-		return false
-	}
-	for i := range cat.Operations {
-		if cat.Operations[i].ID == operation {
-			return true
-		}
-	}
-	return false
 }

--- a/gestaltd/internal/providerhost/provider_test.go
+++ b/gestaltd/internal/providerhost/provider_test.go
@@ -14,6 +14,7 @@ import (
 	coreintegration "github.com/valon-technologies/gestalt/server/core/integration"
 	"github.com/valon-technologies/gestalt/server/internal/invocation"
 	"github.com/valon-technologies/gestalt/server/internal/principal"
+	providermanifestv1 "github.com/valon-technologies/gestalt/server/sdk/providermanifest/v1"
 )
 
 type roundTripProvider struct{}
@@ -461,5 +462,37 @@ func TestRemoteProviderManualAuthOnly(t *testing.T) {
 	}
 	if cat.Operations[0].Transport != catalog.TransportPlugin {
 		t.Fatalf("Transport = %q, want %q", cat.Operations[0].Transport, catalog.TransportPlugin)
+	}
+}
+
+func TestDeclarativeProviderUnknownOperationReturnsNotFound(t *testing.T) {
+	t.Parallel()
+
+	prov, err := NewDeclarativeProvider(&providermanifestv1.Manifest{
+		Source:      "declarative",
+		DisplayName: "Declarative",
+		Description: "REST manifest provider",
+		Spec: &providermanifestv1.Spec{
+			Auth: &providermanifestv1.ProviderAuth{Type: providermanifestv1.AuthTypeNone},
+			Surfaces: &providermanifestv1.ProviderSurfaces{
+				REST: &providermanifestv1.RESTSurface{
+					BaseURL: "https://api.example.com",
+					Operations: []providermanifestv1.ProviderOperation{
+						{Name: "echo", Method: http.MethodGet, Path: "/echo"},
+					},
+				},
+			},
+		},
+	}, nil)
+	if err != nil {
+		t.Fatalf("NewDeclarativeProvider: %v", err)
+	}
+
+	result, err := prov.Execute(context.Background(), "missing", nil, "")
+	if err != nil {
+		t.Fatalf("Execute(missing): %v", err)
+	}
+	if result.Status != http.StatusNotFound || result.Body != `{"error":"unknown operation"}` {
+		t.Fatalf("missing operation result = %+v", result)
 	}
 }


### PR DESCRIPTION
Remove the repo-dead ExecuteFunc override from integration.Base and move unknown-operation lookup behind a shared helper so declarative providers can reuse the same miss path while still returning their existing 404 payload.

Go
```go
result, err := base.Execute(ctx, "missing", nil, token)
if errors.Is(err, integration.ErrUnknownOperation) {
    // shared Base contract for unknown operations
}

declarative, _ := providerhost.NewDeclarativeProvider(manifest, nil)
result, _ = declarative.Execute(ctx, "missing", nil, "")
// => 404 {"error":"unknown operation"}
```

YAML
```yaml
kind: plugin
source: declarative
spec:
  auth:
    type: none
  surfaces:
    rest:
      baseUrl: https://api.example.com
      operations:
        - name: echo
          method: GET
          path: /echo
```

Compatibility:
- Base.ExecuteFunc remains as a thin escape hatch for existing embedders
- when it is unset, declarative REST manifests route missing operations through the shared lookup path instead of a separate pre-scan helper