### PR TITLE
docs: update subject-owned credential model

### DIFF
--- a/docs/content/architecture/data-model.mdx
+++ b/docs/content/architecture/data-model.mdx
@@ -24,12 +24,12 @@ Emails and display names are plaintext. If you need encrypted PII at rest, handl
 
 ### `integration_tokens`
 
-Stores upstream credentials (OAuth tokens, API keys, manual credentials) for each user's connected integrations.
+Stores upstream credentials (OAuth tokens, API keys, manual credentials) for each subject's connected integrations.
 
 | Field | Type | Notes |
 | --- | --- | --- |
 | `id` | string, PK | UUID. |
-| `user_id` | string | References `users.id`. |
+| `subject_id` | string | Canonical credential owner such as `user:<id>`, `workload:<id>`, or a managed identity subject. |
 | `integration` | string | Provider name from config (e.g., `slack`). |
 | `connection` | string | Named connection within the provider (e.g., `default`, `mcp`). |
 | `instance` | string | User-chosen or discovery-assigned name for multi-account providers. |
@@ -43,7 +43,7 @@ Stores upstream credentials (OAuth tokens, API keys, manual credentials) for eac
 | `created_at` | time | |
 | `updated_at` | time | |
 
-Unique index on `(user_id, integration, connection, instance)`. Reconnecting overwrites the existing record via `Put`.
+Unique index on `(subject_id, integration, connection, instance)`. Reconnecting overwrites the existing record via `Put`.
 
 ### `api_tokens`
 
@@ -52,7 +52,11 @@ Gestalt API tokens (`gst_api_*`). The plaintext is never stored, only a one-way 
 | Field | Type | Notes |
 | --- | --- | --- |
 | `id` | string, PK | UUID. |
-| `user_id` | string | References `users.id`. |
+| `identity_id` | string | Legacy compatibility link for managed-identity-scoped tokens. |
+| `owner_kind` | string | Token owner kind (`user` or `managed_identity`). |
+| `owner_id` | string | Owner ID within `owner_kind`. |
+| `token_kind` | string | Token purpose (`api` or `workload`). |
+| `credential_subject_id` | string | Subject whose upstream credentials the token may use. |
 | `name` | string | Display name (e.g., `automation`, `cli-token`). |
 | `hashed_token` | string, unique | **SHA-256 hash.** Plaintext returned once at creation. |
 | `scopes` | string | Plaintext. Space-separated provider names. |
@@ -97,7 +101,7 @@ All encrypted fields use the same key derived from `server.encryptionKey`. There
 
 ## Token storage granularity
 
-Integration tokens are keyed by four dimensions: `user_id`, `integration`, `connection`, and `instance`.
+Integration tokens are keyed by four dimensions: `subject_id`, `integration`, `connection`, and `instance`.
 
 The *integration* is the provider name from your config. The *connection* is the named connection within that provider (most have just `default`). The *instance* distinguishes multiple accounts within the same connection, which matters for providers with post-connect discovery (e.g., a user connected to three Slack workspaces).
 
