### PR TITLE
Operator: drop legacy GitHub asset URL compatibility

### DIFF
--- a/gestaltd/internal/operator/lifecycle.go
+++ b/gestaltd/internal/operator/lifecycle.go
@@ -1439,7 +1439,7 @@ func (l *Lifecycle) installMetadataSourcePackage(ctx context.Context, expectedKi
 	if !ok || archive.URL == "" {
 		return nil, LockEntry{}, fmt.Errorf("no archive for platform %s for %s; publish an explicit %s target or a generic package where allowed", currentPlatform, subject, currentPlatform)
 	}
-	download, err := downloadArchiveForSource(ctx, l.metadataHTTPClient(), sourceLocation, sourceAuthToken(plugin), archive.URL)
+	download, err := downloadArchiveForSource(ctx, l.metadataHTTPClient(), sourceAuthToken(plugin), archive.URL)
 	if err != nil {
 		return nil, LockEntry{}, fmt.Errorf("download metadata source package for %s: %w", subject, err)
 	}
@@ -2304,7 +2304,7 @@ func (l *Lifecycle) materializeLockedProvider(ctx context.Context, paths initPat
 		return fmt.Errorf("no verified hash for platform %s for provider %q; run `gestaltd init %s`", platform, name, formatPlatformInitFlags(paths, platform))
 	}
 
-	download, err := downloadArchiveForSource(ctx, l.metadataHTTPClient(), entry.Source, sourceAuthToken(plugin), archive.URL)
+	download, err := downloadArchiveForSource(ctx, l.metadataHTTPClient(), sourceAuthToken(plugin), archive.URL)
 	if err != nil {
 		return fmt.Errorf("download locked source provider for provider %q: %w", name, err)
 	}
@@ -2344,7 +2344,7 @@ func (l *Lifecycle) materializeLockedComponent(ctx context.Context, paths initPa
 		return fmt.Errorf("no verified hash for platform %s for %s %q; run `gestaltd init %s`", platform, kind, name, formatPlatformInitFlags(paths, platform))
 	}
 
-	download, err := downloadArchiveForSource(ctx, l.metadataHTTPClient(), entry.Source, sourceAuthToken(plugin), archive.URL)
+	download, err := downloadArchiveForSource(ctx, l.metadataHTTPClient(), sourceAuthToken(plugin), archive.URL)
 	if err != nil {
 		return fmt.Errorf("download locked source provider for %s %q: %w", kind, name, err)
 	}
@@ -2389,7 +2389,7 @@ func (l *Lifecycle) materializeLockedUIProvider(ctx context.Context, paths initP
 		return fmt.Errorf("no verified hash for platform %s for ui provider; run `gestaltd init %s`", platform, formatPlatformInitFlags(paths, platform))
 	}
 
-	download, err := downloadArchiveForSource(ctx, l.metadataHTTPClient(), entry.Source, sourceAuthToken(plugin), archive.URL)
+	download, err := downloadArchiveForSource(ctx, l.metadataHTTPClient(), sourceAuthToken(plugin), archive.URL)
 	if err != nil {
 		return fmt.Errorf("download locked source for ui provider: %w", err)
 	}
@@ -2462,7 +2462,7 @@ func (l *Lifecycle) hashArchiveEntry(ctx context.Context, kind, name string, ent
 		return err
 	}
 	token := tokenForSource[entry.Source]
-	dl, err := downloadArchiveForSource(ctx, l.metadataHTTPClient(), entry.Source, token, archive.URL)
+	dl, err := downloadArchiveForSource(ctx, l.metadataHTTPClient(), token, archive.URL)
 	if err != nil {
 		return fmt.Errorf("download archive for platform %s, source %s: %w", platformKey, entry.Source, err)
 	}

--- a/gestaltd/internal/operator/lifecycle_source_test.go
+++ b/gestaltd/internal/operator/lifecycle_source_test.go
@@ -306,8 +306,7 @@ func newGitHubRewriteClient(t *testing.T, target string) *http.Client {
 			base:   http.DefaultTransport,
 			target: targetURL,
 			hosts: map[string]struct{}{
-				"github.com":     {},
-				"api.github.com": {},
+				"github.com": {},
 			},
 		},
 	}
@@ -991,7 +990,7 @@ func TestSourcePluginInitRejectsMetadataSourceManifestMismatch(t *testing.T) {
 	}
 }
 
