### PR TITLE
operator: reject local plugins and UIs in portable flows

### DIFF
--- a/gestaltd/cmd/gestaltd/e2e_test.go
+++ b/gestaltd/cmd/gestaltd/e2e_test.go
@@ -346,13 +346,14 @@ func TestE2EValidateAcceptsLayeredConfigs(t *testing.T) {
 	}
 
 	indexedDBManifest := componentProviderManifestPath(t, setupIndexedDBProviderDir(t, rootDir))
-	setupPluginDir(t, overrideDir)
+	authManifest := componentProviderManifestPath(t, setupAuthProviderDir(t, rootDir, "local"))
 
 	baseConfigPath := filepath.Join(baseDir, "base.yaml")
 	baseConfig := fmt.Sprintf(`server:
   encryptionKey: test-key
   providers:
     indexeddb: sqlite
+    auth: local
 providers:
   indexeddb:
     sqlite:
@@ -360,21 +361,26 @@ providers:
         path: %s
       config:
         path: %q
-plugins:
-  example:
-    source:
-      path: ./missing/manifest.yaml
+  auth:
+    local:
+      source:
+        path: ./missing/manifest.yaml
 `, indexedDBManifest, filepath.Join(rootDir, "gestalt.db"))
 	if err := os.WriteFile(baseConfigPath, []byte(baseConfig), 0o644); err != nil {
 		t.Fatalf("WriteFile base config: %v", err)
 	}
 
+	authRel, err := filepath.Rel(overrideDir, authManifest)
+	if err != nil {
+		t.Fatalf("filepath.Rel(auth): %v", err)
+	}
 	overrideConfigPath := filepath.Join(overrideDir, "local.yaml")
-	overrideConfig := `plugins:
-  example:
-    source:
-      path: ./plugin-src/manifest.yaml
-`
+	overrideConfig := fmt.Sprintf(`providers:
+  auth:
+    local:
+      source:
+        path: %s
+`, filepath.ToSlash(authRel))
 	if err := os.WriteFile(overrideConfigPath, []byte(overrideConfig), 0o644); err != nil {
 		t.Fatalf("WriteFile override config: %v", err)
 	}
@@ -1005,7 +1011,7 @@ plugins:
 	}
 }
 
