### PR TITLE
server: allow email aliases for dynamic admin auth writes

### DIFF
--- a/docs/content/reference/http-api.mdx
+++ b/docs/content/reference/http-api.mdx
@@ -56,15 +56,15 @@ Authenticated routes accept a `session_token` cookie or an `Authorization: Beare
 | `GET` | `/metrics` | Prometheus scrape endpoint for emitted metrics. Requires Gestalt auth only when served on the public listener. The recommended production pattern is to move it to `server.management` and protect that listener at the network or proxy layer. |
 | `GET` | `/admin/api/v1/authorization/plugins` | List plugins that declare `authorizationPolicy`, including the bound policy name and mounted UI path when present. |
 | `GET` | `/admin/api/v1/authorization/plugins/{plugin}/members` | List merged static and dynamic human membership rows for one plugin. Rows include `source`, `effective`, `mutable`, and selector metadata. |
-| `PUT` | `/admin/api/v1/authorization/plugins/{plugin}/members` | Upsert one dynamic human membership row for a plugin by canonical user `subjectId` and role. Rejects subjects who already have static authorization on that plugin. |
+| `PUT` | `/admin/api/v1/authorization/plugins/{plugin}/members` | Upsert one dynamic human membership row for a plugin by canonical user `subjectId` or by `email` alias and role. Rejects subjects who already have static authorization on that plugin. |
 | `DELETE` | `/admin/api/v1/authorization/plugins/{plugin}/members/{subjectID}` | Remove one dynamic human membership row for a plugin. Static rows are read-only and cannot be deleted through the API. |
 | `GET` | `/admin/api/v1/authorization/admins/members` | List merged static and dynamic built-in admin membership rows. |
-| `PUT` | `/admin/api/v1/authorization/admins/members` | Upsert one dynamic built-in admin membership row by canonical user `subjectId` and role. Rejects subjects who already have static built-in admin authorization. |
+| `PUT` | `/admin/api/v1/authorization/admins/members` | Upsert one dynamic built-in admin membership row by canonical user `subjectId` or by `email` alias and role. Rejects subjects who already have static built-in admin authorization. |
 | `DELETE` | `/admin/api/v1/authorization/admins/members/{subjectID}` | Remove one dynamic built-in admin membership row. Static rows are read-only and cannot be deleted through the API. |
 
 `/admin/api/v1/...` mirrors the built-in `/admin` protection model: when `server.admin.authorizationPolicy` is unset, the routes are open wherever `/admin` is open; when it is set, they require the same browser session and role checks as `/admin`, but return JSON `401`/`403` instead of browser redirects.
 
-Mutable human membership APIs are selector-only. User-backed rows use canonical `subjectId` values in the form `user:<user_id>`. Dynamic membership writes require an existing user subject; the admin API no longer creates users from email addresses on write.
+Mutable human membership APIs still list and delete by canonical `subjectId`. User-backed rows use `subjectId` values in the form `user:<user_id>`. Dynamic membership writes accept either a canonical `subjectId` or an `email` alias. When `email` is used, Gestalt resolves it to the canonical user subject and creates the user record if needed before persisting the provider-backed grant.
 
 `PUT` and `DELETE` may return `202 Accepted` with `status: "persisted_pending_reload"` when the dynamic grant was written successfully but the local in-memory authorization snapshot has not reloaded yet. In that case, retry access checks only after the local snapshot converges.
 
@@ -107,8 +107,8 @@ curl -X POST http://localhost:8080/api/v1/slack/chat.postMessage \
   -H 'Content-Type: application/json' \
   -d '{"_connection": "mcp", "channel": "C123", "text": "hello"}'
 
-# Add a dynamic plugin member from the management/admin surface
+# Add a dynamic plugin member from the management/admin surface by email alias
 curl -X PUT http://localhost:9090/admin/api/v1/authorization/plugins/sample_plugin/members \
   -H 'Content-Type: application/json' \
-  -d '{"subjectId":"user:usr_123","role":"viewer"}'
+  -d '{"email":"user@example.com","role":"viewer"}'
 ```

--- a/gestaltd/internal/adminui/out/index.html
+++ b/gestaltd/internal/adminui/out/index.html
@@ -761,9 +761,9 @@
 
           <p class="metric-note controls-note">
             Dynamic grants are plugin-scoped and evaluated only after static
