### PR TITLE
core: inline oauth support into the provider contract

### DIFF
--- a/gestaltd/core/integration/base.go
+++ b/gestaltd/core/integration/base.go
@@ -15,7 +15,7 @@ import (
 )
 
 var (
-	_ core.OAuthProvider = (*Base)(nil)
+	_ core.Provider = (*Base)(nil)
 )
 
 type manualChecker interface{ IsManual() bool }

--- a/gestaltd/core/integration/restricted.go
+++ b/gestaltd/core/integration/restricted.go
@@ -35,14 +35,12 @@ func WithAllowedRoles(roles map[string][]string) RestrictedOption {
 
 // Compile-time interface checks.
 var (
-	_ core.Provider      = (*Restricted)(nil)
-	_ core.OAuthProvider = (*restrictedOAuth)(nil)
+	_ core.Provider = (*Restricted)(nil)
 )
 
 // NewRestricted returns a Provider that gates operations to the allowed set.
 // The ops map maps exposedName -> innerName. If innerName is empty, the
-// exposed name equals the inner name (no alias). If the inner provider
-// implements OAuthProvider, the returned value does too.
+// exposed name equals the inner name (no alias).
 func NewRestricted(inner core.Provider, ops map[string]string, opts ...RestrictedOption) core.Provider {
 	m := make(map[string]struct{}, len(ops))
 	aliases := make(map[string]string)
@@ -69,14 +67,7 @@ func NewRestricted(inner core.Provider, ops map[string]string, opts ...Restricte
 		opt(r)
 	}
 	if scp, ok := inner.(core.SessionCatalogProvider); ok {
-		rs := &restrictedSession{Restricted: r, scp: scp}
-		if oauth, ok := inner.(core.OAuthProvider); ok {
-			return &restrictedOAuth{Restricted: rs.Restricted, inner: oauth, session: rs}
-		}
-		return rs
-	}
-	if oauth, ok := inner.(core.OAuthProvider); ok {
-		return &restrictedOAuth{Restricted: r, inner: oauth}
+		return &restrictedSession{Restricted: r, scp: scp}
 	}
 	return r
 }
@@ -118,6 +109,19 @@ func (r *Restricted) Execute(ctx context.Context, operation string, params map[s
 	}
 	return r.inner.Execute(ctx, innerName, params, token)
 }
+
+func (r *Restricted) AuthorizationURL(state string, scopes []string) string {
+	return r.inner.AuthorizationURL(state, scopes)
+}
+
+func (r *Restricted) ExchangeCode(ctx context.Context, code string) (*core.TokenResponse, error) {
+	return r.inner.ExchangeCode(ctx, code)
+}
+
+func (r *Restricted) RefreshToken(ctx context.Context, refreshToken string) (*core.TokenResponse, error) {
+	return r.inner.RefreshToken(ctx, refreshToken)
+}
+
 func (r *Restricted) Catalog() *catalog.Catalog {
 	cat := r.inner.Catalog()
 	if cat == nil {
@@ -172,33 +176,6 @@ func (rs *restrictedSession) CatalogForRequest(ctx context.Context, token string
 		return cat, err
 	}
 	return rs.filterCatalog(cat), nil
-}
-
-// restrictedOAuth wraps a Restricted provider and delegates OAuth methods
-// to the inner OAuthProvider.
-type restrictedOAuth struct {
-	*Restricted
-	inner   core.OAuthProvider
-	session *restrictedSession
-}
-
-func (r *restrictedOAuth) AuthorizationURL(state string, scopes []string) string {
-	return r.inner.AuthorizationURL(state, scopes)
-}
-
-func (r *restrictedOAuth) ExchangeCode(ctx context.Context, code string) (*core.TokenResponse, error) {
-	return r.inner.ExchangeCode(ctx, code)
-}
-
-func (r *restrictedOAuth) RefreshToken(ctx context.Context, refreshToken string) (*core.TokenResponse, error) {
-	return r.inner.RefreshToken(ctx, refreshToken)
-}
-
-func (r *restrictedOAuth) CatalogForRequest(ctx context.Context, token string) (*catalog.Catalog, error) {
-	if r.session != nil {
-		return r.session.CatalogForRequest(ctx, token)
-	}
-	return nil, nil
 }
 
 func (r *Restricted) AuthTypes() []string {

--- a/gestaltd/core/integration/restricted_test.go
+++ b/gestaltd/core/integration/restricted_test.go
@@ -262,16 +262,11 @@ func TestDelegationMethods(t *testing.T) {
 		t.Errorf("Description: got %q, want %q", got, "A test integration")
 	}
 
-	oauthR, ok := r.(core.OAuthProvider)
-	if !ok {
-		t.Fatal("expected restricted wrapper to implement core OAuth provider")
-	}
-
-	if got := oauthR.AuthorizationURL("state", []string{"read"}); got != "https://example.com/start?state=state" {
+	if got := r.AuthorizationURL("state", []string{"read"}); got != "https://example.com/start?state=state" {
 		t.Errorf("AuthorizationURL: got %q", got)
 	}
 
-	tok, err := oauthR.ExchangeCode(context.Background(), "code")
+	tok, err := r.ExchangeCode(context.Background(), "code")
 	if err != nil {
 		t.Fatalf("ExchangeCode: %v", err)
 	}
@@ -279,7 +274,7 @@ func TestDelegationMethods(t *testing.T) {
 		t.Errorf("ExchangeCode: got %+v, want %+v", tok, exchangeResp)
 	}
 
-	refreshTok, err := oauthR.RefreshToken(context.Background(), "refresh")
+	refreshTok, err := r.RefreshToken(context.Background(), "refresh")
 	if err != nil {
 		t.Fatalf("RefreshToken: %v", err)
 	}

--- a/gestaltd/core/provider.go
+++ b/gestaltd/core/provider.go
@@ -2,6 +2,7 @@ package core
 
 import (
 	"context"
+	"errors"
 
 	"github.com/valon-technologies/gestalt/server/core/catalog"
 )
@@ -21,6 +22,9 @@ type Provider interface {
 	Description() string
 	ConnectionMode() ConnectionMode
 	AuthTypes() []string
+	AuthorizationURL(state string, scopes []string) string
+	ExchangeCode(ctx context.Context, code string) (*TokenResponse, error)
+	RefreshToken(ctx context.Context, refreshToken string) (*TokenResponse, error)
 	ConnectionParamDefs() map[string]ConnectionParamDef
 	CredentialFields() []CredentialFieldDef
 	DiscoveryConfig() *DiscoveryConfig
@@ -29,11 +33,18 @@ type Provider interface {
 	Execute(ctx context.Context, operation string, params map[string]any, token string) (*OperationResult, error)
 }
 
-type OAuthProvider interface {
-	Provider
-	AuthorizationURL(state string, scopes []string) string
-	ExchangeCode(ctx context.Context, code string) (*TokenResponse, error)
-	RefreshToken(ctx context.Context, refreshToken string) (*TokenResponse, error)
+var ErrOAuthUnsupported = errors.New("provider does not support OAuth")
+
+type NoOAuth struct{}
+
+func (NoOAuth) AuthorizationURL(string, []string) string { return "" }
+
+func (NoOAuth) ExchangeCode(context.Context, string) (*TokenResponse, error) {
+	return nil, ErrOAuthUnsupported
+}
+
+func (NoOAuth) RefreshToken(context.Context, string) (*TokenResponse, error) {
+	return nil, ErrOAuthUnsupported
 }
 
 // SessionCatalogProvider is an optional interface for providers whose MCP tool

--- a/gestaltd/core/testing/integration_suite.go
+++ b/gestaltd/core/testing/integration_suite.go
@@ -20,7 +20,7 @@ import (
 //   - "valid-refresh" for RefreshToken (returns a valid TokenResponse)
 //   - "invalid-refresh" for RefreshToken (returns an error)
 //   - "valid-bearer-token" for Execute (succeeds)
-func RunIntegrationTests(t *testing.T, newIntegration func(t *testing.T, mockURL string) core.OAuthProvider, mockServer *httptest.Server) {
+func RunIntegrationTests(t *testing.T, newIntegration func(t *testing.T, mockURL string) core.Provider, mockServer *httptest.Server) {
 	if mockServer == nil {
 		t.Fatal("RunIntegrationTests requires a mock server")
 		return

--- a/gestaltd/core/testing/stubs.go
+++ b/gestaltd/core/testing/stubs.go
@@ -75,7 +75,7 @@ func (s *StubIntegration) ConnectionMode() core.ConnectionMode {
 	}
 	return s.ConnMode
 }
-func (s *StubIntegration) AuthTypes() []string { return nil }
+func (s *StubIntegration) AuthTypes() []string { return []string{"oauth"} }
 func (s *StubIntegration) ConnectionParamDefs() map[string]core.ConnectionParamDef {
 	return nil
 }

--- a/gestaltd/internal/bootstrap/startup_proxy.go
+++ b/gestaltd/internal/bootstrap/startup_proxy.go
@@ -223,6 +223,30 @@ func (p *startupProviderProxy) ConnectionForOperation(operation string) string {
 	return p.operationConnections[operation]
 }
 
+func (p *startupProviderProxy) AuthorizationURL(state string, scopes []string) string {
+	provider := p.resolved()
+	if provider == nil {
+		return ""
+	}
+	return provider.AuthorizationURL(state, scopes)
+}
+
+func (p *startupProviderProxy) ExchangeCode(ctx context.Context, code string) (*core.TokenResponse, error) {
+	provider, err := p.await(ctx)
+	if err != nil {
+		return nil, err
+	}
+	return provider.ExchangeCode(ctx, code)
+}
+
+func (p *startupProviderProxy) RefreshToken(ctx context.Context, refreshToken string) (*core.TokenResponse, error) {
+	provider, err := p.await(ctx)
+	if err != nil {
+		return nil, err
+	}
+	return provider.RefreshToken(ctx, refreshToken)
+}
+
 func (p *startupProviderProxy) ConnectionParamDefs() map[string]core.ConnectionParamDef {
 	return maps.Clone(p.spec.ConnectionParams)
 }

--- a/gestaltd/internal/bootstrap/validate.go
+++ b/gestaltd/internal/bootstrap/validate.go
@@ -155,6 +155,7 @@ func buildProviderForValidation(ctx context.Context, name string, entry *config.
 }
 
 type preparedProviderStub struct {
+	core.NoOAuth
 	name           string
 	displayName    string
 	description    string

--- a/gestaltd/internal/bootstrap/workflow_runtime_test.go
+++ b/gestaltd/internal/bootstrap/workflow_runtime_test.go
@@ -40,6 +40,13 @@ func (p *workflowRoundTripProvider) Description() string { return "workflow roun
 func (p *workflowRoundTripProvider) ConnectionMode() core.ConnectionMode {
 	return core.ConnectionModeNone
 }
+func (p *workflowRoundTripProvider) AuthorizationURL(string, []string) string { return "" }
+func (p *workflowRoundTripProvider) ExchangeCode(context.Context, string) (*core.TokenResponse, error) {
+	return nil, core.ErrOAuthUnsupported
+}
+func (p *workflowRoundTripProvider) RefreshToken(context.Context, string) (*core.TokenResponse, error) {
+	return nil, core.ErrOAuthUnsupported
+}
 func (p *workflowRoundTripProvider) AuthTypes() []string { return nil }
 func (p *workflowRoundTripProvider) ConnectionParamDefs() map[string]core.ConnectionParamDef {
 	return nil

--- a/gestaltd/internal/composite/merged.go
+++ b/gestaltd/internal/composite/merged.go
@@ -12,6 +12,7 @@ import (
 )
 
 type MergedProvider struct {
+	core.NoOAuth
 	catalog  *catalog.Catalog
 	connMode core.ConnectionMode
 	opConn   map[string]string

--- a/gestaltd/internal/composite/merged_test.go
+++ b/gestaltd/internal/composite/merged_test.go
@@ -11,6 +11,7 @@ import (
 )
 
 type fakeProvider struct {
+	core.NoOAuth
 	name     string
 	connMode core.ConnectionMode
 	ops      []core.Operation

--- a/gestaltd/internal/composite/provider.go
+++ b/gestaltd/internal/composite/provider.go
@@ -31,18 +31,14 @@ var (
 	_ core.SessionCatalogProvider = (*Provider)(nil)
 )
 
-// New creates a composite provider. If the API provider implements
-// OAuthProvider, the returned provider does too.
+// New creates a composite provider. Execute goes to the API provider; MCP
+// passthrough and session catalog calls go to the upstream.
 func New(name string, apiProv core.Provider, mcpUp MCPUpstream) core.Provider {
-	p := &Provider{
+	return &Provider{
 		name: name,
 		api:  apiProv,
 		mcp:  mcpUp,
 	}
-	if oauthProv, ok := apiProv.(core.OAuthProvider); ok {
-		return &oauthProvider{Provider: p, auth: oauthProv}
-	}
-	return p
 }
 
 func (p *Provider) Name() string        { return p.name }
@@ -98,6 +94,18 @@ func (p *Provider) AuthTypes() []string {
 	return p.api.AuthTypes()
 }
 
+func (p *Provider) AuthorizationURL(state string, scopes []string) string {
+	return p.api.AuthorizationURL(state, scopes)
+}
+
+func (p *Provider) ExchangeCode(ctx context.Context, code string) (*core.TokenResponse, error) {
+	return p.api.ExchangeCode(ctx, code)
+}
+
+func (p *Provider) RefreshToken(ctx context.Context, refreshToken string) (*core.TokenResponse, error) {
+	return p.api.RefreshToken(ctx, refreshToken)
+}
+
 func (p *Provider) ConnectionParamDefs() map[string]core.ConnectionParamDef {
 	return p.api.ConnectionParamDefs()
 }
@@ -121,23 +129,6 @@ func (p *Provider) Close() error {
 		}
 	}
 	return firstErr
-}
-
-type oauthProvider struct {
-	*Provider
-	auth core.OAuthProvider
-}
-
-func (p *oauthProvider) AuthorizationURL(state string, scopes []string) string {
-	return p.auth.AuthorizationURL(state, scopes)
-}
-
-func (p *oauthProvider) ExchangeCode(ctx context.Context, code string) (*core.TokenResponse, error) {
-	return p.auth.ExchangeCode(ctx, code)
-}
-
-func (p *oauthProvider) RefreshToken(ctx context.Context, refreshToken string) (*core.TokenResponse, error) {
-	return p.auth.RefreshToken(ctx, refreshToken)
 }
 
 func (p *Provider) buildCatalog() *catalog.Catalog {

--- a/gestaltd/internal/mcp/composite_test.go
+++ b/gestaltd/internal/mcp/composite_test.go
@@ -19,6 +19,7 @@ import (
 )
 
 type stubMCPUpstream struct {
+	core.NoOAuth
 	cat    *catalog.Catalog
 	callFn func(ctx context.Context, name string, args map[string]any) (*mcpgo.CallToolResult, error)
 }

--- a/gestaltd/internal/mcpupstream/upstream.go
+++ b/gestaltd/internal/mcpupstream/upstream.go
@@ -40,6 +40,7 @@ func (c *managedMCPClient) Close() error {
 }
 
 type Upstream struct {
+	core.NoOAuth
 	name        string
 	display     string
 	desc        string

--- a/gestaltd/internal/providerhost/provider_client.go
+++ b/gestaltd/internal/providerhost/provider_client.go
@@ -34,6 +34,7 @@ type StaticProviderSpec struct {
 }
 
 type remoteProviderBase struct {
+	core.NoOAuth
 	client      proto.IntegrationProviderClient
 	name        string
 	displayName string

--- a/gestaltd/internal/providerhost/provider_test.go
+++ b/gestaltd/internal/providerhost/provider_test.go
@@ -17,7 +17,7 @@ import (
 	providermanifestv1 "github.com/valon-technologies/gestalt/server/sdk/providermanifest/v1"
 )
 
-type roundTripProvider struct{}
+type roundTripProvider struct{ core.NoOAuth }
 
 func (p *roundTripProvider) Configure(_ context.Context, _ string, _ map[string]any) error {
 	return nil

--- a/gestaltd/internal/server/catalog_resolution_test.go
+++ b/gestaltd/internal/server/catalog_resolution_test.go
@@ -17,6 +17,7 @@ import (
 )
 
 type stubProvider struct {
+	core.NoOAuth
 	name        string
 	displayName string
 	description string

--- a/gestaltd/internal/server/handlers_tokens.go
+++ b/gestaltd/internal/server/handlers_tokens.go
@@ -209,7 +209,7 @@ func (s *Server) populateIntegrationSettings(info *integrationInfo, prov core.Pr
 	info.ConnectionParams = connectionParamInfosFromProvider(prov)
 	info.CredentialFields = credentialFieldInfosFromProvider(prov, authTypes)
 	info.Connections = s.connectionInfosForPlugin(info.Name, s.pluginDefs[info.Name], authTypes, info.CredentialFields)
-	info.AuthTypes = resolvedIntegrationAuthTypes(prov, authTypes, info.Connections)
+	info.AuthTypes = resolvedIntegrationAuthTypes(authTypes, info.Connections)
 	if len(authTypes) == 0 && len(info.AuthTypes) > 0 {
 		info.Connections = s.connectionInfosForPlugin(info.Name, s.pluginDefs[info.Name], info.AuthTypes, info.CredentialFields)
 	}
@@ -335,7 +335,7 @@ func connectionDisplayName(name, configured string) string {
 	return userFacingConnectionName(name)
 }
 
-func resolvedIntegrationAuthTypes(prov core.Provider, authTypes []string, connections []connectionDefInfo) []string {
+func resolvedIntegrationAuthTypes(authTypes []string, connections []connectionDefInfo) []string {
 	if len(authTypes) > 0 {
 		return authTypes
 	}
@@ -345,9 +345,6 @@ func resolvedIntegrationAuthTypes(prov core.Provider, authTypes []string, connec
 	}
 	if authTypes = userFacingAuthTypes(combined); len(authTypes) > 0 {
 		return authTypes
-	}
-	if _, ok := prov.(core.OAuthProvider); ok {
-		return []string{"oauth"}
 	}
 	return []string{}
 }

--- a/gestaltd/internal/server/metrics_test.go
+++ b/gestaltd/internal/server/metrics_test.go
@@ -23,6 +23,7 @@ import (
 )
 
 type manualMetricsProvider struct {
+	core.NoOAuth
 	name string
 }
 

--- a/gestaltd/internal/server/server_test.go
+++ b/gestaltd/internal/server/server_test.go
@@ -10502,8 +10502,9 @@ func (s *stubOAuthIntegration) RefreshToken(ctx context.Context, token string) (
 	return nil, nil
 }
 
-// stubNonOAuthProvider implements core.Provider but NOT core.OAuthProvider.
+// stubNonOAuthProvider exercises providers that report no OAuth auth types.
 type stubNonOAuthProvider struct {
+	core.NoOAuth
 	name    string
 	ops     []core.Operation
 	catalog *catalog.Catalog

--- a/gestaltd/internal/testplugins/echo/main.go
+++ b/gestaltd/internal/testplugins/echo/main.go
@@ -40,7 +40,7 @@ func run() error {
 
 var _ core.Provider = (*echoProvider)(nil)
 
-type echoProvider struct{}
+type echoProvider struct{ core.NoOAuth }
 
 func (p *echoProvider) Name() string                        { return "echo" }
 func (p *echoProvider) DisplayName() string                 { return "Echo" }

--- a/gestaltd/internal/testplugins/echo/proxy_provider.go
+++ b/gestaltd/internal/testplugins/echo/proxy_provider.go
@@ -38,6 +38,15 @@ func (p *proxyProvider) DisplayName() string                 { return p.inner.Di
 func (p *proxyProvider) Description() string                 { return p.inner.Description() }
 func (p *proxyProvider) ConnectionMode() core.ConnectionMode { return p.inner.ConnectionMode() }
 func (p *proxyProvider) AuthTypes() []string                 { return p.inner.AuthTypes() }
+func (p *proxyProvider) AuthorizationURL(state string, scopes []string) string {
+	return p.inner.AuthorizationURL(state, scopes)
+}
+func (p *proxyProvider) ExchangeCode(ctx context.Context, code string) (*core.TokenResponse, error) {
+	return p.inner.ExchangeCode(ctx, code)
+}
+func (p *proxyProvider) RefreshToken(ctx context.Context, refreshToken string) (*core.TokenResponse, error) {
+	return p.inner.RefreshToken(ctx, refreshToken)
+}
 func (p *proxyProvider) ConnectionParamDefs() map[string]core.ConnectionParamDef {
 	return p.inner.ConnectionParamDefs()
 }


### PR DESCRIPTION
Move OAuth methods onto core.Provider and delete the separate side-interface. Unsupported providers now embed core.NoOAuth, so wrappers and callers stop branching on an optional OAuth capability type just to preserve the same behavior.

Go interface examples:

```go
type Provider interface {
    Name() string
    AuthTypes() []string
    AuthorizationURL(state string, scopes []string) string
    ExchangeCode(ctx context.Context, code string) (*TokenResponse, error)
    RefreshToken(ctx context.Context, refreshToken string) (*TokenResponse, error)
    Execute(ctx context.Context, operation string, params map[string]any, token string) (*OperationResult, error)
}

type Upstream struct {
    core.NoOAuth
    // ...
}
```

YAML examples:

```yaml
spec:
  connections:
    api:
      auth:
        type: oauth2
        authorizationUrl: https://auth.example.com/authorize
        tokenUrl: https://auth.example.com/token
```

```yaml
spec:
  connections:
    default:
      auth:
        type: none
```

Behavior:
- restricted and composite providers now delegate OAuth directly instead of returning wrapper-only OAuth shapes
- integration auth type resolution now relies on explicit AuthTypes() or connection auth metadata, not a side-interface probe
- no-oauth providers share one primitive instead of repeating empty OAuth stubs