### PR TITLE
Hide passive default no-auth connections in integrations UI

### DIFF
--- a/gestaltd/internal/server/handlers_tokens.go
+++ b/gestaltd/internal/server/handlers_tokens.go
@@ -189,7 +189,7 @@ func (s *Server) connectionInfosForPlugin(integration string, plugin *config.Pro
 	infos := make([]connectionDefInfo, 0, len(names))
 	for _, name := range names {
 		conn, ok := plan.LookupConnection(name)
-		if !ok || !userFacingConnection(conn) {
+		if !ok || !userFacingConnection(conn) || shouldHidePassiveNamedConnection(plan, name, conn, integrationAuthTypes) {
 			continue
 		}
 		if info, ok := s.connectionInfoFromAuth(integration, userFacingConnectionName(name), conn, integrationAuthTypes, defaultCredentialFields, name != config.PluginConnectionName); ok {
@@ -296,6 +296,33 @@ func (s *Server) connectionInfoFromAuth(integration, name string, conn config.Co
 
 func userFacingConnection(conn config.ConnectionDef) bool {
 	return conn.Mode != providermanifestv1.ConnectionModeIdentity
+}
+
+func shouldHidePassiveNamedConnection(plan config.StaticConnectionPlan, name string, conn config.ConnectionDef, integrationAuthTypes []string) bool {
+	if len(plan.NamedConnectionNames()) != 1 {
+		return false
+	}
+	if config.ResolveConnectionAlias(name) != plan.AuthDefaultConnection() {
+		return false
+	}
+	if conn.Mode != providermanifestv1.ConnectionModeNone {
+		return false
+	}
+	if strings.TrimSpace(conn.DisplayName) != "" {
+		return false
+	}
+	if len(connectionAuthTypes(conn.Auth, integrationAuthTypes)) != 0 {
+		return false
+	}
+	if len(conn.Auth.Credentials) != 0 {
+		return false
+	}
+	for _, def := range conn.ConnectionParams {
+		if strings.TrimSpace(def.From) == "" {
+			return false
+		}
+	}
+	return true
 }
 
 func defaultManualCredentialFieldInfos() []credentialFieldInfo {

--- a/gestaltd/internal/server/server_test.go
+++ b/gestaltd/internal/server/server_test.go
@@ -6172,6 +6172,68 @@ func TestListIntegrations_ConnectionInfosUseResolvedConnectionDefs(t *testing.T)
 			t.Fatalf("expected MCP connection authTypes=[], got %+v", integrations[0].Connections[0].AuthTypes)
 		}
 	})
+
+	t.Run("manifest-backed passive default no-auth connection stays hidden", func(t *testing.T) {
+		t.Parallel()
+
+		stub := &stubNonOAuthProvider{
+			name: "httpbin",
+			ops:  []core.Operation{{Name: "get", Method: http.MethodGet}},
+		}
+		plugin := &config.ProviderEntry{
+			Source: config.NewMetadataSource("https://example.invalid/github-com-acme-plugins-httpbin/v1.0.0/provider-release.yaml"),
+			ResolvedManifest: &providermanifestv1.Manifest{
+				Spec: &providermanifestv1.Spec{
+					Surfaces: &providermanifestv1.ProviderSurfaces{
+						REST: &providermanifestv1.RESTSurface{
+							BaseURL: "https://httpbin.org",
+						},
+					},
+					Connections: map[string]*providermanifestv1.ManifestConnectionDef{
+						"default": {
+							Mode: providermanifestv1.ConnectionModeNone,
+						},
+					},
+				},
+			},
+		}
+
+		ts := newTestServer(t, func(cfg *server.Config) {
+			cfg.Providers = testutil.NewProviderRegistry(t, stub)
+			cfg.PluginDefs = map[string]*config.ProviderEntry{
+				"httpbin": plugin,
+			}
+			cfg.Services = coretesting.NewStubServices(t)
+		})
+		testutil.CloseOnCleanup(t, ts)
+
+		req, _ := http.NewRequest(http.MethodGet, ts.URL+"/api/v1/integrations", nil)
+		resp, err := http.DefaultClient.Do(req)
+		if err != nil {
+			t.Fatalf("request: %v", err)
+		}
+		defer func() { _ = resp.Body.Close() }()
+
+		var integrations []struct {
+			Name        string   `json:"name"`
+			AuthTypes   []string `json:"authTypes"`
+			Connections []struct {
+				Name string `json:"name"`
+			} `json:"connections"`
+		}
+		if err := json.NewDecoder(resp.Body).Decode(&integrations); err != nil {
+			t.Fatalf("decoding: %v", err)
+		}
+		if len(integrations) != 1 {
+			t.Fatalf("expected 1 integration, got %d", len(integrations))
+		}
+		if len(integrations[0].AuthTypes) != 0 {
+			t.Fatalf("expected no top-level auth types, got %+v", integrations[0].AuthTypes)
+		}
+		if len(integrations[0].Connections) != 0 {
+			t.Fatalf("expected passive default connection to stay hidden, got %+v", integrations[0].Connections)
+		}
+	})
 }
 
 func TestListIntegrations_ConnectionInfosHideOAuthConnectionsWithoutHandler(t *testing.T) {


### PR DESCRIPTION
## Summary
This PR preserves the existing integrations UI behavior for downstream manifests that are being normalized onto explicit default connections.

## Behavior
- Keep a sole manifest-backed fallback connection hidden when it is passive: `mode: none`, no auth, no credentials, and no user-entered params.
- Continue exposing explicit named connections that still represent a user-visible connection step.

## Hidden example
```yaml
spec:
  connections:
    default:
      mode: none
```
This still routes operations through the default connection internally, but `/api/v1/integrations` no longer advertises a meaningless settings connection for it.

## Still visible example
```yaml
spec:
  surfaces:
    mcp:
      connection: MCP
      url: https://example.com/mcp
  connections:
    MCP:
      displayName: MCP
      mode: user
      auth:
        type: none
```
Explicit user-facing named connections like this remain visible in the integrations response.

## Validation
- `go test ./internal/server -run TestListIntegrations_ConnectionInfosUseResolvedConnectionDefs -count=1`
- `git diff --check`

## Why now
This makes canonical downstream manifest rewrites such as `spec.connections.default.mode: none` merge-safe before the legacy manifest paths are removed.