### PR TITLE
gestaltd: deduplicate binding-aware token resolution

### DIFF
--- a/gestaltd/internal/invocation/catalog.go
+++ b/gestaltd/internal/invocation/catalog.go
@@ -17,14 +17,6 @@ type TokenResolver interface {
 	ResolveToken(ctx context.Context, p *principal.Principal, providerName, connection, instance string) (context.Context, string, error)
 }
 
-type effectiveCredentialBindingResolver interface {
-	ResolveEffectiveCredentialBinding(p *principal.Principal, providerName, connection, instance string) (CredentialBindingResolution, error)
-}
-
-type bindingTokenResolver interface {
-	ResolveTokenWithBinding(ctx context.Context, p *principal.Principal, providerName, connection, instance string, boundCredential CredentialBindingResolution) (context.Context, string, error)
-}
-
 type requestStaticOperationResolver interface {
 	ResolveStaticOperationForRequest(ctx context.Context, operation string) (catalog.CatalogOperation, bool)
 }
@@ -153,7 +145,7 @@ func resolveSessionCatalog(ctx context.Context, prov core.Provider, provName str
 		return nil, false, nil
 	}
 	boundCredential := CredentialBindingResolution{}
-	if bindingResolver, ok := resolver.(effectiveCredentialBindingResolver); ok && p != nil {
+	if bindingResolver, ok := resolver.(EffectiveCredentialBindingResolver); ok && p != nil {
 		resolvedBinding, err := bindingResolver.ResolveEffectiveCredentialBinding(p, provName, connection, instance)
 		if err != nil {
 			return nil, true, err
@@ -166,7 +158,7 @@ func resolveSessionCatalog(ctx context.Context, prov core.Provider, provName str
 	}
 	if prov.ConnectionMode() == core.ConnectionModeNone {
 		if resolver != nil && p != nil {
-			enrichedCtx, token, err := resolveSessionCatalogToken(ctx, resolver, p, provName, connection, instance, boundCredential)
+			enrichedCtx, token, err := ResolveTokenForBinding(ctx, resolver, p, provName, connection, instance, boundCredential)
 			if err != nil {
 				return nil, true, err
 			}
@@ -181,21 +173,12 @@ func resolveSessionCatalog(ctx context.Context, prov core.Provider, provName str
 		return nil, false, nil
 	}
 
-	ctx, token, err := resolveSessionCatalogToken(ctx, resolver, p, provName, connection, instance, boundCredential)
+	ctx, token, err := ResolveTokenForBinding(ctx, resolver, p, provName, connection, instance, boundCredential)
 	if err != nil {
 		return nil, true, err
 	}
 	cat, _, err := core.CatalogForRequest(ctx, prov, token)
 	return cat, true, err
-}
-
-func resolveSessionCatalogToken(ctx context.Context, resolver TokenResolver, p *principal.Principal, provName, connection, instance string, boundCredential CredentialBindingResolution) (context.Context, string, error) {
-	if boundCredential.HasBinding {
-		if bindingResolver, ok := resolver.(bindingTokenResolver); ok {
-			return bindingResolver.ResolveTokenWithBinding(ctx, p, provName, connection, instance, boundCredential)
-		}
-	}
-	return resolver.ResolveToken(ctx, p, provName, connection, instance)
 }
 
 func resolveSessionOperation(ctx context.Context, prov core.Provider, provName string, resolver TokenResolver, p *principal.Principal, operation string, connections []string, instance string) (catalog.CatalogOperation, string, bool, error) {

--- a/gestaltd/internal/invocation/credential_binding.go
+++ b/gestaltd/internal/invocation/credential_binding.go
@@ -1,6 +1,7 @@
 package invocation
 
 import (
+	"context"
 	"fmt"
 	"strings"
 
@@ -15,6 +16,14 @@ type CredentialBindingResolution struct {
 	CredentialSubjectID string
 	Connection          string
 	Instance            string
+}
+
+type EffectiveCredentialBindingResolver interface {
+	ResolveEffectiveCredentialBinding(p *principal.Principal, providerName, connection, instance string) (CredentialBindingResolution, error)
+}
+
+type BindingTokenResolver interface {
+	ResolveTokenWithBinding(ctx context.Context, p *principal.Principal, providerName, connection, instance string, boundCredential CredentialBindingResolution) (context.Context, string, error)
 }
 
 func ResolveEffectiveCredentialBinding(authz authorization.RuntimeAuthorizer, p *principal.Principal, providerName, connection, instance string) (CredentialBindingResolution, error) {
@@ -81,4 +90,16 @@ func resolveCredentialBinding(authz authorization.RuntimeAuthorizer, p *principa
 
 func bindingSelectorOverrideError() error {
 	return fmt.Errorf("%w: workloads may not override connection or instance bindings", ErrAuthorizationDenied)
+}
+
+func ResolveTokenForBinding(ctx context.Context, resolver TokenResolver, p *principal.Principal, providerName, connection, instance string, boundCredential CredentialBindingResolution) (context.Context, string, error) {
+	if resolver == nil {
+		return ctx, "", fmt.Errorf("token resolution not supported")
+	}
+	if boundCredential.HasBinding {
+		if bindingResolver, ok := resolver.(BindingTokenResolver); ok {
+			return bindingResolver.ResolveTokenWithBinding(ctx, p, providerName, connection, instance, boundCredential)
+		}
+	}
+	return resolver.ResolveToken(ctx, p, providerName, connection, instance)
 }

--- a/gestaltd/internal/invocation/direct_tool.go
+++ b/gestaltd/internal/invocation/direct_tool.go
@@ -25,15 +25,7 @@ func CallDirectTool(ctx context.Context, resolver TokenResolver, p *principal.Pr
 	if resolver != nil && prov.ConnectionMode() != core.ConnectionModeNone {
 		var token string
 		var err error
-		if boundCredential.HasBinding {
-			if bindingResolver, ok := resolver.(bindingTokenResolver); ok {
-				ctx, token, err = bindingResolver.ResolveTokenWithBinding(ctx, p, provName, connection, instance, boundCredential)
-			} else {
-				ctx, token, err = resolver.ResolveToken(ctx, p, provName, connection, instance)
-			}
-		} else {
-			ctx, token, err = resolver.ResolveToken(ctx, p, provName, connection, instance)
-		}
+		ctx, token, err = ResolveTokenForBinding(ctx, resolver, p, provName, connection, instance, boundCredential)
 		if err != nil {
 			return nil, err
 		}

--- a/gestaltd/internal/invocation/guarded.go
+++ b/gestaltd/internal/invocation/guarded.go
@@ -184,20 +184,14 @@ func (g *GuardedInvoker) ResolveSubjectToken(ctx context.Context, prov core.Prov
 }
 
 func (g *GuardedInvoker) ResolveEffectiveCredentialBinding(p *principal.Principal, providerName, connection, instance string) (CredentialBindingResolution, error) {
-	type resolver interface {
-		ResolveEffectiveCredentialBinding(p *principal.Principal, providerName, connection, instance string) (CredentialBindingResolution, error)
-	}
-	if r, ok := g.inner.(resolver); ok {
+	if r, ok := g.inner.(EffectiveCredentialBindingResolver); ok {
 		return r.ResolveEffectiveCredentialBinding(p, providerName, connection, instance)
 	}
 	return CredentialBindingResolution{}, nil
 }
 
 func (g *GuardedInvoker) ResolveTokenWithBinding(ctx context.Context, p *principal.Principal, providerName, connection, instance string, boundCredential CredentialBindingResolution) (context.Context, string, error) {
-	type resolver interface {
-		ResolveTokenWithBinding(ctx context.Context, p *principal.Principal, providerName, connection, instance string, boundCredential CredentialBindingResolution) (context.Context, string, error)
-	}
-	if r, ok := g.inner.(resolver); ok {
+	if r, ok := g.inner.(BindingTokenResolver); ok {
 		return r.ResolveTokenWithBinding(ctx, p, providerName, connection, instance, boundCredential)
 	}
 	return ctx, "", fmt.Errorf("bound token resolution not supported")

--- a/gestaltd/internal/mcp/session_tools.go
+++ b/gestaltd/internal/mcp/session_tools.go
@@ -118,7 +118,7 @@ func resolveSessionToken(ctx context.Context, cfg Config, provName string, prov 
 				if err != nil {
 					return ctx, "", connection, err
 				}
-				sessionCtx, token, err := resolveSessionCredentialToken(ctx, cfg, p, provName, connection, instance, boundCredential)
+				sessionCtx, token, err := invocation.ResolveTokenForBinding(ctx, cfg.TokenResolver, p, provName, connection, instance, boundCredential)
 				if err != nil {
 					return sessionCtx, token, connection, err
 				}
@@ -138,7 +138,7 @@ func resolveSessionToken(ctx context.Context, cfg Config, provName string, prov 
 	if err != nil {
 		return ctx, "", connection, err
 	}
-	sessionCtx, token, err := resolveSessionCredentialToken(ctx, cfg, p, provName, connection, instance, boundCredential)
+	sessionCtx, token, err := invocation.ResolveTokenForBinding(ctx, cfg.TokenResolver, p, provName, connection, instance, boundCredential)
 	if err != nil {
 		return sessionCtx, token, connection, err
 	}
@@ -390,18 +390,6 @@ func sessionCatalogOperationMarkerForInstance(name, provider, instance string) b
 
 func internalSessionToolHandler(context.Context, mcpgo.CallToolRequest) (*mcpgo.CallToolResult, error) {
 	return mcpgo.NewToolResultError("tool not found"), nil
-}
-
-func resolveSessionCredentialToken(ctx context.Context, cfg Config, p *principal.Principal, provName, connection, instance string, boundCredential invocation.CredentialBindingResolution) (context.Context, string, error) {
-	type bindingTokenResolver interface {
-		ResolveTokenWithBinding(ctx context.Context, p *principal.Principal, providerName, connection, instance string, boundCredential invocation.CredentialBindingResolution) (context.Context, string, error)
-	}
-	if boundCredential.HasBinding {
-		if resolver, ok := cfg.TokenResolver.(bindingTokenResolver); ok {
-			return resolver.ResolveTokenWithBinding(ctx, p, provName, connection, instance, boundCredential)
-		}
-	}
-	return cfg.TokenResolver.ResolveToken(ctx, p, provName, connection, instance)
 }
 
 func sessionTokenSelectors(cfg Config, p *principal.Principal, provName, instanceOverride string) (string, string, invocation.CredentialBindingResolution, error) {

--- a/gestaltd/internal/workflowmanager/manager.go
+++ b/gestaltd/internal/workflowmanager/manager.go
@@ -35,14 +35,6 @@ type WorkflowControl interface {
 	ResolveProviderSelection(name string) (providerName string, provider coreworkflow.Provider, err error)
 }
 
-type effectiveCredentialBindingResolver interface {
-	ResolveEffectiveCredentialBinding(p *principal.Principal, providerName, connection, instance string) (invocation.CredentialBindingResolution, error)
-}
-
-type bindingTokenResolver interface {
-	ResolveTokenWithBinding(ctx context.Context, p *principal.Principal, providerName, connection, instance string, boundCredential invocation.CredentialBindingResolution) (context.Context, string, error)
-}
-
 type Service interface {
 	ListSchedules(ctx context.Context, p *principal.Principal) ([]*ManagedSchedule, error)
 	CreateSchedule(ctx context.Context, p *principal.Principal, req ScheduleUpsert) (*ManagedSchedule, error)
@@ -485,7 +477,7 @@ func (m *Manager) resolveTarget(ctx context.Context, p *principal.Principal, tar
 		resolver = tr
 	}
 	boundCredential := invocation.CredentialBindingResolution{}
-	if bindingResolver, ok := m.invoker.(effectiveCredentialBindingResolver); ok {
+	if bindingResolver, ok := m.invoker.(invocation.EffectiveCredentialBindingResolver); ok {
 		boundCredential, err = bindingResolver.ResolveEffectiveCredentialBinding(p, pluginName, connection, instance)
 		if err != nil {
 			return coreworkflow.Target{}, err
@@ -506,15 +498,7 @@ func (m *Manager) resolveTarget(ctx context.Context, p *principal.Principal, tar
 		connection = resolvedConnection
 	}
 	if resolver != nil && sessionInstance == "" {
-		resolveToken := resolver.ResolveToken
-		if boundCredential.HasBinding {
-			if bindingResolver, ok := resolver.(bindingTokenResolver); ok {
-				resolveToken = func(ctx context.Context, p *principal.Principal, providerName, connection, instance string) (context.Context, string, error) {
-					return bindingResolver.ResolveTokenWithBinding(ctx, p, providerName, connection, instance, boundCredential)
-				}
-			}
-		}
-		resolvedCtx, _, err := resolveToken(ctx, p, pluginName, connection, sessionInstance)
+		resolvedCtx, _, err := invocation.ResolveTokenForBinding(ctx, resolver, p, pluginName, connection, sessionInstance, boundCredential)
 		if err != nil {
 			return coreworkflow.Target{}, err
 		}


### PR DESCRIPTION
## Summary

This is the deletive follow-up to `#1213`.

It does **not** change runtime semantics or database shape. It removes the repeated binding-aware token-resolution fallback that `#1213` had to thread through multiple runtime surfaces.

No production DB migration is needed.

## Old Interfaces / Old Pattern

Before this cleanup, several callers repeated the same logic inline:

- `catalog.go`
- `session_tools.go`
- `workflowmanager/manager.go`
- `direct_tool.go`
- `guarded.go`

Repeated pattern:

```go
if boundCredential.HasBinding {
    if bindingResolver, ok := resolver.(interface {
        ResolveTokenWithBinding(...)
    }); ok {
        return bindingResolver.ResolveTokenWithBinding(...)
    }
}
return resolver.ResolveToken(...)
```

And some packages re-declared local interfaces like:

```go
type bindingTokenResolver interface {
    ResolveTokenWithBinding(...)
}

type effectiveCredentialBindingResolver interface {
    ResolveEffectiveCredentialBinding(...)
}
```

## New Interfaces / New Pattern

The binding-aware contract now lives in `invocation` itself:

```go
type EffectiveCredentialBindingResolver interface {
    ResolveEffectiveCredentialBinding(...)
}

type BindingTokenResolver interface {
    ResolveTokenWithBinding(...)
}

func ResolveTokenForBinding(
    ctx context.Context,
    resolver TokenResolver,
    p *principal.Principal,
    providerName, connection, instance string,
    boundCredential CredentialBindingResolution,
) (context.Context, string, error)
```

Callers now use the shared helper:

```go
ctx, token, err := invocation.ResolveTokenForBinding(
    ctx,
    resolver,
    p,
    "slack",
    "workspace",
    "team-a",
    boundCredential,
)
```

Behavior:
- if `boundCredential.HasBinding` and the resolver supports `ResolveTokenWithBinding(...)`, use that path
- otherwise fall back to `ResolveToken(...)`

## Where This Applies

This cleanup switches these paths over to the shared helper:

- session catalog resolution
- MCP session hydration
- workflow target/session-token resolution
- direct MCP tool calls
- guarded invoker forwarding

## Why This Helps

`#1213` made the binding model explicit, but the fallback behavior still lived in several files.

This PR makes the post-`#1213` model smaller and more obvious:
- one shared binding-aware resolver contract
- one shared token-resolution fallback helper
- fewer local interfaces and fewer copies of the same branching logic

## Verification

```bash
cd gestaltd && go test ./internal/invocation ./internal/server ./internal/mcp ./internal/bootstrap
cd gestaltd && golangci-lint run ./internal/invocation ./internal/server ./internal/mcp ./internal/bootstrap ./internal/workflowmanager
```
