### PR TITLE
sdk/typescript: drop plugin wrapper aliases

### DIFF
--- a/sdk/typescript/src/build.ts
+++ b/sdk/typescript/src/build.ts
@@ -82,11 +82,6 @@ export function buildProviderBinary(args: BuildArgs): void {
 }
 
 /**
- * Plugin-specific alias for provider builds.
- */
-export const buildPluginBinary = buildProviderBinary;
-
-/**
  * Constructs the Bun command used to compile a provider binary.
  */
 export function bunBuildCommand(

--- a/sdk/typescript/src/index.ts
+++ b/sdk/typescript/src/index.ts
@@ -54,7 +54,6 @@ export {
   type CatalogSchema,
 } from "./catalog.ts";
 export {
-  buildPluginBinary,
   buildProviderBinary,
   bunBuildCommand,
   bunTarget,
@@ -91,7 +90,7 @@ export {
   type SecretsProviderOptions,
 } from "./secrets.ts";
 export {
-  Plugin,
+  PluginProvider,
   connectionModeToProtoValue,
   connectionParamToProto,
   definePlugin,
@@ -140,30 +139,21 @@ export {
   createSecretsService,
   createProviderService,
   createRuntimeService,
-  loadPluginFromTarget,
   loadProviderFromTarget,
   main as runtimeMain,
   parseRuntimeArgs,
-  pluginCatalogYaml,
-  runBundledPlugin,
   runBundledProvider,
-  runLoadedPlugin,
   runLoadedProvider,
   serve,
 } from "./runtime.ts";
 export {
-  defaultPluginName,
   defaultProviderName,
   formatModuleTarget,
   formatProviderTarget,
   parseModuleTarget,
-  parsePluginTarget,
   parseProviderTarget,
   readPackageConfig,
-  readPackagePluginTarget,
   readPackageProviderTarget,
-  resolvePluginImportUrl,
-  resolvePluginModulePath,
   resolveProviderImportUrl,
   resolveProviderModulePath,
   type ModuleTarget,

--- a/sdk/typescript/src/plugin.ts
+++ b/sdk/typescript/src/plugin.ts
@@ -299,11 +299,6 @@ export class PluginProvider extends RuntimeProvider {
 }
 
 /**
- * Plugin provider implementation consumed by the Gestalt runtime.
- */
-export const Plugin = PluginProvider;
-
-/**
  * Creates a plugin provider.
  */
 export function definePlugin(

--- a/sdk/typescript/src/runtime.ts
+++ b/sdk/typescript/src/runtime.ts
@@ -253,20 +253,6 @@ export async function loadProviderFromTarget(
 }
 
 /**
- * Loads a plugin provider from a package root and optional target.
- */
-export async function loadPluginFromTarget(
-  root: string,
-  rawTarget?: string,
-): Promise<PluginProvider> {
-  const provider = await loadProviderFromTarget(root, rawTarget);
-  if (!isPluginProvider(provider)) {
-    throw new Error("target did not resolve to a plugin provider");
-  }
-  return provider;
-}
-
-/**
  * Runs a provider that has already been loaded into memory.
  */
 export async function runLoadedProvider(
@@ -289,34 +275,11 @@ export async function runLoadedProvider(
         "static catalog generation is only supported for plugin providers",
       );
     }
-    writeFileSync(catalogPath, pluginCatalogYaml(provider), "utf8");
+    writeFileSync(catalogPath, catalogToYaml(provider.staticCatalog()), "utf8");
     return;
   }
 
   await serve(provider);
-}
-
-/**
- * Runs a plugin provider that has already been loaded into memory.
- */
-export async function runLoadedPlugin(
-  plugin: PluginProvider,
-  options: {
-    root?: string;
-    pluginName?: string;
-  } = {},
-): Promise<void> {
-  const runtimeOptions: {
-    root?: string;
-    providerName?: string;
-  } = {};
-  if (options.root !== undefined) {
-    runtimeOptions.root = options.root;
-  }
-  if (options.pluginName !== undefined) {
-    runtimeOptions.providerName = options.pluginName;
-  }
-  await runLoadedProvider(plugin, runtimeOptions);
 }
 
 /**
@@ -330,16 +293,6 @@ export async function runBundledProvider(
   await runLoadedProvider(resolveLoadedProvider(provider, kind, "bundled target"), {
     providerName,
   });
-}
-
-/**
- * Runs a bundled plugin provider export.
- */
-export async function runBundledPlugin(
-  plugin: unknown,
-  pluginName: string,
-): Promise<void> {
-  await runBundledProvider(plugin, "integration", pluginName);
 }
 
 /**
@@ -476,8 +429,11 @@ export function createRuntimeService(
  * @internal
  */
 export function createProviderService(
-  provider: PluginProvider,
+  provider: LoadedProvider,
 ): Partial<ServiceImpl<typeof IntegrationProviderService>> {
+  if (!isPluginProvider(provider)) {
+    throw new Error("provider is not a plugin provider");
+  }
   return {
     getMetadata() {
       return create(ProviderMetadataSchema, {
@@ -726,13 +682,6 @@ export function createSecretsService(
       });
     },
   };
-}
-
-/**
- * Serializes a plugin provider's static catalog as YAML.
- */
-export function pluginCatalogYaml(plugin: PluginProvider): string {
-  return catalogToYaml(plugin.staticCatalog());
 }
 
 function providerRequest(

--- a/sdk/typescript/src/target.ts
+++ b/sdk/typescript/src/target.ts
@@ -87,11 +87,6 @@ export function parseProviderTarget(
 }
 
 /**
- * Parses a plugin module target in the form `./file.ts#namedExport`.
- */
-export const parsePluginTarget = parseModuleTarget;
-
-/**
  * Reads the Gestalt-specific provider metadata from a package directory.
  */
 export function readPackageConfig(root: string): PackageConfig {
@@ -129,28 +124,12 @@ export function readPackageProviderTarget(root: string): ProviderTarget {
 }
 
 /**
- * Reads the plugin-provider target from `package.json`.
- */
-export function readPackagePluginTarget(root: string): string {
-  const target = readPackageProviderTarget(root);
-  if (target.kind !== "integration") {
-    throw new Error(`package.json provider kind ${JSON.stringify(target.kind)} is not a plugin provider`);
-  }
-  return formatModuleTarget(target);
-}
-
-/**
  * Computes a default provider slug from the package name.
  */
 export function defaultProviderName(root: string): string {
   const config = readPackageConfig(root);
   return slugName(config.name ?? "");
 }
-
-/**
- * Computes a default plugin slug from the package name.
- */
-export const defaultPluginName = defaultProviderName;
 
 /**
  * Resolves a provider target to an absolute file path.
@@ -164,21 +143,11 @@ export function resolveProviderModulePath(root: string, target: ProviderTarget |
 }
 
 /**
- * Resolves a plugin target to an absolute file path.
- */
-export const resolvePluginModulePath = resolveProviderModulePath;
-
-/**
  * Resolves a provider target to an importable file URL.
  */
 export function resolveProviderImportUrl(root: string, target: ProviderTarget | ModuleTarget): string {
   return pathToFileURL(resolveProviderModulePath(root, target)).href;
 }
-
-/**
- * Resolves a plugin target to an importable file URL.
- */
-export const resolvePluginImportUrl = resolveProviderImportUrl;
 
 /**
  * Formats a provider target using the public `kind:./path#export` syntax.

--- a/sdk/typescript/tests/runtime.test.ts
+++ b/sdk/typescript/tests/runtime.test.ts
@@ -47,7 +47,6 @@ import {
   createAuthService,
   createProviderService,
   createRuntimeService,
-  loadPluginFromTarget,
   loadProviderFromTarget,
   main,
   parseRuntimeArgs,
@@ -115,8 +114,8 @@ test("loadProviderFromTarget resolves a secrets provider from package metadata",
   expect(provider.displayName).toBe("Fixture Secrets");
 });
 
-test("loadPluginFromTarget falls through null exports to the next plugin candidate", async () => {
-  const plugin = await loadPluginFromTarget(
+test("loadProviderFromTarget falls through null exports to the next plugin candidate", async () => {
+  const plugin = await loadProviderFromTarget(
     fixturePath("basic-provider-null-export"),
   );
   expect(plugin.kind).toBe("integration");
@@ -124,8 +123,8 @@ test("loadPluginFromTarget falls through null exports to the next plugin candida
   expect(plugin.displayName).toBe("Fixture Provider Null Export");
 });
 
-test("loadPluginFromTarget ignores whitespace-only explicit targets", async () => {
-  const plugin = await loadPluginFromTarget(
+test("loadProviderFromTarget ignores whitespace-only explicit targets", async () => {
+  const plugin = await loadProviderFromTarget(
     fixturePath("basic-provider"),
     "   ",
   );
@@ -258,7 +257,7 @@ test("runtime serves a secrets provider over unix gRPC", async () => {
 }, 15_000);
 
 test("integration provider service exposes metadata, configure, execute, and session catalog", async () => {
-  const plugin = await loadPluginFromTarget(fixturePath("basic-provider"));
+  const plugin = await loadProviderFromTarget(fixturePath("basic-provider"));
   const service = createProviderService(plugin);
 
   const metadata = await (service.getMetadata as any)();

--- a/sdk/typescript/tests/schema.test.ts
+++ b/sdk/typescript/tests/schema.test.ts
@@ -1,6 +1,6 @@
 import { expect, test } from "bun:test";
 
-import { array } from "../src/index.ts";
+import { array, definePlugin, PluginProvider } from "../src/index.ts";
 import { s } from "../src/schema.ts";
 
 test("schema parses defaults and optional fields", () => {
@@ -47,4 +47,18 @@ test("number schema accepts full finite numeric strings", () => {
 
 test("schema builders are exported from the package entrypoint", () => {
   expect(array(s.integer()).parse(["1", 2], "$")).toEqual([1, 2]);
+
+  const plugin = definePlugin({
+    operations: [
+      {
+        id: "ping",
+        handler() {
+          return {
+            ok: true,
+          };
+        },
+      },
+    ],
+  });
+  expect(plugin).toBeInstanceOf(PluginProvider);
 });

--- a/sdk/typescript/tests/target.test.ts
+++ b/sdk/typescript/tests/target.test.ts
@@ -6,7 +6,6 @@ import {
   parseModuleTarget,
   parseProviderTarget,
   readPackageConfig,
-  readPackagePluginTarget,
   readPackageProviderTarget,
   resolveProviderModulePath,
 } from "../src/target.ts";
@@ -73,7 +72,6 @@ test("package config reads provider targets", () => {
   expect(formatProviderTarget(readPackageProviderTarget(pluginRoot))).toBe(
     "plugin:./provider.ts#plugin",
   );
-  expect(readPackagePluginTarget(pluginRoot)).toBe("./provider.ts#plugin");
   expect(defaultProviderName(pluginRoot)).toBe("basic-provider");
   expect(
     resolveProviderModulePath(pluginRoot, readPackageProviderTarget(pluginRoot)),


### PR DESCRIPTION
## Summary
Removes plugin-specific wrapper exports that only duplicated the generic provider APIs in the TypeScript SDK. Runtime and test callers now use the provider surface directly instead of carrying parallel plugin aliases.

## Go interface
No change.

## YAML interface
No change.

## TypeScript interface
Removed:
- `buildPluginBinary`
- `Plugin`
- `loadPluginFromTarget`
- `pluginCatalogYaml`
- `runBundledPlugin`
- `runLoadedPlugin`
- `defaultPluginName`
- `parsePluginTarget`
- `readPackagePluginTarget`
- `resolvePluginImportUrl`
- `resolvePluginModulePath`

Use instead:
- `buildProviderBinary(...)`
- `PluginProvider` or `definePlugin(...)`
- `loadProviderFromTarget(root, target?)`
- `runBundledProvider(candidate, "integration", "example-provider")`
- `runLoadedProvider(provider, { root, providerName })`
- `defaultProviderName(root)`
- `parseProviderTarget(...)`
- `resolveProviderImportUrl(...)`
- `resolveProviderModulePath(...)`

## Examples
```ts
import {
  PluginProvider,
  buildProviderBinary,
  definePlugin,
  loadProviderFromTarget,
  runBundledProvider,
} from "@valon-technologies/gestalt";

export const plugin = definePlugin({
  operations: [
    {
      id: "ping",
      handler() {
        return { ok: true };
      },
    },
  ],
});

const alsoPlugin = new PluginProvider({
  operations: [
    {
      id: "pong",
      handler() {
        return { ok: true };
      },
    },
  ],
});

buildProviderBinary({
  root,
  target: "plugin:./provider.ts#plugin",
  outputPath,
  providerName: "example-provider",
  goos: "linux",
  goarch: "amd64",
});

const provider = await loadProviderFromTarget(root);
await runBundledProvider(provider, "integration", "example-provider");
```

```json
{
  "gestalt": {
    "provider": {
      "kind": "plugin",
      "target": "./provider.ts#plugin"
    }
  }
}
```

## Validation
Passed:
- `bun test tests/schema.test.ts tests/runtime.test.ts tests/target.test.ts`
- `bun test tests/s3.transport.test.ts`
- `bunx tsc --noEmit`

Attempted:
- `bun run check`
  - still hits the existing full-suite `tests/s3.transport.test.ts` flake (`copy, delete, exists, and presign round-trip` and `partial stream consumption can be cancelled by the caller`), while that file passes in isolation on this branch
