### PR TITLE
Add global workflow run inspection

### DIFF
--- a/gestalt/cli/src/cli.rs
+++ b/gestalt/cli/src/cli.rs
@@ -374,6 +374,11 @@ pub enum WorkflowCommands {
         #[command(subcommand)]
         command: WorkflowScheduleCommands,
     },
+    /// Inspect workflow runs
+    Runs {
+        #[command(subcommand)]
+        command: WorkflowRunCommands,
+    },
 }
 
 #[derive(Subcommand)]
@@ -406,6 +411,24 @@ pub enum WorkflowScheduleCommands {
     /// Resume a paused workflow schedule
     Resume {
         /// Schedule ID
+        id: String,
+    },
+}
+
+#[derive(Subcommand)]
+pub enum WorkflowRunCommands {
+    /// List workflow runs
+    List {
+        /// Filter runs by target plugin
+        #[arg(long)]
+        plugin: Option<String>,
+        /// Filter runs by status
+        #[arg(long)]
+        status: Option<String>,
+    },
+    /// Show a single workflow run
+    Get {
+        /// Run ID
         id: String,
     },
 }

--- a/gestalt/cli/src/commands/workflows.rs
+++ b/gestalt/cli/src/commands/workflows.rs
@@ -7,6 +7,7 @@ use crate::output::{self, Format};
 use crate::params::{self, ParamEntry};
 
 const SCHEDULES_PATH: &str = "/api/v1/workflow/schedules";
+const RUNS_PATH: &str = "/api/v1/workflow/runs";
 
 pub fn list(client: &ApiClient, plugin: Option<&str>, format: Format) -> Result<()> {
     let resp = client
@@ -85,6 +86,28 @@ pub fn resume(client: &ApiClient, id: &str, format: Format) -> Result<()> {
     Ok(())
 }
 
+pub fn list_runs(
+    client: &ApiClient,
+    plugin: Option<&str>,
+    status: Option<&str>,
+    format: Format,
+) -> Result<()> {
+    let resp = client
+        .get(RUNS_PATH)
+        .context("failed to list workflow runs")?;
+    let filtered = filter_runs(resp, plugin, status);
+    print_runs(&filtered, format);
+    Ok(())
+}
+
+pub fn get_run(client: &ApiClient, id: &str, format: Format) -> Result<()> {
+    let resp = client
+        .get(&format!("{RUNS_PATH}/{id}"))
+        .with_context(|| format!("failed to get workflow run {id}"))?;
+    print_run(&resp, format);
+    Ok(())
+}
+
 fn filter_by_plugin(value: Value, plugin: Option<&str>) -> Value {
     let Some(plugin) = plugin else {
         return value;
@@ -96,6 +119,25 @@ fn filter_by_plugin(value: Value, plugin: Option<&str>) -> Value {
         items
             .into_iter()
             .filter(|item| item["target"]["plugin"].as_str() == Some(plugin))
+            .collect(),
+    )
+}
+
+fn filter_runs(value: Value, plugin: Option<&str>, status: Option<&str>) -> Value {
+    let Value::Array(items) = value else {
+        return value;
+    };
+    Value::Array(
+        items
+            .into_iter()
+            .filter(|item| {
+                plugin
+                    .map(|plugin| item["target"]["plugin"].as_str() == Some(plugin))
+                    .unwrap_or(true)
+                    && status
+                        .map(|status| item["status"].as_str() == Some(status))
+                        .unwrap_or(true)
+            })
             .collect(),
     )
 }
@@ -257,6 +299,27 @@ fn print_schedules(value: &Value, format: Format) {
     }
 }
 
+fn print_run(value: &Value, format: Format) {
+    match format {
+        Format::Json => output::print_json(value),
+        Format::Table => {
+            let rows = vec![run_row(value)];
+            output::print_table(&run_headers(), &rows);
+        }
+    }
+}
+
+fn print_runs(value: &Value, format: Format) {
+    match format {
+        Format::Json => output::print_json(value),
+        Format::Table => {
+            let items = value.as_array().cloned().unwrap_or_default();
+            let rows: Vec<Vec<String>> = items.iter().map(run_row).collect();
+            output::print_table(&run_headers(), &rows);
+        }
+    }
+}
+
 fn schedule_headers() -> [&'static str; 8] {
     [
         "ID",
@@ -287,6 +350,57 @@ fn schedule_row(value: &Value) -> Vec<String> {
         value["nextRunAt"].as_str().unwrap_or("-").to_string(),
         value["createdAt"].as_str().unwrap_or("-").to_string(),
     ]
+}
+
+fn run_headers() -> [&'static str; 7] {
+    [
+        "ID",
+        "Plugin",
+        "Operation",
+        "Status",
+        "Trigger",
+        "Started",
+        "Created",
+    ]
+}
+
+fn run_row(value: &Value) -> Vec<String> {
+    vec![
+        value["id"].as_str().unwrap_or("-").to_string(),
+        value["target"]["plugin"]
+            .as_str()
+            .unwrap_or("-")
+            .to_string(),
+        value["target"]["operation"]
+            .as_str()
+            .unwrap_or("-")
+            .to_string(),
+        value["status"].as_str().unwrap_or("-").to_string(),
+        run_trigger_label(value),
+        value["startedAt"]
+            .as_str()
+            .or_else(|| value["completedAt"].as_str())
+            .unwrap_or("-")
+            .to_string(),
+        value["createdAt"].as_str().unwrap_or("-").to_string(),
+    ]
+}
+
+fn run_trigger_label(value: &Value) -> String {
+    let trigger = &value["trigger"];
+    match trigger["kind"].as_str() {
+        Some("schedule") => trigger["scheduleId"]
+            .as_str()
+            .map(|id| format!("schedule:{id}"))
+            .unwrap_or_else(|| "schedule".to_string()),
+        Some("event") => trigger["triggerId"]
+            .as_str()
+            .map(|id| format!("event:{id}"))
+            .unwrap_or_else(|| "event".to_string()),
+        Some("manual") => "manual".to_string(),
+        Some(other) if !other.is_empty() => other.to_string(),
+        _ => "-".to_string(),
+    }
 }
 
 fn format_bool(value: Option<bool>) -> String {

--- a/gestalt/cli/src/main.rs
+++ b/gestalt/cli/src/main.rs
@@ -3,7 +3,7 @@ use gestalt::api::{self, ApiClient};
 use gestalt::cli::{
     AuthCommands, Cli, Commands, ConfigCommands, DescribeArgs, IdentityCommands,
     IdentityGrantCommands, IdentityMemberCommands, IdentityTokenCommands, InvokeArgs,
-    PluginCommands, TokenCommands, WorkflowCommands, WorkflowScheduleCommands,
+    PluginCommands, TokenCommands, WorkflowCommands, WorkflowRunCommands, WorkflowScheduleCommands,
 };
 use gestalt::commands;
 use gestalt::output;
@@ -150,6 +150,17 @@ fn run() -> anyhow::Result<()> {
                     }
                     WorkflowScheduleCommands::Resume { id } => {
                         commands::workflows::resume(&client, &id, format)
+                    }
+                },
+                WorkflowCommands::Runs { command } => match command {
+                    WorkflowRunCommands::List { plugin, status } => commands::workflows::list_runs(
+                        &client,
+                        plugin.as_deref(),
+                        status.as_deref(),
+                        format,
+                    ),
+                    WorkflowRunCommands::Get { id } => {
+                        commands::workflows::get_run(&client, &id, format)
                     }
                 },
             }

--- a/gestalt/cli/tests/workflows_cli.rs
+++ b/gestalt/cli/tests/workflows_cli.rs
@@ -18,6 +18,23 @@ const SCHEDULE_JSON: &str = r#"{
     "nextRunAt":"2026-04-21T00:00:00Z"
 }"#;
 
