### PR TITLE
remove workload principal kind from runtime context

### DIFF
--- a/gestaltd/core/types.go
+++ b/gestaltd/core/types.go
@@ -57,8 +57,7 @@ const (
 )
 
 const (
-	APITokenKindAPI      = "api"
-	APITokenKindWorkload = "workload"
+	APITokenKindAPI = "api"
 )
 
 type ManagedIdentity struct {

--- a/gestaltd/internal/authorization/authorizer.go
+++ b/gestaltd/internal/authorization/authorizer.go
@@ -186,7 +186,7 @@ func (a *Authorizer) ResolveWorkloadToken(token string) (*principal.ResolvedWork
 }
 
 func (a *Authorizer) IsWorkload(p *principal.Principal) bool {
-	return p != nil && p.Kind == principal.KindWorkload
+	return p != nil && (p.Source == principal.SourceWorkloadToken || a.isManagedIdentityPrincipal(p))
 }
 
 func (a *Authorizer) AllowProvider(ctx context.Context, p *principal.Principal, provider string) bool {
@@ -534,7 +534,7 @@ func normalizeAllowedOperations(ops []string) map[string]struct{} {
 }
 
 func (a *Authorizer) isManagedIdentityPrincipal(p *principal.Principal) bool {
-	return a.IsWorkload(p) && principal.ManagedIdentityIDFromSubjectID(strings.TrimSpace(p.SubjectID)) != ""
+	return p != nil && principal.ManagedIdentityIDFromSubjectID(strings.TrimSpace(p.SubjectID)) != ""
 }
 
 func (a *Authorizer) allowManagedIdentityProvider(p *principal.Principal, provider string) bool {

--- a/gestaltd/internal/bootstrap/workflow_runtime.go
+++ b/gestaltd/internal/bootstrap/workflow_runtime.go
@@ -246,12 +246,17 @@ func workflowExecutionPrincipal(ref *coreworkflow.ExecutionReference) *principal
 	if ref == nil {
 		return nil
 	}
+	subjectID := strings.TrimSpace(ref.SubjectID)
 	permissions := principal.CompilePermissions(ref.Permissions)
-	return principal.Canonicalize(&principal.Principal{
-		SubjectID:        strings.TrimSpace(ref.SubjectID),
+	p := &principal.Principal{
+		SubjectID:        subjectID,
 		Scopes:           principal.PermissionPlugins(permissions),
 		TokenPermissions: permissions,
-	})
+	}
+	if strings.HasPrefix(subjectID, "workload:") {
+		p.Source = principal.SourceWorkloadToken
+	}
+	return principal.Canonicalize(p)
 }
 
 func workflowStartupPrincipal(req coreworkflow.InvokeOperationRequest) *principal.Principal {

--- a/gestaltd/internal/bootstrap/workflow_runtime_test.go
+++ b/gestaltd/internal/bootstrap/workflow_runtime_test.go
@@ -441,8 +441,11 @@ func TestWorkflowRuntimeInvokeExecutionRefUsesStoredWorkloadPrincipal(t *testing
 	if gotPrincipal == nil {
 		t.Fatal("principal = nil")
 	}
-	if gotPrincipal.Kind != principal.KindWorkload {
-		t.Fatalf("principal kind = %q, want %q", gotPrincipal.Kind, principal.KindWorkload)
+	if gotPrincipal.Kind != "" {
+		t.Fatalf("principal kind = %q, want empty", gotPrincipal.Kind)
+	}
+	if gotPrincipal.Source != principal.SourceWorkloadToken {
+		t.Fatalf("principal source = %q, want %q", gotPrincipal.Source.String(), principal.SourceWorkloadToken.String())
 	}
 	if gotPrincipal.SubjectID != principal.WorkloadSubjectID("scheduler") {
 		t.Fatalf("subjectID = %q, want %q", gotPrincipal.SubjectID, principal.WorkloadSubjectID("scheduler"))

--- a/gestaltd/internal/invocation/audit.go
+++ b/gestaltd/internal/invocation/audit.go
@@ -65,8 +65,8 @@ func buildAuditEntry(ctx context.Context, p *principal.Principal, source, provid
 		entry.UserID = p.UserID
 		entry.AuthSource = p.AuthSource()
 		entry.SubjectID = p.SubjectID
-		if p.Kind != "" {
-			entry.SubjectKind = string(p.Kind)
+		if subjectKind := p.LegacySubjectKind(); subjectKind != "" {
+			entry.SubjectKind = subjectKind
 		}
 	}
 	access := AccessContextFromContext(ctx)

--- a/gestaltd/internal/invocation/broker.go
+++ b/gestaltd/internal/invocation/broker.go
@@ -448,7 +448,7 @@ func (b *Broker) resolveToken(ctx context.Context, prov core.Provider, p *princi
 }
 
 func (b *Broker) resolveUserPrincipal(ctx context.Context, p *principal.Principal) error {
-	if p == nil || p.UserID != "" || p.Kind == principal.KindWorkload || p.Identity == nil || p.Identity.Email == "" {
+	if p == nil || p.UserID != "" || !p.HasUserContext() {
 		return nil
 	}
 	if b.users == nil {
@@ -484,7 +484,7 @@ func (b *Broker) resolveWorkloadToken(ctx context.Context, prov core.Provider, p
 	switch binding.Mode {
 	case core.ConnectionModeNone:
 		if requestedConnection != "" || requestedInstance != "" {
-			return ctx, "", fmt.Errorf("%w: workloads may not override connection or instance bindings", ErrAuthorizationDenied)
+			return ctx, "", fmt.Errorf("%w: static identity-token callers may not override connection or instance bindings", ErrAuthorizationDenied)
 		}
 		SetCredentialAudit(ctx, binding.Mode, binding.CredentialSubjectID, binding.Connection, binding.Instance)
 		ctx = WithCredentialContext(ctx, CredentialContext{
@@ -498,7 +498,7 @@ func (b *Broker) resolveWorkloadToken(ctx context.Context, prov core.Provider, p
 		connection := binding.Connection
 		instance := binding.Instance
 		if (requestedConnection != "" && requestedConnection != binding.Connection) || (requestedInstance != "" && requestedInstance != binding.Instance) {
-			return ctx, "", fmt.Errorf("%w: workloads may not override connection or instance bindings", ErrAuthorizationDenied)
+			return ctx, "", fmt.Errorf("%w: static identity-token callers may not override connection or instance bindings", ErrAuthorizationDenied)
 		}
 		subjectID := strings.TrimSpace(binding.CredentialSubjectID)
 		if subjectID == "" {
@@ -510,7 +510,7 @@ func (b *Broker) resolveWorkloadToken(ctx context.Context, prov core.Provider, p
 		SetCredentialAudit(ctx, binding.Mode, subjectID, connection, instance)
 		return b.resolveSubjectToken(ctx, prov, subjectID, providerName, connection, instance, core.ConnectionModeUser, subjectID)
 	default:
-		return ctx, "", fmt.Errorf("%w: workloads may only use credentialed or none providers", ErrAuthorizationDenied)
+		return ctx, "", fmt.Errorf("%w: static identity-token callers may only use credentialed or none providers", ErrAuthorizationDenied)
 	}
 }
 

--- a/gestaltd/internal/invocation/broker_test.go
+++ b/gestaltd/internal/invocation/broker_test.go
@@ -108,7 +108,6 @@ func TestBrokerResolveToken_WorkflowContextDoesNotBypassWorkloadIdentityBinding(
 
 	workload := &principal.Principal{
 		SubjectID: principal.WorkloadSubjectID("workflow.roadmap"),
-		Kind:      principal.KindWorkload,
 		Source:    principal.SourceWorkloadToken,
 	}
 	ctx := WithWorkflowContext(context.Background(), map[string]any{
@@ -119,7 +118,53 @@ func TestBrokerResolveToken_WorkflowContextDoesNotBypassWorkloadIdentityBinding(
 	if err == nil {
 		t.Fatal("expected binding override to be rejected")
 	}
-	if got, want := err.Error(), "workloads may not override connection or instance bindings"; got == "" || !strings.Contains(got, want) {
+	if got, want := err.Error(), "static identity-token callers may not override connection or instance bindings"; got == "" || !strings.Contains(got, want) {
+		t.Fatalf("ResolveToken error = %q, want substring %q", got, want)
+	}
+}
+
+func TestBrokerResolveToken_ManagedIdentityRejectsSelectorOverrides(t *testing.T) {
+	t.Parallel()
+
+	svc := coretesting.NewStubServices(t)
+	providers := testutil.NewProviderRegistry(t, &coretesting.StubIntegration{
+		N:        "slack",
+		ConnMode: core.ConnectionModeUser,
+	})
+	authz := mustAuthorizer(t, config.AuthorizationConfig{}, providers)
+	broker := NewBroker(providers, svc.Users, svc.Tokens, WithAuthorizer(authz))
+
+	if err := svc.Tokens.StoreToken(context.Background(), &core.IntegrationToken{
+		ID:          "managed-default",
+		SubjectID:   principal.ManagedIdentitySubjectID("managed-1"),
+		Integration: "slack",
+		Connection:  "",
+		Instance:    "default",
+		AccessToken: "managed-token",
+	}); err != nil {
+		t.Fatalf("StoreToken: %v", err)
+	}
+
+	managed := &principal.Principal{
+		SubjectID:        principal.ManagedIdentitySubjectID("managed-1"),
+		Source:           principal.SourceAPIToken,
+		Scopes:           []string{"slack"},
+		TokenPermissions: principal.PermissionsFromScopeString("slack"),
+	}
+
+	_, token, err := broker.ResolveToken(context.Background(), managed, "slack", "", "")
+	if err != nil {
+		t.Fatalf("ResolveToken without selectors: %v", err)
+	}
+	if token != "managed-token" {
+		t.Fatalf("token = %q, want %q", token, "managed-token")
+	}
+
+	_, _, err = broker.ResolveToken(context.Background(), managed, "slack", "", "default")
+	if err == nil {
+		t.Fatal("expected managed identity selector override to be rejected")
+	}
+	if got, want := err.Error(), "static identity-token callers may not override connection or instance bindings"; got == "" || !strings.Contains(got, want) {
 		t.Fatalf("ResolveToken error = %q, want substring %q", got, want)
 	}
 }

--- a/gestaltd/internal/mcp/binding_test.go
+++ b/gestaltd/internal/mcp/binding_test.go
@@ -140,7 +140,6 @@ func ctxWithIdentityPrincipal(email, userID string) context.Context {
 
 func ctxWithWorkloadPrincipal(workloadID string) context.Context {
 	p := &principal.Principal{
-		Kind:      principal.KindWorkload,
 		SubjectID: principal.WorkloadSubjectID(workloadID),
 		Source:    principal.SourceWorkloadToken,
 	}
@@ -999,7 +998,7 @@ func TestNewServer_WorkloadListToolsFiltersStaticAndSessionTools(t *testing.T) {
 		},
 		TokenResolver: &stubTokenResolver{
 			resolveFn: func(ctx context.Context, p *principal.Principal, providerName, connection, instance string) (context.Context, string, error) {
-				if p == nil || p.Kind != principal.KindWorkload {
+				if p == nil || !p.IsStaticWorkloadToken() {
 					t.Fatalf("expected workload principal, got %+v", p)
 				}
 				if providerName != "clickhouse" {
@@ -1965,7 +1964,7 @@ func TestNewServer_WorkloadCallToolRejectsInstanceOverride(t *testing.T) {
 		t.Fatalf("expected MCP error result, got %+v", result)
 	}
 	text, ok := result.Content[0].(mcpgo.TextContent)
-	if !ok || text.Text != "workload callers may not override connection or instance bindings" {
+	if !ok || text.Text != "static identity-token callers may not override connection or instance bindings" {
 		t.Fatalf("unexpected MCP error content: %+v", result.Content)
 	}
 	if called {

--- a/gestaltd/internal/mcp/handlers.go
+++ b/gestaltd/internal/mcp/handlers.go
@@ -24,7 +24,7 @@ func makeHandler(cfg Config, provName, opName, connection string) mcpserver.Tool
 		rawArgs := req.GetArguments()
 		instance := normalizedSessionCatalogInstance(rawArgs["_instance"])
 		if workloadInstanceOverrideRequested(cfg.Authorizer, p, instance) {
-			return mcpgo.NewToolResultError("workload callers may not override connection or instance bindings"), nil
+			return mcpgo.NewToolResultError("static identity-token callers may not override connection or instance bindings"), nil
 		}
 		args := make(map[string]any, len(rawArgs))
 		for key, value := range rawArgs {

--- a/gestaltd/internal/principal/principal.go
+++ b/gestaltd/internal/principal/principal.go
@@ -20,12 +20,12 @@ const (
 
 const IdentityPrincipal = "__identity__"
 const managedIdentitySubjectPrefix = "managed_identity:"
+const workloadSubjectPrefix = "workload:"
 
 type Kind string
 
 const (
-	KindUser     Kind = "user"
-	KindWorkload Kind = "workload"
+	KindUser Kind = "user"
 )
 
 type Principal struct {
@@ -82,6 +82,39 @@ func (p *Principal) AuthSource() string {
 	return p.Source.String()
 }
 
+func (p *Principal) HasUserContext() bool {
+	if p == nil {
+		return false
+	}
+	if strings.TrimSpace(p.UserID) != "" {
+		return true
+	}
+	return p.Identity != nil && strings.TrimSpace(p.Identity.Email) != ""
+}
+
+func (p *Principal) IsStaticWorkloadToken() bool {
+	return p != nil && p.Source == SourceWorkloadToken
+}
+
+func (p *Principal) LegacySubjectKind() string {
+	if p == nil {
+		return ""
+	}
+	if p.Kind != "" {
+		return string(p.Kind)
+	}
+	switch {
+	case p.IsStaticWorkloadToken(),
+		strings.HasPrefix(strings.TrimSpace(p.SubjectID), workloadSubjectPrefix),
+		ManagedIdentityIDFromSubjectID(strings.TrimSpace(p.SubjectID)) != "":
+		return "workload"
+	case p.UserID != "", p.Identity != nil, strings.HasPrefix(strings.TrimSpace(p.SubjectID), string(KindUser)+":"):
+		return string(KindUser)
+	default:
+		return ""
+	}
+}
+
 func UserSubjectID(userID string) string {
 	if userID == "" {
 		return ""
@@ -100,7 +133,7 @@ func WorkloadSubjectID(workloadID string) string {
 	if workloadID == "" {
 		return ""
 	}
-	return string(KindWorkload) + ":" + workloadID
+	return workloadSubjectPrefix + workloadID
 }
 
 func IdentitySubjectID() string {
@@ -367,14 +400,6 @@ func Canonicalize(p *Principal) *Principal {
 			if p.Kind == "" {
 				p.Kind = KindUser
 			}
-		}
-	}
-	if p.Kind == "" {
-		switch {
-		case strings.HasPrefix(p.SubjectID, string(KindWorkload)+":"),
-			ManagedIdentityIDFromSubjectID(p.SubjectID) != "",
-			p.SubjectID == IdentitySubjectID():
-			p.Kind = KindWorkload
 		}
 	}
 	if p.SubjectID == "" && p.UserID != "" {

--- a/gestaltd/internal/principal/resolver.go
+++ b/gestaltd/internal/principal/resolver.go
@@ -205,7 +205,6 @@ func (r *Resolver) resolveManagedIdentityAPIToken(ctx context.Context, apiToken 
 		SubjectID:           ManagedIdentitySubjectID(identity.ID),
 		CredentialSubjectID: apiToken.CredentialSubjectID,
 		DisplayName:         identity.DisplayName,
-		Kind:                KindWorkload,
 		Source:              SourceAPIToken,
 		Scopes:              PermissionPlugins(effectivePerms),
 		TokenPermissions:    effectivePerms,
@@ -221,7 +220,6 @@ func (r *Resolver) resolveWorkloadToken(token string) (*Principal, error) {
 		return nil, ErrInvalidToken
 	}
 	return &Principal{
-		Kind:        KindWorkload,
 		SubjectID:   WorkloadSubjectID(workload.ID),
 		DisplayName: workload.DisplayName,
 		Source:      SourceWorkloadToken,

--- a/gestaltd/internal/providerhost/provider_client.go
+++ b/gestaltd/internal/providerhost/provider_client.go
@@ -4,7 +4,6 @@ import (
 	"context"
 	"fmt"
 	"io"
-	"strings"
 	"time"
 
 	"github.com/google/uuid"
@@ -336,19 +335,7 @@ func subjectKindForPrincipal(p *principal.Principal) string {
 	if p == nil {
 		return ""
 	}
-	if p.Kind != "" {
-		return string(p.Kind)
-	}
-	switch {
-	case strings.HasPrefix(p.SubjectID, string(principal.KindUser)+":"):
-		return string(principal.KindUser)
-	case strings.HasPrefix(p.SubjectID, string(principal.KindWorkload)+":"):
-		return string(principal.KindWorkload)
-	}
-	if p.UserID != "" || p.Identity != nil {
-		return string(principal.KindUser)
-	}
-	return ""
+	return p.LegacySubjectKind()
 }
 
 func subjectDisplayName(p *principal.Principal) string {

--- a/gestaltd/internal/providerhost/provider_server.go
+++ b/gestaltd/internal/providerhost/provider_server.go
@@ -112,16 +112,15 @@ func principalFromProto(subject *proto.SubjectContext) *principal.Principal {
 	switch subject.GetKind() {
 	case string(principal.KindUser):
 		p.Kind = principal.KindUser
-	case string(principal.KindWorkload):
-		p.Kind = principal.KindWorkload
+	case "workload":
+		// Backward-compatible read of older snapshots. Current runtimes should
+		// rely on subject ID and auth source instead of a workload kind.
 	}
 	if strings.HasPrefix(subject.GetId(), "user:") {
 		p.UserID = strings.TrimPrefix(subject.GetId(), "user:")
 		if p.Kind == "" {
 			p.Kind = principal.KindUser
 		}
-	} else if strings.HasPrefix(subject.GetId(), "workload:") && p.Kind == "" {
-		p.Kind = principal.KindWorkload
 	}
 	if p.Kind == principal.KindUser && subject.GetDisplayName() != "" {
 		p.Identity = &core.UserIdentity{

--- a/gestaltd/internal/providerhost/provider_test.go
+++ b/gestaltd/internal/providerhost/provider_test.go
@@ -212,11 +212,10 @@ func TestRemoteProviderRoundTrip(t *testing.T) {
 			principal: &principal.Principal{
 				SubjectID:   principal.WorkloadSubjectID("triage-bot"),
 				DisplayName: "Triage Bot",
-				Kind:        principal.KindWorkload,
 				Source:      principal.SourceWorkloadToken,
 			},
-			wantExecuteBody:    "echo|secret-token|hi|acme|workload:triage-bot|workload|Triage Bot|false|workload_token|user|workload:triage-bot|roadmap|admin",
-			wantSessionCatalog: "token-123|workload:triage-bot|workload|Triage Bot|false|workload_token|user|roadmap|admin",
+			wantExecuteBody:    "echo|secret-token|hi|acme|workload:triage-bot||Triage Bot|false|workload_token|user|workload:triage-bot|roadmap|admin",
+			wantSessionCatalog: "token-123|workload:triage-bot||Triage Bot|false|workload_token|user|roadmap|admin",
 		},
 	}
 
@@ -291,7 +290,6 @@ func TestRequestContextProto_PreservesWorkloadDisplayName(t *testing.T) {
 	ctx := principal.WithPrincipal(context.Background(), &principal.Principal{
 		SubjectID:   principal.WorkloadSubjectID("triage-bot"),
 		DisplayName: "Triage Bot",
-		Kind:        principal.KindWorkload,
 		Source:      principal.SourceWorkloadToken,
 	})
 	ctx = invocation.WithAccessContext(ctx, invocation.AccessContext{
@@ -309,8 +307,77 @@ func TestRequestContextProto_PreservesWorkloadDisplayName(t *testing.T) {
 	if got := reqCtx.GetSubject().GetDisplayName(); got != "Triage Bot" {
 		t.Fatalf("subject display name = %q, want %q", got, "Triage Bot")
 	}
+	if got := reqCtx.GetSubject().GetKind(); got != "workload" {
+		t.Fatalf("subject kind = %q, want %q", got, "workload")
+	}
 	if reqCtx.GetAccess() == nil || reqCtx.GetAccess().GetPolicy() != "roadmap" || reqCtx.GetAccess().GetRole() != "viewer" {
 		t.Fatalf("unexpected access context: %#v", reqCtx.GetAccess())
+	}
+}
+
+func TestRequestContextProto_PreservesManagedIdentityLegacyKind(t *testing.T) {
+	t.Parallel()
+
+	ctx := principal.WithPrincipal(context.Background(), &principal.Principal{
+		SubjectID:   principal.ManagedIdentitySubjectID("managed-1"),
+		DisplayName: "Deploy Bot",
+		Source:      principal.SourceAPIToken,
+	})
+
+	reqCtx, err := requestContextProto(ctx)
+	if err != nil {
+		t.Fatalf("requestContextProto: %v", err)
+	}
+	if reqCtx == nil || reqCtx.GetSubject() == nil {
+		t.Fatal("expected request subject context")
+	}
+	if got := reqCtx.GetSubject().GetKind(); got != "workload" {
+		t.Fatalf("subject kind = %q, want %q", got, "workload")
+	}
+}
+
+func TestRestoreRequestSnapshotContext_InheritsSelectorsForHeadlessNonWorkloadPrincipals(t *testing.T) {
+	t.Parallel()
+
+	cases := []struct {
+		name      string
+		principal *principal.Principal
+		wantConn  string
+	}{
+		{
+			name:      "managed identity",
+			principal: &principal.Principal{SubjectID: principal.ManagedIdentitySubjectID("managed-1"), Source: principal.SourceAPIToken},
+			wantConn:  "workspace",
+		},
+		{
+			name:      "system principal",
+			principal: &principal.Principal{SubjectID: "system:workflow-startup"},
+			wantConn:  "workspace",
+		},
+		{
+			name:      "static workload token",
+			principal: &principal.Principal{SubjectID: principal.WorkloadSubjectID("triage-bot"), Source: principal.SourceWorkloadToken},
+			wantConn:  "",
+		},
+	}
+
+	for _, tc := range cases {
+		tc := tc
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+
+			ctx := restoreRequestSnapshotContext(context.Background(), requestSnapshot{
+				principal: tc.principal,
+				credential: invocation.CredentialContext{
+					Connection: "workspace",
+					Instance:   "team-a",
+				},
+			}, "")
+
+			if got := invocation.ConnectionFromContext(ctx); got != tc.wantConn {
+				t.Fatalf("connection = %q, want %q", got, tc.wantConn)
+			}
+		})
 	}
 }
 
@@ -346,7 +413,7 @@ func TestPrincipalFromProto_WorkloadDisplayNameDoesNotCreateIdentity(t *testing.
 
 	p := principalFromProto(&proto.SubjectContext{
 		Id:          principal.WorkloadSubjectID("triage-bot"),
-		Kind:        string(principal.KindWorkload),
+		Kind:        "workload",
 		DisplayName: "Triage Bot",
 		AuthSource:  principal.SourceWorkloadToken.String(),
 	})

--- a/gestaltd/internal/providerhost/request_snapshot.go
+++ b/gestaltd/internal/providerhost/request_snapshot.go
@@ -172,5 +172,5 @@ func restoreRequestSnapshotContext(ctx context.Context, snapshot requestSnapshot
 }
 
 func shouldInheritCredentialSelectors(snapshot requestSnapshot) bool {
-	return snapshot.principal == nil || snapshot.principal.Kind != principal.KindWorkload
+	return snapshot.principal == nil || !snapshot.principal.IsStaticWorkloadToken()
 }

--- a/gestaltd/internal/server/audit.go
+++ b/gestaltd/internal/server/audit.go
@@ -40,13 +40,10 @@ func (s *Server) resolvePrincipalUserID(ctx context.Context, p *principal.Princi
 	if p == nil {
 		return nil, nil
 	}
-	if p.Kind == principal.KindWorkload {
+	if !p.HasUserContext() {
 		return p, nil
 	}
 	if p.UserID != "" {
-		return p, nil
-	}
-	if p.Identity == nil || p.Identity.Email == "" {
 		return p, nil
 	}
 

--- a/gestaltd/internal/server/authorization.go
+++ b/gestaltd/internal/server/authorization.go
@@ -41,7 +41,7 @@ func (s *Server) workloadBinding(p *principal.Principal, provider string) (autho
 }
 
 func rejectWorkloadSelectors(w http.ResponseWriter, p *principal.Principal, connection, instance string) error {
-	if p == nil || p.Kind != principal.KindWorkload {
+	if p == nil || !p.IsStaticWorkloadToken() {
 		return nil
 	}
 	if connection == "" && instance == "" {

--- a/gestaltd/internal/server/catalog_resolution_test.go
+++ b/gestaltd/internal/server/catalog_resolution_test.go
@@ -541,8 +541,8 @@ func TestFilterCatalogForPrincipal_WorkloadFilteringUsesMergedCatalog(t *testing
 	}
 
 	p := &principal.Principal{
-		Kind:      principal.KindWorkload,
 		SubjectID: principal.WorkloadSubjectID("triage-bot"),
+		Source:    principal.SourceWorkloadToken,
 	}
 	cat, err := invocation.ResolveCatalog(context.Background(), prov, "clash-api", &stubTokenResolver{token: "tok_456"}, p, "default", "")
 	if err != nil {

--- a/gestaltd/internal/server/handlers.go
+++ b/gestaltd/internal/server/handlers.go
@@ -41,9 +41,9 @@ const defaultSessionCookieTTL = 24 * time.Hour
 var (
 	errNotAuthenticated  = errors.New("not authenticated")
 	errResolveUser       = errors.New("failed to resolve user")
-	errWorkloadForbidden = errors.New("workload callers are not allowed on this route")
+	errWorkloadForbidden = errors.New("headless callers are not allowed on this route")
 	errOperationAccess   = errors.New("operation access denied")
-	errWorkloadSelector  = errors.New("workload callers may not override connection or instance bindings")
+	errWorkloadSelector  = errors.New("static identity-token callers may not override connection or instance bindings")
 )
 
 var (
@@ -90,8 +90,8 @@ type connectionParamInfo struct {
 }
 
 func (s *Server) resolveUserID(w http.ResponseWriter, r *http.Request) (string, error) {
-	if p := PrincipalFromContext(r.Context()); p != nil && p.Kind == principal.KindWorkload {
-		writeError(w, http.StatusForbidden, "workload callers are not allowed on this route")
+	if p := PrincipalFromContext(r.Context()); p != nil && !p.HasUserContext() {
+		writeError(w, http.StatusForbidden, errWorkloadForbidden.Error())
 		return "", errWorkloadForbidden
 	}
 	user := UserFromContext(r.Context())
@@ -127,7 +127,7 @@ func (s *Server) readinessCheck(w http.ResponseWriter, _ *http.Request) {
 func (s *Server) listIntegrations(w http.ResponseWriter, r *http.Request) {
 	p := PrincipalFromContext(r.Context())
 	connected := map[string][]instanceInfo{}
-	if p == nil || p.Kind != principal.KindWorkload {
+	if p == nil || p.HasUserContext() {
 		var err error
 		connected, err = s.userConnectedIntegrations(r)
 		if err != nil {
@@ -164,7 +164,7 @@ func (s *Server) listIntegrations(w http.ResponseWriter, r *http.Request) {
 		if entry, ok := s.pluginDefs[name]; ok && entry != nil {
 			info.MountedPath = strings.TrimSpace(entry.MountPath)
 		}
-		if p != nil && p.Kind == principal.KindWorkload {
+		if p != nil && !p.HasUserContext() {
 			if binding, ok := s.workloadBinding(p, name); ok {
 				bindingConnected, err := s.workloadBindingConnected(r.Context(), binding, name)
 				if err != nil {

--- a/gestaltd/internal/server/handlers_admin_authorization.go
+++ b/gestaltd/internal/server/handlers_admin_authorization.go
@@ -78,8 +78,8 @@ func (s *Server) adminAPIAuthMiddleware(next http.Handler) http.Handler {
 			writeError(w, http.StatusUnauthorized, "missing authorization")
 			return
 		}
-		if p.Kind == principal.KindWorkload {
-			writeError(w, http.StatusForbidden, "workload callers are not allowed on this route")
+		if !p.HasUserContext() {
+			writeError(w, http.StatusForbidden, errWorkloadForbidden.Error())
 			return
 		}
 

--- a/gestaltd/internal/server/handlers_auth.go
+++ b/gestaltd/internal/server/handlers_auth.go
@@ -573,9 +573,9 @@ func (s *Server) logout(w http.ResponseWriter, r *http.Request) {
 	defer func() {
 		s.auditHTTPEvent(r.Context(), auditPrincipal, s.authProviderName(), "auth.logout", auditAllowed, auditErr)
 	}()
-	if auditPrincipal != nil && auditPrincipal.Kind == principal.KindWorkload {
+	if auditPrincipal != nil && !auditPrincipal.HasUserContext() {
 		auditErr = errWorkloadForbidden
-		writeError(w, http.StatusForbidden, "workload callers are not allowed on this route")
+		writeError(w, http.StatusForbidden, errWorkloadForbidden.Error())
 		return
 	}
 

--- a/gestaltd/internal/server/handlers_connect.go
+++ b/gestaltd/internal/server/handlers_connect.go
@@ -38,9 +38,9 @@ func (s *Server) connectManual(w http.ResponseWriter, r *http.Request) {
 		metricutil.RecordConnectionAuthMetrics(r.Context(), startedAt, metricProviderName, "manual", "complete", connectionMode, auditErr != nil)
 		s.auditHTTPEventWithTarget(r.Context(), PrincipalFromContext(r.Context()), providerName, "connection.manual.connect", auditAllowed, auditErr, auditTarget)
 	}()
-	if p := PrincipalFromContext(r.Context()); p != nil && p.Kind == principal.KindWorkload {
+	if p := PrincipalFromContext(r.Context()); p != nil && !p.HasUserContext() {
 		auditErr = errWorkloadForbidden
-		writeError(w, http.StatusForbidden, "workload callers are not allowed on this route")
+		writeError(w, http.StatusForbidden, errWorkloadForbidden.Error())
 		return
 	}
 

--- a/gestaltd/internal/server/handlers_identities.go
+++ b/gestaltd/internal/server/handlers_identities.go
@@ -1112,7 +1112,7 @@ func (s *Server) managedIdentityGrantCatalogTargets(ctx context.Context, plugin 
 			subjectID = principal.UserSubjectID(p.UserID)
 		}
 	}
-	if p == nil || p.Kind == principal.KindWorkload || subjectID == "" {
+	if p == nil || !p.HasUserContext() || subjectID == "" {
 		if len(targets) == 0 {
 			addTarget("", "")
 		}

--- a/gestaltd/internal/server/handlers_oauth.go
+++ b/gestaltd/internal/server/handlers_oauth.go
@@ -13,7 +13,6 @@ import (
 	"github.com/valon-technologies/gestalt/server/internal/metricutil"
 	"github.com/valon-technologies/gestalt/server/internal/oauth"
 	"github.com/valon-technologies/gestalt/server/internal/paraminterp"
-	"github.com/valon-technologies/gestalt/server/internal/principal"
 )
 
 type startOAuthRequest struct {
@@ -36,9 +35,9 @@ func (s *Server) startIntegrationOAuth(w http.ResponseWriter, r *http.Request) {
 		metricutil.RecordConnectionAuthMetrics(r.Context(), startedAt, metricProviderName, "oauth", "start", connectionMode, auditErr != nil)
 		s.auditHTTPEventWithTarget(r.Context(), PrincipalFromContext(r.Context()), providerName, "connection.oauth.start", auditAllowed, auditErr, auditTarget)
 	}()
-	if p := PrincipalFromContext(r.Context()); p != nil && p.Kind == principal.KindWorkload {
+	if p := PrincipalFromContext(r.Context()); p != nil && !p.HasUserContext() {
 		auditErr = errWorkloadForbidden
-		writeError(w, http.StatusForbidden, "workload callers are not allowed on this route")
+		writeError(w, http.StatusForbidden, errWorkloadForbidden.Error())
 		return
 	}
 

--- a/gestaltd/internal/server/integration_visibility.go
+++ b/gestaltd/internal/server/integration_visibility.go
@@ -20,7 +20,7 @@ func (s *Server) integrationHasUsableSurfaceContext(ctx context.Context, p *prin
 }
 
 func (s *Server) integrationHasSettingsSurface(p *principal.Principal, info integrationInfo) bool {
-	if p != nil && p.Kind == principal.KindWorkload {
+	if p != nil && !p.HasUserContext() {
 		return false
 	}
 	return info.Connected || len(info.AuthTypes) > 0 || len(info.Connections) > 0
@@ -69,7 +69,7 @@ func (s *Server) mountedWebUIRootAccessibleContext(ctx context.Context, p *princ
 	if mounted.AuthorizationPolicy == "" {
 		return true
 	}
-	if s.authorizer == nil || p == nil || p.Kind == principal.KindWorkload {
+	if s.authorizer == nil || p == nil || !p.HasUserContext() {
 		return false
 	}
 

--- a/gestaltd/internal/server/middleware.go
+++ b/gestaltd/internal/server/middleware.go
@@ -133,10 +133,10 @@ func (s *Server) resolveRequestPrincipalWithResolver(r *http.Request, resolver *
 
 	if c, err := r.Cookie(sessionCookieName); err == nil && c.Value != "" {
 		p, err := resolver.ResolveToken(r.Context(), c.Value)
-		if p != nil && p.Kind != principal.KindWorkload {
+		if p != nil && p.HasUserContext() {
 			return p, nil
 		}
-		if p != nil && p.Kind == principal.KindWorkload {
+		if p != nil && !p.HasUserContext() {
 			lastErr = principal.ErrInvalidToken
 		} else {
 			lastErr = err

--- a/gestaltd/internal/server/mounted_ui.go
+++ b/gestaltd/internal/server/mounted_ui.go
@@ -315,8 +315,8 @@ func (s *Server) authorizeProtectedUIRequest(w http.ResponseWriter, r *http.Requ
 		}
 		return nil, false
 	}
-	if p != nil && p.Kind == principal.KindWorkload {
-		writeError(w, http.StatusForbidden, "workload callers are not allowed on this route")
+	if p != nil && !p.HasUserContext() {
+		writeError(w, http.StatusForbidden, errWorkloadForbidden.Error())
 		return nil, false
 	}
 

--- a/gestaltd/internal/server/pending_connection.go
+++ b/gestaltd/internal/server/pending_connection.go
@@ -257,7 +257,7 @@ func (s *Server) resolvePendingConnectionUserID(r *http.Request) (string, bool, 
 	if p == nil {
 		return "", false, nil
 	}
-	if p.Kind == principal.KindWorkload {
+	if !p.HasUserContext() {
 		return "", true, errWorkloadForbidden
 	}
 	subjectID := strings.TrimSpace(p.SubjectID)
@@ -295,7 +295,7 @@ func (s *Server) authorizePendingConnection(w http.ResponseWriter, r *http.Reque
 	subjectID, authenticated, err := s.resolvePendingConnectionUserID(r)
 	if err != nil {
 		if errors.Is(err, errWorkloadForbidden) {
-			writeError(w, http.StatusForbidden, "workload callers are not allowed on this route")
+			writeError(w, http.StatusForbidden, errWorkloadForbidden.Error())
 			return false
 		}
 		if errors.Is(err, principal.ErrInvalidToken) {

--- a/gestaltd/internal/server/server_test.go
+++ b/gestaltd/internal/server/server_test.go
@@ -5656,7 +5656,7 @@ func TestWorkloadAuthorization_ListOperationsFiltersAndRejectsSelectors(t *testi
 	if auditRecord["subject_id"] != "workload:triage-bot" {
 		t.Fatalf("expected workload subject_id, got %v", auditRecord["subject_id"])
 	}
-	if auditRecord["error"] != "workload callers may not override connection or instance bindings" {
+	if auditRecord["error"] != "static identity-token callers may not override connection or instance bindings" {
 		t.Fatalf("unexpected audit error: %v", auditRecord["error"])
 	}
 
@@ -8870,7 +8870,7 @@ func TestWorkloadAuthorization_ExecuteOperation_UsesBoundIdentityAndRejectsSelec
 	if selectorAudit["subject_id"] != "workload:triage-bot" {
 		t.Fatalf("expected selector audit subject_id workload:triage-bot, got %v", selectorAudit["subject_id"])
 	}
-	if selectorAudit["error"] != "workload callers may not override connection or instance bindings" {
+	if selectorAudit["error"] != "static identity-token callers may not override connection or instance bindings" {
 		t.Fatalf("unexpected selector audit error: %v", selectorAudit["error"])
 	}
 }


### PR DESCRIPTION
## Summary

This is the narrower rebuild of the old workload-removal branch.

It does **not** rename the workload feature, remove `authorization.workloads`, or change `gst_wld_...` tokens. Instead, it removes the special internal `kind=workload` runtime path and treats workload-token callers as ordinary headless callers identified by `auth_source=workload_token` and `subject_id=workload:<id>`.

The compatibility boundary is preserved deliberately:
- runtime authorization/binding checks stop depending on `principal.KindWorkload`
- workflow execution refs still round-trip back into `SourceWorkloadToken`
- providerhost and audit still serialize `workload` kind for existing external consumers

## Old interfaces

### Old YAML

```yaml
authorization:
  workloads:
    triage-bot:
      token: gst_wld_triage-bot-token
      providers:
        clickhouse:
          connection: workspace
          instance: team-a
          allow:
            - run_query
```

### Old Go / runtime examples

```go
p := &principal.Principal{
    Kind:      principal.KindWorkload,
    SubjectID: principal.WorkloadSubjectID("triage-bot"),
    Source:    principal.SourceWorkloadToken,
}
```

```go
if p.Kind == principal.KindWorkload {
    // reject human-only route
}
```

Stored workflow refs also implicitly depended on workload kind being re-derived later:

```go
ref := &workflow.ExecutionReference{
    SubjectID: principal.WorkloadSubjectID("triage-bot"),
}
// later rebuilt into a workload principal via canonicalization side effects
```

External payloads could carry workload kind:

```json
{
  "subject_id": "workload:triage-bot",
  "subject_kind": "workload",
  "auth_source": "workload_token"
}
```

## New interfaces

### New YAML

```yaml
authorization:
  workloads:
    triage-bot:
      token: gst_wld_triage-bot-token
      providers:
        clickhouse:
          connection: workspace
          instance: team-a
          allow:
            - run_query
```

YAML is intentionally unchanged in this PR.

### New Go / runtime examples

```go
p := &principal.Principal{
    SubjectID: principal.WorkloadSubjectID("triage-bot"),
    Source:    principal.SourceWorkloadToken,
}
```

```go
if p != nil && !p.HasUserContext() {
    // reject human-only route
}
```

```go
if p != nil && p.IsStaticWorkloadToken() {
    // enforce bound connection / instance rules
}
```

Stored workflow refs now rebuild workload-token callers explicitly from `SubjectID` instead of depending on a special principal kind:

```go
ref := &workflow.ExecutionReference{
    SubjectID: principal.WorkloadSubjectID("triage-bot"),
}
// rebuilt principal gets SourceWorkloadToken so binding/allowlist enforcement still runs
```

External compatibility stays stable:

```json
{
  "subject_id": "workload:triage-bot",
  "subject_kind": "workload",
  "auth_source": "workload_token"
}
```

## What changed

- removed `principal.KindWorkload` from runtime context
- stopped canonicalizing workload callers into a special principal kind
- changed workload detection to key off `SourceWorkloadToken` only where static token binding rules actually require it
- changed human-only route/UI gating to use `HasUserContext()` instead of `kind=workload`
- preserved workflow execution-ref round-tripping by restoring `SourceWorkloadToken` from stored `workload:<id>` subject IDs
- preserved providerhost request-context compatibility by continuing to serialize `kind="workload"` on the wire
- preserved audit compatibility by continuing to emit `subject_kind=workload` for workload-token callers

## Compatibility

- `authorization.workloads` is unchanged
- `gst_wld_...` tokens are unchanged
- `workload:<id>` subject IDs are unchanged
- `auth_source=workload_token` is unchanged
- providerhost still writes and reads `kind="workload"` on the wire for compatibility
- audit still emits `subject_kind=workload` for workload-token callers

## Validation

```bash
go test ./internal/server -run 'TestAuditMetadata_WorkloadSubjectAndCredentialPath|TestAuthMiddleware_ValidWorkloadToken|TestWorkloadAuthorization_ListIntegrationsFiltersAndHidesConnectionAffordances|TestWorkloadAuthorization_ListOperationsFiltersAndRejectsSelectors|TestWorkloadAuthorization_ExecuteOperation_UsesBoundIdentityAndRejectsSelectors|TestWorkloadAuthorization_ExecuteOperation_MissingBoundIdentityTokenReturns412|TestWorkloadAuthorization_HumanRoutesReturn403|TestManagedIdentityTokens_RoleMatrix|TestMountedWebUIRoutes_HumanAuthorization|TestMCPEndpoint_WorkloadAuthorizationAndAudit' -count=1

go test ./internal/mcp -run 'TestNewServer_WorkloadCallToolDeniedReturnsErrorResult|TestNewServer_WorkloadCallToolDeniedForUnboundSessionOnlyProvider|TestNewServer_WorkloadCallToolUsesBoundConnectionForSessionOnlyProvider|TestNewServer_WorkloadCallToolRejectsInstanceOverride' -count=1

go test ./internal/providerhost ./internal/bootstrap ./internal/invocation -run 'TestRemoteProviderRoundTrip|TestRequestContextProto_PreservesWorkloadDisplayName|TestPrincipalFromProto_WorkloadDisplayNameDoesNotCreateIdentity|TestWorkflowRuntimeInvokeExecutionRefUsesStoredWorkloadPrincipal|TestWorkflowRuntimeInvokeExecutionRefRechecksAuthorizationThroughBroker|TestBootstrapWorkloadAuthorizationRejectsEitherProvider|TestBrokerResolveToken_WorkflowContextDoesNotBypassWorkloadIdentityBinding' -count=1

go test ./... -run '^$'

golangci-lint run
```