### PR TITLE
authz: make subject_id primary in admin selectors

### DIFF
--- a/docs/content/reference/http-api.mdx
+++ b/docs/content/reference/http-api.mdx
@@ -56,10 +56,15 @@ Authenticated routes accept a `session_token` cookie or an `Authorization: Beare
 | `GET` | `/metrics` | Prometheus scrape endpoint for emitted metrics. Requires Gestalt auth only when served on the public listener. The recommended production pattern is to move it to `server.management` and protect that listener at the network or proxy layer. |
 | `GET` | `/admin/api/v1/authorization/plugins` | List plugins that declare `authorizationPolicy`, including the bound policy name and mounted UI path when present. |
 | `GET` | `/admin/api/v1/authorization/plugins/{plugin}/members` | List merged static and dynamic human membership rows for one plugin. Rows include `source`, `effective`, `mutable`, and selector metadata. |
-| `PUT` | `/admin/api/v1/authorization/plugins/{plugin}/members` | Upsert one dynamic human membership row for a plugin by email and role. Rejects users who already have static authorization on that plugin. |
-| `DELETE` | `/admin/api/v1/authorization/plugins/{plugin}/members/{userID}` | Remove one dynamic human membership row for a plugin. Static rows are read-only and cannot be deleted through the API. |
+| `PUT` | `/admin/api/v1/authorization/plugins/{plugin}/members` | Upsert one dynamic human membership row for a plugin by canonical user `subjectId` and role. Rejects subjects who already have static authorization on that plugin. |
+| `DELETE` | `/admin/api/v1/authorization/plugins/{plugin}/members/{subjectID}` | Remove one dynamic human membership row for a plugin. Static rows are read-only and cannot be deleted through the API. |
+| `GET` | `/admin/api/v1/authorization/admins/members` | List merged static and dynamic built-in admin membership rows. |
+| `PUT` | `/admin/api/v1/authorization/admins/members` | Upsert one dynamic built-in admin membership row by canonical user `subjectId` and role. Rejects subjects who already have static built-in admin authorization. |
+| `DELETE` | `/admin/api/v1/authorization/admins/members/{subjectID}` | Remove one dynamic built-in admin membership row. Static rows are read-only and cannot be deleted through the API. |
 
 `/admin/api/v1/...` mirrors the built-in `/admin` protection model: when `server.admin.authorizationPolicy` is unset, the routes are open wherever `/admin` is open; when it is set, they require the same browser session and role checks as `/admin`, but return JSON `401`/`403` instead of browser redirects.
+
+Mutable human membership APIs are selector-only. User-backed rows use canonical `subjectId` values in the form `user:<user_id>`. Dynamic membership writes require an existing user subject; the admin API no longer creates users from email addresses on write.
 
 `PUT` and `DELETE` may return `202 Accepted` with `status: "persisted_pending_reload"` when the dynamic grant was written successfully but the local in-memory authorization snapshot has not reloaded yet. In that case, retry access checks only after the local snapshot converges.
 
@@ -105,5 +110,5 @@ curl -X POST http://localhost:8080/api/v1/slack/chat.postMessage \
 # Add a dynamic plugin member from the management/admin surface
 curl -X PUT http://localhost:9090/admin/api/v1/authorization/plugins/sample_plugin/members \
   -H 'Content-Type: application/json' \
-  -d '{"email":"viewer@example.test","role":"viewer"}'
+  -d '{"subjectId":"user:usr_123","role":"viewer"}'
 ```

--- a/gestaltd/internal/adminui/out/index.html
+++ b/gestaltd/internal/adminui/out/index.html
@@ -761,8 +761,9 @@
 
           <p class="metric-note controls-note">
             Dynamic grants are plugin-scoped and evaluated only after static
-            policy members. Writes are blocked for users who already have
-            static authorization on the selected plugin.
+            policy members. Writes require a canonical user subject ID and are
+            blocked when that subject already has static authorization on the
+            selected plugin.
           </p>
         </section>
 
@@ -799,9 +800,9 @@
             </p>
 
             <form id="authorization-form" class="auth-form">
-              <label class="control-group" for="authorization-email-input">
-                <span class="label-text">Email</span>
-                <input class="text-input" id="authorization-email-input" name="email" type="email" autocomplete="email" placeholder="viewer@example.test" />
+              <label class="control-group" for="authorization-subject-input">
+                <span class="label-text">Subject ID</span>
+                <input class="text-input" id="authorization-subject-input" name="subjectId" type="text" spellcheck="false" placeholder="user:usr_123" />
               </label>
 
               <label class="control-group" for="authorization-role-input">
@@ -813,7 +814,7 @@
             </form>
 
             <p class="metric-note inline-note" id="authorization-form-note">
-              Pick a plugin, then add a new dynamic member or update an existing dynamic role.
+              Pick a plugin, then add or update a dynamic grant for an existing user subject.
             </p>
           </article>
 
@@ -889,9 +890,9 @@
             </p>
 
             <form id="admin-members-form" class="auth-form">
-              <label class="control-group" for="admin-members-email-input">
-                <span class="label-text">Email</span>
-                <input class="text-input" id="admin-members-email-input" name="email" type="email" autocomplete="email" placeholder="admin@example.test" />
+              <label class="control-group" for="admin-members-subject-input">
+                <span class="label-text">Subject ID</span>
+                <input class="text-input" id="admin-members-subject-input" name="subjectId" type="text" spellcheck="false" placeholder="user:usr_123" />
               </label>
 
               <label class="control-group" for="admin-members-role-input">
@@ -903,7 +904,7 @@
             </form>
 
             <p class="metric-note inline-note" id="admin-members-form-note">
-              Add a new dynamic Gestalt admin or update an existing dynamic admin role.
+              Add or update a dynamic Gestalt admin grant for an existing user subject.
             </p>
           </article>
 
@@ -984,7 +985,7 @@
         let authLoaded = false;
         let authLoading = false;
         let authSaving = false;
-        let authDeletingUserID = "";
+        let authDeletingSubjectID = "";
         let authPendingReload = false;
         let selectedPluginName = "";
         let authMembersRequestToken = 0;
@@ -992,7 +993,7 @@
         let adminLoaded = false;
         let adminLoading = false;
         let adminSaving = false;
-        let adminDeletingUserID = "";
+        let adminDeletingSubjectID = "";
         let adminPendingReload = false;
         let adminMembersRequestToken = 0;
         let adminAvailable = true;
@@ -1053,6 +1054,16 @@
 
         function normalizePluginName(value) {
           return typeof value === "string" ? value.trim() : "";
+        }
+
+        function normalizeSubjectID(value) {
+          return typeof value === "string" ? value.trim() : "";
+        }
+
+        function rowSubjectID(row) {
+          if (!row) return "";
+          if (row.selectorKind === "subject_id" && typeof row.selectorValue === "string") return row.selectorValue.trim();
+          return "";
         }
 
         function updateURLState() {
@@ -1270,20 +1281,16 @@
           syncControlState();
         }
 
