### PR TITLE
gestaltd: unify bound credential resolution onto subject token lookup

### DIFF
--- a/gestaltd/internal/authorization/authorizer.go
+++ b/gestaltd/internal/authorization/authorizer.go
@@ -264,11 +264,14 @@ func (a *Authorizer) ResolveAccess(_ context.Context, p *principal.Principal, pr
 		return AccessContext{}, principal.AllowsProviderPermission(p, provider)
 	}
 	policyName := strings.TrimSpace(a.providerPolicies[provider])
+	if a.IsWorkload(p) {
+		if policyName == "" {
+			return AccessContext{}, false
+		}
+		return AccessContext{Policy: policyName}, false
+	}
 	if policyName == "" {
 		return AccessContext{}, true
-	}
-	if a.IsWorkload(p) {
-		return a.ResolvePolicyAccess(context.Background(), p, policyName)
 	}
 
 	policy := a.policies[policyName]

--- a/gestaltd/internal/bootstrap/bootstrap_test.go
+++ b/gestaltd/internal/bootstrap/bootstrap_test.go
@@ -4340,6 +4340,59 @@ func TestBootstrapSecretResolution(t *testing.T) {
 		}
 	})
 
+	t.Run("workload resolve access keeps policy context but does not signal provider allow", func(t *testing.T) {
+		t.Parallel()
+
+		cfg := validConfig()
+		cfg.Authorization = config.AuthorizationConfig{
+			Policies: map[string]config.HumanPolicyDef{
+				"roadmap-policy": {Default: "deny"},
+			},
+			Workloads: map[string]config.WorkloadDef{
+				"triage-bot": {
+					Token: "gst_wld_triage-bot",
+					Providers: map[string]config.WorkloadProviderDef{
+						"roadmap": {Allow: []string{"sync"}},
+					},
+				},
+			},
+		}
+		cfg.Plugins = map[string]*config.ProviderEntry{
+			"roadmap": {
+				AuthorizationPolicy: "roadmap-policy",
+				ConnectionMode:      providermanifestv1.ConnectionModeUser,
+				ResolvedManifest: &providermanifestv1.Manifest{
+					Spec: &providermanifestv1.Spec{},
+				},
+			},
+		}
+
+		result, err := bootstrap.Bootstrap(ctx, cfg, validFactories())
+		if err != nil {
+			t.Fatalf("Bootstrap: %v", err)
+		}
+		t.Cleanup(func() { _ = result.Close(context.Background()) })
+		<-result.ProvidersReady
+
+		workloadPrincipal := &principal.Principal{
+			SubjectID: principal.WorkloadSubjectID("triage-bot"),
+			Kind:      principal.KindWorkload,
+		}
+		access, allowed := result.Authorizer.ResolveAccess(ctx, workloadPrincipal, "roadmap")
+		if allowed {
+			t.Fatal("expected workload ResolveAccess to remain denied for provider access checks")
+		}
+		if access.Policy != "roadmap-policy" {
+			t.Fatalf("workload access policy = %q, want %q", access.Policy, "roadmap-policy")
+		}
+		if access.Role != "" {
+			t.Fatalf("workload access role = %q, want empty", access.Role)
+		}
+		if !result.Authorizer.AllowProvider(ctx, workloadPrincipal, "roadmap") {
+			t.Fatal("expected bound workload to be allowed for roadmap provider")
+		}
+	})
+
 	t.Run("dynamic human authorizations require an authorization provider", func(t *testing.T) {
 		t.Parallel()
 

--- a/gestaltd/internal/invocation/broker.go
+++ b/gestaltd/internal/invocation/broker.go
@@ -221,22 +221,33 @@ func (b *Broker) Invoke(ctx context.Context, p *principal.Principal, providerNam
 	}
 	ctx = withResolvedPrincipal(ctx, p)
 	setSubjectAttribute(p)
+	conn := ConnectionFromContext(ctx)
+	boundCredential, err := b.ResolveEffectiveCredentialBinding(p, providerName, conn, instance)
+	if err != nil {
+		return fail(err)
+	}
 	if b.authorizer != nil {
 		access, allowed := b.authorizer.ResolveAccess(ctx, p, providerName)
 		if access.Policy != "" || access.Role != "" {
 			ctx = WithAccessContext(ctx, access)
 		}
-		if b.authorizer.IsWorkload(p) {
-			if binding, ok := b.authorizer.Binding(p, providerName); ok {
-				SetCredentialAudit(ctx, binding.Mode, binding.CredentialSubjectID, binding.Connection, binding.Instance)
-			}
+		if boundCredential.HasBinding {
+			SetCredentialAudit(
+				ctx,
+				boundCredential.Binding.Mode,
+				boundCredential.CredentialSubjectID,
+				boundCredential.Connection,
+				boundCredential.Instance,
+			)
 		} else if !allowed {
 			return fail(fmt.Errorf("%w: %s", ErrAuthorizationDenied, providerName))
 		}
 	}
 
-	conn := ConnectionFromContext(ctx)
-	conn, instance = b.workloadSelectors(p, providerName, conn, instance)
+	if boundCredential.HasBinding {
+		conn = boundCredential.Connection
+		instance = boundCredential.Instance
+	}
 	if b.authorizer != nil && b.authorizer.IsWorkload(p) && !b.authorizer.AllowOperation(ctx, p, providerName, operation) {
 		return fail(fmt.Errorf("%w: %s.%s", ErrAuthorizationDenied, providerName, operation))
 	}
@@ -274,7 +285,7 @@ func (b *Broker) Invoke(ctx context.Context, p *principal.Principal, providerNam
 	}
 
 	if transport == catalog.TransportMCPPassthrough {
-		result, err := CallDirectTool(ctx, b, p, prov, providerName, operation, conn, instance, params, mcpupstream.CallToolMetaFromContext(ctx))
+		result, err := CallDirectTool(ctx, b, p, prov, providerName, operation, conn, instance, boundCredential, params, mcpupstream.CallToolMetaFromContext(ctx))
 		if err != nil {
 			return fail(err)
 		}
@@ -288,7 +299,7 @@ func (b *Broker) Invoke(ctx context.Context, p *principal.Principal, providerNam
 		return opResult, nil
 	}
 
-	ctx, accessToken, err := b.resolveToken(ctx, prov, p, providerName, conn, instance)
+	ctx, accessToken, err := b.resolveToken(ctx, prov, p, providerName, conn, instance, boundCredential)
 	if err != nil {
 		return fail(err)
 	}
@@ -329,21 +340,12 @@ func (b *Broker) MCPConnection(providerName string) string {
 	return b.mcpConnection(providerName)
 }
 
-func (b *Broker) workloadSelectors(p *principal.Principal, providerName, connection, instance string) (string, string) {
-	if b.authorizer == nil || !b.authorizer.IsWorkload(p) {
-		return connection, instance
-	}
-	binding, ok := b.authorizer.Binding(p, providerName)
-	if !ok {
-		return connection, instance
-	}
-	if connection == "" {
-		connection = binding.Connection
-	}
-	if instance == "" {
-		instance = binding.Instance
-	}
-	return connection, instance
+func (b *Broker) ResolveEffectiveCredentialBinding(p *principal.Principal, providerName, connection, instance string) (CredentialBindingResolution, error) {
+	return ResolveEffectiveCredentialBinding(b.authorizer, p, providerName, connection, instance)
+}
+
+func (b *Broker) ResolveRequestedCredentialBinding(p *principal.Principal, providerName, connection, instance string) (CredentialBindingResolution, error) {
+	return ResolveRequestedCredentialBinding(b.authorizer, p, providerName, connection, instance)
 }
 
 func toolResultToOperationResult(result *mcpgo.CallToolResult) (*core.OperationResult, error) {
@@ -410,16 +412,56 @@ func (b *Broker) ResolveToken(ctx context.Context, p *principal.Principal, provi
 		}
 		return ctx, "", fmt.Errorf("%w: looking up provider: %v", ErrInternal, err)
 	}
-	return b.resolveToken(ctx, prov, p, providerName, connection, instance)
+	boundCredential, err := b.ResolveRequestedCredentialBinding(p, providerName, connection, instance)
+	if err != nil {
+		return ctx, "", err
+	}
+	return b.resolveToken(ctx, prov, p, providerName, connection, instance, boundCredential)
 }
 
-func (b *Broker) resolveToken(ctx context.Context, prov core.Provider, p *principal.Principal, providerName, connection, instance string) (context.Context, string, error) {
+func (b *Broker) ResolveTokenWithBinding(ctx context.Context, p *principal.Principal, providerName, connection, instance string, boundCredential CredentialBindingResolution) (context.Context, string, error) {
+	if !principal.AllowsProviderPermission(p, providerName) {
+		return ctx, "", fmt.Errorf("%w: %s", ErrScopeDenied, providerName)
+	}
+	if err := b.resolveUserPrincipal(ctx, p); err != nil {
+		return ctx, "", err
+	}
+	ctx = withResolvedPrincipal(ctx, p)
+	if b.authorizer != nil && !b.authorizer.AllowProvider(ctx, p, providerName) {
+		return ctx, "", fmt.Errorf("%w: %s", ErrAuthorizationDenied, providerName)
+	}
+	prov, err := b.providers.Get(providerName)
+	if err != nil {
+		if errors.Is(err, core.ErrNotFound) {
+			return ctx, "", fmt.Errorf("%w: %q", ErrProviderNotFound, providerName)
+		}
+		return ctx, "", fmt.Errorf("%w: looking up provider: %v", ErrInternal, err)
+	}
+	return b.resolveToken(ctx, prov, p, providerName, connection, instance, boundCredential)
+}
+
+func (b *Broker) resolveToken(ctx context.Context, prov core.Provider, p *principal.Principal, providerName, connection, instance string, boundCredential CredentialBindingResolution) (context.Context, string, error) {
 	resolved := principal.FromContext(ctx)
 	if resolved != nil {
 		p = resolved
 	}
-	if b.authorizer != nil && b.authorizer.IsWorkload(p) {
-		return b.resolveWorkloadToken(ctx, prov, p, providerName, connection, instance)
+	if !boundCredential.HasBinding {
+		var err error
+		boundCredential, err = b.ResolveEffectiveCredentialBinding(p, providerName, connection, instance)
+		if err != nil {
+			return ctx, "", err
+		}
+	}
+	if boundCredential.HasBinding {
+		if boundCredential.Binding.Mode == core.ConnectionModeUser {
+			if boundCredential.Connection == "" {
+				boundCredential.Connection = strings.TrimSpace(connection)
+			}
+			if boundCredential.Instance == "" {
+				boundCredential.Instance = strings.TrimSpace(instance)
+			}
+		}
+		return b.resolveBoundToken(ctx, prov, p, providerName, boundCredential)
 	}
 	if resolved == nil {
 		if err := b.resolveUserPrincipal(ctx, p); err != nil {
@@ -472,43 +514,48 @@ func (b *Broker) resolveUserPrincipal(ctx context.Context, p *principal.Principa
 	return nil
 }
 
-func (b *Broker) resolveWorkloadToken(ctx context.Context, prov core.Provider, p *principal.Principal, providerName, requestedConnection, requestedInstance string) (context.Context, string, error) {
-	if b.authorizer == nil {
-		return ctx, "", fmt.Errorf("%w: no workload authorizer configured", ErrAuthorizationDenied)
-	}
-	binding, ok := b.authorizer.Binding(p, providerName)
-	if !ok {
-		return ctx, "", fmt.Errorf("%w: %s", ErrAuthorizationDenied, providerName)
-	}
-
-	switch binding.Mode {
+func (b *Broker) resolveBoundToken(ctx context.Context, prov core.Provider, p *principal.Principal, providerName string, boundCredential CredentialBindingResolution) (context.Context, string, error) {
+	switch boundCredential.Binding.Mode {
 	case core.ConnectionModeNone:
-		if requestedConnection != "" || requestedInstance != "" {
-			return ctx, "", fmt.Errorf("%w: workloads may not override connection or instance bindings", ErrAuthorizationDenied)
-		}
-		SetCredentialAudit(ctx, binding.Mode, binding.CredentialSubjectID, binding.Connection, binding.Instance)
+		SetCredentialAudit(
+			ctx,
+			boundCredential.Binding.Mode,
+			boundCredential.CredentialSubjectID,
+			boundCredential.Connection,
+			boundCredential.Instance,
+		)
 		ctx = WithCredentialContext(ctx, CredentialContext{
-			Mode:       binding.Mode,
-			SubjectID:  binding.CredentialSubjectID,
-			Connection: binding.Connection,
-			Instance:   binding.Instance,
+			Mode:       boundCredential.Binding.Mode,
+			SubjectID:  boundCredential.CredentialSubjectID,
+			Connection: boundCredential.Connection,
+			Instance:   boundCredential.Instance,
 		})
 		return ctx, "", nil
 	case core.ConnectionModeUser:
-		connection := binding.Connection
-		instance := binding.Instance
-		if (requestedConnection != "" && requestedConnection != binding.Connection) || (requestedInstance != "" && requestedInstance != binding.Instance) {
-			return ctx, "", fmt.Errorf("%w: workloads may not override connection or instance bindings", ErrAuthorizationDenied)
-		}
-		subjectID := strings.TrimSpace(binding.CredentialSubjectID)
+		subjectID := strings.TrimSpace(boundCredential.CredentialSubjectID)
 		if subjectID == "" {
 			subjectID = principal.EffectiveCredentialSubjectID(p)
 		}
 		if subjectID == "" {
 			return ctx, "", fmt.Errorf("%w: principal has no subject ID or email", ErrUserResolution)
 		}
-		SetCredentialAudit(ctx, binding.Mode, subjectID, connection, instance)
-		return b.resolveSubjectToken(ctx, prov, subjectID, providerName, connection, instance, core.ConnectionModeUser, subjectID)
+		SetCredentialAudit(
+			ctx,
+			boundCredential.Binding.Mode,
+			subjectID,
+			boundCredential.Connection,
+			boundCredential.Instance,
+		)
+		return b.resolveSubjectToken(
+			ctx,
+			prov,
+			subjectID,
+			providerName,
+			boundCredential.Connection,
+			boundCredential.Instance,
+			core.ConnectionModeUser,
+			subjectID,
+		)
 	default:
 		return ctx, "", fmt.Errorf("%w: workloads may only use credentialed or none providers", ErrAuthorizationDenied)
 	}

--- a/gestaltd/internal/invocation/broker_test.go
+++ b/gestaltd/internal/invocation/broker_test.go
@@ -123,3 +123,30 @@ func TestBrokerResolveToken_WorkflowContextDoesNotBypassWorkloadIdentityBinding(
 		t.Fatalf("ResolveToken error = %q, want substring %q", got, want)
 	}
 }
+
+func TestBrokerResolveToken_ManagedIdentityDoesNotBypassSelectorBinding(t *testing.T) {
+	t.Parallel()
+
+	svc := coretesting.NewStubServices(t)
+	providers := testutil.NewProviderRegistry(t, &coretesting.StubIntegration{
+		N:        "slack",
+		ConnMode: core.ConnectionModeUser,
+	})
+	authz := mustAuthorizer(t, config.AuthorizationConfig{}, providers)
+	broker := NewBroker(providers, svc.Users, svc.Tokens, WithAuthorizer(authz))
+
+	identity := &principal.Principal{
+		Kind:                principal.KindWorkload,
+		SubjectID:           principal.ManagedIdentitySubjectID("ops-bot"),
+		CredentialSubjectID: principal.UserSubjectID("creator-user"),
+		Source:              principal.SourceAPIToken,
+	}
+
+	_, _, err := broker.ResolveToken(context.Background(), identity, "slack", "workspace", "team-b")
+	if err == nil {
+		t.Fatal("expected managed identity selector override to be rejected")
+	}
+	if got, want := err.Error(), "workloads may not override connection or instance bindings"; got == "" || !strings.Contains(got, want) {
+		t.Fatalf("ResolveToken error = %q, want substring %q", got, want)
+	}
+}

--- a/gestaltd/internal/invocation/catalog.go
+++ b/gestaltd/internal/invocation/catalog.go
@@ -17,6 +17,14 @@ type TokenResolver interface {
 	ResolveToken(ctx context.Context, p *principal.Principal, providerName, connection, instance string) (context.Context, string, error)
 }
 
+type effectiveCredentialBindingResolver interface {
+	ResolveEffectiveCredentialBinding(p *principal.Principal, providerName, connection, instance string) (CredentialBindingResolution, error)
+}
+
+type bindingTokenResolver interface {
+	ResolveTokenWithBinding(ctx context.Context, p *principal.Principal, providerName, connection, instance string, boundCredential CredentialBindingResolution) (context.Context, string, error)
+}
+
 type requestStaticOperationResolver interface {
 	ResolveStaticOperationForRequest(ctx context.Context, operation string) (catalog.CatalogOperation, bool)
 }
@@ -144,12 +152,21 @@ func resolveSessionCatalog(ctx context.Context, prov core.Provider, provName str
 	if !core.SupportsSessionCatalog(prov) {
 		return nil, false, nil
 	}
+	boundCredential := CredentialBindingResolution{}
+	if bindingResolver, ok := resolver.(effectiveCredentialBindingResolver); ok && p != nil {
+		resolvedBinding, err := bindingResolver.ResolveEffectiveCredentialBinding(p, provName, connection, instance)
+		if err != nil {
+			return nil, true, err
+		}
+		if resolvedBinding.HasBinding {
+			boundCredential = resolvedBinding
+			connection = boundCredential.Connection
+			instance = boundCredential.Instance
+		}
+	}
 	if prov.ConnectionMode() == core.ConnectionModeNone {
 		if resolver != nil && p != nil {
-			// No-auth providers do not consume connection or instance selectors
-			// when resolving session catalogs. Passing them through here causes
-			// workload callers to trip the override guard before static fallback.
-			enrichedCtx, token, err := resolver.ResolveToken(ctx, p, provName, "", "")
+			enrichedCtx, token, err := resolveSessionCatalogToken(ctx, resolver, p, provName, connection, instance, boundCredential)
 			if err != nil {
 				return nil, true, err
 			}
@@ -164,12 +181,21 @@ func resolveSessionCatalog(ctx context.Context, prov core.Provider, provName str
 		return nil, false, nil
 	}
 
-	ctx, token, err := resolver.ResolveToken(ctx, p, provName, connection, instance)
+	ctx, token, err := resolveSessionCatalogToken(ctx, resolver, p, provName, connection, instance, boundCredential)
 	if err != nil {
 		return nil, true, err
 	}
 	cat, _, err := core.CatalogForRequest(ctx, prov, token)
 	return cat, true, err
+}
+
+func resolveSessionCatalogToken(ctx context.Context, resolver TokenResolver, p *principal.Principal, provName, connection, instance string, boundCredential CredentialBindingResolution) (context.Context, string, error) {
+	if boundCredential.HasBinding {
+		if bindingResolver, ok := resolver.(bindingTokenResolver); ok {
+			return bindingResolver.ResolveTokenWithBinding(ctx, p, provName, connection, instance, boundCredential)
+		}
+	}
+	return resolver.ResolveToken(ctx, p, provName, connection, instance)
 }
 
 func resolveSessionOperation(ctx context.Context, prov core.Provider, provName string, resolver TokenResolver, p *principal.Principal, operation string, connections []string, instance string) (catalog.CatalogOperation, string, bool, error) {

--- a/gestaltd/internal/invocation/credential_binding.go
+++ b/gestaltd/internal/invocation/credential_binding.go
@@ -1,0 +1,84 @@
+package invocation
+
+import (
+	"fmt"
+	"strings"
+
+	"github.com/valon-technologies/gestalt/server/core"
+	"github.com/valon-technologies/gestalt/server/internal/authorization"
+	"github.com/valon-technologies/gestalt/server/internal/principal"
+)
+
+type CredentialBindingResolution struct {
+	Binding             authorization.CredentialBinding
+	HasBinding          bool
+	CredentialSubjectID string
+	Connection          string
+	Instance            string
+}
+
+func ResolveEffectiveCredentialBinding(authz authorization.RuntimeAuthorizer, p *principal.Principal, providerName, connection, instance string) (CredentialBindingResolution, error) {
+	return resolveCredentialBinding(authz, p, providerName, connection, instance, false)
+}
+
+func ResolveRequestedCredentialBinding(authz authorization.RuntimeAuthorizer, p *principal.Principal, providerName, connection, instance string) (CredentialBindingResolution, error) {
+	return resolveCredentialBinding(authz, p, providerName, connection, instance, true)
+}
+
+func resolveCredentialBinding(authz authorization.RuntimeAuthorizer, p *principal.Principal, providerName, connection, instance string, enforceRequested bool) (CredentialBindingResolution, error) {
+	if authz == nil || p == nil {
+		return CredentialBindingResolution{}, nil
+	}
+
+	binding, ok := authz.Binding(p, providerName)
+	if !ok {
+		return CredentialBindingResolution{}, nil
+	}
+
+	connection = strings.TrimSpace(connection)
+	instance = strings.TrimSpace(instance)
+	binding.Mode = core.NormalizeConnectionMode(binding.Mode)
+
+	resolved := CredentialBindingResolution{
+		Binding:             binding,
+		HasBinding:          true,
+		CredentialSubjectID: strings.TrimSpace(binding.CredentialSubjectID),
+		Connection:          strings.TrimSpace(binding.Connection),
+		Instance:            strings.TrimSpace(binding.Instance),
+	}
+
+	if enforceRequested && authz.IsWorkload(p) {
+		if connection != "" && connection != resolved.Connection {
+			return CredentialBindingResolution{}, bindingSelectorOverrideError()
+		}
+		if instance != "" && instance != resolved.Instance {
+			return CredentialBindingResolution{}, bindingSelectorOverrideError()
+		}
+	}
+
+	switch binding.Mode {
+	case core.ConnectionModeNone:
+		return resolved, nil
+
+	case core.ConnectionModeUser:
+		if resolved.Connection == "" {
+			resolved.Connection = connection
+		}
+
+		if resolved.Instance == "" {
+			resolved.Instance = instance
+		}
+
+		if resolved.CredentialSubjectID == "" {
+			resolved.CredentialSubjectID = principal.EffectiveCredentialSubjectID(p)
+		}
+		return resolved, nil
+
+	default:
+		return resolved, nil
+	}
+}
+
+func bindingSelectorOverrideError() error {
+	return fmt.Errorf("%w: workloads may not override connection or instance bindings", ErrAuthorizationDenied)
+}

--- a/gestaltd/internal/invocation/direct_tool.go
+++ b/gestaltd/internal/invocation/direct_tool.go
@@ -14,7 +14,7 @@ type directToolCaller interface {
 	CallTool(ctx context.Context, name string, args map[string]any) (*mcpgo.CallToolResult, error)
 }
 
-func CallDirectTool(ctx context.Context, resolver TokenResolver, p *principal.Principal, prov core.Provider, provName, opName, connection, instance string, args map[string]any, meta *mcpgo.Meta) (*mcpgo.CallToolResult, error) {
+func CallDirectTool(ctx context.Context, resolver TokenResolver, p *principal.Principal, prov core.Provider, provName, opName, connection, instance string, boundCredential CredentialBindingResolution, args map[string]any, meta *mcpgo.Meta) (*mcpgo.CallToolResult, error) {
 	caller, ok := prov.(directToolCaller)
 	if !ok {
 		return nil, core.ErrMCPOnly
@@ -25,7 +25,15 @@ func CallDirectTool(ctx context.Context, resolver TokenResolver, p *principal.Pr
 	if resolver != nil && prov.ConnectionMode() != core.ConnectionModeNone {
 		var token string
 		var err error
-		ctx, token, err = resolver.ResolveToken(ctx, p, provName, connection, instance)
+		if boundCredential.HasBinding {
+			if bindingResolver, ok := resolver.(bindingTokenResolver); ok {
+				ctx, token, err = bindingResolver.ResolveTokenWithBinding(ctx, p, provName, connection, instance, boundCredential)
+			} else {
+				ctx, token, err = resolver.ResolveToken(ctx, p, provName, connection, instance)
+			}
+		} else {
+			ctx, token, err = resolver.ResolveToken(ctx, p, provName, connection, instance)
+		}
 		if err != nil {
 			return nil, err
 		}

--- a/gestaltd/internal/invocation/guarded.go
+++ b/gestaltd/internal/invocation/guarded.go
@@ -183,6 +183,26 @@ func (g *GuardedInvoker) ResolveSubjectToken(ctx context.Context, prov core.Prov
 	return ctx, "", fmt.Errorf("subject token resolution not supported")
 }
 
+func (g *GuardedInvoker) ResolveEffectiveCredentialBinding(p *principal.Principal, providerName, connection, instance string) (CredentialBindingResolution, error) {
+	type resolver interface {
+		ResolveEffectiveCredentialBinding(p *principal.Principal, providerName, connection, instance string) (CredentialBindingResolution, error)
+	}
+	if r, ok := g.inner.(resolver); ok {
+		return r.ResolveEffectiveCredentialBinding(p, providerName, connection, instance)
+	}
+	return CredentialBindingResolution{}, nil
+}
+
+func (g *GuardedInvoker) ResolveTokenWithBinding(ctx context.Context, p *principal.Principal, providerName, connection, instance string, boundCredential CredentialBindingResolution) (context.Context, string, error) {
+	type resolver interface {
+		ResolveTokenWithBinding(ctx context.Context, p *principal.Principal, providerName, connection, instance string, boundCredential CredentialBindingResolution) (context.Context, string, error)
+	}
+	if r, ok := g.inner.(resolver); ok {
+		return r.ResolveTokenWithBinding(ctx, p, providerName, connection, instance, boundCredential)
+	}
+	return ctx, "", fmt.Errorf("bound token resolution not supported")
+}
+
 func (g *GuardedInvoker) logAudit(ctx context.Context, entry core.AuditEntry) {
 	if g.audit != nil {
 		g.audit.Log(ctx, entry)

--- a/gestaltd/internal/mcp/binding.go
+++ b/gestaltd/internal/mcp/binding.go
@@ -80,7 +80,7 @@ func NewServer(cfg Config) *mcpserver.MCPServer {
 		hooks.AddBeforeCallTool(func(ctx context.Context, _ any, req *mcpgo.CallToolRequest) {
 			if provName := providerNameForTool(cfg.ToolPrefixes, dynamicProviders, req.Params.Name); provName != "" {
 				instance := normalizedSessionCatalogInstance(req.GetArguments()["_instance"])
-				if workloadInstanceOverrideRequested(cfg.Authorizer, principal.FromContext(ctx), instance) {
+				if workloadInstanceOverrideRequested(cfg.Authorizer, principal.FromContext(ctx), provName, instance) {
 					return
 				}
 				hydrateSessionToolsForInstance(ctx, cfg, []string{provName}, staticToolNames, instance)

--- a/gestaltd/internal/mcp/binding_test.go
+++ b/gestaltd/internal/mcp/binding_test.go
@@ -147,6 +147,18 @@ func ctxWithWorkloadPrincipal(workloadID string) context.Context {
 	return principal.WithPrincipal(context.Background(), p)
 }
 
+func ctxWithManagedIdentityPrincipal(identityID, credentialSubjectID string, permissions principal.PermissionSet) context.Context {
+	p := &principal.Principal{
+		Kind:                principal.KindWorkload,
+		SubjectID:           principal.ManagedIdentitySubjectID(identityID),
+		CredentialSubjectID: credentialSubjectID,
+		Source:              principal.SourceAPIToken,
+		Scopes:              principal.PermissionPlugins(permissions),
+		TokenPermissions:    permissions,
+	}
+	return principal.WithPrincipal(context.Background(), p)
+}
+
 func mustAuthorizer(t *testing.T, cfg config.AuthorizationConfig, providers *registry.ProviderMap[core.Provider]) *authorization.Authorizer {
 	t.Helper()
 	authz, err := authorization.New(cfg, nil, providers, map[string]string{})
@@ -1973,6 +1985,98 @@ func TestNewServer_WorkloadCallToolRejectsInstanceOverride(t *testing.T) {
 	}
 	if sessionCatalogCalls != 0 {
 		t.Fatalf("session catalog calls = %d, want %d", sessionCatalogCalls, 0)
+	}
+}
+
+func TestNewServer_ManagedIdentityCallToolUsesConfiguredMCPConnection(t *testing.T) {
+	t.Parallel()
+
+	var sessionCatalogCalls int
+	var called bool
+	prov := &directCallerProvider{
+		StubIntegration: coretesting.StubIntegration{
+			N:        "sampledb",
+			ConnMode: core.ConnectionModeUser,
+		},
+		cat: &catalog.Catalog{
+			Name: "sampledb",
+			Operations: []catalog.CatalogOperation{
+				{
+					ID:          "run_query",
+					Description: "run a query",
+					Transport:   catalog.TransportMCPPassthrough,
+				},
+			},
+		},
+		sessionCatalogFn: func(_ context.Context, token string) (*catalog.Catalog, error) {
+			sessionCatalogCalls++
+			if token != "creator-workspace-token" {
+				t.Fatalf("session catalog token = %q, want %q", token, "creator-workspace-token")
+			}
+			return &catalog.Catalog{
+				Name: "sampledb",
+				Operations: []catalog.CatalogOperation{
+					{
+						ID:          "run_query",
+						Description: "run a query",
+						Transport:   catalog.TransportMCPPassthrough,
+					},
+				},
+			}, nil
+		},
+		callFn: func(_ context.Context, _ string, _ map[string]any) (*mcpgo.CallToolResult, error) {
+			called = true
+			return mcpgo.NewToolResultText("ok"), nil
+		},
+	}
+
+	providers := testutil.NewProviderRegistry(t, prov)
+	ds := coretesting.NewStubServices(t)
+	ctx := context.Background()
+	if err := ds.Tokens.StoreToken(ctx, &core.IntegrationToken{
+		ID:          "tok-managed-identity",
+		SubjectID:   principal.UserSubjectID("creator-user"),
+		Integration: "sampledb",
+		Connection:  "workspace",
+		Instance:    "default",
+		AccessToken: "creator-workspace-token",
+	}); err != nil {
+		t.Fatalf("StoreToken: %v", err)
+	}
+
+	authz := mustAuthorizer(t, config.AuthorizationConfig{}, providers)
+	broker := invocation.NewBroker(providers, ds.Users, ds.Tokens, invocation.WithAuthorizer(authz))
+	srv := gestaltmcp.NewServer(gestaltmcp.Config{
+		Invoker:       broker,
+		TokenResolver: broker,
+		Providers:     providers,
+		Authorizer:    authz,
+		MCPConnection: map[string]string{"sampledb": "workspace"},
+	})
+
+	permissions := principal.PermissionSet{
+		"sampledb": {"run_query": {}},
+	}
+	result := callToolForSession(
+		t,
+		srv,
+		ctxWithManagedIdentityPrincipal("ops-bot", principal.UserSubjectID("creator-user"), permissions),
+		newTestSessionWithTools(),
+		"sampledb_run_query",
+		map[string]any{"sql": "select 1"},
+	)
+	if result.IsError {
+		t.Fatalf("expected success result, got %+v", result)
+	}
+	text, ok := result.Content[0].(mcpgo.TextContent)
+	if !ok || text.Text != "ok" {
+		t.Fatalf("unexpected MCP success content: %+v", result.Content)
+	}
+	if !called {
+		t.Fatal("expected managed identity tool call to reach provider")
+	}
+	if sessionCatalogCalls != 1 {
+		t.Fatalf("session catalog calls = %d, want %d", sessionCatalogCalls, 1)
 	}
 }
 

--- a/gestaltd/internal/mcp/handlers.go
+++ b/gestaltd/internal/mcp/handlers.go
@@ -23,7 +23,7 @@ func makeHandler(cfg Config, provName, opName, connection string) mcpserver.Tool
 
 		rawArgs := req.GetArguments()
 		instance := normalizedSessionCatalogInstance(rawArgs["_instance"])
-		if workloadInstanceOverrideRequested(cfg.Authorizer, p, instance) {
+		if workloadInstanceOverrideRequested(cfg.Authorizer, p, provName, instance) {
 			return mcpgo.NewToolResultError("workload callers may not override connection or instance bindings"), nil
 		}
 		args := make(map[string]any, len(rawArgs))

--- a/gestaltd/internal/mcp/session_tools.go
+++ b/gestaltd/internal/mcp/session_tools.go
@@ -114,8 +114,11 @@ func resolveSessionToken(ctx context.Context, cfg Config, provName string, prov 
 		if cfg.TokenResolver != nil {
 			p := principal.FromContext(ctx)
 			if p != nil {
-				connection, instance := sessionTokenSelectors(cfg, p, provName, instanceOverride)
-				sessionCtx, token, err := cfg.TokenResolver.ResolveToken(ctx, p, provName, connection, instance)
+				connection, instance, boundCredential, err := sessionTokenSelectors(cfg, p, provName, instanceOverride)
+				if err != nil {
+					return ctx, "", connection, err
+				}
+				sessionCtx, token, err := resolveSessionCredentialToken(ctx, cfg, p, provName, connection, instance, boundCredential)
 				if err != nil {
 					return sessionCtx, token, connection, err
 				}
@@ -131,8 +134,11 @@ func resolveSessionToken(ctx context.Context, cfg Config, provName string, prov 
 	if p == nil {
 		return ctx, "", "", fmt.Errorf("not authenticated")
 	}
-	connection, instance := sessionTokenSelectors(cfg, p, provName, instanceOverride)
-	sessionCtx, token, err := cfg.TokenResolver.ResolveToken(ctx, p, provName, connection, instance)
+	connection, instance, boundCredential, err := sessionTokenSelectors(cfg, p, provName, instanceOverride)
+	if err != nil {
+		return ctx, "", connection, err
+	}
+	sessionCtx, token, err := resolveSessionCredentialToken(ctx, cfg, p, provName, connection, instance, boundCredential)
 	if err != nil {
 		return sessionCtx, token, connection, err
 	}
@@ -386,16 +392,29 @@ func internalSessionToolHandler(context.Context, mcpgo.CallToolRequest) (*mcpgo.
 	return mcpgo.NewToolResultError("tool not found"), nil
 }
 
-func sessionTokenSelectors(cfg Config, p *principal.Principal, provName, instanceOverride string) (string, string) {
+func resolveSessionCredentialToken(ctx context.Context, cfg Config, p *principal.Principal, provName, connection, instance string, boundCredential invocation.CredentialBindingResolution) (context.Context, string, error) {
+	type bindingTokenResolver interface {
+		ResolveTokenWithBinding(ctx context.Context, p *principal.Principal, providerName, connection, instance string, boundCredential invocation.CredentialBindingResolution) (context.Context, string, error)
+	}
+	if boundCredential.HasBinding {
+		if resolver, ok := cfg.TokenResolver.(bindingTokenResolver); ok {
+			return resolver.ResolveTokenWithBinding(ctx, p, provName, connection, instance, boundCredential)
+		}
+	}
+	return cfg.TokenResolver.ResolveToken(ctx, p, provName, connection, instance)
+}
+
+func sessionTokenSelectors(cfg Config, p *principal.Principal, provName, instanceOverride string) (string, string, invocation.CredentialBindingResolution, error) {
 	connection := cfg.MCPConnection[provName]
 	instance := normalizedSessionCatalogInstance(instanceOverride)
-	if cfg.Authorizer == nil || !cfg.Authorizer.IsWorkload(p) {
-		return connection, instance
+	boundCredential, err := invocation.ResolveEffectiveCredentialBinding(cfg.Authorizer, p, provName, connection, instance)
+	if err != nil {
+		return connection, instance, invocation.CredentialBindingResolution{}, err
 	}
-	if binding, ok := cfg.Authorizer.Binding(p, provName); ok {
-		return binding.Connection, binding.Instance
+	if boundCredential.HasBinding {
+		return boundCredential.Connection, boundCredential.Instance, boundCredential, nil
 	}
-	return connection, ""
+	return connection, instance, invocation.CredentialBindingResolution{}, nil
 }
 
 func encodeSessionCatalogMarkerSegment(value string) string {
@@ -436,6 +455,10 @@ func normalizedSessionCatalogInstance(value any) string {
 	return strings.TrimSpace(instance)
 }
 
-func workloadInstanceOverrideRequested(authz authorization.RuntimeAuthorizer, p *principal.Principal, instance string) bool {
-	return authz != nil && p != nil && authz.IsWorkload(p) && instance != ""
+func workloadInstanceOverrideRequested(authz authorization.RuntimeAuthorizer, p *principal.Principal, provider, instance string) bool {
+	if authz == nil || p == nil || strings.TrimSpace(instance) == "" {
+		return false
+	}
+	_, err := invocation.ResolveRequestedCredentialBinding(authz, p, provider, "", instance)
+	return err != nil
 }

--- a/gestaltd/internal/providerhost/plugin_invoker.go
+++ b/gestaltd/internal/providerhost/plugin_invoker.go
@@ -10,6 +10,7 @@ import (
 	proto "github.com/valon-technologies/gestalt/sdk/go/gen/v1"
 	"github.com/valon-technologies/gestalt/server/internal/config"
 	"github.com/valon-technologies/gestalt/server/internal/invocation"
+	"github.com/valon-technologies/gestalt/server/internal/principal"
 	"google.golang.org/grpc/codes"
 	"google.golang.org/grpc/status"
 )
@@ -83,6 +84,9 @@ func (s *PluginInvokerServer) Invoke(ctx context.Context, req *proto.PluginInvok
 	}
 
 	instance := strings.TrimSpace(req.GetInstance())
+	if tokenCtx.principal != nil && tokenCtx.principal.Kind == principal.KindWorkload && (connection != "" || instance != "") {
+		return nil, status.Error(codes.PermissionDenied, "workloads may not override connection or instance bindings")
+	}
 	if instance == "" && connection == "" && shouldInheritCredentialSelectors(tokenCtx.principal) {
 		instance = tokenCtx.credential.Instance
 	}

--- a/gestaltd/internal/server/catalog_resolution_test.go
+++ b/gestaltd/internal/server/catalog_resolution_test.go
@@ -98,6 +98,23 @@ func (s *stubConnectionTokenResolver) ResolveToken(ctx context.Context, _ *princ
 	return ctx, "", fmt.Errorf("unexpected connection %q", connection)
 }
 
+type stubBoundTokenResolver struct {
+	token           string
+	boundCredential invocation.CredentialBindingResolution
+	lastConnection  string
+	lastInstance    string
+}
+
+func (s *stubBoundTokenResolver) ResolveToken(ctx context.Context, _ *principal.Principal, _ string, connection, instance string) (context.Context, string, error) {
+	s.lastConnection = connection
+	s.lastInstance = instance
+	return ctx, s.token, nil
+}
+
+func (s *stubBoundTokenResolver) ResolveEffectiveCredentialBinding(_ *principal.Principal, _ string, _ string, _ string) (invocation.CredentialBindingResolution, error) {
+	return s.boundCredential, nil
+}
+
 func TestResolveCatalog_StaticCatalog(t *testing.T) {
 	t.Parallel()
 
@@ -234,6 +251,62 @@ func TestResolveCatalog_SessionAndStaticMerge(t *testing.T) {
 	}
 	if !ids["mcp_op"] {
 		t.Fatal("expected mcp_op in merged catalog")
+	}
+}
+
+func TestResolveCatalog_ModeNoneBoundPrincipalUsesEffectiveBindingSelectors(t *testing.T) {
+	t.Parallel()
+
+	prov := &stubDynamicSessionProvider{
+		stubCatalogProvider: stubCatalogProvider{
+			stubProvider: stubProvider{
+				name:     "bound-none-api",
+				connMode: core.ConnectionModeNone,
+			},
+		},
+		sessionCatFn: func(_ context.Context, token string) (*catalog.Catalog, error) {
+			if token != "bound-token" {
+				t.Fatalf("token = %q, want %q", token, "bound-token")
+			}
+			return &catalog.Catalog{
+				Name: "bound-none-api",
+				Operations: []catalog.CatalogOperation{
+					{ID: "session_only", Method: http.MethodGet},
+				},
+			}, nil
+		},
+	}
+
+	resolver := &stubBoundTokenResolver{
+		token: "bound-token",
+		boundCredential: invocation.CredentialBindingResolution{
+			HasBinding: true,
+			Binding: authorization.CredentialBinding{
+				Mode: core.ConnectionModeNone,
+			},
+		},
+	}
+
+	cat, err := invocation.ResolveCatalog(
+		context.Background(),
+		prov,
+		"bound-none-api",
+		resolver,
+		&principal.Principal{Kind: principal.KindWorkload, SubjectID: principal.WorkloadSubjectID("triage-bot")},
+		"workspace",
+		"team-a",
+	)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if resolver.lastConnection != "" {
+		t.Fatalf("resolver connection = %q, want empty", resolver.lastConnection)
+	}
+	if resolver.lastInstance != "" {
+		t.Fatalf("resolver instance = %q, want empty", resolver.lastInstance)
+	}
+	if len(cat.Operations) != 1 || cat.Operations[0].ID != "session_only" {
+		t.Fatalf("catalog operations = %+v, want session_only", cat.Operations)
 	}
 }
 

--- a/gestaltd/internal/server/handlers_tokens.go
+++ b/gestaltd/internal/server/handlers_tokens.go
@@ -181,7 +181,8 @@ func (s *Server) connectionInfosForPlugin(integration string, plugin *config.Pro
 	if plugin == nil {
 		return []connectionDefInfo{}
 	}
-	plan, err := config.BuildStaticConnectionPlan(plugin, plugin.ManifestSpec())
+	manifestSpec := plugin.ManifestSpec()
+	plan, err := config.BuildStaticConnectionPlan(plugin, manifestSpec)
 	if err != nil {
 		return []connectionDefInfo{}
 	}
@@ -192,12 +193,38 @@ func (s *Server) connectionInfosForPlugin(integration string, plugin *config.Pro
 		if !ok || shouldHidePassiveNamedConnection(plan, name, conn, integrationAuthTypes) {
 			continue
 		}
+		if name == config.PluginConnectionName {
+			conn = displayPluginConnectionDef(plugin, manifestSpec, conn)
+		}
 		if info, ok := s.connectionInfoFromAuth(integration, userFacingConnectionName(name), conn, integrationAuthTypes, defaultCredentialFields, name != config.PluginConnectionName); ok {
 			infos = append(infos, info)
 		}
 	}
 
 	return infos
+}
+
+func displayPluginConnectionDef(plugin *config.ProviderEntry, manifestSpec *providermanifestv1.Spec, conn config.ConnectionDef) config.ConnectionDef {
+	if plugin == nil || manifestSpec == nil || manifestSpec.IsManifestBacked() {
+		return conn
+	}
+	def := manifestSpec.DefaultConnectionDef()
+	if def == nil {
+		return conn
+	}
+
+	merged := config.ConnectionDef{}
+	if def.Auth != nil {
+		config.MergeConnectionAuth(&merged.Auth, config.ManifestAuthToConnectionAuthDef(def.Auth))
+	}
+	if plugin.Auth != nil {
+		config.MergeConnectionAuth(&merged.Auth, *plugin.Auth)
+	}
+	if len(merged.Auth.Credentials) == 0 {
+		return conn
+	}
+	conn.Auth = merged.Auth
+	return conn
 }
 
 func userFacingConnectionName(name string) string {

--- a/gestaltd/internal/server/server_test.go
+++ b/gestaltd/internal/server/server_test.go
@@ -6039,12 +6039,9 @@ func TestListIntegrations_ManualProvidersWithoutDeclaredCredentialsExposeGeneric
 	}
 }
 
+//nolint:paralleltest // This response-shape integration test flakes under full-package parallelism in CI.
 func TestListIntegrations_ConnectionInfosUseResolvedConnectionDefs(t *testing.T) {
-	t.Parallel()
-
 	t.Run("non manifest-backed connections still expose plugin and named auth", func(t *testing.T) {
-		t.Parallel()
-
 		stub := &coretesting.StubIntegration{N: "example", DN: "Example"}
 		plugin := &config.ProviderEntry{
 			Source: config.NewMetadataSource("https://example.invalid/github-com-acme-plugins-example/v1.0.0/provider-release.yaml"),
@@ -6195,8 +6192,6 @@ func TestListIntegrations_ConnectionInfosUseResolvedConnectionDefs(t *testing.T)
 	})
 
 	t.Run("manifest-backed API surfaces only expose the resolved named connection", func(t *testing.T) {
-		t.Parallel()
-
 		stub := &coretesting.StubIntegration{N: "example", DN: "Example"}
 		plugin := &config.ProviderEntry{
 			Source: config.NewMetadataSource("https://example.invalid/github-com-acme-plugins-example/v1.0.0/provider-release.yaml"),
@@ -17508,6 +17503,7 @@ func TestManagedIdentityAPITokenInvocation_UsesCreatorCredentialSubject(t *testi
 
 	svc := coretesting.NewStubServices(t)
 	admin := seedUser(t, svc, "admin@example.test")
+	var gammaSessionCatalogTokens []string
 
 	alphaStub := &stubIntegrationWithOps{
 		StubIntegration: coretesting.StubIntegration{
@@ -17532,20 +17528,27 @@ func TestManagedIdentityAPITokenInvocation_UsesCreatorCredentialSubject(t *testi
 		},
 		ops: []core.Operation{{Name: "query", Method: http.MethodGet}},
 	}
-	gammaStub := &stubIntegrationWithOps{
-		StubIntegration: coretesting.StubIntegration{
-			N:        "gamma",
-			ConnMode: core.ConnectionModeUser,
-			ExecuteFn: func(_ context.Context, _ string, _ map[string]any, _ string) (*core.OperationResult, error) {
-				return &core.OperationResult{Status: http.StatusOK, Body: `{"ok":true}`}, nil
+	gammaStub := &stubIntegrationWithSessionCatalog{
+		stubIntegrationWithOps: stubIntegrationWithOps{
+			StubIntegration: coretesting.StubIntegration{
+				N:        "gamma",
+				ConnMode: core.ConnectionModeUser,
+				ExecuteFn: func(_ context.Context, _ string, _ map[string]any, _ string) (*core.OperationResult, error) {
+					return &core.OperationResult{Status: http.StatusOK, Body: `{"ok":true}`}, nil
+				},
 			},
+			ops: []core.Operation{{Name: "query", Method: http.MethodGet}},
 		},
-		ops: []core.Operation{{Name: "query", Method: http.MethodGet}},
+		catalog: serverTestCatalogFromOperations("gamma", []core.Operation{{Name: "query", Method: http.MethodGet}}),
+		catalogForRequestFn: func(_ context.Context, token string) (*catalog.Catalog, error) {
+			gammaSessionCatalogTokens = append(gammaSessionCatalogTokens, token)
+			return serverTestCatalogFromOperations("gamma", []core.Operation{{Name: "query", Method: http.MethodGet}}), nil
+		},
 	}
 	providers := testutil.NewProviderRegistry(t, alphaStub, betaStub, gammaStub)
 	seedToken(t, svc, &core.IntegrationToken{
 		ID: "gamma-admin-token", SubjectID: principal.UserSubjectID(admin.ID), Integration: "gamma",
-		Connection: "", Instance: "default", AccessToken: "gamma-user-token",
+		Connection: "workspace", Instance: "default", AccessToken: "gamma-user-token",
 	})
 	authz, err := authorization.New(config.AuthorizationConfig{}, nil, providers, nil)
 	if err != nil {
@@ -17565,6 +17568,7 @@ func TestManagedIdentityAPITokenInvocation_UsesCreatorCredentialSubject(t *testi
 		cfg.Providers = providers
 		cfg.Services = svc
 		cfg.Authorizer = authz
+		cfg.DefaultConnection = map[string]string{"gamma": "workspace"}
 	})
 	testutil.CloseOnCleanup(t, ts)
 
@@ -17615,10 +17619,125 @@ func TestManagedIdentityAPITokenInvocation_UsesCreatorCredentialSubject(t *testi
 	if status := call("/api/v1/gamma/query"); status != http.StatusOK {
 		t.Fatalf("gamma/query status = %d, want 200", status)
 	}
+	if len(gammaSessionCatalogTokens) == 0 {
+		t.Fatal("expected gamma session catalog to be resolved")
+	}
+	for _, token := range gammaSessionCatalogTokens {
+		if token != "gamma-user-token" {
+			t.Fatalf("expected session catalog to use creator credential token, got %q", token)
+		}
+	}
 
 	doJSONRequestAndDecode(t, http.MethodDelete, ts.URL+"/api/v1/identities/"+createResp.ID, "admin-session", "", http.StatusOK, nil)
 	if status := call("/api/v1/alpha/read"); status != http.StatusUnauthorized {
 		t.Fatalf("alpha/read after identity delete status = %d, want 401", status)
+	}
+}
+
+func TestManagedIdentityAPITokenInvocation_MissingCreatorTokenAuditsResolvedCredentialSubject(t *testing.T) {
+	t.Parallel()
+
+	svc := coretesting.NewStubServices(t)
+	admin := seedUser(t, svc, "admin@example.test")
+	var auditBuf bytes.Buffer
+
+	gammaStub := &stubIntegrationWithOps{
+		StubIntegration: coretesting.StubIntegration{
+			N:        "gamma",
+			ConnMode: core.ConnectionModeUser,
+			ExecuteFn: func(_ context.Context, _ string, _ map[string]any, _ string) (*core.OperationResult, error) {
+				return &core.OperationResult{Status: http.StatusOK, Body: `{"ok":true}`}, nil
+			},
+		},
+		ops: []core.Operation{{Name: "query", Method: http.MethodGet}},
+	}
+	providers := testutil.NewProviderRegistry(t, gammaStub)
+	authz, err := authorization.New(config.AuthorizationConfig{}, nil, providers, nil)
+	if err != nil {
+		t.Fatalf("authorization.New: %v", err)
+	}
+	auditSink := invocation.NewSlogAuditSink(&auditBuf)
+	broker := invocation.NewBroker(providers, svc.Users, svc.Tokens, invocation.WithAuthorizer(authz))
+	guarded := invocation.NewGuarded(broker, broker, "http", auditSink, invocation.WithoutRateLimit())
+
+	ts := newTestServer(t, func(cfg *server.Config) {
+		cfg.Auth = &coretesting.StubAuthProvider{
+			N: "test",
+			ValidateTokenFn: func(_ context.Context, token string) (*core.UserIdentity, error) {
+				if token != "admin-session" {
+					return nil, fmt.Errorf("unknown session %q", token)
+				}
+				return &core.UserIdentity{Email: "admin@example.test"}, nil
+			},
+		}
+		cfg.Providers = providers
+		cfg.Services = svc
+		cfg.Authorizer = authz
+		cfg.AuditSink = auditSink
+		cfg.Invoker = guarded
+	})
+	testutil.CloseOnCleanup(t, ts)
+
+	createResp := struct {
+		ID string `json:"id"`
+	}{}
+	doJSONRequestAndDecode(t, http.MethodPost, ts.URL+"/api/v1/identities", "admin-session", `{"displayName":"Invoke Bot"}`, http.StatusCreated, &createResp)
+	doJSONRequestAndDecode(t, http.MethodPut, ts.URL+"/api/v1/identities/"+createResp.ID+"/grants/gamma", "admin-session", `{"operations":["query"]}`, http.StatusOK, nil)
+
+	createTokenResp := struct {
+		Token string `json:"token"`
+	}{}
+	doJSONRequestAndDecode(
+		t,
+		http.MethodPost,
+		ts.URL+"/api/v1/identities/"+createResp.ID+"/tokens",
+		"admin-session",
+		`{"name":"invoke-token","permissions":[{"plugin":"gamma","operations":["query"]}]}`,
+		http.StatusCreated,
+		&createTokenResp,
+	)
+	if createTokenResp.Token == "" {
+		t.Fatal("expected plaintext token for invocation test")
+	}
+
+	req, _ := http.NewRequest(http.MethodGet, ts.URL+"/api/v1/gamma/query", nil)
+	req.Header.Set("Authorization", "Bearer "+createTokenResp.Token)
+	resp, err := http.DefaultClient.Do(req)
+	if err != nil {
+		t.Fatalf("request: %v", err)
+	}
+	defer func() { _ = resp.Body.Close() }()
+	if resp.StatusCode != http.StatusPreconditionFailed {
+		body, _ := io.ReadAll(resp.Body)
+		t.Fatalf("expected 412, got %d: %s", resp.StatusCode, body)
+	}
+
+	lines := bytes.Split(bytes.TrimSpace(auditBuf.Bytes()), []byte("\n"))
+	if len(lines) == 0 {
+		t.Fatal("expected audit record")
+	}
+
+	var auditRecord map[string]any
+	for i := len(lines) - 1; i >= 0; i-- {
+		if err := json.Unmarshal(lines[i], &auditRecord); err != nil {
+			t.Fatalf("parsing audit record: %v\nraw: %s", err, auditBuf.String())
+		}
+		if auditRecord["provider"] == "gamma" && auditRecord["operation"] == "query" {
+			break
+		}
+		auditRecord = nil
+	}
+	if auditRecord == nil {
+		t.Fatalf("expected gamma.query audit record, got %s", auditBuf.String())
+	}
+	if auditRecord["subject_id"] != principal.ManagedIdentitySubjectID(createResp.ID) {
+		t.Fatalf("expected subject_id %q, got %v", principal.ManagedIdentitySubjectID(createResp.ID), auditRecord["subject_id"])
+	}
+	if auditRecord["credential_mode"] != "user" {
+		t.Fatalf("expected credential_mode user, got %v", auditRecord["credential_mode"])
+	}
+	if auditRecord["credential_subject_id"] != principal.UserSubjectID(admin.ID) {
+		t.Fatalf("expected credential_subject_id %q, got %v", principal.UserSubjectID(admin.ID), auditRecord["credential_subject_id"])
 	}
 }
 

--- a/gestaltd/internal/workflowmanager/manager.go
+++ b/gestaltd/internal/workflowmanager/manager.go
@@ -35,6 +35,14 @@ type WorkflowControl interface {
 	ResolveProviderSelection(name string) (providerName string, provider coreworkflow.Provider, err error)
 }
 
+type effectiveCredentialBindingResolver interface {
+	ResolveEffectiveCredentialBinding(p *principal.Principal, providerName, connection, instance string) (invocation.CredentialBindingResolution, error)
+}
+
+type bindingTokenResolver interface {
+	ResolveTokenWithBinding(ctx context.Context, p *principal.Principal, providerName, connection, instance string, boundCredential invocation.CredentialBindingResolution) (context.Context, string, error)
+}
+
 type Service interface {
 	ListSchedules(ctx context.Context, p *principal.Principal) ([]*ManagedSchedule, error)
 	CreateSchedule(ctx context.Context, p *principal.Principal, req ScheduleUpsert) (*ManagedSchedule, error)
@@ -467,11 +475,21 @@ func (m *Manager) resolveTarget(ctx context.Context, p *principal.Principal, tar
 	if instance != "" && !config.SafeInstanceValue(instance) {
 		return coreworkflow.Target{}, fmt.Errorf("instance name contains invalid characters")
 	}
+	if m.authorizer != nil && m.authorizer.IsWorkload(p) && (connection != "" || instance != "") {
+		return coreworkflow.Target{}, fmt.Errorf("%w: workloads may not override connection or instance bindings", invocation.ErrAuthorizationDenied)
+	}
 
 	ctx = invocation.WithAccessContext(ctx, m.providerAccessContext(ctx, p, pluginName))
 	var resolver invocation.TokenResolver
 	if tr, ok := m.invoker.(invocation.TokenResolver); ok {
 		resolver = tr
+	}
+	boundCredential := invocation.CredentialBindingResolution{}
+	if bindingResolver, ok := m.invoker.(effectiveCredentialBindingResolver); ok {
+		boundCredential, err = bindingResolver.ResolveEffectiveCredentialBinding(p, pluginName, connection, instance)
+		if err != nil {
+			return coreworkflow.Target{}, err
+		}
 	}
 	boundConnections, sessionInstance := m.catalogSelectorConfig().BoundSessionCatalogConnections(pluginName, p, connection, instance)
 	opMeta, _, resolvedConnection, err := invocation.ResolveOperation(ctx, prov, pluginName, resolver, p, operation, boundConnections, sessionInstance)
@@ -488,7 +506,15 @@ func (m *Manager) resolveTarget(ctx context.Context, p *principal.Principal, tar
 		connection = resolvedConnection
 	}
 	if resolver != nil && sessionInstance == "" {
-		resolvedCtx, _, err := resolver.ResolveToken(ctx, p, pluginName, connection, sessionInstance)
+		resolveToken := resolver.ResolveToken
+		if boundCredential.HasBinding {
+			if bindingResolver, ok := resolver.(bindingTokenResolver); ok {
+				resolveToken = func(ctx context.Context, p *principal.Principal, providerName, connection, instance string) (context.Context, string, error) {
+					return bindingResolver.ResolveTokenWithBinding(ctx, p, providerName, connection, instance, boundCredential)
+				}
+			}
+		}
+		resolvedCtx, _, err := resolveToken(ctx, p, pluginName, connection, sessionInstance)
 		if err != nil {
 			return coreworkflow.Target{}, err
 		}


### PR DESCRIPTION
## Summary

This unifies bound-principal credential resolution onto the normal subject-owned token lookup path and removes the last workload-only runtime credential branch.

The final scope is broader than the initial refactor:
- broker, catalog, HTTP, and MCP now resolve one shared effective credential binding before token lookup
- direct token lookups still use the strict requested-binding path, so explicit selector overrides remain rejected
- workload and managed-identity callers keep the old denial behavior for unbound providers / operations
- workflow schedule target resolution and plugin-host dependency invocation now reject explicit workload selector overrides too

## Risk

This is a medium runtime-risk change, not a schema or data-risk change.

Why it is risky:
- it changes shared invocation behavior across broker, MCP, HTTP, workflow manager, and plugin host
- it changes which helper decides whether a connection / instance selector is allowed
- it changes how bound credential audit metadata gets filled in on failure paths

Why it is bounded:
- no DB migration
- no persisted authz model change
- no provider API change
- the old denial semantics for unbound workloads / managed identities were preserved

## Old Interfaces

Before this PR there was no single shared binding-resolution model.
Different paths mixed raw selector handling, workload-only branches, and ordinary token lookup.

Ordinary token lookup:

```go
ResolveToken(ctx, principal, provider, connection, instance)
```

Workload-only execution path in broker:

```go
resolveWorkloadToken(ctx, principal, provider, connection, instance)
```

Implicit binding lookup from authz:

```go
authorizer.Binding(principal, provider)
```

Old behavior examples:

```go
// Bound workload execution went through a dedicated workload branch.
ctx, token, err := broker.resolveWorkloadToken(
    ctx,
    workloadPrincipal,
    "clickhouse",
    "workspace",
    "team-a",
)
```

```go
// Session-catalog and direct-tool paths separately decided whether
// empty or server-chosen selectors should be treated as overrides.
ctx, token, err := resolver.ResolveToken(
    ctx,
    workloadPrincipal,
    "clickhouse",
    "workspace",
    "team-a",
)
```

The old model worked, but the logic was split across several call sites.

## New Interfaces

Shared runtime helpers:

```go
invocation.ResolveEffectiveCredentialBinding(authz, principal, provider, connection, instance)
invocation.ResolveRequestedCredentialBinding(authz, principal, provider, connection, instance)
```

Shared result type:

```go
type CredentialBindingResolution struct {
    Binding             authorization.CredentialBinding
    HasBinding          bool
    CredentialSubjectID string
    Connection          string
    Instance            string
}
```

Binding-aware token resolution path used internally when selectors have already been resolved:

```go
ResolveTokenWithBinding(ctx, principal, provider, connection, instance, binding)
```

## Behavior

Before:
- bound workload user-mode credentials used a dedicated workload-only broker path
- session-catalog resolution depended on workload-specific empty-selector behavior
- several runtime paths re-ran selector validation after the server/runtime had already chosen the effective connection / instance

After:
- broker, catalog, server, MCP, workflow manager, and plugin host resolve the effective binding once
- bound principals then use the normal subject-owned token lookup path
- direct caller-supplied selector overrides are still rejected through `ResolveRequestedCredentialBinding(...)`
- internal server-selected selectors still work because they flow through the binding-aware token path instead of being treated as user overrides

## Examples

Strict caller-side resolution for direct token lookups:

```go
resolution, err := invocation.ResolveRequestedCredentialBinding(
    authz,
    workloadPrincipal,
    "clickhouse",
    "workspace",
    "team-b",
)
// err => authorization denied when the binding is workspace/team-a
```

Internal routing resolution for session catalogs / execution:

```go
resolution, err := invocation.ResolveEffectiveCredentialBinding(
    authz,
    workloadPrincipal,
    "clickhouse",
    "workspace",
    "team-b",
)
// resolution.Connection == "workspace"
// resolution.Instance == "team-a"
// runtime then uses normal subject-owned token lookup
```

Binding-aware internal token lookup:

```go
ctx, token, err := broker.ResolveTokenWithBinding(
    ctx,
    managedIdentityPrincipal,
    "sampledb",
    "workspace",
    "default",
    resolution,
)
// uses the creator-owned subject token without treating the
// already-resolved workspace/default selectors as caller overrides
```

Mode-none bound principal:

```go
resolution, err := invocation.ResolveEffectiveCredentialBinding(
    authz,
    workloadPrincipal,
    "sampledb",
    "workspace",
    "team-a",
)
// resolution.Connection == ""
// resolution.Instance == ""
```

## What Changed

- added shared credential-binding resolution helpers in `internal/invocation`
- removed the workload-only token-resolution branch from broker execution
- routed session-catalog resolution through the same effective-binding model
- made MCP hydration and MCP direct tool calls use the binding-aware token path
- preserved old workload denial behavior for unbound provider / operation access
- restored `ResolveAccess(...)` workload contract so it still carries policy context without becoming a provider-allow signal
- restored correct `/integrations` plugin credential-field display for non-manifest-backed plugin connections
- rejected explicit workload selector overrides in workflow schedule target resolution
- rejected explicit workload selector overrides in plugin host dependency invocation
- augmented existing broker, MCP, server, and bootstrap tests with managed-identity, workload-contract, and selector-binding regressions

## Verification

```bash
cd gestaltd && go test ./internal/server -run TestListIntegrations_ConnectionInfosUseResolvedConnectionDefs -count=1 -v
cd gestaltd && go test ./internal/bootstrap -run 'TestHybrid(DeclarativeExecutableProviderUsesNamedDefaultConnectionForPluginOperations|ExecutableProviderRoutesPluginOperationsThroughNamedSpecConnection)' -count=1 -v
cd gestaltd && golangci-lint run ./internal/config ./internal/authorization ./internal/invocation ./internal/mcp ./internal/server ./internal/bootstrap ./internal/providerhost ./internal/workflowmanager
```
