### PR TITLE
workflow: resolve subject-based execution refs for human scheduled runs

### DIFF
--- a/gestaltd/core/workflow/workflow.go
+++ b/gestaltd/core/workflow/workflow.go
@@ -3,6 +3,8 @@ package workflow
 import (
 	"context"
 	"time"
+
+	"github.com/valon-technologies/gestalt/server/core"
 )
 
 const ConfigManagedSchedulePrefix = "cfg_"
@@ -30,6 +32,16 @@ type Target struct {
 	Connection string
 	Instance   string
 	Input      map[string]any
+}
+
+type ExecutionReference struct {
+	ID           string
+	ProviderName string
+	Target       Target
+	SubjectID    string
+	Permissions  []core.AccessPermission
+	CreatedAt    *time.Time
+	RevokedAt    *time.Time
 }
 
 type Event struct {

--- a/gestaltd/internal/bootstrap/bootstrap.go
+++ b/gestaltd/internal/bootstrap/bootstrap.go
@@ -673,6 +673,7 @@ func Bootstrap(ctx context.Context, cfg *config.Config, factories *FactoryRegist
 			return nil, err
 		}
 	}
+	prepared.Deps.WorkflowRuntime.SetExecutionRefs(prepared.Services.WorkflowExecutionRefs)
 	sharedInvoker := invocation.NewBroker(providers, prepared.Services.Users, prepared.Services.Tokens,
 		invocation.WithAuthorizer(authz),
 		invocation.WithConnectionMapper(invocation.ConnectionMap(connMaps.APIConnection)),

--- a/gestaltd/internal/bootstrap/workflow_runtime.go
+++ b/gestaltd/internal/bootstrap/workflow_runtime.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"crypto/rand"
 	"encoding/hex"
+	"errors"
 	"fmt"
 	"maps"
 	"slices"
@@ -11,8 +12,10 @@ import (
 	"sync"
 	"time"
 
+	"github.com/valon-technologies/gestalt/server/core/indexeddb"
 	coreworkflow "github.com/valon-technologies/gestalt/server/core/workflow"
 	"github.com/valon-technologies/gestalt/server/internal/config"
+	"github.com/valon-technologies/gestalt/server/internal/coredata"
 	"github.com/valon-technologies/gestalt/server/internal/invocation"
 	"github.com/valon-technologies/gestalt/server/internal/principal"
 )
@@ -31,6 +34,7 @@ type workflowRuntime struct {
 	providers              map[string]coreworkflow.Provider
 	startupWaits           *startupWaitTracker
 	invoker                invocation.Invoker
+	executionRefs          *coredata.WorkflowExecutionRefService
 }
 
 func newWorkflowRuntime(cfg *config.Config) (*workflowRuntime, error) {
@@ -164,6 +168,15 @@ func (r *workflowRuntime) SetInvoker(invoker invocation.Invoker) {
 	r.invoker = invoker
 }
 
+func (r *workflowRuntime) SetExecutionRefs(service *coredata.WorkflowExecutionRefService) {
+	if r == nil {
+		return
+	}
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	r.executionRefs = service
+}
+
 func (r *workflowRuntime) ResolvePlugin(pluginName string) (coreworkflow.Provider, map[string]struct{}, error) {
 	if r == nil {
 		return nil, nil, fmt.Errorf("workflow runtime is not configured")
@@ -235,6 +248,7 @@ func (r *workflowRuntime) Invoke(ctx context.Context, req coreworkflow.InvokeOpe
 	}
 	r.mu.RLock()
 	invoker := r.invoker
+	executionRefs := r.executionRefs
 	r.mu.RUnlock()
 	if invoker == nil {
 		return nil, fmt.Errorf("workflow runtime invoker is not configured")
@@ -253,11 +267,31 @@ func (r *workflowRuntime) Invoke(ctx context.Context, req coreworkflow.InvokeOpe
 	if !r.Allow(req.ProviderName, pluginName, req.Target.Operation) {
 		return nil, fmt.Errorf("workflow target %q for plugin %q is not enabled", req.Target.Operation, pluginName)
 	}
+	principalValue := workflowWorkloadPrincipal(pluginName)
+	target := req.Target
+	invokeConnection := ""
+	invokeInstance := ""
+	if strings.TrimSpace(req.ExecutionRef) != "" {
+		resolvedRef, err := resolveWorkflowExecutionRef(ctx, executionRefs, req)
+		if err != nil {
+			return nil, err
+		}
+		principalValue = workflowExecutionPrincipal(resolvedRef)
+		target.PluginName = resolvedRef.Target.PluginName
+		target.Operation = resolvedRef.Target.Operation
+		target.Connection = resolvedRef.Target.Connection
+		target.Instance = resolvedRef.Target.Instance
+		invokeConnection = strings.TrimSpace(target.Connection)
+		invokeInstance = strings.TrimSpace(target.Instance)
+	}
 	if contextValue := workflowInvocationContext(req); len(contextValue) > 0 {
 		ctx = invocation.WithWorkflowContext(ctx, contextValue)
 	}
+	if invokeConnection != "" {
+		ctx = invocation.WithConnection(ctx, invokeConnection)
+	}
 	params := workflowInvocationParams(req)
-	result, err := invoker.Invoke(ctx, workflowWorkloadPrincipal(pluginName), pluginName, "", req.Target.Operation, params)
+	result, err := invoker.Invoke(ctx, principalValue, target.PluginName, invokeInstance, target.Operation, params)
 	if err != nil {
 		return nil, err
 	}
@@ -268,6 +302,56 @@ func (r *workflowRuntime) Invoke(ctx context.Context, req coreworkflow.InvokeOpe
 		Status: result.Status,
 		Body:   result.Body,
 	}, nil
+}
+
+func resolveWorkflowExecutionRef(ctx context.Context, service *coredata.WorkflowExecutionRefService, req coreworkflow.InvokeOperationRequest) (*coreworkflow.ExecutionReference, error) {
+	if service == nil {
+		return nil, fmt.Errorf("%w: workflow execution refs are not configured", invocation.ErrInternal)
+	}
+	refID := strings.TrimSpace(req.ExecutionRef)
+	ref, err := service.Get(ctx, refID)
+	if err != nil {
+		if errors.Is(err, indexeddb.ErrNotFound) {
+			return nil, fmt.Errorf("%w: workflow execution ref %q was not found", invocation.ErrAuthorizationDenied, refID)
+		}
+		return nil, fmt.Errorf("%w: workflow execution ref %q lookup failed: %v", invocation.ErrInternal, refID, err)
+	}
+	if ref == nil {
+		return nil, fmt.Errorf("%w: workflow execution ref %q was not found", invocation.ErrAuthorizationDenied, refID)
+	}
+	if ref.RevokedAt != nil && !ref.RevokedAt.IsZero() {
+		return nil, fmt.Errorf("%w: workflow execution ref %q is revoked", invocation.ErrAuthorizationDenied, refID)
+	}
+	if strings.TrimSpace(ref.ProviderName) != strings.TrimSpace(req.ProviderName) {
+		return nil, fmt.Errorf("%w: workflow execution ref %q is not valid for provider %q", invocation.ErrAuthorizationDenied, refID, req.ProviderName)
+	}
+	if strings.TrimSpace(ref.Target.PluginName) != strings.TrimSpace(req.Target.PluginName) ||
+		strings.TrimSpace(ref.Target.Operation) != strings.TrimSpace(req.Target.Operation) ||
+		strings.TrimSpace(ref.Target.Connection) != strings.TrimSpace(req.Target.Connection) ||
+		strings.TrimSpace(ref.Target.Instance) != strings.TrimSpace(req.Target.Instance) {
+		return nil, fmt.Errorf("%w: workflow execution ref %q target does not match the scheduled invocation", invocation.ErrAuthorizationDenied, refID)
+	}
+	return ref, nil
+}
+
+func workflowExecutionPrincipal(ref *coreworkflow.ExecutionReference) *principal.Principal {
+	if ref == nil {
+		return nil
+	}
+	subjectID := strings.TrimSpace(ref.SubjectID)
+	userID := principal.UserIDFromSubjectID(subjectID)
+	permissions := principal.CompilePermissions(ref.Permissions)
+	value := &principal.Principal{
+		UserID:           userID,
+		SubjectID:        subjectID,
+		Kind:             principal.KindUser,
+		Scopes:           principal.PermissionPlugins(permissions),
+		TokenPermissions: permissions,
+	}
+	if value.UserID == "" {
+		value.Kind = ""
+	}
+	return value
 }
 
 func workflowInvocationParams(req coreworkflow.InvokeOperationRequest) map[string]any {

--- a/gestaltd/internal/bootstrap/workflow_runtime_test.go
+++ b/gestaltd/internal/bootstrap/workflow_runtime_test.go
@@ -2,6 +2,7 @@ package bootstrap
 
 import (
 	"context"
+	"errors"
 	"net"
 	"net/http"
 	"testing"
@@ -10,10 +11,16 @@ import (
 	proto "github.com/valon-technologies/gestalt/sdk/go/gen/v1"
 	"github.com/valon-technologies/gestalt/server/core"
 	"github.com/valon-technologies/gestalt/server/core/catalog"
+	"github.com/valon-technologies/gestalt/server/core/indexeddb"
+	coretesting "github.com/valon-technologies/gestalt/server/core/testing"
 	coreworkflow "github.com/valon-technologies/gestalt/server/core/workflow"
+	"github.com/valon-technologies/gestalt/server/internal/authorization"
+	"github.com/valon-technologies/gestalt/server/internal/config"
+	"github.com/valon-technologies/gestalt/server/internal/coredata"
 	"github.com/valon-technologies/gestalt/server/internal/invocation"
 	"github.com/valon-technologies/gestalt/server/internal/principal"
 	"github.com/valon-technologies/gestalt/server/internal/providerhost"
+	"github.com/valon-technologies/gestalt/server/internal/registry"
 	"google.golang.org/grpc"
 	"google.golang.org/grpc/credentials/insecure"
 	"google.golang.org/grpc/test/bufconn"
@@ -25,6 +32,75 @@ type funcInvoker struct {
 
 func (f funcInvoker) Invoke(ctx context.Context, p *principal.Principal, providerName, instance, operation string, params map[string]any) (*core.OperationResult, error) {
 	return f.invoke(ctx, p, providerName, instance, operation, params)
+}
+
+type erroringIndexedDB struct {
+	err error
+}
+
+func (d *erroringIndexedDB) ObjectStore(string) indexeddb.ObjectStore {
+	return erroringObjectStore{err: d.err}
+}
+func (d *erroringIndexedDB) CreateObjectStore(context.Context, string, indexeddb.ObjectStoreSchema) error {
+	return d.err
+}
+func (d *erroringIndexedDB) DeleteObjectStore(context.Context, string) error { return d.err }
+func (d *erroringIndexedDB) Ping(context.Context) error                      { return d.err }
+func (d *erroringIndexedDB) Close() error                                    { return d.err }
+
+type erroringObjectStore struct {
+	err error
+}
+
+func (o erroringObjectStore) Get(context.Context, string) (indexeddb.Record, error) {
+	return nil, o.err
+}
+func (o erroringObjectStore) GetKey(context.Context, string) (string, error) { return "", o.err }
+func (o erroringObjectStore) Add(context.Context, indexeddb.Record) error    { return o.err }
+func (o erroringObjectStore) Put(context.Context, indexeddb.Record) error    { return o.err }
+func (o erroringObjectStore) Delete(context.Context, string) error           { return o.err }
+func (o erroringObjectStore) Clear(context.Context) error                    { return o.err }
+func (o erroringObjectStore) GetAll(context.Context, *indexeddb.KeyRange) ([]indexeddb.Record, error) {
+	return nil, o.err
+}
+func (o erroringObjectStore) GetAllKeys(context.Context, *indexeddb.KeyRange) ([]string, error) {
+	return nil, o.err
+}
+func (o erroringObjectStore) Count(context.Context, *indexeddb.KeyRange) (int64, error) {
+	return 0, o.err
+}
+func (o erroringObjectStore) DeleteRange(context.Context, indexeddb.KeyRange) (int64, error) {
+	return 0, o.err
+}
+func (o erroringObjectStore) Index(string) indexeddb.Index { return erroringIndex(o) }
+func (o erroringObjectStore) OpenCursor(context.Context, *indexeddb.KeyRange, indexeddb.CursorDirection) (indexeddb.Cursor, error) {
+	return nil, o.err
+}
+func (o erroringObjectStore) OpenKeyCursor(context.Context, *indexeddb.KeyRange, indexeddb.CursorDirection) (indexeddb.Cursor, error) {
+	return nil, o.err
+}
+
+type erroringIndex struct {
+	err error
+}
+
+func (i erroringIndex) Get(context.Context, ...any) (indexeddb.Record, error) { return nil, i.err }
+func (i erroringIndex) GetKey(context.Context, ...any) (string, error)        { return "", i.err }
+func (i erroringIndex) GetAll(context.Context, *indexeddb.KeyRange, ...any) ([]indexeddb.Record, error) {
+	return nil, i.err
+}
+func (i erroringIndex) GetAllKeys(context.Context, *indexeddb.KeyRange, ...any) ([]string, error) {
+	return nil, i.err
+}
+func (i erroringIndex) Count(context.Context, *indexeddb.KeyRange, ...any) (int64, error) {
+	return 0, i.err
+}
+func (i erroringIndex) Delete(context.Context, ...any) (int64, error) { return 0, i.err }
+func (i erroringIndex) OpenCursor(context.Context, *indexeddb.KeyRange, indexeddb.CursorDirection, ...any) (indexeddb.Cursor, error) {
+	return nil, i.err
+}
+func (i erroringIndex) OpenKeyCursor(context.Context, *indexeddb.KeyRange, indexeddb.CursorDirection, ...any) (indexeddb.Cursor, error) {
+	return nil, i.err
 }
 
 type workflowRoundTripProvider struct {
@@ -132,12 +208,16 @@ func TestWorkflowRuntimeInvokeMergesConfiguredAndPerRunInput(t *testing.T) {
 
 	var gotPrincipal *principal.Principal
 	var gotProvider string
+	var gotInstance string
+	var gotConnection string
 	var gotOperation string
 	var gotParams map[string]any
 	runtime.SetInvoker(funcInvoker{
-		invoke: func(ctx context.Context, p *principal.Principal, providerName, _ string, operation string, params map[string]any) (*core.OperationResult, error) {
+		invoke: func(ctx context.Context, p *principal.Principal, providerName, instance string, operation string, params map[string]any) (*core.OperationResult, error) {
 			gotPrincipal = p
 			gotProvider = providerName
+			gotInstance = instance
+			gotConnection = invocation.ConnectionFromContext(ctx)
 			gotOperation = operation
 			gotParams = params
 			ctx = principal.WithPrincipal(ctx, p)
@@ -149,7 +229,6 @@ func TestWorkflowRuntimeInvokeMergesConfiguredAndPerRunInput(t *testing.T) {
 		ProviderName: "temporal",
 		PluginName:   "roadmap",
 		RunID:        "run-123",
-		ExecutionRef: "exec-ref-123",
 		Target: coreworkflow.Target{
 			PluginName: "roadmap",
 			Operation:  "sync",
@@ -192,6 +271,12 @@ func TestWorkflowRuntimeInvokeMergesConfiguredAndPerRunInput(t *testing.T) {
 	if gotProvider != "roadmap" {
 		t.Fatalf("provider = %q, want %q", gotProvider, "roadmap")
 	}
+	if gotInstance != "" {
+		t.Fatalf("instance = %q, want empty instance for workload invocations", gotInstance)
+	}
+	if gotConnection != "" {
+		t.Fatalf("connection = %q, want empty connection for workload invocations", gotConnection)
+	}
 	if gotOperation != "sync" {
 		t.Fatalf("operation = %q, want %q", gotOperation, "sync")
 	}
@@ -221,9 +306,6 @@ func TestWorkflowRuntimeInvokeMergesConfiguredAndPerRunInput(t *testing.T) {
 	if !ok || createdBy["subjectId"] != principal.UserSubjectID("user-123") || createdBy["authSource"] != principal.SourceAPIToken.String() {
 		t.Fatalf("workflow createdBy = %#v", roundTripProvider.workflowContext["createdBy"])
 	}
-	if got := roundTripProvider.workflowContext["executionRef"]; got != "exec-ref-123" {
-		t.Fatalf("workflow executionRef = %#v, want %q", got, "exec-ref-123")
-	}
 	target, ok := roundTripProvider.workflowContext["target"].(map[string]any)
 	if !ok || target["pluginName"] != "roadmap" || target["operation"] != "sync" {
 		t.Fatalf("workflow target = %#v", roundTripProvider.workflowContext["target"])
@@ -240,6 +322,316 @@ func TestWorkflowRuntimeInvokeMergesConfiguredAndPerRunInput(t *testing.T) {
 	}
 	if got := trigger["scheduledFor"]; got != scheduledFor.UTC().Format(time.RFC3339Nano) {
 		t.Fatalf("scheduledFor = %#v, want %q", got, scheduledFor.UTC().Format(time.RFC3339Nano))
+	}
+}
+
+func TestWorkflowRuntimeInvokeExecutionRefUsesStoredHumanPrincipalAndSelectors(t *testing.T) {
+	t.Parallel()
+
+	services := coretesting.NewStubServices(t)
+	user, err := services.Users.FindOrCreateUser(context.Background(), "ada@example.test")
+	if err != nil {
+		t.Fatalf("FindOrCreateUser: %v", err)
+	}
+	if _, err := services.WorkflowExecutionRefs.Put(context.Background(), &coreworkflow.ExecutionReference{
+		ID:           "exec-ref-123",
+		ProviderName: "temporal",
+		Target: coreworkflow.Target{
+			PluginName: "roadmap",
+			Operation:  "sync",
+			Connection: "analytics",
+			Instance:   "tenant-a",
+		},
+		SubjectID: principal.UserSubjectID(user.ID),
+	}); err != nil {
+		t.Fatalf("Put execution ref: %v", err)
+	}
+
+	runtime := &workflowRuntime{
+		bindings: map[string]workflowBinding{
+			"roadmap": {
+				providerName: "temporal",
+				operations: map[string]struct{}{
+					"sync": {},
+				},
+			},
+		},
+		executionRefs: services.WorkflowExecutionRefs,
+	}
+
+	var gotPrincipal *principal.Principal
+	var gotProvider string
+	var gotInstance string
+	var gotConnection string
+	runtime.SetInvoker(funcInvoker{
+		invoke: func(ctx context.Context, p *principal.Principal, providerName, instance, operation string, params map[string]any) (*core.OperationResult, error) {
+			gotPrincipal = p
+			gotProvider = providerName
+			gotInstance = instance
+			gotConnection = invocation.ConnectionFromContext(ctx)
+			if operation != "sync" {
+				t.Fatalf("operation = %q, want %q", operation, "sync")
+			}
+			if params["taskId"] != "task-123" {
+				t.Fatalf("params = %#v", params)
+			}
+			return &core.OperationResult{Status: http.StatusAccepted, Body: `{"ok":true}`}, nil
+		},
+	})
+
+	resp, err := runtime.Invoke(context.Background(), coreworkflow.InvokeOperationRequest{
+		ProviderName: "temporal",
+		PluginName:   "roadmap",
+		ExecutionRef: "exec-ref-123",
+		Target: coreworkflow.Target{
+			PluginName: "roadmap",
+			Operation:  "sync",
+			Connection: "analytics",
+			Instance:   "tenant-a",
+			Input: map[string]any{
+				"mode": "full",
+			},
+		},
+		Input: map[string]any{
+			"taskId": "task-123",
+		},
+	})
+	if err != nil {
+		t.Fatalf("Invoke: %v", err)
+	}
+	if resp.Status != http.StatusAccepted || resp.Body != `{"ok":true}` {
+		t.Fatalf("response = %#v", resp)
+	}
+	if gotPrincipal == nil || gotPrincipal.Kind != principal.KindUser || gotPrincipal.UserID != user.ID || gotPrincipal.SubjectID != principal.UserSubjectID(user.ID) {
+		t.Fatalf("principal = %#v", gotPrincipal)
+	}
+	if gotProvider != "roadmap" {
+		t.Fatalf("provider = %q, want %q", gotProvider, "roadmap")
+	}
+	if gotInstance != "tenant-a" {
+		t.Fatalf("instance = %q, want %q", gotInstance, "tenant-a")
+	}
+	if gotConnection != "analytics" {
+		t.Fatalf("connection = %q, want %q", gotConnection, "analytics")
+	}
+}
+
+func TestWorkflowRuntimeInvokeExecutionRefRechecksAuthorizationThroughBroker(t *testing.T) {
+	t.Parallel()
+
+	services := coretesting.NewStubServices(t)
+	user, err := services.Users.FindOrCreateUser(context.Background(), "ada@example.test")
+	if err != nil {
+		t.Fatalf("FindOrCreateUser: %v", err)
+	}
+	if _, err := services.WorkflowExecutionRefs.Put(context.Background(), &coreworkflow.ExecutionReference{
+		ID:           "exec-ref-denied",
+		ProviderName: "temporal",
+		Target: coreworkflow.Target{
+			PluginName: "roadmap",
+			Operation:  "sync",
+			Connection: "analytics",
+			Instance:   "tenant-a",
+		},
+		SubjectID: principal.UserSubjectID(user.ID),
+	}); err != nil {
+		t.Fatalf("Put execution ref: %v", err)
+	}
+	if err := services.Tokens.StoreToken(context.Background(), &core.IntegrationToken{
+		UserID:      user.ID,
+		Integration: "roadmap",
+		Connection:  "analytics",
+		Instance:    "tenant-a",
+		AccessToken: "user-token",
+	}); err != nil {
+		t.Fatalf("StoreToken: %v", err)
+	}
+
+	providers := registry.New()
+	executed := false
+	if err := providers.Providers.Register("roadmap", &coretesting.StubIntegration{
+		N:        "roadmap",
+		ConnMode: core.ConnectionModeUser,
+		CatalogVal: &catalog.Catalog{
+			Name: "roadmap",
+			Operations: []catalog.CatalogOperation{
+				{ID: "sync", Method: http.MethodPost},
+			},
+		},
+		ExecuteFn: func(context.Context, string, map[string]any, string) (*core.OperationResult, error) {
+			executed = true
+			return &core.OperationResult{Status: http.StatusAccepted, Body: `{"ok":true}`}, nil
+		},
+	}); err != nil {
+		t.Fatalf("Register provider: %v", err)
+	}
+
+	authz, err := authorization.New(config.AuthorizationConfig{
+		Policies: map[string]config.HumanPolicyDef{
+			"roadmap-policy": {
+				Default: "deny",
+				Members: []config.HumanPolicyMemberDef{
+					{Email: "other@example.test", Role: "viewer"},
+				},
+			},
+		},
+	}, map[string]*config.ProviderEntry{
+		"roadmap": {AuthorizationPolicy: "roadmap-policy"},
+	}, &providers.Providers, nil)
+	if err != nil {
+		t.Fatalf("authorization.New: %v", err)
+	}
+
+	runtime := &workflowRuntime{
+		bindings: map[string]workflowBinding{
+			"roadmap": {
+				providerName: "temporal",
+				operations: map[string]struct{}{
+					"sync": {},
+				},
+			},
+		},
+		executionRefs: services.WorkflowExecutionRefs,
+	}
+	runtime.SetInvoker(invocation.NewBroker(&providers.Providers, services.Users, services.Tokens, invocation.WithAuthorizer(authz)))
+
+	_, err = runtime.Invoke(context.Background(), coreworkflow.InvokeOperationRequest{
+		ProviderName: "temporal",
+		PluginName:   "roadmap",
+		ExecutionRef: "exec-ref-denied",
+		Target: coreworkflow.Target{
+			PluginName: "roadmap",
+			Operation:  "sync",
+			Connection: "analytics",
+			Instance:   "tenant-a",
+		},
+	})
+	if err == nil {
+		t.Fatal("expected authorization error, got nil")
+	}
+	if !errors.Is(err, invocation.ErrAuthorizationDenied) {
+		t.Fatalf("error = %v, want ErrAuthorizationDenied", err)
+	}
+	if executed {
+		t.Fatal("expected provider execution to be skipped")
+	}
+}
+
+func TestWorkflowRuntimeInvokeExecutionRefPreservesTokenPermissionCeiling(t *testing.T) {
+	t.Parallel()
+
+	services := coretesting.NewStubServices(t)
+	ctx := context.Background()
+
+	if _, err := services.WorkflowExecutionRefs.Put(ctx, &coreworkflow.ExecutionReference{
+		ID:           "exec-ref-123",
+		ProviderName: "basic",
+		Target: coreworkflow.Target{
+			PluginName: "roadmap",
+			Operation:  "export",
+			Connection: "analytics",
+			Instance:   "tenant-a",
+		},
+		SubjectID: principal.UserSubjectID("user-123"),
+		Permissions: []core.AccessPermission{{
+			Plugin:     "roadmap",
+			Operations: []string{"sync"},
+		}},
+	}); err != nil {
+		t.Fatalf("Put execution ref: %v", err)
+	}
+
+	providers := registry.New()
+	executed := false
+	if err := providers.Providers.Register("roadmap", &coretesting.StubIntegration{
+		N: "roadmap",
+		CatalogVal: &catalog.Catalog{
+			Name: "roadmap",
+			Operations: []catalog.CatalogOperation{
+				{ID: "export", Method: http.MethodPost},
+			},
+		},
+		ExecuteFn: func(context.Context, string, map[string]any, string) (*core.OperationResult, error) {
+			executed = true
+			return &core.OperationResult{Status: http.StatusOK, Body: `{"ok":true}`}, nil
+		},
+	}); err != nil {
+		t.Fatalf("Register provider: %v", err)
+	}
+
+	broker := invocation.NewBroker(&providers.Providers, services.Users, services.Tokens)
+	runtime := &workflowRuntime{
+		bindings: map[string]workflowBinding{
+			"roadmap": {
+				providerName: "basic",
+				operations: map[string]struct{}{
+					"export": {},
+				},
+			},
+		},
+		invoker:       broker,
+		executionRefs: services.WorkflowExecutionRefs,
+	}
+
+	_, err := runtime.Invoke(ctx, coreworkflow.InvokeOperationRequest{
+		ProviderName: "basic",
+		PluginName:   "roadmap",
+		RunID:        "run-123",
+		Target: coreworkflow.Target{
+			PluginName: "roadmap",
+			Operation:  "export",
+			Connection: "analytics",
+			Instance:   "tenant-a",
+		},
+		ExecutionRef: "exec-ref-123",
+	})
+	if !errors.Is(err, invocation.ErrScopeDenied) {
+		t.Fatalf("Invoke error = %v, want scope denied", err)
+	}
+	if executed {
+		t.Fatal("expected provider Execute not to run when execution-ref permissions do not allow the operation")
+	}
+}
+
+func TestWorkflowRuntimeInvokeExecutionRefLookupInfrastructureErrorIsInternal(t *testing.T) {
+	t.Parallel()
+
+	lookupErr := errors.New("boom")
+	runtime := &workflowRuntime{
+		bindings: map[string]workflowBinding{
+			"roadmap": {
+				providerName: "basic",
+				operations: map[string]struct{}{
+					"sync": {},
+				},
+			},
+		},
+		executionRefs: coredata.NewWorkflowExecutionRefService(&erroringIndexedDB{err: lookupErr}),
+	}
+	runtime.SetInvoker(funcInvoker{
+		invoke: func(context.Context, *principal.Principal, string, string, string, map[string]any) (*core.OperationResult, error) {
+			t.Fatal("invoke should not be called when execution-ref lookup fails")
+			return nil, nil
+		},
+	})
+
+	_, err := runtime.Invoke(context.Background(), coreworkflow.InvokeOperationRequest{
+		ProviderName: "basic",
+		PluginName:   "roadmap",
+		ExecutionRef: "exec-ref-123",
+		Target: coreworkflow.Target{
+			PluginName: "roadmap",
+			Operation:  "sync",
+		},
+	})
+	if err == nil {
+		t.Fatal("expected internal error, got nil")
+	}
+	if !errors.Is(err, invocation.ErrInternal) {
+		t.Fatalf("error = %v, want ErrInternal", err)
+	}
+	if errors.Is(err, invocation.ErrAuthorizationDenied) {
+		t.Fatalf("error = %v, should not be ErrAuthorizationDenied", err)
 	}
 }
 

--- a/gestaltd/internal/coredata/schemas.go
+++ b/gestaltd/internal/coredata/schemas.go
@@ -17,6 +17,7 @@ const (
 	StoreIdentityPluginAccess       = "identity_plugin_access"
 	StoreAPITokenAccess             = "api_token_access"
 	StoreExternalCredentials        = "external_credentials"
+	StoreWorkflowExecutionRefs      = "workflow_execution_refs"
 )
 
 var UsersSchema = indexeddb.ObjectStoreSchema{
@@ -268,5 +269,23 @@ var ExternalCredentialsSchema = indexeddb.ObjectStoreSchema{
 		{Name: "metadata_json", Type: indexeddb.TypeString},
 		{Name: "created_at", Type: indexeddb.TypeTime},
 		{Name: "updated_at", Type: indexeddb.TypeTime},
+	},
+}
+
+var WorkflowExecutionRefsSchema = indexeddb.ObjectStoreSchema{
+	Indexes: []indexeddb.IndexSchema{
+		{Name: "by_subject", KeyPath: []string{"subject_id"}},
+	},
+	Columns: []indexeddb.ColumnDef{
+		{Name: "id", Type: indexeddb.TypeString, PrimaryKey: true},
+		{Name: "provider_name", Type: indexeddb.TypeString, NotNull: true},
+		{Name: "target_plugin", Type: indexeddb.TypeString, NotNull: true},
+		{Name: "target_operation", Type: indexeddb.TypeString, NotNull: true},
+		{Name: "target_connection", Type: indexeddb.TypeString},
+		{Name: "target_instance", Type: indexeddb.TypeString},
+		{Name: "subject_id", Type: indexeddb.TypeString, NotNull: true},
+		{Name: "permissions_json", Type: indexeddb.TypeString},
+		{Name: "created_at", Type: indexeddb.TypeTime},
+		{Name: "revoked_at", Type: indexeddb.TypeTime},
 	},
 }

--- a/gestaltd/internal/coredata/services.go
+++ b/gestaltd/internal/coredata/services.go
@@ -23,6 +23,7 @@ type Services struct {
 	IdentityPluginAccess     *IdentityPluginAccessService
 	APITokenAccess           *APITokenAccessService
 	ExternalCredentials      *ExternalCredentialService
+	WorkflowExecutionRefs    *WorkflowExecutionRefService
 	DB                       indexeddb.IndexedDB
 }
 
@@ -70,6 +71,9 @@ func New(ds indexeddb.IndexedDB, enc *corecrypto.AESGCMEncryptor) (*Services, er
 	if err := ds.CreateObjectStore(ctx, StoreExternalCredentials, ExternalCredentialsSchema); err != nil {
 		return nil, fmt.Errorf("create external_credentials store: %w", err)
 	}
+	if err := ds.CreateObjectStore(ctx, StoreWorkflowExecutionRefs, WorkflowExecutionRefsSchema); err != nil {
+		return nil, fmt.Errorf("create workflow_execution_refs store: %w", err)
+	}
 
 	identities := NewIdentityService(ds)
 	authBindings := NewIdentityAuthBindingService(ds)
@@ -79,6 +83,7 @@ func New(ds indexeddb.IndexedDB, enc *corecrypto.AESGCMEncryptor) (*Services, er
 	identityPluginAccess := NewIdentityPluginAccessService(ds)
 	apiTokenAccess := NewAPITokenAccessService(ds)
 	externalCredentials := NewExternalCredentialService(ds)
+	workflowExecutionRefs := NewWorkflowExecutionRefService(ds)
 
 	users := NewUserService(ds, identities, authBindings)
 	if err := users.BackfillNormalizedEmails(ctx); err != nil {
@@ -127,6 +132,7 @@ func New(ds indexeddb.IndexedDB, enc *corecrypto.AESGCMEncryptor) (*Services, er
 		IdentityPluginAccess:     identityPluginAccess,
 		APITokenAccess:           apiTokenAccess,
 		ExternalCredentials:      externalCredentials,
+		WorkflowExecutionRefs:    workflowExecutionRefs,
 		DB:                       ds,
 	}, nil
 }

--- a/gestaltd/internal/coredata/services_test.go
+++ b/gestaltd/internal/coredata/services_test.go
@@ -14,8 +14,10 @@ import (
 	corecrypto "github.com/valon-technologies/gestalt/server/core/crypto"
 	"github.com/valon-technologies/gestalt/server/core/indexeddb"
 	coretesting "github.com/valon-technologies/gestalt/server/core/testing"
+	coreworkflow "github.com/valon-technologies/gestalt/server/core/workflow"
 	"github.com/valon-technologies/gestalt/server/internal/coredata"
 	"github.com/valon-technologies/gestalt/server/internal/emailutil"
+	"github.com/valon-technologies/gestalt/server/internal/principal"
 )
 
 const testEncryptionKey = "0123456789abcdef0123456789abcdef"
@@ -1526,6 +1528,61 @@ func TestAPITokenService(t *testing.T) {
 		}
 		if token.ID == "" {
 			t.Error("ID should be auto-generated")
+		}
+	})
+}
+
+func TestWorkflowExecutionRefService(t *testing.T) {
+	t.Parallel()
+
+	t.Run("PutGet_round_trips_permissions", func(t *testing.T) {
+		t.Parallel()
+		svc := newTestServices(t)
+		ctx := context.Background()
+
+		ref, err := svc.WorkflowExecutionRefs.Put(ctx, &coreworkflow.ExecutionReference{
+			ID:           "exec-ref-123",
+			ProviderName: "basic",
+			Target: coreworkflow.Target{
+				PluginName: "roadmap",
+				Operation:  "sync",
+			},
+			SubjectID:   principal.UserSubjectID("user-123"),
+			Permissions: []core.AccessPermission{{Plugin: "roadmap", Operations: []string{"sync"}}},
+		})
+		if err != nil {
+			t.Fatalf("Put: %v", err)
+		}
+		if ref.SubjectID != principal.UserSubjectID("user-123") {
+			t.Fatalf("SubjectID = %q, want %q", ref.SubjectID, principal.UserSubjectID("user-123"))
+		}
+
+		got, err := svc.WorkflowExecutionRefs.Get(ctx, "exec-ref-123")
+		if err != nil {
+			t.Fatalf("Get: %v", err)
+		}
+		want := []core.AccessPermission{{Plugin: "roadmap", Operations: []string{"sync"}}}
+		if !reflect.DeepEqual(got.Permissions, want) {
+			t.Fatalf("Permissions = %#v, want %#v", got.Permissions, want)
+		}
+	})
+
+	t.Run("Put_rejects_non_user_subject", func(t *testing.T) {
+		t.Parallel()
+		svc := newTestServices(t)
+		ctx := context.Background()
+
+		_, err := svc.WorkflowExecutionRefs.Put(ctx, &coreworkflow.ExecutionReference{
+			ID:           "exec-ref-bad",
+			ProviderName: "basic",
+			Target: coreworkflow.Target{
+				PluginName: "roadmap",
+				Operation:  "sync",
+			},
+			SubjectID: principal.ManagedIdentitySubjectID("managed-123"),
+		})
+		if err == nil {
+			t.Fatal("expected Put to reject non-user subject_id")
 		}
 	})
 }

--- a/gestaltd/internal/coredata/workflow_execution_refs.go
+++ b/gestaltd/internal/coredata/workflow_execution_refs.go
@@ -1,0 +1,133 @@
+package coredata
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"strings"
+	"time"
+
+	"github.com/valon-technologies/gestalt/server/core"
+	"github.com/valon-technologies/gestalt/server/core/indexeddb"
+	coreworkflow "github.com/valon-technologies/gestalt/server/core/workflow"
+)
+
+type WorkflowExecutionRefService struct {
+	store indexeddb.ObjectStore
+}
+
+func NewWorkflowExecutionRefService(ds indexeddb.IndexedDB) *WorkflowExecutionRefService {
+	return &WorkflowExecutionRefService{store: ds.ObjectStore(StoreWorkflowExecutionRefs)}
+}
+
+func (s *WorkflowExecutionRefService) Put(ctx context.Context, ref *coreworkflow.ExecutionReference) (*coreworkflow.ExecutionReference, error) {
+	if ref == nil {
+		return nil, fmt.Errorf("put workflow execution ref: ref is required")
+	}
+
+	id := strings.TrimSpace(ref.ID)
+	providerName := strings.TrimSpace(ref.ProviderName)
+	targetPlugin := strings.TrimSpace(ref.Target.PluginName)
+	targetOperation := strings.TrimSpace(ref.Target.Operation)
+	subjectID := strings.TrimSpace(ref.SubjectID)
+	if id == "" || providerName == "" || targetPlugin == "" || targetOperation == "" || subjectID == "" {
+		return nil, fmt.Errorf("put workflow execution ref: id, provider_name, target.plugin_name, target.operation, and subject_id are required")
+	}
+	if workflowExecutionRefUserID(subjectID) == "" {
+		return nil, fmt.Errorf("put workflow execution ref: subject_id %q is not a user subject", subjectID)
+	}
+
+	permissionsJSON := ""
+	if len(ref.Permissions) > 0 {
+		raw, err := json.Marshal(ref.Permissions)
+		if err != nil {
+			return nil, fmt.Errorf("put workflow execution ref: marshal permissions: %w", err)
+		}
+		permissionsJSON = string(raw)
+	}
+
+	now := time.Now()
+	createdAt := ref.CreatedAt
+	if existing, err := s.store.Get(ctx, id); err == nil {
+		if created := recTime(existing, "created_at"); !created.IsZero() {
+			createdAt = &created
+		}
+	} else if err != indexeddb.ErrNotFound {
+		return nil, fmt.Errorf("put workflow execution ref: %w", err)
+	}
+	if createdAt == nil || createdAt.IsZero() {
+		createdAt = &now
+	}
+
+	rec := indexeddb.Record{
+		"id":                id,
+		"provider_name":     providerName,
+		"target_plugin":     targetPlugin,
+		"target_operation":  targetOperation,
+		"target_connection": strings.TrimSpace(ref.Target.Connection),
+		"target_instance":   strings.TrimSpace(ref.Target.Instance),
+		"subject_id":        subjectID,
+		"permissions_json":  permissionsJSON,
+		"created_at":        *createdAt,
+		"revoked_at":        timeOrNil(ref.RevokedAt),
+	}
+	if err := s.store.Put(ctx, rec); err != nil {
+		return nil, fmt.Errorf("put workflow execution ref: %w", err)
+	}
+	return recordToWorkflowExecutionRef(rec), nil
+}
+
+func (s *WorkflowExecutionRefService) Get(ctx context.Context, id string) (*coreworkflow.ExecutionReference, error) {
+	rec, err := s.store.Get(ctx, strings.TrimSpace(id))
+	if err != nil {
+		if err == indexeddb.ErrNotFound {
+			return nil, indexeddb.ErrNotFound
+		}
+		return nil, fmt.Errorf("get workflow execution ref: %w", err)
+	}
+	return recordToWorkflowExecutionRef(rec), nil
+}
+
+func recordToWorkflowExecutionRef(rec indexeddb.Record) *coreworkflow.ExecutionReference {
+	return &coreworkflow.ExecutionReference{
+		ID:           recString(rec, "id"),
+		ProviderName: recString(rec, "provider_name"),
+		Target: coreworkflow.Target{
+			PluginName: recString(rec, "target_plugin"),
+			Operation:  recString(rec, "target_operation"),
+			Connection: recString(rec, "target_connection"),
+			Instance:   recString(rec, "target_instance"),
+		},
+		SubjectID:   recString(rec, "subject_id"),
+		Permissions: recWorkflowExecutionRefPermissions(rec),
+		CreatedAt:   recTimePtr(rec, "created_at"),
+		RevokedAt:   recTimePtr(rec, "revoked_at"),
+	}
+}
+
+func recWorkflowExecutionRefPermissions(rec indexeddb.Record) []core.AccessPermission {
+	raw := recString(rec, "permissions_json")
+	if raw == "" {
+		return nil
+	}
+	var permissions []core.AccessPermission
+	if err := json.Unmarshal([]byte(raw), &permissions); err != nil {
+		return nil
+	}
+	return permissions
+}
+
+func workflowExecutionRefUserID(subjectID string) string {
+	const prefix = "user:"
+	if !strings.HasPrefix(subjectID, prefix) {
+		return ""
+	}
+	return strings.TrimPrefix(subjectID, prefix)
+}
+
+func timeOrNil(value *time.Time) any {
+	if value == nil || value.IsZero() {
+		return nil
+	}
+	return *value
+}

--- a/gestaltd/internal/principal/principal.go
+++ b/gestaltd/internal/principal/principal.go
@@ -56,6 +56,21 @@ func (s Source) String() string {
 	}
 }
 
+func ParseSource(value string) Source {
+	switch strings.TrimSpace(value) {
+	case SourceSession.String():
+		return SourceSession
+	case SourceAPIToken.String():
+		return SourceAPIToken
+	case SourceWorkloadToken.String():
+		return SourceWorkloadToken
+	case SourceEnv.String():
+		return SourceEnv
+	default:
+		return SourceUnknown
+	}
+}
+
 func (p *Principal) AuthSource() string {
 	if p == nil {
 		return ""
@@ -71,6 +86,13 @@ func UserSubjectID(userID string) string {
 		return ""
 	}
 	return string(KindUser) + ":" + userID
+}
+
+func UserIDFromSubjectID(subjectID string) string {
+	if !strings.HasPrefix(subjectID, string(KindUser)+":") {
+		return ""
+	}
+	return strings.TrimPrefix(subjectID, string(KindUser)+":")
 }
 
 func WorkloadSubjectID(workloadID string) string {

--- a/gestaltd/internal/providerhost/workflow_server_test.go
+++ b/gestaltd/internal/providerhost/workflow_server_test.go
@@ -935,6 +935,29 @@ func TestWorkflowHostServerMapsInvocationErrors(t *testing.T) {
 	}
 }
 
+func TestWorkflowHostServerMapsInternalInvocationErrors(t *testing.T) {
+	t.Parallel()
+
+	srv := NewWorkflowHostServer(
+		"temporal",
+		func(context.Context, coreworkflow.InvokeOperationRequest) (*coreworkflow.InvokeOperationResponse, error) {
+			return nil, invocation.ErrInternal
+		},
+		func(string, string, string) bool { return true },
+	)
+
+	_, err := srv.InvokeOperation(context.Background(), &proto.InvokeWorkflowOperationRequest{
+		PluginName: "roadmap",
+		Target: &proto.BoundWorkflowTarget{
+			PluginName: "roadmap",
+			Operation:  "sync",
+		},
+	})
+	if status.Code(err) != codes.Internal {
+		t.Fatalf("status code = %v, want %v", status.Code(err), codes.Internal)
+	}
+}
+
 func TestWorkflowServerPublishEventScopesPlugin(t *testing.T) {
 	t.Parallel()
 


### PR DESCRIPTION
Add durable workflow execution references in `gestaltd` and use them during workflow host callbacks to run scheduled invocations as a stored human principal instead of the synthetic workflow workload.

## New Interfaces

```go
type ExecutionReference struct {
    ID           string
    ProviderName string
    Target       Target
    SubjectID    string
    Permissions  []core.AccessPermission
    CreatedAt    *time.Time
    RevokedAt    *time.Time
}

type WorkflowExecutionRefService struct {
    // internal coredata service backed by workflow_execution_refs
}
```

## Store Schema

```text
workflow_execution_refs(
  id,
  provider_name,
  target_plugin,
  target_operation,
  target_connection,
  target_instance,
  subject_id,
  permissions_json,
  created_at,
  revoked_at
)
```

The workflow runtime now resolves `InvokeOperationRequest.ExecutionRef`, validates that the stored provider/target still match the callback, restores a human principal from the canonical `subject_id`, and forwards the stored `connection` and `instance` selectors into the broker.

## Examples

```go
services.WorkflowExecutionRefs.Put(ctx, &workflow.ExecutionReference{
    ID:           "exec-ref-123",
    ProviderName: "temporal",
    Target: workflow.Target{
        PluginName: "roadmap",
        Operation:  "sync",
        Connection: "analytics",
        Instance:   "tenant-a",
    },
    SubjectID:   principal.UserSubjectID("user-123"),
    Permissions: []core.AccessPermission{{Plugin: "roadmap", Operations: []string{"sync"}}},
})
```

```text
InvokeWorkflowOperationRequest{
  plugin_name: "roadmap",
  execution_ref: "exec-ref-123",
  target: {
    plugin_name: "roadmap",
    operation: "sync",
    connection: "analytics",
    instance: "tenant-a"
  }
}
```

When that callback arrives, `gestaltd` now reuses the stored execution reference to:
- run the invocation as the referenced human subject
- re-check live authorization through the broker/authorizer
- derive the user identity from the canonical `user:<id>` subject for token resolution
- reject mismatched or revoked execution references before invoking the plugin
- preserve API-token permission ceilings from `permissions_json`

## Tests
- `go test ./internal/coredata ./internal/bootstrap ./internal/providerhost -count=1`
- `git diff --check`