### PR TITLE
identities: key managed identity memberships by subject_id

### DIFF
--- a/docs/content/reference/http-api.mdx
+++ b/docs/content/reference/http-api.mdx
@@ -49,6 +49,25 @@ Authenticated routes accept a `session_token` cookie or an `Authorization: Beare
 | `DELETE` | `/api/v1/tokens/{id}` | Revoke an API token. |
 | `DELETE` | `/api/v1/tokens` | Revoke all API tokens for the current user. |
 
+### Managed Identities
+
+| Method | Path | Purpose |
+| --- | --- | --- |
+| `GET` | `/api/v1/identities` | List managed identities where the current user is a member. |
+| `POST` | `/api/v1/identities` | Create a managed identity. The creator is seeded as an `admin` member. |
+| `GET` | `/api/v1/identities/{identityID}` | Get one managed identity when the caller has identity membership. |
+| `PATCH` | `/api/v1/identities/{identityID}` | Update the managed identity display name. Requires `admin` membership. |
+| `DELETE` | `/api/v1/identities/{identityID}` | Delete a managed identity and its child state. Requires `admin` membership. |
+| `GET` | `/api/v1/identities/{identityID}/members` | List managed identity membership rows. Responses use canonical user `subjectId` plus `email` metadata. |
+| `PUT` | `/api/v1/identities/{identityID}/members` | Upsert one managed identity membership row by `email` alias and role. Gestalt resolves the email to the canonical user `subjectId` before persisting membership state. |
+| `DELETE` | `/api/v1/identities/{identityID}/members/{email}` | Remove one managed identity membership row by email alias. Gestalt resolves the email to the canonical user `subjectId` before deleting membership state. |
+| `GET` | `/api/v1/identities/{identityID}/grants` | List plugin grants for one managed identity. |
+| `PUT` | `/api/v1/identities/{identityID}/grants/{plugin}` | Upsert plugin grant operations for one managed identity. |
+| `DELETE` | `/api/v1/identities/{identityID}/grants/{plugin}` | Remove one plugin grant from a managed identity. |
+| `GET` | `/api/v1/identities/{identityID}/tokens` | List API tokens owned by one managed identity. |
+| `POST` | `/api/v1/identities/{identityID}/tokens` | Create an API token for one managed identity. |
+| `DELETE` | `/api/v1/identities/{identityID}/tokens/{id}` | Revoke one API token owned by a managed identity. |
+
 ### Operator Surfaces
 
 | Method | Path | Purpose |
@@ -67,6 +86,8 @@ Authenticated routes accept a `session_token` cookie or an `Authorization: Beare
 Mutable human membership APIs still list and delete by canonical `subjectId`. User-backed rows use `subjectId` values in the form `user:<user_id>`. Dynamic membership writes accept either a canonical `subjectId` or an `email` alias. When `email` is used, Gestalt resolves it to the canonical user subject and creates the user record if needed before persisting the provider-backed grant.
 
 `PUT` and `DELETE` may return `202 Accepted` with `status: "persisted_pending_reload"` when the dynamic grant was written successfully but the local in-memory authorization snapshot has not reloaded yet. In that case, retry access checks only after the local snapshot converges.
+
+Managed identity member rows use canonical user `subjectId` values in the form `user:<user_id>`. Member writes remain email-friendly: `PUT` and `DELETE` resolve the supplied email alias to a canonical user subject before membership state is stored or removed.
 
 ## MCP
 

--- a/docs/internal/managed-agent-identities-implementation-plan.md
+++ b/docs/internal/managed-agent-identities-implementation-plan.md
@@ -646,7 +646,7 @@ type ManagedIdentity struct {
 
 type ManagedIdentityMembership struct {
     IdentityID string
-    UserID     string
+    SubjectID  string
     Email      string
     Role       string
 }

--- a/docs/internal/managed-agent-identities.md
+++ b/docs/internal/managed-agent-identities.md
@@ -70,7 +70,7 @@ Properties:
 
 ### Human sharing model
 
-- Membership is user/email-based only in V1.
+- Membership state is keyed by canonical user `subject_id` in V1, with email preserved as UX metadata and write alias.
 - Membership roles are `viewer`, `editor`, and `admin`.
 - The creator should be seeded as an `admin`.
 
@@ -176,7 +176,7 @@ This matrix captures the minimum V1 surface area.
 | Feature | Backend / Data Model | HTTP API | CLI | Default Web UI | Notes |
 | --- | --- | --- | --- | --- | --- |
 | Identity CRUD | Required | Required | Required | Required | Workspace-owned runtime resources |
-| Membership sharing | Required | Required | Required | Required | User/email-based only |
+| Membership sharing | Required | Required | Required | Required | Canonical user `subject_id` storage, email-friendly writes |
 | Viewer/editor/admin enforcement | Required | Required | Required | Required | UI should mirror server enforcement |
 | Plugin grant management | Required | Required | Required | Required | Plugin-wide or operation-scoped |
 | Visibility filtering by human auth | Required | Required | Required | Required | Hidden, not auto-revoked |

--- a/gestalt/cli/src/commands/identities.rs
+++ b/gestalt/cli/src/commands/identities.rs
@@ -256,13 +256,13 @@ fn print_member(value: &serde_json::Value, format: Format) {
         Format::Json => output::print_json(value),
         Format::Table => {
             let row = vec![vec![
-                value["userId"].as_str().unwrap_or("-").to_string(),
+                value["subjectId"].as_str().unwrap_or("-").to_string(),
                 value["email"].as_str().unwrap_or("-").to_string(),
                 value["role"].as_str().unwrap_or("-").to_string(),
                 value["createdAt"].as_str().unwrap_or("-").to_string(),
                 value["updatedAt"].as_str().unwrap_or("-").to_string(),
             ]];
-            output::print_table(&["User ID", "Email", "Role", "Created", "Updated"], &row);
+            output::print_table(&["Subject ID", "Email", "Role", "Created", "Updated"], &row);
         }
     }
 }
