### PR TITLE
authz: remove static email member support

### DIFF
--- a/docs/content/reference/config-file.mdx
+++ b/docs/content/reference/config-file.mdx
@@ -117,7 +117,7 @@ authorization:
     support_staff:
       default: deny
       members:
-        - email: viewer@example.test
+        - subjectID: user:viewer-user
           role: viewer
         - subjectID: user:admin-user
           role: admin
@@ -154,7 +154,7 @@ authorization:
 
 `admin.authorizationPolicy` binds the built-in `/admin` route to one shared human access policy from `authorization.policies`. `admin.allowedRoles` controls which roles may load the built-in admin UI, defaulting to `[admin]`.
 
-`authorization.policies` configures shared human access policies. Each policy resolves a caller to exactly one role by matching either `subjectID` or `email`, then applies a `default` fallback (`allow` or `deny`) when no member matches. Plugins opt into a policy explicitly through `authorizationPolicy`.
+`authorization.policies` configures shared human access policies. Each policy resolves a caller to exactly one role by matching canonical `subjectID` values, then applies a `default` fallback (`allow` or `deny`) when no member matches. Plugins opt into a policy explicitly through `authorizationPolicy`.
 
 Dynamic human grants are plugin-scoped, not policy-scoped. When a plugin sets `authorizationPolicy`, operators can manage additional dynamic members for that plugin from the built-in admin UI at `/admin/?tab=members` or through `/admin/api/v1/authorization/...`. Static policy members always win over dynamic grants, and Gestalt rejects dynamic writes for users who already have static authorization on that plugin.
 
