### PR TITLE
sdk/typescript: align plugin invoker validation order

### DIFF
--- a/sdk/typescript/src/invoker.ts
+++ b/sdk/typescript/src/invoker.ts
@@ -21,12 +21,13 @@ export class PluginInvoker {
   constructor(request: Request);
   constructor(requestHandle: string);
   constructor(requestOrHandle: Request | string) {
+    this.requestHandle = normalizeRequestHandle(requestOrHandle);
+
     const socketPath = process.env[ENV_PLUGIN_INVOKER_SOCKET];
     if (!socketPath) {
       throw new Error(`plugin invoker: ${ENV_PLUGIN_INVOKER_SOCKET} is not set`);
     }
 
-    this.requestHandle = normalizeRequestHandle(requestOrHandle);
     const transport = createGrpcTransport({
       baseUrl: "http://localhost",
       nodeOptions: {
@@ -64,7 +65,7 @@ function normalizeRequestHandle(requestOrHandle: Request | string): string {
       : requestOrHandle.requestHandle;
   const trimmed = requestHandle.trim();
   if (!trimmed) {
-    throw new Error("plugin invoker: request handle is required");
+    throw new Error("plugin invoker: request handle is not available");
   }
   return trimmed;
 }

--- a/sdk/typescript/tests/invoker.transport.test.ts
+++ b/sdk/typescript/tests/invoker.transport.test.ts
@@ -162,3 +162,20 @@ test("PluginInvoker forwards request handles from strings and Request objects", 
     removeTempDir(tempDir);
   }
 });
+
+test("PluginInvoker prioritizes request-handle validation over socket configuration", () => {
+  const previousSocket = process.env[ENV_PLUGIN_INVOKER_SOCKET];
+
+  try {
+    delete process.env[ENV_PLUGIN_INVOKER_SOCKET];
+    expect(() => new PluginInvoker("   ")).toThrow(
+      "plugin invoker: request handle is not available",
+    );
+  } finally {
+    if (previousSocket === undefined) {
+      delete process.env[ENV_PLUGIN_INVOKER_SOCKET];
+    } else {
+      process.env[ENV_PLUGIN_INVOKER_SOCKET] = previousSocket;
+    }
+  }
+});


### PR DESCRIPTION
Follow-up to #1027.

Go interface:
- No Go interface changes.

YAML interface:
- No YAML interface changes.

TypeScript interface:
- `PluginInvoker(request | requestHandle)` now validates the request handle before reading `GESTALT_PLUGIN_INVOKER_SOCKET`, matching the Python and Rust SDKs.
- Blank request handles now raise `plugin invoker: request handle is not available`.

TypeScript examples:
```ts
new PluginInvoker("   ");
// throws: plugin invoker: request handle is not available
```

```ts
process.env.GESTALT_PLUGIN_INVOKER_SOCKET = "/tmp/plugin-invoker.sock";
const invoker = new PluginInvoker("req-123");
await invoker.invoke("github", "get_issue", { issue_number: 42 });
```

Verification:
- `bun test tests/invoker.transport.test.ts`
- `bun run typecheck`