### PR TITLE
authz: require canonical subject ids for static human matching

### DIFF
--- a/gestaltd/internal/authorization/authorizer.go
+++ b/gestaltd/internal/authorization/authorizer.go
@@ -279,7 +279,7 @@ func (a *Authorizer) PolicyNameForProvider(provider string) string {
 	return strings.TrimSpace(a.providerPolicies[provider])
 }
 
-func (a *Authorizer) StaticRoleForPolicyIdentity(policyName, subjectID, userID string) (AccessContext, bool) {
+func (a *Authorizer) StaticRoleForPolicyIdentity(policyName, subjectID string) (AccessContext, bool) {
 	if a == nil {
 		return AccessContext{}, false
 	}
@@ -292,19 +292,19 @@ func (a *Authorizer) StaticRoleForPolicyIdentity(policyName, subjectID, userID s
 		return AccessContext{}, false
 	}
 	access := AccessContext{Policy: policyName}
-	if role, ok := policy.staticRoleForIdentity(subjectID, userID); ok {
+	if role, ok := policy.staticRoleForIdentity(subjectID); ok {
 		access.Role = role
 		return access, true
 	}
 	return access, false
 }
 
-func (a *Authorizer) StaticRoleForProviderIdentity(provider, subjectID, userID string) (AccessContext, bool) {
+func (a *Authorizer) StaticRoleForProviderIdentity(provider, subjectID string) (AccessContext, bool) {
 	if a == nil {
 		return AccessContext{}, false
 	}
 	policyName := a.PolicyNameForProvider(provider)
-	return a.StaticRoleForPolicyIdentity(policyName, subjectID, userID)
+	return a.StaticRoleForPolicyIdentity(policyName, subjectID)
 }
 
 func (a *Authorizer) StaticMembersForPolicy(policyName string) ([]StaticHumanMember, bool) {
@@ -442,20 +442,15 @@ func (p *HumanPolicy) roleForPrincipal(pr *principal.Principal) (string, bool) {
 	if p == nil || pr == nil {
 		return "", false
 	}
-	return p.staticRoleForIdentity(pr.SubjectID, pr.UserID)
+	return p.staticRoleForIdentity(principal.Canonicalize(pr).SubjectID)
 }
 
-func (p *HumanPolicy) staticRoleForIdentity(subjectID, userID string) (string, bool) {
+func (p *HumanPolicy) staticRoleForIdentity(subjectID string) (string, bool) {
 	if p == nil {
 		return "", false
 	}
 	if subjectID = strings.TrimSpace(subjectID); subjectID != "" {
 		if role, ok := p.RolesBySubjectID[subjectID]; ok {
-			return role, true
-		}
-	}
-	if userID = strings.TrimSpace(userID); userID != "" {
-		if role, ok := p.RolesBySubjectID[principal.UserSubjectID(userID)]; ok {
 			return role, true
 		}
 	}

--- a/gestaltd/internal/authorization/provider_backed.go
+++ b/gestaltd/internal/authorization/provider_backed.go
@@ -398,18 +398,18 @@ func (a *ProviderBackedAuthorizer) PolicyNameForProvider(provider string) string
 	return a.base.PolicyNameForProvider(provider)
 }
 
-func (a *ProviderBackedAuthorizer) StaticRoleForPolicyIdentity(policyName, subjectID, userID string) (AccessContext, bool) {
+func (a *ProviderBackedAuthorizer) StaticRoleForPolicyIdentity(policyName, subjectID string) (AccessContext, bool) {
 	if a == nil {
 		return AccessContext{}, false
 	}
-	return a.base.StaticRoleForPolicyIdentity(policyName, subjectID, userID)
+	return a.base.StaticRoleForPolicyIdentity(policyName, subjectID)
 }
 
-func (a *ProviderBackedAuthorizer) StaticRoleForProviderIdentity(provider, subjectID, userID string) (AccessContext, bool) {
+func (a *ProviderBackedAuthorizer) StaticRoleForProviderIdentity(provider, subjectID string) (AccessContext, bool) {
 	if a == nil {
 		return AccessContext{}, false
 	}
-	return a.base.StaticRoleForProviderIdentity(provider, subjectID, userID)
+	return a.base.StaticRoleForProviderIdentity(provider, subjectID)
 }
 
 func (a *ProviderBackedAuthorizer) StaticMembersForPolicy(policyName string) ([]StaticHumanMember, bool) {

--- a/gestaltd/internal/authorization/runtime.go
+++ b/gestaltd/internal/authorization/runtime.go
@@ -29,8 +29,8 @@ type RuntimeAuthorizer interface {
 	AllowCatalogOperation(ctx context.Context, p *principal.Principal, provider string, op catalog.CatalogOperation) bool
 
 	PolicyNameForProvider(provider string) string
-	StaticRoleForPolicyIdentity(policyName, subjectID, userID string) (AccessContext, bool)
-	StaticRoleForProviderIdentity(provider, subjectID, userID string) (AccessContext, bool)
+	StaticRoleForPolicyIdentity(policyName, subjectID string) (AccessContext, bool)
+	StaticRoleForProviderIdentity(provider, subjectID string) (AccessContext, bool)
 	StaticMembersForPolicy(policyName string) ([]StaticHumanMember, bool)
 	StaticMembersForProvider(provider string) (string, []StaticHumanMember, bool)
 }

--- a/gestaltd/internal/principal/principal.go
+++ b/gestaltd/internal/principal/principal.go
@@ -316,10 +316,31 @@ func clonePermissionOps(src map[string]struct{}) map[string]struct{} {
 type contextKey struct{}
 
 func WithPrincipal(ctx context.Context, p *Principal) context.Context {
-	return context.WithValue(ctx, contextKey{}, p)
+	return context.WithValue(ctx, contextKey{}, Canonicalize(p))
 }
 
 func FromContext(ctx context.Context) *Principal {
 	p, _ := ctx.Value(contextKey{}).(*Principal)
+	return Canonicalize(p)
+}
+
+func Canonicalize(p *Principal) *Principal {
+	if p == nil {
+		return nil
+	}
+	if p.UserID == "" && p.SubjectID != "" {
+		if userID := UserIDFromSubjectID(p.SubjectID); userID != "" {
+			p.UserID = userID
+			if p.Kind == "" {
+				p.Kind = KindUser
+			}
+		}
+	}
+	if p.SubjectID == "" && p.UserID != "" {
+		p.SubjectID = UserSubjectID(p.UserID)
+		if p.Kind == "" {
+			p.Kind = KindUser
+		}
+	}
 	return p
 }

--- a/gestaltd/internal/server/handlers_admin_authorization.go
+++ b/gestaltd/internal/server/handlers_admin_authorization.go
@@ -171,7 +171,7 @@ func (s *Server) putAdminAuthorizationPluginMember(w http.ResponseWriter, r *htt
 		writeError(w, http.StatusInternalServerError, "failed to resolve user")
 		return
 	}
-	if access, ok := s.authorizer.StaticRoleForProviderIdentity(plugin, principal.UserSubjectID(user.ID), user.ID); ok && access.Role != "" {
+	if access, ok := s.authorizer.StaticRoleForProviderIdentity(plugin, principal.UserSubjectID(user.ID)); ok && access.Role != "" {
 		writeError(w, http.StatusConflict, "user already has static authorization for this plugin")
 		return
 	}
@@ -295,7 +295,7 @@ func (s *Server) putAdminAuthorizationAdminMember(w http.ResponseWriter, r *http
 		writeError(w, http.StatusInternalServerError, "failed to resolve user")
 		return
 	}
-	if access, ok := s.authorizer.StaticRoleForPolicyIdentity(s.adminRoute.AuthorizationPolicy, principal.UserSubjectID(user.ID), user.ID); ok && access.Role != "" {
+	if access, ok := s.authorizer.StaticRoleForPolicyIdentity(s.adminRoute.AuthorizationPolicy, principal.UserSubjectID(user.ID)); ok && access.Role != "" {
 		writeError(w, http.StatusConflict, "user already has static admin authorization")
 		return
 	}


### PR DESCRIPTION
## Summary
This makes canonical `subject_id` the only internal selector used for static human authorization matching.

It removes the last `userID -> user:<id>` fallback from static role resolution, and instead canonicalizes user principals at the principal boundary so authz code receives a consistent shape.

## Go Interface Change
Before:
```go
type RuntimeAuthorizer interface {
    StaticRoleForPolicyIdentity(policyName, subjectID, userID string) (AccessContext, bool)
    StaticRoleForProviderIdentity(provider, subjectID, userID string) (AccessContext, bool)
}
```

After:
```go
type RuntimeAuthorizer interface {
    StaticRoleForPolicyIdentity(policyName, subjectID string) (AccessContext, bool)
    StaticRoleForProviderIdentity(provider, subjectID string) (AccessContext, bool)
}
```

## Principal Canonicalization
User principals are now normalized so authz callers do not need to thread both identifiers.

```go
ctx = principal.WithPrincipal(ctx, &principal.Principal{UserID: "usr_123"})
p := principal.FromContext(ctx)
// p.SubjectID == "user:usr_123"
```

## Admin API Usage
Static-role conflict checks now use canonical subject IDs directly.

```go
if access, ok := s.authorizer.StaticRoleForProviderIdentity(plugin, principal.UserSubjectID(user.ID)); ok && access.Role != "" {
    // conflict
}
```

## Config / YAML
No YAML surface changes in this PR.
Static human authorization still uses canonical subject IDs in config, e.g.

```yaml
authorization:
  policies:
    admin:
      roles:
        admin:
          members:
            - subjectID: user:usr_123
```

## Why This Is Not Trivial
The deleted fallback was compensating for inconsistent runtime principal construction. Some paths built user principals with only `UserID` and no canonical `SubjectID`. Removing the fallback safely therefore required coordinating:
- principal normalization at the boundary
- stricter `RuntimeAuthorizer` static-role APIs
- admin handler call sites that perform static-role conflict checks

## Database Migration
No database migration is required.

This PR does not change persisted authorization relationships, models, or schema. It only changes runtime principal normalization and static-role matching behavior in-process.

## Verification
```bash
cd gestaltd
go test ./internal/principal ./internal/authorization ./internal/server ./internal/bootstrap ./internal/invocation ./internal/mcp
golangci-lint run ./internal/principal ./internal/authorization ./internal/server ./internal/bootstrap ./internal/invocation ./internal/mcp
```