### PR TITLE
workflow: add global workflow schedule HTTP APIs

### DIFF
--- a/gestaltd/internal/bootstrap/workflow_control.go
+++ b/gestaltd/internal/bootstrap/workflow_control.go
@@ -7,6 +7,7 @@ import coreworkflow "github.com/valon-technologies/gestalt/server/core/workflow"
 type WorkflowControl interface {
 	ResolveBinding(pluginName string) (providerName string, operations map[string]struct{}, err error)
 	ResolveProvider(name string) (coreworkflow.Provider, error)
+	ProviderNames() []string
 }
 
 var _ WorkflowControl = (*workflowRuntime)(nil)

--- a/gestaltd/internal/bootstrap/workflow_runtime.go
+++ b/gestaltd/internal/bootstrap/workflow_runtime.go
@@ -220,6 +220,29 @@ func (r *workflowRuntime) ResolveProvider(name string) (coreworkflow.Provider, e
 	return provider, nil
 }
 
+func (r *workflowRuntime) ProviderNames() []string {
+	if r == nil {
+		return nil
+	}
+	r.mu.RLock()
+	defer r.mu.RUnlock()
+	seen := make(map[string]struct{}, len(r.bindings))
+	names := make([]string, 0, len(r.bindings))
+	for _, binding := range r.bindings {
+		name := strings.TrimSpace(binding.providerName)
+		if name == "" {
+			continue
+		}
+		if _, ok := seen[name]; ok {
+			continue
+		}
+		seen[name] = struct{}{}
+		names = append(names, name)
+	}
+	slices.Sort(names)
+	return names
+}
+
 func (r *workflowRuntime) ManagedScheduleIDs(pluginName string) map[string]struct{} {
 	if r == nil {
 		return nil

--- a/gestaltd/internal/server/handlers_workflow.go
+++ b/gestaltd/internal/server/handlers_workflow.go
@@ -22,6 +22,7 @@ import (
 )
 
 type workflowScheduleTargetRequest struct {
+	Plugin     string         `json:"plugin,omitempty"`
 	Operation  string         `json:"operation"`
 	Connection string         `json:"connection,omitempty"`
 	Instance   string         `json:"instance,omitempty"`
@@ -36,6 +37,7 @@ type workflowScheduleUpsertRequest struct {
 }
 
 type workflowScheduleTargetInfo struct {
+	Plugin     string         `json:"plugin,omitempty"`
 	Operation  string         `json:"operation"`
 	Connection string         `json:"connection,omitempty"`
 	Instance   string         `json:"instance,omitempty"`
@@ -80,12 +82,12 @@ func (s *Server) listWorkflowSchedules(w http.ResponseWriter, r *http.Request) {
 		if strings.TrimSpace(schedule.Target.PluginName) != pluginName {
 			continue
 		}
-		owned, _, err := s.workflowScheduleOwner(r.Context(), p, schedule)
+		owned, ref, err := s.workflowScheduleOwner(r.Context(), p, schedule)
 		if err != nil {
 			writeError(w, http.StatusInternalServerError, "failed to resolve workflow schedule owner")
 			return
 		}
-		if !owned || !s.allowWorkflowScheduleTarget(r.Context(), p, schedule.Target) {
+		if !owned || !workflowScheduleMatchesExecutionRef("", schedule, ref) || !s.allowWorkflowScheduleTarget(r.Context(), p, schedule.Target) {
 			continue
 		}
 		out = append(out, workflowScheduleInfoFromCore(schedule, providerName))
@@ -99,13 +101,47 @@ func (s *Server) listWorkflowSchedules(w http.ResponseWriter, r *http.Request) {
 	writeJSON(w, http.StatusOK, out)
 }
 
-func (s *Server) createWorkflowSchedule(w http.ResponseWriter, r *http.Request) {
-	pluginName := strings.TrimSpace(chi.URLParam(r, "integration"))
+func (s *Server) listGlobalWorkflowSchedules(w http.ResponseWriter, r *http.Request) {
 	p, ok := s.resolveWorkflowScheduleActor(w, r)
 	if !ok {
 		return
 	}
-	providerName, provider, allowed, ok := s.resolveWorkflowScheduleProvider(w, pluginName)
+	providerNames, providers, ok := s.resolveGlobalWorkflowScheduleProviders(w)
+	if !ok {
+		return
+	}
+	out := make([]workflowScheduleInfo, 0)
+	for _, providerName := range providerNames {
+		provider := providers[providerName]
+		schedules, err := provider.ListSchedules(r.Context(), coreworkflow.ListSchedulesRequest{})
+		if err != nil {
+			s.writeWorkflowScheduleProviderError(w, "", "", err)
+			return
+		}
+		for _, schedule := range schedules {
+			owned, ref, err := s.workflowScheduleOwner(r.Context(), p, schedule)
+			if err != nil {
+				writeError(w, http.StatusInternalServerError, "failed to resolve workflow schedule owner")
+				return
+			}
+			if !owned || !workflowScheduleMatchesExecutionRef(providerName, schedule, ref) || !s.allowWorkflowScheduleTarget(r.Context(), p, schedule.Target) {
+				continue
+			}
+			out = append(out, workflowScheduleInfoFromCore(schedule, providerName))
+		}
+	}
+	sort.Slice(out, func(i, j int) bool {
+		if out[i].CreatedAt != nil && out[j].CreatedAt != nil && !out[i].CreatedAt.Equal(*out[j].CreatedAt) {
+			return out[i].CreatedAt.Before(*out[j].CreatedAt)
+		}
+		return out[i].ID < out[j].ID
+	})
+	writeJSON(w, http.StatusOK, out)
+}
+
+func (s *Server) createWorkflowSchedule(w http.ResponseWriter, r *http.Request) {
+	routePluginName := strings.TrimSpace(chi.URLParam(r, "integration"))
+	p, ok := s.resolveWorkflowScheduleActor(w, r)
 	if !ok {
 		return
 	}
@@ -113,6 +149,14 @@ func (s *Server) createWorkflowSchedule(w http.ResponseWriter, r *http.Request) 
 	var req workflowScheduleUpsertRequest
 	if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
 		writeError(w, http.StatusBadRequest, "invalid JSON body")
+		return
+	}
+	pluginName, ok := s.resolveWorkflowScheduleTargetPlugin(w, routePluginName, req.Target.Plugin)
+	if !ok {
+		return
+	}
+	providerName, provider, allowed, ok := s.resolveWorkflowScheduleProvider(w, pluginName)
+	if !ok {
 		return
 	}
 
@@ -164,9 +208,31 @@ func (s *Server) getWorkflowSchedule(w http.ResponseWriter, r *http.Request) {
 	writeJSON(w, http.StatusOK, workflowScheduleInfoFromCore(schedule, providerName))
 }
 
-func (s *Server) updateWorkflowSchedule(w http.ResponseWriter, r *http.Request) {
-	pluginName := strings.TrimSpace(chi.URLParam(r, "integration"))
+func (s *Server) getGlobalWorkflowSchedule(w http.ResponseWriter, r *http.Request) {
 	p, ok := s.resolveWorkflowScheduleActor(w, r)
+	if !ok {
+		return
+	}
+	schedule, _, providerName, _, ok := s.requireOwnedWorkflowScheduleGlobal(r.Context(), w, chi.URLParam(r, "scheduleID"), p)
+	if !ok {
+		return
+	}
+	writeJSON(w, http.StatusOK, workflowScheduleInfoFromCore(schedule, providerName))
+}
+
+func (s *Server) updateWorkflowSchedule(w http.ResponseWriter, r *http.Request) {
+	routePluginName := strings.TrimSpace(chi.URLParam(r, "integration"))
+	p, ok := s.resolveWorkflowScheduleActor(w, r)
+	if !ok {
+		return
+	}
+
+	var req workflowScheduleUpsertRequest
+	if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
+		writeError(w, http.StatusBadRequest, "invalid JSON body")
+		return
+	}
+	pluginName, ok := s.resolveWorkflowScheduleTargetPlugin(w, routePluginName, req.Target.Plugin)
 	if !ok {
 		return
 	}
@@ -177,12 +243,6 @@ func (s *Server) updateWorkflowSchedule(w http.ResponseWriter, r *http.Request) 
 	scheduleID := chi.URLParam(r, "scheduleID")
 	existing, ref, ok := s.requireOwnedWorkflowSchedule(r.Context(), w, provider, pluginName, scheduleID, p)
 	if !ok {
-		return
-	}
-
-	var req workflowScheduleUpsertRequest
-	if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
-		writeError(w, http.StatusBadRequest, "invalid JSON body")
 		return
 	}
 	target, err := s.resolveWorkflowScheduleTarget(r.Context(), pluginName, allowed, p, req.Target)
@@ -218,6 +278,74 @@ func (s *Server) updateWorkflowSchedule(w http.ResponseWriter, r *http.Request) 
 	writeJSON(w, http.StatusOK, workflowScheduleInfoFromCore(schedule, providerName))
 }
 
+func (s *Server) updateGlobalWorkflowSchedule(w http.ResponseWriter, r *http.Request) {
+	p, ok := s.resolveWorkflowScheduleActor(w, r)
+	if !ok {
+		return
+	}
+	scheduleID := chi.URLParam(r, "scheduleID")
+	existing, ref, currentProviderName, currentProvider, ok := s.requireOwnedWorkflowScheduleGlobal(r.Context(), w, scheduleID, p)
+	if !ok {
+		return
+	}
+
+	var req workflowScheduleUpsertRequest
+	if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
+		writeError(w, http.StatusBadRequest, "invalid JSON body")
+		return
+	}
+	pluginName, ok := s.resolveWorkflowScheduleTargetPlugin(w, "", req.Target.Plugin)
+	if !ok {
+		return
+	}
+	nextProviderName, nextProvider, allowed, ok := s.resolveWorkflowScheduleProvider(w, pluginName)
+	if !ok {
+		return
+	}
+	target, err := s.resolveWorkflowScheduleTarget(r.Context(), pluginName, allowed, p, req.Target)
+	if err != nil {
+		s.writeWorkflowScheduleTargetError(w, r, pluginName, strings.TrimSpace(req.Target.Operation), err)
+		return
+	}
+
+	executionRefID := workflowScheduleExecutionRefID(strings.TrimSpace(existing.ID))
+	nextRef, err := s.putWorkflowExecutionRef(r.Context(), executionRefID, nextProviderName, target, p)
+	if err != nil {
+		writeError(w, http.StatusInternalServerError, "failed to store workflow execution reference")
+		return
+	}
+	schedule, err := nextProvider.UpsertSchedule(r.Context(), coreworkflow.UpsertScheduleRequest{
+		ScheduleID:   strings.TrimSpace(existing.ID),
+		Cron:         strings.TrimSpace(req.Cron),
+		Timezone:     strings.TrimSpace(req.Timezone),
+		Target:       target,
+		Paused:       req.Paused,
+		RequestedBy:  workflowActorFromPrincipal(p),
+		ExecutionRef: executionRefID,
+	})
+	if err != nil {
+		s.revokeWorkflowExecutionRef(r.Context(), nextRef)
+		s.writeWorkflowScheduleProviderError(w, pluginName, strings.TrimSpace(existing.ID), err)
+		return
+	}
+	if currentProviderName != nextProviderName {
+		if err := currentProvider.DeleteSchedule(r.Context(), coreworkflow.DeleteScheduleRequest{
+			ScheduleID: strings.TrimSpace(existing.ID),
+		}); err != nil {
+			_ = nextProvider.DeleteSchedule(r.Context(), coreworkflow.DeleteScheduleRequest{
+				ScheduleID: strings.TrimSpace(existing.ID),
+			})
+			s.revokeWorkflowExecutionRef(r.Context(), nextRef)
+			s.writeWorkflowScheduleProviderError(w, strings.TrimSpace(existing.Target.PluginName), strings.TrimSpace(existing.ID), err)
+			return
+		}
+	}
+	if ref != nil && ref.ID != "" && ref.ID != executionRefID {
+		s.revokeWorkflowExecutionRef(r.Context(), ref)
+	}
+	writeJSON(w, http.StatusOK, workflowScheduleInfoFromCore(schedule, nextProviderName))
+}
+
 func (s *Server) deleteWorkflowSchedule(w http.ResponseWriter, r *http.Request) {
 	pluginName := strings.TrimSpace(chi.URLParam(r, "integration"))
 	p, ok := s.resolveWorkflowScheduleActor(w, r)
@@ -236,6 +364,27 @@ func (s *Server) deleteWorkflowSchedule(w http.ResponseWriter, r *http.Request) 
 		ScheduleID: strings.TrimSpace(schedule.ID),
 	}); err != nil {
 		s.writeWorkflowScheduleProviderError(w, pluginName, strings.TrimSpace(schedule.ID), err)
+		return
+	}
+	if ref != nil && ref.ID != "" {
+		s.revokeWorkflowExecutionRef(r.Context(), ref)
+	}
+	writeJSON(w, http.StatusOK, map[string]string{"status": "deleted"})
+}
+
+func (s *Server) deleteGlobalWorkflowSchedule(w http.ResponseWriter, r *http.Request) {
+	p, ok := s.resolveWorkflowScheduleActor(w, r)
+	if !ok {
+		return
+	}
+	schedule, ref, _, provider, ok := s.requireOwnedWorkflowScheduleGlobal(r.Context(), w, chi.URLParam(r, "scheduleID"), p)
+	if !ok {
+		return
+	}
+	if err := provider.DeleteSchedule(r.Context(), coreworkflow.DeleteScheduleRequest{
+		ScheduleID: strings.TrimSpace(schedule.ID),
+	}); err != nil {
+		s.writeWorkflowScheduleProviderError(w, strings.TrimSpace(schedule.Target.PluginName), strings.TrimSpace(schedule.ID), err)
 		return
 	}
 	if ref != nil && ref.ID != "" {
@@ -268,6 +417,25 @@ func (s *Server) pauseWorkflowSchedule(w http.ResponseWriter, r *http.Request) {
 	writeJSON(w, http.StatusOK, workflowScheduleInfoFromCore(value, providerName))
 }
 
+func (s *Server) pauseGlobalWorkflowSchedule(w http.ResponseWriter, r *http.Request) {
+	p, ok := s.resolveWorkflowScheduleActor(w, r)
+	if !ok {
+		return
+	}
+	schedule, _, providerName, provider, ok := s.requireOwnedWorkflowScheduleGlobal(r.Context(), w, chi.URLParam(r, "scheduleID"), p)
+	if !ok {
+		return
+	}
+	value, err := provider.PauseSchedule(r.Context(), coreworkflow.PauseScheduleRequest{
+		ScheduleID: strings.TrimSpace(schedule.ID),
+	})
+	if err != nil {
+		s.writeWorkflowScheduleProviderError(w, strings.TrimSpace(schedule.Target.PluginName), strings.TrimSpace(schedule.ID), err)
+		return
+	}
+	writeJSON(w, http.StatusOK, workflowScheduleInfoFromCore(value, providerName))
+}
+
 func (s *Server) resumeWorkflowSchedule(w http.ResponseWriter, r *http.Request) {
 	pluginName := strings.TrimSpace(chi.URLParam(r, "integration"))
 	p, ok := s.resolveWorkflowScheduleActor(w, r)
@@ -287,6 +455,25 @@ func (s *Server) resumeWorkflowSchedule(w http.ResponseWriter, r *http.Request) 
 	})
 	if err != nil {
 		s.writeWorkflowScheduleProviderError(w, pluginName, strings.TrimSpace(schedule.ID), err)
+		return
+	}
+	writeJSON(w, http.StatusOK, workflowScheduleInfoFromCore(value, providerName))
+}
+
+func (s *Server) resumeGlobalWorkflowSchedule(w http.ResponseWriter, r *http.Request) {
+	p, ok := s.resolveWorkflowScheduleActor(w, r)
+	if !ok {
+		return
+	}
+	schedule, _, providerName, provider, ok := s.requireOwnedWorkflowScheduleGlobal(r.Context(), w, chi.URLParam(r, "scheduleID"), p)
+	if !ok {
+		return
+	}
+	value, err := provider.ResumeSchedule(r.Context(), coreworkflow.ResumeScheduleRequest{
+		ScheduleID: strings.TrimSpace(schedule.ID),
+	})
+	if err != nil {
+		s.writeWorkflowScheduleProviderError(w, strings.TrimSpace(schedule.Target.PluginName), strings.TrimSpace(schedule.ID), err)
 		return
 	}
 	writeJSON(w, http.StatusOK, workflowScheduleInfoFromCore(value, providerName))
@@ -324,6 +511,45 @@ func (s *Server) resolveWorkflowScheduleProvider(w http.ResponseWriter, pluginNa
 		return "", nil, nil, false
 	}
 	return providerName, provider, allowed, true
+}
+
+func (s *Server) resolveGlobalWorkflowScheduleProviders(w http.ResponseWriter) ([]string, map[string]coreworkflow.Provider, bool) {
+	if s.workflow == nil {
+		writeError(w, http.StatusPreconditionFailed, "workflow is not configured")
+		return nil, nil, false
+	}
+	providerNames := s.workflow.ProviderNames()
+	if len(providerNames) == 0 {
+		writeError(w, http.StatusPreconditionFailed, "workflow is not configured")
+		return nil, nil, false
+	}
+	providers := make(map[string]coreworkflow.Provider, len(providerNames))
+	for _, providerName := range providerNames {
+		provider, err := s.workflow.ResolveProvider(providerName)
+		if err != nil {
+			writeError(w, http.StatusPreconditionFailed, err.Error())
+			return nil, nil, false
+		}
+		providers[providerName] = provider
+	}
+	return providerNames, providers, true
+}
+
+func (s *Server) resolveWorkflowScheduleTargetPlugin(w http.ResponseWriter, routePluginName, requestPluginName string) (string, bool) {
+	routePluginName = strings.TrimSpace(routePluginName)
+	requestPluginName = strings.TrimSpace(requestPluginName)
+	switch {
+	case routePluginName != "" && requestPluginName != "" && routePluginName != requestPluginName:
+		writeError(w, http.StatusBadRequest, fmt.Sprintf("workflow target plugin %q does not match route integration %q", requestPluginName, routePluginName))
+		return "", false
+	case routePluginName != "":
+		return routePluginName, true
+	case requestPluginName == "":
+		writeError(w, http.StatusBadRequest, "workflow target plugin is required")
+		return "", false
+	default:
+		return requestPluginName, true
+	}
 }
 
 func (s *Server) resolveWorkflowScheduleTarget(
@@ -437,6 +663,10 @@ func (s *Server) requireOwnedWorkflowSchedule(
 		writeError(w, http.StatusNotFound, fmt.Sprintf("workflow schedule %q not found", scheduleID))
 		return nil, nil, false
 	}
+	if !workflowScheduleMatchesExecutionRef("", schedule, ref) {
+		writeError(w, http.StatusNotFound, fmt.Sprintf("workflow schedule %q not found", scheduleID))
+		return nil, nil, false
+	}
 	if strings.TrimSpace(schedule.Target.PluginName) != pluginName {
 		writeError(w, http.StatusNotFound, fmt.Sprintf("workflow schedule %q not found", scheduleID))
 		return nil, nil, false
@@ -446,6 +676,63 @@ func (s *Server) requireOwnedWorkflowSchedule(
 		return nil, nil, false
 	}
 	return schedule, ref, true
+}
+
+func (s *Server) requireOwnedWorkflowScheduleGlobal(
+	ctx context.Context,
+	w http.ResponseWriter,
+	scheduleID string,
+	p *principal.Principal,
+) (*coreworkflow.Schedule, *coreworkflow.ExecutionReference, string, coreworkflow.Provider, bool) {
+	scheduleID = strings.TrimSpace(scheduleID)
+	if scheduleID == "" {
+		writeError(w, http.StatusBadRequest, "scheduleID is required")
+		return nil, nil, "", nil, false
+	}
+	providerNames, providers, ok := s.resolveGlobalWorkflowScheduleProviders(w)
+	if !ok {
+		return nil, nil, "", nil, false
+	}
+	var (
+		foundSchedule     *coreworkflow.Schedule
+		foundRef          *coreworkflow.ExecutionReference
+		foundProviderName string
+		foundProvider     coreworkflow.Provider
+	)
+	for _, providerName := range providerNames {
+		provider := providers[providerName]
+		schedule, err := provider.GetSchedule(ctx, coreworkflow.GetScheduleRequest{
+			ScheduleID: scheduleID,
+		})
+		if err != nil {
+			if errors.Is(err, core.ErrNotFound) {
+				continue
+			}
+			s.writeWorkflowScheduleProviderError(w, "", scheduleID, err)
+			return nil, nil, "", nil, false
+		}
+		owned, ref, err := s.workflowScheduleOwner(ctx, p, schedule)
+		if err != nil {
+			writeError(w, http.StatusInternalServerError, "failed to resolve workflow schedule owner")
+			return nil, nil, "", nil, false
+		}
+		if !owned || !workflowScheduleMatchesExecutionRef(providerName, schedule, ref) || !s.allowWorkflowScheduleTarget(ctx, p, schedule.Target) {
+			continue
+		}
+		if foundSchedule != nil {
+			writeError(w, http.StatusInternalServerError, fmt.Sprintf("workflow schedule %q matched multiple workflow providers", scheduleID))
+			return nil, nil, "", nil, false
+		}
+		foundSchedule = schedule
+		foundRef = ref
+		foundProviderName = providerName
+		foundProvider = provider
+	}
+	if foundSchedule == nil {
+		writeError(w, http.StatusNotFound, fmt.Sprintf("workflow schedule %q not found", scheduleID))
+		return nil, nil, "", nil, false
+	}
+	return foundSchedule, foundRef, foundProviderName, foundProvider, true
 }
 
 func (s *Server) workflowScheduleOwner(ctx context.Context, p *principal.Principal, schedule *coreworkflow.Schedule) (bool, *coreworkflow.ExecutionReference, error) {
@@ -483,6 +770,19 @@ func workflowExecutionRefOwnedBy(ref *coreworkflow.ExecutionReference, p *princi
 	}
 	subjectID := strings.TrimSpace(p.SubjectID)
 	return subjectID != "" && strings.TrimSpace(ref.SubjectID) == subjectID
+}
+
+func workflowScheduleMatchesExecutionRef(providerName string, schedule *coreworkflow.Schedule, ref *coreworkflow.ExecutionReference) bool {
+	if schedule == nil || ref == nil {
+		return false
+	}
+	if providerName = strings.TrimSpace(providerName); providerName != "" && strings.TrimSpace(ref.ProviderName) != providerName {
+		return false
+	}
+	return strings.TrimSpace(schedule.Target.PluginName) == strings.TrimSpace(ref.Target.PluginName) &&
+		strings.TrimSpace(schedule.Target.Operation) == strings.TrimSpace(ref.Target.Operation) &&
+		strings.TrimSpace(schedule.Target.Connection) == strings.TrimSpace(ref.Target.Connection) &&
+		strings.TrimSpace(schedule.Target.Instance) == strings.TrimSpace(ref.Target.Instance)
 }
 
 func (s *Server) putWorkflowExecutionRef(
@@ -561,6 +861,7 @@ func workflowScheduleInfoFromCore(schedule *coreworkflow.Schedule, providerName 
 	info.UpdatedAt = schedule.UpdatedAt
 	info.NextRunAt = schedule.NextRunAt
 	info.Target = workflowScheduleTargetInfo{
+		Plugin:     schedule.Target.PluginName,
 		Operation:  schedule.Target.Operation,
 		Connection: userFacingConnectionName(schedule.Target.Connection),
 		Instance:   schedule.Target.Instance,
@@ -584,6 +885,10 @@ func (s *Server) writeWorkflowScheduleProviderError(w http.ResponseWriter, plugi
 	case errors.Is(err, core.ErrNotFound):
 		writeError(w, http.StatusNotFound, fmt.Sprintf("workflow schedule %q not found", scheduleID))
 	default:
+		if strings.TrimSpace(pluginName) == "" {
+			writeError(w, http.StatusInternalServerError, "workflow schedule request failed")
+			return
+		}
 		writeError(w, http.StatusInternalServerError, fmt.Sprintf("workflow schedule request failed for integration %q", pluginName))
 	}
 }

--- a/gestaltd/internal/server/routes_user.go
+++ b/gestaltd/internal/server/routes_user.go
@@ -10,6 +10,16 @@ func (s *Server) mountAuthenticatedRoutes(r chi.Router) {
 		r.Delete("/integrations/{name}", s.disconnectIntegration)
 		r.Get("/integrations/{name}/operations", s.listOperations)
 
+		r.Route("/workflow/schedules", func(r chi.Router) {
+			r.Get("/", s.listGlobalWorkflowSchedules)
+			r.Post("/", s.createWorkflowSchedule)
+			r.Get("/{scheduleID}", s.getGlobalWorkflowSchedule)
+			r.Put("/{scheduleID}", s.updateGlobalWorkflowSchedule)
+			r.Delete("/{scheduleID}", s.deleteGlobalWorkflowSchedule)
+			r.Post("/{scheduleID}/pause", s.pauseGlobalWorkflowSchedule)
+			r.Post("/{scheduleID}/resume", s.resumeGlobalWorkflowSchedule)
+		})
+
 		r.Route("/{integration}/workflow/schedules", func(r chi.Router) {
 			r.Get("/", s.listWorkflowSchedules)
 			r.Post("/", s.createWorkflowSchedule)

--- a/gestaltd/internal/server/workflow_schedule_test.go
+++ b/gestaltd/internal/server/workflow_schedule_test.go
@@ -7,6 +7,7 @@ import (
 	"errors"
 	"io"
 	"net/http"
+	"slices"
 	"testing"
 	"time"
 
@@ -19,26 +20,79 @@ import (
 	"github.com/valon-technologies/gestalt/server/internal/testutil"
 )
 
+type stubWorkflowBinding struct {
+	providerName string
+	allowed      map[string]struct{}
+}
+
 type stubWorkflowControl struct {
 	providerName string
 	allowed      map[string]struct{}
 	provider     coreworkflow.Provider
+	bindings     map[string]stubWorkflowBinding
+	providers    map[string]coreworkflow.Provider
+	providerList []string
 	bindingErr   error
 	providerErr  error
 }
 
-func (s *stubWorkflowControl) ResolveBinding(string) (string, map[string]struct{}, error) {
+func (s *stubWorkflowControl) ResolveBinding(pluginName string) (string, map[string]struct{}, error) {
 	if s.bindingErr != nil {
 		return "", nil, s.bindingErr
+	}
+	if s.bindings != nil {
+		binding, ok := s.bindings[pluginName]
+		if !ok {
+			return "", nil, errors.New("binding not found")
+		}
+		return binding.providerName, cloneWorkflowAllowed(binding.allowed), nil
 	}
 	return s.providerName, cloneWorkflowAllowed(s.allowed), nil
 }
 
-func (s *stubWorkflowControl) ResolveProvider(string) (coreworkflow.Provider, error) {
+func (s *stubWorkflowControl) ResolveProvider(name string) (coreworkflow.Provider, error) {
 	if s.providerErr != nil {
 		return nil, s.providerErr
 	}
+	if s.providers != nil {
+		provider, ok := s.providers[name]
+		if !ok {
+			return nil, errors.New("provider not found")
+		}
+		return provider, nil
+	}
 	return s.provider, nil
+}
+
+func (s *stubWorkflowControl) ProviderNames() []string {
+	if len(s.providerList) > 0 {
+		return append([]string(nil), s.providerList...)
+	}
+	if len(s.providers) > 0 {
+		names := make([]string, 0, len(s.providers))
+		for name := range s.providers {
+			names = append(names, name)
+		}
+		slices.Sort(names)
+		return names
+	}
+	if len(s.bindings) > 0 {
+		seen := make(map[string]struct{}, len(s.bindings))
+		names := make([]string, 0, len(s.bindings))
+		for _, binding := range s.bindings {
+			if _, ok := seen[binding.providerName]; ok || binding.providerName == "" {
+				continue
+			}
+			seen[binding.providerName] = struct{}{}
+			names = append(names, binding.providerName)
+		}
+		slices.Sort(names)
+		return names
+	}
+	if s.providerName == "" {
+		return nil
+	}
+	return []string{s.providerName}
 }
 
 func cloneWorkflowAllowed(src map[string]struct{}) map[string]struct{} {
@@ -230,6 +284,7 @@ type workflowScheduleResponse struct {
 	Cron     string `json:"cron"`
 	Timezone string `json:"timezone"`
 	Target   struct {
+		Plugin     string         `json:"plugin"`
 		Operation  string         `json:"operation"`
 		Connection string         `json:"connection"`
 		Instance   string         `json:"instance"`
@@ -294,6 +349,9 @@ func TestWorkflowScheduleCRUD(t *testing.T) {
 	if created.Provider != "basic" || created.Target.Operation != "sync" || created.Target.Connection != "analytics" || created.Target.Instance != "tenant-a" {
 		t.Fatalf("created schedule = %#v", created)
 	}
+	if created.Target.Plugin != "roadmap" {
+		t.Fatalf("created target plugin = %q, want roadmap", created.Target.Plugin)
+	}
 	if len(provider.upsertReqs) != 1 {
 		t.Fatalf("upsert requests = %d, want 1", len(provider.upsertReqs))
 	}
@@ -328,6 +386,9 @@ func TestWorkflowScheduleCRUD(t *testing.T) {
 	}
 	if len(listed) != 1 || listed[0].ID != created.ID {
 		t.Fatalf("listed schedules = %#v", listed)
+	}
+	if listed[0].Target.Plugin != "roadmap" {
+		t.Fatalf("listed target plugin = %q, want roadmap", listed[0].Target.Plugin)
 	}
 
 	updateBody := bytes.NewBufferString(`{"cron":"0 * * * *","timezone":"UTC","target":{"operation":"sync","connection":"analytics","instance":"tenant-a","input":{"mode":"full"}},"paused":true}`)
@@ -926,5 +987,382 @@ func TestWorkflowScheduleCreatePinsResolvedInstance(t *testing.T) {
 	}
 	if provider.upsertReqs[0].Target.Instance != "tenant-a" {
 		t.Fatalf("stored target = %#v, want resolved instance tenant-a", provider.upsertReqs[0].Target)
+	}
+}
+
+func TestGlobalWorkflowScheduleCRUDAcrossProviders(t *testing.T) {
+	t.Parallel()
+
+	services := coretesting.NewStubServices(t)
+	user := seedUser(t, services, "ada@example.test")
+	seedToken(t, services, &core.IntegrationToken{
+		ID:          "roadmap-default-token",
+		UserID:      user.ID,
+		Integration: "roadmap",
+		Connection:  "default",
+		AccessToken: "roadmap-token",
+	})
+	seedToken(t, services, &core.IntegrationToken{
+		ID:          "analytics-default-token",
+		UserID:      user.ID,
+		Integration: "analytics",
+		Connection:  "default",
+		AccessToken: "analytics-token",
+	})
+	basicProvider := newMemoryWorkflowProvider()
+	advancedProvider := newMemoryWorkflowProvider()
+
+	ts := newTestServer(t, func(cfg *server.Config) {
+		cfg.Auth = &coretesting.StubAuthProvider{
+			N: "stub",
+			ValidateTokenFn: func(_ context.Context, token string) (*core.UserIdentity, error) {
+				if token != "ada-session" {
+					return nil, core.ErrNotFound
+				}
+				return &core.UserIdentity{Email: user.Email, DisplayName: "Ada"}, nil
+			},
+		}
+		cfg.Services = services
+		cfg.Providers = testutil.NewProviderRegistry(t,
+			&coretesting.StubIntegration{
+				N:        "roadmap",
+				ConnMode: core.ConnectionModeUser,
+				CatalogVal: &catalog.Catalog{
+					Name: "roadmap",
+					Operations: []catalog.CatalogOperation{
+						{ID: "sync", Method: http.MethodPost},
+					},
+				},
+			},
+			&coretesting.StubIntegration{
+				N:        "analytics",
+				ConnMode: core.ConnectionModeUser,
+				CatalogVal: &catalog.Catalog{
+					Name: "analytics",
+					Operations: []catalog.CatalogOperation{
+						{ID: "sync", Method: http.MethodPost},
+					},
+				},
+			},
+		)
+		cfg.Workflow = &stubWorkflowControl{
+			bindings: map[string]stubWorkflowBinding{
+				"roadmap":   {providerName: "basic", allowed: map[string]struct{}{"sync": {}}},
+				"analytics": {providerName: "advanced", allowed: map[string]struct{}{"sync": {}}},
+			},
+			providers: map[string]coreworkflow.Provider{
+				"basic":    basicProvider,
+				"advanced": advancedProvider,
+			},
+			providerList: []string{"advanced", "basic"},
+		}
+	})
+	testutil.CloseOnCleanup(t, ts)
+
+	createReq, _ := http.NewRequest(
+		http.MethodPost,
+		ts.URL+"/api/v1/workflow/schedules/",
+		bytes.NewBufferString(`{"cron":"*/5 * * * *","timezone":"UTC","target":{"plugin":"roadmap","operation":"sync","connection":"analytics","instance":"tenant-a","input":{"mode":"incremental"}}}`),
+	)
+	createReq.Header.Set("Content-Type", "application/json")
+	createReq.AddCookie(&http.Cookie{Name: "session_token", Value: "ada-session"})
+	createResp, err := http.DefaultClient.Do(createReq)
+	if err != nil {
+		t.Fatalf("create request: %v", err)
+	}
+	defer func() { _ = createResp.Body.Close() }()
+	if createResp.StatusCode != http.StatusCreated {
+		body, _ := io.ReadAll(createResp.Body)
+		t.Fatalf("expected 201, got %d: %s", createResp.StatusCode, body)
+	}
+
+	var created workflowScheduleResponse
+	if err := json.NewDecoder(createResp.Body).Decode(&created); err != nil {
+		t.Fatalf("decode create response: %v", err)
+	}
+	if created.Provider != "basic" || created.Target.Plugin != "roadmap" || created.Target.Operation != "sync" {
+		t.Fatalf("created schedule = %#v", created)
+	}
+	if len(basicProvider.upsertReqs) != 1 {
+		t.Fatalf("basic upsert requests = %d, want 1", len(basicProvider.upsertReqs))
+	}
+	if basicProvider.upsertReqs[0].Target.PluginName != "roadmap" {
+		t.Fatalf("basic create target = %#v", basicProvider.upsertReqs[0].Target)
+	}
+	initialExecutionRef := basicProvider.upsertReqs[0].ExecutionRef
+
+	listReq, _ := http.NewRequest(http.MethodGet, ts.URL+"/api/v1/workflow/schedules/", nil)
+	listReq.AddCookie(&http.Cookie{Name: "session_token", Value: "ada-session"})
+	listResp, err := http.DefaultClient.Do(listReq)
+	if err != nil {
+		t.Fatalf("list request: %v", err)
+	}
+	defer func() { _ = listResp.Body.Close() }()
+	if listResp.StatusCode != http.StatusOK {
+		body, _ := io.ReadAll(listResp.Body)
+		t.Fatalf("expected 200, got %d: %s", listResp.StatusCode, body)
+	}
+	var listed []workflowScheduleResponse
+	if err := json.NewDecoder(listResp.Body).Decode(&listed); err != nil {
+		t.Fatalf("decode list response: %v", err)
+	}
+	if len(listed) != 1 || listed[0].ID != created.ID || listed[0].Provider != "basic" || listed[0].Target.Plugin != "roadmap" {
+		t.Fatalf("listed schedules = %#v", listed)
+	}
+
+	updateReq, _ := http.NewRequest(
+		http.MethodPut,
+		ts.URL+"/api/v1/workflow/schedules/"+created.ID,
+		bytes.NewBufferString(`{"cron":"0 * * * *","timezone":"UTC","target":{"plugin":"analytics","operation":"sync","connection":"warehouse","instance":"tenant-b","input":{"mode":"full"}},"paused":true}`),
+	)
+	updateReq.Header.Set("Content-Type", "application/json")
+	updateReq.AddCookie(&http.Cookie{Name: "session_token", Value: "ada-session"})
+	updateResp, err := http.DefaultClient.Do(updateReq)
+	if err != nil {
+		t.Fatalf("update request: %v", err)
+	}
+	defer func() { _ = updateResp.Body.Close() }()
+	if updateResp.StatusCode != http.StatusOK {
+		body, _ := io.ReadAll(updateResp.Body)
+		t.Fatalf("expected 200, got %d: %s", updateResp.StatusCode, body)
+	}
+
+	var updated workflowScheduleResponse
+	if err := json.NewDecoder(updateResp.Body).Decode(&updated); err != nil {
+		t.Fatalf("decode update response: %v", err)
+	}
+	if updated.Provider != "advanced" || updated.Target.Plugin != "analytics" || !updated.Paused {
+		t.Fatalf("updated schedule = %#v", updated)
+	}
+	if len(advancedProvider.upsertReqs) != 1 {
+		t.Fatalf("advanced upsert requests = %d, want 1", len(advancedProvider.upsertReqs))
+	}
+	if len(basicProvider.deleteReqs) != 1 || basicProvider.deleteReqs[0].ScheduleID != created.ID {
+		t.Fatalf("basic delete requests = %#v", basicProvider.deleteReqs)
+	}
+	if _, ok := basicProvider.schedules[created.ID]; ok {
+		t.Fatal("expected global update to remove schedule from old provider")
+	}
+	if _, ok := advancedProvider.schedules[created.ID]; !ok {
+		t.Fatal("expected global update to store schedule in new provider")
+	}
+	updatedExecutionRef := advancedProvider.upsertReqs[0].ExecutionRef
+	if updatedExecutionRef == "" || updatedExecutionRef == initialExecutionRef {
+		t.Fatalf("updated execution ref = %q, want rotated from %q", updatedExecutionRef, initialExecutionRef)
+	}
+	oldRef, err := services.WorkflowExecutionRefs.Get(context.Background(), initialExecutionRef)
+	if err != nil {
+		t.Fatalf("Get initial execution ref: %v", err)
+	}
+	if oldRef.RevokedAt == nil || oldRef.RevokedAt.IsZero() {
+		t.Fatalf("expected initial execution ref to be revoked, got %#v", oldRef)
+	}
+
+	pauseReq, _ := http.NewRequest(http.MethodPost, ts.URL+"/api/v1/workflow/schedules/"+created.ID+"/pause", nil)
+	pauseReq.AddCookie(&http.Cookie{Name: "session_token", Value: "ada-session"})
+	pauseResp, err := http.DefaultClient.Do(pauseReq)
+	if err != nil {
+		t.Fatalf("pause request: %v", err)
+	}
+	defer func() { _ = pauseResp.Body.Close() }()
+	if pauseResp.StatusCode != http.StatusOK {
+		t.Fatalf("expected 200, got %d", pauseResp.StatusCode)
+	}
+	if len(advancedProvider.pauseReqs) != 1 {
+		t.Fatalf("advanced pause requests = %d, want 1", len(advancedProvider.pauseReqs))
+	}
+
+	resumeReq, _ := http.NewRequest(http.MethodPost, ts.URL+"/api/v1/workflow/schedules/"+created.ID+"/resume", nil)
+	resumeReq.AddCookie(&http.Cookie{Name: "session_token", Value: "ada-session"})
+	resumeResp, err := http.DefaultClient.Do(resumeReq)
+	if err != nil {
+		t.Fatalf("resume request: %v", err)
+	}
+	defer func() { _ = resumeResp.Body.Close() }()
+	if resumeResp.StatusCode != http.StatusOK {
+		t.Fatalf("expected 200, got %d", resumeResp.StatusCode)
+	}
+	if len(advancedProvider.resumeReqs) != 1 {
+		t.Fatalf("advanced resume requests = %d, want 1", len(advancedProvider.resumeReqs))
+	}
+
+	deleteReq, _ := http.NewRequest(http.MethodDelete, ts.URL+"/api/v1/workflow/schedules/"+created.ID, nil)
+	deleteReq.AddCookie(&http.Cookie{Name: "session_token", Value: "ada-session"})
+	deleteResp, err := http.DefaultClient.Do(deleteReq)
+	if err != nil {
+		t.Fatalf("delete request: %v", err)
+	}
+	defer func() { _ = deleteResp.Body.Close() }()
+	if deleteResp.StatusCode != http.StatusOK {
+		t.Fatalf("expected 200, got %d", deleteResp.StatusCode)
+	}
+	if _, ok := advancedProvider.schedules[created.ID]; ok {
+		t.Fatal("expected schedule to be deleted from current global provider")
+	}
+	finalRef, err := services.WorkflowExecutionRefs.Get(context.Background(), updatedExecutionRef)
+	if err != nil {
+		t.Fatalf("Get final execution ref: %v", err)
+	}
+	if finalRef.RevokedAt == nil || finalRef.RevokedAt.IsZero() {
+		t.Fatalf("expected final execution ref to be revoked, got %#v", finalRef)
+	}
+}
+
+func TestGlobalWorkflowScheduleListAndMutationsAreOwnerScopedAcrossProviders(t *testing.T) {
+	t.Parallel()
+
+	services := coretesting.NewStubServices(t)
+	ada := seedUser(t, services, "ada@example.test")
+	grace := seedUser(t, services, "grace@example.test")
+	basicProvider := newMemoryWorkflowProvider()
+	advancedProvider := newMemoryWorkflowProvider()
+	now := time.Now().UTC().Truncate(time.Second)
+
+	basicProvider.schedules["sched-ada-basic"] = &coreworkflow.Schedule{
+		ID:           "sched-ada-basic",
+		Cron:         "*/5 * * * *",
+		Target:       coreworkflow.Target{PluginName: "roadmap", Operation: "sync"},
+		ExecutionRef: "exec-ada-basic",
+		CreatedAt:    &now,
+		UpdatedAt:    &now,
+	}
+	advancedProvider.schedules["sched-ada-advanced"] = &coreworkflow.Schedule{
+		ID:           "sched-ada-advanced",
+		Cron:         "0 * * * *",
+		Target:       coreworkflow.Target{PluginName: "analytics", Operation: "sync"},
+		ExecutionRef: "exec-ada-advanced",
+		CreatedAt:    &now,
+		UpdatedAt:    &now,
+	}
+	advancedProvider.schedules["sched-grace-advanced"] = &coreworkflow.Schedule{
+		ID:           "sched-grace-advanced",
+		Cron:         "15 * * * *",
+		Target:       coreworkflow.Target{PluginName: "analytics", Operation: "sync"},
+		ExecutionRef: "exec-grace-advanced",
+		CreatedAt:    &now,
+		UpdatedAt:    &now,
+	}
+	for _, ref := range []*coreworkflow.ExecutionReference{
+		{
+			ID:           "exec-ada-basic",
+			ProviderName: "basic",
+			Target:       basicProvider.schedules["sched-ada-basic"].Target,
+			SubjectID:    principal.UserSubjectID(ada.ID),
+		},
+		{
+			ID:           "exec-ada-advanced",
+			ProviderName: "advanced",
+			Target:       advancedProvider.schedules["sched-ada-advanced"].Target,
+			SubjectID:    principal.UserSubjectID(ada.ID),
+		},
+		{
+			ID:           "exec-grace-advanced",
+			ProviderName: "advanced",
+			Target:       advancedProvider.schedules["sched-grace-advanced"].Target,
+			SubjectID:    principal.UserSubjectID(grace.ID),
+		},
+	} {
+		if _, err := services.WorkflowExecutionRefs.Put(context.Background(), ref); err != nil {
+			t.Fatalf("Put execution ref %q: %v", ref.ID, err)
+		}
+	}
+
+	ts := newTestServer(t, func(cfg *server.Config) {
+		cfg.Auth = &coretesting.StubAuthProvider{
+			N: "stub",
+			ValidateTokenFn: func(_ context.Context, token string) (*core.UserIdentity, error) {
+				switch token {
+				case "ada-session":
+					return &core.UserIdentity{Email: ada.Email, DisplayName: "Ada"}, nil
+				case "grace-session":
+					return &core.UserIdentity{Email: grace.Email, DisplayName: "Grace"}, nil
+				default:
+					return nil, core.ErrNotFound
+				}
+			},
+		}
+		cfg.Services = services
+		cfg.Providers = testutil.NewProviderRegistry(t,
+			&coretesting.StubIntegration{
+				N:        "roadmap",
+				ConnMode: core.ConnectionModeUser,
+				CatalogVal: &catalog.Catalog{
+					Name: "roadmap",
+					Operations: []catalog.CatalogOperation{
+						{ID: "sync", Method: http.MethodPost},
+					},
+				},
+			},
+			&coretesting.StubIntegration{
+				N:        "analytics",
+				ConnMode: core.ConnectionModeUser,
+				CatalogVal: &catalog.Catalog{
+					Name: "analytics",
+					Operations: []catalog.CatalogOperation{
+						{ID: "sync", Method: http.MethodPost},
+					},
+				},
+			},
+		)
+		cfg.Workflow = &stubWorkflowControl{
+			bindings: map[string]stubWorkflowBinding{
+				"roadmap":   {providerName: "basic", allowed: map[string]struct{}{"sync": {}}},
+				"analytics": {providerName: "advanced", allowed: map[string]struct{}{"sync": {}}},
+			},
+			providers: map[string]coreworkflow.Provider{
+				"basic":    basicProvider,
+				"advanced": advancedProvider,
+			},
+			providerList: []string{"advanced", "basic"},
+		}
+	})
+	testutil.CloseOnCleanup(t, ts)
+
+	listReq, _ := http.NewRequest(http.MethodGet, ts.URL+"/api/v1/workflow/schedules/", nil)
+	listReq.AddCookie(&http.Cookie{Name: "session_token", Value: "ada-session"})
+	listResp, err := http.DefaultClient.Do(listReq)
+	if err != nil {
+		t.Fatalf("list request: %v", err)
+	}
+	defer func() { _ = listResp.Body.Close() }()
+	if listResp.StatusCode != http.StatusOK {
+		t.Fatalf("expected 200, got %d", listResp.StatusCode)
+	}
+	var listed []workflowScheduleResponse
+	if err := json.NewDecoder(listResp.Body).Decode(&listed); err != nil {
+		t.Fatalf("decode list response: %v", err)
+	}
+	if len(listed) != 2 {
+		t.Fatalf("listed schedules = %#v", listed)
+	}
+	listedIDs := []string{listed[0].ID, listed[1].ID}
+	slices.Sort(listedIDs)
+	if !slices.Equal(listedIDs, []string{"sched-ada-advanced", "sched-ada-basic"}) {
+		t.Fatalf("listed schedules = %#v", listed)
+	}
+
+	getReq, _ := http.NewRequest(http.MethodGet, ts.URL+"/api/v1/workflow/schedules/sched-grace-advanced", nil)
+	getReq.AddCookie(&http.Cookie{Name: "session_token", Value: "ada-session"})
+	getResp, err := http.DefaultClient.Do(getReq)
+	if err != nil {
+		t.Fatalf("get request: %v", err)
+	}
+	defer func() { _ = getResp.Body.Close() }()
+	if getResp.StatusCode != http.StatusNotFound {
+		t.Fatalf("expected 404, got %d", getResp.StatusCode)
+	}
+
+	deleteReq, _ := http.NewRequest(http.MethodDelete, ts.URL+"/api/v1/workflow/schedules/sched-grace-advanced", nil)
+	deleteReq.AddCookie(&http.Cookie{Name: "session_token", Value: "ada-session"})
+	deleteResp, err := http.DefaultClient.Do(deleteReq)
+	if err != nil {
+		t.Fatalf("delete request: %v", err)
+	}
+	defer func() { _ = deleteResp.Body.Close() }()
+	if deleteResp.StatusCode != http.StatusNotFound {
+		t.Fatalf("expected 404, got %d", deleteResp.StatusCode)
+	}
+	if _, ok := advancedProvider.schedules["sched-grace-advanced"]; !ok {
+		t.Fatal("expected grace schedule to remain after unauthorized global delete")
 	}
 }


### PR DESCRIPTION
## Summary

Add top-level workflow schedule routes so schedules can be created and managed without going through a plugin-scoped URL.

New routes:
- `GET /api/v1/workflow/schedules`
- `POST /api/v1/workflow/schedules`
- `GET /api/v1/workflow/schedules/{scheduleID}`
- `PUT /api/v1/workflow/schedules/{scheduleID}`
- `DELETE /api/v1/workflow/schedules/{scheduleID}`
- `POST /api/v1/workflow/schedules/{scheduleID}/pause`
- `POST /api/v1/workflow/schedules/{scheduleID}/resume`

The existing plugin-scoped routes remain as compatibility wrappers:
- `/api/v1/{integration}/workflow/schedules/...`

## Interfaces

### Workflow control

```go
type WorkflowControl interface {
    ResolveBinding(pluginName string) (providerName string, operations map[string]struct{}, err error)
    ResolveProvider(name string) (coreworkflow.Provider, error)
    ProviderNames() []string
}
```

### Global schedule request target

```go
type workflowScheduleTargetRequest struct {
    Plugin     string         `json:"plugin,omitempty"`
    Operation  string         `json:"operation"`
    Connection string         `json:"connection,omitempty"`
    Instance   string         `json:"instance,omitempty"`
    Input      map[string]any `json:"input,omitempty"`
}
```

### Schedule response target

```go
type workflowScheduleInfo struct {
    ID       string `json:"id"`
    Provider string `json:"provider"`
    Target   struct {
        Plugin     string         `json:"plugin,omitempty"`
        Operation  string         `json:"operation"`
        Connection string         `json:"connection,omitempty"`
        Instance   string         `json:"instance,omitempty"`
        Input      map[string]any `json:"input,omitempty"`
    } `json:"target"`
}
```

## Examples

### Create a global schedule

```http
POST /api/v1/workflow/schedules
Content-Type: application/json

{
  "cron": "*/5 * * * *",
  "timezone": "UTC",
  "target": {
    "plugin": "roadmap",
    "operation": "sync",
    "connection": "analytics",
    "instance": "tenant-a",
    "input": {
      "mode": "incremental"
    }
  }
}
```

### Move an existing schedule to a different plugin binding

```http
PUT /api/v1/workflow/schedules/{scheduleID}
Content-Type: application/json

{
  "cron": "0 * * * *",
  "timezone": "UTC",
  "target": {
    "plugin": "analytics",
    "operation": "sync",
    "connection": "warehouse",
    "instance": "tenant-b",
    "input": {
      "mode": "full"
    }
  },
  "paused": true
}
```

## Behavior

- Derive the workflow provider from the target plugin binding.
- Search owned schedules across workflow providers by schedule ID.
- Preserve plugin-scoped routes as compatibility wrappers while returning explicit `target.plugin` in schedule responses.

## Testing

Augmented existing integration-style workflow schedule coverage to include:
- global workflow schedule CRUD across providers
- global owner scoping across providers
- existing plugin-scoped schedule CRUD and ownership paths

Validated with:
- `go test ./internal/server -run 'TestWorkflowSchedule(CRUD|ListAndMutationsAreOwnerScoped|APITokenScopeFiltersOperations|UpdateFailureKeepsExistingExecutionRef|CreatePinsResolvedInstance)|TestGlobalWorkflowSchedule(CRUDAcrossProviders|ListAndMutationsAreOwnerScopedAcrossProviders)|TestCreateWorkflowScheduleRejectsOperationOutsideWorkflowBinding' -count=1`
- `go test ./internal/bootstrap ./internal/coredata ./internal/server -count=1`
- `golangci-lint run ./internal/bootstrap ./internal/coredata ./internal/server`
- `git diff --check`