### PR TITLE
[codex] Bump default web UI to alpha.11

### DIFF
--- a/gestaltd/internal/config/config.go
+++ b/gestaltd/internal/config/config.go
@@ -32,7 +32,7 @@ const (
 	DefaultIndexedDBProvider = DefaultProviderRepo + "/indexeddb/relationaldb"
 	DefaultIndexedDBVersion  = "0.0.1-alpha.1"
 	DefaultWebUIProvider     = DefaultProviderRepo + "/web/default"
-	DefaultWebUIVersion      = "0.0.1-alpha.8"
+	DefaultWebUIVersion      = "0.0.1-alpha.11"
 	DefaultProviderInstance  = "default"
 )
 


### PR DESCRIPTION
## Summary
- bump `gestaltd`'s `DefaultWebUIVersion` from `0.0.1-alpha.8` to `0.0.1-alpha.11`
- align fresh default installs with the latest published `web/default` release

## Validation
- `go test ./internal/config`
