### PR TITLE
fix(cli): honor catalog selectors during invoke discovery

### DIFF
--- a/gestalt/cli/src/catalog.rs
+++ b/gestalt/cli/src/catalog.rs
@@ -107,8 +107,27 @@ fn is_valid_operation_query(query: &str) -> bool {
     })
 }
 
-pub fn fetch_catalog(client: &ApiClient, plugin: &str) -> Result<OperationsCatalog> {
-    let path = format!("/api/v1/integrations/{}/operations", plugin);
+pub fn fetch_catalog(
+    client: &ApiClient,
+    plugin: &str,
+    connection: Option<&str>,
+    instance: Option<&str>,
+) -> Result<OperationsCatalog> {
+    let mut params = Vec::new();
+    if let Some(connection) = connection {
+        params.push(("_connection", connection));
+    }
+    if let Some(instance) = instance {
+        params.push(("_instance", instance));
+    }
+
+    let path = if params.is_empty() {
+        format!("/api/v1/integrations/{plugin}/operations")
+    } else {
+        let query =
+            serde_urlencoded::to_string(params).context("failed to encode catalog selectors")?;
+        format!("/api/v1/integrations/{plugin}/operations?{query}")
+    };
     let resp = client.get(&path)?;
     let operations: Vec<CatalogOperation> =
         serde_json::from_value(resp).context("failed to parse operations response")?;

--- a/gestalt/cli/src/commands/describe.rs
+++ b/gestalt/cli/src/commands/describe.rs
@@ -5,7 +5,7 @@ use crate::catalog;
 use crate::output::{self, Format};
 
 pub fn describe(client: &ApiClient, plugin: &str, operation: &str, format: Format) -> Result<()> {
-    let cat = catalog::fetch_catalog(client, plugin)?;
+    let cat = catalog::fetch_catalog(client, plugin, None, None)?;
 
     let op = match cat.find_operation(operation) {
         Some(op) => op,

--- a/gestalt/cli/src/commands/invoke.rs
+++ b/gestalt/cli/src/commands/invoke.rs
@@ -23,7 +23,7 @@ pub fn run(
     options: InvokeOptions<'_>,
     format: Format,
 ) -> Result<()> {
-    let cat = catalog::fetch_catalog(client, plugin)?;
+    let cat = catalog::fetch_catalog(client, plugin, options.connection, options.instance)?;
     let query = segments.join(".");
 
     match cat.resolve(&query)? {
@@ -55,12 +55,12 @@ pub fn invoke(
     options: InvokeOptions<'_>,
     format: Format,
 ) -> Result<()> {
-    let cat = catalog::fetch_catalog(client, plugin)?;
+    let cat = catalog::fetch_catalog(client, plugin, options.connection, options.instance)?;
     execute(client, &cat, plugin, operation, params, options, format)
 }
 
 pub fn list_operations(client: &ApiClient, plugin: &str, format: Format) -> Result<()> {
-    let cat = catalog::fetch_catalog(client, plugin)?;
+    let cat = catalog::fetch_catalog(client, plugin, None, None)?;
     display_operations(cat.operations(), format)
 }
 

--- a/gestalt/cli/tests/invoke_contract.rs
+++ b/gestalt/cli/tests/invoke_contract.rs
@@ -172,7 +172,7 @@ fn test_invoke_with_connection_and_instance() {
     let _catalog_mock = json_mock!(
         server,
         Method::GET,
-        "/api/v1/integrations/test_svc/operations",
+        "/api/v1/integrations/test_svc/operations?_connection=workspace&_instance=team-a",
         StatusCode::OK
     )
     .with_body(catalog_body())
@@ -216,7 +216,7 @@ fn test_invoke_with_connection_and_instance() {
     let _secondary_catalog_mock = authed_json_mock!(
         server,
         Method::GET,
-        "/api/v1/integrations/other_svc/operations",
+        "/api/v1/integrations/other_svc/operations?_connection=workspace&_instance=team-a",
         StatusCode::OK
     )
     .with_body(single_operation_catalog("check_status"))
@@ -256,6 +256,39 @@ fn test_invoke_with_connection_and_instance() {
     assert!(err.contains(
         "Connect it first with `gestalt plugins connect other_svc --connection workspace --instance team-a`"
     ));
+}
+
+#[test]
+fn test_cli_lists_operations_with_connection_and_instance() {
+    let mut server = Server::new();
+    let home = TempDir::new().unwrap();
+
+    let catalog_mock = authed_json_mock!(
+        server,
+        Method::GET,
+        "/api/v1/integrations/test_svc/operations?_connection=workspace&_instance=team-a",
+        StatusCode::OK
+    )
+    .with_body(single_operation_catalog("do_thing"))
+    .create();
+
+    let mut cmd = cli_command(home.path());
+    cmd.env("GESTALT_API_KEY", TEST_TOKEN).args([
+        "--url",
+        &server.url(),
+        "plugins",
+        "invoke",
+        "--connection",
+        "workspace",
+        "--instance",
+        "team-a",
+        "test_svc",
+    ]);
+    cmd.assert()
+        .success()
+        .stdout(predicate::str::contains("do_thing"));
+
+    catalog_mock.assert();
 }
 
 #[test]


### PR DESCRIPTION
## Summary
- pass `--connection` / `--instance` through the catalog fetch used by `gestalt invoke`
- keep list/describe behavior unchanged when no selectors are provided
- add invoke contract coverage for selector-aware catalog discovery

## Problem
`gestalt invoke notion --connection OAuth --instance OAuth ...` still failed before the actual operation call because the CLI fetched `/api/v1/integrations/{plugin}/operations` without `_connection` / `_instance`. That meant catalog discovery hit the server's unqualified path even when the user had explicitly selected a connection.

## Testing
- `cargo test --manifest-path gestalt/Cargo.toml --test invoke_contract`
- `cargo run --manifest-path gestalt/Cargo.toml -- invoke notion --connection OAuth --instance OAuth api_search -p query=test`
