### PR TITLE
authorization: remove legacy human auth runtime codepaths

### DIFF
--- a/gestaltd/internal/authorization/provider_schema.go
+++ b/gestaltd/internal/authorization/provider_schema.go
@@ -132,9 +132,7 @@ func buildProviderAuthorizationResourceType(name string, relations map[string][]
 	for relation := range relations {
 		relationNames = append(relationNames, relation)
 	}
-	slices.SortFunc(relationNames, func(left, right string) int {
-		return strings.Compare(left, right)
-	})
+	slices.SortFunc(relationNames, strings.Compare)
 	for _, relation := range relationNames {
 		resourceType.Relations = append(resourceType.Relations, &core.AuthorizationModelRelation{
 			Name:         relation,

--- a/gestaltd/internal/bootstrap/authorization_canonical_sync.go
+++ b/gestaltd/internal/bootstrap/authorization_canonical_sync.go
@@ -2,6 +2,7 @@ package bootstrap
 
 import (
 	"context"
+	"encoding/json"
 	"errors"
 	"fmt"
 	"strings"
@@ -75,40 +76,40 @@ func syncProviderBackedHumanCanonicalState(ctx context.Context, services *coreda
 		}
 	}
 
-	if services.PluginAuthorizations != nil {
-		memberships, err := services.PluginAuthorizations.ListPluginAuthorizations(ctx)
+	if services.IdentityPluginAccess != nil {
+		accesses, err := services.IdentityPluginAccess.ListAll(ctx)
 		if err != nil {
-			return fmt.Errorf("list legacy plugin authorizations for canonical sync: %w", err)
+			return fmt.Errorf("list canonical plugin access for provider sync: %w", err)
 		}
-		for _, membership := range memberships {
-			identityID, err := legacyMembershipIdentityID(ctx, services.Users, membership.UserID, membership.Email)
-			switch {
-			case err == nil:
-				if identityID != "" {
-					candidateIdentityIDs[identityID] = struct{}{}
-				}
-			case errors.Is(err, core.ErrNotFound):
-			default:
+		for _, access := range accesses {
+			if access == nil {
+				continue
+			}
+			identityID, err := humanCanonicalIdentityID(ctx, services, access.IdentityID)
+			if err != nil {
 				return err
+			}
+			if identityID != "" {
+				candidateIdentityIDs[identityID] = struct{}{}
 			}
 		}
 	}
 
-	if services.AdminAuthorizations != nil {
-		memberships, err := services.AdminAuthorizations.ListAdminAuthorizations(ctx)
+	if services.WorkspaceRoles != nil {
+		roles, err := services.WorkspaceRoles.ListAll(ctx)
 		if err != nil {
-			return fmt.Errorf("list legacy admin authorizations for canonical sync: %w", err)
+			return fmt.Errorf("list canonical workspace roles for provider sync: %w", err)
 		}
-		for _, membership := range memberships {
-			identityID, err := legacyMembershipIdentityID(ctx, services.Users, membership.UserID, membership.Email)
-			switch {
-			case err == nil:
-				if identityID != "" {
-					candidateIdentityIDs[identityID] = struct{}{}
-				}
-			case errors.Is(err, core.ErrNotFound):
-			default:
+		for _, role := range roles {
+			if role == nil {
+				continue
+			}
+			identityID, err := humanCanonicalIdentityID(ctx, services, role.IdentityID)
+			if err != nil {
 				return err
+			}
+			if identityID != "" {
+				candidateIdentityIDs[identityID] = struct{}{}
 			}
 		}
 	}
@@ -182,21 +183,37 @@ func providerRelationshipIdentityID(ctx context.Context, users *coredata.UserSer
 	}
 }
 
-func legacyMembershipIdentityID(ctx context.Context, users *coredata.UserService, userID, email string) (string, error) {
-	if users == nil {
-		return "", core.ErrNotFound
+func humanCanonicalIdentityID(ctx context.Context, services *coredata.Services, identityID string) (string, error) {
+	identityID = strings.TrimSpace(identityID)
+	if identityID == "" || services == nil || services.Identities == nil {
+		return "", nil
 	}
-	if userID = strings.TrimSpace(userID); userID != "" {
-		return users.CanonicalIdentityIDForUser(ctx, userID)
+	identity, err := services.Identities.GetIdentity(ctx, identityID)
+	switch {
+	case err == nil:
+	case errors.Is(err, core.ErrNotFound):
+		return "", nil
+	default:
+		return "", err
 	}
-	if email = strings.TrimSpace(email); email != "" {
-		user, err := users.FindUserByEmail(ctx, email)
-		if err != nil {
-			return "", err
-		}
-		return users.CanonicalIdentityIDForUser(ctx, user.ID)
+	if identityMetadataLabel(identity.MetadataJSON) != "user" {
+		return "", nil
 	}
-	return "", core.ErrNotFound
+	return identityID, nil
+}
+
+func identityMetadataLabel(raw string) string {
+	raw = strings.TrimSpace(raw)
+	if raw == "" {
+		return ""
+	}
+	var payload struct {
+		Label string `json:"label"`
+	}
+	if err := json.Unmarshal([]byte(raw), &payload); err != nil {
+		return ""
+	}
+	return strings.TrimSpace(payload.Label)
 }
 
 func reconcileProviderPluginCanonicalAccess(ctx context.Context, svc *coredata.IdentityPluginAccessService, identityID string, desired map[string]struct{}) error {

--- a/gestaltd/internal/bootstrap/bootstrap_test.go
+++ b/gestaltd/internal/bootstrap/bootstrap_test.go
@@ -376,13 +376,6 @@ func (p *memoryAuthorizationProvider) putRelationship(modelID string, rel *core.
 	p.relsByModel[modelID][bootstrapRelationshipKey(rel.GetSubject(), rel.GetRelation(), rel.GetResource())] = cloneRelationship(rel)
 }
 
-func (p *memoryAuthorizationProvider) hasRelationship(modelID, key string) bool {
-	p.mu.Lock()
-	defer p.mu.Unlock()
-	_, ok := p.relsByModel[modelID][key]
-	return ok
-}
-
 func cloneRelationship(rel *core.Relationship) *core.Relationship {
 	if rel == nil {
 		return nil
@@ -3708,14 +3701,14 @@ func TestBootstrapSecretResolution(t *testing.T) {
 			Email:  dynamicUser.Email,
 			Role:   "editor",
 		}); err != nil {
-			t.Fatalf("UpsertPluginAuthorization: %v", err)
+			t.Fatalf("UpsertPluginAuthorization(seed): %v", err)
 		}
 		if _, err := result.Services.AdminAuthorizations.UpsertAdminAuthorization(ctx, &coredata.AdminAuthorizationMembership{
 			UserID: dynamicUser.ID,
 			Email:  dynamicUser.Email,
 			Role:   "admin",
 		}); err != nil {
-			t.Fatalf("UpsertAdminAuthorization: %v", err)
+			t.Fatalf("UpsertAdminAuthorization(seed): %v", err)
 		}
 
 		if err := result.Start(ctx); err != nil {
@@ -3729,6 +3722,21 @@ func TestBootstrapSecretResolution(t *testing.T) {
 		}
 		if _, ok := provider.relsByModel[existingModelID][unmanagedKey]; !ok {
 			t.Fatal("expected unrelated provider relationship to be preserved")
+		}
+		if err := result.Services.ManagedIdentities.CreateIdentity(ctx, &core.ManagedIdentity{
+			ID:          "svc-bot",
+			DisplayName: "Service Bot",
+		}); err != nil {
+			t.Fatalf("CreateIdentity: %v", err)
+		}
+		if _, err := result.Services.IdentityGrants.UpsertGrant(ctx, &core.ManagedIdentityGrant{
+			IdentityID: "svc-bot",
+			Plugin:     "calendar",
+		}); err != nil {
+			t.Fatalf("UpsertGrant: %v", err)
+		}
+		if _, err := result.Services.IdentityPluginAccess.GetAccess(ctx, "svc-bot", "calendar"); err != nil {
+			t.Fatalf("GetAccess managed identity after start: %v", err)
 		}
 
 		staticPrincipal := &principal.Principal{
@@ -3827,6 +3835,80 @@ func TestBootstrapSecretResolution(t *testing.T) {
 		}
 	})
 
+	t.Run("legacy human dynamic authorizations still work without authorization provider", func(t *testing.T) {
+		t.Parallel()
+
+		cfg := validConfig()
+		cfg.Authorization = config.AuthorizationConfig{
+			Policies: map[string]config.HumanPolicyDef{
+				"calendar-policy": {Default: "deny"},
+				"admin-policy":    {Default: "deny"},
+			},
+		}
+		cfg.Server.Admin.AuthorizationPolicy = "admin-policy"
+		cfg.Plugins = map[string]*config.ProviderEntry{
+			"calendar": {
+				AuthorizationPolicy: "calendar-policy",
+				ResolvedManifest: &providermanifestv1.Manifest{
+					Spec: &providermanifestv1.Spec{},
+				},
+			},
+		}
+
+		result, err := bootstrap.Bootstrap(ctx, cfg, validFactories())
+		if err != nil {
+			t.Fatalf("Bootstrap: %v", err)
+		}
+		t.Cleanup(func() { _ = result.Close(context.Background()) })
+		<-result.ProvidersReady
+
+		dynamicUser, err := result.Services.Users.FindOrCreateUser(ctx, "dynamic@example.test")
+		if err != nil {
+			t.Fatalf("FindOrCreateUser(dynamic): %v", err)
+		}
+		if _, err := result.Services.PluginAuthorizations.UpsertPluginAuthorization(ctx, &coredata.PluginAuthorizationMembership{
+			Plugin: "calendar",
+			UserID: dynamicUser.ID,
+			Email:  dynamicUser.Email,
+			Role:   "editor",
+		}); err != nil {
+			t.Fatalf("UpsertPluginAuthorization: %v", err)
+		}
+		if _, err := result.Services.AdminAuthorizations.UpsertAdminAuthorization(ctx, &coredata.AdminAuthorizationMembership{
+			UserID: dynamicUser.ID,
+			Email:  dynamicUser.Email,
+			Role:   "admin",
+		}); err != nil {
+			t.Fatalf("UpsertAdminAuthorization: %v", err)
+		}
+
+		if err := result.Start(ctx); err != nil {
+			t.Fatalf("Start: %v", err)
+		}
+
+		dynamicPrincipal := &principal.Principal{
+			UserID:    dynamicUser.ID,
+			SubjectID: principal.UserSubjectID(dynamicUser.ID),
+			Identity:  &core.UserIdentity{Email: dynamicUser.Email},
+			Kind:      principal.KindUser,
+		}
+		access, allowed := result.Authorizer.ResolveAccess(ctx, dynamicPrincipal, "calendar")
+		if !allowed {
+			t.Fatal("expected legacy dynamic plugin access to be allowed")
+		}
+		if access.Role != "editor" {
+			t.Fatalf("legacy dynamic plugin role = %q, want %q", access.Role, "editor")
+		}
+
+		adminAccess, allowed := result.Authorizer.ResolveAdminAccess(ctx, dynamicPrincipal, "admin-policy")
+		if !allowed {
+			t.Fatal("expected legacy dynamic admin access to be allowed")
+		}
+		if adminAccess.Role != "admin" {
+			t.Fatalf("legacy dynamic admin role = %q, want %q", adminAccess.Role, "admin")
+		}
+	})
+
 	t.Run("authorization provider rehydrates human canonical state on restart", func(t *testing.T) {
 		t.Parallel()
 
@@ -3876,30 +3958,29 @@ func TestBootstrapSecretResolution(t *testing.T) {
 		if err != nil {
 			t.Fatalf("FindOrCreateUser(dynamic): %v", err)
 		}
-		if _, err := result.Services.PluginAuthorizations.UpsertPluginAuthorization(ctx, &coredata.PluginAuthorizationMembership{
-			Plugin: "calendar",
-			UserID: dynamicUser.ID,
-			Email:  dynamicUser.Email,
-			Role:   "editor",
-		}); err != nil {
-			t.Fatalf("UpsertPluginAuthorization: %v", err)
-		}
-		if _, err := result.Services.AdminAuthorizations.UpsertAdminAuthorization(ctx, &coredata.AdminAuthorizationMembership{
-			UserID: dynamicUser.ID,
-			Email:  dynamicUser.Email,
-			Role:   "admin",
-		}); err != nil {
-			t.Fatalf("UpsertAdminAuthorization: %v", err)
-		}
+		provider.putRelationship(provider.activeModelID, &core.Relationship{
+			Subject:  &core.SubjectRef{Type: authorization.ProviderSubjectTypeEmail, Id: dynamicUser.Email},
+			Relation: "editor",
+			Resource: &core.ResourceRef{Type: authorization.ProviderResourceTypePluginDynamic, Id: "calendar"},
+		})
+		provider.putRelationship(provider.activeModelID, &core.Relationship{
+			Subject:  &core.SubjectRef{Type: authorization.ProviderSubjectTypeEmail, Id: dynamicUser.Email},
+			Relation: "admin",
+			Resource: &core.ResourceRef{Type: authorization.ProviderResourceTypeAdminDynamic, Id: authorization.ProviderResourceIDAdminDynamicGlobal},
+		})
 		if err := result.Start(ctx); err != nil {
 			t.Fatalf("Start(first): %v", err)
 		}
 
-		if err := result.Services.PluginAuthorizations.DeletePluginAuthorization(ctx, "calendar", dynamicUser.ID); err != nil {
-			t.Fatalf("DeletePluginAuthorization: %v", err)
+		canonicalIdentityID, err := result.Services.Users.CanonicalIdentityIDForUser(ctx, dynamicUser.ID)
+		if err != nil {
+			t.Fatalf("CanonicalIdentityIDForUser(first): %v", err)
 		}
-		if err := result.Services.AdminAuthorizations.DeleteAdminAuthorization(ctx, dynamicUser.ID); err != nil {
-			t.Fatalf("DeleteAdminAuthorization: %v", err)
+		if err := result.Services.IdentityPluginAccess.DeleteAccess(ctx, canonicalIdentityID, "calendar"); err != nil {
+			t.Fatalf("DeleteAccess(calendar): %v", err)
+		}
+		if err := result.Services.WorkspaceRoles.DeleteRole(ctx, canonicalIdentityID, "admin"); err != nil {
+			t.Fatalf("DeleteRole(admin): %v", err)
 		}
 		if err := result.Close(context.Background()); err != nil {
 			t.Fatalf("Close(first): %v", err)
@@ -3937,7 +4018,7 @@ func TestBootstrapSecretResolution(t *testing.T) {
 			t.Fatalf("provider-backed admin role after restart = %q, want %q", adminAccess.Role, "admin")
 		}
 
-		canonicalIdentityID, err := result.Services.Users.CanonicalIdentityIDForUser(ctx, dynamicUser.ID)
+		canonicalIdentityID, err = result.Services.Users.CanonicalIdentityIDForUser(ctx, dynamicUser.ID)
 		if err != nil {
 			t.Fatalf("CanonicalIdentityIDForUser: %v", err)
 		}

--- a/gestaltd/internal/coredata/canonical_access.go
+++ b/gestaltd/internal/coredata/canonical_access.go
@@ -171,6 +171,24 @@ func (s *WorkspaceRoleService) ListByIdentity(ctx context.Context, identityID st
 	return out, nil
 }
 
+func (s *WorkspaceRoleService) ListAll(ctx context.Context) ([]*core.WorkspaceRole, error) {
+	recs, err := s.store.GetAll(ctx, nil)
+	if err != nil {
+		return nil, fmt.Errorf("list workspace roles: %w", err)
+	}
+	out := make([]*core.WorkspaceRole, 0, len(recs))
+	for _, rec := range recs {
+		out = append(out, recordToWorkspaceRole(rec))
+	}
+	sort.Slice(out, func(i, j int) bool {
+		if out[i].IdentityID != out[j].IdentityID {
+			return out[i].IdentityID < out[j].IdentityID
+		}
+		return out[i].Role < out[j].Role
+	})
+	return out, nil
+}
+
 func (s *WorkspaceRoleService) ListByPrincipal(ctx context.Context, identityID string) ([]*core.WorkspaceRole, error) {
 	return s.ListByIdentity(ctx, identityID)
 }
@@ -276,6 +294,28 @@ func (s *IdentityPluginAccessService) ListByIdentity(ctx context.Context, identi
 		out = append(out, access)
 	}
 	sort.Slice(out, func(i, j int) bool {
+		return out[i].Plugin < out[j].Plugin
+	})
+	return out, nil
+}
+
+func (s *IdentityPluginAccessService) ListAll(ctx context.Context) ([]*core.IdentityPluginAccess, error) {
+	recs, err := s.store.GetAll(ctx, nil)
+	if err != nil {
+		return nil, fmt.Errorf("list identity plugin access: %w", err)
+	}
+	out := make([]*core.IdentityPluginAccess, 0, len(recs))
+	for _, rec := range recs {
+		access, err := recordToIdentityPluginAccess(rec)
+		if err != nil {
+			return nil, err
+		}
+		out = append(out, access)
+	}
+	sort.Slice(out, func(i, j int) bool {
+		if out[i].IdentityID != out[j].IdentityID {
+			return out[i].IdentityID < out[j].IdentityID
+		}
 		return out[i].Plugin < out[j].Plugin
 	})
 	return out, nil

--- a/gestaltd/internal/server/server_test.go
+++ b/gestaltd/internal/server/server_test.go
@@ -138,6 +138,7 @@ type memoryAuthorizationProvider struct {
 	activeModelID string
 	models        []*core.AuthorizationModelRef
 	relsByModel   map[string]map[string]*core.Relationship
+	writeErr      error
 }
 
 func newMemoryAuthorizationProvider(name string) *memoryAuthorizationProvider {
@@ -255,6 +256,9 @@ func (p *memoryAuthorizationProvider) ReadRelationships(_ context.Context, req *
 func (p *memoryAuthorizationProvider) WriteRelationships(_ context.Context, req *core.WriteRelationshipsRequest) error {
 	p.mu.Lock()
 	defer p.mu.Unlock()
+	if p.writeErr != nil {
+		return p.writeErr
+	}
 	modelID := strings.TrimSpace(req.GetModelId())
 	if modelID == "" {
 		modelID = p.activeModelID
@@ -374,6 +378,15 @@ func cloneMemoryAuthorizationRelationship(rel *core.Relationship) *core.Relation
 			Id:   rel.GetResource().GetId(),
 		},
 	}
+}
+
+func (p *memoryAuthorizationProvider) putRelationship(modelID string, rel *core.Relationship) {
+	p.mu.Lock()
+	defer p.mu.Unlock()
+	if p.relsByModel[modelID] == nil {
+		p.relsByModel[modelID] = map[string]*core.Relationship{}
+	}
+	p.relsByModel[modelID][memoryAuthorizationRelationshipKey(rel.GetSubject(), rel.GetRelation(), rel.GetResource())] = cloneMemoryAuthorizationRelationship(rel)
 }
 
 type putFailingIndexedDB struct {
@@ -568,44 +581,6 @@ func newTestServicesWithUsersPutFailure(t *testing.T) (*coredata.Services, *atom
 	}, enc)
 	if err != nil {
 		t.Fatalf("newTestServicesWithUsersPutFailure: %v", err)
-	}
-	return svc, failPut
-}
-
-func newTestServicesWithPluginAuthorizationPutFailure(t *testing.T) (*coredata.Services, *atomic.Bool) {
-	t.Helper()
-	enc, err := corecrypto.NewAESGCM([]byte("0123456789abcdef0123456789abcdef"))
-	if err != nil {
-		t.Fatalf("newTestServicesWithPluginAuthorizationPutFailure encryptor: %v", err)
-	}
-	failPut := &atomic.Bool{}
-	svc, err := coredata.New(&putFailingIndexedDB{
-		IndexedDB: &coretesting.StubIndexedDB{},
-		failStorePuts: map[string]*atomic.Bool{
-			coredata.StorePluginAuthorizationMemberships: failPut,
-		},
-	}, enc)
-	if err != nil {
-		t.Fatalf("newTestServicesWithPluginAuthorizationPutFailure: %v", err)
-	}
-	return svc, failPut
-}
-
-func newTestServicesWithAdminAuthorizationPutFailure(t *testing.T) (*coredata.Services, *atomic.Bool) {
-	t.Helper()
-	enc, err := corecrypto.NewAESGCM([]byte("0123456789abcdef0123456789abcdef"))
-	if err != nil {
-		t.Fatalf("newTestServicesWithAdminAuthorizationPutFailure encryptor: %v", err)
-	}
-	failPut := &atomic.Bool{}
-	svc, err := coredata.New(&putFailingIndexedDB{
-		IndexedDB: &coretesting.StubIndexedDB{},
-		failStorePuts: map[string]*atomic.Bool{
-			coredata.StoreAdminAuthorizationMemberships: failPut,
-		},
-	}, enc)
-	if err != nil {
-		t.Fatalf("newTestServicesWithAdminAuthorizationPutFailure: %v", err)
 	}
 	return svc, failPut
 }
@@ -939,6 +914,15 @@ func mustAuthorizer(t *testing.T, cfg config.AuthorizationConfig, providers *reg
 	return authz
 }
 
+func mustProviderBackedAuthorizer(t *testing.T, legacy *authorization.Authorizer, provider *memoryAuthorizationProvider) *authorization.ProviderBackedAuthorizer {
+	t.Helper()
+	authz := authorization.NewProviderBacked(legacy, provider)
+	if err := authz.ReloadDynamic(context.Background()); err != nil {
+		t.Fatalf("ReloadDynamic: %v", err)
+	}
+	return authz
+}
+
 func seedDynamicAdminMembership(t *testing.T, svc *coredata.Services, authz *authorization.Authorizer, email, role string) *core.User {
 	t.Helper()
 	authz.SetAdminAuthorizationService(svc.AdminAuthorizations)
@@ -955,6 +939,28 @@ func seedDynamicAdminMembership(t *testing.T, svc *coredata.Services, authz *aut
 	}
 	if err := authz.ReloadDynamic(context.Background()); err != nil {
 		t.Fatalf("ReloadDynamic: %v", err)
+	}
+	return user
+}
+
+func seedProviderDynamicAdminMembership(t *testing.T, svc *coredata.Services, authz authorization.RuntimeAuthorizer, provider *memoryAuthorizationProvider, email, role string) *core.User {
+	t.Helper()
+	user := seedUser(t, svc, email)
+	if provider.activeModelID == "" {
+		if err := authz.ReloadDynamic(context.Background()); err != nil {
+			t.Fatalf("seedProviderDynamicAdminMembership reload: %v", err)
+		}
+	}
+	if provider.activeModelID == "" {
+		t.Fatal("seedProviderDynamicAdminMembership: provider has no active model")
+	}
+	provider.putRelationship(provider.activeModelID, &core.Relationship{
+		Subject:  &core.SubjectRef{Type: authorization.ProviderSubjectTypeEmail, Id: user.Email},
+		Relation: role,
+		Resource: &core.ResourceRef{Type: authorization.ProviderResourceTypeAdminDynamic, Id: authorization.ProviderResourceIDAdminDynamicGlobal},
+	})
+	if err := authz.ReloadDynamic(context.Background()); err != nil {
+		t.Fatalf("seedProviderDynamicAdminMembership reload after write: %v", err)
 	}
 	return user
 }
@@ -1270,7 +1276,7 @@ func TestMountedWebUIRoutes_HumanAuthorization(t *testing.T) {
 
 	svc := coretesting.NewStubServices(t)
 	viewer := seedUser(t, svc, "viewer@example.test")
-	authz := mustAuthorizer(t, config.AuthorizationConfig{
+	legacy := mustAuthorizer(t, config.AuthorizationConfig{
 		Policies: map[string]config.HumanPolicyDef{
 			"sample_policy": {
 				Default: "deny",
@@ -1296,7 +1302,7 @@ func TestMountedWebUIRoutes_HumanAuthorization(t *testing.T) {
 			},
 		}
 		cfg.Services = svc
-		cfg.Authorizer = authz
+		cfg.Authorizer = legacy
 		cfg.MountedWebUIs = []server.MountedWebUI{{
 			Name:                "sample_portal",
 			Path:                "/sample-portal",
@@ -1397,7 +1403,7 @@ func TestMountedWebUIRoutes_HumanAuthorization_DefaultAllowTreatsAuthenticatedUs
 		t.Fatalf("webui handler: %v", err)
 	}
 
-	authz := mustAuthorizer(t, config.AuthorizationConfig{
+	legacy := mustAuthorizer(t, config.AuthorizationConfig{
 		Policies: map[string]config.HumanPolicyDef{
 			"sample_policy": {
 				Default: "allow",
@@ -1424,7 +1430,7 @@ func TestMountedWebUIRoutes_HumanAuthorization_DefaultAllowTreatsAuthenticatedUs
 				}
 			},
 		}
-		cfg.Authorizer = authz
+		cfg.Authorizer = legacy
 		cfg.MountedWebUIs = []server.MountedWebUI{{
 			Name:                "sample_portal",
 			Path:                "/sample-portal",
@@ -1609,7 +1615,7 @@ func TestMountedWebUIRoutes_HumanAuthorization_DefaultAllowTreatsAuthenticatedUs
 		t.Fatalf("webui handler: %v", err)
 	}
 
-	authz := mustAuthorizer(t, config.AuthorizationConfig{
+	legacy := mustAuthorizer(t, config.AuthorizationConfig{
 		Policies: map[string]config.HumanPolicyDef{
 			"sample_policy": {
 				Default: "allow",
@@ -1634,7 +1640,7 @@ func TestMountedWebUIRoutes_HumanAuthorization_DefaultAllowTreatsAuthenticatedUs
 				}
 			},
 		}
-		cfg.Authorizer = authz
+		cfg.Authorizer = legacy
 		cfg.MountedWebUIs = []server.MountedWebUI{{
 			Name:                "sample_portal",
 			Path:                "/sample-portal",
@@ -1685,7 +1691,7 @@ func TestBuiltInAdminRoute_HumanAuthorization(t *testing.T) {
 	svc := coretesting.NewStubServices(t)
 	viewer := seedUser(t, svc, "viewer@example.test")
 	admin := seedUser(t, svc, "admin@example.test")
-	authz := mustAuthorizer(t, config.AuthorizationConfig{
+	legacy := mustAuthorizer(t, config.AuthorizationConfig{
 		Policies: map[string]config.HumanPolicyDef{
 			"admin_policy": {
 				Default: "deny",
@@ -1696,7 +1702,9 @@ func TestBuiltInAdminRoute_HumanAuthorization(t *testing.T) {
 			},
 		},
 	}, nil, nil, nil)
-	seedDynamicAdminMembership(t, svc, authz, "dynamic-admin@example.test", "admin")
+	provider := newMemoryAuthorizationProvider("memory-authorization")
+	authz := mustProviderBackedAuthorizer(t, legacy, provider)
+	seedProviderDynamicAdminMembership(t, svc, authz, provider, "dynamic-admin@example.test", "admin")
 
 	ts := newTestServer(t, func(cfg *server.Config) {
 		cfg.Auth = &coretesting.StubAuthProvider{
@@ -1716,6 +1724,7 @@ func TestBuiltInAdminRoute_HumanAuthorization(t *testing.T) {
 		}
 		cfg.Services = svc
 		cfg.Authorizer = authz
+		cfg.AuthorizationProvider = provider
 		cfg.Admin = server.AdminRouteConfig{
 			AuthorizationPolicy: "admin_policy",
 			AllowedRoles:        []string{"admin"},
@@ -1821,7 +1830,7 @@ func TestBuiltInAdminRoute_HumanAuthorizationOnManagementProfile(t *testing.T) {
 	svc := coretesting.NewStubServices(t)
 	viewer := seedUser(t, svc, "viewer@example.test")
 	admin := seedUser(t, svc, "admin@example.test")
-	authz := mustAuthorizer(t, config.AuthorizationConfig{
+	legacy := mustAuthorizer(t, config.AuthorizationConfig{
 		Policies: map[string]config.HumanPolicyDef{
 			"admin_policy": {
 				Default: "deny",
@@ -1832,7 +1841,9 @@ func TestBuiltInAdminRoute_HumanAuthorizationOnManagementProfile(t *testing.T) {
 			},
 		},
 	}, nil, nil, nil)
-	seedDynamicAdminMembership(t, svc, authz, "dynamic-admin@example.test", "admin")
+	provider := newMemoryAuthorizationProvider("memory-authorization")
+	authz := mustProviderBackedAuthorizer(t, legacy, provider)
+	seedProviderDynamicAdminMembership(t, svc, authz, provider, "dynamic-admin@example.test", "admin")
 
 	ts := newTestServer(t, func(cfg *server.Config) {
 		cfg.Auth = &coretesting.StubAuthProvider{
@@ -1852,6 +1863,7 @@ func TestBuiltInAdminRoute_HumanAuthorizationOnManagementProfile(t *testing.T) {
 		}
 		cfg.Services = svc
 		cfg.Authorizer = authz
+		cfg.AuthorizationProvider = provider
 		cfg.RouteProfile = server.RouteProfileManagement
 		cfg.PublicBaseURL = "https://gestalt.example.test"
 		cfg.ManagementBaseURL = "https://gestalt.example.test:9090"
@@ -1942,7 +1954,7 @@ func TestBuiltInAdminRoute_HumanAuthorizationSplitManagementLoginFlow(t *testing
 	secret := []byte("0123456789abcdef0123456789abcdef")
 	auth := &stubHostIssuedSessionAuth{secret: secret}
 	svc := coretesting.NewStubServices(t)
-	authz := mustAuthorizer(t, config.AuthorizationConfig{
+	legacy := mustAuthorizer(t, config.AuthorizationConfig{
 		Policies: map[string]config.HumanPolicyDef{
 			"admin_policy": {
 				Default: "deny",
@@ -1971,7 +1983,7 @@ func TestBuiltInAdminRoute_HumanAuthorizationSplitManagementLoginFlow(t *testing
 		cfg.Auth = auth
 		cfg.StateSecret = secret
 		cfg.Services = svc
-		cfg.Authorizer = authz
+		cfg.Authorizer = legacy
 		cfg.PublicBaseURL = publicURL
 		cfg.ManagementBaseURL = managementURL
 		cfg.RouteProfile = server.RouteProfilePublic
@@ -1987,7 +1999,7 @@ func TestBuiltInAdminRoute_HumanAuthorizationSplitManagementLoginFlow(t *testing
 		cfg.Auth = auth
 		cfg.StateSecret = secret
 		cfg.Services = svc
-		cfg.Authorizer = authz
+		cfg.Authorizer = legacy
 		cfg.PublicBaseURL = publicURL
 		cfg.ManagementBaseURL = managementURL
 		cfg.RouteProfile = server.RouteProfileManagement
@@ -2111,7 +2123,7 @@ func TestAdminAPI_HumanAuthorization(t *testing.T) {
 	svc := coretesting.NewStubServices(t)
 	viewer := seedUser(t, svc, "viewer@example.test")
 	admin := seedUser(t, svc, "admin@example.test")
-	authz := mustAuthorizer(t, config.AuthorizationConfig{
+	legacy := mustAuthorizer(t, config.AuthorizationConfig{
 		Policies: map[string]config.HumanPolicyDef{
 			"admin_policy": {
 				Default: "deny",
@@ -2125,7 +2137,9 @@ func TestAdminAPI_HumanAuthorization(t *testing.T) {
 	}, nil, map[string]*config.ProviderEntry{
 		"sample_plugin": {AuthorizationPolicy: "sample_policy"},
 	}, nil)
-	seedDynamicAdminMembership(t, svc, authz, "dynamic-admin@example.test", "admin")
+	provider := newMemoryAuthorizationProvider("memory-authorization")
+	authz := mustProviderBackedAuthorizer(t, legacy, provider)
+	seedProviderDynamicAdminMembership(t, svc, authz, provider, "dynamic-admin@example.test", "admin")
 
 	ts := newTestServer(t, func(cfg *server.Config) {
 		cfg.Auth = &coretesting.StubAuthProvider{
@@ -2145,6 +2159,7 @@ func TestAdminAPI_HumanAuthorization(t *testing.T) {
 		}
 		cfg.Services = svc
 		cfg.Authorizer = authz
+		cfg.AuthorizationProvider = provider
 		cfg.PluginDefs = map[string]*config.ProviderEntry{
 			"sample_plugin": {AuthorizationPolicy: "sample_policy"},
 		}
@@ -2250,7 +2265,7 @@ func TestAdminAPI_HumanAuthorizationOnManagementProfile(t *testing.T) {
 
 	svc := coretesting.NewStubServices(t)
 	admin := seedUser(t, svc, "admin@example.test")
-	authz := mustAuthorizer(t, config.AuthorizationConfig{
+	legacy := mustAuthorizer(t, config.AuthorizationConfig{
 		Policies: map[string]config.HumanPolicyDef{
 			"admin_policy": {
 				Default: "deny",
@@ -2263,7 +2278,9 @@ func TestAdminAPI_HumanAuthorizationOnManagementProfile(t *testing.T) {
 	}, nil, map[string]*config.ProviderEntry{
 		"sample_plugin": {AuthorizationPolicy: "sample_policy"},
 	}, nil)
-	seedDynamicAdminMembership(t, svc, authz, "dynamic-admin@example.test", "admin")
+	provider := newMemoryAuthorizationProvider("memory-authorization")
+	authz := mustProviderBackedAuthorizer(t, legacy, provider)
+	seedProviderDynamicAdminMembership(t, svc, authz, provider, "dynamic-admin@example.test", "admin")
 
 	ts := newTestServer(t, func(cfg *server.Config) {
 		cfg.Auth = &coretesting.StubAuthProvider{
@@ -2281,6 +2298,7 @@ func TestAdminAPI_HumanAuthorizationOnManagementProfile(t *testing.T) {
 		}
 		cfg.Services = svc
 		cfg.Authorizer = authz
+		cfg.AuthorizationProvider = provider
 		cfg.PluginDefs = map[string]*config.ProviderEntry{
 			"sample_plugin": {AuthorizationPolicy: "sample_policy"},
 		}
@@ -2410,116 +2428,142 @@ func TestAdminAPIRoutes_HiddenOnPublicProfile(t *testing.T) {
 func TestAdminAPI_PluginAuthorizationCRUD(t *testing.T) {
 	t.Parallel()
 
-	svc := coretesting.NewStubServices(t)
-	authz, err := authorization.New(config.AuthorizationConfig{
-		Policies: map[string]config.HumanPolicyDef{
-			"sample_policy": {
-				Default: "deny",
-				Members: []config.HumanPolicyMemberDef{
-					{Email: "static@example.test", Role: "admin"},
+	for _, tc := range []struct {
+		name     string
+		provider bool
+	}{
+		{name: "legacy", provider: false},
+		{name: "provider_backed", provider: true},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+
+			svc := coretesting.NewStubServices(t)
+			legacy, err := authorization.New(config.AuthorizationConfig{
+				Policies: map[string]config.HumanPolicyDef{
+					"sample_policy": {
+						Default: "deny",
+						Members: []config.HumanPolicyMemberDef{
+							{Email: "static@example.test", Role: "admin"},
+						},
+					},
 				},
-			},
-		},
-	}, map[string]*config.ProviderEntry{
-		"sample_plugin": {AuthorizationPolicy: "sample_policy", MountPath: "/sample"},
-	}, nil, nil, svc.PluginAuthorizations)
-	if err != nil {
-		t.Fatalf("authorization.New: %v", err)
-	}
+			}, map[string]*config.ProviderEntry{
+				"sample_plugin": {AuthorizationPolicy: "sample_policy", MountPath: "/sample"},
+			}, nil, nil, svc.PluginAuthorizations)
+			if err != nil {
+				t.Fatalf("authorization.New: %v", err)
+			}
 
-	ts := newTestServer(t, func(cfg *server.Config) {
-		cfg.Services = svc
-		cfg.Authorizer = authz
-		cfg.PluginDefs = map[string]*config.ProviderEntry{
-			"sample_plugin": {AuthorizationPolicy: "sample_policy", MountPath: "/sample"},
-		}
-		cfg.AdminUI = http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
-			_, _ = w.Write([]byte("admin"))
+			var (
+				authz    authorization.RuntimeAuthorizer = legacy
+				provider *memoryAuthorizationProvider
+			)
+			if tc.provider {
+				provider = newMemoryAuthorizationProvider("memory-authorization")
+				authz = mustProviderBackedAuthorizer(t, legacy, provider)
+			} else if err := legacy.ReloadDynamic(context.Background()); err != nil {
+				t.Fatalf("ReloadDynamic: %v", err)
+			}
+
+			ts := newTestServer(t, func(cfg *server.Config) {
+				cfg.Services = svc
+				cfg.Authorizer = authz
+				if provider != nil {
+					cfg.AuthorizationProvider = provider
+				}
+				cfg.PluginDefs = map[string]*config.ProviderEntry{
+					"sample_plugin": {AuthorizationPolicy: "sample_policy", MountPath: "/sample"},
+				}
+				cfg.AdminUI = http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+					_, _ = w.Write([]byte("admin"))
+				})
+			})
+			testutil.CloseOnCleanup(t, ts)
+
+			resp, err := http.Get(ts.URL + "/admin/api/v1/authorization/plugins")
+			if err != nil {
+				t.Fatalf("GET plugins: %v", err)
+			}
+			defer func() { _ = resp.Body.Close() }()
+			if resp.StatusCode != http.StatusOK {
+				t.Fatalf("plugins status = %d, want 200", resp.StatusCode)
+			}
+
+			body := bytes.NewBufferString(`{"email":"dynamic@example.test","role":"viewer"}`)
+			req, _ := http.NewRequest(http.MethodPut, ts.URL+"/admin/api/v1/authorization/plugins/sample_plugin/members", body)
+			req.Header.Set("Content-Type", "application/json")
+			resp, err = http.DefaultClient.Do(req)
+			if err != nil {
+				t.Fatalf("PUT dynamic member: %v", err)
+			}
+			defer func() { _ = resp.Body.Close() }()
+			if resp.StatusCode != http.StatusOK {
+				respBody, _ := io.ReadAll(resp.Body)
+				t.Fatalf("put dynamic member status = %d, want 200: %s", resp.StatusCode, respBody)
+			}
+
+			resp, err = http.Get(ts.URL + "/admin/api/v1/authorization/plugins/sample_plugin/members")
+			if err != nil {
+				t.Fatalf("GET members: %v", err)
+			}
+			defer func() { _ = resp.Body.Close() }()
+			if resp.StatusCode != http.StatusOK {
+				t.Fatalf("members status = %d, want 200", resp.StatusCode)
+			}
+
+			var members []map[string]any
+			if err := json.NewDecoder(resp.Body).Decode(&members); err != nil {
+				t.Fatalf("decoding members: %v", err)
+			}
+			if len(members) != 2 {
+				t.Fatalf("expected 2 merged members, got %d (%+v)", len(members), members)
+			}
+
+			body = bytes.NewBufferString(`{"email":"static@example.test","role":"viewer"}`)
+			req, _ = http.NewRequest(http.MethodPut, ts.URL+"/admin/api/v1/authorization/plugins/sample_plugin/members", body)
+			req.Header.Set("Content-Type", "application/json")
+			resp, err = http.DefaultClient.Do(req)
+			if err != nil {
+				t.Fatalf("PUT static-conflict member: %v", err)
+			}
+			defer func() { _ = resp.Body.Close() }()
+			if resp.StatusCode != http.StatusConflict {
+				respBody, _ := io.ReadAll(resp.Body)
+				t.Fatalf("put static-conflict status = %d, want 409: %s", resp.StatusCode, respBody)
+			}
+
+			user, err := svc.Users.FindUserByEmail(context.Background(), "dynamic@example.test")
+			if err != nil {
+				t.Fatalf("find dynamic user: %v", err)
+			}
+			req, _ = http.NewRequest(http.MethodDelete, ts.URL+"/admin/api/v1/authorization/plugins/sample_plugin/members/"+url.PathEscape(user.ID), nil)
+			resp, err = http.DefaultClient.Do(req)
+			if err != nil {
+				t.Fatalf("DELETE dynamic member: %v", err)
+			}
+			defer func() { _ = resp.Body.Close() }()
+			if resp.StatusCode != http.StatusOK {
+				respBody, _ := io.ReadAll(resp.Body)
+				t.Fatalf("delete dynamic member status = %d, want 200: %s", resp.StatusCode, respBody)
+			}
+
+			resp, err = http.Get(ts.URL + "/admin/api/v1/authorization/plugins/sample_plugin/members")
+			if err != nil {
+				t.Fatalf("GET members after delete: %v", err)
+			}
+			defer func() { _ = resp.Body.Close() }()
+			if resp.StatusCode != http.StatusOK {
+				t.Fatalf("members after delete status = %d, want 200", resp.StatusCode)
+			}
+			members = nil
+			if err := json.NewDecoder(resp.Body).Decode(&members); err != nil {
+				t.Fatalf("decoding members after delete: %v", err)
+			}
+			if len(members) != 1 || members[0]["source"] != "static" {
+				t.Fatalf("members after delete = %+v, want only static row", members)
+			}
 		})
-	})
-	testutil.CloseOnCleanup(t, ts)
-
-	resp, err := http.Get(ts.URL + "/admin/api/v1/authorization/plugins")
-	if err != nil {
-		t.Fatalf("GET plugins: %v", err)
-	}
-	defer func() { _ = resp.Body.Close() }()
-	if resp.StatusCode != http.StatusOK {
-		t.Fatalf("plugins status = %d, want 200", resp.StatusCode)
-	}
-
-	body := bytes.NewBufferString(`{"email":"dynamic@example.test","role":"viewer"}`)
-	req, _ := http.NewRequest(http.MethodPut, ts.URL+"/admin/api/v1/authorization/plugins/sample_plugin/members", body)
-	req.Header.Set("Content-Type", "application/json")
-	resp, err = http.DefaultClient.Do(req)
-	if err != nil {
-		t.Fatalf("PUT dynamic member: %v", err)
-	}
-	defer func() { _ = resp.Body.Close() }()
-	if resp.StatusCode != http.StatusOK {
-		respBody, _ := io.ReadAll(resp.Body)
-		t.Fatalf("put dynamic member status = %d, want 200: %s", resp.StatusCode, respBody)
-	}
-
-	resp, err = http.Get(ts.URL + "/admin/api/v1/authorization/plugins/sample_plugin/members")
-	if err != nil {
-		t.Fatalf("GET members: %v", err)
-	}
-	defer func() { _ = resp.Body.Close() }()
-	if resp.StatusCode != http.StatusOK {
-		t.Fatalf("members status = %d, want 200", resp.StatusCode)
-	}
-
-	var members []map[string]any
-	if err := json.NewDecoder(resp.Body).Decode(&members); err != nil {
-		t.Fatalf("decoding members: %v", err)
-	}
-	if len(members) != 2 {
-		t.Fatalf("expected 2 merged members, got %d (%+v)", len(members), members)
-	}
-
-	body = bytes.NewBufferString(`{"email":"static@example.test","role":"viewer"}`)
-	req, _ = http.NewRequest(http.MethodPut, ts.URL+"/admin/api/v1/authorization/plugins/sample_plugin/members", body)
-	req.Header.Set("Content-Type", "application/json")
-	resp, err = http.DefaultClient.Do(req)
-	if err != nil {
-		t.Fatalf("PUT static-conflict member: %v", err)
-	}
-	defer func() { _ = resp.Body.Close() }()
-	if resp.StatusCode != http.StatusConflict {
-		respBody, _ := io.ReadAll(resp.Body)
-		t.Fatalf("put static-conflict status = %d, want 409: %s", resp.StatusCode, respBody)
-	}
-
-	user, err := svc.Users.FindUserByEmail(context.Background(), "dynamic@example.test")
-	if err != nil {
-		t.Fatalf("find dynamic user: %v", err)
-	}
-	req, _ = http.NewRequest(http.MethodDelete, ts.URL+"/admin/api/v1/authorization/plugins/sample_plugin/members/"+url.PathEscape(user.ID), nil)
-	resp, err = http.DefaultClient.Do(req)
-	if err != nil {
-		t.Fatalf("DELETE dynamic member: %v", err)
-	}
-	defer func() { _ = resp.Body.Close() }()
-	if resp.StatusCode != http.StatusOK {
-		respBody, _ := io.ReadAll(resp.Body)
-		t.Fatalf("delete dynamic member status = %d, want 200: %s", resp.StatusCode, respBody)
-	}
-
-	resp, err = http.Get(ts.URL + "/admin/api/v1/authorization/plugins/sample_plugin/members")
-	if err != nil {
-		t.Fatalf("GET members after delete: %v", err)
-	}
-	defer func() { _ = resp.Body.Close() }()
-	if resp.StatusCode != http.StatusOK {
-		t.Fatalf("members after delete status = %d, want 200", resp.StatusCode)
-	}
-	members = nil
-	if err := json.NewDecoder(resp.Body).Decode(&members); err != nil {
-		t.Fatalf("decoding members after delete: %v", err)
-	}
-	if len(members) != 1 || members[0]["source"] != "static" {
-		t.Fatalf("members after delete = %+v, want only static row", members)
 	}
 }
 
@@ -2539,14 +2583,11 @@ func TestAdminAPI_PluginAuthorizationProviderBackedReadsAndDebug(t *testing.T) {
 		},
 	}, map[string]*config.ProviderEntry{
 		"sample_plugin": {AuthorizationPolicy: "sample_policy", MountPath: "/sample"},
-	}, nil, nil, svc.PluginAuthorizations)
+	}, nil, nil)
 	if err != nil {
 		t.Fatalf("authorization.New: %v", err)
 	}
-	authz := authorization.NewProviderBacked(legacy, provider)
-	if err := authz.ReloadDynamic(context.Background()); err != nil {
-		t.Fatalf("ReloadDynamic: %v", err)
-	}
+	authz := mustProviderBackedAuthorizer(t, legacy, provider)
 
 	ts := newTestServer(t, func(cfg *server.Config) {
 		cfg.Auth = &coretesting.StubAuthProvider{
@@ -2740,14 +2781,11 @@ func TestAdminAPI_AuthorizationProviderDebugRequiresAdminPolicy(t *testing.T) {
 		},
 	}, map[string]*config.ProviderEntry{
 		"sample_plugin": {AuthorizationPolicy: "sample_policy", MountPath: "/sample"},
-	}, nil, nil, svc.PluginAuthorizations)
+	}, nil, nil)
 	if err != nil {
 		t.Fatalf("authorization.New: %v", err)
 	}
-	authz := authorization.NewProviderBacked(legacy, provider)
-	if err := authz.ReloadDynamic(context.Background()); err != nil {
-		t.Fatalf("ReloadDynamic: %v", err)
-	}
+	authz := mustProviderBackedAuthorizer(t, legacy, provider)
 
 	ts := newTestServer(t, func(cfg *server.Config) {
 		cfg.Services = svc
@@ -2784,181 +2822,206 @@ func TestAdminAPI_AuthorizationProviderDebugRequiresAdminPolicy(t *testing.T) {
 func TestAdminAPI_AdminAuthorizationCRUD(t *testing.T) {
 	t.Parallel()
 
-	svc := coretesting.NewStubServices(t)
-	ctx := context.Background()
-	seedUser(t, svc, "static-admin@example.test")
-	const adminRole = "owner"
-	authz := mustAuthorizer(t, config.AuthorizationConfig{
-		Policies: map[string]config.HumanPolicyDef{
-			"admin_policy": {
-				Default: "deny",
-				Members: []config.HumanPolicyMemberDef{
-					{Email: "static-admin@example.test", Role: adminRole},
+	for _, tc := range []struct {
+		name     string
+		provider bool
+	}{
+		{name: "legacy", provider: false},
+		{name: "provider_backed", provider: true},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+
+			svc := coretesting.NewStubServices(t)
+			ctx := context.Background()
+			seedUser(t, svc, "static-admin@example.test")
+			const adminRole = "owner"
+			legacy := mustAuthorizer(t, config.AuthorizationConfig{
+				Policies: map[string]config.HumanPolicyDef{
+					"admin_policy": {
+						Default: "deny",
+						Members: []config.HumanPolicyMemberDef{
+							{Email: "static-admin@example.test", Role: adminRole},
+						},
+					},
 				},
-			},
-		},
-	}, nil, nil, nil)
-	authz.SetAdminAuthorizationService(svc.AdminAuthorizations)
-	if err := authz.ReloadDynamic(context.Background()); err != nil {
-		t.Fatalf("ReloadDynamic: %v", err)
-	}
+			}, nil, nil, nil)
 
-	ts := newTestServer(t, func(cfg *server.Config) {
-		cfg.Auth = &coretesting.StubAuthProvider{
-			N: "test",
-			ValidateTokenFn: func(_ context.Context, token string) (*core.UserIdentity, error) {
-				if token != "admin-session" {
-					return nil, fmt.Errorf("invalid token")
+			var (
+				authz    authorization.RuntimeAuthorizer = legacy
+				provider *memoryAuthorizationProvider
+			)
+			if tc.provider {
+				provider = newMemoryAuthorizationProvider("memory-authorization")
+				authz = mustProviderBackedAuthorizer(t, legacy, provider)
+			} else {
+				legacy.SetAdminAuthorizationService(svc.AdminAuthorizations)
+				if err := legacy.ReloadDynamic(context.Background()); err != nil {
+					t.Fatalf("ReloadDynamic: %v", err)
 				}
-				return &core.UserIdentity{Email: "static-admin@example.test"}, nil
-			},
-		}
-		cfg.Services = svc
-		cfg.Authorizer = authz
-		cfg.Admin = server.AdminRouteConfig{
-			AuthorizationPolicy: "admin_policy",
-			AllowedRoles:        []string{adminRole, "operator"},
-		}
-		cfg.AdminUI = http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
-			_, _ = w.Write([]byte("admin"))
+			}
+
+			ts := newTestServer(t, func(cfg *server.Config) {
+				cfg.Auth = &coretesting.StubAuthProvider{
+					N: "test",
+					ValidateTokenFn: func(_ context.Context, token string) (*core.UserIdentity, error) {
+						if token != "admin-session" {
+							return nil, fmt.Errorf("invalid token")
+						}
+						return &core.UserIdentity{Email: "static-admin@example.test"}, nil
+					},
+				}
+				cfg.Services = svc
+				cfg.Authorizer = authz
+				if provider != nil {
+					cfg.AuthorizationProvider = provider
+				}
+				cfg.Admin = server.AdminRouteConfig{
+					AuthorizationPolicy: "admin_policy",
+					AllowedRoles:        []string{adminRole, "operator"},
+				}
+				cfg.AdminUI = http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+					_, _ = w.Write([]byte("admin"))
+				})
+			})
+			testutil.CloseOnCleanup(t, ts)
+
+			req, _ := http.NewRequest(http.MethodGet, ts.URL+"/admin/api/v1/authorization/admins/members", nil)
+			req.AddCookie(&http.Cookie{Name: "session_token", Value: "admin-session"})
+			resp, err := http.DefaultClient.Do(req)
+			if err != nil {
+				t.Fatalf("GET admin members: %v", err)
+			}
+			defer func() { _ = resp.Body.Close() }()
+			if resp.StatusCode != http.StatusOK {
+				body, _ := io.ReadAll(resp.Body)
+				t.Fatalf("admin members status = %d, want 200: %s", resp.StatusCode, body)
+			}
+
+			var members []map[string]any
+			if err := json.NewDecoder(resp.Body).Decode(&members); err != nil {
+				t.Fatalf("decoding admin members: %v", err)
+			}
+			if len(members) != 1 || members[0]["source"] != "static" {
+				t.Fatalf("admin members = %+v, want one static row", members)
+			}
+
+			body := bytes.NewBufferString(`{"email":"dynamic-admin@example.test","role":"owner"}`)
+			req, _ = http.NewRequest(http.MethodPut, ts.URL+"/admin/api/v1/authorization/admins/members", body)
+			req.Header.Set("Content-Type", "application/json")
+			req.AddCookie(&http.Cookie{Name: "session_token", Value: "admin-session"})
+			resp, err = http.DefaultClient.Do(req)
+			if err != nil {
+				t.Fatalf("PUT admin member: %v", err)
+			}
+			defer func() { _ = resp.Body.Close() }()
+			if resp.StatusCode != http.StatusOK {
+				respBody, _ := io.ReadAll(resp.Body)
+				t.Fatalf("put admin member status = %d, want 200: %s", resp.StatusCode, respBody)
+			}
+
+			req, _ = http.NewRequest(http.MethodGet, ts.URL+"/admin/api/v1/authorization/admins/members", nil)
+			req.AddCookie(&http.Cookie{Name: "session_token", Value: "admin-session"})
+			resp, err = http.DefaultClient.Do(req)
+			if err != nil {
+				t.Fatalf("GET admin members after put: %v", err)
+			}
+			defer func() { _ = resp.Body.Close() }()
+			if resp.StatusCode != http.StatusOK {
+				t.Fatalf("admin members after put status = %d, want 200", resp.StatusCode)
+			}
+			members = nil
+			if err := json.NewDecoder(resp.Body).Decode(&members); err != nil {
+				t.Fatalf("decoding admin members after put: %v", err)
+			}
+			if len(members) != 2 {
+				t.Fatalf("expected 2 merged admin members, got %d (%+v)", len(members), members)
+			}
+
+			body = bytes.NewBufferString(`{"email":"static-admin@example.test","role":"owner"}`)
+			req, _ = http.NewRequest(http.MethodPut, ts.URL+"/admin/api/v1/authorization/admins/members", body)
+			req.Header.Set("Content-Type", "application/json")
+			req.AddCookie(&http.Cookie{Name: "session_token", Value: "admin-session"})
+			resp, err = http.DefaultClient.Do(req)
+			if err != nil {
+				t.Fatalf("PUT static admin conflict: %v", err)
+			}
+			defer func() { _ = resp.Body.Close() }()
+			if resp.StatusCode != http.StatusConflict {
+				respBody, _ := io.ReadAll(resp.Body)
+				t.Fatalf("put static admin conflict status = %d, want 409: %s", resp.StatusCode, respBody)
+			}
+
+			user, err := svc.Users.FindUserByEmail(context.Background(), "dynamic-admin@example.test")
+			if err != nil {
+				t.Fatalf("find dynamic admin user: %v", err)
+			}
+			roles, err := svc.WorkspaceRoles.ListByPrincipal(ctx, user.ID)
+			if err != nil {
+				t.Fatalf("ListByPrincipal(dynamic admin): %v", err)
+			}
+			if len(roles) != 1 || roles[0].Role != "owner" {
+				t.Fatalf("workspace roles = %+v, want [owner]", roles)
+			}
+
+			body = bytes.NewBufferString(`{"email":"dynamic-admin@example.test","role":"operator"}`)
+			req, _ = http.NewRequest(http.MethodPut, ts.URL+"/admin/api/v1/authorization/admins/members", body)
+			req.Header.Set("Content-Type", "application/json")
+			req.AddCookie(&http.Cookie{Name: "session_token", Value: "admin-session"})
+			resp, err = http.DefaultClient.Do(req)
+			if err != nil {
+				t.Fatalf("PUT dynamic admin role change: %v", err)
+			}
+			defer func() { _ = resp.Body.Close() }()
+			if resp.StatusCode != http.StatusOK {
+				respBody, _ := io.ReadAll(resp.Body)
+				t.Fatalf("put dynamic admin role change status = %d, want 200: %s", resp.StatusCode, respBody)
+			}
+
+			roles, err = svc.WorkspaceRoles.ListByPrincipal(ctx, user.ID)
+			if err != nil {
+				t.Fatalf("ListByPrincipal(dynamic admin) after role change: %v", err)
+			}
+			if len(roles) != 1 || roles[0].Role != "operator" {
+				t.Fatalf("workspace roles after role change = %+v, want [operator]", roles)
+			}
+			req, _ = http.NewRequest(http.MethodDelete, ts.URL+"/admin/api/v1/authorization/admins/members/"+url.PathEscape(user.ID), nil)
+			req.AddCookie(&http.Cookie{Name: "session_token", Value: "admin-session"})
+			resp, err = http.DefaultClient.Do(req)
+			if err != nil {
+				t.Fatalf("DELETE admin member: %v", err)
+			}
+			defer func() { _ = resp.Body.Close() }()
+			if resp.StatusCode != http.StatusOK {
+				respBody, _ := io.ReadAll(resp.Body)
+				t.Fatalf("delete admin member status = %d, want 200: %s", resp.StatusCode, respBody)
+			}
+
+			req, _ = http.NewRequest(http.MethodGet, ts.URL+"/admin/api/v1/authorization/admins/members", nil)
+			req.AddCookie(&http.Cookie{Name: "session_token", Value: "admin-session"})
+			resp, err = http.DefaultClient.Do(req)
+			if err != nil {
+				t.Fatalf("GET admin members after delete: %v", err)
+			}
+			defer func() { _ = resp.Body.Close() }()
+			if resp.StatusCode != http.StatusOK {
+				t.Fatalf("admin members after delete status = %d, want 200", resp.StatusCode)
+			}
+			members = nil
+			if err := json.NewDecoder(resp.Body).Decode(&members); err != nil {
+				t.Fatalf("decoding admin members after delete: %v", err)
+			}
+			if len(members) != 1 || members[0]["source"] != "static" {
+				t.Fatalf("admin members after delete = %+v, want only static row", members)
+			}
+			roles, err = svc.WorkspaceRoles.ListByPrincipal(ctx, user.ID)
+			if err != nil {
+				t.Fatalf("ListByPrincipal(dynamic admin) after delete: %v", err)
+			}
+			if len(roles) != 0 {
+				t.Fatalf("workspace roles after delete = %+v, want none", roles)
+			}
 		})
-	})
-	testutil.CloseOnCleanup(t, ts)
-
-	req, _ := http.NewRequest(http.MethodGet, ts.URL+"/admin/api/v1/authorization/admins/members", nil)
-	req.AddCookie(&http.Cookie{Name: "session_token", Value: "admin-session"})
-	resp, err := http.DefaultClient.Do(req)
-	if err != nil {
-		t.Fatalf("GET admin members: %v", err)
-	}
-	defer func() { _ = resp.Body.Close() }()
-	if resp.StatusCode != http.StatusOK {
-		body, _ := io.ReadAll(resp.Body)
-		t.Fatalf("admin members status = %d, want 200: %s", resp.StatusCode, body)
-	}
-
-	var members []map[string]any
-	if err := json.NewDecoder(resp.Body).Decode(&members); err != nil {
-		t.Fatalf("decoding admin members: %v", err)
-	}
-	if len(members) != 1 || members[0]["source"] != "static" {
-		t.Fatalf("admin members = %+v, want one static row", members)
-	}
-
-	body := bytes.NewBufferString(`{"email":"dynamic-admin@example.test","role":"owner"}`)
-	req, _ = http.NewRequest(http.MethodPut, ts.URL+"/admin/api/v1/authorization/admins/members", body)
-	req.Header.Set("Content-Type", "application/json")
-	req.AddCookie(&http.Cookie{Name: "session_token", Value: "admin-session"})
-	resp, err = http.DefaultClient.Do(req)
-	if err != nil {
-		t.Fatalf("PUT admin member: %v", err)
-	}
-	defer func() { _ = resp.Body.Close() }()
-	if resp.StatusCode != http.StatusOK {
-		respBody, _ := io.ReadAll(resp.Body)
-		t.Fatalf("put admin member status = %d, want 200: %s", resp.StatusCode, respBody)
-	}
-
-	req, _ = http.NewRequest(http.MethodGet, ts.URL+"/admin/api/v1/authorization/admins/members", nil)
-	req.AddCookie(&http.Cookie{Name: "session_token", Value: "admin-session"})
-	resp, err = http.DefaultClient.Do(req)
-	if err != nil {
-		t.Fatalf("GET admin members after put: %v", err)
-	}
-	defer func() { _ = resp.Body.Close() }()
-	if resp.StatusCode != http.StatusOK {
-		t.Fatalf("admin members after put status = %d, want 200", resp.StatusCode)
-	}
-	members = nil
-	if err := json.NewDecoder(resp.Body).Decode(&members); err != nil {
-		t.Fatalf("decoding admin members after put: %v", err)
-	}
-	if len(members) != 2 {
-		t.Fatalf("expected 2 merged admin members, got %d (%+v)", len(members), members)
-	}
-
-	body = bytes.NewBufferString(`{"email":"static-admin@example.test","role":"owner"}`)
-	req, _ = http.NewRequest(http.MethodPut, ts.URL+"/admin/api/v1/authorization/admins/members", body)
-	req.Header.Set("Content-Type", "application/json")
-	req.AddCookie(&http.Cookie{Name: "session_token", Value: "admin-session"})
-	resp, err = http.DefaultClient.Do(req)
-	if err != nil {
-		t.Fatalf("PUT static admin conflict: %v", err)
-	}
-	defer func() { _ = resp.Body.Close() }()
-	if resp.StatusCode != http.StatusConflict {
-		respBody, _ := io.ReadAll(resp.Body)
-		t.Fatalf("put static admin conflict status = %d, want 409: %s", resp.StatusCode, respBody)
-	}
-
-	user, err := svc.Users.FindUserByEmail(context.Background(), "dynamic-admin@example.test")
-	if err != nil {
-		t.Fatalf("find dynamic admin user: %v", err)
-	}
-	roles, err := svc.WorkspaceRoles.ListByPrincipal(ctx, user.ID)
-	if err != nil {
-		t.Fatalf("ListByPrincipal(dynamic admin): %v", err)
-	}
-	if len(roles) != 1 || roles[0].Role != "owner" {
-		t.Fatalf("workspace roles = %+v, want [owner]", roles)
-	}
-
-	body = bytes.NewBufferString(`{"email":"dynamic-admin@example.test","role":"operator"}`)
-	req, _ = http.NewRequest(http.MethodPut, ts.URL+"/admin/api/v1/authorization/admins/members", body)
-	req.Header.Set("Content-Type", "application/json")
-	req.AddCookie(&http.Cookie{Name: "session_token", Value: "admin-session"})
-	resp, err = http.DefaultClient.Do(req)
-	if err != nil {
-		t.Fatalf("PUT dynamic admin role change: %v", err)
-	}
-	defer func() { _ = resp.Body.Close() }()
-	if resp.StatusCode != http.StatusOK {
-		respBody, _ := io.ReadAll(resp.Body)
-		t.Fatalf("put dynamic admin role change status = %d, want 200: %s", resp.StatusCode, respBody)
-	}
-
-	roles, err = svc.WorkspaceRoles.ListByPrincipal(ctx, user.ID)
-	if err != nil {
-		t.Fatalf("ListByPrincipal(dynamic admin) after role change: %v", err)
-	}
-	if len(roles) != 1 || roles[0].Role != "operator" {
-		t.Fatalf("workspace roles after role change = %+v, want [operator]", roles)
-	}
-	req, _ = http.NewRequest(http.MethodDelete, ts.URL+"/admin/api/v1/authorization/admins/members/"+url.PathEscape(user.ID), nil)
-	req.AddCookie(&http.Cookie{Name: "session_token", Value: "admin-session"})
-	resp, err = http.DefaultClient.Do(req)
-	if err != nil {
-		t.Fatalf("DELETE admin member: %v", err)
-	}
-	defer func() { _ = resp.Body.Close() }()
-	if resp.StatusCode != http.StatusOK {
-		respBody, _ := io.ReadAll(resp.Body)
-		t.Fatalf("delete admin member status = %d, want 200: %s", resp.StatusCode, respBody)
-	}
-
-	req, _ = http.NewRequest(http.MethodGet, ts.URL+"/admin/api/v1/authorization/admins/members", nil)
-	req.AddCookie(&http.Cookie{Name: "session_token", Value: "admin-session"})
-	resp, err = http.DefaultClient.Do(req)
-	if err != nil {
-		t.Fatalf("GET admin members after delete: %v", err)
-	}
-	defer func() { _ = resp.Body.Close() }()
-	if resp.StatusCode != http.StatusOK {
-		t.Fatalf("admin members after delete status = %d, want 200", resp.StatusCode)
-	}
-	members = nil
-	if err := json.NewDecoder(resp.Body).Decode(&members); err != nil {
-		t.Fatalf("decoding admin members after delete: %v", err)
-	}
-	if len(members) != 1 || members[0]["source"] != "static" {
-		t.Fatalf("admin members after delete = %+v, want only static row", members)
-	}
-	roles, err = svc.WorkspaceRoles.ListByPrincipal(ctx, user.ID)
-	if err != nil {
-		t.Fatalf("ListByPrincipal(dynamic admin) after delete: %v", err)
-	}
-	if len(roles) != 0 {
-		t.Fatalf("workspace roles after delete = %+v, want none", roles)
 	}
 }
 
@@ -2979,11 +3042,7 @@ func TestAdminAPI_AdminAuthorizationProviderBackedReads(t *testing.T) {
 			},
 		},
 	}, nil, nil, nil)
-	legacy.SetAdminAuthorizationService(svc.AdminAuthorizations)
-	authz := authorization.NewProviderBacked(legacy, provider)
-	if err := authz.ReloadDynamic(context.Background()); err != nil {
-		t.Fatalf("ReloadDynamic: %v", err)
-	}
+	authz := mustProviderBackedAuthorizer(t, legacy, provider)
 
 	ts := newTestServer(t, func(cfg *server.Config) {
 		cfg.Auth = &coretesting.StubAuthProvider{
@@ -3207,7 +3266,8 @@ func TestAdminAPI_AdminAuthorizationWriteUsesAllowedAdminRoles(t *testing.T) {
 	seedUser(t, svc, "static-admin@example.test")
 	seedUser(t, svc, "viewer@example.test")
 	const adminRole = "ops-admin"
-	authz := mustAuthorizer(t, config.AuthorizationConfig{
+	provider := newMemoryAuthorizationProvider("memory-authorization")
+	legacy := mustAuthorizer(t, config.AuthorizationConfig{
 		Policies: map[string]config.HumanPolicyDef{
 			"admin_policy": {
 				Default: "deny",
@@ -3217,10 +3277,7 @@ func TestAdminAPI_AdminAuthorizationWriteUsesAllowedAdminRoles(t *testing.T) {
 			},
 		},
 	}, nil, nil, nil)
-	authz.SetAdminAuthorizationService(svc.AdminAuthorizations)
-	if err := authz.ReloadDynamic(context.Background()); err != nil {
-		t.Fatalf("ReloadDynamic: %v", err)
-	}
+	authz := mustProviderBackedAuthorizer(t, legacy, provider)
 
 	ts := newTestServer(t, func(cfg *server.Config) {
 		cfg.Auth = &coretesting.StubAuthProvider{
@@ -3238,6 +3295,7 @@ func TestAdminAPI_AdminAuthorizationWriteUsesAllowedAdminRoles(t *testing.T) {
 		}
 		cfg.Services = svc
 		cfg.Authorizer = authz
+		cfg.AuthorizationProvider = provider
 		cfg.Admin = server.AdminRouteConfig{
 			AuthorizationPolicy: "admin_policy",
 			AllowedRoles:        []string{adminRole},
@@ -3298,9 +3356,15 @@ func TestAdminAPI_PluginAuthorizationUnavailable(t *testing.T) {
 	t.Parallel()
 
 	svc := coretesting.NewStubServices(t)
+	svc.PluginAuthorizations = nil
 	authz, err := authorization.New(config.AuthorizationConfig{
 		Policies: map[string]config.HumanPolicyDef{
-			"sample_policy": {Default: "deny"},
+			"sample_policy": {
+				Default: "deny",
+				Members: []config.HumanPolicyMemberDef{
+					{Email: "admin@example.test", Role: "admin"},
+				},
+			},
 		},
 	}, map[string]*config.ProviderEntry{
 		"sample_plugin": {AuthorizationPolicy: "sample_policy", MountPath: "/sample"},
@@ -3310,10 +3374,23 @@ func TestAdminAPI_PluginAuthorizationUnavailable(t *testing.T) {
 	}
 
 	ts := newTestServer(t, func(cfg *server.Config) {
+		cfg.Auth = &coretesting.StubAuthProvider{
+			N: "test",
+			ValidateTokenFn: func(_ context.Context, token string) (*core.UserIdentity, error) {
+				if token != "admin-session" {
+					return nil, fmt.Errorf("invalid token")
+				}
+				return &core.UserIdentity{Email: "admin@example.test"}, nil
+			},
+		}
 		cfg.Services = svc
 		cfg.Authorizer = authz
 		cfg.PluginDefs = map[string]*config.ProviderEntry{
 			"sample_plugin": {AuthorizationPolicy: "sample_policy", MountPath: "/sample"},
+		}
+		cfg.Admin = server.AdminRouteConfig{
+			AuthorizationPolicy: "sample_policy",
+			AllowedRoles:        []string{"admin"},
 		}
 		cfg.AdminUI = http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
 			_, _ = w.Write([]byte("admin"))
@@ -3321,7 +3398,9 @@ func TestAdminAPI_PluginAuthorizationUnavailable(t *testing.T) {
 	})
 	testutil.CloseOnCleanup(t, ts)
 
-	resp, err := http.Get(ts.URL + "/admin/api/v1/authorization/plugins/sample_plugin/members")
+	req, _ := http.NewRequest(http.MethodGet, ts.URL+"/admin/api/v1/authorization/plugins/sample_plugin/members", nil)
+	req.AddCookie(&http.Cookie{Name: "session_token", Value: "admin-session"})
+	resp, err := http.DefaultClient.Do(req)
 	if err != nil {
 		t.Fatalf("GET members: %v", err)
 	}
@@ -3425,22 +3504,25 @@ func TestAdminAPI_AdminAuthorizationUnavailable(t *testing.T) {
 func TestAdminAPI_PluginAuthorizationPutFailureReturnsServerError(t *testing.T) {
 	t.Parallel()
 
-	svc, failPut := newTestServicesWithPluginAuthorizationPutFailure(t)
-	authz, err := authorization.New(config.AuthorizationConfig{
+	svc := coretesting.NewStubServices(t)
+	provider := newMemoryAuthorizationProvider("memory-authorization")
+	legacy, err := authorization.New(config.AuthorizationConfig{
 		Policies: map[string]config.HumanPolicyDef{
 			"sample_policy": {Default: "deny"},
 		},
 	}, map[string]*config.ProviderEntry{
 		"sample_plugin": {AuthorizationPolicy: "sample_policy", MountPath: "/sample"},
-	}, nil, nil, svc.PluginAuthorizations)
+	}, nil, nil)
 	if err != nil {
 		t.Fatalf("authorization.New: %v", err)
 	}
-	failPut.Store(true)
+	authz := mustProviderBackedAuthorizer(t, legacy, provider)
+	provider.writeErr = fmt.Errorf("provider write failed")
 
 	ts := newTestServer(t, func(cfg *server.Config) {
 		cfg.Services = svc
 		cfg.Authorizer = authz
+		cfg.AuthorizationProvider = provider
 		cfg.PluginDefs = map[string]*config.ProviderEntry{
 			"sample_plugin": {AuthorizationPolicy: "sample_policy", MountPath: "/sample"},
 		}
@@ -3467,9 +3549,10 @@ func TestAdminAPI_PluginAuthorizationPutFailureReturnsServerError(t *testing.T) 
 func TestAdminAPI_AdminAuthorizationPutFailureReturnsServerError(t *testing.T) {
 	t.Parallel()
 
-	svc, failPut := newTestServicesWithAdminAuthorizationPutFailure(t)
+	svc := coretesting.NewStubServices(t)
 	seedUser(t, svc, "static-admin@example.test")
-	authz := mustAuthorizer(t, config.AuthorizationConfig{
+	provider := newMemoryAuthorizationProvider("memory-authorization")
+	legacy := mustAuthorizer(t, config.AuthorizationConfig{
 		Policies: map[string]config.HumanPolicyDef{
 			"admin_policy": {
 				Default: "deny",
@@ -3479,11 +3562,8 @@ func TestAdminAPI_AdminAuthorizationPutFailureReturnsServerError(t *testing.T) {
 			},
 		},
 	}, nil, nil, nil)
-	authz.SetAdminAuthorizationService(svc.AdminAuthorizations)
-	if err := authz.ReloadDynamic(context.Background()); err != nil {
-		t.Fatalf("ReloadDynamic: %v", err)
-	}
-	failPut.Store(true)
+	authz := mustProviderBackedAuthorizer(t, legacy, provider)
+	provider.writeErr = fmt.Errorf("provider write failed")
 
 	ts := newTestServer(t, func(cfg *server.Config) {
 		cfg.Auth = &coretesting.StubAuthProvider{
@@ -3497,6 +3577,7 @@ func TestAdminAPI_AdminAuthorizationPutFailureReturnsServerError(t *testing.T) {
 		}
 		cfg.Services = svc
 		cfg.Authorizer = authz
+		cfg.AuthorizationProvider = provider
 		cfg.Admin = server.AdminRouteConfig{
 			AuthorizationPolicy: "admin_policy",
 			AllowedRoles:        []string{"admin"},


### PR DESCRIPTION
## Summary

Remove the remaining runtime dependency edges from human plugin/admin authorization back to the legacy membership stores.

This PR keeps the legacy tables in place for one more deploy, but stops using them as the live dynamic human authorization backend in bootstrap, server handlers, and canonical rehydration.

What changes:
- stop wiring `PluginAuthorizationService` / `AdminAuthorizationService` into the runtime authorizer during bootstrap and validation
- require `providers.authorization` for dynamic human admin/plugin read and write flows in the admin API
- rehydrate canonical human state from provider relationships plus canonical `identity_plugin_access` / `workspace_roles` state, not from legacy membership rows
- migrate existing bootstrap/server coverage to provider-backed setups

## Go Interface

```go
type AuthorizationProvider interface {
    Name() string

    Evaluate(ctx context.Context, req *AccessEvaluationRequest) (*AccessDecision, error)
    EvaluateMany(ctx context.Context, req *AccessEvaluationsRequest) (*AccessEvaluationsResponse, error)
    SearchResources(ctx context.Context, req *ResourceSearchRequest) (*ResourceSearchResponse, error)
    SearchSubjects(ctx context.Context, req *SubjectSearchRequest) (*SubjectSearchResponse, error)
    SearchActions(ctx context.Context, req *ActionSearchRequest) (*ActionSearchResponse, error)
    GetMetadata(ctx context.Context) (*AuthorizationMetadata, error)

    ReadRelationships(ctx context.Context, req *ReadRelationshipsRequest) (*ReadRelationshipsResponse, error)
    WriteRelationships(ctx context.Context, req *WriteRelationshipsRequest) error

    GetActiveModel(ctx context.Context) (*GetActiveModelResponse, error)
    ListModels(ctx context.Context, req *ListModelsRequest) (*ListModelsResponse, error)
    WriteModel(ctx context.Context, req *WriteModelRequest) (*AuthorizationModelRef, error)
}
```

## YAML Usage

```yaml
providers:
  authorization:
    indexeddb:
      source:
        ref: github.com/valon-technologies/gestalt-providers/authorization/indexeddb
        version: v0.0.1-alpha.2
      config:
        indexeddb: default

server:
  providers:
    authorization: indexeddb
```

## Example

A dynamic human plugin/admin grant now flows through the authorization provider first, while canonical side effects continue to materialize in `identity_plugin_access` and `workspace_roles`.

## Verification

```bash
cd gestaltd
go test ./internal/authorization ./internal/bootstrap ./internal/invocation ./internal/mcp ./internal/server
golangci-lint run ./internal/authorization ./internal/bootstrap ./internal/server ./internal/coredata
```