### PR TITLE
collapse workload callers into identity tokens

### DIFF
--- a/docs/content/audit-logging.mdx
+++ b/docs/content/audit-logging.mdx
@@ -31,7 +31,7 @@ These fields are emitted when available:
 
 | Field | Meaning |
 | --- | --- |
-| `auth_source` | Auth mechanism for the caller: `session`, `api_token`, `workload_token`, or `env` |
+| `auth_source` | Auth mechanism for the caller: `session`, `api_token`, `identity_token`, or `env` |
 | `user_id` | Stable internal user ID |
 | `target_kind` | Generic kind for the object the event acted on, such as `api_token` or `connection` |
 | `target_id` | Stable identifier for the affected object when one exists |

--- a/docs/content/reference/http-api.mdx
+++ b/docs/content/reference/http-api.mdx
@@ -6,7 +6,7 @@ The HTTP API uses "integrations" in route paths (e.g. `/api/v1/integrations`) as
 
 ## Authentication model
 
-Authenticated routes accept a `session_token` cookie or an `Authorization: Bearer <token>` header. Valid bearer tokens include Gestalt API tokens (`gst_api_...`), workload tokens (`gst_wld_...`), and auth-provider-issued tokens when the configured platform auth provider supports direct token validation.
+Authenticated routes accept a `session_token` cookie or an `Authorization: Bearer <token>` header. Valid bearer tokens include Gestalt API tokens (`gst_api_...`), identity tokens (`gst_wld_...`), and auth-provider-issued tokens when the configured platform auth provider supports direct token validation.
 
 ## Unauthenticated Routes
 

--- a/docs/content/security.mdx
+++ b/docs/content/security.mdx
@@ -35,7 +35,7 @@ Requests are authenticated in the following order:
 
 1. Check for a `session_token` cookie
 2. Check for an `Authorization: Bearer` header with a `gst_api_` prefix (API token lookup via SHA-256 hash)
-3. Check for an `Authorization: Bearer` header with a `gst_wld_` prefix (workload token lookup)
+3. Check for an `Authorization: Bearer` header with a `gst_wld_` prefix (identity token lookup)
 4. Check for an `Authorization: Bearer` header with a provider-issued token
 5. If no valid credentials are found, return 401
 

--- a/gestaltd/internal/authorization/authorizer.go
+++ b/gestaltd/internal/authorization/authorizer.go
@@ -176,7 +176,7 @@ func New(cfg config.AuthorizationConfig, pluginDefs map[string]*config.ProviderE
 		}
 
 		a.workloadsByHash[tokenHash] = workload
-		a.workloadsBySubjectID[principal.WorkloadSubjectID(identityID)] = workload
+		a.workloadsBySubjectID[principal.IdentitySubjectID(identityID)] = workload
 	}
 
 	return a, nil
@@ -196,7 +196,7 @@ func (a *Authorizer) ReloadAuthorizationState(ctx context.Context) error {
 	return nil
 }
 
