### PR TITLE
Add Debian apt packaging support

### DIFF
--- a/.github/scripts/rebuild-apt-repo.sh
+++ b/.github/scripts/rebuild-apt-repo.sh
@@ -1,0 +1,142 @@
+#!/usr/bin/env bash
+
+set -euo pipefail
+
+if [[ -z "${GITHUB_REPOSITORY:-}" ]]; then
+  printf 'GITHUB_REPOSITORY must be set\n' >&2
+  exit 1
+fi
+if [[ -z "${APT_GPG_KEY_ID:-}" ]]; then
+  printf 'APT_GPG_KEY_ID must be set\n' >&2
+  exit 1
+fi
+
+site_dir=
+
+while [[ $# -gt 0 ]]; do
+  case "$1" in
+    --site-dir)
+      site_dir="$2"
+      shift 2
+      ;;
+    *)
+      printf 'unknown argument: %s\n' "$1" >&2
+      exit 1
+      ;;
+  esac
+done
+
+if [[ -z "$site_dir" ]]; then
+  printf 'usage: %s --site-dir DIR\n' "$0" >&2
+  exit 1
+fi
+
+tmp_dir="$(mktemp -d)"
+trap 'rm -rf "${tmp_dir}"' EXIT
+
+repo_dir="${tmp_dir}/repo"
+mkdir -p "${repo_dir}/conf" "${site_dir}/apt"
+
+stable_suites=(jammy noble bookworm trixie)
+preview_suites=(jammy-preview noble-preview bookworm-preview trixie-preview)
+
+{
+  for suite in "${stable_suites[@]}"; do
+    cat <<EOF
+Origin: Gestalt
+Label: Gestalt
+Suite: ${suite}
+Codename: ${suite}
+Architectures: amd64 arm64 armhf source
+Components: main
+Description: Gestalt APT repository (${suite})
+SignWith: ${APT_GPG_KEY_ID}
+Acquire-By-Hash: yes
+
+EOF
+  done
+
+  for suite in "${preview_suites[@]}"; do
+    cat <<EOF
+Origin: Gestalt Preview
+Label: Gestalt Preview
+Suite: ${suite}
+Codename: ${suite}
+Architectures: amd64 arm64 armhf source
+Components: main
+Description: Gestalt APT preview repository (${suite})
+SignWith: ${APT_GPG_KEY_ID}
+Acquire-By-Hash: yes
+
+EOF
+  done
+} > "${repo_dir}/conf/distributions"
+
+gh api --paginate "repos/${GITHUB_REPOSITORY}/releases?per_page=100" | jq -s 'add' > "${tmp_dir}/releases.json"
+
+jq -r '
+  .[]
+  | select(.draft | not)
+  | select(.tag_name | test("^(gestalt|gestaltd)/v"))
+  | {tag_name, prerelease, deb_assets: [.assets[] | select(.name | endswith(".deb")) | .name]}
+  | select(.deb_assets | length > 0)
+  | @base64
+' "${tmp_dir}/releases.json" | while IFS= read -r encoded; do
+  release_json="$(printf '%s' "${encoded}" | base64 --decode)"
+  tag_name="$(printf '%s' "${release_json}" | jq -r '.tag_name')"
+  prerelease="$(printf '%s' "${release_json}" | jq -r '.prerelease')"
+  download_dir="${tmp_dir}/downloads/${tag_name//\//_}"
+  mkdir -p "${download_dir}"
+  gh release download "${tag_name}" --repo "${GITHUB_REPOSITORY}" --pattern "*.deb" --dir "${download_dir}"
+
+  if [[ "${prerelease}" == "true" ]]; then
+    suites=("${preview_suites[@]}")
+  else
+    suites=("${stable_suites[@]}")
+  fi
+
+  while IFS= read -r -d '' deb_file; do
+    for suite in "${suites[@]}"; do
+      reprepro -b "${repo_dir}" includedeb "${suite}" "${deb_file}"
+    done
+  done < <(find "${download_dir}" -type f -name '*.deb' -print0 | sort -z)
+done
+
+gpg --batch --yes --armor --export "${APT_GPG_KEY_ID}" > "${site_dir}/apt/gpg.asc"
+gpg --batch --yes --export "${APT_GPG_KEY_ID}" > "${site_dir}/apt/gpg"
+
+cat > "${site_dir}/index.html" <<'EOF'
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="utf-8">
+    <title>Gestalt APT Repository</title>
+  </head>
+  <body>
+    <h1>Gestalt APT Repository</h1>
+    <p>This site publishes the Debian and Ubuntu apt repository for Gestalt.</p>
+    <p>See the installation docs in the main repository for setup instructions.</p>
+  </body>
+</html>
+EOF
+
+cat > "${site_dir}/apt/index.html" <<'EOF'
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="utf-8">
+    <title>Gestalt APT Repository</title>
+  </head>
+  <body>
+    <h1>Gestalt APT Repository</h1>
+    <p>Use this repository with Debian or Ubuntu apt clients.</p>
+    <ul>
+      <li>Stable suites: <code>jammy</code>, <code>noble</code>, <code>bookworm</code>, <code>trixie</code></li>
+      <li>Preview suites: <code>jammy-preview</code>, <code>noble-preview</code>, <code>bookworm-preview</code>, <code>trixie-preview</code></li>
+    </ul>
+  </body>
+</html>
+EOF
+
+cp -R "${repo_dir}/dists" "${site_dir}/apt/"
+cp -R "${repo_dir}/pool" "${site_dir}/apt/"

