### PR TITLE
Add hosted plugin webhooks with security schemes and dispatch

### DIFF
--- a/docs/content/reference/config-file.mdx
+++ b/docs/content/reference/config-file.mdx
@@ -818,6 +818,8 @@ plugins:
 | `surfaces` | Typed host-side overrides for manifest-declared surfaces, such as `surfaces.openapi.baseUrl` or `surfaces.graphql.url`. |
 | `connections` | Named connection declarations. See [connections](#connections) below. |
 | `allowedOperations` | Allowlist with optional `alias`, `description`, and `allowedRoles` overrides per operation. |
+| `securitySchemes` | Optional hosted-webhook security scheme overrides or additions for this plugin. |
+| `webhooks` | Optional hosted-webhook route overrides or additions for this plugin. |
 | `indexeddb` | Optional plugin IndexedDB config. `indexeddb.provider` selects which named `providers.indexeddb` entry backs the plugin's single IndexedDB SDK socket; when omitted, the plugin inherits the selected/default host IndexedDB. `indexeddb.db` overrides the plugin-visible database name and defaults to the plugin key. Schema-capable backends derive plugin scoping from that `db` name. `indexeddb.objectStores` optionally allowlists the logical object stores the plugin may use. Plugins then call `new IndexedDB()` (or the equivalent SDK helper) against `GESTALT_INDEXEDDB_SOCKET`; they do not choose arbitrary schemas or DSNs at runtime. |
 | `s3` | Optional list of named `providers.s3` bindings exposed to the executable plugin through the SDK transport. A single binding also populates the default S3 SDK env var for compatibility. |
 
@@ -858,6 +860,57 @@ when its `next` path resolves into that plugin's mounted UI. Standalone
 `providers.ui` bundles, the built-in admin UI/admin API, integration OAuth
 helper routes, and `/mcp` still use the server-wide auth provider in this
 phase.
+
+Hosted webhooks can be supplied or overridden from config too. This uses the
+same shapes as the manifest and merges by name over any manifest-declared
+`spec.securitySchemes` and `spec.webhooks` entries:
+
+```yaml
+plugins:
+  slack_agent:
+    source: ./dist/provider-release.yaml
+    securitySchemes:
+      slackSignature:
+        type: hmac
+        secret:
+          env: SLACK_SIGNING_SECRET
+        signature:
+          algorithm: sha256
+          signatureHeader: X-Slack-Signature
+          timestampHeader: X-Slack-Request-Timestamp
+          deliveryIdHeader: X-Slack-Delivery-ID
+          payloadTemplate: "v0:{header.X-Slack-Request-Timestamp}:{raw_body}"
+          digestPrefix: "v0="
+        replay:
+          maxAge: 5m
+    webhooks:
+      slackCommand:
+        path: /webhooks/slack-agent/command
+        post:
+          requestBody:
+            required: true
+            content:
+              application/x-www-form-urlencoded: {}
+          responses:
+            "200":
+              description: accepted
+              content:
+                application/json: {}
+              body:
+                response_type: ephemeral
+                text: Working on it...
+          security:
+            - slackSignature: []
+        target:
+          operation: handle_command
+        execution:
+          mode: async_ack
+          acceptedResponse: "200"
+```
+
+These routes are mounted directly on the public router. They are not protected
+by plugin `auth.provider`; instead they must declare webhook `security` that
+references one of the configured `securitySchemes`.
 For published providers, `source` can point at a `provider-release.yaml`
 metadata URL directly, or it can describe a GitHub release logically:
 

--- a/docs/content/reference/plugin-manifests.mdx
+++ b/docs/content/reference/plugin-manifests.mdx
@@ -66,6 +66,8 @@ The `spec` block for a `kind: plugin` manifest describes a plugin. It supports d
 | --- | --- | --- |
 | `configSchemaPath` | string | Path to a JSON/YAML schema that validates `plugins.<name>.config` in the server config. |
 | `auth` | RouteAuthRef | Optional plugin route-auth reference. Use `auth.provider` to bind the plugin’s mounted routes to a named request-auth provider. Legacy manifests may also use `spec.auth` for upstream connection auth when no `connections` map is defined. |
+| `securitySchemes` | map[string]WebhookSecurityScheme | Reusable hosted-webhook verification schemes such as HMAC, API key, HTTP auth, or mTLS. |
+| `webhooks` | map[string]WebhookDef | Hosted inbound webhook routes that Gestalt mounts directly and dispatches to plugin operations or workflow runs. |
 | `mcp` | bool | When true, the plugin exposes its operations as MCP tools. |
 | `headers` | map[string]string | Static headers injected into every outbound request. |
 | `surfaces` | Surfaces | Spec-loaded and declarative REST surfaces. See [Surfaces](#surfaces). |
@@ -139,6 +141,91 @@ The `connections` map defines named connection profiles. Deployment config can o
 | `auth` | ProviderAuth | Authentication configuration for this connection. |
 | `params` | map[string]ConnectionParam | Connection parameters populated during or after connect. |
 | `discovery` | Discovery | Post-connect discovery configuration. |
+
+### Hosted Webhooks
+
+Hosted webhooks are separate from normal plugin HTTP operation routes. They are mounted directly on the public router and use webhook verification from `spec.securitySchemes`, not `spec.auth`.
+
+Use `spec.securitySchemes` for reusable verification config:
+
+| Field | Type | Purpose |
+| --- | --- | --- |
+| `type` | string | One of `hmac`, `apiKey`, `http`, `mutualTLS`, or `none`. |
+| `secret.env` | string | Environment variable that contains the shared secret. |
+| `secret.secret` | string | Inline shared secret value. Useful for local testing. |
+| `signature.*` | object | HMAC signature settings such as headers, payload template, and digest prefix. |
+| `replay.maxAge` | string | Optional replay window such as `5m`. |
+| `name` / `in` | string | API-key header or query configuration. |
+| `scheme` | string | HTTP auth scheme, either `basic` or `bearer`. |
+| `mtls.subjectAltName` | string | Optional client-certificate SAN to require for mTLS webhook auth. |
+
+Use `spec.webhooks` to bind a public route to either a plugin operation or a workflow run:
+
+| Field | Type | Purpose |
+| --- | --- | --- |
+| `path` | string | Absolute public route Gestalt mounts for the webhook. |
+| `get` / `post` / `put` / `delete` | WebhookOperation | Exactly one HTTP method per webhook in the first pass. |
+| `target.operation` | string | Plugin operation to invoke. |
+| `target.workflow` | WebhookWorkflowTarget | Workflow run target with `provider`, `plugin`, `operation`, and optional `connection`, `instance`, `input`. |
+| `execution.mode` | string | Either `sync` or `async_ack`. |
+| `execution.acceptedResponse` | string | Response code to return immediately in `async_ack` mode. |
+
+Each webhook method supports:
+
+| Field | Type | Purpose |
+| --- | --- | --- |
+| `requestBody.content` | map[string]WebhookMediaType | Declares supported inbound media types such as `application/json` or `application/x-www-form-urlencoded`. |
+| `responses` | map[string]WebhookResponse | Declares response codes and optional static response bodies Gestalt can return. |
+| `security` | SecurityRequirement[] | OpenAPI-style OR-of-AND security requirements referencing `spec.securitySchemes`. |
+
+Example:
+
+```yaml
+spec:
+  connections:
+    default:
+      auth:
+        type: none
+
+  securitySchemes:
+    slackSignature:
+      type: hmac
+      secret:
+        env: SLACK_SIGNING_SECRET
+      signature:
+        algorithm: sha256
+        signatureHeader: X-Slack-Signature
+        timestampHeader: X-Slack-Request-Timestamp
+        deliveryIdHeader: X-Slack-Delivery-ID
+        payloadTemplate: "v0:{header.X-Slack-Request-Timestamp}:{raw_body}"
+        digestPrefix: "v0="
+      replay:
+        maxAge: 5m
+
+  webhooks:
+    slackCommand:
+      path: /webhooks/slack-agent/command
+      post:
+        requestBody:
+          required: true
+          content:
+            application/x-www-form-urlencoded: {}
+        responses:
+          "200":
+            description: accepted
+            content:
+              application/json: {}
+            body:
+              response_type: ephemeral
+              text: Working on it...
+        security:
+          - slackSignature: []
+      target:
+        operation: handle_command
+      execution:
+        mode: async_ack
+        acceptedResponse: "200"
+```
 
 ### Surfaces
 

--- a/gestaltd/internal/config/config.go
+++ b/gestaltd/internal/config/config.go
@@ -316,17 +316,19 @@ type ProviderEntry struct {
 	AuthorizationPolicy string `yaml:"authorizationPolicy,omitempty"`
 
 	// Plugin-specific config fields (parsed from YAML, only valid on plugin entries)
-	MountPath         string                        `yaml:"mountPath,omitempty"`
-	UI                string                        `yaml:"ui,omitempty"`
-	Connections       map[string]*ConnectionDef     `yaml:"connections,omitempty"`
-	AllowedOperations map[string]*OperationOverride `yaml:"allowedOperations,omitempty"`
-	Invokes           []PluginInvocationDependency  `yaml:"invokes,omitempty"`
-	IndexedDB         *PluginIndexedDBConfig        `yaml:"indexeddb,omitempty"`
-	Cache             []string                      `yaml:"cache,omitempty"`
-	S3                []string                      `yaml:"s3,omitempty"`
-	Runtime           *PluginRuntimeConfig          `yaml:"runtime,omitempty"`
-	Surfaces          *ProviderSurfaceOverrides     `yaml:"surfaces,omitempty"`
-	MCP               bool                          `yaml:"mcp,omitempty"`
+	MountPath         string                            `yaml:"mountPath,omitempty"`
+	UI                string                            `yaml:"ui,omitempty"`
+	Connections       map[string]*ConnectionDef         `yaml:"connections,omitempty"`
+	AllowedOperations map[string]*OperationOverride     `yaml:"allowedOperations,omitempty"`
+	SecuritySchemes   map[string]*WebhookSecurityScheme `yaml:"securitySchemes,omitempty"`
+	Webhooks          map[string]*WebhookDef            `yaml:"webhooks,omitempty"`
+	Invokes           []PluginInvocationDependency      `yaml:"invokes,omitempty"`
+	IndexedDB         *PluginIndexedDBConfig            `yaml:"indexeddb,omitempty"`
+	Cache             []string                          `yaml:"cache,omitempty"`
+	S3                []string                          `yaml:"s3,omitempty"`
+	Runtime           *PluginRuntimeConfig              `yaml:"runtime,omitempty"`
+	Surfaces          *ProviderSurfaceOverrides         `yaml:"surfaces,omitempty"`
+	MCP               bool                              `yaml:"mcp,omitempty"`
 
 	// Runtime-resolved fields (populated during init/bootstrap, not from YAML)
 	Command              string                                `yaml:"-"`
@@ -540,6 +542,170 @@ func cloneRouteAuthDef(src *RouteAuthDef) *RouteAuthDef {
 	return &cloned
 }
 
+func cloneWebhookSecuritySchemes(src map[string]*providermanifestv1.WebhookSecurityScheme) map[string]*providermanifestv1.WebhookSecurityScheme {
+	if src == nil {
+		return nil
+	}
+	cloned := make(map[string]*providermanifestv1.WebhookSecurityScheme, len(src))
+	for name, scheme := range src {
+		cloned[name] = cloneWebhookSecurityScheme(scheme)
+	}
+	return cloned
+}
+
+func cloneWebhookSecurityScheme(src *providermanifestv1.WebhookSecurityScheme) *providermanifestv1.WebhookSecurityScheme {
+	if src == nil {
+		return nil
+	}
+	cloned := *src
+	if src.Secret != nil {
+		copySecret := *src.Secret
+		cloned.Secret = &copySecret
+	}
+	if src.Signature != nil {
+		copySignature := *src.Signature
+		cloned.Signature = &copySignature
+	}
+	if src.Replay != nil {
+		copyReplay := *src.Replay
+		cloned.Replay = &copyReplay
+	}
+	if src.MTLS != nil {
+		copyMTLS := *src.MTLS
+		cloned.MTLS = &copyMTLS
+	}
+	return &cloned
+}
+
+func cloneWebhookDefs(src map[string]*providermanifestv1.WebhookDef) map[string]*providermanifestv1.WebhookDef {
+	if src == nil {
+		return nil
+	}
+	cloned := make(map[string]*providermanifestv1.WebhookDef, len(src))
+	for name, def := range src {
+		cloned[name] = cloneWebhookDef(def)
+	}
+	return cloned
+}
+
+func cloneWebhookDef(src *providermanifestv1.WebhookDef) *providermanifestv1.WebhookDef {
+	if src == nil {
+		return nil
+	}
+	cloned := *src
+	cloned.Get = cloneWebhookOperation(src.Get)
+	cloned.Post = cloneWebhookOperation(src.Post)
+	cloned.Put = cloneWebhookOperation(src.Put)
+	cloned.Delete = cloneWebhookOperation(src.Delete)
+	cloned.Target = cloneWebhookTarget(src.Target)
+	cloned.Execution = cloneWebhookExecution(src.Execution)
+	return &cloned
+}
+
+func cloneWebhookOperation(src *providermanifestv1.WebhookOperation) *providermanifestv1.WebhookOperation {
+	if src == nil {
+		return nil
+	}
+	cloned := *src
+	cloned.RequestBody = cloneWebhookRequestBody(src.RequestBody)
+	cloned.Responses = cloneWebhookResponses(src.Responses)
+	cloned.Security = cloneWebhookSecurityRequirements(src.Security)
+	return &cloned
+}
+
+func cloneWebhookRequestBody(src *providermanifestv1.WebhookRequestBody) *providermanifestv1.WebhookRequestBody {
+	if src == nil {
+		return nil
+	}
+	cloned := *src
+	cloned.Content = cloneWebhookMediaTypes(src.Content)
+	return &cloned
+}
+
+func cloneWebhookResponses(src map[string]*providermanifestv1.WebhookResponse) map[string]*providermanifestv1.WebhookResponse {
+	if src == nil {
+		return nil
+	}
+	cloned := make(map[string]*providermanifestv1.WebhookResponse, len(src))
+	for code, resp := range src {
+		if resp == nil {
+			cloned[code] = nil
+			continue
+		}
+		copyResp := *resp
+		if resp.Headers != nil {
+			copyResp.Headers = make(map[string]string, len(resp.Headers))
+			for key, value := range resp.Headers {
+				copyResp.Headers[key] = value
+			}
+		}
+		copyResp.Content = cloneWebhookMediaTypes(resp.Content)
+		cloned[code] = &copyResp
+	}
+	return cloned
+}
+
+func cloneWebhookMediaTypes(src map[string]*providermanifestv1.WebhookMediaType) map[string]*providermanifestv1.WebhookMediaType {
+	if src == nil {
+		return nil
+	}
+	cloned := make(map[string]*providermanifestv1.WebhookMediaType, len(src))
+	for name, mediaType := range src {
+		if mediaType == nil {
+			cloned[name] = nil
+			continue
+		}
+		copyMediaType := *mediaType
+		cloned[name] = &copyMediaType
+	}
+	return cloned
+}
+
+func cloneWebhookSecurityRequirements(src []providermanifestv1.SecurityRequirement) []providermanifestv1.SecurityRequirement {
+	if src == nil {
+		return nil
+	}
+	cloned := make([]providermanifestv1.SecurityRequirement, 0, len(src))
+	for _, requirement := range src {
+		if requirement == nil {
+			cloned = append(cloned, nil)
+			continue
+		}
+		copyRequirement := make(providermanifestv1.SecurityRequirement, len(requirement))
+		for name, scopes := range requirement {
+			copyRequirement[name] = append([]string(nil), scopes...)
+		}
+		cloned = append(cloned, copyRequirement)
+	}
+	return cloned
+}
+
+func cloneWebhookTarget(src *providermanifestv1.WebhookTarget) *providermanifestv1.WebhookTarget {
+	if src == nil {
+		return nil
+	}
+	cloned := *src
+	if src.Workflow != nil {
+		copyWorkflow := *src.Workflow
+		if src.Workflow.Input != nil {
+			copyWorkflow.Input = make(map[string]any, len(src.Workflow.Input))
+			for key, value := range src.Workflow.Input {
+				copyWorkflow.Input[key] = value
+			}
+		}
+		cloned.Workflow = &copyWorkflow
+	}
+	return &cloned
+}
+
+func cloneWebhookExecution(src *providermanifestv1.WebhookExecution) *providermanifestv1.WebhookExecution {
+	if src == nil {
+		return nil
+	}
+	cloned := *src
+	return &cloned
+}
+
 func (f providerEntryFields) toProviderEntry() ProviderEntry {
 	return ProviderEntry(f)
 }
@@ -631,6 +797,40 @@ func (e *ProviderEntry) ManifestSpec() *providermanifestv1.Spec {
 		return nil
 	}
 	return e.ResolvedManifest.Spec
+}
+
+func (e *ProviderEntry) EffectiveWebhookSecuritySchemes() map[string]*providermanifestv1.WebhookSecurityScheme {
+	var merged map[string]*providermanifestv1.WebhookSecurityScheme
+	if spec := e.ManifestSpec(); spec != nil && spec.SecuritySchemes != nil {
+		merged = cloneWebhookSecuritySchemes(spec.SecuritySchemes)
+	}
+	if e == nil || e.SecuritySchemes == nil {
+		return merged
+	}
+	if merged == nil {
+		merged = map[string]*providermanifestv1.WebhookSecurityScheme{}
+	}
+	for name, scheme := range e.SecuritySchemes {
+		merged[name] = cloneWebhookSecurityScheme(scheme)
+	}
+	return merged
+}
+
+func (e *ProviderEntry) EffectiveWebhooks() map[string]*providermanifestv1.WebhookDef {
+	var merged map[string]*providermanifestv1.WebhookDef
+	if spec := e.ManifestSpec(); spec != nil && spec.Webhooks != nil {
+		merged = cloneWebhookDefs(spec.Webhooks)
+	}
+	if e == nil || e.Webhooks == nil {
+		return merged
+	}
+	if merged == nil {
+		merged = map[string]*providermanifestv1.WebhookDef{}
+	}
+	for name, webhook := range e.Webhooks {
+		merged[name] = cloneWebhookDef(webhook)
+	}
+	return merged
 }
 
 func (e *ProviderEntry) DeclaresMCP() bool {
@@ -1055,6 +1255,10 @@ func EffectiveNamedConnectionDef(plugin *ProviderEntry, manifestPlugin *provider
 
 // OperationOverride holds optional alias and description for an allowed operation.
 type OperationOverride = providermanifestv1.ManifestOperationOverride
+type WebhookSecurityScheme = providermanifestv1.WebhookSecurityScheme
+type WebhookDef = providermanifestv1.WebhookDef
+type WebhookTarget = providermanifestv1.WebhookTarget
+type WebhookWorkflowTarget = providermanifestv1.WebhookWorkflowTarget
 
 type PluginInvocationDependency struct {
 	Plugin    string `yaml:"plugin,omitempty"`

--- a/gestaltd/internal/config/config_test.go
+++ b/gestaltd/internal/config/config_test.go
@@ -1385,6 +1385,78 @@ plugins:
 		}
 	})
 
+	t.Run("apiVersion preserves hosted webhooks and security schemes", func(t *testing.T) {
+		t.Parallel()
+
+		path := mustWriteConfigFile(t, `
+apiVersion: gestaltd.config/v3
+plugins:
+  slack_agent:
+    source:
+      path: ./plugins/slack-agent/manifest.yaml
+    securitySchemes:
+      slackSignature:
+        type: hmac
+        secret:
+          env: SLACK_SIGNING_SECRET
+        signature:
+          algorithm: sha256
+          signatureHeader: X-Slack-Signature
+          timestampHeader: X-Slack-Request-Timestamp
+          payloadTemplate: "v0:{header.X-Slack-Request-Timestamp}:{raw_body}"
+          digestPrefix: "v0="
+        replay:
+          maxAge: 5m
+    webhooks:
+      slackCommand:
+        path: /webhooks/slack-agent/command
+        post:
+          requestBody:
+            required: true
+            content:
+              application/x-www-form-urlencoded: {}
+          responses:
+            "200":
+              description: accepted
+              content:
+                application/json: {}
+              body:
+                response_type: ephemeral
+                text: Working on it...
+          security:
+            - slackSignature: []
+        target:
+          operation: handle_command
+        execution:
+          mode: async_ack
+          acceptedResponse: "200"
+`)
+
+		cfg, err := Load(path)
+		if err != nil {
+			t.Fatalf("Load: %v", err)
+		}
+		entry := cfg.Plugins["slack_agent"]
+		if entry == nil {
+			t.Fatal("expected slack_agent plugin config")
+		}
+		if scheme := entry.SecuritySchemes["slackSignature"]; scheme == nil || scheme.Type != providermanifestv1.WebhookSecuritySchemeTypeHMAC {
+			t.Fatalf("SecuritySchemes[slackSignature] = %#v", entry.SecuritySchemes["slackSignature"])
+		}
+		webhook := entry.Webhooks["slackCommand"]
+		if webhook == nil || webhook.Post == nil || webhook.Path != "/webhooks/slack-agent/command" {
+			t.Fatalf("Webhooks[slackCommand] = %#v", webhook)
+		}
+		marshaled, err := yaml.Marshal(entry)
+		if err != nil {
+			t.Fatalf("yaml.Marshal: %v", err)
+		}
+		rendered := string(marshaled)
+		if !strings.Contains(rendered, "securitySchemes:") || !strings.Contains(rendered, "webhooks:") {
+			t.Fatalf("expected rendered entry to preserve webhook metadata:\n%s", rendered)
+		}
+	})
+
 	t.Run("apiVersion preserves nested source auth on local release metadata sources", func(t *testing.T) {
 		t.Parallel()
 

--- a/gestaltd/internal/config/config_validate.go
+++ b/gestaltd/internal/config/config_validate.go
@@ -476,6 +476,9 @@ func validatePlugin(cfg *Config, name string, entry *ProviderEntry, sourceSyntax
 	if err := validatePluginRouteAuth(cfg, name, entry); err != nil {
 		return err
 	}
+	if err := validatePluginWebhooks(name, entry); err != nil {
+		return err
+	}
 	if err := validatePluginIndexedDBConfig(cfg, name, entry); err != nil {
 		return err
 	}
@@ -514,6 +517,24 @@ func validatePluginRouteAuth(cfg *Config, name string, entry *ProviderEntry) err
 	}
 	if _, ok := cfg.Providers.Authentication[entry.RouteAuth.Provider]; !ok {
 		return fmt.Errorf("config validation: plugins.%s.auth.provider references unknown authentication provider %q", name, entry.RouteAuth.Provider)
+	}
+	return nil
+}
+
+func validatePluginWebhooks(name string, entry *ProviderEntry) error {
+	if entry == nil {
+		return nil
+	}
+	schemes := entry.EffectiveWebhookSecuritySchemes()
+	for schemeName, scheme := range schemes {
+		if err := providerpkg.ValidateWebhookSecurityScheme(fmt.Sprintf("plugins.%s.securitySchemes.%s", name, schemeName), scheme); err != nil {
+			return err
+		}
+	}
+	for webhookName, webhook := range entry.EffectiveWebhooks() {
+		if err := providerpkg.ValidateWebhookDef(fmt.Sprintf("plugins.%s.webhooks.%s", name, webhookName), webhook, schemes); err != nil {
+			return err
+		}
 	}
 	return nil
 }
@@ -685,6 +706,12 @@ func validatePluginOnlyProviderFields(subject string, entry *ProviderEntry) erro
 	}
 	if entry.Surfaces != nil {
 		return fmt.Errorf("config validation: %s.surfaces is only supported on plugins.*", subject)
+	}
+	if len(entry.SecuritySchemes) > 0 {
+		return fmt.Errorf("config validation: %s.securitySchemes is only supported on plugins.*", subject)
+	}
+	if len(entry.Webhooks) > 0 {
+		return fmt.Errorf("config validation: %s.webhooks is only supported on plugins.*", subject)
 	}
 	if entry.AuthorizationPolicy != "" && !strings.HasPrefix(subject, "ui.") {
 		return fmt.Errorf("config validation: %s.authorizationPolicy is only supported on plugins.* and ui.*", subject)

--- a/gestaltd/internal/principal/principal.go
+++ b/gestaltd/internal/principal/principal.go
@@ -15,6 +15,7 @@ const (
 	SourceSession
 	SourceAPIToken
 	SourceWorkloadToken
+	SourceWebhook
 	SourceEnv
 )
 
@@ -50,6 +51,8 @@ func (s Source) String() string {
 		return "api_token"
 	case SourceWorkloadToken:
 		return "workload_token"
+	case SourceWebhook:
+		return "webhook"
 	case SourceEnv:
 		return "env"
 	default:
@@ -65,6 +68,8 @@ func ParseSource(value string) Source {
 		return SourceAPIToken
 	case SourceWorkloadToken.String():
 		return SourceWorkloadToken
+	case SourceWebhook.String():
+		return SourceWebhook
 	case SourceEnv.String():
 		return SourceEnv
 	default:

--- a/gestaltd/internal/providerpkg/manifest.go
+++ b/gestaltd/internal/providerpkg/manifest.go
@@ -4,12 +4,15 @@ import (
 	"bytes"
 	"encoding/json"
 	"fmt"
+	"net/http"
 	"os"
 	"path"
 	"path/filepath"
 	"runtime"
 	"slices"
+	"strconv"
 	"strings"
+	"time"
 
 	"github.com/valon-technologies/gestalt/server/internal/pluginsource"
 	providermanifestv1 "github.com/valon-technologies/gestalt/server/sdk/providermanifest/v1"
@@ -413,12 +416,237 @@ func validateRouteAuthRef(path string, auth *providermanifestv1.RouteAuthRef) er
 	return nil
 }
 
+func validateWebhookSecurityScheme(path string, scheme *providermanifestv1.WebhookSecurityScheme) error {
+	if scheme == nil {
+		return fmt.Errorf("%s is required", path)
+	}
+	switch scheme.Type {
+	case providermanifestv1.WebhookSecuritySchemeTypeHMAC:
+		if scheme.Signature == nil {
+			return fmt.Errorf("%s.signature is required for hmac security schemes", path)
+		}
+		if strings.TrimSpace(scheme.Signature.Algorithm) == "" {
+			return fmt.Errorf("%s.signature.algorithm is required", path)
+		}
+		if strings.TrimSpace(scheme.Signature.SignatureHeader) == "" {
+			return fmt.Errorf("%s.signature.signatureHeader is required", path)
+		}
+		if scheme.Secret == nil || (strings.TrimSpace(scheme.Secret.Env) == "" && strings.TrimSpace(scheme.Secret.Secret) == "") {
+			return fmt.Errorf("%s.secret.env or %s.secret.secret is required for hmac security schemes", path, path)
+		}
+		if scheme.Replay != nil && strings.TrimSpace(scheme.Replay.MaxAge) != "" {
+			if _, err := time.ParseDuration(strings.TrimSpace(scheme.Replay.MaxAge)); err != nil {
+				return fmt.Errorf("%s.replay.maxAge is invalid: %w", path, err)
+			}
+		}
+	case providermanifestv1.WebhookSecuritySchemeTypeAPIKey:
+		if strings.TrimSpace(scheme.Name) == "" {
+			return fmt.Errorf("%s.name is required for apiKey security schemes", path)
+		}
+		switch scheme.In {
+		case providermanifestv1.WebhookInHeader, providermanifestv1.WebhookInQuery:
+		default:
+			return fmt.Errorf("%s.in must be %q or %q for apiKey security schemes", path, providermanifestv1.WebhookInHeader, providermanifestv1.WebhookInQuery)
+		}
+		if scheme.Secret == nil || (strings.TrimSpace(scheme.Secret.Env) == "" && strings.TrimSpace(scheme.Secret.Secret) == "") {
+			return fmt.Errorf("%s.secret.env or %s.secret.secret is required for apiKey security schemes", path, path)
+		}
+	case providermanifestv1.WebhookSecuritySchemeTypeHTTP:
+		switch scheme.Scheme {
+		case providermanifestv1.WebhookHTTPSchemeBasic, providermanifestv1.WebhookHTTPSchemeBearer:
+		default:
+			return fmt.Errorf("%s.scheme must be %q or %q for http security schemes", path, providermanifestv1.WebhookHTTPSchemeBasic, providermanifestv1.WebhookHTTPSchemeBearer)
+		}
+		if scheme.Secret == nil || (strings.TrimSpace(scheme.Secret.Env) == "" && strings.TrimSpace(scheme.Secret.Secret) == "") {
+			return fmt.Errorf("%s.secret.env or %s.secret.secret is required for http security schemes", path, path)
+		}
+	case providermanifestv1.WebhookSecuritySchemeTypeMutualTLS:
+		if scheme.Secret != nil || scheme.Signature != nil || scheme.Replay != nil {
+			return fmt.Errorf("%s.mutualTLS does not support secret, signature, or replay configuration", path)
+		}
+	case providermanifestv1.WebhookSecuritySchemeTypeNone:
+	default:
+		return fmt.Errorf("%s.type %q is unsupported", path, scheme.Type)
+	}
+	return nil
+}
+
+func webhookOperationMethod(def *providermanifestv1.WebhookDef) (string, *providermanifestv1.WebhookOperation, int) {
+	if def == nil {
+		return "", nil, 0
+	}
+	var (
+		method string
+		op     *providermanifestv1.WebhookOperation
+		count  int
+	)
+	for _, candidate := range []struct {
+		method string
+		op     *providermanifestv1.WebhookOperation
+	}{
+		{method: http.MethodGet, op: def.Get},
+		{method: http.MethodPost, op: def.Post},
+		{method: http.MethodPut, op: def.Put},
+		{method: http.MethodDelete, op: def.Delete},
+	} {
+		if candidate.op == nil {
+			continue
+		}
+		method = candidate.method
+		op = candidate.op
+		count++
+	}
+	return method, op, count
+}
+
+func validateWebhookOperation(path string, op *providermanifestv1.WebhookOperation, schemes map[string]*providermanifestv1.WebhookSecurityScheme) error {
+	if op == nil {
+		return fmt.Errorf("%s is required", path)
+	}
+	if len(op.Security) == 0 {
+		return fmt.Errorf("%s.security is required", path)
+	}
+	for i, requirement := range op.Security {
+		if len(requirement) == 0 {
+			return fmt.Errorf("%s.security[%d] must declare at least one security scheme", path, i)
+		}
+		for name := range requirement {
+			if _, ok := schemes[name]; !ok {
+				return fmt.Errorf("%s.security[%d] references unknown security scheme %q", path, i, name)
+			}
+		}
+	}
+	if op.RequestBody != nil && op.RequestBody.Required && len(op.RequestBody.Content) == 0 {
+		return fmt.Errorf("%s.requestBody.content is required when requestBody.required is true", path)
+	}
+	if len(op.Responses) == 0 {
+		return fmt.Errorf("%s.responses is required", path)
+	}
+	for code, response := range op.Responses {
+		if strings.TrimSpace(code) == "" {
+			return fmt.Errorf("%s.responses codes must be non-empty", path)
+		}
+		status, err := strconv.Atoi(code)
+		if err != nil || status < 100 || status > 599 || http.StatusText(status) == "" && status < 600 {
+			return fmt.Errorf("%s.responses.%s must be a valid HTTP status code", path, code)
+		}
+		if response == nil {
+			return fmt.Errorf("%s.responses.%s is required", path, code)
+		}
+		if response.Body != nil && len(response.Content) > 1 {
+			return fmt.Errorf("%s.responses.%s.body requires at most one content entry", path, code)
+		}
+	}
+	return nil
+}
+
+func validateWebhookTarget(path string, target *providermanifestv1.WebhookTarget) error {
+	if target == nil {
+		return fmt.Errorf("%s is required", path)
+	}
+	count := 0
+	if strings.TrimSpace(target.Operation) != "" {
+		count++
+	}
+	if target.Workflow != nil {
+		count++
+	}
+	if count != 1 {
+		return fmt.Errorf("%s must declare exactly one of operation or workflow", path)
+	}
+	if target.Workflow != nil {
+		if strings.TrimSpace(target.Workflow.Plugin) == "" {
+			return fmt.Errorf("%s.workflow.plugin is required", path)
+		}
+		if strings.TrimSpace(target.Workflow.Operation) == "" {
+			return fmt.Errorf("%s.workflow.operation is required", path)
+		}
+	}
+	return nil
+}
+
+func validateWebhookExecution(path string, execution *providermanifestv1.WebhookExecution, responses map[string]*providermanifestv1.WebhookResponse) error {
+	if execution == nil {
+		return nil
+	}
+	switch execution.Mode {
+	case "", providermanifestv1.WebhookExecutionModeSync, providermanifestv1.WebhookExecutionModeAsyncAck:
+	default:
+		return fmt.Errorf("%s.mode %q is unsupported", path, execution.Mode)
+	}
+	if execution.Mode != providermanifestv1.WebhookExecutionModeAsyncAck {
+		if strings.TrimSpace(execution.AcceptedResponse) != "" {
+			return fmt.Errorf("%s.acceptedResponse is only supported when mode is %q", path, providermanifestv1.WebhookExecutionModeAsyncAck)
+		}
+		return nil
+	}
+	code := strings.TrimSpace(execution.AcceptedResponse)
+	if code == "" {
+		return fmt.Errorf("%s.acceptedResponse is required when mode is %q", path, providermanifestv1.WebhookExecutionModeAsyncAck)
+	}
+	parsed, err := strconv.Atoi(code)
+	if err != nil || parsed < 200 || parsed >= 300 {
+		return fmt.Errorf("%s.acceptedResponse must reference a 2xx response when mode is %q", path, providermanifestv1.WebhookExecutionModeAsyncAck)
+	}
+	if _, ok := responses[code]; !ok {
+		return fmt.Errorf("%s.acceptedResponse references undefined response %q", path, code)
+	}
+	return nil
+}
+
+func validateWebhookDef(path string, def *providermanifestv1.WebhookDef, schemes map[string]*providermanifestv1.WebhookSecurityScheme) error {
+	if def == nil {
+		return fmt.Errorf("%s is required", path)
+	}
+	if strings.TrimSpace(def.Path) == "" {
+		return fmt.Errorf("%s.path is required", path)
+	}
+	if !strings.HasPrefix(strings.TrimSpace(def.Path), "/") {
+		return fmt.Errorf("%s.path must start with \"/\"", path)
+	}
+	if strings.Contains(def.Path, "*") {
+		return fmt.Errorf("%s.path must not contain wildcards", path)
+	}
+	method, op, methodCount := webhookOperationMethod(def)
+	if methodCount != 1 {
+		return fmt.Errorf("%s must declare exactly one HTTP method in the first pass", path)
+	}
+	if err := validateWebhookOperation(path+"."+strings.ToLower(method), op, schemes); err != nil {
+		return err
+	}
+	if err := validateWebhookTarget(path+".target", def.Target); err != nil {
+		return err
+	}
+	if err := validateWebhookExecution(path+".execution", def.Execution, op.Responses); err != nil {
+		return err
+	}
+	return nil
+}
+
+func ValidateWebhookSecurityScheme(path string, scheme *providermanifestv1.WebhookSecurityScheme) error {
+	return validateWebhookSecurityScheme(path, scheme)
+}
+
+func ValidateWebhookDef(path string, def *providermanifestv1.WebhookDef, schemes map[string]*providermanifestv1.WebhookSecurityScheme) error {
+	return validateWebhookDef(path, def, schemes)
+}
+
 func validateExecutableProviderMetadata(provider *providermanifestv1.Spec) error {
 	if provider == nil {
 		return nil
 	}
 	if err := validateRouteAuthRef("provider.auth", provider.RouteAuth); err != nil {
 		return err
+	}
+	for name, scheme := range provider.SecuritySchemes {
+		if err := validateWebhookSecurityScheme(fmt.Sprintf("provider.securitySchemes.%s", name), scheme); err != nil {
+			return err
+		}
+	}
+	for name, webhook := range provider.Webhooks {
+		if err := validateWebhookDef(fmt.Sprintf("provider.webhooks.%s", name), webhook, provider.SecuritySchemes); err != nil {
+			return err
+		}
 	}
 	for name, conn := range provider.Connections {
 		if conn == nil {

--- a/gestaltd/internal/providerpkg/manifest_workflow_test.go
+++ b/gestaltd/internal/providerpkg/manifest_workflow_test.go
@@ -496,6 +496,133 @@ spec:
 	}
 }
 
+func TestManifestWorkflow_AcceptsHostedWebhooksAndSecuritySchemes(t *testing.T) {
+	t.Parallel()
+
+	dir := t.TempDir()
+	manifestPath := mustWriteManifestData(t, dir, "manifest.yaml", []byte(`
+kind: plugin
+source: github.com/acme/plugins/slack-agent
+version: 1.0.0
+spec:
+  connections:
+    default:
+      auth:
+        type: none
+  securitySchemes:
+    slackSignature:
+      type: hmac
+      secret:
+        env: SLACK_SIGNING_SECRET
+      signature:
+        algorithm: sha256
+        signatureHeader: X-Slack-Signature
+        timestampHeader: X-Slack-Request-Timestamp
+        payloadTemplate: "v0:{header.X-Slack-Request-Timestamp}:{raw_body}"
+        digestPrefix: "v0="
+      replay:
+        maxAge: 5m
+  webhooks:
+    slackCommand:
+      path: /webhooks/slack-agent/command
+      post:
+        requestBody:
+          required: true
+          content:
+            application/x-www-form-urlencoded: {}
+        responses:
+          "200":
+            description: accepted
+            content:
+              application/json: {}
+            body:
+              response_type: ephemeral
+              text: Working on it...
+        security:
+          - slackSignature: []
+      target:
+        operation: handle_command
+      execution:
+        mode: async_ack
+        acceptedResponse: "200"
+`))
+
+	_, manifest, err := ReadSourceManifestFile(manifestPath)
+	if err != nil {
+		t.Fatalf("ReadSourceManifestFile: %v", err)
+	}
+	if manifest.Spec == nil {
+		t.Fatal("expected plugin spec")
+	}
+	if scheme := manifest.Spec.SecuritySchemes["slackSignature"]; scheme == nil || scheme.Type != providermanifestv1.WebhookSecuritySchemeTypeHMAC {
+		t.Fatalf("unexpected security scheme: %#v", manifest.Spec.SecuritySchemes["slackSignature"])
+	}
+	webhook := manifest.Spec.Webhooks["slackCommand"]
+	if webhook == nil || webhook.Post == nil || webhook.Path != "/webhooks/slack-agent/command" {
+		t.Fatalf("unexpected webhook: %#v", webhook)
+	}
+	if webhook.Execution == nil || webhook.Execution.Mode != providermanifestv1.WebhookExecutionModeAsyncAck {
+		t.Fatalf("unexpected webhook execution: %#v", webhook.Execution)
+	}
+
+	encoded, err := EncodeSourceManifestFormat(manifest, ManifestFormatYAML)
+	if err != nil {
+		t.Fatalf("EncodeSourceManifestFormat: %v", err)
+	}
+	rendered := string(encoded)
+	if !strings.Contains(rendered, "securitySchemes:") || !strings.Contains(rendered, "webhooks:") {
+		t.Fatalf("expected encoded manifest to preserve webhook metadata:\n%s", rendered)
+	}
+}
+
+func TestManifestWorkflow_RejectsNon2xxAsyncWebhookAcknowledgements(t *testing.T) {
+	t.Parallel()
+
+	manifestPath := filepath.Join(t.TempDir(), "manifest.yaml")
+	if err := os.WriteFile(manifestPath, []byte(`
+kind: plugin
+source: github.com/acme/plugins/slack-agent
+version: 1.0.0
+spec:
+  connections:
+    default:
+      auth:
+        type: none
+  securitySchemes:
+    slackSignature:
+      type: hmac
+      secret:
+        env: SLACK_SIGNING_SECRET
+      signature:
+        algorithm: sha256
+        signatureHeader: X-Slack-Signature
+  webhooks:
+    slackCommand:
+      path: /webhooks/slack-agent/command
+      post:
+        responses:
+          "500":
+            description: bad ack
+        security:
+          - slackSignature: []
+      target:
+        operation: handle_command
+      execution:
+        mode: async_ack
+        acceptedResponse: "500"
+`), 0o644); err != nil {
+		t.Fatalf("WriteFile manifest: %v", err)
+	}
+
+	_, _, err := ReadSourceManifestFile(manifestPath)
+	if err == nil {
+		t.Fatal("expected non-2xx async webhook acknowledgement to be rejected")
+	}
+	if !strings.Contains(err.Error(), "acceptedResponse must reference a 2xx response") {
+		t.Fatalf("error = %v, want acceptedResponse 2xx validation", err)
+	}
+}
+
 func TestManifestWorkflow_EncodesCanonicalProgrammaticDefaultConnection(t *testing.T) {
 	t.Parallel()
 

--- a/gestaltd/internal/server/handlers_webhooks.go
+++ b/gestaltd/internal/server/handlers_webhooks.go
@@ -1,0 +1,104 @@
+package server
+
+import (
+	"errors"
+	"io"
+	"log/slog"
+	"net/http"
+	"strings"
+
+	providermanifestv1 "github.com/valon-technologies/gestalt/server/sdk/providermanifest/v1"
+)
+
+func (s *Server) handleWebhook(mounted MountedWebhook, w http.ResponseWriter, r *http.Request) {
+	rawBody, err := readWebhookBody(r)
+	if err != nil {
+		writeError(w, http.StatusBadRequest, err.Error())
+		return
+	}
+
+	verified, err := s.verifyWebhookRequest(r, mounted, rawBody)
+	if err != nil {
+		var requestErr *webhookRequestError
+		if errors.As(err, &requestErr) {
+			if requestErr.status >= 500 {
+				slog.ErrorContext(r.Context(), "webhook verification failed", "plugin", mounted.PluginName, "webhook", mounted.Name, "error", err)
+			} else {
+				slog.WarnContext(r.Context(), "webhook verification rejected request", "plugin", mounted.PluginName, "webhook", mounted.Name, "error", err)
+			}
+			writeError(w, requestErr.status, requestErr.message)
+			return
+		}
+		slog.ErrorContext(r.Context(), "webhook verification failed", "plugin", mounted.PluginName, "webhook", mounted.Name, "error", err)
+		writeError(w, http.StatusUnauthorized, "webhook verification failed")
+		return
+	}
+
+	parsed, err := parseWebhookRequest(r, mounted.Operation, rawBody)
+	if err != nil {
+		writeError(w, http.StatusBadRequest, err.Error())
+		return
+	}
+
+	executionMode := providermanifestv1.WebhookExecutionModeSync
+	if mounted.Execution != nil && mounted.Execution.Mode != "" {
+		executionMode = mounted.Execution.Mode
+	}
+
+	switch executionMode {
+	case providermanifestv1.WebhookExecutionModeAsyncAck:
+		s.dispatchWebhookAsync(mounted, verified, parsed.Params)
+		responseCode := strings.TrimSpace(mounted.Execution.AcceptedResponse)
+		response := mounted.Operation.Responses[responseCode]
+		if err := writeWebhookResponse(w, responseCode, response); err != nil {
+			slog.ErrorContext(r.Context(), "write webhook accepted response", "plugin", mounted.PluginName, "webhook", mounted.Name, "error", err)
+			writeError(w, http.StatusInternalServerError, "failed to write webhook response")
+		}
+		return
+	default:
+		switch {
+		case mounted.Target != nil && strings.TrimSpace(mounted.Target.Operation) != "":
+			result, err := s.webhookOperationInvocation(r.Context(), mounted, verified, parsed.Params)
+			if err != nil {
+				s.writeInvocationError(w, r, mounted.PluginName, mounted.Target.Operation, err)
+				return
+			}
+			writeOperationResult(w, result)
+			return
+		case mounted.Target != nil && mounted.Target.Workflow != nil:
+			run, err := s.startWebhookWorkflowRun(r.Context(), mounted, verified, parsed.Params)
+			if err != nil {
+				slog.ErrorContext(r.Context(), "webhook workflow start failed", "plugin", mounted.PluginName, "webhook", mounted.Name, "error", err)
+				writeError(w, http.StatusBadGateway, "workflow start failed")
+				return
+			}
+			if responseCode := defaultWebhookAcceptedResponseCode(mounted.Operation); responseCode != "" {
+				response := mounted.Operation.Responses[responseCode]
+				if response != nil && (response.Body != nil || len(response.Headers) > 0) {
+					if err := writeWebhookResponse(w, responseCode, response); err != nil {
+						slog.ErrorContext(r.Context(), "write webhook workflow response", "plugin", mounted.PluginName, "webhook", mounted.Name, "error", err)
+						writeError(w, http.StatusInternalServerError, "failed to write webhook response")
+					}
+					return
+				}
+			}
+			writeJSON(w, http.StatusAccepted, run)
+			return
+		default:
+			writeError(w, http.StatusInternalServerError, "webhook target is not configured")
+			return
+		}
+	}
+}
+
+func readWebhookBody(r *http.Request) ([]byte, error) {
+	if r == nil || r.Body == nil {
+		return nil, nil
+	}
+	defer func() { _ = r.Body.Close() }()
+	body, err := io.ReadAll(r.Body)
+	if err != nil {
+		return nil, errors.New("failed to read request body")
+	}
+	return body, nil
+}

--- a/gestaltd/internal/server/routes.go
+++ b/gestaltd/internal/server/routes.go
@@ -19,6 +19,7 @@ func (s *Server) routes() {
 		s.mountCoreRoutes(r, metricsHidden)
 		s.mountMCPRoutes(r)
 		s.mountAPIRoutes(r)
+		s.mountWebhookRoutes(r)
 		s.mountMountedWebUIRoutes(r)
 		s.mountManagementHiddenRoutes(r)
 	case RouteProfileManagement:
@@ -30,6 +31,7 @@ func (s *Server) routes() {
 		s.mountCoreRoutes(r, metricsAuthenticated)
 		s.mountMCPRoutes(r)
 		s.mountAPIRoutes(r)
+		s.mountWebhookRoutes(r)
 		s.mountMountedWebUIRoutes(r)
 		s.mountAdminAPIRoutes(r)
 		s.mountAdminUIRoutes(r)

--- a/gestaltd/internal/server/routes_webhooks.go
+++ b/gestaltd/internal/server/routes_webhooks.go
@@ -1,0 +1,143 @@
+package server
+
+import (
+	"fmt"
+	"net/http"
+	"slices"
+	"strings"
+
+	"github.com/go-chi/chi/v5"
+	"github.com/valon-technologies/gestalt/server/internal/config"
+	providermanifestv1 "github.com/valon-technologies/gestalt/server/sdk/providermanifest/v1"
+)
+
+func mountedWebhooksFromEntries(entries map[string]*config.ProviderEntry) ([]MountedWebhook, error) {
+	if len(entries) == 0 {
+		return nil, nil
+	}
+
+	names := make([]string, 0, len(entries))
+	for name := range entries {
+		names = append(names, name)
+	}
+	slices.Sort(names)
+
+	mounted := make([]MountedWebhook, 0)
+	for _, pluginName := range names {
+		entry := entries[pluginName]
+		if entry == nil {
+			continue
+		}
+		schemes := entry.EffectiveWebhookSecuritySchemes()
+		webhooks := entry.EffectiveWebhooks()
+		if len(webhooks) == 0 {
+			continue
+		}
+
+		webhookNames := make([]string, 0, len(webhooks))
+		for name := range webhooks {
+			webhookNames = append(webhookNames, name)
+		}
+		slices.Sort(webhookNames)
+
+		for _, webhookName := range webhookNames {
+			def := webhooks[webhookName]
+			method, op, err := mountedWebhookOperation(def)
+			if err != nil {
+				return nil, fmt.Errorf("resolve webhook %s.%s: %w", pluginName, webhookName, err)
+			}
+			mounted = append(mounted, MountedWebhook{
+				Name:            webhookName,
+				PluginName:      pluginName,
+				Path:            strings.TrimSpace(def.Path),
+				Method:          method,
+				Operation:       op,
+				Target:          def.Target,
+				Execution:       def.Execution,
+				SecuritySchemes: schemes,
+			})
+		}
+	}
+	return mounted, nil
+}
+
+func mountedWebhookOperation(def *providermanifestv1.WebhookDef) (string, *providermanifestv1.WebhookOperation, error) {
+	if def == nil {
+		return "", nil, fmt.Errorf("webhook definition is required")
+	}
+	var (
+		method string
+		op     *providermanifestv1.WebhookOperation
+		count  int
+	)
+	for _, candidate := range []struct {
+		method string
+		op     *providermanifestv1.WebhookOperation
+	}{
+		{method: http.MethodGet, op: def.Get},
+		{method: http.MethodPost, op: def.Post},
+		{method: http.MethodPut, op: def.Put},
+		{method: http.MethodDelete, op: def.Delete},
+	} {
+		if candidate.op == nil {
+			continue
+		}
+		method = candidate.method
+		op = candidate.op
+		count++
+	}
+	if count != 1 {
+		return "", nil, fmt.Errorf("exactly one HTTP method must be configured")
+	}
+	return method, op, nil
+}
+
+func validateMountedWebhookRoutes(webhooks []MountedWebhook, mountedWebUIs []MountedWebUI) error {
+	seen := make(map[string]string, len(webhooks))
+	for _, webhook := range webhooks {
+		path := strings.TrimSpace(webhook.Path)
+		if path == "" {
+			return fmt.Errorf("webhook %s.%s path is required", webhook.PluginName, webhook.Name)
+		}
+		if path == "/" {
+			return fmt.Errorf("webhook %s.%s path \"/\" is not supported", webhook.PluginName, webhook.Name)
+		}
+		if !strings.HasPrefix(path, "/") {
+			return fmt.Errorf("webhook %s.%s path must start with \"/\"", webhook.PluginName, webhook.Name)
+		}
+		if strings.Contains(path, "*") {
+			return fmt.Errorf("webhook %s.%s path must not contain wildcards", webhook.PluginName, webhook.Name)
+		}
+		for _, prefix := range []string{"/api", "/mcp", "/metrics", "/health", "/ready"} {
+			if path == prefix || strings.HasPrefix(path, prefix+"/") {
+				return fmt.Errorf("webhook %s.%s path %q conflicts with core route namespace %q", webhook.PluginName, webhook.Name, path, prefix)
+			}
+		}
+		if path == "/admin" || strings.HasPrefix(path, "/admin/") {
+			return fmt.Errorf("webhook %s.%s path %q conflicts with admin route namespace", webhook.PluginName, webhook.Name, path)
+		}
+		for _, mounted := range mountedWebUIs {
+			if mounted.Path == "" || mounted.Path == "/" {
+				continue
+			}
+			if path == mounted.Path || strings.HasPrefix(path, mounted.Path+"/") {
+				return fmt.Errorf("webhook %s.%s path %q conflicts with mounted UI %q", webhook.PluginName, webhook.Name, path, mounted.Path)
+			}
+		}
+		key := webhook.Method + " " + path
+		if previous, ok := seen[key]; ok {
+			return fmt.Errorf("webhook %s.%s duplicates webhook route %s", webhook.PluginName, webhook.Name, previous)
+		}
+		seen[key] = webhook.PluginName + "." + webhook.Name
+	}
+	return nil
+}
+
+func (s *Server) mountWebhookRoutes(r chi.Router) {
+	for _, mounted := range s.mountedWebhooks {
+		mounted := mounted
+		r.MethodFunc(mounted.Method, mounted.Path, func(w http.ResponseWriter, r *http.Request) {
+			s.handleWebhook(mounted, w, r)
+		})
+	}
+}

--- a/gestaltd/internal/server/server.go
+++ b/gestaltd/internal/server/server.go
@@ -50,6 +50,17 @@ type MountedWebUI struct {
 	builtInAdmin        bool
 }
 
+type MountedWebhook struct {
+	Name            string
+	PluginName      string
+	Path            string
+	Method          string
+	Operation       *providermanifestv1.WebhookOperation
+	Target          *providermanifestv1.WebhookTarget
+	Execution       *providermanifestv1.WebhookExecution
+	SecuritySchemes map[string]*providermanifestv1.WebhookSecurityScheme
+}
+
 type AdminRouteConfig struct {
 	AuthorizationPolicy string
 	AllowedRoles        []string
@@ -103,9 +114,11 @@ type Server struct {
 	prometheusMetrics     http.Handler
 	mcpHandler            http.Handler
 	mountedWebUIs         []MountedWebUI
+	mountedWebhooks       []MountedWebhook
 	adminRoute            AdminRouteConfig
 	adminUI               http.Handler
 	routeProfile          RouteProfile
+	webhookReplayStore    webhookReplayStore
 }
 
 func (s *Server) catalogSelectorConfig() invocation.CatalogSelectorConfig {
@@ -201,6 +214,13 @@ func New(cfg Config) (*Server, error) {
 	if err != nil {
 		return nil, err
 	}
+	mountedWebhooks, err := mountedWebhooksFromEntries(cfg.PluginDefs)
+	if err != nil {
+		return nil, err
+	}
+	if err := validateMountedWebhookRoutes(mountedWebhooks, mountedWebUIs); err != nil {
+		return nil, err
+	}
 	adminUI := cfg.AdminUI
 	if adminUI == nil && cfg.BuiltinAdminUI != nil {
 		adminUI, err = resolveBuiltinAdminUI(*cfg.BuiltinAdminUI)
@@ -281,9 +301,11 @@ func New(cfg Config) (*Server, error) {
 		prometheusMetrics:     cfg.PrometheusMetrics,
 		mcpHandler:            cfg.MCPHandler,
 		mountedWebUIs:         mountedWebUIs,
+		mountedWebhooks:       mountedWebhooks,
 		adminRoute:            adminRoute,
 		adminUI:               adminUI,
 		routeProfile:          cfg.RouteProfile,
+		webhookReplayStore:    newMemoryWebhookReplayStore(),
 	}
 	s.workflowSchedules = workflowmanager.New(workflowmanager.Config{
 		Providers:             cfg.Providers,

--- a/gestaltd/internal/server/server_test.go
+++ b/gestaltd/internal/server/server_test.go
@@ -3,6 +3,7 @@ package server_test
 import (
 	"bytes"
 	"context"
+	"crypto/hmac"
 	"crypto/sha256"
 	"crypto/tls"
 	"encoding/hex"
@@ -35,6 +36,7 @@ import (
 	coreintegration "github.com/valon-technologies/gestalt/server/core/integration"
 	"github.com/valon-technologies/gestalt/server/core/session"
 	coretesting "github.com/valon-technologies/gestalt/server/core/testing"
+	coreworkflow "github.com/valon-technologies/gestalt/server/core/workflow"
 	"github.com/valon-technologies/gestalt/server/internal/adminui"
 	"github.com/valon-technologies/gestalt/server/internal/apiexec"
 	"github.com/valon-technologies/gestalt/server/internal/authorization"
@@ -11623,6 +11625,470 @@ func TestExecuteOperation_POST(t *testing.T) {
 	}
 }
 
+func TestHostedWebhook_HMACAsyncAckDispatchesOperationAndRejectsReplay(t *testing.T) {
+	t.Setenv("SLACK_SIGNING_SECRET", "super-secret")
+
+	type webhookInvocation struct {
+		Params   map[string]any
+		Workflow map[string]any
+	}
+
+	invocations := make(chan webhookInvocation, 1)
+	provider := &stubIntegrationWithOps{
+		StubIntegration: coretesting.StubIntegration{
+			N:        "slack_agent",
+			ConnMode: core.ConnectionModeNone,
+			ExecuteFn: func(ctx context.Context, op string, params map[string]any, _ string) (*core.OperationResult, error) {
+				if op != "handle_command" {
+					t.Fatalf("operation = %q, want %q", op, "handle_command")
+				}
+				invocations <- webhookInvocation{
+					Params:   cloneMap(params),
+					Workflow: invocation.WorkflowContextFromContext(ctx),
+				}
+				return &core.OperationResult{Status: http.StatusOK, Body: `{"ok":true}`}, nil
+			},
+		},
+		ops: []core.Operation{{Name: "handle_command", Method: http.MethodPost}},
+	}
+
+	ts := newTestServer(t, func(cfg *server.Config) {
+		cfg.Providers = testutil.NewProviderRegistry(t, provider)
+		cfg.PluginDefs = map[string]*config.ProviderEntry{
+			"slack_agent": {
+				SecuritySchemes: map[string]*config.WebhookSecurityScheme{
+					"slackSignature": {
+						Type: providermanifestv1.WebhookSecuritySchemeTypeHMAC,
+						Secret: &providermanifestv1.WebhookSecretRef{
+							Env: "SLACK_SIGNING_SECRET",
+						},
+						Signature: &providermanifestv1.WebhookSignatureConfig{
+							Algorithm:        "sha256",
+							SignatureHeader:  "X-Slack-Signature",
+							TimestampHeader:  "X-Slack-Request-Timestamp",
+							DeliveryIDHeader: "X-Slack-Delivery-ID",
+							PayloadTemplate:  "v0:{header.X-Slack-Request-Timestamp}:{raw_body}",
+							DigestPrefix:     "v0=",
+						},
+						Replay: &providermanifestv1.WebhookReplayConfig{MaxAge: "5m"},
+					},
+				},
+				Webhooks: map[string]*config.WebhookDef{
+					"slack_command": {
+						Path: "/webhooks/slack-agent/command",
+						Post: &providermanifestv1.WebhookOperation{
+							RequestBody: &providermanifestv1.WebhookRequestBody{
+								Required: true,
+								Content: map[string]*providermanifestv1.WebhookMediaType{
+									"application/x-www-form-urlencoded": {},
+								},
+							},
+							Responses: map[string]*providermanifestv1.WebhookResponse{
+								"200": {
+									Description: "acknowledged",
+									Content: map[string]*providermanifestv1.WebhookMediaType{
+										"application/json": {},
+									},
+									Body: map[string]any{
+										"response_type": "ephemeral",
+										"text":          "Working on it...",
+									},
+								},
+							},
+							Security: []providermanifestv1.SecurityRequirement{
+								{"slackSignature": nil},
+							},
+						},
+						Target: &providermanifestv1.WebhookTarget{
+							Operation: "handle_command",
+						},
+						Execution: &providermanifestv1.WebhookExecution{
+							Mode:             providermanifestv1.WebhookExecutionModeAsyncAck,
+							AcceptedResponse: "200",
+						},
+					},
+				},
+			},
+		}
+		cfg.Authorizer = mustAuthorizer(t, config.AuthorizationConfig{}, cfg.Providers, cfg.PluginDefs, nil)
+	})
+	testutil.CloseOnCleanup(t, ts)
+
+	body := "text=hello&response_url=https%3A%2F%2Fhooks.example.test%2Fresponse"
+	timestamp := strconv.FormatInt(time.Now().Unix(), 10)
+	signature := webhookTestSignature("super-secret", "v0:"+timestamp+":"+body)
+
+	makeRequest := func(deliveryID string) *http.Request {
+		req, err := http.NewRequest(http.MethodPost, ts.URL+"/webhooks/slack-agent/command?source=query", strings.NewReader(body))
+		if err != nil {
+			t.Fatalf("NewRequest: %v", err)
+		}
+		req.Header.Set("Content-Type", "application/x-www-form-urlencoded")
+		req.Header.Set("X-Slack-Request-Timestamp", timestamp)
+		req.Header.Set("X-Slack-Signature", signature)
+		if deliveryID != "" {
+			req.Header.Set("X-Slack-Delivery-ID", deliveryID)
+		}
+		return req
+	}
+
+	resp, err := http.DefaultClient.Do(makeRequest("delivery-1"))
+	if err != nil {
+		t.Fatalf("webhook request: %v", err)
+	}
+	defer func() { _ = resp.Body.Close() }()
+	if resp.StatusCode != http.StatusOK {
+		t.Fatalf("status = %d, want %d", resp.StatusCode, http.StatusOK)
+	}
+	var ack map[string]any
+	if err := json.NewDecoder(resp.Body).Decode(&ack); err != nil {
+		t.Fatalf("decode ack: %v", err)
+	}
+	if got, want := ack["response_type"], "ephemeral"; got != want {
+		t.Fatalf("response_type = %#v, want %q", got, want)
+	}
+	if got, want := ack["text"], "Working on it..."; got != want {
+		t.Fatalf("text = %#v, want %q", got, want)
+	}
+
+	select {
+	case invocation := <-invocations:
+		if got, want := invocation.Params["text"], "hello"; got != want {
+			t.Fatalf("params[text] = %#v, want %q", got, want)
+		}
+		if got, want := invocation.Params["response_url"], "https://hooks.example.test/response"; got != want {
+			t.Fatalf("params[response_url] = %#v, want %q", got, want)
+		}
+		if got, want := invocation.Params["source"], "query"; got != want {
+			t.Fatalf("params[source] = %#v, want %q", got, want)
+		}
+		webhookCtx, ok := invocation.Workflow["webhook"].(map[string]any)
+		if !ok {
+			t.Fatalf("workflow webhook context = %#v", invocation.Workflow)
+		}
+		if got, want := webhookCtx["name"], "slack_command"; got != want {
+			t.Fatalf("workflow webhook name = %#v, want %q", got, want)
+		}
+		if got, want := webhookCtx["deliveryId"], "delivery-1"; got != want {
+			t.Fatalf("workflow webhook deliveryId = %#v, want %q", got, want)
+		}
+	case <-time.After(2 * time.Second):
+		t.Fatal("timed out waiting for async webhook dispatch")
+	}
+
+	resp, err = http.DefaultClient.Do(makeRequest("delivery-1"))
+	if err != nil {
+		t.Fatalf("duplicate webhook request: %v", err)
+	}
+	defer func() { _ = resp.Body.Close() }()
+	if resp.StatusCode != http.StatusConflict {
+		t.Fatalf("duplicate status = %d, want %d", resp.StatusCode, http.StatusConflict)
+	}
+
+	resp, err = http.DefaultClient.Do(makeRequest(""))
+	if err != nil {
+		t.Fatalf("webhook request without delivery id: %v", err)
+	}
+	defer func() { _ = resp.Body.Close() }()
+	if resp.StatusCode != http.StatusOK {
+		t.Fatalf("status without delivery id = %d, want %d", resp.StatusCode, http.StatusOK)
+	}
+
+	resp, err = http.DefaultClient.Do(makeRequest(""))
+	if err != nil {
+		t.Fatalf("duplicate webhook request without delivery id: %v", err)
+	}
+	defer func() { _ = resp.Body.Close() }()
+	if resp.StatusCode != http.StatusConflict {
+		t.Fatalf("duplicate status without delivery id = %d, want %d", resp.StatusCode, http.StatusConflict)
+	}
+}
+
+func TestHostedWebhook_APIKeySyncStartsWorkflowRun(t *testing.T) {
+	t.Parallel()
+
+	workflowProvider := newMemoryWorkflowProvider()
+	workflowProvider.nextStartRun = &coreworkflow.Run{
+		ID:     "run-123",
+		Status: coreworkflow.RunStatusPending,
+		Target: coreworkflow.Target{
+			PluginName: "workflow_target",
+			Operation:  "process_event",
+		},
+	}
+
+	ts := newTestServer(t, func(cfg *server.Config) {
+		cfg.Workflow = &stubWorkflowControl{
+			defaultProviderName: "jobs",
+			provider:            workflowProvider,
+		}
+		cfg.PluginDefs = map[string]*config.ProviderEntry{
+			"slack_agent": {
+				SecuritySchemes: map[string]*config.WebhookSecurityScheme{
+					"eventKey": {
+						Type: providermanifestv1.WebhookSecuritySchemeTypeAPIKey,
+						Name: "X-Webhook-Key",
+						In:   providermanifestv1.WebhookInHeader,
+						Secret: &providermanifestv1.WebhookSecretRef{
+							Secret: "shared-key",
+						},
+					},
+				},
+				Webhooks: map[string]*config.WebhookDef{
+					"slack_event": {
+						Path: "/webhooks/slack-agent/events",
+						Post: &providermanifestv1.WebhookOperation{
+							RequestBody: &providermanifestv1.WebhookRequestBody{
+								Required: true,
+								Content: map[string]*providermanifestv1.WebhookMediaType{
+									"application/json": {},
+								},
+							},
+							Responses: map[string]*providermanifestv1.WebhookResponse{
+								"202": {Description: "accepted"},
+							},
+							Security: []providermanifestv1.SecurityRequirement{
+								{"eventKey": nil},
+							},
+						},
+						Target: &providermanifestv1.WebhookTarget{
+							Workflow: &providermanifestv1.WebhookWorkflowTarget{
+								Provider:  "jobs",
+								Plugin:    "workflow_target",
+								Operation: "process_event",
+								Input: map[string]any{
+									"kind": "slack",
+								},
+							},
+						},
+					},
+				},
+			},
+		}
+	})
+	testutil.CloseOnCleanup(t, ts)
+
+	req, err := http.NewRequest(http.MethodPost, ts.URL+"/webhooks/slack-agent/events", strings.NewReader(`{"event":"opened","kind":"attacker"}`))
+	if err != nil {
+		t.Fatalf("NewRequest: %v", err)
+	}
+	req.Header.Set("Content-Type", "application/json")
+	req.Header.Set("X-Webhook-Key", "shared-key")
+
+	resp, err := http.DefaultClient.Do(req)
+	if err != nil {
+		t.Fatalf("workflow webhook request: %v", err)
+	}
+	defer func() { _ = resp.Body.Close() }()
+	if resp.StatusCode != http.StatusAccepted {
+		t.Fatalf("status = %d, want %d", resp.StatusCode, http.StatusAccepted)
+	}
+
+	var run coreworkflow.Run
+	if err := json.NewDecoder(resp.Body).Decode(&run); err != nil {
+		t.Fatalf("decode run: %v", err)
+	}
+	if got, want := run.ID, "run-123"; got != want {
+		t.Fatalf("run ID = %q, want %q", got, want)
+	}
+	if len(workflowProvider.startRunReqs) != 1 {
+		t.Fatalf("startRunReqs = %d, want 1", len(workflowProvider.startRunReqs))
+	}
+	start := workflowProvider.startRunReqs[0]
+	if got, want := start.Target.PluginName, "workflow_target"; got != want {
+		t.Fatalf("workflow target plugin = %q, want %q", got, want)
+	}
+	if got, want := start.Target.Operation, "process_event"; got != want {
+		t.Fatalf("workflow target operation = %q, want %q", got, want)
+	}
+	if got, want := start.Target.Input["kind"], "slack"; got != want {
+		t.Fatalf("workflow input kind = %#v, want %q", got, want)
+	}
+	if got, want := start.Target.Input["event"], "opened"; got != want {
+		t.Fatalf("workflow input event = %#v, want %q", got, want)
+	}
+	webhookMeta, ok := start.Target.Input["_gestaltWebhook"].(map[string]any)
+	if !ok {
+		t.Fatalf("_gestaltWebhook = %#v", start.Target.Input["_gestaltWebhook"])
+	}
+	if got, want := webhookMeta["name"], "slack_event"; got != want {
+		t.Fatalf("workflow webhook name = %#v, want %q", got, want)
+	}
+}
+
+func TestHostedWebhook_RejectsMountedUIPathConflicts(t *testing.T) {
+	t.Parallel()
+
+	svc := coretesting.NewStubServices(t)
+	reg := registry.New()
+	cfg := server.Config{
+		Auth:        &coretesting.StubAuthProvider{N: "none"},
+		Services:    svc,
+		Providers:   &reg.Providers,
+		Invoker:     invocation.NewBroker(&reg.Providers, svc.Users, svc.Tokens),
+		StateSecret: []byte("0123456789abcdef0123456789abcdef"),
+		PluginDefs: map[string]*config.ProviderEntry{
+			"slack_agent": {
+				SecuritySchemes: map[string]*config.WebhookSecurityScheme{
+					"none": {Type: providermanifestv1.WebhookSecuritySchemeTypeNone},
+				},
+				Webhooks: map[string]*config.WebhookDef{
+					"slack_command": {
+						Path: "/portal/slack",
+						Post: &providermanifestv1.WebhookOperation{
+							Responses: map[string]*providermanifestv1.WebhookResponse{
+								"200": {Description: "ok"},
+							},
+							Security: []providermanifestv1.SecurityRequirement{{"none": nil}},
+						},
+						Target: &providermanifestv1.WebhookTarget{Operation: "handle_command"},
+					},
+				},
+			},
+		},
+		MountedWebUIs: []server.MountedWebUI{{
+			Name:    "portal",
+			Path:    "/portal",
+			Handler: http.NotFoundHandler(),
+		}},
+	}
+
+	_, err := server.New(cfg)
+	if err == nil {
+		t.Fatal("expected mounted UI webhook path conflict")
+	}
+	if !strings.Contains(err.Error(), "conflicts with mounted UI") {
+		t.Fatalf("error = %v, want mounted UI conflict", err)
+	}
+}
+
+func TestHostedWebhook_RejectsAdminAPIPathConflicts(t *testing.T) {
+	t.Parallel()
+
+	svc := coretesting.NewStubServices(t)
+	reg := registry.New()
+	cfg := server.Config{
+		Auth:        &coretesting.StubAuthProvider{N: "none"},
+		Services:    svc,
+		Providers:   &reg.Providers,
+		Invoker:     invocation.NewBroker(&reg.Providers, svc.Users, svc.Tokens),
+		StateSecret: []byte("0123456789abcdef0123456789abcdef"),
+		PluginDefs: map[string]*config.ProviderEntry{
+			"slack_agent": {
+				SecuritySchemes: map[string]*config.WebhookSecurityScheme{
+					"none": {Type: providermanifestv1.WebhookSecuritySchemeTypeNone},
+				},
+				Webhooks: map[string]*config.WebhookDef{
+					"slack_command": {
+						Path: "/admin/api/v1/authorization/plugins",
+						Post: &providermanifestv1.WebhookOperation{
+							Responses: map[string]*providermanifestv1.WebhookResponse{
+								"200": {Description: "ok"},
+							},
+							Security: []providermanifestv1.SecurityRequirement{{"none": nil}},
+						},
+						Target: &providermanifestv1.WebhookTarget{Operation: "handle_command"},
+					},
+				},
+			},
+		},
+	}
+
+	_, err := server.New(cfg)
+	if err == nil {
+		t.Fatal("expected admin route webhook path conflict")
+	}
+	if !strings.Contains(err.Error(), "conflicts with admin route namespace") {
+		t.Fatalf("error = %v, want admin route conflict", err)
+	}
+}
+
+func TestHostedWebhook_WorkflowSyncIgnoresNon2xxStaticResponses(t *testing.T) {
+	t.Parallel()
+
+	workflowProvider := newMemoryWorkflowProvider()
+	workflowProvider.nextStartRun = &coreworkflow.Run{
+		ID:     "run-500",
+		Status: coreworkflow.RunStatusPending,
+		Target: coreworkflow.Target{
+			PluginName: "workflow_target",
+			Operation:  "process_event",
+		},
+	}
+
+	ts := newTestServer(t, func(cfg *server.Config) {
+		cfg.Workflow = &stubWorkflowControl{
+			defaultProviderName: "jobs",
+			provider:            workflowProvider,
+		}
+		cfg.PluginDefs = map[string]*config.ProviderEntry{
+			"slack_agent": {
+				SecuritySchemes: map[string]*config.WebhookSecurityScheme{
+					"eventKey": {
+						Type: providermanifestv1.WebhookSecuritySchemeTypeAPIKey,
+						Name: "X-Webhook-Key",
+						In:   providermanifestv1.WebhookInHeader,
+						Secret: &providermanifestv1.WebhookSecretRef{
+							Secret: "shared-key",
+						},
+					},
+				},
+				Webhooks: map[string]*config.WebhookDef{
+					"slack_event": {
+						Path: "/webhooks/slack-agent/events",
+						Post: &providermanifestv1.WebhookOperation{
+							RequestBody: &providermanifestv1.WebhookRequestBody{
+								Required: true,
+								Content: map[string]*providermanifestv1.WebhookMediaType{
+									"application/json": {},
+								},
+							},
+							Responses: map[string]*providermanifestv1.WebhookResponse{
+								"500": {Description: "bad static response"},
+							},
+							Security: []providermanifestv1.SecurityRequirement{
+								{"eventKey": nil},
+							},
+						},
+						Target: &providermanifestv1.WebhookTarget{
+							Workflow: &providermanifestv1.WebhookWorkflowTarget{
+								Provider:  "jobs",
+								Plugin:    "workflow_target",
+								Operation: "process_event",
+							},
+						},
+					},
+				},
+			},
+		}
+	})
+	testutil.CloseOnCleanup(t, ts)
+
+	req, err := http.NewRequest(http.MethodPost, ts.URL+"/webhooks/slack-agent/events", strings.NewReader(`{"event":"opened"}`))
+	if err != nil {
+		t.Fatalf("NewRequest: %v", err)
+	}
+	req.Header.Set("Content-Type", "application/json")
+	req.Header.Set("X-Webhook-Key", "shared-key")
+
+	resp, err := http.DefaultClient.Do(req)
+	if err != nil {
+		t.Fatalf("workflow webhook request: %v", err)
+	}
+	defer func() { _ = resp.Body.Close() }()
+	if resp.StatusCode != http.StatusAccepted {
+		t.Fatalf("status = %d, want %d", resp.StatusCode, http.StatusAccepted)
+	}
+
+	var run coreworkflow.Run
+	if err := json.NewDecoder(resp.Body).Decode(&run); err != nil {
+		t.Fatalf("decode run: %v", err)
+	}
+	if got, want := run.ID, "run-500"; got != want {
+		t.Fatalf("run ID = %q, want %q", got, want)
+	}
+}
+
 func TestAuthInfo(t *testing.T) {
 	t.Parallel()
 
@@ -11778,6 +12244,12 @@ func (s *stubIntegrationWithSessionCatalog) CallTool(ctx context.Context, name s
 		return s.callFn(ctx, name, args)
 	}
 	return mcpgo.NewToolResultText("passthrough:" + name), nil
+}
+
+func webhookTestSignature(secret, payload string) string {
+	mac := hmac.New(sha256.New, []byte(secret))
+	_, _ = mac.Write([]byte(payload))
+	return "v0=" + hex.EncodeToString(mac.Sum(nil))
 }
 
 type stubSessionCatalogWithoutManagedIdentitySupport struct {

--- a/gestaltd/internal/server/webhook_dispatch.go
+++ b/gestaltd/internal/server/webhook_dispatch.go
@@ -1,0 +1,175 @@
+package server
+
+import (
+	"context"
+	"fmt"
+	"log/slog"
+	"strings"
+
+	"github.com/valon-technologies/gestalt/server/core"
+	coreworkflow "github.com/valon-technologies/gestalt/server/core/workflow"
+	"github.com/valon-technologies/gestalt/server/internal/config"
+	"github.com/valon-technologies/gestalt/server/internal/invocation"
+	"github.com/valon-technologies/gestalt/server/internal/principal"
+)
+
+func (s *Server) webhookPrincipal(mounted MountedWebhook, verified *verifiedWebhookSender) *principal.Principal {
+	subjectID := "system:webhook:" + mounted.PluginName + ":" + mounted.Name
+	permissions := principal.CompilePermissions([]core.AccessPermission{{
+		Plugin:     mounted.PluginName,
+		Operations: []string{strings.TrimSpace(mounted.Target.Operation)},
+	}})
+	p := &principal.Principal{
+		SubjectID:        subjectID,
+		Source:           principal.SourceWebhook,
+		Scopes:           principal.PermissionPlugins(permissions),
+		TokenPermissions: permissions,
+	}
+	if verified != nil {
+		p.DisplayName = strings.TrimSpace(verified.Subject)
+	}
+	return principal.Canonicalize(p)
+}
+
+func webhookContextValue(mounted MountedWebhook, verified *verifiedWebhookSender) map[string]any {
+	value := map[string]any{
+		"name":   mounted.Name,
+		"plugin": mounted.PluginName,
+	}
+	if verified == nil {
+		return map[string]any{"webhook": value}
+	}
+	if verified.Scheme != "" {
+		value["scheme"] = verified.Scheme
+	}
+	if verified.Subject != "" {
+		value["subject"] = verified.Subject
+	}
+	if verified.DeliveryID != "" {
+		value["deliveryId"] = verified.DeliveryID
+	}
+	if len(verified.Claims) > 0 {
+		claims := make(map[string]any, len(verified.Claims))
+		for key, item := range verified.Claims {
+			claims[key] = item
+		}
+		value["claims"] = claims
+	}
+	return map[string]any{"webhook": value}
+}
+
+func (s *Server) webhookOperationInvocation(ctx context.Context, mounted MountedWebhook, verified *verifiedWebhookSender, params map[string]any) (*core.OperationResult, error) {
+	p := s.webhookPrincipal(mounted, verified)
+	instance := ""
+	if raw, ok := params[httpInstanceParam].(string); ok {
+		instance = strings.TrimSpace(raw)
+		delete(params, httpInstanceParam)
+	}
+	connection := ""
+	if raw, ok := params[httpConnectionParam].(string); ok {
+		connection = strings.TrimSpace(raw)
+		delete(params, httpConnectionParam)
+	}
+	if instance != "" {
+		if !safeParamValue.MatchString(instance) {
+			return nil, fmt.Errorf("instance name contains invalid characters")
+		}
+	}
+	if connection != "" {
+		if !safeParamValue.MatchString(connection) {
+			return nil, fmt.Errorf("connection name contains invalid characters")
+		}
+		connection = config.ResolveConnectionAlias(connection)
+	}
+
+	ctx = principal.WithPrincipal(ctx, p)
+	ctx = invocation.WithAccessContext(ctx, s.providerAccessContextWithContext(ctx, p, mounted.PluginName))
+	ctx = invocation.WithWorkflowContext(ctx, webhookContextValue(mounted, verified))
+	ctx = invocation.WithInvocationSurface(ctx, invocation.InvocationSurfaceHTTP)
+	if connection != "" {
+		ctx = invocation.WithConnection(ctx, connection)
+	}
+	return s.invoker.Invoke(ctx, p, mounted.PluginName, instance, mounted.Target.Operation, params)
+}
+
+func (s *Server) startWebhookWorkflowRun(ctx context.Context, mounted MountedWebhook, verified *verifiedWebhookSender, params map[string]any) (*coreworkflow.Run, error) {
+	if s.workflow == nil {
+		return nil, fmt.Errorf("workflow runtime is not configured")
+	}
+	target := mounted.Target.Workflow
+	if target == nil {
+		return nil, fmt.Errorf("workflow target is not configured")
+	}
+	_, provider, err := s.workflow.ResolveProviderSelection(strings.TrimSpace(target.Provider))
+	if err != nil {
+		return nil, err
+	}
+	input := make(map[string]any, len(target.Input)+len(params)+1)
+	for key, value := range params {
+		input[key] = value
+	}
+	for key, value := range target.Input {
+		input[key] = value
+	}
+	input["_gestaltWebhook"] = webhookContextValue(mounted, verified)["webhook"]
+	return provider.StartRun(ctx, coreworkflow.StartRunRequest{
+		Target: coreworkflow.Target{
+			PluginName: strings.TrimSpace(target.Plugin),
+			Operation:  strings.TrimSpace(target.Operation),
+			Connection: strings.TrimSpace(target.Connection),
+			Instance:   strings.TrimSpace(target.Instance),
+			Input:      input,
+		},
+		IdempotencyKey: strings.TrimSpace(verifiedDeliveryID(verified)),
+		CreatedBy: coreworkflow.Actor{
+			SubjectID:   "system:webhook:" + mounted.PluginName + ":" + mounted.Name,
+			SubjectKind: string(principal.KindWorkload),
+			DisplayName: verifiedDisplayName(verified),
+			AuthSource:  principal.SourceWebhook.String(),
+		},
+		ExecutionRef: "",
+	})
+}
+
+func verifiedDeliveryID(verified *verifiedWebhookSender) string {
+	if verified == nil {
+		return ""
+	}
+	return verified.DeliveryID
+}
+
+func verifiedDisplayName(verified *verifiedWebhookSender) string {
+	if verified == nil {
+		return ""
+	}
+	return verified.Subject
+}
+
+func (s *Server) dispatchWebhookAsync(mounted MountedWebhook, verified *verifiedWebhookSender, params map[string]any) {
+	go func() {
+		ctx := invocation.WithRequestMeta(context.Background(), invocation.RequestMeta{})
+		switch {
+		case mounted.Target != nil && strings.TrimSpace(mounted.Target.Operation) != "":
+			if _, err := s.webhookOperationInvocation(ctx, mounted, verified, cloneMap(params)); err != nil {
+				slog.Error("webhook async operation failed", "plugin", mounted.PluginName, "webhook", mounted.Name, "operation", mounted.Target.Operation, "error", err)
+			}
+		case mounted.Target != nil && mounted.Target.Workflow != nil:
+			if _, err := s.startWebhookWorkflowRun(ctx, mounted, verified, cloneMap(params)); err != nil {
+				slog.Error("webhook async workflow failed", "plugin", mounted.PluginName, "webhook", mounted.Name, "workflow_plugin", mounted.Target.Workflow.Plugin, "workflow_operation", mounted.Target.Workflow.Operation, "error", err)
+			}
+		default:
+			slog.Error("webhook async dispatch skipped because target is missing", "plugin", mounted.PluginName, "webhook", mounted.Name)
+		}
+	}()
+}
+
+func cloneMap(src map[string]any) map[string]any {
+	if src == nil {
+		return nil
+	}
+	dst := make(map[string]any, len(src))
+	for key, value := range src {
+		dst[key] = value
+	}
+	return dst
+}

--- a/gestaltd/internal/server/webhook_parse.go
+++ b/gestaltd/internal/server/webhook_parse.go
@@ -1,0 +1,123 @@
+package server
+
+import (
+	"encoding/json"
+	"fmt"
+	"mime"
+	"net/http"
+	"net/url"
+	"strings"
+
+	providermanifestv1 "github.com/valon-technologies/gestalt/server/sdk/providermanifest/v1"
+)
+
+type parsedWebhookRequest struct {
+	ContentType string
+	Params      map[string]any
+	RawBody     []byte
+}
+
+func parseWebhookRequest(r *http.Request, op *providermanifestv1.WebhookOperation, rawBody []byte) (*parsedWebhookRequest, error) {
+	params := firstValueMap(r.URL.Query())
+	contentType, err := requestMediaType(r.Header.Get("Content-Type"))
+	if err != nil {
+		return nil, err
+	}
+	selectedContentType := contentType
+	if len(rawBody) == 0 {
+		if op != nil && op.RequestBody != nil && op.RequestBody.Required {
+			return nil, fmt.Errorf("request body is required")
+		}
+		return &parsedWebhookRequest{
+			ContentType: selectedContentType,
+			Params:      params,
+			RawBody:     rawBody,
+		}, nil
+	}
+
+	_, resolvedContentType, err := resolveWebhookRequestContentType(op, contentType)
+	if err != nil {
+		return nil, err
+	}
+	if resolvedContentType != "" {
+		selectedContentType = resolvedContentType
+	}
+	switch strings.ToLower(selectedContentType) {
+	case "application/json":
+		var decoded any
+		if err := json.Unmarshal(rawBody, &decoded); err != nil {
+			return nil, fmt.Errorf("invalid JSON body")
+		}
+		switch value := decoded.(type) {
+		case map[string]any:
+			for key, item := range value {
+				params[key] = item
+			}
+		default:
+			params["body"] = value
+		}
+	case "application/x-www-form-urlencoded":
+		values, err := url.ParseQuery(string(rawBody))
+		if err != nil {
+			return nil, fmt.Errorf("invalid form body")
+		}
+		for key, value := range firstValueMap(values) {
+			params[key] = value
+		}
+	default:
+		params["rawBody"] = string(rawBody)
+	}
+
+	return &parsedWebhookRequest{
+		ContentType: selectedContentType,
+		Params:      params,
+		RawBody:     rawBody,
+	}, nil
+}
+
+func resolveWebhookRequestContentType(op *providermanifestv1.WebhookOperation, contentType string) (*providermanifestv1.WebhookMediaType, string, error) {
+	if op == nil || op.RequestBody == nil || len(op.RequestBody.Content) == 0 {
+		return nil, contentType, nil
+	}
+	if contentType != "" {
+		if mediaType, ok := op.RequestBody.Content[contentType]; ok {
+			return mediaType, contentType, nil
+		}
+		if wildcard, ok := op.RequestBody.Content["*/*"]; ok {
+			return wildcard, contentType, nil
+		}
+		return nil, "", fmt.Errorf("unsupported content type %q", contentType)
+	}
+	if len(op.RequestBody.Content) == 1 {
+		for resolved, mediaType := range op.RequestBody.Content {
+			return mediaType, resolved, nil
+		}
+	}
+	return nil, "", fmt.Errorf("content type is required")
+}
+
+func requestMediaType(value string) (string, error) {
+	value = strings.TrimSpace(value)
+	if value == "" {
+		return "", nil
+	}
+	mediaType, _, err := mime.ParseMediaType(value)
+	if err != nil {
+		return "", fmt.Errorf("invalid Content-Type header")
+	}
+	return strings.ToLower(mediaType), nil
+}
+
+func firstValueMap(values url.Values) map[string]any {
+	if len(values) == 0 {
+		return map[string]any{}
+	}
+	params := make(map[string]any, len(values))
+	for key, items := range values {
+		if len(items) == 0 {
+			continue
+		}
+		params[key] = items[0]
+	}
+	return params
+}

--- a/gestaltd/internal/server/webhook_replay.go
+++ b/gestaltd/internal/server/webhook_replay.go
@@ -1,0 +1,46 @@
+package server
+
+import (
+	"sync"
+	"time"
+)
+
+type webhookReplayStore interface {
+	MarkIfNew(key string, ttl time.Duration) bool
+}
+
+type memoryWebhookReplayStore struct {
+	mu      sync.Mutex
+	entries map[string]time.Time
+}
+
+func newMemoryWebhookReplayStore() webhookReplayStore {
+	return &memoryWebhookReplayStore{entries: map[string]time.Time{}}
+}
+
+func (s *memoryWebhookReplayStore) MarkIfNew(key string, ttl time.Duration) bool {
+	if s == nil || key == "" {
+		return true
+	}
+	if ttl <= 0 {
+		ttl = 24 * time.Hour
+	}
+
+	now := time.Now()
+	expiresAt := now.Add(ttl)
+
+	s.mu.Lock()
+	defer s.mu.Unlock()
+
+	for existingKey, deadline := range s.entries {
+		if !deadline.After(now) {
+			delete(s.entries, existingKey)
+		}
+	}
+
+	if deadline, ok := s.entries[key]; ok && deadline.After(now) {
+		return false
+	}
+	s.entries[key] = expiresAt
+	return true
+}

--- a/gestaltd/internal/server/webhook_response.go
+++ b/gestaltd/internal/server/webhook_response.go
@@ -1,0 +1,75 @@
+package server
+
+import (
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"sort"
+	"strconv"
+	"strings"
+
+	providermanifestv1 "github.com/valon-technologies/gestalt/server/sdk/providermanifest/v1"
+)
+
+func writeWebhookResponse(w http.ResponseWriter, code string, response *providermanifestv1.WebhookResponse) error {
+	if response == nil {
+		return fmt.Errorf("webhook response %q is not configured", code)
+	}
+	status, err := strconv.Atoi(strings.TrimSpace(code))
+	if err != nil {
+		return fmt.Errorf("parse webhook response status %q: %w", code, err)
+	}
+	for key, value := range response.Headers {
+		w.Header().Set(key, value)
+	}
+	contentType := w.Header().Get("Content-Type")
+	if contentType == "" && len(response.Content) == 1 {
+		for mediaType := range response.Content {
+			contentType = mediaType
+		}
+	}
+	if contentType == "" && response.Body != nil {
+		contentType = "application/json"
+	}
+	if contentType != "" {
+		w.Header().Set("Content-Type", contentType)
+	}
+	w.WriteHeader(status)
+	if response.Body == nil {
+		return nil
+	}
+	switch {
+	case strings.HasPrefix(contentType, "text/plain"):
+		_, err = fmt.Fprint(w, response.Body)
+	default:
+		data, marshalErr := json.Marshal(response.Body)
+		if marshalErr != nil {
+			return marshalErr
+		}
+		_, err = w.Write(data)
+	}
+	return err
+}
+
+func defaultWebhookAcceptedResponseCode(op *providermanifestv1.WebhookOperation) string {
+	if op == nil || len(op.Responses) == 0 {
+		return ""
+	}
+	codes := make([]int, 0, len(op.Responses))
+	codeByInt := make(map[int]string, len(op.Responses))
+	for code := range op.Responses {
+		parsed, err := strconv.Atoi(code)
+		if err != nil {
+			continue
+		}
+		codes = append(codes, parsed)
+		codeByInt[parsed] = code
+	}
+	sort.Ints(codes)
+	for _, code := range codes {
+		if code >= 200 && code < 300 {
+			return codeByInt[code]
+		}
+	}
+	return ""
+}

--- a/gestaltd/internal/server/webhook_verify.go
+++ b/gestaltd/internal/server/webhook_verify.go
@@ -1,0 +1,370 @@
+package server
+
+import (
+	"crypto/hmac"
+	"crypto/sha256"
+	"crypto/subtle"
+	"crypto/x509"
+	"fmt"
+	"net/http"
+	"os"
+	"regexp"
+	"strconv"
+	"strings"
+	"time"
+
+	providermanifestv1 "github.com/valon-technologies/gestalt/server/sdk/providermanifest/v1"
+)
+
+var webhookHeaderTemplatePattern = regexp.MustCompile(`\{header\.([^}]+)\}`)
+
+type verifiedWebhookSender struct {
+	Scheme     string
+	Subject    string
+	DeliveryID string
+	Claims     map[string]string
+}
+
+type webhookRequestError struct {
+	status  int
+	message string
+	err     error
+}
+
+func (e *webhookRequestError) Error() string {
+	if e == nil {
+		return ""
+	}
+	if e.err != nil {
+		return e.err.Error()
+	}
+	return e.message
+}
+
+func (e *webhookRequestError) Unwrap() error {
+	if e == nil {
+		return nil
+	}
+	return e.err
+}
+
+func newWebhookRequestError(status int, message string, err error) error {
+	return &webhookRequestError{status: status, message: message, err: err}
+}
+
+func (s *Server) verifyWebhookRequest(r *http.Request, mounted MountedWebhook, rawBody []byte) (*verifiedWebhookSender, error) {
+	if mounted.Operation == nil {
+		return nil, newWebhookRequestError(http.StatusInternalServerError, "webhook operation is not initialized", nil)
+	}
+	if len(mounted.Operation.Security) == 0 {
+		return nil, newWebhookRequestError(http.StatusInternalServerError, "webhook security is not configured", nil)
+	}
+
+	var lastErr error
+	for _, requirement := range mounted.Operation.Security {
+		verified := &verifiedWebhookSender{
+			Claims: map[string]string{},
+		}
+		matched := true
+		for schemeName := range requirement {
+			scheme := mounted.SecuritySchemes[schemeName]
+			if scheme == nil {
+				lastErr = newWebhookRequestError(http.StatusInternalServerError, "webhook security scheme is not initialized", nil)
+				matched = false
+				break
+			}
+			result, err := s.verifyWebhookSecurityScheme(r, mounted, schemeName, scheme, rawBody)
+			if err != nil {
+				lastErr = err
+				matched = false
+				break
+			}
+			if verified.Scheme == "" {
+				verified.Scheme = result.Scheme
+			}
+			if verified.Subject == "" {
+				verified.Subject = result.Subject
+			}
+			if verified.DeliveryID == "" {
+				verified.DeliveryID = result.DeliveryID
+			}
+			for key, value := range result.Claims {
+				verified.Claims[key] = value
+			}
+		}
+		if matched {
+			if verified.Subject == "" {
+				verified.Subject = mounted.PluginName + "/" + mounted.Name
+			}
+			if verified.Scheme == "" {
+				verified.Scheme = "none"
+			}
+			return verified, nil
+		}
+	}
+	if lastErr == nil {
+		lastErr = newWebhookRequestError(http.StatusUnauthorized, "webhook verification failed", nil)
+	}
+	return nil, lastErr
+}
+
+func (s *Server) verifyWebhookSecurityScheme(r *http.Request, mounted MountedWebhook, schemeName string, scheme *providermanifestv1.WebhookSecurityScheme, rawBody []byte) (*verifiedWebhookSender, error) {
+	switch scheme.Type {
+	case providermanifestv1.WebhookSecuritySchemeTypeNone:
+		return &verifiedWebhookSender{
+			Scheme:  schemeName,
+			Subject: mounted.PluginName + "/" + mounted.Name + "#" + schemeName,
+			Claims:  map[string]string{},
+		}, nil
+	case providermanifestv1.WebhookSecuritySchemeTypeHMAC:
+		return s.verifyWebhookHMAC(r, mounted, schemeName, scheme, rawBody)
+	case providermanifestv1.WebhookSecuritySchemeTypeAPIKey:
+		return s.verifyWebhookAPIKey(r, mounted, schemeName, scheme)
+	case providermanifestv1.WebhookSecuritySchemeTypeHTTP:
+		return s.verifyWebhookHTTPAuth(r, mounted, schemeName, scheme)
+	case providermanifestv1.WebhookSecuritySchemeTypeMutualTLS:
+		return s.verifyWebhookMutualTLS(r, mounted, schemeName, scheme)
+	default:
+		return nil, newWebhookRequestError(http.StatusInternalServerError, "unsupported webhook security scheme", fmt.Errorf("unsupported scheme type %q", scheme.Type))
+	}
+}
+
+func (s *Server) verifyWebhookHMAC(r *http.Request, mounted MountedWebhook, schemeName string, scheme *providermanifestv1.WebhookSecurityScheme, rawBody []byte) (*verifiedWebhookSender, error) {
+	secret, err := resolveWebhookSharedSecret(scheme.Secret)
+	if err != nil {
+		return nil, newWebhookRequestError(http.StatusInternalServerError, "webhook secret is not configured", err)
+	}
+	signatureHeader := strings.TrimSpace(scheme.Signature.SignatureHeader)
+	signature := strings.TrimSpace(r.Header.Get(signatureHeader))
+	if signature == "" {
+		return nil, newWebhookRequestError(http.StatusUnauthorized, "missing webhook signature", nil)
+	}
+	payload := renderWebhookPayloadTemplate(scheme.Signature.PayloadTemplate, r, rawBody)
+	if payload == "" {
+		payload = string(rawBody)
+	}
+	switch strings.ToLower(strings.TrimSpace(scheme.Signature.Algorithm)) {
+	case "sha256":
+		mac := hmac.New(sha256.New, []byte(secret))
+		_, _ = mac.Write([]byte(payload))
+		expected := strings.TrimSpace(scheme.Signature.DigestPrefix) + fmt.Sprintf("%x", mac.Sum(nil))
+		if subtle.ConstantTimeCompare([]byte(expected), []byte(signature)) != 1 {
+			return nil, newWebhookRequestError(http.StatusUnauthorized, "invalid webhook signature", nil)
+		}
+	default:
+		return nil, newWebhookRequestError(http.StatusInternalServerError, "unsupported webhook signature algorithm", fmt.Errorf("unsupported hmac algorithm %q", scheme.Signature.Algorithm))
+	}
+
+	var deliveryID string
+	if header := strings.TrimSpace(scheme.Signature.DeliveryIDHeader); header != "" {
+		deliveryID = strings.TrimSpace(r.Header.Get(header))
+	}
+	ttl, err := verifyWebhookReplayWindow(r, scheme)
+	if err != nil {
+		return nil, err
+	}
+	replayKey := deliveryID
+	if replayKey == "" && scheme.Replay != nil && strings.TrimSpace(scheme.Replay.MaxAge) != "" {
+		replayKey = "sig:" + signature
+	}
+	if replayKey != "" && !s.webhookReplayStore.MarkIfNew(mounted.PluginName+"\x00"+mounted.Name+"\x00"+schemeName+"\x00"+replayKey, ttl) {
+		return nil, newWebhookRequestError(http.StatusConflict, "duplicate webhook delivery", nil)
+	}
+	return &verifiedWebhookSender{
+		Scheme:     schemeName,
+		Subject:    mounted.PluginName + "/" + mounted.Name + "#" + schemeName,
+		DeliveryID: deliveryID,
+		Claims: map[string]string{
+			"scheme": schemeName,
+		},
+	}, nil
+}
+
+func (s *Server) verifyWebhookAPIKey(r *http.Request, mounted MountedWebhook, schemeName string, scheme *providermanifestv1.WebhookSecurityScheme) (*verifiedWebhookSender, error) {
+	secret, err := resolveWebhookSharedSecret(scheme.Secret)
+	if err != nil {
+		return nil, newWebhookRequestError(http.StatusInternalServerError, "webhook secret is not configured", err)
+	}
+	var actual string
+	switch scheme.In {
+	case providermanifestv1.WebhookInHeader:
+		actual = strings.TrimSpace(r.Header.Get(strings.TrimSpace(scheme.Name)))
+	case providermanifestv1.WebhookInQuery:
+		actual = strings.TrimSpace(r.URL.Query().Get(strings.TrimSpace(scheme.Name)))
+	default:
+		return nil, newWebhookRequestError(http.StatusInternalServerError, "unsupported apiKey location", fmt.Errorf("unsupported apiKey location %q", scheme.In))
+	}
+	if actual == "" {
+		return nil, newWebhookRequestError(http.StatusUnauthorized, "missing webhook credential", nil)
+	}
+	if subtle.ConstantTimeCompare([]byte(secret), []byte(actual)) != 1 {
+		return nil, newWebhookRequestError(http.StatusUnauthorized, "invalid webhook credential", nil)
+	}
+	return &verifiedWebhookSender{
+		Scheme:  schemeName,
+		Subject: mounted.PluginName + "/" + mounted.Name + "#" + schemeName,
+		Claims: map[string]string{
+			"scheme": schemeName,
+		},
+	}, nil
+}
+
+func (s *Server) verifyWebhookHTTPAuth(r *http.Request, mounted MountedWebhook, schemeName string, scheme *providermanifestv1.WebhookSecurityScheme) (*verifiedWebhookSender, error) {
+	secret, err := resolveWebhookSharedSecret(scheme.Secret)
+	if err != nil {
+		return nil, newWebhookRequestError(http.StatusInternalServerError, "webhook secret is not configured", err)
+	}
+	switch scheme.Scheme {
+	case providermanifestv1.WebhookHTTPSchemeBearer:
+		token, err := requestBearerToken(r)
+		if err != nil {
+			return nil, newWebhookRequestError(http.StatusUnauthorized, "invalid authorization header format", err)
+		}
+		if token == "" {
+			return nil, newWebhookRequestError(http.StatusUnauthorized, "missing bearer token", nil)
+		}
+		if subtle.ConstantTimeCompare([]byte(secret), []byte(token)) != 1 {
+			return nil, newWebhookRequestError(http.StatusUnauthorized, "invalid bearer token", nil)
+		}
+	case providermanifestv1.WebhookHTTPSchemeBasic:
+		username, password, ok := r.BasicAuth()
+		if !ok {
+			return nil, newWebhookRequestError(http.StatusUnauthorized, "missing basic authorization", nil)
+		}
+		if subtle.ConstantTimeCompare([]byte(secret), []byte(username+":"+password)) != 1 {
+			return nil, newWebhookRequestError(http.StatusUnauthorized, "invalid basic authorization", nil)
+		}
+	default:
+		return nil, newWebhookRequestError(http.StatusInternalServerError, "unsupported http auth scheme", fmt.Errorf("unsupported http auth scheme %q", scheme.Scheme))
+	}
+	return &verifiedWebhookSender{
+		Scheme:  schemeName,
+		Subject: mounted.PluginName + "/" + mounted.Name + "#" + schemeName,
+		Claims: map[string]string{
+			"scheme": schemeName,
+		},
+	}, nil
+}
+
+func (s *Server) verifyWebhookMutualTLS(r *http.Request, mounted MountedWebhook, schemeName string, scheme *providermanifestv1.WebhookSecurityScheme) (*verifiedWebhookSender, error) {
+	if r.TLS == nil || len(r.TLS.PeerCertificates) == 0 {
+		return nil, newWebhookRequestError(http.StatusUnauthorized, "client certificate is required", nil)
+	}
+	if len(r.TLS.VerifiedChains) == 0 {
+		return nil, newWebhookRequestError(http.StatusUnauthorized, "verified client certificate chain is required", nil)
+	}
+	peer := r.TLS.PeerCertificates[0]
+	subject := peer.Subject.String()
+	expected := ""
+	if scheme.MTLS != nil {
+		expected = strings.TrimSpace(scheme.MTLS.SubjectAltName)
+	}
+	if expected != "" {
+		if !certificateHasSubjectAltName(peer, expected) {
+			return nil, newWebhookRequestError(http.StatusUnauthorized, "client certificate subject alt name mismatch", nil)
+		}
+		subject = expected
+	}
+	return &verifiedWebhookSender{
+		Scheme:  schemeName,
+		Subject: subject,
+		Claims: map[string]string{
+			"scheme": schemeName,
+		},
+	}, nil
+}
+
+func resolveWebhookSharedSecret(ref *providermanifestv1.WebhookSecretRef) (string, error) {
+	if ref == nil {
+		return "", fmt.Errorf("secret reference is required")
+	}
+	if env := strings.TrimSpace(ref.Env); env != "" {
+		value, ok := os.LookupEnv(env)
+		if !ok || strings.TrimSpace(value) == "" {
+			return "", fmt.Errorf("environment variable %q is not set", env)
+		}
+		return value, nil
+	}
+	if secret := strings.TrimSpace(ref.Secret); secret != "" {
+		return secret, nil
+	}
+	return "", fmt.Errorf("secret reference is empty")
+}
+
+func verifyWebhookReplayWindow(r *http.Request, scheme *providermanifestv1.WebhookSecurityScheme) (time.Duration, error) {
+	if scheme == nil || scheme.Replay == nil || strings.TrimSpace(scheme.Replay.MaxAge) == "" {
+		return 24 * time.Hour, nil
+	}
+	maxAge, err := time.ParseDuration(strings.TrimSpace(scheme.Replay.MaxAge))
+	if err != nil {
+		return 0, newWebhookRequestError(http.StatusInternalServerError, "invalid replay configuration", err)
+	}
+	timestampHeader := ""
+	if scheme.Signature != nil {
+		timestampHeader = strings.TrimSpace(scheme.Signature.TimestampHeader)
+	}
+	if timestampHeader == "" {
+		return maxAge, nil
+	}
+	raw := strings.TrimSpace(r.Header.Get(timestampHeader))
+	if raw == "" {
+		return 0, newWebhookRequestError(http.StatusUnauthorized, "missing webhook timestamp", nil)
+	}
+	timestamp, err := parseWebhookTimestamp(raw)
+	if err != nil {
+		return 0, newWebhookRequestError(http.StatusUnauthorized, "invalid webhook timestamp", err)
+	}
+	now := time.Now()
+	if now.Sub(timestamp) > maxAge || timestamp.Sub(now) > maxAge {
+		return 0, newWebhookRequestError(http.StatusUnauthorized, "stale webhook timestamp", nil)
+	}
+	return maxAge, nil
+}
+
+func parseWebhookTimestamp(raw string) (time.Time, error) {
+	if unixSeconds, err := strconv.ParseInt(raw, 10, 64); err == nil {
+		return time.Unix(unixSeconds, 0).UTC(), nil
+	}
+	if parsed, err := time.Parse(time.RFC3339, raw); err == nil {
+		return parsed.UTC(), nil
+	}
+	return time.Time{}, fmt.Errorf("unsupported timestamp format %q", raw)
+}
+
+func renderWebhookPayloadTemplate(template string, r *http.Request, rawBody []byte) string {
+	template = strings.TrimSpace(template)
+	if template == "" {
+		return ""
+	}
+	rendered := strings.ReplaceAll(template, "{raw_body}", string(rawBody))
+	return webhookHeaderTemplatePattern.ReplaceAllStringFunc(rendered, func(match string) string {
+		groups := webhookHeaderTemplatePattern.FindStringSubmatch(match)
+		if len(groups) != 2 {
+			return ""
+		}
+		return r.Header.Get(strings.TrimSpace(groups[1]))
+	})
+}
+
+func certificateHasSubjectAltName(cert *x509.Certificate, expected string) bool {
+	expected = strings.TrimSpace(expected)
+	if expected == "" || cert == nil {
+		return false
+	}
+	for _, value := range cert.DNSNames {
+		if subtle.ConstantTimeCompare([]byte(value), []byte(expected)) == 1 {
+			return true
+		}
+	}
+	for _, value := range cert.EmailAddresses {
+		if subtle.ConstantTimeCompare([]byte(value), []byte(expected)) == 1 {
+			return true
+		}
+	}
+	for _, value := range cert.URIs {
+		if value != nil && subtle.ConstantTimeCompare([]byte(value.String()), []byte(expected)) == 1 {
+			return true
+		}
+	}
+	return false
+}

--- a/gestaltd/internal/server/workflow_schedule_test.go
+++ b/gestaltd/internal/server/workflow_schedule_test.go
@@ -62,6 +62,9 @@ func (s *stubWorkflowControl) ResolveProvider(name string) (coreworkflow.Provide
 }
 
 type memoryWorkflowProvider struct {
+	startRunReqs  []coreworkflow.StartRunRequest
+	nextStartRun  *coreworkflow.Run
+	startRunErr   error
 	schedules     map[string]*coreworkflow.Schedule
 	upsertReqs    []coreworkflow.UpsertScheduleRequest
 	deleteReqs    []coreworkflow.DeleteScheduleRequest
@@ -76,8 +79,22 @@ func newMemoryWorkflowProvider() *memoryWorkflowProvider {
 	return &memoryWorkflowProvider{schedules: map[string]*coreworkflow.Schedule{}}
 }
 
-func (p *memoryWorkflowProvider) StartRun(context.Context, coreworkflow.StartRunRequest) (*coreworkflow.Run, error) {
-	return nil, errors.New("not implemented")
+func (p *memoryWorkflowProvider) StartRun(_ context.Context, req coreworkflow.StartRunRequest) (*coreworkflow.Run, error) {
+	p.startRunReqs = append(p.startRunReqs, req)
+	if p.startRunErr != nil {
+		return nil, p.startRunErr
+	}
+	if p.nextStartRun != nil {
+		return cloneWorkflowRun(p.nextStartRun), nil
+	}
+	now := time.Now().UTC().Truncate(time.Second)
+	return &coreworkflow.Run{
+		ID:        "run-1",
+		Status:    coreworkflow.RunStatusPending,
+		Target:    cloneWorkflowTarget(req.Target),
+		CreatedBy: req.CreatedBy,
+		CreatedAt: &now,
+	}, nil
 }
 
 func (p *memoryWorkflowProvider) GetRun(context.Context, coreworkflow.GetRunRequest) (*coreworkflow.Run, error) {
@@ -228,6 +245,33 @@ func cloneWorkflowSchedule(schedule *coreworkflow.Schedule) *coreworkflow.Schedu
 		cloned.NextRunAt = &value
 	}
 	return &cloned
+}
+
+func cloneWorkflowRun(run *coreworkflow.Run) *coreworkflow.Run {
+	if run == nil {
+		return nil
+	}
+	cloned := *run
+	cloned.Target = cloneWorkflowTarget(run.Target)
+	if run.CreatedAt != nil {
+		value := *run.CreatedAt
+		cloned.CreatedAt = &value
+	}
+	if run.StartedAt != nil {
+		value := *run.StartedAt
+		cloned.StartedAt = &value
+	}
+	if run.CompletedAt != nil {
+		value := *run.CompletedAt
+		cloned.CompletedAt = &value
+	}
+	return &cloned
+}
+
+func cloneWorkflowTarget(target coreworkflow.Target) coreworkflow.Target {
+	cloned := target
+	cloned.Input = cloneMap(target.Input)
+	return cloned
 }
 
 func cloneMap(src map[string]any) map[string]any {

--- a/gestaltd/sdk/providermanifest/v1/manifest.jsonschema.json
+++ b/gestaltd/sdk/providermanifest/v1/manifest.jsonschema.json
@@ -100,6 +100,24 @@
         "auth": {
           "$ref": "#/$defs/routeAuthRef"
         },
+        "securitySchemes": {
+          "type": "object",
+          "propertyNames": {
+            "minLength": 1
+          },
+          "additionalProperties": {
+            "$ref": "#/$defs/webhookSecurityScheme"
+          }
+        },
+        "webhooks": {
+          "type": "object",
+          "propertyNames": {
+            "minLength": 1
+          },
+          "additionalProperties": {
+            "$ref": "#/$defs/webhookDef"
+          }
+        },
         "headers": {
           "type": "object",
           "additionalProperties": {
@@ -166,6 +184,302 @@
       ],
       "properties": {
         "provider": {
+          "type": "string",
+          "minLength": 1
+        }
+      }
+    },
+    "webhookSecurityScheme": {
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "type": {
+          "type": "string",
+          "enum": [
+            "hmac",
+            "apiKey",
+            "http",
+            "mutualTLS",
+            "none"
+          ]
+        },
+        "description": {
+          "type": "string"
+        },
+        "name": {
+          "type": "string",
+          "minLength": 1
+        },
+        "in": {
+          "type": "string",
+          "enum": [
+            "header",
+            "query"
+          ]
+        },
+        "scheme": {
+          "type": "string",
+          "enum": [
+            "basic",
+            "bearer"
+          ]
+        },
+        "secret": {
+          "$ref": "#/$defs/webhookSecretRef"
+        },
+        "signature": {
+          "$ref": "#/$defs/webhookSignatureConfig"
+        },
+        "replay": {
+          "$ref": "#/$defs/webhookReplayConfig"
+        },
+        "mtls": {
+          "$ref": "#/$defs/webhookMTLSConfig"
+        }
+      }
+    },
+    "webhookSecretRef": {
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "env": {
+          "type": "string",
+          "minLength": 1
+        },
+        "secret": {
+          "type": "string",
+          "minLength": 1
+        }
+      }
+    },
+    "webhookSignatureConfig": {
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "algorithm": {
+          "type": "string",
+          "minLength": 1
+        },
+        "signatureHeader": {
+          "type": "string",
+          "minLength": 1
+        },
+        "timestampHeader": {
+          "type": "string",
+          "minLength": 1
+        },
+        "deliveryIdHeader": {
+          "type": "string",
+          "minLength": 1
+        },
+        "payloadTemplate": {
+          "type": "string"
+        },
+        "digestPrefix": {
+          "type": "string"
+        }
+      }
+    },
+    "webhookReplayConfig": {
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "maxAge": {
+          "type": "string",
+          "minLength": 1
+        }
+      }
+    },
+    "webhookMTLSConfig": {
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "subjectAltName": {
+          "type": "string",
+          "minLength": 1
+        }
+      }
+    },
+    "webhookDef": {
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "summary": {
+          "type": "string"
+        },
+        "description": {
+          "type": "string"
+        },
+        "path": {
+          "type": "string",
+          "minLength": 1
+        },
+        "get": {
+          "$ref": "#/$defs/webhookOperation"
+        },
+        "post": {
+          "$ref": "#/$defs/webhookOperation"
+        },
+        "put": {
+          "$ref": "#/$defs/webhookOperation"
+        },
+        "delete": {
+          "$ref": "#/$defs/webhookOperation"
+        },
+        "target": {
+          "$ref": "#/$defs/webhookTarget"
+        },
+        "execution": {
+          "$ref": "#/$defs/webhookExecution"
+        }
+      }
+    },
+    "webhookOperation": {
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "operationId": {
+          "type": "string"
+        },
+        "summary": {
+          "type": "string"
+        },
+        "description": {
+          "type": "string"
+        },
+        "requestBody": {
+          "$ref": "#/$defs/webhookRequestBody"
+        },
+        "responses": {
+          "type": "object",
+          "propertyNames": {
+            "minLength": 1
+          },
+          "additionalProperties": {
+            "$ref": "#/$defs/webhookResponse"
+          }
+        },
+        "security": {
+          "type": "array",
+          "items": {
+            "$ref": "#/$defs/securityRequirement"
+          }
+        }
+      }
+    },
+    "webhookRequestBody": {
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "required": {
+          "type": "boolean"
+        },
+        "content": {
+          "type": "object",
+          "propertyNames": {
+            "minLength": 1
+          },
+          "additionalProperties": {
+            "$ref": "#/$defs/webhookMediaType"
+          }
+        }
+      }
+    },
+    "webhookMediaType": {
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "schema": {}
+      }
+    },
+    "webhookResponse": {
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "description": {
+          "type": "string"
+        },
+        "headers": {
+          "type": "object",
+          "additionalProperties": {
+            "type": "string"
+          }
+        },
+        "content": {
+          "type": "object",
+          "propertyNames": {
+            "minLength": 1
+          },
+          "additionalProperties": {
+            "$ref": "#/$defs/webhookMediaType"
+          }
+        },
+        "body": {}
+      }
+    },
+    "securityRequirement": {
+      "type": "object",
+      "propertyNames": {
+        "minLength": 1
+      },
+      "additionalProperties": {
+        "type": "array",
+        "items": {
+          "type": "string"
+        }
+      }
+    },
+    "webhookTarget": {
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "operation": {
+          "type": "string",
+          "minLength": 1
+        },
+        "workflow": {
+          "$ref": "#/$defs/webhookWorkflowTarget"
+        }
+      }
+    },
+    "webhookWorkflowTarget": {
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "provider": {
+          "type": "string"
+        },
+        "plugin": {
+          "type": "string",
+          "minLength": 1
+        },
+        "operation": {
+          "type": "string",
+          "minLength": 1
+        },
+        "connection": {
+          "type": "string"
+        },
+        "instance": {
+          "type": "string"
+        },
+        "input": {
+          "type": "object"
+        }
+      }
+    },
+    "webhookExecution": {
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "mode": {
+          "type": "string",
+          "enum": [
+            "sync",
+            "async_ack"
+          ]
+        },
+        "acceptedResponse": {
           "type": "string",
           "minLength": 1
         }

--- a/gestaltd/sdk/providermanifest/v1/types.go
+++ b/gestaltd/sdk/providermanifest/v1/types.go
@@ -78,6 +78,8 @@ type Spec struct {
 
 	// Plugin-specific fields
 	RouteAuth         *RouteAuthRef                         `json:"auth,omitempty" yaml:"auth,omitempty"`
+	SecuritySchemes   map[string]*WebhookSecurityScheme     `json:"securitySchemes,omitempty" yaml:"securitySchemes,omitempty"`
+	Webhooks          map[string]*WebhookDef                `json:"webhooks,omitempty" yaml:"webhooks,omitempty"`
 	MCP               bool                                  `json:"mcp,omitempty" yaml:"mcp,omitempty"`
 	Headers           map[string]string                     `json:"headers,omitempty" yaml:"headers,omitempty"`
 	ManagedParameters []ManagedParameter                    `json:"managedParameters,omitempty" yaml:"managedParameters,omitempty"`
@@ -97,6 +99,129 @@ type Spec struct {
 
 type RouteAuthRef struct {
 	Provider string `json:"provider,omitempty" yaml:"provider,omitempty"`
+}
+
+type WebhookExecutionMode string
+
+const (
+	WebhookExecutionModeSync     WebhookExecutionMode = "sync"
+	WebhookExecutionModeAsyncAck WebhookExecutionMode = "async_ack"
+)
+
+type WebhookSecuritySchemeType string
+
+const (
+	WebhookSecuritySchemeTypeHMAC      WebhookSecuritySchemeType = "hmac"
+	WebhookSecuritySchemeTypeAPIKey    WebhookSecuritySchemeType = "apiKey"
+	WebhookSecuritySchemeTypeHTTP      WebhookSecuritySchemeType = "http"
+	WebhookSecuritySchemeTypeMutualTLS WebhookSecuritySchemeType = "mutualTLS"
+	WebhookSecuritySchemeTypeNone      WebhookSecuritySchemeType = "none"
+)
+
+type WebhookIn string
+
+const (
+	WebhookInHeader WebhookIn = "header"
+	WebhookInQuery  WebhookIn = "query"
+)
+
+type WebhookHTTPScheme string
+
+const (
+	WebhookHTTPSchemeBasic  WebhookHTTPScheme = "basic"
+	WebhookHTTPSchemeBearer WebhookHTTPScheme = "bearer"
+)
+
+type WebhookDef struct {
+	Summary     string            `json:"summary,omitempty" yaml:"summary,omitempty"`
+	Description string            `json:"description,omitempty" yaml:"description,omitempty"`
+	Path        string            `json:"path,omitempty" yaml:"path,omitempty"`
+	Get         *WebhookOperation `json:"get,omitempty" yaml:"get,omitempty"`
+	Post        *WebhookOperation `json:"post,omitempty" yaml:"post,omitempty"`
+	Put         *WebhookOperation `json:"put,omitempty" yaml:"put,omitempty"`
+	Delete      *WebhookOperation `json:"delete,omitempty" yaml:"delete,omitempty"`
+	Target      *WebhookTarget    `json:"target,omitempty" yaml:"target,omitempty"`
+	Execution   *WebhookExecution `json:"execution,omitempty" yaml:"execution,omitempty"`
+}
+
+type WebhookOperation struct {
+	OperationID string                      `json:"operationId,omitempty" yaml:"operationId,omitempty"`
+	Summary     string                      `json:"summary,omitempty" yaml:"summary,omitempty"`
+	Description string                      `json:"description,omitempty" yaml:"description,omitempty"`
+	RequestBody *WebhookRequestBody         `json:"requestBody,omitempty" yaml:"requestBody,omitempty"`
+	Responses   map[string]*WebhookResponse `json:"responses,omitempty" yaml:"responses,omitempty"`
+	Security    []SecurityRequirement       `json:"security,omitempty" yaml:"security,omitempty"`
+}
+
+type WebhookRequestBody struct {
+	Required bool                         `json:"required,omitempty" yaml:"required,omitempty"`
+	Content  map[string]*WebhookMediaType `json:"content,omitempty" yaml:"content,omitempty"`
+}
+
+type WebhookMediaType struct {
+	Schema any `json:"schema,omitempty" yaml:"schema,omitempty"`
+}
+
+type WebhookResponse struct {
+	Description string                       `json:"description,omitempty" yaml:"description,omitempty"`
+	Headers     map[string]string            `json:"headers,omitempty" yaml:"headers,omitempty"`
+	Content     map[string]*WebhookMediaType `json:"content,omitempty" yaml:"content,omitempty"`
+	Body        any                          `json:"body,omitempty" yaml:"body,omitempty"`
+}
+
+type SecurityRequirement map[string][]string
+
+type WebhookTarget struct {
+	Operation string                 `json:"operation,omitempty" yaml:"operation,omitempty"`
+	Workflow  *WebhookWorkflowTarget `json:"workflow,omitempty" yaml:"workflow,omitempty"`
+}
+
+type WebhookWorkflowTarget struct {
+	Provider   string         `json:"provider,omitempty" yaml:"provider,omitempty"`
+	Plugin     string         `json:"plugin,omitempty" yaml:"plugin,omitempty"`
+	Operation  string         `json:"operation,omitempty" yaml:"operation,omitempty"`
+	Connection string         `json:"connection,omitempty" yaml:"connection,omitempty"`
+	Instance   string         `json:"instance,omitempty" yaml:"instance,omitempty"`
+	Input      map[string]any `json:"input,omitempty" yaml:"input,omitempty"`
+}
+
+type WebhookExecution struct {
+	Mode             WebhookExecutionMode `json:"mode,omitempty" yaml:"mode,omitempty"`
+	AcceptedResponse string               `json:"acceptedResponse,omitempty" yaml:"acceptedResponse,omitempty"`
+}
+
+type WebhookSecurityScheme struct {
+	Type        WebhookSecuritySchemeType `json:"type,omitempty" yaml:"type,omitempty"`
+	Description string                    `json:"description,omitempty" yaml:"description,omitempty"`
+	Name        string                    `json:"name,omitempty" yaml:"name,omitempty"`
+	In          WebhookIn                 `json:"in,omitempty" yaml:"in,omitempty"`
+	Scheme      WebhookHTTPScheme         `json:"scheme,omitempty" yaml:"scheme,omitempty"`
+	Secret      *WebhookSecretRef         `json:"secret,omitempty" yaml:"secret,omitempty"`
+	Signature   *WebhookSignatureConfig   `json:"signature,omitempty" yaml:"signature,omitempty"`
+	Replay      *WebhookReplayConfig      `json:"replay,omitempty" yaml:"replay,omitempty"`
+	MTLS        *WebhookMTLSConfig        `json:"mtls,omitempty" yaml:"mtls,omitempty"`
+}
+
+type WebhookSecretRef struct {
+	Env    string `json:"env,omitempty" yaml:"env,omitempty"`
+	Secret string `json:"secret,omitempty" yaml:"secret,omitempty"`
+}
+
+type WebhookSignatureConfig struct {
+	Algorithm        string `json:"algorithm,omitempty" yaml:"algorithm,omitempty"`
+	SignatureHeader  string `json:"signatureHeader,omitempty" yaml:"signatureHeader,omitempty"`
+	TimestampHeader  string `json:"timestampHeader,omitempty" yaml:"timestampHeader,omitempty"`
+	DeliveryIDHeader string `json:"deliveryIdHeader,omitempty" yaml:"deliveryIdHeader,omitempty"`
+	PayloadTemplate  string `json:"payloadTemplate,omitempty" yaml:"payloadTemplate,omitempty"`
+	DigestPrefix     string `json:"digestPrefix,omitempty" yaml:"digestPrefix,omitempty"`
+}
+
+type WebhookReplayConfig struct {
+	MaxAge string `json:"maxAge,omitempty" yaml:"maxAge,omitempty"`
+}
+
+type WebhookMTLSConfig struct {
+	SubjectAltName string `json:"subjectAltName,omitempty" yaml:"subjectAltName,omitempty"`
 }
 
 type OwnedUI struct {
@@ -416,6 +541,8 @@ type Entrypoint struct {
 type specJSONWire struct {
 	ConfigSchemaPath  string                                `json:"configSchemaPath,omitempty"`
 	Auth              *RouteAuthRef                         `json:"auth,omitempty"`
+	SecuritySchemes   map[string]*WebhookSecurityScheme     `json:"securitySchemes,omitempty"`
+	Webhooks          map[string]*WebhookDef                `json:"webhooks,omitempty"`
 	MCP               bool                                  `json:"mcp,omitempty"`
 	Headers           map[string]string                     `json:"headers,omitempty"`
 	ManagedParameters []ManagedParameter                    `json:"managedParameters,omitempty"`
@@ -434,6 +561,8 @@ type specJSONWire struct {
 type specYAMLWire struct {
 	ConfigSchemaPath  string                                `yaml:"configSchemaPath,omitempty"`
 	Auth              *RouteAuthRef                         `yaml:"auth,omitempty"`
+	SecuritySchemes   map[string]*WebhookSecurityScheme     `yaml:"securitySchemes,omitempty"`
+	Webhooks          map[string]*WebhookDef                `yaml:"webhooks,omitempty"`
 	MCP               bool                                  `yaml:"mcp,omitempty"`
 	Headers           map[string]string                     `yaml:"headers,omitempty"`
 	ManagedParameters []ManagedParameter                    `yaml:"managedParameters,omitempty"`
@@ -452,6 +581,8 @@ type specYAMLWire struct {
 type specWire struct {
 	ConfigSchemaPath  string                                `json:"configSchemaPath,omitempty" yaml:"configSchemaPath,omitempty"`
 	Auth              *RouteAuthRef                         `json:"auth,omitempty" yaml:"auth,omitempty"`
+	SecuritySchemes   map[string]*WebhookSecurityScheme     `json:"securitySchemes,omitempty" yaml:"securitySchemes,omitempty"`
+	Webhooks          map[string]*WebhookDef                `json:"webhooks,omitempty" yaml:"webhooks,omitempty"`
 	MCP               bool                                  `json:"mcp,omitempty" yaml:"mcp,omitempty"`
 	Headers           map[string]string                     `json:"headers,omitempty" yaml:"headers,omitempty"`
 	ManagedParameters []ManagedParameter                    `json:"managedParameters,omitempty" yaml:"managedParameters,omitempty"`
@@ -480,6 +611,8 @@ func (s *Spec) UnmarshalJSON(data []byte) error {
 	spec := Spec{
 		ConfigSchemaPath:  raw.ConfigSchemaPath,
 		RouteAuth:         raw.Auth,
+		SecuritySchemes:   cloneWebhookSecuritySchemes(raw.SecuritySchemes),
+		Webhooks:          cloneWebhookDefs(raw.Webhooks),
 		MCP:               raw.MCP,
 		Headers:           raw.Headers,
 		ManagedParameters: raw.ManagedParameters,
@@ -527,6 +660,8 @@ func (s *Spec) UnmarshalYAML(value *yaml.Node) error {
 	spec := Spec{
 		ConfigSchemaPath:  raw.ConfigSchemaPath,
 		RouteAuth:         raw.Auth,
+		SecuritySchemes:   cloneWebhookSecuritySchemes(raw.SecuritySchemes),
+		Webhooks:          cloneWebhookDefs(raw.Webhooks),
 		MCP:               raw.MCP,
 		Headers:           raw.Headers,
 		ManagedParameters: raw.ManagedParameters,
@@ -557,6 +692,8 @@ func (s Spec) canonicalWire() (specWire, error) {
 	return specWire{
 		ConfigSchemaPath:  s.ConfigSchemaPath,
 		Auth:              s.RouteAuth,
+		SecuritySchemes:   cloneWebhookSecuritySchemes(s.SecuritySchemes),
+		Webhooks:          cloneWebhookDefs(s.Webhooks),
 		MCP:               s.MCP,
 		Headers:           s.Headers,
 		ManagedParameters: s.ManagedParameters,
@@ -587,6 +724,167 @@ func cloneManifestConnections(src map[string]*ManifestConnectionDef) map[string]
 		cloned[name] = &copyDef
 	}
 	return cloned
+}
+
+func cloneWebhookSecuritySchemes(src map[string]*WebhookSecurityScheme) map[string]*WebhookSecurityScheme {
+	if src == nil {
+		return nil
+	}
+	cloned := make(map[string]*WebhookSecurityScheme, len(src))
+	for name, scheme := range src {
+		if scheme == nil {
+			cloned[name] = nil
+			continue
+		}
+		copyScheme := *scheme
+		if scheme.Secret != nil {
+			copySecret := *scheme.Secret
+			copyScheme.Secret = &copySecret
+		}
+		if scheme.Signature != nil {
+			copySignature := *scheme.Signature
+			copyScheme.Signature = &copySignature
+		}
+		if scheme.Replay != nil {
+			copyReplay := *scheme.Replay
+			copyScheme.Replay = &copyReplay
+		}
+		if scheme.MTLS != nil {
+			copyMTLS := *scheme.MTLS
+			copyScheme.MTLS = &copyMTLS
+		}
+		cloned[name] = &copyScheme
+	}
+	return cloned
+}
+
+func cloneWebhookDefs(src map[string]*WebhookDef) map[string]*WebhookDef {
+	if src == nil {
+		return nil
+	}
+	cloned := make(map[string]*WebhookDef, len(src))
+	for name, def := range src {
+		cloned[name] = cloneWebhookDef(def)
+	}
+	return cloned
+}
+
+func cloneWebhookDef(src *WebhookDef) *WebhookDef {
+	if src == nil {
+		return nil
+	}
+	cloned := *src
+	cloned.Get = cloneWebhookOperation(src.Get)
+	cloned.Post = cloneWebhookOperation(src.Post)
+	cloned.Put = cloneWebhookOperation(src.Put)
+	cloned.Delete = cloneWebhookOperation(src.Delete)
+	cloned.Target = cloneWebhookTarget(src.Target)
+	cloned.Execution = cloneWebhookExecution(src.Execution)
+	return &cloned
+}
+
+func cloneWebhookOperation(src *WebhookOperation) *WebhookOperation {
+	if src == nil {
+		return nil
+	}
+	cloned := *src
+	cloned.RequestBody = cloneWebhookRequestBody(src.RequestBody)
+	cloned.Responses = cloneWebhookResponses(src.Responses)
+	cloned.Security = cloneSecurityRequirements(src.Security)
+	return &cloned
+}
+
+func cloneWebhookRequestBody(src *WebhookRequestBody) *WebhookRequestBody {
+	if src == nil {
+		return nil
+	}
+	cloned := *src
+	cloned.Content = cloneWebhookMediaTypes(src.Content)
+	return &cloned
+}
+
+func cloneWebhookResponses(src map[string]*WebhookResponse) map[string]*WebhookResponse {
+	if src == nil {
+		return nil
+	}
+	cloned := make(map[string]*WebhookResponse, len(src))
+	for code, resp := range src {
+		if resp == nil {
+			cloned[code] = nil
+			continue
+		}
+		copyResp := *resp
+		if resp.Headers != nil {
+			copyResp.Headers = make(map[string]string, len(resp.Headers))
+			for key, value := range resp.Headers {
+				copyResp.Headers[key] = value
+			}
+		}
+		copyResp.Content = cloneWebhookMediaTypes(resp.Content)
+		cloned[code] = &copyResp
+	}
+	return cloned
+}
+
+func cloneWebhookMediaTypes(src map[string]*WebhookMediaType) map[string]*WebhookMediaType {
+	if src == nil {
+		return nil
+	}
+	cloned := make(map[string]*WebhookMediaType, len(src))
+	for name, mediaType := range src {
+		if mediaType == nil {
+			cloned[name] = nil
+			continue
+		}
+		copyMediaType := *mediaType
+		cloned[name] = &copyMediaType
+	}
+	return cloned
+}
+
+func cloneSecurityRequirements(src []SecurityRequirement) []SecurityRequirement {
+	if src == nil {
+		return nil
+	}
+	cloned := make([]SecurityRequirement, 0, len(src))
+	for _, requirement := range src {
+		if requirement == nil {
+			cloned = append(cloned, nil)
+			continue
+		}
+		copyRequirement := make(SecurityRequirement, len(requirement))
+		for name, scopes := range requirement {
+			copyRequirement[name] = append([]string(nil), scopes...)
+		}
+		cloned = append(cloned, copyRequirement)
+	}
+	return cloned
+}
+
+func cloneWebhookTarget(src *WebhookTarget) *WebhookTarget {
+	if src == nil {
+		return nil
+	}
+	cloned := *src
+	if src.Workflow != nil {
+		copyWorkflow := *src.Workflow
+		if src.Workflow.Input != nil {
+			copyWorkflow.Input = make(map[string]any, len(src.Workflow.Input))
+			for key, value := range src.Workflow.Input {
+				copyWorkflow.Input[key] = value
+			}
+		}
+		cloned.Workflow = &copyWorkflow
+	}
+	return &cloned
+}
+
+func cloneWebhookExecution(src *WebhookExecution) *WebhookExecution {
+	if src == nil {
+		return nil
+	}
+	cloned := *src
+	return &cloned
 }
 
 func decodeJSONKnownFields(data []byte, out any) error {
@@ -637,6 +935,8 @@ func validateYAMLWireObjectFields(node *yaml.Node, allowed map[string]struct{}, 
 var specWireFields = map[string]struct{}{
 	"configSchemaPath":  {},
 	"auth":              {},
+	"securitySchemes":   {},
+	"webhooks":          {},
 	"mcp":               {},
 	"headers":           {},
 	"managedParameters": {},


### PR DESCRIPTION
## Summary

This PR adds first-class hosted plugin webhooks with reusable security schemes, direct public route mounting, request verification, payload parsing, operation/workflow dispatch, and async acknowledgements.

## New interfaces

- manifest `spec.securitySchemes` for reusable hosted-webhook verification schemes
- manifest `spec.webhooks` for mounted inbound webhook routes
- config `plugins.<name>.securitySchemes` and `plugins.<name>.webhooks` overrides
- webhook targets:
  - `target.operation: <operation>`
  - `target.workflow: { provider, plugin, operation, connection?, instance?, input? }`
- webhook execution:
  - `mode: sync`
  - `mode: async_ack`
  - `acceptedResponse: "<status>"`
- webhook request/response primitives:
  - `requestBody.content`
  - `responses`
  - `security`
  - static response `body` and `headers`

## Example manifest

```yaml
spec:
  connections:
    default:
      auth:
        type: none

  securitySchemes:
    slackSignature:
      type: hmac
      secret:
        env: SLACK_SIGNING_SECRET
      signature:
        algorithm: sha256
        signatureHeader: X-Slack-Signature
        timestampHeader: X-Slack-Request-Timestamp
        deliveryIdHeader: X-Slack-Delivery-ID
        payloadTemplate: "v0:{header.X-Slack-Request-Timestamp}:{raw_body}"
        digestPrefix: "v0="
      replay:
        maxAge: 5m

  webhooks:
    slackCommand:
      path: /webhooks/slack-agent/command
      post:
        requestBody:
          required: true
          content:
            application/x-www-form-urlencoded: {}
        responses:
          "200":
            description: accepted
            content:
              application/json: {}
            body:
              response_type: ephemeral
              text: Working on it...
        security:
          - slackSignature: []
      target:
        operation: handle_command
      execution:
        mode: async_ack
        acceptedResponse: "200"
```

## Example config override

```yaml
plugins:
  slack_agent:
    source: ./dist/provider-release.yaml
    securitySchemes:
      slackSignature:
        type: hmac
        secret:
          env: SLACK_SIGNING_SECRET
        signature:
          algorithm: sha256
          signatureHeader: X-Slack-Signature
          timestampHeader: X-Slack-Request-Timestamp
          deliveryIdHeader: X-Slack-Delivery-ID
          payloadTemplate: "v0:{header.X-Slack-Request-Timestamp}:{raw_body}"
          digestPrefix: "v0="
        replay:
          maxAge: 5m
    webhooks:
      slackCommand:
        path: /webhooks/slack-agent/command
        post:
          requestBody:
            required: true
            content:
              application/x-www-form-urlencoded: {}
          responses:
            "200":
              description: accepted
              content:
                application/json: {}
              body:
                response_type: ephemeral
                text: Working on it...
          security:
            - slackSignature: []
        target:
          operation: handle_command
        execution:
          mode: async_ack
          acceptedResponse: "200"
```

## Behavior

- mounts hosted webhooks directly on the public router, outside auth middleware
- verifies requests with built-in `hmac`, `apiKey`, `http`, `mutualTLS`, and `none` schemes
- preserves raw bodies, parses JSON and form-urlencoded payloads, and falls back to `rawBody`
- dispatches to plugin operations or workflow runs
- supports async acknowledgement with static configured responses
- rejects startup path conflicts with mounted UIs and core route namespaces
- annotates invocation/workflow context with webhook metadata

## Validation

- `go test ./internal/server -run 'TestHostedWebhook_HMACAsyncAckDispatchesOperationAndRejectsReplay|TestHostedWebhook_APIKeySyncStartsWorkflowRun|TestHostedWebhook_RejectsMountedUIPathConflicts|TestPluginRouteAuth_HTTPRoutesUseNamedProviderOverride|TestMountedWebUIRoutes_HumanAuthorization_UsesPluginRouteAuthOverride' -count=1`
- `go test ./internal/config ./internal/providerpkg -count=1`
- `go test ./internal/bootstrap ./cmd/gestaltd -run TestDoesNotExist -count=1`
- `golangci-lint run ./internal/server/... ./internal/config/... ./internal/providerpkg/... ./sdk/providermanifest/v1/...`
