### PR TITLE
Add hosted HTTP bindings on top of operations

### DIFF
--- a/gestaltd/internal/config/config.go
+++ b/gestaltd/internal/config/config.go
@@ -11,6 +11,7 @@ import (
 	"net/url"
 	"os"
 	"path/filepath"
+	"reflect"
 	"slices"
 	"strconv"
 	"strings"
@@ -303,15 +304,17 @@ func (g GitHubReleaseSourceDef) Location() string {
 
 // ProviderEntry is the universal configuration for any provider.
 type ProviderEntry struct {
-	Source       ProviderSource    `yaml:"source"`
-	Config       yaml.Node         `yaml:"config,omitempty"`
-	Default      bool              `yaml:"default,omitempty"`
-	Env          map[string]string `yaml:"env,omitempty"`
-	AllowedHosts []string          `yaml:"allowedHosts,omitempty"`
-	DisplayName  string            `yaml:"displayName,omitempty"`
-	Description  string            `yaml:"description,omitempty"`
-	IconFile     string            `yaml:"iconFile,omitempty"`
-	RouteAuth    *RouteAuthDef     `yaml:"-"`
+	Source          ProviderSource                 `yaml:"source"`
+	Config          yaml.Node                      `yaml:"config,omitempty"`
+	Default         bool                           `yaml:"default,omitempty"`
+	Env             map[string]string              `yaml:"env,omitempty"`
+	AllowedHosts    []string                       `yaml:"allowedHosts,omitempty"`
+	DisplayName     string                         `yaml:"displayName,omitempty"`
+	Description     string                         `yaml:"description,omitempty"`
+	IconFile        string                         `yaml:"iconFile,omitempty"`
+	RouteAuth       *RouteAuthDef                  `yaml:"-"`
+	SecuritySchemes map[string]*HTTPSecurityScheme `yaml:"securitySchemes,omitempty"`
+	HTTP            map[string]*HTTPBinding        `yaml:"http,omitempty"`
 	// AuthorizationPolicy binds this provider to a shared human access policy.
 	AuthorizationPolicy string `yaml:"authorizationPolicy,omitempty"`
 
@@ -392,6 +395,9 @@ type ProviderSurfaceOverrides struct {
 	GraphQL *ProviderGraphQLSurfaceOverride `yaml:"graphql,omitempty"`
 	MCP     *ProviderMCPSurfaceOverride     `yaml:"mcp,omitempty"`
 }
+
+type HTTPSecurityScheme = providermanifestv1.HTTPSecurityScheme
+type HTTPBinding = providermanifestv1.HTTPBinding
 
 type PluginIndexedDBConfig struct {
 	Provider     string   `yaml:"provider,omitempty"`
@@ -548,6 +554,232 @@ func providerEntryFieldsFromEntry(e ProviderEntry) providerEntryFields {
 	return providerEntryFields(e)
 }
 
+func cloneHTTPSecuritySchemes(src map[string]*HTTPSecurityScheme) map[string]*HTTPSecurityScheme {
+	if src == nil {
+		return nil
+	}
+	cloned := make(map[string]*HTTPSecurityScheme, len(src))
+	for name, scheme := range src {
+		if scheme == nil {
+			cloned[name] = nil
+			continue
+		}
+		copyScheme := *scheme
+		copyScheme.Secret = cloneHTTPSecretRef(scheme.Secret)
+		cloned[name] = &copyScheme
+	}
+	return cloned
+}
+
+func cloneHTTPSecretRef(src *providermanifestv1.HTTPSecretRef) *providermanifestv1.HTTPSecretRef {
+	if src == nil {
+		return nil
+	}
+	cloned := *src
+	return &cloned
+}
+
+func cloneHTTPBindings(src map[string]*HTTPBinding) map[string]*HTTPBinding {
+	if src == nil {
+		return nil
+	}
+	cloned := make(map[string]*HTTPBinding, len(src))
+	for name, binding := range src {
+		if binding == nil {
+			cloned[name] = nil
+			continue
+		}
+		copyBinding := *binding
+		copyBinding.RequestBody = cloneHTTPRequestBody(binding.RequestBody)
+		copyBinding.Ack = cloneHTTPAck(binding.Ack)
+		cloned[name] = &copyBinding
+	}
+	return cloned
+}
+
+func cloneHTTPRequestBody(src *providermanifestv1.HTTPRequestBody) *providermanifestv1.HTTPRequestBody {
+	if src == nil {
+		return nil
+	}
+	cloned := *src
+	if src.Content != nil {
+		cloned.Content = make(map[string]*providermanifestv1.HTTPMediaType, len(src.Content))
+		for mediaType, value := range src.Content {
+			if value == nil {
+				cloned.Content[mediaType] = nil
+				continue
+			}
+			copyMediaType := *value
+			cloned.Content[mediaType] = &copyMediaType
+		}
+	}
+	return &cloned
+}
+
+func cloneHTTPAck(src *providermanifestv1.HTTPAck) *providermanifestv1.HTTPAck {
+	if src == nil {
+		return nil
+	}
+	cloned := *src
+	if src.Headers != nil {
+		cloned.Headers = maps.Clone(src.Headers)
+	}
+	cloned.Body = cloneHTTPBodyValue(src.Body)
+	return &cloned
+}
+
+func cloneHTTPBodyValue(src any) any {
+	if src == nil {
+		return nil
+	}
+	return cloneHTTPBodyReflectValue(reflect.ValueOf(src)).Interface()
+}
+
+func cloneHTTPBodyReflectValue(value reflect.Value) reflect.Value {
+	if !value.IsValid() {
+		return reflect.Value{}
+	}
+	switch value.Kind() {
+	case reflect.Interface:
+		if value.IsNil() {
+			return reflect.Zero(value.Type())
+		}
+		return cloneHTTPBodyReflectValue(value.Elem())
+	case reflect.Pointer:
+		if value.IsNil() {
+			return reflect.Zero(value.Type())
+		}
+		cloned := reflect.New(value.Type().Elem())
+		cloned.Elem().Set(cloneHTTPBodyReflectValue(value.Elem()))
+		return cloned
+	case reflect.Map:
+		if value.IsNil() {
+			return reflect.Zero(value.Type())
+		}
+		cloned := reflect.MakeMapWithSize(value.Type(), value.Len())
+		iter := value.MapRange()
+		for iter.Next() {
+			cloned.SetMapIndex(cloneHTTPBodyReflectValue(iter.Key()), cloneHTTPBodyReflectValue(iter.Value()))
+		}
+		return cloned
+	case reflect.Slice:
+		if value.IsNil() {
+			return reflect.Zero(value.Type())
+		}
+		cloned := reflect.MakeSlice(value.Type(), value.Len(), value.Len())
+		for i := 0; i < value.Len(); i++ {
+			cloned.Index(i).Set(cloneHTTPBodyReflectValue(value.Index(i)))
+		}
+		return cloned
+	case reflect.Array:
+		cloned := reflect.New(value.Type()).Elem()
+		for i := 0; i < value.Len(); i++ {
+			cloned.Index(i).Set(cloneHTTPBodyReflectValue(value.Index(i)))
+		}
+		return cloned
+	default:
+		return value
+	}
+}
+
+func mergeHTTPSecurityScheme(base, override *HTTPSecurityScheme) *HTTPSecurityScheme {
+	if base == nil {
+		if override == nil {
+			return nil
+		}
+		cloned := cloneHTTPSecuritySchemes(map[string]*HTTPSecurityScheme{"_": override})
+		return cloned["_"]
+	}
+	if override == nil {
+		cloned := cloneHTTPSecuritySchemes(map[string]*HTTPSecurityScheme{"_": base})
+		return cloned["_"]
+	}
+	merged := *base
+	if override.Type != "" {
+		merged.Type = override.Type
+	}
+	if override.Description != "" {
+		merged.Description = override.Description
+	}
+	if override.Name != "" {
+		merged.Name = override.Name
+	}
+	if override.In != "" {
+		merged.In = override.In
+	}
+	if override.Scheme != "" {
+		merged.Scheme = override.Scheme
+	}
+	if override.Secret != nil {
+		merged.Secret = cloneHTTPSecretRef(override.Secret)
+	}
+	return &merged
+}
+
+func mergeHTTPBinding(base, override *HTTPBinding) *HTTPBinding {
+	if base == nil {
+		if override == nil {
+			return nil
+		}
+		cloned := cloneHTTPBindings(map[string]*HTTPBinding{"_": override})
+		return cloned["_"]
+	}
+	if override == nil {
+		cloned := cloneHTTPBindings(map[string]*HTTPBinding{"_": base})
+		return cloned["_"]
+	}
+	merged := *base
+	if override.Path != "" {
+		merged.Path = override.Path
+	}
+	if override.Method != "" {
+		merged.Method = override.Method
+	}
+	if override.Security != "" {
+		merged.Security = override.Security
+	}
+	if override.Target != "" {
+		merged.Target = override.Target
+	}
+	if override.RequestBody != nil {
+		if merged.RequestBody == nil {
+			merged.RequestBody = cloneHTTPRequestBody(override.RequestBody)
+		} else {
+			requestBody := *merged.RequestBody
+			if override.RequestBody.Required {
+				requestBody.Required = true
+			}
+			if override.RequestBody.Content != nil {
+				requestBody.Content = cloneHTTPRequestBody(override.RequestBody).Content
+			}
+			merged.RequestBody = &requestBody
+		}
+	}
+	if override.Ack != nil {
+		if merged.Ack == nil {
+			merged.Ack = cloneHTTPAck(override.Ack)
+		} else {
+			ack := cloneHTTPAck(merged.Ack)
+			if override.Ack.Status != 0 {
+				ack.Status = override.Ack.Status
+			}
+			if override.Ack.Headers != nil {
+				if ack.Headers == nil {
+					ack.Headers = map[string]string{}
+				}
+				for key, value := range override.Ack.Headers {
+					ack.Headers[key] = value
+				}
+			}
+			if override.Ack.Body != nil {
+				ack.Body = cloneHTTPBodyValue(override.Ack.Body)
+			}
+			merged.Ack = ack
+		}
+	}
+	return &merged
+}
+
 func (e *ProviderEntry) HasMetadataSource() bool {
 	return e != nil && (e.Source.IsMetadataURL() || e.Source.IsGitHubRelease())
 }
@@ -631,6 +863,48 @@ func (e *ProviderEntry) ManifestSpec() *providermanifestv1.Spec {
 		return nil
 	}
 	return e.ResolvedManifest.Spec
+}
+
+func (e *ProviderEntry) EffectiveHTTPSecuritySchemes() map[string]*HTTPSecurityScheme {
+	var merged map[string]*HTTPSecurityScheme
+	if spec := e.ManifestSpec(); spec != nil && spec.SecuritySchemes != nil {
+		merged = cloneHTTPSecuritySchemes(spec.SecuritySchemes)
+	}
+	if e == nil || e.SecuritySchemes == nil {
+		return merged
+	}
+	if merged == nil {
+		merged = map[string]*HTTPSecurityScheme{}
+	}
+	for name, scheme := range e.SecuritySchemes {
+		if scheme == nil {
+			merged[name] = nil
+			continue
+		}
+		merged[name] = mergeHTTPSecurityScheme(merged[name], scheme)
+	}
+	return merged
+}
+
+func (e *ProviderEntry) EffectiveHTTPBindings() map[string]*HTTPBinding {
+	var merged map[string]*HTTPBinding
+	if spec := e.ManifestSpec(); spec != nil && spec.HTTP != nil {
+		merged = cloneHTTPBindings(spec.HTTP)
+	}
+	if e == nil || e.HTTP == nil {
+		return merged
+	}
+	if merged == nil {
+		merged = map[string]*HTTPBinding{}
+	}
+	for name, binding := range e.HTTP {
+		if binding == nil {
+			merged[name] = nil
+			continue
+		}
+		merged[name] = mergeHTTPBinding(merged[name], binding)
+	}
+	return merged
 }
 
 func (e *ProviderEntry) DeclaresMCP() bool {

--- a/gestaltd/internal/config/config_test.go
+++ b/gestaltd/internal/config/config_test.go
@@ -121,6 +121,125 @@ plugins:
 	}
 }
 
+func TestLoadConfigParsesPluginHTTPSecuritySchemesAndBindings(t *testing.T) {
+	t.Parallel()
+
+	path := mustWriteConfigFile(t, `
+server:
+  encryptionKey: server-key
+plugins:
+  slack:
+    source:
+      path: /tmp/manifest.yaml
+    securitySchemes:
+      slack:
+        type: slack_signature
+        secret:
+          env: SLACK_SIGNING_SECRET
+    http:
+      command:
+        path: /command
+        method: POST
+        security: slack
+        requestBody:
+          required: true
+          content:
+            application/x-www-form-urlencoded: {}
+        target: handle_command
+        ack:
+          body:
+            response_type: ephemeral
+            text: Working on it...
+`)
+
+	cfg, err := Load(path)
+	if err != nil {
+		t.Fatalf("Load: %v", err)
+	}
+	entry := cfg.Plugins["slack"]
+	if entry == nil {
+		t.Fatal("Plugins[slack] = nil")
+	}
+	if entry.SecuritySchemes["slack"] == nil || entry.SecuritySchemes["slack"].Type != providermanifestv1.HTTPSecuritySchemeTypeSlackSignature {
+		t.Fatalf("SecuritySchemes[slack] = %#v", entry.SecuritySchemes["slack"])
+	}
+	if entry.HTTP["command"] == nil {
+		t.Fatal("HTTP[command] = nil")
+	}
+	if got, want := entry.HTTP["command"].Path, "/command"; got != want {
+		t.Fatalf("HTTP[command].Path = %q, want %q", got, want)
+	}
+	if got, want := entry.HTTP["command"].Target, "handle_command"; got != want {
+		t.Fatalf("HTTP[command].Target = %q, want %q", got, want)
+	}
+	if entry.HTTP["command"].Ack == nil || entry.HTTP["command"].Ack.Body == nil {
+		t.Fatalf("HTTP[command].Ack = %#v", entry.HTTP["command"].Ack)
+	}
+}
+
+func TestProviderEntryEffectiveHTTPBindings_ClonesAckBody(t *testing.T) {
+	t.Parallel()
+
+	entry := &ProviderEntry{
+		ResolvedManifest: &providermanifestv1.Manifest{
+			Spec: &providermanifestv1.Spec{
+				HTTP: map[string]*providermanifestv1.HTTPBinding{
+					"command": {
+						Path:     "/command",
+						Method:   "POST",
+						Security: "slack",
+						Target:   "handle_command",
+						Ack: &providermanifestv1.HTTPAck{
+							Headers: map[string]string{"Content-Type": "application/json"},
+							Body: map[string]any{
+								"text": "Working on it...",
+								"meta": map[string]any{
+									"tags": []any{"one", "two"},
+								},
+							},
+						},
+					},
+				},
+			},
+		},
+	}
+
+	effective := entry.EffectiveHTTPBindings()
+	body, ok := effective["command"].Ack.Body.(map[string]any)
+	if !ok {
+		t.Fatalf("effective ack body = %#v", effective["command"].Ack.Body)
+	}
+	body["text"] = "changed"
+	meta, ok := body["meta"].(map[string]any)
+	if !ok {
+		t.Fatalf("effective ack body meta = %#v", body["meta"])
+	}
+	tags, ok := meta["tags"].([]any)
+	if !ok {
+		t.Fatalf("effective ack body tags = %#v", meta["tags"])
+	}
+	tags[0] = "changed"
+
+	originalBody, ok := entry.ResolvedManifest.Spec.HTTP["command"].Ack.Body.(map[string]any)
+	if !ok {
+		t.Fatalf("original ack body = %#v", entry.ResolvedManifest.Spec.HTTP["command"].Ack.Body)
+	}
+	if got, want := originalBody["text"], "Working on it..."; got != want {
+		t.Fatalf("original ack body text = %#v, want %q", got, want)
+	}
+	originalMeta, ok := originalBody["meta"].(map[string]any)
+	if !ok {
+		t.Fatalf("original ack body meta = %#v", originalBody["meta"])
+	}
+	originalTags, ok := originalMeta["tags"].([]any)
+	if !ok {
+		t.Fatalf("original ack body tags = %#v", originalMeta["tags"])
+	}
+	if got, want := originalTags[0], "one"; got != want {
+		t.Fatalf("original ack body tags[0] = %#v, want %q", got, want)
+	}
+}
+
 func TestLoadConfigSelectsDefaultProvidersFromNamedMaps(t *testing.T) {
 	t.Parallel()
 

--- a/gestaltd/internal/providerpkg/manifest.go
+++ b/gestaltd/internal/providerpkg/manifest.go
@@ -4,6 +4,7 @@ import (
 	"bytes"
 	"encoding/json"
 	"fmt"
+	"mime"
 	"os"
 	"path"
 	"path/filepath"
@@ -413,12 +414,142 @@ func validateRouteAuthRef(path string, auth *providermanifestv1.RouteAuthRef) er
 	return nil
 }
 
+func normalizeHTTPBindingPath(field, value string) (string, error) {
+	value = strings.TrimSpace(value)
+	if value == "" {
+		return "", fmt.Errorf("%s is required", field)
+	}
+	if strings.Contains(value, "*") {
+		return "", fmt.Errorf("%s must not contain wildcards", field)
+	}
+	cleaned := path.Clean(strings.ReplaceAll(value, "\\", "/"))
+	if cleaned == "." {
+		cleaned = "/"
+	}
+	if !strings.HasPrefix(cleaned, "/") {
+		cleaned = "/" + cleaned
+	}
+	return cleaned, nil
+}
+
+func normalizeHTTPContentType(field, value string) (string, error) {
+	value = strings.TrimSpace(value)
+	if value == "" {
+		return "", fmt.Errorf("%s must not be empty", field)
+	}
+	mediaType, _, err := mime.ParseMediaType(value)
+	if err != nil {
+		return "", fmt.Errorf("%s must be a valid media type", field)
+	}
+	return strings.ToLower(mediaType), nil
+}
+
+func validateHTTPSecurityScheme(path string, scheme *providermanifestv1.HTTPSecurityScheme) error {
+	if scheme == nil {
+		return fmt.Errorf("%s is required", path)
+	}
+	switch scheme.Type {
+	case providermanifestv1.HTTPSecuritySchemeTypeSlackSignature:
+		if scheme.Secret == nil {
+			return fmt.Errorf("%s.secret is required", path)
+		}
+	case providermanifestv1.HTTPSecuritySchemeTypeAPIKey:
+		if strings.TrimSpace(scheme.Name) == "" {
+			return fmt.Errorf("%s.name is required", path)
+		}
+		switch scheme.In {
+		case providermanifestv1.HTTPInHeader, providermanifestv1.HTTPInQuery:
+		default:
+			return fmt.Errorf("%s.in %q is not supported", path, scheme.In)
+		}
+		if scheme.Secret == nil {
+			return fmt.Errorf("%s.secret is required", path)
+		}
+	case providermanifestv1.HTTPSecuritySchemeTypeHTTP:
+		switch scheme.Scheme {
+		case providermanifestv1.HTTPAuthSchemeBasic, providermanifestv1.HTTPAuthSchemeBearer:
+		default:
+			return fmt.Errorf("%s.scheme %q is not supported", path, scheme.Scheme)
+		}
+		if scheme.Secret == nil {
+			return fmt.Errorf("%s.secret is required", path)
+		}
+	case providermanifestv1.HTTPSecuritySchemeTypeNone:
+	default:
+		return fmt.Errorf("%s.type %q is not supported", path, scheme.Type)
+	}
+	if scheme.Secret != nil && strings.TrimSpace(scheme.Secret.Env) == "" && strings.TrimSpace(scheme.Secret.Secret) == "" {
+		return fmt.Errorf("%s.secret must set env or secret", path)
+	}
+	return nil
+}
+
+func validateHTTPBinding(path string, binding *providermanifestv1.HTTPBinding, schemes map[string]*providermanifestv1.HTTPSecurityScheme) error {
+	if binding == nil {
+		return fmt.Errorf("%s is required", path)
+	}
+	normalizedPath, err := normalizeHTTPBindingPath(path+".path", binding.Path)
+	if err != nil {
+		return err
+	}
+	binding.Path = normalizedPath
+	method := strings.ToUpper(strings.TrimSpace(binding.Method))
+	if !validHTTPMethods[method] {
+		return fmt.Errorf("%s.method %q is not a valid HTTP method", path, binding.Method)
+	}
+	binding.Method = method
+	if strings.TrimSpace(binding.Target) == "" {
+		return fmt.Errorf("%s.target is required", path)
+	}
+	binding.Target = strings.TrimSpace(binding.Target)
+	binding.Security = strings.TrimSpace(binding.Security)
+	if binding.Security == "" {
+		return fmt.Errorf("%s.security is required", path)
+	}
+	if schemes == nil || schemes[binding.Security] == nil {
+		return fmt.Errorf("%s.security %q references an undefined security scheme", path, binding.Security)
+	}
+	if binding.RequestBody != nil {
+		normalizedContent := make(map[string]*providermanifestv1.HTTPMediaType, len(binding.RequestBody.Content))
+		for mediaType := range binding.RequestBody.Content {
+			normalizedMediaType, err := normalizeHTTPContentType(path+".requestBody.content", mediaType)
+			if err != nil {
+				return err
+			}
+			if _, exists := normalizedContent[normalizedMediaType]; exists {
+				return fmt.Errorf("%s.requestBody.content %q is duplicated after normalization", path, normalizedMediaType)
+			}
+			normalizedContent[normalizedMediaType] = binding.RequestBody.Content[mediaType]
+		}
+		binding.RequestBody.Content = normalizedContent
+	}
+	if binding.Ack != nil {
+		if binding.Ack.Status == 0 {
+			binding.Ack.Status = 200
+		}
+		if binding.Ack.Status < 200 || binding.Ack.Status > 299 {
+			return fmt.Errorf("%s.ack.status must be a 2xx status", path)
+		}
+	}
+	return nil
+}
+
 func validateExecutableProviderMetadata(provider *providermanifestv1.Spec) error {
 	if provider == nil {
 		return nil
 	}
 	if err := validateRouteAuthRef("provider.auth", provider.RouteAuth); err != nil {
 		return err
+	}
+	for name, scheme := range provider.SecuritySchemes {
+		if err := validateHTTPSecurityScheme(fmt.Sprintf("provider.securitySchemes.%s", name), scheme); err != nil {
+			return err
+		}
+	}
+	for name, binding := range provider.HTTP {
+		if err := validateHTTPBinding(fmt.Sprintf("provider.http.%s", name), binding, provider.SecuritySchemes); err != nil {
+			return err
+		}
 	}
 	for name, conn := range provider.Connections {
 		if conn == nil {

--- a/gestaltd/internal/providerpkg/manifest_workflow_test.go
+++ b/gestaltd/internal/providerpkg/manifest_workflow_test.go
@@ -496,6 +496,130 @@ spec:
 	}
 }
 
+func TestManifestWorkflow_AcceptsHostedHTTPBindingsAndSecuritySchemes(t *testing.T) {
+	t.Parallel()
+
+	dir := t.TempDir()
+	manifestPath := mustWriteManifestData(t, dir, "manifest.yaml", []byte(`
+kind: plugin
+source: github.com/acme/plugins/slack
+version: 1.0.0
+spec:
+  securitySchemes:
+    slack:
+      type: slack_signature
+      secret:
+        env: SLACK_SIGNING_SECRET
+  http:
+    command:
+      path: /command
+      method: POST
+      security: slack
+      requestBody:
+        required: true
+        content:
+          application/x-www-form-urlencoded: {}
+      target: handle_command
+      ack:
+        body:
+          response_type: ephemeral
+          text: Working on it...
+`))
+
+	_, manifest, err := ReadSourceManifestFile(manifestPath)
+	if err != nil {
+		t.Fatalf("ReadSourceManifestFile: %v", err)
+	}
+	if manifest.Spec == nil {
+		t.Fatal("expected plugin metadata")
+	}
+	if manifest.Spec.SecuritySchemes["slack"] == nil || manifest.Spec.SecuritySchemes["slack"].Type != providermanifestv1.HTTPSecuritySchemeTypeSlackSignature {
+		t.Fatalf("unexpected security scheme: %#v", manifest.Spec.SecuritySchemes["slack"])
+	}
+	if manifest.Spec.HTTP["command"] == nil {
+		t.Fatal("expected http binding")
+	}
+	if got, want := manifest.Spec.HTTP["command"].Path, "/command"; got != want {
+		t.Fatalf("http path = %q, want %q", got, want)
+	}
+	if got, want := manifest.Spec.HTTP["command"].Target, "handle_command"; got != want {
+		t.Fatalf("http target = %q, want %q", got, want)
+	}
+
+	encoded, err := EncodeSourceManifestFormat(manifest, ManifestFormatYAML)
+	if err != nil {
+		t.Fatalf("EncodeSourceManifestFormat: %v", err)
+	}
+	rendered := string(encoded)
+	if !strings.Contains(rendered, "securitySchemes:") || !strings.Contains(rendered, "http:") {
+		t.Fatalf("expected hosted http metadata in canonical output:\n%s", rendered)
+	}
+}
+
+func TestManifestWorkflow_RejectsNon2xxHTTPAckStatus(t *testing.T) {
+	t.Parallel()
+
+	dir := t.TempDir()
+	manifestPath := mustWriteManifestData(t, dir, "manifest.yaml", []byte(`
+kind: plugin
+source: github.com/acme/plugins/bad-http-ack
+version: 1.0.0
+spec:
+  securitySchemes:
+    none:
+      type: none
+  http:
+    command:
+      path: /command
+      method: POST
+      security: none
+      target: handle_command
+      ack:
+        status: 500
+`))
+
+	_, _, err := ReadSourceManifestFile(manifestPath)
+	if err == nil {
+		t.Fatal("expected invalid manifest")
+	}
+	if !strings.Contains(err.Error(), `provider.http.command.ack.status must be a 2xx status`) {
+		t.Fatalf("error = %v", err)
+	}
+}
+
+func TestManifestWorkflow_RejectsDuplicateNormalizedHTTPContentTypes(t *testing.T) {
+	t.Parallel()
+
+	dir := t.TempDir()
+	manifestPath := mustWriteManifestData(t, dir, "manifest.yaml", []byte(`
+kind: plugin
+source: github.com/acme/plugins/bad-http-content
+version: 1.0.0
+spec:
+  securitySchemes:
+    none:
+      type: none
+  http:
+    command:
+      path: /command
+      method: POST
+      security: none
+      target: handle_command
+      requestBody:
+        content:
+          application/json: {}
+          application/json; charset=utf-8: {}
+`))
+
+	_, _, err := ReadSourceManifestFile(manifestPath)
+	if err == nil {
+		t.Fatal("expected invalid manifest")
+	}
+	if !strings.Contains(err.Error(), `provider.http.command.requestBody.content "application/json" is duplicated after normalization`) {
+		t.Fatalf("error = %v", err)
+	}
+}
+
 func TestManifestWorkflow_EncodesCanonicalProgrammaticDefaultConnection(t *testing.T) {
 	t.Parallel()
 

--- a/gestaltd/internal/server/http_binding_dispatch.go
+++ b/gestaltd/internal/server/http_binding_dispatch.go
@@ -1,0 +1,90 @@
+package server
+
+import (
+	"context"
+	"log/slog"
+	"strings"
+
+	"github.com/valon-technologies/gestalt/server/core"
+	"github.com/valon-technologies/gestalt/server/internal/invocation"
+	"github.com/valon-technologies/gestalt/server/internal/principal"
+)
+
+func (s *Server) httpBindingPrincipal(binding MountedHTTPBinding, verified *verifiedHTTPBindingSender) *principal.Principal {
+	permissions := principal.CompilePermissions([]core.AccessPermission{{
+		Plugin:     binding.PluginName,
+		Operations: []string{binding.Target},
+	}})
+	displayName := binding.PluginName + "/" + binding.Name
+	if verified != nil && strings.TrimSpace(verified.Subject) != "" {
+		displayName = strings.TrimSpace(verified.Subject)
+	}
+	return principal.Canonicalize(&principal.Principal{
+		SubjectID:        "system:http_binding:" + binding.PluginName + ":" + binding.Name,
+		DisplayName:      displayName,
+		Scopes:           principal.PermissionPlugins(permissions),
+		TokenPermissions: permissions,
+	})
+}
+
+func httpBindingContextValue(binding MountedHTTPBinding, verified *verifiedHTTPBindingSender, parsed *parsedHTTPBindingRequest) map[string]any {
+	value := map[string]any{
+		"name":   binding.Name,
+		"plugin": binding.PluginName,
+		"path":   binding.Path,
+		"method": binding.Method,
+		"target": binding.Target,
+	}
+	if parsed != nil && parsed.ContentType != "" {
+		value["contentType"] = parsed.ContentType
+	}
+	if verified != nil {
+		if verified.Scheme != "" {
+			value["security"] = verified.Scheme
+		}
+		if verified.Subject != "" {
+			value["subject"] = verified.Subject
+		}
+		if len(verified.Claims) > 0 {
+			claims := make(map[string]any, len(verified.Claims))
+			for key, item := range verified.Claims {
+				claims[key] = item
+			}
+			value["claims"] = claims
+		}
+	}
+	return map[string]any{"http": value}
+}
+
+func (s *Server) httpBindingOperationInvocation(ctx context.Context, binding MountedHTTPBinding, verified *verifiedHTTPBindingSender, parsed *parsedHTTPBindingRequest) (*core.OperationResult, error) {
+	params := map[string]any{}
+	if parsed != nil && parsed.Params != nil {
+		params = cloneAnyMap(parsed.Params)
+	}
+	p := s.httpBindingPrincipal(binding, verified)
+	ctx = principal.WithPrincipal(ctx, p)
+	ctx = invocation.WithAccessContext(ctx, s.providerAccessContextWithContext(ctx, p, binding.PluginName))
+	ctx = invocation.WithWorkflowContext(ctx, httpBindingContextValue(binding, verified, parsed))
+	ctx = invocation.WithInvocationSurface(ctx, invocation.InvocationSurfaceHTTP)
+	return s.invoker.Invoke(ctx, p, binding.PluginName, "", binding.Target, params)
+}
+
+func (s *Server) dispatchHTTPBindingAsync(binding MountedHTTPBinding, verified *verifiedHTTPBindingSender, parsed *parsedHTTPBindingRequest, requestMeta invocation.RequestMeta) {
+	go func() {
+		ctx := invocation.WithRequestMeta(context.Background(), requestMeta)
+		if _, err := s.httpBindingOperationInvocation(ctx, binding, verified, parsed); err != nil {
+			slog.Error("http binding async operation failed", "plugin", binding.PluginName, "binding", binding.Name, "operation", binding.Target, "error", err)
+		}
+	}()
+}
+
+func cloneAnyMap(src map[string]any) map[string]any {
+	if src == nil {
+		return nil
+	}
+	dst := make(map[string]any, len(src))
+	for key, value := range src {
+		dst[key] = value
+	}
+	return dst
+}

--- a/gestaltd/internal/server/http_binding_handler.go
+++ b/gestaltd/internal/server/http_binding_handler.go
@@ -1,0 +1,119 @@
+package server
+
+import (
+	"encoding/json"
+	"errors"
+	"io"
+	"log/slog"
+	"net/http"
+	"strings"
+
+	"github.com/valon-technologies/gestalt/server/internal/invocation"
+	providermanifestv1 "github.com/valon-technologies/gestalt/server/sdk/providermanifest/v1"
+)
+
+func (s *Server) handleHTTPBinding(binding MountedHTTPBinding, w http.ResponseWriter, r *http.Request) {
+	rawBody, err := readHTTPBindingBody(r)
+	if err != nil {
+		writeError(w, http.StatusBadRequest, err.Error())
+		return
+	}
+
+	verified, err := s.verifyHTTPBindingRequest(r, binding, rawBody)
+	if err != nil {
+		var requestErr *httpBindingRequestError
+		if errors.As(err, &requestErr) {
+			if requestErr.status > 0 && requestErr.status < 400 {
+				if binding.Ack != nil {
+					if err := writeHTTPBindingAck(w, binding.Ack); err != nil {
+						slog.ErrorContext(r.Context(), "write http binding ack", "plugin", binding.PluginName, "binding", binding.Name, "error", err)
+						writeError(w, http.StatusInternalServerError, "failed to write http binding response")
+					}
+				} else {
+					w.WriteHeader(requestErr.status)
+				}
+				return
+			}
+			if requestErr.status >= 500 {
+				slog.ErrorContext(r.Context(), "http binding verification failed", "plugin", binding.PluginName, "binding", binding.Name, "error", err)
+			} else {
+				slog.WarnContext(r.Context(), "http binding verification rejected request", "plugin", binding.PluginName, "binding", binding.Name, "error", err)
+			}
+			writeError(w, requestErr.status, requestErr.message)
+			return
+		}
+		slog.ErrorContext(r.Context(), "http binding verification failed", "plugin", binding.PluginName, "binding", binding.Name, "error", err)
+		writeError(w, http.StatusUnauthorized, "http binding verification failed")
+		return
+	}
+
+	parsed, err := parseHTTPBindingRequest(r, binding, rawBody)
+	if err != nil {
+		writeError(w, http.StatusBadRequest, err.Error())
+		return
+	}
+
+	if binding.Ack != nil {
+		if err := writeHTTPBindingAck(w, binding.Ack); err != nil {
+			slog.ErrorContext(r.Context(), "write http binding ack", "plugin", binding.PluginName, "binding", binding.Name, "error", err)
+			writeError(w, http.StatusInternalServerError, "failed to write http binding response")
+			return
+		}
+		s.dispatchHTTPBindingAsync(binding, verified, parsed, invocation.RequestMetaFromContext(r.Context()))
+		return
+	}
+
+	result, err := s.httpBindingOperationInvocation(r.Context(), binding, verified, parsed)
+	if err != nil {
+		s.writeInvocationError(w, r, binding.PluginName, binding.Target, err)
+		return
+	}
+	writeOperationResult(w, result)
+}
+
+func readHTTPBindingBody(r *http.Request) ([]byte, error) {
+	if r == nil || r.Body == nil {
+		return nil, nil
+	}
+	defer func() { _ = r.Body.Close() }()
+	body, err := io.ReadAll(r.Body)
+	if err != nil {
+		return nil, errors.New("failed to read request body")
+	}
+	return body, nil
+}
+
+func writeHTTPBindingAck(w http.ResponseWriter, ack *providermanifestv1.HTTPAck) error {
+	if ack == nil {
+		w.WriteHeader(http.StatusOK)
+		return nil
+	}
+	status := ack.Status
+	if status == 0 {
+		status = http.StatusOK
+	}
+	for key, value := range ack.Headers {
+		w.Header().Set(key, value)
+	}
+	if ack.Body == nil {
+		w.WriteHeader(status)
+		return nil
+	}
+	if contentType := strings.TrimSpace(w.Header().Get("Content-Type")); contentType != "" && !strings.Contains(strings.ToLower(contentType), "json") {
+		switch body := ack.Body.(type) {
+		case string:
+			w.WriteHeader(status)
+			_, err := w.Write([]byte(body))
+			return err
+		case []byte:
+			w.WriteHeader(status)
+			_, err := w.Write(body)
+			return err
+		default:
+			return errors.New("non-JSON ack bodies must be string or bytes")
+		}
+	}
+	w.Header().Set("Content-Type", "application/json")
+	w.WriteHeader(status)
+	return json.NewEncoder(w).Encode(ack.Body)
+}

--- a/gestaltd/internal/server/http_binding_parse.go
+++ b/gestaltd/internal/server/http_binding_parse.go
@@ -1,0 +1,144 @@
+package server
+
+import (
+	"encoding/json"
+	"fmt"
+	"mime"
+	"net/http"
+	"net/url"
+	"strings"
+
+	providermanifestv1 "github.com/valon-technologies/gestalt/server/sdk/providermanifest/v1"
+)
+
+type parsedHTTPBindingRequest struct {
+	ContentType string
+	Params      map[string]any
+	RawBody     []byte
+}
+
+func parseHTTPBindingRequest(r *http.Request, binding MountedHTTPBinding, rawBody []byte) (*parsedHTTPBindingRequest, error) {
+	params := httpBindingQueryParams(r, binding)
+	contentType, err := requestMediaType(r.Header.Get("Content-Type"))
+	if err != nil {
+		return nil, err
+	}
+	selectedContentType := contentType
+	if len(rawBody) == 0 {
+		if binding.RequestBody != nil && binding.RequestBody.Required {
+			return nil, fmt.Errorf("request body is required")
+		}
+		return &parsedHTTPBindingRequest{
+			ContentType: selectedContentType,
+			Params:      params,
+			RawBody:     rawBody,
+		}, nil
+	}
+
+	_, resolvedContentType, err := resolveHTTPBindingRequestContentType(binding.RequestBody, contentType)
+	if err != nil {
+		return nil, err
+	}
+	if resolvedContentType != "" {
+		selectedContentType = resolvedContentType
+	}
+
+	switch strings.ToLower(selectedContentType) {
+	case "application/json":
+		var decoded any
+		if err := json.Unmarshal(rawBody, &decoded); err != nil {
+			return nil, fmt.Errorf("invalid JSON body")
+		}
+		switch value := decoded.(type) {
+		case map[string]any:
+			for key, item := range value {
+				params[key] = item
+			}
+		default:
+			params["body"] = value
+		}
+	case "application/x-www-form-urlencoded":
+		values, err := url.ParseQuery(string(rawBody))
+		if err != nil {
+			return nil, fmt.Errorf("invalid form body")
+		}
+		for key, value := range firstValueMap(values) {
+			params[key] = value
+		}
+	default:
+		params["rawBody"] = string(rawBody)
+	}
+
+	return &parsedHTTPBindingRequest{
+		ContentType: selectedContentType,
+		Params:      params,
+		RawBody:     rawBody,
+	}, nil
+}
+
+func httpBindingQueryParams(r *http.Request, binding MountedHTTPBinding) map[string]any {
+	if r == nil {
+		return map[string]any{}
+	}
+	var excludeKey string
+	if binding.Security != nil &&
+		binding.Security.Type == providermanifestv1.HTTPSecuritySchemeTypeAPIKey &&
+		binding.Security.In == providermanifestv1.HTTPInQuery {
+		excludeKey = strings.TrimSpace(binding.Security.Name)
+	}
+	return firstValueMapExcept(r.URL.Query(), excludeKey)
+}
+
+func resolveHTTPBindingRequestContentType(requestBody *providermanifestv1.HTTPRequestBody, contentType string) (*providermanifestv1.HTTPMediaType, string, error) {
+	if requestBody == nil || len(requestBody.Content) == 0 {
+		return nil, contentType, nil
+	}
+	if contentType != "" {
+		if mediaType, ok := requestBody.Content[contentType]; ok {
+			return mediaType, contentType, nil
+		}
+		if wildcard, ok := requestBody.Content["*/*"]; ok {
+			return wildcard, contentType, nil
+		}
+		return nil, "", fmt.Errorf("unsupported content type %q", contentType)
+	}
+	if len(requestBody.Content) == 1 {
+		for resolved, mediaType := range requestBody.Content {
+			return mediaType, resolved, nil
+		}
+	}
+	return nil, "", fmt.Errorf("content type is required")
+}
+
+func requestMediaType(value string) (string, error) {
+	value = strings.TrimSpace(value)
+	if value == "" {
+		return "", nil
+	}
+	mediaType, _, err := mime.ParseMediaType(value)
+	if err != nil {
+		return "", fmt.Errorf("invalid Content-Type header")
+	}
+	return strings.ToLower(mediaType), nil
+}
+
+func firstValueMap(values url.Values) map[string]any {
+	return firstValueMapExcept(values, "")
+}
+
+func firstValueMapExcept(values url.Values, excludeKey string) map[string]any {
+	if len(values) == 0 {
+		return map[string]any{}
+	}
+	params := make(map[string]any, len(values))
+	for key, items := range values {
+		if excludeKey != "" && key == excludeKey {
+			continue
+		}
+		if len(items) == 0 {
+			continue
+		}
+		params[key] = items[0]
+	}
+	return params
+}

--- a/gestaltd/internal/server/http_binding_replay.go
+++ b/gestaltd/internal/server/http_binding_replay.go
@@ -1,0 +1,45 @@
+package server
+
+import (
+	"sync"
+	"time"
+)
+
+type httpBindingReplayStore interface {
+	MarkIfNew(key string, ttl time.Duration) bool
+}
+
+type memoryHTTPBindingReplayStore struct {
+	mu      sync.Mutex
+	entries map[string]time.Time
+}
+
+func newMemoryHTTPBindingReplayStore() httpBindingReplayStore {
+	return &memoryHTTPBindingReplayStore{entries: map[string]time.Time{}}
+}
+
+func (s *memoryHTTPBindingReplayStore) MarkIfNew(key string, ttl time.Duration) bool {
+	if s == nil || key == "" {
+		return true
+	}
+	if ttl <= 0 {
+		ttl = 24 * time.Hour
+	}
+
+	now := time.Now()
+	expiresAt := now.Add(ttl)
+
+	s.mu.Lock()
+	defer s.mu.Unlock()
+
+	for existingKey, deadline := range s.entries {
+		if !deadline.After(now) {
+			delete(s.entries, existingKey)
+		}
+	}
+	if deadline, ok := s.entries[key]; ok && deadline.After(now) {
+		return false
+	}
+	s.entries[key] = expiresAt
+	return true
+}

--- a/gestaltd/internal/server/http_binding_verify.go
+++ b/gestaltd/internal/server/http_binding_verify.go
@@ -1,0 +1,208 @@
+package server
+
+import (
+	"crypto/hmac"
+	"crypto/sha256"
+	"crypto/subtle"
+	"fmt"
+	"net/http"
+	"os"
+	"strconv"
+	"strings"
+	"time"
+
+	providermanifestv1 "github.com/valon-technologies/gestalt/server/sdk/providermanifest/v1"
+)
+
+type verifiedHTTPBindingSender struct {
+	Scheme  string
+	Subject string
+	Claims  map[string]string
+}
+
+type httpBindingRequestError struct {
+	status  int
+	message string
+	err     error
+}
+
+func (e *httpBindingRequestError) Error() string {
+	if e == nil {
+		return ""
+	}
+	if e.err != nil {
+		return e.err.Error()
+	}
+	return e.message
+}
+
+func (e *httpBindingRequestError) Unwrap() error {
+	if e == nil {
+		return nil
+	}
+	return e.err
+}
+
+func newHTTPBindingRequestError(status int, message string, err error) error {
+	return &httpBindingRequestError{status: status, message: message, err: err}
+}
+
+func (s *Server) verifyHTTPBindingRequest(r *http.Request, binding MountedHTTPBinding, rawBody []byte) (*verifiedHTTPBindingSender, error) {
+	if binding.Security == nil {
+		return nil, newHTTPBindingRequestError(http.StatusInternalServerError, "http binding security is not configured", nil)
+	}
+	switch binding.Security.Type {
+	case providermanifestv1.HTTPSecuritySchemeTypeSlackSignature:
+		return s.verifySlackSignatureRequest(r, binding, rawBody)
+	case providermanifestv1.HTTPSecuritySchemeTypeAPIKey:
+		return verifyHTTPBindingAPIKey(r, binding)
+	case providermanifestv1.HTTPSecuritySchemeTypeHTTP:
+		return verifyHTTPBindingHTTPAuth(r, binding)
+	case providermanifestv1.HTTPSecuritySchemeTypeNone:
+		return &verifiedHTTPBindingSender{
+			Scheme:  binding.SecurityName,
+			Subject: binding.PluginName + "/" + binding.Name + "#" + binding.SecurityName,
+			Claims: map[string]string{
+				"scheme": binding.SecurityName,
+			},
+		}, nil
+	default:
+		return nil, newHTTPBindingRequestError(http.StatusInternalServerError, "unsupported http binding security scheme", fmt.Errorf("unsupported scheme type %q", binding.Security.Type))
+	}
+}
+
+func (s *Server) verifySlackSignatureRequest(r *http.Request, binding MountedHTTPBinding, rawBody []byte) (*verifiedHTTPBindingSender, error) {
+	secret, err := resolveHTTPBindingSecret(binding.Security.Secret)
+	if err != nil {
+		return nil, newHTTPBindingRequestError(http.StatusInternalServerError, "http binding secret is not configured", err)
+	}
+	timestamp := strings.TrimSpace(r.Header.Get("X-Slack-Request-Timestamp"))
+	if timestamp == "" {
+		return nil, newHTTPBindingRequestError(http.StatusUnauthorized, "missing Slack request timestamp", nil)
+	}
+	requestTime, err := parseUnixTimestamp(timestamp)
+	if err != nil {
+		return nil, newHTTPBindingRequestError(http.StatusUnauthorized, "invalid Slack request timestamp", err)
+	}
+	now := time.Now()
+	if s != nil && s.now != nil {
+		now = s.now()
+	}
+	if delta := now.Sub(requestTime); delta > 5*time.Minute || delta < -5*time.Minute {
+		return nil, newHTTPBindingRequestError(http.StatusUnauthorized, "stale Slack request timestamp", nil)
+	}
+	signature := strings.TrimSpace(r.Header.Get("X-Slack-Signature"))
+	if signature == "" {
+		return nil, newHTTPBindingRequestError(http.StatusUnauthorized, "missing Slack signature", nil)
+	}
+	mac := hmac.New(sha256.New, []byte(secret))
+	_, _ = mac.Write([]byte("v0:" + timestamp + ":" + string(rawBody)))
+	expected := "v0=" + fmt.Sprintf("%x", mac.Sum(nil))
+	if subtle.ConstantTimeCompare([]byte(expected), []byte(signature)) != 1 {
+		return nil, newHTTPBindingRequestError(http.StatusUnauthorized, "invalid Slack signature", nil)
+	}
+	if binding.Ack != nil {
+		replayKey := binding.PluginName + "\x00" + binding.Name + "\x00" + binding.SecurityName + "\x00sig:" + signature
+		if !s.httpBindingReplayStore.MarkIfNew(replayKey, 5*time.Minute) {
+			return nil, newHTTPBindingRequestError(http.StatusOK, "duplicate Slack delivery", nil)
+		}
+	}
+	return &verifiedHTTPBindingSender{
+		Scheme:  binding.SecurityName,
+		Subject: binding.PluginName + "/" + binding.Name + "#" + binding.SecurityName,
+		Claims: map[string]string{
+			"scheme": binding.SecurityName,
+		},
+	}, nil
+}
+
+func verifyHTTPBindingAPIKey(r *http.Request, binding MountedHTTPBinding) (*verifiedHTTPBindingSender, error) {
+	secret, err := resolveHTTPBindingSecret(binding.Security.Secret)
+	if err != nil {
+		return nil, newHTTPBindingRequestError(http.StatusInternalServerError, "http binding secret is not configured", err)
+	}
+	var actual string
+	switch binding.Security.In {
+	case providermanifestv1.HTTPInHeader:
+		actual = strings.TrimSpace(r.Header.Get(strings.TrimSpace(binding.Security.Name)))
+	case providermanifestv1.HTTPInQuery:
+		actual = strings.TrimSpace(r.URL.Query().Get(strings.TrimSpace(binding.Security.Name)))
+	default:
+		return nil, newHTTPBindingRequestError(http.StatusInternalServerError, "unsupported apiKey location", fmt.Errorf("unsupported apiKey location %q", binding.Security.In))
+	}
+	if actual == "" {
+		return nil, newHTTPBindingRequestError(http.StatusUnauthorized, "missing http binding credential", nil)
+	}
+	if subtle.ConstantTimeCompare([]byte(secret), []byte(actual)) != 1 {
+		return nil, newHTTPBindingRequestError(http.StatusUnauthorized, "invalid http binding credential", nil)
+	}
+	return &verifiedHTTPBindingSender{
+		Scheme:  binding.SecurityName,
+		Subject: binding.PluginName + "/" + binding.Name + "#" + binding.SecurityName,
+		Claims: map[string]string{
+			"scheme": binding.SecurityName,
+		},
+	}, nil
+}
+
+func verifyHTTPBindingHTTPAuth(r *http.Request, binding MountedHTTPBinding) (*verifiedHTTPBindingSender, error) {
+	secret, err := resolveHTTPBindingSecret(binding.Security.Secret)
+	if err != nil {
+		return nil, newHTTPBindingRequestError(http.StatusInternalServerError, "http binding secret is not configured", err)
+	}
+	switch binding.Security.Scheme {
+	case providermanifestv1.HTTPAuthSchemeBearer:
+		token, err := requestBearerToken(r)
+		if err != nil {
+			return nil, newHTTPBindingRequestError(http.StatusUnauthorized, "invalid authorization header format", err)
+		}
+		if token == "" {
+			return nil, newHTTPBindingRequestError(http.StatusUnauthorized, "missing bearer token", nil)
+		}
+		if subtle.ConstantTimeCompare([]byte(secret), []byte(token)) != 1 {
+			return nil, newHTTPBindingRequestError(http.StatusUnauthorized, "invalid bearer token", nil)
+		}
+	case providermanifestv1.HTTPAuthSchemeBasic:
+		username, password, ok := r.BasicAuth()
+		if !ok {
+			return nil, newHTTPBindingRequestError(http.StatusUnauthorized, "missing basic authorization", nil)
+		}
+		if subtle.ConstantTimeCompare([]byte(secret), []byte(username+":"+password)) != 1 {
+			return nil, newHTTPBindingRequestError(http.StatusUnauthorized, "invalid basic authorization", nil)
+		}
+	default:
+		return nil, newHTTPBindingRequestError(http.StatusInternalServerError, "unsupported http auth scheme", fmt.Errorf("unsupported http auth scheme %q", binding.Security.Scheme))
+	}
+	return &verifiedHTTPBindingSender{
+		Scheme:  binding.SecurityName,
+		Subject: binding.PluginName + "/" + binding.Name + "#" + binding.SecurityName,
+		Claims: map[string]string{
+			"scheme": binding.SecurityName,
+		},
+	}, nil
+}
+
+func resolveHTTPBindingSecret(ref *providermanifestv1.HTTPSecretRef) (string, error) {
+	if ref == nil {
+		return "", fmt.Errorf("secret reference is required")
+	}
+	if env := strings.TrimSpace(ref.Env); env != "" {
+		value, ok := os.LookupEnv(env)
+		if !ok || strings.TrimSpace(value) == "" {
+			return "", fmt.Errorf("environment variable %q is not set", env)
+		}
+		return value, nil
+	}
+	if secret := strings.TrimSpace(ref.Secret); secret != "" {
+		return secret, nil
+	}
+	return "", fmt.Errorf("secret reference is empty")
+}
+
+func parseUnixTimestamp(raw string) (time.Time, error) {
+	seconds, err := strconv.ParseInt(strings.TrimSpace(raw), 10, 64)
+	if err != nil {
+		return time.Time{}, err
+	}
+	return time.Unix(seconds, 0).UTC(), nil
+}

--- a/gestaltd/internal/server/http_bindings.go
+++ b/gestaltd/internal/server/http_bindings.go
@@ -1,0 +1,310 @@
+package server
+
+import (
+	"fmt"
+	"net/http"
+	stdpath "path"
+	"slices"
+	"strings"
+
+	"github.com/go-chi/chi/v5"
+	"github.com/valon-technologies/gestalt/server/core"
+	"github.com/valon-technologies/gestalt/server/core/catalog"
+	"github.com/valon-technologies/gestalt/server/internal/config"
+	"github.com/valon-technologies/gestalt/server/internal/registry"
+	providermanifestv1 "github.com/valon-technologies/gestalt/server/sdk/providermanifest/v1"
+)
+
+var validMountedHTTPBindingMethods = map[string]bool{
+	http.MethodGet:    true,
+	http.MethodPost:   true,
+	http.MethodPut:    true,
+	http.MethodPatch:  true,
+	http.MethodDelete: true,
+}
+
+func mountedHTTPBindingsFromEntries(entries map[string]*config.ProviderEntry, providers *registry.ProviderMap[core.Provider], mountedWebUIs []MountedWebUI) ([]MountedHTTPBinding, error) {
+	if len(entries) == 0 {
+		return nil, nil
+	}
+
+	names := make([]string, 0, len(entries))
+	for name := range entries {
+		names = append(names, name)
+	}
+	slices.Sort(names)
+
+	mounted := make([]MountedHTTPBinding, 0)
+	for _, pluginName := range names {
+		entry := entries[pluginName]
+		if entry == nil {
+			continue
+		}
+		schemes := entry.EffectiveHTTPSecuritySchemes()
+		bindings := entry.EffectiveHTTPBindings()
+		if len(bindings) == 0 {
+			continue
+		}
+		for schemeName, scheme := range schemes {
+			if err := validateMountedHTTPSecurityScheme(pluginName, schemeName, scheme); err != nil {
+				return nil, err
+			}
+		}
+
+		operationIDs, err := providerOperationIDs(providers, pluginName)
+		if err != nil {
+			return nil, fmt.Errorf("resolve http bindings for %s: %w", pluginName, err)
+		}
+
+		bindingNames := make([]string, 0, len(bindings))
+		for name := range bindings {
+			bindingNames = append(bindingNames, name)
+		}
+		slices.Sort(bindingNames)
+
+		for _, bindingName := range bindingNames {
+			binding := bindings[bindingName]
+			if binding == nil {
+				return nil, fmt.Errorf("http binding %s.%s is required", pluginName, bindingName)
+			}
+			if err := validateMountedHTTPBinding(pluginName, bindingName, binding, schemes); err != nil {
+				return nil, err
+			}
+			relativePath, err := normalizeHTTPBindingMountedPath(binding.Path)
+			if err != nil {
+				return nil, fmt.Errorf("http binding %s.%s: %w", pluginName, bindingName, err)
+			}
+			method := strings.ToUpper(strings.TrimSpace(binding.Method))
+			target := strings.TrimSpace(binding.Target)
+			if len(operationIDs) > 0 {
+				if _, ok := operationIDs[target]; !ok {
+					return nil, fmt.Errorf("http binding %s.%s target %q is not in provider catalog", pluginName, bindingName, target)
+				}
+				if relativePathConflictsWithGenericOperation(relativePath, operationIDs) {
+					return nil, fmt.Errorf("http binding %s.%s path %q conflicts with the generic operation route", pluginName, bindingName, binding.Path)
+				}
+			}
+			securityName := strings.TrimSpace(binding.Security)
+			scheme := schemes[securityName]
+			if scheme == nil {
+				return nil, fmt.Errorf("http binding %s.%s references undefined security scheme %q", pluginName, bindingName, securityName)
+			}
+			mounted = append(mounted, MountedHTTPBinding{
+				Name:         bindingName,
+				PluginName:   pluginName,
+				Path:         mountedHTTPBindingPath(pluginName, relativePath),
+				Method:       method,
+				Target:       target,
+				RequestBody:  binding.RequestBody,
+				Ack:          binding.Ack,
+				SecurityName: securityName,
+				Security:     scheme,
+			})
+		}
+	}
+	if err := validateMountedHTTPBindingRoutes(mounted, mountedWebUIs); err != nil {
+		return nil, err
+	}
+	return mounted, nil
+}
+
+func normalizeHTTPBindingMountedPath(pathValue string) (string, error) {
+	pathValue = strings.TrimSpace(pathValue)
+	if pathValue == "" {
+		return "", fmt.Errorf("path is required")
+	}
+	if strings.Contains(pathValue, "*") {
+		return "", fmt.Errorf("path must not contain wildcards")
+	}
+	cleaned := stdpathClean(pathValue)
+	if cleaned == "" {
+		return "", fmt.Errorf("path is required")
+	}
+	if !strings.HasPrefix(cleaned, "/") {
+		cleaned = "/" + cleaned
+	}
+	return cleaned, nil
+}
+
+func mountedHTTPBindingPath(pluginName, relativePath string) string {
+	base := "/api/v1/" + strings.TrimSpace(pluginName)
+	if relativePath == "" || relativePath == "/" {
+		return base
+	}
+	return base + relativePath
+}
+
+func relativePathConflictsWithGenericOperation(relativePath string, operationIDs map[string]struct{}) bool {
+	trimmed := strings.Trim(strings.TrimSpace(relativePath), "/")
+	if trimmed == "" || strings.Contains(trimmed, "/") {
+		return false
+	}
+	_, ok := operationIDs[trimmed]
+	return ok
+}
+
+func providerOperationIDs(providers *registry.ProviderMap[core.Provider], pluginName string) (map[string]struct{}, error) {
+	if providers == nil {
+		return nil, nil
+	}
+	provider, err := providers.Get(pluginName)
+	if err != nil {
+		return nil, err
+	}
+	if provider == nil {
+		return nil, nil
+	}
+	cat := provider.Catalog()
+	if cat == nil {
+		return nil, nil
+	}
+	ids := make(map[string]struct{}, len(cat.Operations))
+	for i := range cat.Operations {
+		op := &cat.Operations[i]
+		if op.Transport == catalog.TransportMCPPassthrough {
+			continue
+		}
+		ids[strings.TrimSpace(op.ID)] = struct{}{}
+	}
+	return ids, nil
+}
+
+func validateMountedHTTPSecurityScheme(pluginName, schemeName string, scheme *config.HTTPSecurityScheme) error {
+	path := fmt.Sprintf("http security scheme %s.%s", pluginName, schemeName)
+	if scheme == nil {
+		return fmt.Errorf("%s is required", path)
+	}
+	switch scheme.Type {
+	case providermanifestv1.HTTPSecuritySchemeTypeSlackSignature:
+		if scheme.Secret == nil {
+			return fmt.Errorf("%s.secret is required", path)
+		}
+	case providermanifestv1.HTTPSecuritySchemeTypeAPIKey:
+		if strings.TrimSpace(scheme.Name) == "" {
+			return fmt.Errorf("%s.name is required", path)
+		}
+		switch scheme.In {
+		case providermanifestv1.HTTPInHeader, providermanifestv1.HTTPInQuery:
+		default:
+			return fmt.Errorf("%s.in %q is not supported", path, scheme.In)
+		}
+		if scheme.Secret == nil {
+			return fmt.Errorf("%s.secret is required", path)
+		}
+	case providermanifestv1.HTTPSecuritySchemeTypeHTTP:
+		switch scheme.Scheme {
+		case providermanifestv1.HTTPAuthSchemeBasic, providermanifestv1.HTTPAuthSchemeBearer:
+		default:
+			return fmt.Errorf("%s.scheme %q is not supported", path, scheme.Scheme)
+		}
+		if scheme.Secret == nil {
+			return fmt.Errorf("%s.secret is required", path)
+		}
+	case providermanifestv1.HTTPSecuritySchemeTypeNone:
+	default:
+		return fmt.Errorf("%s.type %q is not supported", path, scheme.Type)
+	}
+	if scheme.Secret != nil && strings.TrimSpace(scheme.Secret.Env) == "" && strings.TrimSpace(scheme.Secret.Secret) == "" {
+		return fmt.Errorf("%s.secret must set env or secret", path)
+	}
+	return nil
+}
+
+func validateMountedHTTPBinding(pluginName, bindingName string, binding *config.HTTPBinding, schemes map[string]*config.HTTPSecurityScheme) error {
+	path := fmt.Sprintf("http binding %s.%s", pluginName, bindingName)
+	binding.Path = strings.TrimSpace(binding.Path)
+	if binding.Path == "" {
+		return fmt.Errorf("%s.path is required", path)
+	}
+	method := strings.ToUpper(strings.TrimSpace(binding.Method))
+	if !validMountedHTTPBindingMethods[method] {
+		return fmt.Errorf("%s.method %q is not a valid HTTP method", path, binding.Method)
+	}
+	binding.Method = method
+	binding.Target = strings.TrimSpace(binding.Target)
+	if binding.Target == "" {
+		return fmt.Errorf("%s.target is required", path)
+	}
+	binding.Security = strings.TrimSpace(binding.Security)
+	if binding.Security == "" {
+		return fmt.Errorf("%s.security is required", path)
+	}
+	if schemes == nil || schemes[binding.Security] == nil {
+		return fmt.Errorf("%s.security %q references an undefined security scheme", path, binding.Security)
+	}
+	if binding.RequestBody != nil {
+		normalizedContent := make(map[string]*providermanifestv1.HTTPMediaType, len(binding.RequestBody.Content))
+		for mediaType := range binding.RequestBody.Content {
+			normalizedMediaType, err := requestMediaType(mediaType)
+			if err != nil || normalizedMediaType == "" {
+				return fmt.Errorf("%s.requestBody.content %q must be a valid media type", path, mediaType)
+			}
+			if _, exists := normalizedContent[normalizedMediaType]; exists {
+				return fmt.Errorf("%s.requestBody.content %q is duplicated after normalization", path, normalizedMediaType)
+			}
+			normalizedContent[normalizedMediaType] = binding.RequestBody.Content[mediaType]
+		}
+		binding.RequestBody.Content = normalizedContent
+	}
+	if binding.Ack != nil {
+		if binding.Ack.Status == 0 {
+			binding.Ack.Status = http.StatusOK
+		}
+		if binding.Ack.Status < 200 || binding.Ack.Status > 299 {
+			return fmt.Errorf("%s.ack.status must be a 2xx status", path)
+		}
+	}
+	return nil
+}
+
+func validateMountedHTTPBindingRoutes(bindings []MountedHTTPBinding, mountedWebUIs []MountedWebUI) error {
+	seen := make(map[string]string, len(bindings))
+	for _, binding := range bindings {
+		if binding.Path == "" {
+			return fmt.Errorf("http binding %s.%s path is required", binding.PluginName, binding.Name)
+		}
+		for _, prefix := range []string{"/api/v1/auth", "/api/v1/tokens", "/api/v1/identities", "/api/v1/workflow", "/api/v1/integrations"} {
+			if binding.Path == prefix || strings.HasPrefix(binding.Path, prefix+"/") {
+				return fmt.Errorf("http binding %s.%s path %q conflicts with core route namespace %q", binding.PluginName, binding.Name, binding.Path, prefix)
+			}
+		}
+		for _, mounted := range mountedWebUIs {
+			if mounted.Path == "" || mounted.Path == "/" {
+				continue
+			}
+			if binding.Path == mounted.Path || strings.HasPrefix(binding.Path, mounted.Path+"/") {
+				return fmt.Errorf("http binding %s.%s path %q conflicts with mounted UI %q", binding.PluginName, binding.Name, binding.Path, mounted.Path)
+			}
+		}
+		key := binding.Method + " " + binding.Path
+		if previous, ok := seen[key]; ok {
+			return fmt.Errorf("http binding %s.%s duplicates http route %s", binding.PluginName, binding.Name, previous)
+		}
+		seen[key] = binding.PluginName + "." + binding.Name
+	}
+	return nil
+}
+
+func (s *Server) mountHTTPBindingRoutes(r chi.Router) {
+	for _, binding := range s.mountedHTTPBindings {
+		binding := binding
+		r.MethodFunc(binding.Method, binding.Path, func(w http.ResponseWriter, r *http.Request) {
+			s.handleHTTPBinding(binding, w, r)
+		})
+	}
+}
+
+func stdpathClean(pathValue string) string {
+	cleaned := strings.ReplaceAll(strings.TrimSpace(pathValue), "\\", "/")
+	if cleaned == "" {
+		return ""
+	}
+	cleaned = stdpath.Clean(cleaned)
+	if cleaned == "." {
+		return "/"
+	}
+	if !strings.HasPrefix(cleaned, "/") {
+		cleaned = "/" + cleaned
+	}
+	return cleaned
+}

--- a/gestaltd/internal/server/routes.go
+++ b/gestaltd/internal/server/routes.go
@@ -18,6 +18,7 @@ func (s *Server) routes() {
 	case RouteProfilePublic:
 		s.mountCoreRoutes(r, metricsHidden)
 		s.mountMCPRoutes(r)
+		s.mountHTTPBindingRoutes(r)
 		s.mountAPIRoutes(r)
 		s.mountMountedWebUIRoutes(r)
 		s.mountManagementHiddenRoutes(r)
@@ -29,6 +30,7 @@ func (s *Server) routes() {
 	default:
 		s.mountCoreRoutes(r, metricsAuthenticated)
 		s.mountMCPRoutes(r)
+		s.mountHTTPBindingRoutes(r)
 		s.mountAPIRoutes(r)
 		s.mountMountedWebUIRoutes(r)
 		s.mountAdminAPIRoutes(r)

--- a/gestaltd/internal/server/server.go
+++ b/gestaltd/internal/server/server.go
@@ -50,6 +50,18 @@ type MountedWebUI struct {
 	builtInAdmin        bool
 }
 
+type MountedHTTPBinding struct {
+	Name         string
+	PluginName   string
+	Path         string
+	Method       string
+	Target       string
+	RequestBody  *providermanifestv1.HTTPRequestBody
+	Ack          *providermanifestv1.HTTPAck
+	SecurityName string
+	Security     *providermanifestv1.HTTPSecurityScheme
+}
+
 type AdminRouteConfig struct {
 	AuthorizationPolicy string
 	AllowedRoles        []string
@@ -61,51 +73,53 @@ type BuiltinAdminUIOptions struct {
 }
 
 type Server struct {
-	router                chi.Router
-	handler               http.Handler
-	auth                  core.AuthenticationProvider
-	authProviders         map[string]core.AuthenticationProvider
-	serverAuthProvider    string
-	auditSink             core.AuditSink
-	users                 *coredata.UserService
-	tokens                *coredata.TokenService
-	apiTokens             *coredata.APITokenService
-	managedIdentities     *coredata.ManagedIdentityService
-	identityMemberships   *coredata.ManagedIdentityMembershipService
-	identityGrants        *coredata.ManagedIdentityGrantService
-	workspaceRoles        *coredata.WorkspaceRoleService
-	identityPluginAccess  *coredata.IdentityPluginAccessService
-	workflowExecutionRefs *coredata.WorkflowExecutionRefService
-	workflowSchedules     *workflowmanager.Manager
-	authorizationProvider core.AuthorizationProvider
-	managedIdentityMu     sync.Mutex
-	providers             *registry.ProviderMap[core.Provider]
-	workflow              bootstrap.WorkflowControl
-	resolver              *principal.Resolver
-	authResolvers         map[string]*principal.Resolver
-	invoker               invocation.Invoker
-	defaultConnection     map[string]string
-	catalogConnection     map[string]string
-	connectionAuth        func() map[string]map[string]bootstrap.OAuthHandler
-	pluginDefs            map[string]*config.ProviderEntry
-	authorizer            authorization.RuntimeAuthorizer
-	noAuth                bool
-	anonymousPrincipal    *principal.Principal
-	publicBaseURL         string
-	managementBaseURL     string
-	secureCookies         bool
-	encryptor             *cryptoutil.AESGCMEncryptor
-	sessionIssuer         []byte
-	stateCodec            *integrationOAuthStateCodec
-	apiTokenTTL           time.Duration
-	now                   func() time.Time
-	readiness             ReadinessChecker
-	prometheusMetrics     http.Handler
-	mcpHandler            http.Handler
-	mountedWebUIs         []MountedWebUI
-	adminRoute            AdminRouteConfig
-	adminUI               http.Handler
-	routeProfile          RouteProfile
+	router                 chi.Router
+	handler                http.Handler
+	auth                   core.AuthenticationProvider
+	authProviders          map[string]core.AuthenticationProvider
+	serverAuthProvider     string
+	auditSink              core.AuditSink
+	users                  *coredata.UserService
+	tokens                 *coredata.TokenService
+	apiTokens              *coredata.APITokenService
+	managedIdentities      *coredata.ManagedIdentityService
+	identityMemberships    *coredata.ManagedIdentityMembershipService
+	identityGrants         *coredata.ManagedIdentityGrantService
+	workspaceRoles         *coredata.WorkspaceRoleService
+	identityPluginAccess   *coredata.IdentityPluginAccessService
+	workflowExecutionRefs  *coredata.WorkflowExecutionRefService
+	workflowSchedules      *workflowmanager.Manager
+	authorizationProvider  core.AuthorizationProvider
+	managedIdentityMu      sync.Mutex
+	providers              *registry.ProviderMap[core.Provider]
+	workflow               bootstrap.WorkflowControl
+	resolver               *principal.Resolver
+	authResolvers          map[string]*principal.Resolver
+	invoker                invocation.Invoker
+	defaultConnection      map[string]string
+	catalogConnection      map[string]string
+	connectionAuth         func() map[string]map[string]bootstrap.OAuthHandler
+	pluginDefs             map[string]*config.ProviderEntry
+	authorizer             authorization.RuntimeAuthorizer
+	noAuth                 bool
+	anonymousPrincipal     *principal.Principal
+	publicBaseURL          string
+	managementBaseURL      string
+	secureCookies          bool
+	encryptor              *cryptoutil.AESGCMEncryptor
+	sessionIssuer          []byte
+	stateCodec             *integrationOAuthStateCodec
+	apiTokenTTL            time.Duration
+	now                    func() time.Time
+	readiness              ReadinessChecker
+	prometheusMetrics      http.Handler
+	mcpHandler             http.Handler
+	mountedHTTPBindings    []MountedHTTPBinding
+	mountedWebUIs          []MountedWebUI
+	adminRoute             AdminRouteConfig
+	adminUI                http.Handler
+	routeProfile           RouteProfile
+	httpBindingReplayStore httpBindingReplayStore
 }
 
 func (s *Server) catalogSelectorConfig() invocation.CatalogSelectorConfig {
@@ -201,6 +215,10 @@ func New(cfg Config) (*Server, error) {
 	if err != nil {
 		return nil, err
 	}
+	mountedHTTPBindings, err := mountedHTTPBindingsFromEntries(cfg.PluginDefs, cfg.Providers, mountedWebUIs)
+	if err != nil {
+		return nil, err
+	}
 	adminUI := cfg.AdminUI
 	if adminUI == nil && cfg.BuiltinAdminUI != nil {
 		adminUI, err = resolveBuiltinAdminUI(*cfg.BuiltinAdminUI)
@@ -242,48 +260,50 @@ func New(cfg Config) (*Server, error) {
 		otelOptions = append(otelOptions, otelhttp.WithMeterProvider(cfg.MeterProvider))
 	}
 	s := &Server{
-		router:                router,
-		handler:               withRequestMeterProvider(otelhttp.NewHandler(router, "gestaltd", otelOptions...), cfg.MeterProvider),
-		auth:                  cfg.Auth,
-		authProviders:         authProviders,
-		serverAuthProvider:    serverAuthProvider,
-		auditSink:             cfg.AuditSink,
-		users:                 users,
-		tokens:                tokens,
-		apiTokens:             apiTokens,
-		managedIdentities:     managedIdentities,
-		identityMemberships:   identityMemberships,
-		identityGrants:        identityGrants,
-		workspaceRoles:        workspaceRoles,
-		identityPluginAccess:  identityPluginAccess,
-		workflowExecutionRefs: workflowExecutionRefs,
-		authorizationProvider: cfg.AuthorizationProvider,
-		providers:             cfg.Providers,
-		workflow:              cfg.Workflow,
-		resolver:              resolver,
-		authResolvers:         authResolvers,
-		invoker:               cfg.Invoker,
-		defaultConnection:     cfg.DefaultConnection,
-		catalogConnection:     cfg.CatalogConnection,
-		connectionAuth:        cfg.ConnectionAuth,
-		pluginDefs:            cfg.PluginDefs,
-		authorizer:            cfg.Authorizer,
-		noAuth:                noAuth,
-		publicBaseURL:         strings.TrimRight(cfg.PublicBaseURL, "/"),
-		managementBaseURL:     strings.TrimRight(cfg.ManagementBaseURL, "/"),
-		secureCookies:         cfg.SecureCookies,
-		encryptor:             encryptor,
-		sessionIssuer:         cfg.StateSecret,
-		stateCodec:            stateCodec,
-		apiTokenTTL:           cfg.APITokenTTL,
-		now:                   now,
-		readiness:             cfg.Readiness,
-		prometheusMetrics:     cfg.PrometheusMetrics,
-		mcpHandler:            cfg.MCPHandler,
-		mountedWebUIs:         mountedWebUIs,
-		adminRoute:            adminRoute,
-		adminUI:               adminUI,
-		routeProfile:          cfg.RouteProfile,
+		router:                 router,
+		handler:                withRequestMeterProvider(otelhttp.NewHandler(router, "gestaltd", otelOptions...), cfg.MeterProvider),
+		auth:                   cfg.Auth,
+		authProviders:          authProviders,
+		serverAuthProvider:     serverAuthProvider,
+		auditSink:              cfg.AuditSink,
+		users:                  users,
+		tokens:                 tokens,
+		apiTokens:              apiTokens,
+		managedIdentities:      managedIdentities,
+		identityMemberships:    identityMemberships,
+		identityGrants:         identityGrants,
+		workspaceRoles:         workspaceRoles,
+		identityPluginAccess:   identityPluginAccess,
+		workflowExecutionRefs:  workflowExecutionRefs,
+		authorizationProvider:  cfg.AuthorizationProvider,
+		providers:              cfg.Providers,
+		workflow:               cfg.Workflow,
+		resolver:               resolver,
+		authResolvers:          authResolvers,
+		invoker:                cfg.Invoker,
+		defaultConnection:      cfg.DefaultConnection,
+		catalogConnection:      cfg.CatalogConnection,
+		connectionAuth:         cfg.ConnectionAuth,
+		pluginDefs:             cfg.PluginDefs,
+		authorizer:             cfg.Authorizer,
+		noAuth:                 noAuth,
+		publicBaseURL:          strings.TrimRight(cfg.PublicBaseURL, "/"),
+		managementBaseURL:      strings.TrimRight(cfg.ManagementBaseURL, "/"),
+		secureCookies:          cfg.SecureCookies,
+		encryptor:              encryptor,
+		sessionIssuer:          cfg.StateSecret,
+		stateCodec:             stateCodec,
+		apiTokenTTL:            cfg.APITokenTTL,
+		now:                    now,
+		readiness:              cfg.Readiness,
+		prometheusMetrics:      cfg.PrometheusMetrics,
+		mcpHandler:             cfg.MCPHandler,
+		mountedHTTPBindings:    mountedHTTPBindings,
+		mountedWebUIs:          mountedWebUIs,
+		adminRoute:             adminRoute,
+		adminUI:                adminUI,
+		routeProfile:           cfg.RouteProfile,
+		httpBindingReplayStore: newMemoryHTTPBindingReplayStore(),
 	}
 	s.workflowSchedules = workflowmanager.New(workflowmanager.Config{
 		Providers:             cfg.Providers,

--- a/gestaltd/internal/server/server_test.go
+++ b/gestaltd/internal/server/server_test.go
@@ -3,6 +3,7 @@ package server_test
 import (
 	"bytes"
 	"context"
+	"crypto/hmac"
 	"crypto/sha256"
 	"crypto/tls"
 	"encoding/hex"
@@ -11623,6 +11624,685 @@ func TestExecuteOperation_POST(t *testing.T) {
 	}
 }
 
+func TestHostedHTTPBinding_SlackSignatureAckDispatchesOperationAndRejectsReplay(t *testing.T) {
+	t.Setenv("SLACK_SIGNING_SECRET", "super-secret")
+
+	type bindingInvocation struct {
+		Params   map[string]any
+		Workflow map[string]any
+	}
+
+	invocations := make(chan bindingInvocation, 1)
+	provider := &stubIntegrationWithOps{
+		StubIntegration: coretesting.StubIntegration{
+			N:        "slack",
+			ConnMode: core.ConnectionModeNone,
+			ExecuteFn: func(ctx context.Context, op string, params map[string]any, _ string) (*core.OperationResult, error) {
+				if op != "handle_command" {
+					t.Fatalf("operation = %q, want %q", op, "handle_command")
+				}
+				invocations <- bindingInvocation{
+					Params:   cloneAnyMapForTest(params),
+					Workflow: invocation.WorkflowContextFromContext(ctx),
+				}
+				return &core.OperationResult{Status: http.StatusOK, Body: `{"ok":true}`}, nil
+			},
+		},
+		ops: []core.Operation{{Name: "handle_command", Method: http.MethodPost}},
+	}
+
+	ts := newTestServer(t, func(cfg *server.Config) {
+		cfg.Providers = testutil.NewProviderRegistry(t, provider)
+		cfg.PluginDefs = map[string]*config.ProviderEntry{
+			"slack": {
+				SecuritySchemes: map[string]*config.HTTPSecurityScheme{
+					"slack": {
+						Type: providermanifestv1.HTTPSecuritySchemeTypeSlackSignature,
+						Secret: &providermanifestv1.HTTPSecretRef{
+							Env: "SLACK_SIGNING_SECRET",
+						},
+					},
+				},
+				HTTP: map[string]*config.HTTPBinding{
+					"command": {
+						Path:   "/command",
+						Method: http.MethodPost,
+						RequestBody: &providermanifestv1.HTTPRequestBody{
+							Required: true,
+							Content: map[string]*providermanifestv1.HTTPMediaType{
+								"application/x-www-form-urlencoded": {},
+							},
+						},
+						Security: "slack",
+						Target:   "handle_command",
+						Ack: &providermanifestv1.HTTPAck{
+							Body: map[string]any{
+								"response_type": "ephemeral",
+								"text":          "Working on it...",
+							},
+						},
+					},
+				},
+			},
+		}
+		cfg.Authorizer = mustAuthorizer(t, config.AuthorizationConfig{}, cfg.Providers, cfg.PluginDefs, nil)
+	})
+	testutil.CloseOnCleanup(t, ts)
+
+	body := "text=hello&response_url=https%3A%2F%2Fhooks.example.test%2Fresponse"
+	timestamp := strconv.FormatInt(time.Now().Unix(), 10)
+	signature := httpBindingTestSignature("super-secret", "v0:"+timestamp+":"+body)
+
+	makeRequest := func() *http.Request {
+		req, err := http.NewRequest(http.MethodPost, ts.URL+"/api/v1/slack/command?source=query", strings.NewReader(body))
+		if err != nil {
+			t.Fatalf("NewRequest: %v", err)
+		}
+		req.Header.Set("Content-Type", "application/x-www-form-urlencoded")
+		req.Header.Set("X-Slack-Request-Timestamp", timestamp)
+		req.Header.Set("X-Slack-Signature", signature)
+		return req
+	}
+
+	resp, err := http.DefaultClient.Do(makeRequest())
+	if err != nil {
+		t.Fatalf("http binding request: %v", err)
+	}
+	defer func() { _ = resp.Body.Close() }()
+	if resp.StatusCode != http.StatusOK {
+		t.Fatalf("status = %d, want %d", resp.StatusCode, http.StatusOK)
+	}
+	var ack map[string]any
+	if err := json.NewDecoder(resp.Body).Decode(&ack); err != nil {
+		t.Fatalf("decode ack: %v", err)
+	}
+	if got, want := ack["response_type"], "ephemeral"; got != want {
+		t.Fatalf("response_type = %#v, want %q", got, want)
+	}
+	if got, want := ack["text"], "Working on it..."; got != want {
+		t.Fatalf("text = %#v, want %q", got, want)
+	}
+
+	select {
+	case invocation := <-invocations:
+		if got, want := invocation.Params["text"], "hello"; got != want {
+			t.Fatalf("params[text] = %#v, want %q", got, want)
+		}
+		if got, want := invocation.Params["response_url"], "https://hooks.example.test/response"; got != want {
+			t.Fatalf("params[response_url] = %#v, want %q", got, want)
+		}
+		if got, want := invocation.Params["source"], "query"; got != want {
+			t.Fatalf("params[source] = %#v, want %q", got, want)
+		}
+		httpCtx, ok := invocation.Workflow["http"].(map[string]any)
+		if !ok {
+			t.Fatalf("workflow http context = %#v", invocation.Workflow)
+		}
+		if got, want := httpCtx["name"], "command"; got != want {
+			t.Fatalf("http context name = %#v, want %q", got, want)
+		}
+		if got, want := httpCtx["path"], "/api/v1/slack/command"; got != want {
+			t.Fatalf("http context path = %#v, want %q", got, want)
+		}
+		if got, want := httpCtx["security"], "slack"; got != want {
+			t.Fatalf("http context security = %#v, want %q", got, want)
+		}
+	case <-time.After(2 * time.Second):
+		t.Fatal("timed out waiting for async http binding dispatch")
+	}
+
+	resp, err = http.DefaultClient.Do(makeRequest())
+	if err != nil {
+		t.Fatalf("duplicate http binding request: %v", err)
+	}
+	defer func() { _ = resp.Body.Close() }()
+	if resp.StatusCode != http.StatusOK {
+		t.Fatalf("duplicate status = %d, want %d", resp.StatusCode, http.StatusOK)
+	}
+	var duplicateAck map[string]any
+	if err := json.NewDecoder(resp.Body).Decode(&duplicateAck); err != nil {
+		t.Fatalf("decode duplicate ack: %v", err)
+	}
+	if got, want := duplicateAck["response_type"], "ephemeral"; got != want {
+		t.Fatalf("duplicate response_type = %#v, want %q", got, want)
+	}
+	select {
+	case invocation := <-invocations:
+		t.Fatalf("unexpected duplicate async dispatch: %#v", invocation)
+	case <-time.After(200 * time.Millisecond):
+	}
+}
+
+func TestHostedHTTPBinding_MergesManifestAndConfigOverrides(t *testing.T) {
+	t.Setenv("SLACK_SIGNING_SECRET", "super-secret")
+
+	invocations := make(chan map[string]any, 1)
+	provider := &stubIntegrationWithOps{
+		StubIntegration: coretesting.StubIntegration{
+			N:        "slack",
+			ConnMode: core.ConnectionModeNone,
+			ExecuteFn: func(_ context.Context, op string, params map[string]any, _ string) (*core.OperationResult, error) {
+				if op != "handle_command" {
+					t.Fatalf("operation = %q, want %q", op, "handle_command")
+				}
+				invocations <- cloneAnyMapForTest(params)
+				return &core.OperationResult{Status: http.StatusOK, Body: `{"ok":true}`}, nil
+			},
+		},
+		ops: []core.Operation{{Name: "handle_command", Method: http.MethodPost}},
+	}
+
+	ts := newTestServer(t, func(cfg *server.Config) {
+		cfg.Providers = testutil.NewProviderRegistry(t, provider)
+		cfg.PluginDefs = map[string]*config.ProviderEntry{
+			"slack": {
+				ResolvedManifest: &providermanifestv1.Manifest{
+					Spec: &providermanifestv1.Spec{
+						SecuritySchemes: map[string]*providermanifestv1.HTTPSecurityScheme{
+							"slack": {Type: providermanifestv1.HTTPSecuritySchemeTypeSlackSignature},
+						},
+						HTTP: map[string]*providermanifestv1.HTTPBinding{
+							"command": {
+								Path:   "/command",
+								Method: http.MethodPost,
+								RequestBody: &providermanifestv1.HTTPRequestBody{
+									Required: true,
+									Content: map[string]*providermanifestv1.HTTPMediaType{
+										"application/x-www-form-urlencoded": {},
+									},
+								},
+								Security: "slack",
+								Target:   "handle_command",
+							},
+						},
+					},
+				},
+				SecuritySchemes: map[string]*config.HTTPSecurityScheme{
+					"slack": {
+						Secret: &providermanifestv1.HTTPSecretRef{Env: "SLACK_SIGNING_SECRET"},
+					},
+				},
+				HTTP: map[string]*config.HTTPBinding{
+					"command": {
+						Ack: &providermanifestv1.HTTPAck{
+							Body: map[string]any{
+								"response_type": "ephemeral",
+								"text":          "Merged from config",
+							},
+						},
+					},
+				},
+			},
+		}
+		cfg.Authorizer = mustAuthorizer(t, config.AuthorizationConfig{}, cfg.Providers, cfg.PluginDefs, nil)
+	})
+	testutil.CloseOnCleanup(t, ts)
+
+	body := "text=hello"
+	timestamp := strconv.FormatInt(time.Now().Unix(), 10)
+	signature := httpBindingTestSignature("super-secret", "v0:"+timestamp+":"+body)
+
+	req, err := http.NewRequest(http.MethodPost, ts.URL+"/api/v1/slack/command", strings.NewReader(body))
+	if err != nil {
+		t.Fatalf("NewRequest: %v", err)
+	}
+	req.Header.Set("Content-Type", "application/x-www-form-urlencoded")
+	req.Header.Set("X-Slack-Request-Timestamp", timestamp)
+	req.Header.Set("X-Slack-Signature", signature)
+
+	resp, err := http.DefaultClient.Do(req)
+	if err != nil {
+		t.Fatalf("http binding request: %v", err)
+	}
+	defer func() { _ = resp.Body.Close() }()
+	if resp.StatusCode != http.StatusOK {
+		t.Fatalf("status = %d, want %d", resp.StatusCode, http.StatusOK)
+	}
+	var ack map[string]any
+	if err := json.NewDecoder(resp.Body).Decode(&ack); err != nil {
+		t.Fatalf("decode ack: %v", err)
+	}
+	if got, want := ack["text"], "Merged from config"; got != want {
+		t.Fatalf("ack text = %#v, want %q", got, want)
+	}
+
+	select {
+	case params := <-invocations:
+		if got, want := params["text"], "hello"; got != want {
+			t.Fatalf("params[text] = %#v, want %q", got, want)
+		}
+	case <-time.After(2 * time.Second):
+		t.Fatal("timed out waiting for merged hosted http binding invocation")
+	}
+}
+
+func TestHostedHTTPBinding_SlackSignatureSyncRetriesReinvokeOperation(t *testing.T) {
+	t.Setenv("SLACK_SIGNING_SECRET", "super-secret")
+
+	invocations := make(chan map[string]any, 2)
+	provider := &stubIntegrationWithOps{
+		StubIntegration: coretesting.StubIntegration{
+			N:        "slack",
+			ConnMode: core.ConnectionModeNone,
+			ExecuteFn: func(_ context.Context, op string, params map[string]any, _ string) (*core.OperationResult, error) {
+				if op != "handle_command" {
+					t.Fatalf("operation = %q, want %q", op, "handle_command")
+				}
+				invocations <- cloneAnyMapForTest(params)
+				return &core.OperationResult{Status: http.StatusOK, Body: `{"text":"pong"}`}, nil
+			},
+		},
+		ops: []core.Operation{{Name: "handle_command", Method: http.MethodPost}},
+	}
+
+	ts := newTestServer(t, func(cfg *server.Config) {
+		cfg.Providers = testutil.NewProviderRegistry(t, provider)
+		cfg.PluginDefs = map[string]*config.ProviderEntry{
+			"slack": {
+				SecuritySchemes: map[string]*config.HTTPSecurityScheme{
+					"slack": {
+						Type:   providermanifestv1.HTTPSecuritySchemeTypeSlackSignature,
+						Secret: &providermanifestv1.HTTPSecretRef{Env: "SLACK_SIGNING_SECRET"},
+					},
+				},
+				HTTP: map[string]*config.HTTPBinding{
+					"command": {
+						Path:   "/command",
+						Method: http.MethodPost,
+						RequestBody: &providermanifestv1.HTTPRequestBody{
+							Required: true,
+							Content: map[string]*providermanifestv1.HTTPMediaType{
+								"application/x-www-form-urlencoded": {},
+							},
+						},
+						Security: "slack",
+						Target:   "handle_command",
+					},
+				},
+			},
+		}
+		cfg.Authorizer = mustAuthorizer(t, config.AuthorizationConfig{}, cfg.Providers, cfg.PluginDefs, nil)
+	})
+	testutil.CloseOnCleanup(t, ts)
+
+	body := "text=ping"
+	timestamp := strconv.FormatInt(time.Now().Unix(), 10)
+	signature := httpBindingTestSignature("super-secret", "v0:"+timestamp+":"+body)
+
+	makeRequest := func() *http.Request {
+		req, err := http.NewRequest(http.MethodPost, ts.URL+"/api/v1/slack/command", strings.NewReader(body))
+		if err != nil {
+			t.Fatalf("NewRequest: %v", err)
+		}
+		req.Header.Set("Content-Type", "application/x-www-form-urlencoded")
+		req.Header.Set("X-Slack-Request-Timestamp", timestamp)
+		req.Header.Set("X-Slack-Signature", signature)
+		return req
+	}
+
+	for i := 0; i < 2; i++ {
+		resp, err := http.DefaultClient.Do(makeRequest())
+		if err != nil {
+			t.Fatalf("sync slack request %d: %v", i, err)
+		}
+		var result map[string]any
+		if err := json.NewDecoder(resp.Body).Decode(&result); err != nil {
+			_ = resp.Body.Close()
+			t.Fatalf("decode sync result %d: %v", i, err)
+		}
+		_ = resp.Body.Close()
+		if resp.StatusCode != http.StatusOK {
+			t.Fatalf("sync status %d = %d, want %d", i, resp.StatusCode, http.StatusOK)
+		}
+		if got, want := result["text"], "pong"; got != want {
+			t.Fatalf("sync result %d text = %#v, want %q", i, got, want)
+		}
+	}
+
+	for i := 0; i < 2; i++ {
+		select {
+		case params := <-invocations:
+			if got, want := params["text"], "ping"; got != want {
+				t.Fatalf("invocation %d text = %#v, want %q", i, got, want)
+			}
+		case <-time.After(2 * time.Second):
+			t.Fatalf("timed out waiting for sync invocation %d", i)
+		}
+	}
+}
+
+func TestHostedHTTPBinding_APIKeySyncInvokesOperation(t *testing.T) {
+	t.Parallel()
+
+	type bindingInvocation struct {
+		Params   map[string]any
+		Workflow map[string]any
+	}
+
+	invocations := make(chan bindingInvocation, 1)
+	provider := &stubIntegrationWithOps{
+		StubIntegration: coretesting.StubIntegration{
+			N:        "events",
+			ConnMode: core.ConnectionModeNone,
+			ExecuteFn: func(ctx context.Context, op string, params map[string]any, _ string) (*core.OperationResult, error) {
+				if op != "handle_event" {
+					t.Fatalf("operation = %q, want %q", op, "handle_event")
+				}
+				invocations <- bindingInvocation{
+					Params:   cloneAnyMapForTest(params),
+					Workflow: invocation.WorkflowContextFromContext(ctx),
+				}
+				return &core.OperationResult{Status: http.StatusCreated, Body: `{"accepted":true}`}, nil
+			},
+		},
+		ops: []core.Operation{{Name: "handle_event", Method: http.MethodPost}},
+	}
+
+	ts := newTestServer(t, func(cfg *server.Config) {
+		cfg.Providers = testutil.NewProviderRegistry(t, provider)
+		cfg.PluginDefs = map[string]*config.ProviderEntry{
+			"events": {
+				SecuritySchemes: map[string]*config.HTTPSecurityScheme{
+					"eventKey": {
+						Type:   providermanifestv1.HTTPSecuritySchemeTypeAPIKey,
+						Name:   "X-Webhook-Key",
+						In:     providermanifestv1.HTTPInHeader,
+						Secret: &providermanifestv1.HTTPSecretRef{Secret: "shared-key"},
+					},
+				},
+				HTTP: map[string]*config.HTTPBinding{
+					"event": {
+						Path:   "/event",
+						Method: http.MethodPost,
+						RequestBody: &providermanifestv1.HTTPRequestBody{
+							Required: true,
+							Content: map[string]*providermanifestv1.HTTPMediaType{
+								"application/json": {},
+							},
+						},
+						Security: "eventKey",
+						Target:   "handle_event",
+					},
+				},
+			},
+		}
+		cfg.Authorizer = mustAuthorizer(t, config.AuthorizationConfig{}, cfg.Providers, cfg.PluginDefs, nil)
+	})
+	testutil.CloseOnCleanup(t, ts)
+
+	req, err := http.NewRequest(http.MethodPost, ts.URL+"/api/v1/events/event?source=query", strings.NewReader(`{"event":"opened"}`))
+	if err != nil {
+		t.Fatalf("NewRequest: %v", err)
+	}
+	req.Header.Set("Content-Type", "application/json")
+	req.Header.Set("X-Webhook-Key", "shared-key")
+
+	resp, err := http.DefaultClient.Do(req)
+	if err != nil {
+		t.Fatalf("http binding request: %v", err)
+	}
+	defer func() { _ = resp.Body.Close() }()
+	if resp.StatusCode != http.StatusCreated {
+		t.Fatalf("status = %d, want %d", resp.StatusCode, http.StatusCreated)
+	}
+	var result map[string]any
+	if err := json.NewDecoder(resp.Body).Decode(&result); err != nil {
+		t.Fatalf("decode result: %v", err)
+	}
+	if got, want := result["accepted"], true; got != want {
+		t.Fatalf("accepted = %#v, want %#v", got, want)
+	}
+
+	select {
+	case invocation := <-invocations:
+		if got, want := invocation.Params["event"], "opened"; got != want {
+			t.Fatalf("params[event] = %#v, want %q", got, want)
+		}
+		if got, want := invocation.Params["source"], "query"; got != want {
+			t.Fatalf("params[source] = %#v, want %q", got, want)
+		}
+		httpCtx, ok := invocation.Workflow["http"].(map[string]any)
+		if !ok {
+			t.Fatalf("workflow http context = %#v", invocation.Workflow)
+		}
+		if got, want := httpCtx["name"], "event"; got != want {
+			t.Fatalf("http context name = %#v, want %q", got, want)
+		}
+		if got, want := httpCtx["contentType"], "application/json"; got != want {
+			t.Fatalf("http context contentType = %#v, want %q", got, want)
+		}
+	case <-time.After(2 * time.Second):
+		t.Fatal("timed out waiting for sync http binding invocation")
+	}
+}
+
+func TestHostedHTTPBinding_APIKeyQueryDoesNotLeakCredentialParam(t *testing.T) {
+	t.Parallel()
+
+	invocations := make(chan map[string]any, 1)
+	provider := &stubIntegrationWithOps{
+		StubIntegration: coretesting.StubIntegration{
+			N:        "events",
+			ConnMode: core.ConnectionModeNone,
+			ExecuteFn: func(_ context.Context, op string, params map[string]any, _ string) (*core.OperationResult, error) {
+				if op != "handle_event" {
+					t.Fatalf("operation = %q, want %q", op, "handle_event")
+				}
+				invocations <- cloneAnyMapForTest(params)
+				return &core.OperationResult{Status: http.StatusOK, Body: `{"accepted":true}`}, nil
+			},
+		},
+		ops: []core.Operation{{Name: "handle_event", Method: http.MethodPost}},
+	}
+
+	ts := newTestServer(t, func(cfg *server.Config) {
+		cfg.Providers = testutil.NewProviderRegistry(t, provider)
+		cfg.PluginDefs = map[string]*config.ProviderEntry{
+			"events": {
+				SecuritySchemes: map[string]*config.HTTPSecurityScheme{
+					"eventKey": {
+						Type:   providermanifestv1.HTTPSecuritySchemeTypeAPIKey,
+						Name:   "token",
+						In:     providermanifestv1.HTTPInQuery,
+						Secret: &providermanifestv1.HTTPSecretRef{Secret: "shared-key"},
+					},
+				},
+				HTTP: map[string]*config.HTTPBinding{
+					"event": {
+						Path:     "/event",
+						Method:   http.MethodPost,
+						Security: "eventKey",
+						Target:   "handle_event",
+					},
+				},
+			},
+		}
+		cfg.Authorizer = mustAuthorizer(t, config.AuthorizationConfig{}, cfg.Providers, cfg.PluginDefs, nil)
+	})
+	testutil.CloseOnCleanup(t, ts)
+
+	req, err := http.NewRequest(http.MethodPost, ts.URL+"/api/v1/events/event?source=query&token=shared-key", nil)
+	if err != nil {
+		t.Fatalf("NewRequest: %v", err)
+	}
+
+	resp, err := http.DefaultClient.Do(req)
+	if err != nil {
+		t.Fatalf("http binding request: %v", err)
+	}
+	defer func() { _ = resp.Body.Close() }()
+	if resp.StatusCode != http.StatusOK {
+		t.Fatalf("status = %d, want %d", resp.StatusCode, http.StatusOK)
+	}
+
+	select {
+	case params := <-invocations:
+		if got, want := params["source"], "query"; got != want {
+			t.Fatalf("params[source] = %#v, want %q", got, want)
+		}
+		if _, exists := params["token"]; exists {
+			t.Fatalf("params[token] should be stripped from query apiKey binding: %#v", params)
+		}
+	case <-time.After(2 * time.Second):
+		t.Fatal("timed out waiting for query apiKey http binding invocation")
+	}
+}
+
+func TestHostedHTTPBinding_RejectsGenericOperationRouteConflicts(t *testing.T) {
+	t.Parallel()
+
+	svc := coretesting.NewStubServices(t)
+	providers := testutil.NewProviderRegistry(t, &stubIntegrationWithOps{
+		StubIntegration: coretesting.StubIntegration{
+			N:        "reports",
+			ConnMode: core.ConnectionModeNone,
+		},
+		ops: []core.Operation{
+			{Name: "status", Method: http.MethodGet},
+			{Name: "handle_status", Method: http.MethodGet},
+		},
+	})
+	cfg := server.Config{
+		Auth:        &coretesting.StubAuthProvider{N: "none"},
+		Services:    svc,
+		Providers:   providers,
+		Invoker:     invocation.NewBroker(providers, svc.Users, svc.Tokens),
+		StateSecret: []byte("0123456789abcdef0123456789abcdef"),
+		PluginDefs: map[string]*config.ProviderEntry{
+			"reports": {
+				SecuritySchemes: map[string]*config.HTTPSecurityScheme{
+					"none": {Type: providermanifestv1.HTTPSecuritySchemeTypeNone},
+				},
+				HTTP: map[string]*config.HTTPBinding{
+					"status_binding": {
+						Path:     "/status",
+						Method:   http.MethodGet,
+						Security: "none",
+						Target:   "handle_status",
+					},
+				},
+			},
+		},
+	}
+
+	_, err := server.New(cfg)
+	if err == nil {
+		t.Fatal("expected generic operation route conflict")
+	}
+	if !strings.Contains(err.Error(), "generic operation route") {
+		t.Fatalf("error = %v, want generic operation route conflict", err)
+	}
+}
+
+func TestHostedHTTPBinding_RejectsInvalidConfigBindings(t *testing.T) {
+	t.Parallel()
+
+	baseConfig := func(t *testing.T) server.Config {
+		svc := coretesting.NewStubServices(t)
+		providers := testutil.NewProviderRegistry(t, &stubIntegrationWithOps{
+			StubIntegration: coretesting.StubIntegration{
+				N:        "events",
+				ConnMode: core.ConnectionModeNone,
+			},
+			ops: []core.Operation{{Name: "handle_event", Method: http.MethodPost}},
+		})
+		return server.Config{
+			Auth:        &coretesting.StubAuthProvider{N: "none"},
+			Services:    svc,
+			Providers:   providers,
+			Invoker:     invocation.NewBroker(providers, svc.Users, svc.Tokens),
+			StateSecret: []byte("0123456789abcdef0123456789abcdef"),
+		}
+	}
+
+	tests := []struct {
+		name    string
+		entry   *config.ProviderEntry
+		wantErr string
+	}{
+		{
+			name: "invalid ack status",
+			entry: &config.ProviderEntry{
+				SecuritySchemes: map[string]*config.HTTPSecurityScheme{
+					"none": {Type: providermanifestv1.HTTPSecuritySchemeTypeNone},
+				},
+				HTTP: map[string]*config.HTTPBinding{
+					"event": {
+						Path:     "/event",
+						Method:   http.MethodPost,
+						Security: "none",
+						Target:   "handle_event",
+						Ack:      &providermanifestv1.HTTPAck{Status: http.StatusInternalServerError},
+					},
+				},
+			},
+			wantErr: "ack.status must be a 2xx status",
+		},
+		{
+			name: "missing api key secret",
+			entry: &config.ProviderEntry{
+				SecuritySchemes: map[string]*config.HTTPSecurityScheme{
+					"eventKey": {
+						Type: providermanifestv1.HTTPSecuritySchemeTypeAPIKey,
+						Name: "X-Webhook-Key",
+						In:   providermanifestv1.HTTPInHeader,
+					},
+				},
+				HTTP: map[string]*config.HTTPBinding{
+					"event": {
+						Path:     "/event",
+						Method:   http.MethodPost,
+						Security: "eventKey",
+						Target:   "handle_event",
+					},
+				},
+			},
+			wantErr: "secret is required",
+		},
+		{
+			name: "duplicate normalized content types",
+			entry: &config.ProviderEntry{
+				SecuritySchemes: map[string]*config.HTTPSecurityScheme{
+					"none": {Type: providermanifestv1.HTTPSecuritySchemeTypeNone},
+				},
+				HTTP: map[string]*config.HTTPBinding{
+					"event": {
+						Path:   "/event",
+						Method: http.MethodPost,
+						RequestBody: &providermanifestv1.HTTPRequestBody{
+							Content: map[string]*providermanifestv1.HTTPMediaType{
+								"application/json":                {},
+								"application/json; charset=utf-8": {},
+							},
+						},
+						Security: "none",
+						Target:   "handle_event",
+					},
+				},
+			},
+			wantErr: `requestBody.content "application/json" is duplicated after normalization`,
+		},
+	}
+
+	for _, tt := range tests {
+		tt := tt
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			cfg := baseConfig(t)
+			cfg.PluginDefs = map[string]*config.ProviderEntry{"events": tt.entry}
+
+			_, err := server.New(cfg)
+			if err == nil {
+				t.Fatal("expected invalid hosted http config")
+			}
+			if !strings.Contains(err.Error(), tt.wantErr) {
+				t.Fatalf("error = %v, want substring %q", err, tt.wantErr)
+			}
+		})
+	}
+}
+
 func TestAuthInfo(t *testing.T) {
 	t.Parallel()
 
@@ -12025,6 +12705,23 @@ func sortedKeys[V any](m map[string]V) []string {
 	}
 	slices.Sort(keys)
 	return keys
+}
+
+func cloneAnyMapForTest(src map[string]any) map[string]any {
+	if src == nil {
+		return nil
+	}
+	dst := make(map[string]any, len(src))
+	for key, value := range src {
+		dst[key] = value
+	}
+	return dst
+}
+
+func httpBindingTestSignature(secret, payload string) string {
+	mac := hmac.New(sha256.New, []byte(secret))
+	_, _ = mac.Write([]byte(payload))
+	return "v0=" + hex.EncodeToString(mac.Sum(nil))
 }
 
 func TestExecuteOperation_RefreshesExpiredToken(t *testing.T) {

--- a/gestaltd/sdk/providermanifest/v1/manifest.jsonschema.json
+++ b/gestaltd/sdk/providermanifest/v1/manifest.jsonschema.json
@@ -100,6 +100,18 @@
         "auth": {
           "$ref": "#/$defs/routeAuthRef"
         },
+        "securitySchemes": {
+          "type": "object",
+          "additionalProperties": {
+            "$ref": "#/$defs/httpSecurityScheme"
+          }
+        },
+        "http": {
+          "type": "object",
+          "additionalProperties": {
+            "$ref": "#/$defs/httpBinding"
+          }
+        },
         "headers": {
           "type": "object",
           "additionalProperties": {
@@ -168,6 +180,138 @@
         "provider": {
           "type": "string",
           "minLength": 1
+        }
+      }
+    },
+    "httpSecretRef": {
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "env": {
+          "type": "string",
+          "minLength": 1
+        },
+        "secret": {
+          "type": "string",
+          "minLength": 1
+        }
+      }
+    },
+    "httpSecurityScheme": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "type"
+      ],
+      "properties": {
+        "type": {
+          "type": "string",
+          "enum": [
+            "slack_signature",
+            "apiKey",
+            "http",
+            "none"
+          ]
+        },
+        "description": {
+          "type": "string"
+        },
+        "name": {
+          "type": "string",
+          "minLength": 1
+        },
+        "in": {
+          "type": "string",
+          "enum": [
+            "header",
+            "query"
+          ]
+        },
+        "scheme": {
+          "type": "string",
+          "enum": [
+            "basic",
+            "bearer"
+          ]
+        },
+        "secret": {
+          "$ref": "#/$defs/httpSecretRef"
+        }
+      }
+    },
+    "httpMediaType": {
+      "type": "object",
+      "additionalProperties": false
+    },
+    "httpRequestBody": {
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "required": {
+          "type": "boolean"
+        },
+        "content": {
+          "type": "object",
+          "additionalProperties": {
+            "$ref": "#/$defs/httpMediaType"
+          }
+        }
+      }
+    },
+    "httpAck": {
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "status": {
+          "type": "integer",
+          "minimum": 100,
+          "maximum": 599
+        },
+        "headers": {
+          "type": "object",
+          "additionalProperties": {
+            "type": "string"
+          }
+        },
+        "body": {}
+      }
+    },
+    "httpBinding": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "path",
+        "method",
+        "target"
+      ],
+      "properties": {
+        "path": {
+          "type": "string",
+          "minLength": 1
+        },
+        "method": {
+          "type": "string",
+          "enum": [
+            "GET",
+            "POST",
+            "PUT",
+            "PATCH",
+            "DELETE"
+          ]
+        },
+        "requestBody": {
+          "$ref": "#/$defs/httpRequestBody"
+        },
+        "security": {
+          "type": "string",
+          "minLength": 1
+        },
+        "target": {
+          "type": "string",
+          "minLength": 1
+        },
+        "ack": {
+          "$ref": "#/$defs/httpAck"
         }
       }
     },

--- a/gestaltd/sdk/providermanifest/v1/types.go
+++ b/gestaltd/sdk/providermanifest/v1/types.go
@@ -6,6 +6,7 @@ import (
 	"encoding/json"
 	"fmt"
 	"io"
+	"reflect"
 	"strings"
 
 	"gopkg.in/yaml.v3"
@@ -78,6 +79,8 @@ type Spec struct {
 
 	// Plugin-specific fields
 	RouteAuth         *RouteAuthRef                         `json:"auth,omitempty" yaml:"auth,omitempty"`
+	SecuritySchemes   map[string]*HTTPSecurityScheme        `json:"securitySchemes,omitempty" yaml:"securitySchemes,omitempty"`
+	HTTP              map[string]*HTTPBinding               `json:"http,omitempty" yaml:"http,omitempty"`
 	MCP               bool                                  `json:"mcp,omitempty" yaml:"mcp,omitempty"`
 	Headers           map[string]string                     `json:"headers,omitempty" yaml:"headers,omitempty"`
 	ManagedParameters []ManagedParameter                    `json:"managedParameters,omitempty" yaml:"managedParameters,omitempty"`
@@ -97,6 +100,66 @@ type Spec struct {
 
 type RouteAuthRef struct {
 	Provider string `json:"provider,omitempty" yaml:"provider,omitempty"`
+}
+
+type HTTPSecuritySchemeType string
+
+const (
+	HTTPSecuritySchemeTypeSlackSignature HTTPSecuritySchemeType = "slack_signature"
+	HTTPSecuritySchemeTypeAPIKey         HTTPSecuritySchemeType = "apiKey"
+	HTTPSecuritySchemeTypeHTTP           HTTPSecuritySchemeType = "http"
+	HTTPSecuritySchemeTypeNone           HTTPSecuritySchemeType = "none"
+)
+
+type HTTPIn string
+
+const (
+	HTTPInHeader HTTPIn = "header"
+	HTTPInQuery  HTTPIn = "query"
+)
+
+type HTTPAuthScheme string
+
+const (
+	HTTPAuthSchemeBasic  HTTPAuthScheme = "basic"
+	HTTPAuthSchemeBearer HTTPAuthScheme = "bearer"
+)
+
+type HTTPBinding struct {
+	Path        string           `json:"path" yaml:"path"`
+	Method      string           `json:"method" yaml:"method"`
+	RequestBody *HTTPRequestBody `json:"requestBody,omitempty" yaml:"requestBody,omitempty"`
+	Security    string           `json:"security,omitempty" yaml:"security,omitempty"`
+	Target      string           `json:"target" yaml:"target"`
+	Ack         *HTTPAck         `json:"ack,omitempty" yaml:"ack,omitempty"`
+}
+
+type HTTPRequestBody struct {
+	Required bool                      `json:"required,omitempty" yaml:"required,omitempty"`
+	Content  map[string]*HTTPMediaType `json:"content,omitempty" yaml:"content,omitempty"`
+}
+
+type HTTPMediaType struct {
+}
+
+type HTTPAck struct {
+	Status  int               `json:"status,omitempty" yaml:"status,omitempty"`
+	Headers map[string]string `json:"headers,omitempty" yaml:"headers,omitempty"`
+	Body    any               `json:"body,omitempty" yaml:"body,omitempty"`
+}
+
+type HTTPSecurityScheme struct {
+	Type        HTTPSecuritySchemeType `json:"type,omitempty" yaml:"type,omitempty"`
+	Description string                 `json:"description,omitempty" yaml:"description,omitempty"`
+	Name        string                 `json:"name,omitempty" yaml:"name,omitempty"`
+	In          HTTPIn                 `json:"in,omitempty" yaml:"in,omitempty"`
+	Scheme      HTTPAuthScheme         `json:"scheme,omitempty" yaml:"scheme,omitempty"`
+	Secret      *HTTPSecretRef         `json:"secret,omitempty" yaml:"secret,omitempty"`
+}
+
+type HTTPSecretRef struct {
+	Env    string `json:"env,omitempty" yaml:"env,omitempty"`
+	Secret string `json:"secret,omitempty" yaml:"secret,omitempty"`
 }
 
 type OwnedUI struct {
@@ -416,6 +479,8 @@ type Entrypoint struct {
 type specJSONWire struct {
 	ConfigSchemaPath  string                                `json:"configSchemaPath,omitempty"`
 	Auth              *RouteAuthRef                         `json:"auth,omitempty"`
+	SecuritySchemes   map[string]*HTTPSecurityScheme        `json:"securitySchemes,omitempty"`
+	HTTP              map[string]*HTTPBinding               `json:"http,omitempty"`
 	MCP               bool                                  `json:"mcp,omitempty"`
 	Headers           map[string]string                     `json:"headers,omitempty"`
 	ManagedParameters []ManagedParameter                    `json:"managedParameters,omitempty"`
@@ -434,6 +499,8 @@ type specJSONWire struct {
 type specYAMLWire struct {
 	ConfigSchemaPath  string                                `yaml:"configSchemaPath,omitempty"`
 	Auth              *RouteAuthRef                         `yaml:"auth,omitempty"`
+	SecuritySchemes   map[string]*HTTPSecurityScheme        `yaml:"securitySchemes,omitempty"`
+	HTTP              map[string]*HTTPBinding               `yaml:"http,omitempty"`
 	MCP               bool                                  `yaml:"mcp,omitempty"`
 	Headers           map[string]string                     `yaml:"headers,omitempty"`
 	ManagedParameters []ManagedParameter                    `yaml:"managedParameters,omitempty"`
@@ -452,6 +519,8 @@ type specYAMLWire struct {
 type specWire struct {
 	ConfigSchemaPath  string                                `json:"configSchemaPath,omitempty" yaml:"configSchemaPath,omitempty"`
 	Auth              *RouteAuthRef                         `json:"auth,omitempty" yaml:"auth,omitempty"`
+	SecuritySchemes   map[string]*HTTPSecurityScheme        `json:"securitySchemes,omitempty" yaml:"securitySchemes,omitempty"`
+	HTTP              map[string]*HTTPBinding               `json:"http,omitempty" yaml:"http,omitempty"`
 	MCP               bool                                  `json:"mcp,omitempty" yaml:"mcp,omitempty"`
 	Headers           map[string]string                     `json:"headers,omitempty" yaml:"headers,omitempty"`
 	ManagedParameters []ManagedParameter                    `json:"managedParameters,omitempty" yaml:"managedParameters,omitempty"`
@@ -480,6 +549,8 @@ func (s *Spec) UnmarshalJSON(data []byte) error {
 	spec := Spec{
 		ConfigSchemaPath:  raw.ConfigSchemaPath,
 		RouteAuth:         raw.Auth,
+		SecuritySchemes:   cloneHTTPSecuritySchemes(raw.SecuritySchemes),
+		HTTP:              cloneHTTPBindings(raw.HTTP),
 		MCP:               raw.MCP,
 		Headers:           raw.Headers,
 		ManagedParameters: raw.ManagedParameters,
@@ -527,6 +598,8 @@ func (s *Spec) UnmarshalYAML(value *yaml.Node) error {
 	spec := Spec{
 		ConfigSchemaPath:  raw.ConfigSchemaPath,
 		RouteAuth:         raw.Auth,
+		SecuritySchemes:   cloneHTTPSecuritySchemes(raw.SecuritySchemes),
+		HTTP:              cloneHTTPBindings(raw.HTTP),
 		MCP:               raw.MCP,
 		Headers:           raw.Headers,
 		ManagedParameters: raw.ManagedParameters,
@@ -557,6 +630,8 @@ func (s Spec) canonicalWire() (specWire, error) {
 	return specWire{
 		ConfigSchemaPath:  s.ConfigSchemaPath,
 		Auth:              s.RouteAuth,
+		SecuritySchemes:   cloneHTTPSecuritySchemes(s.SecuritySchemes),
+		HTTP:              cloneHTTPBindings(s.HTTP),
 		MCP:               s.MCP,
 		Headers:           s.Headers,
 		ManagedParameters: s.ManagedParameters,
@@ -587,6 +662,146 @@ func cloneManifestConnections(src map[string]*ManifestConnectionDef) map[string]
 		cloned[name] = &copyDef
 	}
 	return cloned
+}
+
+func cloneHTTPSecuritySchemes(src map[string]*HTTPSecurityScheme) map[string]*HTTPSecurityScheme {
+	if src == nil {
+		return nil
+	}
+	cloned := make(map[string]*HTTPSecurityScheme, len(src))
+	for name, scheme := range src {
+		cloned[name] = cloneHTTPSecurityScheme(scheme)
+	}
+	return cloned
+}
+
+func cloneHTTPSecurityScheme(src *HTTPSecurityScheme) *HTTPSecurityScheme {
+	if src == nil {
+		return nil
+	}
+	cloned := *src
+	cloned.Secret = cloneHTTPSecretRef(src.Secret)
+	return &cloned
+}
+
+func cloneHTTPSecretRef(src *HTTPSecretRef) *HTTPSecretRef {
+	if src == nil {
+		return nil
+	}
+	cloned := *src
+	return &cloned
+}
+
+func cloneHTTPBindings(src map[string]*HTTPBinding) map[string]*HTTPBinding {
+	if src == nil {
+		return nil
+	}
+	cloned := make(map[string]*HTTPBinding, len(src))
+	for name, binding := range src {
+		cloned[name] = cloneHTTPBinding(binding)
+	}
+	return cloned
+}
+
+func cloneHTTPBinding(src *HTTPBinding) *HTTPBinding {
+	if src == nil {
+		return nil
+	}
+	cloned := *src
+	cloned.RequestBody = cloneHTTPRequestBody(src.RequestBody)
+	cloned.Ack = cloneHTTPAck(src.Ack)
+	return &cloned
+}
+
+func cloneHTTPRequestBody(src *HTTPRequestBody) *HTTPRequestBody {
+	if src == nil {
+		return nil
+	}
+	cloned := *src
+	if src.Content != nil {
+		cloned.Content = make(map[string]*HTTPMediaType, len(src.Content))
+		for name, mediaType := range src.Content {
+			cloned.Content[name] = cloneHTTPMediaType(mediaType)
+		}
+	}
+	return &cloned
+}
+
+func cloneHTTPMediaType(src *HTTPMediaType) *HTTPMediaType {
+	if src == nil {
+		return nil
+	}
+	cloned := *src
+	return &cloned
+}
+
+func cloneHTTPAck(src *HTTPAck) *HTTPAck {
+	if src == nil {
+		return nil
+	}
+	cloned := *src
+	if src.Headers != nil {
+		cloned.Headers = make(map[string]string, len(src.Headers))
+		for name, value := range src.Headers {
+			cloned.Headers[name] = value
+		}
+	}
+	cloned.Body = cloneHTTPBodyValue(src.Body)
+	return &cloned
+}
+
+func cloneHTTPBodyValue(src any) any {
+	if src == nil {
+		return nil
+	}
+	return cloneHTTPBodyReflectValue(reflect.ValueOf(src)).Interface()
+}
+
+func cloneHTTPBodyReflectValue(value reflect.Value) reflect.Value {
+	if !value.IsValid() {
+		return reflect.Value{}
+	}
+	switch value.Kind() {
+	case reflect.Interface:
+		if value.IsNil() {
+			return reflect.Zero(value.Type())
+		}
+		return cloneHTTPBodyReflectValue(value.Elem())
+	case reflect.Pointer:
+		if value.IsNil() {
+			return reflect.Zero(value.Type())
+		}
+		cloned := reflect.New(value.Type().Elem())
+		cloned.Elem().Set(cloneHTTPBodyReflectValue(value.Elem()))
+		return cloned
+	case reflect.Map:
+		if value.IsNil() {
+			return reflect.Zero(value.Type())
+		}
+		cloned := reflect.MakeMapWithSize(value.Type(), value.Len())
+		iter := value.MapRange()
+		for iter.Next() {
+			cloned.SetMapIndex(cloneHTTPBodyReflectValue(iter.Key()), cloneHTTPBodyReflectValue(iter.Value()))
+		}
+		return cloned
+	case reflect.Slice:
+		if value.IsNil() {
+			return reflect.Zero(value.Type())
+		}
+		cloned := reflect.MakeSlice(value.Type(), value.Len(), value.Len())
+		for i := 0; i < value.Len(); i++ {
+			cloned.Index(i).Set(cloneHTTPBodyReflectValue(value.Index(i)))
+		}
+		return cloned
+	case reflect.Array:
+		cloned := reflect.New(value.Type()).Elem()
+		for i := 0; i < value.Len(); i++ {
+			cloned.Index(i).Set(cloneHTTPBodyReflectValue(value.Index(i)))
+		}
+		return cloned
+	default:
+		return value
+	}
 }
 
 func decodeJSONKnownFields(data []byte, out any) error {
@@ -637,6 +852,8 @@ func validateYAMLWireObjectFields(node *yaml.Node, allowed map[string]struct{}, 
 var specWireFields = map[string]struct{}{
 	"configSchemaPath":  {},
 	"auth":              {},
+	"securitySchemes":   {},
+	"http":              {},
 	"mcp":               {},
 	"headers":           {},
 	"managedParameters": {},


### PR DESCRIPTION
## Summary
This adds a separate hosted HTTP binding layer to plugin manifests. Operations remain the executable capability surface, and `spec.http` binds additional plugin-relative HTTP endpoints onto those operations.

Mounted routes live under `/api/v1/{plugin}`. The existing generic operation routes remain unchanged.

## New interfaces
```yaml
spec:
  securitySchemes:
    slack:
      type: slack_signature
      secret:
        env: SLACK_SIGNING_SECRET

  http:
    command:
      path: /command
      method: POST
      security: slack
      requestBody:
        required: true
        content:
          application/x-www-form-urlencoded: {}
      target: handle_command
      ack:
        body:
          response_type: ephemeral
          text: Working on it...
```

```yaml
spec:
  securitySchemes:
    eventKey:
      type: apiKey
      in: header
      name: X-Webhook-Key
      secret:
        secret: shared-key

  http:
    event:
      path: /event
      method: POST
      security: eventKey
      requestBody:
        required: true
        content:
          application/json: {}
      target: handle_event
```

Interface shape in `sdk/providermanifest/v1/types.go`:
```go
type HTTPBinding struct {
    Path        string
    Method      string
    RequestBody *HTTPRequestBody
    Security    string
    Target      string
    Ack         *HTTPAck
}

type HTTPSecurityScheme struct {
    Type   HTTPSecuritySchemeType
    Name   string
    In     HTTPIn
    Scheme HTTPAuthScheme
    Secret *HTTPSecretRef
}
```

## Behavior
- `path` is plugin-relative and mounts under `/api/v1/{plugin}`
- `target` is the operation to invoke after verification and parsing
- `security` is enforced by `gestaltd` before invocation
- `requestBody.content` controls JSON vs form parsing
- `ack` sends an immediate response and dispatches the target operation asynchronously
- generic `/api/v1/{plugin}/{operation}` routes still exist, so `spec.http` is only for extra/custom ingress

## Implementation
- add `spec.securitySchemes` and `spec.http` to the provider manifest schema
- add config support and manifest validation for hosted HTTP bindings
- mount hosted plugin-relative HTTP routes in `gestaltd`
- support host-side verification for `slack_signature`, `apiKey`, `http`, and `none`
- support JSON and `application/x-www-form-urlencoded` request parsing
- dispatch to operations synchronously or with immediate `ack` + async continuation
- reject hosted-route conflicts with core namespaces, mounted UI paths, duplicate hosted routes, and generic operation routes
- pass hosted HTTP request metadata into workflow context for downstream operations

## Testing
Augmented existing integration-style coverage instead of adding a unit-test-only layer:
- hosted Slack-signature async-ack dispatch and replay rejection
- hosted API-key sync invocation
- manifest workflow acceptance/rejection coverage for hosted HTTP bindings
- config loading coverage for `securitySchemes` and `http`
- generic operation route conflict coverage

This supersedes the earlier hosted-webhook direction in favor of an explicit HTTP binding layer on top of operations.