### PR TITLE
Authorization provider-backed admin reads and debug surface

### DIFF
--- a/docs/content/configuration.mdx
+++ b/docs/content/configuration.mdx
@@ -16,6 +16,7 @@ server:
     telemetry: ...          # optional selected telemetry provider
     audit: ...              # optional selected audit provider
     indexeddb: ...          # selected storage provider
+    authorization: ...      # optional selected authorization provider
   public:                   # public listener (default port 8080)
     host: ...
     port: ...
@@ -42,6 +43,8 @@ providers:
     <name>: ...             # each is a UIEntry
   indexeddb:                # named storage providers
     <name>: ...             # each is a ProviderEntry
+  authorization:            # named authorization providers
+    <name>: ...             # each is a ProviderEntry
   cache:                    # named cache providers
     <name>: ...             # each is a ProviderEntry
   s3:                       # named S3 object-store providers
@@ -59,6 +62,7 @@ Gestalt has seven core concepts you configure in YAML:
 - **[Plugin.](/providers/plugins)** A tool backed by a provider package. Plugins expose operations that agents and users invoke over HTTP, MCP, or the CLI. Plugins can come from published packages or local source.
 - **Connection.** How Gestalt authenticates to an upstream API on behalf of a user or service. Connections handle OAuth flows, API keys, and manual credentials.
 - **[IndexedDB.](/providers/indexeddb)** The persistent storage layer. Stores users, sessions, tokens, and credentials through a provider that implements the IndexedDB interface.
+- **Authorization provider.** Optional host-scoped policy storage and decision engine for shared human authorization state. The first-party `authorization/indexeddb` provider persists models and relationships in the selected host IndexedDB provider.
 - **[S3.](/providers/s3)** Plugin-bound object storage. The provider config chooses the backend, credentials, and endpoint; plugin code chooses buckets, keys, and versions at runtime.
 - **[Auth.](/providers/auth)** Platform login for the Gestalt server. Separate from connection auth, which is per-plugin and per-upstream.
 - **[Secrets.](/providers/secrets)** Resolves structured secret refs in the config at startup. Backed by environment variables, files, or cloud secret managers.
@@ -350,6 +354,36 @@ providers:
 ```
 
 SQLite works for single-instance deployments. For production, use a networked IndexedDB provider such as `indexeddb/relationaldb` with Postgres or MySQL, `indexeddb/dynamodb`, or `indexeddb/mongodb`. See [IndexedDB](/providers/indexeddb) for the full provider model.
+
+## Configuring authorization storage
+
+The `providers.authorization` block is optional. When configured, `server.providers.authorization` selects the host authorization provider Gestalt uses for human authorization relationships and model storage:
+
+```yaml
+server:
+  providers:
+    indexeddb: main
+    authorization: indexeddb
+
+providers:
+  indexeddb:
+    main:
+      source:
+        ref: github.com/valon-technologies/gestalt-providers/indexeddb/relationaldb
+        version: 0.0.1-alpha.1
+      config:
+        dsn: sqlite://./gestalt.db
+
+  authorization:
+    indexeddb:
+      source:
+        ref: github.com/valon-technologies/gestalt-providers/authorization/indexeddb
+        version: 0.0.1-alpha.1
+      config:
+        indexeddb: main
+```
+
+If `providers.authorization` is omitted, Gestalt keeps using its in-process authorization engine only. When it is present, Gestalt seeds the provider from configured static policy members and dynamic admin/plugin grants, then uses that provider for human authorization checks and the built-in admin authorization inspection APIs.
 
 ## Telemetry and audit
 

--- a/docs/content/reference/config-file.mdx
+++ b/docs/content/reference/config-file.mdx
@@ -7,8 +7,8 @@ multiple `--config` flags, Gestalt merges them left-to-right before validation
 and bootstrap. The top-level keys are `server` (listener, encryption, egress,
 and host-provider selection), `authorization` (shared human/workload access
 policy), `providers` (named auth, secrets, telemetry, audit, UI, indexeddb,
-cache, and s3 entries), and `plugins` (executable integrations and optional
-plugin-backed UI mounts):
+authorization, cache, and s3 entries), and `plugins` (executable integrations
+and optional plugin-backed UI mounts):
 
 ```yaml
 server:
@@ -23,6 +23,7 @@ providers:
   audit: {}
   ui: {}
   indexeddb: {}
+  authorization: {}
   cache: {}
   s3: {}
 plugins: {}
@@ -110,6 +111,7 @@ server:
   providers:
     auth: google
     indexeddb: main
+    authorization: indexeddb
 authorization:
   policies:
     support_staff:
