### PR TITLE
gestaltd: add explicit --lockfile overrides for lock state

### DIFF
--- a/docs/content/configuration.mdx
+++ b/docs/content/configuration.mdx
@@ -386,7 +386,7 @@ When `--config` is repeated, Gestalt loads the files left-to-right and merges th
 - later lists replace inherited lists
 - `null` deletes inherited keys
 
-Lockfiles and default prepared-artifact paths stay rooted at the leftmost config file. Relative paths resolve from the directory of the file that declared the value, so override files can safely use their own `source.path`, `iconFile`, and `server.artifactsDir` entries.
+By default, lockfiles and prepared-artifact paths stay rooted at the leftmost config file. `--lockfile` overrides only the lockfile path and resolves like a normal CLI path. Relative config values still resolve from the directory of the file that declared them, so override files can safely use their own `source.path`, `iconFile`, and `server.artifactsDir` entries.
 
 ### Environment expansion
 

--- a/docs/content/reference/cli.mdx
+++ b/docs/content/reference/cli.mdx
@@ -12,9 +12,12 @@ import { Callout } from 'nextra/components'
 | `gestaltd serve --config PATH` | Start the server. Repeat `--config` to layer overrides. |
 | `gestaltd serve --locked --config PATH` | Start from lock state. Uses prepared artifacts when present and can materialize missing artifacts from the lockfile. Repeat `--config` to layer overrides. |
 | `gestaltd serve --artifacts-dir DIR` | Directory for prepared provider artifacts. |
+| `gestaltd serve --lockfile PATH` | Override the lockfile location. `PATH` resolves like a normal CLI path. |
 | `gestaltd init --config PATH` | Resolve published plugin sources and write lock state. Repeat `--config` to layer overrides. |
 | `gestaltd init --artifacts-dir DIR` | Directory for prepared provider artifacts. |
+| `gestaltd init --lockfile PATH` | Override the lockfile location. `PATH` resolves like a normal CLI path. |
 | `gestaltd validate --config PATH` | Validate config without serving. Repeat `--config` to layer overrides. |
+| `gestaltd validate --lockfile PATH` | Accept the same explicit lockfile path used by `init` and `serve` without mutating it. |
 | `gestaltd --version` | Print the server version. |
 
 <Callout type="warning">
@@ -38,6 +41,9 @@ gestaltd
 gestaltd init --config ./config.yaml
 gestaltd serve --locked --config ./config.yaml
 gestaltd validate --config ./config.yaml
+gestaltd init --config ./config.yaml --lockfile ./local/gestalt.lock.json
+gestaltd serve --config ./config.yaml --lockfile ./local/gestalt.lock.json
+gestaltd serve --locked --config ./config.yaml --lockfile ./local/gestalt.lock.json
 gestaltd init --config ./base.yaml --config ./overrides/local.yaml
 gestaltd serve --locked --config ./base.yaml --config ./overrides/prod.yaml
 gestaltd provider release --version 0.0.1-alpha.1
@@ -47,7 +53,8 @@ gestaltd provider release --version 0.0.1-alpha.1 --platform linux/amd64,linux/a
 
 When repeated, `--config` files merge left-to-right. Maps deep-merge, later
 scalar values win, lists replace inherited lists, and `null` deletes inherited
-keys. Lockfiles and default artifact paths stay rooted at the leftmost config
-file.
+keys. By default, lockfiles and artifact paths stay rooted at the leftmost
+config file. `--lockfile` overrides only the lockfile path. `--artifacts-dir`
+keeps its existing config-relative behavior for backward compatibility.
 
 See [Configuration](/configuration) for the relationship between `init`, `serve --locked`, and `validate`.

--- a/docs/content/reference/config-file.mdx
+++ b/docs/content/reference/config-file.mdx
@@ -41,7 +41,8 @@ When multiple config files are loaded, Gestalt applies these merge rules:
 
 Relative file paths resolve relative to the config file that introduced them.
 That includes `source.path`, `iconFile`, and `server.artifactsDir`. Lockfiles
-and default artifact directories stay rooted at the leftmost config file.
+and, by default, artifact directories stay rooted at the leftmost config file.
+`--lockfile` overrides only the lockfile path.
 
 Several fields carry defaults when omitted: `server.public.port` defaults to `8080`; the runtime secrets manager defaults to builtin `env` when `providers.secrets` is omitted; `providers.telemetry.default` defaults to builtin `stdout`; and `providers.audit.default` defaults to builtin `inherit`. Structured secret refs are resolved during bootstrap, not during YAML parsing.
 

--- a/gestaltd/cmd/gestaltd/e2e_test.go
+++ b/gestaltd/cmd/gestaltd/e2e_test.go
@@ -379,6 +379,14 @@ plugins:
 	if _, err := os.Stat(filepath.Join(dir, ".gestaltd")); !os.IsNotExist(err) {
 		t.Fatalf("validate should not leave prepared artifacts in config dir, got err=%v", err)
 	}
+	overrideLockfilePath := filepath.Join(dir, "state", "validate", operator.InitLockfileName)
+	out, err = exec.Command(gestaltdBin, "validate", "--config", cfgPath, "--lockfile", overrideLockfilePath).CombinedOutput()
+	if err != nil {
+		t.Fatalf("expected validate with --lockfile to succeed: %v\n%s", err, out)
+	}
+	if _, err := os.Stat(overrideLockfilePath); !os.IsNotExist(err) {
+		t.Fatalf("validate should not write override lockfile, got err=%v", err)
+	}
 
 	providedArtifactsDir := filepath.Join(dir, "artifacts", "validate")
 	out, err = exec.Command(gestaltdBin, "validate", "--config", cfgPath, "--artifacts-dir", providedArtifactsDir).CombinedOutput()
@@ -894,10 +902,10 @@ plugins:
 	return cfgPath
 }
 
-func startGestaltdWithConfigs(t *testing.T, cfgPaths []string, locked bool) string {
+func startGestaltdWithConfigsAndArgs(t *testing.T, cfgPaths []string, args []string, requiredPath string) string {
 	t.Helper()
 	if len(cfgPaths) == 0 {
-		t.Fatal("startGestaltdWithConfigs requires at least one config path")
+		t.Fatal("startGestaltdWithConfigsAndArgs requires at least one config path")
 	}
 
 	port, holder := reservePort(t)
@@ -914,16 +922,25 @@ func startGestaltdWithConfigs(t *testing.T, cfgPaths []string, locked bool) stri
 	}
 
 	_ = holder.Close()
-	args := []string{"serve"}
-	if locked {
-		args = append(args, "--locked")
-	}
 	for _, cfgPath := range cfgPaths {
 		args = append(args, "--config", cfgPath)
 	}
 	cmd := exec.Command(gestaltdBin, args...)
-	startCommandAndWaitReady(t, cmd, baseURL)
+	if requiredPath != "" {
+		startCommandAndWaitReadyAndFile(t, cmd, baseURL, requiredPath)
+	} else {
+		startCommandAndWaitReady(t, cmd, baseURL)
+	}
 	return baseURL
+}
+
+func startGestaltdWithConfigs(t *testing.T, cfgPaths []string, locked bool) string {
+	t.Helper()
+	args := []string{"serve"}
+	if locked {
+		args = append(args, "--locked")
+	}
+	return startGestaltdWithConfigsAndArgs(t, cfgPaths, args, "")
 }
 
 func startCommandAndWaitReady(t *testing.T, cmd *exec.Cmd, baseURL string) {
@@ -1260,9 +1277,9 @@ plugins:
 		t.Fatalf("write owned-ui config: %v", err)
 	}
 
