### PR TITLE
authz: remove redundant user subject reconstruction

### DIFF
--- a/gestaltd/internal/authorization/authorizer.go
+++ b/gestaltd/internal/authorization/authorizer.go
@@ -442,7 +442,7 @@ func (p *HumanPolicy) roleForPrincipal(pr *principal.Principal) (string, bool) {
 	if p == nil || pr == nil {
 		return "", false
 	}
-	return p.staticRoleForIdentity(principal.Canonicalize(pr).SubjectID)
+	return p.staticRoleForIdentity(principal.Canonicalized(pr).SubjectID)
 }
 
 func (p *HumanPolicy) staticRoleForIdentity(subjectID string) (string, bool) {

--- a/gestaltd/internal/authorization/provider_backed.go
+++ b/gestaltd/internal/authorization/provider_backed.go
@@ -721,11 +721,12 @@ func roleSortKey(role string) string {
 }
 
 func staticSubjectRefs(p *principal.Principal) []*core.SubjectRef {
+	p = principal.Canonicalized(p)
 	if p == nil {
 		return nil
 	}
-	out := make([]*core.SubjectRef, 0, 3)
-	seen := make(map[string]struct{}, 3)
+	out := make([]*core.SubjectRef, 0, 1)
+	seen := make(map[string]struct{}, 1)
 	appendSubject := func(kind, id string) {
 		id = strings.TrimSpace(id)
 		if id == "" {
@@ -739,7 +740,6 @@ func staticSubjectRefs(p *principal.Principal) []*core.SubjectRef {
 		out = append(out, &core.SubjectRef{Type: kind, Id: id})
 	}
 	appendSubject(subjectTypeSubject, p.SubjectID)
-	appendSubject(subjectTypeSubject, principal.UserSubjectID(p.UserID))
 	return out
 }
 

--- a/gestaltd/internal/server/handlers_admin_authorization.go
+++ b/gestaltd/internal/server/handlers_admin_authorization.go
@@ -189,7 +189,7 @@ func (s *Server) putAdminAuthorizationPluginMember(w http.ResponseWriter, r *htt
 		Effective:     true,
 		Mutable:       true,
 		SelectorKind:  "subject_id",
-		SelectorValue: adminAuthorizationUserSubjectID(membership.UserID),
+		SelectorValue: principal.UserSubjectID(strings.TrimSpace(membership.UserID)),
 	}
 	if err := s.reloadAuthorizationState(r.Context()); err != nil {
 		writeJSON(w, http.StatusAccepted, map[string]any{
@@ -312,7 +312,7 @@ func (s *Server) putAdminAuthorizationAdminMember(w http.ResponseWriter, r *http
 		Effective:     true,
 		Mutable:       true,
 		SelectorKind:  "subject_id",
-		SelectorValue: adminAuthorizationUserSubjectID(membership.UserID),
+		SelectorValue: principal.UserSubjectID(strings.TrimSpace(membership.UserID)),
 	}
 	if err := s.reloadAuthorizationState(r.Context()); err != nil {
 		writeJSON(w, http.StatusAccepted, map[string]any{
@@ -512,10 +512,6 @@ func (r adminAuthorizationMemberRow) adminAuthorizationRowKey() string {
 	return r.Source + ":" + r.SelectorKind + ":" + r.SelectorValue
 }
 
-func adminAuthorizationUserSubjectID(userID string) string {
-	return principal.UserSubjectID(strings.TrimSpace(userID))
-}
-
 func adminAuthorizationRowSubjectID(row adminAuthorizationMemberRow) string {
 	return strings.TrimSpace(row.SelectorValue)
 }
@@ -525,11 +521,7 @@ func adminAuthorizationUserIDFromSubjectID(subjectID string) (string, error) {
 	if subjectID == "" {
 		return "", errors.New("subjectID is required")
 	}
-	prefix := string(principal.KindUser) + ":"
-	if !strings.HasPrefix(subjectID, prefix) {
-		return "", errors.New("subjectID must use user:<id>")
-	}
-	userID := strings.TrimSpace(strings.TrimPrefix(subjectID, prefix))
+	userID := strings.TrimSpace(principal.UserIDFromSubjectID(subjectID))
 	if userID == "" {
 		return "", errors.New("subjectID must use user:<id>")
 	}

--- a/gestaltd/internal/server/handlers_admin_authorization_provider.go
+++ b/gestaltd/internal/server/handlers_admin_authorization_provider.go
@@ -9,6 +9,7 @@ import (
 
 	"github.com/valon-technologies/gestalt/server/core"
 	"github.com/valon-technologies/gestalt/server/internal/authorization"
+	"github.com/valon-technologies/gestalt/server/internal/principal"
 )
 
 const (
@@ -235,7 +236,7 @@ func (s *Server) adminAuthorizationDynamicRowFromProviderRelationship(ctx contex
 			return adminAuthorizationMemberRow{}, false, nil
 		}
 		row.SelectorKind = "subject_id"
-		row.SelectorValue = adminAuthorizationUserSubjectID(userID)
+		row.SelectorValue = principal.UserSubjectID(userID)
 	default:
 		return adminAuthorizationMemberRow{}, false, nil
 	}


### PR DESCRIPTION
## Summary
This trims a few remaining places that were still rebuilding or parsing `user:<id>` locally instead of relying on the canonical principal and subject helpers.

## What Changed
- `HumanPolicy.roleForPrincipal(...)` now uses `principal.Canonicalized(...)` instead of mutating the caller with `Canonicalize(...)`.
- `provider_backed.staticSubjectRefs(...)` now canonicalizes the principal once and emits only the canonical subject ref instead of redundantly appending both `p.SubjectID` and `user:<p.UserID>`.
- admin authorization handlers now use `principal.UserSubjectID(...)` directly when shaping rows.
- admin authorization subject parsing now delegates to `principal.UserIDFromSubjectID(...)` instead of open-coding the same `user:<id>` parsing logic.

## Go Before / After
Before:
```go
func (p *HumanPolicy) roleForPrincipal(pr *principal.Principal) (string, bool) {
    return p.staticRoleForIdentity(principal.Canonicalize(pr).SubjectID)
}
```

After:
```go
func (p *HumanPolicy) roleForPrincipal(pr *principal.Principal) (string, bool) {
    return p.staticRoleForIdentity(principal.Canonicalized(pr).SubjectID)
}
```

Before:
```go
appendSubject(subjectTypeSubject, p.SubjectID)
appendSubject(subjectTypeSubject, principal.UserSubjectID(p.UserID))
```

After:
```go
p = principal.Canonicalized(p)
appendSubject(subjectTypeSubject, p.SubjectID)
```

## Why This Is Safe
This does not change selector format or authorization semantics. It removes duplicated reconstruction/parsing in favor of the canonical helpers that `gestaltd` already uses after `#1176` and `#1179`.

## Database Migration
No database migration is required.

This PR does not change persisted relationships, models, or schemas.

## Authorization Providers
No authorization provider changes are required.

This PR only removes redundant in-process reconstruction/parsing in `gestaltd`.

## Verification
```bash
cd gestaltd
go test ./internal/authorization ./internal/server ./internal/bootstrap
golangci-lint run ./internal/authorization ./internal/server ./internal/bootstrap
```