@@ -169,7 +171,7 @@ Dynamic human grants are plugin-scoped, not policy-scoped. When a plugin sets `a
 | `encryptionKey` | | **Required.** Root encryption key. Typically a structured secret ref. |
 | `apiTokenTtl` | `30d` | Lifetime of newly issued API tokens. Go durations or day suffixes (`30d`). |
 | `artifactsDir` | config directory | Directory for prepared `init` artifacts. |
-| `providers.auth` / `providers.secrets` / `providers.telemetry` / `providers.audit` / `providers.indexeddb` | | Optional selectors for the named host-provider entries under `providers.*`. Required for IndexedDB whenever more than one entry exists and recommended for other host-provider maps when more than one entry exists. |
+| `providers.auth` / `providers.secrets` / `providers.telemetry` / `providers.audit` / `providers.indexeddb` / `providers.authorization` | | Optional selectors for the named host-provider entries under `providers.*`. Required for IndexedDB whenever more than one entry exists and recommended for other host-provider maps when more than one entry exists. |
 | `admin.authorizationPolicy` | | Shared human access policy applied to the built-in `/admin` route. |
 | `admin.allowedRoles` | `[admin]` | Roles allowed to load the built-in `/admin` route when `admin.authorizationPolicy` is set. |
 | `authorization.policies` | | Shared human access policies resolved by `subjectID` or `email`. |
@@ -290,6 +292,47 @@ Common first-party IndexedDB packages:
 | RelationalDB | `github.com/valon-technologies/gestalt-providers/indexeddb/relationaldb` | `dsn` |
 | DynamoDB | `github.com/valon-technologies/gestalt-providers/indexeddb/dynamodb` | `table`, `region`, optional `endpoint` |
 | MongoDB | `github.com/valon-technologies/gestalt-providers/indexeddb/mongodb` | `uri`, optional `database` |
+
+## `providers.authorization`
+
+Authorization providers are host-scoped policy engines and relationship stores. Configure one or more named entries under `providers.authorization`, then set `server.providers.authorization` to the name Gestalt should use for human authorization decisions, model lifecycle, and built-in admin authorization inspection. First-party authorization providers are published at `github.com/valon-technologies/gestalt-providers/authorization/<name>`.
+
+```yaml
+server:
+  providers:
+    indexeddb: main
+    authorization: indexeddb
+
+providers:
+  indexeddb:
+    main:
+      source:
+        ref: github.com/valon-technologies/gestalt-providers/indexeddb/relationaldb
+        version: 0.0.1-alpha.1
+      config:
+        dsn: ${DATABASE_URL}
+
+  authorization:
+    indexeddb:
+      source:
+        ref: github.com/valon-technologies/gestalt-providers/authorization/indexeddb
+        version: 0.0.1-alpha.1
+      config:
+        indexeddb: main
+```
+
+Authorization providers are optional. When omitted, Gestalt keeps using the in-process authorization engine only. When configured, Gestalt mirrors static and dynamic human authorization state into the selected provider and uses that provider for runtime human-access checks plus the built-in admin authorization debug APIs under `/admin/api/v1/authorization/...`.
+
+The exact config fields depend on the selected authorization provider package. The first-party `authorization/indexeddb` provider expects the name of a host IndexedDB provider and stores authorization models plus relationships there.
+
+| Field | Description |
+| --- | --- |
+| `default` | Marks this named authorization entry as the default selection when `server.providers.authorization` is omitted. |
+| `source.ref` | Managed provider source address. |
+| `source.version` | Required with `source.ref`. SemVer without a leading `v`. |
+| `config` | Provider-specific config passed into the authorization provider. |
+| `env` | Extra environment variables passed to the provider process. |
+| `allowedHosts` | Outbound host allowlist. For executable plugins, this is only a complete boundary when a supported sandboxed runtime is active. |
 
 ## `providers.cache`
 

--- a/gestaltd/internal/authorization/provider_backed.go
+++ b/gestaltd/internal/authorization/provider_backed.go
@@ -16,32 +16,6 @@ import (
 	"github.com/valon-technologies/gestalt/server/internal/principal"
 )
 
-const (
-	providerAuthzSchema = `version: gestalt.authorization.v1
-resources:
-  - policy_static
-  - plugin_static
-  - plugin_dynamic
-  - admin_policy_static
-  - admin_dynamic
-subjects:
-  - subject
-  - user
-  - email
-`
-
-	resourceTypePolicyStatic      = "policy_static"
-	resourceTypePluginStatic      = "plugin_static"
-	resourceTypePluginDynamic     = "plugin_dynamic"
-	resourceTypeAdminPolicyStatic = "admin_policy_static"
-	resourceTypeAdminDynamic      = "admin_dynamic"
-	resourceIDAdminDynamicGlobal  = "global"
-
-	subjectTypeSubject = "subject"
-	subjectTypeUser    = "user"
-	subjectTypeEmail   = "email"
-)
-
 type providerBackedRoleState struct {
 	modelID            string
 	policyStaticRoles  map[string][]string
@@ -574,6 +548,19 @@ func (a *ProviderBackedAuthorizer) ensureModel(ctx context.Context) (string, err
 	if strings.TrimSpace(state.modelID) != "" {
 		return strings.TrimSpace(state.modelID), nil
 	}
+	active, err := a.provider.GetActiveModel(ctx)
+	if err != nil {
+		return "", fmt.Errorf("get active authorization model: %w", err)
+	}
+	if model := active.GetModel(); model != nil && strings.TrimSpace(model.GetId()) != "" {
+		modelID := strings.TrimSpace(model.GetId())
+		a.stateMu.Lock()
+		if a.state.modelID == "" {
+			a.state.modelID = modelID
+		}
+		a.stateMu.Unlock()
+		return modelID, nil
+	}
 	model, err := a.provider.WriteModel(ctx, &core.WriteModelRequest{Schema: providerAuthzSchema})
 	if err != nil {
 		return "", fmt.Errorf("write authorization model: %w", err)
@@ -947,17 +934,5 @@ func (a *ProviderBackedAuthorizer) currentDynamicSnapshot() *dynamicSnapshot {
 }
 
 func managedRelationship(rel *core.Relationship) bool {
-	if rel == nil || rel.GetResource() == nil {
-		return false
-	}
-	switch rel.GetResource().GetType() {
-	case resourceTypePolicyStatic,
-		resourceTypePluginStatic,
-		resourceTypePluginDynamic,
-		resourceTypeAdminPolicyStatic,
-		resourceTypeAdminDynamic:
-		return true
-	default:
-		return false
-	}
+	return IsManagedProviderRelationship(rel)
 }

--- a/gestaltd/internal/authorization/provider_schema.go
+++ b/gestaltd/internal/authorization/provider_schema.go
@@ -1,0 +1,60 @@
+package authorization
+
+import "github.com/valon-technologies/gestalt/server/core"
+
+const (
+	ProviderAuthzSchema = `version: gestalt.authorization.v1
+resources:
+  - policy_static
+  - plugin_static
+  - plugin_dynamic
+  - admin_policy_static
+  - admin_dynamic
+subjects:
+  - subject
+  - user
+  - email
+`
+
+	ProviderResourceTypePolicyStatic      = "policy_static"
+	ProviderResourceTypePluginStatic      = "plugin_static"
+	ProviderResourceTypePluginDynamic     = "plugin_dynamic"
+	ProviderResourceTypeAdminPolicyStatic = "admin_policy_static"
+	ProviderResourceTypeAdminDynamic      = "admin_dynamic"
+	ProviderResourceIDAdminDynamicGlobal  = "global"
+
+	ProviderSubjectTypeSubject = "subject"
+	ProviderSubjectTypeUser    = "user"
+	ProviderSubjectTypeEmail   = "email"
+)
+
+const (
+	providerAuthzSchema = ProviderAuthzSchema
+
+	resourceTypePolicyStatic      = ProviderResourceTypePolicyStatic
+	resourceTypePluginStatic      = ProviderResourceTypePluginStatic
+	resourceTypePluginDynamic     = ProviderResourceTypePluginDynamic
+	resourceTypeAdminPolicyStatic = ProviderResourceTypeAdminPolicyStatic
+	resourceTypeAdminDynamic      = ProviderResourceTypeAdminDynamic
+	resourceIDAdminDynamicGlobal  = ProviderResourceIDAdminDynamicGlobal
+
+	subjectTypeSubject = ProviderSubjectTypeSubject
+	subjectTypeUser    = ProviderSubjectTypeUser
+	subjectTypeEmail   = ProviderSubjectTypeEmail
+)
+
+func IsManagedProviderRelationship(rel *core.Relationship) bool {
+	if rel == nil || rel.GetResource() == nil {
+		return false
+	}
+	switch rel.GetResource().GetType() {
+	case ProviderResourceTypePolicyStatic,
+		ProviderResourceTypePluginStatic,
+		ProviderResourceTypePluginDynamic,
+		ProviderResourceTypeAdminPolicyStatic,
+		ProviderResourceTypeAdminDynamic:
+		return true
+	default:
+		return false
+	}
+}

--- a/gestaltd/internal/bootstrap/bootstrap_test.go
+++ b/gestaltd/internal/bootstrap/bootstrap_test.go
@@ -3450,6 +3450,11 @@ func TestBootstrapSecretResolution(t *testing.T) {
 		cfg.Server.Providers.Authorization = "indexeddb"
 
 		provider := newMemoryAuthorizationProvider("memory-authorization")
+		provider.models = []*core.AuthorizationModelRef{{
+			Id:      "model-existing",
+			Version: "v1",
+		}}
+		provider.activeModelID = "model-existing"
 		unmanagedKey := bootstrapRelationshipKey(
 			&core.SubjectRef{Type: "team", Id: "ops"},
 			"owner",
@@ -3471,6 +3476,12 @@ func TestBootstrapSecretResolution(t *testing.T) {
 		<-result.ProvidersReady
 		if err := result.Start(ctx); err != nil {
 			t.Fatalf("Start: %v", err)
+		}
+		if got := provider.activeModelID; got != "model-existing" {
+			t.Fatalf("active model id = %q, want %q", got, "model-existing")
+		}
+		if len(provider.models) != 1 {
+			t.Fatalf("expected existing model to be reused, got %d models", len(provider.models))
 		}
 		if _, ok := provider.rels[unmanagedKey]; !ok {
 			t.Fatal("expected unrelated provider relationship to be preserved")

--- a/gestaltd/internal/server/handlers_admin_authorization.go
+++ b/gestaltd/internal/server/handlers_admin_authorization.go
@@ -47,6 +47,9 @@ type putAdminAuthorizationMemberRequest struct {
 const adminAuthorizationCanWriteHeader = "X-Gestalt-Can-Write"
 
 func (s *Server) mountAdminAuthorizationRoutes(r chi.Router) {
+	r.Get("/authorization/provider", s.getAdminAuthorizationProvider)
+	r.Get("/authorization/models", s.listAdminAuthorizationModels)
+	r.Get("/authorization/relationships", s.listAdminAuthorizationRelationships)
 	r.Get("/authorization/admins/members", s.listAdminAuthorizationAdminMembers)
 	r.Put("/authorization/admins/members", s.putAdminAuthorizationAdminMember)
 	r.Delete("/authorization/admins/members/{userID}", s.deleteAdminAuthorizationAdminMember)
@@ -147,6 +150,9 @@ func (s *Server) putAdminAuthorizationPluginMember(w http.ResponseWriter, r *htt
 	if !s.ensureAdminDynamicAuthorizationAvailable(w) {
 		return
 	}
+	if !s.ensureAdminDynamicAuthorizationWriteAvailable(w) {
+		return
+	}
 
 	var req putAdminAuthorizationMemberRequest
 	if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
@@ -219,6 +225,9 @@ func (s *Server) deleteAdminAuthorizationPluginMember(w http.ResponseWriter, r *
 	if !s.ensureAdminDynamicAuthorizationAvailable(w) {
 		return
 	}
+	if !s.ensureAdminDynamicAuthorizationWriteAvailable(w) {
+		return
+	}
 	userID := strings.TrimSpace(chi.URLParam(r, "userID"))
 	if userID == "" {
 		writeError(w, http.StatusBadRequest, "userID is required")
@@ -266,6 +275,9 @@ func (s *Server) listAdminAuthorizationAdminMembers(w http.ResponseWriter, r *ht
 
 func (s *Server) putAdminAuthorizationAdminMember(w http.ResponseWriter, r *http.Request) {
 	if !s.ensureAdminDynamicAdminAvailable(w) {
+		return
+	}
+	if !s.ensureAdminDynamicAdminWriteAvailable(w) {
 		return
 	}
 	if !s.ensureAdminAuthorizationWriteAccess(w, r) {
@@ -336,6 +348,9 @@ func (s *Server) deleteAdminAuthorizationAdminMember(w http.ResponseWriter, r *h
 	if !s.ensureAdminDynamicAdminAvailable(w) {
 		return
 	}
+	if !s.ensureAdminDynamicAdminWriteAvailable(w) {
+		return
+	}
 	if !s.ensureAdminAuthorizationWriteAccess(w, r) {
 		return
 	}
@@ -398,21 +413,45 @@ func (s *Server) writeAdminAuthorizationPluginError(w http.ResponseWriter, err e
 }
 
 func (s *Server) adminAuthorizationMemberRows(ctx context.Context, plugin string) ([]adminAuthorizationMemberRow, error) {
-	if s.pluginAuthorizations == nil || s.authorizer == nil || !s.authorizer.HasDynamicPluginAuthorizations() {
+	if s.authorizer == nil || (!s.authorizer.HasDynamicPluginAuthorizations() && s.authorizationProvider == nil) {
 		return nil, errAdminAuthorizationUnavailable
 	}
 	staticRows, err := s.adminAuthorizationStaticRows(ctx, plugin)
 	if err != nil {
 		return nil, err
 	}
-	dynamicMemberships, err := s.pluginAuthorizations.ListPluginAuthorizationsByPlugin(ctx, plugin)
-	if err != nil {
-		return nil, err
+	dynamicRows := make([]adminAuthorizationMemberRow, 0)
+	if s.authorizationProvider != nil {
+		dynamicRows, err = s.providerPluginAuthorizationRows(ctx, plugin)
+		if err != nil {
+			return nil, err
+		}
+	} else {
+		dynamicMemberships, listErr := s.pluginAuthorizations.ListPluginAuthorizationsByPlugin(ctx, plugin)
+		if listErr != nil {
+			return nil, listErr
+		}
+		for _, membership := range dynamicMemberships {
+			if membership == nil {
+				continue
+			}
+			dynamicRows = append(dynamicRows, adminAuthorizationMemberRow{
+				Plugin:        membership.Plugin,
+				Role:          membership.Role,
+				Source:        "dynamic",
+				Effective:     true,
+				Mutable:       true,
+				SelectorKind:  "user_id",
+				SelectorValue: membership.UserID,
+				UserID:        membership.UserID,
+				Email:         membership.Email,
+			})
+		}
 	}
 
 	staticByUserID := make(map[string]string, len(staticRows))
 	staticByEmail := make(map[string]string, len(staticRows))
-	rows := make([]adminAuthorizationMemberRow, 0, len(staticRows)+len(dynamicMemberships))
+	rows := make([]adminAuthorizationMemberRow, 0, len(staticRows)+len(dynamicRows))
 	for i := range staticRows {
 		row := &staticRows[i]
 		rows = append(rows, *row)
@@ -425,21 +464,8 @@ func (s *Server) adminAuthorizationMemberRows(ctx context.Context, plugin string
 		}
 	}
 
-	for _, membership := range dynamicMemberships {
-		if membership == nil {
-			continue
-		}
-		row := adminAuthorizationMemberRow{
-			Plugin:        membership.Plugin,
-			Role:          membership.Role,
-			Source:        "dynamic",
-			Effective:     true,
-			Mutable:       true,
-			SelectorKind:  "user_id",
-			SelectorValue: membership.UserID,
-			UserID:        membership.UserID,
-			Email:         membership.Email,
-		}
+	for i := range dynamicRows {
+		row := dynamicRows[i]
 		if shadow, ok := staticByUserID[row.UserID]; ok {
 			row.Effective = false
 			row.ShadowedBy = shadow
@@ -466,21 +492,44 @@ func (s *Server) adminAuthorizationMemberRows(ctx context.Context, plugin string
 }
 
 func (s *Server) adminAuthorizationAdminRows(ctx context.Context) ([]adminAuthorizationMemberRow, error) {
-	if s.adminAuthorizations == nil || s.authorizer == nil || !s.authorizer.HasDynamicAdminAuthorizations() {
+	if s.authorizer == nil || (!s.authorizer.HasDynamicAdminAuthorizations() && s.authorizationProvider == nil) {
 		return nil, errAdminAuthorizationUnavailable
 	}
 	staticRows, err := s.adminAuthorizationStaticAdminRows(ctx)
 	if err != nil {
 		return nil, err
 	}
-	dynamicMemberships, err := s.adminAuthorizations.ListAdminAuthorizations(ctx)
-	if err != nil {
-		return nil, err
+	dynamicRows := make([]adminAuthorizationMemberRow, 0)
+	if s.authorizationProvider != nil {
+		dynamicRows, err = s.providerAdminAuthorizationRows(ctx)
+		if err != nil {
+			return nil, err
+		}
+	} else {
+		dynamicMemberships, listErr := s.adminAuthorizations.ListAdminAuthorizations(ctx)
+		if listErr != nil {
+			return nil, listErr
+		}
+		for _, membership := range dynamicMemberships {
+			if membership == nil {
+				continue
+			}
+			dynamicRows = append(dynamicRows, adminAuthorizationMemberRow{
+				Role:          membership.Role,
+				Source:        "dynamic",
+				Effective:     true,
+				Mutable:       true,
+				SelectorKind:  "user_id",
+				SelectorValue: membership.UserID,
+				UserID:        membership.UserID,
+				Email:         membership.Email,
+			})
+		}
 	}
 
 	staticByUserID := make(map[string]string, len(staticRows))
 	staticByEmail := make(map[string]string, len(staticRows))
-	rows := make([]adminAuthorizationMemberRow, 0, len(staticRows)+len(dynamicMemberships))
+	rows := make([]adminAuthorizationMemberRow, 0, len(staticRows)+len(dynamicRows))
 	for i := range staticRows {
 		row := &staticRows[i]
 		rows = append(rows, *row)
@@ -493,20 +542,8 @@ func (s *Server) adminAuthorizationAdminRows(ctx context.Context) ([]adminAuthor
 		}
 	}
 
-	for _, membership := range dynamicMemberships {
-		if membership == nil {
-			continue
-		}
-		row := adminAuthorizationMemberRow{
-			Role:          membership.Role,
-			Source:        "dynamic",
-			Effective:     true,
-			Mutable:       true,
-			SelectorKind:  "user_id",
-			SelectorValue: membership.UserID,
-			UserID:        membership.UserID,
-			Email:         membership.Email,
-		}
+	for i := range dynamicRows {
+		row := dynamicRows[i]
 		if shadow, ok := staticByUserID[row.UserID]; ok {
 			row.Effective = false
 			row.ShadowedBy = shadow
@@ -640,8 +677,23 @@ var (
 )
 
 func (s *Server) ensureAdminDynamicAuthorizationAvailable(w http.ResponseWriter) bool {
-	if s.pluginAuthorizations == nil || s.authorizer == nil || !s.authorizer.HasDynamicPluginAuthorizations() {
+	if s.authorizer == nil {
 		writeError(w, http.StatusServiceUnavailable, "dynamic authorization is unavailable")
+		return false
+	}
+	if s.authorizationProvider != nil {
+		return true
+	}
+	if s.pluginAuthorizations == nil || !s.authorizer.HasDynamicPluginAuthorizations() {
+		writeError(w, http.StatusServiceUnavailable, "dynamic authorization is unavailable")
+		return false
+	}
+	return true
+}
+
+func (s *Server) ensureAdminDynamicAuthorizationWriteAvailable(w http.ResponseWriter) bool {
+	if s.pluginAuthorizations == nil || s.authorizer == nil || !s.authorizer.HasDynamicPluginAuthorizations() {
+		writeError(w, http.StatusServiceUnavailable, "dynamic authorization writes are unavailable")
 		return false
 	}
 	return true
@@ -652,7 +704,11 @@ func (s *Server) ensureAdminDynamicAdminAvailable(w http.ResponseWriter) bool {
 		writeError(w, http.StatusServiceUnavailable, "dynamic admin authorization is unavailable")
 		return false
 	}
-	if s.adminAuthorizations == nil || s.authorizer == nil || !s.authorizer.HasDynamicAdminAuthorizations() {
+	if s.authorizer == nil {
+		writeError(w, http.StatusServiceUnavailable, "dynamic admin authorization is unavailable")
+		return false
+	}
+	if s.authorizationProvider == nil && (s.adminAuthorizations == nil || !s.authorizer.HasDynamicAdminAuthorizations()) {
 		writeError(w, http.StatusServiceUnavailable, "dynamic admin authorization is unavailable")
 		return false
 	}
@@ -670,6 +726,14 @@ func (s *Server) ensureAdminDynamicAdminAvailable(w http.ResponseWriter) bool {
 	}
 	if !hasSeedAdmin {
 		writeError(w, http.StatusServiceUnavailable, "dynamic admin authorization requires at least one static admin member")
+		return false
+	}
+	return true
+}
+
+func (s *Server) ensureAdminDynamicAdminWriteAvailable(w http.ResponseWriter) bool {
+	if s.adminAuthorizations == nil || s.authorizer == nil || !s.authorizer.HasDynamicAdminAuthorizations() {
+		writeError(w, http.StatusServiceUnavailable, "dynamic admin authorization writes are unavailable")
 		return false
 	}
 	return true

--- a/gestaltd/internal/server/handlers_admin_authorization_provider.go
+++ b/gestaltd/internal/server/handlers_admin_authorization_provider.go
@@ -1,0 +1,397 @@
+package server
+
+import (
+	"context"
+	"errors"
+	"net/http"
+	"strconv"
+	"strings"
+	"time"
+
+	"github.com/valon-technologies/gestalt/server/core"
+	"github.com/valon-technologies/gestalt/server/internal/authorization"
+)
+
+const (
+	adminAuthorizationProviderReadPageSize = 500
+	adminAuthorizationDebugDefaultPageSize = 100
+	adminAuthorizationDebugMaximumPageSize = 500
+)
+
+type adminAuthorizationProviderResponse struct {
+	Name          string                         `json:"name"`
+	Capabilities  []string                       `json:"capabilities,omitempty"`
+	ActiveModelID string                         `json:"activeModelId,omitempty"`
+	ActiveModel   *adminAuthorizationModelRecord `json:"activeModel,omitempty"`
+}
+
+type adminAuthorizationModelListResponse struct {
+	Models        []adminAuthorizationModelRecord `json:"models"`
+	NextPageToken string                          `json:"nextPageToken,omitempty"`
+}
+
+type adminAuthorizationModelRecord struct {
+	ID        string `json:"id"`
+	Version   string `json:"version,omitempty"`
+	CreatedAt string `json:"createdAt,omitempty"`
+}
+
+type adminAuthorizationRelationshipListResponse struct {
+	Relationships []adminAuthorizationRelationshipRecord `json:"relationships"`
+	NextPageToken string                                 `json:"nextPageToken,omitempty"`
+	ModelID       string                                 `json:"modelId,omitempty"`
+}
+
+type adminAuthorizationRelationshipRecord struct {
+	Subject  adminAuthorizationRef `json:"subject"`
+	Relation string                `json:"relation"`
+	Resource adminAuthorizationRef `json:"resource"`
+	Managed  bool                  `json:"managed"`
+}
+
+type adminAuthorizationRef struct {
+	Type string `json:"type"`
+	ID   string `json:"id"`
+}
+
+func (s *Server) getAdminAuthorizationProvider(w http.ResponseWriter, r *http.Request) {
+	if !s.ensureAdminAuthorizationProviderAvailable(w) {
+		return
+	}
+
+	metadata, err := s.authorizationProvider.GetMetadata(r.Context())
+	if err != nil {
+		writeError(w, http.StatusInternalServerError, "failed to read authorization provider metadata")
+		return
+	}
+	active, err := s.authorizationProvider.GetActiveModel(r.Context())
+	if err != nil {
+		writeError(w, http.StatusInternalServerError, "failed to read active authorization model")
+		return
+	}
+
+	resp := adminAuthorizationProviderResponse{
+		Name: s.authorizationProvider.Name(),
+	}
+	if metadata != nil {
+		resp.Capabilities = append([]string(nil), metadata.GetCapabilities()...)
+		resp.ActiveModelID = strings.TrimSpace(metadata.GetActiveModelId())
+	}
+	if model := active.GetModel(); model != nil {
+		record := adminAuthorizationModelFromRef(model)
+		resp.ActiveModel = &record
+		if resp.ActiveModelID == "" {
+			resp.ActiveModelID = resp.ActiveModel.ID
+		}
+	}
+	writeJSON(w, http.StatusOK, resp)
+}
+
+func (s *Server) listAdminAuthorizationModels(w http.ResponseWriter, r *http.Request) {
+	if !s.ensureAdminAuthorizationProviderAvailable(w) {
+		return
+	}
+
+	pageSize, ok := adminAuthorizationDebugPageSize(w, r)
+	if !ok {
+		return
+	}
+	resp, err := s.authorizationProvider.ListModels(r.Context(), &core.ListModelsRequest{
+		PageSize:  int32(pageSize),
+		PageToken: strings.TrimSpace(r.URL.Query().Get("pageToken")),
+	})
+	if err != nil {
+		writeError(w, http.StatusInternalServerError, "failed to list authorization models")
+		return
+	}
+
+	out := adminAuthorizationModelListResponse{
+		Models:        make([]adminAuthorizationModelRecord, 0, len(resp.GetModels())),
+		NextPageToken: strings.TrimSpace(resp.GetNextPageToken()),
+	}
+	for _, model := range resp.GetModels() {
+		out.Models = append(out.Models, adminAuthorizationModelFromRef(model))
+	}
+	writeJSON(w, http.StatusOK, out)
+}
+
+func (s *Server) listAdminAuthorizationRelationships(w http.ResponseWriter, r *http.Request) {
+	if !s.ensureAdminAuthorizationProviderAvailable(w) {
+		return
+	}
+
+	pageSize, ok := adminAuthorizationDebugPageSize(w, r)
+	if !ok {
+		return
+	}
+	req := &core.ReadRelationshipsRequest{
+		PageSize:  int32(pageSize),
+		PageToken: strings.TrimSpace(r.URL.Query().Get("pageToken")),
+		ModelId:   strings.TrimSpace(r.URL.Query().Get("modelId")),
+	}
+	if subjectType := strings.TrimSpace(r.URL.Query().Get("subjectType")); subjectType != "" || strings.TrimSpace(r.URL.Query().Get("subjectId")) != "" {
+		req.Subject = &core.SubjectRef{
+			Type: subjectType,
+			Id:   strings.TrimSpace(r.URL.Query().Get("subjectId")),
+		}
+	}
+	req.Relation = strings.TrimSpace(r.URL.Query().Get("relation"))
+	if resourceType := strings.TrimSpace(r.URL.Query().Get("resourceType")); resourceType != "" || strings.TrimSpace(r.URL.Query().Get("resourceId")) != "" {
+		req.Resource = &core.ResourceRef{
+			Type: resourceType,
+			Id:   strings.TrimSpace(r.URL.Query().Get("resourceId")),
+		}
+	}
+
+	resp, err := s.authorizationProvider.ReadRelationships(r.Context(), req)
+	if err != nil {
+		writeError(w, http.StatusInternalServerError, "failed to list authorization relationships")
+		return
+	}
+
+	out := adminAuthorizationRelationshipListResponse{
+		Relationships: make([]adminAuthorizationRelationshipRecord, 0, len(resp.GetRelationships())),
+		NextPageToken: strings.TrimSpace(resp.GetNextPageToken()),
+		ModelID:       strings.TrimSpace(resp.GetModelId()),
+	}
+	for _, rel := range resp.GetRelationships() {
+		if rel == nil {
+			continue
+		}
+		out.Relationships = append(out.Relationships, adminAuthorizationRelationshipFromProvider(rel))
+	}
+	writeJSON(w, http.StatusOK, out)
+}
+
+func (s *Server) providerPluginAuthorizationRows(ctx context.Context, plugin string) ([]adminAuthorizationMemberRow, error) {
+	relationships, err := s.readAllAuthorizationRelationships(ctx, &core.ReadRelationshipsRequest{
+		PageSize: adminAuthorizationProviderReadPageSize,
+		Resource: &core.ResourceRef{
+			Type: authorization.ProviderResourceTypePluginDynamic,
+			Id:   plugin,
+		},
+	})
+	if err != nil {
+		return nil, err
+	}
+	return s.adminAuthorizationRowsFromProviderRelationships(ctx, plugin, relationships)
+}
+
+func (s *Server) providerAdminAuthorizationRows(ctx context.Context) ([]adminAuthorizationMemberRow, error) {
+	relationships, err := s.readAllAuthorizationRelationships(ctx, &core.ReadRelationshipsRequest{
+		PageSize: adminAuthorizationProviderReadPageSize,
+		Resource: &core.ResourceRef{
+			Type: authorization.ProviderResourceTypeAdminDynamic,
+			Id:   authorization.ProviderResourceIDAdminDynamicGlobal,
+		},
+	})
+	if err != nil {
+		return nil, err
+	}
+	return s.adminAuthorizationRowsFromProviderRelationships(ctx, "", relationships)
+}
+
+func (s *Server) adminAuthorizationRowsFromProviderRelationships(ctx context.Context, plugin string, relationships []*core.Relationship) ([]adminAuthorizationMemberRow, error) {
+	rows := make([]adminAuthorizationMemberRow, 0, len(relationships))
+	indexByKey := make(map[string]int, len(relationships))
+	for _, rel := range relationships {
+		row, ok, err := s.adminAuthorizationDynamicRowFromProviderRelationship(ctx, plugin, rel)
+		if err != nil {
+			return nil, err
+		}
+		if !ok {
+			continue
+		}
+		key := adminAuthorizationDynamicRowDedupeKey(row)
+		if idx, exists := indexByKey[key]; exists {
+			rows[idx] = mergeAdminAuthorizationDynamicRows(rows[idx], row)
+			continue
+		}
+		indexByKey[key] = len(rows)
+		rows = append(rows, row)
+	}
+	return rows, nil
+}
+
+func (s *Server) adminAuthorizationDynamicRowFromProviderRelationship(ctx context.Context, plugin string, rel *core.Relationship) (adminAuthorizationMemberRow, bool, error) {
+	if rel == nil || rel.GetSubject() == nil {
+		return adminAuthorizationMemberRow{}, false, nil
+	}
+
+	row := adminAuthorizationMemberRow{
+		Plugin:    plugin,
+		Role:      strings.TrimSpace(rel.GetRelation()),
+		Source:    "dynamic",
+		Effective: true,
+		Mutable:   true,
+	}
+	if row.Role == "" {
+		return adminAuthorizationMemberRow{}, false, nil
+	}
+
+	switch strings.TrimSpace(rel.GetSubject().GetType()) {
+	case authorization.ProviderSubjectTypeUser:
+		userID := strings.TrimSpace(rel.GetSubject().GetId())
+		if userID == "" {
+			return adminAuthorizationMemberRow{}, false, nil
+		}
+		row.SelectorKind = "user_id"
+		row.SelectorValue = userID
+		row.UserID = userID
+		if s.users != nil {
+			user, err := s.users.GetUser(ctx, userID)
+			switch {
+			case err == nil:
+				row.Email = user.Email
+			case errors.Is(err, core.ErrNotFound):
+			case err != nil:
+				return adminAuthorizationMemberRow{}, false, err
+			}
+		}
+	case authorization.ProviderSubjectTypeEmail:
+		email := strings.TrimSpace(rel.GetSubject().GetId())
+		if email == "" {
+			return adminAuthorizationMemberRow{}, false, nil
+		}
+		row.SelectorKind = "email"
+		row.SelectorValue = email
+		row.Email = email
+		if s.users != nil {
+			user, err := s.users.FindUserByEmail(ctx, email)
+			switch {
+			case err == nil:
+				row.UserID = user.ID
+				row.Email = user.Email
+			case errors.Is(err, core.ErrNotFound):
+			case err != nil:
+				return adminAuthorizationMemberRow{}, false, err
+			}
+		}
+	default:
+		return adminAuthorizationMemberRow{}, false, nil
+	}
+
+	return row, true, nil
+}
+
+func (s *Server) readAllAuthorizationRelationships(ctx context.Context, req *core.ReadRelationshipsRequest) ([]*core.Relationship, error) {
+	if s.authorizationProvider == nil {
+		return nil, errAdminAuthorizationUnavailable
+	}
+
+	pageSize := req.GetPageSize()
+	if pageSize <= 0 {
+		pageSize = adminAuthorizationProviderReadPageSize
+	}
+	pageToken := strings.TrimSpace(req.GetPageToken())
+	out := make([]*core.Relationship, 0)
+	for {
+		resp, err := s.authorizationProvider.ReadRelationships(ctx, &core.ReadRelationshipsRequest{
+			Subject:   req.GetSubject(),
+			Relation:  req.GetRelation(),
+			Resource:  req.GetResource(),
+			PageSize:  pageSize,
+			PageToken: pageToken,
+			ModelId:   req.GetModelId(),
+		})
+		if err != nil {
+			return nil, err
+		}
+		out = append(out, resp.GetRelationships()...)
+		pageToken = strings.TrimSpace(resp.GetNextPageToken())
+		if pageToken == "" {
+			return out, nil
+		}
+	}
+}
+
+func (s *Server) ensureAdminAuthorizationProviderAvailable(w http.ResponseWriter) bool {
+	if s.authorizationProvider == nil {
+		writeError(w, http.StatusServiceUnavailable, "authorization provider is unavailable")
+		return false
+	}
+	return true
+}
+
+func adminAuthorizationDebugPageSize(w http.ResponseWriter, r *http.Request) (int, bool) {
+	value := strings.TrimSpace(r.URL.Query().Get("pageSize"))
+	if value == "" {
+		return adminAuthorizationDebugDefaultPageSize, true
+	}
+	pageSize, err := strconv.Atoi(value)
+	if err != nil || pageSize <= 0 {
+		writeError(w, http.StatusBadRequest, "pageSize must be a positive integer")
+		return 0, false
+	}
+	if pageSize > adminAuthorizationDebugMaximumPageSize {
+		pageSize = adminAuthorizationDebugMaximumPageSize
+	}
+	return pageSize, true
+}
+
+func adminAuthorizationModelFromRef(model *core.AuthorizationModelRef) adminAuthorizationModelRecord {
+	record := adminAuthorizationModelRecord{}
+	if model == nil {
+		return record
+	}
+	record.ID = strings.TrimSpace(model.GetId())
+	record.Version = strings.TrimSpace(model.GetVersion())
+	if createdAt := model.GetCreatedAt(); createdAt != nil {
+		if ts := createdAt.AsTime(); !ts.IsZero() {
+			record.CreatedAt = ts.UTC().Format(time.RFC3339)
+		}
+	}
+	return record
+}
+
+func adminAuthorizationRelationshipFromProvider(rel *core.Relationship) adminAuthorizationRelationshipRecord {
+	if rel == nil {
+		return adminAuthorizationRelationshipRecord{}
+	}
+	subject := rel.GetSubject()
+	resource := rel.GetResource()
+	return adminAuthorizationRelationshipRecord{
+		Subject: adminAuthorizationRef{
+			Type: strings.TrimSpace(subject.GetType()),
+			ID:   strings.TrimSpace(subject.GetId()),
+		},
+		Relation: strings.TrimSpace(rel.GetRelation()),
+		Resource: adminAuthorizationRef{
+			Type: strings.TrimSpace(resource.GetType()),
+			ID:   strings.TrimSpace(resource.GetId()),
+		},
+		Managed: authorization.IsManagedProviderRelationship(rel),
+	}
+}
+
+func adminAuthorizationDynamicRowDedupeKey(row adminAuthorizationMemberRow) string {
+	if email := normalizedRowEmail(row); email != "" {
+		return strings.Join([]string{row.Plugin, row.Role, "email", email}, "\x00")
+	}
+	if row.UserID != "" {
+		return strings.Join([]string{row.Plugin, row.Role, "user_id", row.UserID}, "\x00")
+	}
+	return strings.Join([]string{row.Plugin, row.Role, row.SelectorKind, row.SelectorValue}, "\x00")
+}
+
+func mergeAdminAuthorizationDynamicRows(current, next adminAuthorizationMemberRow) adminAuthorizationMemberRow {
+	if current.SelectorKind == "user_id" && next.SelectorKind != "user_id" {
+		if current.Email == "" {
+			current.Email = next.Email
+		}
+		return current
+	}
+	if next.SelectorKind == "user_id" && current.SelectorKind != "user_id" {
+		if next.Email == "" {
+			next.Email = current.Email
+		}
+		return next
+	}
+	if current.UserID == "" {
+		current.UserID = next.UserID
+	}
+	if current.Email == "" {
+		current.Email = next.Email
+	}
+	return current
+}

--- a/gestaltd/internal/server/runtime.go
+++ b/gestaltd/internal/server/runtime.go
@@ -70,15 +70,16 @@ func Run(ctx context.Context, cfg *config.Config, result *bootstrap.Result) erro
 		// HTTP routes expose REST-visible operations, so unqualified session-catalog
 		// resolution should follow the API surface by default. The MCP server keeps
 		// its own MCP-specific routing below.
-		CatalogConnection: httpCatalogConnectionMap(connMaps),
-		ConnectionAuth:    result.ConnectionAuth,
-		PluginDefs:        cfg.Plugins,
-		Authorizer:        result.Authorizer,
-		PublicBaseURL:     cfg.Server.BaseURL,
-		ManagementBaseURL: cfg.Server.ManagementBaseURL(),
-		SecureCookies:     strings.HasPrefix(cfg.Server.BaseURL, "https://"),
-		StateSecret:       crypto.DeriveKey(cfg.Server.EncryptionKey),
-		APITokenTTL:       apiTokenTTL,
+		CatalogConnection:     httpCatalogConnectionMap(connMaps),
+		ConnectionAuth:        result.ConnectionAuth,
+		PluginDefs:            cfg.Plugins,
+		Authorizer:            result.Authorizer,
+		AuthorizationProvider: result.AuthorizationProvider,
+		PublicBaseURL:         cfg.Server.BaseURL,
+		ManagementBaseURL:     cfg.Server.ManagementBaseURL(),
+		SecureCookies:         strings.HasPrefix(cfg.Server.BaseURL, "https://"),
+		StateSecret:           crypto.DeriveKey(cfg.Server.EncryptionKey),
+		APITokenTTL:           apiTokenTTL,
 		Readiness: func() string {
 			select {
 			case <-result.ProvidersReady:

--- a/gestaltd/internal/server/server.go
+++ b/gestaltd/internal/server/server.go
@@ -60,73 +60,75 @@ type BuiltinAdminUIOptions struct {
 }
 
 type Server struct {
-	router               chi.Router
-	handler              http.Handler
-	auth                 core.AuthProvider
-	auditSink            core.AuditSink
-	users                *coredata.UserService
-	tokens               *coredata.TokenService
-	apiTokens            *coredata.APITokenService
-	managedIdentities    *coredata.ManagedIdentityService
-	identityMemberships  *coredata.ManagedIdentityMembershipService
-	identityGrants       *coredata.ManagedIdentityGrantService
-	pluginAuthorizations *coredata.PluginAuthorizationService
-	adminAuthorizations  *coredata.AdminAuthorizationService
-	managedIdentityMu    sync.Mutex
-	providers            *registry.ProviderMap[core.Provider]
-	resolver             *principal.Resolver
-	invoker              invocation.Invoker
-	defaultConnection    map[string]string
-	catalogConnection    map[string]string
-	connectionAuth       func() map[string]map[string]bootstrap.OAuthHandler
-	pluginDefs           map[string]*config.ProviderEntry
-	authorizer           authorization.RuntimeAuthorizer
-	noAuth               bool
-	anonymousPrincipal   *principal.Principal
-	publicBaseURL        string
-	managementBaseURL    string
-	secureCookies        bool
-	encryptor            *cryptoutil.AESGCMEncryptor
-	sessionIssuer        []byte
-	stateCodec           *integrationOAuthStateCodec
-	apiTokenTTL          time.Duration
-	now                  func() time.Time
-	readiness            ReadinessChecker
-	prometheusMetrics    http.Handler
-	mcpHandler           http.Handler
-	mountedWebUIs        []MountedWebUI
-	adminRoute           AdminRouteConfig
-	adminUI              http.Handler
-	routeProfile         RouteProfile
+	router                chi.Router
+	handler               http.Handler
+	auth                  core.AuthProvider
+	auditSink             core.AuditSink
+	users                 *coredata.UserService
+	tokens                *coredata.TokenService
+	apiTokens             *coredata.APITokenService
+	managedIdentities     *coredata.ManagedIdentityService
+	identityMemberships   *coredata.ManagedIdentityMembershipService
+	identityGrants        *coredata.ManagedIdentityGrantService
+	pluginAuthorizations  *coredata.PluginAuthorizationService
+	adminAuthorizations   *coredata.AdminAuthorizationService
+	authorizationProvider core.AuthorizationProvider
+	managedIdentityMu     sync.Mutex
+	providers             *registry.ProviderMap[core.Provider]
+	resolver              *principal.Resolver
+	invoker               invocation.Invoker
+	defaultConnection     map[string]string
+	catalogConnection     map[string]string
+	connectionAuth        func() map[string]map[string]bootstrap.OAuthHandler
+	pluginDefs            map[string]*config.ProviderEntry
+	authorizer            authorization.RuntimeAuthorizer
+	noAuth                bool
+	anonymousPrincipal    *principal.Principal
+	publicBaseURL         string
+	managementBaseURL     string
+	secureCookies         bool
+	encryptor             *cryptoutil.AESGCMEncryptor
+	sessionIssuer         []byte
+	stateCodec            *integrationOAuthStateCodec
+	apiTokenTTL           time.Duration
+	now                   func() time.Time
+	readiness             ReadinessChecker
+	prometheusMetrics     http.Handler
+	mcpHandler            http.Handler
+	mountedWebUIs         []MountedWebUI
+	adminRoute            AdminRouteConfig
+	adminUI               http.Handler
+	routeProfile          RouteProfile
 }
 
 type Config struct {
-	Auth              core.AuthProvider
-	AuditSink         core.AuditSink
-	Services          *coredata.Services
-	Providers         *registry.ProviderMap[core.Provider]
-	Invoker           invocation.Invoker
-	DefaultConnection map[string]string
-	CatalogConnection map[string]string
-	ConnectionAuth    func() map[string]map[string]bootstrap.OAuthHandler
-	PluginDefs        map[string]*config.ProviderEntry
-	ProviderUIs       map[string]*config.UIEntry
-	Authorizer        authorization.RuntimeAuthorizer
-	PublicBaseURL     string
-	ManagementBaseURL string
-	SecureCookies     bool
-	StateSecret       []byte
-	APITokenTTL       time.Duration
-	Now               func() time.Time
-	Readiness         ReadinessChecker
-	PrometheusMetrics http.Handler
-	MCPHandler        http.Handler
-	MountedWebUIs     []MountedWebUI
-	Admin             AdminRouteConfig
-	AdminUI           http.Handler
-	BuiltinAdminUI    *BuiltinAdminUIOptions
-	RouteProfile      RouteProfile
-	MeterProvider     metric.MeterProvider
+	Auth                  core.AuthProvider
+	AuditSink             core.AuditSink
+	Services              *coredata.Services
+	Providers             *registry.ProviderMap[core.Provider]
+	Invoker               invocation.Invoker
+	DefaultConnection     map[string]string
+	CatalogConnection     map[string]string
+	ConnectionAuth        func() map[string]map[string]bootstrap.OAuthHandler
+	PluginDefs            map[string]*config.ProviderEntry
+	ProviderUIs           map[string]*config.UIEntry
+	Authorizer            authorization.RuntimeAuthorizer
+	AuthorizationProvider core.AuthorizationProvider
+	PublicBaseURL         string
+	ManagementBaseURL     string
+	SecureCookies         bool
+	StateSecret           []byte
+	APITokenTTL           time.Duration
+	Now                   func() time.Time
+	Readiness             ReadinessChecker
+	PrometheusMetrics     http.Handler
+	MCPHandler            http.Handler
+	MountedWebUIs         []MountedWebUI
+	Admin                 AdminRouteConfig
+	AdminUI               http.Handler
+	BuiltinAdminUI        *BuiltinAdminUIOptions
+	RouteProfile          RouteProfile
+	MeterProvider         metric.MeterProvider
 }
 
 func New(cfg Config) (*Server, error) {
@@ -196,42 +198,43 @@ func New(cfg Config) (*Server, error) {
 		otelOptions = append(otelOptions, otelhttp.WithMeterProvider(cfg.MeterProvider))
 	}
 	s := &Server{
-		router:               router,
-		handler:              withRequestMeterProvider(otelhttp.NewHandler(router, "gestaltd", otelOptions...), cfg.MeterProvider),
-		auth:                 cfg.Auth,
-		auditSink:            cfg.AuditSink,
-		users:                users,
-		tokens:               tokens,
-		apiTokens:            apiTokens,
-		managedIdentities:    managedIdentities,
-		identityMemberships:  identityMemberships,
-		identityGrants:       identityGrants,
-		pluginAuthorizations: pluginAuthorizations,
-		adminAuthorizations:  adminAuthorizations,
-		providers:            cfg.Providers,
-		resolver:             resolver,
-		invoker:              cfg.Invoker,
-		defaultConnection:    cfg.DefaultConnection,
-		catalogConnection:    cfg.CatalogConnection,
-		connectionAuth:       cfg.ConnectionAuth,
-		pluginDefs:           cfg.PluginDefs,
-		authorizer:           cfg.Authorizer,
-		noAuth:               noAuth,
-		publicBaseURL:        strings.TrimRight(cfg.PublicBaseURL, "/"),
-		managementBaseURL:    strings.TrimRight(cfg.ManagementBaseURL, "/"),
-		secureCookies:        cfg.SecureCookies,
-		encryptor:            encryptor,
-		sessionIssuer:        cfg.StateSecret,
-		stateCodec:           stateCodec,
-		apiTokenTTL:          cfg.APITokenTTL,
-		now:                  now,
-		readiness:            cfg.Readiness,
-		prometheusMetrics:    cfg.PrometheusMetrics,
-		mcpHandler:           cfg.MCPHandler,
-		mountedWebUIs:        mountedWebUIs,
-		adminRoute:           adminRoute,
-		adminUI:              adminUI,
-		routeProfile:         cfg.RouteProfile,
+		router:                router,
+		handler:               withRequestMeterProvider(otelhttp.NewHandler(router, "gestaltd", otelOptions...), cfg.MeterProvider),
+		auth:                  cfg.Auth,
+		auditSink:             cfg.AuditSink,
+		users:                 users,
+		tokens:                tokens,
+		apiTokens:             apiTokens,
+		managedIdentities:     managedIdentities,
+		identityMemberships:   identityMemberships,
+		identityGrants:        identityGrants,
+		pluginAuthorizations:  pluginAuthorizations,
+		adminAuthorizations:   adminAuthorizations,
+		authorizationProvider: cfg.AuthorizationProvider,
+		providers:             cfg.Providers,
+		resolver:              resolver,
+		invoker:               cfg.Invoker,
+		defaultConnection:     cfg.DefaultConnection,
+		catalogConnection:     cfg.CatalogConnection,
+		connectionAuth:        cfg.ConnectionAuth,
+		pluginDefs:            cfg.PluginDefs,
+		authorizer:            cfg.Authorizer,
+		noAuth:                noAuth,
+		publicBaseURL:         strings.TrimRight(cfg.PublicBaseURL, "/"),
+		managementBaseURL:     strings.TrimRight(cfg.ManagementBaseURL, "/"),
+		secureCookies:         cfg.SecureCookies,
+		encryptor:             encryptor,
+		sessionIssuer:         cfg.StateSecret,
+		stateCodec:            stateCodec,
+		apiTokenTTL:           cfg.APITokenTTL,
+		now:                   now,
+		readiness:             cfg.Readiness,
+		prometheusMetrics:     cfg.PrometheusMetrics,
+		mcpHandler:            cfg.MCPHandler,
+		mountedWebUIs:         mountedWebUIs,
+		adminRoute:            adminRoute,
+		adminUI:               adminUI,
+		routeProfile:          cfg.RouteProfile,
 	}
 	if noAuth {
 		s.anonymousPrincipal = resolver.ResolveEmail(anonymousEmail)

--- a/gestaltd/internal/server/server_test.go
+++ b/gestaltd/internal/server/server_test.go
@@ -17,7 +17,9 @@ import (
 	"path/filepath"
 	"reflect"
 	"slices"
+	"strconv"
 	"strings"
+	"sync"
 	"sync/atomic"
 	"testing"
 	"time"
@@ -124,6 +126,209 @@ func (s *stubResolver) ResolveToken(ctx context.Context, _ *principal.Principal,
 		return ctx, "", nil
 	}
 	return ctx, s.token, s.err
+}
+
+type memoryAuthorizationProvider struct {
+	name string
+
+	mu            sync.Mutex
+	activeModelID string
+	models        []*core.AuthorizationModelRef
+	rels          map[string]*core.Relationship
+}
+
+func newMemoryAuthorizationProvider(name string) *memoryAuthorizationProvider {
+	return &memoryAuthorizationProvider{
+		name: name,
+		rels: map[string]*core.Relationship{},
+	}
+}
+
+func (p *memoryAuthorizationProvider) Name() string { return p.name }
+
+func (p *memoryAuthorizationProvider) Evaluate(ctx context.Context, req *core.AccessEvaluationRequest) (*core.AccessDecision, error) {
+	resp, err := p.EvaluateMany(ctx, &core.AccessEvaluationsRequest{Requests: []*core.AccessEvaluationRequest{req}})
+	if err != nil {
+		return nil, err
+	}
+	if len(resp.GetDecisions()) == 0 {
+		return &core.AccessDecision{}, nil
+	}
+	return resp.GetDecisions()[0], nil
+}
+
+func (p *memoryAuthorizationProvider) EvaluateMany(_ context.Context, req *core.AccessEvaluationsRequest) (*core.AccessEvaluationsResponse, error) {
+	p.mu.Lock()
+	defer p.mu.Unlock()
+	resp := &core.AccessEvaluationsResponse{
+		Decisions: make([]*core.AccessDecision, 0, len(req.GetRequests())),
+	}
+	for _, item := range req.GetRequests() {
+		allowed := false
+		if item != nil {
+			_, allowed = p.rels[memoryAuthorizationRelationshipKey(item.GetSubject(), item.GetAction().GetName(), item.GetResource())]
+		}
+		resp.Decisions = append(resp.Decisions, &core.AccessDecision{
+			Allowed: allowed,
+			ModelId: p.activeModelID,
+		})
+	}
+	return resp, nil
+}
+
+func (p *memoryAuthorizationProvider) SearchResources(context.Context, *core.ResourceSearchRequest) (*core.ResourceSearchResponse, error) {
+	return &core.ResourceSearchResponse{}, nil
+}
+
+func (p *memoryAuthorizationProvider) SearchSubjects(context.Context, *core.SubjectSearchRequest) (*core.SubjectSearchResponse, error) {
+	return &core.SubjectSearchResponse{}, nil
+}
+
+func (p *memoryAuthorizationProvider) SearchActions(context.Context, *core.ActionSearchRequest) (*core.ActionSearchResponse, error) {
+	return &core.ActionSearchResponse{}, nil
+}
+
+func (p *memoryAuthorizationProvider) GetMetadata(context.Context) (*core.AuthorizationMetadata, error) {
+	p.mu.Lock()
+	defer p.mu.Unlock()
+	return &core.AuthorizationMetadata{ActiveModelId: p.activeModelID}, nil
+}
+
+func (p *memoryAuthorizationProvider) ReadRelationships(_ context.Context, req *core.ReadRelationshipsRequest) (*core.ReadRelationshipsResponse, error) {
+	p.mu.Lock()
+	defer p.mu.Unlock()
+
+	keys := make([]string, 0, len(p.rels))
+	for key, rel := range p.rels {
+		if !memoryAuthorizationRelationshipMatches(rel, req) {
+			continue
+		}
+		keys = append(keys, key)
+	}
+	slices.Sort(keys)
+
+	start := 0
+	if token := strings.TrimSpace(req.GetPageToken()); token != "" {
+		offset, err := strconv.Atoi(token)
+		if err != nil || offset < 0 {
+			offset = 0
+		}
+		start = offset
+	}
+	if start > len(keys) {
+		start = len(keys)
+	}
+
+	pageSize := int(req.GetPageSize())
+	if pageSize <= 0 {
+		pageSize = len(keys)
+	}
+	end := start + pageSize
+	if end > len(keys) {
+		end = len(keys)
+	}
+
+	out := make([]*core.Relationship, 0, end-start)
+	for _, key := range keys[start:end] {
+		out = append(out, cloneMemoryAuthorizationRelationship(p.rels[key]))
+	}
+	nextPageToken := ""
+	if end < len(keys) {
+		nextPageToken = strconv.Itoa(end)
+	}
+	return &core.ReadRelationshipsResponse{
+		Relationships: out,
+		NextPageToken: nextPageToken,
+		ModelId:       p.activeModelID,
+	}, nil
+}
+
+func (p *memoryAuthorizationProvider) WriteRelationships(_ context.Context, req *core.WriteRelationshipsRequest) error {
+	p.mu.Lock()
+	defer p.mu.Unlock()
+	for _, key := range req.GetDeletes() {
+		delete(p.rels, memoryAuthorizationRelationshipKey(key.GetSubject(), key.GetRelation(), key.GetResource()))
+	}
+	for _, rel := range req.GetWrites() {
+		p.rels[memoryAuthorizationRelationshipKey(rel.GetSubject(), rel.GetRelation(), rel.GetResource())] = cloneMemoryAuthorizationRelationship(rel)
+	}
+	return nil
+}
+
+func (p *memoryAuthorizationProvider) GetActiveModel(context.Context) (*core.GetActiveModelResponse, error) {
+	p.mu.Lock()
+	defer p.mu.Unlock()
+	for _, model := range p.models {
+		if model.GetId() == p.activeModelID {
+			return &core.GetActiveModelResponse{Model: model}, nil
+		}
+	}
+	return &core.GetActiveModelResponse{}, nil
+}
+
+func (p *memoryAuthorizationProvider) ListModels(context.Context, *core.ListModelsRequest) (*core.ListModelsResponse, error) {
+	p.mu.Lock()
+	defer p.mu.Unlock()
+	return &core.ListModelsResponse{Models: append([]*core.AuthorizationModelRef(nil), p.models...)}, nil
+}
+
+func (p *memoryAuthorizationProvider) WriteModel(context.Context, *core.WriteModelRequest) (*core.AuthorizationModelRef, error) {
+	p.mu.Lock()
+	defer p.mu.Unlock()
+	model := &core.AuthorizationModelRef{
+		Id:      fmt.Sprintf("model-%d", len(p.models)+1),
+		Version: "v1",
+	}
+	p.models = append(p.models, model)
+	p.activeModelID = model.GetId()
+	return model, nil
+}
+
+func memoryAuthorizationRelationshipMatches(rel *core.Relationship, req *core.ReadRelationshipsRequest) bool {
+	if rel == nil || req == nil {
+		return rel != nil
+	}
+	if subject := req.GetSubject(); subject != nil {
+		if got := rel.GetSubject(); got == nil || got.GetType() != subject.GetType() || got.GetId() != subject.GetId() {
+			return false
+		}
+	}
+	if relation := strings.TrimSpace(req.GetRelation()); relation != "" && rel.GetRelation() != relation {
+		return false
+	}
+	if resource := req.GetResource(); resource != nil {
+		if got := rel.GetResource(); got == nil || got.GetType() != resource.GetType() || got.GetId() != resource.GetId() {
+			return false
+		}
+	}
+	return true
+}
+
+func memoryAuthorizationRelationshipKey(subject *core.SubjectRef, relation string, resource *core.ResourceRef) string {
+	return strings.Join([]string{
+		subject.GetType(),
+		subject.GetId(),
+		relation,
+		resource.GetType(),
+		resource.GetId(),
+	}, "\x00")
+}
+
+func cloneMemoryAuthorizationRelationship(rel *core.Relationship) *core.Relationship {
+	if rel == nil {
+		return nil
+	}
+	return &core.Relationship{
+		Subject: &core.SubjectRef{
+			Type: rel.GetSubject().GetType(),
+			Id:   rel.GetSubject().GetId(),
+		},
+		Relation: rel.GetRelation(),
+		Resource: &core.ResourceRef{
+			Type: rel.GetResource().GetType(),
+			Id:   rel.GetResource().GetId(),
+		},
+	}
 }
 
 type putFailingIndexedDB struct {
@@ -2273,6 +2478,154 @@ func TestAdminAPI_PluginAuthorizationCRUD(t *testing.T) {
 	}
 }
 
+func TestAdminAPI_PluginAuthorizationProviderBackedReadsAndDebug(t *testing.T) {
+	t.Parallel()
+
+	svc := coretesting.NewStubServices(t)
+	provider := newMemoryAuthorizationProvider("memory-authorization")
+	legacy, err := authorization.New(config.AuthorizationConfig{
+		Policies: map[string]config.HumanPolicyDef{
+			"sample_policy": {
+				Default: "deny",
+				Members: []config.HumanPolicyMemberDef{
+					{Email: "static@example.test", Role: "admin"},
+				},
+			},
+		},
+	}, map[string]*config.ProviderEntry{
+		"sample_plugin": {AuthorizationPolicy: "sample_policy", MountPath: "/sample"},
+	}, nil, nil, svc.PluginAuthorizations)
+	if err != nil {
+		t.Fatalf("authorization.New: %v", err)
+	}
+	authz := authorization.NewProviderBacked(legacy, provider)
+
+	ts := newTestServer(t, func(cfg *server.Config) {
+		cfg.Services = svc
+		cfg.Authorizer = authz
+		cfg.AuthorizationProvider = provider
+		cfg.PluginDefs = map[string]*config.ProviderEntry{
+			"sample_plugin": {AuthorizationPolicy: "sample_policy", MountPath: "/sample"},
+		}
+		cfg.AdminUI = http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+			_, _ = w.Write([]byte("admin"))
+		})
+	})
+	testutil.CloseOnCleanup(t, ts)
+
+	body := bytes.NewBufferString(`{"email":"dynamic@example.test","role":"viewer"}`)
+	req, _ := http.NewRequest(http.MethodPut, ts.URL+"/admin/api/v1/authorization/plugins/sample_plugin/members", body)
+	req.Header.Set("Content-Type", "application/json")
+	resp, err := http.DefaultClient.Do(req)
+	if err != nil {
+		t.Fatalf("PUT dynamic member: %v", err)
+	}
+	defer func() { _ = resp.Body.Close() }()
+	if resp.StatusCode != http.StatusOK {
+		respBody, _ := io.ReadAll(resp.Body)
+		t.Fatalf("put dynamic member status = %d, want 200: %s", resp.StatusCode, respBody)
+	}
+
+	user, err := svc.Users.FindUserByEmail(context.Background(), "dynamic@example.test")
+	if err != nil {
+		t.Fatalf("find dynamic user: %v", err)
+	}
+	if err := svc.PluginAuthorizations.DeletePluginAuthorization(context.Background(), "sample_plugin", user.ID); err != nil {
+		t.Fatalf("DeletePluginAuthorization: %v", err)
+	}
+
+	resp, err = http.Get(ts.URL + "/admin/api/v1/authorization/plugins/sample_plugin/members")
+	if err != nil {
+		t.Fatalf("GET members: %v", err)
+	}
+	defer func() { _ = resp.Body.Close() }()
+	if resp.StatusCode != http.StatusOK {
+		t.Fatalf("members status = %d, want 200", resp.StatusCode)
+	}
+
+	var members []map[string]any
+	if err := json.NewDecoder(resp.Body).Decode(&members); err != nil {
+		t.Fatalf("decoding members: %v", err)
+	}
+	if len(members) != 2 {
+		t.Fatalf("expected provider-backed merged members, got %d (%+v)", len(members), members)
+	}
+
+	resp, err = http.Get(ts.URL + "/admin/api/v1/authorization/provider")
+	if err != nil {
+		t.Fatalf("GET provider summary: %v", err)
+	}
+	defer func() { _ = resp.Body.Close() }()
+	if resp.StatusCode != http.StatusOK {
+		respBody, _ := io.ReadAll(resp.Body)
+		t.Fatalf("provider summary status = %d, want 200: %s", resp.StatusCode, respBody)
+	}
+	var providerSummary struct {
+		Name          string `json:"name"`
+		ActiveModelID string `json:"activeModelId"`
+	}
+	if err := json.NewDecoder(resp.Body).Decode(&providerSummary); err != nil {
+		t.Fatalf("decoding provider summary: %v", err)
+	}
+	if providerSummary.Name != "memory-authorization" {
+		t.Fatalf("provider name = %q, want %q", providerSummary.Name, "memory-authorization")
+	}
+	if providerSummary.ActiveModelID == "" {
+		t.Fatal("expected active model id")
+	}
+
+	resp, err = http.Get(ts.URL + "/admin/api/v1/authorization/models")
+	if err != nil {
+		t.Fatalf("GET models: %v", err)
+	}
+	defer func() { _ = resp.Body.Close() }()
+	if resp.StatusCode != http.StatusOK {
+		respBody, _ := io.ReadAll(resp.Body)
+		t.Fatalf("models status = %d, want 200: %s", resp.StatusCode, respBody)
+	}
+	var modelsResp struct {
+		Models []struct {
+			ID string `json:"id"`
+		} `json:"models"`
+	}
+	if err := json.NewDecoder(resp.Body).Decode(&modelsResp); err != nil {
+		t.Fatalf("decoding models response: %v", err)
+	}
+	if len(modelsResp.Models) != 1 || modelsResp.Models[0].ID == "" {
+		t.Fatalf("models response = %+v, want one active model", modelsResp.Models)
+	}
+
+	resp, err = http.Get(ts.URL + "/admin/api/v1/authorization/relationships?resourceType=plugin_dynamic&resourceId=sample_plugin")
+	if err != nil {
+		t.Fatalf("GET relationships: %v", err)
+	}
+	defer func() { _ = resp.Body.Close() }()
+	if resp.StatusCode != http.StatusOK {
+		respBody, _ := io.ReadAll(resp.Body)
+		t.Fatalf("relationships status = %d, want 200: %s", resp.StatusCode, respBody)
+	}
+	var relationshipsResp struct {
+		ModelID       string `json:"modelId"`
+		Relationships []struct {
+			Managed bool `json:"managed"`
+		} `json:"relationships"`
+	}
+	if err := json.NewDecoder(resp.Body).Decode(&relationshipsResp); err != nil {
+		t.Fatalf("decoding relationships response: %v", err)
+	}
+	if relationshipsResp.ModelID == "" {
+		t.Fatal("expected model id on relationships response")
+	}
+	if len(relationshipsResp.Relationships) != 2 {
+		t.Fatalf("expected 2 provider relationships, got %d", len(relationshipsResp.Relationships))
+	}
+	for _, rel := range relationshipsResp.Relationships {
+		if !rel.Managed {
+			t.Fatalf("expected managed relationship rows, got %+v", relationshipsResp.Relationships)
+		}
+	}
+}
+
 func TestAdminAPI_AdminAuthorizationCRUD(t *testing.T) {
 	t.Parallel()
 
@@ -2451,6 +2804,95 @@ func TestAdminAPI_AdminAuthorizationCRUD(t *testing.T) {
 	}
 	if len(roles) != 0 {
 		t.Fatalf("workspace roles after delete = %+v, want none", roles)
+	}
+}
+
+func TestAdminAPI_AdminAuthorizationProviderBackedReads(t *testing.T) {
+	t.Parallel()
+
+	svc := coretesting.NewStubServices(t)
+	seedUser(t, svc, "static-admin@example.test")
+	const adminRole = "owner"
+	provider := newMemoryAuthorizationProvider("memory-authorization")
+	legacy := mustAuthorizer(t, config.AuthorizationConfig{
+		Policies: map[string]config.HumanPolicyDef{
+			"admin_policy": {
+				Default: "deny",
+				Members: []config.HumanPolicyMemberDef{
+					{Email: "static-admin@example.test", Role: adminRole},
+				},
+			},
+		},
+	}, nil, nil, nil)
+	legacy.SetAdminAuthorizationService(svc.AdminAuthorizations)
+	authz := authorization.NewProviderBacked(legacy, provider)
+	if err := authz.ReloadDynamic(context.Background()); err != nil {
+		t.Fatalf("ReloadDynamic: %v", err)
+	}
+
+	ts := newTestServer(t, func(cfg *server.Config) {
+		cfg.Auth = &coretesting.StubAuthProvider{
+			N: "test",
+			ValidateTokenFn: func(_ context.Context, token string) (*core.UserIdentity, error) {
+				if token != "admin-session" {
+					return nil, fmt.Errorf("invalid token")
+				}
+				return &core.UserIdentity{Email: "static-admin@example.test"}, nil
+			},
+		}
+		cfg.Services = svc
+		cfg.Authorizer = authz
+		cfg.AuthorizationProvider = provider
+		cfg.Admin = server.AdminRouteConfig{
+			AuthorizationPolicy: "admin_policy",
+			AllowedRoles:        []string{adminRole, "operator"},
+		}
+		cfg.AdminUI = http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+			_, _ = w.Write([]byte("admin"))
+		})
+	})
+	testutil.CloseOnCleanup(t, ts)
+
+	body := bytes.NewBufferString(`{"email":"dynamic-admin@example.test","role":"owner"}`)
+	req, _ := http.NewRequest(http.MethodPut, ts.URL+"/admin/api/v1/authorization/admins/members", body)
+	req.Header.Set("Content-Type", "application/json")
+	req.AddCookie(&http.Cookie{Name: "session_token", Value: "admin-session"})
+	resp, err := http.DefaultClient.Do(req)
+	if err != nil {
+		t.Fatalf("PUT admin member: %v", err)
+	}
+	defer func() { _ = resp.Body.Close() }()
+	if resp.StatusCode != http.StatusOK {
+		respBody, _ := io.ReadAll(resp.Body)
+		t.Fatalf("put admin member status = %d, want 200: %s", resp.StatusCode, respBody)
+	}
+
+	user, err := svc.Users.FindUserByEmail(context.Background(), "dynamic-admin@example.test")
+	if err != nil {
+		t.Fatalf("find dynamic admin user: %v", err)
+	}
+	if err := svc.AdminAuthorizations.DeleteAdminAuthorization(context.Background(), user.ID); err != nil {
+		t.Fatalf("DeleteAdminAuthorization: %v", err)
+	}
+
+	req, _ = http.NewRequest(http.MethodGet, ts.URL+"/admin/api/v1/authorization/admins/members", nil)
+	req.AddCookie(&http.Cookie{Name: "session_token", Value: "admin-session"})
+	resp, err = http.DefaultClient.Do(req)
+	if err != nil {
+		t.Fatalf("GET admin members: %v", err)
+	}
+	defer func() { _ = resp.Body.Close() }()
+	if resp.StatusCode != http.StatusOK {
+		respBody, _ := io.ReadAll(resp.Body)
+		t.Fatalf("admin members status = %d, want 200: %s", resp.StatusCode, respBody)
+	}
+
+	var members []map[string]any
+	if err := json.NewDecoder(resp.Body).Decode(&members); err != nil {
+		t.Fatalf("decoding admin members: %v", err)
+	}
+	if len(members) != 2 {
+		t.Fatalf("expected provider-backed merged admin members, got %d (%+v)", len(members), members)
 	}
 }
 


### PR DESCRIPTION
## Summary

This PR moves the built-in admin authorization read/debug surface onto `providers.authorization` when one is configured, while keeping writes on the current migration bridge through legacy dynamic services plus `ReloadDynamic()`.

That means:
- runtime human authz keeps using the configured authorization provider
- built-in admin member reads now come from provider relationships instead of legacy coredata when a provider is present
- `/admin/api/v1/authorization/...` gains provider/model/relationship inspection endpoints
- startup reuses an existing active authorization model instead of writing a fresh one every boot
- docs now show the host-level `providers.authorization` YAML shape

## Go Interface

```go
type AuthorizationProvider interface {
    Name() string

    GetMetadata(ctx context.Context) (*AuthorizationMetadata, error)
    ReadRelationships(ctx context.Context, req *ReadRelationshipsRequest) (*ReadRelationshipsResponse, error)
    GetActiveModel(ctx context.Context) (*GetActiveModelResponse, error)
    ListModels(ctx context.Context, req *ListModelsRequest) (*ListModelsResponse, error)
}
```

## YAML Interface

```yaml
server:
  providers:
    indexeddb: main
    authorization: indexeddb

