### PR TITLE
workflow providers: add IndexedDB host bindings

### DIFF
--- a/gestaltd/internal/bootstrap/bootstrap.go
+++ b/gestaltd/internal/bootstrap/bootstrap.go
@@ -288,6 +288,24 @@ func closeWorkflows(providers ...coreworkflow.Provider) error {
 	return errors.Join(errs...)
 }
 
+type workflowProviderWithCleanup struct {
+	coreworkflow.Provider
+	cleanup func()
+}
+
+func (p *workflowProviderWithCleanup) Close() error {
+	var errs []error
+	if p != nil && p.Provider != nil {
+		if err := p.Provider.Close(); err != nil {
+			errs = append(errs, err)
+		}
+	}
+	if p != nil && p.cleanup != nil {
+		p.cleanup()
+	}
+	return errors.Join(errs...)
+}
+
 type preparedCore struct {
 	Auth            core.AuthProvider
 	Services        *coredata.Services
@@ -938,14 +956,40 @@ func buildWorkflow(ctx context.Context, name string, entry *config.ProviderEntry
 			return nil, fmt.Errorf("workflow provider: %w", err)
 		}
 	}
-	provider, err := factories.Workflow(ctx, name, node, []providerhost.HostService{{
+	hostServices := []providerhost.HostService{{
 		EnvVar: providerhost.DefaultWorkflowHostSocketEnv,
 		Register: func(srv *grpc.Server) {
 			proto.RegisterWorkflowHostServer(srv, providerhost.NewWorkflowHostServer(name, deps.WorkflowRuntime.Invoke, deps.WorkflowRuntime.Allow))
 		},
-	}}, deps)
+	}}
+	var cleanup func()
+	defer func() {
+		if cleanup != nil {
+			cleanup()
+		}
+	}()
+	effectiveIndexedDB, err := config.ResolveEffectiveWorkflowIndexedDB(name, entry, deps.IndexedDBDefs)
 	if err != nil {
 		return nil, fmt.Errorf("workflow provider: %w", err)
+	}
+	if effectiveIndexedDB.Enabled {
+		indexedDBHostServices, indexedDBCleanup, err := buildWorkflowIndexedDBHostServices(name, effectiveIndexedDB, deps)
+		if err != nil {
+			return nil, fmt.Errorf("workflow provider: %w", err)
+		}
+		hostServices = append(hostServices, indexedDBHostServices...)
+		cleanup = chainCleanup(cleanup, indexedDBCleanup)
+	}
+	provider, err := factories.Workflow(ctx, name, node, hostServices, deps)
+	if err != nil {
+		return nil, fmt.Errorf("workflow provider: %w", err)
+	}
+	if cleanup != nil {
+		provider = &workflowProviderWithCleanup{
+			Provider: provider,
+			cleanup:  cleanup,
+		}
+		cleanup = nil
 	}
 	return provider, nil
 }

--- a/gestaltd/internal/bootstrap/bootstrap_test.go
+++ b/gestaltd/internal/bootstrap/bootstrap_test.go
@@ -366,7 +366,7 @@ func withIndexedDBHostClient(t *testing.T, hostService providerhost.HostService,
 	if err != nil {
 		t.Fatalf("grpc.NewClient: %v", err)
 	}
-	defer conn.Close()
+	defer func() { _ = conn.Close() }()
 
 	fn(proto.NewIndexedDBClient(conn))
 }

--- a/gestaltd/internal/bootstrap/bootstrap_test.go
+++ b/gestaltd/internal/bootstrap/bootstrap_test.go
@@ -15,6 +15,7 @@ import (
 	"sync/atomic"
 	"testing"
 
+	gestalt "github.com/valon-technologies/gestalt/sdk/go"
 	proto "github.com/valon-technologies/gestalt/sdk/go/gen/v1"
 	"github.com/valon-technologies/gestalt/server/core"
 	"github.com/valon-technologies/gestalt/server/core/catalog"
@@ -277,6 +278,15 @@ func validConfig() *config.Config {
 	}
 }
 
