### PR TITLE
Move config-managed workflows to top-level workflows config

### DIFF
--- a/gestaltd/internal/bootstrap/bootstrap_test.go
+++ b/gestaltd/internal/bootstrap/bootstrap_test.go
@@ -6,6 +6,7 @@ import (
 	"encoding/base64"
 	"encoding/hex"
 	"fmt"
+	"maps"
 	"net"
 	"net/http"
 	"net/http/httptest"
@@ -795,10 +796,6 @@ func workflowStartupCallbackConfig(baseURL string) *config.Config {
 	cfg.Plugins = map[string]*config.ProviderEntry{
 		"roadmap": {
 			ConnectionMode: providermanifestv1.ConnectionModeIdentity,
-			Workflow: &config.PluginWorkflowConfig{
-				Provider:   "temporal",
-				Operations: []string{"sync"},
-			},
 			ResolvedManifest: &providermanifestv1.Manifest{
 				Spec: &providermanifestv1.Spec{
 					Surfaces: &providermanifestv1.ProviderSurfaces{
@@ -816,7 +813,67 @@ func workflowStartupCallbackConfig(baseURL string) *config.Config {
 	cfg.Providers.Workflow = map[string]*config.ProviderEntry{
 		"temporal": {Source: config.ProviderSource{Path: "stub"}},
 	}
+	setWorkflowFixture(cfg, "roadmap", &config.PluginWorkflowConfig{
+		Provider:   "temporal",
+		Operations: []string{"sync"},
+	})
 	return cfg
+}
+
+func setWorkflowFixture(cfg *config.Config, plugin string, workflow *config.PluginWorkflowConfig) {
+	if cfg == nil {
+		return
+	}
+	if cfg.Workflows.Bindings == nil {
+		cfg.Workflows.Bindings = map[string]*config.WorkflowBindingConfig{}
+	}
+	if cfg.Workflows.Schedules == nil {
+		cfg.Workflows.Schedules = map[string]config.WorkflowScheduleConfig{}
+	}
+	if cfg.Workflows.EventTriggers == nil {
+		cfg.Workflows.EventTriggers = map[string]config.WorkflowEventTriggerConfig{}
+	}
+	delete(cfg.Workflows.Bindings, plugin)
+	for key, schedule := range cfg.Workflows.Schedules {
+		if schedule.Plugin == plugin {
+			delete(cfg.Workflows.Schedules, key)
+		}
+	}
+	for key, trigger := range cfg.Workflows.EventTriggers {
+		if trigger.Plugin == plugin {
+			delete(cfg.Workflows.EventTriggers, key)
+		}
+	}
+	if workflow == nil {
+		return
+	}
+	cfg.Workflows.Bindings[plugin] = &config.WorkflowBindingConfig{
+		Provider:   workflow.Provider,
+		Operations: slices.Clone(workflow.Operations),
+	}
+	for key, schedule := range workflow.Schedules {
+		cfg.Workflows.Schedules[key] = config.WorkflowScheduleConfig{
+			Plugin:    plugin,
+			Cron:      schedule.Cron,
+			Timezone:  schedule.Timezone,
+			Operation: schedule.Operation,
+			Input:     maps.Clone(schedule.Input),
+			Paused:    schedule.Paused,
+		}
+	}
+	for key, trigger := range workflow.EventTriggers {
+		cfg.Workflows.EventTriggers[key] = config.WorkflowEventTriggerConfig{
+			Plugin: plugin,
+			Match: config.WorkflowEventMatch{
+				Type:    trigger.Match.Type,
+				Source:  trigger.Match.Source,
+				Subject: trigger.Match.Subject,
+			},
+			Operation: trigger.Operation,
+			Input:     maps.Clone(trigger.Input),
+			Paused:    trigger.Paused,
+		}
+	}
 }
 
 func transportSecretRef(name string) string {
@@ -1475,7 +1532,7 @@ func TestBootstrapAppliesConfiguredWorkflowSchedules(t *testing.T) {
 	t.Parallel()
 
 	cfg := workflowStartupCallbackConfig("https://example.invalid")
-	cfg.Plugins["roadmap"].Workflow = &config.PluginWorkflowConfig{
+	setWorkflowFixture(cfg, "roadmap", &config.PluginWorkflowConfig{
 		Provider:   "temporal",
 		Operations: []string{"sync"},
 		Schedules: map[string]config.PluginWorkflowSchedule{
@@ -1488,7 +1545,7 @@ func TestBootstrapAppliesConfiguredWorkflowSchedules(t *testing.T) {
 				},
 			},
 		},
-	}
+	})
 	cfg.Providers.Workflow = map[string]*config.ProviderEntry{
 		"temporal": {Source: config.ProviderSource{Path: "stub"}},
 	}
@@ -1550,7 +1607,7 @@ func TestValidateDoesNotApplyConfiguredWorkflowSchedules(t *testing.T) {
 	t.Parallel()
 
 	cfg := workflowStartupCallbackConfig("https://example.invalid")
-	cfg.Plugins["roadmap"].Workflow = &config.PluginWorkflowConfig{
+	setWorkflowFixture(cfg, "roadmap", &config.PluginWorkflowConfig{
 		Provider:   "temporal",
 		Operations: []string{"sync"},
 		Schedules: map[string]config.PluginWorkflowSchedule{
@@ -1561,7 +1618,7 @@ func TestValidateDoesNotApplyConfiguredWorkflowSchedules(t *testing.T) {
 				Paused:    true,
 			},
 		},
-	}
+	})
 	cfg.Providers.Workflow = map[string]*config.ProviderEntry{
 		"temporal": {Source: config.ProviderSource{Path: "stub"}},
 	}
@@ -1604,7 +1661,7 @@ func TestBootstrapDeletesRemovedConfiguredWorkflowSchedules(t *testing.T) {
 	}
 
 	cfg := workflowStartupCallbackConfig("https://example.invalid")
-	cfg.Plugins["roadmap"].Workflow = &config.PluginWorkflowConfig{
+	setWorkflowFixture(cfg, "roadmap", &config.PluginWorkflowConfig{
 		Provider:   "temporal",
 		Operations: []string{"sync"},
 		Schedules: map[string]config.PluginWorkflowSchedule{
@@ -1617,7 +1674,7 @@ func TestBootstrapDeletesRemovedConfiguredWorkflowSchedules(t *testing.T) {
 				},
 			},
 		},
-	}
+	})
 	cfg.Providers.Workflow = map[string]*config.ProviderEntry{
 		"temporal": {Source: config.ProviderSource{Path: "stub"}},
 	}
@@ -1633,10 +1690,10 @@ func TestBootstrapDeletesRemovedConfiguredWorkflowSchedules(t *testing.T) {
 	_ = result.Close(context.Background())
 
 	cfg = workflowStartupCallbackConfig("https://example.invalid")
-	cfg.Plugins["roadmap"].Workflow = &config.PluginWorkflowConfig{
+	setWorkflowFixture(cfg, "roadmap", &config.PluginWorkflowConfig{
 		Provider:   "temporal",
 		Operations: []string{"sync"},
-	}
+	})
 	cfg.Providers.Workflow = map[string]*config.ProviderEntry{
 		"temporal": {Source: config.ProviderSource{Path: "stub"}},
 	}
@@ -1675,10 +1732,10 @@ func TestBootstrapIgnoresUserSchedulesThatOnlyShareCfgPrefix(t *testing.T) {
 	t.Parallel()
 
 	cfg := workflowStartupCallbackConfig("https://example.invalid")
-	cfg.Plugins["roadmap"].Workflow = &config.PluginWorkflowConfig{
+	setWorkflowFixture(cfg, "roadmap", &config.PluginWorkflowConfig{
 		Provider:   "temporal",
 		Operations: []string{"sync"},
-	}
+	})
 	cfg.Providers.Workflow = map[string]*config.ProviderEntry{
 		"temporal": {Source: config.ProviderSource{Path: "stub"}},
 	}
@@ -1723,7 +1780,7 @@ func TestBootstrapMovesConfiguredWorkflowSchedulesToNewProvider(t *testing.T) {
 	}
 
 	cfg := workflowStartupCallbackConfig("https://example.invalid")
-	cfg.Plugins["roadmap"].Workflow = &config.PluginWorkflowConfig{
+	setWorkflowFixture(cfg, "roadmap", &config.PluginWorkflowConfig{
 		Provider:   "temporal",
 		Operations: []string{"sync"},
 		Schedules: map[string]config.PluginWorkflowSchedule{
@@ -1736,7 +1793,7 @@ func TestBootstrapMovesConfiguredWorkflowSchedulesToNewProvider(t *testing.T) {
 				},
 			},
 		},
-	}
+	})
 	cfg.Providers.Workflow = map[string]*config.ProviderEntry{
 		"temporal": {Source: config.ProviderSource{Path: "stub"}},
 		"backup":   {Source: config.ProviderSource{Path: "stub"}},
@@ -1753,7 +1810,7 @@ func TestBootstrapMovesConfiguredWorkflowSchedulesToNewProvider(t *testing.T) {
 	_ = result.Close(context.Background())
 
 	cfg = workflowStartupCallbackConfig("https://example.invalid")
-	cfg.Plugins["roadmap"].Workflow = &config.PluginWorkflowConfig{
+	setWorkflowFixture(cfg, "roadmap", &config.PluginWorkflowConfig{
 		Provider:   "backup",
 		Operations: []string{"sync"},
 		Schedules: map[string]config.PluginWorkflowSchedule{
@@ -1766,7 +1823,7 @@ func TestBootstrapMovesConfiguredWorkflowSchedulesToNewProvider(t *testing.T) {
 				},
 			},
 		},
-	}
+	})
 	cfg.Providers.Workflow = map[string]*config.ProviderEntry{
 		"temporal": {Source: config.ProviderSource{Path: "stub"}},
 		"backup":   {Source: config.ProviderSource{Path: "stub"}},
@@ -1812,10 +1869,10 @@ func TestBootstrapClosesWorkflowProvidersWhenConfigScheduleReconcileFails(t *tes
 	t.Parallel()
 
 	cfg := workflowStartupCallbackConfig("https://example.invalid")
-	cfg.Plugins["roadmap"].Workflow = &config.PluginWorkflowConfig{
+	setWorkflowFixture(cfg, "roadmap", &config.PluginWorkflowConfig{
 		Provider:   "temporal",
 		Operations: []string{"sync"},
-	}
+	})
 	cfg.Providers.Workflow = map[string]*config.ProviderEntry{
 		"temporal": {Source: config.ProviderSource{Path: "stub"}},
 	}
@@ -1828,8 +1885,9 @@ func TestBootstrapClosesWorkflowProvidersWhenConfigScheduleReconcileFails(t *tes
 		return &recordingWorkflowProvider{closed: closed}, nil
 	}
 
-	cfg.Plugins["roadmap"].Workflow.Schedules = map[string]config.PluginWorkflowSchedule{
+	cfg.Workflows.Schedules = map[string]config.WorkflowScheduleConfig{
 		"nightly_sync": {
+			Plugin:    "roadmap",
 			Cron:      "0 2 * * *",
 			Timezone:  "UTC",
 			Operation: "sync",
@@ -1843,7 +1901,7 @@ func TestBootstrapClosesWorkflowProvidersWhenConfigScheduleReconcileFails(t *tes
 	_ = result.Close(context.Background())
 
 	cfg = workflowStartupCallbackConfig("https://example.invalid")
-	cfg.Plugins["roadmap"].Workflow = &config.PluginWorkflowConfig{
+	setWorkflowFixture(cfg, "roadmap", &config.PluginWorkflowConfig{
 		Provider:   "backup",
 		Operations: []string{"sync"},
 		Schedules: map[string]config.PluginWorkflowSchedule{
@@ -1856,7 +1914,7 @@ func TestBootstrapClosesWorkflowProvidersWhenConfigScheduleReconcileFails(t *tes
 				},
 			},
 		},
-	}
+	})
 	cfg.Providers.Workflow = map[string]*config.ProviderEntry{
 		"backup": {Source: config.ProviderSource{Path: "stub"}},
 	}
@@ -1874,7 +1932,7 @@ func TestBootstrapDoesNotApplyConfiguredWorkflowSchedulesWhenAuditBuildFails(t *
 	t.Parallel()
 
 	cfg := workflowStartupCallbackConfig("https://example.invalid")
-	cfg.Plugins["roadmap"].Workflow = &config.PluginWorkflowConfig{
+	setWorkflowFixture(cfg, "roadmap", &config.PluginWorkflowConfig{
 		Provider:   "temporal",
 		Operations: []string{"sync"},
 		Schedules: map[string]config.PluginWorkflowSchedule{
@@ -1887,7 +1945,7 @@ func TestBootstrapDoesNotApplyConfiguredWorkflowSchedulesWhenAuditBuildFails(t *
 				},
 			},
 		},
-	}
+	})
 	cfg.Providers.Workflow = map[string]*config.ProviderEntry{
 		"temporal": {Source: config.ProviderSource{Path: "stub"}},
 	}
@@ -1917,7 +1975,7 @@ func TestBootstrapRejectsExistingUnmanagedWorkflowScheduleID(t *testing.T) {
 	t.Parallel()
 
 	cfg := workflowStartupCallbackConfig("https://example.invalid")
-	cfg.Plugins["roadmap"].Workflow = &config.PluginWorkflowConfig{
+	setWorkflowFixture(cfg, "roadmap", &config.PluginWorkflowConfig{
 		Provider:   "temporal",
 		Operations: []string{"sync"},
 		Schedules: map[string]config.PluginWorkflowSchedule{
@@ -1927,7 +1985,7 @@ func TestBootstrapRejectsExistingUnmanagedWorkflowScheduleID(t *testing.T) {
 				Operation: "sync",
 			},
 		},
-	}
+	})
 	cfg.Providers.Workflow = map[string]*config.ProviderEntry{
 		"temporal": {Source: config.ProviderSource{Path: "stub"}},
 	}
@@ -1963,7 +2021,7 @@ func TestBootstrapReAdoptsManagedSchedulesWhenOwnershipStateIsMissing(t *testing
 	}
 
 	cfg := workflowStartupCallbackConfig("https://example.invalid")
-	cfg.Plugins["roadmap"].Workflow = &config.PluginWorkflowConfig{
+	setWorkflowFixture(cfg, "roadmap", &config.PluginWorkflowConfig{
 		Provider:   "temporal",
 		Operations: []string{"sync"},
 		Schedules: map[string]config.PluginWorkflowSchedule{
@@ -1973,7 +2031,7 @@ func TestBootstrapReAdoptsManagedSchedulesWhenOwnershipStateIsMissing(t *testing
 				Operation: "sync",
 			},
 		},
-	}
+	})
 	cfg.Providers.Workflow = map[string]*config.ProviderEntry{
 		"temporal": {Source: config.ProviderSource{Path: "stub"}},
 	}
@@ -2027,7 +2085,7 @@ func TestBootstrapReusesConfiguredWorkflowExecutionRefAcrossUnchangedBootstrap(t
 	}
 
 	cfg := workflowStartupCallbackConfig("https://example.invalid")
-	cfg.Plugins["roadmap"].Workflow = &config.PluginWorkflowConfig{
+	setWorkflowFixture(cfg, "roadmap", &config.PluginWorkflowConfig{
 		Provider:   "temporal",
 		Operations: []string{"sync"},
 		Schedules: map[string]config.PluginWorkflowSchedule{
@@ -2037,7 +2095,7 @@ func TestBootstrapReusesConfiguredWorkflowExecutionRefAcrossUnchangedBootstrap(t
 				Operation: "sync",
 			},
 		},
-	}
+	})
 	cfg.Providers.Workflow = map[string]*config.ProviderEntry{
 		"temporal": {Source: config.ProviderSource{Path: "stub"}},
 	}
@@ -2084,7 +2142,7 @@ func TestBootstrapIgnoresMissingRemovedConfiguredWorkflowSchedule(t *testing.T) 
 	}
 
 	cfg := workflowStartupCallbackConfig("https://example.invalid")
-	cfg.Plugins["roadmap"].Workflow = &config.PluginWorkflowConfig{
+	setWorkflowFixture(cfg, "roadmap", &config.PluginWorkflowConfig{
 		Provider:   "temporal",
 		Operations: []string{"sync"},
 		Schedules: map[string]config.PluginWorkflowSchedule{
@@ -2094,7 +2152,7 @@ func TestBootstrapIgnoresMissingRemovedConfiguredWorkflowSchedule(t *testing.T) 
 				Operation: "sync",
 			},
 		},
-	}
+	})
 	cfg.Providers.Workflow = map[string]*config.ProviderEntry{
 		"temporal": {Source: config.ProviderSource{Path: "stub"}},
 	}
@@ -2108,10 +2166,10 @@ func TestBootstrapIgnoresMissingRemovedConfiguredWorkflowSchedule(t *testing.T) 
 	provider.schedules = map[string]*coreworkflow.Schedule{}
 
 	cfg = workflowStartupCallbackConfig("https://example.invalid")
-	cfg.Plugins["roadmap"].Workflow = &config.PluginWorkflowConfig{
+	setWorkflowFixture(cfg, "roadmap", &config.PluginWorkflowConfig{
 		Provider:   "temporal",
 		Operations: []string{"sync"},
-	}
+	})
 	cfg.Providers.Workflow = map[string]*config.ProviderEntry{
 		"temporal": {Source: config.ProviderSource{Path: "stub"}},
 	}
@@ -2157,7 +2215,7 @@ func TestBootstrapDeletesRemovedConfiguredWorkflowSchedulesWhenProviderDropsExec
 	}
 
 	cfg := workflowStartupCallbackConfig("https://example.invalid")
-	cfg.Plugins["roadmap"].Workflow = &config.PluginWorkflowConfig{
+	setWorkflowFixture(cfg, "roadmap", &config.PluginWorkflowConfig{
 		Provider:   "temporal",
 		Operations: []string{"sync"},
 		Schedules: map[string]config.PluginWorkflowSchedule{
@@ -2167,7 +2225,7 @@ func TestBootstrapDeletesRemovedConfiguredWorkflowSchedulesWhenProviderDropsExec
 				Operation: "sync",
 			},
 		},
-	}
+	})
 	cfg.Providers.Workflow = map[string]*config.ProviderEntry{
 		"temporal": {Source: config.ProviderSource{Path: "stub"}},
 	}
@@ -2181,10 +2239,10 @@ func TestBootstrapDeletesRemovedConfiguredWorkflowSchedulesWhenProviderDropsExec
 
 	provider.omitScheduleExecutionRef = true
 	cfg = workflowStartupCallbackConfig("https://example.invalid")
-	cfg.Plugins["roadmap"].Workflow = &config.PluginWorkflowConfig{
+	setWorkflowFixture(cfg, "roadmap", &config.PluginWorkflowConfig{
 		Provider:   "temporal",
 		Operations: []string{"sync"},
-	}
+	})
 	cfg.Providers.Workflow = map[string]*config.ProviderEntry{
 		"temporal": {Source: config.ProviderSource{Path: "stub"}},
 	}
@@ -2221,7 +2279,7 @@ func TestBootstrapIgnoresMissingOldScheduleDuringWorkflowProviderMove(t *testing
 	}
 
 	cfg := workflowStartupCallbackConfig("https://example.invalid")
-	cfg.Plugins["roadmap"].Workflow = &config.PluginWorkflowConfig{
+	setWorkflowFixture(cfg, "roadmap", &config.PluginWorkflowConfig{
 		Provider:   "temporal",
 		Operations: []string{"sync"},
 		Schedules: map[string]config.PluginWorkflowSchedule{
@@ -2231,7 +2289,7 @@ func TestBootstrapIgnoresMissingOldScheduleDuringWorkflowProviderMove(t *testing
 				Operation: "sync",
 			},
 		},
-	}
+	})
 	cfg.Providers.Workflow = map[string]*config.ProviderEntry{
 		"temporal": {Source: config.ProviderSource{Path: "stub"}},
 		"backup":   {Source: config.ProviderSource{Path: "stub"}},
@@ -2246,7 +2304,7 @@ func TestBootstrapIgnoresMissingOldScheduleDuringWorkflowProviderMove(t *testing
 	temporal.schedules = map[string]*coreworkflow.Schedule{}
 
 	cfg = workflowStartupCallbackConfig("https://example.invalid")
-	cfg.Plugins["roadmap"].Workflow = &config.PluginWorkflowConfig{
+	setWorkflowFixture(cfg, "roadmap", &config.PluginWorkflowConfig{
 		Provider:   "backup",
 		Operations: []string{"sync"},
 		Schedules: map[string]config.PluginWorkflowSchedule{
@@ -2256,7 +2314,7 @@ func TestBootstrapIgnoresMissingOldScheduleDuringWorkflowProviderMove(t *testing
 				Operation: "sync",
 			},
 		},
-	}
+	})
 	cfg.Providers.Workflow = map[string]*config.ProviderEntry{
 		"temporal": {Source: config.ProviderSource{Path: "stub"}},
 		"backup":   {Source: config.ProviderSource{Path: "stub"}},
@@ -2288,7 +2346,7 @@ func TestBootstrapAppliesConfiguredWorkflowEventTriggers(t *testing.T) {
 	t.Parallel()
 
 	cfg := workflowStartupCallbackConfig("https://example.invalid")
-	cfg.Plugins["roadmap"].Workflow = &config.PluginWorkflowConfig{
+	setWorkflowFixture(cfg, "roadmap", &config.PluginWorkflowConfig{
 		Provider:   "temporal",
 		Operations: []string{"sync"},
 		EventTriggers: map[string]config.PluginWorkflowEventTrigger{
@@ -2303,7 +2361,7 @@ func TestBootstrapAppliesConfiguredWorkflowEventTriggers(t *testing.T) {
 				},
 			},
 		},
-	}
+	})
 	cfg.Providers.Workflow = map[string]*config.ProviderEntry{
 		"temporal": {Source: config.ProviderSource{Path: "stub"}},
 	}
@@ -2352,7 +2410,7 @@ func TestValidateDoesNotApplyConfiguredWorkflowEventTriggers(t *testing.T) {
 	t.Parallel()
 
 	cfg := workflowStartupCallbackConfig("https://example.invalid")
-	cfg.Plugins["roadmap"].Workflow = &config.PluginWorkflowConfig{
+	setWorkflowFixture(cfg, "roadmap", &config.PluginWorkflowConfig{
 		Provider:   "temporal",
 		Operations: []string{"sync"},
 		EventTriggers: map[string]config.PluginWorkflowEventTrigger{
@@ -2364,7 +2422,7 @@ func TestValidateDoesNotApplyConfiguredWorkflowEventTriggers(t *testing.T) {
 				Paused:    true,
 			},
 		},
-	}
+	})
 	cfg.Providers.Workflow = map[string]*config.ProviderEntry{
 		"temporal": {Source: config.ProviderSource{Path: "stub"}},
 	}
@@ -2407,7 +2465,7 @@ func TestBootstrapDeletesRemovedConfiguredWorkflowEventTriggers(t *testing.T) {
 	}
 
 	cfg := workflowStartupCallbackConfig("https://example.invalid")
-	cfg.Plugins["roadmap"].Workflow = &config.PluginWorkflowConfig{
+	setWorkflowFixture(cfg, "roadmap", &config.PluginWorkflowConfig{
 		Provider:   "temporal",
 		Operations: []string{"sync"},
 		EventTriggers: map[string]config.PluginWorkflowEventTrigger{
@@ -2418,7 +2476,7 @@ func TestBootstrapDeletesRemovedConfiguredWorkflowEventTriggers(t *testing.T) {
 				Operation: "sync",
 			},
 		},
-	}
+	})
 	cfg.Providers.Workflow = map[string]*config.ProviderEntry{
 		"temporal": {Source: config.ProviderSource{Path: "stub"}},
 	}
@@ -2433,10 +2491,10 @@ func TestBootstrapDeletesRemovedConfiguredWorkflowEventTriggers(t *testing.T) {
 	_ = result.Close(context.Background())
 
 	cfg = workflowStartupCallbackConfig("https://example.invalid")
-	cfg.Plugins["roadmap"].Workflow = &config.PluginWorkflowConfig{
+	setWorkflowFixture(cfg, "roadmap", &config.PluginWorkflowConfig{
 		Provider:   "temporal",
 		Operations: []string{"sync"},
-	}
+	})
 	cfg.Providers.Workflow = map[string]*config.ProviderEntry{
 		"temporal": {Source: config.ProviderSource{Path: "stub"}},
 	}
@@ -2478,7 +2536,7 @@ func TestBootstrapMovesConfiguredWorkflowEventTriggersToNewProvider(t *testing.T
 	}
 
 	cfg := workflowStartupCallbackConfig("https://example.invalid")
-	cfg.Plugins["roadmap"].Workflow = &config.PluginWorkflowConfig{
+	setWorkflowFixture(cfg, "roadmap", &config.PluginWorkflowConfig{
 		Provider:   "temporal",
 		Operations: []string{"sync"},
 		EventTriggers: map[string]config.PluginWorkflowEventTrigger{
@@ -2489,7 +2547,7 @@ func TestBootstrapMovesConfiguredWorkflowEventTriggersToNewProvider(t *testing.T
 				Operation: "sync",
 			},
 		},
-	}
+	})
 	cfg.Providers.Workflow = map[string]*config.ProviderEntry{
 		"temporal": {Source: config.ProviderSource{Path: "stub"}},
 		"backup":   {Source: config.ProviderSource{Path: "stub"}},
@@ -2505,7 +2563,7 @@ func TestBootstrapMovesConfiguredWorkflowEventTriggersToNewProvider(t *testing.T
 	_ = result.Close(context.Background())
 
 	cfg = workflowStartupCallbackConfig("https://example.invalid")
-	cfg.Plugins["roadmap"].Workflow = &config.PluginWorkflowConfig{
+	setWorkflowFixture(cfg, "roadmap", &config.PluginWorkflowConfig{
 		Provider:   "backup",
 		Operations: []string{"sync"},
 		EventTriggers: map[string]config.PluginWorkflowEventTrigger{
@@ -2516,7 +2574,7 @@ func TestBootstrapMovesConfiguredWorkflowEventTriggersToNewProvider(t *testing.T
 				Operation: "sync",
 			},
 		},
-	}
+	})
 	cfg.Providers.Workflow = map[string]*config.ProviderEntry{
 		"temporal": {Source: config.ProviderSource{Path: "stub"}},
 		"backup":   {Source: config.ProviderSource{Path: "stub"}},
@@ -2557,7 +2615,7 @@ func TestBootstrapRejectsExistingUnmanagedWorkflowEventTriggerIDDuringProviderMo
 	}
 
 	cfg := workflowStartupCallbackConfig("https://example.invalid")
-	cfg.Plugins["roadmap"].Workflow = &config.PluginWorkflowConfig{
+	setWorkflowFixture(cfg, "roadmap", &config.PluginWorkflowConfig{
 		Provider:   "temporal",
 		Operations: []string{"sync"},
 		EventTriggers: map[string]config.PluginWorkflowEventTrigger{
@@ -2568,7 +2626,7 @@ func TestBootstrapRejectsExistingUnmanagedWorkflowEventTriggerIDDuringProviderMo
 				Operation: "sync",
 			},
 		},
-	}
+	})
 	cfg.Providers.Workflow = map[string]*config.ProviderEntry{
 		"temporal": {Source: config.ProviderSource{Path: "stub"}},
 		"backup":   {Source: config.ProviderSource{Path: "stub"}},
@@ -2581,7 +2639,7 @@ func TestBootstrapRejectsExistingUnmanagedWorkflowEventTriggerIDDuringProviderMo
 	_ = result.Close(context.Background())
 
 	cfg = workflowStartupCallbackConfig("https://example.invalid")
-	cfg.Plugins["roadmap"].Workflow = &config.PluginWorkflowConfig{
+	setWorkflowFixture(cfg, "roadmap", &config.PluginWorkflowConfig{
 		Provider:   "backup",
 		Operations: []string{"sync"},
 		EventTriggers: map[string]config.PluginWorkflowEventTrigger{
@@ -2592,7 +2650,7 @@ func TestBootstrapRejectsExistingUnmanagedWorkflowEventTriggerIDDuringProviderMo
 				Operation: "sync",
 			},
 		},
-	}
+	})
 	cfg.Providers.Workflow = map[string]*config.ProviderEntry{
 		"temporal": {Source: config.ProviderSource{Path: "stub"}},
 		"backup":   {Source: config.ProviderSource{Path: "stub"}},
@@ -2614,7 +2672,7 @@ func TestBootstrapRejectsExistingUnmanagedWorkflowEventTriggerID(t *testing.T) {
 	t.Parallel()
 
 	cfg := workflowStartupCallbackConfig("https://example.invalid")
-	cfg.Plugins["roadmap"].Workflow = &config.PluginWorkflowConfig{
+	setWorkflowFixture(cfg, "roadmap", &config.PluginWorkflowConfig{
 		Provider:   "temporal",
 		Operations: []string{"sync"},
 		EventTriggers: map[string]config.PluginWorkflowEventTrigger{
@@ -2625,7 +2683,7 @@ func TestBootstrapRejectsExistingUnmanagedWorkflowEventTriggerID(t *testing.T) {
 				Operation: "sync",
 			},
 		},
-	}
+	})
 	cfg.Providers.Workflow = map[string]*config.ProviderEntry{
 		"temporal": {Source: config.ProviderSource{Path: "stub"}},
 	}
@@ -2661,7 +2719,7 @@ func TestBootstrapReAdoptsManagedEventTriggersWhenOwnershipStateIsMissing(t *tes
 	}
 
 	cfg := workflowStartupCallbackConfig("https://example.invalid")
-	cfg.Plugins["roadmap"].Workflow = &config.PluginWorkflowConfig{
+	setWorkflowFixture(cfg, "roadmap", &config.PluginWorkflowConfig{
 		Provider:   "temporal",
 		Operations: []string{"sync"},
 		EventTriggers: map[string]config.PluginWorkflowEventTrigger{
@@ -2672,7 +2730,7 @@ func TestBootstrapReAdoptsManagedEventTriggersWhenOwnershipStateIsMissing(t *tes
 				Operation: "sync",
 			},
 		},
-	}
+	})
 	cfg.Providers.Workflow = map[string]*config.ProviderEntry{
 		"temporal": {Source: config.ProviderSource{Path: "stub"}},
 	}
@@ -2690,8 +2748,9 @@ func TestBootstrapReAdoptsManagedEventTriggersWhenOwnershipStateIsMissing(t *tes
 	}
 
 	currentDB = db2
-	cfg.Plugins["roadmap"].Workflow.EventTriggers["task_updated"] = config.PluginWorkflowEventTrigger{
-		Match: config.PluginWorkflowEventMatch{
+	cfg.Workflows.EventTriggers["task_updated"] = config.WorkflowEventTriggerConfig{
+		Plugin: "roadmap",
+		Match: config.WorkflowEventMatch{
 			Type: "task.updated",
 		},
 		Operation: "sync",
@@ -2723,7 +2782,7 @@ func TestBootstrapIgnoresMissingRemovedConfiguredWorkflowEventTrigger(t *testing
 	}
 
 	cfg := workflowStartupCallbackConfig("https://example.invalid")
-	cfg.Plugins["roadmap"].Workflow = &config.PluginWorkflowConfig{
+	setWorkflowFixture(cfg, "roadmap", &config.PluginWorkflowConfig{
 		Provider:   "temporal",
 		Operations: []string{"sync"},
 		EventTriggers: map[string]config.PluginWorkflowEventTrigger{
@@ -2734,7 +2793,7 @@ func TestBootstrapIgnoresMissingRemovedConfiguredWorkflowEventTrigger(t *testing
 				Operation: "sync",
 			},
 		},
-	}
+	})
 	cfg.Providers.Workflow = map[string]*config.ProviderEntry{
 		"temporal": {Source: config.ProviderSource{Path: "stub"}},
 	}
@@ -2747,10 +2806,10 @@ func TestBootstrapIgnoresMissingRemovedConfiguredWorkflowEventTrigger(t *testing
 	provider.eventTriggers = map[string]*coreworkflow.EventTrigger{}
 
 	cfg = workflowStartupCallbackConfig("https://example.invalid")
-	cfg.Plugins["roadmap"].Workflow = &config.PluginWorkflowConfig{
+	setWorkflowFixture(cfg, "roadmap", &config.PluginWorkflowConfig{
 		Provider:   "temporal",
 		Operations: []string{"sync"},
-	}
+	})
 	cfg.Providers.Workflow = map[string]*config.ProviderEntry{
 		"temporal": {Source: config.ProviderSource{Path: "stub"}},
 	}
@@ -2793,7 +2852,7 @@ func TestBootstrapIgnoresMissingOldEventTriggerDuringWorkflowProviderMove(t *tes
 	}
 
 	cfg := workflowStartupCallbackConfig("https://example.invalid")
-	cfg.Plugins["roadmap"].Workflow = &config.PluginWorkflowConfig{
+	setWorkflowFixture(cfg, "roadmap", &config.PluginWorkflowConfig{
 		Provider:   "temporal",
 		Operations: []string{"sync"},
 		EventTriggers: map[string]config.PluginWorkflowEventTrigger{
@@ -2804,7 +2863,7 @@ func TestBootstrapIgnoresMissingOldEventTriggerDuringWorkflowProviderMove(t *tes
 				Operation: "sync",
 			},
 		},
-	}
+	})
 	cfg.Providers.Workflow = map[string]*config.ProviderEntry{
 		"temporal": {Source: config.ProviderSource{Path: "stub"}},
 		"backup":   {Source: config.ProviderSource{Path: "stub"}},
@@ -2818,7 +2877,7 @@ func TestBootstrapIgnoresMissingOldEventTriggerDuringWorkflowProviderMove(t *tes
 	temporal.eventTriggers = map[string]*coreworkflow.EventTrigger{}
 
 	cfg = workflowStartupCallbackConfig("https://example.invalid")
-	cfg.Plugins["roadmap"].Workflow = &config.PluginWorkflowConfig{
+	setWorkflowFixture(cfg, "roadmap", &config.PluginWorkflowConfig{
 		Provider:   "backup",
 		Operations: []string{"sync"},
 		EventTriggers: map[string]config.PluginWorkflowEventTrigger{
@@ -2829,7 +2888,7 @@ func TestBootstrapIgnoresMissingOldEventTriggerDuringWorkflowProviderMove(t *tes
 				Operation: "sync",
 			},
 		},
-	}
+	})
 	cfg.Providers.Workflow = map[string]*config.ProviderEntry{
 		"temporal": {Source: config.ProviderSource{Path: "stub"}},
 		"backup":   {Source: config.ProviderSource{Path: "stub"}},
@@ -2989,10 +3048,6 @@ func TestValidateManagedWorkflowStartupCallbackUsesPreparedProviderStub(t *testi
 				"roadmap": {
 					Source:         tc.source,
 					ConnectionMode: providermanifestv1.ConnectionModeIdentity,
-					Workflow: &config.PluginWorkflowConfig{
-						Provider:   "temporal",
-						Operations: []string{"sync"},
-					},
 					ResolvedManifest: &providermanifestv1.Manifest{
 						DisplayName: "Roadmap",
 						Description: "Managed roadmap plugin",
@@ -3013,6 +3068,10 @@ func TestValidateManagedWorkflowStartupCallbackUsesPreparedProviderStub(t *testi
 			cfg.Providers.Workflow = map[string]*config.ProviderEntry{
 				"temporal": {Source: config.ProviderSource{Path: "stub"}},
 			}
+			setWorkflowFixture(cfg, "roadmap", &config.PluginWorkflowConfig{
+				Provider:   "temporal",
+				Operations: []string{"sync"},
+			})
 
 			factories := validFactories()
 			factories.Workflow = func(_ context.Context, name string, _ yaml.Node, hostServices []providerhost.HostService, deps bootstrap.Deps) (coreworkflow.Provider, error) {
@@ -3075,12 +3134,8 @@ func TestValidateManagedWorkflowStartupInvokesMCPPassthroughPreparedProviders(t 
 	cfg := validConfig()
 	cfg.Plugins = map[string]*config.ProviderEntry{
 		"roadmap": {
-			Source:         config.NewMetadataSource("https://example.invalid/github-com-example-roadmap/v0.0.1/provider-release.yaml"),
-			ConnectionMode: providermanifestv1.ConnectionModeIdentity,
-			Workflow: &config.PluginWorkflowConfig{
-				Provider:   "temporal",
-				Operations: []string{"sync"},
-			},
+			Source:               config.NewMetadataSource("https://example.invalid/github-com-example-roadmap/v0.0.1/provider-release.yaml"),
+			ConnectionMode:       providermanifestv1.ConnectionModeIdentity,
 			ResolvedManifestPath: filepath.Join(root, "manifest.yaml"),
 			ResolvedManifest: &providermanifestv1.Manifest{
 				DisplayName: "Roadmap",
@@ -3100,6 +3155,10 @@ func TestValidateManagedWorkflowStartupInvokesMCPPassthroughPreparedProviders(t 
 	cfg.Providers.Workflow = map[string]*config.ProviderEntry{
 		"temporal": {Source: config.ProviderSource{Path: "stub"}},
 	}
+	setWorkflowFixture(cfg, "roadmap", &config.PluginWorkflowConfig{
+		Provider:   "temporal",
+		Operations: []string{"sync"},
+	})
 
 	factories := validFactories()
 	factories.Workflow = func(_ context.Context, name string, _ yaml.Node, _ []providerhost.HostService, deps bootstrap.Deps) (coreworkflow.Provider, error) {
@@ -3312,10 +3371,6 @@ func TestValidate(t *testing.T) {
 		cfg.Plugins = map[string]*config.ProviderEntry{
 			"svc": {
 				ConnectionMode: providermanifestv1.ConnectionMode("either"),
-				Workflow: &config.PluginWorkflowConfig{
-					Provider:   "temporal",
-					Operations: []string{"run"},
-				},
 				ResolvedManifest: &providermanifestv1.Manifest{
 					Spec: &providermanifestv1.Spec{
 						Surfaces: &providermanifestv1.ProviderSurfaces{
@@ -3333,6 +3388,10 @@ func TestValidate(t *testing.T) {
 		cfg.Providers.Workflow = map[string]*config.ProviderEntry{
 			"temporal": {Source: config.ProviderSource{Path: "stub"}},
 		}
+		setWorkflowFixture(cfg, "svc", &config.PluginWorkflowConfig{
+			Provider:   "temporal",
+			Operations: []string{"run"},
+		})
 
 		factories := validFactories()
 		factories.Workflow = func(context.Context, string, yaml.Node, []providerhost.HostService, bootstrap.Deps) (coreworkflow.Provider, error) {
@@ -3373,23 +3432,23 @@ func TestValidate(t *testing.T) {
 		cfg := validConfig()
 		cfg.Plugins = map[string]*config.ProviderEntry{
 			"foo-bar": {
-				Workflow: &config.PluginWorkflowConfig{
-					Provider:   "temporal",
-					Operations: []string{"run"},
-				},
 				ResolvedManifest: manifest,
 			},
 			"foo_bar": {
-				Workflow: &config.PluginWorkflowConfig{
-					Provider:   "temporal",
-					Operations: []string{"run"},
-				},
 				ResolvedManifest: manifest,
 			},
 		}
 		cfg.Providers.Workflow = map[string]*config.ProviderEntry{
 			"temporal": {Source: config.ProviderSource{Path: "stub"}},
 		}
+		setWorkflowFixture(cfg, "foo-bar", &config.PluginWorkflowConfig{
+			Provider:   "temporal",
+			Operations: []string{"run"},
+		})
+		setWorkflowFixture(cfg, "foo_bar", &config.PluginWorkflowConfig{
+			Provider:   "temporal",
+			Operations: []string{"run"},
+		})
 
 		factories := validFactories()
 		factories.Workflow = func(context.Context, string, yaml.Node, []providerhost.HostService, bootstrap.Deps) (coreworkflow.Provider, error) {
@@ -4640,10 +4699,6 @@ func TestBootstrapWorkflowAuthorizationRejectsEitherProvider(t *testing.T) {
 	cfg.Plugins = map[string]*config.ProviderEntry{
 		"svc": {
 			ConnectionMode: providermanifestv1.ConnectionMode("either"),
-			Workflow: &config.PluginWorkflowConfig{
-				Provider:   "temporal",
-				Operations: []string{"run"},
-			},
 			ResolvedManifest: &providermanifestv1.Manifest{
 				Spec: &providermanifestv1.Spec{
 					Surfaces: &providermanifestv1.ProviderSurfaces{
@@ -4662,6 +4717,10 @@ func TestBootstrapWorkflowAuthorizationRejectsEitherProvider(t *testing.T) {
 		"temporal": {Source: config.ProviderSource{Path: "stub"}},
 	}
 	cfg.Authorization = config.AuthorizationConfig{}
+	setWorkflowFixture(cfg, "svc", &config.PluginWorkflowConfig{
+		Provider:   "temporal",
+		Operations: []string{"run"},
+	})
 
 	factories := validFactories()
 	factories.Workflow = func(context.Context, string, yaml.Node, []providerhost.HostService, bootstrap.Deps) (coreworkflow.Provider, error) {

--- a/gestaltd/internal/bootstrap/executable_plugin_test.go
+++ b/gestaltd/internal/bootstrap/executable_plugin_test.go
@@ -1859,7 +1859,11 @@ func TestPluginWorkflowBindingsExposeHostSocketEnv(t *testing.T) {
 				Args:                 []string{"provider"},
 				ResolvedManifest:     manifest,
 				ResolvedManifestPath: filepath.Join(manifestRoot, "manifest.yaml"),
-				Workflow: &config.PluginWorkflowConfig{
+			},
+		},
+		Workflows: config.WorkflowsConfig{
+			Bindings: map[string]*config.WorkflowBindingConfig{
+				"echoext": {
 					Provider:   "temporal",
 					Operations: []string{"read_env"},
 				},

--- a/gestaltd/internal/bootstrap/provider_build.go
+++ b/gestaltd/internal/bootstrap/provider_build.go
@@ -713,7 +713,7 @@ func buildPluginProvider(ctx context.Context, name string, entry *config.Provide
 		execCfg.HostServices = append(execCfg.HostServices, hostServices...)
 		cleanup = chainCleanup(cleanup, cacheCleanup)
 	}
-	if entry.Workflow != nil {
+	if deps.WorkflowRuntime != nil && deps.WorkflowRuntime.HasBinding(name) {
 		hostServices, err := buildPluginWorkflowHostServices(name, deps)
 		if err != nil {
 			return nil, err

--- a/gestaltd/internal/bootstrap/workflow_config_event_triggers.go
+++ b/gestaltd/internal/bootstrap/workflow_config_event_triggers.go
@@ -7,6 +7,7 @@ import (
 	"fmt"
 	"maps"
 	"slices"
+	"strings"
 	"time"
 
 	"github.com/valon-technologies/gestalt/server/core/indexeddb"
@@ -42,7 +43,7 @@ type workflowConfigEventTriggerState struct {
 
 type desiredWorkflowConfigEventTrigger struct {
 	state   workflowConfigEventTriggerState
-	trigger config.PluginWorkflowEventTrigger
+	trigger config.WorkflowEventTriggerConfig
 }
 
 func reconcileWorkflowConfigEventTriggers(ctx context.Context, cfg *config.Config, runtime *workflowRuntime, db indexeddb.IndexedDB) error {
@@ -88,67 +89,59 @@ func reconcileWorkflowConfigEventTriggers(ctx context.Context, cfg *config.Confi
 		}
 	}
 
-	for _, pluginName := range slices.Sorted(maps.Keys(cfg.Plugins)) {
-		entry := cfg.Plugins[pluginName]
-		effective, err := cfg.EffectivePluginWorkflow(pluginName, entry)
-		if err != nil {
-			return err
-		}
-		if !effective.Enabled || len(effective.EventTriggers) == 0 {
-			continue
-		}
+	for _, triggerKey := range slices.Sorted(maps.Keys(cfg.Workflows.EventTriggers)) {
+		trigger := cfg.Workflows.EventTriggers[triggerKey]
+		pluginName := trigger.Plugin
+		managedKey := workflowConfigEventTriggerManagedKey(triggerKey, trigger)
 		provider, allowed, err := runtime.ResolvePlugin(pluginName)
 		if err != nil {
 			return fmt.Errorf("bootstrap: workflow event triggers for plugin %q: %w", pluginName, err)
 		}
-		for _, triggerKey := range slices.Sorted(maps.Keys(effective.EventTriggers)) {
-			trigger := effective.EventTriggers[triggerKey]
-			if _, ok := allowed[trigger.Operation]; !ok {
-				return fmt.Errorf("bootstrap: workflow event trigger %q for plugin %q targets disabled operation %q", triggerKey, pluginName, trigger.Operation)
-			}
-			rowID := workflowConfigEventTriggerStateID(pluginName, triggerKey)
-			desiredEntry := desired[rowID]
-			prev, owned := previous[rowID]
-			providerCtx := invocation.WithWorkflowContextString(ctx, "plugin", pluginName)
-			if !owned || prev.ProviderName != desiredEntry.state.ProviderName {
-				existing, err := provider.GetEventTrigger(providerCtx, coreworkflow.GetEventTriggerRequest{
-					TriggerID: desiredEntry.state.TriggerID,
-				})
-				switch {
-				case err == nil:
-					if !isWorkflowConfigOwnedEventTrigger(existing, pluginName, desiredEntry.state.TriggerID) &&
-						!isAdoptableWorkflowEventTrigger(existing, pluginName, trigger, desiredEntry.state.TriggerID) {
-						return fmt.Errorf("bootstrap: workflow event trigger %q for plugin %q conflicts with existing unmanaged trigger id %q", triggerKey, pluginName, desiredEntry.state.TriggerID)
-					}
-				case isWorkflowObjectNotFound(err):
-				default:
-					return fmt.Errorf("bootstrap: get workflow event trigger %q for plugin %q: %w", desiredEntry.state.TriggerID, pluginName, err)
+		if _, ok := allowed[trigger.Operation]; !ok {
+			return fmt.Errorf("bootstrap: workflow event trigger %q for plugin %q targets disabled operation %q", triggerKey, pluginName, trigger.Operation)
+		}
+		rowID := workflowConfigEventTriggerStateID(pluginName, managedKey)
+		desiredEntry := desired[rowID]
+		prev, owned := previous[rowID]
+		providerCtx := invocation.WithWorkflowContextString(ctx, "plugin", pluginName)
+		if !owned || prev.ProviderName != desiredEntry.state.ProviderName {
+			existing, err := provider.GetEventTrigger(providerCtx, coreworkflow.GetEventTriggerRequest{
+				TriggerID: desiredEntry.state.TriggerID,
+			})
+			switch {
+			case err == nil:
+				if !isWorkflowConfigOwnedEventTrigger(existing, pluginName, desiredEntry.state.TriggerID) &&
+					!isAdoptableWorkflowEventTrigger(existing, trigger, desiredEntry.state.TriggerID) {
+					return fmt.Errorf("bootstrap: workflow event trigger %q for plugin %q conflicts with existing unmanaged trigger id %q", triggerKey, pluginName, desiredEntry.state.TriggerID)
 				}
+			case isWorkflowObjectNotFound(err):
+			default:
+				return fmt.Errorf("bootstrap: get workflow event trigger %q for plugin %q: %w", desiredEntry.state.TriggerID, pluginName, err)
 			}
-			if _, err := provider.UpsertEventTrigger(providerCtx, coreworkflow.UpsertEventTriggerRequest{
-				TriggerID:   desiredEntry.state.TriggerID,
-				Match:       workflowConfigEventTriggerMatch(trigger),
-				Target:      workflowConfigEventTriggerTarget(pluginName, trigger),
-				Paused:      trigger.Paused,
-				RequestedBy: workflowConfigActor(pluginName),
-			}); err != nil {
-				return fmt.Errorf("bootstrap: workflow event trigger %q for plugin %q: %w", triggerKey, pluginName, err)
+		}
+		if _, err := provider.UpsertEventTrigger(providerCtx, coreworkflow.UpsertEventTriggerRequest{
+			TriggerID:   desiredEntry.state.TriggerID,
+			Match:       workflowConfigEventTriggerMatch(trigger),
+			Target:      workflowConfigEventTriggerTarget(trigger),
+			Paused:      trigger.Paused,
+			RequestedBy: workflowConfigActor(pluginName),
+		}); err != nil {
+			return fmt.Errorf("bootstrap: workflow event trigger %q for plugin %q: %w", triggerKey, pluginName, err)
+		}
+		if owned && prev.ProviderName != desiredEntry.state.ProviderName {
+			oldProvider, err := runtime.ResolveProvider(prev.ProviderName)
+			if err != nil {
+				return fmt.Errorf("bootstrap: cleanup workflow event trigger %q for plugin %q requires provider %q: %w", prev.TriggerID, prev.PluginName, prev.ProviderName, err)
 			}
-			if owned && prev.ProviderName != desiredEntry.state.ProviderName {
-				oldProvider, err := runtime.ResolveProvider(prev.ProviderName)
-				if err != nil {
-					return fmt.Errorf("bootstrap: cleanup workflow event trigger %q for plugin %q requires provider %q: %w", prev.TriggerID, prev.PluginName, prev.ProviderName, err)
-				}
-				oldProviderCtx := invocation.WithWorkflowContextString(ctx, "plugin", prev.PluginName)
-				if err := oldProvider.DeleteEventTrigger(oldProviderCtx, coreworkflow.DeleteEventTriggerRequest{
-					TriggerID: prev.TriggerID,
-				}); err != nil && !isWorkflowObjectNotFound(err) {
-					return fmt.Errorf("bootstrap: delete workflow event trigger %q for plugin %q: %w", prev.TriggerID, prev.PluginName, err)
-				}
+			oldProviderCtx := invocation.WithWorkflowContextString(ctx, "plugin", prev.PluginName)
+			if err := oldProvider.DeleteEventTrigger(oldProviderCtx, coreworkflow.DeleteEventTriggerRequest{
+				TriggerID: prev.TriggerID,
+			}); err != nil && !isWorkflowObjectNotFound(err) {
+				return fmt.Errorf("bootstrap: delete workflow event trigger %q for plugin %q: %w", prev.TriggerID, prev.PluginName, err)
 			}
-			if err := store.Put(ctx, desiredEntry.state.record()); err != nil {
-				return fmt.Errorf("bootstrap: store workflow event trigger state %q: %w", rowID, err)
-			}
+		}
+		if err := store.Put(ctx, desiredEntry.state.record()); err != nil {
+			return fmt.Errorf("bootstrap: store workflow event trigger state %q: %w", rowID, err)
 		}
 	}
 	return nil
@@ -160,28 +153,27 @@ func desiredWorkflowConfigEventTriggers(cfg *config.Config) (map[string]desiredW
 		return desired, nil
 	}
 	now := time.Now()
-	for _, pluginName := range slices.Sorted(maps.Keys(cfg.Plugins)) {
-		entry := cfg.Plugins[pluginName]
-		effective, err := cfg.EffectivePluginWorkflow(pluginName, entry)
+	for _, triggerKey := range slices.Sorted(maps.Keys(cfg.Workflows.EventTriggers)) {
+		trigger := cfg.Workflows.EventTriggers[triggerKey]
+		managedKey := workflowConfigEventTriggerManagedKey(triggerKey, trigger)
+		binding, err := cfg.EffectiveWorkflowBinding(trigger.Plugin)
 		if err != nil {
 			return nil, err
 		}
-		if !effective.Enabled {
+		if !binding.Enabled {
 			continue
 		}
-		for _, triggerKey := range slices.Sorted(maps.Keys(effective.EventTriggers)) {
-			rowID := workflowConfigEventTriggerStateID(pluginName, triggerKey)
-			desired[rowID] = desiredWorkflowConfigEventTrigger{
-				state: workflowConfigEventTriggerState{
-					ID:           rowID,
-					PluginName:   pluginName,
-					TriggerKey:   triggerKey,
-					ProviderName: effective.ProviderName,
-					TriggerID:    workflowConfigEventTriggerID(pluginName, triggerKey),
-					UpdatedAt:    now,
-				},
-				trigger: effective.EventTriggers[triggerKey],
-			}
+		rowID := workflowConfigEventTriggerStateID(trigger.Plugin, managedKey)
+		desired[rowID] = desiredWorkflowConfigEventTrigger{
+			state: workflowConfigEventTriggerState{
+				ID:           rowID,
+				PluginName:   trigger.Plugin,
+				TriggerKey:   managedKey,
+				ProviderName: binding.ProviderName,
+				TriggerID:    workflowConfigEventTriggerID(trigger.Plugin, managedKey),
+				UpdatedAt:    now,
+			},
+			trigger: trigger,
 		}
 	}
 	return desired, nil
@@ -222,15 +214,17 @@ func workflowConfigEventTriggerStateFromRecord(rec indexeddb.Record) workflowCon
 	}
 }
 
-func isAdoptableWorkflowEventTrigger(existing *coreworkflow.EventTrigger, pluginName string, trigger config.PluginWorkflowEventTrigger, triggerID string) bool {
+func isAdoptableWorkflowEventTrigger(existing *coreworkflow.EventTrigger, trigger config.WorkflowEventTriggerConfig, triggerID string) bool {
 	if existing == nil {
 		return false
 	}
 	return existing.ID == triggerID &&
 		existing.Match == workflowConfigEventTriggerMatch(trigger) &&
 		existing.Paused == trigger.Paused &&
-		existing.Target.PluginName == pluginName &&
+		existing.Target.PluginName == trigger.Plugin &&
 		existing.Target.Operation == trigger.Operation &&
+		existing.Target.Connection == trigger.Connection &&
+		existing.Target.Instance == trigger.Instance &&
 		workflowTargetInputsEqual(existing.Target.Input, trigger.Input)
 }
 
@@ -246,7 +240,7 @@ func isWorkflowConfigOwnedEventTrigger(existing *coreworkflow.EventTrigger, plug
 		existing.CreatedBy.AuthSource == actor.AuthSource
 }
 
-func workflowConfigEventTriggerMatch(trigger config.PluginWorkflowEventTrigger) coreworkflow.EventMatch {
+func workflowConfigEventTriggerMatch(trigger config.WorkflowEventTriggerConfig) coreworkflow.EventMatch {
 	return coreworkflow.EventMatch{
 		Type:    trigger.Match.Type,
 		Source:  trigger.Match.Source,
@@ -254,12 +248,21 @@ func workflowConfigEventTriggerMatch(trigger config.PluginWorkflowEventTrigger) 
 	}
 }
 
-func workflowConfigEventTriggerTarget(pluginName string, trigger config.PluginWorkflowEventTrigger) coreworkflow.Target {
+func workflowConfigEventTriggerTarget(trigger config.WorkflowEventTriggerConfig) coreworkflow.Target {
 	return coreworkflow.Target{
-		PluginName: pluginName,
+		PluginName: trigger.Plugin,
 		Operation:  trigger.Operation,
+		Connection: trigger.Connection,
+		Instance:   trigger.Instance,
 		Input:      maps.Clone(trigger.Input),
 	}
+}
+
+func workflowConfigEventTriggerManagedKey(triggerKey string, trigger config.WorkflowEventTriggerConfig) string {
+	if managedKey := strings.TrimSpace(trigger.ManagedKey); managedKey != "" {
+		return managedKey
+	}
+	return strings.TrimSpace(triggerKey)
 }
 
 func workflowConfigEventTriggerStateID(pluginName, triggerKey string) string {

--- a/gestaltd/internal/bootstrap/workflow_config_schedules.go
+++ b/gestaltd/internal/bootstrap/workflow_config_schedules.go
@@ -54,7 +54,7 @@ type workflowConfigScheduleState struct {
 
 type desiredWorkflowConfigSchedule struct {
 	state    workflowConfigScheduleState
-	schedule config.PluginWorkflowSchedule
+	schedule config.WorkflowScheduleConfig
 }
 
 func reconcileWorkflowConfigSchedules(ctx context.Context, cfg *config.Config, runtime *workflowRuntime, db indexeddb.IndexedDB) error {
@@ -119,110 +119,102 @@ func reconcileWorkflowConfigSchedules(ctx context.Context, cfg *config.Config, r
 		}
 	}
 
-	for _, pluginName := range slices.Sorted(maps.Keys(cfg.Plugins)) {
-		entry := cfg.Plugins[pluginName]
-		effective, err := cfg.EffectivePluginWorkflow(pluginName, entry)
-		if err != nil {
-			return err
-		}
-		if !effective.Enabled || len(effective.Schedules) == 0 {
-			continue
-		}
+	for _, scheduleKey := range slices.Sorted(maps.Keys(cfg.Workflows.Schedules)) {
+		schedule := cfg.Workflows.Schedules[scheduleKey]
+		pluginName := schedule.Plugin
+		managedKey := workflowConfigScheduleManagedKey(scheduleKey, schedule)
 		provider, allowed, err := runtime.ResolvePlugin(pluginName)
 		if err != nil {
 			return fmt.Errorf("bootstrap: workflow schedules for plugin %q: %w", pluginName, err)
 		}
-		for _, scheduleKey := range slices.Sorted(maps.Keys(effective.Schedules)) {
-			schedule := effective.Schedules[scheduleKey]
-			target := workflowConfigScheduleTarget(pluginName, schedule)
-			if _, ok := allowed[schedule.Operation]; !ok {
-				return fmt.Errorf("bootstrap: workflow schedule %q for plugin %q targets disabled operation %q", scheduleKey, pluginName, schedule.Operation)
+		target := workflowConfigScheduleTarget(schedule)
+		if _, ok := allowed[schedule.Operation]; !ok {
+			return fmt.Errorf("bootstrap: workflow schedule %q for plugin %q targets disabled operation %q", scheduleKey, pluginName, schedule.Operation)
+		}
+		rowID := workflowConfigScheduleStateID(pluginName, managedKey)
+		desiredEntry := desired[rowID]
+		prev, owned := previous[rowID]
+		existingExecutionRef := ""
+		providerCtx := invocation.WithWorkflowContextString(ctx, "plugin", pluginName)
+		existing, err := provider.GetSchedule(providerCtx, coreworkflow.GetScheduleRequest{
+			ScheduleID: desiredEntry.state.ScheduleID,
+		})
+		switch {
+		case err == nil:
+			if !isWorkflowConfigOwnedSchedule(existing, pluginName, desiredEntry.state.ScheduleID) &&
+				!isAdoptableWorkflowSchedule(existing, schedule, desiredEntry.state.ScheduleID) {
+				return fmt.Errorf("bootstrap: workflow schedule %q for plugin %q conflicts with existing unmanaged schedule id %q", scheduleKey, pluginName, desiredEntry.state.ScheduleID)
 			}
-			rowID := workflowConfigScheduleStateID(pluginName, scheduleKey)
-			desiredEntry := desired[rowID]
-			prev, owned := previous[rowID]
-			existingExecutionRef := ""
-			providerCtx := invocation.WithWorkflowContextString(ctx, "plugin", pluginName)
-			existing, err := provider.GetSchedule(providerCtx, coreworkflow.GetScheduleRequest{
-				ScheduleID: desiredEntry.state.ScheduleID,
+		case isWorkflowObjectNotFound(err):
+			existing = nil
+			if owned {
+				existingExecutionRef = strings.TrimSpace(prev.ExecutionRef)
+			}
+		default:
+			return fmt.Errorf("bootstrap: get workflow schedule %q for plugin %q: %w", desiredEntry.state.ScheduleID, pluginName, err)
+		}
+		if existing != nil {
+			existingExecutionRef = workflowScheduleExecutionRef(existing, prev.ExecutionRef)
+		}
+		desiredExecutionRef := &coreworkflow.ExecutionReference{
+			ProviderName: desiredEntry.state.ProviderName,
+			Target:       target,
+			SubjectID:    principal.WorkloadSubjectID(workflowWorkloadID(pluginName)),
+			Permissions:  workflowExecutionRefPermissionsForTarget(target),
+		}
+		executionRefID, createdExecutionRef, err := workflowEnsureConfigScheduleExecutionRef(ctx, executionRefs, desiredEntry.state.ScheduleID, desiredExecutionRef, existingExecutionRef)
+		if err != nil {
+			return fmt.Errorf("bootstrap: store workflow execution ref for schedule %q on plugin %q: %w", scheduleKey, pluginName, err)
+		}
+		if _, err := provider.UpsertSchedule(providerCtx, coreworkflow.UpsertScheduleRequest{
+			ScheduleID:   desiredEntry.state.ScheduleID,
+			Cron:         schedule.Cron,
+			Timezone:     schedule.Timezone,
+			Target:       target,
+			Paused:       schedule.Paused,
+			RequestedBy:  workflowConfigActor(pluginName),
+			ExecutionRef: executionRefID,
+		}); err != nil {
+			if createdExecutionRef {
+				_ = workflowRevokeExecutionRefByID(ctx, executionRefs, executionRefID)
+			}
+			return fmt.Errorf("bootstrap: workflow schedule %q for plugin %q: %w", scheduleKey, pluginName, err)
+		}
+		if existingExecutionRef != executionRefID {
+			if err := workflowRevokeExecutionRefByID(ctx, executionRefs, existingExecutionRef); err != nil {
+				return fmt.Errorf("bootstrap: revoke workflow execution ref %q for schedule %q on plugin %q: %w", existingExecutionRef, desiredEntry.state.ScheduleID, pluginName, err)
+			}
+		}
+		if owned && prev.ProviderName != desiredEntry.state.ProviderName {
+			oldProvider, err := runtime.ResolveProvider(prev.ProviderName)
+			if err != nil {
+				return fmt.Errorf("bootstrap: cleanup workflow schedule %q for plugin %q requires provider %q: %w", prev.ScheduleID, prev.PluginName, prev.ProviderName, err)
+			}
+			oldProviderCtx := invocation.WithWorkflowContextString(ctx, "plugin", prev.PluginName)
+			oldExisting, err := oldProvider.GetSchedule(oldProviderCtx, coreworkflow.GetScheduleRequest{
+				ScheduleID: prev.ScheduleID,
 			})
+			oldExecutionRef := ""
 			switch {
 			case err == nil:
-				if !isWorkflowConfigOwnedSchedule(existing, pluginName, desiredEntry.state.ScheduleID) &&
-					!isAdoptableWorkflowSchedule(existing, pluginName, schedule, desiredEntry.state.ScheduleID) {
-					return fmt.Errorf("bootstrap: workflow schedule %q for plugin %q conflicts with existing unmanaged schedule id %q", scheduleKey, pluginName, desiredEntry.state.ScheduleID)
-				}
+				oldExecutionRef = workflowScheduleExecutionRef(oldExisting, prev.ExecutionRef)
 			case isWorkflowObjectNotFound(err):
-				existing = nil
-				if owned {
-					existingExecutionRef = strings.TrimSpace(prev.ExecutionRef)
-				}
+				oldExecutionRef = strings.TrimSpace(prev.ExecutionRef)
 			default:
-				return fmt.Errorf("bootstrap: get workflow schedule %q for plugin %q: %w", desiredEntry.state.ScheduleID, pluginName, err)
+				return fmt.Errorf("bootstrap: get workflow schedule %q for plugin %q: %w", prev.ScheduleID, prev.PluginName, err)
 			}
-			if existing != nil {
-				existingExecutionRef = workflowScheduleExecutionRef(existing, prev.ExecutionRef)
+			if err := oldProvider.DeleteSchedule(oldProviderCtx, coreworkflow.DeleteScheduleRequest{
+				ScheduleID: prev.ScheduleID,
+			}); err != nil && !isWorkflowObjectNotFound(err) {
+				return fmt.Errorf("bootstrap: delete workflow schedule %q for plugin %q: %w", prev.ScheduleID, prev.PluginName, err)
 			}
-			desiredExecutionRef := &coreworkflow.ExecutionReference{
-				ProviderName: desiredEntry.state.ProviderName,
-				Target:       target,
-				SubjectID:    principal.WorkloadSubjectID(workflowWorkloadID(pluginName)),
-				Permissions:  workflowExecutionRefPermissionsForTarget(target),
+			if err := workflowRevokeExecutionRefByID(ctx, executionRefs, oldExecutionRef); err != nil {
+				return fmt.Errorf("bootstrap: revoke workflow execution ref %q for schedule %q on plugin %q: %w", oldExecutionRef, prev.ScheduleID, prev.PluginName, err)
 			}
-			executionRefID, createdExecutionRef, err := workflowEnsureConfigScheduleExecutionRef(ctx, executionRefs, desiredEntry.state.ScheduleID, desiredExecutionRef, existingExecutionRef)
-			if err != nil {
-				return fmt.Errorf("bootstrap: store workflow execution ref for schedule %q on plugin %q: %w", scheduleKey, pluginName, err)
-			}
-			if _, err := provider.UpsertSchedule(providerCtx, coreworkflow.UpsertScheduleRequest{
-				ScheduleID:   desiredEntry.state.ScheduleID,
-				Cron:         schedule.Cron,
-				Timezone:     schedule.Timezone,
-				Target:       target,
-				Paused:       schedule.Paused,
-				RequestedBy:  workflowConfigActor(pluginName),
-				ExecutionRef: executionRefID,
-			}); err != nil {
-				if createdExecutionRef {
-					_ = workflowRevokeExecutionRefByID(ctx, executionRefs, executionRefID)
-				}
-				return fmt.Errorf("bootstrap: workflow schedule %q for plugin %q: %w", scheduleKey, pluginName, err)
-			}
-			if existingExecutionRef != executionRefID {
-				if err := workflowRevokeExecutionRefByID(ctx, executionRefs, existingExecutionRef); err != nil {
-					return fmt.Errorf("bootstrap: revoke workflow execution ref %q for schedule %q on plugin %q: %w", existingExecutionRef, desiredEntry.state.ScheduleID, pluginName, err)
-				}
-			}
-			if owned && prev.ProviderName != desiredEntry.state.ProviderName {
-				oldProvider, err := runtime.ResolveProvider(prev.ProviderName)
-				if err != nil {
-					return fmt.Errorf("bootstrap: cleanup workflow schedule %q for plugin %q requires provider %q: %w", prev.ScheduleID, prev.PluginName, prev.ProviderName, err)
-				}
-				oldProviderCtx := invocation.WithWorkflowContextString(ctx, "plugin", prev.PluginName)
-				oldExisting, err := oldProvider.GetSchedule(oldProviderCtx, coreworkflow.GetScheduleRequest{
-					ScheduleID: prev.ScheduleID,
-				})
-				oldExecutionRef := ""
-				switch {
-				case err == nil:
-					oldExecutionRef = workflowScheduleExecutionRef(oldExisting, prev.ExecutionRef)
-				case isWorkflowObjectNotFound(err):
-					oldExecutionRef = strings.TrimSpace(prev.ExecutionRef)
-				default:
-					return fmt.Errorf("bootstrap: get workflow schedule %q for plugin %q: %w", prev.ScheduleID, prev.PluginName, err)
-				}
-				if err := oldProvider.DeleteSchedule(oldProviderCtx, coreworkflow.DeleteScheduleRequest{
-					ScheduleID: prev.ScheduleID,
-				}); err != nil && !isWorkflowObjectNotFound(err) {
-					return fmt.Errorf("bootstrap: delete workflow schedule %q for plugin %q: %w", prev.ScheduleID, prev.PluginName, err)
-				}
-				if err := workflowRevokeExecutionRefByID(ctx, executionRefs, oldExecutionRef); err != nil {
-					return fmt.Errorf("bootstrap: revoke workflow execution ref %q for schedule %q on plugin %q: %w", oldExecutionRef, prev.ScheduleID, prev.PluginName, err)
-				}
-			}
-			desiredEntry.state.ExecutionRef = executionRefID
-			if err := store.Put(ctx, desiredEntry.state.record()); err != nil {
-				return fmt.Errorf("bootstrap: store workflow schedule state %q: %w", rowID, err)
-			}
+		}
+		desiredEntry.state.ExecutionRef = executionRefID
+		if err := store.Put(ctx, desiredEntry.state.record()); err != nil {
+			return fmt.Errorf("bootstrap: store workflow schedule state %q: %w", rowID, err)
 		}
 	}
 	return nil
@@ -234,28 +226,27 @@ func desiredWorkflowConfigSchedules(cfg *config.Config) (map[string]desiredWorkf
 		return desired, nil
 	}
 	now := time.Now()
-	for _, pluginName := range slices.Sorted(maps.Keys(cfg.Plugins)) {
-		entry := cfg.Plugins[pluginName]
-		effective, err := cfg.EffectivePluginWorkflow(pluginName, entry)
+	for _, scheduleKey := range slices.Sorted(maps.Keys(cfg.Workflows.Schedules)) {
+		schedule := cfg.Workflows.Schedules[scheduleKey]
+		managedKey := workflowConfigScheduleManagedKey(scheduleKey, schedule)
+		binding, err := cfg.EffectiveWorkflowBinding(schedule.Plugin)
 		if err != nil {
 			return nil, err
 		}
-		if !effective.Enabled {
+		if !binding.Enabled {
 			continue
 		}
-		for _, scheduleKey := range slices.Sorted(maps.Keys(effective.Schedules)) {
-			rowID := workflowConfigScheduleStateID(pluginName, scheduleKey)
-			desired[rowID] = desiredWorkflowConfigSchedule{
-				state: workflowConfigScheduleState{
-					ID:           rowID,
-					PluginName:   pluginName,
-					ScheduleKey:  scheduleKey,
-					ProviderName: effective.ProviderName,
-					ScheduleID:   workflowConfigScheduleID(pluginName, scheduleKey),
-					UpdatedAt:    now,
-				},
-				schedule: effective.Schedules[scheduleKey],
-			}
+		rowID := workflowConfigScheduleStateID(schedule.Plugin, managedKey)
+		desired[rowID] = desiredWorkflowConfigSchedule{
+			state: workflowConfigScheduleState{
+				ID:           rowID,
+				PluginName:   schedule.Plugin,
+				ScheduleKey:  managedKey,
+				ProviderName: binding.ProviderName,
+				ScheduleID:   workflowConfigScheduleID(schedule.Plugin, managedKey),
+				UpdatedAt:    now,
+			},
+			schedule: schedule,
 		}
 	}
 	return desired, nil
@@ -318,7 +309,7 @@ func isWorkflowObjectNotFound(err error) bool {
 	return errors.Is(err, core.ErrNotFound) || status.Code(err) == codes.NotFound
 }
 
-func isAdoptableWorkflowSchedule(existing *coreworkflow.Schedule, pluginName string, schedule config.PluginWorkflowSchedule, scheduleID string) bool {
+func isAdoptableWorkflowSchedule(existing *coreworkflow.Schedule, schedule config.WorkflowScheduleConfig, scheduleID string) bool {
 	if existing == nil {
 		return false
 	}
@@ -326,8 +317,10 @@ func isAdoptableWorkflowSchedule(existing *coreworkflow.Schedule, pluginName str
 		existing.Cron == schedule.Cron &&
 		existing.Timezone == schedule.Timezone &&
 		existing.Paused == schedule.Paused &&
-		existing.Target.PluginName == pluginName &&
+		existing.Target.PluginName == schedule.Plugin &&
 		existing.Target.Operation == schedule.Operation &&
+		existing.Target.Connection == schedule.Connection &&
+		existing.Target.Instance == schedule.Instance &&
 		workflowTargetInputsEqual(existing.Target.Input, schedule.Input)
 }
 
@@ -349,10 +342,12 @@ func workflowTargetInputsEqual(left, right map[string]any) bool {
 	return leftErr == nil && rightErr == nil && bytes.Equal(leftJSON, rightJSON)
 }
 
-func workflowConfigScheduleTarget(pluginName string, schedule config.PluginWorkflowSchedule) coreworkflow.Target {
+func workflowConfigScheduleTarget(schedule config.WorkflowScheduleConfig) coreworkflow.Target {
 	return coreworkflow.Target{
-		PluginName: pluginName,
+		PluginName: schedule.Plugin,
 		Operation:  schedule.Operation,
+		Connection: schedule.Connection,
+		Instance:   schedule.Instance,
 		Input:      maps.Clone(schedule.Input),
 	}
 }
@@ -364,6 +359,13 @@ func workflowConfigActor(pluginName string) coreworkflow.Actor {
 		DisplayName: "Workflow Config (" + pluginName + ")",
 		AuthSource:  "config",
 	}
+}
+
+func workflowConfigScheduleManagedKey(scheduleKey string, schedule config.WorkflowScheduleConfig) string {
+	if managedKey := strings.TrimSpace(schedule.ManagedKey); managedKey != "" {
+		return managedKey
+	}
+	return strings.TrimSpace(scheduleKey)
 }
 
 func workflowConfigScheduleStateID(pluginName, scheduleKey string) string {

--- a/gestaltd/internal/bootstrap/workflow_runtime.go
+++ b/gestaltd/internal/bootstrap/workflow_runtime.go
@@ -39,15 +39,15 @@ type workflowRuntime struct {
 
 func newWorkflowRuntime(cfg *config.Config) (*workflowRuntime, error) {
 	runtime := &workflowRuntime{
-		bindings:               make(map[string]workflowBinding, len(cfg.Plugins)),
+		bindings:               make(map[string]workflowBinding, len(cfg.Workflows.Bindings)),
 		managedScheduleIDs:     make(map[string]map[string]struct{}, len(cfg.Plugins)),
 		managedEventTriggerIDs: make(map[string]map[string]struct{}, len(cfg.Plugins)),
-		workloadTokens:         make(map[string]string, len(cfg.Plugins)),
+		workloadTokens:         make(map[string]string, len(cfg.Workflows.Bindings)),
 		providers:              map[string]coreworkflow.Provider{},
 		startupWaits:           newStartupWaitTracker(),
 	}
-	for pluginName, entry := range cfg.Plugins {
-		effective, err := cfg.EffectivePluginWorkflow(pluginName, entry)
+	for pluginName := range cfg.Workflows.Bindings {
+		effective, err := cfg.EffectiveWorkflowBinding(pluginName)
 		if err != nil {
 			return nil, err
 		}
@@ -62,20 +62,34 @@ func newWorkflowRuntime(cfg *config.Config) (*workflowRuntime, error) {
 			providerName: effective.ProviderName,
 			operations:   allowed,
 		}
-		managedSchedules := make(map[string]struct{}, len(effective.Schedules))
-		for scheduleKey := range effective.Schedules {
-			managedSchedules[workflowConfigScheduleID(pluginName, scheduleKey)] = struct{}{}
-		}
-		runtime.managedScheduleIDs[pluginName] = managedSchedules
-		managedEventTriggers := make(map[string]struct{}, len(effective.EventTriggers))
-		for triggerKey := range effective.EventTriggers {
-			managedEventTriggers[workflowConfigEventTriggerID(pluginName, triggerKey)] = struct{}{}
-		}
-		runtime.managedEventTriggerIDs[pluginName] = managedEventTriggers
 		runtime.workloadTokens[pluginName], err = workflowWorkloadToken()
 		if err != nil {
 			return nil, err
 		}
+	}
+	for scheduleKey := range cfg.Workflows.Schedules {
+		schedule := cfg.Workflows.Schedules[scheduleKey]
+		pluginName := strings.TrimSpace(schedule.Plugin)
+		if pluginName == "" {
+			continue
+		}
+		managedKey := workflowConfigScheduleManagedKey(scheduleKey, schedule)
+		if runtime.managedScheduleIDs[pluginName] == nil {
+			runtime.managedScheduleIDs[pluginName] = map[string]struct{}{}
+		}
+		runtime.managedScheduleIDs[pluginName][workflowConfigScheduleID(pluginName, managedKey)] = struct{}{}
+	}
+	for triggerKey := range cfg.Workflows.EventTriggers {
+		trigger := cfg.Workflows.EventTriggers[triggerKey]
+		pluginName := strings.TrimSpace(trigger.Plugin)
+		if pluginName == "" {
+			continue
+		}
+		managedKey := workflowConfigEventTriggerManagedKey(triggerKey, trigger)
+		if runtime.managedEventTriggerIDs[pluginName] == nil {
+			runtime.managedEventTriggerIDs[pluginName] = map[string]struct{}{}
+		}
+		runtime.managedEventTriggerIDs[pluginName][workflowConfigEventTriggerID(pluginName, managedKey)] = struct{}{}
 	}
 	return runtime, nil
 }

--- a/gestaltd/internal/bootstrap/workflow_startup_test.go
+++ b/gestaltd/internal/bootstrap/workflow_startup_test.go
@@ -241,14 +241,16 @@ func TestBootstrapWorkflowStartupCallbackWaitsForDelayedPluginProvider(t *testin
 			ResolvedManifest:     newExecutableManifest("Roadmap", "Delayed startup provider"),
 			ResolvedManifestPath: filepath.Join(manifestRoot, "manifest.yaml"),
 			ConnectionMode:       providermanifestv1.ConnectionModeIdentity,
-			Workflow: &config.PluginWorkflowConfig{
-				Provider:   "temporal",
-				Operations: []string{"status"},
-			},
 		},
 	}
 	cfg.Providers.Workflow = map[string]*config.ProviderEntry{
 		"temporal": {Source: config.ProviderSource{Path: "stub"}},
+	}
+	cfg.Workflows.Bindings = map[string]*config.WorkflowBindingConfig{
+		"roadmap": {
+			Provider:   "temporal",
+			Operations: []string{"status"},
+		},
 	}
 
 	factories := workflowStartupTestFactories()
@@ -308,14 +310,16 @@ func TestBootstrapPluginStartupWorkflowCallWaitsForWorkflowProvider(t *testing.T
 			Command:              bin,
 			ResolvedManifest:     newExecutableManifest("Roadmap", "Workflow startup client"),
 			ResolvedManifestPath: filepath.Join(manifestRoot, "manifest.yaml"),
-			Workflow: &config.PluginWorkflowConfig{
-				Provider:   "temporal",
-				Operations: []string{"status"},
-			},
 		},
 	}
 	cfg.Providers.Workflow = map[string]*config.ProviderEntry{
 		"temporal": {Source: config.ProviderSource{Path: "stub"}},
+	}
+	cfg.Workflows.Bindings = map[string]*config.WorkflowBindingConfig{
+		"roadmap": {
+			Provider:   "temporal",
+			Operations: []string{"status"},
+		},
 	}
 
 	factories := workflowStartupTestFactories()
@@ -377,14 +381,16 @@ func TestValidatePluginStartupWorkflowCallWaitsForWorkflowProvider(t *testing.T)
 			Command:              bin,
 			ResolvedManifest:     newExecutableManifest("Roadmap", "Workflow startup client"),
 			ResolvedManifestPath: filepath.Join(manifestRoot, "manifest.yaml"),
-			Workflow: &config.PluginWorkflowConfig{
-				Provider:   "temporal",
-				Operations: []string{"status"},
-			},
 		},
 	}
 	cfg.Providers.Workflow = map[string]*config.ProviderEntry{
 		"temporal": {Source: config.ProviderSource{Path: "stub"}},
+	}
+	cfg.Workflows.Bindings = map[string]*config.WorkflowBindingConfig{
+		"roadmap": {
+			Provider:   "temporal",
+			Operations: []string{"status"},
+		},
 	}
 
 	factories := workflowStartupTestFactories()
@@ -425,14 +431,16 @@ func TestBootstrapFailsPendingWorkflowStartupClientsOnAuthorizationErrors(t *tes
 			Command:              bin,
 			ResolvedManifest:     newExecutableManifest("Roadmap", "Workflow startup client"),
 			ResolvedManifestPath: filepath.Join(manifestRoot, "manifest.yaml"),
-			Workflow: &config.PluginWorkflowConfig{
-				Provider:   "temporal",
-				Operations: []string{"status"},
-			},
 		},
 	}
 	cfg.Providers.Workflow = map[string]*config.ProviderEntry{
 		"temporal": {Source: config.ProviderSource{Path: "stub"}},
+	}
+	cfg.Workflows.Bindings = map[string]*config.WorkflowBindingConfig{
+		"roadmap": {
+			Provider:   "temporal",
+			Operations: []string{"status"},
+		},
 	}
 	cfg.Authorization = config.AuthorizationConfig{
 		Workloads: map[string]config.WorkloadDef{
@@ -479,14 +487,16 @@ func TestBootstrapFailsWorkflowStartupDependencyCycles(t *testing.T) {
 			ResolvedManifest:     newExecutableManifest("Roadmap", "Workflow startup client"),
 			ResolvedManifestPath: filepath.Join(manifestRoot, "manifest.yaml"),
 			ConnectionMode:       providermanifestv1.ConnectionModeIdentity,
-			Workflow: &config.PluginWorkflowConfig{
-				Provider:   "temporal",
-				Operations: []string{"status"},
-			},
 		},
 	}
 	cfg.Providers.Workflow = map[string]*config.ProviderEntry{
 		"temporal": {Source: config.ProviderSource{Path: "stub"}},
+	}
+	cfg.Workflows.Bindings = map[string]*config.WorkflowBindingConfig{
+		"roadmap": {
+			Provider:   "temporal",
+			Operations: []string{"status"},
+		},
 	}
 
 	factories := workflowStartupTestFactories()

--- a/gestaltd/internal/config/config.go
+++ b/gestaltd/internal/config/config.go
@@ -60,6 +60,7 @@ type Config struct {
 	Server        ServerConfig              `yaml:"server"`
 	Authorization AuthorizationConfig       `yaml:"authorization,omitempty"`
 	Providers     ProvidersConfig           `yaml:"providers"`
+	Workflows     WorkflowsConfig           `yaml:"workflows,omitempty"`
 	Plugins       map[string]*ProviderEntry `yaml:"plugins,omitempty"`
 }
 
@@ -316,6 +317,46 @@ type PluginIndexedDBConfig struct {
 	Provider     string   `yaml:"provider,omitempty"`
 	DB           string   `yaml:"db,omitempty"`
 	ObjectStores []string `yaml:"objectStores,omitempty"`
+}
+
+type WorkflowsConfig struct {
+	Bindings      map[string]*WorkflowBindingConfig     `yaml:"bindings,omitempty"`
+	Schedules     map[string]WorkflowScheduleConfig     `yaml:"schedules,omitempty"`
+	EventTriggers map[string]WorkflowEventTriggerConfig `yaml:"eventTriggers,omitempty"`
+}
+
+type WorkflowBindingConfig struct {
+	Provider   string   `yaml:"provider,omitempty"`
+	Operations []string `yaml:"operations,omitempty"`
+}
+
+type WorkflowScheduleConfig struct {
+	ManagedKey string         `yaml:"-"`
+	Plugin     string         `yaml:"plugin,omitempty"`
+	Cron       string         `yaml:"cron,omitempty"`
+	Timezone   string         `yaml:"timezone,omitempty"`
+	Operation  string         `yaml:"operation,omitempty"`
+	Connection string         `yaml:"connection,omitempty"`
+	Instance   string         `yaml:"instance,omitempty"`
+	Input      map[string]any `yaml:"input,omitempty"`
+	Paused     bool           `yaml:"paused,omitempty"`
+}
+
+type WorkflowEventTriggerConfig struct {
+	ManagedKey string             `yaml:"-"`
+	Plugin     string             `yaml:"plugin,omitempty"`
+	Match      WorkflowEventMatch `yaml:"match,omitempty"`
+	Operation  string             `yaml:"operation,omitempty"`
+	Connection string             `yaml:"connection,omitempty"`
+	Instance   string             `yaml:"instance,omitempty"`
+	Input      map[string]any     `yaml:"input,omitempty"`
+	Paused     bool               `yaml:"paused,omitempty"`
+}
+
+type WorkflowEventMatch struct {
+	Type    string `yaml:"type,omitempty"`
+	Source  string `yaml:"source,omitempty"`
+	Subject string `yaml:"subject,omitempty"`
 }
 
 type PluginWorkflowConfig struct {
@@ -922,7 +963,105 @@ func NormalizeCompatibility(cfg *Config) error {
 	if err := normalizeAdminConfig(cfg); err != nil {
 		return err
 	}
+	if err := normalizeLegacyPluginWorkflows(cfg); err != nil {
+		return err
+	}
 	return applyPluginMountBindings(cfg)
+}
+
+func normalizeLegacyPluginWorkflows(cfg *Config) error {
+	if cfg == nil {
+		return nil
+	}
+	if cfg.Workflows.Bindings == nil {
+		cfg.Workflows.Bindings = map[string]*WorkflowBindingConfig{}
+	}
+	if cfg.Workflows.Schedules == nil {
+		cfg.Workflows.Schedules = map[string]WorkflowScheduleConfig{}
+	}
+	if cfg.Workflows.EventTriggers == nil {
+		cfg.Workflows.EventTriggers = map[string]WorkflowEventTriggerConfig{}
+	}
+
+	usedScheduleKeys := make(map[string]struct{}, len(cfg.Workflows.Schedules))
+	for key := range cfg.Workflows.Schedules {
+		usedScheduleKeys[key] = struct{}{}
+	}
+	usedTriggerKeys := make(map[string]struct{}, len(cfg.Workflows.EventTriggers))
+	for key := range cfg.Workflows.EventTriggers {
+		usedTriggerKeys[key] = struct{}{}
+	}
+
+	for _, pluginName := range slices.Sorted(maps.Keys(cfg.Plugins)) {
+		entry := cfg.Plugins[pluginName]
+		if entry == nil || entry.Workflow == nil {
+			continue
+		}
+		legacy := entry.Workflow
+		if _, exists := cfg.Workflows.Bindings[pluginName]; exists {
+			return fmt.Errorf("config validation: workflows.bindings.%s conflicts with legacy plugins.%s.workflow", pluginName, pluginName)
+		}
+		cfg.Workflows.Bindings[pluginName] = &WorkflowBindingConfig{
+			Provider:   legacy.Provider,
+			Operations: slices.Clone(legacy.Operations),
+		}
+		for _, key := range slices.Sorted(maps.Keys(legacy.Schedules)) {
+			schedule := legacy.Schedules[key]
+			globalKey := uniqueWorkflowObjectKey(usedScheduleKeys, pluginName, key)
+			cfg.Workflows.Schedules[globalKey] = WorkflowScheduleConfig{
+				ManagedKey: key,
+				Plugin:     pluginName,
+				Cron:       schedule.Cron,
+				Timezone:   schedule.Timezone,
+				Operation:  schedule.Operation,
+				Input:      maps.Clone(schedule.Input),
+				Paused:     schedule.Paused,
+			}
+		}
+		for _, key := range slices.Sorted(maps.Keys(legacy.EventTriggers)) {
+			trigger := legacy.EventTriggers[key]
+			globalKey := uniqueWorkflowObjectKey(usedTriggerKeys, pluginName, key)
+			cfg.Workflows.EventTriggers[globalKey] = WorkflowEventTriggerConfig{
+				ManagedKey: key,
+				Plugin:     pluginName,
+				Match: WorkflowEventMatch{
+					Type:    trigger.Match.Type,
+					Source:  trigger.Match.Source,
+					Subject: trigger.Match.Subject,
+				},
+				Operation: trigger.Operation,
+				Input:     maps.Clone(trigger.Input),
+				Paused:    trigger.Paused,
+			}
+		}
+		entry.Workflow = nil
+	}
+	return nil
+}
+
+func uniqueWorkflowObjectKey(used map[string]struct{}, pluginName, key string) string {
+	key = strings.TrimSpace(key)
+	if _, exists := used[key]; !exists {
+		used[key] = struct{}{}
+		return key
+	}
+	base := strings.TrimSpace(pluginName)
+	if base == "" {
+		base = "workflow"
+	}
+	candidate := base + "." + key
+	if _, exists := used[candidate]; !exists {
+		used[candidate] = struct{}{}
+		return candidate
+	}
+	for i := 2; ; i++ {
+		candidate = fmt.Sprintf("%s.%s.%d", base, key, i)
+		if _, exists := used[candidate]; exists {
+			continue
+		}
+		used[candidate] = struct{}{}
+		return candidate
+	}
 }
 
 func OverlayRemotePluginConfig(path string, cfg *Config) error {
@@ -1635,6 +1774,9 @@ func applyDefaults(cfg *Config) {
 		cfg.Server.Public.Port = 8080
 	}
 	cfg.Plugins = nonNilProviderEntryMap(cfg.Plugins)
+	cfg.Workflows.Bindings = nonNilWorkflowBindingMap(cfg.Workflows.Bindings)
+	cfg.Workflows.Schedules = nonNilWorkflowScheduleMap(cfg.Workflows.Schedules)
+	cfg.Workflows.EventTriggers = nonNilWorkflowEventTriggerMap(cfg.Workflows.EventTriggers)
 	cfg.Providers.UI = nonNilUIEntryMap(cfg.Providers.UI)
 	cfg.Providers.Auth = nonNilProviderEntryMap(cfg.Providers.Auth)
 	cfg.Providers.Authorization = nonNilProviderEntryMap(cfg.Providers.Authorization)
@@ -1645,6 +1787,27 @@ func applyDefaults(cfg *Config) {
 	cfg.Providers.Cache = nonNilProviderEntryMap(cfg.Providers.Cache)
 	cfg.Providers.S3 = nonNilProviderEntryMap(cfg.Providers.S3)
 	cfg.Providers.Workflow = nonNilProviderEntryMap(cfg.Providers.Workflow)
+}
+
+func nonNilWorkflowBindingMap(in map[string]*WorkflowBindingConfig) map[string]*WorkflowBindingConfig {
+	if in == nil {
+		return map[string]*WorkflowBindingConfig{}
+	}
+	return in
+}
+
+func nonNilWorkflowScheduleMap(in map[string]WorkflowScheduleConfig) map[string]WorkflowScheduleConfig {
+	if in == nil {
+		return map[string]WorkflowScheduleConfig{}
+	}
+	return in
+}
+
+func nonNilWorkflowEventTriggerMap(in map[string]WorkflowEventTriggerConfig) map[string]WorkflowEventTriggerConfig {
+	if in == nil {
+		return map[string]WorkflowEventTriggerConfig{}
+	}
+	return in
 }
 
 func normalizeProviderSourceShapes(cfg *Config) {

--- a/gestaltd/internal/config/config_test.go
+++ b/gestaltd/internal/config/config_test.go
@@ -2388,7 +2388,7 @@ server:
 		}
 	})
 
-	t.Run("plugin accepts workflow bindings", func(t *testing.T) {
+	t.Run("top-level workflows config is canonicalized", func(t *testing.T) {
 		t.Parallel()
 
 		path := mustWriteConfigFile(t, `
@@ -2396,26 +2396,30 @@ plugins:
   roadmap:
     source:
       path: ./plugin/manifest.yaml
-    workflow:
+workflows:
+  bindings:
+    roadmap:
       provider: temporal
       operations:
         - nightly_sync
         - backfill_items
-      schedules:
-        nightly:
-          cron: "0 2 * * *"
-          operation: nightly_sync
-          input:
-            source: yaml
-      eventTriggers:
-        task_updated:
-          match:
-            type: roadmap.task.updated
-            source: roadmap
-          operation: backfill_items
-          paused: true
-          input:
-            source: event
+  schedules:
+    nightly:
+      plugin: roadmap
+      cron: "0 2 * * *"
+      operation: nightly_sync
+      input:
+        source: yaml
+  eventTriggers:
+    task_updated:
+      plugin: roadmap
+      match:
+        type: roadmap.task.updated
+        source: roadmap
+      operation: backfill_items
+      paused: true
+      input:
+        source: event
 providers:
   workflow:
     temporal:
@@ -2435,39 +2439,45 @@ server:
 		if err != nil {
 			t.Fatalf("Load: %v", err)
 		}
-		want := &PluginWorkflowConfig{
+		wantBinding := &WorkflowBindingConfig{
 			Provider:   "temporal",
 			Operations: []string{"nightly_sync", "backfill_items"},
-			Schedules: map[string]PluginWorkflowSchedule{
-				"nightly": {
-					Cron:      "0 2 * * *",
-					Timezone:  "UTC",
-					Operation: "nightly_sync",
-					Input: map[string]any{
-						"source": "yaml",
-					},
-				},
-			},
-			EventTriggers: map[string]PluginWorkflowEventTrigger{
-				"task_updated": {
-					Match: PluginWorkflowEventMatch{
-						Type:   "roadmap.task.updated",
-						Source: "roadmap",
-					},
-					Operation: "backfill_items",
-					Paused:    true,
-					Input: map[string]any{
-						"source": "event",
-					},
-				},
+		}
+		if got := cfg.Workflows.Bindings["roadmap"]; !reflect.DeepEqual(got, wantBinding) {
+			t.Fatalf("Workflows.Bindings[roadmap] = %#v, want %#v", got, wantBinding)
+		}
+		wantSchedule := WorkflowScheduleConfig{
+			ManagedKey: "nightly",
+			Plugin:     "roadmap",
+			Cron:       "0 2 * * *",
+			Timezone:   "UTC",
+			Operation:  "nightly_sync",
+			Input: map[string]any{
+				"source": "yaml",
 			},
 		}
-		if got := cfg.Plugins["roadmap"].Workflow; !reflect.DeepEqual(got, want) {
-			t.Fatalf("Plugins[roadmap].Workflow = %#v, want %#v", got, want)
+		if got := cfg.Workflows.Schedules["nightly"]; !reflect.DeepEqual(got, wantSchedule) {
+			t.Fatalf("Workflows.Schedules[nightly] = %#v, want %#v", got, wantSchedule)
+		}
+		wantTrigger := WorkflowEventTriggerConfig{
+			ManagedKey: "task_updated",
+			Plugin:     "roadmap",
+			Match: WorkflowEventMatch{
+				Type:   "roadmap.task.updated",
+				Source: "roadmap",
+			},
+			Operation: "backfill_items",
+			Paused:    true,
+			Input: map[string]any{
+				"source": "event",
+			},
+		}
+		if got := cfg.Workflows.EventTriggers["task_updated"]; !reflect.DeepEqual(got, wantTrigger) {
+			t.Fatalf("Workflows.EventTriggers[task_updated] = %#v, want %#v", got, wantTrigger)
 		}
 	})
 
-	t.Run("plugin workflow binding can select an explicit provider when multiple workflow providers exist", func(t *testing.T) {
+	t.Run("legacy plugin workflow config is canonicalized into top-level workflows", func(t *testing.T) {
 		t.Parallel()
 
 		path := mustWriteConfigFile(t, `
@@ -2476,6 +2486,117 @@ plugins:
     source:
       path: ./plugin/manifest.yaml
     workflow:
+      provider: temporal
+      operations:
+        - nightly_sync
+      schedules:
+        nightly:
+          cron: "0 2 * * *"
+          operation: nightly_sync
+providers:
+  workflow:
+    temporal:
+      source:
+        path: ./providers/workflow/temporal
+  indexeddb:
+    sqlite:
+      source:
+        path: ./providers/datastore/sqlite
+server:
+  providers:
+    indexeddb: sqlite
+  encryptionKey: server-key
+`)
+
+		cfg, err := Load(path)
+		if err != nil {
+			t.Fatalf("Load: %v", err)
+		}
+		if cfg.Plugins["roadmap"].Workflow != nil {
+			t.Fatalf("Plugins[roadmap].Workflow = %#v, want nil after canonicalization", cfg.Plugins["roadmap"].Workflow)
+		}
+		if got := cfg.Workflows.Bindings["roadmap"]; got == nil || got.Provider != "temporal" || !reflect.DeepEqual(got.Operations, []string{"nightly_sync"}) {
+			t.Fatalf("Workflows.Bindings[roadmap] = %#v", got)
+		}
+		schedule, ok := cfg.Workflows.Schedules["nightly"]
+		if !ok {
+			t.Fatalf("Workflows.Schedules = %#v, want nightly", cfg.Workflows.Schedules)
+		}
+		if schedule.Plugin != "roadmap" || schedule.ManagedKey != "nightly" || schedule.Operation != "nightly_sync" {
+			t.Fatalf("Workflows.Schedules[nightly] = %#v", schedule)
+		}
+	})
+
+	t.Run("legacy duplicate workflow keys are lifted deterministically", func(t *testing.T) {
+		t.Parallel()
+
+		path := mustWriteConfigFile(t, `
+plugins:
+  alpha:
+    source:
+      path: ./plugin/manifest.yaml
+    workflow:
+      provider: temporal
+      operations:
+        - sync
+      schedules:
+        nightly:
+          cron: "0 2 * * *"
+          operation: sync
+  beta:
+    source:
+      path: ./plugin/manifest.yaml
+    workflow:
+      provider: temporal
+      operations:
+        - sync
+      schedules:
+        nightly:
+          cron: "0 3 * * *"
+          operation: sync
+providers:
+  workflow:
+    temporal:
+      source:
+        path: ./providers/workflow/temporal
+  indexeddb:
+    sqlite:
+      source:
+        path: ./providers/datastore/sqlite
+server:
+  providers:
+    indexeddb: sqlite
+  encryptionKey: server-key
+`)
+
+		cfg, err := Load(path)
+		if err != nil {
+			t.Fatalf("Load: %v", err)
+		}
+		alpha := cfg.Workflows.Schedules["nightly"]
+		if alpha.Plugin != "alpha" || alpha.ManagedKey != "nightly" {
+			t.Fatalf("Workflows.Schedules[nightly] = %#v", alpha)
+		}
+		beta, ok := cfg.Workflows.Schedules["beta.nightly"]
+		if !ok {
+			t.Fatalf("Workflows.Schedules = %#v, want beta.nightly", cfg.Workflows.Schedules)
+		}
+		if beta.Plugin != "beta" || beta.ManagedKey != "nightly" {
+			t.Fatalf("Workflows.Schedules[beta.nightly] = %#v", beta)
+		}
+	})
+
+	t.Run("workflow binding can select an explicit provider when multiple workflow providers exist", func(t *testing.T) {
+		t.Parallel()
+
+		path := mustWriteConfigFile(t, `
+plugins:
+  roadmap:
+    source:
+      path: ./plugin/manifest.yaml
+workflows:
+  bindings:
+    roadmap:
       provider: temporal
       operations:
         - nightly_sync
@@ -2501,9 +2622,9 @@ server:
 		if err != nil {
 			t.Fatalf("Load: %v", err)
 		}
-		effective, err := cfg.EffectivePluginWorkflow("roadmap", cfg.Plugins["roadmap"])
+		effective, err := cfg.EffectiveWorkflowBinding("roadmap")
 		if err != nil {
-			t.Fatalf("EffectivePluginWorkflow: %v", err)
+			t.Fatalf("EffectiveWorkflowBinding: %v", err)
 		}
 		if effective.ProviderName != "temporal" {
 			t.Fatalf("ProviderName = %q, want %q", effective.ProviderName, "temporal")
@@ -2542,7 +2663,7 @@ server:
 		if err == nil {
 			t.Fatal("Load: expected error, got nil")
 		}
-		if !strings.Contains(err.Error(), `ui.root.workflow is only supported on plugins.*`) {
+		if !strings.Contains(err.Error(), `ui.root.workflow has moved to top-level workflows.bindings, workflows.schedules, and workflows.eventTriggers`) {
 			t.Fatalf("unexpected error: %v", err)
 		}
 	})
@@ -2555,7 +2676,9 @@ plugins:
   roadmap:
     source:
       path: ./plugin/manifest.yaml
-    workflow:
+workflows:
+  bindings:
+    roadmap:
       provider: missing
       operations:
         - nightly_sync
@@ -2578,7 +2701,7 @@ server:
 		if err == nil {
 			t.Fatal("Load: expected error, got nil")
 		}
-		if !strings.Contains(err.Error(), `plugins.roadmap.workflow.provider references unknown workflow "missing"`) {
+		if !strings.Contains(err.Error(), `workflows.bindings.roadmap.provider references unknown workflow "missing"`) {
 			t.Fatalf("unexpected error: %v", err)
 		}
 	})
@@ -2591,7 +2714,9 @@ plugins:
   roadmap:
     source:
       path: ./plugin/manifest.yaml
-    workflow:
+workflows:
+  bindings:
+    roadmap:
       provider: temporal
       operations:
         - nightly_sync
@@ -2632,14 +2757,17 @@ plugins:
   roadmap:
     source:
       path: ./plugin/manifest.yaml
-    workflow:
+workflows:
+  bindings:
+    roadmap:
       provider: temporal
       operations:
         - nightly_sync
-      schedules:
-        invalid:
-          cron: "*/5 * * * *"
-          operation: backfill_items
+  schedules:
+    invalid:
+      plugin: roadmap
+      cron: "*/5 * * * *"
+      operation: backfill_items
 providers:
   workflow:
     temporal:
@@ -2659,7 +2787,7 @@ server:
 		if err == nil {
 			t.Fatal("Load: expected error, got nil")
 		}
-		if !strings.Contains(err.Error(), `workflow.schedules.invalid.operation "backfill_items" must be listed`) {
+		if !strings.Contains(err.Error(), `workflows.schedules.invalid.operation "backfill_items" must be listed`) {
 			t.Fatalf("unexpected error: %v", err)
 		}
 	})
@@ -2672,15 +2800,18 @@ plugins:
   roadmap:
     source:
       path: ./plugin/manifest.yaml
-    workflow:
+workflows:
+  bindings:
+    roadmap:
       provider: temporal
       operations:
         - nightly_sync
-      eventTriggers:
-        invalid:
-          match:
-            type: roadmap.task.updated
-          operation: backfill_items
+  eventTriggers:
+    invalid:
+      plugin: roadmap
+      match:
+        type: roadmap.task.updated
+      operation: backfill_items
 providers:
   workflow:
     temporal:
@@ -2700,7 +2831,7 @@ server:
 		if err == nil {
 			t.Fatal("Load: expected error, got nil")
 		}
-		if !strings.Contains(err.Error(), `workflow.eventTriggers.invalid.operation "backfill_items" must be listed`) {
+		if !strings.Contains(err.Error(), `workflows.eventTriggers.invalid.operation "backfill_items" must be listed`) {
 			t.Fatalf("unexpected error: %v", err)
 		}
 	})
@@ -2713,15 +2844,18 @@ plugins:
   roadmap:
     source:
       path: ./plugin/manifest.yaml
-    workflow:
+workflows:
+  bindings:
+    roadmap:
       provider: temporal
       operations:
         - nightly_sync
-      eventTriggers:
-        invalid:
-          match:
-            source: roadmap
-          operation: nightly_sync
+  eventTriggers:
+    invalid:
+      plugin: roadmap
+      match:
+        source: roadmap
+      operation: nightly_sync
 providers:
   workflow:
     temporal:
@@ -2741,7 +2875,7 @@ server:
 		if err == nil {
 			t.Fatal("Load: expected error, got nil")
 		}
-		if !strings.Contains(err.Error(), `workflow.eventTriggers.invalid.match.type is required`) {
+		if !strings.Contains(err.Error(), `workflows.eventTriggers.invalid.match.type is required`) {
 			t.Fatalf("unexpected error: %v", err)
 		}
 	})
@@ -2754,15 +2888,18 @@ plugins:
   roadmap:
     source:
       path: ./plugin/manifest.yaml
-    workflow:
+workflows:
+  bindings:
+    roadmap:
       provider: temporal
       operations:
         - nightly_sync
-      schedules:
-        invalid:
-          cron: "0 0 0 * * *"
-          timezone: Mars/Olympus
-          operation: nightly_sync
+  schedules:
+    invalid:
+      plugin: roadmap
+      cron: "0 0 0 * * *"
+      timezone: Mars/Olympus
+      operation: nightly_sync
 providers:
   workflow:
     temporal:
@@ -2782,7 +2919,7 @@ server:
 		if err == nil {
 			t.Fatal("Load: expected error, got nil")
 		}
-		if !strings.Contains(err.Error(), `workflow.schedules.invalid.cron`) {
+		if !strings.Contains(err.Error(), `workflows.schedules.invalid.cron`) {
 			t.Fatalf("unexpected error: %v", err)
 		}
 	})

--- a/gestaltd/internal/config/config_validate.go
+++ b/gestaltd/internal/config/config_validate.go
@@ -136,7 +136,7 @@ func ValidateCanonicalStructure(cfg *Config) error {
 			return err
 		}
 	}
-	return nil
+	return validateWorkflowsConfig(cfg)
 }
 
 func validateAPIVersion(cfg *Config) error {
@@ -558,7 +558,7 @@ func validateWorkflowProviderFields(cfg *Config, name string, entry *ProviderEnt
 		return fmt.Errorf("config validation: %s.invokes is only supported on plugins.*", subject)
 	}
 	if entry.Workflow != nil {
-		return fmt.Errorf("config validation: %s.workflow is only supported on plugins.*", subject)
+		return fmt.Errorf("config validation: %s.workflow has moved to top-level workflows.bindings, workflows.schedules, and workflows.eventTriggers", subject)
 	}
 	if entry.Surfaces != nil {
 		return fmt.Errorf("config validation: %s.surfaces is only supported on plugins.*", subject)
@@ -609,7 +609,7 @@ func validatePluginOnlyProviderFields(subject string, entry *ProviderEntry) erro
 		return fmt.Errorf("config validation: %s.invokes is only supported on plugins.*", subject)
 	}
 	if entry.Workflow != nil {
-		return fmt.Errorf("config validation: %s.workflow is only supported on plugins.*", subject)
+		return fmt.Errorf("config validation: %s.workflow has moved to top-level workflows.bindings, workflows.schedules, and workflows.eventTriggers", subject)
 	}
 	if entry.Surfaces != nil {
 		return fmt.Errorf("config validation: %s.surfaces is only supported on plugins.*", subject)
@@ -789,101 +789,161 @@ func validatePluginS3Bindings(cfg *Config, name string, entry *ProviderEntry) er
 	return nil
 }
 
-func validatePluginWorkflowConfig(cfg *Config, name string, entry *ProviderEntry) error {
+func validatePluginWorkflowConfig(_ *Config, name string, entry *ProviderEntry) error {
 	if entry == nil || entry.Workflow == nil {
 		return nil
 	}
-	entry.Workflow.Provider = strings.TrimSpace(entry.Workflow.Provider)
-	seenOps := make(map[string]struct{}, len(entry.Workflow.Operations))
-	for i, op := range entry.Workflow.Operations {
-		op = strings.TrimSpace(op)
-		if op == "" {
-			return fmt.Errorf("config validation: plugins.%s.workflow.operations[%d] is required", name, i)
-		}
-		if _, exists := seenOps[op]; exists {
-			return fmt.Errorf("config validation: plugins.%s.workflow.operations[%d] duplicates %q", name, i, op)
-		}
-		seenOps[op] = struct{}{}
-		entry.Workflow.Operations[i] = op
-	}
-	if len(entry.Workflow.Operations) == 0 {
-		return fmt.Errorf("config validation: plugins.%s.workflow.operations must not be empty", name)
-	}
-	if len(entry.Workflow.Schedules) > 0 {
-		normalized := make(map[string]PluginWorkflowSchedule, len(entry.Workflow.Schedules))
-		for key, schedule := range entry.Workflow.Schedules {
-			key = strings.TrimSpace(key)
-			if key == "" {
-				return fmt.Errorf("config validation: plugins.%s.workflow.schedules keys must not be empty", name)
-			}
-			if _, exists := normalized[key]; exists {
-				return fmt.Errorf("config validation: plugins.%s.workflow.schedules duplicates %q", name, key)
-			}
-			schedule.Cron = strings.TrimSpace(schedule.Cron)
-			if schedule.Cron == "" {
-				return fmt.Errorf("config validation: plugins.%s.workflow.schedules.%s.cron is required", name, key)
-			}
-			if err := validateWorkflowScheduleCron(name, key, schedule.Cron); err != nil {
-				return err
-			}
-			schedule.Operation = strings.TrimSpace(schedule.Operation)
-			if schedule.Operation == "" {
-				return fmt.Errorf("config validation: plugins.%s.workflow.schedules.%s.operation is required", name, key)
-			}
-			if _, exists := seenOps[schedule.Operation]; !exists {
-				return fmt.Errorf("config validation: plugins.%s.workflow.schedules.%s.operation %q must be listed in plugins.%s.workflow.operations", name, key, schedule.Operation, name)
-			}
-			schedule.Timezone = strings.TrimSpace(schedule.Timezone)
-			if schedule.Timezone == "" {
-				schedule.Timezone = "UTC"
-			}
-			if _, err := time.LoadLocation(schedule.Timezone); err != nil {
-				return fmt.Errorf("config validation: plugins.%s.workflow.schedules.%s.timezone %q is invalid: %w", name, key, schedule.Timezone, err)
-			}
-			normalized[key] = schedule
-		}
-		entry.Workflow.Schedules = normalized
-	}
-	if len(entry.Workflow.EventTriggers) > 0 {
-		normalized := make(map[string]PluginWorkflowEventTrigger, len(entry.Workflow.EventTriggers))
-		for key, trigger := range entry.Workflow.EventTriggers {
-			key = strings.TrimSpace(key)
-			if key == "" {
-				return fmt.Errorf("config validation: plugins.%s.workflow.eventTriggers keys must not be empty", name)
-			}
-			if _, exists := normalized[key]; exists {
-				return fmt.Errorf("config validation: plugins.%s.workflow.eventTriggers duplicates %q", name, key)
-			}
-			trigger.Match.Type = strings.TrimSpace(trigger.Match.Type)
-			if trigger.Match.Type == "" {
-				return fmt.Errorf("config validation: plugins.%s.workflow.eventTriggers.%s.match.type is required", name, key)
-			}
-			trigger.Match.Source = strings.TrimSpace(trigger.Match.Source)
-			trigger.Match.Subject = strings.TrimSpace(trigger.Match.Subject)
-			trigger.Operation = strings.TrimSpace(trigger.Operation)
-			if trigger.Operation == "" {
-				return fmt.Errorf("config validation: plugins.%s.workflow.eventTriggers.%s.operation is required", name, key)
-			}
-			if _, exists := seenOps[trigger.Operation]; !exists {
-				return fmt.Errorf("config validation: plugins.%s.workflow.eventTriggers.%s.operation %q must be listed in plugins.%s.workflow.operations", name, key, trigger.Operation, name)
-			}
-			normalized[key] = trigger
-		}
-		entry.Workflow.EventTriggers = normalized
-	}
-	if _, err := cfg.EffectivePluginWorkflow(name, entry); err != nil {
-		return err
-	}
-	return nil
+	return fmt.Errorf("config validation: plugins.%s.workflow has moved to top-level workflows.bindings, workflows.schedules, and workflows.eventTriggers", name)
 }
 
 var workflowScheduleCronParser = cronv3.NewParser(
 	cronv3.Minute | cronv3.Hour | cronv3.Dom | cronv3.Month | cronv3.Dow,
 )
 
-func validateWorkflowScheduleCron(pluginName, scheduleKey, spec string) error {
+func validateWorkflowScheduleCron(scheduleKey, spec string) error {
 	if _, err := workflowScheduleCronParser.Parse(spec); err != nil {
-		return fmt.Errorf("config validation: plugins.%s.workflow.schedules.%s.cron %q is invalid: %w", pluginName, scheduleKey, spec, err)
+		return fmt.Errorf("config validation: workflows.schedules.%s.cron %q is invalid: %w", scheduleKey, spec, err)
+	}
+	return nil
+}
+
+func validateWorkflowsConfig(cfg *Config) error {
+	for pluginName, binding := range cfg.Workflows.Bindings {
+		pluginName = strings.TrimSpace(pluginName)
+		if pluginName == "" {
+			return fmt.Errorf("config validation: workflows.bindings keys must not be empty")
+		}
+		if _, ok := cfg.Plugins[pluginName]; !ok {
+			return fmt.Errorf("config validation: workflows.bindings.%s references unknown plugin %q", pluginName, pluginName)
+		}
+		if binding == nil {
+			return fmt.Errorf("config validation: workflows.bindings.%s is required", pluginName)
+		}
+		binding.Provider = strings.TrimSpace(binding.Provider)
+		seenOps := make(map[string]struct{}, len(binding.Operations))
+		for i, op := range binding.Operations {
+			op = strings.TrimSpace(op)
+			if op == "" {
+				return fmt.Errorf("config validation: workflows.bindings.%s.operations[%d] is required", pluginName, i)
+			}
+			if _, exists := seenOps[op]; exists {
+				return fmt.Errorf("config validation: workflows.bindings.%s.operations[%d] duplicates %q", pluginName, i, op)
+			}
+			seenOps[op] = struct{}{}
+			binding.Operations[i] = op
+		}
+		if len(binding.Operations) == 0 {
+			return fmt.Errorf("config validation: workflows.bindings.%s.operations must not be empty", pluginName)
+		}
+		if _, err := cfg.EffectiveWorkflowBinding(pluginName); err != nil {
+			return err
+		}
+	}
+
+	if len(cfg.Workflows.Schedules) > 0 {
+		normalized := make(map[string]WorkflowScheduleConfig, len(cfg.Workflows.Schedules))
+		for key := range cfg.Workflows.Schedules {
+			schedule := cfg.Workflows.Schedules[key]
+			key = strings.TrimSpace(key)
+			if key == "" {
+				return fmt.Errorf("config validation: workflows.schedules keys must not be empty")
+			}
+			if _, exists := normalized[key]; exists {
+				return fmt.Errorf("config validation: workflows.schedules duplicates %q", key)
+			}
+			schedule.Plugin = strings.TrimSpace(schedule.Plugin)
+			if schedule.Plugin == "" {
+				return fmt.Errorf("config validation: workflows.schedules.%s.plugin is required", key)
+			}
+			if _, ok := cfg.Plugins[schedule.Plugin]; !ok {
+				return fmt.Errorf("config validation: workflows.schedules.%s.plugin references unknown plugin %q", key, schedule.Plugin)
+			}
+			binding, err := cfg.EffectiveWorkflowBinding(schedule.Plugin)
+			if err != nil {
+				return err
+			}
+			if !binding.Enabled {
+				return fmt.Errorf("config validation: workflows.schedules.%s.plugin %q does not have a workflow binding", key, schedule.Plugin)
+			}
+			schedule.Cron = strings.TrimSpace(schedule.Cron)
+			if schedule.Cron == "" {
+				return fmt.Errorf("config validation: workflows.schedules.%s.cron is required", key)
+			}
+			if err := validateWorkflowScheduleCron(key, schedule.Cron); err != nil {
+				return err
+			}
+			schedule.Operation = strings.TrimSpace(schedule.Operation)
+			if schedule.Operation == "" {
+				return fmt.Errorf("config validation: workflows.schedules.%s.operation is required", key)
+			}
+			if !slices.Contains(binding.Operations, schedule.Operation) {
+				return fmt.Errorf("config validation: workflows.schedules.%s.operation %q must be listed in workflows.bindings.%s.operations", key, schedule.Operation, schedule.Plugin)
+			}
+			schedule.Connection = strings.TrimSpace(schedule.Connection)
+			schedule.Instance = strings.TrimSpace(schedule.Instance)
+			schedule.ManagedKey = strings.TrimSpace(schedule.ManagedKey)
+			if schedule.ManagedKey == "" {
+				schedule.ManagedKey = key
+			}
+			schedule.Timezone = strings.TrimSpace(schedule.Timezone)
+			if schedule.Timezone == "" {
+				schedule.Timezone = "UTC"
+			}
+			if _, err := time.LoadLocation(schedule.Timezone); err != nil {
+				return fmt.Errorf("config validation: workflows.schedules.%s.timezone %q is invalid: %w", key, schedule.Timezone, err)
+			}
+			normalized[key] = schedule
+		}
+		cfg.Workflows.Schedules = normalized
+	}
+
+	if len(cfg.Workflows.EventTriggers) > 0 {
+		normalized := make(map[string]WorkflowEventTriggerConfig, len(cfg.Workflows.EventTriggers))
+		for key := range cfg.Workflows.EventTriggers {
+			trigger := cfg.Workflows.EventTriggers[key]
+			key = strings.TrimSpace(key)
+			if key == "" {
+				return fmt.Errorf("config validation: workflows.eventTriggers keys must not be empty")
+			}
+			if _, exists := normalized[key]; exists {
+				return fmt.Errorf("config validation: workflows.eventTriggers duplicates %q", key)
+			}
+			trigger.Plugin = strings.TrimSpace(trigger.Plugin)
+			if trigger.Plugin == "" {
+				return fmt.Errorf("config validation: workflows.eventTriggers.%s.plugin is required", key)
+			}
+			if _, ok := cfg.Plugins[trigger.Plugin]; !ok {
+				return fmt.Errorf("config validation: workflows.eventTriggers.%s.plugin references unknown plugin %q", key, trigger.Plugin)
+			}
+			binding, err := cfg.EffectiveWorkflowBinding(trigger.Plugin)
+			if err != nil {
+				return err
+			}
+			if !binding.Enabled {
+				return fmt.Errorf("config validation: workflows.eventTriggers.%s.plugin %q does not have a workflow binding", key, trigger.Plugin)
+			}
+			trigger.Match.Type = strings.TrimSpace(trigger.Match.Type)
+			if trigger.Match.Type == "" {
+				return fmt.Errorf("config validation: workflows.eventTriggers.%s.match.type is required", key)
+			}
+			trigger.Match.Source = strings.TrimSpace(trigger.Match.Source)
+			trigger.Match.Subject = strings.TrimSpace(trigger.Match.Subject)
+			trigger.Operation = strings.TrimSpace(trigger.Operation)
+			if trigger.Operation == "" {
+				return fmt.Errorf("config validation: workflows.eventTriggers.%s.operation is required", key)
+			}
+			if !slices.Contains(binding.Operations, trigger.Operation) {
+				return fmt.Errorf("config validation: workflows.eventTriggers.%s.operation %q must be listed in workflows.bindings.%s.operations", key, trigger.Operation, trigger.Plugin)
+			}
+			trigger.Connection = strings.TrimSpace(trigger.Connection)
+			trigger.Instance = strings.TrimSpace(trigger.Instance)
+			trigger.ManagedKey = strings.TrimSpace(trigger.ManagedKey)
+			if trigger.ManagedKey == "" {
+				trigger.ManagedKey = key
+			}
+			normalized[key] = trigger
+		}
+		cfg.Workflows.EventTriggers = normalized
 	}
 	return nil
 }

--- a/gestaltd/internal/config/provider_selection.go
+++ b/gestaltd/internal/config/provider_selection.go
@@ -2,7 +2,6 @@ package config
 
 import (
 	"fmt"
-	"maps"
 	"slices"
 	"sort"
 	"strings"
@@ -105,13 +104,11 @@ type EffectiveWorkflowIndexedDB struct {
 	ObjectStores []string
 }
 
-type EffectivePluginWorkflow struct {
-	Enabled       bool
-	ProviderName  string
-	Provider      *ProviderEntry
-	Operations    []string
-	Schedules     map[string]PluginWorkflowSchedule
-	EventTriggers map[string]PluginWorkflowEventTrigger
+type EffectiveWorkflowBinding struct {
+	Enabled      bool
+	ProviderName string
+	Provider     *ProviderEntry
+	Operations   []string
 }
 
 func (c *Config) EffectivePluginIndexedDB(pluginName string, entry *ProviderEntry) (EffectivePluginIndexedDB, error) {
@@ -122,16 +119,20 @@ func (c *Config) EffectivePluginIndexedDB(pluginName string, entry *ProviderEntr
 	return ResolveEffectivePluginIndexedDB(pluginName, entry, selectedName, c.Providers.IndexedDB)
 }
 
-func (c *Config) EffectivePluginWorkflow(pluginName string, entry *ProviderEntry) (EffectivePluginWorkflow, error) {
+func (c *Config) EffectiveWorkflowBinding(pluginName string) (EffectiveWorkflowBinding, error) {
+	binding := (*WorkflowBindingConfig)(nil)
+	if c != nil {
+		binding = c.Workflows.Bindings[pluginName]
+	}
 	selectedName := ""
-	if entry != nil && entry.Workflow != nil && strings.TrimSpace(entry.Workflow.Provider) == "" {
+	if binding != nil && strings.TrimSpace(binding.Provider) == "" {
 		var err error
 		selectedName, _, err = c.SelectedWorkflowProvider()
 		if err != nil {
-			return EffectivePluginWorkflow{}, err
+			return EffectiveWorkflowBinding{}, err
 		}
 	}
-	return ResolveEffectivePluginWorkflow(pluginName, entry, selectedName, c.Providers.Workflow)
+	return ResolveEffectiveWorkflowBinding(pluginName, binding, selectedName, c.Providers.Workflow)
 }
 
 func (c *Config) EffectiveWorkflowIndexedDB(name string, entry *ProviderEntry) (EffectiveWorkflowIndexedDB, error) {
@@ -210,56 +211,30 @@ func ResolveEffectiveWorkflowIndexedDB(name string, entry *ProviderEntry, entrie
 	}, nil
 }
 
-func ResolveEffectivePluginWorkflow(pluginName string, entry *ProviderEntry, selectedName string, entries map[string]*ProviderEntry) (EffectivePluginWorkflow, error) {
-	if entry == nil || entry.Workflow == nil {
-		return EffectivePluginWorkflow{}, nil
+func ResolveEffectiveWorkflowBinding(pluginName string, binding *WorkflowBindingConfig, selectedName string, entries map[string]*ProviderEntry) (EffectiveWorkflowBinding, error) {
+	if binding == nil {
+		return EffectiveWorkflowBinding{}, nil
 	}
 
-	providerName := strings.TrimSpace(entry.Workflow.Provider)
+	providerName := strings.TrimSpace(binding.Provider)
 	if providerName == "" {
 		providerName = strings.TrimSpace(selectedName)
 	}
 	if providerName == "" {
-		return EffectivePluginWorkflow{}, fmt.Errorf("config validation: plugins.%s.workflow requires workflow.provider or a selected/default providers.workflow entry", pluginName)
+		return EffectiveWorkflowBinding{}, fmt.Errorf("config validation: workflows.bindings.%s requires provider or a selected/default providers.workflow entry", pluginName)
 	}
 
 	provider, ok := entries[providerName]
 	if !ok || provider == nil {
-		return EffectivePluginWorkflow{}, fmt.Errorf("config validation: plugins.%s.workflow.provider references unknown workflow %q", pluginName, providerName)
+		return EffectiveWorkflowBinding{}, fmt.Errorf("config validation: workflows.bindings.%s.provider references unknown workflow %q", pluginName, providerName)
 	}
 
-	return EffectivePluginWorkflow{
-		Enabled:       true,
-		ProviderName:  providerName,
-		Provider:      provider,
-		Operations:    slices.Clone(entry.Workflow.Operations),
-		Schedules:     clonePluginWorkflowSchedules(entry.Workflow.Schedules),
-		EventTriggers: clonePluginWorkflowEventTriggers(entry.Workflow.EventTriggers),
+	return EffectiveWorkflowBinding{
+		Enabled:      true,
+		ProviderName: providerName,
+		Provider:     provider,
+		Operations:   slices.Clone(binding.Operations),
 	}, nil
-}
-
-func clonePluginWorkflowSchedules(src map[string]PluginWorkflowSchedule) map[string]PluginWorkflowSchedule {
-	if len(src) == 0 {
-		return nil
-	}
-	dst := make(map[string]PluginWorkflowSchedule, len(src))
-	for key, schedule := range src {
-		schedule.Input = maps.Clone(schedule.Input)
-		dst[key] = schedule
-	}
-	return dst
-}
-
-func clonePluginWorkflowEventTriggers(src map[string]PluginWorkflowEventTrigger) map[string]PluginWorkflowEventTrigger {
-	if len(src) == 0 {
-		return nil
-	}
-	dst := make(map[string]PluginWorkflowEventTrigger, len(src))
-	for key, trigger := range src {
-		trigger.Input = maps.Clone(trigger.Input)
-		dst[key] = trigger
-	}
-	return dst
 }
 
 func ResolveSelectedHostProvider(kind HostProviderKind, explicit string, entries map[string]*ProviderEntry) (string, *ProviderEntry, error) {


### PR DESCRIPTION
## Summary

Move config-managed workflow bindings, schedules, and event triggers out of `plugins.<plugin>.workflow.*` and into a top-level `workflows:` config model.

This keeps `providers.workflow` as the workflow provider registry, but makes managed workflow config global and explicit:
- `workflows.bindings.<plugin>` declares which workflow provider and operations a plugin is bound to
- `workflows.schedules.<name>` declares managed schedules with explicit `plugin`
- `workflows.eventTriggers.<name>` declares managed event triggers with explicit `plugin`

The change also preserves upgrade behavior:
- legacy `plugins.<plugin>.workflow` config is canonicalized into the top-level model during normalization
- config-managed workflow schedule/trigger IDs remain plugin-scoped internally so persisted managed state survives the migration
- duplicate legacy local names like `nightly` across multiple plugins are lifted deterministically by prefixing later collisions in the top-level map while preserving the original plugin-local managed key internally

## New Interfaces

Top-level config:

```yaml
workflows:
  bindings:
    roadmap:
      provider: temporal
      operations:
        - sync
        - backfill

  schedules:
    nightly:
      plugin: roadmap
      cron: "0 2 * * *"
      timezone: America/New_York
      operation: sync
      connection: analytics
      instance: tenant-a
      input:
        source: yaml
      paused: false

  eventTriggers:
    task_updated:
      plugin: roadmap
      match:
        type: roadmap.task.updated
        source: roadmap
        subject: ticket-123
      operation: backfill
      connection: analytics
      instance: tenant-a
      input:
        source: event
      paused: false
```

Effective binding resolution:
- `workflows.bindings.<plugin>.provider`
- `workflows.bindings.<plugin>.operations[]`

Managed schedule fields:
- `workflows.schedules.<name>.plugin`
- `workflows.schedules.<name>.cron`
- `workflows.schedules.<name>.timezone`
- `workflows.schedules.<name>.operation`
- `workflows.schedules.<name>.connection`
- `workflows.schedules.<name>.instance`
- `workflows.schedules.<name>.input`
- `workflows.schedules.<name>.paused`

Managed event trigger fields:
- `workflows.eventTriggers.<name>.plugin`
- `workflows.eventTriggers.<name>.match.type`
- `workflows.eventTriggers.<name>.match.source`
- `workflows.eventTriggers.<name>.match.subject`
- `workflows.eventTriggers.<name>.operation`
- `workflows.eventTriggers.<name>.connection`
- `workflows.eventTriggers.<name>.instance`
- `workflows.eventTriggers.<name>.input`
- `workflows.eventTriggers.<name>.paused`

## Legacy Migration Example

This legacy config:

```yaml
plugins:
  roadmap:
    source:
      path: ./plugin/manifest.yaml
    workflow:
      provider: temporal
      operations:
        - sync
      schedules:
        nightly:
          cron: "0 2 * * *"
          operation: sync
```

is canonicalized to the equivalent top-level model during config normalization.

If multiple plugins previously used the same local schedule or event-trigger key, the lifted top-level keys are made unique deterministically while preserving the original plugin-local managed key internally.

## Behavior Changes

- Config-managed schedules and event triggers are now read from `workflows.schedules` and `workflows.eventTriggers`
- Runtime bindings are built from `workflows.bindings`
- The old `plugins.<plugin>.workflow` shape is no longer the canonical config model
- Workflow provider host services are exposed based on runtime workflow bindings rather than `entry.Workflow != nil`

## Verification

```bash
go test ./internal/config ./internal/bootstrap ./internal/server ./internal/operator -count=1
golangci-lint run ./internal/config ./internal/bootstrap ./internal/server ./internal/operator
```