-func (a *Authorizer) ResolveWorkloadToken(token string) (*principal.ResolvedWorkload, bool) {
+func (a *Authorizer) ResolveIdentityToken(token string) (*principal.ResolvedIdentityToken, bool) {
 	if a == nil {
 		return nil, false
 	}
@@ -204,60 +204,59 @@ func (a *Authorizer) ResolveWorkloadToken(token string) (*principal.ResolvedWork
 	if !ok || workload == nil {
 		return nil, false
 	}
-	return &principal.ResolvedWorkload{ID: workload.ID, DisplayName: workload.DisplayName}, true
-}
-
-func (a *Authorizer) IsWorkload(p *principal.Principal) bool {
-	return p != nil && p.Kind == principal.KindWorkload
+	return &principal.ResolvedIdentityToken{ID: workload.ID, DisplayName: workload.DisplayName}, true
 }
 
 func (a *Authorizer) AllowProvider(ctx context.Context, p *principal.Principal, provider string) bool {
+	if a.isConfiguredIdentityToken(p) {
+		_, ok := a.bindingForSubject(p, provider)
+		return ok
+	}
 	if a.isManagedIdentityPrincipal(p) {
 		return a.allowManagedIdentityProvider(p, provider)
 	}
-	if !a.IsWorkload(p) {
-		_, allowed := a.ResolveAccess(ctx, p, provider)
-		return allowed
-	}
-	_, ok := a.bindingForSubject(p, provider)
-	return ok
+	_, allowed := a.ResolveAccess(ctx, p, provider)
+	return allowed
 }
 
 func (a *Authorizer) AllowOperation(ctx context.Context, p *principal.Principal, provider, operation string) bool {
+	if a.isConfiguredIdentityToken(p) {
+		binding, ok := a.bindingForSubject(p, provider)
+		if !ok {
+			return false
+		}
+		_, ok = binding.Allow[operation]
+		return ok
+	}
 	if a.isManagedIdentityPrincipal(p) {
 		return a.allowManagedIdentityProvider(p, provider) && principal.AllowsOperationPermission(p, provider, operation)
 	}
-	if !a.IsWorkload(p) {
-		return a.AllowProvider(ctx, p, provider)
-	}
-	binding, ok := a.bindingForSubject(p, provider)
-	if !ok {
-		return false
-	}
-	_, ok = binding.Allow[operation]
-	return ok
+	return a.AllowProvider(ctx, p, provider)
 }
 
 func (a *Authorizer) Binding(p *principal.Principal, provider string) (CredentialBinding, bool) {
+	if a.isConfiguredIdentityToken(p) {
+		binding, ok := a.bindingForSubject(p, provider)
+		if !ok {
+			return CredentialBinding{}, false
+		}
+		return binding.CredentialBinding, true
+	}
 	if a.isManagedIdentityPrincipal(p) {
 		if !a.allowManagedIdentityProvider(p, provider) {
 			return CredentialBinding{}, false
 		}
 		return CredentialBinding{Mode: core.ConnectionModeNone}, true
 	}
-	if !a.IsWorkload(p) {
-		return CredentialBinding{}, false
-	}
-	binding, ok := a.bindingForSubject(p, provider)
-	if !ok {
-		return CredentialBinding{}, false
-	}
-	return binding.CredentialBinding, true
+	return CredentialBinding{}, false
 }
 
 func (a *Authorizer) ResolveAccess(_ context.Context, p *principal.Principal, provider string) (AccessContext, bool) {
 	if a == nil {
 		return AccessContext{}, true
+	}
+	if a.isConfiguredIdentityToken(p) {
+		return AccessContext{}, a.AllowProvider(context.Background(), p, provider)
 	}
 	if a.isManagedIdentityPrincipal(p) {
 		return AccessContext{}, a.allowManagedIdentityProvider(p, provider)
@@ -265,9 +264,6 @@ func (a *Authorizer) ResolveAccess(_ context.Context, p *principal.Principal, pr
 	policyName := strings.TrimSpace(a.providerPolicies[provider])
 	if policyName == "" {
 		return AccessContext{}, true
-	}
-	if a.IsWorkload(p) {
-		return a.ResolvePolicyAccess(context.Background(), p, policyName)
 	}
 
 	policy := a.policies[policyName]
@@ -372,7 +368,7 @@ func (a *Authorizer) ResolvePolicyAccess(_ context.Context, p *principal.Princip
 	if policyName == "" {
 		return AccessContext{}, true
 	}
-	if a.IsWorkload(p) {
+	if p != nil && !p.HasUserContext() {
 		return AccessContext{Policy: policyName}, false
 	}
 	policy := a.policies[policyName]
@@ -399,7 +395,7 @@ func (a *Authorizer) ResolveAdminAccess(_ context.Context, p *principal.Principa
 	if policyName == "" {
 		return AccessContext{}, true
 	}
-	if a.IsWorkload(p) {
+	if p != nil && !p.HasUserContext() {
 		return AccessContext{Policy: policyName}, false
 	}
 	policy := a.policies[policyName]
@@ -419,11 +415,11 @@ func (a *Authorizer) ResolveAdminAccess(_ context.Context, p *principal.Principa
 }
 
 func (a *Authorizer) AllowCatalogOperation(ctx context.Context, p *principal.Principal, provider string, op catalog.CatalogOperation) bool {
+	if a.isConfiguredIdentityToken(p) {
+		return a.AllowOperation(ctx, p, provider, op.ID)
+	}
 	if a.isManagedIdentityPrincipal(p) {
 		return a.allowManagedIdentityProvider(p, provider) && principal.AllowsOperationPermission(p, provider, op.ID)
-	}
-	if a.IsWorkload(p) {
-		return a.AllowOperation(ctx, p, provider, op.ID)
 	}
 	access, allowed := a.ResolveAccess(ctx, p, provider)
 	if !allowed {
@@ -448,7 +444,7 @@ func (a *Authorizer) AllowCatalogOperation(ctx context.Context, p *principal.Pri
 }
 
 func (a *Authorizer) bindingForSubject(p *principal.Principal, provider string) (WorkloadProviderBinding, bool) {
-	if a == nil || p == nil || p.SubjectID == "" {
+	if a == nil || !a.isConfiguredIdentityToken(p) || p.SubjectID == "" {
 		return WorkloadProviderBinding{}, false
 	}
 	workload, ok := a.workloadsBySubjectID[p.SubjectID]
@@ -496,7 +492,7 @@ func buildBinding(mode core.ConnectionMode, workloadID, identityID, provider str
 	switch mode {
 	case core.ConnectionModeNone:
 		if strings.TrimSpace(def.Connection) != "" || strings.TrimSpace(def.Instance) != "" {
-			return WorkloadProviderBinding{}, fmt.Errorf("authorization validation: workload %q provider %q does not accept connection or instance bindings", workloadID, provider)
+			return WorkloadProviderBinding{}, fmt.Errorf("authorization validation: identity token %q provider %q does not accept connection or instance bindings", workloadID, provider)
 		}
 		return WorkloadProviderBinding{
 			CredentialBinding: CredentialBinding{
@@ -506,10 +502,10 @@ func buildBinding(mode core.ConnectionMode, workloadID, identityID, provider str
 	case core.ConnectionModeIdentity:
 		ownerIdentityID := strings.TrimSpace(identityID)
 		if ownerIdentityID == "" {
-			return WorkloadProviderBinding{}, fmt.Errorf("authorization validation: workload %q provider %q requires identityID for identity-mode credentials", workloadID, provider)
+			return WorkloadProviderBinding{}, fmt.Errorf("authorization validation: identity token %q provider %q requires identity ownership for identity-mode credentials", workloadID, provider)
 		}
 		if !safeConnectionValue.MatchString(ownerIdentityID) {
-			return WorkloadProviderBinding{}, fmt.Errorf("authorization validation: workload %q identityID contains invalid characters", workloadID)
+			return WorkloadProviderBinding{}, fmt.Errorf("authorization validation: identity token %q identity ID contains invalid characters", workloadID)
 		}
 		connection := strings.TrimSpace(def.Connection)
 		if connection == "" {
@@ -517,10 +513,10 @@ func buildBinding(mode core.ConnectionMode, workloadID, identityID, provider str
 		}
 		connection = config.ResolveConnectionAlias(connection)
 		if connection == "" {
-			return WorkloadProviderBinding{}, fmt.Errorf("authorization validation: workload %q provider %q requires a bound connection", workloadID, provider)
+			return WorkloadProviderBinding{}, fmt.Errorf("authorization validation: identity token %q provider %q requires a bound connection", workloadID, provider)
 		}
 		if !safeConnectionValue.MatchString(connection) {
-			return WorkloadProviderBinding{}, fmt.Errorf("authorization validation: workload %q provider %q connection contains invalid characters", workloadID, provider)
+			return WorkloadProviderBinding{}, fmt.Errorf("authorization validation: identity token %q provider %q connection contains invalid characters", workloadID, provider)
 		}
 
 		instance := strings.TrimSpace(def.Instance)
@@ -528,7 +524,7 @@ func buildBinding(mode core.ConnectionMode, workloadID, identityID, provider str
 			instance = defaultInstance
 		}
 		if !safeInstanceValue.MatchString(instance) {
-			return WorkloadProviderBinding{}, fmt.Errorf("authorization validation: workload %q provider %q instance contains invalid characters", workloadID, provider)
+			return WorkloadProviderBinding{}, fmt.Errorf("authorization validation: identity token %q provider %q instance contains invalid characters", workloadID, provider)
 		}
 		return WorkloadProviderBinding{
 			CredentialBinding: CredentialBinding{
@@ -540,9 +536,9 @@ func buildBinding(mode core.ConnectionMode, workloadID, identityID, provider str
 			},
 		}, nil
 	case core.ConnectionModeUser, core.ConnectionMode("either"), "":
-		return WorkloadProviderBinding{}, fmt.Errorf("authorization validation: workload %q provider %q uses unsupported connection mode %q in v1", workloadID, provider, mode)
+		return WorkloadProviderBinding{}, fmt.Errorf("authorization validation: identity token %q provider %q uses unsupported connection mode %q in v1", workloadID, provider, mode)
 	default:
-		return WorkloadProviderBinding{}, fmt.Errorf("authorization validation: workload %q provider %q uses unknown connection mode %q", workloadID, provider, mode)
+		return WorkloadProviderBinding{}, fmt.Errorf("authorization validation: identity token %q provider %q uses unknown connection mode %q", workloadID, provider, mode)
 	}
 }
 
@@ -563,7 +559,11 @@ func normalizeEmail(email string) string {
 }
 
 func (a *Authorizer) isManagedIdentityPrincipal(p *principal.Principal) bool {
-	return a.IsWorkload(p) && principal.ManagedIdentityIDFromSubjectID(strings.TrimSpace(p.SubjectID)) != ""
+	return p != nil && p.Kind == principal.KindIdentity && p.Source == principal.SourceAPIToken
+}
+
+func (a *Authorizer) isConfiguredIdentityToken(p *principal.Principal) bool {
+	return p != nil && p.Kind == principal.KindIdentity && p.Source == principal.SourceIdentityToken
 }
 
 func (a *Authorizer) allowManagedIdentityProvider(p *principal.Principal, provider string) bool {

--- a/gestaltd/internal/authorization/provider_backed.go
+++ b/gestaltd/internal/authorization/provider_backed.go
@@ -195,25 +195,18 @@ func (a *ProviderBackedAuthorizer) pollLoop(ctx context.Context, done chan struc
 	}
 }
 
-func (a *ProviderBackedAuthorizer) ResolveWorkloadToken(token string) (*principal.ResolvedWorkload, bool) {
+func (a *ProviderBackedAuthorizer) ResolveIdentityToken(token string) (*principal.ResolvedIdentityToken, bool) {
 	if a == nil {
 		return nil, false
 	}
-	return a.base.ResolveWorkloadToken(token)
-}
-
-func (a *ProviderBackedAuthorizer) IsWorkload(p *principal.Principal) bool {
-	if a == nil {
-		return false
-	}
-	return a.base.IsWorkload(p)
+	return a.base.ResolveIdentityToken(token)
 }
 
 func (a *ProviderBackedAuthorizer) AllowProvider(ctx context.Context, p *principal.Principal, provider string) bool {
 	if a == nil {
 		return true
 	}
-	if a.base.IsWorkload(p) || a.base.isManagedIdentityPrincipal(p) {
+	if p != nil && !p.HasUserContext() {
 		return a.base.AllowProvider(ctx, p, provider)
 	}
 	_, allowed := a.ResolveAccess(ctx, p, provider)
@@ -224,7 +217,7 @@ func (a *ProviderBackedAuthorizer) AllowOperation(ctx context.Context, p *princi
 	if a == nil {
 		return true
 	}
-	if a.base.IsWorkload(p) || a.base.isManagedIdentityPrincipal(p) {
+	if p != nil && !p.HasUserContext() {
 		return a.base.AllowOperation(ctx, p, provider, operation)
 	}
 	return a.AllowProvider(ctx, p, provider)
@@ -241,7 +234,7 @@ func (a *ProviderBackedAuthorizer) ResolveAccess(ctx context.Context, p *princip
 	if a == nil {
 		return AccessContext{}, true
 	}
-	if a.base.isManagedIdentityPrincipal(p) || a.base.IsWorkload(p) {
+	if p != nil && !p.HasUserContext() {
 		return a.base.ResolveAccess(ctx, p, provider)
 	}
 
@@ -279,7 +272,7 @@ func (a *ProviderBackedAuthorizer) ResolvePolicyAccess(ctx context.Context, p *p
 	if a == nil {
 		return AccessContext{}, true
 	}
-	if a.base.IsWorkload(p) {
+	if p != nil && !p.HasUserContext() {
 		return a.base.ResolvePolicyAccess(ctx, p, policyName)
 	}
 	policyName = strings.TrimSpace(policyName)
@@ -316,7 +309,7 @@ func (a *ProviderBackedAuthorizer) ResolveAdminAccess(ctx context.Context, p *pr
 	if a == nil {
 		return AccessContext{}, true
 	}
-	if a.base.IsWorkload(p) {
+	if p != nil && !p.HasUserContext() {
 		return a.base.ResolveAdminAccess(ctx, p, policyName)
 	}
 	policyName = strings.TrimSpace(policyName)
@@ -366,7 +359,7 @@ func (a *ProviderBackedAuthorizer) AllowCatalogOperation(ctx context.Context, p 
 	if a == nil {
 		return true
 	}
-	if a.base.IsWorkload(p) || a.base.isManagedIdentityPrincipal(p) {
+	if p != nil && !p.HasUserContext() {
 		return a.base.AllowCatalogOperation(ctx, p, provider, op)
 	}
 

--- a/gestaltd/internal/authorization/runtime.go
+++ b/gestaltd/internal/authorization/runtime.go
@@ -8,17 +8,16 @@ import (
 )
 
 // RuntimeAuthorizer is the internal authorization interface used by gestaltd
-// request paths. It keeps workload execution binding concerns local while
-// allowing human authorization decisions to come from a backing provider.
+// request paths. It keeps identity-token execution binding concerns local while
+// allowing user-context authorization decisions to come from a backing provider.
 type RuntimeAuthorizer interface {
-	principal.WorkloadTokenResolver
+	principal.IdentityTokenResolver
 
 	Start(ctx context.Context) error
 	Close() error
 
 	ReloadAuthorizationState(ctx context.Context) error
 
-	IsWorkload(p *principal.Principal) bool
 	AllowProvider(ctx context.Context, p *principal.Principal, provider string) bool
 	AllowOperation(ctx context.Context, p *principal.Principal, provider, operation string) bool
 	Binding(p *principal.Principal, provider string) (CredentialBinding, bool)

--- a/gestaltd/internal/bootstrap/bootstrap_test.go
+++ b/gestaltd/internal/bootstrap/bootstrap_test.go
@@ -3640,7 +3640,7 @@ func TestBootstrapSecretResolution(t *testing.T) {
 		if result.Authorizer == nil {
 			t.Fatal("Authorizer is nil")
 		}
-		if _, ok := result.Authorizer.ResolveWorkloadToken("gst_wld_resolved-workload-token"); !ok {
+		if _, ok := result.Authorizer.ResolveIdentityToken("gst_wld_resolved-workload-token"); !ok {
 			t.Fatal("expected resolved identity token to authenticate")
 		}
 	})
@@ -4387,7 +4387,7 @@ func TestBootstrapWorkloadAuthorizationRejectsEitherProvider(t *testing.T) {
 
 	cfg := validConfig()
 	cfg.Authorization = config.AuthorizationConfig{
-		Workloads: map[string]config.WorkloadDef{
+		IdentityTokens: map[string]config.WorkloadDef{
 			"triage-bot": {
 				Token: "gst_wld_triage-bot-token",
 				Providers: map[string]config.WorkloadProviderDef{

--- a/gestaltd/internal/bootstrap/workflow_runtime.go
+++ b/gestaltd/internal/bootstrap/workflow_runtime.go
@@ -438,9 +438,9 @@ func (r *workflowRuntime) AugmentAuthorization(cfg config.AuthorizationConfig) (
 
 func workflowWorkloadPrincipal(pluginName string) *principal.Principal {
 	return &principal.Principal{
-		Kind:      principal.KindWorkload,
-		SubjectID: principal.WorkloadSubjectID(workflowWorkloadID(pluginName)),
-		Source:    principal.SourceWorkloadToken,
+		Kind:      principal.KindIdentity,
+		SubjectID: principal.IdentitySubjectID(workflowWorkloadID(pluginName)),
+		Source:    principal.SourceIdentityToken,
 	}
 }
 
@@ -459,7 +459,7 @@ func workflowWorkloadDisplayName(pluginName string) string {
 func workflowWorkloadToken() (string, error) {
 	var raw [16]byte
 	if _, err := rand.Read(raw[:]); err != nil {
-		return "", fmt.Errorf("generate managed workflow workload token: %w", err)
+		return "", fmt.Errorf("generate managed workflow identity token: %w", err)
 	}
 	return "gst_wld_" + hex.EncodeToString(raw[:]), nil
 }

--- a/gestaltd/internal/invocation/broker.go
+++ b/gestaltd/internal/invocation/broker.go
@@ -219,9 +219,12 @@ func (b *Broker) Invoke(ctx context.Context, p *principal.Principal, providerNam
 		if access.Policy != "" || access.Role != "" {
 			ctx = WithAccessContext(ctx, access)
 		}
-		if b.authorizer.IsWorkload(p) {
+		if p != nil && !p.HasUserContext() {
 			if binding, ok := b.authorizer.Binding(p, providerName); ok {
 				SetCredentialAudit(ctx, binding.Mode, binding.CredentialSubjectID, binding.Connection, binding.Instance)
+			}
+			if !b.authorizer.AllowOperation(ctx, p, providerName, operation) {
+				return fail(fmt.Errorf("%w: %s.%s", ErrAuthorizationDenied, providerName, operation))
 			}
 		} else if !allowed {
 			return fail(fmt.Errorf("%w: %s", ErrAuthorizationDenied, providerName))
@@ -229,10 +232,7 @@ func (b *Broker) Invoke(ctx context.Context, p *principal.Principal, providerNam
 	}
 
 	conn := ConnectionFromContext(ctx)
-	conn, instance = b.workloadSelectors(p, providerName, conn, instance)
-	if b.authorizer != nil && b.authorizer.IsWorkload(p) && !b.authorizer.AllowOperation(ctx, p, providerName, operation) {
-		return fail(fmt.Errorf("%w: %s.%s", ErrAuthorizationDenied, providerName, operation))
-	}
+	conn, instance = b.identityTokenSelectors(p, providerName, conn, instance)
 
 	opMeta, transport, resolvedConnection, err := b.resolveOperation(ctx, p, prov, providerName, operation, conn, instance)
 	if err != nil {
@@ -322,8 +322,8 @@ func (b *Broker) MCPConnection(providerName string) string {
 	return b.mcpConnection(providerName)
 }
 
-func (b *Broker) workloadSelectors(p *principal.Principal, providerName, connection, instance string) (string, string) {
-	if b.authorizer == nil || !b.authorizer.IsWorkload(p) {
+func (b *Broker) identityTokenSelectors(p *principal.Principal, providerName, connection, instance string) (string, string) {
+	if b.authorizer == nil || p == nil || p.HasUserContext() {
 		return connection, instance
 	}
 	binding, ok := b.authorizer.Binding(p, providerName)
@@ -411,8 +411,10 @@ func (b *Broker) resolveToken(ctx context.Context, prov core.Provider, p *princi
 	if resolved != nil {
 		p = resolved
 	}
-	if b.authorizer != nil && b.authorizer.IsWorkload(p) {
-		return b.resolveWorkloadToken(ctx, prov, p, providerName, connection, instance)
+	if b.authorizer != nil && p != nil && !p.HasUserContext() {
+		if binding, ok := b.authorizer.Binding(p, providerName); ok {
+			return b.resolveIdentityBinding(ctx, prov, providerName, connection, instance, binding)
+		}
 	}
 	if resolved == nil {
 		if err := b.resolveUserPrincipal(ctx, p); err != nil {
@@ -446,7 +448,7 @@ func (b *Broker) resolveToken(ctx context.Context, prov core.Provider, p *princi
 }
 
 func (b *Broker) resolveUserPrincipal(ctx context.Context, p *principal.Principal) error {
-	if p == nil || p.UserID != "" || p.Kind == principal.KindWorkload || p.Identity == nil || p.Identity.Email == "" {
+	if p == nil || p.UserID != "" || !p.HasUserContext() || p.Identity == nil || p.Identity.Email == "" {
 		return nil
 	}
 	if b.users == nil {
@@ -472,19 +474,11 @@ func (b *Broker) resolveUserPrincipal(ctx context.Context, p *principal.Principa
 	return nil
 }
 
-func (b *Broker) resolveWorkloadToken(ctx context.Context, prov core.Provider, p *principal.Principal, providerName, requestedConnection, requestedInstance string) (context.Context, string, error) {
-	if b.authorizer == nil {
-		return ctx, "", fmt.Errorf("%w: no workload authorizer configured", ErrAuthorizationDenied)
-	}
-	binding, ok := b.authorizer.Binding(p, providerName)
-	if !ok {
-		return ctx, "", fmt.Errorf("%w: %s", ErrAuthorizationDenied, providerName)
-	}
-
+func (b *Broker) resolveIdentityBinding(ctx context.Context, prov core.Provider, providerName, requestedConnection, requestedInstance string, binding authorization.CredentialBinding) (context.Context, string, error) {
 	switch binding.Mode {
 	case core.ConnectionModeNone:
 		if requestedConnection != "" || requestedInstance != "" {
-			return ctx, "", fmt.Errorf("%w: workloads may not override connection or instance bindings", ErrAuthorizationDenied)
+			return ctx, "", fmt.Errorf("%w: identity-token callers may not override connection or instance bindings", ErrAuthorizationDenied)
 		}
 		SetCredentialAudit(ctx, binding.Mode, binding.CredentialSubjectID, binding.Connection, binding.Instance)
 		ctx = WithCredentialContext(ctx, CredentialContext{
@@ -498,15 +492,15 @@ func (b *Broker) resolveWorkloadToken(ctx context.Context, prov core.Provider, p
 		connection := binding.Connection
 		instance := binding.Instance
 		if (requestedConnection != "" && requestedConnection != binding.Connection) || (requestedInstance != "" && requestedInstance != binding.Instance) {
-			return ctx, "", fmt.Errorf("%w: workloads may not override connection or instance bindings", ErrAuthorizationDenied)
+			return ctx, "", fmt.Errorf("%w: identity-token callers may not override connection or instance bindings", ErrAuthorizationDenied)
 		}
 		SetCredentialAudit(ctx, binding.Mode, binding.CredentialSubjectID, connection, instance)
 		if binding.CredentialOwnerID == "" {
-			return ctx, "", fmt.Errorf("%w: workload binding missing identity owner", ErrInternal)
+			return ctx, "", fmt.Errorf("%w: identity binding missing owner identity", ErrInternal)
 		}
 		return b.resolveIdentityToken(ctx, prov, binding.CredentialOwnerID, providerName, connection, instance, core.ConnectionModeIdentity, binding.CredentialSubjectID)
 	default:
-		return ctx, "", fmt.Errorf("%w: workloads may only use identity or none providers", ErrAuthorizationDenied)
+		return ctx, "", fmt.Errorf("%w: identity-token callers may only use identity or none providers", ErrAuthorizationDenied)
 	}
 }
 

--- a/gestaltd/internal/invocation/broker_test.go
+++ b/gestaltd/internal/invocation/broker_test.go
@@ -157,8 +157,8 @@ func TestBrokerResolveToken_WorkflowContextDoesNotBypassWorkloadIdentityBinding(
 
 	workload := &principal.Principal{
 		SubjectID: principal.WorkloadSubjectID("workflow.roadmap"),
-		Kind:      principal.KindWorkload,
-		Source:    principal.SourceWorkloadToken,
+		Kind:      principal.KindIdentity,
+		Source:    principal.SourceIdentityToken,
 	}
 	ctx := WithWorkflowContext(context.Background(), map[string]any{
 		"runId": "run-123",
@@ -168,7 +168,7 @@ func TestBrokerResolveToken_WorkflowContextDoesNotBypassWorkloadIdentityBinding(
 	if err == nil {
 		t.Fatal("expected binding override to be rejected")
 	}
-	if got, want := err.Error(), "workloads may not override connection or instance bindings"; got == "" || !strings.Contains(got, want) {
+	if got, want := err.Error(), "identity-token callers may not override connection or instance bindings"; got == "" || !strings.Contains(got, want) {
 		t.Fatalf("ResolveToken error = %q, want substring %q", got, want)
 	}
 }
@@ -250,8 +250,8 @@ func TestBrokerResolveToken_RefreshesIdentityOwnedWorkloadToken(t *testing.T) {
 
 	workload := &principal.Principal{
 		SubjectID: principal.WorkloadSubjectID("workflow.roadmap"),
-		Kind:      principal.KindWorkload,
-		Source:    principal.SourceWorkloadToken,
+		Kind:      principal.KindIdentity,
+		Source:    principal.SourceIdentityToken,
 	}
 	_, token, err := broker.ResolveToken(context.Background(), workload, "slack", "workspace", "")
 	if err != nil {

--- a/gestaltd/internal/mcp/authorization.go
+++ b/gestaltd/internal/mcp/authorization.go
@@ -16,7 +16,7 @@ func allowOperation(ctx context.Context, cfg Config, p *principal.Principal, pro
 	if cfg.Authorizer == nil {
 		return true
 	}
-	if cfg.Authorizer.IsWorkload(p) {
+	if p != nil && !p.HasUserContext() {
 		return cfg.Authorizer.AllowOperation(ctx, p, provider, operation)
 	}
 	op, ok := catalogOperationForTool(ctx, cfg, provider, operation)

--- a/gestaltd/internal/mcp/binding.go
+++ b/gestaltd/internal/mcp/binding.go
@@ -80,7 +80,7 @@ func NewServer(cfg Config) *mcpserver.MCPServer {
 		hooks.AddBeforeCallTool(func(ctx context.Context, _ any, req *mcpgo.CallToolRequest) {
 			if provName := providerNameForTool(cfg.ToolPrefixes, dynamicProviders, req.Params.Name); provName != "" {
 				instance := normalizedSessionCatalogInstance(req.GetArguments()["_instance"])
-				if workloadInstanceOverrideRequested(cfg.Authorizer, principal.FromContext(ctx), instance) {
+				if headlessInstanceOverrideRequested(cfg.Authorizer, principal.FromContext(ctx), instance) {
 					return
 				}
 				hydrateSessionToolsForInstance(ctx, cfg, []string{provName}, staticToolNames, instance)

--- a/gestaltd/internal/mcp/binding_test.go
+++ b/gestaltd/internal/mcp/binding_test.go
@@ -140,9 +140,9 @@ func ctxWithIdentityPrincipal(email, userID string) context.Context {
 
 func ctxWithWorkloadPrincipal(workloadID string) context.Context {
 	p := &principal.Principal{
-		Kind:      principal.KindWorkload,
+		Kind:      principal.KindIdentity,
 		SubjectID: principal.WorkloadSubjectID(workloadID),
-		Source:    principal.SourceWorkloadToken,
+		Source:    principal.SourceIdentityToken,
 	}
 	return principal.WithPrincipal(context.Background(), p)
 }
@@ -977,10 +977,9 @@ func TestNewServer_WorkloadListToolsFiltersStaticAndSessionTools(t *testing.T) {
 
 	providers := testutil.NewProviderRegistry(t, prov)
 	authz := mustAuthorizer(t, config.AuthorizationConfig{
-		Workloads: map[string]config.WorkloadDef{
+		IdentityTokens: map[string]config.WorkloadDef{
 			"triage-bot": {
-				IdentityID: "triage-bot",
-				Token:      "gst_wld_triage-bot-token",
+				Token: "gst_wld_triage-bot-token",
 				Providers: map[string]config.WorkloadProviderDef{
 					"clickhouse": {
 						Connection: "workspace",
@@ -1000,8 +999,8 @@ func TestNewServer_WorkloadListToolsFiltersStaticAndSessionTools(t *testing.T) {
 		},
 		TokenResolver: &stubTokenResolver{
 			resolveFn: func(ctx context.Context, p *principal.Principal, providerName, connection, instance string) (context.Context, string, error) {
-				if p == nil || p.Kind != principal.KindWorkload {
-					t.Fatalf("expected workload principal, got %+v", p)
+				if p == nil || p.Kind != principal.KindIdentity || p.Source != principal.SourceIdentityToken {
+					t.Fatalf("expected identity-token principal, got %+v", p)
 				}
 				if providerName != "clickhouse" {
 					t.Fatalf("providerName = %q, want %q", providerName, "clickhouse")
@@ -1685,10 +1684,9 @@ func TestNewServer_WorkloadCallToolDeniedReturnsErrorResult(t *testing.T) {
 	providers := testutil.NewProviderRegistry(t, prov)
 	ds := coretesting.NewStubServices(t)
 	authz := mustAuthorizer(t, config.AuthorizationConfig{
-		Workloads: map[string]config.WorkloadDef{
+		IdentityTokens: map[string]config.WorkloadDef{
 			"triage-bot": {
-				IdentityID: "triage-bot",
-				Token:      "gst_wld_triage-bot-token",
+				Token: "gst_wld_triage-bot-token",
 				Providers: map[string]config.WorkloadProviderDef{
 					"clickhouse": {
 						Allow: []string{"run_query"},
@@ -1753,10 +1751,9 @@ func TestNewServer_WorkloadCallToolDeniedForUnboundSessionOnlyProvider(t *testin
 	providers := testutil.NewProviderRegistry(t, prov)
 	ds := coretesting.NewStubServices(t)
 	authz := mustAuthorizer(t, config.AuthorizationConfig{
-		Workloads: map[string]config.WorkloadDef{
+		IdentityTokens: map[string]config.WorkloadDef{
 			"triage-bot": {
-				IdentityID: "triage-bot",
-				Token:      "gst_wld_triage-bot-token",
+				Token: "gst_wld_triage-bot-token",
 			},
 		},
 	}, providers)
@@ -1844,10 +1841,9 @@ func TestNewServer_WorkloadCallToolUsesBoundConnectionForSessionOnlyProvider(t *
 	}
 
 	authz := mustAuthorizer(t, config.AuthorizationConfig{
-		Workloads: map[string]config.WorkloadDef{
+		IdentityTokens: map[string]config.WorkloadDef{
 			"triage-bot": {
-				IdentityID: "triage-bot",
-				Token:      "gst_wld_triage-bot-token",
+				Token: "gst_wld_triage-bot-token",
 				Providers: map[string]config.WorkloadProviderDef{
 					"clickhouse": {
 						Connection: "workspace",
@@ -1938,10 +1934,9 @@ func TestNewServer_WorkloadCallToolRejectsInstanceOverride(t *testing.T) {
 	}
 
 	authz := mustAuthorizer(t, config.AuthorizationConfig{
-		Workloads: map[string]config.WorkloadDef{
+		IdentityTokens: map[string]config.WorkloadDef{
 			"triage-bot": {
-				IdentityID: "triage-bot",
-				Token:      "gst_wld_triage-bot-token",
+				Token: "gst_wld_triage-bot-token",
 				Providers: map[string]config.WorkloadProviderDef{
 					"sampledb": {
 						Connection: "workspace",
@@ -1970,7 +1965,7 @@ func TestNewServer_WorkloadCallToolRejectsInstanceOverride(t *testing.T) {
 		t.Fatalf("expected MCP error result, got %+v", result)
 	}
 	text, ok := result.Content[0].(mcpgo.TextContent)
-	if !ok || text.Text != "workload callers may not override connection or instance bindings" {
+	if !ok || text.Text != "identity-token callers may not override connection or instance bindings" {
 		t.Fatalf("unexpected MCP error content: %+v", result.Content)
 	}
 	if called {

--- a/gestaltd/internal/mcp/handlers.go
+++ b/gestaltd/internal/mcp/handlers.go
@@ -23,8 +23,8 @@ func makeHandler(cfg Config, provName, opName, connection string) mcpserver.Tool
 
 		rawArgs := req.GetArguments()
 		instance := normalizedSessionCatalogInstance(rawArgs["_instance"])
-		if workloadInstanceOverrideRequested(cfg.Authorizer, p, instance) {
-			return mcpgo.NewToolResultError("workload callers may not override connection or instance bindings"), nil
+		if headlessInstanceOverrideRequested(cfg.Authorizer, p, instance) {
+			return mcpgo.NewToolResultError("identity-token callers may not override connection or instance bindings"), nil
 		}
 		args := make(map[string]any, len(rawArgs))
 		for key, value := range rawArgs {

--- a/gestaltd/internal/mcp/session_tools.go
+++ b/gestaltd/internal/mcp/session_tools.go
@@ -144,7 +144,7 @@ func withSessionAccessContext(ctx context.Context, cfg Config, provName string) 
 		return ctx
 	}
 	p := principal.FromContext(ctx)
-	if p == nil || cfg.Authorizer.IsWorkload(p) {
+	if p == nil || !p.HasUserContext() {
 		return ctx
 	}
 	access, allowed := cfg.Authorizer.ResolveAccess(ctx, p, provName)
@@ -389,7 +389,7 @@ func internalSessionToolHandler(context.Context, mcpgo.CallToolRequest) (*mcpgo.
 func sessionTokenSelectors(cfg Config, p *principal.Principal, provName, instanceOverride string) (string, string) {
 	connection := cfg.MCPConnection[provName]
 	instance := normalizedSessionCatalogInstance(instanceOverride)
-	if cfg.Authorizer == nil || !cfg.Authorizer.IsWorkload(p) {
+	if cfg.Authorizer == nil || p == nil || p.HasUserContext() {
 		return connection, instance
 	}
 	if binding, ok := cfg.Authorizer.Binding(p, provName); ok {
@@ -436,6 +436,6 @@ func normalizedSessionCatalogInstance(value any) string {
 	return strings.TrimSpace(instance)
 }
 
-func workloadInstanceOverrideRequested(authz authorization.RuntimeAuthorizer, p *principal.Principal, instance string) bool {
-	return authz != nil && p != nil && authz.IsWorkload(p) && instance != ""
+func headlessInstanceOverrideRequested(authz authorization.RuntimeAuthorizer, p *principal.Principal, instance string) bool {
+	return authz != nil && p != nil && !p.HasUserContext() && instance != ""
 }

--- a/gestaltd/internal/principal/principal.go
+++ b/gestaltd/internal/principal/principal.go
@@ -14,18 +14,20 @@ const (
 	SourceUnknown Source = iota
 	SourceSession
 	SourceAPIToken
-	SourceWorkloadToken
+	SourceIdentityToken
 	SourceEnv
 )
 
+const SourceWorkloadToken Source = SourceIdentityToken
+
 const IdentityPrincipal = "__identity__"
-const managedIdentitySubjectPrefix = "managed_identity:"
+const managedIdentityLegacySubjectPrefix = "managed_identity:"
 
 type Kind string
 
 const (
 	KindUser     Kind = "user"
-	KindWorkload Kind = "workload"
+	KindIdentity Kind = "identity"
 )
 
 type Principal struct {
@@ -47,8 +49,8 @@ func (s Source) String() string {
 		return "session"
 	case SourceAPIToken:
 		return "api_token"
-	case SourceWorkloadToken:
-		return "workload_token"
+	case SourceIdentityToken:
+		return "identity_token"
 	case SourceEnv:
 		return "env"
 	default:
@@ -66,10 +68,6 @@ func (p *Principal) AuthSource() string {
 	return p.Source.String()
 }
 
-func (p *Principal) IsWorkload() bool {
-	return p != nil && p.Kind == KindWorkload
-}
-
 func (p *Principal) HasUserContext() bool {
 	if p == nil {
 		return false
@@ -79,7 +77,6 @@ func (p *Principal) HasUserContext() bool {
 	}
 	return p.Identity != nil && strings.TrimSpace(p.Identity.Email) != ""
 }
-
 func UserSubjectID(userID string) string {
 	if userID == "" {
 		return ""
@@ -88,10 +85,7 @@ func UserSubjectID(userID string) string {
 }
 
 func WorkloadSubjectID(workloadID string) string {
-	if workloadID == "" {
-		return ""
-	}
-	return string(KindWorkload) + ":" + workloadID
+	return IdentitySubjectID(workloadID)
 }
 
 func IdentitySubjectID(identityID string) string {
@@ -102,17 +96,18 @@ func IdentitySubjectID(identityID string) string {
 }
 
 func ManagedIdentitySubjectID(identityID string) string {
-	if identityID == "" {
-		return ""
-	}
-	return managedIdentitySubjectPrefix + identityID
+	return IdentitySubjectID(identityID)
 }
 
 func ManagedIdentityIDFromSubjectID(subjectID string) string {
-	if !strings.HasPrefix(subjectID, managedIdentitySubjectPrefix) {
+	switch {
+	case strings.HasPrefix(subjectID, string(KindIdentity)+":"):
+		return strings.TrimPrefix(subjectID, string(KindIdentity)+":")
+	case strings.HasPrefix(subjectID, managedIdentityLegacySubjectPrefix):
+		return strings.TrimPrefix(subjectID, managedIdentityLegacySubjectPrefix)
+	default:
 		return ""
 	}
-	return strings.TrimPrefix(subjectID, managedIdentitySubjectPrefix)
 }
 
 func CompilePermissions(perms []core.AccessPermission) PermissionSet {

--- a/gestaltd/internal/principal/resolver.go
+++ b/gestaltd/internal/principal/resolver.go
@@ -19,21 +19,23 @@ type TokenType int
 
 const (
 	TokenTypeAPI TokenType = iota
-	TokenTypeWorkload
+	TokenTypeIdentity
 )
+
+const TokenTypeWorkload TokenType = TokenTypeIdentity
 
 const (
 	prefixAPI      = "gst_api_"
 	prefixWorkload = "gst_wld_"
 )
 
-type ResolvedWorkload struct {
+type ResolvedIdentityToken struct {
 	ID          string
 	DisplayName string
 }
 
-type WorkloadTokenResolver interface {
-	ResolveWorkloadToken(token string) (*ResolvedWorkload, bool)
+type IdentityTokenResolver interface {
+	ResolveIdentityToken(token string) (*ResolvedIdentityToken, bool)
 }
 
 func GenerateToken(typ TokenType) (plaintext, hashed string, err error) {
@@ -47,7 +49,7 @@ func GenerateToken(typ TokenType) (plaintext, hashed string, err error) {
 	switch typ {
 	case TokenTypeAPI:
 		prefix = prefixAPI
-	case TokenTypeWorkload:
+	case TokenTypeIdentity:
 		prefix = prefixWorkload
 	default:
 		return "", "", fmt.Errorf("unknown token type %d", typ)
@@ -63,7 +65,7 @@ func ParseTokenType(token string) (TokenType, bool) {
 	case strings.HasPrefix(token, prefixAPI):
 		return TokenTypeAPI, true
 	case strings.HasPrefix(token, prefixWorkload):
-		return TokenTypeWorkload, true
+		return TokenTypeIdentity, true
 	default:
 		return 0, false
 	}
@@ -75,10 +77,10 @@ type Resolver struct {
 	apiTokens         *coredata.APITokenService
 	managedIdentities *coredata.ManagedIdentityService
 	identityGrants    *coredata.ManagedIdentityGrantService
-	workloads         WorkloadTokenResolver
+	workloads         IdentityTokenResolver
 }
 
-func NewResolver(auth core.AuthProvider, users *coredata.UserService, apiTokens *coredata.APITokenService, managedIdentities *coredata.ManagedIdentityService, identityGrants *coredata.ManagedIdentityGrantService, workloads WorkloadTokenResolver) *Resolver {
+func NewResolver(auth core.AuthProvider, users *coredata.UserService, apiTokens *coredata.APITokenService, managedIdentities *coredata.ManagedIdentityService, identityGrants *coredata.ManagedIdentityGrantService, workloads IdentityTokenResolver) *Resolver {
 	return &Resolver{
 		auth:              auth,
 		users:             users,
@@ -94,8 +96,8 @@ func (r *Resolver) ResolveToken(ctx context.Context, token string) (*Principal, 
 		switch typ {
 		case TokenTypeAPI:
 			return r.resolveAPIToken(ctx, token)
-		case TokenTypeWorkload:
-			return r.resolveWorkloadToken(token)
+		case TokenTypeIdentity:
+			return r.resolveIdentityToken(token)
 		}
 	}
 
@@ -196,28 +198,28 @@ func (r *Resolver) resolveManagedIdentityAPIToken(ctx context.Context, apiToken 
 	}
 
 	return &Principal{
-		SubjectID:        ManagedIdentitySubjectID(identity.ID),
+		SubjectID:        IdentitySubjectID(identity.ID),
 		DisplayName:      identity.DisplayName,
-		Kind:             KindWorkload,
+		Kind:             KindIdentity,
 		Source:           SourceAPIToken,
 		Scopes:           PermissionPlugins(effectivePerms),
 		TokenPermissions: effectivePerms,
 	}, nil
 }
 
-func (r *Resolver) resolveWorkloadToken(token string) (*Principal, error) {
+func (r *Resolver) resolveIdentityToken(token string) (*Principal, error) {
 	if r.workloads == nil {
 		return nil, ErrInvalidToken
 	}
-	workload, ok := r.workloads.ResolveWorkloadToken(token)
-	if !ok || workload == nil || workload.ID == "" {
+	identity, ok := r.workloads.ResolveIdentityToken(token)
+	if !ok || identity == nil || identity.ID == "" {
 		return nil, ErrInvalidToken
 	}
 	return &Principal{
-		Kind:        KindWorkload,
-		SubjectID:   WorkloadSubjectID(workload.ID),
-		DisplayName: workload.DisplayName,
-		Source:      SourceWorkloadToken,
+		Kind:        KindIdentity,
+		SubjectID:   IdentitySubjectID(identity.ID),
+		DisplayName: identity.DisplayName,
+		Source:      SourceIdentityToken,
 	}, nil
 }
 

--- a/gestaltd/internal/providerhost/provider_client.go
+++ b/gestaltd/internal/providerhost/provider_client.go
@@ -342,8 +342,10 @@ func subjectKindForPrincipal(p *principal.Principal) string {
 	switch {
 	case strings.HasPrefix(p.SubjectID, string(principal.KindUser)+":"):
 		return string(principal.KindUser)
-	case strings.HasPrefix(p.SubjectID, string(principal.KindWorkload)+":"):
-		return string(principal.KindWorkload)
+	case strings.HasPrefix(p.SubjectID, "identity:"):
+		return string(principal.KindIdentity)
+	case strings.HasPrefix(p.SubjectID, "managed_identity:"):
+		return string(principal.KindIdentity)
 	}
 	if p.UserID != "" || p.Identity != nil {
 		return string(principal.KindUser)

--- a/gestaltd/internal/providerhost/provider_server.go
+++ b/gestaltd/internal/providerhost/provider_server.go
@@ -112,16 +112,19 @@ func principalFromProto(subject *proto.SubjectContext) *principal.Principal {
 	switch subject.GetKind() {
 	case string(principal.KindUser):
 		p.Kind = principal.KindUser
-	case string(principal.KindWorkload):
-		p.Kind = principal.KindWorkload
+	case string(principal.KindIdentity):
+		p.Kind = principal.KindIdentity
 	}
-	if strings.HasPrefix(subject.GetId(), "user:") {
+	switch {
+	case strings.HasPrefix(subject.GetId(), "user:"):
 		p.UserID = strings.TrimPrefix(subject.GetId(), "user:")
 		if p.Kind == "" {
 			p.Kind = principal.KindUser
 		}
-	} else if strings.HasPrefix(subject.GetId(), "workload:") && p.Kind == "" {
-		p.Kind = principal.KindWorkload
+	case strings.HasPrefix(subject.GetId(), "identity:") && p.Kind == "":
+		p.Kind = principal.KindIdentity
+	case strings.HasPrefix(subject.GetId(), "managed_identity:") && p.Kind == "":
+		p.Kind = principal.KindIdentity
 	}
 	if p.Kind == principal.KindUser && subject.GetDisplayName() != "" {
 		p.Identity = &core.UserIdentity{
@@ -140,8 +143,8 @@ func sourceFromString(raw string) principal.Source {
 		return principal.SourceSession
 	case principal.SourceAPIToken.String():
 		return principal.SourceAPIToken
-	case principal.SourceWorkloadToken.String():
-		return principal.SourceWorkloadToken
+	case principal.SourceIdentityToken.String():
+		return principal.SourceIdentityToken
 	case principal.SourceEnv.String():
 		return principal.SourceEnv
 	default:

--- a/gestaltd/internal/providerhost/provider_test.go
+++ b/gestaltd/internal/providerhost/provider_test.go
@@ -208,15 +208,26 @@ func TestRemoteProviderRoundTrip(t *testing.T) {
 			wantSessionCatalog: "token-123|user:user-123|user|Ada|true|api_token|identity|roadmap|admin",
 		},
 		{
-			name: "workload subject",
+			name: "identity token subject",
 			principal: &principal.Principal{
 				SubjectID:   principal.WorkloadSubjectID("triage-bot"),
 				DisplayName: "Triage Bot",
-				Kind:        principal.KindWorkload,
-				Source:      principal.SourceWorkloadToken,
+				Kind:        principal.KindIdentity,
+				Source:      principal.SourceIdentityToken,
 			},
-			wantExecuteBody:    "echo|secret-token|hi|acme|workload:triage-bot|workload|Triage Bot|false|workload_token|identity|identity:__identity__|roadmap|admin",
-			wantSessionCatalog: "token-123|workload:triage-bot|workload|Triage Bot|false|workload_token|identity|roadmap|admin",
+			wantExecuteBody:    "echo|secret-token|hi|acme|identity:triage-bot|identity|Triage Bot|false|identity_token|identity|identity:__identity__|roadmap|admin",
+			wantSessionCatalog: "token-123|identity:triage-bot|identity|Triage Bot|false|identity_token|identity|roadmap|admin",
+		},
+		{
+			name: "managed identity subject",
+			principal: &principal.Principal{
+				SubjectID:   principal.ManagedIdentitySubjectID("release-bot"),
+				DisplayName: "Release Bot",
+				Kind:        principal.KindIdentity,
+				Source:      principal.SourceAPIToken,
+			},
+			wantExecuteBody:    "echo|secret-token|hi|acme|identity:release-bot|identity|Release Bot|false|api_token|identity|identity:__identity__|roadmap|admin",
+			wantSessionCatalog: "token-123|identity:release-bot|identity|Release Bot|false|api_token|identity|roadmap|admin",
 		},
 	}
 
@@ -291,8 +302,8 @@ func TestRequestContextProto_PreservesWorkloadDisplayName(t *testing.T) {
 	ctx := principal.WithPrincipal(context.Background(), &principal.Principal{
 		SubjectID:   principal.WorkloadSubjectID("triage-bot"),
 		DisplayName: "Triage Bot",
-		Kind:        principal.KindWorkload,
-		Source:      principal.SourceWorkloadToken,
+		Kind:        principal.KindIdentity,
+		Source:      principal.SourceIdentityToken,
 	})
 	ctx = invocation.WithAccessContext(ctx, invocation.AccessContext{
 		Policy: "roadmap",
@@ -346,9 +357,9 @@ func TestPrincipalFromProto_WorkloadDisplayNameDoesNotCreateIdentity(t *testing.
 
 	p := principalFromProto(&proto.SubjectContext{
 		Id:          principal.WorkloadSubjectID("triage-bot"),
-		Kind:        string(principal.KindWorkload),
+		Kind:        string(principal.KindIdentity),
 		DisplayName: "Triage Bot",
-		AuthSource:  principal.SourceWorkloadToken.String(),
+		AuthSource:  principal.SourceIdentityToken.String(),
 	})
 	if p == nil {
 		t.Fatal("expected principal")
@@ -358,6 +369,29 @@ func TestPrincipalFromProto_WorkloadDisplayNameDoesNotCreateIdentity(t *testing.
 	}
 	if p.Identity != nil {
 		t.Fatalf("expected workload identity to remain nil, got %#v", p.Identity)
+	}
+}
+
+func TestPrincipalFromProto_ManagedIdentityKindRoundTrips(t *testing.T) {
+	t.Parallel()
+
+	p := principalFromProto(&proto.SubjectContext{
+		Id:          principal.ManagedIdentitySubjectID("release-bot"),
+		Kind:        string(principal.KindIdentity),
+		DisplayName: "Release Bot",
+		AuthSource:  principal.SourceAPIToken.String(),
+	})
+	if p == nil {
+		t.Fatal("expected principal")
+	}
+	if p.Kind != principal.KindIdentity {
+		t.Fatalf("kind = %q, want %q", p.Kind, principal.KindIdentity)
+	}
+	if p.DisplayName != "Release Bot" {
+		t.Fatalf("display name = %q, want %q", p.DisplayName, "Release Bot")
+	}
+	if p.Identity != nil {
+		t.Fatalf("expected managed identity principal to remain non-human, got %#v", p.Identity)
 	}
 }
 

--- a/gestaltd/internal/providerhost/request_snapshot.go
+++ b/gestaltd/internal/providerhost/request_snapshot.go
@@ -172,5 +172,5 @@ func restoreRequestSnapshotContext(ctx context.Context, snapshot requestSnapshot
 }
 
 func shouldInheritCredentialSelectors(snapshot requestSnapshot) bool {
-	return snapshot.principal == nil || snapshot.principal.Kind != principal.KindWorkload
+	return snapshot.principal == nil || snapshot.principal.HasUserContext()
 }

--- a/gestaltd/internal/providerhost/workflow_server_test.go
+++ b/gestaltd/internal/providerhost/workflow_server_test.go
@@ -566,9 +566,9 @@ func TestWorkflowServerPrefersWorkflowCreatorForWorkflowMutations(t *testing.T) 
 	srv := NewWorkflowServer("roadmap", staticWorkflowResolver(provider, map[string]struct{}{"refresh": {}}, nil, nil, nil))
 	ctx := principal.WithPrincipal(context.Background(), &principal.Principal{
 		SubjectID:   principal.WorkloadSubjectID("planner"),
-		Kind:        principal.KindWorkload,
+		Kind:        principal.KindIdentity,
 		DisplayName: "Planner",
-		Source:      principal.SourceWorkloadToken,
+		Source:      principal.SourceIdentityToken,
 	})
 	ctx = invocation.WithWorkflowContext(ctx, map[string]any{
 		"createdBy": map[string]any{

--- a/gestaltd/internal/server/audit.go
+++ b/gestaltd/internal/server/audit.go
@@ -39,7 +39,7 @@ func (s *Server) resolvePrincipalUserID(ctx context.Context, p *principal.Princi
 	if p == nil {
 		return nil, nil
 	}
-	if p.Kind == principal.KindWorkload {
+	if !p.HasUserContext() {
 		return p, nil
 	}
 	if p.Kind == "" {

--- a/gestaltd/internal/server/audit_metadata_test.go
+++ b/gestaltd/internal/server/audit_metadata_test.go
@@ -310,7 +310,7 @@ func TestAuditMetadata_WorkloadSubjectAndCredentialPath(t *testing.T) {
 	var auditBuf bytes.Buffer
 	auditSink := invocation.NewSlogAuditSink(&auditBuf)
 
-	workloadToken, _, err := principal.GenerateToken(principal.TokenTypeWorkload)
+	workloadToken, _, err := principal.GenerateToken(principal.TokenTypeIdentity)
 	if err != nil {
 		t.Fatalf("GenerateToken: %v", err)
 	}
@@ -331,10 +331,9 @@ func TestAuditMetadata_WorkloadSubjectAndCredentialPath(t *testing.T) {
 
 	providers := testutil.NewProviderRegistry(t, stub)
 	authz, err := authorization.New(config.AuthorizationConfig{
-		Workloads: map[string]config.WorkloadDef{
+		IdentityTokens: map[string]config.WorkloadDef{
 			"triage-bot": {
-				IdentityID: "triage-bot",
-				Token:      workloadToken,
+				Token: workloadToken,
 				Providers: map[string]config.WorkloadProviderDef{
 					"audit-workload-prov": {
 						Connection: "workspace",
@@ -398,11 +397,11 @@ func TestAuditMetadata_WorkloadSubjectAndCredentialPath(t *testing.T) {
 		t.Fatalf("failed to parse audit JSON: %v\nraw: %s", err, auditBuf.String())
 	}
 
-	if record["subject_id"] != "workload:triage-bot" {
-		t.Fatalf("expected workload subject_id, got %v", record["subject_id"])
+	if record["subject_id"] != "identity:triage-bot" {
+		t.Fatalf("expected identity subject_id, got %v", record["subject_id"])
 	}
-	if record["subject_kind"] != "workload" {
-		t.Fatalf("expected subject_kind=workload, got %v", record["subject_kind"])
+	if record["subject_kind"] != "identity" {
+		t.Fatalf("expected subject_kind=identity, got %v", record["subject_kind"])
 	}
 	if record["credential_mode"] != "identity" {
 		t.Fatalf("expected credential_mode=identity, got %v", record["credential_mode"])

--- a/gestaltd/internal/server/authorization.go
+++ b/gestaltd/internal/server/authorization.go
@@ -34,32 +34,32 @@ func (s *Server) providerAccessContextWithContext(ctx context.Context, p *princi
 	return access
 }
 
-func (s *Server) workloadBinding(p *principal.Principal, provider string) (authorization.CredentialBinding, bool) {
+func (s *Server) identityBinding(p *principal.Principal, provider string) (authorization.CredentialBinding, bool) {
 	if s.authorizer == nil {
 		return authorization.CredentialBinding{}, false
 	}
 	return s.authorizer.Binding(p, provider)
 }
 
-func rejectWorkloadSelectors(w http.ResponseWriter, p *principal.Principal, connection, instance string) error {
-	if p == nil || p.Kind != principal.KindWorkload {
+func rejectHeadlessSelectors(w http.ResponseWriter, p *principal.Principal, connection, instance string) error {
+	if p == nil || p.HasUserContext() {
 		return nil
 	}
 	if connection == "" && instance == "" {
 		return nil
 	}
-	writeError(w, http.StatusForbidden, errWorkloadSelector.Error())
-	return errWorkloadSelector
+	writeError(w, http.StatusForbidden, errHeadlessSelector.Error())
+	return errHeadlessSelector
 }
 
-func (s *Server) workloadBindingSelectors(p *principal.Principal, provider, connection, instance string) (string, string) {
+func (s *Server) identityBindingSelectors(p *principal.Principal, provider, connection, instance string) (string, string) {
 	resolveConnection := func(connection string) string {
 		return s.sessionCatalogConnections(provider, nil, connection)[0]
 	}
-	if p == nil || p.Kind != principal.KindWorkload {
+	if p == nil || p.HasUserContext() {
 		return resolveConnection(connection), instance
 	}
-	binding, ok := s.workloadBinding(p, provider)
+	binding, ok := s.identityBinding(p, provider)
 	if !ok {
 		return resolveConnection(connection), instance
 	}
@@ -72,13 +72,13 @@ func (s *Server) workloadBindingSelectors(p *principal.Principal, provider, conn
 	return resolveConnection(connection), instance
 }
 
-func (s *Server) workloadBindingConnected(ctx context.Context, binding authorization.CredentialBinding, provider string) (bool, error) {
+func (s *Server) identityBindingConnected(ctx context.Context, binding authorization.CredentialBinding, provider string) (bool, error) {
 	switch binding.Mode {
 	case core.ConnectionModeNone:
 		return true, nil
 	case core.ConnectionModeIdentity:
 		if strings.TrimSpace(binding.CredentialOwnerID) == "" {
-			return false, errors.New("workload binding missing identity owner")
+			return false, errors.New("identity binding missing owner identity")
 		}
 		_, err := s.tokens.IdentityToken(ctx, binding.CredentialOwnerID, provider, binding.Connection, binding.Instance)
 		switch {

--- a/gestaltd/internal/server/catalog_resolution_test.go
+++ b/gestaltd/internal/server/catalog_resolution_test.go
@@ -523,10 +523,9 @@ func TestFilterCatalogForPrincipal_WorkloadFilteringUsesMergedCatalog(t *testing
 
 	providers := testutil.NewProviderRegistry(t, prov)
 	authz, err := authorization.New(config.AuthorizationConfig{
-		Workloads: map[string]config.WorkloadDef{
+		IdentityTokens: map[string]config.WorkloadDef{
 			"triage-bot": {
-				IdentityID: "triage-bot",
-				Token:      "gst_wld_triage-bot-token",
+				Token: "gst_wld_triage-bot-token",
 				Providers: map[string]config.WorkloadProviderDef{
 					"clash-api": {
 						Connection: "default",
@@ -542,8 +541,9 @@ func TestFilterCatalogForPrincipal_WorkloadFilteringUsesMergedCatalog(t *testing
 	}
 
 	p := &principal.Principal{
-		Kind:      principal.KindWorkload,
+		Kind:      principal.KindIdentity,
 		SubjectID: principal.WorkloadSubjectID("triage-bot"),
+		Source:    principal.SourceIdentityToken,
 	}
 	cat, err := invocation.ResolveCatalog(context.Background(), prov, "clash-api", &stubTokenResolver{token: "tok_456"}, p, "default", "")
 	if err != nil {
@@ -552,7 +552,7 @@ func TestFilterCatalogForPrincipal_WorkloadFilteringUsesMergedCatalog(t *testing
 
 	filtered := invocation.FilterCatalogForPrincipal(context.Background(), cat, "clash-api", p, authz)
 	if len(filtered.Operations) != 2 {
-		t.Fatalf("expected 2 operations after workload filtering, got %d", len(filtered.Operations))
+		t.Fatalf("expected 2 operations after identity-token filtering, got %d", len(filtered.Operations))
 	}
 	if filtered.Operations[0].ID != "shared_op" {
 		t.Fatalf("expected first filtered op shared_op, got %q", filtered.Operations[0].ID)

--- a/gestaltd/internal/server/handlers.go
+++ b/gestaltd/internal/server/handlers.go
@@ -43,7 +43,7 @@ var (
 	errResolveUser      = errors.New("failed to resolve user")
 	errNonUserForbidden = errors.New("non-user callers are not allowed on this route")
 	errOperationAccess  = errors.New("operation access denied")
-	errWorkloadSelector = errors.New("workload callers may not override connection or instance bindings")
+	errHeadlessSelector = errors.New("identity-token callers may not override connection or instance bindings")
 )
 
 var (
@@ -165,11 +165,11 @@ func (s *Server) listIntegrations(w http.ResponseWriter, r *http.Request) {
 		if entry, ok := s.pluginDefs[name]; ok && entry != nil {
 			info.MountedPath = strings.TrimSpace(entry.MountPath)
 		}
-		if p != nil && p.IsWorkload() {
-			if binding, ok := s.workloadBinding(p, name); ok {
-				bindingConnected, err := s.workloadBindingConnected(r.Context(), binding, name)
+		if p != nil && !p.HasUserContext() {
+			if binding, ok := s.identityBinding(p, name); ok {
+				bindingConnected, err := s.identityBindingConnected(r.Context(), binding, name)
 				if err != nil {
-					slog.ErrorContext(r.Context(), "checking workload integration status", "provider", name, "error", err)
+					slog.ErrorContext(r.Context(), "checking identity integration status", "provider", name, "error", err)
 					writeError(w, http.StatusInternalServerError, "failed to check integration status")
 					return
 				}
@@ -445,7 +445,7 @@ func (s *Server) listOperations(w http.ResponseWriter, r *http.Request) {
 			return
 		}
 	}
-	if err := rejectWorkloadSelectors(w, p, requestedConnection, requestedInstance); err != nil {
+	if err := rejectHeadlessSelectors(w, p, requestedConnection, requestedInstance); err != nil {
 		s.auditHTTPEvent(r.Context(), p, name, operation, false, err)
 		return
 	}
@@ -540,7 +540,7 @@ func (s *Server) executeOperation(w http.ResponseWriter, r *http.Request) {
 			return
 		}
 	}
-	if err := rejectWorkloadSelectors(w, p, requestedConnection, requestedInstance); err != nil {
+	if err := rejectHeadlessSelectors(w, p, requestedConnection, requestedInstance); err != nil {
 		s.auditHTTPEvent(r.Context(), p, providerName, operationName, false, err)
 		return
 	}
@@ -594,7 +594,7 @@ func (s *Server) executeOperation(w http.ResponseWriter, r *http.Request) {
 		writeError(w, http.StatusBadRequest, fmt.Sprintf("conflicting connection parameter %q in query string and JSON body", httpConnectionParam))
 		return
 	}
-	if err := rejectWorkloadSelectors(w, p, bodyConnection, bodyInstance); err != nil {
+	if err := rejectHeadlessSelectors(w, p, bodyConnection, bodyInstance); err != nil {
 		s.auditHTTPEvent(r.Context(), p, providerName, operationName, false, err)
 		return
 	}
@@ -716,7 +716,7 @@ func (s *Server) sessionCatalogConnections(providerName string, p *principal.Pri
 	if explicit != "" {
 		return []string{config.ResolveConnectionAlias(explicit)}
 	}
-	if s.authorizer != nil && s.authorizer.IsWorkload(p) {
+	if p != nil && !p.HasUserContext() {
 		return []string{""}
 	}
 
@@ -744,7 +744,7 @@ func (s *Server) boundSessionCatalogConnections(providerName string, p *principa
 	boundConnections := make([]string, 0, len(connections))
 	boundInstance := instance
 	for _, connection := range connections {
-		connection, boundInstance = s.workloadBindingSelectors(p, providerName, connection, instance)
+		connection, boundInstance = s.identityBindingSelectors(p, providerName, connection, instance)
 		boundConnections = append(boundConnections, connection)
 	}
 	return boundConnections, boundInstance
@@ -754,7 +754,7 @@ func (s *Server) boundSessionCatalogTargets(providerName string, p *principal.Pr
 	connections := s.sessionCatalogConnections(providerName, p, explicit)
 	targets := make([]invocation.CatalogResolutionTarget, 0, len(connections))
 	for _, connection := range connections {
-		boundConnection, boundInstance := s.workloadBindingSelectors(p, providerName, connection, instance)
+		boundConnection, boundInstance := s.identityBindingSelectors(p, providerName, connection, instance)
 		targets = append(targets, invocation.CatalogResolutionTarget{
 			Connection: boundConnection,
 			Instance:   boundInstance,

--- a/gestaltd/internal/server/handlers_identities.go
+++ b/gestaltd/internal/server/handlers_identities.go
@@ -1182,7 +1182,7 @@ func (s *Server) managedIdentityGrantCatalogTargets(ctx context.Context, plugin 
 	}
 
 	for _, connection := range s.sessionCatalogConnections(plugin, p, "") {
-		connection, instance := s.workloadBindingSelectors(p, plugin, connection, "")
+		connection, instance := s.identityBindingSelectors(p, plugin, connection, "")
 		addTarget(connection, instance)
 	}
 	if p == nil || !p.HasUserContext() || strings.TrimSpace(p.UserID) == "" {

--- a/gestaltd/internal/server/middleware.go
+++ b/gestaltd/internal/server/middleware.go
@@ -114,8 +114,8 @@ func requestedAuthSource(r *http.Request) string {
 			switch typ {
 			case principal.TokenTypeAPI:
 				return principal.SourceAPIToken.String()
-			case principal.TokenTypeWorkload:
-				return principal.SourceWorkloadToken.String()
+			case principal.TokenTypeIdentity:
+				return principal.SourceIdentityToken.String()
 			}
 		}
 		return principal.SourceSession.String()

--- a/gestaltd/internal/server/server_test.go
+++ b/gestaltd/internal/server/server_test.go
@@ -875,14 +875,16 @@ func seedLegacyUserRecord(t *testing.T, svc *coredata.Services, id, email string
 
 func seedIdentityToken(t *testing.T, svc *coredata.Services, integration, connection, instance, accessToken string) {
 	t.Helper()
-	seedToken(t, svc, &core.IntegrationToken{
+	if err := svc.Tokens.StoreIdentityToken(t.Context(), &core.IntegrationToken{
 		ID:          integration + "-" + connection + "-" + instance,
-		UserID:      principal.IdentityPrincipal,
+		IdentityID:  principal.IdentityPrincipal,
 		Integration: integration,
 		Connection:  connection,
 		Instance:    instance,
 		AccessToken: accessToken,
-	})
+	}); err != nil {
+		t.Fatalf("StoreIdentityToken: %v", err)
+	}
 }
 
 func seedIdentityOwnedToken(t *testing.T, svc *coredata.Services, identityID, integration, connection, instance, accessToken string) {
@@ -4545,10 +4547,10 @@ func TestAuthMiddleware_ValidAPIToken(t *testing.T) {
 	}
 }
 
-func TestAuthMiddleware_ValidWorkloadToken(t *testing.T) {
+func TestAuthMiddleware_ValidIdentityToken(t *testing.T) {
 	t.Parallel()
 
-	plaintext, _, err := principal.GenerateToken(principal.TokenTypeWorkload)
+	plaintext, _, err := principal.GenerateToken(principal.TokenTypeIdentity)
 	if err != nil {
 		t.Fatalf("GenerateToken: %v", err)
 	}
@@ -4559,7 +4561,7 @@ func TestAuthMiddleware_ValidWorkloadToken(t *testing.T) {
 	}
 	providers := testutil.NewProviderRegistry(t, stub)
 	authz := mustAuthorizer(t, config.AuthorizationConfig{
-		Workloads: map[string]config.WorkloadDef{
+		IdentityTokens: map[string]config.WorkloadDef{
 			"weather-bot": {
 				Token: plaintext,
 				Providers: map[string]config.WorkloadProviderDef{
@@ -5035,10 +5037,10 @@ func TestListIntegrations_HumanAuthorizationFiltersByMountedUIAccessAndVisibleOp
 	}
 }
 
-func TestWorkloadAuthorization_ListIntegrationsFiltersAndHidesConnectionAffordances(t *testing.T) {
+func TestIdentityTokenAuthorization_ListIntegrationsFiltersAndHidesConnectionAffordances(t *testing.T) {
 	t.Parallel()
 
-	workloadToken, _, err := principal.GenerateToken(principal.TokenTypeWorkload)
+	workloadToken, _, err := principal.GenerateToken(principal.TokenTypeIdentity)
 	if err != nil {
 		t.Fatalf("GenerateToken: %v", err)
 	}
@@ -5068,10 +5070,9 @@ func TestWorkloadAuthorization_ListIntegrationsFiltersAndHidesConnectionAffordan
 	}
 	providers := testutil.NewProviderRegistry(t, svcProvider, weatherProvider, mcpOnlyProvider, secretProvider)
 	authz := mustAuthorizer(t, config.AuthorizationConfig{
-		Workloads: map[string]config.WorkloadDef{
+		IdentityTokens: map[string]config.WorkloadDef{
 			"triage-bot": {
-				IdentityID: "triage-bot",
-				Token:      workloadToken,
+				Token: workloadToken,
 				Providers: map[string]config.WorkloadProviderDef{
 					"svc":      {Allow: []string{"run"}},
 					"weather":  {Allow: []string{"forecast"}},
@@ -5176,14 +5177,14 @@ func TestWorkloadAuthorization_ListIntegrationsFiltersAndHidesConnectionAffordan
 
 	if resp.StatusCode != http.StatusInternalServerError {
 		body, _ := io.ReadAll(resp.Body)
-		t.Fatalf("expected 500 when workload binding lookup fails, got %d: %s", resp.StatusCode, body)
+		t.Fatalf("expected 500 when identity binding lookup fails, got %d: %s", resp.StatusCode, body)
 	}
 }
 
-func TestWorkloadAuthorization_ListOperationsFiltersAndRejectsSelectors(t *testing.T) {
+func TestIdentityTokenAuthorization_ListOperationsFiltersAndRejectsSelectors(t *testing.T) {
 	t.Parallel()
 
-	workloadToken, _, err := principal.GenerateToken(principal.TokenTypeWorkload)
+	workloadToken, _, err := principal.GenerateToken(principal.TokenTypeIdentity)
 	if err != nil {
 		t.Fatalf("GenerateToken: %v", err)
 	}
@@ -5197,10 +5198,9 @@ func TestWorkloadAuthorization_ListOperationsFiltersAndRejectsSelectors(t *testi
 	}
 	providers := testutil.NewProviderRegistry(t, provider)
 	authz := mustAuthorizer(t, config.AuthorizationConfig{
-		Workloads: map[string]config.WorkloadDef{
+		IdentityTokens: map[string]config.WorkloadDef{
 			"triage-bot": {
-				IdentityID: "triage-bot",
-				Token:      workloadToken,
+				Token: workloadToken,
 				Providers: map[string]config.WorkloadProviderDef{
 					"svc": {
 						Connection: "workspace",
@@ -5274,13 +5274,13 @@ func TestWorkloadAuthorization_ListOperationsFiltersAndRejectsSelectors(t *testi
 	if auditRecord["allowed"] != false {
 		t.Fatalf("expected denied audit record, got %v", auditRecord["allowed"])
 	}
-	if auditRecord["auth_source"] != "workload_token" {
-		t.Fatalf("expected workload auth_source, got %v", auditRecord["auth_source"])
+	if auditRecord["auth_source"] != "identity_token" {
+		t.Fatalf("expected identity auth_source, got %v", auditRecord["auth_source"])
 	}
-	if auditRecord["subject_id"] != "workload:triage-bot" {
-		t.Fatalf("expected workload subject_id, got %v", auditRecord["subject_id"])
+	if auditRecord["subject_id"] != "identity:triage-bot" {
+		t.Fatalf("expected identity subject_id, got %v", auditRecord["subject_id"])
 	}
-	if auditRecord["error"] != "workload callers may not override connection or instance bindings" {
+	if auditRecord["error"] != "identity-token callers may not override connection or instance bindings" {
 		t.Fatalf("unexpected audit error: %v", auditRecord["error"])
 	}
 
@@ -5304,10 +5304,9 @@ func TestWorkloadAuthorization_ListOperationsFiltersAndRejectsSelectors(t *testi
 	}
 	sessionProviders := testutil.NewProviderRegistry(t, sessionProvider)
 	sessionAuthz := mustAuthorizer(t, config.AuthorizationConfig{
-		Workloads: map[string]config.WorkloadDef{
+		IdentityTokens: map[string]config.WorkloadDef{
 			"triage-bot": {
-				IdentityID: "triage-bot",
-				Token:      workloadToken,
+				Token: workloadToken,
 				Providers: map[string]config.WorkloadProviderDef{
 					"svc-session": {
 						Connection: "workspace",
@@ -8276,10 +8275,10 @@ func TestExecuteOperation_NoStoredToken(t *testing.T) {
 
 }
 
-func TestWorkloadAuthorization_ExecuteOperation_UsesBoundIdentityAndRejectsSelectors(t *testing.T) {
+func TestIdentityTokenAuthorization_ExecuteOperation_UsesBoundIdentityAndRejectsSelectors(t *testing.T) {
 	t.Parallel()
 
-	workloadToken, _, err := principal.GenerateToken(principal.TokenTypeWorkload)
+	workloadToken, _, err := principal.GenerateToken(principal.TokenTypeIdentity)
 	if err != nil {
 		t.Fatalf("GenerateToken: %v", err)
 	}
@@ -8302,10 +8301,9 @@ func TestWorkloadAuthorization_ExecuteOperation_UsesBoundIdentityAndRejectsSelec
 	}
 	providers := testutil.NewProviderRegistry(t, stub)
 	authz := mustAuthorizer(t, config.AuthorizationConfig{
-		Workloads: map[string]config.WorkloadDef{
+		IdentityTokens: map[string]config.WorkloadDef{
 			"triage-bot": {
-				IdentityID: "triage-bot",
-				Token:      workloadToken,
+				Token: workloadToken,
 				Providers: map[string]config.WorkloadProviderDef{
 					"svc": {
 						Connection: "workspace",
@@ -8408,13 +8406,13 @@ func TestWorkloadAuthorization_ExecuteOperation_UsesBoundIdentityAndRejectsSelec
 	if selectorAudit["allowed"] != false {
 		t.Fatalf("expected selector audit allowed=false, got %v", selectorAudit["allowed"])
 	}
-	if selectorAudit["auth_source"] != "workload_token" {
-		t.Fatalf("expected selector audit auth_source workload_token, got %v", selectorAudit["auth_source"])
+	if selectorAudit["auth_source"] != "identity_token" {
+		t.Fatalf("expected selector audit auth_source identity_token, got %v", selectorAudit["auth_source"])
 	}
-	if selectorAudit["subject_id"] != "workload:triage-bot" {
-		t.Fatalf("expected selector audit subject_id workload:triage-bot, got %v", selectorAudit["subject_id"])
+	if selectorAudit["subject_id"] != "identity:triage-bot" {
+		t.Fatalf("expected selector audit subject_id identity:triage-bot, got %v", selectorAudit["subject_id"])
 	}
-	if selectorAudit["error"] != "workload callers may not override connection or instance bindings" {
+	if selectorAudit["error"] != "identity-token callers may not override connection or instance bindings" {
 		t.Fatalf("unexpected selector audit error: %v", selectorAudit["error"])
 	}
 }
@@ -8823,10 +8821,10 @@ func TestHumanAuthorization_ExecuteOperation_UsesResolvedRoleAndRejectsDisallowe
 	}
 }
 
-func TestWorkloadAuthorization_ExecuteOperation_MissingBoundIdentityTokenReturns412(t *testing.T) {
+func TestIdentityTokenAuthorization_ExecuteOperation_MissingBoundIdentityTokenReturns412(t *testing.T) {
 	t.Parallel()
 
-	workloadToken, _, err := principal.GenerateToken(principal.TokenTypeWorkload)
+	workloadToken, _, err := principal.GenerateToken(principal.TokenTypeIdentity)
 	if err != nil {
 		t.Fatalf("GenerateToken: %v", err)
 	}
@@ -8843,10 +8841,9 @@ func TestWorkloadAuthorization_ExecuteOperation_MissingBoundIdentityTokenReturns
 	}
 	providers := testutil.NewProviderRegistry(t, stub)
 	authz := mustAuthorizer(t, config.AuthorizationConfig{
-		Workloads: map[string]config.WorkloadDef{
+		IdentityTokens: map[string]config.WorkloadDef{
 			"triage-bot": {
-				IdentityID: "triage-bot",
-				Token:      workloadToken,
+				Token: workloadToken,
 				Providers: map[string]config.WorkloadProviderDef{
 					"svc": {
 						Connection: "workspace",
@@ -8888,8 +8885,8 @@ func TestWorkloadAuthorization_ExecuteOperation_MissingBoundIdentityTokenReturns
 	if err := json.Unmarshal(auditBuf.Bytes(), &record); err != nil {
 		t.Fatalf("failed to parse audit JSON: %v\nraw: %s", err, auditBuf.String())
 	}
-	if record["subject_id"] != "workload:triage-bot" {
-		t.Fatalf("expected workload subject_id, got %v", record["subject_id"])
+	if record["subject_id"] != "identity:triage-bot" {
+		t.Fatalf("expected identity subject_id, got %v", record["subject_id"])
 	}
 	if record["credential_subject_id"] != "identity:triage-bot" {
 		t.Fatalf("expected credential_subject_id identity principal, got %v", record["credential_subject_id"])
@@ -8902,10 +8899,10 @@ func TestWorkloadAuthorization_ExecuteOperation_MissingBoundIdentityTokenReturns
 	}
 }
 
-func TestWorkloadAuthorization_HumanRoutesReturn403(t *testing.T) {
+func TestIdentityTokenAuthorization_HumanRoutesReturn403(t *testing.T) {
 	t.Parallel()
 
-	workloadToken, _, err := principal.GenerateToken(principal.TokenTypeWorkload)
+	workloadToken, _, err := principal.GenerateToken(principal.TokenTypeIdentity)
 	if err != nil {
 		t.Fatalf("GenerateToken: %v", err)
 	}
@@ -8916,7 +8913,7 @@ func TestWorkloadAuthorization_HumanRoutesReturn403(t *testing.T) {
 	}
 	providers := testutil.NewProviderRegistry(t, stub)
 	authz := mustAuthorizer(t, config.AuthorizationConfig{
-		Workloads: map[string]config.WorkloadDef{
+		IdentityTokens: map[string]config.WorkloadDef{
 			"triage-bot": {
 				Token: workloadToken,
 				Providers: map[string]config.WorkloadProviderDef{
@@ -13607,10 +13604,9 @@ func TestMCPEndpoint_WorkloadAuthorizationAndAudit(t *testing.T) {
 
 	providers := testutil.NewProviderRegistry(t, prov)
 	authz := mustAuthorizer(t, config.AuthorizationConfig{
-		Workloads: map[string]config.WorkloadDef{
+		IdentityTokens: map[string]config.WorkloadDef{
 			"triage-bot": {
-				IdentityID: "triage-bot",
-				Token:      "gst_wld_triage-bot-token",
+				Token: "gst_wld_triage-bot-token",
 				Providers: map[string]config.WorkloadProviderDef{
 					"clickhouse": {
 						Connection: "default",
@@ -13725,14 +13721,14 @@ func TestMCPEndpoint_WorkloadAuthorizationAndAudit(t *testing.T) {
 	if auditRecord["allowed"] != false {
 		t.Fatalf("expected audit allowed=false, got %v", auditRecord["allowed"])
 	}
-	if auditRecord["auth_source"] != "workload_token" {
-		t.Fatalf("expected audit auth_source workload_token, got %v", auditRecord["auth_source"])
+	if auditRecord["auth_source"] != "identity_token" {
+		t.Fatalf("expected audit auth_source identity_token, got %v", auditRecord["auth_source"])
 	}
-	if auditRecord["subject_id"] != "workload:triage-bot" {
-		t.Fatalf("expected subject_id workload:triage-bot, got %v", auditRecord["subject_id"])
+	if auditRecord["subject_id"] != "identity:triage-bot" {
+		t.Fatalf("expected subject_id identity:triage-bot, got %v", auditRecord["subject_id"])
 	}
-	if auditRecord["subject_kind"] != "workload" {
-		t.Fatalf("expected subject_kind workload, got %v", auditRecord["subject_kind"])
+	if auditRecord["subject_kind"] != "identity" {
+		t.Fatalf("expected subject_kind identity, got %v", auditRecord["subject_kind"])
 	}
 	if auditRecord["credential_mode"] != "identity" {
 		t.Fatalf("expected credential_mode identity, got %v", auditRecord["credential_mode"])
@@ -14174,7 +14170,7 @@ func (s *stubHostIssuedSessionAuth) SessionTokenTTL() time.Duration {
 func TestCookieAuth(t *testing.T) {
 	t.Parallel()
 
-	workloadToken, _, err := principal.GenerateToken(principal.TokenTypeWorkload)
+	workloadToken, _, err := principal.GenerateToken(principal.TokenTypeIdentity)
 	if err != nil {
 		t.Fatalf("GenerateToken: %v", err)
 	}
@@ -14197,7 +14193,7 @@ func TestCookieAuth(t *testing.T) {
 		cfg.Auth = stub
 		cfg.Services = coretesting.NewStubServices(t)
 		cfg.Authorizer = mustAuthorizer(t, config.AuthorizationConfig{
-			Workloads: map[string]config.WorkloadDef{
+			IdentityTokens: map[string]config.WorkloadDef{
 				"triage-bot": {Token: workloadToken},
 			},
 		}, nil, nil, nil)
@@ -14578,10 +14574,16 @@ func TestExecuteOperation_ConnectionModeIdentity(t *testing.T) {
 	t.Parallel()
 
 	svc := coretesting.NewStubServices(t)
-	seedToken(t, svc, &core.IntegrationToken{
-		ID: "tok1", UserID: principal.IdentityPrincipal, Integration: "svc",
-		Connection: "", Instance: "default", AccessToken: "identity-tok",
-	})
+	if err := svc.Tokens.StoreIdentityToken(t.Context(), &core.IntegrationToken{
+		ID:          "tok1",
+		IdentityID:  principal.IdentityPrincipal,
+		Integration: "svc",
+		Connection:  config.PluginConnectionName,
+		Instance:    "default",
+		AccessToken: "identity-tok",
+	}); err != nil {
+		t.Fatalf("StoreIdentityToken: %v", err)
+	}
 
 	stub := &stubIntegrationWithOps{
 		StubIntegration: coretesting.StubIntegration{
@@ -14596,6 +14598,7 @@ func TestExecuteOperation_ConnectionModeIdentity(t *testing.T) {
 
 	ts := newTestServer(t, func(cfg *server.Config) {
 		cfg.Providers = testutil.NewProviderRegistry(t, stub)
+		cfg.DefaultConnection = map[string]string{"svc": config.PluginConnectionName}
 		cfg.Services = svc
 	})
 	testutil.CloseOnCleanup(t, ts)
@@ -14630,10 +14633,16 @@ func TestExecuteOperation_ConnectionModeUserDoesNotFallbackToIdentity(t *testing
 		t.Fatalf("GenerateToken: %v", err)
 	}
 	seedAPIToken(t, svc, apiToken, hashed, "api-user")
-	seedToken(t, svc, &core.IntegrationToken{
-		ID: "tok-identity", UserID: principal.IdentityPrincipal, Integration: "svc",
-		Connection: "", Instance: "default", AccessToken: "identity-tok",
-	})
+	if err := svc.Tokens.StoreIdentityToken(t.Context(), &core.IntegrationToken{
+		ID:          "tok-identity",
+		IdentityID:  principal.IdentityPrincipal,
+		Integration: "svc",
+		Connection:  config.PluginConnectionName,
+		Instance:    "default",
+		AccessToken: "identity-tok",
+	}); err != nil {
+		t.Fatalf("StoreIdentityToken: %v", err)
+	}
 
 	stub := &stubIntegrationWithOps{
 		StubIntegration: coretesting.StubIntegration{
@@ -14649,6 +14658,7 @@ func TestExecuteOperation_ConnectionModeUserDoesNotFallbackToIdentity(t *testing
 	ts := newTestServer(t, func(cfg *server.Config) {
 		cfg.Auth = &coretesting.StubAuthProvider{N: "test"}
 		cfg.Providers = testutil.NewProviderRegistry(t, stub)
+		cfg.DefaultConnection = map[string]string{"svc": config.PluginConnectionName}
 		cfg.Services = svc
 	})
 	testutil.CloseOnCleanup(t, ts)
@@ -16581,6 +16591,7 @@ func TestManagedIdentityTokens_RoleMatrix(t *testing.T) {
 	if err != nil {
 		t.Fatalf("authorization.New: %v", err)
 	}
+	var auditBuf bytes.Buffer
 
 	ts := newTestServer(t, func(cfg *server.Config) {
 		cfg.Auth = &coretesting.StubAuthProvider{
@@ -16601,6 +16612,7 @@ func TestManagedIdentityTokens_RoleMatrix(t *testing.T) {
 		cfg.Providers = providers
 		cfg.Services = svc
 		cfg.Authorizer = authz
+		cfg.AuditSink = invocation.NewSlogAuditSink(&auditBuf)
 	})
 	testutil.CloseOnCleanup(t, ts)
 
@@ -16963,6 +16975,7 @@ func TestManagedIdentityAPITokenInvocation_ModeNoneOnly(t *testing.T) {
 	if err != nil {
 		t.Fatalf("authorization.New: %v", err)
 	}
+	var auditBuf bytes.Buffer
 
 	ts := newTestServer(t, func(cfg *server.Config) {
 		cfg.Auth = &coretesting.StubAuthProvider{
@@ -16977,6 +16990,7 @@ func TestManagedIdentityAPITokenInvocation_ModeNoneOnly(t *testing.T) {
 		cfg.Providers = providers
 		cfg.Services = svc
 		cfg.Authorizer = authz
+		cfg.AuditSink = invocation.NewSlogAuditSink(&auditBuf)
 	})
 	testutil.CloseOnCleanup(t, ts)
 
@@ -17061,6 +17075,21 @@ func TestManagedIdentityAPITokenInvocation_ModeNoneOnly(t *testing.T) {
 	}
 	if status := call("/api/v1/gamma/query"); status != http.StatusForbidden {
 		t.Fatalf("gamma/query status = %d, want 403", status)
+	}
+
+	lines := bytes.Split(bytes.TrimSpace(auditBuf.Bytes()), []byte("\n"))
+	if len(lines) == 0 {
+		t.Fatal("expected managed identity audit record")
+	}
+	var auditRecord map[string]any
+	if err := json.Unmarshal(lines[len(lines)-1], &auditRecord); err != nil {
+		t.Fatalf("parsing managed identity audit record: %v\nraw: %s", err, auditBuf.String())
+	}
+	if auditRecord["subject_id"] != "identity:"+createResp.ID {
+		t.Fatalf("expected managed identity subject_id, got %v", auditRecord["subject_id"])
+	}
+	if auditRecord["subject_kind"] != "identity" {
+		t.Fatalf("expected managed identity subject_kind identity, got %v", auditRecord["subject_kind"])
 	}
 
 	req, _ = http.NewRequest(http.MethodGet, ts.URL+"/api/v1/integrations", nil)


### PR DESCRIPTION
## Summary

This PR removes `workload` as a first-class runtime principal kind. `gst_wld_...` tokens remain as a compatibility token prefix, but they now authenticate as plain identity principals.

## Old interfaces

Go:

```go
const SourceWorkloadToken Source = ...

type WorkloadResolver interface {
    ResolveWorkloadToken(token string) (*ResolvedWorkload, bool)
}
```

Example resolved principal:

```go
&principal.Principal{
    Kind:      principal.KindWorkload,
    SubjectID: principal.WorkloadSubjectID("triage-bot"),
    Source:    principal.SourceWorkloadToken,
}
```

YAML:

```yaml
authorization:
  identityTokens:
    triage-bot:
      token: gst_wld_triage-bot-token
      providers:
        clickhouse:
          connection: workspace
          instance: team-a
          allow: [run_query]
```

Behavior:
- `gst_wld_...` tokens authenticated as workload principals.
- audit and runtime surfaces emitted workload-style subject IDs and kinds.
- managed-identity API tokens did not emit the same identity-shaped subject contract.

## New interfaces

Go:

```go
const SourceIdentityToken Source = ...

type IdentityTokenResolver interface {
    ResolveIdentityToken(token string) (*ResolvedIdentityToken, bool)
}
```

Example resolved principal:

```go
&principal.Principal{
    Kind:      principal.KindIdentity,
    SubjectID: principal.IdentitySubjectID("triage-bot"),
    Source:    principal.SourceIdentityToken,
}
```

YAML:

```yaml
authorization:
  identityTokens:
    triage-bot:
      token: gst_wld_triage-bot-token
      providers:
        clickhouse:
          connection: workspace
          instance: team-a
          allow: [run_query]
```

Behavior:
- `gst_wld_...` tokens authenticate as `identity:<id>` with `auth_source=identity_token`.
- managed-identity API tokens emit `subject_id=identity:<id>` and `subject_kind=identity`.
- HTTP, MCP, providerhost, and audit paths stop modeling a separate workload principal kind.