-            policy members. Writes require a canonical user subject ID and are
-            blocked when that subject already has static authorization on the
-            selected plugin.
+            policy members. Writes accept a user email, resolve it to a
+            canonical user subject ID, and are blocked when that subject
+            already has static authorization on the selected plugin.
           </p>
         </section>
 
@@ -800,9 +800,9 @@
             </p>
 
             <form id="authorization-form" class="auth-form">
-              <label class="control-group" for="authorization-subject-input">
-                <span class="label-text">Subject ID</span>
-                <input class="text-input" id="authorization-subject-input" name="subjectId" type="text" spellcheck="false" placeholder="user:usr_123" />
+              <label class="control-group" for="authorization-email-input">
+                <span class="label-text">User email</span>
+                <input class="text-input" id="authorization-email-input" name="email" type="email" spellcheck="false" placeholder="user@example.com" />
               </label>
 
               <label class="control-group" for="authorization-role-input">
@@ -814,7 +814,7 @@
             </form>
 
             <p class="metric-note inline-note" id="authorization-form-note">
-              Pick a plugin, then add or update a dynamic grant for an existing user subject.
+              Pick a plugin, then add or update a dynamic grant by user email.
             </p>
           </article>
 
@@ -890,9 +890,9 @@
             </p>
 
             <form id="admin-members-form" class="auth-form">
-              <label class="control-group" for="admin-members-subject-input">
-                <span class="label-text">Subject ID</span>
-                <input class="text-input" id="admin-members-subject-input" name="subjectId" type="text" spellcheck="false" placeholder="user:usr_123" />
+              <label class="control-group" for="admin-members-email-input">
+                <span class="label-text">User email</span>
+                <input class="text-input" id="admin-members-email-input" name="email" type="email" spellcheck="false" placeholder="user@example.com" />
               </label>
 
               <label class="control-group" for="admin-members-role-input">
@@ -904,7 +904,7 @@
             </form>
 
             <p class="metric-note inline-note" id="admin-members-form-note">
-              Add or update a dynamic Gestalt admin grant for an existing user subject.
+              Add or update a dynamic Gestalt admin grant by user email.
             </p>
           </article>
 
@@ -1057,6 +1057,10 @@
         }
 
         function normalizeSubjectID(value) {
+          return typeof value === "string" ? value.trim() : "";
+        }
+
+        function normalizeEmailInput(value) {
           return typeof value === "string" ? value.trim() : "";
         }
 
@@ -1419,28 +1423,25 @@
         }
 
         function updateAuthorizationFormState() {
-          const subjectInput = byId("authorization-subject-input");
+          const emailInput = byId("authorization-email-input");
           const roleInput = byId("authorization-role-input");
           const submitButton = byId("authorization-submit-button");
           const formNote = byId("authorization-form-note");
           const pluginSelect = byId("authorization-plugin-select");
           const hasPlugin = !!selectedPluginName;
           pluginSelect.disabled = authLoading || authSaving;
-          subjectInput.disabled = !hasPlugin || authLoading || authSaving;
+          emailInput.disabled = !hasPlugin || authLoading || authSaving;
           roleInput.disabled = !hasPlugin || authLoading || authSaving;
 
-          const subjectID = normalizeSubjectID(subjectInput.value);
+          const email = normalizeEmailInput(emailInput.value);
           const role = String(roleInput.value || "").trim();
-          const staticConflict = subjectID && authStaticSubjectIDs().has(subjectID);
-          submitButton.disabled = !hasPlugin || !subjectID || !role || staticConflict || authLoading || authSaving;
+          submitButton.disabled = !hasPlugin || !email || !role || authLoading || authSaving;
           submitButton.textContent = authSaving ? "Saving..." : "Save dynamic grant";
 
           if (!hasPlugin) {
             formNote.textContent = "Pick a plugin with an authorization policy to manage members.";
-          } else if (staticConflict) {
-            formNote.textContent = "This subject already has static authorization on the selected plugin and cannot receive a dynamic grant.";
           } else {
-            formNote.textContent = "Static rows remain read-only. Dynamic rows use canonical user subject IDs and can be added, updated, or removed here.";
+            formNote.textContent = "Enter a user email. The server resolves it to a canonical user subject ID before writing the dynamic grant.";
           }
         }
 
