### PR TITLE
Authorization provider model-handling follow-ups

### DIFF
--- a/gestaltd/internal/authorization/provider_backed.go
+++ b/gestaltd/internal/authorization/provider_backed.go
@@ -500,7 +500,7 @@ func (a *ProviderBackedAuthorizer) resolveRoleVariants(ctx context.Context, subj
 	}
 
 	a.stateMu.RLock()
-	modelID := a.state.modelID
+	expectedModelID := strings.TrimSpace(a.state.modelID)
 	a.stateMu.RUnlock()
 
 	resource := &core.ResourceRef{Type: resourceType, Id: resourceID}
@@ -521,45 +521,50 @@ func (a *ProviderBackedAuthorizer) resolveRoleVariants(ctx context.Context, subj
 			if i >= len(roles) {
 				break
 			}
+			if decisionModelID := strings.TrimSpace(decision.GetModelId()); expectedModelID != "" && decisionModelID != "" && decisionModelID != expectedModelID {
+				return "", false, fmt.Errorf("authorization provider active model changed: expected %q, got %q", expectedModelID, decisionModelID)
+			}
 			if decision != nil && decision.GetAllowed() {
-				if modelID == "" && decision.GetModelId() != "" {
-					a.stateMu.Lock()
-					if a.state.modelID == "" {
-						a.state.modelID = decision.GetModelId()
-					}
-					a.stateMu.Unlock()
-				}
 				return roles[i], true, nil
 			}
 		}
