### PR TITLE
gestaltd: back human authorization with providers

### DIFF
--- a/gestaltd/internal/authorization/authorizer.go
+++ b/gestaltd/internal/authorization/authorizer.go
@@ -341,24 +341,24 @@ func (a *Authorizer) IsWorkload(p *principal.Principal) bool {
 	return p != nil && p.Kind == principal.KindWorkload
 }
 
-func (a *Authorizer) AllowProvider(p *principal.Principal, provider string) bool {
+func (a *Authorizer) AllowProvider(ctx context.Context, p *principal.Principal, provider string) bool {
 	if a.isManagedIdentityPrincipal(p) {
 		return a.allowManagedIdentityProvider(p, provider)
 	}
 	if !a.IsWorkload(p) {
-		_, allowed := a.ResolveAccess(p, provider)
+		_, allowed := a.ResolveAccess(ctx, p, provider)
 		return allowed
 	}
 	_, ok := a.bindingForSubject(p, provider)
 	return ok
 }
 
-func (a *Authorizer) AllowOperation(p *principal.Principal, provider, operation string) bool {
+func (a *Authorizer) AllowOperation(ctx context.Context, p *principal.Principal, provider, operation string) bool {
 	if a.isManagedIdentityPrincipal(p) {
 		return a.allowManagedIdentityProvider(p, provider) && principal.AllowsOperationPermission(p, provider, operation)
 	}
 	if !a.IsWorkload(p) {
-		return a.AllowProvider(p, provider)
+		return a.AllowProvider(ctx, p, provider)
 	}
 	binding, ok := a.bindingForSubject(p, provider)
 	if !ok {
@@ -385,7 +385,7 @@ func (a *Authorizer) Binding(p *principal.Principal, provider string) (Credentia
 	return binding.CredentialBinding, true
 }
 
-func (a *Authorizer) ResolveAccess(p *principal.Principal, provider string) (AccessContext, bool) {
+func (a *Authorizer) ResolveAccess(_ context.Context, p *principal.Principal, provider string) (AccessContext, bool) {
 	if a == nil {
 		return AccessContext{}, true
 	}
@@ -397,7 +397,7 @@ func (a *Authorizer) ResolveAccess(p *principal.Principal, provider string) (Acc
 		return AccessContext{}, true
 	}
 	if a.IsWorkload(p) {
-		return a.ResolvePolicyAccess(p, policyName)
+		return a.ResolvePolicyAccess(context.Background(), p, policyName)
 	}
 
 	policy := a.policies[policyName]
@@ -499,7 +499,7 @@ func (a *Authorizer) StaticMembersForProvider(provider string) (string, []Static
 	return policyName, members, true
 }
 
-func (a *Authorizer) ResolvePolicyAccess(p *principal.Principal, policyName string) (AccessContext, bool) {
+func (a *Authorizer) ResolvePolicyAccess(_ context.Context, p *principal.Principal, policyName string) (AccessContext, bool) {
 	if a == nil {
 		return AccessContext{}, true
 	}
@@ -525,7 +525,7 @@ func (a *Authorizer) ResolvePolicyAccess(p *principal.Principal, policyName stri
 	return access, false
 }
 
-func (a *Authorizer) ResolveAdminAccess(p *principal.Principal, policyName string) (AccessContext, bool) {
+func (a *Authorizer) ResolveAdminAccess(_ context.Context, p *principal.Principal, policyName string) (AccessContext, bool) {
 	if a == nil {
 		return AccessContext{}, true
 	}
@@ -556,14 +556,14 @@ func (a *Authorizer) ResolveAdminAccess(p *principal.Principal, policyName strin
 	return access, false
 }
 
-func (a *Authorizer) AllowCatalogOperation(p *principal.Principal, provider string, op catalog.CatalogOperation) bool {
+func (a *Authorizer) AllowCatalogOperation(ctx context.Context, p *principal.Principal, provider string, op catalog.CatalogOperation) bool {
 	if a.isManagedIdentityPrincipal(p) {
 		return a.allowManagedIdentityProvider(p, provider) && principal.AllowsOperationPermission(p, provider, op.ID)
 	}
 	if a.IsWorkload(p) {
-		return a.AllowOperation(p, provider, op.ID)
+		return a.AllowOperation(ctx, p, provider, op.ID)
 	}
-	access, allowed := a.ResolveAccess(p, provider)
+	access, allowed := a.ResolveAccess(ctx, p, provider)
 	if !allowed {
 		return false
 	}

--- a/gestaltd/internal/authorization/provider_backed.go
+++ b/gestaltd/internal/authorization/provider_backed.go
@@ -1,0 +1,963 @@
+package authorization
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"log/slog"
+	"sort"
+	"strings"
+	"sync"
+	"time"
+
+	"github.com/valon-technologies/gestalt/server/core"
+	"github.com/valon-technologies/gestalt/server/core/catalog"
+	"github.com/valon-technologies/gestalt/server/internal/emailutil"
+	"github.com/valon-technologies/gestalt/server/internal/principal"
+)
+
+const (
+	providerAuthzSchema = `version: gestalt.authorization.v1
+resources:
+  - policy_static
+  - plugin_static
+  - plugin_dynamic
+  - admin_policy_static
+  - admin_dynamic
+subjects:
+  - subject
+  - user
+  - email
+`
+
+	resourceTypePolicyStatic      = "policy_static"
+	resourceTypePluginStatic      = "plugin_static"
+	resourceTypePluginDynamic     = "plugin_dynamic"
+	resourceTypeAdminPolicyStatic = "admin_policy_static"
+	resourceTypeAdminDynamic      = "admin_dynamic"
+	resourceIDAdminDynamicGlobal  = "global"
+
+	subjectTypeSubject = "subject"
+	subjectTypeUser    = "user"
+	subjectTypeEmail   = "email"
+)
+
+type providerBackedRoleState struct {
+	modelID            string
+	policyStaticRoles  map[string][]string
+	pluginStaticRoles  map[string][]string
+	pluginDynamicRoles map[string][]string
+	adminDynamicRoles  []string
+}
+
+type ProviderBackedAuthorizer struct {
+	legacy *Authorizer
+
+	provider core.AuthorizationProvider
+
+	lifecycleMu sync.Mutex
+	started     bool
+	closed      bool
+	pollCancel  context.CancelFunc
+	pollDone    chan struct{}
+
+	stateMu sync.RWMutex
+	state   providerBackedRoleState
+}
+
+var _ RuntimeAuthorizer = (*ProviderBackedAuthorizer)(nil)
+
+func NewProviderBacked(legacy *Authorizer, provider core.AuthorizationProvider) *ProviderBackedAuthorizer {
+	return &ProviderBackedAuthorizer{
+		legacy:   legacy,
+		provider: provider,
+		state: providerBackedRoleState{
+			policyStaticRoles:  map[string][]string{},
+			pluginStaticRoles:  map[string][]string{},
+			pluginDynamicRoles: map[string][]string{},
+		},
+	}
+}
+
+func (a *ProviderBackedAuthorizer) Start(ctx context.Context) error {
+	if a == nil {
+		return nil
+	}
+	if a.legacy == nil {
+		return nil
+	}
+	if a.provider == nil || a.legacy == nil {
+		return a.legacy.Start(ctx)
+	}
+
+	a.lifecycleMu.Lock()
+	defer a.lifecycleMu.Unlock()
+	if a.closed {
+		return fmt.Errorf("authorizer already closed")
+	}
+	if a.started {
+		return nil
+	}
+	if err := a.ReloadDynamic(ctx); err != nil {
+		return err
+	}
+	a.legacy.lifecycleMu.Lock()
+	a.legacy.started = true
+	a.legacy.lifecycleMu.Unlock()
+
+	if !a.legacy.hasDynamicSources() {
+		a.started = true
+		return nil
+	}
+
+	pollCtx, cancel := context.WithCancel(ctx)
+	done := make(chan struct{})
+	a.pollCancel = cancel
+	a.pollDone = done
+	a.started = true
+	go a.pollLoop(pollCtx, done)
+	return nil
+}
+
+func (a *ProviderBackedAuthorizer) Close() error {
+	if a == nil {
+		return nil
+	}
+	if a.legacy == nil {
+		return nil
+	}
+	if a.provider == nil || a.legacy == nil {
+		return a.legacy.Close()
+	}
+
+	a.lifecycleMu.Lock()
+	if a.closed {
+		a.lifecycleMu.Unlock()
+		return nil
+	}
+	cancel := a.pollCancel
+	done := a.pollDone
+	a.pollCancel = nil
+	a.pollDone = nil
+	a.closed = true
+	a.lifecycleMu.Unlock()
+
+	if cancel != nil {
+		cancel()
+	}
+	if done != nil {
+		<-done
+	}
+	return a.legacy.Close()
+}
+
+func (a *ProviderBackedAuthorizer) ReloadDynamic(ctx context.Context) error {
+	if a == nil {
+		return nil
+	}
+	if a.legacy == nil {
+		return nil
+	}
+	if a.provider == nil {
+		return a.legacy.ReloadDynamic(ctx)
+	}
+
+	reloadErr := a.legacy.ReloadDynamic(ctx)
+
+	modelID, err := a.ensureModel(ctx)
+	if err != nil {
+		return errors.Join(reloadErr, err)
+	}
+	desired, roles, err := a.buildDesiredRelationships(modelID)
+	if err != nil {
+		return errors.Join(reloadErr, err)
+	}
+	existing, err := a.readAllRelationships(ctx, modelID)
+	if err != nil {
+		return errors.Join(reloadErr, err)
+	}
+
+	writes, deletes := diffRelationships(existing, desired)
+	if len(writes) > 0 || len(deletes) > 0 {
+		if err := a.provider.WriteRelationships(ctx, &core.WriteRelationshipsRequest{
+			Writes:  writes,
+			Deletes: deletes,
+			ModelId: modelID,
+		}); err != nil {
+			return errors.Join(reloadErr, fmt.Errorf("sync authorization relationships: %w", err))
+		}
+	}
+
+	a.stateMu.Lock()
+	roles.modelID = modelID
+	a.state = roles
+	a.stateMu.Unlock()
+	return reloadErr
+}
+
+func (a *ProviderBackedAuthorizer) pollLoop(ctx context.Context, done chan struct{}) {
+	defer close(done)
+	ticker := time.NewTicker(a.legacy.dynamicReloadEvery)
+	defer ticker.Stop()
+
+	for {
+		select {
+		case <-ctx.Done():
+			return
+		case <-ticker.C:
+			if err := a.ReloadDynamic(ctx); err != nil {
+				slog.WarnContext(ctx, "authorization: provider-backed reload failed", "error", err)
+			}
+		}
+	}
+}
+
+func (a *ProviderBackedAuthorizer) ResolveWorkloadToken(token string) (*principal.ResolvedWorkload, bool) {
+	if a == nil || a.legacy == nil {
+		return nil, false
+	}
+	return a.legacy.ResolveWorkloadToken(token)
+}
+
+func (a *ProviderBackedAuthorizer) HasDynamicPluginAuthorizations() bool {
+	return a != nil && a.legacy != nil && a.legacy.HasDynamicPluginAuthorizations()
+}
+
+func (a *ProviderBackedAuthorizer) HasDynamicAdminAuthorizations() bool {
+	return a != nil && a.legacy != nil && a.legacy.HasDynamicAdminAuthorizations()
+}
+
+func (a *ProviderBackedAuthorizer) IsWorkload(p *principal.Principal) bool {
+	if a == nil || a.legacy == nil {
+		return false
+	}
+	return a.legacy.IsWorkload(p)
+}
+
+func (a *ProviderBackedAuthorizer) AllowProvider(ctx context.Context, p *principal.Principal, provider string) bool {
+	if a == nil {
+		return true
+	}
+	if a.legacy == nil {
+		return true
+	}
+	if a.provider == nil || a.legacy.IsWorkload(p) || a.legacy.isManagedIdentityPrincipal(p) {
+		return a.legacy.AllowProvider(ctx, p, provider)
+	}
+	_, allowed := a.ResolveAccess(ctx, p, provider)
+	return allowed
+}
+
+func (a *ProviderBackedAuthorizer) AllowOperation(ctx context.Context, p *principal.Principal, provider, operation string) bool {
+	if a == nil {
+		return true
+	}
+	if a.legacy == nil {
+		return true
+	}
+	if a.provider == nil || a.legacy.IsWorkload(p) || a.legacy.isManagedIdentityPrincipal(p) {
+		return a.legacy.AllowOperation(ctx, p, provider, operation)
+	}
+	return a.AllowProvider(ctx, p, provider)
+}
+
+func (a *ProviderBackedAuthorizer) Binding(p *principal.Principal, provider string) (CredentialBinding, bool) {
+	if a == nil || a.legacy == nil {
+		return CredentialBinding{}, false
+	}
+	return a.legacy.Binding(p, provider)
+}
+
+func (a *ProviderBackedAuthorizer) ResolveAccess(ctx context.Context, p *principal.Principal, provider string) (AccessContext, bool) {
+	if a == nil {
+		return AccessContext{}, true
+	}
+	if a.legacy == nil {
+		return AccessContext{}, true
+	}
+	if a.provider == nil {
+		return a.legacy.ResolveAccess(ctx, p, provider)
+	}
+	if a.legacy.isManagedIdentityPrincipal(p) || a.legacy.IsWorkload(p) {
+		return a.legacy.ResolveAccess(ctx, p, provider)
+	}
+
+	policyName := strings.TrimSpace(a.legacy.providerPolicies[provider])
+	if policyName == "" {
+		return AccessContext{}, true
+	}
+	policy := a.legacy.policies[policyName]
+	if policy == nil {
+		return AccessContext{}, false
+	}
+
+	access := AccessContext{Policy: policyName}
+	role, ok, err := a.resolveProviderRole(ctx, provider, p)
+	if err != nil {
+		a.logProviderEvalError("plugin", provider, err)
+		return a.legacy.ResolveAccess(ctx, p, provider)
+	}
+	if ok {
+		access.Role = role
+		return access, true
+	}
+	if policy.DefaultAllow {
+		access.Role = defaultHumanRole
+		return access, true
+	}
+	return access, false
+}
+
+func (a *ProviderBackedAuthorizer) ResolvePolicyAccess(ctx context.Context, p *principal.Principal, policyName string) (AccessContext, bool) {
+	if a == nil {
+		return AccessContext{}, true
+	}
+	if a.legacy == nil {
+		return AccessContext{}, true
+	}
+	if a.provider == nil {
+		return a.legacy.ResolvePolicyAccess(ctx, p, policyName)
+	}
+	if a.legacy.IsWorkload(p) {
+		return a.legacy.ResolvePolicyAccess(ctx, p, policyName)
+	}
+	policyName = strings.TrimSpace(policyName)
+	if policyName == "" {
+		return AccessContext{}, true
+	}
+	policy := a.legacy.policies[policyName]
+	if policy == nil {
+		return AccessContext{}, false
+	}
+
+	access := AccessContext{Policy: policyName}
+	role, ok, err := a.resolvePolicyStaticRole(ctx, policyName, p)
+	if err != nil {
+		a.logProviderEvalError("policy", policyName, err)
+		return a.legacy.ResolvePolicyAccess(ctx, p, policyName)
+	}
+	if ok {
+		access.Role = role
+		return access, true
+	}
+	if policy.DefaultAllow {
+		access.Role = defaultHumanRole
+		return access, true
+	}
+	return access, false
+}
+
+func (a *ProviderBackedAuthorizer) ResolveAdminAccess(ctx context.Context, p *principal.Principal, policyName string) (AccessContext, bool) {
+	if a == nil {
+		return AccessContext{}, true
+	}
+	if a.legacy == nil {
+		return AccessContext{}, true
+	}
+	if a.provider == nil {
+		return a.legacy.ResolveAdminAccess(ctx, p, policyName)
+	}
+	if a.legacy.IsWorkload(p) {
+		return a.legacy.ResolveAdminAccess(ctx, p, policyName)
+	}
+	policyName = strings.TrimSpace(policyName)
+	if policyName == "" {
+		return AccessContext{}, true
+	}
+	policy := a.legacy.policies[policyName]
+	if policy == nil {
+		return AccessContext{}, false
+	}
+
+	access := AccessContext{Policy: policyName}
+	role, ok, err := a.resolveAdminStaticRole(ctx, policyName, p)
+	if err != nil {
+		a.logProviderEvalError("admin_policy", policyName, err)
+		return a.legacy.ResolveAdminAccess(ctx, p, policyName)
+	}
+	if ok {
+		access.Role = role
+		return access, true
+	}
+	role, ok, err = a.resolveAdminDynamicRole(ctx, p)
+	if err != nil {
+		a.logProviderEvalError("admin_dynamic", policyName, err)
+		return a.legacy.ResolveAdminAccess(ctx, p, policyName)
+	}
+	if ok {
+		access.Role = role
+		return access, true
+	}
+	if policy.DefaultAllow {
+		access.Role = defaultHumanRole
+		return access, true
+	}
+	return access, false
+}
+
+func (a *ProviderBackedAuthorizer) AllowCatalogOperation(ctx context.Context, p *principal.Principal, provider string, op catalog.CatalogOperation) bool {
+	if a == nil {
+		return true
+	}
+	if a.legacy == nil {
+		return true
+	}
+	if a.provider == nil || a.legacy.IsWorkload(p) || a.legacy.isManagedIdentityPrincipal(p) {
+		return a.legacy.AllowCatalogOperation(ctx, p, provider, op)
+	}
+
+	access, allowed := a.ResolveAccess(ctx, p, provider)
+	if !allowed {
+		return false
+	}
+	if access.Policy == "" {
+		return true
+	}
+	if access.Policy != "" && len(op.AllowedRoles) == 0 {
+		policy := a.legacy.policies[access.Policy]
+		return policy != nil && policy.DefaultAllow
+	}
+	if access.Role == "" {
+		return false
+	}
+	for _, role := range op.AllowedRoles {
+		if strings.TrimSpace(role) == access.Role {
+			return true
+		}
+	}
+	return false
+}
+
+func (a *ProviderBackedAuthorizer) PolicyNameForProvider(provider string) string {
+	if a == nil || a.legacy == nil {
+		return ""
+	}
+	return a.legacy.PolicyNameForProvider(provider)
+}
+
+func (a *ProviderBackedAuthorizer) StaticRoleForPolicyIdentity(policyName, subjectID, userID, email string) (AccessContext, bool) {
+	if a == nil || a.legacy == nil {
+		return AccessContext{}, false
+	}
+	return a.legacy.StaticRoleForPolicyIdentity(policyName, subjectID, userID, email)
+}
+
+func (a *ProviderBackedAuthorizer) StaticRoleForProviderIdentity(provider, subjectID, userID, email string) (AccessContext, bool) {
+	if a == nil || a.legacy == nil {
+		return AccessContext{}, false
+	}
+	return a.legacy.StaticRoleForProviderIdentity(provider, subjectID, userID, email)
+}
+
+func (a *ProviderBackedAuthorizer) StaticMembersForPolicy(policyName string) ([]StaticHumanMember, bool) {
+	if a == nil || a.legacy == nil {
+		return nil, false
+	}
+	return a.legacy.StaticMembersForPolicy(policyName)
+}
+
+func (a *ProviderBackedAuthorizer) StaticMembersForProvider(provider string) (string, []StaticHumanMember, bool) {
+	if a == nil || a.legacy == nil {
+		return "", nil, false
+	}
+	return a.legacy.StaticMembersForProvider(provider)
+}
+
+func (a *ProviderBackedAuthorizer) resolveProviderRole(ctx context.Context, provider string, p *principal.Principal) (string, bool, error) {
+	state := a.currentState()
+	role, ok, err := a.resolveRoleVariants(
+		ctx,
+		staticSubjectRefs(p),
+		resourceTypePluginStatic,
+		provider,
+		state.pluginStaticRoles[provider],
+	)
+	if err != nil || ok {
+		return role, ok, err
+	}
+	return a.resolveRoleVariants(
+		ctx,
+		dynamicSubjectRefs(p),
+		resourceTypePluginDynamic,
+		provider,
+		state.pluginDynamicRoles[provider],
+	)
+}
+
+func (a *ProviderBackedAuthorizer) resolvePolicyStaticRole(ctx context.Context, policyName string, p *principal.Principal) (string, bool, error) {
+	state := a.currentState()
+	return a.resolveRoleVariants(
+		ctx,
+		staticSubjectRefs(p),
+		resourceTypePolicyStatic,
+		policyName,
+		state.policyStaticRoles[policyName],
+	)
+}
+
+func (a *ProviderBackedAuthorizer) resolveAdminStaticRole(ctx context.Context, policyName string, p *principal.Principal) (string, bool, error) {
+	state := a.currentState()
+	return a.resolveRoleVariants(
+		ctx,
+		staticSubjectRefs(p),
+		resourceTypeAdminPolicyStatic,
+		policyName,
+		state.policyStaticRoles[policyName],
+	)
+}
+
+func (a *ProviderBackedAuthorizer) resolveAdminDynamicRole(ctx context.Context, p *principal.Principal) (string, bool, error) {
+	state := a.currentState()
+	return a.resolveRoleVariants(
+		ctx,
+		dynamicSubjectRefs(p),
+		resourceTypeAdminDynamic,
+		resourceIDAdminDynamicGlobal,
+		state.adminDynamicRoles,
+	)
+}
+
+func (a *ProviderBackedAuthorizer) resolveRoleVariants(ctx context.Context, subjects []*core.SubjectRef, resourceType, resourceID string, roles []string) (string, bool, error) {
+	if len(subjects) == 0 || len(roles) == 0 {
+		return "", false, nil
+	}
+	if ctx == nil {
+		ctx = context.Background()
+	}
+
+	a.stateMu.RLock()
+	modelID := a.state.modelID
+	a.stateMu.RUnlock()
+
+	resource := &core.ResourceRef{Type: resourceType, Id: resourceID}
+	for _, subject := range subjects {
+		reqs := make([]*core.AccessEvaluationRequest, 0, len(roles))
+		for _, role := range roles {
+			reqs = append(reqs, &core.AccessEvaluationRequest{
+				Subject:  subject,
+				Action:   &core.ActionRef{Name: role},
+				Resource: resource,
+			})
+		}
+		resp, err := a.provider.EvaluateMany(ctx, &core.AccessEvaluationsRequest{Requests: reqs})
+		if err != nil {
+			return "", false, err
+		}
+		for i, decision := range resp.GetDecisions() {
+			if i >= len(roles) {
+				break
+			}
+			if decision != nil && decision.GetAllowed() {
+				if modelID == "" && decision.GetModelId() != "" {
+					a.stateMu.Lock()
+					if a.state.modelID == "" {
+						a.state.modelID = decision.GetModelId()
+					}
+					a.stateMu.Unlock()
+				}
+				return roles[i], true, nil
+			}
+		}
+	}
+	if modelID != "" {
+		a.stateMu.Lock()
+		if a.state.modelID == "" {
+			a.state.modelID = modelID
+		}
+		a.stateMu.Unlock()
+	}
+	return "", false, nil
+}
+
+func (a *ProviderBackedAuthorizer) ensureModel(ctx context.Context) (string, error) {
+	state := a.currentState()
+	if strings.TrimSpace(state.modelID) != "" {
+		return strings.TrimSpace(state.modelID), nil
+	}
+	model, err := a.provider.WriteModel(ctx, &core.WriteModelRequest{Schema: providerAuthzSchema})
+	if err != nil {
+		return "", fmt.Errorf("write authorization model: %w", err)
+	}
+	if model == nil || strings.TrimSpace(model.GetId()) == "" {
+		return "", fmt.Errorf("write authorization model: missing model id")
+	}
+	modelID := strings.TrimSpace(model.GetId())
+	a.stateMu.Lock()
+	if a.state.modelID == "" {
+		a.state.modelID = modelID
+	}
+	a.stateMu.Unlock()
+	return modelID, nil
+}
+
+func (a *ProviderBackedAuthorizer) readAllRelationships(ctx context.Context, modelID string) (map[string]*core.Relationship, error) {
+	out := map[string]*core.Relationship{}
+	pageToken := ""
+	for {
+		resp, err := a.provider.ReadRelationships(ctx, &core.ReadRelationshipsRequest{
+			PageSize:  500,
+			PageToken: pageToken,
+			ModelId:   modelID,
+		})
+		if err != nil {
+			return nil, fmt.Errorf("read authorization relationships: %w", err)
+		}
+		for _, rel := range resp.GetRelationships() {
+			if !managedRelationship(rel) {
+				continue
+			}
+			out[relationshipMapKey(rel)] = rel
+		}
+		pageToken = strings.TrimSpace(resp.GetNextPageToken())
+		if pageToken == "" {
+			return out, nil
+		}
+	}
+}
+
+func (a *ProviderBackedAuthorizer) buildDesiredRelationships(modelID string) (map[string]*core.Relationship, providerBackedRoleState, error) {
+	desired := map[string]*core.Relationship{}
+	state := providerBackedRoleState{
+		modelID:            modelID,
+		policyStaticRoles:  map[string][]string{},
+		pluginStaticRoles:  map[string][]string{},
+		pluginDynamicRoles: map[string][]string{},
+	}
+	policyStaticRoles := map[string]map[string]struct{}{}
+	pluginStaticRoles := map[string]map[string]struct{}{}
+	pluginDynamicRoles := map[string]map[string]struct{}{}
+	adminDynamicRoles := map[string]struct{}{}
+
+	providersByPolicy := map[string][]string{}
+	for providerName, policyName := range a.legacy.providerPolicies {
+		policyName = strings.TrimSpace(policyName)
+		if policyName == "" {
+			continue
+		}
+		providersByPolicy[policyName] = append(providersByPolicy[policyName], providerName)
+	}
+
+	for policyName, policy := range a.legacy.policies {
+		if policy == nil {
+			continue
+		}
+		policyRoleSet := ensureRoleSet(policyStaticRoles, policyName)
+		for subjectID, role := range policy.RolesBySubjectID {
+			role = strings.TrimSpace(role)
+			if subjectID == "" || role == "" {
+				continue
+			}
+			policyRoleSet[role] = struct{}{}
+			addDesiredRelationship(desired, &core.Relationship{
+				Subject:  &core.SubjectRef{Type: subjectTypeSubject, Id: subjectID},
+				Relation: role,
+				Resource: &core.ResourceRef{Type: resourceTypePolicyStatic, Id: policyName},
+			})
+			addDesiredRelationship(desired, &core.Relationship{
+				Subject:  &core.SubjectRef{Type: subjectTypeSubject, Id: subjectID},
+				Relation: role,
+				Resource: &core.ResourceRef{Type: resourceTypeAdminPolicyStatic, Id: policyName},
+			})
+			for _, providerName := range providersByPolicy[policyName] {
+				ensureRoleSet(pluginStaticRoles, providerName)[role] = struct{}{}
+				addDesiredRelationship(desired, &core.Relationship{
+					Subject:  &core.SubjectRef{Type: subjectTypeSubject, Id: subjectID},
+					Relation: role,
+					Resource: &core.ResourceRef{Type: resourceTypePluginStatic, Id: providerName},
+				})
+			}
+		}
+		for email, role := range policy.RolesByEmail {
+			role = strings.TrimSpace(role)
+			email = normalizeProviderEmail(email)
+			if email == "" || role == "" {
+				continue
+			}
+			policyRoleSet[role] = struct{}{}
+			addDesiredRelationship(desired, &core.Relationship{
+				Subject:  &core.SubjectRef{Type: subjectTypeEmail, Id: email},
+				Relation: role,
+				Resource: &core.ResourceRef{Type: resourceTypePolicyStatic, Id: policyName},
+			})
+			addDesiredRelationship(desired, &core.Relationship{
+				Subject:  &core.SubjectRef{Type: subjectTypeEmail, Id: email},
+				Relation: role,
+				Resource: &core.ResourceRef{Type: resourceTypeAdminPolicyStatic, Id: policyName},
+			})
+			for _, providerName := range providersByPolicy[policyName] {
+				ensureRoleSet(pluginStaticRoles, providerName)[role] = struct{}{}
+				addDesiredRelationship(desired, &core.Relationship{
+					Subject:  &core.SubjectRef{Type: subjectTypeEmail, Id: email},
+					Relation: role,
+					Resource: &core.ResourceRef{Type: resourceTypePluginStatic, Id: providerName},
+				})
+			}
+		}
+	}
+
+	snapshot := a.currentDynamicSnapshot()
+	for providerName, byUserID := range snapshot.byPluginUserID {
+		providerName = strings.TrimSpace(providerName)
+		if providerName == "" {
+			continue
+		}
+		for userID, grant := range byUserID {
+			role := strings.TrimSpace(grant.Role)
+			userID = strings.TrimSpace(userID)
+			if userID == "" || role == "" {
+				continue
+			}
+			ensureRoleSet(pluginDynamicRoles, providerName)[role] = struct{}{}
+			addDesiredRelationship(desired, &core.Relationship{
+				Subject:  &core.SubjectRef{Type: subjectTypeUser, Id: userID},
+				Relation: role,
+				Resource: &core.ResourceRef{Type: resourceTypePluginDynamic, Id: providerName},
+			})
+		}
+	}
+	for providerName, byEmail := range snapshot.byPluginEmail {
+		providerName = strings.TrimSpace(providerName)
+		if providerName == "" {
+			continue
+		}
+		for email, grant := range byEmail {
+			role := strings.TrimSpace(grant.Role)
+			email = normalizeProviderEmail(email)
+			if email == "" || role == "" {
+				continue
+			}
+			ensureRoleSet(pluginDynamicRoles, providerName)[role] = struct{}{}
+			addDesiredRelationship(desired, &core.Relationship{
+				Subject:  &core.SubjectRef{Type: subjectTypeEmail, Id: email},
+				Relation: role,
+				Resource: &core.ResourceRef{Type: resourceTypePluginDynamic, Id: providerName},
+			})
+		}
+	}
+	for userID, grant := range snapshot.adminByUserID {
+		role := strings.TrimSpace(grant.Role)
+		userID = strings.TrimSpace(userID)
+		if userID == "" || role == "" {
+			continue
+		}
+		adminDynamicRoles[role] = struct{}{}
+		addDesiredRelationship(desired, &core.Relationship{
+			Subject:  &core.SubjectRef{Type: subjectTypeUser, Id: userID},
+			Relation: role,
+			Resource: &core.ResourceRef{Type: resourceTypeAdminDynamic, Id: resourceIDAdminDynamicGlobal},
+		})
+	}
+	for email, grant := range snapshot.adminByEmail {
+		role := strings.TrimSpace(grant.Role)
+		email = normalizeProviderEmail(email)
+		if email == "" || role == "" {
+			continue
+		}
+		adminDynamicRoles[role] = struct{}{}
+		addDesiredRelationship(desired, &core.Relationship{
+			Subject:  &core.SubjectRef{Type: subjectTypeEmail, Id: email},
+			Relation: role,
+			Resource: &core.ResourceRef{Type: resourceTypeAdminDynamic, Id: resourceIDAdminDynamicGlobal},
+		})
+	}
+
+	for name, roles := range policyStaticRoles {
+		state.policyStaticRoles[name] = normalizeRoleList(roles)
+	}
+	for name, roles := range pluginStaticRoles {
+		state.pluginStaticRoles[name] = normalizeRoleList(roles)
+	}
+	for name, roles := range pluginDynamicRoles {
+		state.pluginDynamicRoles[name] = normalizeRoleList(roles)
+	}
+	state.adminDynamicRoles = normalizeRoleList(adminDynamicRoles)
+	return desired, state, nil
+}
+
+func addDesiredRelationship(target map[string]*core.Relationship, rel *core.Relationship) {
+	if rel == nil {
+		return
+	}
+	target[relationshipMapKey(rel)] = rel
+}
+
+func diffRelationships(existing, desired map[string]*core.Relationship) ([]*core.Relationship, []*core.RelationshipKey) {
+	writes := make([]*core.Relationship, 0)
+	deletes := make([]*core.RelationshipKey, 0)
+	for key, rel := range desired {
+		if _, ok := existing[key]; !ok {
+			writes = append(writes, rel)
+		}
+	}
+	for key, rel := range existing {
+		if _, ok := desired[key]; ok {
+			continue
+		}
+		deletes = append(deletes, &core.RelationshipKey{
+			Subject:  rel.GetSubject(),
+			Relation: rel.GetRelation(),
+			Resource: rel.GetResource(),
+		})
+	}
+	sort.Slice(writes, func(i, j int) bool { return relationshipMapKey(writes[i]) < relationshipMapKey(writes[j]) })
+	sort.Slice(deletes, func(i, j int) bool { return relationshipKeyMapKey(deletes[i]) < relationshipKeyMapKey(deletes[j]) })
+	return writes, deletes
+}
+
+func normalizeRoleList(roles map[string]struct{}) []string {
+	if len(roles) == 0 {
+		return nil
+	}
+	out := make([]string, 0, len(roles))
+	for role := range roles {
+		if strings.TrimSpace(role) == "" {
+			continue
+		}
+		out = append(out, role)
+	}
+	sort.Slice(out, func(i, j int) bool {
+		return roleSortKey(out[i]) < roleSortKey(out[j])
+	})
+	return out
+}
+
+func ensureRoleSet(target map[string]map[string]struct{}, key string) map[string]struct{} {
+	values := target[key]
+	if values == nil {
+		values = map[string]struct{}{}
+		target[key] = values
+	}
+	return values
+}
+
+func roleSortKey(role string) string {
+	switch strings.TrimSpace(role) {
+	case "admin":
+		return "0:admin"
+	case "editor":
+		return "1:editor"
+	case "viewer":
+		return "2:viewer"
+	default:
+		return "9:" + strings.TrimSpace(role)
+	}
+}
+
+func staticSubjectRefs(p *principal.Principal) []*core.SubjectRef {
+	if p == nil {
+		return nil
+	}
+	out := make([]*core.SubjectRef, 0, 3)
+	seen := make(map[string]struct{}, 3)
+	appendSubject := func(kind, id string) {
+		id = strings.TrimSpace(id)
+		if id == "" {
+			return
+		}
+		key := kind + "\x00" + id
+		if _, ok := seen[key]; ok {
+			return
+		}
+		seen[key] = struct{}{}
+		out = append(out, &core.SubjectRef{Type: kind, Id: id})
+	}
+	appendSubject(subjectTypeSubject, p.SubjectID)
+	appendSubject(subjectTypeSubject, principal.UserSubjectID(p.UserID))
+	appendSubject(subjectTypeEmail, normalizeProviderEmail(identityEmail(p)))
+	return out
+}
+
+func dynamicSubjectRefs(p *principal.Principal) []*core.SubjectRef {
+	if p == nil {
+		return nil
+	}
+	out := make([]*core.SubjectRef, 0, 2)
+	if userID := strings.TrimSpace(p.UserID); userID != "" {
+		out = append(out, &core.SubjectRef{Type: subjectTypeUser, Id: userID})
+	}
+	if email := normalizeProviderEmail(identityEmail(p)); email != "" {
+		out = append(out, &core.SubjectRef{Type: subjectTypeEmail, Id: email})
+	}
+	return out
+}
+
+func identityEmail(p *principal.Principal) string {
+	if p == nil || p.Identity == nil {
+		return ""
+	}
+	return p.Identity.Email
+}
+
+func normalizeProviderEmail(email string) string {
+	return emailutil.Normalize(email)
+}
+
+func relationshipMapKey(rel *core.Relationship) string {
+	if rel == nil {
+		return ""
+	}
+	return strings.Join([]string{
+		rel.GetSubject().GetType(),
+		rel.GetSubject().GetId(),
+		rel.GetRelation(),
+		rel.GetResource().GetType(),
+		rel.GetResource().GetId(),
+	}, "\x00")
+}
+
+func relationshipKeyMapKey(rel *core.RelationshipKey) string {
+	if rel == nil {
+		return ""
+	}
+	return strings.Join([]string{
+		rel.GetSubject().GetType(),
+		rel.GetSubject().GetId(),
+		rel.GetRelation(),
+		rel.GetResource().GetType(),
+		rel.GetResource().GetId(),
+	}, "\x00")
+}
+
+func (a *ProviderBackedAuthorizer) logProviderEvalError(scope, name string, err error) {
+	if err == nil {
+		return
+	}
+	slog.Warn("authorization: provider evaluation failed; falling back to legacy rules",
+		"scope", scope,
+		"name", name,
+		"error", err,
+	)
+}
+
+func (a *ProviderBackedAuthorizer) currentState() providerBackedRoleState {
+	a.stateMu.RLock()
+	defer a.stateMu.RUnlock()
+	return a.state
+}
+
+func (a *ProviderBackedAuthorizer) currentDynamicSnapshot() *dynamicSnapshot {
+	if a == nil || a.legacy == nil {
+		return emptyDynamicSnapshot()
+	}
+	snapshot := a.legacy.dynamic.Load()
+	if snapshot == nil {
+		return emptyDynamicSnapshot()
+	}
+	return snapshot
+}
+
+func managedRelationship(rel *core.Relationship) bool {
+	if rel == nil || rel.GetResource() == nil {
+		return false
+	}
+	switch rel.GetResource().GetType() {
+	case resourceTypePolicyStatic,
+		resourceTypePluginStatic,
+		resourceTypePluginDynamic,
+		resourceTypeAdminPolicyStatic,
+		resourceTypeAdminDynamic:
+		return true
+	default:
+		return false
+	}
+}

--- a/gestaltd/internal/authorization/runtime.go
+++ b/gestaltd/internal/authorization/runtime.go
@@ -1,0 +1,40 @@
+package authorization
+
+import (
+	"context"
+
+	"github.com/valon-technologies/gestalt/server/core/catalog"
+	"github.com/valon-technologies/gestalt/server/internal/principal"
+)
+
+// RuntimeAuthorizer is the internal authorization interface used by gestaltd
+// request paths. It keeps workload execution binding concerns local while
+// allowing human authorization decisions to come from a backing provider.
+type RuntimeAuthorizer interface {
+	principal.WorkloadTokenResolver
+
+	Start(ctx context.Context) error
+	Close() error
+
+	HasDynamicPluginAuthorizations() bool
+	HasDynamicAdminAuthorizations() bool
+	ReloadDynamic(ctx context.Context) error
+
+	IsWorkload(p *principal.Principal) bool
+	AllowProvider(ctx context.Context, p *principal.Principal, provider string) bool
+	AllowOperation(ctx context.Context, p *principal.Principal, provider, operation string) bool
+	Binding(p *principal.Principal, provider string) (CredentialBinding, bool)
+
+	ResolveAccess(ctx context.Context, p *principal.Principal, provider string) (AccessContext, bool)
+	ResolvePolicyAccess(ctx context.Context, p *principal.Principal, policyName string) (AccessContext, bool)
+	ResolveAdminAccess(ctx context.Context, p *principal.Principal, policyName string) (AccessContext, bool)
+	AllowCatalogOperation(ctx context.Context, p *principal.Principal, provider string, op catalog.CatalogOperation) bool
+
+	PolicyNameForProvider(provider string) string
+	StaticRoleForPolicyIdentity(policyName, subjectID, userID, email string) (AccessContext, bool)
+	StaticRoleForProviderIdentity(provider, subjectID, userID, email string) (AccessContext, bool)
+	StaticMembersForPolicy(policyName string) ([]StaticHumanMember, bool)
+	StaticMembersForProvider(provider string) (string, []StaticHumanMember, bool)
+}
+
+var _ RuntimeAuthorizer = (*Authorizer)(nil)

--- a/gestaltd/internal/bootstrap/bootstrap.go
+++ b/gestaltd/internal/bootstrap/bootstrap.go
@@ -181,7 +181,7 @@ type Result struct {
 	ExtraWorkflows        []coreworkflow.Provider
 	Providers             *registry.ProviderMap[core.Provider]
 	ProvidersReady        <-chan struct{}
-	Authorizer            *authorization.Authorizer
+	Authorizer            authorization.RuntimeAuthorizer
 	ConnectionAuth        func() map[string]map[string]OAuthHandler
 	Invoker               invocation.Invoker
 	CapabilityLister      invocation.CapabilityLister
@@ -225,7 +225,7 @@ func (r *Result) Close(ctx context.Context) error {
 
 	var errs []error
 	errs = append(errs,
-		r.Authorizer.Close(),
+		closeAuthorizer(r.Authorizer),
 		closeAuth(r.Auth),
 		closeAuthorizationProvider(r.AuthorizationProvider),
 		CloseProviders(r.Providers),
@@ -643,7 +643,7 @@ func Bootstrap(ctx context.Context, cfg *config.Config, factories *FactoryRegist
 		prepared.Deps.WorkflowRuntime.FailPendingProviders(err)
 		return nil, err
 	}
-	authz, err := authorization.New(authzCfg, cfg.Plugins, providers, connMaps.DefaultConnection, prepared.Services.PluginAuthorizations)
+	legacyAuthz, err := authorization.New(authzCfg, cfg.Plugins, providers, connMaps.DefaultConnection, prepared.Services.PluginAuthorizations)
 	if err != nil {
 		prepared.Deps.WorkflowRuntime.FailPendingProviders(err)
 		return nil, err
@@ -651,10 +651,14 @@ func Bootstrap(ctx context.Context, cfg *config.Config, factories *FactoryRegist
 	closeAuthz := true
 	defer func() {
 		if closeAuthz {
-			_ = authz.Close()
+			_ = legacyAuthz.Close()
 		}
 	}()
-	authz.SetAdminAuthorizationService(prepared.Services.AdminAuthorizations)
+	legacyAuthz.SetAdminAuthorizationService(prepared.Services.AdminAuthorizations)
+	var authz authorization.RuntimeAuthorizer = legacyAuthz
+	if prepared.AuthorizationProvider != nil {
+		authz = authorization.NewProviderBacked(legacyAuthz, prepared.AuthorizationProvider)
+	}
 	sharedInvoker := invocation.NewBroker(providers, prepared.Services.Users, prepared.Services.Tokens,
 		invocation.WithAuthorizer(authz),
 		invocation.WithConnectionMapper(invocation.ConnectionMap(connMaps.APIConnection)),
@@ -862,6 +866,13 @@ func closeAuth(provider core.AuthProvider) error {
 		return nil
 	}
 	return closer.Close()
+}
+
+func closeAuthorizer(authorizer authorization.RuntimeAuthorizer) error {
+	if authorizer == nil {
+		return nil
+	}
+	return authorizer.Close()
 }
 
 func closeAuthorizationProvider(provider core.AuthorizationProvider) error {

--- a/gestaltd/internal/bootstrap/bootstrap_test.go
+++ b/gestaltd/internal/bootstrap/bootstrap_test.go
@@ -12,6 +12,7 @@ import (
 	"os"
 	"path/filepath"
 	"strings"
+	"sync"
 	"sync/atomic"
 	"testing"
 
@@ -25,6 +26,7 @@ import (
 	coreworkflow "github.com/valon-technologies/gestalt/server/core/workflow"
 	"github.com/valon-technologies/gestalt/server/internal/bootstrap"
 	"github.com/valon-technologies/gestalt/server/internal/config"
+	"github.com/valon-technologies/gestalt/server/internal/coredata"
 	telemetrynoop "github.com/valon-technologies/gestalt/server/internal/drivers/telemetry/noop"
 	"github.com/valon-technologies/gestalt/server/internal/invocation"
 	"github.com/valon-technologies/gestalt/server/internal/principal"
@@ -84,6 +86,159 @@ func (p *stubAuthorizationProvider) WriteModel(context.Context, *core.WriteModel
 func stubAuthorizationFactory(name string) bootstrap.AuthorizationFactory {
 	return func(yaml.Node, bootstrap.Deps) (core.AuthorizationProvider, error) {
 		return &stubAuthorizationProvider{name: name}, nil
+	}
+}
+
+type memoryAuthorizationProvider struct {
+	name string
+
+	mu            sync.Mutex
+	activeModelID string
+	models        []*core.AuthorizationModelRef
+	rels          map[string]*core.Relationship
+}
+
+func newMemoryAuthorizationProvider(name string) *memoryAuthorizationProvider {
+	return &memoryAuthorizationProvider{
+		name: name,
+		rels: map[string]*core.Relationship{},
+	}
+}
+
+func (p *memoryAuthorizationProvider) Name() string { return p.name }
+
+func (p *memoryAuthorizationProvider) Evaluate(ctx context.Context, req *core.AccessEvaluationRequest) (*core.AccessDecision, error) {
+	resp, err := p.EvaluateMany(ctx, &core.AccessEvaluationsRequest{Requests: []*core.AccessEvaluationRequest{req}})
+	if err != nil {
+		return nil, err
+	}
+	if len(resp.Decisions) == 0 {
+		return &core.AccessDecision{}, nil
+	}
+	return resp.Decisions[0], nil
+}
+
+func (p *memoryAuthorizationProvider) EvaluateMany(_ context.Context, req *core.AccessEvaluationsRequest) (*core.AccessEvaluationsResponse, error) {
+	p.mu.Lock()
+	defer p.mu.Unlock()
+	resp := &core.AccessEvaluationsResponse{
+		Decisions: make([]*core.AccessDecision, 0, len(req.GetRequests())),
+	}
+	for _, item := range req.GetRequests() {
+		allowed := false
+		if item != nil {
+			_, allowed = p.rels[bootstrapRelationshipKey(item.GetSubject(), item.GetAction().GetName(), item.GetResource())]
+		}
+		resp.Decisions = append(resp.Decisions, &core.AccessDecision{
+			Allowed: allowed,
+			ModelId: p.activeModelID,
+		})
+	}
+	return resp, nil
+}
+
+func (p *memoryAuthorizationProvider) SearchResources(context.Context, *core.ResourceSearchRequest) (*core.ResourceSearchResponse, error) {
+	return &core.ResourceSearchResponse{}, nil
+}
+
+func (p *memoryAuthorizationProvider) SearchSubjects(context.Context, *core.SubjectSearchRequest) (*core.SubjectSearchResponse, error) {
+	return &core.SubjectSearchResponse{}, nil
+}
+
+func (p *memoryAuthorizationProvider) SearchActions(context.Context, *core.ActionSearchRequest) (*core.ActionSearchResponse, error) {
+	return &core.ActionSearchResponse{}, nil
+}
+
+func (p *memoryAuthorizationProvider) GetMetadata(context.Context) (*core.AuthorizationMetadata, error) {
+	p.mu.Lock()
+	defer p.mu.Unlock()
+	return &core.AuthorizationMetadata{ActiveModelId: p.activeModelID}, nil
+}
+
+func (p *memoryAuthorizationProvider) ReadRelationships(context.Context, *core.ReadRelationshipsRequest) (*core.ReadRelationshipsResponse, error) {
+	p.mu.Lock()
+	defer p.mu.Unlock()
+	out := make([]*core.Relationship, 0, len(p.rels))
+	for _, rel := range p.rels {
+		out = append(out, cloneRelationship(rel))
+	}
+	return &core.ReadRelationshipsResponse{
+		Relationships: out,
+		ModelId:       p.activeModelID,
+	}, nil
+}
+
+func (p *memoryAuthorizationProvider) WriteRelationships(_ context.Context, req *core.WriteRelationshipsRequest) error {
+	p.mu.Lock()
+	defer p.mu.Unlock()
+	for _, key := range req.GetDeletes() {
+		delete(p.rels, bootstrapRelationshipKey(key.GetSubject(), key.GetRelation(), key.GetResource()))
+	}
+	for _, rel := range req.GetWrites() {
+		p.rels[bootstrapRelationshipKey(rel.GetSubject(), rel.GetRelation(), rel.GetResource())] = cloneRelationship(rel)
+	}
+	return nil
+}
+
+func (p *memoryAuthorizationProvider) GetActiveModel(context.Context) (*core.GetActiveModelResponse, error) {
+	p.mu.Lock()
+	defer p.mu.Unlock()
+	for _, model := range p.models {
+		if model.GetId() == p.activeModelID {
+			return &core.GetActiveModelResponse{Model: model}, nil
+		}
+	}
+	return &core.GetActiveModelResponse{}, nil
+}
+
+func (p *memoryAuthorizationProvider) ListModels(context.Context, *core.ListModelsRequest) (*core.ListModelsResponse, error) {
+	p.mu.Lock()
+	defer p.mu.Unlock()
+	return &core.ListModelsResponse{Models: append([]*core.AuthorizationModelRef(nil), p.models...)}, nil
+}
+
+func (p *memoryAuthorizationProvider) WriteModel(context.Context, *core.WriteModelRequest) (*core.AuthorizationModelRef, error) {
+	p.mu.Lock()
+	defer p.mu.Unlock()
+	model := &core.AuthorizationModelRef{
+		Id:      fmt.Sprintf("model-%d", len(p.models)+1),
+		Version: "v1",
+	}
+	p.models = append(p.models, model)
+	p.activeModelID = model.GetId()
+	return model, nil
+}
+
+func memoryAuthorizationFactory(provider *memoryAuthorizationProvider) bootstrap.AuthorizationFactory {
+	return func(yaml.Node, bootstrap.Deps) (core.AuthorizationProvider, error) {
+		return provider, nil
+	}
+}
+
+func bootstrapRelationshipKey(subject *core.SubjectRef, relation string, resource *core.ResourceRef) string {
+	return strings.Join([]string{
+		subject.GetType(),
+		subject.GetId(),
+		relation,
+		resource.GetType(),
+		resource.GetId(),
+	}, "\x00")
+}
+
+func cloneRelationship(rel *core.Relationship) *core.Relationship {
+	if rel == nil {
+		return nil
+	}
+	return &core.Relationship{
+		Subject: &core.SubjectRef{
+			Type: rel.GetSubject().GetType(),
+			Id:   rel.GetSubject().GetId(),
+		},
+		Relation: rel.GetRelation(),
+		Resource: &core.ResourceRef{
+			Type: rel.GetResource().GetType(),
+			Id:   rel.GetResource().GetId(),
+		},
 	}
 }
 
@@ -3257,6 +3412,125 @@ func TestBootstrapSecretResolution(t *testing.T) {
 		}
 		if _, ok := result.Authorizer.ResolveWorkloadToken("gst_wld_resolved-workload-token"); !ok {
 			t.Fatal("expected resolved workload token to authenticate")
+		}
+	})
+
+	t.Run("authorization provider backs human access decisions", func(t *testing.T) {
+		t.Parallel()
+
+		cfg := validConfig()
+		cfg.Authorization = config.AuthorizationConfig{
+			Policies: map[string]config.HumanPolicyDef{
+				"calendar-policy": {
+					Default: "deny",
+					Members: []config.HumanPolicyMemberDef{
+						{Email: "static@example.test", Role: "viewer"},
+					},
+				},
+				"admin-policy": {
+					Default: "deny",
+					Members: []config.HumanPolicyMemberDef{
+						{Email: "seed-admin@example.test", Role: "admin"},
+					},
+				},
+			},
+		}
+		cfg.Server.Admin.AuthorizationPolicy = "admin-policy"
+		cfg.Plugins = map[string]*config.ProviderEntry{
+			"calendar": {
+				AuthorizationPolicy: "calendar-policy",
+				ResolvedManifest: &providermanifestv1.Manifest{
+					Spec: &providermanifestv1.Spec{},
+				},
+			},
+		}
+		cfg.Providers.Authorization = map[string]*config.ProviderEntry{
+			"indexeddb": {Source: config.ProviderSource{Path: "stub"}},
+		}
+		cfg.Server.Providers.Authorization = "indexeddb"
+
+		provider := newMemoryAuthorizationProvider("memory-authorization")
+		unmanagedKey := bootstrapRelationshipKey(
+			&core.SubjectRef{Type: "team", Id: "ops"},
+			"owner",
+			&core.ResourceRef{Type: "foreign_resource", Id: "roadmap"},
+		)
+		provider.rels[unmanagedKey] = &core.Relationship{
+			Subject:  &core.SubjectRef{Type: "team", Id: "ops"},
+			Relation: "owner",
+			Resource: &core.ResourceRef{Type: "foreign_resource", Id: "roadmap"},
+		}
+		factories := validFactories()
+		factories.Authorization = memoryAuthorizationFactory(provider)
+
+		result, err := bootstrap.Bootstrap(ctx, cfg, factories)
+		if err != nil {
+			t.Fatalf("Bootstrap: %v", err)
+		}
+		t.Cleanup(func() { _ = result.Close(context.Background()) })
+		<-result.ProvidersReady
+		if err := result.Start(ctx); err != nil {
+			t.Fatalf("Start: %v", err)
+		}
+		if _, ok := provider.rels[unmanagedKey]; !ok {
+			t.Fatal("expected unrelated provider relationship to be preserved")
+		}
+
+		staticPrincipal := &principal.Principal{
+			Identity: &core.UserIdentity{Email: "static@example.test"},
+			Kind:     principal.KindUser,
+		}
+		access, allowed := result.Authorizer.ResolveAccess(ctx, staticPrincipal, "calendar")
+		if !allowed {
+			t.Fatal("expected static plugin access to be allowed")
+		}
+		if access.Role != "viewer" {
+			t.Fatalf("static plugin role = %q, want %q", access.Role, "viewer")
+		}
+
+		dynamicUser, err := result.Services.Users.FindOrCreateUser(ctx, "dynamic@example.test")
+		if err != nil {
+			t.Fatalf("FindOrCreateUser(dynamic): %v", err)
+		}
+		if _, err := result.Services.PluginAuthorizations.UpsertPluginAuthorization(ctx, &coredata.PluginAuthorizationMembership{
+			Plugin: "calendar",
+			UserID: dynamicUser.ID,
+			Email:  dynamicUser.Email,
+			Role:   "editor",
+		}); err != nil {
+			t.Fatalf("UpsertPluginAuthorization: %v", err)
+		}
+		if _, err := result.Services.AdminAuthorizations.UpsertAdminAuthorization(ctx, &coredata.AdminAuthorizationMembership{
+			UserID: dynamicUser.ID,
+			Email:  dynamicUser.Email,
+			Role:   "admin",
+		}); err != nil {
+			t.Fatalf("UpsertAdminAuthorization: %v", err)
+		}
+		if err := result.Authorizer.ReloadDynamic(ctx); err != nil {
+			t.Fatalf("ReloadDynamic: %v", err)
+		}
+
+		dynamicPrincipal := &principal.Principal{
+			UserID:    dynamicUser.ID,
+			SubjectID: principal.UserSubjectID(dynamicUser.ID),
+			Identity:  &core.UserIdentity{Email: dynamicUser.Email},
+			Kind:      principal.KindUser,
+		}
+		access, allowed = result.Authorizer.ResolveAccess(ctx, dynamicPrincipal, "calendar")
+		if !allowed {
+			t.Fatal("expected dynamic plugin access to be allowed")
+		}
+		if access.Role != "editor" {
+			t.Fatalf("dynamic plugin role = %q, want %q", access.Role, "editor")
+		}
+
+		adminAccess, allowed := result.Authorizer.ResolveAdminAccess(ctx, dynamicPrincipal, "admin-policy")
+		if !allowed {
+			t.Fatal("expected dynamic admin access to be allowed")
+		}
+		if adminAccess.Role != "admin" {
+			t.Fatalf("dynamic admin role = %q, want %q", adminAccess.Role, "admin")
 		}
 	})
 

--- a/gestaltd/internal/invocation/broker.go
+++ b/gestaltd/internal/invocation/broker.go
@@ -95,7 +95,7 @@ type Broker struct {
 	providers      *registry.ProviderMap[core.Provider]
 	users          *coredata.UserService
 	tokens         *coredata.TokenService
-	authorizer     *authorization.Authorizer
+	authorizer     authorization.RuntimeAuthorizer
 	connMapper     ConnectionMapper
 	mcpMapper      ConnectionMapper
 	connectionAuth RefresherResolver
@@ -116,7 +116,7 @@ func WithConnectionAuth(r RefresherResolver) BrokerOption {
 	return func(b *Broker) { b.connectionAuth = r }
 }
 
-func WithAuthorizer(a *authorization.Authorizer) BrokerOption {
+func WithAuthorizer(a authorization.RuntimeAuthorizer) BrokerOption {
 	return func(b *Broker) { b.authorizer = a }
 }
 
@@ -215,7 +215,7 @@ func (b *Broker) Invoke(ctx context.Context, p *principal.Principal, providerNam
 		span.SetAttributes(attrUserID.String(p.UserID))
 	}
 	if b.authorizer != nil {
-		access, allowed := b.authorizer.ResolveAccess(p, providerName)
+		access, allowed := b.authorizer.ResolveAccess(ctx, p, providerName)
 		if access.Policy != "" || access.Role != "" {
 			ctx = WithAccessContext(ctx, access)
 		}
@@ -230,7 +230,7 @@ func (b *Broker) Invoke(ctx context.Context, p *principal.Principal, providerNam
 
 	conn := ConnectionFromContext(ctx)
 	conn, instance = b.workloadSelectors(p, providerName, conn, instance)
-	if b.authorizer != nil && b.authorizer.IsWorkload(p) && !b.authorizer.AllowOperation(p, providerName, operation) {
+	if b.authorizer != nil && b.authorizer.IsWorkload(p) && !b.authorizer.AllowOperation(ctx, p, providerName, operation) {
 		return fail(fmt.Errorf("%w: %s.%s", ErrAuthorizationDenied, providerName, operation))
 	}
 
@@ -238,7 +238,7 @@ func (b *Broker) Invoke(ctx context.Context, p *principal.Principal, providerNam
 	if err != nil {
 		return fail(err)
 	}
-	if b.authorizer != nil && !b.authorizer.AllowCatalogOperation(p, providerName, opMeta) {
+	if b.authorizer != nil && !b.authorizer.AllowCatalogOperation(ctx, p, providerName, opMeta) {
 		return fail(fmt.Errorf("%w: %s.%s", ErrAuthorizationDenied, providerName, operation))
 	}
 	if !principal.AllowsOperationPermission(p, providerName, opMeta.ID) {
@@ -393,7 +393,7 @@ func (b *Broker) ResolveToken(ctx context.Context, p *principal.Principal, provi
 		return ctx, "", err
 	}
 	ctx = withResolvedPrincipal(ctx, p)
-	if b.authorizer != nil && !b.authorizer.AllowProvider(p, providerName) {
+	if b.authorizer != nil && !b.authorizer.AllowProvider(ctx, p, providerName) {
 		return ctx, "", fmt.Errorf("%w: %s", ErrAuthorizationDenied, providerName)
 	}
 	prov, err := b.providers.Get(providerName)

--- a/gestaltd/internal/invocation/catalog.go
+++ b/gestaltd/internal/invocation/catalog.go
@@ -220,7 +220,7 @@ func mergeCatalogs(provName string, staticCat, sessionCat *catalog.Catalog) (*ca
 	return merged, nil
 }
 
-func FilterCatalogForPrincipal(cat *catalog.Catalog, provName string, p *principal.Principal, authorizer *authorization.Authorizer) *catalog.Catalog {
+func FilterCatalogForPrincipal(ctx context.Context, cat *catalog.Catalog, provName string, p *principal.Principal, authorizer authorization.RuntimeAuthorizer) *catalog.Catalog {
 	if cat == nil || authorizer == nil {
 		return cat
 	}
@@ -228,7 +228,7 @@ func FilterCatalogForPrincipal(cat *catalog.Catalog, provName string, p *princip
 	filtered := cat.Clone()
 	ops := filtered.Operations[:0]
 	for i := range filtered.Operations {
-		if authorizer.AllowCatalogOperation(p, provName, filtered.Operations[i]) {
+		if authorizer.AllowCatalogOperation(ctx, p, provName, filtered.Operations[i]) {
 			ops = append(ops, filtered.Operations[i])
 		}
 	}

--- a/gestaltd/internal/mcp/authorization.go
+++ b/gestaltd/internal/mcp/authorization.go
@@ -17,13 +17,13 @@ func allowOperation(ctx context.Context, cfg Config, p *principal.Principal, pro
 		return true
 	}
 	if cfg.Authorizer.IsWorkload(p) {
-		return cfg.Authorizer.AllowOperation(p, provider, operation)
+		return cfg.Authorizer.AllowOperation(ctx, p, provider, operation)
 	}
 	op, ok := catalogOperationForTool(ctx, cfg, provider, operation)
 	if !ok {
 		return false
 	}
-	return cfg.Authorizer.AllowCatalogOperation(p, provider, op)
+	return cfg.Authorizer.AllowCatalogOperation(ctx, p, provider, op)
 }
 
 func toolTarget(cfg Config, providers []string, name string) (provider, operation string, ok bool) {

--- a/gestaltd/internal/mcp/binding.go
+++ b/gestaltd/internal/mcp/binding.go
@@ -24,7 +24,7 @@ type Config struct {
 	TokenResolver    invocation.TokenResolver
 	AuditSink        core.AuditSink
 	Providers        *registry.ProviderMap[core.Provider]
-	Authorizer       *authorization.Authorizer
+	Authorizer       authorization.RuntimeAuthorizer
 	AllowedProviders []string
 	ToolPrefixes     map[string]string
 	IncludeREST      map[string]bool

--- a/gestaltd/internal/mcp/session_tools.go
+++ b/gestaltd/internal/mcp/session_tools.go
@@ -147,7 +147,7 @@ func withSessionAccessContext(ctx context.Context, cfg Config, provName string) 
 	if p == nil || cfg.Authorizer.IsWorkload(p) {
 		return ctx
 	}
-	access, allowed := cfg.Authorizer.ResolveAccess(p, provName)
+	access, allowed := cfg.Authorizer.ResolveAccess(ctx, p, provName)
 	if !allowed || (access.Policy == "" && access.Role == "") {
 		return ctx
 	}
@@ -436,6 +436,6 @@ func normalizedSessionCatalogInstance(value any) string {
 	return strings.TrimSpace(instance)
 }
 
-func workloadInstanceOverrideRequested(authz *authorization.Authorizer, p *principal.Principal, instance string) bool {
+func workloadInstanceOverrideRequested(authz authorization.RuntimeAuthorizer, p *principal.Principal, instance string) bool {
 	return authz != nil && p != nil && authz.IsWorkload(p) && instance != ""
 }

--- a/gestaltd/internal/server/authorization.go
+++ b/gestaltd/internal/server/authorization.go
@@ -11,25 +11,25 @@ import (
 	"github.com/valon-technologies/gestalt/server/internal/principal"
 )
 
-func (s *Server) allowProvider(p *principal.Principal, provider string) bool {
+func (s *Server) allowProviderContext(ctx context.Context, p *principal.Principal, provider string) bool {
 	if s.authorizer == nil {
 		return true
 	}
-	return s.authorizer.AllowProvider(p, provider)
+	return s.authorizer.AllowProvider(ctx, p, provider)
 }
 
-func (s *Server) allowOperation(p *principal.Principal, provider, operation string) bool {
+func (s *Server) allowOperationContext(ctx context.Context, p *principal.Principal, provider, operation string) bool {
 	if s.authorizer == nil {
 		return true
 	}
-	return s.authorizer.AllowOperation(p, provider, operation)
+	return s.authorizer.AllowOperation(ctx, p, provider, operation)
 }
 
-func (s *Server) providerAccessContext(p *principal.Principal, provider string) invocation.AccessContext {
+func (s *Server) providerAccessContextWithContext(ctx context.Context, p *principal.Principal, provider string) invocation.AccessContext {
 	if s.authorizer == nil {
 		return invocation.AccessContext{}
 	}
-	access, _ := s.authorizer.ResolveAccess(p, provider)
+	access, _ := s.authorizer.ResolveAccess(ctx, p, provider)
 	return access
 }
 

--- a/gestaltd/internal/server/catalog_resolution_test.go
+++ b/gestaltd/internal/server/catalog_resolution_test.go
@@ -346,7 +346,7 @@ func TestFilterCatalogForPrincipal_HumanFilteringUsesResolvedRole(t *testing.T) 
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
-	filtered := invocation.FilterCatalogForPrincipal(cat, "sample-api", p, authz)
+	filtered := invocation.FilterCatalogForPrincipal(context.Background(), cat, "sample-api", p, authz)
 	if len(filtered.Operations) != 2 {
 		t.Fatalf("expected 2 operations after human filtering, got %d", len(filtered.Operations))
 	}
@@ -398,7 +398,7 @@ func TestFilterCatalogForPrincipal_HumanDefaultAllowKeepsUnannotatedOperations(t
 		UserID:    "viewer-user",
 		SubjectID: principal.UserSubjectID("viewer-user"),
 	}
-	filtered := invocation.FilterCatalogForPrincipal(prov.Catalog(), "sample-api", p, authz)
+	filtered := invocation.FilterCatalogForPrincipal(context.Background(), prov.Catalog(), "sample-api", p, authz)
 	if len(filtered.Operations) != 1 {
 		t.Fatalf("expected 1 operation after default-allow filtering, got %d", len(filtered.Operations))
 	}
@@ -446,7 +446,7 @@ func TestFilterCatalogForPrincipal_HumanDefaultAllowTreatsUnmatchedUsersAsViewer
 		UserID:    "viewer-user",
 		SubjectID: principal.UserSubjectID("viewer-user"),
 	}
-	filtered := invocation.FilterCatalogForPrincipal(prov.Catalog(), "sample-api", p, authz)
+	filtered := invocation.FilterCatalogForPrincipal(context.Background(), prov.Catalog(), "sample-api", p, authz)
 	if len(filtered.Operations) != 2 {
 		t.Fatalf("expected 2 operations after default-allow filtering, got %d", len(filtered.Operations))
 	}
@@ -484,7 +484,7 @@ func TestFilterCatalogForPrincipal_HumanUnboundProviderKeepsRoleAnnotatedOperati
 		UserID:    "viewer-user",
 		SubjectID: principal.UserSubjectID("viewer-user"),
 	}
-	filtered := invocation.FilterCatalogForPrincipal(prov.Catalog(), "sample-api", p, authz)
+	filtered := invocation.FilterCatalogForPrincipal(context.Background(), prov.Catalog(), "sample-api", p, authz)
 	if len(filtered.Operations) != 2 {
 		t.Fatalf("expected 2 operations after filtering unbound provider, got %d", len(filtered.Operations))
 	}
@@ -549,7 +549,7 @@ func TestFilterCatalogForPrincipal_WorkloadFilteringUsesMergedCatalog(t *testing
 		t.Fatalf("unexpected error: %v", err)
 	}
 
-	filtered := invocation.FilterCatalogForPrincipal(cat, "clash-api", p, authz)
+	filtered := invocation.FilterCatalogForPrincipal(context.Background(), cat, "clash-api", p, authz)
 	if len(filtered.Operations) != 2 {
 		t.Fatalf("expected 2 operations after workload filtering, got %d", len(filtered.Operations))
 	}

--- a/gestaltd/internal/server/handlers.go
+++ b/gestaltd/internal/server/handlers.go
@@ -141,7 +141,7 @@ func (s *Server) listIntegrations(w http.ResponseWriter, r *http.Request) {
 	names := s.providers.List()
 	out := make([]integrationInfo, 0, len(names))
 	for _, name := range names {
-		if !s.allowProvider(p, name) {
+		if !s.allowProviderContext(r.Context(), p, name) {
 			continue
 		}
 		prov, err := s.providers.Get(name)
@@ -175,8 +175,8 @@ func (s *Server) listIntegrations(w http.ResponseWriter, r *http.Request) {
 				}
 				info.Connected = bindingConnected
 			}
-			info.MountedPath = s.integrationMountedPathForPrincipal(p, name, info.MountedPath)
-			if !s.integrationHasUsableSurface(p, name, prov, info) {
+			info.MountedPath = s.integrationMountedPathForPrincipalContext(r.Context(), p, name, info.MountedPath)
+			if !s.integrationHasUsableSurfaceContext(r.Context(), p, name, prov, info) {
 				continue
 			}
 			out = append(out, info)
@@ -187,8 +187,8 @@ func (s *Server) listIntegrations(w http.ResponseWriter, r *http.Request) {
 		info.Connected = len(instances) > 0
 		info.Instances = append(make([]instanceInfo, 0, len(instances)), instances...)
 		s.populateIntegrationSettings(&info, prov)
-		info.MountedPath = s.integrationMountedPathForPrincipal(p, name, info.MountedPath)
-		if !s.integrationHasUsableSurface(p, name, prov, info) {
+		info.MountedPath = s.integrationMountedPathForPrincipalContext(r.Context(), p, name, info.MountedPath)
+		if !s.integrationHasUsableSurfaceContext(r.Context(), p, name, prov, info) {
 			continue
 		}
 		out = append(out, info)
@@ -424,7 +424,7 @@ func (s *Server) listOperations(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 	p := PrincipalFromContext(r.Context())
-	if !s.allowProvider(p, name) {
+	if !s.allowProviderContext(r.Context(), p, name) {
 		s.auditHTTPEvent(r.Context(), p, name, operation, false, errOperationAccess)
 		writeError(w, http.StatusForbidden, errOperationAccess.Error())
 		return
@@ -468,7 +468,7 @@ func (s *Server) listOperations(w http.ResponseWriter, r *http.Request) {
 	} else if core.SupportsSessionCatalog(prov) {
 		strictCatalog = true
 	}
-	ctx := invocation.WithAccessContext(r.Context(), s.providerAccessContext(p, name))
+	ctx := invocation.WithAccessContext(r.Context(), s.providerAccessContextWithContext(r.Context(), p, name))
 	cat, metadata, err := invocation.ResolveCatalogForTargetsWithMetadata(
 		ctx,
 		prov,
@@ -489,7 +489,7 @@ func (s *Server) listOperations(w http.ResponseWriter, r *http.Request) {
 	if recordDiscoveryMetrics {
 		metricutil.RecordDiscoveryMetrics(r.Context(), discoveryStartedAt, name, "list_operations", discoveryConnectionMode, discoveryFailed)
 	}
-	cat = invocation.FilterCatalogForPrincipal(cat, name, p, s.authorizer)
+	cat = invocation.FilterCatalogForPrincipal(ctx, cat, name, p, s.authorizer)
 	ops := httpVisibleCatalogOperations(cat.Operations)
 	sort.Slice(ops, func(i, j int) bool {
 		return ops[i].ID < ops[j].ID
@@ -506,9 +506,9 @@ func (s *Server) executeOperation(w http.ResponseWriter, r *http.Request) {
 	if !ok {
 		return
 	}
-	access := s.providerAccessContext(p, providerName)
-	providerAllowed := s.allowProvider(p, providerName)
-	operationAllowed := s.allowOperation(p, providerName, operationName)
+	access := s.providerAccessContextWithContext(r.Context(), p, providerName)
+	providerAllowed := s.allowProviderContext(r.Context(), p, providerName)
+	operationAllowed := s.allowOperationContext(r.Context(), p, providerName, operationName)
 	if !providerAllowed || !operationAllowed {
 		authz := auditAuthorization{
 			Policy: access.Policy,
@@ -615,7 +615,7 @@ func (s *Server) executeOperation(w http.ResponseWriter, r *http.Request) {
 		s.writeInvocationError(w, r, providerName, operationName, err)
 		return
 	}
-	if s.authorizer != nil && !s.authorizer.AllowCatalogOperation(p, providerName, opMeta) {
+	if s.authorizer != nil && !s.authorizer.AllowCatalogOperation(ctx, p, providerName, opMeta) {
 		s.auditHTTPAuthorizationEvent(ctx, p, providerName, operationName, false, errOperationAccess, auditAuthorization{
 			Policy:   access.Policy,
 			Role:     access.Role,

--- a/gestaltd/internal/server/handlers_admin_authorization.go
+++ b/gestaltd/internal/server/handlers_admin_authorization.go
@@ -81,7 +81,7 @@ func (s *Server) adminAPIAuthMiddleware(next http.Handler) http.Handler {
 			return
 		}
 
-		access, allowed := s.authorizer.ResolveAdminAccess(p, s.adminRoute.AuthorizationPolicy)
+		access, allowed := s.authorizer.ResolveAdminAccess(r.Context(), p, s.adminRoute.AuthorizationPolicy)
 		if !allowed || !mountedWebUIRoleAllowed(access.Role, s.adminRoute.AllowedRoles) {
 			writeError(w, http.StatusForbidden, "admin access denied")
 			return

--- a/gestaltd/internal/server/handlers_identities.go
+++ b/gestaltd/internal/server/handlers_identities.go
@@ -282,7 +282,7 @@ func (s *Server) identitiesProviderHasOperation(ctx context.Context, operation, 
 	if tr, ok := s.invoker.(invocation.TokenResolver); ok {
 		resolver = tr
 	}
-	ctx = invocation.WithAccessContext(ctx, s.providerAccessContext(p, "identities"))
+	ctx = invocation.WithAccessContext(ctx, s.providerAccessContextWithContext(ctx, p, "identities"))
 	targets, err := s.managedIdentityGrantCatalogTargets(ctx, "identities", p)
 	if err != nil {
 		return false
@@ -613,7 +613,7 @@ func (s *Server) listManagedIdentityGrants(w http.ResponseWriter, r *http.Reques
 	p := PrincipalFromContext(r.Context())
 	out := make([]managedIdentityGrantInfo, 0, len(grants))
 	for _, grant := range grants {
-		if !s.managedIdentityGrantVisibleToActor(grant.Plugin, p, actor.Membership.Role) {
+		if !s.managedIdentityGrantVisibleToActor(r.Context(), grant.Plugin, p, actor.Membership.Role) {
 			continue
 		}
 		out = append(out, managedIdentityGrantInfo{
@@ -653,7 +653,7 @@ func (s *Server) putManagedIdentityGrant(w http.ResponseWriter, r *http.Request)
 	}
 
 	p := managedIdentityGrantValidationPrincipal(PrincipalFromContext(r.Context()), actor.UserID)
-	if !s.managedIdentityGrantPluginVisible(plugin, p) {
+	if !s.managedIdentityGrantPluginVisible(r.Context(), plugin, p) {
 		auditErr = errors.New("plugin not found")
 		writeError(w, http.StatusNotFound, "plugin not found")
 		return
@@ -677,7 +677,7 @@ func (s *Server) putManagedIdentityGrant(w http.ResponseWriter, r *http.Request)
 	if !ok {
 		return
 	}
-	if !s.managedIdentityGrantPluginVisible(plugin, p) {
+	if !s.managedIdentityGrantPluginVisible(r.Context(), plugin, p) {
 		auditErr = errors.New("plugin not found")
 		writeError(w, http.StatusNotFound, "plugin not found")
 		return
@@ -745,7 +745,7 @@ func (s *Server) deleteManagedIdentityGrant(w http.ResponseWriter, r *http.Reque
 			writeError(w, http.StatusInternalServerError, "failed to resolve identity grant")
 			return
 		}
-	} else if !s.allowProvider(PrincipalFromContext(r.Context()), plugin) {
+	} else if !s.allowProviderContext(r.Context(), PrincipalFromContext(r.Context()), plugin) {
 		auditErr = errors.New("plugin not found")
 		writeError(w, http.StatusNotFound, "plugin not found")
 		return
@@ -1040,18 +1040,18 @@ func (s *Server) recoverManagedIdentityCreateMembership(ctx context.Context, ide
 	}
 }
 
-func (s *Server) managedIdentityGrantPluginVisible(plugin string, p *principal.Principal) bool {
+func (s *Server) managedIdentityGrantPluginVisible(ctx context.Context, plugin string, p *principal.Principal) bool {
 	if _, err := s.providers.Get(plugin); err != nil {
 		return false
 	}
-	return s.allowProvider(p, plugin)
+	return s.allowProviderContext(ctx, p, plugin)
 }
 
-func (s *Server) managedIdentityGrantVisibleToActor(plugin string, p *principal.Principal, role string) bool {
+func (s *Server) managedIdentityGrantVisibleToActor(ctx context.Context, plugin string, p *principal.Principal, role string) bool {
 	if _, err := s.providers.Get(plugin); err != nil {
 		return errors.Is(err, core.ErrNotFound) && managedIdentityRoleAllows(role, managedIdentityRoleEditor)
 	}
-	return s.allowProvider(p, plugin)
+	return s.allowProviderContext(ctx, p, plugin)
 }
 
 func (s *Server) managedIdentityInvocationSupported(plugin string) bool {
@@ -1146,7 +1146,7 @@ func (s *Server) managedIdentityGrantCatalog(ctx context.Context, plugin string,
 	if tr, ok := s.invoker.(invocation.TokenResolver); ok {
 		resolver = tr
 	}
-	ctx = invocation.WithAccessContext(ctx, s.providerAccessContext(p, plugin))
+	ctx = invocation.WithAccessContext(ctx, s.providerAccessContextWithContext(ctx, p, plugin))
 	targets, err := s.managedIdentityGrantCatalogTargets(ctx, plugin, p)
 	if err != nil {
 		return nil, err
@@ -1407,7 +1407,7 @@ func (s *Server) validateManagedIdentityGrantOperations(ctx context.Context, plu
 	}
 	allowedVisible := visible
 	if s.authorizer != nil {
-		filtered := invocation.FilterCatalogForPrincipal(cat, plugin, p, s.authorizer)
+		filtered := invocation.FilterCatalogForPrincipal(ctx, cat, plugin, p, s.authorizer)
 		allowedVisible = grantableCatalogOperations(filtered.Operations)
 	}
 	allowed := make(map[string]struct{}, len(allowedVisible))

--- a/gestaltd/internal/server/handlers_identity_tokens.go
+++ b/gestaltd/internal/server/handlers_identity_tokens.go
@@ -41,7 +41,7 @@ func (s *Server) listManagedIdentityTokens(w http.ResponseWriter, r *http.Reques
 	out := make([]apiTokenInfo, 0, len(tokens))
 	for _, token := range tokens {
 		info := apiTokenInfoFromCore(token)
-		info.Permissions = s.filterAccessPermissionsForViewer(effectiveManagedIdentityTokenPermissions(token, grantPermissions), viewer)
+		info.Permissions = s.filterAccessPermissionsForViewer(r.Context(), effectiveManagedIdentityTokenPermissions(token, grantPermissions), viewer)
 		out = append(out, info)
 	}
 	sort.Slice(out, func(i, j int) bool {
@@ -184,14 +184,14 @@ func (s *Server) validateManagedIdentityTokenPermissions(ctx context.Context, id
 	}
 	visibleGrants := make(map[string]*core.ManagedIdentityGrant, len(grants))
 	for _, grant := range grants {
-		if grant == nil || !s.allowProvider(viewer, grant.Plugin) {
+		if grant == nil || !s.allowProviderContext(ctx, viewer, grant.Plugin) {
 			continue
 		}
 		visibleGrants[grant.Plugin] = grant
 	}
 
 	for _, permission := range permissions {
-		if !s.managedIdentityGrantPluginVisible(permission.Plugin, viewer) {
+		if !s.managedIdentityGrantPluginVisible(ctx, permission.Plugin, viewer) {
 			return fmt.Errorf("plugin %q is not available", permission.Plugin)
 		}
 		if !s.managedIdentityInvocationSupported(permission.Plugin) {
@@ -295,13 +295,13 @@ func normalizeAccessPermissions(permissions []core.AccessPermission) []core.Acce
 	return out
 }
 
-func (s *Server) filterAccessPermissionsForViewer(permissions []core.AccessPermission, viewer *principal.Principal) []core.AccessPermission {
+func (s *Server) filterAccessPermissionsForViewer(ctx context.Context, permissions []core.AccessPermission, viewer *principal.Principal) []core.AccessPermission {
 	if len(permissions) == 0 {
 		return nil
 	}
 	filtered := make([]core.AccessPermission, 0, len(permissions))
 	for _, permission := range permissions {
-		if viewer != nil && !s.allowProvider(viewer, permission.Plugin) {
+		if viewer != nil && !s.allowProviderContext(ctx, viewer, permission.Plugin) {
 			continue
 		}
 		filtered = append(filtered, core.AccessPermission{

--- a/gestaltd/internal/server/integration_visibility.go
+++ b/gestaltd/internal/server/integration_visibility.go
@@ -1,6 +1,7 @@
 package server
 
 import (
+	"context"
 	"strings"
 
 	"github.com/valon-technologies/gestalt/server/core"
@@ -8,14 +9,14 @@ import (
 	"github.com/valon-technologies/gestalt/server/internal/principal"
 )
 
-func (s *Server) integrationHasUsableSurface(p *principal.Principal, provider string, prov core.Provider, info integrationInfo) bool {
+func (s *Server) integrationHasUsableSurfaceContext(ctx context.Context, p *principal.Principal, provider string, prov core.Provider, info integrationInfo) bool {
 	if info.MountedPath != "" {
 		return true
 	}
 	if s.integrationHasSettingsSurface(p, info) {
 		return true
 	}
-	return s.integrationHasVisibleHTTPOperations(p, provider, prov)
+	return s.integrationHasVisibleHTTPOperationsContext(ctx, p, provider, prov)
 }
 
 func (s *Server) integrationHasSettingsSurface(p *principal.Principal, info integrationInfo) bool {
@@ -25,22 +26,22 @@ func (s *Server) integrationHasSettingsSurface(p *principal.Principal, info inte
 	return info.Connected || len(info.AuthTypes) > 0 || len(info.Connections) > 0
 }
 
-func (s *Server) integrationHasVisibleHTTPOperations(p *principal.Principal, provider string, prov core.Provider) bool {
+func (s *Server) integrationHasVisibleHTTPOperationsContext(ctx context.Context, p *principal.Principal, provider string, prov core.Provider) bool {
 	cat := prov.Catalog()
 	if cat == nil {
 		return false
 	}
-	cat = invocation.FilterCatalogForPrincipal(cat, provider, p, s.authorizer)
+	cat = invocation.FilterCatalogForPrincipal(ctx, cat, provider, p, s.authorizer)
 	return len(httpVisibleCatalogOperations(cat.Operations)) > 0
 }
 
-func (s *Server) integrationMountedPathForPrincipal(p *principal.Principal, provider, mountedPath string) string {
+func (s *Server) integrationMountedPathForPrincipalContext(ctx context.Context, p *principal.Principal, provider, mountedPath string) string {
 	mountedPath = strings.TrimSpace(mountedPath)
 	if mountedPath == "" {
 		return ""
 	}
 	mounted, ok := s.mountedWebUIForProvider(provider, mountedPath)
-	if !ok || !s.mountedWebUIRootAccessible(p, mounted) {
+	if !ok || !s.mountedWebUIRootAccessibleContext(ctx, p, mounted) {
 		return ""
 	}
 	return mountedPath
@@ -64,7 +65,7 @@ func (s *Server) mountedWebUIForProvider(provider, mountedPath string) (MountedW
 	return MountedWebUI{}, false
 }
 
-func (s *Server) mountedWebUIRootAccessible(p *principal.Principal, mounted MountedWebUI) bool {
+func (s *Server) mountedWebUIRootAccessibleContext(ctx context.Context, p *principal.Principal, mounted MountedWebUI) bool {
 	if mounted.AuthorizationPolicy == "" {
 		return true
 	}
@@ -77,9 +78,9 @@ func (s *Server) mountedWebUIRootAccessible(p *principal.Principal, mounted Moun
 		allowed bool
 	)
 	if mounted.PluginName != "" {
-		access, allowed = s.authorizer.ResolveAccess(p, mounted.PluginName)
+		access, allowed = s.authorizer.ResolveAccess(ctx, p, mounted.PluginName)
 	} else {
-		access, allowed = s.authorizer.ResolvePolicyAccess(p, mounted.AuthorizationPolicy)
+		access, allowed = s.authorizer.ResolvePolicyAccess(ctx, p, mounted.AuthorizationPolicy)
 	}
 	if !allowed {
 		return false

--- a/gestaltd/internal/server/mounted_ui.go
+++ b/gestaltd/internal/server/mounted_ui.go
@@ -326,11 +326,11 @@ func (s *Server) authorizeProtectedUIRequest(w http.ResponseWriter, r *http.Requ
 	)
 	switch {
 	case mounted.PluginName != "":
-		access, allowed = s.authorizer.ResolveAccess(p, mounted.PluginName)
+		access, allowed = s.authorizer.ResolveAccess(r.Context(), p, mounted.PluginName)
 	case mounted.builtInAdmin:
-		access, allowed = s.authorizer.ResolveAdminAccess(p, mounted.AuthorizationPolicy)
+		access, allowed = s.authorizer.ResolveAdminAccess(r.Context(), p, mounted.AuthorizationPolicy)
 	default:
-		access, allowed = s.authorizer.ResolvePolicyAccess(p, mounted.AuthorizationPolicy)
+		access, allowed = s.authorizer.ResolvePolicyAccess(r.Context(), p, mounted.AuthorizationPolicy)
 	}
 	if !allowed {
 		writeError(w, http.StatusForbidden, "app access denied")

--- a/gestaltd/internal/server/server.go
+++ b/gestaltd/internal/server/server.go
@@ -80,7 +80,7 @@ type Server struct {
 	catalogConnection    map[string]string
 	connectionAuth       func() map[string]map[string]bootstrap.OAuthHandler
 	pluginDefs           map[string]*config.ProviderEntry
-	authorizer           *authorization.Authorizer
+	authorizer           authorization.RuntimeAuthorizer
 	noAuth               bool
 	anonymousPrincipal   *principal.Principal
 	publicBaseURL        string
@@ -111,7 +111,7 @@ type Config struct {
 	ConnectionAuth    func() map[string]map[string]bootstrap.OAuthHandler
 	PluginDefs        map[string]*config.ProviderEntry
 	ProviderUIs       map[string]*config.UIEntry
-	Authorizer        *authorization.Authorizer
+	Authorizer        authorization.RuntimeAuthorizer
 	PublicBaseURL     string
 	ManagementBaseURL string
 	SecureCookies     bool


### PR DESCRIPTION
## Summary
- add `authorization.RuntimeAuthorizer` as the internal gestaltd contract used by bootstrap, broker, MCP, and server paths
- wrap the legacy authorizer with `authorization.ProviderBackedAuthorizer` when a `providers.authorization` backend is configured
- sync static human policy members plus dynamic plugin/admin memberships into the selected authorization provider and evaluate human access there
- keep workload token resolution, credential binding, and execution semantics on the legacy authorizer path
- scope reconciliation to Gestalt-managed provider resources, preserve partial dynamic reload snapshots, forward request context into provider evaluations, and keep legacy lifecycle state coherent
- extend existing bootstrap integration coverage to verify provider-backed static and dynamic human access

## Go Interface
```go
type RuntimeAuthorizer interface {
	principal.WorkloadTokenResolver

	Start(ctx context.Context) error
	Close() error
	ReloadDynamic(ctx context.Context) error

	ResolveAccess(ctx context.Context, p *principal.Principal, provider string) (AccessContext, bool)
	ResolvePolicyAccess(ctx context.Context, p *principal.Principal, policyName string) (AccessContext, bool)
	ResolveAdminAccess(ctx context.Context, p *principal.Principal, policyName string) (AccessContext, bool)
	AllowProvider(ctx context.Context, p *principal.Principal, provider string) bool
	AllowOperation(ctx context.Context, p *principal.Principal, provider, operation string) bool
	AllowCatalogOperation(ctx context.Context, p *principal.Principal, provider string, op catalog.CatalogOperation) bool
}
```

## YAML Interface
```yaml
providers:
  authorization:
    indexeddb:
      source:
        ref: github.com/valon-technologies/gestalt-providers/authorization/indexeddb
        version: 0.0.1-alpha.1

server:
  providers:
    authorization: indexeddb
  admin:
    authorizationPolicy: admin-policy

authorization:
  policies:
    calendar-policy:
      default: deny
      members:
        - email: static@example.test
          role: viewer
    admin-policy:
      default: deny
      members:
        - email: seed-admin@example.test
          role: admin

plugins:
  calendar:
    authorizationPolicy: calendar-policy
```

## Example Usage
```go
result, err := bootstrap.Bootstrap(ctx, cfg, factories)
if err != nil {
	return err
}
if err := result.Start(ctx); err != nil {
	return err
}

access, allowed := result.Authorizer.ResolveAccess(ctx, principal, "calendar")
adminAccess, adminAllowed := result.Authorizer.ResolveAdminAccess(ctx, principal, "admin-policy")
```

## Verification
- `go test ./internal/bootstrap ./internal/authorization ./internal/invocation ./internal/mcp ./internal/server`
- `golangci-lint run ./internal/authorization ./internal/server ./internal/bootstrap ./internal/invocation ./internal/mcp`
