### PR TITLE
Bootstrap metadata-backed secrets providers and v3 telemetry builtins

### DIFF
--- a/gestaltd/cmd/gestaltd/e2e_test.go
+++ b/gestaltd/cmd/gestaltd/e2e_test.go
@@ -125,6 +125,70 @@ func TestE2EValidateRejectsInvalidAuditSettings(t *testing.T) {
 	}
 }
 
+func TestE2EValidateAcceptsV3TelemetryBuiltins(t *testing.T) {
+	t.Parallel()
+
+	cases := []struct {
+		name           string
+		source         string
+		telemetryBlock string
+	}{
+		{
+			name:   "otlp",
+			source: "otlp",
+			telemetryBlock: `      config:
+        endpoint: localhost:4317
+        protocol: grpc
+        insecure: true`,
+		},
+		{
+			name:   "noop",
+			source: "noop",
+		},
+	}
+
+	for _, tc := range cases {
+		tc := tc
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+
+			dir := t.TempDir()
+			indexedDBManifest := componentProviderManifestPath(t, setupIndexedDBProviderDir(t, dir))
+			pluginManifest := componentProviderManifestPath(t, setupPrebuiltPluginDir(t, dir))
+
+			cfgPath := filepath.Join(dir, "config.yaml")
+			cfg := fmt.Sprintf(`apiVersion: %s
+server:
+  encryptionKey: valid-config-e2e-key
+  providers:
+    telemetry: primary
+    indexeddb: inmem
+providers:
+  telemetry:
+    primary:
+      source: %s
+%s
+  indexeddb:
+    inmem:
+      source:
+        path: %s
+plugins:
+  example:
+    source:
+      path: %s
+`, config.APIVersionV3, tc.source, tc.telemetryBlock, indexedDBManifest, pluginManifest)
+			if err := os.WriteFile(cfgPath, []byte(cfg), 0o644); err != nil {
+				t.Fatalf("write config: %v", err)
+			}
+
+			out, err := exec.Command(gestaltdBin, "validate", "--config", cfgPath).CombinedOutput()
+			if err != nil {
+				t.Fatalf("gestaltd validate failed: %v\noutput: %s", err, out)
+			}
+		})
+	}
+}
+
 func TestE2EValidateRejectsInvalidConfigInput(t *testing.T) {
 	t.Parallel()
 

--- a/gestaltd/internal/bootstrap/bootstrap.go
+++ b/gestaltd/internal/bootstrap/bootstrap.go
@@ -766,7 +766,7 @@ func buildNamedSecretManager(name string, secrets *config.ProviderEntry, factori
 		logicalName = "secrets"
 	}
 
-	if secrets != nil && (secrets.Source.IsManaged() || secrets.Source.IsLocal()) {
+	if secrets != nil && (secrets.HasRemoteSource() || secrets.HasLocalSource()) {
 		factory, ok := factories.Secrets["provider"]
 		if !ok {
 			return nil, fmt.Errorf("bootstrap: secrets provider factory is not registered")

--- a/gestaltd/internal/config/config.go
+++ b/gestaltd/internal/config/config.go
@@ -1565,7 +1565,10 @@ func isBuiltinScalarSource(kind, source string) bool {
 	case providermanifestv1.KindSecrets:
 		return source == "env"
 	case string(HostProviderKindTelemetry):
-		return source == "stdout"
+		switch source {
+		case "noop", "stdout", "otlp":
+			return true
+		}
 	case string(HostProviderKindAudit):
 		switch source {
 		case "inherit", "noop", "stdout", "otlp":

--- a/gestaltd/internal/operator/lifecycle_source_test.go
+++ b/gestaltd/internal/operator/lifecycle_source_test.go
@@ -2797,6 +2797,121 @@ func TestLoadForExecutionAtPath_UnlockedBootstrapMetadataInitPreparesOnce(t *tes
 	}
 }
 
+func TestLoadForExecutionAtPath_UnlockedMetadataSecretsProviderResolvesConfigSecrets(t *testing.T) {
+	t.Parallel()
+
+	dir := t.TempDir()
+	secretsSource := "github.com/acme/tools/secrets-widget"
+	secretsVersion := "1.0.0"
+
+	secretsArchivePath := buildExecutableArchiveFromBinaryPath(
+		t,
+		dir,
+		"secrets-metadata-src",
+		secretsSource,
+		secretsVersion,
+		providermanifestv1.KindSecrets,
+		"secrets-plugin",
+		buildGoSourceSecretsBinary(t),
+	)
+	secretsArchiveData, err := os.ReadFile(secretsArchivePath)
+	if err != nil {
+		t.Fatalf("read secrets archive: %v", err)
+	}
+	secretsArchiveSum := sha256.Sum256(secretsArchiveData)
+
+	var metadataCount atomic.Int64
+	var archiveCount atomic.Int64
+	metadataPath := "/providers/secrets/provider-release.yaml"
+	archivePathURL := "/providers/secrets/secrets-current.tar.gz"
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch r.URL.Path {
+		case metadataPath:
+			metadataCount.Add(1)
+			metadata := providerReleaseMetadata{
+				Schema:        providerReleaseSchemaName,
+				SchemaVersion: providerReleaseSchemaVersion,
+				Package:       secretsSource,
+				Kind:          providermanifestv1.KindSecrets,
+				Version:       secretsVersion,
+				Runtime:       providerReleaseRuntimeExecutable,
+				Artifacts: map[string]providerReleaseArtifact{
+					providerpkg.CurrentPlatformString(): {
+						Path:   filepath.Base(archivePathURL),
+						SHA256: hex.EncodeToString(secretsArchiveSum[:]),
+					},
+				},
+			}
+			data, err := yaml.Marshal(metadata)
+			if err != nil {
+				http.Error(w, "metadata marshal failed", http.StatusInternalServerError)
+				return
+			}
+			w.Header().Set("Content-Type", "application/yaml")
+			_, _ = w.Write(data)
+		case archivePathURL:
+			archiveCount.Add(1)
+			w.Header().Set("Content-Type", "application/octet-stream")
+			_, _ = w.Write(secretsArchiveData)
+		default:
+			http.NotFound(w, r)
+		}
+	}))
+	defer srv.Close()
+
+	artifactsDir := filepath.Join(dir, "prepared-artifacts")
+	configYAML := strings.Join([]string{
+		"apiVersion: " + config.APIVersionV3,
+		requiredIndexedDBConfigYAML(t, dir, filepath.Join(dir, "data.db")),
+		"  secrets:",
+		"    secrets:",
+		"      source: " + srv.URL + metadataPath + "?download=1",
+		"server:",
+		"  providers:",
+		"    indexeddb: sqlite",
+		"    secrets: secrets",
+		"  artifactsDir: " + artifactsDir,
+		"  encryptionKey:",
+		"    secret:",
+		"      provider: secrets",
+		"      name: source-token",
+	}, "\n") + "\n"
+
+	configPath := filepath.Join(dir, "gestalt.yaml")
+	if err := os.WriteFile(configPath, []byte(configYAML), 0o644); err != nil {
+		t.Fatalf("write config: %v", err)
+	}
+
+	factories := bootstrap.NewFactoryRegistry()
+	factories.Secrets["provider"] = secretsprovider.Factory
+
+	lc := NewLifecycle(nil).WithConfigSecretResolver(func(ctx context.Context, cfg *config.Config) error {
+		return bootstrap.ResolveConfigSecrets(ctx, cfg, factories)
+	})
+
+	cfg, _, err := lc.LoadForExecutionAtPath(configPath, false)
+	if err != nil {
+		t.Fatalf("LoadForExecutionAtPath(locked=false): %v", err)
+	}
+	if got := metadataCount.Load(); got != 1 {
+		t.Fatalf("metadata request count = %d, want 1", got)
+	}
+	if got := archiveCount.Load(); got != 1 {
+		t.Fatalf("archive request count = %d, want 1", got)
+	}
+	if got := cfg.Server.EncryptionKey; got != "ghp_inline_auth_source_token" {
+		t.Fatalf("resolved encryption key = %q, want %q", got, "ghp_inline_auth_source_token")
+	}
+
+	secretsProvider := mustSelectedHostProviderEntry(t, cfg, config.HostProviderKindSecrets)
+	if secretsProvider == nil {
+		t.Fatal("secrets provider is nil after load")
+	}
+	if secretsProvider.Command == "" {
+		t.Fatal("secrets provider command is empty after load")
+	}
+}
+
 func TestSourcePluginGitHubResolverEndToEnd(t *testing.T) {
 	t.Setenv("GITHUB_TOKEN", "wrong-env-token")
 


### PR DESCRIPTION
## Summary
This fixes the last compatibility gaps for the provider-release metadata rollout in `gestaltd`:

- bootstrap metadata-backed `secrets` providers before config secret resolution
- recognize `apiVersion: gestaltd.config/v3` telemetry builtin scalars for `noop`, `stdout`, and `otlp`
- keep the locked/unlocked source-loading path on the resolved provider binary contract

## New interfaces

### V3 telemetry builtin scalars
```yaml
apiVersion: gestaltd.config/v3

providers:
  telemetry:
    primary:
      source: otlp
      config:
        endpoint: localhost:4317
        protocol: grpc
        insecure: true
```

```yaml
apiVersion: gestaltd.config/v3

providers:
  telemetry:
    primary:
      source: noop
```

### Metadata-backed secrets provider for config secret resolution
```yaml
apiVersion: gestaltd.config/v3

providers:
  secrets:
    secrets:
      source: https://github.com/valon-technologies/gestalt-providers/releases/download/secrets/google/v0.0.1-alpha.1/provider-release.yaml

server:
  providers:
    secrets: secrets
  encryptionKey:
    secret:
      provider: secrets
      name: gestalt-encryption-key
```

## Verification
- `go test ./cmd/gestaltd -run 'TestE2EValidateAcceptsV3TelemetryBuiltins' -count=1`
- `go test ./internal/operator -run 'TestLoadForExecutionAtPath_UnlockedMetadataSecretsProviderResolvesConfigSecrets|TestLoadForExecutionAtPath_UnlockedBootstrapMetadataInitPreparesOnce' -count=1`

## Notes
The tests are end-to-end/contract coverage only:
- CLI validation for v3 builtin telemetry sources
- metadata fetch -> archive fetch -> bootstrap -> config secret resolution for metadata-backed secrets providers