### PR TITLE
workflow: persist config schedule execution refs

### DIFF
--- a/gestaltd/internal/bootstrap/bootstrap_test.go
+++ b/gestaltd/internal/bootstrap/bootstrap_test.go
@@ -493,6 +493,7 @@ type recordingWorkflowProvider struct {
 	getSchedule                *coreworkflow.Schedule
 	getScheduleErr             error
 	schedules                  map[string]*coreworkflow.Schedule
+	omitScheduleExecutionRef   bool
 	upsertedEventTriggers      []coreworkflow.UpsertEventTriggerRequest
 	listedEventTriggers        []*coreworkflow.EventTrigger
 	listEventTriggersErr       error
@@ -521,12 +522,13 @@ func (p *recordingWorkflowProvider) CancelRun(context.Context, coreworkflow.Canc
 func (p *recordingWorkflowProvider) UpsertSchedule(_ context.Context, req coreworkflow.UpsertScheduleRequest) (*coreworkflow.Schedule, error) {
 	p.upsertedSchedules = append(p.upsertedSchedules, req)
 	schedule := &coreworkflow.Schedule{
-		ID:        req.ScheduleID,
-		Cron:      req.Cron,
-		Timezone:  req.Timezone,
-		Target:    req.Target,
-		Paused:    req.Paused,
-		CreatedBy: req.RequestedBy,
+		ID:           req.ScheduleID,
+		Cron:         req.Cron,
+		Timezone:     req.Timezone,
+		Target:       req.Target,
+		Paused:       req.Paused,
+		ExecutionRef: req.ExecutionRef,
+		CreatedBy:    req.RequestedBy,
 	}
 	if p.schedules == nil {
 		p.schedules = map[string]*coreworkflow.Schedule{}
@@ -536,11 +538,11 @@ func (p *recordingWorkflowProvider) UpsertSchedule(_ context.Context, req corewo
 }
 func (p *recordingWorkflowProvider) GetSchedule(_ context.Context, req coreworkflow.GetScheduleRequest) (*coreworkflow.Schedule, error) {
 	if p.getSchedule != nil || p.getScheduleErr != nil {
-		return p.getSchedule, p.getScheduleErr
+		return p.scheduleGetResponse(p.getSchedule), p.getScheduleErr
 	}
 	if p.schedules != nil {
 		if schedule, ok := p.schedules[req.ScheduleID]; ok {
-			return schedule, nil
+			return p.scheduleGetResponse(schedule), nil
 		}
 	}
 	return nil, core.ErrNotFound
@@ -642,6 +644,17 @@ func (p *recordingWorkflowProvider) Close() error {
 		p.closed.Store(true)
 	}
 	return nil
+}
+
+func (p *recordingWorkflowProvider) scheduleGetResponse(schedule *coreworkflow.Schedule) *coreworkflow.Schedule {
+	if schedule == nil {
+		return nil
+	}
+	value := *schedule
+	if p.omitScheduleExecutionRef {
+		value.ExecutionRef = ""
+	}
+	return &value
 }
 
 type trackedIndexedDB struct {
@@ -1518,6 +1531,19 @@ func TestBootstrapAppliesConfiguredWorkflowSchedules(t *testing.T) {
 	if got.RequestedBy.SubjectID != "config:workflow:roadmap" || got.RequestedBy.SubjectKind != "system" || got.RequestedBy.AuthSource != "config" {
 		t.Fatalf("requestedBy = %#v", got.RequestedBy)
 	}
+	if strings.TrimSpace(got.ExecutionRef) == "" {
+		t.Fatal("execution ref = empty")
+	}
+	ref, err := result.Services.WorkflowExecutionRefs.Get(context.Background(), got.ExecutionRef)
+	if err != nil {
+		t.Fatalf("Get execution ref: %v", err)
+	}
+	if ref.SubjectID != principal.WorkloadSubjectID("workflow.roadmap") {
+		t.Fatalf("subjectID = %q, want %q", ref.SubjectID, principal.WorkloadSubjectID("workflow.roadmap"))
+	}
+	if len(ref.Permissions) != 1 || ref.Permissions[0].Plugin != "roadmap" || len(ref.Permissions[0].Operations) != 1 || ref.Permissions[0].Operations[0] != "sync" {
+		t.Fatalf("permissions = %#v", ref.Permissions)
+	}
 }
 
 func TestValidateDoesNotApplyConfiguredWorkflowSchedules(t *testing.T) {
@@ -1603,6 +1629,7 @@ func TestBootstrapDeletesRemovedConfiguredWorkflowSchedules(t *testing.T) {
 	if len(recorders) != 1 || len(recorders[0].upsertedSchedules) != 1 {
 		t.Fatalf("initial upserts = %#v", recorders)
 	}
+	initialExecutionRef := recorders[0].upsertedSchedules[0].ExecutionRef
 	_ = result.Close(context.Background())
 
 	cfg = workflowStartupCallbackConfig("https://example.invalid")
@@ -1634,6 +1661,13 @@ func TestBootstrapDeletesRemovedConfiguredWorkflowSchedules(t *testing.T) {
 	}
 	if len(recorder.upsertedSchedules) != 0 {
 		t.Fatalf("upserted schedules = %d, want 0", len(recorder.upsertedSchedules))
+	}
+	ref, err := result.Services.WorkflowExecutionRefs.Get(context.Background(), initialExecutionRef)
+	if err != nil {
+		t.Fatalf("Get revoked execution ref: %v", err)
+	}
+	if ref.RevokedAt == nil || ref.RevokedAt.IsZero() {
+		t.Fatalf("revokedAt = %#v, want set", ref.RevokedAt)
 	}
 }
 
@@ -1715,6 +1749,7 @@ func TestBootstrapMovesConfiguredWorkflowSchedulesToNewProvider(t *testing.T) {
 	if len(recorders["temporal"]) != 1 || len(recorders["temporal"][0].upsertedSchedules) != 1 {
 		t.Fatalf("initial temporal recorders = %#v", recorders["temporal"])
 	}
+	initialExecutionRef := recorders["temporal"][0].upsertedSchedules[0].ExecutionRef
 	_ = result.Close(context.Background())
 
 	cfg = workflowStartupCallbackConfig("https://example.invalid")
@@ -1752,6 +1787,24 @@ func TestBootstrapMovesConfiguredWorkflowSchedulesToNewProvider(t *testing.T) {
 	}
 	if len(recorders["backup"][1].upsertedSchedules) != 1 {
 		t.Fatalf("backup upserted schedules = %d, want 1", len(recorders["backup"][1].upsertedSchedules))
+	}
+	backupExecutionRef := recorders["backup"][1].upsertedSchedules[0].ExecutionRef
+	oldRef, err := result.Services.WorkflowExecutionRefs.Get(context.Background(), initialExecutionRef)
+	if err != nil {
+		t.Fatalf("Get initial execution ref: %v", err)
+	}
+	if oldRef.RevokedAt == nil || oldRef.RevokedAt.IsZero() {
+		t.Fatalf("initial revokedAt = %#v, want set", oldRef.RevokedAt)
+	}
+	newRef, err := result.Services.WorkflowExecutionRefs.Get(context.Background(), backupExecutionRef)
+	if err != nil {
+		t.Fatalf("Get backup execution ref: %v", err)
+	}
+	if newRef.ProviderName != "backup" {
+		t.Fatalf("providerName = %q, want %q", newRef.ProviderName, "backup")
+	}
+	if newRef.RevokedAt != nil {
+		t.Fatalf("backup revokedAt = %#v, want nil", newRef.RevokedAt)
 	}
 }
 
@@ -1933,6 +1986,7 @@ func TestBootstrapReAdoptsManagedSchedulesWhenOwnershipStateIsMissing(t *testing
 	if len(provider.upsertedSchedules) != 1 {
 		t.Fatalf("initial upserted schedules = %d, want 1", len(provider.upsertedSchedules))
 	}
+	initialExecutionRef := provider.upsertedSchedules[0].ExecutionRef
 	provider.schedules[workflowConfigScheduleID("roadmap", "nightly_sync")].Target.Input = map[string]any{
 		"limit": float64(1),
 	}
@@ -1947,6 +2001,74 @@ func TestBootstrapReAdoptsManagedSchedulesWhenOwnershipStateIsMissing(t *testing
 
 	if len(provider.upsertedSchedules) != 2 {
 		t.Fatalf("upserted schedules = %d, want 2", len(provider.upsertedSchedules))
+	}
+	rotatedExecutionRef := provider.upsertedSchedules[1].ExecutionRef
+	if rotatedExecutionRef == initialExecutionRef {
+		t.Fatalf("execution ref = %q, want rotation from %q", rotatedExecutionRef, initialExecutionRef)
+	}
+	newRef, err := result.Services.WorkflowExecutionRefs.Get(context.Background(), rotatedExecutionRef)
+	if err != nil {
+		t.Fatalf("Get rotated execution ref: %v", err)
+	}
+	if newRef.RevokedAt != nil {
+		t.Fatalf("rotated revokedAt = %#v, want nil", newRef.RevokedAt)
+	}
+}
+
+func TestBootstrapReusesConfiguredWorkflowExecutionRefAcrossUnchangedBootstrap(t *testing.T) {
+	t.Parallel()
+
+	db := &coretesting.StubIndexedDB{}
+	provider := &recordingWorkflowProvider{}
+	factories := validFactories()
+	factories.IndexedDB = func(yaml.Node) (indexeddb.IndexedDB, error) { return db, nil }
+	factories.Workflow = func(_ context.Context, _ string, _ yaml.Node, _ []providerhost.HostService, _ bootstrap.Deps) (coreworkflow.Provider, error) {
+		return provider, nil
+	}
+
+	cfg := workflowStartupCallbackConfig("https://example.invalid")
+	cfg.Plugins["roadmap"].Workflow = &config.PluginWorkflowConfig{
+		Provider:   "temporal",
+		Operations: []string{"sync"},
+		Schedules: map[string]config.PluginWorkflowSchedule{
+			"nightly_sync": {
+				Cron:      "0 2 * * *",
+				Timezone:  "UTC",
+				Operation: "sync",
+			},
+		},
+	}
+	cfg.Providers.Workflow = map[string]*config.ProviderEntry{
+		"temporal": {Source: config.ProviderSource{Path: "stub"}},
+	}
+
+	result, err := bootstrap.Bootstrap(context.Background(), cfg, factories)
+	if err != nil {
+		t.Fatalf("Bootstrap initial: %v", err)
+	}
+	initialExecutionRef := provider.upsertedSchedules[0].ExecutionRef
+	_ = result.Close(context.Background())
+
+	result, err = bootstrap.Bootstrap(context.Background(), cfg, factories)
+	if err != nil {
+		t.Fatalf("Bootstrap replay: %v", err)
+	}
+	defer func() { _ = result.Close(context.Background()) }()
+	<-result.ProvidersReady
+
+	if len(provider.upsertedSchedules) != 2 {
+		t.Fatalf("upserted schedules = %d, want 2", len(provider.upsertedSchedules))
+	}
+	reusedExecutionRef := provider.upsertedSchedules[1].ExecutionRef
+	if reusedExecutionRef != initialExecutionRef {
+		t.Fatalf("execution ref = %q, want reuse of %q", reusedExecutionRef, initialExecutionRef)
+	}
+	ref, err := result.Services.WorkflowExecutionRefs.Get(context.Background(), initialExecutionRef)
+	if err != nil {
+		t.Fatalf("Get execution ref: %v", err)
+	}
+	if ref.RevokedAt != nil {
+		t.Fatalf("revokedAt = %#v, want nil", ref.RevokedAt)
 	}
 }
 
@@ -1981,6 +2103,7 @@ func TestBootstrapIgnoresMissingRemovedConfiguredWorkflowSchedule(t *testing.T) 
 	if err != nil {
 		t.Fatalf("Bootstrap initial: %v", err)
 	}
+	initialExecutionRef := provider.upsertedSchedules[0].ExecutionRef
 	_ = result.Close(context.Background())
 	provider.schedules = map[string]*coreworkflow.Schedule{}
 
@@ -2002,6 +2125,13 @@ func TestBootstrapIgnoresMissingRemovedConfiguredWorkflowSchedule(t *testing.T) 
 	if len(provider.deletedSchedules) != 1 {
 		t.Fatalf("deleted schedules = %d, want 1", len(provider.deletedSchedules))
 	}
+	ref, err := result.Services.WorkflowExecutionRefs.Get(context.Background(), initialExecutionRef)
+	if err != nil {
+		t.Fatalf("Get revoked execution ref: %v", err)
+	}
+	if ref.RevokedAt == nil || ref.RevokedAt.IsZero() {
+		t.Fatalf("revokedAt = %#v, want set", ref.RevokedAt)
+	}
 
 	result, err = bootstrap.Bootstrap(context.Background(), cfg, factories)
 	if err != nil {
@@ -2012,6 +2142,66 @@ func TestBootstrapIgnoresMissingRemovedConfiguredWorkflowSchedule(t *testing.T) 
 
 	if len(provider.deletedSchedules) != 1 {
 		t.Fatalf("deleted schedules after replay = %d, want 1", len(provider.deletedSchedules))
+	}
+}
+
+func TestBootstrapDeletesRemovedConfiguredWorkflowSchedulesWhenProviderDropsExecutionRef(t *testing.T) {
+	t.Parallel()
+
+	db := &coretesting.StubIndexedDB{}
+	provider := &recordingWorkflowProvider{}
+	factories := validFactories()
+	factories.IndexedDB = func(yaml.Node) (indexeddb.IndexedDB, error) { return db, nil }
+	factories.Workflow = func(_ context.Context, _ string, _ yaml.Node, _ []providerhost.HostService, _ bootstrap.Deps) (coreworkflow.Provider, error) {
+		return provider, nil
+	}
+
+	cfg := workflowStartupCallbackConfig("https://example.invalid")
+	cfg.Plugins["roadmap"].Workflow = &config.PluginWorkflowConfig{
+		Provider:   "temporal",
+		Operations: []string{"sync"},
+		Schedules: map[string]config.PluginWorkflowSchedule{
+			"nightly_sync": {
+				Cron:      "0 2 * * *",
+				Timezone:  "UTC",
+				Operation: "sync",
+			},
+		},
+	}
+	cfg.Providers.Workflow = map[string]*config.ProviderEntry{
+		"temporal": {Source: config.ProviderSource{Path: "stub"}},
+	}
+
+	result, err := bootstrap.Bootstrap(context.Background(), cfg, factories)
+	if err != nil {
+		t.Fatalf("Bootstrap initial: %v", err)
+	}
+	initialExecutionRef := provider.upsertedSchedules[0].ExecutionRef
+	_ = result.Close(context.Background())
+
+	provider.omitScheduleExecutionRef = true
+	cfg = workflowStartupCallbackConfig("https://example.invalid")
+	cfg.Plugins["roadmap"].Workflow = &config.PluginWorkflowConfig{
+		Provider:   "temporal",
+		Operations: []string{"sync"},
+	}
+	cfg.Providers.Workflow = map[string]*config.ProviderEntry{
+		"temporal": {Source: config.ProviderSource{Path: "stub"}},
+	}
+
+	result, err = bootstrap.Bootstrap(context.Background(), cfg, factories)
+	if err != nil {
+		t.Fatalf("Bootstrap remove schedule: %v", err)
+	}
+	defer func() { _ = result.Close(context.Background()) }()
+	<-result.ProvidersReady
+
+	ref, err := result.Services.WorkflowExecutionRefs.Get(context.Background(), initialExecutionRef)
+	if err != nil {
+		t.Fatalf("Get revoked execution ref: %v", err)
+	}
+	if ref.RevokedAt == nil || ref.RevokedAt.IsZero() {
+		t.Fatalf("revokedAt = %#v, want set", ref.RevokedAt)
 	}
 }
 
@@ -2051,6 +2241,7 @@ func TestBootstrapIgnoresMissingOldScheduleDuringWorkflowProviderMove(t *testing
 	if err != nil {
 		t.Fatalf("Bootstrap initial: %v", err)
 	}
+	initialExecutionRef := temporal.upsertedSchedules[0].ExecutionRef
 	_ = result.Close(context.Background())
 	temporal.schedules = map[string]*coreworkflow.Schedule{}
 
@@ -2083,6 +2274,13 @@ func TestBootstrapIgnoresMissingOldScheduleDuringWorkflowProviderMove(t *testing
 	}
 	if len(temporal.deletedSchedules) == 0 {
 		t.Fatal("expected temporal cleanup delete to be attempted")
+	}
+	ref, err := result.Services.WorkflowExecutionRefs.Get(context.Background(), initialExecutionRef)
+	if err != nil {
+		t.Fatalf("Get revoked execution ref: %v", err)
+	}
+	if ref.RevokedAt == nil || ref.RevokedAt.IsZero() {
+		t.Fatalf("revokedAt = %#v, want set", ref.RevokedAt)
 	}
 }
 

--- a/gestaltd/internal/bootstrap/workflow_config_schedules.go
+++ b/gestaltd/internal/bootstrap/workflow_config_schedules.go
@@ -10,12 +10,16 @@ import (
 	"fmt"
 	"maps"
 	"slices"
+	"strings"
 	"time"
 
+	"github.com/google/uuid"
 	"github.com/valon-technologies/gestalt/server/core"
 	"github.com/valon-technologies/gestalt/server/core/indexeddb"
 	coreworkflow "github.com/valon-technologies/gestalt/server/core/workflow"
 	"github.com/valon-technologies/gestalt/server/internal/config"
+	"github.com/valon-technologies/gestalt/server/internal/coredata"
+	"github.com/valon-technologies/gestalt/server/internal/principal"
 	"google.golang.org/grpc/codes"
 	"google.golang.org/grpc/status"
 )
@@ -32,6 +36,7 @@ var workflowConfigScheduleStateSchema = indexeddb.ObjectStoreSchema{
 		{Name: "schedule_key", Type: indexeddb.TypeString, NotNull: true},
 		{Name: "provider_name", Type: indexeddb.TypeString, NotNull: true},
 		{Name: "schedule_id", Type: indexeddb.TypeString, NotNull: true},
+		{Name: "execution_ref", Type: indexeddb.TypeString},
 		{Name: "updated_at", Type: indexeddb.TypeTime},
 	},
 }
@@ -42,6 +47,7 @@ type workflowConfigScheduleState struct {
 	ScheduleKey  string
 	ProviderName string
 	ScheduleID   string
+	ExecutionRef string
 	UpdatedAt    time.Time
 }
 
@@ -54,6 +60,7 @@ func reconcileWorkflowConfigSchedules(ctx context.Context, cfg *config.Config, r
 	if cfg == nil || runtime == nil || db == nil {
 		return nil
 	}
+	executionRefs := coredata.NewWorkflowExecutionRefService(db)
 	if err := db.CreateObjectStore(ctx, workflowConfigScheduleStateStore, workflowConfigScheduleStateSchema); err != nil {
 		return fmt.Errorf("bootstrap: create workflow config schedule store: %w", err)
 	}
@@ -76,17 +83,36 @@ func reconcileWorkflowConfigSchedules(ctx context.Context, cfg *config.Config, r
 		if err != nil {
 			return fmt.Errorf("bootstrap: cleanup workflow schedule %q for plugin %q requires provider %q: %w", prev.ScheduleID, prev.PluginName, prev.ProviderName, err)
 		}
+		existing, err := provider.GetSchedule(ctx, coreworkflow.GetScheduleRequest{
+			PluginName: prev.PluginName,
+			ScheduleID: prev.ScheduleID,
+		})
+		existingExecutionRef := ""
+		switch {
+		case err == nil:
+			existingExecutionRef = workflowScheduleExecutionRef(existing, prev.ExecutionRef)
+		case isWorkflowObjectNotFound(err):
+			existingExecutionRef = strings.TrimSpace(prev.ExecutionRef)
+		default:
+			return fmt.Errorf("bootstrap: get workflow schedule %q for plugin %q: %w", prev.ScheduleID, prev.PluginName, err)
+		}
 		if err := provider.DeleteSchedule(ctx, coreworkflow.DeleteScheduleRequest{
 			PluginName: prev.PluginName,
 			ScheduleID: prev.ScheduleID,
 		}); err != nil {
 			if isWorkflowObjectNotFound(err) {
+				if err := workflowRevokeExecutionRefByID(ctx, executionRefs, existingExecutionRef); err != nil {
+					return fmt.Errorf("bootstrap: revoke workflow execution ref %q for schedule %q on plugin %q: %w", existingExecutionRef, prev.ScheduleID, prev.PluginName, err)
+				}
 				if err := store.Delete(ctx, rowID); err != nil {
 					return fmt.Errorf("bootstrap: delete workflow schedule state %q: %w", rowID, err)
 				}
 				continue
 			}
 			return fmt.Errorf("bootstrap: delete workflow schedule %q for plugin %q: %w", prev.ScheduleID, prev.PluginName, err)
+		}
+		if err := workflowRevokeExecutionRefByID(ctx, executionRefs, existingExecutionRef); err != nil {
+			return fmt.Errorf("bootstrap: revoke workflow execution ref %q for schedule %q on plugin %q: %w", existingExecutionRef, prev.ScheduleID, prev.PluginName, err)
 		}
 		if err := store.Delete(ctx, rowID); err != nil {
 			return fmt.Errorf("bootstrap: delete workflow schedule state %q: %w", rowID, err)
@@ -108,42 +134,81 @@ func reconcileWorkflowConfigSchedules(ctx context.Context, cfg *config.Config, r
 		}
 		for _, scheduleKey := range slices.Sorted(maps.Keys(effective.Schedules)) {
 			schedule := effective.Schedules[scheduleKey]
+			target := workflowConfigScheduleTarget(pluginName, schedule)
 			if _, ok := allowed[schedule.Operation]; !ok {
 				return fmt.Errorf("bootstrap: workflow schedule %q for plugin %q targets disabled operation %q", scheduleKey, pluginName, schedule.Operation)
 			}
 			rowID := workflowConfigScheduleStateID(pluginName, scheduleKey)
 			desiredEntry := desired[rowID]
 			prev, owned := previous[rowID]
-			if !owned {
-				existing, err := provider.GetSchedule(ctx, coreworkflow.GetScheduleRequest{
-					PluginName: pluginName,
-					ScheduleID: desiredEntry.state.ScheduleID,
-				})
-				switch {
-				case err == nil:
-					if !isWorkflowConfigOwnedSchedule(existing, pluginName, desiredEntry.state.ScheduleID) &&
-						!isAdoptableWorkflowSchedule(existing, pluginName, schedule, desiredEntry.state.ScheduleID) {
-						return fmt.Errorf("bootstrap: workflow schedule %q for plugin %q conflicts with existing unmanaged schedule id %q", scheduleKey, pluginName, desiredEntry.state.ScheduleID)
-					}
-				case isWorkflowObjectNotFound(err):
-				default:
-					return fmt.Errorf("bootstrap: get workflow schedule %q for plugin %q: %w", desiredEntry.state.ScheduleID, pluginName, err)
+			existingExecutionRef := ""
+			existing, err := provider.GetSchedule(ctx, coreworkflow.GetScheduleRequest{
+				PluginName: pluginName,
+				ScheduleID: desiredEntry.state.ScheduleID,
+			})
+			switch {
+			case err == nil:
+				if !isWorkflowConfigOwnedSchedule(existing, pluginName, desiredEntry.state.ScheduleID) &&
+					!isAdoptableWorkflowSchedule(existing, pluginName, schedule, desiredEntry.state.ScheduleID) {
+					return fmt.Errorf("bootstrap: workflow schedule %q for plugin %q conflicts with existing unmanaged schedule id %q", scheduleKey, pluginName, desiredEntry.state.ScheduleID)
 				}
+			case isWorkflowObjectNotFound(err):
+				existing = nil
+				if owned {
+					existingExecutionRef = strings.TrimSpace(prev.ExecutionRef)
+				}
+			default:
+				return fmt.Errorf("bootstrap: get workflow schedule %q for plugin %q: %w", desiredEntry.state.ScheduleID, pluginName, err)
+			}
+			if existing != nil {
+				existingExecutionRef = workflowScheduleExecutionRef(existing, prev.ExecutionRef)
+			}
+			desiredExecutionRef := &coreworkflow.ExecutionReference{
+				ProviderName: desiredEntry.state.ProviderName,
+				Target:       target,
+				SubjectID:    principal.WorkloadSubjectID(workflowWorkloadID(pluginName)),
+				Permissions:  workflowExecutionRefPermissionsForTarget(target),
+			}
+			executionRefID, createdExecutionRef, err := workflowEnsureConfigScheduleExecutionRef(ctx, executionRefs, desiredEntry.state.ScheduleID, desiredExecutionRef, existingExecutionRef)
+			if err != nil {
+				return fmt.Errorf("bootstrap: store workflow execution ref for schedule %q on plugin %q: %w", scheduleKey, pluginName, err)
 			}
 			if _, err := provider.UpsertSchedule(ctx, coreworkflow.UpsertScheduleRequest{
-				ScheduleID:  desiredEntry.state.ScheduleID,
-				Cron:        schedule.Cron,
-				Timezone:    schedule.Timezone,
-				Target:      workflowConfigScheduleTarget(pluginName, schedule),
-				Paused:      schedule.Paused,
-				RequestedBy: workflowConfigActor(pluginName),
+				ScheduleID:   desiredEntry.state.ScheduleID,
+				Cron:         schedule.Cron,
+				Timezone:     schedule.Timezone,
+				Target:       target,
+				Paused:       schedule.Paused,
+				RequestedBy:  workflowConfigActor(pluginName),
+				ExecutionRef: executionRefID,
 			}); err != nil {
+				if createdExecutionRef {
+					_ = workflowRevokeExecutionRefByID(ctx, executionRefs, executionRefID)
+				}
 				return fmt.Errorf("bootstrap: workflow schedule %q for plugin %q: %w", scheduleKey, pluginName, err)
+			}
+			if existingExecutionRef != executionRefID {
+				if err := workflowRevokeExecutionRefByID(ctx, executionRefs, existingExecutionRef); err != nil {
+					return fmt.Errorf("bootstrap: revoke workflow execution ref %q for schedule %q on plugin %q: %w", existingExecutionRef, desiredEntry.state.ScheduleID, pluginName, err)
+				}
 			}
 			if owned && prev.ProviderName != desiredEntry.state.ProviderName {
 				oldProvider, err := runtime.ResolveProvider(prev.ProviderName)
 				if err != nil {
 					return fmt.Errorf("bootstrap: cleanup workflow schedule %q for plugin %q requires provider %q: %w", prev.ScheduleID, prev.PluginName, prev.ProviderName, err)
+				}
+				oldExisting, err := oldProvider.GetSchedule(ctx, coreworkflow.GetScheduleRequest{
+					PluginName: prev.PluginName,
+					ScheduleID: prev.ScheduleID,
+				})
+				oldExecutionRef := ""
+				switch {
+				case err == nil:
+					oldExecutionRef = workflowScheduleExecutionRef(oldExisting, prev.ExecutionRef)
+				case isWorkflowObjectNotFound(err):
+					oldExecutionRef = strings.TrimSpace(prev.ExecutionRef)
+				default:
+					return fmt.Errorf("bootstrap: get workflow schedule %q for plugin %q: %w", prev.ScheduleID, prev.PluginName, err)
 				}
 				if err := oldProvider.DeleteSchedule(ctx, coreworkflow.DeleteScheduleRequest{
 					PluginName: prev.PluginName,
@@ -151,7 +216,11 @@ func reconcileWorkflowConfigSchedules(ctx context.Context, cfg *config.Config, r
 				}); err != nil && !isWorkflowObjectNotFound(err) {
 					return fmt.Errorf("bootstrap: delete workflow schedule %q for plugin %q: %w", prev.ScheduleID, prev.PluginName, err)
 				}
+				if err := workflowRevokeExecutionRefByID(ctx, executionRefs, oldExecutionRef); err != nil {
+					return fmt.Errorf("bootstrap: revoke workflow execution ref %q for schedule %q on plugin %q: %w", oldExecutionRef, prev.ScheduleID, prev.PluginName, err)
+				}
 			}
+			desiredEntry.state.ExecutionRef = executionRefID
 			if err := store.Put(ctx, desiredEntry.state.record()); err != nil {
 				return fmt.Errorf("bootstrap: store workflow schedule state %q: %w", rowID, err)
 			}
@@ -213,6 +282,7 @@ func (s workflowConfigScheduleState) record() indexeddb.Record {
 		"schedule_key":  s.ScheduleKey,
 		"provider_name": s.ProviderName,
 		"schedule_id":   s.ScheduleID,
+		"execution_ref": s.ExecutionRef,
 		"updated_at":    s.UpdatedAt,
 	}
 }
@@ -224,6 +294,7 @@ func workflowConfigScheduleStateFromRecord(rec indexeddb.Record) workflowConfigS
 		ScheduleKey:  workflowConfigScheduleRecordString(rec, "schedule_key"),
 		ProviderName: workflowConfigScheduleRecordString(rec, "provider_name"),
 		ScheduleID:   workflowConfigScheduleRecordString(rec, "schedule_id"),
+		ExecutionRef: workflowConfigScheduleRecordString(rec, "execution_ref"),
 		UpdatedAt:    workflowConfigScheduleRecordTime(rec, "updated_at"),
 	}
 }
@@ -303,4 +374,113 @@ func workflowConfigScheduleStateID(pluginName, scheduleKey string) string {
 func workflowConfigScheduleID(pluginName, scheduleKey string) string {
 	sum := sha256.Sum256([]byte(pluginName + "\x00" + scheduleKey))
 	return coreworkflow.ConfigManagedSchedulePrefix + hex.EncodeToString(sum[:])
+}
+
+func workflowConfigScheduleExecutionRefID(scheduleID string) string {
+	return "workflow_schedule:" + scheduleID + ":" + uuid.NewString()
+}
+
+func workflowScheduleExecutionRef(existing *coreworkflow.Schedule, fallback string) string {
+	if existing != nil {
+		if refID := strings.TrimSpace(existing.ExecutionRef); refID != "" {
+			return refID
+		}
+	}
+	return strings.TrimSpace(fallback)
+}
+
+func workflowEnsureConfigScheduleExecutionRef(
+	ctx context.Context,
+	service *coredata.WorkflowExecutionRefService,
+	scheduleID string,
+	desired *coreworkflow.ExecutionReference,
+	candidateIDs ...string,
+) (string, bool, error) {
+	if service == nil {
+		return "", false, fmt.Errorf("workflow execution refs are not configured")
+	}
+	for _, candidateID := range candidateIDs {
+		candidateID = strings.TrimSpace(candidateID)
+		if candidateID == "" {
+			continue
+		}
+		existing, err := service.Get(ctx, candidateID)
+		if err != nil {
+			if errors.Is(err, indexeddb.ErrNotFound) {
+				continue
+			}
+			return "", false, err
+		}
+		if workflowConfigExecutionRefMatches(existing, desired) {
+			return candidateID, false, nil
+		}
+	}
+	refID := workflowConfigScheduleExecutionRefID(scheduleID)
+	desired.ID = refID
+	if _, err := service.Put(ctx, desired); err != nil {
+		return "", false, err
+	}
+	return refID, true, nil
+}
+
+func workflowExecutionRefPermissionsForTarget(target coreworkflow.Target) []core.AccessPermission {
+	pluginName := target.PluginName
+	operation := strings.TrimSpace(target.Operation)
+	if pluginName == "" || operation == "" {
+		return nil
+	}
+	return []core.AccessPermission{{
+		Plugin:     pluginName,
+		Operations: []string{operation},
+	}}
+}
+
+func workflowConfigExecutionRefMatches(existing, desired *coreworkflow.ExecutionReference) bool {
+	if existing == nil || desired == nil {
+		return false
+	}
+	if existing.RevokedAt != nil && !existing.RevokedAt.IsZero() {
+		return false
+	}
+	if strings.TrimSpace(existing.ProviderName) != strings.TrimSpace(desired.ProviderName) {
+		return false
+	}
+	if strings.TrimSpace(existing.SubjectID) != strings.TrimSpace(desired.SubjectID) {
+		return false
+	}
+	if strings.TrimSpace(existing.Target.PluginName) != strings.TrimSpace(desired.Target.PluginName) {
+		return false
+	}
+	if strings.TrimSpace(existing.Target.Operation) != strings.TrimSpace(desired.Target.Operation) {
+		return false
+	}
+	if strings.TrimSpace(existing.Target.Connection) != strings.TrimSpace(desired.Target.Connection) {
+		return false
+	}
+	if strings.TrimSpace(existing.Target.Instance) != strings.TrimSpace(desired.Target.Instance) {
+		return false
+	}
+	existingJSON, existingErr := json.Marshal(existing.Permissions)
+	desiredJSON, desiredErr := json.Marshal(desired.Permissions)
+	return existingErr == nil && desiredErr == nil && bytes.Equal(existingJSON, desiredJSON)
+}
+
+func workflowRevokeExecutionRefByID(ctx context.Context, service *coredata.WorkflowExecutionRefService, refID string) error {
+	if service == nil || strings.TrimSpace(refID) == "" {
+		return nil
+	}
+	ref, err := service.Get(ctx, refID)
+	if err != nil {
+		if errors.Is(err, indexeddb.ErrNotFound) {
+			return nil
+		}
+		return err
+	}
+	if ref == nil || ref.RevokedAt != nil {
+		return nil
+	}
+	now := time.Now()
+	ref.RevokedAt = &now
+	_, err = service.Put(ctx, ref)
+	return err
 }

--- a/gestaltd/internal/bootstrap/workflow_runtime.go
+++ b/gestaltd/internal/bootstrap/workflow_runtime.go
@@ -352,17 +352,20 @@ func workflowExecutionPrincipal(ref *coreworkflow.ExecutionReference) *principal
 		return nil
 	}
 	subjectID := strings.TrimSpace(ref.SubjectID)
-	userID := principal.UserIDFromSubjectID(subjectID)
 	permissions := principal.CompilePermissions(ref.Permissions)
 	value := &principal.Principal{
-		UserID:           userID,
 		SubjectID:        subjectID,
-		Kind:             principal.KindUser,
 		Scopes:           principal.PermissionPlugins(permissions),
 		TokenPermissions: permissions,
 	}
-	if value.UserID == "" {
-		value.Kind = ""
+	switch {
+	case principal.UserIDFromSubjectID(subjectID) != "":
+		value.UserID = principal.UserIDFromSubjectID(subjectID)
+		value.Kind = principal.KindUser
+	case strings.HasPrefix(subjectID, string(principal.KindWorkload)+":"),
+		principal.ManagedIdentityIDFromSubjectID(subjectID) != "",
+		subjectID == principal.IdentitySubjectID():
+		value.Kind = principal.KindWorkload
 	}
 	return value
 }

--- a/gestaltd/internal/bootstrap/workflow_runtime_test.go
+++ b/gestaltd/internal/bootstrap/workflow_runtime_test.go
@@ -416,6 +416,65 @@ func TestWorkflowRuntimeInvokeExecutionRefUsesStoredHumanPrincipalAndSelectors(t
 	}
 }
 
+func TestWorkflowRuntimeInvokeExecutionRefUsesStoredWorkloadPrincipal(t *testing.T) {
+	t.Parallel()
+
+	services := coretesting.NewStubServices(t)
+	if _, err := services.WorkflowExecutionRefs.Put(context.Background(), &coreworkflow.ExecutionReference{
+		ID:           "exec-ref-workload",
+		ProviderName: "temporal",
+		Target: coreworkflow.Target{
+			PluginName: "roadmap",
+			Operation:  "sync",
+		},
+		SubjectID: principal.WorkloadSubjectID("scheduler"),
+	}); err != nil {
+		t.Fatalf("Put execution ref: %v", err)
+	}
+
+	runtime := &workflowRuntime{
+		bindings: map[string]workflowBinding{
+			"roadmap": {
+				providerName: "temporal",
+				operations: map[string]struct{}{
+					"sync": {},
+				},
+			},
+		},
+		executionRefs: services.WorkflowExecutionRefs,
+	}
+
+	var gotPrincipal *principal.Principal
+	runtime.SetInvoker(funcInvoker{
+		invoke: func(ctx context.Context, p *principal.Principal, providerName, instance, operation string, params map[string]any) (*core.OperationResult, error) {
+			gotPrincipal = p
+			return &core.OperationResult{Status: http.StatusAccepted, Body: `{"ok":true}`}, nil
+		},
+	})
+
+	if _, err := runtime.Invoke(context.Background(), coreworkflow.InvokeOperationRequest{
+		ProviderName: "temporal",
+		PluginName:   "roadmap",
+		ExecutionRef: "exec-ref-workload",
+		Target: coreworkflow.Target{
+			PluginName: "roadmap",
+			Operation:  "sync",
+		},
+	}); err != nil {
+		t.Fatalf("Invoke: %v", err)
+	}
+
+	if gotPrincipal == nil {
+		t.Fatal("principal = nil")
+	}
+	if gotPrincipal.Kind != principal.KindWorkload {
+		t.Fatalf("principal kind = %q, want %q", gotPrincipal.Kind, principal.KindWorkload)
+	}
+	if gotPrincipal.SubjectID != principal.WorkloadSubjectID("scheduler") {
+		t.Fatalf("subjectID = %q, want %q", gotPrincipal.SubjectID, principal.WorkloadSubjectID("scheduler"))
+	}
+}
+
 func TestWorkflowRuntimeInvokeExecutionRefRechecksAuthorizationThroughBroker(t *testing.T) {
 	t.Parallel()
 

--- a/gestaltd/internal/coredata/services_test.go
+++ b/gestaltd/internal/coredata/services_test.go
@@ -1567,13 +1567,13 @@ func TestWorkflowExecutionRefService(t *testing.T) {
 		}
 	})
 
-	t.Run("Put_rejects_non_user_subject", func(t *testing.T) {
+	t.Run("Put_allows_non_user_subjects", func(t *testing.T) {
 		t.Parallel()
 		svc := newTestServices(t)
 		ctx := context.Background()
 
-		_, err := svc.WorkflowExecutionRefs.Put(ctx, &coreworkflow.ExecutionReference{
-			ID:           "exec-ref-bad",
+		ref, err := svc.WorkflowExecutionRefs.Put(ctx, &coreworkflow.ExecutionReference{
+			ID:           "exec-ref-workload",
 			ProviderName: "basic",
 			Target: coreworkflow.Target{
 				PluginName: "roadmap",
@@ -1581,8 +1581,11 @@ func TestWorkflowExecutionRefService(t *testing.T) {
 			},
 			SubjectID: principal.ManagedIdentitySubjectID("managed-123"),
 		})
-		if err == nil {
-			t.Fatal("expected Put to reject non-user subject_id")
+		if err != nil {
+			t.Fatalf("Put: %v", err)
+		}
+		if ref.SubjectID != principal.ManagedIdentitySubjectID("managed-123") {
+			t.Fatalf("SubjectID = %q, want %q", ref.SubjectID, principal.ManagedIdentitySubjectID("managed-123"))
 		}
 	})
 }

--- a/gestaltd/internal/coredata/workflow_execution_refs.go
+++ b/gestaltd/internal/coredata/workflow_execution_refs.go
@@ -33,9 +33,6 @@ func (s *WorkflowExecutionRefService) Put(ctx context.Context, ref *coreworkflow
 	if id == "" || providerName == "" || targetPlugin == "" || targetOperation == "" || subjectID == "" {
 		return nil, fmt.Errorf("put workflow execution ref: id, provider_name, target.plugin_name, target.operation, and subject_id are required")
 	}
-	if workflowExecutionRefUserID(subjectID) == "" {
-		return nil, fmt.Errorf("put workflow execution ref: subject_id %q is not a user subject", subjectID)
-	}
 
 	permissionsJSON := ""
 	if len(ref.Permissions) > 0 {
@@ -115,14 +112,6 @@ func recWorkflowExecutionRefPermissions(rec indexeddb.Record) []core.AccessPermi
 		return nil
 	}
 	return permissions
-}
-
-func workflowExecutionRefUserID(subjectID string) string {
-	const prefix = "user:"
-	if !strings.HasPrefix(subjectID, prefix) {
-		return ""
-	}
-	return strings.TrimPrefix(subjectID, prefix)
 }
 
 func timeOrNil(value *time.Time) any {


### PR DESCRIPTION
## Summary
This slice keeps the workflow API shape unchanged and tightens the execution model for persisted schedules.

It does three things:
- lets `coreworkflow.ExecutionReference.SubjectID` store workload-backed subjects instead of only `user:*`
- writes and rotates `ExecutionRef` for bootstrap-managed schedules so configured schedules execute through stored refs instead of the legacy no-ref workload fallback
- persists `execution_ref` in `workflow_config_schedules` state so delete/provider-move cleanup can revoke old refs even when the provider object is already gone

## Interfaces
```go
type ExecutionReference struct {
    ID           string
    ProviderName string
    Target       Target
    SubjectID    string
    Permissions  []core.AccessPermission
    CreatedAt    *time.Time
    RevokedAt    *time.Time
}
```
`SubjectID` now accepts workload-backed subjects like `workload:workflow.roadmap` and managed-identity subjects, not just `user:*`.

```go
type UpsertScheduleRequest struct {
    ScheduleID   string
    Cron         string
    Timezone     string
    Target       Target
    Paused       bool
    RequestedBy  Actor
    ExecutionRef string
}
```
Configured schedule reconcile now always supplies `ExecutionRef` and rotates it on every successful upsert.

Bootstrap-managed schedule state now stores:
```go
type workflowConfigScheduleState struct {
    ID           string
    PluginName   string
    ScheduleKey  string
    ProviderName string
    ScheduleID   string
    ExecutionRef string
    UpdatedAt    time.Time
}
```

## Examples
Execution ref persisted for a config-managed schedule:
```go
coreworkflow.ExecutionReference{
    ID:           "workflow_schedule:cfg_<hash>:<uuid>",
    ProviderName: "temporal",
    Target: coreworkflow.Target{
        PluginName: "roadmap",
        Operation:  "sync",
    },
    SubjectID: principal.WorkloadSubjectID("workflow.roadmap"),
    Permissions: []core.AccessPermission{{
        Plugin:     "roadmap",
        Operations: []string{"sync"},
    }},
}
```

Configured schedule upsert emitted during reconcile:
```go
coreworkflow.UpsertScheduleRequest{
    ScheduleID: workflowConfigScheduleID("roadmap", "nightly_sync"),
    Cron:       "0 2 * * *",
    Timezone:   "America/New_York",
    Target: coreworkflow.Target{
        PluginName: "roadmap",
        Operation:  "sync",
        Input:      map[string]any{"source": "yaml"},
    },
    RequestedBy:  workflowConfigActor("roadmap"),
    ExecutionRef: "workflow_schedule:cfg_<hash>:<uuid>",
}
```

## Verification
- `go test ./internal/bootstrap ./internal/coredata -count=1`
- `golangci-lint run ./internal/bootstrap ./internal/coredata`
- `git diff --check`

## Follow-up
This intentionally does not touch event triggers or the global workflow HTTP surface yet. Those are separate slices because event triggers still need `ExecutionRef` added to core/proto/provider contracts before the no-ref fallback can be removed more broadly.