### PR TITLE
provider release: support workflow components

### DIFF
--- a/gestaltd/cmd/gestaltd/plugin.go
+++ b/gestaltd/cmd/gestaltd/plugin.go
@@ -298,7 +298,7 @@ func releaseRequiresBuildTarget(manifest *providermanifestv1.Manifest) bool {
 	switch kind {
 	case providermanifestv1.KindPlugin:
 		return manifest.Entrypoint == nil && (manifest.Spec == nil || !manifest.Spec.IsManifestBacked())
-	case providermanifestv1.KindAuth, providermanifestv1.KindIndexedDB, providermanifestv1.KindCache, providermanifestv1.KindS3, providermanifestv1.KindSecrets:
+	case providermanifestv1.KindAuth, providermanifestv1.KindIndexedDB, providermanifestv1.KindCache, providermanifestv1.KindS3, providermanifestv1.KindWorkflow, providermanifestv1.KindSecrets:
 		return providerpkg.EntrypointForKind(manifest, kind) == nil
 	default:
 		return false
@@ -309,7 +309,7 @@ func detectReleaseSourceBuildTarget(root, kind string) (bool, error) {
 	switch kind {
 	case providermanifestv1.KindPlugin:
 		return providerpkg.HasSourceProviderPackage(root)
-	case providermanifestv1.KindAuth, providermanifestv1.KindIndexedDB, providermanifestv1.KindCache, providermanifestv1.KindS3, providermanifestv1.KindSecrets:
+	case providermanifestv1.KindAuth, providermanifestv1.KindIndexedDB, providermanifestv1.KindCache, providermanifestv1.KindS3, providermanifestv1.KindWorkflow, providermanifestv1.KindSecrets:
 		return providerpkg.HasSourceComponentPackage(root, kind)
 	default:
 		return false, fmt.Errorf("unsupported release build target kind %q", kind)
@@ -320,7 +320,7 @@ func validateReleaseBuildTarget(root, kind, goos, goarch string) error {
 	switch kind {
 	case providermanifestv1.KindPlugin:
 		return providerpkg.ValidateSourceProviderRelease(root, goos, goarch)
-	case providermanifestv1.KindAuth, providermanifestv1.KindIndexedDB, providermanifestv1.KindCache, providermanifestv1.KindS3, providermanifestv1.KindSecrets:
+	case providermanifestv1.KindAuth, providermanifestv1.KindIndexedDB, providermanifestv1.KindCache, providermanifestv1.KindS3, providermanifestv1.KindWorkflow, providermanifestv1.KindSecrets:
 		return providerpkg.ValidateSourceComponentRelease(root, kind, goos, goarch)
 	default:
 		return fmt.Errorf("unsupported release build target kind %q", kind)
@@ -331,7 +331,7 @@ func isMissingReleaseSourceBuildTarget(err error, kind string) bool {
 	switch kind {
 	case providermanifestv1.KindPlugin:
 		return errors.Is(err, providerpkg.ErrNoSourceProviderPackage)
-	case providermanifestv1.KindAuth, providermanifestv1.KindIndexedDB, providermanifestv1.KindCache, providermanifestv1.KindS3, providermanifestv1.KindSecrets:
+	case providermanifestv1.KindAuth, providermanifestv1.KindIndexedDB, providermanifestv1.KindCache, providermanifestv1.KindS3, providermanifestv1.KindWorkflow, providermanifestv1.KindSecrets:
 		return errors.Is(err, providerpkg.ErrNoSourceComponentPackage)
 	default:
 		return false
@@ -342,7 +342,7 @@ func missingReleaseSourceBuildTargetError(kind string) error {
 	switch kind {
 	case providermanifestv1.KindPlugin:
 		return fmt.Errorf("no Go, Rust, Python, or TypeScript provider package found")
-	case providermanifestv1.KindAuth, providermanifestv1.KindCache, providermanifestv1.KindIndexedDB, providermanifestv1.KindS3, providermanifestv1.KindSecrets:
+	case providermanifestv1.KindAuth, providermanifestv1.KindCache, providermanifestv1.KindIndexedDB, providermanifestv1.KindS3, providermanifestv1.KindWorkflow, providermanifestv1.KindSecrets:
 		return fmt.Errorf("no Go, Rust, Python, or TypeScript %s source package found", kind)
 	default:
 		return fmt.Errorf("unsupported release build target kind %q", kind)

--- a/gestaltd/cmd/gestaltd/plugin_test.go
+++ b/gestaltd/cmd/gestaltd/plugin_test.go
@@ -849,6 +849,72 @@ func TestRun_PluginReleaseBuildsGoSourceSecretsPlugin(t *testing.T) {
 	}
 }
 
+func TestRun_PluginReleaseBuildsGoSourceWorkflowPlugin(t *testing.T) {
+	t.Parallel()
+
+	const workflowReleasePluginName = "workflow-release"
+	const workflowReleaseSource = "github.com/testowner/providers/workflow-release"
+	const workflowReleaseSchemaPath = "workflow.schema.json"
+
+	pluginDir := newSourceComponentReleaseFixture(t, t.TempDir(), sourceComponentReleaseFixtureParams{
+		pluginName: workflowReleasePluginName,
+		schemaPath: workflowReleaseSchemaPath,
+		sourceFile: "workflow.go",
+		sourceCode: testutil.GeneratedWorkflowPackageSource(),
+		manifest: &providermanifestv1.Manifest{
+			Kind:   providermanifestv1.KindWorkflow,
+			Source: workflowReleaseSource, Version: "0.0.1", DisplayName: "Workflow Release",
+			Spec: &providermanifestv1.Spec{ConfigSchemaPath: workflowReleaseSchemaPath},
+		},
+	})
+	outputDir := t.TempDir()
+	const testVersion = "0.0.20-test"
+
+	runPluginReleaseCommand(t, pluginDir,
+		"--version", testVersion,
+		"--platform", runtime.GOOS+"/"+runtime.GOARCH,
+		"--output", outputDir,
+	)
+
+	archiveName := platformArchiveNameForTest(workflowReleasePluginName, testVersion, runtime.GOOS, runtime.GOARCH)
+	extractDir := extractReleasedArchive(t, outputDir, archiveName)
+	manifest := readReleasedManifest(t, outputDir, archiveName)
+	binaryName := releaseBinaryName(workflowReleasePluginName, runtime.GOOS)
+
+	if len(manifest.Artifacts) != 1 || manifest.Artifacts[0].Path != binaryName {
+		t.Fatalf("artifacts = %+v, want path %q", manifest.Artifacts, binaryName)
+	}
+	assertExpectedGoArtifactPlatform(t, manifest.Artifacts[0], runtime.GOOS, runtime.GOARCH, "")
+	if manifest.Entrypoint == nil || manifest.Entrypoint.ArtifactPath != binaryName {
+		t.Fatalf("workflow entrypoint = %+v, want artifact path %q", manifest.Entrypoint, binaryName)
+	}
+	if _, err := os.Stat(filepath.Join(extractDir, workflowReleaseSchemaPath)); err != nil {
+		t.Fatalf("expected %s in archive: %v", workflowReleaseSchemaPath, err)
+	}
+
+	metadata := readProviderReleaseMetadata(t, outputDir)
+	if metadata.Package != workflowReleaseSource {
+		t.Fatalf("release metadata package = %q, want %q", metadata.Package, workflowReleaseSource)
+	}
+	if metadata.Kind != providermanifestv1.KindWorkflow {
+		t.Fatalf("release metadata kind = %q, want %q", metadata.Kind, providermanifestv1.KindWorkflow)
+	}
+	if metadata.Runtime != providerReleaseRuntimeKindExecutable {
+		t.Fatalf("release metadata runtime = %q, want %q", metadata.Runtime, providerReleaseRuntimeKindExecutable)
+	}
+	workflowArtifact, ok := metadata.Artifacts[providerpkg.CurrentPlatformString()]
+	if !ok {
+		t.Fatalf("release metadata artifacts missing current platform key %q: %+v", providerpkg.CurrentPlatformString(), metadata.Artifacts)
+	}
+	workflowDigest, err := providerpkg.ArchiveDigest(filepath.Join(outputDir, archiveName))
+	if err != nil {
+		t.Fatalf("hash workflow archive: %v", err)
+	}
+	if workflowArtifact.Path != archiveName || workflowArtifact.SHA256 != workflowDigest {
+		t.Fatalf("release metadata workflow artifact = %+v, want path %q sha %q", workflowArtifact, archiveName, workflowDigest)
+	}
+}
+
 //nolint:paralleltest // Uses t.Setenv in table-driven subtests, which cannot run under parallel ancestors.
 func TestRun_PluginReleaseBuildsExecutableAuthProviders(t *testing.T) {
 	goAuthFixture := func(t *testing.T) sourceComponentReleaseFixtureParams {

--- a/gestaltd/internal/providerpkg/prepared_stage.go
+++ b/gestaltd/internal/providerpkg/prepared_stage.go
@@ -205,7 +205,7 @@ func preparedInstallRequiresBuild(manifest *providermanifestv1.Manifest, kind st
 	switch kind {
 	case providermanifestv1.KindPlugin:
 		return manifest != nil && manifest.Entrypoint == nil && (manifest.Spec == nil || !manifest.Spec.IsManifestBacked())
-	case providermanifestv1.KindAuth, providermanifestv1.KindAuthorization, providermanifestv1.KindIndexedDB, providermanifestv1.KindCache, providermanifestv1.KindS3, providermanifestv1.KindSecrets:
+	case providermanifestv1.KindAuth, providermanifestv1.KindAuthorization, providermanifestv1.KindIndexedDB, providermanifestv1.KindCache, providermanifestv1.KindS3, providermanifestv1.KindWorkflow, providermanifestv1.KindSecrets:
 		return EntrypointForKind(manifest, kind) == nil
 	default:
 		return false
@@ -223,7 +223,7 @@ func resolvePreparedInstallBuildTarget(root, kind string) (string, error) {
 			return "", ErrNoSourceProviderPackage
 		}
 		return kind, nil
-	case providermanifestv1.KindAuth, providermanifestv1.KindAuthorization, providermanifestv1.KindIndexedDB, providermanifestv1.KindCache, providermanifestv1.KindS3, providermanifestv1.KindSecrets:
+	case providermanifestv1.KindAuth, providermanifestv1.KindAuthorization, providermanifestv1.KindIndexedDB, providermanifestv1.KindCache, providermanifestv1.KindS3, providermanifestv1.KindWorkflow, providermanifestv1.KindSecrets:
 		ok, err := HasSourceComponentPackage(root, kind)
 		if err != nil {
 			return "", err
@@ -241,7 +241,7 @@ func isMissingPreparedInstallBuildTarget(err error, kind string) bool {
 	switch kind {
 	case providermanifestv1.KindPlugin:
 		return errors.Is(err, ErrNoSourceProviderPackage)
-	case providermanifestv1.KindAuth, providermanifestv1.KindAuthorization, providermanifestv1.KindIndexedDB, providermanifestv1.KindCache, providermanifestv1.KindS3, providermanifestv1.KindSecrets:
+	case providermanifestv1.KindAuth, providermanifestv1.KindAuthorization, providermanifestv1.KindIndexedDB, providermanifestv1.KindCache, providermanifestv1.KindS3, providermanifestv1.KindWorkflow, providermanifestv1.KindSecrets:
 		return errors.Is(err, ErrNoSourceComponentPackage)
 	default:
 		return false
@@ -252,7 +252,7 @@ func missingPreparedInstallBuildTargetError(kind string) error {
 	switch kind {
 	case providermanifestv1.KindPlugin:
 		return ErrNoSourceProviderPackage
-	case providermanifestv1.KindAuth, providermanifestv1.KindAuthorization, providermanifestv1.KindIndexedDB, providermanifestv1.KindCache, providermanifestv1.KindS3, providermanifestv1.KindSecrets:
+	case providermanifestv1.KindAuth, providermanifestv1.KindAuthorization, providermanifestv1.KindIndexedDB, providermanifestv1.KindCache, providermanifestv1.KindS3, providermanifestv1.KindWorkflow, providermanifestv1.KindSecrets:
 		return ErrNoSourceComponentPackage
 	default:
 		return fmt.Errorf("unsupported release build target kind %q", kind)
@@ -271,7 +271,7 @@ func buildPreparedInstallBinary(root, outputPath, pluginName, kind, goos, goarch
 	switch kind {
 	case providermanifestv1.KindPlugin:
 		return BuildSourceProviderReleaseBinary(root, outputPath, pluginName, goos, goarch)
-	case providermanifestv1.KindAuth, providermanifestv1.KindAuthorization, providermanifestv1.KindIndexedDB, providermanifestv1.KindCache, providermanifestv1.KindS3, providermanifestv1.KindSecrets:
+	case providermanifestv1.KindAuth, providermanifestv1.KindAuthorization, providermanifestv1.KindIndexedDB, providermanifestv1.KindCache, providermanifestv1.KindS3, providermanifestv1.KindWorkflow, providermanifestv1.KindSecrets:
 		return BuildSourceComponentReleaseBinary(root, outputPath, kind, goos, goarch)
 	default:
 		return "", fmt.Errorf("unsupported release build target kind %q", kind)

--- a/gestaltd/internal/providerpkg/release_target.go
+++ b/gestaltd/internal/providerpkg/release_target.go
@@ -15,7 +15,7 @@ func ReleaseRequiresBuild(manifest *providermanifestv1.Manifest) bool {
 	switch kind {
 	case providermanifestv1.KindPlugin:
 		return manifest.Entrypoint == nil && (manifest.Spec == nil || !manifest.Spec.IsManifestBacked())
-	case providermanifestv1.KindAuth, providermanifestv1.KindAuthorization, providermanifestv1.KindIndexedDB, providermanifestv1.KindCache, providermanifestv1.KindS3, providermanifestv1.KindSecrets:
+	case providermanifestv1.KindAuth, providermanifestv1.KindAuthorization, providermanifestv1.KindIndexedDB, providermanifestv1.KindCache, providermanifestv1.KindS3, providermanifestv1.KindWorkflow, providermanifestv1.KindSecrets:
 		return EntrypointForKind(manifest, kind) == nil
 	default:
 		return false
@@ -28,7 +28,7 @@ func HasSourceReleaseTarget(root, kind string) (bool, error) {
 		return HasSourceProviderPackage(root)
 	case providermanifestv1.KindWebUI:
 		return false, nil
-	case providermanifestv1.KindAuth, providermanifestv1.KindAuthorization, providermanifestv1.KindIndexedDB, providermanifestv1.KindCache, providermanifestv1.KindS3, providermanifestv1.KindSecrets:
+	case providermanifestv1.KindAuth, providermanifestv1.KindAuthorization, providermanifestv1.KindIndexedDB, providermanifestv1.KindCache, providermanifestv1.KindS3, providermanifestv1.KindWorkflow, providermanifestv1.KindSecrets:
 		return HasSourceComponentPackage(root, kind)
 	default:
 		return false, fmt.Errorf("unsupported release build target kind %q", kind)
@@ -39,7 +39,7 @@ func ValidateSourceReleaseTarget(root, kind, goos, goarch string) error {
 	switch kind {
 	case providermanifestv1.KindPlugin:
 		return ValidateSourceProviderRelease(root, goos, goarch)
-	case providermanifestv1.KindAuth, providermanifestv1.KindAuthorization, providermanifestv1.KindIndexedDB, providermanifestv1.KindCache, providermanifestv1.KindS3, providermanifestv1.KindSecrets:
+	case providermanifestv1.KindAuth, providermanifestv1.KindAuthorization, providermanifestv1.KindIndexedDB, providermanifestv1.KindCache, providermanifestv1.KindS3, providermanifestv1.KindWorkflow, providermanifestv1.KindSecrets:
 		return ValidateSourceComponentRelease(root, kind, goos, goarch)
 	default:
 		return fmt.Errorf("unsupported release build target kind %q", kind)
@@ -51,7 +51,7 @@ func BuildSourceReleaseBinary(root, outputPath, pluginName, kind, goos, goarch s
 	case providermanifestv1.KindPlugin:
 		_, err := BuildSourceProviderReleaseBinary(root, outputPath, pluginName, goos, goarch)
 		return err
-	case providermanifestv1.KindAuth, providermanifestv1.KindAuthorization, providermanifestv1.KindIndexedDB, providermanifestv1.KindCache, providermanifestv1.KindS3, providermanifestv1.KindSecrets:
+	case providermanifestv1.KindAuth, providermanifestv1.KindAuthorization, providermanifestv1.KindIndexedDB, providermanifestv1.KindCache, providermanifestv1.KindS3, providermanifestv1.KindWorkflow, providermanifestv1.KindSecrets:
 		_, err := BuildSourceComponentReleaseBinary(root, outputPath, kind, goos, goarch)
 		return err
 	default:
@@ -63,7 +63,7 @@ func IsMissingSourceReleaseTarget(err error, kind string) bool {
 	switch kind {
 	case providermanifestv1.KindPlugin:
 		return errors.Is(err, ErrNoSourceProviderPackage)
-	case providermanifestv1.KindAuth, providermanifestv1.KindAuthorization, providermanifestv1.KindIndexedDB, providermanifestv1.KindCache, providermanifestv1.KindS3, providermanifestv1.KindSecrets:
+	case providermanifestv1.KindAuth, providermanifestv1.KindAuthorization, providermanifestv1.KindIndexedDB, providermanifestv1.KindCache, providermanifestv1.KindS3, providermanifestv1.KindWorkflow, providermanifestv1.KindSecrets:
 		return errors.Is(err, ErrNoSourceComponentPackage)
 	default:
 		return false
@@ -76,7 +76,7 @@ func MissingSourceReleaseTargetError(kind string) error {
 		return fmt.Errorf("no Go, Rust, Python, or TypeScript provider package found")
 	case providermanifestv1.KindAuthorization:
 		return fmt.Errorf("no Go authorization source package found")
-	case providermanifestv1.KindAuth, providermanifestv1.KindCache, providermanifestv1.KindIndexedDB, providermanifestv1.KindS3, providermanifestv1.KindSecrets:
+	case providermanifestv1.KindAuth, providermanifestv1.KindCache, providermanifestv1.KindIndexedDB, providermanifestv1.KindS3, providermanifestv1.KindWorkflow, providermanifestv1.KindSecrets:
 		return fmt.Errorf("no Go, Rust, Python, or TypeScript %s source package found", kind)
 	default:
 		return fmt.Errorf("unsupported release build target kind %q", kind)

--- a/gestaltd/internal/testutil/sdkplugin.go
+++ b/gestaltd/internal/testutil/sdkplugin.go
@@ -237,6 +237,103 @@ func (p *Provider) GetSecret(_ context.Context, name string) (string, error) {
 `
 }
 
+func GeneratedWorkflowPackageSource() string {
+	return `package workflow
+
+import (
+	"context"
+
+	gestalt "github.com/valon-technologies/gestalt/sdk/go"
+	proto "github.com/valon-technologies/gestalt/sdk/go/gen/v1"
+	"google.golang.org/protobuf/types/known/emptypb"
+)
+
+type Provider struct {
+	proto.UnimplementedWorkflowProviderServer
+}
+
+func New() *Provider { return &Provider{} }
+
+func (p *Provider) Configure(context.Context, string, map[string]any) error { return nil }
+
+func (p *Provider) Metadata() gestalt.ProviderMetadata {
+	return gestalt.ProviderMetadata{
+		Kind:        gestalt.ProviderKindWorkflow,
+		Name:        "generated-workflow",
+		DisplayName: "Generated Workflow",
+	}
+}
+
+func (p *Provider) StartRun(context.Context, *proto.StartWorkflowProviderRunRequest) (*proto.BoundWorkflowRun, error) {
+	return &proto.BoundWorkflowRun{Id: "generated-run", Status: proto.WorkflowRunStatus_WORKFLOW_RUN_STATUS_PENDING}, nil
+}
+
+func (p *Provider) GetRun(context.Context, *proto.GetWorkflowProviderRunRequest) (*proto.BoundWorkflowRun, error) {
+	return &proto.BoundWorkflowRun{Id: "generated-run", Status: proto.WorkflowRunStatus_WORKFLOW_RUN_STATUS_PENDING}, nil
+}
+
+func (p *Provider) ListRuns(context.Context, *proto.ListWorkflowProviderRunsRequest) (*proto.ListWorkflowProviderRunsResponse, error) {
+	return &proto.ListWorkflowProviderRunsResponse{}, nil
+}
+
+func (p *Provider) CancelRun(context.Context, *proto.CancelWorkflowProviderRunRequest) (*proto.BoundWorkflowRun, error) {
+	return &proto.BoundWorkflowRun{Id: "generated-run", Status: proto.WorkflowRunStatus_WORKFLOW_RUN_STATUS_CANCELED}, nil
+}
+
+func (p *Provider) UpsertSchedule(context.Context, *proto.UpsertWorkflowProviderScheduleRequest) (*proto.BoundWorkflowSchedule, error) {
+	return &proto.BoundWorkflowSchedule{Id: "generated-schedule"}, nil
+}
+
+func (p *Provider) GetSchedule(context.Context, *proto.GetWorkflowProviderScheduleRequest) (*proto.BoundWorkflowSchedule, error) {
+	return &proto.BoundWorkflowSchedule{Id: "generated-schedule"}, nil
+}
+
+func (p *Provider) ListSchedules(context.Context, *proto.ListWorkflowProviderSchedulesRequest) (*proto.ListWorkflowProviderSchedulesResponse, error) {
+	return &proto.ListWorkflowProviderSchedulesResponse{}, nil
+}
+
+func (p *Provider) DeleteSchedule(context.Context, *proto.DeleteWorkflowProviderScheduleRequest) (*emptypb.Empty, error) {
+	return &emptypb.Empty{}, nil
+}
+
+func (p *Provider) PauseSchedule(context.Context, *proto.PauseWorkflowProviderScheduleRequest) (*proto.BoundWorkflowSchedule, error) {
+	return &proto.BoundWorkflowSchedule{Id: "generated-schedule", Paused: true}, nil
+}
+
+func (p *Provider) ResumeSchedule(context.Context, *proto.ResumeWorkflowProviderScheduleRequest) (*proto.BoundWorkflowSchedule, error) {
+	return &proto.BoundWorkflowSchedule{Id: "generated-schedule"}, nil
+}
+
+func (p *Provider) UpsertEventTrigger(context.Context, *proto.UpsertWorkflowProviderEventTriggerRequest) (*proto.BoundWorkflowEventTrigger, error) {
+	return &proto.BoundWorkflowEventTrigger{Id: "generated-trigger"}, nil
+}
+
+func (p *Provider) GetEventTrigger(context.Context, *proto.GetWorkflowProviderEventTriggerRequest) (*proto.BoundWorkflowEventTrigger, error) {
+	return &proto.BoundWorkflowEventTrigger{Id: "generated-trigger"}, nil
+}
+
+func (p *Provider) ListEventTriggers(context.Context, *proto.ListWorkflowProviderEventTriggersRequest) (*proto.ListWorkflowProviderEventTriggersResponse, error) {
+	return &proto.ListWorkflowProviderEventTriggersResponse{}, nil
+}
+
+func (p *Provider) DeleteEventTrigger(context.Context, *proto.DeleteWorkflowProviderEventTriggerRequest) (*emptypb.Empty, error) {
+	return &emptypb.Empty{}, nil
+}
+
+func (p *Provider) PauseEventTrigger(context.Context, *proto.PauseWorkflowProviderEventTriggerRequest) (*proto.BoundWorkflowEventTrigger, error) {
+	return &proto.BoundWorkflowEventTrigger{Id: "generated-trigger", Paused: true}, nil
+}
+
+func (p *Provider) ResumeEventTrigger(context.Context, *proto.ResumeWorkflowProviderEventTriggerRequest) (*proto.BoundWorkflowEventTrigger, error) {
+	return &proto.BoundWorkflowEventTrigger{Id: "generated-trigger"}, nil
+}
+
+func (p *Provider) PublishEvent(context.Context, *proto.PublishWorkflowProviderEventRequest) (*emptypb.Empty, error) {
+	return &emptypb.Empty{}, nil
+}
+`
+}
+
 func GeneratedCachePackageSource() string {
 	return `package cache
 


### PR DESCRIPTION
## Summary
- allow `gestaltd provider release` to build source workflow providers
- thread `kind: workflow` through the release-target and prepared-install code paths
- add a targeted release test for a Go workflow provider fixture

## Why
The workflow provider code exists, but `provider release` still rejected `kind: workflow`, which blocked publishing `workflow/indexeddb` through the normal release pipeline.

## Interfaces
Go workflow providers continue to use:
```go
func ServeWorkflowProvider(ctx context.Context, provider WorkflowProvider) error
```

Workflow manifests continue to declare:
```yaml
kind: workflow
source: github.com/valon-technologies/gestalt-providers/workflow/indexeddb
version: 0.0.1-alpha.1
```

## Verification
- `go test ./cmd/gestaltd -run 'TestRun_PluginReleaseBuildsGoSource(Workflow|Auth|Secrets)Plugin|TestRun_PluginReleaseRejectsRequiredExecutableKindsWithoutSourceOrEntrypoint' -count=1`
- `go test ./internal/providerpkg -run 'TestDetectSourceComponent|TestHasSourceComponentPackage|TestValidateSourceComponentRelease|TestBuildSourceComponentReleaseBinary' -count=1`
- local `gestaltd provider release --version 0.0.1-alpha.1 --platform all` succeeded in `workflow/indexeddb` and emitted `provider-release.yaml`
