### PR TITLE
gestaltd: add YAML-managed workflow event triggers

### DIFF
--- a/gestaltd/internal/bootstrap/bootstrap.go
+++ b/gestaltd/internal/bootstrap/bootstrap.go
@@ -667,6 +667,9 @@ func Bootstrap(ctx context.Context, cfg *config.Config, factories *FactoryRegist
 	if err := reconcileWorkflowConfigSchedules(ctx, cfg, prepared.Deps.WorkflowRuntime, prepared.Services.DB); err != nil {
 		return nil, err
 	}
+	if err := reconcileWorkflowConfigEventTriggers(ctx, cfg, prepared.Deps.WorkflowRuntime, prepared.Services.DB); err != nil {
+		return nil, err
+	}
 
 	closeProviders = false
 	closeCore = false

--- a/gestaltd/internal/bootstrap/bootstrap_test.go
+++ b/gestaltd/internal/bootstrap/bootstrap_test.go
@@ -127,16 +127,25 @@ func (s *stubWorkflowProvider) Ping(context.Context) error { return nil }
 func (s *stubWorkflowProvider) Close() error               { return nil }
 
 type recordingWorkflowProvider struct {
-	upsertedSchedules     []coreworkflow.UpsertScheduleRequest
-	listedSchedules       []*coreworkflow.Schedule
-	listSchedulesErr      error
-	deletedSchedules      []coreworkflow.DeleteScheduleRequest
-	deleteScheduleErr     error
-	deleteMissingNotFound bool
-	getSchedule           *coreworkflow.Schedule
-	getScheduleErr        error
-	schedules             map[string]*coreworkflow.Schedule
-	closed                *atomic.Bool
+	upsertedSchedules          []coreworkflow.UpsertScheduleRequest
+	listedSchedules            []*coreworkflow.Schedule
+	listSchedulesErr           error
+	deletedSchedules           []coreworkflow.DeleteScheduleRequest
+	deleteScheduleErr          error
+	getSchedule                *coreworkflow.Schedule
+	getScheduleErr             error
+	schedules                  map[string]*coreworkflow.Schedule
+	upsertedEventTriggers      []coreworkflow.UpsertEventTriggerRequest
+	listedEventTriggers        []*coreworkflow.EventTrigger
+	listEventTriggersErr       error
+	deletedEventTriggers       []coreworkflow.DeleteEventTriggerRequest
+	deleteEventTriggerErr      error
+	getEventTrigger            *coreworkflow.EventTrigger
+	getEventTriggerErr         error
+	eventTriggers              map[string]*coreworkflow.EventTrigger
+	deleteMissingNotFound      bool
+	deleteEventMissingNotFound bool
+	closed                     *atomic.Bool
 }
 
 func (p *recordingWorkflowProvider) StartRun(context.Context, coreworkflow.StartRunRequest) (*coreworkflow.Run, error) {
@@ -209,16 +218,55 @@ func (p *recordingWorkflowProvider) PauseSchedule(context.Context, coreworkflow.
 func (p *recordingWorkflowProvider) ResumeSchedule(context.Context, coreworkflow.ResumeScheduleRequest) (*coreworkflow.Schedule, error) {
 	return &coreworkflow.Schedule{}, nil
 }
-func (p *recordingWorkflowProvider) UpsertEventTrigger(context.Context, coreworkflow.UpsertEventTriggerRequest) (*coreworkflow.EventTrigger, error) {
-	return &coreworkflow.EventTrigger{}, nil
+func (p *recordingWorkflowProvider) UpsertEventTrigger(_ context.Context, req coreworkflow.UpsertEventTriggerRequest) (*coreworkflow.EventTrigger, error) {
+	p.upsertedEventTriggers = append(p.upsertedEventTriggers, req)
+	trigger := &coreworkflow.EventTrigger{
+		ID:        req.TriggerID,
+		Match:     req.Match,
+		Target:    req.Target,
+		Paused:    req.Paused,
+		CreatedBy: req.RequestedBy,
+	}
+	if p.eventTriggers == nil {
+		p.eventTriggers = map[string]*coreworkflow.EventTrigger{}
+	}
+	p.eventTriggers[req.TriggerID] = trigger
+	return trigger, nil
 }
-func (p *recordingWorkflowProvider) GetEventTrigger(context.Context, coreworkflow.GetEventTriggerRequest) (*coreworkflow.EventTrigger, error) {
-	return &coreworkflow.EventTrigger{}, nil
+func (p *recordingWorkflowProvider) GetEventTrigger(_ context.Context, req coreworkflow.GetEventTriggerRequest) (*coreworkflow.EventTrigger, error) {
+	if p.getEventTrigger != nil || p.getEventTriggerErr != nil {
+		return p.getEventTrigger, p.getEventTriggerErr
+	}
+	if p.eventTriggers != nil {
+		if trigger, ok := p.eventTriggers[req.TriggerID]; ok {
+			return trigger, nil
+		}
+	}
+	return nil, core.ErrNotFound
 }
 func (p *recordingWorkflowProvider) ListEventTriggers(context.Context, coreworkflow.ListEventTriggersRequest) ([]*coreworkflow.EventTrigger, error) {
-	return nil, nil
+	if p.listEventTriggersErr != nil {
+		return nil, p.listEventTriggersErr
+	}
+	return append([]*coreworkflow.EventTrigger(nil), p.listedEventTriggers...), nil
 }
-func (p *recordingWorkflowProvider) DeleteEventTrigger(context.Context, coreworkflow.DeleteEventTriggerRequest) error {
+func (p *recordingWorkflowProvider) DeleteEventTrigger(_ context.Context, req coreworkflow.DeleteEventTriggerRequest) error {
+	p.deletedEventTriggers = append(p.deletedEventTriggers, req)
+	if p.deleteEventTriggerErr != nil {
+		return p.deleteEventTriggerErr
+	}
+	if p.eventTriggers != nil {
+		if _, ok := p.eventTriggers[req.TriggerID]; ok {
+			delete(p.eventTriggers, req.TriggerID)
+			return nil
+		}
+	}
+	if p.deleteEventMissingNotFound {
+		return core.ErrNotFound
+	}
+	if p.eventTriggers != nil {
+		delete(p.eventTriggers, req.TriggerID)
+	}
 	return nil
 }
 func (p *recordingWorkflowProvider) PauseEventTrigger(context.Context, coreworkflow.PauseEventTriggerRequest) (*coreworkflow.EventTrigger, error) {
@@ -1607,8 +1655,579 @@ func TestBootstrapIgnoresMissingOldScheduleDuringWorkflowProviderMove(t *testing
 	}
 }
 
+func TestBootstrapAppliesConfiguredWorkflowEventTriggers(t *testing.T) {
+	t.Parallel()
+
+	cfg := workflowStartupCallbackConfig("https://example.invalid")
+	cfg.Plugins["roadmap"].Workflow = &config.PluginWorkflowConfig{
+		Provider:   "temporal",
+		Operations: []string{"sync"},
+		EventTriggers: map[string]config.PluginWorkflowEventTrigger{
+			"task_updated": {
+				Match: config.PluginWorkflowEventMatch{
+					Type:   "task.updated",
+					Source: "roadmap",
+				},
+				Operation: "sync",
+				Input: map[string]any{
+					"source": "yaml",
+				},
+			},
+		},
+	}
+	cfg.Providers.Workflow = map[string]*config.ProviderEntry{
+		"temporal": {Source: config.ProviderSource{Path: "stub"}},
+	}
+
+	factories := validFactories()
+	recorders := map[string]*recordingWorkflowProvider{}
+	factories.Workflow = func(_ context.Context, name string, _ yaml.Node, _ []providerhost.HostService, _ bootstrap.Deps) (coreworkflow.Provider, error) {
+		recorder := &recordingWorkflowProvider{}
+		recorders[name] = recorder
+		return recorder, nil
+	}
+
+	result, err := bootstrap.Bootstrap(context.Background(), cfg, factories)
+	if err != nil {
+		t.Fatalf("Bootstrap: %v", err)
+	}
+	defer func() { _ = result.Close(context.Background()) }()
+	<-result.ProvidersReady
+
+	recorder := recorders["temporal"]
+	if recorder == nil {
+		t.Fatal("missing workflow recorder for temporal")
+	}
+	if len(recorder.upsertedEventTriggers) != 1 {
+		t.Fatalf("upserted event triggers = %d, want 1", len(recorder.upsertedEventTriggers))
+	}
+	got := recorder.upsertedEventTriggers[0]
+	if got.TriggerID != workflowConfigEventTriggerID("roadmap", "task_updated") {
+		t.Fatalf("trigger id = %q", got.TriggerID)
+	}
+	if got.Match.Type != "task.updated" || got.Match.Source != "roadmap" || got.Match.Subject != "" {
+		t.Fatalf("match = %#v", got.Match)
+	}
+	if got.Target.PluginName != "roadmap" || got.Target.Operation != "sync" {
+		t.Fatalf("target = %#v", got.Target)
+	}
+	if got.Target.Input["source"] != "yaml" {
+		t.Fatalf("target input = %#v", got.Target.Input)
+	}
+	if got.RequestedBy.SubjectID != "config:workflow:roadmap" || got.RequestedBy.SubjectKind != "system" || got.RequestedBy.AuthSource != "config" {
+		t.Fatalf("requestedBy = %#v", got.RequestedBy)
+	}
+}
+
+func TestValidateDoesNotApplyConfiguredWorkflowEventTriggers(t *testing.T) {
+	t.Parallel()
+
+	cfg := workflowStartupCallbackConfig("https://example.invalid")
+	cfg.Plugins["roadmap"].Workflow = &config.PluginWorkflowConfig{
+		Provider:   "temporal",
+		Operations: []string{"sync"},
+		EventTriggers: map[string]config.PluginWorkflowEventTrigger{
+			"task_updated": {
+				Match: config.PluginWorkflowEventMatch{
+					Type: "task.updated",
+				},
+				Operation: "sync",
+				Paused:    true,
+			},
+		},
+	}
+	cfg.Providers.Workflow = map[string]*config.ProviderEntry{
+		"temporal": {Source: config.ProviderSource{Path: "stub"}},
+	}
+
+	factories := validFactories()
+	recorders := map[string]*recordingWorkflowProvider{}
+	factories.Workflow = func(_ context.Context, name string, _ yaml.Node, _ []providerhost.HostService, _ bootstrap.Deps) (coreworkflow.Provider, error) {
+		recorder := &recordingWorkflowProvider{}
+		recorders[name] = recorder
+		return recorder, nil
+	}
+
+	if _, err := bootstrap.Validate(context.Background(), cfg, factories); err != nil {
+		t.Fatalf("Validate: %v", err)
+	}
+
+	recorder := recorders["temporal"]
+	if recorder == nil {
+		t.Fatal("missing workflow recorder for temporal")
+	}
+	if len(recorder.upsertedEventTriggers) != 0 {
+		t.Fatalf("upserted event triggers = %d, want 0", len(recorder.upsertedEventTriggers))
+	}
+	if len(recorder.deletedEventTriggers) != 0 {
+		t.Fatalf("deleted event triggers = %d, want 0", len(recorder.deletedEventTriggers))
+	}
+}
+
+func TestBootstrapDeletesRemovedConfiguredWorkflowEventTriggers(t *testing.T) {
+	t.Parallel()
+
+	db := &coretesting.StubIndexedDB{}
+	factories := validFactories()
+	factories.IndexedDB = func(yaml.Node) (indexeddb.IndexedDB, error) { return db, nil }
+	recorders := []*recordingWorkflowProvider{}
+	factories.Workflow = func(_ context.Context, _ string, _ yaml.Node, _ []providerhost.HostService, _ bootstrap.Deps) (coreworkflow.Provider, error) {
+		recorder := &recordingWorkflowProvider{}
+		recorders = append(recorders, recorder)
+		return recorder, nil
+	}
+
+	cfg := workflowStartupCallbackConfig("https://example.invalid")
+	cfg.Plugins["roadmap"].Workflow = &config.PluginWorkflowConfig{
+		Provider:   "temporal",
+		Operations: []string{"sync"},
+		EventTriggers: map[string]config.PluginWorkflowEventTrigger{
+			"task_updated": {
+				Match: config.PluginWorkflowEventMatch{
+					Type: "task.updated",
+				},
+				Operation: "sync",
+			},
+		},
+	}
+	cfg.Providers.Workflow = map[string]*config.ProviderEntry{
+		"temporal": {Source: config.ProviderSource{Path: "stub"}},
+	}
+
+	result, err := bootstrap.Bootstrap(context.Background(), cfg, factories)
+	if err != nil {
+		t.Fatalf("Bootstrap: %v", err)
+	}
+	if len(recorders) != 1 || len(recorders[0].upsertedEventTriggers) != 1 {
+		t.Fatalf("initial upserts = %#v", recorders)
+	}
+	_ = result.Close(context.Background())
+
+	cfg = workflowStartupCallbackConfig("https://example.invalid")
+	cfg.Plugins["roadmap"].Workflow = &config.PluginWorkflowConfig{
+		Provider:   "temporal",
+		Operations: []string{"sync"},
+	}
+	cfg.Providers.Workflow = map[string]*config.ProviderEntry{
+		"temporal": {Source: config.ProviderSource{Path: "stub"}},
+	}
+
+	result, err = bootstrap.Bootstrap(context.Background(), cfg, factories)
+	if err != nil {
+		t.Fatalf("Bootstrap remove event trigger: %v", err)
+	}
+	defer func() { _ = result.Close(context.Background()) }()
+	<-result.ProvidersReady
+
+	if len(recorders) != 2 {
+		t.Fatalf("recorders = %d, want 2", len(recorders))
+	}
+	staleID := workflowConfigEventTriggerID("roadmap", "task_updated")
+	recorder := recorders[1]
+	if len(recorder.deletedEventTriggers) != 1 {
+		t.Fatalf("deleted event triggers = %d, want 1", len(recorder.deletedEventTriggers))
+	}
+	if recorder.deletedEventTriggers[0].TriggerID != staleID || recorder.deletedEventTriggers[0].PluginName != "roadmap" {
+		t.Fatalf("delete request = %#v", recorder.deletedEventTriggers[0])
+	}
+	if len(recorder.upsertedEventTriggers) != 0 {
+		t.Fatalf("upserted event triggers = %d, want 0", len(recorder.upsertedEventTriggers))
+	}
+}
+
+func TestBootstrapMovesConfiguredWorkflowEventTriggersToNewProvider(t *testing.T) {
+	t.Parallel()
+
+	db := &coretesting.StubIndexedDB{}
+	factories := validFactories()
+	factories.IndexedDB = func(yaml.Node) (indexeddb.IndexedDB, error) { return db, nil }
+	recorders := map[string][]*recordingWorkflowProvider{}
+	factories.Workflow = func(_ context.Context, name string, _ yaml.Node, _ []providerhost.HostService, _ bootstrap.Deps) (coreworkflow.Provider, error) {
+		recorder := &recordingWorkflowProvider{}
+		recorders[name] = append(recorders[name], recorder)
+		return recorder, nil
+	}
+
+	cfg := workflowStartupCallbackConfig("https://example.invalid")
+	cfg.Plugins["roadmap"].Workflow = &config.PluginWorkflowConfig{
+		Provider:   "temporal",
+		Operations: []string{"sync"},
+		EventTriggers: map[string]config.PluginWorkflowEventTrigger{
+			"task_updated": {
+				Match: config.PluginWorkflowEventMatch{
+					Type: "task.updated",
+				},
+				Operation: "sync",
+			},
+		},
+	}
+	cfg.Providers.Workflow = map[string]*config.ProviderEntry{
+		"temporal": {Source: config.ProviderSource{Path: "stub"}},
+		"backup":   {Source: config.ProviderSource{Path: "stub"}},
+	}
+
+	result, err := bootstrap.Bootstrap(context.Background(), cfg, factories)
+	if err != nil {
+		t.Fatalf("Bootstrap: %v", err)
+	}
+	if len(recorders["temporal"]) != 1 || len(recorders["temporal"][0].upsertedEventTriggers) != 1 {
+		t.Fatalf("initial temporal recorders = %#v", recorders["temporal"])
+	}
+	_ = result.Close(context.Background())
+
+	cfg = workflowStartupCallbackConfig("https://example.invalid")
+	cfg.Plugins["roadmap"].Workflow = &config.PluginWorkflowConfig{
+		Provider:   "backup",
+		Operations: []string{"sync"},
+		EventTriggers: map[string]config.PluginWorkflowEventTrigger{
+			"task_updated": {
+				Match: config.PluginWorkflowEventMatch{
+					Type: "task.updated",
+				},
+				Operation: "sync",
+			},
+		},
+	}
+	cfg.Providers.Workflow = map[string]*config.ProviderEntry{
+		"temporal": {Source: config.ProviderSource{Path: "stub"}},
+		"backup":   {Source: config.ProviderSource{Path: "stub"}},
+	}
+
+	result, err = bootstrap.Bootstrap(context.Background(), cfg, factories)
+	if err != nil {
+		t.Fatalf("Bootstrap move provider: %v", err)
+	}
+	defer func() { _ = result.Close(context.Background()) }()
+	<-result.ProvidersReady
+
+	if len(recorders["temporal"]) != 2 || len(recorders["backup"]) != 2 {
+		t.Fatalf("recorders = %#v", recorders)
+	}
+	if len(recorders["temporal"][1].deletedEventTriggers) != 1 {
+		t.Fatalf("temporal deleted event triggers = %d, want 1", len(recorders["temporal"][1].deletedEventTriggers))
+	}
+	if len(recorders["backup"][1].upsertedEventTriggers) != 1 {
+		t.Fatalf("backup upserted event triggers = %d, want 1", len(recorders["backup"][1].upsertedEventTriggers))
+	}
+}
+
+func TestBootstrapRejectsExistingUnmanagedWorkflowEventTriggerIDDuringProviderMove(t *testing.T) {
+	t.Parallel()
+
+	db := &coretesting.StubIndexedDB{}
+	factories := validFactories()
+	factories.IndexedDB = func(yaml.Node) (indexeddb.IndexedDB, error) { return db, nil }
+	recorders := map[string][]*recordingWorkflowProvider{}
+	factories.Workflow = func(_ context.Context, name string, _ yaml.Node, _ []providerhost.HostService, _ bootstrap.Deps) (coreworkflow.Provider, error) {
+		recorder := &recordingWorkflowProvider{}
+		if name == "backup" && len(recorders[name]) == 1 {
+			recorder.getEventTrigger = &coreworkflow.EventTrigger{ID: workflowConfigEventTriggerID("roadmap", "task_updated")}
+		}
+		recorders[name] = append(recorders[name], recorder)
+		return recorder, nil
+	}
+
+	cfg := workflowStartupCallbackConfig("https://example.invalid")
+	cfg.Plugins["roadmap"].Workflow = &config.PluginWorkflowConfig{
+		Provider:   "temporal",
+		Operations: []string{"sync"},
+		EventTriggers: map[string]config.PluginWorkflowEventTrigger{
+			"task_updated": {
+				Match: config.PluginWorkflowEventMatch{
+					Type: "task.updated",
+				},
+				Operation: "sync",
+			},
+		},
+	}
+	cfg.Providers.Workflow = map[string]*config.ProviderEntry{
+		"temporal": {Source: config.ProviderSource{Path: "stub"}},
+		"backup":   {Source: config.ProviderSource{Path: "stub"}},
+	}
+
+	result, err := bootstrap.Bootstrap(context.Background(), cfg, factories)
+	if err != nil {
+		t.Fatalf("Bootstrap initial: %v", err)
+	}
+	_ = result.Close(context.Background())
+
+	cfg = workflowStartupCallbackConfig("https://example.invalid")
+	cfg.Plugins["roadmap"].Workflow = &config.PluginWorkflowConfig{
+		Provider:   "backup",
+		Operations: []string{"sync"},
+		EventTriggers: map[string]config.PluginWorkflowEventTrigger{
+			"task_updated": {
+				Match: config.PluginWorkflowEventMatch{
+					Type: "task.updated",
+				},
+				Operation: "sync",
+			},
+		},
+	}
+	cfg.Providers.Workflow = map[string]*config.ProviderEntry{
+		"temporal": {Source: config.ProviderSource{Path: "stub"}},
+		"backup":   {Source: config.ProviderSource{Path: "stub"}},
+	}
+
+	_, err = bootstrap.Bootstrap(context.Background(), cfg, factories)
+	if err == nil || !strings.Contains(err.Error(), "conflicts with existing unmanaged trigger id") {
+		t.Fatalf("Bootstrap error = %v, want ownership conflict", err)
+	}
+	if len(recorders["backup"]) != 2 {
+		t.Fatalf("backup recorders = %d, want 2", len(recorders["backup"]))
+	}
+	if len(recorders["backup"][1].upsertedEventTriggers) != 0 {
+		t.Fatalf("backup upserted event triggers = %d, want 0", len(recorders["backup"][1].upsertedEventTriggers))
+	}
+}
+
+func TestBootstrapRejectsExistingUnmanagedWorkflowEventTriggerID(t *testing.T) {
+	t.Parallel()
+
+	cfg := workflowStartupCallbackConfig("https://example.invalid")
+	cfg.Plugins["roadmap"].Workflow = &config.PluginWorkflowConfig{
+		Provider:   "temporal",
+		Operations: []string{"sync"},
+		EventTriggers: map[string]config.PluginWorkflowEventTrigger{
+			"task_updated": {
+				Match: config.PluginWorkflowEventMatch{
+					Type: "task.updated",
+				},
+				Operation: "sync",
+			},
+		},
+	}
+	cfg.Providers.Workflow = map[string]*config.ProviderEntry{
+		"temporal": {Source: config.ProviderSource{Path: "stub"}},
+	}
+
+	recorder := &recordingWorkflowProvider{
+		getEventTrigger: &coreworkflow.EventTrigger{ID: workflowConfigEventTriggerID("roadmap", "task_updated")},
+	}
+	factories := validFactories()
+	factories.Workflow = func(_ context.Context, _ string, _ yaml.Node, _ []providerhost.HostService, _ bootstrap.Deps) (coreworkflow.Provider, error) {
+		return recorder, nil
+	}
+
+	_, err := bootstrap.Bootstrap(context.Background(), cfg, factories)
+	if err == nil || !strings.Contains(err.Error(), "conflicts with existing unmanaged trigger id") {
+		t.Fatalf("Bootstrap error = %v, want ownership conflict", err)
+	}
+	if len(recorder.upsertedEventTriggers) != 0 {
+		t.Fatalf("upserted event triggers = %d, want 0", len(recorder.upsertedEventTriggers))
+	}
+}
+
+func TestBootstrapReAdoptsManagedEventTriggersWhenOwnershipStateIsMissing(t *testing.T) {
+	t.Parallel()
+
+	provider := &recordingWorkflowProvider{}
+	db1 := &coretesting.StubIndexedDB{}
+	db2 := &coretesting.StubIndexedDB{}
+	factories := validFactories()
+	currentDB := db1
+	factories.IndexedDB = func(yaml.Node) (indexeddb.IndexedDB, error) { return currentDB, nil }
+	factories.Workflow = func(_ context.Context, _ string, _ yaml.Node, _ []providerhost.HostService, _ bootstrap.Deps) (coreworkflow.Provider, error) {
+		return provider, nil
+	}
+
+	cfg := workflowStartupCallbackConfig("https://example.invalid")
+	cfg.Plugins["roadmap"].Workflow = &config.PluginWorkflowConfig{
+		Provider:   "temporal",
+		Operations: []string{"sync"},
+		EventTriggers: map[string]config.PluginWorkflowEventTrigger{
+			"task_updated": {
+				Match: config.PluginWorkflowEventMatch{
+					Type: "task.updated",
+				},
+				Operation: "sync",
+			},
+		},
+	}
+	cfg.Providers.Workflow = map[string]*config.ProviderEntry{
+		"temporal": {Source: config.ProviderSource{Path: "stub"}},
+	}
+
+	result, err := bootstrap.Bootstrap(context.Background(), cfg, factories)
+	if err != nil {
+		t.Fatalf("Bootstrap initial: %v", err)
+	}
+	_ = result.Close(context.Background())
+	if len(provider.upsertedEventTriggers) != 1 {
+		t.Fatalf("initial upserted event triggers = %d, want 1", len(provider.upsertedEventTriggers))
+	}
+	provider.eventTriggers[workflowConfigEventTriggerID("roadmap", "task_updated")].Target.Input = map[string]any{
+		"limit": float64(1),
+	}
+
+	currentDB = db2
+	cfg.Plugins["roadmap"].Workflow.EventTriggers["task_updated"] = config.PluginWorkflowEventTrigger{
+		Match: config.PluginWorkflowEventMatch{
+			Type: "task.updated",
+		},
+		Operation: "sync",
+		Input: map[string]any{
+			"limit": 1,
+		},
+	}
+	result, err = bootstrap.Bootstrap(context.Background(), cfg, factories)
+	if err != nil {
+		t.Fatalf("Bootstrap re-adopt: %v", err)
+	}
+	defer func() { _ = result.Close(context.Background()) }()
+	<-result.ProvidersReady
+
+	if len(provider.upsertedEventTriggers) != 2 {
+		t.Fatalf("upserted event triggers = %d, want 2", len(provider.upsertedEventTriggers))
+	}
+}
+
+func TestBootstrapIgnoresMissingRemovedConfiguredWorkflowEventTrigger(t *testing.T) {
+	t.Parallel()
+
+	db := &coretesting.StubIndexedDB{}
+	provider := &recordingWorkflowProvider{deleteEventMissingNotFound: true}
+	factories := validFactories()
+	factories.IndexedDB = func(yaml.Node) (indexeddb.IndexedDB, error) { return db, nil }
+	factories.Workflow = func(_ context.Context, _ string, _ yaml.Node, _ []providerhost.HostService, _ bootstrap.Deps) (coreworkflow.Provider, error) {
+		return provider, nil
+	}
+
+	cfg := workflowStartupCallbackConfig("https://example.invalid")
+	cfg.Plugins["roadmap"].Workflow = &config.PluginWorkflowConfig{
+		Provider:   "temporal",
+		Operations: []string{"sync"},
+		EventTriggers: map[string]config.PluginWorkflowEventTrigger{
+			"task_updated": {
+				Match: config.PluginWorkflowEventMatch{
+					Type: "task.updated",
+				},
+				Operation: "sync",
+			},
+		},
+	}
+	cfg.Providers.Workflow = map[string]*config.ProviderEntry{
+		"temporal": {Source: config.ProviderSource{Path: "stub"}},
+	}
+
+	result, err := bootstrap.Bootstrap(context.Background(), cfg, factories)
+	if err != nil {
+		t.Fatalf("Bootstrap initial: %v", err)
+	}
+	_ = result.Close(context.Background())
+	provider.eventTriggers = map[string]*coreworkflow.EventTrigger{}
+
+	cfg = workflowStartupCallbackConfig("https://example.invalid")
+	cfg.Plugins["roadmap"].Workflow = &config.PluginWorkflowConfig{
+		Provider:   "temporal",
+		Operations: []string{"sync"},
+	}
+	cfg.Providers.Workflow = map[string]*config.ProviderEntry{
+		"temporal": {Source: config.ProviderSource{Path: "stub"}},
+	}
+
+	result, err = bootstrap.Bootstrap(context.Background(), cfg, factories)
+	if err != nil {
+		t.Fatalf("Bootstrap remove missing event trigger: %v", err)
+	}
+	_ = result.Close(context.Background())
+
+	if len(provider.deletedEventTriggers) != 1 {
+		t.Fatalf("deleted event triggers = %d, want 1", len(provider.deletedEventTriggers))
+	}
+
+	result, err = bootstrap.Bootstrap(context.Background(), cfg, factories)
+	if err != nil {
+		t.Fatalf("Bootstrap remove missing event trigger replay: %v", err)
+	}
+	defer func() { _ = result.Close(context.Background()) }()
+	<-result.ProvidersReady
+
+	if len(provider.deletedEventTriggers) != 1 {
+		t.Fatalf("deleted event triggers after replay = %d, want 1", len(provider.deletedEventTriggers))
+	}
+}
+
+func TestBootstrapIgnoresMissingOldEventTriggerDuringWorkflowProviderMove(t *testing.T) {
+	t.Parallel()
+
+	db := &coretesting.StubIndexedDB{}
+	temporal := &recordingWorkflowProvider{deleteEventMissingNotFound: true}
+	backup := &recordingWorkflowProvider{}
+	factories := validFactories()
+	factories.IndexedDB = func(yaml.Node) (indexeddb.IndexedDB, error) { return db, nil }
+	factories.Workflow = func(_ context.Context, name string, _ yaml.Node, _ []providerhost.HostService, _ bootstrap.Deps) (coreworkflow.Provider, error) {
+		if name == "backup" {
+			return backup, nil
+		}
+		return temporal, nil
+	}
+
+	cfg := workflowStartupCallbackConfig("https://example.invalid")
+	cfg.Plugins["roadmap"].Workflow = &config.PluginWorkflowConfig{
+		Provider:   "temporal",
+		Operations: []string{"sync"},
+		EventTriggers: map[string]config.PluginWorkflowEventTrigger{
+			"task_updated": {
+				Match: config.PluginWorkflowEventMatch{
+					Type: "task.updated",
+				},
+				Operation: "sync",
+			},
+		},
+	}
+	cfg.Providers.Workflow = map[string]*config.ProviderEntry{
+		"temporal": {Source: config.ProviderSource{Path: "stub"}},
+		"backup":   {Source: config.ProviderSource{Path: "stub"}},
+	}
+
+	result, err := bootstrap.Bootstrap(context.Background(), cfg, factories)
+	if err != nil {
+		t.Fatalf("Bootstrap initial: %v", err)
+	}
+	_ = result.Close(context.Background())
+	temporal.eventTriggers = map[string]*coreworkflow.EventTrigger{}
+
+	cfg = workflowStartupCallbackConfig("https://example.invalid")
+	cfg.Plugins["roadmap"].Workflow = &config.PluginWorkflowConfig{
+		Provider:   "backup",
+		Operations: []string{"sync"},
+		EventTriggers: map[string]config.PluginWorkflowEventTrigger{
+			"task_updated": {
+				Match: config.PluginWorkflowEventMatch{
+					Type: "task.updated",
+				},
+				Operation: "sync",
+			},
+		},
+	}
+	cfg.Providers.Workflow = map[string]*config.ProviderEntry{
+		"temporal": {Source: config.ProviderSource{Path: "stub"}},
+		"backup":   {Source: config.ProviderSource{Path: "stub"}},
+	}
+
+	result, err = bootstrap.Bootstrap(context.Background(), cfg, factories)
+	if err != nil {
+		t.Fatalf("Bootstrap move provider: %v", err)
+	}
+	defer func() { _ = result.Close(context.Background()) }()
+	<-result.ProvidersReady
+
+	if len(backup.upsertedEventTriggers) != 1 {
+		t.Fatalf("backup upserted event triggers = %d, want 1", len(backup.upsertedEventTriggers))
+	}
+	if len(temporal.deletedEventTriggers) == 0 {
+		t.Fatal("expected temporal cleanup delete to be attempted")
+	}
+}
+
 func workflowConfigScheduleID(pluginName, scheduleKey string) string {
 	sum := sha256.Sum256([]byte(pluginName + "\x00" + scheduleKey))
+	return coreworkflow.ConfigManagedSchedulePrefix + hex.EncodeToString(sum[:])
+}
+
+func workflowConfigEventTriggerID(pluginName, triggerKey string) string {
+	sum := sha256.Sum256([]byte(pluginName + "\x00event_trigger\x00" + triggerKey))
 	return coreworkflow.ConfigManagedSchedulePrefix + hex.EncodeToString(sum[:])
 }
 

--- a/gestaltd/internal/bootstrap/provider_build.go
+++ b/gestaltd/internal/bootstrap/provider_build.go
@@ -791,12 +791,15 @@ func buildPluginWorkflowHostServices(pluginName string, deps Deps) ([]providerho
 	return []providerhost.HostService{{
 		EnvVar: providerhost.DefaultWorkflowSocketEnv,
 		Register: func(srv *grpc.Server) {
-			proto.RegisterWorkflowServer(srv, providerhost.NewWorkflowServer(pluginName, func() (coreworkflow.Provider, map[string]struct{}, map[string]struct{}, error) {
+			proto.RegisterWorkflowServer(srv, providerhost.NewWorkflowServer(pluginName, func() (coreworkflow.Provider, map[string]struct{}, providerhost.WorkflowManagedIDs, error) {
 				provider, allowed, err := deps.WorkflowRuntime.ResolvePlugin(pluginName)
 				if err != nil {
-					return nil, nil, nil, err
+					return nil, nil, providerhost.WorkflowManagedIDs{}, err
 				}
-				return provider, allowed, deps.WorkflowRuntime.ManagedScheduleIDs(pluginName), nil
+				return provider, allowed, providerhost.WorkflowManagedIDs{
+					Schedules:     deps.WorkflowRuntime.ManagedScheduleIDs(pluginName),
+					EventTriggers: deps.WorkflowRuntime.ManagedEventTriggerIDs(pluginName),
+				}, nil
 			}))
 		},
 	}}, nil

--- a/gestaltd/internal/bootstrap/workflow_config_event_triggers.go
+++ b/gestaltd/internal/bootstrap/workflow_config_event_triggers.go
@@ -1,0 +1,271 @@
+package bootstrap
+
+import (
+	"context"
+	"crypto/sha256"
+	"encoding/hex"
+	"fmt"
+	"maps"
+	"slices"
+	"time"
+
+	"github.com/valon-technologies/gestalt/server/core/indexeddb"
+	coreworkflow "github.com/valon-technologies/gestalt/server/core/workflow"
+	"github.com/valon-technologies/gestalt/server/internal/config"
+)
+
+const workflowConfigEventTriggerStateStore = "workflow_config_event_triggers"
+
+var workflowConfigEventTriggerStateSchema = indexeddb.ObjectStoreSchema{
+	Indexes: []indexeddb.IndexSchema{
+		{Name: "by_plugin", KeyPath: []string{"plugin_name"}},
+	},
+	Columns: []indexeddb.ColumnDef{
+		{Name: "id", Type: indexeddb.TypeString, PrimaryKey: true},
+		{Name: "plugin_name", Type: indexeddb.TypeString, NotNull: true},
+		{Name: "trigger_key", Type: indexeddb.TypeString, NotNull: true},
+		{Name: "provider_name", Type: indexeddb.TypeString, NotNull: true},
+		{Name: "trigger_id", Type: indexeddb.TypeString, NotNull: true},
+		{Name: "updated_at", Type: indexeddb.TypeTime},
+	},
+}
+
+type workflowConfigEventTriggerState struct {
+	ID           string
+	PluginName   string
+	TriggerKey   string
+	ProviderName string
+	TriggerID    string
+	UpdatedAt    time.Time
+}
+
+type desiredWorkflowConfigEventTrigger struct {
+	state   workflowConfigEventTriggerState
+	trigger config.PluginWorkflowEventTrigger
+}
+
+func reconcileWorkflowConfigEventTriggers(ctx context.Context, cfg *config.Config, runtime *workflowRuntime, db indexeddb.IndexedDB) error {
+	if cfg == nil || runtime == nil || db == nil {
+		return nil
+	}
+	if err := db.CreateObjectStore(ctx, workflowConfigEventTriggerStateStore, workflowConfigEventTriggerStateSchema); err != nil {
+		return fmt.Errorf("bootstrap: create workflow config event trigger store: %w", err)
+	}
+	store := db.ObjectStore(workflowConfigEventTriggerStateStore)
+	previous, err := loadWorkflowConfigEventTriggerState(ctx, store)
+	if err != nil {
+		return err
+	}
+	desired, err := desiredWorkflowConfigEventTriggers(cfg)
+	if err != nil {
+		return err
+	}
+
+	for _, rowID := range slices.Sorted(maps.Keys(previous)) {
+		prev := previous[rowID]
+		if _, ok := desired[rowID]; ok {
+			continue
+		}
+		provider, err := runtime.ResolveProvider(prev.ProviderName)
+		if err != nil {
+			return fmt.Errorf("bootstrap: cleanup workflow event trigger %q for plugin %q requires provider %q: %w", prev.TriggerID, prev.PluginName, prev.ProviderName, err)
+		}
+		if err := provider.DeleteEventTrigger(ctx, coreworkflow.DeleteEventTriggerRequest{
+			PluginName: prev.PluginName,
+			TriggerID:  prev.TriggerID,
+		}); err != nil {
+			if isWorkflowObjectNotFound(err) {
+				if err := store.Delete(ctx, rowID); err != nil {
+					return fmt.Errorf("bootstrap: delete workflow event trigger state %q: %w", rowID, err)
+				}
+				continue
+			}
+			return fmt.Errorf("bootstrap: delete workflow event trigger %q for plugin %q: %w", prev.TriggerID, prev.PluginName, err)
+		}
+		if err := store.Delete(ctx, rowID); err != nil {
+			return fmt.Errorf("bootstrap: delete workflow event trigger state %q: %w", rowID, err)
+		}
+	}
+
+	for _, pluginName := range slices.Sorted(maps.Keys(cfg.Plugins)) {
+		entry := cfg.Plugins[pluginName]
+		effective, err := cfg.EffectivePluginWorkflow(pluginName, entry)
+		if err != nil {
+			return err
+		}
+		if !effective.Enabled || len(effective.EventTriggers) == 0 {
+			continue
+		}
+		provider, allowed, err := runtime.ResolvePlugin(pluginName)
+		if err != nil {
+			return fmt.Errorf("bootstrap: workflow event triggers for plugin %q: %w", pluginName, err)
+		}
+		for _, triggerKey := range slices.Sorted(maps.Keys(effective.EventTriggers)) {
+			trigger := effective.EventTriggers[triggerKey]
+			if _, ok := allowed[trigger.Operation]; !ok {
+				return fmt.Errorf("bootstrap: workflow event trigger %q for plugin %q targets disabled operation %q", triggerKey, pluginName, trigger.Operation)
+			}
+			rowID := workflowConfigEventTriggerStateID(pluginName, triggerKey)
+			desiredEntry := desired[rowID]
+			prev, owned := previous[rowID]
+			if !owned || prev.ProviderName != desiredEntry.state.ProviderName {
+				existing, err := provider.GetEventTrigger(ctx, coreworkflow.GetEventTriggerRequest{
+					PluginName: pluginName,
+					TriggerID:  desiredEntry.state.TriggerID,
+				})
+				switch {
+				case err == nil:
+					if !isWorkflowConfigOwnedEventTrigger(existing, pluginName, desiredEntry.state.TriggerID) &&
+						!isAdoptableWorkflowEventTrigger(existing, pluginName, trigger, desiredEntry.state.TriggerID) {
+						return fmt.Errorf("bootstrap: workflow event trigger %q for plugin %q conflicts with existing unmanaged trigger id %q", triggerKey, pluginName, desiredEntry.state.TriggerID)
+					}
+				case isWorkflowObjectNotFound(err):
+				default:
+					return fmt.Errorf("bootstrap: get workflow event trigger %q for plugin %q: %w", desiredEntry.state.TriggerID, pluginName, err)
+				}
+			}
+			if _, err := provider.UpsertEventTrigger(ctx, coreworkflow.UpsertEventTriggerRequest{
+				TriggerID:   desiredEntry.state.TriggerID,
+				Match:       workflowConfigEventTriggerMatch(trigger),
+				Target:      workflowConfigEventTriggerTarget(pluginName, trigger),
+				Paused:      trigger.Paused,
+				RequestedBy: workflowConfigActor(pluginName),
+			}); err != nil {
+				return fmt.Errorf("bootstrap: workflow event trigger %q for plugin %q: %w", triggerKey, pluginName, err)
+			}
+			if owned && prev.ProviderName != desiredEntry.state.ProviderName {
+				oldProvider, err := runtime.ResolveProvider(prev.ProviderName)
+				if err != nil {
+					return fmt.Errorf("bootstrap: cleanup workflow event trigger %q for plugin %q requires provider %q: %w", prev.TriggerID, prev.PluginName, prev.ProviderName, err)
+				}
+				if err := oldProvider.DeleteEventTrigger(ctx, coreworkflow.DeleteEventTriggerRequest{
+					PluginName: prev.PluginName,
+					TriggerID:  prev.TriggerID,
+				}); err != nil && !isWorkflowObjectNotFound(err) {
+					return fmt.Errorf("bootstrap: delete workflow event trigger %q for plugin %q: %w", prev.TriggerID, prev.PluginName, err)
+				}
+			}
+			if err := store.Put(ctx, desiredEntry.state.record()); err != nil {
+				return fmt.Errorf("bootstrap: store workflow event trigger state %q: %w", rowID, err)
+			}
+		}
+	}
+	return nil
+}
+
+func desiredWorkflowConfigEventTriggers(cfg *config.Config) (map[string]desiredWorkflowConfigEventTrigger, error) {
+	desired := make(map[string]desiredWorkflowConfigEventTrigger)
+	if cfg == nil {
+		return desired, nil
+	}
+	now := time.Now()
+	for _, pluginName := range slices.Sorted(maps.Keys(cfg.Plugins)) {
+		entry := cfg.Plugins[pluginName]
+		effective, err := cfg.EffectivePluginWorkflow(pluginName, entry)
+		if err != nil {
+			return nil, err
+		}
+		if !effective.Enabled {
+			continue
+		}
+		for _, triggerKey := range slices.Sorted(maps.Keys(effective.EventTriggers)) {
+			rowID := workflowConfigEventTriggerStateID(pluginName, triggerKey)
+			desired[rowID] = desiredWorkflowConfigEventTrigger{
+				state: workflowConfigEventTriggerState{
+					ID:           rowID,
+					PluginName:   pluginName,
+					TriggerKey:   triggerKey,
+					ProviderName: effective.ProviderName,
+					TriggerID:    workflowConfigEventTriggerID(pluginName, triggerKey),
+					UpdatedAt:    now,
+				},
+				trigger: effective.EventTriggers[triggerKey],
+			}
+		}
+	}
+	return desired, nil
+}
+
+func loadWorkflowConfigEventTriggerState(ctx context.Context, store indexeddb.ObjectStore) (map[string]workflowConfigEventTriggerState, error) {
+	recs, err := store.GetAll(ctx, nil)
+	if err != nil {
+		return nil, fmt.Errorf("bootstrap: load workflow event trigger state: %w", err)
+	}
+	state := make(map[string]workflowConfigEventTriggerState, len(recs))
+	for _, rec := range recs {
+		entry := workflowConfigEventTriggerStateFromRecord(rec)
+		state[entry.ID] = entry
+	}
+	return state, nil
+}
+
+func (s workflowConfigEventTriggerState) record() indexeddb.Record {
+	return indexeddb.Record{
+		"id":            s.ID,
+		"plugin_name":   s.PluginName,
+		"trigger_key":   s.TriggerKey,
+		"provider_name": s.ProviderName,
+		"trigger_id":    s.TriggerID,
+		"updated_at":    s.UpdatedAt,
+	}
+}
+
+func workflowConfigEventTriggerStateFromRecord(rec indexeddb.Record) workflowConfigEventTriggerState {
+	return workflowConfigEventTriggerState{
+		ID:           workflowConfigScheduleRecordString(rec, "id"),
+		PluginName:   workflowConfigScheduleRecordString(rec, "plugin_name"),
+		TriggerKey:   workflowConfigScheduleRecordString(rec, "trigger_key"),
+		ProviderName: workflowConfigScheduleRecordString(rec, "provider_name"),
+		TriggerID:    workflowConfigScheduleRecordString(rec, "trigger_id"),
+		UpdatedAt:    workflowConfigScheduleRecordTime(rec, "updated_at"),
+	}
+}
+
+func isAdoptableWorkflowEventTrigger(existing *coreworkflow.EventTrigger, pluginName string, trigger config.PluginWorkflowEventTrigger, triggerID string) bool {
+	if existing == nil {
+		return false
+	}
+	return existing.ID == triggerID &&
+		existing.Match == workflowConfigEventTriggerMatch(trigger) &&
+		existing.Paused == trigger.Paused &&
+		existing.Target.PluginName == pluginName &&
+		existing.Target.Operation == trigger.Operation &&
+		workflowTargetInputsEqual(existing.Target.Input, trigger.Input)
+}
+
+func isWorkflowConfigOwnedEventTrigger(existing *coreworkflow.EventTrigger, pluginName, triggerID string) bool {
+	if existing == nil {
+		return false
+	}
+	actor := workflowConfigActor(pluginName)
+	return existing.ID == triggerID &&
+		existing.Target.PluginName == pluginName &&
+		existing.CreatedBy.SubjectID == actor.SubjectID &&
+		existing.CreatedBy.SubjectKind == actor.SubjectKind &&
+		existing.CreatedBy.AuthSource == actor.AuthSource
+}
+
+func workflowConfigEventTriggerMatch(trigger config.PluginWorkflowEventTrigger) coreworkflow.EventMatch {
+	return coreworkflow.EventMatch{
+		Type:    trigger.Match.Type,
+		Source:  trigger.Match.Source,
+		Subject: trigger.Match.Subject,
+	}
+}
+
+func workflowConfigEventTriggerTarget(pluginName string, trigger config.PluginWorkflowEventTrigger) coreworkflow.Target {
+	return coreworkflow.Target{
+		PluginName: pluginName,
+		Operation:  trigger.Operation,
+		Input:      maps.Clone(trigger.Input),
+	}
+}
+
+func workflowConfigEventTriggerStateID(pluginName, triggerKey string) string {
+	return pluginName + "\x00event_trigger\x00" + triggerKey
+}
+
+func workflowConfigEventTriggerID(pluginName, triggerKey string) string {
+	sum := sha256.Sum256([]byte(pluginName + "\x00event_trigger\x00" + triggerKey))
+	return coreworkflow.ConfigManagedSchedulePrefix + hex.EncodeToString(sum[:])
+}

--- a/gestaltd/internal/bootstrap/workflow_config_schedules.go
+++ b/gestaltd/internal/bootstrap/workflow_config_schedules.go
@@ -80,7 +80,7 @@ func reconcileWorkflowConfigSchedules(ctx context.Context, cfg *config.Config, r
 			PluginName: prev.PluginName,
 			ScheduleID: prev.ScheduleID,
 		}); err != nil {
-			if isWorkflowScheduleNotFound(err) {
+			if isWorkflowObjectNotFound(err) {
 				if err := store.Delete(ctx, rowID); err != nil {
 					return fmt.Errorf("bootstrap: delete workflow schedule state %q: %w", rowID, err)
 				}
@@ -125,7 +125,7 @@ func reconcileWorkflowConfigSchedules(ctx context.Context, cfg *config.Config, r
 						!isAdoptableWorkflowSchedule(existing, pluginName, schedule, desiredEntry.state.ScheduleID) {
 						return fmt.Errorf("bootstrap: workflow schedule %q for plugin %q conflicts with existing unmanaged schedule id %q", scheduleKey, pluginName, desiredEntry.state.ScheduleID)
 					}
-				case isWorkflowScheduleNotFound(err):
+				case isWorkflowObjectNotFound(err):
 				default:
 					return fmt.Errorf("bootstrap: get workflow schedule %q for plugin %q: %w", desiredEntry.state.ScheduleID, pluginName, err)
 				}
@@ -148,7 +148,7 @@ func reconcileWorkflowConfigSchedules(ctx context.Context, cfg *config.Config, r
 				if err := oldProvider.DeleteSchedule(ctx, coreworkflow.DeleteScheduleRequest{
 					PluginName: prev.PluginName,
 					ScheduleID: prev.ScheduleID,
-				}); err != nil && !isWorkflowScheduleNotFound(err) {
+				}); err != nil && !isWorkflowObjectNotFound(err) {
 					return fmt.Errorf("bootstrap: delete workflow schedule %q for plugin %q: %w", prev.ScheduleID, prev.PluginName, err)
 				}
 			}
@@ -244,7 +244,7 @@ func workflowConfigScheduleRecordTime(rec indexeddb.Record, key string) time.Tim
 	return value
 }
 
-func isWorkflowScheduleNotFound(err error) bool {
+func isWorkflowObjectNotFound(err error) bool {
 	return errors.Is(err, core.ErrNotFound) || status.Code(err) == codes.NotFound
 }
 
@@ -258,7 +258,7 @@ func isAdoptableWorkflowSchedule(existing *coreworkflow.Schedule, pluginName str
 		existing.Paused == schedule.Paused &&
 		existing.Target.PluginName == pluginName &&
 		existing.Target.Operation == schedule.Operation &&
-		workflowScheduleInputsEqual(existing.Target.Input, schedule.Input)
+		workflowTargetInputsEqual(existing.Target.Input, schedule.Input)
 }
 
 func isWorkflowConfigOwnedSchedule(existing *coreworkflow.Schedule, pluginName, scheduleID string) bool {
@@ -273,7 +273,7 @@ func isWorkflowConfigOwnedSchedule(existing *coreworkflow.Schedule, pluginName, 
 		existing.CreatedBy.AuthSource == actor.AuthSource
 }
 
-func workflowScheduleInputsEqual(left, right map[string]any) bool {
+func workflowTargetInputsEqual(left, right map[string]any) bool {
 	leftJSON, leftErr := json.Marshal(left)
 	rightJSON, rightErr := json.Marshal(right)
 	return leftErr == nil && rightErr == nil && bytes.Equal(leftJSON, rightJSON)

--- a/gestaltd/internal/bootstrap/workflow_runtime.go
+++ b/gestaltd/internal/bootstrap/workflow_runtime.go
@@ -23,22 +23,24 @@ type workflowBinding struct {
 }
 
 type workflowRuntime struct {
-	mu             sync.RWMutex
-	bindings       map[string]workflowBinding
-	managedIDs     map[string]map[string]struct{}
-	workloadTokens map[string]string
-	providers      map[string]coreworkflow.Provider
-	startupWaits   *startupWaitTracker
-	invoker        invocation.Invoker
+	mu                     sync.RWMutex
+	bindings               map[string]workflowBinding
+	managedScheduleIDs     map[string]map[string]struct{}
+	managedEventTriggerIDs map[string]map[string]struct{}
+	workloadTokens         map[string]string
+	providers              map[string]coreworkflow.Provider
+	startupWaits           *startupWaitTracker
+	invoker                invocation.Invoker
 }
 
 func newWorkflowRuntime(cfg *config.Config) (*workflowRuntime, error) {
 	runtime := &workflowRuntime{
-		bindings:       make(map[string]workflowBinding, len(cfg.Plugins)),
-		managedIDs:     make(map[string]map[string]struct{}, len(cfg.Plugins)),
-		workloadTokens: make(map[string]string, len(cfg.Plugins)),
-		providers:      map[string]coreworkflow.Provider{},
-		startupWaits:   newStartupWaitTracker(),
+		bindings:               make(map[string]workflowBinding, len(cfg.Plugins)),
+		managedScheduleIDs:     make(map[string]map[string]struct{}, len(cfg.Plugins)),
+		managedEventTriggerIDs: make(map[string]map[string]struct{}, len(cfg.Plugins)),
+		workloadTokens:         make(map[string]string, len(cfg.Plugins)),
+		providers:              map[string]coreworkflow.Provider{},
+		startupWaits:           newStartupWaitTracker(),
 	}
 	for pluginName, entry := range cfg.Plugins {
 		effective, err := cfg.EffectivePluginWorkflow(pluginName, entry)
@@ -56,11 +58,16 @@ func newWorkflowRuntime(cfg *config.Config) (*workflowRuntime, error) {
 			providerName: effective.ProviderName,
 			operations:   allowed,
 		}
-		managed := make(map[string]struct{}, len(effective.Schedules))
+		managedSchedules := make(map[string]struct{}, len(effective.Schedules))
 		for scheduleKey := range effective.Schedules {
-			managed[workflowConfigScheduleID(pluginName, scheduleKey)] = struct{}{}
+			managedSchedules[workflowConfigScheduleID(pluginName, scheduleKey)] = struct{}{}
 		}
-		runtime.managedIDs[pluginName] = managed
+		runtime.managedScheduleIDs[pluginName] = managedSchedules
+		managedEventTriggers := make(map[string]struct{}, len(effective.EventTriggers))
+		for triggerKey := range effective.EventTriggers {
+			managedEventTriggers[workflowConfigEventTriggerID(pluginName, triggerKey)] = struct{}{}
+		}
+		runtime.managedEventTriggerIDs[pluginName] = managedEventTriggers
 		runtime.workloadTokens[pluginName], err = workflowWorkloadToken()
 		if err != nil {
 			return nil, err
@@ -193,7 +200,16 @@ func (r *workflowRuntime) ManagedScheduleIDs(pluginName string) map[string]struc
 	}
 	r.mu.RLock()
 	defer r.mu.RUnlock()
-	return maps.Clone(r.managedIDs[pluginName])
+	return maps.Clone(r.managedScheduleIDs[pluginName])
+}
+
+func (r *workflowRuntime) ManagedEventTriggerIDs(pluginName string) map[string]struct{} {
+	if r == nil {
+		return nil
+	}
+	r.mu.RLock()
+	defer r.mu.RUnlock()
+	return maps.Clone(r.managedEventTriggerIDs[pluginName])
 }
 
 func (r *workflowRuntime) Allow(providerName, pluginName, operation string) bool {

--- a/gestaltd/internal/config/config.go
+++ b/gestaltd/internal/config/config.go
@@ -201,9 +201,10 @@ type PluginIndexedDBConfig struct {
 }
 
 type PluginWorkflowConfig struct {
-	Provider   string                            `yaml:"provider,omitempty"`
-	Operations []string                          `yaml:"operations,omitempty"`
-	Schedules  map[string]PluginWorkflowSchedule `yaml:"schedules,omitempty"`
+	Provider      string                                `yaml:"provider,omitempty"`
+	Operations    []string                              `yaml:"operations,omitempty"`
+	Schedules     map[string]PluginWorkflowSchedule     `yaml:"schedules,omitempty"`
+	EventTriggers map[string]PluginWorkflowEventTrigger `yaml:"eventTriggers,omitempty"`
 }
 
 type PluginWorkflowSchedule struct {
@@ -212,6 +213,19 @@ type PluginWorkflowSchedule struct {
 	Operation string         `yaml:"operation,omitempty"`
 	Input     map[string]any `yaml:"input,omitempty"`
 	Paused    bool           `yaml:"paused,omitempty"`
+}
+
+type PluginWorkflowEventTrigger struct {
+	Match     PluginWorkflowEventMatch `yaml:"match,omitempty"`
+	Operation string                   `yaml:"operation,omitempty"`
+	Input     map[string]any           `yaml:"input,omitempty"`
+	Paused    bool                     `yaml:"paused,omitempty"`
+}
+
+type PluginWorkflowEventMatch struct {
+	Type    string `yaml:"type,omitempty"`
+	Source  string `yaml:"source,omitempty"`
+	Subject string `yaml:"subject,omitempty"`
 }
 
 func (c *PluginIndexedDBConfig) UnmarshalYAML(value *yaml.Node) error {

--- a/gestaltd/internal/config/config_test.go
+++ b/gestaltd/internal/config/config_test.go
@@ -2272,6 +2272,15 @@ plugins:
           operation: nightly_sync
           input:
             source: yaml
+      eventTriggers:
+        task_updated:
+          match:
+            type: roadmap.task.updated
+            source: roadmap
+          operation: backfill_items
+          paused: true
+          input:
+            source: event
 providers:
   workflow:
     temporal:
@@ -2301,6 +2310,19 @@ server:
 					Operation: "nightly_sync",
 					Input: map[string]any{
 						"source": "yaml",
+					},
+				},
+			},
+			EventTriggers: map[string]PluginWorkflowEventTrigger{
+				"task_updated": {
+					Match: PluginWorkflowEventMatch{
+						Type:   "roadmap.task.updated",
+						Source: "roadmap",
+					},
+					Operation: "backfill_items",
+					Paused:    true,
+					Input: map[string]any{
+						"source": "event",
 					},
 				},
 			},
@@ -2503,6 +2525,88 @@ server:
 			t.Fatal("Load: expected error, got nil")
 		}
 		if !strings.Contains(err.Error(), `workflow.schedules.invalid.operation "backfill_items" must be listed`) {
+			t.Fatalf("unexpected error: %v", err)
+		}
+	})
+
+	t.Run("rejects workflow event triggers with operations outside workflow bindings", func(t *testing.T) {
+		t.Parallel()
+
+		path := mustWriteConfigFile(t, `
+plugins:
+  roadmap:
+    source:
+      path: ./plugin/manifest.yaml
+    workflow:
+      provider: temporal
+      operations:
+        - nightly_sync
+      eventTriggers:
+        invalid:
+          match:
+            type: roadmap.task.updated
+          operation: backfill_items
+providers:
+  workflow:
+    temporal:
+      source:
+        path: ./providers/workflow/temporal
+  indexeddb:
+    sqlite:
+      source:
+        path: ./providers/datastore/sqlite
+server:
+  providers:
+    indexeddb: sqlite
+  encryptionKey: server-key
+`)
+
+		_, err := Load(path)
+		if err == nil {
+			t.Fatal("Load: expected error, got nil")
+		}
+		if !strings.Contains(err.Error(), `workflow.eventTriggers.invalid.operation "backfill_items" must be listed`) {
+			t.Fatalf("unexpected error: %v", err)
+		}
+	})
+
+	t.Run("rejects workflow event triggers without match type", func(t *testing.T) {
+		t.Parallel()
+
+		path := mustWriteConfigFile(t, `
+plugins:
+  roadmap:
+    source:
+      path: ./plugin/manifest.yaml
+    workflow:
+      provider: temporal
+      operations:
+        - nightly_sync
+      eventTriggers:
+        invalid:
+          match:
+            source: roadmap
+          operation: nightly_sync
+providers:
+  workflow:
+    temporal:
+      source:
+        path: ./providers/workflow/temporal
+  indexeddb:
+    sqlite:
+      source:
+        path: ./providers/datastore/sqlite
+server:
+  providers:
+    indexeddb: sqlite
+  encryptionKey: server-key
+`)
+
+		_, err := Load(path)
+		if err == nil {
+			t.Fatal("Load: expected error, got nil")
+		}
+		if !strings.Contains(err.Error(), `workflow.eventTriggers.invalid.match.type is required`) {
 			t.Fatalf("unexpected error: %v", err)
 		}
 	})

--- a/gestaltd/internal/config/config_validate.go
+++ b/gestaltd/internal/config/config_validate.go
@@ -833,6 +833,33 @@ func validatePluginWorkflowConfig(cfg *Config, name string, entry *ProviderEntry
 		}
 		entry.Workflow.Schedules = normalized
 	}
+	if len(entry.Workflow.EventTriggers) > 0 {
+		normalized := make(map[string]PluginWorkflowEventTrigger, len(entry.Workflow.EventTriggers))
+		for key, trigger := range entry.Workflow.EventTriggers {
+			key = strings.TrimSpace(key)
+			if key == "" {
+				return fmt.Errorf("config validation: plugins.%s.workflow.eventTriggers keys must not be empty", name)
+			}
+			if _, exists := normalized[key]; exists {
+				return fmt.Errorf("config validation: plugins.%s.workflow.eventTriggers duplicates %q", name, key)
+			}
+			trigger.Match.Type = strings.TrimSpace(trigger.Match.Type)
+			if trigger.Match.Type == "" {
+				return fmt.Errorf("config validation: plugins.%s.workflow.eventTriggers.%s.match.type is required", name, key)
+			}
+			trigger.Match.Source = strings.TrimSpace(trigger.Match.Source)
+			trigger.Match.Subject = strings.TrimSpace(trigger.Match.Subject)
+			trigger.Operation = strings.TrimSpace(trigger.Operation)
+			if trigger.Operation == "" {
+				return fmt.Errorf("config validation: plugins.%s.workflow.eventTriggers.%s.operation is required", name, key)
+			}
+			if _, exists := seenOps[trigger.Operation]; !exists {
+				return fmt.Errorf("config validation: plugins.%s.workflow.eventTriggers.%s.operation %q must be listed in plugins.%s.workflow.operations", name, key, trigger.Operation, name)
+			}
+			normalized[key] = trigger
+		}
+		entry.Workflow.EventTriggers = normalized
+	}
 	if _, err := cfg.EffectivePluginWorkflow(name, entry); err != nil {
 		return err
 	}

--- a/gestaltd/internal/config/provider_selection.go
+++ b/gestaltd/internal/config/provider_selection.go
@@ -98,11 +98,12 @@ type EffectiveWorkflowIndexedDB struct {
 }
 
 type EffectivePluginWorkflow struct {
-	Enabled      bool
-	ProviderName string
-	Provider     *ProviderEntry
-	Operations   []string
-	Schedules    map[string]PluginWorkflowSchedule
+	Enabled       bool
+	ProviderName  string
+	Provider      *ProviderEntry
+	Operations    []string
+	Schedules     map[string]PluginWorkflowSchedule
+	EventTriggers map[string]PluginWorkflowEventTrigger
 }
 
 func (c *Config) EffectivePluginIndexedDB(pluginName string, entry *ProviderEntry) (EffectivePluginIndexedDB, error) {
@@ -220,11 +221,12 @@ func ResolveEffectivePluginWorkflow(pluginName string, entry *ProviderEntry, sel
 	}
 
 	return EffectivePluginWorkflow{
-		Enabled:      true,
-		ProviderName: providerName,
-		Provider:     provider,
-		Operations:   slices.Clone(entry.Workflow.Operations),
-		Schedules:    clonePluginWorkflowSchedules(entry.Workflow.Schedules),
+		Enabled:       true,
+		ProviderName:  providerName,
+		Provider:      provider,
+		Operations:    slices.Clone(entry.Workflow.Operations),
+		Schedules:     clonePluginWorkflowSchedules(entry.Workflow.Schedules),
+		EventTriggers: clonePluginWorkflowEventTriggers(entry.Workflow.EventTriggers),
 	}, nil
 }
 
@@ -236,6 +238,18 @@ func clonePluginWorkflowSchedules(src map[string]PluginWorkflowSchedule) map[str
 	for key, schedule := range src {
 		schedule.Input = maps.Clone(schedule.Input)
 		dst[key] = schedule
+	}
+	return dst
+}
+
+func clonePluginWorkflowEventTriggers(src map[string]PluginWorkflowEventTrigger) map[string]PluginWorkflowEventTrigger {
+	if len(src) == 0 {
+		return nil
+	}
+	dst := make(map[string]PluginWorkflowEventTrigger, len(src))
+	for key, trigger := range src {
+		trigger.Input = maps.Clone(trigger.Input)
+		dst[key] = trigger
 	}
 	return dst
 }

--- a/gestaltd/internal/providerhost/workflow_server.go
+++ b/gestaltd/internal/providerhost/workflow_server.go
@@ -12,7 +12,12 @@ import (
 	"google.golang.org/protobuf/types/known/emptypb"
 )
 
-type workflowProviderResolver func() (coreworkflow.Provider, map[string]struct{}, map[string]struct{}, error)
+type WorkflowManagedIDs struct {
+	Schedules     map[string]struct{}
+	EventTriggers map[string]struct{}
+}
+
+type workflowProviderResolver func() (coreworkflow.Provider, map[string]struct{}, WorkflowManagedIDs, error)
 
 type WorkflowServer struct {
 	proto.UnimplementedWorkflowServer
@@ -103,7 +108,7 @@ func (s *WorkflowServer) UpsertSchedule(ctx context.Context, req *proto.UpsertWo
 	if err != nil {
 		return nil, err
 	}
-	if err := rejectManagedWorkflowScheduleID(req.GetScheduleId(), managedIDs); err != nil {
+	if err := rejectManagedWorkflowObjectID("schedule", req.GetScheduleId(), "schedules", managedIDs.Schedules); err != nil {
 		return nil, err
 	}
 	target := pluginWorkflowTargetFromProto(s.pluginName, req.GetTarget())
@@ -164,7 +169,7 @@ func (s *WorkflowServer) DeleteSchedule(ctx context.Context, req *proto.DeleteWo
 	if err != nil {
 		return nil, err
 	}
-	if err := rejectManagedWorkflowScheduleID(req.GetScheduleId(), managedIDs); err != nil {
+	if err := rejectManagedWorkflowObjectID("schedule", req.GetScheduleId(), "schedules", managedIDs.Schedules); err != nil {
 		return nil, err
 	}
 	if err := provider.DeleteSchedule(ctx, coreworkflow.DeleteScheduleRequest{
@@ -181,7 +186,7 @@ func (s *WorkflowServer) PauseSchedule(ctx context.Context, req *proto.PauseWork
 	if err != nil {
 		return nil, err
 	}
-	if err := rejectManagedWorkflowScheduleID(req.GetScheduleId(), managedIDs); err != nil {
+	if err := rejectManagedWorkflowObjectID("schedule", req.GetScheduleId(), "schedules", managedIDs.Schedules); err != nil {
 		return nil, err
 	}
 	value, err := provider.PauseSchedule(ctx, coreworkflow.PauseScheduleRequest{
@@ -199,7 +204,7 @@ func (s *WorkflowServer) ResumeSchedule(ctx context.Context, req *proto.ResumeWo
 	if err != nil {
 		return nil, err
 	}
-	if err := rejectManagedWorkflowScheduleID(req.GetScheduleId(), managedIDs); err != nil {
+	if err := rejectManagedWorkflowObjectID("schedule", req.GetScheduleId(), "schedules", managedIDs.Schedules); err != nil {
 		return nil, err
 	}
 	value, err := provider.ResumeSchedule(ctx, coreworkflow.ResumeScheduleRequest{
@@ -213,8 +218,11 @@ func (s *WorkflowServer) ResumeSchedule(ctx context.Context, req *proto.ResumeWo
 }
 
 func (s *WorkflowServer) UpsertEventTrigger(ctx context.Context, req *proto.UpsertWorkflowEventTriggerRequest) (*proto.WorkflowEventTrigger, error) {
-	provider, allowed, _, err := s.resolve()
+	provider, allowed, managedIDs, err := s.resolve()
 	if err != nil {
+		return nil, err
+	}
+	if err := rejectManagedWorkflowObjectID("event trigger", req.GetTriggerId(), "event triggers", managedIDs.EventTriggers); err != nil {
 		return nil, err
 	}
 	target := pluginWorkflowTargetFromProto(s.pluginName, req.GetTarget())
@@ -270,8 +278,11 @@ func (s *WorkflowServer) ListEventTriggers(ctx context.Context, _ *proto.ListWor
 }
 
 func (s *WorkflowServer) DeleteEventTrigger(ctx context.Context, req *proto.DeleteWorkflowEventTriggerRequest) (*emptypb.Empty, error) {
-	provider, _, _, err := s.resolve()
+	provider, _, managedIDs, err := s.resolve()
 	if err != nil {
+		return nil, err
+	}
+	if err := rejectManagedWorkflowObjectID("event trigger", req.GetTriggerId(), "event triggers", managedIDs.EventTriggers); err != nil {
 		return nil, err
 	}
 	if err := provider.DeleteEventTrigger(ctx, coreworkflow.DeleteEventTriggerRequest{
@@ -284,8 +295,11 @@ func (s *WorkflowServer) DeleteEventTrigger(ctx context.Context, req *proto.Dele
 }
 
 func (s *WorkflowServer) PauseEventTrigger(ctx context.Context, req *proto.PauseWorkflowEventTriggerRequest) (*proto.WorkflowEventTrigger, error) {
-	provider, _, _, err := s.resolve()
+	provider, _, managedIDs, err := s.resolve()
 	if err != nil {
+		return nil, err
+	}
+	if err := rejectManagedWorkflowObjectID("event trigger", req.GetTriggerId(), "event triggers", managedIDs.EventTriggers); err != nil {
 		return nil, err
 	}
 	value, err := provider.PauseEventTrigger(ctx, coreworkflow.PauseEventTriggerRequest{
@@ -299,8 +313,11 @@ func (s *WorkflowServer) PauseEventTrigger(ctx context.Context, req *proto.Pause
 }
 
 func (s *WorkflowServer) ResumeEventTrigger(ctx context.Context, req *proto.ResumeWorkflowEventTriggerRequest) (*proto.WorkflowEventTrigger, error) {
-	provider, _, _, err := s.resolve()
+	provider, _, managedIDs, err := s.resolve()
 	if err != nil {
+		return nil, err
+	}
+	if err := rejectManagedWorkflowObjectID("event trigger", req.GetTriggerId(), "event triggers", managedIDs.EventTriggers); err != nil {
 		return nil, err
 	}
 	value, err := provider.ResumeEventTrigger(ctx, coreworkflow.ResumeEventTriggerRequest{
@@ -425,16 +442,16 @@ func validateWorkflowTargetScope(pluginName string, target coreworkflow.Target, 
 	return status.Errorf(codes.Internal, "workflow %s %q target plugin %q does not match scoped plugin %q", objectKind, objectID, target.PluginName, pluginName)
 }
 
-func (s *WorkflowServer) resolve() (coreworkflow.Provider, map[string]struct{}, map[string]struct{}, error) {
+func (s *WorkflowServer) resolve() (coreworkflow.Provider, map[string]struct{}, WorkflowManagedIDs, error) {
 	if s == nil || s.resolver == nil {
-		return nil, nil, nil, status.Error(codes.FailedPrecondition, "workflow provider is not configured")
+		return nil, nil, WorkflowManagedIDs{}, status.Error(codes.FailedPrecondition, "workflow provider is not configured")
 	}
 	provider, allowed, managedIDs, err := s.resolver()
 	if err != nil {
-		return nil, nil, nil, status.Errorf(codes.FailedPrecondition, "workflow provider: %v", err)
+		return nil, nil, WorkflowManagedIDs{}, status.Errorf(codes.FailedPrecondition, "workflow provider: %v", err)
 	}
 	if provider == nil {
-		return nil, nil, nil, status.Error(codes.FailedPrecondition, "workflow provider is not available")
+		return nil, nil, WorkflowManagedIDs{}, status.Error(codes.FailedPrecondition, "workflow provider is not available")
 	}
 	return provider, allowed, managedIDs, nil
 }
@@ -452,9 +469,9 @@ func validateWorkflowOperationAllowed(operation string, allowed map[string]struc
 	return nil
 }
 
-func rejectManagedWorkflowScheduleID(scheduleID string, managedIDs map[string]struct{}) error {
-	if _, ok := managedIDs[scheduleID]; ok {
-		return status.Errorf(codes.PermissionDenied, "workflow schedule id %q is reserved for config-managed schedules", scheduleID)
+func rejectManagedWorkflowObjectID(kind, objectID, plural string, managedIDs map[string]struct{}) error {
+	if _, ok := managedIDs[objectID]; ok {
+		return status.Errorf(codes.PermissionDenied, "workflow %s id %q is reserved for config-managed %s", kind, objectID, plural)
 	}
 	return nil
 }

--- a/gestaltd/internal/providerhost/workflow_server_test.go
+++ b/gestaltd/internal/providerhost/workflow_server_test.go
@@ -37,6 +37,9 @@ type workflowProviderFunc struct {
 	pauseSchedule      func(context.Context, coreworkflow.PauseScheduleRequest) (*coreworkflow.Schedule, error)
 	resumeSchedule     func(context.Context, coreworkflow.ResumeScheduleRequest) (*coreworkflow.Schedule, error)
 	upsertEventTrigger func(context.Context, coreworkflow.UpsertEventTriggerRequest) (*coreworkflow.EventTrigger, error)
+	deleteEventTrigger func(context.Context, coreworkflow.DeleteEventTriggerRequest) error
+	pauseEventTrigger  func(context.Context, coreworkflow.PauseEventTriggerRequest) (*coreworkflow.EventTrigger, error)
+	resumeEventTrigger func(context.Context, coreworkflow.ResumeEventTriggerRequest) (*coreworkflow.EventTrigger, error)
 }
 
 func (p workflowProviderFunc) StartRun(ctx context.Context, req coreworkflow.StartRunRequest) (*coreworkflow.Run, error) {
@@ -112,15 +115,24 @@ func (p workflowProviderFunc) ListEventTriggers(context.Context, coreworkflow.Li
 	return nil, nil
 }
 
-func (p workflowProviderFunc) DeleteEventTrigger(context.Context, coreworkflow.DeleteEventTriggerRequest) error {
+func (p workflowProviderFunc) DeleteEventTrigger(ctx context.Context, req coreworkflow.DeleteEventTriggerRequest) error {
+	if p.deleteEventTrigger != nil {
+		return p.deleteEventTrigger(ctx, req)
+	}
 	return nil
 }
 
-func (p workflowProviderFunc) PauseEventTrigger(context.Context, coreworkflow.PauseEventTriggerRequest) (*coreworkflow.EventTrigger, error) {
+func (p workflowProviderFunc) PauseEventTrigger(ctx context.Context, req coreworkflow.PauseEventTriggerRequest) (*coreworkflow.EventTrigger, error) {
+	if p.pauseEventTrigger != nil {
+		return p.pauseEventTrigger(ctx, req)
+	}
 	return &coreworkflow.EventTrigger{}, nil
 }
 
-func (p workflowProviderFunc) ResumeEventTrigger(context.Context, coreworkflow.ResumeEventTriggerRequest) (*coreworkflow.EventTrigger, error) {
+func (p workflowProviderFunc) ResumeEventTrigger(ctx context.Context, req coreworkflow.ResumeEventTriggerRequest) (*coreworkflow.EventTrigger, error) {
+	if p.resumeEventTrigger != nil {
+		return p.resumeEventTrigger(ctx, req)
+	}
 	return &coreworkflow.EventTrigger{}, nil
 }
 
@@ -264,13 +276,20 @@ func mustStruct(t *testing.T, value map[string]any) *structpb.Struct {
 	return got
 }
 
+func staticWorkflowResolver(provider coreworkflow.Provider, allowed, managedSchedules, managedEventTriggers map[string]struct{}, err error) workflowProviderResolver {
+	return func() (coreworkflow.Provider, map[string]struct{}, WorkflowManagedIDs, error) {
+		return provider, allowed, WorkflowManagedIDs{
+			Schedules:     managedSchedules,
+			EventTriggers: managedEventTriggers,
+		}, err
+	}
+}
+
 func TestWorkflowServerStartRunScopesTargetToPlugin(t *testing.T) {
 	t.Parallel()
 
 	provider := &recordingWorkflowProvider{}
-	srv := NewWorkflowServer("roadmap", func() (coreworkflow.Provider, map[string]struct{}, map[string]struct{}, error) {
-		return provider, map[string]struct{}{"refresh": {}}, nil, nil
-	})
+	srv := NewWorkflowServer("roadmap", staticWorkflowResolver(provider, map[string]struct{}{"refresh": {}}, nil, nil, nil))
 	ctx := principal.WithPrincipal(context.Background(), &principal.Principal{
 		SubjectID:   principal.UserSubjectID("user-123"),
 		Kind:        principal.KindUser,
@@ -321,9 +340,7 @@ func TestWorkflowServerRejectsDisabledScheduleOperations(t *testing.T) {
 	t.Parallel()
 
 	provider := &recordingWorkflowProvider{}
-	srv := NewWorkflowServer("roadmap", func() (coreworkflow.Provider, map[string]struct{}, map[string]struct{}, error) {
-		return provider, map[string]struct{}{"refresh": {}}, nil, nil
-	})
+	srv := NewWorkflowServer("roadmap", staticWorkflowResolver(provider, map[string]struct{}{"refresh": {}}, nil, nil, nil))
 
 	_, err := srv.UpsertSchedule(context.Background(), &proto.UpsertWorkflowScheduleRequest{
 		ScheduleId: "sched-1",
@@ -392,26 +409,24 @@ func TestWorkflowServerRejectsConfigManagedScheduleMutations(t *testing.T) {
 		t.Run(tc.name, func(t *testing.T) {
 			t.Parallel()
 
-			srv := NewWorkflowServer("roadmap", func() (coreworkflow.Provider, map[string]struct{}, map[string]struct{}, error) {
-				return workflowProviderFunc{
-					upsertSchedule: func(context.Context, coreworkflow.UpsertScheduleRequest) (*coreworkflow.Schedule, error) {
-						t.Fatal("provider UpsertSchedule should not be called for config-managed ids")
-						return nil, nil
-					},
-					deleteSchedule: func(context.Context, coreworkflow.DeleteScheduleRequest) error {
-						t.Fatal("provider DeleteSchedule should not be called for config-managed ids")
-						return nil
-					},
-					pauseSchedule: func(context.Context, coreworkflow.PauseScheduleRequest) (*coreworkflow.Schedule, error) {
-						t.Fatal("provider PauseSchedule should not be called for config-managed ids")
-						return nil, nil
-					},
-					resumeSchedule: func(context.Context, coreworkflow.ResumeScheduleRequest) (*coreworkflow.Schedule, error) {
-						t.Fatal("provider ResumeSchedule should not be called for config-managed ids")
-						return nil, nil
-					},
-				}, map[string]struct{}{"refresh": {}}, map[string]struct{}{managedID: {}}, nil
-			})
+			srv := NewWorkflowServer("roadmap", staticWorkflowResolver(workflowProviderFunc{
+				upsertSchedule: func(context.Context, coreworkflow.UpsertScheduleRequest) (*coreworkflow.Schedule, error) {
+					t.Fatal("provider UpsertSchedule should not be called for config-managed ids")
+					return nil, nil
+				},
+				deleteSchedule: func(context.Context, coreworkflow.DeleteScheduleRequest) error {
+					t.Fatal("provider DeleteSchedule should not be called for config-managed ids")
+					return nil
+				},
+				pauseSchedule: func(context.Context, coreworkflow.PauseScheduleRequest) (*coreworkflow.Schedule, error) {
+					t.Fatal("provider PauseSchedule should not be called for config-managed ids")
+					return nil, nil
+				},
+				resumeSchedule: func(context.Context, coreworkflow.ResumeScheduleRequest) (*coreworkflow.Schedule, error) {
+					t.Fatal("provider ResumeSchedule should not be called for config-managed ids")
+					return nil, nil
+				},
+			}, map[string]struct{}{"refresh": {}}, map[string]struct{}{managedID: {}}, nil, nil))
 
 			err := tc.run(t, srv)
 			if status.Code(err) != codes.PermissionDenied {
@@ -425,9 +440,7 @@ func TestWorkflowServerAllowsUserScheduleIDsThatOnlyShareCfgPrefix(t *testing.T)
 	t.Parallel()
 
 	provider := &recordingWorkflowProvider{}
-	srv := NewWorkflowServer("roadmap", func() (coreworkflow.Provider, map[string]struct{}, map[string]struct{}, error) {
-		return provider, map[string]struct{}{"refresh": {}}, nil, nil
-	})
+	srv := NewWorkflowServer("roadmap", staticWorkflowResolver(provider, map[string]struct{}{"refresh": {}}, nil, nil, nil))
 
 	_, err := srv.UpsertSchedule(context.Background(), &proto.UpsertWorkflowScheduleRequest{
 		ScheduleId: "cfg_backup",
@@ -446,13 +459,111 @@ func TestWorkflowServerAllowsUserScheduleIDsThatOnlyShareCfgPrefix(t *testing.T)
 	}
 }
 
+func TestWorkflowServerRejectsConfigManagedEventTriggerMutations(t *testing.T) {
+	t.Parallel()
+
+	managedID := coreworkflow.ConfigManagedSchedulePrefix + strings.Repeat("b", 64)
+	for _, tc := range []struct {
+		name string
+		run  func(t *testing.T, srv *WorkflowServer) error
+	}{
+		{
+			name: "upsert",
+			run: func(t *testing.T, srv *WorkflowServer) error {
+				_, err := srv.UpsertEventTrigger(context.Background(), &proto.UpsertWorkflowEventTriggerRequest{
+					TriggerId: managedID,
+					Match: &proto.WorkflowEventMatch{
+						Type: "roadmap.task.updated",
+					},
+					Target: &proto.WorkflowTarget{Operation: "refresh"},
+				})
+				return err
+			},
+		},
+		{
+			name: "delete",
+			run: func(t *testing.T, srv *WorkflowServer) error {
+				_, err := srv.DeleteEventTrigger(context.Background(), &proto.DeleteWorkflowEventTriggerRequest{
+					TriggerId: managedID,
+				})
+				return err
+			},
+		},
+		{
+			name: "pause",
+			run: func(t *testing.T, srv *WorkflowServer) error {
+				_, err := srv.PauseEventTrigger(context.Background(), &proto.PauseWorkflowEventTriggerRequest{
+					TriggerId: managedID,
+				})
+				return err
+			},
+		},
+		{
+			name: "resume",
+			run: func(t *testing.T, srv *WorkflowServer) error {
+				_, err := srv.ResumeEventTrigger(context.Background(), &proto.ResumeWorkflowEventTriggerRequest{
+					TriggerId: managedID,
+				})
+				return err
+			},
+		},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+
+			srv := NewWorkflowServer("roadmap", staticWorkflowResolver(workflowProviderFunc{
+				upsertEventTrigger: func(context.Context, coreworkflow.UpsertEventTriggerRequest) (*coreworkflow.EventTrigger, error) {
+					t.Fatal("provider UpsertEventTrigger should not be called for config-managed ids")
+					return nil, nil
+				},
+				deleteEventTrigger: func(context.Context, coreworkflow.DeleteEventTriggerRequest) error {
+					t.Fatal("provider DeleteEventTrigger should not be called for config-managed ids")
+					return nil
+				},
+				pauseEventTrigger: func(context.Context, coreworkflow.PauseEventTriggerRequest) (*coreworkflow.EventTrigger, error) {
+					t.Fatal("provider PauseEventTrigger should not be called for config-managed ids")
+					return nil, nil
+				},
+				resumeEventTrigger: func(context.Context, coreworkflow.ResumeEventTriggerRequest) (*coreworkflow.EventTrigger, error) {
+					t.Fatal("provider ResumeEventTrigger should not be called for config-managed ids")
+					return nil, nil
+				},
+			}, map[string]struct{}{"refresh": {}}, nil, map[string]struct{}{managedID: {}}, nil))
+
+			err := tc.run(t, srv)
+			if status.Code(err) != codes.PermissionDenied {
+				t.Fatalf("status code = %v, want %v", status.Code(err), codes.PermissionDenied)
+			}
+		})
+	}
+}
+
+func TestWorkflowServerAllowsUserEventTriggerIDsThatOnlyShareCfgPrefix(t *testing.T) {
+	t.Parallel()
+
+	provider := &recordingWorkflowProvider{}
+	srv := NewWorkflowServer("roadmap", staticWorkflowResolver(provider, map[string]struct{}{"refresh": {}}, nil, nil, nil))
+
+	_, err := srv.UpsertEventTrigger(context.Background(), &proto.UpsertWorkflowEventTriggerRequest{
+		TriggerId: "cfg_backup",
+		Match: &proto.WorkflowEventMatch{
+			Type: "roadmap.task.updated",
+		},
+		Target: &proto.WorkflowTarget{Operation: "refresh"},
+	})
+	if err != nil {
+		t.Fatalf("UpsertEventTrigger: %v", err)
+	}
+	if provider.upsertEventTriggerReq.TriggerID != "cfg_backup" {
+		t.Fatalf("trigger id = %q, want cfg_backup", provider.upsertEventTriggerReq.TriggerID)
+	}
+}
+
 func TestWorkflowServerPrefersWorkflowCreatorForWorkflowMutations(t *testing.T) {
 	t.Parallel()
 
 	provider := &recordingWorkflowProvider{}
-	srv := NewWorkflowServer("roadmap", func() (coreworkflow.Provider, map[string]struct{}, map[string]struct{}, error) {
-		return provider, map[string]struct{}{"refresh": {}}, nil, nil
-	})
+	srv := NewWorkflowServer("roadmap", staticWorkflowResolver(provider, map[string]struct{}{"refresh": {}}, nil, nil, nil))
 	ctx := principal.WithPrincipal(context.Background(), &principal.Principal{
 		SubjectID:   principal.WorkloadSubjectID("planner"),
 		Kind:        principal.KindWorkload,
@@ -527,20 +638,18 @@ func TestWorkflowServerRejectsCrossPluginProviderResponses(t *testing.T) {
 	t.Run("run", func(t *testing.T) {
 		t.Parallel()
 
-		srv := NewWorkflowServer("roadmap", func() (coreworkflow.Provider, map[string]struct{}, map[string]struct{}, error) {
-			return workflowProviderFunc{
-				startRun: func(context.Context, coreworkflow.StartRunRequest) (*coreworkflow.Run, error) {
-					return &coreworkflow.Run{
-						ID:     "run-1",
-						Status: coreworkflow.RunStatusPending,
-						Target: coreworkflow.Target{
-							PluginName: "analytics",
-							Operation:  "refresh",
-						},
-					}, nil
-				},
-			}, map[string]struct{}{"refresh": {}}, nil, nil
-		})
+		srv := NewWorkflowServer("roadmap", staticWorkflowResolver(workflowProviderFunc{
+			startRun: func(context.Context, coreworkflow.StartRunRequest) (*coreworkflow.Run, error) {
+				return &coreworkflow.Run{
+					ID:     "run-1",
+					Status: coreworkflow.RunStatusPending,
+					Target: coreworkflow.Target{
+						PluginName: "analytics",
+						Operation:  "refresh",
+					},
+				}, nil
+			},
+		}, map[string]struct{}{"refresh": {}}, nil, nil, nil))
 
 		_, err := srv.StartRun(context.Background(), &proto.StartWorkflowRunRequest{
 			Target: &proto.WorkflowTarget{Operation: "refresh"},
@@ -553,21 +662,19 @@ func TestWorkflowServerRejectsCrossPluginProviderResponses(t *testing.T) {
 	t.Run("schedule", func(t *testing.T) {
 		t.Parallel()
 
-		srv := NewWorkflowServer("roadmap", func() (coreworkflow.Provider, map[string]struct{}, map[string]struct{}, error) {
-			return workflowProviderFunc{
-				upsertSchedule: func(context.Context, coreworkflow.UpsertScheduleRequest) (*coreworkflow.Schedule, error) {
-					return &coreworkflow.Schedule{
-						ID:       "sched-1",
-						Cron:     "*/5 * * * *",
-						Timezone: "UTC",
-						Target: coreworkflow.Target{
-							PluginName: "analytics",
-							Operation:  "refresh",
-						},
-					}, nil
-				},
-			}, map[string]struct{}{"refresh": {}}, nil, nil
-		})
+		srv := NewWorkflowServer("roadmap", staticWorkflowResolver(workflowProviderFunc{
+			upsertSchedule: func(context.Context, coreworkflow.UpsertScheduleRequest) (*coreworkflow.Schedule, error) {
+				return &coreworkflow.Schedule{
+					ID:       "sched-1",
+					Cron:     "*/5 * * * *",
+					Timezone: "UTC",
+					Target: coreworkflow.Target{
+						PluginName: "analytics",
+						Operation:  "refresh",
+					},
+				}, nil
+			},
+		}, map[string]struct{}{"refresh": {}}, nil, nil, nil))
 
 		_, err := srv.UpsertSchedule(context.Background(), &proto.UpsertWorkflowScheduleRequest{
 			ScheduleId: "sched-1",
@@ -585,22 +692,20 @@ func TestWorkflowServerRejectsCrossPluginProviderResponses(t *testing.T) {
 	t.Run("event trigger", func(t *testing.T) {
 		t.Parallel()
 
-		srv := NewWorkflowServer("roadmap", func() (coreworkflow.Provider, map[string]struct{}, map[string]struct{}, error) {
-			return workflowProviderFunc{
-				upsertEventTrigger: func(context.Context, coreworkflow.UpsertEventTriggerRequest) (*coreworkflow.EventTrigger, error) {
-					return &coreworkflow.EventTrigger{
-						ID: "trigger-1",
-						Match: coreworkflow.EventMatch{
-							Type: "roadmap.task.updated",
-						},
-						Target: coreworkflow.Target{
-							PluginName: "analytics",
-							Operation:  "refresh",
-						},
-					}, nil
-				},
-			}, map[string]struct{}{"refresh": {}}, nil, nil
-		})
+		srv := NewWorkflowServer("roadmap", staticWorkflowResolver(workflowProviderFunc{
+			upsertEventTrigger: func(context.Context, coreworkflow.UpsertEventTriggerRequest) (*coreworkflow.EventTrigger, error) {
+				return &coreworkflow.EventTrigger{
+					ID: "trigger-1",
+					Match: coreworkflow.EventMatch{
+						Type: "roadmap.task.updated",
+					},
+					Target: coreworkflow.Target{
+						PluginName: "analytics",
+						Operation:  "refresh",
+					},
+				}, nil
+			},
+		}, map[string]struct{}{"refresh": {}}, nil, nil, nil))
 
 		_, err := srv.UpsertEventTrigger(context.Background(), &proto.UpsertWorkflowEventTriggerRequest{
 			TriggerId: "trigger-1",
@@ -621,9 +726,7 @@ func TestWorkflowServerListCallsScopeToPlugin(t *testing.T) {
 	t.Parallel()
 
 	provider := &recordingWorkflowProvider{}
-	srv := NewWorkflowServer("roadmap", func() (coreworkflow.Provider, map[string]struct{}, map[string]struct{}, error) {
-		return provider, map[string]struct{}{"refresh": {}}, nil, nil
-	})
+	srv := NewWorkflowServer("roadmap", staticWorkflowResolver(provider, map[string]struct{}{"refresh": {}}, nil, nil, nil))
 
 	runs, err := srv.ListRuns(context.Background(), &proto.ListWorkflowRunsRequest{})
 	if err != nil {
@@ -810,9 +913,7 @@ func TestWorkflowServerPublishEventScopesPlugin(t *testing.T) {
 	t.Parallel()
 
 	provider := &recordingWorkflowProvider{}
-	srv := NewWorkflowServer("roadmap", func() (coreworkflow.Provider, map[string]struct{}, map[string]struct{}, error) {
-		return provider, map[string]struct{}{"refresh": {}}, nil, nil
-	})
+	srv := NewWorkflowServer("roadmap", staticWorkflowResolver(provider, map[string]struct{}{"refresh": {}}, nil, nil, nil))
 
 	_, err := srv.PublishEvent(context.Background(), &proto.PublishWorkflowEventRequest{
 		Event: &proto.WorkflowEvent{
@@ -834,13 +935,11 @@ func TestWorkflowServerPublishEventScopesPlugin(t *testing.T) {
 func TestWorkflowServerPreservesProviderStatusCodes(t *testing.T) {
 	t.Parallel()
 
-	srv := NewWorkflowServer("roadmap", func() (coreworkflow.Provider, map[string]struct{}, map[string]struct{}, error) {
-		return workflowProviderFunc{
-			getRun: func(context.Context, coreworkflow.GetRunRequest) (*coreworkflow.Run, error) {
-				return nil, status.Error(codes.NotFound, "missing run")
-			},
-		}, map[string]struct{}{"refresh": {}}, nil, nil
-	})
+	srv := NewWorkflowServer("roadmap", staticWorkflowResolver(workflowProviderFunc{
+		getRun: func(context.Context, coreworkflow.GetRunRequest) (*coreworkflow.Run, error) {
+			return nil, status.Error(codes.NotFound, "missing run")
+		},
+	}, map[string]struct{}{"refresh": {}}, nil, nil, nil))
 
 	_, err := srv.GetRun(context.Background(), &proto.GetWorkflowRunRequest{RunId: "run-123"})
 	if status.Code(err) != codes.NotFound {


### PR DESCRIPTION
## Summary

Add YAML-managed workflow event triggers for plugin workflow bindings.

This mirrors the existing YAML-managed schedule flow:
- config accepts `plugins.<plugin>.workflow.eventTriggers`
- bootstrap reconciles those triggers into the bound workflow provider
- `gestaltd` stores ownership rows in system IndexedDB
- plugin workflow clients cannot mutate config-managed trigger ids on `GESTALT_WORKFLOW_SOCKET`

## YAML interface

```yaml
plugins:
  roadmap:
    workflow:
      provider: basic
      operations:
        - sync_tasks
        - rebuild_index
      eventTriggers:
        task_updated:
          match:
            type: task.updated
            source: roadmap
          operation: sync_tasks
          input:
            source: yaml
        search_reindexed:
          match:
            type: task.reindexed
            subject: search
          operation: rebuild_index
          paused: true
```

## Go interfaces

```go
type PluginWorkflowConfig struct {
    Provider      string
    Operations    []string
    Schedules     map[string]PluginWorkflowSchedule
    EventTriggers map[string]PluginWorkflowEventTrigger
}

type PluginWorkflowEventTrigger struct {
    Match     PluginWorkflowEventMatch
    Operation string
    Input     map[string]any
    Paused    bool
}

type PluginWorkflowEventMatch struct {
    Type    string
    Source  string
    Subject string
}
```

## Examples

YAML-managed trigger:

```yaml
plugins:
  roadmap:
    workflow:
      provider: basic
      operations: [sync_tasks]
      eventTriggers:
        task_updated:
          match:
            type: task.updated
            source: roadmap
          operation: sync_tasks
```

Runtime publication that matches the YAML trigger:

```go
workflow, err := gestalt.Workflow()
if err != nil {
    return err
}

err = workflow.PublishEvent(ctx, &proto.WorkflowEvent{
    Id:     "evt-123",
    Type:   "task.updated",
    Source: "roadmap",
})
if err != nil {
    return err
}
```

## Behavior

- trigger ids are deterministic `cfg_<hash>` ids derived from `(plugin, trigger key)`
- bootstrap re-adopts config-managed provider triggers when IndexedDB ownership state is missing
- bootstrap deletes provider triggers removed from YAML and tolerates `NotFound` on retry
- bootstrap moves config-managed triggers when the plugin workflow provider binding changes
- plugin workflow clients reject mutation of config-managed trigger ids

## Verification

- `go test ./internal/config ./internal/bootstrap ./internal/providerhost -count=1`
