### PR TITLE
cli: add `workflows` subcommand for workflow schedules

### DIFF
--- a/gestalt/cli/src/cli.rs
+++ b/gestalt/cli/src/cli.rs
@@ -63,6 +63,12 @@ pub enum Commands {
         #[command(subcommand)]
         command: IdentityCommands,
     },
+
+    /// Manage workflow resources (schedules)
+    Workflows {
+        #[command(subcommand)]
+        command: WorkflowCommands,
+    },
 }
 
 #[derive(Subcommand)]
@@ -359,6 +365,138 @@ pub enum IdentityTokenCommands {
         /// Token ID
         id: String,
     },
+}
+
+#[derive(Subcommand)]
+pub enum WorkflowCommands {
+    /// Manage workflow schedules
+    Schedules {
+        #[command(subcommand)]
+        command: WorkflowScheduleCommands,
+    },
+}
+
+#[derive(Subcommand)]
+pub enum WorkflowScheduleCommands {
+    /// List workflow schedules
+    List {
+        /// Filter schedules by target plugin
+        #[arg(long)]
+        plugin: Option<String>,
+    },
+    /// Show a single workflow schedule
+    Get {
+        /// Schedule ID
+        id: String,
+    },
+    /// Create a workflow schedule
+    Create(WorkflowScheduleCreateArgs),
+    /// Update an existing workflow schedule
+    Update(WorkflowScheduleUpdateArgs),
+    /// Delete a workflow schedule
+    Delete {
+        /// Schedule ID
+        id: String,
+    },
+    /// Pause a workflow schedule
+    Pause {
+        /// Schedule ID
+        id: String,
+    },
+    /// Resume a paused workflow schedule
+    Resume {
+        /// Schedule ID
+        id: String,
+    },
+}
+
+#[derive(Args)]
+pub struct WorkflowScheduleCreateArgs {
+    /// Cron expression (e.g. "0 */5 * * *")
+    #[arg(long)]
+    pub cron: String,
+
+    /// Target plugin (e.g. "slack", "github")
+    #[arg(long)]
+    pub plugin: String,
+
+    /// Target operation (e.g. "chat.postMessage")
+    #[arg(long)]
+    pub operation: String,
+
+    /// IANA timezone for the cron expression
+    #[arg(long)]
+    pub timezone: Option<String>,
+
+    /// Select a named connection
+    #[arg(long)]
+    pub connection: Option<String>,
+
+    /// Select a stored connection instance
+    #[arg(long)]
+    pub instance: Option<String>,
+
+    /// Create the schedule in paused state
+    #[arg(long)]
+    pub paused: bool,
+
+    /// Target input parameters as key=value or key:=json
+    #[arg(short = 'p', long = "param", value_parser = params::parse_param_entry)]
+    pub params: Vec<params::ParamEntry>,
+
+    /// Load target input from a JSON file (use "-" for stdin)
+    #[arg(long = "input-file")]
+    pub input_file: Option<String>,
+}
+
+#[derive(Args)]
+pub struct WorkflowScheduleUpdateArgs {
+    /// Schedule ID
+    pub id: String,
+
+    /// Cron expression (leave unset to keep existing)
+    #[arg(long)]
+    pub cron: Option<String>,
+
+    /// Target plugin (leave unset to keep existing)
+    #[arg(long)]
+    pub plugin: Option<String>,
+
+    /// Target operation (leave unset to keep existing)
+    #[arg(long)]
+    pub operation: Option<String>,
+
+    /// IANA timezone (leave unset to keep existing; pass empty string to clear)
+    #[arg(long)]
+    pub timezone: Option<String>,
+
+    /// Named connection (leave unset to keep existing; pass empty string to clear)
+    #[arg(long)]
+    pub connection: Option<String>,
+
+    /// Stored connection instance (leave unset to keep existing; pass empty string to clear)
+    #[arg(long)]
+    pub instance: Option<String>,
+
+    /// Mark the schedule as paused
+    #[arg(long, conflicts_with = "unpaused", action = clap::ArgAction::SetTrue)]
+    pub paused: bool,
+
+    /// Mark the schedule as not paused
+    #[arg(long = "no-paused", action = clap::ArgAction::SetTrue)]
+    pub unpaused: bool,
+
+    /// Replace target input with these key=value / key:=json entries
+    #[arg(short = 'p', long = "param", value_parser = params::parse_param_entry)]
+    pub params: Vec<params::ParamEntry>,
+
+    /// Replace target input with the contents of this JSON file ("-" for stdin)
+    #[arg(long = "input-file")]
+    pub input_file: Option<String>,
+
+    /// Clear the target input instead of keeping the existing value
+    #[arg(long = "clear-input", conflicts_with_all = ["params", "input_file"])]
+    pub clear_input: bool,
 }
 
 #[derive(clap::ValueEnum, Clone, Copy, Debug, PartialEq, Eq)]

