### PR TITLE
workflow: add user-owned schedule HTTP CRUD

### DIFF
--- a/gestaltd/core/workflow/workflow.go
+++ b/gestaltd/core/workflow/workflow.go
@@ -3,6 +3,8 @@ package workflow
 import (
 	"context"
 	"time"
+
+	"github.com/valon-technologies/gestalt/server/core"
 )
 
 const ConfigManagedSchedulePrefix = "cfg_"
@@ -30,6 +32,16 @@ type Target struct {
 	Connection string
 	Instance   string
 	Input      map[string]any
+}
+
+type ExecutionReference struct {
+	ID           string
+	ProviderName string
+	Target       Target
+	SubjectID    string
+	Permissions  []core.AccessPermission
+	CreatedAt    *time.Time
+	RevokedAt    *time.Time
 }
 
 type Event struct {

--- a/gestaltd/internal/bootstrap/bootstrap.go
+++ b/gestaltd/internal/bootstrap/bootstrap.go
@@ -673,6 +673,7 @@ func Bootstrap(ctx context.Context, cfg *config.Config, factories *FactoryRegist
 			return nil, err
 		}
 	}
+	prepared.Deps.WorkflowRuntime.SetExecutionRefs(prepared.Services.WorkflowExecutionRefs)
 	sharedInvoker := invocation.NewBroker(providers, prepared.Services.Users, prepared.Services.Tokens,
 		invocation.WithAuthorizer(authz),
 		invocation.WithConnectionMapper(invocation.ConnectionMap(connMaps.APIConnection)),

--- a/gestaltd/internal/bootstrap/bootstrap.go
+++ b/gestaltd/internal/bootstrap/bootstrap.go
@@ -183,6 +183,7 @@ type Result struct {
 	ExtraS3s              []s3store.Client
 	ExtraWorkflows        []coreworkflow.Provider
 	Providers             *registry.ProviderMap[core.Provider]
+	WorkflowControl       WorkflowControl
 	ProvidersReady        <-chan struct{}
 	Authorizer            authorization.RuntimeAuthorizer
 	ConnectionAuth        func() map[string]map[string]OAuthHandler
@@ -722,6 +723,7 @@ func Bootstrap(ctx context.Context, cfg *config.Config, factories *FactoryRegist
 		ExtraS3s:              prepared.ExtraS3s,
 		ExtraWorkflows:        extraWorkflows,
 		Providers:             providers,
+		WorkflowControl:       prepared.Deps.WorkflowRuntime,
 		ProvidersReady:        providersReady,
 		Authorizer:            authz,
 		ConnectionAuth:        connAuthResolver,

--- a/gestaltd/internal/bootstrap/workflow_control.go
+++ b/gestaltd/internal/bootstrap/workflow_control.go
@@ -1,0 +1,12 @@
+package bootstrap
+
+import coreworkflow "github.com/valon-technologies/gestalt/server/core/workflow"
+
+// WorkflowControl exposes the small subset of workflow runtime behavior that
+// gestaltd's user-facing HTTP routes need for user-owned schedules.
+type WorkflowControl interface {
+	ResolveBinding(pluginName string) (providerName string, operations map[string]struct{}, err error)
+	ResolveProvider(name string) (coreworkflow.Provider, error)
+}
+
+var _ WorkflowControl = (*workflowRuntime)(nil)

--- a/gestaltd/internal/bootstrap/workflow_runtime.go
+++ b/gestaltd/internal/bootstrap/workflow_runtime.go
@@ -194,6 +194,19 @@ func (r *workflowRuntime) ResolvePlugin(pluginName string) (coreworkflow.Provide
 	return provider, maps.Clone(binding.operations), nil
 }
 
+func (r *workflowRuntime) ResolveBinding(pluginName string) (string, map[string]struct{}, error) {
+	if r == nil {
+		return "", nil, fmt.Errorf("workflow runtime is not configured")
+	}
+	r.mu.RLock()
+	defer r.mu.RUnlock()
+	binding, ok := r.bindings[pluginName]
+	if !ok {
+		return "", nil, fmt.Errorf("plugin %q does not have a workflow binding", pluginName)
+	}
+	return binding.providerName, maps.Clone(binding.operations), nil
+}
+
 func (r *workflowRuntime) ResolveProvider(name string) (coreworkflow.Provider, error) {
 	if r == nil {
 		return nil, fmt.Errorf("workflow runtime is not configured")

--- a/gestaltd/internal/bootstrap/workflow_runtime.go
+++ b/gestaltd/internal/bootstrap/workflow_runtime.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"crypto/rand"
 	"encoding/hex"
+	"errors"
 	"fmt"
 	"maps"
 	"slices"
@@ -11,8 +12,10 @@ import (
 	"sync"
 	"time"
 
+	"github.com/valon-technologies/gestalt/server/core/indexeddb"
 	coreworkflow "github.com/valon-technologies/gestalt/server/core/workflow"
 	"github.com/valon-technologies/gestalt/server/internal/config"
+	"github.com/valon-technologies/gestalt/server/internal/coredata"
 	"github.com/valon-technologies/gestalt/server/internal/invocation"
 	"github.com/valon-technologies/gestalt/server/internal/principal"
 )
@@ -31,6 +34,7 @@ type workflowRuntime struct {
 	providers              map[string]coreworkflow.Provider
 	startupWaits           *startupWaitTracker
 	invoker                invocation.Invoker
+	executionRefs          *coredata.WorkflowExecutionRefService
 }
 
 func newWorkflowRuntime(cfg *config.Config) (*workflowRuntime, error) {
@@ -164,6 +168,15 @@ func (r *workflowRuntime) SetInvoker(invoker invocation.Invoker) {
 	r.invoker = invoker
 }
 
+func (r *workflowRuntime) SetExecutionRefs(service *coredata.WorkflowExecutionRefService) {
+	if r == nil {
+		return
+	}
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	r.executionRefs = service
+}
+
 func (r *workflowRuntime) ResolvePlugin(pluginName string) (coreworkflow.Provider, map[string]struct{}, error) {
 	if r == nil {
 		return nil, nil, fmt.Errorf("workflow runtime is not configured")
@@ -235,6 +248,7 @@ func (r *workflowRuntime) Invoke(ctx context.Context, req coreworkflow.InvokeOpe
 	}
 	r.mu.RLock()
 	invoker := r.invoker
+	executionRefs := r.executionRefs
 	r.mu.RUnlock()
 	if invoker == nil {
 		return nil, fmt.Errorf("workflow runtime invoker is not configured")
@@ -253,11 +267,31 @@ func (r *workflowRuntime) Invoke(ctx context.Context, req coreworkflow.InvokeOpe
 	if !r.Allow(req.ProviderName, pluginName, req.Target.Operation) {
 		return nil, fmt.Errorf("workflow target %q for plugin %q is not enabled", req.Target.Operation, pluginName)
 	}
+	principalValue := workflowWorkloadPrincipal(pluginName)
+	target := req.Target
+	invokeConnection := ""
+	invokeInstance := ""
+	if strings.TrimSpace(req.ExecutionRef) != "" {
+		resolvedRef, err := resolveWorkflowExecutionRef(ctx, executionRefs, req)
+		if err != nil {
+			return nil, err
+		}
+		principalValue = workflowExecutionPrincipal(resolvedRef)
+		target.PluginName = resolvedRef.Target.PluginName
+		target.Operation = resolvedRef.Target.Operation
+		target.Connection = resolvedRef.Target.Connection
+		target.Instance = resolvedRef.Target.Instance
+		invokeConnection = strings.TrimSpace(target.Connection)
+		invokeInstance = strings.TrimSpace(target.Instance)
+	}
 	if contextValue := workflowInvocationContext(req); len(contextValue) > 0 {
 		ctx = invocation.WithWorkflowContext(ctx, contextValue)
 	}
+	if invokeConnection != "" {
+		ctx = invocation.WithConnection(ctx, invokeConnection)
+	}
 	params := workflowInvocationParams(req)
-	result, err := invoker.Invoke(ctx, workflowWorkloadPrincipal(pluginName), pluginName, "", req.Target.Operation, params)
+	result, err := invoker.Invoke(ctx, principalValue, target.PluginName, invokeInstance, target.Operation, params)
 	if err != nil {
 		return nil, err
 	}
@@ -268,6 +302,56 @@ func (r *workflowRuntime) Invoke(ctx context.Context, req coreworkflow.InvokeOpe
 		Status: result.Status,
 		Body:   result.Body,
 	}, nil
+}
+
+func resolveWorkflowExecutionRef(ctx context.Context, service *coredata.WorkflowExecutionRefService, req coreworkflow.InvokeOperationRequest) (*coreworkflow.ExecutionReference, error) {
+	if service == nil {
+		return nil, fmt.Errorf("%w: workflow execution refs are not configured", invocation.ErrInternal)
+	}
+	refID := strings.TrimSpace(req.ExecutionRef)
+	ref, err := service.Get(ctx, refID)
+	if err != nil {
+		if errors.Is(err, indexeddb.ErrNotFound) {
+			return nil, fmt.Errorf("%w: workflow execution ref %q was not found", invocation.ErrAuthorizationDenied, refID)
+		}
+		return nil, fmt.Errorf("%w: workflow execution ref %q lookup failed: %v", invocation.ErrInternal, refID, err)
+	}
+	if ref == nil {
+		return nil, fmt.Errorf("%w: workflow execution ref %q was not found", invocation.ErrAuthorizationDenied, refID)
+	}
+	if ref.RevokedAt != nil && !ref.RevokedAt.IsZero() {
+		return nil, fmt.Errorf("%w: workflow execution ref %q is revoked", invocation.ErrAuthorizationDenied, refID)
+	}
+	if strings.TrimSpace(ref.ProviderName) != strings.TrimSpace(req.ProviderName) {
+		return nil, fmt.Errorf("%w: workflow execution ref %q is not valid for provider %q", invocation.ErrAuthorizationDenied, refID, req.ProviderName)
+	}
+	if strings.TrimSpace(ref.Target.PluginName) != strings.TrimSpace(req.Target.PluginName) ||
+		strings.TrimSpace(ref.Target.Operation) != strings.TrimSpace(req.Target.Operation) ||
+		strings.TrimSpace(ref.Target.Connection) != strings.TrimSpace(req.Target.Connection) ||
+		strings.TrimSpace(ref.Target.Instance) != strings.TrimSpace(req.Target.Instance) {
+		return nil, fmt.Errorf("%w: workflow execution ref %q target does not match the scheduled invocation", invocation.ErrAuthorizationDenied, refID)
+	}
+	return ref, nil
+}
+
+func workflowExecutionPrincipal(ref *coreworkflow.ExecutionReference) *principal.Principal {
+	if ref == nil {
+		return nil
+	}
+	subjectID := strings.TrimSpace(ref.SubjectID)
+	userID := principal.UserIDFromSubjectID(subjectID)
+	permissions := principal.CompilePermissions(ref.Permissions)
+	value := &principal.Principal{
+		UserID:           userID,
+		SubjectID:        subjectID,
+		Kind:             principal.KindUser,
+		Scopes:           principal.PermissionPlugins(permissions),
+		TokenPermissions: permissions,
+	}
+	if value.UserID == "" {
+		value.Kind = ""
+	}
+	return value
 }
 
 func workflowInvocationParams(req coreworkflow.InvokeOperationRequest) map[string]any {

--- a/gestaltd/internal/bootstrap/workflow_runtime_test.go
+++ b/gestaltd/internal/bootstrap/workflow_runtime_test.go
@@ -2,6 +2,7 @@ package bootstrap
 
 import (
 	"context"
+	"errors"
 	"net"
 	"net/http"
 	"testing"
@@ -10,10 +11,16 @@ import (
 	proto "github.com/valon-technologies/gestalt/sdk/go/gen/v1"
 	"github.com/valon-technologies/gestalt/server/core"
 	"github.com/valon-technologies/gestalt/server/core/catalog"
+	"github.com/valon-technologies/gestalt/server/core/indexeddb"
+	coretesting "github.com/valon-technologies/gestalt/server/core/testing"
 	coreworkflow "github.com/valon-technologies/gestalt/server/core/workflow"
+	"github.com/valon-technologies/gestalt/server/internal/authorization"
+	"github.com/valon-technologies/gestalt/server/internal/config"
+	"github.com/valon-technologies/gestalt/server/internal/coredata"
 	"github.com/valon-technologies/gestalt/server/internal/invocation"
 	"github.com/valon-technologies/gestalt/server/internal/principal"
 	"github.com/valon-technologies/gestalt/server/internal/providerhost"
+	"github.com/valon-technologies/gestalt/server/internal/registry"
 	"google.golang.org/grpc"
 	"google.golang.org/grpc/credentials/insecure"
 	"google.golang.org/grpc/test/bufconn"
@@ -25,6 +32,75 @@ type funcInvoker struct {
 
 func (f funcInvoker) Invoke(ctx context.Context, p *principal.Principal, providerName, instance, operation string, params map[string]any) (*core.OperationResult, error) {
 	return f.invoke(ctx, p, providerName, instance, operation, params)
+}
+
+type erroringIndexedDB struct {
+	err error
+}
+
+func (d *erroringIndexedDB) ObjectStore(string) indexeddb.ObjectStore {
+	return erroringObjectStore{err: d.err}
+}
+func (d *erroringIndexedDB) CreateObjectStore(context.Context, string, indexeddb.ObjectStoreSchema) error {
+	return d.err
+}
+func (d *erroringIndexedDB) DeleteObjectStore(context.Context, string) error { return d.err }
+func (d *erroringIndexedDB) Ping(context.Context) error                      { return d.err }
+func (d *erroringIndexedDB) Close() error                                    { return d.err }
+
+type erroringObjectStore struct {
+	err error
+}
+
+func (o erroringObjectStore) Get(context.Context, string) (indexeddb.Record, error) {
+	return nil, o.err
+}
+func (o erroringObjectStore) GetKey(context.Context, string) (string, error) { return "", o.err }
+func (o erroringObjectStore) Add(context.Context, indexeddb.Record) error    { return o.err }
+func (o erroringObjectStore) Put(context.Context, indexeddb.Record) error    { return o.err }
+func (o erroringObjectStore) Delete(context.Context, string) error           { return o.err }
+func (o erroringObjectStore) Clear(context.Context) error                    { return o.err }
+func (o erroringObjectStore) GetAll(context.Context, *indexeddb.KeyRange) ([]indexeddb.Record, error) {
+	return nil, o.err
+}
+func (o erroringObjectStore) GetAllKeys(context.Context, *indexeddb.KeyRange) ([]string, error) {
+	return nil, o.err
+}
+func (o erroringObjectStore) Count(context.Context, *indexeddb.KeyRange) (int64, error) {
+	return 0, o.err
+}
+func (o erroringObjectStore) DeleteRange(context.Context, indexeddb.KeyRange) (int64, error) {
+	return 0, o.err
+}
+func (o erroringObjectStore) Index(string) indexeddb.Index { return erroringIndex(o) }
+func (o erroringObjectStore) OpenCursor(context.Context, *indexeddb.KeyRange, indexeddb.CursorDirection) (indexeddb.Cursor, error) {
+	return nil, o.err
+}
+func (o erroringObjectStore) OpenKeyCursor(context.Context, *indexeddb.KeyRange, indexeddb.CursorDirection) (indexeddb.Cursor, error) {
+	return nil, o.err
+}
+
+type erroringIndex struct {
+	err error
+}
+
+func (i erroringIndex) Get(context.Context, ...any) (indexeddb.Record, error) { return nil, i.err }
+func (i erroringIndex) GetKey(context.Context, ...any) (string, error)        { return "", i.err }
+func (i erroringIndex) GetAll(context.Context, *indexeddb.KeyRange, ...any) ([]indexeddb.Record, error) {
+	return nil, i.err
+}
+func (i erroringIndex) GetAllKeys(context.Context, *indexeddb.KeyRange, ...any) ([]string, error) {
+	return nil, i.err
+}
+func (i erroringIndex) Count(context.Context, *indexeddb.KeyRange, ...any) (int64, error) {
+	return 0, i.err
+}
+func (i erroringIndex) Delete(context.Context, ...any) (int64, error) { return 0, i.err }
+func (i erroringIndex) OpenCursor(context.Context, *indexeddb.KeyRange, indexeddb.CursorDirection, ...any) (indexeddb.Cursor, error) {
+	return nil, i.err
+}
+func (i erroringIndex) OpenKeyCursor(context.Context, *indexeddb.KeyRange, indexeddb.CursorDirection, ...any) (indexeddb.Cursor, error) {
+	return nil, i.err
 }
 
 type workflowRoundTripProvider struct {
@@ -132,12 +208,16 @@ func TestWorkflowRuntimeInvokeMergesConfiguredAndPerRunInput(t *testing.T) {
 
 	var gotPrincipal *principal.Principal
 	var gotProvider string
+	var gotInstance string
+	var gotConnection string
 	var gotOperation string
 	var gotParams map[string]any
 	runtime.SetInvoker(funcInvoker{
-		invoke: func(ctx context.Context, p *principal.Principal, providerName, _ string, operation string, params map[string]any) (*core.OperationResult, error) {
+		invoke: func(ctx context.Context, p *principal.Principal, providerName, instance string, operation string, params map[string]any) (*core.OperationResult, error) {
 			gotPrincipal = p
 			gotProvider = providerName
+			gotInstance = instance
+			gotConnection = invocation.ConnectionFromContext(ctx)
 			gotOperation = operation
 			gotParams = params
 			ctx = principal.WithPrincipal(ctx, p)
@@ -149,7 +229,6 @@ func TestWorkflowRuntimeInvokeMergesConfiguredAndPerRunInput(t *testing.T) {
 		ProviderName: "temporal",
 		PluginName:   "roadmap",
 		RunID:        "run-123",
-		ExecutionRef: "exec-ref-123",
 		Target: coreworkflow.Target{
 			PluginName: "roadmap",
 			Operation:  "sync",
@@ -192,6 +271,12 @@ func TestWorkflowRuntimeInvokeMergesConfiguredAndPerRunInput(t *testing.T) {
 	if gotProvider != "roadmap" {
 		t.Fatalf("provider = %q, want %q", gotProvider, "roadmap")
 	}
+	if gotInstance != "" {
+		t.Fatalf("instance = %q, want empty instance for workload invocations", gotInstance)
+	}
+	if gotConnection != "" {
+		t.Fatalf("connection = %q, want empty connection for workload invocations", gotConnection)
+	}
 	if gotOperation != "sync" {
 		t.Fatalf("operation = %q, want %q", gotOperation, "sync")
 	}
@@ -221,9 +306,6 @@ func TestWorkflowRuntimeInvokeMergesConfiguredAndPerRunInput(t *testing.T) {
 	if !ok || createdBy["subjectId"] != principal.UserSubjectID("user-123") || createdBy["authSource"] != principal.SourceAPIToken.String() {
 		t.Fatalf("workflow createdBy = %#v", roundTripProvider.workflowContext["createdBy"])
 	}
-	if got := roundTripProvider.workflowContext["executionRef"]; got != "exec-ref-123" {
-		t.Fatalf("workflow executionRef = %#v, want %q", got, "exec-ref-123")
-	}
 	target, ok := roundTripProvider.workflowContext["target"].(map[string]any)
 	if !ok || target["pluginName"] != "roadmap" || target["operation"] != "sync" {
 		t.Fatalf("workflow target = %#v", roundTripProvider.workflowContext["target"])
@@ -240,6 +322,316 @@ func TestWorkflowRuntimeInvokeMergesConfiguredAndPerRunInput(t *testing.T) {
 	}
 	if got := trigger["scheduledFor"]; got != scheduledFor.UTC().Format(time.RFC3339Nano) {
 		t.Fatalf("scheduledFor = %#v, want %q", got, scheduledFor.UTC().Format(time.RFC3339Nano))
+	}
+}
+
+func TestWorkflowRuntimeInvokeExecutionRefUsesStoredHumanPrincipalAndSelectors(t *testing.T) {
+	t.Parallel()
+
+	services := coretesting.NewStubServices(t)
+	user, err := services.Users.FindOrCreateUser(context.Background(), "ada@example.test")
+	if err != nil {
+		t.Fatalf("FindOrCreateUser: %v", err)
+	}
+	if _, err := services.WorkflowExecutionRefs.Put(context.Background(), &coreworkflow.ExecutionReference{
+		ID:           "exec-ref-123",
+		ProviderName: "temporal",
+		Target: coreworkflow.Target{
+			PluginName: "roadmap",
+			Operation:  "sync",
+			Connection: "analytics",
+			Instance:   "tenant-a",
+		},
+		SubjectID: principal.UserSubjectID(user.ID),
+	}); err != nil {
+		t.Fatalf("Put execution ref: %v", err)
+	}
+
+	runtime := &workflowRuntime{
+		bindings: map[string]workflowBinding{
+			"roadmap": {
+				providerName: "temporal",
+				operations: map[string]struct{}{
+					"sync": {},
+				},
+			},
+		},
+		executionRefs: services.WorkflowExecutionRefs,
+	}
+
+	var gotPrincipal *principal.Principal
+	var gotProvider string
+	var gotInstance string
+	var gotConnection string
+	runtime.SetInvoker(funcInvoker{
+		invoke: func(ctx context.Context, p *principal.Principal, providerName, instance, operation string, params map[string]any) (*core.OperationResult, error) {
+			gotPrincipal = p
+			gotProvider = providerName
+			gotInstance = instance
+			gotConnection = invocation.ConnectionFromContext(ctx)
+			if operation != "sync" {
+				t.Fatalf("operation = %q, want %q", operation, "sync")
+			}
+			if params["taskId"] != "task-123" {
+				t.Fatalf("params = %#v", params)
+			}
+			return &core.OperationResult{Status: http.StatusAccepted, Body: `{"ok":true}`}, nil
+		},
+	})
+
+	resp, err := runtime.Invoke(context.Background(), coreworkflow.InvokeOperationRequest{
+		ProviderName: "temporal",
+		PluginName:   "roadmap",
+		ExecutionRef: "exec-ref-123",
+		Target: coreworkflow.Target{
+			PluginName: "roadmap",
+			Operation:  "sync",
+			Connection: "analytics",
+			Instance:   "tenant-a",
+			Input: map[string]any{
+				"mode": "full",
+			},
+		},
+		Input: map[string]any{
+			"taskId": "task-123",
+		},
+	})
+	if err != nil {
+		t.Fatalf("Invoke: %v", err)
+	}
+	if resp.Status != http.StatusAccepted || resp.Body != `{"ok":true}` {
+		t.Fatalf("response = %#v", resp)
+	}
+	if gotPrincipal == nil || gotPrincipal.Kind != principal.KindUser || gotPrincipal.UserID != user.ID || gotPrincipal.SubjectID != principal.UserSubjectID(user.ID) {
+		t.Fatalf("principal = %#v", gotPrincipal)
+	}
+	if gotProvider != "roadmap" {
+		t.Fatalf("provider = %q, want %q", gotProvider, "roadmap")
+	}
+	if gotInstance != "tenant-a" {
+		t.Fatalf("instance = %q, want %q", gotInstance, "tenant-a")
+	}
+	if gotConnection != "analytics" {
+		t.Fatalf("connection = %q, want %q", gotConnection, "analytics")
+	}
+}
+
+func TestWorkflowRuntimeInvokeExecutionRefRechecksAuthorizationThroughBroker(t *testing.T) {
+	t.Parallel()
+
+	services := coretesting.NewStubServices(t)
+	user, err := services.Users.FindOrCreateUser(context.Background(), "ada@example.test")
+	if err != nil {
+		t.Fatalf("FindOrCreateUser: %v", err)
+	}
+	if _, err := services.WorkflowExecutionRefs.Put(context.Background(), &coreworkflow.ExecutionReference{
+		ID:           "exec-ref-denied",
+		ProviderName: "temporal",
+		Target: coreworkflow.Target{
+			PluginName: "roadmap",
+			Operation:  "sync",
+			Connection: "analytics",
+			Instance:   "tenant-a",
+		},
+		SubjectID: principal.UserSubjectID(user.ID),
+	}); err != nil {
+		t.Fatalf("Put execution ref: %v", err)
+	}
+	if err := services.Tokens.StoreToken(context.Background(), &core.IntegrationToken{
+		UserID:      user.ID,
+		Integration: "roadmap",
+		Connection:  "analytics",
+		Instance:    "tenant-a",
+		AccessToken: "user-token",
+	}); err != nil {
+		t.Fatalf("StoreToken: %v", err)
+	}
+
+	providers := registry.New()
+	executed := false
+	if err := providers.Providers.Register("roadmap", &coretesting.StubIntegration{
+		N:        "roadmap",
+		ConnMode: core.ConnectionModeUser,
+		CatalogVal: &catalog.Catalog{
+			Name: "roadmap",
+			Operations: []catalog.CatalogOperation{
+				{ID: "sync", Method: http.MethodPost},
+			},
+		},
+		ExecuteFn: func(context.Context, string, map[string]any, string) (*core.OperationResult, error) {
+			executed = true
+			return &core.OperationResult{Status: http.StatusAccepted, Body: `{"ok":true}`}, nil
+		},
+	}); err != nil {
+		t.Fatalf("Register provider: %v", err)
+	}
+
+	authz, err := authorization.New(config.AuthorizationConfig{
+		Policies: map[string]config.HumanPolicyDef{
+			"roadmap-policy": {
+				Default: "deny",
+				Members: []config.HumanPolicyMemberDef{
+					{Email: "other@example.test", Role: "viewer"},
+				},
+			},
+		},
+	}, map[string]*config.ProviderEntry{
+		"roadmap": {AuthorizationPolicy: "roadmap-policy"},
+	}, &providers.Providers, nil)
+	if err != nil {
+		t.Fatalf("authorization.New: %v", err)
+	}
+
+	runtime := &workflowRuntime{
+		bindings: map[string]workflowBinding{
+			"roadmap": {
+				providerName: "temporal",
+				operations: map[string]struct{}{
+					"sync": {},
+				},
+			},
+		},
+		executionRefs: services.WorkflowExecutionRefs,
+	}
+	runtime.SetInvoker(invocation.NewBroker(&providers.Providers, services.Users, services.Tokens, invocation.WithAuthorizer(authz)))
+
+	_, err = runtime.Invoke(context.Background(), coreworkflow.InvokeOperationRequest{
+		ProviderName: "temporal",
+		PluginName:   "roadmap",
+		ExecutionRef: "exec-ref-denied",
+		Target: coreworkflow.Target{
+			PluginName: "roadmap",
+			Operation:  "sync",
+			Connection: "analytics",
+			Instance:   "tenant-a",
+		},
+	})
+	if err == nil {
+		t.Fatal("expected authorization error, got nil")
+	}
+	if !errors.Is(err, invocation.ErrAuthorizationDenied) {
+		t.Fatalf("error = %v, want ErrAuthorizationDenied", err)
+	}
+	if executed {
+		t.Fatal("expected provider execution to be skipped")
+	}
+}
+
+func TestWorkflowRuntimeInvokeExecutionRefPreservesTokenPermissionCeiling(t *testing.T) {
+	t.Parallel()
+
+	services := coretesting.NewStubServices(t)
+	ctx := context.Background()
+
+	if _, err := services.WorkflowExecutionRefs.Put(ctx, &coreworkflow.ExecutionReference{
+		ID:           "exec-ref-123",
+		ProviderName: "basic",
+		Target: coreworkflow.Target{
+			PluginName: "roadmap",
+			Operation:  "export",
+			Connection: "analytics",
+			Instance:   "tenant-a",
+		},
+		SubjectID: principal.UserSubjectID("user-123"),
+		Permissions: []core.AccessPermission{{
+			Plugin:     "roadmap",
+			Operations: []string{"sync"},
+		}},
+	}); err != nil {
+		t.Fatalf("Put execution ref: %v", err)
+	}
+
+	providers := registry.New()
+	executed := false
+	if err := providers.Providers.Register("roadmap", &coretesting.StubIntegration{
+		N: "roadmap",
+		CatalogVal: &catalog.Catalog{
+			Name: "roadmap",
+			Operations: []catalog.CatalogOperation{
+				{ID: "export", Method: http.MethodPost},
+			},
+		},
+		ExecuteFn: func(context.Context, string, map[string]any, string) (*core.OperationResult, error) {
+			executed = true
+			return &core.OperationResult{Status: http.StatusOK, Body: `{"ok":true}`}, nil
+		},
+	}); err != nil {
+		t.Fatalf("Register provider: %v", err)
+	}
+
+	broker := invocation.NewBroker(&providers.Providers, services.Users, services.Tokens)
+	runtime := &workflowRuntime{
+		bindings: map[string]workflowBinding{
+			"roadmap": {
+				providerName: "basic",
+				operations: map[string]struct{}{
+					"export": {},
+				},
+			},
+		},
+		invoker:       broker,
+		executionRefs: services.WorkflowExecutionRefs,
+	}
+
+	_, err := runtime.Invoke(ctx, coreworkflow.InvokeOperationRequest{
+		ProviderName: "basic",
+		PluginName:   "roadmap",
+		RunID:        "run-123",
+		Target: coreworkflow.Target{
+			PluginName: "roadmap",
+			Operation:  "export",
+			Connection: "analytics",
+			Instance:   "tenant-a",
+		},
+		ExecutionRef: "exec-ref-123",
+	})
+	if !errors.Is(err, invocation.ErrScopeDenied) {
+		t.Fatalf("Invoke error = %v, want scope denied", err)
+	}
+	if executed {
+		t.Fatal("expected provider Execute not to run when execution-ref permissions do not allow the operation")
+	}
+}
+
+func TestWorkflowRuntimeInvokeExecutionRefLookupInfrastructureErrorIsInternal(t *testing.T) {
+	t.Parallel()
+
+	lookupErr := errors.New("boom")
+	runtime := &workflowRuntime{
+		bindings: map[string]workflowBinding{
+			"roadmap": {
+				providerName: "basic",
+				operations: map[string]struct{}{
+					"sync": {},
+				},
+			},
+		},
+		executionRefs: coredata.NewWorkflowExecutionRefService(&erroringIndexedDB{err: lookupErr}),
+	}
+	runtime.SetInvoker(funcInvoker{
+		invoke: func(context.Context, *principal.Principal, string, string, string, map[string]any) (*core.OperationResult, error) {
+			t.Fatal("invoke should not be called when execution-ref lookup fails")
+			return nil, nil
+		},
+	})
+
+	_, err := runtime.Invoke(context.Background(), coreworkflow.InvokeOperationRequest{
+		ProviderName: "basic",
+		PluginName:   "roadmap",
+		ExecutionRef: "exec-ref-123",
+		Target: coreworkflow.Target{
+			PluginName: "roadmap",
+			Operation:  "sync",
+		},
+	})
+	if err == nil {
+		t.Fatal("expected internal error, got nil")
+	}
+	if !errors.Is(err, invocation.ErrInternal) {
+		t.Fatalf("error = %v, want ErrInternal", err)
+	}
+	if errors.Is(err, invocation.ErrAuthorizationDenied) {
+		t.Fatalf("error = %v, should not be ErrAuthorizationDenied", err)
 	}
 }
 

--- a/gestaltd/internal/coredata/schemas.go
+++ b/gestaltd/internal/coredata/schemas.go
@@ -17,6 +17,7 @@ const (
 	StoreIdentityPluginAccess       = "identity_plugin_access"
 	StoreAPITokenAccess             = "api_token_access"
 	StoreExternalCredentials        = "external_credentials"
+	StoreWorkflowExecutionRefs      = "workflow_execution_refs"
 )
 
 var UsersSchema = indexeddb.ObjectStoreSchema{
@@ -268,5 +269,23 @@ var ExternalCredentialsSchema = indexeddb.ObjectStoreSchema{
 		{Name: "metadata_json", Type: indexeddb.TypeString},
 		{Name: "created_at", Type: indexeddb.TypeTime},
 		{Name: "updated_at", Type: indexeddb.TypeTime},
+	},
+}
+
+var WorkflowExecutionRefsSchema = indexeddb.ObjectStoreSchema{
+	Indexes: []indexeddb.IndexSchema{
+		{Name: "by_subject", KeyPath: []string{"subject_id"}},
+	},
+	Columns: []indexeddb.ColumnDef{
+		{Name: "id", Type: indexeddb.TypeString, PrimaryKey: true},
+		{Name: "provider_name", Type: indexeddb.TypeString, NotNull: true},
+		{Name: "target_plugin", Type: indexeddb.TypeString, NotNull: true},
+		{Name: "target_operation", Type: indexeddb.TypeString, NotNull: true},
+		{Name: "target_connection", Type: indexeddb.TypeString},
+		{Name: "target_instance", Type: indexeddb.TypeString},
+		{Name: "subject_id", Type: indexeddb.TypeString, NotNull: true},
+		{Name: "permissions_json", Type: indexeddb.TypeString},
+		{Name: "created_at", Type: indexeddb.TypeTime},
+		{Name: "revoked_at", Type: indexeddb.TypeTime},
 	},
 }

--- a/gestaltd/internal/coredata/services.go
+++ b/gestaltd/internal/coredata/services.go
@@ -23,6 +23,7 @@ type Services struct {
 	IdentityPluginAccess     *IdentityPluginAccessService
 	APITokenAccess           *APITokenAccessService
 	ExternalCredentials      *ExternalCredentialService
+	WorkflowExecutionRefs    *WorkflowExecutionRefService
 	DB                       indexeddb.IndexedDB
 }
 
@@ -70,6 +71,9 @@ func New(ds indexeddb.IndexedDB, enc *corecrypto.AESGCMEncryptor) (*Services, er
 	if err := ds.CreateObjectStore(ctx, StoreExternalCredentials, ExternalCredentialsSchema); err != nil {
 		return nil, fmt.Errorf("create external_credentials store: %w", err)
 	}
+	if err := ds.CreateObjectStore(ctx, StoreWorkflowExecutionRefs, WorkflowExecutionRefsSchema); err != nil {
+		return nil, fmt.Errorf("create workflow_execution_refs store: %w", err)
+	}
 
 	identities := NewIdentityService(ds)
 	authBindings := NewIdentityAuthBindingService(ds)
@@ -79,6 +83,7 @@ func New(ds indexeddb.IndexedDB, enc *corecrypto.AESGCMEncryptor) (*Services, er
 	identityPluginAccess := NewIdentityPluginAccessService(ds)
 	apiTokenAccess := NewAPITokenAccessService(ds)
 	externalCredentials := NewExternalCredentialService(ds)
+	workflowExecutionRefs := NewWorkflowExecutionRefService(ds)
 
 	users := NewUserService(ds, identities, authBindings)
 	if err := users.BackfillNormalizedEmails(ctx); err != nil {
@@ -127,6 +132,7 @@ func New(ds indexeddb.IndexedDB, enc *corecrypto.AESGCMEncryptor) (*Services, er
 		IdentityPluginAccess:     identityPluginAccess,
 		APITokenAccess:           apiTokenAccess,
 		ExternalCredentials:      externalCredentials,
+		WorkflowExecutionRefs:    workflowExecutionRefs,
 		DB:                       ds,
 	}, nil
 }

--- a/gestaltd/internal/coredata/services_test.go
+++ b/gestaltd/internal/coredata/services_test.go
@@ -14,8 +14,10 @@ import (
 	corecrypto "github.com/valon-technologies/gestalt/server/core/crypto"
 	"github.com/valon-technologies/gestalt/server/core/indexeddb"
 	coretesting "github.com/valon-technologies/gestalt/server/core/testing"
+	coreworkflow "github.com/valon-technologies/gestalt/server/core/workflow"
 	"github.com/valon-technologies/gestalt/server/internal/coredata"
 	"github.com/valon-technologies/gestalt/server/internal/emailutil"
+	"github.com/valon-technologies/gestalt/server/internal/principal"
 )
 
 const testEncryptionKey = "0123456789abcdef0123456789abcdef"
@@ -1526,6 +1528,61 @@ func TestAPITokenService(t *testing.T) {
 		}
 		if token.ID == "" {
 			t.Error("ID should be auto-generated")
+		}
+	})
+}
+
+func TestWorkflowExecutionRefService(t *testing.T) {
+	t.Parallel()
+
+	t.Run("PutGet_round_trips_permissions", func(t *testing.T) {
+		t.Parallel()
+		svc := newTestServices(t)
+		ctx := context.Background()
+
+		ref, err := svc.WorkflowExecutionRefs.Put(ctx, &coreworkflow.ExecutionReference{
+			ID:           "exec-ref-123",
+			ProviderName: "basic",
+			Target: coreworkflow.Target{
+				PluginName: "roadmap",
+				Operation:  "sync",
+			},
+			SubjectID:   principal.UserSubjectID("user-123"),
+			Permissions: []core.AccessPermission{{Plugin: "roadmap", Operations: []string{"sync"}}},
+		})
+		if err != nil {
+			t.Fatalf("Put: %v", err)
+		}
+		if ref.SubjectID != principal.UserSubjectID("user-123") {
+			t.Fatalf("SubjectID = %q, want %q", ref.SubjectID, principal.UserSubjectID("user-123"))
+		}
+
+		got, err := svc.WorkflowExecutionRefs.Get(ctx, "exec-ref-123")
+		if err != nil {
+			t.Fatalf("Get: %v", err)
+		}
+		want := []core.AccessPermission{{Plugin: "roadmap", Operations: []string{"sync"}}}
+		if !reflect.DeepEqual(got.Permissions, want) {
+			t.Fatalf("Permissions = %#v, want %#v", got.Permissions, want)
+		}
+	})
+
+	t.Run("Put_rejects_non_user_subject", func(t *testing.T) {
+		t.Parallel()
+		svc := newTestServices(t)
+		ctx := context.Background()
+
+		_, err := svc.WorkflowExecutionRefs.Put(ctx, &coreworkflow.ExecutionReference{
+			ID:           "exec-ref-bad",
+			ProviderName: "basic",
+			Target: coreworkflow.Target{
+				PluginName: "roadmap",
+				Operation:  "sync",
+			},
+			SubjectID: principal.ManagedIdentitySubjectID("managed-123"),
+		})
+		if err == nil {
+			t.Fatal("expected Put to reject non-user subject_id")
 		}
 	})
 }

--- a/gestaltd/internal/coredata/workflow_execution_refs.go
+++ b/gestaltd/internal/coredata/workflow_execution_refs.go
@@ -1,0 +1,133 @@
+package coredata
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"strings"
+	"time"
+
+	"github.com/valon-technologies/gestalt/server/core"
+	"github.com/valon-technologies/gestalt/server/core/indexeddb"
+	coreworkflow "github.com/valon-technologies/gestalt/server/core/workflow"
+)
+
+type WorkflowExecutionRefService struct {
+	store indexeddb.ObjectStore
+}
+
+func NewWorkflowExecutionRefService(ds indexeddb.IndexedDB) *WorkflowExecutionRefService {
+	return &WorkflowExecutionRefService{store: ds.ObjectStore(StoreWorkflowExecutionRefs)}
+}
+
+func (s *WorkflowExecutionRefService) Put(ctx context.Context, ref *coreworkflow.ExecutionReference) (*coreworkflow.ExecutionReference, error) {
+	if ref == nil {
+		return nil, fmt.Errorf("put workflow execution ref: ref is required")
+	}
+
+	id := strings.TrimSpace(ref.ID)
+	providerName := strings.TrimSpace(ref.ProviderName)
+	targetPlugin := strings.TrimSpace(ref.Target.PluginName)
+	targetOperation := strings.TrimSpace(ref.Target.Operation)
+	subjectID := strings.TrimSpace(ref.SubjectID)
+	if id == "" || providerName == "" || targetPlugin == "" || targetOperation == "" || subjectID == "" {
+		return nil, fmt.Errorf("put workflow execution ref: id, provider_name, target.plugin_name, target.operation, and subject_id are required")
+	}
+	if workflowExecutionRefUserID(subjectID) == "" {
+		return nil, fmt.Errorf("put workflow execution ref: subject_id %q is not a user subject", subjectID)
+	}
+
+	permissionsJSON := ""
+	if len(ref.Permissions) > 0 {
+		raw, err := json.Marshal(ref.Permissions)
+		if err != nil {
+			return nil, fmt.Errorf("put workflow execution ref: marshal permissions: %w", err)
+		}
+		permissionsJSON = string(raw)
+	}
+
+	now := time.Now()
+	createdAt := ref.CreatedAt
+	if existing, err := s.store.Get(ctx, id); err == nil {
+		if created := recTime(existing, "created_at"); !created.IsZero() {
+			createdAt = &created
+		}
+	} else if err != indexeddb.ErrNotFound {
+		return nil, fmt.Errorf("put workflow execution ref: %w", err)
+	}
+	if createdAt == nil || createdAt.IsZero() {
+		createdAt = &now
+	}
+
+	rec := indexeddb.Record{
+		"id":                id,
+		"provider_name":     providerName,
+		"target_plugin":     targetPlugin,
+		"target_operation":  targetOperation,
+		"target_connection": strings.TrimSpace(ref.Target.Connection),
+		"target_instance":   strings.TrimSpace(ref.Target.Instance),
+		"subject_id":        subjectID,
+		"permissions_json":  permissionsJSON,
+		"created_at":        *createdAt,
+		"revoked_at":        timeOrNil(ref.RevokedAt),
+	}
+	if err := s.store.Put(ctx, rec); err != nil {
+		return nil, fmt.Errorf("put workflow execution ref: %w", err)
+	}
+	return recordToWorkflowExecutionRef(rec), nil
+}
+
+func (s *WorkflowExecutionRefService) Get(ctx context.Context, id string) (*coreworkflow.ExecutionReference, error) {
+	rec, err := s.store.Get(ctx, strings.TrimSpace(id))
+	if err != nil {
+		if err == indexeddb.ErrNotFound {
+			return nil, indexeddb.ErrNotFound
+		}
+		return nil, fmt.Errorf("get workflow execution ref: %w", err)
+	}
+	return recordToWorkflowExecutionRef(rec), nil
+}
+
+func recordToWorkflowExecutionRef(rec indexeddb.Record) *coreworkflow.ExecutionReference {
+	return &coreworkflow.ExecutionReference{
+		ID:           recString(rec, "id"),
+		ProviderName: recString(rec, "provider_name"),
+		Target: coreworkflow.Target{
+			PluginName: recString(rec, "target_plugin"),
+			Operation:  recString(rec, "target_operation"),
+			Connection: recString(rec, "target_connection"),
+			Instance:   recString(rec, "target_instance"),
+		},
+		SubjectID:   recString(rec, "subject_id"),
+		Permissions: recWorkflowExecutionRefPermissions(rec),
+		CreatedAt:   recTimePtr(rec, "created_at"),
+		RevokedAt:   recTimePtr(rec, "revoked_at"),
+	}
+}
+
+func recWorkflowExecutionRefPermissions(rec indexeddb.Record) []core.AccessPermission {
+	raw := recString(rec, "permissions_json")
+	if raw == "" {
+		return nil
+	}
+	var permissions []core.AccessPermission
+	if err := json.Unmarshal([]byte(raw), &permissions); err != nil {
+		return nil
+	}
+	return permissions
+}
+
+func workflowExecutionRefUserID(subjectID string) string {
+	const prefix = "user:"
+	if !strings.HasPrefix(subjectID, prefix) {
+		return ""
+	}
+	return strings.TrimPrefix(subjectID, prefix)
+}
+
+func timeOrNil(value *time.Time) any {
+	if value == nil || value.IsZero() {
+		return nil
+	}
+	return *value
+}

--- a/gestaltd/internal/principal/principal.go
+++ b/gestaltd/internal/principal/principal.go
@@ -56,6 +56,21 @@ func (s Source) String() string {
 	}
 }
 
+func ParseSource(value string) Source {
+	switch strings.TrimSpace(value) {
+	case SourceSession.String():
+		return SourceSession
+	case SourceAPIToken.String():
+		return SourceAPIToken
+	case SourceWorkloadToken.String():
+		return SourceWorkloadToken
+	case SourceEnv.String():
+		return SourceEnv
+	default:
+		return SourceUnknown
+	}
+}
+
 func (p *Principal) AuthSource() string {
 	if p == nil {
 		return ""
@@ -71,6 +86,13 @@ func UserSubjectID(userID string) string {
 		return ""
 	}
 	return string(KindUser) + ":" + userID
+}
+
+func UserIDFromSubjectID(subjectID string) string {
+	if !strings.HasPrefix(subjectID, string(KindUser)+":") {
+		return ""
+	}
+	return strings.TrimPrefix(subjectID, string(KindUser)+":")
 }
 
 func WorkloadSubjectID(workloadID string) string {

--- a/gestaltd/internal/providerhost/workflow_server_test.go
+++ b/gestaltd/internal/providerhost/workflow_server_test.go
@@ -935,6 +935,29 @@ func TestWorkflowHostServerMapsInvocationErrors(t *testing.T) {
 	}
 }
 
+func TestWorkflowHostServerMapsInternalInvocationErrors(t *testing.T) {
+	t.Parallel()
+
+	srv := NewWorkflowHostServer(
+		"temporal",
+		func(context.Context, coreworkflow.InvokeOperationRequest) (*coreworkflow.InvokeOperationResponse, error) {
+			return nil, invocation.ErrInternal
+		},
+		func(string, string, string) bool { return true },
+	)
+
+	_, err := srv.InvokeOperation(context.Background(), &proto.InvokeWorkflowOperationRequest{
+		PluginName: "roadmap",
+		Target: &proto.BoundWorkflowTarget{
+			PluginName: "roadmap",
+			Operation:  "sync",
+		},
+	})
+	if status.Code(err) != codes.Internal {
+		t.Fatalf("status code = %v, want %v", status.Code(err), codes.Internal)
+	}
+}
+
 func TestWorkflowServerPublishEventScopesPlugin(t *testing.T) {
 	t.Parallel()
 

--- a/gestaltd/internal/server/handlers_workflow.go
+++ b/gestaltd/internal/server/handlers_workflow.go
@@ -1,0 +1,611 @@
+package server
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"maps"
+	"net/http"
+	"sort"
+	"strings"
+	"time"
+
+	"github.com/go-chi/chi/v5"
+	"github.com/google/uuid"
+	"github.com/valon-technologies/gestalt/server/core"
+	"github.com/valon-technologies/gestalt/server/core/indexeddb"
+	coreworkflow "github.com/valon-technologies/gestalt/server/core/workflow"
+	"github.com/valon-technologies/gestalt/server/internal/config"
+	"github.com/valon-technologies/gestalt/server/internal/invocation"
+	"github.com/valon-technologies/gestalt/server/internal/principal"
+)
+
+type workflowScheduleTargetRequest struct {
+	Operation  string         `json:"operation"`
+	Connection string         `json:"connection,omitempty"`
+	Instance   string         `json:"instance,omitempty"`
+	Input      map[string]any `json:"input,omitempty"`
+}
+
+type workflowScheduleUpsertRequest struct {
+	Cron     string                        `json:"cron"`
+	Timezone string                        `json:"timezone,omitempty"`
+	Target   workflowScheduleTargetRequest `json:"target"`
+	Paused   bool                          `json:"paused,omitempty"`
+}
+
+type workflowScheduleTargetInfo struct {
+	Operation  string         `json:"operation"`
+	Connection string         `json:"connection,omitempty"`
+	Instance   string         `json:"instance,omitempty"`
+	Input      map[string]any `json:"input,omitempty"`
+}
+
+type workflowScheduleInfo struct {
+	ID        string                     `json:"id"`
+	Provider  string                     `json:"provider"`
+	Cron      string                     `json:"cron"`
+	Timezone  string                     `json:"timezone,omitempty"`
+	Target    workflowScheduleTargetInfo `json:"target"`
+	Paused    bool                       `json:"paused"`
+	CreatedAt *time.Time                 `json:"createdAt,omitempty"`
+	UpdatedAt *time.Time                 `json:"updatedAt,omitempty"`
+	NextRunAt *time.Time                 `json:"nextRunAt,omitempty"`
+}
+
+func (s *Server) listWorkflowSchedules(w http.ResponseWriter, r *http.Request) {
+	pluginName := strings.TrimSpace(chi.URLParam(r, "integration"))
+	p, ok := s.resolveWorkflowScheduleActor(w, r)
+	if !ok {
+		return
+	}
+	providerName, provider, _, ok := s.resolveWorkflowScheduleProvider(w, pluginName)
+	if !ok {
+		return
+	}
+	if !s.allowProviderContext(r.Context(), p, pluginName) {
+		writeError(w, http.StatusForbidden, errOperationAccess.Error())
+		return
+	}
+
+	schedules, err := provider.ListSchedules(r.Context(), coreworkflow.ListSchedulesRequest{PluginName: pluginName})
+	if err != nil {
+		s.writeWorkflowScheduleProviderError(w, pluginName, "", err)
+		return
+	}
+
+	out := make([]workflowScheduleInfo, 0, len(schedules))
+	for _, schedule := range schedules {
+		owned, _, err := s.workflowScheduleOwner(r.Context(), p, schedule)
+		if err != nil {
+			writeError(w, http.StatusInternalServerError, "failed to resolve workflow schedule owner")
+			return
+		}
+		if !owned || !s.allowWorkflowScheduleTarget(r.Context(), p, schedule.Target) {
+			continue
+		}
+		out = append(out, workflowScheduleInfoFromCore(schedule, providerName))
+	}
+	sort.Slice(out, func(i, j int) bool {
+		if out[i].CreatedAt != nil && out[j].CreatedAt != nil && !out[i].CreatedAt.Equal(*out[j].CreatedAt) {
+			return out[i].CreatedAt.Before(*out[j].CreatedAt)
+		}
+		return out[i].ID < out[j].ID
+	})
+	writeJSON(w, http.StatusOK, out)
+}
+
+func (s *Server) createWorkflowSchedule(w http.ResponseWriter, r *http.Request) {
+	pluginName := strings.TrimSpace(chi.URLParam(r, "integration"))
+	p, ok := s.resolveWorkflowScheduleActor(w, r)
+	if !ok {
+		return
+	}
+	providerName, provider, allowed, ok := s.resolveWorkflowScheduleProvider(w, pluginName)
+	if !ok {
+		return
+	}
+
+	var req workflowScheduleUpsertRequest
+	if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
+		writeError(w, http.StatusBadRequest, "invalid JSON body")
+		return
+	}
+
+	target, err := s.resolveWorkflowScheduleTarget(r.Context(), pluginName, allowed, p, req.Target)
+	if err != nil {
+		s.writeWorkflowScheduleTargetError(w, r, pluginName, strings.TrimSpace(req.Target.Operation), err)
+		return
+	}
+
+	scheduleID := uuid.NewString()
+	executionRefID := workflowScheduleExecutionRefID(scheduleID)
+	ref, err := s.putWorkflowExecutionRef(r.Context(), executionRefID, providerName, target, p)
+	if err != nil {
+		writeError(w, http.StatusInternalServerError, "failed to store workflow execution reference")
+		return
+	}
+
+	schedule, err := provider.UpsertSchedule(r.Context(), coreworkflow.UpsertScheduleRequest{
+		ScheduleID:   scheduleID,
+		Cron:         strings.TrimSpace(req.Cron),
+		Timezone:     strings.TrimSpace(req.Timezone),
+		Target:       target,
+		Paused:       req.Paused,
+		RequestedBy:  workflowActorFromPrincipal(p),
+		ExecutionRef: executionRefID,
+	})
+	if err != nil {
+		s.revokeWorkflowExecutionRef(r.Context(), ref)
+		s.writeWorkflowScheduleProviderError(w, pluginName, scheduleID, err)
+		return
+	}
+	writeJSON(w, http.StatusCreated, workflowScheduleInfoFromCore(schedule, providerName))
+}
+
+func (s *Server) getWorkflowSchedule(w http.ResponseWriter, r *http.Request) {
+	pluginName := strings.TrimSpace(chi.URLParam(r, "integration"))
+	p, ok := s.resolveWorkflowScheduleActor(w, r)
+	if !ok {
+		return
+	}
+	providerName, provider, _, ok := s.resolveWorkflowScheduleProvider(w, pluginName)
+	if !ok {
+		return
+	}
+	schedule, _, ok := s.requireOwnedWorkflowSchedule(r.Context(), w, provider, pluginName, chi.URLParam(r, "scheduleID"), p)
+	if !ok {
+		return
+	}
+	writeJSON(w, http.StatusOK, workflowScheduleInfoFromCore(schedule, providerName))
+}
+
+func (s *Server) updateWorkflowSchedule(w http.ResponseWriter, r *http.Request) {
+	pluginName := strings.TrimSpace(chi.URLParam(r, "integration"))
+	p, ok := s.resolveWorkflowScheduleActor(w, r)
+	if !ok {
+		return
+	}
+	providerName, provider, allowed, ok := s.resolveWorkflowScheduleProvider(w, pluginName)
+	if !ok {
+		return
+	}
+	scheduleID := chi.URLParam(r, "scheduleID")
+	existing, ref, ok := s.requireOwnedWorkflowSchedule(r.Context(), w, provider, pluginName, scheduleID, p)
+	if !ok {
+		return
+	}
+
+	var req workflowScheduleUpsertRequest
+	if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
+		writeError(w, http.StatusBadRequest, "invalid JSON body")
+		return
+	}
+	target, err := s.resolveWorkflowScheduleTarget(r.Context(), pluginName, allowed, p, req.Target)
+	if err != nil {
+		s.writeWorkflowScheduleTargetError(w, r, pluginName, strings.TrimSpace(req.Target.Operation), err)
+		return
+	}
+
+	executionRefID := workflowScheduleExecutionRefID(strings.TrimSpace(existing.ID))
+	nextRef, err := s.putWorkflowExecutionRef(r.Context(), executionRefID, providerName, target, p)
+	if err != nil {
+		writeError(w, http.StatusInternalServerError, "failed to store workflow execution reference")
+		return
+	}
+
+	schedule, err := provider.UpsertSchedule(r.Context(), coreworkflow.UpsertScheduleRequest{
+		ScheduleID:   strings.TrimSpace(existing.ID),
+		Cron:         strings.TrimSpace(req.Cron),
+		Timezone:     strings.TrimSpace(req.Timezone),
+		Target:       target,
+		Paused:       req.Paused,
+		RequestedBy:  workflowActorFromPrincipal(p),
+		ExecutionRef: executionRefID,
+	})
+	if err != nil {
+		s.revokeWorkflowExecutionRef(r.Context(), nextRef)
+		s.writeWorkflowScheduleProviderError(w, pluginName, strings.TrimSpace(existing.ID), err)
+		return
+	}
+	if ref != nil && ref.ID != "" && ref.ID != executionRefID {
+		s.revokeWorkflowExecutionRef(r.Context(), ref)
+	}
+	writeJSON(w, http.StatusOK, workflowScheduleInfoFromCore(schedule, providerName))
+}
+
+func (s *Server) deleteWorkflowSchedule(w http.ResponseWriter, r *http.Request) {
+	pluginName := strings.TrimSpace(chi.URLParam(r, "integration"))
+	p, ok := s.resolveWorkflowScheduleActor(w, r)
+	if !ok {
+		return
+	}
+	_, provider, _, ok := s.resolveWorkflowScheduleProvider(w, pluginName)
+	if !ok {
+		return
+	}
+	schedule, ref, ok := s.requireOwnedWorkflowSchedule(r.Context(), w, provider, pluginName, chi.URLParam(r, "scheduleID"), p)
+	if !ok {
+		return
+	}
+	if err := provider.DeleteSchedule(r.Context(), coreworkflow.DeleteScheduleRequest{
+		PluginName: pluginName,
+		ScheduleID: strings.TrimSpace(schedule.ID),
+	}); err != nil {
+		s.writeWorkflowScheduleProviderError(w, pluginName, strings.TrimSpace(schedule.ID), err)
+		return
+	}
+	if ref != nil && ref.ID != "" {
+		s.revokeWorkflowExecutionRef(r.Context(), ref)
+	}
+	writeJSON(w, http.StatusOK, map[string]string{"status": "deleted"})
+}
+
+func (s *Server) pauseWorkflowSchedule(w http.ResponseWriter, r *http.Request) {
+	pluginName := strings.TrimSpace(chi.URLParam(r, "integration"))
+	p, ok := s.resolveWorkflowScheduleActor(w, r)
+	if !ok {
+		return
+	}
+	providerName, provider, _, ok := s.resolveWorkflowScheduleProvider(w, pluginName)
+	if !ok {
+		return
+	}
+	schedule, _, ok := s.requireOwnedWorkflowSchedule(r.Context(), w, provider, pluginName, chi.URLParam(r, "scheduleID"), p)
+	if !ok {
+		return
+	}
+	value, err := provider.PauseSchedule(r.Context(), coreworkflow.PauseScheduleRequest{
+		PluginName: pluginName,
+		ScheduleID: strings.TrimSpace(schedule.ID),
+	})
+	if err != nil {
+		s.writeWorkflowScheduleProviderError(w, pluginName, strings.TrimSpace(schedule.ID), err)
+		return
+	}
+	writeJSON(w, http.StatusOK, workflowScheduleInfoFromCore(value, providerName))
+}
+
+func (s *Server) resumeWorkflowSchedule(w http.ResponseWriter, r *http.Request) {
+	pluginName := strings.TrimSpace(chi.URLParam(r, "integration"))
+	p, ok := s.resolveWorkflowScheduleActor(w, r)
+	if !ok {
+		return
+	}
+	providerName, provider, _, ok := s.resolveWorkflowScheduleProvider(w, pluginName)
+	if !ok {
+		return
+	}
+	schedule, _, ok := s.requireOwnedWorkflowSchedule(r.Context(), w, provider, pluginName, chi.URLParam(r, "scheduleID"), p)
+	if !ok {
+		return
+	}
+	value, err := provider.ResumeSchedule(r.Context(), coreworkflow.ResumeScheduleRequest{
+		PluginName: pluginName,
+		ScheduleID: strings.TrimSpace(schedule.ID),
+	})
+	if err != nil {
+		s.writeWorkflowScheduleProviderError(w, pluginName, strings.TrimSpace(schedule.ID), err)
+		return
+	}
+	writeJSON(w, http.StatusOK, workflowScheduleInfoFromCore(value, providerName))
+}
+
+func (s *Server) resolveWorkflowScheduleActor(w http.ResponseWriter, r *http.Request) (*principal.Principal, bool) {
+	p := PrincipalFromContext(r.Context())
+	if p == nil {
+		writeError(w, http.StatusUnauthorized, "missing authorization")
+		return nil, false
+	}
+	if strings.TrimSpace(p.SubjectID) == "" && strings.TrimSpace(p.UserID) != "" {
+		cloned := *p
+		cloned.SubjectID = principal.UserSubjectID(strings.TrimSpace(p.UserID))
+		p = &cloned
+	}
+	if strings.TrimSpace(p.SubjectID) == "" {
+		writeError(w, http.StatusUnauthorized, "missing subject")
+		return nil, false
+	}
+	return p, true
+}
+
+func (s *Server) resolveWorkflowScheduleProvider(w http.ResponseWriter, pluginName string) (string, coreworkflow.Provider, map[string]struct{}, bool) {
+	if _, ok := s.getProvider(w, pluginName); !ok {
+		return "", nil, nil, false
+	}
+	if s.workflow == nil {
+		writeError(w, http.StatusPreconditionFailed, fmt.Sprintf("workflow is not configured for integration %q", pluginName))
+		return "", nil, nil, false
+	}
+	providerName, allowed, err := s.workflow.ResolveBinding(pluginName)
+	if err != nil {
+		writeError(w, http.StatusPreconditionFailed, err.Error())
+		return "", nil, nil, false
+	}
+	provider, err := s.workflow.ResolveProvider(providerName)
+	if err != nil {
+		writeError(w, http.StatusPreconditionFailed, err.Error())
+		return "", nil, nil, false
+	}
+	return providerName, provider, allowed, true
+}
+
+func (s *Server) resolveWorkflowScheduleTarget(
+	ctx context.Context,
+	pluginName string,
+	allowed map[string]struct{},
+	p *principal.Principal,
+	target workflowScheduleTargetRequest,
+) (coreworkflow.Target, error) {
+	prov, err := s.providers.Get(pluginName)
+	if err != nil {
+		if errors.Is(err, core.ErrNotFound) {
+			return coreworkflow.Target{}, fmt.Errorf("%w: %q", invocation.ErrProviderNotFound, pluginName)
+		}
+		return coreworkflow.Target{}, fmt.Errorf("%w: looking up provider: %v", invocation.ErrInternal, err)
+	}
+
+	operation := strings.TrimSpace(target.Operation)
+	if operation == "" {
+		return coreworkflow.Target{}, fmt.Errorf("%w: workflow target operation is required", invocation.ErrOperationNotFound)
+	}
+	if !s.allowProviderContext(ctx, p, pluginName) || !s.allowOperationContext(ctx, p, pluginName, operation) {
+		return coreworkflow.Target{}, invocation.ErrAuthorizationDenied
+	}
+
+	connection := strings.TrimSpace(target.Connection)
+	if connection != "" && !safeParamValue.MatchString(connection) {
+		return coreworkflow.Target{}, fmt.Errorf("connection name contains invalid characters")
+	}
+	connection = config.ResolveConnectionAlias(connection)
+	instance := strings.TrimSpace(target.Instance)
+	if instance != "" && !safeInstanceValue.MatchString(instance) {
+		return coreworkflow.Target{}, fmt.Errorf("instance name contains invalid characters")
+	}
+
+	access := s.providerAccessContextWithContext(ctx, p, pluginName)
+	ctx = invocation.WithAccessContext(ctx, access)
+	var resolver invocation.TokenResolver
+	if tr, ok := s.invoker.(invocation.TokenResolver); ok {
+		resolver = tr
+	}
+	boundConnections, sessionInstance := s.boundSessionCatalogConnections(pluginName, p, connection, instance)
+	opMeta, _, resolvedConnection, err := invocation.ResolveOperation(ctx, prov, pluginName, resolver, p, operation, boundConnections, sessionInstance)
+	if err != nil {
+		return coreworkflow.Target{}, err
+	}
+	if _, ok := allowed[opMeta.ID]; !ok {
+		return coreworkflow.Target{}, fmt.Errorf("%w: workflow target operation %q is not enabled", invocation.ErrAuthorizationDenied, opMeta.ID)
+	}
+	if !principal.AllowsOperationPermission(p, pluginName, opMeta.ID) {
+		return coreworkflow.Target{}, fmt.Errorf("%w: %s.%s", invocation.ErrAuthorizationDenied, pluginName, opMeta.ID)
+	}
+	if s.authorizer != nil && !s.authorizer.AllowCatalogOperation(ctx, p, pluginName, opMeta) {
+		return coreworkflow.Target{}, fmt.Errorf("%w: %s.%s", invocation.ErrAuthorizationDenied, pluginName, opMeta.ID)
+	}
+	if connection == "" {
+		connection = resolvedConnection
+	}
+	if resolver != nil && sessionInstance == "" {
+		resolvedCtx, _, err := resolver.ResolveToken(ctx, p, pluginName, connection, sessionInstance)
+		if err != nil {
+			return coreworkflow.Target{}, err
+		}
+		cred := invocation.CredentialContextFromContext(resolvedCtx)
+		if cred.Connection != "" {
+			connection = cred.Connection
+		}
+		if cred.Instance != "" {
+			sessionInstance = cred.Instance
+		}
+	}
+	return coreworkflow.Target{
+		PluginName: pluginName,
+		Operation:  opMeta.ID,
+		Connection: connection,
+		Instance:   sessionInstance,
+		Input:      maps.Clone(target.Input),
+	}, nil
+}
+
+func (s *Server) requireOwnedWorkflowSchedule(
+	ctx context.Context,
+	w http.ResponseWriter,
+	provider coreworkflow.Provider,
+	pluginName string,
+	scheduleID string,
+	p *principal.Principal,
+) (*coreworkflow.Schedule, *coreworkflow.ExecutionReference, bool) {
+	scheduleID = strings.TrimSpace(scheduleID)
+	if scheduleID == "" {
+		writeError(w, http.StatusBadRequest, "scheduleID is required")
+		return nil, nil, false
+	}
+	if !s.allowProviderContext(ctx, p, pluginName) {
+		writeError(w, http.StatusForbidden, errOperationAccess.Error())
+		return nil, nil, false
+	}
+	schedule, err := provider.GetSchedule(ctx, coreworkflow.GetScheduleRequest{
+		PluginName: pluginName,
+		ScheduleID: scheduleID,
+	})
+	if err != nil {
+		s.writeWorkflowScheduleProviderError(w, pluginName, scheduleID, err)
+		return nil, nil, false
+	}
+	owned, ref, err := s.workflowScheduleOwner(ctx, p, schedule)
+	if err != nil {
+		writeError(w, http.StatusInternalServerError, "failed to resolve workflow schedule owner")
+		return nil, nil, false
+	}
+	if !owned {
+		writeError(w, http.StatusNotFound, fmt.Sprintf("workflow schedule %q not found", scheduleID))
+		return nil, nil, false
+	}
+	if !s.allowWorkflowScheduleTarget(ctx, p, schedule.Target) {
+		writeError(w, http.StatusNotFound, fmt.Sprintf("workflow schedule %q not found", scheduleID))
+		return nil, nil, false
+	}
+	return schedule, ref, true
+}
+
+func (s *Server) workflowScheduleOwner(ctx context.Context, p *principal.Principal, schedule *coreworkflow.Schedule) (bool, *coreworkflow.ExecutionReference, error) {
+	if schedule == nil || strings.TrimSpace(schedule.ExecutionRef) == "" {
+		return false, nil, nil
+	}
+	if s.workflowExecutionRefs == nil {
+		return false, nil, fmt.Errorf("workflow execution refs are not configured")
+	}
+	ref, err := s.workflowExecutionRefs.Get(ctx, schedule.ExecutionRef)
+	if err != nil {
+		if err == indexeddb.ErrNotFound {
+			return false, nil, nil
+		}
+		return false, nil, err
+	}
+	return workflowExecutionRefOwnedBy(ref, p), ref, nil
+}
+
+func (s *Server) allowWorkflowScheduleTarget(ctx context.Context, p *principal.Principal, target coreworkflow.Target) bool {
+	pluginName := strings.TrimSpace(target.PluginName)
+	operation := strings.TrimSpace(target.Operation)
+	if pluginName == "" || operation == "" {
+		return false
+	}
+	if !s.allowProviderContext(ctx, p, pluginName) || !s.allowOperationContext(ctx, p, pluginName, operation) {
+		return false
+	}
+	return principal.AllowsOperationPermission(p, pluginName, operation)
+}
+
+func workflowExecutionRefOwnedBy(ref *coreworkflow.ExecutionReference, p *principal.Principal) bool {
+	if ref == nil || p == nil {
+		return false
+	}
+	subjectID := strings.TrimSpace(p.SubjectID)
+	return subjectID != "" && strings.TrimSpace(ref.SubjectID) == subjectID
+}
+
+func (s *Server) putWorkflowExecutionRef(
+	ctx context.Context,
+	executionRefID string,
+	providerName string,
+	target coreworkflow.Target,
+	p *principal.Principal,
+) (*coreworkflow.ExecutionReference, error) {
+	if s.workflowExecutionRefs == nil {
+		return nil, fmt.Errorf("workflow execution refs are not configured")
+	}
+	subjectID := workflowExecutionRefSubjectID(p)
+	if subjectID == "" {
+		return nil, fmt.Errorf("workflow execution ref subject is required")
+	}
+	return s.workflowExecutionRefs.Put(ctx, &coreworkflow.ExecutionReference{
+		ID:           executionRefID,
+		ProviderName: providerName,
+		Target:       target,
+		SubjectID:    subjectID,
+		Permissions:  principal.PermissionsToAccessPermissions(p.TokenPermissions),
+	})
+}
+
+func workflowExecutionRefSubjectID(p *principal.Principal) string {
+	if p == nil {
+		return ""
+	}
+	if value := strings.TrimSpace(p.SubjectID); value != "" {
+		return value
+	}
+	return principal.UserSubjectID(strings.TrimSpace(p.UserID))
+}
+
+func workflowScheduleExecutionRefID(scheduleID string) string {
+	return "workflow_schedule:" + strings.TrimSpace(scheduleID) + ":" + uuid.NewString()
+}
+
+func workflowActorFromPrincipal(p *principal.Principal) coreworkflow.Actor {
+	if p == nil {
+		return coreworkflow.Actor{}
+	}
+	return coreworkflow.Actor{
+		SubjectID:   strings.TrimSpace(p.SubjectID),
+		SubjectKind: string(p.Kind),
+		DisplayName: workflowActorDisplayName(p),
+		AuthSource:  p.AuthSource(),
+	}
+}
+
+func workflowActorDisplayName(p *principal.Principal) string {
+	if p == nil {
+		return ""
+	}
+	if value := strings.TrimSpace(p.DisplayName); value != "" {
+		return value
+	}
+	if p.Identity != nil {
+		return strings.TrimSpace(p.Identity.DisplayName)
+	}
+	return ""
+}
+
+func workflowScheduleInfoFromCore(schedule *coreworkflow.Schedule, providerName string) workflowScheduleInfo {
+	info := workflowScheduleInfo{
+		Provider: providerName,
+	}
+	if schedule == nil {
+		return info
+	}
+	info.ID = schedule.ID
+	info.Cron = schedule.Cron
+	info.Timezone = schedule.Timezone
+	info.Paused = schedule.Paused
+	info.CreatedAt = schedule.CreatedAt
+	info.UpdatedAt = schedule.UpdatedAt
+	info.NextRunAt = schedule.NextRunAt
+	info.Target = workflowScheduleTargetInfo{
+		Operation:  schedule.Target.Operation,
+		Connection: userFacingConnectionName(schedule.Target.Connection),
+		Instance:   schedule.Target.Instance,
+		Input:      maps.Clone(schedule.Target.Input),
+	}
+	return info
+}
+
+func (s *Server) revokeWorkflowExecutionRef(ctx context.Context, ref *coreworkflow.ExecutionReference) {
+	if s.workflowExecutionRefs == nil || ref == nil || strings.TrimSpace(ref.ID) == "" {
+		return
+	}
+	cloned := *ref
+	now := s.nowUTCSecond()
+	cloned.RevokedAt = &now
+	_, _ = s.workflowExecutionRefs.Put(ctx, &cloned)
+}
+
+func (s *Server) writeWorkflowScheduleProviderError(w http.ResponseWriter, pluginName, scheduleID string, err error) {
+	switch {
+	case errors.Is(err, core.ErrNotFound):
+		writeError(w, http.StatusNotFound, fmt.Sprintf("workflow schedule %q not found", scheduleID))
+	default:
+		writeError(w, http.StatusInternalServerError, fmt.Sprintf("workflow schedule request failed for integration %q", pluginName))
+	}
+}
+
+func (s *Server) writeWorkflowScheduleTargetError(w http.ResponseWriter, r *http.Request, pluginName, operation string, err error) {
+	switch {
+	case errors.Is(err, invocation.ErrProviderNotFound),
+		errors.Is(err, invocation.ErrOperationNotFound),
+		errors.Is(err, invocation.ErrNotAuthenticated),
+		errors.Is(err, invocation.ErrAuthorizationDenied),
+		errors.Is(err, invocation.ErrScopeDenied),
+		errors.Is(err, invocation.ErrNoToken),
+		errors.Is(err, invocation.ErrReconnectRequired),
+		errors.Is(err, invocation.ErrAmbiguousInstance),
+		errors.Is(err, invocation.ErrUserResolution),
+		errors.Is(err, invocation.ErrInternal),
+		errors.Is(err, core.ErrMCPOnly):
+		s.writeInvocationError(w, r, pluginName, operation, err)
+	default:
+		writeError(w, http.StatusBadRequest, err.Error())
+	}
+}

--- a/gestaltd/internal/server/routes_user.go
+++ b/gestaltd/internal/server/routes_user.go
@@ -10,6 +10,16 @@ func (s *Server) mountAuthenticatedRoutes(r chi.Router) {
 		r.Delete("/integrations/{name}", s.disconnectIntegration)
 		r.Get("/integrations/{name}/operations", s.listOperations)
 
+		r.Route("/{integration}/workflow/schedules", func(r chi.Router) {
+			r.Get("/", s.listWorkflowSchedules)
+			r.Post("/", s.createWorkflowSchedule)
+			r.Get("/{scheduleID}", s.getWorkflowSchedule)
+			r.Put("/{scheduleID}", s.updateWorkflowSchedule)
+			r.Delete("/{scheduleID}", s.deleteWorkflowSchedule)
+			r.Post("/{scheduleID}/pause", s.pauseWorkflowSchedule)
+			r.Post("/{scheduleID}/resume", s.resumeWorkflowSchedule)
+		})
+
 		r.Get("/{integration}/{operation}", s.executeOperation)
 		r.Post("/{integration}/{operation}", s.executeOperation)
 

--- a/gestaltd/internal/server/runtime.go
+++ b/gestaltd/internal/server/runtime.go
@@ -65,6 +65,7 @@ func Run(ctx context.Context, cfg *config.Config, result *bootstrap.Result) erro
 		AuditSink:         result.AuditSink,
 		Services:          result.Services,
 		Providers:         result.Providers,
+		Workflow:          result.WorkflowControl,
 		Invoker:           httpInvoker,
 		DefaultConnection: connMaps.DefaultConnection,
 		// HTTP routes expose REST-visible operations, so unqualified session-catalog

--- a/gestaltd/internal/server/server.go
+++ b/gestaltd/internal/server/server.go
@@ -72,9 +72,11 @@ type Server struct {
 	identityGrants        *coredata.ManagedIdentityGrantService
 	workspaceRoles        *coredata.WorkspaceRoleService
 	identityPluginAccess  *coredata.IdentityPluginAccessService
+	workflowExecutionRefs *coredata.WorkflowExecutionRefService
 	authorizationProvider core.AuthorizationProvider
 	managedIdentityMu     sync.Mutex
 	providers             *registry.ProviderMap[core.Provider]
+	workflow              bootstrap.WorkflowControl
 	resolver              *principal.Resolver
 	invoker               invocation.Invoker
 	defaultConnection     map[string]string
@@ -106,6 +108,7 @@ type Config struct {
 	AuditSink             core.AuditSink
 	Services              *coredata.Services
 	Providers             *registry.ProviderMap[core.Provider]
+	Workflow              bootstrap.WorkflowControl
 	Invoker               invocation.Invoker
 	DefaultConnection     map[string]string
 	CatalogConnection     map[string]string
@@ -190,6 +193,7 @@ func New(cfg Config) (*Server, error) {
 	identityGrants := cfg.Services.IdentityGrants
 	workspaceRoles := cfg.Services.WorkspaceRoles
 	identityPluginAccess := cfg.Services.IdentityPluginAccess
+	workflowExecutionRefs := cfg.Services.WorkflowExecutionRefs
 	resolver := principal.NewResolver(cfg.Auth, users, apiTokens, managedIdentities, identityGrants, cfg.Authorizer)
 
 	router := chi.NewRouter()
@@ -210,8 +214,10 @@ func New(cfg Config) (*Server, error) {
 		identityGrants:        identityGrants,
 		workspaceRoles:        workspaceRoles,
 		identityPluginAccess:  identityPluginAccess,
+		workflowExecutionRefs: workflowExecutionRefs,
 		authorizationProvider: cfg.AuthorizationProvider,
 		providers:             cfg.Providers,
+		workflow:              cfg.Workflow,
 		resolver:              resolver,
 		invoker:               cfg.Invoker,
 		defaultConnection:     cfg.DefaultConnection,

--- a/gestaltd/internal/server/workflow_schedule_test.go
+++ b/gestaltd/internal/server/workflow_schedule_test.go
@@ -1,0 +1,891 @@
+package server_test
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"errors"
+	"io"
+	"net/http"
+	"testing"
+	"time"
+
+	"github.com/valon-technologies/gestalt/server/core"
+	"github.com/valon-technologies/gestalt/server/core/catalog"
+	coretesting "github.com/valon-technologies/gestalt/server/core/testing"
+	coreworkflow "github.com/valon-technologies/gestalt/server/core/workflow"
+	"github.com/valon-technologies/gestalt/server/internal/principal"
+	"github.com/valon-technologies/gestalt/server/internal/server"
+	"github.com/valon-technologies/gestalt/server/internal/testutil"
+)
+
+type stubWorkflowControl struct {
+	providerName string
+	allowed      map[string]struct{}
+	provider     coreworkflow.Provider
+	bindingErr   error
+	providerErr  error
+}
+
+func (s *stubWorkflowControl) ResolveBinding(string) (string, map[string]struct{}, error) {
+	if s.bindingErr != nil {
+		return "", nil, s.bindingErr
+	}
+	return s.providerName, cloneWorkflowAllowed(s.allowed), nil
+}
+
+func (s *stubWorkflowControl) ResolveProvider(string) (coreworkflow.Provider, error) {
+	if s.providerErr != nil {
+		return nil, s.providerErr
+	}
+	return s.provider, nil
+}
+
+func cloneWorkflowAllowed(src map[string]struct{}) map[string]struct{} {
+	if src == nil {
+		return nil
+	}
+	dst := make(map[string]struct{}, len(src))
+	for key := range src {
+		dst[key] = struct{}{}
+	}
+	return dst
+}
+
+type memoryWorkflowProvider struct {
+	schedules     map[string]*coreworkflow.Schedule
+	upsertReqs    []coreworkflow.UpsertScheduleRequest
+	deleteReqs    []coreworkflow.DeleteScheduleRequest
+	pauseReqs     []coreworkflow.PauseScheduleRequest
+	resumeReqs    []coreworkflow.ResumeScheduleRequest
+	nextUpsertErr error
+}
+
+func newMemoryWorkflowProvider() *memoryWorkflowProvider {
+	return &memoryWorkflowProvider{schedules: map[string]*coreworkflow.Schedule{}}
+}
+
+func (p *memoryWorkflowProvider) StartRun(context.Context, coreworkflow.StartRunRequest) (*coreworkflow.Run, error) {
+	return nil, errors.New("not implemented")
+}
+
+func (p *memoryWorkflowProvider) GetRun(context.Context, coreworkflow.GetRunRequest) (*coreworkflow.Run, error) {
+	return nil, errors.New("not implemented")
+}
+
+func (p *memoryWorkflowProvider) ListRuns(context.Context, coreworkflow.ListRunsRequest) ([]*coreworkflow.Run, error) {
+	return nil, nil
+}
+
+func (p *memoryWorkflowProvider) CancelRun(context.Context, coreworkflow.CancelRunRequest) (*coreworkflow.Run, error) {
+	return nil, errors.New("not implemented")
+}
+
+func (p *memoryWorkflowProvider) UpsertSchedule(_ context.Context, req coreworkflow.UpsertScheduleRequest) (*coreworkflow.Schedule, error) {
+	p.upsertReqs = append(p.upsertReqs, req)
+	if p.nextUpsertErr != nil {
+		err := p.nextUpsertErr
+		p.nextUpsertErr = nil
+		return nil, err
+	}
+	now := time.Now().UTC().Truncate(time.Second)
+	existing := p.schedules[req.ScheduleID]
+	createdAt := &now
+	if existing != nil && existing.CreatedAt != nil {
+		createdAt = existing.CreatedAt
+	}
+	schedule := &coreworkflow.Schedule{
+		ID:           req.ScheduleID,
+		Cron:         req.Cron,
+		Timezone:     req.Timezone,
+		Target:       req.Target,
+		Paused:       req.Paused,
+		ExecutionRef: req.ExecutionRef,
+		CreatedBy:    req.RequestedBy,
+		CreatedAt:    createdAt,
+		UpdatedAt:    &now,
+	}
+	p.schedules[req.ScheduleID] = cloneWorkflowSchedule(schedule)
+	return cloneWorkflowSchedule(schedule), nil
+}
+
+func (p *memoryWorkflowProvider) GetSchedule(_ context.Context, req coreworkflow.GetScheduleRequest) (*coreworkflow.Schedule, error) {
+	schedule, ok := p.schedules[req.ScheduleID]
+	if !ok || schedule == nil || schedule.Target.PluginName != req.PluginName {
+		return nil, core.ErrNotFound
+	}
+	return cloneWorkflowSchedule(schedule), nil
+}
+
+func (p *memoryWorkflowProvider) ListSchedules(_ context.Context, req coreworkflow.ListSchedulesRequest) ([]*coreworkflow.Schedule, error) {
+	out := make([]*coreworkflow.Schedule, 0, len(p.schedules))
+	for _, schedule := range p.schedules {
+		if schedule != nil && schedule.Target.PluginName == req.PluginName {
+			out = append(out, cloneWorkflowSchedule(schedule))
+		}
+	}
+	return out, nil
+}
+
+func (p *memoryWorkflowProvider) DeleteSchedule(_ context.Context, req coreworkflow.DeleteScheduleRequest) error {
+	schedule, ok := p.schedules[req.ScheduleID]
+	if !ok || schedule == nil || schedule.Target.PluginName != req.PluginName {
+		return core.ErrNotFound
+	}
+	delete(p.schedules, req.ScheduleID)
+	p.deleteReqs = append(p.deleteReqs, req)
+	return nil
+}
+
+func (p *memoryWorkflowProvider) PauseSchedule(_ context.Context, req coreworkflow.PauseScheduleRequest) (*coreworkflow.Schedule, error) {
+	schedule, ok := p.schedules[req.ScheduleID]
+	if !ok || schedule == nil || schedule.Target.PluginName != req.PluginName {
+		return nil, core.ErrNotFound
+	}
+	now := time.Now().UTC().Truncate(time.Second)
+	schedule.Paused = true
+	schedule.UpdatedAt = &now
+	p.pauseReqs = append(p.pauseReqs, req)
+	return cloneWorkflowSchedule(schedule), nil
+}
+
+func (p *memoryWorkflowProvider) ResumeSchedule(_ context.Context, req coreworkflow.ResumeScheduleRequest) (*coreworkflow.Schedule, error) {
+	schedule, ok := p.schedules[req.ScheduleID]
+	if !ok || schedule == nil || schedule.Target.PluginName != req.PluginName {
+		return nil, core.ErrNotFound
+	}
+	now := time.Now().UTC().Truncate(time.Second)
+	schedule.Paused = false
+	schedule.UpdatedAt = &now
+	p.resumeReqs = append(p.resumeReqs, req)
+	return cloneWorkflowSchedule(schedule), nil
+}
+
+func (p *memoryWorkflowProvider) UpsertEventTrigger(context.Context, coreworkflow.UpsertEventTriggerRequest) (*coreworkflow.EventTrigger, error) {
+	return nil, errors.New("not implemented")
+}
+
+func (p *memoryWorkflowProvider) GetEventTrigger(context.Context, coreworkflow.GetEventTriggerRequest) (*coreworkflow.EventTrigger, error) {
+	return nil, errors.New("not implemented")
+}
+
+func (p *memoryWorkflowProvider) ListEventTriggers(context.Context, coreworkflow.ListEventTriggersRequest) ([]*coreworkflow.EventTrigger, error) {
+	return nil, nil
+}
+
+func (p *memoryWorkflowProvider) DeleteEventTrigger(context.Context, coreworkflow.DeleteEventTriggerRequest) error {
+	return errors.New("not implemented")
+}
+
+func (p *memoryWorkflowProvider) PauseEventTrigger(context.Context, coreworkflow.PauseEventTriggerRequest) (*coreworkflow.EventTrigger, error) {
+	return nil, errors.New("not implemented")
+}
+
+func (p *memoryWorkflowProvider) ResumeEventTrigger(context.Context, coreworkflow.ResumeEventTriggerRequest) (*coreworkflow.EventTrigger, error) {
+	return nil, errors.New("not implemented")
+}
+
+func (p *memoryWorkflowProvider) PublishEvent(context.Context, coreworkflow.PublishEventRequest) error {
+	return nil
+}
+
+func (p *memoryWorkflowProvider) Ping(context.Context) error { return nil }
+func (p *memoryWorkflowProvider) Close() error               { return nil }
+
+func cloneWorkflowSchedule(schedule *coreworkflow.Schedule) *coreworkflow.Schedule {
+	if schedule == nil {
+		return nil
+	}
+	cloned := *schedule
+	cloned.Target.Input = cloneMap(schedule.Target.Input)
+	if schedule.CreatedAt != nil {
+		value := *schedule.CreatedAt
+		cloned.CreatedAt = &value
+	}
+	if schedule.UpdatedAt != nil {
+		value := *schedule.UpdatedAt
+		cloned.UpdatedAt = &value
+	}
+	if schedule.NextRunAt != nil {
+		value := *schedule.NextRunAt
+		cloned.NextRunAt = &value
+	}
+	return &cloned
+}
+
+func cloneMap(src map[string]any) map[string]any {
+	if src == nil {
+		return nil
+	}
+	dst := make(map[string]any, len(src))
+	for key, value := range src {
+		dst[key] = value
+	}
+	return dst
+}
+
+type workflowScheduleResponse struct {
+	ID       string `json:"id"`
+	Provider string `json:"provider"`
+	Cron     string `json:"cron"`
+	Timezone string `json:"timezone"`
+	Target   struct {
+		Operation  string         `json:"operation"`
+		Connection string         `json:"connection"`
+		Instance   string         `json:"instance"`
+		Input      map[string]any `json:"input"`
+	} `json:"target"`
+	Paused bool `json:"paused"`
+}
+
+func TestWorkflowScheduleCRUD(t *testing.T) {
+	t.Parallel()
+
+	services := coretesting.NewStubServices(t)
+	user := seedUser(t, services, "ada@example.test")
+	provider := newMemoryWorkflowProvider()
+	ts := newTestServer(t, func(cfg *server.Config) {
+		cfg.Auth = &coretesting.StubAuthProvider{
+			N: "stub",
+			ValidateTokenFn: func(_ context.Context, token string) (*core.UserIdentity, error) {
+				if token != "ada-session" {
+					return nil, core.ErrNotFound
+				}
+				return &core.UserIdentity{Email: user.Email, DisplayName: "Ada"}, nil
+			},
+		}
+		cfg.Services = services
+		cfg.Providers = testutil.NewProviderRegistry(t, &coretesting.StubIntegration{
+			N:        "roadmap",
+			ConnMode: core.ConnectionModeUser,
+			CatalogVal: &catalog.Catalog{
+				Name: "roadmap",
+				Operations: []catalog.CatalogOperation{
+					{ID: "sync", Method: http.MethodPost},
+				},
+			},
+		})
+		cfg.Workflow = &stubWorkflowControl{
+			providerName: "basic",
+			allowed:      map[string]struct{}{"sync": {}},
+			provider:     provider,
+		}
+	})
+	testutil.CloseOnCleanup(t, ts)
+
+	createBody := bytes.NewBufferString(`{"cron":"*/5 * * * *","timezone":"UTC","target":{"operation":"sync","connection":"analytics","instance":"tenant-a","input":{"mode":"incremental"}}}`)
+	createReq, _ := http.NewRequest(http.MethodPost, ts.URL+"/api/v1/roadmap/workflow/schedules/", createBody)
+	createReq.Header.Set("Content-Type", "application/json")
+	createReq.AddCookie(&http.Cookie{Name: "session_token", Value: "ada-session"})
+	createResp, err := http.DefaultClient.Do(createReq)
+	if err != nil {
+		t.Fatalf("create request: %v", err)
+	}
+	defer func() { _ = createResp.Body.Close() }()
+	if createResp.StatusCode != http.StatusCreated {
+		body, _ := io.ReadAll(createResp.Body)
+		t.Fatalf("expected 201, got %d: %s", createResp.StatusCode, body)
+	}
+
+	var created workflowScheduleResponse
+	if err := json.NewDecoder(createResp.Body).Decode(&created); err != nil {
+		t.Fatalf("decode create response: %v", err)
+	}
+	if created.Provider != "basic" || created.Target.Operation != "sync" || created.Target.Connection != "analytics" || created.Target.Instance != "tenant-a" {
+		t.Fatalf("created schedule = %#v", created)
+	}
+	if len(provider.upsertReqs) != 1 {
+		t.Fatalf("upsert requests = %d, want 1", len(provider.upsertReqs))
+	}
+	createUpsert := provider.upsertReqs[len(provider.upsertReqs)-1]
+	if createUpsert.Target.PluginName != "roadmap" || createUpsert.Target.Operation != "sync" {
+		t.Fatalf("upsert target = %#v", createUpsert.Target)
+	}
+	if createUpsert.ExecutionRef == "" {
+		t.Fatal("expected execution ref to be stored on create")
+	}
+	ref, err := services.WorkflowExecutionRefs.Get(context.Background(), createUpsert.ExecutionRef)
+	if err != nil {
+		t.Fatalf("Get execution ref: %v", err)
+	}
+	if ref.SubjectID != principal.UserSubjectID(user.ID) {
+		t.Fatalf("execution ref = %#v", ref)
+	}
+
+	listReq, _ := http.NewRequest(http.MethodGet, ts.URL+"/api/v1/roadmap/workflow/schedules/", nil)
+	listReq.AddCookie(&http.Cookie{Name: "session_token", Value: "ada-session"})
+	listResp, err := http.DefaultClient.Do(listReq)
+	if err != nil {
+		t.Fatalf("list request: %v", err)
+	}
+	defer func() { _ = listResp.Body.Close() }()
+	if listResp.StatusCode != http.StatusOK {
+		t.Fatalf("expected 200, got %d", listResp.StatusCode)
+	}
+	var listed []workflowScheduleResponse
+	if err := json.NewDecoder(listResp.Body).Decode(&listed); err != nil {
+		t.Fatalf("decode list response: %v", err)
+	}
+	if len(listed) != 1 || listed[0].ID != created.ID {
+		t.Fatalf("listed schedules = %#v", listed)
+	}
+
+	updateBody := bytes.NewBufferString(`{"cron":"0 * * * *","timezone":"UTC","target":{"operation":"sync","connection":"analytics","instance":"tenant-a","input":{"mode":"full"}},"paused":true}`)
+	updateReq, _ := http.NewRequest(http.MethodPut, ts.URL+"/api/v1/roadmap/workflow/schedules/"+created.ID, updateBody)
+	updateReq.Header.Set("Content-Type", "application/json")
+	updateReq.AddCookie(&http.Cookie{Name: "session_token", Value: "ada-session"})
+	updateResp, err := http.DefaultClient.Do(updateReq)
+	if err != nil {
+		t.Fatalf("update request: %v", err)
+	}
+	defer func() { _ = updateResp.Body.Close() }()
+	if updateResp.StatusCode != http.StatusOK {
+		body, _ := io.ReadAll(updateResp.Body)
+		t.Fatalf("expected 200, got %d: %s", updateResp.StatusCode, body)
+	}
+	if len(provider.upsertReqs) != 2 {
+		t.Fatalf("upsert requests after update = %d, want 2", len(provider.upsertReqs))
+	}
+	updateUpsert := provider.upsertReqs[len(provider.upsertReqs)-1]
+	if updateUpsert.ExecutionRef == "" || updateUpsert.ExecutionRef == createUpsert.ExecutionRef {
+		t.Fatalf("update execution ref = %q, want rotated from %q", updateUpsert.ExecutionRef, createUpsert.ExecutionRef)
+	}
+	oldRef, err := services.WorkflowExecutionRefs.Get(context.Background(), createUpsert.ExecutionRef)
+	if err != nil {
+		t.Fatalf("Get rotated old ref: %v", err)
+	}
+	if oldRef.RevokedAt == nil || oldRef.RevokedAt.IsZero() {
+		t.Fatalf("expected rotated execution ref to be revoked, got %#v", oldRef)
+	}
+
+	pauseReq, _ := http.NewRequest(http.MethodPost, ts.URL+"/api/v1/roadmap/workflow/schedules/"+created.ID+"/pause", nil)
+	pauseReq.AddCookie(&http.Cookie{Name: "session_token", Value: "ada-session"})
+	pauseResp, err := http.DefaultClient.Do(pauseReq)
+	if err != nil {
+		t.Fatalf("pause request: %v", err)
+	}
+	defer func() { _ = pauseResp.Body.Close() }()
+	if pauseResp.StatusCode != http.StatusOK {
+		t.Fatalf("expected 200, got %d", pauseResp.StatusCode)
+	}
+
+	resumeReq, _ := http.NewRequest(http.MethodPost, ts.URL+"/api/v1/roadmap/workflow/schedules/"+created.ID+"/resume", nil)
+	resumeReq.AddCookie(&http.Cookie{Name: "session_token", Value: "ada-session"})
+	resumeResp, err := http.DefaultClient.Do(resumeReq)
+	if err != nil {
+		t.Fatalf("resume request: %v", err)
+	}
+	defer func() { _ = resumeResp.Body.Close() }()
+	if resumeResp.StatusCode != http.StatusOK {
+		t.Fatalf("expected 200, got %d", resumeResp.StatusCode)
+	}
+
+	deleteReq, _ := http.NewRequest(http.MethodDelete, ts.URL+"/api/v1/roadmap/workflow/schedules/"+created.ID, nil)
+	deleteReq.AddCookie(&http.Cookie{Name: "session_token", Value: "ada-session"})
+	deleteResp, err := http.DefaultClient.Do(deleteReq)
+	if err != nil {
+		t.Fatalf("delete request: %v", err)
+	}
+	defer func() { _ = deleteResp.Body.Close() }()
+	if deleteResp.StatusCode != http.StatusOK {
+		t.Fatalf("expected 200, got %d", deleteResp.StatusCode)
+	}
+	if _, ok := provider.schedules[created.ID]; ok {
+		t.Fatal("expected schedule to be deleted from provider")
+	}
+	ref, err = services.WorkflowExecutionRefs.Get(context.Background(), updateUpsert.ExecutionRef)
+	if err != nil {
+		t.Fatalf("Get revoked ref: %v", err)
+	}
+	if ref.RevokedAt == nil || ref.RevokedAt.IsZero() {
+		t.Fatalf("expected revoked execution ref, got %#v", ref)
+	}
+}
+
+func TestWorkflowScheduleListAndMutationsAreOwnerScoped(t *testing.T) {
+	t.Parallel()
+
+	services := coretesting.NewStubServices(t)
+	ada := seedUser(t, services, "ada@example.test")
+	grace := seedUser(t, services, "grace@example.test")
+	provider := newMemoryWorkflowProvider()
+	now := time.Now().UTC().Truncate(time.Second)
+	provider.schedules["sched-ada"] = &coreworkflow.Schedule{
+		ID:           "sched-ada",
+		Cron:         "*/5 * * * *",
+		Target:       coreworkflow.Target{PluginName: "roadmap", Operation: "sync"},
+		ExecutionRef: "exec-ada",
+		CreatedAt:    &now,
+		UpdatedAt:    &now,
+	}
+	provider.schedules["sched-grace"] = &coreworkflow.Schedule{
+		ID:           "sched-grace",
+		Cron:         "0 * * * *",
+		Target:       coreworkflow.Target{PluginName: "roadmap", Operation: "sync"},
+		ExecutionRef: "exec-grace",
+		CreatedAt:    &now,
+		UpdatedAt:    &now,
+	}
+	if _, err := services.WorkflowExecutionRefs.Put(context.Background(), &coreworkflow.ExecutionReference{
+		ID:           "exec-ada",
+		ProviderName: "basic",
+		Target:       provider.schedules["sched-ada"].Target,
+		SubjectID:    principal.UserSubjectID(ada.ID),
+	}); err != nil {
+		t.Fatalf("Put ada ref: %v", err)
+	}
+	if _, err := services.WorkflowExecutionRefs.Put(context.Background(), &coreworkflow.ExecutionReference{
+		ID:           "exec-grace",
+		ProviderName: "basic",
+		Target:       provider.schedules["sched-grace"].Target,
+		SubjectID:    principal.UserSubjectID(grace.ID),
+	}); err != nil {
+		t.Fatalf("Put grace ref: %v", err)
+	}
+
+	ts := newTestServer(t, func(cfg *server.Config) {
+		cfg.Auth = &coretesting.StubAuthProvider{
+			N: "stub",
+			ValidateTokenFn: func(_ context.Context, token string) (*core.UserIdentity, error) {
+				switch token {
+				case "ada-session":
+					return &core.UserIdentity{Email: ada.Email, DisplayName: "Ada"}, nil
+				case "grace-session":
+					return &core.UserIdentity{Email: grace.Email, DisplayName: "Grace"}, nil
+				default:
+					return nil, core.ErrNotFound
+				}
+			},
+		}
+		cfg.Services = services
+		cfg.Providers = testutil.NewProviderRegistry(t, &coretesting.StubIntegration{
+			N:        "roadmap",
+			ConnMode: core.ConnectionModeUser,
+			CatalogVal: &catalog.Catalog{
+				Name: "roadmap",
+				Operations: []catalog.CatalogOperation{
+					{ID: "sync", Method: http.MethodPost},
+				},
+			},
+		})
+		cfg.Workflow = &stubWorkflowControl{
+			providerName: "basic",
+			allowed:      map[string]struct{}{"sync": {}},
+			provider:     provider,
+		}
+	})
+	testutil.CloseOnCleanup(t, ts)
+
+	listReq, _ := http.NewRequest(http.MethodGet, ts.URL+"/api/v1/roadmap/workflow/schedules/", nil)
+	listReq.AddCookie(&http.Cookie{Name: "session_token", Value: "ada-session"})
+	listResp, err := http.DefaultClient.Do(listReq)
+	if err != nil {
+		t.Fatalf("list request: %v", err)
+	}
+	defer func() { _ = listResp.Body.Close() }()
+	if listResp.StatusCode != http.StatusOK {
+		t.Fatalf("expected 200, got %d", listResp.StatusCode)
+	}
+	var listed []workflowScheduleResponse
+	if err := json.NewDecoder(listResp.Body).Decode(&listed); err != nil {
+		t.Fatalf("decode list response: %v", err)
+	}
+	if len(listed) != 1 || listed[0].ID != "sched-ada" {
+		t.Fatalf("listed schedules = %#v", listed)
+	}
+
+	getReq, _ := http.NewRequest(http.MethodGet, ts.URL+"/api/v1/roadmap/workflow/schedules/sched-grace", nil)
+	getReq.AddCookie(&http.Cookie{Name: "session_token", Value: "ada-session"})
+	getResp, err := http.DefaultClient.Do(getReq)
+	if err != nil {
+		t.Fatalf("get request: %v", err)
+	}
+	defer func() { _ = getResp.Body.Close() }()
+	if getResp.StatusCode != http.StatusNotFound {
+		t.Fatalf("expected 404, got %d", getResp.StatusCode)
+	}
+
+	deleteReq, _ := http.NewRequest(http.MethodDelete, ts.URL+"/api/v1/roadmap/workflow/schedules/sched-grace", nil)
+	deleteReq.AddCookie(&http.Cookie{Name: "session_token", Value: "ada-session"})
+	deleteResp, err := http.DefaultClient.Do(deleteReq)
+	if err != nil {
+		t.Fatalf("delete request: %v", err)
+	}
+	defer func() { _ = deleteResp.Body.Close() }()
+	if deleteResp.StatusCode != http.StatusNotFound {
+		t.Fatalf("expected 404, got %d", deleteResp.StatusCode)
+	}
+	if _, ok := provider.schedules["sched-grace"]; !ok {
+		t.Fatal("expected grace schedule to remain after unauthorized delete")
+	}
+}
+
+func TestCreateWorkflowScheduleRejectsOperationOutsideWorkflowBinding(t *testing.T) {
+	t.Parallel()
+
+	services := coretesting.NewStubServices(t)
+	user := seedUser(t, services, "ada@example.test")
+	provider := newMemoryWorkflowProvider()
+	ts := newTestServer(t, func(cfg *server.Config) {
+		cfg.Auth = &coretesting.StubAuthProvider{
+			N: "stub",
+			ValidateTokenFn: func(_ context.Context, token string) (*core.UserIdentity, error) {
+				if token != "ada-session" {
+					return nil, core.ErrNotFound
+				}
+				return &core.UserIdentity{Email: user.Email, DisplayName: "Ada"}, nil
+			},
+		}
+		cfg.Services = services
+		cfg.Providers = testutil.NewProviderRegistry(t, &coretesting.StubIntegration{
+			N:        "roadmap",
+			ConnMode: core.ConnectionModeUser,
+			CatalogVal: &catalog.Catalog{
+				Name: "roadmap",
+				Operations: []catalog.CatalogOperation{
+					{ID: "sync", Method: http.MethodPost},
+					{ID: "export", Method: http.MethodPost},
+				},
+			},
+		})
+		cfg.Workflow = &stubWorkflowControl{
+			providerName: "basic",
+			allowed:      map[string]struct{}{"sync": {}},
+			provider:     provider,
+		}
+	})
+	testutil.CloseOnCleanup(t, ts)
+
+	body := bytes.NewBufferString(`{"cron":"*/5 * * * *","timezone":"UTC","target":{"operation":"export"}}`)
+	req, _ := http.NewRequest(http.MethodPost, ts.URL+"/api/v1/roadmap/workflow/schedules/", body)
+	req.Header.Set("Content-Type", "application/json")
+	req.AddCookie(&http.Cookie{Name: "session_token", Value: "ada-session"})
+	resp, err := http.DefaultClient.Do(req)
+	if err != nil {
+		t.Fatalf("request: %v", err)
+	}
+	defer func() { _ = resp.Body.Close() }()
+	if resp.StatusCode != http.StatusForbidden {
+		t.Fatalf("expected 403, got %d", resp.StatusCode)
+	}
+}
+
+func TestWorkflowScheduleAPITokenScopeFiltersOperations(t *testing.T) {
+	t.Parallel()
+
+	services := coretesting.NewStubServices(t)
+	user := seedUser(t, services, "ada@example.test")
+	plaintext, hashed, err := principal.GenerateToken(principal.TokenTypeAPI)
+	if err != nil {
+		t.Fatalf("GenerateToken: %v", err)
+	}
+	expiresAt := time.Now().Add(24 * time.Hour)
+	if err := services.APITokens.StoreAPIToken(context.Background(), &core.APIToken{
+		ID:          "workflow-scope-token",
+		UserID:      user.ID,
+		Name:        "workflow-scope-token",
+		HashedToken: hashed,
+		ExpiresAt:   &expiresAt,
+		Permissions: []core.AccessPermission{{Plugin: "roadmap", Operations: []string{"sync"}}},
+	}); err != nil {
+		t.Fatalf("StoreAPIToken: %v", err)
+	}
+
+	provider := newMemoryWorkflowProvider()
+	now := time.Now().UTC().Truncate(time.Second)
+	provider.schedules["sched-sync"] = &coreworkflow.Schedule{
+		ID:           "sched-sync",
+		Cron:         "*/5 * * * *",
+		Target:       coreworkflow.Target{PluginName: "roadmap", Operation: "sync"},
+		ExecutionRef: "exec-sync",
+		CreatedAt:    &now,
+		UpdatedAt:    &now,
+	}
+	provider.schedules["sched-export"] = &coreworkflow.Schedule{
+		ID:           "sched-export",
+		Cron:         "0 * * * *",
+		Target:       coreworkflow.Target{PluginName: "roadmap", Operation: "export"},
+		ExecutionRef: "exec-export",
+		CreatedAt:    &now,
+		UpdatedAt:    &now,
+	}
+	for _, ref := range []*coreworkflow.ExecutionReference{
+		{
+			ID:           "exec-sync",
+			ProviderName: "basic",
+			Target:       provider.schedules["sched-sync"].Target,
+			SubjectID:    principal.UserSubjectID(user.ID),
+		},
+		{
+			ID:           "exec-export",
+			ProviderName: "basic",
+			Target:       provider.schedules["sched-export"].Target,
+			SubjectID:    principal.UserSubjectID(user.ID),
+		},
+	} {
+		if _, err := services.WorkflowExecutionRefs.Put(context.Background(), ref); err != nil {
+			t.Fatalf("Put execution ref %q: %v", ref.ID, err)
+		}
+	}
+
+	ts := newTestServer(t, func(cfg *server.Config) {
+		cfg.Auth = &coretesting.StubAuthProvider{
+			N: "stub",
+			ValidateTokenFn: func(_ context.Context, _ string) (*core.UserIdentity, error) {
+				return nil, core.ErrNotFound
+			},
+		}
+		cfg.Services = services
+		cfg.Providers = testutil.NewProviderRegistry(t, &coretesting.StubIntegration{
+			N:        "roadmap",
+			ConnMode: core.ConnectionModeUser,
+			CatalogVal: &catalog.Catalog{
+				Name: "roadmap",
+				Operations: []catalog.CatalogOperation{
+					{ID: "sync", Method: http.MethodPost},
+					{ID: "export", Method: http.MethodPost},
+				},
+			},
+		})
+		cfg.Workflow = &stubWorkflowControl{
+			providerName: "basic",
+			allowed:      map[string]struct{}{"sync": {}, "export": {}},
+			provider:     provider,
+		}
+	})
+	testutil.CloseOnCleanup(t, ts)
+
+	listReq, _ := http.NewRequest(http.MethodGet, ts.URL+"/api/v1/roadmap/workflow/schedules/", nil)
+	listReq.Header.Set("Authorization", "Bearer "+plaintext)
+	listResp, err := http.DefaultClient.Do(listReq)
+	if err != nil {
+		t.Fatalf("list request: %v", err)
+	}
+	defer func() { _ = listResp.Body.Close() }()
+	if listResp.StatusCode != http.StatusOK {
+		t.Fatalf("expected 200, got %d", listResp.StatusCode)
+	}
+	var listed []workflowScheduleResponse
+	if err := json.NewDecoder(listResp.Body).Decode(&listed); err != nil {
+		t.Fatalf("decode list response: %v", err)
+	}
+	if len(listed) != 1 || listed[0].ID != "sched-sync" {
+		t.Fatalf("listed schedules = %#v", listed)
+	}
+
+	getReq, _ := http.NewRequest(http.MethodGet, ts.URL+"/api/v1/roadmap/workflow/schedules/sched-export", nil)
+	getReq.Header.Set("Authorization", "Bearer "+plaintext)
+	getResp, err := http.DefaultClient.Do(getReq)
+	if err != nil {
+		t.Fatalf("get request: %v", err)
+	}
+	defer func() { _ = getResp.Body.Close() }()
+	if getResp.StatusCode != http.StatusNotFound {
+		t.Fatalf("expected 404, got %d", getResp.StatusCode)
+	}
+
+	deleteReq, _ := http.NewRequest(http.MethodDelete, ts.URL+"/api/v1/roadmap/workflow/schedules/sched-export", nil)
+	deleteReq.Header.Set("Authorization", "Bearer "+plaintext)
+	deleteResp, err := http.DefaultClient.Do(deleteReq)
+	if err != nil {
+		t.Fatalf("delete request: %v", err)
+	}
+	defer func() { _ = deleteResp.Body.Close() }()
+	if deleteResp.StatusCode != http.StatusNotFound {
+		t.Fatalf("expected 404, got %d", deleteResp.StatusCode)
+	}
+
+	createReq, _ := http.NewRequest(
+		http.MethodPost,
+		ts.URL+"/api/v1/roadmap/workflow/schedules/",
+		bytes.NewBufferString(`{"cron":"*/5 * * * *","timezone":"UTC","target":{"operation":"export","instance":"tenant-a"}}`),
+	)
+	createReq.Header.Set("Authorization", "Bearer "+plaintext)
+	createReq.Header.Set("Content-Type", "application/json")
+	createResp, err := http.DefaultClient.Do(createReq)
+	if err != nil {
+		t.Fatalf("create request: %v", err)
+	}
+	defer func() { _ = createResp.Body.Close() }()
+	if createResp.StatusCode != http.StatusForbidden {
+		t.Fatalf("expected 403, got %d", createResp.StatusCode)
+	}
+}
+
+func TestWorkflowScheduleUpdateFailureKeepsExistingExecutionRef(t *testing.T) {
+	t.Parallel()
+
+	services := coretesting.NewStubServices(t)
+	user := seedUser(t, services, "ada@example.test")
+	provider := newMemoryWorkflowProvider()
+	oldTarget := coreworkflow.Target{
+		PluginName: "roadmap",
+		Operation:  "sync",
+		Connection: "analytics",
+		Instance:   "tenant-a",
+	}
+	now := time.Now().UTC().Truncate(time.Second)
+	provider.schedules["sched-ada"] = &coreworkflow.Schedule{
+		ID:           "sched-ada",
+		Cron:         "*/5 * * * *",
+		Timezone:     "UTC",
+		Target:       oldTarget,
+		ExecutionRef: "exec-old",
+		CreatedAt:    &now,
+		UpdatedAt:    &now,
+	}
+	if _, err := services.WorkflowExecutionRefs.Put(context.Background(), &coreworkflow.ExecutionReference{
+		ID:           "exec-old",
+		ProviderName: "basic",
+		Target:       oldTarget,
+		SubjectID:    principal.UserSubjectID(user.ID),
+	}); err != nil {
+		t.Fatalf("Put old ref: %v", err)
+	}
+	provider.nextUpsertErr = errors.New("boom")
+
+	ts := newTestServer(t, func(cfg *server.Config) {
+		cfg.Auth = &coretesting.StubAuthProvider{
+			N: "stub",
+			ValidateTokenFn: func(_ context.Context, token string) (*core.UserIdentity, error) {
+				if token != "ada-session" {
+					return nil, core.ErrNotFound
+				}
+				return &core.UserIdentity{Email: user.Email, DisplayName: "Ada"}, nil
+			},
+		}
+		cfg.Services = services
+		cfg.Providers = testutil.NewProviderRegistry(t, &coretesting.StubIntegration{
+			N:        "roadmap",
+			ConnMode: core.ConnectionModeUser,
+			CatalogVal: &catalog.Catalog{
+				Name: "roadmap",
+				Operations: []catalog.CatalogOperation{
+					{ID: "sync", Method: http.MethodPost},
+				},
+			},
+		})
+		cfg.Workflow = &stubWorkflowControl{
+			providerName: "basic",
+			allowed:      map[string]struct{}{"sync": {}},
+			provider:     provider,
+		}
+	})
+	testutil.CloseOnCleanup(t, ts)
+
+	updateReq, _ := http.NewRequest(
+		http.MethodPut,
+		ts.URL+"/api/v1/roadmap/workflow/schedules/sched-ada",
+		bytes.NewBufferString(`{"cron":"*/10 * * * *","timezone":"UTC","target":{"operation":"sync","connection":"analytics","instance":"tenant-b"}}`),
+	)
+	updateReq.Header.Set("Content-Type", "application/json")
+	updateReq.AddCookie(&http.Cookie{Name: "session_token", Value: "ada-session"})
+	updateResp, err := http.DefaultClient.Do(updateReq)
+	if err != nil {
+		t.Fatalf("update request: %v", err)
+	}
+	defer func() { _ = updateResp.Body.Close() }()
+	if updateResp.StatusCode != http.StatusInternalServerError {
+		body, _ := io.ReadAll(updateResp.Body)
+		t.Fatalf("expected 500, got %d: %s", updateResp.StatusCode, body)
+	}
+	if len(provider.upsertReqs) != 1 {
+		t.Fatalf("upsert requests = %d, want 1", len(provider.upsertReqs))
+	}
+	if provider.schedules["sched-ada"].ExecutionRef != "exec-old" {
+		t.Fatalf("schedule execution ref = %q, want exec-old", provider.schedules["sched-ada"].ExecutionRef)
+	}
+	if provider.schedules["sched-ada"].Target.Instance != "tenant-a" {
+		t.Fatalf("schedule target after failed update = %#v", provider.schedules["sched-ada"].Target)
+	}
+	oldRef, err := services.WorkflowExecutionRefs.Get(context.Background(), "exec-old")
+	if err != nil {
+		t.Fatalf("Get old ref: %v", err)
+	}
+	if oldRef.RevokedAt != nil && !oldRef.RevokedAt.IsZero() {
+		t.Fatalf("expected old ref to remain active, got %#v", oldRef)
+	}
+	newRef, err := services.WorkflowExecutionRefs.Get(context.Background(), provider.upsertReqs[0].ExecutionRef)
+	if err != nil {
+		t.Fatalf("Get new ref: %v", err)
+	}
+	if newRef.RevokedAt == nil || newRef.RevokedAt.IsZero() {
+		t.Fatalf("expected failed-update ref to be revoked, got %#v", newRef)
+	}
+}
+
+func TestWorkflowScheduleCreatePinsResolvedInstance(t *testing.T) {
+	t.Parallel()
+
+	services := coretesting.NewStubServices(t)
+	user := seedUser(t, services, "ada@example.test")
+	seedToken(t, services, &core.IntegrationToken{
+		ID:          "roadmap-default-tenant-a",
+		UserID:      user.ID,
+		Integration: "roadmap",
+		Connection:  "default",
+		Instance:    "tenant-a",
+		AccessToken: "token-a",
+	})
+
+	provider := newMemoryWorkflowProvider()
+	ts := newTestServer(t, func(cfg *server.Config) {
+		cfg.Auth = &coretesting.StubAuthProvider{
+			N: "stub",
+			ValidateTokenFn: func(_ context.Context, token string) (*core.UserIdentity, error) {
+				if token != "ada-session" {
+					return nil, core.ErrNotFound
+				}
+				return &core.UserIdentity{Email: user.Email, DisplayName: "Ada"}, nil
+			},
+		}
+		cfg.Services = services
+		cfg.Providers = testutil.NewProviderRegistry(t, &coretesting.StubIntegration{
+			N:        "roadmap",
+			ConnMode: core.ConnectionModeUser,
+			CatalogVal: &catalog.Catalog{
+				Name: "roadmap",
+				Operations: []catalog.CatalogOperation{
+					{ID: "sync", Method: http.MethodPost},
+				},
+			},
+		})
+		cfg.Workflow = &stubWorkflowControl{
+			providerName: "basic",
+			allowed:      map[string]struct{}{"sync": {}},
+			provider:     provider,
+		}
+	})
+	testutil.CloseOnCleanup(t, ts)
+
+	createReq, _ := http.NewRequest(
+		http.MethodPost,
+		ts.URL+"/api/v1/roadmap/workflow/schedules/",
+		bytes.NewBufferString(`{"cron":"*/5 * * * *","timezone":"UTC","target":{"operation":"sync","connection":"default"}}`),
+	)
+	createReq.Header.Set("Content-Type", "application/json")
+	createReq.AddCookie(&http.Cookie{Name: "session_token", Value: "ada-session"})
+	createResp, err := http.DefaultClient.Do(createReq)
+	if err != nil {
+		t.Fatalf("create request: %v", err)
+	}
+	defer func() { _ = createResp.Body.Close() }()
+	if createResp.StatusCode != http.StatusCreated {
+		body, _ := io.ReadAll(createResp.Body)
+		t.Fatalf("expected 201, got %d: %s", createResp.StatusCode, body)
+	}
+
+	var created workflowScheduleResponse
+	if err := json.NewDecoder(createResp.Body).Decode(&created); err != nil {
+		t.Fatalf("decode create response: %v", err)
+	}
+	if created.Target.Instance != "tenant-a" {
+		t.Fatalf("created schedule target instance = %q, want tenant-a", created.Target.Instance)
+	}
+	if len(provider.upsertReqs) != 1 {
+		t.Fatalf("upsert requests = %d, want 1", len(provider.upsertReqs))
+	}
+	if provider.upsertReqs[0].Target.Instance != "tenant-a" {
+		t.Fatalf("stored target = %#v, want resolved instance tenant-a", provider.upsertReqs[0].Target)
+	}
+}


### PR DESCRIPTION
## Summary
Adds the first user-facing schedule CRUD surface on top of the workflow primitive without introducing a new top-level automation resource. Schedules stay under the existing plugin workflow surface and are owned through workflow execution refs.

## New Interfaces
### Go
```go
type WorkflowControl interface {
    ResolveBinding(pluginName string) (providerName string, operations map[string]struct{}, err error)
    ResolveProvider(name string) (coreworkflow.Provider, error)
}
```

### HTTP
```text
GET    /api/v1/{integration}/workflow/schedules/
POST   /api/v1/{integration}/workflow/schedules/
GET    /api/v1/{integration}/workflow/schedules/{scheduleID}
PUT    /api/v1/{integration}/workflow/schedules/{scheduleID}
DELETE /api/v1/{integration}/workflow/schedules/{scheduleID}
POST   /api/v1/{integration}/workflow/schedules/{scheduleID}/pause
POST   /api/v1/{integration}/workflow/schedules/{scheduleID}/resume
```

## Behavior
- keeps user-owned schedules under the existing plugin workflow surface
- scopes list/get/update/delete/pause/resume to the authenticated user via workflow execution refs
- revalidates the target operation against workflow bindings and live authorization on create/update
- revokes the execution ref after deleting the schedule from the workflow provider

## Example Request
```http
POST /api/v1/roadmap/workflow/schedules/
Content-Type: application/json

{
  "cron": "*/5 * * * *",
  "timezone": "America/New_York",
  "target": {
    "operation": "sync",
    "connection": "default",
    "instance": "primary",
    "input": {
      "mode": "incremental"
    }
  }
}
```

## Example Response
```json
{
  "id": "sched_123",
  "provider": "basic",
  "cron": "*/5 * * * *",
  "timezone": "America/New_York",
  "target": {
    "operation": "sync",
    "connection": "default",
    "instance": "primary",
    "input": {
      "mode": "incremental"
    }
  },
  "paused": false
}
```

## Verification
- `go test ./internal/server -run 'TestWorkflowSchedule(CRUD|ListAndMutationsAreOwnerScoped)|TestCreateWorkflowScheduleRejectsOperationOutsideWorkflowBinding' -count=1`
- `go test ./internal/bootstrap ./internal/coredata ./internal/server -count=1`