-func TestE2EInitLocalProviders(t *testing.T) {
+func TestE2EInitRejectsLocalPlugins(t *testing.T) {
 	t.Parallel()
 
 	if testing.Short() {
@@ -1016,28 +1022,34 @@ func TestE2EInitLocalProviders(t *testing.T) {
 	cfgPath := writeServeConfig(t, dir, 0, nil)
 
 	out, err := exec.Command(gestaltdBin, "init", "--config", cfgPath).CombinedOutput()
-	if err != nil {
-		t.Fatalf("gestaltd init failed: %v\noutput: %s", err, out)
+	if err == nil {
+		t.Fatalf("gestaltd init unexpectedly succeeded\noutput: %s", out)
 	}
-
 	lockPath := filepath.Join(dir, "gestalt.lock.json")
-	lockData, err := os.ReadFile(lockPath)
-	if err != nil {
-		t.Fatalf("expected lock file at %s: %v", lockPath, err)
+	if !strings.Contains(string(out), "local plugin and UI sources are not supported during init") {
+		t.Fatalf("gestaltd init output = %s, want local source rejection", out)
+	}
+	if _, err := os.Stat(lockPath); !os.IsNotExist(err) {
+		t.Fatalf("lockfile should not be created, got err=%v", err)
+	}
+}
+
+func TestE2EValidateAllowsLocalPlugins(t *testing.T) {
+	t.Parallel()
+
+	if testing.Short() {
+		t.Skip("skipping local plugin validate E2E test in short mode")
 	}
 
-	var lock map[string]any
-	if err := json.Unmarshal(lockData, &lock); err != nil {
-		t.Fatalf("invalid lock file JSON: %v", err)
+	dir := t.TempDir()
+	cfgPath := writeServeConfig(t, dir, 0, nil)
+
+	out, err := exec.Command(gestaltdBin, "validate", "--config", cfgPath).CombinedOutput()
+	if err != nil {
+		t.Fatalf("gestaltd validate failed: %v\noutput: %s", err, out)
 	}
-	if got, _ := lock["schema"].(string); got != "gestaltd-provider-lock" {
-		t.Fatalf("expected provider lock schema, got %v", lock["schema"])
-	}
-	if got, _ := lock["schemaVersion"].(float64); got < 1 {
-		t.Fatalf("expected schemaVersion >= 1, got %v", lock["schemaVersion"])
-	}
-	if _, ok := lock["version"]; ok {
-		t.Fatalf("expected schema-based lockfile, found legacy version field: %v", lock["version"])
+	if !strings.Contains(string(out), "config ok") {
+		t.Fatalf("gestaltd validate output = %s, want config ok", out)
 	}
 }
 
@@ -1296,16 +1308,11 @@ func writeLayeredE2EConfigs(t *testing.T, dir string, port int) (string, string,
 	}
 
 	indexedDBManifest := componentProviderManifestPath(t, setupIndexedDBProviderDir(t, dir))
-	pluginManifest := componentProviderManifestPath(t, setupPrebuiltPluginDir(t, dir))
 	authManifest := componentProviderManifestPath(t, setupAuthProviderDir(t, dir, "local"))
 
 	indexedDBRel, err := filepath.Rel(deployDir, indexedDBManifest)
 	if err != nil {
 		t.Fatalf("filepath.Rel(indexeddb): %v", err)
-	}
-	pluginRel, err := filepath.Rel(deployDir, pluginManifest)
-	if err != nil {
-		t.Fatalf("filepath.Rel(plugin): %v", err)
 	}
 	authRel, err := filepath.Rel(overrideDir, authManifest)
 	if err != nil {
@@ -1325,11 +1332,7 @@ providers:
     inmem:
       source:
         path: %s
-plugins:
-  example:
-    source:
-      path: %s
-`, port, filepath.ToSlash(indexedDBRel), filepath.ToSlash(pluginRel))
+`, port, filepath.ToSlash(indexedDBRel))
 	overrideCfg := fmt.Sprintf(`server:
   providers:
     auth: local

--- a/gestaltd/cmd/gestaltd/run.go
+++ b/gestaltd/cmd/gestaltd/run.go
@@ -499,7 +499,7 @@ func runValidate(args []string) error {
 }
 
 func validateConfigWithArtifactsDir(configFlags []string, artifactsDir string) error {
-	paths, cfg, err := loadConfigForExecutionWithArtifactsDir(configFlags, artifactsDir, true)
+	paths, cfg, err := loadConfigForExecutionWithArtifactsDir(configFlags, artifactsDir, false)
 	if err != nil {
 		return err
 	}

--- a/gestaltd/internal/config/config.go
+++ b/gestaltd/internal/config/config.go
@@ -7,6 +7,7 @@ import (
 	"io"
 	"maps"
 	"net"
+	"net/url"
 	"os"
 	"path/filepath"
 	"slices"
@@ -43,8 +44,10 @@ const PluginConnectionName = "_plugin"
 // PluginConnectionName. In hybrid integrations, mcp.connection can be set
 // to "plugin" to reuse the plugin's OAuth token.
 const PluginConnectionAlias = "plugin"
+const APIVersionV3 = "gestaltd.config/v3"
 
 type Config struct {
+	APIVersion    string                    `yaml:"apiVersion,omitempty"`
 	Server        ServerConfig              `yaml:"server"`
 	Authorization AuthorizationConfig       `yaml:"authorization,omitempty"`
 	Providers     ProvidersConfig           `yaml:"providers"`
@@ -86,16 +89,20 @@ type ServerProvidersConfig struct {
 //   - Managed: source: {ref, version} -> ProviderSource{Ref: "...", Version: "..."}
 //   - Local:   source: {path}         -> ProviderSource{Path: "..."}
 type ProviderSource struct {
-	Builtin string         `yaml:"-"`
-	Ref     string         `yaml:"ref,omitempty"`
-	Version string         `yaml:"version,omitempty"`
-	Path    string         `yaml:"path,omitempty"`
-	Auth    *SourceAuthDef `yaml:"auth,omitempty"`
+	Builtin     string         `yaml:"-"`
+	scalar      string         `yaml:"-"`
+	metadataURL string         `yaml:"-"`
+	unsupported string         `yaml:"-"`
+	Ref         string         `yaml:"ref,omitempty"`
+	Version     string         `yaml:"version,omitempty"`
+	Path        string         `yaml:"path,omitempty"`
+	Auth        *SourceAuthDef `yaml:"auth,omitempty"`
 }
 
 func (s *ProviderSource) UnmarshalYAML(value *yaml.Node) error {
+	*s = ProviderSource{}
 	if value.Kind == yaml.ScalarNode {
-		s.Builtin = strings.TrimSpace(value.Value)
+		s.scalar = strings.TrimSpace(value.Value)
 		return nil
 	}
 	type raw ProviderSource
@@ -106,24 +113,36 @@ func (s ProviderSource) MarshalYAML() (any, error) {
 	if s.Builtin != "" {
 		return s.Builtin, nil
 	}
+	if s.metadataURL != "" && s.Ref == "" && s.Version == "" && s.Path == "" && s.Auth == nil {
+		return s.metadataURL, nil
+	}
+	if s.scalar != "" && s.Ref == "" && s.Version == "" && s.Path == "" && s.Auth == nil {
+		return s.scalar, nil
+	}
 	type raw ProviderSource
 	return raw(s), nil
 }
 
-func (s ProviderSource) IsBuiltin() bool { return s.Builtin != "" }
-func (s ProviderSource) IsManaged() bool { return s.Ref != "" }
-func (s ProviderSource) IsLocal() bool   { return s.Path != "" }
+func (s ProviderSource) IsBuiltin() bool     { return s.Builtin != "" }
+func (s ProviderSource) IsManaged() bool     { return s.Ref != "" }
+func (s ProviderSource) IsMetadataURL() bool { return s.metadataURL != "" }
+func (s ProviderSource) IsLocal() bool       { return s.Path != "" }
+func (s ProviderSource) MetadataURL() string { return s.metadataURL }
+func (s ProviderSource) UnsupportedURL() string {
+	return s.unsupported
+}
 
 // ProviderEntry is the universal configuration for any provider.
 type ProviderEntry struct {
-	Source       ProviderSource    `yaml:"source"`
-	Config       yaml.Node         `yaml:"config,omitempty"`
-	Default      bool              `yaml:"default,omitempty"`
-	Env          map[string]string `yaml:"env,omitempty"`
-	AllowedHosts []string          `yaml:"allowedHosts,omitempty"`
-	DisplayName  string            `yaml:"displayName,omitempty"`
-	Description  string            `yaml:"description,omitempty"`
-	IconFile     string            `yaml:"iconFile,omitempty"`
+	Source           ProviderSource    `yaml:"source"`
+	Config           yaml.Node         `yaml:"config,omitempty"`
+	Default          bool              `yaml:"default,omitempty"`
+	Env              map[string]string `yaml:"env,omitempty"`
+	AllowedHosts     []string          `yaml:"allowedHosts,omitempty"`
+	DisplayName      string            `yaml:"displayName,omitempty"`
+	Description      string            `yaml:"description,omitempty"`
+	IconFile         string            `yaml:"iconFile,omitempty"`
+	InlineSourceAuth *SourceAuthDef    `yaml:"auth,omitempty"`
 	// AuthorizationPolicy binds this provider to a shared human access policy.
 	AuthorizationPolicy string `yaml:"authorizationPolicy,omitempty"`
 
@@ -152,6 +171,16 @@ type ProviderEntry struct {
 	Discovery            *providermanifestv1.ProviderDiscovery `yaml:"-"`
 	ResolvedAssetRoot    string                                `yaml:"-"`
 	MCPToolPrefix        string                                `yaml:"-"`
+}
+
+func (e ProviderEntry) MarshalYAML() (any, error) {
+	type raw ProviderEntry
+	if e.Source.IsMetadataURL() && e.Source.Auth != nil && e.InlineSourceAuth == nil {
+		auth := *e.Source.Auth
+		e.InlineSourceAuth = &auth
+		e.Source.Auth = nil
+	}
+	return raw(e), nil
 }
 
 type ProviderSurfaceOverrides struct {
@@ -211,6 +240,14 @@ func (e *ProviderEntry) HasManagedSource() bool {
 	return e != nil && e.Source.IsManaged()
 }
 
+func (e *ProviderEntry) HasMetadataSource() bool {
+	return e != nil && e.Source.IsMetadataURL()
+}
+
+func (e *ProviderEntry) HasRemoteSource() bool {
+	return e != nil && (e.Source.IsManaged() || e.Source.IsMetadataURL())
+}
+
 func (e *ProviderEntry) HasLocalSource() bool {
 	return e != nil && e.Source.IsLocal()
 }
@@ -221,6 +258,26 @@ func (e *ProviderEntry) SourceRef() string {
 
 func (e *ProviderEntry) SourceVersion() string {
 	return e.Source.Version
+}
+
+func (e *ProviderEntry) SourceMetadataURL() string {
+	if e == nil {
+		return ""
+	}
+	return e.Source.MetadataURL()
+}
+
+func (e *ProviderEntry) SourceRemoteLocation() string {
+	if e == nil {
+		return ""
+	}
+	if e.Source.IsManaged() {
+		return e.Source.Ref
+	}
+	if e.Source.IsMetadataURL() {
+		return e.Source.MetadataURL()
+	}
+	return ""
 }
 
 func (e *ProviderEntry) SourcePath() string {
@@ -662,6 +719,7 @@ func LoadAllowMissingEnvPaths(paths []string) (*Config, error) {
 }
 
 func NormalizeCompatibility(cfg *Config) error {
+	normalizeProviderSourceShapes(cfg)
 	if err := normalizeAuthorizationConfig(cfg); err != nil {
 		return err
 	}
@@ -684,7 +742,7 @@ func OverlayManagedPluginConfigPaths(paths []string, cfg *Config) error {
 	providersNode := mappingValueNode(documentValueNode(&root), "providers")
 	pluginsNode := mappingValueNode(doc, "plugins")
 	for name, entry := range cfg.Plugins {
-		if entry == nil || !entry.HasManagedSource() {
+		if entry == nil || !entry.HasRemoteSource() {
 			continue
 		}
 		if err := overlayManagedEntryConfigNode(mappingValueNode(pluginsNode, name), entry, "plugin "+strconv.Quote(name)); err != nil {
@@ -704,7 +762,7 @@ func OverlayManagedPluginConfigPaths(paths []string, cfg *Config) error {
 	} {
 		kindNode := mappingValueNode(providersNode, string(collection.kind))
 		for name, entry := range collection.entries {
-			if entry == nil || !entry.HasManagedSource() {
+			if entry == nil || !entry.HasRemoteSource() {
 				continue
 			}
 			subject := fmt.Sprintf("%s %q", collection.kind, name)
@@ -715,7 +773,7 @@ func OverlayManagedPluginConfigPaths(paths []string, cfg *Config) error {
 	}
 	s3Node := mappingValueNode(providersNode, "s3")
 	for name, entry := range cfg.Providers.S3 {
-		if entry == nil || !entry.HasManagedSource() {
+		if entry == nil || !entry.HasRemoteSource() {
 			continue
 		}
 		if err := overlayManagedEntryConfigNode(mappingValueNode(s3Node, name), entry, "s3 "+strconv.Quote(name)); err != nil {
@@ -724,7 +782,7 @@ func OverlayManagedPluginConfigPaths(paths []string, cfg *Config) error {
 	}
 	uiNode := mappingValueNode(providersNode, "ui")
 	for name, entry := range cfg.Providers.UI {
-		if entry == nil || !entry.HasManagedSource() {
+		if entry == nil || !entry.HasRemoteSource() {
 			continue
 		}
 		if err := overlayManagedEntryConfigNode(mappingValueNode(uiNode, name), &entry.ProviderEntry, "ui "+strconv.Quote(name)); err != nil {
@@ -743,7 +801,7 @@ const (
 )
 
 func overlayManagedEntryConfigNode(raw *yaml.Node, entry *ProviderEntry, subject string) error {
-	if entry == nil || !entry.HasManagedSource() || raw == nil {
+	if entry == nil || !entry.HasRemoteSource() || raw == nil {
 		return nil
 	}
 	configNode := mappingValueNode(raw, "config")
@@ -840,6 +898,7 @@ func loadWithLookupPaths(paths []string, lookup func(string) (string, bool), all
 		return nil, fmt.Errorf("parsing config YAML: %w", err)
 	}
 
+	normalizeProviderSourceShapes(&cfg)
 	applyDefaults(&cfg)
 	if err := NormalizeCompatibility(&cfg); err != nil {
 		return nil, err
@@ -866,9 +925,14 @@ func loadMergedConfigRoot(paths []string, lookup func(string) (string, bool), mo
 		return yaml.Node{}, fmt.Errorf("reading config file: no config files provided")
 	}
 
+	useV3Classification, err := configPathsUseAPIVersion(paths, lookup, mode, sentinelPrefix)
+	if err != nil {
+		return yaml.Node{}, err
+	}
+
 	var merged any
 	for _, path := range paths {
-		value, err := loadConfigValue(path, lookup, mode, sentinelPrefix)
+		value, err := loadConfigValue(path, lookup, mode, sentinelPrefix, useV3Classification)
 		if err != nil {
 			return yaml.Node{}, err
 		}
@@ -895,7 +959,35 @@ func loadMergedConfigRoot(paths []string, lookup func(string) (string, bool), mo
 	return root, nil
 }
 
-func loadConfigValue(path string, lookup func(string) (string, bool), mode envMissingMode, sentinelPrefix string) (any, error) {
+func configPathsUseAPIVersion(paths []string, lookup func(string) (string, bool), mode envMissingMode, sentinelPrefix string) (bool, error) {
+	for _, path := range paths {
+		root, err := loadValidatedConfigRoot(path, lookup, mode, sentinelPrefix)
+		if err != nil {
+			return false, err
+		}
+		doc := documentValueNode(&root)
+		if doc == nil || doc.Kind != yaml.MappingNode {
+			continue
+		}
+		node := mappingValueNode(doc, "apiVersion")
+		if node == nil {
+			continue
+		}
+		value := strings.TrimSpace(node.Value)
+		if value == "" {
+			continue
+		}
+		if !usesV3ConfigSyntax(value) {
+			return false, fmt.Errorf("config validation: unsupported apiVersion %q", value)
+		}
+		if value != "" {
+			return true, nil
+		}
+	}
+	return false, nil
+}
+
+func loadConfigValue(path string, lookup func(string) (string, bool), mode envMissingMode, sentinelPrefix string, useV3Classification bool) (any, error) {
 	root, err := loadValidatedConfigRoot(path, lookup, mode, sentinelPrefix)
 	if err != nil {
 		return nil, err
@@ -919,7 +1011,7 @@ func loadConfigValue(path string, lookup func(string) (string, bool), mode envMi
 		if !ok {
 			return nil, fmt.Errorf("expected mapping document")
 		}
-		resolveRelativePathsInValue(path, root)
+		resolveRelativePathsInValue(path, root, useV3Classification)
 	}
 	return normalized, nil
 }
@@ -1353,6 +1445,127 @@ func applyDefaults(cfg *Config) {
 	cfg.Providers.S3 = nonNilProviderEntryMap(cfg.Providers.S3)
 }
 
+func normalizeProviderSourceShapes(cfg *Config) {
+	if cfg == nil {
+		return
+	}
+	cfg.APIVersion = strings.TrimSpace(cfg.APIVersion)
+	useV3Classification := usesV3ConfigSyntax(cfg.APIVersion)
+
+	normalizeEntry := func(kind string, entry *ProviderEntry) {
+		if entry == nil {
+			return
+		}
+		normalizeProviderSource(kind, &entry.Source, useV3Classification)
+		if entry.Source.IsMetadataURL() && entry.Source.Auth == nil && entry.InlineSourceAuth != nil {
+			auth := *entry.InlineSourceAuth
+			entry.Source.Auth = &auth
+			entry.InlineSourceAuth = nil
+		}
+	}
+
+	for _, entry := range cfg.Plugins {
+		normalizeEntry(providermanifestv1.KindPlugin, entry)
+	}
+	for _, collection := range []struct {
+		kind    string
+		entries map[string]*ProviderEntry
+	}{
+		{providermanifestv1.KindAuth, cfg.Providers.Auth},
+		{providermanifestv1.KindSecrets, cfg.Providers.Secrets},
+		{string(HostProviderKindTelemetry), cfg.Providers.Telemetry},
+		{string(HostProviderKindAudit), cfg.Providers.Audit},
+		{providermanifestv1.KindIndexedDB, cfg.Providers.IndexedDB},
+		{providermanifestv1.KindCache, cfg.Providers.Cache},
+		{providermanifestv1.KindS3, cfg.Providers.S3},
+	} {
+		for _, entry := range collection.entries {
+			normalizeEntry(collection.kind, entry)
+		}
+	}
+	for _, entry := range cfg.Providers.UI {
+		if entry != nil {
+			normalizeEntry(providermanifestv1.KindWebUI, &entry.ProviderEntry)
+		}
+	}
+}
+
+func normalizeProviderSource(kind string, source *ProviderSource, useV3Classification bool) {
+	if source == nil {
+		return
+	}
+	source.scalar = strings.TrimSpace(source.scalar)
+	if source.Builtin != "" || source.Ref != "" || source.Path != "" || source.metadataURL != "" {
+		source.scalar = ""
+		return
+	}
+	if source.scalar == "" {
+		return
+	}
+	switch {
+	case !useV3Classification:
+		source.Builtin = source.scalar
+	case isBuiltinScalarSource(kind, source.scalar):
+		source.Builtin = source.scalar
+	case looksLikeUnsupportedScalarSource(source.scalar):
+		source.unsupported = source.scalar
+	case looksLikeMetadataURL(source.scalar):
+		source.metadataURL = source.scalar
+	default:
+		source.Path = source.scalar
+	}
+	source.scalar = ""
+}
+
+func isBuiltinScalarSource(kind, source string) bool {
+	switch kind {
+	case providermanifestv1.KindSecrets:
+		return source == "env"
+	case string(HostProviderKindTelemetry):
+		return source == "stdout"
+	case string(HostProviderKindAudit):
+		switch source {
+		case "inherit", "noop", "stdout", "otlp":
+			return true
+		}
+	}
+	return false
+}
+
+func looksLikeMetadataURL(value string) bool {
+	parsed, err := url.ParseRequestURI(strings.TrimSpace(value))
+	if err != nil {
+		return false
+	}
+	switch parsed.Scheme {
+	case "http", "https":
+		return parsed.Host != "" && strings.HasSuffix(parsed.Path, "/provider-release.yaml")
+	default:
+		return false
+	}
+}
+
+func looksLikeUnsupportedScalarSource(value string) bool {
+	trimmed := strings.TrimSpace(value)
+	if strings.HasPrefix(strings.ToLower(trimmed), "git+") {
+		return true
+	}
+	parsed, err := url.ParseRequestURI(trimmed)
+	if err != nil {
+		return false
+	}
+	switch parsed.Scheme {
+	case "http", "https":
+		return parsed.Host != "" && !strings.HasSuffix(parsed.Path, "/provider-release.yaml")
+	default:
+		return false
+	}
+}
+
+func usesV3ConfigSyntax(apiVersion string) bool {
+	return strings.TrimSpace(apiVersion) == APIVersionV3
+}
+
 func nonNilProviderEntryMap(entries map[string]*ProviderEntry) map[string]*ProviderEntry {
 	if entries == nil {
 		return make(map[string]*ProviderEntry)
@@ -1377,7 +1590,7 @@ func applyDefaultBuiltinProviderEntries(entries map[string]*ProviderEntry, defau
 		}
 	}
 	for _, entry := range entries {
-		if entry == nil || entry.Source.IsBuiltin() || entry.Source.IsManaged() || entry.Source.IsLocal() {
+		if entry == nil || entry.Source.IsBuiltin() || entry.Source.IsManaged() || entry.Source.IsMetadataURL() || entry.Source.IsLocal() {
 			continue
 		}
 		entry.Source.Builtin = builtin
@@ -1525,7 +1738,7 @@ func resolveBaseURL(cfg *Config) {
 	cfg.Server.Management.BaseURL = strings.TrimRight(strings.TrimSpace(cfg.Server.Management.BaseURL), "/")
 }
 
-func resolveRelativePathsInValue(configPath string, root map[string]any) {
+func resolveRelativePathsInValue(configPath string, root map[string]any, useV3Classification bool) {
 	baseDir := filepath.Dir(configPath)
 	if absPath, err := filepath.Abs(configPath); err == nil {
 		baseDir = filepath.Dir(absPath)
@@ -1538,24 +1751,37 @@ func resolveRelativePathsInValue(configPath string, root map[string]any) {
 	if providers := nestedMap(root, "providers"); providers != nil {
 		for _, kind := range []string{"auth", "secrets", "telemetry", "audit", "ui", "indexeddb", "cache", "s3"} {
 			for _, entry := range mapValues(nestedMap(providers, kind)) {
-				resolveRelativePathsInEntry(entry, baseDir)
+				resolveRelativePathsInEntry(kind, entry, baseDir, useV3Classification)
 			}
 		}
 	}
 
 	for _, entry := range mapValues(nestedMap(root, "plugins")) {
-		resolveRelativePathsInEntry(entry, baseDir)
+		resolveRelativePathsInEntry(providermanifestv1.KindPlugin, entry, baseDir, useV3Classification)
 	}
 }
 
-func resolveRelativePathsInEntry(entry map[string]any, baseDir string) {
+func resolveRelativePathsInEntry(kind string, entry map[string]any, baseDir string, useV3Classification bool) {
 	if entry == nil {
 		return
 	}
 	resolveRelativeStringField(entry, "iconFile", baseDir)
-	if source := nestedMap(entry, "source"); source != nil {
+	if source, ok := entry["source"].(map[string]any); ok {
 		resolveRelativeStringField(source, "path", baseDir)
+		return
 	}
+	if !useV3Classification {
+		return
+	}
+	sourceValue, ok := entry["source"].(string)
+	if !ok {
+		return
+	}
+	sourceValue = strings.TrimSpace(sourceValue)
+	if sourceValue == "" || isBuiltinScalarSource(kind, sourceValue) || looksLikeMetadataURL(sourceValue) || looksLikeUnsupportedScalarSource(sourceValue) {
+		return
+	}
+	entry["source"] = resolveRelativeConfigValue(baseDir, sourceValue)
 }
 
 func resolveRelativeStringField(fields map[string]any, key, baseDir string) {

--- a/gestaltd/internal/config/config_test.go
+++ b/gestaltd/internal/config/config_test.go
@@ -857,7 +857,10 @@ authorization:
 func TestLoadSucceedsWithoutRuntimeFields(t *testing.T) {
 	t.Parallel()
 
-	path := mustWriteConfigFile(t, `
+	t.Run("mapping local source path", func(t *testing.T) {
+		t.Parallel()
+
+		path := mustWriteConfigFile(t, `
 providers:
 plugins:
     custom_tool:
@@ -865,13 +868,81 @@ plugins:
         path: ./manifest.yaml
 `)
 
-	cfg, err := Load(path)
-	if err != nil {
-		t.Fatalf("Load: %v", err)
-	}
-	if got := cfg.Plugins["custom_tool"].SourcePath(); got != filepath.Join(filepath.Dir(path), "manifest.yaml") {
-		t.Fatalf("unexpected plugin source path: %q", got)
-	}
+		cfg, err := Load(path)
+		if err != nil {
+			t.Fatalf("Load: %v", err)
+		}
+		if got := cfg.Plugins["custom_tool"].SourcePath(); got != filepath.Join(filepath.Dir(path), "manifest.yaml") {
+			t.Fatalf("unexpected plugin source path: %q", got)
+		}
+	})
+
+	t.Run("apiVersion classifies scalar local sources", func(t *testing.T) {
+		t.Parallel()
+
+		path := mustWriteConfigFile(t, `
+apiVersion: gestaltd.config/v3
+providers:
+plugins:
+    custom_tool:
+      source: ./manifest.yaml
+`)
+
+		cfg, err := Load(path)
+		if err != nil {
+			t.Fatalf("Load: %v", err)
+		}
+		if cfg.APIVersion != APIVersionV3 {
+			t.Fatalf("APIVersion = %q, want %q", cfg.APIVersion, APIVersionV3)
+		}
+		if got := cfg.Plugins["custom_tool"].SourcePath(); got != filepath.Join(filepath.Dir(path), "manifest.yaml") {
+			t.Fatalf("unexpected plugin source path: %q", got)
+		}
+	})
+
+	t.Run("apiVersion moves sibling auth onto metadata URL sources", func(t *testing.T) {
+		t.Parallel()
+
+		path := mustWriteConfigFile(t, `
+apiVersion: gestaltd.config/v3
+providers:
+plugins:
+    custom_tool:
+      source: https://example.com/providers/custom_tool/provider-release.yaml?download=1
+      auth:
+        token: test-token
+`)
+
+		cfg, err := Load(path)
+		if err != nil {
+			t.Fatalf("Load: %v", err)
+		}
+		entry := cfg.Plugins["custom_tool"]
+		if got := entry.SourceMetadataURL(); got != "https://example.com/providers/custom_tool/provider-release.yaml?download=1" {
+			t.Fatalf("SourceMetadataURL = %q", got)
+		}
+		if entry.Source.Auth == nil || entry.Source.Auth.Token != "test-token" {
+			t.Fatalf("Source.Auth = %#v", entry.Source.Auth)
+		}
+		if entry.InlineSourceAuth != nil {
+			t.Fatalf("InlineSourceAuth = %#v, want nil", entry.InlineSourceAuth)
+		}
+		marshaled, err := yaml.Marshal(entry)
+		if err != nil {
+			t.Fatalf("yaml.Marshal: %v", err)
+		}
+		var roundTripped map[string]any
+		if err := yaml.Unmarshal(marshaled, &roundTripped); err != nil {
+			t.Fatalf("yaml.Unmarshal: %v", err)
+		}
+		if got, ok := roundTripped["source"].(string); !ok || got != "https://example.com/providers/custom_tool/provider-release.yaml?download=1" {
+			t.Fatalf("round-tripped source = %#v", roundTripped["source"])
+		}
+		auth, ok := roundTripped["auth"].(map[string]any)
+		if !ok || auth["token"] != "test-token" {
+			t.Fatalf("round-tripped auth = %#v", roundTripped["auth"])
+		}
+	})
 }
 
 func TestLoadConfigUIEntries(t *testing.T) {
@@ -2120,6 +2191,28 @@ providers:
         version: 1.0.0
 `,
 		},
+		{
+			name: "apiVersion scalar local source",
+			yaml: `
+apiVersion: gestaltd.config/v3
+providers:
+plugins:
+    external:
+      source: ./plugins/dummy/manifest.yaml
+`,
+		},
+		{
+			name: "apiVersion metadata url with sibling auth",
+			yaml: `
+apiVersion: gestaltd.config/v3
+providers:
+plugins:
+    external:
+      source: https://example.com/providers/external/provider-release.yaml
+      auth:
+        token: test-token
+`,
+		},
 	}
 
 	for _, tc := range cases {
@@ -2182,6 +2275,17 @@ server:
         default: deny
 `,
 			want: `field authorization not found in type config.ServerConfig`,
+		},
+		{
+			name: "unsupported apiVersion is rejected",
+			yaml: `
+apiVersion: gestaltd.config/v99
+providers:
+plugins:
+    external:
+      source: ./plugins/dummy/manifest.yaml
+`,
+			want: `unsupported apiVersion "gestaltd.config/v99"`,
 		},
 	}
 
@@ -2395,6 +2499,70 @@ plugins:
         ref: github.com/acme-corp/tools/widget
         version: 1.2.3
 `,
+		},
+		{
+			name: "apiVersion metadata url with sibling auth is valid",
+			yaml: `
+apiVersion: gestaltd.config/v3
+providers:
+plugins:
+    external:
+      source: https://example.com/providers/external/provider-release.yaml
+      auth:
+        token: test-token
+`,
+		},
+		{
+			name: "apiVersion local source rejects sibling auth",
+			yaml: `
+apiVersion: gestaltd.config/v3
+providers:
+plugins:
+    external:
+      source: ./plugins/dummy/manifest.yaml
+      auth:
+        token: test-token
+`,
+			wantErr: "auth is only valid with metadata URL sources",
+		},
+		{
+			name: "managed ref rejects sibling auth",
+			yaml: `
+apiVersion: gestaltd.config/v3
+providers:
+plugins:
+    external:
+      source:
+        ref: github.com/acme-corp/tools/widget
+        version: 1.2.3
+        auth:
+          token: nested-token
+      auth:
+        token: sibling-token
+`,
+			wantErr: "auth and source.auth are mutually exclusive",
+		},
+		{
+			name: "apiVersion rejects non metadata http source",
+			yaml: `
+apiVersion: gestaltd.config/v3
+providers:
+plugins:
+    external:
+      source: https://example.com/providers/external/archive.tar.gz
+`,
+			wantErr: "only provider-release.yaml metadata URLs are supported for remote sources",
+		},
+		{
+			name: "apiVersion rejects git scalar source",
+			yaml: `
+apiVersion: gestaltd.config/v3
+providers:
+plugins:
+    external:
+      source: git+ssh://git@github.com/example/external.git
+`,
+			wantErr: "git+ sources are not supported in apiVersion v3 configs",
 		},
 		{
 			name: "plugin source with base_url override is rejected",
@@ -2695,6 +2863,48 @@ server:
 	}
 	if got := cfg.Plugins["service-a"].SourcePath(); got != filepath.Join(dir, "bin", "manifest.yaml") {
 		t.Fatalf("integration plugin source path = %q, want %q", got, filepath.Join(dir, "bin", "manifest.yaml"))
+	}
+}
+
+func TestLoadPaths_ResolvesRelativeScalarSourcePathsPerFile(t *testing.T) {
+	t.Parallel()
+
+	dir := t.TempDir()
+	basePath := filepath.Join(dir, "base", "gestalt.yaml")
+	if err := os.MkdirAll(filepath.Dir(basePath), 0o755); err != nil {
+		t.Fatalf("MkdirAll base: %v", err)
+	}
+	if err := os.WriteFile(basePath, []byte(`
+apiVersion: gestaltd.config/v3
+providers:
+plugins:
+    sample:
+      source: ../base-plugin/manifest.yaml
+`), 0o644); err != nil {
+		t.Fatalf("WriteFile base: %v", err)
+	}
+
+	overridePath := filepath.Join(dir, "overrides", "gestalt.yaml")
+	if err := os.MkdirAll(filepath.Dir(overridePath), 0o755); err != nil {
+		t.Fatalf("MkdirAll override: %v", err)
+	}
+	if err := os.WriteFile(overridePath, []byte(`
+providers:
+plugins:
+    sample:
+      source: ./override-plugin/manifest.yaml
+`), 0o644); err != nil {
+		t.Fatalf("WriteFile override: %v", err)
+	}
+
+	cfg, err := LoadPaths([]string{basePath, overridePath})
+	if err != nil {
+		t.Fatalf("LoadPaths: %v", err)
+	}
+
+	wantPath := filepath.Join(filepath.Dir(overridePath), "override-plugin", "manifest.yaml")
+	if got := cfg.Plugins["sample"].SourcePath(); got != wantPath {
+		t.Fatalf("SourcePath = %q, want %q", got, wantPath)
 	}
 }
 

--- a/gestaltd/internal/config/config_validate.go
+++ b/gestaltd/internal/config/config_validate.go
@@ -22,6 +22,9 @@ import (
 // Called by Load (and therefore by init, validate, and serve). Does not require
 // runtime secrets like encryption_key.
 func ValidateStructure(cfg *Config) error {
+	if err := validateAPIVersion(cfg); err != nil {
+		return err
+	}
 	if err := NormalizeCompatibility(cfg); err != nil {
 		return err
 	}
@@ -111,6 +114,19 @@ func ValidateStructure(cfg *Config) error {
 		}
 	}
 	return nil
+}
+
+func validateAPIVersion(cfg *Config) error {
+	if cfg == nil {
+		return nil
+	}
+	apiVersion := strings.TrimSpace(cfg.APIVersion)
+	switch apiVersion {
+	case "", APIVersionV3:
+		return nil
+	default:
+		return fmt.Errorf("config validation: unsupported apiVersion %q", apiVersion)
+	}
 }
 
 func validateHostProviderEntries(kind HostProviderKind, entries map[string]*ProviderEntry) error {
@@ -205,7 +221,19 @@ func validateProviderEntrySource(kind, name string, entry *ProviderEntry) error 
 	}
 	src := entry.Source
 	if src.IsBuiltin() {
+		if entry.InlineSourceAuth != nil {
+			return fmt.Errorf("config validation: %s %q auth is only valid with metadata URL sources", kind, name)
+		}
+		if src.Auth != nil {
+			return fmt.Errorf("config validation: %s %q source.auth is only valid with source.ref or metadata URL sources", kind, name)
+		}
 		return nil
+	}
+	if src.UnsupportedURL() != "" {
+		if strings.HasPrefix(strings.ToLower(strings.TrimSpace(src.UnsupportedURL())), "git+") {
+			return fmt.Errorf("config validation: %s %q git+ sources are not supported in apiVersion v3 configs", kind, name)
+		}
+		return fmt.Errorf("config validation: %s %q only provider-release.yaml metadata URLs are supported for remote sources", kind, name)
 	}
 	modeCount := 0
 	if src.IsLocal() {
@@ -214,11 +242,14 @@ func validateProviderEntrySource(kind, name string, entry *ProviderEntry) error 
 	if src.IsManaged() {
 		modeCount++
 	}
+	if src.IsMetadataURL() {
+		modeCount++
+	}
 	if modeCount == 0 {
 		return fmt.Errorf("config validation: %s %q source.path or source.ref is required", kind, name)
 	}
 	if modeCount > 1 {
-		return fmt.Errorf("config validation: %s %q source.path and source.ref are mutually exclusive", kind, name)
+		return fmt.Errorf("config validation: %s %q source.path, source.ref, and metadata URL sources are mutually exclusive", kind, name)
 	}
 	if src.IsManaged() {
 		if _, err := pluginsource.Parse(src.Ref); err != nil {
@@ -231,15 +262,31 @@ func validateProviderEntrySource(kind, name string, entry *ProviderEntry) error 
 			return fmt.Errorf("config validation: %s %q source.version: %w", kind, name, err)
 		}
 	}
-	if src.IsLocal() && src.Version != "" {
+	if src.IsMetadataURL() {
+		if parsed, err := url.ParseRequestURI(src.MetadataURL()); err != nil || parsed.Host == "" || (parsed.Scheme != "http" && parsed.Scheme != "https") || !strings.HasSuffix(parsed.Path, "/provider-release.yaml") {
+			return fmt.Errorf("config validation: %s %q source metadata URL must be an absolute http(s) provider-release.yaml URL", kind, name)
+		}
+	}
+	if !src.IsManaged() && src.Version != "" {
 		return fmt.Errorf("config validation: %s %q source.version is only valid with source.ref", kind, name)
 	}
+	if entry.InlineSourceAuth != nil && src.Auth != nil {
+		return fmt.Errorf("config validation: %s %q auth and source.auth are mutually exclusive", kind, name)
+	}
 	if src.Auth != nil {
-		if !src.IsManaged() {
-			return fmt.Errorf("config validation: %s %q source.auth is only valid with source.ref", kind, name)
+		if !src.IsManaged() && !src.IsMetadataURL() {
+			return fmt.Errorf("config validation: %s %q source.auth is only valid with source.ref or metadata URL sources", kind, name)
 		}
 		if strings.TrimSpace(src.Auth.Token) == "" {
 			return fmt.Errorf("config validation: %s %q source.auth.token is required when source.auth is set", kind, name)
+		}
+	}
+	if entry.InlineSourceAuth != nil {
+		if !src.IsMetadataURL() {
+			return fmt.Errorf("config validation: %s %q auth is only valid with metadata URL sources", kind, name)
+		}
+		if strings.TrimSpace(entry.InlineSourceAuth.Token) == "" {
+			return fmt.Errorf("config validation: %s %q auth.token is required when auth is set", kind, name)
 		}
 	}
 	return nil

--- a/gestaltd/internal/operator/lifecycle.go
+++ b/gestaltd/internal/operator/lifecycle.go
@@ -102,22 +102,22 @@ func (l *Lifecycle) metadataHTTPClient() *http.Client {
 }
 
 func (l *Lifecycle) InitAtPath(configPath string) (*Lockfile, error) {
-	lock, _, err := l.initAtPaths([]string{configPath}, "")
+	lock, _, err := l.initAtPaths([]string{configPath}, "", false)
 	return lock, err
 }
 
 func (l *Lifecycle) InitAtPathWithArtifactsDir(configPath, artifactsDir string) (*Lockfile, error) {
-	lock, _, err := l.initAtPaths([]string{configPath}, artifactsDir)
+	lock, _, err := l.initAtPaths([]string{configPath}, artifactsDir, false)
 	return lock, err
 }
 
 func (l *Lifecycle) InitAtPaths(configPaths []string) (*Lockfile, error) {
-	lock, _, err := l.initAtPaths(configPaths, "")
+	lock, _, err := l.initAtPaths(configPaths, "", false)
 	return lock, err
 }
 
 func (l *Lifecycle) InitAtPathsWithArtifactsDir(configPaths []string, artifactsDir string) (*Lockfile, error) {
-	lock, _, err := l.initAtPaths(configPaths, artifactsDir)
+	lock, _, err := l.initAtPaths(configPaths, artifactsDir, false)
 	return lock, err
 }
 
@@ -130,7 +130,7 @@ func (l *Lifecycle) InitAtPathWithPlatforms(configPath, artifactsDir string, pla
 // InitAtPathsWithPlatforms runs init and additionally downloads and hashes
 // archives for the specified extra platforms.
 func (l *Lifecycle) InitAtPathsWithPlatforms(configPaths []string, artifactsDir string, platforms []struct{ GOOS, GOARCH, LibC string }) (*Lockfile, error) {
-	lock, cfg, err := l.initAtPaths(configPaths, artifactsDir)
+	lock, cfg, err := l.initAtPaths(configPaths, artifactsDir, false)
 	if err != nil {
 		return nil, err
 	}
@@ -152,11 +152,16 @@ func (l *Lifecycle) InitAtPathsWithPlatforms(configPaths []string, artifactsDir 
 	return lock, nil
 }
 
-func (l *Lifecycle) initAtPaths(configPaths []string, artifactsDir string) (*Lockfile, *config.Config, error) {
+func (l *Lifecycle) initAtPaths(configPaths []string, artifactsDir string, allowLocal bool) (*Lockfile, *config.Config, error) {
 	configPath := primaryConfigPath(configPaths)
 	cfg, err := config.LoadAllowMissingEnvPaths(configPaths)
 	if err != nil {
 		return nil, nil, fmt.Errorf("loading config: %v", err)
+	}
+	if !allowLocal {
+		if err := rejectPortableLocalPluginAndUISources(cfg, "init"); err != nil {
+			return nil, nil, err
+		}
 	}
 	if err := config.OverlayManagedPluginConfigPaths(configPaths, cfg); err != nil {
 		return nil, nil, fmt.Errorf("loading config: %v", err)
@@ -252,6 +257,10 @@ func (l *Lifecycle) initAtPaths(configPaths []string, artifactsDir string) (*Loc
 	return lock, cfg, nil
 }
 
+func (l *Lifecycle) initAtPathsAllowLocal(configPaths []string, artifactsDir string) (*Lockfile, *config.Config, error) {
+	return l.initAtPaths(configPaths, artifactsDir, true)
+}
+
 func buildSourceTokenMap(cfg *config.Config) map[string]string {
 	tokens := make(map[string]string)
 	for _, entry := range cfg.Plugins {
@@ -311,6 +320,11 @@ func (l *Lifecycle) LoadForExecutionAtPathsWithArtifactsDir(configPaths []string
 	cfg, err := config.LoadPaths(configPaths)
 	if err != nil {
 		return nil, nil, fmt.Errorf("loading config: %v", err)
+	}
+	if locked {
+		if err := rejectPortableLocalPluginAndUISources(cfg, "locked execution"); err != nil {
+			return nil, nil, err
+		}
 	}
 	if err := synthesizeLocalSourcePluginOwnedUIEntries(cfg); err != nil {
 		return nil, nil, fmt.Errorf("loading config: %v", err)
@@ -431,7 +445,7 @@ func (l *Lifecycle) lockForSecretsBootstrap(configPaths []string, artifactsDir s
 
 	lock, err := ReadLockfile(paths.lockfilePath)
 	if !locked && (err != nil || !lockMatchesConfig(cfg, paths, lock)) {
-		lock, err = l.InitAtPathsWithArtifactsDir(configPaths, artifactsDir)
+		lock, _, err = l.initAtPathsAllowLocal(configPaths, artifactsDir)
 	}
 	if err != nil {
 		return nil, fmt.Errorf("managed providers require prepared artifacts; run `gestaltd init %s`: %w", formatConfigFlags(configPaths), err)
@@ -691,6 +705,33 @@ func configHasManagedProviderSources(cfg *config.Config) bool {
 		}
 	}
 	return false
+}
+
+// Portable init and locked execution only reject top-level local plugin/UI
+// sources in this slice. Local host-provider manifests remain available until
+// they are cut over to the same published metadata contract.
+func firstPortableRejectedLocalSource(cfg *config.Config) string {
+	if cfg == nil {
+		return ""
+	}
+	for name, entry := range cfg.Plugins {
+		if entry != nil && entry.HasLocalSource() {
+			return fmt.Sprintf("plugins.%s", name)
+		}
+	}
+	for name, entry := range cfg.Providers.UI {
+		if entry != nil && entry.HasLocalSource() {
+			return fmt.Sprintf("providers.ui.%s", name)
+		}
+	}
+	return ""
+}
+
+func rejectPortableLocalPluginAndUISources(cfg *config.Config, mode string) error {
+	if source := firstPortableRejectedLocalSource(cfg); source != "" {
+		return fmt.Errorf("local plugin and UI sources are not supported during %s; %s must run unlocked", mode, source)
+	}
+	return nil
 }
 
 func resolveLockPath(baseDir, provider string) string {
@@ -1580,7 +1621,7 @@ func (l *Lifecycle) applyLockedProviders(configPaths []string, artifactsDir stri
 		}
 		if !locked && (err != nil || !lockMatchesConfig(cfg, paths, lock)) {
 			clearSynthesizedPluginOwnedUIEntries(cfg, synthesizedLockedPluginUIs)
-			lock, err = l.InitAtPathsWithArtifactsDir(configPaths, artifactsDir)
+			lock, _, err = l.initAtPathsAllowLocal(configPaths, artifactsDir)
 		}
 		if err != nil {
 			return fmt.Errorf("managed providers require prepared artifacts; run `gestaltd init %s`: %w", formatConfigFlags(configPaths), err)

--- a/gestaltd/internal/operator/lifecycle.go
+++ b/gestaltd/internal/operator/lifecycle.go
@@ -169,7 +169,7 @@ func (l *Lifecycle) initAtPaths(configPaths []string, artifactsDir string) (*Loc
 	}
 	for _, collection := range hostProviderCollections(cfg) {
 		for name, entry := range collection.entries {
-			if entry == nil || !entry.HasManagedSource() {
+			if entry == nil || !entry.HasRemoteSource() {
 				continue
 			}
 			if collection.kind == config.HostProviderKindSecrets {
@@ -195,7 +195,7 @@ func (l *Lifecycle) initAtPaths(configPaths []string, artifactsDir string) (*Loc
 		lock.Secrets[name] = lockEntry
 	}
 	for name, def := range cfg.Providers.IndexedDB {
-		if def != nil && def.HasManagedSource() {
+		if def != nil && def.HasRemoteSource() {
 			entry, err := l.writeComponentArtifact(context.Background(), paths, providermanifestv1.KindIndexedDB, name, indexeddbDestDir(paths, name), def, def.Config)
 			if err != nil {
 				return nil, nil, err
@@ -204,7 +204,7 @@ func (l *Lifecycle) initAtPaths(configPaths []string, artifactsDir string) (*Loc
 		}
 	}
 	for name, def := range cfg.Providers.S3 {
-		if def != nil && def.HasManagedSource() {
+		if def != nil && def.HasRemoteSource() {
 			entry, err := l.writeComponentArtifact(context.Background(), paths, providermanifestv1.KindS3, name, s3DestDir(paths, name), def, def.Config)
 			if err != nil {
 				return nil, nil, err
@@ -213,7 +213,7 @@ func (l *Lifecycle) initAtPaths(configPaths []string, artifactsDir string) (*Loc
 		}
 	}
 	for name, entry := range cfg.Providers.UI {
-		if entry != nil && entry.HasManagedSource() {
+		if entry != nil && entry.HasRemoteSource() {
 			uiEntry, err := l.writeNamedUIProviderArtifact(context.Background(), paths, name, &entry.ProviderEntry, uiDestDir(paths, name), "ui "+strconv.Quote(name))
 			if err != nil {
 				return nil, nil, err
@@ -241,29 +241,29 @@ func buildSourceTokenMap(cfg *config.Config) map[string]string {
 	tokens := make(map[string]string)
 	for _, entry := range cfg.Plugins {
 		if entry != nil && entry.Source.Auth != nil {
-			tokens[entry.SourceRef()] = entry.Source.Auth.Token
+			tokens[entry.SourceRemoteLocation()] = entry.Source.Auth.Token
 		}
 	}
 	for _, collection := range hostProviderCollections(cfg) {
 		for _, entry := range collection.entries {
 			if entry != nil && entry.Source.Auth != nil {
-				tokens[entry.SourceRef()] = entry.Source.Auth.Token
+				tokens[entry.SourceRemoteLocation()] = entry.Source.Auth.Token
 			}
 		}
 	}
 	for _, def := range cfg.Providers.IndexedDB {
 		if def != nil && def.Source.Auth != nil {
-			tokens[def.SourceRef()] = def.Source.Auth.Token
+			tokens[def.SourceRemoteLocation()] = def.Source.Auth.Token
 		}
 	}
 	for _, def := range cfg.Providers.S3 {
 		if def != nil && def.Source.Auth != nil {
-			tokens[def.SourceRef()] = def.Source.Auth.Token
+			tokens[def.SourceRemoteLocation()] = def.Source.Auth.Token
 		}
 	}
 	for _, entry := range cfg.Providers.UI {
 		if entry != nil && entry.Source.Auth != nil {
-			tokens[entry.SourceRef()] = entry.Source.Auth.Token
+			tokens[entry.SourceRemoteLocation()] = entry.Source.Auth.Token
 		}
 	}
 	return tokens
@@ -402,7 +402,7 @@ func (l *Lifecycle) lockForSecretsBootstrap(configPaths []string, artifactsDir s
 	}
 	needsManagedSecrets := false
 	for _, provider := range referenced {
-		if provider != nil && provider.HasManagedSource() {
+		if provider != nil && provider.HasRemoteSource() {
 			needsManagedSecrets = true
 			break
 		}
@@ -483,7 +483,7 @@ func (l *Lifecycle) primeSecretsProviderForConfigResolution(ctx context.Context,
 			}
 
 			switch {
-			case provider.HasManagedSource():
+			case provider.HasRemoteSource():
 				if lock != nil {
 					lockEntry, ok := lock.Secrets[name]
 					if !ok {
@@ -618,29 +618,29 @@ func lockEntriesForKind(lock *Lockfile, kind config.HostProviderKind) map[string
 
 func configHasProviderLoading(cfg *config.Config) bool {
 	for _, entry := range cfg.Plugins {
-		if entry.HasManagedSource() || entry.HasLocalSource() {
+		if entry.HasRemoteSource() || entry.HasLocalSource() {
 			return true
 		}
 	}
 	for _, collection := range hostProviderCollections(cfg) {
 		for _, entry := range collection.entries {
-			if entry != nil && (entry.HasManagedSource() || entry.HasLocalSource()) {
+			if entry != nil && (entry.HasRemoteSource() || entry.HasLocalSource()) {
 				return true
 			}
 		}
 	}
 	for _, entry := range cfg.Providers.UI {
-		if entry != nil && (entry.HasManagedSource() || entry.HasLocalSource()) {
+		if entry != nil && (entry.HasRemoteSource() || entry.HasLocalSource()) {
 			return true
 		}
 	}
 	for _, def := range cfg.Providers.IndexedDB {
-		if def != nil && (def.HasManagedSource() || def.HasLocalSource()) {
+		if def != nil && (def.HasRemoteSource() || def.HasLocalSource()) {
 			return true
 		}
 	}
 	for _, def := range cfg.Providers.S3 {
-		if def != nil && (def.HasManagedSource() || def.HasLocalSource()) {
+		if def != nil && (def.HasRemoteSource() || def.HasLocalSource()) {
 			return true
 		}
 	}
@@ -649,29 +649,29 @@ func configHasProviderLoading(cfg *config.Config) bool {
 
 func configHasManagedProviderSources(cfg *config.Config) bool {
 	for _, entry := range cfg.Plugins {
-		if entry.HasManagedSource() {
+		if entry.HasRemoteSource() {
 			return true
 		}
 	}
 	for _, collection := range hostProviderCollections(cfg) {
 		for _, entry := range collection.entries {
-			if entry != nil && entry.HasManagedSource() {
+			if entry != nil && entry.HasRemoteSource() {
 				return true
 			}
 		}
 	}
 	for _, entry := range cfg.Providers.UI {
-		if entry != nil && entry.HasManagedSource() {
+		if entry != nil && entry.HasRemoteSource() {
 			return true
 		}
 	}
 	for _, def := range cfg.Providers.IndexedDB {
-		if def != nil && def.HasManagedSource() {
+		if def != nil && def.HasRemoteSource() {
 			return true
 		}
 	}
 	for _, def := range cfg.Providers.S3 {
-		if def != nil && def.HasManagedSource() {
+		if def != nil && def.HasRemoteSource() {
 			return true
 		}
 	}
@@ -890,7 +890,7 @@ func lockMatchesConfig(cfg *config.Config, paths initPaths, lock *Lockfile) bool
 		return false
 	}
 	for name, entry := range cfg.Plugins {
-		if !entry.HasManagedSource() {
+		if !entry.HasRemoteSource() {
 			continue
 		}
 		lockEntry, found := lock.Providers[name]
@@ -901,7 +901,7 @@ func lockMatchesConfig(cfg *config.Config, paths initPaths, lock *Lockfile) bool
 	for _, collection := range hostProviderCollections(cfg) {
 		lockEntries := lockEntriesForKind(lock, collection.kind)
 		for name, entry := range collection.entries {
-			if entry == nil || !entry.HasManagedSource() {
+			if entry == nil || !entry.HasRemoteSource() {
 				continue
 			}
 			lockEntry, found := lockEntries[name]
@@ -911,7 +911,7 @@ func lockMatchesConfig(cfg *config.Config, paths initPaths, lock *Lockfile) bool
 		}
 	}
 	for name, entry := range cfg.Providers.IndexedDB {
-		if entry == nil || !entry.HasManagedSource() {
+		if entry == nil || !entry.HasRemoteSource() {
 			continue
 		}
 		lockEntry, found := lock.IndexedDBs[name]
@@ -920,7 +920,7 @@ func lockMatchesConfig(cfg *config.Config, paths initPaths, lock *Lockfile) bool
 		}
 	}
 	for name, entry := range cfg.Providers.S3 {
-		if entry == nil || !entry.HasManagedSource() {
+		if entry == nil || !entry.HasRemoteSource() {
 			continue
 		}
 		lockEntry, found := lock.S3[name]
@@ -929,7 +929,7 @@ func lockMatchesConfig(cfg *config.Config, paths initPaths, lock *Lockfile) bool
 		}
 	}
 	for name, entry := range cfg.Providers.UI {
-		if entry == nil || !entry.HasManagedSource() {
+		if entry == nil || !entry.HasRemoteSource() {
 			continue
 		}
 		lockEntry, ok := lock.UIs[name]
@@ -964,7 +964,7 @@ func ProviderFingerprint(name string, entry *config.ProviderEntry, configDir str
 
 	input := providerFingerprintInput{
 		Name:    name,
-		Source:  entry.SourceRef(),
+		Source:  entry.SourceRemoteLocation(),
 		Version: entry.SourceVersion(),
 	}
 
@@ -1053,7 +1053,7 @@ func lockEntryMatches(paths initPaths, kind, name string, providerEntry *config.
 	if err != nil || entry.Fingerprint != fingerprint {
 		return false
 	}
-	if entry.Source != providerEntry.SourceRef() || entry.Version != providerEntry.SourceVersion() {
+	if entry.Source != providerEntry.SourceRemoteLocation() || entry.Version != providerEntry.SourceVersion() {
 		return false
 	}
 	if len(entry.Archives) > 0 {
@@ -1181,7 +1181,7 @@ func (l *Lifecycle) writeProviderArtifacts(ctx context.Context, cfg *config.Conf
 		if err != nil {
 			return nil, fmt.Errorf("decode provider config for provider %q: %w", name, err)
 		}
-		if !entry.HasManagedSource() {
+		if !entry.HasRemoteSource() {
 			continue
 		}
 		lockEntry, err := l.lockProviderEntryForSource(ctx, paths, name, entry, configMap)
@@ -1203,16 +1203,17 @@ func (l *Lifecycle) writeComponentArtifact(ctx context.Context, paths initPaths,
 }
 
 func (l *Lifecycle) lockComponentEntryForSource(ctx context.Context, paths initPaths, kind, name, destDir string, plugin *config.ProviderEntry, configMap map[string]any) (LockEntry, error) {
+	sourceLocation := plugin.SourceRemoteLocation()
 	src, err := sourceForProvider(plugin)
 	if err != nil {
-		return LockEntry{}, fmt.Errorf("%s %q source.ref %q: %w", kind, name, plugin.SourceRef(), err)
+		return LockEntry{}, fmt.Errorf("%s %q source %q: %w", kind, name, sourceLocation, err)
 	}
 	if l.sourceResolver == nil {
 		return LockEntry{}, fmt.Errorf("%s %q: source provider resolution requires a source resolver", kind, name)
 	}
 	resolved, err := l.sourceResolver.Resolve(ctx, src, plugin.SourceVersion())
 	if err != nil {
-		return LockEntry{}, fmt.Errorf("%s %q resolve source %q@%s: %w", kind, name, plugin.SourceRef(), plugin.SourceVersion(), err)
+		return LockEntry{}, fmt.Errorf("%s %q resolve source %q@%s: %w", kind, name, sourceLocation, plugin.SourceVersion(), err)
 	}
 	defer resolved.Cleanup()
 
@@ -1223,8 +1224,8 @@ func (l *Lifecycle) lockComponentEntryForSource(ctx context.Context, paths initP
 	if err := validateInstalledManifestKind(kind, name, installed.Manifest); err != nil {
 		return LockEntry{}, err
 	}
-	if installed.Manifest.Source != plugin.SourceRef() {
-		return LockEntry{}, fmt.Errorf("%s %q: manifest source %q does not match config source %q", kind, name, installed.Manifest.Source, plugin.SourceRef())
+	if installed.Manifest.Source != sourceLocation {
+		return LockEntry{}, fmt.Errorf("%s %q: manifest source %q does not match config source %q", kind, name, installed.Manifest.Source, sourceLocation)
 	}
 	if installed.Manifest.Version != plugin.SourceVersion() {
 		return LockEntry{}, fmt.Errorf("%s %q: manifest version %q does not match config version %q", kind, name, installed.Manifest.Version, plugin.SourceVersion())
@@ -1255,7 +1256,7 @@ func (l *Lifecycle) lockComponentEntryForSource(ctx context.Context, paths initP
 	}
 	return LockEntry{
 		Fingerprint: fingerprint,
-		Source:      plugin.SourceRef(),
+		Source:      sourceLocation,
 		Version:     plugin.SourceVersion(),
 		Archives:    archives,
 		Manifest:    filepath.ToSlash(manifestPath),
@@ -1264,16 +1265,17 @@ func (l *Lifecycle) lockComponentEntryForSource(ctx context.Context, paths initP
 }
 
 func (l *Lifecycle) lockProviderEntryForSource(ctx context.Context, paths initPaths, name string, plugin *config.ProviderEntry, configMap map[string]any) (LockProviderEntry, error) {
+	sourceLocation := plugin.SourceRemoteLocation()
 	src, err := sourceForProvider(plugin)
 	if err != nil {
-		return LockProviderEntry{}, fmt.Errorf("provider %q source.ref %q: %w", name, plugin.SourceRef(), err)
+		return LockProviderEntry{}, fmt.Errorf("provider %q source %q: %w", name, sourceLocation, err)
 	}
 	if l.sourceResolver == nil {
 		return LockProviderEntry{}, fmt.Errorf("provider %q: source provider resolution requires a source resolver", name)
 	}
 	resolved, err := l.sourceResolver.Resolve(ctx, src, plugin.SourceVersion())
 	if err != nil {
-		return LockProviderEntry{}, fmt.Errorf("provider %q resolve source %q@%s: %w", name, plugin.SourceRef(), plugin.SourceVersion(), err)
+		return LockProviderEntry{}, fmt.Errorf("provider %q resolve source %q@%s: %w", name, sourceLocation, plugin.SourceVersion(), err)
 	}
 	defer resolved.Cleanup()
 
@@ -1286,8 +1288,8 @@ func (l *Lifecycle) lockProviderEntryForSource(ctx context.Context, paths initPa
 		return LockProviderEntry{}, err
 	}
 
-	if installed.Manifest.Source != plugin.SourceRef() {
-		return LockProviderEntry{}, fmt.Errorf("provider %q: manifest source %q does not match config source %q", name, installed.Manifest.Source, plugin.SourceRef())
+	if installed.Manifest.Source != sourceLocation {
+		return LockProviderEntry{}, fmt.Errorf("provider %q: manifest source %q does not match config source %q", name, installed.Manifest.Source, sourceLocation)
 	}
 	if installed.Manifest.Version != plugin.SourceVersion() {
 		return LockProviderEntry{}, fmt.Errorf("provider %q: manifest version %q does not match config version %q", name, installed.Manifest.Version, plugin.SourceVersion())
@@ -1317,7 +1319,7 @@ func (l *Lifecycle) lockProviderEntryForSource(ctx context.Context, paths initPa
 	}
 	return LockProviderEntry{
 		Fingerprint: fingerprint,
-		Source:      plugin.SourceRef(),
+		Source:      sourceLocation,
 		Version:     plugin.SourceVersion(),
 		Archives:    archives,
 		Manifest:    filepath.ToSlash(manifestPath),
@@ -1326,8 +1328,8 @@ func (l *Lifecycle) lockProviderEntryForSource(ctx context.Context, paths initPa
 }
 
 func (l *Lifecycle) writeNamedUIProviderArtifact(ctx context.Context, paths initPaths, name string, plugin *config.ProviderEntry, destDir string, subject string) (LockUIEntry, error) {
-	if plugin == nil || !plugin.HasManagedSource() {
-		return LockUIEntry{}, fmt.Errorf("%s requires managed source", subject)
+	if plugin == nil || !plugin.HasRemoteSource() {
+		return LockUIEntry{}, fmt.Errorf("%s requires remote source", subject)
 	}
 	configMap, err := config.NodeToMap(plugin.Config)
 	if err != nil {
@@ -1340,14 +1342,14 @@ func (l *Lifecycle) writeNamedUIProviderArtifact(ctx context.Context, paths init
 
 	src, err := sourceForProvider(plugin)
 	if err != nil {
-		return LockUIEntry{}, fmt.Errorf("%s source.ref %q: %w", subject, plugin.SourceRef(), err)
+		return LockUIEntry{}, fmt.Errorf("%s source %q: %w", subject, plugin.SourceRemoteLocation(), err)
 	}
 	if l.sourceResolver == nil {
 		return LockUIEntry{}, fmt.Errorf("%s: source resolution requires a source resolver", subject)
 	}
 	resolved, err := l.sourceResolver.Resolve(ctx, src, plugin.SourceVersion())
 	if err != nil {
-		return LockUIEntry{}, fmt.Errorf("%s resolve source %q@%s: %w", subject, plugin.SourceRef(), plugin.SourceVersion(), err)
+		return LockUIEntry{}, fmt.Errorf("%s resolve source %q@%s: %w", subject, plugin.SourceRemoteLocation(), plugin.SourceVersion(), err)
 	}
 	defer resolved.Cleanup()
 
@@ -1358,8 +1360,8 @@ func (l *Lifecycle) writeNamedUIProviderArtifact(ctx context.Context, paths init
 	if err := validateInstalledManifestKind(providermanifestv1.KindWebUI, subject, installed.Manifest); err != nil {
 		return LockUIEntry{}, err
 	}
-	if installed.Manifest.Source != plugin.SourceRef() {
-		return LockUIEntry{}, fmt.Errorf("%s manifest source %q does not match config source %q", subject, installed.Manifest.Source, plugin.SourceRef())
+	if installed.Manifest.Source != plugin.SourceRemoteLocation() {
+		return LockUIEntry{}, fmt.Errorf("%s manifest source %q does not match config source %q", subject, installed.Manifest.Source, plugin.SourceRemoteLocation())
 	}
 	if installed.Manifest.Version != plugin.SourceVersion() {
 		return LockUIEntry{}, fmt.Errorf("%s manifest version %q does not match config version %q", subject, installed.Manifest.Version, plugin.SourceVersion())
@@ -1381,7 +1383,7 @@ func (l *Lifecycle) writeNamedUIProviderArtifact(ctx context.Context, paths init
 	}
 	return LockUIEntry{
 		Fingerprint: fingerprint,
-		Source:      plugin.SourceRef(),
+		Source:      plugin.SourceRemoteLocation(),
 		Version:     plugin.SourceVersion(),
 		Archives:    archives,
 		Manifest:    filepath.ToSlash(manifestPath),
@@ -1390,6 +1392,9 @@ func (l *Lifecycle) writeNamedUIProviderArtifact(ctx context.Context, paths init
 }
 
 func sourceForProvider(providerEntry *config.ProviderEntry) (pluginsource.Source, error) {
+	if providerEntry != nil && providerEntry.HasMetadataSource() {
+		return pluginsource.Source{}, fmt.Errorf("metadata URL sources are not supported yet")
+	}
 	src, err := pluginsource.Parse(providerEntry.SourceRef())
 	if err != nil {
 		return pluginsource.Source{}, err
@@ -1549,7 +1554,7 @@ func (l *Lifecycle) resolveConfiguredPlugins(paths initPaths, lock *Lockfile, cf
 			return fmt.Errorf("decode provider config for provider %q: %w", name, err)
 		}
 		switch {
-		case entry.HasManagedSource():
+		case entry.HasRemoteSource():
 			if err := l.applyLockedProviderEntry(paths, lock, name, entry, configMap, locked); err != nil {
 				return err
 			}
@@ -1667,7 +1672,7 @@ func synthesizeLockedSourcePluginOwnedUIEntries(cfg *config.Config, paths initPa
 	pluginNames := slices.Sorted(maps.Keys(cfg.Plugins))
 	for _, pluginName := range pluginNames {
 		plugin := cfg.Plugins[pluginName]
-		if plugin == nil || strings.TrimSpace(plugin.UI) != "" || strings.TrimSpace(plugin.MountPath) == "" || !plugin.HasManagedSource() {
+		if plugin == nil || strings.TrimSpace(plugin.UI) != "" || strings.TrimSpace(plugin.MountPath) == "" || !plugin.HasRemoteSource() {
 			continue
 		}
 		lockEntry, ok := lock.Providers[pluginName]
@@ -1792,7 +1797,7 @@ func (l *Lifecycle) applyConfiguredUIProvider(paths initPaths, lockEntry *LockUI
 		return "", fmt.Errorf("decode %s config: %w", subject, err)
 	}
 	switch {
-	case provider.HasManagedSource():
+	case provider.HasRemoteSource():
 		if lockEntry == nil {
 			return "", fmt.Errorf("prepared artifact for %s is missing or stale; run `gestaltd init %s`", subject, paths.configFlags)
 		}
@@ -1849,7 +1854,7 @@ func (l *Lifecycle) applyComponentProvider(paths initPaths, lockEntries map[stri
 		return fmt.Errorf("decode provider config for %s %q: %w", kind, name, err)
 	}
 	switch {
-	case provider.HasManagedSource():
+	case provider.HasRemoteSource():
 		if lockEntries == nil {
 			return fmt.Errorf("prepared artifact for %s %q is missing or stale; run `gestaltd init %s`", kind, name, paths.configFlags)
 		}
@@ -1970,7 +1975,7 @@ func (l *Lifecycle) applyLockedProviderEntry(paths initPaths, lock *Lockfile, na
 	if err != nil {
 		return fmt.Errorf("fingerprinting provider %q: %w", name, err)
 	}
-	if entry.Fingerprint != fingerprint || entry.Source != plugin.SourceRef() || entry.Version != plugin.SourceVersion() {
+	if entry.Fingerprint != fingerprint || entry.Source != plugin.SourceRemoteLocation() || entry.Version != plugin.SourceVersion() {
 		return fmt.Errorf("prepared artifact for provider %q is missing or stale; run `gestaltd init %s`", name, paths.configFlags)
 	}
 
@@ -2024,7 +2029,7 @@ func (l *Lifecycle) applyLockedComponentEntry(paths initPaths, entry *LockEntry,
 	if err != nil {
 		return fmt.Errorf("fingerprinting %s %q provider: %w", kind, name, err)
 	}
-	if entry.Fingerprint != fingerprint || entry.Source != plugin.SourceRef() || entry.Version != plugin.SourceVersion() {
+	if entry.Fingerprint != fingerprint || entry.Source != plugin.SourceRemoteLocation() || entry.Version != plugin.SourceVersion() {
 		return fmt.Errorf("prepared artifact for %s %q is missing or stale; run `gestaltd init %s`", kind, name, paths.configFlags)
 	}
 

--- a/gestaltd/internal/operator/lifecycle.go
+++ b/gestaltd/internal/operator/lifecycle.go
@@ -19,7 +19,6 @@ import (
 
 	"github.com/valon-technologies/gestalt/server/internal/config"
 	"github.com/valon-technologies/gestalt/server/internal/pluginsource"
-	ghresolver "github.com/valon-technologies/gestalt/server/internal/pluginsource/github"
 	"github.com/valon-technologies/gestalt/server/internal/pluginstore"
 	"github.com/valon-technologies/gestalt/server/internal/providerpkg"
 	providermanifestv1 "github.com/valon-technologies/gestalt/server/sdk/providermanifest/v1"
@@ -61,6 +60,9 @@ type LockArchive struct {
 
 type LockEntry struct {
 	Fingerprint string                 `json:"fingerprint"`
+	Package     string                 `json:"package,omitempty"`
+	Kind        string                 `json:"kind,omitempty"`
+	Runtime     string                 `json:"runtime,omitempty"`
 	Source      string                 `json:"source,omitempty"`
 	Version     string                 `json:"version,omitempty"`
 	Archives    map[string]LockArchive `json:"archives,omitempty"`
@@ -75,6 +77,7 @@ type LockUIEntry = LockEntry
 type Lifecycle struct {
 	sourceResolver       pluginsource.Resolver
 	configSecretResolver func(context.Context, *config.Config) error
+	httpClient           *http.Client
 }
 
 func NewLifecycle(sourceResolver pluginsource.Resolver) *Lifecycle {
@@ -84,6 +87,18 @@ func NewLifecycle(sourceResolver pluginsource.Resolver) *Lifecycle {
 func (l *Lifecycle) WithConfigSecretResolver(resolve func(context.Context, *config.Config) error) *Lifecycle {
 	l.configSecretResolver = resolve
 	return l
+}
+
+func (l *Lifecycle) WithHTTPClient(client *http.Client) *Lifecycle {
+	l.httpClient = client
+	return l
+}
+
+func (l *Lifecycle) metadataHTTPClient() *http.Client {
+	if l != nil && l.httpClient != nil {
+		return l.httpClient
+	}
+	return http.DefaultClient
 }
 
 func (l *Lifecycle) InitAtPath(configPath string) (*Lockfile, error) {
@@ -126,7 +141,7 @@ func (l *Lifecycle) InitAtPathsWithPlatforms(configPaths []string, artifactsDir 
 	configPath := primaryConfigPath(configPaths)
 	paths := initPathsForConfigsWithArtifactsDir(configPaths, resolveArtifactsDir(configPath, cfg, artifactsDir))
 	tokenForSource := buildSourceTokenMap(cfg)
-	if err := downloadPlatformArchives(context.Background(), lock, paths, platforms, tokenForSource); err != nil {
+	if err := l.downloadPlatformArchives(context.Background(), lock, paths, platforms, tokenForSource); err != nil {
 		return nil, err
 	}
 
@@ -893,6 +908,9 @@ func lockMatchesConfig(cfg *config.Config, paths initPaths, lock *Lockfile) bool
 		if !entry.HasRemoteSource() {
 			continue
 		}
+		if entry.HasMetadataSource() {
+			return false
+		}
 		lockEntry, found := lock.Providers[name]
 		if !lockEntryMatches(paths, providermanifestv1.KindPlugin, name, entry, lockEntry, found, providerDestDir(paths, name)) {
 			return false
@@ -904,6 +922,9 @@ func lockMatchesConfig(cfg *config.Config, paths initPaths, lock *Lockfile) bool
 			if entry == nil || !entry.HasRemoteSource() {
 				continue
 			}
+			if entry.HasMetadataSource() {
+				return false
+			}
 			lockEntry, found := lockEntries[name]
 			if !lockEntryMatches(paths, providerManifestKind(collection.kind), name, entry, lockEntry, found, componentDestDir(paths, collection.kind, name)) {
 				return false
@@ -914,6 +935,9 @@ func lockMatchesConfig(cfg *config.Config, paths initPaths, lock *Lockfile) bool
 		if entry == nil || !entry.HasRemoteSource() {
 			continue
 		}
+		if entry.HasMetadataSource() {
+			return false
+		}
 		lockEntry, found := lock.IndexedDBs[name]
 		if !lockEntryMatches(paths, providermanifestv1.KindIndexedDB, name, entry, lockEntry, found, indexeddbDestDir(paths, name)) {
 			return false
@@ -923,6 +947,9 @@ func lockMatchesConfig(cfg *config.Config, paths initPaths, lock *Lockfile) bool
 		if entry == nil || !entry.HasRemoteSource() {
 			continue
 		}
+		if entry.HasMetadataSource() {
+			return false
+		}
 		lockEntry, found := lock.S3[name]
 		if !lockEntryMatches(paths, providermanifestv1.KindS3, name, entry, lockEntry, found, s3DestDir(paths, name)) {
 			return false
@@ -931,6 +958,9 @@ func lockMatchesConfig(cfg *config.Config, paths initPaths, lock *Lockfile) bool
 	for name, entry := range cfg.Providers.UI {
 		if entry == nil || !entry.HasRemoteSource() {
 			continue
+		}
+		if entry.HasMetadataSource() {
+			return false
 		}
 		lockEntry, ok := lock.UIs[name]
 		if !ok {
@@ -978,6 +1008,16 @@ func ProviderFingerprint(name string, entry *config.ProviderEntry, configDir str
 
 func NamedUIProviderFingerprint(name string, entry *config.ProviderEntry) (string, error) {
 	return ProviderFingerprint("ui:"+name, entry, "")
+}
+
+func lockEntryVersionMatchesConfig(providerEntry *config.ProviderEntry, entry LockEntry) bool {
+	if providerEntry == nil {
+		return false
+	}
+	if providerEntry.HasMetadataSource() {
+		return strings.TrimSpace(entry.Version) != ""
+	}
+	return entry.Version == providerEntry.SourceVersion()
 }
 
 func archivePolicyKind(kind string) string {
@@ -1053,7 +1093,7 @@ func lockEntryMatches(paths initPaths, kind, name string, providerEntry *config.
 	if err != nil || entry.Fingerprint != fingerprint {
 		return false
 	}
-	if entry.Source != providerEntry.SourceRemoteLocation() || entry.Version != providerEntry.SourceVersion() {
+	if entry.Source != providerEntry.SourceRemoteLocation() || !lockEntryVersionMatchesConfig(providerEntry, entry) {
 		return false
 	}
 	if len(entry.Archives) > 0 {
@@ -1105,7 +1145,7 @@ func preparedManifestMatchesLock(entry LockEntry, manifest *providermanifestv1.M
 	if manifest == nil {
 		return false
 	}
-	if entry.Source != "" && manifest.Source != entry.Source {
+	if expectedPackage := lockEntryPackage(entry); expectedPackage != "" && manifest.Source != expectedPackage {
 		return false
 	}
 	if entry.Version != "" && manifest.Version != entry.Version {
@@ -1171,6 +1211,69 @@ func (l *Lifecycle) buildArchivesMap(ctx context.Context, src pluginsource.Sourc
 	return archives, nil
 }
 
+func (l *Lifecycle) installMetadataSourcePackage(ctx context.Context, expectedKind, name, subject, destDir string, plugin *config.ProviderEntry) (*pluginstore.InstalledPlugin, LockEntry, error) {
+	sourceLocation := plugin.SourceMetadataURL()
+	metadata, err := fetchProviderReleaseMetadata(ctx, l.metadataHTTPClient(), sourceLocation, sourceAuthToken(plugin))
+	if err != nil {
+		return nil, LockEntry{}, fmt.Errorf("%s fetch metadata %q: %w", subject, sourceLocation, err)
+	}
+	if metadata.Kind != expectedKind {
+		return nil, LockEntry{}, fmt.Errorf("%s metadata kind %q does not match expected kind %q", subject, metadata.Kind, expectedKind)
+	}
+	archives, err := providerReleaseArchives(sourceLocation, metadata)
+	if err != nil {
+		return nil, LockEntry{}, fmt.Errorf("%s resolve archive metadata %q: %w", subject, sourceLocation, err)
+	}
+	entry := LockEntry{
+		Package:  metadata.Package,
+		Kind:     metadata.Kind,
+		Runtime:  metadata.Runtime,
+		Source:   sourceLocation,
+		Version:  metadata.Version,
+		Archives: archives,
+	}
+
+	currentPlatform := providerpkg.CurrentPlatformString()
+	archive, resolvedKey, ok := resolveArchiveForPlatform(entry, currentPlatform)
+	if !ok || archive.URL == "" {
+		return nil, LockEntry{}, fmt.Errorf("no archive for platform %s for %s; publish an explicit %s target or a generic package where allowed", currentPlatform, subject, currentPlatform)
+	}
+	download, err := downloadArchiveForSource(ctx, l.metadataHTTPClient(), sourceLocation, sourceAuthToken(plugin), archive.URL)
+	if err != nil {
+		return nil, LockEntry{}, fmt.Errorf("download metadata source package for %s: %w", subject, err)
+	}
+	defer download.Cleanup()
+	if archive.SHA256 != "" && download.SHA256Hex != archive.SHA256 {
+		return nil, LockEntry{}, fmt.Errorf("metadata source digest mismatch for %s: got %s, want %s", subject, download.SHA256Hex, archive.SHA256)
+	}
+
+	installed, err := pluginstore.Install(download.LocalPath, destDir)
+	if err != nil {
+		return nil, LockEntry{}, fmt.Errorf("install metadata source package for %s: %w", subject, err)
+	}
+	if err := validateInstalledManifestKind(expectedKind, name, installed.Manifest); err != nil {
+		return nil, LockEntry{}, err
+	}
+	if installed.Manifest.Source != metadata.Package {
+		return nil, LockEntry{}, fmt.Errorf("%s manifest source %q does not match metadata package %q", subject, installed.Manifest.Source, metadata.Package)
+	}
+	if installed.Manifest.Version != metadata.Version {
+		return nil, LockEntry{}, fmt.Errorf("%s manifest version %q does not match metadata version %q", subject, installed.Manifest.Version, metadata.Version)
+	}
+	installedRuntime := releaseRuntimeForManifest(installed.Manifest, expectedKind)
+	if metadata.Runtime != installedRuntime {
+		return nil, LockEntry{}, fmt.Errorf("%s manifest runtime %q does not match metadata runtime %q", subject, installedRuntime, metadata.Runtime)
+	}
+	entry.Package = installed.Manifest.Source
+	entry.Kind = installed.Manifest.Kind
+	entry.Runtime = installedRuntime
+	entry.Version = installed.Manifest.Version
+	if err := validateLockedArchivePolicy(subject, expectedKind, installed.Manifest, entry, currentPlatform, resolvedKey); err != nil {
+		return nil, LockEntry{}, err
+	}
+	return installed, entry, nil
+}
+
 func (l *Lifecycle) writeProviderArtifacts(ctx context.Context, cfg *config.Config, paths initPaths) (map[string]LockProviderEntry, error) {
 	written := make(map[string]LockProviderEntry)
 	for name, entry := range cfg.Plugins {
@@ -1204,31 +1307,57 @@ func (l *Lifecycle) writeComponentArtifact(ctx context.Context, paths initPaths,
 
 func (l *Lifecycle) lockComponentEntryForSource(ctx context.Context, paths initPaths, kind, name, destDir string, plugin *config.ProviderEntry, configMap map[string]any) (LockEntry, error) {
 	sourceLocation := plugin.SourceRemoteLocation()
-	src, err := sourceForProvider(plugin)
-	if err != nil {
-		return LockEntry{}, fmt.Errorf("%s %q source %q: %w", kind, name, sourceLocation, err)
-	}
-	if l.sourceResolver == nil {
-		return LockEntry{}, fmt.Errorf("%s %q: source provider resolution requires a source resolver", kind, name)
-	}
-	resolved, err := l.sourceResolver.Resolve(ctx, src, plugin.SourceVersion())
-	if err != nil {
-		return LockEntry{}, fmt.Errorf("%s %q resolve source %q@%s: %w", kind, name, sourceLocation, plugin.SourceVersion(), err)
-	}
-	defer resolved.Cleanup()
+	expectedPackage := sourceLocation
+	var (
+		installed *pluginstore.InstalledPlugin
+		entry     LockEntry
+		err       error
+	)
+	subject := fmt.Sprintf("%s %q", kind, name)
+	if plugin.HasMetadataSource() {
+		installed, entry, err = l.installMetadataSourcePackage(ctx, kind, name, subject, destDir, plugin)
+		if err != nil {
+			return LockEntry{}, err
+		}
+		expectedPackage = lockEntryPackage(entry)
+	} else {
+		src, parseErr := sourceForProvider(plugin)
+		if parseErr != nil {
+			return LockEntry{}, fmt.Errorf("%s %q source %q: %w", kind, name, sourceLocation, parseErr)
+		}
+		if l.sourceResolver == nil {
+			return LockEntry{}, fmt.Errorf("%s %q: source provider resolution requires a source resolver", kind, name)
+		}
+		resolved, resolveErr := l.sourceResolver.Resolve(ctx, src, plugin.SourceVersion())
+		if resolveErr != nil {
+			return LockEntry{}, fmt.Errorf("%s %q resolve source %q@%s: %w", kind, name, sourceLocation, plugin.SourceVersion(), resolveErr)
+		}
+		defer resolved.Cleanup()
 
-	installed, err := pluginstore.Install(resolved.LocalPath, destDir)
-	if err != nil {
-		return LockEntry{}, fmt.Errorf("%s %q install source provider: %w", kind, name, err)
+		installed, err = pluginstore.Install(resolved.LocalPath, destDir)
+		if err != nil {
+			return LockEntry{}, fmt.Errorf("%s %q install source provider: %w", kind, name, err)
+		}
+		entry.Archives, err = l.buildArchivesMap(ctx, src, plugin.SourceVersion(), resolved.ResolvedURL, resolved.ArchiveSHA256, kind, subject, installed.Manifest)
+		if err != nil {
+			return LockEntry{}, err
+		}
+		entry.Package = installed.Manifest.Source
+		entry.Kind = installed.Manifest.Kind
+		entry.Runtime = releaseRuntimeForManifest(installed.Manifest, kind)
+		entry.Source = sourceLocation
+		entry.Version = plugin.SourceVersion()
 	}
-	if err := validateInstalledManifestKind(kind, name, installed.Manifest); err != nil {
-		return LockEntry{}, err
-	}
-	if installed.Manifest.Source != sourceLocation {
-		return LockEntry{}, fmt.Errorf("%s %q: manifest source %q does not match config source %q", kind, name, installed.Manifest.Source, sourceLocation)
-	}
-	if installed.Manifest.Version != plugin.SourceVersion() {
-		return LockEntry{}, fmt.Errorf("%s %q: manifest version %q does not match config version %q", kind, name, installed.Manifest.Version, plugin.SourceVersion())
+	if !plugin.HasMetadataSource() {
+		if err := validateInstalledManifestKind(kind, name, installed.Manifest); err != nil {
+			return LockEntry{}, err
+		}
+		if installed.Manifest.Source != expectedPackage {
+			return LockEntry{}, fmt.Errorf("%s %q: manifest source %q does not match expected package %q", kind, name, installed.Manifest.Source, expectedPackage)
+		}
+		if installed.Manifest.Version != entry.Version {
+			return LockEntry{}, fmt.Errorf("%s %q: manifest version %q does not match expected version %q", kind, name, installed.Manifest.Version, entry.Version)
+		}
 	}
 	if err := providerpkg.ValidateConfigForManifest(installed.ManifestPath, installed.Manifest, kind, configMap); err != nil {
 		return LockEntry{}, fmt.Errorf("provider config validation for %s %q: %w", kind, name, err)
@@ -1250,49 +1379,65 @@ func (l *Lifecycle) lockComponentEntryForSource(ctx context.Context, paths initP
 	if err != nil {
 		return LockEntry{}, fmt.Errorf("compute executable path for %s %q: %w", kind, name, err)
 	}
-	archives, err := l.buildArchivesMap(ctx, src, plugin.SourceVersion(), resolved.ResolvedURL, resolved.ArchiveSHA256, kind, fmt.Sprintf("%s %q", kind, name), installed.Manifest)
-	if err != nil {
-		return LockEntry{}, err
-	}
-	return LockEntry{
-		Fingerprint: fingerprint,
-		Source:      sourceLocation,
-		Version:     plugin.SourceVersion(),
-		Archives:    archives,
-		Manifest:    filepath.ToSlash(manifestPath),
-		Executable:  filepath.ToSlash(executablePath),
-	}, nil
+	entry.Fingerprint = fingerprint
+	entry.Manifest = filepath.ToSlash(manifestPath)
+	entry.Executable = filepath.ToSlash(executablePath)
+	return entry, nil
 }
 
 func (l *Lifecycle) lockProviderEntryForSource(ctx context.Context, paths initPaths, name string, plugin *config.ProviderEntry, configMap map[string]any) (LockProviderEntry, error) {
 	sourceLocation := plugin.SourceRemoteLocation()
-	src, err := sourceForProvider(plugin)
-	if err != nil {
-		return LockProviderEntry{}, fmt.Errorf("provider %q source %q: %w", name, sourceLocation, err)
-	}
-	if l.sourceResolver == nil {
-		return LockProviderEntry{}, fmt.Errorf("provider %q: source provider resolution requires a source resolver", name)
-	}
-	resolved, err := l.sourceResolver.Resolve(ctx, src, plugin.SourceVersion())
-	if err != nil {
-		return LockProviderEntry{}, fmt.Errorf("provider %q resolve source %q@%s: %w", name, sourceLocation, plugin.SourceVersion(), err)
-	}
-	defer resolved.Cleanup()
-
+	expectedPackage := sourceLocation
 	destDir := providerDestDir(paths, name)
-	installed, err := pluginstore.Install(resolved.LocalPath, destDir)
-	if err != nil {
-		return LockProviderEntry{}, fmt.Errorf("provider %q install source provider: %w", name, err)
-	}
-	if err := validateInstalledManifestKind(providermanifestv1.KindPlugin, name, installed.Manifest); err != nil {
-		return LockProviderEntry{}, err
-	}
+	var (
+		installed *pluginstore.InstalledPlugin
+		entry     LockProviderEntry
+		err       error
+	)
+	if plugin.HasMetadataSource() {
+		installed, entry, err = l.installMetadataSourcePackage(ctx, providermanifestv1.KindPlugin, name, fmt.Sprintf("provider %q", name), destDir, plugin)
+		if err != nil {
+			return LockProviderEntry{}, err
+		}
+		expectedPackage = lockEntryPackage(entry)
+	} else {
+		src, parseErr := sourceForProvider(plugin)
+		if parseErr != nil {
+			return LockProviderEntry{}, fmt.Errorf("provider %q source %q: %w", name, sourceLocation, parseErr)
+		}
+		if l.sourceResolver == nil {
+			return LockProviderEntry{}, fmt.Errorf("provider %q: source provider resolution requires a source resolver", name)
+		}
+		resolved, resolveErr := l.sourceResolver.Resolve(ctx, src, plugin.SourceVersion())
+		if resolveErr != nil {
+			return LockProviderEntry{}, fmt.Errorf("provider %q resolve source %q@%s: %w", name, sourceLocation, plugin.SourceVersion(), resolveErr)
+		}
+		defer resolved.Cleanup()
 
-	if installed.Manifest.Source != sourceLocation {
-		return LockProviderEntry{}, fmt.Errorf("provider %q: manifest source %q does not match config source %q", name, installed.Manifest.Source, sourceLocation)
+		installed, err = pluginstore.Install(resolved.LocalPath, destDir)
+		if err != nil {
+			return LockProviderEntry{}, fmt.Errorf("provider %q install source provider: %w", name, err)
+		}
+		entry.Archives, err = l.buildArchivesMap(ctx, src, plugin.SourceVersion(), resolved.ResolvedURL, resolved.ArchiveSHA256, providermanifestv1.KindPlugin, fmt.Sprintf("provider %q", name), installed.Manifest)
+		if err != nil {
+			return LockProviderEntry{}, err
+		}
+		entry.Package = installed.Manifest.Source
+		entry.Kind = installed.Manifest.Kind
+		entry.Runtime = releaseRuntimeForManifest(installed.Manifest, providermanifestv1.KindPlugin)
+		entry.Source = sourceLocation
+		entry.Version = plugin.SourceVersion()
 	}
-	if installed.Manifest.Version != plugin.SourceVersion() {
-		return LockProviderEntry{}, fmt.Errorf("provider %q: manifest version %q does not match config version %q", name, installed.Manifest.Version, plugin.SourceVersion())
+	if !plugin.HasMetadataSource() {
+		if err := validateInstalledManifestKind(providermanifestv1.KindPlugin, name, installed.Manifest); err != nil {
+			return LockProviderEntry{}, err
+		}
+		if installed.Manifest.Source != expectedPackage {
+			return LockProviderEntry{}, fmt.Errorf("provider %q: manifest source %q does not match expected package %q", name, installed.Manifest.Source, expectedPackage)
+		}
+		if installed.Manifest.Version != entry.Version {
+			return LockProviderEntry{}, fmt.Errorf("provider %q: manifest version %q does not match expected version %q", name, installed.Manifest.Version, entry.Version)
+		}
 	}
 
 	if err := providerpkg.ValidateConfigForManifest(installed.ManifestPath, installed.Manifest, providermanifestv1.KindPlugin, configMap); err != nil {
@@ -1313,18 +1458,10 @@ func (l *Lifecycle) lockProviderEntryForSource(ctx context.Context, paths initPa
 			return LockProviderEntry{}, fmt.Errorf("compute executable path for provider %q: %w", name, err)
 		}
 	}
-	archives, err := l.buildArchivesMap(ctx, src, plugin.SourceVersion(), resolved.ResolvedURL, resolved.ArchiveSHA256, providermanifestv1.KindPlugin, fmt.Sprintf("provider %q", name), installed.Manifest)
-	if err != nil {
-		return LockProviderEntry{}, err
-	}
-	return LockProviderEntry{
-		Fingerprint: fingerprint,
-		Source:      sourceLocation,
-		Version:     plugin.SourceVersion(),
-		Archives:    archives,
-		Manifest:    filepath.ToSlash(manifestPath),
-		Executable:  filepath.ToSlash(executableRel),
-	}, nil
+	entry.Fingerprint = fingerprint
+	entry.Manifest = filepath.ToSlash(manifestPath)
+	entry.Executable = filepath.ToSlash(executableRel)
+	return entry, nil
 }
 
 func (l *Lifecycle) writeNamedUIProviderArtifact(ctx context.Context, paths initPaths, name string, plugin *config.ProviderEntry, destDir string, subject string) (LockUIEntry, error) {
@@ -1339,32 +1476,57 @@ func (l *Lifecycle) writeNamedUIProviderArtifact(ctx context.Context, paths init
 	if err != nil {
 		return LockUIEntry{}, fmt.Errorf("fingerprinting %s: %w", subject, err)
 	}
+	expectedPackage := plugin.SourceRemoteLocation()
 
-	src, err := sourceForProvider(plugin)
-	if err != nil {
-		return LockUIEntry{}, fmt.Errorf("%s source %q: %w", subject, plugin.SourceRemoteLocation(), err)
-	}
-	if l.sourceResolver == nil {
-		return LockUIEntry{}, fmt.Errorf("%s: source resolution requires a source resolver", subject)
-	}
-	resolved, err := l.sourceResolver.Resolve(ctx, src, plugin.SourceVersion())
-	if err != nil {
-		return LockUIEntry{}, fmt.Errorf("%s resolve source %q@%s: %w", subject, plugin.SourceRemoteLocation(), plugin.SourceVersion(), err)
-	}
-	defer resolved.Cleanup()
+	var (
+		installed *pluginstore.InstalledPlugin
+		entry     LockUIEntry
+		opErr     error
+	)
+	if plugin.HasMetadataSource() {
+		installed, entry, opErr = l.installMetadataSourcePackage(ctx, providermanifestv1.KindWebUI, name, subject, destDir, plugin)
+		if opErr != nil {
+			return LockUIEntry{}, opErr
+		}
+		expectedPackage = lockEntryPackage(entry)
+	} else {
+		src, parseErr := sourceForProvider(plugin)
+		if parseErr != nil {
+			return LockUIEntry{}, fmt.Errorf("%s source %q: %w", subject, plugin.SourceRemoteLocation(), parseErr)
+		}
+		if l.sourceResolver == nil {
+			return LockUIEntry{}, fmt.Errorf("%s: source resolution requires a source resolver", subject)
+		}
+		resolved, resolveErr := l.sourceResolver.Resolve(ctx, src, plugin.SourceVersion())
+		if resolveErr != nil {
+			return LockUIEntry{}, fmt.Errorf("%s resolve source %q@%s: %w", subject, plugin.SourceRemoteLocation(), plugin.SourceVersion(), resolveErr)
+		}
+		defer resolved.Cleanup()
 
-	installed, err := pluginstore.Install(resolved.LocalPath, destDir)
-	if err != nil {
-		return LockUIEntry{}, fmt.Errorf("%s install source: %w", subject, err)
+		installed, opErr = pluginstore.Install(resolved.LocalPath, destDir)
+		if opErr != nil {
+			return LockUIEntry{}, fmt.Errorf("%s install source: %w", subject, opErr)
+		}
+		entry.Archives, opErr = l.buildArchivesMap(ctx, src, plugin.SourceVersion(), resolved.ResolvedURL, resolved.ArchiveSHA256, providermanifestv1.KindWebUI, subject, installed.Manifest)
+		if opErr != nil {
+			return LockUIEntry{}, opErr
+		}
+		entry.Package = installed.Manifest.Source
+		entry.Kind = installed.Manifest.Kind
+		entry.Runtime = releaseRuntimeForManifest(installed.Manifest, providermanifestv1.KindWebUI)
+		entry.Source = plugin.SourceRemoteLocation()
+		entry.Version = plugin.SourceVersion()
 	}
-	if err := validateInstalledManifestKind(providermanifestv1.KindWebUI, subject, installed.Manifest); err != nil {
-		return LockUIEntry{}, err
-	}
-	if installed.Manifest.Source != plugin.SourceRemoteLocation() {
-		return LockUIEntry{}, fmt.Errorf("%s manifest source %q does not match config source %q", subject, installed.Manifest.Source, plugin.SourceRemoteLocation())
-	}
-	if installed.Manifest.Version != plugin.SourceVersion() {
-		return LockUIEntry{}, fmt.Errorf("%s manifest version %q does not match config version %q", subject, installed.Manifest.Version, plugin.SourceVersion())
+	if !plugin.HasMetadataSource() {
+		if err := validateInstalledManifestKind(providermanifestv1.KindWebUI, subject, installed.Manifest); err != nil {
+			return LockUIEntry{}, err
+		}
+		if installed.Manifest.Source != expectedPackage {
+			return LockUIEntry{}, fmt.Errorf("%s manifest source %q does not match expected package %q", subject, installed.Manifest.Source, expectedPackage)
+		}
+		if installed.Manifest.Version != entry.Version {
+			return LockUIEntry{}, fmt.Errorf("%s manifest version %q does not match expected version %q", subject, installed.Manifest.Version, entry.Version)
+		}
 	}
 	if err := providerpkg.ValidateConfigForManifest(installed.ManifestPath, installed.Manifest, providermanifestv1.KindWebUI, configMap); err != nil {
 		return LockUIEntry{}, fmt.Errorf("provider config validation for %s: %w", subject, err)
@@ -1377,18 +1539,10 @@ func (l *Lifecycle) writeNamedUIProviderArtifact(ctx context.Context, paths init
 	if err != nil {
 		return LockUIEntry{}, fmt.Errorf("compute asset root path for %s: %w", subject, err)
 	}
-	archives, err := l.buildArchivesMap(ctx, src, plugin.SourceVersion(), resolved.ResolvedURL, resolved.ArchiveSHA256, providermanifestv1.KindWebUI, subject, installed.Manifest)
-	if err != nil {
-		return LockUIEntry{}, err
-	}
-	return LockUIEntry{
-		Fingerprint: fingerprint,
-		Source:      plugin.SourceRemoteLocation(),
-		Version:     plugin.SourceVersion(),
-		Archives:    archives,
-		Manifest:    filepath.ToSlash(manifestPath),
-		AssetRoot:   filepath.ToSlash(assetRoot),
-	}, nil
+	entry.Fingerprint = fingerprint
+	entry.Manifest = filepath.ToSlash(manifestPath)
+	entry.AssetRoot = filepath.ToSlash(assetRoot)
+	return entry, nil
 }
 
 func sourceForProvider(providerEntry *config.ProviderEntry) (pluginsource.Source, error) {
@@ -1975,7 +2129,7 @@ func (l *Lifecycle) applyLockedProviderEntry(paths initPaths, lock *Lockfile, na
 	if err != nil {
 		return fmt.Errorf("fingerprinting provider %q: %w", name, err)
 	}
-	if entry.Fingerprint != fingerprint || entry.Source != plugin.SourceRemoteLocation() || entry.Version != plugin.SourceVersion() {
+	if entry.Fingerprint != fingerprint || entry.Source != plugin.SourceRemoteLocation() || !lockEntryVersionMatchesConfig(plugin, entry) {
 		return fmt.Errorf("prepared artifact for provider %q is missing or stale; run `gestaltd init %s`", name, paths.configFlags)
 	}
 
@@ -2029,7 +2183,7 @@ func (l *Lifecycle) applyLockedComponentEntry(paths initPaths, entry *LockEntry,
 	if err != nil {
 		return fmt.Errorf("fingerprinting %s %q provider: %w", kind, name, err)
 	}
-	if entry.Fingerprint != fingerprint || entry.Source != plugin.SourceRemoteLocation() || entry.Version != plugin.SourceVersion() {
+	if entry.Fingerprint != fingerprint || entry.Source != plugin.SourceRemoteLocation() || !lockEntryVersionMatchesConfig(plugin, *entry) {
 		return fmt.Errorf("prepared artifact for %s %q is missing or stale; run `gestaltd init %s`", kind, name, paths.configFlags)
 	}
 
@@ -2130,23 +2284,7 @@ func (l *Lifecycle) materializeLockedProvider(ctx context.Context, paths initPat
 		return fmt.Errorf("no verified hash for platform %s for provider %q; run `gestaltd init --platform %s`", platform, name, platform)
 	}
 
-	src, parseErr := sourceForProvider(plugin)
-	if parseErr != nil {
-		src, parseErr = pluginsource.Parse(entry.Source)
-	}
-	var (
-		download *providerpkg.DownloadResult
-		err      error
-	)
-	if parseErr == nil && src.Host == pluginsource.HostGitHub {
-		download, err = ghresolver.DownloadResolvedAsset(ctx, http.DefaultClient, archive.URL, src.Token)
-	} else {
-		req, reqErr := http.NewRequestWithContext(ctx, http.MethodGet, archive.URL, nil)
-		if reqErr != nil {
-			return fmt.Errorf("create locked source provider request for provider %q: %w", name, reqErr)
-		}
-		download, err = providerpkg.DownloadRequest(http.DefaultClient, req)
-	}
+	download, err := downloadArchiveForSource(ctx, l.metadataHTTPClient(), entry.Source, sourceAuthToken(plugin), archive.URL)
 	if err != nil {
 		return fmt.Errorf("download locked source provider for provider %q: %w", name, err)
 	}
@@ -2161,8 +2299,8 @@ func (l *Lifecycle) materializeLockedProvider(ctx context.Context, paths initPat
 		return fmt.Errorf("install locked source provider for provider %q: %w", name, err)
 	}
 	defer func() { _ = cleanupInstall() }()
-	if installed.Manifest.Source != entry.Source {
-		return fmt.Errorf("locked source provider manifest source mismatch for provider %q: got %q, want %q", name, installed.Manifest.Source, entry.Source)
+	if installed.Manifest.Source != lockEntryPackage(entry) {
+		return fmt.Errorf("locked source provider manifest source mismatch for provider %q: got %q, want %q", name, installed.Manifest.Source, lockEntryPackage(entry))
 	}
 	if installed.Manifest.Version != entry.Version {
 		return fmt.Errorf("locked source provider manifest version mismatch for provider %q: got %q, want %q", name, installed.Manifest.Version, entry.Version)
@@ -2186,23 +2324,7 @@ func (l *Lifecycle) materializeLockedComponent(ctx context.Context, paths initPa
 		return fmt.Errorf("no verified hash for platform %s for %s %q; run `gestaltd init --platform %s`", platform, kind, name, platform)
 	}
 
-	src, parseErr := sourceForProvider(plugin)
-	if parseErr != nil {
-		src, parseErr = pluginsource.Parse(entry.Source)
-	}
-	var (
-		download *providerpkg.DownloadResult
-		err      error
-	)
-	if parseErr == nil && src.Host == pluginsource.HostGitHub {
-		download, err = ghresolver.DownloadResolvedAsset(ctx, http.DefaultClient, archive.URL, src.Token)
-	} else {
-		req, reqErr := http.NewRequestWithContext(ctx, http.MethodGet, archive.URL, nil)
-		if reqErr != nil {
-			return fmt.Errorf("create locked source provider request for %s %q: %w", kind, name, reqErr)
-		}
-		download, err = providerpkg.DownloadRequest(http.DefaultClient, req)
-	}
+	download, err := downloadArchiveForSource(ctx, l.metadataHTTPClient(), entry.Source, sourceAuthToken(plugin), archive.URL)
 	if err != nil {
 		return fmt.Errorf("download locked source provider for %s %q: %w", kind, name, err)
 	}
@@ -2222,8 +2344,8 @@ func (l *Lifecycle) materializeLockedComponent(ctx context.Context, paths initPa
 	if err := validateInstalledManifestKind(kind, name, installed.Manifest); err != nil {
 		return err
 	}
-	if installed.Manifest.Source != entry.Source {
-		return fmt.Errorf("locked source provider manifest source mismatch for %s %q: got %q, want %q", kind, name, installed.Manifest.Source, entry.Source)
+	if installed.Manifest.Source != lockEntryPackage(entry) {
+		return fmt.Errorf("locked source provider manifest source mismatch for %s %q: got %q, want %q", kind, name, installed.Manifest.Source, lockEntryPackage(entry))
 	}
 	if installed.Manifest.Version != entry.Version {
 		return fmt.Errorf("locked source provider manifest version mismatch for %s %q: got %q, want %q", kind, name, installed.Manifest.Version, entry.Version)
@@ -2247,23 +2369,7 @@ func (l *Lifecycle) materializeLockedUIProvider(ctx context.Context, paths initP
 		return fmt.Errorf("no verified hash for platform %s for ui provider; run `gestaltd init --platform %s`", platform, platform)
 	}
 
-	src, parseErr := sourceForProvider(plugin)
-	if parseErr != nil {
-		src, parseErr = pluginsource.Parse(entry.Source)
-	}
-	var (
-		download *providerpkg.DownloadResult
-		err      error
-	)
-	if parseErr == nil && src.Host == pluginsource.HostGitHub {
-		download, err = ghresolver.DownloadResolvedAsset(ctx, http.DefaultClient, archive.URL, src.Token)
-	} else {
-		req, reqErr := http.NewRequestWithContext(ctx, http.MethodGet, archive.URL, nil)
-		if reqErr != nil {
-			return fmt.Errorf("create locked source request for ui provider: %w", reqErr)
-		}
-		download, err = providerpkg.DownloadRequest(http.DefaultClient, req)
-	}
+	download, err := downloadArchiveForSource(ctx, l.metadataHTTPClient(), entry.Source, sourceAuthToken(plugin), archive.URL)
 	if err != nil {
 		return fmt.Errorf("download locked source for ui provider: %w", err)
 	}
@@ -2282,24 +2388,30 @@ func (l *Lifecycle) materializeLockedUIProvider(ctx context.Context, paths initP
 	if err := validateInstalledManifestKind(providermanifestv1.KindWebUI, "ui provider", installed.Manifest); err != nil {
 		return err
 	}
+	if installed.Manifest.Source != lockEntryPackage(entry) {
+		return fmt.Errorf("locked source manifest source mismatch for ui provider: got %q, want %q", installed.Manifest.Source, lockEntryPackage(entry))
+	}
+	if installed.Manifest.Version != entry.Version {
+		return fmt.Errorf("locked source manifest version mismatch for ui provider: got %q, want %q", installed.Manifest.Version, entry.Version)
+	}
 	return nil
 }
 
-func downloadPlatformArchives(ctx context.Context, lock *Lockfile, paths initPaths, platforms []struct{ GOOS, GOARCH, LibC string }, tokenForSource map[string]string) error {
+func (l *Lifecycle) downloadPlatformArchives(ctx context.Context, lock *Lockfile, paths initPaths, platforms []struct{ GOOS, GOARCH, LibC string }, tokenForSource map[string]string) error {
 	for _, plat := range platforms {
 		platformKey := providerpkg.PlatformString(plat.GOOS, plat.GOARCH)
-		if err := hashPlatformInEntries(ctx, lock, paths, platformKey, tokenForSource); err != nil {
+		if err := l.hashPlatformInEntries(ctx, lock, paths, platformKey, tokenForSource); err != nil {
 			return err
 		}
 	}
 	return nil
 }
 
-func hashPlatformInEntries(ctx context.Context, lock *Lockfile, paths initPaths, platformKey string, tokenForSource map[string]string) error {
+func (l *Lifecycle) hashPlatformInEntries(ctx context.Context, lock *Lockfile, paths initPaths, platformKey string, tokenForSource map[string]string) error {
 	for _, kind := range providerLockKinds() {
 		lockEntries := lockEntriesForProviderKind(lock, kind)
 		for name, entry := range lockEntries {
-			if err := hashArchiveEntry(ctx, kind, name, &entry, paths, platformKey, tokenForSource); err != nil {
+			if err := l.hashArchiveEntry(ctx, kind, name, &entry, paths, platformKey, tokenForSource); err != nil {
 				return err
 			}
 			lockEntries[name] = entry
@@ -2308,7 +2420,7 @@ func hashPlatformInEntries(ctx context.Context, lock *Lockfile, paths initPaths,
 	return nil
 }
 
-func hashArchiveEntry(ctx context.Context, kind, name string, entry *LockEntry, paths initPaths, platformKey string, tokenForSource map[string]string) error {
+func (l *Lifecycle) hashArchiveEntry(ctx context.Context, kind, name string, entry *LockEntry, paths initPaths, platformKey string, tokenForSource map[string]string) error {
 	if entry.Archives == nil {
 		return nil
 	}
@@ -2329,20 +2441,7 @@ func hashArchiveEntry(ctx context.Context, kind, name string, entry *LockEntry, 
 		return err
 	}
 	token := tokenForSource[entry.Source]
-	src, parseErr := pluginsource.Parse(entry.Source)
-	var (
-		dl  *providerpkg.DownloadResult
-		err error
-	)
-	if parseErr == nil && src.Host == pluginsource.HostGitHub {
-		dl, err = ghresolver.DownloadResolvedAsset(ctx, http.DefaultClient, archive.URL, token)
-	} else {
-		req, reqErr := http.NewRequestWithContext(ctx, http.MethodGet, archive.URL, nil)
-		if reqErr != nil {
-			return fmt.Errorf("create request for platform %s, source %s: %w", platformKey, entry.Source, reqErr)
-		}
-		dl, err = providerpkg.DownloadRequest(http.DefaultClient, req)
-	}
+	dl, err := downloadArchiveForSource(ctx, l.metadataHTTPClient(), entry.Source, token, archive.URL)
 	if err != nil {
 		return fmt.Errorf("download archive for platform %s, source %s: %w", platformKey, entry.Source, err)
 	}

--- a/gestaltd/internal/operator/lifecycle_source_test.go
+++ b/gestaltd/internal/operator/lifecycle_source_test.go
@@ -1168,6 +1168,173 @@ func TestSourcePluginMetadataURLUnlockedLoadRefreshesMutableMetadata(t *testing.
 	}
 }
 
+func TestSourcePluginMetadataURLUnlockedLoadAllowsLocalPlugins(t *testing.T) {
+	t.Parallel()
+
+	dir := t.TempDir()
+	const (
+		packageSource = testSource
+		version       = "1.0.0"
+	)
+
+	localManifestPath := filepath.Join(dir, "local-manifest.yaml")
+	localManifest, err := providerpkg.EncodeSourceManifestFormat(&providermanifestv1.Manifest{
+		Source:      "github.com/testowner/plugins/local-provider",
+		Version:     "0.0.1-alpha.1",
+		DisplayName: "Local Provider",
+		Description: "Local executable provider",
+		Kind:        providermanifestv1.KindPlugin,
+		Spec: &providermanifestv1.Spec{
+			Auth: &providermanifestv1.ProviderAuth{Type: providermanifestv1.AuthTypeNone},
+		},
+	}, providerpkg.ManifestFormatYAML)
+	if err != nil {
+		t.Fatalf("EncodeManifest: %v", err)
+	}
+	if err := os.WriteFile(localManifestPath, localManifest, 0o644); err != nil {
+		t.Fatalf("write local manifest: %v", err)
+	}
+	if err := os.WriteFile(filepath.Join(dir, "catalog.yaml"), []byte("name: provider\noperations:\n  - id: ping\n    method: GET\n"), 0o644); err != nil {
+		t.Fatalf("write local catalog: %v", err)
+	}
+
+	archivePath := buildV2Archive(t, dir, packageSource, version, "metadata-local-plugin")
+	archiveData, err := os.ReadFile(archivePath)
+	if err != nil {
+		t.Fatalf("read archive: %v", err)
+	}
+	archiveSHA := sha256.Sum256(archiveData)
+
+	var metadataCount atomic.Int64
+	var archiveCount atomic.Int64
+	handlerErrs := make(chan error, 4)
+	nextHandlerErr := func() error {
+		t.Helper()
+		select {
+		case err := <-handlerErrs:
+			return err
+		default:
+			return nil
+		}
+	}
+
+	metadataPath := "/providers/alpha/provider-release.yaml"
+	archivePathURL := "/providers/alpha/alpha-current.tar.gz"
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch r.URL.Path {
+		case metadataPath:
+			metadataCount.Add(1)
+			if got := r.Header.Get("Authorization"); got != "Bearer test-token" {
+				handlerErrs <- fmt.Errorf("metadata authorization = %q, want %q", got, "Bearer test-token")
+				http.Error(w, "bad metadata authorization", http.StatusBadRequest)
+				return
+			}
+			metadata := providerReleaseMetadata{
+				Schema:        providerReleaseSchemaName,
+				SchemaVersion: providerReleaseSchemaVersion,
+				Package:       packageSource,
+				Kind:          providermanifestv1.KindPlugin,
+				Version:       version,
+				Runtime:       providerReleaseRuntimeExecutable,
+				Artifacts: map[string]providerReleaseArtifact{
+					providerpkg.CurrentPlatformString(): {
+						Path:   filepath.Base(archivePathURL),
+						SHA256: hex.EncodeToString(archiveSHA[:]),
+					},
+				},
+			}
+			data, err := yaml.Marshal(metadata)
+			if err != nil {
+				handlerErrs <- fmt.Errorf("marshal metadata: %v", err)
+				http.Error(w, "metadata marshal failed", http.StatusInternalServerError)
+				return
+			}
+			w.Header().Set("Content-Type", "application/yaml")
+			_, _ = w.Write(data)
+		case archivePathURL:
+			archiveCount.Add(1)
+			if got := r.Header.Get("Authorization"); got != "Bearer test-token" {
+				handlerErrs <- fmt.Errorf("archive authorization = %q, want %q", got, "Bearer test-token")
+				http.Error(w, "bad archive authorization", http.StatusBadRequest)
+				return
+			}
+			w.Header().Set("Content-Type", "application/octet-stream")
+			_, _ = w.Write(archiveData)
+		default:
+			http.NotFound(w, r)
+		}
+	}))
+	defer srv.Close()
+
+	artifactsDir := filepath.Join(dir, "prepared-artifacts")
+	configPath := filepath.Join(dir, "gestalt.yaml")
+	configYAML := requiredComponentConfigYAML(t, dir, filepath.Join(dir, "data.db")) + strings.Join([]string{
+		"apiVersion: " + config.APIVersionV3,
+		"plugins:",
+		"  alpha:",
+		"    source: " + srv.URL + metadataPath,
+		"    auth:",
+		"      token: test-token",
+		"  local:",
+		"    source: ./local-manifest.yaml",
+		"server:",
+		"  providers:",
+		"    indexeddb: sqlite",
+		"  artifactsDir: " + artifactsDir,
+		"  encryptionKey: aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
+	}, "\n") + "\n"
+	if err := os.WriteFile(configPath, []byte(configYAML), 0o644); err != nil {
+		t.Fatalf("write config: %v", err)
+	}
+
+	lc := NewLifecycle(nil)
+	cfg, _, err := lc.LoadForExecutionAtPath(configPath, false)
+	if err == nil {
+		if handlerErr := nextHandlerErr(); handlerErr != nil {
+			t.Fatal(handlerErr)
+		}
+	}
+	if err != nil {
+		t.Fatalf("LoadForExecutionAtPath(locked=false): %v", err)
+	}
+	if handlerErr := nextHandlerErr(); handlerErr != nil {
+		t.Fatal(handlerErr)
+	}
+	if got := metadataCount.Load(); got != 1 {
+		t.Fatalf("metadata request count = %d, want 1", got)
+	}
+	if got := archiveCount.Load(); got != 1 {
+		t.Fatalf("archive request count = %d, want 1", got)
+	}
+
+	if cfg.Plugins["alpha"] == nil || cfg.Plugins["alpha"].ResolvedManifest == nil {
+		t.Fatal("resolved metadata plugin manifest missing after unlocked load")
+	}
+	if got := cfg.Plugins["alpha"].ResolvedManifest.Version; got != version {
+		t.Fatalf("resolved remote plugin version = %q, want %q", got, version)
+	}
+	if cfg.Plugins["local"] == nil || cfg.Plugins["local"].ResolvedManifest == nil {
+		t.Fatal("resolved local plugin manifest missing after unlocked load")
+	}
+	if got := cfg.Plugins["local"].ResolvedManifestPath; got != localManifestPath {
+		t.Fatalf("resolved local manifest path = %q, want %q", got, localManifestPath)
+	}
+
+	lock, err := ReadLockfile(filepath.Join(dir, InitLockfileName))
+	if err != nil {
+		t.Fatalf("ReadLockfile: %v", err)
+	}
+	if len(lock.Providers) != 1 {
+		t.Fatalf("lock provider count = %d, want 1", len(lock.Providers))
+	}
+	if _, ok := lock.Providers["alpha"]; !ok {
+		t.Fatal(`lock.Providers["alpha"] not found`)
+	}
+	if _, ok := lock.Providers["local"]; ok {
+		t.Fatal(`lock.Providers["local"] unexpectedly found`)
+	}
+}
+
 func TestSourcePluginLoadForExecution_RehydratesWhenCachedManifestVersionMismatchesLock(t *testing.T) {
 	t.Parallel()
 

--- a/gestaltd/internal/operator/lifecycle_source_test.go
+++ b/gestaltd/internal/operator/lifecycle_source_test.go
@@ -366,6 +366,19 @@ func TestSourcePluginEndToEnd(t *testing.T) {
 	if _, ok := written.Providers.Plugin["alpha"]; !ok {
 		t.Fatalf(`written.Providers.Plugin["alpha"] not found`)
 	}
+	writtenEntry := written.Providers.Plugin["alpha"]
+	if writtenEntry.InputDigest == "" {
+		t.Fatal("written plugin inputDigest is empty")
+	}
+	if writtenEntry.Package != source {
+		t.Fatalf("written plugin package = %q, want %q", writtenEntry.Package, source)
+	}
+	if writtenEntry.Kind != providermanifestv1.KindPlugin {
+		t.Fatalf("written plugin kind = %q, want %q", writtenEntry.Kind, providermanifestv1.KindPlugin)
+	}
+	if writtenEntry.Runtime != providerLockRuntimeExecutable {
+		t.Fatalf("written plugin runtime = %q, want %q", writtenEntry.Runtime, providerLockRuntimeExecutable)
+	}
 
 	readBack, err := ReadLockfile(lockPath)
 	if err != nil {
@@ -393,6 +406,33 @@ func TestSourcePluginNilResolver(t *testing.T) {
 	}
 	if !strings.Contains(err.Error(), "source resolver") {
 		t.Errorf("error = %q, want to contain 'source resolver'", err.Error())
+	}
+}
+
+func TestSourcePluginMetadataURLNotYetSupported(t *testing.T) {
+	t.Parallel()
+
+	dir := t.TempDir()
+	configPath := filepath.Join(dir, "gestalt.yaml")
+	if err := os.WriteFile(configPath, []byte(`
+apiVersion: gestaltd.config/v3
+plugins:
+  alpha:
+    source: https://example.com/providers/alpha/provider-release.yaml?download=1
+    auth:
+      token: test-token
+server:
+  artifactsDir: `+filepath.Join(dir, "prepared-artifacts")+`
+`), 0o644); err != nil {
+		t.Fatalf("write config: %v", err)
+	}
+
+	_, err := NewLifecycle(&fakeResolver{}).InitAtPath(configPath)
+	if err == nil {
+		t.Fatal("expected metadata URL source error")
+	}
+	if !strings.Contains(err.Error(), "metadata URL sources are not supported yet") {
+		t.Fatalf("unexpected error: %v", err)
 	}
 }
 
@@ -1607,7 +1647,7 @@ func TestSourcePluginGitHubResolverEndToEnd(t *testing.T) {
 	if strings.Contains(string(lockData), `"version": 7`) {
 		t.Fatalf("lockfile = %s, want schema-based versioning", lockData)
 	}
-	if strings.Contains(string(lockData), `"manifest"`) || strings.Contains(string(lockData), `"executable"`) {
+	if strings.Contains(string(lockData), `"manifest":`) || strings.Contains(string(lockData), `"executable":`) {
 		t.Fatalf("lockfile = %s, want portable entries only", lockData)
 	}
 	var diskLock providerLockfile
@@ -1617,6 +1657,18 @@ func TestSourcePluginGitHubResolverEndToEnd(t *testing.T) {
 	diskEntry, ok := diskLock.Providers.Plugin["alpha"]
 	if !ok {
 		t.Fatal(`disk lock providers.plugin["alpha"] not found`)
+	}
+	if diskEntry.InputDigest == "" {
+		t.Fatal("disk lock plugin inputDigest is empty")
+	}
+	if diskEntry.Package != testSource {
+		t.Fatalf("disk lock plugin package = %q, want %q", diskEntry.Package, testSource)
+	}
+	if diskEntry.Kind != providermanifestv1.KindPlugin {
+		t.Fatalf("disk lock plugin kind = %q, want %q", diskEntry.Kind, providermanifestv1.KindPlugin)
+	}
+	if diskEntry.Runtime != providerLockRuntimeExecutable {
+		t.Fatalf("disk lock plugin runtime = %q, want %q", diskEntry.Runtime, providerLockRuntimeExecutable)
 	}
 	if diskEntry.Source != testSource || diskEntry.Version != testVersion {
 		t.Fatalf("disk lock plugin entry = %#v", diskEntry)

--- a/gestaltd/internal/operator/lifecycle_source_test.go
+++ b/gestaltd/internal/operator/lifecycle_source_test.go
@@ -8,6 +8,7 @@ import (
 	"fmt"
 	"net/http"
 	"net/http/httptest"
+	"net/url"
 	"os"
 	"path/filepath"
 	"runtime"
@@ -61,6 +62,12 @@ type fakeResolverCall struct {
 type fakeMultiResolver struct {
 	results map[string]fakeResolverResult
 	calls   []fakeResolverCall
+}
+
+type hostRewriteTransport struct {
+	base   http.RoundTripper
+	target *url.URL
+	hosts  map[string]struct{}
 }
 
 func (f *fakeResolver) Resolve(_ context.Context, src pluginsource.Source, version string) (*pluginsource.ResolvedPackage, error) {
@@ -390,6 +397,33 @@ func TestSourcePluginEndToEnd(t *testing.T) {
 	}
 }
 
+func (t *hostRewriteTransport) RoundTrip(req *http.Request) (*http.Response, error) {
+	clone := req.Clone(req.Context())
+	if _, ok := t.hosts[strings.ToLower(req.URL.Hostname())]; ok {
+		clone.URL.Scheme = t.target.Scheme
+		clone.URL.Host = t.target.Host
+	}
+	return t.base.RoundTrip(clone)
+}
+
+func newGitHubRewriteClient(t *testing.T, target string) *http.Client {
+	t.Helper()
+	targetURL, err := url.Parse(target)
+	if err != nil {
+		t.Fatalf("parse rewrite target URL: %v", err)
+	}
+	return &http.Client{
+		Transport: &hostRewriteTransport{
+			base:   http.DefaultTransport,
+			target: targetURL,
+			hosts: map[string]struct{}{
+				"github.com":     {},
+				"api.github.com": {},
+			},
+		},
+	}
+}
+
 func TestSourcePluginNilResolver(t *testing.T) {
 	t.Parallel()
 
@@ -409,30 +443,255 @@ func TestSourcePluginNilResolver(t *testing.T) {
 	}
 }
 
-func TestSourcePluginMetadataURLNotYetSupported(t *testing.T) {
+func TestSourcePluginMetadataURLInitAndLockedLoad(t *testing.T) {
 	t.Parallel()
 
 	dir := t.TempDir()
+	packageSource := "github.com/acme/tools/alpha"
+	version := "1.2.3"
+	currentArchivePath := buildV2Archive(t, dir, packageSource, version, "metadata-url-plugin-binary")
+	currentArchiveData, err := os.ReadFile(currentArchivePath)
+	if err != nil {
+		t.Fatalf("read current archive: %v", err)
+	}
+	currentArchiveSHA := sha256.Sum256(currentArchiveData)
+
+	extraPlatform := struct {
+		goos   string
+		goarch string
+	}{
+		goos:   "linux",
+		goarch: "amd64",
+	}
+	for _, candidate := range []struct {
+		goos   string
+		goarch string
+	}{
+		{goos: "linux", goarch: "amd64"},
+		{goos: "linux", goarch: "arm64"},
+		{goos: "darwin", goarch: "amd64"},
+		{goos: "darwin", goarch: "arm64"},
+	} {
+		if candidate.goos != runtime.GOOS || candidate.goarch != runtime.GOARCH {
+			extraPlatform = candidate
+			break
+		}
+	}
+	extraPlatformKey := providerpkg.PlatformString(extraPlatform.goos, extraPlatform.goarch)
+	extraArchiveData := []byte("metadata-extra-platform-archive")
+	extraArchiveSHA := sha256.Sum256(extraArchiveData)
+
+	var metadataCount atomic.Int64
+	var currentArchiveCount atomic.Int64
+	var extraArchiveCount atomic.Int64
+	handlerErrs := make(chan error, 4)
+	nextHandlerErr := func() error {
+		t.Helper()
+		select {
+		case err := <-handlerErrs:
+			return err
+		default:
+			return nil
+		}
+	}
+	metadataPath := "/providers/alpha/provider-release.yaml"
+	currentArchivePathURL := "/providers/alpha/alpha-current.tar.gz"
+	extraArchivePathURL := "/providers/alpha/alpha-extra.tar.gz"
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch r.URL.Path {
+		case metadataPath:
+			metadataCount.Add(1)
+			if got := r.Header.Get("Authorization"); got != "Bearer test-token" {
+				handlerErrs <- fmt.Errorf("metadata authorization = %q, want %q", got, "Bearer test-token")
+				http.Error(w, "bad metadata authorization", http.StatusBadRequest)
+				return
+			}
+			metadata := providerReleaseMetadata{
+				Schema:        providerReleaseSchemaName,
+				SchemaVersion: providerReleaseSchemaVersion,
+				Package:       packageSource,
+				Kind:          providermanifestv1.KindPlugin,
+				Version:       version,
+				Runtime:       providerReleaseRuntimeExecutable,
+				Artifacts: map[string]providerReleaseArtifact{
+					providerpkg.CurrentPlatformString(): {
+						Path:   filepath.Base(currentArchivePathURL),
+						SHA256: hex.EncodeToString(currentArchiveSHA[:]),
+					},
+					extraPlatformKey: {
+						Path:   filepath.Base(extraArchivePathURL),
+						SHA256: hex.EncodeToString(extraArchiveSHA[:]),
+					},
+				},
+			}
+			data, err := yaml.Marshal(metadata)
+			if err != nil {
+				handlerErrs <- fmt.Errorf("marshal metadata: %v", err)
+				http.Error(w, "metadata marshal failed", http.StatusInternalServerError)
+				return
+			}
+			w.Header().Set("Content-Type", "application/yaml")
+			_, _ = w.Write(data)
+		case currentArchivePathURL:
+			currentArchiveCount.Add(1)
+			if got := r.Header.Get("Authorization"); got != "Bearer test-token" {
+				handlerErrs <- fmt.Errorf("current archive authorization = %q, want %q", got, "Bearer test-token")
+				http.Error(w, "bad archive authorization", http.StatusBadRequest)
+				return
+			}
+			w.Header().Set("Content-Type", "application/octet-stream")
+			_, _ = w.Write(currentArchiveData)
+		case extraArchivePathURL:
+			extraArchiveCount.Add(1)
+			if got := r.Header.Get("Authorization"); got != "Bearer test-token" {
+				handlerErrs <- fmt.Errorf("extra archive authorization = %q, want %q", got, "Bearer test-token")
+				http.Error(w, "bad archive authorization", http.StatusBadRequest)
+				return
+			}
+			w.Header().Set("Content-Type", "application/octet-stream")
+			_, _ = w.Write(extraArchiveData)
+		default:
+			http.NotFound(w, r)
+		}
+	}))
+	defer srv.Close()
+
+	artifactsDir := filepath.Join(dir, "prepared-artifacts")
 	configPath := filepath.Join(dir, "gestalt.yaml")
-	if err := os.WriteFile(configPath, []byte(`
-apiVersion: gestaltd.config/v3
-plugins:
-  alpha:
-    source: https://example.com/providers/alpha/provider-release.yaml?download=1
-    auth:
-      token: test-token
-server:
-  artifactsDir: `+filepath.Join(dir, "prepared-artifacts")+`
-`), 0o644); err != nil {
+	configYAML := requiredComponentConfigYAML(t, dir, filepath.Join(dir, "data.db")) + strings.Join([]string{
+		"apiVersion: " + config.APIVersionV3,
+		"plugins:",
+		"  alpha:",
+		"    source: " + srv.URL + metadataPath + "?download=1",
+		"    auth:",
+		"      token: test-token",
+		"server:",
+		"  providers:",
+		"    indexeddb: sqlite",
+		"  artifactsDir: " + artifactsDir,
+		"  encryptionKey: aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
+	}, "\n") + "\n"
+	if err := os.WriteFile(configPath, []byte(configYAML), 0o644); err != nil {
 		t.Fatalf("write config: %v", err)
 	}
 
-	_, err := NewLifecycle(&fakeResolver{}).InitAtPath(configPath)
+	lc := NewLifecycle(nil)
+	lock, err := lc.InitAtPathWithPlatforms(configPath, "", []struct{ GOOS, GOARCH, LibC string }{
+		{GOOS: extraPlatform.goos, GOARCH: extraPlatform.goarch},
+	})
 	if err == nil {
-		t.Fatal("expected metadata URL source error")
+		if handlerErr := nextHandlerErr(); handlerErr != nil {
+			t.Fatal(handlerErr)
+		}
 	}
-	if !strings.Contains(err.Error(), "metadata URL sources are not supported yet") {
-		t.Fatalf("unexpected error: %v", err)
+	if err != nil {
+		t.Fatalf("InitAtPathWithPlatforms: %v", err)
+	}
+	if handlerErr := nextHandlerErr(); handlerErr != nil {
+		t.Fatal(handlerErr)
+	}
+
+	entry, ok := lock.Providers["alpha"]
+	if !ok {
+		t.Fatal(`lock.Providers["alpha"] not found`)
+	}
+	if entry.Source != srv.URL+metadataPath+"?download=1" {
+		t.Fatalf("entry.Source = %q, want %q", entry.Source, srv.URL+metadataPath+"?download=1")
+	}
+	if entry.Package != packageSource {
+		t.Fatalf("entry.Package = %q, want %q", entry.Package, packageSource)
+	}
+	if entry.Kind != providermanifestv1.KindPlugin {
+		t.Fatalf("entry.Kind = %q, want %q", entry.Kind, providermanifestv1.KindPlugin)
+	}
+	if entry.Runtime != providerReleaseRuntimeExecutable {
+		t.Fatalf("entry.Runtime = %q, want %q", entry.Runtime, providerReleaseRuntimeExecutable)
+	}
+	if entry.Version != version {
+		t.Fatalf("entry.Version = %q, want %q", entry.Version, version)
+	}
+	if got := entry.Archives[providerpkg.CurrentPlatformString()].URL; got != srv.URL+currentArchivePathURL {
+		t.Fatalf("current archive URL = %q, want %q", got, srv.URL+currentArchivePathURL)
+	}
+	if got := entry.Archives[extraPlatformKey].SHA256; got != hex.EncodeToString(extraArchiveSHA[:]) {
+		t.Fatalf("extra platform SHA256 = %q, want %q", got, hex.EncodeToString(extraArchiveSHA[:]))
+	}
+	if got := metadataCount.Load(); got != 1 {
+		t.Fatalf("metadata request count = %d, want 1", got)
+	}
+	if got := currentArchiveCount.Load(); got != 1 {
+		t.Fatalf("current archive request count = %d, want 1", got)
+	}
+	if got := extraArchiveCount.Load(); got != 0 {
+		t.Fatalf("extra archive request count = %d, want 0", got)
+	}
+
+	lockData, err := os.ReadFile(filepath.Join(dir, InitLockfileName))
+	if err != nil {
+		t.Fatalf("ReadFile lockfile: %v", err)
+	}
+	var diskLock providerLockfile
+	if err := json.Unmarshal(lockData, &diskLock); err != nil {
+		t.Fatalf("Unmarshal lockfile: %v", err)
+	}
+	diskEntry, ok := diskLock.Providers.Plugin["alpha"]
+	if !ok {
+		t.Fatal(`disk lock providers.plugin["alpha"] not found`)
+	}
+	if diskEntry.Package != packageSource {
+		t.Fatalf("disk lock package = %q, want %q", diskEntry.Package, packageSource)
+	}
+	if diskEntry.Source != srv.URL+metadataPath+"?download=1" {
+		t.Fatalf("disk lock source = %q, want %q", diskEntry.Source, srv.URL+metadataPath+"?download=1")
+	}
+	if diskEntry.Runtime != providerReleaseRuntimeExecutable {
+		t.Fatalf("disk lock runtime = %q, want %q", diskEntry.Runtime, providerReleaseRuntimeExecutable)
+	}
+	if diskEntry.Kind != providermanifestv1.KindPlugin {
+		t.Fatalf("disk lock kind = %q, want %q", diskEntry.Kind, providermanifestv1.KindPlugin)
+	}
+	if got := diskEntry.Archives[extraPlatformKey].URL; got != srv.URL+extraArchivePathURL {
+		t.Fatalf("disk lock extra archive URL = %q, want %q", got, srv.URL+extraArchivePathURL)
+	}
+
+	pluginRoot := filepath.Join(artifactsDir, ".gestaltd", "providers", "alpha")
+	if err := os.RemoveAll(pluginRoot); err != nil {
+		t.Fatalf("RemoveAll plugin root: %v", err)
+	}
+
+	metadataBefore := metadataCount.Load()
+	currentBefore := currentArchiveCount.Load()
+	cfg, _, err := lc.LoadForExecutionAtPath(configPath, true)
+	if err != nil {
+		if handlerErr := nextHandlerErr(); handlerErr != nil {
+			t.Fatal(handlerErr)
+		}
+		t.Fatalf("LoadForExecutionAtPath(locked=true): %v", err)
+	}
+	if handlerErr := nextHandlerErr(); handlerErr != nil {
+		t.Fatal(handlerErr)
+	}
+	if got := metadataCount.Load(); got != metadataBefore {
+		t.Fatalf("metadata request count during locked load = %d, want %d", got, metadataBefore)
+	}
+	if got := currentArchiveCount.Load() - currentBefore; got != 1 {
+		t.Fatalf("current archive request count during locked load = %d, want 1", got)
+	}
+	if got := extraArchiveCount.Load(); got != 0 {
+		t.Fatalf("extra archive request count after locked load = %d, want 0", got)
+	}
+	if cfg.Plugins["alpha"] == nil {
+		t.Fatal(`cfg.Plugins["alpha"] = nil`)
+	}
+	if cfg.Plugins["alpha"].ResolvedManifest == nil {
+		t.Fatal(`cfg.Plugins["alpha"].ResolvedManifest = nil`)
+	}
+	if cfg.Plugins["alpha"].ResolvedManifest.Source != packageSource {
+		t.Fatalf("ResolvedManifest.Source = %q, want %q", cfg.Plugins["alpha"].ResolvedManifest.Source, packageSource)
+	}
+	executablePath := resolveLockPath(artifactsDir, entry.Executable)
+	if cfg.Plugins["alpha"].Command != executablePath {
+		t.Fatalf("plugin command = %q, want %q", cfg.Plugins["alpha"].Command, executablePath)
 	}
 }
 
@@ -537,6 +796,375 @@ func TestSourcePluginLoadForExecution(t *testing.T) {
 	}
 	if cfg.Plugins["gadget"].Command != install.executablePath {
 		t.Fatalf("plugin command = %q, want %q", cfg.Plugins["gadget"].Command, install.executablePath)
+	}
+}
+
+func TestSourcePluginInitRejectsRefSourceManifestMismatch(t *testing.T) {
+	t.Parallel()
+
+	dir := t.TempDir()
+	source := "github.com/acme/tools/gadget"
+	version := "2.0.0"
+
+	archivePath := buildV2Archive(t, dir, "github.com/acme/tools/other-gadget", version, "fake-gadget-binary")
+	archiveData, err := os.ReadFile(archivePath)
+	if err != nil {
+		t.Fatalf("read archive: %v", err)
+	}
+	archiveSum := sha256.Sum256(archiveData)
+	archiveSHA := hex.EncodeToString(archiveSum[:])
+
+	resolver := &fakeResolver{
+		archivePath: archivePath,
+		resolvedURL: "https://example.com/plugin.tar.gz",
+		sha256:      archiveSHA,
+	}
+
+	artifactsDir := filepath.Join(dir, "prepared-artifacts")
+	yaml := requiredComponentConfigYAML(t, dir, filepath.Join(dir, "data.db")) + strings.Join([]string{
+		"plugins:",
+		"  gadget:",
+		"    source:",
+		"      ref: " + source,
+		"      version: " + version,
+		"server:",
+		"  providers:",
+		"    indexeddb: sqlite",
+		"  artifactsDir: " + artifactsDir,
+		"  encryptionKey: aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
+	}, "\n") + "\n"
+
+	configPath := filepath.Join(dir, "gestalt.yaml")
+	if err := os.WriteFile(configPath, []byte(yaml), 0o644); err != nil {
+		t.Fatalf("write config: %v", err)
+	}
+
+	lc := NewLifecycle(resolver)
+	_, err = lc.InitAtPath(configPath)
+	if err == nil {
+		t.Fatal("InitAtPath unexpectedly succeeded")
+	}
+	if !strings.Contains(err.Error(), `manifest source "github.com/acme/tools/other-gadget" does not match expected package "github.com/acme/tools/gadget"`) {
+		t.Fatalf("InitAtPath error = %v, want manifest source mismatch", err)
+	}
+}
+
+func TestSourcePluginMetadataURLUsesGitHubAssetTransport(t *testing.T) {
+	dir := t.TempDir()
+
+	const packageSource = testSource
+	const version = testVersion
+
+	currentArchivePath := buildV2Archive(t, dir, packageSource, version, "metadata-github-asset-plugin-binary")
+	currentArchiveData, err := os.ReadFile(currentArchivePath)
+	if err != nil {
+		t.Fatalf("read current archive: %v", err)
+	}
+	currentArchiveSHA := sha256.Sum256(currentArchiveData)
+
+	var metadataCount atomic.Int64
+	var archiveCount atomic.Int64
+	handlerErrs := make(chan error, 4)
+	nextHandlerErr := func() error {
+		t.Helper()
+		select {
+		case err := <-handlerErrs:
+			return err
+		default:
+			return nil
+		}
+	}
+
+	metadataPath := "/providers/alpha/provider-release.yaml"
+	githubArchiveURL := "https://api.github.com/repos/" + testOwner + "/" + testRepo + "/releases/assets/123"
+	githubArchivePath := "/repos/" + testOwner + "/" + testRepo + "/releases/assets/123"
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch r.URL.Path {
+		case metadataPath:
+			metadataCount.Add(1)
+			if got := r.Header.Get("Authorization"); got != "Bearer test-token" {
+				handlerErrs <- fmt.Errorf("metadata authorization = %q, want %q", got, "Bearer test-token")
+				http.Error(w, "bad metadata authorization", http.StatusBadRequest)
+				return
+			}
+			metadata := providerReleaseMetadata{
+				Schema:        providerReleaseSchemaName,
+				SchemaVersion: providerReleaseSchemaVersion,
+				Package:       packageSource,
+				Kind:          providermanifestv1.KindPlugin,
+				Version:       version,
+				Runtime:       providerReleaseRuntimeExecutable,
+				Artifacts: map[string]providerReleaseArtifact{
+					providerpkg.CurrentPlatformString(): {
+						Path:   githubArchiveURL,
+						SHA256: hex.EncodeToString(currentArchiveSHA[:]),
+					},
+				},
+			}
+			data, err := yaml.Marshal(metadata)
+			if err != nil {
+				handlerErrs <- fmt.Errorf("marshal metadata: %v", err)
+				http.Error(w, "metadata marshal failed", http.StatusInternalServerError)
+				return
+			}
+			w.Header().Set("Content-Type", "application/yaml")
+			_, _ = w.Write(data)
+		case githubArchivePath:
+			archiveCount.Add(1)
+			if got := r.Header.Get("Authorization"); got != "token test-token" {
+				handlerErrs <- fmt.Errorf("archive authorization = %q, want %q", got, "token test-token")
+				http.Error(w, "bad archive authorization", http.StatusBadRequest)
+				return
+			}
+			if got := r.Header.Get("Accept"); got != "application/octet-stream" {
+				handlerErrs <- fmt.Errorf("archive accept = %q, want %q", got, "application/octet-stream")
+				http.Error(w, "bad archive accept", http.StatusBadRequest)
+				return
+			}
+			w.Header().Set("Content-Type", "application/octet-stream")
+			_, _ = w.Write(currentArchiveData)
+		default:
+			http.NotFound(w, r)
+		}
+	}))
+	defer srv.Close()
+
+	artifactsDir := filepath.Join(dir, "prepared-artifacts")
+	configPath := filepath.Join(dir, "gestalt.yaml")
+	configYAML := requiredComponentConfigYAML(t, dir, filepath.Join(dir, "data.db")) + strings.Join([]string{
+		"apiVersion: " + config.APIVersionV3,
+		"plugins:",
+		"  alpha:",
+		"    source: " + srv.URL + metadataPath,
+		"    auth:",
+		"      token: test-token",
+		"server:",
+		"  providers:",
+		"    indexeddb: sqlite",
+		"  artifactsDir: " + artifactsDir,
+		"  encryptionKey: aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
+	}, "\n") + "\n"
+	if err := os.WriteFile(configPath, []byte(configYAML), 0o644); err != nil {
+		t.Fatalf("write config: %v", err)
+	}
+
+	lc := NewLifecycle(nil).WithHTTPClient(newGitHubRewriteClient(t, srv.URL))
+	lock, err := lc.InitAtPath(configPath)
+	if err == nil {
+		if handlerErr := nextHandlerErr(); handlerErr != nil {
+			t.Fatal(handlerErr)
+		}
+	}
+	if err != nil {
+		t.Fatalf("InitAtPath: %v", err)
+	}
+	if handlerErr := nextHandlerErr(); handlerErr != nil {
+		t.Fatal(handlerErr)
+	}
+
+	entry, ok := lock.Providers["alpha"]
+	if !ok {
+		t.Fatal(`lock.Providers["alpha"] not found`)
+	}
+	if got := entry.Archives[providerpkg.CurrentPlatformString()].URL; got != githubArchiveURL {
+		t.Fatalf("current archive URL = %q, want %q", got, githubArchiveURL)
+	}
+	if got := metadataCount.Load(); got != 1 {
+		t.Fatalf("metadata request count = %d, want 1", got)
+	}
+	if got := archiveCount.Load(); got != 1 {
+		t.Fatalf("archive request count = %d, want 1", got)
+	}
+
+	pluginRoot := filepath.Join(artifactsDir, ".gestaltd", "providers", "alpha")
+	if err := os.RemoveAll(pluginRoot); err != nil {
+		t.Fatalf("RemoveAll plugin root: %v", err)
+	}
+
+	metadataBefore := metadataCount.Load()
+	archiveBefore := archiveCount.Load()
+	cfg, _, err := lc.LoadForExecutionAtPath(configPath, true)
+	if err == nil {
+		if handlerErr := nextHandlerErr(); handlerErr != nil {
+			t.Fatal(handlerErr)
+		}
+	}
+	if err != nil {
+		t.Fatalf("LoadForExecutionAtPath(locked=true): %v", err)
+	}
+	if handlerErr := nextHandlerErr(); handlerErr != nil {
+		t.Fatal(handlerErr)
+	}
+	if got := metadataCount.Load(); got != metadataBefore {
+		t.Fatalf("metadata request count during locked load = %d, want %d", got, metadataBefore)
+	}
+	if got := archiveCount.Load() - archiveBefore; got != 1 {
+		t.Fatalf("archive request count during locked load = %d, want 1", got)
+	}
+	if cfg.Plugins["alpha"] == nil || cfg.Plugins["alpha"].ResolvedManifest == nil {
+		t.Fatal("resolved metadata plugin manifest missing after locked load")
+	}
+}
+
+func TestSourcePluginMetadataURLUnlockedLoadRefreshesMutableMetadata(t *testing.T) {
+	dir := t.TempDir()
+
+	const packageSource = testSource
+	const initialVersion = "1.0.0"
+	const updatedVersion = "1.0.1"
+
+	initialArchivePath := buildV2Archive(t, dir, packageSource, initialVersion, "metadata-mutable-plugin-v1")
+	initialArchiveData, err := os.ReadFile(initialArchivePath)
+	if err != nil {
+		t.Fatalf("read initial archive: %v", err)
+	}
+	initialArchiveSHA := sha256.Sum256(initialArchiveData)
+
+	updatedArchivePath := buildV2Archive(t, dir, packageSource, updatedVersion, "metadata-mutable-plugin-v2")
+	updatedArchiveData, err := os.ReadFile(updatedArchivePath)
+	if err != nil {
+		t.Fatalf("read updated archive: %v", err)
+	}
+	updatedArchiveSHA := sha256.Sum256(updatedArchiveData)
+
+	var metadataCount atomic.Int64
+	var archiveCount atomic.Int64
+	currentVersion := initialVersion
+	currentArchiveData := initialArchiveData
+	currentArchiveSHA := initialArchiveSHA
+
+	handlerErrs := make(chan error, 4)
+	nextHandlerErr := func() error {
+		t.Helper()
+		select {
+		case err := <-handlerErrs:
+			return err
+		default:
+			return nil
+		}
+	}
+
+	metadataPath := "/providers/alpha/provider-release.yaml"
+	currentArchivePathURL := "/providers/alpha/alpha-current.tar.gz"
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch r.URL.Path {
+		case metadataPath:
+			metadataCount.Add(1)
+			if got := r.Header.Get("Authorization"); got != "Bearer test-token" {
+				handlerErrs <- fmt.Errorf("metadata authorization = %q, want %q", got, "Bearer test-token")
+				http.Error(w, "bad metadata authorization", http.StatusBadRequest)
+				return
+			}
+			metadata := providerReleaseMetadata{
+				Schema:        providerReleaseSchemaName,
+				SchemaVersion: providerReleaseSchemaVersion,
+				Package:       packageSource,
+				Kind:          providermanifestv1.KindPlugin,
+				Version:       currentVersion,
+				Runtime:       providerReleaseRuntimeExecutable,
+				Artifacts: map[string]providerReleaseArtifact{
+					providerpkg.CurrentPlatformString(): {
+						Path:   filepath.Base(currentArchivePathURL),
+						SHA256: hex.EncodeToString(currentArchiveSHA[:]),
+					},
+				},
+			}
+			data, err := yaml.Marshal(metadata)
+			if err != nil {
+				handlerErrs <- fmt.Errorf("marshal metadata: %v", err)
+				http.Error(w, "metadata marshal failed", http.StatusInternalServerError)
+				return
+			}
+			w.Header().Set("Content-Type", "application/yaml")
+			_, _ = w.Write(data)
+		case currentArchivePathURL:
+			archiveCount.Add(1)
+			if got := r.Header.Get("Authorization"); got != "Bearer test-token" {
+				handlerErrs <- fmt.Errorf("archive authorization = %q, want %q", got, "Bearer test-token")
+				http.Error(w, "bad archive authorization", http.StatusBadRequest)
+				return
+			}
+			w.Header().Set("Content-Type", "application/octet-stream")
+			_, _ = w.Write(currentArchiveData)
+		default:
+			http.NotFound(w, r)
+		}
+	}))
+	defer srv.Close()
+
+	artifactsDir := filepath.Join(dir, "prepared-artifacts")
+	configPath := filepath.Join(dir, "gestalt.yaml")
+	configYAML := requiredComponentConfigYAML(t, dir, filepath.Join(dir, "data.db")) + strings.Join([]string{
+		"apiVersion: " + config.APIVersionV3,
+		"plugins:",
+		"  alpha:",
+		"    source: " + srv.URL + metadataPath,
+		"    auth:",
+		"      token: test-token",
+		"server:",
+		"  providers:",
+		"    indexeddb: sqlite",
+		"  artifactsDir: " + artifactsDir,
+		"  encryptionKey: aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
+	}, "\n") + "\n"
+	if err := os.WriteFile(configPath, []byte(configYAML), 0o644); err != nil {
+		t.Fatalf("write config: %v", err)
+	}
+
+	lc := NewLifecycle(nil)
+	lock, err := lc.InitAtPath(configPath)
+	if err == nil {
+		if handlerErr := nextHandlerErr(); handlerErr != nil {
+			t.Fatal(handlerErr)
+		}
+	}
+	if err != nil {
+		t.Fatalf("InitAtPath: %v", err)
+	}
+	if handlerErr := nextHandlerErr(); handlerErr != nil {
+		t.Fatal(handlerErr)
+	}
+	if got := lock.Providers["alpha"].Version; got != initialVersion {
+		t.Fatalf("initial lock version = %q, want %q", got, initialVersion)
+	}
+
+	currentVersion = updatedVersion
+	currentArchiveData = updatedArchiveData
+	currentArchiveSHA = updatedArchiveSHA
+
+	metadataBefore := metadataCount.Load()
+	archiveBefore := archiveCount.Load()
+	cfg, _, err := lc.LoadForExecutionAtPath(configPath, false)
+	if err == nil {
+		if handlerErr := nextHandlerErr(); handlerErr != nil {
+			t.Fatal(handlerErr)
+		}
+	}
+	if err != nil {
+		t.Fatalf("LoadForExecutionAtPath(locked=false): %v", err)
+	}
+	if handlerErr := nextHandlerErr(); handlerErr != nil {
+		t.Fatal(handlerErr)
+	}
+	if got := metadataCount.Load(); got <= metadataBefore {
+		t.Fatalf("metadata request count after unlocked load = %d, want > %d", got, metadataBefore)
+	}
+	if got := archiveCount.Load(); got <= archiveBefore {
+		t.Fatalf("archive request count after unlocked load = %d, want > %d", got, archiveBefore)
+	}
+	if cfg.Plugins["alpha"] == nil || cfg.Plugins["alpha"].ResolvedManifest == nil {
+		t.Fatal("resolved metadata plugin manifest missing after unlocked refresh")
+	}
+	if got := cfg.Plugins["alpha"].ResolvedManifest.Version; got != updatedVersion {
+		t.Fatalf("resolved manifest version after unlocked refresh = %q, want %q", got, updatedVersion)
+	}
+
+	updatedLock, err := ReadLockfile(filepath.Join(dir, InitLockfileName))
+	if err != nil {
+		t.Fatalf("ReadLockfile: %v", err)
+	}
+	if got := updatedLock.Providers["alpha"].Version; got != updatedVersion {
+		t.Fatalf("updated lock version = %q, want %q", got, updatedVersion)
 	}
 }
 

--- a/gestaltd/internal/operator/lifecycle_test.go
+++ b/gestaltd/internal/operator/lifecycle_test.go
@@ -235,6 +235,22 @@ func TestLoadForExecutionAtPath_ResolvesLocalManifestPluginWithoutLockfile(t *te
 	if _, err := os.Stat(filepath.Join(dir, InitLockfileName)); !os.IsNotExist(err) {
 		t.Fatalf("lockfile should not be created, got err=%v", err)
 	}
+
+	_, _, err = lc.LoadForExecutionAtPath(cfgPath, true)
+	if err == nil {
+		t.Fatal("LoadForExecutionAtPath(locked=true) unexpectedly succeeded")
+	}
+	if !strings.Contains(err.Error(), "local plugin and UI sources are not supported during locked execution") {
+		t.Fatalf("LoadForExecutionAtPath(locked=true) error = %v, want locked local source rejection", err)
+	}
+
+	_, err = lc.InitAtPath(cfgPath)
+	if err == nil {
+		t.Fatal("InitAtPath unexpectedly succeeded")
+	}
+	if !strings.Contains(err.Error(), "local plugin and UI sources are not supported during init") {
+		t.Fatalf("InitAtPath error = %v, want init local source rejection", err)
+	}
 }
 
 func TestLoadForExecutionAtPath_ResolvesLocalMCPOAuthManifestPluginWithoutLockfile(t *testing.T) {
@@ -570,6 +586,73 @@ plugins:
 				t.Fatalf("lockfile should not be created, got err=%v", err)
 			}
 		})
+	}
+}
+
+func TestLoadForExecutionAtPath_RejectsLocalMountedWebUILockedAndDuringInit(t *testing.T) {
+	t.Parallel()
+
+	dir := t.TempDir()
+	webUIDir := filepath.Join(dir, "webui")
+	if err := os.MkdirAll(filepath.Join(webUIDir, "dist"), 0o755); err != nil {
+		t.Fatalf("MkdirAll webui dist: %v", err)
+	}
+	if err := os.WriteFile(filepath.Join(webUIDir, "dist", "index.html"), []byte("<html>roadmap</html>"), 0o644); err != nil {
+		t.Fatalf("WriteFile index.html: %v", err)
+	}
+	manifestPath := filepath.Join(webUIDir, "manifest.yaml")
+	manifest, err := providerpkg.EncodeSourceManifestFormat(&providermanifestv1.Manifest{
+		Kind:        providermanifestv1.KindWebUI,
+		Source:      "github.com/testowner/web/roadmap",
+		Version:     "0.0.1-alpha.1",
+		DisplayName: "Roadmap UI",
+		Spec: &providermanifestv1.Spec{
+			AssetRoot: "dist",
+		},
+	}, providerpkg.ManifestFormatYAML)
+	if err != nil {
+		t.Fatalf("EncodeManifest: %v", err)
+	}
+	if err := os.WriteFile(manifestPath, manifest, 0o644); err != nil {
+		t.Fatalf("WriteFile manifest: %v", err)
+	}
+
+	cfgPath := filepath.Join(dir, "config.yaml")
+	cfg := requiredComponentConfigYAML(t, dir, filepath.Join(dir, "gestalt.db")) + `  ui:
+    roadmap:
+      source:
+        path: ./webui/manifest.yaml
+      path: /create-customer-roadmap-review
+` + `server:
+` + requiredServerDatastoreYAML() + `  encryptionKey: aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa
+`
+	if err := os.WriteFile(cfgPath, []byte(cfg), 0o644); err != nil {
+		t.Fatalf("WriteFile config: %v", err)
+	}
+
+	lc := NewLifecycle(nil)
+	loaded, _, err := lc.LoadForExecutionAtPath(cfgPath, false)
+	if err != nil {
+		t.Fatalf("LoadForExecutionAtPath(locked=false): %v", err)
+	}
+	if loaded.Providers.UI["roadmap"] == nil || loaded.Providers.UI["roadmap"].ResolvedManifest == nil {
+		t.Fatal("resolved local ui manifest missing after unlocked load")
+	}
+
+	_, _, err = lc.LoadForExecutionAtPath(cfgPath, true)
+	if err == nil {
+		t.Fatal("LoadForExecutionAtPath(locked=true) unexpectedly succeeded")
+	}
+	if !strings.Contains(err.Error(), "local plugin and UI sources are not supported during locked execution") {
+		t.Fatalf("LoadForExecutionAtPath(locked=true) error = %v, want locked local ui rejection", err)
+	}
+
+	_, err = lc.InitAtPath(cfgPath)
+	if err == nil {
+		t.Fatal("InitAtPath unexpectedly succeeded")
+	}
+	if !strings.Contains(err.Error(), "local plugin and UI sources are not supported during init") {
+		t.Fatalf("InitAtPath error = %v, want init local ui rejection", err)
 	}
 }
 

--- a/gestaltd/internal/operator/lifecycle_test.go
+++ b/gestaltd/internal/operator/lifecycle_test.go
@@ -2668,6 +2668,46 @@ func TestReadLockfile_RejectsLegacyUILockShapeBeforeUnmarshal(t *testing.T) {
 	}
 }
 
+func TestReadLockfile_AcceptsSchemaV1PortableEntries(t *testing.T) {
+	t.Parallel()
+
+	dir := t.TempDir()
+	lockPath := filepath.Join(dir, InitLockfileName)
+	legacy := `{
+  "schema": "gestaltd-provider-lock",
+  "schemaVersion": 1,
+  "revision": 0,
+  "providers": {
+    "plugin": {
+      "example": {
+        "fingerprint": "provider-fp",
+        "source": "github.com/test-org/test-repo/test-plugin",
+        "version": "1.0.0"
+      }
+    }
+  }
+}
+`
+	if err := os.WriteFile(lockPath, []byte(legacy), 0o644); err != nil {
+		t.Fatalf("WriteFile: %v", err)
+	}
+
+	lock, err := ReadLockfile(lockPath)
+	if err != nil {
+		t.Fatalf("ReadLockfile: %v", err)
+	}
+	entry, ok := lock.Providers["example"]
+	if !ok {
+		t.Fatal(`lock.Providers["example"] not found`)
+	}
+	if entry.Fingerprint != "provider-fp" {
+		t.Fatalf("Fingerprint = %q, want %q", entry.Fingerprint, "provider-fp")
+	}
+	if entry.Source != "github.com/test-org/test-repo/test-plugin" || entry.Version != "1.0.0" {
+		t.Fatalf("entry = %#v", entry)
+	}
+}
+
 func mustBuildManagedProviderPackage(t *testing.T, dir string, manifest *providermanifestv1.Manifest, artifacts map[string]string, includeCatalog bool) string {
 	t.Helper()
 
@@ -2778,6 +2818,18 @@ func TestReadWriteLockfile_RoundTrip(t *testing.T) {
 				Executable: ".gestaltd/providers/example/artifacts/darwin/arm64/provider",
 			},
 		},
+		Auth: map[string]LockEntry{
+			"oauth": {
+				Fingerprint: "auth-fp",
+				Source:      "github.com/test-org/test-repo/auth-oauth",
+				Version:     "1.0.1",
+				Archives: map[string]LockArchive{
+					"darwin/arm64": {URL: "https://example.com/auth-oauth.tar.gz", SHA256: "auth123"},
+				},
+				Manifest:   ".gestaltd/providers/auth/oauth/manifest.json",
+				Executable: ".gestaltd/providers/auth/oauth/artifacts/darwin/arm64/auth-oauth",
+			},
+		},
 		IndexedDBs: map[string]LockEntry{
 			"main": {
 				Fingerprint: "indexeddb-main-fp",
@@ -2827,8 +2879,57 @@ func TestReadWriteLockfile_RoundTrip(t *testing.T) {
 	if strings.Contains(string(lockData), `"version": 7`) {
 		t.Fatalf("lockfile = %s, want schema-based versioning", lockData)
 	}
-	if strings.Contains(string(lockData), `"manifest"`) || strings.Contains(string(lockData), `"executable"`) || strings.Contains(string(lockData), `"assetRoot"`) {
+	if strings.Contains(string(lockData), `"manifest":`) || strings.Contains(string(lockData), `"executable":`) || strings.Contains(string(lockData), `"assetRoot":`) {
 		t.Fatalf("lockfile = %s, want portable entries only", lockData)
+	}
+	var diskLock providerLockfile
+	if err := json.Unmarshal(lockData, &diskLock); err != nil {
+		t.Fatalf("Unmarshal lockfile: %v", err)
+	}
+	providerEntry, ok := diskLock.Providers.Plugin["example"]
+	if !ok {
+		t.Fatal(`disk lock providers.plugin["example"] not found`)
+	}
+	if providerEntry.InputDigest != want.Providers["example"].Fingerprint {
+		t.Fatalf("provider inputDigest = %q, want %q", providerEntry.InputDigest, want.Providers["example"].Fingerprint)
+	}
+	if providerEntry.Package != want.Providers["example"].Source {
+		t.Fatalf("provider package = %q, want %q", providerEntry.Package, want.Providers["example"].Source)
+	}
+	if providerEntry.Kind != providermanifestv1.KindPlugin {
+		t.Fatalf("provider kind = %q, want %q", providerEntry.Kind, providermanifestv1.KindPlugin)
+	}
+	if providerEntry.Runtime != providerLockRuntimeExecutable {
+		t.Fatalf("provider runtime = %q, want %q", providerEntry.Runtime, providerLockRuntimeExecutable)
+	}
+	authEntry, ok := diskLock.Providers.Auth["oauth"]
+	if !ok {
+		t.Fatal(`disk lock providers.auth["oauth"] not found`)
+	}
+	if authEntry.InputDigest != want.Auth["oauth"].Fingerprint {
+		t.Fatalf("auth inputDigest = %q, want %q", authEntry.InputDigest, want.Auth["oauth"].Fingerprint)
+	}
+	if authEntry.Package != want.Auth["oauth"].Source {
+		t.Fatalf("auth package = %q, want %q", authEntry.Package, want.Auth["oauth"].Source)
+	}
+	if authEntry.Kind != providermanifestv1.KindAuth {
+		t.Fatalf("auth kind = %q, want %q", authEntry.Kind, providermanifestv1.KindAuth)
+	}
+	if authEntry.Runtime != providerLockRuntimeExecutable {
+		t.Fatalf("auth runtime = %q, want %q", authEntry.Runtime, providerLockRuntimeExecutable)
+	}
+	uiEntry, ok := diskLock.Providers.WebUI["roadmap"]
+	if !ok {
+		t.Fatal(`disk lock providers.webui["roadmap"] not found`)
+	}
+	if uiEntry.InputDigest != want.UIs["roadmap"].Fingerprint {
+		t.Fatalf("ui inputDigest = %q, want %q", uiEntry.InputDigest, want.UIs["roadmap"].Fingerprint)
+	}
+	if uiEntry.Kind != providermanifestv1.KindWebUI {
+		t.Fatalf("ui kind = %q, want %q", uiEntry.Kind, providermanifestv1.KindWebUI)
+	}
+	if uiEntry.Runtime != providerLockRuntimeAssets {
+		t.Fatalf("ui runtime = %q, want %q", uiEntry.Runtime, providerLockRuntimeAssets)
 	}
 
 	got, err := ReadLockfile(lockPath)
@@ -2843,6 +2944,9 @@ func TestReadWriteLockfile_RoundTrip(t *testing.T) {
 	}
 	if got.Providers["example"].Source != want.Providers["example"].Source || got.Providers["example"].Version != want.Providers["example"].Version {
 		t.Fatal("provider source mismatch")
+	}
+	if got.Auth["oauth"].Fingerprint != want.Auth["oauth"].Fingerprint {
+		t.Fatal("auth fingerprint mismatch")
 	}
 	if got.IndexedDBs["main"].Fingerprint != want.IndexedDBs["main"].Fingerprint {
 		t.Fatal("indexeddb fingerprint mismatch")

--- a/gestaltd/internal/operator/lifecycle_test.go
+++ b/gestaltd/internal/operator/lifecycle_test.go
@@ -1765,7 +1765,7 @@ func TestHashPlatformInEntries_HashesMountedWebUIAndProviderArchives(t *testing.
 		},
 	}
 
-	if err := hashPlatformInEntries(context.Background(), lock, initPaths{}, providerpkg.CurrentPlatformString(), map[string]string{}); err != nil {
+	if err := NewLifecycle(nil).hashPlatformInEntries(context.Background(), lock, initPaths{}, providerpkg.CurrentPlatformString(), map[string]string{}); err != nil {
 		t.Fatalf("hashPlatformInEntries: %v", err)
 	}
 
@@ -3019,7 +3019,7 @@ func TestHashArchiveEntry_HashesFallbackArchive(t *testing.T) {
 		},
 	}
 
-	if err := hashArchiveEntry(context.Background(), providermanifestv1.KindWebUI, "roadmap", &entry, initPaths{}, "linux/amd64", nil); err != nil {
+	if err := NewLifecycle(nil).hashArchiveEntry(context.Background(), providermanifestv1.KindWebUI, "roadmap", &entry, initPaths{}, "linux/amd64", nil); err != nil {
 		t.Fatalf("hashArchiveEntry: %v", err)
 	}
 

--- a/gestaltd/internal/operator/lockschema.go
+++ b/gestaltd/internal/operator/lockschema.go
@@ -8,13 +8,15 @@ import (
 )
 
 const (
-	providerLockSchemaName        = "gestaltd-provider-lock"
-	providerLockSchemaVersion     = 2
-	providerLockRevision          = 0
-	providerLockKindTelemetry     = "telemetry"
-	providerLockKindAudit         = "audit"
-	providerLockRuntimeExecutable = "executable"
-	providerLockRuntimeAssets     = "assets"
+	providerLockSchemaName         = "gestaltd-provider-lock"
+	providerLockSchemaVersion      = 2
+	providerLockRevision           = 0
+	providerLockKindTelemetry      = "telemetry"
+	providerLockKindAudit          = "audit"
+	providerLockRuntimeExecutable  = providerReleaseRuntimeExecutable
+	providerLockRuntimeDeclarative = providerReleaseRuntimeDeclarative
+	providerLockRuntimeWebUI       = providerReleaseRuntimeWebUI
+	providerLockRuntimeAssets      = providerLockRuntimeWebUI
 )
 
 type providerLockfile struct {
@@ -201,9 +203,9 @@ func portableEntriesFromLockEntries(entries map[string]LockEntry, kind string) m
 	for name, entry := range entries {
 		portable[name] = portableLockEntry{
 			InputDigest: entry.Fingerprint,
-			Package:     entry.Source,
-			Kind:        kind,
-			Runtime:     portableRuntimeForKind(kind),
+			Package:     lockEntryPackage(entry),
+			Kind:        lockEntryKind(entry, kind),
+			Runtime:     lockEntryRuntime(entry, kind),
 			Source:      entry.Source,
 			Version:     entry.Version,
 			Archives:    maps.Clone(entry.Archives),
@@ -224,17 +226,13 @@ func lockEntriesFromPortableEntries(entries map[string]portableLockEntry) map[st
 		}
 		runtimeEntries[name] = LockEntry{
 			Fingerprint: fingerprint,
+			Package:     entry.Package,
+			Kind:        entry.Kind,
+			Runtime:     entry.Runtime,
 			Source:      entry.Source,
 			Version:     entry.Version,
 			Archives:    maps.Clone(entry.Archives),
 		}
 	}
 	return runtimeEntries
-}
-
-func portableRuntimeForKind(kind string) string {
-	if kind == providermanifestv1.KindWebUI {
-		return providerLockRuntimeAssets
-	}
-	return providerLockRuntimeExecutable
 }

--- a/gestaltd/internal/operator/lockschema.go
+++ b/gestaltd/internal/operator/lockschema.go
@@ -8,11 +8,13 @@ import (
 )
 
 const (
-	providerLockSchemaName    = "gestaltd-provider-lock"
-	providerLockSchemaVersion = 1
-	providerLockRevision      = 0
-	providerLockKindTelemetry = "telemetry"
-	providerLockKindAudit     = "audit"
+	providerLockSchemaName        = "gestaltd-provider-lock"
+	providerLockSchemaVersion     = 2
+	providerLockRevision          = 0
+	providerLockKindTelemetry     = "telemetry"
+	providerLockKindAudit         = "audit"
+	providerLockRuntimeExecutable = "executable"
+	providerLockRuntimeAssets     = "assets"
 )
 
 type providerLockfile struct {
@@ -35,7 +37,11 @@ type providerLockBuckets struct {
 }
 
 type portableLockEntry struct {
-	Fingerprint string                 `json:"fingerprint"`
+	InputDigest string                 `json:"inputDigest,omitempty"`
+	Fingerprint string                 `json:"fingerprint,omitempty"`
+	Package     string                 `json:"package"`
+	Kind        string                 `json:"kind"`
+	Runtime     string                 `json:"runtime"`
 	Source      string                 `json:"source,omitempty"`
 	Version     string                 `json:"version,omitempty"`
 	Archives    map[string]LockArchive `json:"archives,omitempty"`
@@ -142,15 +148,15 @@ func providerLockfileFromLockfile(lock *Lockfile) *providerLockfile {
 		SchemaVersion: providerLockSchemaVersion,
 		Revision:      providerLockRevision,
 		Providers: providerLockBuckets{
-			Plugin:    portableEntriesFromLockEntries(lock.Providers),
-			Auth:      portableEntriesFromLockEntries(lock.Auth),
-			IndexedDB: portableEntriesFromLockEntries(lock.IndexedDBs),
-			Cache:     portableEntriesFromLockEntries(lock.Caches),
-			S3:        portableEntriesFromLockEntries(lock.S3),
-			Secrets:   portableEntriesFromLockEntries(lock.Secrets),
-			Telemetry: portableEntriesFromLockEntries(lock.Telemetry),
-			Audit:     portableEntriesFromLockEntries(lock.Audit),
-			WebUI:     portableEntriesFromLockEntries(lock.UIs),
+			Plugin:    portableEntriesFromLockEntries(lock.Providers, providermanifestv1.KindPlugin),
+			Auth:      portableEntriesFromLockEntries(lock.Auth, providermanifestv1.KindAuth),
+			IndexedDB: portableEntriesFromLockEntries(lock.IndexedDBs, providermanifestv1.KindIndexedDB),
+			Cache:     portableEntriesFromLockEntries(lock.Caches, providermanifestv1.KindCache),
+			S3:        portableEntriesFromLockEntries(lock.S3, providermanifestv1.KindS3),
+			Secrets:   portableEntriesFromLockEntries(lock.Secrets, providermanifestv1.KindSecrets),
+			Telemetry: portableEntriesFromLockEntries(lock.Telemetry, providerLockKindTelemetry),
+			Audit:     portableEntriesFromLockEntries(lock.Audit, providerLockKindAudit),
+			WebUI:     portableEntriesFromLockEntries(lock.UIs, providermanifestv1.KindWebUI),
 		},
 	}
 }
@@ -179,20 +185,25 @@ func validateProviderLockfile(lock *providerLockfile) error {
 	if lock.Schema != providerLockSchemaName {
 		return fmt.Errorf("unsupported lockfile schema %q; run `gestaltd init` to upgrade", lock.Schema)
 	}
-	if lock.SchemaVersion != providerLockSchemaVersion {
+	switch lock.SchemaVersion {
+	case 1, providerLockSchemaVersion:
+	default:
 		return fmt.Errorf("unsupported lockfile schema version %d; run `gestaltd init` to upgrade", lock.SchemaVersion)
 	}
 	return nil
 }
 
-func portableEntriesFromLockEntries(entries map[string]LockEntry) map[string]portableLockEntry {
+func portableEntriesFromLockEntries(entries map[string]LockEntry, kind string) map[string]portableLockEntry {
 	if len(entries) == 0 {
 		return nil
 	}
 	portable := make(map[string]portableLockEntry, len(entries))
 	for name, entry := range entries {
 		portable[name] = portableLockEntry{
-			Fingerprint: entry.Fingerprint,
+			InputDigest: entry.Fingerprint,
+			Package:     entry.Source,
+			Kind:        kind,
+			Runtime:     portableRuntimeForKind(kind),
 			Source:      entry.Source,
 			Version:     entry.Version,
 			Archives:    maps.Clone(entry.Archives),
@@ -207,12 +218,23 @@ func lockEntriesFromPortableEntries(entries map[string]portableLockEntry) map[st
 	}
 	runtimeEntries := make(map[string]LockEntry, len(entries))
 	for name, entry := range entries {
+		fingerprint := entry.InputDigest
+		if fingerprint == "" {
+			fingerprint = entry.Fingerprint
+		}
 		runtimeEntries[name] = LockEntry{
-			Fingerprint: entry.Fingerprint,
+			Fingerprint: fingerprint,
 			Source:      entry.Source,
 			Version:     entry.Version,
 			Archives:    maps.Clone(entry.Archives),
 		}
 	}
 	return runtimeEntries
+}
+
+func portableRuntimeForKind(kind string) string {
+	if kind == providermanifestv1.KindWebUI {
+		return providerLockRuntimeAssets
+	}
+	return providerLockRuntimeExecutable
 }

--- a/gestaltd/internal/operator/release_metadata.go
+++ b/gestaltd/internal/operator/release_metadata.go
@@ -1,0 +1,254 @@
+package operator
+
+import (
+	"bytes"
+	"context"
+	"fmt"
+	"io"
+	"net/http"
+	"net/url"
+	"strings"
+
+	"github.com/valon-technologies/gestalt/server/internal/config"
+	"github.com/valon-technologies/gestalt/server/internal/pluginsource"
+	ghresolver "github.com/valon-technologies/gestalt/server/internal/pluginsource/github"
+	"github.com/valon-technologies/gestalt/server/internal/providerpkg"
+	providermanifestv1 "github.com/valon-technologies/gestalt/server/sdk/providermanifest/v1"
+	"gopkg.in/yaml.v3"
+)
+
+const (
+	providerReleaseSchemaName         = "gestaltd-provider-release"
+	providerReleaseSchemaVersion      = 1
+	providerReleaseRuntimeExecutable  = "executable"
+	providerReleaseRuntimeDeclarative = "declarative"
+	providerReleaseRuntimeWebUI       = "webui"
+	providerReleaseMetadataMaxBytes   = 4 << 20
+	httpAuthorizationHeader           = "Authorization"
+	httpBearerAuthorizationPrefix     = "Bearer "
+)
+
+type providerReleaseMetadata struct {
+	Schema        string                             `yaml:"schema"`
+	SchemaVersion int                                `yaml:"schemaVersion"`
+	Package       string                             `yaml:"package"`
+	Kind          string                             `yaml:"kind"`
+	Version       string                             `yaml:"version"`
+	Runtime       string                             `yaml:"runtime"`
+	Artifacts     map[string]providerReleaseArtifact `yaml:"artifacts,omitempty"`
+}
+
+type providerReleaseArtifact struct {
+	Path   string `yaml:"path"`
+	SHA256 string `yaml:"sha256"`
+}
+
+func sourceAuthToken(entry *config.ProviderEntry) string {
+	if entry == nil || entry.Source.Auth == nil {
+		return ""
+	}
+	return strings.TrimSpace(entry.Source.Auth.Token)
+}
+
+func decodeProviderReleaseMetadata(data []byte) (*providerReleaseMetadata, error) {
+	var metadata providerReleaseMetadata
+	decoder := yaml.NewDecoder(bytes.NewReader(data))
+	decoder.KnownFields(true)
+	if err := decoder.Decode(&metadata); err != nil {
+		return nil, fmt.Errorf("decode provider release metadata: %w", err)
+	}
+	if err := validateProviderReleaseMetadata(&metadata); err != nil {
+		return nil, err
+	}
+	return &metadata, nil
+}
+
+func validateProviderReleaseMetadata(metadata *providerReleaseMetadata) error {
+	if metadata == nil {
+		return fmt.Errorf("provider release metadata is required")
+	}
+	if metadata.Schema != providerReleaseSchemaName {
+		return fmt.Errorf("unsupported provider release schema %q", metadata.Schema)
+	}
+	if metadata.SchemaVersion != providerReleaseSchemaVersion {
+		return fmt.Errorf("unsupported provider release schema version %d", metadata.SchemaVersion)
+	}
+	if _, err := pluginsource.Parse(strings.TrimSpace(metadata.Package)); err != nil {
+		return fmt.Errorf("provider release package: %w", err)
+	}
+	if err := pluginsource.ValidateVersion(strings.TrimSpace(metadata.Version)); err != nil {
+		return fmt.Errorf("provider release version: %w", err)
+	}
+	switch metadata.Kind {
+	case providermanifestv1.KindPlugin, providermanifestv1.KindAuth, providermanifestv1.KindIndexedDB, providermanifestv1.KindCache, providermanifestv1.KindS3, providermanifestv1.KindSecrets, providermanifestv1.KindWebUI:
+	default:
+		return fmt.Errorf("provider release kind %q is not supported", metadata.Kind)
+	}
+	switch metadata.Runtime {
+	case providerReleaseRuntimeExecutable:
+		if metadata.Kind == providermanifestv1.KindWebUI {
+			return fmt.Errorf("provider release runtime %q is invalid for kind %q", metadata.Runtime, metadata.Kind)
+		}
+	case providerReleaseRuntimeDeclarative:
+		if metadata.Kind != providermanifestv1.KindPlugin {
+			return fmt.Errorf("provider release runtime %q is only valid for kind %q", metadata.Runtime, providermanifestv1.KindPlugin)
+		}
+	case providerReleaseRuntimeWebUI:
+		if metadata.Kind != providermanifestv1.KindWebUI {
+			return fmt.Errorf("provider release runtime %q is only valid for kind %q", metadata.Runtime, providermanifestv1.KindWebUI)
+		}
+	default:
+		return fmt.Errorf("provider release runtime %q is not supported", metadata.Runtime)
+	}
+	if len(metadata.Artifacts) == 0 {
+		return fmt.Errorf("provider release artifacts are required")
+	}
+	for target, artifact := range metadata.Artifacts {
+		switch {
+		case strings.TrimSpace(target) == "":
+			return fmt.Errorf("provider release artifact target is required")
+		case target != platformKeyGeneric:
+			if _, _, err := providerpkg.ParsePlatformString(target); err != nil {
+				return fmt.Errorf("provider release artifact target %q: %w", target, err)
+			}
+		}
+		if strings.TrimSpace(artifact.Path) == "" {
+			return fmt.Errorf("provider release artifact path is required for target %q", target)
+		}
+		if strings.TrimSpace(artifact.SHA256) == "" {
+			return fmt.Errorf("provider release artifact sha256 is required for target %q", target)
+		}
+	}
+	return nil
+}
+
+func fetchProviderReleaseMetadata(ctx context.Context, client *http.Client, metadataURL, token string) (*providerReleaseMetadata, error) {
+	if client == nil {
+		client = http.DefaultClient
+	}
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, metadataURL, nil)
+	if err != nil {
+		return nil, fmt.Errorf("create provider release metadata request: %w", err)
+	}
+	token = strings.TrimSpace(token)
+	if token != "" {
+		req.Header.Set(httpAuthorizationHeader, httpBearerAuthorizationPrefix+token)
+	}
+	resp, err := client.Do(req)
+	if err != nil {
+		return nil, fmt.Errorf("fetch provider release metadata: %w", err)
+	}
+	defer func() { _ = resp.Body.Close() }()
+	if resp.StatusCode != http.StatusOK {
+		return nil, fmt.Errorf("unexpected status %d fetching provider release metadata from %s", resp.StatusCode, metadataURL)
+	}
+	data, err := io.ReadAll(io.LimitReader(resp.Body, providerReleaseMetadataMaxBytes+1))
+	if err != nil {
+		return nil, fmt.Errorf("read provider release metadata: %w", err)
+	}
+	if len(data) > providerReleaseMetadataMaxBytes {
+		return nil, fmt.Errorf("provider release metadata exceeds %d byte limit", providerReleaseMetadataMaxBytes)
+	}
+	return decodeProviderReleaseMetadata(data)
+}
+
+func providerReleaseArchives(metadataURL string, metadata *providerReleaseMetadata) (map[string]LockArchive, error) {
+	if metadata == nil {
+		return nil, fmt.Errorf("provider release metadata is required")
+	}
+	baseURL, err := url.Parse(metadataURL)
+	if err != nil {
+		return nil, fmt.Errorf("parse provider release metadata URL: %w", err)
+	}
+	archives := make(map[string]LockArchive, len(metadata.Artifacts))
+	for target, artifact := range metadata.Artifacts {
+		artifactURL, err := url.Parse(strings.TrimSpace(artifact.Path))
+		if err != nil {
+			return nil, fmt.Errorf("parse provider release artifact path for target %q: %w", target, err)
+		}
+		archives[target] = LockArchive{
+			URL:    baseURL.ResolveReference(artifactURL).String(),
+			SHA256: strings.TrimSpace(artifact.SHA256),
+		}
+	}
+	return archives, nil
+}
+
+func lockEntryPackage(entry LockEntry) string {
+	if value := strings.TrimSpace(entry.Package); value != "" {
+		return value
+	}
+	return strings.TrimSpace(entry.Source)
+}
+
+func lockEntryKind(entry LockEntry, fallback string) string {
+	if value := strings.TrimSpace(entry.Kind); value != "" {
+		return value
+	}
+	switch fallback {
+	case providerLockKindTelemetry, providerLockKindAudit:
+		return providermanifestv1.KindPlugin
+	default:
+		return fallback
+	}
+}
+
+func lockEntryRuntime(entry LockEntry, fallbackKind string) string {
+	if value := strings.TrimSpace(entry.Runtime); value != "" {
+		return value
+	}
+	switch lockEntryKind(entry, fallbackKind) {
+	case providermanifestv1.KindWebUI:
+		return providerReleaseRuntimeWebUI
+	default:
+		return providerReleaseRuntimeExecutable
+	}
+}
+
+func releaseRuntimeForManifest(manifest *providermanifestv1.Manifest, kind string) string {
+	switch kind {
+	case providermanifestv1.KindWebUI:
+		return providerReleaseRuntimeWebUI
+	case providermanifestv1.KindPlugin:
+		if manifest != nil && manifest.IsDeclarativeOnlyProvider() {
+			return providerReleaseRuntimeDeclarative
+		}
+	}
+	return providerReleaseRuntimeExecutable
+}
+
+func usesGitHubAssetTransport(sourceLocation, archiveURL string) bool {
+	if src, err := pluginsource.Parse(sourceLocation); err == nil && src.Host == pluginsource.HostGitHub {
+		return true
+	}
+	parsed, err := url.Parse(strings.TrimSpace(archiveURL))
+	if err != nil {
+		return false
+	}
+	switch strings.ToLower(parsed.Hostname()) {
+	case "api.github.com":
+		return strings.Contains(parsed.Path, "/releases/assets/")
+	case "github.com":
+		return strings.Contains(parsed.Path, "/releases/download/")
+	default:
+		return false
+	}
+}
+
+func downloadArchiveForSource(ctx context.Context, client *http.Client, sourceLocation, token, archiveURL string) (*providerpkg.DownloadResult, error) {
+	if client == nil {
+		client = http.DefaultClient
+	}
+	token = strings.TrimSpace(token)
+	if usesGitHubAssetTransport(sourceLocation, archiveURL) {
+		return ghresolver.DownloadResolvedAsset(ctx, client, archiveURL, token)
+	}
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, archiveURL, nil)
+	if err != nil {
+		return nil, fmt.Errorf("create archive download request: %w", err)
+	}
+	if token != "" {
+		req.Header.Set(httpAuthorizationHeader, httpBearerAuthorizationPrefix+token)
+	}
+	return providerpkg.DownloadRequest(client, req)
+}

--- a/gestaltd/internal/server/server_test.go
+++ b/gestaltd/internal/server/server_test.go
@@ -859,7 +859,7 @@ func TestMountedWebUIRoutes_HumanAuthorization(t *testing.T) {
 	}
 }
 
-func TestMountedWebUIRoutes_HumanAuthorization_DefaultAllowTreatsAuthenticatedUsersAsViewer(t *testing.T) {
+func TestMountedWebUIRoutes_HumanAuthorization_DefaultAllowTreatsAuthenticatedUsersAsViewerWithPluginName(t *testing.T) {
 	t.Parallel()
 
 	dir := t.TempDir()
@@ -902,6 +902,7 @@ func TestMountedWebUIRoutes_HumanAuthorization_DefaultAllowTreatsAuthenticatedUs
 		cfg.MountedWebUIs = []server.MountedWebUI{{
 			Name:                "sample_portal",
 			Path:                "/sample-portal",
+			PluginName:          "sample_portal",
 			AuthorizationPolicy: "sample_policy",
 			Routes: []server.MountedWebUIRoute{
 				{Path: "/admin/*", AllowedRoles: []string{"admin"}},
@@ -1064,6 +1065,76 @@ func TestMountedWebUIRoutes_HumanAuthorization_DynamicGrant(t *testing.T) {
 	}
 	if resp.StatusCode != http.StatusOK {
 		t.Fatalf("static-over-dynamic admin status = %d, want 200", resp.StatusCode)
+	}
+	if !strings.Contains(string(body), "protected-sample-shell") {
+		t.Fatalf("body = %q, want protected sample shell", body)
+	}
+}
+
+func TestMountedWebUIRoutes_HumanAuthorization_DefaultAllowTreatsAuthenticatedUsersAsViewerWithoutPluginName(t *testing.T) {
+	t.Parallel()
+
+	dir := t.TempDir()
+	if err := os.WriteFile(filepath.Join(dir, "index.html"), []byte("<html>protected-sample-shell</html>"), 0o644); err != nil {
+		t.Fatalf("WriteFile index.html: %v", err)
+	}
+	handler, err := testutilWebUIHandler(dir)
+	if err != nil {
+		t.Fatalf("webui handler: %v", err)
+	}
+
+	authz := mustAuthorizer(t, config.AuthorizationConfig{
+		Policies: map[string]config.HumanPolicyDef{
+			"sample_policy": {
+				Default: "allow",
+				Members: []config.HumanPolicyMemberDef{
+					{Email: "admin@example.test", Role: "admin"},
+				},
+			},
+		},
+	}, nil, nil, nil)
+
+	ts := newTestServer(t, func(cfg *server.Config) {
+		cfg.Auth = &coretesting.StubAuthProvider{
+			N: "test",
+			ValidateTokenFn: func(_ context.Context, token string) (*core.UserIdentity, error) {
+				switch token {
+				case "viewer-session":
+					return &core.UserIdentity{Email: "viewer@example.test"}, nil
+				case "admin-session":
+					return &core.UserIdentity{Email: "admin@example.test"}, nil
+				default:
+					return nil, fmt.Errorf("invalid token")
+				}
+			},
+		}
+		cfg.Authorizer = authz
+		cfg.MountedWebUIs = []server.MountedWebUI{{
+			Name:                "sample_portal",
+			Path:                "/sample-portal",
+			AuthorizationPolicy: "sample_policy",
+			Routes: []server.MountedWebUIRoute{
+				{Path: "/admin/*", AllowedRoles: []string{"admin"}},
+				{Path: "/*", AllowedRoles: []string{"viewer", "admin"}},
+			},
+			Handler: handler,
+		}}
+	})
+	testutil.CloseOnCleanup(t, ts)
+
+	req, _ := http.NewRequest(http.MethodGet, ts.URL+"/sample-portal/sync", nil)
+	req.AddCookie(&http.Cookie{Name: "session_token", Value: "viewer-session"})
+	resp, err := http.DefaultClient.Do(req)
+	if err != nil {
+		t.Fatalf("GET default-allow mounted sync without plugin name: %v", err)
+	}
+	body, err := io.ReadAll(resp.Body)
+	_ = resp.Body.Close()
+	if err != nil {
+		t.Fatalf("ReadAll default-allow mounted sync without plugin name: %v", err)
+	}
+	if resp.StatusCode != http.StatusOK {
+		t.Fatalf("default-allow viewer status without plugin name = %d, want %d", resp.StatusCode, http.StatusOK)
 	}
 	if !strings.Contains(string(body), "protected-sample-shell") {
 		t.Fatalf("body = %q, want protected sample shell", body)
@@ -11196,6 +11267,82 @@ func TestRefresh_UsesConnectionAuth(t *testing.T) {
 	}
 	if refreshedVia != "connection-handler" {
 		t.Fatalf("expected refresh via connection handler, got %q", refreshedVia)
+	}
+}
+
+func TestRefresh_UsesResolvedConnectionTokenURL(t *testing.T) {
+	t.Parallel()
+
+	svc := coretesting.NewStubServices(t)
+	u := seedUser(t, svc, "anonymous@gestalt")
+	expired := time.Now().Add(-1 * time.Hour)
+	seedToken(t, svc, &core.IntegrationToken{
+		ID:           "tok1",
+		UserID:       u.ID,
+		Integration:  "fake",
+		Connection:   "default",
+		Instance:     "default",
+		AccessToken:  "old-token",
+		RefreshToken: "old-refresh",
+		ExpiresAt:    &expired,
+		MetadataJSON: `{"tenant":"acme"}`,
+	})
+
+	var refreshedURL string
+	var refreshedToken string
+	var usedToken string
+	stub := &stubOAuthIntegration{
+		stubIntegrationWithOps: stubIntegrationWithOps{
+			StubIntegration: coretesting.StubIntegration{
+				N: "fake",
+				ExecuteFn: func(_ context.Context, _ string, _ map[string]any, token string) (*core.OperationResult, error) {
+					usedToken = token
+					return &core.OperationResult{Status: http.StatusOK, Body: `{"ok":true}`}, nil
+				},
+			},
+			ops: []core.Operation{{Name: "list", Description: "List", Method: http.MethodGet}},
+		},
+	}
+	handler := &testOAuthHandler{
+		tokenURLVal: "https://{tenant}.example.com/oauth/token",
+		refreshTokenFn: func(context.Context, string) (*core.TokenResponse, error) {
+			t.Fatal("expected refresh to use resolved token URL override")
+			return nil, nil
+		},
+		refreshTokenWithURLFn: func(_ context.Context, rt, tokenURL string) (*core.TokenResponse, error) {
+			refreshedToken = rt
+			refreshedURL = tokenURL
+			return &core.TokenResponse{AccessToken: "refreshed-token", ExpiresIn: 3600}, nil
+		},
+	}
+
+	ts := newTestServer(t, func(cfg *server.Config) {
+		cfg.Providers = testutil.NewProviderRegistry(t, stub)
+		cfg.DefaultConnection = map[string]string{"fake": testDefaultConnection}
+		cfg.ConnectionAuth = testConnectionAuth("fake", handler)
+		cfg.Services = svc
+	})
+	testutil.CloseOnCleanup(t, ts)
+
+	req, _ := http.NewRequest(http.MethodGet, ts.URL+"/api/v1/fake/list", nil)
+	req.Header.Set("X-Dev-User-Email", "dev@example.com")
+	resp, err := http.DefaultClient.Do(req)
+	if err != nil {
+		t.Fatalf("request: %v", err)
+	}
+	defer func() { _ = resp.Body.Close() }()
+
+	if resp.StatusCode != http.StatusOK {
+		t.Fatalf("expected 200, got %d", resp.StatusCode)
+	}
+	if refreshedToken != "old-refresh" {
+		t.Fatalf("expected refresh token old-refresh, got %q", refreshedToken)
+	}
+	if refreshedURL != "https://acme.example.com/oauth/token" {
+		t.Fatalf("expected resolved token URL, got %q", refreshedURL)
+	}
+	if usedToken != "refreshed-token" {
+		t.Fatalf("expected operation to use refreshed token, got %q", usedToken)
 	}
 }
 


### PR DESCRIPTION
## Summary

This narrows the portable-flow contract to something we can enforce cleanly today:

- `gestaltd init` rejects local `plugins.*.source.path` and local `providers.ui.*.source.path`
- `gestaltd serve --locked` rejects those same local plugin/UI sources
- unlocked execution still works for mixed configs that combine local plugins with remote metadata-backed providers
- layered CLI coverage is updated so it no longer relies on portable init of a local plugin fixture

This PR is intentionally scoped to local plugins and local UIs only. Local host-provider manifests remain deferred to a later slice.

## New Interface

Portable config that now fails during `init` / `serve --locked`:

```yaml
apiVersion: gestaltd.config/v3
plugins:
  example:
    source: ./plugin/manifest.yaml
```

Mixed local+remote config that still works in unlocked flows:

```yaml
apiVersion: gestaltd.config/v3
plugins:
  remote:
    source: https://artifacts.example.com/plugin/remote/v1.0.0/provider-release.yaml
    auth:
      token: test-token
  local:
    source: ./local-manifest.yaml
```

### Rust example

```rust
use std::process::Command;

let output = Command::new("gestaltd")
    .args(["init", "--config", "gestalt.yaml"])
    .output()?;

assert!(!output.status.success());
assert!(String::from_utf8_lossy(&output.stderr)
    .contains("local plugin and UI sources are not supported during init"));
```

### stdin/stdout example

```text
$ gestaltd init --config gestalt.yaml
local plugin and UI sources are not supported during init; plugins.example must run unlocked

$ gestaltd serve --locked --config gestalt.yaml
local plugin and UI sources are not supported during locked execution; plugins.example must run unlocked
```

## Testing

Functional/integration coverage only, reusing existing lifecycle and CLI flows:

- `go test ./internal/operator`
- `go test ./cmd/gestaltd`
- added mixed local+remote unlocked lifecycle coverage
- added explicit local UI locked/init rejection coverage
- updated layered CLI fixtures to avoid portable local plugin setup