--- a/gestalt/cli/src/commands/mod.rs
+++ b/gestalt/cli/src/commands/mod.rs
@@ -6,3 +6,4 @@ pub mod init;
 pub mod invoke;
 pub mod plugins;
 pub mod tokens;
+pub mod workflows;

--- a/gestalt/cli/src/commands/workflows.rs
+++ b/gestalt/cli/src/commands/workflows.rs
@@ -1,0 +1,298 @@
+use anyhow::{Context, Result, anyhow};
+use serde_json::{Map, Value, json};
+
+use crate::api::ApiClient;
+use crate::cli::{WorkflowScheduleCreateArgs, WorkflowScheduleUpdateArgs};
+use crate::output::{self, Format};
+use crate::params::{self, ParamEntry};
+
+const SCHEDULES_PATH: &str = "/api/v1/workflow/schedules";
+
+pub fn list(client: &ApiClient, plugin: Option<&str>, format: Format) -> Result<()> {
+    let resp = client
+        .get(SCHEDULES_PATH)
+        .context("failed to list workflow schedules")?;
+    let filtered = filter_by_plugin(resp, plugin);
+    print_schedules(&filtered, format);
+    Ok(())
+}
+
+pub fn get(client: &ApiClient, id: &str, format: Format) -> Result<()> {
+    let resp = client
+        .get(&format!("{SCHEDULES_PATH}/{id}"))
+        .with_context(|| format!("failed to get workflow schedule {id}"))?;
+    print_schedule(&resp, format);
+    Ok(())
+}
+
+pub fn create(client: &ApiClient, args: &WorkflowScheduleCreateArgs, format: Format) -> Result<()> {
+    let input = build_target_input(&args.params, args.input_file.as_deref())?;
+    let body = build_upsert_body(
+        &args.cron,
+        args.timezone.as_deref(),
+        &args.plugin,
+        &args.operation,
+        args.connection.as_deref(),
+        args.instance.as_deref(),
+        input.as_ref(),
+        args.paused,
+    );
+
+    let resp = client
+        .post(SCHEDULES_PATH, &body)
+        .context("failed to create workflow schedule")?;
+    print_schedule(&resp, format);
+    Ok(())
+}
+
+pub fn update(client: &ApiClient, args: &WorkflowScheduleUpdateArgs, format: Format) -> Result<()> {
+    let existing = client
+        .get(&format!("{SCHEDULES_PATH}/{id}", id = args.id))
+        .with_context(|| format!("failed to load workflow schedule {}", args.id))?;
+
+    let body = merge_update(args, &existing)?;
+    let resp = client
+        .put(&format!("{SCHEDULES_PATH}/{id}", id = args.id), &body)
+        .with_context(|| format!("failed to update workflow schedule {}", args.id))?;
+    print_schedule(&resp, format);
+    Ok(())
+}
+
+pub fn delete(client: &ApiClient, id: &str, format: Format) -> Result<()> {
+    let resp = client
+        .delete(&format!("{SCHEDULES_PATH}/{id}"))
+        .with_context(|| format!("failed to delete workflow schedule {id}"))?;
+    match format {
+        Format::Json => output::print_json(&resp),
+        Format::Table => output::print_success(&format!("Workflow schedule {id} deleted.")),
+    }
+    Ok(())
+}
+
+pub fn pause(client: &ApiClient, id: &str, format: Format) -> Result<()> {
+    let resp = client
+        .post(&format!("{SCHEDULES_PATH}/{id}/pause"), &json!({}))
+        .with_context(|| format!("failed to pause workflow schedule {id}"))?;
+    print_schedule(&resp, format);
+    Ok(())
+}
+
+pub fn resume(client: &ApiClient, id: &str, format: Format) -> Result<()> {
+    let resp = client
+        .post(&format!("{SCHEDULES_PATH}/{id}/resume"), &json!({}))
+        .with_context(|| format!("failed to resume workflow schedule {id}"))?;
+    print_schedule(&resp, format);
+    Ok(())
+}
+
+fn filter_by_plugin(value: Value, plugin: Option<&str>) -> Value {
+    let Some(plugin) = plugin else {
+        return value;
+    };
+    let Value::Array(items) = value else {
+        return value;
+    };
+    Value::Array(
+        items
+            .into_iter()
+            .filter(|item| item["target"]["plugin"].as_str() == Some(plugin))
+            .collect(),
+    )
+}
+
+fn build_target_input(
+    params: &[ParamEntry],
+    input_file: Option<&str>,
+) -> Result<Option<Map<String, Value>>> {
+    let file_map = match input_file {
+        Some(path) => Some(params::load_input_file(path)?),
+        None => None,
+    };
+    let param_map = params::assemble_params(params, None, "")?;
+
+    if file_map.is_none() && param_map.is_empty() {
+        return Ok(None);
+    }
+    let merged = match file_map {
+        Some(file) => params::merge_params(file, param_map),
+        None => param_map,
+    };
+    if merged.is_empty() {
+        Ok(None)
+    } else {
+        Ok(Some(merged))
+    }
+}
+
+#[allow(clippy::too_many_arguments)]
+fn build_upsert_body(
+    cron: &str,
+    timezone: Option<&str>,
+    plugin: &str,
+    operation: &str,
+    connection: Option<&str>,
+    instance: Option<&str>,
+    input: Option<&Map<String, Value>>,
+    paused: bool,
+) -> Value {
+    let mut target = Map::new();
+    target.insert("plugin".to_string(), Value::String(plugin.to_string()));
+    target.insert(
+        "operation".to_string(),
+        Value::String(operation.to_string()),
+    );
+    if let Some(connection) = connection {
+        target.insert(
+            "connection".to_string(),
+            Value::String(connection.to_string()),
+        );
+    }
+    if let Some(instance) = instance {
+        target.insert("instance".to_string(), Value::String(instance.to_string()));
+    }
+    if let Some(input) = input {
+        target.insert("input".to_string(), Value::Object(input.clone()));
+    }
+
+    let mut body = Map::new();
+    body.insert("cron".to_string(), Value::String(cron.to_string()));
+    if let Some(timezone) = timezone {
+        body.insert("timezone".to_string(), Value::String(timezone.to_string()));
+    }
+    body.insert("target".to_string(), Value::Object(target));
+    body.insert("paused".to_string(), Value::Bool(paused));
+    Value::Object(body)
+}
+
+fn merge_update(args: &WorkflowScheduleUpdateArgs, existing: &Value) -> Result<Value> {
+    let cron = match args.cron.as_deref() {
+        Some(value) => value.to_string(),
+        None => existing["cron"]
+            .as_str()
+            .ok_or_else(|| anyhow!("existing schedule is missing cron; pass --cron"))?
+            .to_string(),
+    };
+
+    let timezone = resolve_optional_string(args.timezone.as_deref(), existing["timezone"].as_str());
+
+    let plugin = match args.plugin.as_deref() {
+        Some(value) => value.to_string(),
+        None => existing["target"]["plugin"]
+            .as_str()
+            .ok_or_else(|| anyhow!("existing schedule is missing target.plugin; pass --plugin"))?
+            .to_string(),
+    };
+    let operation = match args.operation.as_deref() {
+        Some(value) => value.to_string(),
+        None => existing["target"]["operation"]
+            .as_str()
+            .ok_or_else(|| {
+                anyhow!("existing schedule is missing target.operation; pass --operation")
+            })?
+            .to_string(),
+    };
+    let connection = resolve_optional_string(
+        args.connection.as_deref(),
+        existing["target"]["connection"].as_str(),
+    );
+    let instance = resolve_optional_string(
+        args.instance.as_deref(),
+        existing["target"]["instance"].as_str(),
+    );
+
+    let input = if args.clear_input {
+        None
+    } else if !args.params.is_empty() || args.input_file.is_some() {
+        build_target_input(&args.params, args.input_file.as_deref())?
+    } else {
+        existing["target"]["input"].as_object().cloned()
+    };
+
+    let paused = if args.paused {
+        true
+    } else if args.unpaused {
+        false
+    } else {
+        existing["paused"].as_bool().unwrap_or(false)
+    };
+
+    Ok(build_upsert_body(
+        &cron,
+        timezone.as_deref(),
+        &plugin,
+        &operation,
+        connection.as_deref(),
+        instance.as_deref(),
+        input.as_ref(),
+        paused,
+    ))
+}
+
+fn resolve_optional_string(arg: Option<&str>, existing: Option<&str>) -> Option<String> {
+    match arg {
+        Some("") => None,
+        Some(value) => Some(value.to_string()),
+        None => existing.map(str::to_string),
+    }
+}
+
+fn print_schedule(value: &Value, format: Format) {
+    match format {
+        Format::Json => output::print_json(value),
+        Format::Table => {
+            let rows = vec![schedule_row(value)];
+            output::print_table(&schedule_headers(), &rows);
+        }
+    }
+}
+
+fn print_schedules(value: &Value, format: Format) {
+    match format {
+        Format::Json => output::print_json(value),
+        Format::Table => {
+            let items = value.as_array().cloned().unwrap_or_default();
+            let rows: Vec<Vec<String>> = items.iter().map(schedule_row).collect();
+            output::print_table(&schedule_headers(), &rows);
+        }
+    }
+}
+
+fn schedule_headers() -> [&'static str; 8] {
+    [
+        "ID",
+        "Plugin",
+        "Operation",
+        "Cron",
+        "TZ",
+        "Paused",
+        "Next Run",
+        "Created",
+    ]
+}
+
+fn schedule_row(value: &Value) -> Vec<String> {
+    vec![
+        value["id"].as_str().unwrap_or("-").to_string(),
+        value["target"]["plugin"]
+            .as_str()
+            .unwrap_or("-")
+            .to_string(),
+        value["target"]["operation"]
+            .as_str()
+            .unwrap_or("-")
+            .to_string(),
+        value["cron"].as_str().unwrap_or("-").to_string(),
+        value["timezone"].as_str().unwrap_or("-").to_string(),
+        format_bool(value["paused"].as_bool()),
+        value["nextRunAt"].as_str().unwrap_or("-").to_string(),
+        value["createdAt"].as_str().unwrap_or("-").to_string(),
+    ]
+}
+
+fn format_bool(value: Option<bool>) -> String {
+    match value {
+        Some(true) => "yes".to_string(),
+        Some(false) => "no".to_string(),
+        None => "-".to_string(),
+    }
+}