+func mustYAMLNode(t *testing.T, value any) yaml.Node {
+	t.Helper()
+	var node yaml.Node
+	if err := node.Encode(value); err != nil {
+		t.Fatalf("node.Encode: %v", err)
+	}
+	return node
+}
+
 func selectedAuthEntry(t *testing.T, cfg *config.Config) *config.ProviderEntry {
 	t.Helper()
 	_, entry, err := cfg.SelectedAuthProvider()
@@ -328,6 +338,37 @@ func invokeWorkflowHostCallback(t *testing.T, hostServices []providerhost.HostSe
 	t.Cleanup(func() { _ = conn.Close() })
 
 	return proto.NewWorkflowHostClient(conn).InvokeOperation(context.Background(), req)
+}
+
+func withIndexedDBHostClient(t *testing.T, hostService providerhost.HostService, fn func(proto.IndexedDBClient)) {
+	t.Helper()
+	if hostService.Register == nil {
+		t.Fatal("indexeddb host register func is nil")
+	}
+
+	lis := bufconn.Listen(1024 * 1024)
+	srv := grpc.NewServer()
+	hostService.Register(srv)
+	go func() {
+		_ = srv.Serve(lis)
+	}()
+	t.Cleanup(func() {
+		srv.Stop()
+		_ = lis.Close()
+	})
+
+	conn, err := grpc.NewClient("passthrough:///bufnet",
+		grpc.WithContextDialer(func(context.Context, string) (net.Conn, error) {
+			return lis.Dial()
+		}),
+		grpc.WithTransportCredentials(insecure.NewCredentials()),
+	)
+	if err != nil {
+		t.Fatalf("grpc.NewClient: %v", err)
+	}
+	defer conn.Close()
+
+	fn(proto.NewIndexedDBClient(conn))
 }
 
 func workflowStartupCallbackConfig(baseURL string) *config.Config {
@@ -695,6 +736,246 @@ func TestBootstrapPassesConfiguredWorkflowResourceNamesToProviders(t *testing.T)
 		if got := hostSockets[name]; got != providerhost.DefaultWorkflowHostSocketEnv {
 			t.Fatalf("workflow host env for %q = %q, want %q", name, got, providerhost.DefaultWorkflowHostSocketEnv)
 		}
+	}
+}
+
+func TestBootstrapPassesIndexedDBHostSocketToWorkflowProviders(t *testing.T) {
+	t.Parallel()
+
+	cfg := validConfig()
+	cfg.Providers.IndexedDB["workflow_state"] = &config.ProviderEntry{Source: config.ProviderSource{Path: "stub"}}
+	cfg.Providers.Workflow = map[string]*config.ProviderEntry{
+		"basic": {
+			Source: config.ProviderSource{Path: "stub"},
+			IndexedDB: &config.PluginIndexedDBConfig{
+				Provider:     "workflow_state",
+				DB:           "workflow",
+				ObjectStores: []string{"workflow_schedules", "workflow_runs"},
+			},
+		},
+	}
+
+	factories := validFactories()
+	hostEnvs := map[string][]string{}
+	factories.Workflow = func(_ context.Context, name string, node yaml.Node, hostServices []providerhost.HostService, _ bootstrap.Deps) (coreworkflow.Provider, error) {
+		var runtime struct {
+			Name string `yaml:"name"`
+		}
+		if err := node.Decode(&runtime); err != nil {
+			return nil, err
+		}
+		if runtime.Name != name {
+			return nil, fmt.Errorf("workflow runtime name = %q, want %q", runtime.Name, name)
+		}
+		envs := make([]string, 0, len(hostServices))
+		for _, hostService := range hostServices {
+			envs = append(envs, hostService.EnvVar)
+		}
+		hostEnvs[name] = envs
+		return &stubWorkflowProvider{}, nil
+	}
+
+	result, err := bootstrap.Bootstrap(context.Background(), cfg, factories)
+	if err != nil {
+		t.Fatalf("Bootstrap: %v", err)
+	}
+	defer func() { _ = result.Close(context.Background()) }()
+	<-result.ProvidersReady
+
+	got := hostEnvs["basic"]
+	if len(got) != 2 {
+		t.Fatalf("workflow host services = %v, want 2 entries", got)
+	}
+	if got[0] != providerhost.DefaultWorkflowHostSocketEnv {
+		t.Fatalf("workflow host env = %q, want %q", got[0], providerhost.DefaultWorkflowHostSocketEnv)
+	}
+	if got[1] != providerhost.DefaultIndexedDBSocketEnv {
+		t.Fatalf("workflow indexeddb env = %q, want %q", got[1], providerhost.DefaultIndexedDBSocketEnv)
+	}
+}
+
+func TestBootstrapClosesWorkflowIndexedDBAndAppliesScopedConfig(t *testing.T) {
+	t.Parallel()
+
+	cfg := validConfig()
+	cfg.Providers.IndexedDB["workflow_state"] = &config.ProviderEntry{
+		Source: config.ProviderSource{Ref: "github.com/valon-technologies/gestalt-providers/indexeddb/relationaldb"},
+		Config: mustYAMLNode(t, map[string]any{
+			"dsn":          "sqlite://workflow.db",
+			"table_prefix": "host_",
+			"prefix":       "host_",
+			"schema":       "should_be_removed",
+			"namespace":    "should_be_removed",
+		}),
+	}
+	cfg.Providers.Workflow = map[string]*config.ProviderEntry{
+		"basic": {
+			Source: config.ProviderSource{Path: "stub"},
+			IndexedDB: &config.PluginIndexedDBConfig{
+				Provider:     "workflow_state",
+				DB:           "workflow",
+				ObjectStores: []string{"workflow_runs"},
+			},
+		},
+	}
+
+	factories := validFactories()
+	var (
+		workflowCloseCount atomic.Int32
+		captured           map[string]any
+	)
+	factories.IndexedDB = func(node yaml.Node) (indexeddb.IndexedDB, error) {
+		var decoded struct {
+			Config map[string]any `yaml:"config"`
+		}
+		if err := node.Decode(&decoded); err != nil {
+			return nil, err
+		}
+		counter := (*atomic.Int32)(nil)
+		if decoded.Config["table_prefix"] == "workflow_" && decoded.Config["prefix"] == "workflow_" {
+			counter = &workflowCloseCount
+			captured = decoded.Config
+		}
+		return &trackedIndexedDB{
+			StubIndexedDB: &coretesting.StubIndexedDB{},
+			closed:        counter,
+		}, nil
+	}
+	factories.Workflow = func(context.Context, string, yaml.Node, []providerhost.HostService, bootstrap.Deps) (coreworkflow.Provider, error) {
+		return &stubWorkflowProvider{}, nil
+	}
+
+	result, err := bootstrap.Bootstrap(context.Background(), cfg, factories)
+	if err != nil {
+		t.Fatalf("Bootstrap: %v", err)
+	}
+	<-result.ProvidersReady
+
+	if got := captured["table_prefix"]; got != "workflow_" {
+		t.Fatalf("table_prefix = %#v, want %q", got, "workflow_")
+	}
+	if got := captured["prefix"]; got != "workflow_" {
+		t.Fatalf("prefix = %#v, want %q", got, "workflow_")
+	}
+	if _, ok := captured["schema"]; ok {
+		t.Fatalf("schema should be removed, got %#v", captured["schema"])
+	}
+	if _, ok := captured["namespace"]; ok {
+		t.Fatalf("namespace should be removed, got %#v", captured["namespace"])
+	}
+
+	if err := result.Close(context.Background()); err != nil {
+		t.Fatalf("result.Close: %v", err)
+	}
+	if got := workflowCloseCount.Load(); got != 1 {
+		t.Fatalf("workflowCloseCount after workflow shutdown = %d, want 1", got)
+	}
+}
+
+func TestBootstrapRoutesWorkflowIndexedDBHostServices(t *testing.T) {
+	t.Parallel()
+
+	cfg := validConfig()
+	cfg.Providers.IndexedDB["workflow_state"] = &config.ProviderEntry{
+		Source: config.ProviderSource{Path: "./providers/datastore/memory"},
+		Config: mustYAMLNode(t, map[string]any{"bucket": "workflow-state"}),
+	}
+	cfg.Providers.Workflow = map[string]*config.ProviderEntry{
+		"basic": {
+			Source: config.ProviderSource{Path: "stub"},
+			IndexedDB: &config.PluginIndexedDBConfig{
+				Provider:     "workflow_state",
+				DB:           "workflow",
+				ObjectStores: []string{"workflow_runs"},
+			},
+		},
+	}
+
+	factories := validFactories()
+	var (
+		closeCount atomic.Int32
+		boundDB    *trackedIndexedDB
+		hostEnv    []providerhost.HostService
+	)
+	factories.IndexedDB = func(yaml.Node) (indexeddb.IndexedDB, error) {
+		boundDB = &trackedIndexedDB{
+			StubIndexedDB: &coretesting.StubIndexedDB{},
+			closed:        &closeCount,
+		}
+		return boundDB, nil
+	}
+	factories.Workflow = func(_ context.Context, _ string, _ yaml.Node, hostServices []providerhost.HostService, _ bootstrap.Deps) (coreworkflow.Provider, error) {
+		hostEnv = append([]providerhost.HostService(nil), hostServices...)
+		return &stubWorkflowProvider{}, nil
+	}
+
+	result, err := bootstrap.Bootstrap(context.Background(), cfg, factories)
+	if err != nil {
+		t.Fatalf("Bootstrap: %v", err)
+	}
+	defer func() { _ = result.Close(context.Background()) }()
+	<-result.ProvidersReady
+
+	if len(hostEnv) != 2 {
+		t.Fatalf("workflow host services = %d, want 2", len(hostEnv))
+	}
+
+	var indexedDBHost providerhost.HostService
+	for _, hostService := range hostEnv {
+		if hostService.EnvVar == providerhost.DefaultIndexedDBSocketEnv {
+			indexedDBHost = hostService
+			break
+		}
+	}
+	if indexedDBHost.EnvVar == "" {
+		t.Fatal("missing workflow indexeddb host service")
+	}
+
+	withIndexedDBHostClient(t, indexedDBHost, func(client proto.IndexedDBClient) {
+		if _, err := client.CreateObjectStore(context.Background(), &proto.CreateObjectStoreRequest{
+			Name:   "workflow_runs",
+			Schema: &proto.ObjectStoreSchema{},
+		}); err != nil {
+			t.Fatalf("CreateObjectStore(workflow_runs): %v", err)
+		}
+		record, err := gestalt.RecordToProto(gestalt.Record{"id": "run-1", "status": "pending"})
+		if err != nil {
+			t.Fatalf("RecordToProto: %v", err)
+		}
+		if _, err := client.Put(context.Background(), &proto.RecordRequest{
+			Store:  "workflow_runs",
+			Record: record,
+		}); err != nil {
+			t.Fatalf("Put(workflow_runs): %v", err)
+		}
+		resp, err := client.Get(context.Background(), &proto.ObjectStoreRequest{
+			Store: "workflow_runs",
+			Id:    "run-1",
+		})
+		if err != nil {
+			t.Fatalf("Get(workflow_runs): %v", err)
+		}
+		got, err := gestalt.RecordFromProto(resp.GetRecord())
+		if err != nil {
+			t.Fatalf("RecordFromProto: %v", err)
+		}
+		if got["status"] != "pending" {
+			t.Fatalf("status = %#v, want %q", got["status"], "pending")
+		}
+
+		if _, err := client.CreateObjectStore(context.Background(), &proto.CreateObjectStoreRequest{
+			Name:   "workflow_schedules",
+			Schema: &proto.ObjectStoreSchema{},
+		}); err == nil {
+			t.Fatal("CreateObjectStore(workflow_schedules) succeeded, want allowlist failure")
+		}
+	})
+
+	if _, err := boundDB.ObjectStore("workflow_workflow_runs").Get(context.Background(), "run-1"); err != nil {
+		t.Fatalf("prefixed backing store should contain run: %v", err)
+	}
+	if _, err := boundDB.ObjectStore("workflow_runs").Get(context.Background(), "run-1"); err == nil {
+		t.Fatal("unprefixed backing store should remain empty")
 	}
 }
 
