### PR TITLE
authorization: rename authorization state reload hook

### DIFF
--- a/gestaltd/internal/authorization/authorizer.go
+++ b/gestaltd/internal/authorization/authorizer.go
@@ -184,7 +184,7 @@ func (a *Authorizer) Close() error {
 	return nil
 }
 
-func (a *Authorizer) ReloadDynamic(ctx context.Context) error {
+func (a *Authorizer) ReloadAuthorizationState(ctx context.Context) error {
 	_ = ctx
 	return nil
 }

--- a/gestaltd/internal/authorization/provider_backed.go
+++ b/gestaltd/internal/authorization/provider_backed.go
@@ -74,7 +74,7 @@ func (a *ProviderBackedAuthorizer) Start(ctx context.Context) error {
 	if a.started {
 		return nil
 	}
-	if err := a.ReloadDynamic(ctx); err != nil {
+	if err := a.ReloadAuthorizationState(ctx); err != nil {
 		return err
 	}
 	pollCtx, cancel := context.WithCancel(ctx)
@@ -112,7 +112,7 @@ func (a *ProviderBackedAuthorizer) Close() error {
 	return a.base.Close()
 }
 
-func (a *ProviderBackedAuthorizer) ReloadDynamic(ctx context.Context) error {
+func (a *ProviderBackedAuthorizer) ReloadAuthorizationState(ctx context.Context) error {
 	if a == nil {
 		return nil
 	}
@@ -171,9 +171,6 @@ func (a *ProviderBackedAuthorizer) ManagedModelID(ctx context.Context) (string, 
 	if a == nil {
 		return "", fmt.Errorf("authorization provider is unavailable")
 	}
-	if a.provider == nil {
-		return "", fmt.Errorf("authorization provider is unavailable")
-	}
 	state := a.currentState()
 	if modelID := strings.TrimSpace(state.modelID); modelID != "" {
 		return modelID, nil
@@ -191,8 +188,8 @@ func (a *ProviderBackedAuthorizer) pollLoop(ctx context.Context, done chan struc
 		case <-ctx.Done():
 			return
 		case <-ticker.C:
-			if err := a.ReloadDynamic(ctx); err != nil {
-				slog.WarnContext(ctx, "authorization: provider-backed reload failed", "error", err)
+			if err := a.ReloadAuthorizationState(ctx); err != nil {
+				slog.WarnContext(ctx, "authorization: provider-backed authorization state reload failed", "error", err)
 			}
 		}
 	}

--- a/gestaltd/internal/authorization/runtime.go
+++ b/gestaltd/internal/authorization/runtime.go
@@ -16,7 +16,7 @@ type RuntimeAuthorizer interface {
 	Start(ctx context.Context) error
 	Close() error
 
-	ReloadDynamic(ctx context.Context) error
+	ReloadAuthorizationState(ctx context.Context) error
 
 	IsWorkload(p *principal.Principal) bool
 	AllowProvider(ctx context.Context, p *principal.Principal, provider string) bool
@@ -33,6 +33,12 @@ type RuntimeAuthorizer interface {
 	StaticRoleForProviderIdentity(provider, subjectID, userID, email string) (AccessContext, bool)
 	StaticMembersForPolicy(policyName string) ([]StaticHumanMember, bool)
 	StaticMembersForProvider(provider string) (string, []StaticHumanMember, bool)
+}
+
+// ManagedAuthorizationModelResolver exposes the authorization model managed by
+// the current runtime authorizer when one exists.
+type ManagedAuthorizationModelResolver interface {
+	ManagedModelID(ctx context.Context) (string, error)
 }
 
 var _ RuntimeAuthorizer = (*Authorizer)(nil)

--- a/gestaltd/internal/bootstrap/authorization_canonical_sync.go
+++ b/gestaltd/internal/bootstrap/authorization_canonical_sync.go
@@ -14,10 +14,6 @@ import (
 
 const providerCanonicalSyncReadPageSize = 500
 
-type managedAuthorizationModelResolver interface {
-	ManagedModelID(ctx context.Context) (string, error)
-}
-
 func syncProviderBackedHumanCanonicalState(ctx context.Context, services *coredata.Services, authorizer authorization.RuntimeAuthorizer, provider core.AuthorizationProvider) error {
 	if services == nil || provider == nil || services.Users == nil {
 		return nil
@@ -127,7 +123,7 @@ func syncProviderBackedHumanCanonicalState(ctx context.Context, services *coreda
 }
 
 func providerBackedModelID(ctx context.Context, authorizer authorization.RuntimeAuthorizer, provider core.AuthorizationProvider) (string, error) {
-	if resolver, ok := authorizer.(managedAuthorizationModelResolver); ok {
+	if resolver, ok := authorizer.(authorization.ManagedAuthorizationModelResolver); ok {
 		modelID, err := resolver.ManagedModelID(ctx)
 		if err != nil {
 			return "", err

--- a/gestaltd/internal/bootstrap/bootstrap_test.go
+++ b/gestaltd/internal/bootstrap/bootstrap_test.go
@@ -4181,8 +4181,8 @@ func TestBootstrapSecretResolution(t *testing.T) {
 		if access.Role != "" {
 			t.Fatalf("role during active model drift = %q, want empty", access.Role)
 		}
-		if err := result.Authorizer.ReloadDynamic(ctx); err != nil {
-			t.Fatalf("expected reload to heal active model drift: %v", err)
+		if err := result.Authorizer.ReloadAuthorizationState(ctx); err != nil {
+			t.Fatalf("expected authorization state reload to heal active model drift: %v", err)
 		}
 		if got := provider.activeModelID; got != managedModelID {
 			t.Fatalf("active model id after reload = %q, want %q", got, managedModelID)

--- a/gestaltd/internal/server/handlers_admin_authorization.go
+++ b/gestaltd/internal/server/handlers_admin_authorization.go
@@ -190,7 +190,7 @@ func (s *Server) putAdminAuthorizationPluginMember(w http.ResponseWriter, r *htt
 		UserID:        membership.UserID,
 		Email:         membership.Email,
 	}
-	if err := s.reloadDynamicAuthorizations(r.Context()); err != nil {
+	if err := s.reloadAuthorizationState(r.Context()); err != nil {
 		writeJSON(w, http.StatusAccepted, map[string]any{
 			"status":     "persisted_pending_reload",
 			"persisted":  true,
@@ -232,7 +232,7 @@ func (s *Server) deleteAdminAuthorizationPluginMember(w http.ResponseWriter, r *
 		return
 	}
 
-	if err := s.reloadDynamicAuthorizations(r.Context()); err != nil {
+	if err := s.reloadAuthorizationState(r.Context()); err != nil {
 		writeJSON(w, http.StatusAccepted, map[string]any{
 			"status":    "persisted_pending_reload",
 			"persisted": true,
@@ -309,7 +309,7 @@ func (s *Server) putAdminAuthorizationAdminMember(w http.ResponseWriter, r *http
 		UserID:        membership.UserID,
 		Email:         membership.Email,
 	}
-	if err := s.reloadDynamicAuthorizations(r.Context()); err != nil {
+	if err := s.reloadAuthorizationState(r.Context()); err != nil {
 		writeJSON(w, http.StatusAccepted, map[string]any{
 			"status":     "persisted_pending_reload",
 			"persisted":  true,
@@ -349,7 +349,7 @@ func (s *Server) deleteAdminAuthorizationAdminMember(w http.ResponseWriter, r *h
 		return
 	}
 
-	if err := s.reloadDynamicAuthorizations(r.Context()); err != nil {
+	if err := s.reloadAuthorizationState(r.Context()); err != nil {
 		writeJSON(w, http.StatusAccepted, map[string]any{
 			"status":    "persisted_pending_reload",
 			"persisted": true,
@@ -564,14 +564,14 @@ func (s *Server) adminAuthorizationRowsFromStaticMembers(ctx context.Context, pl
 	return rows, nil
 }
 
-func (s *Server) reloadDynamicAuthorizations(ctx context.Context) error {
+func (s *Server) reloadAuthorizationState(ctx context.Context) error {
 	if s.authorizer == nil {
 		return nil
 	}
 
 	var lastErr error
 	for i := 0; i < 3; i++ {
-		if err := s.authorizer.ReloadDynamic(ctx); err == nil {
+		if err := s.authorizer.ReloadAuthorizationState(ctx); err == nil {
 			return nil
 		} else {
 			lastErr = err

--- a/gestaltd/internal/server/handlers_admin_authorization_provider_write.go
+++ b/gestaltd/internal/server/handlers_admin_authorization_provider_write.go
@@ -11,10 +11,6 @@ import (
 	"github.com/valon-technologies/gestalt/server/internal/emailutil"
 )
 
-type managedAuthorizationModelResolver interface {
-	ManagedModelID(ctx context.Context) (string, error)
-}
-
 type providerPluginAuthorizationMembership struct {
 	Plugin string
 	UserID string
@@ -227,7 +223,7 @@ func (s *Server) managedAuthorizationModelID(ctx context.Context) (string, error
 	if s.authorizationProvider == nil {
 		return "", errAdminAuthorizationUnavailable
 	}
-	if resolver, ok := s.authorizer.(managedAuthorizationModelResolver); ok {
+	if resolver, ok := s.authorizer.(authorization.ManagedAuthorizationModelResolver); ok {
 		return resolver.ManagedModelID(ctx)
 	}
 	active, err := s.authorizationProvider.GetActiveModel(ctx)

--- a/gestaltd/internal/server/server_test.go
+++ b/gestaltd/internal/server/server_test.go
@@ -900,8 +900,8 @@ func mustProviderBackedAuthorizer(t *testing.T, base *authorization.Authorizer, 
 	if err != nil {
 		t.Fatalf("NewProviderBacked: %v", err)
 	}
-	if err := authz.ReloadDynamic(context.Background()); err != nil {
-		t.Fatalf("ReloadDynamic: %v", err)
+	if err := authz.ReloadAuthorizationState(context.Background()); err != nil {
+		t.Fatalf("ReloadAuthorizationState: %v", err)
 	}
 	return authz
 }
@@ -910,8 +910,8 @@ func seedProviderDynamicAdminMembership(t *testing.T, svc *coredata.Services, au
 	t.Helper()
 	user := seedUser(t, svc, email)
 	if provider.activeModelID == "" {
-		if err := authz.ReloadDynamic(context.Background()); err != nil {
-			t.Fatalf("seedProviderDynamicAdminMembership reload: %v", err)
+		if err := authz.ReloadAuthorizationState(context.Background()); err != nil {
+			t.Fatalf("seedProviderDynamicAdminMembership authorization state reload: %v", err)
 		}
 	}
 	if provider.activeModelID == "" {
@@ -922,8 +922,8 @@ func seedProviderDynamicAdminMembership(t *testing.T, svc *coredata.Services, au
 		Relation: role,
 		Resource: &core.ResourceRef{Type: authorization.ProviderResourceTypeAdminDynamic, Id: authorization.ProviderResourceIDAdminDynamicGlobal},
 	})
-	if err := authz.ReloadDynamic(context.Background()); err != nil {
-		t.Fatalf("seedProviderDynamicAdminMembership reload after write: %v", err)
+	if err := authz.ReloadAuthorizationState(context.Background()); err != nil {
+		t.Fatalf("seedProviderDynamicAdminMembership authorization state reload after write: %v", err)
 	}
 	return user
 }
@@ -932,8 +932,8 @@ func seedProviderPluginAuthorization(t *testing.T, svc *coredata.Services, authz
 	t.Helper()
 	user := seedUser(t, svc, email)
 	if provider.activeModelID == "" {
-		if err := authz.ReloadDynamic(context.Background()); err != nil {
-			t.Fatalf("seedProviderPluginAuthorization reload: %v", err)
+		if err := authz.ReloadAuthorizationState(context.Background()); err != nil {
+			t.Fatalf("seedProviderPluginAuthorization authorization state reload: %v", err)
 		}
 	}
 	if provider.activeModelID == "" {
@@ -944,8 +944,8 @@ func seedProviderPluginAuthorization(t *testing.T, svc *coredata.Services, authz
 		Relation: role,
 		Resource: &core.ResourceRef{Type: authorization.ProviderResourceTypePluginDynamic, Id: plugin},
 	})
-	if err := authz.ReloadDynamic(context.Background()); err != nil {
-		t.Fatalf("seedProviderPluginAuthorization reload after write: %v", err)
+	if err := authz.ReloadAuthorizationState(context.Background()); err != nil {
+		t.Fatalf("seedProviderPluginAuthorization authorization state reload after write: %v", err)
 	}
 	return user
 }
@@ -2607,8 +2607,8 @@ func TestAdminAPI_PluginAuthorizationProviderBackedReadsAndDebug(t *testing.T) {
 	if !pluginAccess.InvokeAllOperations {
 		t.Fatal("expected provider-backed plugin write to sync canonical invoke-all access")
 	}
-	if err := authz.ReloadDynamic(context.Background()); err != nil {
-		t.Fatalf("ReloadDynamic after provider-backed plugin write: %v", err)
+	if err := authz.ReloadAuthorizationState(context.Background()); err != nil {
+		t.Fatalf("ReloadAuthorizationState after provider-backed plugin write: %v", err)
 	}
 
 	req, _ = http.NewRequest(http.MethodGet, ts.URL+"/admin/api/v1/authorization/plugins/sample_plugin/members", nil)
@@ -3026,8 +3026,8 @@ func TestAdminAPI_AdminAuthorizationProviderBackedReads(t *testing.T) {
 	if len(roles) != 1 || roles[0].Role != "owner" {
 		t.Fatalf("workspace roles after provider-backed write = %+v, want [owner]", roles)
 	}
-	if err := authz.ReloadDynamic(context.Background()); err != nil {
-		t.Fatalf("ReloadDynamic after provider-backed admin write: %v", err)
+	if err := authz.ReloadAuthorizationState(context.Background()); err != nil {
+		t.Fatalf("ReloadAuthorizationState after provider-backed admin write: %v", err)
 	}
 
 	req, _ = http.NewRequest(http.MethodGet, ts.URL+"/admin/api/v1/authorization/admins/members", nil)


### PR DESCRIPTION
## Summary
- rename `RuntimeAuthorizer.ReloadDynamic` to `ReloadAuthorizationState`
- move the shared managed-model resolver interface into `internal/authorization`
- remove the remaining redundant provider-availability guard from `ProviderBackedAuthorizer.ManagedModelID`

## Why
The old `ReloadDynamic` name came from the legacy dynamic human-grant migration path. That path is gone. The hook now means "refresh the runtime authorization state", which for the provider-backed authorizer means reconciling provider-backed state and model metadata, while the plain authorizer remains a no-op. This PR makes that API match reality and removes the duplicate local resolver interfaces that built up around it.

## Verification
- `go test ./internal/authorization ./internal/bootstrap ./internal/server`
- `golangci-lint run ./internal/authorization ./internal/bootstrap ./internal/server`