### PR TITLE
Update docs for metadata URL provider sources

### DIFF
--- a/docs/content/configuration.mdx
+++ b/docs/content/configuration.mdx
@@ -72,9 +72,7 @@ Each entry under `plugins` registers a plugin backed by a provider package:
 plugins:
   github:
     displayName: GitHub
-    source:
-      ref: github.com/valon-technologies/gestalt-providers/plugins/github
-      version: 0.0.1-alpha.1
+    source: https://artifacts.example.com/plugin/github/v0.0.1-alpha.1/provider-release.yaml
     surfaces:
       openapi:
         baseUrl: https://api.github.com
@@ -82,15 +80,14 @@ plugins:
     ui: github_console
 ```
 
-`source.ref` points at a published provider package. Gestalt resolves and downloads it on startup. First-party providers are published to `github.com/valon-technologies/gestalt-providers/`.
+For published providers, `source` points at a `provider-release.yaml` metadata URL. Gestalt resolves the matching platform archive during `init` and records the exact release in the lockfile. First-party providers are published from `github.com/valon-technologies/gestalt-providers/`.
 
 During development, point at a local provider manifest instead:
 
 ```yaml
 plugins:
   support:
-    source:
-      path: ./plugins/support/manifest.yaml
+    source: ./plugins/support/manifest.yaml
 ```
 
 See [Custom Providers](/custom-providers) if you need to build your own.
@@ -102,9 +99,7 @@ A provider package may expose a large catalog. Use `allowedOperations` to publis
 ```yaml
 plugins:
   support:
-    source:
-      ref: github.com/acme/providers/support
-      version: 2.4.0
+    source: https://artifacts.example.com/plugin/support/v2.4.0/provider-release.yaml
     allowedOperations:
       tickets.list:
         alias: list_tickets
@@ -126,9 +121,7 @@ security boundary.
 ```yaml
 plugins:
   example:
-    source:
-      ref: github.com/acme/providers/example
-      version: 1.0.0
+    source: https://artifacts.example.com/plugin/example/v1.0.0/provider-release.yaml
     allowedHosts:
       - api.example.com
       - cdn.example.com
@@ -143,9 +136,7 @@ S3 providers are plugin-only bindings. Configure named entries under
 providers:
   s3:
     assets:
-      source:
-        ref: github.com/valon-technologies/gestalt-providers/s3/s3
-        version: 0.0.1-alpha.1
+      source: https://artifacts.example.com/s3/s3/v0.0.1-alpha.1/provider-release.yaml
       config:
         region: us-east-1
         endpoint: https://s3.us-east-1.amazonaws.com
@@ -157,8 +148,7 @@ providers:
 
 plugins:
   media:
-    source:
-      path: ./plugins/media/manifest.yaml
+    source: ./plugins/media/manifest.yaml
     s3:
       - assets
 ```
