### PR TITLE
treat headless identity callers as server clients without user context

### DIFF
--- a/gestaltd/internal/principal/principal.go
+++ b/gestaltd/internal/principal/principal.go
@@ -66,6 +66,20 @@ func (p *Principal) AuthSource() string {
 	return p.Source.String()
 }
 
+func (p *Principal) IsWorkload() bool {
+	return p != nil && p.Kind == KindWorkload
+}
+
+func (p *Principal) HasUserContext() bool {
+	if p == nil {
+		return false
+	}
+	if strings.TrimSpace(p.UserID) != "" {
+		return true
+	}
+	return p.Identity != nil && strings.TrimSpace(p.Identity.Email) != ""
+}
+
 func UserSubjectID(userID string) string {
 	if userID == "" {
 		return ""

--- a/gestaltd/internal/server/audit.go
+++ b/gestaltd/internal/server/audit.go
@@ -56,6 +56,9 @@ func (s *Server) resolvePrincipalUserID(ctx context.Context, p *principal.Princi
 	if p.Identity == nil || p.Identity.Email == "" {
 		return p, nil
 	}
+	if s.users == nil {
+		return p, nil
+	}
 
 	dbUser, err := s.users.FindOrCreateUser(ctx, p.Identity.Email)
 	if err != nil {

--- a/gestaltd/internal/server/handlers.go
+++ b/gestaltd/internal/server/handlers.go
@@ -39,11 +39,11 @@ const sessionCookieName = "session_token"
 const defaultSessionCookieTTL = 24 * time.Hour
 
 var (
-	errNotAuthenticated  = errors.New("not authenticated")
-	errResolveUser       = errors.New("failed to resolve user")
-	errWorkloadForbidden = errors.New("workload callers are not allowed on this route")
-	errOperationAccess   = errors.New("operation access denied")
-	errWorkloadSelector  = errors.New("workload callers may not override connection or instance bindings")
+	errNotAuthenticated = errors.New("not authenticated")
+	errResolveUser      = errors.New("failed to resolve user")
+	errNonUserForbidden = errors.New("non-user callers are not allowed on this route")
+	errOperationAccess  = errors.New("operation access denied")
+	errWorkloadSelector = errors.New("workload callers may not override connection or instance bindings")
 )
 
 var (
@@ -91,9 +91,9 @@ type connectionParamInfo struct {
 }
 
 func (s *Server) resolveUserID(w http.ResponseWriter, r *http.Request) (string, error) {
-	if p := PrincipalFromContext(r.Context()); p != nil && p.Kind == principal.KindWorkload {
-		writeError(w, http.StatusForbidden, "workload callers are not allowed on this route")
-		return "", errWorkloadForbidden
+	if p := PrincipalFromContext(r.Context()); p != nil && !p.HasUserContext() {
+		writeError(w, http.StatusForbidden, "non-user callers are not allowed on this route")
+		return "", errNonUserForbidden
 	}
 	user := UserFromContext(r.Context())
 	if user == nil || user.Email == "" {
@@ -128,7 +128,7 @@ func (s *Server) readinessCheck(w http.ResponseWriter, _ *http.Request) {
 func (s *Server) listIntegrations(w http.ResponseWriter, r *http.Request) {
 	p := PrincipalFromContext(r.Context())
 	connected := map[string][]instanceInfo{}
-	if p == nil || p.Kind != principal.KindWorkload {
+	if p == nil || p.HasUserContext() {
 		var err error
 		connected, err = s.userConnectedIntegrations(r)
 		if err != nil {
@@ -165,7 +165,7 @@ func (s *Server) listIntegrations(w http.ResponseWriter, r *http.Request) {
 		if entry, ok := s.pluginDefs[name]; ok && entry != nil {
 			info.MountedPath = strings.TrimSpace(entry.MountPath)
 		}
-		if p != nil && p.Kind == principal.KindWorkload {
+		if p != nil && p.IsWorkload() {
 			if binding, ok := s.workloadBinding(p, name); ok {
 				bindingConnected, err := s.workloadBindingConnected(r.Context(), binding, name)
 				if err != nil {

--- a/gestaltd/internal/server/handlers_admin_authorization.go
+++ b/gestaltd/internal/server/handlers_admin_authorization.go
@@ -78,8 +78,8 @@ func (s *Server) adminAPIAuthMiddleware(next http.Handler) http.Handler {
 			writeError(w, http.StatusUnauthorized, "missing authorization")
 			return
 		}
-		if p.Kind == principal.KindWorkload {
-			writeError(w, http.StatusForbidden, "workload callers are not allowed on this route")
+		if p != nil && !p.HasUserContext() {
+			writeError(w, http.StatusForbidden, "non-user callers are not allowed on this route")
 			return
 		}
 

--- a/gestaltd/internal/server/handlers_auth.go
+++ b/gestaltd/internal/server/handlers_auth.go
@@ -547,9 +547,9 @@ func (s *Server) logout(w http.ResponseWriter, r *http.Request) {
 	defer func() {
 		s.auditHTTPEvent(r.Context(), auditPrincipal, s.authProviderName(), "auth.logout", auditAllowed, auditErr)
 	}()
-	if auditPrincipal != nil && auditPrincipal.Kind == principal.KindWorkload {
-		auditErr = errWorkloadForbidden
-		writeError(w, http.StatusForbidden, "workload callers are not allowed on this route")
+	if auditPrincipal != nil && !auditPrincipal.HasUserContext() {
+		auditErr = errNonUserForbidden
+		writeError(w, http.StatusForbidden, "non-user callers are not allowed on this route")
 		return
 	}
 

--- a/gestaltd/internal/server/handlers_connect.go
+++ b/gestaltd/internal/server/handlers_connect.go
@@ -14,7 +14,6 @@ import (
 	"github.com/valon-technologies/gestalt/server/internal/config"
 	"github.com/valon-technologies/gestalt/server/internal/discovery"
 	"github.com/valon-technologies/gestalt/server/internal/metricutil"
-	"github.com/valon-technologies/gestalt/server/internal/principal"
 )
 
 type connectManualRequest struct {
@@ -38,9 +37,9 @@ func (s *Server) connectManual(w http.ResponseWriter, r *http.Request) {
 		metricutil.RecordConnectionAuthMetrics(r.Context(), startedAt, metricProviderName, "manual", "complete", connectionMode, auditErr != nil)
 		s.auditHTTPEventWithTarget(r.Context(), PrincipalFromContext(r.Context()), providerName, "connection.manual.connect", auditAllowed, auditErr, auditTarget)
 	}()
-	if p := PrincipalFromContext(r.Context()); p != nil && p.Kind == principal.KindWorkload {
-		auditErr = errWorkloadForbidden
-		writeError(w, http.StatusForbidden, "workload callers are not allowed on this route")
+	if p := PrincipalFromContext(r.Context()); p != nil && !p.HasUserContext() {
+		auditErr = errNonUserForbidden
+		writeError(w, http.StatusForbidden, "non-user callers are not allowed on this route")
 		return
 	}
 

--- a/gestaltd/internal/server/handlers_identities.go
+++ b/gestaltd/internal/server/handlers_identities.go
@@ -1185,7 +1185,7 @@ func (s *Server) managedIdentityGrantCatalogTargets(ctx context.Context, plugin 
 		connection, instance := s.workloadBindingSelectors(p, plugin, connection, "")
 		addTarget(connection, instance)
 	}
-	if p == nil || p.Kind == principal.KindWorkload || strings.TrimSpace(p.UserID) == "" {
+	if p == nil || !p.HasUserContext() || strings.TrimSpace(p.UserID) == "" {
 		if len(targets) == 0 {
 			addTarget("", "")
 		}

--- a/gestaltd/internal/server/handlers_oauth.go
+++ b/gestaltd/internal/server/handlers_oauth.go
@@ -13,7 +13,6 @@ import (
 	"github.com/valon-technologies/gestalt/server/internal/metricutil"
 	"github.com/valon-technologies/gestalt/server/internal/oauth"
 	"github.com/valon-technologies/gestalt/server/internal/paraminterp"
-	"github.com/valon-technologies/gestalt/server/internal/principal"
 )
 
 type startOAuthRequest struct {
@@ -36,9 +35,9 @@ func (s *Server) startIntegrationOAuth(w http.ResponseWriter, r *http.Request) {
 		metricutil.RecordConnectionAuthMetrics(r.Context(), startedAt, metricProviderName, "oauth", "start", connectionMode, auditErr != nil)
 		s.auditHTTPEventWithTarget(r.Context(), PrincipalFromContext(r.Context()), providerName, "connection.oauth.start", auditAllowed, auditErr, auditTarget)
 	}()
-	if p := PrincipalFromContext(r.Context()); p != nil && p.Kind == principal.KindWorkload {
-		auditErr = errWorkloadForbidden
-		writeError(w, http.StatusForbidden, "workload callers are not allowed on this route")
+	if p := PrincipalFromContext(r.Context()); p != nil && !p.HasUserContext() {
+		auditErr = errNonUserForbidden
+		writeError(w, http.StatusForbidden, "non-user callers are not allowed on this route")
 		return
 	}
 

--- a/gestaltd/internal/server/integration_visibility.go
+++ b/gestaltd/internal/server/integration_visibility.go
@@ -20,7 +20,7 @@ func (s *Server) integrationHasUsableSurfaceContext(ctx context.Context, p *prin
 }
 
 func (s *Server) integrationHasSettingsSurface(p *principal.Principal, info integrationInfo) bool {
-	if p != nil && p.Kind == principal.KindWorkload {
+	if p != nil && !p.HasUserContext() {
 		return false
 	}
 	return info.Connected || len(info.AuthTypes) > 0 || len(info.Connections) > 0
@@ -66,10 +66,13 @@ func (s *Server) mountedWebUIForProvider(provider, mountedPath string) (MountedW
 }
 
 func (s *Server) mountedWebUIRootAccessibleContext(ctx context.Context, p *principal.Principal, mounted MountedWebUI) bool {
+	if p == nil || !p.HasUserContext() {
+		return false
+	}
 	if mounted.AuthorizationPolicy == "" {
 		return true
 	}
-	if s.authorizer == nil || p == nil || p.Kind == principal.KindWorkload {
+	if s.authorizer == nil {
 		return false
 	}
 

--- a/gestaltd/internal/server/middleware.go
+++ b/gestaltd/internal/server/middleware.go
@@ -132,10 +132,10 @@ func (s *Server) resolveRequestPrincipal(r *http.Request) (*principal.Principal,
 
 	if c, err := r.Cookie(sessionCookieName); err == nil && c.Value != "" {
 		p, err := s.resolver.ResolveToken(r.Context(), c.Value)
-		if p != nil && p.Kind != principal.KindWorkload {
+		if p != nil && p.HasUserContext() {
 			return p, nil
 		}
-		if p != nil && p.Kind == principal.KindWorkload {
+		if p != nil && !p.HasUserContext() {
 			lastErr = principal.ErrInvalidToken
 		} else {
 			lastErr = err

--- a/gestaltd/internal/server/mounted_ui.go
+++ b/gestaltd/internal/server/mounted_ui.go
@@ -283,10 +283,6 @@ func (s *Server) adminMountedWebUI() MountedWebUI {
 }
 
 func (s *Server) protectedUIHandler(mounted MountedWebUI, inner http.Handler, redirectLogin protectedUILoginRedirect) http.Handler {
-	if mounted.AuthorizationPolicy == "" {
-		return inner
-	}
-
 	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		ctx, ok := s.authorizeProtectedUIRequest(w, r, mounted, redirectLogin)
 		if !ok {
@@ -297,6 +293,32 @@ func (s *Server) protectedUIHandler(mounted MountedWebUI, inner http.Handler, re
 }
 
 func (s *Server) authorizeProtectedUIRequest(w http.ResponseWriter, r *http.Request, mounted MountedWebUI, redirectLogin protectedUILoginRedirect) (context.Context, bool) {
+	if mounted.AuthorizationPolicy == "" {
+		if requestedAuthSource(r) == "" {
+			return r.Context(), true
+		}
+		p, authenticated, err := s.resolveMountedWebUIPrincipal(r)
+		if err != nil {
+			writeError(w, http.StatusInternalServerError, "failed to resolve user")
+			return nil, false
+		}
+		if !authenticated {
+			if redirectLogin != nil {
+				if err := redirectLogin(w, r); err != nil {
+					writeError(w, http.StatusInternalServerError, err.Error())
+				}
+			}
+			return nil, false
+		}
+		if p != nil && !p.HasUserContext() {
+			writeError(w, http.StatusForbidden, "non-user callers are not allowed on this route")
+			return nil, false
+		}
+		if p == nil {
+			return r.Context(), true
+		}
+		return principal.WithPrincipal(r.Context(), p), true
+	}
 	if s.authorizer == nil {
 		writeError(w, http.StatusInternalServerError, "app authorization is unavailable")
 		return nil, false
@@ -315,8 +337,8 @@ func (s *Server) authorizeProtectedUIRequest(w http.ResponseWriter, r *http.Requ
 		}
 		return nil, false
 	}
-	if p != nil && p.Kind == principal.KindWorkload {
-		writeError(w, http.StatusForbidden, "workload callers are not allowed on this route")
+	if p != nil && !p.HasUserContext() {
+		writeError(w, http.StatusForbidden, "non-user callers are not allowed on this route")
 		return nil, false
 	}
 

--- a/gestaltd/internal/server/pending_connection.go
+++ b/gestaltd/internal/server/pending_connection.go
@@ -256,8 +256,8 @@ func (s *Server) resolvePendingConnectionUserID(r *http.Request) (string, bool, 
 	if p == nil {
 		return "", false, nil
 	}
-	if p.Kind == principal.KindWorkload {
-		return "", true, errWorkloadForbidden
+	if !p.HasUserContext() {
+		return "", true, errNonUserForbidden
 	}
 	if p.UserID == "" {
 		return "", true, fmt.Errorf("authenticated principal missing user ID")
@@ -289,8 +289,8 @@ func (s *Server) authorizePendingConnectionByCookie(r *http.Request, state *pend
 func (s *Server) authorizePendingConnection(w http.ResponseWriter, r *http.Request, state *pendingConnectionState) bool {
 	userID, authenticated, err := s.resolvePendingConnectionUserID(r)
 	if err != nil {
-		if errors.Is(err, errWorkloadForbidden) {
-			writeError(w, http.StatusForbidden, "workload callers are not allowed on this route")
+		if errors.Is(err, errNonUserForbidden) {
+			writeError(w, http.StatusForbidden, "non-user callers are not allowed on this route")
 			return false
 		}
 		if errors.Is(err, principal.ErrInvalidToken) {

--- a/gestaltd/internal/server/server_test.go
+++ b/gestaltd/internal/server/server_test.go
@@ -14174,6 +14174,11 @@ func (s *stubHostIssuedSessionAuth) SessionTokenTTL() time.Duration {
 func TestCookieAuth(t *testing.T) {
 	t.Parallel()
 
+	workloadToken, _, err := principal.GenerateToken(principal.TokenTypeWorkload)
+	if err != nil {
+		t.Fatalf("GenerateToken: %v", err)
+	}
+
 	stub := &coretesting.StubAuthProvider{
 		N: "test",
 		ValidateTokenFn: func(_ context.Context, token string) (*core.UserIdentity, error) {
@@ -14190,6 +14195,12 @@ func TestCookieAuth(t *testing.T) {
 
 	ts := newTestServer(t, func(cfg *server.Config) {
 		cfg.Auth = stub
+		cfg.Services = coretesting.NewStubServices(t)
+		cfg.Authorizer = mustAuthorizer(t, config.AuthorizationConfig{
+			Workloads: map[string]config.WorkloadDef{
+				"triage-bot": {Token: workloadToken},
+			},
+		}, nil, nil, nil)
 	})
 	testutil.CloseOnCleanup(t, ts)
 
@@ -14229,6 +14240,20 @@ func TestCookieAuth(t *testing.T) {
 
 	if fallbackResp.StatusCode == http.StatusUnauthorized {
 		t.Fatal("valid Authorization header should have passed middleware after invalid cookie")
+	}
+
+	// A non-human token in the cookie slot should be ignored the same way as an invalid cookie.
+	reqWithWorkloadCookie, _ := http.NewRequest(http.MethodGet, ts.URL+"/api/v1/integrations", nil)
+	reqWithWorkloadCookie.AddCookie(&http.Cookie{Name: "session_token", Value: workloadToken})
+	reqWithWorkloadCookie.Header.Set("Authorization", "Bearer valid-header-token")
+	workloadFallbackResp, err := http.DefaultClient.Do(reqWithWorkloadCookie)
+	if err != nil {
+		t.Fatalf("request with workload cookie fallback: %v", err)
+	}
+	defer func() { _ = workloadFallbackResp.Body.Close() }()
+
+	if workloadFallbackResp.StatusCode == http.StatusUnauthorized {
+		t.Fatal("valid Authorization header should have passed middleware after workload cookie")
 	}
 }
 
@@ -16905,6 +16930,24 @@ func TestManagedIdentityAPITokenInvocation_ModeNoneOnly(t *testing.T) {
 		},
 		ops: []core.Operation{{Name: "query", Method: http.MethodGet}},
 	}
+	deltaStub := &stubManualProviderWithCapabilities{
+		stubManualProvider: stubManualProvider{
+			StubIntegration: coretesting.StubIntegration{
+				N:        "delta",
+				ConnMode: core.ConnectionModeNone,
+				CatalogVal: serverTestCatalog("delta", []catalog.CatalogOperation{
+					{ID: "inspect", Method: http.MethodGet, Path: "/inspect", Transport: catalog.TransportREST},
+				}),
+				ExecuteFn: func(_ context.Context, _ string, _ map[string]any, _ string) (*core.OperationResult, error) {
+					return &core.OperationResult{Status: http.StatusOK, Body: `{"ok":true}`}, nil
+				},
+			},
+		},
+		credentialFields: []core.CredentialFieldDef{{Name: "api_token", Label: "API Token"}},
+		connectionParams: map[string]core.ConnectionParamDef{
+			"region": {Description: "Optional region"},
+		},
+	}
 	gammaStub := &stubIntegrationWithOps{
 		StubIntegration: coretesting.StubIntegration{
 			N:        "gamma",
@@ -16915,7 +16958,7 @@ func TestManagedIdentityAPITokenInvocation_ModeNoneOnly(t *testing.T) {
 		},
 		ops: []core.Operation{{Name: "query", Method: http.MethodGet}},
 	}
-	providers := testutil.NewProviderRegistry(t, alphaStub, betaStub, gammaStub)
+	providers := testutil.NewProviderRegistry(t, alphaStub, betaStub, deltaStub, gammaStub)
 	authz, err := authorization.New(config.AuthorizationConfig{}, nil, providers, nil)
 	if err != nil {
 		t.Fatalf("authorization.New: %v", err)
@@ -16943,6 +16986,7 @@ func TestManagedIdentityAPITokenInvocation_ModeNoneOnly(t *testing.T) {
 	doJSONRequestAndDecode(t, http.MethodPost, ts.URL+"/api/v1/identities", "admin-session", `{"displayName":"Invoke Bot"}`, http.StatusCreated, &createResp)
 	doJSONRequestAndDecode(t, http.MethodPut, ts.URL+"/api/v1/identities/"+createResp.ID+"/grants/alpha", "admin-session", `{"operations":["read"]}`, http.StatusOK, nil)
 	doJSONRequestAndDecode(t, http.MethodPut, ts.URL+"/api/v1/identities/"+createResp.ID+"/grants/beta", "admin-session", `{"operations":["query"]}`, http.StatusOK, nil)
+	doJSONRequestAndDecode(t, http.MethodPut, ts.URL+"/api/v1/identities/"+createResp.ID+"/grants/delta", "admin-session", `{"operations":["inspect"]}`, http.StatusOK, nil)
 
 	req, _ := http.NewRequest(http.MethodPut, ts.URL+"/api/v1/identities/"+createResp.ID+"/grants/gamma", bytes.NewBufferString(`{"operations":["query"]}`))
 	req.Header.Set("Content-Type", "application/json")
@@ -16984,7 +17028,7 @@ func TestManagedIdentityAPITokenInvocation_ModeNoneOnly(t *testing.T) {
 		http.MethodPost,
 		ts.URL+"/api/v1/identities/"+createResp.ID+"/tokens",
 		"admin-session",
-		`{"name":"invoke-token","permissions":[{"plugin":"alpha","operations":["read"]},{"plugin":"beta","operations":["query"]}]}`,
+		`{"name":"invoke-token","permissions":[{"plugin":"alpha","operations":["read"]},{"plugin":"beta","operations":["query"]},{"plugin":"delta","operations":["inspect"]}]}`,
 		http.StatusCreated,
 		&createTokenResp,
 	)
@@ -17012,8 +17056,62 @@ func TestManagedIdentityAPITokenInvocation_ModeNoneOnly(t *testing.T) {
 	if status := call("/api/v1/beta/query"); status != http.StatusOK {
 		t.Fatalf("beta/query status = %d, want 200", status)
 	}
+	if status := call("/api/v1/delta/inspect"); status != http.StatusOK {
+		t.Fatalf("delta/inspect status = %d, want 200", status)
+	}
 	if status := call("/api/v1/gamma/query"); status != http.StatusForbidden {
 		t.Fatalf("gamma/query status = %d, want 403", status)
+	}
+
+	req, _ = http.NewRequest(http.MethodGet, ts.URL+"/api/v1/integrations", nil)
+	req.Header.Set("Authorization", "Bearer "+createTokenResp.Token)
+	resp, err = http.DefaultClient.Do(req)
+	if err != nil {
+		t.Fatalf("list integrations with managed identity token: %v", err)
+	}
+	type listedIntegration struct {
+		Name             string `json:"name"`
+		AuthTypes        []string
+		Connections      []struct{}          `json:"connections"`
+		CredentialFields []struct{}          `json:"credentialFields"`
+		ConnectionParams map[string]struct{} `json:"connectionParams"`
+	}
+	var integrations []listedIntegration
+	if err := json.NewDecoder(resp.Body).Decode(&integrations); err != nil {
+		_ = resp.Body.Close()
+		t.Fatalf("decode integrations: %v", err)
+	}
+	_ = resp.Body.Close()
+	if resp.StatusCode != http.StatusOK {
+		t.Fatalf("list integrations status = %d, want 200", resp.StatusCode)
+	}
+	var deltaInfo *listedIntegration
+	for i := range integrations {
+		if integrations[i].Name == "delta" {
+			deltaInfo = &integrations[i]
+			break
+		}
+	}
+	if deltaInfo == nil {
+		t.Fatalf("expected delta integration in %+v", integrations)
+	}
+	if len(deltaInfo.AuthTypes) != 0 || len(deltaInfo.Connections) != 0 || len(deltaInfo.CredentialFields) != 0 || len(deltaInfo.ConnectionParams) != 0 {
+		t.Fatalf("managed identity integration info should hide connection affordances: %+v", *deltaInfo)
+	}
+
+	req, _ = http.NewRequest(http.MethodPost, ts.URL+"/api/v1/auth/logout", nil)
+	req.Header.Set("Authorization", "Bearer "+createTokenResp.Token)
+	resp, err = http.DefaultClient.Do(req)
+	if err != nil {
+		t.Fatalf("logout with managed identity token: %v", err)
+	}
+	body, _ = io.ReadAll(resp.Body)
+	_ = resp.Body.Close()
+	if resp.StatusCode != http.StatusForbidden {
+		t.Fatalf("logout status = %d, want 403: %s", resp.StatusCode, body)
+	}
+	if !strings.Contains(string(body), "non-user callers are not allowed on this route") {
+		t.Fatalf("logout body = %q, want non-user route rejection", string(body))
 	}
 
 	doJSONRequestAndDecode(t, http.MethodDelete, ts.URL+"/api/v1/identities/"+createResp.ID, "admin-session", "", http.StatusOK, nil)


### PR DESCRIPTION
## Summary

This PR treats any caller without user context as a headless server client for route and UI gating.

## Old interfaces

Go:

```go
if p != nil && p.IsWorkload() {
    // hide connect/settings affordances and reject user-only routes
}

if p == nil || p.IsWorkload() || strings.TrimSpace(p.UserID) == "" {
    return limitedSurface
}
```

Example:

```go
if p != nil && p.IsWorkload() {
    info.MountedPath = s.integrationMountedPathForPrincipalContext(ctx, p, name, info.MountedPath)
    continue
}
```

YAML:

```yaml
# no public config changes in this PR
```

Behavior:
- route/UI gating treated workload kind as the only headless case.
- empty-`UserID` checks were scattered through user-facing handlers.

## New interfaces

Go:

```go
func (p *Principal) HasUserContext() bool
```

Example:

```go
if p != nil && !p.HasUserContext() {
    // hide connect/settings affordances and reject user-only routes
}
```

YAML:

```yaml
# no public config changes in this PR
```

Behavior:
- user-only routes and mounted UI gating now key off `HasUserContext()`.
- authenticated headless identity callers are blocked from user-only surfaces.
- policyless mounted UIs stay public when no auth is presented.
- integration listing keeps headless callers on the limited server-client surface.