### PR TITLE
gestaltd: support private GitHub release metadata URLs

### DIFF
--- a/gestaltd/internal/operator/lifecycle_source_test.go
+++ b/gestaltd/internal/operator/lifecycle_source_test.go
@@ -1,6 +1,7 @@
 package operator
 
 import (
+	"bytes"
 	"context"
 	"crypto/sha256"
 	"encoding/hex"
@@ -1222,16 +1223,22 @@ func TestSourcePluginMetadataURLUsesGitHubReleaseDownloadTransport(t *testing.T)
 		}
 	}
 
-	metadataPath := "/providers/alpha/provider-release.yaml"
+	githubMetadataPath := "/" + testOwner + "/" + testRepo + "/releases/download/plugin/" + testPlugin + "/" + version + "/provider-release.yaml"
+	githubMetadataURL := "https://github.com" + githubMetadataPath
 	githubArchivePath := "/" + testOwner + "/" + testRepo + "/releases/download/plugin/" + testPlugin + "/" + version + "/alpha-current.tar.gz"
 	githubArchiveURL := "https://github.com" + githubArchivePath
 	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		switch r.URL.Path {
-		case metadataPath:
+		case githubMetadataPath:
 			metadataCount.Add(1)
-			if got := r.Header.Get("Authorization"); got != "Bearer test-token" {
-				handlerErrs <- fmt.Errorf("metadata authorization = %q, want %q", got, "Bearer test-token")
+			if got := r.Header.Get("Authorization"); got != "token test-token" {
+				handlerErrs <- fmt.Errorf("metadata authorization = %q, want %q", got, "token test-token")
 				http.Error(w, "bad metadata authorization", http.StatusBadRequest)
+				return
+			}
+			if got := r.Header.Get("Accept"); got != "application/octet-stream" {
+				handlerErrs <- fmt.Errorf("metadata accept = %q, want %q", got, "application/octet-stream")
+				http.Error(w, "bad metadata accept", http.StatusBadRequest)
 				return
 			}
 			metadata := providerReleaseMetadata{
@@ -1282,7 +1289,7 @@ func TestSourcePluginMetadataURLUsesGitHubReleaseDownloadTransport(t *testing.T)
 		"apiVersion: " + config.APIVersionV3,
 		"plugins:",
 		"  alpha:",
-		"    source: " + srv.URL + metadataPath,
+		"    source: " + githubMetadataURL,
 		"    auth:",
 		"      token: test-token",
 		"server:",
@@ -1350,6 +1357,82 @@ func TestSourcePluginMetadataURLUsesGitHubReleaseDownloadTransport(t *testing.T)
 	}
 	if cfg.Plugins["alpha"] == nil || cfg.Plugins["alpha"].ResolvedManifest == nil {
 		t.Fatal("resolved metadata plugin manifest missing after locked load")
+	}
+}
+
+func TestSourcePluginMetadataURLRejectsOversizedGitHubReleaseMetadata(t *testing.T) {
+	t.Parallel()
+
+	dir := t.TempDir()
+
+	var metadataCount atomic.Int64
+	handlerErrs := make(chan error, 2)
+	nextHandlerErr := func() error {
+		t.Helper()
+		select {
+		case err := <-handlerErrs:
+			return err
+		default:
+			return nil
+		}
+	}
+
+	githubMetadataPath := "/" + testOwner + "/" + testRepo + "/releases/download/plugin/" + testPlugin + "/v" + testVersion + "/provider-release.yaml"
+	githubMetadataURL := "https://github.com" + githubMetadataPath
+	oversizedBody := bytes.Repeat([]byte("x"), providerReleaseMetadataMaxBytes+1)
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path != githubMetadataPath {
+			http.NotFound(w, r)
+			return
+		}
+		metadataCount.Add(1)
+		if got := r.Header.Get("Authorization"); got != "token test-token" {
+			handlerErrs <- fmt.Errorf("metadata authorization = %q, want %q", got, "token test-token")
+			http.Error(w, "bad metadata authorization", http.StatusBadRequest)
+			return
+		}
+		if got := r.Header.Get("Accept"); got != "application/octet-stream" {
+			handlerErrs <- fmt.Errorf("metadata accept = %q, want %q", got, "application/octet-stream")
+			http.Error(w, "bad metadata accept", http.StatusBadRequest)
+			return
+		}
+		w.Header().Set("Content-Type", "application/yaml")
+		_, _ = w.Write(oversizedBody)
+	}))
+	defer srv.Close()
+
+	artifactsDir := filepath.Join(dir, "prepared-artifacts")
+	configPath := filepath.Join(dir, "gestalt.yaml")
+	configYAML := requiredComponentConfigYAML(t, dir, filepath.Join(dir, "data.db")) + strings.Join([]string{
+		"apiVersion: " + config.APIVersionV3,
+		"plugins:",
+		"  alpha:",
+		"    source: " + githubMetadataURL,
+		"    auth:",
+		"      token: test-token",
+		"server:",
+		"  providers:",
+		"    indexeddb: sqlite",
+		"  artifactsDir: " + artifactsDir,
+		"  encryptionKey: aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
+	}, "\n") + "\n"
+	if err := os.WriteFile(configPath, []byte(configYAML), 0o644); err != nil {
+		t.Fatalf("write config: %v", err)
+	}
+
+	lc := NewLifecycle().WithHTTPClient(newGitHubRewriteClient(t, srv.URL))
+	_, err := lc.InitAtPath(configPath)
+	if err == nil {
+		t.Fatal("InitAtPath unexpectedly succeeded")
+	}
+	if handlerErr := nextHandlerErr(); handlerErr != nil {
+		t.Fatal(handlerErr)
+	}
+	if !strings.Contains(err.Error(), fmt.Sprintf("provider release metadata exceeds %d byte limit", providerReleaseMetadataMaxBytes)) {
+		t.Fatalf("InitAtPath error = %v, want metadata size limit", err)
+	}
+	if got := metadataCount.Load(); got != 1 {
+		t.Fatalf("metadata request count = %d, want 1", got)
 	}
 }
 

