### PR TITLE
[codex] surface oauth reconnect errors

### DIFF
--- a/gestaltd/internal/invocation/broker.go
+++ b/gestaltd/internal/invocation/broker.go
@@ -620,7 +620,7 @@ func (b *Broker) refreshTokenIfNeeded(ctx context.Context, token *core.Integrati
 		if time.Now().Before(*token.ExpiresAt) {
 			return token.AccessToken, nil
 		}
-		return "", fmt.Errorf("token expired and refresh failed: %w", err)
+		return "", fmt.Errorf("%w: token expired and refresh failed: %w", ErrReconnectRequired, err)
 	}
 
 	resp := v.(*core.TokenResponse)

--- a/gestaltd/internal/invocation/errors.go
+++ b/gestaltd/internal/invocation/errors.go
@@ -8,6 +8,7 @@ var (
 	ErrNotAuthenticated    = errors.New("not authenticated")
 	ErrAuthorizationDenied = errors.New("authorization denied")
 	ErrNoToken             = errors.New("no integration token")
+	ErrReconnectRequired   = errors.New("integration reconnect required")
 	ErrAmbiguousInstance   = errors.New("ambiguous instance")
 	ErrUserResolution      = errors.New("user resolution failed")
 	ErrInternal            = errors.New("internal error")

--- a/gestaltd/internal/server/handlers.go
+++ b/gestaltd/internal/server/handlers.go
@@ -662,6 +662,8 @@ func (s *Server) writeInvocationError(w http.ResponseWriter, r *http.Request, pr
 		writeError(w, http.StatusForbidden, err.Error())
 	case errors.Is(err, invocation.ErrNoToken):
 		writeError(w, http.StatusPreconditionFailed, fmt.Sprintf("no token stored for integration %q; connect via OAuth first", providerName))
+	case errors.Is(err, invocation.ErrReconnectRequired):
+		writeError(w, http.StatusPreconditionFailed, fmt.Sprintf("OAuth token for integration %q expired or was revoked; reconnect it", providerName))
 	case errors.Is(err, invocation.ErrAmbiguousInstance):
 		writeError(w, http.StatusConflict, err.Error())
 	case errors.Is(err, invocation.ErrUserResolution):

--- a/gestaltd/internal/server/server_test.go
+++ b/gestaltd/internal/server/server_test.go
@@ -13709,6 +13709,52 @@ func TestExecuteOperation_UserFacingErrorMessage(t *testing.T) {
 	}
 }
 
+func TestExecuteOperation_ReconnectRequiredMessage(t *testing.T) {
+	t.Parallel()
+
+	fullStub := &stubIntegrationWithOps{
+		StubIntegration: coretesting.StubIntegration{N: "test-int"},
+		ops: []core.Operation{
+			{Name: "do_thing", Description: "Do a thing", Method: http.MethodGet},
+		},
+	}
+
+	invoker := &testutil.StubInvoker{
+		Err: fmt.Errorf("%w: token endpoint returned 400: {\"error\":\"invalid_grant\"}", invocation.ErrReconnectRequired),
+	}
+
+	ts := newTestServer(t, func(cfg *server.Config) {
+		cfg.Providers = testutil.NewProviderRegistry(t, fullStub)
+		cfg.Invoker = invoker
+	})
+	testutil.CloseOnCleanup(t, ts)
+
+	req, _ := http.NewRequest(http.MethodGet, ts.URL+"/api/v1/test-int/do_thing", nil)
+	resp, err := http.DefaultClient.Do(req)
+	if err != nil {
+		t.Fatalf("request: %v", err)
+	}
+	defer func() { _ = resp.Body.Close() }()
+
+	if resp.StatusCode != http.StatusPreconditionFailed {
+		body, _ := io.ReadAll(resp.Body)
+		t.Fatalf("status = %d, want 412: %s", resp.StatusCode, body)
+	}
+
+	body, _ := io.ReadAll(resp.Body)
+	if strings.Contains(string(body), "invalid_grant") {
+		t.Fatalf("response body contains upstream refresh details: %s", body)
+	}
+
+	var errResp map[string]string
+	if err := json.Unmarshal(body, &errResp); err != nil {
+		t.Fatalf("decoding error response: %v", err)
+	}
+	if errResp["error"] != `OAuth token for integration "test-int" expired or was revoked; reconnect it` {
+		t.Fatalf("expected reconnect-required message, got %q", errResp["error"])
+	}
+}
+
 func TestExecuteOperation_WrappedOperationErrorMessage(t *testing.T) {
 	t.Parallel()
 


### PR DESCRIPTION
## What changed

This change makes expired or revoked OAuth refresh state surface as an actionable reconnect error instead of the generic `operation failed` response.

## Why it changed

While debugging `gestalt invoke clickhouse`, the server logs showed the real failure was an OAuth refresh rejection from ClickHouse:

- stored connection still appeared as connected
- refresh failed with `invalid_grant`
- the HTTP API collapsed that into a generic 502 `operation failed`

That made the CLI failure look like a server-side invocation bug instead of a reconnect-required connection issue.

## Impact

Users now get a concrete reconnect message when a stored OAuth token has expired or been revoked, which should make recovery immediate from both the HTTP API and the CLI.

## Root cause

`refreshTokenIfNeeded` returned a generic wrapped error after refresh failure on an expired token. The server error handler treated that as an unsafe internal error and returned `operation failed`.

This PR introduces a dedicated reconnect-required error path and maps it to a safe user-facing 412 response.

## Validation

- `go test ./internal/server -run 'TestExecuteOperation_(ReconnectRequiredMessage|UserFacingErrorMessage|WrappedOperationErrorMessage)$'`
- `go test ./internal/invocation`
