### PR TITLE
remove workload principals from runtime identity flow

### DIFF
--- a/docs/content/audit-logging.mdx
+++ b/docs/content/audit-logging.mdx
@@ -31,7 +31,7 @@ These fields are emitted when available:
 
 | Field | Meaning |
 | --- | --- |
-| `auth_source` | Auth mechanism for the caller: `session`, `api_token`, `workload_token`, or `env` |
+| `auth_source` | Auth mechanism for the caller: `session`, `api_token`, `identity_token`, or `env` |
 | `user_id` | Stable internal user ID |
 | `target_kind` | Generic kind for the object the event acted on, such as `api_token` or `connection` |
 | `target_id` | Stable identifier for the affected object when one exists |

--- a/docs/content/reference/http-api.mdx
+++ b/docs/content/reference/http-api.mdx
@@ -6,7 +6,7 @@ The HTTP API uses "integrations" in route paths (e.g. `/api/v1/integrations`) as
 
 ## Authentication model
 
-Authenticated routes accept a `session_token` cookie or an `Authorization: Bearer <token>` header. Valid bearer tokens include Gestalt API tokens (`gst_api_...`), workload tokens (`gst_wld_...`), and auth-provider-issued tokens when the configured platform auth provider supports direct token validation.
+Authenticated routes accept a `session_token` cookie or an `Authorization: Bearer <token>` header. Valid bearer tokens include Gestalt API tokens (`gst_api_...`), identity tokens (`gst_wld_...`), and auth-provider-issued tokens when the configured platform auth provider supports direct token validation.
 
 ## Unauthenticated Routes
 

--- a/docs/content/security.mdx
+++ b/docs/content/security.mdx
@@ -35,7 +35,7 @@ Requests are authenticated in the following order:
 
 1. Check for a `session_token` cookie
 2. Check for an `Authorization: Bearer` header with a `gst_api_` prefix (API token lookup via SHA-256 hash)
-3. Check for an `Authorization: Bearer` header with a `gst_wld_` prefix (workload token lookup)
+3. Check for an `Authorization: Bearer` header with a `gst_wld_` prefix (identity token lookup)
 4. Check for an `Authorization: Bearer` header with a provider-issued token
 5. If no valid credentials are found, return 401
 

