### PR TITLE
plugin runtime: add config-driven hosted runtime selection

### DIFF
--- a/gestaltd/internal/bootstrap/bootstrap.go
+++ b/gestaltd/internal/bootstrap/bootstrap.go
@@ -145,6 +145,7 @@ type Deps struct {
 	Egress                EgressDeps
 	PluginInvoker         invocation.Invoker
 	PluginRuntime         pluginruntime.Provider
+	PluginRuntimeRegistry *pluginRuntimeRegistry
 }
 
 type AuthFactory func(node yaml.Node, deps Deps) (core.AuthenticationProvider, error)
@@ -158,21 +159,27 @@ type TelemetryFactory func(node yaml.Node) (core.TelemetryProvider, error)
 type AuditFactory func(ctx context.Context, cfg config.ProviderEntry, telemetry core.TelemetryProvider) (core.AuditSink, func(context.Context) error, error)
 
 type FactoryRegistry struct {
-	Auth          AuthFactory
-	Authorization AuthorizationFactory
-	Secrets       map[string]SecretManagerFactory
-	IndexedDB     IndexedDBFactory
-	Cache         CacheFactory
-	S3            S3Factory
-	Workflow      WorkflowFactory
-	Telemetry     map[string]TelemetryFactory
-	Audit         AuditFactory
-	Builtins      []core.Provider
+	Auth           AuthFactory
+	Authorization  AuthorizationFactory
+	Secrets        map[string]SecretManagerFactory
+	IndexedDB      IndexedDBFactory
+	Cache          CacheFactory
+	PluginRuntimes map[config.RuntimeProviderDriver]pluginRuntimeFactory
+	S3             S3Factory
+	Workflow       WorkflowFactory
+	Telemetry      map[string]TelemetryFactory
+	Audit          AuditFactory
+	Builtins       []core.Provider
 }
 
 func NewFactoryRegistry() *FactoryRegistry {
 	return &FactoryRegistry{
-		Secrets:   make(map[string]SecretManagerFactory),
+		Secrets: make(map[string]SecretManagerFactory),
+		PluginRuntimes: map[config.RuntimeProviderDriver]pluginRuntimeFactory{
+			config.RuntimeProviderDriverLocal: func(context.Context, string, *config.RuntimeProviderEntry, Deps) (pluginruntime.Provider, error) {
+				return pluginruntime.NewLocalProvider(), nil
+			},
+		},
 		Telemetry: make(map[string]TelemetryFactory),
 	}
 }
