### PR TITLE
config: add v3 scalar source parsing and portable lock schema

### DIFF
--- a/gestaltd/internal/bootstrap/startup_proxy.go
+++ b/gestaltd/internal/bootstrap/startup_proxy.go
@@ -208,7 +208,7 @@ func (p *startupProviderProxy) CatalogForRequest(ctx context.Context, token stri
 	scoped, ok := provider.(core.SessionCatalogProvider)
 	if !ok {
 		if p.spec.Catalog != nil {
-			return nil, fmt.Errorf("%w: provider %q does not support session catalogs", core.ErrSessionCatalogUnavailable, p.spec.Name)
+			return p.spec.Catalog.Clone(), nil
 		}
 		return nil, fmt.Errorf("provider %q does not support session catalogs", p.spec.Name)
 	}

--- a/gestaltd/internal/config/config.go
+++ b/gestaltd/internal/config/config.go
@@ -7,6 +7,7 @@ import (
 	"io"
 	"maps"
 	"net"
+	"net/url"
 	"os"
 	"path/filepath"
 	"slices"
@@ -43,8 +44,10 @@ const PluginConnectionName = "_plugin"
 // PluginConnectionName. In hybrid integrations, mcp.connection can be set
 // to "plugin" to reuse the plugin's OAuth token.
 const PluginConnectionAlias = "plugin"
+const APIVersionV3 = "gestaltd.config/v3"
 
 type Config struct {
+	APIVersion    string                    `yaml:"apiVersion,omitempty"`
 	Server        ServerConfig              `yaml:"server"`
 	Authorization AuthorizationConfig       `yaml:"authorization,omitempty"`
 	Providers     ProvidersConfig           `yaml:"providers"`
@@ -88,16 +91,20 @@ type ServerProvidersConfig struct {
 //   - Managed: source: {ref, version} -> ProviderSource{Ref: "...", Version: "..."}
 //   - Local:   source: {path}         -> ProviderSource{Path: "..."}
 type ProviderSource struct {
-	Builtin string         `yaml:"-"`
-	Ref     string         `yaml:"ref,omitempty"`
-	Version string         `yaml:"version,omitempty"`
-	Path    string         `yaml:"path,omitempty"`
-	Auth    *SourceAuthDef `yaml:"auth,omitempty"`
+	Builtin     string         `yaml:"-"`
+	scalar      string         `yaml:"-"`
+	metadataURL string         `yaml:"-"`
+	unsupported string         `yaml:"-"`
+	Ref         string         `yaml:"ref,omitempty"`
+	Version     string         `yaml:"version,omitempty"`
+	Path        string         `yaml:"path,omitempty"`
+	Auth        *SourceAuthDef `yaml:"auth,omitempty"`
 }
 
 func (s *ProviderSource) UnmarshalYAML(value *yaml.Node) error {
+	*s = ProviderSource{}
 	if value.Kind == yaml.ScalarNode {
-		s.Builtin = strings.TrimSpace(value.Value)
+		s.scalar = strings.TrimSpace(value.Value)
 		return nil
 	}
 	type raw ProviderSource
@@ -108,24 +115,36 @@ func (s ProviderSource) MarshalYAML() (any, error) {
 	if s.Builtin != "" {
 		return s.Builtin, nil
 	}
+	if s.metadataURL != "" && s.Ref == "" && s.Version == "" && s.Path == "" {
+		return s.metadataURL, nil
+	}
+	if s.scalar != "" && s.Ref == "" && s.Version == "" && s.Path == "" {
+		return s.scalar, nil
+	}
 	type raw ProviderSource
 	return raw(s), nil
 }
 
-func (s ProviderSource) IsBuiltin() bool { return s.Builtin != "" }
-func (s ProviderSource) IsManaged() bool { return s.Ref != "" }
-func (s ProviderSource) IsLocal() bool   { return s.Path != "" }
+func (s ProviderSource) IsBuiltin() bool     { return s.Builtin != "" }
+func (s ProviderSource) IsManaged() bool     { return s.Ref != "" }
+func (s ProviderSource) IsMetadataURL() bool { return s.metadataURL != "" }
+func (s ProviderSource) IsLocal() bool       { return s.Path != "" }
+func (s ProviderSource) MetadataURL() string { return s.metadataURL }
+func (s ProviderSource) UnsupportedURL() string {
+	return s.unsupported
+}
 
 // ProviderEntry is the universal configuration for any provider.
 type ProviderEntry struct {
-	Source       ProviderSource    `yaml:"source"`
-	Config       yaml.Node         `yaml:"config,omitempty"`
-	Default      bool              `yaml:"default,omitempty"`
-	Env          map[string]string `yaml:"env,omitempty"`
-	AllowedHosts []string          `yaml:"allowedHosts,omitempty"`
-	DisplayName  string            `yaml:"displayName,omitempty"`
-	Description  string            `yaml:"description,omitempty"`
-	IconFile     string            `yaml:"iconFile,omitempty"`
+	Source           ProviderSource    `yaml:"source"`
+	Config           yaml.Node         `yaml:"config,omitempty"`
+	Default          bool              `yaml:"default,omitempty"`
+	Env              map[string]string `yaml:"env,omitempty"`
+	AllowedHosts     []string          `yaml:"allowedHosts,omitempty"`
+	DisplayName      string            `yaml:"displayName,omitempty"`
+	Description      string            `yaml:"description,omitempty"`
+	IconFile         string            `yaml:"iconFile,omitempty"`
+	InlineSourceAuth *SourceAuthDef    `yaml:"auth,omitempty"`
 	// AuthorizationPolicy binds this provider to a shared human access policy.
 	AuthorizationPolicy string `yaml:"authorizationPolicy,omitempty"`
 
@@ -156,6 +175,16 @@ type ProviderEntry struct {
 	Discovery            *providermanifestv1.ProviderDiscovery `yaml:"-"`
 	ResolvedAssetRoot    string                                `yaml:"-"`
 	MCPToolPrefix        string                                `yaml:"-"`
+}
+
+func (e ProviderEntry) MarshalYAML() (any, error) {
+	type raw ProviderEntry
+	if e.Source.IsMetadataURL() && e.Source.Auth != nil && e.InlineSourceAuth == nil {
+		auth := *e.Source.Auth
+		e.InlineSourceAuth = &auth
+		e.Source.Auth = nil
+	}
+	return raw(e), nil
 }
 
 type ProviderSurfaceOverrides struct {
@@ -230,6 +259,14 @@ func (e *ProviderEntry) HasManagedSource() bool {
 	return e != nil && e.Source.IsManaged()
 }
 
+func (e *ProviderEntry) HasMetadataSource() bool {
+	return e != nil && e.Source.IsMetadataURL()
+}
+
+func (e *ProviderEntry) HasRemoteSource() bool {
+	return e != nil && (e.Source.IsManaged() || e.Source.IsMetadataURL())
+}
+
 func (e *ProviderEntry) HasLocalSource() bool {
 	return e != nil && e.Source.IsLocal()
 }
@@ -240,6 +277,26 @@ func (e *ProviderEntry) SourceRef() string {
 
 func (e *ProviderEntry) SourceVersion() string {
 	return e.Source.Version
+}
+
+func (e *ProviderEntry) SourceMetadataURL() string {
+	if e == nil {
+		return ""
+	}
+	return e.Source.MetadataURL()
+}
+
+func (e *ProviderEntry) SourceRemoteLocation() string {
+	if e == nil {
+		return ""
+	}
+	if e.Source.IsManaged() {
+		return e.Source.Ref
+	}
+	if e.Source.IsMetadataURL() {
+		return e.Source.MetadataURL()
+	}
+	return ""
 }
 
 func (e *ProviderEntry) SourcePath() string {
@@ -703,6 +760,17 @@ func LoadAllowMissingEnvPaths(paths []string) (*Config, error) {
 	return loadWithLookupPaths(paths, os.LookupEnv, true)
 }
 
+func NormalizeCompatibility(cfg *Config) error {
+	normalizeProviderSourceShapes(cfg)
+	if err := normalizeAuthorizationConfig(cfg); err != nil {
+		return err
+	}
+	if err := normalizeAdminConfig(cfg); err != nil {
+		return err
+	}
+	return applyPluginMountBindings(cfg)
+}
+
 func OverlayManagedPluginConfig(path string, cfg *Config) error {
 	return OverlayManagedPluginConfigPaths([]string{path}, cfg)
 }
@@ -716,7 +784,7 @@ func OverlayManagedPluginConfigPaths(paths []string, cfg *Config) error {
 	providersNode := mappingValueNode(documentValueNode(&root), "providers")
 	pluginsNode := mappingValueNode(doc, "plugins")
 	for name, entry := range cfg.Plugins {
-		if entry == nil || !entry.HasManagedSource() {
+		if entry == nil || !entry.HasRemoteSource() {
 			continue
 		}
 		if err := overlayManagedEntryConfigNode(mappingValueNode(pluginsNode, name), entry, "plugin "+strconv.Quote(name)); err != nil {
@@ -737,7 +805,7 @@ func OverlayManagedPluginConfigPaths(paths []string, cfg *Config) error {
 	} {
 		kindNode := mappingValueNode(providersNode, string(collection.kind))
 		for name, entry := range collection.entries {
-			if entry == nil || !entry.HasManagedSource() {
+			if entry == nil || !entry.HasRemoteSource() {
 				continue
 			}
 			subject := fmt.Sprintf("%s %q", collection.kind, name)
@@ -748,7 +816,7 @@ func OverlayManagedPluginConfigPaths(paths []string, cfg *Config) error {
 	}
 	s3Node := mappingValueNode(providersNode, "s3")
 	for name, entry := range cfg.Providers.S3 {
-		if entry == nil || !entry.HasManagedSource() {
+		if entry == nil || !entry.HasRemoteSource() {
 			continue
 		}
 		if err := overlayManagedEntryConfigNode(mappingValueNode(s3Node, name), entry, "s3 "+strconv.Quote(name)); err != nil {
@@ -757,7 +825,7 @@ func OverlayManagedPluginConfigPaths(paths []string, cfg *Config) error {
 	}
 	uiNode := mappingValueNode(providersNode, "ui")
 	for name, entry := range cfg.Providers.UI {
-		if entry == nil || !entry.HasManagedSource() {
+		if entry == nil || !entry.HasRemoteSource() {
 			continue
 		}
 		if err := overlayManagedEntryConfigNode(mappingValueNode(uiNode, name), &entry.ProviderEntry, "ui "+strconv.Quote(name)); err != nil {
@@ -776,7 +844,7 @@ const (
 )
 
 func overlayManagedEntryConfigNode(raw *yaml.Node, entry *ProviderEntry, subject string) error {
-	if entry == nil || !entry.HasManagedSource() || raw == nil {
+	if entry == nil || !entry.HasRemoteSource() || raw == nil {
 		return nil
 	}
 	configNode := mappingValueNode(raw, "config")
@@ -873,10 +941,10 @@ func loadWithLookupPaths(paths []string, lookup func(string) (string, bool), all
 		return nil, fmt.Errorf("parsing config YAML: %w", err)
 	}
 
-	applyDefaults(&cfg)
 	if err := CanonicalizeStructure(&cfg); err != nil {
 		return nil, err
 	}
+	applyDefaults(&cfg)
 	resolveBaseURL(&cfg)
 	resolveRelativePaths(primaryConfigPath(paths), &cfg)
 
@@ -899,9 +967,26 @@ func loadMergedConfigRoot(paths []string, lookup func(string) (string, bool), mo
 		return yaml.Node{}, fmt.Errorf("reading config file: no config files provided")
 	}
 
+	roots := make([]yaml.Node, len(paths))
+	useV3Classification := false
+	for i, path := range paths {
+		root, err := loadValidatedConfigRoot(path, lookup, mode, sentinelPrefix)
+		if err != nil {
+			return yaml.Node{}, err
+		}
+		usesV3, err := configRootUsesAPIVersion(root)
+		if err != nil {
+			return yaml.Node{}, err
+		}
+		if usesV3 {
+			useV3Classification = true
+		}
+		roots[i] = root
+	}
+
 	var merged any
-	for _, path := range paths {
-		value, err := loadConfigValue(path, lookup, mode, sentinelPrefix)
+	for i, path := range paths {
+		value, err := loadConfigValue(path, roots[i], useV3Classification)
 		if err != nil {
 			return yaml.Node{}, err
 		}
@@ -928,11 +1013,26 @@ func loadMergedConfigRoot(paths []string, lookup func(string) (string, bool), mo
 	return root, nil
 }
 
-func loadConfigValue(path string, lookup func(string) (string, bool), mode envMissingMode, sentinelPrefix string) (any, error) {
-	root, err := loadValidatedConfigRoot(path, lookup, mode, sentinelPrefix)
-	if err != nil {
-		return nil, err
+func configRootUsesAPIVersion(root yaml.Node) (bool, error) {
+	doc := documentValueNode(&root)
+	if doc == nil || doc.Kind != yaml.MappingNode {
+		return false, nil
 	}
+	node := mappingValueNode(doc, "apiVersion")
+	if node == nil {
+		return false, nil
+	}
+	value := strings.TrimSpace(node.Value)
+	if value == "" {
+		return false, nil
+	}
+	if !usesV3ConfigSyntax(value) {
+		return false, fmt.Errorf("config validation: unsupported apiVersion %q", value)
+	}
+	return true, nil
+}
+
+func loadConfigValue(path string, root yaml.Node, useV3Classification bool) (any, error) {
 	doc := documentValueNode(&root)
 	if doc == nil || doc.Kind == 0 {
 		return nil, nil
@@ -952,7 +1052,7 @@ func loadConfigValue(path string, lookup func(string) (string, bool), mode envMi
 		if !ok {
 			return nil, fmt.Errorf("expected mapping document")
 		}
-		resolveRelativePathsInValue(path, root)
+		resolveRelativePathsInValue(path, root, useV3Classification)
 	}
 	return normalized, nil
 }
@@ -1387,6 +1487,137 @@ func applyDefaults(cfg *Config) {
 	cfg.Providers.Workflow = nonNilProviderEntryMap(cfg.Providers.Workflow)
 }
 
+func normalizeProviderSourceShapes(cfg *Config) {
+	if cfg == nil {
+		return
+	}
+	cfg.APIVersion = strings.TrimSpace(cfg.APIVersion)
+	useV3Classification := usesV3ConfigSyntax(cfg.APIVersion)
+
+	normalizeEntry := func(kind string, entry *ProviderEntry) {
+		if entry == nil {
+			return
+		}
+		normalizeProviderSource(kind, &entry.Source, useV3Classification)
+		if entry.Source.IsMetadataURL() && entry.Source.Auth == nil && entry.InlineSourceAuth != nil {
+			auth := *entry.InlineSourceAuth
+			entry.Source.Auth = &auth
+			entry.InlineSourceAuth = nil
+		}
+	}
+
+	for _, entry := range cfg.Plugins {
+		normalizeEntry(providermanifestv1.KindPlugin, entry)
+	}
+	for _, collection := range []struct {
+		kind    string
+		entries map[string]*ProviderEntry
+	}{
+		{providermanifestv1.KindAuth, cfg.Providers.Auth},
+		{providermanifestv1.KindSecrets, cfg.Providers.Secrets},
+		{string(HostProviderKindTelemetry), cfg.Providers.Telemetry},
+		{string(HostProviderKindAudit), cfg.Providers.Audit},
+		{providermanifestv1.KindIndexedDB, cfg.Providers.IndexedDB},
+		{providermanifestv1.KindCache, cfg.Providers.Cache},
+		{providermanifestv1.KindS3, cfg.Providers.S3},
+		{string(HostProviderKindWorkflow), cfg.Providers.Workflow},
+	} {
+		for _, entry := range collection.entries {
+			normalizeEntry(collection.kind, entry)
+		}
+	}
+	for _, entry := range cfg.Providers.UI {
+		if entry != nil {
+			normalizeEntry(providermanifestv1.KindWebUI, &entry.ProviderEntry)
+		}
+	}
+}
+
+func normalizeProviderSource(kind string, source *ProviderSource, useV3Classification bool) {
+	if source == nil {
+		return
+	}
+	source.scalar = strings.TrimSpace(source.scalar)
+	if source.Builtin != "" || source.Ref != "" || source.Path != "" || source.metadataURL != "" {
+		source.scalar = ""
+		return
+	}
+	if source.scalar == "" {
+		return
+	}
+	switch {
+	case !useV3Classification:
+		source.Builtin = source.scalar
+	case isBuiltinScalarSource(kind, source.scalar):
+		source.Builtin = source.scalar
+	case looksLikeMetadataURL(source.scalar):
+		source.metadataURL = source.scalar
+	case looksLikeUnsupportedScalarSource(source.scalar):
+		source.unsupported = source.scalar
+	default:
+		source.Path = source.scalar
+	}
+	source.scalar = ""
+}
+
+func isBuiltinScalarSource(kind, source string) bool {
+	switch kind {
+	case providermanifestv1.KindSecrets:
+		return source == "env"
+	case string(HostProviderKindTelemetry):
+		return source == "stdout"
+	case string(HostProviderKindAudit):
+		switch source {
+		case "inherit", "noop", "stdout", "otlp":
+			return true
+		}
+	}
+	return false
+}
+
+func looksLikeMetadataURL(value string) bool {
+	parsed, err := url.ParseRequestURI(strings.TrimSpace(value))
+	if err != nil {
+		return false
+	}
+	switch parsed.Scheme {
+	case "http", "https":
+		return parsed.Host != "" && strings.HasSuffix(parsed.Path, "/provider-release.yaml")
+	default:
+		return false
+	}
+}
+
+func looksLikeUnsupportedScalarSource(value string) bool {
+	trimmed := strings.TrimSpace(value)
+	lower := strings.ToLower(trimmed)
+	if strings.HasPrefix(lower, "git+") {
+		return true
+	}
+	if strings.Contains(trimmed, "://") {
+		parsed, err := url.ParseRequestURI(trimmed)
+		if err != nil {
+			return true
+		}
+		switch parsed.Scheme {
+		case "http", "https":
+			return true
+		default:
+			return parsed.Scheme != ""
+		}
+	}
+	for _, prefix := range []string{"http:", "https:", "ssh:", "file:", "ftp:", "ftps:"} {
+		if strings.HasPrefix(lower, prefix) {
+			return true
+		}
+	}
+	return false
+}
+
+func usesV3ConfigSyntax(apiVersion string) bool {
+	return strings.TrimSpace(apiVersion) == APIVersionV3
+}
+
 func nonNilProviderEntryMap(entries map[string]*ProviderEntry) map[string]*ProviderEntry {
 	if entries == nil {
 		return make(map[string]*ProviderEntry)
@@ -1411,7 +1642,7 @@ func applyDefaultBuiltinProviderEntries(entries map[string]*ProviderEntry, defau
 		}
 	}
 	for _, entry := range entries {
-		if entry == nil || entry.Source.IsBuiltin() || entry.Source.IsManaged() || entry.Source.IsLocal() {
+		if entry == nil || entry.Source.IsBuiltin() || entry.Source.IsManaged() || entry.Source.IsMetadataURL() || entry.Source.IsLocal() || entry.Source.UnsupportedURL() != "" {
 			continue
 		}
 		entry.Source.Builtin = builtin
@@ -1563,7 +1794,7 @@ func resolveBaseURL(cfg *Config) {
 	cfg.Server.Management.BaseURL = strings.TrimRight(strings.TrimSpace(cfg.Server.Management.BaseURL), "/")
 }
 
-func resolveRelativePathsInValue(configPath string, root map[string]any) {
+func resolveRelativePathsInValue(configPath string, root map[string]any, useV3Classification bool) {
 	baseDir := filepath.Dir(configPath)
 	if absPath, err := filepath.Abs(configPath); err == nil {
 		baseDir = filepath.Dir(absPath)
@@ -1574,26 +1805,52 @@ func resolveRelativePathsInValue(configPath string, root map[string]any) {
 	}
 
 	if providers := nestedMap(root, "providers"); providers != nil {
-		for _, kind := range []string{"auth", "secrets", "telemetry", "audit", "ui", "indexeddb", "cache", "s3"} {
-			for _, entry := range mapValues(nestedMap(providers, kind)) {
-				resolveRelativePathsInEntry(entry, baseDir)
+		for _, section := range []struct {
+			key  string
+			kind string
+		}{
+			{key: "auth", kind: providermanifestv1.KindAuth},
+			{key: "secrets", kind: providermanifestv1.KindSecrets},
+			{key: "telemetry", kind: string(HostProviderKindTelemetry)},
+			{key: "audit", kind: string(HostProviderKindAudit)},
+			{key: "ui", kind: providermanifestv1.KindWebUI},
+			{key: "indexeddb", kind: providermanifestv1.KindIndexedDB},
+			{key: "cache", kind: providermanifestv1.KindCache},
+			{key: "s3", kind: providermanifestv1.KindS3},
+			{key: "workflow", kind: string(HostProviderKindWorkflow)},
+		} {
+			for _, entry := range mapValues(nestedMap(providers, section.key)) {
+				resolveRelativePathsInEntry(section.kind, entry, baseDir, useV3Classification)
 			}
 		}
 	}
 
 	for _, entry := range mapValues(nestedMap(root, "plugins")) {
-		resolveRelativePathsInEntry(entry, baseDir)
+		resolveRelativePathsInEntry(providermanifestv1.KindPlugin, entry, baseDir, useV3Classification)
 	}
 }
 
-func resolveRelativePathsInEntry(entry map[string]any, baseDir string) {
+func resolveRelativePathsInEntry(kind string, entry map[string]any, baseDir string, useV3Classification bool) {
 	if entry == nil {
 		return
 	}
 	resolveRelativeStringField(entry, "iconFile", baseDir)
-	if source := nestedMap(entry, "source"); source != nil {
+	if source, ok := entry["source"].(map[string]any); ok {
 		resolveRelativeStringField(source, "path", baseDir)
+		return
 	}
+	if !useV3Classification {
+		return
+	}
+	sourceValue, ok := entry["source"].(string)
+	if !ok {
+		return
+	}
+	sourceValue = strings.TrimSpace(sourceValue)
+	if sourceValue == "" || isBuiltinScalarSource(kind, sourceValue) || looksLikeMetadataURL(sourceValue) || looksLikeUnsupportedScalarSource(sourceValue) {
+		return
+	}
+	entry["source"] = resolveRelativeConfigValue(baseDir, sourceValue)
 }
 
 func resolveRelativeStringField(fields map[string]any, key, baseDir string) {

--- a/gestaltd/internal/config/config_test.go
+++ b/gestaltd/internal/config/config_test.go
@@ -879,7 +879,10 @@ authorization:
 func TestLoadSucceedsWithoutRuntimeFields(t *testing.T) {
 	t.Parallel()
 
-	path := mustWriteConfigFile(t, `
+	t.Run("mapping local source path", func(t *testing.T) {
+		t.Parallel()
+
+		path := mustWriteConfigFile(t, `
 providers:
 plugins:
     custom_tool:
@@ -887,13 +890,168 @@ plugins:
         path: ./manifest.yaml
 `)
 
-	cfg, err := Load(path)
-	if err != nil {
-		t.Fatalf("Load: %v", err)
-	}
-	if got := cfg.Plugins["custom_tool"].SourcePath(); got != filepath.Join(filepath.Dir(path), "manifest.yaml") {
-		t.Fatalf("unexpected plugin source path: %q", got)
-	}
+		cfg, err := Load(path)
+		if err != nil {
+			t.Fatalf("Load: %v", err)
+		}
+		if got := cfg.Plugins["custom_tool"].SourcePath(); got != filepath.Join(filepath.Dir(path), "manifest.yaml") {
+			t.Fatalf("unexpected plugin source path: %q", got)
+		}
+	})
+
+	t.Run("apiVersion classifies scalar local sources", func(t *testing.T) {
+		t.Parallel()
+
+		path := mustWriteConfigFile(t, `
+apiVersion: gestaltd.config/v3
+providers:
+plugins:
+    custom_tool:
+      source: ./manifest.yaml
+`)
+
+		cfg, err := Load(path)
+		if err != nil {
+			t.Fatalf("Load: %v", err)
+		}
+		if cfg.APIVersion != APIVersionV3 {
+			t.Fatalf("APIVersion = %q, want %q", cfg.APIVersion, APIVersionV3)
+		}
+		if got := cfg.Plugins["custom_tool"].SourcePath(); got != filepath.Join(filepath.Dir(path), "manifest.yaml") {
+			t.Fatalf("unexpected plugin source path: %q", got)
+		}
+	})
+
+	t.Run("apiVersion keeps colon-containing local sources as paths", func(t *testing.T) {
+		t.Parallel()
+
+		path := mustWriteConfigFile(t, `
+apiVersion: gestaltd.config/v3
+providers:
+plugins:
+    custom_tool:
+      source: demo:manifest.yaml
+`)
+
+		cfg, err := Load(path)
+		if err != nil {
+			t.Fatalf("Load: %v", err)
+		}
+		if got := cfg.Plugins["custom_tool"].SourcePath(); got != filepath.Join(filepath.Dir(path), "demo:manifest.yaml") {
+			t.Fatalf("unexpected plugin source path: %q", got)
+		}
+	})
+
+	t.Run("apiVersion classifies scalar workflow sources", func(t *testing.T) {
+		t.Parallel()
+
+		path := mustWriteConfigFile(t, `
+apiVersion: gestaltd.config/v3
+providers:
+  workflow:
+    demo:
+      source: ./providers/workflow/demo/manifest.yaml
+plugins:
+`)
+
+		cfg, err := Load(path)
+		if err != nil {
+			t.Fatalf("Load: %v", err)
+		}
+		if got := cfg.Providers.Workflow["demo"].SourcePath(); got != filepath.Join(filepath.Dir(path), "providers/workflow/demo/manifest.yaml") {
+			t.Fatalf("unexpected workflow source path: %q", got)
+		}
+	})
+
+	t.Run("apiVersion classifies scalar ui sources", func(t *testing.T) {
+		t.Parallel()
+
+		path := mustWriteConfigFile(t, `
+apiVersion: gestaltd.config/v3
+providers:
+  ui:
+    dashboard:
+      path: /dashboard
+      source: ./providers/ui/dashboard/manifest.yaml
+plugins:
+`)
+
+		cfg, err := Load(path)
+		if err != nil {
+			t.Fatalf("Load: %v", err)
+		}
+		if got := cfg.Providers.UI["dashboard"].SourcePath(); got != filepath.Join(filepath.Dir(path), "providers/ui/dashboard/manifest.yaml") {
+			t.Fatalf("unexpected ui source path: %q", got)
+		}
+	})
+
+	t.Run("apiVersion moves sibling auth onto metadata URL sources", func(t *testing.T) {
+		t.Parallel()
+
+		path := mustWriteConfigFile(t, `
+apiVersion: gestaltd.config/v3
+providers:
+plugins:
+    custom_tool:
+      source: https://example.com/providers/custom_tool/provider-release.yaml?download=1
+      auth:
+        token: test-token
+`)
+
+		cfg, err := Load(path)
+		if err != nil {
+			t.Fatalf("Load: %v", err)
+		}
+		entry := cfg.Plugins["custom_tool"]
+		if got := entry.SourceMetadataURL(); got != "https://example.com/providers/custom_tool/provider-release.yaml?download=1" {
+			t.Fatalf("SourceMetadataURL = %q", got)
+		}
+		if entry.Source.Auth == nil || entry.Source.Auth.Token != "test-token" {
+			t.Fatalf("Source.Auth = %#v", entry.Source.Auth)
+		}
+		if entry.InlineSourceAuth != nil {
+			t.Fatalf("InlineSourceAuth = %#v, want nil", entry.InlineSourceAuth)
+		}
+		marshaled, err := yaml.Marshal(entry)
+		if err != nil {
+			t.Fatalf("yaml.Marshal: %v", err)
+		}
+		var roundTripped map[string]any
+		if err := yaml.Unmarshal(marshaled, &roundTripped); err != nil {
+			t.Fatalf("yaml.Unmarshal: %v", err)
+		}
+		if got, ok := roundTripped["source"].(string); !ok || got != "https://example.com/providers/custom_tool/provider-release.yaml?download=1" {
+			t.Fatalf("round-tripped source = %#v", roundTripped["source"])
+		}
+		auth, ok := roundTripped["auth"].(map[string]any)
+		if !ok || auth["token"] != "test-token" {
+			t.Fatalf("round-tripped auth = %#v", roundTripped["auth"])
+		}
+
+		marshaledConfig, err := yaml.Marshal(cfg)
+		if err != nil {
+			t.Fatalf("yaml.Marshal config: %v", err)
+		}
+		var roundTrippedConfig map[string]any
+		if err := yaml.Unmarshal(marshaledConfig, &roundTrippedConfig); err != nil {
+			t.Fatalf("yaml.Unmarshal config: %v", err)
+		}
+		plugins, ok := roundTrippedConfig["plugins"].(map[string]any)
+		if !ok {
+			t.Fatalf("plugins = %#v", roundTrippedConfig["plugins"])
+		}
+		plugin, ok := plugins["custom_tool"].(map[string]any)
+		if !ok {
+			t.Fatalf("plugins.custom_tool = %#v", plugins["custom_tool"])
+		}
+		if got, ok := plugin["source"].(string); !ok || got != "https://example.com/providers/custom_tool/provider-release.yaml?download=1" {
+			t.Fatalf("config round-tripped source = %#v", plugin["source"])
+		}
+		auth, ok = plugin["auth"].(map[string]any)
+		if !ok || auth["token"] != "test-token" {
+			t.Fatalf("config round-tripped auth = %#v", plugin["auth"])
+		}
+	})
 }
 
 func TestLoadConfigUIEntries(t *testing.T) {
@@ -2440,6 +2598,28 @@ providers:
         version: 1.0.0
 `,
 		},
+		{
+			name: "apiVersion scalar local source",
+			yaml: `
+apiVersion: gestaltd.config/v3
+providers:
+plugins:
+    external:
+      source: ./plugins/dummy/manifest.yaml
+`,
+		},
+		{
+			name: "apiVersion metadata url with sibling auth",
+			yaml: `
+apiVersion: gestaltd.config/v3
+providers:
+plugins:
+    external:
+      source: https://example.com/providers/external/provider-release.yaml
+      auth:
+        token: test-token
+`,
+		},
 	}
 
 	for _, tc := range cases {
@@ -2502,6 +2682,17 @@ server:
         default: deny
 `,
 			want: `field authorization not found in type config.ServerConfig`,
+		},
+		{
+			name: "unsupported apiVersion is rejected",
+			yaml: `
+apiVersion: gestaltd.config/v99
+providers:
+plugins:
+    external:
+      source: ./plugins/dummy/manifest.yaml
+`,
+			want: `unsupported apiVersion "gestaltd.config/v99"`,
 		},
 	}
 
@@ -2715,6 +2906,115 @@ plugins:
         ref: github.com/acme-corp/tools/widget
         version: 1.2.3
 `,
+		},
+		{
+			name: "apiVersion metadata url with sibling auth is valid",
+			yaml: `
+apiVersion: gestaltd.config/v3
+providers:
+plugins:
+    external:
+      source: https://example.com/providers/external/provider-release.yaml
+      auth:
+        token: test-token
+`,
+		},
+		{
+			name: "apiVersion local source rejects sibling auth",
+			yaml: `
+apiVersion: gestaltd.config/v3
+providers:
+plugins:
+    external:
+      source: ./plugins/dummy/manifest.yaml
+      auth:
+        token: test-token
+`,
+			wantErr: "auth is only valid with metadata URL sources",
+		},
+		{
+			name: "managed ref rejects sibling auth",
+			yaml: `
+apiVersion: gestaltd.config/v3
+providers:
+plugins:
+    external:
+      source:
+        ref: github.com/acme-corp/tools/widget
+        version: 1.2.3
+        auth:
+          token: nested-token
+      auth:
+        token: sibling-token
+`,
+			wantErr: "auth and source.auth are mutually exclusive",
+		},
+		{
+			name: "apiVersion rejects non metadata http source",
+			yaml: `
+apiVersion: gestaltd.config/v3
+providers:
+plugins:
+    external:
+      source: https://example.com/providers/external/archive.tar.gz
+`,
+			wantErr: "only provider-release.yaml metadata URLs are supported for remote sources",
+		},
+		{
+			name: "apiVersion rejects git scalar source",
+			yaml: `
+apiVersion: gestaltd.config/v3
+providers:
+plugins:
+    external:
+      source: git+ssh://git@github.com/example/external.git
+`,
+			wantErr: "git+ sources are not supported in apiVersion v3 configs",
+		},
+		{
+			name: "apiVersion rejects unsupported ssh scalar source",
+			yaml: `
+apiVersion: gestaltd.config/v3
+providers:
+plugins:
+    external:
+      source: ssh://github.com/example/external
+`,
+			wantErr: "only provider-release.yaml metadata URLs are supported for remote sources",
+		},
+		{
+			name: "apiVersion rejects unsupported file scalar source",
+			yaml: `
+apiVersion: gestaltd.config/v3
+providers:
+plugins:
+    external:
+      source: file:/tmp/provider-release.yaml
+`,
+			wantErr: "only provider-release.yaml metadata URLs are supported for remote sources",
+		},
+		{
+			name: "apiVersion rejects malformed hostless https metadata source",
+			yaml: `
+apiVersion: gestaltd.config/v3
+providers:
+plugins:
+    external:
+      source: https:///provider-release.yaml
+`,
+			wantErr: "only provider-release.yaml metadata URLs are supported for remote sources",
+		},
+		{
+			name: "apiVersion rejects unsupported telemetry source before builtin defaulting",
+			yaml: `
+apiVersion: gestaltd.config/v3
+providers:
+  telemetry:
+    default:
+      source: https://example.com/providers/telemetry/archive.tar.gz
+plugins:
+`,
+			wantErr: "only provider-release.yaml metadata URLs are supported for remote sources",
 		},
 		{
 			name: "plugin source with base_url override is rejected",
@@ -3015,6 +3315,48 @@ server:
 	}
 	if got := cfg.Plugins["service-a"].SourcePath(); got != filepath.Join(dir, "bin", "manifest.yaml") {
 		t.Fatalf("integration plugin source path = %q, want %q", got, filepath.Join(dir, "bin", "manifest.yaml"))
+	}
+}
+
+func TestLoadPaths_ResolvesRelativeScalarSourcePathsPerFile(t *testing.T) {
+	t.Parallel()
+
+	dir := t.TempDir()
+	basePath := filepath.Join(dir, "base", "gestalt.yaml")
+	if err := os.MkdirAll(filepath.Dir(basePath), 0o755); err != nil {
+		t.Fatalf("MkdirAll base: %v", err)
+	}
+	if err := os.WriteFile(basePath, []byte(`
+apiVersion: gestaltd.config/v3
+providers:
+plugins:
+    sample:
+      source: ../base-plugin/manifest.yaml
+`), 0o644); err != nil {
+		t.Fatalf("WriteFile base: %v", err)
+	}
+
+	overridePath := filepath.Join(dir, "overrides", "gestalt.yaml")
+	if err := os.MkdirAll(filepath.Dir(overridePath), 0o755); err != nil {
+		t.Fatalf("MkdirAll override: %v", err)
+	}
+	if err := os.WriteFile(overridePath, []byte(`
+providers:
+plugins:
+    sample:
+      source: ./override-plugin/manifest.yaml
+`), 0o644); err != nil {
+		t.Fatalf("WriteFile override: %v", err)
+	}
+
+	cfg, err := LoadPaths([]string{basePath, overridePath})
+	if err != nil {
+		t.Fatalf("LoadPaths: %v", err)
+	}
+
+	wantPath := filepath.Join(filepath.Dir(overridePath), "override-plugin", "manifest.yaml")
+	if got := cfg.Plugins["sample"].SourcePath(); got != wantPath {
+		t.Fatalf("SourcePath = %q, want %q", got, wantPath)
 	}
 }
 

--- a/gestaltd/internal/config/config_validate.go
+++ b/gestaltd/internal/config/config_validate.go
@@ -33,13 +33,10 @@ func ValidateStructure(cfg *Config) error {
 // CanonicalizeStructure applies the config-shape normalization required before
 // structural validation or bootstrap consumers operate on the config.
 func CanonicalizeStructure(cfg *Config) error {
-	if err := normalizeAuthorizationConfig(cfg); err != nil {
+	if err := validateAPIVersion(cfg); err != nil {
 		return err
 	}
-	if err := normalizeAdminConfig(cfg); err != nil {
-		return err
-	}
-	if err := applyPluginMountBindings(cfg); err != nil {
+	if err := NormalizeCompatibility(cfg); err != nil {
 		return err
 	}
 	pluginOwnedUIRefs := pluginOwnedUIRefs(cfg)
@@ -140,6 +137,19 @@ func ValidateCanonicalStructure(cfg *Config) error {
 	return nil
 }
 
+func validateAPIVersion(cfg *Config) error {
+	if cfg == nil {
+		return nil
+	}
+	apiVersion := strings.TrimSpace(cfg.APIVersion)
+	switch apiVersion {
+	case "", APIVersionV3:
+		return nil
+	default:
+		return fmt.Errorf("config validation: unsupported apiVersion %q", apiVersion)
+	}
+}
+
 func validateHostProviderEntries(kind HostProviderKind, entries map[string]*ProviderEntry) error {
 	for name, entry := range entries {
 		if entry == nil {
@@ -232,7 +242,19 @@ func validateProviderEntrySource(kind, name string, entry *ProviderEntry) error 
 	}
 	src := entry.Source
 	if src.IsBuiltin() {
+		if entry.InlineSourceAuth != nil {
+			return fmt.Errorf("config validation: %s %q auth is only valid with metadata URL sources", kind, name)
+		}
+		if src.Auth != nil {
+			return fmt.Errorf("config validation: %s %q source.auth is only valid with source.ref or metadata URL sources", kind, name)
+		}
 		return nil
+	}
+	if src.UnsupportedURL() != "" {
+		if strings.HasPrefix(strings.ToLower(strings.TrimSpace(src.UnsupportedURL())), "git+") {
+			return fmt.Errorf("config validation: %s %q git+ sources are not supported in apiVersion v3 configs", kind, name)
+		}
+		return fmt.Errorf("config validation: %s %q only provider-release.yaml metadata URLs are supported for remote sources", kind, name)
 	}
 	modeCount := 0
 	if src.IsLocal() {
@@ -241,11 +263,14 @@ func validateProviderEntrySource(kind, name string, entry *ProviderEntry) error 
 	if src.IsManaged() {
 		modeCount++
 	}
+	if src.IsMetadataURL() {
+		modeCount++
+	}
 	if modeCount == 0 {
 		return fmt.Errorf("config validation: %s %q source.path or source.ref is required", kind, name)
 	}
 	if modeCount > 1 {
-		return fmt.Errorf("config validation: %s %q source.path and source.ref are mutually exclusive", kind, name)
+		return fmt.Errorf("config validation: %s %q source.path, source.ref, and metadata URL sources are mutually exclusive", kind, name)
 	}
 	if src.IsManaged() {
 		if _, err := pluginsource.Parse(src.Ref); err != nil {
@@ -258,15 +283,31 @@ func validateProviderEntrySource(kind, name string, entry *ProviderEntry) error 
 			return fmt.Errorf("config validation: %s %q source.version: %w", kind, name, err)
 		}
 	}
-	if src.IsLocal() && src.Version != "" {
+	if src.IsMetadataURL() {
+		if parsed, err := url.ParseRequestURI(src.MetadataURL()); err != nil || parsed.Host == "" || (parsed.Scheme != "http" && parsed.Scheme != "https") || !strings.HasSuffix(parsed.Path, "/provider-release.yaml") {
+			return fmt.Errorf("config validation: %s %q source metadata URL must be an absolute http(s) provider-release.yaml URL", kind, name)
+		}
+	}
+	if !src.IsManaged() && src.Version != "" {
 		return fmt.Errorf("config validation: %s %q source.version is only valid with source.ref", kind, name)
 	}
+	if entry.InlineSourceAuth != nil && src.Auth != nil {
+		return fmt.Errorf("config validation: %s %q auth and source.auth are mutually exclusive", kind, name)
+	}
 	if src.Auth != nil {
-		if !src.IsManaged() {
-			return fmt.Errorf("config validation: %s %q source.auth is only valid with source.ref", kind, name)
+		if !src.IsManaged() && !src.IsMetadataURL() {
+			return fmt.Errorf("config validation: %s %q source.auth is only valid with source.ref or metadata URL sources", kind, name)
 		}
 		if strings.TrimSpace(src.Auth.Token) == "" {
 			return fmt.Errorf("config validation: %s %q source.auth.token is required when source.auth is set", kind, name)
+		}
+	}
+	if entry.InlineSourceAuth != nil {
+		if !src.IsMetadataURL() {
+			return fmt.Errorf("config validation: %s %q auth is only valid with metadata URL sources", kind, name)
+		}
+		if strings.TrimSpace(entry.InlineSourceAuth.Token) == "" {
+			return fmt.Errorf("config validation: %s %q auth.token is required when auth is set", kind, name)
 		}
 	}
 	return nil

--- a/gestaltd/internal/invocation/catalog.go
+++ b/gestaltd/internal/invocation/catalog.go
@@ -128,7 +128,10 @@ func resolveSessionCatalog(ctx context.Context, prov core.Provider, provName str
 	}
 	if prov.ConnectionMode() == core.ConnectionModeNone {
 		if resolver != nil && p != nil {
-			enrichedCtx, token, err := resolver.ResolveToken(ctx, p, provName, connection, instance)
+			// No-auth providers do not consume connection or instance selectors
+			// when resolving session catalogs. Passing them through here causes
+			// workload callers to trip the override guard before static fallback.
+			enrichedCtx, token, err := resolver.ResolveToken(ctx, p, provName, "", "")
 			if err != nil {
 				return nil, true, err
 			}

--- a/gestaltd/internal/operator/lifecycle.go
+++ b/gestaltd/internal/operator/lifecycle.go
@@ -257,32 +257,32 @@ func (l *Lifecycle) prepareRuntimeLockFromLoadedConfig(ctx context.Context, path
 
 func buildSourceTokenMap(cfg *config.Config) map[string]string {
 	tokens := make(map[string]string)
-	for _, entry := range cfg.Plugins {
-		if entry != nil && entry.Source.Auth != nil {
-			tokens[entry.SourceRef()] = entry.Source.Auth.Token
+	addEntry := func(entry *config.ProviderEntry) {
+		if entry == nil || entry.Source.Auth == nil {
+			return
 		}
+		location := strings.TrimSpace(entry.SourceRemoteLocation())
+		if location == "" {
+			return
+		}
+		tokens[location] = entry.Source.Auth.Token
+	}
+	for _, entry := range cfg.Plugins {
+		addEntry(entry)
 	}
 	for _, collection := range hostProviderCollections(cfg) {
 		for _, entry := range collection.entries {
-			if entry != nil && entry.Source.Auth != nil {
-				tokens[entry.SourceRef()] = entry.Source.Auth.Token
-			}
+			addEntry(entry)
 		}
 	}
 	for _, def := range cfg.Providers.IndexedDB {
-		if def != nil && def.Source.Auth != nil {
-			tokens[def.SourceRef()] = def.Source.Auth.Token
-		}
+		addEntry(def)
 	}
 	for _, def := range cfg.Providers.S3 {
-		if def != nil && def.Source.Auth != nil {
-			tokens[def.SourceRef()] = def.Source.Auth.Token
-		}
+		addEntry(def)
 	}
 	for _, entry := range cfg.Providers.UI {
-		if entry != nil && entry.Source.Auth != nil {
-			tokens[entry.SourceRef()] = entry.Source.Auth.Token
-		}
+		addEntry(&entry.ProviderEntry)
 	}
 	return tokens
 }
@@ -635,7 +635,7 @@ type providerFingerprintInput struct {
 }
 
 func sourceBacked(entry *config.ProviderEntry) bool {
-	return entry != nil && (entry.HasManagedSource() || entry.HasLocalSource())
+	return entry != nil && (entry.HasRemoteSource() || entry.HasLocalSource())
 }
 
 func hostProviderCollections(cfg *config.Config) []struct {
@@ -1049,7 +1049,7 @@ func ProviderFingerprint(name string, entry *config.ProviderEntry, configDir str
 
 	input := providerFingerprintInput{
 		Name:    name,
-		Source:  entry.SourceRef(),
+		Source:  entry.SourceRemoteLocation(),
 		Version: entry.SourceVersion(),
 	}
 	if entry.HasLocalSource() {
@@ -1143,7 +1143,7 @@ func lockEntryMatches(paths initPaths, kind, name string, providerEntry *config.
 	if err != nil || entry.Fingerprint != fingerprint {
 		return false
 	}
-	if entry.Source != providerEntry.SourceRef() || entry.Version != providerEntry.SourceVersion() {
+	if entry.Source != providerEntry.SourceRemoteLocation() || entry.Version != providerEntry.SourceVersion() {
 		return false
 	}
 	if len(entry.Archives) > 0 {
@@ -1434,16 +1434,17 @@ func (l *Lifecycle) lockComponentEntryForSource(ctx context.Context, paths initP
 		return localLockEntryFromPreparedInstall(paths, kind, name, plugin, install)
 	}
 
+	sourceLocation := plugin.SourceRemoteLocation()
 	src, err := sourceForProvider(plugin)
 	if err != nil {
-		return LockEntry{}, fmt.Errorf("%s %q source.ref %q: %w", kind, name, plugin.SourceRef(), err)
+		return LockEntry{}, fmt.Errorf("%s %q source %q: %w", kind, name, sourceLocation, err)
 	}
 	if l.sourceResolver == nil {
 		return LockEntry{}, fmt.Errorf("%s %q: source provider resolution requires a source resolver", kind, name)
 	}
 	resolved, err := l.sourceResolver.Resolve(ctx, src, plugin.SourceVersion())
 	if err != nil {
-		return LockEntry{}, fmt.Errorf("%s %q resolve source %q@%s: %w", kind, name, plugin.SourceRef(), plugin.SourceVersion(), err)
+		return LockEntry{}, fmt.Errorf("%s %q resolve source %q@%s: %w", kind, name, sourceLocation, plugin.SourceVersion(), err)
 	}
 	defer resolved.Cleanup()
 
@@ -1454,8 +1455,8 @@ func (l *Lifecycle) lockComponentEntryForSource(ctx context.Context, paths initP
 	if err := validateInstalledManifestKind(kind, name, installed.Manifest); err != nil {
 		return LockEntry{}, err
 	}
-	if installed.Manifest.Source != plugin.SourceRef() {
-		return LockEntry{}, fmt.Errorf("%s %q: manifest source %q does not match config source %q", kind, name, installed.Manifest.Source, plugin.SourceRef())
+	if installed.Manifest.Source != sourceLocation {
+		return LockEntry{}, fmt.Errorf("%s %q: manifest source %q does not match config source %q", kind, name, installed.Manifest.Source, sourceLocation)
 	}
 	if installed.Manifest.Version != plugin.SourceVersion() {
 		return LockEntry{}, fmt.Errorf("%s %q: manifest version %q does not match config version %q", kind, name, installed.Manifest.Version, plugin.SourceVersion())
@@ -1486,7 +1487,7 @@ func (l *Lifecycle) lockComponentEntryForSource(ctx context.Context, paths initP
 	}
 	return LockEntry{
 		Fingerprint: fingerprint,
-		Source:      plugin.SourceRef(),
+		Source:      sourceLocation,
 		Version:     plugin.SourceVersion(),
 		Archives:    archives,
 		Manifest:    filepath.ToSlash(manifestPath),
@@ -1509,16 +1510,17 @@ func (l *Lifecycle) lockProviderEntryForSource(ctx context.Context, paths initPa
 		return localLockEntryFromPreparedInstall(paths, providermanifestv1.KindPlugin, name, plugin, install)
 	}
 
+	sourceLocation := plugin.SourceRemoteLocation()
 	src, err := sourceForProvider(plugin)
 	if err != nil {
-		return LockProviderEntry{}, fmt.Errorf("provider %q source.ref %q: %w", name, plugin.SourceRef(), err)
+		return LockProviderEntry{}, fmt.Errorf("provider %q source %q: %w", name, sourceLocation, err)
 	}
 	if l.sourceResolver == nil {
 		return LockProviderEntry{}, fmt.Errorf("provider %q: source provider resolution requires a source resolver", name)
 	}
 	resolved, err := l.sourceResolver.Resolve(ctx, src, plugin.SourceVersion())
 	if err != nil {
-		return LockProviderEntry{}, fmt.Errorf("provider %q resolve source %q@%s: %w", name, plugin.SourceRef(), plugin.SourceVersion(), err)
+		return LockProviderEntry{}, fmt.Errorf("provider %q resolve source %q@%s: %w", name, sourceLocation, plugin.SourceVersion(), err)
 	}
 	defer resolved.Cleanup()
 
@@ -1531,8 +1533,8 @@ func (l *Lifecycle) lockProviderEntryForSource(ctx context.Context, paths initPa
 		return LockProviderEntry{}, err
 	}
 
-	if installed.Manifest.Source != plugin.SourceRef() {
-		return LockProviderEntry{}, fmt.Errorf("provider %q: manifest source %q does not match config source %q", name, installed.Manifest.Source, plugin.SourceRef())
+	if installed.Manifest.Source != sourceLocation {
+		return LockProviderEntry{}, fmt.Errorf("provider %q: manifest source %q does not match config source %q", name, installed.Manifest.Source, sourceLocation)
 	}
 	if installed.Manifest.Version != plugin.SourceVersion() {
 		return LockProviderEntry{}, fmt.Errorf("provider %q: manifest version %q does not match config version %q", name, installed.Manifest.Version, plugin.SourceVersion())
@@ -1562,7 +1564,7 @@ func (l *Lifecycle) lockProviderEntryForSource(ctx context.Context, paths initPa
 	}
 	return LockProviderEntry{
 		Fingerprint: fingerprint,
-		Source:      plugin.SourceRef(),
+		Source:      sourceLocation,
 		Version:     plugin.SourceVersion(),
 		Archives:    archives,
 		Manifest:    filepath.ToSlash(manifestPath),
@@ -1603,14 +1605,14 @@ func (l *Lifecycle) writeNamedUIProviderArtifact(ctx context.Context, paths init
 
 	src, err := sourceForProvider(plugin)
 	if err != nil {
-		return LockUIEntry{}, fmt.Errorf("%s source.ref %q: %w", subject, plugin.SourceRef(), err)
+		return LockUIEntry{}, fmt.Errorf("%s source %q: %w", subject, plugin.SourceRemoteLocation(), err)
 	}
 	if l.sourceResolver == nil {
 		return LockUIEntry{}, fmt.Errorf("%s: source resolution requires a source resolver", subject)
 	}
 	resolved, err := l.sourceResolver.Resolve(ctx, src, plugin.SourceVersion())
 	if err != nil {
-		return LockUIEntry{}, fmt.Errorf("%s resolve source %q@%s: %w", subject, plugin.SourceRef(), plugin.SourceVersion(), err)
+		return LockUIEntry{}, fmt.Errorf("%s resolve source %q@%s: %w", subject, plugin.SourceRemoteLocation(), plugin.SourceVersion(), err)
 	}
 	defer resolved.Cleanup()
 
@@ -1621,8 +1623,8 @@ func (l *Lifecycle) writeNamedUIProviderArtifact(ctx context.Context, paths init
 	if err := validateInstalledManifestKind(providermanifestv1.KindWebUI, subject, installed.Manifest); err != nil {
 		return LockUIEntry{}, err
 	}
-	if installed.Manifest.Source != plugin.SourceRef() {
-		return LockUIEntry{}, fmt.Errorf("%s manifest source %q does not match config source %q", subject, installed.Manifest.Source, plugin.SourceRef())
+	if installed.Manifest.Source != plugin.SourceRemoteLocation() {
+		return LockUIEntry{}, fmt.Errorf("%s manifest source %q does not match config source %q", subject, installed.Manifest.Source, plugin.SourceRemoteLocation())
 	}
 	if installed.Manifest.Version != plugin.SourceVersion() {
 		return LockUIEntry{}, fmt.Errorf("%s manifest version %q does not match config version %q", subject, installed.Manifest.Version, plugin.SourceVersion())
@@ -1644,7 +1646,7 @@ func (l *Lifecycle) writeNamedUIProviderArtifact(ctx context.Context, paths init
 	}
 	return LockUIEntry{
 		Fingerprint: fingerprint,
-		Source:      plugin.SourceRef(),
+		Source:      plugin.SourceRemoteLocation(),
 		Version:     plugin.SourceVersion(),
 		Archives:    archives,
 		Manifest:    filepath.ToSlash(manifestPath),
@@ -1653,6 +1655,9 @@ func (l *Lifecycle) writeNamedUIProviderArtifact(ctx context.Context, paths init
 }
 
 func sourceForProvider(providerEntry *config.ProviderEntry) (pluginsource.Source, error) {
+	if providerEntry != nil && providerEntry.HasMetadataSource() {
+		return pluginsource.Source{}, fmt.Errorf("metadata URL sources are not supported yet")
+	}
 	src, err := pluginsource.Parse(providerEntry.SourceRef())
 	if err != nil {
 		return pluginsource.Source{}, err
@@ -2135,7 +2140,7 @@ func (l *Lifecycle) applyLockedProviderEntry(paths initPaths, lock *Lockfile, na
 	if err != nil {
 		return fmt.Errorf("fingerprinting provider %q: %w", name, err)
 	}
-	if entry.Fingerprint != fingerprint || entry.Source != plugin.SourceRef() || entry.Version != plugin.SourceVersion() {
+	if entry.Fingerprint != fingerprint || entry.Source != plugin.SourceRemoteLocation() || entry.Version != plugin.SourceVersion() {
 		return fmt.Errorf("prepared artifact for provider %q is missing or stale; run `gestaltd init %s`", name, paths.configFlags)
 	}
 
@@ -2192,7 +2197,7 @@ func (l *Lifecycle) applyLockedComponentEntry(paths initPaths, entry *LockEntry,
 	if err != nil {
 		return fmt.Errorf("fingerprinting %s %q provider: %w", kind, name, err)
 	}
-	if entry.Fingerprint != fingerprint || entry.Source != plugin.SourceRef() || entry.Version != plugin.SourceVersion() {
+	if entry.Fingerprint != fingerprint || entry.Source != plugin.SourceRemoteLocation() || entry.Version != plugin.SourceVersion() {
 		return fmt.Errorf("prepared artifact for %s %q is missing or stale; run `gestaltd init %s`", kind, name, paths.configFlags)
 	}
 

--- a/gestaltd/internal/operator/lifecycle_source_test.go
+++ b/gestaltd/internal/operator/lifecycle_source_test.go
@@ -366,6 +366,19 @@ func TestSourcePluginEndToEnd(t *testing.T) {
 	if _, ok := written.Providers.Plugin["alpha"]; !ok {
 		t.Fatalf(`written.Providers.Plugin["alpha"] not found`)
 	}
+	writtenEntry := written.Providers.Plugin["alpha"]
+	if writtenEntry.InputDigest == "" {
+		t.Fatal("written plugin inputDigest is empty")
+	}
+	if writtenEntry.Package != source {
+		t.Fatalf("written plugin package = %q, want %q", writtenEntry.Package, source)
+	}
+	if writtenEntry.Kind != providermanifestv1.KindPlugin {
+		t.Fatalf("written plugin kind = %q, want %q", writtenEntry.Kind, providermanifestv1.KindPlugin)
+	}
+	if writtenEntry.Runtime != providerLockRuntimeExecutable {
+		t.Fatalf("written plugin runtime = %q, want %q", writtenEntry.Runtime, providerLockRuntimeExecutable)
+	}
 
 	readBack, err := ReadLockfile(lockPath)
 	if err != nil {
@@ -393,6 +406,33 @@ func TestSourcePluginNilResolver(t *testing.T) {
 	}
 	if !strings.Contains(err.Error(), "source resolver") {
 		t.Errorf("error = %q, want to contain 'source resolver'", err.Error())
+	}
+}
+
+func TestSourcePluginMetadataURLNotYetSupported(t *testing.T) {
+	t.Parallel()
+
+	dir := t.TempDir()
+	configPath := filepath.Join(dir, "gestalt.yaml")
+	if err := os.WriteFile(configPath, []byte(`
+apiVersion: gestaltd.config/v3
+plugins:
+  alpha:
+    source: https://example.com/providers/alpha/provider-release.yaml?download=1
+    auth:
+      token: test-token
+server:
+  artifactsDir: `+filepath.Join(dir, "prepared-artifacts")+`
+`), 0o644); err != nil {
+		t.Fatalf("write config: %v", err)
+	}
+
+	_, err := NewLifecycle(&fakeResolver{}).InitAtPath(configPath)
+	if err == nil {
+		t.Fatal("expected metadata URL source error")
+	}
+	if !strings.Contains(err.Error(), "metadata URL sources are not supported yet") {
+		t.Fatalf("unexpected error: %v", err)
 	}
 }
 
@@ -1747,7 +1787,7 @@ func TestSourcePluginGitHubResolverEndToEnd(t *testing.T) {
 	if strings.Contains(string(lockData), `"version": 7`) {
 		t.Fatalf("lockfile = %s, want schema-based versioning", lockData)
 	}
-	if strings.Contains(string(lockData), `"manifest"`) || strings.Contains(string(lockData), `"executable"`) {
+	if strings.Contains(string(lockData), `"manifest":`) || strings.Contains(string(lockData), `"executable":`) {
 		t.Fatalf("lockfile = %s, want portable entries only", lockData)
 	}
 	var diskLock providerLockfile
@@ -1758,7 +1798,22 @@ func TestSourcePluginGitHubResolverEndToEnd(t *testing.T) {
 	if !ok {
 		t.Fatal(`disk lock providers.plugin["alpha"] not found`)
 	}
-	if diskEntry.Source != testSource || diskEntry.Version != testVersion {
+	if diskEntry.InputDigest == "" {
+		t.Fatal("disk lock plugin inputDigest is empty")
+	}
+	if diskEntry.Package != testSource {
+		t.Fatalf("disk lock plugin package = %q, want %q", diskEntry.Package, testSource)
+	}
+	if diskEntry.Kind != providermanifestv1.KindPlugin {
+		t.Fatalf("disk lock plugin kind = %q, want %q", diskEntry.Kind, providermanifestv1.KindPlugin)
+	}
+	if diskEntry.Runtime != providerLockRuntimeExecutable {
+		t.Fatalf("disk lock plugin runtime = %q, want %q", diskEntry.Runtime, providerLockRuntimeExecutable)
+	}
+	if diskEntry.Source != "" {
+		t.Fatalf("disk lock plugin source = %q, want omitted portable source", diskEntry.Source)
+	}
+	if diskEntry.Version != testVersion {
 		t.Fatalf("disk lock plugin entry = %#v", diskEntry)
 	}
 	readBack, err := ReadLockfile(lockPath)

--- a/gestaltd/internal/operator/lifecycle_test.go
+++ b/gestaltd/internal/operator/lifecycle_test.go
@@ -3584,6 +3584,46 @@ func TestReadLockfile_RejectsLegacyUILockShapeBeforeUnmarshal(t *testing.T) {
 	}
 }
 
+func TestReadLockfile_AcceptsSchemaV1PortableEntries(t *testing.T) {
+	t.Parallel()
+
+	dir := t.TempDir()
+	lockPath := filepath.Join(dir, InitLockfileName)
+	legacy := `{
+  "schema": "gestaltd-provider-lock",
+  "schemaVersion": 1,
+  "revision": 0,
+  "providers": {
+    "plugin": {
+      "example": {
+        "fingerprint": "provider-fp",
+        "source": "github.com/test-org/test-repo/test-plugin",
+        "version": "1.0.0"
+      }
+    }
+  }
+}
+`
+	if err := os.WriteFile(lockPath, []byte(legacy), 0o644); err != nil {
+		t.Fatalf("WriteFile: %v", err)
+	}
+
+	lock, err := ReadLockfile(lockPath)
+	if err != nil {
+		t.Fatalf("ReadLockfile: %v", err)
+	}
+	entry, ok := lock.Providers["example"]
+	if !ok {
+		t.Fatal(`lock.Providers["example"] not found`)
+	}
+	if entry.Fingerprint != "provider-fp" {
+		t.Fatalf("Fingerprint = %q, want %q", entry.Fingerprint, "provider-fp")
+	}
+	if entry.Source != "github.com/test-org/test-repo/test-plugin" || entry.Version != "1.0.0" {
+		t.Fatalf("entry = %#v", entry)
+	}
+}
+
 func mustBuildManagedProviderPackage(t *testing.T, dir string, manifest *providermanifestv1.Manifest, artifacts map[string]string, includeCatalog bool) string {
 	t.Helper()
 
@@ -3694,6 +3734,18 @@ func TestReadWriteLockfile_RoundTrip(t *testing.T) {
 				Executable: ".gestaltd/providers/example/artifacts/darwin/arm64/provider",
 			},
 		},
+		Auth: map[string]LockEntry{
+			"oauth": {
+				Fingerprint: "auth-fp",
+				Source:      "github.com/test-org/test-repo/auth-oauth",
+				Version:     "1.0.1",
+				Archives: map[string]LockArchive{
+					"darwin/arm64": {URL: "https://example.com/auth-oauth.tar.gz", SHA256: "auth123"},
+				},
+				Manifest:   ".gestaltd/providers/auth/oauth/manifest.json",
+				Executable: ".gestaltd/providers/auth/oauth/artifacts/darwin/arm64/auth-oauth",
+			},
+		},
 		IndexedDBs: map[string]LockEntry{
 			"main": {
 				Fingerprint: "indexeddb-main-fp",
@@ -3755,8 +3807,66 @@ func TestReadWriteLockfile_RoundTrip(t *testing.T) {
 	if strings.Contains(string(lockData), `"version": 7`) {
 		t.Fatalf("lockfile = %s, want schema-based versioning", lockData)
 	}
-	if strings.Contains(string(lockData), `"manifest"`) || strings.Contains(string(lockData), `"executable"`) || strings.Contains(string(lockData), `"assetRoot"`) {
+	if strings.Contains(string(lockData), `"manifest":`) || strings.Contains(string(lockData), `"executable":`) || strings.Contains(string(lockData), `"assetRoot":`) {
 		t.Fatalf("lockfile = %s, want portable entries only", lockData)
+	}
+	var diskLock providerLockfile
+	if err := json.Unmarshal(lockData, &diskLock); err != nil {
+		t.Fatalf("Unmarshal lockfile: %v", err)
+	}
+	providerEntry, ok := diskLock.Providers.Plugin["example"]
+	if !ok {
+		t.Fatal(`disk lock providers.plugin["example"] not found`)
+	}
+	if providerEntry.InputDigest != want.Providers["example"].Fingerprint {
+		t.Fatalf("provider inputDigest = %q, want %q", providerEntry.InputDigest, want.Providers["example"].Fingerprint)
+	}
+	if providerEntry.Package != want.Providers["example"].Source {
+		t.Fatalf("provider package = %q, want %q", providerEntry.Package, want.Providers["example"].Source)
+	}
+	if providerEntry.Source != "" {
+		t.Fatalf("provider source = %q, want omitted portable source", providerEntry.Source)
+	}
+	if providerEntry.Kind != providermanifestv1.KindPlugin {
+		t.Fatalf("provider kind = %q, want %q", providerEntry.Kind, providermanifestv1.KindPlugin)
+	}
+	if providerEntry.Runtime != providerLockRuntimeExecutable {
+		t.Fatalf("provider runtime = %q, want %q", providerEntry.Runtime, providerLockRuntimeExecutable)
+	}
+	authEntry, ok := diskLock.Providers.Auth["oauth"]
+	if !ok {
+		t.Fatal(`disk lock providers.auth["oauth"] not found`)
+	}
+	if authEntry.InputDigest != want.Auth["oauth"].Fingerprint {
+		t.Fatalf("auth inputDigest = %q, want %q", authEntry.InputDigest, want.Auth["oauth"].Fingerprint)
+	}
+	if authEntry.Package != want.Auth["oauth"].Source {
+		t.Fatalf("auth package = %q, want %q", authEntry.Package, want.Auth["oauth"].Source)
+	}
+	if authEntry.Source != "" {
+		t.Fatalf("auth source = %q, want omitted portable source", authEntry.Source)
+	}
+	if authEntry.Kind != providermanifestv1.KindAuth {
+		t.Fatalf("auth kind = %q, want %q", authEntry.Kind, providermanifestv1.KindAuth)
+	}
+	if authEntry.Runtime != providerLockRuntimeExecutable {
+		t.Fatalf("auth runtime = %q, want %q", authEntry.Runtime, providerLockRuntimeExecutable)
+	}
+	uiEntry, ok := diskLock.Providers.WebUI["roadmap"]
+	if !ok {
+		t.Fatal(`disk lock providers.webui["roadmap"] not found`)
+	}
+	if uiEntry.InputDigest != want.UIs["roadmap"].Fingerprint {
+		t.Fatalf("ui inputDigest = %q, want %q", uiEntry.InputDigest, want.UIs["roadmap"].Fingerprint)
+	}
+	if uiEntry.Source != "" {
+		t.Fatalf("ui source = %q, want omitted portable source", uiEntry.Source)
+	}
+	if uiEntry.Kind != providermanifestv1.KindWebUI {
+		t.Fatalf("ui kind = %q, want %q", uiEntry.Kind, providermanifestv1.KindWebUI)
+	}
+	if uiEntry.Runtime != providerLockRuntimeAssets {
+		t.Fatalf("ui runtime = %q, want %q", uiEntry.Runtime, providerLockRuntimeAssets)
 	}
 
 	got, err := ReadLockfile(lockPath)
@@ -3771,6 +3881,9 @@ func TestReadWriteLockfile_RoundTrip(t *testing.T) {
 	}
 	if got.Providers["example"].Source != want.Providers["example"].Source || got.Providers["example"].Version != want.Providers["example"].Version {
 		t.Fatal("provider source mismatch")
+	}
+	if got.Auth["oauth"].Fingerprint != want.Auth["oauth"].Fingerprint {
+		t.Fatal("auth fingerprint mismatch")
 	}
 	if got.IndexedDBs["main"].Fingerprint != want.IndexedDBs["main"].Fingerprint {
 		t.Fatal("indexeddb fingerprint mismatch")

--- a/gestaltd/internal/operator/lockschema.go
+++ b/gestaltd/internal/operator/lockschema.go
@@ -8,11 +8,14 @@ import (
 )
 
 const (
-	providerLockSchemaName    = "gestaltd-provider-lock"
-	providerLockSchemaVersion = 1
-	providerLockRevision      = 0
-	providerLockKindTelemetry = "telemetry"
-	providerLockKindAudit     = "audit"
+	providerLockSchemaName        = "gestaltd-provider-lock"
+	providerLockSchemaVersion     = 2
+	providerLockRevision          = 0
+	providerLockKindWorkflow      = "workflow"
+	providerLockKindTelemetry     = "telemetry"
+	providerLockKindAudit         = "audit"
+	providerLockRuntimeExecutable = "executable"
+	providerLockRuntimeAssets     = "assets"
 )
 
 type providerLockfile struct {
@@ -36,7 +39,11 @@ type providerLockBuckets struct {
 }
 
 type portableLockEntry struct {
-	Fingerprint string                 `json:"fingerprint"`
+	InputDigest string                 `json:"inputDigest,omitempty"`
+	Fingerprint string                 `json:"fingerprint,omitempty"`
+	Package     string                 `json:"package"`
+	Kind        string                 `json:"kind"`
+	Runtime     string                 `json:"runtime"`
 	Source      string                 `json:"source,omitempty"`
 	Version     string                 `json:"version,omitempty"`
 	Archives    map[string]LockArchive `json:"archives,omitempty"`
@@ -150,16 +157,16 @@ func providerLockfileFromLockfile(lock *Lockfile) *providerLockfile {
 		SchemaVersion: providerLockSchemaVersion,
 		Revision:      providerLockRevision,
 		Providers: providerLockBuckets{
-			Plugin:    portableEntriesFromLockEntries(lock.Providers),
-			Auth:      portableEntriesFromLockEntries(lock.Auth),
-			IndexedDB: portableEntriesFromLockEntries(lock.IndexedDBs),
-			Cache:     portableEntriesFromLockEntries(lock.Caches),
-			S3:        portableEntriesFromLockEntries(lock.S3),
-			Workflow:  portableEntriesFromLockEntries(lock.Workflows),
-			Secrets:   portableEntriesFromLockEntries(lock.Secrets),
-			Telemetry: portableEntriesFromLockEntries(lock.Telemetry),
-			Audit:     portableEntriesFromLockEntries(lock.Audit),
-			WebUI:     portableEntriesFromLockEntries(lock.UIs),
+			Plugin:    portableEntriesFromLockEntries(lock.Providers, providermanifestv1.KindPlugin),
+			Auth:      portableEntriesFromLockEntries(lock.Auth, providermanifestv1.KindAuth),
+			IndexedDB: portableEntriesFromLockEntries(lock.IndexedDBs, providermanifestv1.KindIndexedDB),
+			Cache:     portableEntriesFromLockEntries(lock.Caches, providermanifestv1.KindCache),
+			S3:        portableEntriesFromLockEntries(lock.S3, providermanifestv1.KindS3),
+			Workflow:  portableEntriesFromLockEntries(lock.Workflows, providerLockKindWorkflow),
+			Secrets:   portableEntriesFromLockEntries(lock.Secrets, providermanifestv1.KindSecrets),
+			Telemetry: portableEntriesFromLockEntries(lock.Telemetry, providerLockKindTelemetry),
+			Audit:     portableEntriesFromLockEntries(lock.Audit, providerLockKindAudit),
+			WebUI:     portableEntriesFromLockEntries(lock.UIs, providermanifestv1.KindWebUI),
 		},
 	}
 }
@@ -189,21 +196,25 @@ func validateProviderLockfile(lock *providerLockfile) error {
 	if lock.Schema != providerLockSchemaName {
 		return fmt.Errorf("unsupported lockfile schema %q; run `gestaltd init` to upgrade", lock.Schema)
 	}
-	if lock.SchemaVersion != providerLockSchemaVersion {
+	switch lock.SchemaVersion {
+	case 1, providerLockSchemaVersion:
+	default:
 		return fmt.Errorf("unsupported lockfile schema version %d; run `gestaltd init` to upgrade", lock.SchemaVersion)
 	}
 	return nil
 }
 
-func portableEntriesFromLockEntries(entries map[string]LockEntry) map[string]portableLockEntry {
+func portableEntriesFromLockEntries(entries map[string]LockEntry, kind string) map[string]portableLockEntry {
 	if len(entries) == 0 {
 		return nil
 	}
 	portable := make(map[string]portableLockEntry, len(entries))
 	for name, entry := range entries {
 		portable[name] = portableLockEntry{
-			Fingerprint: entry.Fingerprint,
-			Source:      entry.Source,
+			InputDigest: entry.Fingerprint,
+			Package:     entry.Source,
+			Kind:        kind,
+			Runtime:     portableRuntimeForKind(kind),
 			Version:     entry.Version,
 			Archives:    maps.Clone(entry.Archives),
 		}
@@ -217,12 +228,27 @@ func lockEntriesFromPortableEntries(entries map[string]portableLockEntry) map[st
 	}
 	runtimeEntries := make(map[string]LockEntry, len(entries))
 	for name, entry := range entries {
+		fingerprint := entry.InputDigest
+		if fingerprint == "" {
+			fingerprint = entry.Fingerprint
+		}
+		source := entry.Source
+		if source == "" {
+			source = entry.Package
+		}
 		runtimeEntries[name] = LockEntry{
-			Fingerprint: entry.Fingerprint,
-			Source:      entry.Source,
+			Fingerprint: fingerprint,
+			Source:      source,
 			Version:     entry.Version,
 			Archives:    maps.Clone(entry.Archives),
 		}
 	}
 	return runtimeEntries
+}
+
+func portableRuntimeForKind(kind string) string {
+	if kind == providermanifestv1.KindWebUI {
+		return providerLockRuntimeAssets
+	}
+	return providerLockRuntimeExecutable
 }


### PR DESCRIPTION
## Summary
- add `apiVersion`-gated scalar source parsing for v3 configs
- normalize sibling inline metadata auth onto the existing source-auth path
- scaffold portable lock schema v2 with `inputDigest`, `package`, `kind`, `runtime`, and archive maps
- fail fast on unsupported scalar remote forms (`git+...`, non-`provider-release.yaml` HTTP URLs)

## Rust interface
```rust
struct PortableLockEntry {
    input_digest: String,
    package: String,
    kind: String,
    runtime: String,
    source: String,
    version: Option<String>,
    archives: BTreeMap<String, LockArchive>,
}

let config = r#"
apiVersion: gestaltd.config/v3
plugins:
  external:
    source: https://example.com/providers/external/provider-release.yaml?download=1
    auth:
      token: ${GITHUB_TOKEN}
"#;
```

## stdin/stdout interface
```yaml
apiVersion: gestaltd.config/v3
plugins:
  external:
    source: https://example.com/providers/external/provider-release.yaml?download=1
    auth:
      token: ${GITHUB_TOKEN}
```

Portable lock output:
```json
{
  "schema": "gestaltd-provider-lock",
  "schemaVersion": 2,
  "revision": 0,
  "providers": {
    "plugin": {
      "external": {
        "inputDigest": "sha256:...",
        "package": "https://example.com/providers/external/provider-release.yaml?download=1",
        "kind": "plugin",
        "runtime": "executable",
        "source": "https://example.com/providers/external/provider-release.yaml?download=1",
        "archives": {
          "linux/amd64": {
            "path": ".gestaltd/providers/external/linux_amd64.tar.gz",
            "sha256": "..."
          }
        }
      }
    }
  }
}
```

## Tests
- `go test ./internal/config`
- `go test ./internal/operator`