-	loadedCfg, _, err := operatorLifecycle().LoadForExecutionAtPathWithArtifactsDir(cfgPath, "", false)
+	loadedCfg, _, err := operatorLifecycle().LoadForExecutionAtPathsWithStatePaths([]string{cfgPath}, operator.StatePaths{}, false)
 	if err != nil {
-		t.Fatalf("LoadForExecutionAtPathWithArtifactsDir(%s): %v", cfgPath, err)
+		t.Fatalf("LoadForExecutionAtPathsWithStatePaths(%s): %v", cfgPath, err)
 	}
 	if got := loadedCfg.Providers.UI["roadmap"].OwnerPlugin; got != "example" {
 		t.Fatalf(`Providers.UI["roadmap"].OwnerPlugin = %q, want %q`, got, "example")
@@ -1397,6 +1414,29 @@ func TestE2EInitLocalProviders(t *testing.T) {
 	}
 }
 
+func TestE2EInitWritesOverrideLockfile(t *testing.T) {
+	t.Parallel()
+
+	if testing.Short() {
+		t.Skip("skipping E2E init lockfile override test in short mode")
+	}
+
+	dir := t.TempDir()
+	cfgPath := writeServeConfig(t, dir, 0, nil)
+	lockPath := filepath.Join(dir, "state", "local", "gestalt.lock.json")
+
+	out, err := exec.Command(gestaltdBin, "init", "--config", cfgPath, "--lockfile", lockPath).CombinedOutput()
+	if err != nil {
+		t.Fatalf("gestaltd init with --lockfile failed: %v\noutput: %s", err, out)
+	}
+	if _, err := os.Stat(lockPath); err != nil {
+		t.Fatalf("expected override lockfile at %s: %v", lockPath, err)
+	}
+	if _, err := os.Stat(filepath.Join(dir, "gestalt.lock.json")); !os.IsNotExist(err) {
+		t.Fatalf("default lockfile should not be written, got err=%v", err)
+	}
+}
+
 func TestE2EInitAndServeLayeredConfigs(t *testing.T) {
 	t.Parallel()
 
@@ -1425,6 +1465,88 @@ func TestE2EInitAndServeLayeredConfigs(t *testing.T) {
 	body, _ := io.ReadAll(resp.Body)
 	if resp.StatusCode != http.StatusUnauthorized {
 		t.Fatalf("expected /api/v1/integrations 401 with layered auth override, got %d: %s", resp.StatusCode, body)
+	}
+}
+
+func TestE2EServeAutoInitUsesOverrideLockfile(t *testing.T) {
+	t.Parallel()
+
+	if testing.Short() {
+		t.Skip("skipping E2E serve lockfile override test in short mode")
+	}
+
+	dir := t.TempDir()
+	cfgPath := writeServeConfig(t, dir, 0, nil)
+	lockPath := filepath.Join(dir, "state", "serve", "gestalt.lock.json")
+
+	baseURL := startGestaltdWithConfigsAndArgs(t, []string{cfgPath}, []string{"serve", "--lockfile", lockPath}, lockPath)
+	resp, err := (&http.Client{Timeout: 2 * time.Second}).Get(baseURL + "/api/v1/integrations")
+	if err != nil {
+		t.Fatalf("GET /api/v1/integrations: %v", err)
+	}
+	defer func() { _ = resp.Body.Close() }()
+	if resp.StatusCode != http.StatusOK {
+		body, _ := io.ReadAll(resp.Body)
+		t.Fatalf("expected /api/v1/integrations 200, got %d: %s", resp.StatusCode, body)
+	}
+	if _, err := os.Stat(filepath.Join(dir, "gestalt.lock.json")); !os.IsNotExist(err) {
+		t.Fatalf("default lockfile should not be written, got err=%v", err)
+	}
+}
+
+func TestE2EDefaultServeAutoInitUsesOverrideLockfile(t *testing.T) {
+	t.Parallel()
+
+	if testing.Short() {
+		t.Skip("skipping default serve lockfile override test in short mode")
+	}
+
+	dir := t.TempDir()
+	cfgPath := writeServeConfig(t, dir, 0, nil)
+	lockPath := filepath.Join(dir, "state", "default-serve", "gestalt.lock.json")
+
+	baseURL := startGestaltdWithConfigsAndArgs(t, []string{cfgPath}, []string{"--lockfile", lockPath}, lockPath)
+	resp, err := (&http.Client{Timeout: 2 * time.Second}).Get(baseURL + "/api/v1/integrations")
+	if err != nil {
+		t.Fatalf("GET /api/v1/integrations: %v", err)
+	}
+	defer func() { _ = resp.Body.Close() }()
+	if resp.StatusCode != http.StatusOK {
+		body, _ := io.ReadAll(resp.Body)
+		t.Fatalf("expected /api/v1/integrations 200, got %d: %s", resp.StatusCode, body)
+	}
+	if _, err := os.Stat(filepath.Join(dir, "gestalt.lock.json")); !os.IsNotExist(err) {
+		t.Fatalf("default lockfile should not be written, got err=%v", err)
+	}
+}
+
+func TestE2EServeLockedUsesOverrideLockfile(t *testing.T) {
+	t.Parallel()
+
+	if testing.Short() {
+		t.Skip("skipping locked serve lockfile override test in short mode")
+	}
+
+	dir := t.TempDir()
+	cfgPath := writeServeConfig(t, dir, 0, nil)
+	lockPath := filepath.Join(dir, "state", "locked-serve", "gestalt.lock.json")
+
+	out, err := exec.Command(gestaltdBin, "init", "--config", cfgPath, "--lockfile", lockPath).CombinedOutput()
+	if err != nil {
+		t.Fatalf("gestaltd init with --lockfile failed: %v\noutput: %s", err, out)
+	}
+	baseURL := startGestaltdWithConfigsAndArgs(t, []string{cfgPath}, []string{"serve", "--locked", "--lockfile", lockPath}, "")
+	resp, err := (&http.Client{Timeout: 2 * time.Second}).Get(baseURL + "/api/v1/integrations")
+	if err != nil {
+		t.Fatalf("GET /api/v1/integrations: %v", err)
+	}
+	defer func() { _ = resp.Body.Close() }()
+	if resp.StatusCode != http.StatusOK {
+		body, _ := io.ReadAll(resp.Body)
+		t.Fatalf("expected /api/v1/integrations 200, got %d: %s", resp.StatusCode, body)
+	}
+	if _, err := os.Stat(filepath.Join(dir, "gestalt.lock.json")); !os.IsNotExist(err) {
+		t.Fatalf("default lockfile should not be written, got err=%v", err)
 	}
 }
 
@@ -1496,6 +1618,63 @@ func TestE2EServeLockedRejectsGenericArchiveForExecutablePlugin(t *testing.T) {
 	}
 	if !strings.Contains(string(out), "generic release archives are not allowed") {
 		t.Fatalf("expected generic-archive policy error, got: %s", out)
+	}
+}
+
+func TestE2EServeLockedMissingHashMentionsOverrideLockfile(t *testing.T) {
+	t.Parallel()
+
+	if testing.Short() {
+		t.Skip("skipping locked missing-hash E2E test in short mode")
+	}
+
+	dir := t.TempDir()
+	cfgPath := writeManagedSourceServeConfig(t, dir, 0)
+	cfg, err := config.Load(cfgPath)
+	if err != nil {
+		t.Fatalf("Load(%s): %v", cfgPath, err)
+	}
+
+	fingerprint, err := operator.ProviderFingerprint("example", cfg.Plugins["example"], filepath.Dir(cfgPath))
+	if err != nil {
+		t.Fatalf("ProviderFingerprint(example): %v", err)
+	}
+
+	lockPath := filepath.Join(dir, "state", "locked-missing-hash", "gestalt.lock.json")
+	lock := &operator.Lockfile{
+		Providers: map[string]operator.LockProviderEntry{
+			"example": {
+				Fingerprint: fingerprint,
+				Source:      cfg.Plugins["example"].SourceRef(),
+				Version:     cfg.Plugins["example"].SourceVersion(),
+				Archives: map[string]operator.LockArchive{
+					providerpkg.CurrentPlatformString(): {
+						URL: "https://example.test/gestalt-plugin-provider_v0.0.1-alpha.1.tar.gz",
+					},
+				},
+			},
+		},
+	}
+	if err := operator.WriteLockfile(lockPath, lock); err != nil {
+		t.Fatalf("WriteLockfile(%s): %v", lockPath, err)
+	}
+
+	ctx, cancel := context.WithTimeout(context.Background(), 3*time.Second)
+	defer cancel()
+
+	cmd := exec.CommandContext(ctx, gestaltdBin, "serve", "--locked", "--config", cfgPath, "--lockfile", lockPath)
+	out, err := cmd.CombinedOutput()
+	if ctx.Err() == context.DeadlineExceeded {
+		t.Fatalf("gestaltd serve --locked unexpectedly stayed up with missing-hash lockfile\noutput: %s", out)
+	}
+	if err == nil {
+		t.Fatalf("expected gestaltd serve --locked to fail, output: %s", out)
+	}
+	if !strings.Contains(string(out), "--lockfile "+lockPath) {
+		t.Fatalf("expected locked missing-hash error to mention override lockfile, got: %s", out)
+	}
+	if !strings.Contains(string(out), "--platform "+providerpkg.CurrentPlatformString()) {
+		t.Fatalf("expected locked missing-hash error to mention platform remediation, got: %s", out)
 	}
 }
 

