### PR TITLE
plugin runtime: add admin session inspection API

### DIFF
--- a/gestaltd/internal/bootstrap/bootstrap.go
+++ b/gestaltd/internal/bootstrap/bootstrap.go
@@ -202,6 +202,7 @@ type Result struct {
 	AuditSink             core.AuditSink
 	SecretManager         core.SecretManager
 	Telemetry             core.TelemetryProvider
+	PluginRuntimes        RuntimeInspector
 
 	pluginRuntimeRegistry *pluginRuntimeRegistry
 	auditClose            func(context.Context) error
@@ -771,6 +772,7 @@ func Bootstrap(ctx context.Context, cfg *config.Config, factories *FactoryRegist
 		AuditSink:             audit,
 		SecretManager:         prepared.SecretManager,
 		Telemetry:             prepared.Telemetry,
+		PluginRuntimes:        prepared.pluginRuntimeRegistry,
 		pluginRuntimeRegistry: prepared.pluginRuntimeRegistry,
 		auditClose:            auditClose,
 	}, nil

--- a/gestaltd/internal/bootstrap/executable_plugin_test.go
+++ b/gestaltd/internal/bootstrap/executable_plugin_test.go
@@ -107,6 +107,10 @@ func (r *capturingPluginRuntime) StartSession(ctx context.Context, req pluginrun
 	return r.provider.StartSession(ctx, req)
 }
 
+func (r *capturingPluginRuntime) ListSessions(ctx context.Context) ([]pluginruntime.Session, error) {
+	return r.provider.ListSessions(ctx)
+}
+
 func (r *capturingPluginRuntime) GetSession(ctx context.Context, req pluginruntime.GetSessionRequest) (*pluginruntime.Session, error) {
 	return r.provider.GetSession(ctx, req)
 }
@@ -170,6 +174,10 @@ func (r *capturingBundlePluginRuntime) Capabilities(context.Context) (pluginrunt
 
 func (r *capturingBundlePluginRuntime) StartSession(ctx context.Context, req pluginruntime.StartSessionRequest) (*pluginruntime.Session, error) {
 	return r.provider.StartSession(ctx, req)
+}
+
+func (r *capturingBundlePluginRuntime) ListSessions(ctx context.Context) ([]pluginruntime.Session, error) {
+	return r.provider.ListSessions(ctx)
 }
 
 func (r *capturingBundlePluginRuntime) GetSession(ctx context.Context, req pluginruntime.GetSessionRequest) (*pluginruntime.Session, error) {
@@ -262,6 +270,10 @@ func (r *slowStopPluginRuntime) StartSession(ctx context.Context, req pluginrunt
 	return r.inner.StartSession(ctx, req)
 }
 
+func (r *slowStopPluginRuntime) ListSessions(ctx context.Context) ([]pluginruntime.Session, error) {
+	return r.inner.ListSessions(ctx)
+}
+
 func (r *slowStopPluginRuntime) GetSession(ctx context.Context, req pluginruntime.GetSessionRequest) (*pluginruntime.Session, error) {
 	return r.inner.GetSession(ctx, req)
 }
@@ -304,6 +316,10 @@ func (r *staticCapabilityPluginRuntime) Capabilities(context.Context) (pluginrun
 
 func (r *staticCapabilityPluginRuntime) StartSession(ctx context.Context, req pluginruntime.StartSessionRequest) (*pluginruntime.Session, error) {
 	return r.inner.StartSession(ctx, req)
+}
+
+func (r *staticCapabilityPluginRuntime) ListSessions(ctx context.Context) ([]pluginruntime.Session, error) {
+	return r.inner.ListSessions(ctx)
 }
 
 func (r *staticCapabilityPluginRuntime) GetSession(ctx context.Context, req pluginruntime.GetSessionRequest) (*pluginruntime.Session, error) {

--- a/gestaltd/internal/bootstrap/plugin_runtime_inspect.go
+++ b/gestaltd/internal/bootstrap/plugin_runtime_inspect.go
@@ -1,0 +1,92 @@
+package bootstrap
+
+import (
+	"context"
+	"fmt"
+	"slices"
+
+	"github.com/valon-technologies/gestalt/server/internal/config"
+	"github.com/valon-technologies/gestalt/server/internal/pluginruntime"
+)
+
+type RuntimeInspector interface {
+	SnapshotPluginRuntimes(ctx context.Context) ([]RuntimeProviderSnapshot, error)
+}
+
+type RuntimeProviderSnapshot struct {
+	Name         string
+	Driver       config.RuntimeProviderDriver
+	Default      bool
+	Loaded       bool
+	Capabilities pluginruntime.Capabilities
+	Sessions     []pluginruntime.Session
+	Error        string
+}
+
+func (r *pluginRuntimeRegistry) SnapshotPluginRuntimes(ctx context.Context) ([]RuntimeProviderSnapshot, error) {
+	if r == nil || r.cfg == nil {
+		return nil, nil
+	}
+
+	type item struct {
+		name     string
+		entry    *config.RuntimeProviderEntry
+		provider pluginruntime.Provider
+	}
+
+	r.mu.Lock()
+	if r.closed {
+		r.mu.Unlock()
+		return nil, fmt.Errorf("plugin runtime registry is closed")
+	}
+	items := make([]item, 0, len(r.cfg.Runtime.Providers))
+	for name, entry := range r.cfg.Runtime.Providers {
+		items = append(items, item{
+			name:     name,
+			entry:    entry,
+			provider: r.providers[name],
+		})
+	}
+	r.mu.Unlock()
+
+	slices.SortFunc(items, func(a, b item) int {
+		switch {
+		case a.name < b.name:
+			return -1
+		case a.name > b.name:
+			return 1
+		default:
+			return 0
+		}
+	})
+
+	out := make([]RuntimeProviderSnapshot, 0, len(items))
+	for _, item := range items {
+		snapshot := RuntimeProviderSnapshot{
+			Name: item.name,
+		}
+		if item.entry != nil {
+			snapshot.Driver = item.entry.Driver
+			snapshot.Default = item.entry.Default
+		}
+		if item.provider != nil {
+			snapshot.Loaded = true
+			caps, err := item.provider.Capabilities(ctx)
+			if err != nil {
+				snapshot.Error = fmt.Sprintf("capabilities: %v", err)
+				out = append(out, snapshot)
+				continue
+			}
+			snapshot.Capabilities = caps
+			sessions, err := item.provider.ListSessions(ctx)
+			if err != nil {
+				snapshot.Error = fmt.Sprintf("list sessions: %v", err)
+				out = append(out, snapshot)
+				continue
+			}
+			snapshot.Sessions = sessions
+		}
+		out = append(out, snapshot)
+	}
+	return out, nil
+}

--- a/gestaltd/internal/pluginruntime/executable.go
+++ b/gestaltd/internal/pluginruntime/executable.go
@@ -3,9 +3,13 @@ package pluginruntime
 import (
 	"context"
 	"fmt"
+	"slices"
+	"sync"
 
 	proto "github.com/valon-technologies/gestalt/sdk/go/gen/v1"
 	"github.com/valon-technologies/gestalt/server/internal/providerhost"
+	"google.golang.org/grpc/codes"
+	"google.golang.org/grpc/status"
 	"google.golang.org/protobuf/types/known/emptypb"
 )
 
@@ -23,6 +27,9 @@ type executableProvider struct {
 	proc      *providerhost.PluginProcess
 	runtime   proto.PluginRuntimeProviderClient
 	lifecycle proto.ProviderLifecycleClient
+
+	mu       sync.Mutex
+	sessions map[string]*Session
 }
 
 func NewExecutableProvider(ctx context.Context, cfg ExecutableConfig) (Provider, error) {
@@ -47,6 +54,7 @@ func NewExecutableProvider(ctx context.Context, cfg ExecutableConfig) (Provider,
 		proc:      proc,
 		runtime:   proto.NewPluginRuntimeProviderClient(proc.Conn()),
 		lifecycle: lifecycle,
+		sessions:  make(map[string]*Session),
 	}, nil
 }
 
@@ -68,7 +76,56 @@ func (p *executableProvider) StartSession(ctx context.Context, req StartSessionR
 	if err != nil {
 		return nil, fmt.Errorf("start runtime session: %w", err)
 	}
-	return sessionFromProto(resp), nil
+	session := sessionFromProto(resp)
+	p.trackSession(session)
+	return session, nil
+}
+
+func (p *executableProvider) ListSessions(ctx context.Context) ([]Session, error) {
+	if p == nil {
+		return nil, fmt.Errorf("plugin runtime is not configured")
+	}
+
+	p.mu.Lock()
+	sessionIDs := make([]string, 0, len(p.sessions))
+	for sessionID := range p.sessions {
+		sessionIDs = append(sessionIDs, sessionID)
+	}
+	p.mu.Unlock()
+	slices.Sort(sessionIDs)
+
+	out := make([]Session, 0, len(sessionIDs))
+	refreshed := make(map[string]*Session, len(sessionIDs))
+	stale := make([]string, 0)
+	for _, sessionID := range sessionIDs {
+		resp, err := p.runtime.GetSession(ctx, &proto.GetPluginRuntimeSessionRequest{
+			SessionId: sessionID,
+		})
+		if err != nil {
+			if status.Code(err) == codes.NotFound {
+				stale = append(stale, sessionID)
+				continue
+			}
+			return nil, fmt.Errorf("list runtime sessions: get session %q: %w", sessionID, err)
+		}
+		session := sessionFromProto(resp)
+		if session == nil {
+			stale = append(stale, sessionID)
+			continue
+		}
+		refreshed[sessionID] = cloneHostedSession(session)
+		out = append(out, *session)
+	}
+
+	p.mu.Lock()
+	defer p.mu.Unlock()
+	for _, sessionID := range stale {
+		delete(p.sessions, sessionID)
+	}
+	for sessionID, session := range refreshed {
+		p.sessions[sessionID] = session
+	}
+	return out, nil
 }
 
 func (p *executableProvider) GetSession(ctx context.Context, req GetSessionRequest) (*Session, error) {
@@ -78,7 +135,9 @@ func (p *executableProvider) GetSession(ctx context.Context, req GetSessionReque
 	if err != nil {
 		return nil, fmt.Errorf("get runtime session: %w", err)
 	}
-	return sessionFromProto(resp), nil
+	session := sessionFromProto(resp)
+	p.trackSession(session)
+	return session, nil
 }
 
 func (p *executableProvider) StopSession(ctx context.Context, req StopSessionRequest) error {
@@ -88,6 +147,9 @@ func (p *executableProvider) StopSession(ctx context.Context, req StopSessionReq
 	if err != nil {
 		return fmt.Errorf("stop runtime session: %w", err)
 	}
+	p.mu.Lock()
+	delete(p.sessions, req.SessionID)
+	p.mu.Unlock()
 	return nil
 }
 
@@ -123,6 +185,11 @@ func (p *executableProvider) StartPlugin(ctx context.Context, req StartPluginReq
 	if err != nil {
 		return nil, fmt.Errorf("start hosted plugin: %w", err)
 	}
+	p.mu.Lock()
+	if session, ok := p.sessions[req.SessionID]; ok && session != nil {
+		session.State = SessionStateRunning
+	}
+	p.mu.Unlock()
 	return &HostedPlugin{
 		ID:         resp.GetId(),
 		SessionID:  resp.GetSessionId(),
@@ -135,6 +202,9 @@ func (p *executableProvider) Close() error {
 	if p == nil || p.proc == nil {
 		return nil
 	}
+	p.mu.Lock()
+	p.sessions = nil
+	p.mu.Unlock()
 	return p.proc.Close()
 }
 
@@ -162,5 +232,28 @@ func sessionFromProto(src *proto.PluginRuntimeSession) *Session {
 		ID:       src.GetId(),
 		State:    SessionState(src.GetState()),
 		Metadata: cloneStringMap(src.GetMetadata()),
+	}
+}
+
+func (p *executableProvider) trackSession(session *Session) {
+	if p == nil || session == nil || session.ID == "" {
+		return
+	}
+	p.mu.Lock()
+	defer p.mu.Unlock()
+	if p.sessions == nil {
+		p.sessions = make(map[string]*Session)
+	}
+	p.sessions[session.ID] = cloneHostedSession(session)
+}
+
+func cloneHostedSession(session *Session) *Session {
+	if session == nil {
+		return nil
+	}
+	return &Session{
+		ID:       session.ID,
+		State:    session.State,
+		Metadata: cloneStringMap(session.Metadata),
 	}
 }

--- a/gestaltd/internal/pluginruntime/local.go
+++ b/gestaltd/internal/pluginruntime/local.go
@@ -7,6 +7,7 @@ import (
 	"os"
 	"path/filepath"
 	"runtime"
+	"slices"
 	"sync"
 	"sync/atomic"
 
@@ -89,6 +90,34 @@ func (p *LocalProvider) StartSession(_ context.Context, req StartSessionRequest)
 	}
 	p.sessions[sessionID] = session
 	return cloneSession(session), nil
+}
+
+func (p *LocalProvider) ListSessions(_ context.Context) ([]Session, error) {
+	if p == nil {
+		return nil, fmt.Errorf("plugin runtime is not configured")
+	}
+
+	p.mu.Lock()
+	defer p.mu.Unlock()
+	if p.closed {
+		return nil, fmt.Errorf("plugin runtime is closed")
+	}
+
+	sessionIDs := make([]string, 0, len(p.sessions))
+	for sessionID := range p.sessions {
+		sessionIDs = append(sessionIDs, sessionID)
+	}
+	slices.Sort(sessionIDs)
+
+	out := make([]Session, 0, len(sessionIDs))
+	for _, sessionID := range sessionIDs {
+		session := cloneSession(p.sessions[sessionID])
+		if session == nil {
+			continue
+		}
+		out = append(out, *session)
+	}
+	return out, nil
 }
 
 func (p *LocalProvider) GetSession(_ context.Context, req GetSessionRequest) (*Session, error) {

--- a/gestaltd/internal/pluginruntime/runtime.go
+++ b/gestaltd/internal/pluginruntime/runtime.go
@@ -104,6 +104,7 @@ type HostedPluginConn interface {
 
 type Provider interface {
 	Capabilities(ctx context.Context) (Capabilities, error)
+	ListSessions(ctx context.Context) ([]Session, error)
 	StartSession(ctx context.Context, req StartSessionRequest) (*Session, error)
 	GetSession(ctx context.Context, req GetSessionRequest) (*Session, error)
 	StopSession(ctx context.Context, req StopSessionRequest) error

--- a/gestaltd/internal/server/handlers_admin_runtime.go
+++ b/gestaltd/internal/server/handlers_admin_runtime.go
@@ -1,0 +1,118 @@
+package server
+
+import (
+	"net/http"
+	"strings"
+
+	"github.com/go-chi/chi/v5"
+	"github.com/valon-technologies/gestalt/server/internal/bootstrap"
+)
+
+type adminRuntimeProviderInfo struct {
+	Name         string                    `json:"name"`
+	Driver       string                    `json:"driver"`
+	Default      bool                      `json:"default"`
+	Loaded       bool                      `json:"loaded"`
+	SessionCount *int                      `json:"sessionCount,omitempty"`
+	Capabilities *adminRuntimeCapabilities `json:"capabilities,omitempty"`
+	Error        string                    `json:"error,omitempty"`
+}
+
+type adminRuntimeCapabilities struct {
+	HostedPluginRuntime bool `json:"hostedPluginRuntime"`
+	HostServiceTunnels  bool `json:"hostServiceTunnels"`
+	ProviderGRPCTunnel  bool `json:"providerGRPCTunnel"`
+	HostnameProxyEgress bool `json:"hostnameProxyEgress"`
+	CIDREgress          bool `json:"cidrEgress"`
+}
+
+type adminRuntimeSessionInfo struct {
+	ID     string `json:"id"`
+	State  string `json:"state"`
+	Plugin string `json:"plugin,omitempty"`
+}
+
+func (s *Server) mountAdminRuntimeRoutes(r chi.Router) {
+	r.Get("/runtime/providers", s.listAdminRuntimeProviders)
+	r.Get("/runtime/providers/{provider}/sessions", s.listAdminRuntimeProviderSessions)
+}
+
+func (s *Server) listAdminRuntimeProviders(w http.ResponseWriter, r *http.Request) {
+	snapshots, err := s.adminRuntimeSnapshots(r)
+	if err != nil {
+		writeError(w, http.StatusInternalServerError, "failed to inspect runtime providers")
+		return
+	}
+
+	out := make([]adminRuntimeProviderInfo, 0, len(snapshots))
+	for _, snapshot := range snapshots {
+		row := adminRuntimeProviderInfo{
+			Name:    snapshot.Name,
+			Driver:  strings.TrimSpace(string(snapshot.Driver)),
+			Default: snapshot.Default,
+			Loaded:  snapshot.Loaded,
+			Error:   strings.TrimSpace(snapshot.Error),
+		}
+		if snapshot.Loaded && row.Error == "" {
+			sessionCount := len(snapshot.Sessions)
+			row.SessionCount = &sessionCount
+		}
+		if snapshot.Loaded && row.Error == "" {
+			row.Capabilities = adminRuntimeCapabilitiesFromSnapshot(snapshot)
+		}
+		out = append(out, row)
+	}
+	writeJSON(w, http.StatusOK, out)
+}
+
+func (s *Server) listAdminRuntimeProviderSessions(w http.ResponseWriter, r *http.Request) {
+	name := strings.TrimSpace(chi.URLParam(r, "provider"))
+	if name == "" {
+		writeError(w, http.StatusBadRequest, "provider is required")
+		return
+	}
+
+	snapshots, err := s.adminRuntimeSnapshots(r)
+	if err != nil {
+		writeError(w, http.StatusInternalServerError, "failed to inspect runtime providers")
+		return
+	}
+	for _, snapshot := range snapshots {
+		if snapshot.Name != name {
+			continue
+		}
+		if strings.TrimSpace(snapshot.Error) != "" {
+			writeError(w, http.StatusServiceUnavailable, "runtime provider inspection is unavailable")
+			return
+		}
+		out := make([]adminRuntimeSessionInfo, 0, len(snapshot.Sessions))
+		for _, session := range snapshot.Sessions {
+			out = append(out, adminRuntimeSessionInfo{
+				ID:     strings.TrimSpace(session.ID),
+				State:  strings.TrimSpace(string(session.State)),
+				Plugin: strings.TrimSpace(session.Metadata["plugin"]),
+			})
+		}
+		writeJSON(w, http.StatusOK, out)
+		return
+	}
+
+	writeError(w, http.StatusNotFound, "runtime provider not found")
+}
+
+func (s *Server) adminRuntimeSnapshots(r *http.Request) ([]bootstrap.RuntimeProviderSnapshot, error) {
+	if s.pluginRuntimes == nil {
+		return nil, nil
+	}
+	return s.pluginRuntimes.SnapshotPluginRuntimes(r.Context())
+}
+
+func adminRuntimeCapabilitiesFromSnapshot(snapshot bootstrap.RuntimeProviderSnapshot) *adminRuntimeCapabilities {
+	return &adminRuntimeCapabilities{
+		HostedPluginRuntime: snapshot.Capabilities.HostedPluginRuntime,
+		HostServiceTunnels:  snapshot.Capabilities.HostServiceTunnels,
+		ProviderGRPCTunnel:  snapshot.Capabilities.ProviderGRPCTunnel,
+		HostnameProxyEgress: snapshot.Capabilities.HostnameProxyEgress,
+		CIDREgress:          snapshot.Capabilities.CIDREgress,
+	}
+}

--- a/gestaltd/internal/server/routes.go
+++ b/gestaltd/internal/server/routes.go
@@ -87,6 +87,7 @@ func (s *Server) mountAdminAPIRoutes(r chi.Router) {
 		if s.adminRoute.AuthorizationPolicy != "" {
 			r.Use(s.adminAPIAuthMiddleware)
 		}
+		s.mountAdminRuntimeRoutes(r)
 		s.mountAdminAuthorizationRoutes(r)
 	})
 }

--- a/gestaltd/internal/server/runtime.go
+++ b/gestaltd/internal/server/runtime.go
@@ -68,6 +68,7 @@ func Run(ctx context.Context, cfg *config.Config, result *bootstrap.Result) erro
 		Services:             result.Services,
 		Providers:            result.Providers,
 		Workflow:             result.WorkflowControl,
+		PluginRuntimes:       result.PluginRuntimes,
 		Invoker:              httpInvoker,
 		DefaultConnection:    connMaps.DefaultConnection,
 		// HTTP routes expose REST-visible operations, so unqualified session-catalog

--- a/gestaltd/internal/server/server.go
+++ b/gestaltd/internal/server/server.go
@@ -93,6 +93,7 @@ type Server struct {
 	managedIdentityMu      sync.Mutex
 	providers              *registry.ProviderMap[core.Provider]
 	workflow               bootstrap.WorkflowControl
+	pluginRuntimes         bootstrap.RuntimeInspector
 	resolver               *principal.Resolver
 	authResolvers          map[string]*principal.Resolver
 	invoker                invocation.Invoker
@@ -139,6 +140,7 @@ type Config struct {
 	Services              *coredata.Services
 	Providers             *registry.ProviderMap[core.Provider]
 	Workflow              bootstrap.WorkflowControl
+	PluginRuntimes        bootstrap.RuntimeInspector
 	Invoker               invocation.Invoker
 	DefaultConnection     map[string]string
 	CatalogConnection     map[string]string
@@ -278,6 +280,7 @@ func New(cfg Config) (*Server, error) {
 		authorizationProvider:  cfg.AuthorizationProvider,
 		providers:              cfg.Providers,
 		workflow:               cfg.Workflow,
+		pluginRuntimes:         cfg.PluginRuntimes,
 		resolver:               resolver,
 		authResolvers:          authResolvers,
 		invoker:                cfg.Invoker,

--- a/gestaltd/internal/server/server_test.go
+++ b/gestaltd/internal/server/server_test.go
@@ -11,6 +11,7 @@ import (
 	"errors"
 	"fmt"
 	"io"
+	"maps"
 	"net"
 	"net/http"
 	"net/http/cookiejar"
@@ -47,6 +48,7 @@ import (
 	"github.com/valon-technologies/gestalt/server/internal/invocation"
 	gestaltmcp "github.com/valon-technologies/gestalt/server/internal/mcp"
 	"github.com/valon-technologies/gestalt/server/internal/oauth"
+	"github.com/valon-technologies/gestalt/server/internal/pluginruntime"
 	"github.com/valon-technologies/gestalt/server/internal/principal"
 	"github.com/valon-technologies/gestalt/server/internal/provider"
 	"github.com/valon-technologies/gestalt/server/internal/registry"
@@ -123,6 +125,34 @@ func newTestHandler(t *testing.T, opts ...func(*server.Config)) http.Handler {
 type stubResolver struct {
 	token string
 	err   error
+}
+
+type staticRuntimeInspector struct {
+	snapshots []bootstrap.RuntimeProviderSnapshot
+	err       error
+}
+
+func (s *staticRuntimeInspector) SnapshotPluginRuntimes(context.Context) ([]bootstrap.RuntimeProviderSnapshot, error) {
+	if s == nil {
+		return nil, nil
+	}
+	if s.err != nil {
+		return nil, s.err
+	}
+	out := make([]bootstrap.RuntimeProviderSnapshot, 0, len(s.snapshots))
+	for _, snapshot := range s.snapshots {
+		cloned := snapshot
+		cloned.Sessions = make([]pluginruntime.Session, 0, len(snapshot.Sessions))
+		for _, session := range snapshot.Sessions {
+			cloned.Sessions = append(cloned.Sessions, pluginruntime.Session{
+				ID:       session.ID,
+				State:    session.State,
+				Metadata: maps.Clone(session.Metadata),
+			})
+		}
+		out = append(out, cloned)
+	}
+	return out, nil
 }
 
 func (s *stubResolver) ResolveToken(ctx context.Context, _ *principal.Principal, _ string, _ string, _ string) (context.Context, string, error) {
@@ -2406,6 +2436,193 @@ func TestAdminAPI_RoutesMountedWithoutAdminUI(t *testing.T) {
 	}
 	if len(plugins) != 1 || plugins[0]["name"] != "sample_plugin" {
 		t.Fatalf("plugins = %+v, want sample_plugin", plugins)
+	}
+}
+
+func TestAdminAPI_RuntimeProviders(t *testing.T) {
+	t.Parallel()
+
+	ts := newTestServer(t, func(cfg *server.Config) {
+		cfg.PluginRuntimes = &staticRuntimeInspector{
+			snapshots: []bootstrap.RuntimeProviderSnapshot{
+				{
+					Name:    "local",
+					Driver:  config.RuntimeProviderDriverLocal,
+					Default: true,
+				},
+				{
+					Name:   "modal",
+					Driver: config.RuntimeProviderDriver("modal"),
+					Loaded: true,
+					Capabilities: pluginruntime.Capabilities{
+						HostedPluginRuntime: true,
+						ProviderGRPCTunnel:  true,
+						CIDREgress:          true,
+					},
+					Sessions: []pluginruntime.Session{{
+						ID:    "session-1",
+						State: pluginruntime.SessionStateRunning,
+						Metadata: map[string]string{
+							"plugin": "support",
+							"owner":  "support-platform",
+						},
+					}},
+				},
+			},
+		}
+	})
+	testutil.CloseOnCleanup(t, ts)
+
+	resp, err := http.Get(ts.URL + "/admin/api/v1/runtime/providers")
+	if err != nil {
+		t.Fatalf("GET runtime providers: %v", err)
+	}
+	defer func() { _ = resp.Body.Close() }()
+	if resp.StatusCode != http.StatusOK {
+		body, _ := io.ReadAll(resp.Body)
+		t.Fatalf("runtime providers status = %d, want 200: %s", resp.StatusCode, body)
+	}
+
+	var providers []map[string]any
+	if err := json.NewDecoder(resp.Body).Decode(&providers); err != nil {
+		t.Fatalf("decoding runtime providers: %v", err)
+	}
+	if len(providers) != 2 {
+		t.Fatalf("runtime providers len = %d, want 2", len(providers))
+	}
+	if got := providers[0]["name"]; got != "local" {
+		t.Fatalf("runtime providers[0].name = %v, want local", got)
+	}
+	if got := providers[0]["loaded"]; got != false {
+		t.Fatalf("runtime providers[0].loaded = %v, want false", got)
+	}
+	if got := providers[0]["default"]; got != true {
+		t.Fatalf("runtime providers[0].default = %v, want true", got)
+	}
+	if _, ok := providers[0]["sessionCount"]; ok {
+		t.Fatalf("runtime providers[0].sessionCount unexpectedly present: %#v", providers[0]["sessionCount"])
+	}
+	if got := providers[1]["name"]; got != "modal" {
+		t.Fatalf("runtime providers[1].name = %v, want modal", got)
+	}
+	if got := providers[1]["loaded"]; got != true {
+		t.Fatalf("runtime providers[1].loaded = %v, want true", got)
+	}
+	if got := providers[1]["sessionCount"]; got != float64(1) {
+		t.Fatalf("runtime providers[1].sessionCount = %v, want 1", got)
+	}
+	caps, ok := providers[1]["capabilities"].(map[string]any)
+	if !ok {
+		t.Fatalf("runtime providers[1].capabilities = %#v, want object", providers[1]["capabilities"])
+	}
+	if caps["hostedPluginRuntime"] != true || caps["providerGRPCTunnel"] != true || caps["cidrEgress"] != true {
+		t.Fatalf("runtime providers[1].capabilities = %#v", caps)
+	}
+}
+
+func TestAdminAPI_RuntimeProviderSessions(t *testing.T) {
+	t.Parallel()
+
+	ts := newTestServer(t, func(cfg *server.Config) {
+		cfg.PluginRuntimes = &staticRuntimeInspector{
+			snapshots: []bootstrap.RuntimeProviderSnapshot{{
+				Name:   "modal",
+				Driver: config.RuntimeProviderDriver("modal"),
+				Loaded: true,
+				Sessions: []pluginruntime.Session{{
+					ID:    "session-1",
+					State: pluginruntime.SessionStateRunning,
+					Metadata: map[string]string{
+						"plugin": "support",
+						"owner":  "support-platform",
+					},
+				}},
+			}},
+		}
+	})
+	testutil.CloseOnCleanup(t, ts)
+
+	resp, err := http.Get(ts.URL + "/admin/api/v1/runtime/providers/modal/sessions")
+	if err != nil {
+		t.Fatalf("GET runtime provider sessions: %v", err)
+	}
+	defer func() { _ = resp.Body.Close() }()
+	if resp.StatusCode != http.StatusOK {
+		body, _ := io.ReadAll(resp.Body)
+		t.Fatalf("runtime provider sessions status = %d, want 200: %s", resp.StatusCode, body)
+	}
+
+	var sessions []map[string]any
+	if err := json.NewDecoder(resp.Body).Decode(&sessions); err != nil {
+		t.Fatalf("decoding runtime provider sessions: %v", err)
+	}
+	if len(sessions) != 1 {
+		t.Fatalf("runtime provider sessions len = %d, want 1", len(sessions))
+	}
+	if got := sessions[0]["id"]; got != "session-1" {
+		t.Fatalf("runtime provider sessions[0].id = %v, want session-1", got)
+	}
+	if got := sessions[0]["state"]; got != string(pluginruntime.SessionStateRunning) {
+		t.Fatalf("runtime provider sessions[0].state = %v, want %q", got, pluginruntime.SessionStateRunning)
+	}
+	if got := sessions[0]["plugin"]; got != "support" {
+		t.Fatalf("runtime provider sessions[0].plugin = %v, want support", got)
+	}
+	if _, ok := sessions[0]["metadata"]; ok {
+		t.Fatalf("runtime provider sessions[0].metadata unexpectedly present: %#v", sessions[0]["metadata"])
+	}
+}
+
+func TestAdminAPI_RuntimeProviderInspectionError(t *testing.T) {
+	t.Parallel()
+
+	ts := newTestServer(t, func(cfg *server.Config) {
+		cfg.PluginRuntimes = &staticRuntimeInspector{
+			snapshots: []bootstrap.RuntimeProviderSnapshot{{
+				Name:   "modal",
+				Driver: config.RuntimeProviderDriver("modal"),
+				Loaded: true,
+				Error:  "capabilities: boom",
+			}},
+		}
+	})
+	testutil.CloseOnCleanup(t, ts)
+
+	providersResp, err := http.Get(ts.URL + "/admin/api/v1/runtime/providers")
+	if err != nil {
+		t.Fatalf("GET runtime providers with inspection error: %v", err)
+	}
+	defer func() { _ = providersResp.Body.Close() }()
+	if providersResp.StatusCode != http.StatusOK {
+		body, _ := io.ReadAll(providersResp.Body)
+		t.Fatalf("runtime providers status = %d, want 200: %s", providersResp.StatusCode, body)
+	}
+
+	var providers []map[string]any
+	if err := json.NewDecoder(providersResp.Body).Decode(&providers); err != nil {
+		t.Fatalf("decoding runtime providers: %v", err)
+	}
+	if len(providers) != 1 {
+		t.Fatalf("runtime providers len = %d, want 1", len(providers))
+	}
+	if got := providers[0]["error"]; got != "capabilities: boom" {
+		t.Fatalf("runtime providers[0].error = %v, want capabilities: boom", got)
+	}
+	if _, ok := providers[0]["capabilities"]; ok {
+		t.Fatalf("runtime providers[0].capabilities unexpectedly present: %#v", providers[0]["capabilities"])
+	}
+	if _, ok := providers[0]["sessionCount"]; ok {
+		t.Fatalf("runtime providers[0].sessionCount unexpectedly present: %#v", providers[0]["sessionCount"])
+	}
+
+	sessionsResp, err := http.Get(ts.URL + "/admin/api/v1/runtime/providers/modal/sessions")
+	if err != nil {
+		t.Fatalf("GET runtime provider sessions with inspection error: %v", err)
+	}
+	defer func() { _ = sessionsResp.Body.Close() }()
+	if sessionsResp.StatusCode != http.StatusServiceUnavailable {
+		body, _ := io.ReadAll(sessionsResp.Body)
+		t.Fatalf("runtime provider sessions status = %d, want 503: %s", sessionsResp.StatusCode, body)
 	}
 }
 


### PR DESCRIPTION
## Summary

This PR adds a read-only admin API for inspecting configured runtime providers and their active hosted sessions.

It uses the existing plugin runtime registry as the source of truth rather than introducing a second runtime state store.
For executable runtime providers, session inspection is host-driven: the internal runtime wrapper tracks sessions it starts and refreshes them with `GetSession`, so this works with the merged manifest-driven `kind: runtime` model without expanding the public runtime-provider RPC surface.

## New Interfaces

Runtime inspection:

```go
type RuntimeInspector interface {
    SnapshotPluginRuntimes(ctx context.Context) ([]RuntimeProviderSnapshot, error)
}

type RuntimeProviderSnapshot struct {
    Name         string
    Driver       config.RuntimeProviderDriver
    Default      bool
    Loaded       bool
    Capabilities pluginruntime.Capabilities
    Sessions     []pluginruntime.Session
    Error        string
}
```

Internal runtime provider surface used by the inspector:

```go
type Provider interface {
    Capabilities(ctx context.Context) (Capabilities, error)
    ListSessions(ctx context.Context) ([]Session, error)
    StartSession(ctx context.Context, req StartSessionRequest) (*Session, error)
    GetSession(ctx context.Context, req GetSessionRequest) (*Session, error)
    StopSession(ctx context.Context, req StopSessionRequest) error
    BindHostService(ctx context.Context, req BindHostServiceRequest) (*HostServiceBinding, error)
    StartPlugin(ctx context.Context, req StartPluginRequest) (*HostedPlugin, error)
    Close() error
}
```

Server wiring:

```go
type Result struct {
    ...
    PluginRuntimes RuntimeInspector
}

type Config struct {
    ...
    PluginRuntimes bootstrap.RuntimeInspector
}
```

## New Admin API Routes

```text
GET /admin/api/v1/runtime/providers
GET /admin/api/v1/runtime/providers/{provider}/sessions
```

Examples:

```bash
curl -s http://localhost:8080/admin/api/v1/runtime/providers
```

Example response:

```json
[
  {
    "name": "local",
    "driver": "local",
    "default": true,
    "loaded": false
  },
  {
    "name": "modal",
    "driver": "modal",
    "default": false,
    "loaded": true,
    "sessionCount": 1,
    "capabilities": {
      "hostedPluginRuntime": true,
      "hostServiceTunnels": false,
      "providerGRPCTunnel": true,
      "hostnameProxyEgress": false,
      "cidrEgress": true
    }
  }
]
```

```bash
curl -s http://localhost:8080/admin/api/v1/runtime/providers/modal/sessions
```

Example response:

```json
[
  {
    "id": "session-1",
    "state": "running",
    "plugin": "support"
  }
]
```

## Safety

Session inspection only exposes a safe summary:
- `id`
- `state`
- injected `plugin` identity

It does not dump arbitrary runtime session metadata through the admin API.

## What Changed

- adds `ListSessions` to the internal runtime host interface
- adds `bootstrap.RuntimeInspector` and `RuntimeProviderSnapshot`
- threads runtime inspection through `bootstrap.Result` and `server.Config`
- mounts admin runtime inspection routes under `/admin/api/v1/runtime/*`
- keeps executable runtime inspection host-side so manifest-driven runtime providers do not need a new public RPC
- adds server tests for provider listing, session listing, and inspection-error behavior

## Tests

Ran:

```bash
cd gestaltd && go test ./internal/pluginruntime ./internal/bootstrap ./internal/server -count=1
```
