### PR TITLE
Split plugin manifest route auth from connection auth

### DIFF
--- a/docs/content/reference/plugin-manifests.mdx
+++ b/docs/content/reference/plugin-manifests.mdx
@@ -65,14 +65,16 @@ The `spec` block for a `kind: plugin` manifest describes a plugin. It supports d
 | Field | Type | Purpose |
 | --- | --- | --- |
 | `configSchemaPath` | string | Path to a JSON/YAML schema that validates `plugins.<name>.config` in the server config. |
-| `auth` | ProviderAuth | Default connection auth when no `connections` map is defined. |
-| `connectionMode` | string | Default connection mode when no `connections` map is defined. One of `none`, `user`, `identity`. |
+| `auth` | RouteAuthRef | Optional plugin route-auth reference. Use `auth.provider` to bind the plugin’s mounted routes to a named request-auth provider. |
 | `mcp` | bool | When true, the plugin exposes its operations as MCP tools. |
 | `headers` | map[string]string | Static headers injected into every outbound request. |
 | `surfaces` | Surfaces | Spec-loaded and declarative REST surfaces. See [Surfaces](#surfaces). |
+| `connections` | map[string]ConnectionDef | Canonical upstream auth and connection definitions. Put upstream OAuth/manual/bearer auth here, typically under `connections.default`. |
 | `defaultConnection` | string | Name of the connection to use when none is specified. |
 | `requires` | string[] | Provider source identifiers that this provider depends on. Gestalt ensures the listed providers are available before starting this provider. |
 | `ui` | OwnedUIRef | Optional owned web UI reference for plugins that publish a mounted UI. |
+
+Legacy manifests may still use top-level `spec.auth`, `spec.connectionMode`, `spec.connectionParams`, and `spec.discovery` for upstream auth. Gestalt accepts that input for compatibility and normalizes it into `spec.connections.default`, but canonical manifests should declare upstream auth only under `spec.connections`.
 
 ### Owned UI
 
@@ -97,7 +99,11 @@ source: github.com/acme/plugins/roadmap-review
 version: 1.0.0
 spec:
   auth:
-    type: none
+    provider: server
+  connections:
+    default:
+      auth:
+        type: none
   ui:
     path: ../ui/manifest.yaml
 ```
@@ -110,7 +116,11 @@ source: github.com/acme/plugins/roadmap-review
 version: 1.0.0
 spec:
   auth:
-    type: none
+    provider: server
+  connections:
+    default:
+      auth:
+        type: none
   ui:
     ref: github.com/acme/web/roadmap-review
     version: 1.0.0
@@ -169,7 +179,7 @@ The `rest`/`openapi`/`graphql` surface types are mutually exclusive (use `surfac
 
 ### Auth Types
 
-The `auth.type` field on a connection accepts these values:
+`spec.auth.provider` selects a route-auth provider for mounted plugin routes. Upstream auth still lives on `spec.connections.<name>.auth`, and the `auth.type` field on a connection accepts these values:
 
 | Type | Purpose |
 | --- | --- |
@@ -183,23 +193,25 @@ Manual auth in provider manifests also supports `authMapping`, using the same `v
 
 ```yaml
 spec:
-  auth:
-    type: manual
-    credentials:
-      - name: organization_id
-        label: Organization ID
-      - name: api_key
-        label: API Key
-    authMapping:
-      basic:
-        username:
-          valueFrom:
-            credentialFieldRef:
-              name: organization_id
-        password:
-          valueFrom:
-            credentialFieldRef:
-              name: api_key
+  connections:
+    default:
+      auth:
+        type: manual
+        credentials:
+          - name: organization_id
+            label: Organization ID
+          - name: api_key
+            label: API Key
+        authMapping:
+          basic:
+            username:
+              valueFrom:
+                credentialFieldRef:
+                  name: organization_id
+            password:
+              valueFrom:
+                credentialFieldRef:
+                  name: api_key
 ```
 
 ### Pagination
@@ -570,11 +582,13 @@ displayName: Support API
 description: Small ticket API
 iconFile: assets/icon.svg
 spec:
-  auth:
-    type: bearer
-    credentials:
-      - name: token
-        label: API Token
+  connections:
+    default:
+      auth:
+        type: bearer
+        credentials:
+          - name: token
+            label: API Token
   surfaces:
     rest:
       baseUrl: https://api.support.example.com

--- a/gestaltd/cmd/gestaltd/provider_test.go
+++ b/gestaltd/cmd/gestaltd/provider_test.go
@@ -1717,11 +1717,11 @@ func TestRun_ProviderReleasePreservesYAMLManifestFormatAndConnectionDefaults(t *
 	if filepath.Base(manifestPath) != "manifest.yaml" {
 		t.Fatalf("released manifest = %q, want manifest.yaml", filepath.Base(manifestPath))
 	}
-	if manifest.Spec == nil || len(manifest.Spec.ConnectionParams) != 1 || !manifest.Spec.ConnectionParams["tenant"].Required {
+	if manifest.Spec == nil || manifest.Spec.Connections["default"] == nil || len(manifest.Spec.Connections["default"].Params) != 1 || !manifest.Spec.Connections["default"].Params["tenant"].Required {
 		t.Fatalf("provider connection_params = %+v", manifest.Spec)
 	}
-	if manifest.Spec.ConnectionMode != "identity" {
-		t.Fatalf("provider connection_mode = %q, want %q", manifest.Spec.ConnectionMode, "identity")
+	if manifest.Spec.Connections["default"].Mode != "identity" {
+		t.Fatalf("provider default connection mode = %q, want %q", manifest.Spec.Connections["default"].Mode, "identity")
 	}
 
 	manifestData, err := os.ReadFile(manifestPath)
@@ -1730,14 +1730,24 @@ func TestRun_ProviderReleasePreservesYAMLManifestFormatAndConnectionDefaults(t *
 	}
 	for _, expected := range []string{
 		"spec:",
-		"connectionMode: identity",
-		"connectionParams:",
+		"connections:",
+		"default:",
+		"mode: identity",
+		"params:",
 		"mcp: true",
 		"entrypoint:",
 		"artifactPath:",
 	} {
 		if !strings.Contains(string(manifestData), expected) {
 			t.Fatalf("expected released manifest to contain canonical field %q, got: %s", expected, manifestData)
+		}
+	}
+	for _, legacy := range []string{
+		"connectionMode:",
+		"connectionParams:",
+	} {
+		if strings.Contains(string(manifestData), legacy) {
+			t.Fatalf("expected released manifest to omit legacy field %q, got: %s", legacy, manifestData)
 		}
 	}
 }

--- a/gestaltd/internal/providerpkg/manifest.go
+++ b/gestaltd/internal/providerpkg/manifest.go
@@ -401,17 +401,45 @@ func validateProviderAuth(path string, auth *providermanifestv1.ProviderAuth) er
 	return nil
 }
 
+func validateRouteAuthRef(path string, auth *providermanifestv1.RouteAuthRef) error {
+	if auth == nil {
+		return nil
+	}
+	if strings.TrimSpace(auth.Provider) == "" {
+		return fmt.Errorf("%s.provider is required", path)
+	}
+	return nil
+}
+
+func cloneManifestConnections(src map[string]*providermanifestv1.ManifestConnectionDef) map[string]*providermanifestv1.ManifestConnectionDef {
+	if src == nil {
+		return nil
+	}
+	cloned := make(map[string]*providermanifestv1.ManifestConnectionDef, len(src))
+	for name, def := range src {
+		if def == nil {
+			cloned[name] = nil
+			continue
+		}
+		copyDef := *def
+		cloned[name] = &copyDef
+	}
+	return cloned
+}
+
 func validateExecutableProviderMetadata(provider *providermanifestv1.Spec) error {
 	if provider == nil {
 		return nil
 	}
-	if err := validateProviderAuth("provider.auth", provider.Auth); err != nil {
+	normalized := *provider
+	normalized.Connections = cloneManifestConnections(provider.Connections)
+	if err := normalized.NormalizeLegacyConnections(); err != nil {
 		return err
 	}
-	if provider.Auth != nil && provider.Auth.Type == providermanifestv1.AuthTypeMCPOAuth && provider.MCPURL() == "" {
-		return fmt.Errorf("provider.auth.type %q requires an MCP surface", providermanifestv1.AuthTypeMCPOAuth)
+	if err := validateRouteAuthRef("provider.auth", normalized.RouteAuth); err != nil {
+		return err
 	}
-	for name, conn := range provider.Connections {
+	for name, conn := range normalized.Connections {
 		if conn == nil {
 			continue
 		}
@@ -430,18 +458,13 @@ func validateExecutableProviderMetadata(provider *providermanifestv1.Spec) error
 			return fmt.Errorf("unsupported provider.connections.%s.mode %q", name, conn.Mode)
 		}
 	}
-	switch provider.ConnectionMode {
-	case "", "none", "user", "identity":
-	default:
-		return fmt.Errorf("unsupported provider.connectionMode %q", provider.ConnectionMode)
-	}
-	if provider.DefaultConnection != "" {
-		if _, ok := provider.Connections[provider.DefaultConnection]; !ok {
-			return fmt.Errorf("provider.defaultConnection %q references undefined provider.connections entry", provider.DefaultConnection)
+	if normalized.DefaultConnection != "" {
+		if _, ok := normalized.Connections[normalized.DefaultConnection]; !ok {
+			return fmt.Errorf("provider.defaultConnection %q references undefined provider.connections entry", normalized.DefaultConnection)
 		}
 	}
-	if len(provider.Connections) > 0 {
-		for name := range provider.Connections {
+	if len(normalized.Connections) > 0 {
+		for name := range normalized.Connections {
 			if strings.TrimSpace(name) == "" {
 				return fmt.Errorf("provider.connections keys must be non-empty")
 			}

--- a/gestaltd/internal/providerpkg/manifest_workflow_test.go
+++ b/gestaltd/internal/providerpkg/manifest_workflow_test.go
@@ -212,9 +212,10 @@ func TestManifestWorkflow_RejectsInvalidPackageInputs(t *testing.T) {
 	t.Parallel()
 
 	tests := []struct {
-		name      string
-		buildData func(t *testing.T, dir string) string
-		wantError string
+		name       string
+		buildData  func(t *testing.T, dir string) string
+		readSource bool
+		wantError  string
 	}{
 		{
 			name: "missing provider and webui",
@@ -300,16 +301,114 @@ spec:
 		{
 			name: "rejects oauth2 auth without token url",
 			buildData: func(t *testing.T, dir string) string {
-				artifactPath := testArtifactPath("provider")
-				manifest := mustProviderManifest("github.com/acme/plugins/missing-token-url", "1.0.0", testArtifactOS, testArtifactArch, artifactPath, sha256Hex("provider"))
-				manifest.Spec.Auth = &providermanifestv1.ProviderAuth{
-					Type:             providermanifestv1.AuthTypeOAuth2,
-					AuthorizationURL: "https://auth.example.com/authorize",
-				}
-				mustWriteFile(t, filepath.Join(dir, filepath.FromSlash(artifactPath)), []byte("provider"), 0o755)
-				return mustWriteManifestData(t, dir, ManifestFile, mustRawManifestJSON(t, manifest))
+				return mustWriteManifestData(t, dir, "manifest.yaml", []byte(`
+kind: plugin
+source: github.com/acme/plugins/missing-token-url
+version: 1.0.0
+spec:
+  auth:
+    type: oauth2
+    authorizationUrl: https://auth.example.com/authorize
+`))
 			},
-			wantError: "provider.auth.tokenUrl is required for oauth2",
+			readSource: true,
+			wantError:  "provider.connections.default.auth.tokenUrl is required for oauth2",
+		},
+		{
+			name: "rejects unknown nested connection auth field",
+			buildData: func(t *testing.T, dir string) string {
+				return mustWriteManifestData(t, dir, "manifest.yaml", []byte(`
+kind: plugin
+source: github.com/acme/plugins/unknown-auth-field
+version: 1.0.0
+spec:
+  connections:
+    default:
+      auth:
+        type: oauth2
+        authorizationUrl: https://auth.example.com/authorize
+        tokenUrl: https://auth.example.com/token
+        extraField: nope
+`))
+			},
+			readSource: true,
+			wantError:  "field extraField not found",
+		},
+		{
+			name: "rejects ambiguous auth object",
+			buildData: func(t *testing.T, dir string) string {
+				return mustWriteManifestData(t, dir, "manifest.yaml", []byte(`
+kind: plugin
+source: github.com/acme/plugins/ambiguous-auth
+version: 1.0.0
+spec:
+  auth:
+    provider: server
+    type: oauth2
+    authorizationUrl: https://auth.example.com/authorize
+    tokenUrl: https://auth.example.com/token
+`))
+			},
+			readSource: true,
+			wantError:  "spec.auth is ambiguous",
+		},
+		{
+			name: "rejects empty route auth object",
+			buildData: func(t *testing.T, dir string) string {
+				return mustWriteManifestData(t, dir, "manifest.yaml", []byte(`
+kind: plugin
+source: github.com/acme/plugins/empty-route-auth
+version: 1.0.0
+spec:
+  auth: {}
+`))
+			},
+			readSource: true,
+			wantError:  "provider.auth.provider is required",
+		},
+		{
+			name: "rejects unknown nested legacy auth field",
+			buildData: func(t *testing.T, dir string) string {
+				return mustWriteManifestData(t, dir, "manifest.yaml", []byte(`
+kind: plugin
+source: github.com/acme/plugins/legacy-auth-unknown-field
+version: 1.0.0
+spec:
+  auth:
+    type: manual
+    credentials:
+      - name: api_key
+        label: API Key
+    authMapping:
+      basic:
+        username:
+          valueFrom:
+            credentialFieldRef:
+              name: api_key
+              typo: bad
+`))
+			},
+			readSource: true,
+			wantError:  "field typo not found",
+		},
+		{
+			name: "rejects legacy top-level connection fields with canonical default connection",
+			buildData: func(t *testing.T, dir string) string {
+				return mustWriteManifestData(t, dir, "manifest.yaml", []byte(`
+kind: plugin
+source: github.com/acme/plugins/duplicate-default
+version: 1.0.0
+spec:
+  auth:
+    provider: server
+  connectionMode: user
+  connections:
+    default:
+      mode: none
+`))
+			},
+			readSource: true,
+			wantError:  "legacy top-level connection fields may not be combined with spec.connections.default",
 		},
 	}
 
@@ -321,7 +420,12 @@ spec:
 			dir := t.TempDir()
 			manifestPath := tc.buildData(t, dir)
 
-			_, _, err := ReadManifestFile(manifestPath)
+			var err error
+			if tc.readSource {
+				_, _, err = ReadSourceManifestFile(manifestPath)
+			} else {
+				_, _, err = ReadManifestFile(manifestPath)
+			}
 			if err == nil {
 				t.Fatal("expected invalid manifest")
 			}
@@ -329,6 +433,200 @@ spec:
 				t.Fatalf("error = %v, want %q", err, tc.wantError)
 			}
 		})
+	}
+}
+
+func TestManifestWorkflow_AcceptsPluginRouteAuthReference(t *testing.T) {
+	t.Parallel()
+
+	dir := t.TempDir()
+	manifestPath := mustWriteManifestData(t, dir, "manifest.yaml", []byte(`
+kind: plugin
+source: github.com/acme/plugins/route-auth
+version: 1.0.0
+spec:
+  auth:
+    provider: server
+  connections:
+    default:
+      auth:
+        type: none
+`))
+
+	_, manifest, err := ReadSourceManifestFile(manifestPath)
+	if err != nil {
+		t.Fatalf("ReadSourceManifestFile: %v", err)
+	}
+	if manifest.Spec == nil || manifest.Spec.RouteAuth == nil || manifest.Spec.RouteAuth.Provider != "server" {
+		t.Fatalf("unexpected route auth: %#v", manifest.Spec)
+	}
+	if manifest.Spec.Connections["default"] == nil || manifest.Spec.Connections["default"].Auth == nil || manifest.Spec.Connections["default"].Auth.Type != providermanifestv1.AuthTypeNone {
+		t.Fatalf("unexpected default connection: %#v", manifest.Spec.Connections["default"])
+	}
+
+	encoded, err := EncodeSourceManifestFormat(manifest, ManifestFormatYAML)
+	if err != nil {
+		t.Fatalf("EncodeSourceManifestFormat: %v", err)
+	}
+	rendered := string(encoded)
+	if !strings.Contains(rendered, "provider: server") {
+		t.Fatalf("expected canonical route auth in output:\n%s", rendered)
+	}
+	if strings.Contains(rendered, "\n  connectionMode:") || strings.Contains(rendered, "\n  connectionParams:") || strings.Contains(rendered, "\n  discovery:") {
+		t.Fatalf("expected canonical output without legacy top-level connection fields:\n%s", rendered)
+	}
+}
+
+func TestManifestWorkflow_AcceptsNullPluginRouteAuth(t *testing.T) {
+	t.Parallel()
+
+	dir := t.TempDir()
+	manifestPath := mustWriteManifestData(t, dir, "manifest.yaml", []byte(`
+kind: plugin
+source: github.com/acme/plugins/null-route-auth
+version: 1.0.0
+spec:
+  auth:
+  connections:
+    default:
+      auth:
+        type: none
+`))
+
+	_, manifest, err := ReadSourceManifestFile(manifestPath)
+	if err != nil {
+		t.Fatalf("ReadSourceManifestFile: %v", err)
+	}
+	if manifest.Spec == nil {
+		t.Fatal("expected plugin metadata")
+	}
+	if manifest.Spec.RouteAuth != nil {
+		t.Fatalf("RouteAuth = %#v, want nil", manifest.Spec.RouteAuth)
+	}
+	if manifest.Spec.Connections["default"] == nil || manifest.Spec.Connections["default"].Auth == nil || manifest.Spec.Connections["default"].Auth.Type != providermanifestv1.AuthTypeNone {
+		t.Fatalf("unexpected default connection: %#v", manifest.Spec.Connections["default"])
+	}
+}
+
+func TestManifestWorkflow_NormalizesLegacyTopLevelConnectionFieldsIntoDefaultConnection(t *testing.T) {
+	t.Parallel()
+
+	dir := t.TempDir()
+	manifestPath := mustWriteManifestData(t, dir, "manifest.yaml", []byte(`
+kind: plugin
+source: github.com/acme/plugins/legacy-auth
+version: 1.0.0
+spec:
+  auth:
+    type: oauth2
+    authorizationUrl: https://auth.example.com/authorize
+    tokenUrl: https://auth.example.com/token
+  connectionMode: user
+  connectionParams:
+    workspace_id:
+      required: true
+      description: Workspace ID
+  discovery:
+    url: https://api.example.com/workspaces
+    idPath: id
+`))
+
+	_, manifest, err := ReadSourceManifestFile(manifestPath)
+	if err != nil {
+		t.Fatalf("ReadSourceManifestFile: %v", err)
+	}
+	if manifest.Spec == nil {
+		t.Fatal("expected plugin metadata")
+	}
+	if manifest.Spec.RouteAuth != nil {
+		t.Fatalf("expected route auth to be empty for legacy connection auth, got %#v", manifest.Spec.RouteAuth)
+	}
+	def := manifest.Spec.Connections["default"]
+	if def == nil {
+		t.Fatalf("expected synthesized default connection: %#v", manifest.Spec.Connections)
+	}
+	if def.Mode != providermanifestv1.ConnectionModeUser {
+		t.Fatalf("default connection mode = %q, want %q", def.Mode, providermanifestv1.ConnectionModeUser)
+	}
+	if def.Auth == nil || def.Auth.Type != providermanifestv1.AuthTypeOAuth2 {
+		t.Fatalf("default connection auth = %#v", def.Auth)
+	}
+	if def.Params["workspace_id"].Description != "Workspace ID" {
+		t.Fatalf("default connection params = %#v", def.Params)
+	}
+	if def.Discovery == nil || def.Discovery.URL != "https://api.example.com/workspaces" {
+		t.Fatalf("default connection discovery = %#v", def.Discovery)
+	}
+
+	encoded, err := EncodeSourceManifestFormat(manifest, ManifestFormatYAML)
+	if err != nil {
+		t.Fatalf("EncodeSourceManifestFormat: %v", err)
+	}
+	rendered := string(encoded)
+	if !strings.Contains(rendered, "connections:") || !strings.Contains(rendered, "default:") {
+		t.Fatalf("expected canonical default connection in output:\n%s", rendered)
+	}
+	if strings.Contains(rendered, "\n  connectionMode:") || strings.Contains(rendered, "\n  connectionParams:") || strings.Contains(rendered, "\n  discovery:") {
+		t.Fatalf("expected canonical output without legacy top-level connection fields:\n%s", rendered)
+	}
+
+	programmatic := &providermanifestv1.Manifest{
+		Kind:    providermanifestv1.KindPlugin,
+		Source:  "github.com/acme/plugins/programmatic-legacy-auth",
+		Version: "1.0.0",
+		Spec: &providermanifestv1.Spec{
+			Auth: &providermanifestv1.ProviderAuth{
+				Type:             providermanifestv1.AuthTypeOAuth2,
+				AuthorizationURL: "https://auth.example.com/authorize",
+				TokenURL:         "https://auth.example.com/token",
+			},
+			ConnectionMode: providermanifestv1.ConnectionModeUser,
+			ConnectionParams: map[string]providermanifestv1.ProviderConnectionParam{
+				"workspace_id": {
+					Required:    true,
+					Description: "Workspace ID",
+				},
+			},
+			Discovery: &providermanifestv1.ProviderDiscovery{
+				URL:    "https://api.example.com/workspaces",
+				IDPath: "id",
+			},
+		},
+	}
+	programmaticEncoded, err := EncodeSourceManifestFormat(programmatic, ManifestFormatYAML)
+	if err != nil {
+		t.Fatalf("EncodeSourceManifestFormat(programmatic): %v", err)
+	}
+	programmaticRendered := string(programmaticEncoded)
+	if !strings.Contains(programmaticRendered, "connections:") || !strings.Contains(programmaticRendered, "default:") {
+		t.Fatalf("expected canonical default connection in programmatic output:\n%s", programmaticRendered)
+	}
+	if strings.Contains(programmaticRendered, "\n  connectionMode:") || strings.Contains(programmaticRendered, "\n  connectionParams:") || strings.Contains(programmaticRendered, "\n  discovery:") {
+		t.Fatalf("expected programmatic canonical output without legacy top-level connection fields:\n%s", programmaticRendered)
+	}
+	if _, ok := programmatic.Spec.Connections["default"]; ok {
+		t.Fatalf("programmatic manifest was mutated during encode: %#v", programmatic.Spec.Connections)
+	}
+
+	conflicting := &providermanifestv1.Manifest{
+		Kind:    providermanifestv1.KindPlugin,
+		Source:  "github.com/acme/plugins/conflicting-legacy-auth",
+		Version: "1.0.0",
+		Spec: &providermanifestv1.Spec{
+			Auth: &providermanifestv1.ProviderAuth{
+				Type:             providermanifestv1.AuthTypeOAuth2,
+				AuthorizationURL: "https://auth.example.com/authorize",
+				TokenURL:         "https://auth.example.com/token",
+			},
+			Connections: map[string]*providermanifestv1.ManifestConnectionDef{
+				"default": {
+					Mode: providermanifestv1.ConnectionModeNone,
+				},
+			},
+		},
+	}
+	if _, err := EncodeSourceManifestFormat(conflicting, ManifestFormatYAML); err == nil || !strings.Contains(err.Error(), "legacy top-level connection fields may not be combined with spec.connections.default") {
+		t.Fatalf("EncodeSourceManifestFormat(conflicting) error = %v", err)
 	}
 }
 

--- a/gestaltd/sdk/providermanifest/v1/manifest.jsonschema.json
+++ b/gestaltd/sdk/providermanifest/v1/manifest.jsonschema.json
@@ -98,7 +98,14 @@
           "type": "boolean"
         },
         "auth": {
-          "$ref": "#/$defs/providerAuth"
+          "oneOf": [
+            {
+              "$ref": "#/$defs/routeAuthRef"
+            },
+            {
+              "$ref": "#/$defs/providerAuth"
+            }
+          ]
         },
         "connectionMode": {
           "type": "string",
@@ -172,6 +179,19 @@
           "items": {
             "$ref": "#/$defs/webuiRoute"
           }
+        }
+      }
+    },
+    "routeAuthRef": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "provider"
+      ],
+      "properties": {
+        "provider": {
+          "type": "string",
+          "minLength": 1
         }
       }
     },

--- a/gestaltd/sdk/providermanifest/v1/types.go
+++ b/gestaltd/sdk/providermanifest/v1/types.go
@@ -1,7 +1,14 @@
 package providermanifestv1
 
 import (
+	"bytes"
 	_ "embed"
+	"encoding/json"
+	"fmt"
+	"io"
+	"strings"
+
+	"gopkg.in/yaml.v3"
 )
 
 const (
@@ -45,13 +52,14 @@ type Spec struct {
 	ConfigSchemaPath string `json:"configSchemaPath,omitempty" yaml:"configSchemaPath,omitempty"`
 
 	// Plugin-specific fields
-	Auth              *ProviderAuth                         `json:"auth,omitempty" yaml:"auth,omitempty"`
-	ConnectionMode    ConnectionMode                        `json:"connectionMode,omitempty" yaml:"connectionMode,omitempty"`
+	RouteAuth         *RouteAuthRef                         `json:"-" yaml:"-"`
+	Auth              *ProviderAuth                         `json:"-" yaml:"-"`
+	ConnectionMode    ConnectionMode                        `json:"-" yaml:"-"`
 	MCP               bool                                  `json:"mcp,omitempty" yaml:"mcp,omitempty"`
 	Headers           map[string]string                     `json:"headers,omitempty" yaml:"headers,omitempty"`
 	ManagedParameters []ManagedParameter                    `json:"managedParameters,omitempty" yaml:"managedParameters,omitempty"`
-	Discovery         *ProviderDiscovery                    `json:"discovery,omitempty" yaml:"discovery,omitempty"`
-	ConnectionParams  map[string]ProviderConnectionParam    `json:"connectionParams,omitempty" yaml:"connectionParams,omitempty"`
+	Discovery         *ProviderDiscovery                    `json:"-" yaml:"-"`
+	ConnectionParams  map[string]ProviderConnectionParam    `json:"-" yaml:"-"`
 	Surfaces          *ProviderSurfaces                     `json:"surfaces,omitempty" yaml:"surfaces,omitempty"`
 	AllowedOperations map[string]*ManifestOperationOverride `json:"allowedOperations,omitempty" yaml:"allowedOperations,omitempty"`
 	DefaultConnection string                                `json:"defaultConnection,omitempty" yaml:"defaultConnection,omitempty"`
@@ -64,6 +72,12 @@ type Spec struct {
 	// WebUI-specific fields
 	AssetRoot string       `json:"assetRoot,omitempty" yaml:"assetRoot,omitempty"`
 	Routes    []WebUIRoute `json:"routes,omitempty" yaml:"routes,omitempty"`
+
+	compatDefaultConnection bool
+}
+
+type RouteAuthRef struct {
+	Provider string `json:"provider,omitempty" yaml:"provider,omitempty"`
 }
 
 type OwnedUI struct {
@@ -162,6 +176,57 @@ func (s *Spec) SurfaceConnectionName(surface string) string {
 		}
 	}
 	return ""
+}
+
+func (s *Spec) NormalizeLegacyConnections() error {
+	if s == nil {
+		return nil
+	}
+
+	legacyPresent := !s.compatDefaultConnection && (s.Auth != nil || s.ConnectionMode != "" || s.Discovery != nil || len(s.ConnectionParams) > 0)
+	if legacyPresent {
+		if s.Connections == nil {
+			s.Connections = make(map[string]*ManifestConnectionDef, 1)
+		}
+		if _, exists := s.Connections["default"]; exists {
+			return fmt.Errorf("legacy top-level connection fields may not be combined with spec.connections.default")
+		}
+		s.Connections["default"] = &ManifestConnectionDef{
+			Mode:      s.ConnectionMode,
+			Auth:      s.Auth,
+			Params:    s.ConnectionParams,
+			Discovery: s.Discovery,
+		}
+	}
+
+	s.syncDefaultConnectionCompatibility()
+	return nil
+}
+
+func (s *Spec) syncDefaultConnectionCompatibility() {
+	if s == nil {
+		return
+	}
+
+	s.compatDefaultConnection = false
+	s.Auth = nil
+	s.ConnectionMode = ""
+	s.Discovery = nil
+	s.ConnectionParams = nil
+
+	if s.Connections == nil {
+		return
+	}
+	def, ok := s.Connections["default"]
+	if !ok || def == nil {
+		return
+	}
+
+	s.compatDefaultConnection = true
+	s.Auth = def.Auth
+	s.ConnectionMode = def.Mode
+	s.Discovery = def.Discovery
+	s.ConnectionParams = def.Params
 }
 
 func (m *Manifest) IsHybridProvider() bool {
@@ -373,6 +438,427 @@ type Entrypoint struct {
 	ArtifactPath string   `json:"artifactPath" yaml:"artifactPath"`
 	Args         []string `json:"args,omitempty" yaml:"args,omitempty"`
 }
+
+type specJSONWire struct {
+	ConfigSchemaPath  string                                `json:"configSchemaPath,omitempty"`
+	Auth              json.RawMessage                       `json:"auth,omitempty"`
+	ConnectionMode    ConnectionMode                        `json:"connectionMode,omitempty"`
+	MCP               bool                                  `json:"mcp,omitempty"`
+	Headers           map[string]string                     `json:"headers,omitempty"`
+	ManagedParameters []ManagedParameter                    `json:"managedParameters,omitempty"`
+	Discovery         *ProviderDiscovery                    `json:"discovery,omitempty"`
+	ConnectionParams  map[string]ProviderConnectionParam    `json:"connectionParams,omitempty"`
+	Surfaces          *ProviderSurfaces                     `json:"surfaces,omitempty"`
+	AllowedOperations map[string]*ManifestOperationOverride `json:"allowedOperations,omitempty"`
+	DefaultConnection string                                `json:"defaultConnection,omitempty"`
+	Connections       map[string]*ManifestConnectionDef     `json:"connections,omitempty"`
+	ResponseMapping   *ManifestResponseMapping              `json:"responseMapping,omitempty"`
+	Pagination        *ManifestPaginationConfig             `json:"pagination,omitempty"`
+	Requires          []string                              `json:"requires,omitempty"`
+	UI                *OwnedUI                              `json:"ui,omitempty"`
+	AssetRoot         string                                `json:"assetRoot,omitempty"`
+	Routes            []WebUIRoute                          `json:"routes,omitempty"`
+}
+
+type specYAMLWire struct {
+	ConfigSchemaPath  string                                `yaml:"configSchemaPath,omitempty"`
+	Auth              any                                   `yaml:"auth,omitempty"`
+	ConnectionMode    ConnectionMode                        `yaml:"connectionMode,omitempty"`
+	MCP               bool                                  `yaml:"mcp,omitempty"`
+	Headers           map[string]string                     `yaml:"headers,omitempty"`
+	ManagedParameters []ManagedParameter                    `yaml:"managedParameters,omitempty"`
+	Discovery         *ProviderDiscovery                    `yaml:"discovery,omitempty"`
+	ConnectionParams  map[string]ProviderConnectionParam    `yaml:"connectionParams,omitempty"`
+	Surfaces          *ProviderSurfaces                     `yaml:"surfaces,omitempty"`
+	AllowedOperations map[string]*ManifestOperationOverride `yaml:"allowedOperations,omitempty"`
+	DefaultConnection string                                `yaml:"defaultConnection,omitempty"`
+	Connections       map[string]*ManifestConnectionDef     `yaml:"connections,omitempty"`
+	ResponseMapping   *ManifestResponseMapping              `yaml:"responseMapping,omitempty"`
+	Pagination        *ManifestPaginationConfig             `yaml:"pagination,omitempty"`
+	Requires          []string                              `yaml:"requires,omitempty"`
+	UI                *OwnedUI                              `yaml:"ui,omitempty"`
+	AssetRoot         string                                `yaml:"assetRoot,omitempty"`
+	Routes            []WebUIRoute                          `yaml:"routes,omitempty"`
+}
+
+type specWire struct {
+	ConfigSchemaPath  string                                `json:"configSchemaPath,omitempty" yaml:"configSchemaPath,omitempty"`
+	Auth              *RouteAuthRef                         `json:"auth,omitempty" yaml:"auth,omitempty"`
+	MCP               bool                                  `json:"mcp,omitempty" yaml:"mcp,omitempty"`
+	Headers           map[string]string                     `json:"headers,omitempty" yaml:"headers,omitempty"`
+	ManagedParameters []ManagedParameter                    `json:"managedParameters,omitempty" yaml:"managedParameters,omitempty"`
+	Surfaces          *ProviderSurfaces                     `json:"surfaces,omitempty" yaml:"surfaces,omitempty"`
+	AllowedOperations map[string]*ManifestOperationOverride `json:"allowedOperations,omitempty" yaml:"allowedOperations,omitempty"`
+	DefaultConnection string                                `json:"defaultConnection,omitempty" yaml:"defaultConnection,omitempty"`
+	Connections       map[string]*ManifestConnectionDef     `json:"connections,omitempty" yaml:"connections,omitempty"`
+	ResponseMapping   *ManifestResponseMapping              `json:"responseMapping,omitempty" yaml:"responseMapping,omitempty"`
+	Pagination        *ManifestPaginationConfig             `json:"pagination,omitempty" yaml:"pagination,omitempty"`
+	Requires          []string                              `json:"requires,omitempty" yaml:"requires,omitempty"`
+	UI                *OwnedUI                              `json:"ui,omitempty" yaml:"ui,omitempty"`
+	AssetRoot         string                                `json:"assetRoot,omitempty" yaml:"assetRoot,omitempty"`
+	Routes            []WebUIRoute                          `json:"routes,omitempty" yaml:"routes,omitempty"`
+}
+
+func (s *Spec) UnmarshalJSON(data []byte) error {
+	if err := validateJSONWireObjectFields(data, specWireFields); err != nil {
+		return err
+	}
+
+	var raw specJSONWire
+	if err := decodeJSONKnownFields(data, &raw); err != nil {
+		return err
+	}
+
+	spec := Spec{
+		ConfigSchemaPath:  raw.ConfigSchemaPath,
+		ConnectionMode:    raw.ConnectionMode,
+		MCP:               raw.MCP,
+		Headers:           raw.Headers,
+		ManagedParameters: raw.ManagedParameters,
+		Discovery:         raw.Discovery,
+		ConnectionParams:  raw.ConnectionParams,
+		Surfaces:          raw.Surfaces,
+		AllowedOperations: raw.AllowedOperations,
+		DefaultConnection: raw.DefaultConnection,
+		Connections:       raw.Connections,
+		ResponseMapping:   raw.ResponseMapping,
+		Pagination:        raw.Pagination,
+		Requires:          raw.Requires,
+		UI:                raw.UI,
+		AssetRoot:         raw.AssetRoot,
+		Routes:            raw.Routes,
+	}
+
+	routeAuth, legacyAuth, err := decodeSpecAuthJSON(raw.Auth)
+	if err != nil {
+		return err
+	}
+	spec.RouteAuth = routeAuth
+	spec.Auth = legacyAuth
+	if err := spec.NormalizeLegacyConnections(); err != nil {
+		return err
+	}
+
+	*s = spec
+	return nil
+}
+
+func (s Spec) MarshalJSON() ([]byte, error) {
+	wire, err := s.canonicalWire()
+	if err != nil {
+		return nil, err
+	}
+	return json.Marshal(wire)
+}
+
+func (s *Spec) UnmarshalYAML(value *yaml.Node) error {
+	if value == nil {
+		*s = Spec{}
+		return nil
+	}
+	if value.Kind != yaml.MappingNode {
+		return fmt.Errorf("spec must be a mapping")
+	}
+	if err := validateYAMLWireObjectFields(value, specWireFields, "spec"); err != nil {
+		return err
+	}
+	authNode := yamlMappingValue(value, "auth")
+
+	var raw specYAMLWire
+	if err := decodeYAMLKnownFields(value, &raw); err != nil {
+		return err
+	}
+
+	spec := Spec{
+		ConfigSchemaPath:  raw.ConfigSchemaPath,
+		ConnectionMode:    raw.ConnectionMode,
+		MCP:               raw.MCP,
+		Headers:           raw.Headers,
+		ManagedParameters: raw.ManagedParameters,
+		Discovery:         raw.Discovery,
+		ConnectionParams:  raw.ConnectionParams,
+		Surfaces:          raw.Surfaces,
+		AllowedOperations: raw.AllowedOperations,
+		DefaultConnection: raw.DefaultConnection,
+		Connections:       raw.Connections,
+		ResponseMapping:   raw.ResponseMapping,
+		Pagination:        raw.Pagination,
+		Requires:          raw.Requires,
+		UI:                raw.UI,
+		AssetRoot:         raw.AssetRoot,
+		Routes:            raw.Routes,
+	}
+
+	routeAuth, legacyAuth, err := decodeSpecAuthYAML(authNode)
+	if err != nil {
+		return err
+	}
+	spec.RouteAuth = routeAuth
+	spec.Auth = legacyAuth
+	if err := spec.NormalizeLegacyConnections(); err != nil {
+		return err
+	}
+
+	*s = spec
+	return nil
+}
+
+func (s *Spec) MarshalYAML() (any, error) {
+	if s == nil {
+		return nil, nil
+	}
+	return s.canonicalWire()
+}
+
+func (s Spec) canonicalWire() (specWire, error) {
+	normalized := s
+	normalized.Connections = cloneManifestConnections(normalized.Connections)
+	if err := normalized.NormalizeLegacyConnections(); err != nil {
+		return specWire{}, err
+	}
+	return specWire{
+		ConfigSchemaPath:  normalized.ConfigSchemaPath,
+		Auth:              normalized.RouteAuth,
+		MCP:               normalized.MCP,
+		Headers:           normalized.Headers,
+		ManagedParameters: normalized.ManagedParameters,
+		Surfaces:          normalized.Surfaces,
+		AllowedOperations: normalized.AllowedOperations,
+		DefaultConnection: normalized.DefaultConnection,
+		Connections:       normalized.Connections,
+		ResponseMapping:   normalized.ResponseMapping,
+		Pagination:        normalized.Pagination,
+		Requires:          normalized.Requires,
+		UI:                normalized.UI,
+		AssetRoot:         normalized.AssetRoot,
+		Routes:            normalized.Routes,
+	}, nil
+}
+
+func cloneManifestConnections(src map[string]*ManifestConnectionDef) map[string]*ManifestConnectionDef {
+	if src == nil {
+		return nil
+	}
+	cloned := make(map[string]*ManifestConnectionDef, len(src))
+	for name, def := range src {
+		if def == nil {
+			cloned[name] = nil
+			continue
+		}
+		copyDef := *def
+		cloned[name] = &copyDef
+	}
+	return cloned
+}
+
+func decodeSpecAuthJSON(data json.RawMessage) (*RouteAuthRef, *ProviderAuth, error) {
+	trimmed := bytes.TrimSpace(data)
+	if len(trimmed) == 0 || bytes.Equal(trimmed, []byte("null")) {
+		return nil, nil, nil
+	}
+	if err := validateJSONWireObjectFields(trimmed, specAuthWireFields); err != nil {
+		return nil, nil, err
+	}
+
+	var fields map[string]json.RawMessage
+	if err := json.Unmarshal(trimmed, &fields); err != nil {
+		return nil, nil, err
+	}
+
+	hasRoute := false
+	hasLegacy := false
+	for name := range fields {
+		if _, ok := routeAuthWireFields[name]; ok {
+			hasRoute = true
+		}
+		if _, ok := providerAuthWireFields[name]; ok {
+			hasLegacy = true
+		}
+	}
+	if hasRoute && hasLegacy {
+		return nil, nil, fmt.Errorf("spec.auth is ambiguous; use either auth.provider for route auth or legacy connection auth fields, not both")
+	}
+	if !hasRoute && !hasLegacy {
+		return &RouteAuthRef{}, nil, nil
+	}
+	if hasRoute {
+		var routeAuth RouteAuthRef
+		if err := decodeJSONKnownFields(trimmed, &routeAuth); err != nil {
+			return nil, nil, err
+		}
+		return &routeAuth, nil, nil
+	}
+
+	var auth ProviderAuth
+	if err := decodeJSONKnownFields(trimmed, &auth); err != nil {
+		return nil, nil, err
+	}
+	return nil, &auth, nil
+}
+
+func decodeSpecAuthYAML(node *yaml.Node) (*RouteAuthRef, *ProviderAuth, error) {
+	if node == nil {
+		return nil, nil, nil
+	}
+	if node.Kind == yaml.DocumentNode && len(node.Content) == 1 {
+		node = node.Content[0]
+	}
+	if node.Kind == yaml.ScalarNode && (node.Tag == "!!null" || strings.TrimSpace(node.Value) == "") {
+		return nil, nil, nil
+	}
+	if node.Kind != yaml.MappingNode {
+		return nil, nil, fmt.Errorf("spec.auth must be a mapping")
+	}
+	if err := validateYAMLWireObjectFields(node, specAuthWireFields, "spec.auth"); err != nil {
+		return nil, nil, err
+	}
+
+	hasRoute := false
+	hasLegacy := false
+	for i := 0; i+1 < len(node.Content); i += 2 {
+		name := node.Content[i].Value
+		if _, ok := routeAuthWireFields[name]; ok {
+			hasRoute = true
+		}
+		if _, ok := providerAuthWireFields[name]; ok {
+			hasLegacy = true
+		}
+	}
+	if hasRoute && hasLegacy {
+		return nil, nil, fmt.Errorf("spec.auth is ambiguous; use either auth.provider for route auth or legacy connection auth fields, not both")
+	}
+	if !hasRoute && !hasLegacy {
+		return &RouteAuthRef{}, nil, nil
+	}
+	if hasRoute {
+		var routeAuth RouteAuthRef
+		if err := decodeYAMLKnownFields(node, &routeAuth); err != nil {
+			return nil, nil, err
+		}
+		return &routeAuth, nil, nil
+	}
+
+	var auth ProviderAuth
+	if err := decodeYAMLKnownFields(node, &auth); err != nil {
+		return nil, nil, err
+	}
+	return nil, &auth, nil
+}
+
+func decodeJSONKnownFields(data []byte, out any) error {
+	dec := json.NewDecoder(bytes.NewReader(data))
+	dec.DisallowUnknownFields()
+	if err := dec.Decode(out); err != nil {
+		return err
+	}
+	return nil
+}
+
+func decodeYAMLKnownFields(node *yaml.Node, out any) error {
+	data, err := yaml.Marshal(node)
+	if err != nil {
+		return err
+	}
+	dec := yaml.NewDecoder(bytes.NewReader(data))
+	dec.KnownFields(true)
+	if err := dec.Decode(out); err != nil && err != io.EOF {
+		return err
+	}
+	return nil
+}
+
+func validateJSONWireObjectFields(data []byte, allowed map[string]struct{}) error {
+	var fields map[string]json.RawMessage
+	if err := json.Unmarshal(data, &fields); err != nil {
+		return err
+	}
+	for name := range fields {
+		if _, ok := allowed[name]; !ok {
+			return fmt.Errorf("json: unknown field %q", name)
+		}
+	}
+	return nil
+}
+
+func validateYAMLWireObjectFields(node *yaml.Node, allowed map[string]struct{}, subject string) error {
+	for i := 0; i+1 < len(node.Content); i += 2 {
+		name := node.Content[i].Value
+		if _, ok := allowed[name]; !ok {
+			return fmt.Errorf("%s.%s is not supported", subject, name)
+		}
+	}
+	return nil
+}
+
+func yamlMappingValue(node *yaml.Node, key string) *yaml.Node {
+	if node == nil {
+		return nil
+	}
+	for i := 0; i+1 < len(node.Content); i += 2 {
+		if node.Content[i].Value == key {
+			return node.Content[i+1]
+		}
+	}
+	return nil
+}
+
+var specWireFields = map[string]struct{}{
+	"configSchemaPath":  {},
+	"auth":              {},
+	"connectionMode":    {},
+	"mcp":               {},
+	"headers":           {},
+	"managedParameters": {},
+	"discovery":         {},
+	"connectionParams":  {},
+	"surfaces":          {},
+	"allowedOperations": {},
+	"defaultConnection": {},
+	"connections":       {},
+	"responseMapping":   {},
+	"pagination":        {},
+	"requires":          {},
+	"ui":                {},
+	"assetRoot":         {},
+	"routes":            {},
+}
+
+var routeAuthWireFields = map[string]struct{}{
+	"provider": {},
+}
+
+var providerAuthWireFields = map[string]struct{}{
+	"type":                {},
+	"authorizationUrl":    {},
+	"tokenUrl":            {},
+	"clientId":            {},
+	"clientSecret":        {},
+	"scopes":              {},
+	"pkce":                {},
+	"clientAuth":          {},
+	"tokenExchange":       {},
+	"accessTokenPath":     {},
+	"scopeParam":          {},
+	"scopeSeparator":      {},
+	"authorizationParams": {},
+	"tokenParams":         {},
+	"refreshParams":       {},
+	"acceptHeader":        {},
+	"tokenMetadata":       {},
+	"credentials":         {},
+	"authMapping":         {},
+}
+
+var specAuthWireFields = func() map[string]struct{} {
+	fields := make(map[string]struct{}, len(routeAuthWireFields)+len(providerAuthWireFields))
+	for name := range routeAuthWireFields {
+		fields[name] = struct{}{}
+	}
+	for name := range providerAuthWireFields {
+		fields[name] = struct{}{}
+	}
+	return fields
+}()
 
 //go:embed manifest.jsonschema.json
 var ManifestJSONSchema []byte


### PR DESCRIPTION
## Summary
This PR makes `spec.connections` the canonical upstream connection/auth model for plugin manifests and repurposes `spec.auth` to mean plugin route auth.

## New interfaces
- `spec.auth.provider` selects plugin route auth.
- `spec.connections` is the canonical upstream connection/auth model.
- Legacy top-level `spec.auth`, `spec.connectionMode`, `spec.connectionParams`, and `spec.discovery` are still accepted and normalize into `spec.connections.default`.

## Canonical example
```yaml
spec:
  auth:
    provider: server
  connections:
    default:
      mode: user
      auth:
        type: oauth2
        authorizationUrl: https://auth.example.com/authorize
        tokenUrl: https://auth.example.com/token
```

## Legacy input still accepted
```yaml
spec:
  auth:
    type: oauth2
    authorizationUrl: https://auth.example.com/authorize
    tokenUrl: https://auth.example.com/token
  connectionMode: user
  connectionParams:
    workspace_id:
      required: true
```

## Canonical output after load/encode
```yaml
spec:
  connections:
    default:
      mode: user
      auth:
        type: oauth2
        authorizationUrl: https://auth.example.com/authorize
        tokenUrl: https://auth.example.com/token
      params:
        workspace_id:
          required: true
```

## Tests
- `go test ./internal/providerpkg -run 'TestManifestWorkflow_(RejectsInvalidPackageInputs|AcceptsPluginRouteAuthReference|NormalizesLegacyTopLevelConnectionFieldsIntoDefaultConnection|AcceptsProviderWireSurfaceManifest|AcceptsProviderWireMCPOAuthManifestAcrossDirectoryAndArchive|RejectsMCPOAuthManifestWithoutMCPSurface|NamedConnectionParamsAndDiscovery)'`
- `go test ./internal/config -run 'TestValidateStructure'`
- `go test ./internal/bootstrap -run 'Test(BuildStartupProviderSpecPreservesStaticCatalogConnectionRouting|PluginManifestOAuthWiresConnectionAuth)'`
- `go test ./internal/operator -run TestDoesNotExist`
- `go test ./internal/pluginstore -run TestDoesNotExist`

## Scope
This PR is Phase 1 schema/compat only. It does not implement runtime per-plugin route-auth dispatch yet.