### PR TITLE
config: remove legacy plugin workflow YAML

### DIFF
--- a/gestaltd/internal/bootstrap/bootstrap_test.go
+++ b/gestaltd/internal/bootstrap/bootstrap_test.go
@@ -813,14 +813,42 @@ func workflowStartupCallbackConfig(baseURL string) *config.Config {
 	cfg.Providers.Workflow = map[string]*config.ProviderEntry{
 		"temporal": {Source: config.ProviderSource{Path: "stub"}},
 	}
-	setWorkflowFixture(cfg, "roadmap", &config.PluginWorkflowConfig{
+	setWorkflowFixture(cfg, "roadmap", &workflowFixture{
 		Provider:   "temporal",
 		Operations: []string{"sync"},
 	})
 	return cfg
 }
 
-func setWorkflowFixture(cfg *config.Config, plugin string, workflow *config.PluginWorkflowConfig) {
+type workflowFixture struct {
+	Provider      string
+	Operations    []string
+	Schedules     map[string]workflowFixtureSchedule
+	EventTriggers map[string]workflowFixtureEventTrigger
+}
+
+type workflowFixtureSchedule struct {
+	Cron      string
+	Timezone  string
+	Operation string
+	Input     map[string]any
+	Paused    bool
+}
+
+type workflowFixtureEventTrigger struct {
+	Match     workflowFixtureEventMatch
+	Operation string
+	Input     map[string]any
+	Paused    bool
+}
+
+type workflowFixtureEventMatch struct {
+	Type    string
+	Source  string
+	Subject string
+}
+
+func setWorkflowFixture(cfg *config.Config, plugin string, workflow *workflowFixture) {
 	if cfg == nil {
 		return
 	}
@@ -1532,10 +1560,10 @@ func TestBootstrapAppliesConfiguredWorkflowSchedules(t *testing.T) {
 	t.Parallel()
 
 	cfg := workflowStartupCallbackConfig("https://example.invalid")
-	setWorkflowFixture(cfg, "roadmap", &config.PluginWorkflowConfig{
+	setWorkflowFixture(cfg, "roadmap", &workflowFixture{
 		Provider:   "temporal",
 		Operations: []string{"sync"},
-		Schedules: map[string]config.PluginWorkflowSchedule{
+		Schedules: map[string]workflowFixtureSchedule{
 			"nightly_sync": {
 				Cron:      "0 2 * * *",
 				Timezone:  "America/New_York",
@@ -1573,7 +1601,7 @@ func TestBootstrapAppliesConfiguredWorkflowSchedules(t *testing.T) {
 		t.Fatalf("upserted schedules = %d, want 1", len(recorder.upsertedSchedules))
 	}
 	got := recorder.upsertedSchedules[0]
-	if got.ScheduleID != workflowConfigScheduleID("roadmap", "nightly_sync") {
+	if got.ScheduleID != workflowConfigScheduleID("nightly_sync") {
 		t.Fatalf("schedule id = %q", got.ScheduleID)
 	}
 	if got.Cron != "0 2 * * *" || got.Timezone != "America/New_York" {
@@ -1607,10 +1635,10 @@ func TestValidateDoesNotApplyConfiguredWorkflowSchedules(t *testing.T) {
 	t.Parallel()
 
 	cfg := workflowStartupCallbackConfig("https://example.invalid")
-	setWorkflowFixture(cfg, "roadmap", &config.PluginWorkflowConfig{
+	setWorkflowFixture(cfg, "roadmap", &workflowFixture{
 		Provider:   "temporal",
 		Operations: []string{"sync"},
-		Schedules: map[string]config.PluginWorkflowSchedule{
+		Schedules: map[string]workflowFixtureSchedule{
 			"nightly_sync": {
 				Cron:      "0 2 * * *",
 				Timezone:  "UTC",
@@ -1661,10 +1689,10 @@ func TestBootstrapDeletesRemovedConfiguredWorkflowSchedules(t *testing.T) {
 	}
 
 	cfg := workflowStartupCallbackConfig("https://example.invalid")
-	setWorkflowFixture(cfg, "roadmap", &config.PluginWorkflowConfig{
+	setWorkflowFixture(cfg, "roadmap", &workflowFixture{
 		Provider:   "temporal",
 		Operations: []string{"sync"},
-		Schedules: map[string]config.PluginWorkflowSchedule{
+		Schedules: map[string]workflowFixtureSchedule{
 			"nightly_sync": {
 				Cron:      "0 2 * * *",
 				Timezone:  "UTC",
@@ -1690,7 +1718,7 @@ func TestBootstrapDeletesRemovedConfiguredWorkflowSchedules(t *testing.T) {
 	_ = result.Close(context.Background())
 
 	cfg = workflowStartupCallbackConfig("https://example.invalid")
-	setWorkflowFixture(cfg, "roadmap", &config.PluginWorkflowConfig{
+	setWorkflowFixture(cfg, "roadmap", &workflowFixture{
 		Provider:   "temporal",
 		Operations: []string{"sync"},
 	})
@@ -1708,7 +1736,7 @@ func TestBootstrapDeletesRemovedConfiguredWorkflowSchedules(t *testing.T) {
 	if len(recorders) != 2 {
 		t.Fatalf("recorders = %d, want 2", len(recorders))
 	}
-	staleID := workflowConfigScheduleID("roadmap", "nightly_sync")
+	staleID := workflowConfigScheduleID("nightly_sync")
 	recorder := recorders[1]
 	if len(recorder.deletedSchedules) != 1 {
 		t.Fatalf("deleted schedules = %d, want 1", len(recorder.deletedSchedules))
@@ -1732,7 +1760,7 @@ func TestBootstrapIgnoresUserSchedulesThatOnlyShareCfgPrefix(t *testing.T) {
 	t.Parallel()
 
 	cfg := workflowStartupCallbackConfig("https://example.invalid")
-	setWorkflowFixture(cfg, "roadmap", &config.PluginWorkflowConfig{
+	setWorkflowFixture(cfg, "roadmap", &workflowFixture{
 		Provider:   "temporal",
 		Operations: []string{"sync"},
 	})
@@ -1780,10 +1808,10 @@ func TestBootstrapMovesConfiguredWorkflowSchedulesToNewProvider(t *testing.T) {
 	}
 
 	cfg := workflowStartupCallbackConfig("https://example.invalid")
-	setWorkflowFixture(cfg, "roadmap", &config.PluginWorkflowConfig{
+	setWorkflowFixture(cfg, "roadmap", &workflowFixture{
 		Provider:   "temporal",
 		Operations: []string{"sync"},
-		Schedules: map[string]config.PluginWorkflowSchedule{
+		Schedules: map[string]workflowFixtureSchedule{
 			"nightly_sync": {
 				Cron:      "0 2 * * *",
 				Timezone:  "UTC",
@@ -1810,10 +1838,10 @@ func TestBootstrapMovesConfiguredWorkflowSchedulesToNewProvider(t *testing.T) {
 	_ = result.Close(context.Background())
 
 	cfg = workflowStartupCallbackConfig("https://example.invalid")
-	setWorkflowFixture(cfg, "roadmap", &config.PluginWorkflowConfig{
+	setWorkflowFixture(cfg, "roadmap", &workflowFixture{
 		Provider:   "backup",
 		Operations: []string{"sync"},
-		Schedules: map[string]config.PluginWorkflowSchedule{
+		Schedules: map[string]workflowFixtureSchedule{
 			"nightly_sync": {
 				Cron:      "0 2 * * *",
 				Timezone:  "UTC",
@@ -1869,7 +1897,7 @@ func TestBootstrapClosesWorkflowProvidersWhenConfigScheduleReconcileFails(t *tes
 	t.Parallel()
 
 	cfg := workflowStartupCallbackConfig("https://example.invalid")
-	setWorkflowFixture(cfg, "roadmap", &config.PluginWorkflowConfig{
+	setWorkflowFixture(cfg, "roadmap", &workflowFixture{
 		Provider:   "temporal",
 		Operations: []string{"sync"},
 	})
@@ -1901,10 +1929,10 @@ func TestBootstrapClosesWorkflowProvidersWhenConfigScheduleReconcileFails(t *tes
 	_ = result.Close(context.Background())
 
 	cfg = workflowStartupCallbackConfig("https://example.invalid")
-	setWorkflowFixture(cfg, "roadmap", &config.PluginWorkflowConfig{
+	setWorkflowFixture(cfg, "roadmap", &workflowFixture{
 		Provider:   "backup",
 		Operations: []string{"sync"},
-		Schedules: map[string]config.PluginWorkflowSchedule{
+		Schedules: map[string]workflowFixtureSchedule{
 			"nightly_sync": {
 				Cron:      "0 2 * * *",
 				Timezone:  "UTC",
@@ -1932,10 +1960,10 @@ func TestBootstrapDoesNotApplyConfiguredWorkflowSchedulesWhenAuditBuildFails(t *
 	t.Parallel()
 
 	cfg := workflowStartupCallbackConfig("https://example.invalid")
-	setWorkflowFixture(cfg, "roadmap", &config.PluginWorkflowConfig{
+	setWorkflowFixture(cfg, "roadmap", &workflowFixture{
 		Provider:   "temporal",
 		Operations: []string{"sync"},
-		Schedules: map[string]config.PluginWorkflowSchedule{
+		Schedules: map[string]workflowFixtureSchedule{
 			"nightly_sync": {
 				Cron:      "0 2 * * *",
 				Timezone:  "UTC",
@@ -1975,10 +2003,10 @@ func TestBootstrapRejectsExistingUnmanagedWorkflowScheduleID(t *testing.T) {
 	t.Parallel()
 
 	cfg := workflowStartupCallbackConfig("https://example.invalid")
-	setWorkflowFixture(cfg, "roadmap", &config.PluginWorkflowConfig{
+	setWorkflowFixture(cfg, "roadmap", &workflowFixture{
 		Provider:   "temporal",
 		Operations: []string{"sync"},
-		Schedules: map[string]config.PluginWorkflowSchedule{
+		Schedules: map[string]workflowFixtureSchedule{
 			"nightly_sync": {
 				Cron:      "0 2 * * *",
 				Timezone:  "UTC",
@@ -1991,7 +2019,7 @@ func TestBootstrapRejectsExistingUnmanagedWorkflowScheduleID(t *testing.T) {
 	}
 
 	recorder := &recordingWorkflowProvider{
-		getSchedule: &coreworkflow.Schedule{ID: workflowConfigScheduleID("roadmap", "nightly_sync")},
+		getSchedule: &coreworkflow.Schedule{ID: workflowConfigScheduleID("nightly_sync")},
 	}
 	factories := validFactories()
 	factories.Workflow = func(_ context.Context, _ string, _ yaml.Node, _ []providerhost.HostService, _ bootstrap.Deps) (coreworkflow.Provider, error) {
@@ -2021,10 +2049,10 @@ func TestBootstrapReAdoptsManagedSchedulesWhenOwnershipStateIsMissing(t *testing
 	}
 
 	cfg := workflowStartupCallbackConfig("https://example.invalid")
-	setWorkflowFixture(cfg, "roadmap", &config.PluginWorkflowConfig{
+	setWorkflowFixture(cfg, "roadmap", &workflowFixture{
 		Provider:   "temporal",
 		Operations: []string{"sync"},
-		Schedules: map[string]config.PluginWorkflowSchedule{
+		Schedules: map[string]workflowFixtureSchedule{
 			"nightly_sync": {
 				Cron:      "0 2 * * *",
 				Timezone:  "UTC",
@@ -2045,7 +2073,7 @@ func TestBootstrapReAdoptsManagedSchedulesWhenOwnershipStateIsMissing(t *testing
 		t.Fatalf("initial upserted schedules = %d, want 1", len(provider.upsertedSchedules))
 	}
 	initialExecutionRef := provider.upsertedSchedules[0].ExecutionRef
-	provider.schedules[workflowConfigScheduleID("roadmap", "nightly_sync")].Target.Input = map[string]any{
+	provider.schedules[workflowConfigScheduleID("nightly_sync")].Target.Input = map[string]any{
 		"limit": float64(1),
 	}
 
@@ -2085,10 +2113,10 @@ func TestBootstrapReusesConfiguredWorkflowExecutionRefAcrossUnchangedBootstrap(t
 	}
 
 	cfg := workflowStartupCallbackConfig("https://example.invalid")
-	setWorkflowFixture(cfg, "roadmap", &config.PluginWorkflowConfig{
+	setWorkflowFixture(cfg, "roadmap", &workflowFixture{
 		Provider:   "temporal",
 		Operations: []string{"sync"},
-		Schedules: map[string]config.PluginWorkflowSchedule{
+		Schedules: map[string]workflowFixtureSchedule{
 			"nightly_sync": {
 				Cron:      "0 2 * * *",
 				Timezone:  "UTC",
@@ -2142,10 +2170,10 @@ func TestBootstrapIgnoresMissingRemovedConfiguredWorkflowSchedule(t *testing.T) 
 	}
 
 	cfg := workflowStartupCallbackConfig("https://example.invalid")
-	setWorkflowFixture(cfg, "roadmap", &config.PluginWorkflowConfig{
+	setWorkflowFixture(cfg, "roadmap", &workflowFixture{
 		Provider:   "temporal",
 		Operations: []string{"sync"},
-		Schedules: map[string]config.PluginWorkflowSchedule{
+		Schedules: map[string]workflowFixtureSchedule{
 			"nightly_sync": {
 				Cron:      "0 2 * * *",
 				Timezone:  "UTC",
@@ -2166,7 +2194,7 @@ func TestBootstrapIgnoresMissingRemovedConfiguredWorkflowSchedule(t *testing.T) 
 	provider.schedules = map[string]*coreworkflow.Schedule{}
 
 	cfg = workflowStartupCallbackConfig("https://example.invalid")
-	setWorkflowFixture(cfg, "roadmap", &config.PluginWorkflowConfig{
+	setWorkflowFixture(cfg, "roadmap", &workflowFixture{
 		Provider:   "temporal",
 		Operations: []string{"sync"},
 	})
@@ -2215,10 +2243,10 @@ func TestBootstrapDeletesRemovedConfiguredWorkflowSchedulesWhenProviderDropsExec
 	}
 
 	cfg := workflowStartupCallbackConfig("https://example.invalid")
-	setWorkflowFixture(cfg, "roadmap", &config.PluginWorkflowConfig{
+	setWorkflowFixture(cfg, "roadmap", &workflowFixture{
 		Provider:   "temporal",
 		Operations: []string{"sync"},
-		Schedules: map[string]config.PluginWorkflowSchedule{
+		Schedules: map[string]workflowFixtureSchedule{
 			"nightly_sync": {
 				Cron:      "0 2 * * *",
 				Timezone:  "UTC",
@@ -2239,7 +2267,7 @@ func TestBootstrapDeletesRemovedConfiguredWorkflowSchedulesWhenProviderDropsExec
 
 	provider.omitScheduleExecutionRef = true
 	cfg = workflowStartupCallbackConfig("https://example.invalid")
-	setWorkflowFixture(cfg, "roadmap", &config.PluginWorkflowConfig{
+	setWorkflowFixture(cfg, "roadmap", &workflowFixture{
 		Provider:   "temporal",
 		Operations: []string{"sync"},
 	})
@@ -2279,10 +2307,10 @@ func TestBootstrapIgnoresMissingOldScheduleDuringWorkflowProviderMove(t *testing
 	}
 
 	cfg := workflowStartupCallbackConfig("https://example.invalid")
-	setWorkflowFixture(cfg, "roadmap", &config.PluginWorkflowConfig{
+	setWorkflowFixture(cfg, "roadmap", &workflowFixture{
 		Provider:   "temporal",
 		Operations: []string{"sync"},
-		Schedules: map[string]config.PluginWorkflowSchedule{
+		Schedules: map[string]workflowFixtureSchedule{
 			"nightly_sync": {
 				Cron:      "0 2 * * *",
 				Timezone:  "UTC",
@@ -2304,10 +2332,10 @@ func TestBootstrapIgnoresMissingOldScheduleDuringWorkflowProviderMove(t *testing
 	temporal.schedules = map[string]*coreworkflow.Schedule{}
 
 	cfg = workflowStartupCallbackConfig("https://example.invalid")
-	setWorkflowFixture(cfg, "roadmap", &config.PluginWorkflowConfig{
+	setWorkflowFixture(cfg, "roadmap", &workflowFixture{
 		Provider:   "backup",
 		Operations: []string{"sync"},
-		Schedules: map[string]config.PluginWorkflowSchedule{
+		Schedules: map[string]workflowFixtureSchedule{
 			"nightly_sync": {
 				Cron:      "0 2 * * *",
 				Timezone:  "UTC",
@@ -2346,12 +2374,12 @@ func TestBootstrapAppliesConfiguredWorkflowEventTriggers(t *testing.T) {
 	t.Parallel()
 
 	cfg := workflowStartupCallbackConfig("https://example.invalid")
-	setWorkflowFixture(cfg, "roadmap", &config.PluginWorkflowConfig{
+	setWorkflowFixture(cfg, "roadmap", &workflowFixture{
 		Provider:   "temporal",
 		Operations: []string{"sync"},
-		EventTriggers: map[string]config.PluginWorkflowEventTrigger{
+		EventTriggers: map[string]workflowFixtureEventTrigger{
 			"task_updated": {
-				Match: config.PluginWorkflowEventMatch{
+				Match: workflowFixtureEventMatch{
 					Type:   "task.updated",
 					Source: "roadmap",
 				},
@@ -2389,7 +2417,7 @@ func TestBootstrapAppliesConfiguredWorkflowEventTriggers(t *testing.T) {
 		t.Fatalf("upserted event triggers = %d, want 1", len(recorder.upsertedEventTriggers))
 	}
 	got := recorder.upsertedEventTriggers[0]
-	if got.TriggerID != workflowConfigEventTriggerID("roadmap", "task_updated") {
+	if got.TriggerID != workflowConfigEventTriggerID("task_updated") {
 		t.Fatalf("trigger id = %q", got.TriggerID)
 	}
 	if got.Match.Type != "task.updated" || got.Match.Source != "roadmap" || got.Match.Subject != "" {
@@ -2410,12 +2438,12 @@ func TestValidateDoesNotApplyConfiguredWorkflowEventTriggers(t *testing.T) {
 	t.Parallel()
 
 	cfg := workflowStartupCallbackConfig("https://example.invalid")
-	setWorkflowFixture(cfg, "roadmap", &config.PluginWorkflowConfig{
+	setWorkflowFixture(cfg, "roadmap", &workflowFixture{
 		Provider:   "temporal",
 		Operations: []string{"sync"},
-		EventTriggers: map[string]config.PluginWorkflowEventTrigger{
+		EventTriggers: map[string]workflowFixtureEventTrigger{
 			"task_updated": {
-				Match: config.PluginWorkflowEventMatch{
+				Match: workflowFixtureEventMatch{
 					Type: "task.updated",
 				},
 				Operation: "sync",
@@ -2465,12 +2493,12 @@ func TestBootstrapDeletesRemovedConfiguredWorkflowEventTriggers(t *testing.T) {
 	}
 
 	cfg := workflowStartupCallbackConfig("https://example.invalid")
-	setWorkflowFixture(cfg, "roadmap", &config.PluginWorkflowConfig{
+	setWorkflowFixture(cfg, "roadmap", &workflowFixture{
 		Provider:   "temporal",
 		Operations: []string{"sync"},
-		EventTriggers: map[string]config.PluginWorkflowEventTrigger{
+		EventTriggers: map[string]workflowFixtureEventTrigger{
 			"task_updated": {
-				Match: config.PluginWorkflowEventMatch{
+				Match: workflowFixtureEventMatch{
 					Type: "task.updated",
 				},
 				Operation: "sync",
@@ -2491,7 +2519,7 @@ func TestBootstrapDeletesRemovedConfiguredWorkflowEventTriggers(t *testing.T) {
 	_ = result.Close(context.Background())
 
 	cfg = workflowStartupCallbackConfig("https://example.invalid")
-	setWorkflowFixture(cfg, "roadmap", &config.PluginWorkflowConfig{
+	setWorkflowFixture(cfg, "roadmap", &workflowFixture{
 		Provider:   "temporal",
 		Operations: []string{"sync"},
 	})
@@ -2509,7 +2537,7 @@ func TestBootstrapDeletesRemovedConfiguredWorkflowEventTriggers(t *testing.T) {
 	if len(recorders) != 2 {
 		t.Fatalf("recorders = %d, want 2", len(recorders))
 	}
-	staleID := workflowConfigEventTriggerID("roadmap", "task_updated")
+	staleID := workflowConfigEventTriggerID("task_updated")
 	recorder := recorders[1]
 	if len(recorder.deletedEventTriggers) != 1 {
 		t.Fatalf("deleted event triggers = %d, want 1", len(recorder.deletedEventTriggers))
@@ -2536,12 +2564,12 @@ func TestBootstrapMovesConfiguredWorkflowEventTriggersToNewProvider(t *testing.T
 	}
 
 	cfg := workflowStartupCallbackConfig("https://example.invalid")
-	setWorkflowFixture(cfg, "roadmap", &config.PluginWorkflowConfig{
+	setWorkflowFixture(cfg, "roadmap", &workflowFixture{
 		Provider:   "temporal",
 		Operations: []string{"sync"},
-		EventTriggers: map[string]config.PluginWorkflowEventTrigger{
+		EventTriggers: map[string]workflowFixtureEventTrigger{
 			"task_updated": {
-				Match: config.PluginWorkflowEventMatch{
+				Match: workflowFixtureEventMatch{
 					Type: "task.updated",
 				},
 				Operation: "sync",
@@ -2563,12 +2591,12 @@ func TestBootstrapMovesConfiguredWorkflowEventTriggersToNewProvider(t *testing.T
 	_ = result.Close(context.Background())
 
 	cfg = workflowStartupCallbackConfig("https://example.invalid")
-	setWorkflowFixture(cfg, "roadmap", &config.PluginWorkflowConfig{
+	setWorkflowFixture(cfg, "roadmap", &workflowFixture{
 		Provider:   "backup",
 		Operations: []string{"sync"},
-		EventTriggers: map[string]config.PluginWorkflowEventTrigger{
+		EventTriggers: map[string]workflowFixtureEventTrigger{
 			"task_updated": {
-				Match: config.PluginWorkflowEventMatch{
+				Match: workflowFixtureEventMatch{
 					Type: "task.updated",
 				},
 				Operation: "sync",
@@ -2608,19 +2636,19 @@ func TestBootstrapRejectsExistingUnmanagedWorkflowEventTriggerIDDuringProviderMo
 	factories.Workflow = func(_ context.Context, name string, _ yaml.Node, _ []providerhost.HostService, _ bootstrap.Deps) (coreworkflow.Provider, error) {
 		recorder := &recordingWorkflowProvider{}
 		if name == "backup" && len(recorders[name]) == 1 {
-			recorder.getEventTrigger = &coreworkflow.EventTrigger{ID: workflowConfigEventTriggerID("roadmap", "task_updated")}
+			recorder.getEventTrigger = &coreworkflow.EventTrigger{ID: workflowConfigEventTriggerID("task_updated")}
 		}
 		recorders[name] = append(recorders[name], recorder)
 		return recorder, nil
 	}
 
 	cfg := workflowStartupCallbackConfig("https://example.invalid")
-	setWorkflowFixture(cfg, "roadmap", &config.PluginWorkflowConfig{
+	setWorkflowFixture(cfg, "roadmap", &workflowFixture{
 		Provider:   "temporal",
 		Operations: []string{"sync"},
-		EventTriggers: map[string]config.PluginWorkflowEventTrigger{
+		EventTriggers: map[string]workflowFixtureEventTrigger{
 			"task_updated": {
-				Match: config.PluginWorkflowEventMatch{
+				Match: workflowFixtureEventMatch{
 					Type: "task.updated",
 				},
 				Operation: "sync",
@@ -2639,12 +2667,12 @@ func TestBootstrapRejectsExistingUnmanagedWorkflowEventTriggerIDDuringProviderMo
 	_ = result.Close(context.Background())
 
 	cfg = workflowStartupCallbackConfig("https://example.invalid")
-	setWorkflowFixture(cfg, "roadmap", &config.PluginWorkflowConfig{
+	setWorkflowFixture(cfg, "roadmap", &workflowFixture{
 		Provider:   "backup",
 		Operations: []string{"sync"},
-		EventTriggers: map[string]config.PluginWorkflowEventTrigger{
+		EventTriggers: map[string]workflowFixtureEventTrigger{
 			"task_updated": {
-				Match: config.PluginWorkflowEventMatch{
+				Match: workflowFixtureEventMatch{
 					Type: "task.updated",
 				},
 				Operation: "sync",
@@ -2672,12 +2700,12 @@ func TestBootstrapRejectsExistingUnmanagedWorkflowEventTriggerID(t *testing.T) {
 	t.Parallel()
 
 	cfg := workflowStartupCallbackConfig("https://example.invalid")
-	setWorkflowFixture(cfg, "roadmap", &config.PluginWorkflowConfig{
+	setWorkflowFixture(cfg, "roadmap", &workflowFixture{
 		Provider:   "temporal",
 		Operations: []string{"sync"},
-		EventTriggers: map[string]config.PluginWorkflowEventTrigger{
+		EventTriggers: map[string]workflowFixtureEventTrigger{
 			"task_updated": {
-				Match: config.PluginWorkflowEventMatch{
+				Match: workflowFixtureEventMatch{
 					Type: "task.updated",
 				},
 				Operation: "sync",
@@ -2689,7 +2717,7 @@ func TestBootstrapRejectsExistingUnmanagedWorkflowEventTriggerID(t *testing.T) {
 	}
 
 	recorder := &recordingWorkflowProvider{
-		getEventTrigger: &coreworkflow.EventTrigger{ID: workflowConfigEventTriggerID("roadmap", "task_updated")},
+		getEventTrigger: &coreworkflow.EventTrigger{ID: workflowConfigEventTriggerID("task_updated")},
 	}
 	factories := validFactories()
 	factories.Workflow = func(_ context.Context, _ string, _ yaml.Node, _ []providerhost.HostService, _ bootstrap.Deps) (coreworkflow.Provider, error) {
@@ -2719,12 +2747,12 @@ func TestBootstrapReAdoptsManagedEventTriggersWhenOwnershipStateIsMissing(t *tes
 	}
 
 	cfg := workflowStartupCallbackConfig("https://example.invalid")
-	setWorkflowFixture(cfg, "roadmap", &config.PluginWorkflowConfig{
+	setWorkflowFixture(cfg, "roadmap", &workflowFixture{
 		Provider:   "temporal",
 		Operations: []string{"sync"},
-		EventTriggers: map[string]config.PluginWorkflowEventTrigger{
+		EventTriggers: map[string]workflowFixtureEventTrigger{
 			"task_updated": {
-				Match: config.PluginWorkflowEventMatch{
+				Match: workflowFixtureEventMatch{
 					Type: "task.updated",
 				},
 				Operation: "sync",
@@ -2743,7 +2771,7 @@ func TestBootstrapReAdoptsManagedEventTriggersWhenOwnershipStateIsMissing(t *tes
 	if len(provider.upsertedEventTriggers) != 1 {
 		t.Fatalf("initial upserted event triggers = %d, want 1", len(provider.upsertedEventTriggers))
 	}
-	provider.eventTriggers[workflowConfigEventTriggerID("roadmap", "task_updated")].Target.Input = map[string]any{
+	provider.eventTriggers[workflowConfigEventTriggerID("task_updated")].Target.Input = map[string]any{
 		"limit": float64(1),
 	}
 
@@ -2782,12 +2810,12 @@ func TestBootstrapIgnoresMissingRemovedConfiguredWorkflowEventTrigger(t *testing
 	}
 
 	cfg := workflowStartupCallbackConfig("https://example.invalid")
-	setWorkflowFixture(cfg, "roadmap", &config.PluginWorkflowConfig{
+	setWorkflowFixture(cfg, "roadmap", &workflowFixture{
 		Provider:   "temporal",
 		Operations: []string{"sync"},
-		EventTriggers: map[string]config.PluginWorkflowEventTrigger{
+		EventTriggers: map[string]workflowFixtureEventTrigger{
 			"task_updated": {
-				Match: config.PluginWorkflowEventMatch{
+				Match: workflowFixtureEventMatch{
 					Type: "task.updated",
 				},
 				Operation: "sync",
@@ -2806,7 +2834,7 @@ func TestBootstrapIgnoresMissingRemovedConfiguredWorkflowEventTrigger(t *testing
 	provider.eventTriggers = map[string]*coreworkflow.EventTrigger{}
 
 	cfg = workflowStartupCallbackConfig("https://example.invalid")
-	setWorkflowFixture(cfg, "roadmap", &config.PluginWorkflowConfig{
+	setWorkflowFixture(cfg, "roadmap", &workflowFixture{
 		Provider:   "temporal",
 		Operations: []string{"sync"},
 	})
@@ -2852,12 +2880,12 @@ func TestBootstrapIgnoresMissingOldEventTriggerDuringWorkflowProviderMove(t *tes
 	}
 
 	cfg := workflowStartupCallbackConfig("https://example.invalid")
-	setWorkflowFixture(cfg, "roadmap", &config.PluginWorkflowConfig{
+	setWorkflowFixture(cfg, "roadmap", &workflowFixture{
 		Provider:   "temporal",
 		Operations: []string{"sync"},
-		EventTriggers: map[string]config.PluginWorkflowEventTrigger{
+		EventTriggers: map[string]workflowFixtureEventTrigger{
 			"task_updated": {
-				Match: config.PluginWorkflowEventMatch{
+				Match: workflowFixtureEventMatch{
 					Type: "task.updated",
 				},
 				Operation: "sync",
@@ -2877,12 +2905,12 @@ func TestBootstrapIgnoresMissingOldEventTriggerDuringWorkflowProviderMove(t *tes
 	temporal.eventTriggers = map[string]*coreworkflow.EventTrigger{}
 
 	cfg = workflowStartupCallbackConfig("https://example.invalid")
-	setWorkflowFixture(cfg, "roadmap", &config.PluginWorkflowConfig{
+	setWorkflowFixture(cfg, "roadmap", &workflowFixture{
 		Provider:   "backup",
 		Operations: []string{"sync"},
-		EventTriggers: map[string]config.PluginWorkflowEventTrigger{
+		EventTriggers: map[string]workflowFixtureEventTrigger{
 			"task_updated": {
-				Match: config.PluginWorkflowEventMatch{
+				Match: workflowFixtureEventMatch{
 					Type: "task.updated",
 				},
 				Operation: "sync",
@@ -2909,13 +2937,13 @@ func TestBootstrapIgnoresMissingOldEventTriggerDuringWorkflowProviderMove(t *tes
 	}
 }
 
-func workflowConfigScheduleID(pluginName, scheduleKey string) string {
-	sum := sha256.Sum256([]byte(pluginName + "\x00" + scheduleKey))
+func workflowConfigScheduleID(scheduleKey string) string {
+	sum := sha256.Sum256([]byte(scheduleKey))
 	return coreworkflow.ConfigManagedSchedulePrefix + hex.EncodeToString(sum[:])
 }
 
-func workflowConfigEventTriggerID(pluginName, triggerKey string) string {
-	sum := sha256.Sum256([]byte(pluginName + "\x00event_trigger\x00" + triggerKey))
+func workflowConfigEventTriggerID(triggerKey string) string {
+	sum := sha256.Sum256([]byte("event_trigger\x00" + triggerKey))
 	return coreworkflow.ConfigManagedSchedulePrefix + hex.EncodeToString(sum[:])
 }
 
@@ -3068,7 +3096,7 @@ func TestValidateManagedWorkflowStartupCallbackUsesPreparedProviderStub(t *testi
 			cfg.Providers.Workflow = map[string]*config.ProviderEntry{
 				"temporal": {Source: config.ProviderSource{Path: "stub"}},
 			}
-			setWorkflowFixture(cfg, "roadmap", &config.PluginWorkflowConfig{
+			setWorkflowFixture(cfg, "roadmap", &workflowFixture{
 				Provider:   "temporal",
 				Operations: []string{"sync"},
 			})
@@ -3155,7 +3183,7 @@ func TestValidateManagedWorkflowStartupInvokesMCPPassthroughPreparedProviders(t 
 	cfg.Providers.Workflow = map[string]*config.ProviderEntry{
 		"temporal": {Source: config.ProviderSource{Path: "stub"}},
 	}
-	setWorkflowFixture(cfg, "roadmap", &config.PluginWorkflowConfig{
+	setWorkflowFixture(cfg, "roadmap", &workflowFixture{
 		Provider:   "temporal",
 		Operations: []string{"sync"},
 	})
@@ -3388,7 +3416,7 @@ func TestValidate(t *testing.T) {
 		cfg.Providers.Workflow = map[string]*config.ProviderEntry{
 			"temporal": {Source: config.ProviderSource{Path: "stub"}},
 		}
-		setWorkflowFixture(cfg, "svc", &config.PluginWorkflowConfig{
+		setWorkflowFixture(cfg, "svc", &workflowFixture{
 			Provider:   "temporal",
 			Operations: []string{"run"},
 		})
@@ -3441,11 +3469,11 @@ func TestValidate(t *testing.T) {
 		cfg.Providers.Workflow = map[string]*config.ProviderEntry{
 			"temporal": {Source: config.ProviderSource{Path: "stub"}},
 		}
-		setWorkflowFixture(cfg, "foo-bar", &config.PluginWorkflowConfig{
+		setWorkflowFixture(cfg, "foo-bar", &workflowFixture{
 			Provider:   "temporal",
 			Operations: []string{"run"},
 		})
-		setWorkflowFixture(cfg, "foo_bar", &config.PluginWorkflowConfig{
+		setWorkflowFixture(cfg, "foo_bar", &workflowFixture{
 			Provider:   "temporal",
 			Operations: []string{"run"},
 		})
@@ -4717,7 +4745,7 @@ func TestBootstrapWorkflowAuthorizationRejectsEitherProvider(t *testing.T) {
 		"temporal": {Source: config.ProviderSource{Path: "stub"}},
 	}
 	cfg.Authorization = config.AuthorizationConfig{}
-	setWorkflowFixture(cfg, "svc", &config.PluginWorkflowConfig{
+	setWorkflowFixture(cfg, "svc", &workflowFixture{
 		Provider:   "temporal",
 		Operations: []string{"run"},
 	})

--- a/gestaltd/internal/bootstrap/workflow_config_event_triggers.go
+++ b/gestaltd/internal/bootstrap/workflow_config_event_triggers.go
@@ -92,7 +92,6 @@ func reconcileWorkflowConfigEventTriggers(ctx context.Context, cfg *config.Confi
 	for _, triggerKey := range slices.Sorted(maps.Keys(cfg.Workflows.EventTriggers)) {
 		trigger := cfg.Workflows.EventTriggers[triggerKey]
 		pluginName := trigger.Plugin
-		managedKey := workflowConfigEventTriggerManagedKey(triggerKey, trigger)
 		provider, allowed, err := runtime.ResolvePlugin(pluginName)
 		if err != nil {
 			return fmt.Errorf("bootstrap: workflow event triggers for plugin %q: %w", pluginName, err)
@@ -100,7 +99,7 @@ func reconcileWorkflowConfigEventTriggers(ctx context.Context, cfg *config.Confi
 		if _, ok := allowed[trigger.Operation]; !ok {
 			return fmt.Errorf("bootstrap: workflow event trigger %q for plugin %q targets disabled operation %q", triggerKey, pluginName, trigger.Operation)
 		}
-		rowID := workflowConfigEventTriggerStateID(pluginName, managedKey)
+		rowID := workflowConfigEventTriggerStateID(triggerKey)
 		desiredEntry := desired[rowID]
 		prev, owned := previous[rowID]
 		providerCtx := invocation.WithWorkflowContextString(ctx, "plugin", pluginName)
@@ -155,7 +154,6 @@ func desiredWorkflowConfigEventTriggers(cfg *config.Config) (map[string]desiredW
 	now := time.Now()
 	for _, triggerKey := range slices.Sorted(maps.Keys(cfg.Workflows.EventTriggers)) {
 		trigger := cfg.Workflows.EventTriggers[triggerKey]
-		managedKey := workflowConfigEventTriggerManagedKey(triggerKey, trigger)
 		binding, err := cfg.EffectiveWorkflowBinding(trigger.Plugin)
 		if err != nil {
 			return nil, err
@@ -163,14 +161,14 @@ func desiredWorkflowConfigEventTriggers(cfg *config.Config) (map[string]desiredW
 		if !binding.Enabled {
 			continue
 		}
-		rowID := workflowConfigEventTriggerStateID(trigger.Plugin, managedKey)
+		rowID := workflowConfigEventTriggerStateID(triggerKey)
 		desired[rowID] = desiredWorkflowConfigEventTrigger{
 			state: workflowConfigEventTriggerState{
 				ID:           rowID,
 				PluginName:   trigger.Plugin,
-				TriggerKey:   managedKey,
+				TriggerKey:   triggerKey,
 				ProviderName: binding.ProviderName,
-				TriggerID:    workflowConfigEventTriggerID(trigger.Plugin, managedKey),
+				TriggerID:    workflowConfigEventTriggerID(triggerKey),
 				UpdatedAt:    now,
 			},
 			trigger: trigger,
@@ -258,18 +256,11 @@ func workflowConfigEventTriggerTarget(trigger config.WorkflowEventTriggerConfig)
 	}
 }
 
-func workflowConfigEventTriggerManagedKey(triggerKey string, trigger config.WorkflowEventTriggerConfig) string {
-	if managedKey := strings.TrimSpace(trigger.ManagedKey); managedKey != "" {
-		return managedKey
-	}
+func workflowConfigEventTriggerStateID(triggerKey string) string {
 	return strings.TrimSpace(triggerKey)
 }
 
-func workflowConfigEventTriggerStateID(pluginName, triggerKey string) string {
-	return pluginName + "\x00event_trigger\x00" + triggerKey
-}
-
-func workflowConfigEventTriggerID(pluginName, triggerKey string) string {
-	sum := sha256.Sum256([]byte(pluginName + "\x00event_trigger\x00" + triggerKey))
+func workflowConfigEventTriggerID(triggerKey string) string {
+	sum := sha256.Sum256([]byte("event_trigger\x00" + strings.TrimSpace(triggerKey)))
 	return coreworkflow.ConfigManagedSchedulePrefix + hex.EncodeToString(sum[:])
 }

--- a/gestaltd/internal/bootstrap/workflow_config_schedules.go
+++ b/gestaltd/internal/bootstrap/workflow_config_schedules.go
@@ -122,7 +122,6 @@ func reconcileWorkflowConfigSchedules(ctx context.Context, cfg *config.Config, r
 	for _, scheduleKey := range slices.Sorted(maps.Keys(cfg.Workflows.Schedules)) {
 		schedule := cfg.Workflows.Schedules[scheduleKey]
 		pluginName := schedule.Plugin
-		managedKey := workflowConfigScheduleManagedKey(scheduleKey, schedule)
 		provider, allowed, err := runtime.ResolvePlugin(pluginName)
 		if err != nil {
 			return fmt.Errorf("bootstrap: workflow schedules for plugin %q: %w", pluginName, err)
@@ -131,7 +130,7 @@ func reconcileWorkflowConfigSchedules(ctx context.Context, cfg *config.Config, r
 		if _, ok := allowed[schedule.Operation]; !ok {
 			return fmt.Errorf("bootstrap: workflow schedule %q for plugin %q targets disabled operation %q", scheduleKey, pluginName, schedule.Operation)
 		}
-		rowID := workflowConfigScheduleStateID(pluginName, managedKey)
+		rowID := workflowConfigScheduleStateID(scheduleKey)
 		desiredEntry := desired[rowID]
 		prev, owned := previous[rowID]
 		existingExecutionRef := ""
@@ -228,7 +227,6 @@ func desiredWorkflowConfigSchedules(cfg *config.Config) (map[string]desiredWorkf
 	now := time.Now()
 	for _, scheduleKey := range slices.Sorted(maps.Keys(cfg.Workflows.Schedules)) {
 		schedule := cfg.Workflows.Schedules[scheduleKey]
-		managedKey := workflowConfigScheduleManagedKey(scheduleKey, schedule)
 		binding, err := cfg.EffectiveWorkflowBinding(schedule.Plugin)
 		if err != nil {
 			return nil, err
@@ -236,14 +234,14 @@ func desiredWorkflowConfigSchedules(cfg *config.Config) (map[string]desiredWorkf
 		if !binding.Enabled {
 			continue
 		}
-		rowID := workflowConfigScheduleStateID(schedule.Plugin, managedKey)
+		rowID := workflowConfigScheduleStateID(scheduleKey)
 		desired[rowID] = desiredWorkflowConfigSchedule{
 			state: workflowConfigScheduleState{
 				ID:           rowID,
 				PluginName:   schedule.Plugin,
-				ScheduleKey:  managedKey,
+				ScheduleKey:  scheduleKey,
 				ProviderName: binding.ProviderName,
-				ScheduleID:   workflowConfigScheduleID(schedule.Plugin, managedKey),
+				ScheduleID:   workflowConfigScheduleID(scheduleKey),
 				UpdatedAt:    now,
 			},
 			schedule: schedule,
@@ -361,19 +359,12 @@ func workflowConfigActor(pluginName string) coreworkflow.Actor {
 	}
 }
 
-func workflowConfigScheduleManagedKey(scheduleKey string, schedule config.WorkflowScheduleConfig) string {
-	if managedKey := strings.TrimSpace(schedule.ManagedKey); managedKey != "" {
-		return managedKey
-	}
+func workflowConfigScheduleStateID(scheduleKey string) string {
 	return strings.TrimSpace(scheduleKey)
 }
 
-func workflowConfigScheduleStateID(pluginName, scheduleKey string) string {
-	return pluginName + "\x00" + scheduleKey
-}
-
-func workflowConfigScheduleID(pluginName, scheduleKey string) string {
-	sum := sha256.Sum256([]byte(pluginName + "\x00" + scheduleKey))
+func workflowConfigScheduleID(scheduleKey string) string {
+	sum := sha256.Sum256([]byte(strings.TrimSpace(scheduleKey)))
 	return coreworkflow.ConfigManagedSchedulePrefix + hex.EncodeToString(sum[:])
 }
 

--- a/gestaltd/internal/bootstrap/workflow_runtime.go
+++ b/gestaltd/internal/bootstrap/workflow_runtime.go
@@ -73,11 +73,10 @@ func newWorkflowRuntime(cfg *config.Config) (*workflowRuntime, error) {
 		if pluginName == "" {
 			continue
 		}
-		managedKey := workflowConfigScheduleManagedKey(scheduleKey, schedule)
 		if runtime.managedScheduleIDs[pluginName] == nil {
 			runtime.managedScheduleIDs[pluginName] = map[string]struct{}{}
 		}
-		runtime.managedScheduleIDs[pluginName][workflowConfigScheduleID(pluginName, managedKey)] = struct{}{}
+		runtime.managedScheduleIDs[pluginName][workflowConfigScheduleID(scheduleKey)] = struct{}{}
 	}
 	for triggerKey := range cfg.Workflows.EventTriggers {
 		trigger := cfg.Workflows.EventTriggers[triggerKey]
@@ -85,11 +84,10 @@ func newWorkflowRuntime(cfg *config.Config) (*workflowRuntime, error) {
 		if pluginName == "" {
 			continue
 		}
-		managedKey := workflowConfigEventTriggerManagedKey(triggerKey, trigger)
 		if runtime.managedEventTriggerIDs[pluginName] == nil {
 			runtime.managedEventTriggerIDs[pluginName] = map[string]struct{}{}
 		}
-		runtime.managedEventTriggerIDs[pluginName][workflowConfigEventTriggerID(pluginName, managedKey)] = struct{}{}
+		runtime.managedEventTriggerIDs[pluginName][workflowConfigEventTriggerID(triggerKey)] = struct{}{}
 	}
 	return runtime, nil
 }

--- a/gestaltd/internal/config/config.go
+++ b/gestaltd/internal/config/config.go
@@ -276,7 +276,6 @@ type ProviderEntry struct {
 	IndexedDB         *PluginIndexedDBConfig        `yaml:"indexeddb,omitempty"`
 	Cache             []string                      `yaml:"cache,omitempty"`
 	S3                []string                      `yaml:"s3,omitempty"`
-	Workflow          *PluginWorkflowConfig         `yaml:"workflow,omitempty"`
 	Surfaces          *ProviderSurfaceOverrides     `yaml:"surfaces,omitempty"`
 	MCP               bool                          `yaml:"mcp,omitempty"`
 
@@ -331,7 +330,6 @@ type WorkflowBindingConfig struct {
 }
 
 type WorkflowScheduleConfig struct {
-	ManagedKey string         `yaml:"-"`
 	Plugin     string         `yaml:"plugin,omitempty"`
 	Cron       string         `yaml:"cron,omitempty"`
 	Timezone   string         `yaml:"timezone,omitempty"`
@@ -343,7 +341,6 @@ type WorkflowScheduleConfig struct {
 }
 
 type WorkflowEventTriggerConfig struct {
-	ManagedKey string             `yaml:"-"`
 	Plugin     string             `yaml:"plugin,omitempty"`
 	Match      WorkflowEventMatch `yaml:"match,omitempty"`
 	Operation  string             `yaml:"operation,omitempty"`
@@ -354,34 +351,6 @@ type WorkflowEventTriggerConfig struct {
 }
 
 type WorkflowEventMatch struct {
-	Type    string `yaml:"type,omitempty"`
-	Source  string `yaml:"source,omitempty"`
-	Subject string `yaml:"subject,omitempty"`
-}
-
-type PluginWorkflowConfig struct {
-	Provider      string                                `yaml:"provider,omitempty"`
-	Operations    []string                              `yaml:"operations,omitempty"`
-	Schedules     map[string]PluginWorkflowSchedule     `yaml:"schedules,omitempty"`
-	EventTriggers map[string]PluginWorkflowEventTrigger `yaml:"eventTriggers,omitempty"`
-}
-
-type PluginWorkflowSchedule struct {
-	Cron      string         `yaml:"cron,omitempty"`
-	Timezone  string         `yaml:"timezone,omitempty"`
-	Operation string         `yaml:"operation,omitempty"`
-	Input     map[string]any `yaml:"input,omitempty"`
-	Paused    bool           `yaml:"paused,omitempty"`
-}
-
-type PluginWorkflowEventTrigger struct {
-	Match     PluginWorkflowEventMatch `yaml:"match,omitempty"`
-	Operation string                   `yaml:"operation,omitempty"`
-	Input     map[string]any           `yaml:"input,omitempty"`
-	Paused    bool                     `yaml:"paused,omitempty"`
-}
-
-type PluginWorkflowEventMatch struct {
 	Type    string `yaml:"type,omitempty"`
 	Source  string `yaml:"source,omitempty"`
 	Subject string `yaml:"subject,omitempty"`
@@ -963,105 +932,7 @@ func NormalizeCompatibility(cfg *Config) error {
 	if err := normalizeAdminConfig(cfg); err != nil {
 		return err
 	}
-	if err := normalizeLegacyPluginWorkflows(cfg); err != nil {
-		return err
-	}
 	return applyPluginMountBindings(cfg)
-}
-
-func normalizeLegacyPluginWorkflows(cfg *Config) error {
-	if cfg == nil {
-		return nil
-	}
-	if cfg.Workflows.Bindings == nil {
-		cfg.Workflows.Bindings = map[string]*WorkflowBindingConfig{}
-	}
-	if cfg.Workflows.Schedules == nil {
-		cfg.Workflows.Schedules = map[string]WorkflowScheduleConfig{}
-	}
-	if cfg.Workflows.EventTriggers == nil {
-		cfg.Workflows.EventTriggers = map[string]WorkflowEventTriggerConfig{}
-	}
-
-	usedScheduleKeys := make(map[string]struct{}, len(cfg.Workflows.Schedules))
-	for key := range cfg.Workflows.Schedules {
-		usedScheduleKeys[key] = struct{}{}
-	}
-	usedTriggerKeys := make(map[string]struct{}, len(cfg.Workflows.EventTriggers))
-	for key := range cfg.Workflows.EventTriggers {
-		usedTriggerKeys[key] = struct{}{}
-	}
-
-	for _, pluginName := range slices.Sorted(maps.Keys(cfg.Plugins)) {
-		entry := cfg.Plugins[pluginName]
-		if entry == nil || entry.Workflow == nil {
-			continue
-		}
-		legacy := entry.Workflow
-		if _, exists := cfg.Workflows.Bindings[pluginName]; exists {
-			return fmt.Errorf("config validation: workflows.bindings.%s conflicts with legacy plugins.%s.workflow", pluginName, pluginName)
-		}
-		cfg.Workflows.Bindings[pluginName] = &WorkflowBindingConfig{
-			Provider:   legacy.Provider,
-			Operations: slices.Clone(legacy.Operations),
-		}
-		for _, key := range slices.Sorted(maps.Keys(legacy.Schedules)) {
-			schedule := legacy.Schedules[key]
-			globalKey := uniqueWorkflowObjectKey(usedScheduleKeys, pluginName, key)
-			cfg.Workflows.Schedules[globalKey] = WorkflowScheduleConfig{
-				ManagedKey: key,
-				Plugin:     pluginName,
-				Cron:       schedule.Cron,
-				Timezone:   schedule.Timezone,
-				Operation:  schedule.Operation,
-				Input:      maps.Clone(schedule.Input),
-				Paused:     schedule.Paused,
-			}
-		}
-		for _, key := range slices.Sorted(maps.Keys(legacy.EventTriggers)) {
-			trigger := legacy.EventTriggers[key]
-			globalKey := uniqueWorkflowObjectKey(usedTriggerKeys, pluginName, key)
-			cfg.Workflows.EventTriggers[globalKey] = WorkflowEventTriggerConfig{
-				ManagedKey: key,
-				Plugin:     pluginName,
-				Match: WorkflowEventMatch{
-					Type:    trigger.Match.Type,
-					Source:  trigger.Match.Source,
-					Subject: trigger.Match.Subject,
-				},
-				Operation: trigger.Operation,
-				Input:     maps.Clone(trigger.Input),
-				Paused:    trigger.Paused,
-			}
-		}
-		entry.Workflow = nil
-	}
-	return nil
-}
-
-func uniqueWorkflowObjectKey(used map[string]struct{}, pluginName, key string) string {
-	key = strings.TrimSpace(key)
-	if _, exists := used[key]; !exists {
-		used[key] = struct{}{}
-		return key
-	}
-	base := strings.TrimSpace(pluginName)
-	if base == "" {
-		base = "workflow"
-	}
-	candidate := base + "." + key
-	if _, exists := used[candidate]; !exists {
-		used[candidate] = struct{}{}
-		return candidate
-	}
-	for i := 2; ; i++ {
-		candidate = fmt.Sprintf("%s.%s.%d", base, key, i)
-		if _, exists := used[candidate]; exists {
-			continue
-		}
-		used[candidate] = struct{}{}
-		return candidate
-	}
 }
 
 func OverlayRemotePluginConfig(path string, cfg *Config) error {

--- a/gestaltd/internal/config/config_test.go
+++ b/gestaltd/internal/config/config_test.go
@@ -2447,11 +2447,10 @@ server:
 			t.Fatalf("Workflows.Bindings[roadmap] = %#v, want %#v", got, wantBinding)
 		}
 		wantSchedule := WorkflowScheduleConfig{
-			ManagedKey: "nightly",
-			Plugin:     "roadmap",
-			Cron:       "0 2 * * *",
-			Timezone:   "UTC",
-			Operation:  "nightly_sync",
+			Plugin:    "roadmap",
+			Cron:      "0 2 * * *",
+			Timezone:  "UTC",
+			Operation: "nightly_sync",
 			Input: map[string]any{
 				"source": "yaml",
 			},
@@ -2460,8 +2459,7 @@ server:
 			t.Fatalf("Workflows.Schedules[nightly] = %#v, want %#v", got, wantSchedule)
 		}
 		wantTrigger := WorkflowEventTriggerConfig{
-			ManagedKey: "task_updated",
-			Plugin:     "roadmap",
+			Plugin: "roadmap",
 			Match: WorkflowEventMatch{
 				Type:   "roadmap.task.updated",
 				Source: "roadmap",
@@ -2477,7 +2475,7 @@ server:
 		}
 	})
 
-	t.Run("legacy plugin workflow config is canonicalized into top-level workflows", func(t *testing.T) {
+	t.Run("legacy plugin workflow config is rejected", func(t *testing.T) {
 		t.Parallel()
 
 		path := mustWriteConfigFile(t, `
@@ -2489,10 +2487,6 @@ plugins:
       provider: temporal
       operations:
         - nightly_sync
-      schedules:
-        nightly:
-          cron: "0 2 * * *"
-          operation: nightly_sync
 providers:
   workflow:
     temporal:
@@ -2508,81 +2502,12 @@ server:
   encryptionKey: server-key
 `)
 
-		cfg, err := Load(path)
-		if err != nil {
-			t.Fatalf("Load: %v", err)
+		_, err := Load(path)
+		if err == nil {
+			t.Fatal("Load succeeded, want error")
 		}
-		if cfg.Plugins["roadmap"].Workflow != nil {
-			t.Fatalf("Plugins[roadmap].Workflow = %#v, want nil after canonicalization", cfg.Plugins["roadmap"].Workflow)
-		}
-		if got := cfg.Workflows.Bindings["roadmap"]; got == nil || got.Provider != "temporal" || !reflect.DeepEqual(got.Operations, []string{"nightly_sync"}) {
-			t.Fatalf("Workflows.Bindings[roadmap] = %#v", got)
-		}
-		schedule, ok := cfg.Workflows.Schedules["nightly"]
-		if !ok {
-			t.Fatalf("Workflows.Schedules = %#v, want nightly", cfg.Workflows.Schedules)
-		}
-		if schedule.Plugin != "roadmap" || schedule.ManagedKey != "nightly" || schedule.Operation != "nightly_sync" {
-			t.Fatalf("Workflows.Schedules[nightly] = %#v", schedule)
-		}
-	})
-
-	t.Run("legacy duplicate workflow keys are lifted deterministically", func(t *testing.T) {
-		t.Parallel()
-
-		path := mustWriteConfigFile(t, `
-plugins:
-  alpha:
-    source:
-      path: ./plugin/manifest.yaml
-    workflow:
-      provider: temporal
-      operations:
-        - sync
-      schedules:
-        nightly:
-          cron: "0 2 * * *"
-          operation: sync
-  beta:
-    source:
-      path: ./plugin/manifest.yaml
-    workflow:
-      provider: temporal
-      operations:
-        - sync
-      schedules:
-        nightly:
-          cron: "0 3 * * *"
-          operation: sync
-providers:
-  workflow:
-    temporal:
-      source:
-        path: ./providers/workflow/temporal
-  indexeddb:
-    sqlite:
-      source:
-        path: ./providers/datastore/sqlite
-server:
-  providers:
-    indexeddb: sqlite
-  encryptionKey: server-key
-`)
-
-		cfg, err := Load(path)
-		if err != nil {
-			t.Fatalf("Load: %v", err)
-		}
-		alpha := cfg.Workflows.Schedules["nightly"]
-		if alpha.Plugin != "alpha" || alpha.ManagedKey != "nightly" {
-			t.Fatalf("Workflows.Schedules[nightly] = %#v", alpha)
-		}
-		beta, ok := cfg.Workflows.Schedules["beta.nightly"]
-		if !ok {
-			t.Fatalf("Workflows.Schedules = %#v, want beta.nightly", cfg.Workflows.Schedules)
-		}
-		if beta.Plugin != "beta" || beta.ManagedKey != "nightly" {
-			t.Fatalf("Workflows.Schedules[beta.nightly] = %#v", beta)
+		if !strings.Contains(err.Error(), `field workflow not found`) {
+			t.Fatalf("Load error = %v, want unknown workflow field", err)
 		}
 	})
 
@@ -2663,7 +2588,7 @@ server:
 		if err == nil {
 			t.Fatal("Load: expected error, got nil")
 		}
-		if !strings.Contains(err.Error(), `ui.root.workflow has moved to top-level workflows.bindings, workflows.schedules, and workflows.eventTriggers`) {
+		if !strings.Contains(err.Error(), `field workflow not found in type config.UIEntry`) {
 			t.Fatalf("unexpected error: %v", err)
 		}
 	})

--- a/gestaltd/internal/config/config_validate.go
+++ b/gestaltd/internal/config/config_validate.go
@@ -440,9 +440,6 @@ func validatePlugin(cfg *Config, name string, entry *ProviderEntry, sourceSyntax
 	if err := validatePluginCacheBindings(cfg, name, entry); err != nil {
 		return err
 	}
-	if err := validatePluginWorkflowConfig(cfg, name, entry); err != nil {
-		return err
-	}
 	if err := validatePluginS3Bindings(cfg, name, entry); err != nil {
 		return err
 	}
@@ -557,9 +554,6 @@ func validateWorkflowProviderFields(cfg *Config, name string, entry *ProviderEnt
 	if len(entry.Invokes) > 0 {
 		return fmt.Errorf("config validation: %s.invokes is only supported on plugins.*", subject)
 	}
-	if entry.Workflow != nil {
-		return fmt.Errorf("config validation: %s.workflow has moved to top-level workflows.bindings, workflows.schedules, and workflows.eventTriggers", subject)
-	}
 	if entry.Surfaces != nil {
 		return fmt.Errorf("config validation: %s.surfaces is only supported on plugins.*", subject)
 	}
@@ -607,9 +601,6 @@ func validatePluginOnlyProviderFields(subject string, entry *ProviderEntry) erro
 	}
 	if len(entry.Invokes) > 0 {
 		return fmt.Errorf("config validation: %s.invokes is only supported on plugins.*", subject)
-	}
-	if entry.Workflow != nil {
-		return fmt.Errorf("config validation: %s.workflow has moved to top-level workflows.bindings, workflows.schedules, and workflows.eventTriggers", subject)
 	}
 	if entry.Surfaces != nil {
 		return fmt.Errorf("config validation: %s.surfaces is only supported on plugins.*", subject)
@@ -789,13 +780,6 @@ func validatePluginS3Bindings(cfg *Config, name string, entry *ProviderEntry) er
 	return nil
 }
 
-func validatePluginWorkflowConfig(_ *Config, name string, entry *ProviderEntry) error {
-	if entry == nil || entry.Workflow == nil {
-		return nil
-	}
-	return fmt.Errorf("config validation: plugins.%s.workflow has moved to top-level workflows.bindings, workflows.schedules, and workflows.eventTriggers", name)
-}
-
 var workflowScheduleCronParser = cronv3.NewParser(
 	cronv3.Minute | cronv3.Hour | cronv3.Dom | cronv3.Month | cronv3.Dow,
 )
@@ -881,10 +865,6 @@ func validateWorkflowsConfig(cfg *Config) error {
 			}
 			schedule.Connection = strings.TrimSpace(schedule.Connection)
 			schedule.Instance = strings.TrimSpace(schedule.Instance)
-			schedule.ManagedKey = strings.TrimSpace(schedule.ManagedKey)
-			if schedule.ManagedKey == "" {
-				schedule.ManagedKey = key
-			}
 			schedule.Timezone = strings.TrimSpace(schedule.Timezone)
 			if schedule.Timezone == "" {
 				schedule.Timezone = "UTC"
@@ -937,10 +917,6 @@ func validateWorkflowsConfig(cfg *Config) error {
 			}
 			trigger.Connection = strings.TrimSpace(trigger.Connection)
 			trigger.Instance = strings.TrimSpace(trigger.Instance)
-			trigger.ManagedKey = strings.TrimSpace(trigger.ManagedKey)
-			if trigger.ManagedKey == "" {
-				trigger.ManagedKey = key
-			}
 			normalized[key] = trigger
 		}
 		cfg.Workflows.EventTriggers = normalized


### PR DESCRIPTION
## Summary
Removes the legacy `plugins.<plugin>.workflow` config surface entirely.

This PR keeps managed workflow config top-level only and drops the compatibility normalization added in `#1187`.

## Interfaces
Removed from config:
```yaml
plugins:
  roadmap:
    workflow:
      provider: temporal
      operations:
        - nightly_sync
```

Supported config surface:
```yaml
workflows:
  bindings:
    roadmap:
      provider: temporal
      operations:
        - nightly_sync
  schedules:
    nightly:
      plugin: roadmap
      cron: "0 2 * * *"
      timezone: UTC
      operation: nightly_sync
  eventTriggers:
    task_updated:
      plugin: roadmap
      match:
        type: roadmap.task.updated
      operation: nightly_sync
```

Go shape:
```go
type WorkflowsConfig struct {
    Bindings      map[string]*WorkflowBindingConfig
    Schedules     map[string]WorkflowScheduleConfig
    EventTriggers map[string]WorkflowEventTriggerConfig
}

type WorkflowScheduleConfig struct {
    Plugin     string
    Cron       string
    Timezone   string
    Operation  string
    Connection string
    Instance   string
    Input      map[string]any
    Paused     bool
}

type WorkflowEventTriggerConfig struct {
    Plugin     string
    Match      WorkflowEventMatch
    Operation  string
    Connection string
    Instance   string
    Input      map[string]any
    Paused     bool
}
```

## Behavioral changes
- `ProviderEntry.Workflow` and the legacy `PluginWorkflow*` config types are removed.
- Old nested workflow YAML now fails strict config parsing as an unknown field.
- Managed config schedule/trigger IDs now derive directly from the top-level config key.
- Tests use top-level workflow fixtures only.

## Verification
```bash
go test ./internal/config ./internal/bootstrap ./internal/server ./internal/operator -count=1
golangci-lint run ./internal/config ./internal/bootstrap ./internal/server ./internal/operator
```