### PR TITLE
sdk/typescript: reject unsupported telemetry provider targets early

### DIFF
--- a/gestaltd/internal/config/config_test.go
+++ b/gestaltd/internal/config/config_test.go
@@ -2424,6 +2424,17 @@ plugins:
 			wantErr: "source.version is required when source.ref is set",
 		},
 		{
+			name: "telemetry source provider is rejected early",
+			yaml: `
+providers:
+  telemetry:
+    custom:
+      source:
+        path: ./providers/telemetry
+`,
+			wantErr: "does not support source.path or source.ref",
+		},
+		{
 			name: "non-default connection params are accepted",
 			yaml: `
 providers:

--- a/gestaltd/internal/config/config_validate.go
+++ b/gestaltd/internal/config/config_validate.go
@@ -151,11 +151,19 @@ func validateHostProviderEntries(kind HostProviderKind, entries map[string]*Prov
 			if err := validateProviderEntrySource("auth", name, entry); err != nil {
 				return err
 			}
-		case HostProviderKindSecrets, HostProviderKindTelemetry:
+		case HostProviderKindSecrets:
 			if !entry.Source.IsBuiltin() {
 				if err := validateProviderEntrySource(string(kind), name, entry); err != nil {
 					return err
 				}
+			}
+		case HostProviderKindTelemetry:
+			switch {
+			case entry.Source.IsBuiltin():
+			case entry.Source.IsLocal() || entry.Source.IsManaged():
+				return fmt.Errorf("config validation: telemetry provider %q does not support source.path or source.ref; use a builtin provider name or omit telemetry", name)
+			default:
+				return fmt.Errorf("config validation: telemetry provider %q source is required", name)
 			}
 		case HostProviderKindAudit:
 			if entry.Source.IsBuiltin() {

--- a/gestaltd/internal/providerpkg/typescript_provider.go
+++ b/gestaltd/internal/providerpkg/typescript_provider.go
@@ -305,8 +305,6 @@ func normalizeTypeScriptProviderKind(value string) string {
 		return "s3"
 	case "secrets":
 		return "secrets"
-	case "telemetry":
-		return "telemetry"
 	default:
 		return ""
 	}

--- a/gestaltd/internal/providerpkg/typescript_provider_test.go
+++ b/gestaltd/internal/providerpkg/typescript_provider_test.go
@@ -175,6 +175,24 @@ func TestDetectTypeScriptProviderTarget_RejectsLegacyIntegrationPrefix(t *testin
 	}
 }
 
+func TestDetectTypeScriptProviderTarget_RejectsTelemetryPrefix(t *testing.T) {
+	t.Parallel()
+
+	root := t.TempDir()
+	mustWriteTypeScriptPackageConfig(t, root, map[string]string{
+		typeScriptProviderKey: "telemetry:./provider.ts#plugin",
+	})
+	mustWriteTypeScriptTargetModule(t, root, typeScriptTestPluginTarget)
+
+	_, err := DetectTypeScriptProviderTarget(root)
+	if err == nil {
+		t.Fatal("expected unsupported TypeScript provider kind error")
+	}
+	if want := `unsupported provider kind "telemetry"`; !containsString(err.Error(), want) {
+		t.Fatalf("error = %q, want mention of %q", err, want)
+	}
+}
+
 func TestDetectTypeScriptProviderTarget_ObjectConfig(t *testing.T) {
 	t.Parallel()
 
@@ -197,6 +215,31 @@ func TestDetectTypeScriptProviderTarget_ObjectConfig(t *testing.T) {
 	}
 	if got != typeScriptTestPluginTarget {
 		t.Fatalf("target = %q, want %q", got, typeScriptTestPluginTarget)
+	}
+}
+
+func TestDetectTypeScriptProviderTarget_ObjectConfigRejectsTelemetryKind(t *testing.T) {
+	t.Parallel()
+
+	root := t.TempDir()
+	mustWriteFile(t, filepath.Join(root, typeScriptProjectFile), []byte(`{
+  "name": "ts-release",
+  "version": "0.0.1",
+  "gestalt": {
+    "provider": {
+      "kind": "telemetry",
+      "target": "./provider.ts#plugin"
+    }
+  }
+}`), 0o644)
+	mustWriteTypeScriptTargetModule(t, root, typeScriptTestPluginTarget)
+
+	_, err := DetectTypeScriptProviderTarget(root)
+	if err == nil {
+		t.Fatal("expected unsupported TypeScript provider kind error")
+	}
+	if want := `unsupported provider kind "telemetry"`; !containsString(err.Error(), want) {
+		t.Fatalf("error = %q, want mention of %q", err, want)
 	}
 }
 
@@ -631,7 +674,7 @@ func mustWriteTypeScriptTargetModule(t *testing.T, root, target string) {
 
 func runtimeTargetModulePath(t *testing.T, target string) string {
 	t.Helper()
-	for _, prefix := range []string{"plugin:", "auth:", "cache:", "indexeddb:", "secrets:", "telemetry:"} {
+	for _, prefix := range []string{"plugin:", "auth:", "cache:", "indexeddb:", "secrets:"} {
 		if strings.HasPrefix(target, prefix) {
 			return strings.TrimPrefix(target, prefix)
 		}

--- a/sdk/typescript/src/provider-kind.ts
+++ b/sdk/typescript/src/provider-kind.ts
@@ -38,12 +38,6 @@ const PROVIDER_KIND_DEFINITIONS = {
     defaultExportNames: ["s3", "provider"],
     label: "s3 provider",
   },
-  telemetry: {
-    tokens: ["telemetry"],
-    formatToken: "telemetry",
-    defaultExportNames: ["telemetry", "provider"],
-    label: "telemetry provider",
-  },
 } satisfies Record<ProviderKind, ProviderKindDefinition>;
 
 const EXTERNAL_PROVIDER_KIND_TOKEN_SET = new Set<string>(

--- a/sdk/typescript/src/provider.ts
+++ b/sdk/typescript/src/provider.ts
@@ -8,8 +8,7 @@ export type ProviderKind =
   | "auth"
   | "cache"
   | "secrets"
-  | "s3"
-  | "telemetry";
+  | "s3";
 
 /**
  * Runtime metadata reported to the Gestalt host during startup.

--- a/sdk/typescript/tests/target.test.ts
+++ b/sdk/typescript/tests/target.test.ts
@@ -44,6 +44,9 @@ test("provider target parsing supports plugin defaults and kind prefixes", () =>
     modulePath: "./provider.ts",
     exportName: "plugin",
   });
+  expect(() =>
+    parseProviderTarget({ kind: "telemetry", target: "./provider.ts#plugin" }),
+  ).toThrow('unsupported provider kind "telemetry"');
   expect(parseProviderTarget("auth:./auth.ts#provider")).toEqual({
     kind: "auth",
     modulePath: "./auth.ts",
@@ -54,6 +57,9 @@ test("provider target parsing supports plugin defaults and kind prefixes", () =>
     modulePath: "./cache.ts",
     exportName: "provider",
   });
+  expect(() => parseProviderTarget("telemetry:./provider.ts#provider")).toThrow(
+    'unsupported provider kind "telemetry"',
+  );
   expect(() => parseProviderTarget("integration:./provider.ts#plugin")).toThrow(
     'unsupported provider kind "integration"',
   );


### PR DESCRIPTION
## Summary
Removes the unsupported TypeScript `telemetry` provider kind from SDK package parsing and rejects provider-backed telemetry sources earlier in host config validation, instead of letting them proceed until bootstrap.

## Go Interface
`providerpkg.DetectTypeScriptProviderTarget()` now rejects both of these package metadata forms:

```json
{"gestalt":{"provider":"telemetry:./provider.ts#plugin"}}
```

```json
{"gestalt":{"provider":{"kind":"telemetry","target":"./provider.ts#plugin"}}}
```

Host config validation now also rejects non-builtin telemetry provider sources before lifecycle/bootstrap:

```go
cfg := &config.Config{
    Providers: config.ProvidersConfig{
        Telemetry: map[string]*config.ProviderEntry{
            "custom": {
                Source: config.ProviderSource{Path: "./providers/telemetry"},
            },
        },
    },
}

err := config.ValidateStructure(cfg)
// err contains: does not support source.path or source.ref
```

## YAML Interface
Builtin telemetry providers remain valid:

```yaml
providers:
  telemetry:
    default:
      source: stdout
```

Provider-backed telemetry sources are now rejected early:

```yaml
providers:
  telemetry:
    custom:
      source:
        path: ./providers/telemetry
```

## TypeScript Package Metadata
Valid plugin target:

```json
{"gestalt":{"provider":"plugin:./provider.ts#plugin"}}
```

Rejected telemetry target:

```json
{"gestalt":{"provider":{"kind":"telemetry","target":"./provider.ts#plugin"}}}
```

## Validation
- `bun test tests/target.test.ts tests/runtime.test.ts tests/build.test.ts`
- `bunx tsc --noEmit`
- `go test ./internal/providerpkg ./internal/config`