-	}
-	if modelID != "" {
-		a.stateMu.Lock()
-		if a.state.modelID == "" {
-			a.state.modelID = modelID
-		}
-		a.stateMu.Unlock()
 	}
 	return "", false, nil
 }
 
 func (a *ProviderBackedAuthorizer) ensureModel(ctx context.Context) (string, error) {
 	state := a.currentState()
-	if strings.TrimSpace(state.modelID) != "" {
-		return strings.TrimSpace(state.modelID), nil
-	}
+	expectedModelID := strings.TrimSpace(state.modelID)
 	active, err := a.provider.GetActiveModel(ctx)
 	if err != nil {
 		return "", fmt.Errorf("get active authorization model: %w", err)
 	}
-	if model := active.GetModel(); model != nil && strings.TrimSpace(model.GetId()) != "" {
-		modelID := strings.TrimSpace(model.GetId())
-		a.stateMu.Lock()
-		if a.state.modelID == "" {
-			a.state.modelID = modelID
+	activeModelID := ""
+	if model := active.GetModel(); model != nil {
+		activeModelID = strings.TrimSpace(model.GetId())
+	}
+	if expectedModelID != "" {
+		if activeModelID == "" {
+			return "", fmt.Errorf("authorization provider lost active model %q", expectedModelID)
 		}
-		a.stateMu.Unlock()
-		return modelID, nil
+		if activeModelID != expectedModelID {
+			return "", fmt.Errorf("authorization provider active model changed: expected %q, got %q", expectedModelID, activeModelID)
+		}
+		return expectedModelID, nil
+	}
+	if activeModelID != "" {
+		relationships, err := a.readAllRelationships(ctx, activeModelID)
+		if err != nil {
+			return "", err
+		}
+		if _, ok := relationships[relationshipMapKey(ProviderModelSentinelRelationship())]; ok {
+			a.stateMu.Lock()
+			if a.state.modelID == "" {
+				a.state.modelID = activeModelID
+			}
+			a.stateMu.Unlock()
+			return activeModelID, nil
+		}
 	}
 	model, err := a.provider.WriteModel(ctx, &core.WriteModelRequest{Schema: providerAuthzSchema})
 	if err != nil {
@@ -610,6 +615,7 @@ func (a *ProviderBackedAuthorizer) buildDesiredRelationships(modelID string) (ma
 		pluginStaticRoles:  map[string][]string{},
 		pluginDynamicRoles: map[string][]string{},
 	}
+	addDesiredRelationship(desired, ProviderModelSentinelRelationship())
 	policyStaticRoles := map[string]map[string]struct{}{}
 	pluginStaticRoles := map[string]map[string]struct{}{}
 	pluginDynamicRoles := map[string]map[string]struct{}{}

--- a/gestaltd/internal/authorization/provider_schema.go
+++ b/gestaltd/internal/authorization/provider_schema.go
@@ -26,6 +26,10 @@ subjects:
 	ProviderSubjectTypeSubject = "subject"
 	ProviderSubjectTypeUser    = "user"
 	ProviderSubjectTypeEmail   = "email"
+
+	ProviderModelSentinelRelation   = "managed"
+	ProviderModelSentinelSubjectID  = "gestalt:authorization"
+	ProviderModelSentinelResourceID = "__gestalt_authorization_model__"
 )
 
 const (
@@ -57,4 +61,29 @@ func IsManagedProviderRelationship(rel *core.Relationship) bool {
 	default:
 		return false
 	}
+}
+
+func ProviderModelSentinelRelationship() *core.Relationship {
+	return &core.Relationship{
+		Subject: &core.SubjectRef{
+			Type: ProviderSubjectTypeSubject,
+			Id:   ProviderModelSentinelSubjectID,
+		},
+		Relation: ProviderModelSentinelRelation,
+		Resource: &core.ResourceRef{
+			Type: ProviderResourceTypePolicyStatic,
+			Id:   ProviderModelSentinelResourceID,
+		},
+	}
+}
+
+func IsProviderModelSentinelRelationship(rel *core.Relationship) bool {
+	if rel == nil || rel.GetSubject() == nil || rel.GetResource() == nil {
+		return false
+	}
+	return rel.GetSubject().GetType() == ProviderSubjectTypeSubject &&
+		rel.GetSubject().GetId() == ProviderModelSentinelSubjectID &&
+		rel.GetRelation() == ProviderModelSentinelRelation &&
+		rel.GetResource().GetType() == ProviderResourceTypePolicyStatic &&
+		rel.GetResource().GetId() == ProviderModelSentinelResourceID
 }

--- a/gestaltd/internal/bootstrap/bootstrap_test.go
+++ b/gestaltd/internal/bootstrap/bootstrap_test.go
@@ -24,6 +24,7 @@ import (
 	s3store "github.com/valon-technologies/gestalt/server/core/s3"
 	coretesting "github.com/valon-technologies/gestalt/server/core/testing"
 	coreworkflow "github.com/valon-technologies/gestalt/server/core/workflow"
+	"github.com/valon-technologies/gestalt/server/internal/authorization"
 	"github.com/valon-technologies/gestalt/server/internal/bootstrap"
 	"github.com/valon-technologies/gestalt/server/internal/config"
 	"github.com/valon-technologies/gestalt/server/internal/coredata"
@@ -95,13 +96,13 @@ type memoryAuthorizationProvider struct {
 	mu            sync.Mutex
 	activeModelID string
 	models        []*core.AuthorizationModelRef
-	rels          map[string]*core.Relationship
+	relsByModel   map[string]map[string]*core.Relationship
 }
 
 func newMemoryAuthorizationProvider(name string) *memoryAuthorizationProvider {
 	return &memoryAuthorizationProvider{
-		name: name,
-		rels: map[string]*core.Relationship{},
+		name:        name,
+		relsByModel: map[string]map[string]*core.Relationship{},
 	}
 }
 
@@ -124,10 +125,11 @@ func (p *memoryAuthorizationProvider) EvaluateMany(_ context.Context, req *core.
 	resp := &core.AccessEvaluationsResponse{
 		Decisions: make([]*core.AccessDecision, 0, len(req.GetRequests())),
 	}
+	rels := p.relsByModel[p.activeModelID]
 	for _, item := range req.GetRequests() {
 		allowed := false
-		if item != nil {
-			_, allowed = p.rels[bootstrapRelationshipKey(item.GetSubject(), item.GetAction().GetName(), item.GetResource())]
+		if item != nil && rels != nil {
+			_, allowed = rels[bootstrapRelationshipKey(item.GetSubject(), item.GetAction().GetName(), item.GetResource())]
 		}
 		resp.Decisions = append(resp.Decisions, &core.AccessDecision{
 			Allowed: allowed,
@@ -155,27 +157,40 @@ func (p *memoryAuthorizationProvider) GetMetadata(context.Context) (*core.Author
 	return &core.AuthorizationMetadata{ActiveModelId: p.activeModelID}, nil
 }
 
-func (p *memoryAuthorizationProvider) ReadRelationships(context.Context, *core.ReadRelationshipsRequest) (*core.ReadRelationshipsResponse, error) {
+func (p *memoryAuthorizationProvider) ReadRelationships(_ context.Context, req *core.ReadRelationshipsRequest) (*core.ReadRelationshipsResponse, error) {
 	p.mu.Lock()
 	defer p.mu.Unlock()
-	out := make([]*core.Relationship, 0, len(p.rels))
-	for _, rel := range p.rels {
+	modelID := strings.TrimSpace(req.GetModelId())
+	if modelID == "" {
+		modelID = p.activeModelID
+	}
+	out := make([]*core.Relationship, 0, len(p.relsByModel[modelID]))
+	for _, rel := range p.relsByModel[modelID] {
 		out = append(out, cloneRelationship(rel))
 	}
 	return &core.ReadRelationshipsResponse{
 		Relationships: out,
-		ModelId:       p.activeModelID,
+		ModelId:       modelID,
 	}, nil
 }
 
 func (p *memoryAuthorizationProvider) WriteRelationships(_ context.Context, req *core.WriteRelationshipsRequest) error {
 	p.mu.Lock()
 	defer p.mu.Unlock()
+	modelID := req.GetModelId()
+	if modelID == "" {
+		modelID = p.activeModelID
+	}
+	rels := p.relsByModel[modelID]
+	if rels == nil {
+		rels = map[string]*core.Relationship{}
+		p.relsByModel[modelID] = rels
+	}
 	for _, key := range req.GetDeletes() {
-		delete(p.rels, bootstrapRelationshipKey(key.GetSubject(), key.GetRelation(), key.GetResource()))
+		delete(rels, bootstrapRelationshipKey(key.GetSubject(), key.GetRelation(), key.GetResource()))
 	}
 	for _, rel := range req.GetWrites() {
-		p.rels[bootstrapRelationshipKey(rel.GetSubject(), rel.GetRelation(), rel.GetResource())] = cloneRelationship(rel)
+		rels[bootstrapRelationshipKey(rel.GetSubject(), rel.GetRelation(), rel.GetResource())] = cloneRelationship(rel)
 	}
 	return nil
 }
@@ -206,6 +221,9 @@ func (p *memoryAuthorizationProvider) WriteModel(context.Context, *core.WriteMod
 	}
 	p.models = append(p.models, model)
 	p.activeModelID = model.GetId()
+	if p.relsByModel[model.GetId()] == nil {
+		p.relsByModel[model.GetId()] = map[string]*core.Relationship{}
+	}
 	return model, nil
 }
 
@@ -223,6 +241,22 @@ func bootstrapRelationshipKey(subject *core.SubjectRef, relation string, resourc
 		resource.GetType(),
 		resource.GetId(),
 	}, "\x00")
+}
+
+func (p *memoryAuthorizationProvider) putRelationship(modelID string, rel *core.Relationship) {
+	p.mu.Lock()
+	defer p.mu.Unlock()
+	if p.relsByModel[modelID] == nil {
+		p.relsByModel[modelID] = map[string]*core.Relationship{}
+	}
+	p.relsByModel[modelID][bootstrapRelationshipKey(rel.GetSubject(), rel.GetRelation(), rel.GetResource())] = cloneRelationship(rel)
+}
+
+func (p *memoryAuthorizationProvider) hasRelationship(modelID, key string) bool {
+	p.mu.Lock()
+	defer p.mu.Unlock()
+	_, ok := p.relsByModel[modelID][key]
+	return ok
 }
 
 func cloneRelationship(rel *core.Relationship) *core.Relationship {
@@ -3455,16 +3489,18 @@ func TestBootstrapSecretResolution(t *testing.T) {
 			Version: "v1",
 		}}
 		provider.activeModelID = "model-existing"
+		provider.relsByModel["model-existing"] = map[string]*core.Relationship{}
 		unmanagedKey := bootstrapRelationshipKey(
 			&core.SubjectRef{Type: "team", Id: "ops"},
 			"owner",
 			&core.ResourceRef{Type: "foreign_resource", Id: "roadmap"},
 		)
-		provider.rels[unmanagedKey] = &core.Relationship{
+		provider.putRelationship("model-existing", &core.Relationship{
 			Subject:  &core.SubjectRef{Type: "team", Id: "ops"},
 			Relation: "owner",
 			Resource: &core.ResourceRef{Type: "foreign_resource", Id: "roadmap"},
-		}
+		})
+		provider.putRelationship("model-existing", authorization.ProviderModelSentinelRelationship())
 		factories := validFactories()
 		factories.Authorization = memoryAuthorizationFactory(provider)
 
@@ -3483,7 +3519,7 @@ func TestBootstrapSecretResolution(t *testing.T) {
 		if len(provider.models) != 1 {
 			t.Fatalf("expected existing model to be reused, got %d models", len(provider.models))
 		}
-		if _, ok := provider.rels[unmanagedKey]; !ok {
+		if _, ok := provider.relsByModel["model-existing"][unmanagedKey]; !ok {
 			t.Fatal("expected unrelated provider relationship to be preserved")
 		}
 
@@ -3542,6 +3578,144 @@ func TestBootstrapSecretResolution(t *testing.T) {
 		}
 		if adminAccess.Role != "admin" {
 			t.Fatalf("dynamic admin role = %q, want %q", adminAccess.Role, "admin")
+		}
+	})
+
+	t.Run("authorization provider provisions a new model when the active model is unmanaged", func(t *testing.T) {
+		t.Parallel()
+
+		cfg := validConfig()
+		cfg.Authorization = config.AuthorizationConfig{
+			Policies: map[string]config.HumanPolicyDef{
+				"calendar-policy": {
+					Default: "deny",
+					Members: []config.HumanPolicyMemberDef{
+						{Email: "static@example.test", Role: "viewer"},
+					},
+				},
+			},
+		}
+		cfg.Plugins = map[string]*config.ProviderEntry{
+			"calendar": {
+				AuthorizationPolicy: "calendar-policy",
+				ResolvedManifest: &providermanifestv1.Manifest{
+					Spec: &providermanifestv1.Spec{},
+				},
+			},
+		}
+		cfg.Providers.Authorization = map[string]*config.ProviderEntry{
+			"indexeddb": {Source: config.ProviderSource{Path: "stub"}},
+		}
+		cfg.Server.Providers.Authorization = "indexeddb"
+
+		provider := newMemoryAuthorizationProvider("memory-authorization")
+		provider.models = []*core.AuthorizationModelRef{{
+			Id:      "model-existing",
+			Version: "v1",
+		}}
+		provider.activeModelID = "model-existing"
+		provider.relsByModel["model-existing"] = map[string]*core.Relationship{}
+		unmanagedKey := bootstrapRelationshipKey(
+			&core.SubjectRef{Type: "team", Id: "ops"},
+			"owner",
+			&core.ResourceRef{Type: "foreign_resource", Id: "roadmap"},
+		)
+		provider.putRelationship("model-existing", &core.Relationship{
+			Subject:  &core.SubjectRef{Type: "team", Id: "ops"},
+			Relation: "owner",
+			Resource: &core.ResourceRef{Type: "foreign_resource", Id: "roadmap"},
+		})
+
+		factories := validFactories()
+		factories.Authorization = memoryAuthorizationFactory(provider)
+
+		result, err := bootstrap.Bootstrap(ctx, cfg, factories)
+		if err != nil {
+			t.Fatalf("Bootstrap: %v", err)
+		}
+		t.Cleanup(func() { _ = result.Close(context.Background()) })
+		<-result.ProvidersReady
+		if err := result.Start(ctx); err != nil {
+			t.Fatalf("Start: %v", err)
+		}
+		if got := provider.activeModelID; got == "model-existing" {
+			t.Fatalf("expected a newly provisioned model, active model remained %q", got)
+		}
+		if len(provider.models) != 2 {
+			t.Fatalf("expected a new model to be written, got %d models", len(provider.models))
+		}
+		if _, ok := provider.relsByModel["model-existing"][unmanagedKey]; !ok {
+			t.Fatal("expected unmanaged relationships on the old model to be preserved")
+		}
+		if !provider.hasRelationship(provider.activeModelID, bootstrapRelationshipKey(
+			authorization.ProviderModelSentinelRelationship().GetSubject(),
+			authorization.ProviderModelSentinelRelationship().GetRelation(),
+			authorization.ProviderModelSentinelRelationship().GetResource(),
+		)) {
+			t.Fatal("expected the new active model to include the Gestalt model sentinel")
+		}
+	})
+
+	t.Run("authorization provider falls back to legacy rules when the active model drifts", func(t *testing.T) {
+		t.Parallel()
+
+		cfg := validConfig()
+		cfg.Authorization = config.AuthorizationConfig{
+			Policies: map[string]config.HumanPolicyDef{
+				"calendar-policy": {
+					Default: "deny",
+					Members: []config.HumanPolicyMemberDef{
+						{Email: "static@example.test", Role: "viewer"},
+					},
+				},
+			},
+		}
+		cfg.Plugins = map[string]*config.ProviderEntry{
+			"calendar": {
+				AuthorizationPolicy: "calendar-policy",
+				ResolvedManifest: &providermanifestv1.Manifest{
+					Spec: &providermanifestv1.Spec{},
+				},
+			},
+		}
+		cfg.Providers.Authorization = map[string]*config.ProviderEntry{
+			"indexeddb": {Source: config.ProviderSource{Path: "stub"}},
+		}
+		cfg.Server.Providers.Authorization = "indexeddb"
+
+		provider := newMemoryAuthorizationProvider("memory-authorization")
+		factories := validFactories()
+		factories.Authorization = memoryAuthorizationFactory(provider)
+
+		result, err := bootstrap.Bootstrap(ctx, cfg, factories)
+		if err != nil {
+			t.Fatalf("Bootstrap: %v", err)
+		}
+		t.Cleanup(func() { _ = result.Close(context.Background()) })
+		<-result.ProvidersReady
+		if err := result.Start(ctx); err != nil {
+			t.Fatalf("Start: %v", err)
+		}
+
+		provider.mu.Lock()
+		provider.models = append(provider.models, &core.AuthorizationModelRef{Id: "model-foreign", Version: "v1"})
+		provider.relsByModel["model-foreign"] = map[string]*core.Relationship{}
+		provider.activeModelID = "model-foreign"
+		provider.mu.Unlock()
+
+		staticPrincipal := &principal.Principal{
+			Identity: &core.UserIdentity{Email: "static@example.test"},
+			Kind:     principal.KindUser,
+		}
+		access, allowed := result.Authorizer.ResolveAccess(ctx, staticPrincipal, "calendar")
+		if !allowed {
+			t.Fatal("expected legacy fallback access to be allowed")
+		}
+		if access.Role != "viewer" {
+			t.Fatalf("legacy fallback role = %q, want %q", access.Role, "viewer")
+		}
+		if err := result.Authorizer.ReloadDynamic(ctx); err == nil {
+			t.Fatal("expected reload to fail after active model drift")
 		}
 	})
 

--- a/gestaltd/internal/server/handlers_admin_authorization_provider.go
+++ b/gestaltd/internal/server/handlers_admin_authorization_provider.go
@@ -55,7 +55,7 @@ type adminAuthorizationRef struct {
 }
 
 func (s *Server) getAdminAuthorizationProvider(w http.ResponseWriter, r *http.Request) {
-	if !s.ensureAdminAuthorizationProviderAvailable(w) {
+	if !s.ensureAdminAuthorizationProviderDebugAvailable(w) {
 		return
 	}
 
@@ -88,7 +88,7 @@ func (s *Server) getAdminAuthorizationProvider(w http.ResponseWriter, r *http.Re
 }
 
 func (s *Server) listAdminAuthorizationModels(w http.ResponseWriter, r *http.Request) {
-	if !s.ensureAdminAuthorizationProviderAvailable(w) {
+	if !s.ensureAdminAuthorizationProviderDebugAvailable(w) {
 		return
 	}
 
@@ -116,7 +116,7 @@ func (s *Server) listAdminAuthorizationModels(w http.ResponseWriter, r *http.Req
 }
 
 func (s *Server) listAdminAuthorizationRelationships(w http.ResponseWriter, r *http.Request) {
-	if !s.ensureAdminAuthorizationProviderAvailable(w) {
+	if !s.ensureAdminAuthorizationProviderDebugAvailable(w) {
 		return
 	}
 
@@ -308,6 +308,17 @@ func (s *Server) readAllAuthorizationRelationships(ctx context.Context, req *cor
 func (s *Server) ensureAdminAuthorizationProviderAvailable(w http.ResponseWriter) bool {
 	if s.authorizationProvider == nil {
 		writeError(w, http.StatusServiceUnavailable, "authorization provider is unavailable")
+		return false
+	}
+	return true
+}
+
+func (s *Server) ensureAdminAuthorizationProviderDebugAvailable(w http.ResponseWriter) bool {
+	if !s.ensureAdminAuthorizationProviderAvailable(w) {
+		return false
+	}
+	if strings.TrimSpace(s.adminRoute.AuthorizationPolicy) == "" {
+		writeError(w, http.StatusServiceUnavailable, "authorization provider debug is unavailable")
 		return false
 	}
 	return true

--- a/gestaltd/internal/server/server_test.go
+++ b/gestaltd/internal/server/server_test.go
@@ -134,13 +134,13 @@ type memoryAuthorizationProvider struct {
 	mu            sync.Mutex
 	activeModelID string
 	models        []*core.AuthorizationModelRef
-	rels          map[string]*core.Relationship
+	relsByModel   map[string]map[string]*core.Relationship
 }
 
 func newMemoryAuthorizationProvider(name string) *memoryAuthorizationProvider {
 	return &memoryAuthorizationProvider{
-		name: name,
-		rels: map[string]*core.Relationship{},
+		name:        name,
+		relsByModel: map[string]map[string]*core.Relationship{},
 	}
 }
 
@@ -163,10 +163,11 @@ func (p *memoryAuthorizationProvider) EvaluateMany(_ context.Context, req *core.
 	resp := &core.AccessEvaluationsResponse{
 		Decisions: make([]*core.AccessDecision, 0, len(req.GetRequests())),
 	}
+	rels := p.relsByModel[p.activeModelID]
 	for _, item := range req.GetRequests() {
 		allowed := false
-		if item != nil {
-			_, allowed = p.rels[memoryAuthorizationRelationshipKey(item.GetSubject(), item.GetAction().GetName(), item.GetResource())]
+		if item != nil && rels != nil {
+			_, allowed = rels[memoryAuthorizationRelationshipKey(item.GetSubject(), item.GetAction().GetName(), item.GetResource())]
 		}
 		resp.Decisions = append(resp.Decisions, &core.AccessDecision{
 			Allowed: allowed,
@@ -198,8 +199,13 @@ func (p *memoryAuthorizationProvider) ReadRelationships(_ context.Context, req *
 	p.mu.Lock()
 	defer p.mu.Unlock()
 
-	keys := make([]string, 0, len(p.rels))
-	for key, rel := range p.rels {
+	modelID := strings.TrimSpace(req.GetModelId())
+	if modelID == "" {
+		modelID = p.activeModelID
+	}
+	rels := p.relsByModel[modelID]
+	keys := make([]string, 0, len(rels))
+	for key, rel := range rels {
 		if !memoryAuthorizationRelationshipMatches(rel, req) {
 			continue
 		}
@@ -230,7 +236,7 @@ func (p *memoryAuthorizationProvider) ReadRelationships(_ context.Context, req *
 
 	out := make([]*core.Relationship, 0, end-start)
 	for _, key := range keys[start:end] {
-		out = append(out, cloneMemoryAuthorizationRelationship(p.rels[key]))
+		out = append(out, cloneMemoryAuthorizationRelationship(rels[key]))
 	}
 	nextPageToken := ""
 	if end < len(keys) {
@@ -239,18 +245,27 @@ func (p *memoryAuthorizationProvider) ReadRelationships(_ context.Context, req *
 	return &core.ReadRelationshipsResponse{
 		Relationships: out,
 		NextPageToken: nextPageToken,
-		ModelId:       p.activeModelID,
+		ModelId:       modelID,
 	}, nil
 }
 
 func (p *memoryAuthorizationProvider) WriteRelationships(_ context.Context, req *core.WriteRelationshipsRequest) error {
 	p.mu.Lock()
 	defer p.mu.Unlock()
+	modelID := strings.TrimSpace(req.GetModelId())
+	if modelID == "" {
+		modelID = p.activeModelID
+	}
+	rels := p.relsByModel[modelID]
+	if rels == nil {
+		rels = map[string]*core.Relationship{}
+		p.relsByModel[modelID] = rels
+	}
 	for _, key := range req.GetDeletes() {
-		delete(p.rels, memoryAuthorizationRelationshipKey(key.GetSubject(), key.GetRelation(), key.GetResource()))
+		delete(rels, memoryAuthorizationRelationshipKey(key.GetSubject(), key.GetRelation(), key.GetResource()))
 	}
 	for _, rel := range req.GetWrites() {
-		p.rels[memoryAuthorizationRelationshipKey(rel.GetSubject(), rel.GetRelation(), rel.GetResource())] = cloneMemoryAuthorizationRelationship(rel)
+		rels[memoryAuthorizationRelationshipKey(rel.GetSubject(), rel.GetRelation(), rel.GetResource())] = cloneMemoryAuthorizationRelationship(rel)
 	}
 	return nil
 }
@@ -281,6 +296,9 @@ func (p *memoryAuthorizationProvider) WriteModel(context.Context, *core.WriteMod
 	}
 	p.models = append(p.models, model)
 	p.activeModelID = model.GetId()
+	if p.relsByModel[model.GetId()] == nil {
+		p.relsByModel[model.GetId()] = map[string]*core.Relationship{}
+	}
 	return model, nil
 }
 
@@ -2499,13 +2517,29 @@ func TestAdminAPI_PluginAuthorizationProviderBackedReadsAndDebug(t *testing.T) {
 		t.Fatalf("authorization.New: %v", err)
 	}
 	authz := authorization.NewProviderBacked(legacy, provider)
+	if err := authz.ReloadDynamic(context.Background()); err != nil {
+		t.Fatalf("ReloadDynamic: %v", err)
+	}
 
 	ts := newTestServer(t, func(cfg *server.Config) {
+		cfg.Auth = &coretesting.StubAuthProvider{
+			N: "test",
+			ValidateTokenFn: func(_ context.Context, token string) (*core.UserIdentity, error) {
+				if token != "admin-session" {
+					return nil, fmt.Errorf("invalid token")
+				}
+				return &core.UserIdentity{Email: "static@example.test"}, nil
+			},
+		}
 		cfg.Services = svc
 		cfg.Authorizer = authz
 		cfg.AuthorizationProvider = provider
 		cfg.PluginDefs = map[string]*config.ProviderEntry{
 			"sample_plugin": {AuthorizationPolicy: "sample_policy", MountPath: "/sample"},
+		}
+		cfg.Admin = server.AdminRouteConfig{
+			AuthorizationPolicy: "sample_policy",
+			AllowedRoles:        []string{"admin"},
 		}
 		cfg.AdminUI = http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
 			_, _ = w.Write([]byte("admin"))
@@ -2516,6 +2550,7 @@ func TestAdminAPI_PluginAuthorizationProviderBackedReadsAndDebug(t *testing.T) {
 	body := bytes.NewBufferString(`{"email":"dynamic@example.test","role":"viewer"}`)
 	req, _ := http.NewRequest(http.MethodPut, ts.URL+"/admin/api/v1/authorization/plugins/sample_plugin/members", body)
 	req.Header.Set("Content-Type", "application/json")
+	req.AddCookie(&http.Cookie{Name: "session_token", Value: "admin-session"})
 	resp, err := http.DefaultClient.Do(req)
 	if err != nil {
 		t.Fatalf("PUT dynamic member: %v", err)
@@ -2534,7 +2569,9 @@ func TestAdminAPI_PluginAuthorizationProviderBackedReadsAndDebug(t *testing.T) {
 		t.Fatalf("DeletePluginAuthorization: %v", err)
 	}
 
-	resp, err = http.Get(ts.URL + "/admin/api/v1/authorization/plugins/sample_plugin/members")
+	req, _ = http.NewRequest(http.MethodGet, ts.URL+"/admin/api/v1/authorization/plugins/sample_plugin/members", nil)
+	req.AddCookie(&http.Cookie{Name: "session_token", Value: "admin-session"})
+	resp, err = http.DefaultClient.Do(req)
 	if err != nil {
 		t.Fatalf("GET members: %v", err)
 	}
@@ -2551,7 +2588,9 @@ func TestAdminAPI_PluginAuthorizationProviderBackedReadsAndDebug(t *testing.T) {
 		t.Fatalf("expected provider-backed merged members, got %d (%+v)", len(members), members)
 	}
 
-	resp, err = http.Get(ts.URL + "/admin/api/v1/authorization/provider")
+	req, _ = http.NewRequest(http.MethodGet, ts.URL+"/admin/api/v1/authorization/provider", nil)
+	req.AddCookie(&http.Cookie{Name: "session_token", Value: "admin-session"})
+	resp, err = http.DefaultClient.Do(req)
 	if err != nil {
 		t.Fatalf("GET provider summary: %v", err)
 	}
@@ -2574,7 +2613,9 @@ func TestAdminAPI_PluginAuthorizationProviderBackedReadsAndDebug(t *testing.T) {
 		t.Fatal("expected active model id")
 	}
 
-	resp, err = http.Get(ts.URL + "/admin/api/v1/authorization/models")
+	req, _ = http.NewRequest(http.MethodGet, ts.URL+"/admin/api/v1/authorization/models", nil)
+	req.AddCookie(&http.Cookie{Name: "session_token", Value: "admin-session"})
+	resp, err = http.DefaultClient.Do(req)
 	if err != nil {
 		t.Fatalf("GET models: %v", err)
 	}
@@ -2595,7 +2636,9 @@ func TestAdminAPI_PluginAuthorizationProviderBackedReadsAndDebug(t *testing.T) {
 		t.Fatalf("models response = %+v, want one active model", modelsResp.Models)
 	}
 
-	resp, err = http.Get(ts.URL + "/admin/api/v1/authorization/relationships?resourceType=plugin_dynamic&resourceId=sample_plugin")
+	req, _ = http.NewRequest(http.MethodGet, ts.URL+"/admin/api/v1/authorization/relationships?resourceType=plugin_dynamic&resourceId=sample_plugin", nil)
+	req.AddCookie(&http.Cookie{Name: "session_token", Value: "admin-session"})
+	resp, err = http.DefaultClient.Do(req)
 	if err != nil {
 		t.Fatalf("GET relationships: %v", err)
 	}
@@ -2623,6 +2666,63 @@ func TestAdminAPI_PluginAuthorizationProviderBackedReadsAndDebug(t *testing.T) {
 		if !rel.Managed {
 			t.Fatalf("expected managed relationship rows, got %+v", relationshipsResp.Relationships)
 		}
+	}
+}
+
+func TestAdminAPI_AuthorizationProviderDebugRequiresAdminPolicy(t *testing.T) {
+	t.Parallel()
+
+	svc := coretesting.NewStubServices(t)
+	provider := newMemoryAuthorizationProvider("memory-authorization")
+	legacy, err := authorization.New(config.AuthorizationConfig{
+		Policies: map[string]config.HumanPolicyDef{
+			"sample_policy": {
+				Default: "deny",
+				Members: []config.HumanPolicyMemberDef{
+					{Email: "static@example.test", Role: "admin"},
+				},
+			},
+		},
+	}, map[string]*config.ProviderEntry{
+		"sample_plugin": {AuthorizationPolicy: "sample_policy", MountPath: "/sample"},
+	}, nil, nil, svc.PluginAuthorizations)
+	if err != nil {
+		t.Fatalf("authorization.New: %v", err)
+	}
+	authz := authorization.NewProviderBacked(legacy, provider)
+	if err := authz.ReloadDynamic(context.Background()); err != nil {
+		t.Fatalf("ReloadDynamic: %v", err)
+	}
+
+	ts := newTestServer(t, func(cfg *server.Config) {
+		cfg.Services = svc
+		cfg.Authorizer = authz
+		cfg.AuthorizationProvider = provider
+		cfg.PluginDefs = map[string]*config.ProviderEntry{
+			"sample_plugin": {AuthorizationPolicy: "sample_policy", MountPath: "/sample"},
+		}
+		cfg.AdminUI = http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+			_, _ = w.Write([]byte("admin"))
+		})
+	})
+	testutil.CloseOnCleanup(t, ts)
+
+	paths := []string{
+		"/admin/api/v1/authorization/provider",
+		"/admin/api/v1/authorization/models",
+		"/admin/api/v1/authorization/relationships",
+	}
+	for _, path := range paths {
+		resp, err := http.Get(ts.URL + path)
+		if err != nil {
+			t.Fatalf("GET %s: %v", path, err)
+		}
+		if resp.StatusCode != http.StatusServiceUnavailable {
+			body, _ := io.ReadAll(resp.Body)
+			_ = resp.Body.Close()
+			t.Fatalf("%s status = %d, want 503: %s", path, resp.StatusCode, body)
+		}
+		_ = resp.Body.Close()
 	}
 }
 


### PR DESCRIPTION
## Summary

This is the immediate follow-up to `#1129`.

It fixes three issues in the provider-backed authorization rollout:
- stops blindly reusing arbitrary active provider models
- detects active-model drift instead of evaluating one model while syncing another
- requires `server.admin.authorizationPolicy` before exposing provider/model/relationship debug endpoints

It also upgrades the in-memory authorization test provider to be model-aware so the tests can actually exercise multiple models and active-model drift.

## Go Interface

```go
type AuthorizationProvider interface {
    Name() string

    EvaluateMany(ctx context.Context, req *AccessEvaluationsRequest) (*AccessEvaluationsResponse, error)
    ReadRelationships(ctx context.Context, req *ReadRelationshipsRequest) (*ReadRelationshipsResponse, error)
    GetActiveModel(ctx context.Context) (*GetActiveModelResponse, error)
    WriteModel(ctx context.Context, req *WriteModelRequest) (*AuthorizationModelRef, error)
}
```

## YAML Interface

```yaml
server:
  admin:
    authorizationPolicy: admin_policy
    allowedRoles: [admin]
  providers:
    indexeddb: main
    authorization: indexeddb

providers:
  indexeddb:
    main:
      source:
        ref: github.com/valon-technologies/gestalt-providers/indexeddb/relationaldb
        version: 0.0.1-alpha.1
      config:
        dsn: sqlite://./gestalt.db

  authorization:
    indexeddb:
      source:
        ref: github.com/valon-technologies/gestalt-providers/authorization/indexeddb
        version: 0.0.1-alpha.1
      config:
        indexeddb: main
```

## Examples

- `GET /admin/api/v1/authorization/provider`
- `GET /admin/api/v1/authorization/models`
- `GET /admin/api/v1/authorization/relationships?resourceType=plugin_dynamic&resourceId=sample_plugin`
- `authorizer.ReloadDynamic(ctx)` now fails when the provider active model drifts out of band

## Behavior Changes

- Gestalt now writes and looks for a managed sentinel relationship before reusing an already-active provider model.
- If the provider active model changes after Gestalt has pinned one, provider-backed evaluation reports an error and falls back to legacy human authorization rather than silently mixing models.
- The provider debug endpoints return `503` unless an admin authorization policy is configured.

## Verification

Ran locally:
- `go test ./internal/authorization ./internal/bootstrap ./internal/invocation ./internal/mcp ./internal/server`
- `golangci-lint run ./internal/authorization ./internal/bootstrap ./internal/server`

No smoke test added in this PR.