@@ -210,9 +200,7 @@ For example, the GitHub plugin requires OAuth app credentials from the [GitHub D
 ```yaml
 plugins:
   github:
-    source:
-      ref: github.com/valon-technologies/gestalt-providers/plugins/github
-      version: 0.0.1
+    source: https://artifacts.example.com/plugin/github/v0.0.1/provider-release.yaml
     config:
       clientId: ${GITHUB_CLIENT_ID}
       clientSecret:
@@ -281,9 +269,7 @@ Or point at a custom UI bundle:
 providers:
   ui:
     roadmap:
-      source:
-        ref: github.com/your-org/your-ui
-        version: 1.0.0
+      source: https://artifacts.example.com/webui/your-ui/v1.0.0/provider-release.yaml
       path: /create-customer-roadmap-review
 ```
 
@@ -303,9 +289,7 @@ server:
 providers:
   auth:
     oidc:
-      source:
-        ref: github.com/valon-technologies/gestalt-providers/auth/oidc
-        version: 0.0.1-alpha.1
+      source: https://artifacts.example.com/auth/oidc/v0.0.1-alpha.1/provider-release.yaml
       config:
         issuerUrl: https://login.example.com
         clientId: ${OIDC_CLIENT_ID}
@@ -342,9 +326,7 @@ server:
 providers:
   indexeddb:
     main:
-      source:
-        ref: github.com/valon-technologies/gestalt-providers/indexeddb/relationaldb
-        version: 0.0.1-alpha.1
+      source: https://artifacts.example.com/indexeddb/relationaldb/v0.0.1-alpha.1/provider-release.yaml
       config:
         dsn: sqlite://./gestalt.db
 ```
@@ -436,9 +418,7 @@ providers:
 
   auth:
     oidc:
-      source:
-        ref: github.com/valon-technologies/gestalt-providers/auth/oidc
-        version: 0.0.1-alpha.1
+      source: https://artifacts.example.com/auth/oidc/v0.0.1-alpha.1/provider-release.yaml
       config:
         issuerUrl: https://login.example.com
         clientId: ${OIDC_CLIENT_ID}
@@ -449,18 +429,14 @@ providers:
 
   indexeddb:
     main:
-      source:
-        ref: github.com/valon-technologies/gestalt-providers/indexeddb/relationaldb
-        version: 0.0.1-alpha.1
+      source: https://artifacts.example.com/indexeddb/relationaldb/v0.0.1-alpha.1/provider-release.yaml
       config:
         dsn: sqlite://./gestalt.db
 
 plugins:
   github:
     displayName: GitHub
-    source:
-      ref: github.com/valon-technologies/gestalt-providers/plugins/github
-      version: 0.0.1-alpha.1
+    source: https://artifacts.example.com/plugin/github/v0.0.1-alpha.1/provider-release.yaml
     surfaces:
       openapi:
         baseUrl: https://api.github.com
@@ -494,9 +470,7 @@ server:
 providers:
   indexeddb:
     main:
-      source:
-        ref: github.com/valon-technologies/gestalt-providers/indexeddb/relationaldb
-        version: 0.0.1-alpha.1
+      source: https://artifacts.example.com/indexeddb/relationaldb/v0.0.1-alpha.1/provider-release.yaml
       config:
         dsn: sqlite://./gestalt.db
 ```

--- a/docs/content/custom-providers/auth.mdx
+++ b/docs/content/custom-providers/auth.mdx
@@ -230,8 +230,7 @@ To use a Google auth provider in a Gestalt deployment, reference it as a named e
 providers:
   auth:
     google:
-      source:
-        path: ./google-auth/manifest.yaml
+      source: ./google-auth/manifest.yaml
       config:
         clientId: ${GOOGLE_CLIENT_ID}
         clientSecret:
@@ -242,7 +241,7 @@ providers:
           - example.com
 ```
 
-`source.path` points at the auth provider's `manifest.yaml` during development. For production, use `source.ref` and `version` to reference a published release. The `config` block is passed to `Configure` at startup and validated against the config schema if one was declared in the manifest.
+`source: ./manifest.yaml` points at the auth provider's `manifest.yaml` during development. For production, use a published `provider-release.yaml` metadata URL. The `config` block is passed to `Configure` at startup and validated against the config schema if one was declared in the manifest.
 
 Structured secret refs like `clientSecret.secret.provider: default` are resolved through the configured secret manager before reaching the provider. Environment variable placeholders like `${GOOGLE_CLIENT_ID}` are expanded during config loading. See [Configuration](/configuration) for details on both.
 

--- a/docs/content/custom-providers/index.mdx
+++ b/docs/content/custom-providers/index.mdx
@@ -12,7 +12,7 @@ deployment, start with [Providers](/providers).
 
 - Implementing executable or declarative plugin providers
 - Building custom auth, cache, IndexedDB, S3, secrets, and web UI providers
-- Testing providers from local source with `source.path`
+- Testing providers from local source with `source: ./manifest.yaml`
 - Packaging releases with `gestaltd provider release`
 
 ## Runtime model
@@ -21,7 +21,8 @@ Custom providers use the same packaging and lifecycle model as first-party
 providers:
 
 - A provider package includes a manifest plus executable code or static assets.
-- `gestaltd` resolves the package from `source.path` or `source.ref`.
+- `gestaltd` resolves the package from a local manifest path or a published
+  `provider-release.yaml` metadata URL.
 - Executable providers start as child processes and connect back to the host
   over gRPC on a temporary Unix socket.
 - Web UI providers are static asset bundles served under configured public path

--- a/docs/content/custom-providers/indexeddb.mdx
+++ b/docs/content/custom-providers/indexeddb.mdx
@@ -391,21 +391,18 @@ server:
 providers:
   indexeddb:
     main:
-      source:
-        path: ./relationaldb/manifest.yaml
+      source: ./relationaldb/manifest.yaml
       config:
         dsn: sqlite://gestalt.db
 ```
 
-For production, use `source.ref` and `version` to reference a published release:
+For production, use a published `provider-release.yaml` metadata URL:
 
 ```yaml
 providers:
   indexeddb:
     main:
-      source:
-        ref: github.com/valon-technologies/gestalt-providers/indexeddb/relationaldb
-        version: 0.0.1-alpha.1
+      source: https://artifacts.example.com/indexeddb/relationaldb/v0.0.1-alpha.1/provider-release.yaml
       config:
         dsn: ${DATABASE_URL}
 ```

--- a/docs/content/custom-providers/plugins.mdx
+++ b/docs/content/custom-providers/plugins.mdx
@@ -517,8 +517,7 @@ You configure a declarative plugin the same way as any other. Point the config a
 ```yaml
 plugins:
   slack-readonly:
-    source:
-      path: ./slack-readonly/manifest.yaml
+    source: ./slack-readonly/manifest.yaml
 ```
 
 ```sh
@@ -645,8 +644,7 @@ Point a local config at the source plugin. Gestalt synthesizes the executable wr
 ```yaml
 plugins:
   slack:
-    source:
-      path: ./slack/manifest.yaml
+    source: ./slack/manifest.yaml
     allowedHosts:
       - slack.com
 ```

--- a/docs/content/custom-providers/releasing.mdx
+++ b/docs/content/custom-providers/releasing.mdx
@@ -4,7 +4,7 @@ import { Tabs } from 'nextra/components'
 
 This page covers packaging and publishing custom providers. If you only need to
 consume an already-published provider package, use [Providers](/providers) and
-reference it with `source.ref` and `version`.
+reference it with a `provider-release.yaml` metadata URL.
 
 Once a provider or UI package works locally, you can publish a release archive
 for distribution. Release archives are self-contained and include a manifest,
@@ -219,8 +219,7 @@ Use `source.path` to point at the source tree directly. Gestalt synthesizes the 
 ```yaml
 plugins:
   my-plugin:
-    source:
-      path: ./plugins/my-plugin/manifest.yaml
+    source: ./plugins/my-plugin/manifest.yaml
 ```
 
 UI bundles work the same way:
@@ -229,21 +228,18 @@ UI bundles work the same way:
 providers:
   ui:
     dashboard:
-      source:
-        path: ./gestalt-ui/manifest.yaml
+      source: ./gestalt-ui/manifest.yaml
       path: /dashboard
 ```
 
 ### For production
 
-Reference a published release by source and version:
+Reference a published release by metadata URL:
 
 ```yaml
 plugins:
   my-plugin:
-    source:
-      ref: github.com/your-org/your-plugins/my-plugin
-      version: 0.0.1-alpha.1
+    source: https://artifacts.example.com/plugin/my-plugin/v0.0.1-alpha.1/provider-release.yaml
 ```
 
 UI bundles use the same pattern under `providers.ui.<name>`:
@@ -252,9 +248,7 @@ UI bundles use the same pattern under `providers.ui.<name>`:
 providers:
   ui:
     dashboard:
-      source:
-        ref: github.com/acme/plugins/web/default
-        version: 1.2.0
+      source: https://artifacts.example.com/webui/default/v1.2.0/provider-release.yaml
       path: /dashboard
       config:
         brand_name: Acme

--- a/docs/content/custom-providers/s3.mdx
+++ b/docs/content/custom-providers/s3.mdx
@@ -352,16 +352,14 @@ Custom S3 providers are wired into Gestalt the same way as first-party ones:
 providers:
   s3:
     assets:
-      source:
-        path: ./providers/s3/custom/manifest.yaml
+      source: ./providers/s3/custom/manifest.yaml
       config:
         endpoint: http://127.0.0.1:9000
         region: us-east-1
 
 plugins:
   media:
-    source:
-      path: ./plugins/media/manifest.yaml
+    source: ./plugins/media/manifest.yaml
     s3:
       - assets
 ```

--- a/docs/content/custom-providers/secrets.mdx
+++ b/docs/content/custom-providers/secrets.mdx
@@ -168,21 +168,18 @@ To use a secrets provider in a Gestalt deployment, reference it as a named entry
 providers:
   secrets:
     google:
-      source:
-        path: ./google-secrets/manifest.yaml
+      source: ./google-secrets/manifest.yaml
       config:
         project: my-gcp-project
 ```
 
-`source.path` points at the provider's `manifest.yaml` during development. For production, use `source.ref` and `version` to reference a published release:
+`source: ./manifest.yaml` points at the provider's `manifest.yaml` during development. For production, use a published `provider-release.yaml` metadata URL:
 
 ```yaml
 providers:
   secrets:
     google:
-      source:
-        ref: github.com/valon-technologies/gestalt-providers/secrets/google
-        version: 0.0.1
+      source: https://artifacts.example.com/secrets/google/v0.0.1/provider-release.yaml
       config:
         project: my-gcp-project
 ```

--- a/docs/content/custom-providers/web-uis.mdx
+++ b/docs/content/custom-providers/web-uis.mdx
@@ -75,21 +75,18 @@ development, point at the source manifest:
 providers:
   ui:
     dashboard:
-      source:
-        path: ./web-default/manifest.yaml
+      source: ./web-default/manifest.yaml
       path: /dashboard
       authorizationPolicy: dashboard_users
 ```
 
-For production, reference a published release by source and version:
+For production, reference a published release metadata URL:
 
 ```yaml
 providers:
   ui:
     dashboard:
-      source:
-        ref: github.com/valon-technologies/gestalt-providers/web/default
-        version: 0.0.1
+      source: https://artifacts.example.com/webui/default/v0.0.1/provider-release.yaml
       path: /dashboard
       authorizationPolicy: dashboard_users
 ```

--- a/docs/content/deploy/helm.mdx
+++ b/docs/content/deploy/helm.mdx
@@ -44,20 +44,16 @@ config:
       auth: oidc
       indexeddb: main
   providers:
-    auth:
-      oidc:
-        source:
-          ref: github.com/valon-technologies/gestalt-providers/auth/oidc
-          version: 0.0.1-alpha.1
+      auth:
+        oidc:
+          source: https://artifacts.example.com/auth/oidc/v0.0.1-alpha.1/provider-release.yaml
         config:
           issuerUrl: "${OIDC_ISSUER_URL}"
           clientId: "${OIDC_CLIENT_ID}"
           clientSecret: "${OIDC_CLIENT_SECRET}"
-    indexeddb:
-      main:
-        source:
-          ref: github.com/valon-technologies/gestalt-providers/indexeddb/relationaldb
-          version: 0.0.1-alpha.1
+      indexeddb:
+        main:
+          source: https://artifacts.example.com/indexeddb/relationaldb/v0.0.1-alpha.1/provider-release.yaml
         config:
           dsn: "${DATABASE_URL}"
 
@@ -126,21 +122,17 @@ config:
       auth: oidc
       indexeddb: main
   providers:
-    auth:
-      oidc:
-        source:
-          ref: github.com/valon-technologies/gestalt-providers/auth/oidc
-          version: 0.0.1-alpha.1
+      auth:
+        oidc:
+          source: https://artifacts.example.com/auth/oidc/v0.0.1-alpha.1/provider-release.yaml
         config:
           issuerUrl: "${OIDC_ISSUER_URL}"
           clientId: "${OIDC_CLIENT_ID}"
           clientSecret: "${OIDC_CLIENT_SECRET}"
           redirectUrl: "${OIDC_REDIRECT_URL}"
-    indexeddb:
-      main:
-        source:
-          ref: github.com/valon-technologies/gestalt-providers/indexeddb/relationaldb
-          version: 0.0.1-alpha.1
+      indexeddb:
+        main:
+          source: https://artifacts.example.com/indexeddb/relationaldb/v0.0.1-alpha.1/provider-release.yaml
         config:
           dsn: "${DATABASE_URL}"
 
@@ -184,7 +176,7 @@ Service rather than exposing it on the public ingress.
 
 ## When to enable `pluginInit`
 
-Enable the init container when your config uses `plugins.*.source.ref`, `providers.auth.*.source.ref`, `providers.indexeddb.*.source.ref`, or `providers.ui.*.source.ref` and you want that state prepared before the main container starts. The init container copies the rendered config and runs:
+Enable the init container when your config uses published provider metadata URLs under `plugins.*.source`, `providers.auth.*.source`, `providers.indexeddb.*.source`, or `providers.ui.*.source` and you want that state prepared before the main container starts. The init container copies the rendered config and runs:
 
 `/gestaltd init --config /etc/gestalt/config.yaml`
 

--- a/docs/content/providers/auth.mdx
+++ b/docs/content/providers/auth.mdx
@@ -23,7 +23,7 @@ Some auth providers also support:
 First-party auth providers live under
 [`valon-technologies/gestalt-providers/auth`](https://github.com/valon-technologies/gestalt-providers/tree/main/auth).
 
-| Provider | Repository | Source ref | Use case |
+| Provider | Repository | Package path | Use case |
 | --- | --- | --- | --- |
 | Google | [`auth/google`](https://github.com/valon-technologies/gestalt-providers/tree/main/auth/google) | `github.com/valon-technologies/gestalt-providers/auth/google` | Google OAuth platform login |
 | OIDC | [`auth/oidc`](https://github.com/valon-technologies/gestalt-providers/tree/main/auth/oidc) | `github.com/valon-technologies/gestalt-providers/auth/oidc` | Generic OpenID Connect providers such as Okta, Auth0, Azure AD, or Keycloak |
@@ -34,9 +34,7 @@ First-party auth providers live under
 providers:
   auth:
     google:
-      source:
-        ref: github.com/valon-technologies/gestalt-providers/auth/google
-        version: 0.0.1-alpha.1
+      source: https://artifacts.example.com/auth/google/v0.0.1-alpha.1/provider-release.yaml
       config:
         clientId: ${GOOGLE_CLIENT_ID}
         clientSecret:
@@ -62,8 +60,7 @@ as the same anonymous user.
 providers:
   auth:
     google:
-      source:
-        path: ./google-auth/manifest.yaml
+      source: ./google-auth/manifest.yaml
       config:
         clientId: ${GOOGLE_CLIENT_ID}
         clientSecret:

--- a/docs/content/providers/cache.mdx
+++ b/docs/content/providers/cache.mdx
@@ -13,25 +13,20 @@ They are only exposed to plugins that request them.
 providers:
   cache:
     session:
-      source:
-        ref: github.com/valon-technologies/gestalt-providers/cache/valkey
-        version: 0.0.1-alpha.1
+      source: https://artifacts.example.com/cache/valkey/v0.0.1-alpha.1/provider-release.yaml
       config:
         address: ${VALKEY_ADDR}
         database: 0
 
     rate_limit:
-      source:
-        ref: github.com/valon-technologies/gestalt-providers/cache/valkey
-        version: 0.0.1-alpha.1
+      source: https://artifacts.example.com/cache/valkey/v0.0.1-alpha.1/provider-release.yaml
       config:
         address: ${VALKEY_ADDR}
         database: 1
 
 plugins:
   search:
-    source:
-      path: ./providers/search/manifest.yaml
+    source: ./providers/search/manifest.yaml
     cache:
       - session
       - rate_limit

--- a/docs/content/providers/index.mdx
+++ b/docs/content/providers/index.mdx
@@ -27,7 +27,7 @@ context it needs.
 
 - Use `source.path` during local development to point at a provider manifest in
   a local source tree.
-- Use `source.ref` and `version` to consume a published provider package.
+- Use `source: https://.../provider-release.yaml` to consume a published provider package.
 - Executable providers run as child processes and connect back to the host over
   gRPC on a temporary Unix socket.
 - Web UI providers are static asset bundles rather than executable processes.
@@ -64,9 +64,7 @@ server:
 providers:
   auth:
     oidc:
-      source:
-        ref: github.com/valon-technologies/gestalt-providers/auth/oidc
-        version: 0.0.1-alpha.1
+      source: https://artifacts.example.com/auth/oidc/v0.0.1-alpha.1/provider-release.yaml
       config:
         issuerUrl: https://login.example.com
         clientId: ${OIDC_CLIENT_ID}
@@ -77,24 +75,19 @@ providers:
 
   indexeddb:
     main:
-      source:
-        ref: github.com/valon-technologies/gestalt-providers/indexeddb/relationaldb
-        version: 0.0.1-alpha.1
+      source: https://artifacts.example.com/indexeddb/relationaldb/v0.0.1-alpha.1/provider-release.yaml
       config:
         dsn: ${DATABASE_URL}
 
   cache:
     session:
-      source:
-        ref: github.com/valon-technologies/gestalt-providers/cache/valkey
-        version: 0.0.1-alpha.1
+      source: https://artifacts.example.com/cache/valkey/v0.0.1-alpha.1/provider-release.yaml
       config:
         address: ${VALKEY_ADDR}
 
   s3:
     assets:
-      source:
-        path: ./providers/s3/minio/manifest.yaml
+      source: ./providers/s3/minio/manifest.yaml
       config:
         endpoint: http://127.0.0.1:9000
         region: us-east-1
@@ -106,15 +99,12 @@ providers:
 
 plugins:
   github:
-    source:
-      ref: github.com/valon-technologies/gestalt-providers/plugins/github
-      version: 0.0.1-alpha.1
+    source: https://artifacts.example.com/plugin/github/v0.0.1-alpha.1/provider-release.yaml
     cache:
       - session
 
   media:
-    source:
-      path: ./plugins/media/manifest.yaml
+    source: ./plugins/media/manifest.yaml
     s3:
       - assets
 ```

--- a/docs/content/providers/indexeddb.mdx
+++ b/docs/content/providers/indexeddb.mdx
@@ -48,22 +48,17 @@ server:
 providers:
   indexeddb:
     main:
-      source:
-        ref: github.com/valon-technologies/gestalt-providers/indexeddb/relationaldb
-        version: 0.0.1-alpha.1
+      source: https://artifacts.example.com/indexeddb/relationaldb/v0.0.1-alpha.1/provider-release.yaml
       config:
         dsn: ${SYSTEM_DATABASE_URL}
     workplaceHub:
-      source:
-        ref: github.com/valon-technologies/gestalt-providers/indexeddb/relationaldb
-        version: 0.0.1-alpha.1
+      source: https://artifacts.example.com/indexeddb/relationaldb/v0.0.1-alpha.1/provider-release.yaml
       config:
         dsn: ${APP_DATABASE_URL}
 
 plugins:
   workplace_hub:
-    source:
-      path: ./plugin/manifest.yaml
+    source: ./plugin/manifest.yaml
     indexeddb:
       provider: workplaceHub
       db: workplace_hub
@@ -85,7 +80,7 @@ select provider and `db` in YAML and use `new IndexedDB()`.
 First-party storage backends live under
 [`valon-technologies/gestalt-providers/indexeddb`](https://github.com/valon-technologies/gestalt-providers/tree/main/indexeddb).
 
-| Provider | Repository | Source ref | Notes |
+| Provider | Repository | Package path | Notes |
 | --- | --- | --- | --- |
 | RelationalDB | [`indexeddb/relationaldb`](https://github.com/valon-technologies/gestalt-providers/tree/main/indexeddb/relationaldb) | `github.com/valon-technologies/gestalt-providers/indexeddb/relationaldb` | Supports PostgreSQL, MySQL, SQLite, and SQL Server through a `dsn` config value |
 | DynamoDB | [`indexeddb/dynamodb`](https://github.com/valon-technologies/gestalt-providers/tree/main/indexeddb/dynamodb) | `github.com/valon-technologies/gestalt-providers/indexeddb/dynamodb` | Uses Amazon DynamoDB with `table`, `region`, and optional `endpoint` config |
@@ -103,13 +98,12 @@ server:
 providers:
   indexeddb:
     main:
-      source:
-        path: ./relationaldb/manifest.yaml
+      source: ./relationaldb/manifest.yaml
       config:
         dsn: sqlite://gestalt.db
 ```
 
-For production, reference a published release:
+For production, reference a published release metadata URL:
 
 ```yaml
 server:
@@ -119,9 +113,7 @@ server:
 providers:
   indexeddb:
     main:
-      source:
-        ref: github.com/valon-technologies/gestalt-providers/indexeddb/relationaldb
-        version: 0.0.1-alpha.1
+      source: https://artifacts.example.com/indexeddb/relationaldb/v0.0.1-alpha.1/provider-release.yaml
       config:
         dsn: ${DATABASE_URL}
 ```
@@ -135,9 +127,7 @@ Other first-party IndexedDB providers use their own config blocks:
 providers:
   indexeddb:
     main:
-      source:
-        ref: github.com/valon-technologies/gestalt-providers/indexeddb/dynamodb
-        version: 0.0.1-alpha.1
+      source: https://artifacts.example.com/indexeddb/dynamodb/v0.0.1-alpha.1/provider-release.yaml
       config:
         table: gestalt
         region: us-east-1
@@ -148,9 +138,7 @@ providers:
 providers:
   indexeddb:
     main:
-      source:
-        ref: github.com/valon-technologies/gestalt-providers/indexeddb/mongodb
-        version: 0.0.1-alpha.1
+      source: https://artifacts.example.com/indexeddb/mongodb/v0.0.1-alpha.1/provider-release.yaml
       config:
         uri: ${MONGODB_URI}
         database: gestalt

--- a/docs/content/providers/plugins.mdx
+++ b/docs/content/providers/plugins.mdx
@@ -12,7 +12,7 @@ fully declarative, and some are hybrid packages that combine both models.
 
 From a deployment point of view, the important pieces are:
 
-- `source.path` or `source.ref` to choose the package
+- `source` to choose the package, using either a local manifest path or a published `provider-release.yaml` metadata URL
 - `config` for provider-specific settings such as OAuth app credentials
 - `allowedOperations` to publish only part of a large catalog
 - `allowedHosts` to declare outbound egress policy
@@ -26,7 +26,7 @@ First-party plugins live under
 [`valon-technologies/gestalt-providers/plugins`](https://github.com/valon-technologies/gestalt-providers/tree/main/plugins).
 Examples include:
 
-| Plugin | Repository | Source ref |
+| Plugin | Repository | Package path |
 | --- | --- | --- |
 | GitHub | [`plugins/github`](https://github.com/valon-technologies/gestalt-providers/tree/main/plugins/github) | `github.com/valon-technologies/gestalt-providers/plugins/github` |
 | Jira | [`plugins/jira`](https://github.com/valon-technologies/gestalt-providers/tree/main/plugins/jira) | `github.com/valon-technologies/gestalt-providers/plugins/jira` |
@@ -41,9 +41,7 @@ their package layouts.
 plugins:
   github:
     displayName: GitHub
-    source:
-      ref: github.com/valon-technologies/gestalt-providers/plugins/github
-      version: 0.0.1-alpha.1
+    source: https://artifacts.example.com/plugin/github/v0.0.1-alpha.1/provider-release.yaml
     config:
       apiBaseUrl: https://api.github.com
       clientId: ${GITHUB_CLIENT_ID}
@@ -58,8 +56,7 @@ During local development, point at a source manifest instead:
 ```yaml
 plugins:
   support:
-    source:
-      path: ./plugins/support/manifest.yaml
+    source: ./plugins/support/manifest.yaml
 ```
 
 ## Connections and credentials
@@ -85,9 +82,7 @@ Use `allowedOperations` to publish only a subset of a large plugin catalog:
 ```yaml
 plugins:
   support:
-    source:
-      ref: github.com/acme/providers/support
-      version: 2.4.0
+    source: https://artifacts.example.com/plugin/support/v2.4.0/provider-release.yaml
     allowedOperations:
       tickets.list:
         alias: list_tickets

--- a/docs/content/providers/releasing.mdx
+++ b/docs/content/providers/releasing.mdx
@@ -4,5 +4,5 @@ The provider packaging and publishing workflow moved to
 [Custom Providers > Releasing](/custom-providers/releasing).
 
 If you only need to consume a published provider package in a deployment, stay
-in [Providers](/providers) and reference the package with `source.ref` and
-`version`.
+in [Providers](/providers) and reference the package with a
+`provider-release.yaml` metadata URL.

--- a/docs/content/providers/s3.mdx
+++ b/docs/content/providers/s3.mdx
@@ -46,9 +46,7 @@ The first-party package lives at
 providers:
   s3:
     assets:
-      source:
-        ref: github.com/valon-technologies/gestalt-providers/s3/s3
-        version: 0.0.1-alpha.1
+      source: https://artifacts.example.com/s3/s3/v0.0.1-alpha.1/provider-release.yaml
       config:
         region: us-east-1
         endpoint: https://s3.us-east-1.amazonaws.com
@@ -61,8 +59,7 @@ providers:
 
 plugins:
   media:
-    source:
-      path: ./plugins/media/manifest.yaml
+    source: ./plugins/media/manifest.yaml
     s3:
       - assets
 ```
@@ -87,9 +84,7 @@ HMAC credentials:
 providers:
   s3:
     archive:
-      source:
-        ref: github.com/valon-technologies/gestalt-providers/s3/s3
-        version: 0.0.1-alpha.1
+      source: https://artifacts.example.com/s3/s3/v0.0.1-alpha.1/provider-release.yaml
       config:
         region: auto
         endpoint: https://storage.googleapis.com

--- a/docs/content/providers/secrets.mdx
+++ b/docs/content/providers/secrets.mdx
@@ -53,9 +53,7 @@ providers:
 providers:
   secrets:
     google:
-      source:
-        ref: github.com/valon-technologies/gestalt-providers/secrets/google
-        version: 0.0.1-alpha.1
+      source: https://artifacts.example.com/secrets/google/v0.0.1-alpha.1/provider-release.yaml
       config:
         project: my-gcp-project
 ```
@@ -65,7 +63,7 @@ provider, plugin provider, or datastore provider receives its config.
 
 ## First-party external secret providers
 
-| Provider | Repository | Source ref |
+| Provider | Repository | Package path |
 | --- | --- | --- |
 | AWS Secrets Manager | [`secrets/aws`](https://github.com/valon-technologies/gestalt-providers/tree/main/secrets/aws) | `github.com/valon-technologies/gestalt-providers/secrets/aws` |
 | Azure Key Vault | [`secrets/azure`](https://github.com/valon-technologies/gestalt-providers/tree/main/secrets/azure) | `github.com/valon-technologies/gestalt-providers/secrets/azure` |

--- a/docs/content/providers/web-uis.mdx
+++ b/docs/content/providers/web-uis.mdx
@@ -17,7 +17,7 @@ starts.
 First-party UI bundles live under
 [`valon-technologies/gestalt-providers/web`](https://github.com/valon-technologies/gestalt-providers/tree/main/web).
 
-| Bundle | Repository | Source ref |
+| Bundle | Repository | Package path |
 | --- | --- | --- |
 | Default Web UI | [`web/default`](https://github.com/valon-technologies/gestalt-providers/tree/main/web/default) | `github.com/valon-technologies/gestalt-providers/web/default` |
 
@@ -34,8 +34,7 @@ Point at a local source bundle during development:
 providers:
   ui:
     roadmap:
-      source:
-        path: ./customer-roadmap-review/ui/manifest.yaml
+      source: ./customer-roadmap-review/ui/manifest.yaml
       path: /create-customer-roadmap-review
       authorizationPolicy: roadmap_review
 ```
@@ -46,13 +45,11 @@ Bind a UI bundle to a plugin-backed app:
 providers:
   ui:
     roadmap:
-      source:
-        path: ./customer-roadmap-review/ui/manifest.yaml
+      source: ./customer-roadmap-review/ui/manifest.yaml
 
 plugins:
   roadmap_review:
-    source:
-      path: ./customer-roadmap-review/plugin/manifest.yaml
+    source: ./customer-roadmap-review/plugin/manifest.yaml
     ui: roadmap
     mountPath: /create-customer-roadmap-review
     authorizationPolicy: roadmap_review
@@ -63,8 +60,7 @@ Or let the plugin manifest own the UI bundle and keep only the deployment bindin
 ```yaml
 plugins:
   roadmap_review:
-    source:
-      path: ./customer-roadmap-review/plugin/manifest.yaml
+    source: ./customer-roadmap-review/plugin/manifest.yaml
     mountPath: /create-customer-roadmap-review
     authorizationPolicy: roadmap_review
 ```
@@ -88,9 +84,7 @@ Reference a published bundle in production:
 providers:
   ui:
     roadmap:
-      source:
-        ref: github.com/your-org/web/customer-roadmap-review
-        version: 0.0.1
+      source: https://artifacts.example.com/webui/customer-roadmap-review/v0.0.1/provider-release.yaml
       path: /create-customer-roadmap-review
       authorizationPolicy: roadmap_review
 ```

--- a/docs/content/reference/built-in-providers.mdx
+++ b/docs/content/reference/built-in-providers.mdx
@@ -23,9 +23,7 @@ Auth providers handle platform login. They are configured under `providers.auth.
 providers:
   auth:
     google:
-      source:
-        ref: github.com/valon-technologies/gestalt-providers/auth/google
-        version: 0.0.1-alpha.1
+      source: https://artifacts.example.com/auth/google/v0.0.1-alpha.1/provider-release.yaml
       config:
         allowedDomains:
           - example.com
@@ -45,9 +43,7 @@ server:
 providers:
   indexeddb:
     main:
-      source:
-        ref: github.com/valon-technologies/gestalt-providers/indexeddb/relationaldb
-        version: 0.0.1-alpha.1
+      source: https://artifacts.example.com/indexeddb/relationaldb/v0.0.1-alpha.1/provider-release.yaml
       config:
         dsn: ${DATABASE_URL}
 ```
@@ -68,9 +64,7 @@ configured under named entries in `providers.s3`, then bound into plugins with
 providers:
   s3:
     assets:
-      source:
-        ref: github.com/valon-technologies/gestalt-providers/s3/s3
-        version: 0.0.1-alpha.1
+      source: https://artifacts.example.com/s3/s3/v0.0.1-alpha.1/provider-release.yaml
       config:
         region: us-east-1
         endpoint: https://s3.us-east-1.amazonaws.com
@@ -83,8 +77,7 @@ providers:
 
 plugins:
   media:
-    source:
-      path: ./plugins/media/manifest.yaml
+    source: ./plugins/media/manifest.yaml
     s3:
       - assets
 ```
@@ -126,11 +119,9 @@ Plugins (BigQuery, Jira, Slack, and others) are published separately from [`valo
 ```yaml
 plugins:
   jira:
-    source:
-      ref: github.com/valon-technologies/gestalt-providers/plugins/jira
-      version: 0.0.1-alpha.1
+    source: https://artifacts.example.com/plugin/jira/v0.0.1-alpha.1/provider-release.yaml
 ```
 
 ## Community and Custom Providers
 
-Third-party auth providers, datastore providers, and plugins use the same provider package model as the first-party packages. Package your implementation with a provider manifest that includes the appropriate `kind` and `spec` block, publish it to a Git-accessible source, and reference it in your config the same way you would reference any first-party provider.
+Third-party auth providers, datastore providers, and plugins use the same provider package model as the first-party packages. Package your implementation with a provider manifest that includes the appropriate `kind` and `spec` block, publish a release with `provider-release.yaml`, and reference that metadata URL in config the same way you would reference any first-party provider.

--- a/docs/content/reference/config-file.mdx
+++ b/docs/content/reference/config-file.mdx
@@ -40,7 +40,7 @@ When multiple config files are loaded, Gestalt applies these merge rules:
 - `null` deletes an inherited key
 
 Relative file paths resolve relative to the config file that introduced them.
-That includes `source.path`, `iconFile`, and `server.artifactsDir`. Lockfiles
+That includes local `source` paths, `iconFile`, and `server.artifactsDir`. Lockfiles
 and, by default, artifact directories stay rooted at the leftmost config file.
 `--lockfile` overrides only the lockfile path.
 
@@ -59,8 +59,7 @@ server:
     port: 8080
 plugins:
   github:
-    source:
-      path: ./plugins/github/manifest.yaml
+    source: ./plugins/github/manifest.yaml
     allowedHosts:
       - api.github.com
       - uploads.github.com
@@ -187,9 +186,7 @@ Platform auth is optional. Omit the `providers.auth` block entirely to disable p
 providers:
   auth:
     google:
-      source:
-        ref: github.com/valon-technologies/gestalt-providers/auth/google
-        version: 0.0.1-alpha.1
+      source: https://artifacts.example.com/auth/google/v0.0.1-alpha.1/provider-release.yaml
       config:
         clientId: ${GOOGLE_CLIENT_ID}
         clientSecret:
@@ -212,9 +209,7 @@ Google checks `email_verified` on every login. Unverified accounts are rejected.
 providers:
   auth:
     oidc:
-      source:
-        ref: github.com/valon-technologies/gestalt-providers/auth/oidc
-        version: 0.0.1-alpha.1
+      source: https://artifacts.example.com/auth/oidc/v0.0.1-alpha.1/provider-release.yaml
       config:
         issuerUrl: https://login.example.com
         clientId: ${OIDC_CLIENT_ID}
@@ -256,8 +251,8 @@ Both `google` and `oidc` use the same ProviderEntry shape under `providers.auth.
 | Field | Description |
 | --- | --- |
 | `default` | Marks this named auth entry as the default selection when `server.providers.auth` is omitted. |
-| `source.ref` | Managed provider source address. |
-| `source.version` | Required with `source.ref`. SemVer without a leading `v`. |
+| `source` | Either a published `provider-release.yaml` metadata URL or a local provider manifest path. |
+| `auth` | Optional inline source auth. Only valid for metadata URL sources. |
 | `config` | Provider-specific config passed into the auth provider. |
 | `env` | Extra environment variables passed to the provider process. |
 | `allowedHosts` | Outbound host allowlist. For executable plugins, this is only a complete boundary when a supported sandboxed runtime is active. |
@@ -274,9 +269,7 @@ server:
 providers:
   indexeddb:
     main:
-      source:
-        ref: github.com/valon-technologies/gestalt-providers/indexeddb/relationaldb
-        version: 0.0.1-alpha.1
+      source: https://artifacts.example.com/indexeddb/relationaldb/v0.0.1-alpha.1/provider-release.yaml
       config:
         dsn: ${DATABASE_URL}
 ```
@@ -285,7 +278,7 @@ The exact config fields depend on the selected external indexeddb provider packa
 
 Common first-party IndexedDB packages:
 
-| Provider | Source ref | Config fields |
+| Provider | Package path | Config fields |
 | --- | --- | --- |
 | RelationalDB | `github.com/valon-technologies/gestalt-providers/indexeddb/relationaldb` | `dsn` |
 | DynamoDB | `github.com/valon-technologies/gestalt-providers/indexeddb/dynamodb` | `table`, `region`, optional `endpoint` |
@@ -301,9 +294,7 @@ Unlike IndexedDB, caches are not selected through `server.providers`.
 providers:
   cache:
     session:
-      source:
-        ref: github.com/valon-technologies/gestalt-providers/cache/valkey
-        version: 0.0.1-alpha.1
+      source: https://artifacts.example.com/cache/valkey/v0.0.1-alpha.1/provider-release.yaml
       config:
         address: ${VALKEY_ADDR}
         database: 0
@@ -319,8 +310,8 @@ First-party cache providers are published at
 
 | Field | Description |
 | --- | --- |
-| `source.ref` | Managed provider source address. |
-| `source.version` | Required with `source.ref`. SemVer without a leading `v`. |
+| `source` | Either a published `provider-release.yaml` metadata URL or a local provider manifest path. |
+| `auth` | Optional inline source auth. Only valid for metadata URL sources. |
 | `config` | Arbitrary provider-specific config passed through to the cache provider. |
 | `env` | Extra environment variables passed to the provider process. |
 | `allowedHosts` | Outbound host allowlist. For executable plugins, this is only a complete boundary when a supported sandboxed runtime is active. |
@@ -336,8 +327,7 @@ state; they are mounted only for plugin code.
 providers:
   s3:
     assets:
-      source:
-        path: ./providers/s3/minio/manifest.yaml
+      source: ./providers/s3/minio/manifest.yaml
       config:
         endpoint: http://127.0.0.1:9000
         region: us-east-1
@@ -348,8 +338,7 @@ providers:
             name: minio-root-password
 plugins:
   media:
-    source:
-      path: ./plugins/media/manifest.yaml
+    source: ./plugins/media/manifest.yaml
     s3:
       - assets
 ```
@@ -389,20 +378,18 @@ providers:
 
 ### Cloud secret backends
 
-Cloud secret managers are external providers configured with `source.ref` instead of a string `source`:
+Cloud secret managers are external providers configured with a metadata URL source:
 
 ```yaml
 providers:
   secrets:
     gsm:
-      source:
-        ref: github.com/valon-technologies/gestalt-providers/secrets/google
-        version: 0.0.1-alpha.13
+      source: https://artifacts.example.com/secrets/google/v0.0.1-alpha.13/provider-release.yaml
       config:
         project: my-gcp-project
 ```
 
-| Provider | Source ref | Config fields |
+| Provider | Package path | Config fields |
 | --- | --- | --- |
 | Google Secret Manager | `github.com/valon-technologies/gestalt-providers/secrets/google` | `project` (required), `version` |
 | AWS Secrets Manager | `github.com/valon-technologies/gestalt-providers/secrets/aws` | `region` (required), `versionStage`, `endpoint` |
@@ -625,9 +612,7 @@ plugins:
     authorizationPolicy: support_staff
     mountPath: /github
     ui: github_console
-    source:
-      ref: github.com/valon-technologies/gestalt-providers/plugins/github
-      version: 1.2.3
+    source: https://artifacts.example.com/plugin/github/v1.2.3/provider-release.yaml
     surfaces:
       openapi:
         baseUrl: https://api.github.com
@@ -675,18 +660,15 @@ binding is configured, Gestalt also sets `GESTALT_S3_SOCKET`.
 Every plugin uses a `source` block to declare its backing provider.
 
 ```yaml
-source:
-  ref: github.com/valon-technologies/gestalt-providers/plugins/github
-  version: 1.2.3
+source: https://artifacts.example.com/plugin/github/v1.2.3/provider-release.yaml
 ```
 
-`source.ref` resolves a versioned provider source during `init` using the format `github.com/<org>/<repo>/<path-after-repo>`, and requires `source.version`. `source.path` loads a local provider manifest instead. `source.path` and `source.ref` are mutually exclusive.
+For published providers, `source` points at a `provider-release.yaml` metadata URL. For local development, `source` can point directly at a provider manifest path instead.
 
 For local development with a source provider package:
 
 ```yaml
-source:
-  path: ./manifest.yaml
+source: ./manifest.yaml
 ```
 
 Gestalt synthesizes Go and Rust executable wrappers automatically when needed and runs Python source providers from the module declared in `[tool.gestalt].provider` or the legacy `[tool.gestalt].plugin`.
@@ -735,9 +717,8 @@ Gestalt synthesizes Go and Rust executable wrappers automatically when needed an
 
 | Field | Description |
 | --- | --- |
-| `source.ref` | Managed provider source address. Mutually exclusive with `source.path`. |
-| `source.version` | Required with `source.ref`. SemVer without a leading `v`. Invalid with `source.path`. |
-| `source.path` | Path to a local provider manifest. Mutually exclusive with `source.ref`. |
+| `source` | A published `provider-release.yaml` metadata URL or a local provider manifest path. |
+| `auth` | Optional inline source auth. Only valid for metadata URL sources. |
 | `env` | Extra environment variables passed to the provider process. |
 | `allowedHosts` | Outbound host allowlist. For executable plugins, this is only a complete boundary when a supported sandboxed runtime is active. |
 
@@ -913,8 +894,7 @@ plugins:
       - api.github.com
       - "*.github.com"
   my-plugin:
-    source:
-      path: ./plugins/my-plugin
+    source: ./plugins/my-plugin
     allowedHosts:
       - external-api.com
 ```
@@ -936,9 +916,7 @@ sandboxed runtime rather than relying on host-specific OS wrappers alone.
 providers:
   ui:
     console:
-      source:
-        ref: github.com/your-org/your-repo/web/console
-        version: 1.0.0
+      source: https://artifacts.example.com/webui/console/v1.0.0/provider-release.yaml
       path: /console
       config:
         brandName: Acme
@@ -954,7 +932,8 @@ When `authorizationPolicy` is set on a mounted UI, the referenced web UI manifes
 | --- | --- |
 | `path` | Direct mount prefix for this UI when not bound through `plugins.<name>.mountPath`. |
 | `authorizationPolicy` | Direct policy binding for this UI when not bound through `plugins.<name>.mountPath`. |
-| `source` | A source mapping with `source.path` or `source.ref`. |
+| `source` | A published `provider-release.yaml` metadata URL or a local UI manifest path. |
+| `auth` | Optional inline source auth. Only valid for metadata URL sources. |
 | `config` | Optional UI-provider config validated against the bundle schema when present. |
 
 ## Validation rules
@@ -963,19 +942,19 @@ Structural validation runs at config load time (`init`, `validate`, `serve`). Ru
 
 ### Structural
 
-Each plugin uses a `source` block. Every plugin must use exactly one loading mode: local `source.path` or managed `source.ref`. `source.version` is required with `source.ref` and invalid with `source.path`.
+Each plugin must set `source` to exactly one loading mode: a local manifest path or a published `provider-release.yaml` metadata URL.
 
 Host-provider entries use the same ProviderEntry shape. When
 `providers.auth.<name>`, `providers.cache.<name>`,
-`providers.indexeddb.<name>`, or `providers.s3.<name>` is set, `source.ref` or
-`source.path` must be present.
+`providers.indexeddb.<name>`, or `providers.s3.<name>` is set, `source`
+must be present.
 `providers.auth.<name>.config`, `providers.cache.<name>.config`,
 `providers.indexeddb.<name>.config`, and `providers.s3.<name>.config` are only
 allowed when their corresponding source is set.
 
 Only `connections.default` may define `params` or `discovery`. All connections in a plugin must share the same mode.
 
-Each `providers.ui.<name>` entry must use exactly one loading mode: local `providers.ui.<name>.source.path` or managed `providers.ui.<name>.source.ref`. `providers.ui.<name>.source.version` is required with `providers.ui.<name>.source.ref` and invalid with `providers.ui.<name>.source.path`. `providers.ui.<name>.config` is only allowed when `providers.ui.<name>.source` is set.
+Each `providers.ui.<name>` entry must set `source` to exactly one loading mode: a local UI manifest path or a published `provider-release.yaml` metadata URL. `providers.ui.<name>.config` is only allowed when `providers.ui.<name>.source` is set.
 
 Each `plugins.<name>` entry may set `mountPath` to publish a plugin-backed UI. When `plugins.<name>.ui` is set, it must reference an existing UI bundle. When `plugins.<name>.ui` is omitted and `plugins.<name>.mountPath` is set, the plugin manifest must declare `spec.ui`. A given UI may be bound by at most one plugin entry. `plugins.<name>.mountPath` must use the same path rules as a directly mounted UI.
 

--- a/docs/content/security.mdx
+++ b/docs/content/security.mdx
@@ -67,9 +67,7 @@ server:
 
 plugins:
   my-plugin:
-    source:
-      ref: github.com/acme/plugins/my-plugin
-      version: 1.0.0
+    source: https://artifacts.example.com/plugin/my-plugin/v1.0.0/provider-release.yaml
     allowedHosts:
       - "api.example.com"
       - "*.slack.com"


### PR DESCRIPTION
## Summary
This updates the public docs away from handwritten `source.ref` / `source.version` config examples and onto the current metadata URL + local path config surface.

## New Config Interface Shown in Docs
Published provider:

```yaml
plugins:
  github:
    source: https://artifacts.example.com/plugin/github/v0.0.1-alpha.1/provider-release.yaml
```

Local development:

```yaml
plugins:
  github:
    source: ./plugins/github/manifest.yaml
```

Inline auth for private metadata URLs remains documented as sibling config where relevant.

## Runtime Interface Impact
No provider runtime protocol changes in this PR.
- Rust providers: unchanged
- stdin/stdout provider execution contract: unchanged

This is a docs-only cleanup so the published docs match the current validator and lock/runtime model.

## What Changed
- replaced stale `source.ref` / `source.version` examples across configuration, provider, custom-provider, security, Helm, and reference docs
- updated wording to describe published providers as `provider-release.yaml` metadata URLs
- kept manifest-level `spec.ui.ref` documentation intact where it still reflects the current owned-UI manifest contract

## Verification
Ran:

```bash
npm --prefix docs ci
npm --prefix docs run build
```
