### PR TITLE
authorization: require provider for dynamic human auth

### DIFF
--- a/gestaltd/internal/bootstrap/bootstrap.go
+++ b/gestaltd/internal/bootstrap/bootstrap.go
@@ -654,7 +654,11 @@ func Bootstrap(ctx context.Context, cfg *config.Config, factories *FactoryRegist
 		prepared.Deps.WorkflowRuntime.FailPendingProviders(err)
 		return nil, err
 	}
-	legacyAuthz, err := authorization.New(authzCfg, cfg.Plugins, providers, connMaps.DefaultConnection, prepared.Services.PluginAuthorizations)
+	var dynamicPluginServices []*coredata.PluginAuthorizationService
+	if prepared.AuthorizationProvider != nil && prepared.Services != nil && prepared.Services.PluginAuthorizations != nil {
+		dynamicPluginServices = append(dynamicPluginServices, prepared.Services.PluginAuthorizations)
+	}
+	legacyAuthz, err := authorization.New(authzCfg, cfg.Plugins, providers, connMaps.DefaultConnection, dynamicPluginServices...)
 	if err != nil {
 		prepared.Deps.WorkflowRuntime.FailPendingProviders(err)
 		return nil, err
@@ -665,9 +669,11 @@ func Bootstrap(ctx context.Context, cfg *config.Config, factories *FactoryRegist
 			_ = legacyAuthz.Close()
 		}
 	}()
-	legacyAuthz.SetAdminAuthorizationService(prepared.Services.AdminAuthorizations)
 	var authz authorization.RuntimeAuthorizer = legacyAuthz
 	if prepared.AuthorizationProvider != nil {
+		if prepared.Services != nil {
+			legacyAuthz.SetAdminAuthorizationService(prepared.Services.AdminAuthorizations)
+		}
 		authz = authorization.NewProviderBacked(legacyAuthz, prepared.AuthorizationProvider)
 	}
 	sharedInvoker := invocation.NewBroker(providers, prepared.Services.Users, prepared.Services.Tokens,

--- a/gestaltd/internal/bootstrap/bootstrap_test.go
+++ b/gestaltd/internal/bootstrap/bootstrap_test.go
@@ -3069,6 +3069,23 @@ func TestValidate(t *testing.T) {
 		}
 	})
 
+	t.Run("with authorization provider configured", func(t *testing.T) {
+		t.Parallel()
+
+		cfg := validConfig()
+		cfg.Providers.Authorization = map[string]*config.ProviderEntry{
+			"indexeddb": {Source: config.ProviderSource{Path: "stub"}},
+		}
+		cfg.Server.Providers.Authorization = "indexeddb"
+
+		factories := validFactories()
+		factories.Authorization = stubAuthorizationFactory("test-authorization")
+
+		if _, err := bootstrap.Validate(context.Background(), cfg, factories); err != nil {
+			t.Fatalf("Validate with authorization provider: %v", err)
+		}
+	})
+
 	t.Run("rejects invalid plugin invokes dependency", func(t *testing.T) {
 		t.Parallel()
 
@@ -3835,7 +3852,7 @@ func TestBootstrapSecretResolution(t *testing.T) {
 		}
 	})
 
