### PR TITLE
gestaltd: fix authorization provider release target detection

### DIFF
--- a/gestaltd/cmd/gestaltd/plugin.go
+++ b/gestaltd/cmd/gestaltd/plugin.go
@@ -1,7 +1,6 @@
 package main
 
 import (
-	"errors"
 	"flag"
 	"fmt"
 	"io"
@@ -187,13 +186,13 @@ func resolveReleaseBuildTarget(root string, manifest *providermanifestv1.Manifes
 	if kind == providermanifestv1.KindWebUI {
 		return nil, nil
 	}
-	hasSource, err := detectReleaseSourceBuildTarget(root, kind)
+	hasSource, err := providerpkg.HasSourceReleaseTarget(root, kind)
 	if err != nil {
 		return nil, fmt.Errorf("detect source %s package: %w", kind, err)
 	}
 	if !hasSource {
-		if releaseRequiresBuildTarget(manifest) {
-			return nil, missingReleaseSourceBuildTargetError(kind)
+		if providerpkg.ReleaseRequiresBuild(manifest) {
+			return nil, providerpkg.MissingSourceReleaseTargetError(kind)
 		}
 		return nil, nil
 	}
@@ -205,7 +204,7 @@ func resolveReleaseBuildPlatforms(root string, manifest *providermanifestv1.Mani
 		return nil, nil
 	}
 
-	buildRequired := releaseRequiresBuildTarget(manifest)
+	buildRequired := providerpkg.ReleaseRequiresBuild(manifest)
 	if !buildRequired && !explicit {
 		return nil, nil
 	}
@@ -226,8 +225,8 @@ func resolveReleaseBuildPlatforms(root string, manifest *providermanifestv1.Mani
 	builds := make([]releasePlatform, 0, len(platforms))
 	var missingSource bool
 	for _, platform := range platforms {
-		if err := validateReleaseBuildTarget(root, target.Kind, platform.GOOS, platform.GOARCH); err != nil {
-			if isMissingReleaseSourceBuildTarget(err, target.Kind) {
+		if err := providerpkg.ValidateSourceReleaseTarget(root, target.Kind, platform.GOOS, platform.GOARCH); err != nil {
+			if providerpkg.IsMissingSourceReleaseTarget(err, target.Kind) {
 				missingSource = true
 				continue
 			}
@@ -237,10 +236,10 @@ func resolveReleaseBuildPlatforms(root string, manifest *providermanifestv1.Mani
 	}
 
 	if len(builds) == 0 {
-		return nil, missingReleaseSourceBuildTargetError(target.Kind)
+		return nil, providerpkg.MissingSourceReleaseTargetError(target.Kind)
 	}
 	if missingSource {
-		return nil, missingReleaseSourceBuildTargetError(target.Kind)
+		return nil, providerpkg.MissingSourceReleaseTargetError(target.Kind)
 	}
 	return builds, nil
 }
@@ -288,65 +287,6 @@ func createReleaseArchive(outputDir, archiveName string, prepare func(stagingDir
 
 	_, _ = fmt.Fprintf(os.Stdout, "created %s\n", archivePath)
 	return archivePath, nil
-}
-
-func releaseRequiresBuildTarget(manifest *providermanifestv1.Manifest) bool {
-	kind, err := providerpkg.ManifestKind(manifest)
-	if err != nil {
-		return false
-	}
-	switch kind {
-	case providermanifestv1.KindPlugin:
-		return manifest.Entrypoint == nil && (manifest.Spec == nil || !manifest.Spec.IsManifestBacked())
-	case providermanifestv1.KindAuth, providermanifestv1.KindIndexedDB, providermanifestv1.KindCache, providermanifestv1.KindS3, providermanifestv1.KindWorkflow, providermanifestv1.KindSecrets:
-		return providerpkg.EntrypointForKind(manifest, kind) == nil
-	default:
-		return false
-	}
-}
-
-func detectReleaseSourceBuildTarget(root, kind string) (bool, error) {
-	switch kind {
-	case providermanifestv1.KindPlugin:
-		return providerpkg.HasSourceProviderPackage(root)
-	case providermanifestv1.KindAuth, providermanifestv1.KindIndexedDB, providermanifestv1.KindCache, providermanifestv1.KindS3, providermanifestv1.KindWorkflow, providermanifestv1.KindSecrets:
-		return providerpkg.HasSourceComponentPackage(root, kind)
-	default:
-		return false, fmt.Errorf("unsupported release build target kind %q", kind)
-	}
-}
-
-func validateReleaseBuildTarget(root, kind, goos, goarch string) error {
-	switch kind {
-	case providermanifestv1.KindPlugin:
-		return providerpkg.ValidateSourceProviderRelease(root, goos, goarch)
-	case providermanifestv1.KindAuth, providermanifestv1.KindIndexedDB, providermanifestv1.KindCache, providermanifestv1.KindS3, providermanifestv1.KindWorkflow, providermanifestv1.KindSecrets:
-		return providerpkg.ValidateSourceComponentRelease(root, kind, goos, goarch)
-	default:
-		return fmt.Errorf("unsupported release build target kind %q", kind)
-	}
-}
-
-func isMissingReleaseSourceBuildTarget(err error, kind string) bool {
-	switch kind {
-	case providermanifestv1.KindPlugin:
-		return errors.Is(err, providerpkg.ErrNoSourceProviderPackage)
-	case providermanifestv1.KindAuth, providermanifestv1.KindIndexedDB, providermanifestv1.KindCache, providermanifestv1.KindS3, providermanifestv1.KindWorkflow, providermanifestv1.KindSecrets:
-		return errors.Is(err, providerpkg.ErrNoSourceComponentPackage)
-	default:
-		return false
-	}
-}
-
-func missingReleaseSourceBuildTargetError(kind string) error {
-	switch kind {
-	case providermanifestv1.KindPlugin:
-		return fmt.Errorf("no Go, Rust, Python, or TypeScript provider package found")
-	case providermanifestv1.KindAuth, providermanifestv1.KindCache, providermanifestv1.KindIndexedDB, providermanifestv1.KindS3, providermanifestv1.KindWorkflow, providermanifestv1.KindSecrets:
-		return fmt.Errorf("no Go, Rust, Python, or TypeScript %s source package found", kind)
-	default:
-		return fmt.Errorf("unsupported release build target kind %q", kind)
-	}
 }
 
 func parseReleasePlatforms(value string) ([]releasePlatform, error) {

--- a/gestaltd/cmd/gestaltd/plugin_test.go
+++ b/gestaltd/cmd/gestaltd/plugin_test.go
@@ -28,31 +28,34 @@ import (
 )
 
 const (
-	releaseTestPluginName        = "release-test"
-	releaseTestSource            = "github.com/testowner/plugins/catalog/release-test"
-	releaseTestModule            = "example.com/release-test"
-	releaseTestIconPath          = "branding/icon.svg"
-	releaseProviderSchemaPath    = "schemas/provider.schema.json"
-	declarativeReleasePluginName = "declarative-release"
-	declarativeReleaseSource     = "github.com/testowner/plugins/catalog/declarative-release"
-	webUITestPluginName          = "webui-test"
-	webUITestSource              = "github.com/testowner/plugins/catalog/webui-test"
-	webUITestAssetRoot           = "out"
-	prebuiltProviderPluginName   = "prebuilt-provider"
-	prebuiltProviderSource       = "github.com/testowner/plugins/prebuilt-provider"
-	prebuiltProviderBinaryPath   = "bin/provider"
-	authReleasePluginName        = "auth-release"
-	authReleaseSource            = "github.com/testowner/plugins/auth-release"
-	authReleaseSchemaPath        = "schemas/auth.schema.json"
-	secretsReleasePluginName     = "secrets-release"
-	secretsReleaseSource         = "github.com/testowner/plugins/secrets-release"
-	secretsReleaseSchemaPath     = "schemas/secrets.schema.json"
-	rustReleasePluginName        = "provider-rust"
-	rustWrapperBinaryName        = "gestalt-provider-wrapper"
-	pythonAuthReleasePluginName  = "python-auth-release"
-	pythonAuthReleaseSource      = "github.com/testowner/plugins/python-auth-release"
-	authReleaseTypeScriptModule  = "./auth.ts#auth"
-	authReleaseTypeScriptTarget  = "auth:./auth.ts#auth"
+	releaseTestPluginName          = "release-test"
+	releaseTestSource              = "github.com/testowner/plugins/catalog/release-test"
+	releaseTestModule              = "example.com/release-test"
+	releaseTestIconPath            = "branding/icon.svg"
+	releaseProviderSchemaPath      = "schemas/provider.schema.json"
+	declarativeReleasePluginName   = "declarative-release"
+	declarativeReleaseSource       = "github.com/testowner/plugins/catalog/declarative-release"
+	webUITestPluginName            = "webui-test"
+	webUITestSource                = "github.com/testowner/plugins/catalog/webui-test"
+	webUITestAssetRoot             = "out"
+	prebuiltProviderPluginName     = "prebuilt-provider"
+	prebuiltProviderSource         = "github.com/testowner/plugins/prebuilt-provider"
+	prebuiltProviderBinaryPath     = "bin/provider"
+	authReleasePluginName          = "auth-release"
+	authReleaseSource              = "github.com/testowner/plugins/auth-release"
+	authReleaseSchemaPath          = "schemas/auth.schema.json"
+	authorizationReleasePluginName = "authorization-release"
+	authorizationReleaseSource     = "github.com/testowner/plugins/authorization-release"
+	authorizationReleaseSchemaPath = "schemas/authorization.schema.json"
+	secretsReleasePluginName       = "secrets-release"
+	secretsReleaseSource           = "github.com/testowner/plugins/secrets-release"
+	secretsReleaseSchemaPath       = "schemas/secrets.schema.json"
+	rustReleasePluginName          = "provider-rust"
+	rustWrapperBinaryName          = "gestalt-provider-wrapper"
+	pythonAuthReleasePluginName    = "python-auth-release"
+	pythonAuthReleaseSource        = "github.com/testowner/plugins/python-auth-release"
+	authReleaseTypeScriptModule    = "./auth.ts#auth"
+	authReleaseTypeScriptTarget    = "auth:./auth.ts#auth"
 )
 
 func TestRun_ProviderCLIUsageAndErrors(t *testing.T) {
@@ -286,7 +289,6 @@ func TestRun_PluginReleaseBuildsPythonSourcePluginForCurrentPlatform(t *testing.
 
 	runPluginReleaseCommand(t, pluginDir,
 		"--version", testVersion,
-		"--platform", runtime.GOOS+"/"+runtime.GOARCH,
 		"--output", outputDir,
 	)
 
@@ -790,6 +792,107 @@ func TestRun_PluginReleaseBuildsGoSourceAuthPlugin(t *testing.T) {
 		t.Fatalf("validated = %+v", validated)
 	}
 }
+
+func TestRun_PluginReleaseBuildsGoSourceAuthorizationProvider(t *testing.T) {
+	t.Parallel()
+
+	pluginDir := newSourceComponentReleaseFixture(t, t.TempDir(), sourceComponentReleaseFixtureParams{
+		pluginName: authorizationReleasePluginName,
+		schemaPath: authorizationReleaseSchemaPath,
+		sourceFile: "authorization.go",
+		sourceCode: testutil.GeneratedAuthorizationPackageSource(),
+		manifest: &providermanifestv1.Manifest{
+			Kind:   providermanifestv1.KindAuthorization,
+			Source: authorizationReleaseSource, Version: "0.0.1", DisplayName: "Authorization Release",
+			Spec: &providermanifestv1.Spec{ConfigSchemaPath: authorizationReleaseSchemaPath},
+		},
+	})
+	outputDir := t.TempDir()
+	const testVersion = "0.0.18-test"
+
+	runPluginReleaseCommand(t, pluginDir,
+		"--version", testVersion,
+		"--platform", runtime.GOOS+"/"+runtime.GOARCH,
+		"--output", outputDir,
+	)
+
+	archiveName := platformArchiveNameForTest(authorizationReleasePluginName, testVersion, runtime.GOOS, runtime.GOARCH)
+	extractDir := extractReleasedArchive(t, outputDir, archiveName)
+	manifest := readReleasedManifest(t, outputDir, archiveName)
+	binaryName := releaseBinaryName(authorizationReleasePluginName, runtime.GOOS)
+
+	if len(manifest.Artifacts) != 1 || manifest.Artifacts[0].Path != binaryName {
+		t.Fatalf("artifacts = %+v, want path %q", manifest.Artifacts, binaryName)
+	}
+	assertExpectedGoArtifactPlatform(t, manifest.Artifacts[0], runtime.GOOS, runtime.GOARCH, "")
+	if manifest.Entrypoint == nil || manifest.Entrypoint.ArtifactPath != binaryName {
+		t.Fatalf("authorization entrypoint = %+v, want artifact path %q", manifest.Entrypoint, binaryName)
+	}
+	if _, err := os.Stat(filepath.Join(extractDir, authorizationReleaseSchemaPath)); err != nil {
+		t.Fatalf("expected %s in archive: %v", authorizationReleaseSchemaPath, err)
+	}
+
+	metadata := readProviderReleaseMetadata(t, outputDir)
+	if metadata.Package != authorizationReleaseSource {
+		t.Fatalf("release metadata package = %q, want %q", metadata.Package, authorizationReleaseSource)
+	}
+	if metadata.Kind != providermanifestv1.KindAuthorization {
+		t.Fatalf("release metadata kind = %q, want %q", metadata.Kind, providermanifestv1.KindAuthorization)
+	}
+	if metadata.Runtime != providerReleaseRuntimeKindExecutable {
+		t.Fatalf("release metadata runtime = %q, want %q", metadata.Runtime, providerReleaseRuntimeKindExecutable)
+	}
+
+	authz, err := providerhost.NewExecutableAuthorizationProvider(context.Background(), providerhost.AuthorizationExecConfig{
+		Command: filepath.Join(extractDir, binaryName),
+		Name:    "authorization-release",
+	})
+	if err != nil {
+		t.Fatalf("NewExecutableAuthorizationProvider: %v", err)
+	}
+	defer func() {
+		if closer, ok := authz.(interface{ Close() error }); ok {
+			_ = closer.Close()
+		}
+	}()
+
+	decision, err := authz.Evaluate(context.Background(), &core.AccessEvaluationRequest{
+		Subject:  &core.SubjectRef{Type: "user", Id: "generated-user"},
+		Action:   &core.ActionRef{Name: "invoke"},
+		Resource: &core.ResourceRef{Type: "plugin", Id: "github"},
+	})
+	if err != nil {
+		t.Fatalf("Evaluate: %v", err)
+	}
+	if decision == nil || !decision.Allowed || decision.ModelId != "model-v1" {
+		t.Fatalf("decision = %+v", decision)
+	}
+
+	providerMetadata, err := authz.GetMetadata(context.Background())
+	if err != nil {
+		t.Fatalf("GetMetadata: %v", err)
+	}
+	if providerMetadata == nil || providerMetadata.ActiveModelId != "model-v1" {
+		t.Fatalf("metadata = %+v", providerMetadata)
+	}
+
+	activeModel, err := authz.GetActiveModel(context.Background())
+	if err != nil {
+		t.Fatalf("GetActiveModel: %v", err)
+	}
+	if activeModel == nil || activeModel.Model == nil || activeModel.Model.Id != "model-v1" {
+		t.Fatalf("active model = %+v", activeModel)
+	}
+
+	relationships, err := authz.ReadRelationships(context.Background(), &core.ReadRelationshipsRequest{})
+	if err != nil {
+		t.Fatalf("ReadRelationships: %v", err)
+	}
+	if relationships == nil || len(relationships.Relationships) != 1 {
+		t.Fatalf("relationships = %+v", relationships)
+	}
+}
+
 func TestRun_PluginReleaseBuildsGoSourceSecretsPlugin(t *testing.T) {
 	t.Parallel()
 
@@ -1687,6 +1790,17 @@ func TestRun_PluginReleaseRejectsRequiredExecutableKindsWithoutSourceOrEntrypoin
 				Spec:        &providermanifestv1.Spec{},
 			},
 			wantError: "no Go, Rust, Python, or TypeScript auth source package found",
+		},
+		{
+			name: "authorization",
+			manifest: &providermanifestv1.Manifest{
+				Kind:        providermanifestv1.KindAuthorization,
+				Source:      "github.com/testowner/plugins/missing-authorization",
+				Version:     "0.0.1",
+				DisplayName: "Missing Authorization",
+				Spec:        &providermanifestv1.Spec{},
+			},
+			wantError: "no Go authorization source package found",
 		},
 		{
 			name: "secrets",

--- a/gestaltd/internal/testutil/sdkplugin.go
+++ b/gestaltd/internal/testutil/sdkplugin.go
@@ -195,6 +195,100 @@ func (p *Provider) SessionTTL() time.Duration { return 90 * time.Minute }
 `
 }
 
+func GeneratedAuthorizationPackageSource() string {
+	return `package authorization
+
+import (
+	"context"
+
+	gestalt "github.com/valon-technologies/gestalt/sdk/go"
+)
+
+type Provider struct{}
+
+func New() *Provider { return &Provider{} }
+
+func (p *Provider) Configure(context.Context, string, map[string]any) error { return nil }
+
+func (p *Provider) Metadata() gestalt.ProviderMetadata {
+	return gestalt.ProviderMetadata{
+		Kind:        gestalt.ProviderKindAuthorization,
+		Name:        "generated-authorization",
+		DisplayName: "Generated Authorization",
+	}
+}
+
+func (p *Provider) Evaluate(_ context.Context, _ *gestalt.AccessEvaluationRequest) (*gestalt.AccessDecision, error) {
+	return &gestalt.AccessDecision{Allowed: true, ModelId: "model-v1"}, nil
+}
+
+func (p *Provider) EvaluateMany(_ context.Context, req *gestalt.AccessEvaluationsRequest) (*gestalt.AccessEvaluationsResponse, error) {
+	decisions := make([]*gestalt.AccessDecision, 0, len(req.GetRequests()))
+	for range req.GetRequests() {
+		decisions = append(decisions, &gestalt.AccessDecision{Allowed: true, ModelId: "model-v1"})
+	}
+	return &gestalt.AccessEvaluationsResponse{Decisions: decisions}, nil
+}
+
+func (p *Provider) SearchResources(_ context.Context, _ *gestalt.ResourceSearchRequest) (*gestalt.ResourceSearchResponse, error) {
+	return &gestalt.ResourceSearchResponse{
+		Resources: []*gestalt.AuthorizationResource{{Type: "plugin", Id: "github"}},
+		ModelId:   "model-v1",
+	}, nil
+}
+
+func (p *Provider) SearchSubjects(_ context.Context, _ *gestalt.SubjectSearchRequest) (*gestalt.SubjectSearchResponse, error) {
+	return &gestalt.SubjectSearchResponse{
+		Subjects: []*gestalt.AuthorizationSubject{{Type: "user", Id: "generated-user"}},
+		ModelId:  "model-v1",
+	}, nil
+}
+
+func (p *Provider) SearchActions(_ context.Context, _ *gestalt.ActionSearchRequest) (*gestalt.ActionSearchResponse, error) {
+	return &gestalt.ActionSearchResponse{
+		Actions: []*gestalt.AuthorizationAction{{Name: "invoke"}},
+		ModelId: "model-v1",
+	}, nil
+}
+
+func (p *Provider) GetMetadata(context.Context) (*gestalt.AuthorizationMetadata, error) {
+	return &gestalt.AuthorizationMetadata{
+		Capabilities: []string{"evaluate", "relationships", "models"},
+		ActiveModelId: "model-v1",
+	}, nil
+}
+
+func (p *Provider) ReadRelationships(_ context.Context, _ *gestalt.ReadRelationshipsRequest) (*gestalt.ReadRelationshipsResponse, error) {
+	return &gestalt.ReadRelationshipsResponse{
+		Relationships: []*gestalt.Relationship{{
+			Subject:  &gestalt.AuthorizationSubject{Type: "user", Id: "generated-user"},
+			Relation: "viewer",
+			Resource: &gestalt.AuthorizationResource{Type: "plugin", Id: "github"},
+		}},
+		ModelId: "model-v1",
+	}, nil
+}
+
+func (p *Provider) WriteRelationships(context.Context, *gestalt.WriteRelationshipsRequest) error { return nil }
+
+func (p *Provider) GetActiveModel(context.Context) (*gestalt.GetActiveModelResponse, error) {
+	return &gestalt.GetActiveModelResponse{
+		Model: &gestalt.AuthorizationModelRef{Id: "model-v1", Version: "v1"},
+	}, nil
+}
+
+func (p *Provider) ListModels(_ context.Context, _ *gestalt.ListModelsRequest) (*gestalt.ListModelsResponse, error) {
+	return &gestalt.ListModelsResponse{
+		Models: []*gestalt.AuthorizationModelRef{{Id: "model-v1", Version: "v1"}},
+	}, nil
+}
+
+func (p *Provider) WriteModel(context.Context, *gestalt.WriteModelRequest) (*gestalt.AuthorizationModelRef, error) {
+	return &gestalt.AuthorizationModelRef{Id: "model-v2", Version: "v2"}, nil
+}
+`
+}
+
 func GeneratedSecretsPackageSource() string {
 	return `package secrets
 


### PR DESCRIPTION
## Summary
- route `gestaltd provider release` source-target detection and validation through `internal/providerpkg` instead of a stale duplicated switch in `gestaltd/cmd/gestaltd`
- add release coverage for a Go `kind: authorization` provider and its missing-source error path
- keep the release path aligned with the merged authorization provider packaging logic so `gestalt-providers/authorization/indexeddb` validates on `main`

## Root Cause
`internal/providerpkg` already knew about `kind: authorization`, but `gestaltd/cmd/gestaltd/plugin.go` still had its own older switch that only handled `plugin`, `auth`, `indexeddb`, `cache`, `s3`, and `secrets`. The `gestalt-providers#128` workflow was failing at:

```text
detect source authorization package: unsupported release build target kind "authorization"
```

This PR removes that divergence by delegating the CLI release checks to `providerpkg`.

## Go Interface
```go
type AuthorizationProvider interface {
    Name() string

    Evaluate(ctx context.Context, req *AccessEvaluationRequest) (*AccessDecision, error)
    EvaluateMany(ctx context.Context, req *AccessEvaluationsRequest) (*AccessEvaluationsResponse, error)
    SearchResources(ctx context.Context, req *ResourceSearchRequest) (*ResourceSearchResponse, error)
    SearchSubjects(ctx context.Context, req *SubjectSearchRequest) (*SubjectSearchResponse, error)
    SearchActions(ctx context.Context, req *ActionSearchRequest) (*ActionSearchResponse, error)
    GetMetadata(ctx context.Context) (*AuthorizationMetadata, error)

    ReadRelationships(ctx context.Context, req *ReadRelationshipsRequest) (*ReadRelationshipsResponse, error)
    WriteRelationships(ctx context.Context, req *WriteRelationshipsRequest) error

    GetActiveModel(ctx context.Context) (*GetActiveModelResponse, error)
    ListModels(ctx context.Context, req *ListModelsRequest) (*ListModelsResponse, error)
    WriteModel(ctx context.Context, req *WriteModelRequest) (*AuthorizationModelRef, error)
}
```

## YAML
```yaml
providers:
  authorization:
    indexeddb:
      source:
        ref: github.com/valon-technologies/gestalt-providers/authorization/indexeddb
        version: 0.0.1-alpha.1
      config:
        indexeddb: default
server:
  providers:
    authorization: indexeddb
```

## Example Manifest
```yaml
kind: authorization
source: github.com/valon-technologies/gestalt-providers/authorization/indexeddb
version: 0.0.1-alpha.1
spec:
  configSchemaPath: schemas/config.schema.json
```

## Verification
- `go test ./cmd/gestaltd -run 'TestRun_PluginReleaseBuildsGoSourceAuthorizationProvider|TestRun_PluginReleaseRejectsRequiredExecutableKindsWithoutSourceOrEntrypoint'`
- `go test ./internal/providerpkg`
- `go test ./...` in `gestalt-providers/authorization`
- built patched `gestaltd`, then ran `provider release` in `gestalt-providers/authorization/indexeddb` and verified it emitted:
  - `gestalt-plugin-indexeddb_v0.0.1-alpha.1_darwin_arm64.tar.gz`
  - `checksums.txt`
  - `provider-release.yaml`
