### PR TITLE
[codex] Fix CLI login callback state validation

### DIFF
--- a/gestaltd/internal/server/handlers_auth.go
+++ b/gestaltd/internal/server/handlers_auth.go
@@ -9,6 +9,7 @@ import (
 	"net/http"
 	"net/url"
 	stdpath "path"
+	"strconv"
 	"strings"
 	"time"
 
@@ -481,10 +482,39 @@ func (s *Server) validateLoginState(r *http.Request, originalState string) (*log
 	if err != nil {
 		return nil, fmt.Errorf("invalid login state cookie: %w", err)
 	}
-	if expected.State != originalState {
+	if !loginStatesMatch(expected.State, originalState) {
 		return nil, fmt.Errorf("login state mismatch")
 	}
 	return expected, nil
+}
+
+func loginStatesMatch(expectedState, originalState string) bool {
+	if expectedState == originalState {
+		return true
+	}
+	if rawState, ok := stripCLIStatePrefix(expectedState); ok && rawState == originalState {
+		return true
+	}
+	if rawState, ok := stripCLIStatePrefix(originalState); ok && rawState == expectedState {
+		return true
+	}
+	return false
+}
+
+func stripCLIStatePrefix(state string) (string, bool) {
+	if !strings.HasPrefix(state, cliStatePrefix) {
+		return "", false
+	}
+	rest := strings.TrimPrefix(state, cliStatePrefix)
+	portText, rawState, ok := strings.Cut(rest, ":")
+	if !ok || portText == "" || rawState == "" {
+		return "", false
+	}
+	port, err := strconv.Atoi(portText)
+	if err != nil || port < 1 || port > maxPort {
+		return "", false
+	}
+	return rawState, true
 }
 
 func (s *Server) clearLoginStateCookie(w http.ResponseWriter) {

--- a/gestaltd/internal/server/server_test.go
+++ b/gestaltd/internal/server/server_test.go
@@ -8620,6 +8620,57 @@ func TestLoginCallbackForCLI(t *testing.T) {
 	}
 }
 
+func TestLoginCallbackForCLIWithCallbackPortStrippedState(t *testing.T) {
+	t.Parallel()
+
+	svc := coretesting.NewStubServices(t)
+	u := seedUser(t, svc, "host@example.com")
+	ts := newTestServer(t, func(cfg *server.Config) {
+		cfg.Auth = &stubHostIssuedSessionAuth{secret: []byte("host-issued-secret")}
+		cfg.Services = svc
+	})
+	testutil.CloseOnCleanup(t, ts)
+
+	jar, _ := cookiejar.New(nil)
+	client := &http.Client{Jar: jar}
+
+	body := bytes.NewBufferString(`{"state":"test-state","callbackPort":54305}`)
+	loginResp, err := client.Post(ts.URL+"/api/v1/auth/login", "application/json", body)
+	if err != nil {
+		t.Fatalf("start login: %v", err)
+	}
+	_ = loginResp.Body.Close()
+
+	resp, err := client.Get(ts.URL + "/api/v1/auth/login/callback?code=good-code&state=test-state&cli=1")
+	if err != nil {
+		t.Fatalf("request: %v", err)
+	}
+	defer func() { _ = resp.Body.Close() }()
+
+	if resp.StatusCode != http.StatusOK {
+		t.Fatalf("expected 200, got %d", resp.StatusCode)
+	}
+
+	var result map[string]any
+	if err := json.NewDecoder(resp.Body).Decode(&result); err != nil {
+		t.Fatalf("decoding: %v", err)
+	}
+	if result["id"] == "" {
+		t.Fatal("expected id in CLI login response")
+	}
+	if result["token"] == "" {
+		t.Fatal("expected token in CLI login response")
+	}
+
+	tokens, err := svc.APITokens.ListAPITokens(context.Background(), u.ID)
+	if err != nil {
+		t.Fatalf("list api tokens: %v", err)
+	}
+	if len(tokens) == 0 {
+		t.Fatal("expected API token to be stored")
+	}
+}
+
 func TestLoginCallbackStateMismatch(t *testing.T) {
 	t.Parallel()
 


### PR DESCRIPTION
## What changed
- allow login state validation to treat `cli:<port>:<state>` and the stripped `<state>` as equivalent for CLI login callbacks
- add a regression test covering the browser bridge flow where `/auth/callback` redirects the browser to the local CLI listener with the stripped state

## Why
CLI login was failing after the browser flow completed. The browser-facing callback page unwraps the CLI state and redirects to `127.0.0.1:<port>` using the bare state value, but the server still validated the encrypted `login_state` cookie against the full prefixed value.

## Root cause
The login start path stores `cli:<port>:<state>` in the login-state cookie for CLI flows. Later, the browser callback bridge strips the `cli:<port>:` prefix before the CLI sends the final `GET /api/v1/auth/login/callback?...&cli=1` exchange. The callback handler compared those values literally and rejected the request with `403 login state validation failed`.

## Impact
- restores `gestalt auth login` for deployments that use the browser callback bridge at `/auth/callback`
- keeps normal state validation intact while explicitly handling the CLI-prefixed form

## Validation
- `go test ./internal/server -run 'TestLoginCallbackForCLI|TestLoginCallbackForCLIWithCallbackPortStrippedState|TestLoginCallbackStateMismatch'`
