### PR TITLE
fix(gestaltd): prefer API catalogs for HTTP routing

### DIFF
--- a/gestaltd/internal/server/runtime.go
+++ b/gestaltd/internal/server/runtime.go
@@ -21,6 +21,10 @@ import (
 
 const runtimeShutdownTimeout = 15 * time.Second
 
+func httpCatalogConnectionMap(connMaps bootstrap.ConnectionMaps) map[string]string {
+	return connMaps.APIConnection
+}
+
 func Run(ctx context.Context, cfg *config.Config, result *bootstrap.Result) error {
 	httpInvoker := invocation.NewGuarded(result.Invoker, result.CapabilityLister, "http", result.AuditSink, invocation.WithoutRateLimit())
 	mcpInvoker := invocation.NewGuarded(result.Invoker, result.CapabilityLister, "mcp", result.AuditSink, invocation.WithoutRateLimit())
@@ -63,7 +67,10 @@ func Run(ctx context.Context, cfg *config.Config, result *bootstrap.Result) erro
 		Providers:         result.Providers,
 		Invoker:           httpInvoker,
 		DefaultConnection: connMaps.DefaultConnection,
-		CatalogConnection: connMaps.MCPConnection,
+		// HTTP routes expose REST-visible operations, so unqualified session-catalog
+		// resolution should follow the API surface by default. The MCP server keeps
+		// its own MCP-specific routing below.
+		CatalogConnection: httpCatalogConnectionMap(connMaps),
 		ConnectionAuth:    result.ConnectionAuth,
 		PluginDefs:        cfg.Plugins,
 		Authorizer:        result.Authorizer,

--- a/gestaltd/internal/server/runtime_test.go
+++ b/gestaltd/internal/server/runtime_test.go
@@ -1,0 +1,22 @@
+package server
+
+import (
+	"testing"
+
+	"github.com/valon-technologies/gestalt/server/internal/bootstrap"
+)
+
+func TestHTTPCatalogConnectionMapUsesAPIConnection(t *testing.T) {
+	t.Parallel()
+
+	connMaps := bootstrap.ConnectionMaps{
+		DefaultConnection: map[string]string{"notion": "OAuth"},
+		APIConnection:     map[string]string{"notion": "OAuth"},
+		MCPConnection:     map[string]string{"notion": "MCP"},
+	}
+
+	got := httpCatalogConnectionMap(connMaps)
+	if got["notion"] != "OAuth" {
+		t.Fatalf("catalog connection = %q, want %q", got["notion"], "OAuth")
+	}
+}


### PR DESCRIPTION
## Summary
- route unqualified HTTP session-catalog discovery through each plugin's API connection
- leave MCP server routing on MCP connections
- add a regression test for the HTTP catalog connection policy

## Problem
For hybrid providers like Notion, the HTTP server was wiring `CatalogConnection` from the MCP connection map. That made unqualified routes like `GET /api/v1/integrations/notion/operations` and bare `gestalt invoke notion` prefer the MCP-side catalog path, even though the HTTP surface only exposes REST-visible operations.

In production this meant explicit `OAuth/OAuth` worked, but the no-selector path still failed.

## Testing
- `go test ./internal/server`
