### PR TITLE
[codex] Fix declarative body param routing

### DIFF
--- a/gestaltd/core/integration/base.go
+++ b/gestaltd/core/integration/base.go
@@ -57,6 +57,7 @@ type Base struct {
 	HTTPClient                  *http.Client
 	Pagination                  map[string]apiexec.PaginationConfig
 	MethodDefaultParamLocations bool
+	RequestContentType          string
 	NoRetry                     bool
 
 	TokenParser     func(token string) (authHeader string, extraHeaders map[string]string, err error)

--- a/gestaltd/core/integration/egress_adapter.go
+++ b/gestaltd/core/integration/egress_adapter.go
@@ -50,6 +50,7 @@ func (b *Base) executeREST(ctx context.Context, operation string, catOp *catalog
 		Path:          catOp.Path,
 		Params:        bodyParams,
 		QueryParams:   queryParams,
+		ContentType:   b.RequestContentType,
 		AuthHeader:    credential.Authorization,
 		CustomHeaders: headers,
 		CheckResponse: b.CheckResponse,
@@ -155,6 +156,8 @@ func partitionParams(catOp *catalog.CatalogOperation, params map[string]any, use
 			httpKey = wn
 		}
 		switch locations[k] {
+		case "body":
+			body[k] = v
 		case "query":
 			query[httpKey] = v
 		case "header":

--- a/gestaltd/core/integration/param_routing_test.go
+++ b/gestaltd/core/integration/param_routing_test.go
@@ -107,6 +107,40 @@ func TestPartitionParams_MixedLocations(t *testing.T) {
 	}
 }
 
+func TestPartitionParams_MethodDefaultModeKeepsExplicitBodyParams(t *testing.T) {
+	t.Parallel()
+
+	catOp := &catalog.CatalogOperation{
+		ID:     "op1",
+		Method: http.MethodPost,
+		Parameters: []catalog.CatalogParameter{
+			{Name: "channel", Type: "string", Location: "body"},
+			{Name: "text", Type: "string", Location: "body"},
+			{Name: "cursor", Type: "string", Location: "query"},
+		},
+	}
+	params := map[string]any{
+		"channel": "D024BGTKK33",
+		"text":    "hello",
+		"cursor":  "abc",
+	}
+
+	body, query, headers := partitionParams(catOp, params, true)
+
+	if body["channel"] != "D024BGTKK33" {
+		t.Fatalf("body[channel] = %v, want D024BGTKK33", body["channel"])
+	}
+	if body["text"] != "hello" {
+		t.Fatalf("body[text] = %v, want hello", body["text"])
+	}
+	if query["cursor"] != "abc" {
+		t.Fatalf("query[cursor] = %v, want abc", query["cursor"])
+	}
+	if len(headers) != 0 {
+		t.Fatalf("headers = %v, want empty", headers)
+	}
+}
+
 func TestPartitionParams_UnknownParam(t *testing.T) {
 	t.Parallel()
 

--- a/gestaltd/internal/apiexec/apiexec.go
+++ b/gestaltd/internal/apiexec/apiexec.go
@@ -234,6 +234,10 @@ func doOnce(
 		httpReq.Header.Set(k, v)
 	}
 
+	if contentType != "" {
+		httpReq.Header.Set("Content-Type", contentType)
+	}
+
 	if req.AuthHeader != "" {
 		httpReq.Header.Set("Authorization", req.AuthHeader)
 	} else if req.Token != "" {

--- a/gestaltd/internal/apiexec/apiexec_content_type_test.go
+++ b/gestaltd/internal/apiexec/apiexec_content_type_test.go
@@ -1,0 +1,48 @@
+package apiexec
+
+import (
+	"context"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/valon-technologies/gestalt/server/internal/testutil"
+)
+
+func TestDo_POSTExplicitContentTypeOverridesCustomHeaders(t *testing.T) {
+	t.Parallel()
+
+	var gotContentType string
+	var gotBody map[string]any
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		gotContentType = r.Header.Get("Content-Type")
+		_ = json.NewDecoder(r.Body).Decode(&gotBody)
+
+		w.Header().Set("Content-Type", "application/json")
+		_ = json.NewEncoder(w).Encode(map[string]any{"ok": true})
+	}))
+	testutil.CloseOnCleanup(t, srv)
+
+	_, err := Do(context.Background(), srv.Client(), Request{
+		Method:      http.MethodPost,
+		BaseURL:     srv.URL,
+		Path:        "/items",
+		Params:      map[string]any{"name": "widget"},
+		ContentType: "application/json; charset=utf-8",
+		CustomHeaders: map[string]string{
+			"Content-Type": "text/plain",
+			"X-Test":       "1",
+		},
+	})
+	if err != nil {
+		t.Fatalf("Do: %v", err)
+	}
+
+	if gotContentType != "application/json; charset=utf-8" {
+		t.Fatalf("Content-Type = %q, want %q", gotContentType, "application/json; charset=utf-8")
+	}
+	if gotBody["name"] != "widget" {
+		t.Fatalf("body[name] = %v, want widget", gotBody["name"])
+	}
+}

--- a/gestaltd/internal/providerhost/declarative.go
+++ b/gestaltd/internal/providerhost/declarative.go
@@ -15,6 +15,7 @@ import (
 )
 
 const declarativeHTTPTimeout = 30 * time.Second
+const declarativeJSONContentType = "application/json; charset=utf-8"
 
 type declarativeOptions struct {
 	displayName    string
@@ -78,6 +79,7 @@ func NewDeclarativeProvider(manifest *providermanifestv1.Manifest, httpClient *h
 		Headers:                     maps.Clone(manifest.Spec.Headers),
 		HTTPClient:                  httpClient,
 		MethodDefaultParamLocations: true,
+		RequestContentType:          declarativeJSONContentType,
 		ConnectionDefs:              ConnectionParamDefsFromManifest(manifest.Spec.ConnectionParams),
 		DiscoveryDef:                DiscoveryConfigFromManifest(manifest.Spec.Discovery),
 		CredentialFieldDefs:         declarativeCredentialFields(auth),

--- a/gestaltd/internal/providerhost/declarative_test.go
+++ b/gestaltd/internal/providerhost/declarative_test.go
@@ -1,0 +1,81 @@
+package providerhost
+
+import (
+	"context"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/valon-technologies/gestalt/server/internal/testutil"
+	providermanifestv1 "github.com/valon-technologies/gestalt/server/sdk/providermanifest/v1"
+)
+
+func TestDeclarativeProvider_POSTUsesExplicitJSONContentType(t *testing.T) {
+	t.Parallel()
+
+	var gotContentType string
+	var gotHeader string
+	var gotBody map[string]any
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		gotContentType = r.Header.Get("Content-Type")
+		gotHeader = r.Header.Get("X-Test")
+		_ = json.NewDecoder(r.Body).Decode(&gotBody)
+
+		w.Header().Set("Content-Type", "application/json")
+		_ = json.NewEncoder(w).Encode(map[string]any{"ok": true})
+	}))
+	testutil.CloseOnCleanup(t, srv)
+
+	manifest := &providermanifestv1.Manifest{
+		Kind:    providermanifestv1.KindPlugin,
+		Source:  "github.com/test/declarative",
+		Version: "0.0.1-alpha.1",
+		Spec: &providermanifestv1.Spec{
+			Headers: map[string]string{
+				"Content-Type": "text/plain",
+				"X-Test":       "kept",
+			},
+			Surfaces: &providermanifestv1.ProviderSurfaces{
+				REST: &providermanifestv1.RESTSurface{
+					BaseURL: srv.URL,
+					Operations: []providermanifestv1.ProviderOperation{{
+						Name:   "chat.postMessage",
+						Method: http.MethodPost,
+						Path:   "/api/chat.postMessage",
+						Parameters: []providermanifestv1.ProviderParameter{
+							{Name: "channel", Type: "string", In: "body", Required: true},
+							{Name: "text", Type: "string", In: "body", Required: true},
+						},
+					}},
+				},
+			},
+		},
+	}
+
+	prov, err := NewDeclarativeProvider(manifest, srv.Client())
+	if err != nil {
+		t.Fatalf("NewDeclarativeProvider: %v", err)
+	}
+
+	_, err = prov.Execute(context.Background(), "chat.postMessage", map[string]any{
+		"channel": "D024BGTKK33",
+		"text":    "hello",
+	}, "")
+	if err != nil {
+		t.Fatalf("Execute: %v", err)
+	}
+
+	if gotContentType != declarativeJSONContentType {
+		t.Fatalf("Content-Type = %q, want %q", gotContentType, declarativeJSONContentType)
+	}
+	if gotHeader != "kept" {
+		t.Fatalf("X-Test = %q, want kept", gotHeader)
+	}
+	if gotBody["channel"] != "D024BGTKK33" {
+		t.Fatalf("body[channel] = %v, want D024BGTKK33", gotBody["channel"])
+	}
+	if gotBody["text"] != "hello" {
+		t.Fatalf("body[text] = %v, want hello", gotBody["text"])
+	}
+}


### PR DESCRIPTION
## Summary
Fix declarative REST write operations so explicitly body-scoped parameters are preserved and JSON request content types remain authoritative.

## Root Cause
Declarative providers on `main` route through `integration.Base` with `MethodDefaultParamLocations` enabled.
In `partitionParams`, parameters declared with `location: body` fell through the default branch and were skipped instead of being added to the request body.
That made Slack-style write operations behave like required body fields were missing.

A second issue was that generic custom headers could overwrite an explicit request `Content-Type`, which is brittle for JSON body operations.

## Changes
- add `RequestContentType` to `integration.Base` and pass it into REST execution
- route explicit `location: body` params into the request body even when method-default routing is enabled
- set declarative providers to use `application/json; charset=utf-8`
- reapply the resolved request content type after generic headers so it cannot be silently clobbered
- add focused regression tests for the routing and header-precedence cases

## Validation
- `go test ./core/integration ./internal/apiexec ./internal/providerhost`

## Impact
Declarative REST providers, including Slack write methods such as `chat.postMessage`, will send required body params upstream correctly and with a stable JSON content type.