### PR TITLE
Fix hybrid plugin default connection routing

### DIFF
--- a/gestaltd/internal/bootstrap/executable_plugin_test.go
+++ b/gestaltd/internal/bootstrap/executable_plugin_test.go
@@ -824,8 +824,8 @@ paths:
 	if err != nil {
 		t.Fatalf("providers.Get(hybrid): %v", err)
 	}
-	if got := prov.ConnectionForOperation("echo"); got != config.PluginConnectionName {
-		t.Fatalf("echo connection = %q, want %q", got, config.PluginConnectionName)
+	if got := prov.ConnectionForOperation("echo"); got != "default" {
+		t.Fatalf("echo connection = %q, want %q", got, "default")
 	}
 	if got := prov.ConnectionForOperation("status"); got != "default" {
 		t.Fatalf("status connection = %q, want %q", got, "default")
@@ -835,11 +835,108 @@ paths:
 	if err != nil {
 		t.Fatalf("buildStartupProviderSpec: %v", err)
 	}
-	if got := operationConnections["echo"]; got != config.PluginConnectionName {
-		t.Fatalf("startup echo connection = %q, want %q", got, config.PluginConnectionName)
+	if got := operationConnections["echo"]; got != "default" {
+		t.Fatalf("startup echo connection = %q, want %q", got, "default")
 	}
 	if _, ok := operationConnections["status"]; ok {
 		t.Fatalf("startup catalog unexpectedly exposed spec-loaded status operation")
+	}
+}
+
+func TestHybridDeclarativeExecutableProviderUsesNamedDefaultConnectionForPluginOperations(t *testing.T) {
+	t.Parallel()
+
+	bin := buildEchoPluginBinary(t)
+	manifestRoot := writeStaticCatalog(t, &catalog.Catalog{
+		Name: "hybrid",
+		Operations: []catalog.CatalogOperation{
+			{ID: "echo", Method: http.MethodPost, Parameters: []catalog.CatalogParameter{{Name: "message", Type: "string", Required: true}}},
+		},
+	})
+
+	manifest := newExecutableManifest("Hybrid", "Hybrid provider")
+	manifest.Entrypoint = &providermanifestv1.Entrypoint{ArtifactPath: "ignored-for-command-mode"}
+	manifest.Spec.Surfaces = &providermanifestv1.ProviderSurfaces{
+		REST: &providermanifestv1.RESTSurface{
+			BaseURL: "https://example.invalid",
+			Operations: []providermanifestv1.ProviderOperation{
+				{
+					Name:   "status",
+					Method: http.MethodGet,
+					Path:   "/status",
+				},
+			},
+		},
+	}
+	manifest.Spec.Connections = map[string]*providermanifestv1.ManifestConnectionDef{
+		"default": {
+			Auth: &providermanifestv1.ProviderAuth{Type: providermanifestv1.AuthTypeBearer},
+		},
+	}
+	manifestPath := filepath.Join(manifestRoot, "manifest.yaml")
+
+	entry := &config.ProviderEntry{
+		Command:              bin,
+		Args:                 []string{"provider"},
+		ResolvedManifest:     manifest,
+		ResolvedManifestPath: manifestPath,
+	}
+	cfg := &config.Config{
+		Plugins: map[string]*config.ProviderEntry{
+			"hybrid": entry,
+		},
+	}
+
+	factories := NewFactoryRegistry()
+	providers, _, err := buildProvidersStrict(context.Background(), cfg, factories, Deps{})
+	if err != nil {
+		t.Fatalf("buildProvidersStrict: %v", err)
+	}
+	defer func() { _ = CloseProviders(providers) }()
+
+	prov, err := providers.Get("hybrid")
+	if err != nil {
+		t.Fatalf("providers.Get(hybrid): %v", err)
+	}
+	if got := prov.ConnectionForOperation("echo"); got != "default" {
+		t.Fatalf("echo connection = %q, want %q", got, "default")
+	}
+	if got := prov.ConnectionForOperation("status"); got != "default" {
+		t.Fatalf("status connection = %q, want %q", got, "default")
+	}
+
+	services := coretesting.NewStubServices(t)
+	subjectID := principal.UserSubjectID("u-hybrid")
+	if err := services.Tokens.StoreToken(context.Background(), &core.IntegrationToken{
+		SubjectID:   subjectID,
+		Integration: "hybrid",
+		Connection:  "default",
+		Instance:    "default",
+		AccessToken: "tok-default",
+	}); err != nil {
+		t.Fatalf("StoreToken(default): %v", err)
+	}
+
+	result, err := invocation.NewBroker(providers, services.Users, services.Tokens).Invoke(
+		context.Background(),
+		&principal.Principal{
+			UserID: "u-hybrid",
+			Kind:   principal.KindUser,
+			Scopes: []string{"hybrid"},
+		},
+		"hybrid",
+		"",
+		"echo",
+		map[string]any{"message": "hello"},
+	)
+	if err != nil {
+		t.Fatalf("Invoke(hybrid.echo): %v", err)
+	}
+	if result.Status != http.StatusOK {
+		t.Fatalf("status = %d, want %d", result.Status, http.StatusOK)
+	}
+	if result.Body != `{"message":"hello"}` {
+		t.Fatalf("body = %q, want %q", result.Body, `{"message":"hello"}`)
 	}
 }
 
@@ -1295,9 +1392,9 @@ func TestPluginManifestOAuthWiresConnectionAuth(t *testing.T) {
 	if !ok {
 		t.Fatal("expected connection auth entry for echoauth")
 	}
-	handler, ok := handlers[config.PluginConnectionName]
+	handler, ok := handlers["default"]
 	if !ok {
-		t.Fatalf("expected handler for connection %q", config.PluginConnectionName)
+		t.Fatalf("expected handler for connection %q", "default")
 	}
 	if handler.AuthorizationBaseURL() != "https://example.com/authorize" {
 		t.Fatalf("authorization URL = %q, want %q", handler.AuthorizationBaseURL(), "https://example.com/authorize")

--- a/gestaltd/internal/config/config.go
+++ b/gestaltd/internal/config/config.go
@@ -991,20 +991,6 @@ func cloneAuthValue(src AuthValueDef) AuthValueDef {
 
 func EffectivePluginConnectionDef(plugin *ProviderEntry, manifestPlugin *providermanifestv1.Spec) ConnectionDef {
 	conn := ConnectionDef{}
-	if manifestPlugin != nil {
-		if def := manifestPlugin.DefaultConnectionDef(); def != nil {
-			conn.Mode = def.Mode
-			if len(def.Params) > 0 {
-				conn.ConnectionParams = maps.Clone(def.Params)
-			}
-			if def.Auth != nil {
-				MergeConnectionAuth(&conn.Auth, ManifestAuthToConnectionAuthDef(def.Auth))
-			}
-			if def.Discovery != nil {
-				conn.Discovery = def.Discovery
-			}
-		}
-	}
 	if plugin != nil {
 		override := &ConnectionDef{
 			Mode:             plugin.ConnectionMode,

--- a/gestaltd/internal/config/config.go
+++ b/gestaltd/internal/config/config.go
@@ -989,7 +989,7 @@ func cloneAuthValue(src AuthValueDef) AuthValueDef {
 	return dst
 }
 
-func EffectivePluginConnectionDef(plugin *ProviderEntry, manifestPlugin *providermanifestv1.Spec) ConnectionDef {
+func EffectivePluginConnectionDef(plugin *ProviderEntry) ConnectionDef {
 	conn := ConnectionDef{}
 	if plugin != nil {
 		override := &ConnectionDef{

--- a/gestaltd/internal/config/config_validate.go
+++ b/gestaltd/internal/config/config_validate.go
@@ -1179,7 +1179,7 @@ func validateExecutableConnectionAuthSupport(name string, plan *StaticConnection
 	}
 
 	supportsMCPOAuth = provider != nil && provider.MCPURL() != ""
-	if conn := EffectivePluginConnectionDef(plugin, provider); conn.Auth.Type == providermanifestv1.AuthTypeMCPOAuth && !supportsMCPOAuth {
+	if conn := EffectivePluginConnectionDef(plugin); conn.Auth.Type == providermanifestv1.AuthTypeMCPOAuth && !supportsMCPOAuth {
 		return fmt.Errorf("config validation: integration %q plugin auth type %q requires an MCP surface", name, providermanifestv1.AuthTypeMCPOAuth)
 	}
 
@@ -1216,7 +1216,7 @@ func validateManifestBackedIntegration(name string, entry *ProviderEntry) error 
 	if err := validateExecutableConnectionAuthSupport(name, plan, entry, effectiveProvider); err != nil {
 		return err
 	}
-	pluginConnection := EffectivePluginConnectionDef(entry, effectiveProvider)
+	pluginConnection := EffectivePluginConnectionDef(entry)
 	if plan != nil {
 		pluginConnection = plan.PluginConnection()
 	}

--- a/gestaltd/internal/config/connection_plan.go
+++ b/gestaltd/internal/config/connection_plan.go
@@ -29,7 +29,7 @@ func BuildStaticConnectionPlan(plugin *ProviderEntry, manifestPlugin *providerma
 	declaredNames := namedConnectionNames(plugin, manifestPlugin)
 	plan := StaticConnectionPlan{
 		manifestBacked:   manifestPlugin != nil && manifestPlugin.IsManifestBacked(),
-		pluginConnection: EffectivePluginConnectionDef(plugin, manifestPlugin),
+		pluginConnection: EffectivePluginConnectionDef(plugin),
 		namedConnections: make(map[string]ConnectionDef),
 		surfaces:         make(map[SpecSurface]ResolvedSpecSurface),
 	}


### PR DESCRIPTION
## Summary
- stop treating `spec.connections.default` as the implicit plugin connection
- route hybrid executable operations through the named default/spec connection when no explicit plugin connection is declared
- add regression coverage for the BigQuery-style shape: executable plugin + declarative REST surface + single named `default` connection

## Root cause
`EffectivePluginConnectionDef()` was folding `spec.connections.default` into the plugin connection. That made the planner think hybrid providers had an explicit plugin connection, so executable operations stayed on `_plugin` instead of inheriting the named default connection. In production this is why `bigquery query` looked disconnected unless `--connection default` was passed.

## Testing
- `go test ./internal/config ./internal/bootstrap -count=1`