@@ -197,9 +204,10 @@ type Result struct {
 	SecretManager         core.SecretManager
 	Telemetry             core.TelemetryProvider
 
-	auditClose func(context.Context) error
-	mu         sync.Mutex
-	closed     bool
+	pluginRuntimeRegistry *pluginRuntimeRegistry
+	auditClose            func(context.Context) error
+	mu                    sync.Mutex
+	closed                bool
 }
 
 func (r *Result) Start(ctx context.Context) error {
@@ -252,6 +260,7 @@ func (r *Result) Close(ctx context.Context) error {
 		closeS3s(r.ExtraS3s...),
 		closeWorkflows(r.ExtraWorkflows...),
 		closeSecretManager(r.SecretManager),
+		closePluginRuntimeRegistry(r.pluginRuntimeRegistry),
 	)
 	if r.auditClose != nil {
 		errs = append(errs, r.auditClose(ctx))
@@ -339,6 +348,8 @@ type preparedCore struct {
 	SecretManager         core.SecretManager
 	Telemetry             core.TelemetryProvider
 	Deps                  Deps
+
+	pluginRuntimeRegistry *pluginRuntimeRegistry
 }
 
 type configSecretManagers struct {
@@ -590,6 +601,8 @@ func prepareCore(ctx context.Context, cfg *config.Config, factories *FactoryRegi
 		_ = closeAuthProviders(authProviders)
 		return nil, err
 	}
+	runtimeRegistry := newPluginRuntimeRegistry(cfg, factories.PluginRuntimes, deps)
+	deps.PluginRuntimeRegistry = runtimeRegistry
 
 	closeSM = false
 	shutdownTelemetry = false
@@ -608,6 +621,7 @@ func prepareCore(ctx context.Context, cfg *config.Config, factories *FactoryRegi
 		SecretManager:         sm,
 		Telemetry:             tp,
 		Deps:                  deps,
+		pluginRuntimeRegistry: runtimeRegistry,
 	}, nil
 }
 
@@ -628,6 +642,7 @@ func (p *preparedCore) Close(ctx context.Context) error {
 		closeIndexedDBs(p.ExtraIndexedDBs...),
 		closeS3s(p.ExtraS3s...),
 		closeSecretManager(p.SecretManager),
+		closePluginRuntimeRegistry(p.pluginRuntimeRegistry),
 	)
 	if p.Telemetry != nil {
 		errs = append(errs, p.Telemetry.Shutdown(ctx))
@@ -746,6 +761,7 @@ func Bootstrap(ctx context.Context, cfg *config.Config, factories *FactoryRegist
 		AuditSink:             audit,
 		SecretManager:         prepared.SecretManager,
 		Telemetry:             prepared.Telemetry,
+		pluginRuntimeRegistry: prepared.pluginRuntimeRegistry,
 		auditClose:            auditClose,
 	}, nil
 }

--- a/gestaltd/internal/bootstrap/executable_plugin_test.go
+++ b/gestaltd/internal/bootstrap/executable_plugin_test.go
@@ -12,6 +12,7 @@ import (
 	"slices"
 	"strconv"
 	"strings"
+	"sync"
 	"sync/atomic"
 	"testing"
 	"time"
@@ -72,42 +73,83 @@ type nestedInvokeHarness struct {
 	services *coredata.Services
 }
 
-type trackingPluginRuntime struct {
-	inner     pluginruntime.Provider
-	stopCount atomic.Int32
+type capturingPluginRuntime struct {
+	provider *pluginruntime.LocalProvider
+
+	mu            sync.Mutex
+	startRequests []pluginruntime.StartSessionRequest
+	stopCount     atomic.Int32
 }
 
-func (r *trackingPluginRuntime) Capabilities(ctx context.Context) (pluginruntime.Capabilities, error) {
-	return r.inner.Capabilities(ctx)
+func newCapturingPluginRuntime() *capturingPluginRuntime {
+	return &capturingPluginRuntime{provider: pluginruntime.NewLocalProvider()}
 }
 
-func (r *trackingPluginRuntime) StartSession(ctx context.Context, req pluginruntime.StartSessionRequest) (*pluginruntime.Session, error) {
-	return r.inner.StartSession(ctx, req)
+func (r *capturingPluginRuntime) Capabilities(ctx context.Context) (pluginruntime.Capabilities, error) {
+	return r.provider.Capabilities(ctx)
 }
 
-func (r *trackingPluginRuntime) GetSession(ctx context.Context, req pluginruntime.GetSessionRequest) (*pluginruntime.Session, error) {
-	return r.inner.GetSession(ctx, req)
+func (r *capturingPluginRuntime) StartSession(ctx context.Context, req pluginruntime.StartSessionRequest) (*pluginruntime.Session, error) {
+	r.mu.Lock()
+	r.startRequests = append(r.startRequests, pluginruntime.StartSessionRequest{
+		PluginName: req.PluginName,
+		Template:   req.Template,
+		Image:      req.Image,
+		Metadata:   cloneRuntimeMetadata(req.Metadata),
+	})
+	r.mu.Unlock()
+	return r.provider.StartSession(ctx, req)
 }
 
-func (r *trackingPluginRuntime) StopSession(ctx context.Context, req pluginruntime.StopSessionRequest) error {
+func (r *capturingPluginRuntime) GetSession(ctx context.Context, req pluginruntime.GetSessionRequest) (*pluginruntime.Session, error) {
+	return r.provider.GetSession(ctx, req)
+}
+
+func (r *capturingPluginRuntime) StopSession(ctx context.Context, req pluginruntime.StopSessionRequest) error {
 	r.stopCount.Add(1)
-	return r.inner.StopSession(ctx, req)
+	return r.provider.StopSession(ctx, req)
 }
 
-func (r *trackingPluginRuntime) BindHostService(ctx context.Context, req pluginruntime.BindHostServiceRequest) (*pluginruntime.HostServiceBinding, error) {
-	return r.inner.BindHostService(ctx, req)
+func (r *capturingPluginRuntime) BindHostService(ctx context.Context, req pluginruntime.BindHostServiceRequest) (*pluginruntime.HostServiceBinding, error) {
+	return r.provider.BindHostService(ctx, req)
 }
 
-func (r *trackingPluginRuntime) StartPlugin(ctx context.Context, req pluginruntime.StartPluginRequest) (*pluginruntime.HostedPlugin, error) {
-	return r.inner.StartPlugin(ctx, req)
+func (r *capturingPluginRuntime) StartPlugin(ctx context.Context, req pluginruntime.StartPluginRequest) (*pluginruntime.HostedPlugin, error) {
+	return r.provider.StartPlugin(ctx, req)
 }
 
-func (r *trackingPluginRuntime) DialPlugin(ctx context.Context, req pluginruntime.DialPluginRequest) (pluginruntime.HostedPluginConn, error) {
-	return r.inner.DialPlugin(ctx, req)
+func (r *capturingPluginRuntime) DialPlugin(ctx context.Context, req pluginruntime.DialPluginRequest) (pluginruntime.HostedPluginConn, error) {
+	return r.provider.DialPlugin(ctx, req)
 }
 
-func (r *trackingPluginRuntime) Close() error {
-	return r.inner.Close()
+func (r *capturingPluginRuntime) Close() error {
+	return r.provider.Close()
+}
+
+func (r *capturingPluginRuntime) startSessionRequests() []pluginruntime.StartSessionRequest {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	out := make([]pluginruntime.StartSessionRequest, len(r.startRequests))
+	for i, req := range r.startRequests {
+		out[i] = pluginruntime.StartSessionRequest{
+			PluginName: req.PluginName,
+			Template:   req.Template,
+			Image:      req.Image,
+			Metadata:   cloneRuntimeMetadata(req.Metadata),
+		}
+	}
+	return out
+}
+
+func cloneRuntimeMetadata(values map[string]string) map[string]string {
+	if len(values) == 0 {
+		return nil
+	}
+	out := make(map[string]string, len(values))
+	for key, value := range values {
+		out[key] = value
+	}
+	return out
 }
 
 type slowStopPluginRuntime struct {
@@ -156,6 +198,43 @@ type failingBindSlowStopPluginRuntime struct {
 
 func (r *failingBindSlowStopPluginRuntime) BindHostService(context.Context, pluginruntime.BindHostServiceRequest) (*pluginruntime.HostServiceBinding, error) {
 	return nil, r.err
+}
+
+type staticCapabilityPluginRuntime struct {
+	inner        pluginruntime.Provider
+	capabilities pluginruntime.Capabilities
+}
+
+func (r *staticCapabilityPluginRuntime) Capabilities(context.Context) (pluginruntime.Capabilities, error) {
+	return r.capabilities, nil
+}
+
+func (r *staticCapabilityPluginRuntime) StartSession(ctx context.Context, req pluginruntime.StartSessionRequest) (*pluginruntime.Session, error) {
+	return r.inner.StartSession(ctx, req)
+}
+
+func (r *staticCapabilityPluginRuntime) GetSession(ctx context.Context, req pluginruntime.GetSessionRequest) (*pluginruntime.Session, error) {
+	return r.inner.GetSession(ctx, req)
+}
+
+func (r *staticCapabilityPluginRuntime) StopSession(ctx context.Context, req pluginruntime.StopSessionRequest) error {
+	return r.inner.StopSession(ctx, req)
+}
+
+func (r *staticCapabilityPluginRuntime) BindHostService(ctx context.Context, req pluginruntime.BindHostServiceRequest) (*pluginruntime.HostServiceBinding, error) {
+	return r.inner.BindHostService(ctx, req)
+}
+
+func (r *staticCapabilityPluginRuntime) StartPlugin(ctx context.Context, req pluginruntime.StartPluginRequest) (*pluginruntime.HostedPlugin, error) {
+	return r.inner.StartPlugin(ctx, req)
+}
+
+func (r *staticCapabilityPluginRuntime) DialPlugin(ctx context.Context, req pluginruntime.DialPluginRequest) (pluginruntime.HostedPluginConn, error) {
+	return r.inner.DialPlugin(ctx, req)
+}
+
+func (r *staticCapabilityPluginRuntime) Close() error {
+	return r.inner.Close()
 }
 
 func TestExecutableSDKExampleProviderReceivesStartConfig(t *testing.T) {
@@ -1955,7 +2034,7 @@ func TestInjectedPluginRuntimeStopsSessionOnProviderClose(t *testing.T) {
 		},
 	})
 	manifest := newExecutableManifest("Echo", "Echoes back the input parameters")
-	runtimeProvider := &trackingPluginRuntime{inner: pluginruntime.NewLocalProvider()}
+	runtimeProvider := newCapturingPluginRuntime()
 	cfg := &config.Config{
 		Plugins: map[string]*config.ProviderEntry{
 			"echoext": {
@@ -2094,6 +2173,208 @@ func TestInjectedPluginRuntimeStopSessionTimeoutDoesNotHangBootstrapFailure(t *t
 
 	if runtimeProvider.stopCount.Load() == 0 {
 		t.Fatal("expected bootstrap failure to attempt stopping the hosted plugin runtime session")
+	}
+}
+
+func TestPluginRuntimeConfigSelectedProviderStartsSessionWithRuntimeFields(t *testing.T) {
+	t.Parallel()
+
+	type runtimeFactoryContextKey struct{}
+
+	bin := buildEchoPluginBinary(t)
+	manifestRoot := writeStaticCatalog(t, &catalog.Catalog{
+		Name: "echoext",
+		Operations: []catalog.CatalogOperation{
+			{ID: "read_env", Method: http.MethodGet, Parameters: []catalog.CatalogParameter{{Name: "name", Type: "string", Required: true}}},
+		},
+	})
+	manifest := newExecutableManifest("Echo", "Echoes back the input parameters")
+	runtimeProvider := newCapturingPluginRuntime()
+	ctxSentinel := &struct{}{}
+	var factoryContextValue any
+	factories := NewFactoryRegistry()
+	factories.PluginRuntimes[config.RuntimeProviderDriver("capture")] = func(ctx context.Context, _ string, _ *config.RuntimeProviderEntry, _ Deps) (pluginruntime.Provider, error) {
+		factoryContextValue = ctx.Value(runtimeFactoryContextKey{})
+		return runtimeProvider, nil
+	}
+	cfg := &config.Config{
+		Server: config.ServerConfig{
+			Runtime: config.ServerRuntimeConfig{Provider: "hosted"},
+		},
+		Runtime: config.RuntimeConfig{
+			Providers: map[string]*config.RuntimeProviderEntry{
+				"hosted": {
+					Driver: config.RuntimeProviderDriver("capture"),
+				},
+			},
+		},
+		Plugins: map[string]*config.ProviderEntry{
+			"echoext": {
+				Command:              bin,
+				Args:                 []string{"provider"},
+				ResolvedManifest:     manifest,
+				ResolvedManifestPath: filepath.Join(manifestRoot, "manifest.yaml"),
+				Runtime: &config.PluginRuntimeConfig{
+					Template: "python-dev",
+					Image:    "ghcr.io/valon/gestalt-python-runtime:latest",
+					Metadata: map[string]string{"tenant": "eng"},
+				},
+			},
+		},
+	}
+
+	deps := Deps{
+		PluginRuntimeRegistry: newPluginRuntimeRegistry(cfg, factories.PluginRuntimes, Deps{}),
+	}
+	buildCtx := context.WithValue(context.Background(), runtimeFactoryContextKey{}, ctxSentinel)
+	providers, _, err := buildProvidersStrict(buildCtx, cfg, factories, deps)
+	if err != nil {
+		t.Fatalf("buildProvidersStrict: %v", err)
+	}
+
+	prov, err := providers.Get("echoext")
+	if err != nil {
+		t.Fatalf("providers.Get: %v", err)
+	}
+	if _, err := prov.Execute(context.Background(), "read_env", map[string]any{"name": "PATH"}, ""); err != nil {
+		t.Fatalf("Execute read_env: %v", err)
+	}
+	if err := CloseProviders(providers); err != nil {
+		t.Fatalf("CloseProviders: %v", err)
+	}
+
+	requests := runtimeProvider.startSessionRequests()
+	if len(requests) != 1 {
+		t.Fatalf("start session requests = %d, want 1", len(requests))
+	}
+	req := requests[0]
+	if req.PluginName != "echoext" {
+		t.Fatalf("StartSession PluginName = %q, want echoext", req.PluginName)
+	}
+	if req.Template != "python-dev" {
+		t.Fatalf("StartSession Template = %q, want python-dev", req.Template)
+	}
+	if req.Image != "ghcr.io/valon/gestalt-python-runtime:latest" {
+		t.Fatalf("StartSession Image = %q", req.Image)
+	}
+	if req.Metadata["tenant"] != "eng" {
+		t.Fatalf("StartSession Metadata[tenant] = %q, want eng", req.Metadata["tenant"])
+	}
+	if req.Metadata["plugin"] != "echoext" {
+		t.Fatalf("StartSession Metadata[plugin] = %q, want echoext", req.Metadata["plugin"])
+	}
+	if factoryContextValue != ctxSentinel {
+		t.Fatalf("runtime factory context value = %#v, want %#v", factoryContextValue, ctxSentinel)
+	}
+}
+
+func TestPluginRuntimeConfigRejectsMissingHostServiceTunnelCapability(t *testing.T) {
+	t.Parallel()
+
+	bin := buildEchoPluginBinary(t)
+	manifestRoot := writeStaticCatalog(t, &catalog.Catalog{
+		Name: "echoext",
+		Operations: []catalog.CatalogOperation{
+			{ID: "read_env", Method: http.MethodGet, Parameters: []catalog.CatalogParameter{{Name: "name", Type: "string", Required: true}}},
+		},
+	})
+	manifest := newExecutableManifest("Echo", "Echoes back the input parameters")
+	runtimeProvider := &staticCapabilityPluginRuntime{
+		inner: pluginruntime.NewLocalProvider(),
+		capabilities: pluginruntime.Capabilities{
+			HostedPluginRuntime: true,
+			ProviderGRPCTunnel:  true,
+			HostnameProxyEgress: true,
+		},
+	}
+	factories := NewFactoryRegistry()
+	factories.PluginRuntimes[config.RuntimeProviderDriver("capture")] = func(context.Context, string, *config.RuntimeProviderEntry, Deps) (pluginruntime.Provider, error) {
+		return runtimeProvider, nil
+	}
+	cfg := &config.Config{
+		Server: config.ServerConfig{
+			Runtime: config.ServerRuntimeConfig{Provider: "hosted"},
+		},
+		Runtime: config.RuntimeConfig{
+			Providers: map[string]*config.RuntimeProviderEntry{
+				"hosted": {
+					Driver: config.RuntimeProviderDriver("capture"),
+				},
+			},
+		},
+		Plugins: map[string]*config.ProviderEntry{
+			"echoext": {
+				Command:              bin,
+				Args:                 []string{"provider"},
+				ResolvedManifest:     manifest,
+				ResolvedManifestPath: filepath.Join(manifestRoot, "manifest.yaml"),
+				Runtime:              &config.PluginRuntimeConfig{},
+				Invokes: []config.PluginInvocationDependency{
+					{Plugin: "other", Operation: "read"},
+				},
+			},
+		},
+	}
+
+	_, _, err := buildProvidersStrict(context.Background(), cfg, factories, Deps{
+		PluginRuntimeRegistry: newPluginRuntimeRegistry(cfg, factories.PluginRuntimes, Deps{}),
+	})
+	if err == nil || !strings.Contains(err.Error(), "host service tunnels") {
+		t.Fatalf("buildProvidersStrict error = %v, want missing host service tunnels", err)
+	}
+}
+
+func TestPluginRuntimeConfigRejectsMissingHostnameEgressCapability(t *testing.T) {
+	t.Parallel()
+
+	bin := buildEchoPluginBinary(t)
+	manifestRoot := writeStaticCatalog(t, &catalog.Catalog{
+		Name: "echoext",
+		Operations: []catalog.CatalogOperation{
+			{ID: "read_env", Method: http.MethodGet, Parameters: []catalog.CatalogParameter{{Name: "name", Type: "string", Required: true}}},
+		},
+	})
+	manifest := newExecutableManifest("Echo", "Echoes back the input parameters")
+	runtimeProvider := &staticCapabilityPluginRuntime{
+		inner: pluginruntime.NewLocalProvider(),
+		capabilities: pluginruntime.Capabilities{
+			HostedPluginRuntime: true,
+			ProviderGRPCTunnel:  true,
+			HostServiceTunnels:  true,
+		},
+	}
+	factories := NewFactoryRegistry()
+	factories.PluginRuntimes[config.RuntimeProviderDriver("capture")] = func(context.Context, string, *config.RuntimeProviderEntry, Deps) (pluginruntime.Provider, error) {
+		return runtimeProvider, nil
+	}
+	cfg := &config.Config{
+		Server: config.ServerConfig{
+			Runtime: config.ServerRuntimeConfig{Provider: "hosted"},
+		},
+		Runtime: config.RuntimeConfig{
+			Providers: map[string]*config.RuntimeProviderEntry{
+				"hosted": {
+					Driver: config.RuntimeProviderDriver("capture"),
+				},
+			},
+		},
+		Plugins: map[string]*config.ProviderEntry{
+			"echoext": {
+				Command:              bin,
+				Args:                 []string{"provider"},
+				ResolvedManifest:     manifest,
+				ResolvedManifestPath: filepath.Join(manifestRoot, "manifest.yaml"),
+				Runtime:              &config.PluginRuntimeConfig{},
+				AllowedHosts:         []string{"api.github.com"},
+			},
+		},
+	}
+
+	_, _, err := buildProvidersStrict(context.Background(), cfg, factories, Deps{
+		PluginRuntimeRegistry: newPluginRuntimeRegistry(cfg, factories.PluginRuntimes, Deps{}),
+	})
+	if err == nil || !strings.Contains(err.Error(), "hostname-based egress controls") {
+		t.Fatalf("buildProvidersStrict error = %v, want missing hostname-based egress controls", err)
 	}
 }
 

--- a/gestaltd/internal/bootstrap/plugin_runtime.go
+++ b/gestaltd/internal/bootstrap/plugin_runtime.go
@@ -1,0 +1,118 @@
+package bootstrap
+
+import (
+	"context"
+	"fmt"
+	"sync"
+
+	"github.com/valon-technologies/gestalt/server/internal/config"
+	"github.com/valon-technologies/gestalt/server/internal/pluginruntime"
+)
+
+type pluginRuntimeFactory func(ctx context.Context, name string, entry *config.RuntimeProviderEntry, deps Deps) (pluginruntime.Provider, error)
+
+type pluginRuntimeRegistry struct {
+	cfg       *config.Config
+	deps      Deps
+	factories map[config.RuntimeProviderDriver]pluginRuntimeFactory
+
+	mu        sync.Mutex
+	providers map[string]pluginruntime.Provider
+	closed    bool
+}
+
+func newPluginRuntimeRegistry(cfg *config.Config, factories map[config.RuntimeProviderDriver]pluginRuntimeFactory, deps Deps) *pluginRuntimeRegistry {
+	if cfg == nil {
+		return nil
+	}
+	return &pluginRuntimeRegistry{
+		cfg:       cfg,
+		deps:      deps,
+		factories: factories,
+		providers: make(map[string]pluginruntime.Provider, len(cfg.Runtime.Providers)),
+	}
+}
+
+func (r *pluginRuntimeRegistry) Resolve(ctx context.Context, pluginName string, entry *config.ProviderEntry) (config.EffectivePluginRuntime, pluginruntime.Provider, error) {
+	if r == nil || r.cfg == nil {
+		return config.EffectivePluginRuntime{}, nil, nil
+	}
+
+	effective, err := r.cfg.EffectivePluginRuntime(pluginName, entry)
+	if err != nil {
+		return config.EffectivePluginRuntime{}, nil, err
+	}
+	if !effective.Enabled || effective.ProviderName == "" || effective.Provider == nil {
+		return effective, nil, nil
+	}
+
+	providerName := effective.ProviderName
+	r.mu.Lock()
+	if r.closed {
+		r.mu.Unlock()
+		return config.EffectivePluginRuntime{}, nil, fmt.Errorf("plugin runtime registry is closed")
+	}
+	if provider, ok := r.providers[providerName]; ok && provider != nil {
+		r.mu.Unlock()
+		return effective, provider, nil
+	}
+	factory := r.factories[effective.Provider.Driver]
+	r.mu.Unlock()
+	if factory == nil {
+		return config.EffectivePluginRuntime{}, nil, fmt.Errorf("runtime provider %q driver %q is not registered", providerName, effective.Provider.Driver)
+	}
+
+	provider, err := factory(ctx, providerName, effective.Provider, r.deps)
+	if err != nil {
+		return config.EffectivePluginRuntime{}, nil, fmt.Errorf("build runtime provider %q: %w", providerName, err)
+	}
+
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	if r.closed {
+		_ = provider.Close()
+		return config.EffectivePluginRuntime{}, nil, fmt.Errorf("plugin runtime registry is closed")
+	}
+	if existing, ok := r.providers[providerName]; ok && existing != nil {
+		_ = provider.Close()
+		return effective, existing, nil
+	}
+	r.providers[providerName] = provider
+	return effective, provider, nil
+}
+
+func (r *pluginRuntimeRegistry) Close() error {
+	if r == nil {
+		return nil
+	}
+
+	r.mu.Lock()
+	if r.closed {
+		r.mu.Unlock()
+		return nil
+	}
+	r.closed = true
+	providers := make([]pluginruntime.Provider, 0, len(r.providers))
+	for _, provider := range r.providers {
+		if provider != nil {
+			providers = append(providers, provider)
+		}
+	}
+	r.providers = nil
+	r.mu.Unlock()
+
+	var firstErr error
+	for _, provider := range providers {
+		if err := provider.Close(); err != nil && firstErr == nil {
+			firstErr = err
+		}
+	}
+	return firstErr
+}
+
+func closePluginRuntimeRegistry(registry *pluginRuntimeRegistry) error {
+	if registry == nil {
+		return nil
+	}
+	return registry.Close()
+}

--- a/gestaltd/internal/bootstrap/provider_build.go
+++ b/gestaltd/internal/bootstrap/provider_build.go
@@ -684,11 +684,31 @@ func buildPluginProvider(ctx context.Context, name string, entry *config.Provide
 			maps.Copy(env, execEnv)
 		}
 	}
-	runtimeProvider, runtimeOwned := effectivePluginRuntime(deps)
-	session, err := runtimeProvider.StartSession(ctx, pluginruntime.StartSessionRequest{
-		PluginName: name,
-		Metadata:   map[string]string{"plugin": name},
-	})
+	runtimeConfig, runtimeProvider, runtimeOwned, err := effectivePluginRuntime(ctx, name, entry, deps)
+	if err != nil {
+		return nil, err
+	}
+	runtimeRequirements, err := pluginRuntimeRequirementsForPlugin(name, entry, deps)
+	if err != nil {
+		if runtimeOwned {
+			_ = runtimeProvider.Close()
+		}
+		return nil, err
+	}
+	runtimeCapabilities, err := runtimeProvider.Capabilities(ctx)
+	if err != nil {
+		if runtimeOwned {
+			_ = runtimeProvider.Close()
+		}
+		return nil, fmt.Errorf("query %s capabilities: %w", pluginRuntimeLabel(runtimeConfig), err)
+	}
+	if err := validatePluginRuntimeCapabilities(pluginRuntimeLabel(runtimeConfig), runtimeCapabilities, runtimeRequirements); err != nil {
+		if runtimeOwned {
+			_ = runtimeProvider.Close()
+		}
+		return nil, err
+	}
+	session, err := runtimeProvider.StartSession(ctx, buildPluginRuntimeStartSessionRequest(name, runtimeConfig))
 	if err != nil {
 		if runtimeOwned {
 			_ = runtimeProvider.Close()
@@ -767,11 +787,91 @@ func buildPluginProvider(ctx context.Context, name string, entry *config.Provide
 	return prov, nil
 }
 
-func effectivePluginRuntime(deps Deps) (pluginruntime.Provider, bool) {
+func effectivePluginRuntime(ctx context.Context, name string, entry *config.ProviderEntry, deps Deps) (config.EffectivePluginRuntime, pluginruntime.Provider, bool, error) {
 	if deps.PluginRuntime != nil {
-		return deps.PluginRuntime, false
+		runtimeConfig := config.EffectivePluginRuntime{}
+		if entry != nil && entry.Runtime != nil {
+			runtimeConfig.Template = strings.TrimSpace(entry.Runtime.Template)
+			runtimeConfig.Image = strings.TrimSpace(entry.Runtime.Image)
+			runtimeConfig.Metadata = maps.Clone(entry.Runtime.Metadata)
+		}
+		return runtimeConfig, deps.PluginRuntime, false, nil
 	}
-	return pluginruntime.NewLocalProvider(), true
+	if deps.PluginRuntimeRegistry != nil {
+		runtimeConfig, runtimeProvider, err := deps.PluginRuntimeRegistry.Resolve(ctx, name, entry)
+		if err != nil {
+			return config.EffectivePluginRuntime{}, nil, false, err
+		}
+		if runtimeProvider != nil {
+			return runtimeConfig, runtimeProvider, false, nil
+		}
+		if runtimeConfig.Enabled {
+			return runtimeConfig, pluginruntime.NewLocalProvider(), true, nil
+		}
+	}
+	return config.EffectivePluginRuntime{}, pluginruntime.NewLocalProvider(), true, nil
+}
+
+type pluginRuntimeCapabilityRequirements struct {
+	HostServiceTunnels  bool
+	HostnameProxyEgress bool
+}
+
+func pluginRuntimeRequirementsForPlugin(name string, entry *config.ProviderEntry, deps Deps) (pluginRuntimeCapabilityRequirements, error) {
+	if entry == nil {
+		return pluginRuntimeCapabilityRequirements{}, nil
+	}
+	effectiveIndexedDB, err := config.ResolveEffectivePluginIndexedDB(name, entry, deps.SelectedIndexedDBName, deps.IndexedDBDefs)
+	if err != nil {
+		return pluginRuntimeCapabilityRequirements{}, err
+	}
+	return pluginRuntimeCapabilityRequirements{
+		HostServiceTunnels:  effectiveIndexedDB.Enabled || len(entry.Cache) > 0 || len(entry.S3) > 0 || len(entry.Invokes) > 0,
+		HostnameProxyEgress: len(entry.AllowedHosts) > 0,
+	}, nil
+}
+
+func pluginRuntimeLabel(runtimeConfig config.EffectivePluginRuntime) string {
+	if name := strings.TrimSpace(runtimeConfig.ProviderName); name != "" {
+		return fmt.Sprintf("runtime provider %q", name)
+	}
+	return "plugin runtime"
+}
+
+func validatePluginRuntimeCapabilities(label string, caps pluginruntime.Capabilities, req pluginRuntimeCapabilityRequirements) error {
+	var missing []string
+	if !caps.HostedPluginRuntime {
+		missing = append(missing, "hosted plugin execution")
+	}
+	if !caps.ProviderGRPCTunnel {
+		missing = append(missing, "provider gRPC tunneling")
+	}
+	if req.HostServiceTunnels && !caps.HostServiceTunnels {
+		missing = append(missing, "host service tunnels")
+	}
+	if req.HostnameProxyEgress && !caps.HostnameProxyEgress {
+		missing = append(missing, "hostname-based egress controls")
+	}
+	if len(missing) == 0 {
+		return nil
+	}
+	return fmt.Errorf("%s is missing required capabilities: %s", label, strings.Join(missing, ", "))
+}
+
+func buildPluginRuntimeStartSessionRequest(name string, runtimeConfig config.EffectivePluginRuntime) pluginruntime.StartSessionRequest {
+	metadata := maps.Clone(runtimeConfig.Metadata)
+	if metadata == nil {
+		metadata = map[string]string{}
+	}
+	if name != "" {
+		metadata["plugin"] = name
+	}
+	return pluginruntime.StartSessionRequest{
+		PluginName: name,
+		Template:   runtimeConfig.Template,
+		Image:      runtimeConfig.Image,
+		Metadata:   metadata,
+	}
 }
 
 const pluginRuntimeStopTimeout = 3 * time.Second

--- a/gestaltd/internal/config/config.go
+++ b/gestaltd/internal/config/config.go
@@ -61,6 +61,7 @@ type Config struct {
 	Server        ServerConfig              `yaml:"server"`
 	Authorization AuthorizationConfig       `yaml:"authorization,omitempty"`
 	Providers     ProvidersConfig           `yaml:"providers"`
+	Runtime       RuntimeConfig             `yaml:"runtime,omitempty"`
 	Workflows     WorkflowsConfig           `yaml:"workflows,omitempty"`
 	Plugins       map[string]*ProviderEntry `yaml:"plugins,omitempty"`
 }
@@ -76,6 +77,20 @@ type ProvidersConfig struct {
 	Cache          map[string]*ProviderEntry `yaml:"cache,omitempty"`
 	S3             map[string]*ProviderEntry `yaml:"s3,omitempty"`
 	Workflow       map[string]*ProviderEntry `yaml:"workflow,omitempty"`
+}
+
+type RuntimeConfig struct {
+	Providers map[string]*RuntimeProviderEntry `yaml:"providers,omitempty"`
+}
+
+type RuntimeProviderDriver string
+
+const RuntimeProviderDriverLocal RuntimeProviderDriver = "local"
+
+type RuntimeProviderEntry struct {
+	Driver  RuntimeProviderDriver `yaml:"driver,omitempty"`
+	Default bool                  `yaml:"default,omitempty"`
+	Config  yaml.Node             `yaml:"config,omitempty"`
 }
 
 type HostProviderKind string
@@ -309,6 +324,7 @@ type ProviderEntry struct {
 	IndexedDB         *PluginIndexedDBConfig        `yaml:"indexeddb,omitempty"`
 	Cache             []string                      `yaml:"cache,omitempty"`
 	S3                []string                      `yaml:"s3,omitempty"`
+	Runtime           *PluginRuntimeConfig          `yaml:"runtime,omitempty"`
 	Surfaces          *ProviderSurfaceOverrides     `yaml:"surfaces,omitempty"`
 	MCP               bool                          `yaml:"mcp,omitempty"`
 
@@ -381,6 +397,13 @@ type PluginIndexedDBConfig struct {
 	Provider     string   `yaml:"provider,omitempty"`
 	DB           string   `yaml:"db,omitempty"`
 	ObjectStores []string `yaml:"objectStores,omitempty"`
+}
+
+type PluginRuntimeConfig struct {
+	Provider string            `yaml:"provider,omitempty"`
+	Template string            `yaml:"template,omitempty"`
+	Image    string            `yaml:"image,omitempty"`
+	Metadata map[string]string `yaml:"metadata,omitempty"`
 }
 
 type WorkflowsConfig struct {
@@ -700,8 +723,13 @@ type ServerConfig struct {
 	APITokenTTL   string                   `yaml:"apiTokenTtl"`
 	ArtifactsDir  string                   `yaml:"artifactsDir"`
 	Providers     ServerProvidersConfig    `yaml:"providers,omitempty"`
+	Runtime       ServerRuntimeConfig      `yaml:"runtime,omitempty"`
 	Egress        EgressConfig             `yaml:"egress,omitempty"`
 	Admin         AdminConfig              `yaml:"admin,omitempty"`
+}
+
+type ServerRuntimeConfig struct {
+	Provider string `yaml:"provider,omitempty"`
 }
 
 func (s ServerConfig) PublicListener() ListenerConfig {

--- a/gestaltd/internal/config/config_validate.go
+++ b/gestaltd/internal/config/config_validate.go
@@ -68,6 +68,9 @@ func ValidateCanonicalStructure(cfg *Config) error {
 	if err := validateEgress(&cfg.Server.Egress); err != nil {
 		return err
 	}
+	if err := validateRuntimeConfig(cfg); err != nil {
+		return err
+	}
 
 	for _, collection := range []struct {
 		kind    HostProviderKind
@@ -393,6 +396,29 @@ func ValidateRuntime(cfg *Config) error {
 	return nil
 }
 
+func validateRuntimeConfig(cfg *Config) error {
+	if cfg == nil {
+		return nil
+	}
+	cfg.Server.Runtime.Provider = strings.TrimSpace(cfg.Server.Runtime.Provider)
+	for name, entry := range cfg.Runtime.Providers {
+		if entry == nil {
+			return fmt.Errorf("config validation: runtime.providers.%s is required", name)
+		}
+		entry.Driver = RuntimeProviderDriver(strings.TrimSpace(string(entry.Driver)))
+		if entry.Driver == "" {
+			return fmt.Errorf("config validation: runtime.providers.%s.driver is required", name)
+		}
+		if entry.Driver == RuntimeProviderDriverLocal && entry.Config.Kind != 0 {
+			return fmt.Errorf("config validation: runtime.providers.%s.config is not supported when driver is %q", name, RuntimeProviderDriverLocal)
+		}
+	}
+	if _, _, err := cfg.SelectedRuntimeProvider(); err != nil {
+		return err
+	}
+	return nil
+}
+
 func validatePlugin(cfg *Config, name string, entry *ProviderEntry, sourceSyntax providerSourceSyntaxMode) error {
 	if entry == nil {
 		return fmt.Errorf("config validation: plugin %q requires a source", name)
@@ -407,6 +433,22 @@ func validatePlugin(cfg *Config, name string, entry *ProviderEntry, sourceSyntax
 		entry.IndexedDB.DB = strings.TrimSpace(entry.IndexedDB.DB)
 		for i, store := range entry.IndexedDB.ObjectStores {
 			entry.IndexedDB.ObjectStores[i] = strings.TrimSpace(store)
+		}
+	}
+	if entry.Runtime != nil {
+		entry.Runtime.Provider = strings.TrimSpace(entry.Runtime.Provider)
+		entry.Runtime.Template = strings.TrimSpace(entry.Runtime.Template)
+		entry.Runtime.Image = strings.TrimSpace(entry.Runtime.Image)
+		trimmed := make(map[string]string, len(entry.Runtime.Metadata))
+		for key, value := range entry.Runtime.Metadata {
+			trimmedKey := strings.TrimSpace(key)
+			if trimmedKey == "" {
+				return fmt.Errorf("config validation: plugins.%s.runtime.metadata keys must be non-empty", name)
+			}
+			trimmed[trimmedKey] = strings.TrimSpace(value)
+		}
+		if entry.Runtime.Metadata != nil {
+			entry.Runtime.Metadata = trimmed
 		}
 	}
 	seenInvokes := make(map[string]int, len(entry.Invokes))
@@ -444,6 +486,9 @@ func validatePlugin(cfg *Config, name string, entry *ProviderEntry, sourceSyntax
 		return err
 	}
 	if err := validateAuthorizationPolicyReference(cfg, "plugin", name, entry.AuthorizationPolicy); err != nil {
+		return err
+	}
+	if _, err := cfg.EffectivePluginRuntime(name, entry); err != nil {
 		return err
 	}
 	return validateManifestBackedIntegration(name, entry)
@@ -581,6 +626,9 @@ func validateWorkflowProviderFields(cfg *Config, name string, entry *ProviderEnt
 	if len(entry.Invokes) > 0 {
 		return fmt.Errorf("config validation: %s.invokes is only supported on plugins.*", subject)
 	}
+	if entry.Runtime != nil {
+		return fmt.Errorf("config validation: %s.runtime is only supported on plugins.*", subject)
+	}
 	if entry.Surfaces != nil {
 		return fmt.Errorf("config validation: %s.surfaces is only supported on plugins.*", subject)
 	}
@@ -631,6 +679,9 @@ func validatePluginOnlyProviderFields(subject string, entry *ProviderEntry) erro
 	}
 	if len(entry.Invokes) > 0 {
 		return fmt.Errorf("config validation: %s.invokes is only supported on plugins.*", subject)
+	}
+	if entry.Runtime != nil {
+		return fmt.Errorf("config validation: %s.runtime is only supported on plugins.*", subject)
 	}
 	if entry.Surfaces != nil {
 		return fmt.Errorf("config validation: %s.surfaces is only supported on plugins.*", subject)

--- a/gestaltd/internal/config/provider_selection.go
+++ b/gestaltd/internal/config/provider_selection.go
@@ -2,6 +2,7 @@ package config
 
 import (
 	"fmt"
+	"maps"
 	"slices"
 	"sort"
 	"strings"
@@ -88,6 +89,13 @@ func (c *Config) SelectedWorkflowProvider() (string, *ProviderEntry, error) {
 	return ResolveSelectedHostProvider(HostProviderKindWorkflow, "", c.HostProviderEntries(HostProviderKindWorkflow))
 }
 
+func (c *Config) SelectedRuntimeProvider() (string, *RuntimeProviderEntry, error) {
+	if c == nil {
+		return "", nil, nil
+	}
+	return ResolveSelectedRuntimeProvider(c.Server.Runtime.Provider, c.Runtime.Providers)
+}
+
 type EffectivePluginIndexedDB struct {
 	Enabled      bool
 	ProviderName string
@@ -102,6 +110,15 @@ type EffectiveWorkflowIndexedDB struct {
 	Provider     *ProviderEntry
 	DB           string
 	ObjectStores []string
+}
+
+type EffectivePluginRuntime struct {
+	Enabled      bool
+	ProviderName string
+	Provider     *RuntimeProviderEntry
+	Template     string
+	Image        string
+	Metadata     map[string]string
 }
 
 func (c *Config) EffectivePluginIndexedDB(pluginName string, entry *ProviderEntry) (EffectivePluginIndexedDB, error) {
@@ -129,6 +146,14 @@ func (c *Config) EffectiveWorkflowProvider(providerName string) (string, *Provid
 
 func (c *Config) EffectiveWorkflowIndexedDB(name string, entry *ProviderEntry) (EffectiveWorkflowIndexedDB, error) {
 	return ResolveEffectiveWorkflowIndexedDB(name, entry, c.Providers.IndexedDB)
+}
+
+func (c *Config) EffectivePluginRuntime(pluginName string, entry *ProviderEntry) (EffectivePluginRuntime, error) {
+	selectedName, _, err := c.SelectedRuntimeProvider()
+	if err != nil {
+		return EffectivePluginRuntime{}, err
+	}
+	return ResolveEffectivePluginRuntime(pluginName, entry, selectedName, c.Runtime.Providers)
 }
 
 func ResolveEffectivePluginIndexedDB(pluginName string, entry *ProviderEntry, selectedName string, entries map[string]*ProviderEntry) (EffectivePluginIndexedDB, error) {
@@ -203,6 +228,35 @@ func ResolveEffectiveWorkflowIndexedDB(name string, entry *ProviderEntry, entrie
 	}, nil
 }
 
+func ResolveEffectivePluginRuntime(pluginName string, entry *ProviderEntry, selectedName string, entries map[string]*RuntimeProviderEntry) (EffectivePluginRuntime, error) {
+	if entry == nil || entry.Runtime == nil {
+		return EffectivePluginRuntime{}, nil
+	}
+
+	providerName := strings.TrimSpace(entry.Runtime.Provider)
+	if providerName == "" {
+		providerName = strings.TrimSpace(selectedName)
+	}
+
+	var provider *RuntimeProviderEntry
+	if providerName != "" {
+		var ok bool
+		provider, ok = entries[providerName]
+		if !ok || provider == nil {
+			return EffectivePluginRuntime{}, fmt.Errorf("config validation: plugins.%s.runtime.provider references unknown runtime %q", pluginName, providerName)
+		}
+	}
+
+	runtime := EffectivePluginRuntime{
+		Enabled:      true,
+		ProviderName: providerName,
+		Provider:     provider,
+		Template:     strings.TrimSpace(entry.Runtime.Template),
+		Image:        strings.TrimSpace(entry.Runtime.Image),
+		Metadata:     maps.Clone(entry.Runtime.Metadata),
+	}
+	return runtime, nil
+}
 func ResolveSelectedHostProvider(kind HostProviderKind, explicit string, entries map[string]*ProviderEntry) (string, *ProviderEntry, error) {
 	if len(entries) == 0 {
 		return "", nil, nil
@@ -241,5 +295,43 @@ func ResolveSelectedHostProvider(kind HostProviderKind, explicit string, entries
 	default:
 		sort.Strings(names)
 		return "", nil, fmt.Errorf("config validation: providers.%s has multiple providers but no selection or default: %s", kind, strings.Join(names, ", "))
+	}
+}
+
+func ResolveSelectedRuntimeProvider(explicit string, entries map[string]*RuntimeProviderEntry) (string, *RuntimeProviderEntry, error) {
+	explicit = strings.TrimSpace(explicit)
+	if explicit != "" {
+		if len(entries) == 0 {
+			return "", nil, fmt.Errorf("config validation: server.runtime.provider references unknown runtime %q", explicit)
+		}
+		entry, ok := entries[explicit]
+		if !ok || entry == nil {
+			return "", nil, fmt.Errorf("config validation: server.runtime.provider references unknown runtime %q", explicit)
+		}
+		return explicit, entry, nil
+	}
+	if len(entries) == 0 {
+		return "", nil, nil
+	}
+
+	defaultNames := make([]string, 0, len(entries))
+	for name, entry := range entries {
+		if entry == nil {
+			continue
+		}
+		if entry.Default {
+			defaultNames = append(defaultNames, name)
+		}
+	}
+
+	switch {
+	case len(defaultNames) == 1:
+		name := defaultNames[0]
+		return name, entries[name], nil
+	case len(defaultNames) > 1:
+		sort.Strings(defaultNames)
+		return "", nil, fmt.Errorf("config validation: runtime.providers declares multiple defaults: %s", strings.Join(defaultNames, ", "))
+	default:
+		return "", nil, nil
 	}
 }

--- a/gestaltd/internal/pluginruntime/local.go
+++ b/gestaltd/internal/pluginruntime/local.go
@@ -127,25 +127,18 @@ func (p *LocalProvider) StopSession(_ context.Context, req StopSessionRequest) e
 	}
 	p.mu.Unlock()
 
+	var errs []error
 	if plugin != nil {
-		err := plugin.Close()
-		if rootDir == "" {
-			return err
+		if err := plugin.Close(); err != nil {
+			errs = append(errs, err)
 		}
-		if cleanupErr := os.RemoveAll(rootDir); cleanupErr != nil {
-			if err != nil {
-				return errors.Join(err, fmt.Errorf("remove runtime session dir: %w", cleanupErr))
-			}
-			return fmt.Errorf("remove runtime session dir: %w", cleanupErr)
-		}
-		return err
 	}
 	if rootDir != "" {
 		if err := os.RemoveAll(rootDir); err != nil {
-			return fmt.Errorf("remove runtime session dir: %w", err)
+			errs = append(errs, fmt.Errorf("remove runtime session dir: %w", err))
 		}
 	}
-	return nil
+	return errors.Join(errs...)
 }
 
 func (p *LocalProvider) BindHostService(_ context.Context, req BindHostServiceRequest) (*HostServiceBinding, error) {
@@ -271,7 +264,7 @@ func (p *LocalProvider) DialPlugin(_ context.Context, req DialPluginRequest) (Ho
 	return &localHostedPluginConn{
 		process: session.plugin.process,
 		onClose: func() {
-			p.forgetSession(req.SessionID)
+			p.releaseSession(req.SessionID)
 		},
 	}, nil
 }
@@ -318,12 +311,17 @@ func (p *LocalProvider) sessionLocked(sessionID string) (*localSession, error) {
 	return session, nil
 }
 
-func (p *LocalProvider) forgetSession(sessionID string) {
+func (p *LocalProvider) releaseSession(sessionID string) {
+	var rootDir string
 	p.mu.Lock()
-	defer p.mu.Unlock()
 	if session, ok := p.sessions[sessionID]; ok && session != nil {
 		session.state = SessionStateStopped
+		rootDir = session.rootDir
 		delete(p.sessions, sessionID)
+	}
+	p.mu.Unlock()
+	if rootDir != "" {
+		_ = os.RemoveAll(rootDir)
 	}
 }
 

--- a/gestaltd/internal/pluginruntime/runtime.go
+++ b/gestaltd/internal/pluginruntime/runtime.go
@@ -34,6 +34,8 @@ type Session struct {
 
 type StartSessionRequest struct {
 	PluginName string
+	Template   string
+	Image      string
 	Metadata   map[string]string
 }
 


### PR DESCRIPTION
## Summary
This stacked PR adds developer-facing runtime configuration for executable plugins and wires that configuration into hosted plugin session startup.

With this slice:
- `plugins.*.runtime` becomes the opt-in surface for hosted runtime execution
- `runtime.providers` holds named hosted runtime backends
- `server.runtime.provider` selects the default named backend for plugins that opt in with `plugins.*.runtime`
- runtime session fields now flow into `pluginruntime.StartSessionRequest`
- the absence of `plugins.*.runtime` still means local same-machine execution

## New Interfaces
```go
type RuntimeConfig struct {
    Providers map[string]*RuntimeProviderEntry `yaml:"providers,omitempty"`
}

type RuntimeProviderEntry struct {
    Driver  RuntimeProviderDriver `yaml:"driver,omitempty"`
    Default bool                  `yaml:"default,omitempty"`
    Config  yaml.Node             `yaml:"config,omitempty"`
}

type ServerRuntimeConfig struct {
    Provider string `yaml:"provider,omitempty"`
}

type PluginRuntimeConfig struct {
    Provider string            `yaml:"provider,omitempty"`
    Template string            `yaml:"template,omitempty"`
    Image    string            `yaml:"image,omitempty"`
    Metadata map[string]string `yaml:"metadata,omitempty"`
}
```

```go
type StartSessionRequest struct {
    PluginName string
    Template   string
    Image      string
    Metadata   map[string]string
}
```

```go
type FactoryRegistry struct {
    PluginRuntimes map[config.RuntimeProviderDriver]pluginRuntimeFactory
    // ... existing fields omitted
}
```

## Example Configuration
This uses `server.runtime.provider` as the default backend selector, but only because the plugin opts in with a `runtime:` block.

```yaml
server:
  runtime:
    provider: hosted

runtime:
  providers:
    hosted:
      driver: capture

plugins:
  coder:
    source:
      path: ./plugins/coder
    runtime:
      template: python-dev
      image: ghcr.io/valon/gestalt-python-runtime:latest
      metadata:
        tenant: eng
```

## Example Factory Registration
```go
factories := bootstrap.NewFactoryRegistry()
factories.PluginRuntimes[config.RuntimeProviderDriver("capture")] = func(ctx context.Context, name string, entry *config.RuntimeProviderEntry, deps bootstrap.Deps) (pluginruntime.Provider, error) {
    return newHostedRuntimeClient(...), nil
}
```

The factory now receives the caller's build context rather than `context.Background()`, so backend initialization can honor cancellation and deadlines.

## Example Session Request Built For A Plugin
```go
pluginruntime.StartSessionRequest{
    PluginName: "coder",
    Template:   "python-dev",
    Image:      "ghcr.io/valon/gestalt-python-runtime:latest",
    Metadata: map[string]string{
        "plugin": "coder",
        "tenant": "eng",
    },
}
```

## Behavior
- No `plugins.*.runtime`: execute locally on the same machine.
- `plugins.*.runtime` with no explicit provider: use `server.runtime.provider` or the single/default entry in `runtime.providers`.
- `plugins.*.runtime.provider`: use that selected configured runtime backend.
- `plugins.*.runtime` with no resolved backend: still local, but through the runtime abstraction.

## Validation
- `go test ./internal/providerhost ./internal/bootstrap ./internal/pluginruntime`