@@ -1606,18 +1607,17 @@
         }
 
         function updateAdminMembersFormState() {
-          const subjectInput = byId("admin-members-subject-input");
+          const emailInput = byId("admin-members-email-input");
           const roleInput = byId("admin-members-role-input");
           const submitButton = byId("admin-members-submit-button");
           const formNote = byId("admin-members-form-note");
 
-          subjectInput.disabled = !adminAvailable || !adminCanWrite || adminLoading || adminSaving;
+          emailInput.disabled = !adminAvailable || !adminCanWrite || adminLoading || adminSaving;
           roleInput.disabled = !adminAvailable || !adminCanWrite || adminLoading || adminSaving;
 
-          const subjectID = normalizeSubjectID(subjectInput.value);
+          const email = normalizeEmailInput(emailInput.value);
           const role = String(roleInput.value || "").trim();
-          const staticConflict = subjectID && adminStaticSubjectIDs().has(subjectID);
-          submitButton.disabled = !adminAvailable || !adminCanWrite || !subjectID || !role || staticConflict || adminLoading || adminSaving;
+          submitButton.disabled = !adminAvailable || !adminCanWrite || !email || !role || adminLoading || adminSaving;
           submitButton.textContent = adminSaving ? "Saving..." : "Save admin grant";
 
           if (adminLoading && !adminLoaded) {
@@ -1628,10 +1628,8 @@
             formNote.textContent = "The last refresh failed. Use Refresh to retry before changing built-in admins.";
           } else if (!adminCanWrite) {
             formNote.textContent = "You can inspect built-in admin memberships here, but only callers with an allowed built-in admin role can change them.";
-          } else if (staticConflict) {
-            formNote.textContent = "This subject already has static built-in admin authorization and cannot receive a dynamic admin grant.";
           } else {
-            formNote.textContent = "Static seed admins remain read-only. Dynamic admin rows use canonical user subject IDs and can be added, updated, or removed here.";
+            formNote.textContent = "Enter a user email. The server resolves it to a canonical user subject ID before writing the dynamic admin grant.";
           }
         }
 
@@ -1751,18 +1749,18 @@
             loadAuthorizationPlugins();
           });
 
-          byId("authorization-subject-input").addEventListener("input", updateAuthorizationFormState);
+          byId("authorization-email-input").addEventListener("input", updateAuthorizationFormState);
           byId("authorization-role-input").addEventListener("input", updateAuthorizationFormState);
 
           byId("authorization-form").addEventListener("submit", async function (event) {
             event.preventDefault();
             if (!selectedPluginName || authSaving) return;
 
-            const subjectInput = byId("authorization-subject-input");
+            const emailInput = byId("authorization-email-input");
             const roleInput = byId("authorization-role-input");
-            const subjectID = normalizeSubjectID(subjectInput.value);
+            const email = normalizeEmailInput(emailInput.value);
             const role = String(roleInput.value || "").trim();
-            if (!subjectID || !role) {
+            if (!email || !role) {
               updateAuthorizationFormState();
               return;
             }
@@ -1779,10 +1777,10 @@
                     Accept: "application/json",
                     "Content-Type": "application/json",
                   },
-                  body: JSON.stringify({ subjectId: subjectID, role: role }),
+                  body: JSON.stringify({ email: email, role: role }),
                 },
               );
-              subjectInput.value = "";
+              emailInput.value = "";
               if (result.payload && result.payload.membership && result.payload.membership.role) {
                 roleInput.value = result.payload.membership.role;
               }
@@ -1840,18 +1838,18 @@
             loadAdminMembers();
           });
 
-          byId("admin-members-subject-input").addEventListener("input", updateAdminMembersFormState);
+          byId("admin-members-email-input").addEventListener("input", updateAdminMembersFormState);
           byId("admin-members-role-input").addEventListener("input", updateAdminMembersFormState);
 
           byId("admin-members-form").addEventListener("submit", async function (event) {
             event.preventDefault();
             if (adminSaving || !adminAvailable) return;
 
-            const subjectInput = byId("admin-members-subject-input");
+            const emailInput = byId("admin-members-email-input");
             const roleInput = byId("admin-members-role-input");
-            const subjectID = normalizeSubjectID(subjectInput.value);
+            const email = normalizeEmailInput(emailInput.value);
             const role = String(roleInput.value || "").trim();
-            if (!subjectID || !role) {
+            if (!email || !role) {
               updateAdminMembersFormState();
               return;
             }
@@ -1866,9 +1864,9 @@
                   Accept: "application/json",
                   "Content-Type": "application/json",
                 },
-                body: JSON.stringify({ subjectId: subjectID, role: role }),
+                body: JSON.stringify({ email: email, role: role }),
               });
