### PR TITLE
[codex] centralize telemetry config parsing

### DIFF
--- a/gestaltd/cmd/gestaltd/factories.go
+++ b/gestaltd/cmd/gestaltd/factories.go
@@ -22,6 +22,7 @@ import (
 	telemetrynoop "github.com/valon-technologies/gestalt/server/internal/drivers/telemetry/noop"
 	telemetryotlp "github.com/valon-technologies/gestalt/server/internal/drivers/telemetry/otlp"
 	telemetrystdout "github.com/valon-technologies/gestalt/server/internal/drivers/telemetry/stdout"
+	"github.com/valon-technologies/gestalt/server/internal/drivers/telemetry/telemetryutil"
 	workflowprovider "github.com/valon-technologies/gestalt/server/internal/drivers/workflow/provider"
 	"github.com/valon-technologies/gestalt/server/internal/invocation"
 	"github.com/valon-technologies/gestalt/server/internal/operator"
@@ -98,8 +99,8 @@ func buildFactories() *bootstrap.FactoryRegistry {
 			return invocation.NewLoggerAuditSink(telemetrynoop.New().Logger()), nil, nil
 		case "stdout":
 			var stdoutCfg struct {
-				Level  string `yaml:"level"`
-				Format string `yaml:"format"`
+				Level  string                  `yaml:"level"`
+				Format telemetryutil.LogFormat `yaml:"format"`
 			}
 			if cfg.Config.Kind != 0 {
 				if err := cfg.Config.Decode(&stdoutCfg); err != nil {

--- a/gestaltd/internal/config/config_validate.go
+++ b/gestaltd/internal/config/config_validate.go
@@ -14,6 +14,7 @@ import (
 	"time"
 
 	cronv3 "github.com/robfig/cron/v3"
+	"github.com/valon-technologies/gestalt/server/internal/drivers/telemetry/telemetryutil"
 	"github.com/valon-technologies/gestalt/server/internal/emailutil"
 	"github.com/valon-technologies/gestalt/server/internal/providerenv"
 	"github.com/valon-technologies/gestalt/server/internal/providerpkg"
@@ -210,8 +211,8 @@ func validateBuiltinAudit(entry *ProviderEntry) error {
 			return nil
 		}
 		var stdoutCfg struct {
-			Level  string `yaml:"level"`
-			Format string `yaml:"format"`
+			Level  string                  `yaml:"level"`
+			Format telemetryutil.LogFormat `yaml:"format"`
 		}
 		if err := entry.Config.Decode(&stdoutCfg); err != nil {
 			return fmt.Errorf("config validation: stdout audit: parsing config: %w", err)
@@ -222,22 +223,15 @@ func validateBuiltinAudit(entry *ProviderEntry) error {
 			return nil
 		}
 		var otlpCfg struct {
-			Protocol string `yaml:"protocol"`
+			Protocol telemetryutil.Protocol `yaml:"protocol"`
 			Logs     struct {
-				Exporter string `yaml:"exporter"`
+				Exporter telemetryutil.LogExporter `yaml:"exporter"`
 			} `yaml:"logs"`
 		}
 		if err := entry.Config.Decode(&otlpCfg); err != nil {
 			return fmt.Errorf("config validation: otlp audit: parsing config: %w", err)
 		}
-		if otlpCfg.Protocol != "" {
-			switch strings.ToLower(otlpCfg.Protocol) {
-			case "grpc", "http":
-			default:
-				return fmt.Errorf("config validation: otlp audit: unknown protocol %q (expected \"grpc\" or \"http\")", otlpCfg.Protocol)
-			}
-		}
-		if otlpCfg.Logs.Exporter != "" && !strings.EqualFold(otlpCfg.Logs.Exporter, "otlp") {
+		if otlpCfg.Logs.Exporter != "" && otlpCfg.Logs.Exporter != telemetryutil.LogExporterOTLP {
 			return fmt.Errorf("config validation: otlp audit: logs.exporter must be %q", "otlp")
 		}
 		return nil

--- a/gestaltd/internal/config/config_validate_test.go
+++ b/gestaltd/internal/config/config_validate_test.go
@@ -1,0 +1,58 @@
+package config
+
+import (
+	"strings"
+	"testing"
+
+	"gopkg.in/yaml.v3"
+)
+
+func TestValidateBuiltinAuditRejectsUnknownOTLPProtocol(t *testing.T) {
+	t.Parallel()
+
+	entry := &ProviderEntry{
+		Source: ProviderSource{Builtin: "otlp"},
+		Config: mustConfigNode(t, "protocol: ftp\n"),
+	}
+
+	err := validateBuiltinAudit(entry)
+	if err == nil {
+		t.Fatal("validateBuiltinAudit() error = nil, want non-nil")
+	}
+	if !strings.Contains(err.Error(), "otlp audit: parsing config") {
+		t.Fatalf("validateBuiltinAudit() error = %q, want parsing config prefix", err)
+	}
+	if !strings.Contains(err.Error(), "unknown protocol") {
+		t.Fatalf("validateBuiltinAudit() error = %q, want unknown protocol detail", err)
+	}
+}
+
+func TestValidateBuiltinAuditRejectsNonOTLPLogsExporter(t *testing.T) {
+	t.Parallel()
+
+	entry := &ProviderEntry{
+		Source: ProviderSource{Builtin: "otlp"},
+		Config: mustConfigNode(t, "logs:\n  exporter: stdout\n"),
+	}
+
+	err := validateBuiltinAudit(entry)
+	if err == nil {
+		t.Fatal("validateBuiltinAudit() error = nil, want non-nil")
+	}
+	if !strings.Contains(err.Error(), `logs.exporter must be "otlp"`) {
+		t.Fatalf("validateBuiltinAudit() error = %q, want exporter requirement", err)
+	}
+}
+
+func mustConfigNode(t *testing.T, content string) yaml.Node {
+	t.Helper()
+
+	var doc yaml.Node
+	if err := yaml.Unmarshal([]byte(content), &doc); err != nil {
+		t.Fatalf("yaml.Unmarshal(): %v", err)
+	}
+	if doc.Kind == yaml.DocumentNode && len(doc.Content) == 1 {
+		return *doc.Content[0]
+	}
+	return doc
+}

--- a/gestaltd/internal/drivers/telemetry/otlp/otlp.go
+++ b/gestaltd/internal/drivers/telemetry/otlp/otlp.go
@@ -6,7 +6,6 @@ import (
 	"fmt"
 	"log/slog"
 	"net/http"
-	"strings"
 	"time"
 
 	"go.opentelemetry.io/otel"
@@ -36,15 +35,15 @@ import (
 var _ core.TelemetryProvider = (*Provider)(nil)
 
 type yamlConfig struct {
-	Endpoint           string            `yaml:"endpoint"`
-	Protocol           string            `yaml:"protocol"`
-	ServiceName        string            `yaml:"serviceName"`
-	Insecure           bool              `yaml:"insecure"`
-	Headers            map[string]string `yaml:"headers"`
-	ResourceAttributes map[string]string `yaml:"resourceAttributes"`
-	Traces             tracesConfig      `yaml:"traces"`
-	Metrics            metricsConfig     `yaml:"metrics"`
-	Logs               logsConfig        `yaml:"logs"`
+	Endpoint           string                 `yaml:"endpoint"`
+	Protocol           telemetryutil.Protocol `yaml:"protocol"`
+	ServiceName        string                 `yaml:"serviceName"`
+	Insecure           bool                   `yaml:"insecure"`
+	Headers            map[string]string      `yaml:"headers"`
+	ResourceAttributes map[string]string      `yaml:"resourceAttributes"`
+	Traces             tracesConfig           `yaml:"traces"`
+	Metrics            metricsConfig          `yaml:"metrics"`
+	Logs               logsConfig             `yaml:"logs"`
 }
 
 type tracesConfig struct {
@@ -57,18 +56,18 @@ type metricsConfig struct {
 }
 
 type logsConfig struct {
-	Level    string `yaml:"level"`
-	Exporter string `yaml:"exporter"`
-	Format   string `yaml:"format"`
+	Level    string                    `yaml:"level"`
+	Exporter telemetryutil.LogExporter `yaml:"exporter"`
+	Format   telemetryutil.LogFormat   `yaml:"format"`
 }
 
 const (
-	defaultProtocol    = "grpc"
+	defaultProtocol    = telemetryutil.ProtocolGRPC
 	defaultServiceName = "gestaltd"
 	defaultInterval    = 60 * time.Second
 	defaultLogLevel    = "info"
-	defaultLogExporter = "otlp"
-	defaultLogFormat   = "text"
+	defaultLogExporter = telemetryutil.LogExporterOTLP
+	defaultLogFormat   = telemetryutil.LogFormatText
 )
 
 type Provider struct {
@@ -82,11 +81,11 @@ type Provider struct {
 func New(ctx context.Context, cfg yamlConfig) (*Provider, error) {
 	applyConfigDefaults(&cfg)
 
-	switch strings.ToLower(cfg.Protocol) {
-	case "grpc", "http":
-	default:
-		return nil, fmt.Errorf("otlp telemetry: unknown protocol %q (expected \"grpc\" or \"http\")", cfg.Protocol)
+	protocol, err := telemetryutil.ParseProtocol(string(cfg.Protocol))
+	if err != nil {
+		return nil, fmt.Errorf("otlp telemetry: %w", err)
 	}
+	cfg.Protocol = protocol
 
 	res := telemetryutil.BuildResource(cfg.ServiceName, cfg.ResourceAttributes)
 
@@ -166,8 +165,8 @@ func buildTracerProvider(ctx context.Context, cfg yamlConfig, res *resource.Reso
 	var exporter sdktrace.SpanExporter
 	var err error
 
-	switch strings.ToLower(cfg.Protocol) {
-	case "http":
+	switch cfg.Protocol {
+	case telemetryutil.ProtocolHTTP:
 		opts := []otlptracehttp.Option{}
 		if cfg.Endpoint != "" {
 			opts = append(opts, otlptracehttp.WithEndpoint(cfg.Endpoint))
@@ -211,8 +210,8 @@ func buildMeterProvider(ctx context.Context, cfg yamlConfig, res *resource.Resou
 	}
 
 	var exporter sdkmetric.Exporter
-	switch strings.ToLower(cfg.Protocol) {
-	case "http":
+	switch cfg.Protocol {
+	case telemetryutil.ProtocolHTTP:
 		opts := []otlpmetrichttp.Option{}
 		if cfg.Endpoint != "" {
 			opts = append(opts, otlpmetrichttp.WithEndpoint(cfg.Endpoint))
@@ -248,8 +247,14 @@ func buildMeterProvider(ctx context.Context, cfg yamlConfig, res *resource.Resou
 }
 
 func buildLogger(ctx context.Context, cfg yamlConfig, res *resource.Resource) (*slog.Logger, *sdklog.LoggerProvider, error) {
-	switch strings.ToLower(cfg.Logs.Exporter) {
-	case "otlp":
+	exporter, err := telemetryutil.ParseLogExporter(string(cfg.Logs.Exporter))
+	if err != nil {
+		return nil, nil, err
+	}
+	cfg.Logs.Exporter = exporter
+
+	switch cfg.Logs.Exporter {
+	case telemetryutil.LogExporterOTLP:
 		lp, err := buildLoggerProvider(ctx, cfg, res)
 		if err != nil {
 			return nil, nil, err
@@ -262,7 +267,7 @@ func buildLogger(ctx context.Context, cfg yamlConfig, res *resource.Resource) (*
 		logger = slog.New(levelFilterHandler{level: level, inner: logger.Handler()})
 		return logger, lp, nil
 
-	case "stdout":
+	case telemetryutil.LogExporterStdout:
 		return telemetrystdout.NewLogger(cfg.Logs.Level, cfg.Logs.Format), nil, nil
 
 	default:
@@ -279,8 +284,8 @@ func buildLoggerProvider(ctx context.Context, cfg yamlConfig, res *resource.Reso
 	var exporter sdklog.Exporter
 	var err error
 
-	switch strings.ToLower(cfg.Protocol) {
-	case "http":
+	switch cfg.Protocol {
+	case telemetryutil.ProtocolHTTP:
 		opts := []otlploghttp.Option{}
 		if cfg.Endpoint != "" {
 			opts = append(opts, otlploghttp.WithEndpoint(cfg.Endpoint))
@@ -360,7 +365,7 @@ func NewAuditLogger(ctx context.Context, node yaml.Node) (*slog.Logger, func(con
 		return nil, nil, err
 	}
 	applyConfigDefaults(&cfg)
-	if !strings.EqualFold(cfg.Logs.Exporter, "otlp") {
+	if cfg.Logs.Exporter != "" && cfg.Logs.Exporter != telemetryutil.LogExporterOTLP {
 		return nil, nil, fmt.Errorf("otlp audit: logs.exporter must be %q", "otlp")
 	}
 

--- a/gestaltd/internal/drivers/telemetry/stdout/stdout.go
+++ b/gestaltd/internal/drivers/telemetry/stdout/stdout.go
@@ -6,7 +6,6 @@ import (
 	"log/slog"
 	"net/http"
 	"os"
-	"strings"
 
 	"go.opentelemetry.io/otel"
 	"go.opentelemetry.io/otel/metric"
@@ -23,11 +22,11 @@ import (
 var _ core.TelemetryProvider = (*Provider)(nil)
 
 type yamlConfig struct {
-	Level              string                 `yaml:"level"`
-	Format             string                 `yaml:"format"`
-	ServiceName        string                 `yaml:"serviceName"`
-	ResourceAttributes map[string]string      `yaml:"resourceAttributes"`
-	Metrics            metricspipeline.Config `yaml:"metrics"`
+	Level              string                  `yaml:"level"`
+	Format             telemetryutil.LogFormat `yaml:"format"`
+	ServiceName        string                  `yaml:"serviceName"`
+	ResourceAttributes map[string]string       `yaml:"resourceAttributes"`
+	Metrics            metricspipeline.Config  `yaml:"metrics"`
 }
 
 type Provider struct {
@@ -37,13 +36,14 @@ type Provider struct {
 	prometheus http.Handler
 }
 
-func NewLogger(levelName, format string) *slog.Logger {
+func NewLogger(levelName string, format telemetryutil.LogFormat) *slog.Logger {
 	level := telemetryutil.ParseLevel(levelName)
 	opts := &slog.HandlerOptions{Level: level}
+	format = telemetryutil.NormalizeLogFormat(string(format))
 
 	var handler slog.Handler
-	switch strings.ToLower(format) {
-	case "json":
+	switch format {
+	case telemetryutil.LogFormatJSON:
 		handler = slog.NewJSONHandler(os.Stdout, opts)
 	default:
 		handler = slog.NewTextHandler(os.Stdout, opts)

--- a/gestaltd/internal/drivers/telemetry/telemetryutil/config.go
+++ b/gestaltd/internal/drivers/telemetry/telemetryutil/config.go
@@ -1,0 +1,85 @@
+package telemetryutil
+
+import (
+	"fmt"
+	"strings"
+)
+
+type Protocol string
+
+const (
+	ProtocolGRPC Protocol = "grpc"
+	ProtocolHTTP Protocol = "http"
+)
+
+func ParseProtocol(value string) (Protocol, error) {
+	switch strings.ToLower(strings.TrimSpace(value)) {
+	case "":
+		return "", nil
+	case string(ProtocolGRPC):
+		return ProtocolGRPC, nil
+	case string(ProtocolHTTP):
+		return ProtocolHTTP, nil
+	default:
+		return "", fmt.Errorf("unknown protocol %q (expected %q or %q)", value, ProtocolGRPC, ProtocolHTTP)
+	}
+}
+
+func (p *Protocol) UnmarshalText(text []byte) error {
+	parsed, err := ParseProtocol(string(text))
+	if err != nil {
+		return err
+	}
+	*p = parsed
+	return nil
+}
+
+type LogExporter string
+
+const (
+	LogExporterOTLP   LogExporter = "otlp"
+	LogExporterStdout LogExporter = "stdout"
+)
+
+func ParseLogExporter(value string) (LogExporter, error) {
+	switch strings.ToLower(strings.TrimSpace(value)) {
+	case "":
+		return "", nil
+	case string(LogExporterOTLP):
+		return LogExporterOTLP, nil
+	case string(LogExporterStdout):
+		return LogExporterStdout, nil
+	default:
+		return "", fmt.Errorf("unknown logs exporter %q (expected %q or %q)", value, LogExporterOTLP, LogExporterStdout)
+	}
+}
+
+func (e *LogExporter) UnmarshalText(text []byte) error {
+	parsed, err := ParseLogExporter(string(text))
+	if err != nil {
+		return err
+	}
+	*e = parsed
+	return nil
+}
+
+type LogFormat string
+
+const (
+	LogFormatText LogFormat = "text"
+	LogFormatJSON LogFormat = "json"
+)
+
+func NormalizeLogFormat(value string) LogFormat {
+	switch strings.ToLower(strings.TrimSpace(value)) {
+	case string(LogFormatJSON):
+		return LogFormatJSON
+	default:
+		return LogFormatText
+	}
+}
+
+func (f *LogFormat) UnmarshalText(text []byte) error {
+	*f = NormalizeLogFormat(string(text))
+	return nil
+}

--- a/gestaltd/internal/drivers/telemetry/telemetryutil/config_test.go
+++ b/gestaltd/internal/drivers/telemetry/telemetryutil/config_test.go
@@ -1,0 +1,100 @@
+package telemetryutil
+
+import "testing"
+
+func TestParseProtocol(t *testing.T) {
+	t.Parallel()
+
+	cases := []struct {
+		name    string
+		input   string
+		want    Protocol
+		wantErr bool
+	}{
+		{name: "empty", input: "", want: ""},
+		{name: "grpc", input: "grpc", want: ProtocolGRPC},
+		{name: "http uppercase", input: "HTTP", want: ProtocolHTTP},
+		{name: "invalid", input: "ftp", wantErr: true},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+
+			got, err := ParseProtocol(tc.input)
+			if tc.wantErr {
+				if err == nil {
+					t.Fatal("ParseProtocol() error = nil, want non-nil")
+				}
+				return
+			}
+			if err != nil {
+				t.Fatalf("ParseProtocol() error = %v", err)
+			}
+			if got != tc.want {
+				t.Fatalf("ParseProtocol() = %q, want %q", got, tc.want)
+			}
+		})
+	}
+}
+
+func TestParseLogExporter(t *testing.T) {
+	t.Parallel()
+
+	cases := []struct {
+		name    string
+		input   string
+		want    LogExporter
+		wantErr bool
+	}{
+		{name: "empty", input: "", want: ""},
+		{name: "otlp", input: "otlp", want: LogExporterOTLP},
+		{name: "stdout uppercase", input: "STDOUT", want: LogExporterStdout},
+		{name: "invalid", input: "file", wantErr: true},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+
+			got, err := ParseLogExporter(tc.input)
+			if tc.wantErr {
+				if err == nil {
+					t.Fatal("ParseLogExporter() error = nil, want non-nil")
+				}
+				return
+			}
+			if err != nil {
+				t.Fatalf("ParseLogExporter() error = %v", err)
+			}
+			if got != tc.want {
+				t.Fatalf("ParseLogExporter() = %q, want %q", got, tc.want)
+			}
+		})
+	}
+}
+
+func TestNormalizeLogFormat(t *testing.T) {
+	t.Parallel()
+
+	cases := []struct {
+		name  string
+		input string
+		want  LogFormat
+	}{
+		{name: "empty defaults to text", input: "", want: LogFormatText},
+		{name: "json", input: "json", want: LogFormatJSON},
+		{name: "json uppercase", input: "JSON", want: LogFormatJSON},
+		{name: "unknown falls back to text", input: "pretty", want: LogFormatText},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+
+			if got := NormalizeLogFormat(tc.input); got != tc.want {
+				t.Fatalf("NormalizeLogFormat() = %q, want %q", got, tc.want)
+			}
+		})
+	}
+}


### PR DESCRIPTION
## What changed
- added typed telemetry config enums for OTLP protocol, logs exporter, and log format in `telemetryutil`
- switched OTLP and stdout telemetry config decoding to use those shared types instead of repeating local string normalization and validation
- reused the shared types in audit config validation and bootstrap audit logger construction
- added focused tests for parser behavior and OTLP audit validation

## Why
The repo was repeating the same telemetry config parsing logic in runtime setup, config validation, and audit bootstrap paths. This change centralizes that parsing in one place while preserving current behavior:
- protocol and logs exporter still reject invalid values
- stdout log format still falls back to text for unknown values

## Validation
- `go test ./internal/drivers/telemetry/... ./internal/config/... ./cmd/gestaltd/...`
- `go test ./...`