@@ -276,7 +276,7 @@ fn print_members(value: &serde_json::Value, format: Format) {
                 .iter()
                 .map(|item| {
                     vec![
-                        item["userId"].as_str().unwrap_or("-").to_string(),
+                        item["subjectId"].as_str().unwrap_or("-").to_string(),
                         item["email"].as_str().unwrap_or("-").to_string(),
                         item["role"].as_str().unwrap_or("-").to_string(),
                         item["createdAt"].as_str().unwrap_or("-").to_string(),
@@ -284,7 +284,10 @@ fn print_members(value: &serde_json::Value, format: Format) {
                     ]
                 })
                 .collect();
-            output::print_table(&["User ID", "Email", "Role", "Created", "Updated"], &rows);
+            output::print_table(
+                &["Subject ID", "Email", "Role", "Created", "Updated"],
+                &rows,
+            );
         }
     }
 }

--- a/gestalt/cli/tests/identities_cli.rs
+++ b/gestalt/cli/tests/identities_cli.rs
@@ -70,7 +70,7 @@ fn test_cli_adds_identity_member() {
         r#"{"email":"viewer@example.test","role":"viewer"}"#.to_string(),
     ))
     .with_body(
-        r#"{"userId":"user-2","email":"viewer@example.test","role":"viewer","createdAt":"2026-04-15T00:00:00Z","updatedAt":"2026-04-15T00:00:00Z"}"#,
+        r#"{"subjectId":"user:user-2","email":"viewer@example.test","role":"viewer","createdAt":"2026-04-15T00:00:00Z","updatedAt":"2026-04-15T00:00:00Z"}"#,
     )
     .create();
 
