### PR TITLE
graphql: allow manifests to override operation selection sets

### DIFF
--- a/gestaltd/internal/bootstrap/provider_build.go
+++ b/gestaltd/internal/bootstrap/provider_build.go
@@ -622,7 +622,7 @@ func loadSpecDefinition(ctx context.Context, name string, resolved config.Resolv
 	case config.SpecSurfaceOpenAPI:
 		return openapi.LoadDefinition(ctx, name, resolved.URL, allowedOperations)
 	case config.SpecSurfaceGraphQL:
-		return graphql.LoadDefinition(ctx, name, resolved.URL, allowedOperations)
+		return graphql.LoadDefinition(ctx, name, resolved.URL, allowedOperations, resolved.GraphQLSelections)
 	default:
 		return nil, fmt.Errorf("unsupported spec definition surface %q", resolved.Surface)
 	}

--- a/gestaltd/internal/config/connection_plan.go
+++ b/gestaltd/internal/config/connection_plan.go
@@ -18,10 +18,11 @@ type StaticConnectionPlan struct {
 }
 
 type ResolvedSpecSurface struct {
-	Surface        SpecSurface
-	URL            string
-	ConnectionName string
-	Connection     ConnectionDef
+	Surface           SpecSurface
+	URL               string
+	ConnectionName    string
+	Connection        ConnectionDef
+	GraphQLSelections map[string]string
 }
 
 func BuildStaticConnectionPlan(plugin *ProviderEntry, manifestPlugin *providermanifestv1.Spec) (StaticConnectionPlan, error) {
@@ -67,6 +68,9 @@ func BuildStaticConnectionPlan(plugin *ProviderEntry, manifestPlugin *providerma
 			Surface:        surface,
 			URL:            url,
 			ConnectionName: plan.resolveSurfaceConnectionName(ManifestProviderSurfaceConnectionName(manifestPlugin, surface)),
+		}
+		if surface == SpecSurfaceGraphQL {
+			resolved.GraphQLSelections = manifestPlugin.GraphQLOperationSelections()
 		}
 		conn, err := plan.connectionDef(resolved.ConnectionName)
 		if err != nil {

--- a/gestaltd/internal/graphql/loader.go
+++ b/gestaltd/internal/graphql/loader.go
@@ -9,7 +9,7 @@ import (
 	"github.com/valon-technologies/gestalt/server/internal/provider"
 )
 
-func LoadDefinition(ctx context.Context, name, endpoint string, allowedOps map[string]*config.OperationOverride) (*provider.Definition, error) {
+func LoadDefinition(ctx context.Context, name, endpoint string, allowedOps map[string]*config.OperationOverride, selectionOverrides map[string]string) (*provider.Definition, error) {
 	schema, err := introspect(ctx, endpoint)
 	if err != nil {
 		return nil, fmt.Errorf("introspecting %s: %w", endpoint, err)
@@ -21,8 +21,8 @@ func LoadDefinition(ctx context.Context, name, endpoint string, allowedOps map[s
 	}
 
 	def.Operations = make(map[string]provider.OperationDef)
-	addOperations(schema, def, schema.QueryType, false, allowedOps)
-	addOperations(schema, def, schema.MutationType, true, allowedOps)
+	addOperations(schema, def, schema.QueryType, false, allowedOps, selectionOverrides)
+	addOperations(schema, def, schema.MutationType, true, allowedOps, selectionOverrides)
 
 	if len(def.Operations) == 0 {
 		return nil, fmt.Errorf("no operations found for %s", endpoint)
@@ -31,7 +31,7 @@ func LoadDefinition(ctx context.Context, name, endpoint string, allowedOps map[s
 	return def, nil
 }
 
-func addOperations(schema *Schema, def *provider.Definition, root *TypeName, isMutation bool, allowedOps map[string]*config.OperationOverride) {
+func addOperations(schema *Schema, def *provider.Definition, root *TypeName, isMutation bool, allowedOps map[string]*config.OperationOverride, selectionOverrides map[string]string) {
 	if root == nil {
 		return
 	}
@@ -64,7 +64,7 @@ func addOperations(schema *Schema, def *provider.Definition, root *TypeName, isM
 			allowedRoles = override.AllowedRoles
 		}
 
-		query := generateQuery(schema, field, isMutation)
+		query := generateQuery(schema, field, isMutation, selectionOverrides[field.Name])
 
 		opDef := provider.OperationDef{
 			Description:  provider.TruncateDescription(desc),

--- a/gestaltd/internal/graphql/loader_test.go
+++ b/gestaltd/internal/graphql/loader_test.go
@@ -4,6 +4,7 @@ import (
 	"encoding/json"
 	"net/http"
 	"net/http/httptest"
+	"strings"
 	"testing"
 
 	"github.com/valon-technologies/gestalt/server/internal/config"
@@ -100,7 +101,7 @@ func TestLoadDefinitionAllOps(t *testing.T) {
 	srv := startIntrospectionServer(t, newTestSchema())
 	defer srv.Close()
 
-	def, err := LoadDefinition(t.Context(), "test", srv.URL, nil)
+	def, err := LoadDefinition(t.Context(), "test", srv.URL, nil, nil)
 	if err != nil {
 		t.Fatalf("LoadDefinition: %v", err)
 	}
@@ -141,7 +142,7 @@ func TestLoadDefinitionWithAllowedOps(t *testing.T) {
 
 	def, err := LoadDefinition(t.Context(), "test", srv.URL, map[string]*config.OperationOverride{
 		"teams": {Description: "My custom description"},
-	})
+	}, nil)
 	if err != nil {
 		t.Fatalf("LoadDefinition: %v", err)
 	}
@@ -156,6 +157,33 @@ func TestLoadDefinitionWithAllowedOps(t *testing.T) {
 	}
 }
 
+func TestLoadDefinitionWithSelectionOverride(t *testing.T) {
+	t.Parallel()
+
+	srv := startIntrospectionServer(t, newTestSchema())
+	defer srv.Close()
+
+	def, err := LoadDefinition(t.Context(), "test", srv.URL, nil, map[string]string{
+		"createIssue": "success issue { id title }",
+	})
+	if err != nil {
+		t.Fatalf("LoadDefinition: %v", err)
+	}
+
+	createIssue, ok := def.Operations["createIssue"]
+	if !ok {
+		t.Fatal("createIssue missing from Operations")
+	}
+	if !strings.Contains(createIssue.Query, "{ success issue { id title } }") {
+		t.Errorf("createIssue.Query should use override selection; got: %s", createIssue.Query)
+	}
+
+	teams := def.Operations["teams"]
+	if strings.Contains(teams.Query, "success issue") {
+		t.Errorf("override should only apply to named op; teams query: %s", teams.Query)
+	}
+}
+
 func TestLoadDefinitionEmptySchemaErrors(t *testing.T) {
 	t.Parallel()
 
@@ -167,7 +195,7 @@ func TestLoadDefinitionEmptySchemaErrors(t *testing.T) {
 	})
 	defer srv.Close()
 
-	_, err := LoadDefinition(t.Context(), "test", srv.URL, nil)
+	_, err := LoadDefinition(t.Context(), "test", srv.URL, nil, nil)
 	if err == nil {
 		t.Fatal("expected error for empty schema")
 	}

--- a/gestaltd/internal/graphql/query.go
+++ b/gestaltd/internal/graphql/query.go
@@ -7,7 +7,7 @@ import (
 
 const defaultMaxDepth = 2
 
-func generateQuery(schema *Schema, field Field, isMutation bool) string {
+func generateQuery(schema *Schema, field Field, isMutation bool, selectionOverride string) string {
 	var b strings.Builder
 
 	if isMutation {
@@ -41,7 +41,12 @@ func generateQuery(schema *Schema, field Field, isMutation bool) string {
 		b.WriteByte(')')
 	}
 
-	selectionSet := buildSelectionSet(schema, field.Type, defaultMaxDepth, nil)
+	var selectionSet string
+	if trimmed := strings.TrimSpace(selectionOverride); trimmed != "" {
+		selectionSet = "{ " + trimmed + " }"
+	} else {
+		selectionSet = buildSelectionSet(schema, field.Type, defaultMaxDepth, nil)
+	}
 	if selectionSet != "" {
 		b.WriteString(" ")
 		b.WriteString(selectionSet)

--- a/gestaltd/internal/graphql/query_test.go
+++ b/gestaltd/internal/graphql/query_test.go
@@ -26,7 +26,7 @@ func TestGenerateQuerySimple(t *testing.T) {
 		Type: TypeRef{Kind: "OBJECT", Name: strPtr("Team")},
 	}
 
-	query := generateQuery(schema, field, false)
+	query := generateQuery(schema, field, false, "")
 
 	if !strings.HasPrefix(query, "query(") {
 		t.Errorf("should start with query(: %s", query)
@@ -62,7 +62,7 @@ func TestGenerateQueryMutation(t *testing.T) {
 		Type: TypeRef{Kind: "OBJECT", Name: strPtr("Result")},
 	}
 
-	query := generateQuery(schema, field, true)
+	query := generateQuery(schema, field, true, "")
 
 	if !strings.HasPrefix(query, "mutation(") {
 		t.Errorf("should start with mutation(: %s", query)
@@ -87,7 +87,7 @@ func TestGenerateQueryNoArgs(t *testing.T) {
 		Type: TypeRef{Kind: "OBJECT", Name: strPtr("User")},
 	}
 
-	query := generateQuery(schema, field, false)
+	query := generateQuery(schema, field, false, "")
 
 	if !strings.HasPrefix(query, "query { viewer") {
 		t.Errorf("should be simple query: %s", query)
@@ -123,7 +123,7 @@ func TestConnectionTypeDetection(t *testing.T) {
 		Type: TypeRef{Kind: "OBJECT", Name: strPtr("IssueConnection")},
 	}
 
-	query := generateQuery(schema, field, false)
+	query := generateQuery(schema, field, false, "")
 
 	if !strings.Contains(query, "nodes { id title }") {
 		t.Errorf("should unwrap connection nodes: %s", query)
@@ -162,7 +162,7 @@ func TestSelectionSetDepthLimit(t *testing.T) {
 		Type: TypeRef{Kind: "OBJECT", Name: strPtr("A")},
 	}
 
-	query := generateQuery(schema, field, false)
+	query := generateQuery(schema, field, false, "")
 
 	if !strings.Contains(query, "value") {
 		t.Errorf("depth 2 should include C.value: %s", query)
@@ -190,7 +190,7 @@ func TestSelectionSetCyclePrevention(t *testing.T) {
 		Type: TypeRef{Kind: "OBJECT", Name: strPtr("Node")},
 	}
 
-	query := generateQuery(schema, field, false)
+	query := generateQuery(schema, field, false, "")
 
 	if strings.Count(query, "parent") > 1 {
 		t.Errorf("should not recurse into self-referential type: %s", query)

--- a/gestaltd/internal/plugininvocation/validation.go
+++ b/gestaltd/internal/plugininvocation/validation.go
@@ -275,7 +275,7 @@ func loadConfiguredAPICatalog(ctx context.Context, name string, entry *config.Pr
 		case config.SpecSurfaceOpenAPI:
 			def, err = openapi.LoadDefinition(ctx, name, url, allowed)
 		case config.SpecSurfaceGraphQL:
-			def, err = graphql.LoadDefinition(ctx, name, url, allowed)
+			def, err = graphql.LoadDefinition(ctx, name, url, allowed, spec.GraphQLOperationSelections())
 		}
 		if err != nil {
 			return nil, fmt.Errorf("plugin %q %s catalog: %w", name, surface, err)

--- a/gestaltd/sdk/providermanifest/v1/manifest.jsonschema.json
+++ b/gestaltd/sdk/providermanifest/v1/manifest.jsonschema.json
@@ -462,6 +462,13 @@
         "url": {
           "type": "string",
           "minLength": 1
+        },
+        "operationSelections": {
+          "type": "object",
+          "additionalProperties": {
+            "type": "string",
+            "minLength": 1
+          }
         }
       }
     },

--- a/gestaltd/sdk/providermanifest/v1/types.go
+++ b/gestaltd/sdk/providermanifest/v1/types.go
@@ -111,6 +111,13 @@ func (s *Spec) GraphQLURL() string {
 	return s.Surfaces.GraphQL.URL
 }
 
+func (s *Spec) GraphQLOperationSelections() map[string]string {
+	if s == nil || s.Surfaces == nil || s.Surfaces.GraphQL == nil {
+		return nil
+	}
+	return s.Surfaces.GraphQL.OperationSelections
+}
+
 func (s *Spec) MCPURL() string {
 	if s == nil || s.Surfaces == nil || s.Surfaces.MCP == nil {
 		return ""
@@ -185,8 +192,9 @@ type OpenAPISurface struct {
 }
 
 type GraphQLSurface struct {
-	Connection string `json:"connection,omitempty" yaml:"connection,omitempty"`
-	URL        string `json:"url" yaml:"url"`
+	Connection          string            `json:"connection,omitempty" yaml:"connection,omitempty"`
+	URL                 string            `json:"url" yaml:"url"`
+	OperationSelections map[string]string `json:"operationSelections,omitempty" yaml:"operationSelections,omitempty"`
 }
 
 type MCPSurface struct {


### PR DESCRIPTION
The GraphQL surface loader auto-generates a selection set for every introspected operation by recursively walking the response type to a fixed depth. For providers like Linear, this pulls in server-gated fields (e.g. "Release management") that fail the whole mutation even when the caller never asked for them.

Add an `operationSelections` map on the GraphQL surface manifest, keyed by operation name. When set, it replaces the auto-generated body for that operation; other operations still use the introspected default. The manifest selection is threaded through ResolvedSpecSurface so both the bootstrap and plugin-invocation load paths pick it up.