### PR TITLE
[codex] fix notion composite REST resolution

### DIFF
--- a/gestaltd/internal/composite/operation_resolution.go
+++ b/gestaltd/internal/composite/operation_resolution.go
@@ -1,0 +1,29 @@
+package composite
+
+import (
+	"context"
+
+	"github.com/valon-technologies/gestalt/server/core/catalog"
+)
+
+// ResolveStaticOperationForRequest marks API-backed operations as authoritative
+// for request execution. Composite session catalogs only describe the MCP
+// surface, so static REST ops should not trigger MCP session initialization.
+func (p *Provider) ResolveStaticOperationForRequest(_ context.Context, operation string) (catalog.CatalogOperation, bool) {
+	return taggedCatalogOperation(p.api.Catalog(), operation, catalog.TransportREST)
+}
+
+func taggedCatalogOperation(cat *catalog.Catalog, operation, transport string) (catalog.CatalogOperation, bool) {
+	if cat == nil {
+		return catalog.CatalogOperation{}, false
+	}
+	for i := range cat.Operations {
+		if cat.Operations[i].ID != operation {
+			continue
+		}
+		op := cat.Operations[i]
+		op.Transport = transport
+		return op, true
+	}
+	return catalog.CatalogOperation{}, false
+}

--- a/gestaltd/internal/invocation/catalog.go
+++ b/gestaltd/internal/invocation/catalog.go
@@ -17,6 +17,10 @@ type TokenResolver interface {
 	ResolveToken(ctx context.Context, p *principal.Principal, providerName, connection, instance string) (context.Context, string, error)
 }
 