@@ -80,8 +80,6 @@ fn test_cli_adds_identity_member() {
         .arg("--url")
         .arg(server.url())
         .args([
-            "--format",
-            "json",
             "identities",
             "members",
             "add",
@@ -92,10 +90,9 @@ fn test_cli_adds_identity_member() {
         ])
         .assert()
         .success()
-        .stdout(predicate::str::contains(
-            r#""email": "viewer@example.test""#,
-        ))
-        .stdout(predicate::str::contains(r#""role": "viewer""#));
+        .stdout(predicate::str::contains("Subject ID"))
+        .stdout(predicate::str::contains("user:user-2"))
+        .stdout(predicate::str::contains("viewer"));
 }
 
 #[test]

--- a/gestaltd/core/types.go
+++ b/gestaltd/core/types.go
@@ -72,7 +72,7 @@ type ManagedIdentity struct {
 type ManagedIdentityMembership struct {
 	ID         string
 	IdentityID string
-	UserID     string
+	SubjectID  string
 	Email      string
 	Role       string
 	CreatedAt  time.Time

--- a/gestaltd/internal/coredata/managed_identity_memberships.go
+++ b/gestaltd/internal/coredata/managed_identity_memberships.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"strings"
 	"time"
 
 	"github.com/google/uuid"
@@ -26,12 +27,16 @@ func NewManagedIdentityMembershipService(ds indexeddb.IndexedDB, canonicalGrants
 }
 
 func (s *ManagedIdentityMembershipService) UpsertMembership(ctx context.Context, membership *core.ManagedIdentityMembership) (*core.ManagedIdentityMembership, error) {
-	if membership == nil || membership.IdentityID == "" || membership.UserID == "" {
-		return nil, fmt.Errorf("upsert managed identity membership: identity_id and user_id are required")
+	if membership == nil || membership.IdentityID == "" || membership.SubjectID == "" {
+		return nil, fmt.Errorf("upsert managed identity membership: identity_id and subject_id are required")
+	}
+	membership.SubjectID = strings.TrimSpace(membership.SubjectID)
+	if managedIdentityMembershipUserIDFromSubjectID(membership.SubjectID) == "" {
+		return nil, fmt.Errorf("upsert managed identity membership: subject_id must be a canonical user subject")
 	}
 
 	now := time.Now()
-	rec, err := s.store.Index("by_identity_user").Get(ctx, membership.IdentityID, membership.UserID)
+	rec, err := s.store.Index("by_identity_subject").Get(ctx, membership.IdentityID, membership.SubjectID)
 	switch {
 	case err == nil:
 		existing := recordToManagedIdentityMembership(rec)
@@ -63,8 +68,8 @@ func (s *ManagedIdentityMembershipService) UpsertMembership(ctx context.Context,
 	return membership, nil
 }
 
-func (s *ManagedIdentityMembershipService) GetMembership(ctx context.Context, identityID, userID string) (*core.ManagedIdentityMembership, error) {
-	rec, err := s.store.Index("by_identity_user").Get(ctx, identityID, userID)
+func (s *ManagedIdentityMembershipService) GetMembership(ctx context.Context, identityID, subjectID string) (*core.ManagedIdentityMembership, error) {
+	rec, err := s.store.Index("by_identity_subject").Get(ctx, identityID, strings.TrimSpace(subjectID))
 	if err != nil {
 		if err == indexeddb.ErrNotFound {
 			return nil, core.ErrNotFound
@@ -86,10 +91,10 @@ func (s *ManagedIdentityMembershipService) ListMembershipsByIdentity(ctx context
 	return out, nil
 }
 
-func (s *ManagedIdentityMembershipService) ListMembershipsByUser(ctx context.Context, userID string) ([]*core.ManagedIdentityMembership, error) {
-	recs, err := s.store.Index("by_user").GetAll(ctx, nil, userID)
+func (s *ManagedIdentityMembershipService) ListMembershipsBySubject(ctx context.Context, subjectID string) ([]*core.ManagedIdentityMembership, error) {
+	recs, err := s.store.Index("by_subject").GetAll(ctx, nil, strings.TrimSpace(subjectID))
 	if err != nil {
-		return nil, fmt.Errorf("list managed identity memberships by user: %w", err)
+		return nil, fmt.Errorf("list managed identity memberships by subject: %w", err)
 	}
 	out := make([]*core.ManagedIdentityMembership, 0, len(recs))
 	for _, rec := range recs {
@@ -98,8 +103,9 @@ func (s *ManagedIdentityMembershipService) ListMembershipsByUser(ctx context.Con
 	return out, nil
 }
 
-func (s *ManagedIdentityMembershipService) DeleteMembership(ctx context.Context, identityID, userID string) error {
-	deleted, err := s.store.Index("by_identity_user").Delete(ctx, identityID, userID)
+func (s *ManagedIdentityMembershipService) DeleteMembership(ctx context.Context, identityID, subjectID string) error {
+	subjectID = strings.TrimSpace(subjectID)
+	deleted, err := s.store.Index("by_identity_subject").Delete(ctx, identityID, subjectID)
 	if err != nil {
 		return fmt.Errorf("delete managed identity membership: %w", err)
 	}
@@ -107,7 +113,7 @@ func (s *ManagedIdentityMembershipService) DeleteMembership(ctx context.Context,
 		return core.ErrNotFound
 	}
 	if s.canonicalGrants != nil {
-		managerIdentityID, resolveErr := s.resolveManagerIdentityID(ctx, userID)
+		managerIdentityID, resolveErr := s.resolveManagerIdentityID(ctx, subjectID)
 		if resolveErr == nil {
 			if err := s.canonicalGrants.DeleteGrant(ctx, managerIdentityID, identityID); err != nil && err != core.ErrNotFound {
 				return fmt.Errorf("delete canonical identity management grant: %w", err)
@@ -118,8 +124,12 @@ func (s *ManagedIdentityMembershipService) DeleteMembership(ctx context.Context,
 }
 
 func (s *ManagedIdentityMembershipService) RestoreMembership(ctx context.Context, membership *core.ManagedIdentityMembership) error {
-	if membership == nil || membership.ID == "" || membership.IdentityID == "" || membership.UserID == "" {
-		return fmt.Errorf("restore managed identity membership: id, identity_id, and user_id are required")
+	if membership == nil || membership.ID == "" || membership.IdentityID == "" || membership.SubjectID == "" {
+		return fmt.Errorf("restore managed identity membership: id, identity_id, and subject_id are required")
+	}
+	membership.SubjectID = strings.TrimSpace(membership.SubjectID)
+	if managedIdentityMembershipUserIDFromSubjectID(membership.SubjectID) == "" {
+		return fmt.Errorf("restore managed identity membership: subject_id must be a canonical user subject")
 	}
 	if err := s.store.Put(ctx, managedIdentityMembershipRecord(membership)); err != nil {
 		return fmt.Errorf("restore managed identity membership: %w", err)
@@ -150,7 +160,7 @@ func managedIdentityMembershipRecord(membership *core.ManagedIdentityMembership)
 	return indexeddb.Record{
 		"id":          membership.ID,
 		"identity_id": membership.IdentityID,
-		"user_id":     membership.UserID,
+		"subject_id":  membership.SubjectID,
 		"email":       membership.Email,
 		"role":        membership.Role,
 		"created_at":  membership.CreatedAt,
@@ -162,7 +172,7 @@ func recordToManagedIdentityMembership(rec indexeddb.Record) *core.ManagedIdenti
 	return &core.ManagedIdentityMembership{
 		ID:         recString(rec, "id"),
 		IdentityID: recString(rec, "identity_id"),
-		UserID:     recString(rec, "user_id"),
+		SubjectID:  recString(rec, "subject_id"),
 		Email:      recString(rec, "email"),
 		Role:       recString(rec, "role"),
 		CreatedAt:  recTime(rec, "created_at"),
@@ -170,7 +180,11 @@ func recordToManagedIdentityMembership(rec indexeddb.Record) *core.ManagedIdenti
 	}
 }
 
-func (s *ManagedIdentityMembershipService) resolveManagerIdentityID(ctx context.Context, userID string) (string, error) {
+func (s *ManagedIdentityMembershipService) resolveManagerIdentityID(ctx context.Context, subjectID string) (string, error) {
+	userID := managedIdentityMembershipUserIDFromSubjectID(subjectID)
+	if userID == "" {
+		return "", core.ErrNotFound
+	}
 	if s.users == nil {
 		return userID, nil
 	}
@@ -178,10 +192,10 @@ func (s *ManagedIdentityMembershipService) resolveManagerIdentityID(ctx context.
 }
 
 func (s *ManagedIdentityMembershipService) syncCanonicalGrant(ctx context.Context, membership *core.ManagedIdentityMembership) error {
-	if s.canonicalGrants == nil || membership == nil || membership.UserID == "" || membership.IdentityID == "" {
+	if s.canonicalGrants == nil || membership == nil || membership.SubjectID == "" || membership.IdentityID == "" {
 		return nil
 	}
-	managerIdentityID, resolveErr := s.resolveManagerIdentityID(ctx, membership.UserID)
+	managerIdentityID, resolveErr := s.resolveManagerIdentityID(ctx, membership.SubjectID)
 	if resolveErr != nil {
 		if errors.Is(resolveErr, core.ErrNotFound) {
 			return nil
@@ -198,4 +212,14 @@ func (s *ManagedIdentityMembershipService) syncCanonicalGrant(ctx context.Contex
 		return fmt.Errorf("sync canonical identity management grant %q/%q: %w", managerIdentityID, membership.IdentityID, err)
 	}
 	return nil
+}
+
+// Keep this local: importing internal/principal here creates a cycle via
+// principal/resolver.go -> coredata.
+func managedIdentityMembershipUserIDFromSubjectID(subjectID string) string {
+	subjectID = strings.TrimSpace(subjectID)
+	if !strings.HasPrefix(subjectID, "user:") {
+		return ""
+	}
+	return strings.TrimPrefix(subjectID, "user:")
 }

--- a/gestaltd/internal/coredata/schemas.go
+++ b/gestaltd/internal/coredata/schemas.go
@@ -99,13 +99,13 @@ var ManagedIdentitiesSchema = indexeddb.ObjectStoreSchema{
 var ManagedIdentityMembershipsSchema = indexeddb.ObjectStoreSchema{
 	Indexes: []indexeddb.IndexSchema{
 		{Name: "by_identity", KeyPath: []string{"identity_id"}},
-		{Name: "by_user", KeyPath: []string{"user_id"}},
-		{Name: "by_identity_user", KeyPath: []string{"identity_id", "user_id"}, Unique: true},
+		{Name: "by_subject", KeyPath: []string{"subject_id"}},
+		{Name: "by_identity_subject", KeyPath: []string{"identity_id", "subject_id"}, Unique: true},
 	},
 	Columns: []indexeddb.ColumnDef{
 		{Name: "id", Type: indexeddb.TypeString, PrimaryKey: true},
 		{Name: "identity_id", Type: indexeddb.TypeString, NotNull: true},
-		{Name: "user_id", Type: indexeddb.TypeString, NotNull: true},
+		{Name: "subject_id", Type: indexeddb.TypeString, NotNull: true},
 		{Name: "email", Type: indexeddb.TypeString, NotNull: true},
 		{Name: "role", Type: indexeddb.TypeString, NotNull: true},
 		{Name: "created_at", Type: indexeddb.TypeTime},

--- a/gestaltd/internal/server/handlers_identities.go
+++ b/gestaltd/internal/server/handlers_identities.go
@@ -44,7 +44,7 @@ type managedIdentityInfo struct {
 }
 
 type managedIdentityMemberInfo struct {
-	UserID    string    `json:"userId"`
+	SubjectID string    `json:"subjectId"`
 	Email     string    `json:"email"`
 	Role      string    `json:"role"`
 	CreatedAt time.Time `json:"createdAt"`
@@ -77,17 +77,18 @@ type putManagedIdentityGrantRequest struct {
 
 type managedIdentityActor struct {
 	UserID     string
+	SubjectID  string
 	Identity   *core.ManagedIdentity
 	Membership *core.ManagedIdentityMembership
 }
 
 func (s *Server) listManagedIdentities(w http.ResponseWriter, r *http.Request) {
-	userID, _, ok := s.resolveManagedIdentityUser(w, r)
+	_, subjectID, _, ok := s.resolveManagedIdentityUser(w, r)
 	if !ok {
 		return
 	}
 
-	memberships, err := s.identityMemberships.ListMembershipsByUser(r.Context(), userID)
+	memberships, err := s.identityMemberships.ListMembershipsBySubject(r.Context(), subjectID)
 	if err != nil {
 		writeError(w, http.StatusInternalServerError, "failed to list identities")
 		return
@@ -134,7 +135,7 @@ func (s *Server) createManagedIdentity(w http.ResponseWriter, r *http.Request) {
 		s.auditHTTPEventWithTarget(r.Context(), PrincipalFromContext(r.Context()), "", "identity.create", auditAllowed, auditErr, auditTarget)
 	}()
 
-	userID, user, ok := s.resolveManagedIdentityUser(w, r)
+	userID, subjectID, user, ok := s.resolveManagedIdentityUser(w, r)
 	if !ok {
 		return
 	}
@@ -170,7 +171,7 @@ func (s *Server) createManagedIdentity(w http.ResponseWriter, r *http.Request) {
 	}
 	membership, err := s.identityMemberships.UpsertMembership(r.Context(), &core.ManagedIdentityMembership{
 		IdentityID: identity.ID,
-		UserID:     userID,
+		SubjectID:  subjectID,
 		Email:      user.Email,
 		Role:       managedIdentityRoleAdmin,
 	})
@@ -178,7 +179,7 @@ func (s *Server) createManagedIdentity(w http.ResponseWriter, r *http.Request) {
 		membership = &core.ManagedIdentityMembership{
 			ID:         uuid.NewString(),
 			IdentityID: identity.ID,
-			UserID:     userID,
+			SubjectID:  subjectID,
 			Email:      user.Email,
 			Role:       managedIdentityRoleAdmin,
 			CreatedAt:  now,
@@ -385,14 +386,14 @@ func (s *Server) deleteManagedIdentity(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	if err := s.deleteManagedIdentityChildren(r.Context(), snapshot, actor.UserID); err != nil {
+	if err := s.deleteManagedIdentityChildren(r.Context(), snapshot, actor.SubjectID); err != nil {
 		auditErr = fmt.Errorf("failed to delete identity children: %w", err)
 		writeError(w, http.StatusInternalServerError, "failed to delete identity")
 		return
 	}
 
 	if err := s.managedIdentities.DeleteIdentity(r.Context(), actor.Identity.ID); err != nil {
-		if restoreErr := s.restoreManagedIdentityChildren(r.Context(), snapshot, actor.UserID); restoreErr != nil {
+		if restoreErr := s.restoreManagedIdentityChildren(r.Context(), snapshot, actor.SubjectID); restoreErr != nil {
 			auditErr = fmt.Errorf("failed to delete identity and restore children: %w", restoreErr)
 			writeError(w, http.StatusInternalServerError, "failed to delete identity")
 			return
@@ -432,7 +433,7 @@ func (s *Server) listManagedIdentityMembers(w http.ResponseWriter, r *http.Reque
 	out := make([]managedIdentityMemberInfo, 0, len(memberships))
 	for _, membership := range memberships {
 		out = append(out, managedIdentityMemberInfo{
-			UserID:    membership.UserID,
+			SubjectID: membership.SubjectID,
 			Email:     membership.Email,
 			Role:      membership.Role,
 			CreatedAt: membership.CreatedAt,
@@ -446,7 +447,7 @@ func (s *Server) listManagedIdentityMembers(w http.ResponseWriter, r *http.Reque
 		if out[i].Email != out[j].Email {
 			return out[i].Email < out[j].Email
 		}
-		return out[i].UserID < out[j].UserID
+		return out[i].SubjectID < out[j].SubjectID
 	})
 
 	writeJSON(w, http.StatusOK, out)
@@ -493,22 +494,23 @@ func (s *Server) putManagedIdentityMember(w http.ResponseWriter, r *http.Request
 		writeError(w, http.StatusInternalServerError, "failed to resolve user")
 		return
 	}
+	subjectID := principal.UserSubjectID(user.ID)
 
-	existing, err := s.identityMemberships.GetMembership(r.Context(), actor.Identity.ID, user.ID)
+	existing, err := s.identityMemberships.GetMembership(r.Context(), actor.Identity.ID, subjectID)
 	if err != nil && !errors.Is(err, core.ErrNotFound) {
 		auditErr = errors.New("failed to resolve existing membership")
 		writeError(w, http.StatusInternalServerError, "failed to resolve existing membership")
 		return
 	}
 	if existing != nil && existing.Role == managedIdentityRoleAdmin && role != managedIdentityRoleAdmin {
-		if !s.ensureManagedIdentityHasAnotherAdmin(w, r, actor.Identity.ID, user.ID) {
+		if !s.ensureManagedIdentityHasAnotherAdmin(w, r, actor.Identity.ID, subjectID) {
 			return
 		}
 	}
 
 	membership, err := s.identityMemberships.UpsertMembership(r.Context(), &core.ManagedIdentityMembership{
 		IdentityID: actor.Identity.ID,
-		UserID:     user.ID,
+		SubjectID:  subjectID,
 		Email:      user.Email,
 		Role:       role,
 	})
@@ -522,7 +524,7 @@ func (s *Server) putManagedIdentityMember(w http.ResponseWriter, r *http.Request
 	auditTarget = managedIdentityMemberAuditTarget(actor.Identity.ID, membership.Email)
 
 	writeJSON(w, http.StatusOK, managedIdentityMemberInfo{
-		UserID:    membership.UserID,
+		SubjectID: membership.SubjectID,
 		Email:     membership.Email,
 		Role:      membership.Role,
 		CreatedAt: membership.CreatedAt,
@@ -571,8 +573,9 @@ func (s *Server) deleteManagedIdentityMember(w http.ResponseWriter, r *http.Requ
 		writeError(w, http.StatusInternalServerError, "failed to resolve identity member")
 		return
 	}
+	subjectID := principal.UserSubjectID(user.ID)
 
-	membership, err := s.identityMemberships.GetMembership(r.Context(), actor.Identity.ID, user.ID)
+	membership, err := s.identityMemberships.GetMembership(r.Context(), actor.Identity.ID, subjectID)
 	if err != nil {
 		if errors.Is(err, core.ErrNotFound) {
 			auditErr = errors.New("identity member not found")
@@ -583,10 +586,10 @@ func (s *Server) deleteManagedIdentityMember(w http.ResponseWriter, r *http.Requ
 		writeError(w, http.StatusInternalServerError, "failed to resolve identity member")
 		return
 	}
-	if membership.Role == managedIdentityRoleAdmin && !s.ensureManagedIdentityHasAnotherAdmin(w, r, actor.Identity.ID, membership.UserID) {
+	if membership.Role == managedIdentityRoleAdmin && !s.ensureManagedIdentityHasAnotherAdmin(w, r, actor.Identity.ID, membership.SubjectID) {
 		return
 	}
-	if err := s.identityMemberships.DeleteMembership(r.Context(), actor.Identity.ID, membership.UserID); err != nil {
+	if err := s.identityMemberships.DeleteMembership(r.Context(), actor.Identity.ID, membership.SubjectID); err != nil {
 		auditErr = errors.New("failed to delete identity member")
 		writeError(w, http.StatusInternalServerError, "failed to delete identity member")
 		return
@@ -762,24 +765,24 @@ func (s *Server) deleteManagedIdentityGrant(w http.ResponseWriter, r *http.Reque
 	writeJSON(w, http.StatusOK, map[string]string{"status": "deleted"})
 }
 
-func (s *Server) resolveManagedIdentityUser(w http.ResponseWriter, r *http.Request) (string, *core.User, bool) {
+func (s *Server) resolveManagedIdentityUser(w http.ResponseWriter, r *http.Request) (string, string, *core.User, bool) {
 	if !s.ensureManagedIdentityRoutesAvailable(w) {
-		return "", nil, false
+		return "", "", nil, false
 	}
 	userID, err := s.resolveUserID(w, r)
 	if err != nil {
-		return "", nil, false
+		return "", "", nil, false
 	}
 	user, err := s.users.GetUser(r.Context(), userID)
 	if err != nil {
 		writeError(w, http.StatusInternalServerError, "failed to resolve user")
-		return "", nil, false
+		return "", "", nil, false
 	}
-	return userID, user, true
+	return userID, principal.UserSubjectID(userID), user, true
 }
 
 func (s *Server) resolveManagedIdentityActor(w http.ResponseWriter, r *http.Request, requiredRole string) (*managedIdentityActor, bool) {
-	userID, _, ok := s.resolveManagedIdentityUser(w, r)
+	userID, subjectID, _, ok := s.resolveManagedIdentityUser(w, r)
 	if !ok {
 		return nil, false
 	}
@@ -798,7 +801,7 @@ func (s *Server) resolveManagedIdentityActor(w http.ResponseWriter, r *http.Requ
 		writeError(w, http.StatusInternalServerError, "failed to resolve identity")
 		return nil, false
 	}
-	membership, err := s.identityMemberships.GetMembership(r.Context(), identityID, userID)
+	membership, err := s.identityMemberships.GetMembership(r.Context(), identityID, subjectID)
 	if err != nil {
 		if errors.Is(err, core.ErrNotFound) {
 			writeError(w, http.StatusNotFound, "identity not found")
@@ -813,6 +816,7 @@ func (s *Server) resolveManagedIdentityActor(w http.ResponseWriter, r *http.Requ
 	}
 	return &managedIdentityActor{
 		UserID:     userID,
+		SubjectID:  subjectID,
 		Identity:   identity,
 		Membership: membership,
 	}, true
@@ -830,14 +834,14 @@ func (s *Server) ensureManagedIdentityRoutesAvailable(w http.ResponseWriter) boo
 	return true
 }
 
-func (s *Server) ensureManagedIdentityHasAnotherAdmin(w http.ResponseWriter, r *http.Request, identityID, excludedUserID string) bool {
+func (s *Server) ensureManagedIdentityHasAnotherAdmin(w http.ResponseWriter, r *http.Request, identityID, excludedSubjectID string) bool {
 	memberships, err := s.identityMemberships.ListMembershipsByIdentity(r.Context(), identityID)
 	if err != nil {
 		writeError(w, http.StatusInternalServerError, "failed to resolve identity admins")
 		return false
 	}
 	for _, membership := range memberships {
-		if membership.UserID == excludedUserID {
+		if membership.SubjectID == excludedSubjectID {
 			continue
 		}
 		if membership.Role == managedIdentityRoleAdmin {
@@ -868,12 +872,12 @@ func (s *Server) loadManagedIdentityDeleteSnapshot(ctx context.Context, identity
 	}, nil
 }
 
-func (s *Server) deleteManagedIdentityChildren(ctx context.Context, snapshot *managedIdentityDeleteSnapshot, actorUserID string) error {
+func (s *Server) deleteManagedIdentityChildren(ctx context.Context, snapshot *managedIdentityDeleteSnapshot, actorSubjectID string) error {
 	deleted := &managedIdentityDeleteSnapshot{}
 
 	for _, grant := range snapshot.Grants {
 		if err := s.identityGrants.DeleteGrant(ctx, grant.IdentityID, grant.Plugin); err != nil {
-			if restoreErr := s.restoreManagedIdentityChildren(ctx, deleted, actorUserID); restoreErr != nil {
+			if restoreErr := s.restoreManagedIdentityChildren(ctx, deleted, actorSubjectID); restoreErr != nil {
 				return fmt.Errorf("delete managed identity grant: %w (restore deleted children: %v)", err, restoreErr)
 			}
 			return err
@@ -881,9 +885,9 @@ func (s *Server) deleteManagedIdentityChildren(ctx context.Context, snapshot *ma
 		deleted.Grants = append(deleted.Grants, cloneManagedIdentityGrant(grant))
 	}
 
-	for _, membership := range managedIdentityDeleteMembershipOrder(snapshot.Memberships, actorUserID) {
-		if err := s.identityMemberships.DeleteMembership(ctx, membership.IdentityID, membership.UserID); err != nil {
-			if restoreErr := s.restoreManagedIdentityChildren(ctx, deleted, actorUserID); restoreErr != nil {
+	for _, membership := range managedIdentityDeleteMembershipOrder(snapshot.Memberships, actorSubjectID) {
+		if err := s.identityMemberships.DeleteMembership(ctx, membership.IdentityID, membership.SubjectID); err != nil {
+			if restoreErr := s.restoreManagedIdentityChildren(ctx, deleted, actorSubjectID); restoreErr != nil {
 				return fmt.Errorf("delete managed identity membership: %w (restore deleted children: %v)", err, restoreErr)
 			}
 			return err
@@ -894,11 +898,11 @@ func (s *Server) deleteManagedIdentityChildren(ctx context.Context, snapshot *ma
 	return nil
 }
 
-func (s *Server) restoreManagedIdentityChildren(ctx context.Context, snapshot *managedIdentityDeleteSnapshot, actorUserID string) error {
+func (s *Server) restoreManagedIdentityChildren(ctx context.Context, snapshot *managedIdentityDeleteSnapshot, actorSubjectID string) error {
 	if snapshot == nil {
 		return nil
 	}
-	failedMemberships := s.restoreManagedIdentityMemberships(ctx, managedIdentityRestoreMembershipOrder(snapshot.Memberships, actorUserID))
+	failedMemberships := s.restoreManagedIdentityMemberships(ctx, managedIdentityRestoreMembershipOrder(snapshot.Memberships, actorSubjectID))
 	if len(failedMemberships) > 0 {
 		failedMemberships = s.restoreManagedIdentityMemberships(ctx, failedMemberships)
 	}
@@ -909,7 +913,7 @@ func (s *Server) restoreManagedIdentityChildren(ctx context.Context, snapshot *m
 
 	var restoreErr error
 	for _, membership := range failedMemberships {
-		restoreErr = errors.Join(restoreErr, fmt.Errorf("restore managed identity membership %s: failed after retry", membership.UserID))
+		restoreErr = errors.Join(restoreErr, fmt.Errorf("restore managed identity membership %s: failed after retry", membership.SubjectID))
 	}
 	for _, grant := range failedGrants {
 		restoreErr = errors.Join(restoreErr, fmt.Errorf("restore managed identity grant %s: failed after retry", grant.Plugin))
@@ -917,36 +921,36 @@ func (s *Server) restoreManagedIdentityChildren(ctx context.Context, snapshot *m
 	return restoreErr
 }
 
-func managedIdentityDeleteMembershipOrder(memberships []*core.ManagedIdentityMembership, actorUserID string) []*core.ManagedIdentityMembership {
+func managedIdentityDeleteMembershipOrder(memberships []*core.ManagedIdentityMembership, actorSubjectID string) []*core.ManagedIdentityMembership {
 	if len(memberships) == 0 {
 		return nil
 	}
 	ordered := cloneManagedIdentityMemberships(memberships)
 	sort.SliceStable(ordered, func(i, j int) bool {
-		if ordered[i].UserID == actorUserID {
+		if ordered[i].SubjectID == actorSubjectID {
 			return false
 		}
-		if ordered[j].UserID == actorUserID {
+		if ordered[j].SubjectID == actorSubjectID {
 			return true
 		}
-		return ordered[i].UserID < ordered[j].UserID
+		return ordered[i].SubjectID < ordered[j].SubjectID
 	})
 	return ordered
 }
 
-func managedIdentityRestoreMembershipOrder(memberships []*core.ManagedIdentityMembership, actorUserID string) []*core.ManagedIdentityMembership {
+func managedIdentityRestoreMembershipOrder(memberships []*core.ManagedIdentityMembership, actorSubjectID string) []*core.ManagedIdentityMembership {
 	if len(memberships) == 0 {
 		return nil
 	}
 	ordered := cloneManagedIdentityMemberships(memberships)
 	sort.SliceStable(ordered, func(i, j int) bool {
-		if ordered[i].UserID == actorUserID {
+		if ordered[i].SubjectID == actorSubjectID {
 			return true
 		}
-		if ordered[j].UserID == actorUserID {
+		if ordered[j].SubjectID == actorSubjectID {
 			return false
 		}
-		return ordered[i].UserID < ordered[j].UserID
+		return ordered[i].SubjectID < ordered[j].SubjectID
 	})
 	return ordered
 }

--- a/gestaltd/internal/server/server_test.go
+++ b/gestaltd/internal/server/server_test.go
@@ -644,7 +644,7 @@ func newTestServicesWithManagedIdentityMembershipDeleteFailure(t *testing.T, fai
 	svc, err := coredata.New(&deleteFailingIndexedDB{
 		IndexedDB: &coretesting.StubIndexedDB{},
 		failIndexDeletes: map[string]*deleteFailureRule{
-			coredata.StoreManagedIdentityMemberships + "/by_identity_user": failDelete,
+			coredata.StoreManagedIdentityMemberships + "/by_identity_subject": failDelete,
 		},
 	}, key)
 	if err != nil {
@@ -15607,13 +15607,31 @@ func TestManagedIdentityCRUDAndMemberships(t *testing.T) {
 	}
 
 	memberResp := struct {
-		UserID string `json:"userId"`
-		Email  string `json:"email"`
-		Role   string `json:"role"`
+		SubjectID string `json:"subjectId"`
+		Email     string `json:"email"`
+		Role      string `json:"role"`
 	}{}
 	doJSONRequestAndDecode(t, http.MethodPut, ts.URL+"/api/v1/identities/"+createResp.ID+"/members", "admin-session", `{"email":"viewer@example.test","role":"viewer"}`, http.StatusOK, &memberResp)
 	if memberResp.Role != "viewer" || memberResp.Email != "viewer@example.test" {
 		t.Fatalf("member response = %+v, want viewer@example.test viewer", memberResp)
+	}
+	if memberResp.SubjectID != principal.UserSubjectID(viewer.ID) {
+		t.Fatalf("member subjectId = %q, want %q", memberResp.SubjectID, principal.UserSubjectID(viewer.ID))
+	}
+	var membersResp []struct {
+		SubjectID string `json:"subjectId"`
+		Email     string `json:"email"`
+		Role      string `json:"role"`
+	}
+	doJSONRequestAndDecode(t, http.MethodGet, ts.URL+"/api/v1/identities/"+createResp.ID+"/members", "admin-session", "", http.StatusOK, &membersResp)
+	if len(membersResp) != 2 {
+		t.Fatalf("members response = %+v, want admin and viewer", membersResp)
+	}
+	if membersResp[0].SubjectID != principal.UserSubjectID(admin.ID) || membersResp[0].Role != "admin" {
+		t.Fatalf("first member = %+v, want admin row", membersResp[0])
+	}
+	if membersResp[1].SubjectID != principal.UserSubjectID(viewer.ID) || membersResp[1].Role != "viewer" {
+		t.Fatalf("second member = %+v, want viewer row", membersResp[1])
 	}
 	viewerGrant, err := svc.IdentityManagementGrants.GetGrant(ctx, viewer.ID, createResp.ID)
 	if err != nil {
@@ -16043,7 +16061,7 @@ func TestManagedIdentityGrantsRespectActorAuthorization(t *testing.T) {
 		}
 		if _, err := svc.IdentityMemberships.UpsertMembership(context.Background(), &core.ManagedIdentityMembership{
 			IdentityID: createResp.ID,
-			UserID:     viewer.ID,
+			SubjectID:  principal.UserSubjectID(viewer.ID),
 			Email:      viewer.Email,
 			Role:       "viewer",
 		}); err != nil {
@@ -16909,7 +16927,7 @@ func TestManagedIdentityDeleteFailuresPreserveRetryPath(t *testing.T) {
 		}
 		originalViewerMembership, err := svc.IdentityMemberships.UpsertMembership(context.Background(), &core.ManagedIdentityMembership{
 			IdentityID: createResp.ID,
-			UserID:     viewer.ID,
+			SubjectID:  principal.UserSubjectID(viewer.ID),
 			Email:      viewer.Email,
 			Role:       "viewer",
 		})
@@ -16954,10 +16972,10 @@ func TestManagedIdentityDeleteFailuresPreserveRetryPath(t *testing.T) {
 		if len(memberships) != 2 {
 			t.Fatalf("membership count = %d, want 2", len(memberships))
 		}
-		if _, err := svc.IdentityMemberships.GetMembership(context.Background(), createResp.ID, admin.ID); err != nil {
+		if _, err := svc.IdentityMemberships.GetMembership(context.Background(), createResp.ID, principal.UserSubjectID(admin.ID)); err != nil {
 			t.Fatalf("GetMembership admin: %v", err)
 		}
-		restoredViewerMembership, err := svc.IdentityMemberships.GetMembership(context.Background(), createResp.ID, viewer.ID)
+		restoredViewerMembership, err := svc.IdentityMemberships.GetMembership(context.Background(), createResp.ID, principal.UserSubjectID(viewer.ID))
 		if err != nil {
 			t.Fatalf("GetMembership viewer: %v", err)
 		}
@@ -16988,7 +17006,7 @@ func TestManagedIdentityDeleteFailuresPreserveRetryPath(t *testing.T) {
 		}
 		originalViewerMembership, err := svc.IdentityMemberships.UpsertMembership(context.Background(), &core.ManagedIdentityMembership{
 			IdentityID: createResp.ID,
-			UserID:     viewer.ID,
+			SubjectID:  principal.UserSubjectID(viewer.ID),
 			Email:      viewer.Email,
 			Role:       "viewer",
 		})
@@ -17033,10 +17051,10 @@ func TestManagedIdentityDeleteFailuresPreserveRetryPath(t *testing.T) {
 		if len(memberships) != 2 {
 			t.Fatalf("membership count after failed parent delete = %d, want 2", len(memberships))
 		}
-		if _, err := svc.IdentityMemberships.GetMembership(context.Background(), createResp.ID, admin.ID); err != nil {
+		if _, err := svc.IdentityMemberships.GetMembership(context.Background(), createResp.ID, principal.UserSubjectID(admin.ID)); err != nil {
 			t.Fatalf("GetMembership admin: %v", err)
 		}
-		restoredViewerMembership, err := svc.IdentityMemberships.GetMembership(context.Background(), createResp.ID, viewer.ID)
+		restoredViewerMembership, err := svc.IdentityMemberships.GetMembership(context.Background(), createResp.ID, principal.UserSubjectID(viewer.ID))
 		if err != nil {
 			t.Fatalf("GetMembership viewer: %v", err)
 		}
@@ -17069,7 +17087,7 @@ func TestManagedIdentityDeleteFailuresPreserveRetryPath(t *testing.T) {
 		}
 		if _, err := svc.IdentityMemberships.UpsertMembership(context.Background(), &core.ManagedIdentityMembership{
 			IdentityID: createResp.ID,
-			UserID:     viewer.ID,
+			SubjectID:  principal.UserSubjectID(viewer.ID),
 			Email:      viewer.Email,
 			Role:       "viewer",
 		}); err != nil {
@@ -17107,7 +17125,7 @@ func TestManagedIdentityDeleteFailuresPreserveRetryPath(t *testing.T) {
 		if len(memberships) != 2 {
 			t.Fatalf("membership count after restore retry = %d, want 2", len(memberships))
 		}
-		if _, err := svc.IdentityMemberships.GetMembership(context.Background(), createResp.ID, viewer.ID); err != nil {
+		if _, err := svc.IdentityMemberships.GetMembership(context.Background(), createResp.ID, principal.UserSubjectID(viewer.ID)); err != nil {
 			t.Fatalf("GetMembership viewer after restore retry: %v", err)
 		}
 	})
@@ -17861,7 +17879,7 @@ func TestDeleteManagedIdentityMemberDecodesEscapedEmailPath(t *testing.T) {
 	if err != nil {
 		t.Fatalf("ListMembershipsByIdentity: %v", err)
 	}
-	if len(members) != 1 || members[0].UserID == member.ID {
+	if len(members) != 1 || members[0].SubjectID == principal.UserSubjectID(member.ID) {
 		t.Fatalf("members after delete = %+v, expected only the admin membership to remain", members)
 	}
 }


### PR DESCRIPTION
## Summary
- migrate managed-identity membership storage and internal matching from raw `user_id` to canonical user `subjectId`
- keep managed-identity membership writes email-friendly while returning canonical `subjectId` in responses
- update the CLI member table output to render `subjectId` instead of the removed `userId` field
- fold the new behavior into the existing managed-identity server and CLI coverage instead of adding redundant standalone tests

## New Interfaces
### HTTP response
Before:
```json
{
  "userId": "usr_123",
  "email": "viewer@example.test",
  "role": "viewer"
}
```

After:
```json
{
  "subjectId": "user:usr_123",
  "email": "viewer@example.test",
  "role": "viewer"
}
```

### HTTP write
Unchanged request shape, still email-friendly:
```http
PUT /api/v1/identities/{identityID}/members
Content-Type: application/json

{"email":"viewer@example.test","role":"viewer"}
```

Server-side persistence now resolves that email to the canonical subject `user:<user_id>` before storing membership state.

### HTTP delete
Still email-based externally:
```http
DELETE /api/v1/identities/{identityID}/members/viewer%40example.test
```

The server resolves the email alias to the canonical `subjectId` before deleting membership state.

### CLI table output
Before:
```text
User ID      Email                Role
usr_123      viewer@example.test  viewer
```

After:
```text
Subject ID       Email                Role
user:usr_123     viewer@example.test  viewer
```

### Go interface
Before:
```go
type ManagedIdentityMembership struct {
    ID         string
    IdentityID string
    UserID     string
    Email      string
    Role       string
    CreatedAt  time.Time
    UpdatedAt  time.Time
}
```

After:
```go
type ManagedIdentityMembership struct {
    ID         string
    IdentityID string
    SubjectID  string
    Email      string
    Role       string
    CreatedAt  time.Time
    UpdatedAt  time.Time
}
```

Service signatures now key on `subjectID`:
```go
GetMembership(ctx, identityID, subjectID)
DeleteMembership(ctx, identityID, subjectID)
ListMembershipsBySubject(ctx, subjectID)
```

## Migration
Prod CloudSQL needs the membership table migrated before rollout because the relational IndexedDB provider does not rewrite existing tables in place.

MySQL / Cloud SQL sequence:
```sql
ALTER TABLE managed_identity_memberships
  ADD COLUMN subject_id VARCHAR(255) NULL AFTER identity_id;

UPDATE managed_identity_memberships
SET subject_id = CONCAT('user:', user_id)
WHERE subject_id IS NULL AND user_id IS NOT NULL;

CREATE INDEX idx_managed_identity_memberships_by_subject
  ON managed_identity_memberships (subject_id);

CREATE UNIQUE INDEX idx_managed_identity_memberships_by_identity_subject
  ON managed_identity_memberships (identity_id, subject_id);

SELECT identity_id, subject_id, COUNT(*) AS n
FROM managed_identity_memberships
GROUP BY identity_id, subject_id
HAVING n > 1;

DROP INDEX idx_managed_identity_memberships_by_user
  ON managed_identity_memberships;
DROP INDEX idx_managed_identity_memberships_by_identity_user
  ON managed_identity_memberships;

ALTER TABLE managed_identity_memberships
  MODIFY subject_id VARCHAR(255) NOT NULL;

ALTER TABLE managed_identity_memberships
  DROP COLUMN user_id;
```

## Verification
```bash
cd gestaltd

go test ./internal/server

golangci-lint run ./internal/server ./internal/coredata

cd ../gestalt
cargo test -p gestalt test_cli_lists_identities
cargo test -p gestalt test_cli_adds_identity_member
```
