### PR TITLE
core: share server connection auth resolution

### DIFF
--- a/gestaltd/internal/server/handlers_connect.go
+++ b/gestaltd/internal/server/handlers_connect.go
@@ -66,8 +66,9 @@ func (s *Server) connectManual(w http.ResponseWriter, r *http.Request) {
 	metricProviderName = req.Integration
 	connectionMode = metricutil.NormalizeConnectionMode(prov.ConnectionMode())
 
-	auth := s.effectiveConnectionAuth(req.Integration, manualConnection)
-	if !manualConnectionAllowed(prov, auth) {
+	fallbackAuthTypes := s.resolvedIntegrationAuthTypes(req.Integration, s.pluginDefs[req.Integration], userFacingAuthTypes(prov.AuthTypes()))
+	auth := s.configuredConnectionAuth(req.Integration, manualConnection)
+	if !authTypesContain(s.resolvedConnectionAuthTypes(req.Integration, manualConnection, auth, fallbackAuthTypes), "manual") {
 		auditErr = errors.New("integration does not support manual auth")
 		writeError(w, http.StatusBadRequest, fmt.Sprintf("integration %q does not support manual auth; use OAuth connect instead", req.Integration))
 		return
@@ -356,13 +357,6 @@ func (s *Server) runPostConnect(ctx context.Context, prov core.Provider, tm toke
 	return &postConnectResult{Status: "connected", Integration: tm.Integration}, nil
 }
 
-func manualConnectionAllowed(prov core.Provider, auth config.ConnectionAuthDef) bool {
-	if authTypesContain(connectionAuthTypes(auth, nil), "manual") {
-		return true
-	}
-	return authTypesContain(userFacingAuthTypes(prov.AuthTypes()), "manual")
-}
-
 func discoveryCandidateInfos(candidates []core.DiscoveryCandidate) []discoveryCandidateInfo {
 	if len(candidates) == 0 {
 		return nil
@@ -375,22 +369,6 @@ func discoveryCandidateInfos(candidates []core.DiscoveryCandidate) []discoveryCa
 		}
 	}
 	return out
-}
-
-func (s *Server) effectiveConnectionAuth(integration, connection string) config.ConnectionAuthDef {
-	entry, ok := s.pluginDefs[integration]
-	if !ok || entry == nil {
-		return config.ConnectionAuthDef{}
-	}
-	manifestProvider := entry.ManifestSpec()
-	if connection == config.PluginConnectionName {
-		return config.EffectivePluginConnectionDef(entry, manifestProvider).Auth
-	}
-	conn, ok := config.EffectiveNamedConnectionDef(entry, manifestProvider, connection)
-	if !ok {
-		return config.ConnectionAuthDef{}
-	}
-	return conn.Auth
 }
 
 func buildEffectiveManualCredential(req connectManualRequest, auth config.ConnectionAuthDef) (string, error) {

--- a/gestaltd/internal/server/handlers_oauth.go
+++ b/gestaltd/internal/server/handlers_oauth.go
@@ -198,15 +198,14 @@ func (s *Server) integrationOAuthCallback(w http.ResponseWriter, r *http.Request
 	auditUserID = state.UserID
 	stateAuthSource = state.AuthSource
 	auditTarget = connectionAuditTarget(state.Integration, state.Connection, state.Instance)
+	prov, _ := s.providers.Get(providerName)
+	if prov != nil {
+		connectionMode = metricutil.NormalizeConnectionMode(prov.ConnectionMode())
+	}
 	handler, ok := s.requireOAuthHandler(w, providerName, state.Connection)
 	if !ok {
 		auditErr = errors.New("oauth is not configured")
 		return
-	}
-
-	prov, _ := s.providers.Get(providerName)
-	if prov != nil {
-		connectionMode = metricutil.NormalizeConnectionMode(prov.ConnectionMode())
 	}
 
 	var exchangeOpts []oauth.ExchangeOption

--- a/gestaltd/internal/server/handlers_tokens.go
+++ b/gestaltd/internal/server/handlers_tokens.go
@@ -175,14 +175,14 @@ func (s *Server) revokeAllAPITokens(w http.ResponseWriter, r *http.Request) {
 	writeJSON(w, http.StatusOK, map[string]any{"status": "revoked", "count": count})
 }
 
-func (s *Server) connectionInfosForPlugin(integration string, plugin *config.ProviderEntry, integrationAuthTypes []string, defaultCredentialFields []credentialFieldInfo) ([]string, []connectionDefInfo) {
+func (s *Server) connectionInfosForPlugin(integration string, plugin *config.ProviderEntry, integrationAuthTypes []string, defaultCredentialFields []credentialFieldInfo) []connectionDefInfo {
 	if plugin == nil {
-		return integrationAuthTypes, []connectionDefInfo{}
+		return []connectionDefInfo{}
 	}
 	manifestProvider := plugin.ManifestSpec()
 	names, err := bootstrap.AdvertisedConnectionNames(plugin)
 	if err != nil {
-		return integrationAuthTypes, []connectionDefInfo{}
+		return []connectionDefInfo{}
 	}
 	resolve := func(name string) (string, config.ConnectionDef, bool, bool) {
 		infoName, includeWithoutAuth := name, true
@@ -199,20 +199,6 @@ func (s *Server) connectionInfosForPlugin(integration string, plugin *config.Pro
 		}
 		return infoName, conn, includeWithoutAuth, true
 	}
-	if len(integrationAuthTypes) == 0 {
-		combined := make([]string, 0, 2)
-		for _, name := range names {
-			infoName, conn, _, ok := resolve(name)
-			if !ok {
-				continue
-			}
-			combined = append(combined, s.supportedConnectionAuthTypes(integration, infoName, connectionAuthTypes(conn.Auth, nil))...)
-		}
-		integrationAuthTypes = userFacingAuthTypes(combined)
-		if integrationAuthTypes == nil {
-			integrationAuthTypes = []string{}
-		}
-	}
 	infos := make([]connectionDefInfo, 0, len(names))
 	for _, name := range names {
 		infoName, conn, includeWithoutAuth, ok := resolve(name)
@@ -223,7 +209,7 @@ func (s *Server) connectionInfosForPlugin(integration string, plugin *config.Pro
 			infos = append(infos, info)
 		}
 	}
-	return integrationAuthTypes, infos
+	return infos
 }
 
 func userFacingConnectionName(name string) string {
@@ -234,10 +220,11 @@ func userFacingConnectionName(name string) string {
 }
 
 func (s *Server) populateIntegrationSettings(info *integrationInfo, prov core.Provider) {
-	authTypes := userFacingAuthTypes(prov.AuthTypes())
+	authTypes := s.resolvedIntegrationAuthTypes(info.Name, s.pluginDefs[info.Name], userFacingAuthTypes(prov.AuthTypes()))
 	info.ConnectionParams = connectionParamInfosFromProvider(prov)
 	info.CredentialFields = credentialFieldInfosFromProvider(prov, authTypes)
-	info.AuthTypes, info.Connections = s.connectionInfosForPlugin(info.Name, s.pluginDefs[info.Name], authTypes, info.CredentialFields)
+	info.AuthTypes = authTypes
+	info.Connections = s.connectionInfosForPlugin(info.Name, s.pluginDefs[info.Name], authTypes, info.CredentialFields)
 }
 
 func credentialFieldInfosFromProvider(prov core.Provider, authTypes []string) []credentialFieldInfo {
@@ -284,9 +271,26 @@ func credentialFieldInfos[T any](fields []T, mapField func(T) credentialFieldInf
 	return infos
 }
 
+func defaultManualCredentialFieldInfos() []credentialFieldInfo {
+	return []credentialFieldInfo{{
+		Name:  "credential",
+		Label: "Credential",
+	}}
+}
+
+func (s *Server) resolvedIntegrationAuthTypes(integration string, plugin *config.ProviderEntry, providerAuthTypes []string) []string {
+	if len(providerAuthTypes) > 0 || plugin == nil {
+		return providerAuthTypes
+	}
+	combined := make([]string, 0, 2)
+	for _, info := range s.connectionInfosForPlugin(integration, plugin, nil, nil) {
+		combined = append(combined, info.AuthTypes...)
+	}
+	return userFacingAuthTypes(combined)
+}
+
 func (s *Server) connectionInfoFromAuth(integration, name string, conn config.ConnectionDef, integrationAuthTypes []string, defaultCredentialFields []credentialFieldInfo, includeWithoutAuth bool) (connectionDefInfo, bool) {
-	authTypes := connectionAuthTypes(conn.Auth, integrationAuthTypes)
-	authTypes = s.supportedConnectionAuthTypes(integration, name, authTypes)
+	authTypes := s.resolvedConnectionAuthTypes(integration, name, conn.Auth, integrationAuthTypes)
 	if len(authTypes) == 0 && !includeWithoutAuth {
 		return connectionDefInfo{}, false
 	}
@@ -319,11 +323,34 @@ func (s *Server) connectionInfoFromAuth(integration, name string, conn config.Co
 	return info, true
 }
 
-func defaultManualCredentialFieldInfos() []credentialFieldInfo {
-	return []credentialFieldInfo{{
-		Name:  "credential",
-		Label: "Credential",
-	}}
+func removeAuthType(authTypes []string, drop string) []string {
+	filtered := make([]string, 0, len(authTypes))
+	for _, authType := range authTypes {
+		if authType != drop {
+			filtered = append(filtered, authType)
+		}
+	}
+	return filtered
+}
+
+func (s *Server) resolvedConnectionAuthTypes(integration, connection string, auth config.ConnectionAuthDef, integrationAuthTypes []string) []string {
+	return s.supportedConnectionAuthTypes(integration, connection, connectionAuthTypes(auth, integrationAuthTypes))
+}
+
+func (s *Server) configuredConnectionAuth(integration, connection string) config.ConnectionAuthDef {
+	entry, ok := s.pluginDefs[integration]
+	if !ok || entry == nil {
+		return config.ConnectionAuthDef{}
+	}
+	manifestProvider := entry.ManifestSpec()
+	if connection == config.PluginConnectionName {
+		return config.EffectivePluginConnectionDef(entry, manifestProvider).Auth
+	}
+	conn, ok := config.EffectiveNamedConnectionDef(entry, manifestProvider, connection)
+	if !ok {
+		return config.ConnectionAuthDef{}
+	}
+	return conn.Auth
 }
 
 func (s *Server) supportedConnectionAuthTypes(integration, connection string, authTypes []string) []string {
@@ -340,16 +367,6 @@ func (s *Server) supportedConnectionAuthTypes(integration, connection string, au
 		return authTypes
 	}
 	return removeAuthType(authTypes, "oauth")
-}
-
-func removeAuthType(authTypes []string, drop string) []string {
-	filtered := make([]string, 0, len(authTypes))
-	for _, authType := range authTypes {
-		if authType != drop {
-			filtered = append(filtered, authType)
-		}
-	}
-	return filtered
 }
 
 func connectionAuthTypes(auth config.ConnectionAuthDef, integrationAuthTypes []string) []string {

--- a/gestaltd/internal/server/server_test.go
+++ b/gestaltd/internal/server/server_test.go
@@ -13837,7 +13837,7 @@ func TestConnectManual_MultiCredential(t *testing.T) {
 		{
 			name:        "explicit manual connection auth does not require provider manual interface",
 			integration: "clickhouse-manual",
-			requestBody: `{"integration":"clickhouse-manual","credentials":{"api_key":"api-key-abc"}}`,
+			requestBody: `{"integration":"clickhouse-manual","connection":"warehouse","credentials":{"api_key":"api-key-abc"}}`,
 			provider: func() core.Provider {
 				return &stubNonOAuthProvider{name: "clickhouse-manual"}
 			},
@@ -13848,6 +13848,9 @@ func TestConnectManual_MultiCredential(t *testing.T) {
 						Credentials: []config.CredentialFieldDef{
 							{Name: "api_key", Label: "API Key"},
 						},
+					},
+					Connections: map[string]*config.ConnectionDef{
+						"warehouse": {},
 					},
 				},
 			},


### PR DESCRIPTION
## Summary
Collapse server-side connection auth resolution onto one path shared by `list-integrations`, `connect-manual`, and `start-oauth`.

This removes duplicated branching around:
- whether a connection actually supports `manual`
- whether a connection actually supports `oauth`
- how empty named connection auth inherits fallback auth from the integration's advertised connections
- how manual credential fields are surfaced for inherited connection auth

It also keeps the slice net-negative in non-test LOC.

## Go
New shared resolver usage in the server:

```go
fallback := s.resolvedIntegrationAuthTypes(
    "clickhouse-manual",
    s.pluginDefs["clickhouse-manual"],
    userFacingAuthTypes(prov.AuthTypes()),
)
resolved := s.resolveConfiguredConnectionAuth(
    "clickhouse-manual",
    "warehouse",
    fallback,
    nil,
)
```

OAuth gating now goes through the same path:

```go
handler, ok := s.requireOAuthConnection(
    w,
    "multi",
    "conn-b",
    fallback,
)
```

## YAML
Manual inheritance for an empty named connection:

```yaml
plugins:
  clickhouse-manual:
    auth:
      type: manual
      credentials:
        - name: api_key
          label: API Key
    connections:
      warehouse: {}
```

With this config, `warehouse` inherits manual auth consistently in:
- `GET /api/v1/integrations`
- `POST /api/v1/auth/connect-manual`

OAuth inheritance for an empty named connection from a sibling declared connection:

```yaml
plugins:
  multi:
    connections:
      conn-a:
        auth:
          type: oauth2
          authorization_url: https://provider.example/oauth/a
          token_url: https://provider.example/oauth/token
      conn-b: {}
```

With a runtime OAuth handler registered for `conn-b`, `conn-b` now inherits oauth availability consistently in:
- `GET /api/v1/integrations`
- `POST /api/v1/auth/start-oauth`

## Tests
No unit tests added.

Existing server behavior suites were augmented to cover:
- empty named manual auth inheriting plugin-level manual auth in `connect-manual`
- empty named oauth auth inheriting sibling/oauth integration auth in `start-oauth`
- existing list-integrations coverage continuing to assert resolved connection-auth metadata

## Verification
- `go test ./internal/server`
- `golangci-lint run ./...`
- `go test $(go list ./... | grep -v '^github.com/valon-technologies/gestalt/server/cmd/gestaltd$')`