### PR TITLE
config: add v4 local provider-release metadata sources

### DIFF
--- a/gestaltd/cmd/gestaltd/factories.go
+++ b/gestaltd/cmd/gestaltd/factories.go
@@ -88,7 +88,7 @@ func buildFactories() *bootstrap.FactoryRegistry {
 	factories.Telemetry["stdout"] = telemetrystdout.Factory
 	factories.Telemetry["otlp"] = telemetryotlp.Factory
 	factories.Audit = func(ctx context.Context, cfg config.ProviderEntry, telemetry core.TelemetryProvider) (core.AuditSink, func(context.Context) error, error) {
-		if cfg.Source.IsMetadataURL() || cfg.Source.IsLocal() {
+		if cfg.HasReleaseMetadataSource() || cfg.HasLocalSource() {
 			return nil, nil, fmt.Errorf("provider-based audit providers are not yet supported")
 		}
 		switch cfg.Source.Builtin {

--- a/gestaltd/cmd/gestaltd/plugin.go
+++ b/gestaltd/cmd/gestaltd/plugin.go
@@ -1,10 +1,12 @@
 package main
 
 import (
+	"bytes"
 	"context"
 	"flag"
 	"fmt"
 	"io"
+	"io/fs"
 	"os"
 	"path"
 	"path/filepath"
@@ -36,7 +38,7 @@ func runProvider(args []string) error {
 	}
 }
 
-const defaultPlatforms = "darwin/amd64,darwin/arm64,linux/amd64,linux/arm,linux/arm64"
+const defaultPlatforms = "darwin/amd64,darwin/arm64,linux/amd64,linux/arm64"
 const allPlatformsValue = "all"
 const defaultReleaseOutputDir = "dist/"
 const releaseBinaryPrefix = "gestalt-plugin-"
@@ -80,7 +82,7 @@ type providerReleaseArtifact struct {
 	SHA256 string `yaml:"sha256"`
 }
 
-func runProviderRelease(args []string) error {
+func runProviderRelease(args []string) (err error) {
 	fs := flag.NewFlagSet("gestaltd provider release", flag.ContinueOnError)
 	fs.Usage = func() { printProviderReleaseUsage(fs.Output()) }
 	version := fs.String("version", "", "semantic version string (required)")
@@ -111,6 +113,15 @@ func runProviderRelease(args []string) error {
 		return err
 	}
 	sourceDir := filepath.Dir(manifestPath)
+	catalogSnapshot, err := snapshotSourceStaticCatalog(sourceDir)
+	if err != nil {
+		return err
+	}
+	defer func() {
+		if restoreErr := catalogSnapshot.Restore(); restoreErr != nil && err == nil {
+			err = fmt.Errorf("restore synthesized static catalog state: %w", restoreErr)
+		}
+	}()
 	_, releaseManifest, err := providerpkg.ReadSourceManifestFile(manifestPath)
 	if err != nil {
 		return fmt.Errorf("read %s: %w", manifestPath, err)
@@ -123,6 +134,9 @@ func runProviderRelease(args []string) error {
 		return fmt.Errorf("read %s after release build: %w", manifestPath, err)
 	}
 	if err := validateReleaseOutputDir(releaseManifest, sourceDir, *outputDir); err != nil {
+		return err
+	}
+	if err := providerpkg.EnsureSourceStaticCatalog(manifestPath, releaseManifest); err != nil {
 		return err
 	}
 	src, err := pluginsource.Parse(releaseManifest.Source)
@@ -184,6 +198,63 @@ func runProviderRelease(args []string) error {
 		return fmt.Errorf("write release metadata: %w", err)
 	}
 
+	return nil
+}
+
+type sourceStaticCatalogSnapshot struct {
+	path   string
+	data   []byte
+	mode   fs.FileMode
+	exists bool
+}
+
+func snapshotSourceStaticCatalog(sourceDir string) (*sourceStaticCatalogSnapshot, error) {
+	path := providerpkg.StaticCatalogPath(sourceDir)
+	info, err := os.Stat(path)
+	if err != nil {
+		if os.IsNotExist(err) {
+			return &sourceStaticCatalogSnapshot{path: path}, nil
+		}
+		return nil, fmt.Errorf("stat source static catalog: %w", err)
+	}
+	data, err := os.ReadFile(path)
+	if err != nil {
+		return nil, fmt.Errorf("read source static catalog: %w", err)
+	}
+	return &sourceStaticCatalogSnapshot{
+		path:   path,
+		data:   data,
+		mode:   info.Mode().Perm(),
+		exists: true,
+	}, nil
+}
+
+func (s *sourceStaticCatalogSnapshot) Restore() error {
+	if s == nil || s.path == "" {
+		return nil
+	}
+	current, err := os.ReadFile(s.path)
+	switch {
+	case err == nil:
+		if s.exists && bytes.Equal(current, s.data) {
+			return nil
+		}
+	case os.IsNotExist(err):
+		if !s.exists {
+			return nil
+		}
+	default:
+		return fmt.Errorf("read current static catalog: %w", err)
+	}
+	if !s.exists {
+		if err := os.Remove(s.path); err != nil && !os.IsNotExist(err) {
+			return fmt.Errorf("remove generated static catalog: %w", err)
+		}
+		return nil
+	}
+	if err := os.WriteFile(s.path, s.data, s.mode); err != nil {
+		return fmt.Errorf("restore static catalog: %w", err)
+	}
 	return nil
 }
 
@@ -533,6 +604,7 @@ func printProviderReleaseUsage(w io.Writer) {
 	writeUsageLine(w, "Pass --platform with a comma-separated os/arch[/libc] list or --platform all")
 	writeUsageLine(w, "to build multiple per-platform tar.gz archives plus a checksums file.")
 	writeUsageLine(w, "Run from the provider source directory.")
+	writeUsageLine(w, "For apiVersion v4 local deploy configs, point source.path at dist/provider-release.yaml.")
 	writeUsageLine(w, "")
 	writeUsageLine(w, "Flags:")
 	writeUsageLine(w, "  --version    Semantic version string (required)")

--- a/gestaltd/cmd/gestaltd/plugin_test.go
+++ b/gestaltd/cmd/gestaltd/plugin_test.go
@@ -54,6 +54,10 @@ const (
 	rustWrapperBinaryName          = "gestalt-provider-wrapper"
 	pythonAuthReleasePluginName    = "python-auth-release"
 	pythonAuthReleaseSource        = "github.com/testowner/plugins/python-auth-release"
+	typeScriptReleasePluginName    = "ts-release"
+	typeScriptReleaseSource        = "github.com/testowner/plugins/ts-release"
+	typeScriptReleaseModule        = "./provider.ts#provider"
+	typeScriptReleaseTarget        = "plugin:./provider.ts#provider"
 	authReleaseTypeScriptModule    = "./auth.ts#auth"
 	authReleaseTypeScriptTarget    = "auth:./auth.ts#auth"
 )
@@ -291,6 +295,9 @@ func TestRun_PluginReleaseBuildsPythonSourcePluginForCurrentPlatform(t *testing.
 		"--version", testVersion,
 		"--output", outputDir,
 	)
+	if _, err := os.Stat(filepath.Join(pluginDir, providerpkg.StaticCatalogFile)); !os.IsNotExist(err) {
+		t.Fatalf("source catalog should not persist after release, got err=%v", err)
+	}
 
 	archiveName := expectedPythonArchiveName(testVersion, runtime.GOOS, runtime.GOARCH)
 	extractDir := extractReleasedArchive(t, outputDir, archiveName)
@@ -335,6 +342,55 @@ func TestRun_PluginReleaseBuildsPythonSourcePluginForCurrentPlatform(t *testing.
 	}
 	if !strings.Contains(result.Body, "Hi, Ada!") {
 		t.Fatalf("body = %q, want greeting", result.Body)
+	}
+}
+
+func TestRun_PluginReleaseBuildsTypeScriptSourcePluginForCurrentPlatform(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("fake Bun build fixture is POSIX-only")
+	}
+
+	t.Setenv("PATH", pathWithoutGo(t))
+
+	pluginDir := newTypeScriptSourceReleaseFixture(t, t.TempDir())
+	bunPath := writeFakeTypeScriptProviderReleaseBun(
+		t,
+		filepath.Join(pluginDir, "fake-bun"),
+		typeScriptReleasePluginName,
+		typeScriptReleaseTarget,
+		runtime.GOOS,
+		runtime.GOARCH,
+	)
+	t.Setenv("GESTALT_BUN", bunPath)
+
+	outputDir := t.TempDir()
+	const testVersion = "0.0.12-ts"
+
+	runPluginReleaseCommand(t, pluginDir,
+		"--version", testVersion,
+		"--output", outputDir,
+	)
+	if _, err := os.Stat(filepath.Join(pluginDir, providerpkg.StaticCatalogFile)); !os.IsNotExist(err) {
+		t.Fatalf("source catalog should not persist after release, got err=%v", err)
+	}
+
+	archiveName := platformArchiveNameForTest(typeScriptReleasePluginName, testVersion, runtime.GOOS, runtime.GOARCH)
+	extractDir := extractReleasedArchive(t, outputDir, archiveName)
+	manifest := readReleasedManifest(t, outputDir, archiveName)
+
+	binaryName := releaseBinaryName(typeScriptReleasePluginName, runtime.GOOS)
+	if len(manifest.Artifacts) != 1 || manifest.Artifacts[0].Path != binaryName {
+		t.Fatalf("artifacts = %+v, want path %q", manifest.Artifacts, binaryName)
+	}
+	if manifest.Entrypoint == nil || manifest.Entrypoint.ArtifactPath != binaryName {
+		t.Fatalf("provider entrypoint = %+v, want artifact path %q", manifest.Entrypoint, binaryName)
+	}
+	catalogData, err := os.ReadFile(filepath.Join(extractDir, providerpkg.StaticCatalogFile))
+	if err != nil {
+		t.Fatalf("read generated catalog: %v", err)
+	}
+	if !strings.Contains(string(catalogData), "id: greet") {
+		t.Fatalf("unexpected generated catalog: %s", catalogData)
 	}
 }
 
@@ -465,6 +521,45 @@ func TestRun_PluginReleaseBuildsRequestedPlatformSets(t *testing.T) {
 			}
 			if _, err := os.Stat(filepath.Join(extractDir, binaryName)); err != nil {
 				t.Fatalf("expected %s in archive: %v", binaryName, err)
+			}
+		})
+	})
+
+	t.Run("typescript auth all", func(t *testing.T) {
+		if runtime.GOOS == "windows" {
+			t.Skip("fake Bun build fixture is POSIX-only")
+		}
+
+		builtBinary := buildGoSourceAuthBinary(t)
+		t.Setenv("PATH", pathWithoutGo(t))
+
+		pluginDir := newTypeScriptSourceAuthReleaseFixture(t, t.TempDir())
+		defaultPlatforms := defaultReleasePlatformsForTest(t)
+		bunPath := writeFakeTypeScriptComponentReleaseBunForPlatforms(
+			t,
+			filepath.Join(pluginDir, "fake-bun"),
+			authReleaseTypeScriptTarget,
+			authReleasePluginName,
+			defaultPlatforms,
+			builtBinary,
+		)
+		t.Setenv("GESTALT_BUN", bunPath)
+
+		outputDir := t.TempDir()
+		const testVersion = "0.0.12-ts-auth-all"
+
+		runPluginReleaseCommand(t, pluginDir,
+			"--version", testVersion,
+			"--platform", allPlatformsValue,
+			"--output", outputDir,
+		)
+
+		assertReleasePlatforms(t, outputDir, defaultPlatforms, func(platform releasePlatform) string {
+			return platformArchiveNameForTest(authReleasePluginName, testVersion, platform.GOOS, platform.GOARCH)
+		}, func(t *testing.T, artifact providermanifestv1.Artifact, platform releasePlatform) {
+			assertExpectedScriptArtifactPlatform(t, artifact, platform.GOOS, platform.GOARCH)
+			if artifact.Path != releaseBinaryName(authReleasePluginName, artifact.OS) {
+				t.Fatalf("artifacts = %+v, want path %q", artifact, releaseBinaryName(authReleasePluginName, artifact.OS))
 			}
 		})
 	})
@@ -2168,6 +2263,20 @@ auth = "provider:auth_provider"
 
 func writeFakeTypeScriptComponentReleaseBun(t *testing.T, path, expectedTarget, expectedPluginName, expectedGOOS, expectedGOARCH, builtBinaryPath string) string {
 	t.Helper()
+	return writeFakeTypeScriptComponentReleaseBunForPlatforms(t, path, expectedTarget, expectedPluginName, []releasePlatform{{
+		GOOS:   expectedGOOS,
+		GOARCH: expectedGOARCH,
+	}}, builtBinaryPath)
+}
+
+func writeFakeTypeScriptComponentReleaseBunForPlatforms(t *testing.T, path, expectedTarget, expectedPluginName string, expectedPlatforms []releasePlatform, builtBinaryPath string) string {
+	t.Helper()
+
+	allowedCases := make([]string, 0, len(expectedPlatforms))
+	for _, platform := range expectedPlatforms {
+		allowedCases = append(allowedCases, fmt.Sprintf("%s/%s", platform.GOOS, platform.GOARCH))
+	}
+	allowedPlatformCase := strings.Join(allowedCases, "|") + ")"
 
 	script := `#!/bin/sh
 set -eu
@@ -2216,6 +2325,113 @@ case "$entry_base" in
       echo "unexpected plugin name: $name" >&2
       exit 1
     fi
+    case "$goos/$goarch" in
+      ` + allowedPlatformCase + `
+        ;;
+      *)
+        echo "unexpected target platform: $goos/$goarch" >&2
+        exit 1
+        ;;
+    esac
+    output_dir="${output%/*}"
+    if [ "$output_dir" = "$output" ]; then
+      output_dir="."
+    fi
+    mkdir -p "$output_dir"
+    cp "` + builtBinaryPath + `" "$output"
+    chmod +x "$output"
+    exit 0
+    ;;
+esac
+
+echo "unexpected fake bun entry: $entry ($*)" >&2
+exit 1
+`
+	writeTestFile(t, filepath.Dir(path), filepath.Base(path), []byte(script), 0o755)
+	return path
+}
+
+func writeFakeTypeScriptProviderReleaseBun(t *testing.T, path, expectedPluginName, expectedTarget, expectedGOOS, expectedGOARCH string) string {
+	t.Helper()
+
+	script := `#!/bin/sh
+set -eu
+
+if [ "$#" -lt 4 ] || [ "$1" != "--cwd" ]; then
+  echo "unexpected fake bun args: $*" >&2
+  exit 1
+fi
+
+cwd="$2"
+shift 2
+
+entry="$1"
+shift
+
+if [ "$#" -gt 0 ] && [ "$1" = "--" ]; then
+  shift
+fi
+
+entry_base="${entry##*/}"
+case "$entry_base" in
+  gestalt-ts-runtime|runtime.ts)
+    if [ "$#" -ne 2 ]; then
+      echo "unexpected runtime args: $*" >&2
+      exit 1
+    fi
+    root="$1"
+    target="$2"
+    if [ "$cwd" != "$root" ]; then
+      echo "unexpected runtime cwd: $cwd != $root" >&2
+      exit 1
+    fi
+    if [ "$target" != "` + typeScriptReleaseTarget + `" ]; then
+      echo "unexpected runtime target: $target" >&2
+      exit 1
+    fi
+    if [ "$target" != "` + expectedTarget + `" ]; then
+      echo "unexpected runtime target: $target" >&2
+      exit 1
+    fi
+    if [ -z "${GESTALT_PLUGIN_WRITE_CATALOG:-}" ]; then
+      echo "missing GESTALT_PLUGIN_WRITE_CATALOG" >&2
+      exit 1
+    fi
+    cat > "$GESTALT_PLUGIN_WRITE_CATALOG" <<'EOF'
+name: ` + typeScriptReleasePluginName + `
+operations:
+  - id: greet
+    method: GET
+EOF
+    exit 0
+    ;;
+  gestalt-ts-build|build.ts)
+    if [ "$#" -ne 6 ]; then
+      echo "unexpected build args: $*" >&2
+      exit 1
+    fi
+    source_dir="$1"
+    target="$2"
+    output="$3"
+    name="$4"
+    goos="$5"
+    goarch="$6"
+    if [ "$cwd" != "$source_dir" ]; then
+      echo "unexpected build cwd: $cwd != $source_dir" >&2
+      exit 1
+    fi
+    if [ "$target" != "` + typeScriptReleaseTarget + `" ]; then
+      echo "unexpected build target: $target" >&2
+      exit 1
+    fi
+    if [ "$target" != "` + expectedTarget + `" ]; then
+      echo "unexpected build target: $target" >&2
+      exit 1
+    fi
+    if [ "$name" != "` + expectedPluginName + `" ]; then
+      echo "unexpected plugin name: $name" >&2
+      exit 1
+    fi
     if [ "$goos" != "` + expectedGOOS + `" ] || [ "$goarch" != "` + expectedGOARCH + `" ]; then
       echo "unexpected target platform: $goos/$goarch" >&2
       exit 1
@@ -2225,7 +2441,7 @@ case "$entry_base" in
       output_dir="."
     fi
     mkdir -p "$output_dir"
-    cp "` + builtBinaryPath + `" "$output"
+    printf '#!/bin/sh\n# fake ts release binary\nexit 0\n' > "$output"
     chmod +x "$output"
     exit 0
     ;;
@@ -2709,6 +2925,37 @@ func newGoSourceReleaseFixture(t *testing.T, dir string) string {
 			Auth: &providermanifestv1.ProviderAuth{Type: providermanifestv1.AuthTypeNone},
 		},
 	})
+	return pluginDir
+}
+
+func newTypeScriptSourceReleaseFixture(t *testing.T, dir string) string {
+	t.Helper()
+
+	pluginDir := filepath.Join(dir, typeScriptReleasePluginName)
+	if err := os.MkdirAll(pluginDir, 0o755); err != nil {
+		t.Fatalf("MkdirAll(pluginDir): %v", err)
+	}
+	writeReleaseTestManifest(t, pluginDir, &providermanifestv1.Manifest{
+		Kind:        providermanifestv1.KindPlugin,
+		Source:      typeScriptReleaseSource,
+		Version:     "0.0.1",
+		DisplayName: "TypeScript Release",
+		Spec: &providermanifestv1.Spec{
+			Auth: &providermanifestv1.ProviderAuth{Type: providermanifestv1.AuthTypeNone},
+		},
+	})
+	if err := os.Remove(filepath.Join(pluginDir, providerpkg.StaticCatalogFile)); err != nil {
+		t.Fatalf("Remove(%s): %v", providerpkg.StaticCatalogFile, err)
+	}
+	writeTestFile(t, pluginDir, "package.json", []byte(`{
+  "name": "ts-release",
+  "version": "0.0.1",
+  "gestalt": {
+    "provider": "`+typeScriptReleaseModule+`"
+  }
+}
+`), 0o644)
+	writeTestFile(t, pluginDir, "provider.ts", []byte("export const provider = {};\n"), 0o644)
 	return pluginDir
 }
 

--- a/gestaltd/cmd/gestaltd/run.go
+++ b/gestaltd/cmd/gestaltd/run.go
@@ -208,10 +208,10 @@ func providerEntryLabel(entry *config.ProviderEntry) string {
 	switch {
 	case entry == nil:
 		return "(not set)"
-	case entry.Source.IsMetadataURL():
-		return entry.Source.MetadataURL()
-	case entry.Source.IsLocal():
-		return entry.Source.Path
+	case entry.HasReleaseMetadataSource():
+		return entry.SourceReleaseLocation()
+	case entry.HasLocalSource():
+		return entry.SourcePath()
 	case entry.Source.IsBuiltin():
 		return entry.Source.Builtin
 	default:

--- a/gestaltd/internal/bootstrap/bootstrap.go
+++ b/gestaltd/internal/bootstrap/bootstrap.go
@@ -814,7 +814,7 @@ func buildNamedSecretManager(name string, secrets *config.ProviderEntry, factori
 		logicalName = "secrets"
 	}
 
-	if secrets != nil && (secrets.HasRemoteSource() || secrets.HasLocalSource()) {
+	if secrets != nil && (secrets.HasRemoteSource() || secrets.HasLocalSource() || secrets.HasLocalReleaseSource()) {
 		factory, ok := factories.Secrets["provider"]
 		if !ok {
 			return nil, fmt.Errorf("bootstrap: secrets provider factory is not registered")

--- a/gestaltd/internal/bootstrap/bootstrap_test.go
+++ b/gestaltd/internal/bootstrap/bootstrap_test.go
@@ -2611,68 +2611,87 @@ func TestValidateStartsWorkflowProvidersAfterInvokerIsReady(t *testing.T) {
 func TestValidateManagedWorkflowStartupCallbackUsesPreparedProviderStub(t *testing.T) {
 	t.Parallel()
 
-	cfg := validConfig()
-	cfg.Plugins = map[string]*config.ProviderEntry{
-		"roadmap": {
-			Source:         config.NewMetadataSource("https://example.invalid/github-com-example-roadmap/v0.0.1/provider-release.yaml"),
-			ConnectionMode: providermanifestv1.ConnectionModeIdentity,
-			Workflow: &config.PluginWorkflowConfig{
-				Provider:   "temporal",
-				Operations: []string{"sync"},
-			},
-			ResolvedManifest: &providermanifestv1.Manifest{
-				DisplayName: "Roadmap",
-				Description: "Managed roadmap plugin",
-				Entrypoint:  &providermanifestv1.Entrypoint{ArtifactPath: "roadmap"},
-				Spec: &providermanifestv1.Spec{
-					Surfaces: &providermanifestv1.ProviderSurfaces{
-						REST: &providermanifestv1.RESTSurface{
-							BaseURL: "https://example.invalid",
-							Operations: []providermanifestv1.ProviderOperation{
-								{Name: "sync", Method: http.MethodPost, Path: "/sync"},
+	for _, tc := range []struct {
+		name   string
+		source config.ProviderSource
+	}{
+		{
+			name:   "remote release metadata",
+			source: config.NewMetadataSource("https://example.invalid/github-com-example-roadmap/v0.0.1/provider-release.yaml"),
+		},
+		{
+			name:   "local release metadata",
+			source: config.NewLocalReleaseMetadataSource(filepath.Join(t.TempDir(), "roadmap", "dist", "provider-release.yaml")),
+		},
+	} {
+		tc := tc
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+
+			cfg := validConfig()
+			cfg.Plugins = map[string]*config.ProviderEntry{
+				"roadmap": {
+					Source:         tc.source,
+					ConnectionMode: providermanifestv1.ConnectionModeIdentity,
+					Workflow: &config.PluginWorkflowConfig{
+						Provider:   "temporal",
+						Operations: []string{"sync"},
+					},
+					ResolvedManifest: &providermanifestv1.Manifest{
+						DisplayName: "Roadmap",
+						Description: "Managed roadmap plugin",
+						Entrypoint:  &providermanifestv1.Entrypoint{ArtifactPath: "roadmap"},
+						Spec: &providermanifestv1.Spec{
+							Surfaces: &providermanifestv1.ProviderSurfaces{
+								REST: &providermanifestv1.RESTSurface{
+									BaseURL: "https://example.invalid",
+									Operations: []providermanifestv1.ProviderOperation{
+										{Name: "sync", Method: http.MethodPost, Path: "/sync"},
+									},
+								},
 							},
 						},
 					},
 				},
-			},
-		},
-	}
-	cfg.Providers.Workflow = map[string]*config.ProviderEntry{
-		"temporal": {Source: config.ProviderSource{Path: "stub"}},
-	}
+			}
+			cfg.Providers.Workflow = map[string]*config.ProviderEntry{
+				"temporal": {Source: config.ProviderSource{Path: "stub"}},
+			}
 
-	factories := validFactories()
-	factories.Workflow = func(_ context.Context, name string, _ yaml.Node, hostServices []providerhost.HostService, deps bootstrap.Deps) (coreworkflow.Provider, error) {
-		if name != "temporal" {
-			return nil, fmt.Errorf("workflow name = %q, want %q", name, "temporal")
-		}
-		if err := deps.Services.Tokens.StoreToken(context.Background(), &core.IntegrationToken{
-			UserID:      principal.IdentityPrincipal,
-			Integration: "roadmap",
-			Connection:  config.PluginConnectionName,
-			Instance:    "default",
-			AccessToken: "workflow-validate-token",
-		}); err != nil {
-			return nil, fmt.Errorf("store identity token: %w", err)
-		}
-		resp, err := invokeWorkflowHostCallback(t, hostServices, &proto.InvokeWorkflowOperationRequest{
-			PluginName: "roadmap",
-			Target: &proto.BoundWorkflowTarget{
-				PluginName: "roadmap",
-				Operation:  "sync",
-			},
+			factories := validFactories()
+			factories.Workflow = func(_ context.Context, name string, _ yaml.Node, hostServices []providerhost.HostService, deps bootstrap.Deps) (coreworkflow.Provider, error) {
+				if name != "temporal" {
+					return nil, fmt.Errorf("workflow name = %q, want %q", name, "temporal")
+				}
+				if err := deps.Services.Tokens.StoreToken(context.Background(), &core.IntegrationToken{
+					UserID:      principal.IdentityPrincipal,
+					Integration: "roadmap",
+					Connection:  config.PluginConnectionName,
+					Instance:    "default",
+					AccessToken: "workflow-validate-token",
+				}); err != nil {
+					return nil, fmt.Errorf("store identity token: %w", err)
+				}
+				resp, err := invokeWorkflowHostCallback(t, hostServices, &proto.InvokeWorkflowOperationRequest{
+					PluginName: "roadmap",
+					Target: &proto.BoundWorkflowTarget{
+						PluginName: "roadmap",
+						Operation:  "sync",
+					},
+				})
+				if err != nil {
+					return nil, fmt.Errorf("startup callback: %w", err)
+				}
+				if resp.GetStatus() != http.StatusAccepted || resp.GetBody() != `{}` {
+					return nil, fmt.Errorf("startup callback response = %#v", resp)
+				}
+				return &stubWorkflowProvider{}, nil
+			}
+
+			if _, err := bootstrap.Validate(context.Background(), cfg, factories); err != nil {
+				t.Fatalf("Validate: %v", err)
+			}
 		})
-		if err != nil {
-			return nil, fmt.Errorf("startup callback: %w", err)
-		}
-		if resp.GetStatus() != http.StatusAccepted || resp.GetBody() != `{}` {
-			return nil, fmt.Errorf("startup callback response = %#v", resp)
-		}
-		return &stubWorkflowProvider{}, nil
-	}
-
-	if _, err := bootstrap.Validate(context.Background(), cfg, factories); err != nil {
-		t.Fatalf("Validate: %v", err)
 	}
 }
 

--- a/gestaltd/internal/bootstrap/validate.go
+++ b/gestaltd/internal/bootstrap/validate.go
@@ -22,10 +22,7 @@ import (
 // starting the server or running migrations. Unlike Bootstrap, provider
 // validation is strict: any provider construction failure is returned.
 func Validate(ctx context.Context, cfg *config.Config, factories *FactoryRegistry) ([]string, error) {
-	if err := plugininvocation.ValidateEffectiveCatalogs(ctx, cfg); err != nil {
-		return nil, err
-	}
-	if err := plugininvocation.ValidateDependencies(ctx, cfg); err != nil {
+	if err := plugininvocation.ValidateEffectiveCatalogsAndDependencies(ctx, cfg); err != nil {
 		return nil, err
 	}
 
@@ -153,7 +150,7 @@ func buildProvidersStrict(ctx context.Context, cfg *config.Config, factories *Fa
 }
 
 func buildProviderForValidation(ctx context.Context, name string, entry *config.ProviderEntry, deps Deps) (*ProviderBuildResult, error) {
-	if entry == nil || !entry.HasRemoteSource() || !entry.HasResolvedManifest() {
+	if entry == nil || !entry.HasReleaseMetadataSource() || !entry.HasResolvedManifest() {
 		return buildProvider(ctx, name, entry, deps)
 	}
 	prov, err := newPreparedProviderStub(name, entry)

--- a/gestaltd/internal/config/config.go
+++ b/gestaltd/internal/config/config.go
@@ -45,6 +45,15 @@ const PluginConnectionName = "_plugin"
 // to "plugin" to reuse the plugin's OAuth token.
 const PluginConnectionAlias = "plugin"
 const APIVersionV3 = "gestaltd.config/v3"
+const APIVersionV4 = "gestaltd.config/v4"
+
+type providerSourceSyntaxMode int
+
+const (
+	providerSourceSyntaxLegacy providerSourceSyntaxMode = iota
+	providerSourceSyntaxV3
+	providerSourceSyntaxV4
+)
 
 type Config struct {
 	APIVersion    string                    `yaml:"apiVersion,omitempty"`
@@ -89,17 +98,21 @@ type ServerProvidersConfig struct {
 	IndexedDB     string `yaml:"indexeddb,omitempty"`
 }
 
-// ProviderSource supports handwritten config in three forms via custom UnmarshalYAML:
+// ProviderSource supports handwritten config in three forms via custom
+// UnmarshalYAML:
 //   - Builtin:  source: "name"                               -> ProviderSource{Builtin: "name"}
 //   - Metadata: source: "https://.../provider-release.yaml"  -> ProviderSource{metadataURL: "..."}
-//   - Local:    source: {path} or source: "./manifest.yaml"  -> ProviderSource{Path: "..."}
+//   - Local:    source: {path} or source: "./manifest.yaml"  -> ProviderSource{Path: "..."} in v3
+//   - Local:    source: {path} or source: "./dist/provider-release.yaml"
+//     -> ProviderSource{metadataPath: "..."} in v4
 type ProviderSource struct {
-	Builtin     string         `yaml:"-"`
-	scalar      string         `yaml:"-"`
-	metadataURL string         `yaml:"-"`
-	unsupported string         `yaml:"-"`
-	Path        string         `yaml:"path,omitempty"`
-	Auth        *SourceAuthDef `yaml:"auth,omitempty"`
+	Builtin      string         `yaml:"-"`
+	scalar       string         `yaml:"-"`
+	metadataURL  string         `yaml:"-"`
+	metadataPath string         `yaml:"-"`
+	unsupported  string         `yaml:"-"`
+	Path         string         `yaml:"path,omitempty"`
+	Auth         *SourceAuthDef `yaml:"auth,omitempty"`
 }
 
 func (s *ProviderSource) UnmarshalYAML(value *yaml.Node) error {
@@ -149,11 +162,17 @@ func (s ProviderSource) MarshalYAML() (any, error) {
 	if s.Builtin != "" {
 		return s.Builtin, nil
 	}
-	if s.metadataURL != "" && s.Path == "" {
+	if s.metadataURL != "" && s.Path == "" && s.metadataPath == "" {
 		return s.metadataURL, nil
 	}
-	if s.scalar != "" && s.Path == "" {
+	if s.scalar != "" && s.Path == "" && s.metadataPath == "" {
 		return s.scalar, nil
+	}
+	if s.metadataPath != "" && s.Path == "" {
+		type raw struct {
+			Path string `yaml:"path,omitempty"`
+		}
+		return raw{Path: s.metadataPath}, nil
 	}
 	type raw ProviderSource
 	return raw(s), nil
@@ -162,13 +181,21 @@ func (s ProviderSource) MarshalYAML() (any, error) {
 func (s ProviderSource) IsBuiltin() bool     { return s.Builtin != "" }
 func (s ProviderSource) IsMetadataURL() bool { return s.metadataURL != "" }
 func (s ProviderSource) IsLocal() bool       { return s.Path != "" }
-func (s ProviderSource) MetadataURL() string { return s.metadataURL }
+func (s ProviderSource) IsLocalMetadataPath() bool {
+	return s.metadataPath != ""
+}
+func (s ProviderSource) MetadataURL() string  { return s.metadataURL }
+func (s ProviderSource) MetadataPath() string { return s.metadataPath }
 func (s ProviderSource) UnsupportedURL() string {
 	return s.unsupported
 }
 
 func NewMetadataSource(rawURL string) ProviderSource {
 	return ProviderSource{metadataURL: strings.TrimSpace(rawURL)}
+}
+
+func NewLocalReleaseMetadataSource(rawPath string) ProviderSource {
+	return ProviderSource{metadataPath: strings.TrimSpace(rawPath)}
 }
 
 // ProviderEntry is the universal configuration for any provider.
@@ -216,7 +243,7 @@ type ProviderEntry struct {
 
 func (e ProviderEntry) MarshalYAML() (any, error) {
 	type raw ProviderEntry
-	if e.Source.IsMetadataURL() && e.Source.Auth != nil && e.InlineSourceAuth == nil {
+	if e.HasReleaseMetadataSource() && e.Source.Auth != nil && e.InlineSourceAuth == nil {
 		auth := *e.Source.Auth
 		e.InlineSourceAuth = &auth
 		e.Source.Auth = nil
@@ -310,12 +337,24 @@ func (e *ProviderEntry) HasMetadataSource() bool {
 	return e != nil && e.Source.IsMetadataURL()
 }
 
+func (e *ProviderEntry) HasReleaseMetadataSource() bool {
+	return e != nil && (e.Source.IsMetadataURL() || e.Source.IsLocalMetadataPath())
+}
+
 func (e *ProviderEntry) HasRemoteSource() bool {
+	return e != nil && e.Source.IsMetadataURL()
+}
+
+func (e *ProviderEntry) HasRemoteReleaseSource() bool {
 	return e != nil && e.Source.IsMetadataURL()
 }
 
 func (e *ProviderEntry) HasLocalSource() bool {
 	return e != nil && e.Source.IsLocal()
+}
+
+func (e *ProviderEntry) HasLocalReleaseSource() bool {
+	return e != nil && e.Source.IsLocalMetadataPath()
 }
 
 func (e *ProviderEntry) SourceMetadataURL() string {
@@ -335,9 +374,29 @@ func (e *ProviderEntry) SourceRemoteLocation() string {
 	return ""
 }
 
+func (e *ProviderEntry) SourceReleaseLocation() string {
+	if e == nil {
+		return ""
+	}
+	if e.Source.IsMetadataURL() {
+		return e.Source.MetadataURL()
+	}
+	if e.Source.IsLocalMetadataPath() {
+		return e.Source.MetadataPath()
+	}
+	return ""
+}
+
 func (e *ProviderEntry) SourcePath() string {
 	if e.Source.IsLocal() {
 		return e.Source.Path
+	}
+	return ""
+}
+
+func (e *ProviderEntry) SourceReleasePath() string {
+	if e.Source.IsLocalMetadataPath() {
+		return e.Source.MetadataPath()
 	}
 	return ""
 }
@@ -1005,25 +1064,28 @@ func loadMergedConfigRoot(paths []string, lookup func(string) (string, bool), mo
 	}
 
 	roots := make([]yaml.Node, len(paths))
-	useV3Classification := false
+	sourceSyntax := providerSourceSyntaxLegacy
 	for i, path := range paths {
 		root, err := loadValidatedConfigRoot(path, lookup, mode, sentinelPrefix)
 		if err != nil {
 			return yaml.Node{}, err
 		}
-		usesV3, err := configRootUsesAPIVersion(root)
+		rootSyntax, err := configRootSourceSyntax(root)
 		if err != nil {
 			return yaml.Node{}, err
 		}
-		if usesV3 {
-			useV3Classification = true
+		if rootSyntax != providerSourceSyntaxLegacy {
+			if sourceSyntax != providerSourceSyntaxLegacy && sourceSyntax != rootSyntax {
+				return yaml.Node{}, fmt.Errorf("config validation: mixed apiVersion values are not supported across merged config files")
+			}
+			sourceSyntax = rootSyntax
 		}
 		roots[i] = root
 	}
 
 	var merged any
 	for i, path := range paths {
-		value, err := loadConfigValue(path, roots[i], useV3Classification)
+		value, err := loadConfigValue(path, roots[i], sourceSyntax)
 		if err != nil {
 			return yaml.Node{}, err
 		}
@@ -1050,26 +1112,27 @@ func loadMergedConfigRoot(paths []string, lookup func(string) (string, bool), mo
 	return root, nil
 }
 
-func configRootUsesAPIVersion(root yaml.Node) (bool, error) {
+func configRootSourceSyntax(root yaml.Node) (providerSourceSyntaxMode, error) {
 	doc := documentValueNode(&root)
 	if doc == nil || doc.Kind != yaml.MappingNode {
-		return false, nil
+		return providerSourceSyntaxLegacy, nil
 	}
 	node := mappingValueNode(doc, "apiVersion")
 	if node == nil {
-		return false, nil
+		return providerSourceSyntaxLegacy, nil
 	}
 	value := strings.TrimSpace(node.Value)
 	if value == "" {
-		return false, nil
+		return providerSourceSyntaxLegacy, nil
 	}
-	if !usesV3ConfigSyntax(value) {
-		return false, fmt.Errorf("config validation: unsupported apiVersion %q", value)
+	mode, err := providerSourceSyntaxForAPIVersion(value)
+	if err != nil {
+		return providerSourceSyntaxLegacy, err
 	}
-	return true, nil
+	return mode, nil
 }
 
-func loadConfigValue(path string, root yaml.Node, useV3Classification bool) (any, error) {
+func loadConfigValue(path string, root yaml.Node, sourceSyntax providerSourceSyntaxMode) (any, error) {
 	doc := documentValueNode(&root)
 	if doc == nil || doc.Kind == 0 {
 		return nil, nil
@@ -1089,7 +1152,7 @@ func loadConfigValue(path string, root yaml.Node, useV3Classification bool) (any
 		if !ok {
 			return nil, fmt.Errorf("expected mapping document")
 		}
-		resolveRelativePathsInValue(path, root, useV3Classification)
+		resolveRelativePathsInValue(path, root, sourceSyntax)
 	}
 	return normalized, nil
 }
@@ -1530,14 +1593,14 @@ func normalizeProviderSourceShapes(cfg *Config) {
 		return
 	}
 	cfg.APIVersion = strings.TrimSpace(cfg.APIVersion)
-	useV3Classification := usesV3ConfigSyntax(cfg.APIVersion)
+	sourceSyntax := sourceSyntaxForConfig(cfg.APIVersion)
 
 	normalizeEntry := func(kind string, entry *ProviderEntry) {
 		if entry == nil {
 			return
 		}
-		normalizeProviderSource(kind, &entry.Source, useV3Classification)
-		if entry.Source.IsMetadataURL() && entry.Source.Auth == nil && entry.InlineSourceAuth != nil {
+		normalizeProviderSource(kind, &entry.Source, sourceSyntax)
+		if entry.HasReleaseMetadataSource() && entry.Source.Auth == nil && entry.InlineSourceAuth != nil {
 			auth := *entry.InlineSourceAuth
 			entry.Source.Auth = &auth
 			entry.InlineSourceAuth = nil
@@ -1572,12 +1635,16 @@ func normalizeProviderSourceShapes(cfg *Config) {
 	}
 }
 
-func normalizeProviderSource(kind string, source *ProviderSource, useV3Classification bool) {
+func normalizeProviderSource(kind string, source *ProviderSource, sourceSyntax providerSourceSyntaxMode) {
 	if source == nil {
 		return
 	}
 	source.scalar = strings.TrimSpace(source.scalar)
-	if source.Builtin != "" || source.Path != "" || source.metadataURL != "" {
+	if sourceSyntax == providerSourceSyntaxV4 && source.Path != "" && source.metadataPath == "" {
+		source.metadataPath = source.Path
+		source.Path = ""
+	}
+	if source.Builtin != "" || source.Path != "" || source.metadataURL != "" || source.metadataPath != "" {
 		source.scalar = ""
 		return
 	}
@@ -1585,7 +1652,7 @@ func normalizeProviderSource(kind string, source *ProviderSource, useV3Classific
 		return
 	}
 	switch {
-	case !useV3Classification:
+	case sourceSyntax == providerSourceSyntaxLegacy:
 		source.Builtin = source.scalar
 	case isBuiltinScalarSource(kind, source.scalar):
 		source.Builtin = source.scalar
@@ -1593,6 +1660,8 @@ func normalizeProviderSource(kind string, source *ProviderSource, useV3Classific
 		source.metadataURL = source.scalar
 	case looksLikeUnsupportedScalarSource(source.scalar):
 		source.unsupported = source.scalar
+	case sourceSyntax == providerSourceSyntaxV4:
+		source.metadataPath = source.scalar
 	default:
 		source.Path = source.scalar
 	}
@@ -1659,8 +1728,25 @@ func looksLikeUnsupportedScalarSource(value string) bool {
 	return false
 }
 
-func usesV3ConfigSyntax(apiVersion string) bool {
-	return strings.TrimSpace(apiVersion) == APIVersionV3
+func providerSourceSyntaxForAPIVersion(apiVersion string) (providerSourceSyntaxMode, error) {
+	switch strings.TrimSpace(apiVersion) {
+	case "":
+		return providerSourceSyntaxLegacy, nil
+	case APIVersionV3:
+		return providerSourceSyntaxV3, nil
+	case APIVersionV4:
+		return providerSourceSyntaxV4, nil
+	default:
+		return providerSourceSyntaxLegacy, fmt.Errorf("config validation: unsupported apiVersion %q", strings.TrimSpace(apiVersion))
+	}
+}
+
+func sourceSyntaxForConfig(apiVersion string) providerSourceSyntaxMode {
+	mode, err := providerSourceSyntaxForAPIVersion(apiVersion)
+	if err != nil {
+		return providerSourceSyntaxLegacy
+	}
+	return mode
 }
 
 func nonNilProviderEntryMap(entries map[string]*ProviderEntry) map[string]*ProviderEntry {
@@ -1687,7 +1773,7 @@ func applyDefaultBuiltinProviderEntries(entries map[string]*ProviderEntry, defau
 		}
 	}
 	for _, entry := range entries {
-		if entry == nil || entry.Source.IsBuiltin() || entry.Source.IsMetadataURL() || entry.Source.IsLocal() || entry.Source.UnsupportedURL() != "" {
+		if entry == nil || entry.Source.IsBuiltin() || entry.Source.IsMetadataURL() || entry.Source.IsLocalMetadataPath() || entry.Source.IsLocal() || entry.Source.UnsupportedURL() != "" {
 			continue
 		}
 		entry.Source.Builtin = builtin
@@ -1839,7 +1925,7 @@ func resolveBaseURL(cfg *Config) {
 	cfg.Server.Management.BaseURL = strings.TrimRight(strings.TrimSpace(cfg.Server.Management.BaseURL), "/")
 }
 
-func resolveRelativePathsInValue(configPath string, root map[string]any, useV3Classification bool) {
+func resolveRelativePathsInValue(configPath string, root map[string]any, sourceSyntax providerSourceSyntaxMode) {
 	baseDir := filepath.Dir(configPath)
 	if absPath, err := filepath.Abs(configPath); err == nil {
 		baseDir = filepath.Dir(absPath)
@@ -1866,17 +1952,17 @@ func resolveRelativePathsInValue(configPath string, root map[string]any, useV3Cl
 			{key: "workflow", kind: string(HostProviderKindWorkflow)},
 		} {
 			for _, entry := range mapValues(nestedMap(providers, section.key)) {
-				resolveRelativePathsInEntry(section.kind, entry, baseDir, useV3Classification)
+				resolveRelativePathsInEntry(section.kind, entry, baseDir, sourceSyntax)
 			}
 		}
 	}
 
 	for _, entry := range mapValues(nestedMap(root, "plugins")) {
-		resolveRelativePathsInEntry(providermanifestv1.KindPlugin, entry, baseDir, useV3Classification)
+		resolveRelativePathsInEntry(providermanifestv1.KindPlugin, entry, baseDir, sourceSyntax)
 	}
 }
 
-func resolveRelativePathsInEntry(kind string, entry map[string]any, baseDir string, useV3Classification bool) {
+func resolveRelativePathsInEntry(kind string, entry map[string]any, baseDir string, sourceSyntax providerSourceSyntaxMode) {
 	if entry == nil {
 		return
 	}
@@ -1885,7 +1971,7 @@ func resolveRelativePathsInEntry(kind string, entry map[string]any, baseDir stri
 		resolveRelativeStringField(source, "path", baseDir)
 		return
 	}
-	if !useV3Classification {
+	if sourceSyntax == providerSourceSyntaxLegacy {
 		return
 	}
 	sourceValue, ok := entry["source"].(string)

--- a/gestaltd/internal/config/config_test.go
+++ b/gestaltd/internal/config/config_test.go
@@ -951,6 +951,32 @@ plugins:
 		}
 	})
 
+	t.Run("apiVersion v4 classifies scalar local provider-release metadata sources", func(t *testing.T) {
+		t.Parallel()
+
+		path := mustWriteConfigFile(t, `
+apiVersion: gestaltd.config/v4
+providers:
+plugins:
+    custom_tool:
+      source: ./dist/provider-release.yaml
+`)
+
+		cfg, err := Load(path)
+		if err != nil {
+			t.Fatalf("Load: %v", err)
+		}
+		if cfg.APIVersion != APIVersionV4 {
+			t.Fatalf("APIVersion = %q, want %q", cfg.APIVersion, APIVersionV4)
+		}
+		if got := cfg.Plugins["custom_tool"].SourceReleasePath(); got != filepath.Join(filepath.Dir(path), "dist", "provider-release.yaml") {
+			t.Fatalf("unexpected plugin release metadata path: %q", got)
+		}
+		if got := cfg.Plugins["custom_tool"].SourcePath(); got != "" {
+			t.Fatalf("SourcePath() = %q, want empty for v4 local release metadata", got)
+		}
+	})
+
 	t.Run("apiVersion classifies scalar workflow sources", func(t *testing.T) {
 		t.Parallel()
 
@@ -1059,6 +1085,52 @@ plugins:
 		auth, ok = plugin["auth"].(map[string]any)
 		if !ok || auth["token"] != "test-token" {
 			t.Fatalf("config round-tripped auth = %#v", plugin["auth"])
+		}
+	})
+
+	t.Run("apiVersion moves sibling auth onto local release metadata sources", func(t *testing.T) {
+		t.Parallel()
+
+		path := mustWriteConfigFile(t, `
+apiVersion: gestaltd.config/v4
+providers:
+plugins:
+    custom_tool:
+      source: ./plugins/custom_tool/dist/provider-release.yaml
+      auth:
+        token: test-token
+`)
+
+		cfg, err := Load(path)
+		if err != nil {
+			t.Fatalf("Load: %v", err)
+		}
+		entry := cfg.Plugins["custom_tool"]
+		wantPath := filepath.Join(filepath.Dir(path), "plugins", "custom_tool", "dist", "provider-release.yaml")
+		if got := entry.SourceReleasePath(); got != wantPath {
+			t.Fatalf("SourceReleasePath = %q, want %q", got, wantPath)
+		}
+		if entry.Source.Auth == nil || entry.Source.Auth.Token != "test-token" {
+			t.Fatalf("Source.Auth = %#v", entry.Source.Auth)
+		}
+		if entry.InlineSourceAuth != nil {
+			t.Fatalf("InlineSourceAuth = %#v, want nil", entry.InlineSourceAuth)
+		}
+		marshaled, err := yaml.Marshal(entry)
+		if err != nil {
+			t.Fatalf("yaml.Marshal: %v", err)
+		}
+		var roundTripped map[string]any
+		if err := yaml.Unmarshal(marshaled, &roundTripped); err != nil {
+			t.Fatalf("yaml.Unmarshal: %v", err)
+		}
+		source, ok := roundTripped["source"].(map[string]any)
+		if !ok || source["path"] != wantPath {
+			t.Fatalf("round-tripped source = %#v", roundTripped["source"])
+		}
+		auth, ok := roundTripped["auth"].(map[string]any)
+		if !ok || auth["token"] != "test-token" {
+			t.Fatalf("round-tripped auth = %#v", roundTripped["auth"])
 		}
 	})
 
@@ -3168,7 +3240,50 @@ plugins:
       auth:
         token: test-token
 `,
-			wantErr: "auth is only valid with metadata URL sources",
+			wantErr: "auth is only valid with provider-release metadata sources",
+		},
+		{
+			name: "apiVersion v4 local provider-release metadata is valid",
+			yaml: `
+apiVersion: gestaltd.config/v4
+providers:
+plugins:
+    external:
+      source: ./plugins/dummy/dist/provider-release.yaml
+`,
+		},
+		{
+			name: "apiVersion v4 local provider-release metadata allows current-directory file",
+			yaml: `
+apiVersion: gestaltd.config/v4
+providers:
+plugins:
+    external:
+      source: provider-release.yaml
+`,
+		},
+		{
+			name: "apiVersion v4 local provider-release metadata accepts sibling auth",
+			yaml: `
+apiVersion: gestaltd.config/v4
+providers:
+plugins:
+    external:
+      source: ./plugins/dummy/dist/provider-release.yaml
+      auth:
+        token: test-token
+`,
+		},
+		{
+			name: "apiVersion v4 rejects local source manifests",
+			yaml: `
+apiVersion: gestaltd.config/v4
+providers:
+plugins:
+    external:
+      source: ./plugins/dummy/manifest.yaml
+`,
+			wantErr: "source.path must reference provider-release.yaml metadata",
 		},
 		{
 			name: "apiVersion rejects non metadata http source",

--- a/gestaltd/internal/config/config_validate.go
+++ b/gestaltd/internal/config/config_validate.go
@@ -5,6 +5,8 @@ import (
 	"maps"
 	"net"
 	"net/url"
+	"path"
+	"path/filepath"
 	"slices"
 	"sort"
 	"strconv"
@@ -49,6 +51,7 @@ func CanonicalizeStructure(cfg *Config) error {
 // already run on the config.
 func ValidateCanonicalStructure(cfg *Config) error {
 	pluginOwnedUIBindings := pluginOwnedUIBindings(cfg)
+	sourceSyntax := sourceSyntaxForConfig(cfg.APIVersion)
 	if err := validateAuthorizationPolicies(cfg); err != nil {
 		return err
 	}
@@ -77,7 +80,7 @@ func ValidateCanonicalStructure(cfg *Config) error {
 		{HostProviderKindTelemetry, cfg.Providers.Telemetry},
 		{HostProviderKindAudit, cfg.Providers.Audit},
 	} {
-		if err := validateHostProviderEntries(collection.kind, collection.entries); err != nil {
+		if err := validateHostProviderEntries(collection.kind, collection.entries, sourceSyntax); err != nil {
 			return err
 		}
 		if _, _, err := cfg.SelectedHostProvider(collection.kind); err != nil {
@@ -94,7 +97,7 @@ func ValidateCanonicalStructure(cfg *Config) error {
 		if entry.Source.IsBuiltin() {
 			return fmt.Errorf("config validation: ui %q does not support builtin providers; use a provider source reference", name)
 		}
-		if err := validateProviderEntrySource("ui", name, &entry.ProviderEntry); err != nil {
+		if err := validateProviderEntrySource("ui", name, &entry.ProviderEntry, sourceSyntax); err != nil {
 			return err
 		}
 		if err := validateAuthorizationPolicyReference(cfg, "ui", name, entry.AuthorizationPolicy); err != nil {
@@ -130,7 +133,7 @@ func ValidateCanonicalStructure(cfg *Config) error {
 
 	// Validate plugins
 	for name, entry := range cfg.Plugins {
-		if err := validatePlugin(cfg, name, entry); err != nil {
+		if err := validatePlugin(cfg, name, entry, sourceSyntax); err != nil {
 			return err
 		}
 	}
@@ -143,14 +146,14 @@ func validateAPIVersion(cfg *Config) error {
 	}
 	apiVersion := strings.TrimSpace(cfg.APIVersion)
 	switch apiVersion {
-	case "", APIVersionV3:
+	case "", APIVersionV3, APIVersionV4:
 		return nil
 	default:
 		return fmt.Errorf("config validation: unsupported apiVersion %q", apiVersion)
 	}
 }
 
-func validateHostProviderEntries(kind HostProviderKind, entries map[string]*ProviderEntry) error {
+func validateHostProviderEntries(kind HostProviderKind, entries map[string]*ProviderEntry, sourceSyntax providerSourceSyntaxMode) error {
 	for name, entry := range entries {
 		if entry == nil {
 			return fmt.Errorf("config validation: providers.%s.%s is required", kind, name)
@@ -163,19 +166,19 @@ func validateHostProviderEntries(kind HostProviderKind, entries map[string]*Prov
 			if entry.Source.IsBuiltin() {
 				return fmt.Errorf("config validation: auth provider %q does not support builtin providers; use a provider source reference or omit auth", name)
 			}
-			if err := validateProviderEntrySource("auth", name, entry); err != nil {
+			if err := validateProviderEntrySource("auth", name, entry, sourceSyntax); err != nil {
 				return err
 			}
 		case HostProviderKindAuthorization:
 			if entry.Source.IsBuiltin() {
 				return fmt.Errorf("config validation: authorization provider %q does not support builtin providers; use a provider source reference or omit authorization", name)
 			}
-			if err := validateProviderEntrySource("authorization", name, entry); err != nil {
+			if err := validateProviderEntrySource("authorization", name, entry, sourceSyntax); err != nil {
 				return err
 			}
 		case HostProviderKindSecrets, HostProviderKindTelemetry:
 			if !entry.Source.IsBuiltin() {
-				if err := validateProviderEntrySource(string(kind), name, entry); err != nil {
+				if err := validateProviderEntrySource(string(kind), name, entry, sourceSyntax); err != nil {
 					return err
 				}
 			}
@@ -185,7 +188,7 @@ func validateHostProviderEntries(kind HostProviderKind, entries map[string]*Prov
 					return err
 				}
 			} else {
-				if err := validateProviderEntrySource("audit", name, entry); err != nil {
+				if err := validateProviderEntrySource("audit", name, entry, sourceSyntax); err != nil {
 					return err
 				}
 			}
@@ -243,7 +246,7 @@ func validateBuiltinAudit(entry *ProviderEntry) error {
 	}
 }
 
-func validateProviderEntrySource(kind, name string, entry *ProviderEntry) error {
+func validateProviderEntrySource(kind, name string, entry *ProviderEntry, sourceSyntax providerSourceSyntaxMode) error {
 	if entry == nil {
 		return nil
 	}
@@ -271,11 +274,28 @@ func validateProviderEntrySource(kind, name string, entry *ProviderEntry) error 
 	if src.IsMetadataURL() {
 		modeCount++
 	}
+	if src.IsLocalMetadataPath() {
+		modeCount++
+	}
 	if modeCount == 0 {
+		if sourceSyntax == providerSourceSyntaxV4 {
+			return fmt.Errorf("config validation: %s %q source.path or provider-release metadata URL is required", kind, name)
+		}
 		return fmt.Errorf("config validation: %s %q source.path or metadata URL is required", kind, name)
 	}
 	if modeCount > 1 {
+		if sourceSyntax == providerSourceSyntaxV4 {
+			return fmt.Errorf("config validation: %s %q local and remote provider-release metadata sources are mutually exclusive", kind, name)
+		}
 		return fmt.Errorf("config validation: %s %q source.path and metadata URL sources are mutually exclusive", kind, name)
+	}
+	if src.IsLocal() && sourceSyntax == providerSourceSyntaxV4 {
+		return fmt.Errorf("config validation: %s %q apiVersion v4 source.path must reference provider-release.yaml metadata, not a source manifest", kind, name)
+	}
+	if src.IsLocalMetadataPath() {
+		if path.Base(filepath.ToSlash(src.MetadataPath())) != "provider-release.yaml" {
+			return fmt.Errorf("config validation: %s %q source.path must reference provider-release.yaml metadata", kind, name)
+		}
 	}
 	if src.IsMetadataURL() {
 		if parsed, err := url.ParseRequestURI(src.MetadataURL()); err != nil || parsed.Host == "" || (parsed.Scheme != "http" && parsed.Scheme != "https") || !strings.HasSuffix(parsed.Path, "/provider-release.yaml") {
@@ -283,8 +303,8 @@ func validateProviderEntrySource(kind, name string, entry *ProviderEntry) error 
 		}
 	}
 	if auth != nil {
-		if !src.IsMetadataURL() {
-			return fmt.Errorf("config validation: %s %q auth is only valid with metadata URL sources", kind, name)
+		if !src.IsMetadataURL() && !src.IsLocalMetadataPath() {
+			return fmt.Errorf("config validation: %s %q auth is only valid with provider-release metadata sources", kind, name)
 		}
 		if strings.TrimSpace(auth.Token) == "" {
 			return fmt.Errorf("config validation: %s %q auth.token is required when auth is set", kind, name)
@@ -357,7 +377,7 @@ func ValidateRuntime(cfg *Config) error {
 	return nil
 }
 
-func validatePlugin(cfg *Config, name string, entry *ProviderEntry) error {
+func validatePlugin(cfg *Config, name string, entry *ProviderEntry, sourceSyntax providerSourceSyntaxMode) error {
 	if entry == nil {
 		return fmt.Errorf("config validation: plugin %q requires a source", name)
 	}
@@ -392,7 +412,7 @@ func validatePlugin(cfg *Config, name string, entry *ProviderEntry) error {
 	if entry.UI != "" && entry.MountPath == "" {
 		return fmt.Errorf("config validation: plugins.%s.ui requires plugins.%s.mountPath", name, name)
 	}
-	if err := validateProviderEntrySource("plugin", name, entry); err != nil {
+	if err := validateProviderEntrySource("plugin", name, entry, sourceSyntax); err != nil {
 		return err
 	}
 	if err := validatePluginIndexedDBConfig(cfg, name, entry); err != nil {
@@ -414,6 +434,7 @@ func validatePlugin(cfg *Config, name string, entry *ProviderEntry) error {
 }
 
 func validateDatastoreConfig(cfg *Config) error {
+	sourceSyntax := sourceSyntaxForConfig(cfg.APIVersion)
 	for name, entry := range cfg.Providers.IndexedDB {
 		if entry == nil {
 			return fmt.Errorf("config validation: providers.indexeddb.%s is required", name)
@@ -421,7 +442,7 @@ func validateDatastoreConfig(cfg *Config) error {
 		if err := validatePluginOnlyProviderFields("providers.indexeddb."+name, entry); err != nil {
 			return err
 		}
-		if err := validateProviderEntrySource("indexeddb", name, entry); err != nil {
+		if err := validateProviderEntrySource("indexeddb", name, entry, sourceSyntax); err != nil {
 			return err
 		}
 	}
@@ -432,6 +453,7 @@ func validateDatastoreConfig(cfg *Config) error {
 }
 
 func validateCacheConfig(cfg *Config) error {
+	sourceSyntax := sourceSyntaxForConfig(cfg.APIVersion)
 	for name, entry := range cfg.Providers.Cache {
 		if entry == nil {
 			return fmt.Errorf("config validation: providers.cache.%s is required", name)
@@ -442,7 +464,7 @@ func validateCacheConfig(cfg *Config) error {
 		if err := validatePluginOnlyProviderFields("providers.cache."+name, entry); err != nil {
 			return err
 		}
-		if err := validateProviderEntrySource("cache", name, entry); err != nil {
+		if err := validateProviderEntrySource("cache", name, entry, sourceSyntax); err != nil {
 			return err
 		}
 	}
@@ -450,6 +472,7 @@ func validateCacheConfig(cfg *Config) error {
 }
 
 func validateS3Config(cfg *Config) error {
+	sourceSyntax := sourceSyntaxForConfig(cfg.APIVersion)
 	for name, entry := range cfg.Providers.S3 {
 		if entry == nil {
 			return fmt.Errorf("config validation: providers.s3.%s is required", name)
@@ -457,7 +480,7 @@ func validateS3Config(cfg *Config) error {
 		if err := validatePluginOnlyProviderFields("providers.s3."+name, entry); err != nil {
 			return err
 		}
-		if err := validateProviderEntrySource("s3", name, entry); err != nil {
+		if err := validateProviderEntrySource("s3", name, entry, sourceSyntax); err != nil {
 			return err
 		}
 	}
@@ -465,6 +488,7 @@ func validateS3Config(cfg *Config) error {
 }
 
 func validateWorkflowConfig(cfg *Config) error {
+	sourceSyntax := sourceSyntaxForConfig(cfg.APIVersion)
 	defaults := make([]string, 0, len(cfg.Providers.Workflow))
 	for name, entry := range cfg.Providers.Workflow {
 		if entry == nil {
@@ -483,7 +507,7 @@ func validateWorkflowConfig(cfg *Config) error {
 		if err := validateWorkflowProviderFields(cfg, name, entry); err != nil {
 			return err
 		}
-		if err := validateProviderEntrySource("workflow", name, entry); err != nil {
+		if err := validateProviderEntrySource("workflow", name, entry, sourceSyntax); err != nil {
 			return err
 		}
 	}

--- a/gestaltd/internal/operator/lifecycle.go
+++ b/gestaltd/internal/operator/lifecycle.go
@@ -172,10 +172,7 @@ func (l *Lifecycle) initAtPaths(configPaths []string, state StatePaths) (*Lockfi
 	if err := config.ValidateResolvedStructure(cfg); err != nil {
 		return nil, nil, initPaths{}, err
 	}
-	if err := plugininvocation.ValidateEffectiveCatalogs(context.Background(), cfg); err != nil {
-		return nil, nil, initPaths{}, err
-	}
-	if err := plugininvocation.ValidateDependencies(context.Background(), cfg); err != nil {
+	if err := plugininvocation.ValidateEffectiveCatalogsAndDependencies(context.Background(), cfg); err != nil {
 		return nil, nil, initPaths{}, err
 	}
 	if err := WriteLockfile(paths.lockfilePath, lock); err != nil {
@@ -258,7 +255,7 @@ func (l *Lifecycle) prepareRuntimeLockFromLoadedConfig(ctx context.Context, path
 	}
 	for name, entry := range cfg.Providers.UI {
 		if entry != nil && sourceBacked(&entry.ProviderEntry) {
-			if _, existed := existingUIEntries[name]; !existed && entry.HasLocalSource() {
+			if _, existed := existingUIEntries[name]; !existed && (entry.HasLocalSource() || entry.HasLocalReleaseSource()) {
 				if plugin := cfg.Plugins[name]; plugin != nil && strings.TrimSpace(plugin.UI) == "" && strings.TrimSpace(plugin.MountPath) != "" {
 					continue
 				}
@@ -654,7 +651,7 @@ type providerFingerprintInput struct {
 }
 
 func sourceBacked(entry *config.ProviderEntry) bool {
-	return entry != nil && (entry.HasRemoteSource() || entry.HasLocalSource())
+	return entry != nil && (entry.HasRemoteSource() || entry.HasLocalSource() || entry.HasLocalReleaseSource())
 }
 
 func hostProviderCollections(cfg *config.Config) []struct {
@@ -734,29 +731,29 @@ func configHasProviderLoading(cfg *config.Config) bool {
 
 func configHasLocalProviderSources(cfg *config.Config) bool {
 	for _, entry := range cfg.Plugins {
-		if entry.HasLocalSource() {
+		if entry.HasLocalSource() || entry.HasLocalReleaseSource() {
 			return true
 		}
 	}
 	for _, collection := range hostProviderCollections(cfg) {
 		for _, entry := range collection.entries {
-			if entry != nil && entry.HasLocalSource() {
+			if entry != nil && (entry.HasLocalSource() || entry.HasLocalReleaseSource()) {
 				return true
 			}
 		}
 	}
 	for _, entry := range cfg.Providers.UI {
-		if entry != nil && entry.HasLocalSource() {
+		if entry != nil && (entry.HasLocalSource() || entry.HasLocalReleaseSource()) {
 			return true
 		}
 	}
 	for _, def := range cfg.Providers.IndexedDB {
-		if def != nil && def.HasLocalSource() {
+		if def != nil && (def.HasLocalSource() || def.HasLocalReleaseSource()) {
 			return true
 		}
 	}
 	for _, def := range cfg.Providers.S3 {
-		if def != nil && def.HasLocalSource() {
+		if def != nil && (def.HasLocalSource() || def.HasLocalReleaseSource()) {
 			return true
 		}
 	}
@@ -1111,11 +1108,17 @@ func ProviderFingerprint(name string, entry *config.ProviderEntry, configDir str
 
 	input := providerFingerprintInput{
 		Name:   name,
-		Source: entry.SourceRemoteLocation(),
+		Source: providerSourceLockLocation(entry, configDir),
 	}
 	if entry.HasLocalSource() {
 		input.Path = fingerprintLocalSourcePath(entry.SourcePath(), configDir)
 		digest, err := fingerprintLocalSourceDigest(entry.SourcePath())
+		if err != nil {
+			return "", err
+		}
+		input.Digest = digest
+	} else if entry.HasLocalReleaseSource() {
+		digest, err := fingerprintLocalReleaseMetadataDigest(entry.SourceReleasePath())
 		if err != nil {
 			return "", err
 		}
@@ -1132,6 +1135,27 @@ func ProviderFingerprint(name string, entry *config.ProviderEntry, configDir str
 
 func NamedUIProviderFingerprint(name string, entry *config.ProviderEntry, configDir string) (string, error) {
 	return ProviderFingerprint("ui:"+name, entry, configDir)
+}
+
+func providerSourceLockLocation(entry *config.ProviderEntry, configDir string) string {
+	if entry == nil {
+		return ""
+	}
+	if entry.HasRemoteSource() {
+		return entry.SourceRemoteLocation()
+	}
+	if entry.HasLocalReleaseSource() {
+		return fingerprintLocalSourcePath(entry.SourceReleasePath(), configDir)
+	}
+	return ""
+}
+
+func resolveLockedArchiveLocation(configDir, sourceLocation, archiveRef string) (string, error) {
+	if isRemoteReleaseMetadataLocation(sourceLocation) {
+		return resolveArchiveSourceLocation(sourceLocation, archiveRef)
+	}
+	metadataPath := resolveLockPath(configDir, sourceLocation)
+	return resolveArchiveSourceLocation(metadataPath, archiveRef)
 }
 
 func fingerprintLocalSourcePath(sourcePath, configDir string) string {
@@ -1177,6 +1201,68 @@ func fingerprintLocalSourceDigest(sourcePath string) (string, error) {
 		return "", err
 	}
 	return providerpkg.DirectoryDigest(sourceDir, manifestPath, manifest)
+}
+
+func fingerprintLocalReleaseMetadataDigest(sourcePath string) (string, error) {
+	payload, err := normalizedLocalReleaseMetadataFingerprintPayloadFromFile(sourcePath)
+	if err != nil {
+		return "", err
+	}
+	if digest, ok, err := fingerprintLocalReleaseSourceTreeDigest(sourcePath); err != nil {
+		return "", err
+	} else if ok {
+		input := struct {
+			SourceDigest string          `json:"sourceDigest"`
+			Metadata     json.RawMessage `json:"metadata"`
+		}{
+			SourceDigest: digest,
+			Metadata:     payload,
+		}
+		data, err := json.Marshal(input)
+		if err != nil {
+			return "", err
+		}
+		sum := sha256.Sum256(data)
+		return hex.EncodeToString(sum[:]), nil
+	}
+	sum := sha256.Sum256(payload)
+	return hex.EncodeToString(sum[:]), nil
+}
+
+func fingerprintLocalReleaseSourceTreeDigest(sourcePath string) (string, bool, error) {
+	cleaned := filepath.Clean(sourcePath)
+	if filepath.Base(cleaned) != "provider-release.yaml" {
+		return "", false, nil
+	}
+	distDir := filepath.Dir(cleaned)
+	if filepath.Base(distDir) != "dist" {
+		return "", false, nil
+	}
+	sourceDir := filepath.Dir(distDir)
+
+	var manifestPath string
+	for _, name := range providerpkg.ManifestFiles {
+		candidate := filepath.Join(sourceDir, name)
+		if _, err := os.Stat(candidate); err == nil {
+			manifestPath = candidate
+			break
+		} else if !os.IsNotExist(err) {
+			return "", false, err
+		}
+	}
+	if manifestPath == "" {
+		return "", false, nil
+	}
+
+	_, manifest, err := providerpkg.PrepareSourceManifest(manifestPath)
+	if err != nil {
+		return "", false, err
+	}
+	digest, err := providerpkg.DirectoryDigest(sourceDir, manifestPath, manifest)
+	if err != nil {
+		return "", false, err
+	}
+	return digest, true, nil
 }
 
 func archivePolicyKind(kind string) string {
@@ -1256,7 +1342,7 @@ func lockEntryMatches(paths initPaths, kind, name string, providerEntry *config.
 	if err != nil || entry.Fingerprint != fingerprint {
 		return false
 	}
-	if entry.Source != providerEntry.SourceRemoteLocation() {
+	if entry.Source != providerSourceLockLocation(providerEntry, paths.configDir) {
 		return false
 	}
 	if len(entry.Archives) > 0 {
@@ -1465,8 +1551,8 @@ func localUILockEntryFromPreparedInstall(paths initPaths, name string, plugin *c
 	}, nil
 }
 
-func (l *Lifecycle) installMetadataSourcePackage(ctx context.Context, expectedKind, name, subject, destDir string, plugin *config.ProviderEntry) (*pluginstore.InstalledPlugin, LockEntry, error) {
-	sourceLocation := plugin.SourceMetadataURL()
+func (l *Lifecycle) installMetadataSourcePackage(ctx context.Context, expectedKind, name, subject, destDir string, plugin *config.ProviderEntry, configDir string) (*pluginstore.InstalledPlugin, LockEntry, error) {
+	sourceLocation := plugin.SourceReleaseLocation()
 	metadata, err := fetchProviderReleaseMetadata(ctx, l.metadataHTTPClient(), sourceLocation, sourceAuthToken(plugin))
 	if err != nil {
 		return nil, LockEntry{}, fmt.Errorf("%s fetch metadata %q: %w", subject, sourceLocation, err)
@@ -1483,7 +1569,7 @@ func (l *Lifecycle) installMetadataSourcePackage(ctx context.Context, expectedKi
 		Package:  metadata.Package,
 		Kind:     metadata.Kind,
 		Runtime:  metadata.Runtime,
-		Source:   sourceLocation,
+		Source:   providerSourceLockLocation(plugin, configDir),
 		Version:  metadata.Version,
 		Archives: archives,
 	}
@@ -1493,7 +1579,11 @@ func (l *Lifecycle) installMetadataSourcePackage(ctx context.Context, expectedKi
 	if !ok || archive.URL == "" {
 		return nil, LockEntry{}, fmt.Errorf("no archive for platform %s for %s; publish an explicit %s target or a generic package where allowed", currentPlatform, subject, currentPlatform)
 	}
-	download, err := downloadArchiveForSource(ctx, l.metadataHTTPClient(), sourceAuthToken(plugin), archive.URL)
+	archiveLocation, err := resolveLockedArchiveLocation(configDir, entry.Source, archive.URL)
+	if err != nil {
+		return nil, LockEntry{}, fmt.Errorf("resolve archive for %s: %w", subject, err)
+	}
+	download, err := downloadArchiveForSource(ctx, l.metadataHTTPClient(), sourceAuthToken(plugin), archiveLocation)
 	if err != nil {
 		return nil, LockEntry{}, fmt.Errorf("download metadata source package for %s: %w", subject, err)
 	}
@@ -1575,17 +1665,17 @@ func (l *Lifecycle) lockComponentEntryForSource(ctx context.Context, paths initP
 		return localLockEntryFromPreparedInstall(paths, kind, name, plugin, install)
 	}
 
-	sourceLocation := plugin.SourceRemoteLocation()
+	sourceLocation := plugin.SourceReleaseLocation()
 	var (
 		installed *pluginstore.InstalledPlugin
 		entry     LockEntry
 		err       error
 	)
 	subject := fmt.Sprintf("%s %q", kind, name)
-	if !plugin.HasMetadataSource() {
-		return LockEntry{}, fmt.Errorf("%s %q source %q: only metadata URL and local path sources are supported", kind, name, sourceLocation)
+	if !plugin.HasReleaseMetadataSource() {
+		return LockEntry{}, fmt.Errorf("%s %q source %q: only provider-release metadata sources and local manifest paths are supported", kind, name, sourceLocation)
 	}
-	installed, entry, err = l.installMetadataSourcePackage(ctx, kind, name, subject, destDir, plugin)
+	installed, entry, err = l.installMetadataSourcePackage(ctx, kind, name, subject, destDir, plugin, paths.configDir)
 	if err != nil {
 		return LockEntry{}, err
 	}
@@ -1630,17 +1720,17 @@ func (l *Lifecycle) lockProviderEntryForSource(ctx context.Context, paths initPa
 		return localLockEntryFromPreparedInstall(paths, providermanifestv1.KindPlugin, name, plugin, install)
 	}
 
-	sourceLocation := plugin.SourceRemoteLocation()
+	sourceLocation := plugin.SourceReleaseLocation()
 	destDir := providerDestDir(paths, name)
 	var (
 		installed *pluginstore.InstalledPlugin
 		entry     LockProviderEntry
 		err       error
 	)
-	if !plugin.HasMetadataSource() {
-		return LockProviderEntry{}, fmt.Errorf("provider %q source %q: only metadata URL and local path sources are supported", name, sourceLocation)
+	if !plugin.HasReleaseMetadataSource() {
+		return LockProviderEntry{}, fmt.Errorf("provider %q source %q: only provider-release metadata sources and local manifest paths are supported", name, sourceLocation)
 	}
-	installed, entry, err = l.installMetadataSourcePackage(ctx, providermanifestv1.KindPlugin, name, fmt.Sprintf("provider %q", name), destDir, plugin)
+	installed, entry, err = l.installMetadataSourcePackage(ctx, providermanifestv1.KindPlugin, name, fmt.Sprintf("provider %q", name), destDir, plugin, paths.configDir)
 	if err != nil {
 		return LockProviderEntry{}, err
 	}
@@ -1699,17 +1789,17 @@ func (l *Lifecycle) writeNamedUIProviderArtifact(ctx context.Context, paths init
 		entry.Fingerprint = fingerprint
 		return entry, nil
 	}
-	expectedPackage := plugin.SourceRemoteLocation()
+	expectedPackage := plugin.SourceReleaseLocation()
 
 	var (
 		installed *pluginstore.InstalledPlugin
 		entry     LockUIEntry
 		opErr     error
 	)
-	if !plugin.HasMetadataSource() {
-		return LockUIEntry{}, fmt.Errorf("%s source %q: only metadata URL and local path sources are supported", subject, expectedPackage)
+	if !plugin.HasReleaseMetadataSource() {
+		return LockUIEntry{}, fmt.Errorf("%s source %q: only provider-release metadata sources and local manifest paths are supported", subject, expectedPackage)
 	}
-	installed, entry, opErr = l.installMetadataSourcePackage(ctx, providermanifestv1.KindWebUI, name, subject, destDir, plugin)
+	installed, entry, opErr = l.installMetadataSourcePackage(ctx, providermanifestv1.KindWebUI, name, subject, destDir, plugin, paths.configDir)
 	if opErr != nil {
 		return LockUIEntry{}, opErr
 	}
@@ -2039,7 +2129,7 @@ func validateSynthesizedPluginUIEntry(pluginName string, existing, expected *con
 	if existing == nil || expected == nil {
 		return nil
 	}
-	if current := strings.TrimSpace(existing.SourceRemoteLocation()); current != "" {
+	if current := strings.TrimSpace(existing.SourceReleaseLocation()); current != "" {
 		return fmt.Errorf("config validation: plugins.%s owned ui conflicts with providers.ui.%s.source", pluginName, pluginName)
 	}
 	if current := strings.TrimSpace(existing.Source.Path); current != "" && !equivalentProviderManifestPath(current, expected.Source.Path) {
@@ -2175,7 +2265,7 @@ func (l *Lifecycle) applyLockedProviderEntry(paths initPaths, lock *Lockfile, na
 	if err != nil {
 		return fmt.Errorf("fingerprinting provider %q: %w", name, err)
 	}
-	if entry.Fingerprint != fingerprint || entry.Source != plugin.SourceRemoteLocation() {
+	if entry.Fingerprint != fingerprint || entry.Source != providerSourceLockLocation(plugin, paths.configDir) {
 		return fmt.Errorf("prepared artifact for provider %q is missing or stale; run `gestaltd init %s`", name, paths.configFlags)
 	}
 
@@ -2232,7 +2322,7 @@ func (l *Lifecycle) applyLockedComponentEntry(paths initPaths, entry *LockEntry,
 	if err != nil {
 		return fmt.Errorf("fingerprinting %s %q provider: %w", kind, name, err)
 	}
-	if entry.Fingerprint != fingerprint || entry.Source != plugin.SourceRemoteLocation() {
+	if entry.Fingerprint != fingerprint || entry.Source != providerSourceLockLocation(plugin, paths.configDir) {
 		return fmt.Errorf("prepared artifact for %s %q is missing or stale; run `gestaltd init %s`", kind, name, paths.configFlags)
 	}
 
@@ -2354,17 +2444,33 @@ func (l *Lifecycle) materializeLockedProvider(ctx context.Context, paths initPat
 	if !ok || archive.URL == "" {
 		return fmt.Errorf("no archive for platform %s for provider %q; run `gestaltd init %s`", platform, name, paths.configFlags)
 	}
-	if locked && archive.SHA256 == "" {
+	archiveLocation, err := resolveLockedArchiveLocation(paths.configDir, entry.Source, archive.URL)
+	if err != nil {
+		return fmt.Errorf("resolve locked source provider for provider %q: %w", name, err)
+	}
+	if locked && archive.SHA256 == "" && archiveReferenceNeedsIntegrityHash(archiveLocation) {
 		return fmt.Errorf("no verified hash for platform %s for provider %q; run `gestaltd init %s`", platform, name, formatPlatformInitFlags(paths, platform))
 	}
-
-	download, err := downloadArchiveForSource(ctx, l.metadataHTTPClient(), sourceAuthToken(plugin), archive.URL)
+	download, err := downloadArchiveForSource(ctx, l.metadataHTTPClient(), sourceAuthToken(plugin), archiveLocation)
 	if err != nil {
 		return fmt.Errorf("download locked source provider for provider %q: %w", name, err)
 	}
 	defer download.Cleanup()
 	if archive.SHA256 != "" && download.SHA256Hex != archive.SHA256 {
 		return fmt.Errorf("locked source provider digest mismatch for provider %q: got %s, want %s", name, download.SHA256Hex, archive.SHA256)
+	}
+	if archive.SHA256 == "" {
+		sourceLocation := entry.Source
+		if !isRemoteReleaseMetadataLocation(sourceLocation) {
+			sourceLocation = resolveLockPath(paths.configDir, sourceLocation)
+		}
+		expectedSHA, err := localReleaseArchiveExpectedSHA(sourceLocation, resolvedKey, archiveLocation)
+		if err != nil {
+			return fmt.Errorf("load local archive metadata for provider %q: %w", name, err)
+		}
+		if expectedSHA != "" && download.SHA256Hex != expectedSHA {
+			return fmt.Errorf("locked source provider digest mismatch for provider %q: got %s, want %s", name, download.SHA256Hex, expectedSHA)
+		}
 	}
 
 	destDir := providerDestDir(paths, name)
@@ -2394,17 +2500,33 @@ func (l *Lifecycle) materializeLockedComponent(ctx context.Context, paths initPa
 	if !ok || archive.URL == "" {
 		return fmt.Errorf("no archive for platform %s for %s %q; run `gestaltd init %s`", platform, kind, name, paths.configFlags)
 	}
-	if locked && archive.SHA256 == "" {
+	archiveLocation, err := resolveLockedArchiveLocation(paths.configDir, entry.Source, archive.URL)
+	if err != nil {
+		return fmt.Errorf("resolve locked source provider for %s %q: %w", kind, name, err)
+	}
+	if locked && archive.SHA256 == "" && archiveReferenceNeedsIntegrityHash(archiveLocation) {
 		return fmt.Errorf("no verified hash for platform %s for %s %q; run `gestaltd init %s`", platform, kind, name, formatPlatformInitFlags(paths, platform))
 	}
-
-	download, err := downloadArchiveForSource(ctx, l.metadataHTTPClient(), sourceAuthToken(plugin), archive.URL)
+	download, err := downloadArchiveForSource(ctx, l.metadataHTTPClient(), sourceAuthToken(plugin), archiveLocation)
 	if err != nil {
 		return fmt.Errorf("download locked source provider for %s %q: %w", kind, name, err)
 	}
 	defer download.Cleanup()
 	if archive.SHA256 != "" && download.SHA256Hex != archive.SHA256 {
 		return fmt.Errorf("locked source provider digest mismatch for %s %q: got %s, want %s", kind, name, download.SHA256Hex, archive.SHA256)
+	}
+	if archive.SHA256 == "" {
+		sourceLocation := entry.Source
+		if !isRemoteReleaseMetadataLocation(sourceLocation) {
+			sourceLocation = resolveLockPath(paths.configDir, sourceLocation)
+		}
+		expectedSHA, err := localReleaseArchiveExpectedSHA(sourceLocation, resolvedKey, archiveLocation)
+		if err != nil {
+			return fmt.Errorf("load local archive metadata for %s %q: %w", kind, name, err)
+		}
+		if expectedSHA != "" && download.SHA256Hex != expectedSHA {
+			return fmt.Errorf("locked source provider digest mismatch for %s %q: got %s, want %s", kind, name, download.SHA256Hex, expectedSHA)
+		}
 	}
 
 	if destDir == "" {
@@ -2435,21 +2557,37 @@ func (l *Lifecycle) materializeLockedComponent(ctx context.Context, paths initPa
 
 func (l *Lifecycle) materializeLockedUIProvider(ctx context.Context, paths initPaths, plugin *config.ProviderEntry, entry LockUIEntry, destDir string, locked bool) error {
 	platform := providerpkg.CurrentPlatformString()
-	archive, _, ok := resolveArchiveForPlatform(entry, platform)
+	archive, resolvedKey, ok := resolveArchiveForPlatform(entry, platform)
 	if !ok || archive.URL == "" {
 		return fmt.Errorf("no archive for platform %s for ui provider; run `gestaltd init %s`", platform, paths.configFlags)
 	}
-	if locked && archive.SHA256 == "" {
+	archiveLocation, err := resolveLockedArchiveLocation(paths.configDir, entry.Source, archive.URL)
+	if err != nil {
+		return fmt.Errorf("resolve locked source for ui provider: %w", err)
+	}
+	if locked && archive.SHA256 == "" && archiveReferenceNeedsIntegrityHash(archiveLocation) {
 		return fmt.Errorf("no verified hash for platform %s for ui provider; run `gestaltd init %s`", platform, formatPlatformInitFlags(paths, platform))
 	}
-
-	download, err := downloadArchiveForSource(ctx, l.metadataHTTPClient(), sourceAuthToken(plugin), archive.URL)
+	download, err := downloadArchiveForSource(ctx, l.metadataHTTPClient(), sourceAuthToken(plugin), archiveLocation)
 	if err != nil {
 		return fmt.Errorf("download locked source for ui provider: %w", err)
 	}
 	defer download.Cleanup()
 	if archive.SHA256 != "" && download.SHA256Hex != archive.SHA256 {
 		return fmt.Errorf("locked source digest mismatch for ui provider: got %s, want %s", download.SHA256Hex, archive.SHA256)
+	}
+	if archive.SHA256 == "" {
+		sourceLocation := entry.Source
+		if !isRemoteReleaseMetadataLocation(sourceLocation) {
+			sourceLocation = resolveLockPath(paths.configDir, sourceLocation)
+		}
+		expectedSHA, err := localReleaseArchiveExpectedSHA(sourceLocation, resolvedKey, archiveLocation)
+		if err != nil {
+			return fmt.Errorf("load local archive metadata for ui provider: %w", err)
+		}
+		if expectedSHA != "" && download.SHA256Hex != expectedSHA {
+			return fmt.Errorf("locked source digest mismatch for ui provider: got %s, want %s", download.SHA256Hex, expectedSHA)
+		}
 	}
 
 	if err := os.RemoveAll(destDir); err != nil {
@@ -2515,8 +2653,15 @@ func (l *Lifecycle) hashArchiveEntry(ctx context.Context, kind, name string, ent
 	if err := validateLockedArchivePolicy(archivePolicySubject(kind, name), policyKind, manifest, *entry, platformKey, resolvedKey); err != nil {
 		return err
 	}
+	archiveLocation, err := resolveLockedArchiveLocation(paths.configDir, entry.Source, archive.URL)
+	if err != nil {
+		return fmt.Errorf("resolve archive for platform %s, source %s: %w", platformKey, entry.Source, err)
+	}
+	if !archiveReferenceNeedsIntegrityHash(archiveLocation) {
+		return nil
+	}
 	token := tokenForSource[entry.Source]
-	dl, err := downloadArchiveForSource(ctx, l.metadataHTTPClient(), token, archive.URL)
+	dl, err := downloadArchiveForSource(ctx, l.metadataHTTPClient(), token, archiveLocation)
 	if err != nil {
 		return fmt.Errorf("download archive for platform %s, source %s: %w", platformKey, entry.Source, err)
 	}

--- a/gestaltd/internal/operator/lifecycle_source_test.go
+++ b/gestaltd/internal/operator/lifecycle_source_test.go
@@ -103,6 +103,21 @@ func buildV2ArchiveForArtifact(t *testing.T, dir, source, version, artifactPath,
 	return archivePath
 }
 
+func writeProviderReleaseMetadataFile(t *testing.T, path string, metadata providerReleaseMetadata) {
+	t.Helper()
+
+	if err := os.MkdirAll(filepath.Dir(path), 0o755); err != nil {
+		t.Fatalf("create metadata dir: %v", err)
+	}
+	data, err := yaml.Marshal(metadata)
+	if err != nil {
+		t.Fatalf("marshal metadata: %v", err)
+	}
+	if err := os.WriteFile(path, data, 0o644); err != nil {
+		t.Fatalf("write metadata: %v", err)
+	}
+}
+
 func buildExecutableArchive(t *testing.T, dir, srcDirName, source, version, kind, binaryName, binaryContent string) string {
 	t.Helper()
 
@@ -315,252 +330,441 @@ func newGitHubRewriteClient(t *testing.T, target string) *http.Client {
 func TestSourcePluginMetadataURLInitAndLockedLoad(t *testing.T) {
 	t.Parallel()
 
-	dir := t.TempDir()
-	packageSource := "github.com/acme/tools/alpha"
-	version := "1.2.3"
-	currentArchivePath := buildV2Archive(t, dir, packageSource, version, "metadata-url-plugin-binary")
-	currentArchiveData, err := os.ReadFile(currentArchivePath)
-	if err != nil {
-		t.Fatalf("read current archive: %v", err)
-	}
-	currentArchiveSHA := sha256.Sum256(currentArchiveData)
-
-	extraPlatform := struct {
-		goos   string
-		goarch string
+	for _, tc := range []struct {
+		name               string
+		apiVersion         string
+		localSource        bool
+		remoteArchives     bool
+		tamperLocalArchive bool
 	}{
-		goos:   "linux",
-		goarch: "amd64",
-	}
-	for _, candidate := range []struct {
-		goos   string
-		goarch string
-	}{
-		{goos: "linux", goarch: "amd64"},
-		{goos: "linux", goarch: "arm64"},
-		{goos: "darwin", goarch: "amd64"},
-		{goos: "darwin", goarch: "arm64"},
+		{name: "remote metadata url", apiVersion: config.APIVersionV3},
+		{name: "local metadata file", apiVersion: config.APIVersionV4, localSource: true},
+		{name: "local metadata file with remote archives", apiVersion: config.APIVersionV4, localSource: true, remoteArchives: true},
+		{name: "local metadata file rejects tampered archive", apiVersion: config.APIVersionV4, localSource: true, tamperLocalArchive: true},
 	} {
-		if candidate.goos != runtime.GOOS || candidate.goarch != runtime.GOARCH {
-			extraPlatform = candidate
-			break
-		}
-	}
-	extraPlatformKey := providerpkg.PlatformString(extraPlatform.goos, extraPlatform.goarch)
-	extraArchiveData := []byte("metadata-extra-platform-archive")
-	extraArchiveSHA := sha256.Sum256(extraArchiveData)
+		tc := tc
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
 
-	var metadataCount atomic.Int64
-	var currentArchiveCount atomic.Int64
-	var extraArchiveCount atomic.Int64
-	handlerErrs := make(chan error, 4)
-	nextHandlerErr := func() error {
-		t.Helper()
-		select {
-		case err := <-handlerErrs:
-			return err
-		default:
-			return nil
-		}
-	}
-	metadataPath := "/providers/alpha/provider-release.yaml"
-	currentArchivePathURL := "/providers/alpha/alpha-current.tar.gz"
-	extraArchivePathURL := "/providers/alpha/alpha-extra.tar.gz"
-	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		switch r.URL.Path {
-		case metadataPath:
-			metadataCount.Add(1)
-			if got := r.Header.Get("Authorization"); got != "Bearer test-token" {
-				handlerErrs <- fmt.Errorf("metadata authorization = %q, want %q", got, "Bearer test-token")
-				http.Error(w, "bad metadata authorization", http.StatusBadRequest)
-				return
-			}
-			metadata := providerReleaseMetadata{
-				Schema:        providerReleaseSchemaName,
-				SchemaVersion: providerReleaseSchemaVersion,
-				Package:       packageSource,
-				Kind:          providermanifestv1.KindPlugin,
-				Version:       version,
-				Runtime:       providerReleaseRuntimeExecutable,
-				Artifacts: map[string]providerReleaseArtifact{
-					providerpkg.CurrentPlatformString(): {
-						Path:   filepath.Base(currentArchivePathURL),
-						SHA256: hex.EncodeToString(currentArchiveSHA[:]),
-					},
-					extraPlatformKey: {
-						Path:   filepath.Base(extraArchivePathURL),
-						SHA256: hex.EncodeToString(extraArchiveSHA[:]),
-					},
-				},
-			}
-			data, err := yaml.Marshal(metadata)
+			dir := t.TempDir()
+			packageSource := "github.com/acme/tools/alpha"
+			version := "1.2.3"
+			currentArchivePath := buildV2Archive(t, dir, packageSource, version, "metadata-url-plugin-binary")
+			currentArchiveData, err := os.ReadFile(currentArchivePath)
 			if err != nil {
-				handlerErrs <- fmt.Errorf("marshal metadata: %v", err)
-				http.Error(w, "metadata marshal failed", http.StatusInternalServerError)
+				t.Fatalf("read current archive: %v", err)
+			}
+			currentArchiveSHA := sha256.Sum256(currentArchiveData)
+
+			extraPlatform := struct {
+				goos   string
+				goarch string
+			}{
+				goos:   "linux",
+				goarch: "amd64",
+			}
+			for _, candidate := range []struct {
+				goos   string
+				goarch string
+			}{
+				{goos: "linux", goarch: "amd64"},
+				{goos: "linux", goarch: "arm64"},
+				{goos: "darwin", goarch: "amd64"},
+				{goos: "darwin", goarch: "arm64"},
+			} {
+				if candidate.goos != runtime.GOOS || candidate.goarch != runtime.GOARCH {
+					extraPlatform = candidate
+					break
+				}
+			}
+			extraPlatformKey := providerpkg.PlatformString(extraPlatform.goos, extraPlatform.goarch)
+			extraArchiveData := []byte("metadata-extra-platform-archive")
+			extraArchiveSHA := sha256.Sum256(extraArchiveData)
+
+			var metadataCount atomic.Int64
+			var currentArchiveCount atomic.Int64
+			var extraArchiveCount atomic.Int64
+			handlerErrs := make(chan error, 4)
+			nextHandlerErr := func() error {
+				t.Helper()
+				select {
+				case err := <-handlerErrs:
+					return err
+				default:
+					return nil
+				}
+			}
+
+			metadataPath := "/providers/alpha/provider-release.yaml"
+			currentArchivePathURL := "/providers/alpha/alpha-current.tar.gz"
+			extraArchivePathURL := "/providers/alpha/alpha-extra.tar.gz"
+			sourceValue := ""
+			wantSource := ""
+			wantCurrentArchiveURL := ""
+			wantExtraArchiveURL := ""
+			localCurrentArchivePath := ""
+			var srv *httptest.Server
+
+			if tc.localSource {
+				metadataRelPath := filepath.ToSlash(filepath.Join("providers", "alpha", "provider-release.yaml"))
+				metadataAbsPath := filepath.Join(dir, filepath.FromSlash(metadataRelPath))
+				metadataDir := filepath.Dir(metadataAbsPath)
+				if err := os.MkdirAll(metadataDir, 0o755); err != nil {
+					t.Fatalf("create metadata dir: %v", err)
+				}
+				currentArchiveName := "alpha-current.tar.gz"
+				extraArchiveName := "alpha-extra.tar.gz"
+				currentArtifactPath := currentArchiveName
+				extraArtifactPath := extraArchiveName
+				localCurrentArchivePath = filepath.Join(metadataDir, currentArchiveName)
+				if tc.remoteArchives {
+					srv = httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+						switch r.URL.Path {
+						case currentArchivePathURL:
+							currentArchiveCount.Add(1)
+							if got := r.Header.Get("Authorization"); got != "Bearer test-token" {
+								handlerErrs <- fmt.Errorf("current archive authorization = %q, want %q", got, "Bearer test-token")
+								http.Error(w, "bad archive authorization", http.StatusBadRequest)
+								return
+							}
+							w.Header().Set("Content-Type", "application/octet-stream")
+							_, _ = w.Write(currentArchiveData)
+						case extraArchivePathURL:
+							extraArchiveCount.Add(1)
+							if got := r.Header.Get("Authorization"); got != "Bearer test-token" {
+								handlerErrs <- fmt.Errorf("extra archive authorization = %q, want %q", got, "Bearer test-token")
+								http.Error(w, "bad archive authorization", http.StatusBadRequest)
+								return
+							}
+							w.Header().Set("Content-Type", "application/octet-stream")
+							_, _ = w.Write(extraArchiveData)
+						default:
+							http.NotFound(w, r)
+						}
+					}))
+					defer srv.Close()
+					currentArtifactPath = srv.URL + currentArchivePathURL
+					extraArtifactPath = srv.URL + extraArchivePathURL
+				} else {
+					if err := os.WriteFile(filepath.Join(metadataDir, currentArchiveName), currentArchiveData, 0o644); err != nil {
+						t.Fatalf("write current archive: %v", err)
+					}
+					if err := os.WriteFile(filepath.Join(metadataDir, extraArchiveName), extraArchiveData, 0o644); err != nil {
+						t.Fatalf("write extra archive: %v", err)
+					}
+				}
+				writeProviderReleaseMetadataFile(t, metadataAbsPath, providerReleaseMetadata{
+					Schema:        providerReleaseSchemaName,
+					SchemaVersion: providerReleaseSchemaVersion,
+					Package:       packageSource,
+					Kind:          providermanifestv1.KindPlugin,
+					Version:       version,
+					Runtime:       providerReleaseRuntimeExecutable,
+					Artifacts: map[string]providerReleaseArtifact{
+						providerpkg.CurrentPlatformString(): {
+							Path:   currentArtifactPath,
+							SHA256: hex.EncodeToString(currentArchiveSHA[:]),
+						},
+						extraPlatformKey: {
+							Path:   extraArtifactPath,
+							SHA256: hex.EncodeToString(extraArchiveSHA[:]),
+						},
+					},
+				})
+				sourceValue = "./" + metadataRelPath
+				wantSource = metadataRelPath
+				if tc.remoteArchives {
+					wantCurrentArchiveURL = srv.URL + currentArchivePathURL
+					wantExtraArchiveURL = srv.URL + extraArchivePathURL
+				} else {
+					wantCurrentArchiveURL = currentArchiveName
+					wantExtraArchiveURL = extraArchiveName
+				}
+			} else {
+				srv = httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+					switch r.URL.Path {
+					case metadataPath:
+						metadataCount.Add(1)
+						if got := r.Header.Get("Authorization"); got != "Bearer test-token" {
+							handlerErrs <- fmt.Errorf("metadata authorization = %q, want %q", got, "Bearer test-token")
+							http.Error(w, "bad metadata authorization", http.StatusBadRequest)
+							return
+						}
+						metadata := providerReleaseMetadata{
+							Schema:        providerReleaseSchemaName,
+							SchemaVersion: providerReleaseSchemaVersion,
+							Package:       packageSource,
+							Kind:          providermanifestv1.KindPlugin,
+							Version:       version,
+							Runtime:       providerReleaseRuntimeExecutable,
+							Artifacts: map[string]providerReleaseArtifact{
+								providerpkg.CurrentPlatformString(): {
+									Path:   filepath.Base(currentArchivePathURL),
+									SHA256: hex.EncodeToString(currentArchiveSHA[:]),
+								},
+								extraPlatformKey: {
+									Path:   filepath.Base(extraArchivePathURL),
+									SHA256: hex.EncodeToString(extraArchiveSHA[:]),
+								},
+							},
+						}
+						data, err := yaml.Marshal(metadata)
+						if err != nil {
+							handlerErrs <- fmt.Errorf("marshal metadata: %v", err)
+							http.Error(w, "metadata marshal failed", http.StatusInternalServerError)
+							return
+						}
+						w.Header().Set("Content-Type", "application/yaml")
+						_, _ = w.Write(data)
+					case currentArchivePathURL:
+						currentArchiveCount.Add(1)
+						if got := r.Header.Get("Authorization"); got != "Bearer test-token" {
+							handlerErrs <- fmt.Errorf("current archive authorization = %q, want %q", got, "Bearer test-token")
+							http.Error(w, "bad archive authorization", http.StatusBadRequest)
+							return
+						}
+						w.Header().Set("Content-Type", "application/octet-stream")
+						_, _ = w.Write(currentArchiveData)
+					case extraArchivePathURL:
+						extraArchiveCount.Add(1)
+						if got := r.Header.Get("Authorization"); got != "Bearer test-token" {
+							handlerErrs <- fmt.Errorf("extra archive authorization = %q, want %q", got, "Bearer test-token")
+							http.Error(w, "bad archive authorization", http.StatusBadRequest)
+							return
+						}
+						w.Header().Set("Content-Type", "application/octet-stream")
+						_, _ = w.Write(extraArchiveData)
+					default:
+						http.NotFound(w, r)
+					}
+				}))
+				defer srv.Close()
+				sourceValue = srv.URL + metadataPath + "?download=1"
+				wantSource = sourceValue
+				wantCurrentArchiveURL = srv.URL + currentArchivePathURL
+				wantExtraArchiveURL = srv.URL + extraArchivePathURL
+			}
+
+			artifactsDir := filepath.Join(dir, "prepared-artifacts")
+			configPath := filepath.Join(dir, "gestalt.yaml")
+			configLines := []string{
+				"apiVersion: " + tc.apiVersion,
+			}
+			if tc.localSource {
+				indexedDBSource := "github.com/acme/tools/indexeddb-sqlite"
+				indexedDBVersion := "0.0.1"
+				indexedDBArchivePath := buildExecutableArchive(t, dir, "indexeddb-src", indexedDBSource, indexedDBVersion, providermanifestv1.KindIndexedDB, "indexeddb", "indexeddb-release-binary")
+				indexedDBArchiveData, err := os.ReadFile(indexedDBArchivePath)
+				if err != nil {
+					t.Fatalf("read indexeddb archive: %v", err)
+				}
+				indexedDBArchiveSum := sha256.Sum256(indexedDBArchiveData)
+				indexedDBRelPath := filepath.ToSlash(filepath.Join("providers", "indexeddb", "provider-release.yaml"))
+				indexedDBAbsPath := filepath.Join(dir, filepath.FromSlash(indexedDBRelPath))
+				indexedDBDir := filepath.Dir(indexedDBAbsPath)
+				if err := os.MkdirAll(indexedDBDir, 0o755); err != nil {
+					t.Fatalf("create indexeddb metadata dir: %v", err)
+				}
+				indexedDBArchiveName := "indexeddb-current.tar.gz"
+				if err := os.WriteFile(filepath.Join(indexedDBDir, indexedDBArchiveName), indexedDBArchiveData, 0o644); err != nil {
+					t.Fatalf("write indexeddb archive: %v", err)
+				}
+				writeProviderReleaseMetadataFile(t, indexedDBAbsPath, providerReleaseMetadata{
+					Schema:        providerReleaseSchemaName,
+					SchemaVersion: providerReleaseSchemaVersion,
+					Package:       indexedDBSource,
+					Kind:          providermanifestv1.KindIndexedDB,
+					Version:       indexedDBVersion,
+					Runtime:       providerReleaseRuntimeExecutable,
+					Artifacts: map[string]providerReleaseArtifact{
+						providerpkg.CurrentPlatformString(): {
+							Path:   indexedDBArchiveName,
+							SHA256: hex.EncodeToString(indexedDBArchiveSum[:]),
+						},
+					},
+				})
+				configLines = append(configLines,
+					"providers:",
+					"  indexeddb:",
+					"    sqlite:",
+					"      source: ./"+indexedDBRelPath,
+					"      config:",
+					"        path: "+filepath.Join(dir, "data.db"),
+				)
+			} else {
+				configLines = append(configLines, strings.Split(strings.TrimSuffix(requiredComponentConfigYAML(t, dir, filepath.Join(dir, "data.db")), "\n"), "\n")...)
+			}
+			configLines = append(configLines,
+				"plugins:",
+				"  alpha:",
+				"    source: "+sourceValue,
+			)
+			if !tc.localSource || tc.remoteArchives {
+				configLines = append(configLines,
+					"    auth:",
+					"      token: test-token",
+				)
+			}
+			configLines = append(configLines,
+				"server:",
+				"  providers:",
+				"    indexeddb: sqlite",
+				"  artifactsDir: "+artifactsDir,
+				"  encryptionKey: aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
+			)
+			configYAML := strings.Join(configLines, "\n") + "\n"
+			if err := os.WriteFile(configPath, []byte(configYAML), 0o644); err != nil {
+				t.Fatalf("write config: %v", err)
+			}
+
+			lc := NewLifecycle()
+			lock, err := lc.InitAtPathWithPlatforms(configPath, "", []struct{ GOOS, GOARCH, LibC string }{
+				{GOOS: extraPlatform.goos, GOARCH: extraPlatform.goarch},
+			})
+			if err == nil {
+				if handlerErr := nextHandlerErr(); handlerErr != nil {
+					t.Fatal(handlerErr)
+				}
+			}
+			if err != nil {
+				t.Fatalf("InitAtPathWithPlatforms: %v", err)
+			}
+			if handlerErr := nextHandlerErr(); handlerErr != nil {
+				t.Fatal(handlerErr)
+			}
+
+			entry, ok := lock.Providers["alpha"]
+			if !ok {
+				t.Fatal(`lock.Providers["alpha"] not found`)
+			}
+			if entry.Source != wantSource {
+				t.Fatalf("entry.Source = %q, want %q", entry.Source, wantSource)
+			}
+			if entry.Package != packageSource {
+				t.Fatalf("entry.Package = %q, want %q", entry.Package, packageSource)
+			}
+			if entry.Kind != providermanifestv1.KindPlugin {
+				t.Fatalf("entry.Kind = %q, want %q", entry.Kind, providermanifestv1.KindPlugin)
+			}
+			if entry.Runtime != providerReleaseRuntimeExecutable {
+				t.Fatalf("entry.Runtime = %q, want %q", entry.Runtime, providerReleaseRuntimeExecutable)
+			}
+			if entry.Version != version {
+				t.Fatalf("entry.Version = %q, want %q", entry.Version, version)
+			}
+			if got := entry.Archives[providerpkg.CurrentPlatformString()].URL; got != wantCurrentArchiveURL {
+				t.Fatalf("current archive URL = %q, want %q", got, wantCurrentArchiveURL)
+			}
+			wantCurrentSHA := hex.EncodeToString(currentArchiveSHA[:])
+			wantExtraSHA := hex.EncodeToString(extraArchiveSHA[:])
+			if got := entry.Archives[providerpkg.CurrentPlatformString()].SHA256; got != wantCurrentSHA {
+				t.Fatalf("current platform SHA256 = %q, want %q", got, wantCurrentSHA)
+			}
+			if got := entry.Archives[extraPlatformKey].SHA256; got != wantExtraSHA {
+				t.Fatalf("extra platform SHA256 = %q, want %q", got, wantExtraSHA)
+			}
+			if !tc.localSource {
+				if got := metadataCount.Load(); got != 1 {
+					t.Fatalf("metadata request count = %d, want 1", got)
+				}
+				if got := currentArchiveCount.Load(); got != 1 {
+					t.Fatalf("current archive request count = %d, want 1", got)
+				}
+				if got := extraArchiveCount.Load(); got != 0 {
+					t.Fatalf("extra archive request count = %d, want 0", got)
+				}
+			}
+
+			lockData, err := os.ReadFile(filepath.Join(dir, InitLockfileName))
+			if err != nil {
+				t.Fatalf("ReadFile lockfile: %v", err)
+			}
+			var diskLock providerLockfile
+			if err := json.Unmarshal(lockData, &diskLock); err != nil {
+				t.Fatalf("Unmarshal lockfile: %v", err)
+			}
+			diskEntry, ok := diskLock.Providers.Plugin["alpha"]
+			if !ok {
+				t.Fatal(`disk lock providers.plugin["alpha"] not found`)
+			}
+			if diskEntry.Package != packageSource {
+				t.Fatalf("disk lock package = %q, want %q", diskEntry.Package, packageSource)
+			}
+			if diskEntry.Source != wantSource {
+				t.Fatalf("disk lock source = %q, want %q", diskEntry.Source, wantSource)
+			}
+			if diskEntry.Runtime != providerReleaseRuntimeExecutable {
+				t.Fatalf("disk lock runtime = %q, want %q", diskEntry.Runtime, providerReleaseRuntimeExecutable)
+			}
+			if diskEntry.Kind != providermanifestv1.KindPlugin {
+				t.Fatalf("disk lock kind = %q, want %q", diskEntry.Kind, providermanifestv1.KindPlugin)
+			}
+			if got := diskEntry.Archives[providerpkg.CurrentPlatformString()].SHA256; got != wantCurrentSHA {
+				t.Fatalf("disk lock current SHA256 = %q, want %q", got, wantCurrentSHA)
+			}
+			if got := diskEntry.Archives[extraPlatformKey].SHA256; got != wantExtraSHA {
+				t.Fatalf("disk lock extra SHA256 = %q, want %q", got, wantExtraSHA)
+			}
+			if got := diskEntry.Archives[extraPlatformKey].URL; got != wantExtraArchiveURL {
+				t.Fatalf("disk lock extra archive URL = %q, want %q", got, wantExtraArchiveURL)
+			}
+
+			pluginRoot := filepath.Join(artifactsDir, ".gestaltd", "providers", "alpha")
+			if err := os.RemoveAll(pluginRoot); err != nil {
+				t.Fatalf("RemoveAll plugin root: %v", err)
+			}
+			if tc.tamperLocalArchive {
+				if err := os.WriteFile(localCurrentArchivePath, []byte("tampered-local-archive"), 0o644); err != nil {
+					t.Fatalf("write tampered archive: %v", err)
+				}
+			}
+
+			metadataBefore := metadataCount.Load()
+			currentBefore := currentArchiveCount.Load()
+			cfg, _, err := lc.LoadForExecutionAtPath(configPath, true)
+			if tc.tamperLocalArchive {
+				if handlerErr := nextHandlerErr(); handlerErr != nil {
+					t.Fatal(handlerErr)
+				}
+				if err == nil || !strings.Contains(err.Error(), "digest mismatch") {
+					t.Fatalf("LoadForExecutionAtPath(locked=true) error = %v, want digest mismatch", err)
+				}
 				return
 			}
-			w.Header().Set("Content-Type", "application/yaml")
-			_, _ = w.Write(data)
-		case currentArchivePathURL:
-			currentArchiveCount.Add(1)
-			if got := r.Header.Get("Authorization"); got != "Bearer test-token" {
-				handlerErrs <- fmt.Errorf("current archive authorization = %q, want %q", got, "Bearer test-token")
-				http.Error(w, "bad archive authorization", http.StatusBadRequest)
-				return
+			if err != nil {
+				if handlerErr := nextHandlerErr(); handlerErr != nil {
+					t.Fatal(handlerErr)
+				}
+				t.Fatalf("LoadForExecutionAtPath(locked=true): %v", err)
 			}
-			w.Header().Set("Content-Type", "application/octet-stream")
-			_, _ = w.Write(currentArchiveData)
-		case extraArchivePathURL:
-			extraArchiveCount.Add(1)
-			if got := r.Header.Get("Authorization"); got != "Bearer test-token" {
-				handlerErrs <- fmt.Errorf("extra archive authorization = %q, want %q", got, "Bearer test-token")
-				http.Error(w, "bad archive authorization", http.StatusBadRequest)
-				return
+			if handlerErr := nextHandlerErr(); handlerErr != nil {
+				t.Fatal(handlerErr)
 			}
-			w.Header().Set("Content-Type", "application/octet-stream")
-			_, _ = w.Write(extraArchiveData)
-		default:
-			http.NotFound(w, r)
-		}
-	}))
-	defer srv.Close()
-
-	artifactsDir := filepath.Join(dir, "prepared-artifacts")
-	configPath := filepath.Join(dir, "gestalt.yaml")
-	configYAML := requiredComponentConfigYAML(t, dir, filepath.Join(dir, "data.db")) + strings.Join([]string{
-		"apiVersion: " + config.APIVersionV3,
-		"plugins:",
-		"  alpha:",
-		"    source: " + srv.URL + metadataPath + "?download=1",
-		"    auth:",
-		"      token: test-token",
-		"server:",
-		"  providers:",
-		"    indexeddb: sqlite",
-		"  artifactsDir: " + artifactsDir,
-		"  encryptionKey: aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
-	}, "\n") + "\n"
-	if err := os.WriteFile(configPath, []byte(configYAML), 0o644); err != nil {
-		t.Fatalf("write config: %v", err)
-	}
-
-	lc := NewLifecycle()
-	lock, err := lc.InitAtPathWithPlatforms(configPath, "", []struct{ GOOS, GOARCH, LibC string }{
-		{GOOS: extraPlatform.goos, GOARCH: extraPlatform.goarch},
-	})
-	if err == nil {
-		if handlerErr := nextHandlerErr(); handlerErr != nil {
-			t.Fatal(handlerErr)
-		}
-	}
-	if err != nil {
-		t.Fatalf("InitAtPathWithPlatforms: %v", err)
-	}
-	if handlerErr := nextHandlerErr(); handlerErr != nil {
-		t.Fatal(handlerErr)
-	}
-
-	entry, ok := lock.Providers["alpha"]
-	if !ok {
-		t.Fatal(`lock.Providers["alpha"] not found`)
-	}
-	if entry.Source != srv.URL+metadataPath+"?download=1" {
-		t.Fatalf("entry.Source = %q, want %q", entry.Source, srv.URL+metadataPath+"?download=1")
-	}
-	if entry.Package != packageSource {
-		t.Fatalf("entry.Package = %q, want %q", entry.Package, packageSource)
-	}
-	if entry.Kind != providermanifestv1.KindPlugin {
-		t.Fatalf("entry.Kind = %q, want %q", entry.Kind, providermanifestv1.KindPlugin)
-	}
-	if entry.Runtime != providerReleaseRuntimeExecutable {
-		t.Fatalf("entry.Runtime = %q, want %q", entry.Runtime, providerReleaseRuntimeExecutable)
-	}
-	if entry.Version != version {
-		t.Fatalf("entry.Version = %q, want %q", entry.Version, version)
-	}
-	if got := entry.Archives[providerpkg.CurrentPlatformString()].URL; got != srv.URL+currentArchivePathURL {
-		t.Fatalf("current archive URL = %q, want %q", got, srv.URL+currentArchivePathURL)
-	}
-	if got := entry.Archives[extraPlatformKey].SHA256; got != hex.EncodeToString(extraArchiveSHA[:]) {
-		t.Fatalf("extra platform SHA256 = %q, want %q", got, hex.EncodeToString(extraArchiveSHA[:]))
-	}
-	if got := metadataCount.Load(); got != 1 {
-		t.Fatalf("metadata request count = %d, want 1", got)
-	}
-	if got := currentArchiveCount.Load(); got != 1 {
-		t.Fatalf("current archive request count = %d, want 1", got)
-	}
-	if got := extraArchiveCount.Load(); got != 0 {
-		t.Fatalf("extra archive request count = %d, want 0", got)
-	}
-
-	lockData, err := os.ReadFile(filepath.Join(dir, InitLockfileName))
-	if err != nil {
-		t.Fatalf("ReadFile lockfile: %v", err)
-	}
-	var diskLock providerLockfile
-	if err := json.Unmarshal(lockData, &diskLock); err != nil {
-		t.Fatalf("Unmarshal lockfile: %v", err)
-	}
-	diskEntry, ok := diskLock.Providers.Plugin["alpha"]
-	if !ok {
-		t.Fatal(`disk lock providers.plugin["alpha"] not found`)
-	}
-	if diskEntry.Package != packageSource {
-		t.Fatalf("disk lock package = %q, want %q", diskEntry.Package, packageSource)
-	}
-	if diskEntry.Source != srv.URL+metadataPath+"?download=1" {
-		t.Fatalf("disk lock source = %q, want %q", diskEntry.Source, srv.URL+metadataPath+"?download=1")
-	}
-	if diskEntry.Runtime != providerReleaseRuntimeExecutable {
-		t.Fatalf("disk lock runtime = %q, want %q", diskEntry.Runtime, providerReleaseRuntimeExecutable)
-	}
-	if diskEntry.Kind != providermanifestv1.KindPlugin {
-		t.Fatalf("disk lock kind = %q, want %q", diskEntry.Kind, providermanifestv1.KindPlugin)
-	}
-	if got := diskEntry.Archives[extraPlatformKey].URL; got != srv.URL+extraArchivePathURL {
-		t.Fatalf("disk lock extra archive URL = %q, want %q", got, srv.URL+extraArchivePathURL)
-	}
-
-	pluginRoot := filepath.Join(artifactsDir, ".gestaltd", "providers", "alpha")
-	if err := os.RemoveAll(pluginRoot); err != nil {
-		t.Fatalf("RemoveAll plugin root: %v", err)
-	}
-
-	metadataBefore := metadataCount.Load()
-	currentBefore := currentArchiveCount.Load()
-	cfg, _, err := lc.LoadForExecutionAtPath(configPath, true)
-	if err != nil {
-		if handlerErr := nextHandlerErr(); handlerErr != nil {
-			t.Fatal(handlerErr)
-		}
-		t.Fatalf("LoadForExecutionAtPath(locked=true): %v", err)
-	}
-	if handlerErr := nextHandlerErr(); handlerErr != nil {
-		t.Fatal(handlerErr)
-	}
-	if got := metadataCount.Load(); got != metadataBefore {
-		t.Fatalf("metadata request count during locked load = %d, want %d", got, metadataBefore)
-	}
-	if got := currentArchiveCount.Load() - currentBefore; got != 1 {
-		t.Fatalf("current archive request count during locked load = %d, want 1", got)
-	}
-	if got := extraArchiveCount.Load(); got != 0 {
-		t.Fatalf("extra archive request count after locked load = %d, want 0", got)
-	}
-	if cfg.Plugins["alpha"] == nil {
-		t.Fatal(`cfg.Plugins["alpha"] = nil`)
-	}
-	if cfg.Plugins["alpha"].ResolvedManifest == nil {
-		t.Fatal(`cfg.Plugins["alpha"].ResolvedManifest = nil`)
-	}
-	if cfg.Plugins["alpha"].ResolvedManifest.Source != packageSource {
-		t.Fatalf("ResolvedManifest.Source = %q, want %q", cfg.Plugins["alpha"].ResolvedManifest.Source, packageSource)
-	}
-	executablePath := resolveLockPath(artifactsDir, entry.Executable)
-	if cfg.Plugins["alpha"].Command != executablePath {
-		t.Fatalf("plugin command = %q, want %q", cfg.Plugins["alpha"].Command, executablePath)
+			if !tc.localSource || tc.remoteArchives {
+				if got := metadataCount.Load(); got != metadataBefore {
+					t.Fatalf("metadata request count during locked load = %d, want %d", got, metadataBefore)
+				}
+				if got := currentArchiveCount.Load() - currentBefore; got != 1 {
+					t.Fatalf("current archive request count during locked load = %d, want 1", got)
+				}
+				if got := extraArchiveCount.Load(); got != 0 {
+					t.Fatalf("extra archive request count after locked load = %d, want 0", got)
+				}
+			}
+			if cfg.Plugins["alpha"] == nil {
+				t.Fatal(`cfg.Plugins["alpha"] = nil`)
+			}
+			if cfg.Plugins["alpha"].ResolvedManifest == nil {
+				t.Fatal(`cfg.Plugins["alpha"].ResolvedManifest = nil`)
+			}
+			if cfg.Plugins["alpha"].ResolvedManifest.Source != packageSource {
+				t.Fatalf("ResolvedManifest.Source = %q, want %q", cfg.Plugins["alpha"].ResolvedManifest.Source, packageSource)
+			}
+			executablePath := resolveLockPath(artifactsDir, entry.Executable)
+			if cfg.Plugins["alpha"].Command != executablePath {
+				t.Fatalf("plugin command = %q, want %q", cfg.Plugins["alpha"].Command, executablePath)
+			}
+		})
 	}
 }
 
@@ -2145,103 +2349,192 @@ func TestManagedCacheSourcesLoadForExecutionWithMultipleBindings(t *testing.T) {
 func TestManagedCacheSourcesInitAtPathWithPlatformsHashesExtraPlatformArchives(t *testing.T) {
 	t.Parallel()
 
-	dir := t.TempDir()
-	cacheSource := "github.com/acme/tools/cache-session"
-	version := "1.0.0"
+	for _, tc := range []struct {
+		name        string
+		apiVersion  string
+		localSource bool
+	}{
+		{name: "remote metadata url", apiVersion: config.APIVersionV3},
+		{name: "local metadata file", apiVersion: config.APIVersionV4, localSource: true},
+	} {
+		tc := tc
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
 
-	extraPlatform := struct{ GOOS, GOARCH, LibC string }{GOOS: "linux", GOARCH: "amd64"}
-	if runtime.GOOS == extraPlatform.GOOS && runtime.GOARCH == extraPlatform.GOARCH {
-		extraPlatform = struct{ GOOS, GOARCH, LibC string }{GOOS: "darwin", GOARCH: "arm64"}
-	}
-	extraPlatformKey := providerpkg.PlatformString(extraPlatform.GOOS, extraPlatform.GOARCH)
-	currentArchivePath := buildExecutableArchive(t, dir, "cache-src", cacheSource, version, providermanifestv1.KindCache, "cache-plugin", "fake-cache-binary")
-	currentArchiveData, err := os.ReadFile(currentArchivePath)
-	if err != nil {
-		t.Fatalf("read current archive: %v", err)
-	}
-	currentArchiveSum := sha256.Sum256(currentArchiveData)
-	extraArchivePathURL := "/providers/cache/cache-extra.tar.gz"
-	currentArchivePathURL := "/providers/cache/cache-current.tar.gz"
-	metadataPath := "/providers/cache/provider-release.yaml"
-	extraArchiveData := []byte("fake-cache-extra-platform-archive")
-	extraArchiveSum := sha256.Sum256(extraArchiveData)
-	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		switch r.URL.Path {
-		case metadataPath:
-			metadata := providerReleaseMetadata{
-				Schema:        providerReleaseSchemaName,
-				SchemaVersion: providerReleaseSchemaVersion,
-				Package:       cacheSource,
-				Kind:          providermanifestv1.KindCache,
-				Version:       version,
-				Runtime:       providerReleaseRuntimeExecutable,
-				Artifacts: map[string]providerReleaseArtifact{
-					providerpkg.CurrentPlatformString(): {
-						Path:   filepath.Base(currentArchivePathURL),
-						SHA256: hex.EncodeToString(currentArchiveSum[:]),
-					},
-					extraPlatformKey: {
-						Path:   filepath.Base(extraArchivePathURL),
-						SHA256: hex.EncodeToString(extraArchiveSum[:]),
-					},
-				},
+			dir := t.TempDir()
+			cacheSource := "github.com/acme/tools/cache-session"
+			version := "1.0.0"
+
+			extraPlatform := struct{ GOOS, GOARCH, LibC string }{GOOS: "linux", GOARCH: "amd64"}
+			if runtime.GOOS == extraPlatform.GOOS && runtime.GOARCH == extraPlatform.GOARCH {
+				extraPlatform = struct{ GOOS, GOARCH, LibC string }{GOOS: "darwin", GOARCH: "arm64"}
 			}
-			data, err := yaml.Marshal(metadata)
+			extraPlatformKey := providerpkg.PlatformString(extraPlatform.GOOS, extraPlatform.GOARCH)
+			currentArchivePath := buildExecutableArchive(t, dir, "cache-src", cacheSource, version, providermanifestv1.KindCache, "cache-plugin", "fake-cache-binary")
+			currentArchiveData, err := os.ReadFile(currentArchivePath)
 			if err != nil {
-				http.Error(w, "metadata marshal failed", http.StatusInternalServerError)
-				return
+				t.Fatalf("read current archive: %v", err)
 			}
-			w.Header().Set("Content-Type", "application/yaml")
-			_, _ = w.Write(data)
-		case currentArchivePathURL:
-			w.Header().Set("Content-Type", "application/octet-stream")
-			_, _ = w.Write(currentArchiveData)
-		case extraArchivePathURL:
-			w.Header().Set("Content-Type", "application/octet-stream")
-			_, _ = w.Write(extraArchiveData)
-		default:
-			http.NotFound(w, r)
-		}
-	}))
-	defer srv.Close()
+			currentArchiveSum := sha256.Sum256(currentArchiveData)
+			extraArchivePathURL := "/providers/cache/cache-extra.tar.gz"
+			currentArchivePathURL := "/providers/cache/cache-current.tar.gz"
+			metadataPath := "/providers/cache/provider-release.yaml"
+			extraArchiveData := []byte("fake-cache-extra-platform-archive")
+			extraArchiveSum := sha256.Sum256(extraArchiveData)
 
-	artifactsDir := filepath.Join(dir, "prepared-artifacts")
-	configYAML := requiredComponentConfigV3YAML(t, dir, filepath.Join(dir, "gestalt.db")) + strings.Join([]string{
-		"  cache:",
-		"    session:",
-		"      source: " + srv.URL + metadataPath,
-		"server:",
-		"  providers:",
-		"    indexeddb: sqlite",
-		"  artifactsDir: " + artifactsDir,
-		"  encryptionKey: aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
-	}, "\n") + "\n"
+			sourceValue := ""
+			wantSource := ""
+			wantExtraArchiveURL := ""
+			var client *http.Client
+			var srv *httptest.Server
 
-	configPath := filepath.Join(dir, "gestalt.yaml")
-	if err := os.WriteFile(configPath, []byte(configYAML), 0o644); err != nil {
-		t.Fatalf("write config: %v", err)
-	}
+			if tc.localSource {
+				metadataRelPath := filepath.ToSlash(filepath.Join("providers", "cache", "provider-release.yaml"))
+				metadataAbsPath := filepath.Join(dir, filepath.FromSlash(metadataRelPath))
+				metadataDir := filepath.Dir(metadataAbsPath)
+				if err := os.MkdirAll(metadataDir, 0o755); err != nil {
+					t.Fatalf("create metadata dir: %v", err)
+				}
+				currentArchiveName := "cache-current.tar.gz"
+				extraArchiveName := "cache-extra.tar.gz"
+				if err := os.WriteFile(filepath.Join(metadataDir, currentArchiveName), currentArchiveData, 0o644); err != nil {
+					t.Fatalf("write current archive: %v", err)
+				}
+				if err := os.WriteFile(filepath.Join(metadataDir, extraArchiveName), extraArchiveData, 0o644); err != nil {
+					t.Fatalf("write extra archive: %v", err)
+				}
+				writeProviderReleaseMetadataFile(t, metadataAbsPath, providerReleaseMetadata{
+					Schema:        providerReleaseSchemaName,
+					SchemaVersion: providerReleaseSchemaVersion,
+					Package:       cacheSource,
+					Kind:          providermanifestv1.KindCache,
+					Version:       version,
+					Runtime:       providerReleaseRuntimeExecutable,
+					Artifacts: map[string]providerReleaseArtifact{
+						providerpkg.CurrentPlatformString(): {
+							Path:   currentArchiveName,
+							SHA256: hex.EncodeToString(currentArchiveSum[:]),
+						},
+						extraPlatformKey: {
+							Path:   extraArchiveName,
+							SHA256: hex.EncodeToString(extraArchiveSum[:]),
+						},
+					},
+				})
+				sourceValue = "./" + metadataRelPath
+				wantSource = metadataRelPath
+				wantExtraArchiveURL = extraArchiveName
+			} else {
+				srv = httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+					switch r.URL.Path {
+					case metadataPath:
+						metadata := providerReleaseMetadata{
+							Schema:        providerReleaseSchemaName,
+							SchemaVersion: providerReleaseSchemaVersion,
+							Package:       cacheSource,
+							Kind:          providermanifestv1.KindCache,
+							Version:       version,
+							Runtime:       providerReleaseRuntimeExecutable,
+							Artifacts: map[string]providerReleaseArtifact{
+								providerpkg.CurrentPlatformString(): {
+									Path:   filepath.Base(currentArchivePathURL),
+									SHA256: hex.EncodeToString(currentArchiveSum[:]),
+								},
+								extraPlatformKey: {
+									Path:   filepath.Base(extraArchivePathURL),
+									SHA256: hex.EncodeToString(extraArchiveSum[:]),
+								},
+							},
+						}
+						data, err := yaml.Marshal(metadata)
+						if err != nil {
+							http.Error(w, "metadata marshal failed", http.StatusInternalServerError)
+							return
+						}
+						w.Header().Set("Content-Type", "application/yaml")
+						_, _ = w.Write(data)
+					case currentArchivePathURL:
+						w.Header().Set("Content-Type", "application/octet-stream")
+						_, _ = w.Write(currentArchiveData)
+					case extraArchivePathURL:
+						w.Header().Set("Content-Type", "application/octet-stream")
+						_, _ = w.Write(extraArchiveData)
+					default:
+						http.NotFound(w, r)
+					}
+				}))
+				defer srv.Close()
+				client = srv.Client()
+				sourceValue = srv.URL + metadataPath
+				wantSource = sourceValue
+				wantExtraArchiveURL = srv.URL + extraArchivePathURL
+			}
 
-	lc := NewLifecycle().WithHTTPClient(srv.Client())
-	lock, err := lc.InitAtPathWithPlatforms(configPath, "", []struct{ GOOS, GOARCH, LibC string }{extraPlatform})
-	if err != nil {
-		t.Fatalf("InitAtPathWithPlatforms: %v", err)
-	}
+			artifactsDir := filepath.Join(dir, "prepared-artifacts")
+			configLines := []string{
+				"apiVersion: " + tc.apiVersion,
+				"providers:",
+				"  cache:",
+				"    session:",
+				"      source: " + sourceValue,
+				"server:",
+				"  providers:",
+				"    indexeddb: sqlite",
+				"  artifactsDir: " + artifactsDir,
+				"  encryptionKey: aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
+			}
+			configYAML := strings.Join(configLines, "\n") + "\n"
 
-	entry, ok := lock.Caches["session"]
-	if !ok {
-		t.Fatal(`lock.Caches["session"] not found`)
-	}
-	if got := entry.Archives[extraPlatformKey].SHA256; got != hex.EncodeToString(extraArchiveSum[:]) {
-		t.Fatalf("lock extra-platform SHA256 = %q, want %q", got, hex.EncodeToString(extraArchiveSum[:]))
-	}
+			configPath := filepath.Join(dir, "gestalt.yaml")
+			if err := os.WriteFile(configPath, []byte(configYAML), 0o644); err != nil {
+				t.Fatalf("write config: %v", err)
+			}
 
-	readBack, err := ReadLockfile(filepath.Join(dir, InitLockfileName))
-	if err != nil {
-		t.Fatalf("ReadLockfile: %v", err)
-	}
-	if got := readBack.Caches["session"].Archives[extraPlatformKey].SHA256; got != hex.EncodeToString(extraArchiveSum[:]) {
-		t.Fatalf("readBack extra-platform SHA256 = %q, want %q", got, hex.EncodeToString(extraArchiveSum[:]))
+			lc := NewLifecycle()
+			if client != nil {
+				lc = lc.WithHTTPClient(client)
+			}
+			lock, err := lc.InitAtPathWithPlatforms(configPath, "", []struct{ GOOS, GOARCH, LibC string }{extraPlatform})
+			if err != nil {
+				t.Fatalf("InitAtPathWithPlatforms: %v", err)
+			}
+
+			entry, ok := lock.Caches["session"]
+			if !ok {
+				t.Fatal(`lock.Caches["session"] not found`)
+			}
+			if entry.Source != wantSource {
+				t.Fatalf("lock source = %q, want %q", entry.Source, wantSource)
+			}
+			wantCurrentSHA := hex.EncodeToString(currentArchiveSum[:])
+			wantExtraSHA := hex.EncodeToString(extraArchiveSum[:])
+			if got := entry.Archives[providerpkg.CurrentPlatformString()].SHA256; got != wantCurrentSHA {
+				t.Fatalf("lock current-platform SHA256 = %q, want %q", got, wantCurrentSHA)
+			}
+			if got := entry.Archives[extraPlatformKey].SHA256; got != wantExtraSHA {
+				t.Fatalf("lock extra-platform SHA256 = %q, want %q", got, wantExtraSHA)
+			}
+			if got := entry.Archives[extraPlatformKey].URL; got != wantExtraArchiveURL {
+				t.Fatalf("lock extra-platform URL = %q, want %q", got, wantExtraArchiveURL)
+			}
+
+			readBack, err := ReadLockfile(filepath.Join(dir, InitLockfileName))
+			if err != nil {
+				t.Fatalf("ReadLockfile: %v", err)
+			}
+			if got := readBack.Caches["session"].Source; got != wantSource {
+				t.Fatalf("readBack source = %q, want %q", got, wantSource)
+			}
+			if got := readBack.Caches["session"].Archives[providerpkg.CurrentPlatformString()].SHA256; got != wantCurrentSHA {
+				t.Fatalf("readBack current-platform SHA256 = %q, want %q", got, wantCurrentSHA)
+			}
+			if got := readBack.Caches["session"].Archives[extraPlatformKey].SHA256; got != wantExtraSHA {
+				t.Fatalf("readBack extra-platform SHA256 = %q, want %q", got, wantExtraSHA)
+			}
+			if got := readBack.Caches["session"].Archives[extraPlatformKey].URL; got != wantExtraArchiveURL {
+				t.Fatalf("readBack extra-platform URL = %q, want %q", got, wantExtraArchiveURL)
+			}
+		})
 	}
 }
 

--- a/gestaltd/internal/operator/release_metadata.go
+++ b/gestaltd/internal/operator/release_metadata.go
@@ -3,10 +3,15 @@ package operator
 import (
 	"bytes"
 	"context"
+	"crypto/sha256"
+	"encoding/hex"
+	"encoding/json"
 	"fmt"
 	"io"
 	"net/http"
 	"net/url"
+	"os"
+	"path/filepath"
 	"strings"
 
 	"github.com/valon-technologies/gestalt/server/internal/config"
@@ -123,6 +128,16 @@ func validateProviderReleaseMetadata(metadata *providerReleaseMetadata) error {
 }
 
 func fetchProviderReleaseMetadata(ctx context.Context, client *http.Client, metadataURL, token string) (*providerReleaseMetadata, error) {
+	if !isRemoteReleaseMetadataLocation(metadataURL) {
+		data, err := os.ReadFile(metadataURL)
+		if err != nil {
+			return nil, fmt.Errorf("read provider release metadata: %w", err)
+		}
+		if len(data) > providerReleaseMetadataMaxBytes {
+			return nil, fmt.Errorf("provider release metadata exceeds %d byte limit", providerReleaseMetadataMaxBytes)
+		}
+		return decodeProviderReleaseMetadata(data)
+	}
 	if client == nil {
 		client = http.DefaultClient
 	}
@@ -155,22 +170,61 @@ func providerReleaseArchives(metadataURL string, metadata *providerReleaseMetada
 	if metadata == nil {
 		return nil, fmt.Errorf("provider release metadata is required")
 	}
-	baseURL, err := url.Parse(metadataURL)
-	if err != nil {
-		return nil, fmt.Errorf("parse provider release metadata URL: %w", err)
-	}
 	archives := make(map[string]LockArchive, len(metadata.Artifacts))
 	for target, artifact := range metadata.Artifacts {
-		artifactURL, err := url.Parse(strings.TrimSpace(artifact.Path))
+		archiveRef, err := archiveReferenceForLock(metadataURL, artifact.Path)
 		if err != nil {
-			return nil, fmt.Errorf("parse provider release artifact path for target %q: %w", target, err)
+			return nil, fmt.Errorf("resolve provider release artifact path for target %q: %w", target, err)
 		}
 		archives[target] = LockArchive{
-			URL:    baseURL.ResolveReference(artifactURL).String(),
+			URL:    archiveRef,
 			SHA256: strings.TrimSpace(artifact.SHA256),
 		}
 	}
 	return archives, nil
+}
+
+func archiveReferenceNeedsIntegrityHash(archiveRef string) bool {
+	return isRemoteReleaseMetadataLocation(archiveRef)
+}
+
+func normalizedLocalReleaseMetadataFingerprintPayload(data []byte) ([]byte, error) {
+	metadata, err := decodeProviderReleaseMetadata(data)
+	if err != nil {
+		return nil, err
+	}
+	return json.Marshal(metadata)
+}
+
+func normalizedLocalReleaseMetadataFingerprintPayloadFromFile(path string) ([]byte, error) {
+	data, err := os.ReadFile(path)
+	if err != nil {
+		return nil, err
+	}
+	return normalizedLocalReleaseMetadataFingerprintPayload(data)
+}
+
+func localReleaseArchiveExpectedSHA(sourceLocation, resolvedKey, archiveLocation string) (string, error) {
+	if isRemoteReleaseMetadataLocation(sourceLocation) || archiveReferenceNeedsIntegrityHash(archiveLocation) {
+		return "", nil
+	}
+
+	metadata, err := fetchProviderReleaseMetadata(context.Background(), nil, sourceLocation, "")
+	if err != nil {
+		return "", err
+	}
+	artifact, ok := metadata.Artifacts[resolvedKey]
+	if !ok {
+		return "", fmt.Errorf("provider release metadata missing artifact for target %q", resolvedKey)
+	}
+	resolvedArchivePath, err := resolveArchiveSourceLocation(sourceLocation, artifact.Path)
+	if err != nil {
+		return "", err
+	}
+	if filepath.Clean(resolvedArchivePath) != filepath.Clean(archiveLocation) {
+		return "", fmt.Errorf("provider release metadata target %q resolved to %s, want %s", resolvedKey, resolvedArchivePath, archiveLocation)
+	}
+	return strings.TrimSpace(artifact.SHA256), nil
 }
 
 func lockEntryPackage(entry LockEntry) string {
@@ -225,6 +279,9 @@ func usesGitHubReleaseDownloadTransport(archiveURL string) bool {
 }
 
 func downloadArchiveForSource(ctx context.Context, client *http.Client, token, archiveURL string) (*providerpkg.DownloadResult, error) {
+	if !isRemoteReleaseMetadataLocation(archiveURL) {
+		return copyLocalArchiveForSource(archiveURL)
+	}
 	if client == nil {
 		client = http.DefaultClient
 	}
@@ -240,6 +297,100 @@ func downloadArchiveForSource(ctx context.Context, client *http.Client, token, a
 		req.Header.Set(httpAuthorizationHeader, httpBearerAuthorizationPrefix+token)
 	}
 	return providerpkg.DownloadRequest(client, req)
+}
+
+func isRemoteReleaseMetadataLocation(location string) bool {
+	parsed, err := url.ParseRequestURI(strings.TrimSpace(location))
+	if err != nil {
+		return false
+	}
+	switch parsed.Scheme {
+	case "http", "https":
+		return parsed.Host != ""
+	default:
+		return false
+	}
+}
+
+func archiveReferenceForLock(metadataLocation, artifactPath string) (string, error) {
+	resolved, err := resolveArchiveSourceLocation(metadataLocation, artifactPath)
+	if err != nil {
+		return "", err
+	}
+	if isRemoteReleaseMetadataLocation(metadataLocation) || isRemoteReleaseMetadataLocation(resolved) {
+		return resolved, nil
+	}
+	baseDir := filepath.Dir(metadataLocation)
+	rel, err := filepath.Rel(baseDir, resolved)
+	if err != nil {
+		return "", fmt.Errorf("relativize local release archive path: %w", err)
+	}
+	return filepath.ToSlash(filepath.Clean(rel)), nil
+}
+
+func resolveArchiveSourceLocation(metadataLocation, archiveRef string) (string, error) {
+	archiveRef = strings.TrimSpace(archiveRef)
+	if archiveRef == "" {
+		return "", fmt.Errorf("archive reference is required")
+	}
+	if isRemoteReleaseMetadataLocation(metadataLocation) {
+		baseURL, err := url.Parse(metadataLocation)
+		if err != nil {
+			return "", fmt.Errorf("parse provider release metadata URL: %w", err)
+		}
+		artifactURL, err := url.Parse(archiveRef)
+		if err != nil {
+			return "", fmt.Errorf("parse provider release artifact path: %w", err)
+		}
+		return baseURL.ResolveReference(artifactURL).String(), nil
+	}
+	if isRemoteReleaseMetadataLocation(archiveRef) {
+		return archiveRef, nil
+	}
+	baseDir := filepath.Dir(metadataLocation)
+	if filepath.IsAbs(archiveRef) {
+		return filepath.Clean(archiveRef), nil
+	}
+	return filepath.Clean(filepath.Join(baseDir, filepath.FromSlash(archiveRef))), nil
+}
+
+func copyLocalArchiveForSource(path string) (*providerpkg.DownloadResult, error) {
+	info, err := os.Stat(path)
+	if err != nil {
+		return nil, fmt.Errorf("stat local archive: %w", err)
+	}
+	if info.Size() > providerpkg.MaxPackageBytes {
+		return nil, fmt.Errorf("download exceeds %d byte limit", providerpkg.MaxPackageBytes)
+	}
+	src, err := os.Open(path)
+	if err != nil {
+		return nil, fmt.Errorf("open local archive: %w", err)
+	}
+	defer func() { _ = src.Close() }()
+
+	tmp, err := os.CreateTemp("", "gestalt-plugin-*.tar.gz")
+	if err != nil {
+		return nil, fmt.Errorf("create temp file: %w", err)
+	}
+	tmpPath := tmp.Name()
+	removeTmp := func() { _ = os.Remove(tmpPath) }
+
+	h := sha256.New()
+	if _, err := io.Copy(io.MultiWriter(tmp, h), io.LimitReader(src, providerpkg.MaxPackageBytes+1)); err != nil {
+		_ = tmp.Close()
+		removeTmp()
+		return nil, fmt.Errorf("copy local archive: %w", err)
+	}
+	if err := tmp.Close(); err != nil {
+		removeTmp()
+		return nil, fmt.Errorf("close temp file: %w", err)
+	}
+
+	return &providerpkg.DownloadResult{
+		LocalPath: tmpPath,
+		Cleanup:   removeTmp,
+		SHA256Hex: hex.EncodeToString(h.Sum(nil)),
+	}, nil
 }
 
 func authorizationHeaderForSourceLocation(sourceLocation, token string) string {

--- a/gestaltd/internal/plugininvocation/validation.go
+++ b/gestaltd/internal/plugininvocation/validation.go
@@ -24,6 +24,32 @@ type resolvedDependencyCatalog struct {
 	err         error
 }
 
+type catalogResolutionCache struct {
+	entries map[string]resolvedDependencyCatalog
+}
+
+func newCatalogResolutionCache(size int) *catalogResolutionCache {
+	if size < 0 {
+		size = 0
+	}
+	return &catalogResolutionCache{entries: make(map[string]resolvedDependencyCatalog, size)}
+}
+
+func (c *catalogResolutionCache) resolve(ctx context.Context, name string, entry *config.ProviderEntry) resolvedDependencyCatalog {
+	if c == nil {
+		resolved := resolvedDependencyCatalog{}
+		resolved.catalog, resolved.sessionOnly, resolved.err = resolveStaticCatalog(ctx, name, entry)
+		return resolved
+	}
+	if resolved, ok := c.entries[name]; ok {
+		return resolved
+	}
+	resolved := resolvedDependencyCatalog{}
+	resolved.catalog, resolved.sessionOnly, resolved.err = resolveStaticCatalog(ctx, name, entry)
+	c.entries[name] = resolved
+	return resolved
+}
+
 func ValidateEffectiveCatalog(ctx context.Context, name string, entry *config.ProviderEntry) error {
 	if entry == nil {
 		return nil
@@ -33,6 +59,18 @@ func ValidateEffectiveCatalog(ctx context.Context, name string, entry *config.Pr
 }
 
 func ValidateEffectiveCatalogs(ctx context.Context, cfg *config.Config) error {
+	return validateEffectiveCatalogs(ctx, cfg, newCatalogResolutionCache(len(cfg.Plugins)))
+}
+
+func ValidateEffectiveCatalogsAndDependencies(ctx context.Context, cfg *config.Config) error {
+	cache := newCatalogResolutionCache(len(cfg.Plugins))
+	if err := validateEffectiveCatalogs(ctx, cfg, cache); err != nil {
+		return err
+	}
+	return validateDependencies(ctx, cfg, cache)
+}
+
+func validateEffectiveCatalogs(ctx context.Context, cfg *config.Config, cache *catalogResolutionCache) error {
 	if cfg == nil {
 		return nil
 	}
@@ -41,18 +79,22 @@ func ValidateEffectiveCatalogs(ctx context.Context, cfg *config.Config) error {
 		if entry == nil {
 			continue
 		}
-		if err := ValidateEffectiveCatalog(ctx, name, entry); err != nil {
-			return fmt.Errorf("config validation: plugins.%s: %w", name, err)
+		resolved := cache.resolve(ctx, name, entry)
+		if resolved.err != nil {
+			return fmt.Errorf("config validation: plugins.%s: %w", name, resolved.err)
 		}
 	}
 	return nil
 }
 
 func ValidateDependencies(ctx context.Context, cfg *config.Config) error {
+	return validateDependencies(ctx, cfg, newCatalogResolutionCache(len(cfg.Plugins)))
+}
+
+func validateDependencies(ctx context.Context, cfg *config.Config, cache *catalogResolutionCache) error {
 	if cfg == nil {
 		return nil
 	}
-	targetCatalogs := make(map[string]resolvedDependencyCatalog, len(cfg.Plugins))
 	for callerName, callerEntry := range cfg.Plugins {
 		if callerEntry == nil || len(callerEntry.Invokes) == 0 {
 			continue
@@ -65,11 +107,7 @@ func ValidateDependencies(ctx context.Context, cfg *config.Config) error {
 			if !ok || targetEntry == nil {
 				return fmt.Errorf("config validation: plugins.%s.invokes[%d] references unknown plugin %q", callerName, i, dependency.Plugin)
 			}
-			resolved, ok := targetCatalogs[dependency.Plugin]
-			if !ok {
-				resolved.catalog, resolved.sessionOnly, resolved.err = resolveStaticCatalog(ctx, dependency.Plugin, targetEntry)
-				targetCatalogs[dependency.Plugin] = resolved
-			}
+			resolved := cache.resolve(ctx, dependency.Plugin, targetEntry)
 			if resolved.err != nil {
 				return fmt.Errorf("config validation: plugins.%s.invokes[%d]: %w", callerName, i, resolved.err)
 			}

--- a/gestaltd/internal/providerpkg/archive.go
+++ b/gestaltd/internal/providerpkg/archive.go
@@ -14,6 +14,7 @@ import (
 	"path/filepath"
 	"slices"
 	"strings"
+	"time"
 
 	providermanifestv1 "github.com/valon-technologies/gestalt/server/sdk/providermanifest/v1"
 )
@@ -150,6 +151,7 @@ func CreatePackageFromDir(sourceDir, outputPath string) (err error) {
 	defer joinCloseError(&err, fmt.Sprintf("close package %q", outputPath), out)
 
 	gzw := gzip.NewWriter(out)
+	gzw.ModTime = time.Unix(0, 0)
 	defer joinCloseError(&err, "close gzip stream", gzw)
 
 	tw := tar.NewWriter(gzw)
@@ -186,6 +188,13 @@ func CreatePackageFromDir(sourceDir, outputPath string) (err error) {
 			return fmt.Errorf("build tar header for %s: %w", rel, err)
 		}
 		hdr.Name = rel
+		hdr.ModTime = time.Unix(0, 0)
+		hdr.AccessTime = time.Unix(0, 0)
+		hdr.ChangeTime = time.Unix(0, 0)
+		hdr.Uid = 0
+		hdr.Gid = 0
+		hdr.Uname = ""
+		hdr.Gname = ""
 		if err := tw.WriteHeader(hdr); err != nil {
 			return fmt.Errorf("write tar header for %s: %w", rel, err)
 		}

--- a/sdk/python/gestalt/_build.py
+++ b/sdk/python/gestalt/_build.py
@@ -68,6 +68,10 @@ def build_plugin_binary(args: BuildArgs) -> None:
             runtime_kind=args.runtime_kind,
         )
 
+        env = os.environ.copy()
+        env["PYINSTALLER_CONFIG_DIR"] = str(work_path / "pyinstaller-config")
+        env["SOURCE_DATE_EPOCH"] = "0"
+
         subprocess.run(
             _pyinstaller_command(
                 root_path=root_path,
@@ -78,6 +82,7 @@ def build_plugin_binary(args: BuildArgs) -> None:
                 target_goarch=args.goarch,
             ),
             cwd=root_path,
+            env=env,
             check=True,
         )
 

--- a/sdk/python/tests/test_build.py
+++ b/sdk/python/tests/test_build.py
@@ -13,6 +13,7 @@ class CapturedBuildRun:
     command: list[str]
     cwd: pathlib.Path
     check: bool
+    env: dict[str, str]
     binary_name: str
     target_arch: str | None
     destination: str
@@ -37,7 +38,12 @@ class BuildTests(unittest.TestCase):
                     root.mkdir()
                     captured: CapturedBuildRun | None = None
 
-                    def fake_run(command: list[str], cwd: pathlib.Path, check: bool) -> None:
+                    def fake_run(
+                        command: list[str],
+                        cwd: pathlib.Path,
+                        env: dict[str, str],
+                        check: bool,
+                    ) -> None:
                         nonlocal captured
 
                         add_data = command[command.index("--add-data") + 1]
@@ -47,6 +53,7 @@ class BuildTests(unittest.TestCase):
                             command=command,
                             cwd=cwd,
                             check=check,
+                            env=env,
                             binary_name=command[command.index("--name") + 1],
                             target_arch=command[command.index("--target-arch") + 1] if "--target-arch" in command else None,
                             destination=destination,
@@ -78,6 +85,8 @@ class BuildTests(unittest.TestCase):
                 self.assertEqual(captured.binary_name, expected_binary_name)
                 self.assertEqual(captured.target_arch, expected_target_arch)
                 self.assertEqual(captured.destination, ".")
+                self.assertEqual(pathlib.Path(captured.env["PYINSTALLER_CONFIG_DIR"]).name, "pyinstaller-config")
+                self.assertEqual(captured.env["SOURCE_DATE_EPOCH"], "0")
                 self.assertEqual(
                     captured.bundle_config,
                     {


### PR DESCRIPTION
New interfaces:
- `apiVersion: gestaltd.config/v4`
- `source: ./dist/provider-release.yaml`
- `source:
    path: ./dist/provider-release.yaml`
- `gestaltd provider release --version 1.2.3 --output dist --platform all`

Examples:
```yaml
apiVersion: gestaltd.config/v4
providers:
  indexeddb:
    sqlite:
      source: ./providers/indexeddb/dist/provider-release.yaml
      config:
        path: ./data.db
  ui:
    dashboard:
      path: /dashboard
      source: ./dashboard/ui/dist/provider-release.yaml
plugins:
  roadmap:
    source: ./roadmap/plugin/dist/provider-release.yaml
    mountPath: /roadmap
```

```yaml
apiVersion: gestaltd.config/v4
plugins:
  roadmap:
    source: https://example.com/providers/roadmap/provider-release.yaml
```

What changes:
- Adds `gestaltd.config/v4`, where handwritten local non-builtin sources are local `provider-release.yaml` files instead of source manifests.
- Routes local and remote release metadata through the same release-metadata install path.
- Stores portable relative source and archive references for local release metadata in the lockfile.
- Keeps v3 local manifest paths working for compatibility.
- Updates `gestaltd provider release` help text to show the new local deploy flow.

Validation:
- `go test ./internal/config -run 'TestLoadSucceedsWithoutRuntimeFields|TestPluginValidation'`
- `go test ./internal/operator -run 'TestSourcePluginMetadataURLInitAndLockedLoad|TestManagedCacheSourcesInitAtPathWithPlatformsHashesExtraPlatformArchives'`
- `go test ./cmd/gestaltd -run 'TestRun_PluginReleaseStagesOwnedWebUIPackage'`