--- a/gestaltd/cmd/gestaltd/factories.go
+++ b/gestaltd/cmd/gestaltd/factories.go
@@ -23,6 +23,7 @@ import (
 	telemetrystdout "github.com/valon-technologies/gestalt/server/internal/drivers/telemetry/stdout"
 	workflowprovider "github.com/valon-technologies/gestalt/server/internal/drivers/workflow/provider"
 	"github.com/valon-technologies/gestalt/server/internal/invocation"
+	"github.com/valon-technologies/gestalt/server/internal/operator"
 )
 
 type bootstrapEnv struct {
@@ -34,8 +35,8 @@ type bootstrapEnv struct {
 	prevLogger *slog.Logger
 }
 
-func setupBootstrapWithConfigPaths(configPaths []string, artifactsDir string, locked bool) (*bootstrapEnv, error) {
-	cfg, err := loadConfigForExecutionAtPathsWithArtifactsDir(configPaths, artifactsDir, locked)
+func setupBootstrapWithConfigPaths(configPaths []string, state operator.StatePaths, locked bool) (*bootstrapEnv, error) {
+	cfg, err := loadConfigForExecutionAtPathsWithStatePaths(configPaths, state, locked)
 	if err != nil {
 		return nil, err
 	}

--- a/gestaltd/cmd/gestaltd/init.go
+++ b/gestaltd/cmd/gestaltd/init.go
@@ -15,10 +15,10 @@ func operatorLifecycle() *operator.Lifecycle {
 	})
 }
 
-func initConfigWithArtifactsDir(configFlags []string, artifactsDir, platformFlag string) error {
+func initConfigWithStatePaths(configFlags []string, state operator.StatePaths, platformFlag string) error {
 	configPaths := operator.ResolveConfigPaths(configFlags)
 	if platformFlag == "" {
-		_, err := operatorLifecycle().InitAtPathsWithArtifactsDir(configPaths, artifactsDir)
+		_, err := operatorLifecycle().InitAtPathsWithStatePaths(configPaths, state)
 		return err
 	}
 
@@ -36,21 +36,21 @@ func initConfigWithArtifactsDir(configFlags []string, artifactsDir, platformFlag
 		platArgs[i] = struct{ GOOS, GOARCH, LibC string }{p.GOOS, p.GOARCH, ""}
 	}
 
-	_, err = operatorLifecycle().InitAtPathsWithPlatforms(configPaths, artifactsDir, platArgs)
+	_, err = operatorLifecycle().InitAtPathsWithPlatforms(configPaths, state, platArgs)
 	return err
 }
 
-func loadConfigForExecutionAtPathsWithArtifactsDir(configPaths []string, artifactsDir string, locked bool) (*config.Config, error) {
-	cfg, _, err := operatorLifecycle().LoadForExecutionAtPathsWithArtifactsDir(configPaths, artifactsDir, locked)
+func loadConfigForExecutionAtPathsWithStatePaths(configPaths []string, state operator.StatePaths, locked bool) (*config.Config, error) {
+	cfg, _, err := operatorLifecycle().LoadForExecutionAtPathsWithStatePaths(configPaths, state, locked)
 	if err != nil {
 		return nil, err
 	}
 	return cfg, nil
 }
 
-func loadConfigForValidationWithArtifactsDir(configFlags []string, artifactsDir string) ([]string, *config.Config, error) {
+func loadConfigForValidationWithStatePaths(configFlags []string, state operator.StatePaths) ([]string, *config.Config, error) {
 	configPaths := operator.ResolveConfigPaths(configFlags)
-	cfg, err := operatorLifecycle().LoadForValidationAtPathsWithArtifactsDir(configPaths, artifactsDir)
+	cfg, err := operatorLifecycle().LoadForValidationAtPathsWithStatePaths(configPaths, state)
 	if err != nil {
 		return nil, nil, err
 	}

--- a/gestaltd/cmd/gestaltd/main_test.go
+++ b/gestaltd/cmd/gestaltd/main_test.go
@@ -18,18 +18,18 @@ func TestE2ECLIHelp(t *testing.T) {
 		{
 			name:      "root",
 			args:      []string{"--help"},
-			wantParts: []string{"gestaltd validate", "gestaltd init", "gestaltd provider <command> [flags]", "gestaltd serve", "--locked", "[--config PATH]..."},
+			wantParts: []string{"gestaltd validate", "gestaltd init", "gestaltd provider <command> [flags]", "gestaltd serve", "--locked", "[--config PATH]...", "--lockfile PATH"},
 			notWant:   []string{"gestaltd bundle", "gestaltd dev"},
 		},
 		{
 			name:      "validate",
 			args:      []string{"validate", "--help"},
-			wantParts: []string{"gestaltd validate", "Repeated --config flags merge left-to-right."},
+			wantParts: []string{"gestaltd validate", "Repeated --config flags merge left-to-right.", "--lockfile PATH"},
 		},
 		{
 			name:      "init",
 			args:      []string{"init", "--help"},
-			wantParts: []string{"gestaltd init", "When repeated, --config files merge left-to-right."},
+			wantParts: []string{"gestaltd init", "When repeated, --config files merge left-to-right.", "--lockfile PATH"},
 		},
 		{
 			name:      "provider",

--- a/gestaltd/cmd/gestaltd/run.go
+++ b/gestaltd/cmd/gestaltd/run.go
@@ -75,6 +75,7 @@ func runServeCommand(name string, usage func(io.Writer), args []string, opts ser
 	var configPaths repeatedStringFlag
 	fs.Var(&configPaths, "config", "path to config file (repeat to layer overrides)")
 	artifactsDir := fs.String("artifacts-dir", "", "path to writable prepared-artifacts directory")
+	lockfilePath := fs.String("lockfile", "", "path to lockfile; defaults to gestalt.lock.json next to the primary config")
 	var lockedFlag *bool
 	if opts.allowLocked {
 		lockedFlag = fs.Bool("locked", false, "require exact lock state; do not auto-init")
@@ -102,7 +103,10 @@ func runServeCommand(name string, usage func(io.Writer), args []string, opts ser
 		locked = *lockedFlag
 	}
 
-	env, err := setupBootstrapWithConfigPaths(resolvedConfigPaths, *artifactsDir, locked)
+	env, err := setupBootstrapWithConfigPaths(resolvedConfigPaths, operator.StatePaths{
+		ArtifactsDir: *artifactsDir,
+		LockfilePath: *lockfilePath,
+	}, locked)
 	if err != nil {
 		return err
 	}
@@ -120,6 +124,7 @@ func runInit(args []string) error {
 	var configPaths repeatedStringFlag
 	fs.Var(&configPaths, "config", "path to config file (repeat to layer overrides)")
 	artifactsDir := fs.String("artifacts-dir", "", "path to writable prepared-artifacts directory")
+	lockfilePath := fs.String("lockfile", "", "path to lockfile; defaults to gestalt.lock.json next to the primary config")
 	platformFlag := fs.String("platform", "", "additional platforms to verify hashes for (comma-separated os/arch[/libc] or \"all\")")
 	if err := fs.Parse(args); err != nil {
 		return err
@@ -128,7 +133,10 @@ func runInit(args []string) error {
 		return fmt.Errorf("unexpected arguments: %s", strings.Join(fs.Args(), " "))
 	}
 
-	return initConfigWithArtifactsDir(configPaths, *artifactsDir, *platformFlag)
+	return initConfigWithStatePaths(configPaths, operator.StatePaths{
+		ArtifactsDir: *artifactsDir,
+		LockfilePath: *lockfilePath,
+	}, *platformFlag)
 }
 
 func runValidate(args []string) error {
@@ -136,6 +144,7 @@ func runValidate(args []string) error {
 	fs.Usage = func() { printValidateUsage(fs.Output()) }
 	var configPaths repeatedStringFlag
 	fs.Var(&configPaths, "config", "path to config file (repeat to layer overrides)")
+	lockfilePath := fs.String("lockfile", "", "path to lockfile; defaults to gestalt.lock.json next to the primary config")
 	if err := fs.Parse(args); err != nil {
 		return err
 	}
@@ -143,17 +152,20 @@ func runValidate(args []string) error {
 		return fmt.Errorf("unexpected arguments: %s", strings.Join(fs.Args(), " "))
 	}
 
-	return validateConfig(configPaths)
+	return validateConfig(configPaths, *lockfilePath)
 }
 
-func validateConfig(configFlags []string) error {
+func validateConfig(configFlags []string, lockfilePath string) error {
 	scratchDir, err := os.MkdirTemp("", "gestaltd-validate-*")
 	if err != nil {
 		return fmt.Errorf("create validation scratch dir: %w", err)
 	}
 	defer func() { _ = os.RemoveAll(scratchDir) }()
 
-	paths, cfg, err := loadConfigForValidationWithArtifactsDir(configFlags, scratchDir)
+	paths, cfg, err := loadConfigForValidationWithStatePaths(configFlags, operator.StatePaths{
+		ArtifactsDir: scratchDir,
+		LockfilePath: lockfilePath,
+	})
 	if err != nil {
 		return err
 	}
@@ -230,11 +242,11 @@ func maskEmpty(s string) string {
 
 func printMainUsage(w io.Writer) {
 	writeUsageLine(w, "Usage:")
-	writeUsageLine(w, "  gestaltd [--config PATH]... [--artifacts-dir PATH]")
-	writeUsageLine(w, "  gestaltd init [--config PATH]... [--artifacts-dir PATH] [--platform PLATFORMS]")
-	writeUsageLine(w, "  gestaltd serve [--config PATH]... [--artifacts-dir PATH] [--locked]")
+	writeUsageLine(w, "  gestaltd [--config PATH]... [--artifacts-dir PATH] [--lockfile PATH]")
+	writeUsageLine(w, "  gestaltd init [--config PATH]... [--artifacts-dir PATH] [--lockfile PATH] [--platform PLATFORMS]")
+	writeUsageLine(w, "  gestaltd serve [--config PATH]... [--artifacts-dir PATH] [--lockfile PATH] [--locked]")
 	writeUsageLine(w, "  gestaltd provider <command> [flags]")
-	writeUsageLine(w, "  gestaltd validate [--config PATH]...")
+	writeUsageLine(w, "  gestaltd validate [--config PATH]... [--lockfile PATH]")
 	writeUsageLine(w, "")
 	writeUsageLine(w, "Commands:")
 	writeUsageLine(w, "  init        Resolve providers and plugins and write lock state")
@@ -246,11 +258,12 @@ func printMainUsage(w io.Writer) {
 	writeUsageLine(w, "Flags:")
 	writeUsageLine(w, "  --config          Path to a config file; repeat to layer left-to-right")
 	writeUsageLine(w, "  --artifacts-dir   Path to writable prepared-artifacts directory for init/serve")
+	writeUsageLine(w, "  --lockfile        Path to lockfile; defaults to gestalt.lock.json next to the primary config")
 }
 
 func printServeUsage(w io.Writer) {
 	writeUsageLine(w, "Usage:")
-	writeUsageLine(w, "  gestaltd serve [--config PATH]... [--artifacts-dir PATH] [--locked]")
+	writeUsageLine(w, "  gestaltd serve [--config PATH]... [--artifacts-dir PATH] [--lockfile PATH] [--locked]")
 	writeUsageLine(w, "")
 	writeUsageLine(w, "Start the server. Auto-inits if lock state is missing or stale.")
 	writeUsageLine(w, "For production, strongly prefer --locked so startup uses the pinned")
@@ -262,10 +275,10 @@ func printServeUsage(w io.Writer) {
 
 func printInitUsage(w io.Writer) {
 	writeUsageLine(w, "Usage:")
-	writeUsageLine(w, "  gestaltd init [--config PATH]... [--artifacts-dir PATH] [--platform PLATFORMS]")
+	writeUsageLine(w, "  gestaltd init [--config PATH]... [--artifacts-dir PATH] [--lockfile PATH] [--platform PLATFORMS]")
 	writeUsageLine(w, "")
 	writeUsageLine(w, "Resolve managed plugin sources and write lock state.")
-	writeUsageLine(w, "Creates gestalt.lock.json in the config directory and prepared artifacts")
+	writeUsageLine(w, "By default, creates gestalt.lock.json in the config directory and prepared artifacts")
 	writeUsageLine(w, "in the artifacts directory. The lockfile records archive URLs for all")
 	writeUsageLine(w, "discovered platforms and verified SHA256 hashes for the current platform.")
 	writeUsageLine(w, "Use --platform to pre-verify hashes for additional deploy targets.")
@@ -275,16 +288,19 @@ func printInitUsage(w io.Writer) {
 	writeUsageLine(w, "Flags:")
 	writeUsageLine(w, "  --config          Path to a config file; repeat to layer left-to-right")
 	writeUsageLine(w, "  --artifacts-dir   Path to writable prepared-artifacts directory")
+	writeUsageLine(w, "  --lockfile        Path to lockfile; defaults to gestalt.lock.json next to the primary config")
 	writeUsageLine(w, "  --platform        Additional platforms to verify (comma-separated os/arch[/libc] or \"all\")")
 }
 
 func printValidateUsage(w io.Writer) {
 	writeUsageLine(w, "Usage:")
-	writeUsageLine(w, "  gestaltd validate [--config PATH]...")
+	writeUsageLine(w, "  gestaltd validate [--config PATH]... [--lockfile PATH]")
 	writeUsageLine(w, "")
 	writeUsageLine(w, "Validate configuration without starting the server or running migrations.")
 	writeUsageLine(w, "Validation always stages source-backed providers in a temporary scratch dir.")
 	writeUsageLine(w, "Repeated --config flags merge left-to-right.")
+	writeUsageLine(w, "The --lockfile path follows normal CLI path resolution; --artifacts-dir keeps")
+	writeUsageLine(w, "its existing config-relative behavior on init/serve for backward compatibility.")
 }
 
 func writeUsageLine(w io.Writer, line string) {

--- a/gestaltd/internal/operator/lifecycle.go
+++ b/gestaltd/internal/operator/lifecycle.go
@@ -81,6 +81,11 @@ type Lifecycle struct {
 	configSecretResolver func(context.Context, *config.Config) error
 }
 
+type StatePaths struct {
+	ArtifactsDir string
+	LockfilePath string
+}
+
 func NewLifecycle(sourceResolver pluginsource.Resolver) *Lifecycle {
 	return &Lifecycle{sourceResolver: sourceResolver}
 }
@@ -93,35 +98,28 @@ func (l *Lifecycle) WithConfigSecretResolver(resolve func(context.Context, *conf
 }
 
 func (l *Lifecycle) InitAtPath(configPath string) (*Lockfile, error) {
-	lock, _, err := l.initAtPaths([]string{configPath}, "")
-	return lock, err
-}
-
-func (l *Lifecycle) InitAtPathWithArtifactsDir(configPath, artifactsDir string) (*Lockfile, error) {
-	lock, _, err := l.initAtPaths([]string{configPath}, artifactsDir)
-	return lock, err
+	return l.InitAtPaths([]string{configPath})
 }
 
 func (l *Lifecycle) InitAtPaths(configPaths []string) (*Lockfile, error) {
-	lock, _, err := l.initAtPaths(configPaths, "")
-	return lock, err
+	return l.InitAtPathsWithStatePaths(configPaths, StatePaths{})
 }
 
-func (l *Lifecycle) InitAtPathsWithArtifactsDir(configPaths []string, artifactsDir string) (*Lockfile, error) {
-	lock, _, err := l.initAtPaths(configPaths, artifactsDir)
+func (l *Lifecycle) InitAtPathsWithStatePaths(configPaths []string, state StatePaths) (*Lockfile, error) {
+	lock, _, _, err := l.initAtPaths(configPaths, state)
 	return lock, err
 }
 
 // InitAtPathWithPlatforms runs init and additionally downloads and hashes
 // archives for the specified extra platforms.
 func (l *Lifecycle) InitAtPathWithPlatforms(configPath, artifactsDir string, platforms []struct{ GOOS, GOARCH, LibC string }) (*Lockfile, error) {
-	return l.InitAtPathsWithPlatforms([]string{configPath}, artifactsDir, platforms)
+	return l.InitAtPathsWithPlatforms([]string{configPath}, StatePaths{ArtifactsDir: artifactsDir}, platforms)
 }
 
 // InitAtPathsWithPlatforms runs init and additionally downloads and hashes
 // archives for the specified extra platforms.
-func (l *Lifecycle) InitAtPathsWithPlatforms(configPaths []string, artifactsDir string, platforms []struct{ GOOS, GOARCH, LibC string }) (*Lockfile, error) {
-	lock, cfg, err := l.initAtPaths(configPaths, artifactsDir)
+func (l *Lifecycle) InitAtPathsWithPlatforms(configPaths []string, state StatePaths, platforms []struct{ GOOS, GOARCH, LibC string }) (*Lockfile, error) {
+	lock, cfg, paths, err := l.initAtPaths(configPaths, state)
 	if err != nil {
 		return nil, err
 	}
@@ -129,50 +127,46 @@ func (l *Lifecycle) InitAtPathsWithPlatforms(configPaths []string, artifactsDir 
 		return lock, nil
 	}
 
-	configPath := primaryConfigPath(configPaths)
-	paths := initPathsForConfigsWithArtifactsDir(configPaths, resolveArtifactsDir(configPath, cfg, artifactsDir))
 	tokenForSource := buildSourceTokenMap(cfg)
 	if err := downloadPlatformArchives(context.Background(), lock, paths, platforms, tokenForSource); err != nil {
 		return nil, err
 	}
 
-	lockPath := lockfilePathForConfig(configPath)
-	if err := WriteLockfile(lockPath, lock); err != nil {
+	if err := WriteLockfile(paths.lockfilePath, lock); err != nil {
 		return nil, err
 	}
 	return lock, nil
 }
 
-func (l *Lifecycle) initAtPaths(configPaths []string, artifactsDir string) (*Lockfile, *config.Config, error) {
-	configPath := primaryConfigPath(configPaths)
+func (l *Lifecycle) initAtPaths(configPaths []string, state StatePaths) (*Lockfile, *config.Config, initPaths, error) {
 	cfg, err := config.LoadAllowMissingEnvPaths(configPaths)
 	if err != nil {
-		return nil, nil, fmt.Errorf("loading config: %v", err)
+		return nil, nil, initPaths{}, fmt.Errorf("loading config: %v", err)
 	}
 	if err := config.OverlayManagedPluginConfigPaths(configPaths, cfg); err != nil {
-		return nil, nil, fmt.Errorf("loading config: %v", err)
+		return nil, nil, initPaths{}, fmt.Errorf("loading config: %v", err)
 	}
-	paths := initPathsForConfigsWithArtifactsDir(configPaths, resolveArtifactsDir(configPath, cfg, artifactsDir))
+	paths := resolveInitPaths(configPaths, cfg, state)
 	lock, err := l.prepareRuntimeLockFromLoadedConfig(context.Background(), paths, cfg)
 	if err != nil {
-		return nil, nil, err
+		return nil, nil, initPaths{}, err
 	}
 	if err := l.applyPreparedProviders(paths, lock, cfg, true); err != nil {
-		return nil, nil, err
+		return nil, nil, initPaths{}, err
 	}
 	if err := config.ValidateResolvedStructure(cfg); err != nil {
-		return nil, nil, err
+		return nil, nil, initPaths{}, err
 	}
 	if err := plugininvocation.ValidateDependencies(context.Background(), cfg); err != nil {
-		return nil, nil, err
+		return nil, nil, initPaths{}, err
 	}
 	if err := WriteLockfile(paths.lockfilePath, lock); err != nil {
-		return nil, nil, err
+		return nil, nil, initPaths{}, err
 	}
 
 	slog.Info("prepared locked artifacts", "providers", len(lock.Providers), "auth", len(lock.Auth), "indexeddbs", len(lock.IndexedDBs), "cache", len(lock.Caches), "s3", len(lock.S3), "workflow", len(lock.Workflows), "secrets", len(lock.Secrets), "telemetry", len(lock.Telemetry), "audit", len(lock.Audit), "uis", len(lock.UIs))
 	slog.Info("wrote lockfile", "path", paths.lockfilePath)
-	return lock, cfg, nil
+	return lock, cfg, paths, nil
 }
 
 func (l *Lifecycle) prepareRuntimeLockFromLoadedConfig(ctx context.Context, paths initPaths, cfg *config.Config) (*Lockfile, error) {
@@ -293,7 +287,7 @@ func buildSourceTokenMap(cfg *config.Config) map[string]string {
 	return tokens
 }
 
-func lockfilePathForConfig(configPath string) string {
+func defaultLockfilePath(configPath string) string {
 	dir := filepath.Dir(configPath)
 	if !filepath.IsAbs(dir) {
 		if abs, err := filepath.Abs(dir); err == nil {
@@ -307,22 +301,17 @@ func (l *Lifecycle) LoadForExecutionAtPath(configPath string, locked bool) (*con
 	return l.LoadForExecutionAtPaths([]string{configPath}, locked)
 }
 
-func (l *Lifecycle) LoadForExecutionAtPathWithArtifactsDir(configPath, artifactsDir string, locked bool) (*config.Config, map[string]string, error) {
-	return l.LoadForExecutionAtPathsWithArtifactsDir([]string{configPath}, artifactsDir, locked)
-}
-
 func (l *Lifecycle) LoadForExecutionAtPaths(configPaths []string, locked bool) (*config.Config, map[string]string, error) {
-	return l.LoadForExecutionAtPathsWithArtifactsDir(configPaths, "", locked)
+	return l.LoadForExecutionAtPathsWithStatePaths(configPaths, StatePaths{}, locked)
 }
 
-func (l *Lifecycle) LoadForExecutionAtPathsWithArtifactsDir(configPaths []string, artifactsDir string, locked bool) (*config.Config, map[string]string, error) {
-	configPath := primaryConfigPath(configPaths)
+func (l *Lifecycle) LoadForExecutionAtPathsWithStatePaths(configPaths []string, state StatePaths, locked bool) (*config.Config, map[string]string, error) {
 	cfg, err := config.LoadPaths(configPaths)
 	if err != nil {
 		return nil, nil, fmt.Errorf("loading config: %v", err)
 	}
-	paths := initPathsForConfigsWithArtifactsDir(configPaths, resolveArtifactsDir(configPath, cfg, artifactsDir))
-	secretsLock, secretsValidated, err := l.lockForSecretsBootstrap(configPaths, artifactsDir, paths, cfg, locked)
+	paths := resolveInitPaths(configPaths, cfg, state)
+	secretsLock, secretsValidated, err := l.lockForSecretsBootstrap(configPaths, state, paths, cfg, locked)
 	if err != nil {
 		return nil, nil, err
 	}
@@ -336,7 +325,7 @@ func (l *Lifecycle) LoadForExecutionAtPathsWithArtifactsDir(configPaths []string
 		return nil, nil, err
 	}
 
-	dependenciesValidated, err := l.applyLockedProviders(configPaths, artifactsDir, cfg, locked, secretsLock)
+	dependenciesValidated, err := l.applyLockedProviders(configPaths, state, cfg, locked, secretsLock)
 	if err != nil {
 		return nil, nil, err
 	}
@@ -351,13 +340,12 @@ func (l *Lifecycle) LoadForExecutionAtPathsWithArtifactsDir(configPaths []string
 	return cfg, nil, nil
 }
 
-func (l *Lifecycle) LoadForValidationAtPathsWithArtifactsDir(configPaths []string, artifactsDir string) (*config.Config, error) {
-	configPath := primaryConfigPath(configPaths)
+func (l *Lifecycle) LoadForValidationAtPathsWithStatePaths(configPaths []string, state StatePaths) (*config.Config, error) {
 	cfg, err := config.LoadPaths(configPaths)
 	if err != nil {
 		return nil, fmt.Errorf("loading config: %v", err)
 	}
-	paths := initPathsForConfigsWithArtifactsDir(configPaths, resolveArtifactsDir(configPath, cfg, artifactsDir))
+	paths := resolveInitPaths(configPaths, cfg, state)
 	lock, err := l.prepareRuntimeLockFromLoadedConfig(context.Background(), paths, cfg)
 	if err != nil {
 		return nil, err
@@ -444,7 +432,7 @@ func (l *Lifecycle) resolveSecretsProviderMetadata(ctx context.Context, name str
 	return nil
 }
 
-func (l *Lifecycle) lockForSecretsBootstrap(configPaths []string, artifactsDir string, paths initPaths, cfg *config.Config, locked bool) (*Lockfile, bool, error) {
+func (l *Lifecycle) lockForSecretsBootstrap(configPaths []string, state StatePaths, paths initPaths, cfg *config.Config, locked bool) (*Lockfile, bool, error) {
 	if cfg == nil {
 		return nil, false, nil
 	}
@@ -469,11 +457,11 @@ func (l *Lifecycle) lockForSecretsBootstrap(configPaths []string, artifactsDir s
 	lock, err := ReadLockfile(paths.lockfilePath)
 	validatedDuringInit := false
 	if !locked && (err != nil || !lockMatchesConfig(cfg, paths, lock) || configHasLocalProviderSources(cfg)) {
-		lock, err = l.InitAtPathsWithArtifactsDir(configPaths, artifactsDir)
+		lock, err = l.InitAtPathsWithStatePaths(configPaths, state)
 		validatedDuringInit = err == nil
 	}
 	if err != nil {
-		return nil, false, fmt.Errorf("source-backed providers require prepared artifacts; run `gestaltd init %s`: %w", formatConfigFlags(configPaths), err)
+		return nil, false, fmt.Errorf("source-backed providers require prepared artifacts; run `gestaltd init %s`: %w", paths.configFlags, err)
 	}
 	return lock, validatedDuringInit, nil
 }
@@ -611,15 +599,32 @@ func primaryConfigPath(paths []string) string {
 	return paths[0]
 }
 
-func formatConfigFlags(paths []string) string {
+func formatInitFlags(paths []string, state StatePaths) string {
 	if len(paths) == 0 {
 		return ""
 	}
-	args := make([]string, 0, len(paths)*2)
+	args := make([]string, 0, len(paths)*2+4)
 	for _, path := range paths {
 		args = append(args, "--config", path)
 	}
+	if state.ArtifactsDir != "" {
+		args = append(args, "--artifacts-dir", state.ArtifactsDir)
+	}
+	if state.LockfilePath != "" {
+		args = append(args, "--lockfile", state.LockfilePath)
+	}
 	return strings.Join(args, " ")
+}
+
+func formatPlatformInitFlags(paths initPaths, platform string) string {
+	args := strings.TrimSpace(paths.configFlags)
+	if platform == "" {
+		return args
+	}
+	if args == "" {
+		return "--platform " + platform
+	}
+	return args + " --platform " + platform
 }
 
 type providerFingerprintInput struct {
@@ -757,25 +762,31 @@ func resolveArtifactsDir(configPath string, cfg *config.Config, override string)
 	return filepath.Join(filepath.Dir(configPath), dir)
 }
 
-func initPathsForConfig(configPath string) initPaths {
-	return initPathsForConfigsWithArtifactsDir([]string{configPath}, "")
+func resolveLockfilePath(configPath, override string) string {
+	if override == "" {
+		return defaultLockfilePath(configPath)
+	}
+	if filepath.IsAbs(override) {
+		return override
+	}
+	if abs, err := filepath.Abs(override); err == nil {
+		return abs
+	}
+	return override
 }
 
-func initPathsForConfigsWithArtifactsDir(configPaths []string, artifactsDir string) initPaths {
+func resolveInitPaths(configPaths []string, cfg *config.Config, state StatePaths) initPaths {
 	configPath := primaryConfigPath(configPaths)
 	configDir := filepath.Dir(configPath)
-	if artifactsDir == "" {
-		artifactsDir = configDir
-	} else if !filepath.IsAbs(artifactsDir) {
-		artifactsDir = filepath.Join(configDir, artifactsDir)
-	}
+	artifactsDir := resolveArtifactsDir(configPath, cfg, state.ArtifactsDir)
+	lockfilePath := resolveLockfilePath(configPath, state.LockfilePath)
 	return initPaths{
 		configPaths:  append([]string(nil), configPaths...),
-		configFlags:  formatConfigFlags(configPaths),
+		configFlags:  formatInitFlags(configPaths, state),
 		configPath:   configPath,
 		configDir:    configDir,
 		artifactsDir: artifactsDir,
-		lockfilePath: filepath.Join(configDir, InitLockfileName),
+		lockfilePath: lockfilePath,
 		providersDir: filepath.Join(artifactsDir, filepath.FromSlash(PreparedProvidersDir)),
 		authDir:      filepath.Join(artifactsDir, filepath.FromSlash(PreparedAuthDir)),
 		secretsDir:   filepath.Join(artifactsDir, filepath.FromSlash(PreparedSecretsDir)),
@@ -785,6 +796,10 @@ func initPathsForConfigsWithArtifactsDir(configPaths []string, artifactsDir stri
 		workflowDir:  filepath.Join(artifactsDir, filepath.FromSlash(PreparedWorkflowDir)),
 		uiDir:        filepath.Join(artifactsDir, filepath.FromSlash(PreparedUIDir)),
 	}
+}
+
+func initPathsForConfig(configPath string) initPaths {
+	return resolveInitPaths([]string{configPath}, nil, StatePaths{})
 }
 
 func providerDestDir(paths initPaths, name string) string {
@@ -946,6 +961,9 @@ func ReadLockfile(path string) (*Lockfile, error) {
 }
 
 func WriteLockfile(path string, lock *Lockfile) error {
+	if err := os.MkdirAll(filepath.Dir(path), 0o755); err != nil {
+		return fmt.Errorf("create lockfile parent directory: %w", err)
+	}
 	if err := writeJSONFile(path, providerLockfileFromLockfile(lock)); err != nil {
 		return fmt.Errorf("writing lockfile: %w", err)
 	}
@@ -1721,13 +1739,12 @@ func (l *Lifecycle) applyPreparedProviders(paths initPaths, lock *Lockfile, cfg 
 	return nil
 }
 
-func (l *Lifecycle) applyLockedProviders(configPaths []string, artifactsDir string, cfg *config.Config, locked bool, bootstrapLock *Lockfile) (bool, error) {
+func (l *Lifecycle) applyLockedProviders(configPaths []string, state StatePaths, cfg *config.Config, locked bool, bootstrapLock *Lockfile) (bool, error) {
 	if !configHasProviderLoading(cfg) {
 		return false, nil
 	}
 
-	configPath := primaryConfigPath(configPaths)
-	paths := initPathsForConfigsWithArtifactsDir(configPaths, resolveArtifactsDir(configPath, cfg, artifactsDir))
+	paths := resolveInitPaths(configPaths, cfg, state)
 	lock := bootstrapLock
 	var err error
 	validatedDuringInit := false
@@ -1735,11 +1752,11 @@ func (l *Lifecycle) applyLockedProviders(configPaths []string, artifactsDir stri
 		lock, err = ReadLockfile(paths.lockfilePath)
 	}
 	if !locked && (err != nil || !lockMatchesConfig(cfg, paths, lock) || (bootstrapLock == nil && configHasLocalProviderSources(cfg))) {
-		lock, err = l.InitAtPathsWithArtifactsDir(configPaths, artifactsDir)
+		lock, err = l.InitAtPathsWithStatePaths(configPaths, state)
 		validatedDuringInit = err == nil
 	}
 	if err != nil {
-		return false, fmt.Errorf("source-backed providers require prepared artifacts; run `gestaltd init %s`: %w", formatConfigFlags(configPaths), err)
+		return false, fmt.Errorf("source-backed providers require prepared artifacts; run `gestaltd init %s`: %w", paths.configFlags, err)
 	}
 	if err := l.applyPreparedProviders(paths, lock, cfg, locked); err != nil {
 		return false, err
@@ -2298,7 +2315,7 @@ func (l *Lifecycle) materializeLockedProvider(ctx context.Context, paths initPat
 		return fmt.Errorf("no archive for platform %s for provider %q; run `gestaltd init %s`", platform, name, paths.configFlags)
 	}
 	if locked && archive.SHA256 == "" {
-		return fmt.Errorf("no verified hash for platform %s for provider %q; run `gestaltd init --platform %s`", platform, name, platform)
+		return fmt.Errorf("no verified hash for platform %s for provider %q; run `gestaltd init %s`", platform, name, formatPlatformInitFlags(paths, platform))
 	}
 
 	src, parseErr := sourceForProvider(plugin)
@@ -2354,7 +2371,7 @@ func (l *Lifecycle) materializeLockedComponent(ctx context.Context, paths initPa
 		return fmt.Errorf("no archive for platform %s for %s %q; run `gestaltd init %s`", platform, kind, name, paths.configFlags)
 	}
 	if locked && archive.SHA256 == "" {
-		return fmt.Errorf("no verified hash for platform %s for %s %q; run `gestaltd init --platform %s`", platform, kind, name, platform)
+		return fmt.Errorf("no verified hash for platform %s for %s %q; run `gestaltd init %s`", platform, kind, name, formatPlatformInitFlags(paths, platform))
 	}
 
 	src, parseErr := sourceForProvider(plugin)
@@ -2415,7 +2432,7 @@ func (l *Lifecycle) materializeLockedUIProvider(ctx context.Context, paths initP
 		return fmt.Errorf("no archive for platform %s for ui provider; run `gestaltd init %s`", platform, paths.configFlags)
 	}
 	if locked && archive.SHA256 == "" {
-		return fmt.Errorf("no verified hash for platform %s for ui provider; run `gestaltd init --platform %s`", platform, platform)
+		return fmt.Errorf("no verified hash for platform %s for ui provider; run `gestaltd init %s`", platform, formatPlatformInitFlags(paths, platform))
 	}
 
 	src, parseErr := sourceForProvider(plugin)

--- a/gestaltd/internal/operator/lifecycle_source_test.go
+++ b/gestaltd/internal/operator/lifecycle_source_test.go
@@ -1941,10 +1941,11 @@ func TestSourcePluginInitWithPlatformsPersistsExtraPlatformHash(t *testing.T) {
 	if err := os.WriteFile(configPath, []byte(configYAML), 0o644); err != nil {
 		t.Fatalf("write config: %v", err)
 	}
+	lockPath := filepath.Join(dir, "state", "platforms", InitLockfileName)
 
 	resolver := &ghresolver.GitHubResolver{BaseURL: srv.URL}
 	lc := NewLifecycle(resolver)
-	lock, err := lc.InitAtPathWithPlatforms(configPath, "", []struct{ GOOS, GOARCH, LibC string }{
+	lock, err := lc.InitAtPathsWithPlatforms([]string{configPath}, StatePaths{LockfilePath: lockPath}, []struct{ GOOS, GOARCH, LibC string }{
 		{GOOS: extraPlatform.goos, GOARCH: extraPlatform.goarch},
 	})
 	if err != nil {
@@ -1974,12 +1975,15 @@ func TestSourcePluginInitWithPlatformsPersistsExtraPlatformHash(t *testing.T) {
 		t.Fatalf("lock extra-platform SHA256 = %q, want %q", got, hex.EncodeToString(extraArchiveSHA[:]))
 	}
 
-	readBack, err := ReadLockfile(filepath.Join(dir, InitLockfileName))
+	readBack, err := ReadLockfile(lockPath)
 	if err != nil {
 		t.Fatalf("ReadLockfile: %v", err)
 	}
 	if got := readBack.Providers["alpha"].Archives[extraPlatformKey].SHA256; got != hex.EncodeToString(extraArchiveSHA[:]) {
 		t.Fatalf("readBack extra-platform SHA256 = %q, want %q", got, hex.EncodeToString(extraArchiveSHA[:]))
+	}
+	if _, err := os.Stat(filepath.Join(dir, InitLockfileName)); !os.IsNotExist(err) {
+		t.Fatalf("default lockfile should not be written, got err=%v", err)
 	}
 }
 

--- a/gestaltd/internal/operator/lifecycle_test.go
+++ b/gestaltd/internal/operator/lifecycle_test.go
@@ -3415,7 +3415,7 @@ func TestApplyLockedPlugins_SkipsNilIntegrationPlugins(t *testing.T) {
 	loaded.Plugins["missing"] = &config.ProviderEntry{}
 
 	lc := NewLifecycle(nil)
-	if _, err := lc.applyLockedProviders([]string{cfgPath}, "", loaded, false, nil); err != nil {
+	if _, err := lc.applyLockedProviders([]string{cfgPath}, StatePaths{}, loaded, false, nil); err != nil {
 		t.Fatalf("applyLockedProviders: %v", err)
 	}
 	if loaded.Plugins["example"] == nil || loaded.Plugins["example"].ResolvedManifest == nil {


### PR DESCRIPTION
## Summary

Add a first-class `--lockfile PATH` override to `gestaltd`, `gestaltd init`, `gestaltd serve`, and `gestaltd validate`, and thread lockfile/artifact overrides through a single Go state-path abstraction instead of relying on the leftmost config path to place lock state.

## New interfaces

### Go

```go
state := operator.StatePaths{
    ArtifactsDir: ".gestaltd/local",
    LockfilePath: filepath.Join("local", "gestalt.lock.json"),
}

lock, err := lifecycle.InitAtPathsWithStatePaths(configPaths, state)
cfg, _, err := lifecycle.LoadForExecutionAtPathsWithStatePaths(configPaths, state, true)
cfg, err := lifecycle.LoadForValidationAtPathsWithStatePaths(configPaths, state)
```

### CLI

```sh
gestaltd [--config PATH]... [--artifacts-dir PATH] [--lockfile PATH]
gestaltd init [--config PATH]... [--artifacts-dir PATH] [--lockfile PATH] [--platform PLATFORMS]
gestaltd serve [--config PATH]... [--artifacts-dir PATH] [--lockfile PATH] [--locked]
gestaltd validate [--config PATH]... [--lockfile PATH]
```

Examples:

```sh
gestaltd init --config ./config.yaml --lockfile ./local/gestalt.lock.json
gestaltd serve --config ./config.yaml --lockfile ./local/gestalt.lock.json
gestaltd serve --locked --config ./config.yaml --lockfile ./local/gestalt.lock.json
gestaltd validate --config ./config.yaml --lockfile ./local/gestalt.lock.json
```

### YAML

No new YAML keys.

Existing config stays unchanged:

```yaml
server:
  encryptionKey: test-key
  providers:
    indexeddb: sqlite
plugins:
  example:
    source:
      path: ./plugin/manifest.yaml
```

Local workflows no longer need a dummy first config file only to move `gestalt.lock.json`; the YAML stays the same and the CLI controls lockfile placement explicitly.

## What changed

- add `operator.StatePaths{ArtifactsDir, LockfilePath}`
- centralize resolved state-path calculation in lifecycle code
- keep `--artifacts-dir` behavior unchanged for backward compatibility
- resolve `--lockfile` like a normal CLI path
- create parent directories automatically before writing an override lockfile
- wire `--lockfile` through bare `gestaltd`, `init`, `serve`, and `validate`
- extend CLI and lifecycle functional coverage for init, locked serve, unlocked serve, bare startup, validate, and `init --platform`
- update CLI reference docs

## Verification

```sh
go test ./cmd/gestaltd ./internal/operator ./internal/config
golangci-lint run
```