### PR TITLE
operator: stabilize local source fingerprints

### DIFF
--- a/gestaltd/internal/operator/lifecycle.go
+++ b/gestaltd/internal/operator/lifecycle.go
@@ -647,6 +647,7 @@ type providerFingerprintInput struct {
 	Name   string `json:"name"`
 	Source string `json:"source,omitempty"`
 	Path   string `json:"path,omitempty"`
+	Digest string `json:"digest,omitempty"`
 }
 
 func sourceBacked(entry *config.ProviderEntry) bool {
@@ -1079,7 +1080,7 @@ func lockMatchesConfig(cfg *config.Config, paths initPaths, lock *Lockfile) bool
 		if !ok {
 			return false
 		}
-		fingerprint, err := NamedUIProviderFingerprint(name, &entry.ProviderEntry)
+		fingerprint, err := NamedUIProviderFingerprint(name, &entry.ProviderEntry, paths.configDir)
 		if err != nil || lockEntry.Fingerprint != fingerprint {
 			return false
 		}
@@ -1110,7 +1111,12 @@ func ProviderFingerprint(name string, entry *config.ProviderEntry, configDir str
 		Source: entry.SourceRemoteLocation(),
 	}
 	if entry.HasLocalSource() {
-		input.Path = entry.SourcePath()
+		input.Path = fingerprintLocalSourcePath(entry.SourcePath(), configDir)
+		digest, err := fingerprintLocalSourceDigest(entry.SourcePath())
+		if err != nil {
+			return "", err
+		}
+		input.Digest = digest
 	}
 
 	payload, err := json.Marshal(input)
@@ -1121,8 +1127,53 @@ func ProviderFingerprint(name string, entry *config.ProviderEntry, configDir str
 	return hex.EncodeToString(sum[:]), nil
 }
 
-func NamedUIProviderFingerprint(name string, entry *config.ProviderEntry) (string, error) {
-	return ProviderFingerprint("ui:"+name, entry, "")
+func NamedUIProviderFingerprint(name string, entry *config.ProviderEntry, configDir string) (string, error) {
+	return ProviderFingerprint("ui:"+name, entry, configDir)
+}
+
+func fingerprintLocalSourcePath(sourcePath, configDir string) string {
+	path := filepath.Clean(sourcePath)
+	if configDir == "" {
+		return filepath.ToSlash(path)
+	}
+
+	baseDir := filepath.Clean(configDir)
+	if !filepath.IsAbs(baseDir) {
+		if abs, err := filepath.Abs(baseDir); err == nil {
+			baseDir = abs
+		}
+	}
+	if !filepath.IsAbs(path) {
+		path = filepath.Join(baseDir, path)
+	}
+	if rel, err := filepath.Rel(baseDir, path); err == nil {
+		return filepath.ToSlash(filepath.Clean(rel))
+	}
+	return filepath.ToSlash(path)
+}
+
+func fingerprintLocalSourceDigest(sourcePath string) (string, error) {
+	manifestPath := sourcePath
+	sourceDir := sourcePath
+
+	info, err := os.Stat(sourcePath)
+	if err != nil {
+		return "", err
+	}
+	if info.IsDir() {
+		manifestPath, err = providerpkg.FindManifestFile(sourcePath)
+		if err != nil {
+			return "", err
+		}
+	} else {
+		sourceDir = filepath.Dir(sourcePath)
+	}
+
+	_, manifest, err := providerpkg.PrepareSourceManifest(manifestPath)
+	if err != nil {
+		return "", err
+	}
+	return providerpkg.DirectoryDigest(sourceDir, manifestPath, manifest)
 }
 
 func archivePolicyKind(kind string) string {
@@ -1392,7 +1443,7 @@ func localLockEntryFromPreparedInstall(paths initPaths, kind, name string, plugi
 }
 
 func localUILockEntryFromPreparedInstall(paths initPaths, name string, plugin *config.ProviderEntry, install *preparedInstall) (LockUIEntry, error) {
-	fingerprint, err := NamedUIProviderFingerprint(name, plugin)
+	fingerprint, err := NamedUIProviderFingerprint(name, plugin, paths.configDir)
 	if err != nil {
 		return LockUIEntry{}, fmt.Errorf("fingerprinting ui %q: %w", name, err)
 	}
@@ -1623,7 +1674,7 @@ func (l *Lifecycle) writeNamedUIProviderArtifact(ctx context.Context, paths init
 	if err != nil {
 		return LockUIEntry{}, fmt.Errorf("decode %s config: %w", subject, err)
 	}
-	fingerprint, err := NamedUIProviderFingerprint(name, plugin)
+	fingerprint, err := NamedUIProviderFingerprint(name, plugin, paths.configDir)
 	if err != nil {
 		return LockUIEntry{}, fmt.Errorf("fingerprinting %s: %w", subject, err)
 	}
@@ -2039,7 +2090,7 @@ func (l *Lifecycle) applyConfiguredUIProvider(paths initPaths, lockEntry *LockUI
 			}
 			return "", fmt.Errorf("prepared artifact for %s is missing or stale; run `gestaltd init %s`", subject, paths.configFlags)
 		}
-		fingerprint, err := NamedUIProviderFingerprint(logicalName, provider)
+		fingerprint, err := NamedUIProviderFingerprint(logicalName, provider, paths.configDir)
 		if err != nil || lockEntry.Fingerprint != fingerprint {
 			return "", fmt.Errorf("prepared artifact for %s is missing or stale; run `gestaltd init %s`", subject, paths.configFlags)
 		}

--- a/gestaltd/internal/operator/lifecycle_test.go
+++ b/gestaltd/internal/operator/lifecycle_test.go
@@ -3356,20 +3356,138 @@ func mustFingerprint(t *testing.T, name string, entry *config.ProviderEntry, con
 func TestProviderFingerprint_Stable(t *testing.T) {
 	t.Parallel()
 
-	plugin := &config.ProviderEntry{
-		Source: config.NewMetadataSource("https://example.invalid/github-com-test-org-test-repo-test-plugin/v1.0.0/provider-release.yaml"),
+	writeSourceManifest := func(t *testing.T, rootDir, manifestRel, kind string) string {
+		t.Helper()
+
+		manifestPath := filepath.Join(rootDir, filepath.FromSlash(manifestRel))
+		if err := os.MkdirAll(filepath.Dir(manifestPath), 0o755); err != nil {
+			t.Fatalf("MkdirAll(%q): %v", filepath.Dir(manifestPath), err)
+		}
+		manifest := fmt.Sprintf("source: github.com/test-org/fingerprint-test/component\nversion: 0.0.1\nkind: %s\n", kind)
+		if kind == providermanifestv1.KindWebUI {
+			assetRoot := filepath.Join(filepath.Dir(manifestPath), "assets")
+			if err := os.MkdirAll(assetRoot, 0o755); err != nil {
+				t.Fatalf("MkdirAll(%q): %v", assetRoot, err)
+			}
+			if err := os.WriteFile(filepath.Join(assetRoot, "index.html"), []byte("<html></html>"), 0o644); err != nil {
+				t.Fatalf("WriteFile(asset): %v", err)
+			}
+			manifest += "spec:\n  assetRoot: assets\n"
+		}
+		if err := os.WriteFile(manifestPath, []byte(manifest), 0o644); err != nil {
+			t.Fatalf("WriteFile(%q): %v", manifestPath, err)
+		}
+		return manifestPath
 	}
-	first, err := ProviderFingerprint("example", plugin, ".")
-	if err != nil {
-		t.Fatalf("ProviderFingerprint: %v", err)
-	}
-	second, err := ProviderFingerprint("example", plugin, ".")
-	if err != nil {
-		t.Fatalf("ProviderFingerprint: %v", err)
-	}
-	if first != second {
-		t.Fatalf("fingerprint not stable: %q != %q", first, second)
-	}
+
+	t.Run("metadata source", func(t *testing.T) {
+		t.Parallel()
+
+		plugin := &config.ProviderEntry{
+			Source: config.NewMetadataSource("https://example.invalid/github-com-test-org-test-repo-test-plugin/v1.0.0/provider-release.yaml"),
+		}
+		first, err := ProviderFingerprint("example", plugin, ".")
+		if err != nil {
+			t.Fatalf("ProviderFingerprint: %v", err)
+		}
+		second, err := ProviderFingerprint("example", plugin, ".")
+		if err != nil {
+			t.Fatalf("ProviderFingerprint: %v", err)
+		}
+		if first != second {
+			t.Fatalf("fingerprint not stable: %q != %q", first, second)
+		}
+	})
+
+	t.Run("local source path is stable across copied config trees", func(t *testing.T) {
+		t.Parallel()
+
+		root := t.TempDir()
+		firstConfigDir := filepath.Join(root, "one", "deploy")
+		secondConfigDir := filepath.Join(root, "two", "deploy")
+		firstManifestPath := writeSourceManifest(t, filepath.Join(root, "one"), "plugins/sample/manifest.yaml", providermanifestv1.KindAuthorization)
+		secondManifestPath := writeSourceManifest(t, filepath.Join(root, "two"), "plugins/sample/manifest.yaml", providermanifestv1.KindAuthorization)
+
+		firstProvider := &config.ProviderEntry{
+			Source: config.ProviderSource{Path: firstManifestPath},
+		}
+		secondProvider := &config.ProviderEntry{
+			Source: config.ProviderSource{Path: secondManifestPath},
+		}
+
+		first, err := ProviderFingerprint("example", firstProvider, firstConfigDir)
+		if err != nil {
+			t.Fatalf("ProviderFingerprint(first): %v", err)
+		}
+		second, err := ProviderFingerprint("example", secondProvider, secondConfigDir)
+		if err != nil {
+			t.Fatalf("ProviderFingerprint(second): %v", err)
+		}
+		if first != second {
+			t.Fatalf("local source fingerprint drifted across copied config trees: %q != %q", first, second)
+		}
+	})
+
+	t.Run("named ui local source path is stable across copied config trees", func(t *testing.T) {
+		t.Parallel()
+
+		root := t.TempDir()
+		firstConfigDir := filepath.Join(root, "one", "deploy")
+		secondConfigDir := filepath.Join(root, "two", "deploy")
+		firstManifestPath := writeSourceManifest(t, filepath.Join(root, "one"), "web/dashboard/manifest.yaml", providermanifestv1.KindWebUI)
+		secondManifestPath := writeSourceManifest(t, filepath.Join(root, "two"), "web/dashboard/manifest.yaml", providermanifestv1.KindWebUI)
+
+		firstProvider := &config.ProviderEntry{
+			Source: config.ProviderSource{Path: firstManifestPath},
+		}
+		secondProvider := &config.ProviderEntry{
+			Source: config.ProviderSource{Path: secondManifestPath},
+		}
+
+		first, err := NamedUIProviderFingerprint("dashboard", firstProvider, firstConfigDir)
+		if err != nil {
+			t.Fatalf("NamedUIProviderFingerprint(first): %v", err)
+		}
+		second, err := NamedUIProviderFingerprint("dashboard", secondProvider, secondConfigDir)
+		if err != nil {
+			t.Fatalf("NamedUIProviderFingerprint(second): %v", err)
+		}
+		if first != second {
+			t.Fatalf("named ui fingerprint drifted across copied config trees: %q != %q", first, second)
+		}
+	})
+
+	t.Run("local source content changes still change the fingerprint", func(t *testing.T) {
+		t.Parallel()
+
+		root := t.TempDir()
+		firstConfigDir := filepath.Join(root, "one", "deploy")
+		secondConfigDir := filepath.Join(root, "two", "deploy")
+		firstManifestPath := writeSourceManifest(t, filepath.Join(root, "one"), "plugins/sample/manifest.yaml", providermanifestv1.KindAuthorization)
+		secondManifestPath := writeSourceManifest(t, filepath.Join(root, "two"), "plugins/sample/manifest.yaml", providermanifestv1.KindAuthorization)
+		if err := os.WriteFile(secondManifestPath, []byte("source: github.com/test-org/two/component\nversion: 0.0.2\nkind: authorization\n"), 0o644); err != nil {
+			t.Fatalf("WriteFile(%q): %v", secondManifestPath, err)
+		}
+
+		firstProvider := &config.ProviderEntry{
+			Source: config.ProviderSource{Path: firstManifestPath},
+		}
+		secondProvider := &config.ProviderEntry{
+			Source: config.ProviderSource{Path: secondManifestPath},
+		}
+
+		first, err := ProviderFingerprint("example", firstProvider, firstConfigDir)
+		if err != nil {
+			t.Fatalf("ProviderFingerprint(first): %v", err)
+		}
+		second, err := ProviderFingerprint("example", secondProvider, secondConfigDir)
+		if err != nil {
+			t.Fatalf("ProviderFingerprint(second): %v", err)
+		}
+		if first == second {
+			t.Fatalf("local source fingerprint should change when manifest content changes: %q", first)
+		}
+	})
 }
 
 func TestProviderFingerprint_ChangesWithName(t *testing.T) {

--- a/gestaltd/internal/providerpkg/digest.go
+++ b/gestaltd/internal/providerpkg/digest.go
@@ -23,16 +23,19 @@ func FileSHA256(path string) (string, error) {
 	return fileSHA256(path)
 }
 
-func DirectoryDigest(dirPath string, manifest *providermanifestv1.Manifest) (string, error) {
+func DirectoryDigest(dirPath, manifestPath string, manifest *providermanifestv1.Manifest) (string, error) {
 	if manifest == nil {
 		return "", fmt.Errorf("manifest is required")
 	}
 
 	var digests []string
 
-	manifestPath, err := FindManifestFile(dirPath)
-	if err != nil {
-		return "", fmt.Errorf("digest manifest: %w", err)
+	if manifestPath == "" {
+		var err error
+		manifestPath, err = FindManifestFile(dirPath)
+		if err != nil {
+			return "", fmt.Errorf("digest manifest: %w", err)
+		}
 	}
 	manifestSum, err := FileSHA256(manifestPath)
 	if err != nil {


### PR DESCRIPTION
## Summary
This fixes stale lockfile churn for local `source.path` providers by making source-provider fingerprints relative to the config root instead of the resolved absolute temp directory.

That matters directly for the new authorization dogfood path in `valon-tools`, where `refresh-lockfile.sh` copies the deploy tree into a temp dir before running `gestaltd init`. Before this fix, the copied absolute paths changed every local plugin, web UI, and `providers.authorization` fingerprint on every run.

## Go Interface
```go
func ProviderFingerprint(name string, entry *config.ProviderEntry, configDir string) (string, error)
func NamedUIProviderFingerprint(name string, entry *config.ProviderEntry, configDir string) (string, error)
```

`configDir` now matters for local `source.path` entries: fingerprints normalize those paths relative to the config root, so copied config trees keep the same `inputDigest` values.

## YAML Interface
```yaml
server:
  providers:
    authorization: indexeddb

providers:
  authorization:
    indexeddb:
      source:
        path: ../providers-src/authorization/indexeddb/manifest.yaml
      config:
        indexeddb: main-db
```

The same stability fix also applies to other local source-backed config entries like:

```yaml
plugins:
  deploymentViewer:
    source:
      path: ../../deployment-viewer/plugin/manifest.yaml

providers:
  ui:
    deploymentViewer:
      source:
        path: ../../deployment-viewer/ui/manifest.yaml
      path: /deployments
```

## Examples
```sh
GESTALTD_BIN=/path/to/gestaltd \
  valon-tools/deploy/refresh-lockfile.sh write

GESTALTD_BIN=/path/to/gestaltd \
  valon-tools/deploy/refresh-lockfile.sh check
```

With this patch, a lockfile written from one copied deploy tree stays fresh when `check` reruns from another copied deploy tree.

## Testing
- `cd gestaltd && go test ./internal/operator -run 'TestProviderFingerprint_Stable|TestProviderFingerprint_ChangesWithName'`
- `cd gestaltd && go test ./internal/operator`
- Built `gestaltd` from this branch and verified:
  - `GESTALTD_BIN=/tmp/gestaltd-lock-fingerprint valon-tools/deploy/refresh-lockfile.sh write`
  - `GESTALTD_BIN=/tmp/gestaltd-lock-fingerprint valon-tools/deploy/refresh-lockfile.sh check`
