### PR TITLE
[codex] Fix reconnect-required server test expectations

### DIFF
--- a/gestaltd/internal/server/metrics_test.go
+++ b/gestaltd/internal/server/metrics_test.go
@@ -267,8 +267,8 @@ func TestRefreshAndOperationResultMetrics(t *testing.T) {
 		t.Fatalf("refresh error request: %v", err)
 	}
 	defer func() { _ = errorResp.Body.Close() }()
-	if errorResp.StatusCode != http.StatusBadGateway {
-		t.Fatalf("refresh error status = %d, want %d", errorResp.StatusCode, http.StatusBadGateway)
+	if errorResp.StatusCode != http.StatusPreconditionFailed {
+		t.Fatalf("refresh error status = %d, want %d", errorResp.StatusCode, http.StatusPreconditionFailed)
 	}
 
 	rm := metrictest.CollectMetrics(t, metrics.Reader)

--- a/gestaltd/internal/server/server_test.go
+++ b/gestaltd/internal/server/server_test.go
@@ -11499,9 +11499,9 @@ func TestExecuteOperation_RefreshFailureEdgeCases(t *testing.T) {
 		wantUsedToken string
 	}{
 		{
-			name:          "expired token returns bad gateway",
+			name:          "expired token requires reconnect",
 			expiresAt:     time.Now().Add(-1 * time.Hour),
-			wantStatus:    http.StatusBadGateway,
+			wantStatus:    http.StatusPreconditionFailed,
 			wantUsedToken: "",
 		},
 		{


### PR DESCRIPTION
## What changed
- updated `internal/server/metrics_test.go` to expect `412 Precondition Failed` when an expired OAuth token cannot be refreshed
- updated `internal/server/server_test.go` to expect the same reconnect-required status and renamed the stale test case accordingly

## Why
`Server.writeInvocationError` already maps `invocation.ErrReconnectRequired` to `412`, but these tests were still expecting the older `502` behavior. That mismatch is what is currently failing `Build Gestaltd` on `main`, and it is unrelated to PR #1138.

## Validation
- `go test ./internal/server -run 'Test(RefreshAndOperationResultMetrics|ExecuteOperation_RefreshFailureEdgeCases)$'`
- `go test ./internal/server`
- `go test -cover ./internal/server`