### PR TITLE
gestaltd: centralize release target resolution

### DIFF
--- a/gestaltd/cmd/gestaltd/plugin.go
+++ b/gestaltd/cmd/gestaltd/plugin.go
@@ -1,7 +1,6 @@
 package main
 
 import (
-	"errors"
 	"flag"
 	"fmt"
 	"io"
@@ -51,10 +50,6 @@ const windowsExecutableSuffix = ".exe"
 type releasePlatform struct {
 	GOOS   string
 	GOARCH string
-}
-
-type releaseBuildTarget struct {
-	Kind string
 }
 
 type releaseArchive struct {
@@ -133,12 +128,12 @@ func runProviderRelease(args []string) error {
 		return fmt.Errorf("create output dir: %w", err)
 	}
 
-	buildTarget, err := resolveReleaseBuildTarget(sourceDir, releaseManifest)
+	buildKind, err := resolveReleaseBuildTarget(sourceDir, releaseManifest)
 	if err != nil {
 		return err
 	}
 
-	buildPlatforms, err := resolveReleaseBuildPlatforms(sourceDir, releaseManifest, buildTarget, *platforms, platformFlagExplicit)
+	buildPlatforms, err := resolveReleaseBuildPlatforms(sourceDir, releaseManifest, buildKind, *platforms, platformFlagExplicit)
 	if err != nil {
 		return err
 	}
@@ -146,7 +141,7 @@ func runProviderRelease(args []string) error {
 	var releaseArchives []releaseArchive
 	if len(buildPlatforms) > 0 {
 		for _, platform := range buildPlatforms {
-			archivePath, err := buildPlatformArchive(manifestPath, pluginName, *version, buildTarget.Kind, platform, *outputDir)
+			archivePath, err := buildPlatformArchive(manifestPath, pluginName, *version, buildKind, platform, *outputDir)
 			if err != nil {
 				return fmt.Errorf("build %s: %w", providerpkg.PlatformString(platform.GOOS, platform.GOARCH), err)
 			}
@@ -179,33 +174,30 @@ func runProviderRelease(args []string) error {
 	return nil
 }
 
-func resolveReleaseBuildTarget(root string, manifest *providermanifestv1.Manifest) (*releaseBuildTarget, error) {
+func resolveReleaseBuildTarget(root string, manifest *providermanifestv1.Manifest) (string, error) {
 	kind, err := providerpkg.ManifestKind(manifest)
 	if err != nil {
-		return nil, err
+		return "", err
 	}
-	if kind == providermanifestv1.KindWebUI {
-		return nil, nil
-	}
-	hasSource, err := detectReleaseSourceBuildTarget(root, kind)
+	hasSource, err := providerpkg.HasSourceReleaseTarget(root, kind)
 	if err != nil {
-		return nil, fmt.Errorf("detect source %s package: %w", kind, err)
+		return "", fmt.Errorf("detect source %s package: %w", kind, err)
 	}
 	if !hasSource {
-		if releaseRequiresBuildTarget(manifest) {
-			return nil, missingReleaseSourceBuildTargetError(kind)
+		if providerpkg.ReleaseRequiresBuild(manifest) {
+			return "", providerpkg.MissingSourceReleaseTargetError(kind)
 		}
-		return nil, nil
+		return "", nil
 	}
-	return &releaseBuildTarget{Kind: kind}, nil
+	return kind, nil
 }
 
-func resolveReleaseBuildPlatforms(root string, manifest *providermanifestv1.Manifest, target *releaseBuildTarget, value string, explicit bool) ([]releasePlatform, error) {
-	if target == nil {
+func resolveReleaseBuildPlatforms(root string, manifest *providermanifestv1.Manifest, buildKind, value string, explicit bool) ([]releasePlatform, error) {
+	if buildKind == "" {
 		return nil, nil
 	}
 
-	buildRequired := releaseRequiresBuildTarget(manifest)
+	buildRequired := providerpkg.ReleaseRequiresBuild(manifest)
 	if !buildRequired && !explicit {
 		return nil, nil
 	}
@@ -216,7 +208,7 @@ func resolveReleaseBuildPlatforms(root string, manifest *providermanifestv1.Mani
 			return nil, err
 		}
 	} else {
-		value = currentReleasePlatform()
+		value = runtime.GOOS + "/" + runtime.GOARCH
 	}
 	platforms, err := parseReleasePlatforms(value)
 	if err != nil {
@@ -226,21 +218,21 @@ func resolveReleaseBuildPlatforms(root string, manifest *providermanifestv1.Mani
 	builds := make([]releasePlatform, 0, len(platforms))
 	var missingSource bool
 	for _, platform := range platforms {
-		if err := validateReleaseBuildTarget(root, target.Kind, platform.GOOS, platform.GOARCH); err != nil {
-			if isMissingReleaseSourceBuildTarget(err, target.Kind) {
+		if err := providerpkg.ValidateSourceReleaseTarget(root, buildKind, platform.GOOS, platform.GOARCH); err != nil {
+			if providerpkg.IsMissingSourceReleaseTarget(err, buildKind) {
 				missingSource = true
 				continue
 			}
-			return nil, fmt.Errorf("detect source %s package for %s/%s: %w", target.Kind, platform.GOOS, platform.GOARCH, err)
+			return nil, fmt.Errorf("detect source %s package for %s/%s: %w", buildKind, platform.GOOS, platform.GOARCH, err)
 		}
 		builds = append(builds, platform)
 	}
 
 	if len(builds) == 0 {
-		return nil, missingReleaseSourceBuildTargetError(target.Kind)
+		return nil, providerpkg.MissingSourceReleaseTargetError(buildKind)
 	}
 	if missingSource {
-		return nil, missingReleaseSourceBuildTargetError(target.Kind)
+		return nil, providerpkg.MissingSourceReleaseTargetError(buildKind)
 	}
 	return builds, nil
 }
@@ -290,65 +282,6 @@ func createReleaseArchive(outputDir, archiveName string, prepare func(stagingDir
 	return archivePath, nil
 }
 
-func releaseRequiresBuildTarget(manifest *providermanifestv1.Manifest) bool {
-	kind, err := providerpkg.ManifestKind(manifest)
-	if err != nil {
-		return false
-	}
-	switch kind {
-	case providermanifestv1.KindPlugin:
-		return manifest.Entrypoint == nil && (manifest.Spec == nil || !manifest.Spec.IsManifestBacked())
-	case providermanifestv1.KindAuth, providermanifestv1.KindIndexedDB, providermanifestv1.KindCache, providermanifestv1.KindS3, providermanifestv1.KindSecrets:
-		return providerpkg.EntrypointForKind(manifest, kind) == nil
-	default:
-		return false
-	}
-}
-
-func detectReleaseSourceBuildTarget(root, kind string) (bool, error) {
-	switch kind {
-	case providermanifestv1.KindPlugin:
-		return providerpkg.HasSourceProviderPackage(root)
-	case providermanifestv1.KindAuth, providermanifestv1.KindIndexedDB, providermanifestv1.KindCache, providermanifestv1.KindS3, providermanifestv1.KindSecrets:
-		return providerpkg.HasSourceComponentPackage(root, kind)
-	default:
-		return false, fmt.Errorf("unsupported release build target kind %q", kind)
-	}
-}
-
-func validateReleaseBuildTarget(root, kind, goos, goarch string) error {
-	switch kind {
-	case providermanifestv1.KindPlugin:
-		return providerpkg.ValidateSourceProviderRelease(root, goos, goarch)
-	case providermanifestv1.KindAuth, providermanifestv1.KindIndexedDB, providermanifestv1.KindCache, providermanifestv1.KindS3, providermanifestv1.KindSecrets:
-		return providerpkg.ValidateSourceComponentRelease(root, kind, goos, goarch)
-	default:
-		return fmt.Errorf("unsupported release build target kind %q", kind)
-	}
-}
-
-func isMissingReleaseSourceBuildTarget(err error, kind string) bool {
-	switch kind {
-	case providermanifestv1.KindPlugin:
-		return errors.Is(err, providerpkg.ErrNoSourceProviderPackage)
-	case providermanifestv1.KindAuth, providermanifestv1.KindIndexedDB, providermanifestv1.KindCache, providermanifestv1.KindS3, providermanifestv1.KindSecrets:
-		return errors.Is(err, providerpkg.ErrNoSourceComponentPackage)
-	default:
-		return false
-	}
-}
-
-func missingReleaseSourceBuildTargetError(kind string) error {
-	switch kind {
-	case providermanifestv1.KindPlugin:
-		return fmt.Errorf("no Go, Rust, Python, or TypeScript provider package found")
-	case providermanifestv1.KindAuth, providermanifestv1.KindCache, providermanifestv1.KindIndexedDB, providermanifestv1.KindS3, providermanifestv1.KindSecrets:
-		return fmt.Errorf("no Go, Rust, Python, or TypeScript %s source package found", kind)
-	default:
-		return fmt.Errorf("unsupported release build target kind %q", kind)
-	}
-}
-
 func parseReleasePlatforms(value string) ([]releasePlatform, error) {
 	parts := strings.Split(value, ",")
 	platforms := make([]releasePlatform, 0, len(parts))
@@ -364,10 +297,6 @@ func parseReleasePlatforms(value string) ([]releasePlatform, error) {
 		})
 	}
 	return platforms, nil
-}
-
-func currentReleasePlatform() string {
-	return runtime.GOOS + "/" + runtime.GOARCH
 }
 
 func buildSourceArchive(manifestPath, pluginName, version, outputDir string) (string, error) {

--- a/gestaltd/internal/providerpkg/prepared_stage.go
+++ b/gestaltd/internal/providerpkg/prepared_stage.go
@@ -2,7 +2,6 @@ package providerpkg
 
 import (
 	"encoding/json"
-	"errors"
 	"fmt"
 	"io"
 	"io/fs"
@@ -125,7 +124,7 @@ func StagePreparedInstallDir(manifestPath, stagingDir string, opts StagePrepared
 		}
 		binaryName := stagedReleaseBinaryName(pluginName, opts.GOOS)
 		binaryPath := filepath.Join(stagingDir, binaryName)
-		if _, err := buildPreparedInstallBinary(sourceDir, binaryPath, pluginName, buildKind, opts.GOOS, opts.GOARCH); err != nil {
+		if _, err := buildSourceReleaseBinaryResult(sourceDir, binaryPath, pluginName, buildKind, opts.GOOS, opts.GOARCH); err != nil {
 			return nil, err
 		}
 		digest, err := FileSHA256(binaryPath)
@@ -180,13 +179,10 @@ func resolvePreparedInstallBuildKind(root string, manifest *providermanifestv1.M
 			return "", err
 		}
 	}
-	if kind == providermanifestv1.KindWebUI {
-		return "", nil
-	}
 
-	if buildKind, err := resolvePreparedInstallBuildTarget(root, kind); err == nil {
+	if buildKind, err := resolveSourceReleaseBuildTarget(root, kind); err == nil {
 		return buildKind, nil
-	} else if !isMissingPreparedInstallBuildTarget(err, kind) {
+	} else if !IsMissingSourceReleaseTarget(err, kind) {
 		return "", err
 	}
 
@@ -196,67 +192,13 @@ func resolvePreparedInstallBuildKind(root string, manifest *providermanifestv1.M
 	}
 
 	if preparedInstallRequiresBuild(manifest, kind) {
-		return "", missingPreparedInstallBuildTargetError(kind)
+		return "", missingSourceReleaseTargetCause(kind)
 	}
 	return "", nil
 }
 
 func preparedInstallRequiresBuild(manifest *providermanifestv1.Manifest, kind string) bool {
-	switch kind {
-	case providermanifestv1.KindPlugin:
-		return manifest != nil && manifest.Entrypoint == nil && (manifest.Spec == nil || !manifest.Spec.IsManifestBacked())
-	case providermanifestv1.KindAuth, providermanifestv1.KindIndexedDB, providermanifestv1.KindCache, providermanifestv1.KindS3, providermanifestv1.KindSecrets:
-		return EntrypointForKind(manifest, kind) == nil
-	default:
-		return false
-	}
-}
-
-func resolvePreparedInstallBuildTarget(root, kind string) (string, error) {
-	switch kind {
-	case providermanifestv1.KindPlugin:
-		ok, err := HasSourceProviderPackage(root)
-		if err != nil {
-			return "", err
-		}
-		if !ok {
-			return "", ErrNoSourceProviderPackage
-		}
-		return kind, nil
-	case providermanifestv1.KindAuth, providermanifestv1.KindIndexedDB, providermanifestv1.KindCache, providermanifestv1.KindS3, providermanifestv1.KindSecrets:
-		ok, err := HasSourceComponentPackage(root, kind)
-		if err != nil {
-			return "", err
-		}
-		if !ok {
-			return "", ErrNoSourceComponentPackage
-		}
-		return kind, nil
-	default:
-		return "", fmt.Errorf("unsupported release build target kind %q", kind)
-	}
-}
-
-func isMissingPreparedInstallBuildTarget(err error, kind string) bool {
-	switch kind {
-	case providermanifestv1.KindPlugin:
-		return errors.Is(err, ErrNoSourceProviderPackage)
-	case providermanifestv1.KindAuth, providermanifestv1.KindIndexedDB, providermanifestv1.KindCache, providermanifestv1.KindS3, providermanifestv1.KindSecrets:
-		return errors.Is(err, ErrNoSourceComponentPackage)
-	default:
-		return false
-	}
-}
-
-func missingPreparedInstallBuildTargetError(kind string) error {
-	switch kind {
-	case providermanifestv1.KindPlugin:
-		return ErrNoSourceProviderPackage
-	case providermanifestv1.KindAuth, providermanifestv1.KindIndexedDB, providermanifestv1.KindCache, providermanifestv1.KindS3, providermanifestv1.KindSecrets:
-		return ErrNoSourceComponentPackage
-	default:
-		return fmt.Errorf("unsupported release build target kind %q", kind)
-	}
+	return releaseRequiresBuildForKind(manifest, kind)
 }
 
 func artifactExistsForEntrypoint(root string, entry *providermanifestv1.Entrypoint) bool {
@@ -265,17 +207,6 @@ func artifactExistsForEntrypoint(root string, entry *providermanifestv1.Entrypoi
 	}
 	_, err := os.Stat(filepath.Join(root, filepath.FromSlash(entry.ArtifactPath)))
 	return err == nil
-}
-
-func buildPreparedInstallBinary(root, outputPath, pluginName, kind, goos, goarch string) (string, error) {
-	switch kind {
-	case providermanifestv1.KindPlugin:
-		return BuildSourceProviderReleaseBinary(root, outputPath, pluginName, goos, goarch)
-	case providermanifestv1.KindAuth, providermanifestv1.KindIndexedDB, providermanifestv1.KindCache, providermanifestv1.KindS3, providermanifestv1.KindSecrets:
-		return BuildSourceComponentReleaseBinary(root, outputPath, kind, goos, goarch)
-	default:
-		return "", fmt.Errorf("unsupported release build target kind %q", kind)
-	}
 }
 
 func buildPreparedInstallSourceManifest(srcManifest *providermanifestv1.Manifest, version, sourceDir string) (*providermanifestv1.Manifest, error) {

--- a/gestaltd/internal/providerpkg/release_target.go
+++ b/gestaltd/internal/providerpkg/release_target.go
@@ -7,14 +7,113 @@ import (
 	providermanifestv1 "github.com/valon-technologies/gestalt/server/sdk/providermanifest/v1"
 )
 
+type releaseTarget struct {
+	kind           string
+	missingErr     error
+	missingMessage string
+	hasSource      func(string) (bool, error)
+	validate       func(string, string, string) error
+	buildBinary    func(string, string, string, string, string) (string, error)
+}
+
 func ReleaseRequiresBuild(manifest *providermanifestv1.Manifest) bool {
 	kind, err := ManifestKind(manifest)
 	if err != nil {
 		return false
 	}
+	return releaseRequiresBuildForKind(manifest, kind)
+}
+
+func HasSourceReleaseTarget(root, kind string) (bool, error) {
+	target, err := releaseTargetForKind(kind)
+	if err != nil {
+		return false, err
+	}
+	if target == nil {
+		return false, nil
+	}
+	return target.hasSource(root)
+}
+
+func ValidateSourceReleaseTarget(root, kind, goos, goarch string) error {
+	target, err := releaseTargetForKind(kind)
+	if err != nil {
+		return err
+	}
+	if target == nil {
+		return fmt.Errorf("unsupported release build target kind %q", kind)
+	}
+	return target.validate(root, goos, goarch)
+}
+
+func BuildSourceReleaseBinary(root, outputPath, pluginName, kind, goos, goarch string) error {
+	_, err := buildSourceReleaseBinaryResult(root, outputPath, pluginName, kind, goos, goarch)
+	return err
+}
+
+func buildSourceReleaseBinaryResult(root, outputPath, pluginName, kind, goos, goarch string) (string, error) {
+	target, err := releaseTargetForKind(kind)
+	if err != nil {
+		return "", err
+	}
+	if target == nil {
+		return "", fmt.Errorf("unsupported release build target kind %q", kind)
+	}
+	return target.buildBinary(root, outputPath, pluginName, goos, goarch)
+}
+
+func IsMissingSourceReleaseTarget(err error, kind string) bool {
+	target, targetErr := releaseTargetForKind(kind)
+	if targetErr != nil || target == nil {
+		return false
+	}
+	return errors.Is(err, target.missingErr)
+}
+
+func MissingSourceReleaseTargetError(kind string) error {
+	target, err := releaseTargetForKind(kind)
+	if err != nil {
+		return err
+	}
+	if target == nil {
+		return fmt.Errorf("unsupported release build target kind %q", kind)
+	}
+	return fmt.Errorf("%s", target.missingMessage)
+}
+
+func missingSourceReleaseTargetCause(kind string) error {
+	target, err := releaseTargetForKind(kind)
+	if err != nil {
+		return err
+	}
+	if target == nil {
+		return fmt.Errorf("unsupported release build target kind %q", kind)
+	}
+	return target.missingErr
+}
+
+func resolveSourceReleaseBuildTarget(root, kind string) (string, error) {
+	target, err := releaseTargetForKind(kind)
+	if err != nil {
+		return "", err
+	}
+	if target == nil {
+		return "", nil
+	}
+	ok, err := target.hasSource(root)
+	if err != nil {
+		return "", err
+	}
+	if !ok {
+		return "", target.missingErr
+	}
+	return target.kind, nil
+}
+
+func releaseRequiresBuildForKind(manifest *providermanifestv1.Manifest, kind string) bool {
 	switch kind {
 	case providermanifestv1.KindPlugin:
-		return manifest.Entrypoint == nil && (manifest.Spec == nil || !manifest.Spec.IsManifestBacked())
+		return manifest != nil && manifest.Entrypoint == nil && (manifest.Spec == nil || !manifest.Spec.IsManifestBacked())
 	case providermanifestv1.KindAuth, providermanifestv1.KindIndexedDB, providermanifestv1.KindCache, providermanifestv1.KindS3, providermanifestv1.KindSecrets:
 		return EntrypointForKind(manifest, kind) == nil
 	default:
@@ -22,61 +121,35 @@ func ReleaseRequiresBuild(manifest *providermanifestv1.Manifest) bool {
 	}
 }
 
-func HasSourceReleaseTarget(root, kind string) (bool, error) {
+func releaseTargetForKind(kind string) (*releaseTarget, error) {
 	switch kind {
-	case providermanifestv1.KindPlugin:
-		return HasSourceProviderPackage(root)
 	case providermanifestv1.KindWebUI:
-		return false, nil
-	case providermanifestv1.KindAuth, providermanifestv1.KindIndexedDB, providermanifestv1.KindCache, providermanifestv1.KindS3, providermanifestv1.KindSecrets:
-		return HasSourceComponentPackage(root, kind)
-	default:
-		return false, fmt.Errorf("unsupported release build target kind %q", kind)
-	}
-}
-
-func ValidateSourceReleaseTarget(root, kind, goos, goarch string) error {
-	switch kind {
+		return nil, nil
 	case providermanifestv1.KindPlugin:
-		return ValidateSourceProviderRelease(root, goos, goarch)
+		return &releaseTarget{
+			kind:           kind,
+			missingErr:     ErrNoSourceProviderPackage,
+			missingMessage: "no Go, Rust, Python, or TypeScript provider package found",
+			hasSource:      HasSourceProviderPackage,
+			validate:       ValidateSourceProviderRelease,
+			buildBinary:    BuildSourceProviderReleaseBinary,
+		}, nil
 	case providermanifestv1.KindAuth, providermanifestv1.KindIndexedDB, providermanifestv1.KindCache, providermanifestv1.KindS3, providermanifestv1.KindSecrets:
-		return ValidateSourceComponentRelease(root, kind, goos, goarch)
+		return &releaseTarget{
+			kind:           kind,
+			missingErr:     ErrNoSourceComponentPackage,
+			missingMessage: fmt.Sprintf("no Go, Rust, Python, or TypeScript %s source package found", kind),
+			hasSource: func(root string) (bool, error) {
+				return HasSourceComponentPackage(root, kind)
+			},
+			validate: func(root, goos, goarch string) error {
+				return ValidateSourceComponentRelease(root, kind, goos, goarch)
+			},
+			buildBinary: func(root, outputPath, _ string, goos, goarch string) (string, error) {
+				return BuildSourceComponentReleaseBinary(root, outputPath, kind, goos, goarch)
+			},
+		}, nil
 	default:
-		return fmt.Errorf("unsupported release build target kind %q", kind)
-	}
-}
-
-func BuildSourceReleaseBinary(root, outputPath, pluginName, kind, goos, goarch string) error {
-	switch kind {
-	case providermanifestv1.KindPlugin:
-		_, err := BuildSourceProviderReleaseBinary(root, outputPath, pluginName, goos, goarch)
-		return err
-	case providermanifestv1.KindAuth, providermanifestv1.KindIndexedDB, providermanifestv1.KindCache, providermanifestv1.KindS3, providermanifestv1.KindSecrets:
-		_, err := BuildSourceComponentReleaseBinary(root, outputPath, kind, goos, goarch)
-		return err
-	default:
-		return fmt.Errorf("unsupported release build target kind %q", kind)
-	}
-}
-
-func IsMissingSourceReleaseTarget(err error, kind string) bool {
-	switch kind {
-	case providermanifestv1.KindPlugin:
-		return errors.Is(err, ErrNoSourceProviderPackage)
-	case providermanifestv1.KindAuth, providermanifestv1.KindIndexedDB, providermanifestv1.KindCache, providermanifestv1.KindS3, providermanifestv1.KindSecrets:
-		return errors.Is(err, ErrNoSourceComponentPackage)
-	default:
-		return false
-	}
-}
-
-func MissingSourceReleaseTargetError(kind string) error {
-	switch kind {
-	case providermanifestv1.KindPlugin:
-		return fmt.Errorf("no Go, Rust, Python, or TypeScript provider package found")
-	case providermanifestv1.KindAuth, providermanifestv1.KindCache, providermanifestv1.KindIndexedDB, providermanifestv1.KindS3, providermanifestv1.KindSecrets:
-		return fmt.Errorf("no Go, Rust, Python, or TypeScript %s source package found", kind)
-	default:
-		return fmt.Errorf("unsupported release build target kind %q", kind)
+		return nil, fmt.Errorf("unsupported release build target kind %q", kind)
 	}
 }


### PR DESCRIPTION
## Summary
- collapse duplicated release-target kind branching into one `providerpkg` release-target primitive
- reuse that primitive from `cmd/gestaltd` release planning and prepared-install staging
- delete redundant target plumbing while keeping the release-product path behavior unchanged

## Go Interface
The internal Go release-target surface is now centralized around:
- `providerpkg.ReleaseRequiresBuild(manifest)`
- `providerpkg.HasSourceReleaseTarget(root, kind)`
- `providerpkg.ValidateSourceReleaseTarget(root, kind, goos, goarch)`

### Go Example
```go
kind := "plugin"
if ok, err := providerpkg.HasSourceReleaseTarget(root, kind); err != nil {
    return err
} else if ok {
    if err := providerpkg.ValidateSourceReleaseTarget(root, kind, "linux", "amd64"); err != nil {
        return err
    }
}
```

## YAML Interface
No schema change.

Release planning still reads the same manifest fields:
- `kind`
- `source`
- `spec`
- `entrypoint.artifactPath`
- `artifacts`

### YAML Example
```yaml
kind: plugin
source: github.com/testowner/plugins/catalog/release-test
spec:
  ui:
    path: _owned_ui/roadmap-ui/manifest.json
entrypoint:
  artifactPath: gestalt-plugin-release-test
```

## Behavior Examples
- `gestaltd provider release --version 0.0.12-go-all --platform all` still resolves build targets once and emits one archive per default platform.
- `gestaltd provider release --version 0.0.15-ts-auth` still validates and packages auth executables through the same shared release-target path.

## Verification
```bash
go test ./internal/providerpkg -count=1 -vet=off
PATH='/usr/local/bin:/System/Cryptexes/App/usr/bin:/usr/bin:/bin:/usr/sbin:/sbin:/var/run/com.apple.security.cryptexd/codex.system/bootstrap/usr/local/bin:/var/run/com.apple.security.cryptexd/codex.system/bootstrap/usr/bin:/var/run/com.apple.security.cryptexd/codex.system/bootstrap/usr/appleinternal/bin:/opt/pkg/env/active/bin:/opt/pmk/env/global/bin:/opt/homebrew/bin:/Users/hugh/.codex/tmp/arg0/codex-arg0IRVTww:/Users/hugh/.bun/bin:/Users/hugh/.local/bin:/Users/hugh/google-cloud-sdk/bin:/opt/homebrew/sbin:/Applications/Ghostty.app/Contents/MacOS' \
GOCACHE=/tmp/gestaltd-release-target-gocache GOMODCACHE=/tmp/gestaltd-release-target-gomod \
  go test ./cmd/gestaltd -run '^(TestRun_Provider|TestRun_PluginRelease)' -parallel 1 -count=1 -vet=off

golangci-lint run ./cmd/gestaltd/... ./internal/providerpkg/...
```