+type requestStaticOperationResolver interface {
+	ResolveStaticOperationForRequest(ctx context.Context, operation string) (catalog.CatalogOperation, bool)
+}
+
 type CatalogResolutionMetadata struct {
 	SessionAttempted bool
 	SessionFailed    bool
@@ -84,6 +88,13 @@ func ResolveOperation(ctx context.Context, prov core.Provider, provName string, 
 	}
 
 	staticOp, staticOK := CatalogOperation(providerCatalog(prov), operation)
+	if staticOK {
+		if resolver, ok := prov.(requestStaticOperationResolver); ok {
+			if op, ok := resolver.ResolveStaticOperationForRequest(ctx, operation); ok {
+				return op, OperationTransport(op), "", nil
+			}
+		}
+	}
 	if !core.SupportsSessionCatalog(prov) {
 		if staticOK {
 			return staticOp, OperationTransport(staticOp), "", nil

--- a/gestaltd/internal/server/catalog_resolution_composite_test.go
+++ b/gestaltd/internal/server/catalog_resolution_composite_test.go
@@ -1,0 +1,93 @@
+package server
+
+import (
+	"context"
+	"fmt"
+	"net/http"
+	"testing"
+
+	mcpgo "github.com/mark3labs/mcp-go/mcp"
+	"github.com/valon-technologies/gestalt/server/core"
+	"github.com/valon-technologies/gestalt/server/core/catalog"
+	"github.com/valon-technologies/gestalt/server/internal/composite"
+	"github.com/valon-technologies/gestalt/server/internal/invocation"
+	"github.com/valon-technologies/gestalt/server/internal/principal"
+)
+
+type stubCompositeMCPUpstream struct {
+	stubProvider
+	cat                 *catalog.Catalog
+	catalogForRequestFn func(context.Context, string) (*catalog.Catalog, error)
+}
+
+func (s *stubCompositeMCPUpstream) Catalog() *catalog.Catalog {
+	return s.cat
+}
+
+func (s *stubCompositeMCPUpstream) CatalogForRequest(ctx context.Context, token string) (*catalog.Catalog, error) {
+	if s.catalogForRequestFn != nil {
+		return s.catalogForRequestFn(ctx, token)
+	}
+	return s.cat, nil
+}
+
+func (s *stubCompositeMCPUpstream) CallTool(context.Context, string, map[string]any) (*mcpgo.CallToolResult, error) {
+	return mcpgo.NewToolResultText("ok"), nil
+}
+
+func (s *stubCompositeMCPUpstream) Close() error { return nil }
+
+func TestResolveOperation_CompositeProviderPrefersStaticRESTWithoutSessionLookup(t *testing.T) {
+	t.Parallel()
+
+	apiProv := &stubCatalogProvider{
+		stubProvider: stubProvider{
+			name:     "notion",
+			connMode: core.ConnectionModeUser,
+		},
+		cat: &catalog.Catalog{
+			Name: "notion",
+			Operations: []catalog.CatalogOperation{
+				{ID: "api_get_self", Method: http.MethodGet, Transport: catalog.TransportREST},
+			},
+		},
+	}
+
+	var requestCatalogCalls int
+	mcpUpstream := &stubCompositeMCPUpstream{
+		stubProvider: stubProvider{
+			name:     "notion",
+			connMode: core.ConnectionModeUser,
+		},
+		catalogForRequestFn: func(context.Context, string) (*catalog.Catalog, error) {
+			requestCatalogCalls++
+			return nil, fmt.Errorf("mcpupstream notion: initialize: transport error: unauthorized (401)")
+		},
+	}
+
+	op, transport, connection, err := invocation.ResolveOperation(
+		context.Background(),
+		composite.New("notion", apiProv, mcpUpstream),
+		"notion",
+		&stubTokenResolver{err: fmt.Errorf("unexpected token resolution")},
+		&principal.Principal{UserID: "u1"},
+		"api_get_self",
+		[]string{"MCP"},
+		"",
+	)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if op.ID != "api_get_self" {
+		t.Fatalf("operation = %q, want %q", op.ID, "api_get_self")
+	}
+	if transport != catalog.TransportREST {
+		t.Fatalf("transport = %q, want %q", transport, catalog.TransportREST)
+	}
+	if connection != "" {
+		t.Fatalf("connection = %q, want empty", connection)
+	}
+	if requestCatalogCalls != 0 {
+		t.Fatalf("request catalog calls = %d, want 0", requestCatalogCalls)
+	}
+}

--- a/gestaltd/internal/server/composite_resolution_test.go
+++ b/gestaltd/internal/server/composite_resolution_test.go
@@ -1,0 +1,94 @@
+package server_test
+
+import (
+	"context"
+	"fmt"
+	"io"
+	"net/http"
+	"sync/atomic"
+	"testing"
+
+	"github.com/valon-technologies/gestalt/server/core"
+	"github.com/valon-technologies/gestalt/server/core/catalog"
+	coretesting "github.com/valon-technologies/gestalt/server/core/testing"
+	"github.com/valon-technologies/gestalt/server/internal/composite"
+	"github.com/valon-technologies/gestalt/server/internal/invocation"
+	"github.com/valon-technologies/gestalt/server/internal/server"
+	"github.com/valon-technologies/gestalt/server/internal/testutil"
+)
+
+func TestExecuteOperation_CompositeStaticRESTBypassesMCPSessionResolution(t *testing.T) {
+	t.Parallel()
+
+	var (
+		gotToken        string
+		mcpCatalogCalls atomic.Int32
+	)
+
+	apiProv := &stubIntegrationWithCatalog{
+		StubIntegration: coretesting.StubIntegration{
+			N:        "notion",
+			ConnMode: core.ConnectionModeUser,
+			ExecuteFn: func(_ context.Context, op string, _ map[string]any, token string) (*core.OperationResult, error) {
+				gotToken = token
+				return &core.OperationResult{Status: http.StatusOK, Body: fmt.Sprintf(`{"operation":%q,"token":%q}`, op, token)}, nil
+			},
+		},
+		catalog: serverTestCatalog("notion", []catalog.CatalogOperation{
+			{ID: "api_get_self", Description: "Retrieve self", Method: http.MethodGet, Transport: catalog.TransportREST},
+		}),
+	}
+	mcpUpstream := &stubIntegrationWithSessionCatalog{
+		stubIntegrationWithOps: stubIntegrationWithOps{
+			StubIntegration: coretesting.StubIntegration{
+				N:        "notion",
+				ConnMode: core.ConnectionModeUser,
+			},
+		},
+		catalogForRequestFn: func(_ context.Context, token string) (*catalog.Catalog, error) {
+			mcpCatalogCalls.Add(1)
+			return nil, fmt.Errorf("mcpupstream notion: initialize: transport error: unauthorized (401) for %q", token)
+		},
+	}
+
+	providers := testutil.NewProviderRegistry(t, composite.New("notion", apiProv, mcpUpstream))
+	svc := coretesting.NewStubServices(t)
+	u := seedUser(t, svc, "anonymous@gestalt")
+	seedToken(t, svc, &core.IntegrationToken{
+		ID: "tok-oauth", UserID: u.ID, Integration: "notion",
+		Connection: "OAuth", Instance: "default", AccessToken: "oauth-token",
+	})
+
+	broker := invocation.NewBroker(
+		providers,
+		svc.Users,
+		svc.Tokens,
+		invocation.WithConnectionMapper(invocation.ConnectionMap(map[string]string{"notion": "OAuth"})),
+		invocation.WithMCPConnectionMapper(invocation.ConnectionMap(map[string]string{"notion": "MCP"})),
+	)
+
+	ts := newTestServer(t, func(cfg *server.Config) {
+		cfg.Providers = providers
+		cfg.Services = svc
+		cfg.Invoker = broker
+	})
+	testutil.CloseOnCleanup(t, ts)
+
+	req, _ := http.NewRequest(http.MethodGet, ts.URL+"/api/v1/notion/api_get_self", nil)
+	resp, err := http.DefaultClient.Do(req)
+	if err != nil {
+		t.Fatalf("request: %v", err)
+	}
+	defer func() { _ = resp.Body.Close() }()
+
+	if resp.StatusCode != http.StatusOK {
+		body, _ := io.ReadAll(resp.Body)
+		t.Fatalf("expected 200, got %d: %s", resp.StatusCode, body)
+	}
+	if gotToken != "oauth-token" {
+		t.Fatalf("execute token = %q, want %q", gotToken, "oauth-token")
+	}
+	if got := mcpCatalogCalls.Load(); got != 0 {
+		t.Fatalf("mcp catalog calls = %d, want 0", got)
+	}
+}


### PR DESCRIPTION
## Summary
This fixes composite provider operation resolution for REST ops that are owned by the API side of the integration.

## Root Cause
`notion` is a composite provider: REST execution goes through the API provider, but request-scoped catalog resolution was still consulting the MCP session catalog first.
For static REST ops like `api_get_self` and `api_list_users`, that meant HTTP invoke could fail during MCP initialization before REST execution even began.
On `valon.tools`, that surfaced as `operation failed` with underlying Notion MCP `401` errors.

## What Changed
- added a request-time static operation resolver hook in invocation resolution
- taught composite providers to treat API-backed REST ops as authoritative for request execution
- added a resolver-level regression test proving composite REST ops do not resolve tokens or hit MCP session catalogs
- added an HTTP regression test proving Notion-style REST invoke succeeds without MCP session initialization

## Impact
REST operations on composite providers no longer depend on MCP session catalog availability when the operation is statically owned by the API provider.
This preserves the existing session-catalog behavior for MCP ops and for providers that genuinely need request-scoped REST metadata.

## Validation
- `go test ./internal/server ./internal/invocation ./internal/composite ./internal/mcp`

## Notes
This is the transport-correct fix rather than another HTTP-side fallback.