### PR TITLE
Add YAML-managed workflow schedules

### DIFF
--- a/gestaltd/core/workflow/workflow.go
+++ b/gestaltd/core/workflow/workflow.go
@@ -5,6 +5,8 @@ import (
 	"time"
 )
 
+const ConfigManagedSchedulePrefix = "cfg_"
+
 type RunStatus string
 
 const (

--- a/gestaltd/go.mod
+++ b/gestaltd/go.mod
@@ -10,6 +10,7 @@ require (
 	github.com/mark3labs/mcp-go v0.48.0
 	github.com/pb33f/libopenapi v0.36.1
 	github.com/prometheus/client_golang v1.23.2
+	github.com/robfig/cron/v3 v3.0.1
 	github.com/santhosh-tekuri/jsonschema/v6 v6.0.2
 	github.com/valon-technologies/gestalt/sdk/go v0.0.0-00010101000000-000000000000
 	go.opentelemetry.io/contrib/bridges/otelslog v0.18.0

--- a/gestaltd/go.sum
+++ b/gestaltd/go.sum
@@ -67,6 +67,8 @@ github.com/prometheus/otlptranslator v1.0.0 h1:s0LJW/iN9dkIH+EnhiD3BlkkP5QVIUVEo
 github.com/prometheus/otlptranslator v1.0.0/go.mod h1:vRYWnXvI6aWGpsdY/mOT/cbeVRBlPWtBNDb7kGR3uKM=
 github.com/prometheus/procfs v0.20.1 h1:XwbrGOIplXW/AU3YhIhLODXMJYyC1isLFfYCsTEycfc=
 github.com/prometheus/procfs v0.20.1/go.mod h1:o9EMBZGRyvDrSPH1RqdxhojkuXstoe4UlK79eF5TGGo=
+github.com/robfig/cron/v3 v3.0.1 h1:WdRxkvbJztn8LMz/QEvLN5sBU+xKpSqwwUO1Pjr4qDs=
+github.com/robfig/cron/v3 v3.0.1/go.mod h1:eQICP3HwyT7UooqI/z+Ov+PtYAWygg1TEWWzGIFLtro=
 github.com/rogpeppe/go-internal v1.14.1 h1:UQB4HGPB6osV0SQTLymcB4TgvyWu6ZyliaW0tI/otEQ=
 github.com/rogpeppe/go-internal v1.14.1/go.mod h1:MaRKkUm5W0goXpeCfT7UZI6fk/L7L7so1lCWt35ZSgc=
 github.com/santhosh-tekuri/jsonschema/v6 v6.0.2 h1:KRzFb2m7YtdldCEkzs6KqmJw4nqEVZGK7IN2kJkjTuQ=

--- a/gestaltd/internal/bootstrap/bootstrap.go
+++ b/gestaltd/internal/bootstrap/bootstrap.go
@@ -639,13 +639,16 @@ func Bootstrap(ctx context.Context, cfg *config.Config, factories *FactoryRegist
 	if err != nil {
 		return nil, err
 	}
-	pluginInvoker.SetTarget(invocation.NewGuarded(sharedInvoker, nil, "plugin", audit, invocation.WithoutRateLimit()))
 	closeAudit := true
 	defer func() {
 		if closeAudit && auditClose != nil {
 			_ = auditClose(context.Background())
 		}
 	}()
+	pluginInvoker.SetTarget(invocation.NewGuarded(sharedInvoker, nil, "plugin", audit, invocation.WithoutRateLimit()))
+	if err := reconcileWorkflowConfigSchedules(ctx, cfg, prepared.Deps.WorkflowRuntime, prepared.Services.DB); err != nil {
+		return nil, err
+	}
 
 	closeProviders = false
 	closeCore = false

--- a/gestaltd/internal/bootstrap/bootstrap_test.go
+++ b/gestaltd/internal/bootstrap/bootstrap_test.go
@@ -2,6 +2,7 @@ package bootstrap_test
 
 import (
 	"context"
+	"crypto/sha256"
 	"encoding/base64"
 	"encoding/hex"
 	"fmt"
@@ -123,6 +124,118 @@ func (s *stubWorkflowProvider) PublishEvent(context.Context, coreworkflow.Publis
 }
 func (s *stubWorkflowProvider) Ping(context.Context) error { return nil }
 func (s *stubWorkflowProvider) Close() error               { return nil }
+
+type recordingWorkflowProvider struct {
+	upsertedSchedules     []coreworkflow.UpsertScheduleRequest
+	listedSchedules       []*coreworkflow.Schedule
+	listSchedulesErr      error
+	deletedSchedules      []coreworkflow.DeleteScheduleRequest
+	deleteScheduleErr     error
+	deleteMissingNotFound bool
+	getSchedule           *coreworkflow.Schedule
+	getScheduleErr        error
+	schedules             map[string]*coreworkflow.Schedule
+	closed                *atomic.Bool
+}
+
+func (p *recordingWorkflowProvider) StartRun(context.Context, coreworkflow.StartRunRequest) (*coreworkflow.Run, error) {
+	return &coreworkflow.Run{}, nil
+}
+func (p *recordingWorkflowProvider) GetRun(context.Context, coreworkflow.GetRunRequest) (*coreworkflow.Run, error) {
+	return &coreworkflow.Run{}, nil
+}
+func (p *recordingWorkflowProvider) ListRuns(context.Context, coreworkflow.ListRunsRequest) ([]*coreworkflow.Run, error) {
+	return nil, nil
+}
+func (p *recordingWorkflowProvider) CancelRun(context.Context, coreworkflow.CancelRunRequest) (*coreworkflow.Run, error) {
+	return &coreworkflow.Run{}, nil
+}
+func (p *recordingWorkflowProvider) UpsertSchedule(_ context.Context, req coreworkflow.UpsertScheduleRequest) (*coreworkflow.Schedule, error) {
+	p.upsertedSchedules = append(p.upsertedSchedules, req)
+	schedule := &coreworkflow.Schedule{
+		ID:        req.ScheduleID,
+		Cron:      req.Cron,
+		Timezone:  req.Timezone,
+		Target:    req.Target,
+		Paused:    req.Paused,
+		CreatedBy: req.RequestedBy,
+	}
+	if p.schedules == nil {
+		p.schedules = map[string]*coreworkflow.Schedule{}
+	}
+	p.schedules[req.ScheduleID] = schedule
+	return schedule, nil
+}
+func (p *recordingWorkflowProvider) GetSchedule(_ context.Context, req coreworkflow.GetScheduleRequest) (*coreworkflow.Schedule, error) {
+	if p.getSchedule != nil || p.getScheduleErr != nil {
+		return p.getSchedule, p.getScheduleErr
+	}
+	if p.schedules != nil {
+		if schedule, ok := p.schedules[req.ScheduleID]; ok {
+			return schedule, nil
+		}
+	}
+	return nil, core.ErrNotFound
+}
+func (p *recordingWorkflowProvider) ListSchedules(context.Context, coreworkflow.ListSchedulesRequest) ([]*coreworkflow.Schedule, error) {
+	if p.listSchedulesErr != nil {
+		return nil, p.listSchedulesErr
+	}
+	return append([]*coreworkflow.Schedule(nil), p.listedSchedules...), nil
+}
+func (p *recordingWorkflowProvider) DeleteSchedule(_ context.Context, req coreworkflow.DeleteScheduleRequest) error {
+	p.deletedSchedules = append(p.deletedSchedules, req)
+	if p.deleteScheduleErr != nil {
+		return p.deleteScheduleErr
+	}
+	if p.schedules != nil {
+		if _, ok := p.schedules[req.ScheduleID]; ok {
+			delete(p.schedules, req.ScheduleID)
+			return nil
+		}
+	}
+	if p.deleteMissingNotFound {
+		return core.ErrNotFound
+	}
+	if p.schedules != nil {
+		delete(p.schedules, req.ScheduleID)
+	}
+	return nil
+}
+func (p *recordingWorkflowProvider) PauseSchedule(context.Context, coreworkflow.PauseScheduleRequest) (*coreworkflow.Schedule, error) {
+	return &coreworkflow.Schedule{}, nil
+}
+func (p *recordingWorkflowProvider) ResumeSchedule(context.Context, coreworkflow.ResumeScheduleRequest) (*coreworkflow.Schedule, error) {
+	return &coreworkflow.Schedule{}, nil
+}
+func (p *recordingWorkflowProvider) UpsertEventTrigger(context.Context, coreworkflow.UpsertEventTriggerRequest) (*coreworkflow.EventTrigger, error) {
+	return &coreworkflow.EventTrigger{}, nil
+}
+func (p *recordingWorkflowProvider) GetEventTrigger(context.Context, coreworkflow.GetEventTriggerRequest) (*coreworkflow.EventTrigger, error) {
+	return &coreworkflow.EventTrigger{}, nil
+}
+func (p *recordingWorkflowProvider) ListEventTriggers(context.Context, coreworkflow.ListEventTriggersRequest) ([]*coreworkflow.EventTrigger, error) {
+	return nil, nil
+}
+func (p *recordingWorkflowProvider) DeleteEventTrigger(context.Context, coreworkflow.DeleteEventTriggerRequest) error {
+	return nil
+}
+func (p *recordingWorkflowProvider) PauseEventTrigger(context.Context, coreworkflow.PauseEventTriggerRequest) (*coreworkflow.EventTrigger, error) {
+	return &coreworkflow.EventTrigger{}, nil
+}
+func (p *recordingWorkflowProvider) ResumeEventTrigger(context.Context, coreworkflow.ResumeEventTriggerRequest) (*coreworkflow.EventTrigger, error) {
+	return &coreworkflow.EventTrigger{}, nil
+}
+func (p *recordingWorkflowProvider) PublishEvent(context.Context, coreworkflow.PublishEventRequest) error {
+	return nil
+}
+func (p *recordingWorkflowProvider) Ping(context.Context) error { return nil }
+func (p *recordingWorkflowProvider) Close() error {
+	if p.closed != nil {
+		p.closed.Store(true)
+	}
+	return nil
+}
 
 type trackedIndexedDB struct {
 	*coretesting.StubIndexedDB
@@ -583,6 +696,639 @@ func TestBootstrapPassesConfiguredWorkflowResourceNamesToProviders(t *testing.T)
 			t.Fatalf("workflow host env for %q = %q, want %q", name, got, providerhost.DefaultWorkflowHostSocketEnv)
 		}
 	}
+}
+
+func TestBootstrapAppliesConfiguredWorkflowSchedules(t *testing.T) {
+	t.Parallel()
+
+	cfg := workflowStartupCallbackConfig("https://example.invalid")
+	cfg.Plugins["roadmap"].Workflow = &config.PluginWorkflowConfig{
+		Provider:   "temporal",
+		Operations: []string{"sync"},
+		Schedules: map[string]config.PluginWorkflowSchedule{
+			"nightly_sync": {
+				Cron:      "0 2 * * *",
+				Timezone:  "America/New_York",
+				Operation: "sync",
+				Input: map[string]any{
+					"source": "yaml",
+				},
+			},
+		},
+	}
+	cfg.Providers.Workflow = map[string]*config.ProviderEntry{
+		"temporal": {Source: config.ProviderSource{Path: "stub"}},
+	}
+
+	factories := validFactories()
+	recorders := map[string]*recordingWorkflowProvider{}
+	factories.Workflow = func(_ context.Context, name string, _ yaml.Node, _ []providerhost.HostService, _ bootstrap.Deps) (coreworkflow.Provider, error) {
+		recorder := &recordingWorkflowProvider{}
+		recorders[name] = recorder
+		return recorder, nil
+	}
+
+	result, err := bootstrap.Bootstrap(context.Background(), cfg, factories)
+	if err != nil {
+		t.Fatalf("Bootstrap: %v", err)
+	}
+	defer func() { _ = result.Close(context.Background()) }()
+	<-result.ProvidersReady
+
+	recorder := recorders["temporal"]
+	if recorder == nil {
+		t.Fatal("missing workflow recorder for temporal")
+	}
+	if len(recorder.upsertedSchedules) != 1 {
+		t.Fatalf("upserted schedules = %d, want 1", len(recorder.upsertedSchedules))
+	}
+	got := recorder.upsertedSchedules[0]
+	if got.ScheduleID != workflowConfigScheduleID("roadmap", "nightly_sync") {
+		t.Fatalf("schedule id = %q", got.ScheduleID)
+	}
+	if got.Cron != "0 2 * * *" || got.Timezone != "America/New_York" {
+		t.Fatalf("schedule timing = %#v", got)
+	}
+	if got.Target.PluginName != "roadmap" || got.Target.Operation != "sync" {
+		t.Fatalf("target = %#v", got.Target)
+	}
+	if got.Target.Input["source"] != "yaml" {
+		t.Fatalf("target input = %#v", got.Target.Input)
+	}
+	if got.RequestedBy.SubjectID != "config:workflow:roadmap" || got.RequestedBy.SubjectKind != "system" || got.RequestedBy.AuthSource != "config" {
+		t.Fatalf("requestedBy = %#v", got.RequestedBy)
+	}
+}
+
+func TestValidateDoesNotApplyConfiguredWorkflowSchedules(t *testing.T) {
+	t.Parallel()
+
+	cfg := workflowStartupCallbackConfig("https://example.invalid")
+	cfg.Plugins["roadmap"].Workflow = &config.PluginWorkflowConfig{
+		Provider:   "temporal",
+		Operations: []string{"sync"},
+		Schedules: map[string]config.PluginWorkflowSchedule{
+			"nightly_sync": {
+				Cron:      "0 2 * * *",
+				Timezone:  "UTC",
+				Operation: "sync",
+				Paused:    true,
+			},
+		},
+	}
+	cfg.Providers.Workflow = map[string]*config.ProviderEntry{
+		"temporal": {Source: config.ProviderSource{Path: "stub"}},
+	}
+
+	factories := validFactories()
+	recorders := map[string]*recordingWorkflowProvider{}
+	factories.Workflow = func(_ context.Context, name string, _ yaml.Node, _ []providerhost.HostService, _ bootstrap.Deps) (coreworkflow.Provider, error) {
+		recorder := &recordingWorkflowProvider{}
+		recorders[name] = recorder
+		return recorder, nil
+	}
+
+	if _, err := bootstrap.Validate(context.Background(), cfg, factories); err != nil {
+		t.Fatalf("Validate: %v", err)
+	}
+
+	recorder := recorders["temporal"]
+	if recorder == nil {
+		t.Fatal("missing workflow recorder for temporal")
+	}
+	if len(recorder.upsertedSchedules) != 0 {
+		t.Fatalf("upserted schedules = %d, want 0", len(recorder.upsertedSchedules))
+	}
+	if len(recorder.deletedSchedules) != 0 {
+		t.Fatalf("deleted schedules = %d, want 0", len(recorder.deletedSchedules))
+	}
+}
+
+func TestBootstrapDeletesRemovedConfiguredWorkflowSchedules(t *testing.T) {
+	t.Parallel()
+
+	db := &coretesting.StubIndexedDB{}
+	factories := validFactories()
+	factories.IndexedDB = func(yaml.Node) (indexeddb.IndexedDB, error) { return db, nil }
+	recorders := []*recordingWorkflowProvider{}
+	factories.Workflow = func(_ context.Context, _ string, _ yaml.Node, _ []providerhost.HostService, _ bootstrap.Deps) (coreworkflow.Provider, error) {
+		recorder := &recordingWorkflowProvider{}
+		recorders = append(recorders, recorder)
+		return recorder, nil
+	}
+
+	cfg := workflowStartupCallbackConfig("https://example.invalid")
+	cfg.Plugins["roadmap"].Workflow = &config.PluginWorkflowConfig{
+		Provider:   "temporal",
+		Operations: []string{"sync"},
+		Schedules: map[string]config.PluginWorkflowSchedule{
+			"nightly_sync": {
+				Cron:      "0 2 * * *",
+				Timezone:  "UTC",
+				Operation: "sync",
+				Input: map[string]any{
+					"limit": 1,
+				},
+			},
+		},
+	}
+	cfg.Providers.Workflow = map[string]*config.ProviderEntry{
+		"temporal": {Source: config.ProviderSource{Path: "stub"}},
+	}
+
+	result, err := bootstrap.Bootstrap(context.Background(), cfg, factories)
+	if err != nil {
+		t.Fatalf("Bootstrap: %v", err)
+	}
+	if len(recorders) != 1 || len(recorders[0].upsertedSchedules) != 1 {
+		t.Fatalf("initial upserts = %#v", recorders)
+	}
+	_ = result.Close(context.Background())
+
+	cfg = workflowStartupCallbackConfig("https://example.invalid")
+	cfg.Plugins["roadmap"].Workflow = &config.PluginWorkflowConfig{
+		Provider:   "temporal",
+		Operations: []string{"sync"},
+	}
+	cfg.Providers.Workflow = map[string]*config.ProviderEntry{
+		"temporal": {Source: config.ProviderSource{Path: "stub"}},
+	}
+
+	result, err = bootstrap.Bootstrap(context.Background(), cfg, factories)
+	if err != nil {
+		t.Fatalf("Bootstrap remove schedule: %v", err)
+	}
+	defer func() { _ = result.Close(context.Background()) }()
+	<-result.ProvidersReady
+
+	if len(recorders) != 2 {
+		t.Fatalf("recorders = %d, want 2", len(recorders))
+	}
+	staleID := workflowConfigScheduleID("roadmap", "nightly_sync")
+	recorder := recorders[1]
+	if len(recorder.deletedSchedules) != 1 {
+		t.Fatalf("deleted schedules = %d, want 1", len(recorder.deletedSchedules))
+	}
+	if recorder.deletedSchedules[0].ScheduleID != staleID || recorder.deletedSchedules[0].PluginName != "roadmap" {
+		t.Fatalf("delete request = %#v", recorder.deletedSchedules[0])
+	}
+	if len(recorder.upsertedSchedules) != 0 {
+		t.Fatalf("upserted schedules = %d, want 0", len(recorder.upsertedSchedules))
+	}
+}
+
+func TestBootstrapIgnoresUserSchedulesThatOnlyShareCfgPrefix(t *testing.T) {
+	t.Parallel()
+
+	cfg := workflowStartupCallbackConfig("https://example.invalid")
+	cfg.Plugins["roadmap"].Workflow = &config.PluginWorkflowConfig{
+		Provider:   "temporal",
+		Operations: []string{"sync"},
+	}
+	cfg.Providers.Workflow = map[string]*config.ProviderEntry{
+		"temporal": {Source: config.ProviderSource{Path: "stub"}},
+	}
+
+	factories := validFactories()
+	recorders := map[string]*recordingWorkflowProvider{}
+	factories.Workflow = func(_ context.Context, name string, _ yaml.Node, _ []providerhost.HostService, _ bootstrap.Deps) (coreworkflow.Provider, error) {
+		recorder := &recordingWorkflowProvider{
+			listedSchedules: []*coreworkflow.Schedule{{ID: "cfg_backup"}},
+		}
+		recorders[name] = recorder
+		return recorder, nil
+	}
+
+	result, err := bootstrap.Bootstrap(context.Background(), cfg, factories)
+	if err != nil {
+		t.Fatalf("Bootstrap: %v", err)
+	}
+	defer func() { _ = result.Close(context.Background()) }()
+	<-result.ProvidersReady
+
+	recorder := recorders["temporal"]
+	if recorder == nil {
+		t.Fatal("missing workflow recorder for temporal")
+	}
+	if len(recorder.deletedSchedules) != 0 {
+		t.Fatalf("deleted schedules = %d, want 0", len(recorder.deletedSchedules))
+	}
+}
+
+func TestBootstrapMovesConfiguredWorkflowSchedulesToNewProvider(t *testing.T) {
+	t.Parallel()
+
+	db := &coretesting.StubIndexedDB{}
+	factories := validFactories()
+	factories.IndexedDB = func(yaml.Node) (indexeddb.IndexedDB, error) { return db, nil }
+	recorders := map[string][]*recordingWorkflowProvider{}
+	factories.Workflow = func(_ context.Context, name string, _ yaml.Node, _ []providerhost.HostService, _ bootstrap.Deps) (coreworkflow.Provider, error) {
+		recorder := &recordingWorkflowProvider{}
+		recorders[name] = append(recorders[name], recorder)
+		return recorder, nil
+	}
+
+	cfg := workflowStartupCallbackConfig("https://example.invalid")
+	cfg.Plugins["roadmap"].Workflow = &config.PluginWorkflowConfig{
+		Provider:   "temporal",
+		Operations: []string{"sync"},
+		Schedules: map[string]config.PluginWorkflowSchedule{
+			"nightly_sync": {
+				Cron:      "0 2 * * *",
+				Timezone:  "UTC",
+				Operation: "sync",
+				Input: map[string]any{
+					"limit": 1,
+				},
+			},
+		},
+	}
+	cfg.Providers.Workflow = map[string]*config.ProviderEntry{
+		"temporal": {Source: config.ProviderSource{Path: "stub"}},
+		"backup":   {Source: config.ProviderSource{Path: "stub"}},
+	}
+
+	result, err := bootstrap.Bootstrap(context.Background(), cfg, factories)
+	if err != nil {
+		t.Fatalf("Bootstrap: %v", err)
+	}
+	if len(recorders["temporal"]) != 1 || len(recorders["temporal"][0].upsertedSchedules) != 1 {
+		t.Fatalf("initial temporal recorders = %#v", recorders["temporal"])
+	}
+	_ = result.Close(context.Background())
+
+	cfg = workflowStartupCallbackConfig("https://example.invalid")
+	cfg.Plugins["roadmap"].Workflow = &config.PluginWorkflowConfig{
+		Provider:   "backup",
+		Operations: []string{"sync"},
+		Schedules: map[string]config.PluginWorkflowSchedule{
+			"nightly_sync": {
+				Cron:      "0 2 * * *",
+				Timezone:  "UTC",
+				Operation: "sync",
+				Input: map[string]any{
+					"limit": 1,
+				},
+			},
+		},
+	}
+	cfg.Providers.Workflow = map[string]*config.ProviderEntry{
+		"temporal": {Source: config.ProviderSource{Path: "stub"}},
+		"backup":   {Source: config.ProviderSource{Path: "stub"}},
+	}
+
+	result, err = bootstrap.Bootstrap(context.Background(), cfg, factories)
+	if err != nil {
+		t.Fatalf("Bootstrap move provider: %v", err)
+	}
+	defer func() { _ = result.Close(context.Background()) }()
+	<-result.ProvidersReady
+
+	if len(recorders["temporal"]) != 2 || len(recorders["backup"]) != 2 {
+		t.Fatalf("recorders = %#v", recorders)
+	}
+	if len(recorders["temporal"][1].deletedSchedules) != 1 {
+		t.Fatalf("temporal deleted schedules = %d, want 1", len(recorders["temporal"][1].deletedSchedules))
+	}
+	if len(recorders["backup"][1].upsertedSchedules) != 1 {
+		t.Fatalf("backup upserted schedules = %d, want 1", len(recorders["backup"][1].upsertedSchedules))
+	}
+}
+
+func TestBootstrapClosesWorkflowProvidersWhenConfigScheduleReconcileFails(t *testing.T) {
+	t.Parallel()
+
+	cfg := workflowStartupCallbackConfig("https://example.invalid")
+	cfg.Plugins["roadmap"].Workflow = &config.PluginWorkflowConfig{
+		Provider:   "temporal",
+		Operations: []string{"sync"},
+	}
+	cfg.Providers.Workflow = map[string]*config.ProviderEntry{
+		"temporal": {Source: config.ProviderSource{Path: "stub"}},
+	}
+
+	closed := &atomic.Bool{}
+	db := &coretesting.StubIndexedDB{}
+	factories := validFactories()
+	factories.IndexedDB = func(yaml.Node) (indexeddb.IndexedDB, error) { return db, nil }
+	factories.Workflow = func(_ context.Context, _ string, _ yaml.Node, _ []providerhost.HostService, _ bootstrap.Deps) (coreworkflow.Provider, error) {
+		return &recordingWorkflowProvider{closed: closed}, nil
+	}
+
+	cfg.Plugins["roadmap"].Workflow.Schedules = map[string]config.PluginWorkflowSchedule{
+		"nightly_sync": {
+			Cron:      "0 2 * * *",
+			Timezone:  "UTC",
+			Operation: "sync",
+		},
+	}
+
+	result, err := bootstrap.Bootstrap(context.Background(), cfg, factories)
+	if err != nil {
+		t.Fatalf("Bootstrap initial: %v", err)
+	}
+	_ = result.Close(context.Background())
+
+	cfg = workflowStartupCallbackConfig("https://example.invalid")
+	cfg.Plugins["roadmap"].Workflow = &config.PluginWorkflowConfig{
+		Provider:   "backup",
+		Operations: []string{"sync"},
+		Schedules: map[string]config.PluginWorkflowSchedule{
+			"nightly_sync": {
+				Cron:      "0 2 * * *",
+				Timezone:  "UTC",
+				Operation: "sync",
+				Input: map[string]any{
+					"limit": 1,
+				},
+			},
+		},
+	}
+	cfg.Providers.Workflow = map[string]*config.ProviderEntry{
+		"backup": {Source: config.ProviderSource{Path: "stub"}},
+	}
+
+	_, err = bootstrap.Bootstrap(context.Background(), cfg, factories)
+	if err == nil || !strings.Contains(err.Error(), `requires provider "temporal"`) {
+		t.Fatalf("Bootstrap error = %v, want missing old provider cleanup failure", err)
+	}
+	if !closed.Load() {
+		t.Fatal("workflow provider was not closed after reconcile failure")
+	}
+}
+
+func TestBootstrapDoesNotApplyConfiguredWorkflowSchedulesWhenAuditBuildFails(t *testing.T) {
+	t.Parallel()
+
+	cfg := workflowStartupCallbackConfig("https://example.invalid")
+	cfg.Plugins["roadmap"].Workflow = &config.PluginWorkflowConfig{
+		Provider:   "temporal",
+		Operations: []string{"sync"},
+		Schedules: map[string]config.PluginWorkflowSchedule{
+			"nightly_sync": {
+				Cron:      "0 2 * * *",
+				Timezone:  "UTC",
+				Operation: "sync",
+				Input: map[string]any{
+					"limit": 1,
+				},
+			},
+		},
+	}
+	cfg.Providers.Workflow = map[string]*config.ProviderEntry{
+		"temporal": {Source: config.ProviderSource{Path: "stub"}},
+	}
+	cfg.Providers.Audit = map[string]*config.ProviderEntry{
+		"default": {Source: config.ProviderSource{Builtin: "test-audit"}},
+	}
+
+	factories := validFactories()
+	recorder := &recordingWorkflowProvider{}
+	factories.Workflow = func(_ context.Context, _ string, _ yaml.Node, _ []providerhost.HostService, _ bootstrap.Deps) (coreworkflow.Provider, error) {
+		return recorder, nil
+	}
+	factories.Audit = func(context.Context, config.ProviderEntry, core.TelemetryProvider) (core.AuditSink, func(context.Context) error, error) {
+		return nil, nil, fmt.Errorf("audit boom")
+	}
+
+	_, err := bootstrap.Bootstrap(context.Background(), cfg, factories)
+	if err == nil || !strings.Contains(err.Error(), "audit boom") {
+		t.Fatalf("Bootstrap error = %v, want audit failure", err)
+	}
+	if len(recorder.upsertedSchedules) != 0 {
+		t.Fatalf("upserted schedules = %d, want 0", len(recorder.upsertedSchedules))
+	}
+}
+
+func TestBootstrapRejectsExistingUnmanagedWorkflowScheduleID(t *testing.T) {
+	t.Parallel()
+
+	cfg := workflowStartupCallbackConfig("https://example.invalid")
+	cfg.Plugins["roadmap"].Workflow = &config.PluginWorkflowConfig{
+		Provider:   "temporal",
+		Operations: []string{"sync"},
+		Schedules: map[string]config.PluginWorkflowSchedule{
+			"nightly_sync": {
+				Cron:      "0 2 * * *",
+				Timezone:  "UTC",
+				Operation: "sync",
+			},
+		},
+	}
+	cfg.Providers.Workflow = map[string]*config.ProviderEntry{
+		"temporal": {Source: config.ProviderSource{Path: "stub"}},
+	}
+
+	recorder := &recordingWorkflowProvider{
+		getSchedule: &coreworkflow.Schedule{ID: workflowConfigScheduleID("roadmap", "nightly_sync")},
+	}
+	factories := validFactories()
+	factories.Workflow = func(_ context.Context, _ string, _ yaml.Node, _ []providerhost.HostService, _ bootstrap.Deps) (coreworkflow.Provider, error) {
+		return recorder, nil
+	}
+
+	_, err := bootstrap.Bootstrap(context.Background(), cfg, factories)
+	if err == nil || !strings.Contains(err.Error(), "conflicts with existing unmanaged schedule id") {
+		t.Fatalf("Bootstrap error = %v, want ownership conflict", err)
+	}
+	if len(recorder.upsertedSchedules) != 0 {
+		t.Fatalf("upserted schedules = %d, want 0", len(recorder.upsertedSchedules))
+	}
+}
+
+func TestBootstrapReAdoptsManagedSchedulesWhenOwnershipStateIsMissing(t *testing.T) {
+	t.Parallel()
+
+	provider := &recordingWorkflowProvider{}
+	db1 := &coretesting.StubIndexedDB{}
+	db2 := &coretesting.StubIndexedDB{}
+	factories := validFactories()
+	currentDB := db1
+	factories.IndexedDB = func(yaml.Node) (indexeddb.IndexedDB, error) { return currentDB, nil }
+	factories.Workflow = func(_ context.Context, _ string, _ yaml.Node, _ []providerhost.HostService, _ bootstrap.Deps) (coreworkflow.Provider, error) {
+		return provider, nil
+	}
+
+	cfg := workflowStartupCallbackConfig("https://example.invalid")
+	cfg.Plugins["roadmap"].Workflow = &config.PluginWorkflowConfig{
+		Provider:   "temporal",
+		Operations: []string{"sync"},
+		Schedules: map[string]config.PluginWorkflowSchedule{
+			"nightly_sync": {
+				Cron:      "0 2 * * *",
+				Timezone:  "UTC",
+				Operation: "sync",
+			},
+		},
+	}
+	cfg.Providers.Workflow = map[string]*config.ProviderEntry{
+		"temporal": {Source: config.ProviderSource{Path: "stub"}},
+	}
+
+	result, err := bootstrap.Bootstrap(context.Background(), cfg, factories)
+	if err != nil {
+		t.Fatalf("Bootstrap initial: %v", err)
+	}
+	_ = result.Close(context.Background())
+	if len(provider.upsertedSchedules) != 1 {
+		t.Fatalf("initial upserted schedules = %d, want 1", len(provider.upsertedSchedules))
+	}
+	provider.schedules[workflowConfigScheduleID("roadmap", "nightly_sync")].Target.Input = map[string]any{
+		"limit": float64(1),
+	}
+
+	currentDB = db2
+	result, err = bootstrap.Bootstrap(context.Background(), cfg, factories)
+	if err != nil {
+		t.Fatalf("Bootstrap re-adopt: %v", err)
+	}
+	defer func() { _ = result.Close(context.Background()) }()
+	<-result.ProvidersReady
+
+	if len(provider.upsertedSchedules) != 2 {
+		t.Fatalf("upserted schedules = %d, want 2", len(provider.upsertedSchedules))
+	}
+}
+
+func TestBootstrapIgnoresMissingRemovedConfiguredWorkflowSchedule(t *testing.T) {
+	t.Parallel()
+
+	db := &coretesting.StubIndexedDB{}
+	provider := &recordingWorkflowProvider{deleteMissingNotFound: true}
+	factories := validFactories()
+	factories.IndexedDB = func(yaml.Node) (indexeddb.IndexedDB, error) { return db, nil }
+	factories.Workflow = func(_ context.Context, _ string, _ yaml.Node, _ []providerhost.HostService, _ bootstrap.Deps) (coreworkflow.Provider, error) {
+		return provider, nil
+	}
+
+	cfg := workflowStartupCallbackConfig("https://example.invalid")
+	cfg.Plugins["roadmap"].Workflow = &config.PluginWorkflowConfig{
+		Provider:   "temporal",
+		Operations: []string{"sync"},
+		Schedules: map[string]config.PluginWorkflowSchedule{
+			"nightly_sync": {
+				Cron:      "0 2 * * *",
+				Timezone:  "UTC",
+				Operation: "sync",
+			},
+		},
+	}
+	cfg.Providers.Workflow = map[string]*config.ProviderEntry{
+		"temporal": {Source: config.ProviderSource{Path: "stub"}},
+	}
+
+	result, err := bootstrap.Bootstrap(context.Background(), cfg, factories)
+	if err != nil {
+		t.Fatalf("Bootstrap initial: %v", err)
+	}
+	_ = result.Close(context.Background())
+	provider.schedules = map[string]*coreworkflow.Schedule{}
+
+	cfg = workflowStartupCallbackConfig("https://example.invalid")
+	cfg.Plugins["roadmap"].Workflow = &config.PluginWorkflowConfig{
+		Provider:   "temporal",
+		Operations: []string{"sync"},
+	}
+	cfg.Providers.Workflow = map[string]*config.ProviderEntry{
+		"temporal": {Source: config.ProviderSource{Path: "stub"}},
+	}
+
+	result, err = bootstrap.Bootstrap(context.Background(), cfg, factories)
+	if err != nil {
+		t.Fatalf("Bootstrap remove missing schedule: %v", err)
+	}
+	_ = result.Close(context.Background())
+
+	if len(provider.deletedSchedules) != 1 {
+		t.Fatalf("deleted schedules = %d, want 1", len(provider.deletedSchedules))
+	}
+
+	result, err = bootstrap.Bootstrap(context.Background(), cfg, factories)
+	if err != nil {
+		t.Fatalf("Bootstrap remove missing schedule replay: %v", err)
+	}
+	defer func() { _ = result.Close(context.Background()) }()
+	<-result.ProvidersReady
+
+	if len(provider.deletedSchedules) != 1 {
+		t.Fatalf("deleted schedules after replay = %d, want 1", len(provider.deletedSchedules))
+	}
+}
+
+func TestBootstrapIgnoresMissingOldScheduleDuringWorkflowProviderMove(t *testing.T) {
+	t.Parallel()
+
+	db := &coretesting.StubIndexedDB{}
+	temporal := &recordingWorkflowProvider{deleteMissingNotFound: true}
+	backup := &recordingWorkflowProvider{}
+	factories := validFactories()
+	factories.IndexedDB = func(yaml.Node) (indexeddb.IndexedDB, error) { return db, nil }
+	factories.Workflow = func(_ context.Context, name string, _ yaml.Node, _ []providerhost.HostService, _ bootstrap.Deps) (coreworkflow.Provider, error) {
+		if name == "backup" {
+			return backup, nil
+		}
+		return temporal, nil
+	}
+
+	cfg := workflowStartupCallbackConfig("https://example.invalid")
+	cfg.Plugins["roadmap"].Workflow = &config.PluginWorkflowConfig{
+		Provider:   "temporal",
+		Operations: []string{"sync"},
+		Schedules: map[string]config.PluginWorkflowSchedule{
+			"nightly_sync": {
+				Cron:      "0 2 * * *",
+				Timezone:  "UTC",
+				Operation: "sync",
+			},
+		},
+	}
+	cfg.Providers.Workflow = map[string]*config.ProviderEntry{
+		"temporal": {Source: config.ProviderSource{Path: "stub"}},
+		"backup":   {Source: config.ProviderSource{Path: "stub"}},
+	}
+
+	result, err := bootstrap.Bootstrap(context.Background(), cfg, factories)
+	if err != nil {
+		t.Fatalf("Bootstrap initial: %v", err)
+	}
+	_ = result.Close(context.Background())
+	temporal.schedules = map[string]*coreworkflow.Schedule{}
+
+	cfg = workflowStartupCallbackConfig("https://example.invalid")
+	cfg.Plugins["roadmap"].Workflow = &config.PluginWorkflowConfig{
+		Provider:   "backup",
+		Operations: []string{"sync"},
+		Schedules: map[string]config.PluginWorkflowSchedule{
+			"nightly_sync": {
+				Cron:      "0 2 * * *",
+				Timezone:  "UTC",
+				Operation: "sync",
+			},
+		},
+	}
+	cfg.Providers.Workflow = map[string]*config.ProviderEntry{
+		"temporal": {Source: config.ProviderSource{Path: "stub"}},
+		"backup":   {Source: config.ProviderSource{Path: "stub"}},
+	}
+
+	result, err = bootstrap.Bootstrap(context.Background(), cfg, factories)
+	if err != nil {
+		t.Fatalf("Bootstrap move provider: %v", err)
+	}
+	defer func() { _ = result.Close(context.Background()) }()
+	<-result.ProvidersReady
+
+	if len(backup.upsertedSchedules) != 1 {
+		t.Fatalf("backup upserted schedules = %d, want 1", len(backup.upsertedSchedules))
+	}
+	if len(temporal.deletedSchedules) == 0 {
+		t.Fatal("expected temporal cleanup delete to be attempted")
+	}
+}
+
+func workflowConfigScheduleID(pluginName, scheduleKey string) string {
+	sum := sha256.Sum256([]byte(pluginName + "\x00" + scheduleKey))
+	return coreworkflow.ConfigManagedSchedulePrefix + hex.EncodeToString(sum[:])
 }
 
 func TestBootstrapStartsWorkflowProvidersAfterInvokerIsReady(t *testing.T) {

--- a/gestaltd/internal/bootstrap/provider_build.go
+++ b/gestaltd/internal/bootstrap/provider_build.go
@@ -791,8 +791,12 @@ func buildPluginWorkflowHostServices(pluginName string, deps Deps) ([]providerho
 	return []providerhost.HostService{{
 		EnvVar: providerhost.DefaultWorkflowSocketEnv,
 		Register: func(srv *grpc.Server) {
-			proto.RegisterWorkflowServer(srv, providerhost.NewWorkflowServer(pluginName, func() (coreworkflow.Provider, map[string]struct{}, error) {
-				return deps.WorkflowRuntime.ResolvePlugin(pluginName)
+			proto.RegisterWorkflowServer(srv, providerhost.NewWorkflowServer(pluginName, func() (coreworkflow.Provider, map[string]struct{}, map[string]struct{}, error) {
+				provider, allowed, err := deps.WorkflowRuntime.ResolvePlugin(pluginName)
+				if err != nil {
+					return nil, nil, nil, err
+				}
+				return provider, allowed, deps.WorkflowRuntime.ManagedScheduleIDs(pluginName), nil
 			}))
 		},
 	}}, nil

--- a/gestaltd/internal/bootstrap/workflow_config_schedules.go
+++ b/gestaltd/internal/bootstrap/workflow_config_schedules.go
@@ -1,0 +1,306 @@
+package bootstrap
+
+import (
+	"bytes"
+	"context"
+	"crypto/sha256"
+	"encoding/hex"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"maps"
+	"slices"
+	"time"
+
+	"github.com/valon-technologies/gestalt/server/core"
+	"github.com/valon-technologies/gestalt/server/core/indexeddb"
+	coreworkflow "github.com/valon-technologies/gestalt/server/core/workflow"
+	"github.com/valon-technologies/gestalt/server/internal/config"
+	"google.golang.org/grpc/codes"
+	"google.golang.org/grpc/status"
+)
+
+const workflowConfigScheduleStateStore = "workflow_config_schedules"
+
+var workflowConfigScheduleStateSchema = indexeddb.ObjectStoreSchema{
+	Indexes: []indexeddb.IndexSchema{
+		{Name: "by_plugin", KeyPath: []string{"plugin_name"}},
+	},
+	Columns: []indexeddb.ColumnDef{
+		{Name: "id", Type: indexeddb.TypeString, PrimaryKey: true},
+		{Name: "plugin_name", Type: indexeddb.TypeString, NotNull: true},
+		{Name: "schedule_key", Type: indexeddb.TypeString, NotNull: true},
+		{Name: "provider_name", Type: indexeddb.TypeString, NotNull: true},
+		{Name: "schedule_id", Type: indexeddb.TypeString, NotNull: true},
+		{Name: "updated_at", Type: indexeddb.TypeTime},
+	},
+}
+
+type workflowConfigScheduleState struct {
+	ID           string
+	PluginName   string
+	ScheduleKey  string
+	ProviderName string
+	ScheduleID   string
+	UpdatedAt    time.Time
+}
+
+type desiredWorkflowConfigSchedule struct {
+	state    workflowConfigScheduleState
+	schedule config.PluginWorkflowSchedule
+}
+
+func reconcileWorkflowConfigSchedules(ctx context.Context, cfg *config.Config, runtime *workflowRuntime, db indexeddb.IndexedDB) error {
+	if cfg == nil || runtime == nil || db == nil {
+		return nil
+	}
+	if err := db.CreateObjectStore(ctx, workflowConfigScheduleStateStore, workflowConfigScheduleStateSchema); err != nil {
+		return fmt.Errorf("bootstrap: create workflow config schedule store: %w", err)
+	}
+	store := db.ObjectStore(workflowConfigScheduleStateStore)
+	previous, err := loadWorkflowConfigScheduleState(ctx, store)
+	if err != nil {
+		return err
+	}
+	desired, err := desiredWorkflowConfigSchedules(cfg)
+	if err != nil {
+		return err
+	}
+
+	for _, rowID := range slices.Sorted(maps.Keys(previous)) {
+		prev := previous[rowID]
+		if _, ok := desired[rowID]; ok {
+			continue
+		}
+		provider, err := runtime.ResolveProvider(prev.ProviderName)
+		if err != nil {
+			return fmt.Errorf("bootstrap: cleanup workflow schedule %q for plugin %q requires provider %q: %w", prev.ScheduleID, prev.PluginName, prev.ProviderName, err)
+		}
+		if err := provider.DeleteSchedule(ctx, coreworkflow.DeleteScheduleRequest{
+			PluginName: prev.PluginName,
+			ScheduleID: prev.ScheduleID,
+		}); err != nil {
+			if isWorkflowScheduleNotFound(err) {
+				if err := store.Delete(ctx, rowID); err != nil {
+					return fmt.Errorf("bootstrap: delete workflow schedule state %q: %w", rowID, err)
+				}
+				continue
+			}
+			return fmt.Errorf("bootstrap: delete workflow schedule %q for plugin %q: %w", prev.ScheduleID, prev.PluginName, err)
+		}
+		if err := store.Delete(ctx, rowID); err != nil {
+			return fmt.Errorf("bootstrap: delete workflow schedule state %q: %w", rowID, err)
+		}
+	}
+
+	for _, pluginName := range slices.Sorted(maps.Keys(cfg.Plugins)) {
+		entry := cfg.Plugins[pluginName]
+		effective, err := cfg.EffectivePluginWorkflow(pluginName, entry)
+		if err != nil {
+			return err
+		}
+		if !effective.Enabled || len(effective.Schedules) == 0 {
+			continue
+		}
+		provider, allowed, err := runtime.ResolvePlugin(pluginName)
+		if err != nil {
+			return fmt.Errorf("bootstrap: workflow schedules for plugin %q: %w", pluginName, err)
+		}
+		for _, scheduleKey := range slices.Sorted(maps.Keys(effective.Schedules)) {
+			schedule := effective.Schedules[scheduleKey]
+			if _, ok := allowed[schedule.Operation]; !ok {
+				return fmt.Errorf("bootstrap: workflow schedule %q for plugin %q targets disabled operation %q", scheduleKey, pluginName, schedule.Operation)
+			}
+			rowID := workflowConfigScheduleStateID(pluginName, scheduleKey)
+			desiredEntry := desired[rowID]
+			prev, owned := previous[rowID]
+			if !owned {
+				existing, err := provider.GetSchedule(ctx, coreworkflow.GetScheduleRequest{
+					PluginName: pluginName,
+					ScheduleID: desiredEntry.state.ScheduleID,
+				})
+				switch {
+				case err == nil:
+					if !isWorkflowConfigOwnedSchedule(existing, pluginName, desiredEntry.state.ScheduleID) &&
+						!isAdoptableWorkflowSchedule(existing, pluginName, schedule, desiredEntry.state.ScheduleID) {
+						return fmt.Errorf("bootstrap: workflow schedule %q for plugin %q conflicts with existing unmanaged schedule id %q", scheduleKey, pluginName, desiredEntry.state.ScheduleID)
+					}
+				case isWorkflowScheduleNotFound(err):
+				default:
+					return fmt.Errorf("bootstrap: get workflow schedule %q for plugin %q: %w", desiredEntry.state.ScheduleID, pluginName, err)
+				}
+			}
+			if _, err := provider.UpsertSchedule(ctx, coreworkflow.UpsertScheduleRequest{
+				ScheduleID:  desiredEntry.state.ScheduleID,
+				Cron:        schedule.Cron,
+				Timezone:    schedule.Timezone,
+				Target:      workflowConfigScheduleTarget(pluginName, schedule),
+				Paused:      schedule.Paused,
+				RequestedBy: workflowConfigActor(pluginName),
+			}); err != nil {
+				return fmt.Errorf("bootstrap: workflow schedule %q for plugin %q: %w", scheduleKey, pluginName, err)
+			}
+			if owned && prev.ProviderName != desiredEntry.state.ProviderName {
+				oldProvider, err := runtime.ResolveProvider(prev.ProviderName)
+				if err != nil {
+					return fmt.Errorf("bootstrap: cleanup workflow schedule %q for plugin %q requires provider %q: %w", prev.ScheduleID, prev.PluginName, prev.ProviderName, err)
+				}
+				if err := oldProvider.DeleteSchedule(ctx, coreworkflow.DeleteScheduleRequest{
+					PluginName: prev.PluginName,
+					ScheduleID: prev.ScheduleID,
+				}); err != nil && !isWorkflowScheduleNotFound(err) {
+					return fmt.Errorf("bootstrap: delete workflow schedule %q for plugin %q: %w", prev.ScheduleID, prev.PluginName, err)
+				}
+			}
+			if err := store.Put(ctx, desiredEntry.state.record()); err != nil {
+				return fmt.Errorf("bootstrap: store workflow schedule state %q: %w", rowID, err)
+			}
+		}
+	}
+	return nil
+}
+
+func desiredWorkflowConfigSchedules(cfg *config.Config) (map[string]desiredWorkflowConfigSchedule, error) {
+	desired := make(map[string]desiredWorkflowConfigSchedule)
+	if cfg == nil {
+		return desired, nil
+	}
+	now := time.Now()
+	for _, pluginName := range slices.Sorted(maps.Keys(cfg.Plugins)) {
+		entry := cfg.Plugins[pluginName]
+		effective, err := cfg.EffectivePluginWorkflow(pluginName, entry)
+		if err != nil {
+			return nil, err
+		}
+		if !effective.Enabled {
+			continue
+		}
+		for _, scheduleKey := range slices.Sorted(maps.Keys(effective.Schedules)) {
+			rowID := workflowConfigScheduleStateID(pluginName, scheduleKey)
+			desired[rowID] = desiredWorkflowConfigSchedule{
+				state: workflowConfigScheduleState{
+					ID:           rowID,
+					PluginName:   pluginName,
+					ScheduleKey:  scheduleKey,
+					ProviderName: effective.ProviderName,
+					ScheduleID:   workflowConfigScheduleID(pluginName, scheduleKey),
+					UpdatedAt:    now,
+				},
+				schedule: effective.Schedules[scheduleKey],
+			}
+		}
+	}
+	return desired, nil
+}
+
+func loadWorkflowConfigScheduleState(ctx context.Context, store indexeddb.ObjectStore) (map[string]workflowConfigScheduleState, error) {
+	recs, err := store.GetAll(ctx, nil)
+	if err != nil {
+		return nil, fmt.Errorf("bootstrap: load workflow schedule state: %w", err)
+	}
+	state := make(map[string]workflowConfigScheduleState, len(recs))
+	for _, rec := range recs {
+		entry := workflowConfigScheduleStateFromRecord(rec)
+		state[entry.ID] = entry
+	}
+	return state, nil
+}
+
+func (s workflowConfigScheduleState) record() indexeddb.Record {
+	return indexeddb.Record{
+		"id":            s.ID,
+		"plugin_name":   s.PluginName,
+		"schedule_key":  s.ScheduleKey,
+		"provider_name": s.ProviderName,
+		"schedule_id":   s.ScheduleID,
+		"updated_at":    s.UpdatedAt,
+	}
+}
+
+func workflowConfigScheduleStateFromRecord(rec indexeddb.Record) workflowConfigScheduleState {
+	return workflowConfigScheduleState{
+		ID:           workflowConfigScheduleRecordString(rec, "id"),
+		PluginName:   workflowConfigScheduleRecordString(rec, "plugin_name"),
+		ScheduleKey:  workflowConfigScheduleRecordString(rec, "schedule_key"),
+		ProviderName: workflowConfigScheduleRecordString(rec, "provider_name"),
+		ScheduleID:   workflowConfigScheduleRecordString(rec, "schedule_id"),
+		UpdatedAt:    workflowConfigScheduleRecordTime(rec, "updated_at"),
+	}
+}
+
+func workflowConfigScheduleRecordString(rec indexeddb.Record, key string) string {
+	if rec == nil {
+		return ""
+	}
+	value, _ := rec[key].(string)
+	return value
+}
+
+func workflowConfigScheduleRecordTime(rec indexeddb.Record, key string) time.Time {
+	if rec == nil {
+		return time.Time{}
+	}
+	value, _ := rec[key].(time.Time)
+	return value
+}
+
+func isWorkflowScheduleNotFound(err error) bool {
+	return errors.Is(err, core.ErrNotFound) || status.Code(err) == codes.NotFound
+}
+
+func isAdoptableWorkflowSchedule(existing *coreworkflow.Schedule, pluginName string, schedule config.PluginWorkflowSchedule, scheduleID string) bool {
+	if existing == nil {
+		return false
+	}
+	return existing.ID == scheduleID &&
+		existing.Cron == schedule.Cron &&
+		existing.Timezone == schedule.Timezone &&
+		existing.Paused == schedule.Paused &&
+		existing.Target.PluginName == pluginName &&
+		existing.Target.Operation == schedule.Operation &&
+		workflowScheduleInputsEqual(existing.Target.Input, schedule.Input)
+}
+
+func isWorkflowConfigOwnedSchedule(existing *coreworkflow.Schedule, pluginName, scheduleID string) bool {
+	if existing == nil {
+		return false
+	}
+	actor := workflowConfigActor(pluginName)
+	return existing.ID == scheduleID &&
+		existing.Target.PluginName == pluginName &&
+		existing.CreatedBy.SubjectID == actor.SubjectID &&
+		existing.CreatedBy.SubjectKind == actor.SubjectKind &&
+		existing.CreatedBy.AuthSource == actor.AuthSource
+}
+
+func workflowScheduleInputsEqual(left, right map[string]any) bool {
+	leftJSON, leftErr := json.Marshal(left)
+	rightJSON, rightErr := json.Marshal(right)
+	return leftErr == nil && rightErr == nil && bytes.Equal(leftJSON, rightJSON)
+}
+
+func workflowConfigScheduleTarget(pluginName string, schedule config.PluginWorkflowSchedule) coreworkflow.Target {
+	return coreworkflow.Target{
+		PluginName: pluginName,
+		Operation:  schedule.Operation,
+		Input:      maps.Clone(schedule.Input),
+	}
+}
+
+func workflowConfigActor(pluginName string) coreworkflow.Actor {
+	return coreworkflow.Actor{
+		SubjectID:   "config:workflow:" + pluginName,
+		SubjectKind: "system",
+		DisplayName: "Workflow Config (" + pluginName + ")",
+		AuthSource:  "config",
+	}
+}
+
+func workflowConfigScheduleStateID(pluginName, scheduleKey string) string {
+	return pluginName + "\x00" + scheduleKey
+}
+
+func workflowConfigScheduleID(pluginName, scheduleKey string) string {
+	sum := sha256.Sum256([]byte(pluginName + "\x00" + scheduleKey))
+	return coreworkflow.ConfigManagedSchedulePrefix + hex.EncodeToString(sum[:])
+}

--- a/gestaltd/internal/bootstrap/workflow_runtime.go
+++ b/gestaltd/internal/bootstrap/workflow_runtime.go
@@ -25,6 +25,7 @@ type workflowBinding struct {
 type workflowRuntime struct {
 	mu             sync.RWMutex
 	bindings       map[string]workflowBinding
+	managedIDs     map[string]map[string]struct{}
 	workloadTokens map[string]string
 	providers      map[string]coreworkflow.Provider
 	startupWaits   *startupWaitTracker
@@ -34,6 +35,7 @@ type workflowRuntime struct {
 func newWorkflowRuntime(cfg *config.Config) (*workflowRuntime, error) {
 	runtime := &workflowRuntime{
 		bindings:       make(map[string]workflowBinding, len(cfg.Plugins)),
+		managedIDs:     make(map[string]map[string]struct{}, len(cfg.Plugins)),
 		workloadTokens: make(map[string]string, len(cfg.Plugins)),
 		providers:      map[string]coreworkflow.Provider{},
 		startupWaits:   newStartupWaitTracker(),
@@ -54,6 +56,11 @@ func newWorkflowRuntime(cfg *config.Config) (*workflowRuntime, error) {
 			providerName: effective.ProviderName,
 			operations:   allowed,
 		}
+		managed := make(map[string]struct{}, len(effective.Schedules))
+		for scheduleKey := range effective.Schedules {
+			managed[workflowConfigScheduleID(pluginName, scheduleKey)] = struct{}{}
+		}
+		runtime.managedIDs[pluginName] = managed
 		runtime.workloadTokens[pluginName], err = workflowWorkloadToken()
 		if err != nil {
 			return nil, err
@@ -165,6 +172,28 @@ func (r *workflowRuntime) ResolvePlugin(pluginName string) (coreworkflow.Provide
 		return nil, nil, fmt.Errorf("workflow provider %q is not available", binding.providerName)
 	}
 	return provider, maps.Clone(binding.operations), nil
+}
+
+func (r *workflowRuntime) ResolveProvider(name string) (coreworkflow.Provider, error) {
+	if r == nil {
+		return nil, fmt.Errorf("workflow runtime is not configured")
+	}
+	r.mu.RLock()
+	defer r.mu.RUnlock()
+	provider, ok := r.providers[strings.TrimSpace(name)]
+	if !ok || provider == nil {
+		return nil, fmt.Errorf("workflow provider %q is not available", name)
+	}
+	return provider, nil
+}
+
+func (r *workflowRuntime) ManagedScheduleIDs(pluginName string) map[string]struct{} {
+	if r == nil {
+		return nil
+	}
+	r.mu.RLock()
+	defer r.mu.RUnlock()
+	return maps.Clone(r.managedIDs[pluginName])
 }
 
 func (r *workflowRuntime) Allow(providerName, pluginName, operation string) bool {

--- a/gestaltd/internal/config/config.go
+++ b/gestaltd/internal/config/config.go
@@ -172,8 +172,17 @@ type PluginIndexedDBConfig struct {
 }
 
 type PluginWorkflowConfig struct {
-	Provider   string   `yaml:"provider,omitempty"`
-	Operations []string `yaml:"operations,omitempty"`
+	Provider   string                            `yaml:"provider,omitempty"`
+	Operations []string                          `yaml:"operations,omitempty"`
+	Schedules  map[string]PluginWorkflowSchedule `yaml:"schedules,omitempty"`
+}
+
+type PluginWorkflowSchedule struct {
+	Cron      string         `yaml:"cron,omitempty"`
+	Timezone  string         `yaml:"timezone,omitempty"`
+	Operation string         `yaml:"operation,omitempty"`
+	Input     map[string]any `yaml:"input,omitempty"`
+	Paused    bool           `yaml:"paused,omitempty"`
 }
 
 func (c *PluginIndexedDBConfig) UnmarshalYAML(value *yaml.Node) error {

--- a/gestaltd/internal/config/config_test.go
+++ b/gestaltd/internal/config/config_test.go
@@ -2071,6 +2071,12 @@ plugins:
       operations:
         - nightly_sync
         - backfill_items
+      schedules:
+        nightly:
+          cron: "0 2 * * *"
+          operation: nightly_sync
+          input:
+            source: yaml
 providers:
   workflow:
     temporal:
@@ -2093,6 +2099,16 @@ server:
 		want := &PluginWorkflowConfig{
 			Provider:   "temporal",
 			Operations: []string{"nightly_sync", "backfill_items"},
+			Schedules: map[string]PluginWorkflowSchedule{
+				"nightly": {
+					Cron:      "0 2 * * *",
+					Timezone:  "UTC",
+					Operation: "nightly_sync",
+					Input: map[string]any{
+						"source": "yaml",
+					},
+				},
+			},
 		}
 		if got := cfg.Plugins["roadmap"].Workflow; !reflect.DeepEqual(got, want) {
 			t.Fatalf("Plugins[roadmap].Workflow = %#v, want %#v", got, want)
@@ -2252,6 +2268,87 @@ server:
 			t.Fatal("Load: expected error, got nil")
 		}
 		if !strings.Contains(err.Error(), `providers.workflow declares multiple defaults: cleanup, temporal`) {
+			t.Fatalf("unexpected error: %v", err)
+		}
+	})
+
+	t.Run("rejects workflow schedules with operations outside workflow bindings", func(t *testing.T) {
+		t.Parallel()
+
+		path := mustWriteConfigFile(t, `
+plugins:
+  roadmap:
+    source:
+      path: ./plugin/manifest.yaml
+    workflow:
+      provider: temporal
+      operations:
+        - nightly_sync
+      schedules:
+        invalid:
+          cron: "*/5 * * * *"
+          operation: backfill_items
+providers:
+  workflow:
+    temporal:
+      source:
+        path: ./providers/workflow/temporal
+  indexeddb:
+    sqlite:
+      source:
+        path: ./providers/datastore/sqlite
+server:
+  providers:
+    indexeddb: sqlite
+  encryptionKey: server-key
+`)
+
+		_, err := Load(path)
+		if err == nil {
+			t.Fatal("Load: expected error, got nil")
+		}
+		if !strings.Contains(err.Error(), `workflow.schedules.invalid.operation "backfill_items" must be listed`) {
+			t.Fatalf("unexpected error: %v", err)
+		}
+	})
+
+	t.Run("rejects invalid workflow schedule cron and timezone", func(t *testing.T) {
+		t.Parallel()
+
+		path := mustWriteConfigFile(t, `
+plugins:
+  roadmap:
+    source:
+      path: ./plugin/manifest.yaml
+    workflow:
+      provider: temporal
+      operations:
+        - nightly_sync
+      schedules:
+        invalid:
+          cron: "0 0 0 * * *"
+          timezone: Mars/Olympus
+          operation: nightly_sync
+providers:
+  workflow:
+    temporal:
+      source:
+        path: ./providers/workflow/temporal
+  indexeddb:
+    sqlite:
+      source:
+        path: ./providers/datastore/sqlite
+server:
+  providers:
+    indexeddb: sqlite
+  encryptionKey: server-key
+`)
+
+		_, err := Load(path)
+		if err == nil {
+			t.Fatal("Load: expected error, got nil")
+		}
+		if !strings.Contains(err.Error(), `workflow.schedules.invalid.cron`) {
 			t.Fatalf("unexpected error: %v", err)
 		}
 	})

--- a/gestaltd/internal/config/config_validate.go
+++ b/gestaltd/internal/config/config_validate.go
@@ -9,7 +9,9 @@ import (
 	"sort"
 	"strconv"
 	"strings"
+	"time"
 
+	cronv3 "github.com/robfig/cron/v3"
 	"github.com/valon-technologies/gestalt/server/internal/emailutil"
 	"github.com/valon-technologies/gestalt/server/internal/pluginsource"
 	"github.com/valon-technologies/gestalt/server/internal/providerenv"
@@ -699,8 +701,54 @@ func validatePluginWorkflowConfig(cfg *Config, name string, entry *ProviderEntry
 	if len(entry.Workflow.Operations) == 0 {
 		return fmt.Errorf("config validation: plugins.%s.workflow.operations must not be empty", name)
 	}
+	if len(entry.Workflow.Schedules) > 0 {
+		normalized := make(map[string]PluginWorkflowSchedule, len(entry.Workflow.Schedules))
+		for key, schedule := range entry.Workflow.Schedules {
+			key = strings.TrimSpace(key)
+			if key == "" {
+				return fmt.Errorf("config validation: plugins.%s.workflow.schedules keys must not be empty", name)
+			}
+			if _, exists := normalized[key]; exists {
+				return fmt.Errorf("config validation: plugins.%s.workflow.schedules duplicates %q", name, key)
+			}
+			schedule.Cron = strings.TrimSpace(schedule.Cron)
+			if schedule.Cron == "" {
+				return fmt.Errorf("config validation: plugins.%s.workflow.schedules.%s.cron is required", name, key)
+			}
+			if err := validateWorkflowScheduleCron(name, key, schedule.Cron); err != nil {
+				return err
+			}
+			schedule.Operation = strings.TrimSpace(schedule.Operation)
+			if schedule.Operation == "" {
+				return fmt.Errorf("config validation: plugins.%s.workflow.schedules.%s.operation is required", name, key)
+			}
+			if _, exists := seenOps[schedule.Operation]; !exists {
+				return fmt.Errorf("config validation: plugins.%s.workflow.schedules.%s.operation %q must be listed in plugins.%s.workflow.operations", name, key, schedule.Operation, name)
+			}
+			schedule.Timezone = strings.TrimSpace(schedule.Timezone)
+			if schedule.Timezone == "" {
+				schedule.Timezone = "UTC"
+			}
+			if _, err := time.LoadLocation(schedule.Timezone); err != nil {
+				return fmt.Errorf("config validation: plugins.%s.workflow.schedules.%s.timezone %q is invalid: %w", name, key, schedule.Timezone, err)
+			}
+			normalized[key] = schedule
+		}
+		entry.Workflow.Schedules = normalized
+	}
 	if _, err := cfg.EffectivePluginWorkflow(name, entry); err != nil {
 		return err
+	}
+	return nil
+}
+
+var workflowScheduleCronParser = cronv3.NewParser(
+	cronv3.Minute | cronv3.Hour | cronv3.Dom | cronv3.Month | cronv3.Dow,
+)
+
+func validateWorkflowScheduleCron(pluginName, scheduleKey, spec string) error {
+	if _, err := workflowScheduleCronParser.Parse(spec); err != nil {
+		return fmt.Errorf("config validation: plugins.%s.workflow.schedules.%s.cron %q is invalid: %w", pluginName, scheduleKey, spec, err)
 	}
 	return nil
 }

--- a/gestaltd/internal/config/provider_selection.go
+++ b/gestaltd/internal/config/provider_selection.go
@@ -2,6 +2,7 @@ package config
 
 import (
 	"fmt"
+	"maps"
 	"slices"
 	"sort"
 	"strings"
@@ -93,6 +94,7 @@ type EffectivePluginWorkflow struct {
 	ProviderName string
 	Provider     *ProviderEntry
 	Operations   []string
+	Schedules    map[string]PluginWorkflowSchedule
 }
 
 func (c *Config) EffectivePluginIndexedDB(pluginName string, entry *ProviderEntry) (EffectivePluginIndexedDB, error) {
@@ -181,7 +183,20 @@ func ResolveEffectivePluginWorkflow(pluginName string, entry *ProviderEntry, sel
 		ProviderName: providerName,
 		Provider:     provider,
 		Operations:   slices.Clone(entry.Workflow.Operations),
+		Schedules:    clonePluginWorkflowSchedules(entry.Workflow.Schedules),
 	}, nil
+}
+
+func clonePluginWorkflowSchedules(src map[string]PluginWorkflowSchedule) map[string]PluginWorkflowSchedule {
+	if len(src) == 0 {
+		return nil
+	}
+	dst := make(map[string]PluginWorkflowSchedule, len(src))
+	for key, schedule := range src {
+		schedule.Input = maps.Clone(schedule.Input)
+		dst[key] = schedule
+	}
+	return dst
 }
 
 func ResolveSelectedHostProvider(kind HostProviderKind, explicit string, entries map[string]*ProviderEntry) (string, *ProviderEntry, error) {

--- a/gestaltd/internal/providerhost/workflow_server.go
+++ b/gestaltd/internal/providerhost/workflow_server.go
@@ -12,7 +12,7 @@ import (
 	"google.golang.org/protobuf/types/known/emptypb"
 )
 
-type workflowProviderResolver func() (coreworkflow.Provider, map[string]struct{}, error)
+type workflowProviderResolver func() (coreworkflow.Provider, map[string]struct{}, map[string]struct{}, error)
 
 type WorkflowServer struct {
 	proto.UnimplementedWorkflowServer
@@ -28,7 +28,7 @@ func NewWorkflowServer(pluginName string, resolver workflowProviderResolver) *Wo
 }
 
 func (s *WorkflowServer) StartRun(ctx context.Context, req *proto.StartWorkflowRunRequest) (*proto.WorkflowRun, error) {
-	provider, allowed, err := s.resolve()
+	provider, allowed, _, err := s.resolve()
 	if err != nil {
 		return nil, err
 	}
@@ -48,7 +48,7 @@ func (s *WorkflowServer) StartRun(ctx context.Context, req *proto.StartWorkflowR
 }
 
 func (s *WorkflowServer) GetRun(ctx context.Context, req *proto.GetWorkflowRunRequest) (*proto.WorkflowRun, error) {
-	provider, _, err := s.resolve()
+	provider, _, _, err := s.resolve()
 	if err != nil {
 		return nil, err
 	}
@@ -63,7 +63,7 @@ func (s *WorkflowServer) GetRun(ctx context.Context, req *proto.GetWorkflowRunRe
 }
 
 func (s *WorkflowServer) ListRuns(ctx context.Context, _ *proto.ListWorkflowRunsRequest) (*proto.ListWorkflowRunsResponse, error) {
-	provider, _, err := s.resolve()
+	provider, _, _, err := s.resolve()
 	if err != nil {
 		return nil, err
 	}
@@ -83,7 +83,7 @@ func (s *WorkflowServer) ListRuns(ctx context.Context, _ *proto.ListWorkflowRuns
 }
 
 func (s *WorkflowServer) CancelRun(ctx context.Context, req *proto.CancelWorkflowRunRequest) (*proto.WorkflowRun, error) {
-	provider, _, err := s.resolve()
+	provider, _, _, err := s.resolve()
 	if err != nil {
 		return nil, err
 	}
@@ -99,8 +99,11 @@ func (s *WorkflowServer) CancelRun(ctx context.Context, req *proto.CancelWorkflo
 }
 
 func (s *WorkflowServer) UpsertSchedule(ctx context.Context, req *proto.UpsertWorkflowScheduleRequest) (*proto.WorkflowSchedule, error) {
-	provider, allowed, err := s.resolve()
+	provider, allowed, managedIDs, err := s.resolve()
 	if err != nil {
+		return nil, err
+	}
+	if err := rejectManagedWorkflowScheduleID(req.GetScheduleId(), managedIDs); err != nil {
 		return nil, err
 	}
 	target := pluginWorkflowTargetFromProto(s.pluginName, req.GetTarget())
@@ -122,7 +125,7 @@ func (s *WorkflowServer) UpsertSchedule(ctx context.Context, req *proto.UpsertWo
 }
 
 func (s *WorkflowServer) GetSchedule(ctx context.Context, req *proto.GetWorkflowScheduleRequest) (*proto.WorkflowSchedule, error) {
-	provider, _, err := s.resolve()
+	provider, _, _, err := s.resolve()
 	if err != nil {
 		return nil, err
 	}
@@ -137,7 +140,7 @@ func (s *WorkflowServer) GetSchedule(ctx context.Context, req *proto.GetWorkflow
 }
 
 func (s *WorkflowServer) ListSchedules(ctx context.Context, _ *proto.ListWorkflowSchedulesRequest) (*proto.ListWorkflowSchedulesResponse, error) {
-	provider, _, err := s.resolve()
+	provider, _, _, err := s.resolve()
 	if err != nil {
 		return nil, err
 	}
@@ -157,8 +160,11 @@ func (s *WorkflowServer) ListSchedules(ctx context.Context, _ *proto.ListWorkflo
 }
 
 func (s *WorkflowServer) DeleteSchedule(ctx context.Context, req *proto.DeleteWorkflowScheduleRequest) (*emptypb.Empty, error) {
-	provider, _, err := s.resolve()
+	provider, _, managedIDs, err := s.resolve()
 	if err != nil {
+		return nil, err
+	}
+	if err := rejectManagedWorkflowScheduleID(req.GetScheduleId(), managedIDs); err != nil {
 		return nil, err
 	}
 	if err := provider.DeleteSchedule(ctx, coreworkflow.DeleteScheduleRequest{
@@ -171,8 +177,11 @@ func (s *WorkflowServer) DeleteSchedule(ctx context.Context, req *proto.DeleteWo
 }
 
 func (s *WorkflowServer) PauseSchedule(ctx context.Context, req *proto.PauseWorkflowScheduleRequest) (*proto.WorkflowSchedule, error) {
-	provider, _, err := s.resolve()
+	provider, _, managedIDs, err := s.resolve()
 	if err != nil {
+		return nil, err
+	}
+	if err := rejectManagedWorkflowScheduleID(req.GetScheduleId(), managedIDs); err != nil {
 		return nil, err
 	}
 	value, err := provider.PauseSchedule(ctx, coreworkflow.PauseScheduleRequest{
@@ -186,8 +195,11 @@ func (s *WorkflowServer) PauseSchedule(ctx context.Context, req *proto.PauseWork
 }
 
 func (s *WorkflowServer) ResumeSchedule(ctx context.Context, req *proto.ResumeWorkflowScheduleRequest) (*proto.WorkflowSchedule, error) {
-	provider, _, err := s.resolve()
+	provider, _, managedIDs, err := s.resolve()
 	if err != nil {
+		return nil, err
+	}
+	if err := rejectManagedWorkflowScheduleID(req.GetScheduleId(), managedIDs); err != nil {
 		return nil, err
 	}
 	value, err := provider.ResumeSchedule(ctx, coreworkflow.ResumeScheduleRequest{
@@ -201,7 +213,7 @@ func (s *WorkflowServer) ResumeSchedule(ctx context.Context, req *proto.ResumeWo
 }
 
 func (s *WorkflowServer) UpsertEventTrigger(ctx context.Context, req *proto.UpsertWorkflowEventTriggerRequest) (*proto.WorkflowEventTrigger, error) {
-	provider, allowed, err := s.resolve()
+	provider, allowed, _, err := s.resolve()
 	if err != nil {
 		return nil, err
 	}
@@ -223,7 +235,7 @@ func (s *WorkflowServer) UpsertEventTrigger(ctx context.Context, req *proto.Upse
 }
 
 func (s *WorkflowServer) GetEventTrigger(ctx context.Context, req *proto.GetWorkflowEventTriggerRequest) (*proto.WorkflowEventTrigger, error) {
-	provider, _, err := s.resolve()
+	provider, _, _, err := s.resolve()
 	if err != nil {
 		return nil, err
 	}
@@ -238,7 +250,7 @@ func (s *WorkflowServer) GetEventTrigger(ctx context.Context, req *proto.GetWork
 }
 
 func (s *WorkflowServer) ListEventTriggers(ctx context.Context, _ *proto.ListWorkflowEventTriggersRequest) (*proto.ListWorkflowEventTriggersResponse, error) {
-	provider, _, err := s.resolve()
+	provider, _, _, err := s.resolve()
 	if err != nil {
 		return nil, err
 	}
@@ -258,7 +270,7 @@ func (s *WorkflowServer) ListEventTriggers(ctx context.Context, _ *proto.ListWor
 }
 
 func (s *WorkflowServer) DeleteEventTrigger(ctx context.Context, req *proto.DeleteWorkflowEventTriggerRequest) (*emptypb.Empty, error) {
-	provider, _, err := s.resolve()
+	provider, _, _, err := s.resolve()
 	if err != nil {
 		return nil, err
 	}
@@ -272,7 +284,7 @@ func (s *WorkflowServer) DeleteEventTrigger(ctx context.Context, req *proto.Dele
 }
 
 func (s *WorkflowServer) PauseEventTrigger(ctx context.Context, req *proto.PauseWorkflowEventTriggerRequest) (*proto.WorkflowEventTrigger, error) {
-	provider, _, err := s.resolve()
+	provider, _, _, err := s.resolve()
 	if err != nil {
 		return nil, err
 	}
@@ -287,7 +299,7 @@ func (s *WorkflowServer) PauseEventTrigger(ctx context.Context, req *proto.Pause
 }
 
 func (s *WorkflowServer) ResumeEventTrigger(ctx context.Context, req *proto.ResumeWorkflowEventTriggerRequest) (*proto.WorkflowEventTrigger, error) {
-	provider, _, err := s.resolve()
+	provider, _, _, err := s.resolve()
 	if err != nil {
 		return nil, err
 	}
@@ -302,7 +314,7 @@ func (s *WorkflowServer) ResumeEventTrigger(ctx context.Context, req *proto.Resu
 }
 
 func (s *WorkflowServer) PublishEvent(ctx context.Context, req *proto.PublishWorkflowEventRequest) (*emptypb.Empty, error) {
-	provider, _, err := s.resolve()
+	provider, _, _, err := s.resolve()
 	if err != nil {
 		return nil, err
 	}
@@ -413,18 +425,18 @@ func validateWorkflowTargetScope(pluginName string, target coreworkflow.Target, 
 	return status.Errorf(codes.Internal, "workflow %s %q target plugin %q does not match scoped plugin %q", objectKind, objectID, target.PluginName, pluginName)
 }
 
-func (s *WorkflowServer) resolve() (coreworkflow.Provider, map[string]struct{}, error) {
+func (s *WorkflowServer) resolve() (coreworkflow.Provider, map[string]struct{}, map[string]struct{}, error) {
 	if s == nil || s.resolver == nil {
-		return nil, nil, status.Error(codes.FailedPrecondition, "workflow provider is not configured")
+		return nil, nil, nil, status.Error(codes.FailedPrecondition, "workflow provider is not configured")
 	}
-	provider, allowed, err := s.resolver()
+	provider, allowed, managedIDs, err := s.resolver()
 	if err != nil {
-		return nil, nil, status.Errorf(codes.FailedPrecondition, "workflow provider: %v", err)
+		return nil, nil, nil, status.Errorf(codes.FailedPrecondition, "workflow provider: %v", err)
 	}
 	if provider == nil {
-		return nil, nil, status.Error(codes.FailedPrecondition, "workflow provider is not available")
+		return nil, nil, nil, status.Error(codes.FailedPrecondition, "workflow provider is not available")
 	}
-	return provider, allowed, nil
+	return provider, allowed, managedIDs, nil
 }
 
 func validateWorkflowOperationAllowed(operation string, allowed map[string]struct{}) error {
@@ -436,6 +448,13 @@ func validateWorkflowOperationAllowed(operation string, allowed map[string]struc
 	}
 	if _, ok := allowed[operation]; !ok {
 		return status.Errorf(codes.PermissionDenied, "workflow target operation %q is not enabled", operation)
+	}
+	return nil
+}
+
+func rejectManagedWorkflowScheduleID(scheduleID string, managedIDs map[string]struct{}) error {
+	if _, ok := managedIDs[scheduleID]; ok {
+		return status.Errorf(codes.PermissionDenied, "workflow schedule id %q is reserved for config-managed schedules", scheduleID)
 	}
 	return nil
 }

--- a/gestaltd/internal/providerhost/workflow_server_test.go
+++ b/gestaltd/internal/providerhost/workflow_server_test.go
@@ -3,6 +3,7 @@ package providerhost
 import (
 	"context"
 	"reflect"
+	"strings"
 	"testing"
 	"time"
 
@@ -32,6 +33,9 @@ type workflowProviderFunc struct {
 	startRun           func(context.Context, coreworkflow.StartRunRequest) (*coreworkflow.Run, error)
 	getRun             func(context.Context, coreworkflow.GetRunRequest) (*coreworkflow.Run, error)
 	upsertSchedule     func(context.Context, coreworkflow.UpsertScheduleRequest) (*coreworkflow.Schedule, error)
+	deleteSchedule     func(context.Context, coreworkflow.DeleteScheduleRequest) error
+	pauseSchedule      func(context.Context, coreworkflow.PauseScheduleRequest) (*coreworkflow.Schedule, error)
+	resumeSchedule     func(context.Context, coreworkflow.ResumeScheduleRequest) (*coreworkflow.Schedule, error)
 	upsertEventTrigger func(context.Context, coreworkflow.UpsertEventTriggerRequest) (*coreworkflow.EventTrigger, error)
 }
 
@@ -72,15 +76,24 @@ func (p workflowProviderFunc) ListSchedules(context.Context, coreworkflow.ListSc
 	return nil, nil
 }
 
-func (p workflowProviderFunc) DeleteSchedule(context.Context, coreworkflow.DeleteScheduleRequest) error {
+func (p workflowProviderFunc) DeleteSchedule(ctx context.Context, req coreworkflow.DeleteScheduleRequest) error {
+	if p.deleteSchedule != nil {
+		return p.deleteSchedule(ctx, req)
+	}
 	return nil
 }
 
-func (p workflowProviderFunc) PauseSchedule(context.Context, coreworkflow.PauseScheduleRequest) (*coreworkflow.Schedule, error) {
+func (p workflowProviderFunc) PauseSchedule(ctx context.Context, req coreworkflow.PauseScheduleRequest) (*coreworkflow.Schedule, error) {
+	if p.pauseSchedule != nil {
+		return p.pauseSchedule(ctx, req)
+	}
 	return &coreworkflow.Schedule{}, nil
 }
 
-func (p workflowProviderFunc) ResumeSchedule(context.Context, coreworkflow.ResumeScheduleRequest) (*coreworkflow.Schedule, error) {
+func (p workflowProviderFunc) ResumeSchedule(ctx context.Context, req coreworkflow.ResumeScheduleRequest) (*coreworkflow.Schedule, error) {
+	if p.resumeSchedule != nil {
+		return p.resumeSchedule(ctx, req)
+	}
 	return &coreworkflow.Schedule{}, nil
 }
 
@@ -255,8 +268,8 @@ func TestWorkflowServerStartRunScopesTargetToPlugin(t *testing.T) {
 	t.Parallel()
 
 	provider := &recordingWorkflowProvider{}
-	srv := NewWorkflowServer("roadmap", func() (coreworkflow.Provider, map[string]struct{}, error) {
-		return provider, map[string]struct{}{"refresh": {}}, nil
+	srv := NewWorkflowServer("roadmap", func() (coreworkflow.Provider, map[string]struct{}, map[string]struct{}, error) {
+		return provider, map[string]struct{}{"refresh": {}}, nil, nil
 	})
 	ctx := principal.WithPrincipal(context.Background(), &principal.Principal{
 		SubjectID:   principal.UserSubjectID("user-123"),
@@ -308,8 +321,8 @@ func TestWorkflowServerRejectsDisabledScheduleOperations(t *testing.T) {
 	t.Parallel()
 
 	provider := &recordingWorkflowProvider{}
-	srv := NewWorkflowServer("roadmap", func() (coreworkflow.Provider, map[string]struct{}, error) {
-		return provider, map[string]struct{}{"refresh": {}}, nil
+	srv := NewWorkflowServer("roadmap", func() (coreworkflow.Provider, map[string]struct{}, map[string]struct{}, error) {
+		return provider, map[string]struct{}{"refresh": {}}, nil, nil
 	})
 
 	_, err := srv.UpsertSchedule(context.Background(), &proto.UpsertWorkflowScheduleRequest{
@@ -328,12 +341,117 @@ func TestWorkflowServerRejectsDisabledScheduleOperations(t *testing.T) {
 	}
 }
 
+func TestWorkflowServerRejectsConfigManagedScheduleMutations(t *testing.T) {
+	t.Parallel()
+
+	managedID := coreworkflow.ConfigManagedSchedulePrefix + strings.Repeat("a", 64)
+	for _, tc := range []struct {
+		name string
+		run  func(t *testing.T, srv *WorkflowServer) error
+	}{
+		{
+			name: "upsert",
+			run: func(t *testing.T, srv *WorkflowServer) error {
+				_, err := srv.UpsertSchedule(context.Background(), &proto.UpsertWorkflowScheduleRequest{
+					ScheduleId: managedID,
+					Cron:       "*/5 * * * *",
+					Timezone:   "UTC",
+					Target:     &proto.WorkflowTarget{Operation: "refresh"},
+				})
+				return err
+			},
+		},
+		{
+			name: "delete",
+			run: func(t *testing.T, srv *WorkflowServer) error {
+				_, err := srv.DeleteSchedule(context.Background(), &proto.DeleteWorkflowScheduleRequest{
+					ScheduleId: managedID,
+				})
+				return err
+			},
+		},
+		{
+			name: "pause",
+			run: func(t *testing.T, srv *WorkflowServer) error {
+				_, err := srv.PauseSchedule(context.Background(), &proto.PauseWorkflowScheduleRequest{
+					ScheduleId: managedID,
+				})
+				return err
+			},
+		},
+		{
+			name: "resume",
+			run: func(t *testing.T, srv *WorkflowServer) error {
+				_, err := srv.ResumeSchedule(context.Background(), &proto.ResumeWorkflowScheduleRequest{
+					ScheduleId: managedID,
+				})
+				return err
+			},
+		},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+
+			srv := NewWorkflowServer("roadmap", func() (coreworkflow.Provider, map[string]struct{}, map[string]struct{}, error) {
+				return workflowProviderFunc{
+					upsertSchedule: func(context.Context, coreworkflow.UpsertScheduleRequest) (*coreworkflow.Schedule, error) {
+						t.Fatal("provider UpsertSchedule should not be called for config-managed ids")
+						return nil, nil
+					},
+					deleteSchedule: func(context.Context, coreworkflow.DeleteScheduleRequest) error {
+						t.Fatal("provider DeleteSchedule should not be called for config-managed ids")
+						return nil
+					},
+					pauseSchedule: func(context.Context, coreworkflow.PauseScheduleRequest) (*coreworkflow.Schedule, error) {
+						t.Fatal("provider PauseSchedule should not be called for config-managed ids")
+						return nil, nil
+					},
+					resumeSchedule: func(context.Context, coreworkflow.ResumeScheduleRequest) (*coreworkflow.Schedule, error) {
+						t.Fatal("provider ResumeSchedule should not be called for config-managed ids")
+						return nil, nil
+					},
+				}, map[string]struct{}{"refresh": {}}, map[string]struct{}{managedID: {}}, nil
+			})
+
+			err := tc.run(t, srv)
+			if status.Code(err) != codes.PermissionDenied {
+				t.Fatalf("status code = %v, want %v", status.Code(err), codes.PermissionDenied)
+			}
+		})
+	}
+}
+
+func TestWorkflowServerAllowsUserScheduleIDsThatOnlyShareCfgPrefix(t *testing.T) {
+	t.Parallel()
+
+	provider := &recordingWorkflowProvider{}
+	srv := NewWorkflowServer("roadmap", func() (coreworkflow.Provider, map[string]struct{}, map[string]struct{}, error) {
+		return provider, map[string]struct{}{"refresh": {}}, nil, nil
+	})
+
+	_, err := srv.UpsertSchedule(context.Background(), &proto.UpsertWorkflowScheduleRequest{
+		ScheduleId: "cfg_backup",
+		Cron:       "*/5 * * * *",
+		Timezone:   "UTC",
+		Target:     &proto.WorkflowTarget{Operation: "refresh"},
+	})
+	if err != nil {
+		t.Fatalf("UpsertSchedule: %v", err)
+	}
+	if !provider.upsertScheduleCalled {
+		t.Fatal("provider UpsertSchedule was not called")
+	}
+	if provider.upsertScheduleReq.ScheduleID != "cfg_backup" {
+		t.Fatalf("schedule id = %q, want cfg_backup", provider.upsertScheduleReq.ScheduleID)
+	}
+}
+
 func TestWorkflowServerPrefersWorkflowCreatorForWorkflowMutations(t *testing.T) {
 	t.Parallel()
 
 	provider := &recordingWorkflowProvider{}
-	srv := NewWorkflowServer("roadmap", func() (coreworkflow.Provider, map[string]struct{}, error) {
-		return provider, map[string]struct{}{"refresh": {}}, nil
+	srv := NewWorkflowServer("roadmap", func() (coreworkflow.Provider, map[string]struct{}, map[string]struct{}, error) {
+		return provider, map[string]struct{}{"refresh": {}}, nil, nil
 	})
 	ctx := principal.WithPrincipal(context.Background(), &principal.Principal{
 		SubjectID:   principal.WorkloadSubjectID("planner"),
@@ -409,7 +527,7 @@ func TestWorkflowServerRejectsCrossPluginProviderResponses(t *testing.T) {
 	t.Run("run", func(t *testing.T) {
 		t.Parallel()
 
-		srv := NewWorkflowServer("roadmap", func() (coreworkflow.Provider, map[string]struct{}, error) {
+		srv := NewWorkflowServer("roadmap", func() (coreworkflow.Provider, map[string]struct{}, map[string]struct{}, error) {
 			return workflowProviderFunc{
 				startRun: func(context.Context, coreworkflow.StartRunRequest) (*coreworkflow.Run, error) {
 					return &coreworkflow.Run{
@@ -421,7 +539,7 @@ func TestWorkflowServerRejectsCrossPluginProviderResponses(t *testing.T) {
 						},
 					}, nil
 				},
-			}, map[string]struct{}{"refresh": {}}, nil
+			}, map[string]struct{}{"refresh": {}}, nil, nil
 		})
 
 		_, err := srv.StartRun(context.Background(), &proto.StartWorkflowRunRequest{
@@ -435,7 +553,7 @@ func TestWorkflowServerRejectsCrossPluginProviderResponses(t *testing.T) {
 	t.Run("schedule", func(t *testing.T) {
 		t.Parallel()
 
-		srv := NewWorkflowServer("roadmap", func() (coreworkflow.Provider, map[string]struct{}, error) {
+		srv := NewWorkflowServer("roadmap", func() (coreworkflow.Provider, map[string]struct{}, map[string]struct{}, error) {
 			return workflowProviderFunc{
 				upsertSchedule: func(context.Context, coreworkflow.UpsertScheduleRequest) (*coreworkflow.Schedule, error) {
 					return &coreworkflow.Schedule{
@@ -448,7 +566,7 @@ func TestWorkflowServerRejectsCrossPluginProviderResponses(t *testing.T) {
 						},
 					}, nil
 				},
-			}, map[string]struct{}{"refresh": {}}, nil
+			}, map[string]struct{}{"refresh": {}}, nil, nil
 		})
 
 		_, err := srv.UpsertSchedule(context.Background(), &proto.UpsertWorkflowScheduleRequest{
@@ -467,7 +585,7 @@ func TestWorkflowServerRejectsCrossPluginProviderResponses(t *testing.T) {
 	t.Run("event trigger", func(t *testing.T) {
 		t.Parallel()
 
-		srv := NewWorkflowServer("roadmap", func() (coreworkflow.Provider, map[string]struct{}, error) {
+		srv := NewWorkflowServer("roadmap", func() (coreworkflow.Provider, map[string]struct{}, map[string]struct{}, error) {
 			return workflowProviderFunc{
 				upsertEventTrigger: func(context.Context, coreworkflow.UpsertEventTriggerRequest) (*coreworkflow.EventTrigger, error) {
 					return &coreworkflow.EventTrigger{
@@ -481,7 +599,7 @@ func TestWorkflowServerRejectsCrossPluginProviderResponses(t *testing.T) {
 						},
 					}, nil
 				},
-			}, map[string]struct{}{"refresh": {}}, nil
+			}, map[string]struct{}{"refresh": {}}, nil, nil
 		})
 
 		_, err := srv.UpsertEventTrigger(context.Background(), &proto.UpsertWorkflowEventTriggerRequest{
@@ -503,8 +621,8 @@ func TestWorkflowServerListCallsScopeToPlugin(t *testing.T) {
 	t.Parallel()
 
 	provider := &recordingWorkflowProvider{}
-	srv := NewWorkflowServer("roadmap", func() (coreworkflow.Provider, map[string]struct{}, error) {
-		return provider, map[string]struct{}{"refresh": {}}, nil
+	srv := NewWorkflowServer("roadmap", func() (coreworkflow.Provider, map[string]struct{}, map[string]struct{}, error) {
+		return provider, map[string]struct{}{"refresh": {}}, nil, nil
 	})
 
 	runs, err := srv.ListRuns(context.Background(), &proto.ListWorkflowRunsRequest{})
@@ -692,8 +810,8 @@ func TestWorkflowServerPublishEventScopesPlugin(t *testing.T) {
 	t.Parallel()
 
 	provider := &recordingWorkflowProvider{}
-	srv := NewWorkflowServer("roadmap", func() (coreworkflow.Provider, map[string]struct{}, error) {
-		return provider, map[string]struct{}{"refresh": {}}, nil
+	srv := NewWorkflowServer("roadmap", func() (coreworkflow.Provider, map[string]struct{}, map[string]struct{}, error) {
+		return provider, map[string]struct{}{"refresh": {}}, nil, nil
 	})
 
 	_, err := srv.PublishEvent(context.Background(), &proto.PublishWorkflowEventRequest{
@@ -716,12 +834,12 @@ func TestWorkflowServerPublishEventScopesPlugin(t *testing.T) {
 func TestWorkflowServerPreservesProviderStatusCodes(t *testing.T) {
 	t.Parallel()
 
-	srv := NewWorkflowServer("roadmap", func() (coreworkflow.Provider, map[string]struct{}, error) {
+	srv := NewWorkflowServer("roadmap", func() (coreworkflow.Provider, map[string]struct{}, map[string]struct{}, error) {
 		return workflowProviderFunc{
 			getRun: func(context.Context, coreworkflow.GetRunRequest) (*coreworkflow.Run, error) {
 				return nil, status.Error(codes.NotFound, "missing run")
 			},
-		}, map[string]struct{}{"refresh": {}}, nil
+		}, map[string]struct{}{"refresh": {}}, nil, nil
 	})
 
 	_, err := srv.GetRun(context.Background(), &proto.GetWorkflowRunRequest{RunId: "run-123"})


### PR DESCRIPTION
## Summary

This PR adds the first standalone slice of declarative workflow schedules in YAML.

The slice now includes daemon-owned ownership state in the system IndexedDB so bootstrap can reconcile config-managed schedules across restarts:
- validate `plugins.<plugin>.workflow.schedules`
- apply those schedules during `Bootstrap(...)`
- persist ownership of config-managed schedules in the system IndexedDB
- delete config-managed schedules when they are removed from YAML
- move config-managed schedules when a plugin is rebound to another configured workflow provider
- keep `Validate(...)` read-only
- reject plugin runtime mutations only for the currently YAML-managed schedule IDs for that plugin

## YAML Interface

```yaml
plugins:
  roadmap:
    workflow:
      provider: temporal
      operations:
        - sync
      schedules:
        nightly_sync:
          cron: "0 2 * * *"
          timezone: "America/New_York"
          operation: sync
          input:
            source: yaml
          paused: false
```

## Go Interfaces

```go
type PluginWorkflowConfig struct {
    Provider   string
    Operations []string
    Schedules  map[string]PluginWorkflowSchedule
}

type PluginWorkflowSchedule struct {
    Cron      string
    Timezone  string
    Operation string
    Input     map[string]any
    Paused    bool
}
```

## Example Behavior

Given the YAML above, `gestaltd` now upserts a config-managed schedule into the bound workflow provider during bootstrap.

```go
provider.UpsertSchedule(ctx, workflow.UpsertScheduleRequest{
    ScheduleID:  "cfg_<sha256(plugin,schedule_key)>",
    Cron:        "0 2 * * *",
    Timezone:    "America/New_York",
    Target: workflow.Target{
        PluginName: "roadmap",
        Operation:  "sync",
        Input: map[string]any{
            "source": "yaml",
        },
    },
    RequestedBy: workflow.Actor{
        SubjectID:   "config:workflow:roadmap",
        SubjectKind: "system",
        DisplayName: "Workflow Config (roadmap)",
        AuthSource:  "config",
    },
})
```

`gestaltd` also records ownership for that schedule in the system IndexedDB so the next bootstrap can reconcile it safely.

```go
record := indexeddb.Record{
    "id":            "roadmap\x00nightly_sync",
    "plugin_name":   "roadmap",
    "schedule_key":  "nightly_sync",
    "provider_name": "temporal",
    "schedule_id":   "cfg_<sha256(plugin,schedule_key)>",
}
```

If the YAML schedule is later removed, bootstrap deletes the previously managed schedule using that ownership row:

```go
provider.DeleteSchedule(ctx, workflow.DeleteScheduleRequest{
    PluginName: "roadmap",
    ScheduleID: "cfg_<sha256(plugin,schedule_key)>",
})
```

If the plugin is rebound to another workflow provider and the old provider is still configured, bootstrap deletes the old schedule there and upserts the same managed schedule on the new provider.

Plugin workflow clients cannot mutate schedule IDs that are currently managed by YAML for that plugin:

```go
workflow.UpsertSchedule(ctx, &proto.UpsertWorkflowScheduleRequest{
    ScheduleId: "cfg_<sha256(plugin,schedule_key)>",
    Cron:       "*/5 * * * *",
    Timezone:   "UTC",
    Target: &proto.WorkflowTarget{
        Operation: "sync",
    },
})
// => PermissionDenied when that ID is currently YAML-managed for the plugin
```

## Validation Rules

- `cron` is required and must be a valid 5-field cron expression
- `timezone` defaults to `UTC` and must be a valid IANA timezone
- `operation` is required and must be listed in `plugins.<plugin>.workflow.operations`
- `Validate(...)` checks the workflow binding surface without mutating provider schedule state

## Known Scope Boundaries

- cleanup and provider moves rely on the previous workflow provider still being configured so bootstrap can reach it
- removing the old provider resource in the same config change will fail bootstrap until cleanup can complete
- richer provider-specific cron/timezone grammars are still deferred; YAML currently uses the generic 5-field cron + IANA timezone contract

## Tests

Augmented existing config/bootstrap/providerhost test coverage to verify:
- config parsing + normalization for YAML schedules
- invalid cron/timezone/operation bindings are rejected
- `Bootstrap(...)` upserts YAML-managed schedules
- `Bootstrap(...)` deletes schedules removed from YAML using persisted ownership state
- `Bootstrap(...)` moves schedules across configured workflow providers using persisted ownership state
- `Bootstrap(...)` closes workflow providers if schedule reconciliation fails
- `Validate(...)` stays read-only for workflow schedules
- workflow plugin sockets reject only the currently YAML-managed schedule IDs for that plugin
- user IDs like `cfg_backup` still work through the plugin workflow socket when YAML does not own them
