### PR TITLE
sdk/typescript: release 0.0.1-alpha.10

### DIFF
--- a/sdk/typescript/package.json
+++ b/sdk/typescript/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@valon-technologies/gestalt",
-  "version": "0.0.1-alpha.1",
+  "version": "0.0.1-alpha.10",
   "description": "TypeScript SDK for Gestalt executable providers",
   "type": "module",
   "repository": {

--- a/sdk/typescript/src/invoker.ts
+++ b/sdk/typescript/src/invoker.ts
@@ -112,7 +112,7 @@ function toJsonValue(value: unknown): JsonValue {
     typeof value === "number" ||
     typeof value === "boolean"
   ) {
-    return value;
+    return value as JsonValue;
   }
   if (Array.isArray(value)) {
     return value.map((entry) => toJsonValue(entry));


### PR DESCRIPTION
## Summary
Release the TypeScript SDK as `@valon-technologies/gestalt@0.0.1-alpha.10` so consumers can depend on the published invocation-token interfaces instead of vendoring the SDK.

## New Interfaces
- `Request.invocationToken`
- `new PluginInvoker(requestOrToken).invoke(plugin, operation, params)`
- `new PluginInvoker(requestOrToken).exchangeInvocationToken({ grants, ttlSeconds })`
- workflow manager calls that propagate `invocationToken`

## Compatibility Fix
- narrow JSON primitive returns in `src/invoker.ts` so consumer `tsc --noEmit` passes when importing the published SDK source package

## Example
```ts
const invoker = new PluginInvoker(request);
const childToken = await invoker.exchangeInvocationToken({
  grants: [
    { plugin: "linear", operations: ["gql"] },
    { plugin: "google_sheets", operations: ["batch_update_values"] },
  ],
  ttlSeconds: 900,
});

const backgroundInvoker = new PluginInvoker(childToken);
await backgroundInvoker.invoke("linear", "gql", { query, variables });
await backgroundInvoker.invoke("google_sheets", "batch_update_values", payload);
```

## Validation
- `bun run check` in `sdk/typescript`
- `npm publish --dry-run --tag alpha` in `sdk/typescript`

## Release
- pushed tags:
  - `sdk/typescript/v0.0.1-alpha.9`
  - `sdk/typescript/v0.0.1-alpha.10`
- consumers should use `0.0.1-alpha.10`
