### PR TITLE
Fix hybrid plugin routing for Gmail draft helper operations

### DIFF
--- a/gestaltd/internal/bootstrap/executable_plugin_test.go
+++ b/gestaltd/internal/bootstrap/executable_plugin_test.go
@@ -428,6 +428,86 @@ paths:
 	}
 }
 
+func TestHybridExecutableProviderRoutesPluginOperationsThroughNamedSpecConnection(t *testing.T) {
+	t.Parallel()
+
+	bin := buildEchoPluginBinary(t)
+	manifestRoot := writeStaticCatalog(t, &catalog.Catalog{
+		Name: "hybrid",
+		Operations: []catalog.CatalogOperation{
+			{ID: "echo", Method: http.MethodPost, Parameters: []catalog.CatalogParameter{{Name: "message", Type: "string", Required: true}}},
+		},
+	})
+	openapiDoc := `openapi: "3.1.0"
+info:
+  title: Hybrid
+  version: "1.0.0"
+paths:
+  /status:
+    get:
+      operationId: status
+      responses:
+        "200":
+          description: OK
+`
+	if err := os.WriteFile(filepath.Join(manifestRoot, "openapi.yaml"), []byte(openapiDoc), 0o644); err != nil {
+		t.Fatalf("WriteFile(openapi.yaml): %v", err)
+	}
+
+	manifest := newExecutableManifest("Hybrid", "Hybrid provider")
+	manifest.Entrypoint = &providermanifestv1.Entrypoint{ArtifactPath: "ignored-for-command-mode"}
+	manifest.Spec.Surfaces = &providermanifestv1.ProviderSurfaces{
+		OpenAPI: &providermanifestv1.OpenAPISurface{Document: "openapi.yaml"},
+	}
+	manifest.Spec.Connections = map[string]*providermanifestv1.ManifestConnectionDef{
+		"default": {
+			Auth: &providermanifestv1.ProviderAuth{Type: providermanifestv1.AuthTypeBearer},
+		},
+	}
+	manifestPath := filepath.Join(manifestRoot, "manifest.yaml")
+
+	entry := &config.ProviderEntry{
+		Command:              bin,
+		Args:                 []string{"provider"},
+		ResolvedManifest:     manifest,
+		ResolvedManifestPath: manifestPath,
+	}
+	cfg := &config.Config{
+		Plugins: map[string]*config.ProviderEntry{
+			"hybrid": entry,
+		},
+	}
+
+	factories := NewFactoryRegistry()
+	providers, _, err := buildProvidersStrict(context.Background(), cfg, factories, Deps{})
+	if err != nil {
+		t.Fatalf("buildProvidersStrict: %v", err)
+	}
+	defer func() { _ = CloseProviders(providers) }()
+
+	prov, err := providers.Get("hybrid")
+	if err != nil {
+		t.Fatalf("providers.Get(hybrid): %v", err)
+	}
+	if got := prov.ConnectionForOperation("echo"); got != "default" {
+		t.Fatalf("echo connection = %q, want %q", got, "default")
+	}
+	if got := prov.ConnectionForOperation("status"); got != "default" {
+		t.Fatalf("status connection = %q, want %q", got, "default")
+	}
+
+	_, operationConnections, err := buildStartupProviderSpec("hybrid", entry)
+	if err != nil {
+		t.Fatalf("buildStartupProviderSpec: %v", err)
+	}
+	if got := operationConnections["echo"]; got != "default" {
+		t.Fatalf("startup echo connection = %q, want %q", got, "default")
+	}
+	if _, ok := operationConnections["status"]; ok {
+		t.Fatalf("startup catalog unexpectedly exposed spec-loaded status operation")
+	}
+}
+
 func TestSpecLoadedDualSurfaceProviderBuildsMCPOperations(t *testing.T) {
 	t.Parallel()
 

--- a/gestaltd/internal/bootstrap/provider_build.go
+++ b/gestaltd/internal/bootstrap/provider_build.go
@@ -9,6 +9,7 @@ import (
 	"maps"
 	"net/url"
 	"path/filepath"
+	"reflect"
 	"runtime"
 	"strings"
 	"sync"
@@ -205,9 +206,10 @@ func operationConnectionsForCatalog(cat *catalog.Catalog, plan config.StaticConn
 		return map[string]string{}
 	}
 	operationConnections := make(map[string]string, len(cat.Operations))
+	pluginConnection := hybridPluginOperationConnection(plan, configuredSpecConnection(plan))
 	for i := range cat.Operations {
 		operation := &cat.Operations[i]
-		connection := config.PluginConnectionName
+		connection := pluginConnection
 		switch operation.Transport {
 		case catalog.TransportREST:
 			connection = plan.APIConnection()
@@ -219,6 +221,33 @@ func operationConnectionsForCatalog(cat *catalog.Catalog, plan config.StaticConn
 		}
 	}
 	return operationConnections
+}
+
+func configuredSpecConnection(plan config.StaticConnectionPlan) string {
+	if resolved, ok := plan.ConfiguredSpecSurface(); ok {
+		return resolved.ConnectionName
+	}
+	return ""
+}
+
+func hybridPluginOperationConnection(plan config.StaticConnectionPlan, specConnection string) string {
+	if explicitPluginConnection(plan) {
+		return config.PluginConnectionName
+	}
+	if specConnection != "" && specConnection != config.PluginConnectionName {
+		return specConnection
+	}
+	if fallback := plan.AuthDefaultConnection(); fallback != "" {
+		return fallback
+	}
+	return config.PluginConnectionName
+}
+
+func explicitPluginConnection(plan config.StaticConnectionPlan) bool {
+	if !reflect.DeepEqual(plan.PluginConnection(), config.ConnectionDef{}) {
+		return true
+	}
+	return plan.AuthDefaultConnection() == config.PluginConnectionName && len(plan.NamedConnectionNames()) > 0
 }
 
 func buildProvider(ctx context.Context, name string, entry *config.ProviderEntry, deps Deps) (*ProviderBuildResult, error) {
@@ -323,7 +352,7 @@ func buildExecutablePluginProvider(ctx context.Context, name string, entry *conf
 			pluginProv.DisplayName(),
 			pluginProv.Description(),
 			firstProviderIconSVG(pluginProv, apiProv),
-			composite.BoundProvider{Provider: pluginProv, Connection: config.PluginConnectionName},
+			composite.BoundProvider{Provider: pluginProv, Connection: hybridPluginOperationConnection(plan, plan.APIConnection())},
 			composite.BoundProvider{Provider: apiProv, Connection: plan.APIConnection()},
 		)
 		if err != nil {
@@ -368,7 +397,7 @@ func buildExecutablePluginProvider(ctx context.Context, name string, entry *conf
 		pluginProv.DisplayName(),
 		pluginProv.Description(),
 		firstProviderIconSVG(pluginProv, specProv),
-		composite.BoundProvider{Provider: pluginProv, Connection: config.PluginConnectionName},
+		composite.BoundProvider{Provider: pluginProv, Connection: hybridPluginOperationConnection(plan, resolved.ConnectionName)},
 		composite.BoundProvider{Provider: specProv, Connection: resolved.ConnectionName},
 	)
 	if err != nil {


### PR DESCRIPTION
## Summary
Fix hybrid executable providers so plugin-side helper operations reuse the integration's named auth connection when the plugin connection is only the implicit empty `_plugin` connection.

## Why
For Gmail, `drafts.create` ran through the OpenAPI side on the connected `default` connection, but `messages.createDraft` ran through the plugin side on `_plugin`. That left `req.token` empty in the plugin and produced a misleading `token is required` error.

## Changes
- route hybrid plugin operations to the configured spec/default auth connection when no explicit plugin connection is defined
- preserve explicit `_plugin` routing when the plugin connection is intentionally configured
- add a regression test covering the Gmail-shaped hybrid case

## Testing
- `go test ./internal/bootstrap`