### PR TITLE
[codex] Expose upstream MCP surfaces on /mcp

### DIFF
--- a/gestaltd/internal/config/config.go
+++ b/gestaltd/internal/config/config.go
@@ -140,6 +140,7 @@ type ProviderEntry struct {
 	S3                []string                      `yaml:"s3,omitempty"`
 	Workflow          *PluginWorkflowConfig         `yaml:"workflow,omitempty"`
 	Surfaces          *ProviderSurfaceOverrides     `yaml:"surfaces,omitempty"`
+	MCP               bool                          `yaml:"mcp,omitempty"`
 
 	// Runtime-resolved fields (populated during init/bootstrap, not from YAML)
 	Command              string                                `yaml:"-"`
@@ -152,7 +153,6 @@ type ProviderEntry struct {
 	Auth                 *ConnectionAuthDef                    `yaml:"-"`
 	DefaultConnection    string                                `yaml:"-"`
 	ConnectionParams     map[string]ConnectionParamDef         `yaml:"-"`
-	MCP                  bool                                  `yaml:"-"`
 	Discovery            *providermanifestv1.ProviderDiscovery `yaml:"-"`
 	ResolvedAssetRoot    string                                `yaml:"-"`
 	MCPToolPrefix        string                                `yaml:"-"`
@@ -263,6 +263,24 @@ func (e *ProviderEntry) DeclaresMCP() bool {
 		return false
 	}
 	return spec.MCP
+}
+
+func (e *ProviderEntry) HasMCPSurface() bool {
+	if e == nil {
+		return false
+	}
+	if ProviderSurfaceURLOverride(e, SpecSurfaceMCP) != "" {
+		return true
+	}
+	return ManifestProviderSurfaceURL(e.ManifestSpec(), SpecSurfaceMCP) != ""
+}
+
+func (e *ProviderEntry) ExposesMCP() bool {
+	return e.DeclaresMCP() || e.HasMCPSurface()
+}
+
+func (e *ProviderEntry) IncludeRESTInMCP() bool {
+	return e.DeclaresMCP()
 }
 
 type SourceAuthDef struct {

--- a/gestaltd/internal/config/config_test.go
+++ b/gestaltd/internal/config/config_test.go
@@ -100,6 +100,28 @@ plugins:
 	}
 }
 
+func TestLoadConfigParsesPluginMCPFlag(t *testing.T) {
+	t.Parallel()
+
+	path := mustWriteConfigFile(t, `
+server:
+  encryptionKey: server-key
+plugins:
+  service-a:
+    source:
+      path: /tmp/manifest.yaml
+    mcp: true
+`)
+
+	cfg, err := Load(path)
+	if err != nil {
+		t.Fatalf("Load: %v", err)
+	}
+	if !cfg.Plugins["service-a"].MCP {
+		t.Fatal("expected plugins.service-a.mcp to be parsed")
+	}
+}
+
 func TestLoadConfigSelectsDefaultProvidersFromNamedMaps(t *testing.T) {
 	t.Parallel()
 

--- a/gestaltd/internal/config/surfaces_test.go
+++ b/gestaltd/internal/config/surfaces_test.go
@@ -6,6 +6,90 @@ import (
 	providermanifestv1 "github.com/valon-technologies/gestalt/server/sdk/providermanifest/v1"
 )
 
+func TestProviderEntryMCPExposure(t *testing.T) {
+	t.Parallel()
+
+	cases := []struct {
+		name        string
+		entry       *ProviderEntry
+		declaresMCP bool
+		hasSurface  bool
+		exposesMCP  bool
+		includeREST bool
+	}{
+		{
+			name: "explicit config mcp",
+			entry: &ProviderEntry{
+				MCP: true,
+			},
+			declaresMCP: true,
+			exposesMCP:  true,
+			includeREST: true,
+		},
+		{
+			name: "manifest mcp flag",
+			entry: &ProviderEntry{
+				ResolvedManifest: &providermanifestv1.Manifest{
+					Spec: &providermanifestv1.Spec{MCP: true},
+				},
+			},
+			declaresMCP: true,
+			exposesMCP:  true,
+			includeREST: true,
+		},
+		{
+			name: "manifest mcp surface only",
+			entry: &ProviderEntry{
+				ResolvedManifest: &providermanifestv1.Manifest{
+					Spec: &providermanifestv1.Spec{
+						Surfaces: &providermanifestv1.ProviderSurfaces{
+							MCP: &providermanifestv1.MCPSurface{URL: "https://mcp.example"},
+						},
+					},
+				},
+			},
+			hasSurface: true,
+			exposesMCP: true,
+		},
+		{
+			name: "config mcp override surface only",
+			entry: &ProviderEntry{
+				Surfaces: &ProviderSurfaceOverrides{
+					MCP: &ProviderMCPSurfaceOverride{URL: "https://override.example/mcp"},
+				},
+			},
+			hasSurface: true,
+			exposesMCP: true,
+		},
+		{
+			name:        "nil entry",
+			entry:       nil,
+			declaresMCP: false,
+			hasSurface:  false,
+			exposesMCP:  false,
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+
+			if got := tc.entry.DeclaresMCP(); got != tc.declaresMCP {
+				t.Fatalf("DeclaresMCP() = %v, want %v", got, tc.declaresMCP)
+			}
+			if got := tc.entry.HasMCPSurface(); got != tc.hasSurface {
+				t.Fatalf("HasMCPSurface() = %v, want %v", got, tc.hasSurface)
+			}
+			if got := tc.entry.ExposesMCP(); got != tc.exposesMCP {
+				t.Fatalf("ExposesMCP() = %v, want %v", got, tc.exposesMCP)
+			}
+			if got := tc.entry.IncludeRESTInMCP(); got != tc.includeREST {
+				t.Fatalf("IncludeRESTInMCP() = %v, want %v", got, tc.includeREST)
+			}
+		})
+	}
+}
+
 func TestProviderSurfaceURLOverride(t *testing.T) {
 	t.Parallel()
 

--- a/gestaltd/internal/mcp/binding_test.go
+++ b/gestaltd/internal/mcp/binding_test.go
@@ -3070,7 +3070,7 @@ func TestNewServer_IncludeRESTFiltering(t *testing.T) {
 		wantCount   int
 	}{
 		{"excluded", false, 1},
-		{"included", true, 2},
+		{"included", true, 3},
 	}
 
 	for _, tc := range cases {
@@ -3081,6 +3081,7 @@ func TestNewServer_IncludeRESTFiltering(t *testing.T) {
 				Name: "acme",
 				Operations: []catalog.CatalogOperation{
 					{ID: "api_op", Method: http.MethodGet, Path: "/api", Transport: catalog.TransportREST},
+					{ID: "graphql_op", Description: "graphql-backed", Transport: "graphql"},
 					{ID: "mcp_op", Description: "passthrough", Transport: catalog.TransportMCPPassthrough},
 				},
 			}
@@ -3107,6 +3108,9 @@ func TestNewServer_IncludeRESTFiltering(t *testing.T) {
 			}
 			if tools["acme_mcp_op"] == nil {
 				t.Fatal("expected acme_mcp_op to always be present")
+			}
+			if !tc.includeREST && tools["acme_graphql_op"] != nil {
+				t.Fatal("expected acme_graphql_op to be excluded when IncludeREST=false")
 			}
 		})
 	}

