### PR TITLE
Make authorization provider authoritative for dynamic human grants

### DIFF
--- a/gestaltd/internal/authorization/provider_backed.go
+++ b/gestaltd/internal/authorization/provider_backed.go
@@ -142,11 +142,11 @@ func (a *ProviderBackedAuthorizer) ReloadDynamic(ctx context.Context) error {
 	if err != nil {
 		return errors.Join(reloadErr, err)
 	}
-	desired, roles, err := a.buildDesiredRelationships(modelID)
+	existing, err := a.readAllRelationships(ctx, modelID)
 	if err != nil {
 		return errors.Join(reloadErr, err)
 	}
-	existing, err := a.readAllRelationships(ctx, modelID)
+	desired, roles, err := a.buildDesiredRelationships(modelID, existing)
 	if err != nil {
 		return errors.Join(reloadErr, err)
 	}
@@ -167,6 +167,16 @@ func (a *ProviderBackedAuthorizer) ReloadDynamic(ctx context.Context) error {
 	a.state = roles
 	a.stateMu.Unlock()
 	return reloadErr
+}
+
+func (a *ProviderBackedAuthorizer) ManagedModelID(ctx context.Context) (string, error) {
+	if a == nil {
+		return "", fmt.Errorf("authorization provider is unavailable")
+	}
+	if a.provider == nil {
+		return "", fmt.Errorf("authorization provider is unavailable")
+	}
+	return a.ensureModel(ctx)
 }
 
 func (a *ProviderBackedAuthorizer) pollLoop(ctx context.Context, done chan struct{}) {
@@ -607,7 +617,7 @@ func (a *ProviderBackedAuthorizer) readAllRelationships(ctx context.Context, mod
 	}
 }
 
-func (a *ProviderBackedAuthorizer) buildDesiredRelationships(modelID string) (map[string]*core.Relationship, providerBackedRoleState, error) {
+func (a *ProviderBackedAuthorizer) buildDesiredRelationships(modelID string, existing map[string]*core.Relationship) (map[string]*core.Relationship, providerBackedRoleState, error) {
 	desired := map[string]*core.Relationship{}
 	state := providerBackedRoleState{
 		modelID:            modelID,
@@ -620,6 +630,30 @@ func (a *ProviderBackedAuthorizer) buildDesiredRelationships(modelID string) (ma
 	pluginStaticRoles := map[string]map[string]struct{}{}
 	pluginDynamicRoles := map[string]map[string]struct{}{}
 	adminDynamicRoles := map[string]struct{}{}
+
+	for _, rel := range existing {
+		if rel == nil || rel.GetResource() == nil {
+			continue
+		}
+		switch strings.TrimSpace(rel.GetResource().GetType()) {
+		case resourceTypePluginDynamic:
+			resourceID := strings.TrimSpace(rel.GetResource().GetId())
+			relation := strings.TrimSpace(rel.GetRelation())
+			if resourceID == "" || relation == "" {
+				continue
+			}
+			addDesiredRelationship(desired, rel)
+			ensureRoleSet(pluginDynamicRoles, resourceID)[relation] = struct{}{}
+		case resourceTypeAdminDynamic:
+			resourceID := strings.TrimSpace(rel.GetResource().GetId())
+			relation := strings.TrimSpace(rel.GetRelation())
+			if resourceID != resourceIDAdminDynamicGlobal || relation == "" {
+				continue
+			}
+			addDesiredRelationship(desired, rel)
+			adminDynamicRoles[relation] = struct{}{}
+		}
+	}
 
 	providersByPolicy := map[string][]string{}
 	for providerName, policyName := range a.legacy.providerPolicies {

--- a/gestaltd/internal/bootstrap/bootstrap_test.go
+++ b/gestaltd/internal/bootstrap/bootstrap_test.go
@@ -3579,6 +3579,32 @@ func TestBootstrapSecretResolution(t *testing.T) {
 		if adminAccess.Role != "admin" {
 			t.Fatalf("dynamic admin role = %q, want %q", adminAccess.Role, "admin")
 		}
+
+		if err := result.Services.PluginAuthorizations.DeletePluginAuthorization(ctx, "calendar", dynamicUser.ID); err != nil {
+			t.Fatalf("DeletePluginAuthorization: %v", err)
+		}
+		if err := result.Services.AdminAuthorizations.DeleteAdminAuthorization(ctx, dynamicUser.ID); err != nil {
+			t.Fatalf("DeleteAdminAuthorization: %v", err)
+		}
+		if err := result.Authorizer.ReloadDynamic(ctx); err != nil {
+			t.Fatalf("ReloadDynamic after deleting legacy authorizations: %v", err)
+		}
+
+		access, allowed = result.Authorizer.ResolveAccess(ctx, dynamicPrincipal, "calendar")
+		if !allowed {
+			t.Fatal("expected provider-backed plugin access to survive legacy deletion")
+		}
+		if access.Role != "editor" {
+			t.Fatalf("provider-backed plugin role after legacy deletion = %q, want %q", access.Role, "editor")
+		}
+
+		adminAccess, allowed = result.Authorizer.ResolveAdminAccess(ctx, dynamicPrincipal, "admin-policy")
+		if !allowed {
+			t.Fatal("expected provider-backed admin access to survive legacy deletion")
+		}
+		if adminAccess.Role != "admin" {
+			t.Fatalf("provider-backed admin role after legacy deletion = %q, want %q", adminAccess.Role, "admin")
+		}
 	})
 
 	t.Run("authorization provider provisions a new model when the active model is unmanaged", func(t *testing.T) {

--- a/gestaltd/internal/server/handlers_admin_authorization.go
+++ b/gestaltd/internal/server/handlers_admin_authorization.go
@@ -177,12 +177,17 @@ func (s *Server) putAdminAuthorizationPluginMember(w http.ResponseWriter, r *htt
 		return
 	}
 
-	membership, err := s.pluginAuthorizations.UpsertPluginAuthorization(r.Context(), &coredata.PluginAuthorizationMembership{
-		Plugin: plugin,
-		UserID: user.ID,
-		Email:  user.Email,
-		Role:   req.Role,
-	})
+	var membership *coredata.PluginAuthorizationMembership
+	if s.authorizationProvider != nil {
+		membership, err = s.upsertProviderPluginAuthorization(r.Context(), user, plugin, req.Role)
+	} else {
+		membership, err = s.pluginAuthorizations.UpsertPluginAuthorization(r.Context(), &coredata.PluginAuthorizationMembership{
+			Plugin: plugin,
+			UserID: user.ID,
+			Email:  user.Email,
+			Role:   req.Role,
+		})
+	}
 	if err != nil {
 		writeError(w, http.StatusInternalServerError, "failed to persist authorization member")
 		return
@@ -234,8 +239,14 @@ func (s *Server) deleteAdminAuthorizationPluginMember(w http.ResponseWriter, r *
 		return
 	}
 
-	if err := s.pluginAuthorizations.DeletePluginAuthorization(r.Context(), plugin, userID); err != nil {
-		if errors.Is(err, core.ErrNotFound) {
+	var deleteErr error
+	if s.authorizationProvider != nil {
+		deleteErr = s.deleteProviderPluginAuthorization(r.Context(), plugin, userID)
+	} else {
+		deleteErr = s.pluginAuthorizations.DeletePluginAuthorization(r.Context(), plugin, userID)
+	}
+	if deleteErr != nil {
+		if errors.Is(deleteErr, core.ErrNotFound) {
 			writeError(w, http.StatusNotFound, "authorization member not found")
 			return
 		}
@@ -307,11 +318,16 @@ func (s *Server) putAdminAuthorizationAdminMember(w http.ResponseWriter, r *http
 		return
 	}
 
-	membership, err := s.adminAuthorizations.UpsertAdminAuthorization(r.Context(), &coredata.AdminAuthorizationMembership{
-		UserID: user.ID,
-		Email:  user.Email,
-		Role:   req.Role,
-	})
+	var membership *coredata.AdminAuthorizationMembership
+	if s.authorizationProvider != nil {
+		membership, err = s.upsertProviderAdminAuthorization(r.Context(), user, req.Role)
+	} else {
+		membership, err = s.adminAuthorizations.UpsertAdminAuthorization(r.Context(), &coredata.AdminAuthorizationMembership{
+			UserID: user.ID,
+			Email:  user.Email,
+			Role:   req.Role,
+		})
+	}
 	if err != nil {
 		writeError(w, http.StatusInternalServerError, "failed to persist admin member")
 		return
@@ -360,8 +376,14 @@ func (s *Server) deleteAdminAuthorizationAdminMember(w http.ResponseWriter, r *h
 		return
 	}
 
-	if err := s.adminAuthorizations.DeleteAdminAuthorization(r.Context(), userID); err != nil {
-		if errors.Is(err, core.ErrNotFound) {
+	var deleteErr error
+	if s.authorizationProvider != nil {
+		deleteErr = s.deleteProviderAdminAuthorization(r.Context(), userID)
+	} else {
+		deleteErr = s.adminAuthorizations.DeleteAdminAuthorization(r.Context(), userID)
+	}
+	if deleteErr != nil {
+		if errors.Is(deleteErr, core.ErrNotFound) {
 			writeError(w, http.StatusNotFound, "admin member not found")
 			return
 		}

--- a/gestaltd/internal/server/handlers_admin_authorization_provider_write.go
+++ b/gestaltd/internal/server/handlers_admin_authorization_provider_write.go
@@ -1,0 +1,400 @@
+package server
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"strings"
+
+	"github.com/valon-technologies/gestalt/server/core"
+	"github.com/valon-technologies/gestalt/server/internal/authorization"
+	"github.com/valon-technologies/gestalt/server/internal/coredata"
+	"github.com/valon-technologies/gestalt/server/internal/emailutil"
+)
+
+type managedAuthorizationModelResolver interface {
+	ManagedModelID(ctx context.Context) (string, error)
+}
+
+func (s *Server) upsertProviderPluginAuthorization(ctx context.Context, user *core.User, plugin, role string) (*coredata.PluginAuthorizationMembership, error) {
+	if s.authorizationProvider == nil {
+		return nil, errAdminAuthorizationUnavailable
+	}
+	if user == nil {
+		return nil, fmt.Errorf("user is required")
+	}
+	resource := &core.ResourceRef{
+		Type: authorization.ProviderResourceTypePluginDynamic,
+		Id:   strings.TrimSpace(plugin),
+	}
+	rollback, err := s.replaceProviderDynamicMembership(ctx, resource, user, strings.TrimSpace(role))
+	if err != nil {
+		return nil, err
+	}
+	membership, err := s.pluginAuthorizations.UpsertPluginAuthorization(ctx, &coredata.PluginAuthorizationMembership{
+		Plugin: plugin,
+		UserID: user.ID,
+		Email:  user.Email,
+		Role:   role,
+	})
+	if err != nil {
+		rollback(ctx)
+		return nil, err
+	}
+	return membership, nil
+}
+
+func (s *Server) deleteProviderPluginAuthorization(ctx context.Context, plugin, userID string) error {
+	if s.authorizationProvider == nil {
+		return errAdminAuthorizationUnavailable
+	}
+	user, userErr := s.users.GetUser(ctx, strings.TrimSpace(userID))
+	if userErr != nil && !errors.Is(userErr, core.ErrNotFound) {
+		return userErr
+	}
+	subjectUser := &core.User{ID: strings.TrimSpace(userID)}
+	if userErr == nil {
+		subjectUser = user
+	}
+	resource := &core.ResourceRef{
+		Type: authorization.ProviderResourceTypePluginDynamic,
+		Id:   strings.TrimSpace(plugin),
+	}
+	rollback, err := s.deleteProviderDynamicMembership(ctx, resource, subjectUser)
+	if err != nil {
+		return err
+	}
+	err = s.pluginAuthorizations.DeletePluginAuthorization(ctx, plugin, userID)
+	switch {
+	case err == nil:
+		return nil
+	case errors.Is(err, core.ErrNotFound):
+		if rollback == nil {
+			return core.ErrNotFound
+		}
+		return nil
+	default:
+		rollback(ctx)
+		return err
+	}
+}
+
+func (s *Server) upsertProviderAdminAuthorization(ctx context.Context, user *core.User, role string) (*coredata.AdminAuthorizationMembership, error) {
+	if s.authorizationProvider == nil {
+		return nil, errAdminAuthorizationUnavailable
+	}
+	if user == nil {
+		return nil, fmt.Errorf("user is required")
+	}
+	resource := &core.ResourceRef{
+		Type: authorization.ProviderResourceTypeAdminDynamic,
+		Id:   authorization.ProviderResourceIDAdminDynamicGlobal,
+	}
+	rollback, err := s.replaceProviderDynamicMembership(ctx, resource, user, strings.TrimSpace(role))
+	if err != nil {
+		return nil, err
+	}
+	membership, err := s.adminAuthorizations.UpsertAdminAuthorization(ctx, &coredata.AdminAuthorizationMembership{
+		UserID: user.ID,
+		Email:  user.Email,
+		Role:   role,
+	})
+	if err != nil {
+		rollback(ctx)
+		return nil, err
+	}
+	return membership, nil
+}
+
+func (s *Server) deleteProviderAdminAuthorization(ctx context.Context, userID string) error {
+	if s.authorizationProvider == nil {
+		return errAdminAuthorizationUnavailable
+	}
+	user, userErr := s.users.GetUser(ctx, strings.TrimSpace(userID))
+	if userErr != nil && !errors.Is(userErr, core.ErrNotFound) {
+		return userErr
+	}
+	subjectUser := &core.User{ID: strings.TrimSpace(userID)}
+	if userErr == nil {
+		subjectUser = user
+	}
+	resource := &core.ResourceRef{
+		Type: authorization.ProviderResourceTypeAdminDynamic,
+		Id:   authorization.ProviderResourceIDAdminDynamicGlobal,
+	}
+	rollback, err := s.deleteProviderDynamicMembership(ctx, resource, subjectUser)
+	if err != nil {
+		return err
+	}
+	err = s.adminAuthorizations.DeleteAdminAuthorization(ctx, userID)
+	switch {
+	case err == nil:
+		return nil
+	case errors.Is(err, core.ErrNotFound):
+		if rollback == nil {
+			return core.ErrNotFound
+		}
+		return nil
+	default:
+		rollback(ctx)
+		return err
+	}
+}
+
+func (s *Server) replaceProviderDynamicMembership(ctx context.Context, resource *core.ResourceRef, user *core.User, role string) (func(context.Context), error) {
+	modelID, err := s.managedAuthorizationModelID(ctx)
+	if err != nil {
+		return nil, err
+	}
+	existing, err := s.providerDynamicRelationshipsForUser(ctx, resource, user)
+	if err != nil {
+		return nil, err
+	}
+	writes := providerDynamicMembershipRelationships(resource, user, role)
+	deletes := filterRelationshipKeys(existing, writes)
+	if len(writes) == 0 && len(deletes) == 0 {
+		return func(context.Context) {}, nil
+	}
+	if err := s.authorizationProvider.WriteRelationships(ctx, &core.WriteRelationshipsRequest{
+		Writes:  writes,
+		Deletes: deletes,
+		ModelId: modelID,
+	}); err != nil {
+		return nil, fmt.Errorf("write authorization relationships: %w", err)
+	}
+	rollbackDeletes := filterRelationshipKeys(writes, existing)
+	rollbackWrites := cloneRelationships(existing)
+	return func(rollbackCtx context.Context) {
+		_ = s.authorizationProvider.WriteRelationships(rollbackCtx, &core.WriteRelationshipsRequest{
+			Writes:  rollbackWrites,
+			Deletes: rollbackDeletes,
+			ModelId: modelID,
+		})
+	}, nil
+}
+
+func (s *Server) deleteProviderDynamicMembership(ctx context.Context, resource *core.ResourceRef, user *core.User) (func(context.Context), error) {
+	modelID, err := s.managedAuthorizationModelID(ctx)
+	if err != nil {
+		return nil, err
+	}
+	existing, err := s.providerDynamicRelationshipsForUser(ctx, resource, user)
+	if err != nil {
+		return nil, err
+	}
+	deletes := relationshipKeys(existing)
+	if len(deletes) == 0 {
+		return nil, nil
+	}
+	if err := s.authorizationProvider.WriteRelationships(ctx, &core.WriteRelationshipsRequest{
+		Deletes: deletes,
+		ModelId: modelID,
+	}); err != nil {
+		return nil, fmt.Errorf("delete authorization relationships: %w", err)
+	}
+	rollbackWrites := cloneRelationships(existing)
+	return func(rollbackCtx context.Context) {
+		_ = s.authorizationProvider.WriteRelationships(rollbackCtx, &core.WriteRelationshipsRequest{
+			Writes:  rollbackWrites,
+			ModelId: modelID,
+		})
+	}, nil
+}
+
+func (s *Server) managedAuthorizationModelID(ctx context.Context) (string, error) {
+	if s.authorizationProvider == nil {
+		return "", errAdminAuthorizationUnavailable
+	}
+	if resolver, ok := s.authorizer.(managedAuthorizationModelResolver); ok {
+		return resolver.ManagedModelID(ctx)
+	}
+	active, err := s.authorizationProvider.GetActiveModel(ctx)
+	if err != nil {
+		return "", err
+	}
+	if model := active.GetModel(); model != nil && strings.TrimSpace(model.GetId()) != "" {
+		return strings.TrimSpace(model.GetId()), nil
+	}
+	return "", fmt.Errorf("authorization provider has no active model")
+}
+
+func (s *Server) providerDynamicRelationshipsForUser(ctx context.Context, resource *core.ResourceRef, user *core.User) ([]*core.Relationship, error) {
+	if s.authorizationProvider == nil {
+		return nil, errAdminAuthorizationUnavailable
+	}
+	relationships, err := s.readAllAuthorizationRelationships(ctx, &core.ReadRelationshipsRequest{
+		PageSize: adminAuthorizationProviderReadPageSize,
+		Resource: resource,
+	})
+	if err != nil {
+		return nil, err
+	}
+	userID := ""
+	email := ""
+	if user != nil {
+		userID = strings.TrimSpace(user.ID)
+		email = emailutil.Normalize(user.Email)
+	}
+	out := make([]*core.Relationship, 0, len(relationships))
+	for _, rel := range relationships {
+		match, err := s.providerRelationshipMatchesUser(ctx, rel, userID, email)
+		if err != nil {
+			return nil, err
+		}
+		if match {
+			out = append(out, rel)
+		}
+	}
+	return out, nil
+}
+
+func (s *Server) providerRelationshipMatchesUser(ctx context.Context, rel *core.Relationship, userID, email string) (bool, error) {
+	if rel == nil || rel.GetSubject() == nil {
+		return false, nil
+	}
+	subjectType := strings.TrimSpace(rel.GetSubject().GetType())
+	subjectID := strings.TrimSpace(rel.GetSubject().GetId())
+	switch subjectType {
+	case authorization.ProviderSubjectTypeUser:
+		return userID != "" && subjectID == userID, nil
+	case authorization.ProviderSubjectTypeEmail:
+		normalized := emailutil.Normalize(subjectID)
+		if normalized == "" {
+			return false, nil
+		}
+		if email != "" && normalized == email {
+			return true, nil
+		}
+		if userID == "" || s.users == nil {
+			return false, nil
+		}
+		user, err := s.users.FindUserByEmail(ctx, normalized)
+		switch {
+		case err == nil:
+			return strings.TrimSpace(user.ID) == userID, nil
+		case errors.Is(err, core.ErrNotFound):
+			return false, nil
+		default:
+			return false, err
+		}
+	default:
+		return false, nil
+	}
+}
+
+func providerDynamicMembershipRelationships(resource *core.ResourceRef, user *core.User, role string) []*core.Relationship {
+	role = strings.TrimSpace(role)
+	if resource == nil || role == "" || user == nil {
+		return nil
+	}
+	writes := make([]*core.Relationship, 0, 2)
+	if userID := strings.TrimSpace(user.ID); userID != "" {
+		writes = append(writes, &core.Relationship{
+			Subject:  &core.SubjectRef{Type: authorization.ProviderSubjectTypeUser, Id: userID},
+			Relation: role,
+			Resource: cloneResourceRef(resource),
+		})
+	}
+	if email := emailutil.Normalize(user.Email); email != "" {
+		writes = append(writes, &core.Relationship{
+			Subject:  &core.SubjectRef{Type: authorization.ProviderSubjectTypeEmail, Id: email},
+			Relation: role,
+			Resource: cloneResourceRef(resource),
+		})
+	}
+	return writes
+}
+
+func relationshipKeys(rels []*core.Relationship) []*core.RelationshipKey {
+	if len(rels) == 0 {
+		return nil
+	}
+	keys := make([]*core.RelationshipKey, 0, len(rels))
+	for _, rel := range rels {
+		if rel == nil {
+			continue
+		}
+		keys = append(keys, &core.RelationshipKey{
+			Subject:  cloneSubjectRef(rel.GetSubject()),
+			Relation: rel.GetRelation(),
+			Resource: cloneResourceRef(rel.GetResource()),
+		})
+	}
+	return keys
+}
+
+func filterRelationshipKeys(rels []*core.Relationship, keep []*core.Relationship) []*core.RelationshipKey {
+	if len(rels) == 0 {
+		return nil
+	}
+	keepKeys := map[string]struct{}{}
+	for _, rel := range keep {
+		keepKeys[providerRelationshipKey(rel)] = struct{}{}
+	}
+	keys := make([]*core.RelationshipKey, 0, len(rels))
+	for _, rel := range rels {
+		if rel == nil {
+			continue
+		}
+		if _, ok := keepKeys[providerRelationshipKey(rel)]; ok {
+			continue
+		}
+		keys = append(keys, &core.RelationshipKey{
+			Subject:  cloneSubjectRef(rel.GetSubject()),
+			Relation: rel.GetRelation(),
+			Resource: cloneResourceRef(rel.GetResource()),
+		})
+	}
+	return keys
+}
+
+func providerRelationshipKey(rel *core.Relationship) string {
+	if rel == nil || rel.GetSubject() == nil || rel.GetResource() == nil {
+		return ""
+	}
+	return strings.Join([]string{
+		strings.TrimSpace(rel.GetSubject().GetType()),
+		strings.TrimSpace(rel.GetSubject().GetId()),
+		strings.TrimSpace(rel.GetRelation()),
+		strings.TrimSpace(rel.GetResource().GetType()),
+		strings.TrimSpace(rel.GetResource().GetId()),
+	}, "\x00")
+}
+
+func cloneRelationships(rels []*core.Relationship) []*core.Relationship {
+	if len(rels) == 0 {
+		return nil
+	}
+	out := make([]*core.Relationship, 0, len(rels))
+	for _, rel := range rels {
+		if rel == nil {
+			continue
+		}
+		out = append(out, &core.Relationship{
+			Subject:  cloneSubjectRef(rel.GetSubject()),
+			Relation: rel.GetRelation(),
+			Resource: cloneResourceRef(rel.GetResource()),
+		})
+	}
+	return out
+}
+
+func cloneSubjectRef(subject *core.SubjectRef) *core.SubjectRef {
+	if subject == nil {
+		return nil
+	}
+	return &core.SubjectRef{
+		Type: subject.GetType(),
+		Id:   subject.GetId(),
+	}
+}
+
+func cloneResourceRef(resource *core.ResourceRef) *core.ResourceRef {
+	if resource == nil {
+		return nil
+	}
+	return &core.ResourceRef{
+		Type: resource.GetType(),
+		Id:   resource.GetId(),
+	}
+}

--- a/gestaltd/internal/server/server_test.go
+++ b/gestaltd/internal/server/server_test.go
@@ -2568,6 +2568,9 @@ func TestAdminAPI_PluginAuthorizationProviderBackedReadsAndDebug(t *testing.T) {
 	if err := svc.PluginAuthorizations.DeletePluginAuthorization(context.Background(), "sample_plugin", user.ID); err != nil {
 		t.Fatalf("DeletePluginAuthorization: %v", err)
 	}
+	if err := authz.ReloadDynamic(context.Background()); err != nil {
+		t.Fatalf("ReloadDynamic after deleting legacy plugin authorization: %v", err)
+	}
 
 	req, _ = http.NewRequest(http.MethodGet, ts.URL+"/admin/api/v1/authorization/plugins/sample_plugin/members", nil)
 	req.AddCookie(&http.Cookie{Name: "session_token", Value: "admin-session"})
@@ -2973,6 +2976,9 @@ func TestAdminAPI_AdminAuthorizationProviderBackedReads(t *testing.T) {
 	}
 	if err := svc.AdminAuthorizations.DeleteAdminAuthorization(context.Background(), user.ID); err != nil {
 		t.Fatalf("DeleteAdminAuthorization: %v", err)
+	}
+	if err := authz.ReloadDynamic(context.Background()); err != nil {
+		t.Fatalf("ReloadDynamic after deleting legacy admin authorization: %v", err)
 	}
 
 	req, _ = http.NewRequest(http.MethodGet, ts.URL+"/admin/api/v1/authorization/admins/members", nil)


### PR DESCRIPTION
## Summary
This makes the configured `providers.authorization` backend the authoritative runtime store for dynamic human plugin/admin grants.

Before this change, provider-backed admin writes still persisted legacy dynamic rows first and `ReloadDynamic()` rebuilt the provider relationship set from those legacy tables.

After this change:
- provider-backed admin writes mutate authorization-provider relationships first
- legacy plugin/admin authorization rows are mirrored only for compatibility and canonical side effects
- provider-backed reload preserves existing provider dynamic human relationships and only imports legacy rows additively for migration

That means a provider-backed dynamic human grant survives a later reload even if the legacy membership row is deleted.

## Go Interface
This PR relies on the existing authorization provider contract and makes that contract the primary write/read surface for dynamic human grants:

```go
type AuthorizationProvider interface {
    Evaluate(ctx context.Context, req *AccessEvaluationRequest) (*AccessDecision, error)
    ReadRelationships(ctx context.Context, req *ReadRelationshipsRequest) (*ReadRelationshipsResponse, error)
    WriteRelationships(ctx context.Context, req *WriteRelationshipsRequest) error
    GetActiveModel(ctx context.Context) (*GetActiveModelResponse, error)
    ListModels(ctx context.Context, req *ListModelsRequest) (*ListModelsResponse, error)
    WriteModel(ctx context.Context, req *WriteModelRequest) (*AuthorizationModelRef, error)
}
```

The server now uses that interface directly for:
- `PUT/DELETE /admin/api/v1/authorization/plugins/{plugin}/members`
- `PUT/DELETE /admin/api/v1/authorization/admins/members`

## YAML Interface
No config shape changes are required. The existing authorization-provider wiring is the same; this PR changes what happens behind it:

```yaml
server:
  providers:
    indexeddb: main-db
    authorization: indexeddb

providers:
  indexeddb:
    main-db:
      config:
        dsn:
          secret:
            provider: secrets
            name: gestalt-mysql-dsn-east4
        schema: gestaltd
  authorization:
    indexeddb:
      source:
        path: ./providers-src/authorization/indexeddb/manifest.yaml
      config:
        indexeddb: main-db
```

## Examples
Provider-backed plugin member write:

```sh
curl -X PUT /admin/api/v1/authorization/plugins/calendar/members \
  -H 'Content-Type: application/json' \
  --data '{"email":"dynamic@example.test","role":"editor"}'
```

Provider-backed admin member write:

```sh
curl -X PUT /admin/api/v1/authorization/admins/members \
  -H 'Content-Type: application/json' \
  --data '{"email":"dynamic-admin@example.test","role":"admin"}'
```

Runtime behavior after migration/import:
- existing legacy dynamic human rows are still imported into the provider on reload
- once the relationship exists in the provider, reload no longer depends on the legacy row remaining present
- direct provider-backed deletes remove the provider relationship set and mirror the legacy delete for compatibility

## Verification
Used the existing coverage and extended only the current provider-backed authz tests:

```sh
cd gestaltd && go test ./internal/server ./internal/bootstrap ./internal/authorization
cd gestaltd && golangci-lint run ./internal/server ./internal/bootstrap ./internal/authorization
```

The updated tests now verify that provider-backed plugin/admin dynamic access survives a reload after the legacy membership row has been deleted.