### PR TITLE
[codex] Validate effective plugin catalogs before runtime

### DIFF
--- a/gestaltd/cmd/gestaltd/e2e_test.go
+++ b/gestaltd/cmd/gestaltd/e2e_test.go
@@ -507,6 +507,72 @@ plugins:
 	}
 }
 
+func TestE2EValidateRejectsHybridExecutableDuplicateEffectiveOperation(t *testing.T) {
+	t.Parallel()
+
+	dir := t.TempDir()
+	pluginDir := setupPluginDir(t, filepath.Join(dir, "target"))
+	manifestPath := componentProviderManifestPath(t, pluginDir)
+	_, manifest, err := providerpkg.ReadSourceManifestFile(manifestPath)
+	if err != nil {
+		t.Fatalf("read source manifest: %v", err)
+	}
+	if manifest.Spec == nil {
+		manifest.Spec = &providermanifestv1.Spec{}
+	}
+	manifest.Spec.Surfaces = &providermanifestv1.ProviderSurfaces{
+		OpenAPI: &providermanifestv1.OpenAPISurface{Document: "openapi.yaml"},
+	}
+	manifest.Spec.AllowedOperations = map[string]*providermanifestv1.ManifestOperationOverride{
+		"external_echo": {Alias: "echo"},
+	}
+	writeManifestFile(t, pluginDir, manifest)
+	if err := os.WriteFile(filepath.Join(pluginDir, "openapi.yaml"), []byte(`openapi: "3.1.0"
+info:
+  title: Hybrid Duplicate
+  version: "1.0.0"
+paths:
+  /external-echo:
+    get:
+      operationId: external_echo
+      responses:
+        "200":
+          description: OK
+`), 0o644); err != nil {
+		t.Fatalf("write OpenAPI document: %v", err)
+	}
+
+	indexedDBManifest := componentProviderManifestPath(t, setupIndexedDBProviderDir(t, dir))
+	cfgPath := filepath.Join(dir, "config.yaml")
+	cfg := fmt.Sprintf(`server:
+  encryptionKey: test-key
+  providers:
+    indexeddb: sqlite
+providers:
+  indexeddb:
+    sqlite:
+      source:
+        path: %s
+      config:
+        path: %q
+plugins:
+  target:
+    source:
+      path: %s
+`, indexedDBManifest, filepath.Join(dir, "gestalt.db"), manifestPath)
+	if err := os.WriteFile(cfgPath, []byte(cfg), 0o644); err != nil {
+		t.Fatalf("WriteFile config: %v", err)
+	}
+
+	out, err := exec.Command(gestaltdBin, "validate", "--config", cfgPath).CombinedOutput()
+	if err == nil {
+		t.Fatalf("expected validate to fail, got success:\n%s", out)
+	}
+	if !strings.Contains(string(out), `duplicate operation \"echo\" across static and API catalogs`) {
+		t.Fatalf("expected validate output to mention duplicate effective operation, got: %s", out)
+	}
+}
+
 func setupPluginDir(t *testing.T, baseDir string) string {
 	t.Helper()
 	return setupPluginDirWithVersion(t, baseDir, "0.0.1-alpha.1")

--- a/gestaltd/cmd/gestaltd/plugin.go
+++ b/gestaltd/cmd/gestaltd/plugin.go
@@ -1,6 +1,7 @@
 package main
 
 import (
+	"context"
 	"flag"
 	"fmt"
 	"io"
@@ -10,6 +11,8 @@ import (
 	"runtime"
 	"strings"
 
+	"github.com/valon-technologies/gestalt/server/internal/config"
+	"github.com/valon-technologies/gestalt/server/internal/plugininvocation"
 	"github.com/valon-technologies/gestalt/server/internal/pluginsource"
 	"github.com/valon-technologies/gestalt/server/internal/providerpkg"
 	providermanifestv1 "github.com/valon-technologies/gestalt/server/sdk/providermanifest/v1"
@@ -127,6 +130,12 @@ func runProviderRelease(args []string) error {
 		return fmt.Errorf("invalid source in manifest: %w", err)
 	}
 	pluginName := src.PluginName()
+	if err := plugininvocation.ValidateEffectiveCatalog(context.Background(), pluginName, &config.ProviderEntry{
+		ResolvedManifestPath: manifestPath,
+		ResolvedManifest:     releaseManifest,
+	}); err != nil {
+		return err
+	}
 
 	if err := os.MkdirAll(*outputDir, 0755); err != nil {
 		return fmt.Errorf("create output dir: %w", err)
@@ -258,26 +267,29 @@ func expandReleasePlatformValue(value string) (string, error) {
 
 func buildPlatformArchive(manifestPath, pluginName, version, buildKind string, platform releasePlatform, outputDir string) (string, error) {
 	archiveName := platformArchiveName(pluginName, version, platform)
-	return createReleaseArchive(outputDir, archiveName, func(stagingDir string) error {
-		_, err := providerpkg.StagePreparedInstallDir(manifestPath, stagingDir, providerpkg.StagePreparedInstallOptions{
+	return createReleaseArchive(outputDir, archiveName, func(stagingDir string) (*providerpkg.StagedPreparedInstall, error) {
+		return providerpkg.StagePreparedInstallDir(manifestPath, stagingDir, providerpkg.StagePreparedInstallOptions{
 			VersionOverride: version,
 			BuildKind:       buildKind,
 			PluginName:      pluginName,
 			GOOS:            platform.GOOS,
 			GOARCH:          platform.GOARCH,
 		})
-		return err
 	})
 }
 
-func createReleaseArchive(outputDir, archiveName string, prepare func(stagingDir string) error) (string, error) {
+func createReleaseArchive(outputDir, archiveName string, prepare func(stagingDir string) (*providerpkg.StagedPreparedInstall, error)) (string, error) {
 	stagingDir, err := os.MkdirTemp("", "gestalt-release-*")
 	if err != nil {
 		return "", err
 	}
 	defer func() { _ = os.RemoveAll(stagingDir) }()
 
-	if err := prepare(stagingDir); err != nil {
+	staged, err := prepare(stagingDir)
+	if err != nil {
+		return "", err
+	}
+	if err := validateStagedReleaseCatalog(staged); err != nil {
 		return "", err
 	}
 	archivePath := filepath.Join(outputDir, archiveName)
@@ -312,11 +324,24 @@ func currentReleasePlatform() string {
 
 func buildSourceArchive(manifestPath, pluginName, version, outputDir string) (string, error) {
 	archiveName := fmt.Sprintf("gestalt-plugin-%s_v%s.tar.gz", pluginName, version)
-	return createReleaseArchive(outputDir, archiveName, func(stagingDir string) error {
-		_, err := providerpkg.StagePreparedInstallDir(manifestPath, stagingDir, providerpkg.StagePreparedInstallOptions{
+	return createReleaseArchive(outputDir, archiveName, func(stagingDir string) (*providerpkg.StagedPreparedInstall, error) {
+		return providerpkg.StagePreparedInstallDir(manifestPath, stagingDir, providerpkg.StagePreparedInstallOptions{
 			VersionOverride: version,
 		})
-		return err
+	})
+}
+
+func validateStagedReleaseCatalog(staged *providerpkg.StagedPreparedInstall) error {
+	if staged == nil || staged.Manifest == nil || staged.Manifest.Kind != providermanifestv1.KindPlugin {
+		return nil
+	}
+	src, err := pluginsource.Parse(staged.Manifest.Source)
+	if err != nil {
+		return fmt.Errorf("invalid source in staged manifest: %w", err)
+	}
+	return plugininvocation.ValidateEffectiveCatalog(context.Background(), src.PluginName(), &config.ProviderEntry{
+		ResolvedManifestPath: staged.ManifestPath,
+		ResolvedManifest:     staged.Manifest,
 	})
 }
 

--- a/gestaltd/cmd/gestaltd/plugin_test.go
+++ b/gestaltd/cmd/gestaltd/plugin_test.go
@@ -1726,6 +1726,55 @@ func TestRun_PluginReleaseRejectsOutputInsideWebUIAssetRoot(t *testing.T) {
 	}
 }
 
+func TestRun_PluginReleaseRejectsHybridExecutableDuplicateEffectiveOperation(t *testing.T) {
+	t.Parallel()
+
+	pluginDir := newSourceProviderReleaseFixture(t, t.TempDir())
+	manifestPath := filepath.Join(pluginDir, providerpkg.ManifestFile)
+	_, manifest, err := providerpkg.ReadSourceManifestFile(manifestPath)
+	if err != nil {
+		t.Fatalf("ReadSourceManifestFile(%s): %v", providerpkg.ManifestFile, err)
+	}
+	if manifest.Spec == nil {
+		manifest.Spec = &providermanifestv1.Spec{}
+	}
+	manifest.Spec.Surfaces = &providermanifestv1.ProviderSurfaces{
+		OpenAPI: &providermanifestv1.OpenAPISurface{Document: "openapi.yaml"},
+	}
+	manifest.Spec.AllowedOperations = map[string]*providermanifestv1.ManifestOperationOverride{
+		"external_op": {Alias: "generated_op"},
+	}
+	manifestData, err := providerpkg.EncodeSourceManifestFormat(manifest, providerpkg.ManifestFormatFromPath(manifestPath))
+	if err != nil {
+		t.Fatalf("EncodeSourceManifestFormat: %v", err)
+	}
+	if err := os.WriteFile(manifestPath, manifestData, 0o644); err != nil {
+		t.Fatalf("WriteFile manifest: %v", err)
+	}
+	if err := os.WriteFile(filepath.Join(pluginDir, "openapi.yaml"), []byte(`openapi: "3.1.0"
+info:
+  title: Hybrid Duplicate
+  version: "1.0.0"
+paths:
+  /external-op:
+    get:
+      operationId: external_op
+      responses:
+        "200":
+          description: OK
+`), 0o644); err != nil {
+		t.Fatalf("WriteFile openapi.yaml: %v", err)
+	}
+
+	out, err := runPluginReleaseCommandResult(pluginDir, "--version", "0.0.4-source.1", "--platform", runtime.GOOS+"/"+runtime.GOARCH, "--output", t.TempDir())
+	if err == nil {
+		t.Fatalf("expected provider release to fail, got output: %s", out)
+	}
+	if !strings.Contains(string(out), `duplicate operation \"generated_op\" across static and API catalogs`) {
+		t.Fatalf("expected duplicate effective operation error, got: %s", out)
+	}
+}
+
 func TestRun_PluginReleaseCompilesProviderWithoutSourceArtifacts(t *testing.T) {
 	t.Parallel()
 

--- a/gestaltd/internal/bootstrap/validate.go
+++ b/gestaltd/internal/bootstrap/validate.go
@@ -22,6 +22,9 @@ import (
 // starting the server or running migrations. Unlike Bootstrap, provider
 // validation is strict: any provider construction failure is returned.
 func Validate(ctx context.Context, cfg *config.Config, factories *FactoryRegistry) ([]string, error) {
+	if err := plugininvocation.ValidateEffectiveCatalogs(ctx, cfg); err != nil {
+		return nil, err
+	}
 	if err := plugininvocation.ValidateDependencies(ctx, cfg); err != nil {
 		return nil, err
 	}

--- a/gestaltd/internal/operator/lifecycle.go
+++ b/gestaltd/internal/operator/lifecycle.go
@@ -172,6 +172,9 @@ func (l *Lifecycle) initAtPaths(configPaths []string, state StatePaths) (*Lockfi
 	if err := config.ValidateResolvedStructure(cfg); err != nil {
 		return nil, nil, initPaths{}, err
 	}
+	if err := plugininvocation.ValidateEffectiveCatalogs(context.Background(), cfg); err != nil {
+		return nil, nil, initPaths{}, err
+	}
 	if err := plugininvocation.ValidateDependencies(context.Background(), cfg); err != nil {
 		return nil, nil, initPaths{}, err
 	}

--- a/gestaltd/internal/operator/lifecycle_test.go
+++ b/gestaltd/internal/operator/lifecycle_test.go
@@ -836,6 +836,33 @@ server:
 	}
 }
 
+func TestInitAtPath_RejectsHybridExecutableDuplicateEffectiveOperation(t *testing.T) {
+	t.Parallel()
+
+	dir := t.TempDir()
+	targetManifestPath := writeLocalExecutableOpenAPIPlugin(t, dir, "target", []string{"ping"}, []string{"status"})
+
+	cfgPath := filepath.Join(dir, "config.yaml")
+	cfg := requiredComponentConfigYAML(t, dir, filepath.Join(dir, "gestalt.db")) + fmt.Sprintf(`plugins:
+    target:
+      source:
+        path: %q
+      allowedOperations:
+        status:
+          alias: ping
+server:
+`, targetManifestPath) + requiredServerDatastoreYAML() + `  encryptionKey: aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa
+`
+	if err := os.WriteFile(cfgPath, []byte(cfg), 0o644); err != nil {
+		t.Fatalf("WriteFile config: %v", err)
+	}
+
+	_, err := NewLifecycle().InitAtPath(cfgPath)
+	if err == nil || !strings.Contains(err.Error(), `duplicate operation "ping" across static and API catalogs`) {
+		t.Fatalf("InitAtPath error = %v, want duplicate operation error", err)
+	}
+}
+
 func TestInitAtPath_AllowsManagedPluginInvokesOnFirstInit(t *testing.T) {
 	t.Parallel()
 

--- a/gestaltd/internal/plugininvocation/validation.go
+++ b/gestaltd/internal/plugininvocation/validation.go
@@ -3,7 +3,9 @@ package plugininvocation
 import (
 	"context"
 	"fmt"
+	"maps"
 	"path/filepath"
+	"slices"
 
 	"github.com/valon-technologies/gestalt/server/core/catalog"
 	"github.com/valon-technologies/gestalt/server/internal/config"
@@ -20,6 +22,30 @@ type resolvedDependencyCatalog struct {
 	catalog     *catalog.Catalog
 	sessionOnly bool
 	err         error
+}
+
+func ValidateEffectiveCatalog(ctx context.Context, name string, entry *config.ProviderEntry) error {
+	if entry == nil {
+		return nil
+	}
+	_, _, err := resolveStaticCatalog(ctx, name, entry)
+	return err
+}
+
+func ValidateEffectiveCatalogs(ctx context.Context, cfg *config.Config) error {
+	if cfg == nil {
+		return nil
+	}
+	for _, name := range slices.Sorted(maps.Keys(cfg.Plugins)) {
+		entry := cfg.Plugins[name]
+		if entry == nil {
+			continue
+		}
+		if err := ValidateEffectiveCatalog(ctx, name, entry); err != nil {
+			return fmt.Errorf("config validation: plugins.%s: %w", name, err)
+		}
+	}
+	return nil
 }
 
 func ValidateDependencies(ctx context.Context, cfg *config.Config) error {


### PR DESCRIPTION
## What changed
- added `plugininvocation.ValidateEffectiveCatalog` and `ValidateEffectiveCatalogs` to resolve each plugin's effective catalog outside the `invokes` path
- wired that validation into `gestaltd init` and `gestaltd validate`
- wired `gestaltd provider release` to validate both the source manifest and the staged package catalog before archiving
- added regressions for the `init`, `validate`, and `provider release` paths covering duplicate effective operations created by hybrid static/API aliasing

## Why
The Gmail regression was only rejected during runtime provider composition. `ValidateDependencies` already resolved merged catalogs, but only for plugins referenced through `plugins.*.invokes`, so a plugin with no incoming invokes could ship a duplicate effective operation and only fail at bootstrap.

`provider release` also missed this because release packaging can generate the final static catalog during staging, after the source-tree manifest has already been validated. This change validates the staged package catalog as well, so release checks the same effective surface that runtime will load.

## Validation
- `go test ./internal/operator -run 'TestInitAtPath_(AllowsInvokesAgainstEffectiveAlias|RejectsHybridExecutableStaticOperationByOriginalNameAfterAlias|RejectsHybridExecutableDuplicateEffectiveOperation)$'`
- `go test ./cmd/gestaltd -run 'Test(Run_PluginReleaseRejectsHybridExecutableDuplicateEffectiveOperation|E2EValidateRejectsHybridExecutableDuplicateEffectiveOperation|E2EValidateRejectsInvalidPluginInvokesDependency)$'`