### PR TITLE
Config: remove source.auth compatibility

### DIFF
--- a/gestaltd/internal/config/config.go
+++ b/gestaltd/internal/config/config.go
@@ -119,6 +119,7 @@ func (s *ProviderSource) UnmarshalYAML(value *yaml.Node) error {
 	if value.Kind == yaml.MappingNode {
 		hasRef := false
 		hasVersion := false
+		hasAuth := false
 		for i := 0; i+1 < len(value.Content); i += 2 {
 			key := strings.TrimSpace(value.Content[i].Value)
 			switch key {
@@ -126,6 +127,8 @@ func (s *ProviderSource) UnmarshalYAML(value *yaml.Node) error {
 				hasRef = true
 			case "version":
 				hasVersion = true
+			case "auth":
+				hasAuth = true
 			}
 		}
 		if hasRef {
@@ -133,6 +136,9 @@ func (s *ProviderSource) UnmarshalYAML(value *yaml.Node) error {
 		}
 		if hasVersion {
 			return fmt.Errorf("source.version is no longer supported; use source: <provider-release.yaml URL>")
+		}
+		if hasAuth {
+			return fmt.Errorf("source.auth is no longer supported; use sibling auth alongside source")
 		}
 	}
 	type raw ProviderSource

--- a/gestaltd/internal/config/config_test.go
+++ b/gestaltd/internal/config/config_test.go
@@ -3145,6 +3145,19 @@ plugins:
 `,
 		},
 		{
+			name: "apiVersion rejects nested source auth compatibility shape",
+			yaml: `
+apiVersion: gestaltd.config/v3
+providers:
+plugins:
+    external:
+      source:
+        auth:
+          token: test-token
+`,
+			wantErr: "source.auth is no longer supported; use sibling auth alongside source",
+		},
+		{
 			name: "apiVersion local source rejects sibling auth",
 			yaml: `
 apiVersion: gestaltd.config/v3

--- a/gestaltd/internal/config/config_validate.go
+++ b/gestaltd/internal/config/config_validate.go
@@ -248,12 +248,13 @@ func validateProviderEntrySource(kind, name string, entry *ProviderEntry) error 
 		return nil
 	}
 	src := entry.Source
+	auth := src.Auth
+	if auth == nil {
+		auth = entry.InlineSourceAuth
+	}
 	if src.IsBuiltin() {
-		if entry.InlineSourceAuth != nil {
+		if auth != nil {
 			return fmt.Errorf("config validation: %s %q auth is only valid with metadata URL sources", kind, name)
-		}
-		if src.Auth != nil {
-			return fmt.Errorf("config validation: %s %q source.auth is only valid with metadata URL sources", kind, name)
 		}
 		return nil
 	}
@@ -281,22 +282,11 @@ func validateProviderEntrySource(kind, name string, entry *ProviderEntry) error 
 			return fmt.Errorf("config validation: %s %q source metadata URL must be an absolute http(s) provider-release.yaml URL", kind, name)
 		}
 	}
-	if entry.InlineSourceAuth != nil && src.Auth != nil {
-		return fmt.Errorf("config validation: %s %q auth and source.auth are mutually exclusive", kind, name)
-	}
-	if src.Auth != nil {
-		if !src.IsMetadataURL() {
-			return fmt.Errorf("config validation: %s %q source.auth is only valid with metadata URL sources", kind, name)
-		}
-		if strings.TrimSpace(src.Auth.Token) == "" {
-			return fmt.Errorf("config validation: %s %q source.auth.token is required when source.auth is set", kind, name)
-		}
-	}
-	if entry.InlineSourceAuth != nil {
+	if auth != nil {
 		if !src.IsMetadataURL() {
 			return fmt.Errorf("config validation: %s %q auth is only valid with metadata URL sources", kind, name)
 		}
-		if strings.TrimSpace(entry.InlineSourceAuth.Token) == "" {
+		if strings.TrimSpace(auth.Token) == "" {
 			return fmt.Errorf("config validation: %s %q auth.token is required when auth is set", kind, name)
 		}
 	}


### PR DESCRIPTION
## Summary
This removes handwritten `source.auth` compatibility from `gestaltd` config parsing.

The only supported public source-fetch auth shape is now sibling `auth` next to `source`.

## New Interface
Supported metadata URL source auth:

```yaml
apiVersion: gestaltd.config/v3
plugins:
  privateFoo:
    source: https://github.com/org/private-repo/releases/download/plugin/private-foo/v1.2.3/provider-release.yaml
    auth:
      token: ${GITHUB_TOKEN}
```

This continues to normalize into internal `Source.Auth` for runtime source fetching.

## Removed Compatibility Shape
This is now rejected:

```yaml
apiVersion: gestaltd.config/v3
plugins:
  privateFoo:
    source:
      auth:
        token: ${GITHUB_TOKEN}
```

with:

```text
source.auth is no longer supported; use sibling auth alongside source
```

## What Changed
- rejects `source.auth` during `ProviderSource` YAML unmarshal
- simplifies source validation to validate the single public `auth` shape
- keeps sibling `auth` normalization into internal `Source.Auth`
- adds regression coverage for rejecting handwritten `source.auth`

## Validation
```bash
go test ./internal/config ./internal/operator ./internal/bootstrap ./internal/server ./cmd/gestaltd -count=1
```