@@ -106,8 +110,7 @@ The `_connection` and `_instance` selectors in the [HTTP API](/reference/http-ap
 ### Connection modes
 
 - **`none`**: No credentials stored. Operations run without upstream auth.
-- **`user`**: Each user connects individually. Tokens keyed by `user_id`.
-- **`identity`**: Single shared credential for the deployment, stored with a fixed internal user ID.
+- **`user`**: Each calling subject connects individually. Tokens are keyed by `subject_id`.
 
 Renaming a `plugins` key in config is a breaking change. Stored tokens reference the old name.
 

--- a/docs/content/architecture/security-internals.mdx
+++ b/docs/content/architecture/security-internals.mdx
@@ -22,7 +22,7 @@ Each encryption generates a fresh 12-byte nonce via `crypto/rand`, encrypts the 
 
 ### Creation
 
-For OAuth connections, Gestalt generates an encrypted state parameter (10-minute TTL) and optional PKCE verifier, redirects the user to the provider, then exchanges the authorization code for tokens on callback. Both the access token and refresh token are encrypted and stored in `integration_tokens`, keyed by `(user_id, integration, connection, instance)`.
+For OAuth connections, Gestalt generates an encrypted state parameter (10-minute TTL) and optional PKCE verifier, redirects the caller to the provider, then exchanges the authorization code for tokens on callback. Both the access token and refresh token are encrypted and stored in `integration_tokens`, keyed by `(subject_id, integration, connection, instance)`.
 
 If the provider supports post-connect discovery (multiple workspaces or accounts), Gestalt fetches the resource list after the token exchange. One resource is auto-selected; multiple resources prompt the user.
 

--- a/docs/content/configuration.mdx
+++ b/docs/content/configuration.mdx
@@ -201,8 +201,7 @@ plugins:
 | Mode | Behavior |
 | --- | --- |
 | `none` | No upstream credential needed. |
-| `user` | Each user stores their own credential. |
-| `identity` | One shared service credential for all callers. |
+| `user` | Credentials are stored for the calling subject (for example `user:<id>`, `workload:<id>`, or a managed identity subject). |
 
 ### Auth types
 
@@ -330,8 +329,7 @@ local plaintext issuer on loopback for development, add
 | --- | --- |
 | Local development | Omit `providers.auth` |
 | Multi-user deployment | `providers.auth.<name>` with a published OIDC or Google auth provider |
-| Per-user upstream access | `mode: user` on plugin connections |
-| Shared service credential | `mode: identity` on plugin connections |
+| Subject-owned upstream access | `mode: user` on plugin connections |
 
 ### API tokens
 

--- a/docs/content/observability.mdx
+++ b/docs/content/observability.mdx
@@ -145,7 +145,7 @@ These metrics carry low-cardinality attributes: `gestalt.provider` (the
 plugin key), `gestalt.operation` (the catalog operation id),
 `gestalt.transport` (how the operation is implemented: `plugin`, `rest`, or
 `mcp-passthrough`), and `gestalt.connection_mode` (the provider auth mode:
-`none`, `user`, or `identity`).
+`none` or `user`).
 
 When a request references an unknown provider or operation, `gestaltd` records
 `unknown` for the missing metric attributes instead of using raw user input.
@@ -176,7 +176,7 @@ These metrics carry low-cardinality attributes: `gestalt.provider` (the
 plugin key), `gestalt.type` (`oauth` or `manual`),
 `gestalt.action` (`start`, `complete`, or `refresh`), and
 `gestalt.connection_mode` (the provider auth mode: `none`, `user`,
-`identity`).
+only).
 
 When a request references an unknown plugin, `gestaltd` records
 `unknown` for the provider and connection mode metric attributes instead of
@@ -233,8 +233,8 @@ session catalog with stored or identity credentials.
 
 These metrics carry low-cardinality attributes: `gestalt.provider` (the plugin
 key), `gestalt.action` (currently `list_operations`), and
-`gestalt.connection_mode` (the provider auth mode: `none`, `user`, or
-`identity`). `gestaltd.discovery.error_count` increments when the
+`gestalt.connection_mode` (the provider auth mode: `none` or `user`).
+`gestaltd.discovery.error_count` increments when the
 credentialed session-catalog path fails, even if `gestaltd` falls back to a
 static catalog and still serves a successful HTTP response.
 

--- a/docs/content/providers/plugins.mdx
+++ b/docs/content/providers/plugins.mdx
@@ -62,13 +62,12 @@ plugins:
 ## Connections and credentials
 
 Plugin packages declare connection models in their manifests, and the server
-stores credentials per user or per shared identity.
+stores credentials per subject.
 
 | Mode | Behavior |
 | --- | --- |
 | `none` | No upstream credential is required |
-| `user` | Each user stores their own credential |
-| `identity` | One shared service credential is used for every caller |
+| `user` | The calling subject stores its own credential (`user:<id>`, `workload:<id>`, or a managed identity subject) |
 
 Common auth types are `oauth2`, `mcp_oauth`, `bearer`, `manual`, and `none`.
 Operator-supplied app credentials such as `clientId` and `clientSecret` go in

