### PR TITLE
core: collapse list integrations auth resolution to one pass

### DIFF
--- a/gestaltd/internal/server/handlers_tokens.go
+++ b/gestaltd/internal/server/handlers_tokens.go
@@ -174,27 +174,56 @@ func (s *Server) revokeAllAPITokens(w http.ResponseWriter, r *http.Request) {
 	writeJSON(w, http.StatusOK, map[string]any{"status": "revoked", "count": count})
 }
 
-func (s *Server) connectionInfosForPlugin(integration string, plugin *config.ProviderEntry, integrationAuthTypes []string, defaultCredentialFields []credentialFieldInfo) []connectionDefInfo {
+func (s *Server) connectionInfosForPlugin(integration string, plugin *config.ProviderEntry, integrationAuthTypes []string, defaultCredentialFields []credentialFieldInfo) ([]string, []connectionDefInfo) {
 	if plugin == nil {
-		return []connectionDefInfo{}
+		return append([]string{}, integrationAuthTypes...), []connectionDefInfo{}
 	}
-	plan, err := config.BuildStaticConnectionPlan(plugin, plugin.ManifestSpec())
+	manifestProvider := plugin.ManifestSpec()
+	plan, err := config.BuildStaticConnectionPlan(plugin, manifestProvider)
 	if err != nil {
-		return []connectionDefInfo{}
+		return integrationAuthTypes, []connectionDefInfo{}
 	}
 	names := plan.AdvertisedConnectionNames()
+	resolve := func(name string) (string, config.ConnectionDef, bool, bool) {
+		infoName, includeWithoutAuth := name, true
+		var conn config.ConnectionDef
+		var ok bool
+		if name == config.PluginConnectionName {
+			conn, ok = config.EffectivePluginConnectionDef(plugin, manifestProvider), true
+			infoName, includeWithoutAuth = config.PluginConnectionAlias, false
+		} else {
+			conn, ok = config.EffectiveNamedConnectionDef(plugin, manifestProvider, name)
+		}
+		if !ok || conn.Mode == providermanifestv1.ConnectionModeIdentity {
+			return "", config.ConnectionDef{}, false, false
+		}
+		return infoName, conn, includeWithoutAuth, true
+	}
+	if len(integrationAuthTypes) == 0 {
+		combined := make([]string, 0, 2)
+		for _, name := range names {
+			infoName, conn, _, ok := resolve(name)
+			if !ok {
+				continue
+			}
+			combined = append(combined, s.supportedConnectionAuthTypes(integration, infoName, connectionAuthTypes(conn.Auth, nil))...)
+		}
+		integrationAuthTypes = userFacingAuthTypes(combined)
+		if integrationAuthTypes == nil {
+			integrationAuthTypes = []string{}
+		}
+	}
 	infos := make([]connectionDefInfo, 0, len(names))
 	for _, name := range names {
-		conn, ok := plan.LookupConnection(name)
-		if !ok || !userFacingConnection(conn) {
+		infoName, conn, includeWithoutAuth, ok := resolve(name)
+		if !ok {
 			continue
 		}
-		if info, ok := s.connectionInfoFromAuth(integration, userFacingConnectionName(name), conn, integrationAuthTypes, defaultCredentialFields, name != config.PluginConnectionName); ok {
+		if info, ok := s.connectionInfoFromAuth(integration, infoName, conn, integrationAuthTypes, defaultCredentialFields, includeWithoutAuth); ok {
 			infos = append(infos, info)
 		}
 	}
-
-	return infos
+	return integrationAuthTypes, infos
 }
 
 func userFacingConnectionName(name string) string {
@@ -208,11 +237,7 @@ func (s *Server) populateIntegrationSettings(info *integrationInfo, prov core.Pr
 	authTypes := userFacingAuthTypes(prov.AuthTypes())
 	info.ConnectionParams = connectionParamInfosFromProvider(prov)
 	info.CredentialFields = credentialFieldInfosFromProvider(prov, authTypes)
-	info.Connections = s.connectionInfosForPlugin(info.Name, s.pluginDefs[info.Name], authTypes, info.CredentialFields)
-	info.AuthTypes = resolvedIntegrationAuthTypes(authTypes, info.Connections)
-	if len(authTypes) == 0 && len(info.AuthTypes) > 0 {
-		info.Connections = s.connectionInfosForPlugin(info.Name, s.pluginDefs[info.Name], info.AuthTypes, info.CredentialFields)
-	}
+	info.AuthTypes, info.Connections = s.connectionInfosForPlugin(info.Name, s.pluginDefs[info.Name], authTypes, info.CredentialFields)
 }
 
 func credentialFieldInfosFromProvider(prov core.Provider, authTypes []string) []credentialFieldInfo {
@@ -291,10 +316,6 @@ func (s *Server) connectionInfoFromAuth(integration, name string, conn config.Co
 	return info, true
 }
 
-func userFacingConnection(conn config.ConnectionDef) bool {
-	return conn.Mode != providermanifestv1.ConnectionModeIdentity
-}
-
 func defaultManualCredentialFieldInfos() []credentialFieldInfo {
 	return []credentialFieldInfo{{
 		Name:  "credential",
@@ -333,20 +354,6 @@ func connectionDisplayName(name, configured string) string {
 		return configured
 	}
 	return userFacingConnectionName(name)
-}
-
-func resolvedIntegrationAuthTypes(authTypes []string, connections []connectionDefInfo) []string {
-	if len(authTypes) > 0 {
-		return authTypes
-	}
-	combined := make([]string, 0, 2)
-	for _, connection := range connections {
-		combined = append(combined, connection.AuthTypes...)
-	}
-	if authTypes = userFacingAuthTypes(combined); len(authTypes) > 0 {
-		return authTypes
-	}
-	return []string{}
 }
 
 func connectionAuthTypes(auth config.ConnectionAuthDef, integrationAuthTypes []string) []string {

--- a/gestaltd/internal/server/server_test.go
+++ b/gestaltd/internal/server/server_test.go
@@ -4796,6 +4796,98 @@ func TestListIntegrations_ConnectionInfosUseResolvedConnectionDefs(t *testing.T)
 		}
 	})
 
+	t.Run("provider auth omitted still lets explicit plugin auth seed empty named connection auth", func(t *testing.T) {
+		t.Parallel()
+
+		stub := &stubNonOAuthProvider{name: "example"}
+		plugin := &config.ProviderEntry{
+			Source: config.ProviderSource{
+				Ref:     "github.com/acme/plugins/example",
+				Version: "1.0.0",
+			},
+			Auth: &config.ConnectionAuthDef{
+				Type: providermanifestv1.AuthTypeManual,
+				Credentials: []config.CredentialFieldDef{
+					{Name: "plugin_token", Label: "Plugin Token"},
+				},
+			},
+			Connections: map[string]*config.ConnectionDef{
+				"workspace": {
+					DisplayName: "Workspace Access",
+				},
+			},
+		}
+
+		ts := newTestServer(t, func(cfg *server.Config) {
+			cfg.Providers = testutil.NewProviderRegistry(t, stub)
+			cfg.PluginDefs = map[string]*config.ProviderEntry{
+				"example": plugin,
+			}
+			cfg.Services = coretesting.NewStubServices(t)
+		})
+		testutil.CloseOnCleanup(t, ts)
+
+		req, _ := http.NewRequest(http.MethodGet, ts.URL+"/api/v1/integrations", nil)
+		resp, err := http.DefaultClient.Do(req)
+		if err != nil {
+			t.Fatalf("request: %v", err)
+		}
+		defer func() { _ = resp.Body.Close() }()
+
+		if resp.StatusCode != http.StatusOK {
+			t.Fatalf("expected 200, got %d", resp.StatusCode)
+		}
+
+		type credentialField struct {
+			Name  string `json:"name"`
+			Label string `json:"label"`
+		}
+		type connectionInfo struct {
+			Name             string            `json:"name"`
+			DisplayName      string            `json:"displayName"`
+			AuthTypes        []string          `json:"authTypes"`
+			CredentialFields []credentialField `json:"credentialFields"`
+		}
+		var integrations []struct {
+			Name        string           `json:"name"`
+			AuthTypes   []string         `json:"authTypes"`
+			Connections []connectionInfo `json:"connections"`
+		}
+		if err := json.NewDecoder(resp.Body).Decode(&integrations); err != nil {
+			t.Fatalf("decoding: %v", err)
+		}
+		if len(integrations) != 1 {
+			t.Fatalf("expected 1 integration, got %d", len(integrations))
+		}
+		if !reflect.DeepEqual(integrations[0].AuthTypes, []string{"manual"}) {
+			t.Fatalf("top-level auth types = %+v, want [manual]", integrations[0].AuthTypes)
+		}
+
+		got := make(map[string]connectionInfo, len(integrations[0].Connections))
+		for _, conn := range integrations[0].Connections {
+			got[conn.Name] = conn
+		}
+		if !reflect.DeepEqual(got[config.PluginConnectionAlias].AuthTypes, []string{"manual"}) {
+			t.Fatalf("plugin connection auth types = %+v, want [manual]", got[config.PluginConnectionAlias].AuthTypes)
+		}
+		if !reflect.DeepEqual(got[config.PluginConnectionAlias].CredentialFields, []credentialField{
+			{Name: "plugin_token", Label: "Plugin Token"},
+		}) {
+			t.Fatalf("plugin connection credential fields = %+v", got[config.PluginConnectionAlias].CredentialFields)
+		}
+		if got["workspace"].DisplayName != "Workspace Access" {
+			t.Fatalf("workspace connection info = %+v", got["workspace"])
+		}
+		if !reflect.DeepEqual(got["workspace"].AuthTypes, []string{"manual"}) {
+			t.Fatalf("workspace auth types = %+v, want [manual]", got["workspace"].AuthTypes)
+		}
+		if !reflect.DeepEqual(got["workspace"].CredentialFields, []credentialField{
+			{Name: "credential", Label: "Credential"},
+		}) {
+			t.Fatalf("workspace credential fields = %+v", got["workspace"].CredentialFields)
+		}
+	})
+
 	t.Run("composite wrappers preserve API metadata", func(t *testing.T) {
 		t.Parallel()
 
@@ -4956,6 +5048,9 @@ func TestListIntegrations_ConnectionInfosUseResolvedConnectionDefs(t *testing.T)
 		}
 		if len(integrations) != 1 {
 			t.Fatalf("expected 1 integration, got %d", len(integrations))
+		}
+		if integrations[0].AuthTypes == nil {
+			t.Fatal("expected authTypes to encode as [], got null")
 		}
 		if len(integrations[0].AuthTypes) != 0 {
 			t.Fatalf("expected no auth types, got %+v", integrations[0].AuthTypes)


### PR DESCRIPTION
Go interface:
- info.AuthTypes, info.Connections = s.connectionInfosForPlugin(info.Name, s.pluginDefs[info.Name], authTypes, info.CredentialFields)

Go example:
- integrationAuthTypes, connections := s.connectionInfosForPlugin("example", plugin, prov.AuthTypes(), credentialFields)

YAML surface honored consistently:
  auth:
    type: manual
    credentials:
      - name: plugin_token
        label: Plugin Token
  connections:
    workspace:
      displayName: Workspace Access

Behavior examples:
- when provider auth is omitted, explicit plugin connection auth now seeds top-level authTypes in the same pass
- empty named connection auth now inherits those resolved authTypes without rebuilding the connection list
- oauth connection auth is still filtered out when no handler exists, and explicit no-auth connections still remain visible

This removes the list-integrations retry branch that rebuilt connection infos after the first pass inferred auth types.