### PR TITLE
core: preserve hydrated session operation metadata

### DIFF
--- a/gestaltd/internal/invocation/catalog.go
+++ b/gestaltd/internal/invocation/catalog.go
@@ -5,6 +5,7 @@ import (
 	"errors"
 	"fmt"
 	"log/slog"
+	"maps"
 
 	"github.com/valon-technologies/gestalt/server/core"
 	"github.com/valon-technologies/gestalt/server/core/catalog"
@@ -17,45 +18,30 @@ type TokenResolver interface {
 	ResolveToken(ctx context.Context, p *principal.Principal, providerName, connection, instance string) (context.Context, string, error)
 }
 
-type CatalogResolutionMetadata struct {
-	SessionAttempted bool
-	SessionFailed    bool
-}
-
-func ResolveCatalogWithMetadata(ctx context.Context, prov core.Provider, provName string, resolver TokenResolver, p *principal.Principal, defaultConnection, instance string, strictSession bool) (*catalog.Catalog, CatalogResolutionMetadata, error) {
-	meta := CatalogResolutionMetadata{}
+func ResolveCatalogWithMetadata(ctx context.Context, prov core.Provider, provName string, resolver TokenResolver, p *principal.Principal, defaultConnection, instance string, strictSession bool) (*catalog.Catalog, bool, error) {
 	staticCat := prov.Catalog()
 	sessionCat, attempted, err := resolveSessionCatalog(ctx, prov, provName, resolver, p, defaultConnection, instance)
-	meta.SessionAttempted = attempted
+	sessionFailed := attempted && err != nil
 	if err != nil {
 		if errors.Is(err, core.ErrSessionCatalogUnavailable) && staticCat != nil {
 			err = nil
+			sessionFailed = false
 		}
 	}
 	if err != nil {
-		meta.SessionFailed = true
 		if strictSession || staticCat == nil {
-			return nil, meta, err
+			return nil, sessionFailed, err
 		}
 		slog.WarnContext(ctx, "catalog session resolution failed", "provider", provName, "error", err)
 	}
 	merged, err := mergeCatalogs(provName, staticCat, sessionCat)
-	return merged, meta, err
+	return merged, sessionFailed, err
 }
 
 func ResolveOperation(ctx context.Context, prov core.Provider, provName string, resolver TokenResolver, p *principal.Principal, operation string, sessionConnections []string, instance string) (catalog.CatalogOperation, string, string, error) {
 	staticOp, staticOK := CatalogOperation(providerCatalog(prov), operation)
 	if op, ok := catalog.OperationFromContext(ctx, provName, operation); ok {
-		if staticOK {
-			op = MergeCatalogOperation(staticOp, op)
-		}
 		return op, OperationTransport(op), "", nil
-	}
-	if !core.SupportsSessionCatalog(prov) {
-		if staticOK {
-			return staticOp, OperationTransport(staticOp), "", nil
-		}
-		return catalog.CatalogOperation{}, "", "", fmt.Errorf("%w: %q on provider %q", ErrOperationNotFound, operation, provName)
 	}
 	sessionOp, sessionConnection, sessionFound, err := resolveSessionOperation(ctx, prov, provName, resolver, p, operation, sessionConnections, instance)
 	if err != nil {
@@ -65,12 +51,9 @@ func ResolveOperation(ctx context.Context, prov core.Provider, provName string, 
 		return catalog.CatalogOperation{}, "", "", err
 	}
 	if sessionFound {
-		if staticOK {
-			sessionOp = MergeCatalogOperation(staticOp, sessionOp)
-		}
 		return sessionOp, OperationTransport(sessionOp), sessionConnection, nil
 	}
-	if instance == "" && staticOK {
+	if staticOK && (!core.SupportsSessionCatalog(prov) || instance == "") {
 		return staticOp, OperationTransport(staticOp), "", nil
 	}
 	return catalog.CatalogOperation{}, "", "", fmt.Errorf("%w: %q on provider %q", ErrOperationNotFound, operation, provName)
@@ -92,8 +75,9 @@ func resolveSessionCatalog(ctx context.Context, prov core.Provider, provName str
 		ctx = WithCredentialContext(ctx, CredentialContext{Mode: core.ConnectionModeNone})
 	}
 	cat, err := scp.CatalogForRequest(ctx, token)
-	return cat, true, err
+	return HydrateSessionCatalog(prov.Catalog(), cat), true, err
 }
+
 func resolveSessionOperation(ctx context.Context, prov core.Provider, provName string, resolver TokenResolver, p *principal.Principal, operation string, connections []string, instance string) (catalog.CatalogOperation, string, bool, error) {
 	if len(connections) == 0 {
 		connections = []string{""}
@@ -122,15 +106,16 @@ func resolveSessionOperation(ctx context.Context, prov core.Provider, provName s
 }
 
 func mergeCatalogs(provName string, staticCat, sessionCat *catalog.Catalog) (*catalog.Catalog, error) {
-	merged := staticCat
-	if merged == nil {
-		merged = sessionCat
-	}
-	if merged == nil {
+	if sessionCat == nil && staticCat == nil {
 		return nil, fmt.Errorf("provider %q does not expose a catalog", provName)
 	}
-	merged = merged.Clone()
-	if staticCat != nil && sessionCat != nil {
+	if staticCat == nil {
+		merged := sessionCat.Clone()
+		integration.CompileSchemas(merged)
+		return merged, nil
+	}
+	merged := staticCat.Clone()
+	if sessionCat != nil {
 		staticIndexes := make(map[string]int, len(merged.Operations))
 		for i := range merged.Operations {
 			staticIndexes[merged.Operations[i].ID] = i
@@ -138,7 +123,7 @@ func mergeCatalogs(provName string, staticCat, sessionCat *catalog.Catalog) (*ca
 		for i := range sessionCat.Operations {
 			op := sessionCat.Operations[i]
 			if idx, exists := staticIndexes[op.ID]; exists {
-				merged.Operations[idx] = MergeCatalogOperation(merged.Operations[idx], op)
+				merged.Operations[idx] = op
 				continue
 			}
 			merged.Operations = append(merged.Operations, op)
@@ -147,7 +132,32 @@ func mergeCatalogs(provName string, staticCat, sessionCat *catalog.Catalog) (*ca
 	integration.CompileSchemas(merged)
 	return merged, nil
 }
-
+func HydrateSessionCatalog(staticCat, sessionCat *catalog.Catalog) *catalog.Catalog {
+	if sessionCat == nil {
+		return nil
+	}
+	merged := sessionCat.Clone()
+	if staticCat == nil {
+		return merged
+	}
+	merged.Name = firstNonEmpty(merged.Name, staticCat.Name)
+	merged.DisplayName = firstNonEmpty(merged.DisplayName, staticCat.DisplayName)
+	merged.Description = firstNonEmpty(merged.Description, staticCat.Description)
+	merged.IconSVG = firstNonEmpty(merged.IconSVG, staticCat.IconSVG)
+	merged.BaseURL = firstNonEmpty(merged.BaseURL, staticCat.BaseURL)
+	merged.AuthStyle = firstNonEmpty(merged.AuthStyle, staticCat.AuthStyle)
+	if len(staticCat.Headers) > 0 {
+		headers := maps.Clone(staticCat.Headers)
+		maps.Copy(headers, merged.Headers)
+		merged.Headers = headers
+	}
+	for i := range merged.Operations {
+		if staticOp, ok := CatalogOperation(staticCat, merged.Operations[i].ID); ok {
+			merged.Operations[i] = MergeCatalogOperation(staticOp, merged.Operations[i])
+		}
+	}
+	return merged
+}
 func MergeCatalogOperation(staticOp, sessionOp catalog.CatalogOperation) catalog.CatalogOperation {
 	sessionMethod := sessionOp.Method
 	sessionPath := sessionOp.Path

--- a/gestaltd/internal/mcp/binding_test.go
+++ b/gestaltd/internal/mcp/binding_test.go
@@ -2448,20 +2448,30 @@ func TestNewServer_SessionHydratedRESTToolUsesHydrationConnection(t *testing.T) 
 		t.Parallel()
 
 		seenToken = ""
+		var seenOperation catalog.CatalogOperation
+		var sawOperationContext bool
 		usedDirectTool := false
 		collisionProv := &directCallerProvider{
 			StubIntegration: coretesting.StubIntegration{
 				N:        "sampledb",
 				ConnMode: core.ConnectionModeUser,
-				ExecuteFn: func(_ context.Context, _ string, _ map[string]any, token string) (*core.OperationResult, error) {
+				ExecuteFn: func(ctx context.Context, _ string, _ map[string]any, token string) (*core.OperationResult, error) {
 					seenToken = token
+					seenOperation, sawOperationContext = catalog.OperationFromContext(ctx, "sampledb", "run_query")
 					return &core.OperationResult{Status: http.StatusOK, Body: `{"ok":true}`}, nil
 				},
 			},
 			cat: &catalog.Catalog{
 				Name: "sampledb",
 				Operations: []catalog.CatalogOperation{
-					{ID: "run_query", Description: "static query", Transport: catalog.TransportMCPPassthrough},
+					{
+						ID:          "run_query",
+						Description: "static query",
+						Transport:   catalog.TransportMCPPassthrough,
+						Parameters: []catalog.CatalogParameter{
+							{Name: "sql", Type: "string", Required: true},
+						},
+					},
 				},
 			},
 			sessionCatalogFn: func(_ context.Context, token string) (*catalog.Catalog, error) {
@@ -2511,6 +2521,21 @@ func TestNewServer_SessionHydratedRESTToolUsesHydrationConnection(t *testing.T) 
 		}
 		if seenToken != "catalog-token" {
 			t.Fatalf("execute token = %q, want %q", seenToken, "catalog-token")
+		}
+		if !sawOperationContext {
+			t.Fatal("expected session catalog operation metadata in execution context")
+		}
+		if seenOperation.Description != "session query" {
+			t.Fatalf("operation description = %q, want %q", seenOperation.Description, "session query")
+		}
+		if seenOperation.Transport != catalog.TransportREST {
+			t.Fatalf("operation transport = %q, want %q", seenOperation.Transport, catalog.TransportREST)
+		}
+		if got := seenOperation.Parameters; len(got) != 1 || got[0].Name != "sql" || !got[0].Required {
+			t.Fatalf("operation parameters = %#v, want hydrated sql parameter", got)
+		}
+		if len(seenOperation.InputSchema) == 0 {
+			t.Fatal("expected hydrated operation input schema in execution context")
 		}
 	})
 }
@@ -2661,6 +2686,9 @@ func TestNewServer_DynamicCatalogProviderDoesNotRehydrateAfterExactCollisionOnly
 					ID:          "run_query",
 					Description: "static query",
 					Transport:   catalog.TransportMCPPassthrough,
+					Parameters: []catalog.CatalogParameter{
+						{Name: "sql", Type: "string", Required: true},
+					},
 				},
 			},
 		},

--- a/gestaltd/internal/mcp/session_tools.go
+++ b/gestaltd/internal/mcp/session_tools.go
@@ -80,16 +80,9 @@ func hydrateSessionToolsForInstance(ctx context.Context, cfg Config, providerNam
 		if cat == nil {
 			continue
 		}
-		effectiveCat := cat.Clone()
-		if staticCat := prov.Catalog(); staticCat != nil {
-			for i := range effectiveCat.Operations {
-				if staticOp, ok := invocation.CatalogOperation(staticCat, effectiveCat.Operations[i].ID); ok {
-					effectiveCat.Operations[i] = invocation.MergeCatalogOperation(staticOp, effectiveCat.Operations[i])
-				}
-			}
-		}
+		effectiveCat := invocation.HydrateSessionCatalog(prov.Catalog(), cat)
 		coreintegration.CompileSchemas(effectiveCat)
-		storeSessionCatalogOperationMetadata(tools, cfg, provName, effectiveCat, staticToolNames, instance, connection)
+		storeSessionCatalogOperationMetadata(tools, cfg, provName, effectiveCat, instance, connection)
 		m := buildToolMap(cfg, provName, effectiveCat)
 		for name := range m {
 			if _, exists := staticToolNames[name]; exists {
@@ -183,19 +176,11 @@ func sessionProviderHydrationAttemptedFromContext(ctx context.Context, provider,
 	}
 	return sessionProviderHydrationAttempted(sessionWithTools.GetSessionTools(), provider, instance)
 }
-func storeSessionCatalogOperationMetadata(tools map[string]mcpserver.ServerTool, cfg Config, provider string, cat *catalog.Catalog, staticToolNames map[string]struct{}, instance string, connection string) {
+func storeSessionCatalogOperationMetadata(tools map[string]mcpserver.ServerTool, cfg Config, provider string, cat *catalog.Catalog, instance string, connection string) {
 	for i := range cat.Operations {
 		op := &cat.Operations[i]
 		payload, err := json.Marshal(sessionCatalogOperationMeta{
-			Operation: catalog.CatalogOperation{
-				ID:           op.ID,
-				AllowedRoles: append([]string(nil), op.AllowedRoles...),
-				Transport:    op.Transport,
-				Method:       op.Method,
-				Path:         op.Path,
-				Query:        op.Query,
-				Parameters:   append([]catalog.CatalogParameter(nil), op.Parameters...),
-			},
+			Operation:  *op,
 			Connection: connection,
 			Projected:  catalogOperationProjectedToMCP(cfg, provider, *op),
 		})

--- a/gestaltd/internal/operator/lifecycle_test.go
+++ b/gestaltd/internal/operator/lifecycle_test.go
@@ -1118,6 +1118,16 @@ func TestInitAtPath_RejectsUnknownOperationInvokesTargets(t *testing.T) {
 			wantError:   `unknown effective operation "private_status" on plugin "target"`,
 		},
 		{
+			name:        "declarative alias mismatch",
+			buildTarget: func(t *testing.T, dir string) string { return writeLocalDeclarativePlugin(t, dir, "target", "status") },
+			operation:   "status",
+			targetConfigYAML: `      allowedOperations:
+        status:
+          alias: renamed_status
+`,
+			wantError: `unknown effective operation "status" on plugin "target"`,
+		},
+		{
 			name: "executable declarative alias mismatch",
 			buildTarget: func(t *testing.T, dir string) string {
 				return writeLocalExecutableAndDeclarativePlugin(t, dir, "target", []string{"echo"}, []string{"status"})
@@ -1126,6 +1136,18 @@ func TestInitAtPath_RejectsUnknownOperationInvokesTargets(t *testing.T) {
 			targetConfigYAML: `      allowedOperations:
         echo:
           alias: renamed_echo
+        status:
+          alias: renamed_status
+`,
+			wantError: `unknown effective operation "status" on plugin "target"`,
+		},
+		{
+			name: "executable declarative alias without static catalog mismatch",
+			buildTarget: func(t *testing.T, dir string) string {
+				return writeLocalExecutableAndDeclarativePlugin(t, dir, "target", nil, []string{"status"})
+			},
+			operation: "status",
+			targetConfigYAML: `      allowedOperations:
         status:
           alias: renamed_status
 `,

--- a/gestaltd/internal/server/authorization.go
+++ b/gestaltd/internal/server/authorization.go
@@ -52,18 +52,15 @@ func rejectWorkloadSelectors(w http.ResponseWriter, p *principal.Principal, conn
 }
 
 func (s *Server) workloadBindingSelectors(p *principal.Principal, provider, connection, instance string) (string, string) {
-	if p == nil || p.Kind != principal.KindWorkload {
-		return s.resolvedSessionCatalogConnection(provider, connection), instance
-	}
-	binding, ok := s.workloadBinding(p, provider)
-	if !ok {
-		return s.resolvedSessionCatalogConnection(provider, connection), instance
-	}
-	if connection == "" {
-		connection = binding.Connection
-	}
-	if instance == "" {
-		instance = binding.Instance
+	if p != nil && p.Kind == principal.KindWorkload {
+		if binding, ok := s.workloadBinding(p, provider); ok {
+			if connection == "" {
+				connection = binding.Connection
+			}
+			if instance == "" {
+				instance = binding.Instance
+			}
+		}
 	}
 	return s.resolvedSessionCatalogConnection(provider, connection), instance
 }

--- a/gestaltd/internal/server/catalog_resolution_test.go
+++ b/gestaltd/internal/server/catalog_resolution_test.go
@@ -663,14 +663,11 @@ func TestResolveCatalog_TokenResolutionFailure_NonFatal(t *testing.T) {
 	resolver := &stubTokenResolver{err: fmt.Errorf("token expired")}
 	p := &principal.Principal{UserID: "u1"}
 
-	cat, metadata, err := invocation.ResolveCatalogWithMetadata(context.Background(), prov, "auth-api", resolver, p, "default", "", false)
+	cat, sessionFailed, err := invocation.ResolveCatalogWithMetadata(context.Background(), prov, "auth-api", resolver, p, "default", "", false)
 	if err != nil {
 		t.Fatalf("expected no error on token failure, got: %v", err)
 	}
-	if !metadata.SessionAttempted {
-		t.Fatal("expected session resolution attempt to be reported")
-	}
-	if !metadata.SessionFailed {
+	if !sessionFailed {
 		t.Fatal("expected session resolution failure to be reported")
 	}
 	if len(cat.Operations) != 1 {
@@ -705,9 +702,12 @@ func TestResolveCatalog_NilResolver(t *testing.T) {
 		},
 	}
 
-	cat, err := resolveCatalogForTest(context.Background(), prov, "noauth-api", nil, &principal.Principal{UserID: "u1"}, "default", "")
+	cat, sessionFailed, err := invocation.ResolveCatalogWithMetadata(context.Background(), prov, "noauth-api", nil, &principal.Principal{UserID: "u1"}, "default", "", false)
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
+	}
+	if sessionFailed {
+		t.Fatal("expected skipped session lookup not to report failure")
 	}
 	if len(cat.Operations) != 1 {
 		t.Fatalf("expected 1 operation (static only), got %d", len(cat.Operations))

--- a/gestaltd/internal/server/handlers.go
+++ b/gestaltd/internal/server/handlers.go
@@ -470,11 +470,11 @@ func (s *Server) listOperations(w http.ResponseWriter, r *http.Request) {
 	ctx := invocation.WithAccessContext(r.Context(), s.providerAccessContext(p, name))
 	var cat *catalog.Catalog
 	var err, firstErr error
+	var sessionFailed bool
 	for _, connection := range connections {
-		var metadata invocation.CatalogResolutionMetadata
-		cat, metadata, err = invocation.ResolveCatalogWithMetadata(ctx, prov, name, resolver, p, connection, instance, strictCatalog)
+		cat, sessionFailed, err = invocation.ResolveCatalogWithMetadata(ctx, prov, name, resolver, p, connection, instance, strictCatalog)
 		if err == nil {
-			discoveryFailed = metadata.SessionFailed
+			discoveryFailed = sessionFailed
 			break
 		}
 		if firstErr == nil {


### PR DESCRIPTION
Go interface:
- invocation.ResolveCatalogWithMetadata(...) now returns (*catalog.Catalog, bool, error), where the bool reports only whether session resolution failed.
- invocation.HydrateSessionCatalog(staticCat, sessionCat) hydrates sparse session catalogs before discovery and MCP projection.

Go example:
  cat, sessionFailed, err := invocation.ResolveCatalogWithMetadata(ctx, prov, "sampledb", resolver, p, "catalog-conn", "", false)
  if sessionFailed {
      slog.Warn("falling back to static catalog")
  }

YAML interface:
  Static catalogs still declare reusable transport and parameter metadata, while session catalogs can override request-scoped behavior for the same operation id.

YAML example static catalog:
  name: sampledb
  operations:
    - id: run_query
      method: POST
      parameters:
        - name: sql
          type: string
          required: true

YAML example session catalog:
  name: sampledb
  operations:
    - id: run_query
      description: session query
      transport: rest

Behavior:
- session discovery and MCP tool hydration now use the same hydrated session operation shape
- sparse session operations keep static transport, path, headers, and parameter wiring
- the unused SessionAttempted metadata branch is removed without changing discovery order