--- a/gestaltd/internal/mcp/projection.go
+++ b/gestaltd/internal/mcp/projection.go
@@ -53,8 +53,10 @@ func catalogOperationProjectedToMCP(cfg Config, provName string, op catalog.Cata
 	if op.Visible != nil && !*op.Visible {
 		return false
 	}
-	if cfg.IncludeREST != nil && op.Transport == catalog.TransportREST && !cfg.IncludeREST[provName] {
-		return false
+	if cfg.IncludeREST != nil {
+		if includeProjectedOps, ok := cfg.IncludeREST[provName]; ok && !includeProjectedOps && op.Transport != catalog.TransportMCPPassthrough {
+			return false
+		}
 	}
 	return true
 }

--- a/gestaltd/internal/server/runtime.go
+++ b/gestaltd/internal/server/runtime.go
@@ -217,13 +217,15 @@ func newMCPHandler(cfg *config.Config, connMaps bootstrap.ConnectionMaps, result
 
 	allowedProviders := make([]string, 0, len(names))
 	toolPrefixes := make(map[string]string)
+	includeREST := make(map[string]bool)
 	mcpConnection := make(map[string]string)
 	for _, name := range names {
 		entry := cfg.Plugins[name]
-		if entry == nil || !entry.DeclaresMCP() {
+		if entry == nil || !entry.ExposesMCP() {
 			continue
 		}
 		allowedProviders = append(allowedProviders, name)
+		includeREST[name] = entry.IncludeRESTInMCP()
 		mcpConnection[name] = connMaps.MCPConnection[name]
 		if entry.MCPToolPrefix != "" {
 			toolPrefixes[name] = entry.MCPToolPrefix
@@ -245,6 +247,7 @@ func newMCPHandler(cfg *config.Config, connMaps bootstrap.ConnectionMaps, result
 			Authorizer:       result.Authorizer,
 			AllowedProviders: allowedProviders,
 			ToolPrefixes:     toolPrefixes,
+			IncludeREST:      includeREST,
 			MCPConnection:    mcpConnection,
 		}),
 		mcpserver.WithStateLess(true),


### PR DESCRIPTION
## What changed
- treat `surfaces.mcp` as enough to mount a provider on Gestalt's `/mcp` surface
- keep API-projected tools on `/mcp` only when MCP exposure is explicit (`mcp: true` or manifest `spec.mcp: true`)
- parse `mcp: true` from deploy YAML so deploy config can opt providers into MCP exposure directly
- extend MCP projection tests to verify non-MCP passthrough operations are hidden when `IncludeREST=false`

## Why
Providers like Linear, Notion, Ramp, and ClickHouse already declare upstream MCP endpoints through `surfaces.mcp`, but they were not mounted onto Gestalt's `/mcp` surface unless they also set the separate `mcp` boolean. That left those upstream MCP tool surfaces invisible.

At the same time, mounting a provider because it has an upstream MCP surface should not automatically project all of its REST or GraphQL operations onto `/mcp`. This change keeps those concerns separate.

## Impact
- providers with `surfaces.mcp` now appear on Gestalt's `/mcp`
- providers included only because of `surfaces.mcp` expose only MCP passthrough tools there
- deploy config can now explicitly declare `mcp: true` on plugin entries

## Validation
- `go test ./internal/config ./internal/mcp ./internal/server`
