### PR TITLE
gestaltd: share operator component-provider traversal

### DIFF
--- a/gestaltd/internal/operator/lifecycle.go
+++ b/gestaltd/internal/operator/lifecycle.go
@@ -189,22 +189,22 @@ func (l *Lifecycle) prepareRuntimeLockFromLoadedConfig(ctx context.Context, path
 	for name := range resolvedProviders {
 		lock.Providers[name] = resolvedProviders[name]
 	}
-	for _, collection := range hostProviderCollections(cfg) {
+	for _, collection := range componentProviderCollections(cfg) {
+		lockEntries := lockEntriesForProviderKind(lock, collection.lockKind)
 		for name, entry := range collection.entries {
 			if entry == nil || !sourceBacked(entry) {
 				continue
 			}
-			if collection.kind == config.HostProviderKindSecrets {
+			if collection.manifestKind == providermanifestv1.KindSecrets {
 				if _, alreadyPrepared := secretsEntries[name]; alreadyPrepared {
 					continue
 				}
 			}
-			destDir := componentDestDir(paths, collection.kind, name)
-			lockEntry, err := l.writeComponentArtifact(ctx, paths, providerManifestKind(collection.kind), name, destDir, entry, entry.Config)
+			lockEntry, err := l.writeComponentArtifact(ctx, paths, collection.manifestKind, name, collection.destDir(paths, name), entry, entry.Config)
 			if err != nil {
 				return nil, err
 			}
-			lockEntriesForKind(lock, collection.kind)[name] = lockEntry
+			lockEntries[name] = lockEntry
 		}
 	}
 	if err := l.resolveConfiguredPlugins(paths, lock, cfg, true); err != nil {
@@ -219,24 +219,6 @@ func (l *Lifecycle) prepareRuntimeLockFromLoadedConfig(ctx context.Context, path
 	}
 	for name, lockEntry := range secretsEntries {
 		lock.Secrets[name] = lockEntry
-	}
-	for name, def := range cfg.Providers.IndexedDB {
-		if sourceBacked(def) {
-			entry, err := l.writeComponentArtifact(ctx, paths, providermanifestv1.KindIndexedDB, name, indexeddbDestDir(paths, name), def, def.Config)
-			if err != nil {
-				return nil, err
-			}
-			lock.IndexedDBs[name] = entry
-		}
-	}
-	for name, def := range cfg.Providers.S3 {
-		if sourceBacked(def) {
-			entry, err := l.writeComponentArtifact(ctx, paths, providermanifestv1.KindS3, name, s3DestDir(paths, name), def, def.Config)
-			if err != nil {
-				return nil, err
-			}
-			lock.S3[name] = entry
-		}
 	}
 	for name, entry := range cfg.Providers.UI {
 		if entry != nil && sourceBacked(&entry.ProviderEntry) {
@@ -262,21 +244,11 @@ func buildSourceTokenMap(cfg *config.Config) map[string]string {
 			tokens[entry.SourceRef()] = entry.Source.Auth.Token
 		}
 	}
-	for _, collection := range hostProviderCollections(cfg) {
+	for _, collection := range componentProviderCollections(cfg) {
 		for _, entry := range collection.entries {
 			if entry != nil && entry.Source.Auth != nil {
 				tokens[entry.SourceRef()] = entry.Source.Auth.Token
 			}
-		}
-	}
-	for _, def := range cfg.Providers.IndexedDB {
-		if def != nil && def.Source.Auth != nil {
-			tokens[def.SourceRef()] = def.Source.Auth.Token
-		}
-	}
-	for _, def := range cfg.Providers.S3 {
-		if def != nil && def.Source.Auth != nil {
-			tokens[def.SourceRef()] = def.Source.Auth.Token
 		}
 	}
 	for _, entry := range cfg.Providers.UI {
@@ -638,107 +610,142 @@ func sourceBacked(entry *config.ProviderEntry) bool {
 	return entry != nil && (entry.HasManagedSource() || entry.HasLocalSource())
 }
 
-func hostProviderCollections(cfg *config.Config) []struct {
-	kind    config.HostProviderKind
-	entries map[string]*config.ProviderEntry
-} {
-	return []struct {
-		kind    config.HostProviderKind
-		entries map[string]*config.ProviderEntry
-	}{
-		{config.HostProviderKindAuth, cfg.Providers.Auth},
-		{config.HostProviderKindSecrets, cfg.Providers.Secrets},
-		{config.HostProviderKindTelemetry, cfg.Providers.Telemetry},
-		{config.HostProviderKindAudit, cfg.Providers.Audit},
-		{config.HostProviderKindCache, cfg.Providers.Cache},
-		{config.HostProviderKindWorkflow, cfg.Providers.Workflow},
+type componentProviderCollection struct {
+	manifestKind string
+	lockKind     string
+	entries      map[string]*config.ProviderEntry
+	destDir      func(initPaths, string) string
+}
+
+func componentProviderCollections(cfg *config.Config) []componentProviderCollection {
+	return []componentProviderCollection{
+		{
+			manifestKind: providermanifestv1.KindAuth,
+			lockKind:     providermanifestv1.KindAuth,
+			entries:      cfg.Providers.Auth,
+			destDir:      authDestDir,
+		},
+		{
+			manifestKind: providermanifestv1.KindSecrets,
+			lockKind:     providermanifestv1.KindSecrets,
+			entries:      cfg.Providers.Secrets,
+			destDir:      secretsDestDir,
+		},
+		{
+			manifestKind: providermanifestv1.KindPlugin,
+			lockKind:     providerLockKindTelemetry,
+			entries:      cfg.Providers.Telemetry,
+			destDir:      telemetryDestDir,
+		},
+		{
+			manifestKind: providermanifestv1.KindPlugin,
+			lockKind:     providerLockKindAudit,
+			entries:      cfg.Providers.Audit,
+			destDir:      auditDestDir,
+		},
+		{
+			manifestKind: providermanifestv1.KindCache,
+			lockKind:     providermanifestv1.KindCache,
+			entries:      cfg.Providers.Cache,
+			destDir:      cacheDestDir,
+		},
+		{
+			manifestKind: providermanifestv1.KindWorkflow,
+			lockKind:     providermanifestv1.KindWorkflow,
+			entries:      cfg.Providers.Workflow,
+			destDir:      workflowDestDir,
+		},
+		{
+			manifestKind: providermanifestv1.KindIndexedDB,
+			lockKind:     providermanifestv1.KindIndexedDB,
+			entries:      cfg.Providers.IndexedDB,
+			destDir:      indexeddbDestDir,
+		},
+		{
+			manifestKind: providermanifestv1.KindS3,
+			lockKind:     providermanifestv1.KindS3,
+			entries:      cfg.Providers.S3,
+			destDir:      s3DestDir,
+		},
 	}
 }
 
-func lockEntriesForKind(lock *Lockfile, kind config.HostProviderKind) map[string]LockEntry {
-	if lock == nil {
-		return nil
-	}
-	switch kind {
-	case config.HostProviderKindAuth:
-		return lock.Auth
-	case config.HostProviderKindSecrets:
-		return lock.Secrets
-	case config.HostProviderKindTelemetry:
-		return lock.Telemetry
-	case config.HostProviderKindAudit:
-		return lock.Audit
-	case config.HostProviderKindCache:
-		return lock.Caches
-	case config.HostProviderKindIndexedDB:
-		return lock.IndexedDBs
-	case config.HostProviderKindWorkflow:
-		return lock.Workflows
-	default:
-		return nil
-	}
-}
-
-func configHasProviderLoading(cfg *config.Config) bool {
-	for _, entry := range cfg.Plugins {
-		if sourceBacked(entry) {
-			return true
+func hasSourceBackedProviderEntries(entries map[string]*config.ProviderEntry, managedOnly bool) bool {
+	for _, entry := range entries {
+		if entry == nil {
+			continue
 		}
-	}
-	for _, collection := range hostProviderCollections(cfg) {
-		for _, entry := range collection.entries {
-			if sourceBacked(entry) {
+		if managedOnly {
+			if entry.HasManagedSource() {
 				return true
 			}
+			continue
 		}
-	}
-	for _, entry := range cfg.Providers.UI {
-		if entry != nil && sourceBacked(&entry.ProviderEntry) {
-			return true
-		}
-	}
-	for _, def := range cfg.Providers.IndexedDB {
-		if sourceBacked(def) {
-			return true
-		}
-	}
-	for _, def := range cfg.Providers.S3 {
-		if sourceBacked(def) {
+		if entry.HasManagedSource() || entry.HasLocalSource() {
 			return true
 		}
 	}
 	return false
 }
 
-func configHasLocalProviderSources(cfg *config.Config) bool {
-	for _, entry := range cfg.Plugins {
-		if entry.HasLocalSource() {
-			return true
-		}
-	}
-	for _, collection := range hostProviderCollections(cfg) {
-		for _, entry := range collection.entries {
-			if entry != nil && entry.HasLocalSource() {
-				return true
-			}
-		}
-	}
-	for _, entry := range cfg.Providers.UI {
+func hasLocalSourceBackedProviderEntries(entries map[string]*config.ProviderEntry) bool {
+	for _, entry := range entries {
 		if entry != nil && entry.HasLocalSource() {
 			return true
 		}
 	}
-	for _, def := range cfg.Providers.IndexedDB {
-		if def != nil && def.HasLocalSource() {
-			return true
+	return false
+}
+
+func hasSourceBackedUIEntries(entries map[string]*config.UIEntry, managedOnly bool) bool {
+	for _, entry := range entries {
+		if entry == nil {
+			continue
 		}
-	}
-	for _, def := range cfg.Providers.S3 {
-		if def != nil && def.HasLocalSource() {
+		if managedOnly {
+			if entry.HasManagedSource() {
+				return true
+			}
+			continue
+		}
+		if entry.HasManagedSource() || entry.HasLocalSource() {
 			return true
 		}
 	}
 	return false
+}
+
+func hasLocalSourceBackedUIEntries(entries map[string]*config.UIEntry) bool {
+	for _, entry := range entries {
+		if entry != nil && entry.HasLocalSource() {
+			return true
+		}
+	}
+	return false
+}
+
+func configHasProviderLoading(cfg *config.Config) bool {
+	if hasSourceBackedProviderEntries(cfg.Plugins, false) {
+		return true
+	}
+	for _, collection := range componentProviderCollections(cfg) {
+		if hasSourceBackedProviderEntries(collection.entries, false) {
+			return true
+		}
+	}
+	return hasSourceBackedUIEntries(cfg.Providers.UI, false)
+}
+
+func configHasLocalProviderSources(cfg *config.Config) bool {
+	if hasLocalSourceBackedProviderEntries(cfg.Plugins) {
+		return true
+	}
+	for _, collection := range componentProviderCollections(cfg) {
+		if hasLocalSourceBackedProviderEntries(collection.entries) {
+			return true
+		}
+	}
+	return hasLocalSourceBackedUIEntries(cfg.Providers.UI)
 }
 
 func resolveLockPath(baseDir, provider string) string {
@@ -842,27 +849,6 @@ func s3DestDir(paths initPaths, name string) string {
 	return filepath.Join(paths.artifactsDir, "s3", name)
 }
 
-func componentDestDir(paths initPaths, kind config.HostProviderKind, name string) string {
-	switch kind {
-	case config.HostProviderKindAuth:
-		return authDestDir(paths, name)
-	case config.HostProviderKindSecrets:
-		return secretsDestDir(paths, name)
-	case config.HostProviderKindTelemetry:
-		return telemetryDestDir(paths, name)
-	case config.HostProviderKindAudit:
-		return auditDestDir(paths, name)
-	case config.HostProviderKindCache:
-		return cacheDestDir(paths, name)
-	case config.HostProviderKindIndexedDB:
-		return indexeddbDestDir(paths, name)
-	case config.HostProviderKindWorkflow:
-		return workflowDestDir(paths, name)
-	default:
-		return ""
-	}
-}
-
 type preparedInstall struct {
 	manifestPath   string
 	executablePath string
@@ -894,25 +880,6 @@ func inspectPreparedInstall(destDir string) (*preparedInstall, error) {
 		install.assetRootPath = filepath.Join(destDir, filepath.FromSlash(manifest.Spec.AssetRoot))
 	}
 	return install, nil
-}
-
-func providerManifestKind(kind config.HostProviderKind) string {
-	switch kind {
-	case config.HostProviderKindAuth:
-		return providermanifestv1.KindAuth
-	case config.HostProviderKindSecrets:
-		return providermanifestv1.KindSecrets
-	case config.HostProviderKindTelemetry, config.HostProviderKindAudit:
-		return providermanifestv1.KindPlugin
-	case config.HostProviderKindCache:
-		return providermanifestv1.KindCache
-	case config.HostProviderKindIndexedDB:
-		return providermanifestv1.KindIndexedDB
-	case config.HostProviderKindWorkflow:
-		return providermanifestv1.KindWorkflow
-	default:
-		return ""
-	}
 }
 
 func writeJSONFile(path string, v any) error {
@@ -983,34 +950,16 @@ func lockMatchesConfig(cfg *config.Config, paths initPaths, lock *Lockfile) bool
 			return false
 		}
 	}
-	for _, collection := range hostProviderCollections(cfg) {
-		lockEntries := lockEntriesForKind(lock, collection.kind)
+	for _, collection := range componentProviderCollections(cfg) {
+		lockEntries := lockEntriesForProviderKind(lock, collection.lockKind)
 		for name, entry := range collection.entries {
 			if entry == nil || !sourceBacked(entry) {
 				continue
 			}
 			lockEntry, found := lockEntries[name]
-			if !lockEntryMatches(paths, providerManifestKind(collection.kind), name, entry, lockEntry, found, componentDestDir(paths, collection.kind, name)) {
+			if !lockEntryMatches(paths, collection.manifestKind, name, entry, lockEntry, found, collection.destDir(paths, name)) {
 				return false
 			}
-		}
-	}
-	for name, entry := range cfg.Providers.IndexedDB {
-		if !sourceBacked(entry) {
-			continue
-		}
-		lockEntry, found := lock.IndexedDBs[name]
-		if !lockEntryMatches(paths, providermanifestv1.KindIndexedDB, name, entry, lockEntry, found, indexeddbDestDir(paths, name)) {
-			return false
-		}
-	}
-	for name, entry := range cfg.Providers.S3 {
-		if !sourceBacked(entry) {
-			continue
-		}
-		lockEntry, found := lock.S3[name]
-		if !lockEntryMatches(paths, providermanifestv1.KindS3, name, entry, lockEntry, found, s3DestDir(paths, name)) {
-			return false
 		}
 	}
 	for name, entry := range cfg.Providers.UI {
@@ -1682,37 +1631,13 @@ func (l *Lifecycle) applyPreparedProviders(paths initPaths, lock *Lockfile, cfg 
 		clearSynthesizedPluginOwnedUIEntries(cfg, synthesizedPluginUIs)
 		return err
 	}
-	for _, collection := range hostProviderCollections(cfg) {
-		lockEntries := lockEntriesForKind(lock, collection.kind)
+	for _, collection := range componentProviderCollections(cfg) {
+		lockEntries := lockEntriesForProviderKind(lock, collection.lockKind)
 		for name, entry := range collection.entries {
 			if entry == nil {
 				continue
 			}
-			if err := l.applyComponentProvider(paths, lockEntries, providerManifestKind(collection.kind), name, entry, entry.Config, &entry.Config, componentDestDir(paths, collection.kind, name), locked); err != nil {
-				clearSynthesizedPluginOwnedUIEntries(cfg, synthesizedPluginUIs)
-				return err
-			}
-		}
-	}
-	indexedDBLocks := map[string]LockEntry(nil)
-	if lock != nil {
-		indexedDBLocks = lock.IndexedDBs
-	}
-	for name, def := range cfg.Providers.IndexedDB {
-		if def != nil {
-			if err := l.applyComponentProvider(paths, indexedDBLocks, providermanifestv1.KindIndexedDB, name, def, def.Config, &def.Config, indexeddbDestDir(paths, name), locked); err != nil {
-				clearSynthesizedPluginOwnedUIEntries(cfg, synthesizedPluginUIs)
-				return err
-			}
-		}
-	}
-	s3Locks := map[string]LockEntry(nil)
-	if lock != nil {
-		s3Locks = lock.S3
-	}
-	for name, def := range cfg.Providers.S3 {
-		if def != nil {
-			if err := l.applyComponentProvider(paths, s3Locks, providermanifestv1.KindS3, name, def, def.Config, &def.Config, s3DestDir(paths, name), locked); err != nil {
+			if err := l.applyComponentProvider(paths, lockEntries, collection.manifestKind, name, entry, entry.Config, &entry.Config, collection.destDir(paths, name), locked); err != nil {
 				clearSynthesizedPluginOwnedUIEntries(cfg, synthesizedPluginUIs)
 				return err
 			}

--- a/gestaltd/internal/operator/lifecycle_source_test.go
+++ b/gestaltd/internal/operator/lifecycle_source_test.go
@@ -954,6 +954,256 @@ func TestManagedIndexedDBSourcesLoadForExecutionWithMultipleBindings(t *testing.
 	}
 }
 
+func TestManagedS3SourcesLoadForExecutionWithMultipleBindings(t *testing.T) {
+	t.Parallel()
+
+	dir := t.TempDir()
+	mainSource := "github.com/acme/providers/s3-main"
+	archiveSource := "github.com/acme/providers/s3-archive"
+	version := "1.0.0"
+
+	mainArchivePath := buildExecutableArchive(t, dir, "s3-main-src", mainSource, version, providermanifestv1.KindS3, "s3-main", "main-s3-binary")
+	archiveArchivePath := buildExecutableArchive(t, dir, "s3-archive-src", archiveSource, version, providermanifestv1.KindS3, "s3-archive", "archive-s3-binary")
+
+	mainArchiveData, err := os.ReadFile(mainArchivePath)
+	if err != nil {
+		t.Fatalf("read main s3 archive: %v", err)
+	}
+	mainArchiveSum := sha256.Sum256(mainArchiveData)
+
+	archiveArchiveData, err := os.ReadFile(archiveArchivePath)
+	if err != nil {
+		t.Fatalf("read archive s3 archive: %v", err)
+	}
+	archiveArchiveSum := sha256.Sum256(archiveArchiveData)
+
+	resolver := &fakeMultiResolver{
+		results: map[string]fakeResolverResult{
+			mainSource: {
+				archivePath: mainArchivePath,
+				resolvedURL: "https://example.com/s3-main.tar.gz",
+				sha256:      hex.EncodeToString(mainArchiveSum[:]),
+			},
+			archiveSource: {
+				archivePath: archiveArchivePath,
+				resolvedURL: "https://example.com/s3-archive.tar.gz",
+				sha256:      hex.EncodeToString(archiveArchiveSum[:]),
+			},
+		},
+	}
+
+	artifactsDir := filepath.Join(dir, "prepared-artifacts")
+	configYAML := strings.Join([]string{
+		"providers:",
+		"  indexeddb:",
+		"    sqlite:",
+		"      source: sqlite",
+		"      config:",
+		`        path: "` + filepath.Join(dir, "system.db") + `"`,
+		"  s3:",
+		"    main:",
+		"      source:",
+		"        ref: " + mainSource,
+		"        version: " + version,
+		"      config:",
+		"        bucket: main-bucket",
+		"    archive:",
+		"      source:",
+		"        ref: " + archiveSource,
+		"        version: " + version,
+		"      config:",
+		"        bucket: archive-bucket",
+		"server:",
+		"  providers:",
+		"    indexeddb: sqlite",
+		"  artifactsDir: " + artifactsDir,
+		"  encryptionKey: aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
+	}, "\n") + "\n"
+
+	configPath := filepath.Join(dir, "gestalt.yaml")
+	if err := os.WriteFile(configPath, []byte(configYAML), 0o644); err != nil {
+		t.Fatalf("write config: %v", err)
+	}
+
+	lc := NewLifecycle(resolver)
+	lock, err := lc.InitAtPath(configPath)
+	if err != nil {
+		t.Fatalf("InitAtPath: %v", err)
+	}
+	if len(lock.S3) != 2 {
+		t.Fatalf("lock.S3 = %#v, want 2 entries", lock.S3)
+	}
+	if _, ok := lock.S3["main"]; !ok {
+		t.Fatal(`lock.S3["main"] not found`)
+	}
+	if _, ok := lock.S3["archive"]; !ok {
+		t.Fatal(`lock.S3["archive"] not found`)
+	}
+
+	callsBefore := len(resolver.calls)
+	cfg, _, err := lc.LoadForExecutionAtPath(configPath, true)
+	if err != nil {
+		t.Fatalf("LoadForExecutionAtPath(locked=true): %v", err)
+	}
+	if len(resolver.calls) != callsBefore {
+		t.Fatalf("resolver called during locked load: got %d calls, want %d", len(resolver.calls), callsBefore)
+	}
+
+	wantBuckets := map[string]string{
+		"main":    "main-bucket",
+		"archive": "archive-bucket",
+	}
+	for _, name := range []string{"main", "archive"} {
+		entry := cfg.Providers.S3[name]
+		if entry == nil {
+			t.Fatalf("cfg.Providers.S3[%q] = nil", name)
+		}
+		if entry.ResolvedManifest == nil {
+			t.Fatalf("cfg.Providers.S3[%q].ResolvedManifest = nil", name)
+		}
+		wantCommand := resolveLockPath(artifactsDir, lock.S3[name].Executable)
+		if entry.Command != wantCommand {
+			t.Fatalf("cfg.Providers.S3[%q].Command = %q, want %q", name, entry.Command, wantCommand)
+		}
+		runtimeCfg, err := config.NodeToMap(entry.Config)
+		if err != nil {
+			t.Fatalf("NodeToMap(s3 %q config): %v", name, err)
+		}
+		configMap, ok := runtimeCfg["config"].(map[string]any)
+		if !ok {
+			t.Fatalf("s3 %q runtime config = %#v", name, runtimeCfg["config"])
+		}
+		if got := configMap["bucket"]; got != wantBuckets[name] {
+			t.Fatalf("s3 %q bucket = %#v, want %q", name, got, wantBuckets[name])
+		}
+	}
+}
+
+func TestManagedTelemetryAndAuditSourcesLoadForExecution(t *testing.T) {
+	t.Parallel()
+
+	dir := t.TempDir()
+	telemetrySource := "github.com/acme/providers/telemetry-otlp"
+	auditSource := "github.com/acme/providers/audit-stream"
+	version := "1.0.0"
+
+	telemetryArchivePath := buildExecutableArchive(t, dir, "telemetry-src", telemetrySource, version, providermanifestv1.KindPlugin, "telemetry-plugin", "telemetry-binary")
+	auditArchivePath := buildExecutableArchive(t, dir, "audit-src", auditSource, version, providermanifestv1.KindPlugin, "audit-plugin", "audit-binary")
+
+	telemetryArchiveData, err := os.ReadFile(telemetryArchivePath)
+	if err != nil {
+		t.Fatalf("read telemetry archive: %v", err)
+	}
+	telemetryArchiveSum := sha256.Sum256(telemetryArchiveData)
+
+	auditArchiveData, err := os.ReadFile(auditArchivePath)
+	if err != nil {
+		t.Fatalf("read audit archive: %v", err)
+	}
+	auditArchiveSum := sha256.Sum256(auditArchiveData)
+
+	resolver := &fakeMultiResolver{
+		results: map[string]fakeResolverResult{
+			telemetrySource: {
+				archivePath: telemetryArchivePath,
+				resolvedURL: "https://example.com/telemetry.tar.gz",
+				sha256:      hex.EncodeToString(telemetryArchiveSum[:]),
+			},
+			auditSource: {
+				archivePath: auditArchivePath,
+				resolvedURL: "https://example.com/audit.tar.gz",
+				sha256:      hex.EncodeToString(auditArchiveSum[:]),
+			},
+		},
+	}
+
+	artifactsDir := filepath.Join(dir, "prepared-artifacts")
+	configYAML := strings.Join([]string{
+		"providers:",
+		"  indexeddb:",
+		"    sqlite:",
+		"      source: sqlite",
+		"      config:",
+		`        path: "` + filepath.Join(dir, "system.db") + `"`,
+		"  telemetry:",
+		"    otlp:",
+		"      source:",
+		"        ref: " + telemetrySource,
+		"        version: " + version,
+		"      config:",
+		"        endpoint: https://telemetry.example.test",
+		"  audit:",
+		"    stream:",
+		"      source:",
+		"        ref: " + auditSource,
+		"        version: " + version,
+		"      config:",
+		"        endpoint: https://audit.example.test",
+		"server:",
+		"  providers:",
+		"    indexeddb: sqlite",
+		"  artifactsDir: " + artifactsDir,
+		"  encryptionKey: aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
+	}, "\n") + "\n"
+
+	configPath := filepath.Join(dir, "gestalt.yaml")
+	if err := os.WriteFile(configPath, []byte(configYAML), 0o644); err != nil {
+		t.Fatalf("write config: %v", err)
+	}
+
+	lc := NewLifecycle(resolver)
+	lock, err := lc.InitAtPath(configPath)
+	if err != nil {
+		t.Fatalf("InitAtPath: %v", err)
+	}
+	if len(lock.Telemetry) != 1 {
+		t.Fatalf("lock.Telemetry = %#v, want 1 entry", lock.Telemetry)
+	}
+	if len(lock.Audit) != 1 {
+		t.Fatalf("lock.Audit = %#v, want 1 entry", lock.Audit)
+	}
+
+	callsBefore := len(resolver.calls)
+	cfg, _, err := lc.LoadForExecutionAtPath(configPath, true)
+	if err != nil {
+		t.Fatalf("LoadForExecutionAtPath(locked=true): %v", err)
+	}
+	if len(resolver.calls) != callsBefore {
+		t.Fatalf("resolver called during locked load: got %d calls, want %d", len(resolver.calls), callsBefore)
+	}
+
+	checkEntry := func(kind, name string, entry *config.ProviderEntry, lockEntry LockEntry, wantEndpoint string) {
+		t.Helper()
+		if entry == nil {
+			t.Fatalf("cfg.Providers.%s[%q] = nil", kind, name)
+		}
+		if entry.ResolvedManifest == nil {
+			t.Fatalf("cfg.Providers.%s[%q].ResolvedManifest = nil", kind, name)
+		}
+		if entry.ResolvedManifest.Kind != providermanifestv1.KindPlugin {
+			t.Fatalf("cfg.Providers.%s[%q].ResolvedManifest.Kind = %q, want %q", kind, name, entry.ResolvedManifest.Kind, providermanifestv1.KindPlugin)
+		}
+		wantCommand := resolveLockPath(artifactsDir, lockEntry.Executable)
+		if entry.Command != wantCommand {
+			t.Fatalf("cfg.Providers.%s[%q].Command = %q, want %q", kind, name, entry.Command, wantCommand)
+		}
+		runtimeCfg, err := config.NodeToMap(entry.Config)
+		if err != nil {
+			t.Fatalf("NodeToMap(%s %q config): %v", kind, name, err)
+		}
+		configMap, ok := runtimeCfg["config"].(map[string]any)
+		if !ok {
+			t.Fatalf("%s %q runtime config = %#v", kind, name, runtimeCfg["config"])
+		}
+		if got := configMap["endpoint"]; got != wantEndpoint {
+			t.Fatalf("%s %q endpoint = %#v, want %q", kind, name, got, wantEndpoint)
+		}
+	}
+
+	checkEntry("telemetry", "otlp", cfg.Providers.Telemetry["otlp"], lock.Telemetry["otlp"], "https://telemetry.example.test")
+	checkEntry("audit", "stream", cfg.Providers.Audit["stream"], lock.Audit["stream"], "https://audit.example.test")
+}
+
 func TestManagedCacheSourcesLoadForExecutionWithMultipleBindings(t *testing.T) {
 	t.Parallel()
 


### PR DESCRIPTION
## Summary
- share operator traversal of source-backed component providers so init, lock matching, source token mapping, and locked materialization use one collection primitive instead of repeating host/indexeddb/s3 loops
- keep UI on its explicit path while removing duplicated branching across auth, secrets, telemetry, audit, cache, indexeddb, and s3 handling
- add product-level locked-load coverage for managed telemetry/audit and make the S3 regression truly S3-only so the traversal guard cannot be masked by another source-backed component

## Interfaces
Go interface: none
YAML interface: none

## Examples
Go:
```go
lc := NewLifecycle(resolver)
lock, err := lc.InitAtPath(configPath)
cfg, _, err := lc.LoadForExecutionAtPath(configPath, true)
```

YAML:
```yaml
providers:
  telemetry:
    otlp:
      source:
        ref: github.com/acme/providers/telemetry-otlp
        version: 1.0.0
  audit:
    stream:
      source:
        ref: github.com/acme/providers/audit-stream
        version: 1.0.0
  s3:
    main:
      source:
        ref: github.com/acme/providers/s3-main
        version: 1.0.0
  indexeddb:
    sqlite:
      source: sqlite
      config:
        path: /tmp/system.db
server:
  providers:
    indexeddb: sqlite
  artifactsDir: ./prepared-artifacts
```

## Verification
- `cd gestaltd && go test ./internal/operator -count=1`
- `cd gestaltd && go test ./internal/... -run TestDoesNotExist -count=1`

## Diff
- production code vs `main`: `+107 / -190` in `internal/operator/lifecycle.go` (net `-83`)
