### PR TITLE
operator: resolve provider-release metadata sources

### DIFF
--- a/gestaltd/internal/operator/lifecycle.go
+++ b/gestaltd/internal/operator/lifecycle.go
@@ -21,7 +21,6 @@ import (
 	"github.com/valon-technologies/gestalt/server/internal/config"
 	"github.com/valon-technologies/gestalt/server/internal/plugininvocation"
 	"github.com/valon-technologies/gestalt/server/internal/pluginsource"
-	ghresolver "github.com/valon-technologies/gestalt/server/internal/pluginsource/github"
 	"github.com/valon-technologies/gestalt/server/internal/pluginstore"
 	"github.com/valon-technologies/gestalt/server/internal/providerpkg"
 	providermanifestv1 "github.com/valon-technologies/gestalt/server/sdk/providermanifest/v1"
@@ -65,6 +64,9 @@ type LockArchive struct {
 
 type LockEntry struct {
 	Fingerprint string                 `json:"fingerprint"`
+	Package     string                 `json:"package,omitempty"`
+	Kind        string                 `json:"kind,omitempty"`
+	Runtime     string                 `json:"runtime,omitempty"`
 	Source      string                 `json:"source,omitempty"`
 	Version     string                 `json:"version,omitempty"`
 	Archives    map[string]LockArchive `json:"archives,omitempty"`
@@ -79,6 +81,7 @@ type LockUIEntry = LockEntry
 type Lifecycle struct {
 	sourceResolver       pluginsource.Resolver
 	configSecretResolver func(context.Context, *config.Config) error
+	httpClient           *http.Client
 }
 
 type StatePaths struct {
@@ -95,6 +98,18 @@ func NewLifecycle(sourceResolver pluginsource.Resolver) *Lifecycle {
 func (l *Lifecycle) WithConfigSecretResolver(resolve func(context.Context, *config.Config) error) *Lifecycle {
 	l.configSecretResolver = resolve
 	return l
+}
+
+func (l *Lifecycle) WithHTTPClient(client *http.Client) *Lifecycle {
+	l.httpClient = client
+	return l
+}
+
+func (l *Lifecycle) metadataHTTPClient() *http.Client {
+	if l != nil && l.httpClient != nil {
+		return l.httpClient
+	}
+	return http.DefaultClient
 }
 
 func (l *Lifecycle) InitAtPath(configPath string) (*Lockfile, error) {
@@ -128,7 +143,7 @@ func (l *Lifecycle) InitAtPathsWithPlatforms(configPaths []string, state StatePa
 	}
 
 	tokenForSource := buildSourceTokenMap(cfg)
-	if err := downloadPlatformArchives(context.Background(), lock, paths, platforms, tokenForSource); err != nil {
+	if err := l.downloadPlatformArchives(context.Background(), lock, paths, platforms, tokenForSource); err != nil {
 		return nil, err
 	}
 
@@ -217,8 +232,8 @@ func (l *Lifecycle) prepareRuntimeLockFromLoadedConfig(ctx context.Context, path
 	if err := synthesizePluginOwnedUIEntries(cfg); err != nil {
 		return nil, err
 	}
-	for name, lockEntry := range secretsEntries {
-		lock.Secrets[name] = lockEntry
+	for name := range secretsEntries {
+		lock.Secrets[name] = secretsEntries[name]
 	}
 	for name, def := range cfg.Providers.IndexedDB {
 		if sourceBacked(def) {
@@ -456,7 +471,7 @@ func (l *Lifecycle) lockForSecretsBootstrap(configPaths []string, state StatePat
 
 	lock, err := ReadLockfile(paths.lockfilePath)
 	validatedDuringInit := false
-	if !locked && (err != nil || !lockMatchesConfig(cfg, paths, lock) || configHasLocalProviderSources(cfg)) {
+	if !locked && (err != nil || !lockMatchesConfig(cfg, paths, lock) || configHasLocalProviderSources(cfg) || configHasMetadataProviderSources(cfg)) {
 		lock, err = l.InitAtPathsWithStatePaths(configPaths, state)
 		validatedDuringInit = err == nil
 	}
@@ -735,6 +750,37 @@ func configHasLocalProviderSources(cfg *config.Config) bool {
 	}
 	for _, def := range cfg.Providers.S3 {
 		if def != nil && def.HasLocalSource() {
+			return true
+		}
+	}
+	return false
+}
+
+func configHasMetadataProviderSources(cfg *config.Config) bool {
+	for _, entry := range cfg.Plugins {
+		if entry != nil && entry.HasMetadataSource() {
+			return true
+		}
+	}
+	for _, collection := range hostProviderCollections(cfg) {
+		for _, entry := range collection.entries {
+			if entry != nil && entry.HasMetadataSource() {
+				return true
+			}
+		}
+	}
+	for _, entry := range cfg.Providers.UI {
+		if entry != nil && entry.HasMetadataSource() {
+			return true
+		}
+	}
+	for _, def := range cfg.Providers.IndexedDB {
+		if def != nil && def.HasMetadataSource() {
+			return true
+		}
+	}
+	for _, def := range cfg.Providers.S3 {
+		if def != nil && def.HasMetadataSource() {
 			return true
 		}
 	}
@@ -1068,6 +1114,16 @@ func NamedUIProviderFingerprint(name string, entry *config.ProviderEntry) (strin
 	return ProviderFingerprint("ui:"+name, entry, "")
 }
 
+func lockEntryVersionMatchesConfig(providerEntry *config.ProviderEntry, entry LockEntry) bool {
+	if providerEntry == nil {
+		return false
+	}
+	if providerEntry.HasMetadataSource() {
+		return strings.TrimSpace(entry.Version) != ""
+	}
+	return entry.Version == providerEntry.SourceVersion()
+}
+
 func archivePolicyKind(kind string) string {
 	switch kind {
 	case providerLockKindTelemetry, providerLockKindAudit:
@@ -1143,7 +1199,7 @@ func lockEntryMatches(paths initPaths, kind, name string, providerEntry *config.
 	if err != nil || entry.Fingerprint != fingerprint {
 		return false
 	}
-	if entry.Source != providerEntry.SourceRemoteLocation() || entry.Version != providerEntry.SourceVersion() {
+	if entry.Source != providerEntry.SourceRemoteLocation() || !lockEntryVersionMatchesConfig(providerEntry, entry) {
 		return false
 	}
 	if len(entry.Archives) > 0 {
@@ -1195,7 +1251,7 @@ func preparedManifestMatchesLock(entry LockEntry, manifest *providermanifestv1.M
 	if manifest == nil {
 		return false
 	}
-	if entry.Source != "" && manifest.Source != entry.Source {
+	if expectedPackage := lockEntryPackage(entry); expectedPackage != "" && manifest.Source != expectedPackage {
 		return false
 	}
 	if entry.Version != "" && manifest.Version != entry.Version {
@@ -1388,6 +1444,70 @@ func localUILockEntryFromPreparedInstall(paths initPaths, name string, plugin *c
 	}, nil
 }
 
+func (l *Lifecycle) installMetadataSourcePackage(ctx context.Context, expectedKind, name, subject, destDir string, plugin *config.ProviderEntry) (*pluginstore.InstalledPlugin, LockEntry, error) {
+	sourceLocation := plugin.SourceMetadataURL()
+	metadata, err := fetchProviderReleaseMetadata(ctx, l.metadataHTTPClient(), sourceLocation, sourceAuthToken(plugin))
+	if err != nil {
+		return nil, LockEntry{}, fmt.Errorf("%s fetch metadata %q: %w", subject, sourceLocation, err)
+	}
+	expectedManifestKind := archivePolicyKind(expectedKind)
+	if metadata.Kind != expectedManifestKind {
+		return nil, LockEntry{}, fmt.Errorf("%s metadata kind %q does not match expected kind %q", subject, metadata.Kind, expectedManifestKind)
+	}
+	archives, err := providerReleaseArchives(sourceLocation, metadata)
+	if err != nil {
+		return nil, LockEntry{}, fmt.Errorf("%s resolve archive metadata %q: %w", subject, sourceLocation, err)
+	}
+	entry := LockEntry{
+		Package:  metadata.Package,
+		Kind:     metadata.Kind,
+		Runtime:  metadata.Runtime,
+		Source:   sourceLocation,
+		Version:  metadata.Version,
+		Archives: archives,
+	}
+
+	currentPlatform := providerpkg.CurrentPlatformString()
+	archive, resolvedKey, ok := resolveArchiveForPlatform(entry, currentPlatform)
+	if !ok || archive.URL == "" {
+		return nil, LockEntry{}, fmt.Errorf("no archive for platform %s for %s; publish an explicit %s target or a generic package where allowed", currentPlatform, subject, currentPlatform)
+	}
+	download, err := downloadArchiveForSource(ctx, l.metadataHTTPClient(), sourceLocation, sourceAuthToken(plugin), archive.URL)
+	if err != nil {
+		return nil, LockEntry{}, fmt.Errorf("download metadata source package for %s: %w", subject, err)
+	}
+	defer download.Cleanup()
+	if archive.SHA256 != "" && download.SHA256Hex != archive.SHA256 {
+		return nil, LockEntry{}, fmt.Errorf("metadata source digest mismatch for %s: got %s, want %s", subject, download.SHA256Hex, archive.SHA256)
+	}
+
+	installed, err := pluginstore.Install(download.LocalPath, destDir)
+	if err != nil {
+		return nil, LockEntry{}, fmt.Errorf("install metadata source package for %s: %w", subject, err)
+	}
+	if err := validateInstalledManifestKind(expectedManifestKind, name, installed.Manifest); err != nil {
+		return nil, LockEntry{}, err
+	}
+	if installed.Manifest.Source != metadata.Package {
+		return nil, LockEntry{}, fmt.Errorf("%s manifest source %q does not match metadata package %q", subject, installed.Manifest.Source, metadata.Package)
+	}
+	if installed.Manifest.Version != metadata.Version {
+		return nil, LockEntry{}, fmt.Errorf("%s manifest version %q does not match metadata version %q", subject, installed.Manifest.Version, metadata.Version)
+	}
+	installedRuntime := releaseRuntimeForManifest(installed.Manifest, expectedManifestKind)
+	if metadata.Runtime != installedRuntime {
+		return nil, LockEntry{}, fmt.Errorf("%s manifest runtime %q does not match metadata runtime %q", subject, installedRuntime, metadata.Runtime)
+	}
+	entry.Package = installed.Manifest.Source
+	entry.Kind = installed.Manifest.Kind
+	entry.Runtime = installedRuntime
+	entry.Version = installed.Manifest.Version
+	if err := validateLockedArchivePolicy(subject, expectedManifestKind, installed.Manifest, entry, currentPlatform, resolvedKey); err != nil {
+		return nil, LockEntry{}, err
+	}
+	return installed, entry, nil
+}
+
 func (l *Lifecycle) writeProviderArtifacts(ctx context.Context, cfg *config.Config, paths initPaths) (map[string]LockProviderEntry, error) {
 	written := make(map[string]LockProviderEntry)
 	for name, entry := range cfg.Plugins {
@@ -1435,31 +1555,57 @@ func (l *Lifecycle) lockComponentEntryForSource(ctx context.Context, paths initP
 	}
 
 	sourceLocation := plugin.SourceRemoteLocation()
-	src, err := sourceForProvider(plugin)
-	if err != nil {
-		return LockEntry{}, fmt.Errorf("%s %q source %q: %w", kind, name, sourceLocation, err)
-	}
-	if l.sourceResolver == nil {
-		return LockEntry{}, fmt.Errorf("%s %q: source provider resolution requires a source resolver", kind, name)
-	}
-	resolved, err := l.sourceResolver.Resolve(ctx, src, plugin.SourceVersion())
-	if err != nil {
-		return LockEntry{}, fmt.Errorf("%s %q resolve source %q@%s: %w", kind, name, sourceLocation, plugin.SourceVersion(), err)
-	}
-	defer resolved.Cleanup()
+	expectedPackage := sourceLocation
+	var (
+		installed *pluginstore.InstalledPlugin
+		entry     LockEntry
+		err       error
+	)
+	subject := fmt.Sprintf("%s %q", kind, name)
+	if plugin.HasMetadataSource() {
+		installed, entry, err = l.installMetadataSourcePackage(ctx, kind, name, subject, destDir, plugin)
+		if err != nil {
+			return LockEntry{}, err
+		}
+		expectedPackage = lockEntryPackage(entry)
+	} else {
+		src, parseErr := sourceForProvider(plugin)
+		if parseErr != nil {
+			return LockEntry{}, fmt.Errorf("%s %q source %q: %w", kind, name, sourceLocation, parseErr)
+		}
+		if l.sourceResolver == nil {
+			return LockEntry{}, fmt.Errorf("%s %q: source provider resolution requires a source resolver", kind, name)
+		}
+		resolved, resolveErr := l.sourceResolver.Resolve(ctx, src, plugin.SourceVersion())
+		if resolveErr != nil {
+			return LockEntry{}, fmt.Errorf("%s %q resolve source %q@%s: %w", kind, name, sourceLocation, plugin.SourceVersion(), resolveErr)
+		}
+		defer resolved.Cleanup()
 
-	installed, err := pluginstore.Install(resolved.LocalPath, destDir)
-	if err != nil {
-		return LockEntry{}, fmt.Errorf("%s %q install source provider: %w", kind, name, err)
+		installed, err = pluginstore.Install(resolved.LocalPath, destDir)
+		if err != nil {
+			return LockEntry{}, fmt.Errorf("%s %q install source provider: %w", kind, name, err)
+		}
+		entry.Archives, err = l.buildArchivesMap(ctx, src, plugin.SourceVersion(), resolved.ResolvedURL, resolved.ArchiveSHA256, kind, subject, installed.Manifest)
+		if err != nil {
+			return LockEntry{}, err
+		}
+		entry.Package = installed.Manifest.Source
+		entry.Kind = installed.Manifest.Kind
+		entry.Runtime = releaseRuntimeForManifest(installed.Manifest, archivePolicyKind(kind))
+		entry.Source = sourceLocation
+		entry.Version = plugin.SourceVersion()
 	}
-	if err := validateInstalledManifestKind(kind, name, installed.Manifest); err != nil {
-		return LockEntry{}, err
-	}
-	if installed.Manifest.Source != sourceLocation {
-		return LockEntry{}, fmt.Errorf("%s %q: manifest source %q does not match config source %q", kind, name, installed.Manifest.Source, sourceLocation)
-	}
-	if installed.Manifest.Version != plugin.SourceVersion() {
-		return LockEntry{}, fmt.Errorf("%s %q: manifest version %q does not match config version %q", kind, name, installed.Manifest.Version, plugin.SourceVersion())
+	if !plugin.HasMetadataSource() {
+		if err := validateInstalledManifestKind(kind, name, installed.Manifest); err != nil {
+			return LockEntry{}, err
+		}
+		if installed.Manifest.Source != expectedPackage {
+			return LockEntry{}, fmt.Errorf("%s %q: manifest source %q does not match expected package %q", kind, name, installed.Manifest.Source, expectedPackage)
+		}
+		if installed.Manifest.Version != entry.Version {
+			return LockEntry{}, fmt.Errorf("%s %q: manifest version %q does not match expected version %q", kind, name, installed.Manifest.Version, entry.Version)
+		}
 	}
 	if err := providerpkg.ValidateConfigForManifest(installed.ManifestPath, installed.Manifest, kind, configMap); err != nil {
 		return LockEntry{}, fmt.Errorf("provider config validation for %s %q: %w", kind, name, err)
@@ -1481,18 +1627,10 @@ func (l *Lifecycle) lockComponentEntryForSource(ctx context.Context, paths initP
 	if err != nil {
 		return LockEntry{}, fmt.Errorf("compute executable path for %s %q: %w", kind, name, err)
 	}
-	archives, err := l.buildArchivesMap(ctx, src, plugin.SourceVersion(), resolved.ResolvedURL, resolved.ArchiveSHA256, kind, fmt.Sprintf("%s %q", kind, name), installed.Manifest)
-	if err != nil {
-		return LockEntry{}, err
-	}
-	return LockEntry{
-		Fingerprint: fingerprint,
-		Source:      sourceLocation,
-		Version:     plugin.SourceVersion(),
-		Archives:    archives,
-		Manifest:    filepath.ToSlash(manifestPath),
-		Executable:  filepath.ToSlash(executablePath),
-	}, nil
+	entry.Fingerprint = fingerprint
+	entry.Manifest = filepath.ToSlash(manifestPath)
+	entry.Executable = filepath.ToSlash(executablePath)
+	return entry, nil
 }
 
 func (l *Lifecycle) lockProviderEntryForSource(ctx context.Context, paths initPaths, name string, plugin *config.ProviderEntry, configMap map[string]any) (LockProviderEntry, error) {
@@ -1511,33 +1649,57 @@ func (l *Lifecycle) lockProviderEntryForSource(ctx context.Context, paths initPa
 	}
 
 	sourceLocation := plugin.SourceRemoteLocation()
-	src, err := sourceForProvider(plugin)
-	if err != nil {
-		return LockProviderEntry{}, fmt.Errorf("provider %q source %q: %w", name, sourceLocation, err)
-	}
-	if l.sourceResolver == nil {
-		return LockProviderEntry{}, fmt.Errorf("provider %q: source provider resolution requires a source resolver", name)
-	}
-	resolved, err := l.sourceResolver.Resolve(ctx, src, plugin.SourceVersion())
-	if err != nil {
-		return LockProviderEntry{}, fmt.Errorf("provider %q resolve source %q@%s: %w", name, sourceLocation, plugin.SourceVersion(), err)
-	}
-	defer resolved.Cleanup()
-
+	expectedPackage := sourceLocation
 	destDir := providerDestDir(paths, name)
-	installed, err := pluginstore.Install(resolved.LocalPath, destDir)
-	if err != nil {
-		return LockProviderEntry{}, fmt.Errorf("provider %q install source provider: %w", name, err)
-	}
-	if err := validateInstalledManifestKind(providermanifestv1.KindPlugin, name, installed.Manifest); err != nil {
-		return LockProviderEntry{}, err
-	}
+	var (
+		installed *pluginstore.InstalledPlugin
+		entry     LockProviderEntry
+		err       error
+	)
+	if plugin.HasMetadataSource() {
+		installed, entry, err = l.installMetadataSourcePackage(ctx, providermanifestv1.KindPlugin, name, fmt.Sprintf("provider %q", name), destDir, plugin)
+		if err != nil {
+			return LockProviderEntry{}, err
+		}
+		expectedPackage = lockEntryPackage(entry)
+	} else {
+		src, parseErr := sourceForProvider(plugin)
+		if parseErr != nil {
+			return LockProviderEntry{}, fmt.Errorf("provider %q source %q: %w", name, sourceLocation, parseErr)
+		}
+		if l.sourceResolver == nil {
+			return LockProviderEntry{}, fmt.Errorf("provider %q: source provider resolution requires a source resolver", name)
+		}
+		resolved, resolveErr := l.sourceResolver.Resolve(ctx, src, plugin.SourceVersion())
+		if resolveErr != nil {
+			return LockProviderEntry{}, fmt.Errorf("provider %q resolve source %q@%s: %w", name, sourceLocation, plugin.SourceVersion(), resolveErr)
+		}
+		defer resolved.Cleanup()
 
-	if installed.Manifest.Source != sourceLocation {
-		return LockProviderEntry{}, fmt.Errorf("provider %q: manifest source %q does not match config source %q", name, installed.Manifest.Source, sourceLocation)
+		installed, err = pluginstore.Install(resolved.LocalPath, destDir)
+		if err != nil {
+			return LockProviderEntry{}, fmt.Errorf("provider %q install source provider: %w", name, err)
+		}
+		entry.Archives, err = l.buildArchivesMap(ctx, src, plugin.SourceVersion(), resolved.ResolvedURL, resolved.ArchiveSHA256, providermanifestv1.KindPlugin, fmt.Sprintf("provider %q", name), installed.Manifest)
+		if err != nil {
+			return LockProviderEntry{}, err
+		}
+		entry.Package = installed.Manifest.Source
+		entry.Kind = installed.Manifest.Kind
+		entry.Runtime = releaseRuntimeForManifest(installed.Manifest, providermanifestv1.KindPlugin)
+		entry.Source = sourceLocation
+		entry.Version = plugin.SourceVersion()
 	}
-	if installed.Manifest.Version != plugin.SourceVersion() {
-		return LockProviderEntry{}, fmt.Errorf("provider %q: manifest version %q does not match config version %q", name, installed.Manifest.Version, plugin.SourceVersion())
+	if !plugin.HasMetadataSource() {
+		if err := validateInstalledManifestKind(providermanifestv1.KindPlugin, name, installed.Manifest); err != nil {
+			return LockProviderEntry{}, err
+		}
+		if installed.Manifest.Source != expectedPackage {
+			return LockProviderEntry{}, fmt.Errorf("provider %q: manifest source %q does not match expected package %q", name, installed.Manifest.Source, expectedPackage)
+		}
+		if installed.Manifest.Version != entry.Version {
+			return LockProviderEntry{}, fmt.Errorf("provider %q: manifest version %q does not match expected version %q", name, installed.Manifest.Version, entry.Version)
+		}
 	}
 
 	if err := providerpkg.ValidateConfigForManifest(installed.ManifestPath, installed.Manifest, providermanifestv1.KindPlugin, configMap); err != nil {
@@ -1558,18 +1720,10 @@ func (l *Lifecycle) lockProviderEntryForSource(ctx context.Context, paths initPa
 			return LockProviderEntry{}, fmt.Errorf("compute executable path for provider %q: %w", name, err)
 		}
 	}
-	archives, err := l.buildArchivesMap(ctx, src, plugin.SourceVersion(), resolved.ResolvedURL, resolved.ArchiveSHA256, providermanifestv1.KindPlugin, fmt.Sprintf("provider %q", name), installed.Manifest)
-	if err != nil {
-		return LockProviderEntry{}, err
-	}
-	return LockProviderEntry{
-		Fingerprint: fingerprint,
-		Source:      sourceLocation,
-		Version:     plugin.SourceVersion(),
-		Archives:    archives,
-		Manifest:    filepath.ToSlash(manifestPath),
-		Executable:  filepath.ToSlash(executableRel),
-	}, nil
+	entry.Fingerprint = fingerprint
+	entry.Manifest = filepath.ToSlash(manifestPath)
+	entry.Executable = filepath.ToSlash(executableRel)
+	return entry, nil
 }
 
 func (l *Lifecycle) writeNamedUIProviderArtifact(ctx context.Context, paths initPaths, name string, plugin *config.ProviderEntry, destDir string, subject string) (LockUIEntry, error) {
@@ -1602,32 +1756,57 @@ func (l *Lifecycle) writeNamedUIProviderArtifact(ctx context.Context, paths init
 		entry.Fingerprint = fingerprint
 		return entry, nil
 	}
+	expectedPackage := plugin.SourceRemoteLocation()
 
-	src, err := sourceForProvider(plugin)
-	if err != nil {
-		return LockUIEntry{}, fmt.Errorf("%s source %q: %w", subject, plugin.SourceRemoteLocation(), err)
-	}
-	if l.sourceResolver == nil {
-		return LockUIEntry{}, fmt.Errorf("%s: source resolution requires a source resolver", subject)
-	}
-	resolved, err := l.sourceResolver.Resolve(ctx, src, plugin.SourceVersion())
-	if err != nil {
-		return LockUIEntry{}, fmt.Errorf("%s resolve source %q@%s: %w", subject, plugin.SourceRemoteLocation(), plugin.SourceVersion(), err)
-	}
-	defer resolved.Cleanup()
+	var (
+		installed *pluginstore.InstalledPlugin
+		entry     LockUIEntry
+		opErr     error
+	)
+	if plugin.HasMetadataSource() {
+		installed, entry, opErr = l.installMetadataSourcePackage(ctx, providermanifestv1.KindWebUI, name, subject, destDir, plugin)
+		if opErr != nil {
+			return LockUIEntry{}, opErr
+		}
+		expectedPackage = lockEntryPackage(entry)
+	} else {
+		src, parseErr := sourceForProvider(plugin)
+		if parseErr != nil {
+			return LockUIEntry{}, fmt.Errorf("%s source %q: %w", subject, plugin.SourceRemoteLocation(), parseErr)
+		}
+		if l.sourceResolver == nil {
+			return LockUIEntry{}, fmt.Errorf("%s: source resolution requires a source resolver", subject)
+		}
+		resolved, resolveErr := l.sourceResolver.Resolve(ctx, src, plugin.SourceVersion())
+		if resolveErr != nil {
+			return LockUIEntry{}, fmt.Errorf("%s resolve source %q@%s: %w", subject, plugin.SourceRemoteLocation(), plugin.SourceVersion(), resolveErr)
+		}
+		defer resolved.Cleanup()
 
-	installed, err := pluginstore.Install(resolved.LocalPath, destDir)
-	if err != nil {
-		return LockUIEntry{}, fmt.Errorf("%s install source: %w", subject, err)
+		installed, opErr = pluginstore.Install(resolved.LocalPath, destDir)
+		if opErr != nil {
+			return LockUIEntry{}, fmt.Errorf("%s install source: %w", subject, opErr)
+		}
+		entry.Archives, opErr = l.buildArchivesMap(ctx, src, plugin.SourceVersion(), resolved.ResolvedURL, resolved.ArchiveSHA256, providermanifestv1.KindWebUI, subject, installed.Manifest)
+		if opErr != nil {
+			return LockUIEntry{}, opErr
+		}
+		entry.Package = installed.Manifest.Source
+		entry.Kind = installed.Manifest.Kind
+		entry.Runtime = releaseRuntimeForManifest(installed.Manifest, providermanifestv1.KindWebUI)
+		entry.Source = plugin.SourceRemoteLocation()
+		entry.Version = plugin.SourceVersion()
 	}
-	if err := validateInstalledManifestKind(providermanifestv1.KindWebUI, subject, installed.Manifest); err != nil {
-		return LockUIEntry{}, err
-	}
-	if installed.Manifest.Source != plugin.SourceRemoteLocation() {
-		return LockUIEntry{}, fmt.Errorf("%s manifest source %q does not match config source %q", subject, installed.Manifest.Source, plugin.SourceRemoteLocation())
-	}
-	if installed.Manifest.Version != plugin.SourceVersion() {
-		return LockUIEntry{}, fmt.Errorf("%s manifest version %q does not match config version %q", subject, installed.Manifest.Version, plugin.SourceVersion())
+	if !plugin.HasMetadataSource() {
+		if err := validateInstalledManifestKind(providermanifestv1.KindWebUI, subject, installed.Manifest); err != nil {
+			return LockUIEntry{}, err
+		}
+		if installed.Manifest.Source != expectedPackage {
+			return LockUIEntry{}, fmt.Errorf("%s manifest source %q does not match expected package %q", subject, installed.Manifest.Source, expectedPackage)
+		}
+		if installed.Manifest.Version != entry.Version {
+			return LockUIEntry{}, fmt.Errorf("%s manifest version %q does not match expected version %q", subject, installed.Manifest.Version, entry.Version)
+		}
 	}
 	if err := providerpkg.ValidateConfigForManifest(installed.ManifestPath, installed.Manifest, providermanifestv1.KindWebUI, configMap); err != nil {
 		return LockUIEntry{}, fmt.Errorf("provider config validation for %s: %w", subject, err)
@@ -1640,18 +1819,10 @@ func (l *Lifecycle) writeNamedUIProviderArtifact(ctx context.Context, paths init
 	if err != nil {
 		return LockUIEntry{}, fmt.Errorf("compute asset root path for %s: %w", subject, err)
 	}
-	archives, err := l.buildArchivesMap(ctx, src, plugin.SourceVersion(), resolved.ResolvedURL, resolved.ArchiveSHA256, providermanifestv1.KindWebUI, subject, installed.Manifest)
-	if err != nil {
-		return LockUIEntry{}, err
-	}
-	return LockUIEntry{
-		Fingerprint: fingerprint,
-		Source:      plugin.SourceRemoteLocation(),
-		Version:     plugin.SourceVersion(),
-		Archives:    archives,
-		Manifest:    filepath.ToSlash(manifestPath),
-		AssetRoot:   filepath.ToSlash(assetRoot),
-	}, nil
+	entry.Fingerprint = fingerprint
+	entry.Manifest = filepath.ToSlash(manifestPath)
+	entry.AssetRoot = filepath.ToSlash(assetRoot)
+	return entry, nil
 }
 
 func sourceForProvider(providerEntry *config.ProviderEntry) (pluginsource.Source, error) {
@@ -1756,7 +1927,7 @@ func (l *Lifecycle) applyLockedProviders(configPaths []string, state StatePaths,
 	if lock == nil {
 		lock, err = ReadLockfile(paths.lockfilePath)
 	}
-	if !locked && (err != nil || !lockMatchesConfig(cfg, paths, lock) || (bootstrapLock == nil && configHasLocalProviderSources(cfg))) {
+	if !locked && (err != nil || !lockMatchesConfig(cfg, paths, lock) || (bootstrapLock == nil && configHasLocalProviderSources(cfg)) || (bootstrapLock == nil && configHasMetadataProviderSources(cfg))) {
 		lock, err = l.InitAtPathsWithStatePaths(configPaths, state)
 		validatedDuringInit = err == nil
 	}
@@ -2140,7 +2311,7 @@ func (l *Lifecycle) applyLockedProviderEntry(paths initPaths, lock *Lockfile, na
 	if err != nil {
 		return fmt.Errorf("fingerprinting provider %q: %w", name, err)
 	}
-	if entry.Fingerprint != fingerprint || entry.Source != plugin.SourceRemoteLocation() || entry.Version != plugin.SourceVersion() {
+	if entry.Fingerprint != fingerprint || entry.Source != plugin.SourceRemoteLocation() || !lockEntryVersionMatchesConfig(plugin, entry) {
 		return fmt.Errorf("prepared artifact for provider %q is missing or stale; run `gestaltd init %s`", name, paths.configFlags)
 	}
 
@@ -2197,7 +2368,7 @@ func (l *Lifecycle) applyLockedComponentEntry(paths initPaths, entry *LockEntry,
 	if err != nil {
 		return fmt.Errorf("fingerprinting %s %q provider: %w", kind, name, err)
 	}
-	if entry.Fingerprint != fingerprint || entry.Source != plugin.SourceRemoteLocation() || entry.Version != plugin.SourceVersion() {
+	if entry.Fingerprint != fingerprint || entry.Source != plugin.SourceRemoteLocation() || !lockEntryVersionMatchesConfig(plugin, *entry) {
 		return fmt.Errorf("prepared artifact for %s %q is missing or stale; run `gestaltd init %s`", kind, name, paths.configFlags)
 	}
 
@@ -2323,23 +2494,7 @@ func (l *Lifecycle) materializeLockedProvider(ctx context.Context, paths initPat
 		return fmt.Errorf("no verified hash for platform %s for provider %q; run `gestaltd init %s`", platform, name, formatPlatformInitFlags(paths, platform))
 	}
 
-	src, parseErr := sourceForProvider(plugin)
-	if parseErr != nil {
-		src, parseErr = pluginsource.Parse(entry.Source)
-	}
-	var (
-		download *providerpkg.DownloadResult
-		err      error
-	)
-	if parseErr == nil && src.Host == pluginsource.HostGitHub {
-		download, err = ghresolver.DownloadResolvedAsset(ctx, http.DefaultClient, archive.URL, src.Token)
-	} else {
-		req, reqErr := http.NewRequestWithContext(ctx, http.MethodGet, archive.URL, nil)
-		if reqErr != nil {
-			return fmt.Errorf("create locked source provider request for provider %q: %w", name, reqErr)
-		}
-		download, err = providerpkg.DownloadRequest(http.DefaultClient, req)
-	}
+	download, err := downloadArchiveForSource(ctx, l.metadataHTTPClient(), entry.Source, sourceAuthToken(plugin), archive.URL)
 	if err != nil {
 		return fmt.Errorf("download locked source provider for provider %q: %w", name, err)
 	}
@@ -2354,8 +2509,8 @@ func (l *Lifecycle) materializeLockedProvider(ctx context.Context, paths initPat
 		return fmt.Errorf("install locked source provider for provider %q: %w", name, err)
 	}
 	defer func() { _ = cleanupInstall() }()
-	if installed.Manifest.Source != entry.Source {
-		return fmt.Errorf("locked source provider manifest source mismatch for provider %q: got %q, want %q", name, installed.Manifest.Source, entry.Source)
+	if installed.Manifest.Source != lockEntryPackage(entry) {
+		return fmt.Errorf("locked source provider manifest source mismatch for provider %q: got %q, want %q", name, installed.Manifest.Source, lockEntryPackage(entry))
 	}
 	if installed.Manifest.Version != entry.Version {
 		return fmt.Errorf("locked source provider manifest version mismatch for provider %q: got %q, want %q", name, installed.Manifest.Version, entry.Version)
@@ -2379,23 +2534,7 @@ func (l *Lifecycle) materializeLockedComponent(ctx context.Context, paths initPa
 		return fmt.Errorf("no verified hash for platform %s for %s %q; run `gestaltd init %s`", platform, kind, name, formatPlatformInitFlags(paths, platform))
 	}
 
-	src, parseErr := sourceForProvider(plugin)
-	if parseErr != nil {
-		src, parseErr = pluginsource.Parse(entry.Source)
-	}
-	var (
-		download *providerpkg.DownloadResult
-		err      error
-	)
-	if parseErr == nil && src.Host == pluginsource.HostGitHub {
-		download, err = ghresolver.DownloadResolvedAsset(ctx, http.DefaultClient, archive.URL, src.Token)
-	} else {
-		req, reqErr := http.NewRequestWithContext(ctx, http.MethodGet, archive.URL, nil)
-		if reqErr != nil {
-			return fmt.Errorf("create locked source provider request for %s %q: %w", kind, name, reqErr)
-		}
-		download, err = providerpkg.DownloadRequest(http.DefaultClient, req)
-	}
+	download, err := downloadArchiveForSource(ctx, l.metadataHTTPClient(), entry.Source, sourceAuthToken(plugin), archive.URL)
 	if err != nil {
 		return fmt.Errorf("download locked source provider for %s %q: %w", kind, name, err)
 	}
@@ -2415,8 +2554,8 @@ func (l *Lifecycle) materializeLockedComponent(ctx context.Context, paths initPa
 	if err := validateInstalledManifestKind(kind, name, installed.Manifest); err != nil {
 		return err
 	}
-	if installed.Manifest.Source != entry.Source {
-		return fmt.Errorf("locked source provider manifest source mismatch for %s %q: got %q, want %q", kind, name, installed.Manifest.Source, entry.Source)
+	if installed.Manifest.Source != lockEntryPackage(entry) {
+		return fmt.Errorf("locked source provider manifest source mismatch for %s %q: got %q, want %q", kind, name, installed.Manifest.Source, lockEntryPackage(entry))
 	}
 	if installed.Manifest.Version != entry.Version {
 		return fmt.Errorf("locked source provider manifest version mismatch for %s %q: got %q, want %q", kind, name, installed.Manifest.Version, entry.Version)
@@ -2440,23 +2579,7 @@ func (l *Lifecycle) materializeLockedUIProvider(ctx context.Context, paths initP
 		return fmt.Errorf("no verified hash for platform %s for ui provider; run `gestaltd init %s`", platform, formatPlatformInitFlags(paths, platform))
 	}
 
-	src, parseErr := sourceForProvider(plugin)
-	if parseErr != nil {
-		src, parseErr = pluginsource.Parse(entry.Source)
-	}
-	var (
-		download *providerpkg.DownloadResult
-		err      error
-	)
-	if parseErr == nil && src.Host == pluginsource.HostGitHub {
-		download, err = ghresolver.DownloadResolvedAsset(ctx, http.DefaultClient, archive.URL, src.Token)
-	} else {
-		req, reqErr := http.NewRequestWithContext(ctx, http.MethodGet, archive.URL, nil)
-		if reqErr != nil {
-			return fmt.Errorf("create locked source request for ui provider: %w", reqErr)
-		}
-		download, err = providerpkg.DownloadRequest(http.DefaultClient, req)
-	}
+	download, err := downloadArchiveForSource(ctx, l.metadataHTTPClient(), entry.Source, sourceAuthToken(plugin), archive.URL)
 	if err != nil {
 		return fmt.Errorf("download locked source for ui provider: %w", err)
 	}
@@ -2475,24 +2598,31 @@ func (l *Lifecycle) materializeLockedUIProvider(ctx context.Context, paths initP
 	if err := validateInstalledManifestKind(providermanifestv1.KindWebUI, "ui provider", installed.Manifest); err != nil {
 		return err
 	}
+	if installed.Manifest.Source != lockEntryPackage(entry) {
+		return fmt.Errorf("locked source manifest source mismatch for ui provider: got %q, want %q", installed.Manifest.Source, lockEntryPackage(entry))
+	}
+	if installed.Manifest.Version != entry.Version {
+		return fmt.Errorf("locked source manifest version mismatch for ui provider: got %q, want %q", installed.Manifest.Version, entry.Version)
+	}
 	return nil
 }
 
-func downloadPlatformArchives(ctx context.Context, lock *Lockfile, paths initPaths, platforms []struct{ GOOS, GOARCH, LibC string }, tokenForSource map[string]string) error {
+func (l *Lifecycle) downloadPlatformArchives(ctx context.Context, lock *Lockfile, paths initPaths, platforms []struct{ GOOS, GOARCH, LibC string }, tokenForSource map[string]string) error {
 	for _, plat := range platforms {
 		platformKey := providerpkg.PlatformString(plat.GOOS, plat.GOARCH)
-		if err := hashPlatformInEntries(ctx, lock, paths, platformKey, tokenForSource); err != nil {
+		if err := l.hashPlatformInEntries(ctx, lock, paths, platformKey, tokenForSource); err != nil {
 			return err
 		}
 	}
 	return nil
 }
 
-func hashPlatformInEntries(ctx context.Context, lock *Lockfile, paths initPaths, platformKey string, tokenForSource map[string]string) error {
+func (l *Lifecycle) hashPlatformInEntries(ctx context.Context, lock *Lockfile, paths initPaths, platformKey string, tokenForSource map[string]string) error {
 	for _, kind := range providerLockKinds() {
 		lockEntries := lockEntriesForProviderKind(lock, kind)
-		for name, entry := range lockEntries {
-			if err := hashArchiveEntry(ctx, kind, name, &entry, paths, platformKey, tokenForSource); err != nil {
+		for name := range lockEntries {
+			entry := lockEntries[name]
+			if err := l.hashArchiveEntry(ctx, kind, name, &entry, paths, platformKey, tokenForSource); err != nil {
 				return err
 			}
 			lockEntries[name] = entry
@@ -2501,7 +2631,7 @@ func hashPlatformInEntries(ctx context.Context, lock *Lockfile, paths initPaths,
 	return nil
 }
 
-func hashArchiveEntry(ctx context.Context, kind, name string, entry *LockEntry, paths initPaths, platformKey string, tokenForSource map[string]string) error {
+func (l *Lifecycle) hashArchiveEntry(ctx context.Context, kind, name string, entry *LockEntry, paths initPaths, platformKey string, tokenForSource map[string]string) error {
 	if entry.Archives == nil {
 		return nil
 	}
@@ -2522,20 +2652,7 @@ func hashArchiveEntry(ctx context.Context, kind, name string, entry *LockEntry, 
 		return err
 	}
 	token := tokenForSource[entry.Source]
-	src, parseErr := pluginsource.Parse(entry.Source)
-	var (
-		dl  *providerpkg.DownloadResult
-		err error
-	)
-	if parseErr == nil && src.Host == pluginsource.HostGitHub {
-		dl, err = ghresolver.DownloadResolvedAsset(ctx, http.DefaultClient, archive.URL, token)
-	} else {
-		req, reqErr := http.NewRequestWithContext(ctx, http.MethodGet, archive.URL, nil)
-		if reqErr != nil {
-			return fmt.Errorf("create request for platform %s, source %s: %w", platformKey, entry.Source, reqErr)
-		}
-		dl, err = providerpkg.DownloadRequest(http.DefaultClient, req)
-	}
+	dl, err := downloadArchiveForSource(ctx, l.metadataHTTPClient(), entry.Source, token, archive.URL)
 	if err != nil {
 		return fmt.Errorf("download archive for platform %s, source %s: %w", platformKey, entry.Source, err)
 	}
@@ -2581,8 +2698,9 @@ func validateInstalledManifestKind(kind, name string, manifest *providermanifest
 	if err != nil {
 		return fmt.Errorf("%s %q manifest is invalid: %w", kind, name, err)
 	}
-	if declared != kind {
-		return fmt.Errorf("%s %q manifest has kind %q, want %q", kind, name, declared, kind)
+	expectedKind := archivePolicyKind(kind)
+	if declared != expectedKind {
+		return fmt.Errorf("%s %q manifest has kind %q, want %q", kind, name, declared, expectedKind)
 	}
 	return nil
 }

--- a/gestaltd/internal/operator/lifecycle_source_test.go
+++ b/gestaltd/internal/operator/lifecycle_source_test.go
@@ -8,10 +8,12 @@ import (
 	"fmt"
 	"net/http"
 	"net/http/httptest"
+	"net/url"
 	"os"
 	"path/filepath"
 	"runtime"
 	"strings"
+	"sync"
 	"sync/atomic"
 	"testing"
 
@@ -61,6 +63,12 @@ type fakeResolverCall struct {
 type fakeMultiResolver struct {
 	results map[string]fakeResolverResult
 	calls   []fakeResolverCall
+}
+
+type hostRewriteTransport struct {
+	base   http.RoundTripper
+	target *url.URL
+	hosts  map[string]struct{}
 }
 
 func (f *fakeResolver) Resolve(_ context.Context, src pluginsource.Source, version string) (*pluginsource.ResolvedPackage, error) {
@@ -390,6 +398,33 @@ func TestSourcePluginEndToEnd(t *testing.T) {
 	}
 }
 
+func (t *hostRewriteTransport) RoundTrip(req *http.Request) (*http.Response, error) {
+	clone := req.Clone(req.Context())
+	if _, ok := t.hosts[strings.ToLower(req.URL.Hostname())]; ok {
+		clone.URL.Scheme = t.target.Scheme
+		clone.URL.Host = t.target.Host
+	}
+	return t.base.RoundTrip(clone)
+}
+
+func newGitHubRewriteClient(t *testing.T, target string) *http.Client {
+	t.Helper()
+	targetURL, err := url.Parse(target)
+	if err != nil {
+		t.Fatalf("parse rewrite target URL: %v", err)
+	}
+	return &http.Client{
+		Transport: &hostRewriteTransport{
+			base:   http.DefaultTransport,
+			target: targetURL,
+			hosts: map[string]struct{}{
+				"github.com":     {},
+				"api.github.com": {},
+			},
+		},
+	}
+}
+
 func TestSourcePluginNilResolver(t *testing.T) {
 	t.Parallel()
 
@@ -409,30 +444,604 @@ func TestSourcePluginNilResolver(t *testing.T) {
 	}
 }
 
-func TestSourcePluginMetadataURLNotYetSupported(t *testing.T) {
+func TestSourcePluginMetadataURLInitAndLockedLoad(t *testing.T) {
 	t.Parallel()
 
 	dir := t.TempDir()
+	packageSource := "github.com/acme/tools/alpha"
+	version := "1.2.3"
+	currentArchivePath := buildV2Archive(t, dir, packageSource, version, "metadata-url-plugin-binary")
+	currentArchiveData, err := os.ReadFile(currentArchivePath)
+	if err != nil {
+		t.Fatalf("read current archive: %v", err)
+	}
+	currentArchiveSHA := sha256.Sum256(currentArchiveData)
+
+	extraPlatform := struct {
+		goos   string
+		goarch string
+	}{
+		goos:   "linux",
+		goarch: "amd64",
+	}
+	for _, candidate := range []struct {
+		goos   string
+		goarch string
+	}{
+		{goos: "linux", goarch: "amd64"},
+		{goos: "linux", goarch: "arm64"},
+		{goos: "darwin", goarch: "amd64"},
+		{goos: "darwin", goarch: "arm64"},
+	} {
+		if candidate.goos != runtime.GOOS || candidate.goarch != runtime.GOARCH {
+			extraPlatform = candidate
+			break
+		}
+	}
+	extraPlatformKey := providerpkg.PlatformString(extraPlatform.goos, extraPlatform.goarch)
+	extraArchiveData := []byte("metadata-extra-platform-archive")
+	extraArchiveSHA := sha256.Sum256(extraArchiveData)
+
+	var metadataCount atomic.Int64
+	var currentArchiveCount atomic.Int64
+	var extraArchiveCount atomic.Int64
+	handlerErrs := make(chan error, 4)
+	nextHandlerErr := func() error {
+		t.Helper()
+		select {
+		case err := <-handlerErrs:
+			return err
+		default:
+			return nil
+		}
+	}
+	metadataPath := "/providers/alpha/provider-release.yaml"
+	currentArchivePathURL := "/providers/alpha/alpha-current.tar.gz"
+	extraArchivePathURL := "/providers/alpha/alpha-extra.tar.gz"
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch r.URL.Path {
+		case metadataPath:
+			metadataCount.Add(1)
+			if got := r.Header.Get("Authorization"); got != "Bearer test-token" {
+				handlerErrs <- fmt.Errorf("metadata authorization = %q, want %q", got, "Bearer test-token")
+				http.Error(w, "bad metadata authorization", http.StatusBadRequest)
+				return
+			}
+			metadata := providerReleaseMetadata{
+				Schema:        providerReleaseSchemaName,
+				SchemaVersion: providerReleaseSchemaVersion,
+				Package:       packageSource,
+				Kind:          providermanifestv1.KindPlugin,
+				Version:       version,
+				Runtime:       providerReleaseRuntimeExecutable,
+				Artifacts: map[string]providerReleaseArtifact{
+					providerpkg.CurrentPlatformString(): {
+						Path:   filepath.Base(currentArchivePathURL),
+						SHA256: hex.EncodeToString(currentArchiveSHA[:]),
+					},
+					extraPlatformKey: {
+						Path:   filepath.Base(extraArchivePathURL),
+						SHA256: hex.EncodeToString(extraArchiveSHA[:]),
+					},
+				},
+			}
+			data, err := yaml.Marshal(metadata)
+			if err != nil {
+				handlerErrs <- fmt.Errorf("marshal metadata: %v", err)
+				http.Error(w, "metadata marshal failed", http.StatusInternalServerError)
+				return
+			}
+			w.Header().Set("Content-Type", "application/yaml")
+			_, _ = w.Write(data)
+		case currentArchivePathURL:
+			currentArchiveCount.Add(1)
+			if got := r.Header.Get("Authorization"); got != "Bearer test-token" {
+				handlerErrs <- fmt.Errorf("current archive authorization = %q, want %q", got, "Bearer test-token")
+				http.Error(w, "bad archive authorization", http.StatusBadRequest)
+				return
+			}
+			w.Header().Set("Content-Type", "application/octet-stream")
+			_, _ = w.Write(currentArchiveData)
+		case extraArchivePathURL:
+			extraArchiveCount.Add(1)
+			if got := r.Header.Get("Authorization"); got != "Bearer test-token" {
+				handlerErrs <- fmt.Errorf("extra archive authorization = %q, want %q", got, "Bearer test-token")
+				http.Error(w, "bad archive authorization", http.StatusBadRequest)
+				return
+			}
+			w.Header().Set("Content-Type", "application/octet-stream")
+			_, _ = w.Write(extraArchiveData)
+		default:
+			http.NotFound(w, r)
+		}
+	}))
+	defer srv.Close()
+
+	artifactsDir := filepath.Join(dir, "prepared-artifacts")
 	configPath := filepath.Join(dir, "gestalt.yaml")
-	if err := os.WriteFile(configPath, []byte(`
-apiVersion: gestaltd.config/v3
-plugins:
-  alpha:
-    source: https://example.com/providers/alpha/provider-release.yaml?download=1
-    auth:
-      token: test-token
-server:
-  artifactsDir: `+filepath.Join(dir, "prepared-artifacts")+`
-`), 0o644); err != nil {
+	configYAML := requiredComponentConfigYAML(t, dir, filepath.Join(dir, "data.db")) + strings.Join([]string{
+		"apiVersion: " + config.APIVersionV3,
+		"plugins:",
+		"  alpha:",
+		"    source: " + srv.URL + metadataPath + "?download=1",
+		"    auth:",
+		"      token: test-token",
+		"server:",
+		"  providers:",
+		"    indexeddb: sqlite",
+		"  artifactsDir: " + artifactsDir,
+		"  encryptionKey: aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
+	}, "\n") + "\n"
+	if err := os.WriteFile(configPath, []byte(configYAML), 0o644); err != nil {
 		t.Fatalf("write config: %v", err)
 	}
 
-	_, err := NewLifecycle(&fakeResolver{}).InitAtPath(configPath)
+	lc := NewLifecycle(nil)
+	lock, err := lc.InitAtPathWithPlatforms(configPath, "", []struct{ GOOS, GOARCH, LibC string }{
+		{GOOS: extraPlatform.goos, GOARCH: extraPlatform.goarch},
+	})
 	if err == nil {
-		t.Fatal("expected metadata URL source error")
+		if handlerErr := nextHandlerErr(); handlerErr != nil {
+			t.Fatal(handlerErr)
+		}
 	}
-	if !strings.Contains(err.Error(), "metadata URL sources are not supported yet") {
-		t.Fatalf("unexpected error: %v", err)
+	if err != nil {
+		t.Fatalf("InitAtPathWithPlatforms: %v", err)
+	}
+	if handlerErr := nextHandlerErr(); handlerErr != nil {
+		t.Fatal(handlerErr)
+	}
+
+	entry, ok := lock.Providers["alpha"]
+	if !ok {
+		t.Fatal(`lock.Providers["alpha"] not found`)
+	}
+	if entry.Source != srv.URL+metadataPath+"?download=1" {
+		t.Fatalf("entry.Source = %q, want %q", entry.Source, srv.URL+metadataPath+"?download=1")
+	}
+	if entry.Package != packageSource {
+		t.Fatalf("entry.Package = %q, want %q", entry.Package, packageSource)
+	}
+	if entry.Kind != providermanifestv1.KindPlugin {
+		t.Fatalf("entry.Kind = %q, want %q", entry.Kind, providermanifestv1.KindPlugin)
+	}
+	if entry.Runtime != providerReleaseRuntimeExecutable {
+		t.Fatalf("entry.Runtime = %q, want %q", entry.Runtime, providerReleaseRuntimeExecutable)
+	}
+	if entry.Version != version {
+		t.Fatalf("entry.Version = %q, want %q", entry.Version, version)
+	}
+	if got := entry.Archives[providerpkg.CurrentPlatformString()].URL; got != srv.URL+currentArchivePathURL {
+		t.Fatalf("current archive URL = %q, want %q", got, srv.URL+currentArchivePathURL)
+	}
+	if got := entry.Archives[extraPlatformKey].SHA256; got != hex.EncodeToString(extraArchiveSHA[:]) {
+		t.Fatalf("extra platform SHA256 = %q, want %q", got, hex.EncodeToString(extraArchiveSHA[:]))
+	}
+	if got := metadataCount.Load(); got != 1 {
+		t.Fatalf("metadata request count = %d, want 1", got)
+	}
+	if got := currentArchiveCount.Load(); got != 1 {
+		t.Fatalf("current archive request count = %d, want 1", got)
+	}
+	if got := extraArchiveCount.Load(); got != 0 {
+		t.Fatalf("extra archive request count = %d, want 0", got)
+	}
+
+	lockData, err := os.ReadFile(filepath.Join(dir, InitLockfileName))
+	if err != nil {
+		t.Fatalf("ReadFile lockfile: %v", err)
+	}
+	var diskLock providerLockfile
+	if err := json.Unmarshal(lockData, &diskLock); err != nil {
+		t.Fatalf("Unmarshal lockfile: %v", err)
+	}
+	diskEntry, ok := diskLock.Providers.Plugin["alpha"]
+	if !ok {
+		t.Fatal(`disk lock providers.plugin["alpha"] not found`)
+	}
+	if diskEntry.Package != packageSource {
+		t.Fatalf("disk lock package = %q, want %q", diskEntry.Package, packageSource)
+	}
+	if diskEntry.Source != srv.URL+metadataPath+"?download=1" {
+		t.Fatalf("disk lock source = %q, want %q", diskEntry.Source, srv.URL+metadataPath+"?download=1")
+	}
+	if diskEntry.Runtime != providerReleaseRuntimeExecutable {
+		t.Fatalf("disk lock runtime = %q, want %q", diskEntry.Runtime, providerReleaseRuntimeExecutable)
+	}
+	if diskEntry.Kind != providermanifestv1.KindPlugin {
+		t.Fatalf("disk lock kind = %q, want %q", diskEntry.Kind, providermanifestv1.KindPlugin)
+	}
+	if got := diskEntry.Archives[extraPlatformKey].URL; got != srv.URL+extraArchivePathURL {
+		t.Fatalf("disk lock extra archive URL = %q, want %q", got, srv.URL+extraArchivePathURL)
+	}
+
+	pluginRoot := filepath.Join(artifactsDir, ".gestaltd", "providers", "alpha")
+	if err := os.RemoveAll(pluginRoot); err != nil {
+		t.Fatalf("RemoveAll plugin root: %v", err)
+	}
+
+	metadataBefore := metadataCount.Load()
+	currentBefore := currentArchiveCount.Load()
+	cfg, _, err := lc.LoadForExecutionAtPath(configPath, true)
+	if err != nil {
+		if handlerErr := nextHandlerErr(); handlerErr != nil {
+			t.Fatal(handlerErr)
+		}
+		t.Fatalf("LoadForExecutionAtPath(locked=true): %v", err)
+	}
+	if handlerErr := nextHandlerErr(); handlerErr != nil {
+		t.Fatal(handlerErr)
+	}
+	if got := metadataCount.Load(); got != metadataBefore {
+		t.Fatalf("metadata request count during locked load = %d, want %d", got, metadataBefore)
+	}
+	if got := currentArchiveCount.Load() - currentBefore; got != 1 {
+		t.Fatalf("current archive request count during locked load = %d, want 1", got)
+	}
+	if got := extraArchiveCount.Load(); got != 0 {
+		t.Fatalf("extra archive request count after locked load = %d, want 0", got)
+	}
+	if cfg.Plugins["alpha"] == nil {
+		t.Fatal(`cfg.Plugins["alpha"] = nil`)
+	}
+	if cfg.Plugins["alpha"].ResolvedManifest == nil {
+		t.Fatal(`cfg.Plugins["alpha"].ResolvedManifest = nil`)
+	}
+	if cfg.Plugins["alpha"].ResolvedManifest.Source != packageSource {
+		t.Fatalf("ResolvedManifest.Source = %q, want %q", cfg.Plugins["alpha"].ResolvedManifest.Source, packageSource)
+	}
+	executablePath := resolveLockPath(artifactsDir, entry.Executable)
+	if cfg.Plugins["alpha"].Command != executablePath {
+		t.Fatalf("plugin command = %q, want %q", cfg.Plugins["alpha"].Command, executablePath)
+	}
+}
+
+func TestSourceWorkflowMetadataURLInitAndLockedLoad(t *testing.T) {
+	t.Parallel()
+
+	dir := t.TempDir()
+	packageSource := "github.com/acme/tools/workflow-runner"
+	version := "2.3.4"
+	archivePath := buildExecutableArchive(t, dir, "workflow-metadata-src", packageSource, version, providermanifestv1.KindWorkflow, "workflow-runner", "metadata-workflow-binary")
+	archiveData, err := os.ReadFile(archivePath)
+	if err != nil {
+		t.Fatalf("read workflow archive: %v", err)
+	}
+	archiveSHA := sha256.Sum256(archiveData)
+
+	var metadataCount atomic.Int64
+	var archiveCount atomic.Int64
+	handlerErrs := make(chan error, 4)
+	nextHandlerErr := func() error {
+		t.Helper()
+		select {
+		case err := <-handlerErrs:
+			return err
+		default:
+			return nil
+		}
+	}
+
+	metadataPath := "/providers/workflow/provider-release.yaml"
+	archivePathURL := "/providers/workflow/workflow-runner.tar.gz"
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch r.URL.Path {
+		case metadataPath:
+			metadataCount.Add(1)
+			if got := r.Header.Get("Authorization"); got != "Bearer test-token" {
+				handlerErrs <- fmt.Errorf("metadata authorization = %q, want %q", got, "Bearer test-token")
+				http.Error(w, "bad metadata authorization", http.StatusBadRequest)
+				return
+			}
+			metadata := providerReleaseMetadata{
+				Schema:        providerReleaseSchemaName,
+				SchemaVersion: providerReleaseSchemaVersion,
+				Package:       packageSource,
+				Kind:          providermanifestv1.KindWorkflow,
+				Version:       version,
+				Runtime:       providerReleaseRuntimeExecutable,
+				Artifacts: map[string]providerReleaseArtifact{
+					providerpkg.CurrentPlatformString(): {
+						Path:   filepath.Base(archivePathURL),
+						SHA256: hex.EncodeToString(archiveSHA[:]),
+					},
+				},
+			}
+			data, err := yaml.Marshal(metadata)
+			if err != nil {
+				handlerErrs <- fmt.Errorf("marshal metadata: %v", err)
+				http.Error(w, "metadata marshal failed", http.StatusInternalServerError)
+				return
+			}
+			w.Header().Set("Content-Type", "application/yaml")
+			_, _ = w.Write(data)
+		case archivePathURL:
+			archiveCount.Add(1)
+			if got := r.Header.Get("Authorization"); got != "Bearer test-token" {
+				handlerErrs <- fmt.Errorf("archive authorization = %q, want %q", got, "Bearer test-token")
+				http.Error(w, "bad archive authorization", http.StatusBadRequest)
+				return
+			}
+			w.Header().Set("Content-Type", "application/octet-stream")
+			_, _ = w.Write(archiveData)
+		default:
+			http.NotFound(w, r)
+		}
+	}))
+	defer srv.Close()
+
+	artifactsDir := filepath.Join(dir, "prepared-artifacts")
+	configPath := filepath.Join(dir, "gestalt.yaml")
+	configYAML := "apiVersion: " + config.APIVersionV3 + "\n" + requiredComponentConfigYAML(t, dir, filepath.Join(dir, "data.db")) + strings.Join([]string{
+		"  workflow:",
+		"    runner:",
+		"      source: " + srv.URL + metadataPath,
+		"      auth:",
+		"        token: test-token",
+		"server:",
+		"  providers:",
+		"    indexeddb: sqlite",
+		"  artifactsDir: " + artifactsDir,
+		"  encryptionKey: aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
+	}, "\n") + "\n"
+	if err := os.WriteFile(configPath, []byte(configYAML), 0o644); err != nil {
+		t.Fatalf("write config: %v", err)
+	}
+
+	lc := NewLifecycle(nil)
+	lock, err := lc.InitAtPath(configPath)
+	if err == nil {
+		if handlerErr := nextHandlerErr(); handlerErr != nil {
+			t.Fatal(handlerErr)
+		}
+	}
+	if err != nil {
+		t.Fatalf("InitAtPath: %v", err)
+	}
+	if handlerErr := nextHandlerErr(); handlerErr != nil {
+		t.Fatal(handlerErr)
+	}
+
+	entry, ok := lock.Workflows["runner"]
+	if !ok {
+		t.Fatal(`lock.Workflows["runner"] not found`)
+	}
+	if entry.Package != packageSource {
+		t.Fatalf("entry.Package = %q, want %q", entry.Package, packageSource)
+	}
+	if entry.Kind != providermanifestv1.KindWorkflow {
+		t.Fatalf("entry.Kind = %q, want %q", entry.Kind, providermanifestv1.KindWorkflow)
+	}
+	if entry.Runtime != providerReleaseRuntimeExecutable {
+		t.Fatalf("entry.Runtime = %q, want %q", entry.Runtime, providerReleaseRuntimeExecutable)
+	}
+	if entry.Version != version {
+		t.Fatalf("entry.Version = %q, want %q", entry.Version, version)
+	}
+	if got := metadataCount.Load(); got != 1 {
+		t.Fatalf("metadata request count = %d, want 1", got)
+	}
+	if got := archiveCount.Load(); got != 1 {
+		t.Fatalf("archive request count = %d, want 1", got)
+	}
+
+	workflowRoot := filepath.Join(artifactsDir, filepath.FromSlash(PreparedWorkflowDir), "runner")
+	if err := os.RemoveAll(workflowRoot); err != nil {
+		t.Fatalf("RemoveAll workflow root: %v", err)
+	}
+
+	metadataBefore := metadataCount.Load()
+	archiveBefore := archiveCount.Load()
+	cfg, _, err := lc.LoadForExecutionAtPath(configPath, true)
+	if err == nil {
+		if handlerErr := nextHandlerErr(); handlerErr != nil {
+			t.Fatal(handlerErr)
+		}
+	}
+	if err != nil {
+		t.Fatalf("LoadForExecutionAtPath(locked=true): %v", err)
+	}
+	if handlerErr := nextHandlerErr(); handlerErr != nil {
+		t.Fatal(handlerErr)
+	}
+	if got := metadataCount.Load(); got != metadataBefore {
+		t.Fatalf("metadata request count during locked load = %d, want %d", got, metadataBefore)
+	}
+	if got := archiveCount.Load() - archiveBefore; got != 1 {
+		t.Fatalf("archive request count during locked load = %d, want 1", got)
+	}
+	workflow := cfg.Providers.Workflow["runner"]
+	if workflow == nil || workflow.ResolvedManifest == nil {
+		t.Fatalf("workflow resolved manifest = %+v", workflow)
+	}
+	if got := workflow.ResolvedManifest.Kind; got != providermanifestv1.KindWorkflow {
+		t.Fatalf("workflow manifest kind = %q, want %q", got, providermanifestv1.KindWorkflow)
+	}
+	if got := workflow.Command; got != resolveLockPath(artifactsDir, entry.Executable) {
+		t.Fatalf("workflow command = %q, want %q", got, resolveLockPath(artifactsDir, entry.Executable))
+	}
+}
+
+func TestSourceWebUIMetadataURLInitAndLockedLoad(t *testing.T) {
+	t.Parallel()
+
+	dir := t.TempDir()
+	packageSource := "github.com/acme/tools/roadmap-ui"
+	version := "0.9.1"
+	archivePath := mustBuildManagedProviderPackage(t, dir, &providermanifestv1.Manifest{
+		Kind:        providermanifestv1.KindWebUI,
+		Source:      packageSource,
+		Version:     version,
+		DisplayName: "Roadmap UI",
+		Spec: &providermanifestv1.Spec{
+			AssetRoot: "dist",
+		},
+	}, map[string]string{
+		"dist/index.html": "<html>roadmap</html>",
+	}, false)
+	archiveData, err := os.ReadFile(archivePath)
+	if err != nil {
+		t.Fatalf("read webui archive: %v", err)
+	}
+	archiveSHA := sha256.Sum256(archiveData)
+
+	var metadataCount atomic.Int64
+	var archiveCount atomic.Int64
+	handlerErrs := make(chan error, 4)
+	nextHandlerErr := func() error {
+		t.Helper()
+		select {
+		case err := <-handlerErrs:
+			return err
+		default:
+			return nil
+		}
+	}
+
+	metadataPath := "/providers/roadmap/provider-release.yaml"
+	archivePathURL := "/providers/roadmap/roadmap-ui.tar.gz"
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch r.URL.Path {
+		case metadataPath:
+			metadataCount.Add(1)
+			if got := r.Header.Get("Authorization"); got != "Bearer test-token" {
+				handlerErrs <- fmt.Errorf("metadata authorization = %q, want %q", got, "Bearer test-token")
+				http.Error(w, "bad metadata authorization", http.StatusBadRequest)
+				return
+			}
+			metadata := providerReleaseMetadata{
+				Schema:        providerReleaseSchemaName,
+				SchemaVersion: providerReleaseSchemaVersion,
+				Package:       packageSource,
+				Kind:          providermanifestv1.KindWebUI,
+				Version:       version,
+				Runtime:       providerReleaseRuntimeWebUI,
+				Artifacts: map[string]providerReleaseArtifact{
+					providerpkg.CurrentPlatformString(): {
+						Path:   filepath.Base(archivePathURL),
+						SHA256: hex.EncodeToString(archiveSHA[:]),
+					},
+				},
+			}
+			data, err := yaml.Marshal(metadata)
+			if err != nil {
+				handlerErrs <- fmt.Errorf("marshal metadata: %v", err)
+				http.Error(w, "metadata marshal failed", http.StatusInternalServerError)
+				return
+			}
+			w.Header().Set("Content-Type", "application/yaml")
+			_, _ = w.Write(data)
+		case archivePathURL:
+			archiveCount.Add(1)
+			if got := r.Header.Get("Authorization"); got != "Bearer test-token" {
+				handlerErrs <- fmt.Errorf("archive authorization = %q, want %q", got, "Bearer test-token")
+				http.Error(w, "bad archive authorization", http.StatusBadRequest)
+				return
+			}
+			w.Header().Set("Content-Type", "application/octet-stream")
+			_, _ = w.Write(archiveData)
+		default:
+			http.NotFound(w, r)
+		}
+	}))
+	defer srv.Close()
+
+	artifactsDir := filepath.Join(dir, "prepared-artifacts")
+	configPath := filepath.Join(dir, "gestalt.yaml")
+	configYAML := "apiVersion: " + config.APIVersionV3 + "\n" + requiredComponentConfigYAML(t, dir, filepath.Join(dir, "data.db")) + strings.Join([]string{
+		"  ui:",
+		"    roadmap:",
+		"      source: " + srv.URL + metadataPath + "?download=1",
+		"      auth:",
+		"        token: test-token",
+		"      path: /roadmap",
+		"server:",
+		"  providers:",
+		"    indexeddb: sqlite",
+		"  artifactsDir: " + artifactsDir,
+		"  encryptionKey: aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
+	}, "\n") + "\n"
+	if err := os.WriteFile(configPath, []byte(configYAML), 0o644); err != nil {
+		t.Fatalf("write config: %v", err)
+	}
+
+	lc := NewLifecycle(nil)
+	lock, err := lc.InitAtPath(configPath)
+	if err == nil {
+		if handlerErr := nextHandlerErr(); handlerErr != nil {
+			t.Fatal(handlerErr)
+		}
+	}
+	if err != nil {
+		t.Fatalf("InitAtPath: %v", err)
+	}
+	if handlerErr := nextHandlerErr(); handlerErr != nil {
+		t.Fatal(handlerErr)
+	}
+
+	entry, ok := lock.UIs["roadmap"]
+	if !ok {
+		t.Fatal(`lock.UIs["roadmap"] not found`)
+	}
+	if entry.Source != srv.URL+metadataPath+"?download=1" {
+		t.Fatalf("entry.Source = %q, want %q", entry.Source, srv.URL+metadataPath+"?download=1")
+	}
+	if entry.Package != packageSource {
+		t.Fatalf("entry.Package = %q, want %q", entry.Package, packageSource)
+	}
+	if entry.Kind != providermanifestv1.KindWebUI {
+		t.Fatalf("entry.Kind = %q, want %q", entry.Kind, providermanifestv1.KindWebUI)
+	}
+	if entry.Runtime != providerReleaseRuntimeWebUI {
+		t.Fatalf("entry.Runtime = %q, want %q", entry.Runtime, providerReleaseRuntimeWebUI)
+	}
+	if entry.Version != version {
+		t.Fatalf("entry.Version = %q, want %q", entry.Version, version)
+	}
+	if got := metadataCount.Load(); got != 1 {
+		t.Fatalf("metadata request count = %d, want 1", got)
+	}
+	if got := archiveCount.Load(); got != 1 {
+		t.Fatalf("archive request count = %d, want 1", got)
+	}
+
+	uiRoot := filepath.Join(artifactsDir, filepath.FromSlash(PreparedUIDir), "roadmap")
+	if err := os.RemoveAll(uiRoot); err != nil {
+		t.Fatalf("RemoveAll ui root: %v", err)
+	}
+
+	metadataBefore := metadataCount.Load()
+	archiveBefore := archiveCount.Load()
+	cfg, _, err := lc.LoadForExecutionAtPath(configPath, true)
+	if err == nil {
+		if handlerErr := nextHandlerErr(); handlerErr != nil {
+			t.Fatal(handlerErr)
+		}
+	}
+	if err != nil {
+		t.Fatalf("LoadForExecutionAtPath(locked=true): %v", err)
+	}
+	if handlerErr := nextHandlerErr(); handlerErr != nil {
+		t.Fatal(handlerErr)
+	}
+	if got := metadataCount.Load(); got != metadataBefore {
+		t.Fatalf("metadata request count during locked load = %d, want %d", got, metadataBefore)
+	}
+	if got := archiveCount.Load() - archiveBefore; got != 1 {
+		t.Fatalf("archive request count during locked load = %d, want 1", got)
+	}
+	ui := cfg.Providers.UI["roadmap"]
+	if ui == nil || ui.ResolvedManifest == nil {
+		t.Fatalf("ui resolved manifest = %+v", ui)
+	}
+	if got := ui.ResolvedManifest.Kind; got != providermanifestv1.KindWebUI {
+		t.Fatalf("ui manifest kind = %q, want %q", got, providermanifestv1.KindWebUI)
+	}
+	if got := ui.ResolvedManifest.Source; got != packageSource {
+		t.Fatalf("ui manifest source = %q, want %q", got, packageSource)
+	}
+	if got := ui.ResolvedAssetRoot; got != resolveLockPath(artifactsDir, entry.AssetRoot) {
+		t.Fatalf("ui asset root = %q, want %q", got, resolveLockPath(artifactsDir, entry.AssetRoot))
 	}
 }
 
@@ -537,6 +1146,389 @@ func TestSourcePluginLoadForExecution(t *testing.T) {
 	}
 	if cfg.Plugins["gadget"].Command != install.executablePath {
 		t.Fatalf("plugin command = %q, want %q", cfg.Plugins["gadget"].Command, install.executablePath)
+	}
+}
+
+func TestSourcePluginInitRejectsRefSourceManifestMismatch(t *testing.T) {
+	t.Parallel()
+
+	dir := t.TempDir()
+	source := "github.com/acme/tools/gadget"
+	version := "2.0.0"
+
+	archivePath := buildV2Archive(t, dir, "github.com/acme/tools/other-gadget", version, "fake-gadget-binary")
+	archiveData, err := os.ReadFile(archivePath)
+	if err != nil {
+		t.Fatalf("read archive: %v", err)
+	}
+	archiveSum := sha256.Sum256(archiveData)
+	archiveSHA := hex.EncodeToString(archiveSum[:])
+
+	resolver := &fakeResolver{
+		archivePath: archivePath,
+		resolvedURL: "https://example.com/plugin.tar.gz",
+		sha256:      archiveSHA,
+	}
+
+	artifactsDir := filepath.Join(dir, "prepared-artifacts")
+	yaml := requiredComponentConfigYAML(t, dir, filepath.Join(dir, "data.db")) + strings.Join([]string{
+		"plugins:",
+		"  gadget:",
+		"    source:",
+		"      ref: " + source,
+		"      version: " + version,
+		"server:",
+		"  providers:",
+		"    indexeddb: sqlite",
+		"  artifactsDir: " + artifactsDir,
+		"  encryptionKey: aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
+	}, "\n") + "\n"
+
+	configPath := filepath.Join(dir, "gestalt.yaml")
+	if err := os.WriteFile(configPath, []byte(yaml), 0o644); err != nil {
+		t.Fatalf("write config: %v", err)
+	}
+
+	lc := NewLifecycle(resolver)
+	_, err = lc.InitAtPath(configPath)
+	if err == nil {
+		t.Fatal("InitAtPath unexpectedly succeeded")
+	}
+	if !strings.Contains(err.Error(), `manifest source "github.com/acme/tools/other-gadget" does not match expected package "github.com/acme/tools/gadget"`) {
+		t.Fatalf("InitAtPath error = %v, want manifest source mismatch", err)
+	}
+}
+
+func TestSourcePluginMetadataURLUsesGitHubAssetTransport(t *testing.T) {
+	t.Parallel()
+
+	dir := t.TempDir()
+
+	const packageSource = testSource
+	const version = testVersion
+
+	currentArchivePath := buildV2Archive(t, dir, packageSource, version, "metadata-github-asset-plugin-binary")
+	currentArchiveData, err := os.ReadFile(currentArchivePath)
+	if err != nil {
+		t.Fatalf("read current archive: %v", err)
+	}
+	currentArchiveSHA := sha256.Sum256(currentArchiveData)
+
+	var metadataCount atomic.Int64
+	var archiveCount atomic.Int64
+	handlerErrs := make(chan error, 4)
+	nextHandlerErr := func() error {
+		t.Helper()
+		select {
+		case err := <-handlerErrs:
+			return err
+		default:
+			return nil
+		}
+	}
+
+	metadataPath := "/providers/alpha/provider-release.yaml"
+	githubArchiveURL := "https://api.github.com/repos/" + testOwner + "/" + testRepo + "/releases/assets/123"
+	githubArchivePath := "/repos/" + testOwner + "/" + testRepo + "/releases/assets/123"
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch r.URL.Path {
+		case metadataPath:
+			metadataCount.Add(1)
+			if got := r.Header.Get("Authorization"); got != "Bearer test-token" {
+				handlerErrs <- fmt.Errorf("metadata authorization = %q, want %q", got, "Bearer test-token")
+				http.Error(w, "bad metadata authorization", http.StatusBadRequest)
+				return
+			}
+			metadata := providerReleaseMetadata{
+				Schema:        providerReleaseSchemaName,
+				SchemaVersion: providerReleaseSchemaVersion,
+				Package:       packageSource,
+				Kind:          providermanifestv1.KindPlugin,
+				Version:       version,
+				Runtime:       providerReleaseRuntimeExecutable,
+				Artifacts: map[string]providerReleaseArtifact{
+					providerpkg.CurrentPlatformString(): {
+						Path:   githubArchiveURL,
+						SHA256: hex.EncodeToString(currentArchiveSHA[:]),
+					},
+				},
+			}
+			data, err := yaml.Marshal(metadata)
+			if err != nil {
+				handlerErrs <- fmt.Errorf("marshal metadata: %v", err)
+				http.Error(w, "metadata marshal failed", http.StatusInternalServerError)
+				return
+			}
+			w.Header().Set("Content-Type", "application/yaml")
+			_, _ = w.Write(data)
+		case githubArchivePath:
+			archiveCount.Add(1)
+			if got := r.Header.Get("Authorization"); got != "token test-token" {
+				handlerErrs <- fmt.Errorf("archive authorization = %q, want %q", got, "token test-token")
+				http.Error(w, "bad archive authorization", http.StatusBadRequest)
+				return
+			}
+			if got := r.Header.Get("Accept"); got != "application/octet-stream" {
+				handlerErrs <- fmt.Errorf("archive accept = %q, want %q", got, "application/octet-stream")
+				http.Error(w, "bad archive accept", http.StatusBadRequest)
+				return
+			}
+			w.Header().Set("Content-Type", "application/octet-stream")
+			_, _ = w.Write(currentArchiveData)
+		default:
+			http.NotFound(w, r)
+		}
+	}))
+	defer srv.Close()
+
+	artifactsDir := filepath.Join(dir, "prepared-artifacts")
+	configPath := filepath.Join(dir, "gestalt.yaml")
+	configYAML := requiredComponentConfigYAML(t, dir, filepath.Join(dir, "data.db")) + strings.Join([]string{
+		"apiVersion: " + config.APIVersionV3,
+		"plugins:",
+		"  alpha:",
+		"    source: " + srv.URL + metadataPath,
+		"    auth:",
+		"      token: test-token",
+		"server:",
+		"  providers:",
+		"    indexeddb: sqlite",
+		"  artifactsDir: " + artifactsDir,
+		"  encryptionKey: aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
+	}, "\n") + "\n"
+	if err := os.WriteFile(configPath, []byte(configYAML), 0o644); err != nil {
+		t.Fatalf("write config: %v", err)
+	}
+
+	lc := NewLifecycle(nil).WithHTTPClient(newGitHubRewriteClient(t, srv.URL))
+	lock, err := lc.InitAtPath(configPath)
+	if err == nil {
+		if handlerErr := nextHandlerErr(); handlerErr != nil {
+			t.Fatal(handlerErr)
+		}
+	}
+	if err != nil {
+		t.Fatalf("InitAtPath: %v", err)
+	}
+	if handlerErr := nextHandlerErr(); handlerErr != nil {
+		t.Fatal(handlerErr)
+	}
+
+	entry, ok := lock.Providers["alpha"]
+	if !ok {
+		t.Fatal(`lock.Providers["alpha"] not found`)
+	}
+	if got := entry.Archives[providerpkg.CurrentPlatformString()].URL; got != githubArchiveURL {
+		t.Fatalf("current archive URL = %q, want %q", got, githubArchiveURL)
+	}
+	if got := metadataCount.Load(); got != 1 {
+		t.Fatalf("metadata request count = %d, want 1", got)
+	}
+	if got := archiveCount.Load(); got != 1 {
+		t.Fatalf("archive request count = %d, want 1", got)
+	}
+
+	pluginRoot := filepath.Join(artifactsDir, ".gestaltd", "providers", "alpha")
+	if err := os.RemoveAll(pluginRoot); err != nil {
+		t.Fatalf("RemoveAll plugin root: %v", err)
+	}
+
+	metadataBefore := metadataCount.Load()
+	archiveBefore := archiveCount.Load()
+	cfg, _, err := lc.LoadForExecutionAtPath(configPath, true)
+	if err == nil {
+		if handlerErr := nextHandlerErr(); handlerErr != nil {
+			t.Fatal(handlerErr)
+		}
+	}
+	if err != nil {
+		t.Fatalf("LoadForExecutionAtPath(locked=true): %v", err)
+	}
+	if handlerErr := nextHandlerErr(); handlerErr != nil {
+		t.Fatal(handlerErr)
+	}
+	if got := metadataCount.Load(); got != metadataBefore {
+		t.Fatalf("metadata request count during locked load = %d, want %d", got, metadataBefore)
+	}
+	if got := archiveCount.Load() - archiveBefore; got != 1 {
+		t.Fatalf("archive request count during locked load = %d, want 1", got)
+	}
+	if cfg.Plugins["alpha"] == nil || cfg.Plugins["alpha"].ResolvedManifest == nil {
+		t.Fatal("resolved metadata plugin manifest missing after locked load")
+	}
+}
+
+func TestSourcePluginMetadataURLUnlockedLoadRefreshesMutableMetadata(t *testing.T) {
+	t.Parallel()
+
+	dir := t.TempDir()
+
+	const packageSource = testSource
+	const initialVersion = "1.0.0"
+	const updatedVersion = "1.0.1"
+
+	initialArchivePath := buildV2Archive(t, dir, packageSource, initialVersion, "metadata-mutable-plugin-v1")
+	initialArchiveData, err := os.ReadFile(initialArchivePath)
+	if err != nil {
+		t.Fatalf("read initial archive: %v", err)
+	}
+	initialArchiveSHA := sha256.Sum256(initialArchiveData)
+
+	updatedArchivePath := buildV2Archive(t, dir, packageSource, updatedVersion, "metadata-mutable-plugin-v2")
+	updatedArchiveData, err := os.ReadFile(updatedArchivePath)
+	if err != nil {
+		t.Fatalf("read updated archive: %v", err)
+	}
+	updatedArchiveSHA := sha256.Sum256(updatedArchiveData)
+
+	var metadataCount atomic.Int64
+	var archiveCount atomic.Int64
+	var currentMu sync.RWMutex
+	currentVersion := initialVersion
+	currentArchiveData := initialArchiveData
+	currentArchiveSHA := initialArchiveSHA
+
+	handlerErrs := make(chan error, 4)
+	nextHandlerErr := func() error {
+		t.Helper()
+		select {
+		case err := <-handlerErrs:
+			return err
+		default:
+			return nil
+		}
+	}
+
+	metadataPath := "/providers/alpha/provider-release.yaml"
+	currentArchivePathURL := "/providers/alpha/alpha-current.tar.gz"
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch r.URL.Path {
+		case metadataPath:
+			metadataCount.Add(1)
+			if got := r.Header.Get("Authorization"); got != "Bearer test-token" {
+				handlerErrs <- fmt.Errorf("metadata authorization = %q, want %q", got, "Bearer test-token")
+				http.Error(w, "bad metadata authorization", http.StatusBadRequest)
+				return
+			}
+			currentMu.RLock()
+			version := currentVersion
+			archiveSHA := currentArchiveSHA
+			currentMu.RUnlock()
+			metadata := providerReleaseMetadata{
+				Schema:        providerReleaseSchemaName,
+				SchemaVersion: providerReleaseSchemaVersion,
+				Package:       packageSource,
+				Kind:          providermanifestv1.KindPlugin,
+				Version:       version,
+				Runtime:       providerReleaseRuntimeExecutable,
+				Artifacts: map[string]providerReleaseArtifact{
+					providerpkg.CurrentPlatformString(): {
+						Path:   filepath.Base(currentArchivePathURL),
+						SHA256: hex.EncodeToString(archiveSHA[:]),
+					},
+				},
+			}
+			data, err := yaml.Marshal(metadata)
+			if err != nil {
+				handlerErrs <- fmt.Errorf("marshal metadata: %v", err)
+				http.Error(w, "metadata marshal failed", http.StatusInternalServerError)
+				return
+			}
+			w.Header().Set("Content-Type", "application/yaml")
+			_, _ = w.Write(data)
+		case currentArchivePathURL:
+			archiveCount.Add(1)
+			if got := r.Header.Get("Authorization"); got != "Bearer test-token" {
+				handlerErrs <- fmt.Errorf("archive authorization = %q, want %q", got, "Bearer test-token")
+				http.Error(w, "bad archive authorization", http.StatusBadRequest)
+				return
+			}
+			currentMu.RLock()
+			archiveData := currentArchiveData
+			currentMu.RUnlock()
+			w.Header().Set("Content-Type", "application/octet-stream")
+			_, _ = w.Write(archiveData)
+		default:
+			http.NotFound(w, r)
+		}
+	}))
+	defer srv.Close()
+
+	artifactsDir := filepath.Join(dir, "prepared-artifacts")
+	configPath := filepath.Join(dir, "gestalt.yaml")
+	configYAML := requiredComponentConfigYAML(t, dir, filepath.Join(dir, "data.db")) + strings.Join([]string{
+		"apiVersion: " + config.APIVersionV3,
+		"plugins:",
+		"  alpha:",
+		"    source: " + srv.URL + metadataPath,
+		"    auth:",
+		"      token: test-token",
+		"server:",
+		"  providers:",
+		"    indexeddb: sqlite",
+		"  artifactsDir: " + artifactsDir,
+		"  encryptionKey: aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
+	}, "\n") + "\n"
+	if err := os.WriteFile(configPath, []byte(configYAML), 0o644); err != nil {
+		t.Fatalf("write config: %v", err)
+	}
+
+	lc := NewLifecycle(nil)
+	lock, err := lc.InitAtPath(configPath)
+	if err == nil {
+		if handlerErr := nextHandlerErr(); handlerErr != nil {
+			t.Fatal(handlerErr)
+		}
+	}
+	if err != nil {
+		t.Fatalf("InitAtPath: %v", err)
+	}
+	if handlerErr := nextHandlerErr(); handlerErr != nil {
+		t.Fatal(handlerErr)
+	}
+	if got := lock.Providers["alpha"].Version; got != initialVersion {
+		t.Fatalf("initial lock version = %q, want %q", got, initialVersion)
+	}
+
+	currentMu.Lock()
+	currentVersion = updatedVersion
+	currentArchiveData = updatedArchiveData
+	currentArchiveSHA = updatedArchiveSHA
+	currentMu.Unlock()
+
+	metadataBefore := metadataCount.Load()
+	archiveBefore := archiveCount.Load()
+	cfg, _, err := lc.LoadForExecutionAtPath(configPath, false)
+	if err == nil {
+		if handlerErr := nextHandlerErr(); handlerErr != nil {
+			t.Fatal(handlerErr)
+		}
+	}
+	if err != nil {
+		t.Fatalf("LoadForExecutionAtPath(locked=false): %v", err)
+	}
+	if handlerErr := nextHandlerErr(); handlerErr != nil {
+		t.Fatal(handlerErr)
+	}
+	if got := metadataCount.Load(); got <= metadataBefore {
+		t.Fatalf("metadata request count after unlocked load = %d, want > %d", got, metadataBefore)
+	}
+	if got := archiveCount.Load(); got <= archiveBefore {
+		t.Fatalf("archive request count after unlocked load = %d, want > %d", got, archiveBefore)
+	}
+	if cfg.Plugins["alpha"] == nil || cfg.Plugins["alpha"].ResolvedManifest == nil {
+		t.Fatal("resolved metadata plugin manifest missing after unlocked refresh")
+	}
+	if got := cfg.Plugins["alpha"].ResolvedManifest.Version; got != updatedVersion {
+		t.Fatalf("resolved manifest version after unlocked refresh = %q, want %q", got, updatedVersion)
+	}
+
+	updatedLock, err := ReadLockfile(filepath.Join(dir, InitLockfileName))
+	if err != nil {
+		t.Fatalf("ReadLockfile: %v", err)
+	}
+	if got := updatedLock.Providers["alpha"].Version; got != updatedVersion {
+		t.Fatalf("updated lock version = %q, want %q", got, updatedVersion)
 	}
 }
 
@@ -1614,6 +2606,186 @@ func TestLoadForExecutionAtPath_UnlockedBootstrapInitPreparesOnce(t *testing.T) 
 	}
 	if resolver.lastSrc.Token != "ghp_inline_auth_source_token" {
 		t.Fatalf("resolver token = %q, want %q", resolver.lastSrc.Token, "ghp_inline_auth_source_token")
+	}
+
+	authProvider := mustSelectedHostProviderEntry(t, cfg, config.HostProviderKindAuth)
+	if authProvider == nil || authProvider.Source.Auth == nil {
+		t.Fatalf("auth provider source auth = %#v", authProvider)
+	}
+	if authProvider.Source.Auth.Token != "ghp_inline_auth_source_token" {
+		t.Fatalf("resolved auth source token = %q, want %q", authProvider.Source.Auth.Token, "ghp_inline_auth_source_token")
+	}
+}
+
+func TestLoadForExecutionAtPath_UnlockedBootstrapMetadataInitPreparesOnce(t *testing.T) {
+	t.Parallel()
+
+	dir := t.TempDir()
+	bootstrapSource := "github.com/acme/tools/bootstrap-secrets"
+	bootstrapVersion := "0.1.0"
+	authSource := "github.com/acme/tools/auth-widget"
+	authVersion := "2.0.0"
+	bootstrapArtifact := filepath.ToSlash(filepath.Join("artifacts", runtime.GOOS, runtime.GOARCH, "bootstrap-secrets"))
+	bootstrapManifestPath := filepath.Join(dir, "bootstrap-secrets-manifest.yaml")
+	bootstrapManifest, err := providerpkg.EncodeSourceManifestFormat(&providermanifestv1.Manifest{
+		Kind:    providermanifestv1.KindSecrets,
+		Source:  bootstrapSource,
+		Version: bootstrapVersion,
+		Spec:    &providermanifestv1.Spec{},
+		Artifacts: []providermanifestv1.Artifact{
+			{OS: runtime.GOOS, Arch: runtime.GOARCH, Path: bootstrapArtifact},
+		},
+		Entrypoint: &providermanifestv1.Entrypoint{ArtifactPath: bootstrapArtifact},
+	}, providerpkg.ManifestFormatYAML)
+	if err != nil {
+		t.Fatalf("EncodeSourceManifestFormat bootstrap: %v", err)
+	}
+	if err := os.WriteFile(bootstrapManifestPath, bootstrapManifest, 0o644); err != nil {
+		t.Fatalf("write bootstrap manifest: %v", err)
+	}
+	bootstrapBinaryData, err := os.ReadFile(buildGoSourceSecretsBinary(t))
+	if err != nil {
+		t.Fatalf("read bootstrap binary: %v", err)
+	}
+	bootstrapBinaryPath := filepath.Join(dir, filepath.FromSlash(bootstrapArtifact))
+	if err := os.MkdirAll(filepath.Dir(bootstrapBinaryPath), 0o755); err != nil {
+		t.Fatalf("MkdirAll bootstrap artifact: %v", err)
+	}
+	if err := os.WriteFile(bootstrapBinaryPath, bootstrapBinaryData, 0o755); err != nil {
+		t.Fatalf("write bootstrap artifact: %v", err)
+	}
+
+	authArchivePath := buildExecutableArchive(
+		t,
+		dir,
+		"auth-metadata-src",
+		authSource,
+		authVersion,
+		providermanifestv1.KindAuth,
+		"auth-plugin",
+		"fake-auth-binary",
+	)
+	authArchiveData, err := os.ReadFile(authArchivePath)
+	if err != nil {
+		t.Fatalf("read auth archive: %v", err)
+	}
+	authArchiveSum := sha256.Sum256(authArchiveData)
+
+	var metadataCount atomic.Int64
+	var archiveCount atomic.Int64
+	handlerErrs := make(chan error, 4)
+	nextHandlerErr := func() error {
+		t.Helper()
+		select {
+		case err := <-handlerErrs:
+			return err
+		default:
+			return nil
+		}
+	}
+
+	metadataPath := "/providers/auth/provider-release.yaml"
+	archivePathURL := "/providers/auth/auth-current.tar.gz"
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch r.URL.Path {
+		case metadataPath:
+			metadataCount.Add(1)
+			if got := r.Header.Get("Authorization"); got != "Bearer ghp_inline_auth_source_token" {
+				handlerErrs <- fmt.Errorf("metadata authorization = %q, want %q", got, "Bearer ghp_inline_auth_source_token")
+				http.Error(w, "bad metadata authorization", http.StatusBadRequest)
+				return
+			}
+			metadata := providerReleaseMetadata{
+				Schema:        providerReleaseSchemaName,
+				SchemaVersion: providerReleaseSchemaVersion,
+				Package:       authSource,
+				Kind:          providermanifestv1.KindAuth,
+				Version:       authVersion,
+				Runtime:       providerReleaseRuntimeExecutable,
+				Artifacts: map[string]providerReleaseArtifact{
+					providerpkg.CurrentPlatformString(): {
+						Path:   filepath.Base(archivePathURL),
+						SHA256: hex.EncodeToString(authArchiveSum[:]),
+					},
+				},
+			}
+			data, err := yaml.Marshal(metadata)
+			if err != nil {
+				handlerErrs <- fmt.Errorf("marshal metadata: %v", err)
+				http.Error(w, "metadata marshal failed", http.StatusInternalServerError)
+				return
+			}
+			w.Header().Set("Content-Type", "application/yaml")
+			_, _ = w.Write(data)
+		case archivePathURL:
+			archiveCount.Add(1)
+			if got := r.Header.Get("Authorization"); got != "Bearer ghp_inline_auth_source_token" {
+				handlerErrs <- fmt.Errorf("archive authorization = %q, want %q", got, "Bearer ghp_inline_auth_source_token")
+				http.Error(w, "bad archive authorization", http.StatusBadRequest)
+				return
+			}
+			w.Header().Set("Content-Type", "application/octet-stream")
+			_, _ = w.Write(authArchiveData)
+		default:
+			http.NotFound(w, r)
+		}
+	}))
+	defer srv.Close()
+
+	artifactsDir := filepath.Join(dir, "prepared-artifacts")
+	configYAML := strings.Join([]string{
+		"apiVersion: " + config.APIVersionV3,
+		requiredIndexedDBConfigYAML(t, dir, filepath.Join(dir, "data.db")),
+		"  secrets:",
+		"    bootstrap:",
+		"      source:",
+		"        path: ./bootstrap-secrets-manifest.yaml",
+		"  auth:",
+		"    auth:",
+		"      source: " + srv.URL + metadataPath + "?download=1",
+		"      auth:",
+		"        token:",
+		"          secret:",
+		"            provider: bootstrap",
+		"            name: source-token",
+		"      config:",
+		"        clientId: managed-auth-client",
+		"server:",
+		"  providers:",
+		"    indexeddb: sqlite",
+		"    secrets: bootstrap",
+		"    auth: auth",
+		"  artifactsDir: " + artifactsDir,
+		"  encryptionKey: aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
+	}, "\n") + "\n"
+
+	configPath := filepath.Join(dir, "gestalt.yaml")
+	if err := os.WriteFile(configPath, []byte(configYAML), 0o644); err != nil {
+		t.Fatalf("write config: %v", err)
+	}
+
+	factories := bootstrap.NewFactoryRegistry()
+	factories.Secrets["provider"] = secretsprovider.Factory
+
+	lc := NewLifecycle(nil).WithConfigSecretResolver(func(ctx context.Context, cfg *config.Config) error {
+		return bootstrap.ResolveConfigSecrets(ctx, cfg, factories)
+	})
+
+	cfg, _, err := lc.LoadForExecutionAtPath(configPath, false)
+	if err != nil {
+		if handlerErr := nextHandlerErr(); handlerErr != nil {
+			t.Fatal(handlerErr)
+		}
+		t.Fatalf("LoadForExecutionAtPath(locked=false): %v", err)
+	}
+	if handlerErr := nextHandlerErr(); handlerErr != nil {
+		t.Fatal(handlerErr)
+	}
+	if got := metadataCount.Load(); got != 1 {
+		t.Fatalf("metadata request count = %d, want 1", got)
+	}
+	if got := archiveCount.Load(); got != 1 {
+		t.Fatalf("archive request count = %d, want 1", got)
 	}
 
 	authProvider := mustSelectedHostProviderEntry(t, cfg, config.HostProviderKindAuth)

--- a/gestaltd/internal/operator/lifecycle_test.go
+++ b/gestaltd/internal/operator/lifecycle_test.go
@@ -2648,7 +2648,7 @@ func TestHashPlatformInEntries_HashesMountedWebUIAndProviderArchives(t *testing.
 		},
 	}
 
-	if err := hashPlatformInEntries(context.Background(), lock, initPaths{}, providerpkg.CurrentPlatformString(), map[string]string{}); err != nil {
+	if err := NewLifecycle(nil).hashPlatformInEntries(context.Background(), lock, initPaths{}, providerpkg.CurrentPlatformString(), map[string]string{}); err != nil {
 		t.Fatalf("hashPlatformInEntries: %v", err)
 	}
 
@@ -3780,6 +3780,30 @@ func TestReadWriteLockfile_RoundTrip(t *testing.T) {
 				Executable: "workflow/temporal/artifacts/darwin/arm64/workflow-temporal",
 			},
 		},
+		Telemetry: map[string]LockEntry{
+			"default": {
+				Fingerprint: "telemetry-fp",
+				Source:      "github.com/test-org/test-repo/telemetry-declarative",
+				Kind:        providermanifestv1.KindPlugin,
+				Runtime:     providerReleaseRuntimeDeclarative,
+				Version:     "1.4.0",
+				Archives: map[string]LockArchive{
+					"generic": {URL: "https://example.com/telemetry.tar.gz", SHA256: "telemetry123"},
+				},
+			},
+		},
+		Audit: map[string]LockEntry{
+			"default": {
+				Fingerprint: "audit-fp",
+				Source:      "github.com/test-org/test-repo/audit-declarative",
+				Kind:        providermanifestv1.KindPlugin,
+				Runtime:     providerReleaseRuntimeDeclarative,
+				Version:     "1.5.0",
+				Archives: map[string]LockArchive{
+					"generic": {URL: "https://example.com/audit.tar.gz", SHA256: "audit123"},
+				},
+			},
+		},
 		UIs: map[string]LockUIEntry{
 			"roadmap": {
 				Fingerprint: "ui-fp",
@@ -3852,6 +3876,32 @@ func TestReadWriteLockfile_RoundTrip(t *testing.T) {
 	if authEntry.Runtime != providerLockRuntimeExecutable {
 		t.Fatalf("auth runtime = %q, want %q", authEntry.Runtime, providerLockRuntimeExecutable)
 	}
+	telemetryEntry, ok := diskLock.Providers.Telemetry["default"]
+	if !ok {
+		t.Fatal(`disk lock providers.telemetry["default"] not found`)
+	}
+	if telemetryEntry.Package != want.Telemetry["default"].Source {
+		t.Fatalf("telemetry package = %q, want %q", telemetryEntry.Package, want.Telemetry["default"].Source)
+	}
+	if telemetryEntry.Kind != providermanifestv1.KindPlugin {
+		t.Fatalf("telemetry kind = %q, want %q", telemetryEntry.Kind, providermanifestv1.KindPlugin)
+	}
+	if telemetryEntry.Runtime != providerReleaseRuntimeDeclarative {
+		t.Fatalf("telemetry runtime = %q, want %q", telemetryEntry.Runtime, providerReleaseRuntimeDeclarative)
+	}
+	auditEntry, ok := diskLock.Providers.Audit["default"]
+	if !ok {
+		t.Fatal(`disk lock providers.audit["default"] not found`)
+	}
+	if auditEntry.Package != want.Audit["default"].Source {
+		t.Fatalf("audit package = %q, want %q", auditEntry.Package, want.Audit["default"].Source)
+	}
+	if auditEntry.Kind != providermanifestv1.KindPlugin {
+		t.Fatalf("audit kind = %q, want %q", auditEntry.Kind, providermanifestv1.KindPlugin)
+	}
+	if auditEntry.Runtime != providerReleaseRuntimeDeclarative {
+		t.Fatalf("audit runtime = %q, want %q", auditEntry.Runtime, providerReleaseRuntimeDeclarative)
+	}
 	uiEntry, ok := diskLock.Providers.WebUI["roadmap"]
 	if !ok {
 		t.Fatal(`disk lock providers.webui["roadmap"] not found`)
@@ -3896,6 +3946,12 @@ func TestReadWriteLockfile_RoundTrip(t *testing.T) {
 	}
 	if got.Workflows["temporal"].Executable != "" {
 		t.Fatal("workflow executable should not round-trip from portable lock schema")
+	}
+	if got.Telemetry["default"].Runtime != providerReleaseRuntimeDeclarative {
+		t.Fatalf("telemetry runtime = %q, want %q", got.Telemetry["default"].Runtime, providerReleaseRuntimeDeclarative)
+	}
+	if got.Audit["default"].Runtime != providerReleaseRuntimeDeclarative {
+		t.Fatalf("audit runtime = %q, want %q", got.Audit["default"].Runtime, providerReleaseRuntimeDeclarative)
 	}
 	if got.UIs["roadmap"].Source != want.UIs["roadmap"].Source || got.UIs["roadmap"].Version != want.UIs["roadmap"].Version {
 		t.Fatal("ui lock entry mismatch")
@@ -3962,7 +4018,7 @@ func TestHashArchiveEntry_HashesFallbackArchive(t *testing.T) {
 		},
 	}
 
-	if err := hashArchiveEntry(context.Background(), providermanifestv1.KindWebUI, "roadmap", &entry, initPaths{}, "linux/amd64", nil); err != nil {
+	if err := NewLifecycle(nil).hashArchiveEntry(context.Background(), providermanifestv1.KindWebUI, "roadmap", &entry, initPaths{}, "linux/amd64", nil); err != nil {
 		t.Fatalf("hashArchiveEntry: %v", err)
 	}
 

--- a/gestaltd/internal/operator/lockschema.go
+++ b/gestaltd/internal/operator/lockschema.go
@@ -3,19 +3,22 @@ package operator
 import (
 	"fmt"
 	"maps"
+	"strings"
 
 	providermanifestv1 "github.com/valon-technologies/gestalt/server/sdk/providermanifest/v1"
 )
 
 const (
-	providerLockSchemaName        = "gestaltd-provider-lock"
-	providerLockSchemaVersion     = 2
-	providerLockRevision          = 0
-	providerLockKindWorkflow      = "workflow"
-	providerLockKindTelemetry     = "telemetry"
-	providerLockKindAudit         = "audit"
-	providerLockRuntimeExecutable = "executable"
-	providerLockRuntimeAssets     = "assets"
+	providerLockSchemaName         = "gestaltd-provider-lock"
+	providerLockSchemaVersion      = 2
+	providerLockRevision           = 0
+	providerLockKindWorkflow       = "workflow"
+	providerLockKindTelemetry      = "telemetry"
+	providerLockKindAudit          = "audit"
+	providerLockRuntimeExecutable  = providerReleaseRuntimeExecutable
+	providerLockRuntimeDeclarative = providerReleaseRuntimeDeclarative
+	providerLockRuntimeWebUI       = providerReleaseRuntimeWebUI
+	providerLockRuntimeAssets      = providerLockRuntimeWebUI
 )
 
 type providerLockfile struct {
@@ -209,12 +212,19 @@ func portableEntriesFromLockEntries(entries map[string]LockEntry, kind string) m
 		return nil
 	}
 	portable := make(map[string]portableLockEntry, len(entries))
-	for name, entry := range entries {
+	for name := range entries {
+		entry := entries[name]
+		packageRef := lockEntryPackage(entry)
+		source := strings.TrimSpace(entry.Source)
+		if source == packageRef {
+			source = ""
+		}
 		portable[name] = portableLockEntry{
 			InputDigest: entry.Fingerprint,
-			Package:     entry.Source,
-			Kind:        kind,
-			Runtime:     portableRuntimeForKind(kind),
+			Package:     packageRef,
+			Kind:        lockEntryKind(entry, kind),
+			Runtime:     lockEntryRuntime(entry, kind),
+			Source:      source,
 			Version:     entry.Version,
 			Archives:    maps.Clone(entry.Archives),
 		}
@@ -238,17 +248,13 @@ func lockEntriesFromPortableEntries(entries map[string]portableLockEntry) map[st
 		}
 		runtimeEntries[name] = LockEntry{
 			Fingerprint: fingerprint,
+			Package:     entry.Package,
+			Kind:        entry.Kind,
+			Runtime:     entry.Runtime,
 			Source:      source,
 			Version:     entry.Version,
 			Archives:    maps.Clone(entry.Archives),
 		}
 	}
 	return runtimeEntries
-}
-
-func portableRuntimeForKind(kind string) string {
-	if kind == providermanifestv1.KindWebUI {
-		return providerLockRuntimeAssets
-	}
-	return providerLockRuntimeExecutable
 }

--- a/gestaltd/internal/operator/release_metadata.go
+++ b/gestaltd/internal/operator/release_metadata.go
@@ -1,0 +1,254 @@
+package operator
+
+import (
+	"bytes"
+	"context"
+	"fmt"
+	"io"
+	"net/http"
+	"net/url"
+	"strings"
+
+	"github.com/valon-technologies/gestalt/server/internal/config"
+	"github.com/valon-technologies/gestalt/server/internal/pluginsource"
+	ghresolver "github.com/valon-technologies/gestalt/server/internal/pluginsource/github"
+	"github.com/valon-technologies/gestalt/server/internal/providerpkg"
+	providermanifestv1 "github.com/valon-technologies/gestalt/server/sdk/providermanifest/v1"
+	"gopkg.in/yaml.v3"
+)
+
+const (
+	providerReleaseSchemaName         = "gestaltd-provider-release"
+	providerReleaseSchemaVersion      = 1
+	providerReleaseRuntimeExecutable  = "executable"
+	providerReleaseRuntimeDeclarative = "declarative"
+	providerReleaseRuntimeWebUI       = "webui"
+	providerReleaseMetadataMaxBytes   = 4 << 20
+	httpAuthorizationHeader           = "Authorization"
+	httpBearerAuthorizationPrefix     = "Bearer "
+)
+
+type providerReleaseMetadata struct {
+	Schema        string                             `yaml:"schema"`
+	SchemaVersion int                                `yaml:"schemaVersion"`
+	Package       string                             `yaml:"package"`
+	Kind          string                             `yaml:"kind"`
+	Version       string                             `yaml:"version"`
+	Runtime       string                             `yaml:"runtime"`
+	Artifacts     map[string]providerReleaseArtifact `yaml:"artifacts,omitempty"`
+}
+
+type providerReleaseArtifact struct {
+	Path   string `yaml:"path"`
+	SHA256 string `yaml:"sha256"`
+}
+
+func sourceAuthToken(entry *config.ProviderEntry) string {
+	if entry == nil || entry.Source.Auth == nil {
+		return ""
+	}
+	return strings.TrimSpace(entry.Source.Auth.Token)
+}
+
+func decodeProviderReleaseMetadata(data []byte) (*providerReleaseMetadata, error) {
+	var metadata providerReleaseMetadata
+	decoder := yaml.NewDecoder(bytes.NewReader(data))
+	decoder.KnownFields(true)
+	if err := decoder.Decode(&metadata); err != nil {
+		return nil, fmt.Errorf("decode provider release metadata: %w", err)
+	}
+	if err := validateProviderReleaseMetadata(&metadata); err != nil {
+		return nil, err
+	}
+	return &metadata, nil
+}
+
+func validateProviderReleaseMetadata(metadata *providerReleaseMetadata) error {
+	if metadata == nil {
+		return fmt.Errorf("provider release metadata is required")
+	}
+	if metadata.Schema != providerReleaseSchemaName {
+		return fmt.Errorf("unsupported provider release schema %q", metadata.Schema)
+	}
+	if metadata.SchemaVersion != providerReleaseSchemaVersion {
+		return fmt.Errorf("unsupported provider release schema version %d", metadata.SchemaVersion)
+	}
+	if _, err := pluginsource.Parse(strings.TrimSpace(metadata.Package)); err != nil {
+		return fmt.Errorf("provider release package: %w", err)
+	}
+	if err := pluginsource.ValidateVersion(strings.TrimSpace(metadata.Version)); err != nil {
+		return fmt.Errorf("provider release version: %w", err)
+	}
+	switch metadata.Kind {
+	case providermanifestv1.KindPlugin, providermanifestv1.KindAuth, providermanifestv1.KindIndexedDB, providermanifestv1.KindCache, providermanifestv1.KindS3, providermanifestv1.KindWorkflow, providermanifestv1.KindSecrets, providermanifestv1.KindWebUI:
+	default:
+		return fmt.Errorf("provider release kind %q is not supported", metadata.Kind)
+	}
+	switch metadata.Runtime {
+	case providerReleaseRuntimeExecutable:
+		if metadata.Kind == providermanifestv1.KindWebUI {
+			return fmt.Errorf("provider release runtime %q is invalid for kind %q", metadata.Runtime, metadata.Kind)
+		}
+	case providerReleaseRuntimeDeclarative:
+		if metadata.Kind != providermanifestv1.KindPlugin {
+			return fmt.Errorf("provider release runtime %q is only valid for kind %q", metadata.Runtime, providermanifestv1.KindPlugin)
+		}
+	case providerReleaseRuntimeWebUI:
+		if metadata.Kind != providermanifestv1.KindWebUI {
+			return fmt.Errorf("provider release runtime %q is only valid for kind %q", metadata.Runtime, providermanifestv1.KindWebUI)
+		}
+	default:
+		return fmt.Errorf("provider release runtime %q is not supported", metadata.Runtime)
+	}
+	if len(metadata.Artifacts) == 0 {
+		return fmt.Errorf("provider release artifacts are required")
+	}
+	for target, artifact := range metadata.Artifacts {
+		switch {
+		case strings.TrimSpace(target) == "":
+			return fmt.Errorf("provider release artifact target is required")
+		case target != platformKeyGeneric:
+			if _, _, err := providerpkg.ParsePlatformString(target); err != nil {
+				return fmt.Errorf("provider release artifact target %q: %w", target, err)
+			}
+		}
+		if strings.TrimSpace(artifact.Path) == "" {
+			return fmt.Errorf("provider release artifact path is required for target %q", target)
+		}
+		if strings.TrimSpace(artifact.SHA256) == "" {
+			return fmt.Errorf("provider release artifact sha256 is required for target %q", target)
+		}
+	}
+	return nil
+}
+
+func fetchProviderReleaseMetadata(ctx context.Context, client *http.Client, metadataURL, token string) (*providerReleaseMetadata, error) {
+	if client == nil {
+		client = http.DefaultClient
+	}
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, metadataURL, nil)
+	if err != nil {
+		return nil, fmt.Errorf("create provider release metadata request: %w", err)
+	}
+	token = strings.TrimSpace(token)
+	if token != "" {
+		req.Header.Set(httpAuthorizationHeader, httpBearerAuthorizationPrefix+token)
+	}
+	resp, err := client.Do(req)
+	if err != nil {
+		return nil, fmt.Errorf("fetch provider release metadata: %w", err)
+	}
+	defer func() { _ = resp.Body.Close() }()
+	if resp.StatusCode != http.StatusOK {
+		return nil, fmt.Errorf("unexpected status %d fetching provider release metadata from %s", resp.StatusCode, metadataURL)
+	}
+	data, err := io.ReadAll(io.LimitReader(resp.Body, providerReleaseMetadataMaxBytes+1))
+	if err != nil {
+		return nil, fmt.Errorf("read provider release metadata: %w", err)
+	}
+	if len(data) > providerReleaseMetadataMaxBytes {
+		return nil, fmt.Errorf("provider release metadata exceeds %d byte limit", providerReleaseMetadataMaxBytes)
+	}
+	return decodeProviderReleaseMetadata(data)
+}
+
+func providerReleaseArchives(metadataURL string, metadata *providerReleaseMetadata) (map[string]LockArchive, error) {
+	if metadata == nil {
+		return nil, fmt.Errorf("provider release metadata is required")
+	}
+	baseURL, err := url.Parse(metadataURL)
+	if err != nil {
+		return nil, fmt.Errorf("parse provider release metadata URL: %w", err)
+	}
+	archives := make(map[string]LockArchive, len(metadata.Artifacts))
+	for target, artifact := range metadata.Artifacts {
+		artifactURL, err := url.Parse(strings.TrimSpace(artifact.Path))
+		if err != nil {
+			return nil, fmt.Errorf("parse provider release artifact path for target %q: %w", target, err)
+		}
+		archives[target] = LockArchive{
+			URL:    baseURL.ResolveReference(artifactURL).String(),
+			SHA256: strings.TrimSpace(artifact.SHA256),
+		}
+	}
+	return archives, nil
+}
+
+func lockEntryPackage(entry LockEntry) string {
+	if value := strings.TrimSpace(entry.Package); value != "" {
+		return value
+	}
+	return strings.TrimSpace(entry.Source)
+}
+
+func lockEntryKind(entry LockEntry, fallback string) string {
+	if value := strings.TrimSpace(entry.Kind); value != "" {
+		return value
+	}
+	switch fallback {
+	case providerLockKindTelemetry, providerLockKindAudit:
+		return providermanifestv1.KindPlugin
+	default:
+		return fallback
+	}
+}
+
+func lockEntryRuntime(entry LockEntry, fallbackKind string) string {
+	if value := strings.TrimSpace(entry.Runtime); value != "" {
+		return value
+	}
+	switch lockEntryKind(entry, fallbackKind) {
+	case providermanifestv1.KindWebUI:
+		return providerReleaseRuntimeWebUI
+	default:
+		return providerReleaseRuntimeExecutable
+	}
+}
+
+func releaseRuntimeForManifest(manifest *providermanifestv1.Manifest, kind string) string {
+	switch kind {
+	case providermanifestv1.KindWebUI:
+		return providerReleaseRuntimeWebUI
+	case providermanifestv1.KindPlugin:
+		if manifest != nil && manifest.IsDeclarativeOnlyProvider() {
+			return providerReleaseRuntimeDeclarative
+		}
+	}
+	return providerReleaseRuntimeExecutable
+}
+
+func usesGitHubAssetTransport(sourceLocation, archiveURL string) bool {
+	if src, err := pluginsource.Parse(sourceLocation); err == nil && src.Host == pluginsource.HostGitHub {
+		return true
+	}
+	parsed, err := url.Parse(strings.TrimSpace(archiveURL))
+	if err != nil {
+		return false
+	}
+	switch strings.ToLower(parsed.Hostname()) {
+	case "api.github.com":
+		return strings.Contains(parsed.Path, "/releases/assets/")
+	case "github.com":
+		return strings.Contains(parsed.Path, "/releases/download/")
+	default:
+		return false
+	}
+}
+
+func downloadArchiveForSource(ctx context.Context, client *http.Client, sourceLocation, token, archiveURL string) (*providerpkg.DownloadResult, error) {
+	if client == nil {
+		client = http.DefaultClient
+	}
+	token = strings.TrimSpace(token)
+	if usesGitHubAssetTransport(sourceLocation, archiveURL) {
+		return ghresolver.DownloadResolvedAsset(ctx, client, archiveURL, token)
+	}
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, archiveURL, nil)
+	if err != nil {
+		return nil, fmt.Errorf("create archive download request: %w", err)
+	}
+	if token != "" {
+		req.Header.Set(httpAuthorizationHeader, httpBearerAuthorizationPrefix+token)
+	}
+	return providerpkg.DownloadRequest(client, req)
+}

--- a/gestaltd/internal/providerpkg/manifest.go
+++ b/gestaltd/internal/providerpkg/manifest.go
@@ -81,6 +81,7 @@ var validManifestKinds = map[string]bool{
 	providermanifestv1.KindIndexedDB: true,
 	providermanifestv1.KindCache:     true,
 	providermanifestv1.KindS3:        true,
+	providermanifestv1.KindWorkflow:  true,
 	providermanifestv1.KindSecrets:   true,
 	providermanifestv1.KindWebUI:     true,
 }
@@ -93,7 +94,7 @@ func ManifestKind(manifest *providermanifestv1.Manifest) (string, error) {
 		return "", fmt.Errorf("manifest kind is required")
 	}
 	if !validManifestKinds[manifest.Kind] {
-		return "", fmt.Errorf("manifest kind %q is not valid; expected one of plugin, auth, indexeddb, cache, s3, secrets, or webui", manifest.Kind)
+		return "", fmt.Errorf("manifest kind %q is not valid; expected one of plugin, auth, indexeddb, cache, s3, workflow, secrets, or webui", manifest.Kind)
 	}
 	return manifest.Kind, nil
 }
@@ -136,7 +137,7 @@ func validateManifest(manifest *providermanifestv1.Manifest, sourceMode bool) er
 	switch kind {
 	case providermanifestv1.KindPlugin:
 		needsArtifacts = needsArtifacts || manifest.Entrypoint != nil
-	case providermanifestv1.KindAuth, providermanifestv1.KindIndexedDB, providermanifestv1.KindCache, providermanifestv1.KindS3, providermanifestv1.KindSecrets:
+	case providermanifestv1.KindAuth, providermanifestv1.KindIndexedDB, providermanifestv1.KindCache, providermanifestv1.KindS3, providermanifestv1.KindWorkflow, providermanifestv1.KindSecrets:
 		needsArtifacts = needsArtifacts || !allowsSourceEntrypointOmission
 	}
 
@@ -198,7 +199,7 @@ func validateManifest(manifest *providermanifestv1.Manifest, sourceMode bool) er
 		default:
 			return fmt.Errorf("entrypoint is required")
 		}
-	case providermanifestv1.KindAuth, providermanifestv1.KindIndexedDB, providermanifestv1.KindCache, providermanifestv1.KindS3, providermanifestv1.KindSecrets:
+	case providermanifestv1.KindAuth, providermanifestv1.KindIndexedDB, providermanifestv1.KindCache, providermanifestv1.KindS3, providermanifestv1.KindWorkflow, providermanifestv1.KindSecrets:
 		if manifest.Entrypoint == nil && !allowsSourceEntrypointOmission {
 			return fmt.Errorf("entrypoint is required")
 		}


### PR DESCRIPTION
## Summary
- resolve `provider-release.yaml` sources during init without using the GitHub ref resolver
- preserve canonical `package` / `kind` / `runtime` identity in portable lock entries
- rehydrate locked metadata-backed artifacts directly from archive URLs with inline bearer auth
- resolve relative artifact paths from metadata against the metadata URL

## Rust interface
```rust
struct PortableLockEntry {
    input_digest: String,
    package: String,
    kind: String,
    runtime: String,
    source: String,
    version: Option<String>,
    archives: BTreeMap<String, LockArchive>,
}

let config = r#"
apiVersion: gestaltd.config/v3
plugins:
  alpha:
    source: https://artifacts.example.com/providers/alpha/provider-release.yaml
    auth:
      token: ${GITHUB_TOKEN}
"#;
```

## stdin/stdout interface
```yaml
apiVersion: gestaltd.config/v3
plugins:
  alpha:
    source: https://artifacts.example.com/providers/alpha/provider-release.yaml
    auth:
      token: ${GITHUB_TOKEN}
```

Portable lock output:
```json
{
  "schema": "gestaltd-provider-lock",
  "schemaVersion": 2,
  "revision": 0,
  "providers": {
    "plugin": {
      "alpha": {
        "inputDigest": "sha256:...",
        "package": "github.com/acme/tools/alpha",
        "kind": "plugin",
        "runtime": "executable",
        "source": "https://artifacts.example.com/providers/alpha/provider-release.yaml",
        "version": "1.2.3",
        "archives": {
          "darwin/arm64": {
            "url": "https://artifacts.example.com/providers/alpha/alpha-darwin-arm64.tar.gz",
            "sha256": "..."
          },
          "linux/amd64": {
            "url": "https://artifacts.example.com/providers/alpha/alpha-linux-amd64.tar.gz",
            "sha256": "..."
          }
        }
      }
    }
  }
}
```

## Tests
- `go test ./internal/operator -run 'Test(SourcePluginMetadataURLInitAndLockedLoad|SourcePluginLoadForExecution|SourcePluginGitHubResolverEndToEnd|SourcePluginInitWithPlatformsRejectsGenericFallbackForExtraPlatform|ReadWriteLockfile_RoundTrip)$'`\n- `go test ./internal/operator`