### PR TITLE
Resolve managed-identity API tokens as service-account principals

### DIFF
--- a/gestaltd/internal/authorization/authorizer.go
+++ b/gestaltd/internal/authorization/authorizer.go
@@ -338,7 +338,7 @@ func (a *Authorizer) ResolveWorkloadToken(token string) (*principal.ResolvedWork
 }
 
 func (a *Authorizer) IsWorkload(p *principal.Principal) bool {
-	return p != nil && p.Kind == principal.KindWorkload
+	return principal.IsWorkloadPrincipal(p)
 }
 
 func (a *Authorizer) AllowProvider(p *principal.Principal, provider string) bool {
@@ -851,7 +851,7 @@ func normalizeEmail(email string) string {
 }
 
 func (a *Authorizer) isManagedIdentityPrincipal(p *principal.Principal) bool {
-	return a.IsWorkload(p) && principal.ManagedIdentityIDFromSubjectID(strings.TrimSpace(p.SubjectID)) != ""
+	return principal.IsServiceAccountPrincipal(p) && principal.ManagedIdentityIDFromSubjectID(strings.TrimSpace(p.SubjectID)) != ""
 }
 
 func (a *Authorizer) allowManagedIdentityProvider(p *principal.Principal, provider string) bool {

--- a/gestaltd/internal/invocation/broker.go
+++ b/gestaltd/internal/invocation/broker.go
@@ -323,7 +323,7 @@ func (b *Broker) MCPConnection(providerName string) string {
 }
 
 func (b *Broker) workloadSelectors(p *principal.Principal, providerName, connection, instance string) (string, string) {
-	if b.authorizer == nil || !b.authorizer.IsWorkload(p) {
+	if b.authorizer == nil || !principal.IsNonUserPrincipal(p) {
 		return connection, instance
 	}
 	binding, ok := b.authorizer.Binding(p, providerName)
@@ -458,28 +458,42 @@ func (b *Broker) resolveToken(ctx context.Context, prov core.Provider, p *princi
 }
 
 func (b *Broker) resolveUserPrincipal(ctx context.Context, p *principal.Principal) error {
-	if p == nil || p.UserID != "" || p.Kind == principal.KindWorkload || p.Identity == nil || p.Identity.Email == "" {
+	if p == nil || principal.IsNonUserPrincipal(p) {
 		return nil
 	}
-	if b.users == nil {
+	if p.UserID == "" && (p.Identity == nil || p.Identity.Email == "") {
+		return nil
+	}
+	if b.users == nil && p.UserID == "" {
 		return fmt.Errorf("%w: no user service configured", ErrUserResolution)
 	}
-	dbUser, err := b.users.FindOrCreateUser(ctx, p.Identity.Email)
-	if err != nil {
-		return fmt.Errorf("%w: %v", ErrUserResolution, err)
+	if p.UserID == "" {
+		dbUser, err := b.users.FindOrCreateUser(ctx, p.Identity.Email)
+		if err != nil {
+			return fmt.Errorf("%w: %v", ErrUserResolution, err)
+		}
+		if dbUser == nil || dbUser.ID == "" {
+			return fmt.Errorf("%w: no user record returned", ErrUserResolution)
+		}
+		p.UserID = dbUser.ID
+		if p.Identity != nil && p.Identity.DisplayName == "" {
+			p.Identity.DisplayName = dbUser.DisplayName
+		}
 	}
-	if dbUser == nil || dbUser.ID == "" {
-		return fmt.Errorf("%w: no user record returned", ErrUserResolution)
+	if p.IdentityID == "" && p.UserID != "" && b.users != nil {
+		identityID, err := b.users.CanonicalIdentityIDForUser(ctx, p.UserID)
+		if err != nil && !errors.Is(err, core.ErrNotFound) {
+			return fmt.Errorf("%w: %v", ErrUserResolution, err)
+		}
+		if err == nil {
+			p.IdentityID = identityID
+		}
 	}
-	p.UserID = dbUser.ID
 	if p.Kind == "" {
 		p.Kind = principal.KindUser
 	}
-	if p.SubjectID == "" {
-		p.SubjectID = principal.UserSubjectID(dbUser.ID)
-	}
-	if p.Identity != nil && p.Identity.DisplayName == "" {
-		p.Identity.DisplayName = dbUser.DisplayName
+	if p.SubjectID == "" && p.UserID != "" {
+		p.SubjectID = principal.UserSubjectID(p.UserID)
 	}
 	return nil
 }

--- a/gestaltd/internal/mcp/binding_test.go
+++ b/gestaltd/internal/mcp/binding_test.go
@@ -2034,7 +2034,7 @@ func TestNewServer_WorkloadCallToolRejectsInstanceOverride(t *testing.T) {
 		t.Fatalf("expected MCP error result, got %+v", result)
 	}
 	text, ok := result.Content[0].(mcpgo.TextContent)
-	if !ok || text.Text != "workload callers may not override connection or instance bindings" {
+	if !ok || text.Text != "non-user callers may not override connection or instance bindings" {
 		t.Fatalf("unexpected MCP error content: %+v", result.Content)
 	}
 	if called {

--- a/gestaltd/internal/mcp/handlers.go
+++ b/gestaltd/internal/mcp/handlers.go
@@ -24,7 +24,7 @@ func makeHandler(cfg Config, provName, opName, connection string) mcpserver.Tool
 		rawArgs := req.GetArguments()
 		instance := normalizedSessionCatalogInstance(rawArgs["_instance"])
 		if workloadInstanceOverrideRequested(cfg.Authorizer, p, instance) {
-			return mcpgo.NewToolResultError("workload callers may not override connection or instance bindings"), nil
+			return mcpgo.NewToolResultError("non-user callers may not override connection or instance bindings"), nil
 		}
 		args := make(map[string]any, len(rawArgs))
 		for key, value := range rawArgs {

--- a/gestaltd/internal/mcp/session_tools.go
+++ b/gestaltd/internal/mcp/session_tools.go
@@ -144,7 +144,7 @@ func withSessionAccessContext(ctx context.Context, cfg Config, provName string) 
 		return ctx
 	}
 	p := principal.FromContext(ctx)
-	if p == nil || cfg.Authorizer.IsWorkload(p) {
+	if p == nil || principal.IsNonUserPrincipal(p) {
 		return ctx
 	}
 	access, allowed := cfg.Authorizer.ResolveAccess(p, provName)
@@ -389,7 +389,7 @@ func internalSessionToolHandler(context.Context, mcpgo.CallToolRequest) (*mcpgo.
 func sessionTokenSelectors(cfg Config, p *principal.Principal, provName, instanceOverride string) (string, string) {
 	connection := cfg.MCPConnection[provName]
 	instance := normalizedSessionCatalogInstance(instanceOverride)
-	if cfg.Authorizer == nil || !cfg.Authorizer.IsWorkload(p) {
+	if cfg.Authorizer == nil || p == nil || !principal.IsNonUserPrincipal(p) {
 		return connection, instance
 	}
 	if binding, ok := cfg.Authorizer.Binding(p, provName); ok {
@@ -436,6 +436,6 @@ func normalizedSessionCatalogInstance(value any) string {
 	return strings.TrimSpace(instance)
 }
 
-func workloadInstanceOverrideRequested(authz *authorization.Authorizer, p *principal.Principal, instance string) bool {
-	return authz != nil && p != nil && authz.IsWorkload(p) && instance != ""
+func workloadInstanceOverrideRequested(_ *authorization.Authorizer, p *principal.Principal, instance string) bool {
+	return p != nil && principal.IsNonUserPrincipal(p) && instance != ""
 }

--- a/gestaltd/internal/principal/principal.go
+++ b/gestaltd/internal/principal/principal.go
@@ -24,12 +24,14 @@ const managedIdentitySubjectPrefix = "managed_identity:"
 type Kind string
 
 const (
-	KindUser     Kind = "user"
-	KindWorkload Kind = "workload"
+	KindUser           Kind = "user"
+	KindServiceAccount Kind = "service_account"
+	KindWorkload       Kind = "workload"
 )
 
 type Principal struct {
 	Identity         *core.UserIdentity
+	IdentityID       string
 	UserID           string
 	SubjectID        string
 	DisplayName      string
@@ -60,7 +62,7 @@ func (p *Principal) AuthSource() string {
 	if p == nil {
 		return ""
 	}
-	if p.Identity == nil && p.UserID == "" && p.SubjectID == "" && p.Kind == "" && len(p.Scopes) == 0 && p.TokenPermissions == nil {
+	if p.Identity == nil && p.IdentityID == "" && p.UserID == "" && p.SubjectID == "" && p.Kind == "" && len(p.Scopes) == 0 && p.TokenPermissions == nil {
 		return ""
 	}
 	return p.Source.String()
@@ -96,6 +98,30 @@ func ManagedIdentityIDFromSubjectID(subjectID string) string {
 		return ""
 	}
 	return strings.TrimPrefix(subjectID, managedIdentitySubjectPrefix)
+}
+
+func IsServiceAccountPrincipal(p *Principal) bool {
+	if p == nil {
+		return false
+	}
+	if p.Kind == KindServiceAccount {
+		return true
+	}
+	if ManagedIdentityIDFromSubjectID(strings.TrimSpace(p.SubjectID)) != "" {
+		return true
+	}
+	return p.IdentityID != "" && strings.TrimSpace(p.UserID) == "" && p.Kind != KindWorkload
+}
+
+func IsWorkloadPrincipal(p *Principal) bool {
+	if p == nil {
+		return false
+	}
+	return p.Kind == KindWorkload && !IsServiceAccountPrincipal(p)
+}
+
+func IsNonUserPrincipal(p *Principal) bool {
+	return IsServiceAccountPrincipal(p) || IsWorkloadPrincipal(p)
 }
 
 func CompilePermissions(perms []core.AccessPermission) PermissionSet {
@@ -235,6 +261,28 @@ func CompileManagedIdentityGrants(grants []*core.ManagedIdentityGrant) Permissio
 			Plugin:     grant.Plugin,
 			Operations: append([]string(nil), grant.Operations...),
 		})
+	}
+	compiled := CompilePermissions(perms)
+	if compiled == nil {
+		return PermissionSet{}
+	}
+	return compiled
+}
+
+func CompileIdentityPluginAccess(access []*core.IdentityPluginAccess) PermissionSet {
+	if len(access) == 0 {
+		return PermissionSet{}
+	}
+	perms := make([]core.AccessPermission, 0, len(access))
+	for _, grant := range access {
+		if grant == nil {
+			continue
+		}
+		perm := core.AccessPermission{Plugin: strings.TrimSpace(grant.Plugin)}
+		if !grant.InvokeAllOperations {
+			perm.Operations = append([]string(nil), grant.Operations...)
+		}
+		perms = append(perms, perm)
 	}
 	compiled := CompilePermissions(perms)
 	if compiled == nil {

--- a/gestaltd/internal/principal/resolver.go
+++ b/gestaltd/internal/principal/resolver.go
@@ -70,22 +70,22 @@ func ParseTokenType(token string) (TokenType, bool) {
 }
 
 type Resolver struct {
-	auth              core.AuthProvider
-	users             *coredata.UserService
-	apiTokens         *coredata.APITokenService
-	managedIdentities *coredata.ManagedIdentityService
-	identityGrants    *coredata.ManagedIdentityGrantService
-	workloads         WorkloadTokenResolver
+	auth           core.AuthProvider
+	users          *coredata.UserService
+	identities     *coredata.IdentityService
+	identityAccess *coredata.IdentityPluginAccessService
+	apiTokens      *coredata.APITokenService
+	workloads      WorkloadTokenResolver
 }
 
-func NewResolver(auth core.AuthProvider, users *coredata.UserService, apiTokens *coredata.APITokenService, managedIdentities *coredata.ManagedIdentityService, identityGrants *coredata.ManagedIdentityGrantService, workloads WorkloadTokenResolver) *Resolver {
+func NewResolver(auth core.AuthProvider, users *coredata.UserService, identities *coredata.IdentityService, identityAccess *coredata.IdentityPluginAccessService, apiTokens *coredata.APITokenService, workloads WorkloadTokenResolver) *Resolver {
 	return &Resolver{
-		auth:              auth,
-		users:             users,
-		apiTokens:         apiTokens,
-		managedIdentities: managedIdentities,
-		identityGrants:    identityGrants,
-		workloads:         workloads,
+		auth:           auth,
+		users:          users,
+		identities:     identities,
+		identityAccess: identityAccess,
+		apiTokens:      apiTokens,
+		workloads:      workloads,
 	}
 }
 
@@ -112,10 +112,41 @@ func (r *Resolver) ResolveToken(ctx context.Context, token string) (*Principal, 
 	identity, err := r.auth.ValidateToken(ctx, token)
 	metricutil.RecordAuthMetrics(ctx, startedAt, provider, "validate_token", err != nil || identity == nil)
 	if err == nil && identity != nil {
-		return &Principal{Identity: identity, Source: SourceSession}, nil
+		return r.resolveSessionPrincipal(ctx, identity)
 	}
 
 	return nil, ErrInvalidToken
+}
+
+func (r *Resolver) resolveSessionPrincipal(ctx context.Context, identity *core.UserIdentity) (*Principal, error) {
+	p := &Principal{Identity: identity, Source: SourceSession, Kind: KindUser}
+	if identity == nil || strings.TrimSpace(identity.Email) == "" || r.users == nil {
+		return p, nil
+	}
+	user := r.lookupSessionUser(ctx, identity.Email)
+	if user == nil || user.ID == "" {
+		return p, nil
+	}
+	if identityID, err := r.users.CanonicalIdentityIDForUser(ctx, user.ID); err == nil {
+		p.IdentityID = identityID
+	}
+	p.UserID = user.ID
+	p.SubjectID = UserSubjectID(user.ID)
+	if p.Identity != nil && p.Identity.DisplayName == "" {
+		p.Identity.DisplayName = user.DisplayName
+	}
+	return p, nil
+}
+
+func (r *Resolver) lookupSessionUser(ctx context.Context, email string) *core.User {
+	if r == nil || r.users == nil {
+		return nil
+	}
+	user, err := r.users.FindOrCreateUser(ctx, email)
+	if err != nil {
+		return nil
+	}
+	return user
 }
 
 func (r *Resolver) resolveAPIToken(ctx context.Context, token string) (*Principal, error) {
@@ -133,12 +164,19 @@ func (r *Resolver) resolveAPIToken(ctx context.Context, token string) (*Principa
 
 	switch ownerKind := r.apiTokenOwnerKind(apiToken); ownerKind {
 	case core.APITokenOwnerKindManagedIdentity:
-		return r.resolveManagedIdentityAPIToken(ctx, apiToken)
+		return r.resolveIdentityAPIToken(ctx, apiToken)
 	case "", core.APITokenOwnerKindUser:
 	default:
 		return nil, ErrInvalidToken
 	}
 
+	identityID, err := r.identityIDForAPIToken(ctx, apiToken)
+	if err != nil {
+		if errors.Is(err, core.ErrNotFound) {
+			return nil, ErrInvalidToken
+		}
+		return nil, err
+	}
 	user, err := r.users.GetUser(ctx, apiToken.UserID)
 	if err != nil {
 		if errors.Is(err, core.ErrNotFound) {
@@ -152,10 +190,11 @@ func (r *Resolver) resolveAPIToken(ctx context.Context, token string) (*Principa
 			Email:       user.Email,
 			DisplayName: user.DisplayName,
 		},
-		UserID:    user.ID,
-		SubjectID: UserSubjectID(user.ID),
-		Kind:      KindUser,
-		Source:    SourceAPIToken,
+		IdentityID: identityID,
+		UserID:     user.ID,
+		SubjectID:  UserSubjectID(user.ID),
+		Kind:       KindUser,
+		Source:     SourceAPIToken,
 	}
 	if perms := permissionsForAPIToken(apiToken); perms != nil {
 		p.TokenPermissions = perms
@@ -164,41 +203,54 @@ func (r *Resolver) resolveAPIToken(ctx context.Context, token string) (*Principa
 	return p, nil
 }
 
-func (r *Resolver) resolveManagedIdentityAPIToken(ctx context.Context, apiToken *core.APIToken) (*Principal, error) {
-	if r.managedIdentities == nil || r.identityGrants == nil {
+func (r *Resolver) resolveIdentityAPIToken(ctx context.Context, apiToken *core.APIToken) (*Principal, error) {
+	if r.identities == nil {
 		return nil, ErrInvalidToken
 	}
-	identityID := strings.TrimSpace(apiToken.OwnerID)
-	if identityID == "" {
-		return nil, ErrInvalidToken
-	}
-
-	identity, err := r.managedIdentities.GetIdentity(ctx, identityID)
+	identityID, err := r.identityIDForAPIToken(ctx, apiToken)
 	if err != nil {
 		if errors.Is(err, core.ErrNotFound) {
 			return nil, ErrInvalidToken
 		}
 		return nil, err
 	}
-	grants, err := r.identityGrants.ListGrantsByIdentity(ctx, identityID)
+	if identityID == "" {
+		return nil, ErrInvalidToken
+	}
+
+	identity, err := r.identities.GetIdentity(ctx, identityID)
 	if err != nil {
+		if errors.Is(err, core.ErrNotFound) {
+			return nil, ErrInvalidToken
+		}
 		return nil, err
 	}
 
-	tokenPerms := permissionsForAPIToken(apiToken)
-	if tokenPerms == nil {
-		tokenPerms = PermissionSet{}
+	identityPerms := PermissionSet{}
+	if r.identityAccess != nil {
+		access, err := r.identityAccess.ListByIdentity(ctx, identityID)
+		if err != nil {
+			return nil, err
+		}
+		identityPerms = CompileIdentityPluginAccess(access)
 	}
-	grantPerms := CompileManagedIdentityGrants(grants)
-	effectivePerms := IntersectPermissions(tokenPerms, grantPerms)
-	if effectivePerms == nil {
-		effectivePerms = PermissionSet{}
+	if identityPerms == nil {
+		identityPerms = PermissionSet{}
+	}
+
+	effectivePerms := identityPerms
+	if tokenPerms := permissionsForAPIToken(apiToken); tokenPerms != nil {
+		effectivePerms = IntersectPermissions(identityPerms, tokenPerms)
+		if effectivePerms == nil {
+			effectivePerms = PermissionSet{}
+		}
 	}
 
 	return &Principal{
+		IdentityID:       identity.ID,
 		SubjectID:        ManagedIdentitySubjectID(identity.ID),
 		DisplayName:      identity.DisplayName,
-		Kind:             KindWorkload,
+		Kind:             KindServiceAccount,
 		Source:           SourceAPIToken,
 		Scopes:           PermissionPlugins(effectivePerms),
 		TokenPermissions: effectivePerms,
@@ -251,8 +303,30 @@ func (r *Resolver) apiTokenOwnerKind(apiToken *core.APIToken) string {
 	if ownerKind := strings.TrimSpace(apiToken.OwnerKind); ownerKind != "" {
 		return ownerKind
 	}
-	if apiToken.UserID != "" {
+	if strings.TrimSpace(apiToken.UserID) != "" {
 		return core.APITokenOwnerKindUser
 	}
+	if strings.TrimSpace(apiToken.IdentityID) != "" || strings.TrimSpace(apiToken.OwnerID) != "" {
+		return core.APITokenOwnerKindManagedIdentity
+	}
 	return ""
+}
+
+func (r *Resolver) identityIDForAPIToken(ctx context.Context, apiToken *core.APIToken) (string, error) {
+	if apiToken == nil {
+		return "", ErrInvalidToken
+	}
+	if identityID := strings.TrimSpace(apiToken.IdentityID); identityID != "" {
+		return identityID, nil
+	}
+	if userID := strings.TrimSpace(apiToken.UserID); userID != "" {
+		if r.users == nil {
+			return userID, nil
+		}
+		return r.users.CanonicalIdentityIDForUser(ctx, userID)
+	}
+	if ownerID := strings.TrimSpace(apiToken.OwnerID); ownerID != "" {
+		return ownerID, nil
+	}
+	return "", ErrInvalidToken
 }

--- a/gestaltd/internal/providerhost/provider_server.go
+++ b/gestaltd/internal/providerhost/provider_server.go
@@ -109,11 +109,8 @@ func principalFromProto(subject *proto.SubjectContext) *principal.Principal {
 		DisplayName: subject.GetDisplayName(),
 		Source:      sourceFromString(subject.GetAuthSource()),
 	}
-	switch subject.GetKind() {
-	case string(principal.KindUser):
-		p.Kind = principal.KindUser
-	case string(principal.KindWorkload):
-		p.Kind = principal.KindWorkload
+	if kind := strings.TrimSpace(subject.GetKind()); kind != "" {
+		p.Kind = principal.Kind(kind)
 	}
 	if strings.HasPrefix(subject.GetId(), "user:") {
 		p.UserID = strings.TrimPrefix(subject.GetId(), "user:")
@@ -123,12 +120,18 @@ func principalFromProto(subject *proto.SubjectContext) *principal.Principal {
 	} else if strings.HasPrefix(subject.GetId(), "workload:") && p.Kind == "" {
 		p.Kind = principal.KindWorkload
 	}
+	if identityID := principal.ManagedIdentityIDFromSubjectID(subject.GetId()); identityID != "" {
+		p.IdentityID = identityID
+		if p.Kind == "" {
+			p.Kind = principal.KindServiceAccount
+		}
+	}
 	if p.Kind == principal.KindUser && subject.GetDisplayName() != "" {
 		p.Identity = &core.UserIdentity{
 			DisplayName: subject.GetDisplayName(),
 		}
 	}
-	if p.UserID == "" && p.SubjectID == "" && p.Kind == "" && p.DisplayName == "" && p.Identity == nil && p.Source == principal.SourceUnknown {
+	if p.IdentityID == "" && p.UserID == "" && p.SubjectID == "" && p.Kind == "" && p.DisplayName == "" && p.Identity == nil && p.Source == principal.SourceUnknown {
 		return &principal.Principal{}
 	}
 	return p

--- a/gestaltd/internal/providerhost/request_snapshot.go
+++ b/gestaltd/internal/providerhost/request_snapshot.go
@@ -172,5 +172,5 @@ func restoreRequestSnapshotContext(ctx context.Context, snapshot requestSnapshot
 }
 
 func shouldInheritCredentialSelectors(snapshot requestSnapshot) bool {
-	return snapshot.principal == nil || snapshot.principal.Kind != principal.KindWorkload
+	return snapshot.principal == nil || !principal.IsNonUserPrincipal(snapshot.principal)
 }

--- a/gestaltd/internal/server/audit.go
+++ b/gestaltd/internal/server/audit.go
@@ -2,6 +2,7 @@ package server
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"net/http"
 	"strings"
@@ -39,36 +40,38 @@ func (s *Server) resolvePrincipalUserID(ctx context.Context, p *principal.Princi
 	if p == nil {
 		return nil, nil
 	}
-	if p.Kind == principal.KindWorkload {
+	if principal.IsNonUserPrincipal(p) {
 		return p, nil
 	}
-	if p.Kind == "" {
-		p.Kind = principal.KindUser
+	clone := *p
+	if clone.Kind == "" {
+		clone.Kind = principal.KindUser
 	}
-	if p.UserID != "" {
-		if p.SubjectID == "" {
-			clone := *p
-			clone.SubjectID = principal.UserSubjectID(p.UserID)
+	if clone.UserID == "" {
+		if clone.Identity == nil || clone.Identity.Email == "" {
 			return &clone, nil
 		}
-		return p, nil
+		dbUser, err := s.users.FindOrCreateUser(ctx, clone.Identity.Email)
+		if err != nil {
+			return nil, err
+		}
+		if dbUser == nil || dbUser.ID == "" {
+			return nil, fmt.Errorf("authenticated principal missing user ID")
+		}
+		clone.UserID = dbUser.ID
 	}
-	if p.Identity == nil || p.Identity.Email == "" {
-		return p, nil
+	if clone.IdentityID == "" && clone.UserID != "" {
+		identityID, err := s.users.CanonicalIdentityIDForUser(ctx, clone.UserID)
+		if err != nil && !errors.Is(err, core.ErrNotFound) {
+			return nil, err
+		}
+		if err == nil {
+			clone.IdentityID = identityID
+		}
 	}
-
-	dbUser, err := s.users.FindOrCreateUser(ctx, p.Identity.Email)
-	if err != nil {
-		return nil, err
+	if clone.SubjectID == "" && clone.UserID != "" {
+		clone.SubjectID = principal.UserSubjectID(clone.UserID)
 	}
-	if dbUser == nil || dbUser.ID == "" {
-		return nil, fmt.Errorf("authenticated principal missing user ID")
-	}
-
-	clone := *p
-	clone.UserID = dbUser.ID
-	clone.Kind = principal.KindUser
-	clone.SubjectID = principal.UserSubjectID(dbUser.ID)
 	return &clone, nil
 }
 

--- a/gestaltd/internal/server/authorization.go
+++ b/gestaltd/internal/server/authorization.go
@@ -40,22 +40,22 @@ func (s *Server) workloadBinding(p *principal.Principal, provider string) (autho
 	return s.authorizer.Binding(p, provider)
 }
 
-func rejectWorkloadSelectors(w http.ResponseWriter, p *principal.Principal, connection, instance string) error {
-	if p == nil || p.Kind != principal.KindWorkload {
+func rejectNonUserSelectors(w http.ResponseWriter, p *principal.Principal, connection, instance string) error {
+	if !principal.IsNonUserPrincipal(p) {
 		return nil
 	}
 	if connection == "" && instance == "" {
 		return nil
 	}
-	writeError(w, http.StatusForbidden, errWorkloadSelector.Error())
-	return errWorkloadSelector
+	writeError(w, http.StatusForbidden, errNonUserSelector.Error())
+	return errNonUserSelector
 }
 
 func (s *Server) workloadBindingSelectors(p *principal.Principal, provider, connection, instance string) (string, string) {
 	resolveConnection := func(connection string) string {
 		return s.sessionCatalogConnections(provider, nil, connection)[0]
 	}
-	if p == nil || p.Kind != principal.KindWorkload {
+	if !principal.IsNonUserPrincipal(p) {
 		return resolveConnection(connection), instance
 	}
 	binding, ok := s.workloadBinding(p, provider)

--- a/gestaltd/internal/server/handlers.go
+++ b/gestaltd/internal/server/handlers.go
@@ -39,11 +39,11 @@ const sessionCookieName = "session_token"
 const defaultSessionCookieTTL = 24 * time.Hour
 
 var (
-	errNotAuthenticated  = errors.New("not authenticated")
-	errResolveUser       = errors.New("failed to resolve user")
-	errWorkloadForbidden = errors.New("workload callers are not allowed on this route")
-	errOperationAccess   = errors.New("operation access denied")
-	errWorkloadSelector  = errors.New("workload callers may not override connection or instance bindings")
+	errNotAuthenticated = errors.New("not authenticated")
+	errResolveUser      = errors.New("failed to resolve user")
+	errNonUserForbidden = errors.New("non-user callers are not allowed on this route")
+	errOperationAccess  = errors.New("operation access denied")
+	errNonUserSelector  = errors.New("non-user callers may not override connection or instance bindings")
 )
 
 var (
@@ -91,9 +91,9 @@ type connectionParamInfo struct {
 }
 
 func (s *Server) resolveUserID(w http.ResponseWriter, r *http.Request) (string, error) {
-	if p := PrincipalFromContext(r.Context()); p != nil && p.Kind == principal.KindWorkload {
-		writeError(w, http.StatusForbidden, "workload callers are not allowed on this route")
-		return "", errWorkloadForbidden
+	if p := PrincipalFromContext(r.Context()); principal.IsNonUserPrincipal(p) {
+		writeError(w, http.StatusForbidden, "non-user callers are not allowed on this route")
+		return "", errNonUserForbidden
 	}
 	user := UserFromContext(r.Context())
 	if user == nil || user.Email == "" {
@@ -128,7 +128,7 @@ func (s *Server) readinessCheck(w http.ResponseWriter, _ *http.Request) {
 func (s *Server) listIntegrations(w http.ResponseWriter, r *http.Request) {
 	p := PrincipalFromContext(r.Context())
 	connected := map[string][]instanceInfo{}
-	if p == nil || p.Kind != principal.KindWorkload {
+	if p == nil || !principal.IsNonUserPrincipal(p) {
 		var err error
 		connected, err = s.userConnectedIntegrations(r)
 		if err != nil {
@@ -165,7 +165,7 @@ func (s *Server) listIntegrations(w http.ResponseWriter, r *http.Request) {
 		if entry, ok := s.pluginDefs[name]; ok && entry != nil {
 			info.MountedPath = strings.TrimSpace(entry.MountPath)
 		}
-		if p != nil && p.Kind == principal.KindWorkload {
+		if principal.IsNonUserPrincipal(p) {
 			if binding, ok := s.workloadBinding(p, name); ok {
 				bindingConnected, err := s.workloadBindingConnected(r.Context(), binding, name)
 				if err != nil {
@@ -445,7 +445,7 @@ func (s *Server) listOperations(w http.ResponseWriter, r *http.Request) {
 			return
 		}
 	}
-	if err := rejectWorkloadSelectors(w, p, requestedConnection, requestedInstance); err != nil {
+	if err := rejectNonUserSelectors(w, p, requestedConnection, requestedInstance); err != nil {
 		s.auditHTTPEvent(r.Context(), p, name, operation, false, err)
 		return
 	}
@@ -540,7 +540,7 @@ func (s *Server) executeOperation(w http.ResponseWriter, r *http.Request) {
 			return
 		}
 	}
-	if err := rejectWorkloadSelectors(w, p, requestedConnection, requestedInstance); err != nil {
+	if err := rejectNonUserSelectors(w, p, requestedConnection, requestedInstance); err != nil {
 		s.auditHTTPEvent(r.Context(), p, providerName, operationName, false, err)
 		return
 	}
@@ -594,7 +594,7 @@ func (s *Server) executeOperation(w http.ResponseWriter, r *http.Request) {
 		writeError(w, http.StatusBadRequest, fmt.Sprintf("conflicting connection parameter %q in query string and JSON body", httpConnectionParam))
 		return
 	}
-	if err := rejectWorkloadSelectors(w, p, bodyConnection, bodyInstance); err != nil {
+	if err := rejectNonUserSelectors(w, p, bodyConnection, bodyInstance); err != nil {
 		s.auditHTTPEvent(r.Context(), p, providerName, operationName, false, err)
 		return
 	}

--- a/gestaltd/internal/server/handlers_admin_authorization.go
+++ b/gestaltd/internal/server/handlers_admin_authorization.go
@@ -76,8 +76,8 @@ func (s *Server) adminAPIAuthMiddleware(next http.Handler) http.Handler {
 			writeError(w, http.StatusUnauthorized, "missing authorization")
 			return
 		}
-		if p.Kind == principal.KindWorkload {
-			writeError(w, http.StatusForbidden, "workload callers are not allowed on this route")
+		if principal.IsNonUserPrincipal(p) {
+			writeError(w, http.StatusForbidden, "non-user callers are not allowed on this route")
 			return
 		}
 

--- a/gestaltd/internal/server/handlers_auth.go
+++ b/gestaltd/internal/server/handlers_auth.go
@@ -547,9 +547,9 @@ func (s *Server) logout(w http.ResponseWriter, r *http.Request) {
 	defer func() {
 		s.auditHTTPEvent(r.Context(), auditPrincipal, s.authProviderName(), "auth.logout", auditAllowed, auditErr)
 	}()
-	if auditPrincipal != nil && auditPrincipal.Kind == principal.KindWorkload {
-		auditErr = errWorkloadForbidden
-		writeError(w, http.StatusForbidden, "workload callers are not allowed on this route")
+	if principal.IsNonUserPrincipal(auditPrincipal) {
+		auditErr = errNonUserForbidden
+		writeError(w, http.StatusForbidden, "non-user callers are not allowed on this route")
 		return
 	}
 

--- a/gestaltd/internal/server/handlers_connect.go
+++ b/gestaltd/internal/server/handlers_connect.go
@@ -38,9 +38,9 @@ func (s *Server) connectManual(w http.ResponseWriter, r *http.Request) {
 		metricutil.RecordConnectionAuthMetrics(r.Context(), startedAt, metricProviderName, "manual", "complete", connectionMode, auditErr != nil)
 		s.auditHTTPEventWithTarget(r.Context(), PrincipalFromContext(r.Context()), providerName, "connection.manual.connect", auditAllowed, auditErr, auditTarget)
 	}()
-	if p := PrincipalFromContext(r.Context()); p != nil && p.Kind == principal.KindWorkload {
-		auditErr = errWorkloadForbidden
-		writeError(w, http.StatusForbidden, "workload callers are not allowed on this route")
+	if p := PrincipalFromContext(r.Context()); principal.IsNonUserPrincipal(p) {
+		auditErr = errNonUserForbidden
+		writeError(w, http.StatusForbidden, "non-user callers are not allowed on this route")
 		return
 	}
 

--- a/gestaltd/internal/server/handlers_identities.go
+++ b/gestaltd/internal/server/handlers_identities.go
@@ -1190,7 +1190,7 @@ func (s *Server) managedIdentityGrantCatalogTargets(ctx context.Context, plugin 
 		connection, instance := s.workloadBindingSelectors(p, plugin, connection, "")
 		addTarget(connection, instance)
 	}
-	if p == nil || p.Kind == principal.KindWorkload || strings.TrimSpace(p.UserID) == "" {
+	if p == nil || principal.IsNonUserPrincipal(p) || strings.TrimSpace(p.UserID) == "" {
 		if len(targets) == 0 {
 			addTarget("", "")
 		}

--- a/gestaltd/internal/server/handlers_oauth.go
+++ b/gestaltd/internal/server/handlers_oauth.go
@@ -36,9 +36,9 @@ func (s *Server) startIntegrationOAuth(w http.ResponseWriter, r *http.Request) {
 		metricutil.RecordConnectionAuthMetrics(r.Context(), startedAt, metricProviderName, "oauth", "start", connectionMode, auditErr != nil)
 		s.auditHTTPEventWithTarget(r.Context(), PrincipalFromContext(r.Context()), providerName, "connection.oauth.start", auditAllowed, auditErr, auditTarget)
 	}()
-	if p := PrincipalFromContext(r.Context()); p != nil && p.Kind == principal.KindWorkload {
-		auditErr = errWorkloadForbidden
-		writeError(w, http.StatusForbidden, "workload callers are not allowed on this route")
+	if p := PrincipalFromContext(r.Context()); principal.IsNonUserPrincipal(p) {
+		auditErr = errNonUserForbidden
+		writeError(w, http.StatusForbidden, "non-user callers are not allowed on this route")
 		return
 	}
 

--- a/gestaltd/internal/server/integration_visibility.go
+++ b/gestaltd/internal/server/integration_visibility.go
@@ -19,7 +19,7 @@ func (s *Server) integrationHasUsableSurface(p *principal.Principal, provider st
 }
 
 func (s *Server) integrationHasSettingsSurface(p *principal.Principal, info integrationInfo) bool {
-	if p != nil && p.Kind == principal.KindWorkload {
+	if principal.IsNonUserPrincipal(p) {
 		return false
 	}
 	return info.Connected || len(info.AuthTypes) > 0 || len(info.Connections) > 0
@@ -65,10 +65,13 @@ func (s *Server) mountedWebUIForProvider(provider, mountedPath string) (MountedW
 }
 
 func (s *Server) mountedWebUIRootAccessible(p *principal.Principal, mounted MountedWebUI) bool {
+	if principal.IsNonUserPrincipal(p) {
+		return false
+	}
 	if mounted.AuthorizationPolicy == "" {
 		return true
 	}
-	if s.authorizer == nil || p == nil || p.Kind == principal.KindWorkload {
+	if s.authorizer == nil || p == nil {
 		return false
 	}
 

--- a/gestaltd/internal/server/middleware.go
+++ b/gestaltd/internal/server/middleware.go
@@ -132,10 +132,10 @@ func (s *Server) resolveRequestPrincipal(r *http.Request) (*principal.Principal,
 
 	if c, err := r.Cookie(sessionCookieName); err == nil && c.Value != "" {
 		p, err := s.resolver.ResolveToken(r.Context(), c.Value)
-		if p != nil && p.Kind != principal.KindWorkload {
+		if p != nil && !principal.IsNonUserPrincipal(p) {
 			return p, nil
 		}
-		if p != nil && p.Kind == principal.KindWorkload {
+		if p != nil && principal.IsNonUserPrincipal(p) {
 			lastErr = principal.ErrInvalidToken
 		} else {
 			lastErr = err

--- a/gestaltd/internal/server/mounted_ui.go
+++ b/gestaltd/internal/server/mounted_ui.go
@@ -315,8 +315,8 @@ func (s *Server) authorizeProtectedUIRequest(w http.ResponseWriter, r *http.Requ
 		}
 		return nil, false
 	}
-	if p != nil && p.Kind == principal.KindWorkload {
-		writeError(w, http.StatusForbidden, "workload callers are not allowed on this route")
+	if principal.IsNonUserPrincipal(p) {
+		writeError(w, http.StatusForbidden, "non-user callers are not allowed on this route")
 		return nil, false
 	}
 

--- a/gestaltd/internal/server/pending_connection.go
+++ b/gestaltd/internal/server/pending_connection.go
@@ -256,8 +256,8 @@ func (s *Server) resolvePendingConnectionUserID(r *http.Request) (string, bool, 
 	if p == nil {
 		return "", false, nil
 	}
-	if p.Kind == principal.KindWorkload {
-		return "", true, errWorkloadForbidden
+	if principal.IsNonUserPrincipal(p) {
+		return "", true, errNonUserForbidden
 	}
 	if p.UserID == "" {
 		return "", true, fmt.Errorf("authenticated principal missing user ID")
@@ -289,8 +289,8 @@ func (s *Server) authorizePendingConnectionByCookie(r *http.Request, state *pend
 func (s *Server) authorizePendingConnection(w http.ResponseWriter, r *http.Request, state *pendingConnectionState) bool {
 	userID, authenticated, err := s.resolvePendingConnectionUserID(r)
 	if err != nil {
-		if errors.Is(err, errWorkloadForbidden) {
-			writeError(w, http.StatusForbidden, "workload callers are not allowed on this route")
+		if errors.Is(err, errNonUserForbidden) {
+			writeError(w, http.StatusForbidden, "non-user callers are not allowed on this route")
 			return false
 		}
 		if errors.Is(err, principal.ErrInvalidToken) {

--- a/gestaltd/internal/server/server.go
+++ b/gestaltd/internal/server/server.go
@@ -188,7 +188,7 @@ func New(cfg Config) (*Server, error) {
 	identityGrants := cfg.Services.IdentityGrants
 	pluginAuthorizations := cfg.Services.PluginAuthorizations
 	adminAuthorizations := cfg.Services.AdminAuthorizations
-	resolver := principal.NewResolver(cfg.Auth, users, apiTokens, managedIdentities, identityGrants, cfg.Authorizer)
+	resolver := principal.NewResolver(cfg.Auth, users, cfg.Services.Identities, cfg.Services.IdentityPluginAccess, apiTokens, cfg.Authorizer)
 
 	router := chi.NewRouter()
 	otelOptions := []otelhttp.Option{}

--- a/gestaltd/internal/server/server_test.go
+++ b/gestaltd/internal/server/server_test.go
@@ -152,6 +152,58 @@ func (s *putFailingObjectStore) Put(ctx context.Context, record indexeddb.Record
 	return s.ObjectStore.Put(ctx, record)
 }
 
+type getFailingIndexedDB struct {
+	indexeddb.IndexedDB
+	failStoreGets map[string]*getFailureRule
+}
+
+func (d *getFailingIndexedDB) ObjectStore(name string) indexeddb.ObjectStore {
+	store := d.IndexedDB.ObjectStore(name)
+	failGet := d.failStoreGets[name]
+	if failGet == nil {
+		return store
+	}
+	return &getFailingObjectStore{ObjectStore: store, storeName: name, failGet: failGet}
+}
+
+type getFailingObjectStore struct {
+	indexeddb.ObjectStore
+	storeName string
+	failGet   *getFailureRule
+}
+
+func (s *getFailingObjectStore) Get(ctx context.Context, key string) (indexeddb.Record, error) {
+	if s.failGet.shouldFail() {
+		return nil, indexeddb.ErrNotFound
+	}
+	return s.ObjectStore.Get(ctx, key)
+}
+
+type getFailureRule struct {
+	failCalls map[int64]struct{}
+	calls     atomic.Int64
+}
+
+func newGetFailureRule(failCalls ...int64) *getFailureRule {
+	rule := &getFailureRule{failCalls: make(map[int64]struct{}, len(failCalls))}
+	for _, call := range failCalls {
+		if call < 1 {
+			continue
+		}
+		rule.failCalls[call] = struct{}{}
+	}
+	return rule
+}
+
+func (r *getFailureRule) shouldFail() bool {
+	if r == nil {
+		return false
+	}
+	call := r.calls.Add(1)
+	_, ok := r.failCalls[call]
+	return ok
+}
+
 type addFailingIndexedDB struct {
 	indexeddb.IndexedDB
 	failStoreAdds    map[string]*atomic.Bool
@@ -339,6 +391,25 @@ func newTestServicesWithPluginAuthorizationPutFailure(t *testing.T) (*coredata.S
 		t.Fatalf("newTestServicesWithPluginAuthorizationPutFailure: %v", err)
 	}
 	return svc, failPut
+}
+
+func newTestServicesWithUsersGetNotFound(t *testing.T, failCalls ...int64) (*coredata.Services, *getFailureRule) {
+	t.Helper()
+	enc, err := corecrypto.NewAESGCM([]byte("0123456789abcdef0123456789abcdef"))
+	if err != nil {
+		t.Fatalf("newTestServicesWithUsersGetNotFound encryptor: %v", err)
+	}
+	failGet := newGetFailureRule(failCalls...)
+	svc, err := coredata.New(&getFailingIndexedDB{
+		IndexedDB: &coretesting.StubIndexedDB{},
+		failStoreGets: map[string]*getFailureRule{
+			coredata.StoreUsers: failGet,
+		},
+	}, enc)
+	if err != nil {
+		t.Fatalf("newTestServicesWithUsersGetNotFound: %v", err)
+	}
+	return svc, failGet
 }
 
 func newTestServicesWithAdminAuthorizationPutFailure(t *testing.T) (*coredata.Services, *atomic.Bool) {
@@ -1132,6 +1203,81 @@ func TestMountedWebUIRoutes_HumanAuthorization(t *testing.T) {
 	}
 	if !strings.Contains(string(body), "protected-sample") {
 		t.Fatalf("asset body = %q, want protected sample asset", body)
+	}
+}
+
+func TestMountedWebUIRoutes_HumanAuthorization_IgnoresMissingCanonicalIdentity(t *testing.T) {
+	t.Parallel()
+
+	dir := t.TempDir()
+	if err := os.WriteFile(filepath.Join(dir, "index.html"), []byte("<html>protected-sample-shell</html>"), 0o644); err != nil {
+		t.Fatalf("WriteFile index.html: %v", err)
+	}
+	handler, err := testutilWebUIHandler(dir)
+	if err != nil {
+		t.Fatalf("webui handler: %v", err)
+	}
+
+	svc, failGet := newTestServicesWithUsersGetNotFound(t, 3, 4)
+	viewer := seedUser(t, svc, "viewer@example.test")
+	authz := mustAuthorizer(t, config.AuthorizationConfig{
+		Policies: map[string]config.HumanPolicyDef{
+			"sample_policy": {
+				Default: "deny",
+				Members: []config.HumanPolicyMemberDef{
+					{SubjectID: principal.UserSubjectID(viewer.ID), Role: "viewer"},
+				},
+			},
+		},
+	}, nil, map[string]*config.ProviderEntry{
+		"sample_portal": {AuthorizationPolicy: "sample_policy"},
+	}, nil)
+
+	ts := newTestServer(t, func(cfg *server.Config) {
+		cfg.Auth = &coretesting.StubAuthProvider{
+			N: "test",
+			ValidateTokenFn: func(_ context.Context, token string) (*core.UserIdentity, error) {
+				switch token {
+				case "viewer-session":
+					return &core.UserIdentity{Email: "viewer@example.test"}, nil
+				default:
+					return nil, fmt.Errorf("invalid token")
+				}
+			},
+		}
+		cfg.Services = svc
+		cfg.Authorizer = authz
+		cfg.MountedWebUIs = []server.MountedWebUI{{
+			Name:                "sample_portal",
+			Path:                "/sample-portal",
+			AuthorizationPolicy: "sample_policy",
+			Routes: []server.MountedWebUIRoute{
+				{Path: "/*", AllowedRoles: []string{"viewer", "admin"}},
+			},
+			Handler: handler,
+		}}
+	})
+	testutil.CloseOnCleanup(t, ts)
+
+	req, _ := http.NewRequest(http.MethodGet, ts.URL+"/sample-portal/sync", nil)
+	req.AddCookie(&http.Cookie{Name: "session_token", Value: "viewer-session"})
+	resp, err := http.DefaultClient.Do(req)
+	if err != nil {
+		t.Fatalf("GET protected mounted sync with viewer session: %v", err)
+	}
+	body, err := io.ReadAll(resp.Body)
+	_ = resp.Body.Close()
+	if err != nil {
+		t.Fatalf("ReadAll protected mounted sync: %v", err)
+	}
+	if resp.StatusCode != http.StatusOK {
+		t.Fatalf("status = %d, want 200", resp.StatusCode)
+	}
+	if !strings.Contains(string(body), "protected-sample-shell") {
+		t.Fatalf("body = %q, want protected sample shell", body)
+	}
+	if failGet.calls.Load() < 4 {
+		t.Fatalf("users store get calls = %d, want at least 4", failGet.calls.Load())
 	}
 }
 
@@ -4479,7 +4625,7 @@ func TestWorkloadAuthorization_ListOperationsFiltersAndRejectsSelectors(t *testi
 	if auditRecord["subject_id"] != "workload:triage-bot" {
 		t.Fatalf("expected workload subject_id, got %v", auditRecord["subject_id"])
 	}
-	if auditRecord["error"] != "workload callers may not override connection or instance bindings" {
+	if auditRecord["error"] != "non-user callers may not override connection or instance bindings" {
 		t.Fatalf("unexpected audit error: %v", auditRecord["error"])
 	}
 
@@ -7626,7 +7772,7 @@ func TestWorkloadAuthorization_ExecuteOperation_UsesBoundIdentityAndRejectsSelec
 	if selectorAudit["subject_id"] != "workload:triage-bot" {
 		t.Fatalf("expected selector audit subject_id workload:triage-bot, got %v", selectorAudit["subject_id"])
 	}
-	if selectorAudit["error"] != "workload callers may not override connection or instance bindings" {
+	if selectorAudit["error"] != "non-user callers may not override connection or instance bindings" {
 		t.Fatalf("unexpected selector audit error: %v", selectorAudit["error"])
 	}
 }
@@ -16094,6 +16240,7 @@ func TestManagedIdentityAPITokenInvocation_ModeNoneOnly(t *testing.T) {
 		t.Fatalf("authorization.New: %v", err)
 	}
 
+	var auditBuf bytes.Buffer
 	ts := newTestServer(t, func(cfg *server.Config) {
 		cfg.Auth = &coretesting.StubAuthProvider{
 			N: "test",
@@ -16107,6 +16254,7 @@ func TestManagedIdentityAPITokenInvocation_ModeNoneOnly(t *testing.T) {
 		cfg.Providers = providers
 		cfg.Services = svc
 		cfg.Authorizer = authz
+		cfg.AuditSink = invocation.NewSlogAuditSink(&auditBuf)
 	})
 	testutil.CloseOnCleanup(t, ts)
 
@@ -16165,6 +16313,72 @@ func TestManagedIdentityAPITokenInvocation_ModeNoneOnly(t *testing.T) {
 		t.Fatal("expected plaintext token for invocation test")
 	}
 
+	req, _ = http.NewRequest(http.MethodGet, ts.URL+"/api/v1/integrations", nil)
+	req.Header.Set("Authorization", "Bearer "+createTokenResp.Token)
+	resp, err = http.DefaultClient.Do(req)
+	if err != nil {
+		t.Fatalf("list integrations: %v", err)
+	}
+	if resp.StatusCode != http.StatusOK {
+		body, _ := io.ReadAll(resp.Body)
+		_ = resp.Body.Close()
+		t.Fatalf("expected 200 from integration list, got %d: %s", resp.StatusCode, body)
+	}
+	var integrations []struct {
+		Name             string                    `json:"name"`
+		Connected        bool                      `json:"connected"`
+		Instances        []map[string]any          `json:"instances"`
+		AuthTypes        []string                  `json:"authTypes"`
+		Connections      []map[string]any          `json:"connections"`
+		CredentialFields []map[string]any          `json:"credentialFields"`
+		ConnectionParams map[string]map[string]any `json:"connectionParams"`
+	}
+	if err := json.NewDecoder(resp.Body).Decode(&integrations); err != nil {
+		t.Fatalf("decoding integrations: %v", err)
+	}
+	_ = resp.Body.Close()
+	if len(integrations) != 2 {
+		t.Fatalf("expected 2 managed-identity integrations, got %+v", integrations)
+	}
+	for _, integration := range integrations {
+		if integration.Name != "alpha" && integration.Name != "beta" {
+			t.Fatalf("unexpected integration listing %+v", integrations)
+		}
+		if !integration.Connected {
+			t.Fatalf("expected %q to be connected for managed-identity token", integration.Name)
+		}
+		if len(integration.Instances) != 0 || len(integration.AuthTypes) != 0 || len(integration.Connections) != 0 || len(integration.CredentialFields) != 0 || len(integration.ConnectionParams) != 0 {
+			t.Fatalf("managed-identity integration %q should not expose connection affordances: %+v", integration.Name, integration)
+		}
+	}
+
+	req, _ = http.NewRequest(http.MethodGet, ts.URL+"/api/v1/integrations", nil)
+	req.AddCookie(&http.Cookie{Name: "session_token", Value: createTokenResp.Token})
+	resp, err = http.DefaultClient.Do(req)
+	if err != nil {
+		t.Fatalf("managed-identity cookie auth request: %v", err)
+	}
+	body, _ = io.ReadAll(resp.Body)
+	_ = resp.Body.Close()
+	if resp.StatusCode != http.StatusUnauthorized {
+		t.Fatalf("managed-identity cookie auth status = %d, want %d: %s", resp.StatusCode, http.StatusUnauthorized, body)
+	}
+
+	req, _ = http.NewRequest(http.MethodGet, ts.URL+"/api/v1/alpha/read?_connection=workspace", nil)
+	req.Header.Set("Authorization", "Bearer "+createTokenResp.Token)
+	resp, err = http.DefaultClient.Do(req)
+	if err != nil {
+		t.Fatalf("managed-identity execute selector request: %v", err)
+	}
+	body, _ = io.ReadAll(resp.Body)
+	_ = resp.Body.Close()
+	if resp.StatusCode != http.StatusForbidden {
+		t.Fatalf("managed-identity execute selector status = %d, want %d: %s", resp.StatusCode, http.StatusForbidden, body)
+	}
+	if !strings.Contains(string(body), "non-user callers may not override connection or instance bindings") {
+		t.Fatalf("managed-identity execute selector body = %q", string(body))
+	}
+
 	call := func(path string) int {
 		req, _ := http.NewRequest(http.MethodGet, ts.URL+path, nil)
 		req.Header.Set("Authorization", "Bearer "+createTokenResp.Token)
@@ -16187,6 +16401,34 @@ func TestManagedIdentityAPITokenInvocation_ModeNoneOnly(t *testing.T) {
 	}
 	if status := call("/api/v1/gamma/query"); status != http.StatusForbidden {
 		t.Fatalf("gamma/query status = %d, want 403", status)
+	}
+
+	lines := bytes.Split(bytes.TrimSpace(auditBuf.Bytes()), []byte("\n"))
+	foundInvocationAudit := false
+	for _, line := range lines {
+		if len(bytes.TrimSpace(line)) == 0 {
+			continue
+		}
+		var auditRecord map[string]any
+		if err := json.Unmarshal(line, &auditRecord); err != nil {
+			t.Fatalf("parsing audit record: %v\nraw: %s", err, auditBuf.String())
+		}
+		if auditRecord["provider"] != "alpha" || auditRecord["operation"] != "write" || auditRecord["allowed"] != false {
+			continue
+		}
+		foundInvocationAudit = true
+		if auditRecord["auth_source"] != "api_token" {
+			t.Fatalf("expected managed-identity audit auth_source api_token, got %v", auditRecord["auth_source"])
+		}
+		if auditRecord["subject_kind"] != string(principal.KindServiceAccount) {
+			t.Fatalf("expected managed-identity audit subject_kind %q, got %v", principal.KindServiceAccount, auditRecord["subject_kind"])
+		}
+		if auditRecord["subject_id"] != principal.ManagedIdentitySubjectID(createResp.ID) {
+			t.Fatalf("expected managed-identity audit subject_id %q, got %v", principal.ManagedIdentitySubjectID(createResp.ID), auditRecord["subject_id"])
+		}
+	}
+	if !foundInvocationAudit {
+		t.Fatalf("expected managed-identity invocation audit record, got raw: %s", auditBuf.String())
 	}
 
 	doJSONRequestAndDecode(t, http.MethodDelete, ts.URL+"/api/v1/identities/"+createResp.ID, "admin-session", "", http.StatusOK, nil)


### PR DESCRIPTION
## Summary

PR2 is the next runtime slice on top of #1113.

It keeps the current product restriction that non-user identity tokens still only work against `mode: none` providers in this phase, but it moves the runtime onto canonical identity state instead of the older managed-identity masquerade.

Concretely:

- non-user API tokens now resolve through canonical `identity_id`
- non-user token permissions are computed from canonical `identity_plugin_access` downscoped by the token
- MCP / HTTP / providerhost selector handling now uses one shared non-user path instead of workload-only special cases
- providerhost now round-trips non-user identity subjects instead of dropping them back to the old workload-only model

## New Go Interfaces

Runtime-facing changes in this PR:

- `principal.Principal` now carries canonical `identity_id` alongside legacy `user_id`, `subject_id`, and advisory `kind`
- `principal.NewResolver(auth, users, identities, identityPluginAccess, apiTokens, workloads)`
- non-user token permissions resolve as:
  - `identity_plugin_access(identity_id, plugin)`
  - intersect token-scoped `api_tokens.permissions`

Example Go usage:

```go
resolver := principal.NewResolver(
    authProvider,
    services.Users,
    services.Identities,
    services.IdentityPluginAccess,
    services.APITokens,
    authorizer,
)

p, err := resolver.ResolveToken(ctx, token)
if err != nil {
    return err
}
if principal.IsNonUserPrincipal(p) {
    // Permissions come from canonical identity_plugin_access(identity_id, plugin)
    // downscoped by the token itself.
}
```

Providerhost / MCP example:

```go
if principal.IsNonUserPrincipal(p) {
    // Non-user callers do not regain selector override behavior by
    // crossing the MCP or providerhost boundary.
}
```

## YAML / Runtime Interface

This PR does **not** add new YAML keys. Existing config stays valid.

Providers that continue to work for non-user identity tokens in this slice:

```yaml
spec:
  connections:
    default:
      mode: none
      auth:
        type: none
```

Existing workload YAML still works, but its MCP/providerhost selector restrictions now share the same non-user enforcement path as service-account identity tokens:

```yaml
authorization:
  workloads:
    triage-bot:
      token: gst_wld_triage-bot-token
      providers:
        clickhouse:
          connection: workspace
          instance: team-a
          allow: [run_query]
```

Still intentionally out of scope in this PR:

```yaml
spec:
  connections:
    default:
      mode: user
      auth:
        type: oauth2
```

A non-user identity token is still denied from that provider shape in this phase.

## Behavior Examples

HTTP example:

```http
POST /api/v1/identities/{identityID}/tokens
Authorization: Bearer <human session>
Content-Type: application/json

{
  "name": "invoke-token",
  "permissions": [
    {"plugin": "alpha", "operations": ["read"]},
    {"plugin": "beta", "operations": ["query"]}
  ]
}
```

That token now authenticates through canonical identity state:

- `identity_id = <identityID>`
- `subject_id = managed_identity:<identityID>`
- `subject_kind = service_account`
- effective invocation permissions = canonical `identity_plugin_access` intersect token permissions

MCP example:

- `_instance` override rejection now applies consistently to all non-user callers, not just static workloads
- nested providerhost calls no longer recover human-style selector inheritance for non-user identity subjects

## Validation

- `go test ./internal/server -run 'TestManagedIdentityTokens_RoleMatrix|TestManagedIdentityAPITokenInvocation_ModeNoneOnly|TestCookieAuth|TestWorkloadAuthorization_ListOperationsFiltersAndRejectsSelectors|TestWorkloadAuthorization_ExecuteOperation_UsesBoundIdentityAndRejectsSelectors' -count=1`
- `go test ./internal/mcp -run 'TestNewServer_WorkloadCallToolUsesBoundConnectionForSessionOnlyProvider|TestNewServer_WorkloadCallToolRejectsInstanceOverride' -count=1`
- `go test ./internal/providerhost -run 'TestRemoteProviderRoundTripRequestContext|TestRequestContextProto_PreservesWorkloadDisplayName|TestPrincipalFromProto_WorkloadDisplayNameDoesNotCreateIdentity' -count=1`
- `go test ./internal/invocation -run 'TestBrokerResolveToken_ConnectionModeNoneResolvesSessionUserSubject|TestBrokerResolveToken_WorkflowContextDoesNotBypassWorkloadIdentityBinding' -count=1`
- `go test ./... -run '^$'`
- `golangci-lint run`
