### PR TITLE
Fix follow-up regressions from metadata source rollout

### DIFF
--- a/gestaltd/internal/config/config.go
+++ b/gestaltd/internal/config/config.go
@@ -1563,9 +1563,15 @@ func normalizeProviderSource(kind string, source *ProviderSource, useV3Classific
 func isBuiltinScalarSource(kind, source string) bool {
 	switch kind {
 	case providermanifestv1.KindSecrets:
-		return source == "env"
+		switch source {
+		case "env", "file":
+			return true
+		}
 	case string(HostProviderKindTelemetry):
-		return source == "stdout"
+		switch source {
+		case "noop", "stdout", "otlp":
+			return true
+		}
 	case string(HostProviderKindAudit):
 		switch source {
 		case "inherit", "noop", "stdout", "otlp":

--- a/gestaltd/internal/config/config_test.go
+++ b/gestaltd/internal/config/config_test.go
@@ -1052,6 +1052,43 @@ plugins:
 			t.Fatalf("config round-tripped auth = %#v", plugin["auth"])
 		}
 	})
+
+	t.Run("apiVersion preserves builtin scalar host provider sources", func(t *testing.T) {
+		t.Parallel()
+
+		path := mustWriteConfigFile(t, `
+apiVersion: gestaltd.config/v3
+providers:
+  secrets:
+    default:
+      source: file
+      config:
+        dir: /tmp/gestalt-secrets
+  telemetry:
+    default:
+      source: otlp
+      config:
+        endpoint: otel-collector:4317
+plugins:
+`)
+
+		cfg, err := Load(path)
+		if err != nil {
+			t.Fatalf("Load: %v", err)
+		}
+		if got := cfg.Providers.Secrets["default"].Source.Builtin; got != "file" {
+			t.Fatalf("secrets builtin = %q, want %q", got, "file")
+		}
+		if got := cfg.Providers.Telemetry["default"].Source.Builtin; got != "otlp" {
+			t.Fatalf("telemetry builtin = %q, want %q", got, "otlp")
+		}
+		if cfg.Providers.Secrets["default"].Source.Path != "" {
+			t.Fatalf("secrets path = %q, want empty", cfg.Providers.Secrets["default"].Source.Path)
+		}
+		if cfg.Providers.Telemetry["default"].Source.Path != "" {
+			t.Fatalf("telemetry path = %q, want empty", cfg.Providers.Telemetry["default"].Source.Path)
+		}
+	})
 }
 
 func TestLoadConfigUIEntries(t *testing.T) {

--- a/gestaltd/internal/operator/lifecycle.go
+++ b/gestaltd/internal/operator/lifecycle.go
@@ -1295,7 +1295,7 @@ func (l *Lifecycle) buildArchivesMap(ctx context.Context, src pluginsource.Sourc
 	}
 	platformArchives, err := enumerator.ListPlatformArchives(ctx, src, version)
 	if err != nil {
-		if !allowsGenericArchive(kind, manifest) {
+		if !allowsGenericArchive(archivePolicyKind(kind), manifest) {
 			return nil, fmt.Errorf("enumerate platform archives for %s: %w", subject, err)
 		}
 		slog.Warn("failed to enumerate platform archives; lockfile will only contain current platform", "error", err)

--- a/gestaltd/internal/operator/lifecycle.go
+++ b/gestaltd/internal/operator/lifecycle.go
@@ -1311,7 +1311,7 @@ func (l *Lifecycle) buildArchivesMap(ctx context.Context, src pluginsource.Sourc
 		}
 		archives[pa.Platform] = LockArchive{URL: pa.URL}
 	}
-	if err := validateResolvedArchivePolicy(subject, kind, manifest, currentPlatform, currentURL, available); err != nil {
+	if err := validateResolvedArchivePolicy(subject, archivePolicyKind(kind), manifest, currentPlatform, currentURL, available); err != nil {
 		return nil, err
 	}
 	return archives, nil
@@ -2377,7 +2377,7 @@ func (l *Lifecycle) applyLockedComponentEntry(paths initPaths, entry *LockEntry,
 	if err == nil && !needMaterialize {
 		platform := providerpkg.CurrentPlatformString()
 		if _, resolvedKey, ok := resolveArchiveForPlatform(*entry, platform); ok {
-			if policyErr := validateLockedArchivePolicy(fmt.Sprintf("%s %q", kind, name), kind, install.manifest, *entry, platform, resolvedKey); policyErr != nil {
+			if policyErr := validateLockedArchivePolicy(fmt.Sprintf("%s %q", kind, name), archivePolicyKind(kind), install.manifest, *entry, platform, resolvedKey); policyErr != nil {
 				return policyErr
 			}
 		}
@@ -2560,7 +2560,7 @@ func (l *Lifecycle) materializeLockedComponent(ctx context.Context, paths initPa
 	if installed.Manifest.Version != entry.Version {
 		return fmt.Errorf("locked source provider manifest version mismatch for %s %q: got %q, want %q", kind, name, installed.Manifest.Version, entry.Version)
 	}
-	if err := validateLockedArchivePolicy(fmt.Sprintf("%s %q", kind, name), kind, installed.Manifest, entry, platform, resolvedKey); err != nil {
+	if err := validateLockedArchivePolicy(fmt.Sprintf("%s %q", kind, name), archivePolicyKind(kind), installed.Manifest, entry, platform, resolvedKey); err != nil {
 		return err
 	}
 	if err := commitInstall(); err != nil {

--- a/gestaltd/internal/operator/lifecycle_source_test.go
+++ b/gestaltd/internal/operator/lifecycle_source_test.go
@@ -1358,6 +1358,250 @@ func TestSourcePluginMetadataURLUsesGitHubAssetTransport(t *testing.T) {
 	}
 }
 
+func TestSourcePluginMetadataURLUsesGitHubTokenFallbackForMetadata(t *testing.T) {
+	dir := t.TempDir()
+	t.Setenv("GITHUB_TOKEN", "env-fallback-token")
+
+	const packageSource = testSource
+	const version = testVersion
+
+	currentArchivePath := buildV2Archive(t, dir, packageSource, version, "metadata-github-fallback-plugin-binary")
+	currentArchiveData, err := os.ReadFile(currentArchivePath)
+	if err != nil {
+		t.Fatalf("read current archive: %v", err)
+	}
+	currentArchiveSHA := sha256.Sum256(currentArchiveData)
+
+	var metadataCount atomic.Int64
+	var archiveCount atomic.Int64
+	handlerErrs := make(chan error, 4)
+	nextHandlerErr := func() error {
+		t.Helper()
+		select {
+		case err := <-handlerErrs:
+			return err
+		default:
+			return nil
+		}
+	}
+
+	metadataPath := "/" + testOwner + "/" + testRepo + "/releases/download/plugin/" + testPlugin + "/" + version + "/provider-release.yaml"
+	metadataURL := "https://github.com" + metadataPath
+	githubArchiveURL := "https://api.github.com/repos/" + testOwner + "/" + testRepo + "/releases/assets/456"
+	githubArchivePath := "/repos/" + testOwner + "/" + testRepo + "/releases/assets/456"
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch r.URL.Path {
+		case metadataPath:
+			metadataCount.Add(1)
+			if got := r.Header.Get("Authorization"); got != "token env-fallback-token" {
+				handlerErrs <- fmt.Errorf("metadata authorization = %q, want %q", got, "token env-fallback-token")
+				http.Error(w, "bad metadata authorization", http.StatusBadRequest)
+				return
+			}
+			metadata := providerReleaseMetadata{
+				Schema:        providerReleaseSchemaName,
+				SchemaVersion: providerReleaseSchemaVersion,
+				Package:       packageSource,
+				Kind:          providermanifestv1.KindPlugin,
+				Version:       version,
+				Runtime:       providerReleaseRuntimeExecutable,
+				Artifacts: map[string]providerReleaseArtifact{
+					providerpkg.CurrentPlatformString(): {
+						Path:   githubArchiveURL,
+						SHA256: hex.EncodeToString(currentArchiveSHA[:]),
+					},
+				},
+			}
+			data, err := yaml.Marshal(metadata)
+			if err != nil {
+				handlerErrs <- fmt.Errorf("marshal metadata: %v", err)
+				http.Error(w, "metadata marshal failed", http.StatusInternalServerError)
+				return
+			}
+			w.Header().Set("Content-Type", "application/yaml")
+			_, _ = w.Write(data)
+		case githubArchivePath:
+			archiveCount.Add(1)
+			if got := r.Header.Get("Authorization"); got != "token env-fallback-token" {
+				handlerErrs <- fmt.Errorf("archive authorization = %q, want %q", got, "token env-fallback-token")
+				http.Error(w, "bad archive authorization", http.StatusBadRequest)
+				return
+			}
+			if got := r.Header.Get("Accept"); got != "application/octet-stream" {
+				handlerErrs <- fmt.Errorf("archive accept = %q, want %q", got, "application/octet-stream")
+				http.Error(w, "bad archive accept", http.StatusBadRequest)
+				return
+			}
+			w.Header().Set("Content-Type", "application/octet-stream")
+			_, _ = w.Write(currentArchiveData)
+		default:
+			http.NotFound(w, r)
+		}
+	}))
+	defer srv.Close()
+
+	artifactsDir := filepath.Join(dir, "prepared-artifacts")
+	configPath := filepath.Join(dir, "gestalt.yaml")
+	configYAML := requiredComponentConfigYAML(t, dir, filepath.Join(dir, "data.db")) + strings.Join([]string{
+		"apiVersion: " + config.APIVersionV3,
+		"plugins:",
+		"  alpha:",
+		"    source: " + metadataURL,
+		"server:",
+		"  providers:",
+		"    indexeddb: sqlite",
+		"  artifactsDir: " + artifactsDir,
+		"  encryptionKey: aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
+	}, "\n") + "\n"
+	if err := os.WriteFile(configPath, []byte(configYAML), 0o644); err != nil {
+		t.Fatalf("write config: %v", err)
+	}
+
+	lc := NewLifecycle(nil).WithHTTPClient(newGitHubRewriteClient(t, srv.URL))
+	lock, err := lc.InitAtPath(configPath)
+	if err == nil {
+		if handlerErr := nextHandlerErr(); handlerErr != nil {
+			t.Fatal(handlerErr)
+		}
+	}
+	if err != nil {
+		t.Fatalf("InitAtPath: %v", err)
+	}
+	if handlerErr := nextHandlerErr(); handlerErr != nil {
+		t.Fatal(handlerErr)
+	}
+	if got := metadataCount.Load(); got != 1 {
+		t.Fatalf("metadata request count = %d, want 1", got)
+	}
+	if got := archiveCount.Load(); got != 1 {
+		t.Fatalf("archive request count = %d, want 1", got)
+	}
+	if got := lock.Providers["alpha"].Source; got != metadataURL {
+		t.Fatalf("entry.Source = %q, want %q", got, metadataURL)
+	}
+}
+
+func TestBuildArchivesMap_AllowsGenericDeclarativeTelemetryAndAuditPackages(t *testing.T) {
+	t.Parallel()
+
+	const source = "github.com/acme/providers/declarative"
+	const version = "1.0.0"
+	const archiveURL = "https://example.com/releases/download/provider/declarative.tar.gz"
+
+	src, err := pluginsource.Parse(source)
+	if err != nil {
+		t.Fatalf("Parse source: %v", err)
+	}
+	manifest := &providermanifestv1.Manifest{
+		Kind:    providermanifestv1.KindPlugin,
+		Source:  source,
+		Version: version,
+		Spec: &providermanifestv1.Spec{
+			Surfaces: &providermanifestv1.ProviderSurfaces{
+				REST: &providermanifestv1.RESTSurface{
+					BaseURL: "https://api.example.com",
+					Operations: []providermanifestv1.ProviderOperation{
+						{Name: "ping", Method: "GET", Path: "/ping"},
+					},
+				},
+			},
+		},
+	}
+	resolver := &fakeMultiResolver{
+		results: map[string]fakeResolverResult{
+			src.String(): {
+				platformArchives: []pluginsource.PlatformArchive{
+					{Platform: platformKeyGeneric, URL: archiveURL},
+				},
+			},
+		},
+	}
+	lc := NewLifecycle(resolver)
+
+	for _, kind := range []string{providerLockKindTelemetry, providerLockKindAudit} {
+		kind := kind
+		t.Run(kind, func(t *testing.T) {
+			archives, err := lc.buildArchivesMap(context.Background(), src, version, archiveURL, "", kind, kind+` "default"`, manifest)
+			if err != nil {
+				t.Fatalf("buildArchivesMap: %v", err)
+			}
+			if got := archives[platformKeyGeneric].URL; got != archiveURL {
+				t.Fatalf("generic archive URL = %q, want %q", got, archiveURL)
+			}
+		})
+	}
+}
+
+func TestMaterializeLockedComponent_AllowsGenericDeclarativeTelemetryAndAuditPackages(t *testing.T) {
+	t.Parallel()
+
+	dir := t.TempDir()
+	const source = "github.com/acme/providers/declarative"
+	const version = "1.0.0"
+
+	pkgPath := mustBuildManagedProviderPackage(t, dir, &providermanifestv1.Manifest{
+		Kind:    providermanifestv1.KindPlugin,
+		Source:  source,
+		Version: version,
+		Spec: &providermanifestv1.Spec{
+			Surfaces: &providermanifestv1.ProviderSurfaces{
+				REST: &providermanifestv1.RESTSurface{
+					BaseURL: "https://api.example.com",
+					Operations: []providermanifestv1.ProviderOperation{
+						{Name: "ping", Method: "GET", Path: "/ping"},
+					},
+				},
+			},
+		},
+	}, nil, false)
+	pkgData, err := os.ReadFile(pkgPath)
+	if err != nil {
+		t.Fatalf("read package: %v", err)
+	}
+	pkgSum := sha256.Sum256(pkgData)
+
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/octet-stream")
+		_, _ = w.Write(pkgData)
+	}))
+	defer srv.Close()
+
+	lc := NewLifecycle(nil)
+	entry := LockEntry{
+		Source:  source,
+		Version: version,
+		Archives: map[string]LockArchive{
+			platformKeyGeneric: {
+				URL:    srv.URL,
+				SHA256: hex.EncodeToString(pkgSum[:]),
+			},
+		},
+	}
+	providerEntry := &config.ProviderEntry{
+		Source: config.ProviderSource{
+			Ref:     source,
+			Version: version,
+		},
+	}
+
+	for _, kind := range []string{providerLockKindTelemetry, providerLockKindAudit} {
+		kind := kind
+		t.Run(kind, func(t *testing.T) {
+			destDir := filepath.Join(dir, kind)
+			if err := lc.materializeLockedComponent(context.Background(), initPaths{}, kind, "default", providerEntry, entry, destDir, true); err != nil {
+				t.Fatalf("materializeLockedComponent: %v", err)
+			}
+			install, err := inspectPreparedInstall(destDir)
+			if err != nil {
+				t.Fatalf("inspectPreparedInstall: %v", err)
+			}
+			if install.manifest == nil || !install.manifest.IsDeclarativeOnlyProvider() {
+				t.Fatalf("prepared manifest = %#v, want declarative manifest", install.manifest)
+			}
+		})
+	}
+}
+
 func TestSourcePluginMetadataURLUnlockedLoadRefreshesMutableMetadata(t *testing.T) {
 	t.Parallel()
 

--- a/gestaltd/internal/operator/lifecycle_source_test.go
+++ b/gestaltd/internal/operator/lifecycle_source_test.go
@@ -1562,12 +1562,6 @@ func TestMaterializeLockedComponent_AllowsGenericDeclarativeTelemetryAndAuditPac
 	}
 	pkgSum := sha256.Sum256(pkgData)
 
-	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		w.Header().Set("Content-Type", "application/octet-stream")
-		_, _ = w.Write(pkgData)
-	}))
-	defer srv.Close()
-
 	lc := NewLifecycle(nil)
 
 	for _, kind := range []string{providerLockKindTelemetry, providerLockKindAudit} {

--- a/gestaltd/internal/operator/lifecycle_source_test.go
+++ b/gestaltd/internal/operator/lifecycle_source_test.go
@@ -1521,6 +1521,8 @@ func TestBuildArchivesMap_AllowsGenericDeclarativeTelemetryAndAuditPackages(t *t
 	for _, kind := range []string{providerLockKindTelemetry, providerLockKindAudit} {
 		kind := kind
 		t.Run(kind, func(t *testing.T) {
+			t.Parallel()
+
 			archives, err := lc.buildArchivesMap(context.Background(), src, version, archiveURL, "", kind, kind+` "default"`, manifest)
 			if err != nil {
 				t.Fatalf("buildArchivesMap: %v", err)
@@ -1567,26 +1569,34 @@ func TestMaterializeLockedComponent_AllowsGenericDeclarativeTelemetryAndAuditPac
 	defer srv.Close()
 
 	lc := NewLifecycle(nil)
-	entry := LockEntry{
-		Source:  source,
-		Version: version,
-		Archives: map[string]LockArchive{
-			platformKeyGeneric: {
-				URL:    srv.URL,
-				SHA256: hex.EncodeToString(pkgSum[:]),
-			},
-		},
-	}
-	providerEntry := &config.ProviderEntry{
-		Source: config.ProviderSource{
-			Ref:     source,
-			Version: version,
-		},
-	}
 
 	for _, kind := range []string{providerLockKindTelemetry, providerLockKindAudit} {
 		kind := kind
 		t.Run(kind, func(t *testing.T) {
+			t.Parallel()
+
+			srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+				w.Header().Set("Content-Type", "application/octet-stream")
+				_, _ = w.Write(pkgData)
+			}))
+			defer srv.Close()
+
+			entry := LockEntry{
+				Source:  source,
+				Version: version,
+				Archives: map[string]LockArchive{
+					platformKeyGeneric: {
+						URL:    srv.URL,
+						SHA256: hex.EncodeToString(pkgSum[:]),
+					},
+				},
+			}
+			providerEntry := &config.ProviderEntry{
+				Source: config.ProviderSource{
+					Ref:     source,
+					Version: version,
+				},
+			}
 			destDir := filepath.Join(dir, kind)
 			if err := lc.materializeLockedComponent(context.Background(), initPaths{}, kind, "default", providerEntry, entry, destDir, true); err != nil {
 				t.Fatalf("materializeLockedComponent: %v", err)

--- a/gestaltd/internal/operator/release_metadata.go
+++ b/gestaltd/internal/operator/release_metadata.go
@@ -130,9 +130,8 @@ func fetchProviderReleaseMetadata(ctx context.Context, client *http.Client, meta
 	if err != nil {
 		return nil, fmt.Errorf("create provider release metadata request: %w", err)
 	}
-	token = strings.TrimSpace(token)
-	if token != "" {
-		req.Header.Set(httpAuthorizationHeader, httpBearerAuthorizationPrefix+token)
+	if authHeader := authorizationHeaderForSourceLocation(metadataURL, token); authHeader != "" {
+		req.Header.Set(httpAuthorizationHeader, authHeader)
 	}
 	resp, err := client.Do(req)
 	if err != nil {
@@ -251,4 +250,32 @@ func downloadArchiveForSource(ctx context.Context, client *http.Client, sourceLo
 		req.Header.Set(httpAuthorizationHeader, httpBearerAuthorizationPrefix+token)
 	}
 	return providerpkg.DownloadRequest(client, req)
+}
+
+func authorizationHeaderForSourceLocation(sourceLocation, token string) string {
+	token = strings.TrimSpace(token)
+	if usesGitHubMetadataTransport(sourceLocation) {
+		token = ghresolver.ResolveGitHubToken(token)
+		if token == "" {
+			return ""
+		}
+		return "token " + token
+	}
+	if token == "" {
+		return ""
+	}
+	return httpBearerAuthorizationPrefix + token
+}
+
+func usesGitHubMetadataTransport(sourceLocation string) bool {
+	parsed, err := url.Parse(strings.TrimSpace(sourceLocation))
+	if err != nil {
+		return false
+	}
+	switch strings.ToLower(parsed.Hostname()) {
+	case "github.com", "api.github.com":
+		return true
+	default:
+		return false
+	}
 }

--- a/gestaltd/internal/pluginsource/github/resolver.go
+++ b/gestaltd/internal/pluginsource/github/resolver.go
@@ -62,7 +62,7 @@ type GitHubResolver struct {
 	HTTPClient *http.Client
 }
 
-func resolveGitHubToken(token string) string {
+func ResolveGitHubToken(token string) string {
 	for _, candidate := range []string{
 		strings.TrimSpace(token),
 		strings.TrimSpace(os.Getenv("GITHUB_TOKEN")),
@@ -84,7 +84,7 @@ func (r *GitHubResolver) Resolve(ctx context.Context, src pluginsource.Source, v
 	if client == nil {
 		client = http.DefaultClient
 	}
-	token := resolveGitHubToken(src.Token)
+	token := ResolveGitHubToken(src.Token)
 
 	tag := src.ReleaseTag(version)
 	releaseURL := fmt.Sprintf("%s/repos/%s/releases/tags/%s", baseURL, src.RepoSlug(), url.PathEscape(tag))
@@ -123,7 +123,7 @@ func (r *GitHubResolver) ListPlatformArchives(ctx context.Context, src pluginsou
 	if client == nil {
 		client = http.DefaultClient
 	}
-	token := resolveGitHubToken(src.Token)
+	token := ResolveGitHubToken(src.Token)
 
 	tag := src.ReleaseTag(version)
 	releaseURL := fmt.Sprintf("%s/repos/%s/releases/tags/%s", baseURL, src.RepoSlug(), url.PathEscape(tag))
@@ -354,7 +354,7 @@ func DownloadResolvedAsset(ctx context.Context, client *http.Client, assetURL, t
 	if client == nil {
 		client = http.DefaultClient
 	}
-	token = resolveGitHubToken(token)
+	token = ResolveGitHubToken(token)
 	req, err := http.NewRequestWithContext(ctx, http.MethodGet, assetURL, nil)
 	if err != nil {
 		return nil, fmt.Errorf("create asset download request: %w", err)


### PR DESCRIPTION
## Summary
- preserve documented builtin scalar sources in `apiVersion: gestaltd.config/v3` configs
- apply plugin archive policy semantics when telemetry/audit entries carry declarative generic archives
- reuse GitHub token fallback for GitHub-hosted metadata URL fetches

## Details
This follows up on regressions introduced after `#1105` and `#1106` merged:
- `providers.secrets.*.source: file` and `providers.telemetry.*.source: otlp|noop|stdout` were being misclassified as local paths under v3
- declarative generic telemetry/audit archives were still rejected because some operator call sites passed the raw bucket kind instead of the archive policy kind
- private GitHub-hosted `provider-release.yaml` URLs no longer picked up `GITHUB_TOKEN` / `GH_TOKEN` unless inline auth was present

## Testing
- `go test ./internal/config`
- `go test ./internal/operator`
- `go test ./internal/pluginsource/github`