+const RUN_JSON: &str = r#"{
+    "id":"run-1",
+    "provider":"test-provider",
+    "status":"succeeded",
+    "target":{
+        "plugin":"dummy",
+        "operation":"doit",
+        "input":{"k":"v"}
+    },
+    "trigger":{"kind":"schedule","scheduleId":"sched-1"},
+    "createdAt":"2026-04-20T00:00:00Z",
+    "startedAt":"2026-04-20T00:01:00Z",
+    "completedAt":"2026-04-20T00:02:00Z",
+    "statusMessage":"done",
+    "resultBody":"{\"ok\":true}"
+}"#;
+
 #[test]
 fn test_cli_lists_schedules() {
     let mut server = Server::new();
@@ -259,4 +276,70 @@ fn test_cli_list_schedules_json_format() {
         .success()
         .stdout(predicate::str::contains(r#""id": "sched-1""#))
         .stdout(predicate::str::contains(r#""plugin": "dummy""#));
+}
+
+#[test]
+fn test_cli_lists_runs() {
+    let mut server = Server::new();
+    let _mock = authed_json_mock!(server, Method::GET, "/api/v1/workflow/runs", StatusCode::OK)
+        .with_body(format!("[{RUN_JSON}]"))
+        .create();
+
+    let home = tempfile::tempdir().unwrap();
+    cli_command_for_server(home.path(), &server)
+        .args(["workflows", "runs", "list"])
+        .assert()
+        .success()
+        .stdout(predicate::str::contains("run-1"))
+        .stdout(predicate::str::contains("dummy"))
+        .stdout(predicate::str::contains("succeeded"));
+}
+
+#[test]
+fn test_cli_list_runs_filters() {
+    let body = r#"[
+        {"id":"run-a","status":"running","target":{"plugin":"alpha","operation":"x"},"trigger":{"kind":"manual"}},
+        {"id":"run-b","status":"failed","target":{"plugin":"beta","operation":"y"},"trigger":{"kind":"event","triggerId":"evt-1"}}
+    ]"#;
+    let mut server = Server::new();
+    let _mock = authed_json_mock!(server, Method::GET, "/api/v1/workflow/runs", StatusCode::OK)
+        .with_body(body)
+        .create();
+
+    let home = tempfile::tempdir().unwrap();
+    cli_command_for_server(home.path(), &server)
+        .args([
+            "workflows",
+            "runs",
+            "list",
+            "--plugin",
+            "beta",
+            "--status",
+            "failed",
+        ])
+        .assert()
+        .success()
+        .stdout(predicate::str::contains("run-b"))
+        .stdout(predicate::str::contains("run-a").not());
+}
+
+#[test]
+fn test_cli_gets_run() {
+    let mut server = Server::new();
+    let _mock = authed_json_mock!(
+        server,
+        Method::GET,
+        "/api/v1/workflow/runs/run-1",
+        StatusCode::OK
+    )
+    .with_body(RUN_JSON)
+    .create();
+
+    let home = tempfile::tempdir().unwrap();
+    cli_command_for_server(home.path(), &server)
+        .args(["workflows", "runs", "get", "run-1"])
+        .assert()
+        .success()
+        .stdout(predicate::str::contains("run-1"))
+        .stdout(predicate::str::contains("succeeded"));
 }

--- a/gestaltd/internal/bootstrap/bootstrap.go
+++ b/gestaltd/internal/bootstrap/bootstrap.go
@@ -1150,7 +1150,7 @@ func buildWorkflow(ctx context.Context, name string, entry *config.ProviderEntry
 	hostServices := []providerhost.HostService{{
 		EnvVar: providerhost.DefaultWorkflowHostSocketEnv,
 		Register: func(srv *grpc.Server) {
-			proto.RegisterWorkflowHostServer(srv, providerhost.NewWorkflowHostServer(name, deps.WorkflowRuntime.Invoke))
+			proto.RegisterWorkflowHostServer(srv, providerhost.NewWorkflowHostServer(name, deps.WorkflowRuntime.Invoke, workflowHostStartupContextFunc(deps.WorkflowRuntime, name)))
 		},
 	}}
 	var cleanup func()

--- a/gestaltd/internal/bootstrap/bootstrap_test.go
+++ b/gestaltd/internal/bootstrap/bootstrap_test.go
@@ -3388,13 +3388,22 @@ func TestValidateManagedWorkflowStartupInvokesMCPPassthroughPreparedProviders(t 
 		}); err != nil {
 			return nil, fmt.Errorf("store identity token for connection %q: %w", connection, err)
 		}
-		resp, err := deps.WorkflowRuntime.Invoke(context.Background(), coreworkflow.InvokeOperationRequest{
+		req := coreworkflow.InvokeOperationRequest{
 			ProviderName: name,
 			Target: coreworkflow.Target{
 				PluginName: "roadmap",
 				Operation:  "sync",
 			},
-		})
+		}
+		startupPrincipal := &principal.Principal{
+			SubjectID:           "system:workflow-startup",
+			CredentialSubjectID: principal.IdentitySubjectID(),
+			TokenPermissions: principal.CompilePermissions([]core.AccessPermission{{
+				Plugin:     "roadmap",
+				Operations: []string{"sync"},
+			}}),
+		}
+		resp, err := deps.WorkflowRuntime.Invoke(principal.WithPrincipal(context.Background(), startupPrincipal), req)
 		if err != nil {
 			return nil, fmt.Errorf("startup invoke: %w", err)
 		}

--- a/gestaltd/internal/bootstrap/workflow_runtime.go
+++ b/gestaltd/internal/bootstrap/workflow_runtime.go
@@ -160,6 +160,16 @@ func (r *workflowRuntime) ResolveProviderSelection(name string) (string, corewor
 	return selectedName, provider, nil
 }
 
+func (r *workflowRuntime) StartupPendingProvider(name string) bool {
+	if r == nil {
+		return false
+	}
+	r.mu.RLock()
+	defer r.mu.RUnlock()
+	_, ok := r.providers[strings.TrimSpace(name)].(*startupWorkflowProviderProxy)
+	return ok
+}
+
 func (r *workflowRuntime) Invoke(ctx context.Context, req coreworkflow.InvokeOperationRequest) (*coreworkflow.InvokeOperationResponse, error) {
 	if r == nil {
 		return nil, fmt.Errorf("workflow runtime is not configured")
@@ -175,7 +185,7 @@ func (r *workflowRuntime) Invoke(ctx context.Context, req coreworkflow.InvokeOpe
 	if targetPluginName == "" {
 		return nil, fmt.Errorf("workflow target plugin is required")
 	}
-	principalValue := workflowStartupPrincipal(req)
+	principalValue := principal.Canonicalized(principal.FromContext(ctx))
 	target := req.Target
 	invokeConnection := ""
 	invokeInstance := ""
@@ -191,6 +201,8 @@ func (r *workflowRuntime) Invoke(ctx context.Context, req coreworkflow.InvokeOpe
 		target.Instance = resolvedRef.Target.Instance
 		invokeConnection = strings.TrimSpace(target.Connection)
 		invokeInstance = strings.TrimSpace(target.Instance)
+	} else if principalValue == nil || strings.TrimSpace(principalValue.SubjectID) == "" {
+		return nil, fmt.Errorf("%w: workflow execution principal is required when execution_ref is omitted", invocation.ErrInternal)
 	}
 	if contextValue := workflowInvocationContext(req); len(contextValue) > 0 {
 		ctx = invocation.WithWorkflowContext(ctx, contextValue)

--- a/gestaltd/internal/bootstrap/workflow_runtime_test.go
+++ b/gestaltd/internal/bootstrap/workflow_runtime_test.go
@@ -216,7 +216,7 @@ func TestWorkflowRuntimeInvokeMergesConfiguredAndPerRunInput(t *testing.T) {
 		},
 	})
 
-	resp, err := runtime.Invoke(context.Background(), coreworkflow.InvokeOperationRequest{
+	req := coreworkflow.InvokeOperationRequest{
 		ProviderName: "temporal",
 		RunID:        "run-123",
 		Target: coreworkflow.Target{
@@ -248,7 +248,8 @@ func TestWorkflowRuntimeInvokeMergesConfiguredAndPerRunInput(t *testing.T) {
 				ScheduledFor: &scheduledFor,
 			},
 		},
-	})
+	}
+	resp, err := runtime.Invoke(principal.WithPrincipal(context.Background(), workflowStartupPrincipal(req)), req)
 	if err != nil {
 		t.Fatalf("Invoke: %v", err)
 	}

--- a/gestaltd/internal/bootstrap/workflow_startup_context.go
+++ b/gestaltd/internal/bootstrap/workflow_startup_context.go
@@ -1,0 +1,22 @@
+package bootstrap
+
+import (
+	"context"
+	"strings"
+
+	coreworkflow "github.com/valon-technologies/gestalt/server/core/workflow"
+	"github.com/valon-technologies/gestalt/server/internal/principal"
+)
+
+func workflowHostStartupContextFunc(runtime *workflowRuntime, providerName string) func(context.Context, coreworkflow.InvokeOperationRequest) context.Context {
+	providerName = strings.TrimSpace(providerName)
+	return func(ctx context.Context, req coreworkflow.InvokeOperationRequest) context.Context {
+		if runtime == nil || providerName == "" || strings.TrimSpace(req.ExecutionRef) != "" || principal.FromContext(ctx) != nil {
+			return ctx
+		}
+		if !runtime.StartupPendingProvider(providerName) {
+			return ctx
+		}
+		return principal.WithPrincipal(ctx, workflowStartupPrincipal(req))
+	}
+}

--- a/gestaltd/internal/providerhost/workflow_host_server.go
+++ b/gestaltd/internal/providerhost/workflow_host_server.go
@@ -13,17 +13,20 @@ import (
 )
 
 type workflowInvokeFunc func(context.Context, coreworkflow.InvokeOperationRequest) (*coreworkflow.InvokeOperationResponse, error)
+type workflowInvokeContextFunc func(context.Context, coreworkflow.InvokeOperationRequest) context.Context
 
 type WorkflowHostServer struct {
 	proto.UnimplementedWorkflowHostServer
 	providerName string
 	invoke       workflowInvokeFunc
+	prepareCtx   workflowInvokeContextFunc
 }
 
-func NewWorkflowHostServer(providerName string, invoke workflowInvokeFunc) *WorkflowHostServer {
+func NewWorkflowHostServer(providerName string, invoke workflowInvokeFunc, prepareCtx workflowInvokeContextFunc) *WorkflowHostServer {
 	return &WorkflowHostServer{
 		providerName: providerName,
 		invoke:       invoke,
+		prepareCtx:   prepareCtx,
 	}
 }
 
@@ -44,6 +47,9 @@ func (s *WorkflowHostServer) InvokeOperation(ctx context.Context, req *proto.Inv
 		return nil, status.Error(codes.InvalidArgument, "workflow invoke operation: target.operation is required")
 	}
 	value.ProviderName = s.providerName
+	if s.prepareCtx != nil {
+		ctx = s.prepareCtx(ctx, value)
+	}
 	resp, err := s.invoke(ctx, value)
 	if err != nil {
 		return nil, status.Errorf(workflowInvokeErrorCode(err), "workflow invoke operation: %v", err)

--- a/gestaltd/internal/server/handlers_workflow_runs.go
+++ b/gestaltd/internal/server/handlers_workflow_runs.go
@@ -1,0 +1,201 @@
+package server
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"log/slog"
+	"maps"
+	"net/http"
+	"strings"
+	"time"
+
+	"github.com/go-chi/chi/v5"
+	"github.com/valon-technologies/gestalt/server/core"
+	coreworkflow "github.com/valon-technologies/gestalt/server/core/workflow"
+	"github.com/valon-technologies/gestalt/server/internal/workflowmanager"
+)
+
+type workflowActorInfo struct {
+	SubjectID   string `json:"subjectId,omitempty"`
+	SubjectKind string `json:"subjectKind,omitempty"`
+	DisplayName string `json:"displayName,omitempty"`
+	AuthSource  string `json:"authSource,omitempty"`
+}
+
+type workflowRunEventInfo struct {
+	ID              string         `json:"id,omitempty"`
+	Source          string         `json:"source,omitempty"`
+	SpecVersion     string         `json:"specVersion,omitempty"`
+	Type            string         `json:"type,omitempty"`
+	Subject         string         `json:"subject,omitempty"`
+	Time            *time.Time     `json:"time,omitempty"`
+	DataContentType string         `json:"dataContentType,omitempty"`
+	Data            map[string]any `json:"data,omitempty"`
+	Extensions      map[string]any `json:"extensions,omitempty"`
+}
+
+type workflowRunTriggerInfo struct {
+	Kind         string                `json:"kind,omitempty"`
+	ScheduleID   string                `json:"scheduleId,omitempty"`
+	ScheduledFor *time.Time            `json:"scheduledFor,omitempty"`
+	TriggerID    string                `json:"triggerId,omitempty"`
+	Event        *workflowRunEventInfo `json:"event,omitempty"`
+}
+
+type workflowRunInfo struct {
+	ID            string                     `json:"id"`
+	Provider      string                     `json:"provider"`
+	Status        string                     `json:"status,omitempty"`
+	Target        workflowScheduleTargetInfo `json:"target"`
+	Trigger       *workflowRunTriggerInfo    `json:"trigger,omitempty"`
+	CreatedBy     *workflowActorInfo         `json:"createdBy,omitempty"`
+	CreatedAt     *time.Time                 `json:"createdAt,omitempty"`
+	StartedAt     *time.Time                 `json:"startedAt,omitempty"`
+	CompletedAt   *time.Time                 `json:"completedAt,omitempty"`
+	StatusMessage string                     `json:"statusMessage,omitempty"`
+	ResultBody    string                     `json:"resultBody,omitempty"`
+}
+
+func (s *Server) listGlobalWorkflowRuns(w http.ResponseWriter, r *http.Request) {
+	p, ok := s.resolveWorkflowScheduleActor(w, r)
+	if !ok {
+		return
+	}
+	runs, err := s.workflowSchedules.ListRuns(r.Context(), p)
+	if err != nil {
+		s.writeWorkflowRunManagerError(w, r, "", err)
+		return
+	}
+	pluginFilter := strings.TrimSpace(r.URL.Query().Get("plugin"))
+	statusFilter := strings.TrimSpace(r.URL.Query().Get("status"))
+	out := make([]workflowRunInfo, 0, len(runs))
+	for _, managed := range runs {
+		if managed == nil || managed.Run == nil {
+			continue
+		}
+		if pluginFilter != "" && strings.TrimSpace(managed.Run.Target.PluginName) != pluginFilter {
+			continue
+		}
+		if statusFilter != "" && strings.TrimSpace(string(managed.Run.Status)) != statusFilter {
+			continue
+		}
+		out = append(out, workflowRunInfoFromManaged(managed))
+	}
+	writeJSON(w, http.StatusOK, out)
+}
+
+func (s *Server) getGlobalWorkflowRun(w http.ResponseWriter, r *http.Request) {
+	p, ok := s.resolveWorkflowScheduleActor(w, r)
+	if !ok {
+		return
+	}
+	managed, err := s.workflowSchedules.GetRun(r.Context(), p, chi.URLParam(r, "runID"))
+	if err != nil {
+		s.writeWorkflowRunManagerError(w, r, chi.URLParam(r, "runID"), err)
+		return
+	}
+	writeJSON(w, http.StatusOK, workflowRunInfoFromManaged(managed))
+}
+
+func workflowRunInfoFromManaged(managed *workflowmanager.ManagedRun) workflowRunInfo {
+	if managed == nil {
+		return workflowRunInfo{}
+	}
+	return workflowRunInfoFromCore(managed.Run, strings.TrimSpace(managed.ProviderName))
+}
+
+func workflowRunInfoFromCore(run *coreworkflow.Run, providerName string) workflowRunInfo {
+	info := workflowRunInfo{Provider: providerName}
+	if run == nil {
+		return info
+	}
+	info.ID = run.ID
+	info.Status = strings.TrimSpace(string(run.Status))
+	info.CreatedAt = run.CreatedAt
+	info.StartedAt = run.StartedAt
+	info.CompletedAt = run.CompletedAt
+	info.StatusMessage = run.StatusMessage
+	info.ResultBody = run.ResultBody
+	info.Target = workflowScheduleTargetInfo{
+		Plugin:     run.Target.PluginName,
+		Operation:  run.Target.Operation,
+		Connection: userFacingConnectionName(run.Target.Connection),
+		Instance:   run.Target.Instance,
+		Input:      maps.Clone(run.Target.Input),
+	}
+	info.Trigger = workflowRunTriggerInfoFromCore(run.Trigger)
+	info.CreatedBy = workflowActorInfoFromCore(run.CreatedBy)
+	return info
+}
+
+func workflowRunTriggerInfoFromCore(trigger coreworkflow.RunTrigger) *workflowRunTriggerInfo {
+	switch {
+	case trigger.Schedule != nil:
+		return &workflowRunTriggerInfo{
+			Kind:         "schedule",
+			ScheduleID:   trigger.Schedule.ScheduleID,
+			ScheduledFor: trigger.Schedule.ScheduledFor,
+		}
+	case trigger.Event != nil:
+		return &workflowRunTriggerInfo{
+			Kind:      "event",
+			TriggerID: trigger.Event.TriggerID,
+			Event: &workflowRunEventInfo{
+				ID:              trigger.Event.Event.ID,
+				Source:          trigger.Event.Event.Source,
+				SpecVersion:     trigger.Event.Event.SpecVersion,
+				Type:            trigger.Event.Event.Type,
+				Subject:         trigger.Event.Event.Subject,
+				Time:            trigger.Event.Event.Time,
+				DataContentType: trigger.Event.Event.DataContentType,
+				Data:            maps.Clone(trigger.Event.Event.Data),
+				Extensions:      maps.Clone(trigger.Event.Event.Extensions),
+			},
+		}
+	case trigger.Manual:
+		return &workflowRunTriggerInfo{Kind: "manual"}
+	default:
+		return nil
+	}
+}
+
+func workflowActorInfoFromCore(actor coreworkflow.Actor) *workflowActorInfo {
+	if actor == (coreworkflow.Actor{}) {
+		return nil
+	}
+	return &workflowActorInfo{
+		SubjectID:   actor.SubjectID,
+		SubjectKind: actor.SubjectKind,
+		DisplayName: actor.DisplayName,
+		AuthSource:  actor.AuthSource,
+	}
+}
+
+func (s *Server) writeWorkflowRunManagerError(w http.ResponseWriter, r *http.Request, runID string, err error) {
+	switch {
+	case errors.Is(err, workflowmanager.ErrWorkflowNotConfigured),
+		errors.Is(err, workflowmanager.ErrExecutionRefsNotConfigured):
+		writeError(w, http.StatusPreconditionFailed, err.Error())
+	case errors.Is(err, workflowmanager.ErrWorkflowSubjectRequired),
+		errors.Is(err, workflowmanager.ErrWorkflowScheduleSubject):
+		writeError(w, http.StatusUnauthorized, err.Error())
+	case errors.Is(err, core.ErrNotFound):
+		s.writeWorkflowRunProviderError(r.Context(), w, runID, err)
+	default:
+		s.writeWorkflowRunProviderError(r.Context(), w, runID, err)
+	}
+}
+
+func (s *Server) writeWorkflowRunProviderError(ctx context.Context, w http.ResponseWriter, runID string, err error) {
+	switch {
+	case errors.Is(err, core.ErrNotFound):
+		writeError(w, http.StatusNotFound, fmt.Sprintf("workflow run %q not found", runID))
+	default:
+		slog.ErrorContext(ctx, "workflow run provider error",
+			"run_id", runID,
+			"error", err,
+		)
+		writeError(w, http.StatusInternalServerError, "workflow run request failed")
+	}
+}

--- a/gestaltd/internal/server/routes_user.go
+++ b/gestaltd/internal/server/routes_user.go
@@ -18,6 +18,10 @@ func (s *Server) mountAuthenticatedRoutes(r chi.Router) {
 			r.Post("/{scheduleID}/pause", s.pauseGlobalWorkflowSchedule)
 			r.Post("/{scheduleID}/resume", s.resumeGlobalWorkflowSchedule)
 		})
+		r.Route("/workflow/runs", func(r chi.Router) {
+			r.Get("/", s.listGlobalWorkflowRuns)
+			r.Get("/{runID}", s.getGlobalWorkflowRun)
+		})
 
 		r.Post("/auth/start-oauth", s.startIntegrationOAuth)
 		r.Post("/auth/connect-manual", s.connectManual)

--- a/gestaltd/internal/server/workflow_run_test.go
+++ b/gestaltd/internal/server/workflow_run_test.go
@@ -1,0 +1,279 @@
+package server_test
+
+import (
+	"context"
+	"encoding/json"
+	"net/http"
+	"testing"
+	"time"
+
+	"github.com/valon-technologies/gestalt/server/core"
+	"github.com/valon-technologies/gestalt/server/core/catalog"
+	coretesting "github.com/valon-technologies/gestalt/server/core/testing"
+	coreworkflow "github.com/valon-technologies/gestalt/server/core/workflow"
+	"github.com/valon-technologies/gestalt/server/internal/principal"
+	"github.com/valon-technologies/gestalt/server/internal/server"
+	"github.com/valon-technologies/gestalt/server/internal/testutil"
+)
+
+type workflowRunResponse struct {
+	ID     string `json:"id"`
+	Status string `json:"status"`
+	Target struct {
+		Plugin    string `json:"plugin"`
+		Operation string `json:"operation"`
+	} `json:"target"`
+	Trigger struct {
+		Kind       string `json:"kind"`
+		ScheduleID string `json:"scheduleId"`
+	} `json:"trigger"`
+}
+
+func TestGlobalWorkflowRunInspectionIncludesHistoricalRevokedRefs(t *testing.T) {
+	t.Parallel()
+
+	services := coretesting.NewStubServices(t)
+	user := seedUser(t, services, "ada@example.test")
+	other := seedUser(t, services, "grace@example.test")
+	provider := newMemoryWorkflowProvider()
+
+	now := time.Now().UTC().Truncate(time.Second)
+	older := now.Add(-2 * time.Hour)
+	revokedAt := now.Add(-1 * time.Hour)
+	provider.runs["run-new"] = &coreworkflow.Run{
+		ID:           "run-new",
+		Status:       coreworkflow.RunStatusRunning,
+		Target:       coreworkflow.Target{PluginName: "roadmap", Operation: "sync"},
+		Trigger:      coreworkflow.RunTrigger{Schedule: &coreworkflow.ScheduleTrigger{ScheduleID: "sched-new"}},
+		ExecutionRef: "workflow_schedule:sched-new:ref-active",
+		CreatedAt:    &now,
+	}
+	provider.runs["run-old"] = &coreworkflow.Run{
+		ID:            "run-old",
+		Status:        coreworkflow.RunStatusSucceeded,
+		Target:        coreworkflow.Target{PluginName: "roadmap", Operation: "sync"},
+		Trigger:       coreworkflow.RunTrigger{Schedule: &coreworkflow.ScheduleTrigger{ScheduleID: "sched-old"}},
+		ExecutionRef:  "workflow_schedule:sched-old:ref-revoked",
+		CreatedAt:     &older,
+		CompletedAt:   &now,
+		StatusMessage: "done",
+		ResultBody:    `{"ok":true}`,
+	}
+	provider.runs["run-other"] = &coreworkflow.Run{
+		ID:           "run-other",
+		Status:       coreworkflow.RunStatusSucceeded,
+		Target:       coreworkflow.Target{PluginName: "roadmap", Operation: "sync"},
+		ExecutionRef: "workflow_schedule:sched-other:ref-other",
+		CreatedAt:    &now,
+	}
+
+	for _, ref := range []*coreworkflow.ExecutionReference{
+		{
+			ID:           "workflow_schedule:sched-new:ref-active",
+			ProviderName: "basic",
+			Target:       provider.runs["run-new"].Target,
+			SubjectID:    principal.UserSubjectID(user.ID),
+		},
+		{
+			ID:           "workflow_schedule:sched-old:ref-revoked",
+			ProviderName: "basic",
+			Target:       provider.runs["run-old"].Target,
+			SubjectID:    principal.UserSubjectID(user.ID),
+			RevokedAt:    &revokedAt,
+		},
+		{
+			ID:           "workflow_schedule:sched-other:ref-other",
+			ProviderName: "basic",
+			Target:       provider.runs["run-other"].Target,
+			SubjectID:    principal.UserSubjectID(other.ID),
+		},
+	} {
+		if _, err := services.WorkflowExecutionRefs.Put(context.Background(), ref); err != nil {
+			t.Fatalf("Put execution ref %q: %v", ref.ID, err)
+		}
+	}
+
+	ts := newTestServer(t, func(cfg *server.Config) {
+		cfg.Auth = &coretesting.StubAuthProvider{
+			N: "stub",
+			ValidateTokenFn: func(_ context.Context, token string) (*core.UserIdentity, error) {
+				if token != "ada-session" {
+					return nil, core.ErrNotFound
+				}
+				return &core.UserIdentity{Email: user.Email, DisplayName: "Ada"}, nil
+			},
+		}
+		cfg.Services = services
+		cfg.Providers = testutil.NewProviderRegistry(t, &coretesting.StubIntegration{
+			N:        "roadmap",
+			ConnMode: core.ConnectionModeNone,
+			CatalogVal: &catalog.Catalog{
+				Name: "roadmap",
+				Operations: []catalog.CatalogOperation{
+					{ID: "sync", Method: http.MethodPost},
+				},
+			},
+		})
+		cfg.Workflow = &stubWorkflowControl{
+			defaultProviderName: "basic",
+			provider:            provider,
+		}
+	})
+	testutil.CloseOnCleanup(t, ts)
+
+	listReq, _ := http.NewRequest(http.MethodGet, ts.URL+"/api/v1/workflow/runs/", nil)
+	listReq.AddCookie(&http.Cookie{Name: "session_token", Value: "ada-session"})
+	listResp, err := http.DefaultClient.Do(listReq)
+	if err != nil {
+		t.Fatalf("list request: %v", err)
+	}
+	defer func() { _ = listResp.Body.Close() }()
+	if listResp.StatusCode != http.StatusOK {
+		t.Fatalf("expected 200, got %d", listResp.StatusCode)
+	}
+	var listed []workflowRunResponse
+	if err := json.NewDecoder(listResp.Body).Decode(&listed); err != nil {
+		t.Fatalf("decode list response: %v", err)
+	}
+	if len(listed) != 2 {
+		t.Fatalf("listed runs = %#v, want 2 items", listed)
+	}
+	if listed[0].ID != "run-new" || listed[1].ID != "run-old" {
+		t.Fatalf("listed run order = %#v", listed)
+	}
+	if listed[1].Trigger.Kind != "schedule" || listed[1].Trigger.ScheduleID != "sched-old" {
+		t.Fatalf("historical trigger = %#v", listed[1].Trigger)
+	}
+
+	getReq, _ := http.NewRequest(http.MethodGet, ts.URL+"/api/v1/workflow/runs/run-old", nil)
+	getReq.AddCookie(&http.Cookie{Name: "session_token", Value: "ada-session"})
+	getResp, err := http.DefaultClient.Do(getReq)
+	if err != nil {
+		t.Fatalf("get request: %v", err)
+	}
+	defer func() { _ = getResp.Body.Close() }()
+	if getResp.StatusCode != http.StatusOK {
+		t.Fatalf("expected 200, got %d", getResp.StatusCode)
+	}
+	var got workflowRunResponse
+	if err := json.NewDecoder(getResp.Body).Decode(&got); err != nil {
+		t.Fatalf("decode get response: %v", err)
+	}
+	if got.ID != "run-old" || got.Status != string(coreworkflow.RunStatusSucceeded) {
+		t.Fatalf("run = %#v", got)
+	}
+}
+
+func TestGlobalWorkflowRunInspectionAPITokenScopeFiltersOperations(t *testing.T) {
+	t.Parallel()
+
+	services := coretesting.NewStubServices(t)
+	user := seedUser(t, services, "ada@example.test")
+	plaintext, hashed, err := principal.GenerateToken(principal.TokenTypeAPI)
+	if err != nil {
+		t.Fatalf("GenerateToken: %v", err)
+	}
+	expiresAt := time.Now().Add(24 * time.Hour)
+	if err := services.APITokens.StoreAPIToken(context.Background(), &core.APIToken{
+		ID:                  "workflow-runs-token",
+		OwnerKind:           core.APITokenOwnerKindUser,
+		OwnerID:             user.ID,
+		CredentialSubjectID: principal.UserSubjectID(user.ID),
+		Name:                "workflow-runs-token",
+		HashedToken:         hashed,
+		ExpiresAt:           &expiresAt,
+		Permissions:         []core.AccessPermission{{Plugin: "roadmap", Operations: []string{"sync"}}},
+	}); err != nil {
+		t.Fatalf("StoreAPIToken: %v", err)
+	}
+
+	provider := newMemoryWorkflowProvider()
+	now := time.Now().UTC().Truncate(time.Second)
+	provider.runs["run-sync"] = &coreworkflow.Run{
+		ID:           "run-sync",
+		Status:       coreworkflow.RunStatusSucceeded,
+		Target:       coreworkflow.Target{PluginName: "roadmap", Operation: "sync"},
+		ExecutionRef: "workflow_schedule:sched-sync:ref-sync",
+		CreatedAt:    &now,
+	}
+	provider.runs["run-export"] = &coreworkflow.Run{
+		ID:           "run-export",
+		Status:       coreworkflow.RunStatusFailed,
+		Target:       coreworkflow.Target{PluginName: "roadmap", Operation: "export"},
+		ExecutionRef: "workflow_schedule:sched-export:ref-export",
+		CreatedAt:    &now,
+	}
+	for _, ref := range []*coreworkflow.ExecutionReference{
+		{
+			ID:           "workflow_schedule:sched-sync:ref-sync",
+			ProviderName: "basic",
+			Target:       provider.runs["run-sync"].Target,
+			SubjectID:    principal.UserSubjectID(user.ID),
+		},
+		{
+			ID:           "workflow_schedule:sched-export:ref-export",
+			ProviderName: "basic",
+			Target:       provider.runs["run-export"].Target,
+			SubjectID:    principal.UserSubjectID(user.ID),
+		},
+	} {
+		if _, err := services.WorkflowExecutionRefs.Put(context.Background(), ref); err != nil {
+			t.Fatalf("Put execution ref %q: %v", ref.ID, err)
+		}
+	}
+
+	ts := newTestServer(t, func(cfg *server.Config) {
+		cfg.Auth = &coretesting.StubAuthProvider{
+			N: "stub",
+			ValidateTokenFn: func(_ context.Context, _ string) (*core.UserIdentity, error) {
+				return nil, core.ErrNotFound
+			},
+		}
+		cfg.Services = services
+		cfg.Providers = testutil.NewProviderRegistry(t, &coretesting.StubIntegration{
+			N:        "roadmap",
+			ConnMode: core.ConnectionModeUser,
+			CatalogVal: &catalog.Catalog{
+				Name: "roadmap",
+				Operations: []catalog.CatalogOperation{
+					{ID: "sync", Method: http.MethodPost},
+					{ID: "export", Method: http.MethodPost},
+				},
+			},
+		})
+		cfg.Workflow = &stubWorkflowControl{
+			defaultProviderName: "basic",
+			provider:            provider,
+		}
+	})
+	testutil.CloseOnCleanup(t, ts)
+
+	listReq, _ := http.NewRequest(http.MethodGet, ts.URL+"/api/v1/workflow/runs/", nil)
+	listReq.Header.Set("Authorization", "Bearer "+plaintext)
+	listResp, err := http.DefaultClient.Do(listReq)
+	if err != nil {
+		t.Fatalf("list request: %v", err)
+	}
+	defer func() { _ = listResp.Body.Close() }()
+	if listResp.StatusCode != http.StatusOK {
+		t.Fatalf("expected 200, got %d", listResp.StatusCode)
+	}
+	var listed []workflowRunResponse
+	if err := json.NewDecoder(listResp.Body).Decode(&listed); err != nil {
+		t.Fatalf("decode list response: %v", err)
+	}
+	if len(listed) != 1 || listed[0].ID != "run-sync" {
+		t.Fatalf("listed runs = %#v", listed)
+	}
+
+	getReq, _ := http.NewRequest(http.MethodGet, ts.URL+"/api/v1/workflow/runs/run-export", nil)
+	getReq.Header.Set("Authorization", "Bearer "+plaintext)
+	getResp, err := http.DefaultClient.Do(getReq)
+	if err != nil {
+		t.Fatalf("get request: %v", err)
+	}
+	defer func() { _ = getResp.Body.Close() }()
+	if getResp.StatusCode != http.StatusNotFound {
+		t.Fatalf("expected 404, got %d", getResp.StatusCode)
+	}
+}

--- a/gestaltd/internal/server/workflow_schedule_test.go
+++ b/gestaltd/internal/server/workflow_schedule_test.go
@@ -63,6 +63,7 @@ func (s *stubWorkflowControl) ResolveProvider(name string) (coreworkflow.Provide
 
 type memoryWorkflowProvider struct {
 	schedules     map[string]*coreworkflow.Schedule
+	runs          map[string]*coreworkflow.Run
 	upsertReqs    []coreworkflow.UpsertScheduleRequest
 	deleteReqs    []coreworkflow.DeleteScheduleRequest
 	pauseReqs     []coreworkflow.PauseScheduleRequest
@@ -70,22 +71,43 @@ type memoryWorkflowProvider struct {
 	nextUpsertErr error
 	getErr        error
 	listErr       error
+	getRunErr     error
+	listRunsErr   error
 }
 
 func newMemoryWorkflowProvider() *memoryWorkflowProvider {
-	return &memoryWorkflowProvider{schedules: map[string]*coreworkflow.Schedule{}}
+	return &memoryWorkflowProvider{
+		schedules: map[string]*coreworkflow.Schedule{},
+		runs:      map[string]*coreworkflow.Run{},
+	}
 }
 
 func (p *memoryWorkflowProvider) StartRun(context.Context, coreworkflow.StartRunRequest) (*coreworkflow.Run, error) {
 	return nil, errors.New("not implemented")
 }
 
-func (p *memoryWorkflowProvider) GetRun(context.Context, coreworkflow.GetRunRequest) (*coreworkflow.Run, error) {
-	return nil, errors.New("not implemented")
+func (p *memoryWorkflowProvider) GetRun(_ context.Context, req coreworkflow.GetRunRequest) (*coreworkflow.Run, error) {
+	if p.getRunErr != nil {
+		return nil, p.getRunErr
+	}
+	run, ok := p.runs[req.RunID]
+	if !ok || run == nil {
+		return nil, core.ErrNotFound
+	}
+	return cloneWorkflowRun(run), nil
 }
 
-func (p *memoryWorkflowProvider) ListRuns(context.Context, coreworkflow.ListRunsRequest) ([]*coreworkflow.Run, error) {
-	return nil, nil
+func (p *memoryWorkflowProvider) ListRuns(_ context.Context, _ coreworkflow.ListRunsRequest) ([]*coreworkflow.Run, error) {
+	if p.listRunsErr != nil {
+		return nil, p.listRunsErr
+	}
+	out := make([]*coreworkflow.Run, 0, len(p.runs))
+	for _, run := range p.runs {
+		if run != nil {
+			out = append(out, cloneWorkflowRun(run))
+		}
+	}
+	return out, nil
 }
 
 func (p *memoryWorkflowProvider) CancelRun(context.Context, coreworkflow.CancelRunRequest) (*coreworkflow.Run, error) {
@@ -226,6 +248,45 @@ func cloneWorkflowSchedule(schedule *coreworkflow.Schedule) *coreworkflow.Schedu
 	if schedule.NextRunAt != nil {
 		value := *schedule.NextRunAt
 		cloned.NextRunAt = &value
+	}
+	return &cloned
+}
+
+func cloneWorkflowRun(run *coreworkflow.Run) *coreworkflow.Run {
+	if run == nil {
+		return nil
+	}
+	cloned := *run
+	cloned.Target.Input = cloneMap(run.Target.Input)
+	if run.Trigger.Event != nil {
+		event := *run.Trigger.Event
+		event.Event.Data = cloneMap(run.Trigger.Event.Event.Data)
+		event.Event.Extensions = cloneMap(run.Trigger.Event.Event.Extensions)
+		if run.Trigger.Event.Event.Time != nil {
+			value := *run.Trigger.Event.Event.Time
+			event.Event.Time = &value
+		}
+		cloned.Trigger.Event = &event
+	}
+	if run.Trigger.Schedule != nil {
+		schedule := *run.Trigger.Schedule
+		if run.Trigger.Schedule.ScheduledFor != nil {
+			value := *run.Trigger.Schedule.ScheduledFor
+			schedule.ScheduledFor = &value
+		}
+		cloned.Trigger.Schedule = &schedule
+	}
+	if run.CreatedAt != nil {
+		value := *run.CreatedAt
+		cloned.CreatedAt = &value
+	}
+	if run.StartedAt != nil {
+		value := *run.StartedAt
+		cloned.StartedAt = &value
+	}
+	if run.CompletedAt != nil {
+		value := *run.CompletedAt
+		cloned.CompletedAt = &value
 	}
 	return &cloned
 }

--- a/gestaltd/internal/workflowmanager/manager.go
+++ b/gestaltd/internal/workflowmanager/manager.go
@@ -23,7 +23,8 @@ import (
 var (
 	ErrWorkflowNotConfigured      = errors.New("workflow is not configured")
 	ErrExecutionRefsNotConfigured = errors.New("workflow execution refs are not configured")
-	ErrWorkflowScheduleSubject    = errors.New("workflow schedule subject is required")
+	ErrWorkflowSubjectRequired    = errors.New("workflow subject is required")
+	ErrWorkflowScheduleSubject    = ErrWorkflowSubjectRequired
 	ErrDuplicateExecutionRefs     = errors.New("workflow schedule matched multiple execution references")
 )
 
@@ -81,6 +82,13 @@ type ManagedSchedule struct {
 	provider     coreworkflow.Provider
 }
 
+type ManagedRun struct {
+	ProviderName string
+	Run          *coreworkflow.Run
+	ExecutionRef *coreworkflow.ExecutionReference
+	provider     coreworkflow.Provider
+}
+
 func New(cfg Config) *Manager {
 	now := cfg.Now
 	if now == nil {
@@ -98,8 +106,103 @@ func New(cfg Config) *Manager {
 	}
 }
 
+func (m *Manager) ListRuns(ctx context.Context, p *principal.Principal) ([]*ManagedRun, error) {
+	refs, err := m.listOwnedExecutionRefs(ctx, p, false)
+	if err != nil {
+		return nil, err
+	}
+	refsByProvider := executionRefsByProvider(refs)
+	out := make([]*ManagedRun, 0, len(refs))
+	for providerName, providerRefs := range refsByProvider {
+		provider, err := m.resolveProviderByName(providerName)
+		if err != nil {
+			return nil, err
+		}
+		runs, err := provider.ListRuns(ctx, coreworkflow.ListRunsRequest{})
+		if err != nil {
+			return nil, err
+		}
+		refIndex := executionRefsByID(providerRefs)
+		for _, run := range runs {
+			if run == nil {
+				continue
+			}
+			ref := refIndex[strings.TrimSpace(run.ExecutionRef)]
+			if ref == nil || !m.allowTarget(ctx, p, ref.Target) || !runMatchesExecutionRef(providerName, run, ref) {
+				continue
+			}
+			out = append(out, &ManagedRun{
+				ProviderName: providerName,
+				Run:          run,
+				ExecutionRef: ref,
+				provider:     provider,
+			})
+		}
+	}
+	sort.Slice(out, func(i, j int) bool {
+		left := out[i]
+		right := out[j]
+		if left.Run != nil && right.Run != nil && left.Run.CreatedAt != nil && right.Run.CreatedAt != nil && !left.Run.CreatedAt.Equal(*right.Run.CreatedAt) {
+			return left.Run.CreatedAt.After(*right.Run.CreatedAt)
+		}
+		leftID := ""
+		rightID := ""
+		if left.Run != nil {
+			leftID = left.Run.ID
+		}
+		if right.Run != nil {
+			rightID = right.Run.ID
+		}
+		return leftID < rightID
+	})
+	return out, nil
+}
+
+func (m *Manager) GetRun(ctx context.Context, p *principal.Principal, runID string) (*ManagedRun, error) {
+	runID = strings.TrimSpace(runID)
+	if runID == "" {
+		return nil, core.ErrNotFound
+	}
+	refs, err := m.listOwnedExecutionRefs(ctx, p, false)
+	if err != nil {
+		return nil, err
+	}
+	refsByProvider := executionRefsByProvider(refs)
+	var firstErr error
+	for providerName, providerRefs := range refsByProvider {
+		provider, err := m.resolveProviderByName(providerName)
+		if err != nil {
+			return nil, err
+		}
+		run, err := provider.GetRun(ctx, coreworkflow.GetRunRequest{RunID: runID})
+		if err != nil {
+			if errors.Is(err, core.ErrNotFound) {
+				continue
+			}
+			if firstErr == nil {
+				firstErr = err
+			}
+			continue
+		}
+		ref := executionRefsByID(providerRefs)[strings.TrimSpace(run.ExecutionRef)]
+		if ref == nil || !m.allowTarget(ctx, p, ref.Target) || !runMatchesExecutionRef(providerName, run, ref) {
+			continue
+		}
+		return &ManagedRun{
+			ProviderName: providerName,
+			Run:          run,
+			ExecutionRef: ref,
+			provider:     provider,
+		}, nil
+	}
+	if firstErr != nil {
+		return nil, firstErr
+	}
+	return nil, core.ErrNotFound
+}
+
 func (m *Manager) ListSchedules(ctx context.Context, p *principal.Principal) ([]*ManagedSchedule, error) {
-	refs, err := m.listOwnedExecutionRefs(ctx, p)
+	refs, err := m.listOwnedExecutionRefs(ctx, p, true)
 	if err != nil {
 		return nil, err
 	}
@@ -155,7 +258,7 @@ func (m *Manager) ListSchedules(ctx context.Context, p *principal.Principal) ([]
 func (m *Manager) CreateSchedule(ctx context.Context, p *principal.Principal, req ScheduleUpsert) (*ManagedSchedule, error) {
 	p = principal.Canonicalized(p)
 	if strings.TrimSpace(principalSubjectID(p)) == "" {
-		return nil, ErrWorkflowScheduleSubject
+		return nil, ErrWorkflowSubjectRequired
 	}
 	providerName, provider, err := m.resolveProviderSelection(strings.TrimSpace(req.ProviderName))
 	if err != nil {
@@ -200,7 +303,7 @@ func (m *Manager) GetSchedule(ctx context.Context, p *principal.Principal, sched
 func (m *Manager) UpdateSchedule(ctx context.Context, p *principal.Principal, scheduleID string, req ScheduleUpsert) (*ManagedSchedule, error) {
 	p = principal.Canonicalized(p)
 	if strings.TrimSpace(principalSubjectID(p)) == "" {
-		return nil, ErrWorkflowScheduleSubject
+		return nil, ErrWorkflowSubjectRequired
 	}
 	existing, err := m.requireOwnedSchedule(ctx, scheduleID, p)
 	if err != nil {
@@ -415,13 +518,13 @@ func (m *Manager) requireOwnedSchedule(ctx context.Context, scheduleID string, p
 	}, nil
 }
 
-func (m *Manager) listOwnedExecutionRefs(ctx context.Context, p *principal.Principal) ([]*coreworkflow.ExecutionReference, error) {
+func (m *Manager) listOwnedExecutionRefs(ctx context.Context, p *principal.Principal, activeOnly bool) ([]*coreworkflow.ExecutionReference, error) {
 	if m == nil || m.workflowExecutionRefs == nil {
 		return nil, ErrExecutionRefsNotConfigured
 	}
 	subjectID := strings.TrimSpace(principalSubjectID(principal.Canonicalized(p)))
 	if subjectID == "" {
-		return nil, ErrWorkflowScheduleSubject
+		return nil, ErrWorkflowSubjectRequired
 	}
 	refs, err := m.workflowExecutionRefs.ListBySubject(ctx, subjectID)
 	if err != nil {
@@ -429,7 +532,7 @@ func (m *Manager) listOwnedExecutionRefs(ctx context.Context, p *principal.Princ
 	}
 	out := make([]*coreworkflow.ExecutionReference, 0, len(refs))
 	for _, ref := range refs {
-		if !executionRefActive(ref) || !executionRefOwnedBy(ref, p) {
+		if !executionRefOwnedBy(ref, p) || (activeOnly && !executionRefActive(ref)) {
 			continue
 		}
 		out = append(out, ref)
@@ -438,7 +541,7 @@ func (m *Manager) listOwnedExecutionRefs(ctx context.Context, p *principal.Princ
 }
 
 func (m *Manager) findOwnedExecutionRef(ctx context.Context, scheduleID string, p *principal.Principal) (*coreworkflow.ExecutionReference, error) {
-	refs, err := m.listOwnedExecutionRefs(ctx, p)
+	refs, err := m.listOwnedExecutionRefs(ctx, p, true)
 	if err != nil {
 		return nil, err
 	}
@@ -466,7 +569,7 @@ func (m *Manager) putExecutionRef(ctx context.Context, executionRefID, providerN
 	p = principal.Canonicalized(p)
 	subjectID := strings.TrimSpace(principalSubjectID(p))
 	if subjectID == "" {
-		return nil, ErrWorkflowScheduleSubject
+		return nil, ErrWorkflowSubjectRequired
 	}
 	return m.workflowExecutionRefs.Put(ctx, &coreworkflow.ExecutionReference{
 		ID:           executionRefID,
@@ -542,6 +645,38 @@ func executionRefActive(ref *coreworkflow.ExecutionReference) bool {
 	return ref != nil && (ref.RevokedAt == nil || ref.RevokedAt.IsZero())
 }
 
+func executionRefsByProvider(refs []*coreworkflow.ExecutionReference) map[string][]*coreworkflow.ExecutionReference {
+	if len(refs) == 0 {
+		return nil
+	}
+	out := make(map[string][]*coreworkflow.ExecutionReference)
+	for _, ref := range refs {
+		if ref == nil {
+			continue
+		}
+		providerName := strings.TrimSpace(ref.ProviderName)
+		if providerName == "" {
+			continue
+		}
+		out[providerName] = append(out[providerName], ref)
+	}
+	return out
+}
+
+func executionRefsByID(refs []*coreworkflow.ExecutionReference) map[string]*coreworkflow.ExecutionReference {
+	if len(refs) == 0 {
+		return nil
+	}
+	out := make(map[string]*coreworkflow.ExecutionReference, len(refs))
+	for _, ref := range refs {
+		if ref == nil || strings.TrimSpace(ref.ID) == "" {
+			continue
+		}
+		out[strings.TrimSpace(ref.ID)] = ref
+	}
+	return out
+}
+
 func scheduleMatchesExecutionRef(providerName string, schedule *coreworkflow.Schedule, ref *coreworkflow.ExecutionReference) bool {
 	if schedule == nil || ref == nil {
 		return false
@@ -553,6 +688,19 @@ func scheduleMatchesExecutionRef(providerName string, schedule *coreworkflow.Sch
 		strings.TrimSpace(schedule.Target.Operation) == strings.TrimSpace(ref.Target.Operation) &&
 		strings.TrimSpace(schedule.Target.Connection) == strings.TrimSpace(ref.Target.Connection) &&
 		strings.TrimSpace(schedule.Target.Instance) == strings.TrimSpace(ref.Target.Instance)
+}
+
+func runMatchesExecutionRef(providerName string, run *coreworkflow.Run, ref *coreworkflow.ExecutionReference) bool {
+	if run == nil || ref == nil {
+		return false
+	}
+	if providerName = strings.TrimSpace(providerName); providerName != "" && strings.TrimSpace(ref.ProviderName) != providerName {
+		return false
+	}
+	return strings.TrimSpace(run.Target.PluginName) == strings.TrimSpace(ref.Target.PluginName) &&
+		strings.TrimSpace(run.Target.Operation) == strings.TrimSpace(ref.Target.Operation) &&
+		strings.TrimSpace(run.Target.Connection) == strings.TrimSpace(ref.Target.Connection) &&
+		strings.TrimSpace(run.Target.Instance) == strings.TrimSpace(ref.Target.Instance)
 }
 
 func workflowActorFromPrincipal(p *principal.Principal) coreworkflow.Actor {


### PR DESCRIPTION
## Summary
- add global workflow run inspection endpoints and CLI commands
- keep historical runs inspectable after execution refs are revoked by schedule changes
- move the startup-only workflow auth fallback out of the generic runtime path and into bootstrap workflow-host context preparation

## Interfaces
- `GET /api/v1/workflow/runs`
- `GET /api/v1/workflow/runs/{runID}`
- `gestalt workflows runs list [--plugin <plugin>] [--status <status>]`
- `gestalt workflows runs get <run-id>`

## Examples
```bash
curl -H 'Authorization: Bearer $TOKEN' \
  'http://localhost:8080/api/v1/workflow/runs?plugin=slack&status=succeeded'

curl -H 'Authorization: Bearer $TOKEN' \
  'http://localhost:8080/api/v1/workflow/runs/run_123'

gestalt workflows runs list --plugin slack --status succeeded
gestalt workflows runs get run_123
```

## Notes
- run visibility is owner-scoped to the current subject
- historical runs still resolve through revoked execution refs, so users can inspect old runs after schedule rotation or deletion
- when `execution_ref` is omitted, the generic runtime now requires a principal already in context; bootstrap is the only place that injects the startup principal fallback

## Verification
- `go test ./internal/server ./internal/bootstrap ./internal/workflowmanager ./internal/providerhost -count=1`
- `golangci-lint run ./internal/server ./internal/bootstrap ./internal/workflowmanager ./internal/providerhost`
- `cargo test --test workflows_cli`
- `git diff --check`