### PR TITLE
Docs: update authorization provider source examples

### DIFF
--- a/docs/content/reference/config-file.mdx
+++ b/docs/content/reference/config-file.mdx
@@ -299,17 +299,13 @@ server:
 providers:
   indexeddb:
     main:
-      source:
-        ref: github.com/valon-technologies/gestalt-providers/indexeddb/relationaldb
-        version: 0.0.1-alpha.1
+      source: https://artifacts.example.com/indexeddb/relationaldb/v0.0.1-alpha.1/provider-release.yaml
       config:
         dsn: ${DATABASE_URL}
 
   authorization:
     indexeddb:
-      source:
-        ref: github.com/valon-technologies/gestalt-providers/authorization/indexeddb
-        version: 0.0.1-alpha.1
+      source: https://artifacts.example.com/authorization/indexeddb/v0.0.1-alpha.1/provider-release.yaml
       config:
         indexeddb: main
 ```
@@ -321,8 +317,8 @@ The exact config fields depend on the selected authorization provider package. T
 | Field | Description |
 | --- | --- |
 | `default` | Marks this named authorization entry as the default selection when `server.providers.authorization` is omitted. |
-| `source.ref` | Managed provider source address. |
-| `source.version` | Required with `source.ref`. SemVer without a leading `v`. |
+| `source` | Either a published `provider-release.yaml` metadata URL or a local provider manifest path. |
+| `auth` | Optional inline source auth. Only valid for metadata URL sources. |
 | `config` | Provider-specific config passed into the authorization provider. |
 | `env` | Extra environment variables passed to the provider process. |
 | `allowedHosts` | Outbound host allowlist. For executable plugins, this is only a complete boundary when a supported sandboxed runtime is active. |


### PR DESCRIPTION
## Summary
This removes the last public `source.ref` / `source.version` example from the config reference.

## Updated Interface
Authorization providers now use the same config shape already documented for other host providers:

```yaml
server:
  providers:
    indexeddb: main
    authorization: indexeddb

providers:
  indexeddb:
    main:
      source: https://artifacts.example.com/indexeddb/relationaldb/v0.0.1-alpha.1/provider-release.yaml
      config:
        dsn: ${DATABASE_URL}

  authorization:
    indexeddb:
      source: https://artifacts.example.com/authorization/indexeddb/v0.0.1-alpha.1/provider-release.yaml
      config:
        indexeddb: main
```

The field reference now matches that interface:
- `source`: published `provider-release.yaml` metadata URL or local manifest path
- `auth`: optional inline source auth for metadata URLs

## Validation
```bash
rg -n "source\.ref|source\.version|spec\.ui\.ref|spec\.ui\.version" docs -g'*.md' -g'*.mdx'
npm --prefix docs ci
npm --prefix docs run build
```