### PR TITLE
[codex] Fix Bugbot workflow and auth follow-ups

### DIFF
--- a/docs/content/providers/index.mdx
+++ b/docs/content/providers/index.mdx
@@ -32,7 +32,7 @@ starts it with the permissions and request context it needs.
 - Use `source: https://.../provider-release.yaml` to consume a published provider package.
 - Use `source.githubRelease` when the published `provider-release.yaml` lives in
   a private GitHub Release and you want checked-in config to stay readable.
-- Use sibling `auth.token` when a remote release source, including
+- Use `source.auth.token` when a remote release source, including
   `source.githubRelease`, needs authenticated metadata or archive fetches.
 - Executable providers run as child processes and connect back to the host over
   gRPC on a temporary Unix socket.

--- a/docs/content/reference/plugin-manifests.mdx
+++ b/docs/content/reference/plugin-manifests.mdx
@@ -78,14 +78,11 @@ The `spec` block for a `kind: plugin` manifest describes a plugin. It supports d
 
 Plugins that back mounted apps may declare their UI artifact in the plugin manifest. Deployment config still chooses whether to mount the app, which public path to use, and which authorization policy to bind. The manifest only says which UI bundle belongs to the plugin.
 
-`spec.ui` supports two mutually exclusive forms:
+`spec.ui` currently supports a single packaged-path form:
 
-| Field        | Type   | Purpose                                                                                                                                                                            |
-| ------------ | ------ | ---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| `path`       | string | Relative path to a co-packaged `kind: webui` manifest. Source releases may point at sibling UI packages; `gestaltd provider release` rewrites them into the archive automatically. |
-| `ref`        | string | Managed provider source ref for the owned UI bundle.                                                                                                                               |
-| `version`    | string | Optional version for `ref`. Defaults to the plugin manifest version when omitted.                                                                                                  |
-| `auth.token` | string | Optional source token used when resolving a private managed `ref`. Only valid with `ref`.                                                                                          |
+| Field | Type | Purpose |
+| --- | --- | --- |
+| `path` | string | Relative path to a co-packaged `kind: webui` manifest. Source releases may point at sibling UI packages; `gestaltd provider release` rewrites them into the archive automatically. |
 
 When a deployment sets `plugins.<name>.mountPath` and omits `plugins.<name>.ui`, Gestalt synthesizes the mounted UI binding from this block.
 
@@ -106,7 +103,7 @@ spec:
     path: ../ui/manifest.yaml
 ```
 
-Published-manifest example:
+Packaged-manifest example:
 
 ```yaml
 kind: plugin
@@ -120,13 +117,7 @@ spec:
       auth:
         type: none
   ui:
