### PR TITLE
[codex] improve reconnect guidance for invoke

### DIFF
--- a/gestalt/cli/src/api.rs
+++ b/gestalt/cli/src/api.rs
@@ -5,6 +5,7 @@ use reqwest::blocking::Client;
 use reqwest::header::{self, HeaderValue};
 use serde::{Deserialize, Serialize};
 use std::collections::BTreeMap;
+use std::fmt;
 use std::path::{Path, PathBuf};
 
 use crate::config::ConfigStore;
@@ -202,6 +203,43 @@ pub struct ApiClient {
     token: String,
     token_source: TokenSource,
 }
+
+#[derive(Debug, Clone)]
+pub struct ApiError {
+    message: String,
+    code: Option<String>,
+    integration: Option<String>,
+}
+
+impl ApiError {
+    fn new(message: String, code: Option<String>, integration: Option<String>) -> Self {
+        Self {
+            message,
+            code,
+            integration,
+        }
+    }
+
+    pub fn message(&self) -> &str {
+        &self.message
+    }
+
+    pub fn code(&self) -> Option<&str> {
+        self.code.as_deref()
+    }
+
+    pub fn integration(&self) -> Option<&str> {
+        self.integration.as_deref()
+    }
+}
+
+impl fmt::Display for ApiError {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        write!(f, "{}", self.message)
+    }
+}
+
+impl std::error::Error for ApiError {}
 
 impl ApiClient {
     pub fn from_env(url_override: Option<&str>) -> Result<Self> {
@@ -412,9 +450,12 @@ impl ApiClient {
 
     fn bail_on_error_response(&self, status: StatusCode, body: &str) -> Result<()> {
         if status.is_client_error() || status.is_server_error() {
-            let message = serde_json::from_str::<serde_json::Value>(body)
+            let api_error = serde_json::from_str::<serde_json::Value>(body)
                 .ok()
-                .and_then(|v| extract_error_message(&v))
+                .and_then(|v| extract_api_error(&v));
+            let message = api_error
+                .as_ref()
+                .map(|err| err.message().to_string())
                 .unwrap_or_else(|| format!("HTTP {}: {}", status.as_u16(), body));
 
             if status == StatusCode::UNAUTHORIZED && self.token_source == TokenSource::EnvVar {
@@ -434,29 +475,60 @@ impl ApiClient {
                 );
             }
 
+            if let Some(api_error) = api_error {
+                return Err(api_error.into());
+            }
+
             bail!("{}", message);
         }
         Ok(())
     }
 }
 
-fn extract_error_message(value: &serde_json::Value) -> Option<String> {
+fn extract_api_error(value: &serde_json::Value) -> Option<ApiError> {
     match value {
         serde_json::Value::Object(obj) => {
-            if let Some(message) = obj.get("error").and_then(|err| match err {
-                serde_json::Value::String(message) => Some(message.clone()),
+            let root_code = obj
+                .get("code")
+                .and_then(|code| code.as_str())
+                .map(String::from);
+            let root_integration = obj
+                .get("integration")
+                .and_then(|integration| integration.as_str())
+                .map(String::from);
+
+            if let Some(api_error) = obj.get("error").and_then(|err| match err {
+                serde_json::Value::String(message) => Some(ApiError::new(
+                    message.clone(),
+                    root_code.clone(),
+                    root_integration.clone(),
+                )),
                 serde_json::Value::Object(err_obj) => err_obj
                     .get("message")
                     .and_then(|message| message.as_str())
-                    .map(String::from),
+                    .map(|message| {
+                        ApiError::new(
+                            message.to_string(),
+                            err_obj
+                                .get("code")
+                                .and_then(|code| code.as_str())
+                                .map(String::from)
+                                .or(root_code.clone()),
+                            err_obj
+                                .get("integration")
+                                .and_then(|integration| integration.as_str())
+                                .map(String::from)
+                                .or(root_integration.clone()),
+                        )
+                    }),
                 _ => None,
             }) {
-                return Some(message);
+                return Some(api_error);
             }
 
             obj.get("message")
                 .and_then(|message| message.as_str())
-                .map(String::from)
+                .map(|message| ApiError::new(message.to_string(), root_code, root_integration))
         }
         _ => None,
     }

--- a/gestalt/cli/src/commands/invoke.rs
+++ b/gestalt/cli/src/commands/invoke.rs
@@ -23,8 +23,9 @@ pub fn run(
     options: InvokeOptions<'_>,
     format: Format,
 ) -> Result<()> {
-    let cat = catalog::fetch_catalog(client, plugin, options.connection, options.instance)?;
     let query = segments.join(".");
+    let cat =
+        load_catalog_for_invoke(client, plugin, &query, options.connection, options.instance)?;
 
     match cat.resolve(&query)? {
         ResolvedOperation::All(ops) => {
@@ -55,7 +56,13 @@ pub fn invoke(
     options: InvokeOptions<'_>,
     format: Format,
 ) -> Result<()> {
-    let cat = catalog::fetch_catalog(client, plugin, options.connection, options.instance)?;
+    let cat = load_catalog_for_invoke(
+        client,
+        plugin,
+        operation,
+        options.connection,
+        options.instance,
+    )?;
     execute(client, &cat, plugin, operation, params, options, format)
 }
 
@@ -99,28 +106,7 @@ fn execute(
     } else {
         client.post(&path, &serde_json::Value::Object(param_map))
     })
-    .map_err(|err| {
-        let message = err.to_string();
-        if !message.contains("no token stored for integration") {
-            return err;
-        }
-
-        let mut connect_command = format!("gestalt plugins connect {}", plugin);
-        if let Some(connection) = options.connection {
-            connect_command.push_str(" --connection ");
-            connect_command.push_str(connection);
-        }
-        if let Some(instance) = options.instance {
-            connect_command.push_str(" --instance ");
-            connect_command.push_str(instance);
-        }
-
-        anyhow::anyhow!(
-            "plugin {:?} is not connected. Connect it first with `{}`",
-            plugin,
-            connect_command,
-        )
-    })
+    .map_err(|err| rewrite_connect_error(err, plugin, options.connection, options.instance))
     .with_context(|| format!("failed to invoke {}.{}", plugin, operation))?;
 
     let output_value = match options.select {
@@ -168,6 +154,67 @@ fn display_operations<'a>(
 fn warn_ignored_params(params: &[ParamEntry], reason: &str) {
     if !params.is_empty() {
         output::print_warning(&format!("parameters ignored; {}", reason));
+    }
+}
+
+fn load_catalog_for_invoke(
+    client: &ApiClient,
+    plugin: &str,
+    operation: &str,
+    connection: Option<&str>,
+    instance: Option<&str>,
+) -> Result<OperationsCatalog> {
+    catalog::fetch_catalog(client, plugin, connection, instance)
+        .map_err(|err| rewrite_connect_error(err, plugin, connection, instance))
+        .with_context(|| format!("failed to invoke {}", invoke_target(plugin, operation)))
+}
+
+fn rewrite_connect_error(
+    err: anyhow::Error,
+    plugin: &str,
+    connection: Option<&str>,
+    instance: Option<&str>,
+) -> anyhow::Error {
+    let message = err.to_string();
+    let connect_command = connect_command(plugin, connection, instance);
+
+    if message.contains("no token stored for integration") {
+        return anyhow::anyhow!(
+            "plugin {:?} is not connected. Connect it first with `{}`",
+            plugin,
+            connect_command,
+        );
+    }
+
+    if message.contains("expired or was revoked") {
+        return anyhow::anyhow!(
+            "token for plugin {:?} expired or was revoked. Reconnect it with `{}`",
+            plugin,
+            connect_command,
+        );
+    }
+
+    err
+}
+
+fn connect_command(plugin: &str, connection: Option<&str>, instance: Option<&str>) -> String {
+    let mut connect_command = format!("gestalt plugins connect {}", plugin);
+    if let Some(connection) = connection {
+        connect_command.push_str(" --connection ");
+        connect_command.push_str(connection);
+    }
+    if let Some(instance) = instance {
+        connect_command.push_str(" --instance ");
+        connect_command.push_str(instance);
+    }
+    connect_command
+}
+
+fn invoke_target(plugin: &str, operation: &str) -> String {
+    if operation.is_empty() {
+        plugin.to_string()
+    } else {
+        format!("{plugin}.{operation}")
     }
 }
 

--- a/gestalt/cli/src/commands/invoke.rs
+++ b/gestalt/cli/src/commands/invoke.rs
@@ -1,6 +1,6 @@
 use anyhow::{Context, Result};
 
-use crate::api::ApiClient;
+use crate::api::{ApiClient, ApiError};
 use crate::catalog::{
     self, CatalogOperation, CatalogParameter, OperationsCatalog, ResolvedOperation,
 };
@@ -175,26 +175,21 @@ fn rewrite_connect_error(
     connection: Option<&str>,
     instance: Option<&str>,
 ) -> anyhow::Error {
-    let message = err.to_string();
     let connect_command = connect_command(plugin, connection, instance);
 
-    if message.contains("no token stored for integration") {
-        return anyhow::anyhow!(
+    match connect_error_kind(&err) {
+        Some(ConnectErrorKind::NotConnected) => anyhow::anyhow!(
             "plugin {:?} is not connected. Connect it first with `{}`",
             plugin,
             connect_command,
-        );
-    }
-
-    if message.contains("expired or was revoked") {
-        return anyhow::anyhow!(
+        ),
+        Some(ConnectErrorKind::ReconnectRequired) => anyhow::anyhow!(
             "token for plugin {:?} expired or was revoked. Reconnect it with `{}`",
             plugin,
             connect_command,
-        );
+        ),
+        None => err,
     }
-
-    err
 }
 
 fn connect_command(plugin: &str, connection: Option<&str>, instance: Option<&str>) -> String {
@@ -216,6 +211,30 @@ fn invoke_target(plugin: &str, operation: &str) -> String {
     } else {
         format!("{plugin}.{operation}")
     }
+}
+
+enum ConnectErrorKind {
+    NotConnected,
+    ReconnectRequired,
+}
+
+fn connect_error_kind(err: &anyhow::Error) -> Option<ConnectErrorKind> {
+    if let Some(api_error) = err.downcast_ref::<ApiError>() {
+        match api_error.code() {
+            Some("not_connected") => return Some(ConnectErrorKind::NotConnected),
+            Some("reconnect_required") => return Some(ConnectErrorKind::ReconnectRequired),
+            _ => {}
+        }
+    }
+
+    let message = err.to_string();
+    if message.contains("no token stored for integration") {
+        return Some(ConnectErrorKind::NotConnected);
+    }
+    if message.contains("expired or was revoked") {
+        return Some(ConnectErrorKind::ReconnectRequired);
+    }
+    None
 }
 
 fn format_parameters(params: &[CatalogParameter]) -> String {

--- a/gestalt/cli/tests/invoke_contract.rs
+++ b/gestalt/cli/tests/invoke_contract.rs
@@ -59,6 +59,67 @@ fn test_invoke_precondition_error_suggests_connect_command() {
 }
 
 #[test]
+fn test_invoke_reconnect_error_suggests_reconnect_command() {
+    let mut server = Server::new();
+    let home = TempDir::new().unwrap();
+
+    let _catalog_mock = authed_json_mock!(
+        server,
+        Method::GET,
+        "/api/v1/integrations/clickhouse/operations",
+        StatusCode::OK
+    )
+    .with_body(single_operation_catalog("run_query"))
+    .create();
+
+    let _invoke_mock = authed_json_mock!(
+        server,
+        Method::GET,
+        "/api/v1/clickhouse/run_query",
+        StatusCode::PRECONDITION_FAILED
+    )
+    .with_body(
+        r#"{"error":"OAuth token for integration \"clickhouse\" expired or was revoked; reconnect it"}"#,
+    )
+    .create();
+
+    cli_command_for_server(home.path(), &server)
+        .args(["plugins", "invoke", "clickhouse", "run_query"])
+        .assert()
+        .failure()
+        .stderr(predicate::str::contains(
+            "failed to invoke clickhouse.run_query: token for plugin \"clickhouse\" expired or was revoked. Reconnect it with `gestalt plugins connect clickhouse`",
+        ))
+        .stderr(predicate::str::contains("OAuth token for integration").not());
+}
+
+#[test]
+fn test_catalog_reconnect_error_suggests_reconnect_command() {
+    let mut server = Server::new();
+    let home = TempDir::new().unwrap();
+
+    let _catalog_mock = authed_json_mock!(
+        server,
+        Method::GET,
+        "/api/v1/integrations/clickhouse/operations",
+        StatusCode::PRECONDITION_FAILED
+    )
+    .with_body(
+        r#"{"error":"OAuth token for integration \"clickhouse\" expired or was revoked; reconnect it"}"#,
+    )
+    .create();
+
+    cli_command_for_server(home.path(), &server)
+        .args(["plugins", "invoke", "clickhouse"])
+        .assert()
+        .failure()
+        .stderr(predicate::str::contains(
+            "failed to invoke clickhouse: token for plugin \"clickhouse\" expired or was revoked. Reconnect it with `gestalt plugins connect clickhouse`",
+        ))
+        .stderr(predicate::str::contains("OAuth token for integration").not());
+}
+
+#[test]
 fn test_list_operations_formats_parameters() {
     let mut server = Server::new();
     let mock = authed_json_mock!(

--- a/gestalt/cli/tests/invoke_contract.rs
+++ b/gestalt/cli/tests/invoke_contract.rs
@@ -43,9 +43,7 @@ fn test_invoke_precondition_error_suggests_connect_command() {
         "/api/v1/auth_svc/list_items",
         StatusCode::PRECONDITION_FAILED
     )
-    .with_body(
-        r#"{"error":"no token stored for integration \"auth_svc\"; connect via OAuth first"}"#,
-    )
+    .with_body(r#"{"error":"no token stored for integration \"auth_svc\"; connect via OAuth first","code":"not_connected","integration":"auth_svc"}"#)
     .create();
 
     cli_command_for_server(home.path(), &server)
@@ -78,9 +76,7 @@ fn test_invoke_reconnect_error_suggests_reconnect_command() {
         "/api/v1/clickhouse/run_query",
         StatusCode::PRECONDITION_FAILED
     )
-    .with_body(
-        r#"{"error":"OAuth token for integration \"clickhouse\" expired or was revoked; reconnect it"}"#,
-    )
+    .with_body(r#"{"error":"OAuth token for integration \"clickhouse\" expired or was revoked; reconnect it","code":"reconnect_required","integration":"clickhouse"}"#)
     .create();
 
     cli_command_for_server(home.path(), &server)
@@ -104,9 +100,7 @@ fn test_catalog_reconnect_error_suggests_reconnect_command() {
         "/api/v1/integrations/clickhouse/operations",
         StatusCode::PRECONDITION_FAILED
     )
-    .with_body(
-        r#"{"error":"OAuth token for integration \"clickhouse\" expired or was revoked; reconnect it"}"#,
-    )
+    .with_body(r#"{"error":"OAuth token for integration \"clickhouse\" expired or was revoked; reconnect it","code":"reconnect_required","integration":"clickhouse"}"#)
     .create();
 
     cli_command_for_server(home.path(), &server)

--- a/gestaltd/internal/server/handlers.go
+++ b/gestaltd/internal/server/handlers.go
@@ -661,9 +661,21 @@ func (s *Server) writeInvocationError(w http.ResponseWriter, r *http.Request, pr
 	case errors.Is(err, invocation.ErrScopeDenied):
 		writeError(w, http.StatusForbidden, err.Error())
 	case errors.Is(err, invocation.ErrNoToken):
-		writeError(w, http.StatusPreconditionFailed, fmt.Sprintf("no token stored for integration %q; connect via OAuth first", providerName))
+		writeTypedError(
+			w,
+			http.StatusPreconditionFailed,
+			"not_connected",
+			providerName,
+			fmt.Sprintf("no token stored for integration %q; connect via OAuth first", providerName),
+		)
 	case errors.Is(err, invocation.ErrReconnectRequired):
-		writeError(w, http.StatusPreconditionFailed, fmt.Sprintf("OAuth token for integration %q expired or was revoked; reconnect it", providerName))
+		writeTypedError(
+			w,
+			http.StatusPreconditionFailed,
+			"reconnect_required",
+			providerName,
+			fmt.Sprintf("OAuth token for integration %q expired or was revoked; reconnect it", providerName),
+		)
 	case errors.Is(err, invocation.ErrAmbiguousInstance):
 		writeError(w, http.StatusConflict, err.Error())
 	case errors.Is(err, invocation.ErrUserResolution):

--- a/gestaltd/internal/server/response.go
+++ b/gestaltd/internal/server/response.go
@@ -7,6 +7,12 @@ import (
 	"github.com/valon-technologies/gestalt/server/core"
 )
 
+type apiErrorResponse struct {
+	Error       string `json:"error"`
+	Code        string `json:"code,omitempty"`
+	Integration string `json:"integration,omitempty"`
+}
+
 func writeJSON(w http.ResponseWriter, status int, v any) {
 	w.Header().Set("Content-Type", "application/json")
 	w.WriteHeader(status)
@@ -14,7 +20,15 @@ func writeJSON(w http.ResponseWriter, status int, v any) {
 }
 
 func writeError(w http.ResponseWriter, status int, message string) {
-	writeJSON(w, status, map[string]string{"error": message})
+	writeJSON(w, status, apiErrorResponse{Error: message})
+}
+
+func writeTypedError(w http.ResponseWriter, status int, code, integration, message string) {
+	writeJSON(w, status, apiErrorResponse{
+		Error:       message,
+		Code:        code,
+		Integration: integration,
+	})
 }
 
 func writeOperationResult(w http.ResponseWriter, result *core.OperationResult) {

--- a/gestaltd/internal/server/server_test.go
+++ b/gestaltd/internal/server/server_test.go
@@ -7585,6 +7585,24 @@ func TestListOperations_TokenSelectionErrors(t *testing.T) {
 			body, _ := io.ReadAll(resp.Body)
 			t.Fatalf("expected 412, got %d: %s", resp.StatusCode, body)
 		}
+
+		var errResp struct {
+			Error       string `json:"error"`
+			Code        string `json:"code"`
+			Integration string `json:"integration"`
+		}
+		if err := json.NewDecoder(resp.Body).Decode(&errResp); err != nil {
+			t.Fatalf("decoding error response: %v", err)
+		}
+		if errResp.Error != `no token stored for integration "test-int"; connect via OAuth first` {
+			t.Fatalf("expected no-token message, got %q", errResp.Error)
+		}
+		if errResp.Code != "not_connected" {
+			t.Fatalf("expected not_connected code, got %q", errResp.Code)
+		}
+		if errResp.Integration != "test-int" {
+			t.Fatalf("expected integration test-int, got %q", errResp.Integration)
+		}
 	})
 
 	t.Run("ambiguous_instance", func(t *testing.T) {
@@ -13746,12 +13764,22 @@ func TestExecuteOperation_ReconnectRequiredMessage(t *testing.T) {
 		t.Fatalf("response body contains upstream refresh details: %s", body)
 	}
 
-	var errResp map[string]string
+	var errResp struct {
+		Error       string `json:"error"`
+		Code        string `json:"code"`
+		Integration string `json:"integration"`
+	}
 	if err := json.Unmarshal(body, &errResp); err != nil {
 		t.Fatalf("decoding error response: %v", err)
 	}
-	if errResp["error"] != `OAuth token for integration "test-int" expired or was revoked; reconnect it` {
-		t.Fatalf("expected reconnect-required message, got %q", errResp["error"])
+	if errResp.Error != `OAuth token for integration "test-int" expired or was revoked; reconnect it` {
+		t.Fatalf("expected reconnect-required message, got %q", errResp.Error)
+	}
+	if errResp.Code != "reconnect_required" {
+		t.Fatalf("expected reconnect_required code, got %q", errResp.Code)
+	}
+	if errResp.Integration != "test-int" {
+		t.Fatalf("expected integration test-int, got %q", errResp.Integration)
 	}
 }
 


### PR DESCRIPTION
## Summary
- surface reconnect guidance for expired or revoked plugin tokens during `gestalt invoke`
- share the reconnect-message rewrite path across both catalog fetch and operation execution
- add CLI coverage for both reconnect-required failure modes

## Testing
- `cargo test -p gestalt --test invoke_contract`
