### PR TITLE
authorization: detach human grant sync from legacy tables

### DIFF
--- a/gestaltd/internal/authorization/provider_backed.go
+++ b/gestaltd/internal/authorization/provider_backed.go
@@ -79,11 +79,6 @@ func (a *ProviderBackedAuthorizer) Start(ctx context.Context) error {
 	a.legacy.started = true
 	a.legacy.lifecycleMu.Unlock()
 
-	if !a.legacy.hasDynamicSources() {
-		a.started = true
-		return nil
-	}
-
 	pollCtx, cancel := context.WithCancel(ctx)
 	done := make(chan struct{})
 	a.pollCancel = cancel
@@ -146,7 +141,15 @@ func (a *ProviderBackedAuthorizer) ReloadDynamic(ctx context.Context) error {
 	if err != nil {
 		return errors.Join(reloadErr, err)
 	}
-	desired, roles, err := a.buildDesiredRelationships(modelID, existing)
+	_, legacyImported := existing[relationshipMapKey(ProviderLegacyHumanImportSentinelRelationship())]
+	importLegacy := !legacyImported && reloadErr == nil
+
+	var snapshot *dynamicSnapshot
+	if importLegacy {
+		snapshot = a.currentDynamicSnapshot()
+	}
+
+	desired, roles, err := a.buildDesiredRelationships(modelID, existing, snapshot, legacyImported || importLegacy)
 	if err != nil {
 		return errors.Join(reloadErr, err)
 	}
@@ -617,7 +620,7 @@ func (a *ProviderBackedAuthorizer) readAllRelationships(ctx context.Context, mod
 	}
 }
 
-func (a *ProviderBackedAuthorizer) buildDesiredRelationships(modelID string, existing map[string]*core.Relationship) (map[string]*core.Relationship, providerBackedRoleState, error) {
+func (a *ProviderBackedAuthorizer) buildDesiredRelationships(modelID string, existing map[string]*core.Relationship, snapshot *dynamicSnapshot, markLegacyImported bool) (map[string]*core.Relationship, providerBackedRoleState, error) {
 	desired := map[string]*core.Relationship{}
 	state := providerBackedRoleState{
 		modelID:            modelID,
@@ -626,10 +629,14 @@ func (a *ProviderBackedAuthorizer) buildDesiredRelationships(modelID string, exi
 		pluginDynamicRoles: map[string][]string{},
 	}
 	addDesiredRelationship(desired, ProviderModelSentinelRelationship())
+	if markLegacyImported {
+		addDesiredRelationship(desired, ProviderLegacyHumanImportSentinelRelationship())
+	}
 	policyStaticRoles := map[string]map[string]struct{}{}
 	pluginStaticRoles := map[string]map[string]struct{}{}
 	pluginDynamicRoles := map[string]map[string]struct{}{}
 	adminDynamicRoles := map[string]struct{}{}
+	existingDynamicSubjects := map[string]struct{}{}
 
 	for _, rel := range existing {
 		if rel == nil || rel.GetResource() == nil {
@@ -643,6 +650,7 @@ func (a *ProviderBackedAuthorizer) buildDesiredRelationships(modelID string, exi
 				continue
 			}
 			addDesiredRelationship(desired, rel)
+			existingDynamicSubjects[dynamicMembershipSubjectResourceKey(rel.GetSubject(), rel.GetResource())] = struct{}{}
 			ensureRoleSet(pluginDynamicRoles, resourceID)[relation] = struct{}{}
 		case resourceTypeAdminDynamic:
 			resourceID := strings.TrimSpace(rel.GetResource().GetId())
@@ -651,6 +659,7 @@ func (a *ProviderBackedAuthorizer) buildDesiredRelationships(modelID string, exi
 				continue
 			}
 			addDesiredRelationship(desired, rel)
+			existingDynamicSubjects[dynamicMembershipSubjectResourceKey(rel.GetSubject(), rel.GetResource())] = struct{}{}
 			adminDynamicRoles[relation] = struct{}{}
 		}
 	}
@@ -722,70 +731,116 @@ func (a *ProviderBackedAuthorizer) buildDesiredRelationships(modelID string, exi
 		}
 	}
 
-	snapshot := a.currentDynamicSnapshot()
-	for providerName, byUserID := range snapshot.byPluginUserID {
-		providerName = strings.TrimSpace(providerName)
-		if providerName == "" {
-			continue
+	if snapshot != nil {
+		type legacyPluginImport struct {
+			providerName string
+			grant        dynamicGrant
 		}
-		for userID, grant := range byUserID {
-			role := strings.TrimSpace(grant.Role)
-			userID = strings.TrimSpace(userID)
-			if userID == "" || role == "" {
+		pluginImports := map[string]legacyPluginImport{}
+		for providerName, byUserID := range snapshot.byPluginUserID {
+			providerName = strings.TrimSpace(providerName)
+			if providerName == "" {
 				continue
 			}
-			ensureRoleSet(pluginDynamicRoles, providerName)[role] = struct{}{}
-			addDesiredRelationship(desired, &core.Relationship{
-				Subject:  &core.SubjectRef{Type: subjectTypeUser, Id: userID},
-				Relation: role,
-				Resource: &core.ResourceRef{Type: resourceTypePluginDynamic, Id: providerName},
-			})
+			for _, grant := range byUserID {
+				key := strings.Join([]string{
+					providerName,
+					strings.TrimSpace(grant.UserID),
+					normalizeProviderEmail(grant.Email),
+				}, "\x00")
+				pluginImports[key] = legacyPluginImport{providerName: providerName, grant: grant}
+			}
 		}
-	}
-	for providerName, byEmail := range snapshot.byPluginEmail {
-		providerName = strings.TrimSpace(providerName)
-		if providerName == "" {
-			continue
-		}
-		for email, grant := range byEmail {
-			role := strings.TrimSpace(grant.Role)
-			email = normalizeProviderEmail(email)
-			if email == "" || role == "" {
+		for providerName, byEmail := range snapshot.byPluginEmail {
+			providerName = strings.TrimSpace(providerName)
+			if providerName == "" {
 				continue
 			}
-			ensureRoleSet(pluginDynamicRoles, providerName)[role] = struct{}{}
-			addDesiredRelationship(desired, &core.Relationship{
-				Subject:  &core.SubjectRef{Type: subjectTypeEmail, Id: email},
-				Relation: role,
-				Resource: &core.ResourceRef{Type: resourceTypePluginDynamic, Id: providerName},
-			})
+			for _, grant := range byEmail {
+				key := strings.Join([]string{
+					providerName,
+					strings.TrimSpace(grant.UserID),
+					normalizeProviderEmail(grant.Email),
+				}, "\x00")
+				pluginImports[key] = legacyPluginImport{providerName: providerName, grant: grant}
+			}
 		}
-	}
-	for userID, grant := range snapshot.adminByUserID {
-		role := strings.TrimSpace(grant.Role)
-		userID = strings.TrimSpace(userID)
-		if userID == "" || role == "" {
-			continue
+		for _, item := range pluginImports {
+			role := strings.TrimSpace(item.grant.Role)
+			userID := strings.TrimSpace(item.grant.UserID)
+			email := normalizeProviderEmail(item.grant.Email)
+			if role == "" || (userID == "" && email == "") {
+				continue
+			}
+			keys := dynamicMembershipImportKeys(userID, email, resourceTypePluginDynamic, item.providerName)
+			if dynamicMembershipKeysPresent(existingDynamicSubjects, keys...) {
+				continue
+			}
+			for _, key := range keys {
+				existingDynamicSubjects[key] = struct{}{}
+			}
+			ensureRoleSet(pluginDynamicRoles, item.providerName)[role] = struct{}{}
+			if userID != "" {
+				addDesiredRelationship(desired, &core.Relationship{
+					Subject:  &core.SubjectRef{Type: subjectTypeUser, Id: userID},
+					Relation: role,
+					Resource: &core.ResourceRef{Type: resourceTypePluginDynamic, Id: item.providerName},
+				})
+			}
+			if email != "" {
+				addDesiredRelationship(desired, &core.Relationship{
+					Subject:  &core.SubjectRef{Type: subjectTypeEmail, Id: email},
+					Relation: role,
+					Resource: &core.ResourceRef{Type: resourceTypePluginDynamic, Id: item.providerName},
+				})
+			}
 		}
-		adminDynamicRoles[role] = struct{}{}
-		addDesiredRelationship(desired, &core.Relationship{
-			Subject:  &core.SubjectRef{Type: subjectTypeUser, Id: userID},
-			Relation: role,
-			Resource: &core.ResourceRef{Type: resourceTypeAdminDynamic, Id: resourceIDAdminDynamicGlobal},
-		})
-	}
-	for email, grant := range snapshot.adminByEmail {
-		role := strings.TrimSpace(grant.Role)
-		email = normalizeProviderEmail(email)
-		if email == "" || role == "" {
-			continue
+
+		adminImports := map[string]dynamicGrant{}
+		for _, grant := range snapshot.adminByUserID {
+			key := strings.Join([]string{
+				strings.TrimSpace(grant.UserID),
+				normalizeProviderEmail(grant.Email),
+			}, "\x00")
+			adminImports[key] = grant
 		}
-		adminDynamicRoles[role] = struct{}{}
-		addDesiredRelationship(desired, &core.Relationship{
-			Subject:  &core.SubjectRef{Type: subjectTypeEmail, Id: email},
-			Relation: role,
-			Resource: &core.ResourceRef{Type: resourceTypeAdminDynamic, Id: resourceIDAdminDynamicGlobal},
-		})
+		for _, grant := range snapshot.adminByEmail {
+			key := strings.Join([]string{
+				strings.TrimSpace(grant.UserID),
+				normalizeProviderEmail(grant.Email),
+			}, "\x00")
+			adminImports[key] = grant
+		}
+		for _, grant := range adminImports {
+			role := strings.TrimSpace(grant.Role)
+			userID := strings.TrimSpace(grant.UserID)
+			email := normalizeProviderEmail(grant.Email)
+			if role == "" || (userID == "" && email == "") {
+				continue
+			}
+			keys := dynamicMembershipImportKeys(userID, email, resourceTypeAdminDynamic, resourceIDAdminDynamicGlobal)
+			if dynamicMembershipKeysPresent(existingDynamicSubjects, keys...) {
+				continue
+			}
+			for _, key := range keys {
+				existingDynamicSubjects[key] = struct{}{}
+			}
+			adminDynamicRoles[role] = struct{}{}
+			if userID != "" {
+				addDesiredRelationship(desired, &core.Relationship{
+					Subject:  &core.SubjectRef{Type: subjectTypeUser, Id: userID},
+					Relation: role,
+					Resource: &core.ResourceRef{Type: resourceTypeAdminDynamic, Id: resourceIDAdminDynamicGlobal},
+				})
+			}
+			if email != "" {
+				addDesiredRelationship(desired, &core.Relationship{
+					Subject:  &core.SubjectRef{Type: subjectTypeEmail, Id: email},
+					Relation: role,
+					Resource: &core.ResourceRef{Type: resourceTypeAdminDynamic, Id: resourceIDAdminDynamicGlobal},
+				})
+			}
+		}
 	}
 
 	for name, roles := range policyStaticRoles {
@@ -868,6 +923,50 @@ func roleSortKey(role string) string {
 	default:
 		return "9:" + strings.TrimSpace(role)
 	}
+}
+
+func dynamicMembershipSubjectResourceKey(subject *core.SubjectRef, resource *core.ResourceRef) string {
+	if subject == nil || resource == nil {
+		return ""
+	}
+	return dynamicMembershipKey(
+		strings.TrimSpace(subject.GetType()),
+		strings.TrimSpace(subject.GetId()),
+		strings.TrimSpace(resource.GetType()),
+		strings.TrimSpace(resource.GetId()),
+	)
+}
+
+func dynamicMembershipKey(subjectType, subjectID, resourceType, resourceID string) string {
+	return strings.Join([]string{
+		strings.TrimSpace(subjectType),
+		strings.TrimSpace(subjectID),
+		strings.TrimSpace(resourceType),
+		strings.TrimSpace(resourceID),
+	}, "\x00")
+}
+
+func dynamicMembershipImportKeys(userID, email, resourceType, resourceID string) []string {
+	keys := make([]string, 0, 2)
+	if userID = strings.TrimSpace(userID); userID != "" {
+		keys = append(keys, dynamicMembershipKey(subjectTypeUser, userID, resourceType, resourceID))
+	}
+	if email = normalizeProviderEmail(email); email != "" {
+		keys = append(keys, dynamicMembershipKey(subjectTypeEmail, email, resourceType, resourceID))
+	}
+	return keys
+}
+
+func dynamicMembershipKeysPresent(existing map[string]struct{}, keys ...string) bool {
+	for _, key := range keys {
+		if key == "" {
+			continue
+		}
+		if _, ok := existing[key]; ok {
+			return true
+		}
+	}
+	return false
 }
 
 func staticSubjectRefs(p *principal.Principal) []*core.SubjectRef {

--- a/gestaltd/internal/authorization/provider_schema.go
+++ b/gestaltd/internal/authorization/provider_schema.go
@@ -30,6 +30,10 @@ subjects:
 	ProviderModelSentinelRelation   = "managed"
 	ProviderModelSentinelSubjectID  = "gestalt:authorization"
 	ProviderModelSentinelResourceID = "__gestalt_authorization_model__"
+
+	ProviderLegacyHumanImportSentinelRelation   = "managed"
+	ProviderLegacyHumanImportSentinelSubjectID  = "gestalt:authorization"
+	ProviderLegacyHumanImportSentinelResourceID = "__gestalt_legacy_human_import_v1__"
 )
 
 const (
@@ -86,4 +90,18 @@ func IsProviderModelSentinelRelationship(rel *core.Relationship) bool {
 		rel.GetRelation() == ProviderModelSentinelRelation &&
 		rel.GetResource().GetType() == ProviderResourceTypePolicyStatic &&
 		rel.GetResource().GetId() == ProviderModelSentinelResourceID
+}
+
+func ProviderLegacyHumanImportSentinelRelationship() *core.Relationship {
+	return &core.Relationship{
+		Subject: &core.SubjectRef{
+			Type: ProviderSubjectTypeSubject,
+			Id:   ProviderLegacyHumanImportSentinelSubjectID,
+		},
+		Relation: ProviderLegacyHumanImportSentinelRelation,
+		Resource: &core.ResourceRef{
+			Type: ProviderResourceTypePolicyStatic,
+			Id:   ProviderLegacyHumanImportSentinelResourceID,
+		},
+	}
 }

--- a/gestaltd/internal/bootstrap/authorization_canonical_sync.go
+++ b/gestaltd/internal/bootstrap/authorization_canonical_sync.go
@@ -1,0 +1,280 @@
+package bootstrap
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"strings"
+
+	"github.com/valon-technologies/gestalt/server/core"
+	"github.com/valon-technologies/gestalt/server/internal/authorization"
+	"github.com/valon-technologies/gestalt/server/internal/coredata"
+)
+
+const providerCanonicalSyncReadPageSize = 500
+
+type managedAuthorizationModelResolver interface {
+	ManagedModelID(ctx context.Context) (string, error)
+}
+
+func syncProviderBackedHumanCanonicalState(ctx context.Context, services *coredata.Services, authorizer authorization.RuntimeAuthorizer, provider core.AuthorizationProvider) error {
+	if services == nil || provider == nil || services.Users == nil {
+		return nil
+	}
+
+	modelID, err := providerBackedModelID(ctx, authorizer, provider)
+	if err != nil {
+		return err
+	}
+	if strings.TrimSpace(modelID) == "" {
+		return nil
+	}
+
+	relationships, err := readAllAuthorizationRelationships(ctx, provider, modelID)
+	if err != nil {
+		return err
+	}
+
+	desiredPluginAccess := map[string]map[string]struct{}{}
+	desiredWorkspaceRoles := map[string]map[string]struct{}{}
+	candidateIdentityIDs := map[string]struct{}{}
+
+	for _, rel := range relationships {
+		if rel == nil || rel.GetSubject() == nil || rel.GetResource() == nil {
+			continue
+		}
+		identityID, err := providerRelationshipIdentityID(ctx, services.Users, rel.GetSubject())
+		switch {
+		case err == nil:
+		case errors.Is(err, core.ErrNotFound):
+			continue
+		default:
+			return err
+		}
+		if identityID == "" {
+			continue
+		}
+		candidateIdentityIDs[identityID] = struct{}{}
+
+		switch strings.TrimSpace(rel.GetResource().GetType()) {
+		case authorization.ProviderResourceTypePluginDynamic:
+			plugin := strings.TrimSpace(rel.GetResource().GetId())
+			if plugin == "" {
+				continue
+			}
+			ensureStringSet(desiredPluginAccess, identityID)[plugin] = struct{}{}
+		case authorization.ProviderResourceTypeAdminDynamic:
+			if strings.TrimSpace(rel.GetResource().GetId()) != authorization.ProviderResourceIDAdminDynamicGlobal {
+				continue
+			}
+			role := strings.TrimSpace(rel.GetRelation())
+			if role == "" {
+				continue
+			}
+			ensureStringSet(desiredWorkspaceRoles, identityID)[role] = struct{}{}
+		}
+	}
+
+	if services.PluginAuthorizations != nil {
+		memberships, err := services.PluginAuthorizations.ListPluginAuthorizations(ctx)
+		if err != nil {
+			return fmt.Errorf("list legacy plugin authorizations for canonical sync: %w", err)
+		}
+		for _, membership := range memberships {
+			identityID, err := legacyMembershipIdentityID(ctx, services.Users, membership.UserID, membership.Email)
+			switch {
+			case err == nil:
+				if identityID != "" {
+					candidateIdentityIDs[identityID] = struct{}{}
+				}
+			case errors.Is(err, core.ErrNotFound):
+			default:
+				return err
+			}
+		}
+	}
+
+	if services.AdminAuthorizations != nil {
+		memberships, err := services.AdminAuthorizations.ListAdminAuthorizations(ctx)
+		if err != nil {
+			return fmt.Errorf("list legacy admin authorizations for canonical sync: %w", err)
+		}
+		for _, membership := range memberships {
+			identityID, err := legacyMembershipIdentityID(ctx, services.Users, membership.UserID, membership.Email)
+			switch {
+			case err == nil:
+				if identityID != "" {
+					candidateIdentityIDs[identityID] = struct{}{}
+				}
+			case errors.Is(err, core.ErrNotFound):
+			default:
+				return err
+			}
+		}
+	}
+
+	for identityID := range candidateIdentityIDs {
+		if err := reconcileProviderPluginCanonicalAccess(ctx, services.IdentityPluginAccess, identityID, desiredPluginAccess[identityID]); err != nil {
+			return err
+		}
+		if err := reconcileProviderWorkspaceRoles(ctx, services.WorkspaceRoles, identityID, desiredWorkspaceRoles[identityID]); err != nil {
+			return err
+		}
+	}
+
+	return nil
+}
+
+func providerBackedModelID(ctx context.Context, authorizer authorization.RuntimeAuthorizer, provider core.AuthorizationProvider) (string, error) {
+	if resolver, ok := authorizer.(managedAuthorizationModelResolver); ok {
+		modelID, err := resolver.ManagedModelID(ctx)
+		if err != nil {
+			return "", err
+		}
+		return strings.TrimSpace(modelID), nil
+	}
+
+	active, err := provider.GetActiveModel(ctx)
+	if err != nil {
+		return "", fmt.Errorf("get active authorization model: %w", err)
+	}
+	if model := active.GetModel(); model != nil {
+		return strings.TrimSpace(model.GetId()), nil
+	}
+	return "", nil
+}
+
+func readAllAuthorizationRelationships(ctx context.Context, provider core.AuthorizationProvider, modelID string) ([]*core.Relationship, error) {
+	pageToken := ""
+	var out []*core.Relationship
+	for {
+		resp, err := provider.ReadRelationships(ctx, &core.ReadRelationshipsRequest{
+			PageSize:  providerCanonicalSyncReadPageSize,
+			PageToken: pageToken,
+			ModelId:   modelID,
+		})
+		if err != nil {
+			return nil, fmt.Errorf("read authorization relationships for canonical sync: %w", err)
+		}
+		out = append(out, resp.GetRelationships()...)
+		pageToken = strings.TrimSpace(resp.GetNextPageToken())
+		if pageToken == "" {
+			return out, nil
+		}
+	}
+}
+
+func providerRelationshipIdentityID(ctx context.Context, users *coredata.UserService, subject *core.SubjectRef) (string, error) {
+	if users == nil || subject == nil {
+		return "", core.ErrNotFound
+	}
+	switch strings.TrimSpace(subject.GetType()) {
+	case authorization.ProviderSubjectTypeUser:
+		return users.CanonicalIdentityIDForUser(ctx, strings.TrimSpace(subject.GetId()))
+	case authorization.ProviderSubjectTypeEmail:
+		user, err := users.FindUserByEmail(ctx, strings.TrimSpace(subject.GetId()))
+		if err != nil {
+			return "", err
+		}
+		return users.CanonicalIdentityIDForUser(ctx, user.ID)
+	default:
+		return "", core.ErrNotFound
+	}
+}
+
+func legacyMembershipIdentityID(ctx context.Context, users *coredata.UserService, userID, email string) (string, error) {
+	if users == nil {
+		return "", core.ErrNotFound
+	}
+	if userID = strings.TrimSpace(userID); userID != "" {
+		return users.CanonicalIdentityIDForUser(ctx, userID)
+	}
+	if email = strings.TrimSpace(email); email != "" {
+		user, err := users.FindUserByEmail(ctx, email)
+		if err != nil {
+			return "", err
+		}
+		return users.CanonicalIdentityIDForUser(ctx, user.ID)
+	}
+	return "", core.ErrNotFound
+}
+
+func reconcileProviderPluginCanonicalAccess(ctx context.Context, svc *coredata.IdentityPluginAccessService, identityID string, desired map[string]struct{}) error {
+	if svc == nil || strings.TrimSpace(identityID) == "" {
+		return nil
+	}
+
+	existing, err := svc.ListByIdentity(ctx, identityID)
+	if err != nil {
+		return err
+	}
+
+	for plugin := range desired {
+		if _, err := svc.UpsertAccess(ctx, &core.IdentityPluginAccess{
+			IdentityID:          identityID,
+			Plugin:              plugin,
+			InvokeAllOperations: true,
+		}); err != nil {
+			return fmt.Errorf("sync provider-backed plugin access %q/%q: %w", identityID, plugin, err)
+		}
+	}
+
+	for _, access := range existing {
+		if access == nil {
+			continue
+		}
+		plugin := strings.TrimSpace(access.Plugin)
+		if _, ok := desired[plugin]; ok {
+			continue
+		}
+		if err := svc.DeleteAccess(ctx, identityID, plugin); err != nil && !errors.Is(err, core.ErrNotFound) {
+			return fmt.Errorf("delete stale provider-backed plugin access %q/%q: %w", identityID, plugin, err)
+		}
+	}
+
+	return nil
+}
+
+func reconcileProviderWorkspaceRoles(ctx context.Context, svc *coredata.WorkspaceRoleService, identityID string, desired map[string]struct{}) error {
+	if svc == nil || strings.TrimSpace(identityID) == "" {
+		return nil
+	}
+
+	existing, err := svc.ListByIdentity(ctx, identityID)
+	if err != nil {
+		return err
+	}
+
+	for role := range desired {
+		if _, err := svc.UpsertRole(ctx, &core.WorkspaceRole{
+			IdentityID: identityID,
+			Role:       role,
+		}); err != nil {
+			return fmt.Errorf("sync provider-backed workspace role %q/%q: %w", identityID, role, err)
+		}
+	}
+
+	for _, role := range existing {
+		if role == nil {
+			continue
+		}
+		name := strings.TrimSpace(role.Role)
+		if _, ok := desired[name]; ok {
+			continue
+		}
+		if err := svc.DeleteRole(ctx, identityID, name); err != nil && !errors.Is(err, core.ErrNotFound) {
+			return fmt.Errorf("delete stale provider-backed workspace role %q/%q: %w", identityID, name, err)
+		}
+	}
+
+	return nil
+}
+
+func ensureStringSet(target map[string]map[string]struct{}, key string) map[string]struct{} {
+	values := target[key]
+	if values == nil {
+		values = map[string]struct{}{}
+		target[key] = values
+	}
+	return values
+}

--- a/gestaltd/internal/bootstrap/bootstrap.go
+++ b/gestaltd/internal/bootstrap/bootstrap.go
@@ -209,6 +209,9 @@ func (r *Result) Start(ctx context.Context) error {
 			return err
 		}
 	}
+	if err := syncProviderBackedHumanCanonicalState(ctx, r.Services, r.Authorizer, r.AuthorizationProvider); err != nil {
+		return err
+	}
 	return nil
 }
 

--- a/gestaltd/internal/bootstrap/bootstrap_test.go
+++ b/gestaltd/internal/bootstrap/bootstrap_test.go
@@ -3510,6 +3510,26 @@ func TestBootstrapSecretResolution(t *testing.T) {
 		}
 		t.Cleanup(func() { _ = result.Close(context.Background()) })
 		<-result.ProvidersReady
+		dynamicUser, err := result.Services.Users.FindOrCreateUser(ctx, "dynamic@example.test")
+		if err != nil {
+			t.Fatalf("FindOrCreateUser(dynamic): %v", err)
+		}
+		if _, err := result.Services.PluginAuthorizations.UpsertPluginAuthorization(ctx, &coredata.PluginAuthorizationMembership{
+			Plugin: "calendar",
+			UserID: dynamicUser.ID,
+			Email:  dynamicUser.Email,
+			Role:   "editor",
+		}); err != nil {
+			t.Fatalf("UpsertPluginAuthorization: %v", err)
+		}
+		if _, err := result.Services.AdminAuthorizations.UpsertAdminAuthorization(ctx, &coredata.AdminAuthorizationMembership{
+			UserID: dynamicUser.ID,
+			Email:  dynamicUser.Email,
+			Role:   "admin",
+		}); err != nil {
+			t.Fatalf("UpsertAdminAuthorization: %v", err)
+		}
+
 		if err := result.Start(ctx); err != nil {
 			t.Fatalf("Start: %v", err)
 		}
@@ -3535,29 +3555,6 @@ func TestBootstrapSecretResolution(t *testing.T) {
 			t.Fatalf("static plugin role = %q, want %q", access.Role, "viewer")
 		}
 
-		dynamicUser, err := result.Services.Users.FindOrCreateUser(ctx, "dynamic@example.test")
-		if err != nil {
-			t.Fatalf("FindOrCreateUser(dynamic): %v", err)
-		}
-		if _, err := result.Services.PluginAuthorizations.UpsertPluginAuthorization(ctx, &coredata.PluginAuthorizationMembership{
-			Plugin: "calendar",
-			UserID: dynamicUser.ID,
-			Email:  dynamicUser.Email,
-			Role:   "editor",
-		}); err != nil {
-			t.Fatalf("UpsertPluginAuthorization: %v", err)
-		}
-		if _, err := result.Services.AdminAuthorizations.UpsertAdminAuthorization(ctx, &coredata.AdminAuthorizationMembership{
-			UserID: dynamicUser.ID,
-			Email:  dynamicUser.Email,
-			Role:   "admin",
-		}); err != nil {
-			t.Fatalf("UpsertAdminAuthorization: %v", err)
-		}
-		if err := result.Authorizer.ReloadDynamic(ctx); err != nil {
-			t.Fatalf("ReloadDynamic: %v", err)
-		}
-
 		dynamicPrincipal := &principal.Principal{
 			UserID:    dynamicUser.ID,
 			SubjectID: principal.UserSubjectID(dynamicUser.ID),
@@ -3578,6 +3575,41 @@ func TestBootstrapSecretResolution(t *testing.T) {
 		}
 		if adminAccess.Role != "admin" {
 			t.Fatalf("dynamic admin role = %q, want %q", adminAccess.Role, "admin")
+		}
+
+		if _, err := result.Services.PluginAuthorizations.UpsertPluginAuthorization(ctx, &coredata.PluginAuthorizationMembership{
+			Plugin: "calendar",
+			UserID: dynamicUser.ID,
+			Email:  dynamicUser.Email,
+			Role:   "viewer",
+		}); err != nil {
+			t.Fatalf("UpsertPluginAuthorization(update): %v", err)
+		}
+		if _, err := result.Services.AdminAuthorizations.UpsertAdminAuthorization(ctx, &coredata.AdminAuthorizationMembership{
+			UserID: dynamicUser.ID,
+			Email:  dynamicUser.Email,
+			Role:   "operator",
+		}); err != nil {
+			t.Fatalf("UpsertAdminAuthorization(update): %v", err)
+		}
+		if err := result.Authorizer.ReloadDynamic(ctx); err != nil {
+			t.Fatalf("ReloadDynamic after mutating legacy authorizations: %v", err)
+		}
+
+		access, allowed = result.Authorizer.ResolveAccess(ctx, dynamicPrincipal, "calendar")
+		if !allowed {
+			t.Fatal("expected provider-backed plugin access to ignore later legacy mutations")
+		}
+		if access.Role != "editor" {
+			t.Fatalf("provider-backed plugin role after legacy mutation = %q, want %q", access.Role, "editor")
+		}
+
+		adminAccess, allowed = result.Authorizer.ResolveAdminAccess(ctx, dynamicPrincipal, "admin-policy")
+		if !allowed {
+			t.Fatal("expected provider-backed admin access to ignore later legacy mutations")
+		}
+		if adminAccess.Role != "admin" {
+			t.Fatalf("provider-backed admin role after legacy mutation = %q, want %q", adminAccess.Role, "admin")
 		}
 
 		if err := result.Services.PluginAuthorizations.DeletePluginAuthorization(ctx, "calendar", dynamicUser.ID); err != nil {
@@ -3604,6 +3636,238 @@ func TestBootstrapSecretResolution(t *testing.T) {
 		}
 		if adminAccess.Role != "admin" {
 			t.Fatalf("provider-backed admin role after legacy deletion = %q, want %q", adminAccess.Role, "admin")
+		}
+	})
+
+	t.Run("authorization provider rehydrates human canonical state on restart", func(t *testing.T) {
+		t.Parallel()
+
+		cfg := validConfig()
+		cfg.Authorization = config.AuthorizationConfig{
+			Policies: map[string]config.HumanPolicyDef{
+				"calendar-policy": {Default: "deny"},
+				"admin-policy":    {Default: "deny"},
+			},
+		}
+		cfg.Server.Admin.AuthorizationPolicy = "admin-policy"
+		cfg.Plugins = map[string]*config.ProviderEntry{
+			"calendar": {
+				AuthorizationPolicy: "calendar-policy",
+				ResolvedManifest: &providermanifestv1.Manifest{
+					Spec: &providermanifestv1.Spec{},
+				},
+			},
+		}
+		cfg.Providers.Authorization = map[string]*config.ProviderEntry{
+			"indexeddb": {Source: config.ProviderSource{Path: "stub"}},
+		}
+		cfg.Server.Providers.Authorization = "indexeddb"
+
+		db := &coretesting.StubIndexedDB{}
+		provider := newMemoryAuthorizationProvider("memory-authorization")
+		provider.models = []*core.AuthorizationModelRef{{
+			Id:      "model-existing",
+			Version: "v1",
+		}}
+		provider.activeModelID = "model-existing"
+		provider.relsByModel["model-existing"] = map[string]*core.Relationship{}
+		provider.putRelationship("model-existing", authorization.ProviderModelSentinelRelationship())
+
+		factories := validFactories()
+		factories.IndexedDB = func(yaml.Node) (indexeddb.IndexedDB, error) {
+			return db, nil
+		}
+		factories.Authorization = memoryAuthorizationFactory(provider)
+
+		result, err := bootstrap.Bootstrap(ctx, cfg, factories)
+		if err != nil {
+			t.Fatalf("Bootstrap(first): %v", err)
+		}
+		<-result.ProvidersReady
+
+		dynamicUser, err := result.Services.Users.FindOrCreateUser(ctx, "dynamic@example.test")
+		if err != nil {
+			t.Fatalf("FindOrCreateUser(dynamic): %v", err)
+		}
+		if _, err := result.Services.PluginAuthorizations.UpsertPluginAuthorization(ctx, &coredata.PluginAuthorizationMembership{
+			Plugin: "calendar",
+			UserID: dynamicUser.ID,
+			Email:  dynamicUser.Email,
+			Role:   "editor",
+		}); err != nil {
+			t.Fatalf("UpsertPluginAuthorization: %v", err)
+		}
+		if _, err := result.Services.AdminAuthorizations.UpsertAdminAuthorization(ctx, &coredata.AdminAuthorizationMembership{
+			UserID: dynamicUser.ID,
+			Email:  dynamicUser.Email,
+			Role:   "admin",
+		}); err != nil {
+			t.Fatalf("UpsertAdminAuthorization: %v", err)
+		}
+		if err := result.Start(ctx); err != nil {
+			t.Fatalf("Start(first): %v", err)
+		}
+
+		if err := result.Services.PluginAuthorizations.DeletePluginAuthorization(ctx, "calendar", dynamicUser.ID); err != nil {
+			t.Fatalf("DeletePluginAuthorization: %v", err)
+		}
+		if err := result.Services.AdminAuthorizations.DeleteAdminAuthorization(ctx, dynamicUser.ID); err != nil {
+			t.Fatalf("DeleteAdminAuthorization: %v", err)
+		}
+		if err := result.Close(context.Background()); err != nil {
+			t.Fatalf("Close(first): %v", err)
+		}
+
+		result, err = bootstrap.Bootstrap(ctx, cfg, factories)
+		if err != nil {
+			t.Fatalf("Bootstrap(second): %v", err)
+		}
+		t.Cleanup(func() { _ = result.Close(context.Background()) })
+		<-result.ProvidersReady
+		if err := result.Start(ctx); err != nil {
+			t.Fatalf("Start(second): %v", err)
+		}
+
+		dynamicPrincipal := &principal.Principal{
+			UserID:    dynamicUser.ID,
+			SubjectID: principal.UserSubjectID(dynamicUser.ID),
+			Identity:  &core.UserIdentity{Email: dynamicUser.Email},
+			Kind:      principal.KindUser,
+		}
+		access, allowed := result.Authorizer.ResolveAccess(ctx, dynamicPrincipal, "calendar")
+		if !allowed {
+			t.Fatal("expected provider-backed plugin access after restart")
+		}
+		if access.Role != "editor" {
+			t.Fatalf("provider-backed plugin role after restart = %q, want %q", access.Role, "editor")
+		}
+
+		adminAccess, allowed := result.Authorizer.ResolveAdminAccess(ctx, dynamicPrincipal, "admin-policy")
+		if !allowed {
+			t.Fatal("expected provider-backed admin access after restart")
+		}
+		if adminAccess.Role != "admin" {
+			t.Fatalf("provider-backed admin role after restart = %q, want %q", adminAccess.Role, "admin")
+		}
+
+		canonicalIdentityID, err := result.Services.Users.CanonicalIdentityIDForUser(ctx, dynamicUser.ID)
+		if err != nil {
+			t.Fatalf("CanonicalIdentityIDForUser: %v", err)
+		}
+		pluginAccess, err := result.Services.IdentityPluginAccess.GetAccess(ctx, canonicalIdentityID, "calendar")
+		if err != nil {
+			t.Fatalf("GetAccess(calendar): %v", err)
+		}
+		if !pluginAccess.InvokeAllOperations {
+			t.Fatal("expected restart rehydrate to restore invoke-all plugin access")
+		}
+		roles, err := result.Services.WorkspaceRoles.ListByPrincipal(ctx, canonicalIdentityID)
+		if err != nil {
+			t.Fatalf("ListByPrincipal: %v", err)
+		}
+		if len(roles) != 1 || roles[0].Role != "admin" {
+			t.Fatalf("workspace roles after restart = %+v, want [admin]", roles)
+		}
+	})
+
+	t.Run("authorization provider migration preserves existing provider dynamic roles", func(t *testing.T) {
+		t.Parallel()
+
+		cfg := validConfig()
+		cfg.Authorization = config.AuthorizationConfig{
+			Policies: map[string]config.HumanPolicyDef{
+				"calendar-policy": {Default: "deny"},
+				"admin-policy":    {Default: "deny"},
+			},
+		}
+		cfg.Server.Admin.AuthorizationPolicy = "admin-policy"
+		cfg.Plugins = map[string]*config.ProviderEntry{
+			"calendar": {
+				AuthorizationPolicy: "calendar-policy",
+				ResolvedManifest: &providermanifestv1.Manifest{
+					Spec: &providermanifestv1.Spec{},
+				},
+			},
+		}
+		cfg.Providers.Authorization = map[string]*config.ProviderEntry{
+			"indexeddb": {Source: config.ProviderSource{Path: "stub"}},
+		}
+		cfg.Server.Providers.Authorization = "indexeddb"
+
+		provider := newMemoryAuthorizationProvider("memory-authorization")
+		provider.models = []*core.AuthorizationModelRef{{
+			Id:      "model-existing",
+			Version: "v1",
+		}}
+		provider.activeModelID = "model-existing"
+		provider.relsByModel["model-existing"] = map[string]*core.Relationship{}
+		provider.putRelationship("model-existing", authorization.ProviderModelSentinelRelationship())
+
+		factories := validFactories()
+		factories.Authorization = memoryAuthorizationFactory(provider)
+
+		result, err := bootstrap.Bootstrap(ctx, cfg, factories)
+		if err != nil {
+			t.Fatalf("Bootstrap: %v", err)
+		}
+		t.Cleanup(func() { _ = result.Close(context.Background()) })
+		<-result.ProvidersReady
+
+		dynamicUser, err := result.Services.Users.FindOrCreateUser(ctx, "dynamic@example.test")
+		if err != nil {
+			t.Fatalf("FindOrCreateUser(dynamic): %v", err)
+		}
+		provider.putRelationship("model-existing", &core.Relationship{
+			Subject:  &core.SubjectRef{Type: authorization.ProviderSubjectTypeEmail, Id: dynamicUser.Email},
+			Relation: "viewer",
+			Resource: &core.ResourceRef{Type: authorization.ProviderResourceTypePluginDynamic, Id: "calendar"},
+		})
+		provider.putRelationship("model-existing", &core.Relationship{
+			Subject:  &core.SubjectRef{Type: authorization.ProviderSubjectTypeEmail, Id: dynamicUser.Email},
+			Relation: "operator",
+			Resource: &core.ResourceRef{Type: authorization.ProviderResourceTypeAdminDynamic, Id: authorization.ProviderResourceIDAdminDynamicGlobal},
+		})
+
+		if _, err := result.Services.PluginAuthorizations.UpsertPluginAuthorization(ctx, &coredata.PluginAuthorizationMembership{
+			Plugin: "calendar",
+			UserID: dynamicUser.ID,
+			Email:  dynamicUser.Email,
+			Role:   "editor",
+		}); err != nil {
+			t.Fatalf("UpsertPluginAuthorization: %v", err)
+		}
+		if _, err := result.Services.AdminAuthorizations.UpsertAdminAuthorization(ctx, &coredata.AdminAuthorizationMembership{
+			UserID: dynamicUser.ID,
+			Email:  dynamicUser.Email,
+			Role:   "admin",
+		}); err != nil {
+			t.Fatalf("UpsertAdminAuthorization: %v", err)
+		}
+
+		if err := result.Start(ctx); err != nil {
+			t.Fatalf("Start: %v", err)
+		}
+
+		dynamicPrincipal := &principal.Principal{
+			UserID:    dynamicUser.ID,
+			SubjectID: principal.UserSubjectID(dynamicUser.ID),
+			Identity:  &core.UserIdentity{Email: dynamicUser.Email},
+			Kind:      principal.KindUser,
+		}
+		access, allowed := result.Authorizer.ResolveAccess(ctx, dynamicPrincipal, "calendar")
+		if !allowed {
+			t.Fatal("expected provider-backed plugin access to be allowed")
+		}
+		if access.Role != "viewer" {
+			t.Fatalf("provider-backed plugin role after migration = %q, want %q", access.Role, "viewer")
+		}
+
+		adminAccess, allowed := result.Authorizer.ResolveAdminAccess(ctx, dynamicPrincipal, "admin-policy")
+		if !allowed {
+			t.Fatal("expected provider-backed admin access to be allowed")
+		}
+		if adminAccess.Role != "operator" {
+			t.Fatalf("provider-backed admin role after migration = %q, want %q", adminAccess.Role, "operator")
 		}
 	})
 

--- a/gestaltd/internal/server/handlers_admin_authorization.go
+++ b/gestaltd/internal/server/handlers_admin_authorization.go
@@ -714,6 +714,9 @@ func (s *Server) ensureAdminDynamicAuthorizationAvailable(w http.ResponseWriter)
 }
 
 func (s *Server) ensureAdminDynamicAuthorizationWriteAvailable(w http.ResponseWriter) bool {
+	if s.authorizationProvider != nil {
+		return true
+	}
 	if s.pluginAuthorizations == nil || s.authorizer == nil || !s.authorizer.HasDynamicPluginAuthorizations() {
 		writeError(w, http.StatusServiceUnavailable, "dynamic authorization writes are unavailable")
 		return false
@@ -754,6 +757,9 @@ func (s *Server) ensureAdminDynamicAdminAvailable(w http.ResponseWriter) bool {
 }
 
 func (s *Server) ensureAdminDynamicAdminWriteAvailable(w http.ResponseWriter) bool {
+	if s.authorizationProvider != nil {
+		return true
+	}
 	if s.adminAuthorizations == nil || s.authorizer == nil || !s.authorizer.HasDynamicAdminAuthorizations() {
 		writeError(w, http.StatusServiceUnavailable, "dynamic admin authorization writes are unavailable")
 		return false

--- a/gestaltd/internal/server/handlers_admin_authorization_provider_write.go
+++ b/gestaltd/internal/server/handlers_admin_authorization_provider_write.go
@@ -27,17 +27,17 @@ func (s *Server) upsertProviderPluginAuthorization(ctx context.Context, user *co
 		Type: authorization.ProviderResourceTypePluginDynamic,
 		Id:   strings.TrimSpace(plugin),
 	}
-	rollback, err := s.replaceProviderDynamicMembership(ctx, resource, user, strings.TrimSpace(role))
+	_, rollback, err := s.replaceProviderDynamicMembership(ctx, resource, user, strings.TrimSpace(role))
 	if err != nil {
 		return nil, err
 	}
-	membership, err := s.pluginAuthorizations.UpsertPluginAuthorization(ctx, &coredata.PluginAuthorizationMembership{
+	membership := &coredata.PluginAuthorizationMembership{
 		Plugin: plugin,
 		UserID: user.ID,
 		Email:  user.Email,
 		Role:   role,
-	})
-	if err != nil {
+	}
+	if err := s.syncProviderPluginCanonicalAccess(ctx, membership.UserID, membership.Plugin); err != nil {
 		rollback(ctx)
 		return nil, err
 	}
@@ -60,21 +60,26 @@ func (s *Server) deleteProviderPluginAuthorization(ctx context.Context, plugin, 
 		Type: authorization.ProviderResourceTypePluginDynamic,
 		Id:   strings.TrimSpace(plugin),
 	}
-	rollback, err := s.deleteProviderDynamicMembership(ctx, resource, subjectUser)
+	existing, rollback, err := s.deleteProviderDynamicMembership(ctx, resource, subjectUser)
 	if err != nil {
 		return err
 	}
-	err = s.pluginAuthorizations.DeletePluginAuthorization(ctx, plugin, userID)
+	err = s.deleteProviderPluginCanonicalAccess(ctx, strings.TrimSpace(userID), strings.TrimSpace(plugin))
 	switch {
 	case err == nil:
+		if len(existing) == 0 {
+			return core.ErrNotFound
+		}
 		return nil
 	case errors.Is(err, core.ErrNotFound):
-		if rollback == nil {
+		if len(existing) == 0 {
 			return core.ErrNotFound
 		}
 		return nil
 	default:
-		rollback(ctx)
+		if rollback != nil {
+			rollback(ctx)
+		}
 		return err
 	}
 }
@@ -90,16 +95,16 @@ func (s *Server) upsertProviderAdminAuthorization(ctx context.Context, user *cor
 		Type: authorization.ProviderResourceTypeAdminDynamic,
 		Id:   authorization.ProviderResourceIDAdminDynamicGlobal,
 	}
-	rollback, err := s.replaceProviderDynamicMembership(ctx, resource, user, strings.TrimSpace(role))
+	existing, rollback, err := s.replaceProviderDynamicMembership(ctx, resource, user, strings.TrimSpace(role))
 	if err != nil {
 		return nil, err
 	}
-	membership, err := s.adminAuthorizations.UpsertAdminAuthorization(ctx, &coredata.AdminAuthorizationMembership{
+	membership := &coredata.AdminAuthorizationMembership{
 		UserID: user.ID,
 		Email:  user.Email,
 		Role:   role,
-	})
-	if err != nil {
+	}
+	if err := s.syncProviderAdminCanonicalRole(ctx, membership.UserID, membership.Role, providerRelationshipRelations(existing)); err != nil {
 		rollback(ctx)
 		return nil, err
 	}
@@ -122,49 +127,54 @@ func (s *Server) deleteProviderAdminAuthorization(ctx context.Context, userID st
 		Type: authorization.ProviderResourceTypeAdminDynamic,
 		Id:   authorization.ProviderResourceIDAdminDynamicGlobal,
 	}
-	rollback, err := s.deleteProviderDynamicMembership(ctx, resource, subjectUser)
+	existing, rollback, err := s.deleteProviderDynamicMembership(ctx, resource, subjectUser)
 	if err != nil {
 		return err
 	}
-	err = s.adminAuthorizations.DeleteAdminAuthorization(ctx, userID)
+	err = s.deleteProviderAdminCanonicalRoles(ctx, strings.TrimSpace(userID), providerRelationshipRelations(existing))
 	switch {
 	case err == nil:
+		if len(existing) == 0 {
+			return core.ErrNotFound
+		}
 		return nil
 	case errors.Is(err, core.ErrNotFound):
-		if rollback == nil {
+		if len(existing) == 0 {
 			return core.ErrNotFound
 		}
 		return nil
 	default:
-		rollback(ctx)
+		if rollback != nil {
+			rollback(ctx)
+		}
 		return err
 	}
 }
 
-func (s *Server) replaceProviderDynamicMembership(ctx context.Context, resource *core.ResourceRef, user *core.User, role string) (func(context.Context), error) {
+func (s *Server) replaceProviderDynamicMembership(ctx context.Context, resource *core.ResourceRef, user *core.User, role string) ([]*core.Relationship, func(context.Context), error) {
 	modelID, err := s.managedAuthorizationModelID(ctx)
 	if err != nil {
-		return nil, err
+		return nil, nil, err
 	}
 	existing, err := s.providerDynamicRelationshipsForUser(ctx, resource, user)
 	if err != nil {
-		return nil, err
+		return nil, nil, err
 	}
 	writes := providerDynamicMembershipRelationships(resource, user, role)
 	deletes := filterRelationshipKeys(existing, writes)
 	if len(writes) == 0 && len(deletes) == 0 {
-		return func(context.Context) {}, nil
+		return existing, func(context.Context) {}, nil
 	}
 	if err := s.authorizationProvider.WriteRelationships(ctx, &core.WriteRelationshipsRequest{
 		Writes:  writes,
 		Deletes: deletes,
 		ModelId: modelID,
 	}); err != nil {
-		return nil, fmt.Errorf("write authorization relationships: %w", err)
+		return nil, nil, fmt.Errorf("write authorization relationships: %w", err)
 	}
 	rollbackDeletes := filterRelationshipKeys(writes, existing)
 	rollbackWrites := cloneRelationships(existing)
-	return func(rollbackCtx context.Context) {
+	return existing, func(rollbackCtx context.Context) {
 		_ = s.authorizationProvider.WriteRelationships(rollbackCtx, &core.WriteRelationshipsRequest{
 			Writes:  rollbackWrites,
 			Deletes: rollbackDeletes,
@@ -173,27 +183,27 @@ func (s *Server) replaceProviderDynamicMembership(ctx context.Context, resource 
 	}, nil
 }
 
-func (s *Server) deleteProviderDynamicMembership(ctx context.Context, resource *core.ResourceRef, user *core.User) (func(context.Context), error) {
+func (s *Server) deleteProviderDynamicMembership(ctx context.Context, resource *core.ResourceRef, user *core.User) ([]*core.Relationship, func(context.Context), error) {
 	modelID, err := s.managedAuthorizationModelID(ctx)
 	if err != nil {
-		return nil, err
+		return nil, nil, err
 	}
 	existing, err := s.providerDynamicRelationshipsForUser(ctx, resource, user)
 	if err != nil {
-		return nil, err
+		return nil, nil, err
 	}
 	deletes := relationshipKeys(existing)
 	if len(deletes) == 0 {
-		return nil, nil
+		return existing, nil, nil
 	}
 	if err := s.authorizationProvider.WriteRelationships(ctx, &core.WriteRelationshipsRequest{
 		Deletes: deletes,
 		ModelId: modelID,
 	}); err != nil {
-		return nil, fmt.Errorf("delete authorization relationships: %w", err)
+		return nil, nil, fmt.Errorf("delete authorization relationships: %w", err)
 	}
 	rollbackWrites := cloneRelationships(existing)
-	return func(rollbackCtx context.Context) {
+	return existing, func(rollbackCtx context.Context) {
 		_ = s.authorizationProvider.WriteRelationships(rollbackCtx, &core.WriteRelationshipsRequest{
 			Writes:  rollbackWrites,
 			ModelId: modelID,
@@ -397,4 +407,136 @@ func cloneResourceRef(resource *core.ResourceRef) *core.ResourceRef {
 		Type: resource.GetType(),
 		Id:   resource.GetId(),
 	}
+}
+
+func (s *Server) syncProviderPluginCanonicalAccess(ctx context.Context, userID, plugin string) error {
+	if s.identityPluginAccess == nil {
+		return nil
+	}
+	identityID, err := s.canonicalIdentityIDForUser(ctx, userID)
+	if err != nil {
+		return err
+	}
+	_, err = s.identityPluginAccess.UpsertAccess(ctx, &core.IdentityPluginAccess{
+		IdentityID:          identityID,
+		Plugin:              plugin,
+		InvokeAllOperations: true,
+	})
+	if err != nil {
+		return fmt.Errorf("sync canonical identity plugin access %q/%q: %w", identityID, plugin, err)
+	}
+	return nil
+}
+
+func (s *Server) deleteProviderPluginCanonicalAccess(ctx context.Context, userID, plugin string) error {
+	if s.identityPluginAccess == nil {
+		return nil
+	}
+	identityID, err := s.canonicalIdentityIDForUser(ctx, userID)
+	switch {
+	case err == nil:
+	case errors.Is(err, core.ErrNotFound):
+		return nil
+	default:
+		return err
+	}
+	if err := s.identityPluginAccess.DeleteAccess(ctx, identityID, plugin); err != nil {
+		if errors.Is(err, core.ErrNotFound) {
+			return core.ErrNotFound
+		}
+		return fmt.Errorf("delete canonical identity plugin access %q/%q: %w", identityID, plugin, err)
+	}
+	return nil
+}
+
+func (s *Server) syncProviderAdminCanonicalRole(ctx context.Context, userID, role string, staleRoles []string) error {
+	if s.workspaceRoles == nil {
+		return nil
+	}
+	identityID, err := s.canonicalIdentityIDForUser(ctx, userID)
+	if err != nil {
+		return err
+	}
+	if _, err := s.workspaceRoles.UpsertRole(ctx, &core.WorkspaceRole{
+		IdentityID: identityID,
+		Role:       strings.TrimSpace(role),
+	}); err != nil {
+		return fmt.Errorf("sync canonical workspace role %q/%q: %w", identityID, role, err)
+	}
+	for _, staleRole := range staleRoles {
+		staleRole = strings.TrimSpace(staleRole)
+		if staleRole == "" || staleRole == strings.TrimSpace(role) {
+			continue
+		}
+		if err := s.workspaceRoles.DeleteRole(ctx, identityID, staleRole); err != nil && !errors.Is(err, core.ErrNotFound) {
+			return fmt.Errorf("delete stale canonical workspace role %q/%q: %w", identityID, staleRole, err)
+		}
+	}
+	return nil
+}
+
+func (s *Server) deleteProviderAdminCanonicalRoles(ctx context.Context, userID string, roles []string) error {
+	if s.workspaceRoles == nil {
+		return nil
+	}
+	identityID, err := s.canonicalIdentityIDForUser(ctx, userID)
+	switch {
+	case err == nil:
+	case errors.Is(err, core.ErrNotFound):
+		return nil
+	default:
+		return err
+	}
+	deleted := false
+	for _, role := range roles {
+		role = strings.TrimSpace(role)
+		if role == "" {
+			continue
+		}
+		if err := s.workspaceRoles.DeleteRole(ctx, identityID, role); err != nil {
+			if errors.Is(err, core.ErrNotFound) {
+				continue
+			}
+			return fmt.Errorf("delete canonical workspace role %q/%q: %w", identityID, role, err)
+		}
+		deleted = true
+	}
+	if !deleted && len(roles) > 0 {
+		return core.ErrNotFound
+	}
+	return nil
+}
+
+func (s *Server) canonicalIdentityIDForUser(ctx context.Context, userID string) (string, error) {
+	userID = strings.TrimSpace(userID)
+	if userID == "" {
+		return "", fmt.Errorf("user id is required")
+	}
+	if s.users == nil {
+		return userID, nil
+	}
+	return s.users.CanonicalIdentityIDForUser(ctx, userID)
+}
+
+func providerRelationshipRelations(rels []*core.Relationship) []string {
+	if len(rels) == 0 {
+		return nil
+	}
+	seen := make(map[string]struct{}, len(rels))
+	out := make([]string, 0, len(rels))
+	for _, rel := range rels {
+		if rel == nil {
+			continue
+		}
+		relation := strings.TrimSpace(rel.GetRelation())
+		if relation == "" {
+			continue
+		}
+		if _, ok := seen[relation]; ok {
+			continue
+		}
+		seen[relation] = struct{}{}
+		out = append(out, relation)
+	}
+	return out
 }

--- a/gestaltd/internal/server/server.go
+++ b/gestaltd/internal/server/server.go
@@ -72,6 +72,8 @@ type Server struct {
 	identityGrants        *coredata.ManagedIdentityGrantService
 	pluginAuthorizations  *coredata.PluginAuthorizationService
 	adminAuthorizations   *coredata.AdminAuthorizationService
+	workspaceRoles        *coredata.WorkspaceRoleService
+	identityPluginAccess  *coredata.IdentityPluginAccessService
 	authorizationProvider core.AuthorizationProvider
 	managedIdentityMu     sync.Mutex
 	providers             *registry.ProviderMap[core.Provider]
@@ -190,6 +192,8 @@ func New(cfg Config) (*Server, error) {
 	identityGrants := cfg.Services.IdentityGrants
 	pluginAuthorizations := cfg.Services.PluginAuthorizations
 	adminAuthorizations := cfg.Services.AdminAuthorizations
+	workspaceRoles := cfg.Services.WorkspaceRoles
+	identityPluginAccess := cfg.Services.IdentityPluginAccess
 	resolver := principal.NewResolver(cfg.Auth, users, apiTokens, managedIdentities, identityGrants, cfg.Authorizer)
 
 	router := chi.NewRouter()
@@ -210,6 +214,8 @@ func New(cfg Config) (*Server, error) {
 		identityGrants:        identityGrants,
 		pluginAuthorizations:  pluginAuthorizations,
 		adminAuthorizations:   adminAuthorizations,
+		workspaceRoles:        workspaceRoles,
+		identityPluginAccess:  identityPluginAccess,
 		authorizationProvider: cfg.AuthorizationProvider,
 		providers:             cfg.Providers,
 		resolver:              resolver,

--- a/gestaltd/internal/server/server_test.go
+++ b/gestaltd/internal/server/server_test.go
@@ -2565,11 +2565,26 @@ func TestAdminAPI_PluginAuthorizationProviderBackedReadsAndDebug(t *testing.T) {
 	if err != nil {
 		t.Fatalf("find dynamic user: %v", err)
 	}
-	if err := svc.PluginAuthorizations.DeletePluginAuthorization(context.Background(), "sample_plugin", user.ID); err != nil {
-		t.Fatalf("DeletePluginAuthorization: %v", err)
+	legacyMemberships, err := svc.PluginAuthorizations.ListPluginAuthorizationsByPlugin(context.Background(), "sample_plugin")
+	if err != nil {
+		t.Fatalf("ListPluginAuthorizationsByPlugin: %v", err)
+	}
+	if len(legacyMemberships) != 0 {
+		t.Fatalf("legacy plugin authorizations = %+v, want none for provider-backed writes", legacyMemberships)
+	}
+	canonicalIdentityID, err := svc.Users.CanonicalIdentityIDForUser(context.Background(), user.ID)
+	if err != nil {
+		t.Fatalf("CanonicalIdentityIDForUser(dynamic): %v", err)
+	}
+	pluginAccess, err := svc.IdentityPluginAccess.GetAccess(context.Background(), canonicalIdentityID, "sample_plugin")
+	if err != nil {
+		t.Fatalf("GetAccess(sample_plugin): %v", err)
+	}
+	if !pluginAccess.InvokeAllOperations {
+		t.Fatal("expected provider-backed plugin write to sync canonical invoke-all access")
 	}
 	if err := authz.ReloadDynamic(context.Background()); err != nil {
-		t.Fatalf("ReloadDynamic after deleting legacy plugin authorization: %v", err)
+		t.Fatalf("ReloadDynamic after provider-backed plugin write: %v", err)
 	}
 
 	req, _ = http.NewRequest(http.MethodGet, ts.URL+"/admin/api/v1/authorization/plugins/sample_plugin/members", nil)
@@ -2974,11 +2989,26 @@ func TestAdminAPI_AdminAuthorizationProviderBackedReads(t *testing.T) {
 	if err != nil {
 		t.Fatalf("find dynamic admin user: %v", err)
 	}
-	if err := svc.AdminAuthorizations.DeleteAdminAuthorization(context.Background(), user.ID); err != nil {
-		t.Fatalf("DeleteAdminAuthorization: %v", err)
+	legacyMemberships, err := svc.AdminAuthorizations.ListAdminAuthorizations(context.Background())
+	if err != nil {
+		t.Fatalf("ListAdminAuthorizations: %v", err)
+	}
+	if len(legacyMemberships) != 0 {
+		t.Fatalf("legacy admin authorizations = %+v, want none for provider-backed writes", legacyMemberships)
+	}
+	canonicalIdentityID, err := svc.Users.CanonicalIdentityIDForUser(context.Background(), user.ID)
+	if err != nil {
+		t.Fatalf("CanonicalIdentityIDForUser(dynamic admin): %v", err)
+	}
+	roles, err := svc.WorkspaceRoles.ListByPrincipal(context.Background(), canonicalIdentityID)
+	if err != nil {
+		t.Fatalf("ListByPrincipal(dynamic admin): %v", err)
+	}
+	if len(roles) != 1 || roles[0].Role != "owner" {
+		t.Fatalf("workspace roles after provider-backed write = %+v, want [owner]", roles)
 	}
 	if err := authz.ReloadDynamic(context.Background()); err != nil {
-		t.Fatalf("ReloadDynamic after deleting legacy admin authorization: %v", err)
+		t.Fatalf("ReloadDynamic after provider-backed admin write: %v", err)
 	}
 
 	req, _ = http.NewRequest(http.MethodGet, ts.URL+"/admin/api/v1/authorization/admins/members", nil)
@@ -3000,6 +3030,137 @@ func TestAdminAPI_AdminAuthorizationProviderBackedReads(t *testing.T) {
 	if len(members) != 2 {
 		t.Fatalf("expected provider-backed merged admin members, got %d (%+v)", len(members), members)
 	}
+}
+
+func TestAdminAPI_ProviderBackedWritesDoNotRequireLegacyDynamicStores(t *testing.T) {
+	t.Parallel()
+
+	t.Run("plugin members", func(t *testing.T) {
+		t.Parallel()
+
+		svc := coretesting.NewStubServices(t)
+		svc.PluginAuthorizations = nil
+		provider := newMemoryAuthorizationProvider("memory-authorization")
+		legacy, err := authorization.New(config.AuthorizationConfig{
+			Policies: map[string]config.HumanPolicyDef{
+				"sample_policy": {
+					Default: "deny",
+					Members: []config.HumanPolicyMemberDef{
+						{Email: "static@example.test", Role: "admin"},
+					},
+				},
+			},
+		}, map[string]*config.ProviderEntry{
+			"sample_plugin": {AuthorizationPolicy: "sample_policy", MountPath: "/sample"},
+		}, nil, nil, nil)
+		if err != nil {
+			t.Fatalf("authorization.New: %v", err)
+		}
+		authz := authorization.NewProviderBacked(legacy, provider)
+		if err := authz.ReloadDynamic(context.Background()); err != nil {
+			t.Fatalf("ReloadDynamic: %v", err)
+		}
+
+		ts := newTestServer(t, func(cfg *server.Config) {
+			cfg.Auth = &coretesting.StubAuthProvider{
+				N: "test",
+				ValidateTokenFn: func(_ context.Context, token string) (*core.UserIdentity, error) {
+					if token != "admin-session" {
+						return nil, fmt.Errorf("invalid token")
+					}
+					return &core.UserIdentity{Email: "static@example.test"}, nil
+				},
+			}
+			cfg.Services = svc
+			cfg.Authorizer = authz
+			cfg.AuthorizationProvider = provider
+			cfg.PluginDefs = map[string]*config.ProviderEntry{
+				"sample_plugin": {AuthorizationPolicy: "sample_policy", MountPath: "/sample"},
+			}
+			cfg.Admin = server.AdminRouteConfig{
+				AuthorizationPolicy: "sample_policy",
+				AllowedRoles:        []string{"admin"},
+			}
+			cfg.AdminUI = http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+				_, _ = w.Write([]byte("admin"))
+			})
+		})
+		testutil.CloseOnCleanup(t, ts)
+
+		body := bytes.NewBufferString(`{"email":"dynamic@example.test","role":"viewer"}`)
+		req, _ := http.NewRequest(http.MethodPut, ts.URL+"/admin/api/v1/authorization/plugins/sample_plugin/members", body)
+		req.Header.Set("Content-Type", "application/json")
+		req.AddCookie(&http.Cookie{Name: "session_token", Value: "admin-session"})
+		resp, err := http.DefaultClient.Do(req)
+		if err != nil {
+			t.Fatalf("PUT dynamic member: %v", err)
+		}
+		defer func() { _ = resp.Body.Close() }()
+		if resp.StatusCode != http.StatusOK {
+			respBody, _ := io.ReadAll(resp.Body)
+			t.Fatalf("put dynamic member status = %d, want 200: %s", resp.StatusCode, respBody)
+		}
+	})
+
+	t.Run("admin members", func(t *testing.T) {
+		t.Parallel()
+
+		svc := coretesting.NewStubServices(t)
+		svc.AdminAuthorizations = nil
+		provider := newMemoryAuthorizationProvider("memory-authorization")
+		seedUser(t, svc, "static-admin@example.test")
+		legacy := mustAuthorizer(t, config.AuthorizationConfig{
+			Policies: map[string]config.HumanPolicyDef{
+				"admin_policy": {
+					Default: "deny",
+					Members: []config.HumanPolicyMemberDef{
+						{Email: "static-admin@example.test", Role: "owner"},
+					},
+				},
+			},
+		}, nil, nil, nil)
+		authz := authorization.NewProviderBacked(legacy, provider)
+		if err := authz.ReloadDynamic(context.Background()); err != nil {
+			t.Fatalf("ReloadDynamic: %v", err)
+		}
+
+		ts := newTestServer(t, func(cfg *server.Config) {
+			cfg.Auth = &coretesting.StubAuthProvider{
+				N: "test",
+				ValidateTokenFn: func(_ context.Context, token string) (*core.UserIdentity, error) {
+					if token != "admin-session" {
+						return nil, fmt.Errorf("invalid token")
+					}
+					return &core.UserIdentity{Email: "static-admin@example.test"}, nil
+				},
+			}
+			cfg.Services = svc
+			cfg.Authorizer = authz
+			cfg.AuthorizationProvider = provider
+			cfg.Admin = server.AdminRouteConfig{
+				AuthorizationPolicy: "admin_policy",
+				AllowedRoles:        []string{"owner", "operator"},
+			}
+			cfg.AdminUI = http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+				_, _ = w.Write([]byte("admin"))
+			})
+		})
+		testutil.CloseOnCleanup(t, ts)
+
+		body := bytes.NewBufferString(`{"email":"dynamic-admin@example.test","role":"operator"}`)
+		req, _ := http.NewRequest(http.MethodPut, ts.URL+"/admin/api/v1/authorization/admins/members", body)
+		req.Header.Set("Content-Type", "application/json")
+		req.AddCookie(&http.Cookie{Name: "session_token", Value: "admin-session"})
+		resp, err := http.DefaultClient.Do(req)
+		if err != nil {
+			t.Fatalf("PUT admin member: %v", err)
+		}
+		defer func() { _ = resp.Body.Close() }()
+		if resp.StatusCode != http.StatusOK {
+			respBody, _ := io.ReadAll(resp.Body)
+			t.Fatalf("put admin member status = %d, want 200: %s", resp.StatusCode, respBody)
+		}
+	})
 }
 
 func TestAdminAPI_AdminAuthorizationWriteUsesAllowedAdminRoles(t *testing.T) {


### PR DESCRIPTION
## Summary
This PR removes the remaining human-auth semantic dependency on the legacy dynamic membership tables without deleting those tables yet.

It does three things:
- provider-backed admin/plugin membership writes now sync canonical human state directly instead of depending on legacy human-auth table side effects
- the provider-backed reload path now does a one-time legacy human-grant import, writes a migration sentinel, and ignores later legacy mutations
- `Result.Start()` now rehydrates canonical human plugin access and workspace roles from the authorization provider so restart no longer depends on stale legacy rows

It also fixes two follow-on correctness issues discovered during review:
- provider-backed write endpoints now stay writable even when the legacy dynamic services are absent
- the one-time legacy import is provider-first at the person/resource level, so stale legacy `user` rows cannot override an existing provider `email` row for the same person during migration

## Go Interface
```go
type AuthorizationProvider interface {
    ReadRelationships(ctx context.Context, req *ReadRelationshipsRequest) (*ReadRelationshipsResponse, error)
    WriteRelationships(ctx context.Context, req *WriteRelationshipsRequest) error
    GetActiveModel(ctx context.Context) (*GetActiveModelResponse, error)
}
```

## YAML Interface
```yaml
providers:
  authorization:
    indexeddb:
      source:
        ref: github.com/valon-technologies/gestalt-providers/authorization/indexeddb
        version: 0.0.1-alpha.1
      config:
        indexeddb: default

server:
  providers:
    authorization: indexeddb
```

## Behavior Examples
```go
// Provider-backed admin/plugin mutations now go to the authorization provider
// and then sync canonical human state directly.
_, _ = authorizationProvider.WriteRelationships(ctx, &core.WriteRelationshipsRequest{...})
_, _ = services.IdentityPluginAccess.UpsertAccess(ctx, &core.IdentityPluginAccess{...})
_, _ = services.WorkspaceRoles.UpsertRole(ctx, &core.WorkspaceRole{...})
```

```yaml
# With provider-backed auth enabled, legacy human-auth tables are no longer
# the source of truth for canonical human plugin/admin state.
server:
  providers:
    authorization: indexeddb
```

Migration examples in this PR:
- first provider-backed reload imports legacy dynamic human grants once and writes a migration sentinel
- later legacy table mutations are ignored by provider-backed reloads
- on restart, `gestaltd` rebuilds canonical human plugin/admin state from provider relationships
- provider-backed writes remain available even if `PluginAuthorizations` / `AdminAuthorizations` are nil

## Verification
```bash
cd gestaltd
go test ./internal/authorization ./internal/bootstrap ./internal/invocation ./internal/mcp ./internal/server
golangci-lint run ./internal/authorization ./internal/bootstrap ./internal/server
```