### PR TITLE
runtime: collapse provider connection modes to none or user

### DIFF
--- a/gestaltd/cmd/gestaltd/provider_test.go
+++ b/gestaltd/cmd/gestaltd/provider_test.go
@@ -1699,7 +1699,7 @@ func TestRun_ProviderReleasePreservesYAMLManifestFormatAndConnectionDefaults(t *
 			MCP:              true,
 			Connections: map[string]*providermanifestv1.ManifestConnectionDef{
 				"default": {
-					Mode: providermanifestv1.ConnectionModeIdentity,
+					Mode: providermanifestv1.ConnectionModeUser,
 					Params: map[string]providermanifestv1.ProviderConnectionParam{
 						"tenant": {Required: true},
 					},
@@ -1728,8 +1728,8 @@ func TestRun_ProviderReleasePreservesYAMLManifestFormatAndConnectionDefaults(t *
 	if manifest.Spec == nil || manifest.Spec.Connections["default"] == nil || len(manifest.Spec.Connections["default"].Params) != 1 || !manifest.Spec.Connections["default"].Params["tenant"].Required {
 		t.Fatalf("provider connection_params = %+v", manifest.Spec)
 	}
-	if manifest.Spec.Connections["default"].Mode != "identity" {
-		t.Fatalf("provider default connection mode = %q, want %q", manifest.Spec.Connections["default"].Mode, "identity")
+	if manifest.Spec.Connections["default"].Mode != "user" {
+		t.Fatalf("provider default connection mode = %q, want %q", manifest.Spec.Connections["default"].Mode, "user")
 	}
 
 	manifestData, err := os.ReadFile(manifestPath)
@@ -1740,7 +1740,7 @@ func TestRun_ProviderReleasePreservesYAMLManifestFormatAndConnectionDefaults(t *
 		"spec:",
 		"connections:",
 		"default:",
-		"mode: identity",
+		"mode: user",
 		"params:",
 		"mcp: true",
 		"entrypoint:",

--- a/gestaltd/core/provider.go
+++ b/gestaltd/core/provider.go
@@ -9,18 +9,14 @@ import (
 type ConnectionMode string
 
 const (
-	ConnectionModeNone     ConnectionMode = "none"
-	ConnectionModeUser     ConnectionMode = "user"
-	ConnectionModeIdentity ConnectionMode = "identity"
-	ConnectionModeEither   ConnectionMode = "either"
+	ConnectionModeNone ConnectionMode = "none"
+	ConnectionModeUser ConnectionMode = "user"
 )
 
 func NormalizeConnectionMode(mode ConnectionMode) ConnectionMode {
 	switch mode {
-	case "", ConnectionModeUser, ConnectionModeEither:
+	case "", ConnectionModeUser:
 		return ConnectionModeUser
-	case ConnectionModeIdentity:
-		return ConnectionModeIdentity
 	case ConnectionModeNone:
 		return ConnectionModeNone
 	default:

--- a/gestaltd/internal/authorization/authorizer.go
+++ b/gestaltd/internal/authorization/authorizer.go
@@ -230,11 +230,6 @@ func (a *Authorizer) Binding(p *principal.Principal, provider string) (Credentia
 		switch core.NormalizeConnectionMode(a.providerModes[provider]) {
 		case core.ConnectionModeNone:
 			return CredentialBinding{Mode: core.ConnectionModeNone}, true
-		case core.ConnectionModeIdentity:
-			return CredentialBinding{
-				Mode:                core.ConnectionModeIdentity,
-				CredentialSubjectID: principal.IdentitySubjectID(),
-			}, true
 		case core.ConnectionModeUser:
 			subjectID := principal.EffectiveCredentialSubjectID(p)
 			if subjectID == "" {
@@ -486,7 +481,7 @@ func buildBinding(mode core.ConnectionMode, workloadID, provider string, def con
 				Mode: core.ConnectionModeNone,
 			},
 		}, nil
-	case core.ConnectionModeIdentity:
+	case core.ConnectionModeUser:
 		connection := strings.TrimSpace(def.Connection)
 		if connection == "" {
 			connection = defaultConnections[provider]
@@ -509,14 +504,12 @@ func buildBinding(mode core.ConnectionMode, workloadID, provider string, def con
 
 		return WorkloadProviderBinding{
 			CredentialBinding: CredentialBinding{
-				Mode:                core.ConnectionModeIdentity,
-				CredentialSubjectID: principal.IdentitySubjectID(),
+				Mode:                core.ConnectionModeUser,
+				CredentialSubjectID: principal.WorkloadSubjectID(workloadID),
 				Connection:          connection,
 				Instance:            instance,
 			},
 		}, nil
-	case core.ConnectionModeUser:
-		return WorkloadProviderBinding{}, fmt.Errorf("authorization validation: workload %q provider %q uses unsupported connection mode %q in v1", workloadID, provider, mode)
 	default:
 		return WorkloadProviderBinding{}, fmt.Errorf("authorization validation: workload %q provider %q uses unknown connection mode %q", workloadID, provider, mode)
 	}
@@ -550,10 +543,8 @@ func (a *Authorizer) allowManagedIdentityProvider(p *principal.Principal, provid
 		return false
 	}
 	switch core.NormalizeConnectionMode(mode) {
-	case core.ConnectionModeNone, core.ConnectionModeIdentity:
+	case core.ConnectionModeNone, core.ConnectionModeUser:
 		return true
-	case core.ConnectionModeUser:
-		return principal.EffectiveCredentialSubjectID(p) != ""
 	default:
 		return false
 	}

--- a/gestaltd/internal/bootstrap/bootstrap_test.go
+++ b/gestaltd/internal/bootstrap/bootstrap_test.go
@@ -795,7 +795,7 @@ func workflowStartupCallbackConfig(baseURL string) *config.Config {
 	cfg := validConfig()
 	cfg.Plugins = map[string]*config.ProviderEntry{
 		"roadmap": {
-			ConnectionMode: providermanifestv1.ConnectionModeIdentity,
+			ConnectionMode: providermanifestv1.ConnectionModeUser,
 			ResolvedManifest: &providermanifestv1.Manifest{
 				Spec: &providermanifestv1.Spec{
 					Surfaces: &providermanifestv1.ProviderSurfaces{
@@ -2993,7 +2993,7 @@ func TestBootstrapStartsWorkflowProvidersAfterInvokerIsReady(t *testing.T) {
 			return nil, fmt.Errorf("workflow name = %q, want %q", name, "temporal")
 		}
 		if err := deps.Services.Tokens.StoreToken(context.Background(), &core.IntegrationToken{
-			SubjectID:   principal.IdentitySubjectID(),
+			SubjectID:   principal.WorkloadSubjectID("workflow.config"),
 			Integration: "roadmap",
 			Connection:  config.PluginConnectionName,
 			Instance:    "default",
@@ -3047,7 +3047,7 @@ func TestValidateStartsWorkflowProvidersAfterInvokerIsReady(t *testing.T) {
 			return nil, fmt.Errorf("workflow name = %q, want %q", name, "temporal")
 		}
 		if err := deps.Services.Tokens.StoreToken(context.Background(), &core.IntegrationToken{
-			SubjectID:   principal.IdentitySubjectID(),
+			SubjectID:   principal.WorkloadSubjectID("workflow.config"),
 			Integration: "roadmap",
 			Connection:  config.PluginConnectionName,
 			Instance:    "default",
@@ -3102,7 +3102,7 @@ func TestValidateManagedWorkflowStartupCallbackUsesPreparedProviderStub(t *testi
 			cfg.Plugins = map[string]*config.ProviderEntry{
 				"roadmap": {
 					Source:         tc.source,
-					ConnectionMode: providermanifestv1.ConnectionModeIdentity,
+					ConnectionMode: providermanifestv1.ConnectionModeUser,
 					ResolvedManifest: &providermanifestv1.Manifest{
 						DisplayName: "Roadmap",
 						Description: "Managed roadmap plugin",
@@ -3134,7 +3134,7 @@ func TestValidateManagedWorkflowStartupCallbackUsesPreparedProviderStub(t *testi
 					return nil, fmt.Errorf("workflow name = %q, want %q", name, "temporal")
 				}
 				if err := deps.Services.Tokens.StoreToken(context.Background(), &core.IntegrationToken{
-					SubjectID:   principal.IdentitySubjectID(),
+					SubjectID:   principal.WorkloadSubjectID("workflow.config"),
 					Integration: "roadmap",
 					Connection:  config.PluginConnectionName,
 					Instance:    "default",
@@ -3190,7 +3190,7 @@ func TestValidateManagedWorkflowStartupInvokesMCPPassthroughPreparedProviders(t 
 	cfg.Plugins = map[string]*config.ProviderEntry{
 		"roadmap": {
 			Source:               config.NewMetadataSource("https://example.invalid/github-com-example-roadmap/v0.0.1/provider-release.yaml"),
-			ConnectionMode:       providermanifestv1.ConnectionModeIdentity,
+			ConnectionMode:       providermanifestv1.ConnectionModeUser,
 			ResolvedManifestPath: filepath.Join(root, "manifest.yaml"),
 			ResolvedManifest: &providermanifestv1.Manifest{
 				DisplayName: "Roadmap",
@@ -3229,7 +3229,7 @@ func TestValidateManagedWorkflowStartupInvokesMCPPassthroughPreparedProviders(t 
 			connection = config.PluginConnectionName
 		}
 		if err := deps.Services.Tokens.StoreToken(context.Background(), &core.IntegrationToken{
-			SubjectID:   principal.IdentitySubjectID(),
+			SubjectID:   principal.WorkloadSubjectID("workflow.config"),
 			Integration: "roadmap",
 			Connection:  connection,
 			Instance:    "default",
@@ -3425,7 +3425,7 @@ func TestValidate(t *testing.T) {
 		cfg := validConfig()
 		cfg.Plugins = map[string]*config.ProviderEntry{
 			"svc": {
-				ConnectionMode: providermanifestv1.ConnectionMode("either"),
+				ConnectionMode: providermanifestv1.ConnectionModeUser,
 				ResolvedManifest: &providermanifestv1.Manifest{
 					Spec: &providermanifestv1.Spec{
 						Surfaces: &providermanifestv1.ProviderSurfaces{
@@ -4725,8 +4725,9 @@ func TestBootstrapRejectsBuiltinEitherProviderWithoutAuthorizationConfig(t *test
 		&coretesting.StubIntegration{N: "svc", ConnMode: core.ConnectionMode("either")},
 	}
 
-	if _, err := bootstrap.Bootstrap(context.Background(), cfg, factories); err != nil {
-		t.Fatalf("unexpected error: %v", err)
+	_, err := bootstrap.Bootstrap(context.Background(), cfg, factories)
+	if err == nil || !strings.Contains(err.Error(), `unsupported connection mode "either"`) {
+		t.Fatalf("Bootstrap error = %v, want unsupported connection mode either", err)
 	}
 }
 
@@ -4742,7 +4743,7 @@ func TestBootstrapWorkflowAuthorizationSkipsNormalizedCredentialedProvider(t *te
 	cfg := validConfig()
 	cfg.Plugins = map[string]*config.ProviderEntry{
 		"svc": {
-			ConnectionMode: providermanifestv1.ConnectionMode("either"),
+			ConnectionMode: providermanifestv1.ConnectionModeUser,
 			ResolvedManifest: &providermanifestv1.Manifest{
 				Spec: &providermanifestv1.Spec{
 					Surfaces: &providermanifestv1.ProviderSurfaces{

--- a/gestaltd/internal/bootstrap/executable_plugin_test.go
+++ b/gestaltd/internal/bootstrap/executable_plugin_test.go
@@ -870,11 +870,11 @@ func TestBuildStartupProviderSpecPreservesStaticCatalogConnectionRouting(t *test
 	manifest.Spec.DefaultConnection = config.PluginConnectionAlias
 	manifest.Spec.Connections = map[string]*providermanifestv1.ManifestConnectionDef{
 		"api": {
-			Mode: providermanifestv1.ConnectionModeIdentity,
+			Mode: providermanifestv1.ConnectionModeUser,
 			Auth: &providermanifestv1.ProviderAuth{Type: providermanifestv1.AuthTypeBearer},
 		},
 		"mcp": {
-			Mode: providermanifestv1.ConnectionModeIdentity,
+			Mode: providermanifestv1.ConnectionModeUser,
 			Auth: &providermanifestv1.ProviderAuth{Type: providermanifestv1.AuthTypeBearer},
 		},
 	}
@@ -1079,7 +1079,7 @@ func TestPreparedProviderStub_RejectsMixedConnectionModes(t *testing.T) {
 					Spec: &providermanifestv1.Spec{
 						Connections: map[string]*providermanifestv1.ManifestConnectionDef{
 							"default": {
-								Mode: providermanifestv1.ConnectionModeIdentity,
+								Mode: providermanifestv1.ConnectionModeUser,
 								Auth: &providermanifestv1.ProviderAuth{Type: providermanifestv1.AuthTypeNone},
 							},
 							"workspace": {
@@ -1094,13 +1094,10 @@ func TestPreparedProviderStub_RejectsMixedConnectionModes(t *testing.T) {
 	}
 
 	providers, _, err := buildProvidersStrict(context.Background(), cfg, NewFactoryRegistry(), Deps{})
-	if err == nil {
-		defer func() { _ = CloseProviders(providers) }()
-		t.Fatal("expected mixed connection mode error, got nil")
+	if err != nil {
+		t.Fatalf("buildProvidersStrict: %v", err)
 	}
-	if !strings.Contains(err.Error(), `plugins may not mix "user" and "identity" connection modes across connections`) {
-		t.Fatalf("unexpected error: %v", err)
-	}
+	defer func() { _ = CloseProviders(providers) }()
 }
 
 func TestPluginProcessEnvIsolation(t *testing.T) {

--- a/gestaltd/internal/bootstrap/provider_build.go
+++ b/gestaltd/internal/bootstrap/provider_build.go
@@ -183,7 +183,7 @@ func buildProvidersAsync(
 
 func validateProviderConnectionMode(provider string, mode core.ConnectionMode) error {
 	switch core.NormalizeConnectionMode(mode) {
-	case core.ConnectionModeNone, core.ConnectionModeUser, core.ConnectionModeIdentity:
+	case core.ConnectionModeNone, core.ConnectionModeUser:
 		return nil
 	default:
 		return fmt.Errorf("unsupported connection mode %q for provider %q", mode, provider)

--- a/gestaltd/internal/bootstrap/workflow_runtime.go
+++ b/gestaltd/internal/bootstrap/workflow_runtime.go
@@ -25,6 +25,7 @@ type workflowRuntime struct {
 	mu                  sync.RWMutex
 	defaultProviderName string
 	configPermissions   map[string]map[string]struct{}
+	configConnections   map[string]string
 	configProviderModes map[string]core.ConnectionMode
 	configWorkloadToken string
 	providers           map[string]coreworkflow.Provider
@@ -36,6 +37,7 @@ type workflowRuntime struct {
 func newWorkflowRuntime(cfg *config.Config) (*workflowRuntime, error) {
 	runtime := &workflowRuntime{
 		configPermissions:   map[string]map[string]struct{}{},
+		configConnections:   map[string]string{},
 		configProviderModes: map[string]core.ConnectionMode{},
 		providers:           map[string]coreworkflow.Provider{},
 		startupWaits:        newStartupWaitTracker(),
@@ -47,10 +49,11 @@ func newWorkflowRuntime(cfg *config.Config) (*workflowRuntime, error) {
 		}
 		for _, pluginName := range slices.Sorted(maps.Keys(cfg.Plugins)) {
 			entry := cfg.Plugins[pluginName]
-			spec, _, err := buildStartupProviderSpec(pluginName, entry)
+			spec, operationConnections, err := buildStartupProviderSpec(pluginName, entry)
 			if err != nil || spec.Catalog == nil {
 				continue
 			}
+			runtime.configConnections[pluginName] = workflowBindingConnection(operationConnections)
 			runtime.configProviderModes[pluginName] = spec.ConnectionMode
 			for i := range spec.Catalog.Operations {
 				runtime.addConfigPermission(pluginName, spec.Catalog.Operations[i].ID)
@@ -475,15 +478,16 @@ func (r *workflowRuntime) AugmentAuthorization(cfg config.AuthorizationConfig) (
 	}
 	providers := make(map[string]config.WorkloadProviderDef, len(r.configPermissions))
 	for pluginName, operations := range r.configPermissions {
-		if r.configProviderModes[pluginName] == core.ConnectionModeUser {
-			continue
-		}
 		allow := make([]string, 0, len(operations))
 		for operation := range operations {
 			allow = append(allow, operation)
 		}
 		slices.Sort(allow)
-		providers[pluginName] = config.WorkloadProviderDef{Allow: allow}
+		binding := config.WorkloadProviderDef{Allow: allow}
+		if r.configProviderModes[pluginName] == core.ConnectionModeUser {
+			binding.Connection = r.configConnections[pluginName]
+		}
+		providers[pluginName] = binding
 	}
 	if len(providers) == 0 {
 		return cfg, nil
@@ -497,6 +501,27 @@ func (r *workflowRuntime) AugmentAuthorization(cfg config.AuthorizationConfig) (
 		Providers:   providers,
 	}
 	return cfg, nil
+}
+
+func workflowBindingConnection(operationConnections map[string]string) string {
+	if len(operationConnections) == 0 {
+		return ""
+	}
+	connection := ""
+	for _, raw := range operationConnections {
+		resolved := config.ResolveConnectionAlias(strings.TrimSpace(raw))
+		if resolved == "" {
+			continue
+		}
+		if connection == "" {
+			connection = resolved
+			continue
+		}
+		if connection != resolved {
+			return ""
+		}
+	}
+	return connection
 }
 
 func workflowWorkloadPrincipal() *principal.Principal {

--- a/gestaltd/internal/bootstrap/workflow_startup_test.go
+++ b/gestaltd/internal/bootstrap/workflow_startup_test.go
@@ -238,7 +238,7 @@ func TestBootstrapWorkflowStartupCallbackWaitsForDelayedPluginProvider(t *testin
 			Command:              bin,
 			ResolvedManifest:     newExecutableManifest("Roadmap", "Delayed startup provider"),
 			ResolvedManifestPath: filepath.Join(manifestRoot, "manifest.yaml"),
-			ConnectionMode:       providermanifestv1.ConnectionModeIdentity,
+			ConnectionMode:       providermanifestv1.ConnectionModeUser,
 		},
 	}
 	cfg.Providers.Workflow = map[string]*config.ProviderEntry{
@@ -251,7 +251,7 @@ func TestBootstrapWorkflowStartupCallbackWaitsForDelayedPluginProvider(t *testin
 			return nil, fmt.Errorf("workflow name = %q, want %q", name, "temporal")
 		}
 		if err := deps.Services.Tokens.StoreToken(context.Background(), &core.IntegrationToken{
-			SubjectID:   principal.IdentitySubjectID(),
+			SubjectID:   principal.WorkloadSubjectID("workflow.config"),
 			Integration: "roadmap",
 			Connection:  config.PluginConnectionName,
 			Instance:    "default",

--- a/gestaltd/internal/composite/provider.go
+++ b/gestaltd/internal/composite/provider.go
@@ -60,9 +60,8 @@ func (p *Provider) mcpConnectionMode() core.ConnectionMode {
 }
 
 var connectionModeRank = map[core.ConnectionMode]int{
-	core.ConnectionModeNone:     0,
-	core.ConnectionModeIdentity: 1,
-	core.ConnectionModeUser:     2,
+	core.ConnectionModeNone: 0,
+	core.ConnectionModeUser: 1,
 }
 
 func stricterConnectionMode(a, b core.ConnectionMode) core.ConnectionMode {

--- a/gestaltd/internal/config/connection_plan.go
+++ b/gestaltd/internal/config/connection_plan.go
@@ -164,45 +164,23 @@ func (plan StaticConnectionPlan) AdvertisedConnectionNames() []string {
 }
 
 func (plan StaticConnectionPlan) ConnectionMode() core.ConnectionMode {
-	needUser := false
-	needIdentity := false
-
-	addMode := func(mode core.ConnectionMode) {
-		switch core.NormalizeConnectionMode(mode) {
-		case core.ConnectionModeUser:
-			needUser = true
-		case core.ConnectionModeIdentity:
-			needIdentity = true
-		}
-	}
-
-	addMode(connectionModeForConnection(plan.pluginConnection))
-	for _, name := range plan.NamedConnectionNames() {
-		addMode(connectionModeForConnection(plan.namedConnections[name]))
-	}
-
-	switch {
-	case needUser:
+	if connectionModeForConnection(plan.pluginConnection) == core.ConnectionModeUser {
 		return core.ConnectionModeUser
-	case needIdentity:
-		return core.ConnectionModeIdentity
+	}
+	for _, name := range plan.NamedConnectionNames() {
+		if connectionModeForConnection(plan.namedConnections[name]) == core.ConnectionModeUser {
+			return core.ConnectionModeUser
+		}
 	}
 	return core.ConnectionModeNone
 }
 
 func (plan StaticConnectionPlan) validateConnectionModes() error {
-	needUser := false
-	needIdentity := false
-
 	addMode := func(scope string, mode core.ConnectionMode) error {
 		switch core.NormalizeConnectionMode(mode) {
 		case core.ConnectionModeNone:
 			return nil
 		case core.ConnectionModeUser:
-			needUser = true
-			return nil
-		case core.ConnectionModeIdentity:
-			needIdentity = true
 			return nil
 		default:
 			return fmt.Errorf("%s uses unsupported connection mode %q", scope, mode)
@@ -216,9 +194,6 @@ func (plan StaticConnectionPlan) validateConnectionModes() error {
 		if err := addMode(fmt.Sprintf("connection %q", name), connectionModeForConnection(plan.namedConnections[name])); err != nil {
 			return err
 		}
-	}
-	if needUser && needIdentity {
-		return fmt.Errorf("plugins may not mix %q and %q connection modes across connections", core.ConnectionModeUser, core.ConnectionModeIdentity)
 	}
 	return nil
 }

--- a/gestaltd/internal/invocation/broker.go
+++ b/gestaltd/internal/invocation/broker.go
@@ -435,9 +435,6 @@ func (b *Broker) resolveToken(ctx context.Context, prov core.Provider, p *princi
 		}
 		return b.resolveSubjectToken(ctx, prov, subjectID, providerName, connection, instance, core.ConnectionModeUser, subjectID)
 
-	case core.ConnectionModeIdentity:
-		return b.resolveSubjectToken(ctx, prov, principal.IdentitySubjectID(), providerName, connection, instance, core.ConnectionModeIdentity, principal.IdentitySubjectID())
-
 	default:
 		return ctx, "", fmt.Errorf("%w: unknown connection mode %q", ErrInternal, mode)
 	}
@@ -490,14 +487,6 @@ func (b *Broker) resolveWorkloadToken(ctx context.Context, prov core.Provider, p
 			Instance:   binding.Instance,
 		})
 		return ctx, "", nil
-	case core.ConnectionModeIdentity:
-		connection := binding.Connection
-		instance := binding.Instance
-		if (requestedConnection != "" && requestedConnection != binding.Connection) || (requestedInstance != "" && requestedInstance != binding.Instance) {
-			return ctx, "", fmt.Errorf("%w: workloads may not override connection or instance bindings", ErrAuthorizationDenied)
-		}
-		SetCredentialAudit(ctx, binding.Mode, binding.CredentialSubjectID, connection, instance)
-		return b.resolveSubjectToken(ctx, prov, principal.IdentitySubjectID(), providerName, connection, instance, core.ConnectionModeIdentity, binding.CredentialSubjectID)
 	case core.ConnectionModeUser:
 		connection := binding.Connection
 		instance := binding.Instance
@@ -514,7 +503,7 @@ func (b *Broker) resolveWorkloadToken(ctx context.Context, prov core.Provider, p
 		SetCredentialAudit(ctx, binding.Mode, subjectID, connection, instance)
 		return b.resolveSubjectToken(ctx, prov, subjectID, providerName, connection, instance, core.ConnectionModeUser, subjectID)
 	default:
-		return ctx, "", fmt.Errorf("%w: workloads may only use identity or none providers", ErrAuthorizationDenied)
+		return ctx, "", fmt.Errorf("%w: workloads may only use credentialed or none providers", ErrAuthorizationDenied)
 	}
 }
 

--- a/gestaltd/internal/invocation/broker_test.go
+++ b/gestaltd/internal/invocation/broker_test.go
@@ -67,7 +67,7 @@ func TestBrokerResolveToken_WorkflowContextDoesNotBypassWorkloadIdentityBinding(
 	svc := coretesting.NewStubServices(t)
 	providers := testutil.NewProviderRegistry(t, &coretesting.StubIntegration{
 		N:        "slack",
-		ConnMode: core.ConnectionModeIdentity,
+		ConnMode: core.ConnectionModeUser,
 	})
 	authz := mustAuthorizer(t, config.AuthorizationConfig{
 		Workloads: map[string]config.WorkloadDef{

--- a/gestaltd/internal/invocation/guarded_test.go
+++ b/gestaltd/internal/invocation/guarded_test.go
@@ -244,7 +244,7 @@ func TestGuardedInvoker_AuditLoggedOnPanic(t *testing.T) {
 	sink := &capturingSink{}
 	guarded := invocation.NewGuarded(funcInvoker{
 		invoke: func(ctx context.Context, _ *principal.Principal, _ string, _ string, _ string, _ map[string]any) (*core.OperationResult, error) {
-			invocation.SetCredentialAudit(ctx, core.ConnectionModeIdentity, principal.IdentitySubjectID(), "workspace", "team-a")
+			invocation.SetCredentialAudit(ctx, core.ConnectionModeUser, principal.IdentitySubjectID(), "workspace", "team-a")
 			panic("boom")
 		},
 	}, nil, "test", sink, invocation.WithoutRateLimit())
@@ -264,7 +264,7 @@ func TestGuardedInvoker_AuditLoggedOnPanic(t *testing.T) {
 		if !entry.Allowed {
 			t.Fatal("expected panicing invocation to keep allowed=true audit entry")
 		}
-		if entry.CredentialMode != string(core.ConnectionModeIdentity) {
+		if entry.CredentialMode != string(core.ConnectionModeUser) {
 			t.Fatalf("expected credential mode identity, got %q", entry.CredentialMode)
 		}
 		if entry.CredentialSubjectID != principal.IdentitySubjectID() {

--- a/gestaltd/internal/mcp/binding_test.go
+++ b/gestaltd/internal/mcp/binding_test.go
@@ -965,7 +965,7 @@ func TestNewServer_WorkloadListToolsFiltersStaticAndSessionTools(t *testing.T) {
 	}
 
 	prov := &directCallerProvider{
-		StubIntegration: coretesting.StubIntegration{N: "clickhouse", ConnMode: core.ConnectionModeIdentity},
+		StubIntegration: coretesting.StubIntegration{N: "clickhouse", ConnMode: core.ConnectionModeUser},
 		cat:             staticCat,
 		sessionCatalogFn: func(_ context.Context, token string) (*catalog.Catalog, error) {
 			if token != "identity-token" {
@@ -1793,7 +1793,7 @@ func TestNewServer_WorkloadCallToolUsesBoundConnectionForSessionOnlyProvider(t *
 	prov := &directCallerProvider{
 		StubIntegration: coretesting.StubIntegration{
 			N:        "clickhouse",
-			ConnMode: core.ConnectionModeIdentity,
+			ConnMode: core.ConnectionModeUser,
 		},
 		sessionCatalogFn: func(_ context.Context, token string) (*catalog.Catalog, error) {
 			sessionCatalogCalls++
@@ -1888,7 +1888,7 @@ func TestNewServer_WorkloadCallToolRejectsInstanceOverride(t *testing.T) {
 	prov := &directCallerProvider{
 		StubIntegration: coretesting.StubIntegration{
 			N:        "sampledb",
-			ConnMode: core.ConnectionModeIdentity,
+			ConnMode: core.ConnectionModeUser,
 		},
 		cat: &catalog.Catalog{
 			Name: "sampledb",

--- a/gestaltd/internal/provider/build.go
+++ b/gestaltd/internal/provider/build.go
@@ -83,8 +83,7 @@ func Build(def *Definition, conn config.ConnectionDef, opts ...BuildOption) (cor
 		connMode = providermanifestv1.ConnectionMode(def.ConnectionMode)
 	}
 	switch connMode {
-	case "", providermanifestv1.ConnectionModeNone, providermanifestv1.ConnectionModeUser,
-		providermanifestv1.ConnectionModeIdentity:
+	case "", providermanifestv1.ConnectionModeNone, providermanifestv1.ConnectionModeUser:
 		if connMode != "" {
 			base.ConnMode = core.NormalizeConnectionMode(core.ConnectionMode(connMode))
 		}

--- a/gestaltd/internal/providerhost/provider_test.go
+++ b/gestaltd/internal/providerhost/provider_test.go
@@ -139,7 +139,7 @@ func manualOnlyStaticSpec() StaticProviderSpec {
 		Name:           "manual-only",
 		DisplayName:    "Manual Only",
 		Description:    "manual auth provider",
-		ConnectionMode: core.ConnectionModeIdentity,
+		ConnectionMode: core.ConnectionModeUser,
 		Catalog: &catalog.Catalog{
 			Name:        "manual-only",
 			DisplayName: "Manual Only",
@@ -204,8 +204,8 @@ func TestRemoteProviderRoundTrip(t *testing.T) {
 				Identity:    &core.UserIdentity{DisplayName: "Ada"},
 				Source:      principal.SourceAPIToken,
 			},
-			wantExecuteBody:    "echo|secret-token|hi|acme|user:user-123|user|Ada|true|api_token|identity|identity:__identity__|roadmap|admin",
-			wantSessionCatalog: "token-123|user:user-123|user|Ada|true|api_token|identity|roadmap|admin",
+			wantExecuteBody:    "echo|secret-token|hi|acme|user:user-123|user|Ada|true|api_token|user|user:user-123|roadmap|admin",
+			wantSessionCatalog: "token-123|user:user-123|user|Ada|true|api_token|user|roadmap|admin",
 		},
 		{
 			name: "workload subject",
@@ -215,8 +215,8 @@ func TestRemoteProviderRoundTrip(t *testing.T) {
 				Kind:        principal.KindWorkload,
 				Source:      principal.SourceWorkloadToken,
 			},
-			wantExecuteBody:    "echo|secret-token|hi|acme|workload:triage-bot|workload|Triage Bot|false|workload_token|identity|identity:__identity__|roadmap|admin",
-			wantSessionCatalog: "token-123|workload:triage-bot|workload|Triage Bot|false|workload_token|identity|roadmap|admin",
+			wantExecuteBody:    "echo|secret-token|hi|acme|workload:triage-bot|workload|Triage Bot|false|workload_token|user|workload:triage-bot|roadmap|admin",
+			wantSessionCatalog: "token-123|workload:triage-bot|workload|Triage Bot|false|workload_token|user|roadmap|admin",
 		},
 	}
 
@@ -228,8 +228,8 @@ func TestRemoteProviderRoundTrip(t *testing.T) {
 			ctx := core.WithConnectionParams(context.Background(), map[string]string{"tenant": "acme"})
 			ctx = principal.WithPrincipal(ctx, tc.principal)
 			ctx = invocation.WithCredentialContext(ctx, invocation.CredentialContext{
-				Mode:       core.ConnectionModeIdentity,
-				SubjectID:  "identity:__identity__",
+				Mode:       core.ConnectionModeUser,
+				SubjectID:  principal.EffectiveCredentialSubjectID(tc.principal),
 				Connection: "workspace",
 				Instance:   "default",
 			})

--- a/gestaltd/internal/providerpkg/manifest.go
+++ b/gestaltd/internal/providerpkg/manifest.go
@@ -432,7 +432,7 @@ func validateExecutableProviderMetadata(provider *providermanifestv1.Spec) error
 			continue
 		}
 		switch conn.Mode {
-		case "none", "user", "identity":
+		case "none", "user":
 		default:
 			return fmt.Errorf("unsupported provider.connections.%s.mode %q", name, conn.Mode)
 		}

--- a/gestaltd/internal/server/audit_metadata_test.go
+++ b/gestaltd/internal/server/audit_metadata_test.go
@@ -318,7 +318,7 @@ func TestAuditMetadata_WorkloadSubjectAndCredentialPath(t *testing.T) {
 	stub := &stubIntegrationWithOps{
 		StubIntegration: coretesting.StubIntegration{
 			N:        "audit-workload-prov",
-			ConnMode: core.ConnectionModeIdentity,
+			ConnMode: core.ConnectionModeUser,
 			ExecuteFn: func(_ context.Context, _ string, _ map[string]any, token string) (*core.OperationResult, error) {
 				if token != "identity-token" {
 					t.Fatalf("unexpected token %q", token)
@@ -351,7 +351,7 @@ func TestAuditMetadata_WorkloadSubjectAndCredentialPath(t *testing.T) {
 	svc := coretesting.NewStubServices(t)
 	if err := svc.Tokens.StoreToken(t.Context(), &core.IntegrationToken{
 		ID:          "identity-audit-token",
-		SubjectID:   principal.IdentitySubjectID(),
+		SubjectID:   principal.WorkloadSubjectID("triage-bot"),
 		Integration: "audit-workload-prov",
 		Connection:  "workspace",
 		Instance:    "team-a",
@@ -403,11 +403,11 @@ func TestAuditMetadata_WorkloadSubjectAndCredentialPath(t *testing.T) {
 	if record["subject_kind"] != "workload" {
 		t.Fatalf("expected subject_kind=workload, got %v", record["subject_kind"])
 	}
-	if record["credential_mode"] != "identity" {
-		t.Fatalf("expected credential_mode=identity, got %v", record["credential_mode"])
+	if record["credential_mode"] != "user" {
+		t.Fatalf("expected credential_mode=user, got %v", record["credential_mode"])
 	}
-	if record["credential_subject_id"] != "identity:__identity__" {
-		t.Fatalf("expected credential_subject_id identity principal, got %v", record["credential_subject_id"])
+	if record["credential_subject_id"] != "workload:triage-bot" {
+		t.Fatalf("expected credential_subject_id workload principal, got %v", record["credential_subject_id"])
 	}
 	if record["credential_connection"] != "workspace" {
 		t.Fatalf("expected credential_connection=workspace, got %v", record["credential_connection"])

--- a/gestaltd/internal/server/authorization.go
+++ b/gestaltd/internal/server/authorization.go
@@ -75,7 +75,7 @@ func (s *Server) workloadBindingConnected(ctx context.Context, binding authoriza
 	switch binding.Mode {
 	case core.ConnectionModeNone:
 		return true, nil
-	case core.ConnectionModeIdentity, core.ConnectionModeUser:
+	case core.ConnectionModeUser:
 		_, err := s.tokens.Token(ctx, binding.CredentialSubjectID, provider, binding.Connection, binding.Instance)
 		switch {
 		case err == nil:

--- a/gestaltd/internal/server/catalog_resolution_test.go
+++ b/gestaltd/internal/server/catalog_resolution_test.go
@@ -502,7 +502,7 @@ func TestFilterCatalogForPrincipal_WorkloadFilteringUsesMergedCatalog(t *testing
 		stubCatalogProvider: stubCatalogProvider{
 			stubProvider: stubProvider{
 				name:     "clash-api",
-				connMode: core.ConnectionModeIdentity,
+				connMode: core.ConnectionModeUser,
 			},
 			cat: &catalog.Catalog{
 				Name: "clash-api",

--- a/gestaltd/internal/server/handlers_tokens.go
+++ b/gestaltd/internal/server/handlers_tokens.go
@@ -189,7 +189,7 @@ func (s *Server) connectionInfosForPlugin(integration string, plugin *config.Pro
 	infos := make([]connectionDefInfo, 0, len(names))
 	for _, name := range names {
 		conn, ok := plan.LookupConnection(name)
-		if !ok || !userFacingConnection(conn) || shouldHidePassiveNamedConnection(plan, name, conn, integrationAuthTypes) {
+		if !ok || shouldHidePassiveNamedConnection(plan, name, conn, integrationAuthTypes) {
 			continue
 		}
 		if info, ok := s.connectionInfoFromAuth(integration, userFacingConnectionName(name), conn, integrationAuthTypes, defaultCredentialFields, name != config.PluginConnectionName); ok {
@@ -292,10 +292,6 @@ func (s *Server) connectionInfoFromAuth(integration, name string, conn config.Co
 		info.CredentialFields = defaultManualCredentialFieldInfos()
 	}
 	return info, true
-}
-
-func userFacingConnection(conn config.ConnectionDef) bool {
-	return conn.Mode != providermanifestv1.ConnectionModeIdentity
 }
 
 func shouldHidePassiveNamedConnection(plan config.StaticConnectionPlan, name string, conn config.ConnectionDef, integrationAuthTypes []string) bool {

--- a/gestaltd/internal/server/metrics_test.go
+++ b/gestaltd/internal/server/metrics_test.go
@@ -579,7 +579,7 @@ func TestHTTPDiscoveryMetrics(t *testing.T) {
 
 	prov := &stubIntegrationWithSessionCatalog{
 		stubIntegrationWithOps: stubIntegrationWithOps{
-			StubIntegration: coretesting.StubIntegration{N: providerName, ConnMode: core.ConnectionModeIdentity},
+			StubIntegration: coretesting.StubIntegration{N: providerName, ConnMode: core.ConnectionModeUser},
 		},
 		catalogForRequestFn: func(_ context.Context, token string) (*catalog.Catalog, error) {
 			if token != "identity-token" {
@@ -595,7 +595,8 @@ func TestHTTPDiscoveryMetrics(t *testing.T) {
 	}
 
 	svc := coretesting.NewStubServices(t)
-	seedIdentityToken(t, svc, providerName, testDefaultConnection, "default", "identity-token")
+	u := seedUser(t, svc, "user@example.com")
+	seedSubjectToken(t, svc, principal.UserSubjectID(u.ID), providerName, testDefaultConnection, "default", "identity-token")
 	ts := newTestServer(t, func(cfg *server.Config) {
 		cfg.MeterProvider = metrics.Provider
 		cfg.Auth = &coretesting.StubAuthProvider{
@@ -628,7 +629,7 @@ func TestHTTPDiscoveryMetrics(t *testing.T) {
 	attrs := map[string]string{
 		"gestalt.provider":        providerName,
 		"gestalt.action":          "list_operations",
-		"gestalt.connection_mode": "identity",
+		"gestalt.connection_mode": "user",
 	}
 	metrictest.RequireInt64Sum(t, rm, "gestaltd.discovery.count", 1, attrs)
 	metrictest.RequireNoInt64Sum(t, rm, "gestaltd.discovery.error_count", attrs)
@@ -643,7 +644,7 @@ func TestHTTPDiscoveryMetrics_FailureRecordsErrorCount(t *testing.T) {
 
 	prov := &stubIntegrationWithSessionCatalog{
 		stubIntegrationWithOps: stubIntegrationWithOps{
-			StubIntegration: coretesting.StubIntegration{N: providerName, ConnMode: core.ConnectionModeIdentity},
+			StubIntegration: coretesting.StubIntegration{N: providerName, ConnMode: core.ConnectionModeUser},
 		},
 		catalogForRequestFn: func(_ context.Context, token string) (*catalog.Catalog, error) {
 			if token != "identity-token" {
@@ -654,7 +655,8 @@ func TestHTTPDiscoveryMetrics_FailureRecordsErrorCount(t *testing.T) {
 	}
 
 	svc := coretesting.NewStubServices(t)
-	seedIdentityToken(t, svc, providerName, testDefaultConnection, "default", "identity-token")
+	u := seedUser(t, svc, "user@example.com")
+	seedSubjectToken(t, svc, principal.UserSubjectID(u.ID), providerName, testDefaultConnection, "default", "identity-token")
 	ts := newTestServer(t, func(cfg *server.Config) {
 		cfg.MeterProvider = metrics.Provider
 		cfg.Auth = &coretesting.StubAuthProvider{
@@ -687,7 +689,7 @@ func TestHTTPDiscoveryMetrics_FailureRecordsErrorCount(t *testing.T) {
 	attrs := map[string]string{
 		"gestalt.provider":        providerName,
 		"gestalt.action":          "list_operations",
-		"gestalt.connection_mode": "identity",
+		"gestalt.connection_mode": "user",
 	}
 	metrictest.RequireInt64Sum(t, rm, "gestaltd.discovery.count", 1, attrs)
 	metrictest.RequireInt64Sum(t, rm, "gestaltd.discovery.error_count", 1, attrs)

--- a/gestaltd/internal/server/server_test.go
+++ b/gestaltd/internal/server/server_test.go
@@ -883,11 +883,11 @@ func seedLegacyUserRecord(t *testing.T, svc *coredata.Services, id, email string
 	}
 }
 
-func seedIdentityToken(t *testing.T, svc *coredata.Services, integration, connection, instance, accessToken string) {
+func seedSubjectToken(t *testing.T, svc *coredata.Services, subjectID, integration, connection, instance, accessToken string) {
 	t.Helper()
 	seedToken(t, svc, &core.IntegrationToken{
 		ID:          integration + "-" + connection + "-" + instance,
-		SubjectID:   principal.IdentitySubjectID(),
+		SubjectID:   subjectID,
 		Integration: integration,
 		Connection:  connection,
 		Instance:    instance,
@@ -5099,10 +5099,10 @@ func TestWorkloadAuthorization_ListIntegrationsFiltersAndHidesConnectionAffordan
 	}
 
 	svc := coretesting.NewStubServices(t)
-	seedIdentityToken(t, svc, "svc", "workspace", "default", "identity-svc-token")
+	seedSubjectToken(t, svc, principal.WorkloadSubjectID("triage-bot"), "svc", "workspace", "default", "identity-svc-token")
 
 	svcProvider := &stubIntegrationWithOps{
-		StubIntegration: coretesting.StubIntegration{N: "svc", DN: "Service", ConnMode: core.ConnectionModeIdentity},
+		StubIntegration: coretesting.StubIntegration{N: "svc", DN: "Service", ConnMode: core.ConnectionModeUser},
 		ops:             []core.Operation{{Name: "run", Method: http.MethodGet}},
 	}
 	weatherProvider := &stubIntegrationWithOps{
@@ -5243,7 +5243,7 @@ func TestWorkloadAuthorization_ListOperationsFiltersAndRejectsSelectors(t *testi
 	}
 
 	provider := &stubIntegrationWithOps{
-		StubIntegration: coretesting.StubIntegration{N: "svc", ConnMode: core.ConnectionModeIdentity},
+		StubIntegration: coretesting.StubIntegration{N: "svc", ConnMode: core.ConnectionModeUser},
 		ops: []core.Operation{
 			{Name: "run", Method: http.MethodGet},
 			{Name: "admin", Method: http.MethodGet},
@@ -5338,12 +5338,12 @@ func TestWorkloadAuthorization_ListOperationsFiltersAndRejectsSelectors(t *testi
 	}
 
 	svc := coretesting.NewStubServices(t)
-	seedIdentityToken(t, svc, "svc-session", "workspace", "team-a", "session-bound-token")
+	seedSubjectToken(t, svc, principal.WorkloadSubjectID("triage-bot"), "svc-session", "workspace", "team-a", "session-bound-token")
 
 	var sessionCatalogToken string
 	sessionProvider := &stubIntegrationWithSessionCatalog{
 		stubIntegrationWithOps: stubIntegrationWithOps{
-			StubIntegration: coretesting.StubIntegration{N: "svc-session", ConnMode: core.ConnectionModeIdentity},
+			StubIntegration: coretesting.StubIntegration{N: "svc-session", ConnMode: core.ConnectionModeUser},
 		},
 		catalogForRequestFn: func(_ context.Context, token string) (*catalog.Catalog, error) {
 			sessionCatalogToken = token
@@ -5565,7 +5565,7 @@ func TestListIntegrations_DerivesAuthTypesFromConnectionsWhenProviderOmitsThem(t
 	}
 }
 
-func TestListIntegrations_HidesIdentityConnectionsFromUserFacingMetadata(t *testing.T) {
+func TestListIntegrations_ShowsCredentialedConnectionsInUserFacingMetadata(t *testing.T) {
 	t.Parallel()
 
 	stub := &stubManualProvider{
@@ -5583,7 +5583,7 @@ func TestListIntegrations_HidesIdentityConnectionsFromUserFacingMetadata(t *test
 				},
 				Connections: map[string]*providermanifestv1.ManifestConnectionDef{
 					"default": {
-						Mode: providermanifestv1.ConnectionModeIdentity,
+						Mode: providermanifestv1.ConnectionModeUser,
 						Auth: &providermanifestv1.ProviderAuth{
 							Type: providermanifestv1.AuthTypeManual,
 						},
@@ -5630,8 +5630,19 @@ func TestListIntegrations_HidesIdentityConnectionsFromUserFacingMetadata(t *test
 	if !reflect.DeepEqual(integrations[0].AuthTypes, []string{"manual"}) {
 		t.Fatalf("auth types = %v, want [manual]", integrations[0].AuthTypes)
 	}
-	if len(integrations[0].Connections) != 0 {
-		t.Fatalf("connections = %+v, want no user-facing connections", integrations[0].Connections)
+	if len(integrations[0].Connections) != 2 {
+		t.Fatalf("connections = %+v, want plugin and default user-facing connections", integrations[0].Connections)
+	}
+	if integrations[0].Connections[0].Name != "plugin" {
+		t.Fatalf("first connection name = %q, want %q", integrations[0].Connections[0].Name, "plugin")
+	}
+	if integrations[0].Connections[1].Name != "default" {
+		t.Fatalf("second connection name = %q, want %q", integrations[0].Connections[1].Name, "default")
+	}
+	for _, conn := range integrations[0].Connections {
+		if !reflect.DeepEqual(conn.AuthTypes, []string{"manual"}) {
+			t.Fatalf("connection auth types = %v, want [manual]", conn.AuthTypes)
+		}
 	}
 }
 
@@ -8405,12 +8416,12 @@ func TestWorkloadAuthorization_ExecuteOperation_UsesBoundIdentityAndRejectsSelec
 	}
 
 	svc := coretesting.NewStubServices(t)
-	seedIdentityToken(t, svc, "svc", "workspace", "team-a", "identity-bound-token")
+	seedSubjectToken(t, svc, principal.WorkloadSubjectID("triage-bot"), "svc", "workspace", "team-a", "identity-bound-token")
 
 	stub := &stubIntegrationWithOps{
 		StubIntegration: coretesting.StubIntegration{
 			N:        "svc",
-			ConnMode: core.ConnectionModeIdentity,
+			ConnMode: core.ConnectionModeUser,
 			ExecuteFn: func(_ context.Context, op string, _ map[string]any, token string) (*core.OperationResult, error) {
 				return &core.OperationResult{Status: http.StatusOK, Body: fmt.Sprintf(`{"operation":%q,"token":%q}`, op, token)}, nil
 			},
@@ -8956,7 +8967,7 @@ func TestWorkloadAuthorization_ExecuteOperation_MissingBoundIdentityTokenReturns
 	stub := &stubIntegrationWithOps{
 		StubIntegration: coretesting.StubIntegration{
 			N:        "svc",
-			ConnMode: core.ConnectionModeIdentity,
+			ConnMode: core.ConnectionModeUser,
 		},
 		ops: []core.Operation{{Name: "run", Method: http.MethodGet}},
 	}
@@ -9009,8 +9020,8 @@ func TestWorkloadAuthorization_ExecuteOperation_MissingBoundIdentityTokenReturns
 	if record["subject_id"] != "workload:triage-bot" {
 		t.Fatalf("expected workload subject_id, got %v", record["subject_id"])
 	}
-	if record["credential_subject_id"] != "identity:__identity__" {
-		t.Fatalf("expected credential_subject_id identity principal, got %v", record["credential_subject_id"])
+	if record["credential_subject_id"] != "workload:triage-bot" {
+		t.Fatalf("expected credential_subject_id workload principal, got %v", record["credential_subject_id"])
 	}
 	if record["credential_connection"] != "workspace" {
 		t.Fatalf("expected credential_connection=workspace, got %v", record["credential_connection"])
@@ -13686,7 +13697,7 @@ func TestMCPEndpoint_WorkloadAuthorizationAndAudit(t *testing.T) {
 	auditSink := invocation.NewSlogAuditSink(&auditBuf)
 	prov := &stubIntegrationWithSessionCatalog{
 		stubIntegrationWithOps: stubIntegrationWithOps{
-			StubIntegration: coretesting.StubIntegration{N: "clickhouse", ConnMode: core.ConnectionModeIdentity},
+			StubIntegration: coretesting.StubIntegration{N: "clickhouse", ConnMode: core.ConnectionModeUser},
 			ops: []core.Operation{
 				{Name: "run_query", Description: "Execute a SQL query"},
 				{Name: "delete_table", Description: "Delete a table"},
@@ -13700,7 +13711,7 @@ func TestMCPEndpoint_WorkloadAuthorizationAndAudit(t *testing.T) {
 	}
 
 	svc := coretesting.NewStubServices(t)
-	seedIdentityToken(t, svc, "clickhouse", "default", "default", "identity-token")
+	seedSubjectToken(t, svc, principal.WorkloadSubjectID("triage-bot"), "clickhouse", "default", "default", "identity-token")
 
 	providers := testutil.NewProviderRegistry(t, prov)
 	authz := mustAuthorizer(t, config.AuthorizationConfig{
@@ -13830,11 +13841,11 @@ func TestMCPEndpoint_WorkloadAuthorizationAndAudit(t *testing.T) {
 	if auditRecord["subject_kind"] != "workload" {
 		t.Fatalf("expected subject_kind workload, got %v", auditRecord["subject_kind"])
 	}
-	if auditRecord["credential_mode"] != "identity" {
-		t.Fatalf("expected credential_mode identity, got %v", auditRecord["credential_mode"])
+	if auditRecord["credential_mode"] != "user" {
+		t.Fatalf("expected credential_mode user, got %v", auditRecord["credential_mode"])
 	}
-	if auditRecord["credential_subject_id"] != "identity:__identity__" {
-		t.Fatalf("expected credential_subject_id identity:__identity__, got %v", auditRecord["credential_subject_id"])
+	if auditRecord["credential_subject_id"] != "workload:triage-bot" {
+		t.Fatalf("expected credential_subject_id workload:triage-bot, got %v", auditRecord["credential_subject_id"])
 	}
 	if auditRecord["credential_connection"] != "default" {
 		t.Fatalf("expected credential_connection default, got %v", auditRecord["credential_connection"])
@@ -14642,53 +14653,6 @@ func TestLogout_NoAuthNilProvider(t *testing.T) {
 	}
 	if auditRecord["allowed"] != true {
 		t.Fatalf("expected audit allowed=true, got %v", auditRecord["allowed"])
-	}
-}
-
-func TestExecuteOperation_ConnectionModeIdentity(t *testing.T) {
-	t.Parallel()
-
-	svc := coretesting.NewStubServices(t)
-	seedToken(t, svc, &core.IntegrationToken{
-		ID: "tok1", SubjectID: principal.IdentitySubjectID(), Integration: "svc",
-		Connection: "", Instance: "default", AccessToken: "identity-tok",
-	})
-
-	stub := &stubIntegrationWithOps{
-		StubIntegration: coretesting.StubIntegration{
-			N:        "svc",
-			ConnMode: core.ConnectionModeIdentity,
-			ExecuteFn: func(_ context.Context, _ string, _ map[string]any, token string) (*core.OperationResult, error) {
-				return &core.OperationResult{Status: http.StatusOK, Body: fmt.Sprintf(`{"token":%q}`, token)}, nil
-			},
-		},
-		ops: []core.Operation{{Name: "do", Method: http.MethodGet}},
-	}
-
-	ts := newTestServer(t, func(cfg *server.Config) {
-		cfg.Providers = testutil.NewProviderRegistry(t, stub)
-		cfg.Services = svc
-	})
-	testutil.CloseOnCleanup(t, ts)
-
-	req, _ := http.NewRequest(http.MethodGet, ts.URL+"/api/v1/svc/do", nil)
-	resp, err := http.DefaultClient.Do(req)
-	if err != nil {
-		t.Fatalf("request: %v", err)
-	}
-	defer func() { _ = resp.Body.Close() }()
-
-	if resp.StatusCode != http.StatusOK {
-		body, _ := io.ReadAll(resp.Body)
-		t.Fatalf("expected 200, got %d: %s", resp.StatusCode, body)
-	}
-
-	var result map[string]any
-	if err := json.NewDecoder(resp.Body).Decode(&result); err != nil {
-		t.Fatalf("decoding: %v", err)
-	}
-	if result["token"] != "identity-tok" {
-		t.Fatalf("expected identity-tok, got %v", result["token"])
 	}
 }
 

--- a/gestaltd/sdk/providermanifest/v1/manifest.jsonschema.json
+++ b/gestaltd/sdk/providermanifest/v1/manifest.jsonschema.json
@@ -202,8 +202,7 @@
           "type": "string",
           "enum": [
             "none",
-            "user",
-            "identity"
+            "user"
           ]
         },
         "auth": {

--- a/gestaltd/sdk/providermanifest/v1/types.go
+++ b/gestaltd/sdk/providermanifest/v1/types.go
@@ -311,9 +311,8 @@ const (
 type ConnectionMode string
 
 const (
-	ConnectionModeNone     ConnectionMode = "none"
-	ConnectionModeUser     ConnectionMode = "user"
-	ConnectionModeIdentity ConnectionMode = "identity"
+	ConnectionModeNone ConnectionMode = "none"
+	ConnectionModeUser ConnectionMode = "user"
 )
 
 type PaginationStyle string


### PR DESCRIPTION
## Summary

This removes owner-specific provider connection modes from `gestaltd` and leaves only the real runtime distinction:

- `none`: no credential is required
- `user`: a credential is required and is resolved by `subject_id`

The old `identity` and `either` connection modes are removed from core runtime handling, manifest validation, and provider metadata.

## Go Interface

Before:
```go
type ConnectionMode string

const (
    ConnectionModeNone     ConnectionMode = "none"
    ConnectionModeUser     ConnectionMode = "user"
    ConnectionModeIdentity ConnectionMode = "identity"
    ConnectionModeEither   ConnectionMode = "either"
)
```

After:
```go
type ConnectionMode string

const (
    ConnectionModeNone ConnectionMode = "none"
    ConnectionModeUser ConnectionMode = "user"
)
```

Runtime effect:
- direct invocation resolves credentialed providers with `principal.EffectiveCredentialSubjectID(...)`
- workload bindings now use subject-owned tokens instead of the shared `identity:__identity__` credential path
- managed workflow workloads no longer skip credentialed providers during authz augmentation

## YAML Interface

Before:
```yaml
connections:
  default:
    mode: identity
    auth:
      type: bearer
```

or
```yaml
connections:
  default:
    mode: either
```

After:
```yaml
connections:
  default:
    mode: user
    auth:
      type: bearer
```

Valid provider connection modes are now only:
- `none`
- `user`

## Examples

Credentialed plugin connection:
```yaml
plugins:
  bigquery:
    connections:
      default:
        mode: user
        auth:
          type: oauth2
```

Tokenless plugin connection:
```yaml
plugins:
  weather:
    connections:
      default:
        mode: none
        auth:
          type: none
```

Workload binding now resolves the token by workload subject:
```yaml
authorization:
  workloads:
    triage-bot:
      token: ${TRIAGE_BOT_TOKEN}
      providers:
        slack:
          connection: workspace
          instance: default
          allow:
            - post_message
```

## Verification

```bash
cd gestaltd
go test ./internal/authorization ./internal/invocation ./internal/bootstrap ./internal/server ./internal/providerpkg ./internal/provider ./internal/composite ./internal/providerhost ./cmd/gestaltd
golangci-lint run ./internal/authorization ./internal/invocation ./internal/bootstrap ./internal/server ./internal/providerpkg ./internal/provider ./internal/composite ./internal/providerhost ./cmd/gestaltd
```

## Migration

No database migration is required for this PR.

The live token tables already use subject-owned credentials, and prod currently has no remaining integration tokens under the removed shared `identity` credential mode.