-    ref: github.com/acme/web/roadmap-review
-    version: 1.0.0
-    auth:
-      token:
-        secret:
-          provider: default
-          name: roadmap-review-ui-source-token
+    path: ui/manifest.yaml
 ```
 
 ### Connections

--- a/gestaltd/internal/authorization/authorizer.go
+++ b/gestaltd/internal/authorization/authorizer.go
@@ -57,6 +57,7 @@ type Authorizer struct {
 	policies             map[string]*HumanPolicy
 	providerPolicies     map[string]string
 	providerModes        map[string]core.ConnectionMode
+	defaultConnections   map[string]string
 }
 
 func New(cfg config.AuthorizationConfig, pluginDefs map[string]*config.ProviderEntry, providers *registry.ProviderMap[core.Provider], defaultConnections map[string]string) (*Authorizer, error) {
@@ -66,6 +67,7 @@ func New(cfg config.AuthorizationConfig, pluginDefs map[string]*config.ProviderE
 		policies:             map[string]*HumanPolicy{},
 		providerPolicies:     map[string]string{},
 		providerModes:        map[string]core.ConnectionMode{},
+		defaultConnections:   defaultConnections,
 	}
 
 	for policyID, def := range cfg.Policies {
@@ -224,24 +226,7 @@ func (a *Authorizer) AllowOperation(ctx context.Context, p *principal.Principal,
 
 func (a *Authorizer) Binding(p *principal.Principal, provider string) (CredentialBinding, bool) {
 	if a.isManagedIdentityPrincipal(p) {
-		if !a.allowManagedIdentityProvider(p, provider) {
-			return CredentialBinding{}, false
-		}
-		switch core.NormalizeConnectionMode(a.providerModes[provider]) {
-		case core.ConnectionModeNone:
-			return CredentialBinding{Mode: core.ConnectionModeNone}, true
-		case core.ConnectionModeUser:
-			subjectID := principal.EffectiveCredentialSubjectID(p)
-			if subjectID == "" {
-				return CredentialBinding{}, false
-			}
-			return CredentialBinding{
-				Mode:                core.ConnectionModeUser,
-				CredentialSubjectID: subjectID,
-			}, true
-		default:
-			return CredentialBinding{}, false
-		}
+		return a.managedIdentityBinding(p, provider)
 	}
 	if !a.IsWorkload(p) {
 		return CredentialBinding{}, false
@@ -557,6 +542,37 @@ func (a *Authorizer) allowManagedIdentityProvider(p *principal.Principal, provid
 	default:
 		return false
 	}
+}
+
+func (a *Authorizer) managedIdentityBinding(p *principal.Principal, provider string) (CredentialBinding, bool) {
+	if !a.allowManagedIdentityProvider(p, provider) {
+		return CredentialBinding{}, false
+	}
+	switch core.NormalizeConnectionMode(a.providerModes[provider]) {
+	case core.ConnectionModeNone:
+		return CredentialBinding{Mode: core.ConnectionModeNone}, true
+	case core.ConnectionModeUser:
+		return a.managedIdentityCredentialBinding(principal.EffectiveCredentialSubjectID(p), core.ConnectionModeUser, provider)
+	default:
+		return CredentialBinding{}, false
+	}
+}
+
+func (a *Authorizer) managedIdentityCredentialBinding(subjectID string, mode core.ConnectionMode, provider string) (CredentialBinding, bool) {
+	subjectID = strings.TrimSpace(subjectID)
+	if subjectID == "" {
+		return CredentialBinding{}, false
+	}
+	connection := ""
+	if a != nil {
+		connection = config.ResolveConnectionAlias(strings.TrimSpace(a.defaultConnections[provider]))
+	}
+	return CredentialBinding{
+		Mode:                mode,
+		CredentialSubjectID: subjectID,
+		Connection:          connection,
+		Instance:            defaultInstance,
+	}, true
 }
 
 func providerMode(provider string, pluginDefs map[string]*config.ProviderEntry, providers *registry.ProviderMap[core.Provider]) (core.ConnectionMode, bool, error) {

--- a/gestaltd/internal/bootstrap/bootstrap.go
+++ b/gestaltd/internal/bootstrap/bootstrap.go
@@ -248,9 +248,11 @@ func (r *Result) Close(ctx context.Context) error {
 	}
 
 	var errs []error
-	authCloseErr := closeAuth(r.Auth)
+	authCloseErr := error(nil)
 	if len(r.AuthProviders) != 0 {
 		authCloseErr = closeAuthProviders(r.AuthProviders)
+	} else {
+		authCloseErr = closeAuth(r.Auth)
 	}
 	errs = append(errs,
 		closeAuthorizer(r.Authorizer),
@@ -633,9 +635,11 @@ func (p *preparedCore) Close(ctx context.Context) error {
 	}
 
 	var errs []error
-	authCloseErr := closeAuth(p.Auth)
+	authCloseErr := error(nil)
 	if len(p.AuthProviders) != 0 {
 		authCloseErr = closeAuthProviders(p.AuthProviders)
+	} else {
+		authCloseErr = closeAuth(p.Auth)
 	}
 	errs = append(errs,
 		authCloseErr,

--- a/gestaltd/internal/bootstrap/bootstrap_close_test.go
+++ b/gestaltd/internal/bootstrap/bootstrap_close_test.go
@@ -1,0 +1,56 @@
+package bootstrap
+
+import (
+	"context"
+	"sync/atomic"
+	"testing"
+
+	"github.com/valon-technologies/gestalt/server/core"
+	coretesting "github.com/valon-technologies/gestalt/server/core/testing"
+)
+
+type countedAuthProvider struct {
+	*coretesting.StubAuthProvider
+	closeCount *atomic.Int32
+}
+
+func (p *countedAuthProvider) Close() error {
+	if p.closeCount != nil {
+		p.closeCount.Add(1)
+	}
+	return nil
+}
+
+func TestPreparedCoreCloseClosesEachAuthProviderOnce(t *testing.T) {
+	t.Parallel()
+
+	var selectedClosed atomic.Int32
+	var extraClosed atomic.Int32
+	selected := &countedAuthProvider{
+		StubAuthProvider: &coretesting.StubAuthProvider{N: "selected"},
+		closeCount:       &selectedClosed,
+	}
+	extra := &countedAuthProvider{
+		StubAuthProvider: &coretesting.StubAuthProvider{N: "extra"},
+		closeCount:       &extraClosed,
+	}
+
+	prepared := &preparedCore{
+		Auth: selected,
+		AuthProviders: map[string]core.AuthProvider{
+			"selected": selected,
+			"extra":    extra,
+		},
+		Services: coretesting.NewStubServices(t),
+	}
+
+	if err := prepared.Close(context.Background()); err != nil {
+		t.Fatalf("preparedCore.Close: %v", err)
+	}
+	if got := selectedClosed.Load(); got != 1 {
+		t.Fatalf("selected auth close count = %d, want 1", got)
+	}
+	if got := extraClosed.Load(); got != 1 {
+		t.Fatalf("extra auth close count = %d, want 1", got)
+	}
+}

--- a/gestaltd/internal/bootstrap/bootstrap_close_test.go
+++ b/gestaltd/internal/bootstrap/bootstrap_close_test.go
@@ -37,7 +37,7 @@ func TestPreparedCoreCloseClosesEachAuthProviderOnce(t *testing.T) {
 
 	prepared := &preparedCore{
 		Auth: selected,
-		AuthProviders: map[string]core.AuthProvider{
+		AuthProviders: map[string]core.AuthenticationProvider{
 			"selected": selected,
 			"extra":    extra,
 		},

--- a/gestaltd/internal/bootstrap/bootstrap_test.go
+++ b/gestaltd/internal/bootstrap/bootstrap_test.go
@@ -3530,18 +3530,18 @@ func TestResultCloseClosesEachAuthProviderOnce(t *testing.T) {
 	t.Parallel()
 
 	cfg := validConfig()
-	cfg.Providers.Auth["secondary"] = &config.ProviderEntry{
+	cfg.Providers.Authentication["secondary"] = &config.ProviderEntry{
 		Source: config.NewMetadataSource("https://example.invalid/github-com-valon-technologies-gestalt-providers-auth-google/v0.0.1-alpha.1/provider-release.yaml"),
 		Config: yaml.Node{Kind: yaml.MappingNode},
 	}
-	cfg.Server.Providers.Auth = "secondary"
+	cfg.Server.Providers.Authentication = "secondary"
 
 	var builds atomic.Int32
 	var firstClosed atomic.Int32
 	var secondClosed atomic.Int32
 
 	factories := validFactories()
-	factories.Auth = func(yaml.Node, bootstrap.Deps) (core.AuthProvider, error) {
+	factories.Auth = func(yaml.Node, bootstrap.Deps) (core.AuthenticationProvider, error) {
 		provider := &closableAuthProvider{
 			StubAuthProvider: &coretesting.StubAuthProvider{N: "test-auth"},
 		}

--- a/gestaltd/internal/bootstrap/bootstrap_test.go
+++ b/gestaltd/internal/bootstrap/bootstrap_test.go
@@ -414,11 +414,17 @@ func stubTelemetryFactory() bootstrap.TelemetryFactory {
 
 type closableAuthProvider struct {
 	*coretesting.StubAuthProvider
-	closed *atomic.Bool
+	closed     *atomic.Bool
+	closeCount *atomic.Int32
 }
 
 func (p *closableAuthProvider) Close() error {
-	p.closed.Store(true)
+	if p.closed != nil {
+		p.closed.Store(true)
+	}
+	if p.closeCount != nil {
+		p.closeCount.Add(1)
+	}
 	return nil
 }
 
@@ -3517,6 +3523,51 @@ func TestResultCloseClosesAuthProvider(t *testing.T) {
 	}
 	if !closed.Load() {
 		t.Fatal("authentication provider was not closed")
+	}
+}
+
+func TestResultCloseClosesEachAuthProviderOnce(t *testing.T) {
+	t.Parallel()
+
+	cfg := validConfig()
+	cfg.Providers.Auth["secondary"] = &config.ProviderEntry{
+		Source: config.NewMetadataSource("https://example.invalid/github-com-valon-technologies-gestalt-providers-auth-google/v0.0.1-alpha.1/provider-release.yaml"),
+		Config: yaml.Node{Kind: yaml.MappingNode},
+	}
+	cfg.Server.Providers.Auth = "secondary"
+
+	var builds atomic.Int32
+	var firstClosed atomic.Int32
+	var secondClosed atomic.Int32
+
+	factories := validFactories()
+	factories.Auth = func(yaml.Node, bootstrap.Deps) (core.AuthProvider, error) {
+		provider := &closableAuthProvider{
+			StubAuthProvider: &coretesting.StubAuthProvider{N: "test-auth"},
+		}
+		switch builds.Add(1) {
+		case 1:
+			provider.closeCount = &firstClosed
+		case 2:
+			provider.closeCount = &secondClosed
+		default:
+			t.Fatalf("unexpected auth build count %d", builds.Load())
+		}
+		return provider, nil
+	}
+
+	result, err := bootstrap.Bootstrap(context.Background(), cfg, factories)
+	if err != nil {
+		t.Fatalf("Bootstrap: %v", err)
+	}
+	if err := result.Close(context.Background()); err != nil {
+		t.Fatalf("Result.Close: %v", err)
+	}
+	if got := firstClosed.Load(); got != 1 {
+		t.Fatalf("first auth close count = %d, want 1", got)
+	}
+	if got := secondClosed.Load(); got != 1 {
+		t.Fatalf("second auth close count = %d, want 1", got)
 	}
 }
 

--- a/gestaltd/internal/invocation/broker_test.go
+++ b/gestaltd/internal/invocation/broker_test.go
@@ -23,6 +23,15 @@ func mustAuthorizer(t *testing.T, cfg config.AuthorizationConfig, providers *reg
 	return authz
 }
 
+func mustAuthorizerWithDefaults(t *testing.T, cfg config.AuthorizationConfig, providers *registry.ProviderMap[core.Provider], defaultConnections map[string]string) *authorization.Authorizer {
+	t.Helper()
+	authz, err := authorization.New(cfg, nil, providers, defaultConnections)
+	if err != nil {
+		t.Fatalf("authorization.New: %v", err)
+	}
+	return authz
+}
+
 func TestBrokerResolveToken_ConnectionModeNoneResolvesSessionUserSubject(t *testing.T) {
 	t.Parallel()
 
@@ -148,5 +157,83 @@ func TestBrokerResolveToken_ManagedIdentityDoesNotBypassSelectorBinding(t *testi
 	}
 	if got, want := err.Error(), "workloads may not override connection or instance bindings"; got == "" || !strings.Contains(got, want) {
 		t.Fatalf("ResolveToken error = %q, want substring %q", got, want)
+	}
+}
+
+func TestBrokerResolveToken_ManagedIdentityUsesDefaultBindingSelectors(t *testing.T) {
+	t.Parallel()
+
+	testCases := []struct {
+		name                 string
+		mode                 core.ConnectionMode
+		credentialSubjectID  string
+		storedTokenSubjectID string
+		wantMode             core.ConnectionMode
+	}{
+		{
+			name:                 "user",
+			mode:                 core.ConnectionModeUser,
+			credentialSubjectID:  principal.UserSubjectID("user-123"),
+			storedTokenSubjectID: principal.UserSubjectID("user-123"),
+			wantMode:             core.ConnectionModeUser,
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+
+			svc := coretesting.NewStubServices(t)
+			providers := testutil.NewProviderRegistry(t, &coretesting.StubIntegration{
+				N:        "sampledb",
+				ConnMode: tc.mode,
+			})
+			authz := mustAuthorizerWithDefaults(t, config.AuthorizationConfig{}, providers, map[string]string{
+				"sampledb": "workspace",
+			})
+			broker := NewBroker(providers, svc.Users, svc.Tokens, WithAuthorizer(authz))
+
+			if err := svc.Tokens.StoreToken(context.Background(), &core.IntegrationToken{
+				ID:          "tok-default",
+				SubjectID:   tc.storedTokenSubjectID,
+				Integration: "sampledb",
+				Connection:  "workspace",
+				Instance:    "default",
+				AccessToken: "bound-token",
+			}); err != nil {
+				t.Fatalf("StoreToken: %v", err)
+			}
+
+			p := &principal.Principal{
+				SubjectID:           principal.ManagedIdentitySubjectID("bot-123"),
+				CredentialSubjectID: tc.credentialSubjectID,
+				Kind:                principal.KindWorkload,
+				Source:              principal.SourceWorkloadToken,
+				TokenPermissions: principal.CompilePermissions([]core.AccessPermission{
+					{Plugin: "sampledb"},
+				}),
+			}
+
+			ctx, token, err := broker.ResolveToken(context.Background(), p, "sampledb", "", "")
+			if err != nil {
+				t.Fatalf("ResolveToken: %v", err)
+			}
+			if token != "bound-token" {
+				t.Fatalf("token = %q, want %q", token, "bound-token")
+			}
+			credentialCtx := CredentialContextFromContext(ctx)
+			if credentialCtx.Connection != "workspace" {
+				t.Fatalf("connection = %q, want %q", credentialCtx.Connection, "workspace")
+			}
+			if credentialCtx.Instance != "default" {
+				t.Fatalf("instance = %q, want %q", credentialCtx.Instance, "default")
+			}
+			if credentialCtx.Mode != tc.wantMode {
+				t.Fatalf("mode = %q, want %q", credentialCtx.Mode, tc.wantMode)
+			}
+			if credentialCtx.SubjectID != tc.storedTokenSubjectID {
+				t.Fatalf("subjectID = %q, want %q", credentialCtx.SubjectID, tc.storedTokenSubjectID)
+			}
+		})
 	}
 }

--- a/gestaltd/internal/server/workflow_schedule_test.go
+++ b/gestaltd/internal/server/workflow_schedule_test.go
@@ -1204,6 +1204,91 @@ func TestGlobalWorkflowScheduleLookupIgnoresUnrelatedProviderFailures(t *testing
 	}
 }
 
+func TestGlobalWorkflowScheduleListSkipsMissingProviderReferences(t *testing.T) {
+	t.Parallel()
+
+	services := coretesting.NewStubServices(t)
+	user := seedUser(t, services, "ada@example.test")
+	provider := newMemoryWorkflowProvider()
+	now := time.Now().UTC().Truncate(time.Second)
+	provider.schedules["sched-ada-basic"] = &coreworkflow.Schedule{
+		ID:           "sched-ada-basic",
+		Cron:         "*/5 * * * *",
+		Target:       coreworkflow.Target{PluginName: "roadmap", Operation: "sync"},
+		ExecutionRef: "workflow_schedule:sched-ada-basic:ref-basic",
+		CreatedAt:    &now,
+		UpdatedAt:    &now,
+	}
+	for _, ref := range []*coreworkflow.ExecutionReference{
+		{
+			ID:           "workflow_schedule:sched-ada-basic:ref-basic",
+			ProviderName: "basic",
+			Target:       provider.schedules["sched-ada-basic"].Target,
+			SubjectID:    principal.UserSubjectID(user.ID),
+		},
+		{
+			ID:           "workflow_schedule:sched-missing:ref-missing",
+			ProviderName: "missing",
+			Target:       coreworkflow.Target{PluginName: "roadmap", Operation: "sync"},
+			SubjectID:    principal.UserSubjectID(user.ID),
+		},
+	} {
+		if _, err := services.WorkflowExecutionRefs.Put(context.Background(), ref); err != nil {
+			t.Fatalf("Put execution ref %q: %v", ref.ID, err)
+		}
+	}
+
+	ts := newTestServer(t, func(cfg *server.Config) {
+		cfg.Auth = &coretesting.StubAuthProvider{
+			N: "stub",
+			ValidateTokenFn: func(_ context.Context, token string) (*core.UserIdentity, error) {
+				if token != "ada-session" {
+					return nil, core.ErrNotFound
+				}
+				return &core.UserIdentity{Email: user.Email, DisplayName: "Ada"}, nil
+			},
+		}
+		cfg.Services = services
+		cfg.Providers = testutil.NewProviderRegistry(t, &coretesting.StubIntegration{
+			N:        "roadmap",
+			ConnMode: core.ConnectionModeUser,
+			CatalogVal: &catalog.Catalog{
+				Name: "roadmap",
+				Operations: []catalog.CatalogOperation{
+					{ID: "sync", Method: http.MethodPost},
+				},
+			},
+		})
+		cfg.Workflow = &stubWorkflowControl{
+			defaultProviderName: "basic",
+			providers: map[string]coreworkflow.Provider{
+				"basic": provider,
+			},
+		}
+	})
+	testutil.CloseOnCleanup(t, ts)
+
+	listReq, _ := http.NewRequest(http.MethodGet, ts.URL+"/api/v1/workflow/schedules/", nil)
+	listReq.AddCookie(&http.Cookie{Name: "session_token", Value: "ada-session"})
+	listResp, err := http.DefaultClient.Do(listReq)
+	if err != nil {
+		t.Fatalf("list request: %v", err)
+	}
+	defer func() { _ = listResp.Body.Close() }()
+	if listResp.StatusCode != http.StatusOK {
+		body, _ := io.ReadAll(listResp.Body)
+		t.Fatalf("expected 200, got %d: %s", listResp.StatusCode, body)
+	}
+
+	var listed []workflowScheduleResponse
+	if err := json.NewDecoder(listResp.Body).Decode(&listed); err != nil {
+		t.Fatalf("decode list response: %v", err)
+	}
+	if len(listed) != 1 || listed[0].ID != "sched-ada-basic" {
+		t.Fatalf("listed schedules = %#v", listed)
+	}
+}
+
 func TestGlobalWorkflowScheduleRejectsDuplicateActiveExecutionRefs(t *testing.T) {
 	t.Parallel()
 

--- a/gestaltd/internal/workflowmanager/manager.go
+++ b/gestaltd/internal/workflowmanager/manager.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"log/slog"
 	"maps"
 	"sort"
 	"strings"
@@ -239,14 +240,16 @@ func (m *Manager) ListSchedules(ctx context.Context, p *principal.Principal) ([]
 		}
 		provider, err := m.resolveProviderByName(strings.TrimSpace(ref.ProviderName))
 		if err != nil {
-			return nil, err
+			slog.WarnContext(ctx, "skipping workflow schedule with unavailable provider", "provider", strings.TrimSpace(ref.ProviderName), "schedule_id", scheduleID, "error", err)
+			continue
 		}
 		schedule, err := provider.GetSchedule(ctx, coreworkflow.GetScheduleRequest{ScheduleID: scheduleID})
 		if err != nil {
 			if errors.Is(err, core.ErrNotFound) {
 				continue
 			}
-			return nil, err
+			slog.WarnContext(ctx, "skipping workflow schedule after provider lookup failed", "provider", strings.TrimSpace(ref.ProviderName), "plugin", strings.TrimSpace(ref.Target.PluginName), "schedule_id", scheduleID, "error", err)
+			continue
 		}
 		if !scheduleMatchesExecutionRef(ref.ProviderName, schedule, ref) {
 			continue


### PR DESCRIPTION
## Summary
This PR addresses the Bugbot follow-ups that still looked live on `main`.

It fixes:
- managed-identity token binding dropping default connection/instance selectors
- config-managed workflow authorization being broader than the configured workflow targets
- workflow schedule listing aborting on stale or unhealthy provider references
- auth providers being closed twice during shutdown when the selected provider is also present in the provider map
- stale docs that still described release-source auth and owned UI manifests using unsupported shapes

## Root Cause
Two different classes of problems were still present:

1. The runtime/auth path was relying on broad default behavior instead of explicit bindings.
   - Managed identities could lose the connection/instance needed to find stored tokens.
   - `workflow.config` was being granted every catalog operation from every plugin rather than only the configured workflow targets.
   - Workflow schedule listing treated one bad provider reference as a fatal error for the entire list.

2. Lifecycle/docs paths had drifted.
   - Shutdown closed `Auth` directly and then closed the full `AuthProviders` map, which could hit the selected provider twice.
   - Docs still described `auth.token`/owned-UI manifest shapes that do not match the current config/runtime behavior.

## What Changed
- Added managed-identity binding logic that preserves default connection and instance selectors while still allowing empty-connection providers.
- Scoped workflow-config permissions to configured schedule/event-trigger targets, while using a startup-scoped principal for workflow-provider startup callbacks so startup behavior remains intact.
- Made global workflow schedule listing skip unavailable providers and provider lookup failures instead of failing the whole response.
- Changed auth shutdown to close either the selected provider or the provider map, not both.
- Added regression coverage for the new auth/workflow behaviors.
- Updated provider/config/plugin-manifest docs to use the current `source.auth` and packaged UI semantics.

## Impact
- Managed identities can resolve stored credentials reliably for default-bound connections again.
- Config-managed workflows no longer keep a broad standing allowlist unrelated to their configured targets.
- Users can still list their schedules when one stored workflow reference points at a missing or failing provider.
- Shutdown no longer double-closes auth providers.
- Docs now match the supported config and manifest shapes.

## Validation
- `go test ./internal/bootstrap ./internal/invocation ./internal/server`
