### PR TITLE
docs: add workflow and authorization provider docs

### DIFF
--- a/docs/content/configuration.mdx
+++ b/docs/content/configuration.mdx
@@ -45,6 +45,8 @@ providers:
     <name>: ...             # each is a ProviderEntry
   authorization:            # named authorization providers
     <name>: ...             # each is a ProviderEntry
+  workflow:                 # named workflow providers
+    <name>: ...             # each is a ProviderEntry
   cache:                    # named cache providers
     <name>: ...             # each is a ProviderEntry
   s3:                       # named S3 object-store providers
@@ -57,15 +59,16 @@ ProviderEntry-backed entries accept `source` (where to load it from), `config` (
 
 ## Key concepts
 
-Gestalt has seven core concepts you configure in YAML:
+Gestalt has nine core concepts you configure in YAML:
 
 - **[Plugin.](/providers/plugins)** A tool backed by a provider package. Plugins expose operations that agents and users invoke over HTTP, MCP, or the CLI. Plugins can come from published packages or local source.
 - **Connection.** How Gestalt authenticates to an upstream API on behalf of a user or service. Connections handle OAuth flows, API keys, and manual credentials.
 - **[IndexedDB.](/providers/indexeddb)** The persistent storage layer. Stores users, sessions, tokens, and credentials through a provider that implements the IndexedDB interface.
-- **Authorization provider.** Optional host-scoped policy storage and decision engine for shared human authorization state. The first-party `authorization/indexeddb` provider persists models and relationships in the selected host IndexedDB provider.
+- **[Authorization.](/providers/authorization)** Optional host-scoped policy storage and decision engine for dynamic human authorization state. The first-party `authorization/indexeddb` provider persists models and relationships in the selected host IndexedDB provider.
 - **[S3.](/providers/s3)** Plugin-bound object storage. The provider config chooses the backend, credentials, and endpoint; plugin code chooses buckets, keys, and versions at runtime.
 - **[Auth.](/providers/auth)** Platform login for the Gestalt server. Separate from connection auth, which is per-plugin and per-upstream.
 - **[Secrets.](/providers/secrets)** Resolves structured secret refs in the config at startup. Backed by environment variables, files, or cloud secret managers.
+- **[Workflow.](/providers/workflow)** Plugin-scoped workflow runs, schedules, and event triggers backed by a workflow provider and optional host IndexedDB storage.
 - **[UI.](/providers/web-uis)** Public static UI bundles served under configured path prefixes, either directly from `providers.ui` or through `plugins.<name>.mountPath`. Omit `providers.ui` to run headless.
 
 ## Adding a plugin
@@ -353,7 +356,9 @@ SQLite works for single-instance deployments. For production, use a networked In
 
 ## Configuring authorization storage
 
-The `providers.authorization` block is optional. When configured, `server.providers.authorization` selects the host authorization provider Gestalt uses for human authorization relationships and model storage:
+The `providers.authorization` block is optional. When configured,
+`server.providers.authorization` selects the host authorization provider
+Gestalt uses for dynamic human authorization relationships and model storage:
 
 ```yaml
 server:
@@ -379,7 +384,53 @@ providers:
         indexeddb: main
 ```
 
-If `providers.authorization` is omitted, Gestalt keeps using its in-process authorization engine only. When it is present, Gestalt seeds the provider from configured static policy members and dynamic admin/plugin grants, then uses that provider for human authorization checks and the built-in admin authorization inspection APIs.
+If `providers.authorization` is omitted, static policy members from config still
+work, but there is no provider-backed relationship store and the dynamic human
+authorization control plane is unavailable. When it is present, Gestalt uses
+that provider for dynamic human authorization, human authorization checks, and
+the built-in admin authorization APIs.
+
+## Configuring workflow providers
+
+The `providers.workflow` block declares workflow backends. Plugins opt in under
+`plugins.<name>.workflow`. If a plugin omits `workflow.provider`, Gestalt uses
+the sole/default workflow provider.
+
+```yaml
+providers:
+  indexeddb:
+    workflow_state:
+      source: https://artifacts.example.com/indexeddb/relationaldb/v0.0.1-alpha.1/provider-release.yaml
+      config:
+        dsn: sqlite://./gestalt.db
+
+  workflow:
+    local:
+      source: https://artifacts.example.com/workflow/indexeddb/v0.0.1-alpha.1/provider-release.yaml
+      indexeddb:
+        provider: workflow_state
+        db: workflow
+      config:
+        pollInterval: 1s
+
+plugins:
+  roadmap:
+    workflow:
+      provider: local
+      operations:
+        - sync_items
+      schedules:
+        nightly_sync:
+          cron: "0 3 * * *"
+          timezone: America/New_York
+          operation: sync_items
+```
+
+`workflow.operations` is the allowlist of plugin operations the workflow
+provider may invoke for that plugin. `workflow.schedules` and
+`workflow.eventTriggers` declare config-owned schedules and event triggers that
+Gestalt reconciles into the provider at startup. See
+[Workflow](/providers/workflow) for the full provider model.
 
 ## Telemetry and audit
 

--- a/docs/content/custom-providers/_meta.ts
+++ b/docs/content/custom-providers/_meta.ts
@@ -1,10 +1,12 @@
 export default {
   plugins: "Plugins",
   auth: "Auth",
+  authorization: "Authorization",
   cache: "Cache",
   indexeddb: "IndexedDB",
   s3: "S3",
   secrets: "Secrets",
+  workflow: "Workflow",
   "web-uis": "Web UIs",
   releasing: "Releasing",
 };

--- a/docs/content/custom-providers/authorization.mdx
+++ b/docs/content/custom-providers/authorization.mdx
@@ -1,0 +1,174 @@
+# Authorization
+
+This page covers building custom authorization providers. If you only need to
+configure authorization storage for a deployment, use
+[Providers > Authorization](/providers/authorization).
+
+Authorization providers are host-scoped policy engines and relationship
+stores. Gestalt uses them for dynamic human authorization, built-in admin
+authorization APIs, and authorization model lifecycle.
+
+## Manifest
+
+An authorization provider manifest declares `kind: authorization`:
+
+```yaml
+kind: authorization
+source: github.com/your-org/authorization/example
+version: 0.0.1
+displayName: Example Authorization
+description: Authorization provider with custom model and relationship storage.
+spec:
+  configSchemaPath: ./authorization_config.json
+```
+
+## Provider interface
+
+Authorization provider authoring is currently exposed through the Go SDK.
+
+The contract has three parts:
+
+| Area | Methods |
+| --- | --- |
+| Decision plane | `Evaluate`, `EvaluateMany`, `SearchResources`, `SearchSubjects`, `SearchActions`, `GetMetadata` |
+| Relationship control plane | `ReadRelationships`, `WriteRelationships` |
+| Model lifecycle | `GetActiveModel`, `ListModels`, `WriteModel` |
+
+The example below shows the shape of a minimal in-memory provider. The
+remaining methods follow the same request/response pattern.
+
+```go
+package exampleauthz
+
+import (
+	"context"
+	"fmt"
+
+	gestalt "github.com/valon-technologies/gestalt/sdk/go"
+)
+
+type Provider struct {
+	modelID string
+}
+
+func New() *Provider { return &Provider{} }
+
+func (p *Provider) Configure(_ context.Context, _ string, config map[string]any) error {
+	p.modelID, _ = config["modelId"].(string)
+	return nil
+}
+
+func (p *Provider) Evaluate(_ context.Context, req *gestalt.AccessEvaluationRequest) (*gestalt.AccessDecision, error) {
+	allowed := req.GetAction().GetName() == "read"
+	return &gestalt.AccessDecision{
+		Allowed: allowed,
+		ModelId: p.modelID,
+	}, nil
+}
+
+func (p *Provider) EvaluateMany(ctx context.Context, req *gestalt.AccessEvaluationsRequest) (*gestalt.AccessEvaluationsResponse, error) {
+	decisions := make([]*gestalt.AccessDecision, 0, len(req.GetRequests()))
+	for _, item := range req.GetRequests() {
+		decision, err := p.Evaluate(ctx, item)
+		if err != nil {
+			return nil, err
+		}
+		decisions = append(decisions, decision)
+	}
+	return &gestalt.AccessEvaluationsResponse{Decisions: decisions}, nil
+}
+
+func (p *Provider) SearchResources(context.Context, *gestalt.ResourceSearchRequest) (*gestalt.ResourceSearchResponse, error) {
+	return &gestalt.ResourceSearchResponse{ModelId: p.modelID}, nil
+}
+
+func (p *Provider) SearchSubjects(context.Context, *gestalt.SubjectSearchRequest) (*gestalt.SubjectSearchResponse, error) {
+	return &gestalt.SubjectSearchResponse{ModelId: p.modelID}, nil
+}
+
+func (p *Provider) SearchActions(context.Context, *gestalt.ActionSearchRequest) (*gestalt.ActionSearchResponse, error) {
+	return &gestalt.ActionSearchResponse{ModelId: p.modelID}, nil
+}
+
+func (p *Provider) GetMetadata(context.Context) (*gestalt.AuthorizationMetadata, error) {
+	return &gestalt.AuthorizationMetadata{
+		Capabilities:  []string{"evaluate", "relationships", "models"},
+		ActiveModelId: p.modelID,
+	}, nil
+}
+
+func (p *Provider) ReadRelationships(context.Context, *gestalt.ReadRelationshipsRequest) (*gestalt.ReadRelationshipsResponse, error) {
+	return &gestalt.ReadRelationshipsResponse{ModelId: p.modelID}, nil
+}
+
+func (p *Provider) WriteRelationships(context.Context, *gestalt.WriteRelationshipsRequest) error {
+	return nil
+}
+
+func (p *Provider) GetActiveModel(context.Context) (*gestalt.GetActiveModelResponse, error) {
+	if p.modelID == "" {
+		return &gestalt.GetActiveModelResponse{}, nil
+	}
+	return &gestalt.GetActiveModelResponse{
+		Model: &gestalt.AuthorizationModelRef{Id: p.modelID, Version: "v1"},
+	}, nil
+}
+
+func (p *Provider) ListModels(context.Context, *gestalt.ListModelsRequest) (*gestalt.ListModelsResponse, error) {
+	if p.modelID == "" {
+		return &gestalt.ListModelsResponse{}, nil
+	}
+	return &gestalt.ListModelsResponse{
+		Models: []*gestalt.AuthorizationModelRef{{Id: p.modelID, Version: "v1"}},
+	}, nil
+}
+
+func (p *Provider) WriteModel(_ context.Context, req *gestalt.WriteModelRequest) (*gestalt.AuthorizationModelRef, error) {
+	if req.GetModel() == nil {
+		return nil, fmt.Errorf("model is required")
+	}
+	p.modelID = "example-model"
+	return &gestalt.AuthorizationModelRef{Id: p.modelID, Version: "v1"}, nil
+}
+
+func main() {
+	if err := gestalt.ServeAuthorizationProvider(context.Background(), New()); err != nil {
+		panic(err)
+	}
+}
+```
+
+## Config reference
+
+To use a custom authorization provider in a deployment, reference it as a named
+entry in `providers.authorization`:
+
+```yaml
+server:
+  providers:
+    indexeddb: main
+    authorization: example
+
+providers:
+  indexeddb:
+    main:
+      source: https://artifacts.example.com/indexeddb/relationaldb/v0.0.1-alpha.1/provider-release.yaml
+      config:
+        dsn: ${DATABASE_URL}
+
+  authorization:
+    example:
+      source: ./authorization/manifest.yaml
+      config:
+        modelId: default
+```
+
+Use `source: ./manifest.yaml` during development. For production, publish a
+release and point `source` at the resulting `provider-release.yaml` metadata
+URL.
+
+## What to read next
+
+- [Providers > Authorization](/providers/authorization): configuring host authorization providers
+- [Releasing](/custom-providers/releasing): packaging and publishing provider releases
+- [Built-in Providers](/reference/built-in-providers): first-party authorization provider reference

--- a/docs/content/custom-providers/index.mdx
+++ b/docs/content/custom-providers/index.mdx
@@ -11,7 +11,8 @@ deployment, start with [Providers](/providers).
 ## What belongs here
 
 - Implementing executable or declarative plugin providers
-- Building custom auth, cache, IndexedDB, S3, secrets, and web UI providers
+- Building custom auth, authorization, cache, IndexedDB, S3, secrets,
+  workflow, and web UI providers
 - Testing providers from local source with `source: ./manifest.yaml`
 - Packaging releases with `gestaltd provider release`
 
@@ -36,6 +37,8 @@ providers:
   operations, declarative surfaces, and hybrid catalogs
 - [Auth](/custom-providers/auth): platform login providers and optional bearer
   token validation
+- [Authorization](/custom-providers/authorization): human authorization
+  decision and control-plane providers
 - [Cache](/custom-providers/cache): plugin-bound cache backends
 - [IndexedDB](/custom-providers/indexeddb): custom storage backends for system
   state
@@ -44,6 +47,8 @@ providers:
 - [Secrets](/custom-providers/secrets): secret managers for structured secret
   refs
   resolution
+- [Workflow](/custom-providers/workflow): workflow run, schedule, and
+  event-trigger providers
 - [Web UIs](/custom-providers/web-uis): public UI bundles served under
   configured path prefixes
 - [Releasing](/custom-providers/releasing): packaging, platform builds, and

--- a/docs/content/custom-providers/workflow.mdx
+++ b/docs/content/custom-providers/workflow.mdx
@@ -1,0 +1,487 @@
+import { Tabs } from 'nextra/components'
+
+# Workflow
+
+This page covers building custom workflow providers. If you only need to
+configure workflow storage for a deployment, use
+[Providers > Workflow](/providers/workflow).
+
+Workflow providers back plugin-scoped workflow runs, schedules, and event
+triggers. Gestalt uses them to persist workflow state and to call back into
+allowed plugin operations through the workflow host socket.
+
+## Manifest
+
+A workflow provider manifest declares `kind: workflow`:
+
+```yaml
+kind: workflow
+source: github.com/your-org/workflow/example
+version: 0.0.1
+displayName: Example Workflow
+description: Workflow provider with custom run and schedule storage.
+spec:
+  configSchemaPath: ./workflow_config.json
+```
+
+## Provider interface
+
+The workflow service includes:
+
+| Method | Purpose |
+| --- | --- |
+| `StartRun` / `GetRun` / `ListRuns` / `CancelRun` | Manage workflow runs |
+| `UpsertSchedule` / `GetSchedule` / `ListSchedules` / `DeleteSchedule` / `PauseSchedule` / `ResumeSchedule` | Manage schedules |
+| `UpsertEventTrigger` / `GetEventTrigger` / `ListEventTriggers` / `DeleteEventTrigger` / `PauseEventTrigger` / `ResumeEventTrigger` | Manage event triggers |
+| `PublishEvent` | Deliver an event into the provider |
+
+The examples below show the core methods. The remaining methods follow the same
+request/response shape.
+
+<Tabs items={['Go', 'Python', 'Rust', 'TypeScript']}>
+  <Tabs.Tab>
+    ```go
+    package exampleworkflow
+
+    import (
+    	"context"
+
+    	gestalt "github.com/valon-technologies/gestalt/sdk/go"
+    	proto "github.com/valon-technologies/gestalt/sdk/go/gen/v1"
+    )
+
+    type Provider struct{}
+
+    func New() *Provider { return &Provider{} }
+
+    func (p *Provider) Configure(_ context.Context, _ string, config map[string]any) error {
+    	return nil
+    }
+
+    func (p *Provider) StartRun(_ context.Context, req *proto.StartWorkflowProviderRunRequest) (*proto.BoundWorkflowRun, error) {
+    	return &proto.BoundWorkflowRun{
+    		Id:     req.GetTarget().GetPluginName() + ":run-1",
+    		Status: proto.WorkflowRunStatus_WORKFLOW_RUN_STATUS_PENDING,
+    		Target: req.GetTarget(),
+    	}, nil
+    }
+
+    func (p *Provider) GetRun(_ context.Context, req *proto.GetWorkflowProviderRunRequest) (*proto.BoundWorkflowRun, error) {
+    	return &proto.BoundWorkflowRun{
+    		Id: req.GetRunId(),
+    		Target: &proto.BoundWorkflowTarget{
+    			PluginName: req.GetPluginName(),
+    		},
+    	}, nil
+    }
+
+    func (p *Provider) ListRuns(context.Context, *proto.ListWorkflowProviderRunsRequest) (*proto.ListWorkflowProviderRunsResponse, error) {
+    	return &proto.ListWorkflowProviderRunsResponse{}, nil
+    }
+
+    func (p *Provider) CancelRun(_ context.Context, req *proto.CancelWorkflowProviderRunRequest) (*proto.BoundWorkflowRun, error) {
+    	return &proto.BoundWorkflowRun{
+    		Id:     req.GetRunId(),
+    		Status: proto.WorkflowRunStatus_WORKFLOW_RUN_STATUS_CANCELED,
+    	}, nil
+    }
+
+    func (p *Provider) UpsertSchedule(_ context.Context, req *proto.UpsertWorkflowProviderScheduleRequest) (*proto.BoundWorkflowSchedule, error) {
+    	return &proto.BoundWorkflowSchedule{
+    		Id:     req.GetScheduleId(),
+    		Cron:   req.GetCron(),
+    		Target: req.GetTarget(),
+    		Paused: req.GetPaused(),
+    	}, nil
+    }
+
+    func (p *Provider) GetSchedule(_ context.Context, req *proto.GetWorkflowProviderScheduleRequest) (*proto.BoundWorkflowSchedule, error) {
+    	return &proto.BoundWorkflowSchedule{Id: req.GetScheduleId()}, nil
+    }
+
+    func (p *Provider) ListSchedules(context.Context, *proto.ListWorkflowProviderSchedulesRequest) (*proto.ListWorkflowProviderSchedulesResponse, error) {
+    	return &proto.ListWorkflowProviderSchedulesResponse{}, nil
+    }
+
+    func (p *Provider) DeleteSchedule(context.Context, *proto.DeleteWorkflowProviderScheduleRequest) error {
+    	return nil
+    }
+
+    func (p *Provider) PauseSchedule(_ context.Context, req *proto.PauseWorkflowProviderScheduleRequest) (*proto.BoundWorkflowSchedule, error) {
+    	return &proto.BoundWorkflowSchedule{Id: req.GetScheduleId(), Paused: true}, nil
+    }
+
+    func (p *Provider) ResumeSchedule(_ context.Context, req *proto.ResumeWorkflowProviderScheduleRequest) (*proto.BoundWorkflowSchedule, error) {
+    	return &proto.BoundWorkflowSchedule{Id: req.GetScheduleId(), Paused: false}, nil
+    }
+
+    func (p *Provider) UpsertEventTrigger(_ context.Context, req *proto.UpsertWorkflowProviderEventTriggerRequest) (*proto.BoundWorkflowEventTrigger, error) {
+    	return &proto.BoundWorkflowEventTrigger{
+    		Id:     req.GetTriggerId(),
+    		Match:  req.GetMatch(),
+    		Target: req.GetTarget(),
+    		Paused: req.GetPaused(),
+    	}, nil
+    }
+
+    func (p *Provider) GetEventTrigger(_ context.Context, req *proto.GetWorkflowProviderEventTriggerRequest) (*proto.BoundWorkflowEventTrigger, error) {
+    	return &proto.BoundWorkflowEventTrigger{Id: req.GetTriggerId()}, nil
+    }
+
+    func (p *Provider) ListEventTriggers(context.Context, *proto.ListWorkflowProviderEventTriggersRequest) (*proto.ListWorkflowProviderEventTriggersResponse, error) {
+    	return &proto.ListWorkflowProviderEventTriggersResponse{}, nil
+    }
+
+    func (p *Provider) DeleteEventTrigger(context.Context, *proto.DeleteWorkflowProviderEventTriggerRequest) error {
+    	return nil
+    }
+
+    func (p *Provider) PauseEventTrigger(_ context.Context, req *proto.PauseWorkflowProviderEventTriggerRequest) (*proto.BoundWorkflowEventTrigger, error) {
+    	return &proto.BoundWorkflowEventTrigger{Id: req.GetTriggerId(), Paused: true}, nil
+    }
+
+    func (p *Provider) ResumeEventTrigger(_ context.Context, req *proto.ResumeWorkflowProviderEventTriggerRequest) (*proto.BoundWorkflowEventTrigger, error) {
+    	return &proto.BoundWorkflowEventTrigger{Id: req.GetTriggerId(), Paused: false}, nil
+    }
+
+    func (p *Provider) PublishEvent(context.Context, *proto.PublishWorkflowProviderEventRequest) error {
+    	return nil
+    }
+
+    func main() {
+    	if err := gestalt.ServeWorkflowProvider(context.Background(), New()); err != nil {
+    		panic(err)
+    	}
+    }
+    ```
+  </Tabs.Tab>
+  <Tabs.Tab>
+    ```python
+    import gestalt
+
+    class ExampleWorkflow(gestalt.WorkflowProvider):
+        def configure(self, name: str, config: dict) -> None:
+            pass
+
+        def StartRun(self, request, context):
+            return gestalt.pb.BoundWorkflowRun(
+                id=f"{request.target.plugin_name}:run-1",
+                status=gestalt.pb.WORKFLOW_RUN_STATUS_PENDING,
+                target=request.target,
+            )
+
+        def GetRun(self, request, context):
+            return gestalt.pb.BoundWorkflowRun(id=request.run_id)
+
+        def ListRuns(self, request, context):
+            return gestalt.pb.ListWorkflowProviderRunsResponse(runs=[])
+
+        def CancelRun(self, request, context):
+            return gestalt.pb.BoundWorkflowRun(
+                id=request.run_id,
+                status=gestalt.pb.WORKFLOW_RUN_STATUS_CANCELED,
+            )
+
+        def UpsertSchedule(self, request, context):
+            return gestalt.pb.BoundWorkflowSchedule(
+                id=request.schedule_id,
+                cron=request.cron,
+                target=request.target,
+                paused=request.paused,
+            )
+
+        def PublishEvent(self, request, context):
+            return gestalt.pb.google_dot_protobuf_dot_empty__pb2.Empty()
+    ```
+  </Tabs.Tab>
+  <Tabs.Tab>
+    ```rust
+    use tonic::{Request, Response, Status};
+
+    use gestalt::generated::v1 as proto;
+
+    #[derive(Default)]
+    struct ExampleWorkflow;
+
+    #[gestalt::async_trait]
+    impl gestalt::WorkflowProvider for ExampleWorkflow {
+        async fn start_run(
+            &self,
+            request: Request<proto::StartWorkflowProviderRunRequest>,
+        ) -> Result<Response<proto::BoundWorkflowRun>, Status> {
+            let req = request.into_inner();
+            Ok(Response::new(proto::BoundWorkflowRun {
+                id: format!("{}:run-1", req.plugin_name),
+                status: proto::WorkflowRunStatus::Pending as i32,
+                target: req.target,
+                ..Default::default()
+            }))
+        }
+
+        async fn get_run(
+            &self,
+            request: Request<proto::GetWorkflowProviderRunRequest>,
+        ) -> Result<Response<proto::BoundWorkflowRun>, Status> {
+            let req = request.into_inner();
+            Ok(Response::new(proto::BoundWorkflowRun {
+                id: req.run_id,
+                ..Default::default()
+            }))
+        }
+
+        async fn list_runs(
+            &self,
+            _request: Request<proto::ListWorkflowProviderRunsRequest>,
+        ) -> Result<Response<proto::ListWorkflowProviderRunsResponse>, Status> {
+            Ok(Response::new(proto::ListWorkflowProviderRunsResponse { runs: vec![] }))
+        }
+
+        async fn cancel_run(
+            &self,
+            request: Request<proto::CancelWorkflowProviderRunRequest>,
+        ) -> Result<Response<proto::BoundWorkflowRun>, Status> {
+            let req = request.into_inner();
+            Ok(Response::new(proto::BoundWorkflowRun {
+                id: req.run_id,
+                status: proto::WorkflowRunStatus::Canceled as i32,
+                ..Default::default()
+            }))
+        }
+
+        async fn publish_event(
+            &self,
+            _request: Request<proto::PublishWorkflowProviderEventRequest>,
+        ) -> Result<Response<()>, Status> {
+            Ok(Response::new(()))
+        }
+    }
+
+    gestalt::export_workflow_provider!(constructor = ExampleWorkflow::default);
+    ```
+  </Tabs.Tab>
+  <Tabs.Tab>
+    ```ts
+    import {
+      WorkflowRunStatus,
+      defineWorkflowProvider,
+    } from "@valon-technologies/gestalt";
+
+    export const provider = defineWorkflowProvider({
+      async configure(_name, _config) {},
+
+      async startRun(request) {
+        return {
+          id: `${request.pluginName}:run-1`,
+          status: WorkflowRunStatus.PENDING,
+          target: request.target,
+        };
+      },
+
+      async getRun(request) {
+        return {
+          id: request.runId,
+        };
+      },
+
+      async listRuns(_request) {
+        return [];
+      },
+
+      async cancelRun(request) {
+        return {
+          id: request.runId,
+          status: WorkflowRunStatus.CANCELED,
+        };
+      },
+
+      async upsertSchedule(request) {
+        return {
+          id: request.scheduleId,
+          cron: request.cron,
+          target: request.target,
+          paused: request.paused,
+        };
+      },
+
+      async getSchedule(request) {
+        return { id: request.scheduleId };
+      },
+
+      async listSchedules(_request) {
+        return [];
+      },
+
+      async deleteSchedule(_request) {},
+
+      async pauseSchedule(request) {
+        return { id: request.scheduleId, paused: true };
+      },
+
+      async resumeSchedule(request) {
+        return { id: request.scheduleId, paused: false };
+      },
+
+      async upsertEventTrigger(request) {
+        return {
+          id: request.triggerId,
+          match: request.match,
+          target: request.target,
+          paused: request.paused,
+        };
+      },
+
+      async getEventTrigger(request) {
+        return { id: request.triggerId };
+      },
+
+      async listEventTriggers(_request) {
+        return [];
+      },
+
+      async deleteEventTrigger(_request) {},
+
+      async pauseEventTrigger(request) {
+        return { id: request.triggerId, paused: true };
+      },
+
+      async resumeEventTrigger(request) {
+        return { id: request.triggerId, paused: false };
+      },
+
+      async publishEvent(_request) {},
+    });
+    ```
+
+    Point `package.json` at the workflow provider with `gestalt.provider`:
+
+    ```json
+    {
+      "gestalt": {
+        "provider": {
+          "kind": "workflow",
+          "target": "./workflow.ts#provider"
+        }
+      }
+    }
+    ```
+  </Tabs.Tab>
+</Tabs>
+
+## Workflow host
+
+Workflow providers call back into Gestalt through the workflow host socket to
+invoke allowed plugin operations.
+
+<Tabs items={['Go', 'Python', 'Rust', 'TypeScript']}>
+  <Tabs.Tab>
+    ```go
+    host, err := gestalt.WorkflowHost()
+    if err != nil {
+    	return nil, err
+    }
+    defer host.Close()
+
+    resp, err := host.InvokeOperation(ctx, &proto.InvokeWorkflowOperationRequest{
+    	PluginName: "roadmap",
+    	Target: &proto.BoundWorkflowTarget{
+    		PluginName: "roadmap",
+    		Operation:  "sync_items",
+    	},
+    	RunId: "run-1",
+    })
+    ```
+  </Tabs.Tab>
+  <Tabs.Tab>
+    ```python
+    with gestalt.WorkflowHost() as host:
+        resp = host.invoke_operation(
+            gestalt.pb.InvokeWorkflowOperationRequest(
+                plugin_name="roadmap",
+                target=gestalt.pb.BoundWorkflowTarget(
+                    plugin_name="roadmap",
+                    operation="sync_items",
+                ),
+                run_id="run-1",
+            )
+        )
+    ```
+  </Tabs.Tab>
+  <Tabs.Tab>
+    ```rust
+    let mut host = gestalt::WorkflowHost::connect().await?;
+    let resp = host
+        .invoke_operation(proto::InvokeWorkflowOperationRequest {
+            plugin_name: "roadmap".into(),
+            target: Some(proto::BoundWorkflowTarget {
+                plugin_name: "roadmap".into(),
+                operation: "sync_items".into(),
+                ..Default::default()
+            }),
+            run_id: "run-1".into(),
+            ..Default::default()
+        })
+        .await?;
+    ```
+  </Tabs.Tab>
+  <Tabs.Tab>
+    ```ts
+    import { WorkflowHost } from "@valon-technologies/gestalt";
+
+    const host = new WorkflowHost();
+    const resp = await host.invokeOperation({
+      pluginName: "roadmap",
+      target: {
+        pluginName: "roadmap",
+        operation: "sync_items",
+      },
+      runId: "run-1",
+    });
+    ```
+  </Tabs.Tab>
+</Tabs>
+
+## Config reference
+
+To use a workflow provider in a deployment, configure it under
+`providers.workflow`, then bind plugins to it under `plugins.<name>.workflow`:
+
+```yaml
+providers:
+  indexeddb:
+    workflow_state:
+      source: https://artifacts.example.com/indexeddb/relationaldb/v0.0.1-alpha.1/provider-release.yaml
+      config:
+        dsn: ${DATABASE_URL}
+
+  workflow:
+    local:
+      source: ./workflow/manifest.yaml
+      indexeddb:
+        provider: workflow_state
+        db: workflow
+      config:
+        pollInterval: 1s
+
+plugins:
+  roadmap:
+    source: ./roadmap/manifest.yaml
+    workflow:
+      provider: local
+      operations:
+        - sync_items
+      schedules:
+        nightly_sync:
+          cron: "0 3 * * *"
+          timezone: America/New_York
+          operation: sync_items
+```
+
+`providers.workflow.<name>.indexeddb` is optional. When present, Gestalt
+exposes a host IndexedDB binding to the workflow provider over the usual
+IndexedDB SDK socket.
+
+## What to read next
+
+- [Providers > Workflow](/providers/workflow): configuring workflow providers
+- [Releasing](/custom-providers/releasing): packaging and publishing provider releases
+- [Built-in Providers](/reference/built-in-providers): first-party workflow provider reference

--- a/docs/content/providers/_meta.ts
+++ b/docs/content/providers/_meta.ts
@@ -1,10 +1,12 @@
 export default {
   plugins: "Plugins",
   auth: "Auth",
+  authorization: "Authorization",
   cache: "Cache",
   indexeddb: "IndexedDB",
   s3: "S3",
   secrets: "Secrets",
+  workflow: "Workflow",
   "web-uis": "Web UIs",
   releasing: {
     display: "hidden",

--- a/docs/content/providers/authorization.mdx
+++ b/docs/content/providers/authorization.mdx
@@ -1,0 +1,74 @@
+# Authorization
+
+Authorization providers back dynamic human authorization state. They are
+separate from platform login: `providers.auth.<name>` decides how users sign in
+to Gestalt, while `providers.authorization.<name>` stores authorization
+relationships and answers authorization queries for Gestalt itself.
+
+## How authorization providers work
+
+Static shared policies still live under top-level `authorization.policies`.
+When `server.providers.authorization` selects a provider, Gestalt writes its
+authorization model plus dynamic human plugin and built-in admin relationships
+into that provider and uses it for runtime human authorization checks.
+
+Dynamic human plugin/admin grants and the built-in authorization control-plane
+APIs require an authorization provider. If you omit `providers.authorization`,
+Gestalt still evaluates static policy members from config, but there is no
+provider-backed relationship storage or dynamic human-grant control plane.
+
+## First-party authorization providers
+
+First-party authorization providers live under
+[`valon-technologies/gestalt-providers/authorization`](https://github.com/valon-technologies/gestalt-providers/tree/main/authorization).
+
+| Provider | Repository | Package path | Use case |
+| --- | --- | --- | --- |
+| IndexedDB Authorization | [`authorization/indexeddb`](https://github.com/valon-technologies/gestalt-providers/tree/main/authorization/indexeddb) | `github.com/valon-technologies/gestalt-providers/authorization/indexeddb` | Stores authorization models and relationships in a host IndexedDB provider |
+
+## Configuring `providers.authorization`
+
+```yaml
+server:
+  providers:
+    indexeddb: main
+    authorization: indexeddb
+
+providers:
+  indexeddb:
+    main:
+      source: https://artifacts.example.com/indexeddb/relationaldb/v0.0.1-alpha.1/provider-release.yaml
+      config:
+        dsn: ${DATABASE_URL}
+
+  authorization:
+    indexeddb:
+      source: https://artifacts.example.com/authorization/indexeddb/v0.0.1-alpha.1/provider-release.yaml
+      config:
+        indexeddb: main
+```
+
+The first-party `authorization/indexeddb` provider expects the name of a host
+IndexedDB provider and stores authorization models plus relationships there.
+
+## Operational notes
+
+- `server.providers.authorization` selects the host authorization provider.
+- If more than one entry exists under `providers.authorization`, set
+  `server.providers.authorization` explicitly or mark one entry `default: true`.
+- Built-in admin authorization membership and inspection APIs use the selected
+  provider.
+- Static policy members still take precedence over dynamic grants.
+
+## Building your own authorization provider
+
+Implementation details for the decision plane, relationship control plane, and
+model lifecycle now live under
+[Custom Providers > Authorization](/custom-providers/authorization).
+
+## What to read next
+
+- [Configuration](/configuration): server and provider config structure
+- [Config File](/reference/config-file): full `providers.authorization` reference
+- [Built-in Providers](/reference/built-in-providers): first-party authorization provider reference
+- [Custom Authorization Providers](/custom-providers/authorization): advanced authoring docs

--- a/docs/content/providers/index.mdx
+++ b/docs/content/providers/index.mdx
@@ -6,10 +6,10 @@ asIndexPage: true
 
 Gestalt loads most integration and platform surfaces as providers instead of
 compiling them into `gestaltd`. Plugins, auth backends, IndexedDB backends,
-cache backends, S3 object stores, external secret managers, and public web UIs
-all use the same provider model: you reference a package in config, the host
-resolves it, validates it, and starts it with the permissions and request
-context it needs.
+authorization backends, workflow backends, cache backends, S3 object stores,
+external secret managers, and public web UIs all use the same provider model:
+you reference a package in config, the host resolves it, validates it, and
+starts it with the permissions and request context it needs.
 
 ## Provider kinds
 
@@ -17,10 +17,12 @@ context it needs.
 | --- | --- | --- |
 | `plugin` | Tool providers that expose operations over CLI, HTTP API, and MCP | `plugins.<name>` |
 | `auth` | Platform login backends | `providers.auth.<name>` |
+| `authorization` | Dynamic human authorization backends | `providers.authorization.<name>` |
 | `cache` | Plugin-bound cache backends | `providers.cache.<name>` |
 | `indexeddb` | Persistent state backends for users, sessions, tokens, and credentials | `providers.indexeddb.<name>` |
 | `s3` | S3-compatible object stores mounted into plugins | `providers.s3.<name>` |
 | `secrets` | Secret managers that resolve structured secret refs | `providers.secrets.<name>` |
+| `workflow` | Workflow run, schedule, and event-trigger backends | `providers.workflow.<name>` and `plugins.<name>.workflow` |
 | `webui` | Public UI bundles served under configured path prefixes | `providers.ui` |
 
 ## How providers work
@@ -50,10 +52,12 @@ The repository is organized by provider type:
 | --- | --- | --- |
 | Plugins | [`plugins/`](https://github.com/valon-technologies/gestalt-providers/tree/main/plugins) | `plugins.<name>` |
 | Auth | [`auth/`](https://github.com/valon-technologies/gestalt-providers/tree/main/auth) | `providers.auth.<name>` |
+| Authorization | [`authorization/`](https://github.com/valon-technologies/gestalt-providers/tree/main/authorization) | `providers.authorization.<name>` |
 | Cache | [`cache/`](https://github.com/valon-technologies/gestalt-providers/tree/main/cache) | `providers.cache.<name>` |
 | IndexedDB | [`indexeddb/`](https://github.com/valon-technologies/gestalt-providers/tree/main/indexeddb) | `providers.indexeddb.<name>` |
 | S3 | [`s3/`](https://github.com/valon-technologies/gestalt-providers/tree/main/s3) | `providers.s3.<name>` |
 | Secrets | [`secrets/`](https://github.com/valon-technologies/gestalt-providers/tree/main/secrets) | `providers.secrets.<name>` |
+| Workflow | [`workflow/`](https://github.com/valon-technologies/gestalt-providers/tree/main/workflow) | `providers.workflow.<name>` |
 | Web UI bundles | [`web/`](https://github.com/valon-technologies/gestalt-providers/tree/main/web) | `providers.ui` |
 
 ## Using providers
@@ -125,9 +129,11 @@ release workflow now lives under [Custom Providers](/custom-providers).
 
 - [Plugins](/providers/plugins): choosing and configuring plugin providers
 - [Auth](/providers/auth): platform login providers
+- [Authorization](/providers/authorization): human authorization providers
 - [Cache](/providers/cache): plugin-bound cache backends
 - [IndexedDB](/providers/indexeddb): storage backends
 - [S3](/providers/s3): S3-compatible object store providers
 - [Secrets](/providers/secrets): built-in and external secret managers
+- [Workflow](/providers/workflow): workflow run, schedule, and event-trigger backends
 - [Web UIs](/providers/web-uis): public UI bundles
 - [Custom Providers](/custom-providers): advanced implementation and release docs

--- a/docs/content/providers/workflow.mdx
+++ b/docs/content/providers/workflow.mdx
@@ -1,0 +1,89 @@
+# Workflow
+
+Workflow providers back plugin-scoped workflow runs, schedules, and event
+triggers. They are configured under `providers.workflow`, then bound per plugin
+through `plugins.<name>.workflow`.
+
+## How workflow providers work
+
+Workflow providers are selected per plugin, not globally. A plugin chooses a
+workflow provider with `plugins.<name>.workflow.provider`, or inherits the
+sole/default `providers.workflow` entry when that field is omitted.
+
+`plugins.<name>.workflow.operations` allowlists which plugin operations the
+workflow provider may invoke for that plugin. `workflow.schedules` and
+`workflow.eventTriggers` declare config-owned schedules and event triggers that
+Gestalt reconciles into the provider at startup. A workflow provider may also
+bind a host IndexedDB provider through `providers.workflow.<name>.indexeddb`.
+
+## First-party workflow providers
+
+First-party workflow providers live under
+[`valon-technologies/gestalt-providers/workflow`](https://github.com/valon-technologies/gestalt-providers/tree/main/workflow).
+
+| Provider | Repository | Package path | Use case |
+| --- | --- | --- | --- |
+| IndexedDB Workflow Provider | [`workflow/indexeddb`](https://github.com/valon-technologies/gestalt-providers/tree/main/workflow/indexeddb) | `github.com/valon-technologies/gestalt-providers/workflow/indexeddb` | Stores workflow runs, schedules, and event triggers in IndexedDB and invokes plugin operations through the workflow host |
+
+## Configuring `providers.workflow`
+
+```yaml
+providers:
+  indexeddb:
+    workflow_state:
+      source: https://artifacts.example.com/indexeddb/relationaldb/v0.0.1-alpha.1/provider-release.yaml
+      config:
+        dsn: ${DATABASE_URL}
+
+  workflow:
+    local:
+      source: https://artifacts.example.com/workflow/indexeddb/v0.0.1-alpha.1/provider-release.yaml
+      indexeddb:
+        provider: workflow_state
+        db: workflow
+      config:
+        pollInterval: 1s
+
+plugins:
+  roadmap:
+    source: https://artifacts.example.com/plugin/roadmap/v0.0.1-alpha.1/provider-release.yaml
+    workflow:
+      provider: local
+      operations:
+        - sync_items
+      schedules:
+        nightly_sync:
+          cron: "0 3 * * *"
+          timezone: America/New_York
+          operation: sync_items
+      eventTriggers:
+        item_updated:
+          match:
+            type: roadmap.item.updated
+          operation: sync_items
+```
+
+If a plugin omits `workflow.provider`, Gestalt falls back to the sole/default
+entry under `providers.workflow`.
+
+## Operational notes
+
+- A workflow provider is required only for plugins that configure
+  `plugins.<name>.workflow`.
+- Config-owned schedules and event triggers are reconciled into the provider at
+  startup and removed when deleted from config.
+- Workflow providers may invoke only the operations listed in
+  `plugins.<name>.workflow.operations`.
+
+## Building your own workflow provider
+
+Implementation details for the workflow runtime surface, host callbacks, and
+release flow now live under
+[Custom Providers > Workflow](/custom-providers/workflow).
+
+## What to read next
+
+- [Configuration](/configuration): server and provider config structure
+- [Config File](/reference/config-file): full `providers.workflow` and plugin workflow reference
+- [Built-in Providers](/reference/built-in-providers): first-party workflow provider reference
+- [Custom Workflow Providers](/custom-providers/workflow): advanced authoring docs

--- a/docs/content/reference/built-in-providers.mdx
+++ b/docs/content/reference/built-in-providers.mdx
@@ -1,9 +1,9 @@
 # First-Party Providers
 
-Gestalt does not compile auth, IndexedDB, or S3 providers into the `gestaltd`
-binary. They are loaded at startup as external provider processes through the
-same runtime model that also powers plugins. The first-party implementations
-are published from
+Gestalt does not compile auth, authorization, workflow, IndexedDB, or S3
+providers into the `gestaltd` binary. They are loaded at startup as external
+provider processes through the same runtime model that also powers plugins. The
+first-party implementations are published from
 [`valon-technologies/gestalt-providers`](https://github.com/valon-technologies/gestalt-providers)
 and maintained alongside the server.
 
@@ -31,6 +31,36 @@ providers:
 
 To disable platform auth entirely, omit the `providers.auth` block.
 
+## Authorization Providers
+
+Authorization providers back dynamic human authorization state. They are
+configured under `providers.authorization.<name>`, and
+`server.providers.authorization` selects which one Gestalt uses.
+
+```yaml
+server:
+  providers:
+    indexeddb: main
+    authorization: indexeddb
+
+providers:
+  indexeddb:
+    main:
+      source: https://artifacts.example.com/indexeddb/relationaldb/v0.0.1-alpha.1/provider-release.yaml
+      config:
+        dsn: ${DATABASE_URL}
+
+  authorization:
+    indexeddb:
+      source: https://artifacts.example.com/authorization/indexeddb/v0.0.1-alpha.1/provider-release.yaml
+      config:
+        indexeddb: main
+```
+
+| Name | Purpose |
+| --- | --- |
+| `indexeddb` | Stores authorization models and relationships in a host IndexedDB provider. |
+
 ## IndexedDB Providers
 
 Datastore providers back the persistent state layer. They are configured under named entries in `providers.indexeddb`, and `server.providers.indexeddb` selects which one the host uses. Gestalt does not compile datastore drivers into the binary; it starts the configured external datastore provider process at runtime.
@@ -53,6 +83,41 @@ providers:
 | `relationaldb` | SQL-backed IndexedDB provider for PostgreSQL, MySQL, SQLite, and SQL Server. |
 | `dynamodb` | Amazon DynamoDB-backed IndexedDB provider for managed key-value and document storage. |
 | `mongodb` | MongoDB-backed IndexedDB provider for document-oriented storage. |
+
+## Workflow Providers
+
+Workflow providers back plugin-scoped runs, schedules, and event triggers. They
+are configured under `providers.workflow.<name>`, then bound per plugin through
+`plugins.<name>.workflow`.
+
+```yaml
+providers:
+  indexeddb:
+    workflow_state:
+      source: https://artifacts.example.com/indexeddb/relationaldb/v0.0.1-alpha.1/provider-release.yaml
+      config:
+        dsn: ${DATABASE_URL}
+
+  workflow:
+    local:
+      source: https://artifacts.example.com/workflow/indexeddb/v0.0.1-alpha.1/provider-release.yaml
+      indexeddb:
+        provider: workflow_state
+        db: workflow
+      config:
+        pollInterval: 1s
+
+plugins:
+  roadmap:
+    workflow:
+      provider: local
+      operations:
+        - sync_items
+```
+
+| Name | Purpose |
+| --- | --- |
+| `indexeddb` | Stores workflow runs, schedules, and event triggers in IndexedDB and invokes plugin operations through the workflow host. |
 
 ## S3 Providers
 

--- a/docs/content/reference/config-file.mdx
+++ b/docs/content/reference/config-file.mdx
@@ -7,8 +7,8 @@ multiple `--config` flags, Gestalt merges them left-to-right before validation
 and bootstrap. The top-level keys are `server` (listener, encryption, egress,
 and host-provider selection), `authorization` (shared human/workload access
 policy), `providers` (named auth, secrets, telemetry, audit, UI, indexeddb,
-authorization, cache, and s3 entries), and `plugins` (executable integrations
-and optional plugin-backed UI mounts):
+authorization, workflow, cache, and s3 entries), and `plugins` (executable
+integrations and optional plugin-backed UI mounts):
 
 ```yaml
 server:
@@ -24,6 +24,7 @@ providers:
   ui: {}
   indexeddb: {}
   authorization: {}
+  workflow: {}
   cache: {}
   s3: {}
 plugins: {}
@@ -288,7 +289,12 @@ Common first-party IndexedDB packages:
 
 ## `providers.authorization`
 
-Authorization providers are host-scoped policy engines and relationship stores. Configure one or more named entries under `providers.authorization`, then set `server.providers.authorization` to the name Gestalt should use for human authorization decisions, model lifecycle, and built-in admin authorization inspection. First-party authorization providers are published at `github.com/valon-technologies/gestalt-providers/authorization/<name>`.
+Authorization providers are host-scoped policy engines and relationship stores.
+Configure one or more named entries under `providers.authorization`, then set
+`server.providers.authorization` to the name Gestalt should use for dynamic
+human authorization decisions, relationship storage, model lifecycle, and
+built-in admin authorization APIs. First-party authorization providers are
+published at `github.com/valon-technologies/gestalt-providers/authorization/<name>`.
 
 ```yaml
 server:
@@ -310,7 +316,16 @@ providers:
         indexeddb: main
 ```
 
-Authorization providers are optional. When omitted, Gestalt keeps using the in-process authorization engine only. When configured, Gestalt mirrors static and dynamic human authorization state into the selected provider and uses that provider for runtime human-access checks plus the built-in admin authorization debug APIs under `/admin/api/v1/authorization/...`.
+Authorization providers are optional only when you are relying on static human
+policy members from config. When configured, Gestalt uses the selected
+provider for dynamic human plugin/admin authorization, relationship storage,
+model lifecycle, and the built-in admin authorization APIs under
+`/admin/api/v1/authorization/...`.
+
+If `providers.authorization` is omitted, static policy members under
+`authorization.policies` still work, but there is no provider-backed
+relationship store and the dynamic human authorization control plane is
+unavailable.
 
 The exact config fields depend on the selected authorization provider package. The first-party `authorization/indexeddb` provider expects the name of a host IndexedDB provider and stores authorization models plus relationships there.
 
@@ -320,6 +335,69 @@ The exact config fields depend on the selected authorization provider package. T
 | `source` | Either a local provider manifest path, a published `provider-release.yaml` metadata URL, or `source.githubRelease` for a GitHub-hosted release asset. |
 | `auth` | Optional inline source auth for remote release sources, including direct metadata URLs and `source.githubRelease`. |
 | `config` | Provider-specific config passed into the authorization provider. |
+| `env` | Extra environment variables passed to the provider process. |
+| `allowedHosts` | Outbound host allowlist. For executable plugins, this is only a complete boundary when a supported sandboxed runtime is active. |
+
+## `providers.workflow`
+
+Workflow providers back plugin-scoped runs, schedules, and event triggers.
+Configure one or more named entries under `providers.workflow`, then bind
+plugins to them through `plugins.<name>.workflow`. There is no
+`server.providers.workflow`: each plugin chooses a provider explicitly with
+`plugins.<name>.workflow.provider`, or inherits the sole/default workflow
+provider when that field is omitted.
+
+```yaml
+providers:
+  indexeddb:
+    workflow_state:
+      source: https://artifacts.example.com/indexeddb/relationaldb/v0.0.1-alpha.1/provider-release.yaml
+      config:
+        dsn: ${DATABASE_URL}
+
+  workflow:
+    local:
+      source: https://artifacts.example.com/workflow/indexeddb/v0.0.1-alpha.1/provider-release.yaml
+      indexeddb:
+        provider: workflow_state
+        db: workflow
+        objectStores:
+          - schedules
+          - event_triggers
+          - runs
+      config:
+        pollInterval: 1s
+
+plugins:
+  roadmap:
+    workflow:
+      provider: local
+      operations:
+        - sync_items
+      schedules:
+        nightly_sync:
+          cron: "0 3 * * *"
+          timezone: America/New_York
+          operation: sync_items
+      eventTriggers:
+        item_updated:
+          match:
+            type: roadmap.item.updated
+          operation: sync_items
+```
+
+`providers.workflow.<name>.indexeddb` is optional. When present, it binds a
+named host IndexedDB provider into the workflow provider. `indexeddb.db`
+defaults to the workflow provider name, and `indexeddb.objectStores` can
+allowlist logical stores exposed through that binding.
+
+| Field | Description |
+| --- | --- |
+| `default` | Marks this named workflow entry as the default selection when a plugin omits `plugins.<name>.workflow.provider`. |
+| `source` | Either a local provider manifest path, a published `provider-release.yaml` metadata URL, or `source.githubRelease` for a GitHub-hosted release asset. |
+| `auth` | Optional inline source auth for remote release sources, including direct metadata URLs and `source.githubRelease`. |
+| `config` | Provider-specific config passed into the workflow provider. |
+| `indexeddb` | Optional host IndexedDB binding for the workflow provider, including `provider`, optional `db`, and optional `objectStores`. |
 | `env` | Extra environment variables passed to the provider process. |
 | `allowedHosts` | Outbound host allowlist. For executable plugins, this is only a complete boundary when a supported sandboxed runtime is active. |
 
@@ -661,6 +739,14 @@ plugins:
       objectStores:
         - tasks
         - snapshots
+    workflow:
+      operations:
+        - sync_items
+      schedules:
+        nightly_sync:
+          cron: "0 3 * * *"
+          timezone: America/New_York
+          operation: sync_items
     connections:
       default:
         mode: user
@@ -689,6 +775,7 @@ plugins:
 | `connections` | Named connection declarations. See [connections](#connections) below. |
 | `allowedOperations` | Allowlist with optional `alias`, `description`, and `allowedRoles` overrides per operation. |
 | `indexeddb` | Optional plugin IndexedDB config. `indexeddb.provider` selects which named `providers.indexeddb` entry backs the plugin's single IndexedDB SDK socket; when omitted, the plugin inherits the selected/default host IndexedDB. `indexeddb.db` overrides the plugin-visible database name and defaults to the plugin key. Schema-capable backends derive plugin scoping from that `db` name. `indexeddb.objectStores` optionally allowlists the logical object stores the plugin may use. Plugins then call `new IndexedDB()` (or the equivalent SDK helper) against `GESTALT_INDEXEDDB_SOCKET`; they do not choose arbitrary schemas or DSNs at runtime. |
+| `workflow` | Optional plugin workflow config. `workflow.provider` selects which named `providers.workflow` entry backs the plugin's workflow runtime; when omitted, the plugin inherits the sole/default workflow provider. `workflow.operations` is the allowlist of plugin operations the workflow provider may invoke for that plugin. `workflow.schedules` and `workflow.eventTriggers` declare config-owned schedules and event triggers that Gestalt reconciles into the provider at startup. |
 | `s3` | Optional list of named `providers.s3` bindings exposed to the executable plugin through the SDK transport. A single binding also populates the default S3 SDK env var for compatibility. |
 
 S3 bindings are exposed as `GESTALT_S3_SOCKET_<NAME>`. When exactly one S3


### PR DESCRIPTION
## Summary
- add new provider docs for Authorization and Workflow under `docs/content/providers`
- add new custom-provider authoring docs for Authorization and Workflow under `docs/content/custom-providers`
- update provider nav, landing pages, built-in provider reference, configuration guide, and config-file reference so the new provider kinds are documented consistently
- refresh the authorization docs to match current provider-backed dynamic human auth behavior and document `providers.workflow` plus `plugins.<name>.workflow`

## Verification
- `cd docs && npm run typecheck`
- `cd docs && npm run build`