### PR TITLE
Enforce plugin route auth on browser login and mounted UIs

### DIFF
--- a/docs/content/providers/web-uis.mdx
+++ b/docs/content/providers/web-uis.mdx
@@ -117,6 +117,9 @@ dashboard and a plugin authorization workspace at `/admin/?tab=members`.
 Plugin-backed mounted UIs inherit the owning plugin's dynamic grants when that
 plugin declares `authorizationPolicy`; direct `providers.ui.<name>.authorizationPolicy`
 bindings remain static-only.
+Plugin-backed mounted UIs also inherit the owning plugin's route-auth provider
+when that plugin declares `auth.provider`; direct `providers.ui` bundles and
+the built-in admin UI continue using the server-wide auth provider.
 
 ## Building your own web UI bundle
 

--- a/docs/content/reference/config-file.mdx
+++ b/docs/content/reference/config-file.mdx
@@ -813,7 +813,7 @@ plugins:
 | `ui` | Optional UI key from `providers.ui` used with `mountPath`. Omit it to mount the plugin manifest's owned `spec.ui`. |
 | `source` | **Required.** The backing provider source. See [source shape](#pluginssource) below. |
 | `source.auth` | Optional metadata-fetch auth for release sources. Use this for `source.url`, `source.githubRelease`, or local `provider-release.yaml` metadata. |
-| `auth` | Optional plugin route auth reference. Use `auth.provider` to reference either the reserved `server` alias or a named entry from `providers.authentication`. Gestalt enforces this on plugin HTTP operation routes (`/api/v1/integrations/{name}/operations` and `/api/v1/{integration}/{operation}`). Browser login, mounted UIs, and `/mcp` still use the server-wide auth provider in this phase. |
+| `auth` | Optional plugin route auth reference. Use `auth.provider` to reference either the reserved `server` alias or a named entry from `providers.authentication`. Gestalt enforces this on plugin HTTP operation routes (`/api/v1/integrations/{name}/operations` and `/api/v1/{integration}/{operation}`) and on plugin-backed mounted UIs, including browser-login flows whose `next` path resolves into that plugin's mount. Standalone `providers.ui` bundles, the built-in admin UI/admin API, and `/mcp` still use the server-wide auth provider in this phase. |
 | `config` | Provider-specific configuration passed into the provider package. |
 | `surfaces` | Typed host-side overrides for manifest-declared surfaces, such as `surfaces.openapi.baseUrl` or `surfaces.graphql.url`. |
 | `connections` | Named connection declarations. See [connections](#connections) below. |
@@ -852,9 +852,12 @@ plugins:
       provider: server
 ```
 
-This field changes runtime authentication for plugin HTTP operation routes only.
-Browser login, mounted UIs, integration OAuth helper routes, and `/mcp` still
-use the server-wide auth provider in this phase.
+This field changes runtime authentication for plugin HTTP operation routes and
+plugin-backed mounted UIs. Browser login uses the plugin's route-auth provider
+when its `next` path resolves into that plugin's mounted UI. Standalone
+`providers.ui` bundles, the built-in admin UI/admin API, integration OAuth
+helper routes, and `/mcp` still use the server-wide auth provider in this
+phase.
 For published providers, `source` can point at a `provider-release.yaml`
 metadata URL directly, or it can describe a GitHub release logically:
 
@@ -922,7 +925,7 @@ Gestalt synthesizes Go and Rust executable wrappers automatically when needed an
 | --- | --- |
 | `source` | A local provider manifest path, a published `provider-release.yaml` metadata URL, `source.url`, or `source.githubRelease` for a GitHub-hosted release asset. |
 | `source.auth` | Optional metadata-fetch auth for release sources, including direct metadata URLs, `source.githubRelease`, and local `provider-release.yaml` metadata. |
-| `auth` | Optional plugin route auth reference. Use `auth.provider` to reference either `server` or a named `providers.authentication` entry. Gestalt enforces this on plugin HTTP operation routes only; browser login, mounted UIs, and `/mcp` still use the server-wide auth provider in this phase. |
+| `auth` | Optional plugin route auth reference. Use `auth.provider` to reference either `server` or a named `providers.authentication` entry. Gestalt enforces this on plugin HTTP operation routes and on plugin-backed mounted UIs. Standalone `providers.ui` bundles, the built-in admin UI/admin API, and `/mcp` still use the server-wide auth provider in this phase. |
 | `env` | Extra environment variables passed to the provider process. |
 | `allowedHosts` | Outbound host allowlist. For executable plugins, this is only a complete boundary when a supported sandboxed runtime is active. |
 

--- a/docs/content/reference/plugin-manifests.mdx
+++ b/docs/content/reference/plugin-manifests.mdx
@@ -177,7 +177,7 @@ The `rest`/`openapi`/`graphql` surface types are mutually exclusive (use `surfac
 
 ### Authentication Types
 
-`spec.auth.provider` selects a route-auth provider for plugin HTTP operation routes. Gestalt currently enforces it on `/api/v1/integrations/{name}/operations` and `/api/v1/{integration}/{operation}` only; browser login, mounted UIs, integration OAuth helper routes, and `/mcp` still use the server-wide auth provider. Upstream auth still lives on `spec.connections.<name>.auth`, and the `auth.type` field on a connection accepts these values:
+`spec.auth.provider` selects a route-auth provider for plugin HTTP routes. Gestalt currently enforces it on `/api/v1/integrations/{name}/operations`, `/api/v1/{integration}/{operation}`, and plugin-backed mounted UIs, including browser-login flows whose `next` path resolves into that plugin's mounted UI. Standalone `providers.ui` bundles, the built-in admin UI/admin API, integration OAuth helper routes, and `/mcp` still use the server-wide auth provider. Upstream auth still lives on `spec.connections.<name>.auth`, and the `auth.type` field on a connection accepts these values:
 
 | Type        | Purpose                                                                                                                                                            |
 | ----------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------ |

--- a/gestaltd/internal/server/handlers_admin_authorization.go
+++ b/gestaltd/internal/server/handlers_admin_authorization.go
@@ -69,7 +69,7 @@ func (s *Server) adminAPIAuthMiddleware(next http.Handler) http.Handler {
 			return
 		}
 
-		p, authenticated, err := s.resolveMountedWebUIPrincipal(r)
+		p, authenticated, err := s.resolveMountedWebUIPrincipal(r, s.adminMountedWebUI())
 		if err != nil {
 			writeError(w, http.StatusInternalServerError, "failed to resolve user")
 			return

--- a/gestaltd/internal/server/handlers_auth.go
+++ b/gestaltd/internal/server/handlers_auth.go
@@ -30,6 +30,9 @@ type authInfoResponse struct {
 }
 
 func (s *Server) authProviderName() string {
+	if s.serverAuthProvider != "" {
+		return s.serverAuthProvider
+	}
 	if s.auth == nil {
 		return "none"
 	}
@@ -59,10 +62,10 @@ func (s *Server) startLogin(w http.ResponseWriter, r *http.Request) {
 	startedAt := time.Now()
 	auditAllowed := false
 	auditErr := errors.New("login start failed")
-	providerName := s.authProviderName()
+	auth := s.serverAuthRuntime()
 	defer func() {
-		metricutil.RecordAuthMetrics(r.Context(), startedAt, providerName, "begin_login", auditErr != nil)
-		s.auditHTTPEvent(r.Context(), nil, s.authProviderName(), "auth.login.start", auditAllowed, auditErr)
+		metricutil.RecordAuthMetrics(r.Context(), startedAt, auth.providerName, "begin_login", auditErr != nil)
+		s.auditHTTPEvent(r.Context(), nil, auth.providerName, "auth.login.start", auditAllowed, auditErr)
 	}()
 
 	var req loginRequest
@@ -75,12 +78,12 @@ func (s *Server) startLogin(w http.ResponseWriter, r *http.Request) {
 	if req.CallbackPort > 0 && req.CallbackPort <= maxPort {
 		state = fmt.Sprintf("%s%d:%s", cliStatePrefix, req.CallbackPort, req.State)
 	}
-	if !s.authEnabled() {
+	if auth.noAuth || auth.provider == nil {
 		auditErr = errors.New("auth is disabled")
 		writeError(w, http.StatusNotFound, "auth is disabled")
 		return
 	}
-	loginURL, err := s.beginLogin(w, r, state, "")
+	loginURL, err := s.beginLogin(w, r, auth, state, "")
 	if err != nil {
 		auditErr = err
 		status := http.StatusInternalServerError
@@ -101,10 +104,10 @@ func (s *Server) startBrowserLogin(w http.ResponseWriter, r *http.Request) {
 	startedAt := time.Now()
 	auditAllowed := false
 	auditErr := errors.New("login start failed")
-	providerName := s.authProviderName()
+	auth := s.serverAuthRuntime()
 	defer func() {
-		metricutil.RecordAuthMetrics(r.Context(), startedAt, providerName, "begin_login", auditErr != nil)
-		s.auditHTTPEvent(r.Context(), nil, s.authProviderName(), "auth.login.start", auditAllowed, auditErr)
+		metricutil.RecordAuthMetrics(r.Context(), startedAt, auth.providerName, "begin_login", auditErr != nil)
+		s.auditHTTPEvent(r.Context(), nil, auth.providerName, "auth.login.start", auditAllowed, auditErr)
 	}()
 
 	nextPath, err := resolveLoginRedirectPath(r.URL.Query().Get("next"), s.allowedLoginRedirectBaseURLs())
@@ -113,13 +116,19 @@ func (s *Server) startBrowserLogin(w http.ResponseWriter, r *http.Request) {
 		writeError(w, http.StatusBadRequest, err.Error())
 		return
 	}
-	if !s.authEnabled() {
+	auth, err = s.loginAuthRuntimeForNextPath(nextPath)
+	if err != nil {
+		auditErr = err
+		writeError(w, http.StatusInternalServerError, err.Error())
+		return
+	}
+	if auth.noAuth || auth.provider == nil {
 		auditErr = errors.New("auth is disabled")
 		writeError(w, http.StatusNotFound, "auth is disabled")
 		return
 	}
 
-	loginURL, err := s.beginLogin(w, r, browserLoginStateForNextPath(nextPath), nextPath)
+	loginURL, err := s.beginLogin(w, r, auth, browserLoginStateForNextPath(nextPath), nextPath)
 	if err != nil {
 		auditErr = err
 		writeError(w, http.StatusInternalServerError, err.Error())
@@ -131,8 +140,8 @@ func (s *Server) startBrowserLogin(w http.ResponseWriter, r *http.Request) {
 	http.Redirect(w, r, loginURL, http.StatusFound)
 }
 
-func (s *Server) beginLogin(w http.ResponseWriter, r *http.Request, state, nextPath string) (string, error) {
-	loginURLRaw, err := loginURLForRequest(r.Context(), s.auth, state)
+func (s *Server) beginLogin(w http.ResponseWriter, r *http.Request, auth authRuntime, state, nextPath string) (string, error) {
+	loginURLRaw, err := loginURLForRequest(r.Context(), auth.provider, state)
 	if err != nil {
 		return "", errors.New("failed to generate login URL")
 	}
@@ -143,6 +152,7 @@ func (s *Server) beginLogin(w http.ResponseWriter, r *http.Request, state, nextP
 	if s.encryptor != nil {
 		encoded, encErr := encodeLoginState(s.encryptor, loginState{
 			State:     state,
+			Provider:  auth.providerRef,
 			NextPath:  nextPath,
 			ExpiresAt: s.now().Add(loginStateTTL).Unix(),
 		})
@@ -310,9 +320,9 @@ type SessionTokenTTLProvider interface {
 	SessionTokenTTL() time.Duration
 }
 
-func (s *Server) setSessionCookie(w http.ResponseWriter, token string) {
+func (s *Server) setSessionCookie(provider core.AuthenticationProvider, w http.ResponseWriter, token string) {
 	maxAge := int(defaultSessionCookieTTL.Seconds())
-	if p, ok := s.auth.(SessionTokenTTLProvider); ok {
+	if p, ok := provider.(SessionTokenTTLProvider); ok {
 		maxAge = int(p.SessionTokenTTL().Seconds())
 	}
 	http.SetCookie(w, &http.Cookie{
@@ -357,14 +367,14 @@ func (s *Server) loginCallback(w http.ResponseWriter, r *http.Request) {
 	auditAllowed := false
 	auditErr := errors.New("login callback failed")
 	auditUserID := ""
-	providerName := s.authProviderName()
+	auth := s.serverAuthRuntime()
 	defer func() {
-		metricutil.RecordAuthMetrics(r.Context(), startedAt, providerName, "complete_login", auditErr != nil)
+		metricutil.RecordAuthMetrics(r.Context(), startedAt, auth.providerName, "complete_login", auditErr != nil)
 		if auditUserID != "" {
-			s.auditHTTPEventWithUserID(r.Context(), auditUserID, principal.SourceSession.String(), s.authProviderName(), "auth.login.complete", auditAllowed, auditErr)
+			s.auditHTTPEventWithUserID(r.Context(), auditUserID, principal.SourceSession.String(), auth.providerName, "auth.login.complete", auditAllowed, auditErr)
 			return
 		}
-		s.auditHTTPEvent(r.Context(), nil, s.authProviderName(), "auth.login.complete", auditAllowed, auditErr)
+		s.auditHTTPEvent(r.Context(), nil, auth.providerName, "auth.login.complete", auditAllowed, auditErr)
 	}()
 
 	code := r.URL.Query().Get("code")
@@ -373,7 +383,22 @@ func (s *Server) loginCallback(w http.ResponseWriter, r *http.Request) {
 		writeError(w, http.StatusBadRequest, "missing code parameter")
 		return
 	}
-	if !s.authEnabled() {
+	loginState, err := s.loginStateForCallback(r)
+	if err != nil {
+		auditErr = errors.New("login state validation failed")
+		slog.ErrorContext(r.Context(), "login state validation failed", "error", err)
+		writeError(w, http.StatusForbidden, "login state validation failed")
+		return
+	}
+
+	auth, err = s.authRuntimeForProvider(loginState.Provider)
+	if err != nil {
+		auditErr = err
+		slog.ErrorContext(r.Context(), "login auth provider resolution failed", "error", err)
+		writeError(w, http.StatusInternalServerError, "login auth provider is not initialized")
+		return
+	}
+	if auth.noAuth || auth.provider == nil {
 		auditErr = errors.New("auth is disabled")
 		writeError(w, http.StatusNotFound, "auth is disabled")
 		return
@@ -381,16 +406,15 @@ func (s *Server) loginCallback(w http.ResponseWriter, r *http.Request) {
 
 	var identity *core.UserIdentity
 	var originalState string
-	var err error
 
-	if handler, ok := s.auth.(RequestCallbackHandler); ok {
+	if handler, ok := auth.provider.(RequestCallbackHandler); ok {
 		identity, originalState, err = handler.HandleCallbackRequest(r.Context(), r.URL.Query())
-	} else if stateful, ok := s.auth.(StatefulCallbackHandler); ok {
+	} else if stateful, ok := auth.provider.(StatefulCallbackHandler); ok {
 		state := r.URL.Query().Get("state")
 		identity, originalState, err = stateful.HandleCallbackWithState(r.Context(), code, state)
 	} else {
 		originalState = r.URL.Query().Get("state")
-		identity, err = s.auth.HandleCallback(r.Context(), code)
+		identity, err = auth.provider.HandleCallback(r.Context(), code)
 	}
 	if err != nil {
 		auditErr = errors.New("login failed")
@@ -399,10 +423,9 @@ func (s *Server) loginCallback(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	loginState, csrfErr := s.validateLoginState(r, originalState)
-	if csrfErr != nil {
+	if !loginStatesMatch(loginState.State, originalState) {
 		auditErr = errors.New("login state validation failed")
-		slog.ErrorContext(r.Context(), "login state validation failed", "error", csrfErr)
+		slog.ErrorContext(r.Context(), "login state validation failed", "error", errors.New("login state mismatch"))
 		writeError(w, http.StatusForbidden, "login state validation failed")
 		return
 	}
@@ -453,13 +476,13 @@ func (s *Server) loginCallback(w http.ResponseWriter, r *http.Request) {
 		"displayName": identity.DisplayName,
 	}
 
-	token, err := s.issueSessionToken(identity)
+	token, err := s.issueSessionToken(auth.provider, identity)
 	if err != nil {
 		auditErr = errors.New("failed to issue session token")
 		writeError(w, http.StatusInternalServerError, "failed to issue session token")
 		return
 	}
-	s.setSessionCookie(w, token)
+	s.setSessionCookie(auth.provider, w, token)
 
 	auditAllowed = true
 	auditErr = nil
@@ -470,22 +493,25 @@ func (s *Server) loginCallback(w http.ResponseWriter, r *http.Request) {
 	writeJSON(w, http.StatusOK, resp)
 }
 
-func (s *Server) validateLoginState(r *http.Request, originalState string) (*loginState, error) {
+func (s *Server) loginStateForCallback(r *http.Request) (*loginState, error) {
 	if s.encryptor == nil {
-		return &loginState{State: originalState}, nil
+		return &loginState{
+			State:    r.URL.Query().Get("state"),
+			Provider: "server",
+		}, nil
 	}
 	cookie, err := r.Cookie(loginStateCookieName)
 	if err != nil {
 		return nil, fmt.Errorf("missing login state cookie")
 	}
-	expected, err := decodeLoginState(s.encryptor, cookie.Value, s.now())
+	state, err := decodeLoginState(s.encryptor, cookie.Value, s.now())
 	if err != nil {
 		return nil, fmt.Errorf("invalid login state cookie: %w", err)
 	}
-	if !loginStatesMatch(expected.State, originalState) {
-		return nil, fmt.Errorf("login state mismatch")
+	if strings.TrimSpace(state.Provider) == "" {
+		state.Provider = "server"
 	}
-	return expected, nil
+	return state, nil
 }
 
 func loginStatesMatch(expectedState, originalState string) bool {

--- a/gestaltd/internal/server/middleware.go
+++ b/gestaltd/internal/server/middleware.go
@@ -228,30 +228,19 @@ func (s *Server) pluginRouteAuthMiddleware(pluginParam string) func(http.Handler
 		return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 			pluginName := strings.TrimSpace(chi.URLParam(r, pluginParam))
 			if pluginName == "" {
-				s.serveAuthenticated(w, r, next, s.resolver, s.noAuth, s.anonymousPrincipal, "")
+				auth := s.serverAuthRuntime()
+				s.serveAuthenticated(w, r, next, auth.resolver, auth.noAuth, auth.anonymous, auth.providerName)
 				return
 			}
 
-			entry := s.pluginDefs[pluginName]
-			if entry == nil || entry.RouteAuth == nil || strings.TrimSpace(entry.RouteAuth.Provider) == "" {
-				s.serveAuthenticated(w, r, next, s.resolver, s.noAuth, s.anonymousPrincipal, "")
-				return
-			}
-
-			providerName := strings.TrimSpace(entry.RouteAuth.Provider)
-			if providerName == "server" {
-				s.serveAuthenticated(w, r, next, s.resolver, s.noAuth, s.anonymousPrincipal, "")
-				return
-			}
-
-			resolver := s.authResolvers[providerName]
-			if resolver == nil {
-				slog.ErrorContext(r.Context(), "plugin route auth provider is not initialized", "plugin", pluginName, "auth_provider", providerName)
+			auth, err := s.pluginAuthRuntime(pluginName)
+			if err != nil {
+				slog.ErrorContext(r.Context(), "plugin route auth provider is not initialized", "plugin", pluginName, "error", err)
 				writeError(w, http.StatusInternalServerError, "plugin route auth provider is not initialized")
 				return
 			}
 
-			s.serveAuthenticated(w, r, next, resolver, false, nil, providerName)
+			s.serveAuthenticated(w, r, next, auth.resolver, auth.noAuth, auth.anonymous, auth.providerName)
 		})
 	}
 }

--- a/gestaltd/internal/server/mounted_ui.go
+++ b/gestaltd/internal/server/mounted_ui.go
@@ -302,7 +302,7 @@ func (s *Server) authorizeProtectedUIRequest(w http.ResponseWriter, r *http.Requ
 		return nil, false
 	}
 
-	p, authenticated, err := s.resolveMountedWebUIPrincipal(r)
+	p, authenticated, err := s.resolveMountedWebUIPrincipal(r, mounted)
 	if err != nil {
 		writeError(w, http.StatusInternalServerError, "failed to resolve user")
 		return nil, false
@@ -352,12 +352,16 @@ func (s *Server) authorizeProtectedUIRequest(w http.ResponseWriter, r *http.Requ
 	return ctx, true
 }
 
-func (s *Server) resolveMountedWebUIPrincipal(r *http.Request) (*principal.Principal, bool, error) {
-	if s.noAuth {
-		return s.anonymousPrincipal, true, nil
+func (s *Server) resolveMountedWebUIPrincipal(r *http.Request, mounted MountedWebUI) (*principal.Principal, bool, error) {
+	auth, err := s.mountedWebUIAuthRuntime(mounted)
+	if err != nil {
+		return nil, false, err
+	}
+	if auth.noAuth {
+		return auth.anonymous, true, nil
 	}
 
-	p, err := s.resolveRequestPrincipal(r)
+	p, err := s.resolveRequestPrincipalWithResolver(r, auth.resolver)
 	switch {
 	case err == nil && p != nil:
 		enriched, enrichErr := s.resolvePrincipalUserID(r.Context(), p)

--- a/gestaltd/internal/server/oauth_state.go
+++ b/gestaltd/internal/server/oauth_state.go
@@ -100,6 +100,7 @@ const loginStateCookieName = "login_state"
 
 type loginState struct {
 	State     string `json:"s"`
+	Provider  string `json:"p,omitempty"`
 	NextPath  string `json:"n,omitempty"`
 	ExpiresAt int64  `json:"exp"`
 }

--- a/gestaltd/internal/server/route_auth_runtime.go
+++ b/gestaltd/internal/server/route_auth_runtime.go
@@ -1,0 +1,145 @@
+package server
+
+import (
+	"fmt"
+	"net/url"
+	"strings"
+
+	"github.com/valon-technologies/gestalt/server/core"
+	"github.com/valon-technologies/gestalt/server/internal/principal"
+)
+
+type authRuntime struct {
+	providerRef  string
+	providerName string
+	provider     core.AuthenticationProvider
+	resolver     *principal.Resolver
+	noAuth       bool
+	anonymous    *principal.Principal
+}
+
+func (s *Server) serverAuthRuntime() authRuntime {
+	return authRuntime{
+		providerRef:  "server",
+		providerName: s.authProviderName(),
+		provider:     s.auth,
+		resolver:     s.resolver,
+		noAuth:       s.noAuth,
+		anonymous:    s.anonymousPrincipal,
+	}
+}
+
+func (s *Server) authRuntimeForProvider(providerName string) (authRuntime, error) {
+	providerName = strings.TrimSpace(providerName)
+	if providerName == "" || providerName == "server" {
+		return s.serverAuthRuntime(), nil
+	}
+
+	provider := s.authProviders[providerName]
+	resolver := s.authResolvers[providerName]
+	if provider == nil || resolver == nil {
+		return authRuntime{
+			providerRef:  providerName,
+			providerName: providerName,
+		}, fmt.Errorf("plugin route auth provider %q is not initialized", providerName)
+	}
+
+	runtime := authRuntime{
+		providerRef:  providerName,
+		providerName: providerName,
+		provider:     provider,
+		resolver:     resolver,
+	}
+	if provider.Name() == "none" {
+		runtime.noAuth = true
+		runtime.anonymous = s.anonymousPrincipal
+		if runtime.anonymous == nil {
+			runtime.anonymous = s.resolver.ResolveEmail(anonymousEmail)
+		}
+	}
+	return runtime, nil
+}
+
+func (s *Server) pluginAuthRuntime(pluginName string) (authRuntime, error) {
+	pluginName = strings.TrimSpace(pluginName)
+	if pluginName == "" {
+		return s.serverAuthRuntime(), nil
+	}
+
+	entry := s.pluginDefs[pluginName]
+	if entry == nil || entry.RouteAuth == nil {
+		return s.serverAuthRuntime(), nil
+	}
+	return s.authRuntimeForProvider(entry.RouteAuth.Provider)
+}
+
+func (s *Server) mountedWebUIAuthRuntime(mounted MountedWebUI) (authRuntime, error) {
+	if strings.TrimSpace(mounted.PluginName) == "" {
+		return s.serverAuthRuntime(), nil
+	}
+	return s.pluginAuthRuntime(mounted.PluginName)
+}
+
+func (s *Server) loginAuthRuntimeForNextPath(nextPath string) (authRuntime, error) {
+	mounted, ok := s.mountedWebUIForNextPath(nextPath)
+	if !ok {
+		return s.serverAuthRuntime(), nil
+	}
+	return s.mountedWebUIAuthRuntime(mounted)
+}
+
+func (s *Server) mountedWebUIForNextPath(nextPath string) (MountedWebUI, bool) {
+	parsed, err := url.Parse(nextPath)
+	if err != nil {
+		return MountedWebUI{}, false
+	}
+	path := parsed.Path
+	if path == "" {
+		path = "/"
+	}
+	if !strings.HasPrefix(path, "/") {
+		path = "/" + path
+	}
+	return s.mountedWebUIForPath(path)
+}
+
+func (s *Server) mountedWebUIForPath(path string) (MountedWebUI, bool) {
+	path = strings.TrimSpace(path)
+	if path == "" {
+		path = "/"
+	}
+	if !strings.HasPrefix(path, "/") {
+		path = "/" + path
+	}
+
+	var (
+		best        MountedWebUI
+		bestLen     int
+		bestMatched bool
+	)
+	consider := func(candidate MountedWebUI) {
+		if candidate.Path == "" || !mountedWebUIPathMatches(path, candidate.Path) {
+			return
+		}
+		if !bestMatched || len(candidate.Path) > bestLen {
+			best = candidate
+			bestLen = len(candidate.Path)
+			bestMatched = true
+		}
+	}
+
+	for _, mounted := range s.mountedWebUIs {
+		consider(mounted)
+	}
+	if s.adminUI != nil {
+		consider(s.adminMountedWebUI())
+	}
+	return best, bestMatched
+}
+
+func mountedWebUIPathMatches(requestPath, mountedPath string) bool {
+	if mountedPath == "/" {
+		return strings.HasPrefix(requestPath, "/")
+	}
+	return requestPath == mountedPath || strings.HasPrefix(requestPath, mountedPath+"/")
+}

--- a/gestaltd/internal/server/server.go
+++ b/gestaltd/internal/server/server.go
@@ -63,6 +63,8 @@ type Server struct {
 	router                chi.Router
 	handler               http.Handler
 	auth                  core.AuthenticationProvider
+	authProviders         map[string]core.AuthenticationProvider
+	serverAuthProvider    string
 	auditSink             core.AuditSink
 	users                 *coredata.UserService
 	tokens                *coredata.TokenService
@@ -142,6 +144,14 @@ func New(cfg Config) (*Server, error) {
 		return nil, fmt.Errorf("invoker is required")
 	}
 	noAuth := cfg.Auth == nil || cfg.Auth.Name() == "none"
+	serverAuthProvider := strings.TrimSpace(cfg.SelectedAuthProvider)
+	if serverAuthProvider == "" {
+		if cfg.Auth == nil {
+			serverAuthProvider = "none"
+		} else {
+			serverAuthProvider = cfg.Auth.Name()
+		}
+	}
 	var stateCodec *integrationOAuthStateCodec
 	var encryptor *cryptoutil.AESGCMEncryptor
 	if len(cfg.StateSecret) > 0 {
@@ -224,6 +234,8 @@ func New(cfg Config) (*Server, error) {
 		router:                router,
 		handler:               withRequestMeterProvider(otelhttp.NewHandler(router, "gestaltd", otelOptions...), cfg.MeterProvider),
 		auth:                  cfg.Auth,
+		authProviders:         authProviders,
+		serverAuthProvider:    serverAuthProvider,
 		auditSink:             cfg.AuditSink,
 		users:                 users,
 		tokens:                tokens,
@@ -262,7 +274,7 @@ func New(cfg Config) (*Server, error) {
 		adminUI:               adminUI,
 		routeProfile:          cfg.RouteProfile,
 	}
-	if noAuth {
+	if noAuth || hasAnonymousAuthProvider(authProviders) {
 		s.anonymousPrincipal = resolver.ResolveEmail(anonymousEmail)
 	}
 
@@ -270,18 +282,27 @@ func New(cfg Config) (*Server, error) {
 	return s, nil
 }
 
-func (s *Server) issueSessionToken(identity *core.UserIdentity) (string, error) {
-	if issuer, ok := s.auth.(SessionTokenIssuer); ok {
+func (s *Server) issueSessionToken(provider core.AuthenticationProvider, identity *core.UserIdentity) (string, error) {
+	if issuer, ok := provider.(SessionTokenIssuer); ok {
 		return issuer.IssueSessionToken(identity)
 	}
 	if len(s.sessionIssuer) == 0 {
 		return "", fmt.Errorf("session secret is not configured")
 	}
 	ttl := defaultSessionCookieTTL
-	if p, ok := s.auth.(SessionTokenTTLProvider); ok {
+	if p, ok := provider.(SessionTokenTTLProvider); ok {
 		ttl = p.SessionTokenTTL()
 	}
 	return session.IssueToken(identity, s.sessionIssuer, ttl)
+}
+
+func hasAnonymousAuthProvider(providers map[string]core.AuthenticationProvider) bool {
+	for _, provider := range providers {
+		if provider != nil && provider.Name() == "none" {
+			return true
+		}
+	}
+	return false
 }
 
 func (s *Server) ServeHTTP(w http.ResponseWriter, r *http.Request) {

--- a/gestaltd/internal/server/server_test.go
+++ b/gestaltd/internal/server/server_test.go
@@ -1386,6 +1386,154 @@ func TestMountedWebUIRoutes_HumanAuthorization(t *testing.T) {
 	}
 }
 
+func TestMountedWebUIRoutes_HumanAuthorization_UsesPluginRouteAuthOverride(t *testing.T) {
+	t.Parallel()
+
+	dir := t.TempDir()
+	if err := os.WriteFile(filepath.Join(dir, "index.html"), []byte("<html>protected-sample-shell</html>"), 0o644); err != nil {
+		t.Fatalf("WriteFile index.html: %v", err)
+	}
+	handler, err := testutilWebUIHandler(dir)
+	if err != nil {
+		t.Fatalf("webui handler: %v", err)
+	}
+
+	svc := coretesting.NewStubServices(t)
+	viewer := seedUser(t, svc, "viewer@example.test")
+	legacy := mustAuthorizer(t, config.AuthorizationConfig{
+		Policies: map[string]config.HumanPolicyDef{
+			"sample_policy": {
+				Default: "deny",
+				Members: []config.HumanPolicyMemberDef{
+					{SubjectID: principal.UserSubjectID(viewer.ID), Role: "viewer"},
+				},
+			},
+		},
+	}, nil, map[string]*config.ProviderEntry{
+		"sample_portal": {AuthorizationPolicy: "sample_policy"},
+	}, nil)
+
+	serverSecret := []byte("0123456789abcdef0123456789abcdef")
+	altSecret := []byte("abcdef0123456789abcdef0123456789")
+	jar, err := cookiejar.New(nil)
+	if err != nil {
+		t.Fatalf("cookiejar.New: %v", err)
+	}
+	client := &http.Client{
+		Jar: jar,
+		CheckRedirect: func(_ *http.Request, _ []*http.Request) error {
+			return http.ErrUseLastResponse
+		},
+	}
+
+	ts := newTestServer(t, func(cfg *server.Config) {
+		cfg.Auth = &stubHostIssuedSessionAuth{
+			secret:    serverSecret,
+			name:      "server",
+			loginHost: "server-idp.example.test",
+			email:     "server@example.test",
+		}
+		cfg.StateSecret = altSecret
+		cfg.SelectedAuthProvider = "server"
+		cfg.AuthProviders = map[string]core.AuthenticationProvider{
+			"alt": &stubHostIssuedSessionAuth{
+				secret:    altSecret,
+				name:      "alt",
+				loginHost: "alt-idp.example.test",
+				email:     "viewer@example.test",
+			},
+		}
+		cfg.Services = svc
+		cfg.Authorizer = legacy
+		cfg.PluginDefs = map[string]*config.ProviderEntry{
+			"sample_portal": {
+				AuthorizationPolicy: "sample_policy",
+				RouteAuth:           &config.RouteAuthDef{Provider: "alt"},
+			},
+		}
+		cfg.MountedWebUIs = []server.MountedWebUI{{
+			Name:                "sample_portal",
+			Path:                "/sample-portal",
+			PluginName:          "sample_portal",
+			AuthorizationPolicy: "sample_policy",
+			Routes: []server.MountedWebUIRoute{
+				{Path: "/*", AllowedRoles: []string{"viewer", "admin"}},
+			},
+			Handler: handler,
+		}}
+	})
+	testutil.CloseOnCleanup(t, ts)
+
+	protectedPath := "/sample-portal/sync?code=invite-code&state=abc123"
+	resp, err := client.Get(ts.URL + protectedPath)
+	if err != nil {
+		t.Fatalf("GET protected mounted ui without auth: %v", err)
+	}
+	defer func() { _ = resp.Body.Close() }()
+	if resp.StatusCode != http.StatusFound {
+		t.Fatalf("start status = %d, want %d", resp.StatusCode, http.StatusFound)
+	}
+	if got, want := resp.Header.Get("Location"), "/api/v1/auth/login?next=%2Fsample-portal%2Fsync%3Fcode%3Dinvite-code%26state%3Dabc123"; got != want {
+		t.Fatalf("start Location = %q, want %q", got, want)
+	}
+
+	loginStartResp, err := client.Get(ts.URL + resp.Header.Get("Location"))
+	if err != nil {
+		t.Fatalf("start browser login: %v", err)
+	}
+	defer func() { _ = loginStartResp.Body.Close() }()
+	if loginStartResp.StatusCode != http.StatusFound {
+		t.Fatalf("login start status = %d, want %d", loginStartResp.StatusCode, http.StatusFound)
+	}
+	loginURL, err := url.Parse(loginStartResp.Header.Get("Location"))
+	if err != nil {
+		t.Fatalf("parse login redirect: %v", err)
+	}
+	if got, want := loginURL.Host, "alt-idp.example.test"; got != want {
+		t.Fatalf("login redirect host = %q, want %q", got, want)
+	}
+	if got, want := loginURL.Query().Get("state"), "/sample-portal/sync"; got != want {
+		t.Fatalf("login redirect state = %q, want %q", got, want)
+	}
+
+	callbackResp, err := client.Get(ts.URL + "/api/v1/auth/login/callback?code=good-code&state=" + url.QueryEscape(loginURL.Query().Get("state")))
+	if err != nil {
+		t.Fatalf("browser login callback: %v", err)
+	}
+	defer func() { _ = callbackResp.Body.Close() }()
+	if callbackResp.StatusCode != http.StatusFound {
+		t.Fatalf("callback status = %d, want %d", callbackResp.StatusCode, http.StatusFound)
+	}
+	if got, want := callbackResp.Header.Get("Location"), protectedPath; got != want {
+		t.Fatalf("callback redirect = %q, want %q", got, want)
+	}
+
+	resp, err = client.Get(ts.URL + protectedPath)
+	if err != nil {
+		t.Fatalf("GET protected mounted ui with route-auth session: %v", err)
+	}
+	body, err := io.ReadAll(resp.Body)
+	_ = resp.Body.Close()
+	if err != nil {
+		t.Fatalf("ReadAll protected mounted ui: %v", err)
+	}
+	if resp.StatusCode != http.StatusOK {
+		t.Fatalf("protected mounted ui status = %d, want %d", resp.StatusCode, http.StatusOK)
+	}
+	if !strings.Contains(string(body), "protected-sample-shell") {
+		t.Fatalf("body = %q, want protected sample shell", body)
+	}
+
+	resp, err = client.Get(ts.URL + "/api/v1/integrations")
+	if err != nil {
+		t.Fatalf("GET integrations with route-auth session: %v", err)
+	}
+	defer func() { _ = resp.Body.Close() }()
+	if resp.StatusCode != http.StatusUnauthorized {
+		t.Fatalf("integrations status = %d, want %d", resp.StatusCode, http.StatusUnauthorized)
+	}
+}
+
 func TestMountedWebUIRoutes_HumanAuthorization_DefaultAllowTreatsAuthenticatedUsersAsViewerWithPluginName(t *testing.T) {
 	t.Parallel()
 
@@ -9977,6 +10125,54 @@ func TestStartLogin_NoAuthInvalidJSON(t *testing.T) {
 	}
 }
 
+func TestStartBrowserLogin_MissingPluginRouteAuthProviderAuditsAttemptedProvider(t *testing.T) {
+	t.Parallel()
+
+	var auditBuf bytes.Buffer
+	auditSink := invocation.NewSlogAuditSink(&auditBuf)
+	ts := newTestServer(t, func(cfg *server.Config) {
+		cfg.Auth = &stubHostIssuedSessionAuth{name: "server"}
+		cfg.SelectedAuthProvider = "server"
+		cfg.AuditSink = auditSink
+		cfg.MountedWebUIs = []server.MountedWebUI{{
+			Name:       "sample_portal",
+			Path:       "/sample-portal",
+			PluginName: "sample_portal",
+			Handler:    http.NotFoundHandler(),
+		}}
+		cfg.PluginDefs = map[string]*config.ProviderEntry{
+			"sample_portal": {RouteAuth: &config.RouteAuthDef{Provider: "alt"}},
+		}
+	})
+	testutil.CloseOnCleanup(t, ts)
+
+	noRedirect := &http.Client{CheckRedirect: func(_ *http.Request, _ []*http.Request) error {
+		return http.ErrUseLastResponse
+	}}
+	resp, err := noRedirect.Get(ts.URL + "/api/v1/auth/login?next=" + url.QueryEscape("/sample-portal"))
+	if err != nil {
+		t.Fatalf("GET browser login start: %v", err)
+	}
+	defer func() { _ = resp.Body.Close() }()
+	if resp.StatusCode != http.StatusInternalServerError {
+		t.Fatalf("status = %d, want %d", resp.StatusCode, http.StatusInternalServerError)
+	}
+
+	var auditRecord map[string]any
+	if err := json.Unmarshal(bytes.TrimSpace(auditBuf.Bytes()), &auditRecord); err != nil {
+		t.Fatalf("parsing audit record: %v\nraw: %s", err, auditBuf.String())
+	}
+	if auditRecord["operation"] != "auth.login.start" {
+		t.Fatalf("expected audit operation auth.login.start, got %v", auditRecord["operation"])
+	}
+	if auditRecord["provider"] != "alt" {
+		t.Fatalf("expected audit provider alt, got %v", auditRecord["provider"])
+	}
+	if auditRecord["allowed"] != false {
+		t.Fatalf("expected audit allowed=false, got %v", auditRecord["allowed"])
+	}
+}
+
 func TestLoginCallback(t *testing.T) {
 	t.Parallel()
 
@@ -10052,6 +10248,96 @@ func TestLoginCallback(t *testing.T) {
 	}
 	if uid, ok := auditRecord["user_id"].(string); !ok || uid != existing.ID {
 		t.Fatalf("expected audit user_id %q, got %v", existing.ID, auditRecord["user_id"])
+	}
+}
+
+func TestLoginCallback_MissingPluginRouteAuthProviderAuditsAttemptedProvider(t *testing.T) {
+	t.Parallel()
+
+	secret := []byte("0123456789abcdef0123456789abcdef")
+	startJar, err := cookiejar.New(nil)
+	if err != nil {
+		t.Fatalf("cookiejar.New: %v", err)
+	}
+	startClient := &http.Client{
+		Jar: startJar,
+		CheckRedirect: func(_ *http.Request, _ []*http.Request) error {
+			return http.ErrUseLastResponse
+		},
+	}
+
+	startServer := newTestServer(t, func(cfg *server.Config) {
+		cfg.Auth = &stubHostIssuedSessionAuth{name: "server"}
+		cfg.SelectedAuthProvider = "server"
+		cfg.StateSecret = secret
+		cfg.AuthProviders = map[string]core.AuthenticationProvider{
+			"alt": &stubHostIssuedSessionAuth{name: "alt"},
+		}
+		cfg.MountedWebUIs = []server.MountedWebUI{{
+			Name:       "sample_portal",
+			Path:       "/sample-portal",
+			PluginName: "sample_portal",
+			Handler:    http.NotFoundHandler(),
+		}}
+		cfg.PluginDefs = map[string]*config.ProviderEntry{
+			"sample_portal": {RouteAuth: &config.RouteAuthDef{Provider: "alt"}},
+		}
+	})
+	testutil.CloseOnCleanup(t, startServer)
+
+	startResp, err := startClient.Get(startServer.URL + "/api/v1/auth/login?next=" + url.QueryEscape("/sample-portal"))
+	if err != nil {
+		t.Fatalf("start browser login: %v", err)
+	}
+	defer func() { _ = startResp.Body.Close() }()
+	if startResp.StatusCode != http.StatusFound {
+		t.Fatalf("start status = %d, want %d", startResp.StatusCode, http.StatusFound)
+	}
+
+	var loginStateCookie *http.Cookie
+	for _, cookie := range startJar.Cookies(startResp.Request.URL) {
+		if cookie.Name == "login_state" {
+			c := *cookie
+			loginStateCookie = &c
+			break
+		}
+	}
+	if loginStateCookie == nil {
+		t.Fatal("expected login_state cookie")
+	}
+
+	var auditBuf bytes.Buffer
+	callbackServer := newTestServer(t, func(cfg *server.Config) {
+		cfg.Auth = &stubHostIssuedSessionAuth{name: "server"}
+		cfg.SelectedAuthProvider = "server"
+		cfg.StateSecret = secret
+		cfg.AuditSink = invocation.NewSlogAuditSink(&auditBuf)
+	})
+	testutil.CloseOnCleanup(t, callbackServer)
+
+	req, _ := http.NewRequest(http.MethodGet, callbackServer.URL+"/api/v1/auth/login/callback?code=good-code&state="+url.QueryEscape("/sample-portal"), nil)
+	req.AddCookie(loginStateCookie)
+	resp, err := http.DefaultClient.Do(req)
+	if err != nil {
+		t.Fatalf("callback request: %v", err)
+	}
+	defer func() { _ = resp.Body.Close() }()
+	if resp.StatusCode != http.StatusInternalServerError {
+		t.Fatalf("callback status = %d, want %d", resp.StatusCode, http.StatusInternalServerError)
+	}
+
+	var auditRecord map[string]any
+	if err := json.Unmarshal(bytes.TrimSpace(auditBuf.Bytes()), &auditRecord); err != nil {
+		t.Fatalf("parsing audit record: %v\nraw: %s", err, auditBuf.String())
+	}
+	if auditRecord["operation"] != "auth.login.complete" {
+		t.Fatalf("expected audit operation auth.login.complete, got %v", auditRecord["operation"])
+	}
+	if auditRecord["provider"] != "alt" {
+		t.Fatalf("expected audit provider alt, got %v", auditRecord["provider"])
+	}
+	if auditRecord["allowed"] != false {
+		t.Fatalf("expected audit allowed=false, got %v", auditRecord["allowed"])
 	}
 }
 
@@ -14425,13 +14711,26 @@ func (s *stubAuthWithToken) SessionTokenTTL() time.Duration {
 }
 
 type stubHostIssuedSessionAuth struct {
-	secret []byte
+	secret      []byte
+	name        string
+	loginHost   string
+	email       string
+	displayName string
 }
 
-func (s *stubHostIssuedSessionAuth) Name() string { return "host-issued" }
+func (s *stubHostIssuedSessionAuth) Name() string {
+	if s.name != "" {
+		return s.name
+	}
+	return "host-issued"
+}
 
 func (s *stubHostIssuedSessionAuth) LoginURL(state string) (string, error) {
-	return "https://idp.example.test/login?state=" + url.QueryEscape(state), nil
+	host := s.loginHost
+	if host == "" {
+		host = "idp.example.test"
+	}
+	return "https://" + host + "/login?state=" + url.QueryEscape(state), nil
 }
 
 func (s *stubHostIssuedSessionAuth) HandleCallback(_ context.Context, _ string) (*core.UserIdentity, error) {
@@ -14442,7 +14741,15 @@ func (s *stubHostIssuedSessionAuth) HandleCallbackWithState(_ context.Context, c
 	if code != "good-code" {
 		return nil, "", fmt.Errorf("unexpected code %q", code)
 	}
-	return &core.UserIdentity{Email: "host@example.com", DisplayName: "Host Issued"}, state, nil
+	email := s.email
+	if email == "" {
+		email = "host@example.com"
+	}
+	displayName := s.displayName
+	if displayName == "" {
+		displayName = "Host Issued"
+	}
+	return &core.UserIdentity{Email: email, DisplayName: displayName}, state, nil
 }
 
 func (s *stubHostIssuedSessionAuth) ValidateToken(_ context.Context, token string) (*core.UserIdentity, error) {


### PR DESCRIPTION
## Summary

Extend plugin route auth beyond HTTP operation routes so plugin-backed mounted UIs and browser login flows whose `next` path resolves into a plugin mount use the same named auth-provider override.

## Interfaces

Manifest:

```yaml
spec:
  auth:
    provider: slack_sso
  connections:
    default:
      mode: user
      auth:
        type: oauth2
        authorizationUrl: https://slack.com/oauth/v2/authorize
        tokenUrl: https://slack.com/api/oauth.v2.access
```

Config:

```yaml
plugins:
  slack_bot:
    mountPath: /slack-bot
    auth:
      provider: slack_sso
```

Runtime scope now includes:
- `GET /api/v1/integrations/{name}/operations`
- `GET|POST /api/v1/{integration}/{operation}`
- plugin-backed mounted UIs
- browser login when `next` resolves into a plugin-backed mounted UI

Runtime scope still excludes:
- standalone `providers.ui` bundles
- built-in admin UI and admin API
- integration OAuth helper routes
- `/mcp`

## Behavior

- `/slack-bot/*` browser login redirects use the `slack_sso` auth provider.
- The callback issues a session using that provider's auth runtime.
- Mounted UI requests validate that session with the same provider override.
- Standalone `providers.ui` bundles and admin surfaces continue using server auth.

## Validation

- `go test ./internal/server -run 'TestPluginRouteAuth_HTTPRoutesUseNamedProviderOverride|TestMountedWebUIRoutes_HumanAuthorization|TestMountedWebUIRoutes_HumanAuthorization_UsesPluginRouteAuthOverride|TestBrowserLoginRedirect_RedirectsBackToNextPath|TestBuiltInAdminRoute_HumanAuthorizationSplitManagementLoginFlow|TestAuditMetadata_AuthMiddlewareFailures|TestAuthInfo|TestAuthInfoFallback|TestAuthInfoNoAuth|TestCookieAuth' -count=1`
- `go test ./internal/bootstrap -run 'TestResultCloseClosesAuthProvider|TestBootstrapHostFactorySelection/auth_source_map|TestBootstrapHostFactorySelection/omits_auth_when_auth_provider_is_unset' -count=1`
