### PR TITLE
runtime: make credentials subject-owned

### DIFF
--- a/gestaltd/core/provider.go
+++ b/gestaltd/core/provider.go
@@ -12,7 +12,21 @@ const (
 	ConnectionModeNone     ConnectionMode = "none"
 	ConnectionModeUser     ConnectionMode = "user"
 	ConnectionModeIdentity ConnectionMode = "identity"
+	ConnectionModeEither   ConnectionMode = "either"
 )
+
+func NormalizeConnectionMode(mode ConnectionMode) ConnectionMode {
+	switch mode {
+	case "", ConnectionModeUser, ConnectionModeEither:
+		return ConnectionModeUser
+	case ConnectionModeIdentity:
+		return ConnectionModeIdentity
+	case ConnectionModeNone:
+		return ConnectionModeNone
+	default:
+		return mode
+	}
+}
 
 type Provider interface {
 	Name() string

--- a/gestaltd/core/types.go
+++ b/gestaltd/core/types.go
@@ -16,6 +16,7 @@ type User struct {
 type IntegrationToken struct {
 	ID                string
 	UserID            string
+	SubjectID         string
 	Integration       string
 	Connection        string
 	Instance          string
@@ -36,19 +37,20 @@ type AccessPermission struct {
 }
 
 type APIToken struct {
-	ID          string
-	IdentityID  string
-	UserID      string
-	OwnerKind   string
-	OwnerID     string
-	TokenKind   string
-	Name        string
-	HashedToken string
-	Scopes      string
-	Permissions []AccessPermission
-	ExpiresAt   *time.Time
-	CreatedAt   time.Time
-	UpdatedAt   time.Time
+	ID                  string
+	IdentityID          string
+	UserID              string
+	OwnerKind           string
+	OwnerID             string
+	CredentialSubjectID string
+	TokenKind           string
+	Name                string
+	HashedToken         string
+	Scopes              string
+	Permissions         []AccessPermission
+	ExpiresAt           *time.Time
+	CreatedAt           time.Time
+	UpdatedAt           time.Time
 }
 
 const (

--- a/gestaltd/internal/authorization/authorizer.go
+++ b/gestaltd/internal/authorization/authorizer.go
@@ -26,7 +26,6 @@ var (
 type CredentialBinding struct {
 	Mode                core.ConnectionMode
 	CredentialSubjectID string
-	CredentialOwnerID   string
 	Connection          string
 	Instance            string
 }
@@ -228,7 +227,26 @@ func (a *Authorizer) Binding(p *principal.Principal, provider string) (Credentia
 		if !a.allowManagedIdentityProvider(p, provider) {
 			return CredentialBinding{}, false
 		}
-		return CredentialBinding{Mode: core.ConnectionModeNone}, true
+		switch core.NormalizeConnectionMode(a.providerModes[provider]) {
+		case core.ConnectionModeNone:
+			return CredentialBinding{Mode: core.ConnectionModeNone}, true
+		case core.ConnectionModeIdentity:
+			return CredentialBinding{
+				Mode:                core.ConnectionModeIdentity,
+				CredentialSubjectID: principal.IdentitySubjectID(),
+			}, true
+		case core.ConnectionModeUser:
+			subjectID := principal.EffectiveCredentialSubjectID(p)
+			if subjectID == "" {
+				return CredentialBinding{}, false
+			}
+			return CredentialBinding{
+				Mode:                core.ConnectionModeUser,
+				CredentialSubjectID: subjectID,
+			}, true
+		default:
+			return CredentialBinding{}, false
+		}
 	}
 	if !a.IsWorkload(p) {
 		return CredentialBinding{}, false
@@ -458,7 +476,7 @@ func (p *HumanPolicy) staticRoleForIdentity(subjectID string) (string, bool) {
 }
 
 func buildBinding(mode core.ConnectionMode, workloadID, provider string, def config.WorkloadProviderDef, defaultConnections map[string]string) (WorkloadProviderBinding, error) {
-	switch mode {
+	switch core.NormalizeConnectionMode(mode) {
 	case core.ConnectionModeNone:
 		if strings.TrimSpace(def.Connection) != "" || strings.TrimSpace(def.Instance) != "" {
 			return WorkloadProviderBinding{}, fmt.Errorf("authorization validation: workload %q provider %q does not accept connection or instance bindings", workloadID, provider)
@@ -493,12 +511,11 @@ func buildBinding(mode core.ConnectionMode, workloadID, provider string, def con
 			CredentialBinding: CredentialBinding{
 				Mode:                core.ConnectionModeIdentity,
 				CredentialSubjectID: principal.IdentitySubjectID(),
-				CredentialOwnerID:   principal.IdentityPrincipal,
 				Connection:          connection,
 				Instance:            instance,
 			},
 		}, nil
-	case core.ConnectionModeUser, core.ConnectionMode("either"), "":
+	case core.ConnectionModeUser:
 		return WorkloadProviderBinding{}, fmt.Errorf("authorization validation: workload %q provider %q uses unsupported connection mode %q in v1", workloadID, provider, mode)
 	default:
 		return WorkloadProviderBinding{}, fmt.Errorf("authorization validation: workload %q provider %q uses unknown connection mode %q", workloadID, provider, mode)
@@ -532,7 +549,14 @@ func (a *Authorizer) allowManagedIdentityProvider(p *principal.Principal, provid
 	if !ok {
 		return false
 	}
-	return mode == core.ConnectionModeNone
+	switch core.NormalizeConnectionMode(mode) {
+	case core.ConnectionModeNone, core.ConnectionModeIdentity:
+		return true
+	case core.ConnectionModeUser:
+		return principal.EffectiveCredentialSubjectID(p) != ""
+	default:
+		return false
+	}
 }
 
 func providerMode(provider string, pluginDefs map[string]*config.ProviderEntry, providers *registry.ProviderMap[core.Provider]) (core.ConnectionMode, bool, error) {

--- a/gestaltd/internal/bootstrap/bootstrap_test.go
+++ b/gestaltd/internal/bootstrap/bootstrap_test.go
@@ -3299,7 +3299,7 @@ func TestValidate(t *testing.T) {
 		}
 	})
 
-	t.Run("workflow managed workloads reject either providers", func(t *testing.T) {
+	t.Run("workflow managed workloads reject normalized credentialed providers", func(t *testing.T) {
 		t.Parallel()
 
 		srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
@@ -3340,11 +3340,8 @@ func TestValidate(t *testing.T) {
 		}
 
 		_, err := bootstrap.Validate(context.Background(), cfg, factories)
-		if err == nil {
-			t.Fatal("expected error, got nil")
-		}
-		if !strings.Contains(err.Error(), `unsupported connection mode "either"`) {
-			t.Fatalf("unexpected error: %v", err)
+		if err == nil || !strings.Contains(err.Error(), `unsupported connection mode "user"`) {
+			t.Fatalf("Validate error = %v, want unsupported connection mode user", err)
 		}
 	})
 
@@ -4589,7 +4586,7 @@ func TestBootstrapWorkloadAuthorizationRejectsEitherProvider(t *testing.T) {
 			"triage-bot": {
 				Token: "gst_wld_triage-bot-token",
 				Providers: map[string]config.WorkloadProviderDef{
-					"svc": {Allow: []string{"run"}},
+					"svc": {Allow: []string{"run"}, Connection: "default"},
 				},
 			},
 		},
@@ -4601,11 +4598,8 @@ func TestBootstrapWorkloadAuthorizationRejectsEitherProvider(t *testing.T) {
 	}
 
 	_, err := bootstrap.Bootstrap(context.Background(), cfg, factories)
-	if err == nil {
-		t.Fatal("expected error, got nil")
-	}
-	if !strings.Contains(err.Error(), `unsupported connection mode "either"`) {
-		t.Fatalf("unexpected error: %v", err)
+	if err == nil || !strings.Contains(err.Error(), `unsupported connection mode "either"`) {
+		t.Fatalf("Bootstrap error = %v, want unsupported connection mode either", err)
 	}
 }
 
@@ -4618,16 +4612,12 @@ func TestBootstrapRejectsBuiltinEitherProviderWithoutAuthorizationConfig(t *test
 		&coretesting.StubIntegration{N: "svc", ConnMode: core.ConnectionMode("either")},
 	}
 
-	_, err := bootstrap.Bootstrap(context.Background(), cfg, factories)
-	if err == nil {
-		t.Fatal("expected error, got nil")
-	}
-	if !strings.Contains(err.Error(), `unsupported connection mode "either"`) {
+	if _, err := bootstrap.Bootstrap(context.Background(), cfg, factories); err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
 }
 
-func TestBootstrapWorkflowAuthorizationRejectsEitherProvider(t *testing.T) {
+func TestBootstrapWorkflowAuthorizationRejectsNormalizedCredentialedProvider(t *testing.T) {
 	t.Parallel()
 
 	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
@@ -4669,10 +4659,7 @@ func TestBootstrapWorkflowAuthorizationRejectsEitherProvider(t *testing.T) {
 	}
 
 	_, err := bootstrap.Bootstrap(context.Background(), cfg, factories)
-	if err == nil {
-		t.Fatal("expected error, got nil")
-	}
-	if !strings.Contains(err.Error(), `unsupported connection mode "either"`) {
-		t.Fatalf("unexpected error: %v", err)
+	if err == nil || !strings.Contains(err.Error(), `unsupported connection mode "user"`) {
+		t.Fatalf("Bootstrap error = %v, want unsupported connection mode user", err)
 	}
 }

--- a/gestaltd/internal/bootstrap/provider_build.go
+++ b/gestaltd/internal/bootstrap/provider_build.go
@@ -183,7 +183,7 @@ func buildProvidersAsync(
 }
 
 func validateProviderConnectionMode(provider string, mode core.ConnectionMode) error {
-	switch mode {
+	switch core.NormalizeConnectionMode(mode) {
 	case core.ConnectionModeNone, core.ConnectionModeUser, core.ConnectionModeIdentity:
 		return nil
 	default:

--- a/gestaltd/internal/config/connection_plan.go
+++ b/gestaltd/internal/config/connection_plan.go
@@ -168,7 +168,7 @@ func (plan StaticConnectionPlan) ConnectionMode() core.ConnectionMode {
 	needIdentity := false
 
 	addMode := func(mode core.ConnectionMode) {
-		switch mode {
+		switch core.NormalizeConnectionMode(mode) {
 		case core.ConnectionModeUser:
 			needUser = true
 		case core.ConnectionModeIdentity:
@@ -186,9 +186,8 @@ func (plan StaticConnectionPlan) ConnectionMode() core.ConnectionMode {
 		return core.ConnectionModeUser
 	case needIdentity:
 		return core.ConnectionModeIdentity
-	default:
-		return core.ConnectionModeNone
 	}
+	return core.ConnectionModeNone
 }
 
 func (plan StaticConnectionPlan) validateConnectionModes() error {
@@ -196,8 +195,8 @@ func (plan StaticConnectionPlan) validateConnectionModes() error {
 	needIdentity := false
 
 	addMode := func(scope string, mode core.ConnectionMode) error {
-		switch mode {
-		case "", core.ConnectionModeNone:
+		switch core.NormalizeConnectionMode(mode) {
+		case core.ConnectionModeNone:
 			return nil
 		case core.ConnectionModeUser:
 			needUser = true
@@ -332,7 +331,7 @@ func namedConnectionNames(plugin *ProviderEntry, manifestPlugin *providermanifes
 
 func connectionModeForConnection(conn ConnectionDef) core.ConnectionMode {
 	if conn.Mode != "" {
-		return core.ConnectionMode(conn.Mode)
+		return core.NormalizeConnectionMode(core.ConnectionMode(conn.Mode))
 	}
 	switch conn.Auth.Type {
 	case "", providermanifestv1.AuthTypeNone:

--- a/gestaltd/internal/coredata/api_tokens.go
+++ b/gestaltd/internal/coredata/api_tokens.go
@@ -52,19 +52,20 @@ func (s *APITokenService) StoreAPIToken(ctx context.Context, token *core.APIToke
 	}
 	now := time.Now()
 	rec := indexeddb.Record{
-		"id":               token.ID,
-		"identity_id":      identityID,
-		"user_id":          token.UserID,
-		"owner_kind":       ownerKind,
-		"owner_id":         ownerID,
-		"token_kind":       token.TokenKind,
-		"name":             token.Name,
-		"hashed_token":     token.HashedToken,
-		"scopes":           token.Scopes,
-		"permissions_json": string(permissionsJSON),
-		"expires_at":       token.ExpiresAt,
-		"created_at":       now,
-		"updated_at":       now,
+		"id":                    token.ID,
+		"identity_id":           identityID,
+		"user_id":               token.UserID,
+		"owner_kind":            ownerKind,
+		"owner_id":              ownerID,
+		"credential_subject_id": token.CredentialSubjectID,
+		"token_kind":            token.TokenKind,
+		"name":                  token.Name,
+		"hashed_token":          token.HashedToken,
+		"scopes":                token.Scopes,
+		"permissions_json":      string(permissionsJSON),
+		"expires_at":            token.ExpiresAt,
+		"created_at":            now,
+		"updated_at":            now,
 	}
 	if err := s.store.Add(ctx, rec); err != nil {
 		return fmt.Errorf("store api token: %w", err)
@@ -317,18 +318,19 @@ func (s *APITokenService) BackfillTokenAccess(ctx context.Context) error {
 
 func recordToAPIToken(rec indexeddb.Record) *core.APIToken {
 	token := &core.APIToken{
-		ID:          recString(rec, "id"),
-		IdentityID:  recString(rec, "identity_id"),
-		UserID:      recString(rec, "user_id"),
-		OwnerKind:   recString(rec, "owner_kind"),
-		OwnerID:     recString(rec, "owner_id"),
-		TokenKind:   recString(rec, "token_kind"),
-		Name:        recString(rec, "name"),
-		HashedToken: recString(rec, "hashed_token"),
-		Scopes:      recString(rec, "scopes"),
-		ExpiresAt:   recTimePtr(rec, "expires_at"),
-		CreatedAt:   recTime(rec, "created_at"),
-		UpdatedAt:   recTime(rec, "updated_at"),
+		ID:                  recString(rec, "id"),
+		IdentityID:          recString(rec, "identity_id"),
+		UserID:              recString(rec, "user_id"),
+		OwnerKind:           recString(rec, "owner_kind"),
+		OwnerID:             recString(rec, "owner_id"),
+		CredentialSubjectID: recString(rec, "credential_subject_id"),
+		TokenKind:           recString(rec, "token_kind"),
+		Name:                recString(rec, "name"),
+		HashedToken:         recString(rec, "hashed_token"),
+		Scopes:              recString(rec, "scopes"),
+		ExpiresAt:           recTimePtr(rec, "expires_at"),
+		CreatedAt:           recTime(rec, "created_at"),
+		UpdatedAt:           recTime(rec, "updated_at"),
 	}
 	if token.OwnerKind == "" && token.UserID != "" {
 		token.OwnerKind = core.APITokenOwnerKindUser
@@ -346,6 +348,9 @@ func recordToAPIToken(rec indexeddb.Record) *core.APIToken {
 	}
 	if token.TokenKind == "" {
 		token.TokenKind = core.APITokenKindAPI
+	}
+	if token.CredentialSubjectID == "" && token.OwnerKind == core.APITokenOwnerKindUser && token.OwnerID != "" {
+		token.CredentialSubjectID = "user:" + token.OwnerID
 	}
 	if raw := recString(rec, "permissions_json"); raw != "" {
 		var permissions []core.AccessPermission

--- a/gestaltd/internal/coredata/schemas.go
+++ b/gestaltd/internal/coredata/schemas.go
@@ -37,14 +37,14 @@ var UsersSchema = indexeddb.ObjectStoreSchema{
 
 var IntegrationTokensSchema = indexeddb.ObjectStoreSchema{
 	Indexes: []indexeddb.IndexSchema{
-		{Name: "by_user", KeyPath: []string{"user_id"}},
-		{Name: "by_user_integration", KeyPath: []string{"user_id", "integration"}},
-		{Name: "by_user_connection", KeyPath: []string{"user_id", "integration", "connection"}},
-		{Name: "by_lookup", KeyPath: []string{"user_id", "integration", "connection", "instance"}, Unique: true},
+		{Name: "by_subject", KeyPath: []string{"subject_id"}},
+		{Name: "by_subject_integration", KeyPath: []string{"subject_id", "integration"}},
+		{Name: "by_subject_connection", KeyPath: []string{"subject_id", "integration", "connection"}},
+		{Name: "by_lookup", KeyPath: []string{"subject_id", "integration", "connection", "instance"}, Unique: true},
 	},
 	Columns: []indexeddb.ColumnDef{
 		{Name: "id", Type: indexeddb.TypeString, PrimaryKey: true},
-		{Name: "user_id", Type: indexeddb.TypeString, NotNull: true},
+		{Name: "subject_id", Type: indexeddb.TypeString, NotNull: true},
 		{Name: "integration", Type: indexeddb.TypeString, NotNull: true},
 		{Name: "connection", Type: indexeddb.TypeString, NotNull: true},
 		{Name: "instance", Type: indexeddb.TypeString},
@@ -78,6 +78,7 @@ var APITokensSchema = indexeddb.ObjectStoreSchema{
 		{Name: "owner_kind", Type: indexeddb.TypeString},
 		{Name: "owner_id", Type: indexeddb.TypeString},
 		{Name: "token_kind", Type: indexeddb.TypeString},
+		{Name: "credential_subject_id", Type: indexeddb.TypeString},
 		{Name: "name", Type: indexeddb.TypeString},
 		{Name: "hashed_token", Type: indexeddb.TypeString, NotNull: true, Unique: true},
 		{Name: "scopes", Type: indexeddb.TypeString},

--- a/gestaltd/internal/coredata/services.go
+++ b/gestaltd/internal/coredata/services.go
@@ -113,6 +113,9 @@ func New(ds indexeddb.IndexedDB, enc *corecrypto.AESGCMEncryptor) (*Services, er
 	if err := apiTokens.BackfillTokenAccess(ctx); err != nil {
 		return nil, fmt.Errorf("backfill canonical api token access: %w", err)
 	}
+	if err := tokens.BackfillSubjectIDs(ctx); err != nil {
+		return nil, fmt.Errorf("backfill integration token subjects: %w", err)
+	}
 	if err := tokens.BackfillCanonicalCredentials(ctx); err != nil {
 		return nil, fmt.Errorf("backfill canonical external credentials: %w", err)
 	}

--- a/gestaltd/internal/coredata/services_test.go
+++ b/gestaltd/internal/coredata/services_test.go
@@ -662,7 +662,7 @@ func TestTokenService(t *testing.T) {
 			t.Fatalf("StoreToken: %v", err)
 		}
 
-		got, err := svc.Tokens.Token(ctx, user.ID, "test-svc", "default", "inst-1")
+		got, err := svc.Tokens.Token(ctx, principal.UserSubjectID(user.ID), "test-svc", "default", "inst-1")
 		if err != nil {
 			t.Fatalf("Token: %v", err)
 		}
@@ -721,7 +721,7 @@ func TestTokenService(t *testing.T) {
 			}
 		}
 
-		tokens, err := svc.Tokens.ListTokens(ctx, userA.ID)
+		tokens, err := svc.Tokens.ListTokens(ctx, principal.UserSubjectID(userA.ID))
 		if err != nil {
 			t.Fatalf("ListTokens: %v", err)
 		}
@@ -746,7 +746,7 @@ func TestTokenService(t *testing.T) {
 			}
 		}
 
-		tokens, err := svc.Tokens.ListTokensForIntegration(ctx, user.ID, "svc-a")
+		tokens, err := svc.Tokens.ListTokensForIntegration(ctx, principal.UserSubjectID(user.ID), "svc-a")
 		if err != nil {
 			t.Fatalf("ListTokensForIntegration: %v", err)
 		}
@@ -771,7 +771,7 @@ func TestTokenService(t *testing.T) {
 			}
 		}
 
-		tokens, err := svc.Tokens.ListTokensForConnection(ctx, user.ID, "svc", "conn-a")
+		tokens, err := svc.Tokens.ListTokensForConnection(ctx, principal.UserSubjectID(user.ID), "svc", "conn-a")
 		if err != nil {
 			t.Fatalf("ListTokensForConnection: %v", err)
 		}
@@ -799,7 +799,7 @@ func TestTokenService(t *testing.T) {
 			t.Fatalf("DeleteToken: %v", err)
 		}
 
-		_, err := svc.Tokens.Token(ctx, user.ID, "svc", "default", "i1")
+		_, err := svc.Tokens.Token(ctx, principal.UserSubjectID(user.ID), "svc", "default", "i1")
 		if err != core.ErrNotFound {
 			t.Fatalf("Token after delete = %v, want ErrNotFound", err)
 		}
@@ -838,7 +838,7 @@ func TestTokenService(t *testing.T) {
 			t.Fatalf("second StoreToken: %v", err)
 		}
 
-		got, err := svc.Tokens.Token(ctx, user.ID, "svc", "default", "i1")
+		got, err := svc.Tokens.Token(ctx, principal.UserSubjectID(user.ID), "svc", "default", "i1")
 		if err != nil {
 			t.Fatalf("Token: %v", err)
 		}
@@ -849,7 +849,7 @@ func TestTokenService(t *testing.T) {
 			t.Errorf("AccessToken = %q, want %q", got.AccessToken, "updated")
 		}
 
-		tokens, err := svc.Tokens.ListTokensForConnection(ctx, user.ID, "svc", "default")
+		tokens, err := svc.Tokens.ListTokensForConnection(ctx, principal.UserSubjectID(user.ID), "svc", "default")
 		if err != nil {
 			t.Fatalf("ListTokensForConnection: %v", err)
 		}
@@ -918,7 +918,7 @@ func TestTokenService(t *testing.T) {
 			t.Fatalf("Put duplicate raw token: %v", err)
 		}
 
-		tokens, err := svc.Tokens.ListTokensForConnection(ctx, user.ID, "svc", "default")
+		tokens, err := svc.Tokens.ListTokensForConnection(ctx, principal.UserSubjectID(user.ID), "svc", "default")
 		if err != nil {
 			t.Fatalf("ListTokensForConnection: %v", err)
 		}
@@ -1128,7 +1128,7 @@ func TestTokenService(t *testing.T) {
 			}
 		}
 
-		tokens, err := svc.Tokens.ListTokens(ctx, user.ID)
+		tokens, err := svc.Tokens.ListTokens(ctx, principal.UserSubjectID(user.ID))
 		if err != nil {
 			t.Fatalf("ListTokens: %v", err)
 		}
@@ -1176,7 +1176,7 @@ func TestTokenService(t *testing.T) {
 			t.Error("refresh_token_encrypted should not be empty")
 		}
 
-		got, err := svc.Tokens.Token(ctx, user.ID, "svc", "default", "i1")
+		got, err := svc.Tokens.Token(ctx, principal.UserSubjectID(user.ID), "svc", "default", "i1")
 		if err != nil {
 			t.Fatalf("Token: %v", err)
 		}

--- a/gestaltd/internal/coredata/tokens.go
+++ b/gestaltd/internal/coredata/tokens.go
@@ -5,6 +5,7 @@ import (
 	"errors"
 	"fmt"
 	"sort"
+	"strings"
 	"time"
 
 	"github.com/google/uuid"
@@ -32,6 +33,9 @@ func NewTokenService(ds indexeddb.IndexedDB, enc *corecrypto.AESGCMEncryptor, ex
 }
 
 func (s *TokenService) StoreToken(ctx context.Context, token *core.IntegrationToken) error {
+	token.SubjectID = canonicalTokenSubjectID(token.SubjectID, token.UserID)
+	token.UserID = tokenUserIDFromSubjectID(token.SubjectID)
+
 	accessEnc, refreshEnc, err := s.enc.EncryptTokenPair(token.AccessToken, token.RefreshToken)
 	if err != nil {
 		return fmt.Errorf("encrypt token pair: %w", err)
@@ -41,7 +45,7 @@ func (s *TokenService) StoreToken(ctx context.Context, token *core.IntegrationTo
 	}
 	now := time.Now()
 	fields := indexeddb.Record{
-		"user_id":                 token.UserID,
+		"subject_id":              token.SubjectID,
 		"integration":             token.Integration,
 		"connection":              token.Connection,
 		"instance":                token.Instance,
@@ -55,7 +59,7 @@ func (s *TokenService) StoreToken(ctx context.Context, token *core.IntegrationTo
 		"updated_at":              now,
 	}
 
-	existing, err := s.tokenRecord(ctx, token.UserID, token.Integration, token.Connection, token.Instance)
+	existing, err := s.tokenRecord(ctx, token.SubjectID, token.Integration, token.Connection, token.Instance)
 	switch err {
 	case nil:
 		token.ID = recString(existing, "id")
@@ -78,7 +82,7 @@ func (s *TokenService) StoreToken(ctx context.Context, token *core.IntegrationTo
 		return fmt.Errorf("check existing token: %w", err)
 	}
 
-	if err := s.deleteDuplicateLookupRecords(ctx, token.ID, token.UserID, token.Integration, token.Connection, token.Instance); err != nil {
+	if err := s.deleteDuplicateLookupRecords(ctx, token.ID, token.SubjectID, token.Integration, token.Connection, token.Instance); err != nil {
 		return err
 	}
 	if err := s.syncExternalCredential(ctx, token, accessEnc, refreshEnc); err != nil {
@@ -87,32 +91,32 @@ func (s *TokenService) StoreToken(ctx context.Context, token *core.IntegrationTo
 	return nil
 }
 
-func (s *TokenService) Token(ctx context.Context, userID, integration, connection, instance string) (*core.IntegrationToken, error) {
-	rec, err := s.tokenRecord(ctx, userID, integration, connection, instance)
+func (s *TokenService) Token(ctx context.Context, subjectID, integration, connection, instance string) (*core.IntegrationToken, error) {
+	rec, err := s.tokenRecord(ctx, subjectID, integration, connection, instance)
 	if err != nil {
 		return nil, err
 	}
 	return s.recordToToken(rec)
 }
 
-func (s *TokenService) ListTokens(ctx context.Context, userID string) ([]*core.IntegrationToken, error) {
-	recs, err := s.store.Index("by_user").GetAll(ctx, nil, userID)
+func (s *TokenService) ListTokens(ctx context.Context, subjectID string) ([]*core.IntegrationToken, error) {
+	recs, err := s.store.Index("by_subject").GetAll(ctx, nil, subjectID)
 	if err != nil {
 		return nil, fmt.Errorf("list tokens: %w", err)
 	}
 	return s.recordsToTokens(recs)
 }
 
-func (s *TokenService) ListTokensForIntegration(ctx context.Context, userID, integration string) ([]*core.IntegrationToken, error) {
-	recs, err := s.store.Index("by_user_integration").GetAll(ctx, nil, userID, integration)
+func (s *TokenService) ListTokensForIntegration(ctx context.Context, subjectID, integration string) ([]*core.IntegrationToken, error) {
+	recs, err := s.store.Index("by_subject_integration").GetAll(ctx, nil, subjectID, integration)
 	if err != nil {
 		return nil, fmt.Errorf("list tokens for integration: %w", err)
 	}
 	return s.recordsToTokens(recs)
 }
 
-func (s *TokenService) ListTokensForConnection(ctx context.Context, userID, integration, connection string) ([]*core.IntegrationToken, error) {
-	recs, err := s.store.Index("by_user_connection").GetAll(ctx, nil, userID, integration, connection)
+func (s *TokenService) ListTokensForConnection(ctx context.Context, subjectID, integration, connection string) ([]*core.IntegrationToken, error) {
+	recs, err := s.store.Index("by_subject_connection").GetAll(ctx, nil, subjectID, integration, connection)
 	if err != nil {
 		return nil, fmt.Errorf("list tokens for connection: %w", err)
 	}
@@ -134,7 +138,8 @@ func (s *TokenService) DeleteToken(ctx context.Context, id string) error {
 		return err
 	}
 	if s.externalCredentials != nil {
-		remaining, err := s.store.Index("by_lookup").GetAll(ctx, nil, recString(rec, "user_id"), recString(rec, "integration"), recString(rec, "connection"), recString(rec, "instance"))
+		subjectID := tokenRecordSubjectID(rec)
+		remaining, err := s.store.Index("by_lookup").GetAll(ctx, nil, subjectID, recString(rec, "integration"), recString(rec, "connection"), recString(rec, "instance"))
 		if err != nil {
 			return fmt.Errorf("list remaining duplicate tokens: %w", err)
 		}
@@ -144,7 +149,7 @@ func (s *TokenService) DeleteToken(ctx context.Context, id string) error {
 				return err
 			}
 		} else {
-			identityID, resolveErr := s.resolveIdentityID(ctx, recString(rec, "user_id"))
+			identityID, resolveErr := s.resolveIdentityID(ctx, tokenUserIDFromSubjectID(subjectID))
 			if resolveErr == nil {
 				if err := s.externalCredentials.DeleteCredential(ctx, identityID, recString(rec, "integration"), recString(rec, "connection"), recString(rec, "instance")); err != nil && err != core.ErrNotFound {
 					return fmt.Errorf("delete canonical external credential: %w", err)
@@ -165,7 +170,8 @@ func (s *TokenService) recordToToken(rec indexeddb.Record) (*core.IntegrationTok
 	}
 	return &core.IntegrationToken{
 		ID:                recString(rec, "id"),
-		UserID:            recString(rec, "user_id"),
+		UserID:            tokenUserIDFromSubjectID(tokenRecordSubjectID(rec)),
+		SubjectID:         tokenRecordSubjectID(rec),
 		Integration:       recString(rec, "integration"),
 		Connection:        recString(rec, "connection"),
 		Instance:          recString(rec, "instance"),
@@ -194,8 +200,8 @@ func (s *TokenService) recordsToTokens(recs []indexeddb.Record) ([]*core.Integra
 	return out, nil
 }
 
-func (s *TokenService) tokenRecord(ctx context.Context, userID, integration, connection, instance string) (indexeddb.Record, error) {
-	recs, err := s.store.Index("by_lookup").GetAll(ctx, nil, userID, integration, connection, instance)
+func (s *TokenService) tokenRecord(ctx context.Context, subjectID, integration, connection, instance string) (indexeddb.Record, error) {
+	recs, err := s.store.Index("by_lookup").GetAll(ctx, nil, subjectID, integration, connection, instance)
 	if err != nil {
 		return nil, fmt.Errorf("get token: %w", err)
 	}
@@ -206,8 +212,8 @@ func (s *TokenService) tokenRecord(ctx context.Context, userID, integration, con
 	return recs[0], nil
 }
 
-func (s *TokenService) deleteDuplicateLookupRecords(ctx context.Context, keepID, userID, integration, connection, instance string) error {
-	recs, err := s.store.Index("by_lookup").GetAll(ctx, nil, userID, integration, connection, instance)
+func (s *TokenService) deleteDuplicateLookupRecords(ctx context.Context, keepID, subjectID, integration, connection, instance string) error {
+	recs, err := s.store.Index("by_lookup").GetAll(ctx, nil, subjectID, integration, connection, instance)
 	if err != nil {
 		return fmt.Errorf("list duplicate tokens: %w", err)
 	}
@@ -242,6 +248,24 @@ func (s *TokenService) BackfillCanonicalCredentials(ctx context.Context) error {
 	return nil
 }
 
+func (s *TokenService) BackfillSubjectIDs(ctx context.Context) error {
+	recs, err := s.store.GetAll(ctx, nil)
+	if err != nil {
+		return fmt.Errorf("list integration tokens for subject_id backfill: %w", err)
+	}
+	for _, rec := range recs {
+		subjectID := tokenRecordSubjectID(rec)
+		if subjectID == "" || recString(rec, "subject_id") == subjectID {
+			continue
+		}
+		rec["subject_id"] = subjectID
+		if err := s.store.Put(ctx, rec); err != nil {
+			return fmt.Errorf("backfill integration token subject_id %q: %w", recString(rec, "id"), err)
+		}
+	}
+	return nil
+}
+
 func dedupeTokenRecords(recs []indexeddb.Record) []indexeddb.Record {
 	if len(recs) <= 1 {
 		return recs
@@ -267,10 +291,40 @@ func dedupeTokenRecords(recs []indexeddb.Record) []indexeddb.Record {
 }
 
 func tokenLookupKey(rec indexeddb.Record) string {
-	return recString(rec, "user_id") + "\x00" +
+	return tokenRecordSubjectID(rec) + "\x00" +
 		recString(rec, "integration") + "\x00" +
 		recString(rec, "connection") + "\x00" +
 		recString(rec, "instance")
+}
+
+func tokenRecordSubjectID(rec indexeddb.Record) string {
+	return canonicalTokenSubjectID(recString(rec, "subject_id"), recString(rec, "user_id"))
+}
+
+func canonicalTokenSubjectID(subjectID, userID string) string {
+	subjectID = strings.TrimSpace(subjectID)
+	if subjectID != "" {
+		return subjectID
+	}
+	userID = strings.TrimSpace(userID)
+	switch userID {
+	case "":
+		return ""
+	case "__identity__":
+		return "identity:__identity__"
+	}
+	return "user:" + userID
+}
+
+func tokenUserIDFromSubjectID(subjectID string) string {
+	switch {
+	case strings.HasPrefix(subjectID, "user:"):
+		return strings.TrimPrefix(subjectID, "user:")
+	case subjectID == "identity:__identity__":
+		return "__identity__"
+	default:
+		return ""
+	}
 }
 
 func tokenRecordLess(a, b indexeddb.Record) bool {
@@ -349,7 +403,7 @@ func (s *TokenService) syncExternalCredentialRecord(ctx context.Context, rec ind
 	if s.externalCredentials == nil {
 		return nil
 	}
-	identityID, resolveErr := s.resolveIdentityID(ctx, recString(rec, "user_id"))
+	identityID, resolveErr := s.resolveIdentityID(ctx, tokenUserIDFromSubjectID(tokenRecordSubjectID(rec)))
 	if resolveErr != nil {
 		if errors.Is(resolveErr, core.ErrNotFound) {
 			return nil

--- a/gestaltd/internal/invocation/broker.go
+++ b/gestaltd/internal/invocation/broker.go
@@ -421,24 +421,22 @@ func (b *Broker) resolveToken(ctx context.Context, prov core.Provider, p *princi
 		ctx = withResolvedPrincipal(ctx, p)
 	}
 
-	mode := prov.ConnectionMode()
+	mode := core.NormalizeConnectionMode(prov.ConnectionMode())
 	switch mode {
 	case core.ConnectionModeNone:
 		SetCredentialAudit(ctx, core.ConnectionModeNone, "", "", "")
 		ctx = WithCredentialContext(ctx, CredentialContext{Mode: core.ConnectionModeNone})
 		return ctx, "", nil
 
-	case core.ConnectionModeUser, "":
-		if p.UserID == "" {
-			return ctx, "", fmt.Errorf("%w: principal has no user ID or email", ErrUserResolution)
+	case core.ConnectionModeUser:
+		subjectID := principal.EffectiveCredentialSubjectID(p)
+		if subjectID == "" {
+			return ctx, "", fmt.Errorf("%w: principal has no subject ID or email", ErrUserResolution)
 		}
-		return b.resolveUserToken(ctx, prov, p.UserID, providerName, connection, instance, core.ConnectionModeUser, principal.UserSubjectID(p.UserID))
+		return b.resolveSubjectToken(ctx, prov, subjectID, providerName, connection, instance, core.ConnectionModeUser, subjectID)
 
 	case core.ConnectionModeIdentity:
-		return b.resolveUserToken(ctx, prov, principal.IdentityPrincipal, providerName, connection, instance, core.ConnectionModeIdentity, principal.IdentitySubjectID())
-
-	case core.ConnectionMode("either"):
-		return ctx, "", fmt.Errorf("%w: unsupported connection mode %q", ErrInternal, mode)
+		return b.resolveSubjectToken(ctx, prov, principal.IdentitySubjectID(), providerName, connection, instance, core.ConnectionModeIdentity, principal.IdentitySubjectID())
 
 	default:
 		return ctx, "", fmt.Errorf("%w: unknown connection mode %q", ErrInternal, mode)
@@ -499,18 +497,33 @@ func (b *Broker) resolveWorkloadToken(ctx context.Context, prov core.Provider, p
 			return ctx, "", fmt.Errorf("%w: workloads may not override connection or instance bindings", ErrAuthorizationDenied)
 		}
 		SetCredentialAudit(ctx, binding.Mode, binding.CredentialSubjectID, connection, instance)
-		return b.resolveUserToken(ctx, prov, principal.IdentityPrincipal, providerName, connection, instance, core.ConnectionModeIdentity, binding.CredentialSubjectID)
+		return b.resolveSubjectToken(ctx, prov, principal.IdentitySubjectID(), providerName, connection, instance, core.ConnectionModeIdentity, binding.CredentialSubjectID)
+	case core.ConnectionModeUser:
+		connection := binding.Connection
+		instance := binding.Instance
+		if (requestedConnection != "" && requestedConnection != binding.Connection) || (requestedInstance != "" && requestedInstance != binding.Instance) {
+			return ctx, "", fmt.Errorf("%w: workloads may not override connection or instance bindings", ErrAuthorizationDenied)
+		}
+		subjectID := strings.TrimSpace(binding.CredentialSubjectID)
+		if subjectID == "" {
+			subjectID = principal.EffectiveCredentialSubjectID(p)
+		}
+		if subjectID == "" {
+			return ctx, "", fmt.Errorf("%w: principal has no subject ID or email", ErrUserResolution)
+		}
+		SetCredentialAudit(ctx, binding.Mode, subjectID, connection, instance)
+		return b.resolveSubjectToken(ctx, prov, subjectID, providerName, connection, instance, core.ConnectionModeUser, subjectID)
 	default:
 		return ctx, "", fmt.Errorf("%w: workloads may only use identity or none providers", ErrAuthorizationDenied)
 	}
 }
 
-func (b *Broker) resolveUserToken(ctx context.Context, prov core.Provider, userID, providerName, connection, instance string, credentialMode core.ConnectionMode, credentialSubjectID string) (context.Context, string, error) {
+func (b *Broker) resolveSubjectToken(ctx context.Context, prov core.Provider, subjectID, providerName, connection, instance string, credentialMode core.ConnectionMode, credentialSubjectID string) (context.Context, string, error) {
 	var storedToken *core.IntegrationToken
 	var err error
 
 	if instance != "" {
-		storedToken, err = b.tokens.Token(ctx, userID, providerName, connection, instance)
+		storedToken, err = b.tokens.Token(ctx, subjectID, providerName, connection, instance)
 		if err != nil {
 			if errors.Is(err, core.ErrNotFound) {
 				return ctx, "", fmt.Errorf("%w: no token stored for integration %q instance %q", ErrNoToken, providerName, instance)
@@ -518,7 +531,7 @@ func (b *Broker) resolveUserToken(ctx context.Context, prov core.Provider, userI
 			return ctx, "", fmt.Errorf("%w: retrieving integration token: %v", ErrInternal, err)
 		}
 	} else {
-		tokens, listErr := b.tokens.ListTokensForConnection(ctx, userID, providerName, connection)
+		tokens, listErr := b.tokens.ListTokensForConnection(ctx, subjectID, providerName, connection)
 		if listErr != nil {
 			return ctx, "", fmt.Errorf("%w: listing tokens: %v", ErrInternal, listErr)
 		}
@@ -561,15 +574,15 @@ func (b *Broker) resolveUserToken(ctx context.Context, prov core.Provider, userI
 	return ctx, accessToken, err
 }
 
-// ResolveUserToken exposes the broker's refresh-aware user token lookup for
-// callers that need a user-scoped credential even when the provider runtime
-// connection mode would not normally resolve one.
-func (b *Broker) ResolveUserToken(ctx context.Context, prov core.Provider, userID, providerName, connection, instance string) (context.Context, string, error) {
-	userID = strings.TrimSpace(userID)
-	if userID == "" {
-		return ctx, "", fmt.Errorf("%w: principal has no user ID or email", ErrUserResolution)
+// ResolveSubjectToken exposes the broker's refresh-aware token lookup for
+// callers that need a specific subject-owned credential even when the provider
+// runtime connection mode would not normally resolve one.
+func (b *Broker) ResolveSubjectToken(ctx context.Context, prov core.Provider, subjectID, providerName, connection, instance string) (context.Context, string, error) {
+	subjectID = strings.TrimSpace(subjectID)
+	if subjectID == "" {
+		return ctx, "", fmt.Errorf("%w: principal has no subject ID or email", ErrUserResolution)
 	}
-	return b.resolveUserToken(ctx, prov, userID, providerName, connection, instance, core.ConnectionModeUser, principal.UserSubjectID(userID))
+	return b.resolveSubjectToken(ctx, prov, subjectID, providerName, connection, instance, core.ConnectionModeUser, subjectID)
 }
 
 func (b *Broker) refreshTokenIfNeeded(ctx context.Context, token *core.IntegrationToken, providerName, connection, connectionMode string) (string, error) {
@@ -585,7 +598,7 @@ func (b *Broker) refreshTokenIfNeeded(ctx context.Context, token *core.Integrati
 		return token.AccessToken, nil
 	}
 
-	key := token.UserID + ":" + providerName + ":" + connection + ":" + token.Instance
+	key := token.SubjectID + ":" + providerName + ":" + connection + ":" + token.Instance
 	v, err, _ := b.refreshGroup.Do(key, func() (any, error) {
 		refreshCtx := context.WithoutCancel(ctx)
 		startedAt := time.Now()
@@ -594,7 +607,7 @@ func (b *Broker) refreshTokenIfNeeded(ctx context.Context, token *core.Integrati
 		return resp, err
 	})
 	if err != nil {
-		fresh, fetchErr := b.tokens.Token(ctx, token.UserID, token.Integration, token.Connection, token.Instance)
+		fresh, fetchErr := b.tokens.Token(ctx, token.SubjectID, token.Integration, token.Connection, token.Instance)
 		if fetchErr == nil && fresh != nil && fresh.AccessToken != token.AccessToken {
 			return fresh.AccessToken, nil
 		}

--- a/gestaltd/internal/invocation/guarded.go
+++ b/gestaltd/internal/invocation/guarded.go
@@ -173,14 +173,14 @@ func (g *GuardedInvoker) ResolveToken(ctx context.Context, p *principal.Principa
 	return ctx, "", fmt.Errorf("token resolution not supported")
 }
 
-func (g *GuardedInvoker) ResolveUserToken(ctx context.Context, prov core.Provider, userID, providerName, connection, instance string) (context.Context, string, error) {
+func (g *GuardedInvoker) ResolveSubjectToken(ctx context.Context, prov core.Provider, subjectID, providerName, connection, instance string) (context.Context, string, error) {
 	type resolver interface {
-		ResolveUserToken(ctx context.Context, prov core.Provider, userID, providerName, connection, instance string) (context.Context, string, error)
+		ResolveSubjectToken(ctx context.Context, prov core.Provider, subjectID, providerName, connection, instance string) (context.Context, string, error)
 	}
 	if r, ok := g.inner.(resolver); ok {
-		return r.ResolveUserToken(ctx, prov, userID, providerName, connection, instance)
+		return r.ResolveSubjectToken(ctx, prov, subjectID, providerName, connection, instance)
 	}
-	return ctx, "", fmt.Errorf("user token resolution not supported")
+	return ctx, "", fmt.Errorf("subject token resolution not supported")
 }
 
 func (g *GuardedInvoker) logAudit(ctx context.Context, entry core.AuditEntry) {

--- a/gestaltd/internal/metricutil/meter.go
+++ b/gestaltd/internal/metricutil/meter.go
@@ -75,10 +75,7 @@ func NewFloat64Histogram(meter metric.Meter, name, desc, unit string) metric.Flo
 }
 
 func NormalizeConnectionMode(mode core.ConnectionMode) string {
-	if mode == "" {
-		return string(core.ConnectionModeUser)
-	}
-	return string(mode)
+	return string(core.NormalizeConnectionMode(mode))
 }
 
 func meterProviderCacheKey(provider metric.MeterProvider) (string, bool) {

--- a/gestaltd/internal/principal/principal.go
+++ b/gestaltd/internal/principal/principal.go
@@ -29,14 +29,15 @@ const (
 )
 
 type Principal struct {
-	Identity         *core.UserIdentity
-	UserID           string
-	SubjectID        string
-	DisplayName      string
-	Kind             Kind
-	Source           Source
-	Scopes           []string
-	TokenPermissions PermissionSet
+	Identity            *core.UserIdentity
+	UserID              string
+	SubjectID           string
+	CredentialSubjectID string
+	DisplayName         string
+	Kind                Kind
+	Source              Source
+	Scopes              []string
+	TokenPermissions    PermissionSet
 }
 
 type PermissionSet map[string]map[string]struct{}
@@ -104,6 +105,22 @@ func WorkloadSubjectID(workloadID string) string {
 
 func IdentitySubjectID() string {
 	return "identity:" + IdentityPrincipal
+}
+
+func EffectiveCredentialSubjectID(p *Principal) string {
+	if p == nil {
+		return ""
+	}
+	if subjectID := strings.TrimSpace(p.CredentialSubjectID); subjectID != "" {
+		return subjectID
+	}
+	if subjectID := strings.TrimSpace(p.SubjectID); subjectID != "" {
+		return subjectID
+	}
+	if userID := strings.TrimSpace(p.UserID); userID != "" {
+		return UserSubjectID(userID)
+	}
+	return ""
 }
 
 func ManagedIdentitySubjectID(identityID string) string {

--- a/gestaltd/internal/principal/resolver.go
+++ b/gestaltd/internal/principal/resolver.go
@@ -152,10 +152,11 @@ func (r *Resolver) resolveAPIToken(ctx context.Context, token string) (*Principa
 			Email:       user.Email,
 			DisplayName: user.DisplayName,
 		},
-		UserID:    user.ID,
-		SubjectID: UserSubjectID(user.ID),
-		Kind:      KindUser,
-		Source:    SourceAPIToken,
+		UserID:              user.ID,
+		SubjectID:           UserSubjectID(user.ID),
+		CredentialSubjectID: apiToken.CredentialSubjectID,
+		Kind:                KindUser,
+		Source:              SourceAPIToken,
 	}
 	if perms := permissionsForAPIToken(apiToken); perms != nil {
 		p.TokenPermissions = perms
@@ -196,12 +197,13 @@ func (r *Resolver) resolveManagedIdentityAPIToken(ctx context.Context, apiToken 
 	}
 
 	return &Principal{
-		SubjectID:        ManagedIdentitySubjectID(identity.ID),
-		DisplayName:      identity.DisplayName,
-		Kind:             KindWorkload,
-		Source:           SourceAPIToken,
-		Scopes:           PermissionPlugins(effectivePerms),
-		TokenPermissions: effectivePerms,
+		SubjectID:           ManagedIdentitySubjectID(identity.ID),
+		CredentialSubjectID: apiToken.CredentialSubjectID,
+		DisplayName:         identity.DisplayName,
+		Kind:                KindWorkload,
+		Source:              SourceAPIToken,
+		Scopes:              PermissionPlugins(effectivePerms),
+		TokenPermissions:    effectivePerms,
 	}, nil
 }
 

--- a/gestaltd/internal/provider/build.go
+++ b/gestaltd/internal/provider/build.go
@@ -86,7 +86,7 @@ func Build(def *Definition, conn config.ConnectionDef, opts ...BuildOption) (cor
 	case "", providermanifestv1.ConnectionModeNone, providermanifestv1.ConnectionModeUser,
 		providermanifestv1.ConnectionModeIdentity:
 		if connMode != "" {
-			base.ConnMode = core.ConnectionMode(connMode)
+			base.ConnMode = core.NormalizeConnectionMode(core.ConnectionMode(connMode))
 		}
 	default:
 		return nil, fmt.Errorf("%s: unknown connectionMode %q", def.Provider, connMode)

--- a/gestaltd/internal/server/authorization.go
+++ b/gestaltd/internal/server/authorization.go
@@ -75,8 +75,8 @@ func (s *Server) workloadBindingConnected(ctx context.Context, binding authoriza
 	switch binding.Mode {
 	case core.ConnectionModeNone:
 		return true, nil
-	case core.ConnectionModeIdentity:
-		_, err := s.tokens.Token(ctx, binding.CredentialOwnerID, provider, binding.Connection, binding.Instance)
+	case core.ConnectionModeIdentity, core.ConnectionModeUser:
+		_, err := s.tokens.Token(ctx, binding.CredentialSubjectID, provider, binding.Connection, binding.Instance)
 		switch {
 		case err == nil:
 			return true, nil

--- a/gestaltd/internal/server/handlers.go
+++ b/gestaltd/internal/server/handlers.go
@@ -212,7 +212,7 @@ func (s *Server) userConnectedIntegrations(r *http.Request) (map[string][]instan
 		}
 		userID = dbUser.ID
 	}
-	tokens, err := s.tokens.ListTokens(r.Context(), userID)
+	tokens, err := s.tokens.ListTokens(r.Context(), principal.UserSubjectID(userID))
 	if err != nil {
 		return nil, fmt.Errorf("listing tokens: %w", err)
 	}
@@ -240,6 +240,7 @@ func (s *Server) disconnectIntegration(w http.ResponseWriter, r *http.Request) {
 		auditErr = err
 		return
 	}
+	subjectID := principal.UserSubjectID(userID)
 
 	if _, ok := s.getProvider(w, name); !ok {
 		auditErr = errors.New("integration not found")
@@ -268,7 +269,7 @@ func (s *Server) disconnectIntegration(w http.ResponseWriter, r *http.Request) {
 		auditTarget = connectionAuditTarget(name, requestedConnection, requestedInstance)
 	}
 
-	tokens, err := s.tokens.ListTokensForIntegration(r.Context(), userID, name)
+	tokens, err := s.tokens.ListTokensForIntegration(r.Context(), subjectID, name)
 	if err != nil {
 		auditErr = errors.New("failed to list tokens")
 		writeError(w, http.StatusInternalServerError, "failed to list tokens")

--- a/gestaltd/internal/server/handlers_connect.go
+++ b/gestaltd/internal/server/handlers_connect.go
@@ -73,7 +73,7 @@ func (s *Server) connectManual(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	dbUserID, manualInstance, err := s.resolveUserConnectionSetup(w, r, req.Instance)
+	subjectID, manualInstance, err := s.resolveUserConnectionSetup(w, r, req.Instance)
 	if err != nil {
 		auditErr = err
 		return
@@ -110,7 +110,7 @@ func (s *Server) connectManual(w http.ResponseWriter, r *http.Request) {
 		authSource = p.AuthSource()
 	}
 	tm := tokenMaterial{
-		UserID:       dbUserID,
+		SubjectID:    subjectID,
 		AuthSource:   authSource,
 		Integration:  req.Integration,
 		Connection:   manualConnection,
@@ -153,7 +153,7 @@ func (s *Server) resolveUserConnectionSetup(w http.ResponseWriter, r *http.Reque
 	if !ok {
 		return "", "", errors.New("invalid instance")
 	}
-	return userID, instance, nil
+	return principal.UserSubjectID(userID), instance, nil
 }
 
 func validateConnectionParams(defs map[string]core.ConnectionParamDef, provided map[string]string) (map[string]string, error) {
@@ -237,7 +237,7 @@ func (t *bearerTransport) RoundTrip(req *http.Request) (*http.Response, error) {
 }
 
 type tokenMaterial struct {
-	UserID         string
+	SubjectID      string
 	AuthSource     string
 	Integration    string
 	Connection     string
@@ -265,7 +265,7 @@ func (s *Server) storeTokenFromMaterial(ctx context.Context, tm tokenMaterial) (
 	now := s.now().UTC().Truncate(time.Second)
 	tok := &core.IntegrationToken{
 		ID:              uuid.NewString(),
-		UserID:          tm.UserID,
+		SubjectID:       tm.SubjectID,
 		Integration:     tm.Integration,
 		Connection:      tm.Connection,
 		Instance:        tm.Instance,

--- a/gestaltd/internal/server/handlers_identities.go
+++ b/gestaltd/internal/server/handlers_identities.go
@@ -682,11 +682,6 @@ func (s *Server) putManagedIdentityGrant(w http.ResponseWriter, r *http.Request)
 		writeError(w, http.StatusNotFound, "plugin not found")
 		return
 	}
-	if !s.managedIdentityInvocationSupported(plugin) {
-		auditErr = fmt.Errorf("plugin %q does not yet support managed-identity invocation in this phase", plugin)
-		writeError(w, http.StatusBadRequest, auditErr.Error())
-		return
-	}
 	auditTarget = managedIdentityGrantAuditTarget(actor.Identity.ID, plugin)
 
 	grant, err := s.identityGrants.UpsertGrant(r.Context(), &core.ManagedIdentityGrant{
@@ -1053,85 +1048,6 @@ func (s *Server) managedIdentityGrantVisibleToActor(ctx context.Context, plugin 
 	}
 	return s.allowProviderContext(ctx, p, plugin)
 }
-
-func (s *Server) managedIdentityInvocationSupported(plugin string) bool {
-	if entry, ok := s.pluginDefs[plugin]; ok && entry != nil {
-		return managedIdentityPluginConnectionMode(entry) == core.ConnectionModeNone
-	}
-	prov, err := s.providers.Get(plugin)
-	if err != nil || prov == nil {
-		return false
-	}
-	return prov.ConnectionMode() == core.ConnectionModeNone
-}
-
-func managedIdentityPluginConnectionMode(entry *config.ProviderEntry) core.ConnectionMode {
-	needUser := false
-	needIdentity := false
-
-	addMode := func(mode core.ConnectionMode) {
-		switch mode {
-		case core.ConnectionModeUser:
-			needUser = true
-		case core.ConnectionModeIdentity:
-			needIdentity = true
-		}
-	}
-
-	addMode(managedIdentityConnectionModeForDef(config.EffectivePluginConnectionDef(entry, entry.ManifestSpec())))
-
-	for name := range managedIdentityGrantNamedConnectionNames(entry) {
-		conn, ok := config.EffectiveNamedConnectionDef(entry, entry.ManifestSpec(), name)
-		if !ok {
-			continue
-		}
-		addMode(managedIdentityConnectionModeForDef(conn))
-	}
-
-	switch {
-	case needUser:
-		return core.ConnectionModeUser
-	case needIdentity:
-		return core.ConnectionModeIdentity
-	default:
-		return core.ConnectionModeNone
-	}
-}
-
-func managedIdentityGrantNamedConnectionNames(entry *config.ProviderEntry) map[string]struct{} {
-	names := make(map[string]struct{})
-	if entry == nil {
-		return names
-	}
-	if spec := entry.ManifestSpec(); spec != nil {
-		for name := range spec.Connections {
-			resolved := config.ResolveConnectionAlias(name)
-			if resolved != "" && resolved != config.PluginConnectionName {
-				names[resolved] = struct{}{}
-			}
-		}
-	}
-	for name := range entry.Connections {
-		resolved := config.ResolveConnectionAlias(name)
-		if resolved != "" && resolved != config.PluginConnectionName {
-			names[resolved] = struct{}{}
-		}
-	}
-	return names
-}
-
-func managedIdentityConnectionModeForDef(conn config.ConnectionDef) core.ConnectionMode {
-	if conn.Mode != "" {
-		return core.ConnectionMode(conn.Mode)
-	}
-	switch conn.Auth.Type {
-	case "", "none":
-		return core.ConnectionModeNone
-	default:
-		return core.ConnectionModeUser
-	}
-}
-
 func (s *Server) managedIdentityGrantCatalog(ctx context.Context, plugin string, p *principal.Principal) (*catalog.Catalog, error) {
 	prov, err := s.providers.Get(plugin)
 	if err != nil {
@@ -1185,14 +1101,21 @@ func (s *Server) managedIdentityGrantCatalogTargets(ctx context.Context, plugin 
 		connection, instance := s.workloadBindingSelectors(p, plugin, connection, "")
 		addTarget(connection, instance)
 	}
-	if p == nil || p.Kind == principal.KindWorkload || strings.TrimSpace(p.UserID) == "" {
+	subjectID := ""
+	if p != nil {
+		subjectID = strings.TrimSpace(p.SubjectID)
+		if subjectID == "" && strings.TrimSpace(p.UserID) != "" {
+			subjectID = principal.UserSubjectID(p.UserID)
+		}
+	}
+	if p == nil || p.Kind == principal.KindWorkload || subjectID == "" {
 		if len(targets) == 0 {
 			addTarget("", "")
 		}
 		return targets, nil
 	}
 
-	tokens, err := s.tokens.ListTokensForIntegration(ctx, p.UserID, plugin)
+	tokens, err := s.tokens.ListTokensForIntegration(ctx, subjectID, plugin)
 	if err != nil {
 		return nil, fmt.Errorf("list integration tokens for grant validation: %w", err)
 	}
@@ -1309,15 +1232,22 @@ func managedIdentityGrantValidationPrincipal(p *principal.Principal, userID stri
 }
 
 type managedIdentitySessionTokenResolver interface {
-	ResolveUserToken(ctx context.Context, prov core.Provider, userID, providerName, connection, instance string) (context.Context, string, error)
+	ResolveSubjectToken(ctx context.Context, prov core.Provider, subjectID, providerName, connection, instance string) (context.Context, string, error)
 }
 
 func (s *Server) managedIdentityGrantUserSessionContext(ctx context.Context, prov core.Provider, plugin string, resolver invocation.TokenResolver, p *principal.Principal, connection string, instance string) (context.Context, string, bool, error) {
-	if p == nil || strings.TrimSpace(p.UserID) == "" {
+	if p == nil {
+		return ctx, "", false, nil
+	}
+	subjectID := strings.TrimSpace(p.SubjectID)
+	if subjectID == "" && strings.TrimSpace(p.UserID) != "" {
+		subjectID = principal.UserSubjectID(p.UserID)
+	}
+	if subjectID == "" {
 		return ctx, "", false, nil
 	}
 	if userResolver, ok := resolver.(managedIdentitySessionTokenResolver); ok {
-		enrichedCtx, token, err := userResolver.ResolveUserToken(ctx, prov, p.UserID, plugin, connection, instance)
+		enrichedCtx, token, err := userResolver.ResolveSubjectToken(ctx, prov, subjectID, plugin, connection, instance)
 		if err != nil {
 			if errors.Is(err, invocation.ErrNoToken) {
 				return ctx, "", false, nil
@@ -1335,7 +1265,7 @@ func (s *Server) managedIdentityGrantUserSessionContext(ctx context.Context, pro
 		err         error
 	)
 	if strings.TrimSpace(instance) != "" {
-		storedToken, err = s.tokens.Token(ctx, p.UserID, plugin, connection, instance)
+		storedToken, err = s.tokens.Token(ctx, subjectID, plugin, connection, instance)
 		if err != nil {
 			if errors.Is(err, core.ErrNotFound) {
 				return ctx, "", false, nil
@@ -1343,7 +1273,7 @@ func (s *Server) managedIdentityGrantUserSessionContext(ctx context.Context, pro
 			return ctx, "", true, err
 		}
 	} else {
-		tokens, listErr := s.tokens.ListTokensForConnection(ctx, p.UserID, plugin, connection)
+		tokens, listErr := s.tokens.ListTokensForConnection(ctx, subjectID, plugin, connection)
 		if listErr != nil {
 			return ctx, "", true, listErr
 		}
@@ -1362,7 +1292,7 @@ func (s *Server) managedIdentityGrantUserSessionContext(ctx context.Context, pro
 
 	ctx = invocation.WithCredentialContext(ctx, invocation.CredentialContext{
 		Mode:       core.ConnectionModeUser,
-		SubjectID:  principal.UserSubjectID(p.UserID),
+		SubjectID:  subjectID,
 		Connection: storedToken.Connection,
 		Instance:   storedToken.Instance,
 	})

--- a/gestaltd/internal/server/handlers_identity_tokens.go
+++ b/gestaltd/internal/server/handlers_identity_tokens.go
@@ -114,7 +114,13 @@ func (s *Server) createManagedIdentityToken(w http.ResponseWriter, r *http.Reque
 		return
 	}
 
-	apiToken, plaintext, err := s.issueManagedIdentityAPIToken(r.Context(), actor.Identity.ID, req.Name, permissions, false)
+	credentialSubjectID := principal.EffectiveCredentialSubjectID(viewer)
+	if credentialSubjectID == "" {
+		auditErr = errors.New("viewer subject is required")
+		writeError(w, http.StatusBadRequest, "viewer subject is required")
+		return
+	}
+	apiToken, plaintext, err := s.issueManagedIdentityAPIToken(r.Context(), actor.Identity.ID, credentialSubjectID, req.Name, permissions, false)
 	if err != nil {
 		auditErr = errors.New("failed to generate identity token")
 		writeError(w, http.StatusInternalServerError, "failed to generate identity token")
@@ -193,9 +199,6 @@ func (s *Server) validateManagedIdentityTokenPermissions(ctx context.Context, id
 	for _, permission := range permissions {
 		if !s.managedIdentityGrantPluginVisible(ctx, permission.Plugin, viewer) {
 			return fmt.Errorf("plugin %q is not available", permission.Plugin)
-		}
-		if !s.managedIdentityInvocationSupported(permission.Plugin) {
-			return fmt.Errorf("plugin %q does not yet support managed-identity invocation in this phase", permission.Plugin)
 		}
 		if len(permission.Operations) > 0 {
 			if err := s.validateManagedIdentityPermissionOperations(ctx, permission.Plugin, permission.Operations, viewer); err != nil {

--- a/gestaltd/internal/server/handlers_oauth.go
+++ b/gestaltd/internal/server/handlers_oauth.go
@@ -70,7 +70,7 @@ func (s *Server) startIntegrationOAuth(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	dbUserID, instance, err := s.resolveUserConnectionSetup(w, r, req.Instance)
+	subjectID, instance, err := s.resolveUserConnectionSetup(w, r, req.Instance)
 	if err != nil {
 		auditErr = err
 		return
@@ -101,7 +101,7 @@ func (s *Server) startIntegrationOAuth(w http.ResponseWriter, r *http.Request) {
 		authSource = p.AuthSource()
 	}
 	state, err := s.stateCodec.Encode(integrationOAuthState{
-		UserID:           dbUserID,
+		SubjectID:        subjectID,
 		AuthSource:       authSource,
 		Integration:      req.Integration,
 		Connection:       connection,
@@ -195,7 +195,7 @@ func (s *Server) integrationOAuthCallback(w http.ResponseWriter, r *http.Request
 		return
 	}
 	providerName = state.Integration
-	auditUserID = state.UserID
+	auditUserID = principal.UserIDFromSubjectID(state.SubjectID)
 	stateAuthSource = state.AuthSource
 	auditTarget = connectionAuditTarget(state.Integration, state.Connection, state.Instance)
 	handler, ok := s.requireOAuthHandler(w, providerName, state.Connection)
@@ -258,7 +258,7 @@ func (s *Server) integrationOAuthCallback(w http.ResponseWriter, r *http.Request
 	}
 
 	tm := tokenMaterial{
-		UserID:         state.UserID,
+		SubjectID:      state.SubjectID,
 		AuthSource:     state.AuthSource,
 		Integration:    providerName,
 		Connection:     state.Connection,

--- a/gestaltd/internal/server/oauth_state.go
+++ b/gestaltd/internal/server/oauth_state.go
@@ -17,7 +17,7 @@ const pendingConnectionTTL = 30 * time.Minute
 var errPendingConnectionExpired = errors.New("pending connection expired")
 
 type integrationOAuthState struct {
-	UserID           string            `json:"uid"`
+	SubjectID        string            `json:"sid"`
 	AuthSource       string            `json:"src,omitempty"`
 	Integration      string            `json:"int"`
 	Connection       string            `json:"con,omitempty"`
@@ -65,8 +65,8 @@ func decodeEncryptedState[T any](enc *cryptoutil.AESGCMEncryptor, label, encoded
 }
 
 func validateIntegrationOAuthState(state *integrationOAuthState, now time.Time) error {
-	if state.UserID == "" {
-		return fmt.Errorf("oauth state missing user ID")
+	if state.SubjectID == "" {
+		return fmt.Errorf("oauth state missing subject ID")
 	}
 	if state.Integration == "" {
 		return fmt.Errorf("oauth state missing integration")
@@ -149,8 +149,8 @@ func encodePendingConnectionState(enc *cryptoutil.AESGCMEncryptor, state pending
 }
 
 func validatePendingConnectionState(state *pendingConnectionState, now time.Time) error {
-	if state.Token.UserID == "" {
-		return fmt.Errorf("pending connection missing user ID")
+	if state.Token.SubjectID == "" {
+		return fmt.Errorf("pending connection missing subject ID")
 	}
 	if state.Token.Integration == "" {
 		return fmt.Errorf("pending connection missing integration")

--- a/gestaltd/internal/server/pending_connection.go
+++ b/gestaltd/internal/server/pending_connection.go
@@ -7,6 +7,7 @@ import (
 	"html/template"
 	"net/http"
 	"strconv"
+	"strings"
 	"time"
 
 	"github.com/google/uuid"
@@ -259,10 +260,14 @@ func (s *Server) resolvePendingConnectionUserID(r *http.Request) (string, bool, 
 	if p.Kind == principal.KindWorkload {
 		return "", true, errWorkloadForbidden
 	}
-	if p.UserID == "" {
-		return "", true, fmt.Errorf("authenticated principal missing user ID")
+	subjectID := strings.TrimSpace(p.SubjectID)
+	if subjectID == "" && strings.TrimSpace(p.UserID) != "" {
+		subjectID = principal.UserSubjectID(p.UserID)
 	}
-	return p.UserID, true, nil
+	if subjectID == "" {
+		return "", true, fmt.Errorf("authenticated principal missing subject ID")
+	}
+	return subjectID, true, nil
 }
 
 func (s *Server) authorizePendingConnectionByCookie(r *http.Request, state *pendingConnectionState) error {
@@ -287,7 +292,7 @@ func (s *Server) authorizePendingConnectionByCookie(r *http.Request, state *pend
 }
 
 func (s *Server) authorizePendingConnection(w http.ResponseWriter, r *http.Request, state *pendingConnectionState) bool {
-	userID, authenticated, err := s.resolvePendingConnectionUserID(r)
+	subjectID, authenticated, err := s.resolvePendingConnectionUserID(r)
 	if err != nil {
 		if errors.Is(err, errWorkloadForbidden) {
 			writeError(w, http.StatusForbidden, "workload callers are not allowed on this route")
@@ -300,7 +305,7 @@ func (s *Server) authorizePendingConnection(w http.ResponseWriter, r *http.Reque
 		writeError(w, http.StatusInternalServerError, "failed to validate pending connection")
 		return false
 	}
-	if authenticated && userID != state.Token.UserID {
+	if authenticated && subjectID != state.Token.SubjectID {
 		writeError(w, http.StatusNotFound, "pending connection not found")
 		return false
 	}
@@ -359,7 +364,7 @@ func (s *Server) selectPendingConnection(w http.ResponseWriter, r *http.Request)
 		auditErr = errors.New("pending connection authorization required")
 		return
 	}
-	auditUserID = state.Token.UserID
+	auditUserID = principal.UserIDFromSubjectID(state.Token.SubjectID)
 	auditAuthSource = state.Token.AuthSource
 	if candidateIndex == "" && candidateID == "" {
 		auditAllowed = true

--- a/gestaltd/internal/server/server_test.go
+++ b/gestaltd/internal/server/server_test.go
@@ -6803,7 +6803,7 @@ func TestDisconnectIntegration(t *testing.T) {
 			body, _ := io.ReadAll(resp.Body)
 			t.Fatalf("expected 200, got %d: %s", resp.StatusCode, body)
 		}
-		tokens, err := svc.Tokens.ListTokensForIntegration(context.Background(), u.ID, "slack")
+		tokens, err := svc.Tokens.ListTokensForIntegration(context.Background(), principal.UserSubjectID(u.ID), "slack")
 		if err != nil {
 			t.Fatalf("ListTokensForIntegration: %v", err)
 		}
@@ -6907,7 +6907,7 @@ func TestDisconnectIntegration(t *testing.T) {
 			body, _ := io.ReadAll(resp.Body)
 			t.Fatalf("expected 200, got %d: %s", resp.StatusCode, body)
 		}
-		tokens, err := svc.Tokens.ListTokensForIntegration(context.Background(), u.ID, "notion")
+		tokens, err := svc.Tokens.ListTokensForIntegration(context.Background(), principal.UserSubjectID(u.ID), "notion")
 		if err != nil {
 			t.Fatalf("ListTokensForIntegration: %v", err)
 		}
@@ -10313,7 +10313,7 @@ func TestIntegrationOAuthCallback(t *testing.T) {
 			t.Fatalf("expected redirect to /integrations?connected=slack, got %q", loc)
 		}
 		u, _ := svc.Users.FindOrCreateUser(context.Background(), "user@example.com")
-		tokens, _ := svc.Tokens.ListTokens(context.Background(), u.ID)
+		tokens, _ := svc.Tokens.ListTokens(context.Background(), principal.UserSubjectID(u.ID))
 		if len(tokens) == 0 {
 			t.Fatal("expected token to be stored")
 		}
@@ -10487,7 +10487,7 @@ func TestIntegrationOAuthCallback(t *testing.T) {
 			t.Fatalf("expected 200, got %d", selectResp.StatusCode)
 		}
 		u, _ := svc.Users.FindOrCreateUser(context.Background(), "cli@test.local")
-		tokens, _ := svc.Tokens.ListTokens(context.Background(), u.ID)
+		tokens, _ := svc.Tokens.ListTokens(context.Background(), principal.UserSubjectID(u.ID))
 		if len(tokens) == 0 {
 			t.Fatal("expected token to be stored after selection")
 		}
@@ -11649,7 +11649,7 @@ func TestExecuteOperation_RefreshPassesThroughStoredTokenWhenRefreshDoesNotApply
 			svc := coretesting.NewStubServices(t)
 			u := seedUser(t, svc, "anonymous@gestalt")
 			token := tc.token
-			token.UserID = u.ID
+			token.SubjectID = principal.UserSubjectID(u.ID)
 			seedToken(t, svc, &token)
 
 			refreshCalled := false
@@ -11786,7 +11786,7 @@ func TestExecuteOperation_RefreshPersistsReturnedTokenFields(t *testing.T) {
 				t.Fatalf("expected 200, got %d", resp.StatusCode)
 			}
 
-			stored, err := svc.Tokens.Token(context.Background(), u.ID, "fake", "default", "default")
+			stored, err := svc.Tokens.Token(context.Background(), principal.UserSubjectID(u.ID), "fake", "default", "default")
 			if err != nil {
 				t.Fatalf("Token: %v", err)
 			}
@@ -12276,7 +12276,7 @@ func TestConnectManual(t *testing.T) {
 		}
 
 		u, _ := svc.Users.FindOrCreateUser(context.Background(), "anonymous@gestalt")
-		tokens, _ := svc.Tokens.ListTokens(context.Background(), u.ID)
+		tokens, _ := svc.Tokens.ListTokens(context.Background(), principal.UserSubjectID(u.ID))
 		if len(tokens) == 0 {
 			t.Fatal("expected StoreToken to be called")
 		}
@@ -12522,7 +12522,7 @@ func TestConnectManual(t *testing.T) {
 			t.Fatalf("expected redirect to /integrations?connected=manual-svc, got %q", loc)
 		}
 		u, _ := svc.Users.FindOrCreateUser(context.Background(), "same@test.local")
-		tokens, _ := svc.Tokens.ListTokens(context.Background(), u.ID)
+		tokens, _ := svc.Tokens.ListTokens(context.Background(), principal.UserSubjectID(u.ID))
 		if len(tokens) == 0 {
 			t.Fatal("expected token to be stored")
 		}
@@ -12692,7 +12692,7 @@ func TestConnectManual(t *testing.T) {
 		}
 
 		u, _ := svc.Users.FindOrCreateUser(context.Background(), "anonymous@gestalt")
-		tokens, _ := svc.Tokens.ListTokens(context.Background(), u.ID)
+		tokens, _ := svc.Tokens.ListTokens(context.Background(), principal.UserSubjectID(u.ID))
 		if len(tokens) != 1 {
 			t.Fatalf("expected 1 stored token, got %d", len(tokens))
 		}
@@ -12769,7 +12769,7 @@ func TestConnectManual(t *testing.T) {
 		}
 
 		u, _ := svc.Users.FindOrCreateUser(context.Background(), "anonymous@gestalt")
-		tokens, _ := svc.Tokens.ListTokens(context.Background(), u.ID)
+		tokens, _ := svc.Tokens.ListTokens(context.Background(), principal.UserSubjectID(u.ID))
 		if len(tokens) != 1 {
 			t.Fatalf("expected 1 stored token, got %d", len(tokens))
 		}
@@ -14646,17 +14646,6 @@ func TestExecuteOperation_ConnectionModeIdentity(t *testing.T) {
 func TestExecuteOperation_ConnectionModeUserDoesNotFallbackToIdentity(t *testing.T) {
 	t.Parallel()
 
-	svc := coretesting.NewStubServices(t)
-	apiToken, hashed, err := principal.GenerateToken(principal.TokenTypeAPI)
-	if err != nil {
-		t.Fatalf("GenerateToken: %v", err)
-	}
-	seedAPIToken(t, svc, apiToken, hashed, "api-user")
-	seedToken(t, svc, &core.IntegrationToken{
-		ID: "tok-identity", UserID: principal.IdentityPrincipal, Integration: "svc",
-		Connection: "", Instance: "default", AccessToken: "identity-tok",
-	})
-
 	stub := &stubIntegrationWithOps{
 		StubIntegration: coretesting.StubIntegration{
 			N:        "svc",
@@ -14668,43 +14657,97 @@ func TestExecuteOperation_ConnectionModeUserDoesNotFallbackToIdentity(t *testing
 		ops: []core.Operation{{Name: "do", Method: http.MethodGet}},
 	}
 
-	ts := newTestServer(t, func(cfg *server.Config) {
-		cfg.Auth = &coretesting.StubAuthProvider{N: "test"}
-		cfg.Providers = testutil.NewProviderRegistry(t, stub)
-		cfg.Services = svc
+	t.Run("prefers user token", func(t *testing.T) {
+		t.Parallel()
+
+		svc := coretesting.NewStubServices(t)
+		apiToken, hashed, err := principal.GenerateToken(principal.TokenTypeAPI)
+		if err != nil {
+			t.Fatalf("GenerateToken: %v", err)
+		}
+		seedAPIToken(t, svc, apiToken, hashed, "api-user")
+		u, _ := svc.Users.FindOrCreateUser(context.Background(), "api-user@test.local")
+		seedToken(t, svc, &core.IntegrationToken{
+			ID: "tok-user", UserID: u.ID, Integration: "svc",
+			Connection: "", Instance: "default", AccessToken: "user-tok",
+		})
+
+		ts := newTestServer(t, func(cfg *server.Config) {
+			cfg.Auth = &coretesting.StubAuthProvider{N: "test"}
+			cfg.Providers = testutil.NewProviderRegistry(t, stub)
+			cfg.Services = svc
+		})
+		testutil.CloseOnCleanup(t, ts)
+
+		req, _ := http.NewRequest(http.MethodGet, ts.URL+"/api/v1/svc/do", nil)
+		req.Header.Set("Authorization", "Bearer "+apiToken)
+		resp, err := http.DefaultClient.Do(req)
+		if err != nil {
+			t.Fatalf("request: %v", err)
+		}
+		defer func() { _ = resp.Body.Close() }()
+
+		var result map[string]any
+		if err := json.NewDecoder(resp.Body).Decode(&result); err != nil {
+			t.Fatalf("decoding: %v", err)
+		}
+		if result["token"] != "user-tok" {
+			t.Fatalf("expected user-tok (preferred), got %v", result["token"])
+		}
 	})
-	testutil.CloseOnCleanup(t, ts)
 
-	req, _ := http.NewRequest(http.MethodGet, ts.URL+"/api/v1/svc/do", nil)
-	req.Header.Set("Authorization", "Bearer "+apiToken)
-	resp, err := http.DefaultClient.Do(req)
-	if err != nil {
-		t.Fatalf("request: %v", err)
-	}
-	defer func() { _ = resp.Body.Close() }()
+	t.Run("no longer falls back to shared identity", func(t *testing.T) {
+		t.Parallel()
 
-	if resp.StatusCode != http.StatusPreconditionFailed {
-		body, _ := io.ReadAll(resp.Body)
-		t.Fatalf("expected 412, got %d: %s", resp.StatusCode, body)
-	}
+		svc := coretesting.NewStubServices(t)
+		apiToken, hashed, err := principal.GenerateToken(principal.TokenTypeAPI)
+		if err != nil {
+			t.Fatalf("GenerateToken: %v", err)
+		}
+		seedAPIToken(t, svc, apiToken, hashed, "api-user")
+		seedToken(t, svc, &core.IntegrationToken{
+			ID: "tok-identity", UserID: principal.IdentityPrincipal, Integration: "svc",
+			Connection: "", Instance: "default", AccessToken: "identity-tok",
+		})
 
-	var errResp struct {
-		Error       string `json:"error"`
-		Code        string `json:"code"`
-		Integration string `json:"integration"`
-	}
-	if err := json.NewDecoder(resp.Body).Decode(&errResp); err != nil {
-		t.Fatalf("decoding error response: %v", err)
-	}
-	if errResp.Code != "not_connected" {
-		t.Fatalf("expected not_connected code, got %q", errResp.Code)
-	}
-	if errResp.Error != `no token stored for integration "svc"; connect via OAuth first` {
-		t.Fatalf("unexpected error message: %q", errResp.Error)
-	}
-	if errResp.Integration != "svc" {
-		t.Fatalf("expected integration svc, got %q", errResp.Integration)
-	}
+		ts := newTestServer(t, func(cfg *server.Config) {
+			cfg.Auth = &coretesting.StubAuthProvider{N: "test"}
+			cfg.Providers = testutil.NewProviderRegistry(t, stub)
+			cfg.Services = svc
+		})
+		testutil.CloseOnCleanup(t, ts)
+
+		req, _ := http.NewRequest(http.MethodGet, ts.URL+"/api/v1/svc/do", nil)
+		req.Header.Set("Authorization", "Bearer "+apiToken)
+		resp, err := http.DefaultClient.Do(req)
+		if err != nil {
+			t.Fatalf("request: %v", err)
+		}
+		defer func() { _ = resp.Body.Close() }()
+
+		if resp.StatusCode != http.StatusPreconditionFailed {
+			body, _ := io.ReadAll(resp.Body)
+			t.Fatalf("expected 412, got %d: %s", resp.StatusCode, body)
+		}
+
+		var errResp struct {
+			Error       string `json:"error"`
+			Code        string `json:"code"`
+			Integration string `json:"integration"`
+		}
+		if err := json.NewDecoder(resp.Body).Decode(&errResp); err != nil {
+			t.Fatalf("decoding error response: %v", err)
+		}
+		if errResp.Code != "not_connected" {
+			t.Fatalf("expected not_connected code, got %q", errResp.Code)
+		}
+		if errResp.Error != `no token stored for integration "svc"; connect via OAuth first` {
+			t.Fatalf("unexpected error message: %q", errResp.Error)
+		}
+		if errResp.Integration != "svc" {
+			t.Fatalf("expected integration svc, got %q", errResp.Integration)
+		}
+	})
 }
 
 func TestConnectManual_MultiCredential(t *testing.T) {
@@ -14817,7 +14860,7 @@ func TestConnectManual_MultiCredential(t *testing.T) {
 			}
 
 			u, _ := svc.Users.FindOrCreateUser(context.Background(), "anonymous@gestalt")
-			tokens, _ := svc.Tokens.ListTokens(context.Background(), u.ID)
+			tokens, _ := svc.Tokens.ListTokens(context.Background(), principal.UserSubjectID(u.ID))
 			if len(tokens) == 0 {
 				t.Fatal("expected StoreToken to be called")
 			}
@@ -15892,9 +15935,9 @@ func TestManagedIdentityGrantValidationUsesSessionCatalog(t *testing.T) {
 			t.Fatalf("session-fallback grant request: %v", err)
 		}
 		defer func() { _ = resp.Body.Close() }()
-		if resp.StatusCode != http.StatusBadRequest {
+		if resp.StatusCode != http.StatusOK {
 			body, _ := io.ReadAll(resp.Body)
-			t.Fatalf("session-fallback grant status = %d, want %d: %s", resp.StatusCode, http.StatusBadRequest, body)
+			t.Fatalf("session-fallback grant status = %d, want %d: %s", resp.StatusCode, http.StatusOK, body)
 		}
 	})
 
@@ -16732,7 +16775,7 @@ func TestManagedIdentityTokens_RoleMatrix(t *testing.T) {
 			{
 				name:         "unsupported plugin rejected",
 				body:         `{"name":"invalid","permissions":[{"plugin":"gamma","operations":["query"]}]}`,
-				wantContains: "does not yet support managed-identity invocation",
+				wantContains: "is not granted to this identity",
 			},
 			{
 				name: "broader than grant rejected",
@@ -16923,11 +16966,11 @@ func TestManagedIdentityTokenPermissionsUsePluginLevelViewerCeiling(t *testing.T
 	}
 }
 
-func TestManagedIdentityAPITokenInvocation_ModeNoneOnly(t *testing.T) {
+func TestManagedIdentityAPITokenInvocation_UsesCreatorCredentialSubject(t *testing.T) {
 	t.Parallel()
 
 	svc := coretesting.NewStubServices(t)
-	seedUser(t, svc, "admin@example.test")
+	admin := seedUser(t, svc, "admin@example.test")
 
 	alphaStub := &stubIntegrationWithOps{
 		StubIntegration: coretesting.StubIntegration{
@@ -16963,6 +17006,10 @@ func TestManagedIdentityAPITokenInvocation_ModeNoneOnly(t *testing.T) {
 		ops: []core.Operation{{Name: "query", Method: http.MethodGet}},
 	}
 	providers := testutil.NewProviderRegistry(t, alphaStub, betaStub, gammaStub)
+	seedToken(t, svc, &core.IntegrationToken{
+		ID: "gamma-admin-token", UserID: admin.ID, Integration: "gamma",
+		Connection: "", Instance: "default", AccessToken: "gamma-user-token",
+	})
 	authz, err := authorization.New(config.AuthorizationConfig{}, nil, providers, nil)
 	if err != nil {
 		t.Fatalf("authorization.New: %v", err)
@@ -16990,38 +17037,7 @@ func TestManagedIdentityAPITokenInvocation_ModeNoneOnly(t *testing.T) {
 	doJSONRequestAndDecode(t, http.MethodPost, ts.URL+"/api/v1/identities", "admin-session", `{"displayName":"Invoke Bot"}`, http.StatusCreated, &createResp)
 	doJSONRequestAndDecode(t, http.MethodPut, ts.URL+"/api/v1/identities/"+createResp.ID+"/grants/alpha", "admin-session", `{"operations":["read"]}`, http.StatusOK, nil)
 	doJSONRequestAndDecode(t, http.MethodPut, ts.URL+"/api/v1/identities/"+createResp.ID+"/grants/beta", "admin-session", `{"operations":["query"]}`, http.StatusOK, nil)
-
-	req, _ := http.NewRequest(http.MethodPut, ts.URL+"/api/v1/identities/"+createResp.ID+"/grants/gamma", bytes.NewBufferString(`{"operations":["query"]}`))
-	req.Header.Set("Content-Type", "application/json")
-	req.AddCookie(&http.Cookie{Name: "session_token", Value: "admin-session"})
-	resp, err := http.DefaultClient.Do(req)
-	if err != nil {
-		t.Fatalf("gamma grant request: %v", err)
-	}
-	body, _ := io.ReadAll(resp.Body)
-	_ = resp.Body.Close()
-	if resp.StatusCode != http.StatusBadRequest {
-		t.Fatalf("gamma grant status = %d, want %d: %s", resp.StatusCode, http.StatusBadRequest, body)
-	}
-	if !strings.Contains(string(body), "does not yet support managed-identity invocation") {
-		t.Fatalf("gamma grant body = %q, want managed-identity invocation rejection", string(body))
-	}
-
-	req, _ = http.NewRequest(http.MethodPost, ts.URL+"/api/v1/identities/"+createResp.ID+"/tokens", bytes.NewBufferString(`{"name":"invalid-token","permissions":[{"plugin":"gamma","operations":["query"]}]}`))
-	req.Header.Set("Content-Type", "application/json")
-	req.AddCookie(&http.Cookie{Name: "session_token", Value: "admin-session"})
-	resp, err = http.DefaultClient.Do(req)
-	if err != nil {
-		t.Fatalf("gamma token request: %v", err)
-	}
-	body, _ = io.ReadAll(resp.Body)
-	_ = resp.Body.Close()
-	if resp.StatusCode != http.StatusBadRequest {
-		t.Fatalf("gamma token status = %d, want %d: %s", resp.StatusCode, http.StatusBadRequest, body)
-	}
-	if !strings.Contains(string(body), "does not yet support managed-identity invocation") {
-		t.Fatalf("gamma token body = %q, want managed-identity invocation rejection", string(body))
-	}
+	doJSONRequestAndDecode(t, http.MethodPut, ts.URL+"/api/v1/identities/"+createResp.ID+"/grants/gamma", "admin-session", `{"operations":["query"]}`, http.StatusOK, nil)
 
 	createTokenResp := struct {
 		Token string `json:"token"`
@@ -17031,7 +17047,7 @@ func TestManagedIdentityAPITokenInvocation_ModeNoneOnly(t *testing.T) {
 		http.MethodPost,
 		ts.URL+"/api/v1/identities/"+createResp.ID+"/tokens",
 		"admin-session",
-		`{"name":"invoke-token","permissions":[{"plugin":"alpha","operations":["read"]},{"plugin":"beta","operations":["query"]}]}`,
+		`{"name":"invoke-token","permissions":[{"plugin":"alpha","operations":["read"]},{"plugin":"beta","operations":["query"]},{"plugin":"gamma","operations":["query"]}]}`,
 		http.StatusCreated,
 		&createTokenResp,
 	)
@@ -17059,8 +17075,8 @@ func TestManagedIdentityAPITokenInvocation_ModeNoneOnly(t *testing.T) {
 	if status := call("/api/v1/beta/query"); status != http.StatusOK {
 		t.Fatalf("beta/query status = %d, want 200", status)
 	}
-	if status := call("/api/v1/gamma/query"); status != http.StatusForbidden {
-		t.Fatalf("gamma/query status = %d, want 403", status)
+	if status := call("/api/v1/gamma/query"); status != http.StatusOK {
+		t.Fatalf("gamma/query status = %d, want 200", status)
 	}
 
 	doJSONRequestAndDecode(t, http.MethodDelete, ts.URL+"/api/v1/identities/"+createResp.ID, "admin-session", "", http.StatusOK, nil)

--- a/gestaltd/internal/server/token_helpers.go
+++ b/gestaltd/internal/server/token_helpers.go
@@ -18,20 +18,22 @@ func (s *Server) nowUTCSecond() time.Time {
 
 func (s *Server) issueAPIToken(ctx context.Context, userID, name, scopes string, nonExpiring bool) (*core.APIToken, string, error) {
 	return s.issueOwnedAPIToken(ctx, &core.APIToken{
-		UserID:    userID,
-		OwnerKind: core.APITokenOwnerKindUser,
-		OwnerID:   userID,
-		Name:      name,
-		Scopes:    scopes,
+		UserID:              userID,
+		OwnerKind:           core.APITokenOwnerKindUser,
+		OwnerID:             userID,
+		CredentialSubjectID: principal.UserSubjectID(userID),
+		Name:                name,
+		Scopes:              scopes,
 	}, nonExpiring)
 }
 
-func (s *Server) issueManagedIdentityAPIToken(ctx context.Context, identityID, name string, permissions []core.AccessPermission, nonExpiring bool) (*core.APIToken, string, error) {
+func (s *Server) issueManagedIdentityAPIToken(ctx context.Context, identityID, credentialSubjectID, name string, permissions []core.AccessPermission, nonExpiring bool) (*core.APIToken, string, error) {
 	return s.issueOwnedAPIToken(ctx, &core.APIToken{
-		OwnerKind:   core.APITokenOwnerKindManagedIdentity,
-		OwnerID:     identityID,
-		Name:        name,
-		Permissions: append([]core.AccessPermission(nil), permissions...),
+		OwnerKind:           core.APITokenOwnerKindManagedIdentity,
+		OwnerID:             identityID,
+		CredentialSubjectID: credentialSubjectID,
+		Name:                name,
+		Permissions:         append([]core.AccessPermission(nil), permissions...),
 	}, nonExpiring)
 }
 


### PR DESCRIPTION
## Summary
This makes stored credentials subject-owned at runtime instead of raw-`user_id` owned, while preserving `identity` as a real shared credential owner for existing deployments.

## Go interfaces
```go
type IntegrationToken struct {
    ID         string
    UserID     string
    SubjectID  string
    Integration string
    Connection  string
    Instance    string
    ...
}

type APIToken struct {
    ID                  string
    IdentityID          string
    UserID              string
    OwnerKind           string
    OwnerID             string
    CredentialSubjectID string
    TokenKind           string
    ...
}

type Principal struct {
    Identity            *core.UserIdentity
    UserID              string
    SubjectID           string
    CredentialSubjectID string
    ...
}
```

New helper:
```go
func EffectiveCredentialSubjectID(p *Principal) string
```

## YAML examples
Shared service credential owner remains explicit:
```yaml
plugins:
  launchdarkly:
    connection:
      mode: identity
```

User-owned credential:
```yaml
plugins:
  bigquery:
    connection:
      mode: user
```

## Runtime behavior
- Stored integration credentials now resolve by `subject_id`.
- Shared service credentials live under `subject_id=identity:__identity__`.
- Managed-identity API tokens can carry `credential_subject_id` and use delegated user-owned credentials for `mode: user` providers.
- Plain workload bindings remain limited to `none` / `identity` providers.

## Rollout notes
- Existing `integration_tokens` rows need `subject_id` populated before deploy on persistent databases.
- Existing identity-mode credentials continue to work after migration because they move from raw `user_id=__identity__` to `subject_id=identity:__identity__`.
- Existing user-owned API tokens backfill their credential subject on read.

## Verification
```bash
go test ./internal/coredata ./internal/authorization ./internal/invocation ./internal/server ./internal/bootstrap ./internal/config ./internal/composite ./internal/principal
golangci-lint run ./internal/coredata ./internal/server ./internal/bootstrap ./internal/invocation ./internal/config ./internal/composite ./internal/principal ./internal/authorization
```