--- a/.github/workflows/build-apt-packages.yml
+++ b/.github/workflows/build-apt-packages.yml
@@ -1,0 +1,113 @@
+name: Build APT Packages
+
+on:
+  push:
+    branches:
+      - main
+    paths:
+      - 'gestalt/**'
+      - 'gestaltd/**'
+      - 'packaging/deb/**'
+      - '.github/scripts/rebuild-apt-repo.sh'
+      - '.github/workflows/build-apt-packages.yml'
+      - '.github/workflows/publish-apt-repo.yml'
+      - '.github/workflows/release-gestalt-cli.yml'
+      - '.github/workflows/release-gestaltd.yml'
+      - '.github/workflows/rust-build-matrix.yml'
+  pull_request:
+    paths:
+      - 'gestalt/**'
+      - 'gestaltd/**'
+      - 'packaging/deb/**'
+      - '.github/scripts/rebuild-apt-repo.sh'
+      - '.github/workflows/build-apt-packages.yml'
+      - '.github/workflows/publish-apt-repo.yml'
+      - '.github/workflows/release-gestalt-cli.yml'
+      - '.github/workflows/release-gestaltd.yml'
+      - '.github/workflows/rust-build-matrix.yml'
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+jobs:
+  package:
+    name: Package Debian artifacts
+    runs-on: ubuntu-latest
+    timeout-minutes: 20
+
+    steps:
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
+
+      - uses: actions/setup-go@40f1582b2485089dde7abd97c1529aa768e1baff # v5
+        with:
+          go-version-file: gestaltd/go.mod
+          cache-dependency-path: gestaltd/go.sum
+
+      - uses: dtolnay/rust-toolchain@29eef336d9b2848a0b548edc03f92a220660cdb8 # stable
+        with:
+          toolchain: stable
+
+      - name: Install packaging dependencies
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y dpkg-dev systemd
+
+      - name: Verify packaging script syntax
+        run: |
+          bash -n ./.github/scripts/rebuild-apt-repo.sh
+          bash -n ./packaging/deb/lib.sh
+          bash -n ./packaging/deb/build-gestalt-deb.sh
+          bash -n ./packaging/deb/build-gestaltd-deb.sh
+
+      - name: Build CLI binary
+        working-directory: gestalt
+        run: cargo build --release
+
+      - name: Build server binary
+        run: |
+          mkdir -p dist
+          go build -ldflags "-X main.version=0.0.0-dev.0" -o dist/gestaltd ./gestaltd/cmd/gestaltd
+          cp gestalt/target/release/gestalt dist/gestalt
+
+      - name: Package Debian artifacts
+        run: |
+          ./packaging/deb/build-gestalt-deb.sh \
+            --binary dist/gestalt \
+            --version 0.0.0-dev.0 \
+            --arch amd64 \
+            --out-dir dist
+
+          ./packaging/deb/build-gestaltd-deb.sh \
+            --binary dist/gestaltd \
+            --version 0.0.0-dev.0 \
+            --arch amd64 \
+            --out-dir dist
+
+      - name: Smoke test via apt
+        run: |
+          repo_dir="$(mktemp -d)"
+          trap 'rm -rf "${repo_dir}"' EXIT
+          cp dist/*.deb "${repo_dir}/"
+          dpkg-scanpackages "${repo_dir}" /dev/null > "${repo_dir}/Packages"
+          gzip -9fk "${repo_dir}/Packages"
+
+          echo "deb [trusted=yes] file:${repo_dir} ./" | sudo tee /etc/apt/sources.list.d/gestalt-local.list
+          sudo apt-get update
+          sudo apt-get install -y gestalt gestaltd
+
+          gestalt --version
+          gestaltd version
+          id gestaltd
+          test -f /lib/systemd/system/gestaltd.service
+          test -f /usr/share/doc/gestaltd/examples/config.yaml
+          systemd-analyze verify /lib/systemd/system/gestaltd.service
+
+      - name: Upload package artifacts
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4
+        with:
+          name: apt-packages-amd64
+          path: |
+            dist/*.deb
+            dist/*.deb.sha256
+          if-no-files-found: error

--- a/.github/workflows/build-gestalt-cli.yml
+++ b/.github/workflows/build-gestalt-cli.yml
@@ -6,11 +6,13 @@ on:
       - main
     paths:
       - 'gestalt/**'
+      - 'packaging/deb/**'
       - '.github/workflows/build-gestalt-cli.yml'
       - '.github/workflows/rust-build-matrix.yml'
   pull_request:
     paths:
       - 'gestalt/**'
+      - 'packaging/deb/**'
       - '.github/workflows/build-gestalt-cli.yml'
       - '.github/workflows/rust-build-matrix.yml'
 

--- a/.github/workflows/publish-apt-repo.yml
+++ b/.github/workflows/publish-apt-repo.yml
@@ -1,0 +1,61 @@
+name: Publish APT Repository
+
+on:
+  release:
+    types:
+      - published
+  workflow_dispatch:
+
+permissions:
+  contents: read
+  pages: write
+  id-token: write
+
+concurrency:
+  group: apt-repository
+  cancel-in-progress: false
+
+jobs:
+  build:
+    if: ${{ github.event_name == 'workflow_dispatch' || startsWith(github.event.release.tag_name, 'gestalt/v') || startsWith(github.event.release.tag_name, 'gestaltd/v') }}
+    runs-on: ubuntu-latest
+    timeout-minutes: 20
+
+    steps:
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
+
+      - uses: actions/configure-pages@v5
+
+      - name: Install repository tooling
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y gnupg jq reprepro
+
+      - name: Import signing key
+        env:
+          APT_REPO_GPG_PRIVATE_KEY: ${{ secrets.APT_REPO_GPG_PRIVATE_KEY }}
+        run: |
+          printf '%s' "${APT_REPO_GPG_PRIVATE_KEY}" | gpg --batch --import
+
+      - name: Rebuild apt repository
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          APT_GPG_KEY_ID: ${{ secrets.APT_REPO_GPG_KEY_ID }}
+        run: ./.github/scripts/rebuild-apt-repo.sh --site-dir _site
+
+      - uses: actions/upload-pages-artifact@v3
+        with:
+          path: _site
+
+  deploy:
+    needs: build
+    if: ${{ needs.build.result == 'success' }}
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    environment:
+      name: github-pages
+      url: ${{ steps.deployment.outputs.page_url }}
+
+    steps:
+      - id: deployment
+        uses: actions/deploy-pages@v4

--- a/.github/workflows/release-gestalt-cli.yml
+++ b/.github/workflows/release-gestalt-cli.yml
@@ -19,6 +19,7 @@ jobs:
       working-directory: gestalt
       binary-name: gestalt
       artifact-prefix: gestalt
+      version-prefix: 'gestalt/v'
       run-tests: true
       package: true
       package-deb: true

--- a/.github/workflows/release-gestalt-cli.yml
+++ b/.github/workflows/release-gestalt-cli.yml
@@ -21,6 +21,7 @@ jobs:
       artifact-prefix: gestalt
       run-tests: true
       package: true
+      package-deb: true
 
   release:
     name: Publish Release
@@ -36,6 +37,7 @@ jobs:
         Command-line client for authenticating with Gestalt, connecting integrations, invoking operations, and managing API tokens from the terminal.
       install-markdown: |
         - Homebrew: `brew upgrade gestalt`
+        - Apt (Debian/Ubuntu): [APT install instructions](https://gestaltd.ai/install/apt)
         - Docker: `docker pull valontechnologies/gestalt:${version}`
         - Docs: [CLI reference](https://gestaltd.ai/reference/cli)
       exclude-subject-patterns: |

--- a/.github/workflows/release-gestaltd.yml
+++ b/.github/workflows/release-gestaltd.yml
@@ -68,12 +68,33 @@ jobs:
         run: |
           tar -czvf gestaltd-${{ matrix.platform.suffix }}.tar.gz -C build gestaltd
           shasum -a 256 gestaltd-${{ matrix.platform.suffix }}.tar.gz > gestaltd-${{ matrix.platform.suffix }}.tar.gz.sha256
+      - name: Package Debian artifact
+        if: ${{ startsWith(matrix.platform.suffix, 'linux-') }}
+        run: |
+          case "${{ matrix.platform.suffix }}" in
+            linux-x86_64) deb_arch="amd64" ;;
+            linux-arm64) deb_arch="arm64" ;;
+            linux-armv7) deb_arch="armhf" ;;
+            *)
+              echo "unsupported Debian package target: ${{ matrix.platform.suffix }}" >&2
+              exit 1
+              ;;
+          esac
+
+          mkdir -p dist
+          ./packaging/deb/build-gestaltd-deb.sh \
+            --binary build/gestaltd \
+            --version "${{ steps.version.outputs.version }}" \
+            --arch "${deb_arch}" \
+            --out-dir dist
       - uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4
         with:
           name: gestaltd-${{ matrix.platform.suffix }}
           path: |
             gestaltd-${{ matrix.platform.suffix }}.tar.gz
             gestaltd-${{ matrix.platform.suffix }}.tar.gz.sha256
+            dist/gestaltd_*.deb
+            dist/gestaltd_*.deb.sha256
           if-no-files-found: error
 
   release:
@@ -90,6 +111,7 @@ jobs:
         Self-hosted integration gateway for Gestalt with the embedded client UI, admin UI, HTTP API, and optional MCP endpoint.
       install-markdown: |
         - Homebrew: `brew upgrade gestaltd`
+        - Apt (Debian/Ubuntu): [APT install instructions](https://gestaltd.ai/install/apt)
         - Docker: `docker pull valontechnologies/gestaltd:${version}`
         - Docs: [Deployment guide](https://gestaltd.ai/deploy)
       exclude-subject-patterns: |

--- a/.github/workflows/release-gestaltd.yml
+++ b/.github/workflows/release-gestaltd.yml
@@ -66,8 +66,9 @@ jobs:
           )
       - name: Package
         run: |
-          tar -czvf gestaltd-${{ matrix.platform.suffix }}.tar.gz -C build gestaltd
-          shasum -a 256 gestaltd-${{ matrix.platform.suffix }}.tar.gz > gestaltd-${{ matrix.platform.suffix }}.tar.gz.sha256
+          mkdir -p dist
+          tar -czvf dist/gestaltd-${{ matrix.platform.suffix }}.tar.gz -C build gestaltd
+          shasum -a 256 dist/gestaltd-${{ matrix.platform.suffix }}.tar.gz > dist/gestaltd-${{ matrix.platform.suffix }}.tar.gz.sha256
       - name: Package Debian artifact
         if: ${{ startsWith(matrix.platform.suffix, 'linux-') }}
         run: |
@@ -91,8 +92,8 @@ jobs:
         with:
           name: gestaltd-${{ matrix.platform.suffix }}
           path: |
-            gestaltd-${{ matrix.platform.suffix }}.tar.gz
-            gestaltd-${{ matrix.platform.suffix }}.tar.gz.sha256
+            dist/gestaltd-${{ matrix.platform.suffix }}.tar.gz
+            dist/gestaltd-${{ matrix.platform.suffix }}.tar.gz.sha256
             dist/gestaltd_*.deb
             dist/gestaltd_*.deb.sha256
           if-no-files-found: error

--- a/.github/workflows/rust-build-matrix.yml
+++ b/.github/workflows/rust-build-matrix.yml
@@ -15,6 +15,10 @@ on:
         description: 'Prefix for artifact names (e.g., gestalt)'
         type: string
         default: 'gestalt'
+      version-prefix:
+        description: 'Tag prefix to strip when deriving package versions'
+        type: string
+        default: ''
       package:
         description: 'Create tar.gz + sha256 packages'
         type: boolean
@@ -135,6 +139,8 @@ jobs:
 
       - name: Package Debian artifact
         if: ${{ inputs.package-deb && matrix.platform.cross }}
+        env:
+          VERSION_PREFIX: ${{ inputs.version-prefix }}
         run: |
           case "${{ matrix.platform.suffix }}" in
             linux-x86_64) deb_arch="amd64" ;;
@@ -146,10 +152,19 @@ jobs:
               ;;
           esac
 
+          version="${GITHUB_REF_NAME}"
+          if [ -n "${VERSION_PREFIX}" ]; then
+            version="${GITHUB_REF_NAME#${VERSION_PREFIX}}"
+            if [ "${version}" = "${GITHUB_REF_NAME}" ]; then
+              echo "expected GITHUB_REF_NAME to start with ${VERSION_PREFIX}, got ${GITHUB_REF_NAME}" >&2
+              exit 1
+            fi
+          fi
+
           mkdir -p dist
           ./packaging/deb/build-gestalt-deb.sh \
             --binary "${{ inputs.working-directory }}/target/${{ matrix.platform.target }}/release/${{ inputs.binary-name }}" \
-            --version "${GITHUB_REF_NAME#gestalt/v}" \
+            --version "${version}" \
             --arch "${deb_arch}" \
             --out-dir dist
 

--- a/.github/workflows/rust-build-matrix.yml
+++ b/.github/workflows/rust-build-matrix.yml
@@ -19,6 +19,10 @@ on:
         description: 'Create tar.gz + sha256 packages'
         type: boolean
         default: false
+      package-deb:
+        description: 'Create Debian packages for Linux targets'
+        type: boolean
+        default: false
       run-tests:
         description: 'Run tests on native targets'
         type: boolean
@@ -129,6 +133,26 @@ jobs:
           tar -czvf ${{ inputs.artifact-prefix }}-${{ matrix.platform.suffix }}.tar.gz ${{ inputs.binary-name }}
           shasum -a 256 ${{ inputs.artifact-prefix }}-${{ matrix.platform.suffix }}.tar.gz > ${{ inputs.artifact-prefix }}-${{ matrix.platform.suffix }}.tar.gz.sha256
 
+      - name: Package Debian artifact
+        if: ${{ inputs.package-deb && matrix.platform.cross }}
+        run: |
+          case "${{ matrix.platform.suffix }}" in
+            linux-x86_64) deb_arch="amd64" ;;
+            linux-arm64) deb_arch="arm64" ;;
+            linux-armv7) deb_arch="armhf" ;;
+            *)
+              echo "unsupported Debian package target: ${{ matrix.platform.suffix }}" >&2
+              exit 1
+              ;;
+          esac
+
+          mkdir -p dist
+          ./packaging/deb/build-gestalt-deb.sh \
+            --binary "${{ inputs.working-directory }}/target/${{ matrix.platform.target }}/release/${{ inputs.binary-name }}" \
+            --version "${GITHUB_REF_NAME#gestalt/v}" \
+            --arch "${deb_arch}" \
+            --out-dir dist
+
       - name: Package binary (Windows)
         if: ${{ inputs.package && matrix.platform.windows }}
         shell: pwsh
@@ -147,6 +171,7 @@ jobs:
           name: ${{ inputs.artifact-prefix }}-${{ matrix.platform.suffix }}
           path: |
             dist/${{ inputs.artifact-prefix }}-${{ matrix.platform.suffix }}.tar.gz*
+            dist/${{ inputs.artifact-prefix }}_*.deb*
             dist/${{ inputs.artifact-prefix }}-${{ matrix.platform.suffix }}.zip*
           if-no-files-found: error
 

--- a/docs/content/install/_meta.ts
+++ b/docs/content/install/_meta.ts
@@ -1,4 +1,5 @@
 export default {
+  apt: "Apt (Debian/Ubuntu)",
   homebrew: "Homebrew",
   binary: "Binary Releases",
   source: "Build from Source",

--- a/docs/content/install/apt.mdx
+++ b/docs/content/install/apt.mdx
@@ -1,0 +1,84 @@
+# Apt (Debian/Ubuntu)
+
+Gestalt publishes Debian packages for Ubuntu and Debian through the official apt repository hosted at:
+
+```text
+https://valon-technologies.github.io/gestalt/apt
+```
+
+Supported architectures:
+
+- `amd64`
+- `arm64`
+- `armhf`
+
+Current Gestalt releases are alpha builds. Until the first stable release is published, use the `*-preview` suites described below.
+
+## Add the signing key
+
+```sh
+sudo apt update
+sudo apt install curl gpg
+curl -fsSL https://valon-technologies.github.io/gestalt/apt/gpg.asc \
+  | sudo gpg --dearmor -o /usr/share/keyrings/gestalt-archive-keyring.gpg
+```
+
+## Add the repository
+
+### Stable suites
+
+Use these once stable Gestalt releases are available:
+
+```sh
+codename="$(. /etc/os-release && echo "${VERSION_CODENAME}")"
+echo "deb [arch=$(dpkg --print-architecture) signed-by=/usr/share/keyrings/gestalt-archive-keyring.gpg] https://valon-technologies.github.io/gestalt/apt ${codename} main" \
+  | sudo tee /etc/apt/sources.list.d/gestalt.list
+```
+
+### Preview suites
+
+Use these for the current alpha releases:
+
+```sh
+codename="$(. /etc/os-release && echo "${VERSION_CODENAME}")"
+echo "deb [arch=$(dpkg --print-architecture) signed-by=/usr/share/keyrings/gestalt-archive-keyring.gpg] https://valon-technologies.github.io/gestalt/apt ${codename}-preview main" \
+  | sudo tee /etc/apt/sources.list.d/gestalt.list
+```
+
+## Install
+
+`apt` and `apt-get` use the same repository. After the repo is configured, either command works.
+
+```sh
+sudo apt update
+sudo apt install gestaltd gestalt
+```
+
+## Verify
+
+```sh
+gestaltd version
+gestalt --version
+```
+
+## Configure the server service
+
+The `gestaltd` package installs a `systemd` unit, creates the `gestaltd` system user, and prepares `/var/lib/gestaltd`, but it does not generate a live config or auto-start the daemon.
+
+Create a config from the packaged example:
+
+```sh
+sudo install -d -m 0755 /etc/gestaltd
+sudo cp /usr/share/doc/gestaltd/examples/config.yaml /etc/gestaltd/config.yaml
+sudo editor /etc/gestaltd/config.yaml
+```
+
+At minimum, replace the placeholder `server.encryptionKey` before starting the service.
+
+Then enable the daemon:
+
+```sh
+sudo systemctl enable --now gestaltd
+```
+
+For a local developer quick start, running `gestaltd` directly can still be simpler because it auto-generates `~/.gestaltd/config.yaml` when no config exists. See [Getting Started](/getting-started).

--- a/docs/content/install/homebrew.mdx
+++ b/docs/content/install/homebrew.mdx
@@ -2,7 +2,7 @@
 
 Gestalt publishes a Homebrew tap for macOS and Linux.
 
-If you need a direct-download install or a Linux-specific release artifact, see [Binary Releases](/install/binary).
+If you need Debian or Ubuntu packages, see [Apt](/install/apt). If you need a direct-download install or a Linux-specific release artifact, see [Binary Releases](/install/binary).
 
 Tap the repository first:
 

--- a/docs/content/install/index.mdx
+++ b/docs/content/install/index.mdx
@@ -6,6 +6,10 @@ asIndexPage: true
 
 Gestalt ships two binaries: `gestaltd` (the server) and `gestalt` (the CLI client). Install both to get started.
 
+## Apt (Debian/Ubuntu)
+
+Official Debian packages for Ubuntu and Debian. Current alpha releases are published under the `*-preview` suites. See [Apt](/install/apt).
+
 ## Homebrew
 
 The fastest path on macOS and Linux. See [Homebrew](/install/homebrew).

--- a/packaging/deb/build-gestalt-deb.sh
+++ b/packaging/deb/build-gestalt-deb.sh
@@ -1,0 +1,69 @@
+#!/usr/bin/env bash
+
+set -euo pipefail
+
+script_dir="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+source "${script_dir}/lib.sh"
+
+binary=
+version=
+arch=
+out_dir=
+
+while [[ $# -gt 0 ]]; do
+  case "$1" in
+    --binary)
+      binary="$2"
+      shift 2
+      ;;
+    --version)
+      version="$2"
+      shift 2
+      ;;
+    --arch)
+      arch="$2"
+      shift 2
+      ;;
+    --out-dir)
+      out_dir="$2"
+      shift 2
+      ;;
+    *)
+      printf 'unknown argument: %s\n' "$1" >&2
+      exit 1
+      ;;
+  esac
+done
+
+if [[ -z "$binary" || -z "$version" || -z "$arch" || -z "$out_dir" ]]; then
+  printf 'usage: %s --binary PATH --version VERSION --arch ARCH --out-dir DIR\n' "$0" >&2
+  exit 1
+fi
+
+pkg_arch="$(debian_arch "$arch")"
+pkg_version="$(debian_version "$version")"
+pkg_name="gestalt"
+stage_dir="$(mktemp -d)"
+trap 'rm -rf "${stage_dir}"' EXIT
+
+mkdir -p "${stage_dir}/DEBIAN" "${stage_dir}/usr/bin"
+install -m 0755 "$binary" "${stage_dir}/usr/bin/gestalt"
+
+cat > "${stage_dir}/DEBIAN/control" <<EOF
+Package: ${pkg_name}
+Version: ${pkg_version}
+Section: utils
+Priority: optional
+Architecture: ${pkg_arch}
+Maintainer: ${GESTALT_PACKAGE_MAINTAINER}
+Depends: ca-certificates
+Homepage: ${GESTALT_PACKAGE_HOMEPAGE}
+Description: Gestalt CLI
+ Command-line client for authenticating with Gestalt, connecting plugins,
+ invoking operations, and managing API tokens from the terminal.
+EOF
+
+mkdir -p "$out_dir"
+pkg_file="${out_dir}/${pkg_name}_${pkg_version}_${pkg_arch}.deb"
+dpkg-deb --build --root-owner-group "${stage_dir}" "${pkg_file}"
+write_sha256_file "${pkg_file}"

--- a/packaging/deb/build-gestaltd-deb.sh
+++ b/packaging/deb/build-gestaltd-deb.sh
@@ -1,0 +1,79 @@
+#!/usr/bin/env bash
+
+set -euo pipefail
+
+script_dir="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+source "${script_dir}/lib.sh"
+
+binary=
+version=
+arch=
+out_dir=
+
+while [[ $# -gt 0 ]]; do
+  case "$1" in
+    --binary)
+      binary="$2"
+      shift 2
+      ;;
+    --version)
+      version="$2"
+      shift 2
+      ;;
+    --arch)
+      arch="$2"
+      shift 2
+      ;;
+    --out-dir)
+      out_dir="$2"
+      shift 2
+      ;;
+    *)
+      printf 'unknown argument: %s\n' "$1" >&2
+      exit 1
+      ;;
+  esac
+done
+
+if [[ -z "$binary" || -z "$version" || -z "$arch" || -z "$out_dir" ]]; then
+  printf 'usage: %s --binary PATH --version VERSION --arch ARCH --out-dir DIR\n' "$0" >&2
+  exit 1
+fi
+
+pkg_arch="$(debian_arch "$arch")"
+pkg_version="$(debian_version "$version")"
+pkg_name="gestaltd"
+stage_dir="$(mktemp -d)"
+trap 'rm -rf "${stage_dir}"' EXIT
+
+mkdir -p \
+  "${stage_dir}/DEBIAN" \
+  "${stage_dir}/usr/bin" \
+  "${stage_dir}/lib/systemd/system" \
+  "${stage_dir}/usr/share/doc/gestaltd/examples"
+
+install -m 0755 "$binary" "${stage_dir}/usr/bin/gestaltd"
+install -m 0644 "${script_dir}/gestaltd.service" "${stage_dir}/lib/systemd/system/gestaltd.service"
+install -m 0644 "${script_dir}/gestaltd.config.yaml" "${stage_dir}/usr/share/doc/gestaltd/examples/config.yaml"
+install -m 0755 "${script_dir}/gestaltd.postinst" "${stage_dir}/DEBIAN/postinst"
+install -m 0755 "${script_dir}/gestaltd.postrm" "${stage_dir}/DEBIAN/postrm"
+
+cat > "${stage_dir}/DEBIAN/control" <<EOF
+Package: ${pkg_name}
+Version: ${pkg_version}
+Section: admin
+Priority: optional
+Architecture: ${pkg_arch}
+Maintainer: ${GESTALT_PACKAGE_MAINTAINER}
+Depends: adduser, ca-certificates
+Recommends: systemd
+Homepage: ${GESTALT_PACKAGE_HOMEPAGE}
+Description: Gestalt server daemon
+ Self-hosted integration gateway for Gestalt with the embedded client UI,
+ admin UI, HTTP API, and optional MCP endpoint.
+EOF
+
+mkdir -p "$out_dir"
+pkg_file="${out_dir}/${pkg_name}_${pkg_version}_${pkg_arch}.deb"
+dpkg-deb --build --root-owner-group "${stage_dir}" "${pkg_file}"
+write_sha256_file "${pkg_file}"

--- a/packaging/deb/gestaltd.config.yaml
+++ b/packaging/deb/gestaltd.config.yaml
@@ -1,0 +1,26 @@
+apiVersion: gestaltd.config/v3
+server:
+  public:
+    port: 8080
+  encryptionKey: "replace-with-64-hex-characters"
+  providers:
+    indexeddb: main
+providers:
+  indexeddb:
+    main:
+      source: https://github.com/valon-technologies/gestalt-providers/releases/download/indexeddb/relationaldb/v0.0.1-alpha.1/provider-release.yaml
+      config:
+        dsn: sqlite:///var/lib/gestaltd/gestalt.db
+  ui:
+    root:
+      source: https://github.com/valon-technologies/gestalt-providers/releases/download/web/default/v0.0.1-alpha.1/provider-release.yaml
+      path: /
+  secrets:
+    env:
+      source: env
+plugins:
+  httpbin:
+    displayName: HTTPBin
+    source: https://github.com/valon-technologies/gestalt-providers/releases/download/plugins/httpbin/v0.0.1-alpha.1/provider-release.yaml
+    allowedHosts:
+      - httpbin.org

--- a/packaging/deb/gestaltd.postinst
+++ b/packaging/deb/gestaltd.postinst
@@ -1,0 +1,28 @@
+#!/bin/sh
+
+set -eu
+
+case "$1" in
+  configure)
+    if ! getent group gestaltd >/dev/null 2>&1; then
+      addgroup --system gestaltd
+    fi
+    if ! id gestaltd >/dev/null 2>&1; then
+      adduser \
+        --system \
+        --ingroup gestaltd \
+        --home /var/lib/gestaltd \
+        --no-create-home \
+        --shell /usr/sbin/nologin \
+        gestaltd
+    fi
+    install -d -o root -g root -m 0755 /etc/gestaltd
+    install -d -o gestaltd -g gestaltd -m 0750 /var/lib/gestaltd
+    install -d -o gestaltd -g gestaltd -m 0750 /var/lib/gestaltd/artifacts
+    if command -v systemctl >/dev/null 2>&1; then
+      systemctl daemon-reload >/dev/null 2>&1 || true
+    fi
+    ;;
+esac
+
+exit 0

--- a/packaging/deb/gestaltd.postrm
+++ b/packaging/deb/gestaltd.postrm
@@ -1,0 +1,13 @@
+#!/bin/sh
+
+set -eu
+
+case "$1" in
+  remove|purge|upgrade|failed-upgrade|disappear)
+    if command -v systemctl >/dev/null 2>&1; then
+      systemctl daemon-reload >/dev/null 2>&1 || true
+    fi
+    ;;
+esac
+
+exit 0

--- a/packaging/deb/gestaltd.service
+++ b/packaging/deb/gestaltd.service
@@ -1,0 +1,16 @@
+[Unit]
+Description=Gestalt server daemon
+After=network-online.target
+Wants=network-online.target
+ConditionPathExists=/etc/gestaltd/config.yaml
+
+[Service]
+User=gestaltd
+Group=gestaltd
+WorkingDirectory=/var/lib/gestaltd
+ExecStart=/usr/bin/gestaltd serve --config /etc/gestaltd/config.yaml --artifacts-dir /var/lib/gestaltd/artifacts --lockfile /var/lib/gestaltd/gestalt.lock.json
+Restart=on-failure
+RestartSec=3
+
+[Install]
+WantedBy=multi-user.target

--- a/packaging/deb/lib.sh
+++ b/packaging/deb/lib.sh
@@ -1,0 +1,44 @@
+#!/usr/bin/env bash
+
+set -euo pipefail
+
+readonly GESTALT_PACKAGE_MAINTAINER="Gestalt Maintainers <opensource@valon.com>"
+readonly GESTALT_PACKAGE_HOMEPAGE="https://github.com/valon-technologies/gestalt"
+
+debian_arch() {
+  local arch="$1"
+  case "$arch" in
+    amd64|x86_64|linux-x86_64)
+      printf 'amd64\n'
+      ;;
+    arm64|aarch64|linux-arm64)
+      printf 'arm64\n'
+      ;;
+    armhf|armv7|linux-armv7)
+      printf 'armhf\n'
+      ;;
+    *)
+      printf 'unsupported Debian architecture: %s\n' "$arch" >&2
+      return 1
+      ;;
+  esac
+}
+
+debian_version() {
+  local version="$1"
+  local marker=
+  for marker in alpha beta rc dev; do
+    if [[ "$version" == *"-${marker}."* ]]; then
+      local base="${version%%-"${marker}".*}"
+      local suffix="${version#${base}-}"
+      printf '%s~%s-1\n' "$base" "$suffix"
+      return 0
+    fi
+  done
+  printf '%s-1\n' "$version"
+}
+
+write_sha256_file() {
+  local file="$1"
+  sha256sum "$file" > "${file}.sha256"
+}


### PR DESCRIPTION
## Summary
- add Debian package builders for both `gestalt` and `gestaltd`
- publish `.deb` artifacts from the existing release workflows and add an apt repository publisher
- add Debian/Ubuntu install docs plus a CI smoke test for the new packaging path

## What changed
- added `packaging/deb/*` scripts and assets to build `gestalt` and `gestaltd` Debian packages
- extended the CLI and server release workflows so Linux releases now attach `.deb` packages alongside existing tarballs
- added `publish-apt-repo.yml` plus `.github/scripts/rebuild-apt-repo.sh` to rebuild a signed apt repository from GitHub Releases and deploy it to GitHub Pages
- added `build-apt-packages.yml` to validate package generation and local apt installation on CI
- added `/install/apt` docs and linked it from the install docs index and Homebrew page

## Notes
- stable suites are documented, but current alpha releases are intended to be installed from the `*-preview` suites
- the publisher workflow expects two repo secrets to exist before it can run successfully:
  - `APT_REPO_GPG_PRIVATE_KEY`
  - `APT_REPO_GPG_KEY_ID`

## Verification
- `bash -n` passed for the packaging and apt-repo scripts
- `npm run build` passed in `docs`
- I could not complete the local containerized apt install smoke test because Docker is installed on this machine but the daemon is not running; the PR adds CI coverage for that path