### PR TITLE
plugin runtime: route executable plugins through hosted sessions

### DIFF
--- a/gestaltd/internal/bootstrap/bootstrap.go
+++ b/gestaltd/internal/bootstrap/bootstrap.go
@@ -23,6 +23,7 @@ import (
 	"github.com/valon-technologies/gestalt/server/internal/invocation"
 	"github.com/valon-technologies/gestalt/server/internal/metricutil"
 	"github.com/valon-technologies/gestalt/server/internal/oauth"
+	"github.com/valon-technologies/gestalt/server/internal/pluginruntime"
 	"github.com/valon-technologies/gestalt/server/internal/provider"
 	"github.com/valon-technologies/gestalt/server/internal/providerhost"
 	"github.com/valon-technologies/gestalt/server/internal/registry"
@@ -143,6 +144,7 @@ type Deps struct {
 	WorkflowRuntime       *workflowRuntime
 	Egress                EgressDeps
 	PluginInvoker         invocation.Invoker
+	PluginRuntime         pluginruntime.Provider
 }
 
 type AuthFactory func(node yaml.Node, deps Deps) (core.AuthenticationProvider, error)

--- a/gestaltd/internal/bootstrap/executable_plugin_test.go
+++ b/gestaltd/internal/bootstrap/executable_plugin_test.go
@@ -14,6 +14,7 @@ import (
 	"strings"
 	"sync/atomic"
 	"testing"
+	"time"
 
 	mcpgo "github.com/mark3labs/mcp-go/mcp"
 	mcpserver "github.com/mark3labs/mcp-go/server"
@@ -27,6 +28,7 @@ import (
 	"github.com/valon-technologies/gestalt/server/internal/config"
 	"github.com/valon-technologies/gestalt/server/internal/coredata"
 	"github.com/valon-technologies/gestalt/server/internal/invocation"
+	"github.com/valon-technologies/gestalt/server/internal/pluginruntime"
 	"github.com/valon-technologies/gestalt/server/internal/principal"
 	"github.com/valon-technologies/gestalt/server/internal/providerhost"
 	"github.com/valon-technologies/gestalt/server/internal/providerpkg"
@@ -68,6 +70,92 @@ type requestContextBody struct {
 type nestedInvokeHarness struct {
 	invoker  invocation.Invoker
 	services *coredata.Services
+}
+
+type trackingPluginRuntime struct {
+	inner     pluginruntime.Provider
+	stopCount atomic.Int32
+}
+
+func (r *trackingPluginRuntime) Capabilities(ctx context.Context) (pluginruntime.Capabilities, error) {
+	return r.inner.Capabilities(ctx)
+}
+
+func (r *trackingPluginRuntime) StartSession(ctx context.Context, req pluginruntime.StartSessionRequest) (*pluginruntime.Session, error) {
+	return r.inner.StartSession(ctx, req)
+}
+
+func (r *trackingPluginRuntime) GetSession(ctx context.Context, req pluginruntime.GetSessionRequest) (*pluginruntime.Session, error) {
+	return r.inner.GetSession(ctx, req)
+}
+
+func (r *trackingPluginRuntime) StopSession(ctx context.Context, req pluginruntime.StopSessionRequest) error {
+	r.stopCount.Add(1)
+	return r.inner.StopSession(ctx, req)
+}
+
+func (r *trackingPluginRuntime) BindHostService(ctx context.Context, req pluginruntime.BindHostServiceRequest) (*pluginruntime.HostServiceBinding, error) {
+	return r.inner.BindHostService(ctx, req)
+}
+
+func (r *trackingPluginRuntime) StartPlugin(ctx context.Context, req pluginruntime.StartPluginRequest) (*pluginruntime.HostedPlugin, error) {
+	return r.inner.StartPlugin(ctx, req)
+}
+
+func (r *trackingPluginRuntime) DialPlugin(ctx context.Context, req pluginruntime.DialPluginRequest) (pluginruntime.HostedPluginConn, error) {
+	return r.inner.DialPlugin(ctx, req)
+}
+
+func (r *trackingPluginRuntime) Close() error {
+	return r.inner.Close()
+}
+
+type slowStopPluginRuntime struct {
+	inner     pluginruntime.Provider
+	stopCount atomic.Int32
+}
+
+func (r *slowStopPluginRuntime) Capabilities(ctx context.Context) (pluginruntime.Capabilities, error) {
+	return r.inner.Capabilities(ctx)
+}
+
+func (r *slowStopPluginRuntime) StartSession(ctx context.Context, req pluginruntime.StartSessionRequest) (*pluginruntime.Session, error) {
+	return r.inner.StartSession(ctx, req)
+}
+
+func (r *slowStopPluginRuntime) GetSession(ctx context.Context, req pluginruntime.GetSessionRequest) (*pluginruntime.Session, error) {
+	return r.inner.GetSession(ctx, req)
+}
+
+func (r *slowStopPluginRuntime) StopSession(ctx context.Context, req pluginruntime.StopSessionRequest) error {
+	r.stopCount.Add(1)
+	<-ctx.Done()
+	return ctx.Err()
+}
+
+func (r *slowStopPluginRuntime) BindHostService(ctx context.Context, req pluginruntime.BindHostServiceRequest) (*pluginruntime.HostServiceBinding, error) {
+	return r.inner.BindHostService(ctx, req)
+}
+
+func (r *slowStopPluginRuntime) StartPlugin(ctx context.Context, req pluginruntime.StartPluginRequest) (*pluginruntime.HostedPlugin, error) {
+	return r.inner.StartPlugin(ctx, req)
+}
+
+func (r *slowStopPluginRuntime) DialPlugin(ctx context.Context, req pluginruntime.DialPluginRequest) (pluginruntime.HostedPluginConn, error) {
+	return r.inner.DialPlugin(ctx, req)
+}
+
+func (r *slowStopPluginRuntime) Close() error {
+	return r.inner.Close()
+}
+
+type failingBindSlowStopPluginRuntime struct {
+	slowStopPluginRuntime
+	err error
+}
+
+func (r *failingBindSlowStopPluginRuntime) BindHostService(context.Context, pluginruntime.BindHostServiceRequest) (*pluginruntime.HostServiceBinding, error) {
+	return nil, r.err
 }
 
 func TestExecutableSDKExampleProviderReceivesStartConfig(t *testing.T) {
@@ -1853,6 +1941,159 @@ func TestPluginCacheBindingsExposeHostSocketEnv(t *testing.T) {
 	}
 	if got := checkEnv(t, []string{"session", "rate_limit"}, providerhost.CacheSocketEnv("rate_limit")); !got {
 		t.Fatal(`named cache env for "rate_limit" should be set with multiple plugin cache bindings`)
+	}
+}
+
+func TestInjectedPluginRuntimeStopsSessionOnProviderClose(t *testing.T) {
+	t.Parallel()
+
+	bin := buildEchoPluginBinary(t)
+	manifestRoot := writeStaticCatalog(t, &catalog.Catalog{
+		Name: "echoext",
+		Operations: []catalog.CatalogOperation{
+			{ID: "read_env", Method: http.MethodGet, Parameters: []catalog.CatalogParameter{{Name: "name", Type: "string", Required: true}}},
+		},
+	})
+	manifest := newExecutableManifest("Echo", "Echoes back the input parameters")
+	runtimeProvider := &trackingPluginRuntime{inner: pluginruntime.NewLocalProvider()}
+	cfg := &config.Config{
+		Plugins: map[string]*config.ProviderEntry{
+			"echoext": {
+				Command:              bin,
+				Args:                 []string{"provider"},
+				ResolvedManifest:     manifest,
+				ResolvedManifestPath: filepath.Join(manifestRoot, "manifest.yaml"),
+			},
+		},
+	}
+
+	providers, _, err := buildProvidersStrict(context.Background(), cfg, NewFactoryRegistry(), Deps{
+		PluginRuntime: runtimeProvider,
+	})
+	if err != nil {
+		t.Fatalf("buildProvidersStrict: %v", err)
+	}
+
+	prov, err := providers.Get("echoext")
+	if err != nil {
+		t.Fatalf("providers.Get: %v", err)
+	}
+	if _, err := prov.Execute(context.Background(), "read_env", map[string]any{"name": "PATH"}, ""); err != nil {
+		t.Fatalf("Execute read_env: %v", err)
+	}
+	if err := CloseProviders(providers); err != nil {
+		t.Fatalf("CloseProviders: %v", err)
+	}
+	if runtimeProvider.stopCount.Load() == 0 {
+		t.Fatal("expected CloseProviders to stop the hosted plugin runtime session")
+	}
+}
+
+func TestInjectedPluginRuntimeStopSessionTimeoutDoesNotHangProviderClose(t *testing.T) {
+	t.Parallel()
+
+	bin := buildEchoPluginBinary(t)
+	manifestRoot := writeStaticCatalog(t, &catalog.Catalog{
+		Name: "echoext",
+		Operations: []catalog.CatalogOperation{
+			{ID: "read_env", Method: http.MethodGet, Parameters: []catalog.CatalogParameter{{Name: "name", Type: "string", Required: true}}},
+		},
+	})
+	manifest := newExecutableManifest("Echo", "Echoes back the input parameters")
+	runtimeProvider := &slowStopPluginRuntime{inner: pluginruntime.NewLocalProvider()}
+	cfg := &config.Config{
+		Plugins: map[string]*config.ProviderEntry{
+			"echoext": {
+				Command:              bin,
+				Args:                 []string{"provider"},
+				ResolvedManifest:     manifest,
+				ResolvedManifestPath: filepath.Join(manifestRoot, "manifest.yaml"),
+			},
+		},
+	}
+
+	providers, _, err := buildProvidersStrict(context.Background(), cfg, NewFactoryRegistry(), Deps{
+		PluginRuntime: runtimeProvider,
+	})
+	if err != nil {
+		t.Fatalf("buildProvidersStrict: %v", err)
+	}
+
+	prov, err := providers.Get("echoext")
+	if err != nil {
+		t.Fatalf("providers.Get: %v", err)
+	}
+	if _, err := prov.Execute(context.Background(), "read_env", map[string]any{"name": "PATH"}, ""); err != nil {
+		t.Fatalf("Execute read_env: %v", err)
+	}
+
+	done := make(chan error, 1)
+	go func() {
+		done <- CloseProviders(providers)
+	}()
+
+	select {
+	case err := <-done:
+		if err == nil || !strings.Contains(err.Error(), context.DeadlineExceeded.Error()) {
+			t.Fatalf("CloseProviders error = %v, want deadline exceeded", err)
+		}
+	case <-time.After(5 * time.Second):
+		t.Fatal("CloseProviders hung waiting for hosted runtime shutdown")
+	}
+
+	if runtimeProvider.stopCount.Load() == 0 {
+		t.Fatal("expected CloseProviders to attempt stopping the hosted plugin runtime session")
+	}
+}
+
+func TestInjectedPluginRuntimeStopSessionTimeoutDoesNotHangBootstrapFailure(t *testing.T) {
+	t.Parallel()
+
+	bin := buildEchoPluginBinary(t)
+	manifestRoot := writeStaticCatalog(t, &catalog.Catalog{
+		Name: "echoext",
+		Operations: []catalog.CatalogOperation{
+			{ID: "read_env", Method: http.MethodGet, Parameters: []catalog.CatalogParameter{{Name: "name", Type: "string", Required: true}}},
+		},
+	})
+	manifest := newExecutableManifest("Echo", "Echoes back the input parameters")
+	runtimeProvider := &failingBindSlowStopPluginRuntime{
+		slowStopPluginRuntime: slowStopPluginRuntime{inner: pluginruntime.NewLocalProvider()},
+		err:                   fmt.Errorf("bind failed"),
+	}
+	cfg := &config.Config{
+		Plugins: map[string]*config.ProviderEntry{
+			"echoext": {
+				Command:              bin,
+				Args:                 []string{"provider"},
+				ResolvedManifest:     manifest,
+				ResolvedManifestPath: filepath.Join(manifestRoot, "manifest.yaml"),
+				Invokes: []config.PluginInvocationDependency{
+					{Plugin: "other", Operation: "read"},
+				},
+			},
+		},
+	}
+
+	done := make(chan error, 1)
+	go func() {
+		_, _, err := buildProvidersStrict(context.Background(), cfg, NewFactoryRegistry(), Deps{
+			PluginRuntime: runtimeProvider,
+		})
+		done <- err
+	}()
+
+	select {
+	case err := <-done:
+		if err == nil || !strings.Contains(err.Error(), "bind host service") {
+			t.Fatalf("buildProvidersStrict error = %v, want bind host service failure", err)
+		}
+	case <-time.After(5 * time.Second):
+		t.Fatal("buildProvidersStrict hung waiting for hosted runtime shutdown")
+	}
+
+	if runtimeProvider.stopCount.Load() == 0 {
+		t.Fatal("expected bootstrap failure to attempt stopping the hosted plugin runtime session")
 	}
 }
 

--- a/gestaltd/internal/bootstrap/provider_build.go
+++ b/gestaltd/internal/bootstrap/provider_build.go
@@ -13,6 +13,7 @@ import (
 	"runtime"
 	"strings"
 	"sync"
+	"time"
 
 	proto "github.com/valon-technologies/gestalt/sdk/go/gen/v1"
 	"github.com/valon-technologies/gestalt/server/core"
@@ -30,6 +31,7 @@ import (
 	"github.com/valon-technologies/gestalt/server/internal/oauth"
 	"github.com/valon-technologies/gestalt/server/internal/openapi"
 	"github.com/valon-technologies/gestalt/server/internal/operationexposure"
+	"github.com/valon-technologies/gestalt/server/internal/pluginruntime"
 	"github.com/valon-technologies/gestalt/server/internal/principal"
 	"github.com/valon-technologies/gestalt/server/internal/provider"
 	"github.com/valon-technologies/gestalt/server/internal/providerhost"
@@ -682,55 +684,210 @@ func buildPluginProvider(ctx context.Context, name string, entry *config.Provide
 			maps.Copy(env, execEnv)
 		}
 	}
-	execCfg := providerhost.ExecConfig{
+	runtimeProvider, runtimeOwned := effectivePluginRuntime(deps)
+	session, err := runtimeProvider.StartSession(ctx, pluginruntime.StartSessionRequest{
+		PluginName: name,
+		Metadata:   map[string]string{"plugin": name},
+	})
+	if err != nil {
+		if runtimeOwned {
+			_ = runtimeProvider.Close()
+		}
+		return nil, fmt.Errorf("start plugin runtime session: %w", err)
+	}
+	sessionID := session.ID
+	stopSession := true
+	defer func() {
+		if !stopSession {
+			return
+		}
+		_ = stopPluginRuntimeSession(runtimeProvider, sessionID)
+		if runtimeOwned {
+			_ = runtimeProvider.Close()
+		}
+	}()
+	if err := waitForPluginRuntimeSessionReady(ctx, runtimeProvider, sessionID); err != nil {
+		return nil, fmt.Errorf("wait for plugin runtime session %q ready: %w", sessionID, err)
+	}
+
+	hostServices, snapshots, runtimeCleanup, err := buildPluginRuntimeHostServices(name, entry, deps)
+	if err != nil {
+		return nil, err
+	}
+	cleanup = chainCleanup(cleanup, runtimeCleanup)
+	for _, hostService := range hostServices {
+		if _, err := runtimeProvider.BindHostService(ctx, pluginruntime.BindHostServiceRequest{
+			SessionID: sessionID,
+			EnvVar:    hostService.EnvVar,
+			Register:  hostService.Register,
+		}); err != nil {
+			return nil, fmt.Errorf("bind host service %q: %w", hostService.EnvVar, err)
+		}
+	}
+
+	hostedPlugin, err := runtimeProvider.StartPlugin(ctx, pluginruntime.StartPluginRequest{
+		SessionID:     sessionID,
+		PluginName:    name,
 		Command:       command,
 		Args:          args,
 		Env:           env,
-		StaticSpec:    spec,
-		Config:        pluginConfig,
 		AllowedHosts:  entry.AllowedHosts,
 		DefaultAction: deps.Egress.DefaultAction,
 		HostBinary:    entry.HostBinary,
-	}
-	effectiveIndexedDB, err := config.ResolveEffectivePluginIndexedDB(name, entry, deps.SelectedIndexedDBName, deps.IndexedDBDefs)
+		Cleanup:       cleanup,
+	})
 	if err != nil {
+		return nil, fmt.Errorf("start hosted plugin: %w", err)
+	}
+	// The started plugin process now owns cleanup through the runtime session.
+	cleanup = nil
+	conn, err := runtimeProvider.DialPlugin(ctx, pluginruntime.DialPluginRequest{
+		SessionID: sessionID,
+		PluginID:  hostedPlugin.ID,
+	})
+	if err != nil {
+		return nil, fmt.Errorf("dial hosted plugin: %w", err)
+	}
+	opts := []providerhost.RemoteProviderOption{providerhost.WithCloser(&runtimeBackedPluginCloser{
+		conn:         conn,
+		runtime:      runtimeProvider,
+		sessionID:    sessionID,
+		closeRuntime: runtimeOwned,
+	})}
+	if snapshots != nil {
+		opts = append(opts, providerhost.WithRequestSnapshots(snapshots))
+	}
+	prov, err := providerhost.NewRemoteProvider(ctx, conn.Integration(), spec, pluginConfig, opts...)
+	if err != nil {
+		_ = conn.Close()
 		return nil, err
 	}
-	if effectiveIndexedDB.Enabled {
-		hostServices, indexedDBCleanup, err := buildPluginIndexedDBHostServices(name, effectiveIndexedDB, deps)
+	stopSession = false
+	cleanup = nil
+	return prov, nil
+}
+
+func effectivePluginRuntime(deps Deps) (pluginruntime.Provider, bool) {
+	if deps.PluginRuntime != nil {
+		return deps.PluginRuntime, false
+	}
+	return pluginruntime.NewLocalProvider(), true
+}
+
+const pluginRuntimeStopTimeout = 3 * time.Second
+
+type runtimeBackedPluginCloser struct {
+	conn         pluginruntime.HostedPluginConn
+	runtime      pluginruntime.Provider
+	sessionID    string
+	closeRuntime bool
+}
+
+func (c *runtimeBackedPluginCloser) Close() error {
+	if c == nil {
+		return nil
+	}
+	var errs []error
+	if c.runtime != nil && c.sessionID != "" {
+		errs = append(errs, stopPluginRuntimeSession(c.runtime, c.sessionID))
+	}
+	if c.conn != nil {
+		errs = append(errs, c.conn.Close())
+	}
+	if c.closeRuntime && c.runtime != nil {
+		errs = append(errs, c.runtime.Close())
+	}
+	return errors.Join(errs...)
+}
+
+func stopPluginRuntimeSession(runtimeProvider pluginruntime.Provider, sessionID string) error {
+	if runtimeProvider == nil || sessionID == "" {
+		return nil
+	}
+	ctx, cancel := context.WithTimeout(context.Background(), pluginRuntimeStopTimeout)
+	defer cancel()
+
+	done := make(chan error, 1)
+	go func() {
+		done <- runtimeProvider.StopSession(ctx, pluginruntime.StopSessionRequest{SessionID: sessionID})
+	}()
+
+	select {
+	case err := <-done:
+		return err
+	case <-ctx.Done():
+		return fmt.Errorf("stop plugin runtime session %q: %w", sessionID, ctx.Err())
+	}
+}
+
+func waitForPluginRuntimeSessionReady(ctx context.Context, runtimeProvider pluginruntime.Provider, sessionID string) error {
+	for {
+		session, err := runtimeProvider.GetSession(ctx, pluginruntime.GetSessionRequest{SessionID: sessionID})
 		if err != nil {
-			return nil, err
+			return err
 		}
-		execCfg.HostServices = append(execCfg.HostServices, hostServices...)
+		switch session.State {
+		case pluginruntime.SessionStateReady, pluginruntime.SessionStateRunning:
+			return nil
+		case pluginruntime.SessionStateFailed, pluginruntime.SessionStateStopped:
+			return fmt.Errorf("session entered %q state", session.State)
+		}
+
+		select {
+		case <-ctx.Done():
+			return ctx.Err()
+		case <-time.After(25 * time.Millisecond):
+		}
+	}
+}
+
+func buildPluginRuntimeHostServices(name string, entry *config.ProviderEntry, deps Deps) ([]providerhost.HostService, *providerhost.RequestSnapshotStore, func(), error) {
+	var (
+		hostServices []providerhost.HostService
+		cleanup      func()
+		snapshots    *providerhost.RequestSnapshotStore
+	)
+	fail := func(err error) ([]providerhost.HostService, *providerhost.RequestSnapshotStore, func(), error) {
+		if cleanup != nil {
+			cleanup()
+			cleanup = nil
+		}
+		return nil, nil, nil, err
+	}
+
+	effectiveIndexedDB, err := config.ResolveEffectivePluginIndexedDB(name, entry, deps.SelectedIndexedDBName, deps.IndexedDBDefs)
+	if err != nil {
+		return fail(err)
+	}
+	if effectiveIndexedDB.Enabled {
+		services, indexedDBCleanup, err := buildPluginIndexedDBHostServices(name, effectiveIndexedDB, deps)
+		if err != nil {
+			return fail(err)
+		}
+		hostServices = append(hostServices, services...)
 		cleanup = chainCleanup(cleanup, indexedDBCleanup)
 	}
 	if len(entry.Cache) > 0 {
-		hostServices, cacheCleanup, err := buildPluginCacheHostServices(name, entry, deps)
+		services, cacheCleanup, err := buildPluginCacheHostServices(name, entry, deps)
 		if err != nil {
-			return nil, err
+			return fail(err)
 		}
-		execCfg.HostServices = append(execCfg.HostServices, hostServices...)
+		hostServices = append(hostServices, services...)
 		cleanup = chainCleanup(cleanup, cacheCleanup)
 	}
 	if len(entry.S3) > 0 {
-		hostServices, err := buildPluginS3HostServices(name, entry, deps)
+		services, err := buildPluginS3HostServices(name, entry, deps)
 		if err != nil {
-			return nil, err
+			return fail(err)
 		}
-		execCfg.HostServices = append(execCfg.HostServices, hostServices...)
+		hostServices = append(hostServices, services...)
 	}
 	if len(entry.Invokes) > 0 {
-		hostService, snapshots := buildPluginInvokerHostService(name, entry, deps)
-		execCfg.HostServices = append(execCfg.HostServices, hostService)
-		execCfg.RequestSnapshots = snapshots
+		hostService, requestSnapshots := buildPluginInvokerHostService(name, entry, deps)
+		hostServices = append(hostServices, hostService)
+		snapshots = requestSnapshots
 	}
-	execCfg.Cleanup = cleanup
-	prov, err := providerhost.NewExecutableProvider(ctx, execCfg)
-	if err != nil {
-		return nil, err
-	}
-	cleanup = nil
-	return prov, nil
+	return hostServices, snapshots, cleanup, nil
 }
 
 func buildPluginIndexedDBHostServices(pluginName string, effective config.EffectivePluginIndexedDB, deps Deps) ([]providerhost.HostService, func(), error) {

--- a/gestaltd/internal/pluginruntime/local.go
+++ b/gestaltd/internal/pluginruntime/local.go
@@ -1,0 +1,380 @@
+package pluginruntime
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"os"
+	"path/filepath"
+	"sync"
+	"sync/atomic"
+
+	proto "github.com/valon-technologies/gestalt/sdk/go/gen/v1"
+	"github.com/valon-technologies/gestalt/server/internal/providerhost"
+	"google.golang.org/grpc"
+)
+
+type LocalProvider struct {
+	nextID uint64
+
+	mu       sync.Mutex
+	sessions map[string]*localSession
+	closed   bool
+}
+
+type localSession struct {
+	id       string
+	rootDir  string
+	state    SessionState
+	metadata map[string]string
+	bindings []localBinding
+	plugin   *localPlugin
+}
+
+type localBinding struct {
+	id       string
+	envVar   string
+	register func(*grpc.Server)
+}
+
+type localPlugin struct {
+	id      string
+	name    string
+	process *providerhost.PluginProcess
+}
+
+type localHostedPluginConn struct {
+	process   *providerhost.PluginProcess
+	onClose   func()
+	closeOnce sync.Once
+}
+
+func NewLocalProvider() *LocalProvider {
+	return &LocalProvider{
+		sessions: make(map[string]*localSession),
+	}
+}
+
+func (p *LocalProvider) Capabilities(context.Context) (Capabilities, error) {
+	return Capabilities{
+		HostedPluginRuntime: true,
+		HostServiceTunnels:  true,
+		ProviderGRPCTunnel:  true,
+		HostnameProxyEgress: true,
+	}, nil
+}
+
+func (p *LocalProvider) StartSession(_ context.Context, req StartSessionRequest) (*Session, error) {
+	if p == nil {
+		return nil, fmt.Errorf("plugin runtime is not configured")
+	}
+
+	rootDir, err := providerhost.NewPluginTempDir("gestalt-plugin-runtime-*")
+	if err != nil {
+		return nil, fmt.Errorf("create runtime session dir: %w", err)
+	}
+	sessionID := p.newID("session")
+
+	p.mu.Lock()
+	defer p.mu.Unlock()
+	if p.closed {
+		_ = os.RemoveAll(rootDir)
+		return nil, fmt.Errorf("plugin runtime is closed")
+	}
+	session := &localSession{
+		id:       sessionID,
+		rootDir:  rootDir,
+		state:    SessionStateReady,
+		metadata: cloneStringMap(req.Metadata),
+	}
+	if session.metadata == nil {
+		session.metadata = map[string]string{}
+	}
+	p.sessions[sessionID] = session
+	return cloneSession(session), nil
+}
+
+func (p *LocalProvider) GetSession(_ context.Context, req GetSessionRequest) (*Session, error) {
+	if p == nil {
+		return nil, fmt.Errorf("plugin runtime is not configured")
+	}
+
+	p.mu.Lock()
+	defer p.mu.Unlock()
+	session, err := p.sessionLocked(req.SessionID)
+	if err != nil {
+		return nil, err
+	}
+	return cloneSession(session), nil
+}
+
+func (p *LocalProvider) StopSession(_ context.Context, req StopSessionRequest) error {
+	if p == nil {
+		return nil
+	}
+
+	var plugin *providerhost.PluginProcess
+	var rootDir string
+
+	p.mu.Lock()
+	session, ok := p.sessions[req.SessionID]
+	if ok {
+		delete(p.sessions, req.SessionID)
+		if session.plugin != nil {
+			plugin = session.plugin.process
+		}
+		rootDir = session.rootDir
+	}
+	p.mu.Unlock()
+
+	if plugin != nil {
+		err := plugin.Close()
+		if rootDir == "" {
+			return err
+		}
+		if cleanupErr := os.RemoveAll(rootDir); cleanupErr != nil {
+			if err != nil {
+				return errors.Join(err, fmt.Errorf("remove runtime session dir: %w", cleanupErr))
+			}
+			return fmt.Errorf("remove runtime session dir: %w", cleanupErr)
+		}
+		return err
+	}
+	if rootDir != "" {
+		if err := os.RemoveAll(rootDir); err != nil {
+			return fmt.Errorf("remove runtime session dir: %w", err)
+		}
+	}
+	return nil
+}
+
+func (p *LocalProvider) BindHostService(_ context.Context, req BindHostServiceRequest) (*HostServiceBinding, error) {
+	if p == nil {
+		return nil, fmt.Errorf("plugin runtime is not configured")
+	}
+	if req.EnvVar == "" {
+		return nil, fmt.Errorf("host service env var is required")
+	}
+	if req.Register == nil {
+		return nil, fmt.Errorf("host service register callback is required")
+	}
+
+	p.mu.Lock()
+	defer p.mu.Unlock()
+	session, err := p.sessionLocked(req.SessionID)
+	if err != nil {
+		return nil, err
+	}
+	binding := localBinding{
+		id:       p.newID("binding"),
+		envVar:   req.EnvVar,
+		register: req.Register,
+	}
+	index := len(session.bindings)
+	session.bindings = append(session.bindings, binding)
+	return &HostServiceBinding{
+		ID:         binding.id,
+		SessionID:  session.id,
+		EnvVar:     binding.envVar,
+		SocketPath: filepath.Join(session.rootDir, fmt.Sprintf("host-%d.sock", index)),
+	}, nil
+}
+
+func (p *LocalProvider) StartPlugin(ctx context.Context, req StartPluginRequest) (*HostedPlugin, error) {
+	if p == nil {
+		return nil, fmt.Errorf("plugin runtime is not configured")
+	}
+	if req.Command == "" {
+		return nil, fmt.Errorf("plugin command is required")
+	}
+
+	p.mu.Lock()
+	session, err := p.sessionLocked(req.SessionID)
+	if err != nil {
+		p.mu.Unlock()
+		return nil, err
+	}
+	if session.plugin != nil {
+		p.mu.Unlock()
+		return nil, fmt.Errorf("plugin runtime session %q already has a running plugin", req.SessionID)
+	}
+	hostServices := make([]providerhost.HostService, 0, len(session.bindings))
+	for _, binding := range session.bindings {
+		hostServices = append(hostServices, providerhost.HostService{
+			EnvVar:   binding.envVar,
+			Register: binding.register,
+		})
+	}
+	session.state = SessionStateRunning
+	rootDir := session.rootDir
+	p.mu.Unlock()
+
+	process, err := providerhost.StartPluginProcess(ctx, providerhost.ProcessConfig{
+		Command:       req.Command,
+		Args:          req.Args,
+		Env:           req.Env,
+		AllowedHosts:  req.AllowedHosts,
+		DefaultAction: req.DefaultAction,
+		HostBinary:    req.HostBinary,
+		Cleanup:       req.Cleanup,
+		HostServices:  hostServices,
+		SocketDir:     rootDir,
+	})
+	if err != nil {
+		p.mu.Lock()
+		if session, ok := p.sessions[req.SessionID]; ok {
+			session.state = SessionStateFailed
+		}
+		p.mu.Unlock()
+		return nil, err
+	}
+
+	plugin := &localPlugin{
+		id:      p.newID("plugin"),
+		name:    req.PluginName,
+		process: process,
+	}
+
+	p.mu.Lock()
+	defer p.mu.Unlock()
+	session, err = p.sessionLocked(req.SessionID)
+	if err != nil {
+		_ = process.Close()
+		return nil, err
+	}
+	session.plugin = plugin
+	session.state = SessionStateRunning
+	return &HostedPlugin{
+		ID:         plugin.id,
+		SessionID:  session.id,
+		PluginName: plugin.name,
+	}, nil
+}
+
+func (p *LocalProvider) DialPlugin(_ context.Context, req DialPluginRequest) (HostedPluginConn, error) {
+	if p == nil {
+		return nil, fmt.Errorf("plugin runtime is not configured")
+	}
+
+	p.mu.Lock()
+	defer p.mu.Unlock()
+	session, err := p.sessionLocked(req.SessionID)
+	if err != nil {
+		return nil, err
+	}
+	if session.plugin == nil || session.plugin.process == nil {
+		return nil, fmt.Errorf("plugin runtime session %q has no started plugin", req.SessionID)
+	}
+	if req.PluginID != "" && session.plugin.id != req.PluginID {
+		return nil, fmt.Errorf("plugin runtime session %q has no plugin %q", req.SessionID, req.PluginID)
+	}
+	return &localHostedPluginConn{
+		process: session.plugin.process,
+		onClose: func() {
+			p.forgetSession(req.SessionID)
+		},
+	}, nil
+}
+
+func (p *LocalProvider) Close() error {
+	if p == nil {
+		return nil
+	}
+
+	p.mu.Lock()
+	if p.closed {
+		p.mu.Unlock()
+		return nil
+	}
+	p.closed = true
+	sessionIDs := make([]string, 0, len(p.sessions))
+	for sessionID := range p.sessions {
+		sessionIDs = append(sessionIDs, sessionID)
+	}
+	p.mu.Unlock()
+
+	var firstErr error
+	for _, sessionID := range sessionIDs {
+		if err := p.StopSession(context.Background(), StopSessionRequest{SessionID: sessionID}); err != nil && firstErr == nil {
+			firstErr = err
+		}
+	}
+	return firstErr
+}
+
+func (p *LocalProvider) newID(prefix string) string {
+	value := atomic.AddUint64(&p.nextID, 1)
+	return fmt.Sprintf("%s-%d", prefix, value)
+}
+
+func (p *LocalProvider) sessionLocked(sessionID string) (*localSession, error) {
+	if p.closed {
+		return nil, fmt.Errorf("plugin runtime is closed")
+	}
+	session, ok := p.sessions[sessionID]
+	if !ok || session == nil {
+		return nil, fmt.Errorf("plugin runtime session %q is not available", sessionID)
+	}
+	return session, nil
+}
+
+func (p *LocalProvider) forgetSession(sessionID string) {
+	p.mu.Lock()
+	defer p.mu.Unlock()
+	if session, ok := p.sessions[sessionID]; ok && session != nil {
+		session.state = SessionStateStopped
+		delete(p.sessions, sessionID)
+	}
+}
+
+func (c *localHostedPluginConn) Lifecycle() proto.ProviderLifecycleClient {
+	if c == nil || c.process == nil {
+		return nil
+	}
+	return c.process.Lifecycle()
+}
+
+func (c *localHostedPluginConn) Integration() proto.IntegrationProviderClient {
+	if c == nil || c.process == nil {
+		return nil
+	}
+	return c.process.Integration()
+}
+
+func (c *localHostedPluginConn) Close() error {
+	if c == nil {
+		return nil
+	}
+	var err error
+	c.closeOnce.Do(func() {
+		if c.process != nil {
+			err = c.process.Close()
+		}
+		if c.onClose != nil {
+			c.onClose()
+		}
+	})
+	return err
+}
+
+func cloneSession(session *localSession) *Session {
+	if session == nil {
+		return nil
+	}
+	return &Session{
+		ID:       session.id,
+		State:    session.state,
+		Metadata: cloneStringMap(session.metadata),
+	}
+}
+
+func cloneStringMap(values map[string]string) map[string]string {
+	if len(values) == 0 {
+		return nil
+	}
+	out := make(map[string]string, len(values))
+	for key, value := range values {
+		out[key] = value
+	}
+	return out
+}

--- a/gestaltd/internal/pluginruntime/runtime.go
+++ b/gestaltd/internal/pluginruntime/runtime.go
@@ -1,0 +1,108 @@
+package pluginruntime
+
+import (
+	"context"
+
+	proto "github.com/valon-technologies/gestalt/sdk/go/gen/v1"
+	"github.com/valon-technologies/gestalt/server/internal/egress"
+	"google.golang.org/grpc"
+)
+
+type SessionState string
+
+const (
+	SessionStatePending SessionState = "pending"
+	SessionStateReady   SessionState = "ready"
+	SessionStateRunning SessionState = "running"
+	SessionStateStopped SessionState = "stopped"
+	SessionStateFailed  SessionState = "failed"
+)
+
+type Capabilities struct {
+	HostedPluginRuntime bool
+	HostServiceTunnels  bool
+	ProviderGRPCTunnel  bool
+	HostnameProxyEgress bool
+	CIDREgress          bool
+}
+
+type Session struct {
+	ID       string
+	State    SessionState
+	Metadata map[string]string
+}
+
+type StartSessionRequest struct {
+	PluginName string
+	Metadata   map[string]string
+}
+
+type GetSessionRequest struct {
+	SessionID string
+}
+
+type StopSessionRequest struct {
+	SessionID string
+}
+
+type BindHostServiceRequest struct {
+	SessionID string
+	EnvVar    string
+	Register  func(*grpc.Server)
+}
+
+type HostServiceBinding struct {
+	ID         string
+	SessionID  string
+	EnvVar     string
+	SocketPath string
+}
+
+// StartPluginRequest describes the plugin process to launch inside a runtime
+// session. Implementations own allocation and injection of the plugin's
+// provider listener endpoint (for example, GESTALT_PLUGIN_SOCKET); the host
+// does not pass an explicit listener path through this contract.
+type StartPluginRequest struct {
+	SessionID     string
+	PluginName    string
+	Command       string
+	Args          []string
+	Env           map[string]string
+	AllowedHosts  []string
+	DefaultAction egress.PolicyAction
+	HostBinary    string
+	Cleanup       func()
+}
+
+type HostedPlugin struct {
+	ID         string
+	SessionID  string
+	PluginName string
+}
+
+type DialPluginRequest struct {
+	SessionID string
+	PluginID  string
+}
+
+type HostedPluginConn interface {
+	Lifecycle() proto.ProviderLifecycleClient
+	Integration() proto.IntegrationProviderClient
+	Close() error
+}
+
+type Provider interface {
+	Capabilities(ctx context.Context) (Capabilities, error)
+	StartSession(ctx context.Context, req StartSessionRequest) (*Session, error)
+	GetSession(ctx context.Context, req GetSessionRequest) (*Session, error)
+	StopSession(ctx context.Context, req StopSessionRequest) error
+	BindHostService(ctx context.Context, req BindHostServiceRequest) (*HostServiceBinding, error)
+	// StartPlugin launches a plugin inside the session. Implementations must
+	// allocate and inject the plugin listener endpoint before startup and only
+	// return success once DialPlugin can connect to the running plugin.
+	StartPlugin(ctx context.Context, req StartPluginRequest) (*HostedPlugin, error)
+	// DialPlugin connects to the listener established by StartPlugin using the
+	// backend-specific transport or tunnel.
+	DialPlugin(ctx context.Context, req DialPluginRequest) (HostedPluginConn, error)
+	Close() error
+}

--- a/gestaltd/internal/providerhost/auth_client.go
+++ b/gestaltd/internal/providerhost/auth_client.go
@@ -53,7 +53,7 @@ type remoteAuthenticationProvider struct {
 }
 
 func NewExecutableAuthenticationProvider(ctx context.Context, cfg AuthenticationExecConfig) (core.AuthenticationProvider, error) {
-	proc, err := startProviderProcess(ctx, ExecConfig{
+	execCfg := ExecConfig{
 		Command:      cfg.Command,
 		Args:         cfg.Args,
 		Env:          cfg.Env,
@@ -61,7 +61,8 @@ func NewExecutableAuthenticationProvider(ctx context.Context, cfg Authentication
 		AllowedHosts: cfg.AllowedHosts,
 		HostBinary:   cfg.HostBinary,
 		Cleanup:      cfg.Cleanup,
-	})
+	}
+	proc, err := startProviderProcess(ctx, execCfg.processConfig())
 	if err != nil {
 		return nil, err
 	}

--- a/gestaltd/internal/providerhost/authorization_client.go
+++ b/gestaltd/internal/providerhost/authorization_client.go
@@ -29,7 +29,7 @@ type remoteAuthorizationProvider struct {
 }
 
 func NewExecutableAuthorizationProvider(ctx context.Context, cfg AuthorizationExecConfig) (core.AuthorizationProvider, error) {
-	proc, err := startProviderProcess(ctx, ExecConfig{
+	execCfg := ExecConfig{
 		Command:      cfg.Command,
 		Args:         cfg.Args,
 		Env:          cfg.Env,
@@ -38,7 +38,8 @@ func NewExecutableAuthorizationProvider(ctx context.Context, cfg AuthorizationEx
 		HostBinary:   cfg.HostBinary,
 		Cleanup:      cfg.Cleanup,
 		HostServices: cfg.HostServices,
-	})
+	}
+	proc, err := startProviderProcess(ctx, execCfg.processConfig())
 	if err != nil {
 		return nil, err
 	}

--- a/gestaltd/internal/providerhost/cache_client.go
+++ b/gestaltd/internal/providerhost/cache_client.go
@@ -30,7 +30,7 @@ type remoteCache struct {
 }
 
 func NewExecutableCache(ctx context.Context, cfg CacheExecConfig) (corecache.Cache, error) {
-	proc, err := startProviderProcess(ctx, ExecConfig{
+	execCfg := ExecConfig{
 		Command:      cfg.Command,
 		Args:         cfg.Args,
 		Env:          cfg.Env,
@@ -38,7 +38,8 @@ func NewExecutableCache(ctx context.Context, cfg CacheExecConfig) (corecache.Cac
 		AllowedHosts: cfg.AllowedHosts,
 		HostBinary:   cfg.HostBinary,
 		Cleanup:      cfg.Cleanup,
-	})
+	}
+	proc, err := startProviderProcess(ctx, execCfg.processConfig())
 	if err != nil {
 		return nil, err
 	}

--- a/gestaltd/internal/providerhost/indexeddb_client.go
+++ b/gestaltd/internal/providerhost/indexeddb_client.go
@@ -31,7 +31,7 @@ type remoteIndexedDB struct {
 }
 
 func NewExecutableIndexedDB(ctx context.Context, cfg IndexedDBExecConfig) (indexeddb.IndexedDB, error) {
-	proc, err := startProviderProcess(ctx, ExecConfig{
+	execCfg := ExecConfig{
 		Command:      cfg.Command,
 		Args:         cfg.Args,
 		Env:          cfg.Env,
@@ -39,7 +39,8 @@ func NewExecutableIndexedDB(ctx context.Context, cfg IndexedDBExecConfig) (index
 		AllowedHosts: cfg.AllowedHosts,
 		HostBinary:   cfg.HostBinary,
 		Cleanup:      cfg.Cleanup,
-	})
+	}
+	proc, err := startProviderProcess(ctx, execCfg.processConfig())
 	if err != nil {
 		return nil, err
 	}

--- a/gestaltd/internal/providerhost/process.go
+++ b/gestaltd/internal/providerhost/process.go
@@ -28,6 +28,18 @@ const (
 	processShutdownTimeout = 2 * time.Second
 )
 
+type ProcessConfig struct {
+	Command       string
+	Args          []string
+	Env           map[string]string
+	AllowedHosts  []string
+	DefaultAction egress.PolicyAction
+	HostBinary    string
+	Cleanup       func()
+	HostServices  []HostService
+	SocketDir     string
+}
+
 type ExecConfig struct {
 	Command          string
 	Args             []string
@@ -62,29 +74,75 @@ type providerProcess struct {
 	closeErr       error
 }
 
+type PluginProcess struct {
+	proc *providerProcess
+}
+
 func NewExecutableProvider(ctx context.Context, cfg ExecConfig) (core.Provider, error) {
-	proc, err := startProviderProcess(ctx, cfg)
+	proc, err := startProviderProcess(ctx, cfg.processConfig())
 	if err != nil {
 		return nil, err
 	}
 
-	client := proto.NewIntegrationProviderClient(proc.conn)
-	opts := []RemoteProviderOption{WithCloser(proc)}
+	conn := &PluginProcess{proc: proc}
+	opts := []RemoteProviderOption{WithCloser(conn)}
 	if cfg.RequestSnapshots != nil {
 		opts = append(opts, WithRequestSnapshots(cfg.RequestSnapshots))
 	}
 	prov, err := NewRemoteProvider(
 		ctx,
-		client,
+		conn.Integration(),
 		cfg.StaticSpec,
 		cfg.Config,
 		opts...,
 	)
 	if err != nil {
-		_ = proc.Close()
+		_ = conn.Close()
 		return nil, err
 	}
 	return prov, nil
+}
+
+func (c ExecConfig) processConfig() ProcessConfig {
+	return ProcessConfig{
+		Command:       c.Command,
+		Args:          c.Args,
+		Env:           c.Env,
+		AllowedHosts:  c.AllowedHosts,
+		DefaultAction: c.DefaultAction,
+		HostBinary:    c.HostBinary,
+		Cleanup:       c.Cleanup,
+		HostServices:  c.HostServices,
+	}
+}
+
+func StartPluginProcess(ctx context.Context, cfg ProcessConfig) (*PluginProcess, error) {
+	proc, err := startProviderProcess(ctx, cfg)
+	if err != nil {
+		return nil, err
+	}
+	return &PluginProcess{proc: proc}, nil
+}
+
+func (p *PluginProcess) Lifecycle() proto.ProviderLifecycleClient {
+	if p == nil || p.proc == nil {
+		return nil
+	}
+	return proto.NewProviderLifecycleClient(p.proc.conn)
+}
+
+func (p *PluginProcess) Integration() proto.IntegrationProviderClient {
+	if p == nil || p.proc == nil {
+		return nil
+	}
+	return proto.NewIntegrationProviderClient(p.proc.conn)
+}
+
+func (p *PluginProcess) Close() error {
+	if p == nil || p.proc == nil {
+		return nil
+	}
+	return p.proc.Close()
 }
 
 func ServeProvider(ctx context.Context, provider core.Provider) error {
@@ -129,16 +187,22 @@ func serveProvider(ctx context.Context, register func(*grpc.Server)) error {
 	return err
 }
 
-func startProviderProcess(ctx context.Context, cfg ExecConfig) (*providerProcess, error) {
+func startProviderProcess(ctx context.Context, cfg ProcessConfig) (*providerProcess, error) {
 	if cfg.Command == "" {
 		return nil, fmt.Errorf("plugin command is required")
 	}
 
 	sandboxActive := len(cfg.AllowedHosts) > 0 || cfg.DefaultAction == egress.PolicyDeny
 
-	dir, err := newSocketDir()
-	if err != nil {
-		return nil, err
+	dir := strings.TrimSpace(cfg.SocketDir)
+	if dir == "" {
+		var err error
+		dir, err = newSocketDir()
+		if err != nil {
+			return nil, err
+		}
+	} else if err := os.MkdirAll(dir, 0o755); err != nil {
+		return nil, fmt.Errorf("create socket dir: %w", err)
 	}
 	pluginSocket := filepath.Join(dir, "plugin.sock")
 	env := mergeExecEnv(cfg.Env, map[string]string{
@@ -155,7 +219,16 @@ func startProviderProcess(ctx context.Context, cfg ExecConfig) (*providerProcess
 		hostSocket := filepath.Join(dir, fmt.Sprintf("host-%d.sock", i))
 		lis, err := net.Listen("unix", hostSocket)
 		if err != nil {
-			_ = os.RemoveAll(dir)
+			cleanupStartupHostServices(proc)
+			if cleanupErr := os.Remove(hostSocket); cleanupErr != nil && !os.IsNotExist(cleanupErr) {
+				return nil, errors.Join(
+					fmt.Errorf("listen on host socket: %w", err),
+					fmt.Errorf("cleanup failed host socket %q: %w", hostSocket, cleanupErr),
+				)
+			}
+			if cfg.SocketDir == "" {
+				_ = os.RemoveAll(dir)
+			}
 			return nil, fmt.Errorf("listen on host socket: %w", err)
 		}
 		srv := grpc.NewServer()
@@ -346,8 +419,32 @@ func (p *providerProcess) Close() error {
 	return p.closeErr
 }
 
+func cleanupStartupHostServices(proc *providerProcess) {
+	if proc == nil {
+		return
+	}
+	for _, hostSrv := range proc.hostSrvs {
+		hostSrv.Stop()
+	}
+	for _, hostLis := range proc.hostLiss {
+		if hostLis == nil {
+			continue
+		}
+		_ = hostLis.Close()
+		socketPath := strings.TrimSpace(hostLis.Addr().String())
+		if socketPath == "" {
+			continue
+		}
+		_ = os.Remove(socketPath)
+	}
+}
+
+func NewPluginTempDir(pattern string) (string, error) {
+	return newPluginTempDir(pattern)
+}
+
 func newSocketDir() (string, error) {
-	return newPluginTempDir("gstp-")
+	return NewPluginTempDir("gstp-")
 }
 
 func newPluginTempDir(pattern string) (string, error) {

--- a/gestaltd/internal/providerhost/s3_client.go
+++ b/gestaltd/internal/providerhost/s3_client.go
@@ -32,7 +32,7 @@ type remoteS3 struct {
 }
 
 func NewExecutableS3(ctx context.Context, cfg S3ExecConfig) (s3store.Client, error) {
-	proc, err := startProviderProcess(ctx, ExecConfig{
+	execCfg := ExecConfig{
 		Command:      cfg.Command,
 		Args:         cfg.Args,
 		Env:          cfg.Env,
@@ -40,7 +40,8 @@ func NewExecutableS3(ctx context.Context, cfg S3ExecConfig) (s3store.Client, err
 		AllowedHosts: cfg.AllowedHosts,
 		HostBinary:   cfg.HostBinary,
 		Cleanup:      cfg.Cleanup,
-	})
+	}
+	proc, err := startProviderProcess(ctx, execCfg.processConfig())
 	if err != nil {
 		return nil, err
 	}

--- a/gestaltd/internal/providerhost/secrets_client.go
+++ b/gestaltd/internal/providerhost/secrets_client.go
@@ -26,7 +26,7 @@ type remoteSecretManager struct {
 }
 
 func NewExecutableSecretManager(ctx context.Context, cfg SecretsExecConfig) (core.SecretManager, error) {
-	proc, err := startProviderProcess(ctx, ExecConfig{
+	execCfg := ExecConfig{
 		Command:      cfg.Command,
 		Args:         cfg.Args,
 		Env:          cfg.Env,
@@ -34,7 +34,8 @@ func NewExecutableSecretManager(ctx context.Context, cfg SecretsExecConfig) (cor
 		AllowedHosts: cfg.AllowedHosts,
 		HostBinary:   cfg.HostBinary,
 		Cleanup:      cfg.Cleanup,
-	})
+	}
+	proc, err := startProviderProcess(ctx, execCfg.processConfig())
 	if err != nil {
 		return nil, err
 	}

--- a/gestaltd/internal/providerhost/workflow_client.go
+++ b/gestaltd/internal/providerhost/workflow_client.go
@@ -32,7 +32,7 @@ type remoteWorkflow struct {
 }
 
 func NewExecutableWorkflow(ctx context.Context, cfg WorkflowExecConfig) (coreworkflow.Provider, error) {
-	proc, err := startWorkflowProviderProcess(ctx, ExecConfig{
+	execCfg := ExecConfig{
 		Command:       cfg.Command,
 		Args:          cfg.Args,
 		Env:           cfg.Env,
@@ -42,7 +42,8 @@ func NewExecutableWorkflow(ctx context.Context, cfg WorkflowExecConfig) (corewor
 		HostBinary:    cfg.HostBinary,
 		Cleanup:       cfg.Cleanup,
 		HostServices:  cfg.HostServices,
-	})
+	}
+	proc, err := startWorkflowProviderProcess(ctx, execCfg.processConfig())
 	if err != nil {
 		return nil, err
 	}

--- a/gestaltd/internal/providerhost/workflow_client_test.go
+++ b/gestaltd/internal/providerhost/workflow_client_test.go
@@ -15,8 +15,8 @@ func TestNewExecutableWorkflowForwardsDefaultEgressAction(t *testing.T) {
 	defer func() { startWorkflowProviderProcess = originalStart }()
 
 	wantErr := errors.New("boom")
-	var got ExecConfig
-	startWorkflowProviderProcess = func(_ context.Context, cfg ExecConfig) (*providerProcess, error) {
+	var got ProcessConfig
+	startWorkflowProviderProcess = func(_ context.Context, cfg ProcessConfig) (*providerProcess, error) {
 		got = cfg
 		return nil, wantErr
 	}


### PR DESCRIPTION
## Summary
This PR introduces an internal hosted-plugin runtime abstraction and routes executable plugin startup through it, while preserving the current default behavior: plugins still run on the same machine unless a different runtime backend is selected later.

This first slice:
- adds the `pluginruntime` package
- adds a built-in `pluginruntime.NewLocalProvider()` backend
- refactors executable plugin bootstrap to use runtime sessions, host-service binding, plugin start, and dial
- keeps plugin author ergonomics unchanged
- does not add developer-facing `runtime:` config yet

## New Interfaces
```go
type Provider interface {
    Capabilities(ctx context.Context) (Capabilities, error)
    StartSession(ctx context.Context, req StartSessionRequest) (*Session, error)
    GetSession(ctx context.Context, req GetSessionRequest) (*Session, error)
    StopSession(ctx context.Context, req StopSessionRequest) error
    BindHostService(ctx context.Context, req BindHostServiceRequest) (*HostServiceBinding, error)
    StartPlugin(ctx context.Context, req StartPluginRequest) (*HostedPlugin, error)
    DialPlugin(ctx context.Context, req DialPluginRequest) (HostedPluginConn, error)
    Close() error
}

type HostedPluginConn interface {
    Lifecycle() proto.ProviderLifecycleClient
    Integration() proto.IntegrationProviderClient
    Close() error
}
```

```go
type ProcessConfig struct {
    Command       string
    Args          []string
    Env           map[string]string
    AllowedHosts  []string
    DefaultAction egress.PolicyAction
    HostBinary    string
    Cleanup       func()
    HostServices  []HostService
    SocketDir     string
}

func StartPluginProcess(ctx context.Context, cfg ProcessConfig) (*PluginProcess, error)
```

## Hosted Plugin Contract
`StartPlugin` owns allocation and injection of the provider listener endpoint. The host does not pass a socket path through the runtime contract.

```go
type StartPluginRequest struct {
    SessionID     string
    PluginName    string
    Command       string
    Args          []string
    Env           map[string]string
    AllowedHosts  []string
    DefaultAction egress.PolicyAction
    HostBinary    string
    Cleanup       func()
}
```

The built-in local backend satisfies that contract by reusing `providerhost.StartPluginProcess(...)`, which allocates `plugin.sock`, injects `GESTALT_PLUGIN_SOCKET`, and then exposes the existing provider gRPC surface back through `HostedPluginConn`.

## Bootstrap Flow
`buildPluginProvider(...)` now does this:
```go
runtimeConfig, runtimeProvider, runtimeOwned, _ := effectivePluginRuntime(ctx, name, entry, deps)
session, _ := runtimeProvider.StartSession(ctx, buildPluginRuntimeStartSessionRequest(name, runtimeConfig))

_, _ = runtimeProvider.BindHostService(ctx, pluginruntime.BindHostServiceRequest{
    SessionID: session.ID,
    EnvVar:    providerhost.DefaultPluginInvokerSocketEnv,
    Register:  pluginInvokerRegister,
})

plugin, _ := runtimeProvider.StartPlugin(ctx, pluginruntime.StartPluginRequest{
    SessionID:     session.ID,
    PluginName:    name,
    Command:       command,
    Args:          args,
    Env:           env,
    AllowedHosts:  entry.AllowedHosts,
    DefaultAction: deps.Egress.DefaultAction,
    HostBinary:    entry.HostBinary,
    Cleanup:       cleanup,
})

conn, _ := runtimeProvider.DialPlugin(ctx, pluginruntime.DialPluginRequest{
    SessionID: session.ID,
    PluginID:  plugin.ID,
})

prov, _ := providerhost.NewRemoteProvider(ctx, conn.Integration(), spec, pluginConfig)
```

## Runtime Behavior
The local backend remains the default:
```go
runtimeProvider := pluginruntime.NewLocalProvider()
```

That backend:
- allocates a runtime session directory
- records host-service bindings for injected guest socket env vars
- starts the plugin with `providerhost.StartPluginProcess(...)`
- dials the plugin over the existing gRPC surface
- tears the session down on provider close

Provider shutdown now stops the hosted runtime session through a bounded host-side timeout instead of waiting indefinitely:
```go
const pluginRuntimeStopTimeout = 3 * time.Second
```

Host-service startup also cleans up already-open listeners if a later bind fails, so partial startup does not leak orphaned sockets or goroutines.

## Developer Impact
Plugin authors still do not configure `GESTALT_PLUGIN_SOCKET` or any other host-service socket env vars manually. Those remain runtime internals managed by `gestaltd` and the runtime backend.

## Validation
- `go test ./internal/providerhost ./internal/bootstrap ./internal/pluginruntime`
