### PR TITLE
server: drop trivial subject-id wrapper helpers

### DIFF
--- a/gestaltd/internal/server/audit.go
+++ b/gestaltd/internal/server/audit.go
@@ -36,17 +36,15 @@ type auditAuthorization struct {
 }
 
 func (s *Server) resolvePrincipalUserID(ctx context.Context, p *principal.Principal) (*principal.Principal, error) {
+	p = principal.Canonicalized(p)
 	if p == nil {
 		return nil, nil
 	}
 	if p.Kind == principal.KindWorkload {
 		return p, nil
 	}
-	if p.Kind == "" {
-		p.Kind = principal.KindUser
-	}
 	if p.UserID != "" {
-		return principal.Canonicalized(p), nil
+		return p, nil
 	}
 	if p.Identity == nil || p.Identity.Email == "" {
 		return p, nil

--- a/gestaltd/internal/server/handlers_admin_authorization.go
+++ b/gestaltd/internal/server/handlers_admin_authorization.go
@@ -459,11 +459,11 @@ func mergeAdminAuthorizationRows(staticRows, dynamicRows []adminAuthorizationMem
 	for i := range staticRows {
 		row := &staticRows[i]
 		rows = append(rows, *row)
-		staticBySubjectID[adminAuthorizationRowSubjectID(*row)] = row.adminAuthorizationRowKey()
+		staticBySubjectID[strings.TrimSpace(row.SelectorValue)] = row.adminAuthorizationRowKey()
 	}
 	for i := range dynamicRows {
 		row := dynamicRows[i]
-		if shadow, ok := staticBySubjectID[adminAuthorizationRowSubjectID(row)]; ok {
+		if shadow, ok := staticBySubjectID[strings.TrimSpace(row.SelectorValue)]; ok {
 			row.Effective = false
 			row.ShadowedBy = shadow
 		}
@@ -510,10 +510,6 @@ func (s *Server) reloadAuthorizationState(ctx context.Context) error {
 
 func (r adminAuthorizationMemberRow) adminAuthorizationRowKey() string {
 	return r.Source + ":" + r.SelectorKind + ":" + r.SelectorValue
-}
-
-func adminAuthorizationRowSubjectID(row adminAuthorizationMemberRow) string {
-	return strings.TrimSpace(row.SelectorValue)
 }
 
 func adminAuthorizationUserIDFromSubjectID(subjectID string) (string, error) {

--- a/gestaltd/internal/server/handlers_workflow.go
+++ b/gestaltd/internal/server/handlers_workflow.go
@@ -795,7 +795,11 @@ func (s *Server) putWorkflowExecutionRef(
 	if s.workflowExecutionRefs == nil {
 		return nil, fmt.Errorf("workflow execution refs are not configured")
 	}
-	subjectID := workflowExecutionRefSubjectID(p)
+	p = principal.Canonicalized(p)
+	subjectID := ""
+	if p != nil {
+		subjectID = strings.TrimSpace(p.SubjectID)
+	}
 	if subjectID == "" {
 		return nil, fmt.Errorf("workflow execution ref subject is required")
 	}
@@ -806,14 +810,6 @@ func (s *Server) putWorkflowExecutionRef(
 		SubjectID:    subjectID,
 		Permissions:  principal.PermissionsToAccessPermissions(p.TokenPermissions),
 	})
-}
-
-func workflowExecutionRefSubjectID(p *principal.Principal) string {
-	p = principal.Canonicalized(p)
-	if p == nil {
-		return ""
-	}
-	return strings.TrimSpace(p.SubjectID)
 }
 
 func workflowScheduleExecutionRefID(scheduleID string) string {


### PR DESCRIPTION
## Summary
This removes a few now-trivial helper wrappers from the server authz/runtime path and leans directly on the canonical principal/subject helpers already in use after `#1176`, `#1179`, and `#1180`.

## What Changed
- `resolvePrincipalUserID(...)` now canonicalizes the incoming principal first instead of mutating it just to default the kind.
- `putWorkflowExecutionRef(...)` now canonicalizes the principal inline and reads `SubjectID` directly.
- removed `workflowExecutionRefSubjectID(...)`.
- removed `adminAuthorizationRowSubjectID(...)` and inlined its `strings.TrimSpace(row.SelectorValue)` usage.

## Why This Is Safe
This does not change selector format, persisted data, or authorization semantics.
It only removes wrappers that had become one-line pass-throughs after the earlier canonicalization work.

## Database Migration
No database migration is required.

## Authorization Providers
No authorization provider changes are required.

## Verification
```bash
cd gestaltd
go test ./internal/server ./internal/bootstrap ./internal/authorization
golangci-lint run ./internal/server ./internal/bootstrap ./internal/authorization
```