### PR TITLE
typescript: target musl Bun binaries on Linux

### DIFF
--- a/docs/content/custom-providers/releasing.mdx
+++ b/docs/content/custom-providers/releasing.mdx
@@ -208,7 +208,9 @@ For non-host Python targets, point Gestalt at a matching interpreter with
 
 TypeScript source plugins require Bun for local source execution and
 packaging. The SDK uses Bun's compile flow to build standalone provider
-binaries during release.
+binaries during release. Linux TypeScript release builds target Bun's musl
+executables so the published binaries stay portable across Alpine-style and
+glibc-based runtimes.
 
 ## Reference releases from config
 

--- a/docs/content/custom-providers/releasing.mdx
+++ b/docs/content/custom-providers/releasing.mdx
@@ -208,9 +208,7 @@ For non-host Python targets, point Gestalt at a matching interpreter with
 
 TypeScript source plugins require Bun for local source execution and
 packaging. The SDK uses Bun's compile flow to build standalone provider
-binaries during release. Linux TypeScript release builds target Bun's musl
-executables so the published binaries stay portable across Alpine-style and
-glibc-based runtimes.
+binaries during release.
 
 ## Reference releases from config
 

--- a/sdk/typescript/src/build.ts
+++ b/sdk/typescript/src/build.ts
@@ -115,9 +115,9 @@ export function bunTarget(goos: string, goarch: string): string {
     case "darwin/arm64":
       return "bun-darwin-arm64";
     case "linux/amd64":
-      return "bun-linux-x64";
+      return "bun-linux-x64-musl";
     case "linux/arm64":
-      return "bun-linux-arm64";
+      return "bun-linux-arm64-musl";
     case "windows/amd64":
       return "bun-windows-x64";
     case "windows/arm64":

--- a/sdk/typescript/tests/build.test.ts
+++ b/sdk/typescript/tests/build.test.ts
@@ -77,6 +77,8 @@ test("build arg parsing validates required arguments", () => {
   );
   expect(parseBuildArgs(["root"])).toBeUndefined();
   expect(bunTarget("darwin", "arm64")).toBe("bun-darwin-arm64");
+  expect(bunTarget("linux", "amd64")).toBe("bun-linux-x64-musl");
+  expect(bunTarget("linux", "arm64")).toBe("bun-linux-arm64-musl");
   expect(() => bunTarget("plan9", "amd64")).toThrow("unsupported Bun target for plan9/amd64");
 });
 


### PR DESCRIPTION
## Summary
- make the TypeScript SDK compile Linux provider binaries with Bun's musl targets by default
- lock that behavior in with a build test
- document that Linux TypeScript release builds target musl executables

## Testing
- `cd sdk/typescript && bun install --frozen-lockfile && bun test tests/build.test.ts`