### PR TITLE
core: centralize session catalog selector precedence

### DIFF
--- a/gestaltd/internal/invocation/broker.go
+++ b/gestaltd/internal/invocation/broker.go
@@ -215,6 +215,7 @@ func (b *Broker) Invoke(ctx context.Context, p *principal.Principal, providerNam
 	if p.UserID != "" {
 		span.SetAttributes(attrUserID.String(p.UserID))
 	}
+	bindingConnection, bindingInstance := "", ""
 	if b.authorizer != nil {
 		access, allowed := b.authorizer.ResolveAccess(p, providerName)
 		if access.Policy != "" || access.Role != "" {
@@ -223,6 +224,7 @@ func (b *Broker) Invoke(ctx context.Context, p *principal.Principal, providerNam
 		if b.authorizer.IsWorkload(p) {
 			if binding, ok := b.authorizer.Binding(p, providerName); ok {
 				SetCredentialAudit(ctx, binding.Mode, binding.CredentialSubjectID, binding.Connection, binding.Instance)
+				bindingConnection, bindingInstance = binding.Connection, binding.Instance
 			}
 		} else if !allowed {
 			return fail(fmt.Errorf("%w: %s", ErrAuthorizationDenied, providerName))
@@ -230,12 +232,10 @@ func (b *Broker) Invoke(ctx context.Context, p *principal.Principal, providerNam
 	}
 
 	conn := ConnectionFromContext(ctx)
-	conn, instance = b.workloadSelectors(p, providerName, conn, instance)
 	if b.authorizer != nil && b.authorizer.IsWorkload(p) && !b.authorizer.AllowOperation(p, providerName, operation) {
 		return fail(fmt.Errorf("%w: %s.%s", ErrAuthorizationDenied, providerName, operation))
 	}
-
-	opMeta, transport, resolvedConnection, err := b.resolveOperation(ctx, p, prov, providerName, operation, conn, instance)
+	opMeta, transport, resolvedConnection, err := b.resolveOperation(ctx, p, prov, providerName, operation, conn, instance, bindingConnection, bindingInstance)
 	if err != nil {
 		return fail(err)
 	}
@@ -251,6 +251,12 @@ func (b *Broker) Invoke(ctx context.Context, p *principal.Principal, providerNam
 		return fail(core.ErrMCPOnly)
 	}
 
+	if conn == "" {
+		conn = bindingConnection
+	}
+	if instance == "" {
+		instance = bindingInstance
+	}
 	if conn == "" {
 		conn = resolvedConnection
 	}
@@ -293,15 +299,8 @@ func (b *Broker) Invoke(ctx context.Context, p *principal.Principal, providerNam
 	return result, nil
 }
 
-func (b *Broker) resolveOperation(ctx context.Context, p *principal.Principal, prov core.Provider, providerName, operation, connection, instance string) (catalog.CatalogOperation, string, string, error) {
-	sessionConnections := []string{connection}
-	if connection == "" {
-		sessionConnections = nil
-		if mcpConnection := b.mcpConnection(providerName); mcpConnection != "" {
-			sessionConnections = []string{mcpConnection}
-		}
-	}
-
+func (b *Broker) resolveOperation(ctx context.Context, p *principal.Principal, prov core.Provider, providerName, operation, connection, instance, bindingConnection, bindingInstance string) (catalog.CatalogOperation, string, string, error) {
+	sessionConnections, instance := OrderedSessionSelectors(p, connection, instance, b.mcpConnection(providerName), "", bindingConnection, bindingInstance)
 	return ResolveOperation(ctx, prov, providerName, b, p, operation, sessionConnections, instance)
 }
 
@@ -319,23 +318,6 @@ func (b *Broker) mcpConnection(providerName string) string {
 
 func (b *Broker) MCPConnection(providerName string) string {
 	return b.mcpConnection(providerName)
-}
-
-func (b *Broker) workloadSelectors(p *principal.Principal, providerName, connection, instance string) (string, string) {
-	if b.authorizer == nil || !b.authorizer.IsWorkload(p) {
-		return connection, instance
-	}
-	binding, ok := b.authorizer.Binding(p, providerName)
-	if !ok {
-		return connection, instance
-	}
-	if connection == "" {
-		connection = binding.Connection
-	}
-	if instance == "" {
-		instance = binding.Instance
-	}
-	return connection, instance
 }
 
 func toolResultToOperationResult(result *mcpgo.CallToolResult) (*core.OperationResult, error) {

--- a/gestaltd/internal/invocation/catalog.go
+++ b/gestaltd/internal/invocation/catalog.go
@@ -16,6 +16,27 @@ type TokenResolver interface {
 	ResolveToken(ctx context.Context, p *principal.Principal, providerName, connection, instance string) (context.Context, string, error)
 }
 
+func OrderedSessionSelectors(p *principal.Principal, explicitConnection, explicitInstance, preferredConnection, fallbackConnection, bindingConnection, bindingInstance string) ([]string, string) {
+	instance := explicitInstance
+	if instance == "" && p != nil && p.Kind == principal.KindWorkload {
+		instance = bindingInstance
+	}
+	switch {
+	case explicitConnection != "":
+		return []string{explicitConnection}, instance
+	case p != nil && p.Kind == principal.KindWorkload && bindingConnection != "":
+		return []string{bindingConnection}, instance
+	case preferredConnection != "" && fallbackConnection != "" && fallbackConnection != preferredConnection:
+		return []string{preferredConnection, fallbackConnection}, instance
+	case preferredConnection != "":
+		return []string{preferredConnection}, instance
+	case fallbackConnection != "":
+		return []string{fallbackConnection}, instance
+	default:
+		return []string{""}, instance
+	}
+}
+
 func ResolveCatalogWithMetadata(ctx context.Context, prov core.Provider, provName string, resolver TokenResolver, p *principal.Principal, defaultConnection, instance string, strictSession bool) (*catalog.Catalog, bool, error) {
 	staticCat := prov.Catalog()
 	sessionCat, attempted, err := resolveSessionCatalog(ctx, prov, provName, resolver, p, defaultConnection, instance)

--- a/gestaltd/internal/mcp/session_tools.go
+++ b/gestaltd/internal/mcp/session_tools.go
@@ -106,7 +106,7 @@ func resolveSessionToken(ctx context.Context, cfg Config, provName string, prov 
 		if cfg.TokenResolver != nil {
 			p := principal.FromContext(ctx)
 			if p != nil {
-				connection, instance := sessionTokenSelectors(cfg, p, provName, instanceOverride)
+				connection, instance := orderedSessionSelectors(cfg, p, provName, instanceOverride)
 				sessionCtx, token, err := cfg.TokenResolver.ResolveToken(ctx, p, provName, connection, instance)
 				if err != nil {
 					return sessionCtx, token, connection, err
@@ -123,7 +123,7 @@ func resolveSessionToken(ctx context.Context, cfg Config, provName string, prov 
 	if p == nil {
 		return ctx, "", "", fmt.Errorf("not authenticated")
 	}
-	connection, instance := sessionTokenSelectors(cfg, p, provName, instanceOverride)
+	connection, instance := orderedSessionSelectors(cfg, p, provName, instanceOverride)
 	sessionCtx, token, err := cfg.TokenResolver.ResolveToken(ctx, p, provName, connection, instance)
 	if err != nil {
 		return sessionCtx, token, connection, err
@@ -366,16 +366,23 @@ func internalSessionToolHandler(context.Context, mcpgo.CallToolRequest) (*mcpgo.
 	return mcpgo.NewToolResultError("tool not found"), nil
 }
 
-func sessionTokenSelectors(cfg Config, p *principal.Principal, provName, instanceOverride string) (string, string) {
-	connection := cfg.MCPConnection[provName]
-	instance := normalizedSessionCatalogInstance(instanceOverride)
-	if cfg.Authorizer == nil || !cfg.Authorizer.IsWorkload(p) {
-		return connection, instance
+func orderedSessionSelectors(cfg Config, p *principal.Principal, provName, instanceOverride string) (string, string) {
+	bindingConnection, bindingInstance := "", ""
+	if cfg.Authorizer != nil && cfg.Authorizer.IsWorkload(p) {
+		if binding, ok := cfg.Authorizer.Binding(p, provName); ok {
+			bindingConnection, bindingInstance = binding.Connection, binding.Instance
+		}
 	}
-	if binding, ok := cfg.Authorizer.Binding(p, provName); ok {
-		return binding.Connection, binding.Instance
-	}
-	return connection, ""
+	connections, instance := invocation.OrderedSessionSelectors(
+		p,
+		"",
+		normalizedSessionCatalogInstance(instanceOverride),
+		cfg.MCPConnection[provName],
+		"",
+		bindingConnection,
+		bindingInstance,
+	)
+	return connections[0], instance
 }
 
 func encodeSessionCatalogMarkerSegment(value string) string {

--- a/gestaltd/internal/server/authorization.go
+++ b/gestaltd/internal/server/authorization.go
@@ -51,18 +51,13 @@ func rejectWorkloadSelectors(w http.ResponseWriter, p *principal.Principal, conn
 	return errWorkloadSelector
 }
 
-func (s *Server) workloadBindingSelectors(p *principal.Principal, provider, connection, instance string) (string, string) {
+func (s *Server) workloadSessionBinding(p *principal.Principal, provider string) (string, string) {
 	if p != nil && p.Kind == principal.KindWorkload {
 		if binding, ok := s.workloadBinding(p, provider); ok {
-			if connection == "" {
-				connection = binding.Connection
-			}
-			if instance == "" {
-				instance = binding.Instance
-			}
+			return binding.Connection, binding.Instance
 		}
 	}
-	return s.resolvedSessionCatalogConnection(provider, connection), instance
+	return "", ""
 }
 
 func (s *Server) workloadBindingConnected(ctx context.Context, binding authorization.CredentialBinding, provider string) (bool, error) {

--- a/gestaltd/internal/server/handlers.go
+++ b/gestaltd/internal/server/handlers.go
@@ -463,10 +463,13 @@ func (s *Server) listOperations(w http.ResponseWriter, r *http.Request) {
 		discoveryConnectionMode = metricutil.NormalizeConnectionMode(prov.ConnectionMode())
 	}
 	strictCatalog := requestedConnection != "" || requestedInstance != "" || core.SupportsSessionCatalog(prov)
-	connections, instance := s.boundSessionCatalogConnections(name, p, requestedConnection, requestedInstance)
-	if !strictCatalog || requestedConnection != "" || requestedInstance != "" || (s.authorizer != nil && s.authorizer.IsWorkload(p)) {
-		connections = connections[:1]
-	}
+	connections, instance := s.orderedSessionSelectors(
+		p,
+		name,
+		requestedConnection,
+		requestedInstance,
+		strictCatalog && requestedConnection == "" && requestedInstance == "" && (s.authorizer == nil || !s.authorizer.IsWorkload(p)),
+	)
 	ctx := invocation.WithAccessContext(r.Context(), s.providerAccessContext(p, name))
 	var cat *catalog.Catalog
 	var err, firstErr error
@@ -615,7 +618,7 @@ func (s *Server) executeOperation(w http.ResponseWriter, r *http.Request) {
 	if tr, ok := s.invoker.(invocation.TokenResolver); ok {
 		resolver = tr
 	}
-	boundSessionConnections, sessionInstance := s.boundSessionCatalogConnections(providerName, p, connection, instance)
+	boundSessionConnections, sessionInstance := s.orderedSessionSelectors(p, providerName, connection, instance, true)
 	opMeta, _, resolvedConnection, err := invocation.ResolveOperation(ctx, prov, providerName, resolver, p, operationName, boundSessionConnections, sessionInstance)
 	if err != nil {
 		s.writeInvocationError(w, r, providerName, operationName, err)
@@ -704,48 +707,33 @@ func (s *Server) writeInvocationError(w http.ResponseWriter, r *http.Request, pr
 	}
 }
 
-func (s *Server) boundSessionCatalogConnections(providerName string, p *principal.Principal, explicit, instance string) ([]string, string) {
-	var connections []string
-	switch {
-	case explicit != "":
-		connections = []string{config.ResolveConnectionAlias(explicit)}
-	case s.authorizer != nil && s.authorizer.IsWorkload(p):
-		connections = []string{""}
-	default:
-		preferred := s.resolvedSessionCatalogConnection(providerName, "")
-		defaultConnection := s.defaultConnection[providerName]
-		if preferred != "" {
-			connections = append(connections, preferred)
-		}
-		if defaultConnection != "" && preferred != defaultConnection && s.catalogConnection[providerName] == "" {
-			connections = append(connections, defaultConnection)
-		}
-		if len(connections) == 0 {
-			connections = []string{""}
-		}
-	}
-	boundConnections := make([]string, 0, len(connections))
-	boundInstance := instance
-	for _, connection := range connections {
-		connection, boundInstance = s.workloadBindingSelectors(p, providerName, connection, instance)
-		boundConnections = append(boundConnections, connection)
-	}
-	return boundConnections, boundInstance
-}
-
-func (s *Server) resolvedSessionCatalogConnection(providerName, explicit string) string {
-	if explicit != "" {
-		return config.ResolveConnectionAlias(explicit)
-	}
+func (s *Server) sessionCatalogPreferredConnection(providerName string) string {
 	if conn := s.catalogConnection[providerName]; conn != "" {
-		return conn
+		return config.ResolveConnectionAlias(conn)
 	}
 	if broker, ok := s.invoker.(interface{ MCPConnection(string) string }); ok {
 		if conn := broker.MCPConnection(providerName); conn != "" {
-			return conn
+			return config.ResolveConnectionAlias(conn)
 		}
 	}
 	return s.defaultConnection[providerName]
+}
+
+func (s *Server) orderedSessionSelectors(p *principal.Principal, providerName, explicitConnection, explicitInstance string, allowFallback bool) ([]string, string) {
+	bindingConnection, bindingInstance := s.workloadSessionBinding(p, providerName)
+	fallbackConnection := ""
+	if allowFallback && s.catalogConnection[providerName] == "" {
+		fallbackConnection = s.defaultConnection[providerName]
+	}
+	return invocation.OrderedSessionSelectors(
+		p,
+		explicitConnection,
+		explicitInstance,
+		s.sessionCatalogPreferredConnection(providerName),
+		fallbackConnection,
+		bindingConnection,
+		bindingInstance,
+	)
 }
 
 func httpVisibleCatalogOperations(ops []catalog.CatalogOperation) []catalog.CatalogOperation {

--- a/gestaltd/internal/server/server_test.go
+++ b/gestaltd/internal/server/server_test.go
@@ -6262,13 +6262,17 @@ func TestListOperations_UsesBrokerCatalogConnectionFallback(t *testing.T) {
 func TestListOperations_RetriesDefaultConnectionAfterBrokerCatalogError(t *testing.T) {
 	t.Parallel()
 
+	var resolvedToken atomic.Value
 	stub := &stubIntegrationWithSessionCatalog{
 		stubIntegrationWithOps: stubIntegrationWithOps{
 			StubIntegration: coretesting.StubIntegration{N: "sample-int", ConnMode: core.ConnectionModeUser},
 		},
 		catalogForRequestFn: func(_ context.Context, token string) (*catalog.Catalog, error) {
+			resolvedToken.Store(token)
 			switch token {
 			case "rest-token":
+				fallthrough
+			case "rest-team-b-token":
 				return &catalog.Catalog{
 					Name: "sample-int",
 					Operations: []catalog.CatalogOperation{
@@ -6323,6 +6327,45 @@ func TestListOperations_RetriesDefaultConnectionAfterBrokerCatalogError(t *testi
 	}
 	if len(ops) != 1 || ops[0]["id"] != "run" {
 		t.Fatalf("operations = %+v, want only run", ops)
+	}
+	if got, _ := resolvedToken.Load().(string); got != "rest-token" {
+		t.Fatalf("resolved token = %q, want %q", got, "rest-token")
+	}
+
+	seedToken(t, svc, &core.IntegrationToken{
+		ID: "tok-rest-team-b", UserID: u.ID, Integration: "sample-int",
+		Connection: "rest-conn", Instance: "team-b", AccessToken: "rest-team-b-token",
+	})
+
+	ts = newTestServer(t, func(cfg *server.Config) {
+		cfg.Providers = providers
+		cfg.Services = svc
+		cfg.Invoker = invocation.NewBroker(providers, svc.Users, svc.Tokens)
+		cfg.DefaultConnection = map[string]string{"sample-int": "rest-conn"}
+	})
+	testutil.CloseOnCleanup(t, ts)
+
+	req, _ = http.NewRequest(http.MethodGet, ts.URL+"/api/v1/integrations/sample-int/operations?_instance=team-b", nil)
+	resp, err = http.DefaultClient.Do(req)
+	if err != nil {
+		t.Fatalf("instance-only request: %v", err)
+	}
+	defer func() { _ = resp.Body.Close() }()
+
+	if resp.StatusCode != http.StatusOK {
+		body, _ := io.ReadAll(resp.Body)
+		t.Fatalf("expected 200 for instance-only discovery, got %d: %s", resp.StatusCode, body)
+	}
+
+	ops = nil
+	if err := json.NewDecoder(resp.Body).Decode(&ops); err != nil {
+		t.Fatalf("decoding instance-only response: %v", err)
+	}
+	if len(ops) != 1 || ops[0]["id"] != "run" {
+		t.Fatalf("instance-only operations = %+v, want only run", ops)
+	}
+	if got, _ := resolvedToken.Load().(string); got != "rest-team-b-token" {
+		t.Fatalf("instance-only resolved token = %q, want %q", got, "rest-team-b-token")
 	}
 }
 
@@ -8164,6 +8207,178 @@ func TestExecuteOperation_PinsSessionCatalogConnectionIntoExecution(t *testing.T
 	}
 	if gotToken != "mcp-token" {
 		t.Fatalf("execute token = %q, want %q", gotToken, "mcp-token")
+	}
+}
+
+func TestExecuteOperation_UsesBodyInstanceForSessionCatalogResolution(t *testing.T) {
+	t.Parallel()
+
+	var gotToken string
+	var gotParams map[string]any
+	sessionStub := &stubIntegrationWithSessionCatalog{
+		stubIntegrationWithOps: stubIntegrationWithOps{
+			StubIntegration: coretesting.StubIntegration{
+				N:        "sample-int",
+				ConnMode: core.ConnectionModeUser,
+				ExecuteFn: func(_ context.Context, op string, params map[string]any, token string) (*core.OperationResult, error) {
+					gotToken = token
+					gotParams = params
+					return &core.OperationResult{Status: http.StatusOK, Body: fmt.Sprintf(`{"operation":%q,"token":%q}`, op, token)}, nil
+				},
+			},
+		},
+		catalogForRequestFn: func(_ context.Context, token string) (*catalog.Catalog, error) {
+			switch token {
+			case "tenant-token":
+				return &catalog.Catalog{
+					Name: "sample-int",
+					Operations: []catalog.CatalogOperation{
+						{ID: "run", Description: "Run", Method: http.MethodPost, Transport: catalog.TransportREST},
+					},
+				}, nil
+			default:
+				return nil, fmt.Errorf("unexpected token %q", token)
+			}
+		},
+	}
+
+	svc := coretesting.NewStubServices(t)
+	u := seedUser(t, svc, "anonymous@gestalt")
+	seedToken(t, svc, &core.IntegrationToken{
+		ID: "tok-tenant", UserID: u.ID, Integration: "sample-int",
+		Connection: "catalog-conn", Instance: "tenant-a", AccessToken: "tenant-token",
+	})
+
+	ts := newTestServer(t, func(cfg *server.Config) {
+		cfg.Providers = testutil.NewProviderRegistry(t, sessionStub)
+		cfg.Services = svc
+		cfg.CatalogConnection = map[string]string{"sample-int": "catalog-conn"}
+	})
+	testutil.CloseOnCleanup(t, ts)
+
+	req, _ := http.NewRequest(http.MethodPost, ts.URL+"/api/v1/sample-int/run", bytes.NewBufferString(`{"_instance":"tenant-a","foo":"bar"}`))
+	req.Header.Set("Content-Type", "application/json")
+	resp, err := http.DefaultClient.Do(req)
+	if err != nil {
+		t.Fatalf("request: %v", err)
+	}
+	defer func() { _ = resp.Body.Close() }()
+
+	if resp.StatusCode != http.StatusOK {
+		body, _ := io.ReadAll(resp.Body)
+		t.Fatalf("expected 200, got %d: %s", resp.StatusCode, body)
+	}
+	if gotToken != "tenant-token" {
+		t.Fatalf("execute token = %q, want %q", gotToken, "tenant-token")
+	}
+	if gotParams["foo"] != "bar" {
+		t.Fatalf("expected foo=bar, got %v", gotParams["foo"])
+	}
+	if _, ok := gotParams["_instance"]; ok {
+		t.Fatalf("expected _instance to be stripped from params, got %v", gotParams["_instance"])
+	}
+}
+
+func TestExecuteOperation_IgnoresLegacySelectorParams(t *testing.T) {
+	t.Parallel()
+
+	var gotToken string
+	var gotParams map[string]any
+	sessionStub := &stubIntegrationWithSessionCatalog{
+		stubIntegrationWithOps: stubIntegrationWithOps{
+			StubIntegration: coretesting.StubIntegration{
+				N:        "sample-int",
+				ConnMode: core.ConnectionModeUser,
+				ExecuteFn: func(_ context.Context, op string, params map[string]any, token string) (*core.OperationResult, error) {
+					gotToken = token
+					gotParams = params
+					return &core.OperationResult{Status: http.StatusOK, Body: fmt.Sprintf(`{"operation":%q,"token":%q}`, op, token)}, nil
+				},
+			},
+		},
+		catalogForRequestFn: func(_ context.Context, token string) (*catalog.Catalog, error) {
+			switch token {
+			case "catalog-token", "alt-token":
+				return &catalog.Catalog{
+					Name: "sample-int",
+					Operations: []catalog.CatalogOperation{
+						{ID: "run", Description: "Run", Method: http.MethodGet, Transport: catalog.TransportREST},
+					},
+				}, nil
+			default:
+				return nil, fmt.Errorf("unexpected token %q", token)
+			}
+		},
+	}
+
+	svc := coretesting.NewStubServices(t)
+	u := seedUser(t, svc, "anonymous@gestalt")
+	seedToken(t, svc, &core.IntegrationToken{
+		ID: "tok-catalog", UserID: u.ID, Integration: "sample-int",
+		Connection: "catalog-conn", Instance: "default", AccessToken: "catalog-token",
+	})
+	seedToken(t, svc, &core.IntegrationToken{
+		ID: "tok-alt", UserID: u.ID, Integration: "sample-int",
+		Connection: "alt-conn", Instance: "tenant-a", AccessToken: "alt-token",
+	})
+
+	ts := newTestServer(t, func(cfg *server.Config) {
+		cfg.Providers = testutil.NewProviderRegistry(t, sessionStub)
+		cfg.Services = svc
+		cfg.CatalogConnection = map[string]string{"sample-int": "catalog-conn"}
+	})
+	testutil.CloseOnCleanup(t, ts)
+
+	req, _ := http.NewRequest(http.MethodGet, ts.URL+"/api/v1/sample-int/run?connection=alt-conn&instance=tenant-a&foo=bar", nil)
+	resp, err := http.DefaultClient.Do(req)
+	if err != nil {
+		t.Fatalf("request: %v", err)
+	}
+	defer func() { _ = resp.Body.Close() }()
+
+	if resp.StatusCode != http.StatusOK {
+		body, _ := io.ReadAll(resp.Body)
+		t.Fatalf("expected 200, got %d: %s", resp.StatusCode, body)
+	}
+	if gotToken != "catalog-token" {
+		t.Fatalf("execute token = %q, want %q", gotToken, "catalog-token")
+	}
+	if gotParams["connection"] != "alt-conn" {
+		t.Fatalf("expected legacy connection param to pass through, got %v", gotParams["connection"])
+	}
+	if gotParams["instance"] != "tenant-a" {
+		t.Fatalf("expected legacy instance param to pass through, got %v", gotParams["instance"])
+	}
+	if gotParams["foo"] != "bar" {
+		t.Fatalf("expected foo=bar, got %v", gotParams["foo"])
+	}
+
+	gotToken = ""
+	gotParams = nil
+
+	req, _ = http.NewRequest(http.MethodPost, ts.URL+"/api/v1/sample-int/run?connection=alt-conn&instance=tenant-a", bytes.NewBufferString(`{"foo":"bar"}`))
+	req.Header.Set("Content-Type", "application/json")
+	resp, err = http.DefaultClient.Do(req)
+	if err != nil {
+		t.Fatalf("post request: %v", err)
+	}
+	defer func(body io.ReadCloser) { _ = body.Close() }(resp.Body)
+
+	if resp.StatusCode != http.StatusOK {
+		body, _ := io.ReadAll(resp.Body)
+		t.Fatalf("expected 200 for POST, got %d: %s", resp.StatusCode, body)
+	}
+	if gotToken != "catalog-token" {
+		t.Fatalf("post execute token = %q, want %q", gotToken, "catalog-token")
+	}
+	if gotParams["foo"] != "bar" {
+		t.Fatalf("expected post foo=bar, got %v", gotParams["foo"])
+	}
+	if _, ok := gotParams["connection"]; ok {
+		t.Fatalf("expected post legacy connection query param to be ignored, got %v", gotParams["connection"])
+	}
+	if _, ok := gotParams["instance"]; ok {
+		t.Fatalf("expected post legacy instance query param to be ignored, got %v", gotParams["instance"])
 	}
 }
 


### PR DESCRIPTION
## Summary
Centralize session-catalog connection and instance selection into one invocation helper, then make HTTP discovery, HTTP execution, broker resolution, and MCP token selection all use the same precedence rules.

Diff vs `codex/core-oauth-provider-inline`:
- non-test: `+81 / -88` net `-7`
- test: `+215 / -0` net `+215`

The test-only growth includes the HTTP contract coverage moved over from superseded `#1073`, so the behavior stays pinned on the cleaner shared-selector primitive branch instead of a separate extraction layer.

## Go Interface
```go
connections, instance := invocation.OrderedSessionSelectors(
    p,
    explicitConnection,
    explicitInstance,
    preferredConnection,
    fallbackConnection,
    bindingConnection,
    bindingInstance,
)
```

Example call site:
```go
connections, instance := invocation.OrderedSessionSelectors(
    p,
    connection,
    instance,
    s.sessionCatalogPreferredConnection(providerName),
    s.defaultConnection[providerName],
    bindingConnection,
    bindingInstance,
)
```

## YAML Surface
No new YAML surface was added. This PR makes the existing `defaultConnection` YAML contract apply consistently to `_instance`-scoped session-catalog discovery.

```yaml
providers:
  sample-int:
    defaultConnection: rest-conn
```

Example behaviors with that config:
```yaml
# no selectors:
# catalogConnection or broker MCP mapping wins first; defaultConnection is the fallback
providers:
  sample-int:
    defaultConnection: rest-conn
```

```yaml
# _instance only:
# when no catalogConnection or broker MCP mapping exists,
# discovery still resolves against defaultConnection
providers:
  sample-int:
    defaultConnection: rest-conn
```

## What Changed
- added `invocation.OrderedSessionSelectors(...)`
- removed duplicated selector branching from:
  - `internal/server/handlers.go`
  - `internal/server/authorization.go`
  - `internal/invocation/broker.go`
  - `internal/mcp/session_tools.go`
- preserved workload binding precedence and instance binding
- preserved broker-to-default fallback for discovery
- restored `_instance`-only discovery to use `defaultConnection` when no catalog/MCP selector is configured

## Tests
Augmented existing functional/integration coverage instead of adding a new standalone unit suite.

Coverage on this branch includes:
- `_instance`-only discovery using `defaultConnection`
- execute-path pinning to the resolved session catalog connection
- POST body `_instance` participating in session-catalog resolution
- legacy `connection` / `instance` query params remaining non-selector passthroughs on HTTP execute

## Verification
```bash
golangci-lint run ./...
go test ./internal/server
go test $(go list ./... | grep -v '^github.com/valon-technologies/gestalt/server/cmd/gestaltd$')
```