### PR TITLE
Enforce plugin route auth on HTTP operation routes

### DIFF
--- a/docs/content/reference/config-file.mdx
+++ b/docs/content/reference/config-file.mdx
@@ -831,6 +831,8 @@ plugins:
 | `mountPath` | Optional public path prefix for a plugin-backed mounted UI. When set, Gestalt mounts either `plugins.<name>.ui` or the plugin manifest's `spec.ui`. |
 | `ui` | Optional UI key from `providers.ui` used with `mountPath`. Omit it to mount the plugin manifest's owned `spec.ui`. |
 | `source` | **Required.** The backing provider source. See [source shape](#pluginssource) below. |
+| `source.auth` | Optional metadata-fetch auth for release sources. Use this for `source.url`, `source.githubRelease`, or local `provider-release.yaml` metadata. |
+| `auth` | Optional plugin route auth reference. Use `auth.provider` to reference either the reserved `server` alias or a named entry from `providers.auth`. Gestalt enforces this on plugin HTTP operation routes (`/api/v1/integrations/{name}/operations` and `/api/v1/{integration}/{operation}`). Browser login, mounted UIs, and `/mcp` still use the server-wide auth provider in this phase. |
 | `config` | Provider-specific configuration passed into the provider package. |
 | `surfaces` | Typed host-side overrides for manifest-declared surfaces, such as `surfaces.openapi.baseUrl` or `surfaces.graphql.url`. |
 | `connections` | Named connection declarations. See [connections](#connections) below. |
@@ -849,6 +851,29 @@ Every plugin uses a `source` block to declare its backing provider.
 source: https://artifacts.example.com/plugin/github/v1.2.3/provider-release.yaml
 ```
 
+Canonical metadata-source auth lives under `source.auth`. For direct metadata URLs:
+
+```yaml
+source:
+  url: https://artifacts.example.com/plugin/github/v1.2.3/provider-release.yaml
+  auth:
+    token: ${PLUGIN_RELEASE_TOKEN}
+```
+
+Plugin route auth overrides are declared separately:
+
+```yaml
+apiVersion: gestaltd.config/v4
+plugins:
+  slack_bot:
+    source: ./dist/provider-release.yaml
+    auth:
+      provider: server
+```
+
+This field changes runtime authentication for plugin HTTP operation routes only.
+Browser login, mounted UIs, integration OAuth helper routes, and `/mcp` still
+use the server-wide auth provider in this phase.
 For published providers, `source` can point at a `provider-release.yaml`
 metadata URL directly, or it can describe a GitHub release logically:
 
@@ -914,8 +939,9 @@ Gestalt synthesizes Go and Rust executable wrappers automatically when needed an
 
 | Field | Description |
 | --- | --- |
-| `source` | A local provider manifest path, a published `provider-release.yaml` metadata URL, or `source.githubRelease` for a GitHub-hosted release asset. |
-| `auth` | Optional inline source auth for remote release sources, including direct metadata URLs and `source.githubRelease`. |
+| `source` | A local provider manifest path, a published `provider-release.yaml` metadata URL, `source.url`, or `source.githubRelease` for a GitHub-hosted release asset. |
+| `source.auth` | Optional metadata-fetch auth for release sources, including direct metadata URLs, `source.githubRelease`, and local `provider-release.yaml` metadata. |
+| `auth` | Optional plugin route auth reference. Use `auth.provider` to reference either `server` or a named `providers.auth` entry. Gestalt enforces this on plugin HTTP operation routes only; browser login, mounted UIs, and `/mcp` still use the server-wide auth provider in this phase. |
 | `env` | Extra environment variables passed to the provider process. |
 | `allowedHosts` | Outbound host allowlist. For executable plugins, this is only a complete boundary when a supported sandboxed runtime is active. |
 

--- a/docs/content/reference/plugin-manifests.mdx
+++ b/docs/content/reference/plugin-manifests.mdx
@@ -177,7 +177,7 @@ The `rest`/`openapi`/`graphql` surface types are mutually exclusive (use `surfac
 
 ### Auth Types
 
-`spec.auth.provider` selects a route-auth provider for mounted plugin routes. Upstream auth still lives on `spec.connections.<name>.auth`, and the `auth.type` field on a connection accepts these values:
+`spec.auth.provider` selects a route-auth provider for plugin HTTP operation routes. Gestalt currently enforces it on `/api/v1/integrations/{name}/operations` and `/api/v1/{integration}/{operation}` only; browser login, mounted UIs, integration OAuth helper routes, and `/mcp` still use the server-wide auth provider. Upstream auth still lives on `spec.connections.<name>.auth`, and the `auth.type` field on a connection accepts these values:
 
 | Type | Purpose |
 | --- | --- |

--- a/gestaltd/internal/bootstrap/bootstrap.go
+++ b/gestaltd/internal/bootstrap/bootstrap.go
@@ -177,6 +177,8 @@ func NewFactoryRegistry() *FactoryRegistry {
 
 type Result struct {
 	Auth                  core.AuthProvider
+	SelectedAuthProvider  string
+	AuthProviders         map[string]core.AuthProvider
 	AuthorizationProvider core.AuthorizationProvider
 	Services              *coredata.Services
 	ExtraIndexedDBs       []indexeddb.IndexedDB
@@ -234,9 +236,13 @@ func (r *Result) Close(ctx context.Context) error {
 	}
 
 	var errs []error
+	authCloseErr := closeAuth(r.Auth)
+	if len(r.AuthProviders) != 0 {
+		authCloseErr = closeAuthProviders(r.AuthProviders)
+	}
 	errs = append(errs,
 		closeAuthorizer(r.Authorizer),
-		closeAuth(r.Auth),
+		authCloseErr,
 		closeAuthorizationProvider(r.AuthorizationProvider),
 		CloseProviders(r.Providers),
 		r.Services.Close(),
@@ -322,6 +328,8 @@ func (p *workflowProviderWithCleanup) Close() error {
 
 type preparedCore struct {
 	Auth                  core.AuthProvider
+	SelectedAuthProvider  string
+	AuthProviders         map[string]core.AuthProvider
 	AuthorizationProvider core.AuthorizationProvider
 	Services              *coredata.Services
 	ExtraIndexedDBs       []indexeddb.IndexedDB
@@ -483,10 +491,11 @@ func prepareCore(ctx context.Context, cfg *config.Config, factories *FactoryRegi
 	workflowRuntime.InitProviderPlaceholders(cfg.Providers.Workflow)
 	deps.WorkflowRuntime = workflowRuntime
 
-	auth, err := buildAuth(cfg, factories, deps)
+	selectedAuthName, authProviders, err := buildAuthProviders(cfg, factories, deps)
 	if err != nil {
 		return nil, err
 	}
+	auth := authProviders[selectedAuthName]
 	var authzProvider core.AuthorizationProvider
 	closeAuthorizationOnError := true
 	defer func() {
@@ -576,7 +585,7 @@ func prepareCore(ctx context.Context, cfg *config.Config, factories *FactoryRegi
 
 	authzProvider, err = buildAuthorization(cfg, factories, deps)
 	if err != nil {
-		_ = closeAuth(auth)
+		_ = closeAuthProviders(authProviders)
 		return nil, err
 	}
 
@@ -588,6 +597,8 @@ func prepareCore(ctx context.Context, cfg *config.Config, factories *FactoryRegi
 	closeAuthorizationOnError = false
 	return &preparedCore{
 		Auth:                  auth,
+		SelectedAuthProvider:  selectedAuthName,
+		AuthProviders:         authProviders,
 		AuthorizationProvider: authzProvider,
 		Services:              svc,
 		ExtraIndexedDBs:       extraIndexedDBs,
@@ -604,8 +615,12 @@ func (p *preparedCore) Close(ctx context.Context) error {
 	}
 
 	var errs []error
+	authCloseErr := closeAuth(p.Auth)
+	if len(p.AuthProviders) != 0 {
+		authCloseErr = closeAuthProviders(p.AuthProviders)
+	}
 	errs = append(errs,
-		closeAuth(p.Auth),
+		authCloseErr,
 		closeAuthorizationProvider(p.AuthorizationProvider),
 		p.Services.Close(),
 		closeIndexedDBs(p.ExtraIndexedDBs...),
@@ -717,6 +732,8 @@ func Bootstrap(ctx context.Context, cfg *config.Config, factories *FactoryRegist
 	closeWorkflowsOnError = false
 	return &Result{
 		Auth:                  prepared.Auth,
+		SelectedAuthProvider:  prepared.SelectedAuthProvider,
+		AuthProviders:         prepared.AuthProviders,
 		AuthorizationProvider: prepared.AuthorizationProvider,
 		Services:              prepared.Services,
 		ExtraIndexedDBs:       prepared.ExtraIndexedDBs,
@@ -885,6 +902,20 @@ func closeAuth(provider core.AuthProvider) error {
 	return closer.Close()
 }
 
+func closeAuthProviders(providers map[string]core.AuthProvider) error {
+	if len(providers) == 0 {
+		return nil
+	}
+	var errs []error
+	for _, provider := range providers {
+		if provider == nil {
+			continue
+		}
+		errs = append(errs, closeAuth(provider))
+	}
+	return errors.Join(errs...)
+}
+
 func closeAuthorizer(authorizer authorization.RuntimeAuthorizer) error {
 	if authorizer == nil {
 		return nil
@@ -908,28 +939,47 @@ func closeSecretManager(sm core.SecretManager) error {
 	return closer.Close()
 }
 
-func buildAuth(cfg *config.Config, factories *FactoryRegistry, deps Deps) (core.AuthProvider, error) {
-	_, authEntry, err := cfg.SelectedAuthProvider()
+func buildAuthProviders(cfg *config.Config, factories *FactoryRegistry, deps Deps) (string, map[string]core.AuthProvider, error) {
+	selectedName, _, err := cfg.SelectedAuthProvider()
 	if err != nil {
-		return nil, err
+		return "", nil, err
 	}
-	if authEntry == nil {
-		return nil, nil
+	if len(cfg.Providers.Auth) == 0 {
+		return selectedName, nil, nil
 	}
 	if factories.Auth == nil {
-		return nil, fmt.Errorf("bootstrap: auth factory is not registered")
+		return "", nil, fmt.Errorf("bootstrap: auth factory is not registered")
+	}
+	providers := make(map[string]core.AuthProvider, len(cfg.Providers.Auth))
+	for name, authEntry := range cfg.Providers.Auth {
+		if authEntry == nil {
+			continue
+		}
+		auth, err := buildNamedAuthProvider(name, authEntry, factories, deps)
+		if err != nil {
+			_ = closeAuthProviders(providers)
+			return "", nil, err
+		}
+		providers[name] = auth
+	}
+	return selectedName, providers, nil
+}
+
+func buildNamedAuthProvider(name string, authEntry *config.ProviderEntry, factories *FactoryRegistry, deps Deps) (core.AuthProvider, error) {
+	if authEntry == nil {
+		return nil, nil
 	}
 	node := authEntry.Config
 	if !config.IsComponentRuntimeConfigNode(node) {
 		var err error
-		node, err = config.BuildComponentRuntimeConfigNode("auth", "auth", authEntry, authEntry.Config)
+		node, err = config.BuildComponentRuntimeConfigNode(name, "auth", authEntry, authEntry.Config)
 		if err != nil {
-			return nil, fmt.Errorf("bootstrap: auth provider: %w", err)
+			return nil, fmt.Errorf("bootstrap: auth provider %q: %w", name, err)
 		}
 	}
 	auth, err := factories.Auth(node, deps)
 	if err != nil {
-		return nil, fmt.Errorf("bootstrap: auth provider: %w", err)
+		return nil, fmt.Errorf("bootstrap: auth provider %q: %w", name, err)
 	}
 	return auth, nil
 }

--- a/gestaltd/internal/server/audit_metadata_test.go
+++ b/gestaltd/internal/server/audit_metadata_test.go
@@ -192,9 +192,12 @@ func TestAuditMetadata_AuthMiddlewareFailures(t *testing.T) {
 		body           string
 		authHeader     string
 		withMCPHandler bool
+		pluginName     string
+		routeAuth      string
 		wantSource     string
 		wantError      string
 		wantAuthSource string
+		wantProvider   string
 	}{
 		{
 			name:       "missing_http_auth",
@@ -223,6 +226,16 @@ func TestAuditMetadata_AuthMiddlewareFailures(t *testing.T) {
 			wantError:      "invalid token",
 			wantAuthSource: "session",
 		},
+		{
+			name:         "missing_plugin_route_auth_uses_named_provider_in_audit",
+			method:       http.MethodGet,
+			path:         "/api/v1/locked/ping",
+			pluginName:   "locked",
+			routeAuth:    "alt",
+			wantSource:   "http",
+			wantError:    "missing authorization",
+			wantProvider: "alt",
+		},
 	}
 
 	for _, tc := range testCases {
@@ -242,6 +255,26 @@ func TestAuditMetadata_AuthMiddlewareFailures(t *testing.T) {
 				}
 				cfg.AuditSink = auditSink
 				cfg.Services = coretesting.NewStubServices(t)
+				if tc.pluginName != "" {
+					cfg.AuthProviders = map[string]core.AuthProvider{
+						tc.routeAuth: &coretesting.StubAuthProvider{
+							N: tc.routeAuth,
+							ValidateTokenFn: func(_ context.Context, _ string) (*core.UserIdentity, error) {
+								return nil, fmt.Errorf("invalid token")
+							},
+						},
+					}
+					cfg.PluginDefs = map[string]*config.ProviderEntry{
+						tc.pluginName: {RouteAuth: &config.RouteAuthDef{Provider: tc.routeAuth}},
+					}
+					cfg.Providers = testutil.NewProviderRegistry(t, &stubIntegrationWithOps{
+						StubIntegration: coretesting.StubIntegration{
+							N:        tc.pluginName,
+							ConnMode: core.ConnectionModeNone,
+						},
+						ops: []core.Operation{{Name: "ping", Method: http.MethodGet}},
+					})
+				}
 				if tc.withMCPHandler {
 					cfg.MCPHandler = http.HandlerFunc(func(http.ResponseWriter, *http.Request) {
 						t.Fatal("unexpected MCP handler invocation")
@@ -290,8 +323,8 @@ func TestAuditMetadata_AuthMiddlewareFailures(t *testing.T) {
 			if record["error"] != tc.wantError {
 				t.Fatalf("expected error %q, got %v", tc.wantError, record["error"])
 			}
-			if record["provider"] != "" {
-				t.Fatalf("expected empty provider, got %v", record["provider"])
+			if record["provider"] != tc.wantProvider {
+				t.Fatalf("expected provider %q, got %v", tc.wantProvider, record["provider"])
 			}
 			if tc.wantAuthSource == "" {
 				if authSource, ok := record["auth_source"]; ok && authSource != "" {

--- a/gestaltd/internal/server/middleware.go
+++ b/gestaltd/internal/server/middleware.go
@@ -7,6 +7,7 @@ import (
 	"net/http"
 	"strings"
 
+	"github.com/go-chi/chi/v5"
 	"github.com/valon-technologies/gestalt/server/core"
 	"github.com/valon-technologies/gestalt/server/internal/invocation"
 	"github.com/valon-technologies/gestalt/server/internal/principal"
@@ -127,11 +128,11 @@ func requestedAuthSource(r *http.Request) string {
 	return ""
 }
 
-func (s *Server) resolveRequestPrincipal(r *http.Request) (*principal.Principal, error) {
+func (s *Server) resolveRequestPrincipalWithResolver(r *http.Request, resolver *principal.Resolver) (*principal.Principal, error) {
 	var lastErr error
 
 	if c, err := r.Cookie(sessionCookieName); err == nil && c.Value != "" {
-		p, err := s.resolver.ResolveToken(r.Context(), c.Value)
+		p, err := resolver.ResolveToken(r.Context(), c.Value)
 		if p != nil && p.Kind != principal.KindWorkload {
 			return p, nil
 		}
@@ -150,7 +151,7 @@ func (s *Server) resolveRequestPrincipal(r *http.Request) (*principal.Principal,
 		return nil, lastErr
 	}
 
-	p, err := s.resolver.ResolveToken(r.Context(), token)
+	p, err := resolver.ResolveToken(r.Context(), token)
 	if p != nil {
 		return p, nil
 	}
@@ -158,6 +159,10 @@ func (s *Server) resolveRequestPrincipal(r *http.Request) (*principal.Principal,
 		lastErr = err
 	}
 	return nil, lastErr
+}
+
+func (s *Server) resolveRequestPrincipal(r *http.Request) (*principal.Principal, error) {
+	return s.resolveRequestPrincipalWithResolver(r, s.resolver)
 }
 
 func (s *Server) resolveRequestPrincipalWithUserID(r *http.Request) (*principal.Principal, error) {
@@ -168,48 +173,85 @@ func (s *Server) resolveRequestPrincipalWithUserID(r *http.Request) (*principal.
 	return s.resolvePrincipalUserID(r.Context(), p)
 }
 
+func (s *Server) serveAuthenticated(w http.ResponseWriter, r *http.Request, next http.Handler, resolver *principal.Resolver, noAuth bool, anonymous *principal.Principal, auditProvider string) {
+	if noAuth {
+		ctx := principal.WithPrincipal(r.Context(), anonymous)
+		next.ServeHTTP(w, r.WithContext(ctx))
+		return
+	}
+
+	p, err := s.resolveRequestPrincipalWithResolver(r, resolver)
+	if err == nil && p != nil {
+		enriched, enrichErr := s.resolvePrincipalUserID(r.Context(), p)
+		switch {
+		case enrichErr == nil && enriched != nil:
+			p = enriched
+		case enrichErr != nil:
+			slog.WarnContext(r.Context(), "auth: unable to resolve user ID", "error", enrichErr)
+		}
+		ctx := principal.WithPrincipal(r.Context(), p)
+		next.ServeHTTP(w, r.WithContext(ctx))
+		return
+	}
+
+	authSource := requestedAuthSource(r)
+	switch {
+	case err == nil:
+		s.auditRequestEventWithAuthSource(r, authSource, auditProvider, "auth.authenticate", false, errors.New("missing authorization"))
+		writeError(w, http.StatusUnauthorized, "missing authorization")
+		return
+	case errors.Is(err, errInvalidAuthorizationHeader):
+		s.auditRequestEventWithAuthSource(r, authSource, auditProvider, "auth.authenticate", false, errInvalidAuthorizationHeader)
+		writeError(w, http.StatusUnauthorized, "invalid authorization header format")
+		return
+	case errors.Is(err, principal.ErrInvalidToken):
+		slog.InfoContext(r.Context(), "auth: invalid token", "remote_addr", r.RemoteAddr)
+		s.auditRequestEventWithAuthSource(r, authSource, auditProvider, "auth.authenticate", false, principal.ErrInvalidToken)
+		writeError(w, http.StatusUnauthorized, "invalid token")
+		return
+	default:
+		slog.ErrorContext(r.Context(), "auth: token validation failed", "remote_addr", r.RemoteAddr, "error", err)
+		s.auditRequestEventWithAuthSource(r, authSource, auditProvider, "auth.authenticate", false, errors.New("token validation failed"))
+		writeError(w, http.StatusInternalServerError, "token validation failed")
+		return
+	}
+}
+
 func (s *Server) authMiddleware(next http.Handler) http.Handler {
 	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		if s.noAuth {
-			ctx := principal.WithPrincipal(r.Context(), s.anonymousPrincipal)
-			next.ServeHTTP(w, r.WithContext(ctx))
-			return
-		}
-
-		p, err := s.resolveRequestPrincipal(r)
-		if err == nil && p != nil {
-			enriched, enrichErr := s.resolvePrincipalUserID(r.Context(), p)
-			switch {
-			case enrichErr == nil && enriched != nil:
-				p = enriched
-			case enrichErr != nil:
-				slog.WarnContext(r.Context(), "auth: unable to resolve user ID", "error", enrichErr)
-			}
-			ctx := principal.WithPrincipal(r.Context(), p)
-			next.ServeHTTP(w, r.WithContext(ctx))
-			return
-		}
-
-		authSource := requestedAuthSource(r)
-		switch {
-		case err == nil:
-			s.auditRequestEventWithAuthSource(r, authSource, "", "auth.authenticate", false, errors.New("missing authorization"))
-			writeError(w, http.StatusUnauthorized, "missing authorization")
-			return
-		case errors.Is(err, errInvalidAuthorizationHeader):
-			s.auditRequestEventWithAuthSource(r, authSource, "", "auth.authenticate", false, errInvalidAuthorizationHeader)
-			writeError(w, http.StatusUnauthorized, "invalid authorization header format")
-			return
-		case errors.Is(err, principal.ErrInvalidToken):
-			slog.InfoContext(r.Context(), "auth: invalid token", "remote_addr", r.RemoteAddr)
-			s.auditRequestEventWithAuthSource(r, authSource, "", "auth.authenticate", false, principal.ErrInvalidToken)
-			writeError(w, http.StatusUnauthorized, "invalid token")
-			return
-		default:
-			slog.ErrorContext(r.Context(), "auth: token validation failed", "remote_addr", r.RemoteAddr, "error", err)
-			s.auditRequestEventWithAuthSource(r, authSource, "", "auth.authenticate", false, errors.New("token validation failed"))
-			writeError(w, http.StatusInternalServerError, "token validation failed")
-			return
-		}
+		s.serveAuthenticated(w, r, next, s.resolver, s.noAuth, s.anonymousPrincipal, "")
 	})
+}
+
+func (s *Server) pluginRouteAuthMiddleware(pluginParam string) func(http.Handler) http.Handler {
+	return func(next http.Handler) http.Handler {
+		return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			pluginName := strings.TrimSpace(chi.URLParam(r, pluginParam))
+			if pluginName == "" {
+				s.serveAuthenticated(w, r, next, s.resolver, s.noAuth, s.anonymousPrincipal, "")
+				return
+			}
+
+			entry := s.pluginDefs[pluginName]
+			if entry == nil || entry.RouteAuth == nil || strings.TrimSpace(entry.RouteAuth.Provider) == "" {
+				s.serveAuthenticated(w, r, next, s.resolver, s.noAuth, s.anonymousPrincipal, "")
+				return
+			}
+
+			providerName := strings.TrimSpace(entry.RouteAuth.Provider)
+			if providerName == "server" {
+				s.serveAuthenticated(w, r, next, s.resolver, s.noAuth, s.anonymousPrincipal, "")
+				return
+			}
+
+			resolver := s.authResolvers[providerName]
+			if resolver == nil {
+				slog.ErrorContext(r.Context(), "plugin route auth provider is not initialized", "plugin", pluginName, "auth_provider", providerName)
+				writeError(w, http.StatusInternalServerError, "plugin route auth provider is not initialized")
+				return
+			}
+
+			s.serveAuthenticated(w, r, next, resolver, false, nil, providerName)
+		})
+	}
 }

--- a/gestaltd/internal/server/routes_user.go
+++ b/gestaltd/internal/server/routes_user.go
@@ -8,7 +8,6 @@ func (s *Server) mountAuthenticatedRoutes(r chi.Router) {
 
 		r.Get("/integrations", s.listIntegrations)
 		r.Delete("/integrations/{name}", s.disconnectIntegration)
-		r.Get("/integrations/{name}/operations", s.listOperations)
 
 		r.Route("/workflow/schedules", func(r chi.Router) {
 			r.Get("/", s.listGlobalWorkflowSchedules)
@@ -19,9 +18,6 @@ func (s *Server) mountAuthenticatedRoutes(r chi.Router) {
 			r.Post("/{scheduleID}/pause", s.pauseGlobalWorkflowSchedule)
 			r.Post("/{scheduleID}/resume", s.resumeGlobalWorkflowSchedule)
 		})
-
-		r.Get("/{integration}/{operation}", s.executeOperation)
-		r.Post("/{integration}/{operation}", s.executeOperation)
 
 		r.Post("/auth/start-oauth", s.startIntegrationOAuth)
 		r.Post("/auth/connect-manual", s.connectManual)
@@ -49,4 +45,8 @@ func (s *Server) mountAuthenticatedRoutes(r chi.Router) {
 			r.Delete("/{identityID}/tokens/{id}", s.revokeManagedIdentityToken)
 		})
 	})
+
+	r.With(s.pluginRouteAuthMiddleware("name")).Get("/integrations/{name}/operations", s.listOperations)
+	r.With(s.pluginRouteAuthMiddleware("integration")).Get("/{integration}/{operation}", s.executeOperation)
+	r.With(s.pluginRouteAuthMiddleware("integration")).Post("/{integration}/{operation}", s.executeOperation)
 }

--- a/gestaltd/internal/server/runtime.go
+++ b/gestaltd/internal/server/runtime.go
@@ -61,13 +61,15 @@ func Run(ctx context.Context, cfg *config.Config, result *bootstrap.Result) erro
 	managementAddr := cfg.Server.ManagementAddr()
 	mcpSlot := &switchableHandler{}
 	baseConfig := Config{
-		Auth:              result.Auth,
-		AuditSink:         result.AuditSink,
-		Services:          result.Services,
-		Providers:         result.Providers,
-		Workflow:          result.WorkflowControl,
-		Invoker:           httpInvoker,
-		DefaultConnection: connMaps.DefaultConnection,
+		Auth:                 result.Auth,
+		SelectedAuthProvider: result.SelectedAuthProvider,
+		AuthProviders:        result.AuthProviders,
+		AuditSink:            result.AuditSink,
+		Services:             result.Services,
+		Providers:            result.Providers,
+		Workflow:             result.WorkflowControl,
+		Invoker:              httpInvoker,
+		DefaultConnection:    connMaps.DefaultConnection,
 		// HTTP routes expose REST-visible operations, so unqualified session-catalog
 		// resolution should follow the API surface by default. The MCP server keeps
 		// its own MCP-specific routing below.

--- a/gestaltd/internal/server/server.go
+++ b/gestaltd/internal/server/server.go
@@ -78,6 +78,7 @@ type Server struct {
 	providers             *registry.ProviderMap[core.Provider]
 	workflow              bootstrap.WorkflowControl
 	resolver              *principal.Resolver
+	authResolvers         map[string]*principal.Resolver
 	invoker               invocation.Invoker
 	defaultConnection     map[string]string
 	catalogConnection     map[string]string
@@ -105,6 +106,8 @@ type Server struct {
 
 type Config struct {
 	Auth                  core.AuthProvider
+	SelectedAuthProvider  string
+	AuthProviders         map[string]core.AuthProvider
 	AuditSink             core.AuditSink
 	Services              *coredata.Services
 	Providers             *registry.ProviderMap[core.Provider]
@@ -195,6 +198,22 @@ func New(cfg Config) (*Server, error) {
 	identityPluginAccess := cfg.Services.IdentityPluginAccess
 	workflowExecutionRefs := cfg.Services.WorkflowExecutionRefs
 	resolver := principal.NewResolver(cfg.Auth, users, apiTokens, managedIdentities, identityGrants, cfg.Authorizer)
+	authProviders := make(map[string]core.AuthProvider, len(cfg.AuthProviders)+1)
+	for name, provider := range cfg.AuthProviders {
+		if provider == nil {
+			continue
+		}
+		authProviders[name] = provider
+	}
+	if cfg.Auth != nil && cfg.SelectedAuthProvider != "" {
+		if _, ok := authProviders[cfg.SelectedAuthProvider]; !ok {
+			authProviders[cfg.SelectedAuthProvider] = cfg.Auth
+		}
+	}
+	authResolvers := make(map[string]*principal.Resolver, len(authProviders))
+	for name, provider := range authProviders {
+		authResolvers[name] = principal.NewResolver(provider, users, apiTokens, managedIdentities, identityGrants, cfg.Authorizer)
+	}
 
 	router := chi.NewRouter()
 	otelOptions := []otelhttp.Option{}
@@ -219,6 +238,7 @@ func New(cfg Config) (*Server, error) {
 		providers:             cfg.Providers,
 		workflow:              cfg.Workflow,
 		resolver:              resolver,
+		authResolvers:         authResolvers,
 		invoker:               cfg.Invoker,
 		defaultConnection:     cfg.DefaultConnection,
 		catalogConnection:     cfg.CatalogConnection,

--- a/gestaltd/internal/server/server_test.go
+++ b/gestaltd/internal/server/server_test.go
@@ -4678,6 +4678,161 @@ func TestAuthMiddleware_NoAuth(t *testing.T) {
 	}
 }
 
+func TestPluginRouteAuth_HTTPRoutesUseNamedProviderOverride(t *testing.T) {
+	t.Parallel()
+
+	plaintext, hashed, err := principal.GenerateToken(principal.TokenTypeAPI)
+	if err != nil {
+		t.Fatalf("GenerateToken: %v", err)
+	}
+
+	svc := coretesting.NewStubServices(t)
+	seedAPIToken(t, svc, plaintext, hashed, "api-user")
+	openProvider := &stubIntegrationWithOps{
+		StubIntegration: coretesting.StubIntegration{
+			N:        "open",
+			ConnMode: core.ConnectionModeNone,
+			ExecuteFn: func(_ context.Context, op string, _ map[string]any, _ string) (*core.OperationResult, error) {
+				return &core.OperationResult{Status: http.StatusOK, Body: "open:" + op}, nil
+			},
+		},
+		ops: []core.Operation{{Name: "ping", Method: http.MethodGet}},
+	}
+	lockedProvider := &stubIntegrationWithOps{
+		StubIntegration: coretesting.StubIntegration{
+			N:        "locked",
+			ConnMode: core.ConnectionModeNone,
+			ExecuteFn: func(_ context.Context, op string, _ map[string]any, _ string) (*core.OperationResult, error) {
+				return &core.OperationResult{Status: http.StatusOK, Body: "locked:" + op}, nil
+			},
+		},
+		ops: []core.Operation{{Name: "ping", Method: http.MethodGet}},
+	}
+
+	ts := newTestServer(t, func(cfg *server.Config) {
+		cfg.Auth = nil
+		cfg.AuthProviders = map[string]core.AuthProvider{
+			"alt": &coretesting.StubAuthProvider{
+				N: "alt",
+				ValidateTokenFn: func(_ context.Context, token string) (*core.UserIdentity, error) {
+					if token != "alt-session" {
+						return nil, fmt.Errorf("invalid token")
+					}
+					return &core.UserIdentity{Email: "alt-user@example.test"}, nil
+				},
+			},
+		}
+		cfg.Services = svc
+		cfg.Providers = testutil.NewProviderRegistry(t, openProvider, lockedProvider)
+		cfg.PluginDefs = map[string]*config.ProviderEntry{
+			"locked": {
+				RouteAuth: &config.RouteAuthDef{Provider: "alt"},
+			},
+		}
+	})
+	testutil.CloseOnCleanup(t, ts)
+
+	t.Run("server-level routes and plugins without overrides remain anonymous", func(t *testing.T) {
+		t.Parallel()
+
+		resp, err := http.Get(ts.URL + "/api/v1/integrations")
+		if err != nil {
+			t.Fatalf("GET integrations: %v", err)
+		}
+		defer func() { _ = resp.Body.Close() }()
+		if resp.StatusCode != http.StatusOK {
+			body, _ := io.ReadAll(resp.Body)
+			t.Fatalf("integrations status = %d, want 200: %s", resp.StatusCode, body)
+		}
+
+		resp, err = http.Get(ts.URL + "/api/v1/open/ping")
+		if err != nil {
+			t.Fatalf("GET open ping: %v", err)
+		}
+		body, _ := io.ReadAll(resp.Body)
+		_ = resp.Body.Close()
+		if resp.StatusCode != http.StatusOK {
+			t.Fatalf("open ping status = %d, want 200: %s", resp.StatusCode, body)
+		}
+		if string(body) != "open:ping" {
+			t.Fatalf("open ping body = %q, want %q", body, "open:ping")
+		}
+
+		resp, err = http.Get(ts.URL + "/api/v1/integrations/open/operations")
+		if err != nil {
+			t.Fatalf("GET open operations: %v", err)
+		}
+		defer func() { _ = resp.Body.Close() }()
+		if resp.StatusCode != http.StatusOK {
+			body, _ := io.ReadAll(resp.Body)
+			t.Fatalf("open operations status = %d, want 200: %s", resp.StatusCode, body)
+		}
+	})
+
+	t.Run("plugin override requires its named auth provider", func(t *testing.T) {
+		t.Parallel()
+
+		resp, err := http.Get(ts.URL + "/api/v1/locked/ping")
+		if err != nil {
+			t.Fatalf("GET locked ping: %v", err)
+		}
+		defer func() { _ = resp.Body.Close() }()
+		if resp.StatusCode != http.StatusUnauthorized {
+			body, _ := io.ReadAll(resp.Body)
+			t.Fatalf("locked ping status = %d, want 401: %s", resp.StatusCode, body)
+		}
+
+		resp, err = http.Get(ts.URL + "/api/v1/integrations/locked/operations")
+		if err != nil {
+			t.Fatalf("GET locked operations: %v", err)
+		}
+		defer func() { _ = resp.Body.Close() }()
+		if resp.StatusCode != http.StatusUnauthorized {
+			body, _ := io.ReadAll(resp.Body)
+			t.Fatalf("locked operations status = %d, want 401: %s", resp.StatusCode, body)
+		}
+	})
+
+	t.Run("named auth provider and api tokens both pass through route auth", func(t *testing.T) {
+		t.Parallel()
+
+		req, _ := http.NewRequest(http.MethodGet, ts.URL+"/api/v1/locked/ping", nil)
+		req.Header.Set("Authorization", "Bearer alt-session")
+		resp, err := http.DefaultClient.Do(req)
+		if err != nil {
+			t.Fatalf("GET locked ping with named auth: %v", err)
+		}
+		body, _ := io.ReadAll(resp.Body)
+		_ = resp.Body.Close()
+		if resp.StatusCode != http.StatusOK {
+			t.Fatalf("locked ping with named auth status = %d, want 200: %s", resp.StatusCode, body)
+		}
+		if string(body) != "locked:ping" {
+			t.Fatalf("locked ping body = %q, want %q", body, "locked:ping")
+		}
+
+		req, _ = http.NewRequest(http.MethodGet, ts.URL+"/api/v1/integrations/locked/operations", nil)
+		req.Header.Set("Authorization", "Bearer "+plaintext)
+		resp, err = http.DefaultClient.Do(req)
+		if err != nil {
+			t.Fatalf("GET locked operations with api token: %v", err)
+		}
+		defer func() { _ = resp.Body.Close() }()
+		if resp.StatusCode != http.StatusOK {
+			body, _ := io.ReadAll(resp.Body)
+			t.Fatalf("locked operations with api token status = %d, want 200: %s", resp.StatusCode, body)
+		}
+
+		var ops []catalog.CatalogOperation
+		if err := json.NewDecoder(resp.Body).Decode(&ops); err != nil {
+			t.Fatalf("decoding locked operations: %v", err)
+		}
+		if len(ops) != 1 || ops[0].ID != "ping" {
+			t.Fatalf("operations = %#v, want [ping]", ops)
+		}
+	})
+}
+
 func TestAuthMiddleware_UnprefixedTokenRejected(t *testing.T) {
 	t.Parallel()
 


### PR DESCRIPTION
## Summary
This PR turns `plugins.<name>.auth.provider` / `spec.auth.provider` into a runtime-enforced auth selector for plugin HTTP operation routes.

New interfaces:
- `bootstrap.Result`
  - `SelectedAuthProvider string`
  - `AuthProviders map[string]core.AuthProvider`
- `server.Config`
  - `SelectedAuthProvider string`
  - `AuthProviders map[string]core.AuthProvider`
- Plugin route auth is now enforced on:
  - `GET /api/v1/integrations/{name}/operations`
  - `GET /api/v1/{integration}/{operation}`
  - `POST /api/v1/{integration}/{operation}`

Behavior:
- Server-wide auth still applies by default.
- A plugin can override those HTTP operation routes to use a named `providers.auth.<name>` entry.
- API tokens and workload tokens still work on route-auth-protected plugin routes because the named route-auth path reuses `principal.Resolver`.
- Browser login, mounted UIs, integration OAuth helper routes, and `/mcp` still use the server-wide auth provider in this phase.

## Examples
Keep server auth on plugin HTTP routes:
```yaml
plugins:
  github:
    auth:
      provider: server
```

Use a named auth provider for plugin HTTP routes:
```yaml
providers:
  auth:
    corporate:
      source:
        url: https://artifacts.example.com/providers/auth/corporate/provider-release.yaml

plugins:
  slack_bot:
    auth:
      provider: corporate
```

Manifest route auth plus separate upstream connection auth:
```yaml
spec:
  auth:
    provider: corporate
  connections:
    default:
      mode: user
      auth:
        type: oauth2
        authorizationUrl: https://slack.com/oauth/v2/authorize
        tokenUrl: https://slack.com/api/oauth.v2.access
```

## Testing
- `go test ./internal/server -run 'TestPluginRouteAuth_HTTPRoutesUseNamedProviderOverride|TestAuditMetadata_AuthMiddlewareFailures|TestAuthMiddleware_ValidAPIToken|TestAuthMiddleware_ValidWorkloadToken|TestAuthMiddleware_NoAuth' -count=1`
- `go test ./internal/server -run 'TestListOperations$|TestExecuteOperation$|TestExecuteOperation_POST$|TestCookieAuth$' -count=1`
- `go test ./internal/bootstrap -run 'TestResultCloseClosesAuthProvider|TestBootstrapHostFactorySelection/auth_source_map|TestBootstrapHostFactorySelection/omits_auth_when_auth_provider_is_unset' -count=1`
- `go test ./internal/server ./internal/bootstrap -run TestDoesNotExist -count=1`

## Notes
A separate `gpt-5.4` reviewer-agent pass was attempted twice, but both review agents stalled before returning findings. I reviewed the final diff manually after the targeted test pass.