### PR TITLE
Introduce canonical principal stores behind legacy identity APIs

### DIFF
--- a/gestaltd/core/provider_capabilities.go
+++ b/gestaltd/core/provider_capabilities.go
@@ -8,13 +8,21 @@ import (
 )
 
 var ErrSessionCatalogUnavailable = errors.New("session catalog unavailable")
+var ErrSessionCatalogUnsupported = errors.New("session catalog unsupported")
 
 type sessionCatalogUnavailableError struct {
-	cause error
+	cause       error
+	unsupported bool
 }
 
 func (e *sessionCatalogUnavailableError) Error() string {
-	if e == nil || e.cause == nil {
+	if e == nil {
+		return ErrSessionCatalogUnavailable.Error()
+	}
+	if e.cause == nil {
+		if e.unsupported {
+			return ErrSessionCatalogUnsupported.Error()
+		}
 		return ErrSessionCatalogUnavailable.Error()
 	}
 	return e.cause.Error()
@@ -28,7 +36,10 @@ func (e *sessionCatalogUnavailableError) Unwrap() error {
 }
 
 func (e *sessionCatalogUnavailableError) Is(target error) bool {
-	return target == ErrSessionCatalogUnavailable
+	if target == ErrSessionCatalogUnavailable {
+		return true
+	}
+	return e.unsupported && target == ErrSessionCatalogUnsupported
 }
 
 func wrapSessionCatalogUnavailable(err error) error {
@@ -38,7 +49,23 @@ func wrapSessionCatalogUnavailable(err error) error {
 	return &sessionCatalogUnavailableError{cause: err}
 }
 
+func WrapSessionCatalogUnsupported(err error) error {
+	if err == nil {
+		err = ErrSessionCatalogUnsupported
+	}
+	if errors.Is(err, ErrSessionCatalogUnavailable) && errors.Is(err, ErrSessionCatalogUnsupported) {
+		return err
+	}
+	return &sessionCatalogUnavailableError{
+		cause:       err,
+		unsupported: true,
+	}
+}
+
 func SupportsSessionCatalog(prov Provider) bool {
+	if aware, ok := prov.(interface{ SupportsSessionCatalog() bool }); ok {
+		return aware.SupportsSessionCatalog()
+	}
 	_, ok := prov.(SessionCatalogProvider)
 	return ok
 }

--- a/gestaltd/core/types.go
+++ b/gestaltd/core/types.go
@@ -79,6 +79,90 @@ type ManagedIdentityGrant struct {
 	UpdatedAt  time.Time
 }
 
+const (
+	PrincipalKindUser           = "user"
+	PrincipalKindServiceAccount = "service_account"
+)
+
+type Principal struct {
+	ID          string
+	Kind        string
+	Status      string
+	DisplayName string
+	CreatedAt   time.Time
+	UpdatedAt   time.Time
+}
+
+type UserProfile struct {
+	PrincipalID     string
+	Email           string
+	NormalizedEmail string
+	AuthProvider    string
+	AuthSubject     string
+	AvatarURL       string
+	CreatedAt       time.Time
+	UpdatedAt       time.Time
+}
+
+type ServiceAccount struct {
+	PrincipalID          string
+	Name                 string
+	Description          string
+	CreatedByPrincipalID string
+	CreatedAt            time.Time
+	UpdatedAt            time.Time
+}
+
+const (
+	ServiceAccountManagementRoleViewer = "viewer"
+	ServiceAccountManagementRoleEditor = "editor"
+	ServiceAccountManagementRoleAdmin  = "admin"
+)
+
+type ServiceAccountManagementGrant struct {
+	ID                              string
+	MemberPrincipalID               string
+	TargetServiceAccountPrincipalID string
+	Role                            string
+	ExpiresAt                       *time.Time
+	CreatedAt                       time.Time
+	UpdatedAt                       time.Time
+}
+
+const (
+	WorkspaceRoleAdmin    = "admin"
+	WorkspaceRoleOperator = "operator"
+)
+
+type WorkspaceRole struct {
+	ID          string
+	PrincipalID string
+	Role        string
+	CreatedAt   time.Time
+	UpdatedAt   time.Time
+}
+
+type PrincipalPluginAccess struct {
+	ID                  string
+	PrincipalID         string
+	Plugin              string
+	InvokeAllOperations bool
+	Operations          []string
+	ExpiresAt           *time.Time
+	CreatedAt           time.Time
+	UpdatedAt           time.Time
+}
+
+type ServiceAccountDelegation struct {
+	ID                              string
+	ActorUserPrincipalID            string
+	TargetServiceAccountPrincipalID string
+	Plugin                          string
+	ExpiresAt                       *time.Time
+	CreatedAt                       time.Time
+	UpdatedAt                       time.Time
+}
+
 type UserIdentity struct {
 	Email       string
 	DisplayName string
@@ -106,6 +190,49 @@ type Parameter struct {
 	Description string
 	Required    bool
 	Default     any
+}
+
+const (
+	APITokenKindAPI      = "api"
+	APITokenKindWorkload = "workload"
+)
+
+type APITokenAccess struct {
+	ID                  string
+	TokenID             string
+	Plugin              string
+	InvokeAllOperations bool
+	Operations          []string
+	ExpiresAt           *time.Time
+	CreatedAt           time.Time
+	UpdatedAt           time.Time
+}
+
+type ExternalCredential struct {
+	ID                string
+	PrincipalID       string
+	Plugin            string
+	Connection        string
+	Instance          string
+	AuthType          string
+	PayloadEncrypted  string
+	Scopes            string
+	ExpiresAt         *time.Time
+	LastRefreshedAt   *time.Time
+	RefreshErrorCount int
+	MetadataJSON      string
+	CreatedAt         time.Time
+	UpdatedAt         time.Time
+}
+
+type ServiceAccountAuthBinding struct {
+	ID                        string
+	ServiceAccountPrincipalID string
+	BindingKind               string
+	LookupKey                 string
+	BindingJSON               string
+	CreatedAt                 time.Time
+	UpdatedAt                 time.Time
 }
 
 type OperationResult struct {

--- a/gestaltd/core/types.go
+++ b/gestaltd/core/types.go
@@ -30,11 +30,18 @@ type IntegrationToken struct {
 	UpdatedAt         time.Time
 }
 
+type AccessPermission struct {
+	Plugin     string   `json:"plugin"`
+	Operations []string `json:"operations,omitempty"`
+}
+
 type APIToken struct {
 	ID          string
+	IdentityID  string
 	UserID      string
 	OwnerKind   string
 	OwnerID     string
+	TokenKind   string
 	Name        string
 	HashedToken string
 	Scopes      string
@@ -49,15 +56,17 @@ const (
 	APITokenOwnerKindManagedIdentity = "managed_identity"
 )
 
-type AccessPermission struct {
-	Plugin     string   `json:"plugin"`
-	Operations []string `json:"operations,omitempty"`
-}
+const (
+	APITokenKindAPI      = "api"
+	APITokenKindWorkload = "workload"
+)
+
 type ManagedIdentity struct {
-	ID          string
-	DisplayName string
-	CreatedAt   time.Time
-	UpdatedAt   time.Time
+	ID                  string
+	DisplayName         string
+	CreatedByIdentityID string
+	CreatedAt           time.Time
+	UpdatedAt           time.Time
 }
 
 type ManagedIdentityMembership struct {
@@ -79,54 +88,48 @@ type ManagedIdentityGrant struct {
 	UpdatedAt  time.Time
 }
 
-const (
-	PrincipalKindUser           = "user"
-	PrincipalKindServiceAccount = "service_account"
-)
+type Identity struct {
+	ID                  string
+	Status              string
+	DisplayName         string
+	CreatedByIdentityID string
+	MetadataJSON        string
+	CreatedAt           time.Time
+	UpdatedAt           time.Time
+}
 
-type Principal struct {
+type IdentityAuthBinding struct {
 	ID          string
-	Kind        string
-	Status      string
-	DisplayName string
+	IdentityID  string
+	BindingKind string
+	Authority   string
+	LookupKey   string
+	BindingJSON string
 	CreatedAt   time.Time
 	UpdatedAt   time.Time
 }
 
-type UserProfile struct {
-	PrincipalID     string
-	Email           string
-	NormalizedEmail string
-	AuthProvider    string
-	AuthSubject     string
-	AvatarURL       string
-	CreatedAt       time.Time
-	UpdatedAt       time.Time
-}
-
-type ServiceAccount struct {
-	PrincipalID          string
-	Name                 string
-	Description          string
-	CreatedByPrincipalID string
-	CreatedAt            time.Time
-	UpdatedAt            time.Time
-}
-
 const (
-	ServiceAccountManagementRoleViewer = "viewer"
-	ServiceAccountManagementRoleEditor = "editor"
-	ServiceAccountManagementRoleAdmin  = "admin"
+	IdentityAuthBindingKindOIDCSubject          = "oidc_subject"
+	IdentityAuthBindingKindEmail                = "email"
+	IdentityAuthBindingKindSPIFFE               = "spiffe"
+	IdentityAuthBindingKindKubernetesServiceAcc = "kubernetes_serviceaccount"
 )
 
-type ServiceAccountManagementGrant struct {
-	ID                              string
-	MemberPrincipalID               string
-	TargetServiceAccountPrincipalID string
-	Role                            string
-	ExpiresAt                       *time.Time
-	CreatedAt                       time.Time
-	UpdatedAt                       time.Time
+const (
+	IdentityManagementRoleViewer = "viewer"
+	IdentityManagementRoleEditor = "editor"
+	IdentityManagementRoleAdmin  = "admin"
+)
+
+type IdentityManagementGrant struct {
+	ID                string
+	ManagerIdentityID string
+	TargetIdentityID  string
+	Role              string
+	ExpiresAt         *time.Time
+	CreatedAt         time.Time
+	UpdatedAt         time.Time
 }
 
 const (
@@ -135,16 +138,16 @@ const (
 )
 
 type WorkspaceRole struct {
-	ID          string
-	PrincipalID string
-	Role        string
-	CreatedAt   time.Time
-	UpdatedAt   time.Time
+	ID         string
+	IdentityID string
+	Role       string
+	CreatedAt  time.Time
+	UpdatedAt  time.Time
 }
 
-type PrincipalPluginAccess struct {
+type IdentityPluginAccess struct {
 	ID                  string
-	PrincipalID         string
+	IdentityID          string
 	Plugin              string
 	InvokeAllOperations bool
 	Operations          []string
@@ -153,14 +156,42 @@ type PrincipalPluginAccess struct {
 	UpdatedAt           time.Time
 }
 
-type ServiceAccountDelegation struct {
-	ID                              string
-	ActorUserPrincipalID            string
-	TargetServiceAccountPrincipalID string
-	Plugin                          string
-	ExpiresAt                       *time.Time
-	CreatedAt                       time.Time
-	UpdatedAt                       time.Time
+type IdentityDelegation struct {
+	ID               string
+	ActorIdentityID  string
+	TargetIdentityID string
+	Plugin           string
+	ExpiresAt        *time.Time
+	CreatedAt        time.Time
+	UpdatedAt        time.Time
+}
+
+type APITokenAccess struct {
+	ID                  string
+	TokenID             string
+	Plugin              string
+	InvokeAllOperations bool
+	Operations          []string
+	ExpiresAt           *time.Time
+	CreatedAt           time.Time
+	UpdatedAt           time.Time
+}
+
+type ExternalCredential struct {
+	ID                string
+	IdentityID        string
+	Plugin            string
+	Connection        string
+	Instance          string
+	AuthType          string
+	PayloadEncrypted  string
+	Scopes            string
+	ExpiresAt         *time.Time
+	LastRefreshedAt   *time.Time
+	RefreshErrorCount int
+	MetadataJSON      string
+	CreatedAt         time.Time
+	UpdatedAt         time.Time
 }
 
 type UserIdentity struct {
@@ -190,49 +221,6 @@ type Parameter struct {
 	Description string
 	Required    bool
 	Default     any
-}
-
-const (
-	APITokenKindAPI      = "api"
-	APITokenKindWorkload = "workload"
-)
-
-type APITokenAccess struct {
-	ID                  string
-	TokenID             string
-	Plugin              string
-	InvokeAllOperations bool
-	Operations          []string
-	ExpiresAt           *time.Time
-	CreatedAt           time.Time
-	UpdatedAt           time.Time
-}
-
-type ExternalCredential struct {
-	ID                string
-	PrincipalID       string
-	Plugin            string
-	Connection        string
-	Instance          string
-	AuthType          string
-	PayloadEncrypted  string
-	Scopes            string
-	ExpiresAt         *time.Time
-	LastRefreshedAt   *time.Time
-	RefreshErrorCount int
-	MetadataJSON      string
-	CreatedAt         time.Time
-	UpdatedAt         time.Time
-}
-
-type ServiceAccountAuthBinding struct {
-	ID                        string
-	ServiceAccountPrincipalID string
-	BindingKind               string
-	LookupKey                 string
-	BindingJSON               string
-	CreatedAt                 time.Time
-	UpdatedAt                 time.Time
 }
 
 type OperationResult struct {

--- a/gestaltd/internal/bootstrap/startup_proxy.go
+++ b/gestaltd/internal/bootstrap/startup_proxy.go
@@ -153,6 +153,13 @@ func (p *startupProviderProxy) Description() string { return p.spec.Description 
 func (p *startupProviderProxy) ConnectionMode() core.ConnectionMode {
 	return p.spec.ConnectionMode
 }
+func (p *startupProviderProxy) SupportsSessionCatalog() bool {
+	provider := p.resolved()
+	if provider == nil {
+		return true
+	}
+	return core.SupportsSessionCatalog(provider)
+}
 func (p *startupProviderProxy) Catalog() *catalog.Catalog {
 	if p.spec.Catalog == nil {
 		return nil
@@ -205,14 +212,11 @@ func (p *startupProviderProxy) CatalogForRequest(ctx context.Context, token stri
 	if err != nil {
 		return nil, err
 	}
-	scoped, ok := provider.(core.SessionCatalogProvider)
-	if !ok {
-		if p.spec.Catalog != nil {
-			return p.spec.Catalog.Clone(), nil
-		}
-		return nil, fmt.Errorf("provider %q does not support session catalogs", p.spec.Name)
+	cat, scoped, err := core.CatalogForRequest(ctx, provider, token)
+	if !scoped {
+		return nil, core.WrapSessionCatalogUnsupported(fmt.Errorf("provider %q does not support session catalogs", p.spec.Name))
 	}
-	return scoped.CatalogForRequest(ctx, token)
+	return cat, err
 }
 
 func (p *startupProviderProxy) ConnectionForOperation(operation string) string {

--- a/gestaltd/internal/bootstrap/validate.go
+++ b/gestaltd/internal/bootstrap/validate.go
@@ -37,7 +37,13 @@ func Validate(ctx context.Context, cfg *config.Config, factories *FactoryRegistr
 		warnings = w.Warnings()
 	}
 
-	providers, providersReady, connAuthResolver, errResolver, err := buildProvidersAsync(ctx, cfg, factories, prepared.Deps, buildProviderForValidation)
+	providers, providersReady, connAuthResolver, errResolver, err := buildProvidersAsync(
+		ctx,
+		cfg,
+		factories,
+		prepared.Deps,
+		buildProviderForValidation,
+	)
 	if err != nil {
 		return warnings, err
 	}

--- a/gestaltd/internal/coredata/admin_authorizations.go
+++ b/gestaltd/internal/coredata/admin_authorizations.go
@@ -2,6 +2,7 @@ package coredata
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"strings"
 	"time"
@@ -23,12 +24,14 @@ type AdminAuthorizationMembership struct {
 type AdminAuthorizationService struct {
 	store          indexeddb.ObjectStore
 	workspaceRoles *WorkspaceRoleService
+	users          *UserService
 }
 
-func NewAdminAuthorizationService(ds indexeddb.IndexedDB, workspaceRoles *WorkspaceRoleService) *AdminAuthorizationService {
+func NewAdminAuthorizationService(ds indexeddb.IndexedDB, workspaceRoles *WorkspaceRoleService, users *UserService) *AdminAuthorizationService {
 	return &AdminAuthorizationService{
 		store:          ds.ObjectStore(StoreAdminAuthorizationMemberships),
 		workspaceRoles: workspaceRoles,
+		users:          users,
 	}
 }
 
@@ -88,8 +91,11 @@ func (s *AdminAuthorizationService) UpsertAdminAuthorization(ctx context.Context
 		return nil, fmt.Errorf("upsert admin authorization: %w", err)
 	}
 	if s.workspaceRoles != nil && previousRole != "" && previousRole != role {
-		if err := s.workspaceRoles.DeleteRole(ctx, userID, previousRole); err != nil && err != core.ErrNotFound {
-			return nil, fmt.Errorf("delete stale canonical workspace role: %w", err)
+		identityID, resolveErr := s.resolveIdentityID(ctx, userID)
+		if resolveErr == nil {
+			if err := s.workspaceRoles.DeleteRole(ctx, identityID, previousRole); err != nil && err != core.ErrNotFound {
+				return nil, fmt.Errorf("delete stale canonical workspace role: %w", err)
+			}
 		}
 	}
 	if err := s.syncWorkspaceRole(ctx, recordToAdminAuthorizationMembership(rec)); err != nil {
@@ -118,8 +124,11 @@ func (s *AdminAuthorizationService) DeleteAdminAuthorization(ctx context.Context
 		if existing != nil && recString(existing, "role") != "" {
 			role = recString(existing, "role")
 		}
-		if err := s.workspaceRoles.DeleteRole(ctx, userID, role); err != nil && err != core.ErrNotFound {
-			return fmt.Errorf("delete canonical workspace role: %w", err)
+		identityID, resolveErr := s.resolveIdentityID(ctx, userID)
+		if resolveErr == nil {
+			if err := s.workspaceRoles.DeleteRole(ctx, identityID, role); err != nil && err != core.ErrNotFound {
+				return fmt.Errorf("delete canonical workspace role: %w", err)
+			}
 		}
 	}
 	return nil
@@ -156,17 +165,31 @@ func recordToAdminAuthorizationMembership(rec indexeddb.Record) *AdminAuthorizat
 	}
 }
 
+func (s *AdminAuthorizationService) resolveIdentityID(ctx context.Context, userID string) (string, error) {
+	if s.users == nil {
+		return userID, nil
+	}
+	return s.users.CanonicalIdentityIDForUser(ctx, userID)
+}
+
 func (s *AdminAuthorizationService) syncWorkspaceRole(ctx context.Context, membership *AdminAuthorizationMembership) error {
 	if s.workspaceRoles == nil || membership == nil || membership.UserID == "" || membership.Role == "" {
 		return nil
 	}
+	identityID, resolveErr := s.resolveIdentityID(ctx, membership.UserID)
+	if resolveErr != nil {
+		if errors.Is(resolveErr, core.ErrNotFound) {
+			return nil
+		}
+		return resolveErr
+	}
 	if _, err := s.workspaceRoles.UpsertRole(ctx, &core.WorkspaceRole{
-		PrincipalID: membership.UserID,
-		Role:        membership.Role,
-		CreatedAt:   membership.CreatedAt,
-		UpdatedAt:   membership.UpdatedAt,
+		IdentityID: identityID,
+		Role:       membership.Role,
+		CreatedAt:  membership.CreatedAt,
+		UpdatedAt:  membership.UpdatedAt,
 	}); err != nil {
-		return fmt.Errorf("sync canonical workspace role %q/%q: %w", membership.UserID, membership.Role, err)
+		return fmt.Errorf("sync canonical workspace role %q/%q: %w", identityID, membership.Role, err)
 	}
 	return nil
 }

--- a/gestaltd/internal/coredata/admin_authorizations.go
+++ b/gestaltd/internal/coredata/admin_authorizations.go
@@ -21,11 +21,15 @@ type AdminAuthorizationMembership struct {
 }
 
 type AdminAuthorizationService struct {
-	store indexeddb.ObjectStore
+	store          indexeddb.ObjectStore
+	workspaceRoles *WorkspaceRoleService
 }
 
-func NewAdminAuthorizationService(ds indexeddb.IndexedDB) *AdminAuthorizationService {
-	return &AdminAuthorizationService{store: ds.ObjectStore(StoreAdminAuthorizationMemberships)}
+func NewAdminAuthorizationService(ds indexeddb.IndexedDB, workspaceRoles *WorkspaceRoleService) *AdminAuthorizationService {
+	return &AdminAuthorizationService{
+		store:          ds.ObjectStore(StoreAdminAuthorizationMemberships),
+		workspaceRoles: workspaceRoles,
+	}
 }
 
 func (s *AdminAuthorizationService) ListAdminAuthorizations(ctx context.Context) ([]*AdminAuthorizationMembership, error) {
@@ -60,8 +64,10 @@ func (s *AdminAuthorizationService) UpsertAdminAuthorization(ctx context.Context
 	id := adminAuthorizationRecordID(userID)
 	now := time.Now()
 	createdAt := now
+	previousRole := ""
 	if existing, err := s.store.Get(ctx, id); err == nil {
 		createdAt = recTime(existing, "created_at")
+		previousRole = strings.TrimSpace(recString(existing, "role"))
 	} else if err != indexeddb.ErrNotFound {
 		return nil, fmt.Errorf("upsert admin authorization: %w", err)
 	}
@@ -81,6 +87,14 @@ func (s *AdminAuthorizationService) UpsertAdminAuthorization(ctx context.Context
 	if err := s.store.Put(ctx, rec); err != nil {
 		return nil, fmt.Errorf("upsert admin authorization: %w", err)
 	}
+	if s.workspaceRoles != nil && previousRole != "" && previousRole != role {
+		if err := s.workspaceRoles.DeleteRole(ctx, userID, previousRole); err != nil && err != core.ErrNotFound {
+			return nil, fmt.Errorf("delete stale canonical workspace role: %w", err)
+		}
+	}
+	if err := s.syncWorkspaceRole(ctx, recordToAdminAuthorizationMembership(rec)); err != nil {
+		return nil, err
+	}
 	return recordToAdminAuthorizationMembership(rec), nil
 }
 
@@ -89,11 +103,40 @@ func (s *AdminAuthorizationService) DeleteAdminAuthorization(ctx context.Context
 	if userID == "" {
 		return fmt.Errorf("delete admin authorization: userID is required")
 	}
+	existing, err := s.store.Get(ctx, adminAuthorizationRecordID(userID))
+	if err != nil && err != indexeddb.ErrNotFound {
+		return fmt.Errorf("delete admin authorization: %w", err)
+	}
 	if err := s.store.Delete(ctx, adminAuthorizationRecordID(userID)); err != nil {
 		if err == indexeddb.ErrNotFound {
 			return core.ErrNotFound
 		}
 		return fmt.Errorf("delete admin authorization: %w", err)
+	}
+	if s.workspaceRoles != nil {
+		role := core.WorkspaceRoleAdmin
+		if existing != nil && recString(existing, "role") != "" {
+			role = recString(existing, "role")
+		}
+		if err := s.workspaceRoles.DeleteRole(ctx, userID, role); err != nil && err != core.ErrNotFound {
+			return fmt.Errorf("delete canonical workspace role: %w", err)
+		}
+	}
+	return nil
+}
+
+func (s *AdminAuthorizationService) BackfillCanonicalWorkspaceRoles(ctx context.Context) error {
+	if s.workspaceRoles == nil {
+		return nil
+	}
+	recs, err := s.store.GetAll(ctx, nil)
+	if err != nil {
+		return fmt.Errorf("list admin authorizations for canonical backfill: %w", err)
+	}
+	for _, rec := range recs {
+		if err := s.syncWorkspaceRole(ctx, recordToAdminAuthorizationMembership(rec)); err != nil {
+			return err
+		}
 	}
 	return nil
 }
@@ -111,4 +154,19 @@ func recordToAdminAuthorizationMembership(rec indexeddb.Record) *AdminAuthorizat
 		CreatedAt: recTime(rec, "created_at"),
 		UpdatedAt: recTime(rec, "updated_at"),
 	}
+}
+
+func (s *AdminAuthorizationService) syncWorkspaceRole(ctx context.Context, membership *AdminAuthorizationMembership) error {
+	if s.workspaceRoles == nil || membership == nil || membership.UserID == "" || membership.Role == "" {
+		return nil
+	}
+	if _, err := s.workspaceRoles.UpsertRole(ctx, &core.WorkspaceRole{
+		PrincipalID: membership.UserID,
+		Role:        membership.Role,
+		CreatedAt:   membership.CreatedAt,
+		UpdatedAt:   membership.UpdatedAt,
+	}); err != nil {
+		return fmt.Errorf("sync canonical workspace role %q/%q: %w", membership.UserID, membership.Role, err)
+	}
+	return nil
 }

--- a/gestaltd/internal/coredata/api_tokens.go
+++ b/gestaltd/internal/coredata/api_tokens.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
+	"strings"
 	"time"
 
 	"github.com/google/uuid"
@@ -14,12 +15,14 @@ import (
 type APITokenService struct {
 	store           indexeddb.ObjectStore
 	canonicalAccess *APITokenAccessService
+	users           *UserService
 }
 
-func NewAPITokenService(ds indexeddb.IndexedDB, canonicalAccess *APITokenAccessService) *APITokenService {
+func NewAPITokenService(ds indexeddb.IndexedDB, canonicalAccess *APITokenAccessService, users *UserService) *APITokenService {
 	return &APITokenService{
 		store:           ds.ObjectStore(StoreAPITokens),
 		canonicalAccess: canonicalAccess,
+		users:           users,
 	}
 }
 
@@ -35,6 +38,14 @@ func (s *APITokenService) StoreAPIToken(ctx context.Context, token *core.APIToke
 	if ownerID == "" && token.UserID != "" {
 		ownerID = token.UserID
 	}
+	identityID, err := s.identityIDForToken(ctx, token)
+	if err != nil {
+		return err
+	}
+	token.IdentityID = identityID
+	if token.TokenKind == "" {
+		token.TokenKind = core.APITokenKindAPI
+	}
 	permissionsJSON, err := json.Marshal(token.Permissions)
 	if err != nil {
 		return fmt.Errorf("marshal api token permissions: %w", err)
@@ -42,9 +53,11 @@ func (s *APITokenService) StoreAPIToken(ctx context.Context, token *core.APIToke
 	now := time.Now()
 	rec := indexeddb.Record{
 		"id":               token.ID,
+		"identity_id":      identityID,
 		"user_id":          token.UserID,
 		"owner_kind":       ownerKind,
 		"owner_id":         ownerID,
+		"token_kind":       token.TokenKind,
 		"name":             token.Name,
 		"hashed_token":     token.HashedToken,
 		"scopes":           token.Scopes,
@@ -79,6 +92,18 @@ func (s *APITokenService) ValidateAPIToken(ctx context.Context, hashedToken stri
 
 func (s *APITokenService) ListAPITokens(ctx context.Context, userID string) ([]*core.APIToken, error) {
 	return s.ListAPITokensByOwner(ctx, core.APITokenOwnerKindUser, userID)
+}
+
+func (s *APITokenService) ListAPITokensByIdentity(ctx context.Context, identityID string) ([]*core.APIToken, error) {
+	recs, err := s.store.Index("by_identity").GetAll(ctx, nil, identityID)
+	if err != nil {
+		return nil, fmt.Errorf("list api tokens: %w", err)
+	}
+	out := make([]*core.APIToken, len(recs))
+	for i, rec := range recs {
+		out[i] = recordToAPIToken(rec)
+	}
+	return out, nil
 }
 
 func (s *APITokenService) ListAPITokensByOwner(ctx context.Context, ownerKind, ownerID string) ([]*core.APIToken, error) {
@@ -138,6 +163,22 @@ func (s *APITokenService) RevokeAPIToken(ctx context.Context, userID, id string)
 	return s.RevokeAPITokenByOwner(ctx, core.APITokenOwnerKindUser, userID, id)
 }
 
+func (s *APITokenService) RevokeAPITokenByIdentity(ctx context.Context, identityID, id string) error {
+	deleted, err := s.store.Index("by_identity_id").Delete(ctx, id, identityID)
+	if err != nil {
+		return fmt.Errorf("revoke api token: %w", err)
+	}
+	if deleted == 0 {
+		return core.ErrNotFound
+	}
+	if s.canonicalAccess != nil {
+		if err := s.canonicalAccess.ReplaceForToken(ctx, id, nil); err != nil {
+			return fmt.Errorf("delete canonical api token access: %w", err)
+		}
+	}
+	return nil
+}
+
 func (s *APITokenService) RevokeAPITokenByOwner(ctx context.Context, ownerKind, ownerID, id string) error {
 	var (
 		deleted int64
@@ -145,7 +186,6 @@ func (s *APITokenService) RevokeAPITokenByOwner(ctx context.Context, ownerKind, 
 	)
 	if ownerKind == core.APITokenOwnerKindUser {
 		if deleted, err = s.store.Index("by_user_id").Delete(ctx, id, ownerID); err == nil && deleted > 0 {
-			// Prefer the legacy user index when records were created before owner fields existed.
 		} else if err == nil {
 			deleted, err = s.store.Index("by_owner_id").Delete(ctx, id, ownerKind, ownerID)
 		}
@@ -185,6 +225,26 @@ func (s *APITokenService) RevokeAllAPITokens(ctx context.Context, userID string)
 	return s.RevokeAllAPITokensByOwner(ctx, core.APITokenOwnerKindUser, userID)
 }
 
+func (s *APITokenService) RevokeAllAPITokensByIdentity(ctx context.Context, identityID string) (int64, error) {
+	tokensBefore, err := s.ListAPITokensByIdentity(ctx, identityID)
+	if err != nil {
+		return 0, err
+	}
+	deletedIDs := collectAPITokenIDs(tokensBefore)
+	deleted, err := s.store.Index("by_identity").Delete(ctx, identityID)
+	if err != nil {
+		return 0, fmt.Errorf("revoke all api tokens: %w", err)
+	}
+	if s.canonicalAccess != nil && len(deletedIDs) > 0 {
+		for _, id := range deletedIDs {
+			if accessErr := s.canonicalAccess.ReplaceForToken(ctx, id, nil); accessErr != nil {
+				return 0, fmt.Errorf("delete canonical api token access: %w", accessErr)
+			}
+		}
+	}
+	return deleted, nil
+}
+
 func (s *APITokenService) RevokeAllAPITokensByOwner(ctx context.Context, ownerKind, ownerID string) (int64, error) {
 	var deletedIDs []string
 	var (
@@ -197,7 +257,6 @@ func (s *APITokenService) RevokeAllAPITokensByOwner(ctx context.Context, ownerKi
 	}
 	if ownerKind == core.APITokenOwnerKindUser {
 		if deleted, err = s.store.Index("by_user").Delete(ctx, ownerID); err == nil && deleted > 0 {
-			// Prefer the legacy user index when records were created before owner fields existed.
 		} else if err == nil {
 			deleted, err = s.store.Index("by_owner").Delete(ctx, ownerKind, ownerID)
 		}
@@ -259,9 +318,11 @@ func (s *APITokenService) BackfillTokenAccess(ctx context.Context) error {
 func recordToAPIToken(rec indexeddb.Record) *core.APIToken {
 	token := &core.APIToken{
 		ID:          recString(rec, "id"),
+		IdentityID:  recString(rec, "identity_id"),
 		UserID:      recString(rec, "user_id"),
 		OwnerKind:   recString(rec, "owner_kind"),
 		OwnerID:     recString(rec, "owner_id"),
+		TokenKind:   recString(rec, "token_kind"),
 		Name:        recString(rec, "name"),
 		HashedToken: recString(rec, "hashed_token"),
 		Scopes:      recString(rec, "scopes"),
@@ -275,6 +336,17 @@ func recordToAPIToken(rec indexeddb.Record) *core.APIToken {
 	if token.OwnerID == "" && token.UserID != "" {
 		token.OwnerID = token.UserID
 	}
+	if token.IdentityID == "" {
+		switch token.OwnerKind {
+		case core.APITokenOwnerKindManagedIdentity:
+			token.IdentityID = token.OwnerID
+		case "", core.APITokenOwnerKindUser:
+			token.IdentityID = token.UserID
+		}
+	}
+	if token.TokenKind == "" {
+		token.TokenKind = core.APITokenKindAPI
+	}
 	if raw := recString(rec, "permissions_json"); raw != "" {
 		var permissions []core.AccessPermission
 		if err := json.Unmarshal([]byte(raw), &permissions); err == nil {
@@ -284,12 +356,43 @@ func recordToAPIToken(rec indexeddb.Record) *core.APIToken {
 	return token
 }
 
+func (s *APITokenService) identityIDForOwner(ctx context.Context, ownerKind, ownerID string) (string, error) {
+	switch ownerKind {
+	case core.APITokenOwnerKindManagedIdentity:
+		return ownerID, nil
+	case "", core.APITokenOwnerKindUser:
+		if s.users == nil {
+			return ownerID, nil
+		}
+		return s.users.CanonicalIdentityIDForUser(ctx, ownerID)
+	default:
+		return ownerID, nil
+	}
+}
+
+func (s *APITokenService) identityIDForToken(ctx context.Context, token *core.APIToken) (string, error) {
+	if token == nil {
+		return "", fmt.Errorf("store api token: token is required")
+	}
+	if token.IdentityID != "" {
+		return token.IdentityID, nil
+	}
+	if token.OwnerKind != "" || token.OwnerID != "" {
+		return s.identityIDForOwner(ctx, token.OwnerKind, token.OwnerID)
+	}
+	if token.UserID != "" {
+		return s.identityIDForOwner(ctx, core.APITokenOwnerKindUser, token.UserID)
+	}
+	return "", fmt.Errorf("store api token: identity_id is required")
+}
+
 func (s *APITokenService) syncTokenAccess(ctx context.Context, token *core.APIToken) error {
 	if s.canonicalAccess == nil || token == nil || token.ID == "" {
 		return nil
 	}
-	access := make([]core.APITokenAccess, 0, len(token.Permissions))
-	for _, perm := range token.Permissions {
+	permissions := apiTokenAccessPermissions(token)
+	access := make([]core.APITokenAccess, 0, len(permissions))
+	for _, perm := range permissions {
 		plugin := perm.Plugin
 		if plugin == "" {
 			continue
@@ -308,6 +411,29 @@ func (s *APITokenService) syncTokenAccess(ctx context.Context, token *core.APITo
 		return fmt.Errorf("sync canonical api token access %q: %w", token.ID, err)
 	}
 	return nil
+}
+
+func apiTokenAccessPermissions(token *core.APIToken) []core.AccessPermission {
+	if token == nil {
+		return nil
+	}
+	if len(token.Permissions) > 0 {
+		return append([]core.AccessPermission(nil), token.Permissions...)
+	}
+	seen := make(map[string]struct{})
+	permissions := make([]core.AccessPermission, 0, len(strings.Fields(token.Scopes)))
+	for _, scope := range strings.Fields(token.Scopes) {
+		plugin := strings.TrimSpace(scope)
+		if plugin == "" {
+			continue
+		}
+		if _, ok := seen[plugin]; ok {
+			continue
+		}
+		seen[plugin] = struct{}{}
+		permissions = append(permissions, core.AccessPermission{Plugin: plugin})
+	}
+	return permissions
 }
 
 func collectAPITokenIDs(tokens []*core.APIToken) []string {

--- a/gestaltd/internal/coredata/api_tokens.go
+++ b/gestaltd/internal/coredata/api_tokens.go
@@ -12,11 +12,15 @@ import (
 )
 
 type APITokenService struct {
-	store indexeddb.ObjectStore
+	store           indexeddb.ObjectStore
+	canonicalAccess *APITokenAccessService
 }
 
-func NewAPITokenService(ds indexeddb.IndexedDB) *APITokenService {
-	return &APITokenService{store: ds.ObjectStore(StoreAPITokens)}
+func NewAPITokenService(ds indexeddb.IndexedDB, canonicalAccess *APITokenAccessService) *APITokenService {
+	return &APITokenService{
+		store:           ds.ObjectStore(StoreAPITokens),
+		canonicalAccess: canonicalAccess,
+	}
 }
 
 func (s *APITokenService) StoreAPIToken(ctx context.Context, token *core.APIToken) error {
@@ -51,6 +55,9 @@ func (s *APITokenService) StoreAPIToken(ctx context.Context, token *core.APIToke
 	}
 	if err := s.store.Add(ctx, rec); err != nil {
 		return fmt.Errorf("store api token: %w", err)
+	}
+	if err := s.syncTokenAccess(ctx, token); err != nil {
+		return err
 	}
 	return nil
 }
@@ -166,6 +173,11 @@ func (s *APITokenService) RevokeAPITokenByOwner(ctx context.Context, ownerKind, 
 	if deleted == 0 {
 		return core.ErrNotFound
 	}
+	if s.canonicalAccess != nil {
+		if err := s.canonicalAccess.ReplaceForToken(ctx, id, nil); err != nil {
+			return fmt.Errorf("delete canonical api token access: %w", err)
+		}
+	}
 	return nil
 }
 
@@ -174,10 +186,15 @@ func (s *APITokenService) RevokeAllAPITokens(ctx context.Context, userID string)
 }
 
 func (s *APITokenService) RevokeAllAPITokensByOwner(ctx context.Context, ownerKind, ownerID string) (int64, error) {
+	var deletedIDs []string
 	var (
 		deleted int64
 		err     error
 	)
+	tokensBefore, listErr := s.ListAPITokensByOwner(ctx, ownerKind, ownerID)
+	if listErr == nil {
+		deletedIDs = collectAPITokenIDs(tokensBefore)
+	}
 	if ownerKind == core.APITokenOwnerKindUser {
 		if deleted, err = s.store.Index("by_user").Delete(ctx, ownerID); err == nil && deleted > 0 {
 			// Prefer the legacy user index when records were created before owner fields existed.
@@ -205,7 +222,38 @@ func (s *APITokenService) RevokeAllAPITokensByOwner(ctx context.Context, ownerKi
 	if err != nil {
 		return 0, fmt.Errorf("revoke all api tokens: %w", err)
 	}
+	if s.canonicalAccess != nil && len(deletedIDs) > 0 {
+		remainingTokens, listErr := s.ListAPITokensByOwner(ctx, ownerKind, ownerID)
+		if listErr != nil {
+			return 0, fmt.Errorf("revoke all api tokens: %w", listErr)
+		}
+		remainingIDs := tokenIDSet(remainingTokens)
+		for _, id := range deletedIDs {
+			if _, ok := remainingIDs[id]; ok {
+				continue
+			}
+			if accessErr := s.canonicalAccess.ReplaceForToken(ctx, id, nil); accessErr != nil {
+				return 0, fmt.Errorf("delete canonical api token access: %w", accessErr)
+			}
+		}
+	}
 	return deleted, nil
+}
+
+func (s *APITokenService) BackfillTokenAccess(ctx context.Context) error {
+	if s.canonicalAccess == nil {
+		return nil
+	}
+	recs, err := s.store.GetAll(ctx, nil)
+	if err != nil {
+		return fmt.Errorf("list api tokens for canonical backfill: %w", err)
+	}
+	for _, rec := range recs {
+		if err := s.syncTokenAccess(ctx, recordToAPIToken(rec)); err != nil {
+			return err
+		}
+	}
+	return nil
 }
 
 func recordToAPIToken(rec indexeddb.Record) *core.APIToken {
@@ -234,4 +282,58 @@ func recordToAPIToken(rec indexeddb.Record) *core.APIToken {
 		}
 	}
 	return token
+}
+
+func (s *APITokenService) syncTokenAccess(ctx context.Context, token *core.APIToken) error {
+	if s.canonicalAccess == nil || token == nil || token.ID == "" {
+		return nil
+	}
+	access := make([]core.APITokenAccess, 0, len(token.Permissions))
+	for _, perm := range token.Permissions {
+		plugin := perm.Plugin
+		if plugin == "" {
+			continue
+		}
+		access = append(access, core.APITokenAccess{
+			TokenID:             token.ID,
+			Plugin:              plugin,
+			InvokeAllOperations: len(perm.Operations) == 0,
+			Operations:          append([]string(nil), perm.Operations...),
+			ExpiresAt:           token.ExpiresAt,
+			CreatedAt:           token.CreatedAt,
+			UpdatedAt:           token.UpdatedAt,
+		})
+	}
+	if err := s.canonicalAccess.ReplaceForToken(ctx, token.ID, access); err != nil {
+		return fmt.Errorf("sync canonical api token access %q: %w", token.ID, err)
+	}
+	return nil
+}
+
+func collectAPITokenIDs(tokens []*core.APIToken) []string {
+	if len(tokens) == 0 {
+		return nil
+	}
+	out := make([]string, 0, len(tokens))
+	for _, token := range tokens {
+		if token == nil || token.ID == "" {
+			continue
+		}
+		out = append(out, token.ID)
+	}
+	return out
+}
+
+func tokenIDSet(tokens []*core.APIToken) map[string]struct{} {
+	if len(tokens) == 0 {
+		return nil
+	}
+	out := make(map[string]struct{}, len(tokens))
+	for _, token := range tokens {
+		if token == nil || token.ID == "" {
+			continue
+		}
+		out[token.ID] = struct{}{}
+	}
+	return out
 }

--- a/gestaltd/internal/coredata/canonical_access.go
+++ b/gestaltd/internal/coredata/canonical_access.go
@@ -12,35 +12,35 @@ import (
 	"github.com/valon-technologies/gestalt/server/core/indexeddb"
 )
 
-type ServiceAccountManagementGrantService struct {
+type IdentityManagementGrantService struct {
 	store indexeddb.ObjectStore
 }
 
-func NewServiceAccountManagementGrantService(ds indexeddb.IndexedDB) *ServiceAccountManagementGrantService {
-	return &ServiceAccountManagementGrantService{store: ds.ObjectStore(StoreServiceAccountManagementGrants)}
+func NewIdentityManagementGrantService(ds indexeddb.IndexedDB) *IdentityManagementGrantService {
+	return &IdentityManagementGrantService{store: ds.ObjectStore(StoreIdentityManagementGrants)}
 }
 
-func (s *ServiceAccountManagementGrantService) UpsertGrant(ctx context.Context, grant *core.ServiceAccountManagementGrant) (*core.ServiceAccountManagementGrant, error) {
+func (s *IdentityManagementGrantService) UpsertGrant(ctx context.Context, grant *core.IdentityManagementGrant) (*core.IdentityManagementGrant, error) {
 	if grant == nil {
-		return nil, fmt.Errorf("upsert service account management grant: grant is required")
+		return nil, fmt.Errorf("upsert identity management grant: grant is required")
 	}
-	memberID := strings.TrimSpace(grant.MemberPrincipalID)
-	targetID := strings.TrimSpace(grant.TargetServiceAccountPrincipalID)
+	managerID := strings.TrimSpace(grant.ManagerIdentityID)
+	targetID := strings.TrimSpace(grant.TargetIdentityID)
 	role := strings.TrimSpace(grant.Role)
-	if memberID == "" || targetID == "" || role == "" {
-		return nil, fmt.Errorf("upsert service account management grant: member_principal_id, target_service_account_principal_id, and role are required")
+	if managerID == "" || targetID == "" || role == "" {
+		return nil, fmt.Errorf("upsert identity management grant: manager_identity_id, target_identity_id, and role are required")
 	}
 
 	now := time.Now()
 	id := grant.ID
 	createdAt := grant.CreatedAt
-	if existing, err := s.store.Index("by_member_target").Get(ctx, memberID, targetID); err == nil {
+	if existing, err := s.store.Index("by_manager_target").Get(ctx, managerID, targetID); err == nil {
 		id = recString(existing, "id")
 		if created := recTime(existing, "created_at"); !created.IsZero() {
 			createdAt = created
 		}
 	} else if err != indexeddb.ErrNotFound {
-		return nil, fmt.Errorf("upsert service account management grant: %w", err)
+		return nil, fmt.Errorf("upsert identity management grant: %w", err)
 	}
 	if id == "" {
 		id = newRecordID()
@@ -50,47 +50,47 @@ func (s *ServiceAccountManagementGrantService) UpsertGrant(ctx context.Context, 
 	}
 
 	rec := indexeddb.Record{
-		"id":                                  id,
-		"member_principal_id":                 memberID,
-		"target_service_account_principal_id": targetID,
-		"role":                                role,
-		"expires_at":                          grant.ExpiresAt,
-		"created_at":                          createdAt,
-		"updated_at":                          now,
+		"id":                  id,
+		"manager_identity_id": managerID,
+		"target_identity_id":  targetID,
+		"role":                role,
+		"expires_at":          grant.ExpiresAt,
+		"created_at":          createdAt,
+		"updated_at":          now,
 	}
 	if err := s.store.Put(ctx, rec); err != nil {
-		return nil, fmt.Errorf("upsert service account management grant: %w", err)
+		return nil, fmt.Errorf("upsert identity management grant: %w", err)
 	}
-	return recordToServiceAccountManagementGrant(rec), nil
+	return recordToIdentityManagementGrant(rec), nil
 }
 
-func (s *ServiceAccountManagementGrantService) GetGrant(ctx context.Context, memberPrincipalID, targetPrincipalID string) (*core.ServiceAccountManagementGrant, error) {
-	rec, err := s.store.Index("by_member_target").Get(ctx, strings.TrimSpace(memberPrincipalID), strings.TrimSpace(targetPrincipalID))
+func (s *IdentityManagementGrantService) GetGrant(ctx context.Context, managerIdentityID, targetIdentityID string) (*core.IdentityManagementGrant, error) {
+	rec, err := s.store.Index("by_manager_target").Get(ctx, strings.TrimSpace(managerIdentityID), strings.TrimSpace(targetIdentityID))
 	if err != nil {
 		if err == indexeddb.ErrNotFound {
 			return nil, core.ErrNotFound
 		}
-		return nil, fmt.Errorf("get service account management grant: %w", err)
+		return nil, fmt.Errorf("get identity management grant: %w", err)
 	}
-	return recordToServiceAccountManagementGrant(rec), nil
+	return recordToIdentityManagementGrant(rec), nil
 }
 
-func (s *ServiceAccountManagementGrantService) ListByTarget(ctx context.Context, targetPrincipalID string) ([]*core.ServiceAccountManagementGrant, error) {
-	recs, err := s.store.Index("by_target").GetAll(ctx, nil, strings.TrimSpace(targetPrincipalID))
+func (s *IdentityManagementGrantService) ListByTarget(ctx context.Context, targetIdentityID string) ([]*core.IdentityManagementGrant, error) {
+	recs, err := s.store.Index("by_target").GetAll(ctx, nil, strings.TrimSpace(targetIdentityID))
 	if err != nil {
-		return nil, fmt.Errorf("list service account management grants: %w", err)
+		return nil, fmt.Errorf("list identity management grants: %w", err)
 	}
-	out := make([]*core.ServiceAccountManagementGrant, 0, len(recs))
+	out := make([]*core.IdentityManagementGrant, 0, len(recs))
 	for _, rec := range recs {
-		out = append(out, recordToServiceAccountManagementGrant(rec))
+		out = append(out, recordToIdentityManagementGrant(rec))
 	}
 	return out, nil
 }
 
-func (s *ServiceAccountManagementGrantService) DeleteGrant(ctx context.Context, memberPrincipalID, targetPrincipalID string) error {
-	deleted, err := s.store.Index("by_member_target").Delete(ctx, strings.TrimSpace(memberPrincipalID), strings.TrimSpace(targetPrincipalID))
+func (s *IdentityManagementGrantService) DeleteGrant(ctx context.Context, managerIdentityID, targetIdentityID string) error {
+	deleted, err := s.store.Index("by_manager_target").Delete(ctx, strings.TrimSpace(managerIdentityID), strings.TrimSpace(targetIdentityID))
 	if err != nil {
-		return fmt.Errorf("delete service account management grant: %w", err)
+		return fmt.Errorf("delete identity management grant: %w", err)
 	}
 	if deleted == 0 {
 		return core.ErrNotFound
@@ -98,15 +98,15 @@ func (s *ServiceAccountManagementGrantService) DeleteGrant(ctx context.Context, 
 	return nil
 }
 
-func recordToServiceAccountManagementGrant(rec indexeddb.Record) *core.ServiceAccountManagementGrant {
-	return &core.ServiceAccountManagementGrant{
-		ID:                              recString(rec, "id"),
-		MemberPrincipalID:               recString(rec, "member_principal_id"),
-		TargetServiceAccountPrincipalID: recString(rec, "target_service_account_principal_id"),
-		Role:                            recString(rec, "role"),
-		ExpiresAt:                       recTimePtr(rec, "expires_at"),
-		CreatedAt:                       recTime(rec, "created_at"),
-		UpdatedAt:                       recTime(rec, "updated_at"),
+func recordToIdentityManagementGrant(rec indexeddb.Record) *core.IdentityManagementGrant {
+	return &core.IdentityManagementGrant{
+		ID:                recString(rec, "id"),
+		ManagerIdentityID: recString(rec, "manager_identity_id"),
+		TargetIdentityID:  recString(rec, "target_identity_id"),
+		Role:              recString(rec, "role"),
+		ExpiresAt:         recTimePtr(rec, "expires_at"),
+		CreatedAt:         recTime(rec, "created_at"),
+		UpdatedAt:         recTime(rec, "updated_at"),
 	}
 }
 
@@ -122,16 +122,16 @@ func (s *WorkspaceRoleService) UpsertRole(ctx context.Context, role *core.Worksp
 	if role == nil {
 		return nil, fmt.Errorf("upsert workspace role: role is required")
 	}
-	principalID := strings.TrimSpace(role.PrincipalID)
+	identityID := strings.TrimSpace(role.IdentityID)
 	roleName := strings.TrimSpace(role.Role)
-	if principalID == "" || roleName == "" {
-		return nil, fmt.Errorf("upsert workspace role: principal_id and role are required")
+	if identityID == "" || roleName == "" {
+		return nil, fmt.Errorf("upsert workspace role: identity_id and role are required")
 	}
 
 	now := time.Now()
 	id := role.ID
 	createdAt := role.CreatedAt
-	if existing, err := s.store.Index("by_principal_role").Get(ctx, principalID, roleName); err == nil {
+	if existing, err := s.store.Index("by_identity_role").Get(ctx, identityID, roleName); err == nil {
 		id = recString(existing, "id")
 		if created := recTime(existing, "created_at"); !created.IsZero() {
 			createdAt = created
@@ -147,11 +147,11 @@ func (s *WorkspaceRoleService) UpsertRole(ctx context.Context, role *core.Worksp
 	}
 
 	rec := indexeddb.Record{
-		"id":           id,
-		"principal_id": principalID,
-		"role":         roleName,
-		"created_at":   createdAt,
-		"updated_at":   now,
+		"id":          id,
+		"identity_id": identityID,
+		"role":        roleName,
+		"created_at":  createdAt,
+		"updated_at":  now,
 	}
 	if err := s.store.Put(ctx, rec); err != nil {
 		return nil, fmt.Errorf("upsert workspace role: %w", err)
@@ -159,8 +159,8 @@ func (s *WorkspaceRoleService) UpsertRole(ctx context.Context, role *core.Worksp
 	return recordToWorkspaceRole(rec), nil
 }
 
-func (s *WorkspaceRoleService) ListByPrincipal(ctx context.Context, principalID string) ([]*core.WorkspaceRole, error) {
-	recs, err := s.store.Index("by_principal").GetAll(ctx, nil, strings.TrimSpace(principalID))
+func (s *WorkspaceRoleService) ListByIdentity(ctx context.Context, identityID string) ([]*core.WorkspaceRole, error) {
+	recs, err := s.store.Index("by_identity").GetAll(ctx, nil, strings.TrimSpace(identityID))
 	if err != nil {
 		return nil, fmt.Errorf("list workspace roles: %w", err)
 	}
@@ -171,8 +171,12 @@ func (s *WorkspaceRoleService) ListByPrincipal(ctx context.Context, principalID 
 	return out, nil
 }
 
-func (s *WorkspaceRoleService) DeleteRole(ctx context.Context, principalID, role string) error {
-	deleted, err := s.store.Index("by_principal_role").Delete(ctx, strings.TrimSpace(principalID), strings.TrimSpace(role))
+func (s *WorkspaceRoleService) ListByPrincipal(ctx context.Context, identityID string) ([]*core.WorkspaceRole, error) {
+	return s.ListByIdentity(ctx, identityID)
+}
+
+func (s *WorkspaceRoleService) DeleteRole(ctx context.Context, identityID, role string) error {
+	deleted, err := s.store.Index("by_identity_role").Delete(ctx, strings.TrimSpace(identityID), strings.TrimSpace(role))
 	if err != nil {
 		return fmt.Errorf("delete workspace role: %w", err)
 	}
@@ -184,42 +188,42 @@ func (s *WorkspaceRoleService) DeleteRole(ctx context.Context, principalID, role
 
 func recordToWorkspaceRole(rec indexeddb.Record) *core.WorkspaceRole {
 	return &core.WorkspaceRole{
-		ID:          recString(rec, "id"),
-		PrincipalID: recString(rec, "principal_id"),
-		Role:        recString(rec, "role"),
-		CreatedAt:   recTime(rec, "created_at"),
-		UpdatedAt:   recTime(rec, "updated_at"),
+		ID:         recString(rec, "id"),
+		IdentityID: recString(rec, "identity_id"),
+		Role:       recString(rec, "role"),
+		CreatedAt:  recTime(rec, "created_at"),
+		UpdatedAt:  recTime(rec, "updated_at"),
 	}
 }
 
-type PrincipalPluginAccessService struct {
+type IdentityPluginAccessService struct {
 	store indexeddb.ObjectStore
 }
 
-func NewPrincipalPluginAccessService(ds indexeddb.IndexedDB) *PrincipalPluginAccessService {
-	return &PrincipalPluginAccessService{store: ds.ObjectStore(StorePrincipalPluginAccess)}
+func NewIdentityPluginAccessService(ds indexeddb.IndexedDB) *IdentityPluginAccessService {
+	return &IdentityPluginAccessService{store: ds.ObjectStore(StoreIdentityPluginAccess)}
 }
 
-func (s *PrincipalPluginAccessService) UpsertAccess(ctx context.Context, access *core.PrincipalPluginAccess) (*core.PrincipalPluginAccess, error) {
+func (s *IdentityPluginAccessService) UpsertAccess(ctx context.Context, access *core.IdentityPluginAccess) (*core.IdentityPluginAccess, error) {
 	if access == nil {
-		return nil, fmt.Errorf("upsert principal plugin access: access is required")
+		return nil, fmt.Errorf("upsert identity plugin access: access is required")
 	}
-	principalID := strings.TrimSpace(access.PrincipalID)
+	identityID := strings.TrimSpace(access.IdentityID)
 	plugin := strings.TrimSpace(access.Plugin)
-	if principalID == "" || plugin == "" {
-		return nil, fmt.Errorf("upsert principal plugin access: principal_id and plugin are required")
+	if identityID == "" || plugin == "" {
+		return nil, fmt.Errorf("upsert identity plugin access: identity_id and plugin are required")
 	}
 
 	now := time.Now()
 	id := access.ID
 	createdAt := access.CreatedAt
-	if existing, err := s.store.Index("by_principal_plugin").Get(ctx, principalID, plugin); err == nil {
+	if existing, err := s.store.Index("by_identity_plugin").Get(ctx, identityID, plugin); err == nil {
 		id = recString(existing, "id")
 		if created := recTime(existing, "created_at"); !created.IsZero() {
 			createdAt = created
 		}
 	} else if err != indexeddb.ErrNotFound {
-		return nil, fmt.Errorf("upsert principal plugin access: %w", err)
+		return nil, fmt.Errorf("upsert identity plugin access: %w", err)
 	}
 	if id == "" {
 		id = newRecordID()
@@ -228,9 +232,9 @@ func (s *PrincipalPluginAccessService) UpsertAccess(ctx context.Context, access 
 		createdAt = now
 	}
 	operations := canonicalOperations(access.Operations)
-	rec, err := principalPluginAccessRecord(&core.PrincipalPluginAccess{
+	rec, err := identityPluginAccessRecord(&core.IdentityPluginAccess{
 		ID:                  id,
-		PrincipalID:         principalID,
+		IdentityID:          identityID,
 		Plugin:              plugin,
 		InvokeAllOperations: access.InvokeAllOperations,
 		Operations:          operations,
@@ -242,30 +246,30 @@ func (s *PrincipalPluginAccessService) UpsertAccess(ctx context.Context, access 
 		return nil, err
 	}
 	if err := s.store.Put(ctx, rec); err != nil {
-		return nil, fmt.Errorf("upsert principal plugin access: %w", err)
+		return nil, fmt.Errorf("upsert identity plugin access: %w", err)
 	}
-	return recordToPrincipalPluginAccess(rec)
+	return recordToIdentityPluginAccess(rec)
 }
 
-func (s *PrincipalPluginAccessService) GetAccess(ctx context.Context, principalID, plugin string) (*core.PrincipalPluginAccess, error) {
-	rec, err := s.store.Index("by_principal_plugin").Get(ctx, strings.TrimSpace(principalID), strings.TrimSpace(plugin))
+func (s *IdentityPluginAccessService) GetAccess(ctx context.Context, identityID, plugin string) (*core.IdentityPluginAccess, error) {
+	rec, err := s.store.Index("by_identity_plugin").Get(ctx, strings.TrimSpace(identityID), strings.TrimSpace(plugin))
 	if err != nil {
 		if err == indexeddb.ErrNotFound {
 			return nil, core.ErrNotFound
 		}
-		return nil, fmt.Errorf("get principal plugin access: %w", err)
+		return nil, fmt.Errorf("get identity plugin access: %w", err)
 	}
-	return recordToPrincipalPluginAccess(rec)
+	return recordToIdentityPluginAccess(rec)
 }
 
-func (s *PrincipalPluginAccessService) ListByPrincipal(ctx context.Context, principalID string) ([]*core.PrincipalPluginAccess, error) {
-	recs, err := s.store.Index("by_principal").GetAll(ctx, nil, strings.TrimSpace(principalID))
+func (s *IdentityPluginAccessService) ListByIdentity(ctx context.Context, identityID string) ([]*core.IdentityPluginAccess, error) {
+	recs, err := s.store.Index("by_identity").GetAll(ctx, nil, strings.TrimSpace(identityID))
 	if err != nil {
-		return nil, fmt.Errorf("list principal plugin access: %w", err)
+		return nil, fmt.Errorf("list identity plugin access: %w", err)
 	}
-	out := make([]*core.PrincipalPluginAccess, 0, len(recs))
+	out := make([]*core.IdentityPluginAccess, 0, len(recs))
 	for _, rec := range recs {
-		access, err := recordToPrincipalPluginAccess(rec)
+		access, err := recordToIdentityPluginAccess(rec)
 		if err != nil {
 			return nil, err
 		}
@@ -277,10 +281,10 @@ func (s *PrincipalPluginAccessService) ListByPrincipal(ctx context.Context, prin
 	return out, nil
 }
 
-func (s *PrincipalPluginAccessService) DeleteAccess(ctx context.Context, principalID, plugin string) error {
-	deleted, err := s.store.Index("by_principal_plugin").Delete(ctx, strings.TrimSpace(principalID), strings.TrimSpace(plugin))
+func (s *IdentityPluginAccessService) DeleteAccess(ctx context.Context, identityID, plugin string) error {
+	deleted, err := s.store.Index("by_identity_plugin").Delete(ctx, strings.TrimSpace(identityID), strings.TrimSpace(plugin))
 	if err != nil {
-		return fmt.Errorf("delete principal plugin access: %w", err)
+		return fmt.Errorf("delete identity plugin access: %w", err)
 	}
 	if deleted == 0 {
 		return core.ErrNotFound
@@ -288,18 +292,18 @@ func (s *PrincipalPluginAccessService) DeleteAccess(ctx context.Context, princip
 	return nil
 }
 
-func principalPluginAccessRecord(access *core.PrincipalPluginAccess) (indexeddb.Record, error) {
+func identityPluginAccessRecord(access *core.IdentityPluginAccess) (indexeddb.Record, error) {
 	operationsJSON := ""
 	if len(access.Operations) > 0 {
 		b, err := json.Marshal(access.Operations)
 		if err != nil {
-			return nil, fmt.Errorf("marshal principal plugin access operations: %w", err)
+			return nil, fmt.Errorf("marshal identity plugin access operations: %w", err)
 		}
 		operationsJSON = string(b)
 	}
 	return indexeddb.Record{
 		"id":                    access.ID,
-		"principal_id":          access.PrincipalID,
+		"identity_id":           access.IdentityID,
 		"plugin":                access.Plugin,
 		"invoke_all_operations": access.InvokeAllOperations,
 		"operations_json":       operationsJSON,
@@ -309,10 +313,10 @@ func principalPluginAccessRecord(access *core.PrincipalPluginAccess) (indexeddb.
 	}, nil
 }
 
-func recordToPrincipalPluginAccess(rec indexeddb.Record) (*core.PrincipalPluginAccess, error) {
-	access := &core.PrincipalPluginAccess{
+func recordToIdentityPluginAccess(rec indexeddb.Record) (*core.IdentityPluginAccess, error) {
+	access := &core.IdentityPluginAccess{
 		ID:                  recString(rec, "id"),
-		PrincipalID:         recString(rec, "principal_id"),
+		IdentityID:          recString(rec, "identity_id"),
 		Plugin:              recString(rec, "plugin"),
 		InvokeAllOperations: recBool(rec, "invoke_all_operations"),
 		ExpiresAt:           recTimePtr(rec, "expires_at"),
@@ -321,7 +325,7 @@ func recordToPrincipalPluginAccess(rec indexeddb.Record) (*core.PrincipalPluginA
 	}
 	if raw := recString(rec, "operations_json"); raw != "" {
 		if err := json.Unmarshal([]byte(raw), &access.Operations); err != nil {
-			return nil, fmt.Errorf("decode principal plugin access operations: %w", err)
+			return nil, fmt.Errorf("decode identity plugin access operations: %w", err)
 		}
 	}
 	return access, nil

--- a/gestaltd/internal/coredata/canonical_access.go
+++ b/gestaltd/internal/coredata/canonical_access.go
@@ -1,0 +1,452 @@
+package coredata
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"sort"
+	"strings"
+	"time"
+
+	"github.com/valon-technologies/gestalt/server/core"
+	"github.com/valon-technologies/gestalt/server/core/indexeddb"
+)
+
+type ServiceAccountManagementGrantService struct {
+	store indexeddb.ObjectStore
+}
+
+func NewServiceAccountManagementGrantService(ds indexeddb.IndexedDB) *ServiceAccountManagementGrantService {
+	return &ServiceAccountManagementGrantService{store: ds.ObjectStore(StoreServiceAccountManagementGrants)}
+}
+
+func (s *ServiceAccountManagementGrantService) UpsertGrant(ctx context.Context, grant *core.ServiceAccountManagementGrant) (*core.ServiceAccountManagementGrant, error) {
+	if grant == nil {
+		return nil, fmt.Errorf("upsert service account management grant: grant is required")
+	}
+	memberID := strings.TrimSpace(grant.MemberPrincipalID)
+	targetID := strings.TrimSpace(grant.TargetServiceAccountPrincipalID)
+	role := strings.TrimSpace(grant.Role)
+	if memberID == "" || targetID == "" || role == "" {
+		return nil, fmt.Errorf("upsert service account management grant: member_principal_id, target_service_account_principal_id, and role are required")
+	}
+
+	now := time.Now()
+	id := grant.ID
+	createdAt := grant.CreatedAt
+	if existing, err := s.store.Index("by_member_target").Get(ctx, memberID, targetID); err == nil {
+		id = recString(existing, "id")
+		if created := recTime(existing, "created_at"); !created.IsZero() {
+			createdAt = created
+		}
+	} else if err != indexeddb.ErrNotFound {
+		return nil, fmt.Errorf("upsert service account management grant: %w", err)
+	}
+	if id == "" {
+		id = newRecordID()
+	}
+	if createdAt.IsZero() {
+		createdAt = now
+	}
+
+	rec := indexeddb.Record{
+		"id":                                  id,
+		"member_principal_id":                 memberID,
+		"target_service_account_principal_id": targetID,
+		"role":                                role,
+		"expires_at":                          grant.ExpiresAt,
+		"created_at":                          createdAt,
+		"updated_at":                          now,
+	}
+	if err := s.store.Put(ctx, rec); err != nil {
+		return nil, fmt.Errorf("upsert service account management grant: %w", err)
+	}
+	return recordToServiceAccountManagementGrant(rec), nil
+}
+
+func (s *ServiceAccountManagementGrantService) GetGrant(ctx context.Context, memberPrincipalID, targetPrincipalID string) (*core.ServiceAccountManagementGrant, error) {
+	rec, err := s.store.Index("by_member_target").Get(ctx, strings.TrimSpace(memberPrincipalID), strings.TrimSpace(targetPrincipalID))
+	if err != nil {
+		if err == indexeddb.ErrNotFound {
+			return nil, core.ErrNotFound
+		}
+		return nil, fmt.Errorf("get service account management grant: %w", err)
+	}
+	return recordToServiceAccountManagementGrant(rec), nil
+}
+
+func (s *ServiceAccountManagementGrantService) ListByTarget(ctx context.Context, targetPrincipalID string) ([]*core.ServiceAccountManagementGrant, error) {
+	recs, err := s.store.Index("by_target").GetAll(ctx, nil, strings.TrimSpace(targetPrincipalID))
+	if err != nil {
+		return nil, fmt.Errorf("list service account management grants: %w", err)
+	}
+	out := make([]*core.ServiceAccountManagementGrant, 0, len(recs))
+	for _, rec := range recs {
+		out = append(out, recordToServiceAccountManagementGrant(rec))
+	}
+	return out, nil
+}
+
+func (s *ServiceAccountManagementGrantService) DeleteGrant(ctx context.Context, memberPrincipalID, targetPrincipalID string) error {
+	deleted, err := s.store.Index("by_member_target").Delete(ctx, strings.TrimSpace(memberPrincipalID), strings.TrimSpace(targetPrincipalID))
+	if err != nil {
+		return fmt.Errorf("delete service account management grant: %w", err)
+	}
+	if deleted == 0 {
+		return core.ErrNotFound
+	}
+	return nil
+}
+
+func recordToServiceAccountManagementGrant(rec indexeddb.Record) *core.ServiceAccountManagementGrant {
+	return &core.ServiceAccountManagementGrant{
+		ID:                              recString(rec, "id"),
+		MemberPrincipalID:               recString(rec, "member_principal_id"),
+		TargetServiceAccountPrincipalID: recString(rec, "target_service_account_principal_id"),
+		Role:                            recString(rec, "role"),
+		ExpiresAt:                       recTimePtr(rec, "expires_at"),
+		CreatedAt:                       recTime(rec, "created_at"),
+		UpdatedAt:                       recTime(rec, "updated_at"),
+	}
+}
+
+type WorkspaceRoleService struct {
+	store indexeddb.ObjectStore
+}
+
+func NewWorkspaceRoleService(ds indexeddb.IndexedDB) *WorkspaceRoleService {
+	return &WorkspaceRoleService{store: ds.ObjectStore(StoreWorkspaceRoles)}
+}
+
+func (s *WorkspaceRoleService) UpsertRole(ctx context.Context, role *core.WorkspaceRole) (*core.WorkspaceRole, error) {
+	if role == nil {
+		return nil, fmt.Errorf("upsert workspace role: role is required")
+	}
+	principalID := strings.TrimSpace(role.PrincipalID)
+	roleName := strings.TrimSpace(role.Role)
+	if principalID == "" || roleName == "" {
+		return nil, fmt.Errorf("upsert workspace role: principal_id and role are required")
+	}
+
+	now := time.Now()
+	id := role.ID
+	createdAt := role.CreatedAt
+	if existing, err := s.store.Index("by_principal_role").Get(ctx, principalID, roleName); err == nil {
+		id = recString(existing, "id")
+		if created := recTime(existing, "created_at"); !created.IsZero() {
+			createdAt = created
+		}
+	} else if err != indexeddb.ErrNotFound {
+		return nil, fmt.Errorf("upsert workspace role: %w", err)
+	}
+	if id == "" {
+		id = newRecordID()
+	}
+	if createdAt.IsZero() {
+		createdAt = now
+	}
+
+	rec := indexeddb.Record{
+		"id":           id,
+		"principal_id": principalID,
+		"role":         roleName,
+		"created_at":   createdAt,
+		"updated_at":   now,
+	}
+	if err := s.store.Put(ctx, rec); err != nil {
+		return nil, fmt.Errorf("upsert workspace role: %w", err)
+	}
+	return recordToWorkspaceRole(rec), nil
+}
+
+func (s *WorkspaceRoleService) ListByPrincipal(ctx context.Context, principalID string) ([]*core.WorkspaceRole, error) {
+	recs, err := s.store.Index("by_principal").GetAll(ctx, nil, strings.TrimSpace(principalID))
+	if err != nil {
+		return nil, fmt.Errorf("list workspace roles: %w", err)
+	}
+	out := make([]*core.WorkspaceRole, 0, len(recs))
+	for _, rec := range recs {
+		out = append(out, recordToWorkspaceRole(rec))
+	}
+	return out, nil
+}
+
+func (s *WorkspaceRoleService) DeleteRole(ctx context.Context, principalID, role string) error {
+	deleted, err := s.store.Index("by_principal_role").Delete(ctx, strings.TrimSpace(principalID), strings.TrimSpace(role))
+	if err != nil {
+		return fmt.Errorf("delete workspace role: %w", err)
+	}
+	if deleted == 0 {
+		return core.ErrNotFound
+	}
+	return nil
+}
+
+func recordToWorkspaceRole(rec indexeddb.Record) *core.WorkspaceRole {
+	return &core.WorkspaceRole{
+		ID:          recString(rec, "id"),
+		PrincipalID: recString(rec, "principal_id"),
+		Role:        recString(rec, "role"),
+		CreatedAt:   recTime(rec, "created_at"),
+		UpdatedAt:   recTime(rec, "updated_at"),
+	}
+}
+
+type PrincipalPluginAccessService struct {
+	store indexeddb.ObjectStore
+}
+
+func NewPrincipalPluginAccessService(ds indexeddb.IndexedDB) *PrincipalPluginAccessService {
+	return &PrincipalPluginAccessService{store: ds.ObjectStore(StorePrincipalPluginAccess)}
+}
+
+func (s *PrincipalPluginAccessService) UpsertAccess(ctx context.Context, access *core.PrincipalPluginAccess) (*core.PrincipalPluginAccess, error) {
+	if access == nil {
+		return nil, fmt.Errorf("upsert principal plugin access: access is required")
+	}
+	principalID := strings.TrimSpace(access.PrincipalID)
+	plugin := strings.TrimSpace(access.Plugin)
+	if principalID == "" || plugin == "" {
+		return nil, fmt.Errorf("upsert principal plugin access: principal_id and plugin are required")
+	}
+
+	now := time.Now()
+	id := access.ID
+	createdAt := access.CreatedAt
+	if existing, err := s.store.Index("by_principal_plugin").Get(ctx, principalID, plugin); err == nil {
+		id = recString(existing, "id")
+		if created := recTime(existing, "created_at"); !created.IsZero() {
+			createdAt = created
+		}
+	} else if err != indexeddb.ErrNotFound {
+		return nil, fmt.Errorf("upsert principal plugin access: %w", err)
+	}
+	if id == "" {
+		id = newRecordID()
+	}
+	if createdAt.IsZero() {
+		createdAt = now
+	}
+	operations := canonicalOperations(access.Operations)
+	rec, err := principalPluginAccessRecord(&core.PrincipalPluginAccess{
+		ID:                  id,
+		PrincipalID:         principalID,
+		Plugin:              plugin,
+		InvokeAllOperations: access.InvokeAllOperations,
+		Operations:          operations,
+		ExpiresAt:           access.ExpiresAt,
+		CreatedAt:           createdAt,
+		UpdatedAt:           now,
+	})
+	if err != nil {
+		return nil, err
+	}
+	if err := s.store.Put(ctx, rec); err != nil {
+		return nil, fmt.Errorf("upsert principal plugin access: %w", err)
+	}
+	return recordToPrincipalPluginAccess(rec)
+}
+
+func (s *PrincipalPluginAccessService) GetAccess(ctx context.Context, principalID, plugin string) (*core.PrincipalPluginAccess, error) {
+	rec, err := s.store.Index("by_principal_plugin").Get(ctx, strings.TrimSpace(principalID), strings.TrimSpace(plugin))
+	if err != nil {
+		if err == indexeddb.ErrNotFound {
+			return nil, core.ErrNotFound
+		}
+		return nil, fmt.Errorf("get principal plugin access: %w", err)
+	}
+	return recordToPrincipalPluginAccess(rec)
+}
+
+func (s *PrincipalPluginAccessService) ListByPrincipal(ctx context.Context, principalID string) ([]*core.PrincipalPluginAccess, error) {
+	recs, err := s.store.Index("by_principal").GetAll(ctx, nil, strings.TrimSpace(principalID))
+	if err != nil {
+		return nil, fmt.Errorf("list principal plugin access: %w", err)
+	}
+	out := make([]*core.PrincipalPluginAccess, 0, len(recs))
+	for _, rec := range recs {
+		access, err := recordToPrincipalPluginAccess(rec)
+		if err != nil {
+			return nil, err
+		}
+		out = append(out, access)
+	}
+	sort.Slice(out, func(i, j int) bool {
+		return out[i].Plugin < out[j].Plugin
+	})
+	return out, nil
+}
+
+func (s *PrincipalPluginAccessService) DeleteAccess(ctx context.Context, principalID, plugin string) error {
+	deleted, err := s.store.Index("by_principal_plugin").Delete(ctx, strings.TrimSpace(principalID), strings.TrimSpace(plugin))
+	if err != nil {
+		return fmt.Errorf("delete principal plugin access: %w", err)
+	}
+	if deleted == 0 {
+		return core.ErrNotFound
+	}
+	return nil
+}
+
+func principalPluginAccessRecord(access *core.PrincipalPluginAccess) (indexeddb.Record, error) {
+	operationsJSON := ""
+	if len(access.Operations) > 0 {
+		b, err := json.Marshal(access.Operations)
+		if err != nil {
+			return nil, fmt.Errorf("marshal principal plugin access operations: %w", err)
+		}
+		operationsJSON = string(b)
+	}
+	return indexeddb.Record{
+		"id":                    access.ID,
+		"principal_id":          access.PrincipalID,
+		"plugin":                access.Plugin,
+		"invoke_all_operations": access.InvokeAllOperations,
+		"operations_json":       operationsJSON,
+		"expires_at":            access.ExpiresAt,
+		"created_at":            access.CreatedAt,
+		"updated_at":            access.UpdatedAt,
+	}, nil
+}
+
+func recordToPrincipalPluginAccess(rec indexeddb.Record) (*core.PrincipalPluginAccess, error) {
+	access := &core.PrincipalPluginAccess{
+		ID:                  recString(rec, "id"),
+		PrincipalID:         recString(rec, "principal_id"),
+		Plugin:              recString(rec, "plugin"),
+		InvokeAllOperations: recBool(rec, "invoke_all_operations"),
+		ExpiresAt:           recTimePtr(rec, "expires_at"),
+		CreatedAt:           recTime(rec, "created_at"),
+		UpdatedAt:           recTime(rec, "updated_at"),
+	}
+	if raw := recString(rec, "operations_json"); raw != "" {
+		if err := json.Unmarshal([]byte(raw), &access.Operations); err != nil {
+			return nil, fmt.Errorf("decode principal plugin access operations: %w", err)
+		}
+	}
+	return access, nil
+}
+
+type APITokenAccessService struct {
+	store indexeddb.ObjectStore
+}
+
+func NewAPITokenAccessService(ds indexeddb.IndexedDB) *APITokenAccessService {
+	return &APITokenAccessService{store: ds.ObjectStore(StoreAPITokenAccess)}
+}
+
+func (s *APITokenAccessService) ReplaceForToken(ctx context.Context, tokenID string, access []core.APITokenAccess) error {
+	tokenID = strings.TrimSpace(tokenID)
+	if tokenID == "" {
+		return fmt.Errorf("replace api token access: token_id is required")
+	}
+	existing, err := s.store.Index("by_token").GetAll(ctx, nil, tokenID)
+	if err != nil {
+		return fmt.Errorf("replace api token access: %w", err)
+	}
+	for _, rec := range existing {
+		if err := s.store.Delete(ctx, recString(rec, "id")); err != nil && err != indexeddb.ErrNotFound {
+			return fmt.Errorf("replace api token access: %w", err)
+		}
+	}
+	now := time.Now()
+	for i := range access {
+		item := access[i]
+		rec, err := apiTokenAccessRecord(&core.APITokenAccess{
+			ID:                  newRecordID(),
+			TokenID:             tokenID,
+			Plugin:              strings.TrimSpace(item.Plugin),
+			InvokeAllOperations: item.InvokeAllOperations,
+			Operations:          canonicalOperations(item.Operations),
+			ExpiresAt:           item.ExpiresAt,
+			CreatedAt:           now,
+			UpdatedAt:           now,
+		})
+		if err != nil {
+			return err
+		}
+		if err := s.store.Put(ctx, rec); err != nil {
+			return fmt.Errorf("replace api token access: %w", err)
+		}
+	}
+	return nil
+}
+
+func (s *APITokenAccessService) ListByToken(ctx context.Context, tokenID string) ([]*core.APITokenAccess, error) {
+	recs, err := s.store.Index("by_token").GetAll(ctx, nil, strings.TrimSpace(tokenID))
+	if err != nil {
+		return nil, fmt.Errorf("list api token access: %w", err)
+	}
+	out := make([]*core.APITokenAccess, 0, len(recs))
+	for _, rec := range recs {
+		access, err := recordToAPITokenAccess(rec)
+		if err != nil {
+			return nil, err
+		}
+		out = append(out, access)
+	}
+	sort.Slice(out, func(i, j int) bool {
+		return out[i].Plugin < out[j].Plugin
+	})
+	return out, nil
+}
+
+func apiTokenAccessRecord(access *core.APITokenAccess) (indexeddb.Record, error) {
+	operationsJSON := ""
+	if len(access.Operations) > 0 {
+		b, err := json.Marshal(access.Operations)
+		if err != nil {
+			return nil, fmt.Errorf("marshal api token access operations: %w", err)
+		}
+		operationsJSON = string(b)
+	}
+	return indexeddb.Record{
+		"id":                    access.ID,
+		"token_id":              access.TokenID,
+		"plugin":                access.Plugin,
+		"invoke_all_operations": access.InvokeAllOperations,
+		"operations_json":       operationsJSON,
+		"expires_at":            access.ExpiresAt,
+		"created_at":            access.CreatedAt,
+		"updated_at":            access.UpdatedAt,
+	}, nil
+}
+
+func recordToAPITokenAccess(rec indexeddb.Record) (*core.APITokenAccess, error) {
+	access := &core.APITokenAccess{
+		ID:                  recString(rec, "id"),
+		TokenID:             recString(rec, "token_id"),
+		Plugin:              recString(rec, "plugin"),
+		InvokeAllOperations: recBool(rec, "invoke_all_operations"),
+		ExpiresAt:           recTimePtr(rec, "expires_at"),
+		CreatedAt:           recTime(rec, "created_at"),
+		UpdatedAt:           recTime(rec, "updated_at"),
+	}
+	if raw := recString(rec, "operations_json"); raw != "" {
+		if err := json.Unmarshal([]byte(raw), &access.Operations); err != nil {
+			return nil, fmt.Errorf("decode api token access operations: %w", err)
+		}
+	}
+	return access, nil
+}
+
+func canonicalOperations(operations []string) []string {
+	if len(operations) == 0 {
+		return nil
+	}
+	seen := make(map[string]struct{}, len(operations))
+	out := make([]string, 0, len(operations))
+	for _, operation := range operations {
+		name := strings.TrimSpace(operation)
+		if name == "" {
+			continue
+		}
+		if _, ok := seen[name]; ok {
+			continue
+		}
+		seen[name] = struct{}{}
+		out = append(out, name)
+	}
+	sort.Strings(out)
+	return out
+}

--- a/gestaltd/internal/coredata/canonical_future.go
+++ b/gestaltd/internal/coredata/canonical_future.go
@@ -1,0 +1,186 @@
+package coredata
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"strings"
+	"time"
+
+	"github.com/valon-technologies/gestalt/server/core"
+	"github.com/valon-technologies/gestalt/server/core/indexeddb"
+)
+
+type ServiceAccountDelegationService struct {
+	store indexeddb.ObjectStore
+}
+
+func NewServiceAccountDelegationService(ds indexeddb.IndexedDB) *ServiceAccountDelegationService {
+	return &ServiceAccountDelegationService{store: ds.ObjectStore(StoreServiceAccountDelegations)}
+}
+
+func (s *ServiceAccountDelegationService) UpsertDelegation(ctx context.Context, delegation *core.ServiceAccountDelegation) (*core.ServiceAccountDelegation, error) {
+	if delegation == nil {
+		return nil, fmt.Errorf("upsert service account delegation: delegation is required")
+	}
+	actorID := strings.TrimSpace(delegation.ActorUserPrincipalID)
+	targetID := strings.TrimSpace(delegation.TargetServiceAccountPrincipalID)
+	if actorID == "" || targetID == "" {
+		return nil, fmt.Errorf("upsert service account delegation: actor_user_principal_id and target_service_account_principal_id are required")
+	}
+	if delegation.ID == "" {
+		delegation.ID = newRecordID()
+	}
+	now := time.Now()
+	if delegation.CreatedAt.IsZero() {
+		delegation.CreatedAt = now
+	}
+	delegation.UpdatedAt = now
+	rec := indexeddb.Record{
+		"id":                                  delegation.ID,
+		"actor_user_principal_id":             actorID,
+		"target_service_account_principal_id": targetID,
+		"plugin":                              strings.TrimSpace(delegation.Plugin),
+		"expires_at":                          delegation.ExpiresAt,
+		"created_at":                          delegation.CreatedAt,
+		"updated_at":                          delegation.UpdatedAt,
+	}
+	if err := s.store.Put(ctx, rec); err != nil {
+		return nil, fmt.Errorf("upsert service account delegation: %w", err)
+	}
+	return recordToServiceAccountDelegation(rec), nil
+}
+
+func recordToServiceAccountDelegation(rec indexeddb.Record) *core.ServiceAccountDelegation {
+	return &core.ServiceAccountDelegation{
+		ID:                              recString(rec, "id"),
+		ActorUserPrincipalID:            recString(rec, "actor_user_principal_id"),
+		TargetServiceAccountPrincipalID: recString(rec, "target_service_account_principal_id"),
+		Plugin:                          recString(rec, "plugin"),
+		ExpiresAt:                       recTimePtr(rec, "expires_at"),
+		CreatedAt:                       recTime(rec, "created_at"),
+		UpdatedAt:                       recTime(rec, "updated_at"),
+	}
+}
+
+type ExternalCredentialService struct {
+	store indexeddb.ObjectStore
+}
+
+func NewExternalCredentialService(ds indexeddb.IndexedDB) *ExternalCredentialService {
+	return &ExternalCredentialService{store: ds.ObjectStore(StoreExternalCredentials)}
+}
+
+func (s *ExternalCredentialService) UpsertCredential(ctx context.Context, credential *core.ExternalCredential) (*core.ExternalCredential, error) {
+	if credential == nil {
+		return nil, fmt.Errorf("upsert external credential: credential is required")
+	}
+	principalID := strings.TrimSpace(credential.PrincipalID)
+	plugin := strings.TrimSpace(credential.Plugin)
+	connection := strings.TrimSpace(credential.Connection)
+	instance := strings.TrimSpace(credential.Instance)
+	authType := strings.TrimSpace(credential.AuthType)
+	if principalID == "" || plugin == "" || connection == "" || authType == "" {
+		return nil, fmt.Errorf("upsert external credential: principal_id, plugin, connection, and auth_type are required")
+	}
+
+	now := time.Now()
+	id := credential.ID
+	createdAt := credential.CreatedAt
+	if existing, err := s.store.Index("by_lookup").Get(ctx, principalID, plugin, connection, instance); err == nil {
+		id = recString(existing, "id")
+		if created := recTime(existing, "created_at"); !created.IsZero() {
+			createdAt = created
+		}
+	} else if err != indexeddb.ErrNotFound {
+		return nil, fmt.Errorf("upsert external credential: %w", err)
+	}
+	if id == "" {
+		id = newRecordID()
+	}
+	if createdAt.IsZero() {
+		createdAt = now
+	}
+
+	rec := indexeddb.Record{
+		"id":                  id,
+		"principal_id":        principalID,
+		"plugin":              plugin,
+		"connection":          connection,
+		"instance":            instance,
+		"auth_type":           authType,
+		"payload_encrypted":   credential.PayloadEncrypted,
+		"scopes":              credential.Scopes,
+		"expires_at":          credential.ExpiresAt,
+		"last_refreshed_at":   credential.LastRefreshedAt,
+		"refresh_error_count": credential.RefreshErrorCount,
+		"metadata_json":       credential.MetadataJSON,
+		"created_at":          createdAt,
+		"updated_at":          now,
+	}
+	if err := s.store.Put(ctx, rec); err != nil {
+		return nil, fmt.Errorf("upsert external credential: %w", err)
+	}
+	return recordToExternalCredential(rec), nil
+}
+
+func (s *ExternalCredentialService) DeleteCredential(ctx context.Context, principalID, plugin, connection, instance string) error {
+	deleted, err := s.store.Index("by_lookup").Delete(ctx, strings.TrimSpace(principalID), strings.TrimSpace(plugin), strings.TrimSpace(connection), strings.TrimSpace(instance))
+	if err != nil {
+		return fmt.Errorf("delete external credential: %w", err)
+	}
+	if deleted == 0 {
+		return core.ErrNotFound
+	}
+	return nil
+}
+
+func (s *ExternalCredentialService) GetCredential(ctx context.Context, principalID, plugin, connection, instance string) (*core.ExternalCredential, error) {
+	rec, err := s.store.Index("by_lookup").Get(ctx, strings.TrimSpace(principalID), strings.TrimSpace(plugin), strings.TrimSpace(connection), strings.TrimSpace(instance))
+	if err != nil {
+		if err == indexeddb.ErrNotFound {
+			return nil, core.ErrNotFound
+		}
+		return nil, fmt.Errorf("get external credential: %w", err)
+	}
+	return recordToExternalCredential(rec), nil
+}
+
+type ServiceAccountAuthBindingService struct {
+	store indexeddb.ObjectStore
+}
+
+func NewServiceAccountAuthBindingService(ds indexeddb.IndexedDB) *ServiceAccountAuthBindingService {
+	return &ServiceAccountAuthBindingService{store: ds.ObjectStore(StoreServiceAccountAuthBindings)}
+}
+
+func encodeLegacyCredentialPayload(accessTokenEncrypted, refreshTokenEncrypted string) (string, error) {
+	payload := map[string]string{
+		"access_token_encrypted":  accessTokenEncrypted,
+		"refresh_token_encrypted": refreshTokenEncrypted,
+	}
+	raw, err := json.Marshal(payload)
+	if err != nil {
+		return "", fmt.Errorf("encode legacy credential payload: %w", err)
+	}
+	return string(raw), nil
+}
+
+func recordToExternalCredential(rec indexeddb.Record) *core.ExternalCredential {
+	return &core.ExternalCredential{
+		ID:                recString(rec, "id"),
+		PrincipalID:       recString(rec, "principal_id"),
+		Plugin:            recString(rec, "plugin"),
+		Connection:        recString(rec, "connection"),
+		Instance:          recString(rec, "instance"),
+		AuthType:          recString(rec, "auth_type"),
+		PayloadEncrypted:  recString(rec, "payload_encrypted"),
+		Scopes:            recString(rec, "scopes"),
+		ExpiresAt:         recTimePtr(rec, "expires_at"),
+		LastRefreshedAt:   recTimePtr(rec, "last_refreshed_at"),
+		RefreshErrorCount: recInt(rec, "refresh_error_count"),
+		MetadataJSON:      recString(rec, "metadata_json"),
+		CreatedAt:         recTime(rec, "created_at"),
+		UpdatedAt:         recTime(rec, "updated_at"),
+	}
+}

--- a/gestaltd/internal/coredata/canonical_future.go
+++ b/gestaltd/internal/coredata/canonical_future.go
@@ -11,55 +11,89 @@ import (
 	"github.com/valon-technologies/gestalt/server/core/indexeddb"
 )
 
-type ServiceAccountDelegationService struct {
+type IdentityDelegationService struct {
 	store indexeddb.ObjectStore
 }
 
-func NewServiceAccountDelegationService(ds indexeddb.IndexedDB) *ServiceAccountDelegationService {
-	return &ServiceAccountDelegationService{store: ds.ObjectStore(StoreServiceAccountDelegations)}
+func NewIdentityDelegationService(ds indexeddb.IndexedDB) *IdentityDelegationService {
+	return &IdentityDelegationService{store: ds.ObjectStore(StoreIdentityDelegations)}
 }
 
-func (s *ServiceAccountDelegationService) UpsertDelegation(ctx context.Context, delegation *core.ServiceAccountDelegation) (*core.ServiceAccountDelegation, error) {
+func (s *IdentityDelegationService) UpsertDelegation(ctx context.Context, delegation *core.IdentityDelegation) (*core.IdentityDelegation, error) {
 	if delegation == nil {
-		return nil, fmt.Errorf("upsert service account delegation: delegation is required")
+		return nil, fmt.Errorf("upsert identity delegation: delegation is required")
 	}
-	actorID := strings.TrimSpace(delegation.ActorUserPrincipalID)
-	targetID := strings.TrimSpace(delegation.TargetServiceAccountPrincipalID)
+	actorID := strings.TrimSpace(delegation.ActorIdentityID)
+	targetID := strings.TrimSpace(delegation.TargetIdentityID)
 	if actorID == "" || targetID == "" {
-		return nil, fmt.Errorf("upsert service account delegation: actor_user_principal_id and target_service_account_principal_id are required")
+		return nil, fmt.Errorf("upsert identity delegation: actor_identity_id and target_identity_id are required")
 	}
-	if delegation.ID == "" {
-		delegation.ID = newRecordID()
-	}
+
 	now := time.Now()
-	if delegation.CreatedAt.IsZero() {
-		delegation.CreatedAt = now
+	id := delegation.ID
+	createdAt := delegation.CreatedAt
+	plugin := strings.TrimSpace(delegation.Plugin)
+	if existing, err := s.store.Index("by_actor_target_plugin").Get(ctx, actorID, targetID, plugin); err == nil {
+		id = recString(existing, "id")
+		if created := recTime(existing, "created_at"); !created.IsZero() {
+			createdAt = created
+		}
+	} else if err != indexeddb.ErrNotFound {
+		return nil, fmt.Errorf("upsert identity delegation: %w", err)
 	}
-	delegation.UpdatedAt = now
+	if id == "" {
+		id = newRecordID()
+	}
+	if createdAt.IsZero() {
+		createdAt = now
+	}
+
 	rec := indexeddb.Record{
-		"id":                                  delegation.ID,
-		"actor_user_principal_id":             actorID,
-		"target_service_account_principal_id": targetID,
-		"plugin":                              strings.TrimSpace(delegation.Plugin),
-		"expires_at":                          delegation.ExpiresAt,
-		"created_at":                          delegation.CreatedAt,
-		"updated_at":                          delegation.UpdatedAt,
+		"id":                 id,
+		"actor_identity_id":  actorID,
+		"target_identity_id": targetID,
+		"plugin":             plugin,
+		"expires_at":         delegation.ExpiresAt,
+		"created_at":         createdAt,
+		"updated_at":         now,
 	}
 	if err := s.store.Put(ctx, rec); err != nil {
-		return nil, fmt.Errorf("upsert service account delegation: %w", err)
+		return nil, fmt.Errorf("upsert identity delegation: %w", err)
 	}
-	return recordToServiceAccountDelegation(rec), nil
+	return recordToIdentityDelegation(rec), nil
 }
 
-func recordToServiceAccountDelegation(rec indexeddb.Record) *core.ServiceAccountDelegation {
-	return &core.ServiceAccountDelegation{
-		ID:                              recString(rec, "id"),
-		ActorUserPrincipalID:            recString(rec, "actor_user_principal_id"),
-		TargetServiceAccountPrincipalID: recString(rec, "target_service_account_principal_id"),
-		Plugin:                          recString(rec, "plugin"),
-		ExpiresAt:                       recTimePtr(rec, "expires_at"),
-		CreatedAt:                       recTime(rec, "created_at"),
-		UpdatedAt:                       recTime(rec, "updated_at"),
+func (s *IdentityDelegationService) GetDelegation(ctx context.Context, actorIdentityID, targetIdentityID, plugin string) (*core.IdentityDelegation, error) {
+	rec, err := s.store.Index("by_actor_target_plugin").Get(ctx, strings.TrimSpace(actorIdentityID), strings.TrimSpace(targetIdentityID), strings.TrimSpace(plugin))
+	if err != nil {
+		if err == indexeddb.ErrNotFound {
+			return nil, core.ErrNotFound
+		}
+		return nil, fmt.Errorf("get identity delegation: %w", err)
+	}
+	return recordToIdentityDelegation(rec), nil
+}
+
+func (s *IdentityDelegationService) DeleteDelegation(ctx context.Context, actorIdentityID, targetIdentityID, plugin string) error {
+	deleted, err := s.store.Index("by_actor_target_plugin").Delete(ctx, strings.TrimSpace(actorIdentityID), strings.TrimSpace(targetIdentityID), strings.TrimSpace(plugin))
+	if err != nil {
+		return fmt.Errorf("delete identity delegation: %w", err)
+	}
+	if deleted == 0 {
+		return core.ErrNotFound
+	}
+	return nil
+}
+
+func recordToIdentityDelegation(rec indexeddb.Record) *core.IdentityDelegation {
+	return &core.IdentityDelegation{
+		ID:               recString(rec, "id"),
+		ActorIdentityID:  recString(rec, "actor_identity_id"),
+		TargetIdentityID: recString(rec, "target_identity_id"),
+		Plugin:           recString(rec, "plugin"),
+		ExpiresAt:        recTimePtr(rec, "expires_at"),
+		CreatedAt:        recTime(rec, "created_at"),
+		UpdatedAt:        recTime(rec, "updated_at"),
 	}
 }
 
@@ -75,19 +109,19 @@ func (s *ExternalCredentialService) UpsertCredential(ctx context.Context, creden
 	if credential == nil {
 		return nil, fmt.Errorf("upsert external credential: credential is required")
 	}
-	principalID := strings.TrimSpace(credential.PrincipalID)
+	identityID := strings.TrimSpace(credential.IdentityID)
 	plugin := strings.TrimSpace(credential.Plugin)
 	connection := strings.TrimSpace(credential.Connection)
 	instance := strings.TrimSpace(credential.Instance)
 	authType := strings.TrimSpace(credential.AuthType)
-	if principalID == "" || plugin == "" || connection == "" || authType == "" {
-		return nil, fmt.Errorf("upsert external credential: principal_id, plugin, connection, and auth_type are required")
+	if identityID == "" || plugin == "" || connection == "" || authType == "" {
+		return nil, fmt.Errorf("upsert external credential: identity_id, plugin, connection, and auth_type are required")
 	}
 
 	now := time.Now()
 	id := credential.ID
 	createdAt := credential.CreatedAt
-	if existing, err := s.store.Index("by_lookup").Get(ctx, principalID, plugin, connection, instance); err == nil {
+	if existing, err := s.store.Index("by_lookup").Get(ctx, identityID, plugin, connection, instance); err == nil {
 		id = recString(existing, "id")
 		if created := recTime(existing, "created_at"); !created.IsZero() {
 			createdAt = created
@@ -104,7 +138,7 @@ func (s *ExternalCredentialService) UpsertCredential(ctx context.Context, creden
 
 	rec := indexeddb.Record{
 		"id":                  id,
-		"principal_id":        principalID,
+		"identity_id":         identityID,
 		"plugin":              plugin,
 		"connection":          connection,
 		"instance":            instance,
@@ -124,8 +158,8 @@ func (s *ExternalCredentialService) UpsertCredential(ctx context.Context, creden
 	return recordToExternalCredential(rec), nil
 }
 
-func (s *ExternalCredentialService) DeleteCredential(ctx context.Context, principalID, plugin, connection, instance string) error {
-	deleted, err := s.store.Index("by_lookup").Delete(ctx, strings.TrimSpace(principalID), strings.TrimSpace(plugin), strings.TrimSpace(connection), strings.TrimSpace(instance))
+func (s *ExternalCredentialService) DeleteCredential(ctx context.Context, identityID, plugin, connection, instance string) error {
+	deleted, err := s.store.Index("by_lookup").Delete(ctx, strings.TrimSpace(identityID), strings.TrimSpace(plugin), strings.TrimSpace(connection), strings.TrimSpace(instance))
 	if err != nil {
 		return fmt.Errorf("delete external credential: %w", err)
 	}
@@ -135,8 +169,8 @@ func (s *ExternalCredentialService) DeleteCredential(ctx context.Context, princi
 	return nil
 }
 
-func (s *ExternalCredentialService) GetCredential(ctx context.Context, principalID, plugin, connection, instance string) (*core.ExternalCredential, error) {
-	rec, err := s.store.Index("by_lookup").Get(ctx, strings.TrimSpace(principalID), strings.TrimSpace(plugin), strings.TrimSpace(connection), strings.TrimSpace(instance))
+func (s *ExternalCredentialService) GetCredential(ctx context.Context, identityID, plugin, connection, instance string) (*core.ExternalCredential, error) {
+	rec, err := s.store.Index("by_lookup").Get(ctx, strings.TrimSpace(identityID), strings.TrimSpace(plugin), strings.TrimSpace(connection), strings.TrimSpace(instance))
 	if err != nil {
 		if err == indexeddb.ErrNotFound {
 			return nil, core.ErrNotFound
@@ -144,14 +178,6 @@ func (s *ExternalCredentialService) GetCredential(ctx context.Context, principal
 		return nil, fmt.Errorf("get external credential: %w", err)
 	}
 	return recordToExternalCredential(rec), nil
-}
-
-type ServiceAccountAuthBindingService struct {
-	store indexeddb.ObjectStore
-}
-
-func NewServiceAccountAuthBindingService(ds indexeddb.IndexedDB) *ServiceAccountAuthBindingService {
-	return &ServiceAccountAuthBindingService{store: ds.ObjectStore(StoreServiceAccountAuthBindings)}
 }
 
 func encodeLegacyCredentialPayload(accessTokenEncrypted, refreshTokenEncrypted string) (string, error) {
@@ -169,7 +195,7 @@ func encodeLegacyCredentialPayload(accessTokenEncrypted, refreshTokenEncrypted s
 func recordToExternalCredential(rec indexeddb.Record) *core.ExternalCredential {
 	return &core.ExternalCredential{
 		ID:                recString(rec, "id"),
-		PrincipalID:       recString(rec, "principal_id"),
+		IdentityID:        recString(rec, "identity_id"),
 		Plugin:            recString(rec, "plugin"),
 		Connection:        recString(rec, "connection"),
 		Instance:          recString(rec, "instance"),

--- a/gestaltd/internal/coredata/canonical_principals.go
+++ b/gestaltd/internal/coredata/canonical_principals.go
@@ -1,0 +1,282 @@
+package coredata
+
+import (
+	"context"
+	"fmt"
+	"strings"
+	"time"
+
+	"github.com/google/uuid"
+	"github.com/valon-technologies/gestalt/server/core"
+	"github.com/valon-technologies/gestalt/server/core/indexeddb"
+	"github.com/valon-technologies/gestalt/server/internal/emailutil"
+)
+
+const principalStatusActive = "active"
+const legacySharedServiceAccountPrincipalID = "__identity__"
+
+type PrincipalService struct {
+	store indexeddb.ObjectStore
+}
+
+func NewPrincipalService(ds indexeddb.IndexedDB) *PrincipalService {
+	return &PrincipalService{store: ds.ObjectStore(StorePrincipals)}
+}
+
+func (s *PrincipalService) UpsertPrincipal(ctx context.Context, principal *core.Principal) (*core.Principal, error) {
+	if principal == nil {
+		return nil, fmt.Errorf("upsert principal: principal is required")
+	}
+	id := strings.TrimSpace(principal.ID)
+	kind := strings.TrimSpace(principal.Kind)
+	displayName := strings.TrimSpace(principal.DisplayName)
+	if id == "" || kind == "" || displayName == "" {
+		return nil, fmt.Errorf("upsert principal: id, kind, and display_name are required")
+	}
+	status := strings.TrimSpace(principal.Status)
+	if status == "" {
+		status = principalStatusActive
+	}
+
+	now := time.Now()
+	createdAt := principal.CreatedAt
+	if existing, err := s.store.Get(ctx, id); err == nil {
+		if created := recTime(existing, "created_at"); !created.IsZero() {
+			createdAt = created
+		}
+	} else if err != indexeddb.ErrNotFound {
+		return nil, fmt.Errorf("upsert principal: %w", err)
+	}
+	if createdAt.IsZero() {
+		createdAt = now
+	}
+
+	rec := indexeddb.Record{
+		"id":           id,
+		"kind":         kind,
+		"status":       status,
+		"display_name": displayName,
+		"created_at":   createdAt,
+		"updated_at":   now,
+	}
+	if err := s.store.Put(ctx, rec); err != nil {
+		return nil, fmt.Errorf("upsert principal: %w", err)
+	}
+	return recordToPrincipal(rec), nil
+}
+
+func (s *PrincipalService) GetPrincipal(ctx context.Context, id string) (*core.Principal, error) {
+	rec, err := s.store.Get(ctx, strings.TrimSpace(id))
+	if err != nil {
+		if err == indexeddb.ErrNotFound {
+			return nil, core.ErrNotFound
+		}
+		return nil, fmt.Errorf("get principal: %w", err)
+	}
+	return recordToPrincipal(rec), nil
+}
+
+func (s *PrincipalService) DeletePrincipal(ctx context.Context, id string) error {
+	if err := s.store.Delete(ctx, strings.TrimSpace(id)); err != nil {
+		if err == indexeddb.ErrNotFound {
+			return core.ErrNotFound
+		}
+		return fmt.Errorf("delete principal: %w", err)
+	}
+	return nil
+}
+
+func recordToPrincipal(rec indexeddb.Record) *core.Principal {
+	return &core.Principal{
+		ID:          recString(rec, "id"),
+		Kind:        recString(rec, "kind"),
+		Status:      recString(rec, "status"),
+		DisplayName: recString(rec, "display_name"),
+		CreatedAt:   recTime(rec, "created_at"),
+		UpdatedAt:   recTime(rec, "updated_at"),
+	}
+}
+
+type UserProfileService struct {
+	store indexeddb.ObjectStore
+}
+
+func NewUserProfileService(ds indexeddb.IndexedDB) *UserProfileService {
+	return &UserProfileService{store: ds.ObjectStore(StoreUserProfiles)}
+}
+
+func (s *UserProfileService) UpsertProfile(ctx context.Context, profile *core.UserProfile) (*core.UserProfile, error) {
+	if profile == nil {
+		return nil, fmt.Errorf("upsert user profile: profile is required")
+	}
+	principalID := strings.TrimSpace(profile.PrincipalID)
+	email := emailutil.Normalize(profile.Email)
+	normalizedEmail := emailutil.Normalize(profile.NormalizedEmail)
+	if normalizedEmail == "" {
+		normalizedEmail = email
+	}
+	if principalID == "" || email == "" || normalizedEmail == "" {
+		return nil, fmt.Errorf("upsert user profile: principal_id and email are required")
+	}
+
+	now := time.Now()
+	createdAt := profile.CreatedAt
+	if existing, err := s.store.Get(ctx, principalID); err == nil {
+		if created := recTime(existing, "created_at"); !created.IsZero() {
+			createdAt = created
+		}
+	} else if err != indexeddb.ErrNotFound {
+		return nil, fmt.Errorf("upsert user profile: %w", err)
+	}
+	if createdAt.IsZero() {
+		createdAt = now
+	}
+
+	rec := indexeddb.Record{
+		"id":               principalID,
+		"principal_id":     principalID,
+		"email":            email,
+		"normalized_email": normalizedEmail,
+		"avatar_url":       strings.TrimSpace(profile.AvatarURL),
+		"created_at":       createdAt,
+		"updated_at":       now,
+	}
+	authProvider := strings.TrimSpace(profile.AuthProvider)
+	authSubject := strings.TrimSpace(profile.AuthSubject)
+	if authProvider != "" && authSubject != "" {
+		rec["auth_provider"] = authProvider
+		rec["auth_subject"] = authSubject
+	}
+	if err := s.store.Put(ctx, rec); err != nil {
+		return nil, fmt.Errorf("upsert user profile: %w", err)
+	}
+	return recordToUserProfile(rec), nil
+}
+
+func (s *UserProfileService) GetProfile(ctx context.Context, principalID string) (*core.UserProfile, error) {
+	rec, err := s.store.Get(ctx, strings.TrimSpace(principalID))
+	if err != nil {
+		if err == indexeddb.ErrNotFound {
+			return nil, core.ErrNotFound
+		}
+		return nil, fmt.Errorf("get user profile: %w", err)
+	}
+	return recordToUserProfile(rec), nil
+}
+
+func recordToUserProfile(rec indexeddb.Record) *core.UserProfile {
+	return &core.UserProfile{
+		PrincipalID:     recString(rec, "principal_id"),
+		Email:           recString(rec, "email"),
+		NormalizedEmail: recString(rec, "normalized_email"),
+		AuthProvider:    recString(rec, "auth_provider"),
+		AuthSubject:     recString(rec, "auth_subject"),
+		AvatarURL:       recString(rec, "avatar_url"),
+		CreatedAt:       recTime(rec, "created_at"),
+		UpdatedAt:       recTime(rec, "updated_at"),
+	}
+}
+
+type ServiceAccountService struct {
+	store indexeddb.ObjectStore
+}
+
+func NewServiceAccountService(ds indexeddb.IndexedDB) *ServiceAccountService {
+	return &ServiceAccountService{store: ds.ObjectStore(StoreServiceAccounts)}
+}
+
+func (s *ServiceAccountService) UpsertServiceAccount(ctx context.Context, sa *core.ServiceAccount) (*core.ServiceAccount, error) {
+	if sa == nil {
+		return nil, fmt.Errorf("upsert service account: service account is required")
+	}
+	principalID := strings.TrimSpace(sa.PrincipalID)
+	name := strings.TrimSpace(sa.Name)
+	if principalID == "" || name == "" {
+		return nil, fmt.Errorf("upsert service account: principal_id and name are required")
+	}
+
+	now := time.Now()
+	createdAt := sa.CreatedAt
+	if existing, err := s.store.Get(ctx, principalID); err == nil {
+		if created := recTime(existing, "created_at"); !created.IsZero() {
+			createdAt = created
+		}
+	} else if err != indexeddb.ErrNotFound {
+		return nil, fmt.Errorf("upsert service account: %w", err)
+	}
+	if createdAt.IsZero() {
+		createdAt = now
+	}
+
+	rec := indexeddb.Record{
+		"id":                      principalID,
+		"principal_id":            principalID,
+		"name":                    name,
+		"description":             strings.TrimSpace(sa.Description),
+		"created_by_principal_id": strings.TrimSpace(sa.CreatedByPrincipalID),
+		"created_at":              createdAt,
+		"updated_at":              now,
+	}
+	if err := s.store.Put(ctx, rec); err != nil {
+		return nil, fmt.Errorf("upsert service account: %w", err)
+	}
+	return recordToServiceAccount(rec), nil
+}
+
+func (s *ServiceAccountService) GetServiceAccount(ctx context.Context, principalID string) (*core.ServiceAccount, error) {
+	rec, err := s.store.Get(ctx, strings.TrimSpace(principalID))
+	if err != nil {
+		if err == indexeddb.ErrNotFound {
+			return nil, core.ErrNotFound
+		}
+		return nil, fmt.Errorf("get service account: %w", err)
+	}
+	return recordToServiceAccount(rec), nil
+}
+
+func (s *ServiceAccountService) DeleteServiceAccount(ctx context.Context, principalID string) error {
+	if err := s.store.Delete(ctx, strings.TrimSpace(principalID)); err != nil {
+		if err == indexeddb.ErrNotFound {
+			return core.ErrNotFound
+		}
+		return fmt.Errorf("delete service account: %w", err)
+	}
+	return nil
+}
+
+func recordToServiceAccount(rec indexeddb.Record) *core.ServiceAccount {
+	return &core.ServiceAccount{
+		PrincipalID:          recString(rec, "principal_id"),
+		Name:                 recString(rec, "name"),
+		Description:          recString(rec, "description"),
+		CreatedByPrincipalID: recString(rec, "created_by_principal_id"),
+		CreatedAt:            recTime(rec, "created_at"),
+		UpdatedAt:            recTime(rec, "updated_at"),
+	}
+}
+
+func newRecordID() string {
+	return uuid.NewString()
+}
+
+func ensureLegacySharedServiceAccount(ctx context.Context, principals *PrincipalService, serviceAccounts *ServiceAccountService) error {
+	if principals == nil || serviceAccounts == nil {
+		return nil
+	}
+	if _, err := principals.UpsertPrincipal(ctx, &core.Principal{
+		ID:          legacySharedServiceAccountPrincipalID,
+		Kind:        core.PrincipalKindServiceAccount,
+		Status:      principalStatusActive,
+		DisplayName: "Legacy Shared Identity",
+	}); err != nil {
+		return fmt.Errorf("seed legacy shared service-account principal: %w", err)
+	}
+	if _, err := serviceAccounts.UpsertServiceAccount(ctx, &core.ServiceAccount{
+		PrincipalID: legacySharedServiceAccountPrincipalID,
+		Name:        "legacy-shared-identity",
+		Description: "Compatibility shim for legacy __identity__-owned credentials",
+	}); err != nil {
+		return fmt.Errorf("seed legacy shared service account: %w", err)
+	}
+	return nil
+}

--- a/gestaltd/internal/coredata/canonical_principals.go
+++ b/gestaltd/internal/coredata/canonical_principals.go
@@ -2,6 +2,7 @@ package coredata
 
 import (
 	"context"
+	"encoding/json"
 	"fmt"
 	"strings"
 	"time"
@@ -9,43 +10,140 @@ import (
 	"github.com/google/uuid"
 	"github.com/valon-technologies/gestalt/server/core"
 	"github.com/valon-technologies/gestalt/server/core/indexeddb"
-	"github.com/valon-technologies/gestalt/server/internal/emailutil"
 )
 
-const principalStatusActive = "active"
-const legacySharedServiceAccountPrincipalID = "__identity__"
+const identityStatusActive = "active"
 
-type PrincipalService struct {
+const legacyIdentityBindingAuthority = "legacy"
+
+type IdentityService struct {
 	store indexeddb.ObjectStore
 }
 
-func NewPrincipalService(ds indexeddb.IndexedDB) *PrincipalService {
-	return &PrincipalService{store: ds.ObjectStore(StorePrincipals)}
+func NewIdentityService(ds indexeddb.IndexedDB) *IdentityService {
+	return &IdentityService{store: ds.ObjectStore(StoreIdentities)}
 }
 
-func (s *PrincipalService) UpsertPrincipal(ctx context.Context, principal *core.Principal) (*core.Principal, error) {
-	if principal == nil {
-		return nil, fmt.Errorf("upsert principal: principal is required")
+func (s *IdentityService) UpsertIdentity(ctx context.Context, identity *core.Identity) (*core.Identity, error) {
+	if identity == nil {
+		return nil, fmt.Errorf("upsert identity: identity is required")
 	}
-	id := strings.TrimSpace(principal.ID)
-	kind := strings.TrimSpace(principal.Kind)
-	displayName := strings.TrimSpace(principal.DisplayName)
-	if id == "" || kind == "" || displayName == "" {
-		return nil, fmt.Errorf("upsert principal: id, kind, and display_name are required")
+	id := strings.TrimSpace(identity.ID)
+	displayName := strings.TrimSpace(identity.DisplayName)
+	if id == "" || displayName == "" {
+		return nil, fmt.Errorf("upsert identity: id and display_name are required")
 	}
-	status := strings.TrimSpace(principal.Status)
+	status := strings.TrimSpace(identity.Status)
 	if status == "" {
-		status = principalStatusActive
+		status = identityStatusActive
 	}
 
 	now := time.Now()
-	createdAt := principal.CreatedAt
+	createdAt := identity.CreatedAt
 	if existing, err := s.store.Get(ctx, id); err == nil {
 		if created := recTime(existing, "created_at"); !created.IsZero() {
 			createdAt = created
 		}
 	} else if err != indexeddb.ErrNotFound {
-		return nil, fmt.Errorf("upsert principal: %w", err)
+		return nil, fmt.Errorf("upsert identity: %w", err)
+	}
+	if createdAt.IsZero() {
+		createdAt = now
+	}
+
+	rec := indexeddb.Record{
+		"id":                     id,
+		"status":                 status,
+		"display_name":           displayName,
+		"created_by_identity_id": strings.TrimSpace(identity.CreatedByIdentityID),
+		"metadata_json":          strings.TrimSpace(identity.MetadataJSON),
+		"created_at":             createdAt,
+		"updated_at":             now,
+	}
+	if err := s.store.Put(ctx, rec); err != nil {
+		return nil, fmt.Errorf("upsert identity: %w", err)
+	}
+	return recordToIdentity(rec), nil
+}
+
+func (s *IdentityService) GetIdentity(ctx context.Context, id string) (*core.Identity, error) {
+	rec, err := s.store.Get(ctx, strings.TrimSpace(id))
+	if err != nil {
+		if err == indexeddb.ErrNotFound {
+			return nil, core.ErrNotFound
+		}
+		return nil, fmt.Errorf("get identity: %w", err)
+	}
+	return recordToIdentity(rec), nil
+}
+
+func (s *IdentityService) DeleteIdentity(ctx context.Context, id string) error {
+	if err := s.store.Delete(ctx, strings.TrimSpace(id)); err != nil {
+		if err == indexeddb.ErrNotFound {
+			return core.ErrNotFound
+		}
+		return fmt.Errorf("delete identity: %w", err)
+	}
+	return nil
+}
+
+func (s *IdentityService) ListIdentities(ctx context.Context) ([]*core.Identity, error) {
+	recs, err := s.store.GetAll(ctx, nil)
+	if err != nil {
+		return nil, fmt.Errorf("list identities: %w", err)
+	}
+	out := make([]*core.Identity, 0, len(recs))
+	for _, rec := range recs {
+		out = append(out, recordToIdentity(rec))
+	}
+	return out, nil
+}
+
+func recordToIdentity(rec indexeddb.Record) *core.Identity {
+	return &core.Identity{
+		ID:                  recString(rec, "id"),
+		Status:              recString(rec, "status"),
+		DisplayName:         recString(rec, "display_name"),
+		CreatedByIdentityID: recString(rec, "created_by_identity_id"),
+		MetadataJSON:        recString(rec, "metadata_json"),
+		CreatedAt:           recTime(rec, "created_at"),
+		UpdatedAt:           recTime(rec, "updated_at"),
+	}
+}
+
+type IdentityAuthBindingService struct {
+	store indexeddb.ObjectStore
+}
+
+func NewIdentityAuthBindingService(ds indexeddb.IndexedDB) *IdentityAuthBindingService {
+	return &IdentityAuthBindingService{store: ds.ObjectStore(StoreIdentityAuthBindings)}
+}
+
+func (s *IdentityAuthBindingService) UpsertBinding(ctx context.Context, binding *core.IdentityAuthBinding) (*core.IdentityAuthBinding, error) {
+	if binding == nil {
+		return nil, fmt.Errorf("upsert identity auth binding: binding is required")
+	}
+	identityID := strings.TrimSpace(binding.IdentityID)
+	bindingKind := strings.TrimSpace(binding.BindingKind)
+	authority := strings.TrimSpace(binding.Authority)
+	lookupKey := strings.TrimSpace(binding.LookupKey)
+	if identityID == "" || bindingKind == "" || authority == "" || lookupKey == "" {
+		return nil, fmt.Errorf("upsert identity auth binding: identity_id, binding_kind, authority, and lookup_key are required")
+	}
+
+	now := time.Now()
+	id := binding.ID
+	createdAt := binding.CreatedAt
+	if existing, err := s.store.Index("by_lookup").Get(ctx, bindingKind, authority, lookupKey); err == nil {
+		id = recString(existing, "id")
+		if created := recTime(existing, "created_at"); !created.IsZero() {
+			createdAt = created
+		}
+	} else if err != indexeddb.ErrNotFound {
+		return nil, fmt.Errorf("upsert identity auth binding: %w", err)
+	}
+	if id == "" {
+		id = newRecordID()
 	}
 	if createdAt.IsZero() {
 		createdAt = now
@@ -53,205 +151,64 @@ func (s *PrincipalService) UpsertPrincipal(ctx context.Context, principal *core.
 
 	rec := indexeddb.Record{
 		"id":           id,
-		"kind":         kind,
-		"status":       status,
-		"display_name": displayName,
+		"identity_id":  identityID,
+		"binding_kind": bindingKind,
+		"authority":    authority,
+		"lookup_key":   lookupKey,
+		"binding_json": strings.TrimSpace(binding.BindingJSON),
 		"created_at":   createdAt,
 		"updated_at":   now,
 	}
 	if err := s.store.Put(ctx, rec); err != nil {
-		return nil, fmt.Errorf("upsert principal: %w", err)
+		return nil, fmt.Errorf("upsert identity auth binding: %w", err)
 	}
-	return recordToPrincipal(rec), nil
+	return recordToIdentityAuthBinding(rec), nil
 }
 
-func (s *PrincipalService) GetPrincipal(ctx context.Context, id string) (*core.Principal, error) {
-	rec, err := s.store.Get(ctx, strings.TrimSpace(id))
+func (s *IdentityAuthBindingService) GetBinding(ctx context.Context, bindingKind, authority, lookupKey string) (*core.IdentityAuthBinding, error) {
+	rec, err := s.store.Index("by_lookup").Get(ctx, strings.TrimSpace(bindingKind), strings.TrimSpace(authority), strings.TrimSpace(lookupKey))
 	if err != nil {
 		if err == indexeddb.ErrNotFound {
 			return nil, core.ErrNotFound
 		}
-		return nil, fmt.Errorf("get principal: %w", err)
+		return nil, fmt.Errorf("get identity auth binding: %w", err)
 	}
-	return recordToPrincipal(rec), nil
+	return recordToIdentityAuthBinding(rec), nil
 }
 
-func (s *PrincipalService) DeletePrincipal(ctx context.Context, id string) error {
-	if err := s.store.Delete(ctx, strings.TrimSpace(id)); err != nil {
-		if err == indexeddb.ErrNotFound {
-			return core.ErrNotFound
-		}
-		return fmt.Errorf("delete principal: %w", err)
+func (s *IdentityAuthBindingService) ListByIdentity(ctx context.Context, identityID string) ([]*core.IdentityAuthBinding, error) {
+	recs, err := s.store.Index("by_identity").GetAll(ctx, nil, strings.TrimSpace(identityID))
+	if err != nil {
+		return nil, fmt.Errorf("list identity auth bindings: %w", err)
+	}
+	out := make([]*core.IdentityAuthBinding, 0, len(recs))
+	for _, rec := range recs {
+		out = append(out, recordToIdentityAuthBinding(rec))
+	}
+	return out, nil
+}
+
+func (s *IdentityAuthBindingService) DeleteBinding(ctx context.Context, bindingKind, authority, lookupKey string) error {
+	deleted, err := s.store.Index("by_lookup").Delete(ctx, strings.TrimSpace(bindingKind), strings.TrimSpace(authority), strings.TrimSpace(lookupKey))
+	if err != nil {
+		return fmt.Errorf("delete identity auth binding: %w", err)
+	}
+	if deleted == 0 {
+		return core.ErrNotFound
 	}
 	return nil
 }
 
-func recordToPrincipal(rec indexeddb.Record) *core.Principal {
-	return &core.Principal{
+func recordToIdentityAuthBinding(rec indexeddb.Record) *core.IdentityAuthBinding {
+	return &core.IdentityAuthBinding{
 		ID:          recString(rec, "id"),
-		Kind:        recString(rec, "kind"),
-		Status:      recString(rec, "status"),
-		DisplayName: recString(rec, "display_name"),
+		IdentityID:  recString(rec, "identity_id"),
+		BindingKind: recString(rec, "binding_kind"),
+		Authority:   recString(rec, "authority"),
+		LookupKey:   recString(rec, "lookup_key"),
+		BindingJSON: recString(rec, "binding_json"),
 		CreatedAt:   recTime(rec, "created_at"),
 		UpdatedAt:   recTime(rec, "updated_at"),
-	}
-}
-
-type UserProfileService struct {
-	store indexeddb.ObjectStore
-}
-
-func NewUserProfileService(ds indexeddb.IndexedDB) *UserProfileService {
-	return &UserProfileService{store: ds.ObjectStore(StoreUserProfiles)}
-}
-
-func (s *UserProfileService) UpsertProfile(ctx context.Context, profile *core.UserProfile) (*core.UserProfile, error) {
-	if profile == nil {
-		return nil, fmt.Errorf("upsert user profile: profile is required")
-	}
-	principalID := strings.TrimSpace(profile.PrincipalID)
-	email := emailutil.Normalize(profile.Email)
-	normalizedEmail := emailutil.Normalize(profile.NormalizedEmail)
-	if normalizedEmail == "" {
-		normalizedEmail = email
-	}
-	if principalID == "" || email == "" || normalizedEmail == "" {
-		return nil, fmt.Errorf("upsert user profile: principal_id and email are required")
-	}
-
-	now := time.Now()
-	createdAt := profile.CreatedAt
-	if existing, err := s.store.Get(ctx, principalID); err == nil {
-		if created := recTime(existing, "created_at"); !created.IsZero() {
-			createdAt = created
-		}
-	} else if err != indexeddb.ErrNotFound {
-		return nil, fmt.Errorf("upsert user profile: %w", err)
-	}
-	if createdAt.IsZero() {
-		createdAt = now
-	}
-
-	rec := indexeddb.Record{
-		"id":               principalID,
-		"principal_id":     principalID,
-		"email":            email,
-		"normalized_email": normalizedEmail,
-		"avatar_url":       strings.TrimSpace(profile.AvatarURL),
-		"created_at":       createdAt,
-		"updated_at":       now,
-	}
-	authProvider := strings.TrimSpace(profile.AuthProvider)
-	authSubject := strings.TrimSpace(profile.AuthSubject)
-	if authProvider != "" && authSubject != "" {
-		rec["auth_provider"] = authProvider
-		rec["auth_subject"] = authSubject
-	}
-	if err := s.store.Put(ctx, rec); err != nil {
-		return nil, fmt.Errorf("upsert user profile: %w", err)
-	}
-	return recordToUserProfile(rec), nil
-}
-
-func (s *UserProfileService) GetProfile(ctx context.Context, principalID string) (*core.UserProfile, error) {
-	rec, err := s.store.Get(ctx, strings.TrimSpace(principalID))
-	if err != nil {
-		if err == indexeddb.ErrNotFound {
-			return nil, core.ErrNotFound
-		}
-		return nil, fmt.Errorf("get user profile: %w", err)
-	}
-	return recordToUserProfile(rec), nil
-}
-
-func recordToUserProfile(rec indexeddb.Record) *core.UserProfile {
-	return &core.UserProfile{
-		PrincipalID:     recString(rec, "principal_id"),
-		Email:           recString(rec, "email"),
-		NormalizedEmail: recString(rec, "normalized_email"),
-		AuthProvider:    recString(rec, "auth_provider"),
-		AuthSubject:     recString(rec, "auth_subject"),
-		AvatarURL:       recString(rec, "avatar_url"),
-		CreatedAt:       recTime(rec, "created_at"),
-		UpdatedAt:       recTime(rec, "updated_at"),
-	}
-}
-
-type ServiceAccountService struct {
-	store indexeddb.ObjectStore
-}
-
-func NewServiceAccountService(ds indexeddb.IndexedDB) *ServiceAccountService {
-	return &ServiceAccountService{store: ds.ObjectStore(StoreServiceAccounts)}
-}
-
-func (s *ServiceAccountService) UpsertServiceAccount(ctx context.Context, sa *core.ServiceAccount) (*core.ServiceAccount, error) {
-	if sa == nil {
-		return nil, fmt.Errorf("upsert service account: service account is required")
-	}
-	principalID := strings.TrimSpace(sa.PrincipalID)
-	name := strings.TrimSpace(sa.Name)
-	if principalID == "" || name == "" {
-		return nil, fmt.Errorf("upsert service account: principal_id and name are required")
-	}
-
-	now := time.Now()
-	createdAt := sa.CreatedAt
-	if existing, err := s.store.Get(ctx, principalID); err == nil {
-		if created := recTime(existing, "created_at"); !created.IsZero() {
-			createdAt = created
-		}
-	} else if err != indexeddb.ErrNotFound {
-		return nil, fmt.Errorf("upsert service account: %w", err)
-	}
-	if createdAt.IsZero() {
-		createdAt = now
-	}
-
-	rec := indexeddb.Record{
-		"id":                      principalID,
-		"principal_id":            principalID,
-		"name":                    name,
-		"description":             strings.TrimSpace(sa.Description),
-		"created_by_principal_id": strings.TrimSpace(sa.CreatedByPrincipalID),
-		"created_at":              createdAt,
-		"updated_at":              now,
-	}
-	if err := s.store.Put(ctx, rec); err != nil {
-		return nil, fmt.Errorf("upsert service account: %w", err)
-	}
-	return recordToServiceAccount(rec), nil
-}
-
-func (s *ServiceAccountService) GetServiceAccount(ctx context.Context, principalID string) (*core.ServiceAccount, error) {
-	rec, err := s.store.Get(ctx, strings.TrimSpace(principalID))
-	if err != nil {
-		if err == indexeddb.ErrNotFound {
-			return nil, core.ErrNotFound
-		}
-		return nil, fmt.Errorf("get service account: %w", err)
-	}
-	return recordToServiceAccount(rec), nil
-}
-
-func (s *ServiceAccountService) DeleteServiceAccount(ctx context.Context, principalID string) error {
-	if err := s.store.Delete(ctx, strings.TrimSpace(principalID)); err != nil {
-		if err == indexeddb.ErrNotFound {
-			return core.ErrNotFound
-		}
-		return fmt.Errorf("delete service account: %w", err)
-	}
-	return nil
-}
-
-func recordToServiceAccount(rec indexeddb.Record) *core.ServiceAccount {
-	return &core.ServiceAccount{
-		PrincipalID:          recString(rec, "principal_id"),
-		Name:                 recString(rec, "name"),
-		Description:          recString(rec, "description"),
-		CreatedByPrincipalID: recString(rec, "created_by_principal_id"),
-		CreatedAt:            recTime(rec, "created_at"),
-		UpdatedAt:            recTime(rec, "updated_at"),
 	}
 }
 
@@ -259,24 +216,19 @@ func newRecordID() string {
 	return uuid.NewString()
 }
 
-func ensureLegacySharedServiceAccount(ctx context.Context, principals *PrincipalService, serviceAccounts *ServiceAccountService) error {
-	if principals == nil || serviceAccounts == nil {
-		return nil
+func legacyIdentityMetadataJSON(label string, extra map[string]string) string {
+	payload := map[string]string{
+		"label": label,
 	}
-	if _, err := principals.UpsertPrincipal(ctx, &core.Principal{
-		ID:          legacySharedServiceAccountPrincipalID,
-		Kind:        core.PrincipalKindServiceAccount,
-		Status:      principalStatusActive,
-		DisplayName: "Legacy Shared Identity",
-	}); err != nil {
-		return fmt.Errorf("seed legacy shared service-account principal: %w", err)
+	for key, value := range extra {
+		if strings.TrimSpace(key) == "" || strings.TrimSpace(value) == "" {
+			continue
+		}
+		payload[key] = value
 	}
-	if _, err := serviceAccounts.UpsertServiceAccount(ctx, &core.ServiceAccount{
-		PrincipalID: legacySharedServiceAccountPrincipalID,
-		Name:        "legacy-shared-identity",
-		Description: "Compatibility shim for legacy __identity__-owned credentials",
-	}); err != nil {
-		return fmt.Errorf("seed legacy shared service account: %w", err)
+	raw, err := json.Marshal(payload)
+	if err != nil {
+		return ""
 	}
-	return nil
+	return string(raw)
 }

--- a/gestaltd/internal/coredata/convert.go
+++ b/gestaltd/internal/coredata/convert.go
@@ -38,6 +38,25 @@ func recInt(rec indexeddb.Record, key string) int {
 	}
 }
 
+func recBool(rec indexeddb.Record, key string) bool {
+	v, ok := rec[key]
+	if !ok || v == nil {
+		return false
+	}
+	switch b := v.(type) {
+	case bool:
+		return b
+	case int:
+		return b != 0
+	case int64:
+		return b != 0
+	case float64:
+		return b != 0
+	default:
+		return false
+	}
+}
+
 func recTime(rec indexeddb.Record, key string) time.Time {
 	v, ok := rec[key]
 	if !ok || v == nil {

--- a/gestaltd/internal/coredata/managed_identities.go
+++ b/gestaltd/internal/coredata/managed_identities.go
@@ -11,11 +11,17 @@ import (
 )
 
 type ManagedIdentityService struct {
-	store indexeddb.ObjectStore
+	store           indexeddb.ObjectStore
+	principals      *PrincipalService
+	serviceAccounts *ServiceAccountService
 }
 
-func NewManagedIdentityService(ds indexeddb.IndexedDB) *ManagedIdentityService {
-	return &ManagedIdentityService{store: ds.ObjectStore(StoreManagedIdentities)}
+func NewManagedIdentityService(ds indexeddb.IndexedDB, principals *PrincipalService, serviceAccounts *ServiceAccountService) *ManagedIdentityService {
+	return &ManagedIdentityService{
+		store:           ds.ObjectStore(StoreManagedIdentities),
+		principals:      principals,
+		serviceAccounts: serviceAccounts,
+	}
 }
 
 func (s *ManagedIdentityService) CreateIdentity(ctx context.Context, identity *core.ManagedIdentity) error {
@@ -36,6 +42,9 @@ func (s *ManagedIdentityService) CreateIdentity(ctx context.Context, identity *c
 		"updated_at":   identity.UpdatedAt,
 	}); err != nil {
 		return fmt.Errorf("create managed identity: %w", err)
+	}
+	if err := s.syncCanonicalServiceAccount(ctx, identity); err != nil {
+		return err
 	}
 	return nil
 }
@@ -71,6 +80,9 @@ func (s *ManagedIdentityService) UpdateIdentity(ctx context.Context, identity *c
 	}); err != nil {
 		return fmt.Errorf("update managed identity: %w", err)
 	}
+	if err := s.syncCanonicalServiceAccount(ctx, identity); err != nil {
+		return err
+	}
 	return nil
 }
 
@@ -80,6 +92,16 @@ func (s *ManagedIdentityService) DeleteIdentity(ctx context.Context, id string) 
 	}
 	if err := s.store.Delete(ctx, id); err != nil {
 		return fmt.Errorf("delete managed identity: %w", err)
+	}
+	if s.serviceAccounts != nil {
+		if err := s.serviceAccounts.DeleteServiceAccount(ctx, id); err != nil && err != core.ErrNotFound {
+			return fmt.Errorf("delete canonical service account: %w", err)
+		}
+	}
+	if s.principals != nil {
+		if err := s.principals.DeletePrincipal(ctx, id); err != nil && err != core.ErrNotFound {
+			return fmt.Errorf("delete canonical principal: %w", err)
+		}
 	}
 	return nil
 }
@@ -102,6 +124,22 @@ func (s *ManagedIdentityService) ListIdentitiesByIDs(ctx context.Context, ids []
 	return out, nil
 }
 
+func (s *ManagedIdentityService) BackfillCanonicalServiceAccounts(ctx context.Context) error {
+	if s.principals == nil || s.serviceAccounts == nil {
+		return nil
+	}
+	recs, err := s.store.GetAll(ctx, nil)
+	if err != nil {
+		return fmt.Errorf("list managed identities for canonical backfill: %w", err)
+	}
+	for _, rec := range recs {
+		if err := s.syncCanonicalServiceAccount(ctx, recordToManagedIdentity(rec)); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
 func recordToManagedIdentity(rec indexeddb.Record) *core.ManagedIdentity {
 	return &core.ManagedIdentity{
 		ID:          recString(rec, "id"),
@@ -109,4 +147,34 @@ func recordToManagedIdentity(rec indexeddb.Record) *core.ManagedIdentity {
 		CreatedAt:   recTime(rec, "created_at"),
 		UpdatedAt:   recTime(rec, "updated_at"),
 	}
+}
+
+func (s *ManagedIdentityService) syncCanonicalServiceAccount(ctx context.Context, identity *core.ManagedIdentity) error {
+	if s.principals == nil || s.serviceAccounts == nil || identity == nil || identity.ID == "" {
+		return nil
+	}
+	displayName := identity.DisplayName
+	if displayName == "" {
+		displayName = identity.ID
+	}
+	if _, err := s.principals.UpsertPrincipal(ctx, &core.Principal{
+		ID:          identity.ID,
+		Kind:        core.PrincipalKindServiceAccount,
+		Status:      principalStatusActive,
+		DisplayName: displayName,
+		CreatedAt:   identity.CreatedAt,
+		UpdatedAt:   identity.UpdatedAt,
+	}); err != nil {
+		return fmt.Errorf("sync canonical service-account principal %q: %w", identity.ID, err)
+	}
+	if _, err := s.serviceAccounts.UpsertServiceAccount(ctx, &core.ServiceAccount{
+		PrincipalID: identity.ID,
+		Name:        identity.ID,
+		Description: identity.DisplayName,
+		CreatedAt:   identity.CreatedAt,
+		UpdatedAt:   identity.UpdatedAt,
+	}); err != nil {
+		return fmt.Errorf("sync canonical service account %q: %w", identity.ID, err)
+	}
+	return nil
 }

--- a/gestaltd/internal/coredata/managed_identities.go
+++ b/gestaltd/internal/coredata/managed_identities.go
@@ -11,16 +11,14 @@ import (
 )
 
 type ManagedIdentityService struct {
-	store           indexeddb.ObjectStore
-	principals      *PrincipalService
-	serviceAccounts *ServiceAccountService
+	store      indexeddb.ObjectStore
+	identities *IdentityService
 }
 
-func NewManagedIdentityService(ds indexeddb.IndexedDB, principals *PrincipalService, serviceAccounts *ServiceAccountService) *ManagedIdentityService {
+func NewManagedIdentityService(ds indexeddb.IndexedDB, identities *IdentityService) *ManagedIdentityService {
 	return &ManagedIdentityService{
-		store:           ds.ObjectStore(StoreManagedIdentities),
-		principals:      principals,
-		serviceAccounts: serviceAccounts,
+		store:      ds.ObjectStore(StoreManagedIdentities),
+		identities: identities,
 	}
 }
 
@@ -36,14 +34,15 @@ func (s *ManagedIdentityService) CreateIdentity(ctx context.Context, identity *c
 		identity.UpdatedAt = identity.CreatedAt
 	}
 	if err := s.store.Add(ctx, indexeddb.Record{
-		"id":           identity.ID,
-		"display_name": identity.DisplayName,
-		"created_at":   identity.CreatedAt,
-		"updated_at":   identity.UpdatedAt,
+		"id":                     identity.ID,
+		"display_name":           identity.DisplayName,
+		"created_by_identity_id": identity.CreatedByIdentityID,
+		"created_at":             identity.CreatedAt,
+		"updated_at":             identity.UpdatedAt,
 	}); err != nil {
 		return fmt.Errorf("create managed identity: %w", err)
 	}
-	if err := s.syncCanonicalServiceAccount(ctx, identity); err != nil {
+	if err := s.syncCanonicalIdentity(ctx, identity); err != nil {
 		return err
 	}
 	return nil
@@ -69,18 +68,22 @@ func (s *ManagedIdentityService) UpdateIdentity(ctx context.Context, identity *c
 		return err
 	}
 	identity.CreatedAt = existing.CreatedAt
+	if identity.CreatedByIdentityID == "" {
+		identity.CreatedByIdentityID = existing.CreatedByIdentityID
+	}
 	if identity.UpdatedAt.IsZero() {
 		identity.UpdatedAt = time.Now()
 	}
 	if err := s.store.Put(ctx, indexeddb.Record{
-		"id":           identity.ID,
-		"display_name": identity.DisplayName,
-		"created_at":   identity.CreatedAt,
-		"updated_at":   identity.UpdatedAt,
+		"id":                     identity.ID,
+		"display_name":           identity.DisplayName,
+		"created_by_identity_id": identity.CreatedByIdentityID,
+		"created_at":             identity.CreatedAt,
+		"updated_at":             identity.UpdatedAt,
 	}); err != nil {
 		return fmt.Errorf("update managed identity: %w", err)
 	}
-	if err := s.syncCanonicalServiceAccount(ctx, identity); err != nil {
+	if err := s.syncCanonicalIdentity(ctx, identity); err != nil {
 		return err
 	}
 	return nil
@@ -93,14 +96,9 @@ func (s *ManagedIdentityService) DeleteIdentity(ctx context.Context, id string) 
 	if err := s.store.Delete(ctx, id); err != nil {
 		return fmt.Errorf("delete managed identity: %w", err)
 	}
-	if s.serviceAccounts != nil {
-		if err := s.serviceAccounts.DeleteServiceAccount(ctx, id); err != nil && err != core.ErrNotFound {
-			return fmt.Errorf("delete canonical service account: %w", err)
-		}
-	}
-	if s.principals != nil {
-		if err := s.principals.DeletePrincipal(ctx, id); err != nil && err != core.ErrNotFound {
-			return fmt.Errorf("delete canonical principal: %w", err)
+	if s.identities != nil {
+		if err := s.identities.DeleteIdentity(ctx, id); err != nil && err != core.ErrNotFound {
+			return fmt.Errorf("delete canonical identity: %w", err)
 		}
 	}
 	return nil
@@ -124,8 +122,8 @@ func (s *ManagedIdentityService) ListIdentitiesByIDs(ctx context.Context, ids []
 	return out, nil
 }
 
-func (s *ManagedIdentityService) BackfillCanonicalServiceAccounts(ctx context.Context) error {
-	if s.principals == nil || s.serviceAccounts == nil {
+func (s *ManagedIdentityService) BackfillCanonicalIdentities(ctx context.Context) error {
+	if s.identities == nil {
 		return nil
 	}
 	recs, err := s.store.GetAll(ctx, nil)
@@ -133,7 +131,7 @@ func (s *ManagedIdentityService) BackfillCanonicalServiceAccounts(ctx context.Co
 		return fmt.Errorf("list managed identities for canonical backfill: %w", err)
 	}
 	for _, rec := range recs {
-		if err := s.syncCanonicalServiceAccount(ctx, recordToManagedIdentity(rec)); err != nil {
+		if err := s.syncCanonicalIdentity(ctx, recordToManagedIdentity(rec)); err != nil {
 			return err
 		}
 	}
@@ -142,39 +140,32 @@ func (s *ManagedIdentityService) BackfillCanonicalServiceAccounts(ctx context.Co
 
 func recordToManagedIdentity(rec indexeddb.Record) *core.ManagedIdentity {
 	return &core.ManagedIdentity{
-		ID:          recString(rec, "id"),
-		DisplayName: recString(rec, "display_name"),
-		CreatedAt:   recTime(rec, "created_at"),
-		UpdatedAt:   recTime(rec, "updated_at"),
+		ID:                  recString(rec, "id"),
+		DisplayName:         recString(rec, "display_name"),
+		CreatedByIdentityID: recString(rec, "created_by_identity_id"),
+		CreatedAt:           recTime(rec, "created_at"),
+		UpdatedAt:           recTime(rec, "updated_at"),
 	}
 }
 
-func (s *ManagedIdentityService) syncCanonicalServiceAccount(ctx context.Context, identity *core.ManagedIdentity) error {
-	if s.principals == nil || s.serviceAccounts == nil || identity == nil || identity.ID == "" {
+func (s *ManagedIdentityService) syncCanonicalIdentity(ctx context.Context, identity *core.ManagedIdentity) error {
+	if s.identities == nil || identity == nil || identity.ID == "" {
 		return nil
 	}
 	displayName := identity.DisplayName
 	if displayName == "" {
 		displayName = identity.ID
 	}
-	if _, err := s.principals.UpsertPrincipal(ctx, &core.Principal{
-		ID:          identity.ID,
-		Kind:        core.PrincipalKindServiceAccount,
-		Status:      principalStatusActive,
-		DisplayName: displayName,
-		CreatedAt:   identity.CreatedAt,
-		UpdatedAt:   identity.UpdatedAt,
+	if _, err := s.identities.UpsertIdentity(ctx, &core.Identity{
+		ID:                  identity.ID,
+		Status:              identityStatusActive,
+		DisplayName:         displayName,
+		CreatedByIdentityID: identity.CreatedByIdentityID,
+		MetadataJSON:        legacyIdentityMetadataJSON("service_account", nil),
+		CreatedAt:           identity.CreatedAt,
+		UpdatedAt:           identity.UpdatedAt,
 	}); err != nil {
-		return fmt.Errorf("sync canonical service-account principal %q: %w", identity.ID, err)
-	}
-	if _, err := s.serviceAccounts.UpsertServiceAccount(ctx, &core.ServiceAccount{
-		PrincipalID: identity.ID,
-		Name:        identity.ID,
-		Description: identity.DisplayName,
-		CreatedAt:   identity.CreatedAt,
-		UpdatedAt:   identity.UpdatedAt,
-	}); err != nil {
-		return fmt.Errorf("sync canonical service account %q: %w", identity.ID, err)
+		return fmt.Errorf("sync canonical identity %q: %w", identity.ID, err)
 	}
 	return nil
 }

--- a/gestaltd/internal/coredata/managed_identity_grants.go
+++ b/gestaltd/internal/coredata/managed_identity_grants.go
@@ -12,11 +12,15 @@ import (
 )
 
 type ManagedIdentityGrantService struct {
-	store indexeddb.ObjectStore
+	store           indexeddb.ObjectStore
+	canonicalAccess *PrincipalPluginAccessService
 }
 
-func NewManagedIdentityGrantService(ds indexeddb.IndexedDB) *ManagedIdentityGrantService {
-	return &ManagedIdentityGrantService{store: ds.ObjectStore(StoreManagedIdentityGrants)}
+func NewManagedIdentityGrantService(ds indexeddb.IndexedDB, canonicalAccess *PrincipalPluginAccessService) *ManagedIdentityGrantService {
+	return &ManagedIdentityGrantService{
+		store:           ds.ObjectStore(StoreManagedIdentityGrants),
+		canonicalAccess: canonicalAccess,
+	}
 }
 
 func (s *ManagedIdentityGrantService) UpsertGrant(ctx context.Context, grant *core.ManagedIdentityGrant) (*core.ManagedIdentityGrant, error) {
@@ -41,6 +45,9 @@ func (s *ManagedIdentityGrantService) UpsertGrant(ctx context.Context, grant *co
 		if err := s.store.Put(ctx, record); err != nil {
 			return nil, fmt.Errorf("update managed identity grant: %w", err)
 		}
+		if err := s.syncCanonicalAccess(ctx, existing); err != nil {
+			return nil, err
+		}
 		return existing, nil
 	case err != nil && err != indexeddb.ErrNotFound:
 		return nil, fmt.Errorf("lookup managed identity grant: %w", err)
@@ -57,6 +64,9 @@ func (s *ManagedIdentityGrantService) UpsertGrant(ctx context.Context, grant *co
 	}
 	if err := s.store.Add(ctx, record); err != nil {
 		return nil, fmt.Errorf("create managed identity grant: %w", err)
+	}
+	if err := s.syncCanonicalAccess(ctx, grant); err != nil {
+		return nil, err
 	}
 	return grant, nil
 }
@@ -100,6 +110,11 @@ func (s *ManagedIdentityGrantService) DeleteGrant(ctx context.Context, identityI
 	if deleted == 0 {
 		return core.ErrNotFound
 	}
+	if s.canonicalAccess != nil {
+		if err := s.canonicalAccess.DeleteAccess(ctx, identityID, plugin); err != nil && err != core.ErrNotFound {
+			return fmt.Errorf("delete canonical principal plugin access: %w", err)
+		}
+	}
 	return nil
 }
 
@@ -113,6 +128,29 @@ func (s *ManagedIdentityGrantService) RestoreGrant(ctx context.Context, grant *c
 	}
 	if err := s.store.Put(ctx, record); err != nil {
 		return fmt.Errorf("restore managed identity grant: %w", err)
+	}
+	if err := s.syncCanonicalAccess(ctx, grant); err != nil {
+		return err
+	}
+	return nil
+}
+
+func (s *ManagedIdentityGrantService) BackfillCanonicalAccess(ctx context.Context) error {
+	if s.canonicalAccess == nil {
+		return nil
+	}
+	recs, err := s.store.GetAll(ctx, nil)
+	if err != nil {
+		return fmt.Errorf("list managed identity grants for canonical backfill: %w", err)
+	}
+	for _, rec := range recs {
+		grant, err := recordToManagedIdentityGrant(rec)
+		if err != nil {
+			return err
+		}
+		if err := s.syncCanonicalAccess(ctx, grant); err != nil {
+			return err
+		}
 	}
 	return nil
 }
@@ -150,4 +188,21 @@ func recordToManagedIdentityGrant(rec indexeddb.Record) (*core.ManagedIdentityGr
 		}
 	}
 	return grant, nil
+}
+
+func (s *ManagedIdentityGrantService) syncCanonicalAccess(ctx context.Context, grant *core.ManagedIdentityGrant) error {
+	if s.canonicalAccess == nil || grant == nil || grant.IdentityID == "" || grant.Plugin == "" {
+		return nil
+	}
+	if _, err := s.canonicalAccess.UpsertAccess(ctx, &core.PrincipalPluginAccess{
+		PrincipalID:         grant.IdentityID,
+		Plugin:              grant.Plugin,
+		InvokeAllOperations: len(grant.Operations) == 0,
+		Operations:          append([]string(nil), grant.Operations...),
+		CreatedAt:           grant.CreatedAt,
+		UpdatedAt:           grant.UpdatedAt,
+	}); err != nil {
+		return fmt.Errorf("sync canonical principal plugin access %q/%q: %w", grant.IdentityID, grant.Plugin, err)
+	}
+	return nil
 }

--- a/gestaltd/internal/coredata/managed_identity_grants.go
+++ b/gestaltd/internal/coredata/managed_identity_grants.go
@@ -3,6 +3,7 @@ package coredata
 import (
 	"context"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"time"
 
@@ -13,10 +14,12 @@ import (
 
 type ManagedIdentityGrantService struct {
 	store           indexeddb.ObjectStore
-	canonicalAccess *PrincipalPluginAccessService
+	canonicalAccess *IdentityPluginAccessService
 }
 
-func NewManagedIdentityGrantService(ds indexeddb.IndexedDB, canonicalAccess *PrincipalPluginAccessService) *ManagedIdentityGrantService {
+var errMalformedStoredManagedIdentityGrant = errors.New("malformed stored managed identity grant")
+
+func NewManagedIdentityGrantService(ds indexeddb.IndexedDB, canonicalAccess *IdentityPluginAccessService) *ManagedIdentityGrantService {
 	return &ManagedIdentityGrantService{
 		store:           ds.ObjectStore(StoreManagedIdentityGrants),
 		canonicalAccess: canonicalAccess,
@@ -112,7 +115,7 @@ func (s *ManagedIdentityGrantService) DeleteGrant(ctx context.Context, identityI
 	}
 	if s.canonicalAccess != nil {
 		if err := s.canonicalAccess.DeleteAccess(ctx, identityID, plugin); err != nil && err != core.ErrNotFound {
-			return fmt.Errorf("delete canonical principal plugin access: %w", err)
+			return fmt.Errorf("delete canonical identity plugin access: %w", err)
 		}
 	}
 	return nil
@@ -146,6 +149,9 @@ func (s *ManagedIdentityGrantService) BackfillCanonicalAccess(ctx context.Contex
 	for _, rec := range recs {
 		grant, err := recordToManagedIdentityGrant(rec)
 		if err != nil {
+			if errors.Is(err, errMalformedStoredManagedIdentityGrant) {
+				continue
+			}
 			return err
 		}
 		if err := s.syncCanonicalAccess(ctx, grant); err != nil {
@@ -184,7 +190,7 @@ func recordToManagedIdentityGrant(rec indexeddb.Record) (*core.ManagedIdentityGr
 	}
 	if raw := recString(rec, "operations_json"); raw != "" {
 		if err := json.Unmarshal([]byte(raw), &grant.Operations); err != nil {
-			return nil, fmt.Errorf("decode managed identity grant operations: %w", err)
+			return nil, fmt.Errorf("%w: decode managed identity grant operations: %v", errMalformedStoredManagedIdentityGrant, err)
 		}
 	}
 	return grant, nil
@@ -194,15 +200,15 @@ func (s *ManagedIdentityGrantService) syncCanonicalAccess(ctx context.Context, g
 	if s.canonicalAccess == nil || grant == nil || grant.IdentityID == "" || grant.Plugin == "" {
 		return nil
 	}
-	if _, err := s.canonicalAccess.UpsertAccess(ctx, &core.PrincipalPluginAccess{
-		PrincipalID:         grant.IdentityID,
+	if _, err := s.canonicalAccess.UpsertAccess(ctx, &core.IdentityPluginAccess{
+		IdentityID:          grant.IdentityID,
 		Plugin:              grant.Plugin,
 		InvokeAllOperations: len(grant.Operations) == 0,
 		Operations:          append([]string(nil), grant.Operations...),
 		CreatedAt:           grant.CreatedAt,
 		UpdatedAt:           grant.UpdatedAt,
 	}); err != nil {
-		return fmt.Errorf("sync canonical principal plugin access %q/%q: %w", grant.IdentityID, grant.Plugin, err)
+		return fmt.Errorf("sync canonical identity plugin access %q/%q: %w", grant.IdentityID, grant.Plugin, err)
 	}
 	return nil
 }

--- a/gestaltd/internal/coredata/managed_identity_memberships.go
+++ b/gestaltd/internal/coredata/managed_identity_memberships.go
@@ -2,6 +2,7 @@ package coredata
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"time"
 
@@ -12,13 +13,15 @@ import (
 
 type ManagedIdentityMembershipService struct {
 	store           indexeddb.ObjectStore
-	canonicalGrants *ServiceAccountManagementGrantService
+	canonicalGrants *IdentityManagementGrantService
+	users           *UserService
 }
 
-func NewManagedIdentityMembershipService(ds indexeddb.IndexedDB, canonicalGrants *ServiceAccountManagementGrantService) *ManagedIdentityMembershipService {
+func NewManagedIdentityMembershipService(ds indexeddb.IndexedDB, canonicalGrants *IdentityManagementGrantService, users *UserService) *ManagedIdentityMembershipService {
 	return &ManagedIdentityMembershipService{
 		store:           ds.ObjectStore(StoreManagedIdentityMemberships),
 		canonicalGrants: canonicalGrants,
+		users:           users,
 	}
 }
 
@@ -104,8 +107,11 @@ func (s *ManagedIdentityMembershipService) DeleteMembership(ctx context.Context,
 		return core.ErrNotFound
 	}
 	if s.canonicalGrants != nil {
-		if err := s.canonicalGrants.DeleteGrant(ctx, userID, identityID); err != nil && err != core.ErrNotFound {
-			return fmt.Errorf("delete canonical service account management grant: %w", err)
+		managerIdentityID, resolveErr := s.resolveManagerIdentityID(ctx, userID)
+		if resolveErr == nil {
+			if err := s.canonicalGrants.DeleteGrant(ctx, managerIdentityID, identityID); err != nil && err != core.ErrNotFound {
+				return fmt.Errorf("delete canonical identity management grant: %w", err)
+			}
 		}
 	}
 	return nil
@@ -164,18 +170,32 @@ func recordToManagedIdentityMembership(rec indexeddb.Record) *core.ManagedIdenti
 	}
 }
 
+func (s *ManagedIdentityMembershipService) resolveManagerIdentityID(ctx context.Context, userID string) (string, error) {
+	if s.users == nil {
+		return userID, nil
+	}
+	return s.users.CanonicalIdentityIDForUser(ctx, userID)
+}
+
 func (s *ManagedIdentityMembershipService) syncCanonicalGrant(ctx context.Context, membership *core.ManagedIdentityMembership) error {
 	if s.canonicalGrants == nil || membership == nil || membership.UserID == "" || membership.IdentityID == "" {
 		return nil
 	}
-	if _, err := s.canonicalGrants.UpsertGrant(ctx, &core.ServiceAccountManagementGrant{
-		MemberPrincipalID:               membership.UserID,
-		TargetServiceAccountPrincipalID: membership.IdentityID,
-		Role:                            membership.Role,
-		CreatedAt:                       membership.CreatedAt,
-		UpdatedAt:                       membership.UpdatedAt,
+	managerIdentityID, resolveErr := s.resolveManagerIdentityID(ctx, membership.UserID)
+	if resolveErr != nil {
+		if errors.Is(resolveErr, core.ErrNotFound) {
+			return nil
+		}
+		return resolveErr
+	}
+	if _, err := s.canonicalGrants.UpsertGrant(ctx, &core.IdentityManagementGrant{
+		ManagerIdentityID: managerIdentityID,
+		TargetIdentityID:  membership.IdentityID,
+		Role:              membership.Role,
+		CreatedAt:         membership.CreatedAt,
+		UpdatedAt:         membership.UpdatedAt,
 	}); err != nil {
-		return fmt.Errorf("sync canonical service account management grant %q/%q: %w", membership.UserID, membership.IdentityID, err)
+		return fmt.Errorf("sync canonical identity management grant %q/%q: %w", managerIdentityID, membership.IdentityID, err)
 	}
 	return nil
 }

--- a/gestaltd/internal/coredata/managed_identity_memberships.go
+++ b/gestaltd/internal/coredata/managed_identity_memberships.go
@@ -11,11 +11,15 @@ import (
 )
 
 type ManagedIdentityMembershipService struct {
-	store indexeddb.ObjectStore
+	store           indexeddb.ObjectStore
+	canonicalGrants *ServiceAccountManagementGrantService
 }
 
-func NewManagedIdentityMembershipService(ds indexeddb.IndexedDB) *ManagedIdentityMembershipService {
-	return &ManagedIdentityMembershipService{store: ds.ObjectStore(StoreManagedIdentityMemberships)}
+func NewManagedIdentityMembershipService(ds indexeddb.IndexedDB, canonicalGrants *ServiceAccountManagementGrantService) *ManagedIdentityMembershipService {
+	return &ManagedIdentityMembershipService{
+		store:           ds.ObjectStore(StoreManagedIdentityMemberships),
+		canonicalGrants: canonicalGrants,
+	}
 }
 
 func (s *ManagedIdentityMembershipService) UpsertMembership(ctx context.Context, membership *core.ManagedIdentityMembership) (*core.ManagedIdentityMembership, error) {
@@ -34,6 +38,9 @@ func (s *ManagedIdentityMembershipService) UpsertMembership(ctx context.Context,
 		if err := s.store.Put(ctx, managedIdentityMembershipRecord(existing)); err != nil {
 			return nil, fmt.Errorf("update managed identity membership: %w", err)
 		}
+		if err := s.syncCanonicalGrant(ctx, existing); err != nil {
+			return nil, err
+		}
 		return existing, nil
 	case err != nil && err != indexeddb.ErrNotFound:
 		return nil, fmt.Errorf("lookup managed identity membership: %w", err)
@@ -46,6 +53,9 @@ func (s *ManagedIdentityMembershipService) UpsertMembership(ctx context.Context,
 	membership.UpdatedAt = now
 	if err := s.store.Add(ctx, managedIdentityMembershipRecord(membership)); err != nil {
 		return nil, fmt.Errorf("create managed identity membership: %w", err)
+	}
+	if err := s.syncCanonicalGrant(ctx, membership); err != nil {
+		return nil, err
 	}
 	return membership, nil
 }
@@ -93,6 +103,11 @@ func (s *ManagedIdentityMembershipService) DeleteMembership(ctx context.Context,
 	if deleted == 0 {
 		return core.ErrNotFound
 	}
+	if s.canonicalGrants != nil {
+		if err := s.canonicalGrants.DeleteGrant(ctx, userID, identityID); err != nil && err != core.ErrNotFound {
+			return fmt.Errorf("delete canonical service account management grant: %w", err)
+		}
+	}
 	return nil
 }
 
@@ -102,6 +117,25 @@ func (s *ManagedIdentityMembershipService) RestoreMembership(ctx context.Context
 	}
 	if err := s.store.Put(ctx, managedIdentityMembershipRecord(membership)); err != nil {
 		return fmt.Errorf("restore managed identity membership: %w", err)
+	}
+	if err := s.syncCanonicalGrant(ctx, membership); err != nil {
+		return err
+	}
+	return nil
+}
+
+func (s *ManagedIdentityMembershipService) BackfillCanonicalGrants(ctx context.Context) error {
+	if s.canonicalGrants == nil {
+		return nil
+	}
+	recs, err := s.store.GetAll(ctx, nil)
+	if err != nil {
+		return fmt.Errorf("list managed identity memberships for canonical backfill: %w", err)
+	}
+	for _, rec := range recs {
+		if err := s.syncCanonicalGrant(ctx, recordToManagedIdentityMembership(rec)); err != nil {
+			return err
+		}
 	}
 	return nil
 }
@@ -128,4 +162,20 @@ func recordToManagedIdentityMembership(rec indexeddb.Record) *core.ManagedIdenti
 		CreatedAt:  recTime(rec, "created_at"),
 		UpdatedAt:  recTime(rec, "updated_at"),
 	}
+}
+
+func (s *ManagedIdentityMembershipService) syncCanonicalGrant(ctx context.Context, membership *core.ManagedIdentityMembership) error {
+	if s.canonicalGrants == nil || membership == nil || membership.UserID == "" || membership.IdentityID == "" {
+		return nil
+	}
+	if _, err := s.canonicalGrants.UpsertGrant(ctx, &core.ServiceAccountManagementGrant{
+		MemberPrincipalID:               membership.UserID,
+		TargetServiceAccountPrincipalID: membership.IdentityID,
+		Role:                            membership.Role,
+		CreatedAt:                       membership.CreatedAt,
+		UpdatedAt:                       membership.UpdatedAt,
+	}); err != nil {
+		return fmt.Errorf("sync canonical service account management grant %q/%q: %w", membership.UserID, membership.IdentityID, err)
+	}
+	return nil
 }

--- a/gestaltd/internal/coredata/plugin_authorizations.go
+++ b/gestaltd/internal/coredata/plugin_authorizations.go
@@ -22,11 +22,15 @@ type PluginAuthorizationMembership struct {
 }
 
 type PluginAuthorizationService struct {
-	store indexeddb.ObjectStore
+	store           indexeddb.ObjectStore
+	canonicalAccess *PrincipalPluginAccessService
 }
 
-func NewPluginAuthorizationService(ds indexeddb.IndexedDB) *PluginAuthorizationService {
-	return &PluginAuthorizationService{store: ds.ObjectStore(StorePluginAuthorizationMemberships)}
+func NewPluginAuthorizationService(ds indexeddb.IndexedDB, canonicalAccess *PrincipalPluginAccessService) *PluginAuthorizationService {
+	return &PluginAuthorizationService{
+		store:           ds.ObjectStore(StorePluginAuthorizationMemberships),
+		canonicalAccess: canonicalAccess,
+	}
 }
 
 func (s *PluginAuthorizationService) ListPluginAuthorizations(ctx context.Context) ([]*PluginAuthorizationMembership, error) {
@@ -102,6 +106,9 @@ func (s *PluginAuthorizationService) UpsertPluginAuthorization(ctx context.Conte
 	if err := s.store.Put(ctx, rec); err != nil {
 		return nil, fmt.Errorf("upsert plugin authorization: %w", err)
 	}
+	if err := s.syncCanonicalAccess(ctx, recordToPluginAuthorizationMembership(rec)); err != nil {
+		return nil, err
+	}
 	return recordToPluginAuthorizationMembership(rec), nil
 }
 
@@ -116,6 +123,27 @@ func (s *PluginAuthorizationService) DeletePluginAuthorization(ctx context.Conte
 			return core.ErrNotFound
 		}
 		return fmt.Errorf("delete plugin authorization: %w", err)
+	}
+	if s.canonicalAccess != nil {
+		if err := s.canonicalAccess.DeleteAccess(ctx, userID, plugin); err != nil && err != core.ErrNotFound {
+			return fmt.Errorf("delete canonical principal plugin access: %w", err)
+		}
+	}
+	return nil
+}
+
+func (s *PluginAuthorizationService) BackfillCanonicalAccess(ctx context.Context) error {
+	if s.canonicalAccess == nil {
+		return nil
+	}
+	recs, err := s.store.GetAll(ctx, nil)
+	if err != nil {
+		return fmt.Errorf("list plugin authorizations for canonical backfill: %w", err)
+	}
+	for _, rec := range recs {
+		if err := s.syncCanonicalAccess(ctx, recordToPluginAuthorizationMembership(rec)); err != nil {
+			return err
+		}
 	}
 	return nil
 }
@@ -134,4 +162,22 @@ func recordToPluginAuthorizationMembership(rec indexeddb.Record) *PluginAuthoriz
 		CreatedAt: recTime(rec, "created_at"),
 		UpdatedAt: recTime(rec, "updated_at"),
 	}
+}
+
+func (s *PluginAuthorizationService) syncCanonicalAccess(ctx context.Context, membership *PluginAuthorizationMembership) error {
+	if s.canonicalAccess == nil || membership == nil || membership.UserID == "" || membership.Plugin == "" {
+		return nil
+	}
+	// Dynamic plugin roles remain authoritative for runtime in v1. The canonical
+	// store records the broad plugin-level invocation relationship only.
+	if _, err := s.canonicalAccess.UpsertAccess(ctx, &core.PrincipalPluginAccess{
+		PrincipalID:         membership.UserID,
+		Plugin:              membership.Plugin,
+		InvokeAllOperations: true,
+		CreatedAt:           membership.CreatedAt,
+		UpdatedAt:           membership.UpdatedAt,
+	}); err != nil {
+		return fmt.Errorf("sync canonical principal plugin access %q/%q: %w", membership.UserID, membership.Plugin, err)
+	}
+	return nil
 }

--- a/gestaltd/internal/coredata/plugin_authorizations.go
+++ b/gestaltd/internal/coredata/plugin_authorizations.go
@@ -2,6 +2,7 @@ package coredata
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"strings"
 	"time"
@@ -23,13 +24,15 @@ type PluginAuthorizationMembership struct {
 
 type PluginAuthorizationService struct {
 	store           indexeddb.ObjectStore
-	canonicalAccess *PrincipalPluginAccessService
+	canonicalAccess *IdentityPluginAccessService
+	users           *UserService
 }
 
-func NewPluginAuthorizationService(ds indexeddb.IndexedDB, canonicalAccess *PrincipalPluginAccessService) *PluginAuthorizationService {
+func NewPluginAuthorizationService(ds indexeddb.IndexedDB, canonicalAccess *IdentityPluginAccessService, users *UserService) *PluginAuthorizationService {
 	return &PluginAuthorizationService{
 		store:           ds.ObjectStore(StorePluginAuthorizationMemberships),
 		canonicalAccess: canonicalAccess,
+		users:           users,
 	}
 }
 
@@ -125,8 +128,11 @@ func (s *PluginAuthorizationService) DeletePluginAuthorization(ctx context.Conte
 		return fmt.Errorf("delete plugin authorization: %w", err)
 	}
 	if s.canonicalAccess != nil {
-		if err := s.canonicalAccess.DeleteAccess(ctx, userID, plugin); err != nil && err != core.ErrNotFound {
-			return fmt.Errorf("delete canonical principal plugin access: %w", err)
+		identityID, resolveErr := s.resolveIdentityID(ctx, userID)
+		if resolveErr == nil {
+			if err := s.canonicalAccess.DeleteAccess(ctx, identityID, plugin); err != nil && err != core.ErrNotFound {
+				return fmt.Errorf("delete canonical identity plugin access: %w", err)
+			}
 		}
 	}
 	return nil
@@ -164,20 +170,32 @@ func recordToPluginAuthorizationMembership(rec indexeddb.Record) *PluginAuthoriz
 	}
 }
 
+func (s *PluginAuthorizationService) resolveIdentityID(ctx context.Context, userID string) (string, error) {
+	if s.users == nil {
+		return userID, nil
+	}
+	return s.users.CanonicalIdentityIDForUser(ctx, userID)
+}
+
 func (s *PluginAuthorizationService) syncCanonicalAccess(ctx context.Context, membership *PluginAuthorizationMembership) error {
 	if s.canonicalAccess == nil || membership == nil || membership.UserID == "" || membership.Plugin == "" {
 		return nil
 	}
-	// Dynamic plugin roles remain authoritative for runtime in v1. The canonical
-	// store records the broad plugin-level invocation relationship only.
-	if _, err := s.canonicalAccess.UpsertAccess(ctx, &core.PrincipalPluginAccess{
-		PrincipalID:         membership.UserID,
+	identityID, resolveErr := s.resolveIdentityID(ctx, membership.UserID)
+	if resolveErr != nil {
+		if errors.Is(resolveErr, core.ErrNotFound) {
+			return nil
+		}
+		return resolveErr
+	}
+	if _, err := s.canonicalAccess.UpsertAccess(ctx, &core.IdentityPluginAccess{
+		IdentityID:          identityID,
 		Plugin:              membership.Plugin,
 		InvokeAllOperations: true,
 		CreatedAt:           membership.CreatedAt,
 		UpdatedAt:           membership.UpdatedAt,
 	}); err != nil {
-		return fmt.Errorf("sync canonical principal plugin access %q/%q: %w", membership.UserID, membership.Plugin, err)
+		return fmt.Errorf("sync canonical identity plugin access %q/%q: %w", identityID, membership.Plugin, err)
 	}
 	return nil
 }

--- a/gestaltd/internal/coredata/schemas.go
+++ b/gestaltd/internal/coredata/schemas.go
@@ -11,6 +11,16 @@ const (
 	StoreManagedIdentityGrants          = "managed_identity_grants"
 	StorePluginAuthorizationMemberships = "plugin_authorization_memberships"
 	StoreAdminAuthorizationMemberships  = "admin_authorization_memberships"
+	StorePrincipals                     = "principals"
+	StoreUserProfiles                   = "user_profiles"
+	StoreServiceAccounts                = "service_accounts"
+	StoreServiceAccountManagementGrants = "service_account_management_grants"
+	StoreWorkspaceRoles                 = "workspace_roles"
+	StorePrincipalPluginAccess          = "principal_plugin_access"
+	StoreServiceAccountDelegations      = "service_account_delegations"
+	StoreAPITokenAccess                 = "api_token_access"
+	StoreExternalCredentials            = "external_credentials"
+	StoreServiceAccountAuthBindings     = "service_account_auth_bindings"
 )
 
 var UsersSchema = indexeddb.ObjectStoreSchema{
@@ -142,6 +152,181 @@ var AdminAuthorizationMembershipsSchema = indexeddb.ObjectStoreSchema{
 		{Name: "user_id", Type: indexeddb.TypeString, NotNull: true},
 		{Name: "email", Type: indexeddb.TypeString, NotNull: true},
 		{Name: "role", Type: indexeddb.TypeString, NotNull: true},
+		{Name: "created_at", Type: indexeddb.TypeTime},
+		{Name: "updated_at", Type: indexeddb.TypeTime},
+	},
+}
+
+var PrincipalsSchema = indexeddb.ObjectStoreSchema{
+	Indexes: []indexeddb.IndexSchema{
+		{Name: "by_kind", KeyPath: []string{"kind"}},
+		{Name: "by_status", KeyPath: []string{"status"}},
+	},
+	Columns: []indexeddb.ColumnDef{
+		{Name: "id", Type: indexeddb.TypeString, PrimaryKey: true},
+		{Name: "kind", Type: indexeddb.TypeString, NotNull: true},
+		{Name: "status", Type: indexeddb.TypeString, NotNull: true},
+		{Name: "display_name", Type: indexeddb.TypeString, NotNull: true},
+		{Name: "created_at", Type: indexeddb.TypeTime},
+		{Name: "updated_at", Type: indexeddb.TypeTime},
+	},
+}
+
+var UserProfilesSchema = indexeddb.ObjectStoreSchema{
+	Indexes: []indexeddb.IndexSchema{
+		{Name: "by_email", KeyPath: []string{"email"}, Unique: true},
+		{Name: "by_normalized_email", KeyPath: []string{"normalized_email"}, Unique: true},
+		{Name: "by_auth_subject", KeyPath: []string{"auth_provider", "auth_subject"}, Unique: true},
+	},
+	Columns: []indexeddb.ColumnDef{
+		{Name: "id", Type: indexeddb.TypeString, PrimaryKey: true},
+		{Name: "principal_id", Type: indexeddb.TypeString, NotNull: true},
+		{Name: "email", Type: indexeddb.TypeString, NotNull: true, Unique: true},
+		{Name: "normalized_email", Type: indexeddb.TypeString, NotNull: true, Unique: true},
+		{Name: "auth_provider", Type: indexeddb.TypeString},
+		{Name: "auth_subject", Type: indexeddb.TypeString},
+		{Name: "avatar_url", Type: indexeddb.TypeString},
+		{Name: "created_at", Type: indexeddb.TypeTime},
+		{Name: "updated_at", Type: indexeddb.TypeTime},
+	},
+}
+
+var ServiceAccountsSchema = indexeddb.ObjectStoreSchema{
+	Indexes: []indexeddb.IndexSchema{
+		{Name: "by_name", KeyPath: []string{"name"}, Unique: true},
+		{Name: "by_creator", KeyPath: []string{"created_by_principal_id"}},
+	},
+	Columns: []indexeddb.ColumnDef{
+		{Name: "id", Type: indexeddb.TypeString, PrimaryKey: true},
+		{Name: "principal_id", Type: indexeddb.TypeString, NotNull: true},
+		{Name: "name", Type: indexeddb.TypeString, NotNull: true, Unique: true},
+		{Name: "description", Type: indexeddb.TypeString},
+		{Name: "created_by_principal_id", Type: indexeddb.TypeString},
+		{Name: "created_at", Type: indexeddb.TypeTime},
+		{Name: "updated_at", Type: indexeddb.TypeTime},
+	},
+}
+
+var ServiceAccountManagementGrantsSchema = indexeddb.ObjectStoreSchema{
+	Indexes: []indexeddb.IndexSchema{
+		{Name: "by_member", KeyPath: []string{"member_principal_id"}},
+		{Name: "by_target", KeyPath: []string{"target_service_account_principal_id"}},
+		{Name: "by_member_target", KeyPath: []string{"member_principal_id", "target_service_account_principal_id"}, Unique: true},
+	},
+	Columns: []indexeddb.ColumnDef{
+		{Name: "id", Type: indexeddb.TypeString, PrimaryKey: true},
+		{Name: "member_principal_id", Type: indexeddb.TypeString, NotNull: true},
+		{Name: "target_service_account_principal_id", Type: indexeddb.TypeString, NotNull: true},
+		{Name: "role", Type: indexeddb.TypeString, NotNull: true},
+		{Name: "expires_at", Type: indexeddb.TypeTime},
+		{Name: "created_at", Type: indexeddb.TypeTime},
+		{Name: "updated_at", Type: indexeddb.TypeTime},
+	},
+}
+
+var WorkspaceRolesSchema = indexeddb.ObjectStoreSchema{
+	Indexes: []indexeddb.IndexSchema{
+		{Name: "by_principal", KeyPath: []string{"principal_id"}},
+		{Name: "by_principal_role", KeyPath: []string{"principal_id", "role"}, Unique: true},
+	},
+	Columns: []indexeddb.ColumnDef{
+		{Name: "id", Type: indexeddb.TypeString, PrimaryKey: true},
+		{Name: "principal_id", Type: indexeddb.TypeString, NotNull: true},
+		{Name: "role", Type: indexeddb.TypeString, NotNull: true},
+		{Name: "created_at", Type: indexeddb.TypeTime},
+		{Name: "updated_at", Type: indexeddb.TypeTime},
+	},
+}
+
+var PrincipalPluginAccessSchema = indexeddb.ObjectStoreSchema{
+	Indexes: []indexeddb.IndexSchema{
+		{Name: "by_principal", KeyPath: []string{"principal_id"}},
+		{Name: "by_plugin", KeyPath: []string{"plugin"}},
+		{Name: "by_principal_plugin", KeyPath: []string{"principal_id", "plugin"}, Unique: true},
+	},
+	Columns: []indexeddb.ColumnDef{
+		{Name: "id", Type: indexeddb.TypeString, PrimaryKey: true},
+		{Name: "principal_id", Type: indexeddb.TypeString, NotNull: true},
+		{Name: "plugin", Type: indexeddb.TypeString, NotNull: true},
+		{Name: "invoke_all_operations", Type: indexeddb.TypeBool, NotNull: true},
+		{Name: "operations_json", Type: indexeddb.TypeString},
+		{Name: "expires_at", Type: indexeddb.TypeTime},
+		{Name: "created_at", Type: indexeddb.TypeTime},
+		{Name: "updated_at", Type: indexeddb.TypeTime},
+	},
+}
+
+var ServiceAccountDelegationsSchema = indexeddb.ObjectStoreSchema{
+	Indexes: []indexeddb.IndexSchema{
+		{Name: "by_actor", KeyPath: []string{"actor_user_principal_id"}},
+		{Name: "by_target", KeyPath: []string{"target_service_account_principal_id"}},
+		{Name: "by_actor_target_plugin", KeyPath: []string{"actor_user_principal_id", "target_service_account_principal_id", "plugin"}, Unique: true},
+	},
+	Columns: []indexeddb.ColumnDef{
+		{Name: "id", Type: indexeddb.TypeString, PrimaryKey: true},
+		{Name: "actor_user_principal_id", Type: indexeddb.TypeString, NotNull: true},
+		{Name: "target_service_account_principal_id", Type: indexeddb.TypeString, NotNull: true},
+		{Name: "plugin", Type: indexeddb.TypeString},
+		{Name: "expires_at", Type: indexeddb.TypeTime},
+		{Name: "created_at", Type: indexeddb.TypeTime},
+		{Name: "updated_at", Type: indexeddb.TypeTime},
+	},
+}
+
+var APITokenAccessSchema = indexeddb.ObjectStoreSchema{
+	Indexes: []indexeddb.IndexSchema{
+		{Name: "by_token", KeyPath: []string{"token_id"}},
+		{Name: "by_token_plugin", KeyPath: []string{"token_id", "plugin"}, Unique: true},
+	},
+	Columns: []indexeddb.ColumnDef{
+		{Name: "id", Type: indexeddb.TypeString, PrimaryKey: true},
+		{Name: "token_id", Type: indexeddb.TypeString, NotNull: true},
+		{Name: "plugin", Type: indexeddb.TypeString, NotNull: true},
+		{Name: "invoke_all_operations", Type: indexeddb.TypeBool, NotNull: true},
+		{Name: "operations_json", Type: indexeddb.TypeString},
+		{Name: "expires_at", Type: indexeddb.TypeTime},
+		{Name: "created_at", Type: indexeddb.TypeTime},
+		{Name: "updated_at", Type: indexeddb.TypeTime},
+	},
+}
+
+var ExternalCredentialsSchema = indexeddb.ObjectStoreSchema{
+	Indexes: []indexeddb.IndexSchema{
+		{Name: "by_principal", KeyPath: []string{"principal_id"}},
+		{Name: "by_principal_plugin", KeyPath: []string{"principal_id", "plugin"}},
+		{Name: "by_principal_connection", KeyPath: []string{"principal_id", "plugin", "connection"}},
+		{Name: "by_lookup", KeyPath: []string{"principal_id", "plugin", "connection", "instance"}, Unique: true},
+	},
+	Columns: []indexeddb.ColumnDef{
+		{Name: "id", Type: indexeddb.TypeString, PrimaryKey: true},
+		{Name: "principal_id", Type: indexeddb.TypeString, NotNull: true},
+		{Name: "plugin", Type: indexeddb.TypeString, NotNull: true},
+		{Name: "connection", Type: indexeddb.TypeString, NotNull: true},
+		{Name: "instance", Type: indexeddb.TypeString, NotNull: true},
+		{Name: "auth_type", Type: indexeddb.TypeString, NotNull: true},
+		{Name: "payload_encrypted", Type: indexeddb.TypeString},
+		{Name: "scopes", Type: indexeddb.TypeString},
+		{Name: "expires_at", Type: indexeddb.TypeTime},
+		{Name: "last_refreshed_at", Type: indexeddb.TypeTime},
+		{Name: "refresh_error_count", Type: indexeddb.TypeInt},
+		{Name: "metadata_json", Type: indexeddb.TypeString},
+		{Name: "created_at", Type: indexeddb.TypeTime},
+		{Name: "updated_at", Type: indexeddb.TypeTime},
+	},
+}
+
+var ServiceAccountAuthBindingsSchema = indexeddb.ObjectStoreSchema{
+	Indexes: []indexeddb.IndexSchema{
+		{Name: "by_service_account", KeyPath: []string{"service_account_principal_id"}},
+		{Name: "by_binding_kind", KeyPath: []string{"binding_kind"}},
+		{Name: "by_lookup", KeyPath: []string{"binding_kind", "lookup_key"}, Unique: true},
+	},
+	Columns: []indexeddb.ColumnDef{
+		{Name: "id", Type: indexeddb.TypeString, PrimaryKey: true},
+		{Name: "service_account_principal_id", Type: indexeddb.TypeString, NotNull: true},
+		{Name: "binding_kind", Type: indexeddb.TypeString, NotNull: true},
+		{Name: "lookup_key", Type: indexeddb.TypeString, NotNull: true},
+		{Name: "binding_json", Type: indexeddb.TypeString},
 		{Name: "created_at", Type: indexeddb.TypeTime},
 		{Name: "updated_at", Type: indexeddb.TypeTime},
 	},

--- a/gestaltd/internal/coredata/schemas.go
+++ b/gestaltd/internal/coredata/schemas.go
@@ -11,16 +11,14 @@ const (
 	StoreManagedIdentityGrants          = "managed_identity_grants"
 	StorePluginAuthorizationMemberships = "plugin_authorization_memberships"
 	StoreAdminAuthorizationMemberships  = "admin_authorization_memberships"
-	StorePrincipals                     = "principals"
-	StoreUserProfiles                   = "user_profiles"
-	StoreServiceAccounts                = "service_accounts"
-	StoreServiceAccountManagementGrants = "service_account_management_grants"
+	StoreIdentities                     = "identities"
+	StoreIdentityAuthBindings           = "identity_auth_bindings"
+	StoreIdentityManagementGrants       = "identity_management_grants"
+	StoreIdentityDelegations            = "identity_delegations"
 	StoreWorkspaceRoles                 = "workspace_roles"
-	StorePrincipalPluginAccess          = "principal_plugin_access"
-	StoreServiceAccountDelegations      = "service_account_delegations"
+	StoreIdentityPluginAccess           = "identity_plugin_access"
 	StoreAPITokenAccess                 = "api_token_access"
 	StoreExternalCredentials            = "external_credentials"
-	StoreServiceAccountAuthBindings     = "service_account_auth_bindings"
 )
 
 var UsersSchema = indexeddb.ObjectStoreSchema{
@@ -66,6 +64,9 @@ var IntegrationTokensSchema = indexeddb.ObjectStoreSchema{
 var APITokensSchema = indexeddb.ObjectStoreSchema{
 	Indexes: []indexeddb.IndexSchema{
 		{Name: "by_hash", KeyPath: []string{"hashed_token"}, Unique: true},
+		{Name: "by_identity", KeyPath: []string{"identity_id"}},
+		{Name: "by_identity_id", KeyPath: []string{"id", "identity_id"}, Unique: true},
+		{Name: "by_token_kind", KeyPath: []string{"token_kind"}},
 		{Name: "by_user", KeyPath: []string{"user_id"}},
 		{Name: "by_user_id", KeyPath: []string{"id", "user_id"}, Unique: true},
 		{Name: "by_owner", KeyPath: []string{"owner_kind", "owner_id"}},
@@ -73,9 +74,11 @@ var APITokensSchema = indexeddb.ObjectStoreSchema{
 	},
 	Columns: []indexeddb.ColumnDef{
 		{Name: "id", Type: indexeddb.TypeString, PrimaryKey: true},
-		{Name: "user_id", Type: indexeddb.TypeString, NotNull: true},
+		{Name: "identity_id", Type: indexeddb.TypeString},
+		{Name: "user_id", Type: indexeddb.TypeString},
 		{Name: "owner_kind", Type: indexeddb.TypeString},
 		{Name: "owner_id", Type: indexeddb.TypeString},
+		{Name: "token_kind", Type: indexeddb.TypeString},
 		{Name: "name", Type: indexeddb.TypeString},
 		{Name: "hashed_token", Type: indexeddb.TypeString, NotNull: true, Unique: true},
 		{Name: "scopes", Type: indexeddb.TypeString},
@@ -90,6 +93,7 @@ var ManagedIdentitiesSchema = indexeddb.ObjectStoreSchema{
 	Columns: []indexeddb.ColumnDef{
 		{Name: "id", Type: indexeddb.TypeString, PrimaryKey: true},
 		{Name: "display_name", Type: indexeddb.TypeString, NotNull: true},
+		{Name: "created_by_identity_id", Type: indexeddb.TypeString},
 		{Name: "created_at", Type: indexeddb.TypeTime},
 		{Name: "updated_at", Type: indexeddb.TypeTime},
 	},
@@ -157,67 +161,68 @@ var AdminAuthorizationMembershipsSchema = indexeddb.ObjectStoreSchema{
 	},
 }
 
-var PrincipalsSchema = indexeddb.ObjectStoreSchema{
+var IdentitiesSchema = indexeddb.ObjectStoreSchema{
 	Indexes: []indexeddb.IndexSchema{
-		{Name: "by_kind", KeyPath: []string{"kind"}},
 		{Name: "by_status", KeyPath: []string{"status"}},
+		{Name: "by_creator", KeyPath: []string{"created_by_identity_id"}},
 	},
 	Columns: []indexeddb.ColumnDef{
 		{Name: "id", Type: indexeddb.TypeString, PrimaryKey: true},
-		{Name: "kind", Type: indexeddb.TypeString, NotNull: true},
 		{Name: "status", Type: indexeddb.TypeString, NotNull: true},
 		{Name: "display_name", Type: indexeddb.TypeString, NotNull: true},
+		{Name: "created_by_identity_id", Type: indexeddb.TypeString},
+		{Name: "metadata_json", Type: indexeddb.TypeString},
 		{Name: "created_at", Type: indexeddb.TypeTime},
 		{Name: "updated_at", Type: indexeddb.TypeTime},
 	},
 }
 
-var UserProfilesSchema = indexeddb.ObjectStoreSchema{
+var IdentityAuthBindingsSchema = indexeddb.ObjectStoreSchema{
 	Indexes: []indexeddb.IndexSchema{
-		{Name: "by_email", KeyPath: []string{"email"}, Unique: true},
-		{Name: "by_normalized_email", KeyPath: []string{"normalized_email"}, Unique: true},
-		{Name: "by_auth_subject", KeyPath: []string{"auth_provider", "auth_subject"}, Unique: true},
+		{Name: "by_identity", KeyPath: []string{"identity_id"}},
+		{Name: "by_binding_kind", KeyPath: []string{"binding_kind"}},
+		{Name: "by_lookup", KeyPath: []string{"binding_kind", "authority", "lookup_key"}, Unique: true},
 	},
 	Columns: []indexeddb.ColumnDef{
 		{Name: "id", Type: indexeddb.TypeString, PrimaryKey: true},
-		{Name: "principal_id", Type: indexeddb.TypeString, NotNull: true},
-		{Name: "email", Type: indexeddb.TypeString, NotNull: true, Unique: true},
-		{Name: "normalized_email", Type: indexeddb.TypeString, NotNull: true, Unique: true},
-		{Name: "auth_provider", Type: indexeddb.TypeString},
-		{Name: "auth_subject", Type: indexeddb.TypeString},
-		{Name: "avatar_url", Type: indexeddb.TypeString},
+		{Name: "identity_id", Type: indexeddb.TypeString, NotNull: true},
+		{Name: "binding_kind", Type: indexeddb.TypeString, NotNull: true},
+		{Name: "authority", Type: indexeddb.TypeString, NotNull: true},
+		{Name: "lookup_key", Type: indexeddb.TypeString, NotNull: true},
+		{Name: "binding_json", Type: indexeddb.TypeString},
 		{Name: "created_at", Type: indexeddb.TypeTime},
 		{Name: "updated_at", Type: indexeddb.TypeTime},
 	},
 }
 
-var ServiceAccountsSchema = indexeddb.ObjectStoreSchema{
+var IdentityManagementGrantsSchema = indexeddb.ObjectStoreSchema{
 	Indexes: []indexeddb.IndexSchema{
-		{Name: "by_name", KeyPath: []string{"name"}, Unique: true},
-		{Name: "by_creator", KeyPath: []string{"created_by_principal_id"}},
+		{Name: "by_manager", KeyPath: []string{"manager_identity_id"}},
+		{Name: "by_target", KeyPath: []string{"target_identity_id"}},
+		{Name: "by_manager_target", KeyPath: []string{"manager_identity_id", "target_identity_id"}, Unique: true},
 	},
 	Columns: []indexeddb.ColumnDef{
 		{Name: "id", Type: indexeddb.TypeString, PrimaryKey: true},
-		{Name: "principal_id", Type: indexeddb.TypeString, NotNull: true},
-		{Name: "name", Type: indexeddb.TypeString, NotNull: true, Unique: true},
-		{Name: "description", Type: indexeddb.TypeString},
-		{Name: "created_by_principal_id", Type: indexeddb.TypeString},
-		{Name: "created_at", Type: indexeddb.TypeTime},
-		{Name: "updated_at", Type: indexeddb.TypeTime},
-	},
-}
-
-var ServiceAccountManagementGrantsSchema = indexeddb.ObjectStoreSchema{
-	Indexes: []indexeddb.IndexSchema{
-		{Name: "by_member", KeyPath: []string{"member_principal_id"}},
-		{Name: "by_target", KeyPath: []string{"target_service_account_principal_id"}},
-		{Name: "by_member_target", KeyPath: []string{"member_principal_id", "target_service_account_principal_id"}, Unique: true},
-	},
-	Columns: []indexeddb.ColumnDef{
-		{Name: "id", Type: indexeddb.TypeString, PrimaryKey: true},
-		{Name: "member_principal_id", Type: indexeddb.TypeString, NotNull: true},
-		{Name: "target_service_account_principal_id", Type: indexeddb.TypeString, NotNull: true},
+		{Name: "manager_identity_id", Type: indexeddb.TypeString, NotNull: true},
+		{Name: "target_identity_id", Type: indexeddb.TypeString, NotNull: true},
 		{Name: "role", Type: indexeddb.TypeString, NotNull: true},
+		{Name: "expires_at", Type: indexeddb.TypeTime},
+		{Name: "created_at", Type: indexeddb.TypeTime},
+		{Name: "updated_at", Type: indexeddb.TypeTime},
+	},
+}
+
+var IdentityDelegationsSchema = indexeddb.ObjectStoreSchema{
+	Indexes: []indexeddb.IndexSchema{
+		{Name: "by_actor", KeyPath: []string{"actor_identity_id"}},
+		{Name: "by_target", KeyPath: []string{"target_identity_id"}},
+		{Name: "by_actor_target_plugin", KeyPath: []string{"actor_identity_id", "target_identity_id", "plugin"}, Unique: true},
+	},
+	Columns: []indexeddb.ColumnDef{
+		{Name: "id", Type: indexeddb.TypeString, PrimaryKey: true},
+		{Name: "actor_identity_id", Type: indexeddb.TypeString, NotNull: true},
+		{Name: "target_identity_id", Type: indexeddb.TypeString, NotNull: true},
+		{Name: "plugin", Type: indexeddb.TypeString},
 		{Name: "expires_at", Type: indexeddb.TypeTime},
 		{Name: "created_at", Type: indexeddb.TypeTime},
 		{Name: "updated_at", Type: indexeddb.TypeTime},
@@ -226,47 +231,30 @@ var ServiceAccountManagementGrantsSchema = indexeddb.ObjectStoreSchema{
 
 var WorkspaceRolesSchema = indexeddb.ObjectStoreSchema{
 	Indexes: []indexeddb.IndexSchema{
-		{Name: "by_principal", KeyPath: []string{"principal_id"}},
-		{Name: "by_principal_role", KeyPath: []string{"principal_id", "role"}, Unique: true},
+		{Name: "by_identity", KeyPath: []string{"identity_id"}},
+		{Name: "by_identity_role", KeyPath: []string{"identity_id", "role"}, Unique: true},
 	},
 	Columns: []indexeddb.ColumnDef{
 		{Name: "id", Type: indexeddb.TypeString, PrimaryKey: true},
-		{Name: "principal_id", Type: indexeddb.TypeString, NotNull: true},
+		{Name: "identity_id", Type: indexeddb.TypeString, NotNull: true},
 		{Name: "role", Type: indexeddb.TypeString, NotNull: true},
 		{Name: "created_at", Type: indexeddb.TypeTime},
 		{Name: "updated_at", Type: indexeddb.TypeTime},
 	},
 }
 
-var PrincipalPluginAccessSchema = indexeddb.ObjectStoreSchema{
+var IdentityPluginAccessSchema = indexeddb.ObjectStoreSchema{
 	Indexes: []indexeddb.IndexSchema{
-		{Name: "by_principal", KeyPath: []string{"principal_id"}},
+		{Name: "by_identity", KeyPath: []string{"identity_id"}},
 		{Name: "by_plugin", KeyPath: []string{"plugin"}},
-		{Name: "by_principal_plugin", KeyPath: []string{"principal_id", "plugin"}, Unique: true},
+		{Name: "by_identity_plugin", KeyPath: []string{"identity_id", "plugin"}, Unique: true},
 	},
 	Columns: []indexeddb.ColumnDef{
 		{Name: "id", Type: indexeddb.TypeString, PrimaryKey: true},
-		{Name: "principal_id", Type: indexeddb.TypeString, NotNull: true},
+		{Name: "identity_id", Type: indexeddb.TypeString, NotNull: true},
 		{Name: "plugin", Type: indexeddb.TypeString, NotNull: true},
 		{Name: "invoke_all_operations", Type: indexeddb.TypeBool, NotNull: true},
 		{Name: "operations_json", Type: indexeddb.TypeString},
-		{Name: "expires_at", Type: indexeddb.TypeTime},
-		{Name: "created_at", Type: indexeddb.TypeTime},
-		{Name: "updated_at", Type: indexeddb.TypeTime},
-	},
-}
-
-var ServiceAccountDelegationsSchema = indexeddb.ObjectStoreSchema{
-	Indexes: []indexeddb.IndexSchema{
-		{Name: "by_actor", KeyPath: []string{"actor_user_principal_id"}},
-		{Name: "by_target", KeyPath: []string{"target_service_account_principal_id"}},
-		{Name: "by_actor_target_plugin", KeyPath: []string{"actor_user_principal_id", "target_service_account_principal_id", "plugin"}, Unique: true},
-	},
-	Columns: []indexeddb.ColumnDef{
-		{Name: "id", Type: indexeddb.TypeString, PrimaryKey: true},
-		{Name: "actor_user_principal_id", Type: indexeddb.TypeString, NotNull: true},
-		{Name: "target_service_account_principal_id", Type: indexeddb.TypeString, NotNull: true},
-		{Name: "plugin", Type: indexeddb.TypeString},
 		{Name: "expires_at", Type: indexeddb.TypeTime},
 		{Name: "created_at", Type: indexeddb.TypeTime},
 		{Name: "updated_at", Type: indexeddb.TypeTime},
@@ -292,14 +280,14 @@ var APITokenAccessSchema = indexeddb.ObjectStoreSchema{
 
 var ExternalCredentialsSchema = indexeddb.ObjectStoreSchema{
 	Indexes: []indexeddb.IndexSchema{
-		{Name: "by_principal", KeyPath: []string{"principal_id"}},
-		{Name: "by_principal_plugin", KeyPath: []string{"principal_id", "plugin"}},
-		{Name: "by_principal_connection", KeyPath: []string{"principal_id", "plugin", "connection"}},
-		{Name: "by_lookup", KeyPath: []string{"principal_id", "plugin", "connection", "instance"}, Unique: true},
+		{Name: "by_identity", KeyPath: []string{"identity_id"}},
+		{Name: "by_identity_plugin", KeyPath: []string{"identity_id", "plugin"}},
+		{Name: "by_identity_connection", KeyPath: []string{"identity_id", "plugin", "connection"}},
+		{Name: "by_lookup", KeyPath: []string{"identity_id", "plugin", "connection", "instance"}, Unique: true},
 	},
 	Columns: []indexeddb.ColumnDef{
 		{Name: "id", Type: indexeddb.TypeString, PrimaryKey: true},
-		{Name: "principal_id", Type: indexeddb.TypeString, NotNull: true},
+		{Name: "identity_id", Type: indexeddb.TypeString, NotNull: true},
 		{Name: "plugin", Type: indexeddb.TypeString, NotNull: true},
 		{Name: "connection", Type: indexeddb.TypeString, NotNull: true},
 		{Name: "instance", Type: indexeddb.TypeString, NotNull: true},
@@ -310,23 +298,6 @@ var ExternalCredentialsSchema = indexeddb.ObjectStoreSchema{
 		{Name: "last_refreshed_at", Type: indexeddb.TypeTime},
 		{Name: "refresh_error_count", Type: indexeddb.TypeInt},
 		{Name: "metadata_json", Type: indexeddb.TypeString},
-		{Name: "created_at", Type: indexeddb.TypeTime},
-		{Name: "updated_at", Type: indexeddb.TypeTime},
-	},
-}
-
-var ServiceAccountAuthBindingsSchema = indexeddb.ObjectStoreSchema{
-	Indexes: []indexeddb.IndexSchema{
-		{Name: "by_service_account", KeyPath: []string{"service_account_principal_id"}},
-		{Name: "by_binding_kind", KeyPath: []string{"binding_kind"}},
-		{Name: "by_lookup", KeyPath: []string{"binding_kind", "lookup_key"}, Unique: true},
-	},
-	Columns: []indexeddb.ColumnDef{
-		{Name: "id", Type: indexeddb.TypeString, PrimaryKey: true},
-		{Name: "service_account_principal_id", Type: indexeddb.TypeString, NotNull: true},
-		{Name: "binding_kind", Type: indexeddb.TypeString, NotNull: true},
-		{Name: "lookup_key", Type: indexeddb.TypeString, NotNull: true},
-		{Name: "binding_json", Type: indexeddb.TypeString},
 		{Name: "created_at", Type: indexeddb.TypeTime},
 		{Name: "updated_at", Type: indexeddb.TypeTime},
 	},

--- a/gestaltd/internal/coredata/services.go
+++ b/gestaltd/internal/coredata/services.go
@@ -9,15 +9,25 @@ import (
 )
 
 type Services struct {
-	Users                *UserService
-	Tokens               *TokenService
-	APITokens            *APITokenService
-	ManagedIdentities    *ManagedIdentityService
-	IdentityMemberships  *ManagedIdentityMembershipService
-	IdentityGrants       *ManagedIdentityGrantService
-	PluginAuthorizations *PluginAuthorizationService
-	AdminAuthorizations  *AdminAuthorizationService
-	DB                   indexeddb.IndexedDB
+	Users                          *UserService
+	Tokens                         *TokenService
+	APITokens                      *APITokenService
+	ManagedIdentities              *ManagedIdentityService
+	IdentityMemberships            *ManagedIdentityMembershipService
+	IdentityGrants                 *ManagedIdentityGrantService
+	PluginAuthorizations           *PluginAuthorizationService
+	AdminAuthorizations            *AdminAuthorizationService
+	Principals                     *PrincipalService
+	UserProfiles                   *UserProfileService
+	ServiceAccounts                *ServiceAccountService
+	ServiceAccountManagementGrants *ServiceAccountManagementGrantService
+	WorkspaceRoles                 *WorkspaceRoleService
+	PrincipalPluginAccess          *PrincipalPluginAccessService
+	ServiceAccountDelegations      *ServiceAccountDelegationService
+	APITokenAccess                 *APITokenAccessService
+	ExternalCredentials            *ExternalCredentialService
+	ServiceAccountAuthBindings     *ServiceAccountAuthBindingService
+	DB                             indexeddb.IndexedDB
 }
 
 func New(ds indexeddb.IndexedDB, enc *corecrypto.AESGCMEncryptor) (*Services, error) {
@@ -40,26 +50,107 @@ func New(ds indexeddb.IndexedDB, enc *corecrypto.AESGCMEncryptor) (*Services, er
 	if err := ds.CreateObjectStore(ctx, StoreManagedIdentityGrants, ManagedIdentityGrantsSchema); err != nil {
 		return nil, fmt.Errorf("create managed_identity_grants store: %w", err)
 	}
-	users := NewUserService(ds)
-	if err := users.BackfillNormalizedEmails(ctx); err != nil {
-		return nil, fmt.Errorf("backfill users store: %w", err)
-	}
 	if err := ds.CreateObjectStore(ctx, StorePluginAuthorizationMemberships, PluginAuthorizationMembershipsSchema); err != nil {
 		return nil, fmt.Errorf("create plugin_authorization_memberships store: %w", err)
 	}
 	if err := ds.CreateObjectStore(ctx, StoreAdminAuthorizationMemberships, AdminAuthorizationMembershipsSchema); err != nil {
 		return nil, fmt.Errorf("create admin_authorization_memberships store: %w", err)
 	}
+	if err := ds.CreateObjectStore(ctx, StorePrincipals, PrincipalsSchema); err != nil {
+		return nil, fmt.Errorf("create principals store: %w", err)
+	}
+	if err := ds.CreateObjectStore(ctx, StoreUserProfiles, UserProfilesSchema); err != nil {
+		return nil, fmt.Errorf("create user_profiles store: %w", err)
+	}
+	if err := ds.CreateObjectStore(ctx, StoreServiceAccounts, ServiceAccountsSchema); err != nil {
+		return nil, fmt.Errorf("create service_accounts store: %w", err)
+	}
+	if err := ds.CreateObjectStore(ctx, StoreServiceAccountManagementGrants, ServiceAccountManagementGrantsSchema); err != nil {
+		return nil, fmt.Errorf("create service_account_management_grants store: %w", err)
+	}
+	if err := ds.CreateObjectStore(ctx, StoreWorkspaceRoles, WorkspaceRolesSchema); err != nil {
+		return nil, fmt.Errorf("create workspace_roles store: %w", err)
+	}
+	if err := ds.CreateObjectStore(ctx, StorePrincipalPluginAccess, PrincipalPluginAccessSchema); err != nil {
+		return nil, fmt.Errorf("create principal_plugin_access store: %w", err)
+	}
+	if err := ds.CreateObjectStore(ctx, StoreServiceAccountDelegations, ServiceAccountDelegationsSchema); err != nil {
+		return nil, fmt.Errorf("create service_account_delegations store: %w", err)
+	}
+	if err := ds.CreateObjectStore(ctx, StoreAPITokenAccess, APITokenAccessSchema); err != nil {
+		return nil, fmt.Errorf("create api_token_access store: %w", err)
+	}
+	if err := ds.CreateObjectStore(ctx, StoreExternalCredentials, ExternalCredentialsSchema); err != nil {
+		return nil, fmt.Errorf("create external_credentials store: %w", err)
+	}
+	if err := ds.CreateObjectStore(ctx, StoreServiceAccountAuthBindings, ServiceAccountAuthBindingsSchema); err != nil {
+		return nil, fmt.Errorf("create service_account_auth_bindings store: %w", err)
+	}
+	principals := NewPrincipalService(ds)
+	userProfiles := NewUserProfileService(ds)
+	serviceAccounts := NewServiceAccountService(ds)
+	serviceAccountManagementGrants := NewServiceAccountManagementGrantService(ds)
+	workspaceRoles := NewWorkspaceRoleService(ds)
+	principalPluginAccess := NewPrincipalPluginAccessService(ds)
+	serviceAccountDelegations := NewServiceAccountDelegationService(ds)
+	apiTokenAccess := NewAPITokenAccessService(ds)
+	externalCredentials := NewExternalCredentialService(ds)
+	serviceAccountAuthBindings := NewServiceAccountAuthBindingService(ds)
+	if err := ensureLegacySharedServiceAccount(ctx, principals, serviceAccounts); err != nil {
+		return nil, fmt.Errorf("seed legacy shared service account: %w", err)
+	}
+	users := NewUserService(ds, principals, userProfiles)
+	if err := users.BackfillNormalizedEmails(ctx); err != nil {
+		return nil, fmt.Errorf("backfill users store: %w", err)
+	}
+	managedIdentities := NewManagedIdentityService(ds, principals, serviceAccounts)
+	identityMemberships := NewManagedIdentityMembershipService(ds, serviceAccountManagementGrants)
+	identityGrants := NewManagedIdentityGrantService(ds, principalPluginAccess)
+	apiTokens := NewAPITokenService(ds, apiTokenAccess)
+	pluginAuthorizations := NewPluginAuthorizationService(ds, nil)
+	adminAuthorizations := NewAdminAuthorizationService(ds, workspaceRoles)
+	tokens := NewTokenService(ds, enc, externalCredentials)
+	if err := users.BackfillCanonicalPrincipals(ctx); err != nil {
+		return nil, fmt.Errorf("backfill canonical user principals: %w", err)
+	}
+	if err := managedIdentities.BackfillCanonicalServiceAccounts(ctx); err != nil {
+		return nil, fmt.Errorf("backfill canonical service accounts: %w", err)
+	}
+	if err := identityMemberships.BackfillCanonicalGrants(ctx); err != nil {
+		return nil, fmt.Errorf("backfill canonical service account management grants: %w", err)
+	}
+	if err := identityGrants.BackfillCanonicalAccess(ctx); err != nil {
+		return nil, fmt.Errorf("backfill canonical identity grants: %w", err)
+	}
+	if err := adminAuthorizations.BackfillCanonicalWorkspaceRoles(ctx); err != nil {
+		return nil, fmt.Errorf("backfill canonical workspace roles: %w", err)
+	}
+	if err := apiTokens.BackfillTokenAccess(ctx); err != nil {
+		return nil, fmt.Errorf("backfill canonical api token access: %w", err)
+	}
+	if err := tokens.BackfillCanonicalCredentials(ctx); err != nil {
+		return nil, fmt.Errorf("backfill canonical external credentials: %w", err)
+	}
 	return &Services{
-		Users:                users,
-		Tokens:               NewTokenService(ds, enc),
-		APITokens:            NewAPITokenService(ds),
-		ManagedIdentities:    NewManagedIdentityService(ds),
-		IdentityMemberships:  NewManagedIdentityMembershipService(ds),
-		IdentityGrants:       NewManagedIdentityGrantService(ds),
-		PluginAuthorizations: NewPluginAuthorizationService(ds),
-		AdminAuthorizations:  NewAdminAuthorizationService(ds),
-		DB:                   ds,
+		Users:                          users,
+		Tokens:                         tokens,
+		APITokens:                      apiTokens,
+		ManagedIdentities:              managedIdentities,
+		IdentityMemberships:            identityMemberships,
+		IdentityGrants:                 identityGrants,
+		PluginAuthorizations:           pluginAuthorizations,
+		AdminAuthorizations:            adminAuthorizations,
+		Principals:                     principals,
+		UserProfiles:                   userProfiles,
+		ServiceAccounts:                serviceAccounts,
+		ServiceAccountManagementGrants: serviceAccountManagementGrants,
+		WorkspaceRoles:                 workspaceRoles,
+		PrincipalPluginAccess:          principalPluginAccess,
+		ServiceAccountDelegations:      serviceAccountDelegations,
+		APITokenAccess:                 apiTokenAccess,
+		ExternalCredentials:            externalCredentials,
+		ServiceAccountAuthBindings:     serviceAccountAuthBindings,
+		DB:                             ds,
 	}, nil
 }
 

--- a/gestaltd/internal/coredata/services.go
+++ b/gestaltd/internal/coredata/services.go
@@ -9,25 +9,23 @@ import (
 )
 
 type Services struct {
-	Users                          *UserService
-	Tokens                         *TokenService
-	APITokens                      *APITokenService
-	ManagedIdentities              *ManagedIdentityService
-	IdentityMemberships            *ManagedIdentityMembershipService
-	IdentityGrants                 *ManagedIdentityGrantService
-	PluginAuthorizations           *PluginAuthorizationService
-	AdminAuthorizations            *AdminAuthorizationService
-	Principals                     *PrincipalService
-	UserProfiles                   *UserProfileService
-	ServiceAccounts                *ServiceAccountService
-	ServiceAccountManagementGrants *ServiceAccountManagementGrantService
-	WorkspaceRoles                 *WorkspaceRoleService
-	PrincipalPluginAccess          *PrincipalPluginAccessService
-	ServiceAccountDelegations      *ServiceAccountDelegationService
-	APITokenAccess                 *APITokenAccessService
-	ExternalCredentials            *ExternalCredentialService
-	ServiceAccountAuthBindings     *ServiceAccountAuthBindingService
-	DB                             indexeddb.IndexedDB
+	Users                    *UserService
+	Tokens                   *TokenService
+	APITokens                *APITokenService
+	ManagedIdentities        *ManagedIdentityService
+	IdentityMemberships      *ManagedIdentityMembershipService
+	IdentityGrants           *ManagedIdentityGrantService
+	PluginAuthorizations     *PluginAuthorizationService
+	AdminAuthorizations      *AdminAuthorizationService
+	Identities               *IdentityService
+	IdentityAuthBindings     *IdentityAuthBindingService
+	IdentityManagementGrants *IdentityManagementGrantService
+	IdentityDelegations      *IdentityDelegationService
+	WorkspaceRoles           *WorkspaceRoleService
+	IdentityPluginAccess     *IdentityPluginAccessService
+	APITokenAccess           *APITokenAccessService
+	ExternalCredentials      *ExternalCredentialService
+	DB                       indexeddb.IndexedDB
 }
 
 func New(ds indexeddb.IndexedDB, enc *corecrypto.AESGCMEncryptor) (*Services, error) {
@@ -56,26 +54,23 @@ func New(ds indexeddb.IndexedDB, enc *corecrypto.AESGCMEncryptor) (*Services, er
 	if err := ds.CreateObjectStore(ctx, StoreAdminAuthorizationMemberships, AdminAuthorizationMembershipsSchema); err != nil {
 		return nil, fmt.Errorf("create admin_authorization_memberships store: %w", err)
 	}
-	if err := ds.CreateObjectStore(ctx, StorePrincipals, PrincipalsSchema); err != nil {
-		return nil, fmt.Errorf("create principals store: %w", err)
+	if err := ds.CreateObjectStore(ctx, StoreIdentities, IdentitiesSchema); err != nil {
+		return nil, fmt.Errorf("create identities store: %w", err)
 	}
-	if err := ds.CreateObjectStore(ctx, StoreUserProfiles, UserProfilesSchema); err != nil {
-		return nil, fmt.Errorf("create user_profiles store: %w", err)
+	if err := ds.CreateObjectStore(ctx, StoreIdentityAuthBindings, IdentityAuthBindingsSchema); err != nil {
+		return nil, fmt.Errorf("create identity_auth_bindings store: %w", err)
 	}
-	if err := ds.CreateObjectStore(ctx, StoreServiceAccounts, ServiceAccountsSchema); err != nil {
-		return nil, fmt.Errorf("create service_accounts store: %w", err)
+	if err := ds.CreateObjectStore(ctx, StoreIdentityManagementGrants, IdentityManagementGrantsSchema); err != nil {
+		return nil, fmt.Errorf("create identity_management_grants store: %w", err)
 	}
-	if err := ds.CreateObjectStore(ctx, StoreServiceAccountManagementGrants, ServiceAccountManagementGrantsSchema); err != nil {
-		return nil, fmt.Errorf("create service_account_management_grants store: %w", err)
+	if err := ds.CreateObjectStore(ctx, StoreIdentityDelegations, IdentityDelegationsSchema); err != nil {
+		return nil, fmt.Errorf("create identity_delegations store: %w", err)
 	}
 	if err := ds.CreateObjectStore(ctx, StoreWorkspaceRoles, WorkspaceRolesSchema); err != nil {
 		return nil, fmt.Errorf("create workspace_roles store: %w", err)
 	}
-	if err := ds.CreateObjectStore(ctx, StorePrincipalPluginAccess, PrincipalPluginAccessSchema); err != nil {
-		return nil, fmt.Errorf("create principal_plugin_access store: %w", err)
-	}
-	if err := ds.CreateObjectStore(ctx, StoreServiceAccountDelegations, ServiceAccountDelegationsSchema); err != nil {
-		return nil, fmt.Errorf("create service_account_delegations store: %w", err)
+	if err := ds.CreateObjectStore(ctx, StoreIdentityPluginAccess, IdentityPluginAccessSchema); err != nil {
+		return nil, fmt.Errorf("create identity_plugin_access store: %w", err)
 	}
 	if err := ds.CreateObjectStore(ctx, StoreAPITokenAccess, APITokenAccessSchema); err != nil {
 		return nil, fmt.Errorf("create api_token_access store: %w", err)
@@ -83,44 +78,45 @@ func New(ds indexeddb.IndexedDB, enc *corecrypto.AESGCMEncryptor) (*Services, er
 	if err := ds.CreateObjectStore(ctx, StoreExternalCredentials, ExternalCredentialsSchema); err != nil {
 		return nil, fmt.Errorf("create external_credentials store: %w", err)
 	}
-	if err := ds.CreateObjectStore(ctx, StoreServiceAccountAuthBindings, ServiceAccountAuthBindingsSchema); err != nil {
-		return nil, fmt.Errorf("create service_account_auth_bindings store: %w", err)
-	}
-	principals := NewPrincipalService(ds)
-	userProfiles := NewUserProfileService(ds)
-	serviceAccounts := NewServiceAccountService(ds)
-	serviceAccountManagementGrants := NewServiceAccountManagementGrantService(ds)
+
+	identities := NewIdentityService(ds)
+	authBindings := NewIdentityAuthBindingService(ds)
+	identityManagementGrants := NewIdentityManagementGrantService(ds)
+	identityDelegations := NewIdentityDelegationService(ds)
 	workspaceRoles := NewWorkspaceRoleService(ds)
-	principalPluginAccess := NewPrincipalPluginAccessService(ds)
-	serviceAccountDelegations := NewServiceAccountDelegationService(ds)
+	identityPluginAccess := NewIdentityPluginAccessService(ds)
 	apiTokenAccess := NewAPITokenAccessService(ds)
 	externalCredentials := NewExternalCredentialService(ds)
-	serviceAccountAuthBindings := NewServiceAccountAuthBindingService(ds)
-	if err := ensureLegacySharedServiceAccount(ctx, principals, serviceAccounts); err != nil {
-		return nil, fmt.Errorf("seed legacy shared service account: %w", err)
-	}
-	users := NewUserService(ds, principals, userProfiles)
+
+	users := NewUserService(ds, identities, authBindings)
 	if err := users.BackfillNormalizedEmails(ctx); err != nil {
 		return nil, fmt.Errorf("backfill users store: %w", err)
 	}
-	managedIdentities := NewManagedIdentityService(ds, principals, serviceAccounts)
-	identityMemberships := NewManagedIdentityMembershipService(ds, serviceAccountManagementGrants)
-	identityGrants := NewManagedIdentityGrantService(ds, principalPluginAccess)
-	apiTokens := NewAPITokenService(ds, apiTokenAccess)
-	pluginAuthorizations := NewPluginAuthorizationService(ds, nil)
-	adminAuthorizations := NewAdminAuthorizationService(ds, workspaceRoles)
-	tokens := NewTokenService(ds, enc, externalCredentials)
-	if err := users.BackfillCanonicalPrincipals(ctx); err != nil {
-		return nil, fmt.Errorf("backfill canonical user principals: %w", err)
+	managedIdentities := NewManagedIdentityService(ds, identities)
+	identityMemberships := NewManagedIdentityMembershipService(ds, identityManagementGrants, users)
+	identityGrants := NewManagedIdentityGrantService(ds, identityPluginAccess)
+	pluginAuthorizations := NewPluginAuthorizationService(ds, identityPluginAccess, users)
+	adminAuthorizations := NewAdminAuthorizationService(ds, workspaceRoles, users)
+	apiTokens := NewAPITokenService(ds, apiTokenAccess, users)
+	tokens := NewTokenService(ds, enc, externalCredentials, users)
+
+	if err := rebuildCanonicalIdentityGraph(ctx, identities, authBindings, identityManagementGrants, workspaceRoles, identityPluginAccess, apiTokenAccess, externalCredentials); err != nil {
+		return nil, err
 	}
-	if err := managedIdentities.BackfillCanonicalServiceAccounts(ctx); err != nil {
-		return nil, fmt.Errorf("backfill canonical service accounts: %w", err)
+	if err := users.BackfillCanonicalIdentities(ctx); err != nil {
+		return nil, fmt.Errorf("backfill canonical identities from users: %w", err)
+	}
+	if err := managedIdentities.BackfillCanonicalIdentities(ctx); err != nil {
+		return nil, fmt.Errorf("backfill canonical identities from managed identities: %w", err)
 	}
 	if err := identityMemberships.BackfillCanonicalGrants(ctx); err != nil {
-		return nil, fmt.Errorf("backfill canonical service account management grants: %w", err)
+		return nil, fmt.Errorf("backfill canonical identity management grants: %w", err)
 	}
 	if err := identityGrants.BackfillCanonicalAccess(ctx); err != nil {
 		return nil, fmt.Errorf("backfill canonical identity grants: %w", err)
+	}
+	if err := pluginAuthorizations.BackfillCanonicalAccess(ctx); err != nil {
+		return nil, fmt.Errorf("backfill canonical plugin authorizations: %w", err)
 	}
 	if err := adminAuthorizations.BackfillCanonicalWorkspaceRoles(ctx); err != nil {
 		return nil, fmt.Errorf("backfill canonical workspace roles: %w", err)
@@ -131,27 +127,43 @@ func New(ds indexeddb.IndexedDB, enc *corecrypto.AESGCMEncryptor) (*Services, er
 	if err := tokens.BackfillCanonicalCredentials(ctx); err != nil {
 		return nil, fmt.Errorf("backfill canonical external credentials: %w", err)
 	}
+
 	return &Services{
-		Users:                          users,
-		Tokens:                         tokens,
-		APITokens:                      apiTokens,
-		ManagedIdentities:              managedIdentities,
-		IdentityMemberships:            identityMemberships,
-		IdentityGrants:                 identityGrants,
-		PluginAuthorizations:           pluginAuthorizations,
-		AdminAuthorizations:            adminAuthorizations,
-		Principals:                     principals,
-		UserProfiles:                   userProfiles,
-		ServiceAccounts:                serviceAccounts,
-		ServiceAccountManagementGrants: serviceAccountManagementGrants,
-		WorkspaceRoles:                 workspaceRoles,
-		PrincipalPluginAccess:          principalPluginAccess,
-		ServiceAccountDelegations:      serviceAccountDelegations,
-		APITokenAccess:                 apiTokenAccess,
-		ExternalCredentials:            externalCredentials,
-		ServiceAccountAuthBindings:     serviceAccountAuthBindings,
-		DB:                             ds,
+		Users:                    users,
+		Tokens:                   tokens,
+		APITokens:                apiTokens,
+		ManagedIdentities:        managedIdentities,
+		IdentityMemberships:      identityMemberships,
+		IdentityGrants:           identityGrants,
+		PluginAuthorizations:     pluginAuthorizations,
+		AdminAuthorizations:      adminAuthorizations,
+		Identities:               identities,
+		IdentityAuthBindings:     authBindings,
+		IdentityManagementGrants: identityManagementGrants,
+		IdentityDelegations:      identityDelegations,
+		WorkspaceRoles:           workspaceRoles,
+		IdentityPluginAccess:     identityPluginAccess,
+		APITokenAccess:           apiTokenAccess,
+		ExternalCredentials:      externalCredentials,
+		DB:                       ds,
 	}, nil
+}
+
+func rebuildCanonicalIdentityGraph(ctx context.Context, identities *IdentityService, authBindings *IdentityAuthBindingService, managementGrants *IdentityManagementGrantService, workspaceRoles *WorkspaceRoleService, pluginAccess *IdentityPluginAccessService, apiTokenAccess *APITokenAccessService, externalCredentials *ExternalCredentialService) error {
+	for _, store := range []indexeddb.ObjectStore{
+		identities.store,
+		authBindings.store,
+		managementGrants.store,
+		workspaceRoles.store,
+		pluginAccess.store,
+		apiTokenAccess.store,
+		externalCredentials.store,
+	} {
+		if err := store.Clear(ctx); err != nil {
+			return fmt.Errorf("clear canonical identity graph store: %w", err)
+		}
+	}
+	return nil
 }
 
 func (s *Services) Ping(ctx context.Context) error {

--- a/gestaltd/internal/coredata/services_test.go
+++ b/gestaltd/internal/coredata/services_test.go
@@ -223,7 +223,7 @@ func TestNew(t *testing.T) {
 		}
 	})
 
-	t.Run("backfills_one_canonical_profile_for_case_insensitive_duplicate_legacy_users", func(t *testing.T) {
+	t.Run("backfills_one_canonical_identity_for_case_insensitive_duplicate_legacy_users", func(t *testing.T) {
 		t.Parallel()
 
 		db := &coretesting.StubIndexedDB{}
@@ -260,22 +260,147 @@ func TestNew(t *testing.T) {
 			t.Fatalf("coredata.New: %v", err)
 		}
 
-		if _, err := svc.UserProfiles.GetProfile(ctx, "legacy-canonical"); err != nil {
-			t.Fatalf("GetProfile(canonical winner): %v", err)
+		if _, err := svc.Identities.GetIdentity(ctx, "legacy-canonical"); err != nil {
+			t.Fatalf("GetIdentity(canonical winner): %v", err)
 		}
-		if _, err := svc.UserProfiles.GetProfile(ctx, "legacy-mixed"); err != core.ErrNotFound {
-			t.Fatalf("GetProfile(mixed-case loser) = %v, want ErrNotFound", err)
+		if _, err := svc.Identities.GetIdentity(ctx, "legacy-mixed"); err != core.ErrNotFound {
+			t.Fatalf("GetIdentity(mixed-case loser) = %v, want ErrNotFound", err)
 		}
-		count, err := svc.DB.ObjectStore(coredata.StoreUserProfiles).Count(ctx, nil)
+		binding, err := svc.IdentityAuthBindings.GetBinding(ctx, core.IdentityAuthBindingKindEmail, "legacy", "user@example.com")
 		if err != nil {
-			t.Fatalf("Count user_profiles: %v", err)
+			t.Fatalf("GetBinding(canonical email): %v", err)
+		}
+		if binding.IdentityID != "legacy-canonical" {
+			t.Fatalf("binding.IdentityID = %q, want %q", binding.IdentityID, "legacy-canonical")
+		}
+		count, err := svc.DB.ObjectStore(coredata.StoreIdentities).Count(ctx, nil)
+		if err != nil {
+			t.Fatalf("Count identities: %v", err)
 		}
 		if count != 1 {
-			t.Fatalf("user_profiles count = %d, want 1", count)
+			t.Fatalf("identities count = %d, want 1", count)
 		}
 	})
 
-	t.Run("backfills_multiple_canonical_profiles_without_blank_auth_subject_keys", func(t *testing.T) {
+	t.Run("skips_unreadable_legacy_integration_tokens_during_canonical_backfill", func(t *testing.T) {
+		t.Parallel()
+
+		db := &coretesting.StubIndexedDB{}
+		ctx := context.Background()
+		createdAt := time.Date(2026, 1, 2, 12, 0, 0, 0, time.UTC)
+		seedLegacyUserRecord(t, &coredata.Services{DB: db}, "legacy-user", "user@example.com", createdAt)
+
+		enc, err := corecrypto.NewAESGCM([]byte(testEncryptionKey))
+		if err != nil {
+			t.Fatalf("NewAESGCM: %v", err)
+		}
+		accessEnc, refreshEnc, err := enc.EncryptTokenPair("plaintext-access", "")
+		if err != nil {
+			t.Fatalf("EncryptTokenPair: %v", err)
+		}
+		if err := db.ObjectStore(coredata.StoreIntegrationTokens).Add(ctx, indexeddb.Record{
+			"id":                      "good-token",
+			"user_id":                 "legacy-user",
+			"integration":             "slack",
+			"connection":              "workspace",
+			"instance":                "",
+			"access_token_encrypted":  accessEnc,
+			"refresh_token_encrypted": refreshEnc,
+			"scopes":                  "channels:read",
+			"created_at":              createdAt,
+			"updated_at":              createdAt,
+		}); err != nil {
+			t.Fatalf("seed valid integration token: %v", err)
+		}
+		if err := db.ObjectStore(coredata.StoreIntegrationTokens).Add(ctx, indexeddb.Record{
+			"id":                      "bad-token",
+			"user_id":                 "legacy-user",
+			"integration":             "github",
+			"connection":              "workspace",
+			"instance":                "",
+			"access_token_encrypted":  "not-valid-ciphertext",
+			"refresh_token_encrypted": "",
+			"created_at":              createdAt,
+			"updated_at":              createdAt,
+		}); err != nil {
+			t.Fatalf("seed invalid integration token: %v", err)
+		}
+
+		svc, err := coredata.New(db, enc)
+		if err != nil {
+			t.Fatalf("coredata.New: %v", err)
+		}
+
+		good, err := svc.ExternalCredentials.GetCredential(ctx, "legacy-user", "slack", "workspace", "")
+		if err != nil {
+			t.Fatalf("GetCredential valid token: %v", err)
+		}
+		if good.IdentityID != "legacy-user" {
+			t.Fatalf("valid credential identity_id = %q, want %q", good.IdentityID, "legacy-user")
+		}
+		if _, err := svc.ExternalCredentials.GetCredential(ctx, "legacy-user", "github", "workspace", ""); !errors.Is(err, core.ErrNotFound) {
+			t.Fatalf("GetCredential invalid token err = %v, want ErrNotFound", err)
+		}
+	})
+
+	t.Run("skips_malformed_managed_identity_grants_during_canonical_backfill", func(t *testing.T) {
+		t.Parallel()
+
+		db := &coretesting.StubIndexedDB{}
+		ctx := context.Background()
+		createdAt := time.Date(2026, 1, 3, 12, 0, 0, 0, time.UTC)
+		if err := db.ObjectStore(coredata.StoreManagedIdentities).Add(ctx, indexeddb.Record{
+			"id":                     "mi-1",
+			"display_name":           "Deploy Bot",
+			"created_by_identity_id": "legacy-user",
+			"created_at":             createdAt,
+			"updated_at":             createdAt,
+		}); err != nil {
+			t.Fatalf("seed managed identity: %v", err)
+		}
+		if err := db.ObjectStore(coredata.StoreManagedIdentityGrants).Add(ctx, indexeddb.Record{
+			"id":              "grant-good",
+			"identity_id":     "mi-1",
+			"plugin":          "slack",
+			"operations_json": `["read"]`,
+			"created_at":      createdAt,
+			"updated_at":      createdAt,
+		}); err != nil {
+			t.Fatalf("seed valid managed identity grant: %v", err)
+		}
+		if err := db.ObjectStore(coredata.StoreManagedIdentityGrants).Add(ctx, indexeddb.Record{
+			"id":              "grant-bad",
+			"identity_id":     "mi-1",
+			"plugin":          "github",
+			"operations_json": `{`,
+			"created_at":      createdAt,
+			"updated_at":      createdAt,
+		}); err != nil {
+			t.Fatalf("seed invalid managed identity grant: %v", err)
+		}
+
+		enc, err := corecrypto.NewAESGCM([]byte(testEncryptionKey))
+		if err != nil {
+			t.Fatalf("NewAESGCM: %v", err)
+		}
+		svc, err := coredata.New(db, enc)
+		if err != nil {
+			t.Fatalf("coredata.New: %v", err)
+		}
+
+		access, err := svc.IdentityPluginAccess.GetAccess(ctx, "mi-1", "slack")
+		if err != nil {
+			t.Fatalf("GetAccess valid grant: %v", err)
+		}
+		if access.Plugin != "slack" {
+			t.Fatalf("valid access plugin = %q, want %q", access.Plugin, "slack")
+		}
+		if _, err := svc.IdentityPluginAccess.GetAccess(ctx, "mi-1", "github"); !errors.Is(err, core.ErrNotFound) {
+			t.Fatalf("GetAccess invalid grant err = %v, want ErrNotFound", err)
+		}
+	})
+
+	t.Run("backfills_multiple_identity_bindings_without_blank_auth_subject_keys", func(t *testing.T) {
 		t.Parallel()
 
 		db := &coretesting.StubIndexedDB{}
@@ -313,19 +438,19 @@ func TestNew(t *testing.T) {
 			t.Fatalf("coredata.New: %v", err)
 		}
 
-		profiles, err := svc.DB.ObjectStore(coredata.StoreUserProfiles).GetAll(ctx, nil)
+		bindings, err := svc.DB.ObjectStore(coredata.StoreIdentityAuthBindings).GetAll(ctx, nil)
 		if err != nil {
-			t.Fatalf("GetAll user profiles: %v", err)
+			t.Fatalf("GetAll identity auth bindings: %v", err)
 		}
-		if len(profiles) != 2 {
-			t.Fatalf("canonical user profiles len = %d, want 2", len(profiles))
+		if len(bindings) != 2 {
+			t.Fatalf("identity auth bindings len = %d, want 2", len(bindings))
 		}
-		for _, rec := range profiles {
-			if _, ok := rec["auth_provider"]; ok {
-				t.Fatalf("auth_provider unexpectedly present in %+v", rec)
+		for _, rec := range bindings {
+			if got := rec["binding_kind"]; got != core.IdentityAuthBindingKindEmail {
+				t.Fatalf("binding_kind = %v, want %q", got, core.IdentityAuthBindingKindEmail)
 			}
-			if _, ok := rec["auth_subject"]; ok {
-				t.Fatalf("auth_subject unexpectedly present in %+v", rec)
+			if got := rec["authority"]; got != "legacy" {
+				t.Fatalf("authority = %v, want %q", got, "legacy")
 			}
 		}
 	})
@@ -1344,6 +1469,44 @@ func TestAPITokenService(t *testing.T) {
 		}
 		if len(access) != 1 || access[0].Plugin != "owner-only" {
 			t.Fatalf("owner-only token access = %+v, want surviving access", access)
+		}
+	})
+
+	t.Run("BackfillTokenAccess_uses_scopes_when_permissions_are_empty", func(t *testing.T) {
+		t.Parallel()
+		svc := newTestServices(t)
+		ctx := context.Background()
+
+		user := mustCreateUser(t, svc, "scoped@test.com")
+		now := time.Now().UTC()
+		if err := svc.DB.ObjectStore(coredata.StoreAPITokens).Add(ctx, indexeddb.Record{
+			"id":           "scoped-token",
+			"user_id":      user.ID,
+			"name":         "scoped",
+			"hashed_token": "sha256:scoped",
+			"scopes":       "alpha beta alpha",
+			"created_at":   now,
+			"updated_at":   now,
+		}); err != nil {
+			t.Fatalf("seed scoped api token: %v", err)
+		}
+		if err := svc.APITokens.BackfillTokenAccess(ctx); err != nil {
+			t.Fatalf("BackfillTokenAccess: %v", err)
+		}
+
+		access, err := svc.APITokenAccess.ListByToken(ctx, "scoped-token")
+		if err != nil {
+			t.Fatalf("ListByToken: %v", err)
+		}
+		if len(access) != 2 {
+			t.Fatalf("scope-backed access len = %d, want 2: %+v", len(access), access)
+		}
+		got := make(map[string]bool, len(access))
+		for _, row := range access {
+			got[row.Plugin] = row.InvokeAllOperations
+		}
+		if !reflect.DeepEqual(got, map[string]bool{"alpha": true, "beta": true}) {
+			t.Fatalf("scope-backed access = %+v, want alpha/beta invoke-all", got)
 		}
 	})
 

--- a/gestaltd/internal/coredata/services_test.go
+++ b/gestaltd/internal/coredata/services_test.go
@@ -2,8 +2,10 @@ package coredata_test
 
 import (
 	"context"
+	"encoding/json"
 	"errors"
 	"fmt"
+	"reflect"
 	"sync"
 	"testing"
 	"time"
@@ -218,6 +220,113 @@ func TestNew(t *testing.T) {
 		}
 		if got := raw["normalized_email"]; got != "user@example.com" {
 			t.Fatalf("normalized_email = %v, want %q", got, "user@example.com")
+		}
+	})
+
+	t.Run("backfills_one_canonical_profile_for_case_insensitive_duplicate_legacy_users", func(t *testing.T) {
+		t.Parallel()
+
+		db := &coretesting.StubIndexedDB{}
+		ctx := context.Background()
+		older := time.Date(2026, 1, 1, 12, 0, 0, 0, time.UTC)
+		newer := older.Add(time.Hour)
+		if err := db.ObjectStore(coredata.StoreUsers).Add(ctx, indexeddb.Record{
+			"id":               "legacy-mixed",
+			"email":            "User@Example.com",
+			"normalized_email": "user@example.com",
+			"display_name":     "",
+			"created_at":       older,
+			"updated_at":       older,
+		}); err != nil {
+			t.Fatalf("seed mixed-case legacy user: %v", err)
+		}
+		if err := db.ObjectStore(coredata.StoreUsers).Add(ctx, indexeddb.Record{
+			"id":               "legacy-canonical",
+			"email":            "user@example.com",
+			"normalized_email": "user@example.com",
+			"display_name":     "",
+			"created_at":       newer,
+			"updated_at":       newer,
+		}); err != nil {
+			t.Fatalf("seed canonical legacy user: %v", err)
+		}
+
+		enc, err := corecrypto.NewAESGCM([]byte(testEncryptionKey))
+		if err != nil {
+			t.Fatalf("NewAESGCM: %v", err)
+		}
+		svc, err := coredata.New(db, enc)
+		if err != nil {
+			t.Fatalf("coredata.New: %v", err)
+		}
+
+		if _, err := svc.UserProfiles.GetProfile(ctx, "legacy-canonical"); err != nil {
+			t.Fatalf("GetProfile(canonical winner): %v", err)
+		}
+		if _, err := svc.UserProfiles.GetProfile(ctx, "legacy-mixed"); err != core.ErrNotFound {
+			t.Fatalf("GetProfile(mixed-case loser) = %v, want ErrNotFound", err)
+		}
+		count, err := svc.DB.ObjectStore(coredata.StoreUserProfiles).Count(ctx, nil)
+		if err != nil {
+			t.Fatalf("Count user_profiles: %v", err)
+		}
+		if count != 1 {
+			t.Fatalf("user_profiles count = %d, want 1", count)
+		}
+	})
+
+	t.Run("backfills_multiple_canonical_profiles_without_blank_auth_subject_keys", func(t *testing.T) {
+		t.Parallel()
+
+		db := &coretesting.StubIndexedDB{}
+		ctx := context.Background()
+		createdAt := time.Date(2026, 1, 2, 12, 0, 0, 0, time.UTC)
+		for _, rec := range []indexeddb.Record{
+			{
+				"id":               "legacy-a",
+				"email":            "alice@example.com",
+				"normalized_email": "alice@example.com",
+				"display_name":     "",
+				"created_at":       createdAt,
+				"updated_at":       createdAt,
+			},
+			{
+				"id":               "legacy-b",
+				"email":            "bob@example.com",
+				"normalized_email": "bob@example.com",
+				"display_name":     "",
+				"created_at":       createdAt.Add(time.Minute),
+				"updated_at":       createdAt.Add(time.Minute),
+			},
+		} {
+			if err := db.ObjectStore(coredata.StoreUsers).Add(ctx, rec); err != nil {
+				t.Fatalf("seed legacy user %q: %v", rec["id"], err)
+			}
+		}
+
+		enc, err := corecrypto.NewAESGCM([]byte(testEncryptionKey))
+		if err != nil {
+			t.Fatalf("NewAESGCM: %v", err)
+		}
+		svc, err := coredata.New(db, enc)
+		if err != nil {
+			t.Fatalf("coredata.New: %v", err)
+		}
+
+		profiles, err := svc.DB.ObjectStore(coredata.StoreUserProfiles).GetAll(ctx, nil)
+		if err != nil {
+			t.Fatalf("GetAll user profiles: %v", err)
+		}
+		if len(profiles) != 2 {
+			t.Fatalf("canonical user profiles len = %d, want 2", len(profiles))
+		}
+		for _, rec := range profiles {
+			if _, ok := rec["auth_provider"]; ok {
+				t.Fatalf("auth_provider unexpectedly present in %+v", rec)
+			}
+			if _, ok := rec["auth_subject"]; ok {
+				t.Fatalf("auth_subject unexpectedly present in %+v", rec)
+			}
 		}
 	})
 }
@@ -445,6 +554,16 @@ func TestTokenService(t *testing.T) {
 		if got.MetadataJSON != `{"key":"val"}` {
 			t.Errorf("MetadataJSON = %q, want %q", got.MetadataJSON, `{"key":"val"}`)
 		}
+		credential, err := svc.ExternalCredentials.GetCredential(ctx, user.ID, "test-svc", "default", "inst-1")
+		if err != nil {
+			t.Fatalf("GetCredential: %v", err)
+		}
+		if credential.AuthType != "oauth2" {
+			t.Errorf("AuthType = %q, want %q", credential.AuthType, "oauth2")
+		}
+		if credential.MetadataJSON != `{"key":"val"}` {
+			t.Errorf("MetadataJSON = %q, want %q", credential.MetadataJSON, `{"key":"val"}`)
+		}
 	})
 
 	t.Run("Token_not_found", func(t *testing.T) {
@@ -556,6 +675,9 @@ func TestTokenService(t *testing.T) {
 		_, err := svc.Tokens.Token(ctx, user.ID, "svc", "default", "i1")
 		if err != core.ErrNotFound {
 			t.Fatalf("Token after delete = %v, want ErrNotFound", err)
+		}
+		if _, err := svc.ExternalCredentials.GetCredential(ctx, user.ID, "svc", "default", "i1"); err != core.ErrNotFound {
+			t.Fatalf("GetCredential after delete = %v, want ErrNotFound", err)
 		}
 	})
 
@@ -682,6 +804,168 @@ func TestTokenService(t *testing.T) {
 		if tokens[0].AccessToken != "newest" {
 			t.Fatalf("AccessToken = %q, want %q", tokens[0].AccessToken, "newest")
 		}
+
+		if err := svc.Tokens.DeleteToken(ctx, newest.ID); err != nil {
+			t.Fatalf("DeleteToken newest: %v", err)
+		}
+		credential, err := svc.ExternalCredentials.GetCredential(ctx, user.ID, "svc", "default", "i1")
+		if err != nil {
+			t.Fatalf("GetCredential after deleting newest duplicate: %v", err)
+		}
+		var payload map[string]string
+		if err := json.Unmarshal([]byte(credential.PayloadEncrypted), &payload); err != nil {
+			t.Fatalf("Unmarshal credential payload: %v", err)
+		}
+		wantAccess, _ := duplicate["access_token_encrypted"].(string)
+		wantRefresh, _ := duplicate["refresh_token_encrypted"].(string)
+		if payload["access_token_encrypted"] != wantAccess {
+			t.Fatalf("access_token_encrypted = %q, want %q", payload["access_token_encrypted"], wantAccess)
+		}
+		if payload["refresh_token_encrypted"] != wantRefresh {
+			t.Fatalf("refresh_token_encrypted = %q, want %q", payload["refresh_token_encrypted"], wantRefresh)
+		}
+	})
+
+	t.Run("startup_backfill_uses_deduped_legacy_winner_for_external_credentials", func(t *testing.T) {
+		t.Parallel()
+
+		svc, db := newTestServicesWithDB(t)
+		ctx := context.Background()
+		user := mustCreateUser(t, svc, "startup-dupes@test.com")
+
+		newest := &core.IntegrationToken{
+			ID:           "tok-startup-primary",
+			UserID:       user.ID,
+			Integration:  "svc",
+			Connection:   "default",
+			Instance:     "i1",
+			AccessToken:  "newest",
+			RefreshToken: "refresh-newest",
+		}
+		if err := svc.Tokens.StoreToken(ctx, newest); err != nil {
+			t.Fatalf("StoreToken newest: %v", err)
+		}
+		legacySource := &core.IntegrationToken{
+			ID:           "tok-startup-legacy",
+			UserID:       user.ID,
+			Integration:  "svc",
+			Connection:   "default",
+			Instance:     "legacy-source",
+			AccessToken:  "legacy",
+			RefreshToken: "refresh-legacy",
+		}
+		if err := svc.Tokens.StoreToken(ctx, legacySource); err != nil {
+			t.Fatalf("StoreToken legacy source: %v", err)
+		}
+
+		store := db.ObjectStore(coredata.StoreIntegrationTokens)
+		primaryRaw, err := store.Get(ctx, newest.ID)
+		if err != nil {
+			t.Fatalf("Get primary raw: %v", err)
+		}
+		legacyRaw, err := store.Get(ctx, legacySource.ID)
+		if err != nil {
+			t.Fatalf("Get legacy raw: %v", err)
+		}
+		if err := store.Delete(ctx, legacySource.ID); err != nil {
+			t.Fatalf("Delete legacy source: %v", err)
+		}
+
+		duplicate := indexeddb.Record{}
+		for k, v := range legacyRaw {
+			duplicate[k] = v
+		}
+		duplicate["id"] = "tok-startup-duplicate"
+		duplicate["user_id"] = user.ID
+		duplicate["integration"] = "svc"
+		duplicate["connection"] = "default"
+		duplicate["instance"] = "i1"
+		duplicate["created_at"] = recOrNow(primaryRaw, "created_at").Add(-time.Minute)
+		duplicate["updated_at"] = recOrNow(primaryRaw, "updated_at").Add(-time.Minute)
+		if err := store.Put(ctx, duplicate); err != nil {
+			t.Fatalf("Put duplicate raw token: %v", err)
+		}
+
+		enc, err := corecrypto.NewAESGCM([]byte(testEncryptionKey))
+		if err != nil {
+			t.Fatalf("NewAESGCM: %v", err)
+		}
+		reloaded, err := coredata.New(db, enc)
+		if err != nil {
+			t.Fatalf("reload services for startup backfill: %v", err)
+		}
+
+		credential, err := reloaded.ExternalCredentials.GetCredential(ctx, user.ID, "svc", "default", "i1")
+		if err != nil {
+			t.Fatalf("GetCredential after reload: %v", err)
+		}
+		var payload map[string]string
+		if err := json.Unmarshal([]byte(credential.PayloadEncrypted), &payload); err != nil {
+			t.Fatalf("Unmarshal credential payload: %v", err)
+		}
+		wantAccess, _ := primaryRaw["access_token_encrypted"].(string)
+		wantRefresh, _ := primaryRaw["refresh_token_encrypted"].(string)
+		if payload["access_token_encrypted"] != wantAccess {
+			t.Fatalf("access_token_encrypted after reload = %q, want %q", payload["access_token_encrypted"], wantAccess)
+		}
+		if payload["refresh_token_encrypted"] != wantRefresh {
+			t.Fatalf("refresh_token_encrypted after reload = %q, want %q", payload["refresh_token_encrypted"], wantRefresh)
+		}
+	})
+
+	t.Run("startup_backfill_preserves_external_credential_auth_type", func(t *testing.T) {
+		t.Parallel()
+
+		tests := []struct {
+			name         string
+			accessToken  string
+			refreshToken string
+			wantAuthType string
+		}{
+			{name: "oauth2", accessToken: "access", refreshToken: "refresh", wantAuthType: "oauth2"},
+			{name: "bearer", accessToken: "access", wantAuthType: "bearer"},
+			{name: "manual", wantAuthType: "manual"},
+		}
+
+		for _, tc := range tests {
+			tc := tc
+			t.Run(tc.name, func(t *testing.T) {
+				t.Parallel()
+				svc, db := newTestServicesWithDB(t)
+				ctx := context.Background()
+				user := mustCreateUser(t, svc, tc.name+"@test.com")
+
+				token := &core.IntegrationToken{
+					ID:           "tok-" + tc.name,
+					UserID:       user.ID,
+					Integration:  "svc",
+					Connection:   "default",
+					Instance:     "i1",
+					AccessToken:  tc.accessToken,
+					RefreshToken: tc.refreshToken,
+				}
+				if err := svc.Tokens.StoreToken(ctx, token); err != nil {
+					t.Fatalf("StoreToken: %v", err)
+				}
+
+				enc, err := corecrypto.NewAESGCM([]byte(testEncryptionKey))
+				if err != nil {
+					t.Fatalf("NewAESGCM: %v", err)
+				}
+				reloaded, err := coredata.New(db, enc)
+				if err != nil {
+					t.Fatalf("reload services for startup backfill: %v", err)
+				}
+
+				credential, err := reloaded.ExternalCredentials.GetCredential(ctx, user.ID, "svc", "default", "i1")
+				if err != nil {
+					t.Fatalf("GetCredential after reload: %v", err)
+				}
+				if credential.AuthType != tc.wantAuthType {
+					t.Fatalf("AuthType after reload = %q, want %q", credential.AuthType, tc.wantAuthType)
+				}
+			})
+		}
 	})
 
 	t.Run("ConcurrentTokenWrites", func(t *testing.T) {
@@ -800,6 +1084,10 @@ func TestAPITokenService(t *testing.T) {
 			Name:        "ci-token",
 			HashedToken: "sha256:abc123",
 			Scopes:      "read:tokens",
+			Permissions: []core.AccessPermission{
+				{Plugin: "sample", Operations: []string{"read"}},
+				{Plugin: "other"},
+			},
 		}
 		if err := svc.APITokens.StoreAPIToken(ctx, token); err != nil {
 			t.Fatalf("StoreAPIToken: %v", err)
@@ -817,6 +1105,19 @@ func TestAPITokenService(t *testing.T) {
 		}
 		if got.Scopes != "read:tokens" {
 			t.Errorf("Scopes = %q, want %q", got.Scopes, "read:tokens")
+		}
+		access, err := svc.APITokenAccess.ListByToken(ctx, token.ID)
+		if err != nil {
+			t.Fatalf("ListByToken: %v", err)
+		}
+		if len(access) != 2 {
+			t.Fatalf("token access len = %d, want 2", len(access))
+		}
+		if access[0].Plugin != "other" || !access[0].InvokeAllOperations {
+			t.Fatalf("first token access = %+v, want plugin other with invoke-all", access[0])
+		}
+		if access[1].Plugin != "sample" || access[1].InvokeAllOperations || !reflect.DeepEqual(access[1].Operations, []string{"read"}) {
+			t.Fatalf("second token access = %+v, want sample [read]", access[1])
 		}
 	})
 
@@ -929,6 +1230,13 @@ func TestAPITokenService(t *testing.T) {
 		if err != core.ErrNotFound {
 			t.Fatalf("ValidateAPIToken after revoke = %v, want ErrNotFound", err)
 		}
+		access, err := svc.APITokenAccess.ListByToken(ctx, token.ID)
+		if err != nil {
+			t.Fatalf("ListByToken after revoke: %v", err)
+		}
+		if len(access) != 0 {
+			t.Fatalf("token access after revoke = %+v, want none", access)
+		}
 	})
 
 	t.Run("RevokeAPIToken_nonexistent", func(t *testing.T) {
@@ -973,6 +1281,69 @@ func TestAPITokenService(t *testing.T) {
 		}
 		if len(tokens) != 0 {
 			t.Errorf("got %d tokens after revoke-all, want 0", len(tokens))
+		}
+	})
+
+	t.Run("RevokeAllAPITokens_preserves_access_for_owner_only_survivors", func(t *testing.T) {
+		t.Parallel()
+		svc := newTestServices(t)
+		ctx := context.Background()
+
+		user := mustCreateUser(t, svc, "alice@test.com")
+		legacy := &core.APIToken{
+			ID:          "legacy-token",
+			UserID:      user.ID,
+			Name:        "legacy",
+			HashedToken: "sha256:legacy",
+			Permissions: []core.AccessPermission{{Plugin: "legacy"}},
+		}
+		if err := svc.APITokens.StoreAPIToken(ctx, legacy); err != nil {
+			t.Fatalf("StoreAPIToken legacy: %v", err)
+		}
+
+		permissionsJSON, err := json.Marshal([]core.AccessPermission{{Plugin: "owner-only"}})
+		if err != nil {
+			t.Fatalf("Marshal permissions: %v", err)
+		}
+		now := time.Now()
+		if err := svc.DB.ObjectStore(coredata.StoreAPITokens).Add(ctx, indexeddb.Record{
+			"id":               "owner-only-token",
+			"owner_kind":       core.APITokenOwnerKindUser,
+			"owner_id":         user.ID,
+			"name":             "owner-only",
+			"hashed_token":     "sha256:owner-only",
+			"permissions_json": string(permissionsJSON),
+			"created_at":       now,
+			"updated_at":       now,
+		}); err != nil {
+			t.Fatalf("seed owner-only token: %v", err)
+		}
+		if err := svc.APITokens.BackfillTokenAccess(ctx); err != nil {
+			t.Fatalf("BackfillTokenAccess: %v", err)
+		}
+
+		deleted, err := svc.APITokens.RevokeAllAPITokens(ctx, user.ID)
+		if err != nil {
+			t.Fatalf("RevokeAllAPITokens: %v", err)
+		}
+		if deleted != 1 {
+			t.Fatalf("deleted = %d, want 1", deleted)
+		}
+
+		tokens, err := svc.APITokens.ListAPITokens(ctx, user.ID)
+		if err != nil {
+			t.Fatalf("ListAPITokens: %v", err)
+		}
+		if len(tokens) != 1 || tokens[0].ID != "owner-only-token" {
+			t.Fatalf("remaining tokens = %+v, want owner-only survivor", tokens)
+		}
+
+		access, err := svc.APITokenAccess.ListByToken(ctx, "owner-only-token")
+		if err != nil {
+			t.Fatalf("ListByToken owner-only-token: %v", err)
+		}
+		if len(access) != 1 || access[0].Plugin != "owner-only" {
+			t.Fatalf("owner-only token access = %+v, want surviving access", access)
 		}
 	})
 

--- a/gestaltd/internal/coredata/tokens.go
+++ b/gestaltd/internal/coredata/tokens.go
@@ -2,6 +2,7 @@ package coredata
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"sort"
 	"time"
@@ -16,13 +17,17 @@ type TokenService struct {
 	store               indexeddb.ObjectStore
 	enc                 *corecrypto.AESGCMEncryptor
 	externalCredentials *ExternalCredentialService
+	users               *UserService
 }
 
-func NewTokenService(ds indexeddb.IndexedDB, enc *corecrypto.AESGCMEncryptor, externalCredentials *ExternalCredentialService) *TokenService {
+var errUnreadableStoredIntegrationToken = errors.New("unreadable stored integration token")
+
+func NewTokenService(ds indexeddb.IndexedDB, enc *corecrypto.AESGCMEncryptor, externalCredentials *ExternalCredentialService, users *UserService) *TokenService {
 	return &TokenService{
 		store:               ds.ObjectStore(StoreIntegrationTokens),
 		enc:                 enc,
 		externalCredentials: externalCredentials,
+		users:               users,
 	}
 }
 
@@ -138,8 +143,13 @@ func (s *TokenService) DeleteToken(ctx context.Context, id string) error {
 			if err := s.syncExternalCredentialRecord(ctx, remaining[0]); err != nil {
 				return err
 			}
-		} else if err := s.externalCredentials.DeleteCredential(ctx, recString(rec, "user_id"), recString(rec, "integration"), recString(rec, "connection"), recString(rec, "instance")); err != nil && err != core.ErrNotFound {
-			return fmt.Errorf("delete canonical external credential: %w", err)
+		} else {
+			identityID, resolveErr := s.resolveIdentityID(ctx, recString(rec, "user_id"))
+			if resolveErr == nil {
+				if err := s.externalCredentials.DeleteCredential(ctx, identityID, recString(rec, "integration"), recString(rec, "connection"), recString(rec, "instance")); err != nil && err != core.ErrNotFound {
+					return fmt.Errorf("delete canonical external credential: %w", err)
+				}
+			}
 		}
 	}
 	return nil
@@ -151,7 +161,7 @@ func (s *TokenService) recordToToken(rec indexeddb.Record) (*core.IntegrationTok
 		recString(rec, "refresh_token_encrypted"),
 	)
 	if err != nil {
-		return nil, fmt.Errorf("decrypt token pair: %w", err)
+		return nil, fmt.Errorf("%w: decrypt token pair: %v", errUnreadableStoredIntegrationToken, err)
 	}
 	return &core.IntegrationToken{
 		ID:                recString(rec, "id"),
@@ -223,6 +233,9 @@ func (s *TokenService) BackfillCanonicalCredentials(ctx context.Context) error {
 	}
 	for _, rec := range dedupeTokenRecords(recs) {
 		if err := s.syncExternalCredentialRecord(ctx, rec); err != nil {
+			if errors.Is(err, errUnreadableStoredIntegrationToken) {
+				continue
+			}
 			return err
 		}
 	}
@@ -276,9 +289,23 @@ func tokenRecordLess(a, b indexeddb.Record) bool {
 	return recString(a, "id") < recString(b, "id")
 }
 
+func (s *TokenService) resolveIdentityID(ctx context.Context, userID string) (string, error) {
+	if s.users == nil {
+		return userID, nil
+	}
+	return s.users.CanonicalIdentityIDForUser(ctx, userID)
+}
+
 func (s *TokenService) syncExternalCredential(ctx context.Context, token *core.IntegrationToken, accessTokenEncrypted, refreshTokenEncrypted string) error {
 	if s.externalCredentials == nil || token == nil || token.UserID == "" || token.Integration == "" || token.Connection == "" {
 		return nil
+	}
+	identityID, resolveErr := s.resolveIdentityID(ctx, token.UserID)
+	if resolveErr != nil {
+		if errors.Is(resolveErr, core.ErrNotFound) {
+			return nil
+		}
+		return resolveErr
 	}
 	payloadEncrypted, err := encodeLegacyCredentialPayload(accessTokenEncrypted, refreshTokenEncrypted)
 	if err != nil {
@@ -286,7 +313,7 @@ func (s *TokenService) syncExternalCredential(ctx context.Context, token *core.I
 	}
 	if _, err := s.externalCredentials.UpsertCredential(ctx, &core.ExternalCredential{
 		ID:                token.ID,
-		PrincipalID:       token.UserID,
+		IdentityID:        identityID,
 		Plugin:            token.Integration,
 		Connection:        token.Connection,
 		Instance:          token.Instance,
@@ -300,7 +327,7 @@ func (s *TokenService) syncExternalCredential(ctx context.Context, token *core.I
 		CreatedAt:         token.CreatedAt,
 		UpdatedAt:         token.UpdatedAt,
 	}); err != nil {
-		return fmt.Errorf("sync canonical external credential %q/%q/%q/%q: %w", token.UserID, token.Integration, token.Connection, token.Instance, err)
+		return fmt.Errorf("sync canonical external credential %q/%q/%q/%q: %w", identityID, token.Integration, token.Connection, token.Instance, err)
 	}
 	return nil
 }
@@ -322,10 +349,16 @@ func (s *TokenService) syncExternalCredentialRecord(ctx context.Context, rec ind
 	if s.externalCredentials == nil {
 		return nil
 	}
-	principalID := recString(rec, "user_id")
+	identityID, resolveErr := s.resolveIdentityID(ctx, recString(rec, "user_id"))
+	if resolveErr != nil {
+		if errors.Is(resolveErr, core.ErrNotFound) {
+			return nil
+		}
+		return resolveErr
+	}
 	plugin := recString(rec, "integration")
 	connection := recString(rec, "connection")
-	if principalID == "" || plugin == "" || connection == "" {
+	if identityID == "" || plugin == "" || connection == "" {
 		return nil
 	}
 	accessTokenEncrypted := recString(rec, "access_token_encrypted")
@@ -336,11 +369,11 @@ func (s *TokenService) syncExternalCredentialRecord(ctx context.Context, rec ind
 	}
 	token, err := s.recordToToken(rec)
 	if err != nil {
-		return fmt.Errorf("decode token for canonical external credential %q/%q/%q/%q: %w", principalID, plugin, connection, recString(rec, "instance"), err)
+		return fmt.Errorf("decode token for canonical external credential %q/%q/%q/%q: %w", identityID, plugin, connection, recString(rec, "instance"), err)
 	}
 	if _, err := s.externalCredentials.UpsertCredential(ctx, &core.ExternalCredential{
 		ID:                recString(rec, "id"),
-		PrincipalID:       principalID,
+		IdentityID:        identityID,
 		Plugin:            plugin,
 		Connection:        connection,
 		Instance:          recString(rec, "instance"),
@@ -354,7 +387,7 @@ func (s *TokenService) syncExternalCredentialRecord(ctx context.Context, rec ind
 		CreatedAt:         recTime(rec, "created_at"),
 		UpdatedAt:         recTime(rec, "updated_at"),
 	}); err != nil {
-		return fmt.Errorf("sync canonical external credential record %q/%q/%q/%q: %w", principalID, plugin, connection, recString(rec, "instance"), err)
+		return fmt.Errorf("sync canonical external credential record %q/%q/%q/%q: %w", identityID, plugin, connection, recString(rec, "instance"), err)
 	}
 	return nil
 }

--- a/gestaltd/internal/coredata/tokens.go
+++ b/gestaltd/internal/coredata/tokens.go
@@ -13,14 +13,16 @@ import (
 )
 
 type TokenService struct {
-	store indexeddb.ObjectStore
-	enc   *corecrypto.AESGCMEncryptor
+	store               indexeddb.ObjectStore
+	enc                 *corecrypto.AESGCMEncryptor
+	externalCredentials *ExternalCredentialService
 }
 
-func NewTokenService(ds indexeddb.IndexedDB, enc *corecrypto.AESGCMEncryptor) *TokenService {
+func NewTokenService(ds indexeddb.IndexedDB, enc *corecrypto.AESGCMEncryptor, externalCredentials *ExternalCredentialService) *TokenService {
 	return &TokenService{
-		store: ds.ObjectStore(StoreIntegrationTokens),
-		enc:   enc,
+		store:               ds.ObjectStore(StoreIntegrationTokens),
+		enc:                 enc,
+		externalCredentials: externalCredentials,
 	}
 }
 
@@ -74,6 +76,9 @@ func (s *TokenService) StoreToken(ctx context.Context, token *core.IntegrationTo
 	if err := s.deleteDuplicateLookupRecords(ctx, token.ID, token.UserID, token.Integration, token.Connection, token.Instance); err != nil {
 		return err
 	}
+	if err := s.syncExternalCredential(ctx, token, accessEnc, refreshEnc); err != nil {
+		return err
+	}
 	return nil
 }
 
@@ -110,7 +115,34 @@ func (s *TokenService) ListTokensForConnection(ctx context.Context, userID, inte
 }
 
 func (s *TokenService) DeleteToken(ctx context.Context, id string) error {
-	return s.store.Delete(ctx, id)
+	if id == "" {
+		return s.store.Delete(ctx, id)
+	}
+	rec, err := s.store.Get(ctx, id)
+	if err != nil {
+		if err == indexeddb.ErrNotFound {
+			return nil
+		}
+		return err
+	}
+	if err := s.store.Delete(ctx, id); err != nil {
+		return err
+	}
+	if s.externalCredentials != nil {
+		remaining, err := s.store.Index("by_lookup").GetAll(ctx, nil, recString(rec, "user_id"), recString(rec, "integration"), recString(rec, "connection"), recString(rec, "instance"))
+		if err != nil {
+			return fmt.Errorf("list remaining duplicate tokens: %w", err)
+		}
+		remaining = dedupeTokenRecords(remaining)
+		if len(remaining) > 0 {
+			if err := s.syncExternalCredentialRecord(ctx, remaining[0]); err != nil {
+				return err
+			}
+		} else if err := s.externalCredentials.DeleteCredential(ctx, recString(rec, "user_id"), recString(rec, "integration"), recString(rec, "connection"), recString(rec, "instance")); err != nil && err != core.ErrNotFound {
+			return fmt.Errorf("delete canonical external credential: %w", err)
+		}
+	}
+	return nil
 }
 
 func (s *TokenService) recordToToken(rec indexeddb.Record) (*core.IntegrationToken, error) {
@@ -181,6 +213,22 @@ func (s *TokenService) deleteDuplicateLookupRecords(ctx context.Context, keepID,
 	return nil
 }
 
+func (s *TokenService) BackfillCanonicalCredentials(ctx context.Context) error {
+	if s.externalCredentials == nil {
+		return nil
+	}
+	recs, err := s.store.GetAll(ctx, nil)
+	if err != nil {
+		return fmt.Errorf("list integration tokens for canonical backfill: %w", err)
+	}
+	for _, rec := range dedupeTokenRecords(recs) {
+		if err := s.syncExternalCredentialRecord(ctx, rec); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
 func dedupeTokenRecords(recs []indexeddb.Record) []indexeddb.Record {
 	if len(recs) <= 1 {
 		return recs
@@ -226,4 +274,87 @@ func tokenRecordLess(a, b indexeddb.Record) bool {
 	}
 
 	return recString(a, "id") < recString(b, "id")
+}
+
+func (s *TokenService) syncExternalCredential(ctx context.Context, token *core.IntegrationToken, accessTokenEncrypted, refreshTokenEncrypted string) error {
+	if s.externalCredentials == nil || token == nil || token.UserID == "" || token.Integration == "" || token.Connection == "" {
+		return nil
+	}
+	payloadEncrypted, err := encodeLegacyCredentialPayload(accessTokenEncrypted, refreshTokenEncrypted)
+	if err != nil {
+		return err
+	}
+	if _, err := s.externalCredentials.UpsertCredential(ctx, &core.ExternalCredential{
+		ID:                token.ID,
+		PrincipalID:       token.UserID,
+		Plugin:            token.Integration,
+		Connection:        token.Connection,
+		Instance:          token.Instance,
+		AuthType:          externalCredentialAuthType(token),
+		PayloadEncrypted:  payloadEncrypted,
+		Scopes:            token.Scopes,
+		ExpiresAt:         token.ExpiresAt,
+		LastRefreshedAt:   token.LastRefreshedAt,
+		RefreshErrorCount: token.RefreshErrorCount,
+		MetadataJSON:      token.MetadataJSON,
+		CreatedAt:         token.CreatedAt,
+		UpdatedAt:         token.UpdatedAt,
+	}); err != nil {
+		return fmt.Errorf("sync canonical external credential %q/%q/%q/%q: %w", token.UserID, token.Integration, token.Connection, token.Instance, err)
+	}
+	return nil
+}
+
+func externalCredentialAuthType(token *core.IntegrationToken) string {
+	if token == nil {
+		return ""
+	}
+	if token.RefreshToken != "" {
+		return "oauth2"
+	}
+	if token.AccessToken != "" {
+		return "bearer"
+	}
+	return "manual"
+}
+
+func (s *TokenService) syncExternalCredentialRecord(ctx context.Context, rec indexeddb.Record) error {
+	if s.externalCredentials == nil {
+		return nil
+	}
+	principalID := recString(rec, "user_id")
+	plugin := recString(rec, "integration")
+	connection := recString(rec, "connection")
+	if principalID == "" || plugin == "" || connection == "" {
+		return nil
+	}
+	accessTokenEncrypted := recString(rec, "access_token_encrypted")
+	refreshTokenEncrypted := recString(rec, "refresh_token_encrypted")
+	payloadEncrypted, err := encodeLegacyCredentialPayload(accessTokenEncrypted, refreshTokenEncrypted)
+	if err != nil {
+		return err
+	}
+	token, err := s.recordToToken(rec)
+	if err != nil {
+		return fmt.Errorf("decode token for canonical external credential %q/%q/%q/%q: %w", principalID, plugin, connection, recString(rec, "instance"), err)
+	}
+	if _, err := s.externalCredentials.UpsertCredential(ctx, &core.ExternalCredential{
+		ID:                recString(rec, "id"),
+		PrincipalID:       principalID,
+		Plugin:            plugin,
+		Connection:        connection,
+		Instance:          recString(rec, "instance"),
+		AuthType:          externalCredentialAuthType(token),
+		PayloadEncrypted:  payloadEncrypted,
+		Scopes:            recString(rec, "scopes"),
+		ExpiresAt:         recTimePtr(rec, "expires_at"),
+		LastRefreshedAt:   recTimePtr(rec, "last_refreshed_at"),
+		RefreshErrorCount: recInt(rec, "refresh_error_count"),
+		MetadataJSON:      recString(rec, "metadata_json"),
+		CreatedAt:         recTime(rec, "created_at"),
+		UpdatedAt:         recTime(rec, "updated_at"),
+	}); err != nil {
+		return fmt.Errorf("sync canonical external credential record %q/%q/%q/%q: %w", principalID, plugin, connection, recString(rec, "instance"), err)
+	}
+	return nil
 }

--- a/gestaltd/internal/coredata/users.go
+++ b/gestaltd/internal/coredata/users.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"sort"
 	"strings"
 	"time"
 
@@ -14,11 +15,17 @@ import (
 )
 
 type UserService struct {
-	store indexeddb.ObjectStore
+	store      indexeddb.ObjectStore
+	principals *PrincipalService
+	profiles   *UserProfileService
 }
 
-func NewUserService(ds indexeddb.IndexedDB) *UserService {
-	return &UserService{store: ds.ObjectStore(StoreUsers)}
+func NewUserService(ds indexeddb.IndexedDB, principals *PrincipalService, profiles *UserProfileService) *UserService {
+	return &UserService{
+		store:      ds.ObjectStore(StoreUsers),
+		principals: principals,
+		profiles:   profiles,
+	}
 }
 
 func (s *UserService) BackfillNormalizedEmails(ctx context.Context) error {
@@ -51,6 +58,23 @@ func (s *UserService) GetUser(ctx context.Context, id string) (*core.User, error
 	return recordToUser(rec), nil
 }
 
+func (s *UserService) BackfillCanonicalPrincipals(ctx context.Context) error {
+	if s.principals == nil || s.profiles == nil {
+		return nil
+	}
+	recs, err := s.store.GetAll(ctx, nil)
+	if err != nil {
+		return fmt.Errorf("list users for canonical backfill: %w", err)
+	}
+	winners := preferredCanonicalUserRecords(recs)
+	for _, rec := range winners {
+		if err := s.syncCanonicalUser(ctx, recordToUser(rec)); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
 func (s *UserService) FindOrCreateUser(ctx context.Context, email string) (*core.User, error) {
 	rawEmail := strings.TrimSpace(email)
 	email = emailutil.Normalize(email)
@@ -61,6 +85,9 @@ func (s *UserService) FindOrCreateUser(ctx context.Context, email string) (*core
 	user, err := s.findUserByNormalizedEmail(ctx, rawEmail, email)
 	switch {
 	case err == nil:
+		if err := s.syncCanonicalUser(ctx, user); err != nil {
+			return nil, err
+		}
 		return user, nil
 	case !errors.Is(err, core.ErrNotFound):
 		return nil, err
@@ -80,9 +107,16 @@ func (s *UserService) FindOrCreateUser(ctx context.Context, email string) (*core
 		if retryErr != nil {
 			return nil, fmt.Errorf("create user: %w", err)
 		}
+		if err := s.syncCanonicalUser(ctx, user); err != nil {
+			return nil, err
+		}
 		return user, nil
 	}
-	return recordToUser(newRec), nil
+	user = recordToUser(newRec)
+	if err := s.syncCanonicalUser(ctx, user); err != nil {
+		return nil, err
+	}
+	return user, nil
 }
 
 func (s *UserService) FindUserByEmail(ctx context.Context, email string) (*core.User, error) {
@@ -180,4 +214,88 @@ func recordToUser(rec indexeddb.Record) *core.User {
 		CreatedAt:   recTime(rec, "created_at"),
 		UpdatedAt:   recTime(rec, "updated_at"),
 	}
+}
+
+func (s *UserService) syncCanonicalUser(ctx context.Context, user *core.User) error {
+	if s.principals == nil || s.profiles == nil || user == nil || user.ID == "" {
+		return nil
+	}
+	displayName := strings.TrimSpace(user.DisplayName)
+	if displayName == "" {
+		displayName = user.Email
+	}
+	if _, err := s.principals.UpsertPrincipal(ctx, &core.Principal{
+		ID:          user.ID,
+		Kind:        core.PrincipalKindUser,
+		Status:      principalStatusActive,
+		DisplayName: displayName,
+		CreatedAt:   user.CreatedAt,
+		UpdatedAt:   user.UpdatedAt,
+	}); err != nil {
+		return fmt.Errorf("sync canonical user principal %q: %w", user.ID, err)
+	}
+	if _, err := s.profiles.UpsertProfile(ctx, &core.UserProfile{
+		PrincipalID:     user.ID,
+		Email:           user.Email,
+		NormalizedEmail: user.Email,
+		CreatedAt:       user.CreatedAt,
+		UpdatedAt:       user.UpdatedAt,
+	}); err != nil {
+		return fmt.Errorf("sync canonical user profile %q: %w", user.ID, err)
+	}
+	return nil
+}
+
+func preferredCanonicalUserRecords(recs []indexeddb.Record) []indexeddb.Record {
+	if len(recs) == 0 {
+		return nil
+	}
+	grouped := make(map[string][]indexeddb.Record, len(recs))
+	groupNormalized := make(map[string]string, len(recs))
+	for _, rec := range recs {
+		normalizedEmail := emailutil.Normalize(recString(rec, "normalized_email"))
+		if normalizedEmail == "" {
+			normalizedEmail = emailutil.Normalize(recString(rec, "email"))
+		}
+		key := normalizedEmail
+		if key == "" {
+			key = "id:" + recString(rec, "id")
+		}
+		grouped[key] = append(grouped[key], rec)
+		groupNormalized[key] = normalizedEmail
+	}
+	out := make([]indexeddb.Record, 0, len(grouped))
+	keys := make([]string, 0, len(grouped))
+	for key := range grouped {
+		keys = append(keys, key)
+	}
+	sort.Strings(keys)
+	for _, key := range keys {
+		if winner := preferredCanonicalUserRecord(grouped[key], groupNormalized[key]); winner != nil {
+			out = append(out, winner)
+		}
+	}
+	return out
+}
+
+func preferredCanonicalUserRecord(recs []indexeddb.Record, normalizedEmail string) indexeddb.Record {
+	var canonicalMatch indexeddb.Record
+	var fallbackMatch indexeddb.Record
+	for _, rec := range recs {
+		email := strings.TrimSpace(recString(rec, "email"))
+		switch {
+		case normalizedEmail != "" && email == normalizedEmail:
+			if preferUserRecord(rec, canonicalMatch) {
+				canonicalMatch = rec
+			}
+		default:
+			if preferUserRecord(rec, fallbackMatch) {
+				fallbackMatch = rec
+			}
+		}
+	}
+	if canonicalMatch != nil {
+		return canonicalMatch
+	}
+	return fallbackMatch
 }

--- a/gestaltd/internal/coredata/users.go
+++ b/gestaltd/internal/coredata/users.go
@@ -15,16 +15,16 @@ import (
 )
 
 type UserService struct {
-	store      indexeddb.ObjectStore
-	principals *PrincipalService
-	profiles   *UserProfileService
+	store        indexeddb.ObjectStore
+	identities   *IdentityService
+	authBindings *IdentityAuthBindingService
 }
 
-func NewUserService(ds indexeddb.IndexedDB, principals *PrincipalService, profiles *UserProfileService) *UserService {
+func NewUserService(ds indexeddb.IndexedDB, identities *IdentityService, authBindings *IdentityAuthBindingService) *UserService {
 	return &UserService{
-		store:      ds.ObjectStore(StoreUsers),
-		principals: principals,
-		profiles:   profiles,
+		store:        ds.ObjectStore(StoreUsers),
+		identities:   identities,
+		authBindings: authBindings,
 	}
 }
 
@@ -58,8 +58,8 @@ func (s *UserService) GetUser(ctx context.Context, id string) (*core.User, error
 	return recordToUser(rec), nil
 }
 
-func (s *UserService) BackfillCanonicalPrincipals(ctx context.Context) error {
-	if s.principals == nil || s.profiles == nil {
+func (s *UserService) BackfillCanonicalIdentities(ctx context.Context) error {
+	if s.identities == nil || s.authBindings == nil {
 		return nil
 	}
 	recs, err := s.store.GetAll(ctx, nil)
@@ -68,11 +68,19 @@ func (s *UserService) BackfillCanonicalPrincipals(ctx context.Context) error {
 	}
 	winners := preferredCanonicalUserRecords(recs)
 	for _, rec := range winners {
-		if err := s.syncCanonicalUser(ctx, recordToUser(rec)); err != nil {
+		if err := s.syncCanonicalIdentity(ctx, recordToUser(rec)); err != nil {
 			return err
 		}
 	}
 	return nil
+}
+
+func (s *UserService) CanonicalIdentityIDForUser(ctx context.Context, userID string) (string, error) {
+	rec, err := s.canonicalUserRecordForUserID(ctx, strings.TrimSpace(userID))
+	if err != nil {
+		return "", err
+	}
+	return recString(rec, "id"), nil
 }
 
 func (s *UserService) FindOrCreateUser(ctx context.Context, email string) (*core.User, error) {
@@ -85,7 +93,7 @@ func (s *UserService) FindOrCreateUser(ctx context.Context, email string) (*core
 	user, err := s.findUserByNormalizedEmail(ctx, rawEmail, email)
 	switch {
 	case err == nil:
-		if err := s.syncCanonicalUser(ctx, user); err != nil {
+		if err := s.syncCanonicalIdentity(ctx, user); err != nil {
 			return nil, err
 		}
 		return user, nil
@@ -107,13 +115,13 @@ func (s *UserService) FindOrCreateUser(ctx context.Context, email string) (*core
 		if retryErr != nil {
 			return nil, fmt.Errorf("create user: %w", err)
 		}
-		if err := s.syncCanonicalUser(ctx, user); err != nil {
+		if err := s.syncCanonicalIdentity(ctx, user); err != nil {
 			return nil, err
 		}
 		return user, nil
 	}
 	user = recordToUser(newRec)
-	if err := s.syncCanonicalUser(ctx, user); err != nil {
+	if err := s.syncCanonicalIdentity(ctx, user); err != nil {
 		return nil, err
 	}
 	return user, nil
@@ -171,8 +179,6 @@ func (s *UserService) findUserByNormalizedEmail(ctx context.Context, rawEmail, n
 		return nil, core.ErrNotFound
 	}
 	if len(recs) == 1 && (recString(match, "email") != normalizedEmail || recString(match, "normalized_email") != normalizedEmail) {
-		// Best-effort repair for legacy mixed-case rows. Reads should not fail
-		// if the canonicalizing write cannot be completed.
 		updated := cloneRecord(match)
 		updated["email"] = normalizedEmail
 		updated["normalized_email"] = normalizedEmail
@@ -182,6 +188,38 @@ func (s *UserService) findUserByNormalizedEmail(ctx context.Context, rawEmail, n
 		}
 	}
 	return recordToUser(match), nil
+}
+
+func (s *UserService) canonicalUserRecordForUserID(ctx context.Context, userID string) (indexeddb.Record, error) {
+	if userID == "" {
+		return nil, core.ErrNotFound
+	}
+	rec, err := s.store.Get(ctx, userID)
+	if err != nil {
+		if err == indexeddb.ErrNotFound {
+			return nil, core.ErrNotFound
+		}
+		return nil, fmt.Errorf("lookup canonical user record: %w", err)
+	}
+	normalizedEmail := emailutil.Normalize(recString(rec, "normalized_email"))
+	if normalizedEmail == "" {
+		normalizedEmail = emailutil.Normalize(recString(rec, "email"))
+	}
+	if normalizedEmail == "" {
+		return rec, nil
+	}
+	recs, err := s.store.Index("by_normalized_email").GetAll(ctx, nil, normalizedEmail)
+	if err != nil {
+		return nil, fmt.Errorf("lookup canonical user record: %w", err)
+	}
+	if len(recs) == 0 {
+		return rec, nil
+	}
+	winner := preferredCanonicalUserRecord(recs, normalizedEmail)
+	if winner == nil {
+		return rec, nil
+	}
+	return winner, nil
 }
 
 func preferUserRecord(candidate, current indexeddb.Record) bool {
@@ -216,32 +254,45 @@ func recordToUser(rec indexeddb.Record) *core.User {
 	}
 }
 
-func (s *UserService) syncCanonicalUser(ctx context.Context, user *core.User) error {
-	if s.principals == nil || s.profiles == nil || user == nil || user.ID == "" {
+func (s *UserService) syncCanonicalIdentity(ctx context.Context, user *core.User) error {
+	if s.identities == nil || s.authBindings == nil || user == nil || user.ID == "" {
 		return nil
 	}
-	displayName := strings.TrimSpace(user.DisplayName)
+	canonicalRec, err := s.canonicalUserRecordForUserID(ctx, user.ID)
+	if err != nil {
+		return err
+	}
+	canonicalUser := recordToUser(canonicalRec)
+	displayName := strings.TrimSpace(canonicalUser.DisplayName)
 	if displayName == "" {
-		displayName = user.Email
+		displayName = canonicalUser.Email
 	}
-	if _, err := s.principals.UpsertPrincipal(ctx, &core.Principal{
-		ID:          user.ID,
-		Kind:        core.PrincipalKindUser,
-		Status:      principalStatusActive,
+	if _, err := s.identities.UpsertIdentity(ctx, &core.Identity{
+		ID:          canonicalUser.ID,
+		Status:      identityStatusActive,
 		DisplayName: displayName,
-		CreatedAt:   user.CreatedAt,
-		UpdatedAt:   user.UpdatedAt,
+		MetadataJSON: legacyIdentityMetadataJSON("user", map[string]string{
+			"email": emailutil.Normalize(canonicalUser.Email),
+		}),
+		CreatedAt: canonicalUser.CreatedAt,
+		UpdatedAt: canonicalUser.UpdatedAt,
 	}); err != nil {
-		return fmt.Errorf("sync canonical user principal %q: %w", user.ID, err)
+		return fmt.Errorf("sync canonical identity %q: %w", canonicalUser.ID, err)
 	}
-	if _, err := s.profiles.UpsertProfile(ctx, &core.UserProfile{
-		PrincipalID:     user.ID,
-		Email:           user.Email,
-		NormalizedEmail: user.Email,
-		CreatedAt:       user.CreatedAt,
-		UpdatedAt:       user.UpdatedAt,
+	lookupKey := emailutil.Normalize(canonicalUser.Email)
+	if lookupKey == "" {
+		return nil
+	}
+	if _, err := s.authBindings.UpsertBinding(ctx, &core.IdentityAuthBinding{
+		IdentityID:  canonicalUser.ID,
+		BindingKind: core.IdentityAuthBindingKindEmail,
+		Authority:   legacyIdentityBindingAuthority,
+		LookupKey:   lookupKey,
+		BindingJSON: legacyIdentityMetadataJSON("email", map[string]string{"email": lookupKey}),
+		CreatedAt:   canonicalUser.CreatedAt,
+		UpdatedAt:   canonicalUser.UpdatedAt,
 	}); err != nil {
-		return fmt.Errorf("sync canonical user profile %q: %w", user.ID, err)
+		return fmt.Errorf("sync canonical identity auth binding %q: %w", canonicalUser.ID, err)
 	}
 	return nil
 }

--- a/gestaltd/internal/invocation/catalog.go
+++ b/gestaltd/internal/invocation/catalog.go
@@ -93,6 +93,9 @@ func ResolveOperation(ctx context.Context, prov core.Provider, provName string, 
 
 	sessionOp, sessionConnection, sessionFound, err := resolveSessionOperation(ctx, prov, provName, resolver, p, operation, sessionConnections, instance)
 	if err != nil {
+		if staticOK && sessionCatalogUnsupported(err) {
+			return staticOp, OperationTransport(staticOp), "", nil
+		}
 		return catalog.CatalogOperation{}, "", "", err
 	}
 	if sessionFound {
@@ -102,6 +105,10 @@ func ResolveOperation(ctx context.Context, prov core.Provider, provName string, 
 		return staticOp, OperationTransport(staticOp), "", nil
 	}
 	return catalog.CatalogOperation{}, "", "", fmt.Errorf("%w: %q on provider %q", ErrOperationNotFound, operation, provName)
+}
+
+func sessionCatalogUnsupported(err error) bool {
+	return err != nil && errors.Is(err, core.ErrSessionCatalogUnsupported)
 }
 
 func resolveCatalog(ctx context.Context, prov core.Provider, provName string, resolver TokenResolver, p *principal.Principal, defaultConnection, instance string, strictSession bool) (*catalog.Catalog, CatalogResolutionMetadata, error) {

--- a/gestaltd/internal/server/catalog_resolution_test.go
+++ b/gestaltd/internal/server/catalog_resolution_test.go
@@ -820,6 +820,51 @@ func TestResolveOperation_DoesNotFallBackOnSessionCatalogError(t *testing.T) {
 	}
 }
 
+func TestResolveOperation_FallsBackWhenSessionCatalogUnsupported(t *testing.T) {
+	t.Parallel()
+
+	unsupportedErr := core.WrapSessionCatalogUnsupported(fmt.Errorf("provider %q does not support session catalogs", "session-op-api"))
+	prov := &stubSessionProvider{
+		stubCatalogProvider: stubCatalogProvider{
+			stubProvider: stubProvider{
+				name:     "session-op-api",
+				connMode: core.ConnectionModeUser,
+			},
+			cat: &catalog.Catalog{
+				Name: "session-op-api",
+				Operations: []catalog.CatalogOperation{
+					{ID: "static_only", Method: http.MethodGet, Transport: catalog.TransportREST},
+				},
+			},
+		},
+		sessionErr: fmt.Errorf("nested session resolution wrapper: %w", unsupportedErr),
+	}
+
+	resolver := &stubTokenResolver{token: "tok_123"}
+	op, transport, connection, err := invocation.ResolveOperation(
+		context.Background(),
+		prov,
+		"session-op-api",
+		resolver,
+		&principal.Principal{UserID: "u1"},
+		"static_only",
+		[]string{"default"},
+		"default",
+	)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if op.ID != "static_only" {
+		t.Fatalf("operation = %q, want %q", op.ID, "static_only")
+	}
+	if transport != catalog.TransportREST {
+		t.Fatalf("transport = %q, want %q", transport, catalog.TransportREST)
+	}
+	if connection != "" {
+		t.Fatalf("connection = %q, want empty", connection)
+	}
+}
+
 func TestResolveCatalog_NilResolver(t *testing.T) {
 	t.Parallel()
 

--- a/gestaltd/internal/server/handlers_identities.go
+++ b/gestaltd/internal/server/handlers_identities.go
@@ -157,10 +157,11 @@ func (s *Server) createManagedIdentity(w http.ResponseWriter, r *http.Request) {
 
 	now := s.nowUTCSecond()
 	identity := &core.ManagedIdentity{
-		ID:          uuid.NewString(),
-		DisplayName: req.DisplayName,
-		CreatedAt:   now,
-		UpdatedAt:   now,
+		ID:                  uuid.NewString(),
+		DisplayName:         req.DisplayName,
+		CreatedByIdentityID: userID,
+		CreatedAt:           now,
+		UpdatedAt:           now,
 	}
 	if err := s.managedIdentities.CreateIdentity(r.Context(), identity); err != nil {
 		auditErr = errors.New("failed to create identity")

--- a/gestaltd/internal/server/server_test.go
+++ b/gestaltd/internal/server/server_test.go
@@ -2277,6 +2277,7 @@ func TestAdminAPI_AdminAuthorizationCRUD(t *testing.T) {
 	t.Parallel()
 
 	svc := coretesting.NewStubServices(t)
+	ctx := context.Background()
 	seedUser(t, svc, "static-admin@example.test")
 	const adminRole = "owner"
 	authz := mustAuthorizer(t, config.AuthorizationConfig{
@@ -2308,7 +2309,7 @@ func TestAdminAPI_AdminAuthorizationCRUD(t *testing.T) {
 		cfg.Authorizer = authz
 		cfg.Admin = server.AdminRouteConfig{
 			AuthorizationPolicy: "admin_policy",
-			AllowedRoles:        []string{adminRole},
+			AllowedRoles:        []string{adminRole, "operator"},
 		}
 		cfg.AdminUI = http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
 			_, _ = w.Write([]byte("admin"))
@@ -2386,6 +2387,35 @@ func TestAdminAPI_AdminAuthorizationCRUD(t *testing.T) {
 	if err != nil {
 		t.Fatalf("find dynamic admin user: %v", err)
 	}
+	roles, err := svc.WorkspaceRoles.ListByPrincipal(ctx, user.ID)
+	if err != nil {
+		t.Fatalf("ListByPrincipal(dynamic admin): %v", err)
+	}
+	if len(roles) != 1 || roles[0].Role != "owner" {
+		t.Fatalf("workspace roles = %+v, want [owner]", roles)
+	}
+
+	body = bytes.NewBufferString(`{"email":"dynamic-admin@example.test","role":"operator"}`)
+	req, _ = http.NewRequest(http.MethodPut, ts.URL+"/admin/api/v1/authorization/admins/members", body)
+	req.Header.Set("Content-Type", "application/json")
+	req.AddCookie(&http.Cookie{Name: "session_token", Value: "admin-session"})
+	resp, err = http.DefaultClient.Do(req)
+	if err != nil {
+		t.Fatalf("PUT dynamic admin role change: %v", err)
+	}
+	defer func() { _ = resp.Body.Close() }()
+	if resp.StatusCode != http.StatusOK {
+		respBody, _ := io.ReadAll(resp.Body)
+		t.Fatalf("put dynamic admin role change status = %d, want 200: %s", resp.StatusCode, respBody)
+	}
+
+	roles, err = svc.WorkspaceRoles.ListByPrincipal(ctx, user.ID)
+	if err != nil {
+		t.Fatalf("ListByPrincipal(dynamic admin) after role change: %v", err)
+	}
+	if len(roles) != 1 || roles[0].Role != "operator" {
+		t.Fatalf("workspace roles after role change = %+v, want [operator]", roles)
+	}
 	req, _ = http.NewRequest(http.MethodDelete, ts.URL+"/admin/api/v1/authorization/admins/members/"+url.PathEscape(user.ID), nil)
 	req.AddCookie(&http.Cookie{Name: "session_token", Value: "admin-session"})
 	resp, err = http.DefaultClient.Do(req)
@@ -2414,6 +2444,13 @@ func TestAdminAPI_AdminAuthorizationCRUD(t *testing.T) {
 	}
 	if len(members) != 1 || members[0]["source"] != "static" {
 		t.Fatalf("admin members after delete = %+v, want only static row", members)
+	}
+	roles, err = svc.WorkspaceRoles.ListByPrincipal(ctx, user.ID)
+	if err != nil {
+		t.Fatalf("ListByPrincipal(dynamic admin) after delete: %v", err)
+	}
+	if len(roles) != 0 {
+		t.Fatalf("workspace roles after delete = %+v, want none", roles)
 	}
 }
 
@@ -14077,8 +14114,9 @@ func TestManagedIdentityCRUDAndMemberships(t *testing.T) {
 	t.Parallel()
 
 	svc := coretesting.NewStubServices(t)
+	ctx := context.Background()
 	admin := seedUser(t, svc, "admin@example.test")
-	seedUser(t, svc, "viewer@example.test")
+	viewer := seedUser(t, svc, "viewer@example.test")
 
 	ts := newTestServer(t, func(cfg *server.Config) {
 		cfg.Auth = &coretesting.StubAuthProvider{
@@ -14110,9 +14148,50 @@ func TestManagedIdentityCRUDAndMemberships(t *testing.T) {
 	if createResp.DisplayName != "Release Bot" {
 		t.Fatalf("displayName = %q, want %q", createResp.DisplayName, "Release Bot")
 	}
-	createdIdentity, err := svc.ManagedIdentities.GetIdentity(context.Background(), createResp.ID)
+	createdIdentity, err := svc.ManagedIdentities.GetIdentity(ctx, createResp.ID)
 	if err != nil {
 		t.Fatalf("GetIdentity after create: %v", err)
+	}
+	adminPrincipal, err := svc.Principals.GetPrincipal(ctx, admin.ID)
+	if err != nil {
+		t.Fatalf("GetPrincipal(admin): %v", err)
+	}
+	if adminPrincipal.Kind != core.PrincipalKindUser {
+		t.Fatalf("admin principal kind = %q, want %q", adminPrincipal.Kind, core.PrincipalKindUser)
+	}
+	adminProfile, err := svc.UserProfiles.GetProfile(ctx, admin.ID)
+	if err != nil {
+		t.Fatalf("GetProfile(admin): %v", err)
+	}
+	if adminProfile.Email != admin.Email {
+		t.Fatalf("admin profile email = %q, want %q", adminProfile.Email, admin.Email)
+	}
+	serviceAccountPrincipal, err := svc.Principals.GetPrincipal(ctx, createResp.ID)
+	if err != nil {
+		t.Fatalf("GetPrincipal(identity): %v", err)
+	}
+	if serviceAccountPrincipal.Kind != core.PrincipalKindServiceAccount {
+		t.Fatalf("identity principal kind = %q, want %q", serviceAccountPrincipal.Kind, core.PrincipalKindServiceAccount)
+	}
+	if serviceAccountPrincipal.DisplayName != "Release Bot" {
+		t.Fatalf("identity principal display name = %q, want %q", serviceAccountPrincipal.DisplayName, "Release Bot")
+	}
+	serviceAccount, err := svc.ServiceAccounts.GetServiceAccount(ctx, createResp.ID)
+	if err != nil {
+		t.Fatalf("GetServiceAccount(identity): %v", err)
+	}
+	if serviceAccount.Name != createResp.ID {
+		t.Fatalf("service account name = %q, want %q", serviceAccount.Name, createResp.ID)
+	}
+	if serviceAccount.Description != "Release Bot" {
+		t.Fatalf("service account description = %q, want %q", serviceAccount.Description, "Release Bot")
+	}
+	adminGrant, err := svc.ServiceAccountManagementGrants.GetGrant(ctx, admin.ID, createResp.ID)
+	if err != nil {
+		t.Fatalf("GetGrant(admin): %v", err)
+	}
+	if adminGrant.Role != "admin" {
+		t.Fatalf("admin management grant role = %q, want %q", adminGrant.Role, "admin")
 	}
 
 	var listResp []struct {
@@ -14133,6 +14212,13 @@ func TestManagedIdentityCRUDAndMemberships(t *testing.T) {
 	doJSONRequestAndDecode(t, http.MethodPut, ts.URL+"/api/v1/identities/"+createResp.ID+"/members", "admin-session", `{"email":"viewer@example.test","role":"viewer"}`, http.StatusOK, &memberResp)
 	if memberResp.Role != "viewer" || memberResp.Email != "viewer@example.test" {
 		t.Fatalf("member response = %+v, want viewer@example.test viewer", memberResp)
+	}
+	viewerGrant, err := svc.ServiceAccountManagementGrants.GetGrant(ctx, viewer.ID, createResp.ID)
+	if err != nil {
+		t.Fatalf("GetGrant(viewer): %v", err)
+	}
+	if viewerGrant.Role != "viewer" {
+		t.Fatalf("viewer management grant role = %q, want %q", viewerGrant.Role, "viewer")
 	}
 
 	var viewerList []struct {
@@ -14165,12 +14251,26 @@ func TestManagedIdentityCRUDAndMemberships(t *testing.T) {
 	if updateResp.DisplayName != "Release Automation" {
 		t.Fatalf("updated displayName = %q, want %q", updateResp.DisplayName, "Release Automation")
 	}
-	updatedIdentity, err := svc.ManagedIdentities.GetIdentity(context.Background(), createResp.ID)
+	updatedIdentity, err := svc.ManagedIdentities.GetIdentity(ctx, createResp.ID)
 	if err != nil {
 		t.Fatalf("GetIdentity after update: %v", err)
 	}
 	if !updatedIdentity.CreatedAt.Equal(createdIdentity.CreatedAt) {
 		t.Fatalf("createdAt changed across update: got %v want %v", updatedIdentity.CreatedAt, createdIdentity.CreatedAt)
+	}
+	serviceAccountPrincipal, err = svc.Principals.GetPrincipal(ctx, createResp.ID)
+	if err != nil {
+		t.Fatalf("GetPrincipal(identity) after update: %v", err)
+	}
+	if serviceAccountPrincipal.DisplayName != "Release Automation" {
+		t.Fatalf("identity principal display name after update = %q, want %q", serviceAccountPrincipal.DisplayName, "Release Automation")
+	}
+	serviceAccount, err = svc.ServiceAccounts.GetServiceAccount(ctx, createResp.ID)
+	if err != nil {
+		t.Fatalf("GetServiceAccount(identity) after update: %v", err)
+	}
+	if serviceAccount.Description != "Release Automation" {
+		t.Fatalf("service account description after update = %q, want %q", serviceAccount.Description, "Release Automation")
 	}
 
 	req, _ = http.NewRequest(http.MethodDelete, ts.URL+"/api/v1/identities/"+createResp.ID+"/members/"+admin.Email, nil)
@@ -14195,6 +14295,18 @@ func TestManagedIdentityCRUDAndMemberships(t *testing.T) {
 	defer func() { _ = resp.Body.Close() }()
 	if resp.StatusCode != http.StatusNotFound {
 		t.Fatalf("get deleted identity status = %d, want %d", resp.StatusCode, http.StatusNotFound)
+	}
+	if _, err := svc.Principals.GetPrincipal(ctx, createResp.ID); !errors.Is(err, core.ErrNotFound) {
+		t.Fatalf("GetPrincipal(identity) after delete = %v, want not found", err)
+	}
+	if _, err := svc.ServiceAccounts.GetServiceAccount(ctx, createResp.ID); !errors.Is(err, core.ErrNotFound) {
+		t.Fatalf("GetServiceAccount(identity) after delete = %v, want not found", err)
+	}
+	if _, err := svc.ServiceAccountManagementGrants.GetGrant(ctx, admin.ID, createResp.ID); !errors.Is(err, core.ErrNotFound) {
+		t.Fatalf("GetGrant(admin) after delete = %v, want not found", err)
+	}
+	if _, err := svc.ServiceAccountManagementGrants.GetGrant(ctx, viewer.ID, createResp.ID); !errors.Is(err, core.ErrNotFound) {
+		t.Fatalf("GetGrant(viewer) after delete = %v, want not found", err)
 	}
 }
 
@@ -14302,6 +14414,7 @@ func TestManagedIdentityGrantsRespectActorAuthorization(t *testing.T) {
 	t.Parallel()
 
 	svc := coretesting.NewStubServices(t)
+	ctx := context.Background()
 	admin := seedUser(t, svc, "admin@example.test")
 	seedUser(t, svc, "viewer@example.test")
 
@@ -14445,6 +14558,26 @@ func TestManagedIdentityGrantsRespectActorAuthorization(t *testing.T) {
 	if grantResp.Plugin != "gamma" || !reflect.DeepEqual(grantResp.Operations, []string{}) {
 		t.Fatalf("plugin-wide grant response = %+v, want gamma []", grantResp)
 	}
+	alphaAccess, err := svc.PrincipalPluginAccess.GetAccess(ctx, createResp.ID, "alpha")
+	if err != nil {
+		t.Fatalf("GetAccess(alpha): %v", err)
+	}
+	if alphaAccess.InvokeAllOperations {
+		t.Fatal("alpha access invoke_all_operations = true, want false")
+	}
+	if !reflect.DeepEqual(alphaAccess.Operations, []string{"read"}) {
+		t.Fatalf("alpha access operations = %+v, want [read]", alphaAccess.Operations)
+	}
+	gammaAccess, err := svc.PrincipalPluginAccess.GetAccess(ctx, createResp.ID, "gamma")
+	if err != nil {
+		t.Fatalf("GetAccess(gamma): %v", err)
+	}
+	if !gammaAccess.InvokeAllOperations {
+		t.Fatal("gamma access invoke_all_operations = false, want true")
+	}
+	if len(gammaAccess.Operations) != 0 {
+		t.Fatalf("gamma access operations = %+v, want []", gammaAccess.Operations)
+	}
 
 	req, _ = http.NewRequest(http.MethodPut, ts.URL+"/api/v1/identities/"+createResp.ID+"/grants/beta", bytes.NewBufferString(`{"operations":["read"]}`))
 	req.Header.Set("Content-Type", "application/json")
@@ -14545,6 +14678,9 @@ func TestManagedIdentityGrantsRespectActorAuthorization(t *testing.T) {
 
 		if _, err := svc.IdentityGrants.GetGrant(context.Background(), createResp.ID, "removed-plugin"); !errors.Is(err, core.ErrNotFound) {
 			t.Fatalf("GetGrant after delete error = %v, want not found", err)
+		}
+		if _, err := svc.PrincipalPluginAccess.GetAccess(context.Background(), createResp.ID, "removed-plugin"); !errors.Is(err, core.ErrNotFound) {
+			t.Fatalf("GetAccess after delete error = %v, want not found", err)
 		}
 	})
 

--- a/gestaltd/internal/server/server_test.go
+++ b/gestaltd/internal/server/server_test.go
@@ -14152,41 +14152,31 @@ func TestManagedIdentityCRUDAndMemberships(t *testing.T) {
 	if err != nil {
 		t.Fatalf("GetIdentity after create: %v", err)
 	}
-	adminPrincipal, err := svc.Principals.GetPrincipal(ctx, admin.ID)
+	adminIdentity, err := svc.Identities.GetIdentity(ctx, admin.ID)
 	if err != nil {
-		t.Fatalf("GetPrincipal(admin): %v", err)
+		t.Fatalf("GetIdentity(admin): %v", err)
 	}
-	if adminPrincipal.Kind != core.PrincipalKindUser {
-		t.Fatalf("admin principal kind = %q, want %q", adminPrincipal.Kind, core.PrincipalKindUser)
+	if adminIdentity.DisplayName != admin.Email {
+		t.Fatalf("admin identity display name = %q, want %q", adminIdentity.DisplayName, admin.Email)
 	}
-	adminProfile, err := svc.UserProfiles.GetProfile(ctx, admin.ID)
+	adminBindings, err := svc.IdentityAuthBindings.ListByIdentity(ctx, admin.ID)
 	if err != nil {
-		t.Fatalf("GetProfile(admin): %v", err)
+		t.Fatalf("ListByIdentity(admin): %v", err)
 	}
-	if adminProfile.Email != admin.Email {
-		t.Fatalf("admin profile email = %q, want %q", adminProfile.Email, admin.Email)
+	if len(adminBindings) != 1 || adminBindings[0].LookupKey != admin.Email {
+		t.Fatalf("admin bindings = %+v, want single email binding %q", adminBindings, admin.Email)
 	}
-	serviceAccountPrincipal, err := svc.Principals.GetPrincipal(ctx, createResp.ID)
+	serviceAccountIdentity, err := svc.Identities.GetIdentity(ctx, createResp.ID)
 	if err != nil {
-		t.Fatalf("GetPrincipal(identity): %v", err)
+		t.Fatalf("GetIdentity(identity): %v", err)
 	}
-	if serviceAccountPrincipal.Kind != core.PrincipalKindServiceAccount {
-		t.Fatalf("identity principal kind = %q, want %q", serviceAccountPrincipal.Kind, core.PrincipalKindServiceAccount)
+	if serviceAccountIdentity.DisplayName != "Release Bot" {
+		t.Fatalf("identity display name = %q, want %q", serviceAccountIdentity.DisplayName, "Release Bot")
 	}
-	if serviceAccountPrincipal.DisplayName != "Release Bot" {
-		t.Fatalf("identity principal display name = %q, want %q", serviceAccountPrincipal.DisplayName, "Release Bot")
+	if serviceAccountIdentity.CreatedByIdentityID != admin.ID {
+		t.Fatalf("identity created_by_identity_id = %q, want %q", serviceAccountIdentity.CreatedByIdentityID, admin.ID)
 	}
-	serviceAccount, err := svc.ServiceAccounts.GetServiceAccount(ctx, createResp.ID)
-	if err != nil {
-		t.Fatalf("GetServiceAccount(identity): %v", err)
-	}
-	if serviceAccount.Name != createResp.ID {
-		t.Fatalf("service account name = %q, want %q", serviceAccount.Name, createResp.ID)
-	}
-	if serviceAccount.Description != "Release Bot" {
-		t.Fatalf("service account description = %q, want %q", serviceAccount.Description, "Release Bot")
-	}
-	adminGrant, err := svc.ServiceAccountManagementGrants.GetGrant(ctx, admin.ID, createResp.ID)
+	adminGrant, err := svc.IdentityManagementGrants.GetGrant(ctx, admin.ID, createResp.ID)
 	if err != nil {
 		t.Fatalf("GetGrant(admin): %v", err)
 	}
@@ -14213,7 +14203,7 @@ func TestManagedIdentityCRUDAndMemberships(t *testing.T) {
 	if memberResp.Role != "viewer" || memberResp.Email != "viewer@example.test" {
 		t.Fatalf("member response = %+v, want viewer@example.test viewer", memberResp)
 	}
-	viewerGrant, err := svc.ServiceAccountManagementGrants.GetGrant(ctx, viewer.ID, createResp.ID)
+	viewerGrant, err := svc.IdentityManagementGrants.GetGrant(ctx, viewer.ID, createResp.ID)
 	if err != nil {
 		t.Fatalf("GetGrant(viewer): %v", err)
 	}
@@ -14258,19 +14248,12 @@ func TestManagedIdentityCRUDAndMemberships(t *testing.T) {
 	if !updatedIdentity.CreatedAt.Equal(createdIdentity.CreatedAt) {
 		t.Fatalf("createdAt changed across update: got %v want %v", updatedIdentity.CreatedAt, createdIdentity.CreatedAt)
 	}
-	serviceAccountPrincipal, err = svc.Principals.GetPrincipal(ctx, createResp.ID)
+	serviceAccountIdentity, err = svc.Identities.GetIdentity(ctx, createResp.ID)
 	if err != nil {
-		t.Fatalf("GetPrincipal(identity) after update: %v", err)
+		t.Fatalf("GetIdentity(identity) after update: %v", err)
 	}
-	if serviceAccountPrincipal.DisplayName != "Release Automation" {
-		t.Fatalf("identity principal display name after update = %q, want %q", serviceAccountPrincipal.DisplayName, "Release Automation")
-	}
-	serviceAccount, err = svc.ServiceAccounts.GetServiceAccount(ctx, createResp.ID)
-	if err != nil {
-		t.Fatalf("GetServiceAccount(identity) after update: %v", err)
-	}
-	if serviceAccount.Description != "Release Automation" {
-		t.Fatalf("service account description after update = %q, want %q", serviceAccount.Description, "Release Automation")
+	if serviceAccountIdentity.DisplayName != "Release Automation" {
+		t.Fatalf("identity display name after update = %q, want %q", serviceAccountIdentity.DisplayName, "Release Automation")
 	}
 
 	req, _ = http.NewRequest(http.MethodDelete, ts.URL+"/api/v1/identities/"+createResp.ID+"/members/"+admin.Email, nil)
@@ -14296,16 +14279,13 @@ func TestManagedIdentityCRUDAndMemberships(t *testing.T) {
 	if resp.StatusCode != http.StatusNotFound {
 		t.Fatalf("get deleted identity status = %d, want %d", resp.StatusCode, http.StatusNotFound)
 	}
-	if _, err := svc.Principals.GetPrincipal(ctx, createResp.ID); !errors.Is(err, core.ErrNotFound) {
-		t.Fatalf("GetPrincipal(identity) after delete = %v, want not found", err)
+	if _, err := svc.Identities.GetIdentity(ctx, createResp.ID); !errors.Is(err, core.ErrNotFound) {
+		t.Fatalf("GetIdentity(identity) after delete = %v, want not found", err)
 	}
-	if _, err := svc.ServiceAccounts.GetServiceAccount(ctx, createResp.ID); !errors.Is(err, core.ErrNotFound) {
-		t.Fatalf("GetServiceAccount(identity) after delete = %v, want not found", err)
-	}
-	if _, err := svc.ServiceAccountManagementGrants.GetGrant(ctx, admin.ID, createResp.ID); !errors.Is(err, core.ErrNotFound) {
+	if _, err := svc.IdentityManagementGrants.GetGrant(ctx, admin.ID, createResp.ID); !errors.Is(err, core.ErrNotFound) {
 		t.Fatalf("GetGrant(admin) after delete = %v, want not found", err)
 	}
-	if _, err := svc.ServiceAccountManagementGrants.GetGrant(ctx, viewer.ID, createResp.ID); !errors.Is(err, core.ErrNotFound) {
+	if _, err := svc.IdentityManagementGrants.GetGrant(ctx, viewer.ID, createResp.ID); !errors.Is(err, core.ErrNotFound) {
 		t.Fatalf("GetGrant(viewer) after delete = %v, want not found", err)
 	}
 }
@@ -14558,7 +14538,7 @@ func TestManagedIdentityGrantsRespectActorAuthorization(t *testing.T) {
 	if grantResp.Plugin != "gamma" || !reflect.DeepEqual(grantResp.Operations, []string{}) {
 		t.Fatalf("plugin-wide grant response = %+v, want gamma []", grantResp)
 	}
-	alphaAccess, err := svc.PrincipalPluginAccess.GetAccess(ctx, createResp.ID, "alpha")
+	alphaAccess, err := svc.IdentityPluginAccess.GetAccess(ctx, createResp.ID, "alpha")
 	if err != nil {
 		t.Fatalf("GetAccess(alpha): %v", err)
 	}
@@ -14568,7 +14548,7 @@ func TestManagedIdentityGrantsRespectActorAuthorization(t *testing.T) {
 	if !reflect.DeepEqual(alphaAccess.Operations, []string{"read"}) {
 		t.Fatalf("alpha access operations = %+v, want [read]", alphaAccess.Operations)
 	}
-	gammaAccess, err := svc.PrincipalPluginAccess.GetAccess(ctx, createResp.ID, "gamma")
+	gammaAccess, err := svc.IdentityPluginAccess.GetAccess(ctx, createResp.ID, "gamma")
 	if err != nil {
 		t.Fatalf("GetAccess(gamma): %v", err)
 	}
@@ -14679,7 +14659,7 @@ func TestManagedIdentityGrantsRespectActorAuthorization(t *testing.T) {
 		if _, err := svc.IdentityGrants.GetGrant(context.Background(), createResp.ID, "removed-plugin"); !errors.Is(err, core.ErrNotFound) {
 			t.Fatalf("GetGrant after delete error = %v, want not found", err)
 		}
-		if _, err := svc.PrincipalPluginAccess.GetAccess(context.Background(), createResp.ID, "removed-plugin"); !errors.Is(err, core.ErrNotFound) {
+		if _, err := svc.IdentityPluginAccess.GetAccess(context.Background(), createResp.ID, "removed-plugin"); !errors.Is(err, core.ErrNotFound) {
 			t.Fatalf("GetAccess after delete error = %v, want not found", err)
 		}
 	})


### PR DESCRIPTION
## Summary

PR1 replaces the earlier canonical `principal/user_profile/service_account` split with the storage foundation for a single identity graph.

This slice keeps legacy runtime behavior in place while moving canonical ownership and authorization state behind the existing user, managed-identity, dynamic-admin, API-token, and integration-token interfaces.

## New Go Interfaces

Canonical types added or made authoritative in `gestaltd/core/types.go` and `gestaltd/internal/coredata`:

- `core.Identity { id, status, display_name, created_by_identity_id, metadata_json, created_at, updated_at }`
- `core.IdentityAuthBinding { identity_id, binding_kind, authority, lookup_key, binding_json }`
- `core.IdentityManagementGrant { manager_identity_id, target_identity_id, role, expires_at }`
- `core.IdentityDelegation { actor_identity_id, target_identity_id, plugin, expires_at }`
- `core.IdentityPluginAccess { identity_id, plugin, invoke_all_operations, operations }`
- `core.WorkspaceRole { identity_id, role }`
- `core.APIToken` now carries canonical `identity_id` alongside legacy compatibility fields during migration
- `core.APITokenAccess { token_id, plugin, invoke_all_operations, operations }`
- `core.ExternalCredential { identity_id, plugin, connection, instance, auth_type, payload_encrypted }`

Example Go usage:

```go
identity, _ := services.Identities.UpsertIdentity(ctx, &core.Identity{
    ID:                  user.ID,
    Status:              "active",
    DisplayName:         user.Email,
    CreatedByIdentityID: user.ID,
})

binding, _ := services.IdentityAuthBindings.UpsertBinding(ctx, &core.IdentityAuthBinding{
    IdentityID:  identity.ID,
    BindingKind: core.IdentityAuthBindingKindEmail,
    Authority:   "legacy",
    LookupKey:   "alice@example.com",
})

access, _ := services.IdentityPluginAccess.UpsertAccess(ctx, &core.IdentityPluginAccess{
    IdentityID:          identity.ID,
    Plugin:              "github",
    InvokeAllOperations: false,
    Operations:          []string{"pull_requests.read"},
})
```

## IndexedDB Stores

Canonical stores in this PR:

- `identities`
- `identity_auth_bindings`
- `identity_management_grants`
- `identity_delegations`
- `workspace_roles`
- `identity_plugin_access`
- `api_tokens`
- `api_token_access`
- `external_credentials`

## YAML / Runtime Shape This PR Enables

This PR does **not** make the new runtime shape authoritative yet, but it stages the canonical storage model for the later runtime cutover.

```yaml
authorization:
  workloads:
    triage-bot:
      token: gst_wld_triage-bot-token
      providers:
        clickhouse:
          connection: workspace
          instance: team-a
          allow: [run_query]
```

```yaml
spec:
  connections:
    default:
      mode: none
      auth:
        type: none
```

What the storage model behind that YAML now looks like:

- browser / legacy email auth resolves through `identity_auth_bindings(kind=email, authority=legacy, lookup_key=<normalized email>)`
- canonical credential ownership is `external_credentials(identity_id, plugin, connection, instance)`
- canonical plugin invocation authority is `identity_plugin_access(identity_id, plugin)`
- managed identity creation now persists `created_by_identity_id` on the canonical `identities` row

## Implementation

- add canonical IndexedDB stores for identities, auth bindings, management grants, workspace roles, plugin access, token access, delegations, and external credentials
- dual-write legacy user / managed identity / membership / grant / dynamic admin / API token / integration token mutations into canonical identity stores
- remove the old canonical subtype-store plan in favor of the single `identities` graph
- rebuild the derived identity graph from legacy sources at startup so stale canonical rows are repaired on restart
- collapse case-insensitive duplicate legacy users onto one canonical identity when syncing grants, roles, API token access, and external credentials
- augment existing coredata and server tests instead of adding new redundant unit-test suites

## Validation

- `go test ./internal/coredata -run 'Test(New|TokenService|APITokenService)$' -count=1`
- `go test ./internal/server -run 'TestManagedIdentityCRUDAndMemberships|TestManagedIdentityGrantsRespectActorAuthorization|TestAdminAPI_PluginAuthorizationCRUD|TestAdminAPI_AdminAuthorizationCRUD' -count=1`
- `go test ./... -run '^$'`