--- a/gestalt/cli/src/main.rs
+++ b/gestalt/cli/src/main.rs
@@ -3,7 +3,7 @@ use gestalt::api::{self, ApiClient};
 use gestalt::cli::{
     AuthCommands, Cli, Commands, ConfigCommands, DescribeArgs, IdentityCommands,
     IdentityGrantCommands, IdentityMemberCommands, IdentityTokenCommands, InvokeArgs,
-    PluginCommands, TokenCommands,
+    PluginCommands, TokenCommands, WorkflowCommands, WorkflowScheduleCommands,
 };
 use gestalt::commands;
 use gestalt::output;
@@ -122,6 +122,34 @@ fn run() -> anyhow::Result<()> {
                     ),
                     IdentityTokenCommands::Revoke { identity, id } => {
                         commands::identities::revoke_token(&client, &identity, &id, format)
+                    }
+                },
+            }
+        }
+        Commands::Workflows { command } => {
+            let client = ApiClient::from_env(url)?;
+            match command {
+                WorkflowCommands::Schedules { command } => match command {
+                    WorkflowScheduleCommands::List { plugin } => {
+                        commands::workflows::list(&client, plugin.as_deref(), format)
+                    }
+                    WorkflowScheduleCommands::Get { id } => {
+                        commands::workflows::get(&client, &id, format)
+                    }
+                    WorkflowScheduleCommands::Create(args) => {
+                        commands::workflows::create(&client, &args, format)
+                    }
+                    WorkflowScheduleCommands::Update(args) => {
+                        commands::workflows::update(&client, &args, format)
+                    }
+                    WorkflowScheduleCommands::Delete { id } => {
+                        commands::workflows::delete(&client, &id, format)
+                    }
+                    WorkflowScheduleCommands::Pause { id } => {
+                        commands::workflows::pause(&client, &id, format)
+                    }
+                    WorkflowScheduleCommands::Resume { id } => {
+                        commands::workflows::resume(&client, &id, format)
                     }
                 },
             }

--- a/gestalt/cli/tests/workflows_cli.rs
+++ b/gestalt/cli/tests/workflows_cli.rs
@@ -1,0 +1,262 @@
+mod support;
+
+use support::*;
+
+const SCHEDULE_JSON: &str = r#"{
+    "id":"sched-1",
+    "provider":"test-provider",
+    "cron":"0 0 * * *",
+    "timezone":"UTC",
+    "target":{
+        "plugin":"dummy",
+        "operation":"doit",
+        "input":{"k":"v"}
+    },
+    "paused":false,
+    "createdAt":"2026-04-20T00:00:00Z",
+    "updatedAt":"2026-04-20T00:00:00Z",
+    "nextRunAt":"2026-04-21T00:00:00Z"
+}"#;
+
+#[test]
+fn test_cli_lists_schedules() {
+    let mut server = Server::new();
+    let _mock = authed_json_mock!(
+        server,
+        Method::GET,
+        "/api/v1/workflow/schedules",
+        StatusCode::OK
+    )
+    .with_body(format!("[{SCHEDULE_JSON}]"))
+    .create();
+
+    let home = tempfile::tempdir().unwrap();
+    cli_command_for_server(home.path(), &server)
+        .args(["workflows", "schedules", "list"])
+        .assert()
+        .success()
+        .stdout(predicate::str::contains("sched-1"))
+        .stdout(predicate::str::contains("dummy"))
+        .stdout(predicate::str::contains("doit"));
+}
+
+#[test]
+fn test_cli_list_schedules_filters_by_plugin() {
+    let body = r#"[
+        {"id":"sched-a","provider":"p","cron":"* * * * *","target":{"plugin":"alpha","operation":"x"},"paused":false},
+        {"id":"sched-b","provider":"p","cron":"* * * * *","target":{"plugin":"beta","operation":"y"},"paused":false}
+    ]"#;
+    let mut server = Server::new();
+    let _mock = authed_json_mock!(
+        server,
+        Method::GET,
+        "/api/v1/workflow/schedules",
+        StatusCode::OK
+    )
+    .with_body(body)
+    .create();
+
+    let home = tempfile::tempdir().unwrap();
+    cli_command_for_server(home.path(), &server)
+        .args(["workflows", "schedules", "list", "--plugin", "beta"])
+        .assert()
+        .success()
+        .stdout(predicate::str::contains("sched-b"))
+        .stdout(predicate::str::contains("sched-a").not());
+}
+
+#[test]
+fn test_cli_gets_schedule() {
+    let mut server = Server::new();
+    let _mock = authed_json_mock!(
+        server,
+        Method::GET,
+        "/api/v1/workflow/schedules/sched-1",
+        StatusCode::OK
+    )
+    .with_body(SCHEDULE_JSON)
+    .create();
+
+    let home = tempfile::tempdir().unwrap();
+    cli_command_for_server(home.path(), &server)
+        .args(["workflows", "schedules", "get", "sched-1"])
+        .assert()
+        .success()
+        .stdout(predicate::str::contains("sched-1"))
+        .stdout(predicate::str::contains("dummy"));
+}
+
+#[test]
+fn test_cli_creates_schedule() {
+    let mut server = Server::new();
+    let _mock = authed_json_mock!(
+        server,
+        Method::POST,
+        "/api/v1/workflow/schedules",
+        StatusCode::CREATED
+    )
+    .match_header(header::CONTENT_TYPE.as_str(), http::APPLICATION_JSON)
+    .match_body(Matcher::JsonString(
+        r#"{
+            "cron":"0 */5 * * *",
+            "timezone":"UTC",
+            "target":{"plugin":"dummy","operation":"doit","input":{"channel":"C1","text":"hi"}},
+            "paused":false
+        }"#
+        .to_string(),
+    ))
+    .with_body(SCHEDULE_JSON)
+    .create();
+
+    let home = tempfile::tempdir().unwrap();
+    cli_command_for_server(home.path(), &server)
+        .args([
+            "workflows",
+            "schedules",
+            "create",
+            "--cron",
+            "0 */5 * * *",
+            "--timezone",
+            "UTC",
+            "--plugin",
+            "dummy",
+            "--operation",
+            "doit",
+            "-p",
+            "channel=C1",
+            "-p",
+            "text=hi",
+        ])
+        .assert()
+        .success()
+        .stdout(predicate::str::contains("sched-1"));
+}
+
+#[test]
+fn test_cli_updates_schedule_merges_existing_fields() {
+    let mut server = Server::new();
+    let _get = authed_json_mock!(
+        server,
+        Method::GET,
+        "/api/v1/workflow/schedules/sched-1",
+        StatusCode::OK
+    )
+    .with_body(SCHEDULE_JSON)
+    .create();
+
+    let _put = authed_json_mock!(
+        server,
+        Method::PUT,
+        "/api/v1/workflow/schedules/sched-1",
+        StatusCode::OK
+    )
+    .match_header(header::CONTENT_TYPE.as_str(), http::APPLICATION_JSON)
+    .match_body(Matcher::JsonString(
+        r#"{
+            "cron":"15 * * * *",
+            "timezone":"UTC",
+            "target":{"plugin":"dummy","operation":"doit","input":{"k":"v"}},
+            "paused":true
+        }"#
+        .to_string(),
+    ))
+    .with_body(SCHEDULE_JSON)
+    .create();
+
+    let home = tempfile::tempdir().unwrap();
+    cli_command_for_server(home.path(), &server)
+        .args([
+            "workflows",
+            "schedules",
+            "update",
+            "sched-1",
+            "--cron",
+            "15 * * * *",
+            "--paused",
+        ])
+        .assert()
+        .success();
+}
+
+#[test]
+fn test_cli_deletes_schedule() {
+    let mut server = Server::new();
+    let _mock = authed_json_mock!(
+        server,
+        Method::DELETE,
+        "/api/v1/workflow/schedules/sched-1",
+        StatusCode::OK
+    )
+    .with_body(r#"{"status":"deleted"}"#)
+    .create();
+
+    let home = tempfile::tempdir().unwrap();
+    cli_command_for_server(home.path(), &server)
+        .args(["workflows", "schedules", "delete", "sched-1"])
+        .assert()
+        .success()
+        .stderr(predicate::str::contains(
+            "Workflow schedule sched-1 deleted.",
+        ));
+}
+
+#[test]
+fn test_cli_pauses_schedule() {
+    let mut server = Server::new();
+    let _mock = authed_json_mock!(
+        server,
+        Method::POST,
+        "/api/v1/workflow/schedules/sched-1/pause",
+        StatusCode::OK
+    )
+    .with_body(SCHEDULE_JSON)
+    .create();
+
+    let home = tempfile::tempdir().unwrap();
+    cli_command_for_server(home.path(), &server)
+        .args(["workflows", "schedules", "pause", "sched-1"])
+        .assert()
+        .success()
+        .stdout(predicate::str::contains("sched-1"));
+}
+
+#[test]
+fn test_cli_resumes_schedule() {
+    let mut server = Server::new();
+    let _mock = authed_json_mock!(
+        server,
+        Method::POST,
+        "/api/v1/workflow/schedules/sched-1/resume",
+        StatusCode::OK
+    )
+    .with_body(SCHEDULE_JSON)
+    .create();
+
+    let home = tempfile::tempdir().unwrap();
+    cli_command_for_server(home.path(), &server)
+        .args(["workflows", "schedules", "resume", "sched-1"])
+        .assert()
+        .success()
+        .stdout(predicate::str::contains("sched-1"));
+}
+
+#[test]
+fn test_cli_list_schedules_json_format() {
+    let mut server = Server::new();
+    let _mock = authed_json_mock!(
+        server,
+        Method::GET,
+        "/api/v1/workflow/schedules",
+        StatusCode::OK
+    )
+    .with_body(format!("[{SCHEDULE_JSON}]"))
+    .create();
+
+    let home = tempfile::tempdir().unwrap();
+    cli_command_for_server(home.path(), &server)
+        .args(["--format", "json", "workflows", "schedules", "list"])
+        .assert()
+        .success()
+        .stdout(predicate::str::contains(r#""id": "sched-1""#))
+        .stdout(predicate::str::contains(r#""plugin": "dummy""#));
+}


### PR DESCRIPTION
The `gestaltd` server now exposes HTTP CRUD for workflow schedules, but
the `gestalt` CLI had no first-class way to drive those endpoints. This
adds `gestalt workflows schedules` with `list`, `get`, `create`,
`update`, `delete`, `pause`, and `resume` so users can manage their
scheduled operation runs without dropping to raw HTTP. Target input
reuses the same `-p key=value` / `--input-file` surface as `gestalt
invoke`, and table output shows the schedule `ID`, target plugin and
operation, cron, timezone, paused state, and next run time.

The command namespace is nested under `workflows` intentionally so that
`runs` and event triggers can be added alongside `schedules` once those
pick up HTTP endpoints, without a later rename.

Co-authored-by: Claude Opus 4.6 (1M context) <noreply@anthropic.com>