--- a/docs/content/reference/config-file.mdx
+++ b/docs/content/reference/config-file.mdx
@@ -162,7 +162,7 @@ authorization:
 
 Dynamic human grants are plugin-scoped, not policy-scoped. When a plugin sets `authorizationPolicy`, operators can manage additional dynamic members for that plugin from the built-in admin UI at `/admin/?tab=members` or through `/admin/api/v1/authorization/...`. Static policy members always win over dynamic grants, and Gestalt rejects dynamic writes for users who already have static authorization on that plugin.
 
-`authorization.workloads` configures non-human workload callers. Each workload uses a dedicated bearer token with the `gst_wld_` prefix and a per-provider allowlist. In v1, workloads may bind only to `identity` or `none` providers. For `identity` providers, `connection` and `instance` resolve the exact stored identity credential the workload may use; `instance` defaults to `default` and `connection` falls back to the provider's default connection when omitted. For `none` providers, omit `connection` and `instance`.
+`authorization.workloads` configures non-human workload callers. Each workload uses a dedicated bearer token with the `gst_wld_` prefix and a per-provider allowlist. In the current runtime, workloads may bind only to `user` or `none` providers. For `user` providers, `connection` and `instance` resolve the exact stored workload credential the workload may use under its own subject (`workload:<id>`); `instance` defaults to `default` and `connection` falls back to the provider's default connection when omitted. For `none` providers, omit `connection` and `instance`.
 
 | Field | Default | Description |
 | --- | --- | --- |
@@ -179,7 +179,7 @@ Dynamic human grants are plugin-scoped, not policy-scoped. When a plugin sets `a
 | `admin.authorizationPolicy` | | Shared human access policy applied to the built-in `/admin` route. |
 | `admin.allowedRoles` | `[admin]` | Roles allowed to load the built-in `/admin` route when `admin.authorizationPolicy` is set. |
 | `authorization.policies` | | Shared human access policies resolved by canonical `subjectID`. |
-| `authorization.workloads` | | Workload bearer tokens, per-provider allowlists, and identity credential bindings. |
+| `authorization.workloads` | | Workload bearer tokens, per-provider allowlists, and workload-owned credential bindings. |
 
 When `server.management` is configured, Gestalt serves `/`, `/api/v1/*`, auth routes, and `/mcp` on the public listener, while `/admin`, `/admin/api/v1/*`, `/metrics`, `/health`, and `/ready` move to the management listener. The management listener is intended to be protected by deployment infrastructure such as private networking, VPN, or an internal-only reverse proxy. Gestalt does not apply its own session or API-token auth to `/metrics` on the management listener. When `server.admin.authorizationPolicy` is set, Gestalt does apply browser session auth plus role-based policy checks to `/admin` and `/admin/api/v1/*`.
 
@@ -969,7 +969,7 @@ connections:
       type: mcp_oauth
 ```
 
-Connection `mode` determines how credentials are managed: `none` requires no credentials, `user` requires each user to connect individually, and `identity` uses a shared operator credential. All connections in a single plugin must share the same mode.
+Connection `mode` determines how credentials are managed: `none` requires no credentials, and `user` stores credentials for the caller's effective subject. For humans that is typically `user:<id>`; for workloads it is `workload:<id>`; for managed identities it is the managed identity subject. All connections in a single plugin must share the same mode.
 
 #### Auth shapes
 

--- a/docs/content/reference/plugin-manifests.mdx
+++ b/docs/content/reference/plugin-manifests.mdx
@@ -135,7 +135,7 @@ The `connections` map defines named connection profiles. Deployment config can o
 
 | Field | Type | Purpose |
 | --- | --- | --- |
-| `mode` | string | One of `none`, `user`, `identity`. |
+| `mode` | string | One of `none` or `user`. |
 | `auth` | ProviderAuth | Authentication configuration for this connection. |
 | `params` | map[string]ConnectionParam | Connection parameters populated during or after connect. |
 | `discovery` | Discovery | Post-connect discovery configuration. |


### PR DESCRIPTION
## Summary
- update public docs to describe the current subject-owned credential model
- remove stale `identity` connection-mode references from config, manifest, architecture, and observability docs
- document workload bindings and integration token storage in terms of `subject_id`

## Verification
- `cd docs && npm ci`
- `cd docs && npm run build`