### PR TITLE
Clean up portable lock v1 compat and metadata URL examples

### DIFF
--- a/docs/dockerhub/gestaltd.md
+++ b/docs/dockerhub/gestaltd.md
@@ -58,6 +58,7 @@ Generate the encryption key once with `openssl rand -hex 32` and use that value 
 Example minimal config:
 
 ```yaml
+apiVersion: gestaltd.config/v3
 server:
   public:
     port: 8080
@@ -68,9 +69,7 @@ server:
 providers:
   indexeddb:
     main:
-      source:
-        ref: github.com/valon-technologies/gestalt-providers/indexeddb/relationaldb
-        version: 0.0.1-alpha.1
+      source: https://github.com/valon-technologies/gestalt-providers/releases/download/indexeddb/relationaldb/v0.0.1-alpha.1/provider-release.yaml
       config:
         dsn: sqlite:///data/gestalt.db
 

--- a/gestaltd/cmd/gestaltd/e2e_test.go
+++ b/gestaltd/cmd/gestaltd/e2e_test.go
@@ -553,6 +553,7 @@ func authIndexedDBConfigYAML(t *testing.T, dir, authName, datastoreName, dbPath 
 	t.Helper()
 
 	authBlock := ""
+	indexedDBManifestPath := componentProviderManifestPath(t, setupIndexedDBProviderDir(t, dir))
 	serverProvidersBlock := fmt.Sprintf(`  providers:
     indexeddb: %s
 `, datastoreName)
@@ -570,11 +571,10 @@ providers:
 %s  indexeddb:
     %s:
       source:
-        ref: github.com/valon-technologies/gestalt-providers/indexeddb/relationaldb
-        version: 0.0.1-alpha.1
+        path: %s
       config:
         dsn: %q
-`, serverProvidersBlock, authBlock, datastoreName, "sqlite://"+dbPath)
+`, serverProvidersBlock, authBlock, datastoreName, indexedDBManifestPath, "sqlite://"+dbPath)
 }
 
 func writeManifestFile(t *testing.T, pluginDir string, manifest *providermanifestv1.Manifest) {

--- a/gestaltd/deploy/helm/gestalt/values.yaml
+++ b/gestaltd/deploy/helm/gestalt/values.yaml
@@ -73,6 +73,7 @@ persistence:
 # placeholders at startup, so secrets can be injected via extraEnv when
 # you enable OAuth/OIDC or an external datastore below.
 config:
+  apiVersion: gestaltd.config/v3
   server:
     public:
       port: 8080
@@ -96,9 +97,7 @@ config:
       main:
         # SQLite is appropriate for local development or single-instance
         # deployments with mounted persistent storage at /data.
-        source:
-          ref: github.com/valon-technologies/gestalt-providers/indexeddb/relationaldb
-          version: 0.0.1-alpha.1
+        source: https://github.com/valon-technologies/gestalt-providers/releases/download/indexeddb/relationaldb/v0.0.1-alpha.1/provider-release.yaml
         config:
           dsn: "sqlite:///data/gestalt.db"
     # Add providers.ui.<name> entries when you want to mount public static UI bundles.

--- a/gestaltd/internal/bootstrap/provider_build.go
+++ b/gestaltd/internal/bootstrap/provider_build.go
@@ -7,6 +7,7 @@ import (
 	"fmt"
 	"log/slog"
 	"maps"
+	"net/url"
 	"path/filepath"
 	"runtime"
 	"strings"
@@ -958,6 +959,13 @@ func pluginIndexedDBUsesScopedProviderConfig(entry *config.ProviderEntry, cfg ma
 func isRelationalIndexedDBEntry(entry *config.ProviderEntry) bool {
 	if entry == nil {
 		return false
+	}
+	if metadataURL := strings.TrimSpace(entry.SourceMetadataURL()); metadataURL != "" {
+		parsed, err := url.Parse(metadataURL)
+		if err == nil {
+			path := filepath.ToSlash(parsed.Path)
+			return strings.Contains(path, "/indexeddb/relationaldb/") && strings.HasSuffix(path, "/provider-release.yaml")
+		}
 	}
 	if ref := strings.TrimSpace(entry.SourceRef()); ref != "" {
 		return strings.HasSuffix(ref, "/indexeddb/relationaldb")

--- a/gestaltd/internal/operator/lifecycle_test.go
+++ b/gestaltd/internal/operator/lifecycle_test.go
@@ -3584,7 +3584,7 @@ func TestReadLockfile_RejectsLegacyUILockShapeBeforeUnmarshal(t *testing.T) {
 	}
 }
 
-func TestReadLockfile_AcceptsSchemaV1PortableEntries(t *testing.T) {
+func TestReadLockfile_RejectsSchemaV1PortableEntries(t *testing.T) {
 	t.Parallel()
 
 	dir := t.TempDir()
@@ -3608,19 +3608,12 @@ func TestReadLockfile_AcceptsSchemaV1PortableEntries(t *testing.T) {
 		t.Fatalf("WriteFile: %v", err)
 	}
 
-	lock, err := ReadLockfile(lockPath)
-	if err != nil {
-		t.Fatalf("ReadLockfile: %v", err)
+	_, err := ReadLockfile(lockPath)
+	if err == nil {
+		t.Fatal("expected error for schema v1 portable lockfile")
 	}
-	entry, ok := lock.Providers["example"]
-	if !ok {
-		t.Fatal(`lock.Providers["example"] not found`)
-	}
-	if entry.Fingerprint != "provider-fp" {
-		t.Fatalf("Fingerprint = %q, want %q", entry.Fingerprint, "provider-fp")
-	}
-	if entry.Source != "github.com/test-org/test-repo/test-plugin" || entry.Version != "1.0.0" {
-		t.Fatalf("entry = %#v", entry)
+	if !strings.Contains(err.Error(), "unsupported lockfile schema version 1") {
+		t.Fatalf("unexpected error: %v", err)
 	}
 }
 

--- a/gestaltd/internal/operator/localconfig.go
+++ b/gestaltd/internal/operator/localconfig.go
@@ -7,6 +7,7 @@ import (
 	"log/slog"
 	"os"
 	"path/filepath"
+	"strings"
 
 	"github.com/valon-technologies/gestalt/server/internal/config"
 )
@@ -109,8 +110,14 @@ func GenerateDefaultConfig(configDir string) (string, error) {
 	return configPath, nil
 }
 
+func defaultProviderMetadataURL(source, version string) string {
+	rel := strings.TrimPrefix(strings.TrimSpace(source), config.DefaultProviderRepo+"/")
+	return fmt.Sprintf("https://github.com/valon-technologies/gestalt-providers/releases/download/%s/v%s/provider-release.yaml", rel, strings.TrimSpace(version))
+}
+
 func defaultManagedConfig(dbPath, encryptionKey string) string {
-	return fmt.Sprintf(`server:
+	return fmt.Sprintf(`apiVersion: gestaltd.config/v3
+server:
   public:
     port: 8080
   encryptionKey: %q
@@ -119,16 +126,12 @@ func defaultManagedConfig(dbPath, encryptionKey string) string {
 providers:
   indexeddb:
     main:
-      source:
-        ref: %s
-        version: %s
+      source: %s
       config:
         dsn: %q
   ui:
     root:
-      source:
-        ref: %s
-        version: %s
+      source: %s
       path: /
   secrets:
     env:
@@ -136,16 +139,19 @@ providers:
 plugins:
   httpbin:
     displayName: HTTPBin
-    source:
-      ref: %s
-      version: %s
+    source: %s
     allowedHosts:
       - httpbin.org
-`, encryptionKey, config.DefaultIndexedDBProvider, config.DefaultIndexedDBVersion, "sqlite://"+dbPath, config.DefaultWebUIProvider, config.DefaultWebUIVersion, defaultHTTPBinProvider, defaultHTTPBinVersion)
+`, encryptionKey,
+		defaultProviderMetadataURL(config.DefaultIndexedDBProvider, config.DefaultIndexedDBVersion),
+		"sqlite://"+dbPath,
+		defaultProviderMetadataURL(config.DefaultWebUIProvider, config.DefaultWebUIVersion),
+		defaultProviderMetadataURL(defaultHTTPBinProvider, defaultHTTPBinVersion))
 }
 
 func defaultLocalSourceConfig(providersDir, dbPath, encryptionKey string) string {
-	return fmt.Sprintf(`server:
+	return fmt.Sprintf(`apiVersion: gestaltd.config/v3
+server:
   public:
     port: 8080
   encryptionKey: %q

--- a/gestaltd/internal/operator/localconfig_test.go
+++ b/gestaltd/internal/operator/localconfig_test.go
@@ -28,11 +28,9 @@ func TestDefaultManagedConfigIncludesRootWebUI(t *testing.T) {
 	if rootUI == nil {
 		t.Fatal(`Providers.UI["root"] = nil`)
 	}
-	if got := rootUI.SourceRef(); got != config.DefaultWebUIProvider {
-		t.Fatalf(`Providers.UI["root"].Source.Ref = %q, want %q`, got, config.DefaultWebUIProvider)
-	}
-	if got := rootUI.SourceVersion(); got != config.DefaultWebUIVersion {
-		t.Fatalf(`Providers.UI["root"].Source.Version = %q, want %q`, got, config.DefaultWebUIVersion)
+	wantURL := defaultProviderMetadataURL(config.DefaultWebUIProvider, config.DefaultWebUIVersion)
+	if got := rootUI.SourceMetadataURL(); got != wantURL {
+		t.Fatalf(`Providers.UI["root"].SourceMetadataURL() = %q, want %q`, got, wantURL)
 	}
 	if got := rootUI.Path; got != "/" {
 		t.Fatalf(`Providers.UI["root"].Path = %q, want %q`, got, "/")

--- a/gestaltd/internal/operator/lockschema.go
+++ b/gestaltd/internal/operator/lockschema.go
@@ -43,7 +43,6 @@ type providerLockBuckets struct {
 
 type portableLockEntry struct {
 	InputDigest string                 `json:"inputDigest,omitempty"`
-	Fingerprint string                 `json:"fingerprint,omitempty"`
 	Package     string                 `json:"package"`
 	Kind        string                 `json:"kind"`
 	Runtime     string                 `json:"runtime"`
@@ -199,9 +198,7 @@ func validateProviderLockfile(lock *providerLockfile) error {
 	if lock.Schema != providerLockSchemaName {
 		return fmt.Errorf("unsupported lockfile schema %q; run `gestaltd init` to upgrade", lock.Schema)
 	}
-	switch lock.SchemaVersion {
-	case 1, providerLockSchemaVersion:
-	default:
+	if lock.SchemaVersion != providerLockSchemaVersion {
 		return fmt.Errorf("unsupported lockfile schema version %d; run `gestaltd init` to upgrade", lock.SchemaVersion)
 	}
 	return nil
@@ -238,16 +235,12 @@ func lockEntriesFromPortableEntries(entries map[string]portableLockEntry) map[st
 	}
 	runtimeEntries := make(map[string]LockEntry, len(entries))
 	for name, entry := range entries {
-		fingerprint := entry.InputDigest
-		if fingerprint == "" {
-			fingerprint = entry.Fingerprint
-		}
 		source := entry.Source
 		if source == "" {
 			source = entry.Package
 		}
 		runtimeEntries[name] = LockEntry{
-			Fingerprint: fingerprint,
+			Fingerprint: entry.InputDigest,
 			Package:     entry.Package,
 			Kind:        entry.Kind,
 			Runtime:     entry.Runtime,

--- a/gestaltd/internal/testutil/testdata/provider-go/config.yaml
+++ b/gestaltd/internal/testutil/testdata/provider-go/config.yaml
@@ -1,3 +1,4 @@
+apiVersion: gestaltd.config/v3
 server:
   encryptionKey: dev-key-for-example-only
   providers:
@@ -6,9 +7,7 @@ server:
 providers:
   indexeddb:
     main:
-      source:
-        ref: github.com/valon-technologies/gestalt-providers/indexeddb/relationaldb
-        version: 0.0.1-alpha.1
+      source: https://github.com/valon-technologies/gestalt-providers/releases/download/indexeddb/relationaldb/v0.0.1-alpha.1/provider-release.yaml
       config:
         dsn: sqlite://./example.db
 

--- a/gestaltd/internal/testutil/testdata/provider-rust/config.yaml
+++ b/gestaltd/internal/testutil/testdata/provider-rust/config.yaml
@@ -1,3 +1,4 @@
+apiVersion: gestaltd.config/v3
 server:
   encryptionKey: dev-key-for-example-only
   providers:
@@ -6,9 +7,7 @@ server:
 providers:
   indexeddb:
     main:
-      source:
-        ref: github.com/valon-technologies/gestalt-providers/indexeddb/relationaldb
-        version: 0.0.1-alpha.1
+      source: https://github.com/valon-technologies/gestalt-providers/releases/download/indexeddb/relationaldb/v0.0.1-alpha.1/provider-release.yaml
       config:
         dsn: sqlite://./example.db
 


### PR DESCRIPTION
## Summary
- switch shipped docs/examples/default generated config to `apiVersion: gestaltd.config/v3` metadata URL sources
- remove portable lock schema v1 support and legacy `fingerprint` fallback from the portable lock reader
- teach relational IndexedDB detection to recognize metadata URL sources during bootstrap/test setup

## New Config Shape
Managed provider examples now use metadata URLs instead of `source.ref/version`:

```yaml
apiVersion: gestaltd.config/v3

providers:
  indexeddb:
    source: https://github.com/valon-technologies/gestalt-providers/releases/download/indexeddb/relationaldb/v0.0.1-alpha.1/provider-release.yaml
```

Plugin example:

```yaml
apiVersion: gestaltd.config/v3

plugins:
  httpbin:
    source: https://github.com/valon-technologies/gestalt-providers/releases/download/plugin/httpbin/v0.0.1-alpha.1/provider-release.yaml
```

## Portable Lock Behavior
Portable lockfiles must now be schema v2 and provide `inputDigest`; schema v1 and legacy `fingerprint` are rejected.

## Tests
- `go test ./internal/config ./internal/operator ./internal/bootstrap`
- `go test ./cmd/gestaltd -count=1`

## Deferred
I evaluated removing handwritten `source.ref/version` config support entirely, but left that out of this PR. The remaining callers still run through broader managed-source and plugin-owned UI paths, so that removal needs its own migration PR rather than being mixed into this cleanup.