-              subjectInput.value = "";
+              emailInput.value = "";
               if (result.payload && result.payload.membership && result.payload.membership.role) {
                 roleInput.value = result.payload.membership.role;
               }

--- a/gestaltd/internal/server/handlers_admin_authorization.go
+++ b/gestaltd/internal/server/handlers_admin_authorization.go
@@ -5,6 +5,7 @@ import (
 	"encoding/json"
 	"errors"
 	"net/http"
+	"net/mail"
 	"sort"
 	"strconv"
 	"strings"
@@ -37,6 +38,7 @@ type adminAuthorizationMemberRow struct {
 
 type putAdminAuthorizationMemberRequest struct {
 	SubjectID string `json:"subjectId"`
+	Email     string `json:"email"`
 	Role      string `json:"role"`
 }
 
@@ -152,23 +154,13 @@ func (s *Server) putAdminAuthorizationPluginMember(w http.ResponseWriter, r *htt
 		writeError(w, http.StatusBadRequest, "invalid JSON body")
 		return
 	}
-	userID, err := adminAuthorizationUserIDFromSubjectID(req.SubjectID)
-	if err != nil {
-		writeError(w, http.StatusBadRequest, err.Error())
-		return
-	}
 	if strings.TrimSpace(req.Role) == "" {
 		writeError(w, http.StatusBadRequest, "role is required")
 		return
 	}
-	user, err := s.users.GetUser(r.Context(), userID)
-	switch {
-	case err == nil:
-	case errors.Is(err, core.ErrNotFound):
-		writeError(w, http.StatusNotFound, "subject not found")
-		return
-	default:
-		writeError(w, http.StatusInternalServerError, "failed to resolve user")
+	user, status, message := s.resolveAdminAuthorizationWriteUser(r.Context(), req)
+	if status != 0 {
+		writeError(w, status, message)
 		return
 	}
 	if access, ok := s.authorizer.StaticRoleForProviderIdentity(plugin, principal.UserSubjectID(user.ID)); ok && access.Role != "" {
@@ -276,23 +268,13 @@ func (s *Server) putAdminAuthorizationAdminMember(w http.ResponseWriter, r *http
 		writeError(w, http.StatusBadRequest, "invalid JSON body")
 		return
 	}
-	userID, err := adminAuthorizationUserIDFromSubjectID(req.SubjectID)
-	if err != nil {
-		writeError(w, http.StatusBadRequest, err.Error())
-		return
-	}
 	if strings.TrimSpace(req.Role) == "" {
 		writeError(w, http.StatusBadRequest, "role is required")
 		return
 	}
-	user, err := s.users.GetUser(r.Context(), userID)
-	switch {
-	case err == nil:
-	case errors.Is(err, core.ErrNotFound):
-		writeError(w, http.StatusNotFound, "subject not found")
-		return
-	default:
-		writeError(w, http.StatusInternalServerError, "failed to resolve user")
+	user, status, message := s.resolveAdminAuthorizationWriteUser(r.Context(), req)
+	if status != 0 {
+		writeError(w, status, message)
 		return
 	}
 	if access, ok := s.authorizer.StaticRoleForPolicyIdentity(s.adminRoute.AuthorizationPolicy, principal.UserSubjectID(user.ID)); ok && access.Role != "" {
@@ -510,6 +492,41 @@ func (s *Server) reloadAuthorizationState(ctx context.Context) error {
 
 func (r adminAuthorizationMemberRow) adminAuthorizationRowKey() string {
 	return r.Source + ":" + r.SelectorKind + ":" + r.SelectorValue
+}
+
+func (s *Server) resolveAdminAuthorizationWriteUser(ctx context.Context, req putAdminAuthorizationMemberRequest) (*core.User, int, string) {
+	subjectID := strings.TrimSpace(req.SubjectID)
+	email := strings.TrimSpace(req.Email)
+	switch {
+	case subjectID != "" && email != "":
+		return nil, http.StatusBadRequest, "provide either subjectId or email, not both"
+	case subjectID != "":
+		userID, err := adminAuthorizationUserIDFromSubjectID(subjectID)
+		if err != nil {
+			return nil, http.StatusBadRequest, err.Error()
+		}
+		user, err := s.users.GetUser(ctx, userID)
+		switch {
+		case err == nil:
+			return user, 0, ""
+		case errors.Is(err, core.ErrNotFound):
+			return nil, http.StatusNotFound, "subject not found"
+		default:
+			return nil, http.StatusInternalServerError, "failed to resolve user"
+		}
+	case email != "":
+		parsed, err := mail.ParseAddress(email)
+		if err != nil || strings.TrimSpace(parsed.Address) == "" {
+			return nil, http.StatusBadRequest, "email must be a valid email address"
+		}
+		user, err := s.users.FindOrCreateUser(ctx, parsed.Address)
+		if err != nil {
+			return nil, http.StatusInternalServerError, "failed to resolve user"
+		}
+		return user, 0, ""
+	default:
+		return nil, http.StatusBadRequest, "subjectId or email is required"
+	}
 }
 
 func adminAuthorizationUserIDFromSubjectID(subjectID string) (string, error) {

--- a/gestaltd/internal/server/handlers_workflow.go
+++ b/gestaltd/internal/server/handlers_workflow.go
@@ -84,7 +84,7 @@ func (s *Server) listGlobalWorkflowSchedules(w http.ResponseWriter, r *http.Requ
 			if errors.Is(err, core.ErrNotFound) {
 				continue
 			}
-			s.writeWorkflowScheduleProviderError(w, r.Context(), strings.TrimSpace(ref.Target.PluginName), scheduleID, err)
+			s.writeWorkflowScheduleProviderError(r.Context(), w, strings.TrimSpace(ref.Target.PluginName), scheduleID, err)
 			return
 		}
 		if !workflowScheduleMatchesExecutionRef(ref.ProviderName, schedule, ref) {
@@ -153,7 +153,7 @@ func (s *Server) createWorkflowSchedule(w http.ResponseWriter, r *http.Request) 
 	})
 	if err != nil {
 		s.revokeWorkflowExecutionRef(r.Context(), ref)
-		s.writeWorkflowScheduleProviderError(w, r.Context(), pluginName, scheduleID, err)
+		s.writeWorkflowScheduleProviderError(r.Context(), w, pluginName, scheduleID, err)
 		return
 	}
 	writeJSON(w, http.StatusCreated, workflowScheduleInfoFromCore(schedule, providerName))
@@ -225,7 +225,7 @@ func (s *Server) updateGlobalWorkflowSchedule(w http.ResponseWriter, r *http.Req
 	})
 	if err != nil {
 		s.revokeWorkflowExecutionRef(r.Context(), nextRef)
-		s.writeWorkflowScheduleProviderError(w, r.Context(), pluginName, strings.TrimSpace(existing.ID), err)
+		s.writeWorkflowScheduleProviderError(r.Context(), w, pluginName, strings.TrimSpace(existing.ID), err)
 		return
 	}
 	if currentProviderName != nextProviderName {
@@ -236,7 +236,7 @@ func (s *Server) updateGlobalWorkflowSchedule(w http.ResponseWriter, r *http.Req
 				ScheduleID: strings.TrimSpace(existing.ID),
 			})
 			s.revokeWorkflowExecutionRef(r.Context(), nextRef)
-			s.writeWorkflowScheduleProviderError(w, r.Context(), strings.TrimSpace(existing.Target.PluginName), strings.TrimSpace(existing.ID), err)
+			s.writeWorkflowScheduleProviderError(r.Context(), w, strings.TrimSpace(existing.Target.PluginName), strings.TrimSpace(existing.ID), err)
 			return
 		}
 	}
@@ -258,7 +258,7 @@ func (s *Server) deleteGlobalWorkflowSchedule(w http.ResponseWriter, r *http.Req
 	if err := provider.DeleteSchedule(r.Context(), coreworkflow.DeleteScheduleRequest{
 		ScheduleID: strings.TrimSpace(schedule.ID),
 	}); err != nil {
-		s.writeWorkflowScheduleProviderError(w, r.Context(), strings.TrimSpace(schedule.Target.PluginName), strings.TrimSpace(schedule.ID), err)
+		s.writeWorkflowScheduleProviderError(r.Context(), w, strings.TrimSpace(schedule.Target.PluginName), strings.TrimSpace(schedule.ID), err)
 		return
 	}
 	if ref != nil && ref.ID != "" {
@@ -280,7 +280,7 @@ func (s *Server) pauseGlobalWorkflowSchedule(w http.ResponseWriter, r *http.Requ
 		ScheduleID: strings.TrimSpace(schedule.ID),
 	})
 	if err != nil {
-		s.writeWorkflowScheduleProviderError(w, r.Context(), strings.TrimSpace(schedule.Target.PluginName), strings.TrimSpace(schedule.ID), err)
+		s.writeWorkflowScheduleProviderError(r.Context(), w, strings.TrimSpace(schedule.Target.PluginName), strings.TrimSpace(schedule.ID), err)
 		return
 	}
 	writeJSON(w, http.StatusOK, workflowScheduleInfoFromCore(value, providerName))
@@ -299,7 +299,7 @@ func (s *Server) resumeGlobalWorkflowSchedule(w http.ResponseWriter, r *http.Req
 		ScheduleID: strings.TrimSpace(schedule.ID),
 	})
 	if err != nil {
-		s.writeWorkflowScheduleProviderError(w, r.Context(), strings.TrimSpace(schedule.Target.PluginName), strings.TrimSpace(schedule.ID), err)
+		s.writeWorkflowScheduleProviderError(r.Context(), w, strings.TrimSpace(schedule.Target.PluginName), strings.TrimSpace(schedule.ID), err)
 		return
 	}
 	writeJSON(w, http.StatusOK, workflowScheduleInfoFromCore(value, providerName))
@@ -443,7 +443,7 @@ func (s *Server) requireOwnedWorkflowScheduleGlobal(
 	}
 	schedule, err := provider.GetSchedule(ctx, coreworkflow.GetScheduleRequest{ScheduleID: scheduleID})
 	if err != nil {
-		s.writeWorkflowScheduleProviderError(w, ctx, strings.TrimSpace(ref.Target.PluginName), scheduleID, err)
+		s.writeWorkflowScheduleProviderError(ctx, w, strings.TrimSpace(ref.Target.PluginName), scheduleID, err)
 		return nil, nil, "", nil, false
 	}
 	if !workflowScheduleMatchesExecutionRef(ref.ProviderName, schedule, ref) {
@@ -657,7 +657,7 @@ func (s *Server) revokeWorkflowExecutionRef(ctx context.Context, ref *coreworkfl
 	_, _ = s.workflowExecutionRefs.Put(ctx, &cloned)
 }
 
-func (s *Server) writeWorkflowScheduleProviderError(w http.ResponseWriter, ctx context.Context, pluginName, scheduleID string, err error) {
+func (s *Server) writeWorkflowScheduleProviderError(ctx context.Context, w http.ResponseWriter, pluginName, scheduleID string, err error) {
 	switch {
 	case errors.Is(err, core.ErrNotFound):
 		writeError(w, http.StatusNotFound, fmt.Sprintf("workflow schedule %q not found", scheduleID))

--- a/gestaltd/internal/server/server_test.go
+++ b/gestaltd/internal/server/server_test.go
@@ -2469,8 +2469,8 @@ func TestAdminAPI_PluginAuthorizationCRUD(t *testing.T) {
 		t.Fatalf("plugins status = %d, want 200", resp.StatusCode)
 	}
 
-	dynamicUser := seedUser(t, svc, "dynamic@example.test")
-	body := bytes.NewBufferString(fmt.Sprintf(`{"subjectId":%q,"role":"viewer"}`, principal.UserSubjectID(dynamicUser.ID)))
+	dynamicEmail := "dynamic@example.test"
+	body := bytes.NewBufferString(fmt.Sprintf(`{"email":%q,"role":"viewer"}`, dynamicEmail))
 	req, _ := http.NewRequest(http.MethodPut, ts.URL+"/admin/api/v1/authorization/plugins/sample_plugin/members", body)
 	req.Header.Set("Content-Type", "application/json")
 	resp, err = http.DefaultClient.Do(req)
@@ -2491,6 +2491,10 @@ func TestAdminAPI_PluginAuthorizationCRUD(t *testing.T) {
 	}
 	if err := json.NewDecoder(resp.Body).Decode(&putPluginMembershipResp); err != nil {
 		t.Fatalf("decode plugin membership response: %v", err)
+	}
+	dynamicUser, err := svc.Users.FindUserByEmail(context.Background(), dynamicEmail)
+	if err != nil {
+		t.Fatalf("FindUserByEmail dynamic plugin member: %v", err)
 	}
 	if putPluginMembershipResp.Membership.SelectorKind != "subject_id" {
 		t.Fatalf("plugin membership selectorKind = %q, want subject_id", putPluginMembershipResp.Membership.SelectorKind)
@@ -2532,8 +2536,7 @@ func TestAdminAPI_PluginAuthorizationCRUD(t *testing.T) {
 		t.Fatalf("expected one dynamic plugin member, got %+v", members)
 	}
 
-	staticUser := seedUser(t, svc, "static@example.test")
-	body = bytes.NewBufferString(fmt.Sprintf(`{"subjectId":%q,"role":"viewer"}`, principal.UserSubjectID(staticUser.ID)))
+	body = bytes.NewBufferString(`{"email":"static@example.test","role":"viewer"}`)
 	req, _ = http.NewRequest(http.MethodPut, ts.URL+"/admin/api/v1/authorization/plugins/sample_plugin/members", body)
 	req.Header.Set("Content-Type", "application/json")
 	resp, err = http.DefaultClient.Do(req)
@@ -2879,8 +2882,8 @@ func TestAdminAPI_AdminAuthorizationCRUD(t *testing.T) {
 		t.Fatalf("admin members = %+v, want one static row", members)
 	}
 
-	dynamicAdmin := seedUser(t, svc, "dynamic-admin@example.test")
-	body := bytes.NewBufferString(fmt.Sprintf(`{"subjectId":%q,"role":"owner"}`, principal.UserSubjectID(dynamicAdmin.ID)))
+	dynamicAdminEmail := "dynamic-admin@example.test"
+	body := bytes.NewBufferString(fmt.Sprintf(`{"email":%q,"role":"owner"}`, dynamicAdminEmail))
 	req, _ = http.NewRequest(http.MethodPut, ts.URL+"/admin/api/v1/authorization/admins/members", body)
 	req.Header.Set("Content-Type", "application/json")
 	req.AddCookie(&http.Cookie{Name: "session_token", Value: "admin-session"})
@@ -2902,6 +2905,10 @@ func TestAdminAPI_AdminAuthorizationCRUD(t *testing.T) {
 	}
 	if err := json.NewDecoder(resp.Body).Decode(&putAdminMembershipResp); err != nil {
 		t.Fatalf("decode admin membership response: %v", err)
+	}
+	dynamicAdmin, err := svc.Users.FindUserByEmail(context.Background(), dynamicAdminEmail)
+	if err != nil {
+		t.Fatalf("FindUserByEmail dynamic admin member: %v", err)
 	}
 	if putAdminMembershipResp.Membership.SelectorKind != "subject_id" {
 		t.Fatalf("admin membership selectorKind = %q, want subject_id", putAdminMembershipResp.Membership.SelectorKind)
@@ -2944,8 +2951,7 @@ func TestAdminAPI_AdminAuthorizationCRUD(t *testing.T) {
 		t.Fatalf("expected one dynamic admin member, got %+v", members)
 	}
 
-	staticAdmin := seedUser(t, svc, "static-admin@example.test")
-	body = bytes.NewBufferString(fmt.Sprintf(`{"subjectId":%q,"role":"owner"}`, principal.UserSubjectID(staticAdmin.ID)))
+	body = bytes.NewBufferString(`{"email":"static-admin@example.test","role":"owner"}`)
 	req, _ = http.NewRequest(http.MethodPut, ts.URL+"/admin/api/v1/authorization/admins/members", body)
 	req.Header.Set("Content-Type", "application/json")
 	req.AddCookie(&http.Cookie{Name: "session_token", Value: "admin-session"})


### PR DESCRIPTION
## Summary
- accept `email` as a write alias for dynamic plugin/admin membership PUTs while keeping storage, list, and delete canonical on `subjectId`
- switch the built-in `/admin` membership forms back to email entry and update the admin HTTP API docs to match
- fold email-alias coverage into the existing plugin/admin CRUD tests and include the small `handlers_workflow.go` lint fix needed to keep the branch green

## Verification
- `cd gestaltd && go test ./internal/server ./internal/bootstrap ./internal/authorization`
- `cd gestaltd && golangci-lint run ./internal/server ./internal/bootstrap ./internal/authorization`
- `cd docs && npm ci && npm run build`