### PR TITLE
server: show emails in admin auth member lists

### DIFF
--- a/gestaltd/internal/adminui/out/index.html
+++ b/gestaltd/internal/adminui/out/index.html
@@ -1339,11 +1339,15 @@
 
         function principalLabel(row) {
           if (!row) return "Unknown";
+          if (row.email) return row.email;
           return row.selectorValue || "Unknown";
         }
 
         function principalMeta(row) {
           if (!row) return "";
+          if (row.selectorKind === "subject_id" && typeof row.selectorValue === "string" && row.selectorValue.trim()) {
+            return "subject_id: " + row.selectorValue.trim();
+          }
           return row.selectorKind || "";
         }
 

--- a/gestaltd/internal/server/handlers_admin_authorization.go
+++ b/gestaltd/internal/server/handlers_admin_authorization.go
@@ -33,6 +33,7 @@ type adminAuthorizationMemberRow struct {
 	Mutable       bool   `json:"mutable"`
 	SelectorKind  string `json:"selectorKind"`
 	SelectorValue string `json:"selectorValue"`
+	Email         string `json:"email,omitempty"`
 	ShadowedBy    string `json:"shadowedBy,omitempty"`
 }
 
@@ -182,6 +183,7 @@ func (s *Server) putAdminAuthorizationPluginMember(w http.ResponseWriter, r *htt
 		Mutable:       true,
 		SelectorKind:  "subject_id",
 		SelectorValue: principal.UserSubjectID(strings.TrimSpace(membership.UserID)),
+		Email:         strings.TrimSpace(user.Email),
 	}
 	if err := s.reloadAuthorizationState(r.Context()); err != nil {
 		writeJSON(w, http.StatusAccepted, map[string]any{
@@ -295,6 +297,7 @@ func (s *Server) putAdminAuthorizationAdminMember(w http.ResponseWriter, r *http
 		Mutable:       true,
 		SelectorKind:  "subject_id",
 		SelectorValue: principal.UserSubjectID(strings.TrimSpace(membership.UserID)),
+		Email:         strings.TrimSpace(user.Email),
 	}
 	if err := s.reloadAuthorizationState(r.Context()); err != nil {
 		writeJSON(w, http.StatusAccepted, map[string]any{
@@ -383,7 +386,7 @@ func (s *Server) adminAuthorizationMemberRows(ctx context.Context, plugin string
 	if s.authorizer == nil || s.authorizationProvider == nil {
 		return nil, errAdminAuthorizationUnavailable
 	}
-	staticRows := s.adminAuthorizationStaticRows(plugin)
+	staticRows := s.adminAuthorizationStaticRows(ctx, plugin)
 	dynamicRows, err := s.providerPluginAuthorizationRows(ctx, plugin)
 	if err != nil {
 		return nil, err
@@ -395,7 +398,7 @@ func (s *Server) adminAuthorizationAdminRows(ctx context.Context) ([]adminAuthor
 	if s.authorizer == nil || s.authorizationProvider == nil {
 		return nil, errAdminAuthorizationUnavailable
 	}
-	staticRows := s.adminAuthorizationStaticAdminRows()
+	staticRows := s.adminAuthorizationStaticAdminRows(ctx)
 	dynamicRows, err := s.providerAdminAuthorizationRows(ctx)
 	if err != nil {
 		return nil, err
@@ -403,23 +406,23 @@ func (s *Server) adminAuthorizationAdminRows(ctx context.Context) ([]adminAuthor
 	return mergeAdminAuthorizationRows(staticRows, dynamicRows), nil
 }
 
-func (s *Server) adminAuthorizationStaticRows(plugin string) []adminAuthorizationMemberRow {
+func (s *Server) adminAuthorizationStaticRows(ctx context.Context, plugin string) []adminAuthorizationMemberRow {
 	_, members, ok := s.authorizer.StaticMembersForProvider(plugin)
 	if !ok {
 		return nil
 	}
-	return s.adminAuthorizationRowsFromStaticMembers(plugin, members)
+	return s.adminAuthorizationRowsFromStaticMembers(ctx, plugin, members)
 }
 
-func (s *Server) adminAuthorizationStaticAdminRows() []adminAuthorizationMemberRow {
+func (s *Server) adminAuthorizationStaticAdminRows(ctx context.Context) []adminAuthorizationMemberRow {
 	members, ok := s.authorizer.StaticMembersForPolicy(s.adminRoute.AuthorizationPolicy)
 	if !ok {
 		return nil
 	}
-	return s.adminAuthorizationRowsFromStaticMembers("", members)
+	return s.adminAuthorizationRowsFromStaticMembers(ctx, "", members)
 }
 
-func (s *Server) adminAuthorizationRowsFromStaticMembers(plugin string, members []authorization.StaticHumanMember) []adminAuthorizationMemberRow {
+func (s *Server) adminAuthorizationRowsFromStaticMembers(ctx context.Context, plugin string, members []authorization.StaticHumanMember) []adminAuthorizationMemberRow {
 	rows := make([]adminAuthorizationMemberRow, 0, len(members))
 	for _, member := range members {
 		rows = append(rows, adminAuthorizationMemberRow{
@@ -430,6 +433,7 @@ func (s *Server) adminAuthorizationRowsFromStaticMembers(plugin string, members 
 			Mutable:       false,
 			SelectorKind:  "subject_id",
 			SelectorValue: member.SubjectID,
+			Email:         s.adminAuthorizationEmailForSubjectID(ctx, member.SubjectID),
 		})
 	}
 	return rows
@@ -492,6 +496,18 @@ func (s *Server) reloadAuthorizationState(ctx context.Context) error {
 
 func (r adminAuthorizationMemberRow) adminAuthorizationRowKey() string {
 	return r.Source + ":" + r.SelectorKind + ":" + r.SelectorValue
+}
+
+func (s *Server) adminAuthorizationEmailForSubjectID(ctx context.Context, subjectID string) string {
+	userID := strings.TrimSpace(principal.UserIDFromSubjectID(subjectID))
+	if userID == "" || s.users == nil {
+		return ""
+	}
+	user, err := s.users.GetUser(ctx, userID)
+	if err != nil || user == nil {
+		return ""
+	}
+	return strings.TrimSpace(user.Email)
 }
 
 func (s *Server) resolveAdminAuthorizationWriteUser(ctx context.Context, req putAdminAuthorizationMemberRequest) (*core.User, int, string) {

--- a/gestaltd/internal/server/handlers_admin_authorization_provider.go
+++ b/gestaltd/internal/server/handlers_admin_authorization_provider.go
@@ -237,6 +237,7 @@ func (s *Server) adminAuthorizationDynamicRowFromProviderRelationship(ctx contex
 		}
 		row.SelectorKind = "subject_id"
 		row.SelectorValue = subjectID
+		row.Email = s.adminAuthorizationEmailForSubjectID(ctx, subjectID)
 	default:
 		return adminAuthorizationMemberRow{}, false, nil
 	}

--- a/gestaltd/internal/server/server_test.go
+++ b/gestaltd/internal/server/server_test.go
@@ -2486,6 +2486,7 @@ func TestAdminAPI_PluginAuthorizationCRUD(t *testing.T) {
 		Membership struct {
 			SelectorKind  string `json:"selectorKind"`
 			SelectorValue string `json:"selectorValue"`
+			Email         string `json:"email"`
 			Role          string `json:"role"`
 		} `json:"membership"`
 	}
@@ -2501,6 +2502,9 @@ func TestAdminAPI_PluginAuthorizationCRUD(t *testing.T) {
 	}
 	if putPluginMembershipResp.Membership.SelectorValue != principal.UserSubjectID(dynamicUser.ID) {
 		t.Fatalf("plugin membership selectorValue = %q, want canonical subject id", putPluginMembershipResp.Membership.SelectorValue)
+	}
+	if putPluginMembershipResp.Membership.Email != dynamicEmail {
+		t.Fatalf("plugin membership email = %q, want %q", putPluginMembershipResp.Membership.Email, dynamicEmail)
 	}
 
 	resp, err = http.Get(ts.URL + "/admin/api/v1/authorization/plugins/sample_plugin/members")
@@ -2530,6 +2534,9 @@ func TestAdminAPI_PluginAuthorizationCRUD(t *testing.T) {
 		}
 		if member["selectorValue"] != principal.UserSubjectID(dynamicUser.ID) {
 			t.Fatalf("dynamic plugin member selector metadata = %+v, want canonical subject_id selectorValue", member)
+		}
+		if member["email"] != dynamicEmail {
+			t.Fatalf("dynamic plugin member email = %v, want %q", member["email"], dynamicEmail)
 		}
 	}
 	if !foundDynamicPluginMember {
@@ -2900,6 +2907,7 @@ func TestAdminAPI_AdminAuthorizationCRUD(t *testing.T) {
 		Membership struct {
 			SelectorKind  string `json:"selectorKind"`
 			SelectorValue string `json:"selectorValue"`
+			Email         string `json:"email"`
 			Role          string `json:"role"`
 		} `json:"membership"`
 	}
@@ -2915,6 +2923,9 @@ func TestAdminAPI_AdminAuthorizationCRUD(t *testing.T) {
 	}
 	if putAdminMembershipResp.Membership.SelectorValue != principal.UserSubjectID(dynamicAdmin.ID) {
 		t.Fatalf("admin membership selectorValue = %q, want canonical subject id", putAdminMembershipResp.Membership.SelectorValue)
+	}
+	if putAdminMembershipResp.Membership.Email != dynamicAdminEmail {
+		t.Fatalf("admin membership email = %q, want %q", putAdminMembershipResp.Membership.Email, dynamicAdminEmail)
 	}
 
 	req, _ = http.NewRequest(http.MethodGet, ts.URL+"/admin/api/v1/authorization/admins/members", nil)
@@ -2945,6 +2956,9 @@ func TestAdminAPI_AdminAuthorizationCRUD(t *testing.T) {
 		}
 		if member["selectorValue"] != principal.UserSubjectID(dynamicAdmin.ID) {
 			t.Fatalf("dynamic admin member selector metadata = %+v, want canonical subject_id selectorValue", member)
+		}
+		if member["email"] != dynamicAdminEmail {
+			t.Fatalf("dynamic admin member email = %v, want %q", member["email"], dynamicAdminEmail)
 		}
 	}
 	if !foundDynamicAdminMember {


### PR DESCRIPTION
## Summary
- hydrate admin authorization member rows with resolved user emails when the selector is a canonical `user:<id>` subject
- make the built-in admin UI prefer `email` for the primary label while keeping the canonical `subject_id` in the secondary line
- extend the existing plugin/admin CRUD coverage to assert the returned email metadata

## Verification
- `cd gestaltd && go test ./internal/server ./internal/bootstrap ./internal/authorization`
- `cd gestaltd && golangci-lint run ./internal/server ./internal/bootstrap ./internal/authorization`