@@ -1505,7 +1786,7 @@ func TestValidateManagedWorkflowStartupCallbackUsesPreparedProviderStub(t *testi
 	}
 }
 
-func TestValidateManagedWorkflowStartupCallbackSupportsMCPPassthroughPreparedProviders(t *testing.T) {
+func TestValidateManagedWorkflowStartupInvokesMCPPassthroughPreparedProviders(t *testing.T) {
 	t.Parallel()
 
 	root := t.TempDir()
@@ -1530,7 +1811,8 @@ func TestValidateManagedWorkflowStartupCallbackSupportsMCPPassthroughPreparedPro
 	cfg := validConfig()
 	cfg.Plugins = map[string]*config.ProviderEntry{
 		"roadmap": {
-			Source: config.ProviderSource{Ref: "github.com/example/roadmap", Version: "0.0.1"},
+			Source:         config.ProviderSource{Ref: "github.com/example/roadmap", Version: "0.0.1"},
+			ConnectionMode: providermanifestv1.ConnectionModeIdentity,
 			Workflow: &config.PluginWorkflowConfig{
 				Provider:   "temporal",
 				Operations: []string{"sync"},
@@ -1543,7 +1825,8 @@ func TestValidateManagedWorkflowStartupCallbackSupportsMCPPassthroughPreparedPro
 				Spec: &providermanifestv1.Spec{
 					Surfaces: &providermanifestv1.ProviderSurfaces{
 						MCP: &providermanifestv1.MCPSurface{
-							URL: "https://example.invalid/mcp",
+							Connection: config.PluginConnectionName,
+							URL:        "https://example.invalid/mcp",
 						},
 					},
 				},
@@ -1555,22 +1838,40 @@ func TestValidateManagedWorkflowStartupCallbackSupportsMCPPassthroughPreparedPro
 	}
 
 	factories := validFactories()
-	factories.Workflow = func(_ context.Context, name string, _ yaml.Node, hostServices []providerhost.HostService, deps bootstrap.Deps) (coreworkflow.Provider, error) {
+	factories.Workflow = func(_ context.Context, name string, _ yaml.Node, _ []providerhost.HostService, deps bootstrap.Deps) (coreworkflow.Provider, error) {
 		if name != "temporal" {
 			return nil, fmt.Errorf("workflow name = %q, want %q", name, "temporal")
 		}
-		resp, err := invokeWorkflowHostCallback(t, hostServices, &proto.InvokeWorkflowOperationRequest{
-			PluginName: "roadmap",
-			Target: &proto.BoundWorkflowTarget{
+		connMaps, err := bootstrap.BuildConnectionMaps(cfg)
+		if err != nil {
+			return nil, fmt.Errorf("build connection maps: %w", err)
+		}
+		connection := connMaps.DefaultConnection["roadmap"]
+		if connection == "" {
+			connection = config.PluginConnectionName
+		}
+		if err := deps.Services.Tokens.StoreToken(context.Background(), &core.IntegrationToken{
+			UserID:      principal.IdentityPrincipal,
+			Integration: "roadmap",
+			Connection:  connection,
+			Instance:    "default",
+			AccessToken: "workflow-validate-token",
+		}); err != nil {
+			return nil, fmt.Errorf("store identity token for connection %q: %w", connection, err)
+		}
+		resp, err := deps.WorkflowRuntime.Invoke(context.Background(), coreworkflow.InvokeOperationRequest{
+			ProviderName: name,
+			PluginName:   "roadmap",
+			Target: coreworkflow.Target{
 				PluginName: "roadmap",
 				Operation:  "sync",
 			},
 		})
 		if err != nil {
-			return nil, fmt.Errorf("startup callback: %w", err)
+			return nil, fmt.Errorf("startup invoke: %w", err)
 		}
-		if resp.GetStatus() != http.StatusOK || resp.GetBody() != `{}` {
-			return nil, fmt.Errorf("startup callback response = %#v", resp)
+		if resp.Status != http.StatusOK || resp.Body != `{}` {
+			return nil, fmt.Errorf("startup invoke response = %#v", resp)
 		}
 		return &stubWorkflowProvider{}, nil
 	}

--- a/gestaltd/internal/bootstrap/provider_build.go
+++ b/gestaltd/internal/bootstrap/provider_build.go
@@ -802,6 +802,29 @@ func buildPluginWorkflowHostServices(pluginName string, deps Deps) ([]providerho
 	}}, nil
 }
 
+func buildWorkflowIndexedDBHostServices(name string, effective config.EffectiveWorkflowIndexedDB, deps Deps) ([]providerhost.HostService, func(), error) {
+	if deps.IndexedDBFactory == nil || len(deps.IndexedDBDefs) == 0 {
+		return nil, nil, fmt.Errorf("indexeddb host services are not available")
+	}
+
+	ds, err := buildWorkflowScopedIndexedDB(name, effective, deps)
+	if err != nil {
+		return nil, nil, err
+	}
+
+	hostServices := []providerhost.HostService{{
+		EnvVar: providerhost.DefaultIndexedDBSocketEnv,
+		Register: func(srv *grpc.Server) {
+			proto.RegisterIndexedDBServer(srv, providerhost.NewIndexedDBServer(ds, name, providerhost.IndexedDBServerOptions{
+				AllowedStores: effective.ObjectStores,
+			}))
+		},
+	}}
+	return hostServices, func() {
+		_ = closeIndexedDBs(ds)
+	}, nil
+}
+
 func buildPluginInvokerHostService(pluginName string, entry *config.ProviderEntry, deps Deps) (providerhost.HostService, *providerhost.RequestSnapshotStore) {
 	invoker := deps.PluginInvoker
 	if invoker == nil {
@@ -843,6 +866,26 @@ func buildPluginScopedIndexedDB(pluginName string, effective config.EffectivePlu
 	return metricutil.InstrumentIndexedDB(ds, effective.ProviderName), nil
 }
 
+func buildWorkflowScopedIndexedDB(name string, effective config.EffectiveWorkflowIndexedDB, deps Deps) (indexeddb.IndexedDB, error) {
+	def, ok := deps.IndexedDBDefs[effective.ProviderName]
+	if !ok || def == nil {
+		return nil, fmt.Errorf("indexeddb %q is not available", effective.ProviderName)
+	}
+	scopedDef, transportPrefix, err := newWorkflowScopedIndexedDBDef(def, effective.DB)
+	if err != nil {
+		return nil, fmt.Errorf("indexeddb %q: %w", effective.ProviderName, err)
+	}
+	ds, err := buildIndexedDB(scopedDef, &FactoryRegistry{IndexedDB: deps.IndexedDBFactory})
+	if err != nil {
+		return nil, fmt.Errorf("indexeddb %q: %w", effective.ProviderName, err)
+	}
+	ds = newPluginIndexedDBTransport(ds, pluginIndexedDBTransportOptions{
+		StorePrefix:   transportPrefix,
+		AllowedStores: effective.ObjectStores,
+	})
+	return metricutil.InstrumentIndexedDB(ds, name), nil
+}
+
 func newPluginScopedIndexedDBDef(entry *config.ProviderEntry, pluginName, db string) (*config.ProviderEntry, string, error) {
 	if entry == nil {
 		return nil, "", fmt.Errorf("datastore provider is required")
@@ -860,6 +903,46 @@ func newPluginScopedIndexedDBDef(entry *config.ProviderEntry, pluginName, db str
 		if legacyPrefix := legacyPluginIndexedDBPrefix(pluginName); legacyPrefix != "" {
 			cfg["legacy_table_prefix"] = legacyPrefix
 		}
+		delete(cfg, "legacy_prefix")
+		delete(cfg, "namespace")
+		if isSQLiteIndexedDBConfig(cfg) {
+			delete(cfg, "schema")
+			cfg["table_prefix"] = db + "_"
+			cfg["prefix"] = db + "_"
+		} else {
+			delete(cfg, "table_prefix")
+			delete(cfg, "prefix")
+			cfg["schema"] = db
+		}
+	} else {
+		transportPrefix = db + "_"
+	}
+
+	configNode, err := mapToYAMLNode(cfg)
+	if err != nil {
+		return nil, "", fmt.Errorf("encode config: %w", err)
+	}
+
+	cloned := *entry
+	cloned.Config = configNode
+	return &cloned, transportPrefix, nil
+}
+
+func newWorkflowScopedIndexedDBDef(entry *config.ProviderEntry, db string) (*config.ProviderEntry, string, error) {
+	if entry == nil {
+		return nil, "", fmt.Errorf("datastore provider is required")
+	}
+	cfg, err := config.NodeToMap(entry.Config)
+	if err != nil {
+		return nil, "", fmt.Errorf("decode config: %w", err)
+	}
+	if cfg == nil {
+		cfg = make(map[string]any)
+	}
+
+	transportPrefix := ""
+	if pluginIndexedDBUsesScopedProviderConfig(entry, cfg) {
+		delete(cfg, "legacy_table_prefix")
 		delete(cfg, "legacy_prefix")
 		delete(cfg, "namespace")
 		if isSQLiteIndexedDBConfig(cfg) {

--- a/gestaltd/internal/bootstrap/provider_build.go
+++ b/gestaltd/internal/bootstrap/provider_build.go
@@ -846,47 +846,64 @@ func (unavailablePluginInvoker) Invoke(context.Context, *principal.Principal, st
 }
 
 func buildPluginScopedIndexedDB(pluginName string, effective config.EffectivePluginIndexedDB, deps Deps) (indexeddb.IndexedDB, error) {
-	def, ok := deps.IndexedDBDefs[effective.ProviderName]
-	if !ok || def == nil {
-		return nil, fmt.Errorf("indexeddb %q is not available", effective.ProviderName)
-	}
-	scopedDef, transportPrefix, err := newPluginScopedIndexedDBDef(def, pluginName, effective.DB)
-	if err != nil {
-		return nil, fmt.Errorf("indexeddb %q: %w", effective.ProviderName, err)
-	}
-	ds, err := buildIndexedDB(scopedDef, &FactoryRegistry{IndexedDB: deps.IndexedDBFactory})
-	if err != nil {
-		return nil, fmt.Errorf("indexeddb %q: %w", effective.ProviderName, err)
-	}
-	ds = newPluginIndexedDBTransport(ds, pluginIndexedDBTransportOptions{
-		StorePrefix:       transportPrefix,
-		LegacyStorePrefix: legacyPluginIndexedDBPrefix(pluginName),
-		AllowedStores:     effective.ObjectStores,
-	})
-	return metricutil.InstrumentIndexedDB(ds, effective.ProviderName), nil
+	return buildScopedIndexedDB(scopedIndexedDBBuildOptions{
+		MetricsName:        effective.ProviderName,
+		ProviderName:       effective.ProviderName,
+		DB:                 effective.DB,
+		AllowedStores:      effective.ObjectStores,
+		LegacyStorePrefix:  legacyPluginIndexedDBPrefix(pluginName),
+		LegacyConfigPrefix: legacyPluginIndexedDBPrefix(pluginName),
+	}, deps)
 }
 
 func buildWorkflowScopedIndexedDB(name string, effective config.EffectiveWorkflowIndexedDB, deps Deps) (indexeddb.IndexedDB, error) {
-	def, ok := deps.IndexedDBDefs[effective.ProviderName]
+	return buildScopedIndexedDB(scopedIndexedDBBuildOptions{
+		MetricsName:   name,
+		ProviderName:  effective.ProviderName,
+		DB:            effective.DB,
+		AllowedStores: effective.ObjectStores,
+	}, deps)
+}
+
+type scopedIndexedDBBuildOptions struct {
+	MetricsName        string
+	ProviderName       string
+	DB                 string
+	AllowedStores      []string
+	LegacyStorePrefix  string
+	LegacyConfigPrefix string
+}
+
+func buildScopedIndexedDB(opts scopedIndexedDBBuildOptions, deps Deps) (indexeddb.IndexedDB, error) {
+	def, ok := deps.IndexedDBDefs[opts.ProviderName]
 	if !ok || def == nil {
-		return nil, fmt.Errorf("indexeddb %q is not available", effective.ProviderName)
+		return nil, fmt.Errorf("indexeddb %q is not available", opts.ProviderName)
 	}
-	scopedDef, transportPrefix, err := newWorkflowScopedIndexedDBDef(def, effective.DB)
+	scopedDef, transportPrefix, err := newScopedIndexedDBDef(def, scopedIndexedDBDefOptions{
+		DB:                 opts.DB,
+		LegacyConfigPrefix: opts.LegacyConfigPrefix,
+	})
 	if err != nil {
-		return nil, fmt.Errorf("indexeddb %q: %w", effective.ProviderName, err)
+		return nil, fmt.Errorf("indexeddb %q: %w", opts.ProviderName, err)
 	}
 	ds, err := buildIndexedDB(scopedDef, &FactoryRegistry{IndexedDB: deps.IndexedDBFactory})
 	if err != nil {
-		return nil, fmt.Errorf("indexeddb %q: %w", effective.ProviderName, err)
+		return nil, fmt.Errorf("indexeddb %q: %w", opts.ProviderName, err)
 	}
 	ds = newPluginIndexedDBTransport(ds, pluginIndexedDBTransportOptions{
-		StorePrefix:   transportPrefix,
-		AllowedStores: effective.ObjectStores,
+		StorePrefix:       transportPrefix,
+		LegacyStorePrefix: opts.LegacyStorePrefix,
+		AllowedStores:     opts.AllowedStores,
 	})
-	return metricutil.InstrumentIndexedDB(ds, name), nil
+	return metricutil.InstrumentIndexedDB(ds, opts.MetricsName), nil
 }
 
-func newPluginScopedIndexedDBDef(entry *config.ProviderEntry, pluginName, db string) (*config.ProviderEntry, string, error) {
+type scopedIndexedDBDefOptions struct {
+	DB                 string
+	LegacyConfigPrefix string
+}
+
+func newScopedIndexedDBDef(entry *config.ProviderEntry, opts scopedIndexedDBDefOptions) (*config.ProviderEntry, string, error) {
 	if entry == nil {
 		return nil, "", fmt.Errorf("datastore provider is required")
 	}
@@ -900,62 +917,24 @@ func newPluginScopedIndexedDBDef(entry *config.ProviderEntry, pluginName, db str
 
 	transportPrefix := ""
 	if pluginIndexedDBUsesScopedProviderConfig(entry, cfg) {
-		if legacyPrefix := legacyPluginIndexedDBPrefix(pluginName); legacyPrefix != "" {
-			cfg["legacy_table_prefix"] = legacyPrefix
+		if opts.LegacyConfigPrefix != "" {
+			cfg["legacy_table_prefix"] = opts.LegacyConfigPrefix
+		} else {
+			delete(cfg, "legacy_table_prefix")
 		}
 		delete(cfg, "legacy_prefix")
 		delete(cfg, "namespace")
 		if isSQLiteIndexedDBConfig(cfg) {
 			delete(cfg, "schema")
-			cfg["table_prefix"] = db + "_"
-			cfg["prefix"] = db + "_"
+			cfg["table_prefix"] = opts.DB + "_"
+			cfg["prefix"] = opts.DB + "_"
 		} else {
 			delete(cfg, "table_prefix")
 			delete(cfg, "prefix")
-			cfg["schema"] = db
+			cfg["schema"] = opts.DB
 		}
 	} else {
-		transportPrefix = db + "_"
-	}
-
-	configNode, err := mapToYAMLNode(cfg)
-	if err != nil {
-		return nil, "", fmt.Errorf("encode config: %w", err)
-	}
-
-	cloned := *entry
-	cloned.Config = configNode
-	return &cloned, transportPrefix, nil
-}
-
-func newWorkflowScopedIndexedDBDef(entry *config.ProviderEntry, db string) (*config.ProviderEntry, string, error) {
-	if entry == nil {
-		return nil, "", fmt.Errorf("datastore provider is required")
-	}
-	cfg, err := config.NodeToMap(entry.Config)
-	if err != nil {
-		return nil, "", fmt.Errorf("decode config: %w", err)
-	}
-	if cfg == nil {
-		cfg = make(map[string]any)
-	}
-
-	transportPrefix := ""
-	if pluginIndexedDBUsesScopedProviderConfig(entry, cfg) {
-		delete(cfg, "legacy_table_prefix")
-		delete(cfg, "legacy_prefix")
-		delete(cfg, "namespace")
-		if isSQLiteIndexedDBConfig(cfg) {
-			delete(cfg, "schema")
-			cfg["table_prefix"] = db + "_"
-			cfg["prefix"] = db + "_"
-		} else {
-			delete(cfg, "table_prefix")
-			delete(cfg, "prefix")
-			cfg["schema"] = db
-		}
-	} else {
-		transportPrefix = db + "_"
+		transportPrefix = opts.DB + "_"
 	}
 
 	configNode, err := mapToYAMLNode(cfg)

--- a/gestaltd/internal/config/config_test.go
+++ b/gestaltd/internal/config/config_test.go
@@ -2352,6 +2352,82 @@ server:
 			t.Fatalf("unexpected error: %v", err)
 		}
 	})
+
+	t.Run("workflow provider accepts indexeddb bindings", func(t *testing.T) {
+		t.Parallel()
+
+		path := mustWriteConfigFile(t, `
+providers:
+  workflow:
+    basic:
+      source:
+        path: ./providers/workflow/indexeddb
+      indexeddb:
+        provider: workflow_state
+        db: workflow
+        objectStores:
+          - workflow_schedules
+          - workflow_runs
+  indexeddb:
+    workflow_state:
+      source:
+        path: ./providers/datastore/sqlite
+server:
+  providers:
+    indexeddb: workflow_state
+  encryptionKey: server-key
+`)
+
+		cfg, err := Load(path)
+		if err != nil {
+			t.Fatalf("Load: %v", err)
+		}
+		want := &PluginIndexedDBConfig{
+			Provider:     "workflow_state",
+			DB:           "workflow",
+			ObjectStores: []string{"workflow_schedules", "workflow_runs"},
+		}
+		if got := cfg.Providers.Workflow["basic"].IndexedDB; !reflect.DeepEqual(got, want) {
+			t.Fatalf("Providers.Workflow[basic].IndexedDB = %#v, want %#v", got, want)
+		}
+		effective, err := cfg.EffectiveWorkflowIndexedDB("basic", cfg.Providers.Workflow["basic"])
+		if err != nil {
+			t.Fatalf("EffectiveWorkflowIndexedDB: %v", err)
+		}
+		if effective.ProviderName != "workflow_state" || effective.DB != "workflow" {
+			t.Fatalf("effective = %#v", effective)
+		}
+	})
+
+	t.Run("rejects unknown indexeddb bindings on workflow providers", func(t *testing.T) {
+		t.Parallel()
+
+		path := mustWriteConfigFile(t, `
+providers:
+  workflow:
+    basic:
+      source:
+        path: ./providers/workflow/indexeddb
+      indexeddb:
+        provider: missing
+  indexeddb:
+    workflow_state:
+      source:
+        path: ./providers/datastore/sqlite
+server:
+  providers:
+    indexeddb: workflow_state
+  encryptionKey: server-key
+`)
+
+		_, err := Load(path)
+		if err == nil {
+			t.Fatal("Load: expected error, got nil")
+		}
+		if !strings.Contains(err.Error(), `providers.workflow.basic.indexeddb.provider references unknown indexeddb "missing"`) {
+			t.Fatalf("unexpected error: %v", err)
+		}
+	})
 }
 
 func TestLoadRejectsUnknownProviderFields(t *testing.T) {

--- a/gestaltd/internal/config/config_validate.go
+++ b/gestaltd/internal/config/config_validate.go
@@ -452,7 +452,14 @@ func validateWorkflowConfig(cfg *Config) error {
 		if entry.Default {
 			defaults = append(defaults, name)
 		}
-		if err := validatePluginOnlyProviderFields("providers.workflow."+name, entry); err != nil {
+		if entry.IndexedDB != nil {
+			entry.IndexedDB.Provider = strings.TrimSpace(entry.IndexedDB.Provider)
+			entry.IndexedDB.DB = strings.TrimSpace(entry.IndexedDB.DB)
+			for i, store := range entry.IndexedDB.ObjectStores {
+				entry.IndexedDB.ObjectStores[i] = strings.TrimSpace(store)
+			}
+		}
+		if err := validateWorkflowProviderFields(cfg, name, entry); err != nil {
 			return err
 		}
 		if err := validateProviderEntrySource("workflow", name, entry); err != nil {
@@ -462,6 +469,55 @@ func validateWorkflowConfig(cfg *Config) error {
 	if len(defaults) > 1 {
 		sort.Strings(defaults)
 		return fmt.Errorf("config validation: providers.workflow declares multiple defaults: %s", strings.Join(defaults, ", "))
+	}
+	return nil
+}
+
+func validateWorkflowProviderFields(cfg *Config, name string, entry *ProviderEntry) error {
+	if entry == nil {
+		return nil
+	}
+	subject := "providers.workflow." + name
+	if strings.TrimSpace(entry.MountPath) != "" {
+		return fmt.Errorf("config validation: %s.mountPath is only supported on plugins.*", subject)
+	}
+	if strings.TrimSpace(entry.UI) != "" {
+		return fmt.Errorf("config validation: %s.ui is only supported on plugins.*", subject)
+	}
+	if len(entry.Cache) > 0 {
+		return fmt.Errorf("config validation: %s.cache is only supported on plugins.*", subject)
+	}
+	if len(entry.S3) > 0 {
+		return fmt.Errorf("config validation: %s.s3 is only supported on plugins.*", subject)
+	}
+	if len(entry.Invokes) > 0 {
+		return fmt.Errorf("config validation: %s.invokes is only supported on plugins.*", subject)
+	}
+	if entry.Workflow != nil {
+		return fmt.Errorf("config validation: %s.workflow is only supported on plugins.*", subject)
+	}
+	if entry.Surfaces != nil {
+		return fmt.Errorf("config validation: %s.surfaces is only supported on plugins.*", subject)
+	}
+	if entry.AuthorizationPolicy != "" {
+		return fmt.Errorf("config validation: %s.authorizationPolicy is only supported on plugins.* and ui.*", subject)
+	}
+	if entry.IndexedDB == nil {
+		return nil
+	}
+
+	seenStores := make(map[string]struct{}, len(entry.IndexedDB.ObjectStores))
+	for i, store := range entry.IndexedDB.ObjectStores {
+		if store == "" {
+			return fmt.Errorf("config validation: %s.indexeddb.objectStores[%d] is required", subject, i)
+		}
+		if _, exists := seenStores[store]; exists {
+			return fmt.Errorf("config validation: %s.indexeddb.objectStores[%d] duplicates %q", subject, i, store)
+		}
+		seenStores[store] = struct{}{}
+	}
+	if _, err := cfg.EffectiveWorkflowIndexedDB(name, entry); err != nil {
+		return err
 	}
 	return nil
 }

--- a/gestaltd/internal/config/provider_selection.go
+++ b/gestaltd/internal/config/provider_selection.go
@@ -89,6 +89,14 @@ type EffectivePluginIndexedDB struct {
 	ObjectStores []string
 }
 
+type EffectiveWorkflowIndexedDB struct {
+	Enabled      bool
+	ProviderName string
+	Provider     *ProviderEntry
+	DB           string
+	ObjectStores []string
+}
+
 type EffectivePluginWorkflow struct {
 	Enabled      bool
 	ProviderName string
@@ -115,6 +123,10 @@ func (c *Config) EffectivePluginWorkflow(pluginName string, entry *ProviderEntry
 		}
 	}
 	return ResolveEffectivePluginWorkflow(pluginName, entry, selectedName, c.Providers.Workflow)
+}
+
+func (c *Config) EffectiveWorkflowIndexedDB(name string, entry *ProviderEntry) (EffectiveWorkflowIndexedDB, error) {
+	return ResolveEffectiveWorkflowIndexedDB(name, entry, c.Providers.IndexedDB)
 }
 
 func ResolveEffectivePluginIndexedDB(pluginName string, entry *ProviderEntry, selectedName string, entries map[string]*ProviderEntry) (EffectivePluginIndexedDB, error) {
@@ -157,6 +169,35 @@ func ResolveEffectivePluginIndexedDB(pluginName string, entry *ProviderEntry, se
 		Provider:     provider,
 		DB:           dbName,
 		ObjectStores: objectStores,
+	}, nil
+}
+
+func ResolveEffectiveWorkflowIndexedDB(name string, entry *ProviderEntry, entries map[string]*ProviderEntry) (EffectiveWorkflowIndexedDB, error) {
+	if entry == nil || entry.IndexedDB == nil {
+		return EffectiveWorkflowIndexedDB{}, nil
+	}
+
+	providerName := strings.TrimSpace(entry.IndexedDB.Provider)
+	if providerName == "" {
+		return EffectiveWorkflowIndexedDB{}, fmt.Errorf("config validation: providers.workflow.%s.indexeddb.provider is required", name)
+	}
+
+	provider, ok := entries[providerName]
+	if !ok || provider == nil {
+		return EffectiveWorkflowIndexedDB{}, fmt.Errorf("config validation: providers.workflow.%s.indexeddb.provider references unknown indexeddb %q", name, providerName)
+	}
+
+	dbName := strings.TrimSpace(entry.IndexedDB.DB)
+	if dbName == "" {
+		dbName = name
+	}
+
+	return EffectiveWorkflowIndexedDB{
+		Enabled:      true,
+		ProviderName: providerName,
+		Provider:     provider,
+		DB:           dbName,
+		ObjectStores: slices.Clone(entry.IndexedDB.ObjectStores),
 	}, nil
 }
 


### PR DESCRIPTION
## Summary

This PR lets `providers.workflow.<name>` bind one IndexedDB provider and receive `GESTALT_INDEXEDDB_SOCKET` alongside `GESTALT_WORKFLOW_HOST_SOCKET`.

That is the core wiring needed for a simple external `workflow/indexeddb` provider to persist its state through the IndexedDB primitive instead of talking to SQLite tables directly.

## YAML Interface

```yaml
providers:
  indexeddb:
    workflow_state:
      source:
        path: github.com/valon-technologies/gestalt-providers/indexeddb/relationaldb
      config:
        dsn: "file:/var/lib/gestalt/workflow.db?_pragma=journal_mode(WAL)"

  workflow:
    basic:
      source:
        path: github.com/valon-technologies/gestalt-providers/workflow/indexeddb
      indexeddb:
        provider: workflow_state
        db: workflow
        objectStores:
          - workflow_schedules
          - workflow_event_triggers
          - workflow_runs
          - workflow_idempotency
      config:
        pollInterval: 5s
```

## Go Interfaces

```go
type PluginIndexedDBConfig struct {
    Provider     string   `yaml:"provider,omitempty"`
    DB           string   `yaml:"db,omitempty"`
    ObjectStores []string `yaml:"objectStores,omitempty"`
}

type EffectiveWorkflowIndexedDB struct {
    Enabled      bool
    ProviderName string
    Provider     *ProviderEntry
    DB           string
    ObjectStores []string
}
```

## Example Behavior

Config resolution now treats the workflow provider's IndexedDB binding as a first-class host dependency:

```go
effective, err := cfg.EffectiveWorkflowIndexedDB("basic", cfg.Providers.Workflow["basic"])
if err != nil {
    return err
}

hostServices, cleanup, err := buildWorkflowIndexedDBHostServices("basic", effective, deps)
if err != nil {
    return err
}
defer cleanup()
```

A workflow provider process can then use the existing Go SDK IndexedDB client through the injected default socket:

```go
db, err := gestalt.IndexedDB()
if err != nil {
    return err
}
store := db.ObjectStore("workflow_runs")
```

## What This Includes

- config resolution for `providers.workflow.<name>.indexeddb`
- validation for workflow-provider IndexedDB bindings and allowed object stores
- bootstrap wiring so workflow providers get an IndexedDB host service and default socket env
- config/bootstrap coverage for workflow-provider IndexedDB bindings and socket exposure

## Tests

- `go test ./internal/config ./internal/bootstrap`
- `git diff --check`
