### PR TITLE
audit: emit subject-first audit records and telemetry attrs

### DIFF
--- a/docs/content/audit-logging.mdx
+++ b/docs/content/audit-logging.mdx
@@ -10,7 +10,7 @@ backend without having to reconstruct behavior from mixed application logs.
 
 Audit events cover HTTP and MCP operation invocations, other guarded runtime surfaces such as binding hooks, failed auth on protected routes, HTTP authorization denials rejected before `GuardedInvoker` runs, login and logout flows, plugin connect and disconnect flows, and API token inventory and lifecycle events. Each event carries a `source` field (`http`, `mcp`, or a surface-specific value like `binding:...`) so consumers can filter by surface.
 
-`gestaltd` resolves the authenticated user ID before emitting session-backed audit events, so both session requests and API-token requests produce stable `user_id` values when a user identity exists.
+`gestaltd` resolves the authenticated canonical subject before emitting user-backed audit events, so both session requests and API-token requests produce stable `subject_id` values such as `user:usr_123`. Emitted audit records do not include a separate `user_id` field.
 
 ## Fields
 
@@ -32,7 +32,8 @@ These fields are emitted when available:
 | Field | Meaning |
 | --- | --- |
 | `auth_source` | Authentication mechanism for the caller: `session`, `api_token`, `workload_token`, or `env` |
-| `user_id` | Stable internal user ID |
+| `subject_id` | Canonical caller subject such as `user:<id>` or `workload:<id>` |
+| `subject_kind` | Canonical subject type, such as `user` or `workload` |
 | `target_kind` | Generic kind for the object the event acted on, such as `api_token` or `connection` |
 | `target_id` | Stable identifier for the affected object when one exists |
 | `target_name` | Human-readable label for the affected object |
@@ -111,7 +112,8 @@ definitions.
   "request_id": "2a7c1d7f-2b25-4b7a-8ae8-02f4d8f6f2b2",
   "source": "mcp",
   "auth_source": "api_token",
-  "user_id": "usr_123",
+  "subject_id": "user:usr_123",
+  "subject_kind": "user",
   "provider": "github",
   "operation": "issues_list",
   "depth": 0,
@@ -132,7 +134,7 @@ With the default `providers.audit.default.source: inherit`, you can still split 
 ## Metrics Notes
 
 Audit logs are a good source for invocation-based activity metrics. In
-particular, `source`, `auth_source`, `user_id`, `provider`, `operation`, and
+particular, `source`, `auth_source`, `subject_id`, `provider`, `operation`, and
 `allowed` are enough to derive distinct-user activity over guarded invocations.
 
-For DAU, WAU, or MAU built from tool usage, filter to successful top-level invocations where `allowed = true`, `depth = 0`, and `user_id` is non-empty. That produces a clean “users who actually invoked a tool” metric. If you need a broader product-activity definition, treat the non-invocation audit events as a separate metric family rather than mixing them into invocation counts.
+For DAU, WAU, or MAU built from tool usage, filter to successful top-level invocations where `allowed = true`, `depth = 0`, and `subject_id` is non-empty. That produces a clean “subjects who actually invoked a tool” metric. If you need a broader product-activity definition, treat the non-invocation audit events as a separate metric family rather than mixing them into invocation counts.

--- a/docs/content/reference/config-file.mdx
+++ b/docs/content/reference/config-file.mdx
@@ -688,7 +688,7 @@ Disables all telemetry. Instrumentation points remain but produce zero overhead.
 | Layer | Span name | Key attributes |
 | --- | --- | --- |
 | HTTP | `gestaltd: {method} {route}` | Standard HTTP semantic conventions |
-| Broker | `broker.invoke` | `gestalt.provider`, `gestalt.operation`, `gestalt.userId`, `gestalt.connectionMode` |
+| Broker | `broker.invoke` | `gestalt.provider`, `gestalt.operation`, `gestalt.subject_id`, `gestalt.connection_mode` |
 | gRPC plugin | Per-RPC spans | Standard gRPC semantic conventions |
 
 ## `providers.audit`