--- a/gestaltd/core/types.go
+++ b/gestaltd/core/types.go
@@ -15,6 +15,7 @@ type User struct {
 
 type IntegrationToken struct {
 	ID                string
+	IdentityID        string
 	UserID            string
 	Integration       string
 	Connection        string
@@ -57,8 +58,7 @@ const (
 )
 
 const (
-	APITokenKindAPI      = "api"
-	APITokenKindWorkload = "workload"
+	APITokenKindAPI = "api"
 )
 
 type ManagedIdentity struct {

--- a/gestaltd/internal/authorization/authorizer.go
+++ b/gestaltd/internal/authorization/authorizer.go
@@ -40,6 +40,7 @@ type WorkloadProviderBinding struct {
 type Workload struct {
 	ID          string
 	DisplayName string
+	IdentityID  string
 	Providers   map[string]WorkloadProviderBinding
 }
 
@@ -123,26 +124,31 @@ func New(cfg config.AuthorizationConfig, pluginDefs map[string]*config.ProviderE
 		}
 	}
 
-	if len(cfg.Workloads) == 0 {
+	if len(cfg.IdentityTokens) == 0 {
 		return a, nil
 	}
 
-	for workloadID, def := range cfg.Workloads {
+	for identityID, def := range cfg.IdentityTokens {
+		ownerIdentityID := strings.TrimSpace(def.IdentityID)
+		if ownerIdentityID == "" {
+			ownerIdentityID = identityID
+		}
 		token := strings.TrimSpace(def.Token)
 		if token == "" {
-			return nil, fmt.Errorf("authorization validation: workload %q token is required", workloadID)
+			return nil, fmt.Errorf("authorization validation: identity token %q token is required", identityID)
 		}
 		if !strings.HasPrefix(token, "gst_wld_") {
-			return nil, fmt.Errorf("authorization validation: workload %q token must use gst_wld_ prefix", workloadID)
+			return nil, fmt.Errorf("authorization validation: identity token %q token must use gst_wld_ prefix", identityID)
 		}
 		tokenHash := principal.HashToken(token)
 		if _, exists := a.workloadsByHash[tokenHash]; exists {
-			return nil, fmt.Errorf("authorization validation: workload %q token duplicates another workload", workloadID)
+			return nil, fmt.Errorf("authorization validation: identity token %q token duplicates another configured identity token", identityID)
 		}
 
 		workload := &Workload{
-			ID:          workloadID,
+			ID:          identityID,
 			DisplayName: def.DisplayName,
+			IdentityID:  ownerIdentityID,
 			Providers:   make(map[string]WorkloadProviderBinding, len(def.Providers)),
 		}
 
@@ -152,15 +158,15 @@ func New(cfg config.AuthorizationConfig, pluginDefs map[string]*config.ProviderE
 				return nil, err
 			}
 			if !ok {
-				return nil, fmt.Errorf("authorization validation: workload %q references unknown provider %q", workloadID, providerName)
+				return nil, fmt.Errorf("authorization validation: identity token %q references unknown provider %q", identityID, providerName)
 			}
 
 			allow := normalizeAllowedOperations(providerDef.Allow)
 			if len(allow) == 0 {
-				return nil, fmt.Errorf("authorization validation: workload %q provider %q allow must not be empty", workloadID, providerName)
+				return nil, fmt.Errorf("authorization validation: identity token %q provider %q allow must not be empty", identityID, providerName)
 			}
 
-			binding, err := buildBinding(mode, workloadID, providerName, providerDef, defaultConnections)
+			binding, err := buildBinding(mode, identityID, workload.IdentityID, providerName, providerDef, defaultConnections)
 			if err != nil {
 				return nil, err
 			}
@@ -169,7 +175,7 @@ func New(cfg config.AuthorizationConfig, pluginDefs map[string]*config.ProviderE
 		}
 
 		a.workloadsByHash[tokenHash] = workload
-		a.workloadsBySubjectID[principal.WorkloadSubjectID(workloadID)] = workload
+		a.workloadsBySubjectID[principal.IdentitySubjectID(identityID)] = workload
 	}
 
 	return a, nil
@@ -189,7 +195,7 @@ func (a *Authorizer) ReloadAuthorizationState(ctx context.Context) error {
 	return nil
 }
 
-func (a *Authorizer) ResolveWorkloadToken(token string) (*principal.ResolvedWorkload, bool) {
+func (a *Authorizer) ResolveIdentityToken(token string) (*principal.ResolvedIdentityToken, bool) {
 	if a == nil {
 		return nil, false
 	}
@@ -197,60 +203,59 @@ func (a *Authorizer) ResolveWorkloadToken(token string) (*principal.ResolvedWork
 	if !ok || workload == nil {
 		return nil, false
 	}
-	return &principal.ResolvedWorkload{ID: workload.ID, DisplayName: workload.DisplayName}, true
-}
-
-func (a *Authorizer) IsWorkload(p *principal.Principal) bool {
-	return p != nil && p.Kind == principal.KindWorkload
+	return &principal.ResolvedIdentityToken{ID: workload.ID, DisplayName: workload.DisplayName}, true
 }
 
 func (a *Authorizer) AllowProvider(ctx context.Context, p *principal.Principal, provider string) bool {
+	if a.isConfiguredIdentityToken(p) {
+		_, ok := a.bindingForSubject(p, provider)
+		return ok
+	}
 	if a.isManagedIdentityPrincipal(p) {
 		return a.allowManagedIdentityProvider(p, provider)
 	}
-	if !a.IsWorkload(p) {
-		_, allowed := a.ResolveAccess(ctx, p, provider)
-		return allowed
-	}
-	_, ok := a.bindingForSubject(p, provider)
-	return ok
+	_, allowed := a.ResolveAccess(ctx, p, provider)
+	return allowed
 }
 
 func (a *Authorizer) AllowOperation(ctx context.Context, p *principal.Principal, provider, operation string) bool {
+	if a.isConfiguredIdentityToken(p) {
+		binding, ok := a.bindingForSubject(p, provider)
+		if !ok {
+			return false
+		}
+		_, ok = binding.Allow[operation]
+		return ok
+	}
 	if a.isManagedIdentityPrincipal(p) {
 		return a.allowManagedIdentityProvider(p, provider) && principal.AllowsOperationPermission(p, provider, operation)
 	}
-	if !a.IsWorkload(p) {
-		return a.AllowProvider(ctx, p, provider)
-	}
-	binding, ok := a.bindingForSubject(p, provider)
-	if !ok {
-		return false
-	}
-	_, ok = binding.Allow[operation]
-	return ok
+	return a.AllowProvider(ctx, p, provider)
 }
 
 func (a *Authorizer) Binding(p *principal.Principal, provider string) (CredentialBinding, bool) {
+	if a.isConfiguredIdentityToken(p) {
+		binding, ok := a.bindingForSubject(p, provider)
+		if !ok {
+			return CredentialBinding{}, false
+		}
+		return binding.CredentialBinding, true
+	}
 	if a.isManagedIdentityPrincipal(p) {
 		if !a.allowManagedIdentityProvider(p, provider) {
 			return CredentialBinding{}, false
 		}
 		return CredentialBinding{Mode: core.ConnectionModeNone}, true
 	}
-	if !a.IsWorkload(p) {
-		return CredentialBinding{}, false
-	}
-	binding, ok := a.bindingForSubject(p, provider)
-	if !ok {
-		return CredentialBinding{}, false
-	}
-	return binding.CredentialBinding, true
+	return CredentialBinding{}, false
 }
 
 func (a *Authorizer) ResolveAccess(_ context.Context, p *principal.Principal, provider string) (AccessContext, bool) {
 	if a == nil {
 		return AccessContext{}, true
+	}
+	if a.isConfiguredIdentityToken(p) {
+		return AccessContext{}, a.AllowProvider(context.Background(), p, provider)
 	}
 	if a.isManagedIdentityPrincipal(p) {
 		return AccessContext{}, a.allowManagedIdentityProvider(p, provider)
@@ -258,9 +263,6 @@ func (a *Authorizer) ResolveAccess(_ context.Context, p *principal.Principal, pr
 	policyName := strings.TrimSpace(a.providerPolicies[provider])
 	if policyName == "" {
 		return AccessContext{}, true
-	}
-	if a.IsWorkload(p) {
-		return a.ResolvePolicyAccess(context.Background(), p, policyName)
 	}
 
 	policy := a.policies[policyName]
@@ -365,7 +367,7 @@ func (a *Authorizer) ResolvePolicyAccess(_ context.Context, p *principal.Princip
 	if policyName == "" {
 		return AccessContext{}, true
 	}
-	if a.IsWorkload(p) {
+	if p != nil && !p.HasUserContext() {
 		return AccessContext{Policy: policyName}, false
 	}
 	policy := a.policies[policyName]
@@ -392,7 +394,7 @@ func (a *Authorizer) ResolveAdminAccess(_ context.Context, p *principal.Principa
 	if policyName == "" {
 		return AccessContext{}, true
 	}
-	if a.IsWorkload(p) {
+	if p != nil && !p.HasUserContext() {
 		return AccessContext{Policy: policyName}, false
 	}
 	policy := a.policies[policyName]
@@ -412,11 +414,11 @@ func (a *Authorizer) ResolveAdminAccess(_ context.Context, p *principal.Principa
 }
 
 func (a *Authorizer) AllowCatalogOperation(ctx context.Context, p *principal.Principal, provider string, op catalog.CatalogOperation) bool {
+	if a.isConfiguredIdentityToken(p) {
+		return a.AllowOperation(ctx, p, provider, op.ID)
+	}
 	if a.isManagedIdentityPrincipal(p) {
 		return a.allowManagedIdentityProvider(p, provider) && principal.AllowsOperationPermission(p, provider, op.ID)
-	}
-	if a.IsWorkload(p) {
-		return a.AllowOperation(ctx, p, provider, op.ID)
 	}
 	access, allowed := a.ResolveAccess(ctx, p, provider)
 	if !allowed {
@@ -441,7 +443,7 @@ func (a *Authorizer) AllowCatalogOperation(ctx context.Context, p *principal.Pri
 }
 
 func (a *Authorizer) bindingForSubject(p *principal.Principal, provider string) (WorkloadProviderBinding, bool) {
-	if a == nil || p == nil || p.SubjectID == "" {
+	if a == nil || !a.isConfiguredIdentityToken(p) || p.SubjectID == "" {
 		return WorkloadProviderBinding{}, false
 	}
 	workload, ok := a.workloadsBySubjectID[p.SubjectID]
@@ -485,11 +487,11 @@ func (p *HumanPolicy) staticRoleForIdentity(subjectID, userID, email string) (st
 	return "", false
 }
 
-func buildBinding(mode core.ConnectionMode, workloadID, provider string, def config.WorkloadProviderDef, defaultConnections map[string]string) (WorkloadProviderBinding, error) {
+func buildBinding(mode core.ConnectionMode, workloadID, identityID, provider string, def config.WorkloadProviderDef, defaultConnections map[string]string) (WorkloadProviderBinding, error) {
 	switch mode {
 	case core.ConnectionModeNone:
 		if strings.TrimSpace(def.Connection) != "" || strings.TrimSpace(def.Instance) != "" {
-			return WorkloadProviderBinding{}, fmt.Errorf("authorization validation: workload %q provider %q does not accept connection or instance bindings", workloadID, provider)
+			return WorkloadProviderBinding{}, fmt.Errorf("authorization validation: identity token %q provider %q does not accept connection or instance bindings", workloadID, provider)
 		}
 		return WorkloadProviderBinding{
 			CredentialBinding: CredentialBinding{
@@ -497,16 +499,23 @@ func buildBinding(mode core.ConnectionMode, workloadID, provider string, def con
 			},
 		}, nil
 	case core.ConnectionModeIdentity:
+		ownerIdentityID := strings.TrimSpace(identityID)
+		if ownerIdentityID == "" {
+			return WorkloadProviderBinding{}, fmt.Errorf("authorization validation: identity token %q provider %q requires identity ownership for identity-mode credentials", workloadID, provider)
+		}
+		if !safeConnectionValue.MatchString(ownerIdentityID) {
+			return WorkloadProviderBinding{}, fmt.Errorf("authorization validation: identity token %q identity ID contains invalid characters", workloadID)
+		}
 		connection := strings.TrimSpace(def.Connection)
 		if connection == "" {
 			connection = defaultConnections[provider]
 		}
 		connection = config.ResolveConnectionAlias(connection)
 		if connection == "" {
-			return WorkloadProviderBinding{}, fmt.Errorf("authorization validation: workload %q provider %q requires a bound connection", workloadID, provider)
+			return WorkloadProviderBinding{}, fmt.Errorf("authorization validation: identity token %q provider %q requires a bound connection", workloadID, provider)
 		}
 		if !safeConnectionValue.MatchString(connection) {
-			return WorkloadProviderBinding{}, fmt.Errorf("authorization validation: workload %q provider %q connection contains invalid characters", workloadID, provider)
+			return WorkloadProviderBinding{}, fmt.Errorf("authorization validation: identity token %q provider %q connection contains invalid characters", workloadID, provider)
 		}
 
 		instance := strings.TrimSpace(def.Instance)
@@ -514,22 +523,22 @@ func buildBinding(mode core.ConnectionMode, workloadID, provider string, def con
 			instance = defaultInstance
 		}
 		if !safeInstanceValue.MatchString(instance) {
-			return WorkloadProviderBinding{}, fmt.Errorf("authorization validation: workload %q provider %q instance contains invalid characters", workloadID, provider)
+			return WorkloadProviderBinding{}, fmt.Errorf("authorization validation: identity token %q provider %q instance contains invalid characters", workloadID, provider)
 		}
 
 		return WorkloadProviderBinding{
 			CredentialBinding: CredentialBinding{
 				Mode:                core.ConnectionModeIdentity,
-				CredentialSubjectID: principal.IdentitySubjectID(),
-				CredentialOwnerID:   principal.IdentityPrincipal,
+				CredentialSubjectID: principal.IdentitySubjectID(ownerIdentityID),
+				CredentialOwnerID:   ownerIdentityID,
 				Connection:          connection,
 				Instance:            instance,
 			},
 		}, nil
 	case core.ConnectionModeUser, core.ConnectionMode("either"), "":
-		return WorkloadProviderBinding{}, fmt.Errorf("authorization validation: workload %q provider %q uses unsupported connection mode %q in v1", workloadID, provider, mode)
+		return WorkloadProviderBinding{}, fmt.Errorf("authorization validation: identity token %q provider %q uses unsupported connection mode %q in v1", workloadID, provider, mode)
 	default:
-		return WorkloadProviderBinding{}, fmt.Errorf("authorization validation: workload %q provider %q uses unknown connection mode %q", workloadID, provider, mode)
+		return WorkloadProviderBinding{}, fmt.Errorf("authorization validation: identity token %q provider %q uses unknown connection mode %q", workloadID, provider, mode)
 	}
 }
 
@@ -550,7 +559,11 @@ func normalizeEmail(email string) string {
 }
 
 func (a *Authorizer) isManagedIdentityPrincipal(p *principal.Principal) bool {
-	return a.IsWorkload(p) && principal.ManagedIdentityIDFromSubjectID(strings.TrimSpace(p.SubjectID)) != ""
+	return p != nil && p.Kind == principal.KindIdentity && p.Source == principal.SourceAPIToken
+}
+
+func (a *Authorizer) isConfiguredIdentityToken(p *principal.Principal) bool {
+	return p != nil && p.Kind == principal.KindIdentity && p.Source == principal.SourceIdentityToken
 }
 
 func (a *Authorizer) allowManagedIdentityProvider(p *principal.Principal, provider string) bool {

--- a/gestaltd/internal/authorization/provider_backed.go
+++ b/gestaltd/internal/authorization/provider_backed.go
@@ -195,25 +195,18 @@ func (a *ProviderBackedAuthorizer) pollLoop(ctx context.Context, done chan struc
 	}
 }
 
-func (a *ProviderBackedAuthorizer) ResolveWorkloadToken(token string) (*principal.ResolvedWorkload, bool) {
+func (a *ProviderBackedAuthorizer) ResolveIdentityToken(token string) (*principal.ResolvedIdentityToken, bool) {
 	if a == nil {
 		return nil, false
 	}
-	return a.base.ResolveWorkloadToken(token)
-}
-
-func (a *ProviderBackedAuthorizer) IsWorkload(p *principal.Principal) bool {
-	if a == nil {
-		return false
-	}
-	return a.base.IsWorkload(p)
+	return a.base.ResolveIdentityToken(token)
 }
 
 func (a *ProviderBackedAuthorizer) AllowProvider(ctx context.Context, p *principal.Principal, provider string) bool {
 	if a == nil {
 		return true
 	}
-	if a.base.IsWorkload(p) || a.base.isManagedIdentityPrincipal(p) {
+	if p != nil && !p.HasUserContext() {
 		return a.base.AllowProvider(ctx, p, provider)
 	}
 	_, allowed := a.ResolveAccess(ctx, p, provider)
@@ -224,7 +217,7 @@ func (a *ProviderBackedAuthorizer) AllowOperation(ctx context.Context, p *princi
 	if a == nil {
 		return true
 	}
-	if a.base.IsWorkload(p) || a.base.isManagedIdentityPrincipal(p) {
+	if p != nil && !p.HasUserContext() {
 		return a.base.AllowOperation(ctx, p, provider, operation)
 	}
 	return a.AllowProvider(ctx, p, provider)
@@ -241,7 +234,7 @@ func (a *ProviderBackedAuthorizer) ResolveAccess(ctx context.Context, p *princip
 	if a == nil {
 		return AccessContext{}, true
 	}
-	if a.base.isManagedIdentityPrincipal(p) || a.base.IsWorkload(p) {
+	if p != nil && !p.HasUserContext() {
 		return a.base.ResolveAccess(ctx, p, provider)
 	}
 
@@ -279,7 +272,7 @@ func (a *ProviderBackedAuthorizer) ResolvePolicyAccess(ctx context.Context, p *p
 	if a == nil {
 		return AccessContext{}, true
 	}
-	if a.base.IsWorkload(p) {
+	if p != nil && !p.HasUserContext() {
 		return a.base.ResolvePolicyAccess(ctx, p, policyName)
 	}
 	policyName = strings.TrimSpace(policyName)
@@ -316,7 +309,7 @@ func (a *ProviderBackedAuthorizer) ResolveAdminAccess(ctx context.Context, p *pr
 	if a == nil {
 		return AccessContext{}, true
 	}
-	if a.base.IsWorkload(p) {
+	if p != nil && !p.HasUserContext() {
 		return a.base.ResolveAdminAccess(ctx, p, policyName)
 	}
 	policyName = strings.TrimSpace(policyName)
@@ -366,7 +359,7 @@ func (a *ProviderBackedAuthorizer) AllowCatalogOperation(ctx context.Context, p 
 	if a == nil {
 		return true
 	}
-	if a.base.IsWorkload(p) || a.base.isManagedIdentityPrincipal(p) {
+	if p != nil && !p.HasUserContext() {
 		return a.base.AllowCatalogOperation(ctx, p, provider, op)
 	}
 

--- a/gestaltd/internal/authorization/runtime.go
+++ b/gestaltd/internal/authorization/runtime.go
@@ -8,17 +8,16 @@ import (
 )
 
 // RuntimeAuthorizer is the internal authorization interface used by gestaltd
-// request paths. It keeps workload execution binding concerns local while
-// allowing human authorization decisions to come from a backing provider.
+// request paths. It keeps identity-token execution binding concerns local while
+// allowing user-context authorization decisions to come from a backing provider.
 type RuntimeAuthorizer interface {
-	principal.WorkloadTokenResolver
+	principal.IdentityTokenResolver
 
 	Start(ctx context.Context) error
 	Close() error
 
 	ReloadAuthorizationState(ctx context.Context) error
 
-	IsWorkload(p *principal.Principal) bool
 	AllowProvider(ctx context.Context, p *principal.Principal, provider string) bool
 	AllowOperation(ctx context.Context, p *principal.Principal, provider, operation string) bool
 	Binding(p *principal.Principal, provider string) (CredentialBinding, bool)

--- a/gestaltd/internal/bootstrap/bootstrap_test.go
+++ b/gestaltd/internal/bootstrap/bootstrap_test.go
@@ -2680,8 +2680,8 @@ func TestBootstrapStartsWorkflowProvidersAfterInvokerIsReady(t *testing.T) {
 		if name != "temporal" {
 			return nil, fmt.Errorf("workflow name = %q, want %q", name, "temporal")
 		}
-		if err := deps.Services.Tokens.StoreToken(context.Background(), &core.IntegrationToken{
-			UserID:      principal.IdentityPrincipal,
+		if err := deps.Services.Tokens.StoreIdentityToken(context.Background(), &core.IntegrationToken{
+			IdentityID:  "workflow.roadmap",
 			Integration: "roadmap",
 			Connection:  config.PluginConnectionName,
 			Instance:    "default",
@@ -2735,8 +2735,8 @@ func TestValidateStartsWorkflowProvidersAfterInvokerIsReady(t *testing.T) {
 		if name != "temporal" {
 			return nil, fmt.Errorf("workflow name = %q, want %q", name, "temporal")
 		}
-		if err := deps.Services.Tokens.StoreToken(context.Background(), &core.IntegrationToken{
-			UserID:      principal.IdentityPrincipal,
+		if err := deps.Services.Tokens.StoreIdentityToken(context.Background(), &core.IntegrationToken{
+			IdentityID:  "workflow.roadmap",
 			Integration: "roadmap",
 			Connection:  config.PluginConnectionName,
 			Instance:    "default",
@@ -2823,8 +2823,8 @@ func TestValidateManagedWorkflowStartupCallbackUsesPreparedProviderStub(t *testi
 				if name != "temporal" {
 					return nil, fmt.Errorf("workflow name = %q, want %q", name, "temporal")
 				}
-				if err := deps.Services.Tokens.StoreToken(context.Background(), &core.IntegrationToken{
-					UserID:      principal.IdentityPrincipal,
+				if err := deps.Services.Tokens.StoreIdentityToken(context.Background(), &core.IntegrationToken{
+					IdentityID:  "workflow.roadmap",
 					Integration: "roadmap",
 					Connection:  config.PluginConnectionName,
 					Instance:    "default",
@@ -2919,8 +2919,8 @@ func TestValidateManagedWorkflowStartupInvokesMCPPassthroughPreparedProviders(t 
 		if connection == "" {
 			connection = config.PluginConnectionName
 		}
-		if err := deps.Services.Tokens.StoreToken(context.Background(), &core.IntegrationToken{
-			UserID:      principal.IdentityPrincipal,
+		if err := deps.Services.Tokens.StoreIdentityToken(context.Background(), &core.IntegrationToken{
+			IdentityID:  "workflow.roadmap",
 			Integration: "roadmap",
 			Connection:  connection,
 			Instance:    "default",
@@ -3640,8 +3640,8 @@ func TestBootstrapSecretResolution(t *testing.T) {
 		if result.Authorizer == nil {
 			t.Fatal("Authorizer is nil")
 		}
-		if _, ok := result.Authorizer.ResolveWorkloadToken("gst_wld_resolved-workload-token"); !ok {
-			t.Fatal("expected resolved workload token to authenticate")
+		if _, ok := result.Authorizer.ResolveIdentityToken("gst_wld_resolved-workload-token"); !ok {
+			t.Fatal("expected resolved identity token to authenticate")
 		}
 	})
 
@@ -4387,7 +4387,7 @@ func TestBootstrapWorkloadAuthorizationRejectsEitherProvider(t *testing.T) {
 
 	cfg := validConfig()
 	cfg.Authorization = config.AuthorizationConfig{
-		Workloads: map[string]config.WorkloadDef{
+		IdentityTokens: map[string]config.WorkloadDef{
 			"triage-bot": {
 				Token: "gst_wld_triage-bot-token",
 				Providers: map[string]config.WorkloadProviderDef{

--- a/gestaltd/internal/bootstrap/workflow_runtime.go
+++ b/gestaltd/internal/bootstrap/workflow_runtime.go
@@ -510,14 +510,14 @@ func (r *workflowRuntime) AugmentAuthorization(cfg config.AuthorizationConfig) (
 		return cfg, nil
 	}
 	cfg.Policies = maps.Clone(cfg.Policies)
-	cfg.Workloads = maps.Clone(cfg.Workloads)
-	if cfg.Workloads == nil {
-		cfg.Workloads = map[string]config.WorkloadDef{}
+	cfg.IdentityTokens = maps.Clone(cfg.IdentityTokens)
+	if cfg.IdentityTokens == nil {
+		cfg.IdentityTokens = map[string]config.WorkloadDef{}
 	}
 	for pluginName, binding := range r.bindings {
 		workloadID := workflowWorkloadID(pluginName)
-		if _, exists := cfg.Workloads[workloadID]; exists {
-			return config.AuthorizationConfig{}, fmt.Errorf("authorization validation: managed workflow workload %q conflicts with configured workload", workloadID)
+		if _, exists := cfg.IdentityTokens[workloadID]; exists {
+			return config.AuthorizationConfig{}, fmt.Errorf("authorization validation: managed workflow identity token %q conflicts with configured identity token", workloadID)
 		}
 		allow := make([]string, 0, len(binding.operations))
 		for operation := range binding.operations {
@@ -526,10 +526,11 @@ func (r *workflowRuntime) AugmentAuthorization(cfg config.AuthorizationConfig) (
 		slices.Sort(allow)
 		token, ok := r.workloadTokens[pluginName]
 		if !ok {
-			return config.AuthorizationConfig{}, fmt.Errorf("authorization validation: managed workflow workload %q is missing a token", workloadID)
+			return config.AuthorizationConfig{}, fmt.Errorf("authorization validation: managed workflow identity token %q is missing a token", workloadID)
 		}
-		cfg.Workloads[workloadID] = config.WorkloadDef{
+		cfg.IdentityTokens[workloadID] = config.WorkloadDef{
 			DisplayName: workflowWorkloadDisplayName(pluginName),
+			IdentityID:  workloadID,
 			Token:       token,
 			Providers: map[string]config.WorkloadProviderDef{
 				pluginName: {
@@ -543,9 +544,9 @@ func (r *workflowRuntime) AugmentAuthorization(cfg config.AuthorizationConfig) (
 
 func workflowWorkloadPrincipal(pluginName string) *principal.Principal {
 	return &principal.Principal{
-		Kind:      principal.KindWorkload,
-		SubjectID: principal.WorkloadSubjectID(workflowWorkloadID(pluginName)),
-		Source:    principal.SourceWorkloadToken,
+		Kind:      principal.KindIdentity,
+		SubjectID: principal.IdentitySubjectID(workflowWorkloadID(pluginName)),
+		Source:    principal.SourceIdentityToken,
 	}
 }
 
@@ -564,7 +565,7 @@ func workflowWorkloadDisplayName(pluginName string) string {
 func workflowWorkloadToken() (string, error) {
 	var raw [16]byte
 	if _, err := rand.Read(raw[:]); err != nil {
-		return "", fmt.Errorf("generate managed workflow workload token: %w", err)
+		return "", fmt.Errorf("generate managed workflow identity token: %w", err)
 	}
 	return "gst_wld_" + hex.EncodeToString(raw[:]), nil
 }

--- a/gestaltd/internal/bootstrap/workflow_runtime_test.go
+++ b/gestaltd/internal/bootstrap/workflow_runtime_test.go
@@ -265,7 +265,7 @@ func TestWorkflowRuntimeInvokeMergesConfiguredAndPerRunInput(t *testing.T) {
 	if resp.Status != http.StatusAccepted || resp.Body != `{"ok":true}` {
 		t.Fatalf("response = %#v", resp)
 	}
-	if gotPrincipal == nil || gotPrincipal.SubjectID != principal.WorkloadSubjectID("workflow.roadmap") {
+	if gotPrincipal == nil || gotPrincipal.SubjectID != principal.IdentitySubjectID("workflow.roadmap") {
 		t.Fatalf("principal = %#v", gotPrincipal)
 	}
 	if gotProvider != "roadmap" {

--- a/gestaltd/internal/bootstrap/workflow_startup_test.go
+++ b/gestaltd/internal/bootstrap/workflow_startup_test.go
@@ -19,7 +19,6 @@ import (
 	coretesting "github.com/valon-technologies/gestalt/server/core/testing"
 	coreworkflow "github.com/valon-technologies/gestalt/server/core/workflow"
 	"github.com/valon-technologies/gestalt/server/internal/config"
-	"github.com/valon-technologies/gestalt/server/internal/principal"
 	"github.com/valon-technologies/gestalt/server/internal/providerhost"
 	"github.com/valon-technologies/gestalt/server/internal/testutil"
 	providermanifestv1 "github.com/valon-technologies/gestalt/server/sdk/providermanifest/v1"
@@ -256,8 +255,8 @@ func TestBootstrapWorkflowStartupCallbackWaitsForDelayedPluginProvider(t *testin
 		if name != "temporal" {
 			return nil, fmt.Errorf("workflow name = %q, want %q", name, "temporal")
 		}
-		if err := deps.Services.Tokens.StoreToken(context.Background(), &core.IntegrationToken{
-			UserID:      principal.IdentityPrincipal,
+		if err := deps.Services.Tokens.StoreIdentityToken(context.Background(), &core.IntegrationToken{
+			IdentityID:  "workflow.roadmap",
 			Integration: "roadmap",
 			Connection:  config.PluginConnectionName,
 			Instance:    "default",
@@ -436,7 +435,7 @@ func TestBootstrapFailsPendingWorkflowStartupClientsOnAuthorizationErrors(t *tes
 		"temporal": {Source: config.ProviderSource{Path: "stub"}},
 	}
 	cfg.Authorization = config.AuthorizationConfig{
-		Workloads: map[string]config.WorkloadDef{
+		IdentityTokens: map[string]config.WorkloadDef{
 			"workflow.roadmap": {
 				Token: "gst_wld_conflict",
 			},
@@ -454,7 +453,7 @@ func TestBootstrapFailsPendingWorkflowStartupClientsOnAuthorizationErrors(t *tes
 		if err == nil {
 			t.Fatal("expected error, got nil")
 		}
-		if !strings.Contains(err.Error(), `conflicts with configured workload`) {
+		if !strings.Contains(err.Error(), `conflicts with configured identity token`) {
 			t.Fatalf("unexpected error: %v", err)
 		}
 	case <-time.After(15 * time.Second):
@@ -492,8 +491,8 @@ func TestBootstrapFailsWorkflowStartupDependencyCycles(t *testing.T) {
 
 	factories := workflowStartupTestFactories()
 	factories.Workflow = func(_ context.Context, name string, _ yaml.Node, hostServices []providerhost.HostService, deps Deps) (coreworkflow.Provider, error) {
-		if err := deps.Services.Tokens.StoreToken(context.Background(), &core.IntegrationToken{
-			UserID:      principal.IdentityPrincipal,
+		if err := deps.Services.Tokens.StoreIdentityToken(context.Background(), &core.IntegrationToken{
+			IdentityID:  "workflow.roadmap",
 			Integration: "roadmap",
 			Connection:  config.PluginConnectionName,
 			Instance:    "default",

--- a/gestaltd/internal/config/config.go
+++ b/gestaltd/internal/config/config.go
@@ -513,8 +513,9 @@ type EgressConfig struct {
 }
 
 type AuthorizationConfig struct {
-	Workloads map[string]WorkloadDef    `yaml:"workloads,omitempty"`
-	Policies  map[string]HumanPolicyDef `yaml:"policies,omitempty"`
+	IdentityTokens map[string]WorkloadDef    `yaml:"identityTokens,omitempty"`
+	Workloads      map[string]WorkloadDef    `yaml:"workloads,omitempty"`
+	Policies       map[string]HumanPolicyDef `yaml:"policies,omitempty"`
 }
 
 type HumanPolicyDef struct {
@@ -530,6 +531,7 @@ type HumanPolicyMemberDef struct {
 
 type WorkloadDef struct {
 	DisplayName string                         `yaml:"displayName,omitempty"`
+	IdentityID  string                         `yaml:"identityID,omitempty"`
 	Token       string                         `yaml:"token"`
 	Providers   map[string]WorkloadProviderDef `yaml:"providers,omitempty"`
 }
@@ -1848,11 +1850,15 @@ func normalizeAuthorizationConfig(cfg *Config) error {
 	if cfg == nil {
 		return nil
 	}
-	cfg.Authorization = normalizedAuthorizationConfig(cfg.Authorization)
+	normalized, err := normalizedAuthorizationConfig(cfg.Authorization)
+	if err != nil {
+		return err
+	}
+	cfg.Authorization = normalized
 	return nil
 }
 
-func normalizedAuthorizationConfig(cfg AuthorizationConfig) AuthorizationConfig {
+func normalizedAuthorizationConfig(cfg AuthorizationConfig) (AuthorizationConfig, error) {
 	if len(cfg.Policies) == 0 {
 		cfg.Policies = nil
 	} else {
@@ -1862,16 +1868,49 @@ func normalizedAuthorizationConfig(cfg AuthorizationConfig) AuthorizationConfig 
 		}
 		cfg.Policies = policies
 	}
-	if len(cfg.Workloads) == 0 {
-		cfg.Workloads = nil
-	} else {
-		workloads := make(map[string]WorkloadDef, len(cfg.Workloads))
-		for name, workload := range cfg.Workloads {
-			workloads[name] = normalizedWorkloadDef(workload)
+	identityTokens := make(map[string]WorkloadDef, len(cfg.IdentityTokens)+len(cfg.Workloads))
+	addIdentityToken := func(source, name string, identityToken WorkloadDef) error {
+		name = strings.TrimSpace(name)
+		identityToken = normalizedWorkloadDef(identityToken)
+		identityID := strings.TrimSpace(identityToken.IdentityID)
+		switch source {
+		case "identityTokens":
+			if identityID == "" {
+				identityID = name
+			} else if identityID != name {
+				return fmt.Errorf("normalize authorization config: authorization.identityTokens.%s identityID %q must match map key", name, identityID)
+			}
+		case "workloads":
+			if identityID == "" {
+				identityID = name
+			}
+		default:
+			return fmt.Errorf("normalize authorization config: unsupported identity token source %q", source)
 		}
-		cfg.Workloads = workloads
+		identityToken.IdentityID = identityID
+		if _, exists := identityTokens[identityID]; exists {
+			return fmt.Errorf("normalize authorization config: authorization.%s.%s duplicates authorization.identityTokens.%s", source, name, identityID)
+		}
+		identityTokens[identityID] = identityToken
+		return nil
 	}
-	return cfg
+	for name, identityToken := range cfg.IdentityTokens {
+		if err := addIdentityToken("identityTokens", name, identityToken); err != nil {
+			return AuthorizationConfig{}, err
+		}
+	}
+	for name, identityToken := range cfg.Workloads {
+		if err := addIdentityToken("workloads", name, identityToken); err != nil {
+			return AuthorizationConfig{}, err
+		}
+	}
+	if len(identityTokens) == 0 {
+		cfg.IdentityTokens = nil
+	} else {
+		cfg.IdentityTokens = identityTokens
+	}
+	cfg.Workloads = nil
+	return cfg, nil
 }
 
 func normalizeAdminConfig(cfg *Config) error {

--- a/gestaltd/internal/coredata/canonical_future.go
+++ b/gestaltd/internal/coredata/canonical_future.go
@@ -180,6 +180,18 @@ func (s *ExternalCredentialService) GetCredential(ctx context.Context, identityI
 	return recordToExternalCredential(rec), nil
 }
 
+func (s *ExternalCredentialService) ListByIdentityConnection(ctx context.Context, identityID, plugin, connection string) ([]*core.ExternalCredential, error) {
+	recs, err := s.store.Index("by_identity_connection").GetAll(ctx, nil, strings.TrimSpace(identityID), strings.TrimSpace(plugin), strings.TrimSpace(connection))
+	if err != nil {
+		return nil, fmt.Errorf("list external credentials: %w", err)
+	}
+	out := make([]*core.ExternalCredential, 0, len(recs))
+	for _, rec := range recs {
+		out = append(out, recordToExternalCredential(rec))
+	}
+	return out, nil
+}
+
 func encodeLegacyCredentialPayload(accessTokenEncrypted, refreshTokenEncrypted string) (string, error) {
 	payload := map[string]string{
 		"access_token_encrypted":  accessTokenEncrypted,

--- a/gestaltd/internal/coredata/tokens.go
+++ b/gestaltd/internal/coredata/tokens.go
@@ -2,9 +2,11 @@ package coredata
 
 import (
 	"context"
+	"encoding/json"
 	"errors"
 	"fmt"
 	"sort"
+	"strings"
 	"time"
 
 	"github.com/google/uuid"
@@ -119,6 +121,95 @@ func (s *TokenService) ListTokensForConnection(ctx context.Context, userID, inte
 	return s.recordsToTokens(recs)
 }
 
+func (s *TokenService) IdentityToken(ctx context.Context, identityID, integration, connection, instance string) (*core.IntegrationToken, error) {
+	if s.externalCredentials == nil {
+		return nil, core.ErrNotFound
+	}
+	credential, err := s.externalCredentials.GetCredential(ctx, identityID, integration, connection, instance)
+	if err != nil {
+		return nil, err
+	}
+	return s.credentialToToken(credential)
+}
+
+func (s *TokenService) ListIdentityTokensForConnection(ctx context.Context, identityID, integration, connection string) ([]*core.IntegrationToken, error) {
+	if s.externalCredentials == nil {
+		return nil, nil
+	}
+	credentials, err := s.externalCredentials.ListByIdentityConnection(ctx, identityID, integration, connection)
+	if err != nil {
+		return nil, err
+	}
+	out := make([]*core.IntegrationToken, 0, len(credentials))
+	for _, credential := range credentials {
+		token, err := s.credentialToToken(credential)
+		if err != nil {
+			return nil, err
+		}
+		out = append(out, token)
+	}
+	sort.Slice(out, func(i, j int) bool {
+		if !out[i].UpdatedAt.Equal(out[j].UpdatedAt) {
+			return out[i].UpdatedAt.After(out[j].UpdatedAt)
+		}
+		if !out[i].CreatedAt.Equal(out[j].CreatedAt) {
+			return out[i].CreatedAt.After(out[j].CreatedAt)
+		}
+		return out[i].ID < out[j].ID
+	})
+	return out, nil
+}
+
+func (s *TokenService) StoreIdentityToken(ctx context.Context, token *core.IntegrationToken) error {
+	if s.externalCredentials == nil {
+		return fmt.Errorf("store identity token: external credentials store is not configured")
+	}
+	if token == nil {
+		return fmt.Errorf("store identity token: token is required")
+	}
+	if strings.TrimSpace(token.IdentityID) == "" || strings.TrimSpace(token.Integration) == "" || strings.TrimSpace(token.Connection) == "" {
+		return fmt.Errorf("store identity token: identity_id, integration, and connection are required")
+	}
+	accessEnc, refreshEnc, err := s.enc.EncryptTokenPair(token.AccessToken, token.RefreshToken)
+	if err != nil {
+		return fmt.Errorf("encrypt token pair: %w", err)
+	}
+	payloadEncrypted, err := encodeLegacyCredentialPayload(accessEnc, refreshEnc)
+	if err != nil {
+		return err
+	}
+	now := time.Now()
+	if token.ID == "" {
+		token.ID = uuid.New().String()
+	}
+	if token.CreatedAt.IsZero() {
+		token.CreatedAt = now
+	}
+	if token.UpdatedAt.IsZero() {
+		token.UpdatedAt = now
+	}
+	credential := &core.ExternalCredential{
+		ID:                token.ID,
+		IdentityID:        strings.TrimSpace(token.IdentityID),
+		Plugin:            strings.TrimSpace(token.Integration),
+		Connection:        strings.TrimSpace(token.Connection),
+		Instance:          strings.TrimSpace(token.Instance),
+		AuthType:          externalCredentialAuthType(token),
+		PayloadEncrypted:  payloadEncrypted,
+		Scopes:            token.Scopes,
+		ExpiresAt:         token.ExpiresAt,
+		LastRefreshedAt:   token.LastRefreshedAt,
+		RefreshErrorCount: token.RefreshErrorCount,
+		MetadataJSON:      token.MetadataJSON,
+		CreatedAt:         token.CreatedAt,
+		UpdatedAt:         token.UpdatedAt,
+	}
+	if _, err := s.externalCredentials.UpsertCredential(ctx, credential); err != nil {
+		return err
+	}
+	return nil
+}
+
 func (s *TokenService) DeleteToken(ctx context.Context, id string) error {
 	if id == "" {
 		return s.store.Delete(ctx, id)
@@ -178,6 +269,47 @@ func (s *TokenService) recordToToken(rec indexeddb.Record) (*core.IntegrationTok
 		MetadataJSON:      recString(rec, "metadata_json"),
 		CreatedAt:         recTime(rec, "created_at"),
 		UpdatedAt:         recTime(rec, "updated_at"),
+	}, nil
+}
+
+func decodeLegacyCredentialPayload(payload string) (string, string, error) {
+	if strings.TrimSpace(payload) == "" {
+		return "", "", nil
+	}
+	var stored map[string]string
+	if err := json.Unmarshal([]byte(payload), &stored); err != nil {
+		return "", "", fmt.Errorf("decode credential payload: %w", err)
+	}
+	return stored["access_token_encrypted"], stored["refresh_token_encrypted"], nil
+}
+
+func (s *TokenService) credentialToToken(credential *core.ExternalCredential) (*core.IntegrationToken, error) {
+	if credential == nil {
+		return nil, core.ErrNotFound
+	}
+	accessEnc, refreshEnc, err := decodeLegacyCredentialPayload(credential.PayloadEncrypted)
+	if err != nil {
+		return nil, fmt.Errorf("%w: %v", errUnreadableStoredIntegrationToken, err)
+	}
+	access, refresh, err := s.enc.DecryptTokenPair(accessEnc, refreshEnc)
+	if err != nil {
+		return nil, fmt.Errorf("%w: decrypt token pair: %v", errUnreadableStoredIntegrationToken, err)
+	}
+	return &core.IntegrationToken{
+		ID:                credential.ID,
+		IdentityID:        credential.IdentityID,
+		Integration:       credential.Plugin,
+		Connection:        credential.Connection,
+		Instance:          credential.Instance,
+		AccessToken:       access,
+		RefreshToken:      refresh,
+		Scopes:            credential.Scopes,
+		ExpiresAt:         credential.ExpiresAt,
+		LastRefreshedAt:   credential.LastRefreshedAt,
+		RefreshErrorCount: credential.RefreshErrorCount,
+		MetadataJSON:      credential.MetadataJSON,
+		CreatedAt:         credential.CreatedAt,
+		UpdatedAt:         credential.UpdatedAt,
 	}, nil
 }
 

--- a/gestaltd/internal/invocation/broker.go
+++ b/gestaltd/internal/invocation/broker.go
@@ -219,9 +219,12 @@ func (b *Broker) Invoke(ctx context.Context, p *principal.Principal, providerNam
 		if access.Policy != "" || access.Role != "" {
 			ctx = WithAccessContext(ctx, access)
 		}
-		if b.authorizer.IsWorkload(p) {
+		if p != nil && !p.HasUserContext() {
 			if binding, ok := b.authorizer.Binding(p, providerName); ok {
 				SetCredentialAudit(ctx, binding.Mode, binding.CredentialSubjectID, binding.Connection, binding.Instance)
+			}
+			if !b.authorizer.AllowOperation(ctx, p, providerName, operation) {
+				return fail(fmt.Errorf("%w: %s.%s", ErrAuthorizationDenied, providerName, operation))
 			}
 		} else if !allowed {
 			return fail(fmt.Errorf("%w: %s", ErrAuthorizationDenied, providerName))
@@ -229,10 +232,7 @@ func (b *Broker) Invoke(ctx context.Context, p *principal.Principal, providerNam
 	}
 
 	conn := ConnectionFromContext(ctx)
-	conn, instance = b.workloadSelectors(p, providerName, conn, instance)
-	if b.authorizer != nil && b.authorizer.IsWorkload(p) && !b.authorizer.AllowOperation(ctx, p, providerName, operation) {
-		return fail(fmt.Errorf("%w: %s.%s", ErrAuthorizationDenied, providerName, operation))
-	}
+	conn, instance = b.identityTokenSelectors(p, providerName, conn, instance)
 
 	opMeta, transport, resolvedConnection, err := b.resolveOperation(ctx, p, prov, providerName, operation, conn, instance)
 	if err != nil {
@@ -322,8 +322,8 @@ func (b *Broker) MCPConnection(providerName string) string {
 	return b.mcpConnection(providerName)
 }
 
-func (b *Broker) workloadSelectors(p *principal.Principal, providerName, connection, instance string) (string, string) {
-	if b.authorizer == nil || !b.authorizer.IsWorkload(p) {
+func (b *Broker) identityTokenSelectors(p *principal.Principal, providerName, connection, instance string) (string, string) {
+	if b.authorizer == nil || p == nil || p.HasUserContext() {
 		return connection, instance
 	}
 	binding, ok := b.authorizer.Binding(p, providerName)
@@ -411,8 +411,10 @@ func (b *Broker) resolveToken(ctx context.Context, prov core.Provider, p *princi
 	if resolved != nil {
 		p = resolved
 	}
-	if b.authorizer != nil && b.authorizer.IsWorkload(p) {
-		return b.resolveWorkloadToken(ctx, prov, p, providerName, connection, instance)
+	if b.authorizer != nil && p != nil && !p.HasUserContext() {
+		if binding, ok := b.authorizer.Binding(p, providerName); ok {
+			return b.resolveIdentityBinding(ctx, prov, providerName, connection, instance, binding)
+		}
 	}
 	if resolved == nil {
 		if err := b.resolveUserPrincipal(ctx, p); err != nil {
@@ -435,7 +437,18 @@ func (b *Broker) resolveToken(ctx context.Context, prov core.Provider, p *princi
 		return b.resolveUserToken(ctx, prov, p.UserID, providerName, connection, instance, core.ConnectionModeUser, principal.UserSubjectID(p.UserID))
 
 	case core.ConnectionModeIdentity:
-		return b.resolveUserToken(ctx, prov, principal.IdentityPrincipal, providerName, connection, instance, core.ConnectionModeIdentity, principal.IdentitySubjectID())
+		identityID := strings.TrimSpace(p.UserID)
+		if identityID == "" {
+			return ctx, "", fmt.Errorf("%w: principal has no user ID or email", ErrUserResolution)
+		}
+		if b.users != nil {
+			canonicalIdentityID, err := b.users.CanonicalIdentityIDForUser(ctx, identityID)
+			if err != nil {
+				return ctx, "", fmt.Errorf("%w: resolving identity owner: %v", ErrUserResolution, err)
+			}
+			identityID = canonicalIdentityID
+		}
+		return b.resolveIdentityToken(ctx, prov, identityID, providerName, connection, instance, core.ConnectionModeIdentity, principal.IdentitySubjectID(identityID))
 
 	case core.ConnectionMode("either"):
 		return ctx, "", fmt.Errorf("%w: unsupported connection mode %q", ErrInternal, mode)
@@ -446,7 +459,7 @@ func (b *Broker) resolveToken(ctx context.Context, prov core.Provider, p *princi
 }
 
 func (b *Broker) resolveUserPrincipal(ctx context.Context, p *principal.Principal) error {
-	if p == nil || p.UserID != "" || p.Kind == principal.KindWorkload || p.Identity == nil || p.Identity.Email == "" {
+	if p == nil || p.UserID != "" || !p.HasUserContext() || p.Identity == nil || p.Identity.Email == "" {
 		return nil
 	}
 	if b.users == nil {
@@ -472,19 +485,11 @@ func (b *Broker) resolveUserPrincipal(ctx context.Context, p *principal.Principa
 	return nil
 }
 
-func (b *Broker) resolveWorkloadToken(ctx context.Context, prov core.Provider, p *principal.Principal, providerName, requestedConnection, requestedInstance string) (context.Context, string, error) {
-	if b.authorizer == nil {
-		return ctx, "", fmt.Errorf("%w: no workload authorizer configured", ErrAuthorizationDenied)
-	}
-	binding, ok := b.authorizer.Binding(p, providerName)
-	if !ok {
-		return ctx, "", fmt.Errorf("%w: %s", ErrAuthorizationDenied, providerName)
-	}
-
+func (b *Broker) resolveIdentityBinding(ctx context.Context, prov core.Provider, providerName, requestedConnection, requestedInstance string, binding authorization.CredentialBinding) (context.Context, string, error) {
 	switch binding.Mode {
 	case core.ConnectionModeNone:
 		if requestedConnection != "" || requestedInstance != "" {
-			return ctx, "", fmt.Errorf("%w: workloads may not override connection or instance bindings", ErrAuthorizationDenied)
+			return ctx, "", fmt.Errorf("%w: identity-token callers may not override connection or instance bindings", ErrAuthorizationDenied)
 		}
 		SetCredentialAudit(ctx, binding.Mode, binding.CredentialSubjectID, binding.Connection, binding.Instance)
 		ctx = WithCredentialContext(ctx, CredentialContext{
@@ -498,13 +503,72 @@ func (b *Broker) resolveWorkloadToken(ctx context.Context, prov core.Provider, p
 		connection := binding.Connection
 		instance := binding.Instance
 		if (requestedConnection != "" && requestedConnection != binding.Connection) || (requestedInstance != "" && requestedInstance != binding.Instance) {
-			return ctx, "", fmt.Errorf("%w: workloads may not override connection or instance bindings", ErrAuthorizationDenied)
+			return ctx, "", fmt.Errorf("%w: identity-token callers may not override connection or instance bindings", ErrAuthorizationDenied)
 		}
 		SetCredentialAudit(ctx, binding.Mode, binding.CredentialSubjectID, connection, instance)
-		return b.resolveUserToken(ctx, prov, principal.IdentityPrincipal, providerName, connection, instance, core.ConnectionModeIdentity, binding.CredentialSubjectID)
+		if binding.CredentialOwnerID == "" {
+			return ctx, "", fmt.Errorf("%w: identity binding missing owner identity", ErrInternal)
+		}
+		return b.resolveIdentityToken(ctx, prov, binding.CredentialOwnerID, providerName, connection, instance, core.ConnectionModeIdentity, binding.CredentialSubjectID)
 	default:
-		return ctx, "", fmt.Errorf("%w: workloads may only use identity or none providers", ErrAuthorizationDenied)
+		return ctx, "", fmt.Errorf("%w: identity-token callers may only use identity or none providers", ErrAuthorizationDenied)
 	}
+}
+
+func (b *Broker) resolveIdentityToken(ctx context.Context, prov core.Provider, identityID, providerName, connection, instance string, credentialMode core.ConnectionMode, credentialSubjectID string) (context.Context, string, error) {
+	var storedToken *core.IntegrationToken
+	var err error
+
+	if instance != "" {
+		storedToken, err = b.tokens.IdentityToken(ctx, identityID, providerName, connection, instance)
+		if err != nil {
+			if errors.Is(err, core.ErrNotFound) {
+				return ctx, "", fmt.Errorf("%w: no token stored for integration %q instance %q", ErrNoToken, providerName, instance)
+			}
+			return ctx, "", fmt.Errorf("%w: retrieving identity token: %v", ErrInternal, err)
+		}
+	} else {
+		tokens, listErr := b.tokens.ListIdentityTokensForConnection(ctx, identityID, providerName, connection)
+		if listErr != nil {
+			return ctx, "", fmt.Errorf("%w: listing identity tokens: %v", ErrInternal, listErr)
+		}
+		switch len(tokens) {
+		case 0:
+			return ctx, "", fmt.Errorf("%w: no token stored for integration %q", ErrNoToken, providerName)
+		case 1:
+			storedToken = tokens[0]
+		default:
+			instances := make([]string, len(tokens))
+			for i, t := range tokens {
+				instances[i] = t.Instance
+			}
+			return ctx, "", fmt.Errorf("%w: integration %q has %d connections (%v); specify which instance to use with the %q parameter",
+				ErrAmbiguousInstance, providerName, len(tokens), instances, "_instance")
+		}
+	}
+
+	if storedToken == nil {
+		return ctx, "", fmt.Errorf("%w: no token stored for integration %q", ErrNoToken, providerName)
+	}
+	SetCredentialAudit(ctx, credentialMode, credentialSubjectID, storedToken.Connection, storedToken.Instance)
+	ctx = WithCredentialContext(ctx, CredentialContext{
+		Mode:       credentialMode,
+		SubjectID:  credentialSubjectID,
+		Connection: storedToken.Connection,
+		Instance:   storedToken.Instance,
+	})
+
+	if storedToken.MetadataJSON != "" {
+		var connParams map[string]string
+		if err := json.Unmarshal([]byte(storedToken.MetadataJSON), &connParams); err != nil {
+			slog.WarnContext(ctx, "malformed metadata JSON", "provider", providerName, "error", err)
+		} else if len(connParams) > 0 {
+			ctx = core.WithConnectionParams(ctx, connParams)
+		}
+	}
+
+	accessToken, err := b.refreshTokenIfNeeded(ctx, storedToken, providerName, connection, metricutil.NormalizeConnectionMode(prov.ConnectionMode()))
+	return ctx, accessToken, err
 }
 
 func (b *Broker) resolveUserToken(ctx context.Context, prov core.Provider, userID, providerName, connection, instance string, credentialMode core.ConnectionMode, credentialSubjectID string) (context.Context, string, error) {
@@ -587,7 +651,11 @@ func (b *Broker) refreshTokenIfNeeded(ctx context.Context, token *core.Integrati
 		return token.AccessToken, nil
 	}
 
-	key := token.UserID + ":" + providerName + ":" + connection + ":" + token.Instance
+	tokenOwner := token.UserID
+	if token.IdentityID != "" {
+		tokenOwner = token.IdentityID
+	}
+	key := tokenOwner + ":" + providerName + ":" + connection + ":" + token.Instance
 	v, err, _ := b.refreshGroup.Do(key, func() (any, error) {
 		refreshCtx := context.WithoutCancel(ctx)
 		startedAt := time.Now()
@@ -596,13 +664,19 @@ func (b *Broker) refreshTokenIfNeeded(ctx context.Context, token *core.Integrati
 		return resp, err
 	})
 	if err != nil {
-		fresh, fetchErr := b.tokens.Token(ctx, token.UserID, token.Integration, token.Connection, token.Instance)
+		var fresh *core.IntegrationToken
+		var fetchErr error
+		if token.IdentityID != "" {
+			fresh, fetchErr = b.tokens.IdentityToken(ctx, token.IdentityID, token.Integration, token.Connection, token.Instance)
+		} else {
+			fresh, fetchErr = b.tokens.Token(ctx, token.UserID, token.Integration, token.Connection, token.Instance)
+		}
 		if fetchErr == nil && fresh != nil && fresh.AccessToken != token.AccessToken {
 			return fresh.AccessToken, nil
 		}
 		token.RefreshErrorCount++
 		token.UpdatedAt = time.Now()
-		if storeErr := b.tokens.StoreToken(ctx, token); storeErr != nil {
+		if storeErr := b.storeResolvedToken(ctx, token); storeErr != nil {
 			slog.WarnContext(ctx, "failed to persist refresh error count", "provider", providerName, "error", storeErr)
 		}
 		if time.Now().Before(*token.ExpiresAt) {
@@ -627,10 +701,17 @@ func (b *Broker) refreshTokenIfNeeded(ctx context.Context, token *core.Integrati
 	token.RefreshErrorCount = 0
 	token.UpdatedAt = now
 
-	if err := b.tokens.StoreToken(ctx, token); err != nil {
+	if err := b.storeResolvedToken(ctx, token); err != nil {
 		return "", fmt.Errorf("persisting refreshed token: %w", err)
 	}
 	return token.AccessToken, nil
+}
+
+func (b *Broker) storeResolvedToken(ctx context.Context, token *core.IntegrationToken) error {
+	if token != nil && token.IdentityID != "" {
+		return b.tokens.StoreIdentityToken(ctx, token)
+	}
+	return b.tokens.StoreToken(ctx, token)
 }
 
 func (b *Broker) resolveRefresher(integration, connection string) OAuthRefresher {

--- a/gestaltd/internal/invocation/broker_test.go
+++ b/gestaltd/internal/invocation/broker_test.go
@@ -2,8 +2,10 @@ package invocation
 
 import (
 	"context"
+	"errors"
 	"strings"
 	"testing"
+	"time"
 
 	"github.com/valon-technologies/gestalt/server/core"
 	coretesting "github.com/valon-technologies/gestalt/server/core/testing"
@@ -61,6 +63,57 @@ func TestBrokerResolveToken_ConnectionModeNoneResolvesSessionUserSubject(t *test
 	}
 }
 
+func TestBrokerResolveToken_ConnectionModeIdentityUsesCanonicalIdentityStore(t *testing.T) {
+	t.Parallel()
+
+	svc := coretesting.NewStubServices(t)
+	user, err := svc.Users.FindOrCreateUser(context.Background(), "user@example.com")
+	if err != nil {
+		t.Fatalf("FindOrCreateUser: %v", err)
+	}
+	if err := svc.Tokens.StoreIdentityToken(context.Background(), &core.IntegrationToken{
+		ID:          "user-identity-default",
+		IdentityID:  user.ID,
+		Integration: "slack",
+		Connection:  "workspace",
+		Instance:    "default",
+		AccessToken: "identity-token",
+	}); err != nil {
+		t.Fatalf("StoreIdentityToken: %v", err)
+	}
+
+	broker := NewBroker(
+		testutil.NewProviderRegistry(t, &coretesting.StubIntegration{
+			N:        "slack",
+			ConnMode: core.ConnectionModeIdentity,
+		}),
+		svc.Users,
+		svc.Tokens,
+	)
+	p := &principal.Principal{
+		Identity: &core.UserIdentity{
+			Email: "user@example.com",
+		},
+		Kind:   principal.KindUser,
+		Source: principal.SourceSession,
+	}
+
+	ctx, token, err := broker.ResolveToken(context.Background(), p, "slack", "workspace", "")
+	if err != nil {
+		t.Fatalf("ResolveToken: %v", err)
+	}
+	if token != "identity-token" {
+		t.Fatalf("token = %q, want %q", token, "identity-token")
+	}
+	cred := CredentialContextFromContext(ctx)
+	if cred.Mode != core.ConnectionModeIdentity {
+		t.Fatalf("credential mode = %q, want %q", cred.Mode, core.ConnectionModeIdentity)
+	}
+	if cred.SubjectID != principal.IdentitySubjectID(user.ID) {
+		t.Fatalf("credential subject = %q, want %q", cred.SubjectID, principal.IdentitySubjectID(user.ID))
+	}
+}
+
 func TestBrokerResolveToken_WorkflowContextDoesNotBypassWorkloadIdentityBinding(t *testing.T) {
 	t.Parallel()
 
@@ -70,9 +123,10 @@ func TestBrokerResolveToken_WorkflowContextDoesNotBypassWorkloadIdentityBinding(
 		ConnMode: core.ConnectionModeIdentity,
 	})
 	authz := mustAuthorizer(t, config.AuthorizationConfig{
-		Workloads: map[string]config.WorkloadDef{
+		IdentityTokens: map[string]config.WorkloadDef{
 			"workflow.roadmap": {
-				Token: "gst_wld_workflow-roadmap",
+				IdentityID: "workflow.roadmap",
+				Token:      "gst_wld_workflow-roadmap",
 				Providers: map[string]config.WorkloadProviderDef{
 					"slack": {
 						Connection: "workspace",
@@ -85,31 +139,31 @@ func TestBrokerResolveToken_WorkflowContextDoesNotBypassWorkloadIdentityBinding(
 	}, providers)
 	broker := NewBroker(providers, svc.Users, svc.Tokens, WithAuthorizer(authz))
 
-	if err := svc.Tokens.StoreToken(context.Background(), &core.IntegrationToken{
+	if err := svc.Tokens.StoreIdentityToken(context.Background(), &core.IntegrationToken{
 		ID:          "identity-workspace-team-a",
-		UserID:      principal.IdentityPrincipal,
+		IdentityID:  "workflow.roadmap",
 		Integration: "slack",
 		Connection:  "workspace",
 		Instance:    "team-a",
 		AccessToken: "team-a-token",
 	}); err != nil {
-		t.Fatalf("StoreToken team-a: %v", err)
+		t.Fatalf("StoreIdentityToken team-a: %v", err)
 	}
-	if err := svc.Tokens.StoreToken(context.Background(), &core.IntegrationToken{
+	if err := svc.Tokens.StoreIdentityToken(context.Background(), &core.IntegrationToken{
 		ID:          "identity-workspace-team-b",
-		UserID:      principal.IdentityPrincipal,
+		IdentityID:  "workflow.roadmap",
 		Integration: "slack",
 		Connection:  "workspace",
 		Instance:    "team-b",
 		AccessToken: "team-b-token",
 	}); err != nil {
-		t.Fatalf("StoreToken team-b: %v", err)
+		t.Fatalf("StoreIdentityToken team-b: %v", err)
 	}
 
 	workload := &principal.Principal{
-		SubjectID: principal.WorkloadSubjectID("workflow.roadmap"),
-		Kind:      principal.KindWorkload,
-		Source:    principal.SourceWorkloadToken,
+		SubjectID: principal.IdentitySubjectID("workflow.roadmap"),
+		Kind:      principal.KindIdentity,
+		Source:    principal.SourceIdentityToken,
 	}
 	ctx := WithWorkflowContext(context.Background(), map[string]any{
 		"runId": "run-123",
@@ -119,7 +173,112 @@ func TestBrokerResolveToken_WorkflowContextDoesNotBypassWorkloadIdentityBinding(
 	if err == nil {
 		t.Fatal("expected binding override to be rejected")
 	}
-	if got, want := err.Error(), "workloads may not override connection or instance bindings"; got == "" || !strings.Contains(got, want) {
+	if got, want := err.Error(), "identity-token callers may not override connection or instance bindings"; got == "" || !strings.Contains(got, want) {
 		t.Fatalf("ResolveToken error = %q, want substring %q", got, want)
+	}
+}
+
+type stubOAuthRefresher struct {
+	refreshTokenFn func(context.Context, string) (*core.TokenResponse, error)
+}
+
+func (s stubOAuthRefresher) RefreshToken(ctx context.Context, refreshToken string) (*core.TokenResponse, error) {
+	return s.refreshTokenFn(ctx, refreshToken)
+}
+
+func (s stubOAuthRefresher) RefreshTokenWithURL(ctx context.Context, refreshToken, _ string) (*core.TokenResponse, error) {
+	return s.refreshTokenFn(ctx, refreshToken)
+}
+
+func (stubOAuthRefresher) TokenURL() string { return "" }
+
+func TestBrokerResolveToken_RefreshesIdentityOwnedWorkloadToken(t *testing.T) {
+	t.Parallel()
+
+	svc := coretesting.NewStubServices(t)
+	providers := testutil.NewProviderRegistry(t, &coretesting.StubIntegration{
+		N:        "slack",
+		ConnMode: core.ConnectionModeIdentity,
+	})
+	authz := mustAuthorizer(t, config.AuthorizationConfig{
+		IdentityTokens: map[string]config.WorkloadDef{
+			"workflow.roadmap": {
+				IdentityID: "workflow.roadmap",
+				Token:      "gst_wld_workflow-roadmap",
+				Providers: map[string]config.WorkloadProviderDef{
+					"slack": {
+						Connection: "workspace",
+						Instance:   "team-a",
+						Allow:      []string{"list"},
+					},
+				},
+			},
+		},
+	}, providers)
+	expired := time.Now().Add(-1 * time.Hour)
+	if err := svc.Tokens.StoreIdentityToken(context.Background(), &core.IntegrationToken{
+		ID:           "identity-workspace-team-a",
+		IdentityID:   "workflow.roadmap",
+		Integration:  "slack",
+		Connection:   "workspace",
+		Instance:     "team-a",
+		AccessToken:  "stale-token",
+		RefreshToken: "refresh-me",
+		ExpiresAt:    &expired,
+	}); err != nil {
+		t.Fatalf("StoreIdentityToken: %v", err)
+	}
+
+	broker := NewBroker(
+		providers,
+		svc.Users,
+		svc.Tokens,
+		WithAuthorizer(authz),
+		WithConnectionAuth(func() map[string]map[string]OAuthRefresher {
+			return map[string]map[string]OAuthRefresher{
+				"slack": {
+					"workspace": stubOAuthRefresher{
+						refreshTokenFn: func(_ context.Context, refreshToken string) (*core.TokenResponse, error) {
+							if refreshToken != "refresh-me" {
+								return nil, errors.New("unexpected refresh token")
+							}
+							return &core.TokenResponse{
+								AccessToken:  "fresh-token",
+								RefreshToken: "rotated-refresh",
+								ExpiresIn:    3600,
+							}, nil
+						},
+					},
+				},
+			}
+		}),
+	)
+
+	workload := &principal.Principal{
+		SubjectID: principal.IdentitySubjectID("workflow.roadmap"),
+		Kind:      principal.KindIdentity,
+		Source:    principal.SourceIdentityToken,
+	}
+	_, token, err := broker.ResolveToken(context.Background(), workload, "slack", "workspace", "")
+	if err != nil {
+		t.Fatalf("ResolveToken: %v", err)
+	}
+	if token != "fresh-token" {
+		t.Fatalf("token = %q, want %q", token, "fresh-token")
+	}
+
+	stored, err := svc.Tokens.IdentityToken(context.Background(), "workflow.roadmap", "slack", "workspace", "team-a")
+	if err != nil {
+		t.Fatalf("IdentityToken: %v", err)
+	}
+	if stored.AccessToken != "fresh-token" {
+		t.Fatalf("stored access token = %q, want %q", stored.AccessToken, "fresh-token")
+	}
+	if stored.RefreshToken != "rotated-refresh" {
+		t.Fatalf("stored refresh token = %q, want %q", stored.RefreshToken, "rotated-refresh")
+	}
+
+	if _, err := svc.Tokens.Token(context.Background(), "", "slack", "workspace", "team-a"); !errors.Is(err, core.ErrNotFound) {
+		t.Fatalf("legacy empty-user token lookup err = %v, want %v", err, core.ErrNotFound)
 	}
 }

--- a/gestaltd/internal/invocation/guarded_test.go
+++ b/gestaltd/internal/invocation/guarded_test.go
@@ -244,7 +244,7 @@ func TestGuardedInvoker_AuditLoggedOnPanic(t *testing.T) {
 	sink := &capturingSink{}
 	guarded := invocation.NewGuarded(funcInvoker{
 		invoke: func(ctx context.Context, _ *principal.Principal, _ string, _ string, _ string, _ map[string]any) (*core.OperationResult, error) {
-			invocation.SetCredentialAudit(ctx, core.ConnectionModeIdentity, principal.IdentitySubjectID(), "workspace", "team-a")
+			invocation.SetCredentialAudit(ctx, core.ConnectionModeIdentity, principal.IdentitySubjectID(principal.IdentityPrincipal), "workspace", "team-a")
 			panic("boom")
 		},
 	}, nil, "test", sink, invocation.WithoutRateLimit())
@@ -267,8 +267,8 @@ func TestGuardedInvoker_AuditLoggedOnPanic(t *testing.T) {
 		if entry.CredentialMode != string(core.ConnectionModeIdentity) {
 			t.Fatalf("expected credential mode identity, got %q", entry.CredentialMode)
 		}
-		if entry.CredentialSubjectID != principal.IdentitySubjectID() {
-			t.Fatalf("expected credential subject %q, got %q", principal.IdentitySubjectID(), entry.CredentialSubjectID)
+		if entry.CredentialSubjectID != principal.IdentitySubjectID(principal.IdentityPrincipal) {
+			t.Fatalf("expected credential subject %q, got %q", principal.IdentitySubjectID(principal.IdentityPrincipal), entry.CredentialSubjectID)
 		}
 		if entry.CredentialConnection != "workspace" {
 			t.Fatalf("expected credential connection workspace, got %q", entry.CredentialConnection)

--- a/gestaltd/internal/mcp/authorization.go
+++ b/gestaltd/internal/mcp/authorization.go
@@ -16,7 +16,7 @@ func allowOperation(ctx context.Context, cfg Config, p *principal.Principal, pro
 	if cfg.Authorizer == nil {
 		return true
 	}
-	if cfg.Authorizer.IsWorkload(p) {
+	if p != nil && !p.HasUserContext() {
 		return cfg.Authorizer.AllowOperation(ctx, p, provider, operation)
 	}
 	op, ok := catalogOperationForTool(ctx, cfg, provider, operation)

--- a/gestaltd/internal/mcp/binding.go
+++ b/gestaltd/internal/mcp/binding.go
@@ -80,7 +80,7 @@ func NewServer(cfg Config) *mcpserver.MCPServer {
 		hooks.AddBeforeCallTool(func(ctx context.Context, _ any, req *mcpgo.CallToolRequest) {
 			if provName := providerNameForTool(cfg.ToolPrefixes, dynamicProviders, req.Params.Name); provName != "" {
 				instance := normalizedSessionCatalogInstance(req.GetArguments()["_instance"])
-				if workloadInstanceOverrideRequested(cfg.Authorizer, principal.FromContext(ctx), instance) {
+				if headlessInstanceOverrideRequested(cfg.Authorizer, principal.FromContext(ctx), instance) {
 					return
 				}
 				hydrateSessionToolsForInstance(ctx, cfg, []string{provName}, staticToolNames, instance)

--- a/gestaltd/internal/mcp/binding_test.go
+++ b/gestaltd/internal/mcp/binding_test.go
@@ -140,9 +140,9 @@ func ctxWithIdentityPrincipal(email, userID string) context.Context {
 
 func ctxWithWorkloadPrincipal(workloadID string) context.Context {
 	p := &principal.Principal{
-		Kind:      principal.KindWorkload,
-		SubjectID: principal.WorkloadSubjectID(workloadID),
-		Source:    principal.SourceWorkloadToken,
+		Kind:      principal.KindIdentity,
+		SubjectID: principal.IdentitySubjectID(workloadID),
+		Source:    principal.SourceIdentityToken,
 	}
 	return principal.WithPrincipal(context.Background(), p)
 }
@@ -977,7 +977,7 @@ func TestNewServer_WorkloadListToolsFiltersStaticAndSessionTools(t *testing.T) {
 
 	providers := testutil.NewProviderRegistry(t, prov)
 	authz := mustAuthorizer(t, config.AuthorizationConfig{
-		Workloads: map[string]config.WorkloadDef{
+		IdentityTokens: map[string]config.WorkloadDef{
 			"triage-bot": {
 				Token: "gst_wld_triage-bot-token",
 				Providers: map[string]config.WorkloadProviderDef{
@@ -999,8 +999,8 @@ func TestNewServer_WorkloadListToolsFiltersStaticAndSessionTools(t *testing.T) {
 		},
 		TokenResolver: &stubTokenResolver{
 			resolveFn: func(ctx context.Context, p *principal.Principal, providerName, connection, instance string) (context.Context, string, error) {
-				if p == nil || p.Kind != principal.KindWorkload {
-					t.Fatalf("expected workload principal, got %+v", p)
+				if p == nil || p.Kind != principal.KindIdentity || p.Source != principal.SourceIdentityToken {
+					t.Fatalf("expected identity-token principal, got %+v", p)
 				}
 				if providerName != "clickhouse" {
 					t.Fatalf("providerName = %q, want %q", providerName, "clickhouse")
@@ -1684,7 +1684,7 @@ func TestNewServer_WorkloadCallToolDeniedReturnsErrorResult(t *testing.T) {
 	providers := testutil.NewProviderRegistry(t, prov)
 	ds := coretesting.NewStubServices(t)
 	authz := mustAuthorizer(t, config.AuthorizationConfig{
-		Workloads: map[string]config.WorkloadDef{
+		IdentityTokens: map[string]config.WorkloadDef{
 			"triage-bot": {
 				Token: "gst_wld_triage-bot-token",
 				Providers: map[string]config.WorkloadProviderDef{
@@ -1751,7 +1751,7 @@ func TestNewServer_WorkloadCallToolDeniedForUnboundSessionOnlyProvider(t *testin
 	providers := testutil.NewProviderRegistry(t, prov)
 	ds := coretesting.NewStubServices(t)
 	authz := mustAuthorizer(t, config.AuthorizationConfig{
-		Workloads: map[string]config.WorkloadDef{
+		IdentityTokens: map[string]config.WorkloadDef{
 			"triage-bot": {
 				Token: "gst_wld_triage-bot-token",
 			},
@@ -1829,19 +1829,19 @@ func TestNewServer_WorkloadCallToolUsesBoundConnectionForSessionOnlyProvider(t *
 	providers := testutil.NewProviderRegistry(t, prov)
 	ds := coretesting.NewStubServices(t)
 	ctx := context.Background()
-	if err := ds.Tokens.StoreToken(ctx, &core.IntegrationToken{
+	if err := ds.Tokens.StoreIdentityToken(ctx, &core.IntegrationToken{
 		ID:          "tok-identity",
-		UserID:      principal.IdentityPrincipal,
+		IdentityID:  "triage-bot",
 		Integration: "clickhouse",
 		Connection:  "workspace",
 		Instance:    "team-a",
 		AccessToken: "identity-token",
 	}); err != nil {
-		t.Fatalf("StoreToken: %v", err)
+		t.Fatalf("StoreIdentityToken: %v", err)
 	}
 
 	authz := mustAuthorizer(t, config.AuthorizationConfig{
-		Workloads: map[string]config.WorkloadDef{
+		IdentityTokens: map[string]config.WorkloadDef{
 			"triage-bot": {
 				Token: "gst_wld_triage-bot-token",
 				Providers: map[string]config.WorkloadProviderDef{
@@ -1934,7 +1934,7 @@ func TestNewServer_WorkloadCallToolRejectsInstanceOverride(t *testing.T) {
 	}
 
 	authz := mustAuthorizer(t, config.AuthorizationConfig{
-		Workloads: map[string]config.WorkloadDef{
+		IdentityTokens: map[string]config.WorkloadDef{
 			"triage-bot": {
 				Token: "gst_wld_triage-bot-token",
 				Providers: map[string]config.WorkloadProviderDef{
@@ -1965,7 +1965,7 @@ func TestNewServer_WorkloadCallToolRejectsInstanceOverride(t *testing.T) {
 		t.Fatalf("expected MCP error result, got %+v", result)
 	}
 	text, ok := result.Content[0].(mcpgo.TextContent)
-	if !ok || text.Text != "workload callers may not override connection or instance bindings" {
+	if !ok || text.Text != "identity-token callers may not override connection or instance bindings" {
 		t.Fatalf("unexpected MCP error content: %+v", result.Content)
 	}
 	if called {

--- a/gestaltd/internal/mcp/handlers.go
+++ b/gestaltd/internal/mcp/handlers.go
@@ -23,8 +23,8 @@ func makeHandler(cfg Config, provName, opName, connection string) mcpserver.Tool
 
 		rawArgs := req.GetArguments()
 		instance := normalizedSessionCatalogInstance(rawArgs["_instance"])
-		if workloadInstanceOverrideRequested(cfg.Authorizer, p, instance) {
-			return mcpgo.NewToolResultError("workload callers may not override connection or instance bindings"), nil
+		if headlessInstanceOverrideRequested(cfg.Authorizer, p, instance) {
+			return mcpgo.NewToolResultError("identity-token callers may not override connection or instance bindings"), nil
 		}
 		args := make(map[string]any, len(rawArgs))
 		for key, value := range rawArgs {

--- a/gestaltd/internal/mcp/session_tools.go
+++ b/gestaltd/internal/mcp/session_tools.go
@@ -144,7 +144,7 @@ func withSessionAccessContext(ctx context.Context, cfg Config, provName string) 
 		return ctx
 	}
 	p := principal.FromContext(ctx)
-	if p == nil || cfg.Authorizer.IsWorkload(p) {
+	if p == nil || !p.HasUserContext() {
 		return ctx
 	}
 	access, allowed := cfg.Authorizer.ResolveAccess(ctx, p, provName)
@@ -389,7 +389,7 @@ func internalSessionToolHandler(context.Context, mcpgo.CallToolRequest) (*mcpgo.
 func sessionTokenSelectors(cfg Config, p *principal.Principal, provName, instanceOverride string) (string, string) {
 	connection := cfg.MCPConnection[provName]
 	instance := normalizedSessionCatalogInstance(instanceOverride)
-	if cfg.Authorizer == nil || !cfg.Authorizer.IsWorkload(p) {
+	if cfg.Authorizer == nil || p == nil || p.HasUserContext() {
 		return connection, instance
 	}
 	if binding, ok := cfg.Authorizer.Binding(p, provName); ok {
@@ -436,6 +436,6 @@ func normalizedSessionCatalogInstance(value any) string {
 	return strings.TrimSpace(instance)
 }
 
-func workloadInstanceOverrideRequested(authz authorization.RuntimeAuthorizer, p *principal.Principal, instance string) bool {
-	return authz != nil && p != nil && authz.IsWorkload(p) && instance != ""
+func headlessInstanceOverrideRequested(authz authorization.RuntimeAuthorizer, p *principal.Principal, instance string) bool {
+	return authz != nil && p != nil && !p.HasUserContext() && instance != ""
 }

--- a/gestaltd/internal/principal/principal.go
+++ b/gestaltd/internal/principal/principal.go
@@ -14,18 +14,18 @@ const (
 	SourceUnknown Source = iota
 	SourceSession
 	SourceAPIToken
-	SourceWorkloadToken
+	SourceIdentityToken
 	SourceEnv
 )
 
 const IdentityPrincipal = "__identity__"
-const managedIdentitySubjectPrefix = "managed_identity:"
+const managedIdentityLegacySubjectPrefix = "managed_identity:"
 
 type Kind string
 
 const (
 	KindUser     Kind = "user"
-	KindWorkload Kind = "workload"
+	KindIdentity Kind = "identity"
 )
 
 type Principal struct {
@@ -47,8 +47,8 @@ func (s Source) String() string {
 		return "session"
 	case SourceAPIToken:
 		return "api_token"
-	case SourceWorkloadToken:
-		return "workload_token"
+	case SourceIdentityToken:
+		return "identity_token"
 	case SourceEnv:
 		return "env"
 	default:
@@ -62,8 +62,8 @@ func ParseSource(value string) Source {
 		return SourceSession
 	case SourceAPIToken.String():
 		return SourceAPIToken
-	case SourceWorkloadToken.String():
-		return SourceWorkloadToken
+	case SourceIdentityToken.String():
+		return SourceIdentityToken
 	case SourceEnv.String():
 		return SourceEnv
 	default:
@@ -81,6 +81,15 @@ func (p *Principal) AuthSource() string {
 	return p.Source.String()
 }
 
+func (p *Principal) HasUserContext() bool {
+	if p == nil {
+		return false
+	}
+	if strings.TrimSpace(p.UserID) != "" {
+		return true
+	}
+	return p.Identity != nil && strings.TrimSpace(p.Identity.Email) != ""
+}
 func UserSubjectID(userID string) string {
 	if userID == "" {
 		return ""
@@ -95,29 +104,26 @@ func UserIDFromSubjectID(subjectID string) string {
 	return strings.TrimPrefix(subjectID, string(KindUser)+":")
 }
 
-func WorkloadSubjectID(workloadID string) string {
-	if workloadID == "" {
-		return ""
-	}
-	return string(KindWorkload) + ":" + workloadID
-}
-
-func IdentitySubjectID() string {
-	return "identity:" + IdentityPrincipal
-}
-
-func ManagedIdentitySubjectID(identityID string) string {
+func IdentitySubjectID(identityID string) string {
 	if identityID == "" {
 		return ""
 	}
-	return managedIdentitySubjectPrefix + identityID
+	return "identity:" + identityID
+}
+
+func ManagedIdentitySubjectID(identityID string) string {
+	return IdentitySubjectID(identityID)
 }
 
 func ManagedIdentityIDFromSubjectID(subjectID string) string {
-	if !strings.HasPrefix(subjectID, managedIdentitySubjectPrefix) {
+	switch {
+	case strings.HasPrefix(subjectID, string(KindIdentity)+":"):
+		return strings.TrimPrefix(subjectID, string(KindIdentity)+":")
+	case strings.HasPrefix(subjectID, managedIdentityLegacySubjectPrefix):
+		return strings.TrimPrefix(subjectID, managedIdentityLegacySubjectPrefix)
+	default:
 		return ""
 	}
-	return strings.TrimPrefix(subjectID, managedIdentitySubjectPrefix)
 }
 
 func CompilePermissions(perms []core.AccessPermission) PermissionSet {

--- a/gestaltd/internal/principal/resolver.go
+++ b/gestaltd/internal/principal/resolver.go
@@ -19,7 +19,7 @@ type TokenType int
 
 const (
 	TokenTypeAPI TokenType = iota
-	TokenTypeWorkload
+	TokenTypeIdentity
 )
 
 const (
@@ -27,13 +27,13 @@ const (
 	prefixWorkload = "gst_wld_"
 )
 
-type ResolvedWorkload struct {
+type ResolvedIdentityToken struct {
 	ID          string
 	DisplayName string
 }
 
-type WorkloadTokenResolver interface {
-	ResolveWorkloadToken(token string) (*ResolvedWorkload, bool)
+type IdentityTokenResolver interface {
+	ResolveIdentityToken(token string) (*ResolvedIdentityToken, bool)
 }
 
 func GenerateToken(typ TokenType) (plaintext, hashed string, err error) {
@@ -47,7 +47,7 @@ func GenerateToken(typ TokenType) (plaintext, hashed string, err error) {
 	switch typ {
 	case TokenTypeAPI:
 		prefix = prefixAPI
-	case TokenTypeWorkload:
+	case TokenTypeIdentity:
 		prefix = prefixWorkload
 	default:
 		return "", "", fmt.Errorf("unknown token type %d", typ)
@@ -63,7 +63,7 @@ func ParseTokenType(token string) (TokenType, bool) {
 	case strings.HasPrefix(token, prefixAPI):
 		return TokenTypeAPI, true
 	case strings.HasPrefix(token, prefixWorkload):
-		return TokenTypeWorkload, true
+		return TokenTypeIdentity, true
 	default:
 		return 0, false
 	}
@@ -75,10 +75,10 @@ type Resolver struct {
 	apiTokens         *coredata.APITokenService
 	managedIdentities *coredata.ManagedIdentityService
 	identityGrants    *coredata.ManagedIdentityGrantService
-	workloads         WorkloadTokenResolver
+	workloads         IdentityTokenResolver
 }
 
-func NewResolver(auth core.AuthProvider, users *coredata.UserService, apiTokens *coredata.APITokenService, managedIdentities *coredata.ManagedIdentityService, identityGrants *coredata.ManagedIdentityGrantService, workloads WorkloadTokenResolver) *Resolver {
+func NewResolver(auth core.AuthProvider, users *coredata.UserService, apiTokens *coredata.APITokenService, managedIdentities *coredata.ManagedIdentityService, identityGrants *coredata.ManagedIdentityGrantService, workloads IdentityTokenResolver) *Resolver {
 	return &Resolver{
 		auth:              auth,
 		users:             users,
@@ -94,8 +94,8 @@ func (r *Resolver) ResolveToken(ctx context.Context, token string) (*Principal, 
 		switch typ {
 		case TokenTypeAPI:
 			return r.resolveAPIToken(ctx, token)
-		case TokenTypeWorkload:
-			return r.resolveWorkloadToken(token)
+		case TokenTypeIdentity:
+			return r.resolveIdentityToken(token)
 		}
 	}
 
@@ -196,28 +196,28 @@ func (r *Resolver) resolveManagedIdentityAPIToken(ctx context.Context, apiToken 
 	}
 
 	return &Principal{
-		SubjectID:        ManagedIdentitySubjectID(identity.ID),
+		SubjectID:        IdentitySubjectID(identity.ID),
 		DisplayName:      identity.DisplayName,
-		Kind:             KindWorkload,
+		Kind:             KindIdentity,
 		Source:           SourceAPIToken,
 		Scopes:           PermissionPlugins(effectivePerms),
 		TokenPermissions: effectivePerms,
 	}, nil
 }
 
-func (r *Resolver) resolveWorkloadToken(token string) (*Principal, error) {
+func (r *Resolver) resolveIdentityToken(token string) (*Principal, error) {
 	if r.workloads == nil {
 		return nil, ErrInvalidToken
 	}
-	workload, ok := r.workloads.ResolveWorkloadToken(token)
-	if !ok || workload == nil || workload.ID == "" {
+	identity, ok := r.workloads.ResolveIdentityToken(token)
+	if !ok || identity == nil || identity.ID == "" {
 		return nil, ErrInvalidToken
 	}
 	return &Principal{
-		Kind:        KindWorkload,
-		SubjectID:   WorkloadSubjectID(workload.ID),
-		DisplayName: workload.DisplayName,
-		Source:      SourceWorkloadToken,
+		Kind:        KindIdentity,
+		SubjectID:   IdentitySubjectID(identity.ID),
+		DisplayName: identity.DisplayName,
+		Source:      SourceIdentityToken,
 	}, nil
 }
 

--- a/gestaltd/internal/providerhost/provider_client.go
+++ b/gestaltd/internal/providerhost/provider_client.go
@@ -342,8 +342,10 @@ func subjectKindForPrincipal(p *principal.Principal) string {
 	switch {
 	case strings.HasPrefix(p.SubjectID, string(principal.KindUser)+":"):
 		return string(principal.KindUser)
-	case strings.HasPrefix(p.SubjectID, string(principal.KindWorkload)+":"):
-		return string(principal.KindWorkload)
+	case strings.HasPrefix(p.SubjectID, "identity:"):
+		return string(principal.KindIdentity)
+	case strings.HasPrefix(p.SubjectID, "managed_identity:"):
+		return string(principal.KindIdentity)
 	}
 	if p.UserID != "" || p.Identity != nil {
 		return string(principal.KindUser)

--- a/gestaltd/internal/providerhost/provider_server.go
+++ b/gestaltd/internal/providerhost/provider_server.go
@@ -112,16 +112,19 @@ func principalFromProto(subject *proto.SubjectContext) *principal.Principal {
 	switch subject.GetKind() {
 	case string(principal.KindUser):
 		p.Kind = principal.KindUser
-	case string(principal.KindWorkload):
-		p.Kind = principal.KindWorkload
+	case string(principal.KindIdentity):
+		p.Kind = principal.KindIdentity
 	}
-	if strings.HasPrefix(subject.GetId(), "user:") {
+	switch {
+	case strings.HasPrefix(subject.GetId(), "user:"):
 		p.UserID = strings.TrimPrefix(subject.GetId(), "user:")
 		if p.Kind == "" {
 			p.Kind = principal.KindUser
 		}
-	} else if strings.HasPrefix(subject.GetId(), "workload:") && p.Kind == "" {
-		p.Kind = principal.KindWorkload
+	case strings.HasPrefix(subject.GetId(), "identity:") && p.Kind == "":
+		p.Kind = principal.KindIdentity
+	case strings.HasPrefix(subject.GetId(), "managed_identity:") && p.Kind == "":
+		p.Kind = principal.KindIdentity
 	}
 	if p.Kind == principal.KindUser && subject.GetDisplayName() != "" {
 		p.Identity = &core.UserIdentity{
@@ -140,8 +143,8 @@ func sourceFromString(raw string) principal.Source {
 		return principal.SourceSession
 	case principal.SourceAPIToken.String():
 		return principal.SourceAPIToken
-	case principal.SourceWorkloadToken.String():
-		return principal.SourceWorkloadToken
+	case principal.SourceIdentityToken.String():
+		return principal.SourceIdentityToken
 	case principal.SourceEnv.String():
 		return principal.SourceEnv
 	default:

--- a/gestaltd/internal/providerhost/provider_test.go
+++ b/gestaltd/internal/providerhost/provider_test.go
@@ -208,15 +208,26 @@ func TestRemoteProviderRoundTrip(t *testing.T) {
 			wantSessionCatalog: "token-123|user:user-123|user|Ada|true|api_token|identity|roadmap|admin",
 		},
 		{
-			name: "workload subject",
+			name: "identity token subject",
 			principal: &principal.Principal{
-				SubjectID:   principal.WorkloadSubjectID("triage-bot"),
+				SubjectID:   principal.IdentitySubjectID("triage-bot"),
 				DisplayName: "Triage Bot",
-				Kind:        principal.KindWorkload,
-				Source:      principal.SourceWorkloadToken,
+				Kind:        principal.KindIdentity,
+				Source:      principal.SourceIdentityToken,
 			},
-			wantExecuteBody:    "echo|secret-token|hi|acme|workload:triage-bot|workload|Triage Bot|false|workload_token|identity|identity:__identity__|roadmap|admin",
-			wantSessionCatalog: "token-123|workload:triage-bot|workload|Triage Bot|false|workload_token|identity|roadmap|admin",
+			wantExecuteBody:    "echo|secret-token|hi|acme|identity:triage-bot|identity|Triage Bot|false|identity_token|identity|identity:__identity__|roadmap|admin",
+			wantSessionCatalog: "token-123|identity:triage-bot|identity|Triage Bot|false|identity_token|identity|roadmap|admin",
+		},
+		{
+			name: "managed identity subject",
+			principal: &principal.Principal{
+				SubjectID:   principal.ManagedIdentitySubjectID("release-bot"),
+				DisplayName: "Release Bot",
+				Kind:        principal.KindIdentity,
+				Source:      principal.SourceAPIToken,
+			},
+			wantExecuteBody:    "echo|secret-token|hi|acme|identity:release-bot|identity|Release Bot|false|api_token|identity|identity:__identity__|roadmap|admin",
+			wantSessionCatalog: "token-123|identity:release-bot|identity|Release Bot|false|api_token|identity|roadmap|admin",
 		},
 	}
 
@@ -289,10 +300,10 @@ func TestRequestContextProto_PreservesWorkloadDisplayName(t *testing.T) {
 	t.Parallel()
 
 	ctx := principal.WithPrincipal(context.Background(), &principal.Principal{
-		SubjectID:   principal.WorkloadSubjectID("triage-bot"),
+		SubjectID:   principal.IdentitySubjectID("triage-bot"),
 		DisplayName: "Triage Bot",
-		Kind:        principal.KindWorkload,
-		Source:      principal.SourceWorkloadToken,
+		Kind:        principal.KindIdentity,
+		Source:      principal.SourceIdentityToken,
 	})
 	ctx = invocation.WithAccessContext(ctx, invocation.AccessContext{
 		Policy: "roadmap",
@@ -345,10 +356,10 @@ func TestPrincipalFromProto_WorkloadDisplayNameDoesNotCreateIdentity(t *testing.
 	t.Parallel()
 
 	p := principalFromProto(&proto.SubjectContext{
-		Id:          principal.WorkloadSubjectID("triage-bot"),
-		Kind:        string(principal.KindWorkload),
+		Id:          principal.IdentitySubjectID("triage-bot"),
+		Kind:        string(principal.KindIdentity),
 		DisplayName: "Triage Bot",
-		AuthSource:  principal.SourceWorkloadToken.String(),
+		AuthSource:  principal.SourceIdentityToken.String(),
 	})
 	if p == nil {
 		t.Fatal("expected principal")
@@ -358,6 +369,29 @@ func TestPrincipalFromProto_WorkloadDisplayNameDoesNotCreateIdentity(t *testing.
 	}
 	if p.Identity != nil {
 		t.Fatalf("expected workload identity to remain nil, got %#v", p.Identity)
+	}
+}
+
+func TestPrincipalFromProto_ManagedIdentityKindRoundTrips(t *testing.T) {
+	t.Parallel()
+
+	p := principalFromProto(&proto.SubjectContext{
+		Id:          principal.ManagedIdentitySubjectID("release-bot"),
+		Kind:        string(principal.KindIdentity),
+		DisplayName: "Release Bot",
+		AuthSource:  principal.SourceAPIToken.String(),
+	})
+	if p == nil {
+		t.Fatal("expected principal")
+	}
+	if p.Kind != principal.KindIdentity {
+		t.Fatalf("kind = %q, want %q", p.Kind, principal.KindIdentity)
+	}
+	if p.DisplayName != "Release Bot" {
+		t.Fatalf("display name = %q, want %q", p.DisplayName, "Release Bot")
+	}
+	if p.Identity != nil {
+		t.Fatalf("expected managed identity principal to remain non-human, got %#v", p.Identity)
 	}
 }
 

--- a/gestaltd/internal/providerhost/request_snapshot.go
+++ b/gestaltd/internal/providerhost/request_snapshot.go
@@ -172,5 +172,5 @@ func restoreRequestSnapshotContext(ctx context.Context, snapshot requestSnapshot
 }
 
 func shouldInheritCredentialSelectors(snapshot requestSnapshot) bool {
-	return snapshot.principal == nil || snapshot.principal.Kind != principal.KindWorkload
+	return snapshot.principal == nil || snapshot.principal.HasUserContext()
 }

--- a/gestaltd/internal/providerhost/workflow_server_test.go
+++ b/gestaltd/internal/providerhost/workflow_server_test.go
@@ -582,10 +582,10 @@ func TestWorkflowServerPrefersWorkflowCreatorForWorkflowMutations(t *testing.T) 
 	provider := &recordingWorkflowProvider{}
 	srv := NewWorkflowServer("roadmap", staticWorkflowResolver(provider, map[string]struct{}{"refresh": {}}, nil, nil, nil))
 	ctx := principal.WithPrincipal(context.Background(), &principal.Principal{
-		SubjectID:   principal.WorkloadSubjectID("planner"),
-		Kind:        principal.KindWorkload,
+		SubjectID:   principal.IdentitySubjectID("planner"),
+		Kind:        principal.KindIdentity,
 		DisplayName: "Planner",
-		Source:      principal.SourceWorkloadToken,
+		Source:      principal.SourceIdentityToken,
 	})
 	ctx = invocation.WithWorkflowContext(ctx, map[string]any{
 		"createdBy": map[string]any{

--- a/gestaltd/internal/server/audit.go
+++ b/gestaltd/internal/server/audit.go
@@ -39,7 +39,7 @@ func (s *Server) resolvePrincipalUserID(ctx context.Context, p *principal.Princi
 	if p == nil {
 		return nil, nil
 	}
-	if p.Kind == principal.KindWorkload {
+	if !p.HasUserContext() {
 		return p, nil
 	}
 	if p.Kind == "" {
@@ -54,6 +54,9 @@ func (s *Server) resolvePrincipalUserID(ctx context.Context, p *principal.Princi
 		return p, nil
 	}
 	if p.Identity == nil || p.Identity.Email == "" {
+		return p, nil
+	}
+	if s.users == nil {
 		return p, nil
 	}
 

--- a/gestaltd/internal/server/audit_metadata_test.go
+++ b/gestaltd/internal/server/audit_metadata_test.go
@@ -310,7 +310,7 @@ func TestAuditMetadata_WorkloadSubjectAndCredentialPath(t *testing.T) {
 	var auditBuf bytes.Buffer
 	auditSink := invocation.NewSlogAuditSink(&auditBuf)
 
-	workloadToken, _, err := principal.GenerateToken(principal.TokenTypeWorkload)
+	workloadToken, _, err := principal.GenerateToken(principal.TokenTypeIdentity)
 	if err != nil {
 		t.Fatalf("GenerateToken: %v", err)
 	}
@@ -331,7 +331,7 @@ func TestAuditMetadata_WorkloadSubjectAndCredentialPath(t *testing.T) {
 
 	providers := testutil.NewProviderRegistry(t, stub)
 	authz, err := authorization.New(config.AuthorizationConfig{
-		Workloads: map[string]config.WorkloadDef{
+		IdentityTokens: map[string]config.WorkloadDef{
 			"triage-bot": {
 				Token: workloadToken,
 				Providers: map[string]config.WorkloadProviderDef{
@@ -349,15 +349,15 @@ func TestAuditMetadata_WorkloadSubjectAndCredentialPath(t *testing.T) {
 	}
 
 	svc := coretesting.NewStubServices(t)
-	if err := svc.Tokens.StoreToken(t.Context(), &core.IntegrationToken{
+	if err := svc.Tokens.StoreIdentityToken(t.Context(), &core.IntegrationToken{
 		ID:          "identity-audit-token",
-		UserID:      principal.IdentityPrincipal,
+		IdentityID:  "triage-bot",
 		Integration: "audit-workload-prov",
 		Connection:  "workspace",
 		Instance:    "team-a",
 		AccessToken: "identity-token",
 	}); err != nil {
-		t.Fatalf("StoreToken: %v", err)
+		t.Fatalf("StoreIdentityToken: %v", err)
 	}
 
 	broker := invocation.NewBroker(providers, svc.Users, svc.Tokens, invocation.WithAuthorizer(authz))
@@ -397,17 +397,17 @@ func TestAuditMetadata_WorkloadSubjectAndCredentialPath(t *testing.T) {
 		t.Fatalf("failed to parse audit JSON: %v\nraw: %s", err, auditBuf.String())
 	}
 
-	if record["subject_id"] != "workload:triage-bot" {
-		t.Fatalf("expected workload subject_id, got %v", record["subject_id"])
+	if record["subject_id"] != "identity:triage-bot" {
+		t.Fatalf("expected identity subject_id, got %v", record["subject_id"])
 	}
-	if record["subject_kind"] != "workload" {
-		t.Fatalf("expected subject_kind=workload, got %v", record["subject_kind"])
+	if record["subject_kind"] != "identity" {
+		t.Fatalf("expected subject_kind=identity, got %v", record["subject_kind"])
 	}
 	if record["credential_mode"] != "identity" {
 		t.Fatalf("expected credential_mode=identity, got %v", record["credential_mode"])
 	}
-	if record["credential_subject_id"] != "identity:__identity__" {
-		t.Fatalf("expected credential_subject_id identity principal, got %v", record["credential_subject_id"])
+	if record["credential_subject_id"] != "identity:triage-bot" {
+		t.Fatalf("expected credential_subject_id triage-bot, got %v", record["credential_subject_id"])
 	}
 	if record["credential_connection"] != "workspace" {
 		t.Fatalf("expected credential_connection=workspace, got %v", record["credential_connection"])

--- a/gestaltd/internal/server/authorization.go
+++ b/gestaltd/internal/server/authorization.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"errors"
 	"net/http"
+	"strings"
 
 	"github.com/valon-technologies/gestalt/server/core"
 	"github.com/valon-technologies/gestalt/server/internal/authorization"
@@ -33,32 +34,32 @@ func (s *Server) providerAccessContextWithContext(ctx context.Context, p *princi
 	return access
 }
 
-func (s *Server) workloadBinding(p *principal.Principal, provider string) (authorization.CredentialBinding, bool) {
+func (s *Server) identityBinding(p *principal.Principal, provider string) (authorization.CredentialBinding, bool) {
 	if s.authorizer == nil {
 		return authorization.CredentialBinding{}, false
 	}
 	return s.authorizer.Binding(p, provider)
 }
 
-func rejectWorkloadSelectors(w http.ResponseWriter, p *principal.Principal, connection, instance string) error {
-	if p == nil || p.Kind != principal.KindWorkload {
+func rejectHeadlessSelectors(w http.ResponseWriter, p *principal.Principal, connection, instance string) error {
+	if p == nil || p.HasUserContext() {
 		return nil
 	}
 	if connection == "" && instance == "" {
 		return nil
 	}
-	writeError(w, http.StatusForbidden, errWorkloadSelector.Error())
-	return errWorkloadSelector
+	writeError(w, http.StatusForbidden, errHeadlessSelector.Error())
+	return errHeadlessSelector
 }
 
-func (s *Server) workloadBindingSelectors(p *principal.Principal, provider, connection, instance string) (string, string) {
+func (s *Server) identityBindingSelectors(p *principal.Principal, provider, connection, instance string) (string, string) {
 	resolveConnection := func(connection string) string {
 		return s.sessionCatalogConnections(provider, nil, connection)[0]
 	}
-	if p == nil || p.Kind != principal.KindWorkload {
+	if p == nil || p.HasUserContext() {
 		return resolveConnection(connection), instance
 	}
-	binding, ok := s.workloadBinding(p, provider)
+	binding, ok := s.identityBinding(p, provider)
 	if !ok {
 		return resolveConnection(connection), instance
 	}
@@ -71,12 +72,15 @@ func (s *Server) workloadBindingSelectors(p *principal.Principal, provider, conn
 	return resolveConnection(connection), instance
 }
 
-func (s *Server) workloadBindingConnected(ctx context.Context, binding authorization.CredentialBinding, provider string) (bool, error) {
+func (s *Server) identityBindingConnected(ctx context.Context, binding authorization.CredentialBinding, provider string) (bool, error) {
 	switch binding.Mode {
 	case core.ConnectionModeNone:
 		return true, nil
 	case core.ConnectionModeIdentity:
-		_, err := s.tokens.Token(ctx, binding.CredentialOwnerID, provider, binding.Connection, binding.Instance)
+		if strings.TrimSpace(binding.CredentialOwnerID) == "" {
+			return false, errors.New("identity binding missing owner identity")
+		}
+		_, err := s.tokens.IdentityToken(ctx, binding.CredentialOwnerID, provider, binding.Connection, binding.Instance)
 		switch {
 		case err == nil:
 			return true, nil

--- a/gestaltd/internal/server/catalog_resolution_test.go
+++ b/gestaltd/internal/server/catalog_resolution_test.go
@@ -523,7 +523,7 @@ func TestFilterCatalogForPrincipal_WorkloadFilteringUsesMergedCatalog(t *testing
 
 	providers := testutil.NewProviderRegistry(t, prov)
 	authz, err := authorization.New(config.AuthorizationConfig{
-		Workloads: map[string]config.WorkloadDef{
+		IdentityTokens: map[string]config.WorkloadDef{
 			"triage-bot": {
 				Token: "gst_wld_triage-bot-token",
 				Providers: map[string]config.WorkloadProviderDef{
@@ -541,8 +541,9 @@ func TestFilterCatalogForPrincipal_WorkloadFilteringUsesMergedCatalog(t *testing
 	}
 
 	p := &principal.Principal{
-		Kind:      principal.KindWorkload,
-		SubjectID: principal.WorkloadSubjectID("triage-bot"),
+		Kind:      principal.KindIdentity,
+		SubjectID: principal.IdentitySubjectID("triage-bot"),
+		Source:    principal.SourceIdentityToken,
 	}
 	cat, err := invocation.ResolveCatalog(context.Background(), prov, "clash-api", &stubTokenResolver{token: "tok_456"}, p, "default", "")
 	if err != nil {
@@ -551,7 +552,7 @@ func TestFilterCatalogForPrincipal_WorkloadFilteringUsesMergedCatalog(t *testing
 
 	filtered := invocation.FilterCatalogForPrincipal(context.Background(), cat, "clash-api", p, authz)
 	if len(filtered.Operations) != 2 {
-		t.Fatalf("expected 2 operations after workload filtering, got %d", len(filtered.Operations))
+		t.Fatalf("expected 2 operations after identity-token filtering, got %d", len(filtered.Operations))
 	}
 	if filtered.Operations[0].ID != "shared_op" {
 		t.Fatalf("expected first filtered op shared_op, got %q", filtered.Operations[0].ID)

--- a/gestaltd/internal/server/handlers.go
+++ b/gestaltd/internal/server/handlers.go
@@ -39,11 +39,11 @@ const sessionCookieName = "session_token"
 const defaultSessionCookieTTL = 24 * time.Hour
 
 var (
-	errNotAuthenticated  = errors.New("not authenticated")
-	errResolveUser       = errors.New("failed to resolve user")
-	errWorkloadForbidden = errors.New("workload callers are not allowed on this route")
-	errOperationAccess   = errors.New("operation access denied")
-	errWorkloadSelector  = errors.New("workload callers may not override connection or instance bindings")
+	errNotAuthenticated = errors.New("not authenticated")
+	errResolveUser      = errors.New("failed to resolve user")
+	errNonUserForbidden = errors.New("non-user callers are not allowed on this route")
+	errOperationAccess  = errors.New("operation access denied")
+	errHeadlessSelector = errors.New("identity-token callers may not override connection or instance bindings")
 )
 
 var (
@@ -91,9 +91,9 @@ type connectionParamInfo struct {
 }
 
 func (s *Server) resolveUserID(w http.ResponseWriter, r *http.Request) (string, error) {
-	if p := PrincipalFromContext(r.Context()); p != nil && p.Kind == principal.KindWorkload {
-		writeError(w, http.StatusForbidden, "workload callers are not allowed on this route")
-		return "", errWorkloadForbidden
+	if p := PrincipalFromContext(r.Context()); p != nil && !p.HasUserContext() {
+		writeError(w, http.StatusForbidden, "non-user callers are not allowed on this route")
+		return "", errNonUserForbidden
 	}
 	user := UserFromContext(r.Context())
 	if user == nil || user.Email == "" {
@@ -128,7 +128,7 @@ func (s *Server) readinessCheck(w http.ResponseWriter, _ *http.Request) {
 func (s *Server) listIntegrations(w http.ResponseWriter, r *http.Request) {
 	p := PrincipalFromContext(r.Context())
 	connected := map[string][]instanceInfo{}
-	if p == nil || p.Kind != principal.KindWorkload {
+	if p == nil || p.HasUserContext() {
 		var err error
 		connected, err = s.userConnectedIntegrations(r)
 		if err != nil {
@@ -165,11 +165,11 @@ func (s *Server) listIntegrations(w http.ResponseWriter, r *http.Request) {
 		if entry, ok := s.pluginDefs[name]; ok && entry != nil {
 			info.MountedPath = strings.TrimSpace(entry.MountPath)
 		}
-		if p != nil && p.Kind == principal.KindWorkload {
-			if binding, ok := s.workloadBinding(p, name); ok {
-				bindingConnected, err := s.workloadBindingConnected(r.Context(), binding, name)
+		if p != nil && !p.HasUserContext() {
+			if binding, ok := s.identityBinding(p, name); ok {
+				bindingConnected, err := s.identityBindingConnected(r.Context(), binding, name)
 				if err != nil {
-					slog.ErrorContext(r.Context(), "checking workload integration status", "provider", name, "error", err)
+					slog.ErrorContext(r.Context(), "checking identity integration status", "provider", name, "error", err)
 					writeError(w, http.StatusInternalServerError, "failed to check integration status")
 					return
 				}
@@ -445,7 +445,7 @@ func (s *Server) listOperations(w http.ResponseWriter, r *http.Request) {
 			return
 		}
 	}
-	if err := rejectWorkloadSelectors(w, p, requestedConnection, requestedInstance); err != nil {
+	if err := rejectHeadlessSelectors(w, p, requestedConnection, requestedInstance); err != nil {
 		s.auditHTTPEvent(r.Context(), p, name, operation, false, err)
 		return
 	}
@@ -540,7 +540,7 @@ func (s *Server) executeOperation(w http.ResponseWriter, r *http.Request) {
 			return
 		}
 	}
-	if err := rejectWorkloadSelectors(w, p, requestedConnection, requestedInstance); err != nil {
+	if err := rejectHeadlessSelectors(w, p, requestedConnection, requestedInstance); err != nil {
 		s.auditHTTPEvent(r.Context(), p, providerName, operationName, false, err)
 		return
 	}
@@ -594,7 +594,7 @@ func (s *Server) executeOperation(w http.ResponseWriter, r *http.Request) {
 		writeError(w, http.StatusBadRequest, fmt.Sprintf("conflicting connection parameter %q in query string and JSON body", httpConnectionParam))
 		return
 	}
-	if err := rejectWorkloadSelectors(w, p, bodyConnection, bodyInstance); err != nil {
+	if err := rejectHeadlessSelectors(w, p, bodyConnection, bodyInstance); err != nil {
 		s.auditHTTPEvent(r.Context(), p, providerName, operationName, false, err)
 		return
 	}
@@ -716,7 +716,7 @@ func (s *Server) sessionCatalogConnections(providerName string, p *principal.Pri
 	if explicit != "" {
 		return []string{config.ResolveConnectionAlias(explicit)}
 	}
-	if s.authorizer != nil && s.authorizer.IsWorkload(p) {
+	if p != nil && !p.HasUserContext() {
 		return []string{""}
 	}
 
@@ -744,7 +744,7 @@ func (s *Server) boundSessionCatalogConnections(providerName string, p *principa
 	boundConnections := make([]string, 0, len(connections))
 	boundInstance := instance
 	for _, connection := range connections {
-		connection, boundInstance = s.workloadBindingSelectors(p, providerName, connection, instance)
+		connection, boundInstance = s.identityBindingSelectors(p, providerName, connection, instance)
 		boundConnections = append(boundConnections, connection)
 	}
 	return boundConnections, boundInstance
@@ -754,7 +754,7 @@ func (s *Server) boundSessionCatalogTargets(providerName string, p *principal.Pr
 	connections := s.sessionCatalogConnections(providerName, p, explicit)
 	targets := make([]invocation.CatalogResolutionTarget, 0, len(connections))
 	for _, connection := range connections {
-		boundConnection, boundInstance := s.workloadBindingSelectors(p, providerName, connection, instance)
+		boundConnection, boundInstance := s.identityBindingSelectors(p, providerName, connection, instance)
 		targets = append(targets, invocation.CatalogResolutionTarget{
 			Connection: boundConnection,
 			Instance:   boundInstance,

--- a/gestaltd/internal/server/handlers_admin_authorization.go
+++ b/gestaltd/internal/server/handlers_admin_authorization.go
@@ -75,8 +75,8 @@ func (s *Server) adminAPIAuthMiddleware(next http.Handler) http.Handler {
 			writeError(w, http.StatusUnauthorized, "missing authorization")
 			return
 		}
-		if p.Kind == principal.KindWorkload {
-			writeError(w, http.StatusForbidden, "workload callers are not allowed on this route")
+		if p != nil && !p.HasUserContext() {
+			writeError(w, http.StatusForbidden, "non-user callers are not allowed on this route")
 			return
 		}
 

--- a/gestaltd/internal/server/handlers_auth.go
+++ b/gestaltd/internal/server/handlers_auth.go
@@ -547,9 +547,9 @@ func (s *Server) logout(w http.ResponseWriter, r *http.Request) {
 	defer func() {
 		s.auditHTTPEvent(r.Context(), auditPrincipal, s.authProviderName(), "auth.logout", auditAllowed, auditErr)
 	}()
-	if auditPrincipal != nil && auditPrincipal.Kind == principal.KindWorkload {
-		auditErr = errWorkloadForbidden
-		writeError(w, http.StatusForbidden, "workload callers are not allowed on this route")
+	if auditPrincipal != nil && !auditPrincipal.HasUserContext() {
+		auditErr = errNonUserForbidden
+		writeError(w, http.StatusForbidden, "non-user callers are not allowed on this route")
 		return
 	}
 

--- a/gestaltd/internal/server/handlers_connect.go
+++ b/gestaltd/internal/server/handlers_connect.go
@@ -14,7 +14,6 @@ import (
 	"github.com/valon-technologies/gestalt/server/internal/config"
 	"github.com/valon-technologies/gestalt/server/internal/discovery"
 	"github.com/valon-technologies/gestalt/server/internal/metricutil"
-	"github.com/valon-technologies/gestalt/server/internal/principal"
 )
 
 type connectManualRequest struct {
@@ -38,9 +37,9 @@ func (s *Server) connectManual(w http.ResponseWriter, r *http.Request) {
 		metricutil.RecordConnectionAuthMetrics(r.Context(), startedAt, metricProviderName, "manual", "complete", connectionMode, auditErr != nil)
 		s.auditHTTPEventWithTarget(r.Context(), PrincipalFromContext(r.Context()), providerName, "connection.manual.connect", auditAllowed, auditErr, auditTarget)
 	}()
-	if p := PrincipalFromContext(r.Context()); p != nil && p.Kind == principal.KindWorkload {
-		auditErr = errWorkloadForbidden
-		writeError(w, http.StatusForbidden, "workload callers are not allowed on this route")
+	if p := PrincipalFromContext(r.Context()); p != nil && !p.HasUserContext() {
+		auditErr = errNonUserForbidden
+		writeError(w, http.StatusForbidden, "non-user callers are not allowed on this route")
 		return
 	}
 

--- a/gestaltd/internal/server/handlers_identities.go
+++ b/gestaltd/internal/server/handlers_identities.go
@@ -1182,10 +1182,10 @@ func (s *Server) managedIdentityGrantCatalogTargets(ctx context.Context, plugin 
 	}
 
 	for _, connection := range s.sessionCatalogConnections(plugin, p, "") {
-		connection, instance := s.workloadBindingSelectors(p, plugin, connection, "")
+		connection, instance := s.identityBindingSelectors(p, plugin, connection, "")
 		addTarget(connection, instance)
 	}
-	if p == nil || p.Kind == principal.KindWorkload || strings.TrimSpace(p.UserID) == "" {
+	if p == nil || !p.HasUserContext() || strings.TrimSpace(p.UserID) == "" {
 		if len(targets) == 0 {
 			addTarget("", "")
 		}

--- a/gestaltd/internal/server/handlers_oauth.go
+++ b/gestaltd/internal/server/handlers_oauth.go
@@ -13,7 +13,6 @@ import (
 	"github.com/valon-technologies/gestalt/server/internal/metricutil"
 	"github.com/valon-technologies/gestalt/server/internal/oauth"
 	"github.com/valon-technologies/gestalt/server/internal/paraminterp"
-	"github.com/valon-technologies/gestalt/server/internal/principal"
 )
 
 type startOAuthRequest struct {
@@ -36,9 +35,9 @@ func (s *Server) startIntegrationOAuth(w http.ResponseWriter, r *http.Request) {
 		metricutil.RecordConnectionAuthMetrics(r.Context(), startedAt, metricProviderName, "oauth", "start", connectionMode, auditErr != nil)
 		s.auditHTTPEventWithTarget(r.Context(), PrincipalFromContext(r.Context()), providerName, "connection.oauth.start", auditAllowed, auditErr, auditTarget)
 	}()
-	if p := PrincipalFromContext(r.Context()); p != nil && p.Kind == principal.KindWorkload {
-		auditErr = errWorkloadForbidden
-		writeError(w, http.StatusForbidden, "workload callers are not allowed on this route")
+	if p := PrincipalFromContext(r.Context()); p != nil && !p.HasUserContext() {
+		auditErr = errNonUserForbidden
+		writeError(w, http.StatusForbidden, "non-user callers are not allowed on this route")
 		return
 	}
 

--- a/gestaltd/internal/server/integration_visibility.go
+++ b/gestaltd/internal/server/integration_visibility.go
@@ -20,7 +20,7 @@ func (s *Server) integrationHasUsableSurfaceContext(ctx context.Context, p *prin
 }
 
 func (s *Server) integrationHasSettingsSurface(p *principal.Principal, info integrationInfo) bool {
-	if p != nil && p.Kind == principal.KindWorkload {
+	if p != nil && !p.HasUserContext() {
 		return false
 	}
 	return info.Connected || len(info.AuthTypes) > 0 || len(info.Connections) > 0
@@ -66,10 +66,13 @@ func (s *Server) mountedWebUIForProvider(provider, mountedPath string) (MountedW
 }
 
 func (s *Server) mountedWebUIRootAccessibleContext(ctx context.Context, p *principal.Principal, mounted MountedWebUI) bool {
+	if p == nil || !p.HasUserContext() {
+		return false
+	}
 	if mounted.AuthorizationPolicy == "" {
 		return true
 	}
-	if s.authorizer == nil || p == nil || p.Kind == principal.KindWorkload {
+	if s.authorizer == nil {
 		return false
 	}
 

--- a/gestaltd/internal/server/metrics_test.go
+++ b/gestaltd/internal/server/metrics_test.go
@@ -594,7 +594,7 @@ func TestHTTPDiscoveryMetrics(t *testing.T) {
 	}
 
 	svc := coretesting.NewStubServices(t)
-	seedIdentityToken(t, svc, providerName, testDefaultConnection, "default", "identity-token")
+	seedSessionIdentityToken(t, svc, "user@example.com", providerName, testDefaultConnection, "default", "identity-token")
 	ts := newTestServer(t, func(cfg *server.Config) {
 		cfg.MeterProvider = metrics.Provider
 		cfg.Auth = &coretesting.StubAuthProvider{
@@ -653,7 +653,7 @@ func TestHTTPDiscoveryMetrics_FailureRecordsErrorCount(t *testing.T) {
 	}
 
 	svc := coretesting.NewStubServices(t)
-	seedIdentityToken(t, svc, providerName, testDefaultConnection, "default", "identity-token")
+	seedSessionIdentityToken(t, svc, "user@example.com", providerName, testDefaultConnection, "default", "identity-token")
 	ts := newTestServer(t, func(cfg *server.Config) {
 		cfg.MeterProvider = metrics.Provider
 		cfg.Auth = &coretesting.StubAuthProvider{

--- a/gestaltd/internal/server/middleware.go
+++ b/gestaltd/internal/server/middleware.go
@@ -114,8 +114,8 @@ func requestedAuthSource(r *http.Request) string {
 			switch typ {
 			case principal.TokenTypeAPI:
 				return principal.SourceAPIToken.String()
-			case principal.TokenTypeWorkload:
-				return principal.SourceWorkloadToken.String()
+			case principal.TokenTypeIdentity:
+				return principal.SourceIdentityToken.String()
 			}
 		}
 		return principal.SourceSession.String()
@@ -132,10 +132,10 @@ func (s *Server) resolveRequestPrincipal(r *http.Request) (*principal.Principal,
 
 	if c, err := r.Cookie(sessionCookieName); err == nil && c.Value != "" {
 		p, err := s.resolver.ResolveToken(r.Context(), c.Value)
-		if p != nil && p.Kind != principal.KindWorkload {
+		if p != nil && p.HasUserContext() {
 			return p, nil
 		}
-		if p != nil && p.Kind == principal.KindWorkload {
+		if p != nil && !p.HasUserContext() {
 			lastErr = principal.ErrInvalidToken
 		} else {
 			lastErr = err

--- a/gestaltd/internal/server/mounted_ui.go
+++ b/gestaltd/internal/server/mounted_ui.go
@@ -283,10 +283,6 @@ func (s *Server) adminMountedWebUI() MountedWebUI {
 }
 
 func (s *Server) protectedUIHandler(mounted MountedWebUI, inner http.Handler, redirectLogin protectedUILoginRedirect) http.Handler {
-	if mounted.AuthorizationPolicy == "" {
-		return inner
-	}
-
 	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		ctx, ok := s.authorizeProtectedUIRequest(w, r, mounted, redirectLogin)
 		if !ok {
@@ -297,6 +293,32 @@ func (s *Server) protectedUIHandler(mounted MountedWebUI, inner http.Handler, re
 }
 
 func (s *Server) authorizeProtectedUIRequest(w http.ResponseWriter, r *http.Request, mounted MountedWebUI, redirectLogin protectedUILoginRedirect) (context.Context, bool) {
+	if mounted.AuthorizationPolicy == "" {
+		if requestedAuthSource(r) == "" {
+			return r.Context(), true
+		}
+		p, authenticated, err := s.resolveMountedWebUIPrincipal(r)
+		if err != nil {
+			writeError(w, http.StatusInternalServerError, "failed to resolve user")
+			return nil, false
+		}
+		if !authenticated {
+			if redirectLogin != nil {
+				if err := redirectLogin(w, r); err != nil {
+					writeError(w, http.StatusInternalServerError, err.Error())
+				}
+			}
+			return nil, false
+		}
+		if p != nil && !p.HasUserContext() {
+			writeError(w, http.StatusForbidden, "non-user callers are not allowed on this route")
+			return nil, false
+		}
+		if p == nil {
+			return r.Context(), true
+		}
+		return principal.WithPrincipal(r.Context(), p), true
+	}
 	if s.authorizer == nil {
 		writeError(w, http.StatusInternalServerError, "app authorization is unavailable")
 		return nil, false
@@ -315,8 +337,8 @@ func (s *Server) authorizeProtectedUIRequest(w http.ResponseWriter, r *http.Requ
 		}
 		return nil, false
 	}
-	if p != nil && p.Kind == principal.KindWorkload {
-		writeError(w, http.StatusForbidden, "workload callers are not allowed on this route")
+	if p != nil && !p.HasUserContext() {
+		writeError(w, http.StatusForbidden, "non-user callers are not allowed on this route")
 		return nil, false
 	}
 

--- a/gestaltd/internal/server/pending_connection.go
+++ b/gestaltd/internal/server/pending_connection.go
@@ -256,8 +256,8 @@ func (s *Server) resolvePendingConnectionUserID(r *http.Request) (string, bool, 
 	if p == nil {
 		return "", false, nil
 	}
-	if p.Kind == principal.KindWorkload {
-		return "", true, errWorkloadForbidden
+	if !p.HasUserContext() {
+		return "", true, errNonUserForbidden
 	}
 	if p.UserID == "" {
 		return "", true, fmt.Errorf("authenticated principal missing user ID")
@@ -289,8 +289,8 @@ func (s *Server) authorizePendingConnectionByCookie(r *http.Request, state *pend
 func (s *Server) authorizePendingConnection(w http.ResponseWriter, r *http.Request, state *pendingConnectionState) bool {
 	userID, authenticated, err := s.resolvePendingConnectionUserID(r)
 	if err != nil {
-		if errors.Is(err, errWorkloadForbidden) {
-			writeError(w, http.StatusForbidden, "workload callers are not allowed on this route")
+		if errors.Is(err, errNonUserForbidden) {
+			writeError(w, http.StatusForbidden, "non-user callers are not allowed on this route")
 			return false
 		}
 		if errors.Is(err, principal.ErrInvalidToken) {

--- a/gestaltd/internal/server/server_test.go
+++ b/gestaltd/internal/server/server_test.go
@@ -873,16 +873,24 @@ func seedLegacyUserRecord(t *testing.T, svc *coredata.Services, id, email string
 	}
 }
 
-func seedIdentityToken(t *testing.T, svc *coredata.Services, integration, connection, instance, accessToken string) {
+func seedIdentityOwnedToken(t *testing.T, svc *coredata.Services, identityID, integration, connection, instance, accessToken string) {
 	t.Helper()
-	seedToken(t, svc, &core.IntegrationToken{
-		ID:          integration + "-" + connection + "-" + instance,
-		UserID:      principal.IdentityPrincipal,
+	if err := svc.Tokens.StoreIdentityToken(t.Context(), &core.IntegrationToken{
+		ID:          integration + "-" + connection + "-" + instance + "-" + identityID,
+		IdentityID:  identityID,
 		Integration: integration,
 		Connection:  connection,
 		Instance:    instance,
 		AccessToken: accessToken,
-	})
+	}); err != nil {
+		t.Fatalf("StoreIdentityToken: %v", err)
+	}
+}
+
+func seedSessionIdentityToken(t *testing.T, svc *coredata.Services, email, integration, connection, instance, accessToken string) {
+	t.Helper()
+	user := seedUser(t, svc, email)
+	seedIdentityOwnedToken(t, svc, user.ID, integration, connection, instance, accessToken)
 }
 
 func mustAuthorizer(t *testing.T, cfg config.AuthorizationConfig, providers *registry.ProviderMap[core.Provider], pluginDefs map[string]*config.ProviderEntry, defaultConnections map[string]string) *authorization.Authorizer {
@@ -4586,10 +4594,10 @@ func TestAuthMiddleware_ValidAPIToken(t *testing.T) {
 	}
 }
 
-func TestAuthMiddleware_ValidWorkloadToken(t *testing.T) {
+func TestAuthMiddleware_ValidIdentityToken(t *testing.T) {
 	t.Parallel()
 
-	plaintext, _, err := principal.GenerateToken(principal.TokenTypeWorkload)
+	plaintext, _, err := principal.GenerateToken(principal.TokenTypeIdentity)
 	if err != nil {
 		t.Fatalf("GenerateToken: %v", err)
 	}
@@ -4600,7 +4608,7 @@ func TestAuthMiddleware_ValidWorkloadToken(t *testing.T) {
 	}
 	providers := testutil.NewProviderRegistry(t, stub)
 	authz := mustAuthorizer(t, config.AuthorizationConfig{
-		Workloads: map[string]config.WorkloadDef{
+		IdentityTokens: map[string]config.WorkloadDef{
 			"weather-bot": {
 				Token: plaintext,
 				Providers: map[string]config.WorkloadProviderDef{
@@ -5076,16 +5084,16 @@ func TestListIntegrations_HumanAuthorizationFiltersByMountedUIAccessAndVisibleOp
 	}
 }
 
-func TestWorkloadAuthorization_ListIntegrationsFiltersAndHidesConnectionAffordances(t *testing.T) {
+func TestIdentityTokenAuthorization_ListIntegrationsFiltersAndHidesConnectionAffordances(t *testing.T) {
 	t.Parallel()
 
-	workloadToken, _, err := principal.GenerateToken(principal.TokenTypeWorkload)
+	workloadToken, _, err := principal.GenerateToken(principal.TokenTypeIdentity)
 	if err != nil {
 		t.Fatalf("GenerateToken: %v", err)
 	}
 
 	svc := coretesting.NewStubServices(t)
-	seedIdentityToken(t, svc, "svc", "workspace", "default", "identity-svc-token")
+	seedIdentityOwnedToken(t, svc, "triage-bot", "svc", "workspace", "default", "identity-svc-token")
 
 	svcProvider := &stubIntegrationWithOps{
 		StubIntegration: coretesting.StubIntegration{N: "svc", DN: "Service", ConnMode: core.ConnectionModeIdentity},
@@ -5109,7 +5117,7 @@ func TestWorkloadAuthorization_ListIntegrationsFiltersAndHidesConnectionAffordan
 	}
 	providers := testutil.NewProviderRegistry(t, svcProvider, weatherProvider, mcpOnlyProvider, secretProvider)
 	authz := mustAuthorizer(t, config.AuthorizationConfig{
-		Workloads: map[string]config.WorkloadDef{
+		IdentityTokens: map[string]config.WorkloadDef{
 			"triage-bot": {
 				Token: workloadToken,
 				Providers: map[string]config.WorkloadProviderDef{
@@ -5216,14 +5224,14 @@ func TestWorkloadAuthorization_ListIntegrationsFiltersAndHidesConnectionAffordan
 
 	if resp.StatusCode != http.StatusInternalServerError {
 		body, _ := io.ReadAll(resp.Body)
-		t.Fatalf("expected 500 when workload binding lookup fails, got %d: %s", resp.StatusCode, body)
+		t.Fatalf("expected 500 when identity binding lookup fails, got %d: %s", resp.StatusCode, body)
 	}
 }
 
-func TestWorkloadAuthorization_ListOperationsFiltersAndRejectsSelectors(t *testing.T) {
+func TestIdentityTokenAuthorization_ListOperationsFiltersAndRejectsSelectors(t *testing.T) {
 	t.Parallel()
 
-	workloadToken, _, err := principal.GenerateToken(principal.TokenTypeWorkload)
+	workloadToken, _, err := principal.GenerateToken(principal.TokenTypeIdentity)
 	if err != nil {
 		t.Fatalf("GenerateToken: %v", err)
 	}
@@ -5237,7 +5245,7 @@ func TestWorkloadAuthorization_ListOperationsFiltersAndRejectsSelectors(t *testi
 	}
 	providers := testutil.NewProviderRegistry(t, provider)
 	authz := mustAuthorizer(t, config.AuthorizationConfig{
-		Workloads: map[string]config.WorkloadDef{
+		IdentityTokens: map[string]config.WorkloadDef{
 			"triage-bot": {
 				Token: workloadToken,
 				Providers: map[string]config.WorkloadProviderDef{
@@ -5313,18 +5321,18 @@ func TestWorkloadAuthorization_ListOperationsFiltersAndRejectsSelectors(t *testi
 	if auditRecord["allowed"] != false {
 		t.Fatalf("expected denied audit record, got %v", auditRecord["allowed"])
 	}
-	if auditRecord["auth_source"] != "workload_token" {
-		t.Fatalf("expected workload auth_source, got %v", auditRecord["auth_source"])
+	if auditRecord["auth_source"] != "identity_token" {
+		t.Fatalf("expected identity auth_source, got %v", auditRecord["auth_source"])
 	}
-	if auditRecord["subject_id"] != "workload:triage-bot" {
-		t.Fatalf("expected workload subject_id, got %v", auditRecord["subject_id"])
+	if auditRecord["subject_id"] != "identity:triage-bot" {
+		t.Fatalf("expected identity subject_id, got %v", auditRecord["subject_id"])
 	}
-	if auditRecord["error"] != "workload callers may not override connection or instance bindings" {
+	if auditRecord["error"] != "identity-token callers may not override connection or instance bindings" {
 		t.Fatalf("unexpected audit error: %v", auditRecord["error"])
 	}
 
 	svc := coretesting.NewStubServices(t)
-	seedIdentityToken(t, svc, "svc-session", "workspace", "team-a", "session-bound-token")
+	seedIdentityOwnedToken(t, svc, "triage-bot", "svc-session", "workspace", "team-a", "session-bound-token")
 
 	var sessionCatalogToken string
 	sessionProvider := &stubIntegrationWithSessionCatalog{
@@ -5343,7 +5351,7 @@ func TestWorkloadAuthorization_ListOperationsFiltersAndRejectsSelectors(t *testi
 	}
 	sessionProviders := testutil.NewProviderRegistry(t, sessionProvider)
 	sessionAuthz := mustAuthorizer(t, config.AuthorizationConfig{
-		Workloads: map[string]config.WorkloadDef{
+		IdentityTokens: map[string]config.WorkloadDef{
 			"triage-bot": {
 				Token: workloadToken,
 				Providers: map[string]config.WorkloadProviderDef{
@@ -8314,16 +8322,16 @@ func TestExecuteOperation_NoStoredToken(t *testing.T) {
 
 }
 
-func TestWorkloadAuthorization_ExecuteOperation_UsesBoundIdentityAndRejectsSelectors(t *testing.T) {
+func TestIdentityTokenAuthorization_ExecuteOperation_UsesBoundIdentityAndRejectsSelectors(t *testing.T) {
 	t.Parallel()
 
-	workloadToken, _, err := principal.GenerateToken(principal.TokenTypeWorkload)
+	workloadToken, _, err := principal.GenerateToken(principal.TokenTypeIdentity)
 	if err != nil {
 		t.Fatalf("GenerateToken: %v", err)
 	}
 
 	svc := coretesting.NewStubServices(t)
-	seedIdentityToken(t, svc, "svc", "workspace", "team-a", "identity-bound-token")
+	seedIdentityOwnedToken(t, svc, "triage-bot", "svc", "workspace", "team-a", "identity-bound-token")
 
 	stub := &stubIntegrationWithOps{
 		StubIntegration: coretesting.StubIntegration{
@@ -8340,7 +8348,7 @@ func TestWorkloadAuthorization_ExecuteOperation_UsesBoundIdentityAndRejectsSelec
 	}
 	providers := testutil.NewProviderRegistry(t, stub)
 	authz := mustAuthorizer(t, config.AuthorizationConfig{
-		Workloads: map[string]config.WorkloadDef{
+		IdentityTokens: map[string]config.WorkloadDef{
 			"triage-bot": {
 				Token: workloadToken,
 				Providers: map[string]config.WorkloadProviderDef{
@@ -8445,13 +8453,13 @@ func TestWorkloadAuthorization_ExecuteOperation_UsesBoundIdentityAndRejectsSelec
 	if selectorAudit["allowed"] != false {
 		t.Fatalf("expected selector audit allowed=false, got %v", selectorAudit["allowed"])
 	}
-	if selectorAudit["auth_source"] != "workload_token" {
-		t.Fatalf("expected selector audit auth_source workload_token, got %v", selectorAudit["auth_source"])
+	if selectorAudit["auth_source"] != "identity_token" {
+		t.Fatalf("expected selector audit auth_source identity_token, got %v", selectorAudit["auth_source"])
 	}
-	if selectorAudit["subject_id"] != "workload:triage-bot" {
-		t.Fatalf("expected selector audit subject_id workload:triage-bot, got %v", selectorAudit["subject_id"])
+	if selectorAudit["subject_id"] != "identity:triage-bot" {
+		t.Fatalf("expected selector audit subject_id identity:triage-bot, got %v", selectorAudit["subject_id"])
 	}
-	if selectorAudit["error"] != "workload callers may not override connection or instance bindings" {
+	if selectorAudit["error"] != "identity-token callers may not override connection or instance bindings" {
 		t.Fatalf("unexpected selector audit error: %v", selectorAudit["error"])
 	}
 }
@@ -8860,10 +8868,10 @@ func TestHumanAuthorization_ExecuteOperation_UsesResolvedRoleAndRejectsDisallowe
 	}
 }
 
-func TestWorkloadAuthorization_ExecuteOperation_MissingBoundIdentityTokenReturns412(t *testing.T) {
+func TestIdentityTokenAuthorization_ExecuteOperation_MissingBoundIdentityTokenReturns412(t *testing.T) {
 	t.Parallel()
 
-	workloadToken, _, err := principal.GenerateToken(principal.TokenTypeWorkload)
+	workloadToken, _, err := principal.GenerateToken(principal.TokenTypeIdentity)
 	if err != nil {
 		t.Fatalf("GenerateToken: %v", err)
 	}
@@ -8880,7 +8888,7 @@ func TestWorkloadAuthorization_ExecuteOperation_MissingBoundIdentityTokenReturns
 	}
 	providers := testutil.NewProviderRegistry(t, stub)
 	authz := mustAuthorizer(t, config.AuthorizationConfig{
-		Workloads: map[string]config.WorkloadDef{
+		IdentityTokens: map[string]config.WorkloadDef{
 			"triage-bot": {
 				Token: workloadToken,
 				Providers: map[string]config.WorkloadProviderDef{
@@ -8924,11 +8932,11 @@ func TestWorkloadAuthorization_ExecuteOperation_MissingBoundIdentityTokenReturns
 	if err := json.Unmarshal(auditBuf.Bytes(), &record); err != nil {
 		t.Fatalf("failed to parse audit JSON: %v\nraw: %s", err, auditBuf.String())
 	}
-	if record["subject_id"] != "workload:triage-bot" {
-		t.Fatalf("expected workload subject_id, got %v", record["subject_id"])
+	if record["subject_id"] != "identity:triage-bot" {
+		t.Fatalf("expected identity subject_id, got %v", record["subject_id"])
 	}
-	if record["credential_subject_id"] != "identity:__identity__" {
-		t.Fatalf("expected credential_subject_id identity principal, got %v", record["credential_subject_id"])
+	if record["credential_subject_id"] != "identity:triage-bot" {
+		t.Fatalf("expected credential_subject_id triage-bot, got %v", record["credential_subject_id"])
 	}
 	if record["credential_connection"] != "workspace" {
 		t.Fatalf("expected credential_connection=workspace, got %v", record["credential_connection"])
@@ -8938,10 +8946,10 @@ func TestWorkloadAuthorization_ExecuteOperation_MissingBoundIdentityTokenReturns
 	}
 }
 
-func TestWorkloadAuthorization_HumanRoutesReturn403(t *testing.T) {
+func TestIdentityTokenAuthorization_HumanRoutesReturn403(t *testing.T) {
 	t.Parallel()
 
-	workloadToken, _, err := principal.GenerateToken(principal.TokenTypeWorkload)
+	workloadToken, _, err := principal.GenerateToken(principal.TokenTypeIdentity)
 	if err != nil {
 		t.Fatalf("GenerateToken: %v", err)
 	}
@@ -8952,7 +8960,7 @@ func TestWorkloadAuthorization_HumanRoutesReturn403(t *testing.T) {
 	}
 	providers := testutil.NewProviderRegistry(t, stub)
 	authz := mustAuthorizer(t, config.AuthorizationConfig{
-		Workloads: map[string]config.WorkloadDef{
+		IdentityTokens: map[string]config.WorkloadDef{
 			"triage-bot": {
 				Token: workloadToken,
 				Providers: map[string]config.WorkloadProviderDef{
@@ -13639,11 +13647,11 @@ func TestMCPEndpoint_WorkloadAuthorizationAndAudit(t *testing.T) {
 	}
 
 	svc := coretesting.NewStubServices(t)
-	seedIdentityToken(t, svc, "clickhouse", "default", "default", "identity-token")
+	seedIdentityOwnedToken(t, svc, "triage-bot", "clickhouse", "default", "default", "identity-token")
 
 	providers := testutil.NewProviderRegistry(t, prov)
 	authz := mustAuthorizer(t, config.AuthorizationConfig{
-		Workloads: map[string]config.WorkloadDef{
+		IdentityTokens: map[string]config.WorkloadDef{
 			"triage-bot": {
 				Token: "gst_wld_triage-bot-token",
 				Providers: map[string]config.WorkloadProviderDef{
@@ -13760,20 +13768,20 @@ func TestMCPEndpoint_WorkloadAuthorizationAndAudit(t *testing.T) {
 	if auditRecord["allowed"] != false {
 		t.Fatalf("expected audit allowed=false, got %v", auditRecord["allowed"])
 	}
-	if auditRecord["auth_source"] != "workload_token" {
-		t.Fatalf("expected audit auth_source workload_token, got %v", auditRecord["auth_source"])
+	if auditRecord["auth_source"] != "identity_token" {
+		t.Fatalf("expected audit auth_source identity_token, got %v", auditRecord["auth_source"])
 	}
-	if auditRecord["subject_id"] != "workload:triage-bot" {
-		t.Fatalf("expected subject_id workload:triage-bot, got %v", auditRecord["subject_id"])
+	if auditRecord["subject_id"] != "identity:triage-bot" {
+		t.Fatalf("expected subject_id identity:triage-bot, got %v", auditRecord["subject_id"])
 	}
-	if auditRecord["subject_kind"] != "workload" {
-		t.Fatalf("expected subject_kind workload, got %v", auditRecord["subject_kind"])
+	if auditRecord["subject_kind"] != "identity" {
+		t.Fatalf("expected subject_kind identity, got %v", auditRecord["subject_kind"])
 	}
 	if auditRecord["credential_mode"] != "identity" {
 		t.Fatalf("expected credential_mode identity, got %v", auditRecord["credential_mode"])
 	}
-	if auditRecord["credential_subject_id"] != "identity:__identity__" {
-		t.Fatalf("expected credential_subject_id identity:__identity__, got %v", auditRecord["credential_subject_id"])
+	if auditRecord["credential_subject_id"] != "identity:triage-bot" {
+		t.Fatalf("expected credential_subject_id identity:triage-bot, got %v", auditRecord["credential_subject_id"])
 	}
 	if auditRecord["credential_connection"] != "default" {
 		t.Fatalf("expected credential_connection default, got %v", auditRecord["credential_connection"])
@@ -14209,6 +14217,11 @@ func (s *stubHostIssuedSessionAuth) SessionTokenTTL() time.Duration {
 func TestCookieAuth(t *testing.T) {
 	t.Parallel()
 
+	workloadToken, _, err := principal.GenerateToken(principal.TokenTypeIdentity)
+	if err != nil {
+		t.Fatalf("GenerateToken: %v", err)
+	}
+
 	stub := &coretesting.StubAuthProvider{
 		N: "test",
 		ValidateTokenFn: func(_ context.Context, token string) (*core.UserIdentity, error) {
@@ -14225,6 +14238,12 @@ func TestCookieAuth(t *testing.T) {
 
 	ts := newTestServer(t, func(cfg *server.Config) {
 		cfg.Auth = stub
+		cfg.Services = coretesting.NewStubServices(t)
+		cfg.Authorizer = mustAuthorizer(t, config.AuthorizationConfig{
+			IdentityTokens: map[string]config.WorkloadDef{
+				"triage-bot": {Token: workloadToken},
+			},
+		}, nil, nil, nil)
 	})
 	testutil.CloseOnCleanup(t, ts)
 
@@ -14264,6 +14283,20 @@ func TestCookieAuth(t *testing.T) {
 
 	if fallbackResp.StatusCode == http.StatusUnauthorized {
 		t.Fatal("valid Authorization header should have passed middleware after invalid cookie")
+	}
+
+	// A non-human token in the cookie slot should be ignored the same way as an invalid cookie.
+	reqWithWorkloadCookie, _ := http.NewRequest(http.MethodGet, ts.URL+"/api/v1/integrations", nil)
+	reqWithWorkloadCookie.AddCookie(&http.Cookie{Name: "session_token", Value: workloadToken})
+	reqWithWorkloadCookie.Header.Set("Authorization", "Bearer valid-header-token")
+	workloadFallbackResp, err := http.DefaultClient.Do(reqWithWorkloadCookie)
+	if err != nil {
+		t.Fatalf("request with workload cookie fallback: %v", err)
+	}
+	defer func() { _ = workloadFallbackResp.Body.Close() }()
+
+	if workloadFallbackResp.StatusCode == http.StatusUnauthorized {
+		t.Fatal("valid Authorization header should have passed middleware after workload cookie")
 	}
 }
 
@@ -14588,10 +14621,7 @@ func TestExecuteOperation_ConnectionModeIdentity(t *testing.T) {
 	t.Parallel()
 
 	svc := coretesting.NewStubServices(t)
-	seedToken(t, svc, &core.IntegrationToken{
-		ID: "tok1", UserID: principal.IdentityPrincipal, Integration: "svc",
-		Connection: "", Instance: "default", AccessToken: "identity-tok",
-	})
+	seedSessionIdentityToken(t, svc, "user@example.com", "svc", config.PluginConnectionName, "default", "identity-tok")
 
 	stub := &stubIntegrationWithOps{
 		StubIntegration: coretesting.StubIntegration{
@@ -14605,12 +14635,23 @@ func TestExecuteOperation_ConnectionModeIdentity(t *testing.T) {
 	}
 
 	ts := newTestServer(t, func(cfg *server.Config) {
+		cfg.Auth = &coretesting.StubAuthProvider{
+			N: "stub",
+			ValidateTokenFn: func(_ context.Context, token string) (*core.UserIdentity, error) {
+				if token != "session-token" {
+					return nil, core.ErrNotFound
+				}
+				return &core.UserIdentity{Email: "user@example.com"}, nil
+			},
+		}
 		cfg.Providers = testutil.NewProviderRegistry(t, stub)
+		cfg.DefaultConnection = map[string]string{"svc": config.PluginConnectionName}
 		cfg.Services = svc
 	})
 	testutil.CloseOnCleanup(t, ts)
 
 	req, _ := http.NewRequest(http.MethodGet, ts.URL+"/api/v1/svc/do", nil)
+	req.AddCookie(&http.Cookie{Name: "session_token", Value: "session-token"})
 	resp, err := http.DefaultClient.Do(req)
 	if err != nil {
 		t.Fatalf("request: %v", err)
@@ -14640,10 +14681,16 @@ func TestExecuteOperation_ConnectionModeUserDoesNotFallbackToIdentity(t *testing
 		t.Fatalf("GenerateToken: %v", err)
 	}
 	seedAPIToken(t, svc, apiToken, hashed, "api-user")
-	seedToken(t, svc, &core.IntegrationToken{
-		ID: "tok-identity", UserID: principal.IdentityPrincipal, Integration: "svc",
-		Connection: "", Instance: "default", AccessToken: "identity-tok",
-	})
+	if err := svc.Tokens.StoreIdentityToken(t.Context(), &core.IntegrationToken{
+		ID:          "tok-identity",
+		IdentityID:  principal.IdentityPrincipal,
+		Integration: "svc",
+		Connection:  config.PluginConnectionName,
+		Instance:    "default",
+		AccessToken: "identity-tok",
+	}); err != nil {
+		t.Fatalf("StoreIdentityToken: %v", err)
+	}
 
 	stub := &stubIntegrationWithOps{
 		StubIntegration: coretesting.StubIntegration{
@@ -14659,6 +14706,7 @@ func TestExecuteOperation_ConnectionModeUserDoesNotFallbackToIdentity(t *testing
 	ts := newTestServer(t, func(cfg *server.Config) {
 		cfg.Auth = &coretesting.StubAuthProvider{N: "test"}
 		cfg.Providers = testutil.NewProviderRegistry(t, stub)
+		cfg.DefaultConnection = map[string]string{"svc": config.PluginConnectionName}
 		cfg.Services = svc
 	})
 	testutil.CloseOnCleanup(t, ts)
@@ -16591,6 +16639,7 @@ func TestManagedIdentityTokens_RoleMatrix(t *testing.T) {
 	if err != nil {
 		t.Fatalf("authorization.New: %v", err)
 	}
+	var auditBuf bytes.Buffer
 
 	ts := newTestServer(t, func(cfg *server.Config) {
 		cfg.Auth = &coretesting.StubAuthProvider{
@@ -16611,6 +16660,7 @@ func TestManagedIdentityTokens_RoleMatrix(t *testing.T) {
 		cfg.Providers = providers
 		cfg.Services = svc
 		cfg.Authorizer = authz
+		cfg.AuditSink = invocation.NewSlogAuditSink(&auditBuf)
 	})
 	testutil.CloseOnCleanup(t, ts)
 
@@ -16940,6 +16990,24 @@ func TestManagedIdentityAPITokenInvocation_ModeNoneOnly(t *testing.T) {
 		},
 		ops: []core.Operation{{Name: "query", Method: http.MethodGet}},
 	}
+	deltaStub := &stubManualProviderWithCapabilities{
+		stubManualProvider: stubManualProvider{
+			StubIntegration: coretesting.StubIntegration{
+				N:        "delta",
+				ConnMode: core.ConnectionModeNone,
+				CatalogVal: serverTestCatalog("delta", []catalog.CatalogOperation{
+					{ID: "inspect", Method: http.MethodGet, Path: "/inspect", Transport: catalog.TransportREST},
+				}),
+				ExecuteFn: func(_ context.Context, _ string, _ map[string]any, _ string) (*core.OperationResult, error) {
+					return &core.OperationResult{Status: http.StatusOK, Body: `{"ok":true}`}, nil
+				},
+			},
+		},
+		credentialFields: []core.CredentialFieldDef{{Name: "api_token", Label: "API Token"}},
+		connectionParams: map[string]core.ConnectionParamDef{
+			"region": {Description: "Optional region"},
+		},
+	}
 	gammaStub := &stubIntegrationWithOps{
 		StubIntegration: coretesting.StubIntegration{
 			N:        "gamma",
@@ -16950,11 +17018,12 @@ func TestManagedIdentityAPITokenInvocation_ModeNoneOnly(t *testing.T) {
 		},
 		ops: []core.Operation{{Name: "query", Method: http.MethodGet}},
 	}
-	providers := testutil.NewProviderRegistry(t, alphaStub, betaStub, gammaStub)
+	providers := testutil.NewProviderRegistry(t, alphaStub, betaStub, deltaStub, gammaStub)
 	authz, err := authorization.New(config.AuthorizationConfig{}, nil, providers, nil)
 	if err != nil {
 		t.Fatalf("authorization.New: %v", err)
 	}
+	var auditBuf bytes.Buffer
 
 	ts := newTestServer(t, func(cfg *server.Config) {
 		cfg.Auth = &coretesting.StubAuthProvider{
@@ -16969,6 +17038,7 @@ func TestManagedIdentityAPITokenInvocation_ModeNoneOnly(t *testing.T) {
 		cfg.Providers = providers
 		cfg.Services = svc
 		cfg.Authorizer = authz
+		cfg.AuditSink = invocation.NewSlogAuditSink(&auditBuf)
 	})
 	testutil.CloseOnCleanup(t, ts)
 
@@ -16978,6 +17048,7 @@ func TestManagedIdentityAPITokenInvocation_ModeNoneOnly(t *testing.T) {
 	doJSONRequestAndDecode(t, http.MethodPost, ts.URL+"/api/v1/identities", "admin-session", `{"displayName":"Invoke Bot"}`, http.StatusCreated, &createResp)
 	doJSONRequestAndDecode(t, http.MethodPut, ts.URL+"/api/v1/identities/"+createResp.ID+"/grants/alpha", "admin-session", `{"operations":["read"]}`, http.StatusOK, nil)
 	doJSONRequestAndDecode(t, http.MethodPut, ts.URL+"/api/v1/identities/"+createResp.ID+"/grants/beta", "admin-session", `{"operations":["query"]}`, http.StatusOK, nil)
+	doJSONRequestAndDecode(t, http.MethodPut, ts.URL+"/api/v1/identities/"+createResp.ID+"/grants/delta", "admin-session", `{"operations":["inspect"]}`, http.StatusOK, nil)
 
 	req, _ := http.NewRequest(http.MethodPut, ts.URL+"/api/v1/identities/"+createResp.ID+"/grants/gamma", bytes.NewBufferString(`{"operations":["query"]}`))
 	req.Header.Set("Content-Type", "application/json")
@@ -17019,7 +17090,7 @@ func TestManagedIdentityAPITokenInvocation_ModeNoneOnly(t *testing.T) {
 		http.MethodPost,
 		ts.URL+"/api/v1/identities/"+createResp.ID+"/tokens",
 		"admin-session",
-		`{"name":"invoke-token","permissions":[{"plugin":"alpha","operations":["read"]},{"plugin":"beta","operations":["query"]}]}`,
+		`{"name":"invoke-token","permissions":[{"plugin":"alpha","operations":["read"]},{"plugin":"beta","operations":["query"]},{"plugin":"delta","operations":["inspect"]}]}`,
 		http.StatusCreated,
 		&createTokenResp,
 	)
@@ -17047,8 +17118,77 @@ func TestManagedIdentityAPITokenInvocation_ModeNoneOnly(t *testing.T) {
 	if status := call("/api/v1/beta/query"); status != http.StatusOK {
 		t.Fatalf("beta/query status = %d, want 200", status)
 	}
+	if status := call("/api/v1/delta/inspect"); status != http.StatusOK {
+		t.Fatalf("delta/inspect status = %d, want 200", status)
+	}
 	if status := call("/api/v1/gamma/query"); status != http.StatusForbidden {
 		t.Fatalf("gamma/query status = %d, want 403", status)
+	}
+
+	lines := bytes.Split(bytes.TrimSpace(auditBuf.Bytes()), []byte("\n"))
+	if len(lines) == 0 {
+		t.Fatal("expected managed identity audit record")
+	}
+	var auditRecord map[string]any
+	if err := json.Unmarshal(lines[len(lines)-1], &auditRecord); err != nil {
+		t.Fatalf("parsing managed identity audit record: %v\nraw: %s", err, auditBuf.String())
+	}
+	if auditRecord["subject_id"] != "identity:"+createResp.ID {
+		t.Fatalf("expected managed identity subject_id, got %v", auditRecord["subject_id"])
+	}
+	if auditRecord["subject_kind"] != "identity" {
+		t.Fatalf("expected managed identity subject_kind identity, got %v", auditRecord["subject_kind"])
+	}
+
+	req, _ = http.NewRequest(http.MethodGet, ts.URL+"/api/v1/integrations", nil)
+	req.Header.Set("Authorization", "Bearer "+createTokenResp.Token)
+	resp, err = http.DefaultClient.Do(req)
+	if err != nil {
+		t.Fatalf("list integrations with managed identity token: %v", err)
+	}
+	type listedIntegration struct {
+		Name             string `json:"name"`
+		AuthTypes        []string
+		Connections      []struct{}          `json:"connections"`
+		CredentialFields []struct{}          `json:"credentialFields"`
+		ConnectionParams map[string]struct{} `json:"connectionParams"`
+	}
+	var integrations []listedIntegration
+	if err := json.NewDecoder(resp.Body).Decode(&integrations); err != nil {
+		_ = resp.Body.Close()
+		t.Fatalf("decode integrations: %v", err)
+	}
+	_ = resp.Body.Close()
+	if resp.StatusCode != http.StatusOK {
+		t.Fatalf("list integrations status = %d, want 200", resp.StatusCode)
+	}
+	var deltaInfo *listedIntegration
+	for i := range integrations {
+		if integrations[i].Name == "delta" {
+			deltaInfo = &integrations[i]
+			break
+		}
+	}
+	if deltaInfo == nil {
+		t.Fatalf("expected delta integration in %+v", integrations)
+	}
+	if len(deltaInfo.AuthTypes) != 0 || len(deltaInfo.Connections) != 0 || len(deltaInfo.CredentialFields) != 0 || len(deltaInfo.ConnectionParams) != 0 {
+		t.Fatalf("managed identity integration info should hide connection affordances: %+v", *deltaInfo)
+	}
+
+	req, _ = http.NewRequest(http.MethodPost, ts.URL+"/api/v1/auth/logout", nil)
+	req.Header.Set("Authorization", "Bearer "+createTokenResp.Token)
+	resp, err = http.DefaultClient.Do(req)
+	if err != nil {
+		t.Fatalf("logout with managed identity token: %v", err)
+	}
+	body, _ = io.ReadAll(resp.Body)
+	_ = resp.Body.Close()
+	if resp.StatusCode != http.StatusForbidden {
+		t.Fatalf("logout status = %d, want 403: %s", resp.StatusCode, body)
+	}
+	if !strings.Contains(string(body), "non-user callers are not allowed on this route") {
+		t.Fatalf("logout body = %q, want non-user route rejection", string(body))
 	}
 
 	doJSONRequestAndDecode(t, http.MethodDelete, ts.URL+"/api/v1/identities/"+createResp.ID, "admin-session", "", http.StatusOK, nil)


### PR DESCRIPTION
## Summary

This supersedes the closed `#1164` stack with a fresh rebuild on current `main`.

It removes the runtime concept of a workload principal and routes `gst_wld_*` tokens through ordinary identity-token handling with explicit `identity_id` ownership.

## Old interfaces

### Old YAML

```yaml
authorization:
  workloads:
    triage-bot:
      token: gst_wld_triage-bot-token
      providers:
        clickhouse:
          connection: workspace
          instance: team-a
          allow:
            - run_query
```

### Old Go

```go
resolved := &principal.Principal{
    Kind:      principal.KindIdentity,
    SubjectID: principal.WorkloadSubjectID("triage-bot"),
    Source:    principal.SourceIdentityToken,
}

ctx, token, err := broker.ResolveToken(ctx, resolved, "clickhouse", "workspace", "team-a")
// identity-mode credentials ultimately fell back through the shared __identity__ owner
```

## New interfaces

### New YAML

```yaml
authorization:
  identityTokens:
    triage-bot:
      identityID: triage-bot
      token: gst_wld_triage-bot-token
      providers:
        clickhouse:
          connection: workspace
          instance: team-a
          allow:
            - run_query
```

Compatibility note:

```yaml
authorization:
  workloads:
    triage-bot:
      token: gst_wld_triage-bot-token
      providers:
        clickhouse:
          connection: workspace
          instance: team-a
          allow:
            - run_query
```

still normalizes into the same `identityTokens["triage-bot"]` entry, but the canonical surface is now `identityTokens`.

### New Go

```go
resolved := &principal.Principal{
    Kind:      principal.KindIdentity,
    SubjectID: principal.IdentitySubjectID("triage-bot"),
    Source:    principal.SourceIdentityToken,
}

ctx, token, err := broker.ResolveToken(ctx, resolved, "clickhouse", "workspace", "team-a")
// identity-mode credentials resolve through the explicit identity_id bound to the token
```

For session-backed `ConnectionModeIdentity` providers, the broker now resolves the authenticated user's canonical `identity_id` and reads credentials from canonical identity storage instead of falling back to shared `__identity__` ownership.

## What changed

- removed workload-specific principal subject handling from runtime/tests and switched callers to `principal.IdentitySubjectID(...)`
- added `authorization.identityTokens` as the canonical config surface, with `authorization.workloads` normalized as compatibility input
- required explicit identity ownership for identity-mode identity-token bindings
- added canonical identity-token storage/read/refresh paths in `coredata.TokenService`
- updated broker/session/MCP/providerhost/server/workflow paths to use explicit identity-owned credential resolution
- updated docs and functional tests around identity-token auth, session catalogs, MCP, workflow startup, and audit metadata

## Validation

```bash
go test ./internal/invocation ./internal/mcp ./internal/providerhost ./internal/server ./internal/bootstrap -count=1
go test ./... -run '^$'
golangci-lint run
```