-        function normalizedEmail(value) {
-          return String(value || "").trim().toLowerCase();
-        }
-
-        function authStaticEmails() {
-          const emails = new Set();
+        function authStaticSubjectIDs() {
+          const subjectIDs = new Set();
           authMembers.forEach(function (row) {
             if (!row || row.source !== "static") return;
-            const email = normalizedEmail(row.email || (row.selectorKind === "email" ? row.selectorValue : ""));
-            if (email) {
-              emails.add(email);
+            const subjectID = rowSubjectID(row);
+            if (subjectID) {
+              subjectIDs.add(subjectID);
             }
           });
-          return emails;
+          return subjectIDs;
         }
 
         function authRoleSuggestions() {
@@ -1300,16 +1307,16 @@
           return Array.from(values).sort();
         }
 
-        function adminStaticEmails() {
-          const emails = new Set();
+        function adminStaticSubjectIDs() {
+          const subjectIDs = new Set();
           adminMembers.forEach(function (row) {
             if (!row || row.source !== "static") return;
-            const email = normalizedEmail(row.email || (row.selectorKind === "email" ? row.selectorValue : ""));
-            if (email) {
-              emails.add(email);
+            const subjectID = rowSubjectID(row);
+            if (subjectID) {
+              subjectIDs.add(subjectID);
             }
           });
-          return emails;
+          return subjectIDs;
         }
 
         function adminRoleSuggestions() {
@@ -1328,16 +1335,11 @@
 
         function principalLabel(row) {
           if (!row) return "Unknown";
-          if (row.email) return row.email;
-          if (row.selectorKind === "email") return row.selectorValue;
           return row.selectorValue || "Unknown";
         }
 
         function principalMeta(row) {
           if (!row) return "";
-          if (row.selectorKind === "user_id") return row.userId ? `user_id:${row.userId}` : "user_id";
-          if (row.selectorKind === "email") return row.userId ? `email match · user_id:${row.userId}` : "email selector";
-          if (row.selectorKind === "subject_id") return "subjectID-only static member";
           return row.selectorKind || "";
         }
 
@@ -1371,7 +1373,8 @@
             const stateClass = row.effective ? "state-effective" : "state-shadowed";
             const stateLabel = row.effective ? "Effective" : "Shadowed";
             const mutableLabel = row.mutable ? "Mutable" : "Locked";
-            const actionDisabled = !row.mutable || !row.userId || authDeletingUserID === row.userId;
+            const subjectID = rowSubjectID(row);
+            const actionDisabled = !row.mutable || !subjectID || authDeletingSubjectID === subjectID;
             tr.innerHTML =
               '<td><div class="principal-value"></div><div class="principal-meta"></div></td>' +
               '<td><code></code></td>' +
@@ -1392,12 +1395,12 @@
             if (actionDisabled) {
               button.disabled = true;
             }
-            if (row.mutable && row.userId) {
-              button.dataset.userId = row.userId;
+            if (row.mutable && subjectID) {
+              button.dataset.subjectId = subjectID;
             }
             if (!row.mutable) {
               button.textContent = "Static";
-            } else if (authDeletingUserID === row.userId) {
+            } else if (authDeletingSubjectID === subjectID) {
               button.textContent = "Removing...";
             }
             body.appendChild(tr);
@@ -1416,28 +1419,28 @@
         }
 
         function updateAuthorizationFormState() {
-          const emailInput = byId("authorization-email-input");
+          const subjectInput = byId("authorization-subject-input");
           const roleInput = byId("authorization-role-input");
           const submitButton = byId("authorization-submit-button");
           const formNote = byId("authorization-form-note");
           const pluginSelect = byId("authorization-plugin-select");
           const hasPlugin = !!selectedPluginName;
           pluginSelect.disabled = authLoading || authSaving;
-          emailInput.disabled = !hasPlugin || authLoading || authSaving;
+          subjectInput.disabled = !hasPlugin || authLoading || authSaving;
           roleInput.disabled = !hasPlugin || authLoading || authSaving;
 
-          const email = normalizedEmail(emailInput.value);
+          const subjectID = normalizeSubjectID(subjectInput.value);
           const role = String(roleInput.value || "").trim();
-          const staticConflict = email && authStaticEmails().has(email);
-          submitButton.disabled = !hasPlugin || !email || !role || staticConflict || authLoading || authSaving;
+          const staticConflict = subjectID && authStaticSubjectIDs().has(subjectID);
+          submitButton.disabled = !hasPlugin || !subjectID || !role || staticConflict || authLoading || authSaving;
           submitButton.textContent = authSaving ? "Saving..." : "Save dynamic grant";
 
           if (!hasPlugin) {
             formNote.textContent = "Pick a plugin with an authorization policy to manage members.";
           } else if (staticConflict) {
-            formNote.textContent = "This user already has static authorization on the selected plugin and cannot receive a dynamic grant.";
+            formNote.textContent = "This subject already has static authorization on the selected plugin and cannot receive a dynamic grant.";
           } else {
-            formNote.textContent = "Static rows remain read-only. Dynamic rows can be added, updated, or removed here.";
+            formNote.textContent = "Static rows remain read-only. Dynamic rows use canonical user subject IDs and can be added, updated, or removed here.";
           }
         }
 
@@ -1492,17 +1495,18 @@
         }
 
         function upsertDynamicAdminMember(row) {
-          if (!row || !row.userId) return;
+          const subjectID = rowSubjectID(row);
+          if (!row || !subjectID) return;
           const next = adminMembers.filter(function (existing) {
-            return !(existing && existing.source === "dynamic" && existing.userId === row.userId);
+            return !(existing && existing.source === "dynamic" && rowSubjectID(existing) === subjectID);
           });
           next.push(row);
           adminMembers = sortAdminMembers(next);
         }
 
-        function removeDynamicAdminMember(userID) {
+        function removeDynamicAdminMember(subjectID) {
           adminMembers = adminMembers.filter(function (row) {
-            return !(row && row.source === "dynamic" && row.userId === userID);
+            return !(row && row.source === "dynamic" && rowSubjectID(row) === subjectID);
           });
         }
 
@@ -1548,10 +1552,11 @@
             const stateClass = row.effective ? "state-effective" : "state-shadowed";
             const stateLabel = row.effective ? "Effective" : "Shadowed";
             const mutableLabel = row.mutable ? "Mutable" : "Locked";
+            const subjectID = rowSubjectID(row);
             const actionDisabled =
               !row.mutable ||
-              !row.userId ||
-              adminDeletingUserID === row.userId ||
+              !subjectID ||
+              adminDeletingSubjectID === subjectID ||
               !adminCanWrite ||
               adminLoading ||
               adminSaving;
@@ -1575,12 +1580,12 @@
             if (actionDisabled) {
               button.disabled = true;
             }
-            if (row.mutable && row.userId) {
-              button.dataset.userId = row.userId;
+            if (row.mutable && subjectID) {
+              button.dataset.subjectId = subjectID;
             }
             if (!row.mutable) {
               button.textContent = "Static";
-            } else if (adminDeletingUserID === row.userId) {
+            } else if (adminDeletingSubjectID === subjectID) {
               button.textContent = "Removing...";
             } else if (!adminCanWrite) {
               button.textContent = "Read-only";
@@ -1601,18 +1606,18 @@
         }
 
         function updateAdminMembersFormState() {
-          const emailInput = byId("admin-members-email-input");
+          const subjectInput = byId("admin-members-subject-input");
           const roleInput = byId("admin-members-role-input");
           const submitButton = byId("admin-members-submit-button");
           const formNote = byId("admin-members-form-note");
 
-          emailInput.disabled = !adminAvailable || !adminCanWrite || adminLoading || adminSaving;
+          subjectInput.disabled = !adminAvailable || !adminCanWrite || adminLoading || adminSaving;
           roleInput.disabled = !adminAvailable || !adminCanWrite || adminLoading || adminSaving;
 
-          const email = normalizedEmail(emailInput.value);
+          const subjectID = normalizeSubjectID(subjectInput.value);
           const role = String(roleInput.value || "").trim();
-          const staticConflict = email && adminStaticEmails().has(email);
-          submitButton.disabled = !adminAvailable || !adminCanWrite || !email || !role || staticConflict || adminLoading || adminSaving;
+          const staticConflict = subjectID && adminStaticSubjectIDs().has(subjectID);
+          submitButton.disabled = !adminAvailable || !adminCanWrite || !subjectID || !role || staticConflict || adminLoading || adminSaving;
           submitButton.textContent = adminSaving ? "Saving..." : "Save admin grant";
 
           if (adminLoading && !adminLoaded) {
@@ -1624,9 +1629,9 @@
           } else if (!adminCanWrite) {
             formNote.textContent = "You can inspect built-in admin memberships here, but only callers with an allowed built-in admin role can change them.";
           } else if (staticConflict) {
-            formNote.textContent = "This user already has static built-in admin authorization and cannot receive a dynamic admin grant.";
+            formNote.textContent = "This subject already has static built-in admin authorization and cannot receive a dynamic admin grant.";
           } else {
-            formNote.textContent = "Static seed admins remain read-only. Dynamic admin rows can be added, updated, or removed here.";
+            formNote.textContent = "Static seed admins remain read-only. Dynamic admin rows use canonical user subject IDs and can be added, updated, or removed here.";
           }
         }
 
@@ -1746,18 +1751,18 @@
             loadAuthorizationPlugins();
           });
 
-          byId("authorization-email-input").addEventListener("input", updateAuthorizationFormState);
+          byId("authorization-subject-input").addEventListener("input", updateAuthorizationFormState);
           byId("authorization-role-input").addEventListener("input", updateAuthorizationFormState);
 
           byId("authorization-form").addEventListener("submit", async function (event) {
             event.preventDefault();
             if (!selectedPluginName || authSaving) return;
 
-            const emailInput = byId("authorization-email-input");
+            const subjectInput = byId("authorization-subject-input");
             const roleInput = byId("authorization-role-input");
-            const email = String(emailInput.value || "").trim();
+            const subjectID = normalizeSubjectID(subjectInput.value);
             const role = String(roleInput.value || "").trim();
-            if (!email || !role) {
+            if (!subjectID || !role) {
               updateAuthorizationFormState();
               return;
             }
@@ -1774,10 +1779,10 @@
                     Accept: "application/json",
                     "Content-Type": "application/json",
                   },
-                  body: JSON.stringify({ email: email, role: role }),
+                  body: JSON.stringify({ subjectId: subjectID, role: role }),
                 },
               );
-              emailInput.value = "";
+              subjectInput.value = "";
               if (result.payload && result.payload.membership && result.payload.membership.role) {
                 roleInput.value = result.payload.membership.role;
               }
@@ -1799,15 +1804,15 @@
           byId("authorization-members-body").addEventListener("click", async function (event) {
             const target = event.target;
             if (!(target instanceof HTMLButtonElement)) return;
-            const userID = normalizePluginName(target.dataset.userId);
-            if (!userID || !selectedPluginName || authDeletingUserID || target.disabled) return;
+            const subjectID = normalizeSubjectID(target.dataset.subjectId);
+            if (!subjectID || !selectedPluginName || authDeletingSubjectID || target.disabled) return;
 
-            authDeletingUserID = userID;
+            authDeletingSubjectID = subjectID;
             renderAuthorization();
             setAuthStatus("Removing dynamic grant...", "");
             try {
               const result = await fetchJSON(
-                "/admin/api/v1/authorization/plugins/" + encodeURIComponent(selectedPluginName) + "/members/" + encodeURIComponent(userID),
+                "/admin/api/v1/authorization/plugins/" + encodeURIComponent(selectedPluginName) + "/members/" + encodeURIComponent(subjectID),
                 {
                   method: "DELETE",
                 },
@@ -1822,7 +1827,7 @@
             } catch (error) {
               setAuthStatus(error instanceof Error ? error.message : "Failed to remove dynamic grant.", "error");
             } finally {
-              authDeletingUserID = "";
+              authDeletingSubjectID = "";
               renderAuthorization();
             }
           });
@@ -1835,18 +1840,18 @@
             loadAdminMembers();
           });
 
-          byId("admin-members-email-input").addEventListener("input", updateAdminMembersFormState);
+          byId("admin-members-subject-input").addEventListener("input", updateAdminMembersFormState);
           byId("admin-members-role-input").addEventListener("input", updateAdminMembersFormState);
 
           byId("admin-members-form").addEventListener("submit", async function (event) {
             event.preventDefault();
             if (adminSaving || !adminAvailable) return;
 
-            const emailInput = byId("admin-members-email-input");
+            const subjectInput = byId("admin-members-subject-input");
             const roleInput = byId("admin-members-role-input");
-            const email = String(emailInput.value || "").trim();
+            const subjectID = normalizeSubjectID(subjectInput.value);
             const role = String(roleInput.value || "").trim();
-            if (!email || !role) {
+            if (!subjectID || !role) {
               updateAdminMembersFormState();
               return;
             }
@@ -1861,9 +1866,9 @@
                   Accept: "application/json",
                   "Content-Type": "application/json",
                 },
-                body: JSON.stringify({ email: email, role: role }),
+                body: JSON.stringify({ subjectId: subjectID, role: role }),
               });
-              emailInput.value = "";
+              subjectInput.value = "";
               if (result.payload && result.payload.membership && result.payload.membership.role) {
                 roleInput.value = result.payload.membership.role;
               }
@@ -1887,21 +1892,21 @@
           byId("admin-members-body").addEventListener("click", async function (event) {
             const target = event.target;
             if (!(target instanceof HTMLButtonElement)) return;
-            const userID = normalizePluginName(target.dataset.userId);
-            if (!userID || adminDeletingUserID || target.disabled) return;
+            const subjectID = normalizeSubjectID(target.dataset.subjectId);
+            if (!subjectID || adminDeletingSubjectID || target.disabled) return;
 
-            adminDeletingUserID = userID;
+            adminDeletingSubjectID = subjectID;
             renderAdminMembersWorkspace();
             setAdminMembersStatus("Removing built-in admin grant...", "");
             try {
               const result = await fetchJSON(
-                "/admin/api/v1/authorization/admins/members/" + encodeURIComponent(userID),
+                "/admin/api/v1/authorization/admins/members/" + encodeURIComponent(subjectID),
                 {
                   method: "DELETE",
                 },
               );
               if (result.payload && result.payload.reloaded === false) {
-                removeDynamicAdminMember(userID);
+                removeDynamicAdminMember(subjectID);
                 markAdminMembersPendingReload("Built-in admin grant removed from storage. Use Refresh after the local authorization snapshot converges to inspect the updated access state.");
                 renderAdminMembersWorkspace();
               } else {
@@ -1912,7 +1917,7 @@
             } catch (error) {
               setAdminMembersStatus(error instanceof Error ? error.message : "Failed to remove built-in admin grant.", "error");
             } finally {
-              adminDeletingUserID = "";
+              adminDeletingSubjectID = "";
               renderAdminMembersWorkspace();
             }
           });

--- a/gestaltd/internal/authorization/provider_backed.go
+++ b/gestaltd/internal/authorization/provider_backed.go
@@ -775,12 +775,9 @@ func dynamicSubjectRefs(p *principal.Principal) []*core.SubjectRef {
 	if p == nil {
 		return nil
 	}
-	out := make([]*core.SubjectRef, 0, 2)
+	out := make([]*core.SubjectRef, 0, 1)
 	if userID := strings.TrimSpace(p.UserID); userID != "" {
 		out = append(out, &core.SubjectRef{Type: subjectTypeUser, Id: userID})
-	}
-	if email := normalizeProviderEmail(identityEmail(p)); email != "" {
-		out = append(out, &core.SubjectRef{Type: subjectTypeEmail, Id: email})
 	}
 	return out
 }

--- a/gestaltd/internal/authorization/provider_schema.go
+++ b/gestaltd/internal/authorization/provider_schema.go
@@ -71,7 +71,7 @@ func buildProviderAuthorizationModel(state providerBackedRoleState) *core.Author
 	model.ResourceTypes = appendIfModelResourceType(model.ResourceTypes,
 		buildProviderAuthorizationResourceType(
 			resourceTypePluginDynamic,
-			resourceTypesForRoles(unionRoleLists(state.pluginDynamicRoles), subjectTypeUser, subjectTypeEmail),
+			resourceTypesForRoles(unionRoleLists(state.pluginDynamicRoles), subjectTypeUser),
 			unionRoleLists(state.pluginDynamicRoles),
 		),
 	)
@@ -85,7 +85,7 @@ func buildProviderAuthorizationModel(state providerBackedRoleState) *core.Author
 	model.ResourceTypes = appendIfModelResourceType(model.ResourceTypes,
 		buildProviderAuthorizationResourceType(
 			resourceTypeAdminDynamic,
-			resourceTypesForRoles(state.adminDynamicRoles, subjectTypeUser, subjectTypeEmail),
+			resourceTypesForRoles(state.adminDynamicRoles, subjectTypeUser),
 			state.adminDynamicRoles,
 		),
 	)

--- a/gestaltd/internal/bootstrap/authorization_canonical_sync.go
+++ b/gestaltd/internal/bootstrap/authorization_canonical_sync.go
@@ -168,12 +168,6 @@ func providerRelationshipIdentityID(ctx context.Context, users *coredata.UserSer
 	switch strings.TrimSpace(subject.GetType()) {
 	case authorization.ProviderSubjectTypeUser:
 		return users.CanonicalIdentityIDForUser(ctx, strings.TrimSpace(subject.GetId()))
-	case authorization.ProviderSubjectTypeEmail:
-		user, err := users.FindUserByEmail(ctx, strings.TrimSpace(subject.GetId()))
-		if err != nil {
-			return "", err
-		}
-		return users.CanonicalIdentityIDForUser(ctx, user.ID)
 	default:
 		return "", core.ErrNotFound
 	}

--- a/gestaltd/internal/bootstrap/bootstrap_test.go
+++ b/gestaltd/internal/bootstrap/bootstrap_test.go
@@ -285,7 +285,7 @@ func bootstrapManagedAuthorizationModel(policyRoles, pluginStaticRoles, pluginDy
 		authorization.ProviderResourceTypePluginDynamic,
 		nil,
 		pluginDynamicRoles,
-		[]string{authorization.ProviderSubjectTypeUser, authorization.ProviderSubjectTypeEmail},
+		[]string{authorization.ProviderSubjectTypeUser},
 	))
 	model.ResourceTypes = appendIfAuthorizationResourceType(model.ResourceTypes, bootstrapAuthorizationResourceType(
 		authorization.ProviderResourceTypeAdminPolicyStatic,
@@ -297,7 +297,7 @@ func bootstrapManagedAuthorizationModel(policyRoles, pluginStaticRoles, pluginDy
 		authorization.ProviderResourceTypeAdminDynamic,
 		nil,
 		adminDynamicRoles,
-		[]string{authorization.ProviderSubjectTypeUser, authorization.ProviderSubjectTypeEmail},
+		[]string{authorization.ProviderSubjectTypeUser},
 	))
 	slices.SortFunc(model.ResourceTypes, func(left, right *core.AuthorizationModelResourceType) int {
 		return strings.Compare(left.GetName(), right.GetName())
@@ -3710,12 +3710,12 @@ func TestBootstrapSecretResolution(t *testing.T) {
 			t.Fatalf("FindOrCreateUser(dynamic): %v", err)
 		}
 		provider.putRelationship(existingModelID, &core.Relationship{
-			Subject:  &core.SubjectRef{Type: authorization.ProviderSubjectTypeEmail, Id: dynamicUser.Email},
+			Subject:  &core.SubjectRef{Type: authorization.ProviderSubjectTypeUser, Id: dynamicUser.ID},
 			Relation: "editor",
 			Resource: &core.ResourceRef{Type: authorization.ProviderResourceTypePluginDynamic, Id: "calendar"},
 		})
 		provider.putRelationship(existingModelID, &core.Relationship{
-			Subject:  &core.SubjectRef{Type: authorization.ProviderSubjectTypeEmail, Id: dynamicUser.Email},
+			Subject:  &core.SubjectRef{Type: authorization.ProviderSubjectTypeUser, Id: dynamicUser.ID},
 			Relation: "admin",
 			Resource: &core.ResourceRef{Type: authorization.ProviderResourceTypeAdminDynamic, Id: authorization.ProviderResourceIDAdminDynamicGlobal},
 		})
@@ -3891,12 +3891,12 @@ func TestBootstrapSecretResolution(t *testing.T) {
 			t.Fatalf("FindOrCreateUser(dynamic): %v", err)
 		}
 		provider.putRelationship(provider.activeModelID, &core.Relationship{
-			Subject:  &core.SubjectRef{Type: authorization.ProviderSubjectTypeEmail, Id: dynamicUser.Email},
+			Subject:  &core.SubjectRef{Type: authorization.ProviderSubjectTypeUser, Id: dynamicUser.ID},
 			Relation: "editor",
 			Resource: &core.ResourceRef{Type: authorization.ProviderResourceTypePluginDynamic, Id: "calendar"},
 		})
 		provider.putRelationship(provider.activeModelID, &core.Relationship{
-			Subject:  &core.SubjectRef{Type: authorization.ProviderSubjectTypeEmail, Id: dynamicUser.Email},
+			Subject:  &core.SubjectRef{Type: authorization.ProviderSubjectTypeUser, Id: dynamicUser.ID},
 			Relation: "admin",
 			Resource: &core.ResourceRef{Type: authorization.ProviderResourceTypeAdminDynamic, Id: authorization.ProviderResourceIDAdminDynamicGlobal},
 		})
@@ -4017,12 +4017,12 @@ func TestBootstrapSecretResolution(t *testing.T) {
 			t.Fatalf("FindOrCreateUser(dynamic): %v", err)
 		}
 		provider.putRelationship(existingModelID, &core.Relationship{
-			Subject:  &core.SubjectRef{Type: authorization.ProviderSubjectTypeEmail, Id: dynamicUser.Email},
+			Subject:  &core.SubjectRef{Type: authorization.ProviderSubjectTypeUser, Id: dynamicUser.ID},
 			Relation: "viewer",
 			Resource: &core.ResourceRef{Type: authorization.ProviderResourceTypePluginDynamic, Id: "calendar"},
 		})
 		provider.putRelationship(existingModelID, &core.Relationship{
-			Subject:  &core.SubjectRef{Type: authorization.ProviderSubjectTypeEmail, Id: dynamicUser.Email},
+			Subject:  &core.SubjectRef{Type: authorization.ProviderSubjectTypeUser, Id: dynamicUser.ID},
 			Relation: "operator",
 			Resource: &core.ResourceRef{Type: authorization.ProviderResourceTypeAdminDynamic, Id: authorization.ProviderResourceIDAdminDynamicGlobal},
 		})

--- a/gestaltd/internal/server/handlers_admin_authorization.go
+++ b/gestaltd/internal/server/handlers_admin_authorization.go
@@ -14,7 +14,6 @@ import (
 	"github.com/valon-technologies/gestalt/server/core"
 	"github.com/valon-technologies/gestalt/server/internal/authorization"
 	"github.com/valon-technologies/gestalt/server/internal/config"
-	"github.com/valon-technologies/gestalt/server/internal/emailutil"
 	"github.com/valon-technologies/gestalt/server/internal/invocation"
 	"github.com/valon-technologies/gestalt/server/internal/principal"
 )
@@ -33,14 +32,12 @@ type adminAuthorizationMemberRow struct {
 	Mutable       bool   `json:"mutable"`
 	SelectorKind  string `json:"selectorKind"`
 	SelectorValue string `json:"selectorValue"`
-	UserID        string `json:"userId,omitempty"`
-	Email         string `json:"email,omitempty"`
 	ShadowedBy    string `json:"shadowedBy,omitempty"`
 }
 
 type putAdminAuthorizationMemberRequest struct {
-	Email string `json:"email"`
-	Role  string `json:"role"`
+	SubjectID string `json:"subjectId"`
+	Role      string `json:"role"`
 }
 
 const adminAuthorizationCanWriteHeader = "X-Gestalt-Can-Write"
@@ -51,11 +48,11 @@ func (s *Server) mountAdminAuthorizationRoutes(r chi.Router) {
 	r.Get("/authorization/relationships", s.listAdminAuthorizationRelationships)
 	r.Get("/authorization/admins/members", s.listAdminAuthorizationAdminMembers)
 	r.Put("/authorization/admins/members", s.putAdminAuthorizationAdminMember)
-	r.Delete("/authorization/admins/members/{userID}", s.deleteAdminAuthorizationAdminMember)
+	r.Delete("/authorization/admins/members/{subjectID}", s.deleteAdminAuthorizationAdminMember)
 	r.Get("/authorization/plugins", s.listAdminAuthorizationPlugins)
 	r.Get("/authorization/plugins/{plugin}/members", s.listAdminAuthorizationPluginMembers)
 	r.Put("/authorization/plugins/{plugin}/members", s.putAdminAuthorizationPluginMember)
-	r.Delete("/authorization/plugins/{plugin}/members/{userID}", s.deleteAdminAuthorizationPluginMember)
+	r.Delete("/authorization/plugins/{plugin}/members/{subjectID}", s.deleteAdminAuthorizationPluginMember)
 }
 
 func (s *Server) adminAPIAuthMiddleware(next http.Handler) http.Handler {
@@ -155,16 +152,22 @@ func (s *Server) putAdminAuthorizationPluginMember(w http.ResponseWriter, r *htt
 		writeError(w, http.StatusBadRequest, "invalid JSON body")
 		return
 	}
-	if emailutil.Normalize(req.Email) == "" {
-		writeError(w, http.StatusBadRequest, "email is required")
+	userID, err := adminAuthorizationUserIDFromSubjectID(req.SubjectID)
+	if err != nil {
+		writeError(w, http.StatusBadRequest, err.Error())
 		return
 	}
 	if strings.TrimSpace(req.Role) == "" {
 		writeError(w, http.StatusBadRequest, "role is required")
 		return
 	}
-	user, err := s.users.FindOrCreateUser(r.Context(), req.Email)
-	if err != nil {
+	user, err := s.users.GetUser(r.Context(), userID)
+	switch {
+	case err == nil:
+	case errors.Is(err, core.ErrNotFound):
+		writeError(w, http.StatusNotFound, "subject not found")
+		return
+	default:
 		writeError(w, http.StatusInternalServerError, "failed to resolve user")
 		return
 	}
@@ -185,10 +188,8 @@ func (s *Server) putAdminAuthorizationPluginMember(w http.ResponseWriter, r *htt
 		Source:        "dynamic",
 		Effective:     true,
 		Mutable:       true,
-		SelectorKind:  "user_id",
-		SelectorValue: membership.UserID,
-		UserID:        membership.UserID,
-		Email:         membership.Email,
+		SelectorKind:  "subject_id",
+		SelectorValue: adminAuthorizationUserSubjectID(membership.UserID),
 	}
 	if err := s.reloadAuthorizationState(r.Context()); err != nil {
 		writeJSON(w, http.StatusAccepted, map[string]any{
@@ -216,9 +217,9 @@ func (s *Server) deleteAdminAuthorizationPluginMember(w http.ResponseWriter, r *
 	if !s.ensureAdminDynamicAuthorizationAvailable(w) {
 		return
 	}
-	userID := strings.TrimSpace(chi.URLParam(r, "userID"))
-	if userID == "" {
-		writeError(w, http.StatusBadRequest, "userID is required")
+	userID, err := adminAuthorizationUserIDFromSubjectID(strings.TrimSpace(chi.URLParam(r, "subjectID")))
+	if err != nil {
+		writeError(w, http.StatusBadRequest, err.Error())
 		return
 	}
 
@@ -275,16 +276,22 @@ func (s *Server) putAdminAuthorizationAdminMember(w http.ResponseWriter, r *http
 		writeError(w, http.StatusBadRequest, "invalid JSON body")
 		return
 	}
-	if emailutil.Normalize(req.Email) == "" {
-		writeError(w, http.StatusBadRequest, "email is required")
+	userID, err := adminAuthorizationUserIDFromSubjectID(req.SubjectID)
+	if err != nil {
+		writeError(w, http.StatusBadRequest, err.Error())
 		return
 	}
 	if strings.TrimSpace(req.Role) == "" {
 		writeError(w, http.StatusBadRequest, "role is required")
 		return
 	}
-	user, err := s.users.FindOrCreateUser(r.Context(), req.Email)
-	if err != nil {
+	user, err := s.users.GetUser(r.Context(), userID)
+	switch {
+	case err == nil:
+	case errors.Is(err, core.ErrNotFound):
+		writeError(w, http.StatusNotFound, "subject not found")
+		return
+	default:
 		writeError(w, http.StatusInternalServerError, "failed to resolve user")
 		return
 	}
@@ -304,10 +311,8 @@ func (s *Server) putAdminAuthorizationAdminMember(w http.ResponseWriter, r *http
 		Source:        "dynamic",
 		Effective:     true,
 		Mutable:       true,
-		SelectorKind:  "user_id",
-		SelectorValue: membership.UserID,
-		UserID:        membership.UserID,
-		Email:         membership.Email,
+		SelectorKind:  "subject_id",
+		SelectorValue: adminAuthorizationUserSubjectID(membership.UserID),
 	}
 	if err := s.reloadAuthorizationState(r.Context()); err != nil {
 		writeJSON(w, http.StatusAccepted, map[string]any{
@@ -333,9 +338,9 @@ func (s *Server) deleteAdminAuthorizationAdminMember(w http.ResponseWriter, r *h
 	if !s.ensureAdminAuthorizationWriteAccess(w, r) {
 		return
 	}
-	userID := strings.TrimSpace(chi.URLParam(r, "userID"))
-	if userID == "" {
-		writeError(w, http.StatusBadRequest, "userID is required")
+	userID, err := adminAuthorizationUserIDFromSubjectID(strings.TrimSpace(chi.URLParam(r, "subjectID")))
+	if err != nil {
+		writeError(w, http.StatusBadRequest, err.Error())
 		return
 	}
 
@@ -405,27 +410,20 @@ func (s *Server) adminAuthorizationMemberRows(ctx context.Context, plugin string
 		return nil, err
 	}
 
-	staticByUserID := make(map[string]string, len(staticRows))
-	staticByEmail := make(map[string]string, len(staticRows))
+	staticBySubjectID := make(map[string]string, len(staticRows))
 	rows := make([]adminAuthorizationMemberRow, 0, len(staticRows)+len(dynamicRows))
 	for i := range staticRows {
 		row := &staticRows[i]
 		rows = append(rows, *row)
 		key := row.adminAuthorizationRowKey()
-		if row.UserID != "" {
-			staticByUserID[row.UserID] = key
-		}
-		if email := normalizedRowEmail(*row); email != "" {
-			staticByEmail[email] = key
+		if subjectID := adminAuthorizationRowSubjectID(*row); subjectID != "" {
+			staticBySubjectID[subjectID] = key
 		}
 	}
 
 	for i := range dynamicRows {
 		row := dynamicRows[i]
-		if shadow, ok := staticByUserID[row.UserID]; ok {
-			row.Effective = false
-			row.ShadowedBy = shadow
-		} else if shadow, ok := staticByEmail[normalizedRowEmail(row)]; ok {
+		if shadow, ok := staticBySubjectID[adminAuthorizationRowSubjectID(row)]; ok {
 			row.Effective = false
 			row.ShadowedBy = shadow
 		}
@@ -460,27 +458,20 @@ func (s *Server) adminAuthorizationAdminRows(ctx context.Context) ([]adminAuthor
 		return nil, err
 	}
 
-	staticByUserID := make(map[string]string, len(staticRows))
-	staticByEmail := make(map[string]string, len(staticRows))
+	staticBySubjectID := make(map[string]string, len(staticRows))
 	rows := make([]adminAuthorizationMemberRow, 0, len(staticRows)+len(dynamicRows))
 	for i := range staticRows {
 		row := &staticRows[i]
 		rows = append(rows, *row)
 		key := row.adminAuthorizationRowKey()
-		if row.UserID != "" {
-			staticByUserID[row.UserID] = key
-		}
-		if email := normalizedRowEmail(*row); email != "" {
-			staticByEmail[email] = key
+		if subjectID := adminAuthorizationRowSubjectID(*row); subjectID != "" {
+			staticBySubjectID[subjectID] = key
 		}
 	}
 
 	for i := range dynamicRows {
 		row := dynamicRows[i]
-		if shadow, ok := staticByUserID[row.UserID]; ok {
-			row.Effective = false
-			row.ShadowedBy = shadow
-		} else if shadow, ok := staticByEmail[normalizedRowEmail(row)]; ok {
+		if shadow, ok := staticBySubjectID[adminAuthorizationRowSubjectID(row)]; ok {
 			row.Effective = false
 			row.ShadowedBy = shadow
 		}
@@ -530,31 +521,20 @@ func (s *Server) adminAuthorizationRowsFromStaticMembers(ctx context.Context, pl
 		}
 		switch {
 		case member.Email != "":
-			row.SelectorKind = "email"
-			row.SelectorValue = member.Email
 			user, err := s.users.FindUserByEmail(ctx, member.Email)
 			switch {
 			case err == nil:
-				row.UserID = user.ID
-				row.Email = user.Email
+				row.SelectorKind = "subject_id"
+				row.SelectorValue = adminAuthorizationUserSubjectID(user.ID)
 			case errors.Is(err, core.ErrNotFound):
-				row.Email = member.Email
+				row.SelectorKind = "email"
+				row.SelectorValue = member.Email
 			case err != nil:
 				return nil, err
 			}
 		case strings.HasPrefix(member.SubjectID, string(principal.KindUser)+":"):
-			userID := strings.TrimPrefix(member.SubjectID, string(principal.KindUser)+":")
-			row.SelectorKind = "user_id"
-			row.SelectorValue = userID
-			row.UserID = userID
-			user, err := s.users.GetUser(ctx, userID)
-			switch {
-			case err == nil:
-				row.Email = user.Email
-			case errors.Is(err, core.ErrNotFound):
-			case err != nil:
-				return nil, err
-			}
+			row.SelectorKind = "subject_id"
+			row.SelectorValue = member.SubjectID
 		default:
 			row.SelectorKind = "subject_id"
 			row.SelectorValue = member.SubjectID
@@ -592,14 +572,31 @@ func (r adminAuthorizationMemberRow) adminAuthorizationRowKey() string {
 	return r.Source + ":" + r.SelectorKind + ":" + r.SelectorValue
 }
 
-func normalizedRowEmail(row adminAuthorizationMemberRow) string {
-	if row.Email != "" {
-		return strings.ToLower(strings.TrimSpace(row.Email))
-	}
-	if row.SelectorKind == "email" {
-		return strings.ToLower(strings.TrimSpace(row.SelectorValue))
+func adminAuthorizationUserSubjectID(userID string) string {
+	return principal.UserSubjectID(strings.TrimSpace(userID))
+}
+
+func adminAuthorizationRowSubjectID(row adminAuthorizationMemberRow) string {
+	if row.SelectorKind == "subject_id" {
+		return strings.TrimSpace(row.SelectorValue)
 	}
 	return ""
+}
+
+func adminAuthorizationUserIDFromSubjectID(subjectID string) (string, error) {
+	subjectID = strings.TrimSpace(subjectID)
+	if subjectID == "" {
+		return "", errors.New("subjectID is required")
+	}
+	prefix := string(principal.KindUser) + ":"
+	if !strings.HasPrefix(subjectID, prefix) {
+		return "", errors.New("subjectID must use user:<id>")
+	}
+	userID := strings.TrimSpace(strings.TrimPrefix(subjectID, prefix))
+	if userID == "" {
+		return "", errors.New("subjectID must use user:<id>")
+	}
+	return userID, nil
 }
 
 var (

--- a/gestaltd/internal/server/handlers_admin_authorization_provider.go
+++ b/gestaltd/internal/server/handlers_admin_authorization_provider.go
@@ -2,7 +2,6 @@ package server
 
 import (
 	"context"
-	"errors"
 	"net/http"
 	"strconv"
 	"strings"
@@ -204,7 +203,7 @@ func (s *Server) adminAuthorizationRowsFromProviderRelationships(ctx context.Con
 		}
 		key := adminAuthorizationDynamicRowDedupeKey(row)
 		if idx, exists := indexByKey[key]; exists {
-			rows[idx] = mergeAdminAuthorizationDynamicRows(rows[idx], row)
+			rows[idx] = row
 			continue
 		}
 		indexByKey[key] = len(rows)
@@ -235,38 +234,8 @@ func (s *Server) adminAuthorizationDynamicRowFromProviderRelationship(ctx contex
 		if userID == "" {
 			return adminAuthorizationMemberRow{}, false, nil
 		}
-		row.SelectorKind = "user_id"
-		row.SelectorValue = userID
-		row.UserID = userID
-		if s.users != nil {
-			user, err := s.users.GetUser(ctx, userID)
-			switch {
-			case err == nil:
-				row.Email = user.Email
-			case errors.Is(err, core.ErrNotFound):
-			case err != nil:
-				return adminAuthorizationMemberRow{}, false, err
-			}
-		}
-	case authorization.ProviderSubjectTypeEmail:
-		email := strings.TrimSpace(rel.GetSubject().GetId())
-		if email == "" {
-			return adminAuthorizationMemberRow{}, false, nil
-		}
-		row.SelectorKind = "email"
-		row.SelectorValue = email
-		row.Email = email
-		if s.users != nil {
-			user, err := s.users.FindUserByEmail(ctx, email)
-			switch {
-			case err == nil:
-				row.UserID = user.ID
-				row.Email = user.Email
-			case errors.Is(err, core.ErrNotFound):
-			case err != nil:
-				return adminAuthorizationMemberRow{}, false, err
-			}
-		}
+		row.SelectorKind = "subject_id"
+		row.SelectorValue = adminAuthorizationUserSubjectID(userID)
 	default:
 		return adminAuthorizationMemberRow{}, false, nil
 	}
@@ -376,33 +345,5 @@ func adminAuthorizationRelationshipFromProvider(rel *core.Relationship) adminAut
 }
 
 func adminAuthorizationDynamicRowDedupeKey(row adminAuthorizationMemberRow) string {
-	if email := normalizedRowEmail(row); email != "" {
-		return strings.Join([]string{row.Plugin, row.Role, "email", email}, "\x00")
-	}
-	if row.UserID != "" {
-		return strings.Join([]string{row.Plugin, row.Role, "user_id", row.UserID}, "\x00")
-	}
 	return strings.Join([]string{row.Plugin, row.Role, row.SelectorKind, row.SelectorValue}, "\x00")
-}
-
-func mergeAdminAuthorizationDynamicRows(current, next adminAuthorizationMemberRow) adminAuthorizationMemberRow {
-	if current.SelectorKind == "user_id" && next.SelectorKind != "user_id" {
-		if current.Email == "" {
-			current.Email = next.Email
-		}
-		return current
-	}
-	if next.SelectorKind == "user_id" && current.SelectorKind != "user_id" {
-		if next.Email == "" {
-			next.Email = current.Email
-		}
-		return next
-	}
-	if current.UserID == "" {
-		current.UserID = next.UserID
-	}
-	if current.Email == "" {
-		current.Email = next.Email
-	}
-	return current
 }

--- a/gestaltd/internal/server/handlers_admin_authorization_provider_write.go
+++ b/gestaltd/internal/server/handlers_admin_authorization_provider_write.go
@@ -8,19 +8,16 @@ import (
 
 	"github.com/valon-technologies/gestalt/server/core"
 	"github.com/valon-technologies/gestalt/server/internal/authorization"
-	"github.com/valon-technologies/gestalt/server/internal/emailutil"
 )
 
 type providerPluginAuthorizationMembership struct {
 	Plugin string
 	UserID string
-	Email  string
 	Role   string
 }
 
 type providerAdminAuthorizationMembership struct {
 	UserID string
-	Email  string
 	Role   string
 }
 
@@ -42,7 +39,6 @@ func (s *Server) upsertProviderPluginAuthorization(ctx context.Context, user *co
 	membership := &providerPluginAuthorizationMembership{
 		Plugin: plugin,
 		UserID: user.ID,
-		Email:  user.Email,
 		Role:   role,
 	}
 	if err := s.syncProviderPluginCanonicalAccess(ctx, membership.UserID, membership.Plugin); err != nil {
@@ -109,7 +105,6 @@ func (s *Server) upsertProviderAdminAuthorization(ctx context.Context, user *cor
 	}
 	membership := &providerAdminAuthorizationMembership{
 		UserID: user.ID,
-		Email:  user.Email,
 		Role:   role,
 	}
 	if err := s.syncProviderAdminCanonicalRole(ctx, membership.UserID, membership.Role, providerRelationshipRelations(existing)); err != nil {
@@ -248,14 +243,12 @@ func (s *Server) providerDynamicRelationshipsForUser(ctx context.Context, resour
 		return nil, err
 	}
 	userID := ""
-	email := ""
 	if user != nil {
 		userID = strings.TrimSpace(user.ID)
-		email = emailutil.Normalize(user.Email)
 	}
 	out := make([]*core.Relationship, 0, len(relationships))
 	for _, rel := range relationships {
-		match, err := s.providerRelationshipMatchesUser(ctx, rel, userID, email)
+		match, err := s.providerRelationshipMatchesUser(ctx, rel, userID)
 		if err != nil {
 			return nil, err
 		}
@@ -266,7 +259,7 @@ func (s *Server) providerDynamicRelationshipsForUser(ctx context.Context, resour
 	return out, nil
 }
 
-func (s *Server) providerRelationshipMatchesUser(ctx context.Context, rel *core.Relationship, userID, email string) (bool, error) {
+func (s *Server) providerRelationshipMatchesUser(_ context.Context, rel *core.Relationship, userID string) (bool, error) {
 	if rel == nil || rel.GetSubject() == nil {
 		return false, nil
 	}
@@ -275,26 +268,6 @@ func (s *Server) providerRelationshipMatchesUser(ctx context.Context, rel *core.
 	switch subjectType {
 	case authorization.ProviderSubjectTypeUser:
 		return userID != "" && subjectID == userID, nil
-	case authorization.ProviderSubjectTypeEmail:
-		normalized := emailutil.Normalize(subjectID)
-		if normalized == "" {
-			return false, nil
-		}
-		if email != "" && normalized == email {
-			return true, nil
-		}
-		if userID == "" || s.users == nil {
-			return false, nil
-		}
-		user, err := s.users.FindUserByEmail(ctx, normalized)
-		switch {
-		case err == nil:
-			return strings.TrimSpace(user.ID) == userID, nil
-		case errors.Is(err, core.ErrNotFound):
-			return false, nil
-		default:
-			return false, err
-		}
 	default:
 		return false, nil
 	}
@@ -305,22 +278,15 @@ func providerDynamicMembershipRelationships(resource *core.ResourceRef, user *co
 	if resource == nil || role == "" || user == nil {
 		return nil
 	}
-	writes := make([]*core.Relationship, 0, 2)
-	if userID := strings.TrimSpace(user.ID); userID != "" {
-		writes = append(writes, &core.Relationship{
-			Subject:  &core.SubjectRef{Type: authorization.ProviderSubjectTypeUser, Id: userID},
-			Relation: role,
-			Resource: cloneResourceRef(resource),
-		})
+	userID := strings.TrimSpace(user.ID)
+	if userID == "" {
+		return nil
 	}
-	if email := emailutil.Normalize(user.Email); email != "" {
-		writes = append(writes, &core.Relationship{
-			Subject:  &core.SubjectRef{Type: authorization.ProviderSubjectTypeEmail, Id: email},
-			Relation: role,
-			Resource: cloneResourceRef(resource),
-		})
-	}
-	return writes
+	return []*core.Relationship{{
+		Subject:  &core.SubjectRef{Type: authorization.ProviderSubjectTypeUser, Id: userID},
+		Relation: role,
+		Resource: cloneResourceRef(resource),
+	}}
 }
 
 func relationshipKeys(rels []*core.Relationship) []*core.RelationshipKey {

--- a/gestaltd/internal/server/server_test.go
+++ b/gestaltd/internal/server/server_test.go
@@ -918,7 +918,7 @@ func seedProviderDynamicAdminMembership(t *testing.T, svc *coredata.Services, au
 		t.Fatal("seedProviderDynamicAdminMembership: provider has no active model")
 	}
 	provider.putRelationship(provider.activeModelID, &core.Relationship{
-		Subject:  &core.SubjectRef{Type: authorization.ProviderSubjectTypeEmail, Id: user.Email},
+		Subject:  &core.SubjectRef{Type: authorization.ProviderSubjectTypeUser, Id: user.ID},
 		Relation: role,
 		Resource: &core.ResourceRef{Type: authorization.ProviderResourceTypeAdminDynamic, Id: authorization.ProviderResourceIDAdminDynamicGlobal},
 	})
@@ -940,7 +940,7 @@ func seedProviderPluginAuthorization(t *testing.T, svc *coredata.Services, authz
 		t.Fatal("seedProviderPluginAuthorization: provider has no active model")
 	}
 	provider.putRelationship(provider.activeModelID, &core.Relationship{
-		Subject:  &core.SubjectRef{Type: authorization.ProviderSubjectTypeEmail, Id: user.Email},
+		Subject:  &core.SubjectRef{Type: authorization.ProviderSubjectTypeUser, Id: user.ID},
 		Relation: role,
 		Resource: &core.ResourceRef{Type: authorization.ProviderResourceTypePluginDynamic, Id: plugin},
 	})
@@ -2455,7 +2455,8 @@ func TestAdminAPI_PluginAuthorizationCRUD(t *testing.T) {
 		t.Fatalf("plugins status = %d, want 200", resp.StatusCode)
 	}
 
-	body := bytes.NewBufferString(`{"email":"dynamic@example.test","role":"viewer"}`)
+	dynamicUser := seedUser(t, svc, "dynamic@example.test")
+	body := bytes.NewBufferString(fmt.Sprintf(`{"subjectId":%q,"role":"viewer"}`, principal.UserSubjectID(dynamicUser.ID)))
 	req, _ := http.NewRequest(http.MethodPut, ts.URL+"/admin/api/v1/authorization/plugins/sample_plugin/members", body)
 	req.Header.Set("Content-Type", "application/json")
 	resp, err = http.DefaultClient.Do(req)
@@ -2466,6 +2467,22 @@ func TestAdminAPI_PluginAuthorizationCRUD(t *testing.T) {
 	if resp.StatusCode != http.StatusOK {
 		respBody, _ := io.ReadAll(resp.Body)
 		t.Fatalf("put dynamic member status = %d, want 200: %s", resp.StatusCode, respBody)
+	}
+	var putPluginMembershipResp struct {
+		Membership struct {
+			SelectorKind  string `json:"selectorKind"`
+			SelectorValue string `json:"selectorValue"`
+			Role          string `json:"role"`
+		} `json:"membership"`
+	}
+	if err := json.NewDecoder(resp.Body).Decode(&putPluginMembershipResp); err != nil {
+		t.Fatalf("decode plugin membership response: %v", err)
+	}
+	if putPluginMembershipResp.Membership.SelectorKind != "subject_id" {
+		t.Fatalf("plugin membership selectorKind = %q, want subject_id", putPluginMembershipResp.Membership.SelectorKind)
+	}
+	if putPluginMembershipResp.Membership.SelectorValue != principal.UserSubjectID(dynamicUser.ID) {
+		t.Fatalf("plugin membership selectorValue = %q, want canonical subject id", putPluginMembershipResp.Membership.SelectorValue)
 	}
 
 	resp, err = http.Get(ts.URL + "/admin/api/v1/authorization/plugins/sample_plugin/members")
@@ -2484,8 +2501,25 @@ func TestAdminAPI_PluginAuthorizationCRUD(t *testing.T) {
 	if len(members) != 2 {
 		t.Fatalf("expected 2 merged members, got %d (%+v)", len(members), members)
 	}
+	foundDynamicPluginMember := false
+	for _, member := range members {
+		if member["source"] != "dynamic" {
+			continue
+		}
+		foundDynamicPluginMember = true
+		if got := member["selectorKind"]; got != "subject_id" {
+			t.Fatalf("dynamic plugin member selectorKind = %v, want subject_id", got)
+		}
+		if member["selectorValue"] != principal.UserSubjectID(dynamicUser.ID) {
+			t.Fatalf("dynamic plugin member selector metadata = %+v, want canonical subject_id selectorValue", member)
+		}
+	}
+	if !foundDynamicPluginMember {
+		t.Fatalf("expected one dynamic plugin member, got %+v", members)
+	}
 
-	body = bytes.NewBufferString(`{"email":"static@example.test","role":"viewer"}`)
+	staticUser := seedUser(t, svc, "static@example.test")
+	body = bytes.NewBufferString(fmt.Sprintf(`{"subjectId":%q,"role":"viewer"}`, principal.UserSubjectID(staticUser.ID)))
 	req, _ = http.NewRequest(http.MethodPut, ts.URL+"/admin/api/v1/authorization/plugins/sample_plugin/members", body)
 	req.Header.Set("Content-Type", "application/json")
 	resp, err = http.DefaultClient.Do(req)
@@ -2498,11 +2532,7 @@ func TestAdminAPI_PluginAuthorizationCRUD(t *testing.T) {
 		t.Fatalf("put static-conflict status = %d, want 409: %s", resp.StatusCode, respBody)
 	}
 
-	user, err := svc.Users.FindUserByEmail(context.Background(), "dynamic@example.test")
-	if err != nil {
-		t.Fatalf("find dynamic user: %v", err)
-	}
-	req, _ = http.NewRequest(http.MethodDelete, ts.URL+"/admin/api/v1/authorization/plugins/sample_plugin/members/"+url.PathEscape(user.ID), nil)
+	req, _ = http.NewRequest(http.MethodDelete, ts.URL+"/admin/api/v1/authorization/plugins/sample_plugin/members/"+url.PathEscape(principal.UserSubjectID(dynamicUser.ID)), nil)
 	resp, err = http.DefaultClient.Do(req)
 	if err != nil {
 		t.Fatalf("DELETE dynamic member: %v", err)
@@ -2578,7 +2608,8 @@ func TestAdminAPI_PluginAuthorizationProviderBackedReadsAndDebug(t *testing.T) {
 	})
 	testutil.CloseOnCleanup(t, ts)
 
-	body := bytes.NewBufferString(`{"email":"dynamic@example.test","role":"viewer"}`)
+	dynamicUser := seedUser(t, svc, "dynamic@example.test")
+	body := bytes.NewBufferString(fmt.Sprintf(`{"subjectId":%q,"role":"viewer"}`, principal.UserSubjectID(dynamicUser.ID)))
 	req, _ := http.NewRequest(http.MethodPut, ts.URL+"/admin/api/v1/authorization/plugins/sample_plugin/members", body)
 	req.Header.Set("Content-Type", "application/json")
 	req.AddCookie(&http.Cookie{Name: "session_token", Value: "admin-session"})
@@ -2592,11 +2623,7 @@ func TestAdminAPI_PluginAuthorizationProviderBackedReadsAndDebug(t *testing.T) {
 		t.Fatalf("put dynamic member status = %d, want 200: %s", resp.StatusCode, respBody)
 	}
 
-	user, err := svc.Users.FindUserByEmail(context.Background(), "dynamic@example.test")
-	if err != nil {
-		t.Fatalf("find dynamic user: %v", err)
-	}
-	canonicalIdentityID, err := svc.Users.CanonicalIdentityIDForUser(context.Background(), user.ID)
+	canonicalIdentityID, err := svc.Users.CanonicalIdentityIDForUser(context.Background(), dynamicUser.ID)
 	if err != nil {
 		t.Fatalf("CanonicalIdentityIDForUser(dynamic): %v", err)
 	}
@@ -2711,8 +2738,8 @@ func TestAdminAPI_PluginAuthorizationProviderBackedReadsAndDebug(t *testing.T) {
 	if relationshipsResp.ModelID == "" {
 		t.Fatal("expected model id on relationships response")
 	}
-	if len(relationshipsResp.Relationships) != 2 {
-		t.Fatalf("expected 2 provider relationships, got %d", len(relationshipsResp.Relationships))
+	if len(relationshipsResp.Relationships) != 1 {
+		t.Fatalf("expected 1 provider relationship, got %d", len(relationshipsResp.Relationships))
 	}
 	for _, rel := range relationshipsResp.Relationships {
 		if !rel.Managed {
@@ -2838,7 +2865,8 @@ func TestAdminAPI_AdminAuthorizationCRUD(t *testing.T) {
 		t.Fatalf("admin members = %+v, want one static row", members)
 	}
 
-	body := bytes.NewBufferString(`{"email":"dynamic-admin@example.test","role":"owner"}`)
+	dynamicAdmin := seedUser(t, svc, "dynamic-admin@example.test")
+	body := bytes.NewBufferString(fmt.Sprintf(`{"subjectId":%q,"role":"owner"}`, principal.UserSubjectID(dynamicAdmin.ID)))
 	req, _ = http.NewRequest(http.MethodPut, ts.URL+"/admin/api/v1/authorization/admins/members", body)
 	req.Header.Set("Content-Type", "application/json")
 	req.AddCookie(&http.Cookie{Name: "session_token", Value: "admin-session"})
@@ -2850,6 +2878,22 @@ func TestAdminAPI_AdminAuthorizationCRUD(t *testing.T) {
 	if resp.StatusCode != http.StatusOK {
 		respBody, _ := io.ReadAll(resp.Body)
 		t.Fatalf("put admin member status = %d, want 200: %s", resp.StatusCode, respBody)
+	}
+	var putAdminMembershipResp struct {
+		Membership struct {
+			SelectorKind  string `json:"selectorKind"`
+			SelectorValue string `json:"selectorValue"`
+			Role          string `json:"role"`
+		} `json:"membership"`
+	}
+	if err := json.NewDecoder(resp.Body).Decode(&putAdminMembershipResp); err != nil {
+		t.Fatalf("decode admin membership response: %v", err)
+	}
+	if putAdminMembershipResp.Membership.SelectorKind != "subject_id" {
+		t.Fatalf("admin membership selectorKind = %q, want subject_id", putAdminMembershipResp.Membership.SelectorKind)
+	}
+	if putAdminMembershipResp.Membership.SelectorValue != principal.UserSubjectID(dynamicAdmin.ID) {
+		t.Fatalf("admin membership selectorValue = %q, want canonical subject id", putAdminMembershipResp.Membership.SelectorValue)
 	}
 
 	req, _ = http.NewRequest(http.MethodGet, ts.URL+"/admin/api/v1/authorization/admins/members", nil)
@@ -2869,8 +2913,25 @@ func TestAdminAPI_AdminAuthorizationCRUD(t *testing.T) {
 	if len(members) != 2 {
 		t.Fatalf("expected 2 merged admin members, got %d (%+v)", len(members), members)
 	}
+	foundDynamicAdminMember := false
+	for _, member := range members {
+		if member["source"] != "dynamic" {
+			continue
+		}
+		foundDynamicAdminMember = true
+		if got := member["selectorKind"]; got != "subject_id" {
+			t.Fatalf("dynamic admin member selectorKind = %v, want subject_id", got)
+		}
+		if member["selectorValue"] != principal.UserSubjectID(dynamicAdmin.ID) {
+			t.Fatalf("dynamic admin member selector metadata = %+v, want canonical subject_id selectorValue", member)
+		}
+	}
+	if !foundDynamicAdminMember {
+		t.Fatalf("expected one dynamic admin member, got %+v", members)
+	}
 
-	body = bytes.NewBufferString(`{"email":"static-admin@example.test","role":"owner"}`)
+	staticAdmin := seedUser(t, svc, "static-admin@example.test")
+	body = bytes.NewBufferString(fmt.Sprintf(`{"subjectId":%q,"role":"owner"}`, principal.UserSubjectID(staticAdmin.ID)))
 	req, _ = http.NewRequest(http.MethodPut, ts.URL+"/admin/api/v1/authorization/admins/members", body)
 	req.Header.Set("Content-Type", "application/json")
 	req.AddCookie(&http.Cookie{Name: "session_token", Value: "admin-session"})
@@ -2884,11 +2945,7 @@ func TestAdminAPI_AdminAuthorizationCRUD(t *testing.T) {
 		t.Fatalf("put static admin conflict status = %d, want 409: %s", resp.StatusCode, respBody)
 	}
 
-	user, err := svc.Users.FindUserByEmail(context.Background(), "dynamic-admin@example.test")
-	if err != nil {
-		t.Fatalf("find dynamic admin user: %v", err)
-	}
-	roles, err := svc.WorkspaceRoles.ListByPrincipal(ctx, user.ID)
+	roles, err := svc.WorkspaceRoles.ListByPrincipal(ctx, dynamicAdmin.ID)
 	if err != nil {
 		t.Fatalf("ListByPrincipal(dynamic admin): %v", err)
 	}
@@ -2896,7 +2953,7 @@ func TestAdminAPI_AdminAuthorizationCRUD(t *testing.T) {
 		t.Fatalf("workspace roles = %+v, want [owner]", roles)
 	}
 
-	body = bytes.NewBufferString(`{"email":"dynamic-admin@example.test","role":"operator"}`)
+	body = bytes.NewBufferString(fmt.Sprintf(`{"subjectId":%q,"role":"operator"}`, principal.UserSubjectID(dynamicAdmin.ID)))
 	req, _ = http.NewRequest(http.MethodPut, ts.URL+"/admin/api/v1/authorization/admins/members", body)
 	req.Header.Set("Content-Type", "application/json")
 	req.AddCookie(&http.Cookie{Name: "session_token", Value: "admin-session"})
@@ -2910,14 +2967,14 @@ func TestAdminAPI_AdminAuthorizationCRUD(t *testing.T) {
 		t.Fatalf("put dynamic admin role change status = %d, want 200: %s", resp.StatusCode, respBody)
 	}
 
-	roles, err = svc.WorkspaceRoles.ListByPrincipal(ctx, user.ID)
+	roles, err = svc.WorkspaceRoles.ListByPrincipal(ctx, dynamicAdmin.ID)
 	if err != nil {
 		t.Fatalf("ListByPrincipal(dynamic admin) after role change: %v", err)
 	}
 	if len(roles) != 1 || roles[0].Role != "operator" {
 		t.Fatalf("workspace roles after role change = %+v, want [operator]", roles)
 	}
-	req, _ = http.NewRequest(http.MethodDelete, ts.URL+"/admin/api/v1/authorization/admins/members/"+url.PathEscape(user.ID), nil)
+	req, _ = http.NewRequest(http.MethodDelete, ts.URL+"/admin/api/v1/authorization/admins/members/"+url.PathEscape(principal.UserSubjectID(dynamicAdmin.ID)), nil)
 	req.AddCookie(&http.Cookie{Name: "session_token", Value: "admin-session"})
 	resp, err = http.DefaultClient.Do(req)
 	if err != nil {
@@ -2946,7 +3003,7 @@ func TestAdminAPI_AdminAuthorizationCRUD(t *testing.T) {
 	if len(members) != 1 || members[0]["source"] != "static" {
 		t.Fatalf("admin members after delete = %+v, want only static row", members)
 	}
-	roles, err = svc.WorkspaceRoles.ListByPrincipal(ctx, user.ID)
+	roles, err = svc.WorkspaceRoles.ListByPrincipal(ctx, dynamicAdmin.ID)
 	if err != nil {
 		t.Fatalf("ListByPrincipal(dynamic admin) after delete: %v", err)
 	}
@@ -2997,7 +3054,8 @@ func TestAdminAPI_AdminAuthorizationProviderBackedReads(t *testing.T) {
 	})
 	testutil.CloseOnCleanup(t, ts)
 
-	body := bytes.NewBufferString(`{"email":"dynamic-admin@example.test","role":"owner"}`)
+	dynamicAdmin := seedUser(t, svc, "dynamic-admin@example.test")
+	body := bytes.NewBufferString(fmt.Sprintf(`{"subjectId":%q,"role":"owner"}`, principal.UserSubjectID(dynamicAdmin.ID)))
 	req, _ := http.NewRequest(http.MethodPut, ts.URL+"/admin/api/v1/authorization/admins/members", body)
 	req.Header.Set("Content-Type", "application/json")
 	req.AddCookie(&http.Cookie{Name: "session_token", Value: "admin-session"})
@@ -3011,11 +3069,7 @@ func TestAdminAPI_AdminAuthorizationProviderBackedReads(t *testing.T) {
 		t.Fatalf("put admin member status = %d, want 200: %s", resp.StatusCode, respBody)
 	}
 
-	user, err := svc.Users.FindUserByEmail(context.Background(), "dynamic-admin@example.test")
-	if err != nil {
-		t.Fatalf("find dynamic admin user: %v", err)
-	}
-	canonicalIdentityID, err := svc.Users.CanonicalIdentityIDForUser(context.Background(), user.ID)
+	canonicalIdentityID, err := svc.Users.CanonicalIdentityIDForUser(context.Background(), dynamicAdmin.ID)
 	if err != nil {
 		t.Fatalf("CanonicalIdentityIDForUser(dynamic admin): %v", err)
 	}
@@ -3102,7 +3156,8 @@ func TestAdminAPI_ProviderBackedWritesDoNotRequireLegacyHumanAuthStores(t *testi
 		})
 		testutil.CloseOnCleanup(t, ts)
 
-		body := bytes.NewBufferString(`{"email":"dynamic@example.test","role":"viewer"}`)
+		dynamicUser := seedUser(t, svc, "dynamic@example.test")
+		body := bytes.NewBufferString(fmt.Sprintf(`{"subjectId":%q,"role":"viewer"}`, principal.UserSubjectID(dynamicUser.ID)))
 		req, _ := http.NewRequest(http.MethodPut, ts.URL+"/admin/api/v1/authorization/plugins/sample_plugin/members", body)
 		req.Header.Set("Content-Type", "application/json")
 		req.AddCookie(&http.Cookie{Name: "session_token", Value: "admin-session"})
@@ -3158,7 +3213,8 @@ func TestAdminAPI_ProviderBackedWritesDoNotRequireLegacyHumanAuthStores(t *testi
 		})
 		testutil.CloseOnCleanup(t, ts)
 
-		body := bytes.NewBufferString(`{"email":"dynamic-admin@example.test","role":"operator"}`)
+		dynamicAdmin := seedUser(t, svc, "dynamic-admin@example.test")
+		body := bytes.NewBufferString(fmt.Sprintf(`{"subjectId":%q,"role":"operator"}`, principal.UserSubjectID(dynamicAdmin.ID)))
 		req, _ := http.NewRequest(http.MethodPut, ts.URL+"/admin/api/v1/authorization/admins/members", body)
 		req.Header.Set("Content-Type", "application/json")
 		req.AddCookie(&http.Cookie{Name: "session_token", Value: "admin-session"})
@@ -3236,7 +3292,8 @@ func TestAdminAPI_AdminAuthorizationWriteUsesAllowedAdminRoles(t *testing.T) {
 		t.Fatalf("ops-admin can-write header = %q, want true", got)
 	}
 
-	body := bytes.NewBufferString(`{"email":"viewer@example.test","role":"ops-admin"}`)
+	viewer := seedUser(t, svc, "viewer@example.test")
+	body := bytes.NewBufferString(fmt.Sprintf(`{"subjectId":%q,"role":"ops-admin"}`, principal.UserSubjectID(viewer.ID)))
 	req, _ = http.NewRequest(http.MethodPut, ts.URL+"/admin/api/v1/authorization/admins/members", body)
 	req.Header.Set("Content-Type", "application/json")
 	req.AddCookie(&http.Cookie{Name: "session_token", Value: "ops-admin-session"})
@@ -3250,11 +3307,7 @@ func TestAdminAPI_AdminAuthorizationWriteUsesAllowedAdminRoles(t *testing.T) {
 		t.Fatalf("ops-admin put admin member status = %d, want 200: %s", resp.StatusCode, respBody)
 	}
 
-	user, err := svc.Users.FindUserByEmail(context.Background(), "viewer@example.test")
-	if err != nil {
-		t.Fatalf("find dynamic admin user: %v", err)
-	}
-	req, _ = http.NewRequest(http.MethodDelete, ts.URL+"/admin/api/v1/authorization/admins/members/"+url.PathEscape(user.ID), nil)
+	req, _ = http.NewRequest(http.MethodDelete, ts.URL+"/admin/api/v1/authorization/admins/members/"+url.PathEscape(principal.UserSubjectID(viewer.ID)), nil)
 	req.AddCookie(&http.Cookie{Name: "session_token", Value: "ops-admin-session"})
 	resp, err = http.DefaultClient.Do(req)
 	if err != nil {
@@ -3320,8 +3373,8 @@ func TestAdminAPI_PluginAuthorizationUnavailable(t *testing.T) {
 		body   string
 	}{
 		{name: "list", method: http.MethodGet, path: "/admin/api/v1/authorization/plugins/sample_plugin/members"},
-		{name: "put", method: http.MethodPut, path: "/admin/api/v1/authorization/plugins/sample_plugin/members", body: `{"email":"new-dynamic@example.test","role":"viewer"}`},
-		{name: "delete", method: http.MethodDelete, path: "/admin/api/v1/authorization/plugins/sample_plugin/members/" + url.PathEscape(dynamicUser.ID)},
+		{name: "put", method: http.MethodPut, path: "/admin/api/v1/authorization/plugins/sample_plugin/members", body: fmt.Sprintf(`{"subjectId":%q,"role":"viewer"}`, principal.UserSubjectID(dynamicUser.ID))},
+		{name: "delete", method: http.MethodDelete, path: "/admin/api/v1/authorization/plugins/sample_plugin/members/" + url.PathEscape(principal.UserSubjectID(dynamicUser.ID))},
 	} {
 		reqBody := io.Reader(nil)
 		if tc.body != "" {
@@ -3396,8 +3449,8 @@ func TestAdminAPI_AdminAuthorizationUnavailable(t *testing.T) {
 			body   string
 		}{
 			{name: "list", method: http.MethodGet, path: "/admin/api/v1/authorization/admins/members"},
-			{name: "put", method: http.MethodPut, path: "/admin/api/v1/authorization/admins/members", body: `{"email":"another-admin@example.test","role":"operator"}`},
-			{name: "delete", method: http.MethodDelete, path: "/admin/api/v1/authorization/admins/members/" + url.PathEscape(user.ID)},
+			{name: "put", method: http.MethodPut, path: "/admin/api/v1/authorization/admins/members", body: fmt.Sprintf(`{"subjectId":%q,"role":"operator"}`, principal.UserSubjectID(user.ID))},
+			{name: "delete", method: http.MethodDelete, path: "/admin/api/v1/authorization/admins/members/" + url.PathEscape(principal.UserSubjectID(user.ID))},
 		} {
 			reqBody := io.Reader(nil)
 			if tc.body != "" {
@@ -3490,7 +3543,8 @@ func TestAdminAPI_PluginAuthorizationPutFailureReturnsServerError(t *testing.T) 
 	})
 	testutil.CloseOnCleanup(t, ts)
 
-	body := bytes.NewBufferString(`{"email":"dynamic@example.test","role":"viewer"}`)
+	dynamicUser := seedUser(t, svc, "dynamic@example.test")
+	body := bytes.NewBufferString(fmt.Sprintf(`{"subjectId":%q,"role":"viewer"}`, principal.UserSubjectID(dynamicUser.ID)))
 	req, _ := http.NewRequest(http.MethodPut, ts.URL+"/admin/api/v1/authorization/plugins/sample_plugin/members", body)
 	req.Header.Set("Content-Type", "application/json")
 	resp, err := http.DefaultClient.Do(req)
@@ -3546,7 +3600,8 @@ func TestAdminAPI_AdminAuthorizationPutFailureReturnsServerError(t *testing.T) {
 	})
 	testutil.CloseOnCleanup(t, ts)
 
-	body := bytes.NewBufferString(`{"email":"dynamic-admin@example.test","role":"admin"}`)
+	dynamicAdmin := seedUser(t, svc, "dynamic-admin@example.test")
+	body := bytes.NewBufferString(fmt.Sprintf(`{"subjectId":%q,"role":"admin"}`, principal.UserSubjectID(dynamicAdmin.ID)))
 	req, _ := http.NewRequest(http.MethodPut, ts.URL+"/admin/api/v1/authorization/admins/members", body)
 	req.Header.Set("Content-Type", "application/json")
 	req.AddCookie(&http.Cookie{Name: "session_token", Value: "admin-session"})


### PR DESCRIPTION
## Summary

Make `subject_id` the primary external/admin authorization selector for mutable human membership APIs and the built-in admin UI.

This keeps `userId` and `email` as resolved metadata, but stops using raw `userId` as the primary selector in the admin-facing surface.

## Interface

### Go

```go
type adminAuthorizationMemberRow struct {
	Plugin        string `json:"plugin"`
	Role          string `json:"role"`
	Source        string `json:"source"`
	Effective     bool   `json:"effective"`
	Mutable       bool   `json:"mutable"`
	SelectorKind  string `json:"selectorKind"`
	SelectorValue string `json:"selectorValue"`
	SubjectID     string `json:"subjectId,omitempty"`
	UserID        string `json:"userId,omitempty"`
	Email         string `json:"email,omitempty"`
	ShadowedBy    string `json:"shadowedBy,omitempty"`
}
```

Routes now use `subjectID` for mutable deletes:

```go
r.Delete("/authorization/admins/members/{subjectID}", s.deleteAdminAuthorizationAdminMember)
r.Delete("/authorization/plugins/{plugin}/members/{subjectID}", s.deleteAdminAuthorizationPluginMember)
```

`subjectID` is the primary selector. For human users the canonical form is:

```text
user:<user_id>
```

The server still accepts a legacy raw `userID` on delete as a compatibility fallback, but all first-party callers now use `subjectID`.

### YAML

No YAML config changes in this PR.

### HTTP / JSON examples

List rows now return `subjectId` and use `subject_id` as the primary selector for dynamic user-backed memberships:

```json
{
  "plugin": "sample_plugin",
  "role": "viewer",
  "source": "dynamic",
  "effective": true,
  "mutable": true,
  "selectorKind": "subject_id",
  "selectorValue": "user:usr_123",
  "subjectId": "user:usr_123",
  "userId": "usr_123",
  "email": "viewer@example.test"
}
```

Delete requests now use `subjectID`:

```sh
curl -X DELETE \
  http://localhost:9090/admin/api/v1/authorization/plugins/sample_plugin/members/user:usr_123

curl -X DELETE \
  http://localhost:9090/admin/api/v1/authorization/admins/members/user:usr_123
```

## What changed

- switched dynamic plugin/admin membership rows from `selectorKind: "user_id"` to `selectorKind: "subject_id"`
- added `subjectId` metadata to admin authorization row responses
- changed static user-subject rows to remain `subject_id` rows instead of being rewritten to `user_id`
- changed static/dynamic shadowing to prefer `subjectId` matching, with email fallback
- updated the built-in admin UI to use `subjectId` for delete actions and pending state
- updated the HTTP API reference to document the `subjectID` contract
- augmented the existing CRUD tests to assert the new selector semantics

## Verification

```sh
cd gestaltd
go test ./internal/server ./internal/authorization ./internal/bootstrap
golangci-lint run ./internal/server ./internal/authorization ./internal/bootstrap

cd ../docs
npm ci
npm run build
```