--- a/gestaltd/internal/invocation/audit.go
+++ b/gestaltd/internal/invocation/audit.go
@@ -5,6 +5,7 @@ import (
 	"io"
 	"log/slog"
 	"os"
+	"strings"
 	"time"
 
 	"github.com/valon-technologies/gestalt/server/core"
@@ -47,6 +48,7 @@ func newLoggerAuditSink(logger *slog.Logger, respectLevel bool) *SlogAuditSink {
 }
 
 func buildAuditEntry(ctx context.Context, p *principal.Principal, source, providerName, operation string, meta *InvocationMeta) core.AuditEntry {
+	p = principal.Canonicalized(p)
 	reqMeta := RequestMetaFromContext(ctx)
 	entry := core.AuditEntry{
 		Timestamp:  time.Now(),
@@ -107,6 +109,11 @@ func SetCredentialAudit(ctx context.Context, mode core.ConnectionMode, subjectID
 }
 
 func (s *SlogAuditSink) Log(ctx context.Context, entry core.AuditEntry) {
+	auditPrincipal := principal.Canonicalized(&principal.Principal{
+		UserID:    strings.TrimSpace(entry.UserID),
+		SubjectID: strings.TrimSpace(entry.SubjectID),
+		Kind:      principal.Kind(strings.TrimSpace(entry.SubjectKind)),
+	})
 	attrs := []slog.Attr{
 		slog.String("log.type", auditLogType),
 		slog.Time("event_time", entry.Timestamp),
@@ -121,14 +128,11 @@ func (s *SlogAuditSink) Log(ctx context.Context, entry core.AuditEntry) {
 	if entry.AuthSource != "" {
 		attrs = append(attrs, slog.String("auth_source", entry.AuthSource))
 	}
-	if entry.UserID != "" {
-		attrs = append(attrs, slog.String("user_id", entry.UserID))
+	if auditPrincipal.SubjectID != "" {
+		attrs = append(attrs, slog.String("subject_id", auditPrincipal.SubjectID))
 	}
-	if entry.SubjectID != "" {
-		attrs = append(attrs, slog.String("subject_id", entry.SubjectID))
-	}
-	if entry.SubjectKind != "" {
-		attrs = append(attrs, slog.String("subject_kind", entry.SubjectKind))
+	if auditPrincipal.Kind != "" {
+		attrs = append(attrs, slog.String("subject_kind", string(auditPrincipal.Kind)))
 	}
 	if entry.AccessPolicy != "" {
 		attrs = append(attrs, slog.String("access_policy", entry.AccessPolicy))

--- a/gestaltd/internal/invocation/audit_test.go
+++ b/gestaltd/internal/invocation/audit_test.go
@@ -12,6 +12,7 @@ import (
 
 	"github.com/valon-technologies/gestalt/server/core"
 	"github.com/valon-technologies/gestalt/server/internal/invocation"
+	"github.com/valon-technologies/gestalt/server/internal/principal"
 	"go.opentelemetry.io/otel/trace"
 )
 
@@ -59,8 +60,14 @@ func TestSlogAuditSink_AllowedEntry(t *testing.T) {
 	if record["source"] != "binding:test-hook" {
 		t.Errorf("expected source=binding:test-hook, got %v", record["source"])
 	}
-	if record["user_id"] != "user-42" {
-		t.Errorf("expected user_id=user-42, got %v", record["user_id"])
+	if record["subject_id"] != principal.UserSubjectID("user-42") {
+		t.Errorf("expected subject_id=%q, got %v", principal.UserSubjectID("user-42"), record["subject_id"])
+	}
+	if record["subject_kind"] != string(principal.KindUser) {
+		t.Errorf("expected subject_kind=%q, got %v", principal.KindUser, record["subject_kind"])
+	}
+	if _, has := record["user_id"]; has {
+		t.Errorf("expected emitted audit record to omit user_id, got %v", record["user_id"])
 	}
 	if record["provider"] != "alpha" {
 		t.Errorf("expected provider=alpha, got %v", record["provider"])
@@ -137,7 +144,7 @@ func TestSlogAuditSink_WithSpanContext(t *testing.T) {
 		Timestamp: time.Now(),
 		RequestID: "req-trace-789",
 		Source:    "binding:traced",
-		UserID:    "user-1",
+		SubjectID: principal.UserSubjectID("user-1"),
 		Provider:  "gamma",
 		Operation: "read",
 		Depth:     0,
@@ -175,7 +182,7 @@ func TestSlogAuditSink_NoTraceContext(t *testing.T) {
 		Timestamp: time.Now(),
 		RequestID: "req-no-trace",
 		Source:    "binding:test-hook",
-		UserID:    "user-1",
+		SubjectID: principal.UserSubjectID("user-1"),
 		Provider:  "delta",
 		Operation: "read",
 		Depth:     0,
@@ -217,7 +224,7 @@ func TestSlogAuditSink_GuaranteedDelivery(t *testing.T) {
 			Timestamp: time.Now(),
 			RequestID: "req-allowed",
 			Source:    "binding:test-hook",
-			UserID:    "user-1",
+			SubjectID: principal.UserSubjectID("user-1"),
 			Provider:  "epsilon",
 			Operation: "read",
 			Allowed:   true,
@@ -226,7 +233,7 @@ func TestSlogAuditSink_GuaranteedDelivery(t *testing.T) {
 			Timestamp: time.Now(),
 			RequestID: "req-denied",
 			Source:    "binding:test-hook",
-			UserID:    "user-2",
+			SubjectID: principal.UserSubjectID("user-2"),
 			Provider:  "zeta",
 			Operation: "write",
 			Allowed:   false,
@@ -280,7 +287,7 @@ func TestSlogAuditSink_NilWriterFallsBackToStderr(t *testing.T) { //nolint:paral
 		Timestamp: time.Now(),
 		RequestID: "req-stderr",
 		Source:    "binding:test-hook",
-		UserID:    "user-stderr",
+		SubjectID: principal.UserSubjectID("user-stderr"),
 		Provider:  "theta",
 		Operation: "read",
 		Allowed:   true,

--- a/gestaltd/internal/invocation/broker.go
+++ b/gestaltd/internal/invocation/broker.go
@@ -34,7 +34,7 @@ const (
 	attrProvider       = attribute.Key("gestalt.provider")
 	attrOperation      = attribute.Key("gestalt.operation")
 	attrTransport      = attribute.Key("gestalt.transport")
-	attrUserID         = attribute.Key("gestalt.user_id")
+	attrSubjectID      = attribute.Key("gestalt.subject_id")
 	attrConnectionMode = attribute.Key("gestalt.connection_mode")
 )
 
@@ -181,6 +181,18 @@ func (b *Broker) Invoke(ctx context.Context, p *principal.Principal, providerNam
 		span.SetStatus(codes.Error, err.Error())
 		return nil, err
 	}
+	setSubjectAttribute := func(p *principal.Principal) {
+		if p == nil {
+			return
+		}
+		subjectID := strings.TrimSpace(p.SubjectID)
+		if subjectID == "" && strings.TrimSpace(p.UserID) != "" {
+			subjectID = principal.UserSubjectID(strings.TrimSpace(p.UserID))
+		}
+		if subjectID != "" {
+			span.SetAttributes(attrSubjectID.String(subjectID))
+		}
+	}
 
 	prov, err := b.providers.Get(providerName)
 	if err != nil {
@@ -199,10 +211,7 @@ func (b *Broker) Invoke(ctx context.Context, p *principal.Principal, providerNam
 	if p == nil {
 		return fail(ErrNotAuthenticated)
 	}
-
-	if p.UserID != "" {
-		span.SetAttributes(attrUserID.String(p.UserID))
-	}
+	setSubjectAttribute(p)
 
 	if !principal.AllowsProviderPermission(p, providerName) {
 		return fail(fmt.Errorf("%w: %s", ErrScopeDenied, providerName))
@@ -211,9 +220,7 @@ func (b *Broker) Invoke(ctx context.Context, p *principal.Principal, providerNam
 		return fail(err)
 	}
 	ctx = withResolvedPrincipal(ctx, p)
-	if p.UserID != "" {
-		span.SetAttributes(attrUserID.String(p.UserID))
-	}
+	setSubjectAttribute(p)
 	if b.authorizer != nil {
 		access, allowed := b.authorizer.ResolveAccess(ctx, p, providerName)
 		if access.Policy != "" || access.Role != "" {

--- a/gestaltd/internal/server/audit.go
+++ b/gestaltd/internal/server/audit.go
@@ -92,12 +92,12 @@ func (s *Server) auditEventWithAuthSource(ctx context.Context, authSource, sourc
 	s.auditSink.Log(ctx, entry)
 }
 
-func (s *Server) auditEventWithUserIDAndTarget(ctx context.Context, userID, authSource, source, provider, operation string, allowed bool, err error, target auditTarget) {
+func (s *Server) auditEventWithSubjectIDAndTarget(ctx context.Context, subjectID, authSource, source, provider, operation string, allowed bool, err error, target auditTarget) {
 	if s.auditSink == nil {
 		return
 	}
 
-	ctx, entry := invocation.BuildAuditEntry(ctx, &principal.Principal{UserID: userID}, source, provider, operation)
+	ctx, entry := invocation.BuildAuditEntry(ctx, &principal.Principal{SubjectID: strings.TrimSpace(subjectID)}, source, provider, operation)
 	entry.AuthSource = authSource
 	populateAuditEntry(&entry, allowed, err, target, auditAuthorization{})
 	s.auditSink.Log(ctx, entry)
@@ -213,10 +213,10 @@ func (s *Server) auditRequestEventWithAuthSource(r *http.Request, authSource, pr
 	s.auditEventWithAuthSource(r.Context(), authSource, auditSourceForRequest(r), provider, operation, allowed, err)
 }
 
-func (s *Server) auditHTTPEventWithUserID(ctx context.Context, userID, authSource, provider, operation string, allowed bool, err error) {
-	s.auditHTTPEventWithUserIDAndTarget(ctx, userID, authSource, provider, operation, allowed, err, auditTarget{})
+func (s *Server) auditHTTPEventWithSubjectID(ctx context.Context, subjectID, authSource, provider, operation string, allowed bool, err error) {
+	s.auditHTTPEventWithSubjectIDAndTarget(ctx, subjectID, authSource, provider, operation, allowed, err, auditTarget{})
 }
 
-func (s *Server) auditHTTPEventWithUserIDAndTarget(ctx context.Context, userID, authSource, provider, operation string, allowed bool, err error, target auditTarget) {
-	s.auditEventWithUserIDAndTarget(ctx, userID, authSource, "http", provider, operation, allowed, err, target)
+func (s *Server) auditHTTPEventWithSubjectIDAndTarget(ctx context.Context, subjectID, authSource, provider, operation string, allowed bool, err error, target auditTarget) {
+	s.auditEventWithSubjectIDAndTarget(ctx, subjectID, authSource, "http", provider, operation, allowed, err, target)
 }

--- a/gestaltd/internal/server/audit_metadata_test.go
+++ b/gestaltd/internal/server/audit_metadata_test.go
@@ -104,8 +104,11 @@ func TestAuditMetadata_IPAndUserAgent(t *testing.T) {
 	if record["auth_source"] != "session" {
 		t.Errorf("expected auth_source=session, got %v", record["auth_source"])
 	}
-	if uid, ok := record["user_id"].(string); !ok || uid == "" {
-		t.Errorf("expected non-empty user_id, got %v", record["user_id"])
+	if subjectID, ok := record["subject_id"].(string); !ok || subjectID == "" {
+		t.Errorf("expected non-empty subject_id, got %v", record["subject_id"])
+	}
+	if _, ok := record["user_id"]; ok {
+		t.Errorf("expected emitted audit record to omit user_id, got %v", record["user_id"])
 	}
 	if record["allowed"] != true {
 		t.Errorf("expected allowed=true, got %v", record["allowed"])

--- a/gestaltd/internal/server/handlers_auth.go
+++ b/gestaltd/internal/server/handlers_auth.go
@@ -366,12 +366,12 @@ func (s *Server) loginCallback(w http.ResponseWriter, r *http.Request) {
 	startedAt := time.Now()
 	auditAllowed := false
 	auditErr := errors.New("login callback failed")
-	auditUserID := ""
+	auditSubjectID := ""
 	auth := s.serverAuthRuntime()
 	defer func() {
 		metricutil.RecordAuthMetrics(r.Context(), startedAt, auth.providerName, "complete_login", auditErr != nil)
-		if auditUserID != "" {
-			s.auditHTTPEventWithUserID(r.Context(), auditUserID, principal.SourceSession.String(), auth.providerName, "auth.login.complete", auditAllowed, auditErr)
+		if auditSubjectID != "" {
+			s.auditHTTPEventWithSubjectID(r.Context(), auditSubjectID, principal.SourceSession.String(), auth.providerName, "auth.login.complete", auditAllowed, auditErr)
 			return
 		}
 		s.auditHTTPEvent(r.Context(), nil, auth.providerName, "auth.login.complete", auditAllowed, auditErr)
@@ -440,14 +440,14 @@ func (s *Server) loginCallback(w http.ResponseWriter, r *http.Request) {
 			writeError(w, http.StatusInternalServerError, "failed to resolve user")
 			return
 		}
-		auditUserID = dbUser.ID
+		auditSubjectID = principal.UserSubjectID(dbUser.ID)
 		apiToken, plaintext, issueErr := s.issueAPIToken(r.Context(), dbUser.ID, cliLoginTokenName, "", true)
 		if issueErr != nil {
 			auditErr = errors.New("failed to issue CLI API token")
 			writeError(w, http.StatusInternalServerError, "failed to issue CLI API token")
 			return
 		}
-		s.auditHTTPEventWithUserID(r.Context(), dbUser.ID, principal.SourceSession.String(), "", "api_token.create", true, nil)
+		s.auditHTTPEventWithSubjectID(r.Context(), principal.UserSubjectID(dbUser.ID), principal.SourceSession.String(), "", "api_token.create", true, nil)
 		auditAllowed = true
 		auditErr = nil
 		writeJSON(w, http.StatusOK, createTokenResponse{
@@ -465,7 +465,7 @@ func (s *Server) loginCallback(w http.ResponseWriter, r *http.Request) {
 		case auditPrincipalErr != nil:
 			slog.WarnContext(r.Context(), "login audit user resolution failed", "error", auditPrincipalErr)
 		case dbUser != nil && dbUser.ID != "":
-			auditUserID = dbUser.ID
+			auditSubjectID = principal.UserSubjectID(dbUser.ID)
 		default:
 			slog.WarnContext(r.Context(), "login audit user resolution failed", "error", "authenticated principal missing user ID")
 		}

--- a/gestaltd/internal/server/handlers_oauth.go
+++ b/gestaltd/internal/server/handlers_oauth.go
@@ -132,15 +132,15 @@ func (s *Server) integrationOAuthCallback(w http.ResponseWriter, r *http.Request
 	startedAt := time.Now()
 	auditAllowed := false
 	auditErr := errors.New("oauth callback failed")
-	auditUserID := ""
+	auditSubjectID := ""
 	auditTarget := auditTarget{Kind: auditTargetKindConnection}
 	stateAuthSource := ""
 	providerName := ""
 	connectionMode := metricutil.UnknownAttrValue
 	defer func() {
 		metricutil.RecordConnectionAuthMetrics(r.Context(), startedAt, providerName, "oauth", "complete", connectionMode, auditErr != nil)
-		if auditUserID != "" {
-			s.auditHTTPEventWithUserIDAndTarget(r.Context(), auditUserID, stateAuthSource, providerName, "connection.oauth.complete", auditAllowed, auditErr, auditTarget)
+		if auditSubjectID != "" {
+			s.auditHTTPEventWithSubjectIDAndTarget(r.Context(), auditSubjectID, stateAuthSource, providerName, "connection.oauth.complete", auditAllowed, auditErr, auditTarget)
 			return
 		}
 		s.auditHTTPEventWithTarget(r.Context(), nil, providerName, "connection.oauth.complete", auditAllowed, auditErr, auditTarget)
@@ -195,7 +195,7 @@ func (s *Server) integrationOAuthCallback(w http.ResponseWriter, r *http.Request
 		return
 	}
 	providerName = state.Integration
-	auditUserID = principal.UserIDFromSubjectID(state.SubjectID)
+	auditSubjectID = state.SubjectID
 	stateAuthSource = state.AuthSource
 	auditTarget = connectionAuditTarget(state.Integration, state.Connection, state.Instance)
 	handler, ok := s.requireOAuthHandler(w, providerName, state.Connection)

--- a/gestaltd/internal/server/pending_connection.go
+++ b/gestaltd/internal/server/pending_connection.go
@@ -321,13 +321,13 @@ func (s *Server) authorizePendingConnection(w http.ResponseWriter, r *http.Reque
 func (s *Server) selectPendingConnection(w http.ResponseWriter, r *http.Request) {
 	auditAllowed := false
 	auditErr := errors.New("pending connection selection failed")
-	auditUserID := ""
+	auditSubjectID := ""
 	auditAuthSource := ""
 	auditTarget := auditTarget{Kind: auditTargetKindConnection}
 	providerName := ""
 	defer func() {
-		if auditUserID != "" {
-			s.auditHTTPEventWithUserIDAndTarget(r.Context(), auditUserID, auditAuthSource, providerName, "connection.pending.select", auditAllowed, auditErr, auditTarget)
+		if auditSubjectID != "" {
+			s.auditHTTPEventWithSubjectIDAndTarget(r.Context(), auditSubjectID, auditAuthSource, providerName, "connection.pending.select", auditAllowed, auditErr, auditTarget)
 			return
 		}
 		s.auditHTTPEventWithTarget(r.Context(), PrincipalFromContext(r.Context()), providerName, "connection.pending.select", auditAllowed, auditErr, auditTarget)
@@ -364,7 +364,7 @@ func (s *Server) selectPendingConnection(w http.ResponseWriter, r *http.Request)
 		auditErr = errors.New("pending connection authorization required")
 		return
 	}
-	auditUserID = principal.UserIDFromSubjectID(state.Token.SubjectID)
+	auditSubjectID = state.Token.SubjectID
 	auditAuthSource = state.Token.AuthSource
 	if candidateIndex == "" && candidateID == "" {
 		auditAllowed = true

--- a/gestaltd/internal/server/server_test.go
+++ b/gestaltd/internal/server/server_test.go
@@ -7114,8 +7114,11 @@ func TestLoginCallback_LegacyMixedCaseRepairFailureStillSucceeds(t *testing.T) {
 	if auditRecord["operation"] != "auth.login.complete" {
 		t.Fatalf("expected audit operation auth.login.complete, got %v", auditRecord["operation"])
 	}
-	if uid, ok := auditRecord["user_id"].(string); !ok || uid != existing.ID {
-		t.Fatalf("expected audit user_id %q, got %v", existing.ID, auditRecord["user_id"])
+	if subjectID, ok := auditRecord["subject_id"].(string); !ok || subjectID != principal.UserSubjectID(existing.ID) {
+		t.Fatalf("expected audit subject_id %q, got %v", principal.UserSubjectID(existing.ID), auditRecord["subject_id"])
+	}
+	if _, ok := auditRecord["user_id"]; ok {
+		t.Fatalf("expected emitted audit record to omit user_id, got %v", auditRecord["user_id"])
 	}
 }
 
@@ -10246,8 +10249,11 @@ func TestLoginCallback(t *testing.T) {
 	if auditRecord["auth_source"] != "session" {
 		t.Fatalf("expected audit auth_source session, got %v", auditRecord["auth_source"])
 	}
-	if uid, ok := auditRecord["user_id"].(string); !ok || uid != existing.ID {
-		t.Fatalf("expected audit user_id %q, got %v", existing.ID, auditRecord["user_id"])
+	if subjectID, ok := auditRecord["subject_id"].(string); !ok || subjectID != principal.UserSubjectID(existing.ID) {
+		t.Fatalf("expected audit subject_id %q, got %v", principal.UserSubjectID(existing.ID), auditRecord["subject_id"])
+	}
+	if _, ok := auditRecord["user_id"]; ok {
+		t.Fatalf("expected emitted audit record to omit user_id, got %v", auditRecord["user_id"])
 	}
 }
 
@@ -10431,8 +10437,11 @@ func TestLoginCallbackForCLI(t *testing.T) {
 	if tokenAudit["auth_source"] != "session" {
 		t.Fatalf("expected token audit auth_source session, got %v", tokenAudit["auth_source"])
 	}
-	if uid, ok := tokenAudit["user_id"].(string); !ok || uid != u.ID {
-		t.Fatalf("expected token audit user_id %q, got %v", u.ID, tokenAudit["user_id"])
+	if subjectID, ok := tokenAudit["subject_id"].(string); !ok || subjectID != principal.UserSubjectID(u.ID) {
+		t.Fatalf("expected token audit subject_id %q, got %v", principal.UserSubjectID(u.ID), tokenAudit["subject_id"])
+	}
+	if _, ok := tokenAudit["user_id"]; ok {
+		t.Fatalf("expected emitted token audit record to omit user_id, got %v", tokenAudit["user_id"])
 	}
 	if tokenAudit["allowed"] != true {
 		t.Fatalf("expected token audit allowed=true, got %v", tokenAudit["allowed"])
@@ -10445,8 +10454,11 @@ func TestLoginCallbackForCLI(t *testing.T) {
 	if loginAudit["operation"] != "auth.login.complete" {
 		t.Fatalf("expected auth.login.complete audit operation, got %v", loginAudit["operation"])
 	}
-	if uid, ok := loginAudit["user_id"].(string); !ok || uid != u.ID {
-		t.Fatalf("expected login audit user_id %q, got %v", u.ID, loginAudit["user_id"])
+	if subjectID, ok := loginAudit["subject_id"].(string); !ok || subjectID != principal.UserSubjectID(u.ID) {
+		t.Fatalf("expected login audit subject_id %q, got %v", principal.UserSubjectID(u.ID), loginAudit["subject_id"])
+	}
+	if _, ok := loginAudit["user_id"]; ok {
+		t.Fatalf("expected emitted login audit record to omit user_id, got %v", loginAudit["user_id"])
 	}
 }
 
@@ -10881,8 +10893,11 @@ func TestIntegrationOAuthCallback(t *testing.T) {
 		if auditRecord["auth_source"] != "session" {
 			t.Fatalf("expected audit auth_source session, got %v", auditRecord["auth_source"])
 		}
-		if uid, ok := auditRecord["user_id"].(string); !ok || uid == "" {
-			t.Fatalf("expected non-empty audit user_id, got %v", auditRecord["user_id"])
+		if subjectID, ok := auditRecord["subject_id"].(string); !ok || subjectID != principal.UserSubjectID(u.ID) {
+			t.Fatalf("expected audit subject_id %q, got %v", principal.UserSubjectID(u.ID), auditRecord["subject_id"])
+		}
+		if _, ok := auditRecord["user_id"]; ok {
+			t.Fatalf("expected emitted audit record to omit user_id, got %v", auditRecord["user_id"])
 		}
 		if auditRecord["target_kind"] != "connection" {
 			t.Fatalf("expected audit target_kind connection, got %v", auditRecord["target_kind"])
@@ -11351,8 +11366,11 @@ func TestCreateAPIToken_DefaultExpiry(t *testing.T) {
 	if auditRecord["auth_source"] != "session" {
 		t.Fatalf("expected audit auth_source session, got %v", auditRecord["auth_source"])
 	}
-	if uid, ok := auditRecord["user_id"].(string); !ok || uid != existing.ID {
-		t.Fatalf("expected audit user_id %q, got %v", existing.ID, auditRecord["user_id"])
+	if subjectID, ok := auditRecord["subject_id"].(string); !ok || subjectID != principal.UserSubjectID(existing.ID) {
+		t.Fatalf("expected audit subject_id %q, got %v", principal.UserSubjectID(existing.ID), auditRecord["subject_id"])
+	}
+	if _, ok := auditRecord["user_id"]; ok {
+		t.Fatalf("expected emitted audit record to omit user_id, got %v", auditRecord["user_id"])
 	}
 	if auditRecord["allowed"] != true {
 		t.Fatalf("expected audit allowed=true, got %v", auditRecord["allowed"])
@@ -12977,8 +12995,8 @@ func TestConnectManual(t *testing.T) {
 		if noAuthAudit["allowed"] != false {
 			t.Fatalf("expected denied pending connection audit, got %v", noAuthAudit["allowed"])
 		}
-		if userID, ok := noAuthAudit["user_id"]; ok && userID != "" {
-			t.Fatalf("expected unauthenticated denied selection to omit user_id, got %v", userID)
+		if subjectID, ok := noAuthAudit["subject_id"]; ok && subjectID != "" {
+			t.Fatalf("expected unauthenticated denied selection to omit subject_id, got %v", subjectID)
 		}
 		if noAuthAudit["target_kind"] != "connection" {
 			t.Fatalf("expected pending connection target_kind connection, got %v", noAuthAudit["target_kind"])
@@ -13020,8 +13038,8 @@ func TestConnectManual(t *testing.T) {
 		if mismatchAudit["allowed"] != false {
 			t.Fatalf("expected denied pending connection audit, got %v", mismatchAudit["allowed"])
 		}
-		if mismatchAudit["user_id"] == "u1" {
-			t.Fatalf("expected denied selection not to be attributed to token owner, got %v", mismatchAudit["user_id"])
+		if mismatchAudit["subject_id"] == principal.UserSubjectID("u1") {
+			t.Fatalf("expected denied selection not to be attributed to token owner, got %v", mismatchAudit["subject_id"])
 		}
 		form := url.Values{
 			"pending_token":   {connectResult.PendingToken},
@@ -14086,8 +14104,11 @@ func TestMCPEndpoint_DirectPassthrough(t *testing.T) {
 	if auditRecord["auth_source"] != "session" {
 		t.Fatalf("expected audit auth_source session, got %v", auditRecord["auth_source"])
 	}
-	if uid, ok := auditRecord["user_id"].(string); !ok || uid == "" {
-		t.Fatalf("expected non-empty audit user_id, got %v", auditRecord["user_id"])
+	if subjectID, ok := auditRecord["subject_id"].(string); !ok || subjectID == "" {
+		t.Fatalf("expected non-empty audit subject_id, got %v", auditRecord["subject_id"])
+	}
+	if _, ok := auditRecord["user_id"]; ok {
+		t.Fatalf("expected emitted audit record to omit user_id, got %v", auditRecord["user_id"])
 	}
 	if auditRecord["allowed"] != true {
 		t.Fatalf("expected audit allowed=true, got %v", auditRecord["allowed"])
@@ -15093,8 +15114,11 @@ func TestLogout(t *testing.T) {
 	if auditRecord["auth_source"] != "session" {
 		t.Fatalf("expected audit auth_source session, got %v", auditRecord["auth_source"])
 	}
-	if uid, ok := auditRecord["user_id"].(string); !ok || uid == "" {
-		t.Fatalf("expected non-empty audit user_id, got %v", auditRecord["user_id"])
+	if subjectID, ok := auditRecord["subject_id"].(string); !ok || subjectID == "" {
+		t.Fatalf("expected non-empty audit subject_id, got %v", auditRecord["subject_id"])
+	}
+	if _, ok := auditRecord["user_id"]; ok {
+		t.Fatalf("expected emitted audit record to omit user_id, got %v", auditRecord["user_id"])
 	}
 	if auditRecord["allowed"] != true {
 		t.Fatalf("expected audit allowed=true, got %v", auditRecord["allowed"])

--- a/gestaltd/internal/server/tracing_test.go
+++ b/gestaltd/internal/server/tracing_test.go
@@ -13,6 +13,7 @@ import (
 	"github.com/valon-technologies/gestalt/server/core"
 	coretesting "github.com/valon-technologies/gestalt/server/core/testing"
 	"github.com/valon-technologies/gestalt/server/internal/invocation"
+	"github.com/valon-technologies/gestalt/server/internal/principal"
 	"github.com/valon-technologies/gestalt/server/internal/server"
 	"github.com/valon-technologies/gestalt/server/internal/testutil"
 	"go.opentelemetry.io/otel"
@@ -45,7 +46,15 @@ func TestTracing_HTTPAndBrokerSpans(t *testing.T) { //nolint:paralleltest // mut
 	broker := invocation.NewBroker(providers, ds.Users, ds.Tokens)
 
 	srv, err := server.New(server.Config{
-		Auth:        &coretesting.StubAuthProvider{N: "none"},
+		Auth: &coretesting.StubAuthProvider{
+			N: "stub",
+			ValidateTokenFn: func(_ context.Context, token string) (*core.UserIdentity, error) {
+				if token != "session-token" {
+					return nil, core.ErrNotFound
+				}
+				return &core.UserIdentity{Email: "trace@example.com"}, nil
+			},
+		},
 		Services:    ds,
 		Providers:   providers,
 		Invoker:     broker,
@@ -58,6 +67,7 @@ func TestTracing_HTTPAndBrokerSpans(t *testing.T) { //nolint:paralleltest // mut
 	t.Cleanup(ts.Close)
 
 	req, _ := http.NewRequest(http.MethodPost, ts.URL+"/api/v1/tracer-prov/ping", bytes.NewBufferString(`{}`))
+	req.AddCookie(&http.Cookie{Name: "session_token", Value: "session-token"})
 	resp, err := http.DefaultClient.Do(req)
 	if err != nil {
 		t.Fatalf("request: %v", err)
@@ -88,9 +98,15 @@ func TestTracing_HTTPAndBrokerSpans(t *testing.T) { //nolint:paralleltest // mut
 	if brokerSpan == nil {
 		t.Fatal("expected broker span named 'broker.invoke'")
 	}
+	dbUser, err := ds.Users.FindOrCreateUser(context.Background(), "trace@example.com")
+	if err != nil {
+		t.Fatalf("resolve trace user: %v", err)
+	}
 	assertSpanHasAttr(t, brokerSpan, "gestalt.provider", "tracer-prov")
 	assertSpanHasAttr(t, brokerSpan, "gestalt.operation", "ping")
+	assertSpanHasAttr(t, brokerSpan, "gestalt.subject_id", principal.UserSubjectID(dbUser.ID))
 	assertSpanHasAttr(t, brokerSpan, "gestalt.connection_mode", "none")
+	assertSpanLacksAttr(t, brokerSpan, "gestalt.user_id")
 
 	if brokerSpan.Parent.TraceID() != httpSpan.SpanContext.TraceID() {
 		t.Errorf("broker span should share trace ID with HTTP span: broker=%s http=%s",
@@ -195,4 +211,14 @@ func assertSpanHasAttr(t *testing.T, span *tracetest.SpanStub, key, expected str
 		}
 	}
 	t.Errorf("span %q: missing attribute %q", span.Name, key)
+}
+
+func assertSpanLacksAttr(t *testing.T, span *tracetest.SpanStub, key string) {
+	t.Helper()
+	for _, attr := range span.Attributes {
+		if string(attr.Key) == key {
+			t.Errorf("span %q: unexpected attribute %q=%q", span.Name, key, attr.Value.AsString())
+			return
+		}
+	}
 }


### PR DESCRIPTION
## Summary
- make emitted audit records canonical and subject-first by removing `user_id` from emitted audit logs
- replace broker span attribute `gestalt.user_id` with `gestalt.subject_id`
- route login/oauth/manual-connect audit helpers through subject-based emission while keeping internal compatibility ballast only where needed
- fold the behavior into existing invocation/server/tracing coverage instead of adding redundant standalone tests

## New Emitted Interfaces
### Audit record
Before:
```json
{
  "auth_source": "api_token",
  "user_id": "usr_123",
  "provider": "github",
  "operation": "issues_list"
}
```

After:
```json
{
  "auth_source": "api_token",
  "subject_id": "user:usr_123",
  "subject_kind": "user",
  "provider": "github",
  "operation": "issues_list"
}
```

### Broker tracing attribute
Before:
```text
gestalt.user_id=usr_123
```

After:
```text
gestalt.subject_id=user:usr_123
```

## Compatibility
- internal user resolution still exists where needed for login/session/token flows
- `core.AuditEntry.UserID` remains in-process for now, but emitted audit logs no longer include `user_id`
- subject-based audit helpers are now the canonical path; dead user-ID wrappers were removed once they became unused

## Verification
```bash
cd gestaltd

go test ./internal/invocation ./internal/server

golangci-lint run ./internal/invocation ./internal/server
```
