### PR TITLE
core: load declarative catalogs without booting providers

### DIFF
--- a/gestaltd/internal/bootstrap/executable_plugin_test.go
+++ b/gestaltd/internal/bootstrap/executable_plugin_test.go
@@ -428,6 +428,116 @@ paths:
 	}
 }
 
+func TestHybridExecutableProviderAppliesAllowedOperationsToStaticAndDeclarativeCatalogs(t *testing.T) {
+	t.Parallel()
+
+	bin := buildEchoPluginBinary(t)
+	manifestRoot := writeStaticCatalog(t, &catalog.Catalog{
+		Name: "hybrid",
+		Operations: []catalog.CatalogOperation{
+			{ID: "echo", Method: http.MethodPost, Parameters: []catalog.CatalogParameter{{Name: "message", Type: "string", Required: true}}},
+		},
+	})
+
+	manifest := newExecutableManifest("Hybrid", "Hybrid provider")
+	manifest.Entrypoint = &providermanifestv1.Entrypoint{ArtifactPath: "ignored-for-command-mode"}
+	manifest.Spec.Surfaces = &providermanifestv1.ProviderSurfaces{
+		REST: &providermanifestv1.RESTSurface{
+			BaseURL: "https://api.example.test",
+			Operations: []providermanifestv1.ProviderOperation{
+				{Name: "status", Method: http.MethodGet, Path: "/status"},
+			},
+		},
+	}
+	manifestPath := filepath.Join(manifestRoot, "manifest.yaml")
+
+	cfg := &config.Config{
+		Plugins: map[string]*config.ProviderEntry{
+			"hybrid": {
+				Command:              bin,
+				Args:                 []string{"provider"},
+				ResolvedManifest:     manifest,
+				ResolvedManifestPath: manifestPath,
+				AllowedOperations: map[string]*config.OperationOverride{
+					"echo":   {Alias: "renamed_echo"},
+					"status": {Alias: "renamed_status"},
+				},
+			},
+		},
+	}
+
+	providers, _, err := buildProvidersStrict(context.Background(), cfg, NewFactoryRegistry(), Deps{})
+	if err != nil {
+		t.Fatalf("buildProvidersStrict: %v", err)
+	}
+	defer func() { _ = CloseProviders(providers) }()
+
+	prov, err := providers.Get("hybrid")
+	if err != nil {
+		t.Fatalf("providers.Get(hybrid): %v", err)
+	}
+	cat := prov.Catalog()
+	if cat == nil {
+		t.Fatal("Catalog() = nil")
+	}
+
+	hasOperation := func(id string) bool {
+		return slices.ContainsFunc(cat.Operations, func(op catalog.CatalogOperation) bool {
+			return op.ID == id
+		})
+	}
+	if !hasOperation("renamed_echo") || !hasOperation("renamed_status") {
+		t.Fatalf("catalog operations = %+v, want renamed static and declarative operations", cat.Operations)
+	}
+	if hasOperation("echo") || hasOperation("status") {
+		t.Fatalf("catalog operations = %+v, want original operation ids hidden", cat.Operations)
+	}
+
+	t.Run("without static catalog", func(t *testing.T) {
+		root := t.TempDir()
+
+		manifest := newExecutableManifest("Hybrid", "Hybrid provider")
+		manifest.Entrypoint = &providermanifestv1.Entrypoint{ArtifactPath: "ignored-for-command-mode"}
+		manifest.Spec.Surfaces = &providermanifestv1.ProviderSurfaces{
+			REST: &providermanifestv1.RESTSurface{
+				BaseURL: "https://api.example.test",
+				Operations: []providermanifestv1.ProviderOperation{
+					{Name: "status", Method: http.MethodGet, Path: "/status"},
+				},
+			},
+		}
+
+		cfg := &config.Config{
+			Plugins: map[string]*config.ProviderEntry{
+				"hybrid": {
+					Command:              bin,
+					Args:                 []string{"provider"},
+					ResolvedManifest:     manifest,
+					ResolvedManifestPath: filepath.Join(root, "manifest.yaml"),
+					AllowedOperations: map[string]*config.OperationOverride{
+						"status": {Alias: "renamed_status"},
+					},
+				},
+			},
+		}
+
+		providers, _, err := buildProvidersStrict(context.Background(), cfg, NewFactoryRegistry(), Deps{})
+		if err != nil {
+			t.Fatalf("buildProvidersStrict: %v", err)
+		}
+		defer func() { _ = CloseProviders(providers) }()
+
+		prov, err := providers.Get("hybrid")
+		if err != nil {
+			t.Fatalf("providers.Get(hybrid): %v", err)
+		}
+		cat := prov.Catalog()
+		if cat == nil || len(cat.Operations) != 1 || cat.Operations[0].ID != "renamed_status" {
+			t.Fatalf("catalog = %+v, want only renamed_status from the declarative surface", cat)
+		}
+	})
+}
+
 func TestSpecLoadedDualSurfaceProviderBuildsMCPOperations(t *testing.T) {
 	t.Parallel()
 

--- a/gestaltd/internal/bootstrap/provider_build.go
+++ b/gestaltd/internal/bootstrap/provider_build.go
@@ -250,18 +250,8 @@ func buildProvider(ctx context.Context, name string, entry *config.ProviderEntry
 		if err != nil {
 			return nil, fmt.Errorf("build declarative provider %q: %w", name, err)
 		}
-		declarative, err := providerhost.NewDeclarativeProvider(
-			manifest,
-			nil,
-			providerhost.WithDeclarativeMetadataOverrides(meta.displayName, meta.description, meta.iconSVG),
-			providerhost.WithDeclarativeConnectionMode(plan.ConnectionMode()),
-		)
+		prov, err := buildAllowedDeclarativeProvider(name, manifest, meta, plan, allowedOperations)
 		if err != nil {
-			return nil, fmt.Errorf("create declarative provider %q: %w", name, err)
-		}
-		prov, err := applyAllowedOperations(name, allowedOperations, declarative)
-		if err != nil {
-			closeIfPossible(declarative)
 			return nil, err
 		}
 		return newProviderBuildResult(name, entry, manifest, pluginConfig, prov, nil, deps)
@@ -301,18 +291,13 @@ func buildExecutablePluginProvider(ctx context.Context, name string, entry *conf
 			return nil, err
 		}
 		pluginProv = filteredPluginProv
-		declarative, err := providerhost.NewDeclarativeProvider(
-			manifest,
-			nil,
-			providerhost.WithDeclarativeMetadataOverrides(meta.displayName, meta.description, meta.iconSVG),
-			providerhost.WithDeclarativeConnectionMode(plan.ConnectionMode()),
-		)
+		apiCatalog, err := providerhost.CatalogFromDeclarativeManifest(manifest)
 		if err != nil {
 			closeIfPossible(pluginProv)
-			return nil, fmt.Errorf("create declarative provider %q: %w", name, err)
+			return nil, fmt.Errorf("load declarative catalog for %q: %w", name, err)
 		}
-		apiAllowedOperations := operationexposure.MatchingAllowedOperations(allowedOperations, declarative.Catalog())
-		apiProv, err := applyAllowedOperations(name, apiAllowedOperations, declarative)
+		apiAllowedOperations := operationexposure.MatchingAllowedOperations(allowedOperations, apiCatalog)
+		apiProv, err := buildAllowedDeclarativeProvider(name, manifest, meta, plan, apiAllowedOperations)
 		if err != nil {
 			closeIfPossible(apiProv, pluginProv)
 			return nil, err
@@ -382,6 +367,24 @@ func buildExecutablePluginProvider(ctx context.Context, name string, entry *conf
 		}
 	}
 	return newProviderBuildResult(name, entry, manifest, pluginConfig, merged, authFallback, deps)
+}
+
+func buildAllowedDeclarativeProvider(name string, manifest *providermanifestv1.Manifest, meta providerMetadata, plan config.StaticConnectionPlan, allowedOperations map[string]*config.OperationOverride) (core.Provider, error) {
+	declarative, err := providerhost.NewDeclarativeProvider(
+		manifest,
+		nil,
+		providerhost.WithDeclarativeMetadataOverrides(meta.displayName, meta.description, meta.iconSVG),
+		providerhost.WithDeclarativeConnectionMode(plan.ConnectionMode()),
+	)
+	if err != nil {
+		return nil, fmt.Errorf("create declarative provider %q: %w", name, err)
+	}
+	prov, err := applyAllowedOperations(name, allowedOperations, declarative)
+	if err != nil {
+		closeIfPossible(declarative)
+		return nil, err
+	}
+	return prov, nil
 }
 
 type specProviderConfig struct {

--- a/gestaltd/internal/operator/lifecycle_test.go
+++ b/gestaltd/internal/operator/lifecycle_test.go
@@ -270,6 +270,117 @@ func writeLocalMCPSpecPlugin(t *testing.T, dir, name string) string {
 	return manifestPath
 }
 
+func writeLocalDeclarativePlugin(t *testing.T, dir, name string, operations ...string) string {
+	t.Helper()
+
+	root := filepath.Join(dir, name)
+	if err := os.MkdirAll(root, 0o755); err != nil {
+		t.Fatalf("MkdirAll(%s): %v", root, err)
+	}
+	manifestPath := filepath.Join(root, "manifest.yaml")
+	ops := make([]providermanifestv1.ProviderOperation, 0, len(operations))
+	for _, operation := range operations {
+		ops = append(ops, providermanifestv1.ProviderOperation{
+			Name:   operation,
+			Method: http.MethodGet,
+			Path:   "/" + operation,
+		})
+	}
+	manifest, err := providerpkg.EncodeSourceManifestFormat(&providermanifestv1.Manifest{
+		Kind:        providermanifestv1.KindPlugin,
+		Source:      "github.com/test/plugins/" + name,
+		Version:     "0.0.1-alpha.1",
+		DisplayName: testDisplayName(name),
+		Spec: &providermanifestv1.Spec{
+			Auth: &providermanifestv1.ProviderAuth{Type: providermanifestv1.AuthTypeNone},
+			Surfaces: &providermanifestv1.ProviderSurfaces{
+				REST: &providermanifestv1.RESTSurface{
+					BaseURL:    "https://api.example.test",
+					Operations: ops,
+				},
+			},
+		},
+	}, providerpkg.ManifestFormatYAML)
+	if err != nil {
+		t.Fatalf("EncodeSourceManifestFormat(%s): %v", name, err)
+	}
+	if err := os.WriteFile(manifestPath, manifest, 0o644); err != nil {
+		t.Fatalf("WriteFile(%s): %v", manifestPath, err)
+	}
+	return manifestPath
+}
+
+func writeLocalExecutableAndDeclarativePlugin(t *testing.T, dir, name string, staticOps, declarativeOps []string) string {
+	t.Helper()
+
+	root := filepath.Join(dir, name)
+	if err := os.MkdirAll(root, 0o755); err != nil {
+		t.Fatalf("MkdirAll(%s): %v", root, err)
+	}
+
+	artifactPath := filepath.ToSlash(filepath.Join("artifacts", runtime.GOOS, runtime.GOARCH, "plugin"))
+	artifactFullPath := filepath.Join(root, filepath.FromSlash(artifactPath))
+	if err := os.MkdirAll(filepath.Dir(artifactFullPath), 0o755); err != nil {
+		t.Fatalf("MkdirAll(%s): %v", filepath.Dir(artifactFullPath), err)
+	}
+	artifactContent := []byte(name + "-binary")
+	if err := os.WriteFile(artifactFullPath, artifactContent, 0o755); err != nil {
+		t.Fatalf("WriteFile(%s): %v", artifactFullPath, err)
+	}
+	artifactSum := sha256.Sum256(artifactContent)
+
+	manifestPath := filepath.Join(root, "manifest.yaml")
+	ops := make([]providermanifestv1.ProviderOperation, 0, len(declarativeOps))
+	for _, operation := range declarativeOps {
+		ops = append(ops, providermanifestv1.ProviderOperation{
+			Name:   operation,
+			Method: http.MethodGet,
+			Path:   "/" + operation,
+		})
+	}
+	manifest, err := providerpkg.EncodeSourceManifestFormat(&providermanifestv1.Manifest{
+		Kind:        providermanifestv1.KindPlugin,
+		Source:      "github.com/test/plugins/" + name,
+		Version:     "0.0.1-alpha.1",
+		DisplayName: testDisplayName(name),
+		Entrypoint:  &providermanifestv1.Entrypoint{ArtifactPath: artifactPath},
+		Artifacts: []providermanifestv1.Artifact{{
+			OS:     runtime.GOOS,
+			Arch:   runtime.GOARCH,
+			Path:   artifactPath,
+			SHA256: hex.EncodeToString(artifactSum[:]),
+		}},
+		Spec: &providermanifestv1.Spec{
+			Auth: &providermanifestv1.ProviderAuth{Type: providermanifestv1.AuthTypeNone},
+			Surfaces: &providermanifestv1.ProviderSurfaces{
+				REST: &providermanifestv1.RESTSurface{
+					BaseURL:    "https://api.example.test",
+					Operations: ops,
+				},
+			},
+		},
+	}, providerpkg.ManifestFormatYAML)
+	if err != nil {
+		t.Fatalf("EncodeSourceManifestFormat(%s): %v", name, err)
+	}
+	if err := os.WriteFile(manifestPath, manifest, 0o644); err != nil {
+		t.Fatalf("WriteFile(%s): %v", manifestPath, err)
+	}
+
+	var builder strings.Builder
+	if len(staticOps) > 0 {
+		builder.WriteString("name: " + name + "\noperations:\n")
+		for _, operation := range staticOps {
+			builder.WriteString("  - id: " + operation + "\n")
+			builder.WriteString("    method: GET\n")
+		}
+		if err := os.WriteFile(filepath.Join(root, "catalog.yaml"), []byte(builder.String()), 0o644); err != nil {
+			t.Fatalf("WriteFile(catalog.yaml): %v", err)
+		}
+	}
+	return manifestPath
+}
+
 func writeLocalOpenAPIAndMCPSpecPlugin(t *testing.T, dir, name string) string {
 	t.Helper()
 
@@ -728,33 +839,87 @@ func TestInitAtPath_RejectsInvalidPluginInvokesShape(t *testing.T) {
 func TestInitAtPath_AllowsInvokesAgainstEffectiveAlias(t *testing.T) {
 	t.Parallel()
 
-	dir := t.TempDir()
-	callerManifestPath := writeLocalExecutablePlugin(t, dir, "caller", "invoke")
-	targetManifestPath := writeLocalExecutablePlugin(t, dir, "target", "ping")
+	cases := []struct {
+		name             string
+		buildTarget      func(t *testing.T, dir string) string
+		operation        string
+		targetConfigYAML string
+	}{
+		{
+			name:        "static executable alias",
+			buildTarget: func(t *testing.T, dir string) string { return writeLocalExecutablePlugin(t, dir, "target", "ping") },
+			operation:   "renamed_ping",
+			targetConfigYAML: `      allowedOperations:
+        ping:
+          alias: renamed_ping
+`,
+		},
+		{
+			name: "executable declarative alias",
+			buildTarget: func(t *testing.T, dir string) string {
+				return writeLocalExecutableAndDeclarativePlugin(t, dir, "target", []string{"echo"}, []string{"status"})
+			},
+			operation: "renamed_status",
+			targetConfigYAML: `      allowedOperations:
+        echo:
+          alias: renamed_echo
+        status:
+          alias: renamed_status
+`,
+		},
+		{
+			name:        "declarative-only alias",
+			buildTarget: func(t *testing.T, dir string) string { return writeLocalDeclarativePlugin(t, dir, "target", "status") },
+			operation:   "renamed_status",
+			targetConfigYAML: `      allowedOperations:
+        status:
+          alias: renamed_status
+`,
+		},
+		{
+			name: "executable declarative alias without static catalog",
+			buildTarget: func(t *testing.T, dir string) string {
+				return writeLocalExecutableAndDeclarativePlugin(t, dir, "target", nil, []string{"status"})
+			},
+			operation: "renamed_status",
+			targetConfigYAML: `      allowedOperations:
+        status:
+          alias: renamed_status
+`,
+		},
+	}
 
-	cfgPath := filepath.Join(dir, "config.yaml")
-	cfg := requiredComponentConfigYAML(t, dir, filepath.Join(dir, "gestalt.db")) + fmt.Sprintf(`plugins:
+	for _, tc := range cases {
+		tc := tc
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+
+			dir := t.TempDir()
+			callerManifestPath := writeLocalExecutablePlugin(t, dir, "caller", "invoke")
+			targetManifestPath := tc.buildTarget(t, dir)
+
+			cfgPath := filepath.Join(dir, "config.yaml")
+			cfg := requiredComponentConfigYAML(t, dir, filepath.Join(dir, "gestalt.db")) + fmt.Sprintf(`plugins:
     caller:
       source:
         path: %q
       invokes:
         - plugin: target
-          operation: renamed_ping
+          operation: %s
     target:
       source:
         path: %q
-      allowedOperations:
-        ping:
-          alias: renamed_ping
-server:
-`, callerManifestPath, targetManifestPath) + requiredServerDatastoreYAML() + `  encryptionKey: aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa
+%sserver:
+`, callerManifestPath, tc.operation, targetManifestPath, tc.targetConfigYAML) + requiredServerDatastoreYAML() + `  encryptionKey: aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa
 `
-	if err := os.WriteFile(cfgPath, []byte(cfg), 0o644); err != nil {
-		t.Fatalf("WriteFile config: %v", err)
-	}
+			if err := os.WriteFile(cfgPath, []byte(cfg), 0o644); err != nil {
+				t.Fatalf("WriteFile config: %v", err)
+			}
 
-	if _, err := NewLifecycle(nil).InitAtPath(cfgPath); err != nil {
-		t.Fatalf("InitAtPath: %v", err)
+			if _, err := NewLifecycle(nil).InitAtPath(cfgPath); err != nil {
+				t.Fatalf("InitAtPath: %v", err)
+			}
+		})
 	}
 }
 
@@ -930,37 +1095,79 @@ server:
 	}
 }
 
-func TestInitAtPath_RejectsHybridMCPTypoAsUnknownOperation(t *testing.T) {
+func TestInitAtPath_RejectsUnknownOperationInvokesTargets(t *testing.T) {
 	t.Parallel()
 
-	dir := t.TempDir()
-	callerManifestPath := writeLocalExecutablePlugin(t, dir, "caller", "invoke")
-	targetManifestPath := writeLocalOpenAPIAndMCPSpecPlugin(t, dir, "target")
+	cases := []struct {
+		name             string
+		buildTarget      func(t *testing.T, dir string) string
+		operation        string
+		targetConfigYAML string
+		wantError        string
+	}{
+		{
+			name:        "hybrid mcp typo",
+			buildTarget: func(t *testing.T, dir string) string { return writeLocalOpenAPIAndMCPSpecPlugin(t, dir, "target") },
+			operation:   "private_search",
+			wantError:   `unknown effective operation "private_search" on plugin "target"`,
+		},
+		{
+			name:        "declarative typo",
+			buildTarget: func(t *testing.T, dir string) string { return writeLocalDeclarativePlugin(t, dir, "target", "status") },
+			operation:   "private_status",
+			wantError:   `unknown effective operation "private_status" on plugin "target"`,
+		},
+		{
+			name: "executable declarative alias mismatch",
+			buildTarget: func(t *testing.T, dir string) string {
+				return writeLocalExecutableAndDeclarativePlugin(t, dir, "target", []string{"echo"}, []string{"status"})
+			},
+			operation: "status",
+			targetConfigYAML: `      allowedOperations:
+        echo:
+          alias: renamed_echo
+        status:
+          alias: renamed_status
+`,
+			wantError: `unknown effective operation "status" on plugin "target"`,
+		},
+	}
 
-	cfgPath := filepath.Join(dir, "config.yaml")
-	cfg := requiredComponentConfigYAML(t, dir, filepath.Join(dir, "gestalt.db")) + fmt.Sprintf(`plugins:
+	for _, tc := range cases {
+		tc := tc
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+
+			dir := t.TempDir()
+			callerManifestPath := writeLocalExecutablePlugin(t, dir, "caller", "invoke")
+			targetManifestPath := tc.buildTarget(t, dir)
+
+			cfgPath := filepath.Join(dir, "config.yaml")
+			cfg := requiredComponentConfigYAML(t, dir, filepath.Join(dir, "gestalt.db")) + fmt.Sprintf(`plugins:
     caller:
       source:
         path: %q
       invokes:
         - plugin: target
-          operation: private_search
+          operation: %s
     target:
       source:
         path: %q
-server:
-`, callerManifestPath, targetManifestPath) + requiredServerDatastoreYAML() + `  encryptionKey: aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa
+%sserver:
+`, callerManifestPath, tc.operation, targetManifestPath, tc.targetConfigYAML) + requiredServerDatastoreYAML() + `  encryptionKey: aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa
 `
-	if err := os.WriteFile(cfgPath, []byte(cfg), 0o644); err != nil {
-		t.Fatalf("WriteFile config: %v", err)
-	}
+			if err := os.WriteFile(cfgPath, []byte(cfg), 0o644); err != nil {
+				t.Fatalf("WriteFile config: %v", err)
+			}
 
-	_, err := NewLifecycle(nil).InitAtPath(cfgPath)
-	if err == nil || !strings.Contains(err.Error(), `unknown effective operation "private_search" on plugin "target"`) {
-		t.Fatalf("InitAtPath error = %v, want unknown operation error", err)
-	}
-	if strings.Contains(err.Error(), "session-catalog-only operation") {
-		t.Fatalf("InitAtPath error = %v, want unknown operation classification", err)
+			_, err := NewLifecycle(nil).InitAtPath(cfgPath)
+			if err == nil || !strings.Contains(err.Error(), tc.wantError) {
+				t.Fatalf("InitAtPath error = %v, want %q", err, tc.wantError)
+			}
+			if strings.Contains(err.Error(), "session-catalog-only operation") {
+				t.Fatalf("InitAtPath error = %v, want unknown operation classification", err)
+			}
+		})
 	}
 }
 

--- a/gestaltd/internal/plugininvocation/validation.go
+++ b/gestaltd/internal/plugininvocation/validation.go
@@ -65,16 +65,7 @@ func isExecutablePlugin(entry *config.ProviderEntry) bool {
 	}
 	manifest := entry.ResolvedManifest
 	spec := entry.ManifestSpec()
-	if manifest == nil || spec == nil {
-		return false
-	}
-	if spec.IsSpecLoaded() && manifest.Entrypoint == nil {
-		return false
-	}
-	if spec.IsDeclarative() && manifest.Entrypoint == nil {
-		return false
-	}
-	return true
+	return manifest != nil && spec != nil && (manifest.Entrypoint != nil || (!spec.IsSpecLoaded() && !spec.IsDeclarative()))
 }
 
 func resolveStaticCatalog(ctx context.Context, name string, entry *config.ProviderEntry) (*catalog.Catalog, bool, error) {
@@ -86,41 +77,25 @@ func resolveStaticCatalog(ctx context.Context, name string, entry *config.Provid
 	allowed := effectiveAllowedOperations(entry, spec)
 	switch {
 	case spec.IsSpecLoaded() && manifest.Entrypoint == nil:
-		return resolveSpecLoadedCatalog(ctx, name, entry, spec, allowed)
+		apiCatalog, err := loadConfiguredAPICatalog(ctx, name, entry, spec, allowed)
+		if err != nil {
+			return nil, false, err
+		}
+		_, hasMCP := resolvedSurfaceURL(entry, spec, config.SpecSurfaceMCP)
+		return apiCatalog, hasMCP && apiCatalog == nil, nil
 	case spec.IsDeclarative() && manifest.Entrypoint == nil:
-		return resolveDeclarativeCatalog(name, manifest, allowed)
+		rawCatalog, err := providerhost.CatalogFromDeclarativeManifest(manifest)
+		if err != nil {
+			return nil, false, fmt.Errorf("plugin %q declarative catalog: %w", name, err)
+		}
+		filtered, err := applyOperationExposure(rawCatalog, allowed)
+		if err != nil {
+			return nil, false, fmt.Errorf("plugin %q declarative catalog: %w", name, err)
+		}
+		return filtered, false, nil
 	default:
 		return resolveExecutableCatalog(ctx, name, entry, manifest, spec, allowed)
 	}
-}
-
-func resolveSpecLoadedCatalog(ctx context.Context, name string, entry *config.ProviderEntry, spec *providermanifestv1.Spec, allowed map[string]*config.OperationOverride) (*catalog.Catalog, bool, error) {
-	apiCatalog, err := loadConfiguredAPICatalog(ctx, name, entry, spec, allowed)
-	if err != nil {
-		return nil, false, err
-	}
-	_, hasMCP := resolvedSurfaceURL(entry, spec, config.SpecSurfaceMCP)
-	return apiCatalog, hasMCP && apiCatalog == nil, nil
-}
-
-func resolveDeclarativeCatalog(name string, manifest *providermanifestv1.Manifest, allowed map[string]*config.OperationOverride) (*catalog.Catalog, bool, error) {
-	rawCatalog, err := loadDeclarativeCatalog(name, manifest)
-	if err != nil {
-		return nil, false, err
-	}
-	filtered, err := applyOperationExposure(rawCatalog, allowed)
-	if err != nil {
-		return nil, false, fmt.Errorf("plugin %q declarative catalog: %w", name, err)
-	}
-	return filtered, false, nil
-}
-
-func loadDeclarativeCatalog(name string, manifest *providermanifestv1.Manifest) (*catalog.Catalog, error) {
-	prov, err := providerhost.NewDeclarativeProvider(manifest, nil)
-	if err != nil {
-		return nil, fmt.Errorf("plugin %q declarative catalog: %w", name, err)
-	}
-	return prov.Catalog(), nil
 }
 
 func resolveExecutableCatalog(ctx context.Context, name string, entry *config.ProviderEntry, manifest *providermanifestv1.Manifest, spec *providermanifestv1.Spec, allowed map[string]*config.OperationOverride) (*catalog.Catalog, bool, error) {
@@ -143,9 +118,9 @@ func resolveExecutableCatalog(ctx context.Context, name string, entry *config.Pr
 	}
 
 	if spec.IsDeclarative() {
-		apiCatalog, err := loadDeclarativeCatalog(name, manifest)
+		apiCatalog, err := providerhost.CatalogFromDeclarativeManifest(manifest)
 		if err != nil {
-			return nil, false, err
+			return nil, false, fmt.Errorf("plugin %q declarative catalog: %w", name, err)
 		}
 		if err := validateAllowedOperationCoverage(name, allowed, pluginCatalog, apiCatalog); err != nil {
 			return nil, false, err

--- a/gestaltd/internal/providerhost/declarative.go
+++ b/gestaltd/internal/providerhost/declarative.go
@@ -50,6 +50,16 @@ type DeclarativeProvider struct {
 	authorizationURL string
 }
 
+func CatalogFromDeclarativeManifest(manifest *providermanifestv1.Manifest) (*catalog.Catalog, error) {
+	if manifest == nil {
+		return nil, fmt.Errorf("manifest is required")
+	}
+	if manifest.Spec == nil || !manifest.Spec.IsDeclarative() {
+		return nil, fmt.Errorf("manifest is not a declarative provider")
+	}
+	return declarativeCatalog(manifest, declarativeOptions{}), nil
+}
+
 func NewDeclarativeProvider(manifest *providermanifestv1.Manifest, httpClient *http.Client, opts ...DeclarativeProviderOption) (*DeclarativeProvider, error) {
 	if manifest == nil {
 		return nil, fmt.Errorf("manifest is required")


### PR DESCRIPTION
Go interfaces:
- providerhost.CatalogFromDeclarativeManifest(manifest)

Go example:
  cat, err := providerhost.CatalogFromDeclarativeManifest(manifest)
  if err != nil {
      return err
  }
  allowed := operationexposure.MatchingAllowedOperations(overrides, cat)

YAML interface:
  Declarative REST manifests keep using the same static surface.

YAML example:
  spec:
    surfaces:
      rest:
        operations:
          - name: users.list
            method: GET
            path: /users

Behavior:
- declarative catalog reads no longer instantiate a provider just to inspect operations
- bootstrap and plugin validation share the same manifest-to-catalog path
- alias validation coverage stays in the existing functional suites instead of new unit-only helpers