-	t.Run("legacy human dynamic authorizations still work without authorization provider", func(t *testing.T) {
+	t.Run("dynamic human authorizations require an authorization provider", func(t *testing.T) {
 		t.Parallel()
 
 		cfg := validConfig()
@@ -3893,19 +3910,19 @@ func TestBootstrapSecretResolution(t *testing.T) {
 			Kind:      principal.KindUser,
 		}
 		access, allowed := result.Authorizer.ResolveAccess(ctx, dynamicPrincipal, "calendar")
-		if !allowed {
-			t.Fatal("expected legacy dynamic plugin access to be allowed")
+		if allowed {
+			t.Fatal("expected dynamic plugin access to be denied without authorization provider")
 		}
-		if access.Role != "editor" {
-			t.Fatalf("legacy dynamic plugin role = %q, want %q", access.Role, "editor")
+		if access.Role != "" {
+			t.Fatalf("dynamic plugin role without authorization provider = %q, want empty", access.Role)
 		}
 
 		adminAccess, allowed := result.Authorizer.ResolveAdminAccess(ctx, dynamicPrincipal, "admin-policy")
-		if !allowed {
-			t.Fatal("expected legacy dynamic admin access to be allowed")
+		if allowed {
+			t.Fatal("expected dynamic admin access to be denied without authorization provider")
 		}
-		if adminAccess.Role != "admin" {
-			t.Fatalf("legacy dynamic admin role = %q, want %q", adminAccess.Role, "admin")
+		if adminAccess.Role != "" {
+			t.Fatalf("dynamic admin role without authorization provider = %q, want empty", adminAccess.Role)
 		}
 	})
 

--- a/gestaltd/internal/bootstrap/validate.go
+++ b/gestaltd/internal/bootstrap/validate.go
@@ -12,6 +12,7 @@ import (
 	"github.com/valon-technologies/gestalt/server/core/catalog"
 	"github.com/valon-technologies/gestalt/server/internal/authorization"
 	"github.com/valon-technologies/gestalt/server/internal/config"
+	"github.com/valon-technologies/gestalt/server/internal/coredata"
 	"github.com/valon-technologies/gestalt/server/internal/invocation"
 	"github.com/valon-technologies/gestalt/server/internal/metricutil"
 	"github.com/valon-technologies/gestalt/server/internal/plugininvocation"
@@ -61,7 +62,14 @@ func Validate(ctx context.Context, cfg *config.Config, factories *FactoryRegistr
 		prepared.Deps.WorkflowRuntime.FailPendingProviders(err)
 		return warnings, err
 	}
-	authz, err := authorization.New(authzCfg, cfg.Plugins, providers, connMaps.DefaultConnection, prepared.Services.PluginAuthorizations)
+	var dynamicPluginServices []*coredata.PluginAuthorizationService
+	if _, authzEntry, err := cfg.SelectedAuthorizationProvider(); err != nil {
+		prepared.Deps.WorkflowRuntime.FailPendingProviders(err)
+		return warnings, err
+	} else if authzEntry != nil && prepared.Services != nil && prepared.Services.PluginAuthorizations != nil {
+		dynamicPluginServices = append(dynamicPluginServices, prepared.Services.PluginAuthorizations)
+	}
+	authz, err := authorization.New(authzCfg, cfg.Plugins, providers, connMaps.DefaultConnection, dynamicPluginServices...)
 	if err != nil {
 		prepared.Deps.WorkflowRuntime.FailPendingProviders(err)
 		return warnings, err

--- a/gestaltd/internal/server/handlers_admin_authorization.go
+++ b/gestaltd/internal/server/handlers_admin_authorization.go
@@ -14,7 +14,6 @@ import (
 	"github.com/valon-technologies/gestalt/server/core"
 	"github.com/valon-technologies/gestalt/server/internal/authorization"
 	"github.com/valon-technologies/gestalt/server/internal/config"
-	"github.com/valon-technologies/gestalt/server/internal/coredata"
 	"github.com/valon-technologies/gestalt/server/internal/emailutil"
 	"github.com/valon-technologies/gestalt/server/internal/invocation"
 	"github.com/valon-technologies/gestalt/server/internal/principal"
@@ -150,9 +149,6 @@ func (s *Server) putAdminAuthorizationPluginMember(w http.ResponseWriter, r *htt
 	if !s.ensureAdminDynamicAuthorizationAvailable(w) {
 		return
 	}
-	if !s.ensureAdminDynamicAuthorizationWriteAvailable(w) {
-		return
-	}
 
 	var req putAdminAuthorizationMemberRequest
 	if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
@@ -177,17 +173,7 @@ func (s *Server) putAdminAuthorizationPluginMember(w http.ResponseWriter, r *htt
 		return
 	}
 
-	var membership *coredata.PluginAuthorizationMembership
-	if s.authorizationProvider != nil {
-		membership, err = s.upsertProviderPluginAuthorization(r.Context(), user, plugin, req.Role)
-	} else {
-		membership, err = s.pluginAuthorizations.UpsertPluginAuthorization(r.Context(), &coredata.PluginAuthorizationMembership{
-			Plugin: plugin,
-			UserID: user.ID,
-			Email:  user.Email,
-			Role:   req.Role,
-		})
-	}
+	membership, err := s.upsertProviderPluginAuthorization(r.Context(), user, plugin, req.Role)
 	if err != nil {
 		writeError(w, http.StatusInternalServerError, "failed to persist authorization member")
 		return
@@ -230,21 +216,13 @@ func (s *Server) deleteAdminAuthorizationPluginMember(w http.ResponseWriter, r *
 	if !s.ensureAdminDynamicAuthorizationAvailable(w) {
 		return
 	}
-	if !s.ensureAdminDynamicAuthorizationWriteAvailable(w) {
-		return
-	}
 	userID := strings.TrimSpace(chi.URLParam(r, "userID"))
 	if userID == "" {
 		writeError(w, http.StatusBadRequest, "userID is required")
 		return
 	}
 
-	var deleteErr error
-	if s.authorizationProvider != nil {
-		deleteErr = s.deleteProviderPluginAuthorization(r.Context(), plugin, userID)
-	} else {
-		deleteErr = s.pluginAuthorizations.DeletePluginAuthorization(r.Context(), plugin, userID)
-	}
+	deleteErr := s.deleteProviderPluginAuthorization(r.Context(), plugin, userID)
 	if deleteErr != nil {
 		if errors.Is(deleteErr, core.ErrNotFound) {
 			writeError(w, http.StatusNotFound, "authorization member not found")
@@ -288,9 +266,6 @@ func (s *Server) putAdminAuthorizationAdminMember(w http.ResponseWriter, r *http
 	if !s.ensureAdminDynamicAdminAvailable(w) {
 		return
 	}
-	if !s.ensureAdminDynamicAdminWriteAvailable(w) {
-		return
-	}
 	if !s.ensureAdminAuthorizationWriteAccess(w, r) {
 		return
 	}
@@ -318,16 +293,7 @@ func (s *Server) putAdminAuthorizationAdminMember(w http.ResponseWriter, r *http
 		return
 	}
 
-	var membership *coredata.AdminAuthorizationMembership
-	if s.authorizationProvider != nil {
-		membership, err = s.upsertProviderAdminAuthorization(r.Context(), user, req.Role)
-	} else {
-		membership, err = s.adminAuthorizations.UpsertAdminAuthorization(r.Context(), &coredata.AdminAuthorizationMembership{
-			UserID: user.ID,
-			Email:  user.Email,
-			Role:   req.Role,
-		})
-	}
+	membership, err := s.upsertProviderAdminAuthorization(r.Context(), user, req.Role)
 	if err != nil {
 		writeError(w, http.StatusInternalServerError, "failed to persist admin member")
 		return
@@ -364,9 +330,6 @@ func (s *Server) deleteAdminAuthorizationAdminMember(w http.ResponseWriter, r *h
 	if !s.ensureAdminDynamicAdminAvailable(w) {
 		return
 	}
-	if !s.ensureAdminDynamicAdminWriteAvailable(w) {
-		return
-	}
 	if !s.ensureAdminAuthorizationWriteAccess(w, r) {
 		return
 	}
@@ -376,12 +339,7 @@ func (s *Server) deleteAdminAuthorizationAdminMember(w http.ResponseWriter, r *h
 		return
 	}
 
-	var deleteErr error
-	if s.authorizationProvider != nil {
-		deleteErr = s.deleteProviderAdminAuthorization(r.Context(), userID)
-	} else {
-		deleteErr = s.adminAuthorizations.DeleteAdminAuthorization(r.Context(), userID)
-	}
+	deleteErr := s.deleteProviderAdminAuthorization(r.Context(), userID)
 	if deleteErr != nil {
 		if errors.Is(deleteErr, core.ErrNotFound) {
 			writeError(w, http.StatusNotFound, "admin member not found")
@@ -435,40 +393,16 @@ func (s *Server) writeAdminAuthorizationPluginError(w http.ResponseWriter, err e
 }
 
 func (s *Server) adminAuthorizationMemberRows(ctx context.Context, plugin string) ([]adminAuthorizationMemberRow, error) {
-	if s.authorizer == nil || (!s.authorizer.HasDynamicPluginAuthorizations() && s.authorizationProvider == nil) {
+	if s.authorizer == nil || s.authorizationProvider == nil {
 		return nil, errAdminAuthorizationUnavailable
 	}
 	staticRows, err := s.adminAuthorizationStaticRows(ctx, plugin)
 	if err != nil {
 		return nil, err
 	}
-	dynamicRows := make([]adminAuthorizationMemberRow, 0)
-	if s.authorizationProvider != nil {
-		dynamicRows, err = s.providerPluginAuthorizationRows(ctx, plugin)
-		if err != nil {
-			return nil, err
-		}
-	} else {
-		dynamicMemberships, listErr := s.pluginAuthorizations.ListPluginAuthorizationsByPlugin(ctx, plugin)
-		if listErr != nil {
-			return nil, listErr
-		}
-		for _, membership := range dynamicMemberships {
-			if membership == nil {
-				continue
-			}
-			dynamicRows = append(dynamicRows, adminAuthorizationMemberRow{
-				Plugin:        membership.Plugin,
-				Role:          membership.Role,
-				Source:        "dynamic",
-				Effective:     true,
-				Mutable:       true,
-				SelectorKind:  "user_id",
-				SelectorValue: membership.UserID,
-				UserID:        membership.UserID,
-				Email:         membership.Email,
-			})
-		}
+	dynamicRows, err := s.providerPluginAuthorizationRows(ctx, plugin)
+	if err != nil {
+		return nil, err
 	}
 
 	staticByUserID := make(map[string]string, len(staticRows))
@@ -514,39 +448,16 @@ func (s *Server) adminAuthorizationMemberRows(ctx context.Context, plugin string
 }
 
 func (s *Server) adminAuthorizationAdminRows(ctx context.Context) ([]adminAuthorizationMemberRow, error) {
-	if s.authorizer == nil || (!s.authorizer.HasDynamicAdminAuthorizations() && s.authorizationProvider == nil) {
+	if s.authorizer == nil || s.authorizationProvider == nil {
 		return nil, errAdminAuthorizationUnavailable
 	}
 	staticRows, err := s.adminAuthorizationStaticAdminRows(ctx)
 	if err != nil {
 		return nil, err
 	}
-	dynamicRows := make([]adminAuthorizationMemberRow, 0)
-	if s.authorizationProvider != nil {
-		dynamicRows, err = s.providerAdminAuthorizationRows(ctx)
-		if err != nil {
-			return nil, err
-		}
-	} else {
-		dynamicMemberships, listErr := s.adminAuthorizations.ListAdminAuthorizations(ctx)
-		if listErr != nil {
-			return nil, listErr
-		}
-		for _, membership := range dynamicMemberships {
-			if membership == nil {
-				continue
-			}
-			dynamicRows = append(dynamicRows, adminAuthorizationMemberRow{
-				Role:          membership.Role,
-				Source:        "dynamic",
-				Effective:     true,
-				Mutable:       true,
-				SelectorKind:  "user_id",
-				SelectorValue: membership.UserID,
-				UserID:        membership.UserID,
-				Email:         membership.Email,
-			})
-		}
+	dynamicRows, err := s.providerAdminAuthorizationRows(ctx)
+	if err != nil {
+		return nil, err
 	}
 
 	staticByUserID := make(map[string]string, len(staticRows))
@@ -699,26 +610,8 @@ var (
 )
 
 func (s *Server) ensureAdminDynamicAuthorizationAvailable(w http.ResponseWriter) bool {
-	if s.authorizer == nil {
-		writeError(w, http.StatusServiceUnavailable, "dynamic authorization is unavailable")
-		return false
-	}
-	if s.authorizationProvider != nil {
-		return true
-	}
-	if s.pluginAuthorizations == nil || !s.authorizer.HasDynamicPluginAuthorizations() {
-		writeError(w, http.StatusServiceUnavailable, "dynamic authorization is unavailable")
-		return false
-	}
-	return true
-}
-
-func (s *Server) ensureAdminDynamicAuthorizationWriteAvailable(w http.ResponseWriter) bool {
-	if s.authorizationProvider != nil {
-		return true
-	}
-	if s.pluginAuthorizations == nil || s.authorizer == nil || !s.authorizer.HasDynamicPluginAuthorizations() {
-		writeError(w, http.StatusServiceUnavailable, "dynamic authorization writes are unavailable")
+	if s.authorizer == nil || s.authorizationProvider == nil {
+		writeError(w, http.StatusServiceUnavailable, "dynamic authorization requires an authorization provider")
 		return false
 	}
 	return true
@@ -733,8 +626,8 @@ func (s *Server) ensureAdminDynamicAdminAvailable(w http.ResponseWriter) bool {
 		writeError(w, http.StatusServiceUnavailable, "dynamic admin authorization is unavailable")
 		return false
 	}
-	if s.authorizationProvider == nil && (s.adminAuthorizations == nil || !s.authorizer.HasDynamicAdminAuthorizations()) {
-		writeError(w, http.StatusServiceUnavailable, "dynamic admin authorization is unavailable")
+	if s.authorizationProvider == nil {
+		writeError(w, http.StatusServiceUnavailable, "dynamic admin authorization requires an authorization provider")
 		return false
 	}
 	members, ok := s.authorizer.StaticMembersForPolicy(s.adminRoute.AuthorizationPolicy)
@@ -751,17 +644,6 @@ func (s *Server) ensureAdminDynamicAdminAvailable(w http.ResponseWriter) bool {
 	}
 	if !hasSeedAdmin {
 		writeError(w, http.StatusServiceUnavailable, "dynamic admin authorization requires at least one static admin member")
-		return false
-	}
-	return true
-}
-
-func (s *Server) ensureAdminDynamicAdminWriteAvailable(w http.ResponseWriter) bool {
-	if s.authorizationProvider != nil {
-		return true
-	}
-	if s.adminAuthorizations == nil || s.authorizer == nil || !s.authorizer.HasDynamicAdminAuthorizations() {
-		writeError(w, http.StatusServiceUnavailable, "dynamic admin authorization writes are unavailable")
 		return false
 	}
 	return true

--- a/gestaltd/internal/server/server.go
+++ b/gestaltd/internal/server/server.go
@@ -70,8 +70,6 @@ type Server struct {
 	managedIdentities     *coredata.ManagedIdentityService
 	identityMemberships   *coredata.ManagedIdentityMembershipService
 	identityGrants        *coredata.ManagedIdentityGrantService
-	pluginAuthorizations  *coredata.PluginAuthorizationService
-	adminAuthorizations   *coredata.AdminAuthorizationService
 	workspaceRoles        *coredata.WorkspaceRoleService
 	identityPluginAccess  *coredata.IdentityPluginAccessService
 	authorizationProvider core.AuthorizationProvider
@@ -190,8 +188,6 @@ func New(cfg Config) (*Server, error) {
 	managedIdentities := cfg.Services.ManagedIdentities
 	identityMemberships := cfg.Services.IdentityMemberships
 	identityGrants := cfg.Services.IdentityGrants
-	pluginAuthorizations := cfg.Services.PluginAuthorizations
-	adminAuthorizations := cfg.Services.AdminAuthorizations
 	workspaceRoles := cfg.Services.WorkspaceRoles
 	identityPluginAccess := cfg.Services.IdentityPluginAccess
 	resolver := principal.NewResolver(cfg.Auth, users, apiTokens, managedIdentities, identityGrants, cfg.Authorizer)
@@ -212,8 +208,6 @@ func New(cfg Config) (*Server, error) {
 		managedIdentities:     managedIdentities,
 		identityMemberships:   identityMemberships,
 		identityGrants:        identityGrants,
-		pluginAuthorizations:  pluginAuthorizations,
-		adminAuthorizations:   adminAuthorizations,
 		workspaceRoles:        workspaceRoles,
 		identityPluginAccess:  identityPluginAccess,
 		authorizationProvider: cfg.AuthorizationProvider,

--- a/gestaltd/internal/server/server_test.go
+++ b/gestaltd/internal/server/server_test.go
@@ -2428,142 +2428,119 @@ func TestAdminAPIRoutes_HiddenOnPublicProfile(t *testing.T) {
 func TestAdminAPI_PluginAuthorizationCRUD(t *testing.T) {
 	t.Parallel()
 
-	for _, tc := range []struct {
-		name     string
-		provider bool
-	}{
-		{name: "legacy", provider: false},
-		{name: "provider_backed", provider: true},
-	} {
-		t.Run(tc.name, func(t *testing.T) {
-			t.Parallel()
-
-			svc := coretesting.NewStubServices(t)
-			legacy, err := authorization.New(config.AuthorizationConfig{
-				Policies: map[string]config.HumanPolicyDef{
-					"sample_policy": {
-						Default: "deny",
-						Members: []config.HumanPolicyMemberDef{
-							{Email: "static@example.test", Role: "admin"},
-						},
-					},
+	svc := coretesting.NewStubServices(t)
+	legacy, err := authorization.New(config.AuthorizationConfig{
+		Policies: map[string]config.HumanPolicyDef{
+			"sample_policy": {
+				Default: "deny",
+				Members: []config.HumanPolicyMemberDef{
+					{Email: "static@example.test", Role: "admin"},
 				},
-			}, map[string]*config.ProviderEntry{
-				"sample_plugin": {AuthorizationPolicy: "sample_policy", MountPath: "/sample"},
-			}, nil, nil, svc.PluginAuthorizations)
-			if err != nil {
-				t.Fatalf("authorization.New: %v", err)
-			}
+			},
+		},
+	}, map[string]*config.ProviderEntry{
+		"sample_plugin": {AuthorizationPolicy: "sample_policy", MountPath: "/sample"},
+	}, nil, nil, nil)
+	if err != nil {
+		t.Fatalf("authorization.New: %v", err)
+	}
+	provider := newMemoryAuthorizationProvider("memory-authorization")
+	authz := mustProviderBackedAuthorizer(t, legacy, provider)
 
-			var (
-				authz    authorization.RuntimeAuthorizer = legacy
-				provider *memoryAuthorizationProvider
-			)
-			if tc.provider {
-				provider = newMemoryAuthorizationProvider("memory-authorization")
-				authz = mustProviderBackedAuthorizer(t, legacy, provider)
-			} else if err := legacy.ReloadDynamic(context.Background()); err != nil {
-				t.Fatalf("ReloadDynamic: %v", err)
-			}
-
-			ts := newTestServer(t, func(cfg *server.Config) {
-				cfg.Services = svc
-				cfg.Authorizer = authz
-				if provider != nil {
-					cfg.AuthorizationProvider = provider
-				}
-				cfg.PluginDefs = map[string]*config.ProviderEntry{
-					"sample_plugin": {AuthorizationPolicy: "sample_policy", MountPath: "/sample"},
-				}
-				cfg.AdminUI = http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
-					_, _ = w.Write([]byte("admin"))
-				})
-			})
-			testutil.CloseOnCleanup(t, ts)
-
-			resp, err := http.Get(ts.URL + "/admin/api/v1/authorization/plugins")
-			if err != nil {
-				t.Fatalf("GET plugins: %v", err)
-			}
-			defer func() { _ = resp.Body.Close() }()
-			if resp.StatusCode != http.StatusOK {
-				t.Fatalf("plugins status = %d, want 200", resp.StatusCode)
-			}
-
-			body := bytes.NewBufferString(`{"email":"dynamic@example.test","role":"viewer"}`)
-			req, _ := http.NewRequest(http.MethodPut, ts.URL+"/admin/api/v1/authorization/plugins/sample_plugin/members", body)
-			req.Header.Set("Content-Type", "application/json")
-			resp, err = http.DefaultClient.Do(req)
-			if err != nil {
-				t.Fatalf("PUT dynamic member: %v", err)
-			}
-			defer func() { _ = resp.Body.Close() }()
-			if resp.StatusCode != http.StatusOK {
-				respBody, _ := io.ReadAll(resp.Body)
-				t.Fatalf("put dynamic member status = %d, want 200: %s", resp.StatusCode, respBody)
-			}
-
-			resp, err = http.Get(ts.URL + "/admin/api/v1/authorization/plugins/sample_plugin/members")
-			if err != nil {
-				t.Fatalf("GET members: %v", err)
-			}
-			defer func() { _ = resp.Body.Close() }()
-			if resp.StatusCode != http.StatusOK {
-				t.Fatalf("members status = %d, want 200", resp.StatusCode)
-			}
-
-			var members []map[string]any
-			if err := json.NewDecoder(resp.Body).Decode(&members); err != nil {
-				t.Fatalf("decoding members: %v", err)
-			}
-			if len(members) != 2 {
-				t.Fatalf("expected 2 merged members, got %d (%+v)", len(members), members)
-			}
-
-			body = bytes.NewBufferString(`{"email":"static@example.test","role":"viewer"}`)
-			req, _ = http.NewRequest(http.MethodPut, ts.URL+"/admin/api/v1/authorization/plugins/sample_plugin/members", body)
-			req.Header.Set("Content-Type", "application/json")
-			resp, err = http.DefaultClient.Do(req)
-			if err != nil {
-				t.Fatalf("PUT static-conflict member: %v", err)
-			}
-			defer func() { _ = resp.Body.Close() }()
-			if resp.StatusCode != http.StatusConflict {
-				respBody, _ := io.ReadAll(resp.Body)
-				t.Fatalf("put static-conflict status = %d, want 409: %s", resp.StatusCode, respBody)
-			}
-
-			user, err := svc.Users.FindUserByEmail(context.Background(), "dynamic@example.test")
-			if err != nil {
-				t.Fatalf("find dynamic user: %v", err)
-			}
-			req, _ = http.NewRequest(http.MethodDelete, ts.URL+"/admin/api/v1/authorization/plugins/sample_plugin/members/"+url.PathEscape(user.ID), nil)
-			resp, err = http.DefaultClient.Do(req)
-			if err != nil {
-				t.Fatalf("DELETE dynamic member: %v", err)
-			}
-			defer func() { _ = resp.Body.Close() }()
-			if resp.StatusCode != http.StatusOK {
-				respBody, _ := io.ReadAll(resp.Body)
-				t.Fatalf("delete dynamic member status = %d, want 200: %s", resp.StatusCode, respBody)
-			}
-
-			resp, err = http.Get(ts.URL + "/admin/api/v1/authorization/plugins/sample_plugin/members")
-			if err != nil {
-				t.Fatalf("GET members after delete: %v", err)
-			}
-			defer func() { _ = resp.Body.Close() }()
-			if resp.StatusCode != http.StatusOK {
-				t.Fatalf("members after delete status = %d, want 200", resp.StatusCode)
-			}
-			members = nil
-			if err := json.NewDecoder(resp.Body).Decode(&members); err != nil {
-				t.Fatalf("decoding members after delete: %v", err)
-			}
-			if len(members) != 1 || members[0]["source"] != "static" {
-				t.Fatalf("members after delete = %+v, want only static row", members)
-			}
+	ts := newTestServer(t, func(cfg *server.Config) {
+		cfg.Services = svc
+		cfg.Authorizer = authz
+		cfg.AuthorizationProvider = provider
+		cfg.PluginDefs = map[string]*config.ProviderEntry{
+			"sample_plugin": {AuthorizationPolicy: "sample_policy", MountPath: "/sample"},
+		}
+		cfg.AdminUI = http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+			_, _ = w.Write([]byte("admin"))
 		})
+	})
+	testutil.CloseOnCleanup(t, ts)
+
+	resp, err := http.Get(ts.URL + "/admin/api/v1/authorization/plugins")
+	if err != nil {
+		t.Fatalf("GET plugins: %v", err)
+	}
+	defer func() { _ = resp.Body.Close() }()
+	if resp.StatusCode != http.StatusOK {
+		t.Fatalf("plugins status = %d, want 200", resp.StatusCode)
+	}
+
+	body := bytes.NewBufferString(`{"email":"dynamic@example.test","role":"viewer"}`)
+	req, _ := http.NewRequest(http.MethodPut, ts.URL+"/admin/api/v1/authorization/plugins/sample_plugin/members", body)
+	req.Header.Set("Content-Type", "application/json")
+	resp, err = http.DefaultClient.Do(req)
+	if err != nil {
+		t.Fatalf("PUT dynamic member: %v", err)
+	}
+	defer func() { _ = resp.Body.Close() }()
+	if resp.StatusCode != http.StatusOK {
+		respBody, _ := io.ReadAll(resp.Body)
+		t.Fatalf("put dynamic member status = %d, want 200: %s", resp.StatusCode, respBody)
+	}
+
+	resp, err = http.Get(ts.URL + "/admin/api/v1/authorization/plugins/sample_plugin/members")
+	if err != nil {
+		t.Fatalf("GET members: %v", err)
+	}
+	defer func() { _ = resp.Body.Close() }()
+	if resp.StatusCode != http.StatusOK {
+		t.Fatalf("members status = %d, want 200", resp.StatusCode)
+	}
+
+	var members []map[string]any
+	if err := json.NewDecoder(resp.Body).Decode(&members); err != nil {
+		t.Fatalf("decoding members: %v", err)
+	}
+	if len(members) != 2 {
+		t.Fatalf("expected 2 merged members, got %d (%+v)", len(members), members)
+	}
+
+	body = bytes.NewBufferString(`{"email":"static@example.test","role":"viewer"}`)
+	req, _ = http.NewRequest(http.MethodPut, ts.URL+"/admin/api/v1/authorization/plugins/sample_plugin/members", body)
+	req.Header.Set("Content-Type", "application/json")
+	resp, err = http.DefaultClient.Do(req)
+	if err != nil {
+		t.Fatalf("PUT static-conflict member: %v", err)
+	}
+	defer func() { _ = resp.Body.Close() }()
+	if resp.StatusCode != http.StatusConflict {
+		respBody, _ := io.ReadAll(resp.Body)
+		t.Fatalf("put static-conflict status = %d, want 409: %s", resp.StatusCode, respBody)
+	}
+
+	user, err := svc.Users.FindUserByEmail(context.Background(), "dynamic@example.test")
+	if err != nil {
+		t.Fatalf("find dynamic user: %v", err)
+	}
+	req, _ = http.NewRequest(http.MethodDelete, ts.URL+"/admin/api/v1/authorization/plugins/sample_plugin/members/"+url.PathEscape(user.ID), nil)
+	resp, err = http.DefaultClient.Do(req)
+	if err != nil {
+		t.Fatalf("DELETE dynamic member: %v", err)
+	}
+	defer func() { _ = resp.Body.Close() }()
+	if resp.StatusCode != http.StatusOK {
+		respBody, _ := io.ReadAll(resp.Body)
+		t.Fatalf("delete dynamic member status = %d, want 200: %s", resp.StatusCode, respBody)
+	}
+
+	resp, err = http.Get(ts.URL + "/admin/api/v1/authorization/plugins/sample_plugin/members")
+	if err != nil {
+		t.Fatalf("GET members after delete: %v", err)
+	}
+	defer func() { _ = resp.Body.Close() }()
+	if resp.StatusCode != http.StatusOK {
+		t.Fatalf("members after delete status = %d, want 200", resp.StatusCode)
+	}
+	members = nil
+	if err := json.NewDecoder(resp.Body).Decode(&members); err != nil {
+		t.Fatalf("decoding members after delete: %v", err)
+	}
+	if len(members) != 1 || members[0]["source"] != "static" {
+		t.Fatalf("members after delete = %+v, want only static row", members)
 	}
 }
 
@@ -2822,206 +2799,180 @@ func TestAdminAPI_AuthorizationProviderDebugRequiresAdminPolicy(t *testing.T) {
 func TestAdminAPI_AdminAuthorizationCRUD(t *testing.T) {
 	t.Parallel()
 
-	for _, tc := range []struct {
-		name     string
-		provider bool
-	}{
-		{name: "legacy", provider: false},
-		{name: "provider_backed", provider: true},
-	} {
-		t.Run(tc.name, func(t *testing.T) {
-			t.Parallel()
-
-			svc := coretesting.NewStubServices(t)
-			ctx := context.Background()
-			seedUser(t, svc, "static-admin@example.test")
-			const adminRole = "owner"
-			legacy := mustAuthorizer(t, config.AuthorizationConfig{
-				Policies: map[string]config.HumanPolicyDef{
-					"admin_policy": {
-						Default: "deny",
-						Members: []config.HumanPolicyMemberDef{
-							{Email: "static-admin@example.test", Role: adminRole},
-						},
-					},
+	svc := coretesting.NewStubServices(t)
+	ctx := context.Background()
+	seedUser(t, svc, "static-admin@example.test")
+	const adminRole = "owner"
+	legacy := mustAuthorizer(t, config.AuthorizationConfig{
+		Policies: map[string]config.HumanPolicyDef{
+			"admin_policy": {
+				Default: "deny",
+				Members: []config.HumanPolicyMemberDef{
+					{Email: "static-admin@example.test", Role: adminRole},
 				},
-			}, nil, nil, nil)
+			},
+		},
+	}, nil, nil, nil)
+	provider := newMemoryAuthorizationProvider("memory-authorization")
+	authz := mustProviderBackedAuthorizer(t, legacy, provider)
 
-			var (
-				authz    authorization.RuntimeAuthorizer = legacy
-				provider *memoryAuthorizationProvider
-			)
-			if tc.provider {
-				provider = newMemoryAuthorizationProvider("memory-authorization")
-				authz = mustProviderBackedAuthorizer(t, legacy, provider)
-			} else {
-				legacy.SetAdminAuthorizationService(svc.AdminAuthorizations)
-				if err := legacy.ReloadDynamic(context.Background()); err != nil {
-					t.Fatalf("ReloadDynamic: %v", err)
+	ts := newTestServer(t, func(cfg *server.Config) {
+		cfg.Auth = &coretesting.StubAuthProvider{
+			N: "test",
+			ValidateTokenFn: func(_ context.Context, token string) (*core.UserIdentity, error) {
+				if token != "admin-session" {
+					return nil, fmt.Errorf("invalid token")
 				}
-			}
-
-			ts := newTestServer(t, func(cfg *server.Config) {
-				cfg.Auth = &coretesting.StubAuthProvider{
-					N: "test",
-					ValidateTokenFn: func(_ context.Context, token string) (*core.UserIdentity, error) {
-						if token != "admin-session" {
-							return nil, fmt.Errorf("invalid token")
-						}
-						return &core.UserIdentity{Email: "static-admin@example.test"}, nil
-					},
-				}
-				cfg.Services = svc
-				cfg.Authorizer = authz
-				if provider != nil {
-					cfg.AuthorizationProvider = provider
-				}
-				cfg.Admin = server.AdminRouteConfig{
-					AuthorizationPolicy: "admin_policy",
-					AllowedRoles:        []string{adminRole, "operator"},
-				}
-				cfg.AdminUI = http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
-					_, _ = w.Write([]byte("admin"))
-				})
-			})
-			testutil.CloseOnCleanup(t, ts)
-
-			req, _ := http.NewRequest(http.MethodGet, ts.URL+"/admin/api/v1/authorization/admins/members", nil)
-			req.AddCookie(&http.Cookie{Name: "session_token", Value: "admin-session"})
-			resp, err := http.DefaultClient.Do(req)
-			if err != nil {
-				t.Fatalf("GET admin members: %v", err)
-			}
-			defer func() { _ = resp.Body.Close() }()
-			if resp.StatusCode != http.StatusOK {
-				body, _ := io.ReadAll(resp.Body)
-				t.Fatalf("admin members status = %d, want 200: %s", resp.StatusCode, body)
-			}
-
-			var members []map[string]any
-			if err := json.NewDecoder(resp.Body).Decode(&members); err != nil {
-				t.Fatalf("decoding admin members: %v", err)
-			}
-			if len(members) != 1 || members[0]["source"] != "static" {
-				t.Fatalf("admin members = %+v, want one static row", members)
-			}
-
-			body := bytes.NewBufferString(`{"email":"dynamic-admin@example.test","role":"owner"}`)
-			req, _ = http.NewRequest(http.MethodPut, ts.URL+"/admin/api/v1/authorization/admins/members", body)
-			req.Header.Set("Content-Type", "application/json")
-			req.AddCookie(&http.Cookie{Name: "session_token", Value: "admin-session"})
-			resp, err = http.DefaultClient.Do(req)
-			if err != nil {
-				t.Fatalf("PUT admin member: %v", err)
-			}
-			defer func() { _ = resp.Body.Close() }()
-			if resp.StatusCode != http.StatusOK {
-				respBody, _ := io.ReadAll(resp.Body)
-				t.Fatalf("put admin member status = %d, want 200: %s", resp.StatusCode, respBody)
-			}
-
-			req, _ = http.NewRequest(http.MethodGet, ts.URL+"/admin/api/v1/authorization/admins/members", nil)
-			req.AddCookie(&http.Cookie{Name: "session_token", Value: "admin-session"})
-			resp, err = http.DefaultClient.Do(req)
-			if err != nil {
-				t.Fatalf("GET admin members after put: %v", err)
-			}
-			defer func() { _ = resp.Body.Close() }()
-			if resp.StatusCode != http.StatusOK {
-				t.Fatalf("admin members after put status = %d, want 200", resp.StatusCode)
-			}
-			members = nil
-			if err := json.NewDecoder(resp.Body).Decode(&members); err != nil {
-				t.Fatalf("decoding admin members after put: %v", err)
-			}
-			if len(members) != 2 {
-				t.Fatalf("expected 2 merged admin members, got %d (%+v)", len(members), members)
-			}
-
-			body = bytes.NewBufferString(`{"email":"static-admin@example.test","role":"owner"}`)
-			req, _ = http.NewRequest(http.MethodPut, ts.URL+"/admin/api/v1/authorization/admins/members", body)
-			req.Header.Set("Content-Type", "application/json")
-			req.AddCookie(&http.Cookie{Name: "session_token", Value: "admin-session"})
-			resp, err = http.DefaultClient.Do(req)
-			if err != nil {
-				t.Fatalf("PUT static admin conflict: %v", err)
-			}
-			defer func() { _ = resp.Body.Close() }()
-			if resp.StatusCode != http.StatusConflict {
-				respBody, _ := io.ReadAll(resp.Body)
-				t.Fatalf("put static admin conflict status = %d, want 409: %s", resp.StatusCode, respBody)
-			}
-
-			user, err := svc.Users.FindUserByEmail(context.Background(), "dynamic-admin@example.test")
-			if err != nil {
-				t.Fatalf("find dynamic admin user: %v", err)
-			}
-			roles, err := svc.WorkspaceRoles.ListByPrincipal(ctx, user.ID)
-			if err != nil {
-				t.Fatalf("ListByPrincipal(dynamic admin): %v", err)
-			}
-			if len(roles) != 1 || roles[0].Role != "owner" {
-				t.Fatalf("workspace roles = %+v, want [owner]", roles)
-			}
-
-			body = bytes.NewBufferString(`{"email":"dynamic-admin@example.test","role":"operator"}`)
-			req, _ = http.NewRequest(http.MethodPut, ts.URL+"/admin/api/v1/authorization/admins/members", body)
-			req.Header.Set("Content-Type", "application/json")
-			req.AddCookie(&http.Cookie{Name: "session_token", Value: "admin-session"})
-			resp, err = http.DefaultClient.Do(req)
-			if err != nil {
-				t.Fatalf("PUT dynamic admin role change: %v", err)
-			}
-			defer func() { _ = resp.Body.Close() }()
-			if resp.StatusCode != http.StatusOK {
-				respBody, _ := io.ReadAll(resp.Body)
-				t.Fatalf("put dynamic admin role change status = %d, want 200: %s", resp.StatusCode, respBody)
-			}
-
-			roles, err = svc.WorkspaceRoles.ListByPrincipal(ctx, user.ID)
-			if err != nil {
-				t.Fatalf("ListByPrincipal(dynamic admin) after role change: %v", err)
-			}
-			if len(roles) != 1 || roles[0].Role != "operator" {
-				t.Fatalf("workspace roles after role change = %+v, want [operator]", roles)
-			}
-			req, _ = http.NewRequest(http.MethodDelete, ts.URL+"/admin/api/v1/authorization/admins/members/"+url.PathEscape(user.ID), nil)
-			req.AddCookie(&http.Cookie{Name: "session_token", Value: "admin-session"})
-			resp, err = http.DefaultClient.Do(req)
-			if err != nil {
-				t.Fatalf("DELETE admin member: %v", err)
-			}
-			defer func() { _ = resp.Body.Close() }()
-			if resp.StatusCode != http.StatusOK {
-				respBody, _ := io.ReadAll(resp.Body)
-				t.Fatalf("delete admin member status = %d, want 200: %s", resp.StatusCode, respBody)
-			}
-
-			req, _ = http.NewRequest(http.MethodGet, ts.URL+"/admin/api/v1/authorization/admins/members", nil)
-			req.AddCookie(&http.Cookie{Name: "session_token", Value: "admin-session"})
-			resp, err = http.DefaultClient.Do(req)
-			if err != nil {
-				t.Fatalf("GET admin members after delete: %v", err)
-			}
-			defer func() { _ = resp.Body.Close() }()
-			if resp.StatusCode != http.StatusOK {
-				t.Fatalf("admin members after delete status = %d, want 200", resp.StatusCode)
-			}
-			members = nil
-			if err := json.NewDecoder(resp.Body).Decode(&members); err != nil {
-				t.Fatalf("decoding admin members after delete: %v", err)
-			}
-			if len(members) != 1 || members[0]["source"] != "static" {
-				t.Fatalf("admin members after delete = %+v, want only static row", members)
-			}
-			roles, err = svc.WorkspaceRoles.ListByPrincipal(ctx, user.ID)
-			if err != nil {
-				t.Fatalf("ListByPrincipal(dynamic admin) after delete: %v", err)
-			}
-			if len(roles) != 0 {
-				t.Fatalf("workspace roles after delete = %+v, want none", roles)
-			}
+				return &core.UserIdentity{Email: "static-admin@example.test"}, nil
+			},
+		}
+		cfg.Services = svc
+		cfg.Authorizer = authz
+		cfg.AuthorizationProvider = provider
+		cfg.Admin = server.AdminRouteConfig{
+			AuthorizationPolicy: "admin_policy",
+			AllowedRoles:        []string{adminRole, "operator"},
+		}
+		cfg.AdminUI = http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+			_, _ = w.Write([]byte("admin"))
 		})
+	})
+	testutil.CloseOnCleanup(t, ts)
+
+	req, _ := http.NewRequest(http.MethodGet, ts.URL+"/admin/api/v1/authorization/admins/members", nil)
+	req.AddCookie(&http.Cookie{Name: "session_token", Value: "admin-session"})
+	resp, err := http.DefaultClient.Do(req)
+	if err != nil {
+		t.Fatalf("GET admin members: %v", err)
+	}
+	defer func() { _ = resp.Body.Close() }()
+	if resp.StatusCode != http.StatusOK {
+		body, _ := io.ReadAll(resp.Body)
+		t.Fatalf("admin members status = %d, want 200: %s", resp.StatusCode, body)
+	}
+
+	var members []map[string]any
+	if err := json.NewDecoder(resp.Body).Decode(&members); err != nil {
+		t.Fatalf("decoding admin members: %v", err)
+	}
+	if len(members) != 1 || members[0]["source"] != "static" {
+		t.Fatalf("admin members = %+v, want one static row", members)
+	}
+
+	body := bytes.NewBufferString(`{"email":"dynamic-admin@example.test","role":"owner"}`)
+	req, _ = http.NewRequest(http.MethodPut, ts.URL+"/admin/api/v1/authorization/admins/members", body)
+	req.Header.Set("Content-Type", "application/json")
+	req.AddCookie(&http.Cookie{Name: "session_token", Value: "admin-session"})
+	resp, err = http.DefaultClient.Do(req)
+	if err != nil {
+		t.Fatalf("PUT admin member: %v", err)
+	}
+	defer func() { _ = resp.Body.Close() }()
+	if resp.StatusCode != http.StatusOK {
+		respBody, _ := io.ReadAll(resp.Body)
+		t.Fatalf("put admin member status = %d, want 200: %s", resp.StatusCode, respBody)
+	}
+
+	req, _ = http.NewRequest(http.MethodGet, ts.URL+"/admin/api/v1/authorization/admins/members", nil)
+	req.AddCookie(&http.Cookie{Name: "session_token", Value: "admin-session"})
+	resp, err = http.DefaultClient.Do(req)
+	if err != nil {
+		t.Fatalf("GET admin members after put: %v", err)
+	}
+	defer func() { _ = resp.Body.Close() }()
+	if resp.StatusCode != http.StatusOK {
+		t.Fatalf("admin members after put status = %d, want 200", resp.StatusCode)
+	}
+	members = nil
+	if err := json.NewDecoder(resp.Body).Decode(&members); err != nil {
+		t.Fatalf("decoding admin members after put: %v", err)
+	}
+	if len(members) != 2 {
+		t.Fatalf("expected 2 merged admin members, got %d (%+v)", len(members), members)
+	}
+
+	body = bytes.NewBufferString(`{"email":"static-admin@example.test","role":"owner"}`)
+	req, _ = http.NewRequest(http.MethodPut, ts.URL+"/admin/api/v1/authorization/admins/members", body)
+	req.Header.Set("Content-Type", "application/json")
+	req.AddCookie(&http.Cookie{Name: "session_token", Value: "admin-session"})
+	resp, err = http.DefaultClient.Do(req)
+	if err != nil {
+		t.Fatalf("PUT static admin conflict: %v", err)
+	}
+	defer func() { _ = resp.Body.Close() }()
+	if resp.StatusCode != http.StatusConflict {
+		respBody, _ := io.ReadAll(resp.Body)
+		t.Fatalf("put static admin conflict status = %d, want 409: %s", resp.StatusCode, respBody)
+	}
+
+	user, err := svc.Users.FindUserByEmail(context.Background(), "dynamic-admin@example.test")
+	if err != nil {
+		t.Fatalf("find dynamic admin user: %v", err)
+	}
+	roles, err := svc.WorkspaceRoles.ListByPrincipal(ctx, user.ID)
+	if err != nil {
+		t.Fatalf("ListByPrincipal(dynamic admin): %v", err)
+	}
+	if len(roles) != 1 || roles[0].Role != "owner" {
+		t.Fatalf("workspace roles = %+v, want [owner]", roles)
+	}
+
+	body = bytes.NewBufferString(`{"email":"dynamic-admin@example.test","role":"operator"}`)
+	req, _ = http.NewRequest(http.MethodPut, ts.URL+"/admin/api/v1/authorization/admins/members", body)
+	req.Header.Set("Content-Type", "application/json")
+	req.AddCookie(&http.Cookie{Name: "session_token", Value: "admin-session"})
+	resp, err = http.DefaultClient.Do(req)
+	if err != nil {
+		t.Fatalf("PUT dynamic admin role change: %v", err)
+	}
+	defer func() { _ = resp.Body.Close() }()
+	if resp.StatusCode != http.StatusOK {
+		respBody, _ := io.ReadAll(resp.Body)
+		t.Fatalf("put dynamic admin role change status = %d, want 200: %s", resp.StatusCode, respBody)
+	}
+
+	roles, err = svc.WorkspaceRoles.ListByPrincipal(ctx, user.ID)
+	if err != nil {
+		t.Fatalf("ListByPrincipal(dynamic admin) after role change: %v", err)
+	}
+	if len(roles) != 1 || roles[0].Role != "operator" {
+		t.Fatalf("workspace roles after role change = %+v, want [operator]", roles)
+	}
+	req, _ = http.NewRequest(http.MethodDelete, ts.URL+"/admin/api/v1/authorization/admins/members/"+url.PathEscape(user.ID), nil)
+	req.AddCookie(&http.Cookie{Name: "session_token", Value: "admin-session"})
+	resp, err = http.DefaultClient.Do(req)
+	if err != nil {
+		t.Fatalf("DELETE admin member: %v", err)
+	}
+	defer func() { _ = resp.Body.Close() }()
+	if resp.StatusCode != http.StatusOK {
+		respBody, _ := io.ReadAll(resp.Body)
+		t.Fatalf("delete admin member status = %d, want 200: %s", resp.StatusCode, respBody)
+	}
+
+	req, _ = http.NewRequest(http.MethodGet, ts.URL+"/admin/api/v1/authorization/admins/members", nil)
+	req.AddCookie(&http.Cookie{Name: "session_token", Value: "admin-session"})
+	resp, err = http.DefaultClient.Do(req)
+	if err != nil {
+		t.Fatalf("GET admin members after delete: %v", err)
+	}
+	defer func() { _ = resp.Body.Close() }()
+	if resp.StatusCode != http.StatusOK {
+		t.Fatalf("admin members after delete status = %d, want 200", resp.StatusCode)
+	}
+	members = nil
+	if err := json.NewDecoder(resp.Body).Decode(&members); err != nil {
+		t.Fatalf("decoding admin members after delete: %v", err)
+	}
+	if len(members) != 1 || members[0]["source"] != "static" {
+		t.Fatalf("admin members after delete = %+v, want only static row", members)
+	}
+	roles, err = svc.WorkspaceRoles.ListByPrincipal(ctx, user.ID)
+	if err != nil {
+		t.Fatalf("ListByPrincipal(dynamic admin) after delete: %v", err)
+	}
+	if len(roles) != 0 {
+		t.Fatalf("workspace roles after delete = %+v, want none", roles)
 	}
 }
 
@@ -3356,7 +3307,6 @@ func TestAdminAPI_PluginAuthorizationUnavailable(t *testing.T) {
 	t.Parallel()
 
 	svc := coretesting.NewStubServices(t)
-	svc.PluginAuthorizations = nil
 	authz, err := authorization.New(config.AuthorizationConfig{
 		Policies: map[string]config.HumanPolicyDef{
 			"sample_policy": {
@@ -3372,6 +3322,7 @@ func TestAdminAPI_PluginAuthorizationUnavailable(t *testing.T) {
 	if err != nil {
 		t.Fatalf("authorization.New: %v", err)
 	}
+	dynamicUser := seedPluginAuthorization(t, svc, nil, "sample_plugin", "dynamic@example.test", "viewer")
 
 	ts := newTestServer(t, func(cfg *server.Config) {
 		cfg.Auth = &coretesting.StubAuthProvider{
@@ -3398,20 +3349,119 @@ func TestAdminAPI_PluginAuthorizationUnavailable(t *testing.T) {
 	})
 	testutil.CloseOnCleanup(t, ts)
 
-	req, _ := http.NewRequest(http.MethodGet, ts.URL+"/admin/api/v1/authorization/plugins/sample_plugin/members", nil)
-	req.AddCookie(&http.Cookie{Name: "session_token", Value: "admin-session"})
-	resp, err := http.DefaultClient.Do(req)
-	if err != nil {
-		t.Fatalf("GET members: %v", err)
-	}
-	defer func() { _ = resp.Body.Close() }()
-	if resp.StatusCode != http.StatusServiceUnavailable {
-		t.Fatalf("members status = %d, want 503", resp.StatusCode)
+	for _, tc := range []struct {
+		name   string
+		method string
+		path   string
+		body   string
+	}{
+		{name: "list", method: http.MethodGet, path: "/admin/api/v1/authorization/plugins/sample_plugin/members"},
+		{name: "put", method: http.MethodPut, path: "/admin/api/v1/authorization/plugins/sample_plugin/members", body: `{"email":"new-dynamic@example.test","role":"viewer"}`},
+		{name: "delete", method: http.MethodDelete, path: "/admin/api/v1/authorization/plugins/sample_plugin/members/" + url.PathEscape(dynamicUser.ID)},
+	} {
+		reqBody := io.Reader(nil)
+		if tc.body != "" {
+			reqBody = strings.NewReader(tc.body)
+		}
+		req, _ := http.NewRequest(tc.method, ts.URL+tc.path, reqBody)
+		if tc.body != "" {
+			req.Header.Set("Content-Type", "application/json")
+		}
+		req.AddCookie(&http.Cookie{Name: "session_token", Value: "admin-session"})
+		resp, err := http.DefaultClient.Do(req)
+		if err != nil {
+			t.Fatalf("%s members: %v", tc.name, err)
+		}
+		defer func() { _ = resp.Body.Close() }()
+		if resp.StatusCode != http.StatusServiceUnavailable {
+			body, _ := io.ReadAll(resp.Body)
+			t.Fatalf("%s members status = %d, want 503: %s", tc.name, resp.StatusCode, body)
+		}
 	}
 }
 
 func TestAdminAPI_AdminAuthorizationUnavailable(t *testing.T) {
 	t.Parallel()
+
+	t.Run("authorization provider missing", func(t *testing.T) {
+		t.Parallel()
+
+		svc := coretesting.NewStubServices(t)
+		seedUser(t, svc, "admin@example.test")
+		authz := mustAuthorizer(t, config.AuthorizationConfig{
+			Policies: map[string]config.HumanPolicyDef{
+				"admin_policy": {
+					Default: "deny",
+					Members: []config.HumanPolicyMemberDef{
+						{Email: "admin@example.test", Role: "admin"},
+					},
+				},
+			},
+		}, nil, nil, nil)
+		user, err := svc.Users.FindOrCreateUser(context.Background(), "dynamic-admin@example.test")
+		if err != nil {
+			t.Fatalf("FindOrCreateUser dynamic admin: %v", err)
+		}
+		if _, err := svc.AdminAuthorizations.UpsertAdminAuthorization(context.Background(), &coredata.AdminAuthorizationMembership{
+			UserID: user.ID,
+			Email:  user.Email,
+			Role:   "operator",
+		}); err != nil {
+			t.Fatalf("UpsertAdminAuthorization: %v", err)
+		}
+
+		ts := newTestServer(t, func(cfg *server.Config) {
+			cfg.Auth = &coretesting.StubAuthProvider{
+				N: "test",
+				ValidateTokenFn: func(_ context.Context, token string) (*core.UserIdentity, error) {
+					if token != "admin-session" {
+						return nil, fmt.Errorf("invalid token")
+					}
+					return &core.UserIdentity{Email: "admin@example.test"}, nil
+				},
+			}
+			cfg.Services = svc
+			cfg.Authorizer = authz
+			cfg.Admin = server.AdminRouteConfig{
+				AuthorizationPolicy: "admin_policy",
+				AllowedRoles:        []string{"admin"},
+			}
+			cfg.AdminUI = http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+				_, _ = w.Write([]byte("admin"))
+			})
+		})
+		testutil.CloseOnCleanup(t, ts)
+
+		for _, tc := range []struct {
+			name   string
+			method string
+			path   string
+			body   string
+		}{
+			{name: "list", method: http.MethodGet, path: "/admin/api/v1/authorization/admins/members"},
+			{name: "put", method: http.MethodPut, path: "/admin/api/v1/authorization/admins/members", body: `{"email":"another-admin@example.test","role":"operator"}`},
+			{name: "delete", method: http.MethodDelete, path: "/admin/api/v1/authorization/admins/members/" + url.PathEscape(user.ID)},
+		} {
+			reqBody := io.Reader(nil)
+			if tc.body != "" {
+				reqBody = strings.NewReader(tc.body)
+			}
+			req, _ := http.NewRequest(tc.method, ts.URL+tc.path, reqBody)
+			if tc.body != "" {
+				req.Header.Set("Content-Type", "application/json")
+			}
+			req.AddCookie(&http.Cookie{Name: "session_token", Value: "admin-session"})
+			resp, err := http.DefaultClient.Do(req)
+			if err != nil {
+				t.Fatalf("%s admin members without authorization provider: %v", tc.name, err)
+			}
+			defer func() { _ = resp.Body.Close() }()
+			if resp.StatusCode != http.StatusServiceUnavailable {
+				body, _ := io.ReadAll(resp.Body)
+				t.Fatalf("%s status = %d, want 503: %s", tc.name, resp.StatusCode, body)
+			}
+		}
+	})
 
 	t.Run("admin policy unset", func(t *testing.T) {
 		t.Parallel()


### PR DESCRIPTION
## Summary

This PR makes dynamic human plugin/admin authorization provider-only at runtime.

- `Bootstrap` and `Validate` now only wire legacy dynamic human stores into the in-process authorizer when an authorization provider is selected.
- Built-in admin plugin/admin membership list/write/delete routes now require `cfg.AuthorizationProvider` instead of falling back to legacy membership services.
- Server runtime no longer carries legacy plugin/admin membership services for those admin routes.
- Existing tests were folded toward the provider-backed path rather than keeping separate legacy CRUD branches.

## Go Interface

```go
type AuthorizationProvider interface {
	Name() string

	Evaluate(ctx context.Context, req *AccessEvaluationRequest) (*AccessDecision, error)
	EvaluateMany(ctx context.Context, req *AccessEvaluationsRequest) (*AccessEvaluationsResponse, error)
	SearchResources(ctx context.Context, req *ResourceSearchRequest) (*ResourceSearchResponse, error)
	SearchSubjects(ctx context.Context, req *SubjectSearchRequest) (*SubjectSearchResponse, error)
	SearchActions(ctx context.Context, req *ActionSearchRequest) (*ActionSearchResponse, error)
	GetMetadata(ctx context.Context) (*AuthorizationMetadata, error)
	ReadRelationships(ctx context.Context, req *ReadRelationshipsRequest) (*ReadRelationshipsResponse, error)
	WriteRelationships(ctx context.Context, req *WriteRelationshipsRequest) error
	GetActiveModel(ctx context.Context) (*GetActiveModelResponse, error)
	ListModels(ctx context.Context, req *ListModelsRequest) (*ListModelsResponse, error)
	WriteModel(ctx context.Context, req *WriteModelRequest) (*AuthorizationModelRef, error)
}
```

## YAML Usage

```yaml
providers:
  authorization:
    indexeddb:
      source:
        ref: github.com/valon-technologies/gestalt-providers/authorization/indexeddb
        version: v0.0.1-alpha.2
      config:
        indexeddb: default

server:
  providers:
    authorization: indexeddb
```

## Behavior

With `server.providers.authorization: indexeddb`:

- `GET/PUT/DELETE /admin/api/v1/authorization/plugins/{plugin}/members`
- `GET/PUT/DELETE /admin/api/v1/authorization/admins/members`

continue to work through provider-backed reads/writes.

Without an authorization provider:

- static policy checks still work
- dynamic human plugin/admin membership APIs now return `503`
- no-provider runtime bootstrap no longer ingests legacy human grants into the in-process authorizer

## Tests

Reused and augmented existing coverage instead of adding a new standalone suite:

- `go test ./internal/bootstrap ./internal/server ./internal/authorization ./internal/invocation ./internal/mcp`
- `golangci-lint run ./internal/bootstrap ./internal/server ./internal/authorization`