-func TestSourcePluginMetadataURLUsesGitHubAssetTransport(t *testing.T) {
+func TestSourcePluginMetadataURLUsesGitHubReleaseDownloadTransport(t *testing.T) {
 	t.Parallel()
 
 	dir := t.TempDir()
@@ -1020,8 +1019,8 @@ func TestSourcePluginMetadataURLUsesGitHubAssetTransport(t *testing.T) {
 	}
 
 	metadataPath := "/providers/alpha/provider-release.yaml"
-	githubArchiveURL := "https://api.github.com/repos/" + testOwner + "/" + testRepo + "/releases/assets/123"
-	githubArchivePath := "/repos/" + testOwner + "/" + testRepo + "/releases/assets/123"
+	githubArchivePath := "/" + testOwner + "/" + testRepo + "/releases/download/plugin/" + testPlugin + "/" + version + "/alpha-current.tar.gz"
+	githubArchiveURL := "https://github.com" + githubArchivePath
 	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		switch r.URL.Path {
 		case metadataPath:
@@ -1324,7 +1323,7 @@ func TestSourcePluginMetadataURLUnlockedLoadRefreshesMutableMetadata(t *testing.
 	}
 }
 
-func TestSourcePluginMetadataURLUsesGitHubTokenFallbackForMetadata(t *testing.T) {
+func TestSourcePluginMetadataURLUsesGitHubTokenFallbackForMetadataAndReleaseDownloads(t *testing.T) {
 	dir := t.TempDir()
 	t.Setenv("GITHUB_TOKEN", "env-fallback-token")
 
@@ -1353,8 +1352,8 @@ func TestSourcePluginMetadataURLUsesGitHubTokenFallbackForMetadata(t *testing.T)
 
 	metadataPath := "/" + testOwner + "/" + testRepo + "/releases/download/plugin/" + testPlugin + "/" + version + "/provider-release.yaml"
 	metadataURL := "https://github.com" + metadataPath
-	githubArchiveURL := "https://api.github.com/repos/" + testOwner + "/" + testRepo + "/releases/assets/456"
-	githubArchivePath := "/repos/" + testOwner + "/" + testRepo + "/releases/assets/456"
+	githubArchivePath := "/" + testOwner + "/" + testRepo + "/releases/download/plugin/" + testPlugin + "/" + version + "/alpha-current.tar.gz"
+	githubArchiveURL := "https://github.com" + githubArchivePath
 	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		switch r.URL.Path {
 		case metadataPath:

--- a/gestaltd/internal/operator/release_metadata.go
+++ b/gestaltd/internal/operator/release_metadata.go
@@ -216,31 +216,21 @@ func releaseRuntimeForManifest(manifest *providermanifestv1.Manifest, kind strin
 	return providerReleaseRuntimeExecutable
 }
 
-func usesGitHubAssetTransport(sourceLocation, archiveURL string) bool {
-	if src, err := pluginsource.Parse(sourceLocation); err == nil && src.Host == pluginsource.HostGitHub {
-		return true
-	}
+func usesGitHubReleaseDownloadTransport(archiveURL string) bool {
 	parsed, err := url.Parse(strings.TrimSpace(archiveURL))
 	if err != nil {
 		return false
 	}
-	switch strings.ToLower(parsed.Hostname()) {
-	case "api.github.com":
-		return strings.Contains(parsed.Path, "/releases/assets/")
-	case "github.com":
-		return strings.Contains(parsed.Path, "/releases/download/")
-	default:
-		return false
-	}
+	return strings.EqualFold(parsed.Hostname(), "github.com") && strings.Contains(parsed.Path, "/releases/download/")
 }
 
-func downloadArchiveForSource(ctx context.Context, client *http.Client, sourceLocation, token, archiveURL string) (*providerpkg.DownloadResult, error) {
+func downloadArchiveForSource(ctx context.Context, client *http.Client, token, archiveURL string) (*providerpkg.DownloadResult, error) {
 	if client == nil {
 		client = http.DefaultClient
 	}
 	token = strings.TrimSpace(token)
-	if usesGitHubAssetTransport(sourceLocation, archiveURL) {
-		return ghresolver.DownloadResolvedAsset(ctx, client, archiveURL, token)
+	if usesGitHubReleaseDownloadTransport(archiveURL) {
+		return ghresolver.DownloadGitHubReleaseArchive(ctx, client, archiveURL, token)
 	}
 	req, err := http.NewRequestWithContext(ctx, http.MethodGet, archiveURL, nil)
 	if err != nil {

--- a/gestaltd/internal/pluginsource/github/download.go
+++ b/gestaltd/internal/pluginsource/github/download.go
@@ -30,14 +30,14 @@ func ResolveGitHubToken(token string) string {
 	return ""
 }
 
-func DownloadResolvedAsset(ctx context.Context, client *http.Client, assetURL, token string) (*providerpkg.DownloadResult, error) {
+func DownloadGitHubReleaseArchive(ctx context.Context, client *http.Client, archiveURL, token string) (*providerpkg.DownloadResult, error) {
 	if client == nil {
 		client = http.DefaultClient
 	}
 	token = ResolveGitHubToken(token)
-	req, err := http.NewRequestWithContext(ctx, http.MethodGet, assetURL, nil)
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, archiveURL, nil)
 	if err != nil {
-		return nil, fmt.Errorf("create asset download request: %w", err)
+		return nil, fmt.Errorf("create GitHub release download request: %w", err)
 	}
 	req.Header.Set(headerAccept, acceptOctetStream)
 	if token != "" {


### PR DESCRIPTION
## Summary
This removes support for legacy GitHub API asset URLs (`api.github.com/.../releases/assets/...`) during provider archive rehydration.

The remaining GitHub-specific path is the current release-download flow used by `provider-release.yaml` metadata:
- metadata URL fetches from GitHub continue to use GitHub token header semantics
- archive downloads continue to support `https://github.com/.../releases/download/...`
- old API asset URLs are no longer treated as a supported runtime transport

## Current Supported Interface
Metadata-backed GitHub releases continue to work with release-download URLs:

```yaml
apiVersion: gestaltd.config/v3
plugins:
  example:
    source: https://github.com/org/repo/releases/download/plugin/example/v1.2.3/provider-release.yaml
    auth:
      token: ${GITHUB_TOKEN}
```

That metadata may point at archives like:

```text
https://github.com/org/repo/releases/download/plugin/example/v1.2.3/example_linux_amd64.tar.gz
```

## Removed Compatibility
The runtime no longer supports rehydrating old archive URLs like:

```text
https://api.github.com/repos/org/repo/releases/assets/123
```

## What Changed
- removes old `/releases/assets/` detection from archive download routing
- keeps GitHub-specific transport only for `github.com/.../releases/download/...` archives
- renames the helper to reflect current GitHub release-download behavior
- updates operator tests to cover release-download URLs instead of deprecated API asset URLs

## Validation
```bash
go test ./internal/operator ./internal/pluginsource/... -count=1
golangci-lint run ./internal/operator/... ./internal/pluginsource/...
```