--- a/gestaltd/internal/operator/release_metadata.go
+++ b/gestaltd/internal/operator/release_metadata.go
@@ -29,6 +29,8 @@ const (
 	providerReleaseRuntimeDeclarative = "declarative"
 	providerReleaseRuntimeWebUI       = "webui"
 	providerReleaseMetadataMaxBytes   = 4 << 20
+	httpAcceptHeader                  = "Accept"
+	httpAcceptOctetStream             = "application/octet-stream"
 	httpAuthorizationHeader           = "Authorization"
 	httpBearerAuthorizationPrefix     = "Bearer "
 )
@@ -129,12 +131,9 @@ func validateProviderReleaseMetadata(metadata *providerReleaseMetadata) error {
 
 func fetchProviderReleaseMetadata(ctx context.Context, client *http.Client, metadataURL, token string) (*providerReleaseMetadata, error) {
 	if !isRemoteReleaseMetadataLocation(metadataURL) {
-		data, err := os.ReadFile(metadataURL)
+		data, err := readProviderReleaseMetadataFile(metadataURL)
 		if err != nil {
-			return nil, fmt.Errorf("read provider release metadata: %w", err)
-		}
-		if len(data) > providerReleaseMetadataMaxBytes {
-			return nil, fmt.Errorf("provider release metadata exceeds %d byte limit", providerReleaseMetadataMaxBytes)
+			return nil, err
 		}
 		return decodeProviderReleaseMetadata(data)
 	}
@@ -144,6 +143,9 @@ func fetchProviderReleaseMetadata(ctx context.Context, client *http.Client, meta
 	req, err := http.NewRequestWithContext(ctx, http.MethodGet, metadataURL, nil)
 	if err != nil {
 		return nil, fmt.Errorf("create provider release metadata request: %w", err)
+	}
+	if usesGitHubMetadataTransport(metadataURL) {
+		req.Header.Set(httpAcceptHeader, httpAcceptOctetStream)
 	}
 	if authHeader := authorizationHeaderForSourceLocation(metadataURL, token); authHeader != "" {
 		req.Header.Set(httpAuthorizationHeader, authHeader)
@@ -164,6 +166,17 @@ func fetchProviderReleaseMetadata(ctx context.Context, client *http.Client, meta
 		return nil, fmt.Errorf("provider release metadata exceeds %d byte limit", providerReleaseMetadataMaxBytes)
 	}
 	return decodeProviderReleaseMetadata(data)
+}
+
+func readProviderReleaseMetadataFile(path string) ([]byte, error) {
+	data, err := os.ReadFile(path)
+	if err != nil {
+		return nil, fmt.Errorf("read provider release metadata: %w", err)
+	}
+	if len(data) > providerReleaseMetadataMaxBytes {
+		return nil, fmt.Errorf("provider release metadata exceeds %d byte limit", providerReleaseMetadataMaxBytes)
+	}
+	return data, nil
 }
 
 func providerReleaseArchives(metadataURL string, metadata *providerReleaseMetadata) (map[string]LockArchive, error) {

--- a/gestaltd/internal/pluginsource/github/download.go
+++ b/gestaltd/internal/pluginsource/github/download.go
@@ -30,12 +30,12 @@ func ResolveGitHubToken(token string) string {
 	return ""
 }
 
-func DownloadGitHubReleaseArchive(ctx context.Context, client *http.Client, archiveURL, token string) (*providerpkg.DownloadResult, error) {
+func DownloadGitHubReleaseAsset(ctx context.Context, client *http.Client, assetURL, token string) (*providerpkg.DownloadResult, error) {
 	if client == nil {
 		client = http.DefaultClient
 	}
 	token = ResolveGitHubToken(token)
-	req, err := http.NewRequestWithContext(ctx, http.MethodGet, archiveURL, nil)
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, assetURL, nil)
 	if err != nil {
 		return nil, fmt.Errorf("create GitHub release download request: %w", err)
 	}
@@ -44,4 +44,8 @@ func DownloadGitHubReleaseArchive(ctx context.Context, client *http.Client, arch
 		req.Header.Set(headerAuthorization, authTokenPrefix+token)
 	}
 	return providerpkg.DownloadRequest(client, req)
+}
+
+func DownloadGitHubReleaseArchive(ctx context.Context, client *http.Client, archiveURL, token string) (*providerpkg.DownloadResult, error) {
+	return DownloadGitHubReleaseAsset(ctx, client, archiveURL, token)
 }


### PR DESCRIPTION
## Interface

YAML source metadata can now point at private GitHub release assets directly:

```yaml
plugins:
  workplaceHub:
    source: https://github.com/valon-technologies/toolshed/releases/download/plugins/workplace-hub/v0.0.1-alpha.1/provider-release.yaml
    auth:
      token: ${GITHUB_TOKEN}
```

Behavior:
- `gestaltd init`, `serve`, and locked execution now fetch `provider-release.yaml` through GitHub's release-asset transport when the metadata URL is on `github.com` / `api.github.com`.
- The metadata fetch now matches archive fetch behavior for private releases.

## What changed

- route remote GitHub metadata downloads through the GitHub asset downloader instead of plain `GET`
- keep plain HTTP fetch behavior unchanged for non-GitHub metadata URLs
- extend the existing operator transport coverage so a private `github.com/.../provider-release.yaml` metadata URL is exercised end to end

## Verification

```bash
cd gestaltd
go test ./internal/operator -run "TestSourcePluginMetadataURLUsesGitHubReleaseDownloadTransport|TestSourcePluginMetadataURLUsesGitHubAssetTransport"
go test ./internal/operator
golangci-lint run ./internal/operator/... ./internal/pluginsource/github/...
```