@@ -174,7 +174,7 @@ Dynamic human grants are plugin-scoped, not policy-scoped. When a plugin sets `a
 | `providers.auth` / `providers.secrets` / `providers.telemetry` / `providers.audit` / `providers.indexeddb` / `providers.authorization` | | Optional selectors for the named host-provider entries under `providers.*`. Required for IndexedDB whenever more than one entry exists and recommended for other host-provider maps when more than one entry exists. |
 | `admin.authorizationPolicy` | | Shared human access policy applied to the built-in `/admin` route. |
 | `admin.allowedRoles` | `[admin]` | Roles allowed to load the built-in `/admin` route when `admin.authorizationPolicy` is set. |
-| `authorization.policies` | | Shared human access policies resolved by `subjectID` or `email`. |
+| `authorization.policies` | | Shared human access policies resolved by canonical `subjectID`. |
 | `authorization.workloads` | | Workload bearer tokens, per-provider allowlists, and identity credential bindings. |
 
 When `server.management` is configured, Gestalt serves `/`, `/api/v1/*`, auth routes, and `/mcp` on the public listener, while `/admin`, `/admin/api/v1/*`, `/metrics`, `/health`, and `/ready` move to the management listener. The management listener is intended to be protected by deployment infrastructure such as private networking, VPN, or an internal-only reverse proxy. Gestalt does not apply its own session or API-token auth to `/metrics` on the management listener. When `server.admin.authorizationPolicy` is set, Gestalt does apply browser session auth plus role-based policy checks to `/admin` and `/admin/api/v1/*`.
@@ -1102,7 +1102,7 @@ Mounted UI bundles are served on the public listener only. The built-in admin UI
 
 `server.egress.defaultAction` must be `allow` or `deny`.
 
-`authorization.policies.<name>.default` must be `allow` or `deny` when set. Each policy member must set exactly one of `subjectID` or `email`, and every member must set a non-empty `role`.
+`authorization.policies.<name>.default` must be `allow` or `deny` when set. Each policy member must set a non-empty `subjectID` and a non-empty `role`.
 
 Server listener ports must be greater than zero. When `server.management` is configured, it must differ from `server.public`.
 

--- a/gestaltd/internal/authorization/authorizer.go
+++ b/gestaltd/internal/authorization/authorizer.go
@@ -9,7 +9,6 @@ import (
 	"github.com/valon-technologies/gestalt/server/core"
 	"github.com/valon-technologies/gestalt/server/core/catalog"
 	"github.com/valon-technologies/gestalt/server/internal/config"
-	"github.com/valon-technologies/gestalt/server/internal/emailutil"
 	"github.com/valon-technologies/gestalt/server/internal/principal"
 	"github.com/valon-technologies/gestalt/server/internal/registry"
 )
@@ -52,12 +51,10 @@ type HumanPolicy struct {
 	ID               string
 	DefaultAllow     bool
 	RolesBySubjectID map[string]string
-	RolesByEmail     map[string]string
 }
 
 type StaticHumanMember struct {
 	SubjectID string
-	Email     string
 	Role      string
 }
 
@@ -83,16 +80,11 @@ func New(cfg config.AuthorizationConfig, pluginDefs map[string]*config.ProviderE
 			ID:               policyID,
 			DefaultAllow:     strings.EqualFold(strings.TrimSpace(def.Default), "allow"),
 			RolesBySubjectID: make(map[string]string, len(def.Members)),
-			RolesByEmail:     make(map[string]string, len(def.Members)),
 		}
 		for _, member := range def.Members {
 			role := strings.TrimSpace(member.Role)
 			if subjectID := strings.TrimSpace(member.SubjectID); subjectID != "" {
 				policy.RolesBySubjectID[subjectID] = role
-				continue
-			}
-			if email := normalizeEmail(member.Email); email != "" {
-				policy.RolesByEmail[email] = role
 			}
 		}
 		a.policies[policyID] = policy
@@ -287,7 +279,7 @@ func (a *Authorizer) PolicyNameForProvider(provider string) string {
 	return strings.TrimSpace(a.providerPolicies[provider])
 }
 
-func (a *Authorizer) StaticRoleForPolicyIdentity(policyName, subjectID, userID, email string) (AccessContext, bool) {
+func (a *Authorizer) StaticRoleForPolicyIdentity(policyName, subjectID, userID string) (AccessContext, bool) {
 	if a == nil {
 		return AccessContext{}, false
 	}
@@ -300,19 +292,19 @@ func (a *Authorizer) StaticRoleForPolicyIdentity(policyName, subjectID, userID, 
 		return AccessContext{}, false
 	}
 	access := AccessContext{Policy: policyName}
-	if role, ok := policy.staticRoleForIdentity(subjectID, userID, email); ok {
+	if role, ok := policy.staticRoleForIdentity(subjectID, userID); ok {
 		access.Role = role
 		return access, true
 	}
 	return access, false
 }
 
-func (a *Authorizer) StaticRoleForProviderIdentity(provider, subjectID, userID, email string) (AccessContext, bool) {
+func (a *Authorizer) StaticRoleForProviderIdentity(provider, subjectID, userID string) (AccessContext, bool) {
 	if a == nil {
 		return AccessContext{}, false
 	}
 	policyName := a.PolicyNameForProvider(provider)
-	return a.StaticRoleForPolicyIdentity(policyName, subjectID, userID, email)
+	return a.StaticRoleForPolicyIdentity(policyName, subjectID, userID)
 }
 
 func (a *Authorizer) StaticMembersForPolicy(policyName string) ([]StaticHumanMember, bool) {
@@ -327,17 +319,11 @@ func (a *Authorizer) StaticMembersForPolicy(policyName string) ([]StaticHumanMem
 	if policy == nil {
 		return nil, false
 	}
-	members := make([]StaticHumanMember, 0, len(policy.RolesBySubjectID)+len(policy.RolesByEmail))
+	members := make([]StaticHumanMember, 0, len(policy.RolesBySubjectID))
 	for subjectID, role := range policy.RolesBySubjectID {
 		members = append(members, StaticHumanMember{
 			SubjectID: subjectID,
 			Role:      role,
-		})
-	}
-	for email, role := range policy.RolesByEmail {
-		members = append(members, StaticHumanMember{
-			Email: email,
-			Role:  role,
 		})
 	}
 	return members, true
@@ -456,14 +442,10 @@ func (p *HumanPolicy) roleForPrincipal(pr *principal.Principal) (string, bool) {
 	if p == nil || pr == nil {
 		return "", false
 	}
-	email := ""
-	if pr.Identity != nil {
-		email = pr.Identity.Email
-	}
-	return p.staticRoleForIdentity(pr.SubjectID, pr.UserID, email)
+	return p.staticRoleForIdentity(pr.SubjectID, pr.UserID)
 }
 
-func (p *HumanPolicy) staticRoleForIdentity(subjectID, userID, email string) (string, bool) {
+func (p *HumanPolicy) staticRoleForIdentity(subjectID, userID string) (string, bool) {
 	if p == nil {
 		return "", false
 	}
@@ -474,11 +456,6 @@ func (p *HumanPolicy) staticRoleForIdentity(subjectID, userID, email string) (st
 	}
 	if userID = strings.TrimSpace(userID); userID != "" {
 		if role, ok := p.RolesBySubjectID[principal.UserSubjectID(userID)]; ok {
-			return role, true
-		}
-	}
-	if email = normalizeEmail(email); email != "" {
-		if role, ok := p.RolesByEmail[email]; ok {
 			return role, true
 		}
 	}
@@ -543,10 +520,6 @@ func normalizeAllowedOperations(ops []string) map[string]struct{} {
 		allowed[name] = struct{}{}
 	}
 	return allowed
-}
-
-func normalizeEmail(email string) string {
-	return emailutil.Normalize(email)
 }
 
 func (a *Authorizer) isManagedIdentityPrincipal(p *principal.Principal) bool {

--- a/gestaltd/internal/authorization/provider_backed.go
+++ b/gestaltd/internal/authorization/provider_backed.go
@@ -12,7 +12,6 @@ import (
 
 	"github.com/valon-technologies/gestalt/server/core"
 	"github.com/valon-technologies/gestalt/server/core/catalog"
-	"github.com/valon-technologies/gestalt/server/internal/emailutil"
 	"github.com/valon-technologies/gestalt/server/internal/principal"
 )
 
@@ -399,18 +398,18 @@ func (a *ProviderBackedAuthorizer) PolicyNameForProvider(provider string) string
 	return a.base.PolicyNameForProvider(provider)
 }
 
-func (a *ProviderBackedAuthorizer) StaticRoleForPolicyIdentity(policyName, subjectID, userID, email string) (AccessContext, bool) {
+func (a *ProviderBackedAuthorizer) StaticRoleForPolicyIdentity(policyName, subjectID, userID string) (AccessContext, bool) {
 	if a == nil {
 		return AccessContext{}, false
 	}
-	return a.base.StaticRoleForPolicyIdentity(policyName, subjectID, userID, email)
+	return a.base.StaticRoleForPolicyIdentity(policyName, subjectID, userID)
 }
 
-func (a *ProviderBackedAuthorizer) StaticRoleForProviderIdentity(provider, subjectID, userID, email string) (AccessContext, bool) {
+func (a *ProviderBackedAuthorizer) StaticRoleForProviderIdentity(provider, subjectID, userID string) (AccessContext, bool) {
 	if a == nil {
 		return AccessContext{}, false
 	}
-	return a.base.StaticRoleForProviderIdentity(provider, subjectID, userID, email)
+	return a.base.StaticRoleForProviderIdentity(provider, subjectID, userID)
 }
 
 func (a *ProviderBackedAuthorizer) StaticMembersForPolicy(policyName string) ([]StaticHumanMember, bool) {
@@ -637,32 +636,6 @@ func (a *ProviderBackedAuthorizer) buildDesiredRelationships(existing map[string
 				})
 			}
 		}
-		for email, role := range policy.RolesByEmail {
-			role = strings.TrimSpace(role)
-			email = normalizeProviderEmail(email)
-			if email == "" || role == "" {
-				continue
-			}
-			policyRoleSet[role] = struct{}{}
-			addDesiredRelationship(desired, &core.Relationship{
-				Subject:  &core.SubjectRef{Type: subjectTypeEmail, Id: email},
-				Relation: role,
-				Resource: &core.ResourceRef{Type: resourceTypePolicyStatic, Id: policyName},
-			})
-			addDesiredRelationship(desired, &core.Relationship{
-				Subject:  &core.SubjectRef{Type: subjectTypeEmail, Id: email},
-				Relation: role,
-				Resource: &core.ResourceRef{Type: resourceTypeAdminPolicyStatic, Id: policyName},
-			})
-			for _, providerName := range providersByPolicy[policyName] {
-				ensureRoleSet(pluginStaticRoles, providerName)[role] = struct{}{}
-				addDesiredRelationship(desired, &core.Relationship{
-					Subject:  &core.SubjectRef{Type: subjectTypeEmail, Id: email},
-					Relation: role,
-					Resource: &core.ResourceRef{Type: resourceTypePluginStatic, Id: providerName},
-				})
-			}
-		}
 	}
 
 	for name, roles := range policyStaticRoles {
@@ -767,7 +740,6 @@ func staticSubjectRefs(p *principal.Principal) []*core.SubjectRef {
 	}
 	appendSubject(subjectTypeSubject, p.SubjectID)
 	appendSubject(subjectTypeSubject, principal.UserSubjectID(p.UserID))
-	appendSubject(subjectTypeEmail, normalizeProviderEmail(identityEmail(p)))
 	return out
 }
 
@@ -780,17 +752,6 @@ func dynamicSubjectRefs(p *principal.Principal) []*core.SubjectRef {
 		out = append(out, &core.SubjectRef{Type: subjectTypeUser, Id: userID})
 	}
 	return out
-}
-
-func identityEmail(p *principal.Principal) string {
-	if p == nil || p.Identity == nil {
-		return ""
-	}
-	return p.Identity.Email
-}
-
-func normalizeProviderEmail(email string) string {
-	return emailutil.Normalize(email)
 }
 
 func relationshipMapKey(rel *core.Relationship) string {

--- a/gestaltd/internal/authorization/provider_schema.go
+++ b/gestaltd/internal/authorization/provider_schema.go
@@ -17,7 +17,6 @@ const (
 
 	ProviderSubjectTypeSubject = "subject"
 	ProviderSubjectTypeUser    = "user"
-	ProviderSubjectTypeEmail   = "email"
 )
 
 const (
@@ -30,7 +29,6 @@ const (
 
 	subjectTypeSubject = ProviderSubjectTypeSubject
 	subjectTypeUser    = ProviderSubjectTypeUser
-	subjectTypeEmail   = ProviderSubjectTypeEmail
 )
 
 func IsManagedProviderRelationship(rel *core.Relationship) bool {
@@ -55,7 +53,7 @@ func buildProviderAuthorizationModel(state providerBackedRoleState) *core.Author
 	policyRoles := unionRoleLists(state.policyStaticRoles)
 	policyRelations := map[string][]string{}
 	for _, role := range policyRoles {
-		policyRelations[role] = []string{subjectTypeSubject, subjectTypeEmail}
+		policyRelations[role] = []string{subjectTypeSubject}
 	}
 	model.ResourceTypes = appendIfModelResourceType(model.ResourceTypes,
 		buildProviderAuthorizationResourceType(resourceTypePolicyStatic, policyRelations, policyRoles),
@@ -64,7 +62,7 @@ func buildProviderAuthorizationModel(state providerBackedRoleState) *core.Author
 	model.ResourceTypes = appendIfModelResourceType(model.ResourceTypes,
 		buildProviderAuthorizationResourceType(
 			resourceTypePluginStatic,
-			resourceTypesForRoles(unionRoleLists(state.pluginStaticRoles), subjectTypeSubject, subjectTypeEmail),
+			resourceTypesForRoles(unionRoleLists(state.pluginStaticRoles), subjectTypeSubject),
 			unionRoleLists(state.pluginStaticRoles),
 		),
 	)
@@ -78,7 +76,7 @@ func buildProviderAuthorizationModel(state providerBackedRoleState) *core.Author
 	model.ResourceTypes = appendIfModelResourceType(model.ResourceTypes,
 		buildProviderAuthorizationResourceType(
 			resourceTypeAdminPolicyStatic,
-			resourceTypesForRoles(policyRoles, subjectTypeSubject, subjectTypeEmail),
+			resourceTypesForRoles(policyRoles, subjectTypeSubject),
 			policyRoles,
 		),
 	)

--- a/gestaltd/internal/authorization/runtime.go
+++ b/gestaltd/internal/authorization/runtime.go
@@ -29,8 +29,8 @@ type RuntimeAuthorizer interface {
 	AllowCatalogOperation(ctx context.Context, p *principal.Principal, provider string, op catalog.CatalogOperation) bool
 
 	PolicyNameForProvider(provider string) string
-	StaticRoleForPolicyIdentity(policyName, subjectID, userID, email string) (AccessContext, bool)
-	StaticRoleForProviderIdentity(provider, subjectID, userID, email string) (AccessContext, bool)
+	StaticRoleForPolicyIdentity(policyName, subjectID, userID string) (AccessContext, bool)
+	StaticRoleForProviderIdentity(provider, subjectID, userID string) (AccessContext, bool)
 	StaticMembersForPolicy(policyName string) ([]StaticHumanMember, bool)
 	StaticMembersForProvider(provider string) (string, []StaticHumanMember, bool)
 }

--- a/gestaltd/internal/bootstrap/bootstrap_test.go
+++ b/gestaltd/internal/bootstrap/bootstrap_test.go
@@ -273,13 +273,13 @@ func bootstrapManagedAuthorizationModel(policyRoles, pluginStaticRoles, pluginDy
 		authorization.ProviderResourceTypePolicyStatic,
 		nil,
 		policyRoles,
-		[]string{authorization.ProviderSubjectTypeSubject, authorization.ProviderSubjectTypeEmail},
+		[]string{authorization.ProviderSubjectTypeSubject},
 	))
 	model.ResourceTypes = appendIfAuthorizationResourceType(model.ResourceTypes, bootstrapAuthorizationResourceType(
 		authorization.ProviderResourceTypePluginStatic,
 		nil,
 		pluginStaticRoles,
-		[]string{authorization.ProviderSubjectTypeSubject, authorization.ProviderSubjectTypeEmail},
+		[]string{authorization.ProviderSubjectTypeSubject},
 	))
 	model.ResourceTypes = appendIfAuthorizationResourceType(model.ResourceTypes, bootstrapAuthorizationResourceType(
 		authorization.ProviderResourceTypePluginDynamic,
@@ -291,7 +291,7 @@ func bootstrapManagedAuthorizationModel(policyRoles, pluginStaticRoles, pluginDy
 		authorization.ProviderResourceTypeAdminPolicyStatic,
 		nil,
 		policyRoles,
-		[]string{authorization.ProviderSubjectTypeSubject, authorization.ProviderSubjectTypeEmail},
+		[]string{authorization.ProviderSubjectTypeSubject},
 	))
 	model.ResourceTypes = appendIfAuthorizationResourceType(model.ResourceTypes, bootstrapAuthorizationResourceType(
 		authorization.ProviderResourceTypeAdminDynamic,
@@ -3654,13 +3654,13 @@ func TestBootstrapSecretResolution(t *testing.T) {
 				"calendar-policy": {
 					Default: "deny",
 					Members: []config.HumanPolicyMemberDef{
-						{Email: "static@example.test", Role: "viewer"},
+						{SubjectID: "user:static-viewer", Role: "viewer"},
 					},
 				},
 				"admin-policy": {
 					Default: "deny",
 					Members: []config.HumanPolicyMemberDef{
-						{Email: "seed-admin@example.test", Role: "admin"},
+						{SubjectID: "user:seed-admin", Role: "admin"},
 					},
 				},
 			},
@@ -3749,8 +3749,10 @@ func TestBootstrapSecretResolution(t *testing.T) {
 		}
 
 		staticPrincipal := &principal.Principal{
-			Identity: &core.UserIdentity{Email: "static@example.test"},
-			Kind:     principal.KindUser,
+			SubjectID: "user:static-viewer",
+			UserID:    "static-viewer",
+			Identity:  &core.UserIdentity{Email: "static@example.test"},
+			Kind:      principal.KindUser,
 		}
 		access, allowed := result.Authorizer.ResolveAccess(ctx, staticPrincipal, "calendar")
 		if !allowed {
@@ -4063,7 +4065,7 @@ func TestBootstrapSecretResolution(t *testing.T) {
 				"calendar-policy": {
 					Default: "deny",
 					Members: []config.HumanPolicyMemberDef{
-						{Email: "static@example.test", Role: "viewer"},
+						{SubjectID: "user:static-viewer", Role: "viewer"},
 					},
 				},
 			},
@@ -4131,7 +4133,7 @@ func TestBootstrapSecretResolution(t *testing.T) {
 				"calendar-policy": {
 					Default: "deny",
 					Members: []config.HumanPolicyMemberDef{
-						{Email: "static@example.test", Role: "viewer"},
+						{SubjectID: "user:static-viewer", Role: "viewer"},
 					},
 				},
 			},
@@ -4171,8 +4173,10 @@ func TestBootstrapSecretResolution(t *testing.T) {
 		provider.mu.Unlock()
 
 		staticPrincipal := &principal.Principal{
-			Identity: &core.UserIdentity{Email: "static@example.test"},
-			Kind:     principal.KindUser,
+			SubjectID: "user:static-viewer",
+			UserID:    "static-viewer",
+			Identity:  &core.UserIdentity{Email: "static@example.test"},
+			Kind:      principal.KindUser,
 		}
 		access, allowed := result.Authorizer.ResolveAccess(ctx, staticPrincipal, "calendar")
 		if allowed {

--- a/gestaltd/internal/bootstrap/workflow_runtime_test.go
+++ b/gestaltd/internal/bootstrap/workflow_runtime_test.go
@@ -471,7 +471,7 @@ func TestWorkflowRuntimeInvokeExecutionRefRechecksAuthorizationThroughBroker(t *
 			"roadmap-policy": {
 				Default: "deny",
 				Members: []config.HumanPolicyMemberDef{
-					{Email: "other@example.test", Role: "viewer"},
+					{SubjectID: "user:other-user", Role: "viewer"},
 				},
 			},
 		},

--- a/gestaltd/internal/config/config.go
+++ b/gestaltd/internal/config/config.go
@@ -524,7 +524,6 @@ type HumanPolicyDef struct {
 
 type HumanPolicyMemberDef struct {
 	SubjectID string `yaml:"subjectID,omitempty"`
-	Email     string `yaml:"email,omitempty"`
 	Role      string `yaml:"role"`
 }
 

--- a/gestaltd/internal/config/config_test.go
+++ b/gestaltd/internal/config/config_test.go
@@ -531,12 +531,11 @@ func TestValidateStructureRejectsDuplicateAuthorizationPolicyMembers(t *testing.
 			want: "subjectID duplicates",
 		},
 		{
-			name: "duplicate email after normalization",
+			name: "missing subject id",
 			members: []HumanPolicyMemberDef{
-				{Email: "Viewer@Test.local", Role: "viewer"},
-				{Email: " viewer@test.local ", Role: "admin"},
+				{Role: "viewer"},
 			},
-			want: "email duplicates",
+			want: "subjectID is required",
 		},
 	}
 
@@ -1477,7 +1476,7 @@ authorization:
     roadmap_policy:
       default: deny
       members:
-        - email: viewer@example.test
+        - subjectID: user:viewer-user
           role: viewer
 server:
   providers:

--- a/gestaltd/internal/config/config_validate.go
+++ b/gestaltd/internal/config/config_validate.go
@@ -14,7 +14,6 @@ import (
 	"time"
 
 	cronv3 "github.com/robfig/cron/v3"
-	"github.com/valon-technologies/gestalt/server/internal/emailutil"
 	"github.com/valon-technologies/gestalt/server/internal/providerenv"
 	"github.com/valon-technologies/gestalt/server/internal/providerpkg"
 	providermanifestv1 "github.com/valon-technologies/gestalt/server/sdk/providermanifest/v1"
@@ -632,31 +631,19 @@ func validateAuthorizationPolicies(cfg *Config) error {
 			return fmt.Errorf("config validation: authorization.policies.%s.default must be %q or %q", name, "allow", "deny")
 		}
 		seenSubjectIDs := make(map[string]int, len(policy.Members))
-		seenEmails := make(map[string]int, len(policy.Members))
 		for i, member := range policy.Members {
 			subjectID := strings.TrimSpace(member.SubjectID)
-			email := emailutil.Normalize(member.Email)
 			role := strings.TrimSpace(member.Role)
 			switch {
 			case role == "":
 				return fmt.Errorf("config validation: authorization.policies.%s.members[%d].role is required", name, i)
-			case subjectID == "" && email == "":
-				return fmt.Errorf("config validation: authorization.policies.%s.members[%d] must set subjectID or email", name, i)
-			case subjectID != "" && email != "":
-				return fmt.Errorf("config validation: authorization.policies.%s.members[%d] may not set both subjectID and email", name, i)
+			case subjectID == "":
+				return fmt.Errorf("config validation: authorization.policies.%s.members[%d].subjectID is required", name, i)
 			}
-			if subjectID != "" {
-				if prev, exists := seenSubjectIDs[subjectID]; exists {
-					return fmt.Errorf("config validation: authorization.policies.%s.members[%d].subjectID duplicates members[%d]", name, i, prev)
-				}
-				seenSubjectIDs[subjectID] = i
+			if prev, exists := seenSubjectIDs[subjectID]; exists {
+				return fmt.Errorf("config validation: authorization.policies.%s.members[%d].subjectID duplicates members[%d]", name, i, prev)
 			}
-			if email != "" {
-				if prev, exists := seenEmails[email]; exists {
-					return fmt.Errorf("config validation: authorization.policies.%s.members[%d].email duplicates members[%d]", name, i, prev)
-				}
-				seenEmails[email] = i
-			}
+			seenSubjectIDs[subjectID] = i
 		}
 	}
 	return nil

--- a/gestaltd/internal/operator/lifecycle_test.go
+++ b/gestaltd/internal/operator/lifecycle_test.go
@@ -1205,7 +1205,7 @@ plugins:
     roadmap_policy:
       default: deny
       members:
-        - email: viewer@example.test
+        - subjectID: user:viewer-user
           role: viewer
 `,
 			uiKey:      "roadmap",
@@ -1263,7 +1263,7 @@ plugins:
     roadmap_policy:
       default: deny
       members:
-        - email: viewer@example.test
+        - subjectID: user:viewer-user
           role: viewer
 `,
 			uiKey:       "roadmap",
@@ -1285,7 +1285,7 @@ plugins:
     roadmap_policy:
       default: deny
       members:
-        - email: viewer@example.test
+        - subjectID: user:viewer-user
           role: viewer
 `,
 			uiKey:       "roadmap",
@@ -1312,7 +1312,7 @@ plugins:
     roadmap_policy:
       default: deny
       members:
-        - email: viewer@example.test
+        - subjectID: user:viewer-user
           role: viewer
 `,
 			uiKey:       "roadmap",
@@ -2436,7 +2436,7 @@ authorization:
     sample_policy:
       default: deny
       members:
-        - email: viewer@example.test
+        - subjectID: user:viewer-user
           role: viewer
 ` + `server:
 ` + requiredServerDatastoreYAML() + `  encryptionKey: aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa

--- a/gestaltd/internal/server/handlers_admin_authorization.go
+++ b/gestaltd/internal/server/handlers_admin_authorization.go
@@ -171,7 +171,7 @@ func (s *Server) putAdminAuthorizationPluginMember(w http.ResponseWriter, r *htt
 		writeError(w, http.StatusInternalServerError, "failed to resolve user")
 		return
 	}
-	if access, ok := s.authorizer.StaticRoleForProviderIdentity(plugin, principal.UserSubjectID(user.ID), user.ID, user.Email); ok && access.Role != "" {
+	if access, ok := s.authorizer.StaticRoleForProviderIdentity(plugin, principal.UserSubjectID(user.ID), user.ID); ok && access.Role != "" {
 		writeError(w, http.StatusConflict, "user already has static authorization for this plugin")
 		return
 	}
@@ -295,7 +295,7 @@ func (s *Server) putAdminAuthorizationAdminMember(w http.ResponseWriter, r *http
 		writeError(w, http.StatusInternalServerError, "failed to resolve user")
 		return
 	}
-	if access, ok := s.authorizer.StaticRoleForPolicyIdentity(s.adminRoute.AuthorizationPolicy, principal.UserSubjectID(user.ID), user.ID, user.Email); ok && access.Role != "" {
+	if access, ok := s.authorizer.StaticRoleForPolicyIdentity(s.adminRoute.AuthorizationPolicy, principal.UserSubjectID(user.ID), user.ID); ok && access.Role != "" {
 		writeError(w, http.StatusConflict, "user already has static admin authorization")
 		return
 	}
@@ -401,10 +401,7 @@ func (s *Server) adminAuthorizationMemberRows(ctx context.Context, plugin string
 	if s.authorizer == nil || s.authorizationProvider == nil {
 		return nil, errAdminAuthorizationUnavailable
 	}
-	staticRows, err := s.adminAuthorizationStaticRows(ctx, plugin)
-	if err != nil {
-		return nil, err
-	}
+	staticRows := s.adminAuthorizationStaticRows(plugin)
 	dynamicRows, err := s.providerPluginAuthorizationRows(ctx, plugin)
 	if err != nil {
 		return nil, err
@@ -449,10 +446,7 @@ func (s *Server) adminAuthorizationAdminRows(ctx context.Context) ([]adminAuthor
 	if s.authorizer == nil || s.authorizationProvider == nil {
 		return nil, errAdminAuthorizationUnavailable
 	}
-	staticRows, err := s.adminAuthorizationStaticAdminRows(ctx)
-	if err != nil {
-		return nil, err
-	}
+	staticRows := s.adminAuthorizationStaticAdminRows()
 	dynamicRows, err := s.providerAdminAuthorizationRows(ctx)
 	if err != nil {
 		return nil, err
@@ -493,55 +487,36 @@ func (s *Server) adminAuthorizationAdminRows(ctx context.Context) ([]adminAuthor
 	return rows, nil
 }
 
-func (s *Server) adminAuthorizationStaticRows(ctx context.Context, plugin string) ([]adminAuthorizationMemberRow, error) {
+func (s *Server) adminAuthorizationStaticRows(plugin string) []adminAuthorizationMemberRow {
 	_, members, ok := s.authorizer.StaticMembersForProvider(plugin)
 	if !ok {
-		return nil, nil
+		return nil
 	}
-	return s.adminAuthorizationRowsFromStaticMembers(ctx, plugin, members)
+	return s.adminAuthorizationRowsFromStaticMembers(plugin, members)
 }
 
-func (s *Server) adminAuthorizationStaticAdminRows(ctx context.Context) ([]adminAuthorizationMemberRow, error) {
+func (s *Server) adminAuthorizationStaticAdminRows() []adminAuthorizationMemberRow {
 	members, ok := s.authorizer.StaticMembersForPolicy(s.adminRoute.AuthorizationPolicy)
 	if !ok {
-		return nil, nil
+		return nil
 	}
-	return s.adminAuthorizationRowsFromStaticMembers(ctx, "", members)
+	return s.adminAuthorizationRowsFromStaticMembers("", members)
 }
 
-func (s *Server) adminAuthorizationRowsFromStaticMembers(ctx context.Context, plugin string, members []authorization.StaticHumanMember) ([]adminAuthorizationMemberRow, error) {
+func (s *Server) adminAuthorizationRowsFromStaticMembers(plugin string, members []authorization.StaticHumanMember) []adminAuthorizationMemberRow {
 	rows := make([]adminAuthorizationMemberRow, 0, len(members))
 	for _, member := range members {
-		row := adminAuthorizationMemberRow{
-			Plugin:    plugin,
-			Role:      member.Role,
-			Source:    "static",
-			Effective: true,
-			Mutable:   false,
-		}
-		switch {
-		case member.Email != "":
-			user, err := s.users.FindUserByEmail(ctx, member.Email)
-			switch {
-			case err == nil:
-				row.SelectorKind = "subject_id"
-				row.SelectorValue = adminAuthorizationUserSubjectID(user.ID)
-			case errors.Is(err, core.ErrNotFound):
-				row.SelectorKind = "email"
-				row.SelectorValue = member.Email
-			case err != nil:
-				return nil, err
-			}
-		case strings.HasPrefix(member.SubjectID, string(principal.KindUser)+":"):
-			row.SelectorKind = "subject_id"
-			row.SelectorValue = member.SubjectID
-		default:
-			row.SelectorKind = "subject_id"
-			row.SelectorValue = member.SubjectID
-		}
-		rows = append(rows, row)
+		rows = append(rows, adminAuthorizationMemberRow{
+			Plugin:        plugin,
+			Role:          member.Role,
+			Source:        "static",
+			Effective:     true,
+			Mutable:       false,
+			SelectorKind:  "subject_id",
+			SelectorValue: member.SubjectID,
+		})
 	}
-	return rows, nil
+	return rows
 }
 
 func (s *Server) reloadAuthorizationState(ctx context.Context) error {

--- a/gestaltd/internal/server/server_test.go
+++ b/gestaltd/internal/server/server_test.go
@@ -850,6 +850,14 @@ func seedUser(t *testing.T, svc *coredata.Services, email string) *core.User {
 	return u
 }
 
+func staticPolicyUserMember(t *testing.T, svc *coredata.Services, email, role string) config.HumanPolicyMemberDef {
+	t.Helper()
+	return config.HumanPolicyMemberDef{
+		SubjectID: principal.UserSubjectID(seedUser(t, svc, email).ID),
+		Role:      role,
+	}
+}
+
 func seedLegacyUserRecord(t *testing.T, svc *coredata.Services, id, email string, createdAt time.Time) *core.User {
 	t.Helper()
 	ctx := context.Background()
@@ -1388,12 +1396,13 @@ func TestMountedWebUIRoutes_HumanAuthorization_DefaultAllowTreatsAuthenticatedUs
 		t.Fatalf("webui handler: %v", err)
 	}
 
+	svc := coretesting.NewStubServices(t)
 	legacy := mustAuthorizer(t, config.AuthorizationConfig{
 		Policies: map[string]config.HumanPolicyDef{
 			"sample_policy": {
 				Default: "allow",
 				Members: []config.HumanPolicyMemberDef{
-					{Email: "admin@example.test", Role: "admin"},
+					staticPolicyUserMember(t, svc, "admin@example.test", "admin"),
 				},
 			},
 		},
@@ -1415,6 +1424,7 @@ func TestMountedWebUIRoutes_HumanAuthorization_DefaultAllowTreatsAuthenticatedUs
 				}
 			},
 		}
+		cfg.Services = svc
 		cfg.Authorizer = legacy
 		cfg.MountedWebUIs = []server.MountedWebUI{{
 			Name:                "sample_portal",
@@ -1601,12 +1611,13 @@ func TestMountedWebUIRoutes_HumanAuthorization_DefaultAllowTreatsAuthenticatedUs
 		t.Fatalf("webui handler: %v", err)
 	}
 
+	svc := coretesting.NewStubServices(t)
 	legacy := mustAuthorizer(t, config.AuthorizationConfig{
 		Policies: map[string]config.HumanPolicyDef{
 			"sample_policy": {
 				Default: "allow",
 				Members: []config.HumanPolicyMemberDef{
-					{Email: "admin@example.test", Role: "admin"},
+					staticPolicyUserMember(t, svc, "admin@example.test", "admin"),
 				},
 			},
 		},
@@ -1626,6 +1637,7 @@ func TestMountedWebUIRoutes_HumanAuthorization_DefaultAllowTreatsAuthenticatedUs
 				}
 			},
 		}
+		cfg.Services = svc
 		cfg.Authorizer = legacy
 		cfg.MountedWebUIs = []server.MountedWebUI{{
 			Name:                "sample_portal",
@@ -1945,7 +1957,7 @@ func TestBuiltInAdminRoute_HumanAuthorizationSplitManagementLoginFlow(t *testing
 			"admin_policy": {
 				Default: "deny",
 				Members: []config.HumanPolicyMemberDef{
-					{Email: "host@example.com", Role: "admin"},
+					staticPolicyUserMember(t, svc, "host@example.com", "admin"),
 				},
 			},
 		},
@@ -2420,7 +2432,7 @@ func TestAdminAPI_PluginAuthorizationCRUD(t *testing.T) {
 			"sample_policy": {
 				Default: "deny",
 				Members: []config.HumanPolicyMemberDef{
-					{Email: "static@example.test", Role: "admin"},
+					staticPolicyUserMember(t, svc, "static@example.test", "admin"),
 				},
 			},
 		},
@@ -2570,7 +2582,7 @@ func TestAdminAPI_PluginAuthorizationProviderBackedReadsAndDebug(t *testing.T) {
 			"sample_policy": {
 				Default: "deny",
 				Members: []config.HumanPolicyMemberDef{
-					{Email: "static@example.test", Role: "admin"},
+					staticPolicyUserMember(t, svc, "static@example.test", "admin"),
 				},
 			},
 		},
@@ -2758,7 +2770,7 @@ func TestAdminAPI_AuthorizationProviderDebugRequiresAdminPolicy(t *testing.T) {
 			"sample_policy": {
 				Default: "deny",
 				Members: []config.HumanPolicyMemberDef{
-					{Email: "static@example.test", Role: "admin"},
+					staticPolicyUserMember(t, svc, "static@example.test", "admin"),
 				},
 			},
 		},
@@ -2814,7 +2826,7 @@ func TestAdminAPI_AdminAuthorizationCRUD(t *testing.T) {
 			"admin_policy": {
 				Default: "deny",
 				Members: []config.HumanPolicyMemberDef{
-					{Email: "static-admin@example.test", Role: adminRole},
+					staticPolicyUserMember(t, svc, "static-admin@example.test", adminRole),
 				},
 			},
 		},
@@ -3024,7 +3036,7 @@ func TestAdminAPI_AdminAuthorizationProviderBackedReads(t *testing.T) {
 			"admin_policy": {
 				Default: "deny",
 				Members: []config.HumanPolicyMemberDef{
-					{Email: "static-admin@example.test", Role: adminRole},
+					staticPolicyUserMember(t, svc, "static-admin@example.test", adminRole),
 				},
 			},
 		},
@@ -3118,7 +3130,7 @@ func TestAdminAPI_ProviderBackedWritesDoNotRequireLegacyHumanAuthStores(t *testi
 				"sample_policy": {
 					Default: "deny",
 					Members: []config.HumanPolicyMemberDef{
-						{Email: "static@example.test", Role: "admin"},
+						staticPolicyUserMember(t, svc, "static@example.test", "admin"),
 					},
 				},
 			},
@@ -3183,7 +3195,7 @@ func TestAdminAPI_ProviderBackedWritesDoNotRequireLegacyHumanAuthStores(t *testi
 				"admin_policy": {
 					Default: "deny",
 					Members: []config.HumanPolicyMemberDef{
-						{Email: "static-admin@example.test", Role: "owner"},
+						staticPolicyUserMember(t, svc, "static-admin@example.test", "owner"),
 					},
 				},
 			},
@@ -3243,7 +3255,7 @@ func TestAdminAPI_AdminAuthorizationWriteUsesAllowedAdminRoles(t *testing.T) {
 			"admin_policy": {
 				Default: "deny",
 				Members: []config.HumanPolicyMemberDef{
-					{Email: "static-admin@example.test", Role: adminRole},
+					staticPolicyUserMember(t, svc, "static-admin@example.test", adminRole),
 				},
 			},
 		},
@@ -3329,7 +3341,7 @@ func TestAdminAPI_PluginAuthorizationUnavailable(t *testing.T) {
 			"sample_policy": {
 				Default: "deny",
 				Members: []config.HumanPolicyMemberDef{
-					{Email: "admin@example.test", Role: "admin"},
+					staticPolicyUserMember(t, svc, "admin@example.test", "admin"),
 				},
 			},
 		},
@@ -3410,7 +3422,7 @@ func TestAdminAPI_AdminAuthorizationUnavailable(t *testing.T) {
 				"admin_policy": {
 					Default: "deny",
 					Members: []config.HumanPolicyMemberDef{
-						{Email: "admin@example.test", Role: "admin"},
+						staticPolicyUserMember(t, svc, "admin@example.test", "admin"),
 					},
 				},
 			},
@@ -3569,7 +3581,7 @@ func TestAdminAPI_AdminAuthorizationPutFailureReturnsServerError(t *testing.T) {
 			"admin_policy": {
 				Default: "deny",
 				Members: []config.HumanPolicyMemberDef{
-					{Email: "static-admin@example.test", Role: "admin"},
+					staticPolicyUserMember(t, svc, "static-admin@example.test", "admin"),
 				},
 			},
 		},
@@ -3648,7 +3660,7 @@ func TestMountedWebUIAuthorizationPolicyRequiresExplicitRouteCoverage(t *testing
 				"sample_policy": {
 					Default: "deny",
 					Members: []config.HumanPolicyMemberDef{
-						{Email: "viewer@example.test", Role: "viewer"},
+						staticPolicyUserMember(t, svc, "viewer@example.test", "viewer"),
 					},
 				},
 			},
@@ -3731,7 +3743,7 @@ func TestMountedWebUIAuthorizationPolicyNamedBuiltinAdminDoesNotUseAdminResolver
 			"admin_policy": {
 				Default: "deny",
 				Members: []config.HumanPolicyMemberDef{
-					{Email: "static-admin@example.test", Role: "admin"},
+					staticPolicyUserMember(t, svc, "static-admin@example.test", "admin"),
 				},
 			},
 			"sample_policy": {
@@ -8504,7 +8516,7 @@ func TestHumanAuthorization_ExecuteOperation_UsesResolvedRoleAndRejectsDisallowe
 			"sample_policy": {
 				Default: "deny",
 				Members: []config.HumanPolicyMemberDef{
-					{Email: "viewer-user@test.local", Role: "viewer"},
+					staticPolicyUserMember(t, svc, "viewer-user@test.local", "viewer"),
 					{SubjectID: principal.UserSubjectID(viewer.ID), Role: "viewer"},
 				},
 			},
@@ -8639,7 +8651,7 @@ func TestHumanAuthorization_ExecuteOperation_DefaultAllowTreatsAuthenticatedUser
 			"sample_policy": {
 				Default: "allow",
 				Members: []config.HumanPolicyMemberDef{
-					{Email: "admin-user@test.local", Role: "admin"},
+					staticPolicyUserMember(t, svc, "admin-user@test.local", "admin"),
 				},
 			},
 		},


### PR DESCRIPTION
## Summary

This makes static human authorization subject-only instead of supporting both `subjectID` and `email`.

What changed:
- static policy members now require canonical `subjectID`
- removed static `email` member support from config parsing, validation, authorizer state, provider model sync, and provider-backed static subject probing
- simplified admin static membership rows to always surface `selectorKind: "subject_id"`
- removed the dead `user:` switch branch in `adminAuthorizationRowsFromStaticMembers`
- updated existing config/bootstrap/server/operator coverage and config docs to match the subject-only model

## Interface changes

Before:
```yaml
authorization:
  policies:
    roadmap_policy:
      default: deny
      members:
        - email: viewer@example.test
          role: viewer
        - subjectID: user:admin-user
          role: admin
```

After:
```yaml
authorization:
  policies:
    roadmap_policy:
      default: deny
      members:
        - subjectID: user:viewer-user
          role: viewer
        - subjectID: user:admin-user
          role: admin
```

Before:
```go
type HumanPolicyMemberDef struct {
    SubjectID string `yaml:"subjectID,omitempty"`
    Email     string `yaml:"email,omitempty"`
    Role      string `yaml:"role"`
}

type StaticHumanMember struct {
    SubjectID string
    Email     string
    Role      string
}

StaticRoleForPolicyIdentity(policyName, subjectID, userID, email string) (AccessContext, bool)
StaticRoleForProviderIdentity(provider, subjectID, userID, email string) (AccessContext, bool)
```

After:
```go
type HumanPolicyMemberDef struct {
    SubjectID string `yaml:"subjectID,omitempty"`
    Role      string `yaml:"role"`
}

type StaticHumanMember struct {
    SubjectID string
    Role      string
}

StaticRoleForPolicyIdentity(policyName, subjectID, userID string) (AccessContext, bool)
StaticRoleForProviderIdentity(provider, subjectID, userID string) (AccessContext, bool)
```

Before:
```json
{
  "selectorKind": "email",
  "selectorValue": "viewer@example.test"
}
```

After:
```json
{
  "selectorKind": "subject_id",
  "selectorValue": "user:viewer-user"
}
```

## Verification

```bash
cd gestaltd
go test ./internal/authorization ./internal/server ./internal/config ./internal/bootstrap ./internal/operator
golangci-lint run ./internal/authorization ./internal/server ./internal/config ./internal/bootstrap ./internal/operator

cd ../docs
npm ci
npm run build
```