### PR TITLE
runtime: centralize principal canonicalization

### DIFF
--- a/gestaltd/internal/bootstrap/workflow_runtime.go
+++ b/gestaltd/internal/bootstrap/workflow_runtime.go
@@ -351,23 +351,12 @@ func workflowExecutionPrincipal(ref *coreworkflow.ExecutionReference) *principal
 	if ref == nil {
 		return nil
 	}
-	subjectID := strings.TrimSpace(ref.SubjectID)
 	permissions := principal.CompilePermissions(ref.Permissions)
-	value := &principal.Principal{
-		SubjectID:        subjectID,
+	return principal.Canonicalize(&principal.Principal{
+		SubjectID:        strings.TrimSpace(ref.SubjectID),
 		Scopes:           principal.PermissionPlugins(permissions),
 		TokenPermissions: permissions,
-	}
-	switch {
-	case principal.UserIDFromSubjectID(subjectID) != "":
-		value.UserID = principal.UserIDFromSubjectID(subjectID)
-		value.Kind = principal.KindUser
-	case strings.HasPrefix(subjectID, string(principal.KindWorkload)+":"),
-		principal.ManagedIdentityIDFromSubjectID(subjectID) != "",
-		subjectID == principal.IdentitySubjectID():
-		value.Kind = principal.KindWorkload
-	}
-	return value
+	})
 }
 
 func workflowInvocationParams(req coreworkflow.InvokeOperationRequest) map[string]any {

--- a/gestaltd/internal/invocation/audit.go
+++ b/gestaltd/internal/invocation/audit.go
@@ -89,6 +89,8 @@ func BuildAuditEntry(ctx context.Context, p *principal.Principal, source, provid
 	ctx, meta := ensureMeta(ctx)
 	if p == nil {
 		p = principal.FromContext(ctx)
+	} else {
+		p = principal.Canonicalized(p)
 	}
 	return ctx, buildAuditEntry(ctx, p, source, providerName, operation, meta)
 }

--- a/gestaltd/internal/invocation/broker.go
+++ b/gestaltd/internal/invocation/broker.go
@@ -463,9 +463,7 @@ func (b *Broker) resolveUserPrincipal(ctx context.Context, p *principal.Principa
 	if p.Kind == "" {
 		p.Kind = principal.KindUser
 	}
-	if p.SubjectID == "" {
-		p.SubjectID = principal.UserSubjectID(dbUser.ID)
-	}
+	principal.Canonicalize(p)
 	if p.Identity != nil && p.Identity.DisplayName == "" {
 		p.Identity.DisplayName = dbUser.DisplayName
 	}

--- a/gestaltd/internal/principal/principal.go
+++ b/gestaltd/internal/principal/principal.go
@@ -316,12 +316,20 @@ func clonePermissionOps(src map[string]struct{}) map[string]struct{} {
 type contextKey struct{}
 
 func WithPrincipal(ctx context.Context, p *Principal) context.Context {
-	return context.WithValue(ctx, contextKey{}, Canonicalize(p))
+	return context.WithValue(ctx, contextKey{}, Canonicalized(p))
 }
 
 func FromContext(ctx context.Context) *Principal {
 	p, _ := ctx.Value(contextKey{}).(*Principal)
 	return Canonicalize(p)
+}
+
+func Canonicalized(p *Principal) *Principal {
+	if p == nil {
+		return nil
+	}
+	clone := *p
+	return Canonicalize(&clone)
 }
 
 func Canonicalize(p *Principal) *Principal {
@@ -334,6 +342,14 @@ func Canonicalize(p *Principal) *Principal {
 			if p.Kind == "" {
 				p.Kind = KindUser
 			}
+		}
+	}
+	if p.Kind == "" {
+		switch {
+		case strings.HasPrefix(p.SubjectID, string(KindWorkload)+":"),
+			ManagedIdentityIDFromSubjectID(p.SubjectID) != "",
+			p.SubjectID == IdentitySubjectID():
+			p.Kind = KindWorkload
 		}
 	}
 	if p.SubjectID == "" && p.UserID != "" {

--- a/gestaltd/internal/server/audit.go
+++ b/gestaltd/internal/server/audit.go
@@ -46,12 +46,7 @@ func (s *Server) resolvePrincipalUserID(ctx context.Context, p *principal.Princi
 		p.Kind = principal.KindUser
 	}
 	if p.UserID != "" {
-		if p.SubjectID == "" {
-			clone := *p
-			clone.SubjectID = principal.UserSubjectID(p.UserID)
-			return &clone, nil
-		}
-		return p, nil
+		return principal.Canonicalized(p), nil
 	}
 	if p.Identity == nil || p.Identity.Email == "" {
 		return p, nil
@@ -68,8 +63,7 @@ func (s *Server) resolvePrincipalUserID(ctx context.Context, p *principal.Princi
 	clone := *p
 	clone.UserID = dbUser.ID
 	clone.Kind = principal.KindUser
-	clone.SubjectID = principal.UserSubjectID(dbUser.ID)
-	return &clone, nil
+	return principal.Canonicalize(&clone), nil
 }
 
 func auditSourceForRequest(r *http.Request) string {
@@ -105,11 +99,8 @@ func (s *Server) auditEventWithUserIDAndTarget(ctx context.Context, userID, auth
 		return
 	}
 
-	ctx, entry := invocation.BuildAuditEntry(ctx, nil, source, provider, operation)
-	entry.UserID = userID
+	ctx, entry := invocation.BuildAuditEntry(ctx, &principal.Principal{UserID: userID}, source, provider, operation)
 	entry.AuthSource = authSource
-	entry.SubjectID = principal.UserSubjectID(userID)
-	entry.SubjectKind = string(principal.KindUser)
 	populateAuditEntry(&entry, allowed, err, target, auditAuthorization{})
 	s.auditSink.Log(ctx, entry)
 }

--- a/gestaltd/internal/server/handlers_identities.go
+++ b/gestaltd/internal/server/handlers_identities.go
@@ -1295,21 +1295,17 @@ func managedIdentityGrantValidationPrincipal(p *principal.Principal, userID stri
 		return p
 	}
 	if p == nil {
-		return &principal.Principal{
-			Kind:      principal.KindUser,
-			UserID:    userID,
-			SubjectID: principal.UserSubjectID(userID),
-		}
+		return principal.Canonicalize(&principal.Principal{
+			Kind:   principal.KindUser,
+			UserID: userID,
+		})
 	}
 	if p.UserID == userID {
-		return p
+		return principal.Canonicalized(p)
 	}
 	clone := *p
 	clone.UserID = userID
-	if strings.TrimSpace(clone.SubjectID) == "" {
-		clone.SubjectID = principal.UserSubjectID(userID)
-	}
-	return &clone
+	return principal.Canonicalize(&clone)
 }
 
 type managedIdentitySessionTokenResolver interface {

--- a/gestaltd/internal/server/handlers_workflow.go
+++ b/gestaltd/internal/server/handlers_workflow.go
@@ -293,15 +293,10 @@ func (s *Server) resumeWorkflowSchedule(w http.ResponseWriter, r *http.Request) 
 }
 
 func (s *Server) resolveWorkflowScheduleActor(w http.ResponseWriter, r *http.Request) (*principal.Principal, bool) {
-	p := PrincipalFromContext(r.Context())
+	p := principal.Canonicalized(PrincipalFromContext(r.Context()))
 	if p == nil {
 		writeError(w, http.StatusUnauthorized, "missing authorization")
 		return nil, false
-	}
-	if strings.TrimSpace(p.SubjectID) == "" && strings.TrimSpace(p.UserID) != "" {
-		cloned := *p
-		cloned.SubjectID = principal.UserSubjectID(strings.TrimSpace(p.UserID))
-		p = &cloned
 	}
 	if strings.TrimSpace(p.SubjectID) == "" {
 		writeError(w, http.StatusUnauthorized, "missing subject")
@@ -511,13 +506,11 @@ func (s *Server) putWorkflowExecutionRef(
 }
 
 func workflowExecutionRefSubjectID(p *principal.Principal) string {
+	p = principal.Canonicalized(p)
 	if p == nil {
 		return ""
 	}
-	if value := strings.TrimSpace(p.SubjectID); value != "" {
-		return value
-	}
-	return principal.UserSubjectID(strings.TrimSpace(p.UserID))
+	return strings.TrimSpace(p.SubjectID)
 }
 
 func workflowScheduleExecutionRefID(scheduleID string) string {
@@ -525,6 +518,7 @@ func workflowScheduleExecutionRefID(scheduleID string) string {
 }
 
 func workflowActorFromPrincipal(p *principal.Principal) coreworkflow.Actor {
+	p = principal.Canonicalized(p)
 	if p == nil {
 		return coreworkflow.Actor{}
 	}


### PR DESCRIPTION
## Summary
This removes the remaining hand-written runtime branches that repaired `SubjectID` from `UserID` in audit, workflow, invocation, and managed-identity code.

Instead of each path rebuilding `user:<id>` independently, they now route through the principal package’s canonicalization helper.

## Go Interface Change
This PR adds a non-mutating helper in `internal/principal`:

```go
func Canonicalized(p *Principal) *Principal
```

Usage pattern:

Before:
```go
if p.SubjectID == "" && p.UserID != "" {
    clone := *p
    clone.SubjectID = principal.UserSubjectID(p.UserID)
    p = &clone
}
```

After:
```go
p = principal.Canonicalized(p)
```

## What Changed
- `principal.WithPrincipal(...)` now stores a canonicalized copy instead of mutating the caller’s principal.
- `invocation.BuildAuditEntry(...)` canonicalizes explicit principals before reading audit fields.
- `server/audit.go` no longer rebuilds `user:<id>` by hand.
- workflow schedule actor / execution-ref paths now use canonical principals instead of ad hoc subject repair.
- managed-identity grant validation principals now canonicalize through the principal package.
- broker user resolution now sets `UserID` and lets canonicalization fill `SubjectID`.

## Why This Is Not Trivial
The logic being deleted was duplicated, but it was duplicated across runtime paths that care about slightly different things:
- audit logs need stable `user_id` and `subject_id`
- workflow schedule ownership keys off `subject_id`
- invocation still needs concrete `user_id` for token lookup
- managed-identity grant validation swaps the acting user while preserving the rest of the principal

So the safe cut is not just deleting `UserSubjectID(...)` calls. It is centralizing normalization while preserving the places that still need `UserID` as runtime metadata.

## Database Migration
No database migration is required.

This PR does not change authorization-provider storage, relationship data, models, or any database schema. It only removes duplicated in-process principal normalization logic in `gestaltd`.

## Authorization Providers
No authorization provider changes are required.

This PR does not change the provider contract or the stored selector format. It only changes how `gestaltd` canonicalizes principals before audit/workflow/invocation logic uses them.

## Verification
```bash
cd gestaltd
go test ./internal/principal ./internal/invocation ./internal/server ./internal/bootstrap ./internal/authorization
golangci-lint run ./internal/principal ./internal/invocation ./internal/server ./internal/bootstrap
```