providers:
  indexeddb:
    main:
      source:
        ref: github.com/valon-technologies/gestalt-providers/indexeddb/relationaldb
        version: 0.0.1-alpha.1
      config:
        dsn: sqlite://./gestalt.db

  authorization:
    indexeddb:
      source:
        ref: github.com/valon-technologies/gestalt-providers/authorization/indexeddb
        version: 0.0.1-alpha.1
      config:
        indexeddb: main
```

## Examples

Admin/debug API examples:
- `GET /admin/api/v1/authorization/provider`
- `GET /admin/api/v1/authorization/models`
- `GET /admin/api/v1/authorization/relationships?resourceType=plugin_dynamic&resourceId=sample_plugin`
- `GET /admin/api/v1/authorization/admins/members`
- `GET /admin/api/v1/authorization/plugins/sample_plugin/members`

## Migration Behavior

This PR keeps the current migration approach:
- static policy members and legacy dynamic admin/plugin grants are still seeded into the authorization provider via `ReloadDynamic()`
- admin writes still persist through the legacy services, then reload into the provider
- provider-backed admin reads now prove out the provider as the runtime read surface without introducing a second unsynchronized write path

## Verification

Ran locally:
- `go test ./internal/authorization ./internal/bootstrap ./internal/invocation ./internal/mcp ./internal/server`
- `golangci-lint run ./internal/authorization ./internal/bootstrap ./internal/server`

Not included in this PR:
- smoke test / end-to-end runtime dogfood test