### PR TITLE
rename webui to ui and tighten provider docs semantics

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -9,7 +9,7 @@ Thanks for contributing. Before opening a PR, run the checks that match the part
 | `gestaltd/cmd/gestaltd` | Server entrypoint, command handling, and built-in registration. |
 | `gestaltd/core` | Public Go interfaces for auth, datastore, secrets, cache, telemetry, and providers. |
 | `gestaltd/internal` | Bootstrap, config loading, invocation, HTTP and MCP serving, operator lifecycle, and other server internals. |
-| `gestaltd/internal/webui` | Embedded admin UI asset serving and related tests. |
+| `gestaltd/internal/ui` | Embedded admin UI asset serving and related tests. |
 | `gestaltd/deploy` | Docker and Helm deployment assets for the server. |
 | `gestalt` | Rust CLI client. |
 | `sdk/go` | Go SDK. |
@@ -25,7 +25,7 @@ When you update docs, keep them aligned with:
 - config structs in `gestaltd/internal/config`
 - bootstrap wiring in `gestaltd/cmd/gestaltd` and `gestaltd/internal/bootstrap`
 - HTTP and MCP behavior in `gestaltd/internal/server` and `gestaltd/internal/mcp`
-- admin and mounted UI behavior in `gestaltd/internal/webui` and `gestaltd/internal/server/mounted_ui.go`
+- admin and mounted UI behavior in `gestaltd/internal/ui` and `gestaltd/internal/server/mounted_ui.go`
 - deployment assets in `gestaltd/Dockerfile` and `gestaltd/deploy/helm`
 
 The easiest way to make docs drift is to copy previous prose instead of reading the code path that actually implements the feature.

--- a/docs/content/client/_meta.ts
+++ b/docs/content/client/_meta.ts
@@ -1,4 +1,4 @@
 export default {
   cli: "CLI",
-  web: "Web UI",
+  web: "UI",
 };

--- a/docs/content/client/cli/index.mdx
+++ b/docs/content/client/cli/index.mdx
@@ -27,6 +27,8 @@ asIndexPage: true
 | `gestalt plugins disconnect NAME` | Disconnect a plugin, removing stored credentials. |
 | `gestalt plugins invoke NAME [OPERATION]` | Invoke an operation or list operations when omitted. |
 | `gestalt plugins describe NAME OPERATION` | Show one operation's parameter contract. |
+| `gestalt workflows schedules ...` | Create, list, inspect, update, pause, resume, or delete workflow schedules. |
+| `gestalt workflows runs ...` | List, inspect, and cancel workflow runs. |
 | `gestalt tokens create\|list\|revoke` | Manage Gestalt API tokens. |
 
 ## URL resolution
@@ -88,5 +90,56 @@ gestalt plugins invoke slack chat postMessage \
   --connection plugin \
   -p channel=C123 \
   -p text='hello'
+gestalt workflows schedules create \
+  --cron "0 */6 * * *" \
+  --plugin github \
+  --operation issues.list \
+  -p owner=valon-technologies \
+  -p repo=gestalt
+gestalt workflows runs list --plugin github --status failed
 gestalt tokens create --name automation
 ```
+
+## Workflow commands
+
+The workflow CLI currently covers global schedules and workflow runs.
+
+### Schedules
+
+```sh
+gestalt workflows schedules list
+gestalt workflows schedules list --plugin github
+gestalt workflows schedules get <schedule-id>
+gestalt workflows schedules create \
+  --cron "0 */6 * * *" \
+  --timezone America/New_York \
+  --plugin github \
+  --operation issues.list \
+  --connection default \
+  --instance acme-org \
+  -p owner=valon-technologies \
+  -p repo=gestalt \
+  -p state=open
+gestalt workflows schedules update <schedule-id> --cron "0 9 * * 1-5"
+gestalt workflows schedules pause <schedule-id>
+gestalt workflows schedules resume <schedule-id>
+gestalt workflows schedules delete <schedule-id>
+```
+
+Use `-p key=value` for strings and `-p key:=json` for structured values. Use
+`--input-file file.json` to load the target input from JSON instead of flags.
+
+### Runs
+
+```sh
+gestalt workflows runs list
+gestalt workflows runs list --plugin github --status failed
+gestalt workflows runs get <run-id>
+gestalt workflows runs cancel <run-id> --reason "operator requested"
+```
+
+### Event triggers
+
+Event triggers are not exposed as a CLI CRUD surface yet. Define them in the
+server config under top-level `workflows.eventTriggers`. See
+[Workflow](/providers/workflow) for examples.

--- a/docs/content/client/index.mdx
+++ b/docs/content/client/index.mdx
@@ -4,4 +4,4 @@ asIndexPage: true
 
 # Clients
 
-Gestalt exposes two client interfaces for interacting with a running `gestaltd` server: the [CLI](/client/cli) for terminal workflows and automation, and the [Web UI](/client/web) for browser-based access. Both use the same HTTP API and authentication model.
+Gestalt exposes two client interfaces for interacting with a running `gestaltd` server: the [CLI](/client/cli) for terminal workflows and automation, and the [UI](/client/web) for browser-based access. Both use the same HTTP API and authentication model.

--- a/docs/content/client/web.mdx
+++ b/docs/content/client/web.mdx
@@ -1,14 +1,28 @@
-# Web UI
+# UI
 
 Open your Gestalt server's base URL in a browser to access the web client. For a local server, that's `http://localhost:8080`.
 
-The web UI lets you browse plugins, connect to upstream services through OAuth or manual authentication, invoke operations, and manage API tokens. It uses the same HTTP API and authentication model as the CLI.
+The UI lets you browse plugins, connect to upstream services through OAuth or
+manual authentication, invoke operations, and manage API tokens. It uses the
+same HTTP API and authentication model as the CLI.
 
 ## Dashboard
 
 The dashboard shows an overview of the workspace with plugin and API token counts.
 
 ![Dashboard](/images/web-dashboard.png)
+
+## Workflows
+
+When the default web bundle is mounted, the workflow UI is available at
+`/workflows`.
+
+It currently focuses on workflow runs:
+it shows recent run history, supports search and status filtering, lets you
+inspect run details, and lets you cancel pending runs.
+
+Schedules and event triggers are still configured through the workflow HTTP
+API, CLI, or YAML config rather than the default UI.
 
 ## Plugins
 
@@ -24,14 +38,18 @@ Create and revoke API tokens for programmatic access. Each token shows its name,
 
 ## Authentication
 
-When `providers.authentication` points to an interactive authentication provider such as OIDC, the web UI redirects to your identity provider for login. When `providers.authentication` is omitted, every request is anonymous.
+When `providers.authentication` points to an interactive authentication
+provider such as OIDC, the UI redirects to your identity provider for login.
+When `providers.authentication` is omitted, every request is anonymous.
 
 ## Custom UI bundles
 
-Public web UI bundles are configured through the `providers.ui` map.
+Public UI bundles are configured through the `providers.ui` map.
 
 - Omit `providers.ui` to run headless with no public UI bundles.
 - Add `ui.<name>` entries with `source` and explicit `path` fields to mount static SPAs under public URL prefixes.
 - UI bundles use the normal `/api/v1` and `/mcp` surfaces; there is no separate plugin-local browser route surface.
 
-The built-in admin UI at `/admin` remains available regardless. See [Custom Web UIs](/custom-providers/web-uis) for the bundle format and [Releasing](/custom-providers/releasing) for packaging.
+The built-in admin UI at `/admin` remains available regardless. See
+[Custom UI](/custom-providers/ui) for the bundle format and
+[Releasing](/custom-providers/releasing) for packaging.

--- a/docs/content/configuration.mdx
+++ b/docs/content/configuration.mdx
@@ -4,7 +4,7 @@ Gestalt is configured from one or more YAML files. This page covers the key conc
 
 ## Config file structure
 
-A Gestalt config has five top-level keys: `server` for host settings and host-provider selection, `authorization` for shared human/workload access policy, `providers` for named host-scoped providers and web UIs, `workflows` for config-managed schedules and event triggers, and `plugins` for executable integrations and optional plugin-backed UI mounts.
+A Gestalt config has five top-level keys: `server` for host settings and host-provider selection, `authorization` for shared human/workload access policy, `providers` for named host-scoped providers and UIs, `workflows` for config-managed schedules and event triggers, and `plugins` for executable integrations and optional plugin-backed UI mounts.
 
 ```yaml
 authorization:
@@ -50,7 +50,7 @@ providers:
   telemetry:
     <name>: ...            # default: providers.telemetry.default = stdout
 
-  # named web UI bundles
+  # named UI bundles
   ui:
     <name>: ...             # each is a UIEntry
 
@@ -107,7 +107,7 @@ Gestalt has nine core concepts you configure in YAML:
 - **[Authentication.](/providers/authentication)** Platform login for the Gestalt server. Separate from connection authentication, which is per-plugin and per-upstream.
 - **[Secrets.](/providers/secrets)** Resolves structured secret refs in the config at startup. Backed by environment variables, files, or cloud secret managers.
 - **[Workflow.](/providers/workflow)** Global workflow runs, schedules, and event triggers backed by a workflow provider and optional host IndexedDB storage.
-- **[UI.](/providers/web-uis)** Public static UI bundles served under configured path prefixes, either directly from `providers.ui` or through `plugins.<name>.mountPath`. Omit `providers.ui` to run headless.
+- **[UI.](/providers/ui)** Public static UI bundles served under configured path prefixes, either directly from `providers.ui` or through `plugins.<name>.mountPath`. Omit `providers.ui` to run headless.
 
 ## Adding a plugin
 
@@ -312,7 +312,7 @@ providers:
 
 Cloud backends (Google Secret Manager, AWS Secrets Manager, HashiCorp Vault, Azure Key Vault) are also available. See [Secret Providers](/providers/secrets) for the full list.
 
-## Web UI
+## UI
 
 The `providers.ui` map controls public static UI bundles served under explicit non-root paths. Omit it to run headless:
 
@@ -326,15 +326,15 @@ Or point at a custom UI bundle:
 providers:
   ui:
     roadmap:
-      source: https://artifacts.example.com/webui/your-ui/v1.0.0/provider-release.yaml
+      source: https://artifacts.example.com/ui/your-ui/v1.0.0/provider-release.yaml
       path: /create-customer-roadmap-review
 ```
 
-The built-in admin UI at `/admin` is always available regardless of this setting. See [Web UIs](/providers/web-uis) for the bundle format.
+The built-in admin UI at `/admin` is always available regardless of this setting. See [UIs](/providers/ui) for the bundle format.
 
 ## Platform Authentication
 
-The `providers.authentication` map protects the web UI, HTTP API, and `/mcp` endpoint. For local development, omit it:
+The `providers.authentication` map protects the UI, HTTP API, and `/mcp` endpoint. For local development, omit it:
 
 For multi-user deployments, point at a published authentication provider:
 
@@ -467,7 +467,7 @@ workflows:
 Workflow targets are always explicit: `plugin`, `operation`, and optional
 `connection`, `instance`, and `input`. Config-managed schedules and event
 triggers are reconciled into the provider at startup. See
-[Workflow](/providers/workflow) for the full provider model.
+[Workflow](/providers/workflow) for the user-facing and provider model.
 
 ## Telemetry and audit
 

--- a/docs/content/custom-providers/_meta.ts
+++ b/docs/content/custom-providers/_meta.ts
@@ -1,12 +1,12 @@
 export default {
-  plugins: "Plugins",
+  plugins: "Plugin",
   authentication: "Authentication",
   authorization: "Authorization",
   cache: "Cache",
   indexeddb: "IndexedDB",
   s3: "S3",
-  secrets: "Secrets",
+  secrets: "Secret",
   workflow: "Workflow",
-  "web-uis": "Web UIs",
+  ui: "UI",
   releasing: "Releasing",
 };

--- a/docs/content/custom-providers/authentication.mdx
+++ b/docs/content/custom-providers/authentication.mdx
@@ -5,7 +5,7 @@ import { Tabs } from "nextra/components";
 This page covers building custom authentication providers. If you only need to
 configure platform login for a deployment, use [Providers > Authentication](/providers/authentication).
 
-Authentication providers handle platform login. When a user visits the Gestalt web UI or hits the HTTP API without a valid session, the authentication provider drives the login flow, validates the callback, and returns an authenticated identity. Gestalt then issues a session cookie and manages session lifetime on its own.
+Authentication providers handle platform login. When a user visits the Gestalt UI or hits the HTTP API without a valid session, the authentication provider drives the login flow, validates the callback, and returns an authenticated identity. Gestalt then issues a session cookie and manages session lifetime on its own.
 
 Beyond the core login flow, an authentication provider can optionally validate externally issued tokens (so API clients can present a bearer token directly instead of going through the browser) and control session TTL.
 

--- a/docs/content/custom-providers/index.mdx
+++ b/docs/content/custom-providers/index.mdx
@@ -12,7 +12,7 @@ deployment, start with [Providers](/providers).
 
 - Implementing executable or declarative plugin providers
 - Building custom authentication, authorization, cache, IndexedDB, S3, secrets,
-  workflow, and web UI providers
+  workflow, and UI providers
 - Testing providers from local source with `source: ./manifest.yaml`
 - Packaging releases with `gestaltd provider release`
 
@@ -26,14 +26,14 @@ providers:
   `provider-release.yaml` metadata URL.
 - Executable providers start as child processes and connect back to the host
   over gRPC on a temporary Unix socket.
-- Web UI providers are static asset bundles served under configured public path
+- UI providers are static asset bundles served under configured public path
   prefixes.
 - Published packages are prepared with `gestaltd init` and referenced from
   `gestalt.lock.json`.
 
 ## Choose a starting point
 
-- [Plugins](/custom-providers/plugins): custom tool providers, executable
+- [Plugin](/custom-providers/plugins): custom tool providers, executable
   operations, declarative surfaces, and hybrid catalogs
 - [Authentication](/custom-providers/authentication): platform login providers and optional bearer
   token validation
@@ -44,12 +44,12 @@ providers:
   state
 - [S3](/custom-providers/s3): custom object-store backends for executable
   plugins
-- [Secrets](/custom-providers/secrets): secret managers for structured secret
+- [Secret](/custom-providers/secrets): secret managers for structured secret
   refs
   resolution
 - [Workflow](/custom-providers/workflow): workflow run, schedule, and
   event-trigger providers
-- [Web UIs](/custom-providers/web-uis): public UI bundles served under
+- [UI](/custom-providers/ui): public UI bundles served under
   configured path prefixes
 - [Releasing](/custom-providers/releasing): packaging, platform builds, and
   release archives

--- a/docs/content/custom-providers/plugins.mdx
+++ b/docs/content/custom-providers/plugins.mdx
@@ -1,10 +1,10 @@
 import { Tabs } from 'nextra/components'
 
-# Plugins
+# Plugin
 
 This page covers building custom plugin providers. If you only need to
 configure a published plugin in a Gestalt deployment, use
-[Providers > Plugins](/providers/plugins).
+[Providers > Plugin](/providers/plugins).
 
 Plugins are one provider kind. Their manifests use a top-level `spec:` block, and deployments reference them under `plugins`. A plugin can define operations as executable code (handled by the provider process), as passthrough surfaces (REST, OpenAPI, GraphQL, or MCP endpoints forwarded by the host), or both.
 

--- a/docs/content/custom-providers/releasing.mdx
+++ b/docs/content/custom-providers/releasing.mdx
@@ -12,7 +12,7 @@ the executable artifacts for packaged providers, and optional static assets.
 
 ## What can be released
 
-Gestalt uses the same release system for executable provider packages, authentication and datastore component packages, and packaged web UI bundles. Every package is described by a provider manifest file: `manifest.yaml`, `manifest.yml`, or `manifest.json`.
+Gestalt uses the same release system for executable provider packages, authentication and datastore component packages, and packaged UI bundles. Every package is described by a provider manifest file: `manifest.yaml`, `manifest.yml`, or `manifest.json`.
 
 ## Source manifests vs release manifests
 
@@ -128,12 +128,12 @@ packaging.
 ### Source release builds
 
 Source manifests may optionally define a `release.build` command. Gestalt runs
-it before source-manifest preparation, which lets web UI packages generate
+it before source-manifest preparation, which lets UI packages generate
 static assets and lets provider/authentication/datastore packages generate support files
 such as config schemas before packaging.
 
 ```yaml
-kind: webui
+kind: ui
 source: github.com/acme/plugins/gestalt-ui
 version: 1.2.0
 release:
@@ -172,7 +172,7 @@ artifacts:
 UI packages use the same manifest system:
 
 ```yaml
-kind: webui
+kind: ui
 source: github.com/acme/plugins/web/default
 version: 1.2.0
 spec:
@@ -248,7 +248,7 @@ UI bundles use the same pattern under `providers.ui.<name>`:
 providers:
   ui:
     dashboard:
-      source: https://artifacts.example.com/webui/default/v1.2.0/provider-release.yaml
+      source: https://artifacts.example.com/ui/default/v1.2.0/provider-release.yaml
       path: /dashboard
       config:
         brand_name: Acme

--- a/docs/content/custom-providers/secrets.mdx
+++ b/docs/content/custom-providers/secrets.mdx
@@ -1,10 +1,10 @@
 import { Tabs } from 'nextra/components'
 
-# Secrets
+# Secret
 
 This page covers building custom secrets providers. If you only need to
 configure secret resolution for a deployment, use
-[Providers > Secrets](/providers/secrets).
+[Providers > Secret](/providers/secrets).
 
 Secrets providers resolve named secrets at server startup. When the Gestalt config references a structured secret ref, the secrets provider fetches the value from whatever backend it wraps (a cloud key vault, a file on disk, an environment variable, etc.) and injects it into the config before any other component starts.
 

--- a/docs/content/custom-providers/ui.mdx
+++ b/docs/content/custom-providers/ui.mdx
@@ -1,27 +1,30 @@
 import { Tabs } from 'nextra/components'
 
-# Web UIs
+# UI
 
-This page covers building custom web UI bundles. If you only need to configure
-which UI a deployment serves, use [Providers > Web UIs](/providers/web-uis).
+This page covers building custom UI bundles. If you only need to configure
+which UI a deployment serves, use [Providers > UI](/providers/ui).
 
-Web UI bundles are static asset packages. Gestalt serves them under the path
+UI bundles are static asset packages. Gestalt serves them under the path
 prefixes configured in `providers.ui.<name>.path`. The built-in admin UI at
 `/admin` remains available regardless of whether a custom UI bundle is
 configured.
 
-A UI bundle is not a plugin in the executable sense. It contains no server-side code. Gestalt simply serves the static files from the asset root directory. The bundle talks to Gestalt through the same HTTP API and MCP endpoints that any other client would use.
+A UI bundle is not a plugin in the executable sense. It contains no server-side
+code. Gestalt simply serves the static files from the asset root directory. The
+bundle talks to Gestalt through the same HTTP API and MCP endpoints that any
+other client would use.
 
 ## Manifest
 
-The Default Web UI manifest declares `spec.assetRoot`, which points to the directory containing the built static assets. The source field identifies the provider in the registry.
+The Default UI manifest declares `spec.assetRoot`, which points to the directory containing the built static assets. The source field identifies the provider in the registry.
 
 ```yaml
-kind: webui
+kind: ui
 source: github.com/valon-technologies/gestalt-providers/web/default
 version: 0.0.1
-displayName: Default Web UI
-description: Default Gestalt web UI bundle.
+displayName: Default UI
+description: Default Gestalt UI bundle.
 release:
   build:
     command:
@@ -48,10 +51,10 @@ declare non-empty `allowedRoles`.
 
 If your UI needs a build step before packaging, use `release.build` to run it automatically during `gestaltd provider release`. This runs before source-manifest preparation, so the built assets are included in the release archive.
 
-The Default Web UI uses a shell script that runs `npm ci && npm run build` to produce the static output:
+The Default UI uses a shell script that runs `npm ci && npm run build` to produce the static output:
 
 ```yaml
-kind: webui
+kind: ui
 source: github.com/valon-technologies/gestalt-providers/web/default
 version: 0.0.1
 release:
@@ -86,7 +89,7 @@ For production, reference a published release metadata URL:
 providers:
   ui:
     dashboard:
-      source: https://artifacts.example.com/webui/default/v0.0.1/provider-release.yaml
+      source: https://artifacts.example.com/ui/default/v0.0.1/provider-release.yaml
       path: /dashboard
       authorizationPolicy: dashboard_users
 ```

--- a/docs/content/getting-started.mdx
+++ b/docs/content/getting-started.mdx
@@ -16,7 +16,7 @@ Run `gestaltd` with no arguments:
 gestaltd
 ```
 
-When no config file exists, `gestaltd` generates one at `~/.gestaltd/config.yaml` and starts immediately with SQLite storage via the [RelationalDB](https://github.com/valon-technologies/gestalt-providers/tree/main/indexeddb/relationaldb) implementation of the [IndexedDB provider](/providers/indexeddb), the [default web UI](https://github.com/valon-technologies/gestalt-providers/tree/main/web/default) mounted at `/`, no authentication, and an [HTTPBin](https://github.com/valon-technologies/gestalt-providers/tree/main/plugins/httpbin) implementation of the [plugin provider](/providers/plugins) on port 8080.
+When no config file exists, `gestaltd` generates one at `~/.gestaltd/config.yaml` and starts immediately with SQLite storage via the [RelationalDB](https://github.com/valon-technologies/gestalt-providers/tree/main/indexeddb/relationaldb) implementation of the [IndexedDB provider](/providers/indexeddb), the [default UI](https://github.com/valon-technologies/gestalt-providers/tree/main/web/default) mounted at `/`, no authentication, and an [HTTPBin](https://github.com/valon-technologies/gestalt-providers/tree/main/plugins/httpbin) implementation of the [plugin provider](/providers/plugins) on port 8080.
 
 ```
 2026/04/10 10:00:00 INFO generated default config path=~/.gestaltd/config.yaml
@@ -156,7 +156,7 @@ Gestalt exposes all MCP-enabled plugins at a single endpoint: `http://localhost:
   </Tabs.Tab>
 </Tabs>
 
-Once connected, your agent can call any operation exposed by the server. The same auth model applies: when plugins require credentials, users connect through the Gestalt web UI or CLI before the agent can invoke those tools.
+Once connected, your agent can call any operation exposed by the server. The same auth model applies: when plugins require credentials, users connect through the Gestalt UI or CLI before the agent can invoke those tools.
 
 ## Next steps
 

--- a/docs/content/index.mdx
+++ b/docs/content/index.mdx
@@ -27,8 +27,8 @@ Gestalt handles this so individual agents and applications don't have to. A sing
 
 - Credentials and connection data are encrypted at rest, on infrastructure you control. See [Security](/security).
 - A single YAML config declaratively defines which tools to expose, how users authenticate, and how credentials are managed. See [Configuration](/configuration).
-- The same operations are available over MCP, HTTP, CLI, and optional mounted web UIs for cloud agents, local coding assistants, and human operators. See [HTTP API](/reference/http-api).
-- Authentication backends, datastores, secret managers, and the web UI are replaceable provider packages. Use the first-party providers or write your own in Go, Python, Rust, or TypeScript. See [Built-in Providers](/reference/built-in-providers).
+- The same operations are available over MCP, HTTP, CLI, and optional mounted UIs for cloud agents, local coding assistants, and human operators. See [HTTP API](/reference/http-api).
+- Authentication backends, datastores, secret managers, and the UI are replaceable provider packages. Use the first-party providers or write your own in Go, Python, Rust, or TypeScript. See [Built-in Providers](/reference/built-in-providers).
 - Deploy on any infrastructure you control with Docker, Helm, or bare containers. See [Deploy](/deploy).
 
 ## What Gestalt is not
@@ -45,6 +45,9 @@ Gestalt does not replace your existing APIs. It sits between agents and upstream
   </Cards.Card>
   <Cards.Card title="Configuration" href="/configuration">
     The config model, plugin setup, authentication, connections, and MCP.
+  </Cards.Card>
+  <Cards.Card title="Workflows" href="/providers/workflow">
+    Schedules, runs, event triggers, and the current workflow API surface.
   </Cards.Card>
   <Cards.Card title="Providers" href="/providers">
     Plugins, authentication backends, datastores, and custom UIs as provider packages.

--- a/docs/content/providers/_meta.ts
+++ b/docs/content/providers/_meta.ts
@@ -3,10 +3,10 @@ export default {
   authorization: "Authorization",
   cache: "Cache",
   indexeddb: "IndexedDB",
-  plugins: "Plugins",
+  plugins: "Plugin",
   s3: "S3",
-  secrets: "Secrets",
-  "web-uis": "Web UIs",
+  secrets: "Secret",
+  ui: "UI",
   workflow: "Workflow",
   releasing: {
     display: "hidden",

--- a/docs/content/providers/authentication.mdx
+++ b/docs/content/providers/authentication.mdx
@@ -20,13 +20,15 @@ Some authentication providers also support:
 
 ## First-Party Authentication Providers
 
-First-party authentication providers live under
+Gestalt includes one built-in authentication provider, `local`, for
+single-user development. Published first-party authentication providers live
+under
 [`valon-technologies/gestalt-providers/auth`](https://github.com/valon-technologies/gestalt-providers/tree/main/auth).
 
 | Provider | Use case |
 | --- | --- |
 | `local` | Single-user development on a trusted machine |
-| [`valon-technologies/gestalt-providers/auth/oidc`](https://github.com/valon-technologies/gestalt-providers/tree/main/auth/oidc) | Generic OpenID Connect providers such as Google, Okta, Auth0, Azure AD, or Keycloak |
+| [`github.com/valon-technologies/gestalt-providers/auth/oidc`](https://github.com/valon-technologies/gestalt-providers/tree/main/auth/oidc) | Generic OpenID Connect providers such as Google, Okta, Auth0, Azure AD, or Keycloak |
 
 ## Configuring `providers.authentication`
 

--- a/docs/content/providers/authorization.mdx
+++ b/docs/content/providers/authorization.mdx
@@ -21,14 +21,48 @@ APIs require an authorization provider. If you omit `providers.authorization`,
 Gestalt still evaluates static policy members from config, but there is no
 provider-backed relationship storage or dynamic human-grant control plane.
 
+## Product authorization semantics
+
+At the product level, authorization is about subjects and runtime surfaces.
+Gestalt resolves each request to a canonical subject such as `user:<id>`,
+`workload:<id>`, or a system subject, then asks whether that subject may access
+the thing they are trying to use. Static memberships under
+`authorization.policies` are always available. When you configure an
+authorization provider, Gestalt adds dynamic relationship storage on top so
+those decisions can change without editing YAML.
+
+This is separate from authentication. Authentication answers who the caller is.
+Authorization answers what that caller may do once their subject is known.
+
+### Plugin invocation
+
+Plugin authorization happens at request time. Gestalt checks whether the
+calling subject may access the plugin or operation before it invokes the
+target. The subject's upstream connection is also scoped to that same subject,
+so access is both identity-aware and credential-aware.
+
+### Workflow execution
+
+Workflow authorization happens twice. Gestalt checks access when a user creates
+a schedule, then checks again when that schedule or trigger fires later. User
+owned workflows keep the creating subject plus a permission ceiling for delayed
+execution. Config-managed workflows use the system config subject instead.
+
+### UI routes
+
+Mounted UI bundles can bind an `authorizationPolicy`, and their manifests can
+declare route-level `allowedRoles`. Gestalt resolves the caller's subject,
+derives their role for the bound policy, and checks that role before serving
+the matched route. The built-in admin UI uses the same model.
+
 ## First-party authorization providers
 
 First-party authorization providers live under
 [`valon-technologies/gestalt-providers/authorization`](https://github.com/valon-technologies/gestalt-providers/tree/main/authorization).
 
-| Provider | Repository | Package path | Use case |
-| --- | --- | --- | --- |
-| IndexedDB Authorization | [`authorization/indexeddb`](https://github.com/valon-technologies/gestalt-providers/tree/main/authorization/indexeddb) | `github.com/valon-technologies/gestalt-providers/authorization/indexeddb` | Stores authorization models and relationships in a host IndexedDB provider |
+| Provider | Use case |
+| --- | --- |
+| [`github.com/valon-technologies/gestalt-providers/authorization/indexeddb`](https://github.com/valon-technologies/gestalt-providers/tree/main/authorization/indexeddb) | Stores authorization models and relationships in a host IndexedDB provider |
 
 ## Configuring `providers.authorization`
 
@@ -57,12 +91,11 @@ IndexedDB provider and stores authorization models plus relationships there.
 
 ## Operational notes
 
-- `server.providers.authorization` selects the host authorization provider.
-- If more than one entry exists under `providers.authorization`, set
-  `server.providers.authorization` explicitly or mark one entry `default: true`.
-- Built-in admin authorization membership and inspection APIs use the selected
-  provider.
-- Static policy members still take precedence over dynamic grants.
+`server.providers.authorization` selects the host authorization provider. If
+more than one entry exists under `providers.authorization`, set
+`server.providers.authorization` explicitly or mark one entry `default: true`.
+Built-in admin authorization membership and inspection APIs use the selected
+provider. Static policy members still take precedence over dynamic grants.
 
 ## Building your own authorization provider
 
@@ -72,7 +105,10 @@ model lifecycle now live under
 
 ## What to read next
 
-- [Configuration](/configuration): server and provider config structure
-- [Config File](/reference/config-file): full `providers.authorization` reference
-- [Built-in Providers](/reference/built-in-providers): first-party authorization provider reference
-- [Custom Authorization Providers](/custom-providers/authorization): advanced authoring docs
+For the full server and provider config structure, read
+[Configuration](/configuration). For the exact `providers.authorization`
+reference, continue to [Config File](/reference/config-file). If you want to
+see how these semantics apply to concrete surfaces, read
+[Plugin](/providers/plugins), [Workflow](/providers/workflow), and
+[UI](/providers/ui). For provider implementation details, see
+[Custom Authorization Providers](/custom-providers/authorization).

--- a/docs/content/providers/cache.mdx
+++ b/docs/content/providers/cache.mdx
@@ -1,3 +1,5 @@
+import { Tabs } from 'nextra/components'
+
 # Cache
 
 Cache providers are plugin-bound utilities for short-lived key/value state.
@@ -7,7 +9,28 @@ They are configured under `providers.cache` and attached to plugins with
 Unlike IndexedDB, cache providers are not selected through `server.providers`.
 They are only exposed to plugins that request them.
 
-## Configuration
+## How cache providers work
+
+Each entry under `providers.cache` defines a named cache backend. Plugins opt
+into those backends with `plugins.<name>.cache`, which is just a list of named
+bindings. Every binding name must already exist under `providers.cache`, and
+duplicate bindings are rejected during config validation.
+
+In plugin code you usually open a cache by binding name, such as `session` or
+`rate_limit`. If a plugin binds exactly one cache, the SDKs also support the
+default unnamed cache handle, but using the explicit binding name is usually
+clearer.
+
+## First-party cache providers
+
+First-party cache providers live under
+[`valon-technologies/gestalt-providers/cache`](https://github.com/valon-technologies/gestalt-providers/tree/main/cache).
+
+| Provider | Use case |
+| --- | --- |
+| [`github.com/valon-technologies/gestalt-providers/cache/valkey`](https://github.com/valon-technologies/gestalt-providers/tree/main/cache/valkey) | Valkey or Redis-compatible cache backend for short-lived plugin state |
+
+## Configuring `providers.cache`
 
 ```yaml
 providers:
@@ -32,77 +55,111 @@ plugins:
       - rate_limit
 ```
 
-## How bindings work
+This example binds two caches into the `search` plugin. Both bindings use the
+same provider package, but they point at different logical databases. That is a
+common pattern for keeping session and rate-limit state separate without
+introducing a second cache technology.
 
-- `plugins.<name>.cache` is a list of named cache bindings.
-- Cache names must exist under `providers.cache`.
-- Duplicate cache names are rejected during config validation.
-- With one binding, the host sets both `GESTALT_CACHE_SOCKET` and the named env var.
-- With multiple bindings, the host sets only the named env vars:
-  `GESTALT_CACHE_SOCKET_<NAME>`.
+## Using `Cache` from a plugin
 
-For a binding named `session`, the SDK env var is:
+<Tabs items={['Go', 'Python', 'Rust', 'TypeScript']}>
+  <Tabs.Tab>
+    ```go
+    import (
+        "context"
+        "log"
+        "time"
 
-```text
-GESTALT_CACHE_SOCKET_SESSION
-```
+        gestalt "github.com/valon-technologies/gestalt/sdk/go"
+    )
 
-Names are normalized to uppercase with non-alphanumeric characters replaced by `_`.
+    ctx := context.Background()
 
-## SDK use
+    cache, err := gestalt.Cache("session")
+    if err != nil {
+        log.Fatal(err)
+    }
+    defer cache.Close()
 
-Go:
+    if err := cache.Set(ctx, "user:1", []byte("alpha"), gestalt.CacheSetOptions{
+        TTL: 5 * time.Minute,
+    }); err != nil {
+        log.Fatal(err)
+    }
 
-```go
-cache, err := gestalt.Cache("session")
-if err != nil {
-    panic(err)
-}
-defer cache.Close()
+    value, found, err := cache.Get(ctx, "user:1")
+    if err != nil {
+        log.Fatal(err)
+    }
+    _ = value
+    _ = found
+    ```
+  </Tabs.Tab>
+  <Tabs.Tab>
+    ```python
+    import datetime as dt
+    import gestalt
 
-value, found, err := cache.Get(ctx, "user:1")
-if err != nil {
-    panic(err)
-}
-_ = value
-_ = found
-```
+    cache = gestalt.Cache("session")
+    cache.set("user:1", b"alpha", ttl=dt.timedelta(minutes=5))
+    value = cache.get("user:1") or b""
+    cache.close()
+    ```
+  </Tabs.Tab>
+  <Tabs.Tab>
+    ```rust
+    use std::time::Duration;
 
-Python:
+    use gestalt::{Cache, CacheSetOptions};
 
-```python
-import datetime as dt
-import gestalt
+    let mut cache = Cache::connect_named("session").await?;
+    cache
+        .set(
+            "user:1",
+            b"alpha",
+            CacheSetOptions {
+                ttl: Some(Duration::from_secs(5 * 60)),
+            },
+        )
+        .await?;
+    let value = cache.get("user:1").await?;
+    ```
+  </Tabs.Tab>
+  <Tabs.Tab>
+    ```ts
+    import { Cache } from "@valon-technologies/gestalt";
 
-cache = gestalt.Cache("session")
-cache.set("user:1", b"alpha", ttl=dt.timedelta(minutes=5))
-value = cache.get("user:1")
-cache.close()
-```
+    const cache = new Cache("session");
+    await cache.set("user:1", new TextEncoder().encode("alpha"), {
+      ttlMs: 5 * 60 * 1000,
+    });
+    const value = await cache.get("user:1");
+    ```
+  </Tabs.Tab>
+</Tabs>
 
-Rust:
+The host resolves the configured cache bindings and exposes them to the plugin
+through the language SDK. Plugin code does not choose raw Redis or Valkey
+endpoints directly at runtime. It just opens the bound cache by name.
 
-```rust
-let mut cache = gestalt::Cache::connect_named("session").await?;
-let value = cache.get("user:1").await?;
-```
+## Operational notes
 
-TypeScript:
+Cache providers are best for short-lived, non-authoritative state such as
+sessions, idempotency helpers, and rate-limit counters. They remain
+plugin-bound, so they do not participate in the host-wide `server.providers`
+selection model. The exact `config` block depends on the selected provider
+package. For the first-party `cache/valkey` provider, that usually means an
+address plus any backend-specific connection settings.
 
-```ts
-import { Cache } from "@valon-technologies/gestalt";
-
-const cache = new Cache("session");
-const value = await cache.get("user:1");
-```
-
-## First-party providers
-
-First-party cache backends can live under
-`github.com/valon-technologies/gestalt-providers/cache/...`.
-The exact package set depends on what has been published so far.
-
-## Custom implementations
+## Building your own cache provider
 
 For manifests, SDK authoring surfaces, and release flow, see
+[Custom Providers > Cache](/custom-providers/cache).
+
+## What to read next
+
+If you want the full config reference, read
+[Config File](/reference/config-file#providerscache). For plugin-side binding
+behavior in the broader config model, see [Configuration](/configuration). If
+you need implementation details, continue to
 [Custom Providers > Cache](/custom-providers/cache).

--- a/docs/content/providers/index.mdx
+++ b/docs/content/providers/index.mdx
@@ -7,7 +7,7 @@ asIndexPage: true
 Gestalt loads most integration and platform surfaces as providers instead of
 compiling them into `gestaltd`. Plugins, authentication backends, IndexedDB backends,
 authorization backends, workflow backends, cache backends, S3 object stores,
-external secret managers, and public web UIs all use the same provider model:
+external secret managers, and public UIs all use the same provider model:
 you reference a package in config, the host resolves it, validates it, and
 starts it with the permissions and request context it needs.
 
@@ -23,7 +23,7 @@ starts it with the permissions and request context it needs.
 | `s3` | S3-compatible object stores mounted into plugins | `providers.s3.<name>` |
 | `secrets` | Secret managers that resolve structured secret refs | `providers.secrets.<name>` |
 | `workflow` | Workflow run, schedule, and event-trigger backends | `providers.workflow.<name>` plus top-level `workflows.*` |
-| `webui` | Public UI bundles served under configured path prefixes | `providers.ui` |
+| `ui` | Public UI bundles served under configured path prefixes | `providers.ui` |
 
 ## How providers work
 
@@ -36,7 +36,7 @@ starts it with the permissions and request context it needs.
   `source.githubRelease`, needs authenticated metadata or archive fetches.
 - Executable providers run as child processes and connect back to the host over
   gRPC on a temporary Unix socket.
-- Web UI providers are static asset bundles rather than executable processes.
+- UI providers are static asset bundles rather than executable processes.
 - `allowedHosts` and `server.egress` declare outbound policy for executable
   providers, with complete enforcement depending on the sandbox runtime in use.
 - Two simple secret managers, `env` and `file`, remain built into
@@ -50,15 +50,15 @@ The repository is organized by provider type:
 
 | Type | Repository path | Typical config key |
 | --- | --- | --- |
-| Plugins | [`plugins/`](https://github.com/valon-technologies/gestalt-providers/tree/main/plugins) | `plugins.<name>` |
+| Plugin | [`plugins/`](https://github.com/valon-technologies/gestalt-providers/tree/main/plugins) | `plugins.<name>` |
 | Authentication | [`auth/`](https://github.com/valon-technologies/gestalt-providers/tree/main/auth) | `providers.authentication.<name>` |
 | Authorization | [`authorization/`](https://github.com/valon-technologies/gestalt-providers/tree/main/authorization) | `providers.authorization.<name>` |
 | Cache | [`cache/`](https://github.com/valon-technologies/gestalt-providers/tree/main/cache) | `providers.cache.<name>` |
 | IndexedDB | [`indexeddb/`](https://github.com/valon-technologies/gestalt-providers/tree/main/indexeddb) | `providers.indexeddb.<name>` |
 | S3 | [`s3/`](https://github.com/valon-technologies/gestalt-providers/tree/main/s3) | `providers.s3.<name>` |
-| Secrets | [`secrets/`](https://github.com/valon-technologies/gestalt-providers/tree/main/secrets) | `providers.secrets.<name>` |
+| Secret | [`secrets/`](https://github.com/valon-technologies/gestalt-providers/tree/main/secrets) | `providers.secrets.<name>` |
 | Workflow | [`workflow/`](https://github.com/valon-technologies/gestalt-providers/tree/main/workflow) | `providers.workflow.<name>` |
-| Web UI bundles | [`web/`](https://github.com/valon-technologies/gestalt-providers/tree/main/web) | `providers.ui` |
+| UI | [`web/`](https://github.com/valon-technologies/gestalt-providers/tree/main/web) | `providers.ui` |
 
 ## Using providers
 
@@ -131,9 +131,9 @@ release workflow now lives under [Custom Providers](/custom-providers).
 - [Authorization](/providers/authorization): human authorization providers
 - [Cache](/providers/cache): plugin-bound cache backends
 - [IndexedDB](/providers/indexeddb): storage backends
-- [Plugins](/providers/plugins): choosing and configuring plugin providers
+- [Plugin](/providers/plugins): choosing and configuring plugin providers
 - [S3](/providers/s3): S3-compatible object store providers
-- [Secrets](/providers/secrets): built-in and external secret managers
-- [Web UIs](/providers/web-uis): public UI bundles
+- [Secret](/providers/secrets): built-in and external secret managers
+- [UI](/providers/ui): public UI bundles
 - [Workflow](/providers/workflow): workflow run, schedule, and event-trigger backends
 - [Custom Providers](/custom-providers): advanced implementation and release docs

--- a/docs/content/providers/indexeddb.mdx
+++ b/docs/content/providers/indexeddb.mdx
@@ -1,3 +1,5 @@
+import { Tabs } from 'nextra/components'
+
 # IndexedDB
 
 IndexedDB providers back Gestalt's persistent state layer. The host uses them
@@ -21,22 +23,20 @@ fall back to `<db>_` transport-level store prefixes. Plugins may also set
 `plugins.<name>.indexeddb.objectStores` to allowlist logical stores such as
 `tasks`.
 
-## How plugins use IndexedDB in code
+## Using IndexedDB from a plugin
 
 Executable plugins do not choose raw database DSNs or relational schemas at
 runtime. They receive one IndexedDB SDK socket from the host, and the host
 decides what that socket points to from config.
 
-- In plugin code, use `new IndexedDB()` to open the plugin's configured
-  IndexedDB connection.
-- `plugins.<name>.indexeddb.provider` selects which named
-  `providers.indexeddb` entry backs that socket.
-- `plugins.<name>.indexeddb.db` selects the plugin-visible database name used
-  for backend scoping. On schema-capable backends such as RelationalDB, that
-  becomes the backend schema name.
-- If the plugin omits `plugins.<name>.indexeddb`, it inherits the
-  host-selected IndexedDB provider and uses the plugin key as the default `db`
-  name.
+In plugin code, use the IndexedDB client from the language SDK. The
+`plugins.<name>.indexeddb.provider` field selects which named
+`providers.indexeddb` entry backs that client, and `plugins.<name>.indexeddb.db`
+selects the plugin-visible database name used for backend scoping. On
+schema-capable backends such as RelationalDB, that becomes the backend schema
+name. If the plugin omits `plugins.<name>.indexeddb`, it inherits the
+host-selected IndexedDB provider and uses the plugin key as the default `db`
+name.
 
 For example:
 
@@ -66,25 +66,99 @@ plugins:
 
 Then inside the plugin:
 
-```ts
-const db = new IndexedDB();
-```
+<Tabs items={['Go', 'Python', 'Rust', 'TypeScript']}>
+  <Tabs.Tab>
+    ```go
+    import (
+        "context"
+        "log"
 
-The TypeScript SDK also accepts `new IndexedDB("name")`, which looks for a
-named `GESTALT_INDEXEDDB_SOCKET_<NAME>` environment variable. Standard plugin
-config does not expose multiple IndexedDB sockets, so normal plugins should
-select provider and `db` in YAML and use `new IndexedDB()`.
+        gestalt "github.com/valon-technologies/gestalt/sdk/go"
+    )
+
+    ctx := context.Background()
+
+    db, err := gestalt.IndexedDB()
+    if err != nil {
+        log.Fatal(err)
+    }
+    defer db.Close()
+
+    tasks := db.ObjectStore("tasks")
+    if err := tasks.Put(ctx, gestalt.Record{
+        "id":    "task-1",
+        "title": "Ship docs",
+    }); err != nil {
+        log.Fatal(err)
+    }
+
+    record, err := tasks.Get(ctx, "task-1")
+    if err != nil {
+        log.Fatal(err)
+    }
+    _ = record
+    ```
+  </Tabs.Tab>
+  <Tabs.Tab>
+    ```python
+    import gestalt
+
+    db = gestalt.IndexedDB()
+    tasks = db.object_store("tasks")
+
+    tasks.put({"id": "task-1", "title": "Ship docs"})
+    record = tasks.get("task-1")
+
+    db.close()
+    ```
+  </Tabs.Tab>
+  <Tabs.Tab>
+    ```rust
+    use std::collections::BTreeMap;
+
+    use gestalt::IndexedDB;
+    use serde_json::json;
+
+    let db = IndexedDB::connect().await?;
+    let mut tasks = db.object_store("tasks");
+
+    tasks
+        .put(BTreeMap::from([
+            ("id".to_string(), json!("task-1")),
+            ("title".to_string(), json!("Ship docs")),
+        ]))
+        .await?;
+
+    let record = tasks.get("task-1").await?;
+    ```
+  </Tabs.Tab>
+  <Tabs.Tab>
+    ```ts
+    import { IndexedDB } from "@valon-technologies/gestalt";
+
+    const db = new IndexedDB();
+    const tasks = db.objectStore("tasks");
+
+    await tasks.put({ id: "task-1", title: "Ship docs" });
+    const record = await tasks.get("task-1");
+    ```
+  </Tabs.Tab>
+</Tabs>
+
+Normal plugin config gives the plugin one effective IndexedDB binding. If you
+need a different backing store or a different scoped database name, choose that
+in YAML instead of encoding transport details in plugin code.
 
 ## First-party IndexedDB providers
 
 First-party storage backends live under
 [`valon-technologies/gestalt-providers/indexeddb`](https://github.com/valon-technologies/gestalt-providers/tree/main/indexeddb).
 
-| Provider | Repository | Package path | Notes |
-| --- | --- | --- | --- |
-| RelationalDB | [`indexeddb/relationaldb`](https://github.com/valon-technologies/gestalt-providers/tree/main/indexeddb/relationaldb) | `github.com/valon-technologies/gestalt-providers/indexeddb/relationaldb` | Supports PostgreSQL, MySQL, SQLite, and SQL Server through a `dsn` config value |
-| DynamoDB | [`indexeddb/dynamodb`](https://github.com/valon-technologies/gestalt-providers/tree/main/indexeddb/dynamodb) | `github.com/valon-technologies/gestalt-providers/indexeddb/dynamodb` | Uses Amazon DynamoDB with `table`, `region`, and optional `endpoint` config |
-| MongoDB | [`indexeddb/mongodb`](https://github.com/valon-technologies/gestalt-providers/tree/main/indexeddb/mongodb) | `github.com/valon-technologies/gestalt-providers/indexeddb/mongodb` | Uses MongoDB with `uri` and optional `database` config |
+| Provider | Notes |
+| --- | --- |
+| [`github.com/valon-technologies/gestalt-providers/indexeddb/relationaldb`](https://github.com/valon-technologies/gestalt-providers/tree/main/indexeddb/relationaldb) | Supports PostgreSQL, MySQL, SQLite, and SQL Server through a `dsn` config value |
+| [`github.com/valon-technologies/gestalt-providers/indexeddb/dynamodb`](https://github.com/valon-technologies/gestalt-providers/tree/main/indexeddb/dynamodb) | Uses Amazon DynamoDB with `table`, `region`, and optional `endpoint` config |
+| [`github.com/valon-technologies/gestalt-providers/indexeddb/mongodb`](https://github.com/valon-technologies/gestalt-providers/tree/main/indexeddb/mongodb) | Uses MongoDB with `uri` and optional `database` config |
 
 ## Configuring storage
 
@@ -146,11 +220,11 @@ providers:
 
 ## Operational notes
 
-- Gestalt needs exactly one active datastore selected by `server.providers.indexeddb`.
-- Published datastore packages can be prepared with `gestaltd init` just like
-  other provider types.
-- Plugins still go through the host's request and auth model; they do not talk
-  to the datastore provider directly.
+Gestalt needs exactly one active datastore selected by
+`server.providers.indexeddb`. Published datastore packages can be prepared with
+`gestaltd init` just like other provider types. Plugins still go through the
+host's request and auth model, so they do not talk to the datastore provider
+directly.
 
 ## Building your own datastore provider
 
@@ -160,6 +234,8 @@ release flow now live under
 
 ## What to read next
 
-- [Configuration](/configuration): server and provider config structure
-- [Built-in Providers](/reference/built-in-providers): first-party datastore reference
-- [Custom IndexedDB Providers](/custom-providers/indexeddb): advanced authoring docs
+For the broader server and provider config model, continue to
+[Configuration](/configuration). For the catalog of first-party packages, see
+[Built-in Providers](/reference/built-in-providers). If you want to implement
+the contract yourself, read
+[Custom IndexedDB Providers](/custom-providers/indexeddb).

--- a/docs/content/providers/plugins.mdx
+++ b/docs/content/providers/plugins.mdx
@@ -1,4 +1,4 @@
-# Plugins
+# Plugin
 
 Plugin providers are the packages that expose tools through Gestalt. Operators
 configure them under `plugins`, while the host takes care of catalog
@@ -20,17 +20,29 @@ From a deployment point of view, the important pieces are:
 If the manifest enables MCP, the same operations are also exposed through the
 server's `/mcp` endpoint.
 
+## How plugin invocation uses authorization
+
+Gestalt resolves every plugin request to a canonical subject before it invokes
+the target operation. Authorization then decides whether that subject may use
+the plugin or operation at all. A plugin can be configured and healthy, but a
+particular subject may still be denied at request time if their static policy
+memberships or dynamic grants do not allow that operation.
+
+Connections are still stored per subject. Authorization answers whether the
+subject may invoke the plugin, while authentication and connection management
+answer how that subject proves itself to the upstream system.
+
 ## First-party plugin packages
 
 First-party plugins live under
 [`valon-technologies/gestalt-providers/plugins`](https://github.com/valon-technologies/gestalt-providers/tree/main/plugins).
 Examples include:
 
-| Plugin | Repository | Package path |
-| --- | --- | --- |
-| GitHub | [`plugins/github`](https://github.com/valon-technologies/gestalt-providers/tree/main/plugins/github) | `github.com/valon-technologies/gestalt-providers/plugins/github` |
-| Jira | [`plugins/jira`](https://github.com/valon-technologies/gestalt-providers/tree/main/plugins/jira) | `github.com/valon-technologies/gestalt-providers/plugins/jira` |
-| HTTPBin | [`plugins/httpbin`](https://github.com/valon-technologies/gestalt-providers/tree/main/plugins/httpbin) | `github.com/valon-technologies/gestalt-providers/plugins/httpbin` |
+| Provider |
+| --- |
+| [`github.com/valon-technologies/gestalt-providers/plugins/github`](https://github.com/valon-technologies/gestalt-providers/tree/main/plugins/github) |
+| [`github.com/valon-technologies/gestalt-providers/plugins/jira`](https://github.com/valon-technologies/gestalt-providers/tree/main/plugins/jira) |
+| [`github.com/valon-technologies/gestalt-providers/plugins/httpbin`](https://github.com/valon-technologies/gestalt-providers/tree/main/plugins/httpbin) |
 
 See the repository directory for the broader catalog of first-party plugins and
 their package layouts.
@@ -107,11 +119,12 @@ provides that sandbox contract.
 ## Building your own plugin
 
 Plugin implementation details, declarative surfaces, local testing, and custom
-release packaging now live under [Custom Providers > Plugins](/custom-providers/plugins).
+release packaging now live under [Custom Providers > Plugin](/custom-providers/plugins).
 
 ## What to read next
 
 - [Configuration](/configuration): provider entries, connections, and `allowedHosts`
 - [HTTP API](/reference/http-api): invoking plugin operations
 - [Provider Manifests](/reference/plugin-manifests): manifest field reference
-- [Custom Plugins](/custom-providers/plugins): advanced authoring docs
+- [Authorization](/providers/authorization): runtime authorization semantics
+- [Custom Plugin](/custom-providers/plugins): advanced authoring docs

--- a/docs/content/providers/s3.mdx
+++ b/docs/content/providers/s3.mdx
@@ -14,28 +14,19 @@ executable plugins with `plugins.<name>.s3`. The host starts one provider
 process per enabled named entry and only exposes the bindings each plugin is
 granted.
 
-When a plugin binds exactly one S3 provider, Gestalt sets both:
-
-- `GESTALT_S3_SOCKET`
-- `GESTALT_S3_SOCKET_<NAME>`
-
-When a plugin binds multiple S3 providers, only the named env vars are set.
-
 Plugins still work with ordinary `{bucket, key, version_id}` references. The
 host keeps plugin data isolated with an internal namespace prefix, so plugins
 do not need to invent their own storage prefix scheme.
 
-The portable contract covers:
+When a plugin binds exactly one S3 provider, the SDKs let it open the default
+client directly. When a plugin binds more than one S3 provider, the plugin
+opens the named binding it wants to use. That keeps plugin code portable while
+letting the host decide which concrete storage backend sits behind each
+binding.
 
-| Method | Typical S3 operation |
-| --- | --- |
-| `HeadObject` | `HeadObject` |
-| `ReadObject` | `GetObject` |
-| `WriteObject` | `PutObject` |
-| `DeleteObject` | `DeleteObject` |
-| `ListObjects` | `ListObjectsV2` |
-| `CopyObject` | `CopyObject` |
-| `PresignObject` | presigned `GET` / `PUT` / `DELETE` / `HEAD` |
+The contract stays close to familiar S3 semantics. It supports metadata reads,
+object reads and writes, deletes, paginated listing, server-side copy, and
+presigned `GET`, `PUT`, `DELETE`, and `HEAD` URLs.
 
 ## Configuring the first-party S3 provider
 
@@ -64,17 +55,12 @@ plugins:
       - assets
 ```
 
-The first-party provider accepts these config fields:
-
-- `region`: signing region for the backend.
-- `endpoint`: optional base URL for S3-compatible services such as MinIO or
-  GCS XML interoperability.
-- `forcePathStyle`: toggles path-style versus virtual-host-style requests.
-- `accessKeyId`: optional static HMAC access key.
-- `secretAccessKey`: optional static HMAC secret key.
-- `sessionToken`: optional session token for temporary credentials.
-
-If static credentials are omitted, the provider falls back to the AWS SDK
+The main settings are `region`, which controls request signing, and `endpoint`,
+which lets you target S3-compatible systems such as MinIO or GCS XML
+interoperability instead of AWS itself. `forcePathStyle` switches between
+path-style and virtual-host-style requests. If you want to provide static HMAC
+credentials directly, set `accessKeyId`, `secretAccessKey`, and optionally
+`sessionToken`. If you leave those out, the provider falls back to the AWS SDK
 default credential chain.
 
 GCS XML interoperability uses the same provider with a different endpoint and
@@ -96,7 +82,7 @@ providers:
             name: gcs-hmac-secret
 ```
 
-## Using S3 from a plugin
+## Using `S3` from a plugin
 
 The SDK exposes an S3 client plus object-handle helpers in every supported
 language.
@@ -104,24 +90,31 @@ language.
 <Tabs items={['Go', 'Python', 'Rust', 'TypeScript']}>
   <Tabs.Tab>
     ```go
+    import (
+      "context"
+      "log"
+
+      gestalt "github.com/valon-technologies/gestalt/sdk/go"
+    )
+
     ctx := context.Background()
 
     s3, err := gestalt.S3()
     if err != nil {
-    	log.Fatal(err)
+      log.Fatal(err)
     }
     defer s3.Close()
 
     avatar := s3.Object("uploads", "avatars/user-123.png")
     if _, err := avatar.WriteBytes(ctx, pngBytes, &gestalt.WriteOptions{
-    	ContentType: "image/png",
+      ContentType: "image/png",
     }); err != nil {
-    	log.Fatal(err)
+      log.Fatal(err)
     }
 
     body, err := avatar.Bytes(ctx, nil)
     if err != nil {
-    	log.Fatal(err)
+      log.Fatal(err)
     }
     _ = body
     ```
@@ -142,13 +135,15 @@ language.
   </Tabs.Tab>
   <Tabs.Tab>
     ```rust
-    let s3 = gestalt::S3::connect().await?;
+    use gestalt::{s3::WriteOptions, S3};
+
+    let s3 = S3::connect().await?;
     let mut avatar = s3.object("uploads", "avatars/user-123.png");
 
     avatar
         .write_bytes(
             &png_bytes,
-            Some(gestalt::WriteOptions {
+            Some(WriteOptions {
                 content_type: "image/png".to_string(),
                 ..Default::default()
             }),
@@ -178,19 +173,16 @@ Python use `gestalt.S3("archive")`, Rust uses
 
 ## Operational notes
 
-- Gestalt does not use S3 providers for its own system state. They are
-  plugin-only bindings.
-- The first-party provider preserves the portable object identity
-  `{bucket, key, version_id}`. Buckets are chosen by the caller, not fixed in
-  provider config.
-- Plugin-scoped presigning is not available through the SDK transport. Signed
-  URLs would expose the provider-internal namespace prefix that the host uses
-  to isolate plugin data.
-- The first-party provider currently rejects writes and copies above the
-  single-request S3 limit instead of exposing multipart controls through the
-  public contract.
-- `gestaltd init` can prepare published S3 provider packages the same way it
-  prepares auth, indexeddb, cache, and secrets providers.
+Gestalt does not use S3 providers for its own system state, so these bindings
+are plugin-only. The first-party provider preserves the portable object
+identity `{bucket, key, version_id}`, which means buckets are chosen by the
+caller instead of being fixed in provider config. Plugin-scoped presigning is
+not available through the SDK transport because signed URLs would expose the
+provider-internal namespace prefix that the host uses for isolation. The
+first-party provider also rejects writes and copies above the single-request S3
+limit instead of exposing multipart controls through the public contract.
+Published S3 provider packages can still be prepared with `gestaltd init`, just
+like auth, indexeddb, cache, and secrets providers.
 
 ## Building your own S3 provider
 

--- a/docs/content/providers/secrets.mdx
+++ b/docs/content/providers/secrets.mdx
@@ -1,4 +1,4 @@
-# Secrets
+# Secret
 
 Secrets providers resolve structured secret refs before the rest of the server
 starts. That lets provider config, OAuth app secrets, DSNs, and other sensitive
@@ -63,22 +63,22 @@ provider, plugin provider, or datastore provider receives its config.
 
 ## First-party external secret providers
 
-| Provider | Repository | Package path |
-| --- | --- | --- |
-| AWS Secrets Manager | [`secrets/aws`](https://github.com/valon-technologies/gestalt-providers/tree/main/secrets/aws) | `github.com/valon-technologies/gestalt-providers/secrets/aws` |
-| Azure Key Vault | [`secrets/azure`](https://github.com/valon-technologies/gestalt-providers/tree/main/secrets/azure) | `github.com/valon-technologies/gestalt-providers/secrets/azure` |
-| Google Secret Manager | [`secrets/google`](https://github.com/valon-technologies/gestalt-providers/tree/main/secrets/google) | `github.com/valon-technologies/gestalt-providers/secrets/google` |
-| HashiCorp Vault | [`secrets/vault`](https://github.com/valon-technologies/gestalt-providers/tree/main/secrets/vault) | `github.com/valon-technologies/gestalt-providers/secrets/vault` |
+| Provider |
+| --- |
+| [`github.com/valon-technologies/gestalt-providers/secrets/aws`](https://github.com/valon-technologies/gestalt-providers/tree/main/secrets/aws) |
+| [`github.com/valon-technologies/gestalt-providers/secrets/azure`](https://github.com/valon-technologies/gestalt-providers/tree/main/secrets/azure) |
+| [`github.com/valon-technologies/gestalt-providers/secrets/google`](https://github.com/valon-technologies/gestalt-providers/tree/main/secrets/google) |
+| [`github.com/valon-technologies/gestalt-providers/secrets/vault`](https://github.com/valon-technologies/gestalt-providers/tree/main/secrets/vault) |
 
 See each provider directory for its config schema and backend-specific settings.
 
 ## Building your own secrets provider
 
 Implementation details for custom secrets providers now live under
-[Custom Providers > Secrets](/custom-providers/secrets).
+[Custom Providers > Secret](/custom-providers/secrets).
 
 ## What to read next
 
 - [Configuration](/configuration): using structured secret refs across the server config
 - [Built-in Providers](/reference/built-in-providers): built-in `env` and `file`
-- [Custom Secrets Providers](/custom-providers/secrets): advanced authoring docs
+- [Custom Secret](/custom-providers/secrets): advanced authoring docs

--- a/docs/content/providers/ui.mdx
+++ b/docs/content/providers/ui.mdx
@@ -1,25 +1,38 @@
-# Web UIs
+# UI
 
-Web UI providers are static asset bundles. Gestalt serves each configured
+UI providers are static asset bundles. Gestalt serves each configured
 bundle either directly from `providers.ui.<name>.path` or via
 `plugins.<name>.mountPath`. The built-in admin UI at `/admin` remains available
 regardless of whether public UI bundles are configured.
 
-## How web UI providers work
+## How UI providers work
 
-Unlike executable providers, a web UI provider is just a packaged asset root.
+Unlike executable providers, a UI provider is just a packaged asset root.
 `gestaltd` resolves the bundle, prepares it during `gestaltd init`, and then
 serves the pinned assets from the configured public path prefix when the server
 starts.
+
+## How UI routes use authorization
+
+UI authorization is route-based. When you bind an `authorizationPolicy` to a UI
+entry, Gestalt authenticates the caller, resolves their role under that policy,
+and compares it to the mounted UI manifest's `spec.routes[].allowedRoles`
+rules before serving the matching route or its static assets.
+
+Plugin-backed mounted UIs inherit more than just a mount path. They also
+inherit the owning plugin's dynamic grants when that plugin declares an
+`authorizationPolicy`, and they inherit the plugin's route-auth provider when
+the plugin declares `auth.provider`. Direct `providers.ui` bundles and the
+built-in admin UI keep using the server-wide auth configuration instead.
 
 ## First-party UI bundles
 
 First-party UI bundles live under
 [`valon-technologies/gestalt-providers/web`](https://github.com/valon-technologies/gestalt-providers/tree/main/web).
 
-| Bundle | Repository | Package path |
-| --- | --- | --- |
-| Default Web UI | [`web/default`](https://github.com/valon-technologies/gestalt-providers/tree/main/web/default) | `github.com/valon-technologies/gestalt-providers/web/default` |
+| Provider |
+| --- |
+| [`github.com/valon-technologies/gestalt-providers/web/default`](https://github.com/valon-technologies/gestalt-providers/tree/main/web/default) |
 
 ## Configuring `providers.ui`
 
@@ -84,14 +97,14 @@ Reference a published bundle in production:
 providers:
   ui:
     roadmap:
-      source: https://artifacts.example.com/webui/customer-roadmap-review/v0.0.1/provider-release.yaml
+      source: https://artifacts.example.com/ui/customer-roadmap-review/v0.0.1/provider-release.yaml
       path: /create-customer-roadmap-review
       authorizationPolicy: roadmap_review
 ```
 
 When `authorizationPolicy` is set, Gestalt authenticates the caller, resolves
-their role from `authorization.policies.<policy>`, and checks the web
-UI manifest's `spec.routes[].allowedRoles` before serving the route or its
+their role from `authorization.policies.<policy>`, and checks the UI
+manifest's `spec.routes[].allowedRoles` before serving the route or its
 associated static assets.
 
 ## Locked deployments
@@ -121,14 +134,15 @@ Plugin-backed mounted UIs also inherit the owning plugin's route-auth provider
 when that plugin declares `auth.provider`; direct `providers.ui` bundles and
 the built-in admin UI continue using the server-wide auth provider.
 
-## Building your own web UI bundle
+## Building your own UI bundle
 
 Asset-root layout, build hooks, and release packaging now live under
-[Custom Providers > Web UIs](/custom-providers/web-uis) and
+[Custom Providers > UI](/custom-providers/ui) and
 [Custom Providers > Releasing](/custom-providers/releasing).
 
 ## What to read next
 
 - [Configuration](/configuration): `providers.ui`, `plugins.<name>.mountPath`, and headless deployments
-- [Client Web UI](/client/web): what the default client exposes
-- [Custom Web UIs](/custom-providers/web-uis): advanced authoring docs
+- [Client UI](/client/web): what the default client exposes
+- [Authorization](/providers/authorization): route and role semantics
+- [Custom UI](/custom-providers/ui): advanced authoring docs

--- a/docs/content/providers/workflow.mdx
+++ b/docs/content/providers/workflow.mdx
@@ -1,36 +1,73 @@
+import { Callout, Tabs } from 'nextra/components'
+
 # Workflow
 
-Workflow providers back global workflow runs, schedules, and event triggers.
-Configure them under `providers.workflow`, then use them from either:
+Gestalt workflows let you invoke a plugin operation later instead of right now.
+Today that primarily means cron-based schedules, workflow run history and run
+cancelation, and config-managed event triggers. The workflow model is global.
+A workflow target is always explicit: `plugin`, `operation`, and optional
+`connection`, `instance`, and `input`.
 
-- top-level `workflows.schedules` and `workflows.eventTriggers` for
-  config-managed workflows
-- the global workflow API and CLI for user-owned schedules:
-  `/api/v1/workflow/schedules` and `gestalt workflows ...`
+<Callout type="info">
+  Event triggers exist today, but only as config-managed objects under
+  top-level `workflows.eventTriggers`. There is not yet a public HTTP or CLI
+  CRUD surface for event triggers or a generic public event-publish endpoint.
+</Callout>
+
+## Mental model
+
+Start by configuring at least one workflow provider under
+`providers.workflow`, then define a workflow target for the plugin operation
+you want Gestalt to invoke. From there you create either a schedule, which runs
+on a cron expression, or an event trigger, which runs when a published event
+matches. The workflow provider persists that object, creates workflow runs, and
+calls back into Gestalt when a run should execute. Gestalt then invokes the
+target plugin operation, and you inspect or cancel the resulting runs through
+the global workflow runs surface.
+
+There are two ownership modes. Config-managed workflows live in YAML under
+top-level `workflows:` and execute as the system config actor. User-owned
+schedules are created through the global API or CLI and execute as the subject
+that created them.
 
 ## How workflow providers work
 
-Workflow provider selection is global, not plugin-scoped.
+Workflow provider selection is global, not plugin-scoped. A config-managed
+workflow object chooses a provider with `provider`, or inherits the
+sole/default `providers.workflow` entry when that field is omitted.
+User-owned schedules use the same provider pool through the global HTTP API and
+CLI. In every case the target is explicit, and a workflow provider may bind a
+host IndexedDB provider through `providers.workflow.<name>.indexeddb`.
 
-- Config-managed workflow objects choose a provider with `provider`, or inherit
-  the sole/default `providers.workflow` entry when that field is omitted.
-- User-owned schedules use the same provider pool through the global HTTP API
-  and CLI.
-- Workflow targets are explicit: `plugin`, `operation`, and optional
-  `connection`, `instance`, and `input`.
-- A workflow provider may bind a host IndexedDB provider through
-  `providers.workflow.<name>.indexeddb`.
+## How workflow execution uses authorization
+
+Workflow authorization is easiest to reason about if you split it into creation
+time and run time. When a user creates a schedule, Gestalt checks whether the
+current subject is allowed to invoke the target operation right now. It then
+stores the owner subject plus a permission ceiling for delayed execution.
+
+When the workflow fires later, Gestalt resolves that stored owner reference and
+checks authorization again before invoking the target. That means a schedule
+can still fail at run time if the subject lost access, if the target operation
+is no longer allowed, or if the original token had narrower permissions than
+the full subject would otherwise have.
+
+Config-managed workflows follow the same pattern, but the owner is the system
+config actor rather than a human subject.
 
 ## First-party workflow providers
 
 First-party workflow providers live under
 [`valon-technologies/gestalt-providers/workflow`](https://github.com/valon-technologies/gestalt-providers/tree/main/workflow).
 
-| Provider | Repository | Package path | Use case |
-| --- | --- | --- | --- |
-| IndexedDB Workflow Provider | [`workflow/indexeddb`](https://github.com/valon-technologies/gestalt-providers/tree/main/workflow/indexeddb) | `github.com/valon-technologies/gestalt-providers/workflow/indexeddb` | Stores workflow runs, schedules, and event triggers in IndexedDB and invokes target plugin operations through the workflow host |
+| Provider | Use case |
+| --- | --- |
+| [`github.com/valon-technologies/gestalt-providers/workflow/indexeddb`](https://github.com/valon-technologies/gestalt-providers/tree/main/workflow/indexeddb) | Stores workflow runs, schedules, and event triggers in IndexedDB and invokes target plugin operations through the workflow host |
 
 ## Configuring `providers.workflow`
+
+You need at least one entry under `providers.workflow`. The first-party
+IndexedDB workflow provider is the usual starting point:
 
 ```yaml
 providers:
@@ -49,39 +86,230 @@ providers:
         db: workflow
       config:
         pollInterval: 1s
+```
 
+If you configure exactly one workflow provider, or mark one as `default: true`,
+then schedules and event triggers may omit `provider`.
+
+## Defining config-managed workflows
+
+Config-managed workflows live under the top-level `workflows:` block.
+
+### Schedules
+
+```yaml
 workflows:
   schedules:
     nightly_sync:
+      provider: local
       plugin: roadmap
       cron: "0 3 * * *"
       timezone: America/New_York
-      operation: sync_items
+      operation: sync
+      connection: default
+      instance: tenant-a
+      input:
+        mode: incremental
+        includeArchived: false
+```
 
+This creates a durable schedule named `nightly_sync` that invokes
+`roadmap.sync` every day at 3:00 AM New York time.
+
+### Event triggers
+
+```yaml
+workflows:
   eventTriggers:
-    item_updated:
-      plugin: roadmap
+    roadmap_item_updated:
+      provider: local
+      plugin: slack
       match:
         type: roadmap.item.updated
-      operation: sync_items
+        source: roadmap
+        subject: item
+      operation: chat.postMessage
+      connection: alerts
+      instance: engineering
+      input:
+        channel: C123456
+        text: "A roadmap item changed."
 ```
 
-With that config in place, operators get config-managed workflows from
-`workflows:` and users can create their own schedules with the same provider:
+This creates a durable event trigger that listens for published events with:
+`type = "roadmap.item.updated"`, plus optional exact matches for
+`source = "roadmap"` and `subject = "item"`. When an event matches, Gestalt
+invokes `slack.chat.postMessage` with the static input above and records a
+workflow run.
 
-```sh
-gestalt workflows create \
-  --plugin roadmap \
-  --operation sync_items \
-  --cron "0 6 * * 1-5"
-```
+### Match semantics
 
-## Operational notes
+Event trigger matching is exact string matching. `match.type` is required.
+`match.source` and `match.subject` are optional. If `source` or `subject` is
+omitted, that field is ignored during matching.
 
-- A workflow provider is required only when you use global workflows.
-- Config-managed schedules and event triggers are reconciled into the provider
-  at startup and removed when deleted from config.
-- User-owned schedules are global resources, not nested under plugins.
+## Creating user-owned schedules
+
+User-owned schedules are global resources exposed through
+`POST /api/v1/workflow/schedules` and `gestalt workflows schedules ...`.
+These schedules execute as the creating subject, not as a plugin-local or
+synthetic workflow workload.
+
+<Tabs items={['CLI', 'HTTP']}>
+  <Tabs.Tab>
+    ```sh
+    gestalt workflows schedules create \
+      --cron "0 */6 * * *" \
+      --timezone America/New_York \
+      --plugin github \
+      --operation issues.list \
+      --connection default \
+      --instance acme-org \
+      -p owner=valon-technologies \
+      -p repo=gestalt \
+      -p state=open
+    ```
+
+    List schedules:
+
+    ```sh
+    gestalt workflows schedules list
+    gestalt workflows schedules list --plugin github
+    ```
+
+    Inspect, update, pause, resume, or delete a schedule:
+
+    ```sh
+    gestalt workflows schedules get <schedule-id>
+    gestalt workflows schedules update <schedule-id> --cron "0 9 * * 1-5"
+    gestalt workflows schedules pause <schedule-id>
+    gestalt workflows schedules resume <schedule-id>
+    gestalt workflows schedules delete <schedule-id>
+    ```
+  </Tabs.Tab>
+  <Tabs.Tab>
+    ```sh
+    curl -X POST "$GESTALT_URL/api/v1/workflow/schedules" \
+      -H "Authorization: Bearer $GESTALT_API_KEY" \
+      -H "Content-Type: application/json" \
+      -d '{
+        "cron": "0 */6 * * *",
+        "timezone": "America/New_York",
+        "target": {
+          "plugin": "github",
+          "operation": "issues.list",
+          "connection": "default",
+          "instance": "acme-org",
+          "input": {
+            "owner": "valon-technologies",
+            "repo": "gestalt",
+            "state": "open"
+          }
+        }
+      }'
+    ```
+
+    List or inspect schedules:
+
+    ```sh
+    curl -H "Authorization: Bearer $GESTALT_API_KEY" \
+      "$GESTALT_URL/api/v1/workflow/schedules"
+
+    curl -H "Authorization: Bearer $GESTALT_API_KEY" \
+      "$GESTALT_URL/api/v1/workflow/schedules/<schedule-id>"
+    ```
+
+    Pause, resume, or delete:
+
+    ```sh
+    curl -X POST -H "Authorization: Bearer $GESTALT_API_KEY" \
+      "$GESTALT_URL/api/v1/workflow/schedules/<schedule-id>/pause"
+
+    curl -X POST -H "Authorization: Bearer $GESTALT_API_KEY" \
+      "$GESTALT_URL/api/v1/workflow/schedules/<schedule-id>/resume"
+
+    curl -X DELETE -H "Authorization: Bearer $GESTALT_API_KEY" \
+      "$GESTALT_URL/api/v1/workflow/schedules/<schedule-id>"
+    ```
+  </Tabs.Tab>
+</Tabs>
+
+The `provider` field is available on the HTTP API. Omit it when you have a
+sole/default workflow provider; include it when you need to select a specific
+workflow backend.
+
+## Inspecting and canceling workflow runs
+
+Runs are the execution records produced by schedules, event triggers, or other
+workflow-provider actions. The global run surface is
+`GET /api/v1/workflow/runs`, `GET /api/v1/workflow/runs/{runID}`,
+`POST /api/v1/workflow/runs/{runID}/cancel`, and
+`gestalt workflows runs ...`.
+
+<Tabs items={['CLI', 'HTTP', 'UI']}>
+  <Tabs.Tab>
+    ```sh
+    gestalt workflows runs list
+    gestalt workflows runs list --plugin github --status failed
+    gestalt workflows runs get <run-id>
+    gestalt workflows runs cancel <run-id> --reason "operator requested"
+    ```
+  </Tabs.Tab>
+  <Tabs.Tab>
+    ```sh
+    curl -H "Authorization: Bearer $GESTALT_API_KEY" \
+      "$GESTALT_URL/api/v1/workflow/runs"
+
+    curl -H "Authorization: Bearer $GESTALT_API_KEY" \
+      "$GESTALT_URL/api/v1/workflow/runs?plugin=github&status=failed"
+
+    curl -H "Authorization: Bearer $GESTALT_API_KEY" \
+      "$GESTALT_URL/api/v1/workflow/runs/<run-id>"
+
+    curl -X POST "$GESTALT_URL/api/v1/workflow/runs/<run-id>/cancel" \
+      -H "Authorization: Bearer $GESTALT_API_KEY" \
+      -H "Content-Type: application/json" \
+      -d '{"reason":"operator requested"}'
+    ```
+  </Tabs.Tab>
+  <Tabs.Tab>
+    When you mount the default web bundle, the workflow runs UI is available at
+    `/workflows`. It shows recent runs, supports filtering and search, and lets
+    you cancel pending runs from the detail panel.
+  </Tabs.Tab>
+</Tabs>
+
+Run responses include `id`, `provider`, `status`, `target`, `trigger`,
+`createdBy`, `createdAt`, `startedAt`, `completedAt`, `statusMessage`, and
+`resultBody`. The `trigger.kind` value is `schedule`, `event`, or `manual`.
+
+## Event triggers today
+
+Event triggers are usable today, but they are more primitive than schedules
+from a product-surface perspective. What exists today is top-level config under
+`workflows.eventTriggers`, durable storage in the workflow provider, matching
+against published events, and normal workflow run records once a trigger fires.
+What does not exist yet is `gestalt workflows triggers ...`,
+`/api/v1/workflow/event-triggers`, or a generic public
+`/api/v1/workflow/events` publish endpoint.
+
+In practice, that makes event triggers most useful for deployment-managed
+automation defined in YAML, or for custom workflow providers and internal
+components that can publish events into the workflow provider.
+
+If you are implementing a provider or another event producer, see
+[Custom Providers > Workflow](/custom-providers/workflow) for the
+`PublishEvent` interface.
+
+## How execution works
+
+When a workflow fires, the workflow provider creates a run and calls back into
+Gestalt through the workflow host. Gestalt invokes the target plugin operation,
+then the run is updated to `succeeded`, `failed`, or `canceled`.
+
+The execution identity depends on how the workflow was created. Config-managed
+schedules and event triggers execute as `system:config`, while user-owned
+schedules execute as the creating subject.
 
 ## Building your own workflow provider
 
@@ -91,10 +319,9 @@ release flow live under
 
 ## What to read next
 
-- [Configuration](/configuration): server and provider config structure
-- [Config File](/reference/config-file): full `providers.workflow` and
-  `workflows.*` reference
-- [Built-in Providers](/reference/built-in-providers): first-party workflow
-  provider reference
-- [Custom Workflow Providers](/custom-providers/workflow): advanced authoring
-  docs
+If you want the surrounding config model, read [Configuration](/configuration)
+and the full [Config File](/reference/config-file) reference. For route and
+command details, see [HTTP API](/reference/http-api) and [CLI](/client/cli).
+If you need provider implementation details, continue to
+[Custom Workflow Providers](/custom-providers/workflow) or the
+[Built-in Providers](/reference/built-in-providers) reference.

--- a/docs/content/reference/config-file.mdx
+++ b/docs/content/reference/config-file.mdx
@@ -394,6 +394,12 @@ These objects are reconciled into the selected workflow provider at startup and
 invoke explicit workflow targets: `plugin`, `operation`, and optional
 `connection`, `instance`, and `input`.
 
+Config-managed workflows are deployment-owned. They are created from YAML at
+startup, updated when config changes, and removed when deleted from config.
+They are distinct from user-owned schedules created through the global workflow
+HTTP API and CLI. For an end-to-end usage guide, see
+[Workflow](/providers/workflow).
+
 ```yaml
 workflows:
   schedules:
@@ -450,6 +456,11 @@ workflows:
 | `instance` | Optional target instance name. |
 | `input` | Optional static input merged into the invocation payload. |
 | `paused` | When `true`, Gestalt reconciles the trigger in a paused state. |
+
+Event trigger matching is exact string matching. `match.type` is required;
+`match.source` and `match.subject` are optional exact-match filters. Event
+triggers are config-managed only today; there is not yet a public HTTP or CLI
+CRUD surface for them.
 
 ## `providers.cache`
 
@@ -1123,17 +1134,17 @@ sandboxed runtime rather than relying on host-specific OS wrappers alone.
 providers:
   ui:
     console:
-      source: https://artifacts.example.com/webui/console/v1.0.0/provider-release.yaml
+      source: https://artifacts.example.com/ui/console/v1.0.0/provider-release.yaml
       path: /console
       config:
         brandName: Acme
 ```
 
-`providers.ui` is a map of `webui` bundles. Entries may mount directly by setting `path`, or they may act as named UI bundles that `plugins.<name>.ui` binds to `plugins.<name>.mountPath`. When a plugin manifest declares `spec.ui`, `plugins.<name>.ui` may be omitted entirely and Gestalt synthesizes the mounted UI entry from the plugin-owned reference. The built-in admin UI remains available at `/admin`. Omit `providers.ui` entirely to run headless with no public UI bundles.
+`providers.ui` is a map of `ui` bundles. Entries may mount directly by setting `path`, or they may act as named UI bundles that `plugins.<name>.ui` binds to `plugins.<name>.mountPath`. When a plugin manifest declares `spec.ui`, `plugins.<name>.ui` may be omitted entirely and Gestalt synthesizes the mounted UI entry from the plugin-owned reference. The built-in admin UI remains available at `/admin`. Omit `providers.ui` entirely to run headless with no public UI bundles.
 
 Plugin-backed mounted UIs inherit the owning plugin's dynamic authorization grants when that plugin sets `authorizationPolicy`. Direct `providers.ui.<name>.authorizationPolicy` bindings remain static-only.
 
-When `authorizationPolicy` is set on a mounted UI, the referenced web UI manifest must declare `spec.routes` with non-empty `allowedRoles`, and at least one route must cover `/`.
+When `authorizationPolicy` is set on a mounted UI, the referenced UI manifest must declare `spec.routes` with non-empty `allowedRoles`, and at least one route must cover `/`.
 
 | Field | Description |
 | --- | --- |

--- a/docs/content/reference/http-api.mdx
+++ b/docs/content/reference/http-api.mdx
@@ -40,6 +40,24 @@ Authenticated routes accept a `session_token` cookie or an `Authorization: Beare
 | `POST` | `/api/v1/auth/start-oauth` | Start a plugin OAuth flow. |
 | `POST` | `/api/v1/auth/connect-manual` | Submit manual plugin credentials. |
 
+### Workflows
+
+| Method | Path | Purpose |
+| --- | --- | --- |
+| `GET` | `/api/v1/workflow/schedules` | List user-owned workflow schedules. |
+| `POST` | `/api/v1/workflow/schedules` | Create a user-owned workflow schedule. |
+| `GET` | `/api/v1/workflow/schedules/{scheduleID}` | Inspect one workflow schedule. |
+| `PUT` | `/api/v1/workflow/schedules/{scheduleID}` | Update one workflow schedule. |
+| `DELETE` | `/api/v1/workflow/schedules/{scheduleID}` | Delete one workflow schedule. |
+| `POST` | `/api/v1/workflow/schedules/{scheduleID}/pause` | Pause one workflow schedule. |
+| `POST` | `/api/v1/workflow/schedules/{scheduleID}/resume` | Resume one workflow schedule. |
+| `GET` | `/api/v1/workflow/runs` | List workflow runs. Supports optional `plugin` and `status` query filters. |
+| `GET` | `/api/v1/workflow/runs/{runID}` | Inspect one workflow run. |
+| `POST` | `/api/v1/workflow/runs/{runID}/cancel` | Cancel one workflow run. The request body may include an optional `reason`. |
+
+Event triggers are not exposed as a public HTTP CRUD surface yet. Today they
+are config-managed under top-level `workflows.eventTriggers`.
+
 ### API Tokens
 
 | Method | Path | Purpose |
@@ -127,6 +145,27 @@ curl 'http://localhost:8080/api/v1/slack/chat.postMessage?_connection=mcp&_insta
 curl -X POST http://localhost:8080/api/v1/slack/chat.postMessage \
   -H 'Content-Type: application/json' \
   -d '{"_connection": "mcp", "channel": "C123", "text": "hello"}'
+
+# Create a workflow schedule
+curl -X POST http://localhost:8080/api/v1/workflow/schedules \
+  -H 'Authorization: Bearer gst_api_...' \
+  -H 'Content-Type: application/json' \
+  -d '{
+    "cron": "0 */6 * * *",
+    "timezone": "America/New_York",
+    "target": {
+      "plugin": "github",
+      "operation": "issues.list",
+      "input": {
+        "owner": "valon-technologies",
+        "repo": "gestalt"
+      }
+    }
+  }'
+
+# List failed workflow runs for one plugin
+curl 'http://localhost:8080/api/v1/workflow/runs?plugin=github&status=failed' \
+  -H 'Authorization: Bearer gst_api_...'
 
 # Add a dynamic plugin member from the management/admin surface by email alias
 curl -X PUT http://localhost:9090/admin/api/v1/authorization/plugins/sample_plugin/members \

--- a/docs/content/reference/plugin-manifests.mdx
+++ b/docs/content/reference/plugin-manifests.mdx
@@ -21,7 +21,7 @@ Every manifest defines exactly one provider kind, set by the `kind` field:
 | `indexeddb` | Persistence backend.                                 |
 | `s3`        | S3-compatible object store backend.                  |
 | `secrets`   | Secret manager for resolving structured secret refs. |
-| `webui`     | Static UI package served by `gestaltd`.              |
+| `ui`     | Static UI package served by `gestaltd`.              |
 
 The `kind` field is required. Kind-specific configuration goes under the `spec` block.
 
@@ -31,7 +31,7 @@ These fields appear at the top level of every manifest regardless of kind.
 
 | Field         | Type       | Required | Purpose                                                                                                                                                                                              |
 | ------------- | ---------- | -------- | ---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| `kind`        | string     | yes      | The provider kind (`plugin`, `auth`, `cache`, `indexeddb`, `s3`, `secrets`, `webui`).                                                                                                                |
+| `kind`        | string     | yes      | The provider kind (`plugin`, `auth`, `cache`, `indexeddb`, `s3`, `secrets`, `ui`).                                                                                                                |
 | `source`      | string     | yes      | Canonical provider source identifier. Use `github.com/<org>/<repo>/<path>`. The final path segment is the provider package name; preceding segments are used for release tags and source resolution. |
 | `version`     | string     | yes      | Semver version. Pre-release suffixes like `-alpha.1` are allowed.                                                                                                                                    |
 | `displayName` | string     | no       | Human-readable label shown in the UI.                                                                                                                                                                |
@@ -72,7 +72,7 @@ The `spec` block for a `kind: plugin` manifest describes a plugin. It supports d
 | `connections` | map[string]ConnectionDef | Canonical upstream auth and connection definitions. Put upstream OAuth/manual/bearer auth here, typically under `connections.default`. |
 | `defaultConnection` | string | Name of the connection to use when none is specified. |
 | `requires` | string[] | Provider source identifiers that this provider depends on. Gestalt ensures the listed providers are available before starting this provider. |
-| `ui` | OwnedUIRef | Optional owned web UI reference for plugins that publish a mounted UI. |
+| `ui` | OwnedUIRef | Optional owned UI reference for plugins that publish a mounted UI. |
 
 ### Owned UI
 
@@ -82,7 +82,7 @@ Plugins that back mounted apps may declare their UI artifact in the plugin manif
 
 | Field        | Type   | Purpose                                                                                                                                                                            |
 | ------------ | ------ | ---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| `path`       | string | Relative path to a co-packaged `kind: webui` manifest. Source releases may point at sibling UI packages; `gestaltd provider release` rewrites them into the archive automatically. |
+| `path`       | string | Relative path to a co-packaged `kind: ui` manifest. Source releases may point at sibling UI packages; `gestaltd provider release` rewrites them into the archive automatically. |
 | `ref`        | string | Managed provider source ref for the owned UI bundle.                                                                                                                               |
 | `version`    | string | Optional version for `ref`. Defaults to the plugin manifest version when omitted.                                                                                                  |
 | `auth.token` | string | Optional source token used when resolving a private managed `ref`. Only valid with `ref`.                                                                                          |
@@ -359,14 +359,14 @@ artifacts:
     path: artifacts/linux/amd64/provider
 ```
 
-## Web UI Metadata
+## UI Metadata
 
-The `spec` block for a `kind: webui` manifest describes a static UI package.
+The `spec` block for a `kind: ui` manifest describes a static UI package.
 
 | Field       | Type         | Required | Purpose                                                                                                                     |
 | ----------- | ------------ | -------- | --------------------------------------------------------------------------------------------------------------------------- |
 | `assetRoot` | string       | yes      | Directory containing the built static assets.                                                                               |
-| `routes`    | WebUIRoute[] | no       | Optional route-level authorization rules used when a deployment binds this UI to `providers.ui.<name>.authorizationPolicy`. |
+| `routes`    | UIRoute[] | no       | Optional route-level authorization rules used when a deployment binds this UI to `providers.ui.<name>.authorizationPolicy`. |
 
 Each `spec.routes` entry declares a mounted path and the allowed human roles for that path. Path matching is exact or longest-prefix with a terminal `/*`. When a deployment sets `authorizationPolicy`, route definitions must have non-empty `allowedRoles`, and the manifest must include a route that covers `/`.
 
@@ -376,7 +376,7 @@ Each `spec.routes` entry declares a mounted path and the allowed human roles for
 | `allowedRoles` | string[] | yes      | Roles permitted to load the route or its associated static assets. |
 
 ```yaml
-kind: webui
+kind: ui
 source: github.com/acme/plugins/gestalt-ui
 version: 1.0.0
 displayName: Custom UI
@@ -605,7 +605,7 @@ spec:
 
 ## Authoring Notes
 
-Manifest paths must stay inside the package. `kind`, `source`, and `version` are required. A manifest defines exactly one provider kind: `kind: plugin`, `kind: authentication`, `kind: indexeddb`, `kind: secrets`, or `kind: webui`.
+Manifest paths must stay inside the package. `kind`, `source`, and `version` are required. A manifest defines exactly one provider kind: `kind: plugin`, `kind: authentication`, `kind: indexeddb`, `kind: secrets`, or `kind: ui`.
 
 `configSchemaPath` validates per-plugin config and may be written in JSON or YAML. Any connection may define `params` and `discovery`. The OpenAPI/GraphQL surface types are mutually exclusive, but MCP may be added alongside either.
 
@@ -683,7 +683,7 @@ packages generate support files or UI bundles without checking built artifacts
 into source control.
 
 ```yaml
-kind: webui
+kind: ui
 source: github.com/acme/plugins/gestalt-ui
 version: 1.0.0
 release:

--- a/docs/content/troubleshooting.mdx
+++ b/docs/content/troubleshooting.mdx
@@ -20,7 +20,7 @@ A "provider not found" error means the plugin key in the request does not match 
 
 An "operation not found" error means the operation ID does not exist in the plugin's catalog. Check that the operation is exposed and that `allowedOperations`, if set, includes it.
 
-A "not authenticated" error on an API or MCP request means no valid session or API token was presented. Log in through the web UI or pass a bearer token in the `Authorization` header.
+A "not authenticated" error on an API or MCP request means no valid session or API token was presented. Log in through the UI or pass a bearer token in the `Authorization` header.
 
 A "no integration token" error means the user has not connected the plugin. Complete the OAuth or manual-auth flow for the provider and connection before invoking operations.
 

--- a/docs/internal/managed-agent-identities.md
+++ b/docs/internal/managed-agent-identities.md
@@ -173,7 +173,7 @@ Additional rules:
 
 This matrix captures the minimum V1 surface area.
 
-| Feature | Backend / Data Model | HTTP API | CLI | Default Web UI | Notes |
+| Feature | Backend / Data Model | HTTP API | CLI | Default UI | Notes |
 | --- | --- | --- | --- | --- | --- |
 | Identity CRUD | Required | Required | Required | Required | Workspace-owned runtime resources |
 | Membership sharing | Required | Required | Required | Required | Canonical user `subject_id` storage, email-friendly writes |

--- a/gestaltd/cmd/gestaltd/e2e_test.go
+++ b/gestaltd/cmd/gestaltd/e2e_test.go
@@ -809,15 +809,15 @@ type mountedUITestConfig struct {
 	ManifestPath string
 }
 
-func setupMountedWebUIDir(t *testing.T, baseDir string) *mountedUITestConfig {
+func setupMountedUIDir(t *testing.T, baseDir string) *mountedUITestConfig {
 	t.Helper()
-	return setupMountedWebUIDirWithRoutes(t, baseDir, nil)
+	return setupMountedUIDirWithRoutes(t, baseDir, nil)
 }
 
-func setupMountedWebUIDirWithRoutes(t *testing.T, baseDir string, routes []providermanifestv1.WebUIRoute) *mountedUITestConfig {
+func setupMountedUIDirWithRoutes(t *testing.T, baseDir string, routes []providermanifestv1.UIRoute) *mountedUITestConfig {
 	t.Helper()
 
-	uiDir := filepath.Join(baseDir, "mounted-webui")
+	uiDir := filepath.Join(baseDir, "mounted-ui")
 	distDir := filepath.Join(uiDir, "dist")
 	assetsDir := filepath.Join(distDir, "assets")
 	if err := os.MkdirAll(assetsDir, 0o755); err != nil {
@@ -839,8 +839,8 @@ func setupMountedWebUIDirWithRoutes(t *testing.T, baseDir string, routes []provi
 	writeTestFile(t, uiDir, filepath.Join("dist", "assets", "app.js"), []byte(`window.__ROADMAP_REVIEW_UI__ = "ready";
 `), 0o644)
 	writeManifestFile(t, uiDir, &providermanifestv1.Manifest{
-		Kind:        providermanifestv1.KindWebUI,
-		Source:      "github.com/test/webui/roadmap-review",
+		Kind:        providermanifestv1.KindUI,
+		Source:      "github.com/test/ui/roadmap-review",
 		Version:     "0.0.1-alpha.1",
 		DisplayName: "Roadmap Review UI",
 		Spec: &providermanifestv1.Spec{
@@ -902,8 +902,8 @@ func setupDefaultLocalProvidersDir(t *testing.T, baseDir string) string {
 </html>
 `), 0o644)
 	writeManifestFile(t, rootUIDir, &providermanifestv1.Manifest{
-		Kind:        providermanifestv1.KindWebUI,
-		Source:      "github.com/test/webui/default",
+		Kind:        providermanifestv1.KindUI,
+		Source:      "github.com/test/ui/default",
 		Version:     "0.0.1-alpha.1",
 		DisplayName: "Default Gestalt UI",
 		Spec:        &providermanifestv1.Spec{AssetRoot: "dist"},
@@ -1247,7 +1247,7 @@ func TestE2EServeSplitManagementRoutes(t *testing.T) {
 	}
 
 	dir := t.TempDir()
-	mountedUI := setupMountedWebUIDir(t, dir)
+	mountedUI := setupMountedUIDir(t, dir)
 	publicPort, publicHolder := reservePort(t)
 	managementPort, managementHolder := reservePort(t)
 	publicURL := fmt.Sprintf("http://127.0.0.1:%d", publicPort)
@@ -1345,7 +1345,7 @@ func TestE2EServePluginOwnedUIWiring(t *testing.T) {
 	dir := t.TempDir()
 	indexedDBManifest := componentProviderManifestPath(t, setupIndexedDBProviderDir(t, dir))
 	pluginManifest := componentProviderManifestPath(t, setupPrebuiltPluginDir(t, dir))
-	mountedUI := setupMountedWebUIDirWithRoutes(t, dir, []providermanifestv1.WebUIRoute{{
+	mountedUI := setupMountedUIDirWithRoutes(t, dir, []providermanifestv1.UIRoute{{
 		Path:         "/*",
 		AllowedRoles: []string{"viewer"},
 	}})

--- a/gestaltd/cmd/gestaltd/provider.go
+++ b/gestaltd/cmd/gestaltd/provider.go
@@ -47,7 +47,7 @@ const providerReleaseSchemaName = "gestaltd-provider-release"
 const providerReleaseSchemaVersion = 1
 const providerReleaseRuntimeKindExecutable = "executable"
 const providerReleaseRuntimeKindDeclarative = "declarative"
-const providerReleaseRuntimeKindWebUI = "webui"
+const providerReleaseRuntimeKindUI = "ui"
 const providerReleaseGenericTarget = "generic"
 const windowsOS = "windows"
 const windowsExecutableSuffix = ".exe"
@@ -257,7 +257,7 @@ func resolveReleaseBuildTarget(root string, manifest *providermanifestv1.Manifes
 	if err != nil {
 		return nil, err
 	}
-	if kind == providermanifestv1.KindWebUI {
+	if kind == providermanifestv1.KindUI {
 		return nil, nil
 	}
 	hasSource, err := providerpkg.HasSourceReleaseTarget(root, kind)
@@ -523,8 +523,8 @@ func releaseRuntimeMetadata(manifest *providermanifestv1.Manifest) (string, erro
 			return providerReleaseRuntimeKindDeclarative, nil
 		}
 		return providerReleaseRuntimeKindExecutable, nil
-	case providermanifestv1.KindWebUI:
-		return providerReleaseRuntimeKindWebUI, nil
+	case providermanifestv1.KindUI:
+		return providerReleaseRuntimeKindUI, nil
 	default:
 		return providerReleaseRuntimeKindExecutable, nil
 	}
@@ -553,10 +553,10 @@ func validateReleaseOutputDir(manifest *providermanifestv1.Manifest, sourceDir, 
 
 	insideAssetRoot, err := pathWithinBase(outputDirAbs, assetRootAbs)
 	if err != nil {
-		return fmt.Errorf("compare output dir to webui asset_root: %w", err)
+		return fmt.Errorf("compare output dir to ui asset_root: %w", err)
 	}
 	if insideAssetRoot {
-		return fmt.Errorf("--output %q must not be inside webui.asset_root %q", outputDir, manifest.Spec.AssetRoot)
+		return fmt.Errorf("--output %q must not be inside ui.asset_root %q", outputDir, manifest.Spec.AssetRoot)
 	}
 
 	return nil

--- a/gestaltd/cmd/gestaltd/provider_test.go
+++ b/gestaltd/cmd/gestaltd/provider_test.go
@@ -35,9 +35,9 @@ const (
 	releaseProviderSchemaPath      = "schemas/provider.schema.json"
 	declarativeReleasePluginName   = "declarative-release"
 	declarativeReleaseSource       = "github.com/testowner/plugins/catalog/declarative-release"
-	webUITestPluginName            = "webui-test"
-	webUITestSource                = "github.com/testowner/plugins/catalog/webui-test"
-	webUITestAssetRoot             = "out"
+	uiTestPluginName               = "ui-test"
+	uiTestSource                   = "github.com/testowner/plugins/catalog/ui-test"
+	uiTestAssetRoot                = "out"
 	prebuiltProviderPluginName     = "prebuilt-provider"
 	prebuiltProviderSource         = "github.com/testowner/plugins/prebuilt-provider"
 	prebuiltProviderBinaryPath     = "bin/provider"
@@ -1313,10 +1313,10 @@ func TestRun_ProviderReleaseCopiesCompiledSupportFiles(t *testing.T) {
 	}
 }
 
-func TestRun_ProviderReleaseCopiesWebUISupportFiles(t *testing.T) {
+func TestRun_ProviderReleaseCopiesUISupportFiles(t *testing.T) {
 	t.Parallel()
 
-	pluginDir := newWebUIReleaseFixture(t, t.TempDir())
+	pluginDir := newUIReleaseFixture(t, t.TempDir())
 	outputDir := t.TempDir()
 	testVersion := "0.0.3-test"
 
@@ -1325,7 +1325,7 @@ func TestRun_ProviderReleaseCopiesWebUISupportFiles(t *testing.T) {
 		"--output", outputDir,
 	)
 
-	archiveName := "gestalt-plugin-webui-test_v" + testVersion + ".tar.gz"
+	archiveName := "gestalt-plugin-ui-test_v" + testVersion + ".tar.gz"
 	extractDir := extractReleasedArchive(t, outputDir, archiveName)
 
 	for _, rel := range []string{
@@ -1339,29 +1339,29 @@ func TestRun_ProviderReleaseCopiesWebUISupportFiles(t *testing.T) {
 	}
 
 	metadata := readProviderReleaseMetadata(t, outputDir)
-	if metadata.Package != webUITestSource {
-		t.Fatalf("release metadata package = %q, want %q", metadata.Package, webUITestSource)
+	if metadata.Package != uiTestSource {
+		t.Fatalf("release metadata package = %q, want %q", metadata.Package, uiTestSource)
 	}
-	if metadata.Kind != providermanifestv1.KindWebUI {
-		t.Fatalf("release metadata kind = %q, want %q", metadata.Kind, providermanifestv1.KindWebUI)
+	if metadata.Kind != providermanifestv1.KindUI {
+		t.Fatalf("release metadata kind = %q, want %q", metadata.Kind, providermanifestv1.KindUI)
 	}
-	if metadata.Runtime != providerReleaseRuntimeKindWebUI {
-		t.Fatalf("release metadata runtime = %q, want %q", metadata.Runtime, providerReleaseRuntimeKindWebUI)
+	if metadata.Runtime != providerReleaseRuntimeKindUI {
+		t.Fatalf("release metadata runtime = %q, want %q", metadata.Runtime, providerReleaseRuntimeKindUI)
 	}
-	webUIArtifact, ok := metadata.Artifacts[providerReleaseGenericTarget]
+	uiArtifact, ok := metadata.Artifacts[providerReleaseGenericTarget]
 	if !ok {
 		t.Fatalf("release metadata artifacts missing generic key: %+v", metadata.Artifacts)
 	}
-	webUIDigest, err := providerpkg.ArchiveDigest(filepath.Join(outputDir, archiveName))
+	uiDigest, err := providerpkg.ArchiveDigest(filepath.Join(outputDir, archiveName))
 	if err != nil {
-		t.Fatalf("hash webui archive: %v", err)
+		t.Fatalf("hash ui archive: %v", err)
 	}
-	if webUIArtifact.Path != archiveName || webUIArtifact.SHA256 != webUIDigest {
-		t.Fatalf("release metadata webui artifact = %+v, want path %q sha %q", webUIArtifact, archiveName, webUIDigest)
+	if uiArtifact.Path != archiveName || uiArtifact.SHA256 != uiDigest {
+		t.Fatalf("release metadata ui artifact = %+v, want path %q sha %q", uiArtifact, archiveName, uiDigest)
 	}
 }
 
-func TestRun_ProviderReleaseStagesOwnedWebUIPackage(t *testing.T) {
+func TestRun_ProviderReleaseStagesOwnedUIPackage(t *testing.T) {
 	t.Parallel()
 
 	tests := []struct {
@@ -1541,23 +1541,23 @@ func TestRun_ProviderReleaseBuildsProviderSupportFilesBeforePackaging(t *testing
 	}
 }
 
-func TestRun_ProviderReleaseBuildsWebUIAssetsBeforePackaging(t *testing.T) {
+func TestRun_ProviderReleaseBuildsUIAssetsBeforePackaging(t *testing.T) {
 	t.Parallel()
 
 	if runtime.GOOS == "windows" {
 		t.Skip("release build fixture uses POSIX shell")
 	}
 
-	pluginDir := newBuiltWebUIReleaseFixture(t, t.TempDir())
+	pluginDir := newBuiltUIReleaseFixture(t, t.TempDir())
 	outputDir := t.TempDir()
-	const testVersion = "0.0.3-build-webui"
+	const testVersion = "0.0.3-build-ui"
 
 	runProviderReleaseCommand(t, pluginDir,
 		"--version", testVersion,
 		"--output", outputDir,
 	)
 
-	archiveName := "gestalt-plugin-webui-test_v" + testVersion + ".tar.gz"
+	archiveName := "gestalt-plugin-ui-test_v" + testVersion + ".tar.gz"
 	extractDir := extractReleasedArchive(t, outputDir, archiveName)
 	manifest := readReleasedManifest(t, outputDir, archiveName)
 	if manifest.Release != nil {
@@ -1577,15 +1577,15 @@ func TestRun_ProviderReleaseBuildsWebUIAssetsBeforePackaging(t *testing.T) {
 func TestRun_ProviderReleaseAllowsOverlappingSupportPaths(t *testing.T) {
 	t.Parallel()
 
-	pluginDir := filepath.Join(t.TempDir(), "webui-overlap")
+	pluginDir := filepath.Join(t.TempDir(), "ui-overlap")
 	if err := os.MkdirAll(pluginDir, 0o755); err != nil {
 		t.Fatalf("MkdirAll(pluginDir): %v", err)
 	}
 	writeReleaseTestManifest(t, pluginDir, &providermanifestv1.Manifest{
-		Kind:        providermanifestv1.KindWebUI,
-		Source:      "github.com/testowner/plugins/webui-overlap",
+		Kind:        providermanifestv1.KindUI,
+		Source:      "github.com/testowner/plugins/ui-overlap",
 		Version:     "0.0.1",
-		DisplayName: "WebUI Overlap",
+		DisplayName: "UI Overlap",
 		IconFile:    "out/icon.svg",
 		Spec: &providermanifestv1.Spec{
 			AssetRoot: "out",
@@ -1602,7 +1602,7 @@ func TestRun_ProviderReleaseAllowsOverlappingSupportPaths(t *testing.T) {
 		"--output", outputDir,
 	)
 
-	archiveName := "gestalt-plugin-webui-overlap_v" + testVersion + ".tar.gz"
+	archiveName := "gestalt-plugin-ui-overlap_v" + testVersion + ".tar.gz"
 	extractDir := extractReleasedArchive(t, outputDir, archiveName)
 	for _, rel := range []string{"out/icon.svg", "out/index.html"} {
 		if _, err := os.Stat(filepath.Join(extractDir, filepath.FromSlash(rel))); err != nil {
@@ -1614,23 +1614,23 @@ func TestRun_ProviderReleaseAllowsOverlappingSupportPaths(t *testing.T) {
 func TestRun_ProviderReleaseTreatsGoModWithoutProviderPackageAsDeclarative(t *testing.T) {
 	t.Parallel()
 
-	pluginDir := newWebUIReleaseFixture(t, t.TempDir())
+	pluginDir := newUIReleaseFixture(t, t.TempDir())
 	outputDir := t.TempDir()
 	testVersion := "0.0.4-test"
 
-	writeTestFile(t, pluginDir, "go.mod", []byte("module example.com/webui-test\n\ngo 1.22\n"), 0644)
+	writeTestFile(t, pluginDir, "go.mod", []byte("module example.com/ui-test\n\ngo 1.22\n"), 0644)
 
 	runProviderReleaseCommand(t, pluginDir,
 		"--version", testVersion,
 		"--output", outputDir,
 	)
 
-	archiveName := "gestalt-plugin-webui-test_v" + testVersion + ".tar.gz"
+	archiveName := "gestalt-plugin-ui-test_v" + testVersion + ".tar.gz"
 	if _, err := os.Stat(filepath.Join(outputDir, archiveName)); err != nil {
 		t.Fatalf("expected declarative archive %s to exist: %v", archiveName, err)
 	}
 
-	compiledArchiveName := "gestalt-plugin-webui-test_v" + testVersion + "_" + runtime.GOOS + "_" + runtime.GOARCH + ".tar.gz"
+	compiledArchiveName := "gestalt-plugin-ui-test_v" + testVersion + "_" + runtime.GOOS + "_" + runtime.GOARCH + ".tar.gz"
 	if _, err := os.Stat(filepath.Join(outputDir, compiledArchiveName)); !os.IsNotExist(err) {
 		t.Fatalf("unexpected compiled archive %s: %v", compiledArchiveName, err)
 	}
@@ -1800,7 +1800,7 @@ func TestRun_ProviderReleaseSupportsSourcePackageManifestFile(t *testing.T) {
 func TestRun_ProviderReleaseChecksumsOnlyCurrentArchives(t *testing.T) {
 	t.Parallel()
 
-	pluginDir := newWebUIReleaseFixture(t, t.TempDir())
+	pluginDir := newUIReleaseFixture(t, t.TempDir())
 	outputDir := t.TempDir()
 
 	runProviderReleaseCommand(t, pluginDir,
@@ -1817,24 +1817,24 @@ func TestRun_ProviderReleaseChecksumsOnlyCurrentArchives(t *testing.T) {
 	if err != nil {
 		t.Fatalf("read checksums.txt: %v", err)
 	}
-	if got := string(checksumData); strings.Contains(got, "gestalt-plugin-webui-test_v1.0.0.tar.gz") {
+	if got := string(checksumData); strings.Contains(got, "gestalt-plugin-ui-test_v1.0.0.tar.gz") {
 		t.Fatalf("checksums.txt unexpectedly included stale archive: %s", got)
-	} else if !strings.Contains(got, "gestalt-plugin-webui-test_v1.0.1.tar.gz") {
+	} else if !strings.Contains(got, "gestalt-plugin-ui-test_v1.0.1.tar.gz") {
 		t.Fatalf("checksums.txt missing current archive: %s", got)
 	}
 }
 
-func TestRun_ProviderReleaseRejectsOutputInsideWebUIAssetRoot(t *testing.T) {
+func TestRun_ProviderReleaseRejectsOutputInsideUIAssetRoot(t *testing.T) {
 	t.Parallel()
 
-	pluginDir := newWebUIReleaseFixtureWithAssetRoot(t, t.TempDir(), "release-output")
+	pluginDir := newUIReleaseFixtureWithAssetRoot(t, t.TempDir(), "release-output")
 	outputDir := filepath.Join(pluginDir, "release-output", "nested")
 
 	out, err := runProviderReleaseCommandResult(pluginDir, "--version", "1.0.0", "--output", outputDir)
 	if err == nil {
 		t.Fatalf("expected provider release to fail, got output: %s", out)
 	}
-	if !strings.Contains(string(out), "must not be inside webui.asset_root") {
+	if !strings.Contains(string(out), "must not be inside ui.asset_root") {
 		t.Fatalf("expected overlap error, got: %s", out)
 	}
 }
@@ -3287,22 +3287,22 @@ func newPrebuiltProviderReleaseFixture(t *testing.T, dir string) string {
 	return pluginDir
 }
 
-func newWebUIReleaseFixture(t *testing.T, dir string) string {
-	return newWebUIReleaseFixtureWithAssetRoot(t, dir, webUITestAssetRoot)
+func newUIReleaseFixture(t *testing.T, dir string) string {
+	return newUIReleaseFixtureWithAssetRoot(t, dir, uiTestAssetRoot)
 }
 
-func newBuiltWebUIReleaseFixture(t *testing.T, dir string) string {
+func newBuiltUIReleaseFixture(t *testing.T, dir string) string {
 	t.Helper()
 
-	pluginDir := filepath.Join(dir, webUITestPluginName)
+	pluginDir := filepath.Join(dir, uiTestPluginName)
 	if err := os.MkdirAll(pluginDir, 0755); err != nil {
 		t.Fatalf("MkdirAll(pluginDir): %v", err)
 	}
 	writeReleaseTestManifest(t, pluginDir, &providermanifestv1.Manifest{
-		Kind:        providermanifestv1.KindWebUI,
-		Source:      webUITestSource,
+		Kind:        providermanifestv1.KindUI,
+		Source:      uiTestSource,
 		Version:     "0.0.1",
-		DisplayName: "WebUI Test",
+		DisplayName: "UI Test",
 		IconFile:    releaseTestIconPath,
 		Release: &providermanifestv1.ReleaseMetadata{
 			Build: &providermanifestv1.ReleaseBuild{
@@ -3328,7 +3328,7 @@ func newSourceProviderReleaseFixtureWithOwnedUI(t *testing.T, dir string) string
 		t.Fatalf("MkdirAll(uiDir): %v", err)
 	}
 	writeReleaseTestManifest(t, uiDir, &providermanifestv1.Manifest{
-		Kind:        providermanifestv1.KindWebUI,
+		Kind:        providermanifestv1.KindUI,
 		Source:      "github.com/testowner/web/roadmap-ui",
 		Version:     "0.0.1",
 		DisplayName: "Roadmap UI",
@@ -3361,7 +3361,7 @@ func newSourceProviderReleaseFixtureWithBuiltOwnedUI(t *testing.T, dir string) s
 		t.Fatalf("MkdirAll(uiDir): %v", err)
 	}
 	writeReleaseTestManifest(t, uiDir, &providermanifestv1.Manifest{
-		Kind:        providermanifestv1.KindWebUI,
+		Kind:        providermanifestv1.KindUI,
 		Source:      "github.com/testowner/web/roadmap-ui",
 		Version:     "0.0.1",
 		DisplayName: "Roadmap UI",
@@ -3390,18 +3390,18 @@ func newSourceProviderReleaseFixtureWithBuiltOwnedUI(t *testing.T, dir string) s
 	return pluginDir
 }
 
-func newWebUIReleaseFixtureWithAssetRoot(t *testing.T, dir, assetRoot string) string {
+func newUIReleaseFixtureWithAssetRoot(t *testing.T, dir, assetRoot string) string {
 	t.Helper()
 
-	pluginDir := filepath.Join(dir, webUITestPluginName)
+	pluginDir := filepath.Join(dir, uiTestPluginName)
 	if err := os.MkdirAll(pluginDir, 0755); err != nil {
 		t.Fatalf("MkdirAll(pluginDir): %v", err)
 	}
 	writeReleaseTestManifest(t, pluginDir, &providermanifestv1.Manifest{
-		Kind:        providermanifestv1.KindWebUI,
-		Source:      webUITestSource,
+		Kind:        providermanifestv1.KindUI,
+		Source:      uiTestSource,
 		Version:     "0.0.1",
-		DisplayName: "WebUI Test",
+		DisplayName: "UI Test",
 		IconFile:    releaseTestIconPath,
 		Spec: &providermanifestv1.Spec{
 			AssetRoot: assetRoot,

--- a/gestaltd/internal/config/config.go
+++ b/gestaltd/internal/config/config.go
@@ -33,8 +33,8 @@ const (
 
 	DefaultIndexedDBProvider = DefaultProviderRepo + "/indexeddb/relationaldb"
 	DefaultIndexedDBVersion  = "0.0.1-alpha.1"
-	DefaultWebUIProvider     = DefaultProviderRepo + "/web/default"
-	DefaultWebUIVersion      = "0.0.1-alpha.11"
+	DefaultUIProvider        = DefaultProviderRepo + "/web/default"
+	DefaultUIVersion         = "0.0.1-alpha.11"
 	DefaultProviderInstance  = "default"
 )
 
@@ -2131,7 +2131,7 @@ func normalizeProviderSourceShapes(cfg *Config) {
 	}
 	for _, entry := range cfg.Providers.UI {
 		if entry != nil {
-			normalizeEntry(providermanifestv1.KindWebUI, &entry.ProviderEntry)
+			normalizeEntry(providermanifestv1.KindUI, &entry.ProviderEntry)
 		}
 	}
 }
@@ -2336,7 +2336,7 @@ func normalizeAdminConfig(cfg *Config) error {
 		return nil
 	}
 
-	roles, err := providerpkg.NormalizeWebUIAllowedRoles("server.admin.allowedRoles", admin.AllowedRoles)
+	roles, err := providerpkg.NormalizeUIAllowedRoles("server.admin.allowedRoles", admin.AllowedRoles)
 	if err != nil {
 		if admin.AuthorizationPolicy == "" {
 			return fmt.Errorf("normalize admin config: server.admin.allowedRoles requires server.admin.authorizationPolicy")
@@ -2454,7 +2454,7 @@ func resolveRelativePathsInValue(configPath string, root map[string]any, sourceS
 			{key: "secrets", kind: providermanifestv1.KindSecrets},
 			{key: "telemetry", kind: string(HostProviderKindTelemetry)},
 			{key: "audit", kind: string(HostProviderKindAudit)},
-			{key: "ui", kind: providermanifestv1.KindWebUI},
+			{key: "ui", kind: providermanifestv1.KindUI},
 			{key: "indexeddb", kind: providermanifestv1.KindIndexedDB},
 			{key: "cache", kind: providermanifestv1.KindCache},
 			{key: "s3", kind: providermanifestv1.KindS3},

--- a/gestaltd/internal/config/config_validate.go
+++ b/gestaltd/internal/config/config_validate.go
@@ -371,9 +371,9 @@ func ValidateResolvedStructure(cfg *Config) error {
 			continue
 		}
 		if entry.ResolvedManifest == nil || entry.ManifestSpec() == nil {
-			return fmt.Errorf("config validation: ui %q authorizationPolicy requires a resolved webui manifest", name)
+			return fmt.Errorf("config validation: ui %q authorizationPolicy requires a resolved ui manifest", name)
 		}
-		if err := providerpkg.ValidatePolicyBoundWebUIRoutes(entry.ManifestSpec().Routes); err != nil {
+		if err := providerpkg.ValidatePolicyBoundUIRoutes(entry.ManifestSpec().Routes); err != nil {
 			return fmt.Errorf("config validation: ui %q authorizationPolicy: %w", name, err)
 		}
 	}

--- a/gestaltd/internal/operator/archive_policy.go
+++ b/gestaltd/internal/operator/archive_policy.go
@@ -8,7 +8,7 @@ import (
 
 func allowsGenericArchive(kind string, manifest *providermanifestv1.Manifest) bool {
 	switch kind {
-	case providermanifestv1.KindWebUI:
+	case providermanifestv1.KindUI:
 		return true
 	case providermanifestv1.KindPlugin:
 		return manifest != nil && manifest.IsDeclarativeOnlyProvider()
@@ -34,7 +34,7 @@ func validateLockedArchivePolicy(subject, kind string, manifest *providermanifes
 
 func unsafeGenericArchiveError(subject, platform string) error {
 	return fmt.Errorf(
-		"generic release archives are not allowed for %s on %s; publish an explicit %s archive or keep the package platform-neutral (webui or declarative/spec-only plugin package)",
+		"generic release archives are not allowed for %s on %s; publish an explicit %s archive or keep the package platform-neutral (ui or declarative/spec-only plugin package)",
 		subject,
 		platform,
 		platform,

--- a/gestaltd/internal/operator/lifecycle.go
+++ b/gestaltd/internal/operator/lifecycle.go
@@ -1279,7 +1279,7 @@ func archivePolicySubject(kind, name string) string {
 	switch archivePolicyKind(kind) {
 	case providermanifestv1.KindPlugin:
 		return fmt.Sprintf("provider %q", name)
-	case providermanifestv1.KindWebUI:
+	case providermanifestv1.KindUI:
 		return fmt.Sprintf("ui provider %q", name)
 	default:
 		return fmt.Sprintf("%s %q", kind, name)
@@ -1308,7 +1308,7 @@ func lockEntryDestDir(paths initPaths, kind, name string) string {
 		return telemetryDestDir(paths, name)
 	case providerLockKindAudit:
 		return auditDestDir(paths, name)
-	case providermanifestv1.KindWebUI:
+	case providermanifestv1.KindUI:
 		return uiDestDir(paths, name)
 	default:
 		return ""
@@ -1773,14 +1773,14 @@ func (l *Lifecycle) writeNamedUIProviderArtifact(ctx context.Context, paths init
 		return LockUIEntry{}, fmt.Errorf("fingerprinting %s: %w", subject, err)
 	}
 	if plugin.HasLocalSource() {
-		install, err := prepareLocalSourceInstall(providermanifestv1.KindWebUI, name, plugin.SourcePath(), destDir)
+		install, err := prepareLocalSourceInstall(providermanifestv1.KindUI, name, plugin.SourcePath(), destDir)
 		if err != nil {
 			return LockUIEntry{}, err
 		}
-		if err := validateInstalledManifestKind(providermanifestv1.KindWebUI, subject, install.manifest); err != nil {
+		if err := validateInstalledManifestKind(providermanifestv1.KindUI, subject, install.manifest); err != nil {
 			return LockUIEntry{}, err
 		}
-		if err := providerpkg.ValidateConfigForManifest(install.manifestPath, install.manifest, providermanifestv1.KindWebUI, configMap); err != nil {
+		if err := providerpkg.ValidateConfigForManifest(install.manifestPath, install.manifest, providermanifestv1.KindUI, configMap); err != nil {
 			return LockUIEntry{}, fmt.Errorf("provider config validation for %s: %w", subject, err)
 		}
 		entry, err := localUILockEntryFromPreparedInstall(paths, name, plugin, install)
@@ -1800,11 +1800,11 @@ func (l *Lifecycle) writeNamedUIProviderArtifact(ctx context.Context, paths init
 	if !plugin.HasReleaseMetadataSource() {
 		return LockUIEntry{}, fmt.Errorf("%s source %q: only provider-release metadata sources and local manifest paths are supported", subject, expectedPackage)
 	}
-	installed, entry, opErr = l.installMetadataSourcePackage(ctx, providermanifestv1.KindWebUI, name, subject, destDir, plugin, paths.configDir)
+	installed, entry, opErr = l.installMetadataSourcePackage(ctx, providermanifestv1.KindUI, name, subject, destDir, plugin, paths.configDir)
 	if opErr != nil {
 		return LockUIEntry{}, opErr
 	}
-	if err := providerpkg.ValidateConfigForManifest(installed.ManifestPath, installed.Manifest, providermanifestv1.KindWebUI, configMap); err != nil {
+	if err := providerpkg.ValidateConfigForManifest(installed.ManifestPath, installed.Manifest, providermanifestv1.KindUI, configMap); err != nil {
 		return LockUIEntry{}, fmt.Errorf("provider config validation for %s: %w", subject, err)
 	}
 	manifestPath, err := filepath.Rel(paths.artifactsDir, installed.ManifestPath)
@@ -2405,10 +2405,10 @@ func bindResolvedComponentManifest(kind, name string, plugin *config.ProviderEnt
 
 func bindResolvedUIManifest(plugin *config.ProviderEntry, manifestPath string, manifest *providermanifestv1.Manifest, configMap map[string]any) error {
 	manifest = providerpkg.ResolveManifestLocalReferences(manifest, manifestPath)
-	if err := validateInstalledManifestKind(providermanifestv1.KindWebUI, "provider", manifest); err != nil {
+	if err := validateInstalledManifestKind(providermanifestv1.KindUI, "provider", manifest); err != nil {
 		return err
 	}
-	if err := providerpkg.ValidateConfigForManifest(manifestPath, manifest, providermanifestv1.KindWebUI, configMap); err != nil {
+	if err := providerpkg.ValidateConfigForManifest(manifestPath, manifest, providermanifestv1.KindUI, configMap); err != nil {
 		return fmt.Errorf("provider config validation for ui provider: %w", err)
 	}
 	resolveProviderIcon(manifest, manifestPath, plugin)
@@ -2598,7 +2598,7 @@ func (l *Lifecycle) materializeLockedUIProvider(ctx context.Context, paths initP
 	if err != nil {
 		return fmt.Errorf("install locked source for ui provider: %w", err)
 	}
-	if err := validateInstalledManifestKind(providermanifestv1.KindWebUI, "ui provider", installed.Manifest); err != nil {
+	if err := validateInstalledManifestKind(providermanifestv1.KindUI, "ui provider", installed.Manifest); err != nil {
 		return err
 	}
 	if installed.Manifest.Source != lockEntryPackage(entry) {

--- a/gestaltd/internal/operator/lifecycle_source_test.go
+++ b/gestaltd/internal/operator/lifecycle_source_test.go
@@ -919,14 +919,14 @@ func TestSourceWorkflowMetadataURLInitAndLockedLoad(t *testing.T) {
 	}
 }
 
-func TestSourceWebUIMetadataURLInitAndLockedLoad(t *testing.T) {
+func TestSourceUIMetadataURLInitAndLockedLoad(t *testing.T) {
 	t.Parallel()
 
 	dir := t.TempDir()
 	packageSource := "github.com/acme/tools/roadmap-ui"
 	version := "0.9.1"
 	archivePath := mustBuildManagedProviderPackage(t, dir, &providermanifestv1.Manifest{
-		Kind:        providermanifestv1.KindWebUI,
+		Kind:        providermanifestv1.KindUI,
 		Source:      packageSource,
 		Version:     version,
 		DisplayName: "Roadmap UI",
@@ -938,7 +938,7 @@ func TestSourceWebUIMetadataURLInitAndLockedLoad(t *testing.T) {
 	}, false)
 	archiveData, err := os.ReadFile(archivePath)
 	if err != nil {
-		t.Fatalf("read webui archive: %v", err)
+		t.Fatalf("read ui archive: %v", err)
 	}
 	archiveSHA := sha256.Sum256(archiveData)
 
@@ -970,9 +970,9 @@ func TestSourceWebUIMetadataURLInitAndLockedLoad(t *testing.T) {
 				Schema:        providerReleaseSchemaName,
 				SchemaVersion: providerReleaseSchemaVersion,
 				Package:       packageSource,
-				Kind:          providermanifestv1.KindWebUI,
+				Kind:          providermanifestv1.KindUI,
 				Version:       version,
-				Runtime:       providerReleaseRuntimeWebUI,
+				Runtime:       providerReleaseRuntimeUI,
 				Artifacts: map[string]providerReleaseArtifact{
 					providerpkg.CurrentPlatformString(): {
 						Path:   filepath.Base(archivePathURL),
@@ -1047,11 +1047,11 @@ func TestSourceWebUIMetadataURLInitAndLockedLoad(t *testing.T) {
 	if entry.Package != packageSource {
 		t.Fatalf("entry.Package = %q, want %q", entry.Package, packageSource)
 	}
-	if entry.Kind != providermanifestv1.KindWebUI {
-		t.Fatalf("entry.Kind = %q, want %q", entry.Kind, providermanifestv1.KindWebUI)
+	if entry.Kind != providermanifestv1.KindUI {
+		t.Fatalf("entry.Kind = %q, want %q", entry.Kind, providermanifestv1.KindUI)
 	}
-	if entry.Runtime != providerReleaseRuntimeWebUI {
-		t.Fatalf("entry.Runtime = %q, want %q", entry.Runtime, providerReleaseRuntimeWebUI)
+	if entry.Runtime != providerReleaseRuntimeUI {
+		t.Fatalf("entry.Runtime = %q, want %q", entry.Runtime, providerReleaseRuntimeUI)
 	}
 	if entry.Version != version {
 		t.Fatalf("entry.Version = %q, want %q", entry.Version, version)
@@ -1092,8 +1092,8 @@ func TestSourceWebUIMetadataURLInitAndLockedLoad(t *testing.T) {
 	if ui == nil || ui.ResolvedManifest == nil {
 		t.Fatalf("ui resolved manifest = %+v", ui)
 	}
-	if got := ui.ResolvedManifest.Kind; got != providermanifestv1.KindWebUI {
-		t.Fatalf("ui manifest kind = %q, want %q", got, providermanifestv1.KindWebUI)
+	if got := ui.ResolvedManifest.Kind; got != providermanifestv1.KindUI {
+		t.Fatalf("ui manifest kind = %q, want %q", got, providermanifestv1.KindUI)
 	}
 	if got := ui.ResolvedManifest.Source; got != packageSource {
 		t.Fatalf("ui manifest source = %q, want %q", got, packageSource)

--- a/gestaltd/internal/operator/lifecycle_test.go
+++ b/gestaltd/internal/operator/lifecycle_test.go
@@ -3611,6 +3611,54 @@ func TestReadLockfile_RejectsSchemaV1PortableEntries(t *testing.T) {
 	}
 }
 
+func TestReadLockfile_PreservesLegacyPortableWebUILockEntries(t *testing.T) {
+	t.Parallel()
+
+	dir := t.TempDir()
+	lockPath := filepath.Join(dir, InitLockfileName)
+	legacy := `{
+  "schema": "gestaltd-provider-lock",
+  "schemaVersion": 3,
+  "revision": 0,
+  "providers": {
+    "webui": {
+      "admin": {
+        "inputDigest": "ui-fp",
+        "package": "github.com/test-org/test-repo/test-ui",
+        "kind": "webui",
+        "runtime": "ui",
+        "version": "2.0.0"
+      }
+    }
+  }
+}
+`
+	if err := os.WriteFile(lockPath, []byte(legacy), 0o644); err != nil {
+		t.Fatalf("WriteFile: %v", err)
+	}
+
+	lock, err := ReadLockfile(lockPath)
+	if err != nil {
+		t.Fatalf("ReadLockfile: %v", err)
+	}
+	entry, ok := lock.UIs["admin"]
+	if !ok {
+		t.Fatal("expected legacy webui portable entry to be preserved in ui lock entries")
+	}
+	if got, want := entry.Fingerprint, "ui-fp"; got != want {
+		t.Fatalf("Fingerprint = %q, want %q", got, want)
+	}
+	if got, want := entry.Source, "github.com/test-org/test-repo/test-ui"; got != want {
+		t.Fatalf("Source = %q, want %q", got, want)
+	}
+	if got, want := entry.Runtime, "ui"; got != want {
+		t.Fatalf("Runtime = %q, want %q", got, want)
+	}
+	if got, want := entry.Kind, providermanifestv1.KindUI; got != want {
+		t.Fatalf("Kind = %q, want %q", got, want)
+	}
+}
+
 func mustBuildManagedProviderPackage(t *testing.T, dir string, manifest *providermanifestv1.Manifest, artifacts map[string]string, includeCatalog bool) string {
 	t.Helper()
 

--- a/gestaltd/internal/operator/lifecycle_test.go
+++ b/gestaltd/internal/operator/lifecycle_test.go
@@ -214,7 +214,7 @@ func newManagedMetadataServer(t *testing.T, releases []managedMetadataRelease) *
 	}))
 }
 
-func writeLocalWebUIManifest(t *testing.T, dir, name, source, version string, spec *providermanifestv1.Spec, files map[string]string) string {
+func writeLocalUIManifest(t *testing.T, dir, name, source, version string, spec *providermanifestv1.Spec, files map[string]string) string {
 	t.Helper()
 
 	root := filepath.Join(dir, name)
@@ -232,7 +232,7 @@ func writeLocalWebUIManifest(t *testing.T, dir, name, source, version string, sp
 	}
 	manifestPath := filepath.Join(root, "manifest.yaml")
 	manifest, err := providerpkg.EncodeSourceManifestFormat(&providermanifestv1.Manifest{
-		Kind:        providermanifestv1.KindWebUI,
+		Kind:        providermanifestv1.KindUI,
 		Source:      source,
 		Version:     version,
 		DisplayName: testDisplayName(name),
@@ -1170,7 +1170,7 @@ server:
 	}
 }
 
-func TestLoadForExecutionAtPath_ResolvesLocalMountedWebUIWithoutLockfile(t *testing.T) {
+func TestLoadForExecutionAtPath_ResolvesLocalMountedUIWithoutLockfile(t *testing.T) {
 	t.Parallel()
 
 	tests := []struct {
@@ -1189,7 +1189,7 @@ func TestLoadForExecutionAtPath_ResolvesLocalMountedWebUIWithoutLockfile(t *test
 			uiConfigYAML: `  ui:
     roadmap:
       source:
-        path: ./webui/manifest.yaml
+        path: ./ui/manifest.yaml
       path: /create-customer-roadmap-review
 `,
 			uiKey:    "roadmap",
@@ -1200,7 +1200,7 @@ func TestLoadForExecutionAtPath_ResolvesLocalMountedWebUIWithoutLockfile(t *test
 			uiConfigYAML: `  ui:
     roadmap:
       source:
-        path: ./webui/manifest.yaml
+        path: ./ui/manifest.yaml
 plugins:
     roadmap:
       source:
@@ -1226,10 +1226,10 @@ plugins:
 			uiConfigYAML: `  ui:
     roadmap:
       source:
-        path: ./webui/manifest.yaml
+        path: ./ui/manifest.yaml
     console:
       source:
-        path: ./webui/manifest.yaml
+        path: ./ui/manifest.yaml
       path: /console
 plugins:
     roadmap:
@@ -1248,7 +1248,7 @@ plugins:
 			uiConfigYAML: `  ui:
     roadmap:
       source:
-        path: ./webui/manifest.yaml
+        path: ./ui/manifest.yaml
 plugins:
     roadmap:
       disabled: true
@@ -1278,7 +1278,7 @@ plugins:
 			uiKey:       "roadmap",
 			wantPath:    "/create-customer-roadmap-review",
 			wantPolicy:  "roadmap_policy",
-			ownedUIPath: "../webui/manifest.yaml",
+			ownedUIPath: "../ui/manifest.yaml",
 		},
 		{
 			name: "plugin owned ui via plugin mount with noncanonical manifest filename",
@@ -1300,7 +1300,7 @@ plugins:
 			uiKey:       "roadmap",
 			wantPath:    "/create-customer-roadmap-review",
 			wantPolicy:  "roadmap_policy",
-			ownedUIPath: "../webui/ui-manifest.yaml",
+			ownedUIPath: "../ui/ui-manifest.yaml",
 			uiManifest:  "ui-manifest.yaml",
 		},
 		{
@@ -1308,7 +1308,7 @@ plugins:
 			uiConfigYAML: `  ui:
     roadmap:
       source:
-        path: ./webui/manifest.yaml
+        path: ./ui/manifest.yaml
 plugins:
     roadmap:
       source:
@@ -1327,7 +1327,7 @@ plugins:
 			uiKey:       "roadmap",
 			wantPath:    "/create-customer-roadmap-review",
 			wantPolicy:  "roadmap_policy",
-			ownedUIPath: "../webui/manifest.yaml",
+			ownedUIPath: "../ui/manifest.yaml",
 		},
 		{
 			name: "disabled same-name ui overlay is rejected at parse time",
@@ -1335,7 +1335,7 @@ plugins:
     roadmap:
       disabled: true
       source:
-        path: ./webui/manifest.yaml
+        path: ./ui/manifest.yaml
 plugins:
     roadmap:
       source:
@@ -1343,7 +1343,7 @@ plugins:
       mountPath: /create-customer-roadmap-review
 `,
 			wantErr:     "field disabled not found",
-			ownedUIPath: "../webui/manifest.yaml",
+			ownedUIPath: "../ui/manifest.yaml",
 		},
 	}
 
@@ -1353,23 +1353,23 @@ plugins:
 			t.Parallel()
 
 			dir := t.TempDir()
-			webUIDir := filepath.Join(dir, "webui")
-			if err := os.MkdirAll(filepath.Join(webUIDir, "dist"), 0o755); err != nil {
-				t.Fatalf("MkdirAll webui dist: %v", err)
+			uiDir := filepath.Join(dir, "ui")
+			if err := os.MkdirAll(filepath.Join(uiDir, "dist"), 0o755); err != nil {
+				t.Fatalf("MkdirAll ui dist: %v", err)
 			}
-			if err := os.WriteFile(filepath.Join(webUIDir, "dist", "index.html"), []byte("<html>roadmap</html>"), 0o644); err != nil {
+			if err := os.WriteFile(filepath.Join(uiDir, "dist", "index.html"), []byte("<html>roadmap</html>"), 0o644); err != nil {
 				t.Fatalf("WriteFile index.html: %v", err)
 			}
 			manifestName := cmp.Or(tc.uiManifest, "manifest.yaml")
-			manifestPath := filepath.Join(webUIDir, manifestName)
+			manifestPath := filepath.Join(uiDir, manifestName)
 			spec := &providermanifestv1.Spec{AssetRoot: "dist"}
 			if tc.wantPolicy != "" {
-				spec.Routes = []providermanifestv1.WebUIRoute{
+				spec.Routes = []providermanifestv1.UIRoute{
 					{Path: "/", AllowedRoles: []string{"viewer"}},
 				}
 			}
 			manifest, err := providerpkg.EncodeSourceManifestFormat(&providermanifestv1.Manifest{
-				Kind:        providermanifestv1.KindWebUI,
+				Kind:        providermanifestv1.KindUI,
 				Source:      "github.com/testowner/web/roadmap",
 				Version:     "0.0.1-alpha.1",
 				DisplayName: "Roadmap UI",
@@ -1454,13 +1454,13 @@ plugins:
 			}
 			gotManifestPath := filepath.ToSlash(entry.ResolvedManifestPath)
 			wantUIManifest := filepath.ToSlash(filepath.Join(".gestaltd", "ui", tc.uiKey, "manifest.yaml"))
-			wantOwnedManifest := filepath.ToSlash(filepath.Join(".gestaltd", "providers", "roadmap", "_owned_ui", "webui", "manifest.yaml"))
+			wantOwnedManifest := filepath.ToSlash(filepath.Join(".gestaltd", "providers", "roadmap", "_owned_ui", "ui", "manifest.yaml"))
 			if !strings.HasSuffix(gotManifestPath, wantUIManifest) && !strings.HasSuffix(gotManifestPath, wantOwnedManifest) {
 				t.Fatalf("ResolvedManifestPath = %q", gotManifestPath)
 			}
 			gotAssetRoot := filepath.ToSlash(entry.ResolvedAssetRoot)
 			wantUIAssetRoot := filepath.ToSlash(filepath.Join(".gestaltd", "ui", tc.uiKey, "dist"))
-			wantOwnedAssetRoot := filepath.ToSlash(filepath.Join(".gestaltd", "providers", "roadmap", "_owned_ui", "webui", "dist"))
+			wantOwnedAssetRoot := filepath.ToSlash(filepath.Join(".gestaltd", "providers", "roadmap", "_owned_ui", "ui", "dist"))
 			if !strings.HasSuffix(gotAssetRoot, wantUIAssetRoot) && !strings.HasSuffix(gotAssetRoot, wantOwnedAssetRoot) {
 				t.Fatalf("ResolvedAssetRoot = %q", gotAssetRoot)
 			}
@@ -1495,15 +1495,15 @@ func TestLoadForExecutionAtPath_RejectsLockedExplicitLocalUIWithoutPreparedUILoc
 	t.Parallel()
 
 	dir := t.TempDir()
-	webUIDir := filepath.Join(dir, "webui")
-	if err := os.MkdirAll(filepath.Join(webUIDir, "dist"), 0o755); err != nil {
-		t.Fatalf("MkdirAll webui dist: %v", err)
+	uiDir := filepath.Join(dir, "ui")
+	if err := os.MkdirAll(filepath.Join(uiDir, "dist"), 0o755); err != nil {
+		t.Fatalf("MkdirAll ui dist: %v", err)
 	}
-	if err := os.WriteFile(filepath.Join(webUIDir, "dist", "index.html"), []byte("<html>roadmap</html>"), 0o644); err != nil {
+	if err := os.WriteFile(filepath.Join(uiDir, "dist", "index.html"), []byte("<html>roadmap</html>"), 0o644); err != nil {
 		t.Fatalf("WriteFile index.html: %v", err)
 	}
 	manifest, err := providerpkg.EncodeSourceManifestFormat(&providermanifestv1.Manifest{
-		Kind:        providermanifestv1.KindWebUI,
+		Kind:        providermanifestv1.KindUI,
 		Source:      "github.com/testowner/web/roadmap",
 		Version:     "0.0.1-alpha.1",
 		DisplayName: "Roadmap UI",
@@ -1512,7 +1512,7 @@ func TestLoadForExecutionAtPath_RejectsLockedExplicitLocalUIWithoutPreparedUILoc
 	if err != nil {
 		t.Fatalf("EncodeManifest: %v", err)
 	}
-	if err := os.WriteFile(filepath.Join(webUIDir, "manifest.yaml"), manifest, 0o644); err != nil {
+	if err := os.WriteFile(filepath.Join(uiDir, "manifest.yaml"), manifest, 0o644); err != nil {
 		t.Fatalf("WriteFile manifest: %v", err)
 	}
 
@@ -1520,7 +1520,7 @@ func TestLoadForExecutionAtPath_RejectsLockedExplicitLocalUIWithoutPreparedUILoc
 	cfg := requiredComponentConfigYAML(t, dir, filepath.Join(dir, "gestalt.db")) + `  ui:
     roadmap:
       source:
-        path: ./webui/manifest.yaml
+        path: ./ui/manifest.yaml
       path: /create-customer-roadmap-review
 server:
 ` + requiredServerDatastoreYAML() + `  encryptionKey: aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa
@@ -1572,7 +1572,7 @@ func TestLoadForExecutionAtPath_ResolvesManagedPluginOwnedUIFromManagedPath(t *t
 
 	ownedUIManifestPath := filepath.ToSlash(filepath.Join("_owned_ui", "roadmap-ui", providerpkg.ManifestFile))
 	ownedUIManifestBytes, err := providerpkg.EncodeManifest(&providermanifestv1.Manifest{
-		Kind:        providermanifestv1.KindWebUI,
+		Kind:        providermanifestv1.KindUI,
 		Source:      "github.com/testowner/web/roadmap-review",
 		Version:     version,
 		DisplayName: "Roadmap Review UI",
@@ -1628,7 +1628,7 @@ func TestLoadForExecutionAtPath_ResolvesManagedPluginOwnedUIFromManagedPath(t *t
 		t.Fatalf("MkdirAll owned ui dir: %v", err)
 	}
 	outsideOwnedUIManifest, err := providerpkg.EncodeManifest(&providermanifestv1.Manifest{
-		Kind:        providermanifestv1.KindWebUI,
+		Kind:        providermanifestv1.KindUI,
 		Source:      "github.com/testowner/web/outside-roadmap",
 		Version:     version,
 		DisplayName: "Outside Roadmap UI",
@@ -1957,7 +1957,7 @@ func TestLoadForExecutionAtPath_UsesDerivedPreparedPathsWhenLockPathsAreStale(t 
 	const version = "0.0.1-alpha.1"
 	pluginManifestPath := writeLocalExecutablePlugin(t, dir, "example", "ping")
 	indexedDBManifestPath := writeStubIndexedDBManifest(t, dir)
-	webUIManifestPath := writeLocalWebUIManifest(t, dir, "roadmap-ui", "github.com/testowner/web/roadmap", version, &providermanifestv1.Spec{
+	uiManifestPath := writeLocalUIManifest(t, dir, "roadmap-ui", "github.com/testowner/web/roadmap", version, &providermanifestv1.Spec{
 		AssetRoot: "dist",
 	}, map[string]string{
 		"dist/index.html": "<html>roadmap</html>",
@@ -1984,7 +1984,7 @@ server:
   providers:
     indexeddb: main
   encryptionKey: aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa
-`, indexedDBManifestPath, filepath.Join(dir, "gestalt.db"), webUIManifestPath, pluginManifestPath)
+`, indexedDBManifestPath, filepath.Join(dir, "gestalt.db"), uiManifestPath, pluginManifestPath)
 	if err := os.WriteFile(cfgPath, []byte(cfg), 0o644); err != nil {
 		t.Fatalf("WriteFile config: %v", err)
 	}
@@ -2111,7 +2111,7 @@ func TestInitAtPath_RejectsManagedPluginOwnedUIPathOutsidePackage(t *testing.T) 
 		t.Fatalf("MkdirAll outside owned UI dist: %v", err)
 	}
 	outsideOwnedUIManifest, err := providerpkg.EncodeManifest(&providermanifestv1.Manifest{
-		Kind:        providermanifestv1.KindWebUI,
+		Kind:        providermanifestv1.KindUI,
 		Source:      "github.com/testowner/web/outside-roadmap",
 		Version:     version,
 		DisplayName: "Outside Roadmap UI",
@@ -2161,7 +2161,7 @@ server:
 	}
 }
 
-func TestLoadForExecutionAtPath_RejectsDisabledLocalMountedWebUIWithoutLockfile(t *testing.T) {
+func TestLoadForExecutionAtPath_RejectsDisabledLocalMountedUIWithoutLockfile(t *testing.T) {
 	t.Parallel()
 
 	dir := t.TempDir()
@@ -2170,7 +2170,7 @@ func TestLoadForExecutionAtPath_RejectsDisabledLocalMountedWebUIWithoutLockfile(
     roadmap:
       disabled: true
       source:
-        path: ./missing-webui/manifest.yaml
+        path: ./missing-ui/manifest.yaml
       path: /create-customer-roadmap-review
 ` + `server:
 ` + requiredServerDatastoreYAML() + `  encryptionKey: aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa
@@ -2189,7 +2189,7 @@ func TestLoadForExecutionAtPath_RejectsDisabledLocalMountedWebUIWithoutLockfile(
 	}
 }
 
-func TestInitAtPath_RejectsDisabledManagedMountedWebUI(t *testing.T) {
+func TestInitAtPath_RejectsDisabledManagedMountedUI(t *testing.T) {
 	t.Parallel()
 
 	dir := t.TempDir()
@@ -2375,7 +2375,7 @@ providers:
 	}
 }
 
-func TestInitAtPath_RejectsPolicyBoundManagedMountedWebUIWithoutExplicitRouteCoverage(t *testing.T) {
+func TestInitAtPath_RejectsPolicyBoundManagedMountedUIWithoutExplicitRouteCoverage(t *testing.T) {
 	t.Parallel()
 
 	tests := []struct {
@@ -2392,7 +2392,7 @@ func TestInitAtPath_RejectsPolicyBoundManagedMountedWebUIWithoutExplicitRouteCov
 			name: "missing root coverage",
 			spec: &providermanifestv1.Spec{
 				AssetRoot: "dist",
-				Routes: []providermanifestv1.WebUIRoute{
+				Routes: []providermanifestv1.UIRoute{
 					{Path: "/reports", AllowedRoles: []string{"admin"}},
 				},
 			},
@@ -2406,7 +2406,7 @@ func TestInitAtPath_RejectsPolicyBoundManagedMountedWebUIWithoutExplicitRouteCov
 
 			dir := t.TempDir()
 			pkgPath := mustBuildManagedProviderPackage(t, dir, &providermanifestv1.Manifest{
-				Kind:        providermanifestv1.KindWebUI,
+				Kind:        providermanifestv1.KindUI,
 				Source:      "github.com/testowner/web/sample-portal",
 				Version:     "0.0.1-alpha.1",
 				DisplayName: "Sample Portal",
@@ -2420,8 +2420,8 @@ func TestInitAtPath_RejectsPolicyBoundManagedMountedWebUIWithoutExplicitRouteCov
 				archiveFilePath: pkgPath,
 				packageSource:   "github.com/testowner/web/sample-portal",
 				version:         "0.0.1-alpha.1",
-				kind:            providermanifestv1.KindWebUI,
-				runtime:         providerReleaseRuntimeWebUI,
+				kind:            providermanifestv1.KindUI,
+				runtime:         providerReleaseRuntimeUI,
 			}})
 			defer srv.Close()
 
@@ -2496,10 +2496,10 @@ func TestLockProviderEntryForSource_RejectsManifestWithoutProviderKind(t *testin
 	}
 }
 
-func TestHashPlatformInEntries_HashesMountedWebUIAndProviderArchives(t *testing.T) {
+func TestHashPlatformInEntries_HashesMountedUIAndProviderArchives(t *testing.T) {
 	t.Parallel()
 
-	archiveBytes := []byte("mounted-web-ui-archive")
+	archiveBytes := []byte("mounted-ui-archive")
 	sum := sha256.Sum256(archiveBytes)
 	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		_, _ = w.Write(archiveBytes)
@@ -2540,7 +2540,7 @@ func TestHashPlatformInEntries_HashesMountedWebUIAndProviderArchives(t *testing.
 	got := lock.UIs["roadmap"].Archives[platformKeyGeneric].SHA256
 	want := hex.EncodeToString(sum[:])
 	if got != want {
-		t.Fatalf("webui SHA256 = %q, want %q", got, want)
+		t.Fatalf("ui SHA256 = %q, want %q", got, want)
 	}
 	if got := lock.Caches["session"].Archives[providerpkg.CurrentPlatformString()].SHA256; got != want {
 		t.Fatalf("cache SHA256 = %q, want %q", got, want)
@@ -3385,7 +3385,7 @@ func TestProviderFingerprint_Stable(t *testing.T) {
 			t.Fatalf("MkdirAll(%q): %v", filepath.Dir(manifestPath), err)
 		}
 		manifest := fmt.Sprintf("source: github.com/test-org/fingerprint-test/component\nversion: 0.0.1\nkind: %s\n", kind)
-		if kind == providermanifestv1.KindWebUI {
+		if kind == providermanifestv1.KindUI {
 			assetRoot := filepath.Join(filepath.Dir(manifestPath), "assets")
 			if err := os.MkdirAll(assetRoot, 0o755); err != nil {
 				t.Fatalf("MkdirAll(%q): %v", assetRoot, err)
@@ -3455,8 +3455,8 @@ func TestProviderFingerprint_Stable(t *testing.T) {
 		root := t.TempDir()
 		firstConfigDir := filepath.Join(root, "one", "deploy")
 		secondConfigDir := filepath.Join(root, "two", "deploy")
-		firstManifestPath := writeSourceManifest(t, filepath.Join(root, "one"), "web/dashboard/manifest.yaml", providermanifestv1.KindWebUI)
-		secondManifestPath := writeSourceManifest(t, filepath.Join(root, "two"), "web/dashboard/manifest.yaml", providermanifestv1.KindWebUI)
+		firstManifestPath := writeSourceManifest(t, filepath.Join(root, "one"), "web/dashboard/manifest.yaml", providermanifestv1.KindUI)
+		secondManifestPath := writeSourceManifest(t, filepath.Join(root, "two"), "web/dashboard/manifest.yaml", providermanifestv1.KindUI)
 
 		firstProvider := &config.ProviderEntry{
 			Source: config.ProviderSource{Path: firstManifestPath},
@@ -3889,9 +3889,9 @@ func TestReadWriteLockfile_RoundTrip(t *testing.T) {
 	if auditEntry.Runtime != providerReleaseRuntimeDeclarative {
 		t.Fatalf("audit runtime = %q, want %q", auditEntry.Runtime, providerReleaseRuntimeDeclarative)
 	}
-	uiEntry, ok := diskLock.Providers.WebUI["roadmap"]
+	uiEntry, ok := diskLock.Providers.UI["roadmap"]
 	if !ok {
-		t.Fatal(`disk lock providers.webui["roadmap"] not found`)
+		t.Fatal(`disk lock providers.ui["roadmap"] not found`)
 	}
 	if uiEntry.InputDigest != want.UIs["roadmap"].Fingerprint {
 		t.Fatalf("ui inputDigest = %q, want %q", uiEntry.InputDigest, want.UIs["roadmap"].Fingerprint)
@@ -3899,8 +3899,8 @@ func TestReadWriteLockfile_RoundTrip(t *testing.T) {
 	if uiEntry.Source != "" {
 		t.Fatalf("ui source = %q, want omitted portable source", uiEntry.Source)
 	}
-	if uiEntry.Kind != providermanifestv1.KindWebUI {
-		t.Fatalf("ui kind = %q, want %q", uiEntry.Kind, providermanifestv1.KindWebUI)
+	if uiEntry.Kind != providermanifestv1.KindUI {
+		t.Fatalf("ui kind = %q, want %q", uiEntry.Kind, providermanifestv1.KindUI)
 	}
 	if uiEntry.Runtime != providerLockRuntimeAssets {
 		t.Fatalf("ui runtime = %q, want %q", uiEntry.Runtime, providerLockRuntimeAssets)
@@ -4005,7 +4005,7 @@ func TestHashArchiveEntry_HashesFallbackArchive(t *testing.T) {
 		},
 	}
 
-	if err := NewLifecycle().hashArchiveEntry(context.Background(), providermanifestv1.KindWebUI, "roadmap", &entry, initPaths{}, "linux/amd64", nil); err != nil {
+	if err := NewLifecycle().hashArchiveEntry(context.Background(), providermanifestv1.KindUI, "roadmap", &entry, initPaths{}, "linux/amd64", nil); err != nil {
 		t.Fatalf("hashArchiveEntry: %v", err)
 	}
 

--- a/gestaltd/internal/operator/localconfig.go
+++ b/gestaltd/internal/operator/localconfig.go
@@ -145,7 +145,7 @@ plugins:
 `, encryptionKey,
 		defaultProviderMetadataURL(config.DefaultIndexedDBProvider, config.DefaultIndexedDBVersion),
 		"sqlite://"+dbPath,
-		defaultProviderMetadataURL(config.DefaultWebUIProvider, config.DefaultWebUIVersion),
+		defaultProviderMetadataURL(config.DefaultUIProvider, config.DefaultUIVersion),
 		defaultProviderMetadataURL(defaultHTTPBinProvider, defaultHTTPBinVersion))
 }
 

--- a/gestaltd/internal/operator/localconfig_test.go
+++ b/gestaltd/internal/operator/localconfig_test.go
@@ -8,7 +8,7 @@ import (
 	"github.com/valon-technologies/gestalt/server/internal/config"
 )
 
-func TestDefaultManagedConfigIncludesRootWebUI(t *testing.T) {
+func TestDefaultManagedConfigIncludesRootUI(t *testing.T) {
 	t.Parallel()
 
 	dir := t.TempDir()
@@ -28,7 +28,7 @@ func TestDefaultManagedConfigIncludesRootWebUI(t *testing.T) {
 	if rootUI == nil {
 		t.Fatal(`Providers.UI["root"] = nil`)
 	}
-	wantURL := defaultProviderMetadataURL(config.DefaultWebUIProvider, config.DefaultWebUIVersion)
+	wantURL := defaultProviderMetadataURL(config.DefaultUIProvider, config.DefaultUIVersion)
 	if got := rootUI.SourceMetadataURL(); got != wantURL {
 		t.Fatalf(`Providers.UI["root"].SourceMetadataURL() = %q, want %q`, got, wantURL)
 	}
@@ -37,7 +37,7 @@ func TestDefaultManagedConfigIncludesRootWebUI(t *testing.T) {
 	}
 }
 
-func TestDefaultLocalSourceConfigIncludesRootWebUI(t *testing.T) {
+func TestDefaultLocalSourceConfigIncludesRootUI(t *testing.T) {
 	t.Parallel()
 
 	dir := t.TempDir()

--- a/gestaltd/internal/operator/lockschema.go
+++ b/gestaltd/internal/operator/lockschema.go
@@ -18,8 +18,8 @@ const (
 	providerLockKindAudit          = "audit"
 	providerLockRuntimeExecutable  = providerReleaseRuntimeExecutable
 	providerLockRuntimeDeclarative = providerReleaseRuntimeDeclarative
-	providerLockRuntimeWebUI       = providerReleaseRuntimeWebUI
-	providerLockRuntimeAssets      = providerLockRuntimeWebUI
+	providerLockRuntimeUI          = providerReleaseRuntimeUI
+	providerLockRuntimeAssets      = providerLockRuntimeUI
 )
 
 type providerLockfile struct {
@@ -41,7 +41,7 @@ type providerLockBuckets struct {
 	Secrets        map[string]portableLockEntry `json:"secrets,omitempty"`
 	Telemetry      map[string]portableLockEntry `json:"telemetry,omitempty"`
 	Audit          map[string]portableLockEntry `json:"audit,omitempty"`
-	WebUI          map[string]portableLockEntry `json:"webui,omitempty"`
+	UI             map[string]portableLockEntry `json:"ui,omitempty"`
 }
 
 type portableLockEntry struct {
@@ -166,7 +166,7 @@ func providerLockKinds() []string {
 		providermanifestv1.KindSecrets,
 		providerLockKindTelemetry,
 		providerLockKindAudit,
-		providermanifestv1.KindWebUI,
+		providermanifestv1.KindUI,
 	}
 }
 
@@ -195,7 +195,7 @@ func lockEntriesForProviderKind(lock *Lockfile, kind string) map[string]LockEntr
 		return lock.Telemetry
 	case providerLockKindAudit:
 		return lock.Audit
-	case providermanifestv1.KindWebUI:
+	case providermanifestv1.KindUI:
 		return lock.UIs
 	default:
 		return nil
@@ -219,7 +219,7 @@ func providerLockfileFromLockfile(lock *Lockfile) *providerLockfile {
 			Secrets:        portableEntriesFromLockEntries(lock.Secrets, providermanifestv1.KindSecrets),
 			Telemetry:      portableEntriesFromLockEntries(lock.Telemetry, providerLockKindTelemetry),
 			Audit:          portableEntriesFromLockEntries(lock.Audit, providerLockKindAudit),
-			WebUI:          portableEntriesFromLockEntries(lock.UIs, providermanifestv1.KindWebUI),
+			UI:             portableEntriesFromLockEntries(lock.UIs, providermanifestv1.KindUI),
 		},
 	}
 }
@@ -239,7 +239,7 @@ func (lock *providerLockfile) toLockfile() *Lockfile {
 	runtimeLock.Secrets = lockEntriesFromPortableEntries(lock.Providers.Secrets)
 	runtimeLock.Telemetry = lockEntriesFromPortableEntries(lock.Providers.Telemetry)
 	runtimeLock.Audit = lockEntriesFromPortableEntries(lock.Providers.Audit)
-	runtimeLock.UIs = lockEntriesFromPortableEntries(lock.Providers.WebUI)
+	runtimeLock.UIs = lockEntriesFromPortableEntries(lock.Providers.UI)
 	return runtimeLock
 }
 

--- a/gestaltd/internal/operator/lockschema.go
+++ b/gestaltd/internal/operator/lockschema.go
@@ -42,6 +42,7 @@ type providerLockBuckets struct {
 	Telemetry      map[string]portableLockEntry `json:"telemetry,omitempty"`
 	Audit          map[string]portableLockEntry `json:"audit,omitempty"`
 	UI             map[string]portableLockEntry `json:"ui,omitempty"`
+	LegacyWebUI    map[string]portableLockEntry `json:"webui,omitempty"`
 }
 
 type portableLockEntry struct {
@@ -239,7 +240,7 @@ func (lock *providerLockfile) toLockfile() *Lockfile {
 	runtimeLock.Secrets = lockEntriesFromPortableEntries(lock.Providers.Secrets)
 	runtimeLock.Telemetry = lockEntriesFromPortableEntries(lock.Providers.Telemetry)
 	runtimeLock.Audit = lockEntriesFromPortableEntries(lock.Providers.Audit)
-	runtimeLock.UIs = lockEntriesFromPortableEntries(lock.Providers.UI)
+	runtimeLock.UIs = lockEntriesFromPortableEntries(mergePortableLockEntries(lock.Providers.UI, lock.Providers.LegacyWebUI))
 	return runtimeLock
 }
 
@@ -294,7 +295,7 @@ func lockEntriesFromPortableEntries(entries map[string]portableLockEntry) map[st
 		runtimeEntries[name] = LockEntry{
 			Fingerprint: entry.InputDigest,
 			Package:     entry.Package,
-			Kind:        entry.Kind,
+			Kind:        providermanifestv1.NormalizeKind(entry.Kind),
 			Runtime:     entry.Runtime,
 			Source:      source,
 			Version:     entry.Version,

--- a/gestaltd/internal/operator/release_metadata.go
+++ b/gestaltd/internal/operator/release_metadata.go
@@ -27,7 +27,7 @@ const (
 	providerReleaseSchemaVersion      = 1
 	providerReleaseRuntimeExecutable  = "executable"
 	providerReleaseRuntimeDeclarative = "declarative"
-	providerReleaseRuntimeWebUI       = "webui"
+	providerReleaseRuntimeUI          = "ui"
 	providerReleaseMetadataMaxBytes   = 4 << 20
 	httpAcceptHeader                  = "Accept"
 	httpAcceptOctetStream             = "application/octet-stream"
@@ -104,22 +104,22 @@ func validateProviderReleaseMetadata(metadata *providerReleaseMetadata) error {
 		return fmt.Errorf("provider release version: %w", err)
 	}
 	switch metadata.Kind {
-	case providermanifestv1.KindPlugin, providermanifestv1.KindAuthentication, providermanifestv1.KindAuthorization, providermanifestv1.KindIndexedDB, providermanifestv1.KindCache, providermanifestv1.KindS3, providermanifestv1.KindWorkflow, providermanifestv1.KindSecrets, providermanifestv1.KindWebUI:
+	case providermanifestv1.KindPlugin, providermanifestv1.KindAuthentication, providermanifestv1.KindAuthorization, providermanifestv1.KindIndexedDB, providermanifestv1.KindCache, providermanifestv1.KindS3, providermanifestv1.KindWorkflow, providermanifestv1.KindSecrets, providermanifestv1.KindUI:
 	default:
 		return fmt.Errorf("provider release kind %q is not supported", metadata.Kind)
 	}
 	switch metadata.Runtime {
 	case providerReleaseRuntimeExecutable:
-		if metadata.Kind == providermanifestv1.KindWebUI {
+		if metadata.Kind == providermanifestv1.KindUI {
 			return fmt.Errorf("provider release runtime %q is invalid for kind %q", metadata.Runtime, metadata.Kind)
 		}
 	case providerReleaseRuntimeDeclarative:
 		if metadata.Kind != providermanifestv1.KindPlugin {
 			return fmt.Errorf("provider release runtime %q is only valid for kind %q", metadata.Runtime, providermanifestv1.KindPlugin)
 		}
-	case providerReleaseRuntimeWebUI:
-		if metadata.Kind != providermanifestv1.KindWebUI {
-			return fmt.Errorf("provider release runtime %q is only valid for kind %q", metadata.Runtime, providermanifestv1.KindWebUI)
+	case providerReleaseRuntimeUI:
+		if metadata.Kind != providermanifestv1.KindUI {
+			return fmt.Errorf("provider release runtime %q is only valid for kind %q", metadata.Runtime, providermanifestv1.KindUI)
 		}
 	default:
 		return fmt.Errorf("provider release runtime %q is not supported", metadata.Runtime)
@@ -380,8 +380,8 @@ func lockEntryRuntime(entry LockEntry, fallbackKind string) string {
 		return value
 	}
 	switch lockEntryKind(entry, fallbackKind) {
-	case providermanifestv1.KindWebUI:
-		return providerReleaseRuntimeWebUI
+	case providermanifestv1.KindUI:
+		return providerReleaseRuntimeUI
 	default:
 		return providerReleaseRuntimeExecutable
 	}
@@ -389,8 +389,8 @@ func lockEntryRuntime(entry LockEntry, fallbackKind string) string {
 
 func releaseRuntimeForManifest(manifest *providermanifestv1.Manifest, kind string) string {
 	switch kind {
-	case providermanifestv1.KindWebUI:
-		return providerReleaseRuntimeWebUI
+	case providermanifestv1.KindUI:
+		return providerReleaseRuntimeUI
 	case providermanifestv1.KindPlugin:
 		if manifest != nil && manifest.IsDeclarativeOnlyProvider() {
 			return providerReleaseRuntimeDeclarative

--- a/gestaltd/internal/pluginstore/store.go
+++ b/gestaltd/internal/pluginstore/store.go
@@ -24,9 +24,9 @@ type InstalledPlugin struct {
 	Artifact       *providermanifestv1.Artifact
 }
 
-func isWebUIOnly(manifest *providermanifestv1.Manifest) bool {
+func isUIOnly(manifest *providermanifestv1.Manifest) bool {
 	kind, err := providerpkg.ManifestKind(manifest)
-	return err == nil && kind == providermanifestv1.KindWebUI
+	return err == nil && kind == providermanifestv1.KindUI
 }
 
 func manifestNeedsExecutableArtifact(manifest *providermanifestv1.Manifest) bool {
@@ -43,7 +43,7 @@ func Install(packagePath, destDir string) (*InstalledPlugin, error) {
 		return nil, err
 	}
 
-	if isWebUIOnly(manifest) {
+	if isUIOnly(manifest) {
 		if err := os.MkdirAll(destDir, 0755); err != nil {
 			return nil, fmt.Errorf("create plugin directory: %w", err)
 		}
@@ -102,7 +102,7 @@ func InstallFromDir(dirPath, destDir string) (*InstalledPlugin, error) {
 		return nil, err
 	}
 
-	if isWebUIOnly(manifest) {
+	if isUIOnly(manifest) {
 		if err := os.MkdirAll(destDir, 0755); err != nil {
 			return nil, fmt.Errorf("create plugin directory: %w", err)
 		}
@@ -199,7 +199,7 @@ func executablePathForManifest(root string, manifest *providermanifestv1.Manifes
 	if manifest == nil {
 		return "", fmt.Errorf("manifest is required")
 	}
-	if isWebUIOnly(manifest) {
+	if isUIOnly(manifest) {
 		return "", nil
 	}
 	kind, err := providerpkg.ManifestKind(manifest)

--- a/gestaltd/internal/providerpkg/digest.go
+++ b/gestaltd/internal/providerpkg/digest.go
@@ -85,7 +85,7 @@ func DirectoryDigest(dirPath, manifestPath string, manifest *providermanifestv1.
 			digests = append(digests, rel+"="+sum)
 			return nil
 		}); err != nil {
-			return "", fmt.Errorf("digest webui assets: %w", err)
+			return "", fmt.Errorf("digest ui assets: %w", err)
 		}
 	}
 

--- a/gestaltd/internal/providerpkg/manifest.go
+++ b/gestaltd/internal/providerpkg/manifest.go
@@ -85,7 +85,7 @@ var validManifestKinds = map[string]bool{
 	providermanifestv1.KindS3:             true,
 	providermanifestv1.KindWorkflow:       true,
 	providermanifestv1.KindSecrets:        true,
-	providermanifestv1.KindWebUI:          true,
+	providermanifestv1.KindUI:             true,
 }
 
 func ManifestKind(manifest *providermanifestv1.Manifest) (string, error) {
@@ -97,7 +97,7 @@ func ManifestKind(manifest *providermanifestv1.Manifest) (string, error) {
 	}
 	kind := providermanifestv1.NormalizeKind(manifest.Kind)
 	if !validManifestKinds[manifest.Kind] && !validManifestKinds[kind] {
-		return "", fmt.Errorf("manifest kind %q is not valid; expected one of plugin, authentication, authorization, indexeddb, cache, s3, workflow, secrets, or webui", manifest.Kind)
+		return "", fmt.Errorf("manifest kind %q is not valid; expected one of plugin, authentication, authorization, indexeddb, cache, s3, workflow, secrets, or ui", manifest.Kind)
 	}
 	manifest.Kind = kind
 	return kind, nil
@@ -212,17 +212,17 @@ func validateManifest(manifest *providermanifestv1.Manifest, sourceMode bool) er
 				return err
 			}
 		}
-	case providermanifestv1.KindWebUI:
+	case providermanifestv1.KindUI:
 		if manifest.Entrypoint != nil {
-			return fmt.Errorf("webui manifests may not define entrypoints")
+			return fmt.Errorf("ui manifests may not define entrypoints")
 		}
 		if spec == nil || spec.AssetRoot == "" {
-			return fmt.Errorf("spec.assetRoot is required for webui manifests")
+			return fmt.Errorf("spec.assetRoot is required for ui manifests")
 		}
 		if err := validateRelativePackagePath(spec.AssetRoot, "spec.assetRoot"); err != nil {
 			return err
 		}
-		if err := validateWebUIRoutes(spec.Routes); err != nil {
+		if err := validateUIRoutes(spec.Routes); err != nil {
 			return err
 		}
 	default:
@@ -258,10 +258,10 @@ func validateOwnedUI(ownedUI *providermanifestv1.OwnedUI, sourceMode bool) error
 	return fmt.Errorf("spec.ui.path is required when spec.ui is set")
 }
 
-func validateWebUIRoutes(routes []providermanifestv1.WebUIRoute) error {
+func validateUIRoutes(routes []providermanifestv1.UIRoute) error {
 	seenPaths := make(map[string]struct{}, len(routes))
 	for i := range routes {
-		normalized, err := NormalizeWebUIRoutePath(fmt.Sprintf("spec.routes[%d].path", i), routes[i].Path)
+		normalized, err := NormalizeUIRoutePath(fmt.Sprintf("spec.routes[%d].path", i), routes[i].Path)
 		if err != nil {
 			return err
 		}
@@ -271,7 +271,7 @@ func validateWebUIRoutes(routes []providermanifestv1.WebUIRoute) error {
 		}
 		seenPaths[normalized] = struct{}{}
 
-		roles, err := NormalizeWebUIAllowedRoles(fmt.Sprintf("spec.routes[%d].allowedRoles", i), routes[i].AllowedRoles)
+		roles, err := NormalizeUIAllowedRoles(fmt.Sprintf("spec.routes[%d].allowedRoles", i), routes[i].AllowedRoles)
 		if err != nil {
 			return err
 		}
@@ -280,7 +280,7 @@ func validateWebUIRoutes(routes []providermanifestv1.WebUIRoute) error {
 	return nil
 }
 
-func ValidatePolicyBoundWebUIRoutes(routes []providermanifestv1.WebUIRoute) error {
+func ValidatePolicyBoundUIRoutes(routes []providermanifestv1.UIRoute) error {
 	if len(routes) == 0 {
 		return fmt.Errorf("policy-bound UIs must declare at least one route")
 	}
@@ -289,7 +289,7 @@ func ValidatePolicyBoundWebUIRoutes(routes []providermanifestv1.WebUIRoute) erro
 		if len(routes[i].AllowedRoles) == 0 {
 			return fmt.Errorf("spec.routes[%d].allowedRoles must not be empty", i)
 		}
-		if WebUIRouteMatches(routes[i].Path, "/") {
+		if UIRouteMatches(routes[i].Path, "/") {
 			coversRoot = true
 		}
 	}

--- a/gestaltd/internal/providerpkg/manifest_workflow_test.go
+++ b/gestaltd/internal/providerpkg/manifest_workflow_test.go
@@ -69,18 +69,18 @@ func TestManifestWorkflow_RoundTripsProviderPackagesAcrossDirectoryAndArchive(t 
 
 }
 
-func TestManifestWorkflow_RoundTripsWebUIPackage(t *testing.T) {
+func TestManifestWorkflow_RoundTripsUIPackage(t *testing.T) {
 	t.Parallel()
 
 	root := t.TempDir()
-	sourceDir := filepath.Join(root, "webui")
+	sourceDir := filepath.Join(root, "ui")
 	manifest := &providermanifestv1.Manifest{
-		Kind:    providermanifestv1.KindWebUI,
-		Source:  "github.com/acme/plugins/webui",
+		Kind:    providermanifestv1.KindUI,
+		Source:  "github.com/acme/plugins/ui",
 		Version: "1.0.0",
 		Spec: &providermanifestv1.Spec{
 			AssetRoot: "ui/dist",
-			Routes: []providermanifestv1.WebUIRoute{
+			Routes: []providermanifestv1.UIRoute{
 				{Path: "/admin/*", AllowedRoles: []string{"admin"}},
 				{Path: "/*", AllowedRoles: []string{"viewer", "admin"}},
 			},
@@ -98,13 +98,13 @@ func TestManifestWorkflow_RoundTripsWebUIPackage(t *testing.T) {
 		t.Fatalf("manifest path = %q, want manifest.yml", gotPath)
 	}
 	if manifest.Spec == nil || manifest.Spec.AssetRoot != "ui/dist" {
-		t.Fatalf("unexpected webui manifest: %#v", manifest.Spec)
+		t.Fatalf("unexpected ui manifest: %#v", manifest.Spec)
 	}
 	if len(manifest.Spec.Routes) != 2 || manifest.Spec.Routes[0].Path != "/admin/*" || manifest.Spec.Routes[1].Path != "/*" {
-		t.Fatalf("unexpected webui routes: %#v", manifest.Spec.Routes)
+		t.Fatalf("unexpected ui routes: %#v", manifest.Spec.Routes)
 	}
 
-	archivePath := filepath.Join(root, "webui.tar.gz")
+	archivePath := filepath.Join(root, "ui.tar.gz")
 	if err := CreatePackageFromDir(sourceDir, archivePath); err != nil {
 		t.Fatalf("CreatePackageFromDir: %v", err)
 	}
@@ -182,7 +182,7 @@ func TestLoadManifestFromPath_PrefersManifestFileOrder(t *testing.T) {
 					source = "github.com/acme/plugins/yaml-first"
 				}
 				manifest := &providermanifestv1.Manifest{
-					Kind:    providermanifestv1.KindWebUI,
+					Kind:    providermanifestv1.KindUI,
 					Source:  source,
 					Version: "1.0.0",
 					Spec:    &providermanifestv1.Spec{AssetRoot: "ui"},
@@ -218,7 +218,7 @@ func TestManifestWorkflow_RejectsInvalidPackageInputs(t *testing.T) {
 		wantError  string
 	}{
 		{
-			name: "missing provider and webui",
+			name: "missing provider and ui",
 			buildData: func(t *testing.T, dir string) string {
 				return mustWriteManifestData(t, dir, ManifestFile, mustRawManifestJSON(t, &providermanifestv1.Manifest{
 					Kind:    "",
@@ -229,12 +229,12 @@ func TestManifestWorkflow_RejectsInvalidPackageInputs(t *testing.T) {
 			wantError: "manifest kind is required",
 		},
 		{
-			name: "rejects webui route without allowed roles",
+			name: "rejects ui route without allowed roles",
 			buildData: func(t *testing.T, dir string) string {
 				mustWriteFile(t, filepath.Join(dir, "ui", "dist", "index.html"), []byte("<html/>"), 0o644)
 				return mustWriteManifestData(t, dir, "manifest.yml", []byte(`
-kind: webui
-source: github.com/acme/plugins/webui-routes
+kind: ui
+source: github.com/acme/plugins/ui-routes
 version: 1.0.0
 spec:
   assetRoot: ui/dist
@@ -245,12 +245,12 @@ spec:
 			wantError: "allowedRoles must not be empty",
 		},
 		{
-			name: "rejects non-terminal wildcard webui route",
+			name: "rejects non-terminal wildcard ui route",
 			buildData: func(t *testing.T, dir string) string {
 				mustWriteFile(t, filepath.Join(dir, "ui", "dist", "index.html"), []byte("<html/>"), 0o644)
 				return mustWriteManifestData(t, dir, "manifest.yml", []byte(`
-kind: webui
-source: github.com/acme/plugins/webui-routes
+kind: ui
+source: github.com/acme/plugins/ui-routes
 version: 1.0.0
 spec:
   assetRoot: ui/dist

--- a/gestaltd/internal/providerpkg/prepared_stage.go
+++ b/gestaltd/internal/providerpkg/prepared_stage.go
@@ -180,7 +180,7 @@ func resolvePreparedInstallBuildKind(root string, manifest *providermanifestv1.M
 			return "", err
 		}
 	}
-	if kind == providermanifestv1.KindWebUI {
+	if kind == providermanifestv1.KindUI {
 		return "", nil
 	}
 

--- a/gestaltd/internal/providerpkg/release_target.go
+++ b/gestaltd/internal/providerpkg/release_target.go
@@ -26,7 +26,7 @@ func HasSourceReleaseTarget(root, kind string) (bool, error) {
 	switch kind {
 	case providermanifestv1.KindPlugin:
 		return HasSourceProviderPackage(root)
-	case providermanifestv1.KindWebUI:
+	case providermanifestv1.KindUI:
 		return false, nil
 	case providermanifestv1.KindAuthentication, providermanifestv1.KindAuthorization, providermanifestv1.KindIndexedDB, providermanifestv1.KindCache, providermanifestv1.KindS3, providermanifestv1.KindWorkflow, providermanifestv1.KindSecrets:
 		return HasSourceComponentPackage(root, kind)

--- a/gestaltd/internal/providerpkg/ui_routes.go
+++ b/gestaltd/internal/providerpkg/ui_routes.go
@@ -6,7 +6,7 @@ import (
 	"strings"
 )
 
-func NormalizeWebUIRoutePath(label, routePath string) (string, error) {
+func NormalizeUIRoutePath(label, routePath string) (string, error) {
 	routePath = strings.TrimSpace(routePath)
 	if routePath == "" {
 		return "", fmt.Errorf("%s is required", label)
@@ -46,7 +46,7 @@ func NormalizeWebUIRoutePath(label, routePath string) (string, error) {
 	return routePath, nil
 }
 
-func NormalizeWebUIAllowedRoles(label string, allowedRoles []string) ([]string, error) {
+func NormalizeUIAllowedRoles(label string, allowedRoles []string) ([]string, error) {
 	if len(allowedRoles) == 0 {
 		return nil, fmt.Errorf("%s must not be empty", label)
 	}
@@ -66,7 +66,7 @@ func NormalizeWebUIAllowedRoles(label string, allowedRoles []string) ([]string, 
 	return roles, nil
 }
 
-func WebUIRouteMatches(routePath, requestPath string) bool {
+func UIRouteMatches(routePath, requestPath string) bool {
 	if routePath == "/*" {
 		return true
 	}

--- a/gestaltd/internal/server/handlers_admin_authorization.go
+++ b/gestaltd/internal/server/handlers_admin_authorization.go
@@ -69,7 +69,7 @@ func (s *Server) adminAPIAuthMiddleware(next http.Handler) http.Handler {
 			return
 		}
 
-		p, authenticated, err := s.resolveMountedWebUIPrincipal(r, s.adminMountedWebUI())
+		p, authenticated, err := s.resolveMountedUIPrincipal(r, s.adminMountedUI())
 		if err != nil {
 			writeError(w, http.StatusInternalServerError, "failed to resolve user")
 			return
@@ -84,7 +84,7 @@ func (s *Server) adminAPIAuthMiddleware(next http.Handler) http.Handler {
 		}
 
 		access, allowed := s.authorizer.ResolveAdminAccess(r.Context(), p, s.adminRoute.AuthorizationPolicy)
-		if !allowed || !mountedWebUIRoleAllowed(access.Role, s.adminRoute.AllowedRoles) {
+		if !allowed || !mountedUIRoleAllowed(access.Role, s.adminRoute.AllowedRoles) {
 			writeError(w, http.StatusForbidden, "admin access denied")
 			return
 		}
@@ -614,5 +614,5 @@ func (s *Server) ensureAdminAuthorizationWriteAccess(w http.ResponseWriter, r *h
 }
 
 func (s *Server) adminRoleCanMutate(role string) bool {
-	return mountedWebUIRoleAllowed(strings.TrimSpace(role), s.adminRoute.AllowedRoles)
+	return mountedUIRoleAllowed(strings.TrimSpace(role), s.adminRoute.AllowedRoles)
 }

--- a/gestaltd/internal/server/http_bindings.go
+++ b/gestaltd/internal/server/http_bindings.go
@@ -23,7 +23,7 @@ var validMountedHTTPBindingMethods = map[string]bool{
 	http.MethodDelete: true,
 }
 
-func mountedHTTPBindingsFromEntries(entries map[string]*config.ProviderEntry, providers *registry.ProviderMap[core.Provider], mountedWebUIs []MountedWebUI) ([]MountedHTTPBinding, error) {
+func mountedHTTPBindingsFromEntries(entries map[string]*config.ProviderEntry, providers *registry.ProviderMap[core.Provider], mountedUIs []MountedUI) ([]MountedHTTPBinding, error) {
 	if len(entries) == 0 {
 		return nil, nil
 	}
@@ -102,7 +102,7 @@ func mountedHTTPBindingsFromEntries(entries map[string]*config.ProviderEntry, pr
 			})
 		}
 	}
-	if err := validateMountedHTTPBindingRoutes(mounted, mountedWebUIs); err != nil {
+	if err := validateMountedHTTPBindingRoutes(mounted, mountedUIs); err != nil {
 		return nil, err
 	}
 	return mounted, nil
@@ -257,7 +257,7 @@ func validateMountedHTTPBinding(pluginName, bindingName string, binding *config.
 	return nil
 }
 
-func validateMountedHTTPBindingRoutes(bindings []MountedHTTPBinding, mountedWebUIs []MountedWebUI) error {
+func validateMountedHTTPBindingRoutes(bindings []MountedHTTPBinding, mountedUIs []MountedUI) error {
 	seen := make(map[string]string, len(bindings))
 	for _, binding := range bindings {
 		if binding.Path == "" {
@@ -268,7 +268,7 @@ func validateMountedHTTPBindingRoutes(bindings []MountedHTTPBinding, mountedWebU
 				return fmt.Errorf("http binding %s.%s path %q conflicts with core route namespace %q", binding.PluginName, binding.Name, binding.Path, prefix)
 			}
 		}
-		for _, mounted := range mountedWebUIs {
+		for _, mounted := range mountedUIs {
 			if mounted.Path == "" || mounted.Path == "/" {
 				continue
 			}

--- a/gestaltd/internal/server/integration_visibility.go
+++ b/gestaltd/internal/server/integration_visibility.go
@@ -40,15 +40,15 @@ func (s *Server) integrationMountedPathForPrincipalContext(ctx context.Context, 
 	if mountedPath == "" {
 		return ""
 	}
-	mounted, ok := s.mountedWebUIForProvider(provider, mountedPath)
-	if !ok || !s.mountedWebUIRootAccessibleContext(ctx, p, mounted) {
+	mounted, ok := s.mountedUIForProvider(provider, mountedPath)
+	if !ok || !s.mountedUIRootAccessibleContext(ctx, p, mounted) {
 		return ""
 	}
 	return mountedPath
 }
 
-func (s *Server) mountedWebUIForProvider(provider, mountedPath string) (MountedWebUI, bool) {
-	for _, mounted := range s.mountedWebUIs {
+func (s *Server) mountedUIForProvider(provider, mountedPath string) (MountedUI, bool) {
+	for _, mounted := range s.mountedUIs {
 		if mounted.Handler == nil || mounted.Path != mountedPath {
 			continue
 		}
@@ -56,16 +56,16 @@ func (s *Server) mountedWebUIForProvider(provider, mountedPath string) (MountedW
 			return mounted, true
 		}
 	}
-	for _, mounted := range s.mountedWebUIs {
+	for _, mounted := range s.mountedUIs {
 		if mounted.Handler == nil || mounted.Path != mountedPath {
 			continue
 		}
 		return mounted, true
 	}
-	return MountedWebUI{}, false
+	return MountedUI{}, false
 }
 
-func (s *Server) mountedWebUIRootAccessibleContext(ctx context.Context, p *principal.Principal, mounted MountedWebUI) bool {
+func (s *Server) mountedUIRootAccessibleContext(ctx context.Context, p *principal.Principal, mounted MountedUI) bool {
 	if mounted.AuthorizationPolicy == "" {
 		return true
 	}
@@ -86,11 +86,11 @@ func (s *Server) mountedWebUIRootAccessibleContext(ctx context.Context, p *princ
 		return false
 	}
 
-	route, matched := mounted.routeForRequestPath(mountedWebUIRootRequestPath(mounted))
-	return matched && len(route.AllowedRoles) > 0 && mountedWebUIRoleAllowed(access.Role, route.AllowedRoles)
+	route, matched := mounted.routeForRequestPath(mountedUIRootRequestPath(mounted))
+	return matched && len(route.AllowedRoles) > 0 && mountedUIRoleAllowed(access.Role, route.AllowedRoles)
 }
 
-func mountedWebUIRootRequestPath(mounted MountedWebUI) string {
+func mountedUIRootRequestPath(mounted MountedUI) string {
 	if mounted.Path == "/" {
 		return "/"
 	}

--- a/gestaltd/internal/server/mounted_ui.go
+++ b/gestaltd/internal/server/mounted_ui.go
@@ -16,13 +16,13 @@ import (
 	"github.com/valon-technologies/gestalt/server/internal/invocation"
 	"github.com/valon-technologies/gestalt/server/internal/principal"
 	"github.com/valon-technologies/gestalt/server/internal/providerpkg"
-	"github.com/valon-technologies/gestalt/server/internal/webui"
+	"github.com/valon-technologies/gestalt/server/internal/ui"
 )
 
 const browserLoginPath = "/api/v1/auth/login"
 const adminUIDirEnv = "GESTALTD_ADMIN_UI_DIR"
 
-type mountedWebUINavigationPathResolver interface {
+type mountedUINavigationPathResolver interface {
 	NavigationPathForRequest(string) (string, bool)
 }
 
@@ -42,7 +42,7 @@ func normalizeAdminRouteConfig(admin AdminRouteConfig) (AdminRouteConfig, error)
 		return admin, nil
 	}
 
-	roles, err := providerpkg.NormalizeWebUIAllowedRoles("admin allowedRoles", admin.AllowedRoles)
+	roles, err := providerpkg.NormalizeUIAllowedRoles("admin allowedRoles", admin.AllowedRoles)
 	if err != nil {
 		return AdminRouteConfig{}, err
 	}
@@ -96,14 +96,14 @@ func parseAbsoluteBaseURL(label, raw string) (*url.URL, error) {
 	return parsed, nil
 }
 
-func mountedWebUIsFromEntries(entries map[string]*config.UIEntry) ([]MountedWebUI, error) {
+func mountedUIsFromEntries(entries map[string]*config.UIEntry) ([]MountedUI, error) {
 	names := make([]string, 0, len(entries))
 	for name := range entries {
 		names = append(names, name)
 	}
 	slices.Sort(names)
 
-	mounted := make([]MountedWebUI, 0, len(names))
+	mounted := make([]MountedUI, 0, len(names))
 	for _, name := range names {
 		entry := entries[name]
 		if entry == nil {
@@ -113,23 +113,23 @@ func mountedWebUIsFromEntries(entries map[string]*config.UIEntry) ([]MountedWebU
 			return nil, fmt.Errorf("ui %q configured but asset root not resolved", name)
 		}
 
-		handler, err := webui.DirHandler(entry.ResolvedAssetRoot)
+		handler, err := ui.DirHandler(entry.ResolvedAssetRoot)
 		if err != nil {
 			return nil, fmt.Errorf("ui %q: %w", name, err)
 		}
 
-		routes := []MountedWebUIRoute(nil)
+		routes := []MountedUIRoute(nil)
 		if spec := entry.ManifestSpec(); spec != nil && len(spec.Routes) > 0 {
-			routes = make([]MountedWebUIRoute, 0, len(spec.Routes))
+			routes = make([]MountedUIRoute, 0, len(spec.Routes))
 			for _, route := range spec.Routes {
-				routes = append(routes, MountedWebUIRoute{
+				routes = append(routes, MountedUIRoute{
 					Path:         route.Path,
 					AllowedRoles: append([]string(nil), route.AllowedRoles...),
 				})
 			}
 		}
 
-		mounted = append(mounted, MountedWebUI{
+		mounted = append(mounted, MountedUI{
 			Name:                name,
 			Path:                entry.Path,
 			PluginName:          entry.OwnerPlugin,
@@ -157,14 +157,14 @@ func resolveBuiltinAdminUI(opts BuiltinAdminUIOptions) (http.Handler, error) {
 	return handler, nil
 }
 
-func normalizeMountedWebUIs(mounted []MountedWebUI) ([]MountedWebUI, error) {
+func normalizeMountedUIs(mounted []MountedUI) ([]MountedUI, error) {
 	if len(mounted) == 0 {
 		return nil, nil
 	}
 
-	normalized := append([]MountedWebUI(nil), mounted...)
+	normalized := append([]MountedUI(nil), mounted...)
 	for i := range normalized {
-		routes, err := normalizeMountedWebUIRoutes(normalized[i].Routes)
+		routes, err := normalizeMountedUIRoutes(normalized[i].Routes)
 		if err != nil {
 			name := normalized[i].Name
 			if name == "" {
@@ -173,7 +173,7 @@ func normalizeMountedWebUIs(mounted []MountedWebUI) ([]MountedWebUI, error) {
 			return nil, fmt.Errorf("normalize mounted ui %q routes: %w", name, err)
 		}
 		normalized[i].Routes = routes
-		if err := validatePolicyBoundMountedWebUIRoutes(normalized[i]); err != nil {
+		if err := validatePolicyBoundMountedUIRoutes(normalized[i]); err != nil {
 			name := normalized[i].Name
 			if name == "" {
 				name = normalized[i].Path
@@ -184,15 +184,15 @@ func normalizeMountedWebUIs(mounted []MountedWebUI) ([]MountedWebUI, error) {
 	return normalized, nil
 }
 
-func normalizeMountedWebUIRoutes(routes []MountedWebUIRoute) ([]MountedWebUIRoute, error) {
+func normalizeMountedUIRoutes(routes []MountedUIRoute) ([]MountedUIRoute, error) {
 	if len(routes) == 0 {
 		return nil, nil
 	}
 
-	normalized := append([]MountedWebUIRoute(nil), routes...)
+	normalized := append([]MountedUIRoute(nil), routes...)
 	seenPaths := make(map[string]struct{}, len(normalized))
 	for i := range normalized {
-		routePath, err := providerpkg.NormalizeWebUIRoutePath(fmt.Sprintf("route %d path", i), normalized[i].Path)
+		routePath, err := providerpkg.NormalizeUIRoutePath(fmt.Sprintf("route %d path", i), normalized[i].Path)
 		if err != nil {
 			return nil, err
 		}
@@ -202,16 +202,16 @@ func normalizeMountedWebUIRoutes(routes []MountedWebUIRoute) ([]MountedWebUIRout
 		}
 		seenPaths[routePath] = struct{}{}
 
-		roles, err := providerpkg.NormalizeWebUIAllowedRoles(fmt.Sprintf("route %d allowedRoles", i), normalized[i].AllowedRoles)
+		roles, err := providerpkg.NormalizeUIAllowedRoles(fmt.Sprintf("route %d allowedRoles", i), normalized[i].AllowedRoles)
 		if err != nil {
 			return nil, err
 		}
 		normalized[i].AllowedRoles = roles
 	}
 
-	slices.SortFunc(normalized, func(a, b MountedWebUIRoute) int {
-		aLen, aWildcard := mountedWebUIRouteSpecificity(a.Path)
-		bLen, bWildcard := mountedWebUIRouteSpecificity(b.Path)
+	slices.SortFunc(normalized, func(a, b MountedUIRoute) int {
+		aLen, aWildcard := mountedUIRouteSpecificity(a.Path)
+		bLen, bWildcard := mountedUIRouteSpecificity(b.Path)
 		if aLen != bLen {
 			return bLen - aLen
 		}
@@ -226,7 +226,7 @@ func normalizeMountedWebUIRoutes(routes []MountedWebUIRoute) ([]MountedWebUIRout
 	return normalized, nil
 }
 
-func validatePolicyBoundMountedWebUIRoutes(mounted MountedWebUI) error {
+func validatePolicyBoundMountedUIRoutes(mounted MountedUI) error {
 	if mounted.AuthorizationPolicy == "" {
 		return nil
 	}
@@ -238,7 +238,7 @@ func validatePolicyBoundMountedWebUIRoutes(mounted MountedWebUI) error {
 		if len(mounted.Routes[i].AllowedRoles) == 0 {
 			return fmt.Errorf("route %q allowedRoles must not be empty", mounted.Routes[i].Path)
 		}
-		if providerpkg.WebUIRouteMatches(mounted.Routes[i].Path, "/") {
+		if providerpkg.UIRouteMatches(mounted.Routes[i].Path, "/") {
 			coversRoot = true
 		}
 	}
@@ -248,7 +248,7 @@ func validatePolicyBoundMountedWebUIRoutes(mounted MountedWebUI) error {
 	return nil
 }
 
-func (s *Server) mountedWebUIHandler(mounted MountedWebUI) http.Handler {
+func (s *Server) mountedUIHandler(mounted MountedUI) http.Handler {
 	inner := mounted.Handler
 	if inner == nil {
 		return http.NotFoundHandler()
@@ -256,25 +256,25 @@ func (s *Server) mountedWebUIHandler(mounted MountedWebUI) http.Handler {
 	if mounted.Path != "/" {
 		inner = http.StripPrefix(mounted.Path, inner)
 	}
-	return s.protectedUIHandler(mounted, inner, s.redirectMountedWebUILogin)
+	return s.protectedUIHandler(mounted, inner, s.redirectMountedUILogin)
 }
 
 func (s *Server) adminUIHandler() http.Handler {
 	if s.adminUI == nil {
 		return http.NotFoundHandler()
 	}
-	mounted := s.adminMountedWebUI()
+	mounted := s.adminMountedUI()
 	inner := http.StripPrefix(mounted.Path, mounted.Handler)
 	return s.protectedUIHandler(mounted, inner, s.redirectAdminUILogin)
 }
 
-func (s *Server) adminMountedWebUI() MountedWebUI {
-	return MountedWebUI{
+func (s *Server) adminMountedUI() MountedUI {
+	return MountedUI{
 		Name:                "builtin_admin",
 		Path:                "/admin",
 		AuthorizationPolicy: s.adminRoute.AuthorizationPolicy,
 		builtInAdmin:        true,
-		Routes: []MountedWebUIRoute{{
+		Routes: []MountedUIRoute{{
 			Path:         "/*",
 			AllowedRoles: append([]string(nil), s.adminRoute.AllowedRoles...),
 		}},
@@ -282,7 +282,7 @@ func (s *Server) adminMountedWebUI() MountedWebUI {
 	}
 }
 
-func (s *Server) protectedUIHandler(mounted MountedWebUI, inner http.Handler, redirectLogin protectedUILoginRedirect) http.Handler {
+func (s *Server) protectedUIHandler(mounted MountedUI, inner http.Handler, redirectLogin protectedUILoginRedirect) http.Handler {
 	if mounted.AuthorizationPolicy == "" {
 		return inner
 	}
@@ -296,13 +296,13 @@ func (s *Server) protectedUIHandler(mounted MountedWebUI, inner http.Handler, re
 	})
 }
 
-func (s *Server) authorizeProtectedUIRequest(w http.ResponseWriter, r *http.Request, mounted MountedWebUI, redirectLogin protectedUILoginRedirect) (context.Context, bool) {
+func (s *Server) authorizeProtectedUIRequest(w http.ResponseWriter, r *http.Request, mounted MountedUI, redirectLogin protectedUILoginRedirect) (context.Context, bool) {
 	if s.authorizer == nil {
 		writeError(w, http.StatusInternalServerError, "app authorization is unavailable")
 		return nil, false
 	}
 
-	p, authenticated, err := s.resolveMountedWebUIPrincipal(r, mounted)
+	p, authenticated, err := s.resolveMountedUIPrincipal(r, mounted)
 	if err != nil {
 		writeError(w, http.StatusInternalServerError, "failed to resolve user")
 		return nil, false
@@ -337,7 +337,7 @@ func (s *Server) authorizeProtectedUIRequest(w http.ResponseWriter, r *http.Requ
 		return nil, false
 	}
 	route, matched := mounted.routeForRequestPath(r.URL.Path)
-	if !matched || len(route.AllowedRoles) == 0 || !mountedWebUIRoleAllowed(access.Role, route.AllowedRoles) {
+	if !matched || len(route.AllowedRoles) == 0 || !mountedUIRoleAllowed(access.Role, route.AllowedRoles) {
 		writeError(w, http.StatusForbidden, "app access denied")
 		return nil, false
 	}
@@ -352,8 +352,8 @@ func (s *Server) authorizeProtectedUIRequest(w http.ResponseWriter, r *http.Requ
 	return ctx, true
 }
 
-func (s *Server) resolveMountedWebUIPrincipal(r *http.Request, mounted MountedWebUI) (*principal.Principal, bool, error) {
-	auth, err := s.mountedWebUIAuthRuntime(mounted)
+func (s *Server) resolveMountedUIPrincipal(r *http.Request, mounted MountedUI) (*principal.Principal, bool, error) {
+	auth, err := s.mountedUIAuthRuntime(mounted)
 	if err != nil {
 		return nil, false, err
 	}
@@ -378,7 +378,7 @@ func (s *Server) resolveMountedWebUIPrincipal(r *http.Request, mounted MountedWe
 	}
 }
 
-func (s *Server) redirectMountedWebUILogin(w http.ResponseWriter, r *http.Request) error {
+func (s *Server) redirectMountedUILogin(w http.ResponseWriter, r *http.Request) error {
 	target := browserLoginPath + "?next=" + url.QueryEscape(r.URL.RequestURI())
 	http.Redirect(w, r, target, http.StatusFound)
 	return nil
@@ -386,7 +386,7 @@ func (s *Server) redirectMountedWebUILogin(w http.ResponseWriter, r *http.Reques
 
 func (s *Server) redirectAdminUILogin(w http.ResponseWriter, r *http.Request) error {
 	if s.routeProfile != RouteProfileManagement {
-		return s.redirectMountedWebUILogin(w, r)
+		return s.redirectMountedUILogin(w, r)
 	}
 	if s.publicBaseURL == "" {
 		return fmt.Errorf("admin login redirect requires server.baseUrl")
@@ -400,17 +400,17 @@ func (s *Server) redirectAdminUILogin(w http.ResponseWriter, r *http.Request) er
 	return nil
 }
 
-func (m MountedWebUI) routeForRequestPath(requestPath string) (MountedWebUIRoute, bool) {
+func (m MountedUI) routeForRequestPath(requestPath string) (MountedUIRoute, bool) {
 	var (
-		best        MountedWebUIRoute
+		best        MountedUIRoute
 		bestMatched bool
 		bestLen     int
 		bestWild    bool
 	)
 	for _, routePath := range m.authorizationPathsForRequest(requestPath) {
 		for _, route := range m.Routes {
-			if providerpkg.WebUIRouteMatches(route.Path, routePath) {
-				routeLen, routeWild := mountedWebUIRouteSpecificity(route.Path)
+			if providerpkg.UIRouteMatches(route.Path, routePath) {
+				routeLen, routeWild := mountedUIRouteSpecificity(route.Path)
 				if !bestMatched || routeLen > bestLen || (routeLen == bestLen && bestWild && !routeWild) {
 					best = route
 					bestMatched = true
@@ -423,7 +423,7 @@ func (m MountedWebUI) routeForRequestPath(requestPath string) (MountedWebUIRoute
 	return best, bestMatched
 }
 
-func (m MountedWebUI) authorizationPathsForRequest(requestPath string) []string {
+func (m MountedUI) authorizationPathsForRequest(requestPath string) []string {
 	relativePath := requestPath
 	if m.Path != "/" {
 		relativePath = strings.TrimPrefix(requestPath, m.Path)
@@ -434,25 +434,25 @@ func (m MountedWebUI) authorizationPathsForRequest(requestPath string) []string 
 	if !strings.HasPrefix(relativePath, "/") {
 		relativePath = "/" + relativePath
 	}
-	requestAuthorizationPath := cleanMountedWebUIAuthorizationPath(relativePath)
+	requestAuthorizationPath := cleanMountedUIAuthorizationPath(relativePath)
 	paths := []string{requestAuthorizationPath}
-	if resolver, ok := m.Handler.(mountedWebUINavigationPathResolver); ok {
+	if resolver, ok := m.Handler.(mountedUINavigationPathResolver); ok {
 		if routePath, navigation := resolver.NavigationPathForRequest(relativePath); navigation {
-			return appendMountedWebUIAuthorizationPath(paths, cleanMountedWebUIAuthorizationPath(routePath))
+			return appendMountedUIAuthorizationPath(paths, cleanMountedUIAuthorizationPath(routePath))
 		}
-		for path := cleanMountedWebUIAuthorizationPath(stdpath.Dir(relativePath)); ; {
-			paths = appendMountedWebUIAuthorizationPath(paths, path)
+		for path := cleanMountedUIAuthorizationPath(stdpath.Dir(relativePath)); ; {
+			paths = appendMountedUIAuthorizationPath(paths, path)
 			if path == "/" {
 				break
 			}
-			path = cleanMountedWebUIAuthorizationPath(stdpath.Dir(path))
+			path = cleanMountedUIAuthorizationPath(stdpath.Dir(path))
 		}
 		return paths
 	}
 	return paths
 }
 
-func cleanMountedWebUIAuthorizationPath(routePath string) string {
+func cleanMountedUIAuthorizationPath(routePath string) string {
 	routePath = stdpath.Clean(routePath)
 	if routePath == "." {
 		return "/"
@@ -460,21 +460,21 @@ func cleanMountedWebUIAuthorizationPath(routePath string) string {
 	return routePath
 }
 
-func appendMountedWebUIAuthorizationPath(paths []string, path string) []string {
+func appendMountedUIAuthorizationPath(paths []string, path string) []string {
 	if len(paths) == 0 || paths[len(paths)-1] != path {
 		return append(paths, path)
 	}
 	return paths
 }
 
-func mountedWebUIRouteSpecificity(routePath string) (int, bool) {
+func mountedUIRouteSpecificity(routePath string) (int, bool) {
 	if strings.HasSuffix(routePath, "/*") {
 		return len(strings.TrimSuffix(routePath, "/*")), true
 	}
 	return len(routePath), false
 }
 
-func mountedWebUIRoleAllowed(role string, allowedRoles []string) bool {
+func mountedUIRoleAllowed(role string, allowedRoles []string) bool {
 	role = strings.TrimSpace(role)
 	if role == "" {
 		return false

--- a/gestaltd/internal/server/route_auth_runtime.go
+++ b/gestaltd/internal/server/route_auth_runtime.go
@@ -73,7 +73,7 @@ func (s *Server) pluginAuthRuntime(pluginName string) (authRuntime, error) {
 	return s.authRuntimeForProvider(entry.RouteAuth.Provider)
 }
 
-func (s *Server) mountedWebUIAuthRuntime(mounted MountedWebUI) (authRuntime, error) {
+func (s *Server) mountedUIAuthRuntime(mounted MountedUI) (authRuntime, error) {
 	if strings.TrimSpace(mounted.PluginName) == "" {
 		return s.serverAuthRuntime(), nil
 	}
@@ -81,17 +81,17 @@ func (s *Server) mountedWebUIAuthRuntime(mounted MountedWebUI) (authRuntime, err
 }
 
 func (s *Server) loginAuthRuntimeForNextPath(nextPath string) (authRuntime, error) {
-	mounted, ok := s.mountedWebUIForNextPath(nextPath)
+	mounted, ok := s.mountedUIForNextPath(nextPath)
 	if !ok {
 		return s.serverAuthRuntime(), nil
 	}
-	return s.mountedWebUIAuthRuntime(mounted)
+	return s.mountedUIAuthRuntime(mounted)
 }
 
-func (s *Server) mountedWebUIForNextPath(nextPath string) (MountedWebUI, bool) {
+func (s *Server) mountedUIForNextPath(nextPath string) (MountedUI, bool) {
 	parsed, err := url.Parse(nextPath)
 	if err != nil {
-		return MountedWebUI{}, false
+		return MountedUI{}, false
 	}
 	path := parsed.Path
 	if path == "" {
@@ -100,10 +100,10 @@ func (s *Server) mountedWebUIForNextPath(nextPath string) (MountedWebUI, bool) {
 	if !strings.HasPrefix(path, "/") {
 		path = "/" + path
 	}
-	return s.mountedWebUIForPath(path)
+	return s.mountedUIForPath(path)
 }
 
-func (s *Server) mountedWebUIForPath(path string) (MountedWebUI, bool) {
+func (s *Server) mountedUIForPath(path string) (MountedUI, bool) {
 	path = strings.TrimSpace(path)
 	if path == "" {
 		path = "/"
@@ -113,12 +113,12 @@ func (s *Server) mountedWebUIForPath(path string) (MountedWebUI, bool) {
 	}
 
 	var (
-		best        MountedWebUI
+		best        MountedUI
 		bestLen     int
 		bestMatched bool
 	)
-	consider := func(candidate MountedWebUI) {
-		if candidate.Path == "" || !mountedWebUIPathMatches(path, candidate.Path) {
+	consider := func(candidate MountedUI) {
+		if candidate.Path == "" || !mountedUIPathMatches(path, candidate.Path) {
 			return
 		}
 		if !bestMatched || len(candidate.Path) > bestLen {
@@ -128,16 +128,16 @@ func (s *Server) mountedWebUIForPath(path string) (MountedWebUI, bool) {
 		}
 	}
 
-	for _, mounted := range s.mountedWebUIs {
+	for _, mounted := range s.mountedUIs {
 		consider(mounted)
 	}
 	if s.adminUI != nil {
-		consider(s.adminMountedWebUI())
+		consider(s.adminMountedUI())
 	}
 	return best, bestMatched
 }
 
-func mountedWebUIPathMatches(requestPath, mountedPath string) bool {
+func mountedUIPathMatches(requestPath, mountedPath string) bool {
 	if mountedPath == "/" {
 		return strings.HasPrefix(requestPath, "/")
 	}

--- a/gestaltd/internal/server/routes.go
+++ b/gestaltd/internal/server/routes.go
@@ -20,7 +20,7 @@ func (s *Server) routes() {
 		s.mountMCPRoutes(r)
 		s.mountHTTPBindingRoutes(r)
 		s.mountAPIRoutes(r)
-		s.mountMountedWebUIRoutes(r)
+		s.mountMountedUIRoutes(r)
 		s.mountManagementHiddenRoutes(r)
 	case RouteProfileManagement:
 		s.mountCoreRoutes(r, metricsUnauthenticated)
@@ -32,7 +32,7 @@ func (s *Server) routes() {
 		s.mountMCPRoutes(r)
 		s.mountHTTPBindingRoutes(r)
 		s.mountAPIRoutes(r)
-		s.mountMountedWebUIRoutes(r)
+		s.mountMountedUIRoutes(r)
 		s.mountAdminAPIRoutes(r)
 		s.mountAdminUIRoutes(r)
 	}
@@ -91,14 +91,14 @@ func (s *Server) mountAdminAPIRoutes(r chi.Router) {
 	})
 }
 
-func (s *Server) mountMountedWebUIRoutes(r chi.Router) {
+func (s *Server) mountMountedUIRoutes(r chi.Router) {
 	var rootHandler http.Handler
-	for _, mounted := range s.mountedWebUIs {
+	for _, mounted := range s.mountedUIs {
 		if mounted.Handler == nil || mounted.Path == "" {
 			continue
 		}
 		path := mounted.Path
-		handler := s.mountedWebUIHandler(mounted)
+		handler := s.mountedUIHandler(mounted)
 		if path == "/" {
 			rootHandler = handler
 			continue

--- a/gestaltd/internal/server/server.go
+++ b/gestaltd/internal/server/server.go
@@ -38,14 +38,14 @@ const (
 	RouteProfileManagement
 )
 
-type MountedWebUIRoute = providermanifestv1.WebUIRoute
+type MountedUIRoute = providermanifestv1.UIRoute
 
-type MountedWebUI struct {
+type MountedUI struct {
 	Name                string
 	Path                string
 	PluginName          string
 	AuthorizationPolicy string
-	Routes              []MountedWebUIRoute
+	Routes              []MountedUIRoute
 	Handler             http.Handler
 	builtInAdmin        bool
 }
@@ -73,52 +73,52 @@ type BuiltinAdminUIOptions struct {
 }
 
 type Server struct {
-	router                 chi.Router
-	handler                http.Handler
-	auth                   core.AuthenticationProvider
-	authProviders          map[string]core.AuthenticationProvider
-	serverAuthProvider     string
-	auditSink              core.AuditSink
-	users                  *coredata.UserService
-	tokens                 *coredata.TokenService
-	apiTokens              *coredata.APITokenService
-	managedIdentities      *coredata.ManagedIdentityService
-	identityMemberships    *coredata.ManagedIdentityMembershipService
-	identityGrants         *coredata.ManagedIdentityGrantService
-	workspaceRoles         *coredata.WorkspaceRoleService
-	identityPluginAccess   *coredata.IdentityPluginAccessService
-	workflowExecutionRefs  *coredata.WorkflowExecutionRefService
-	workflowSchedules      *workflowmanager.Manager
-	authorizationProvider  core.AuthorizationProvider
-	managedIdentityMu      sync.Mutex
-	providers              *registry.ProviderMap[core.Provider]
-	workflow               bootstrap.WorkflowControl
-	resolver               *principal.Resolver
-	authResolvers          map[string]*principal.Resolver
-	invoker                invocation.Invoker
-	defaultConnection      map[string]string
-	catalogConnection      map[string]string
-	connectionAuth         func() map[string]map[string]bootstrap.OAuthHandler
-	pluginDefs             map[string]*config.ProviderEntry
-	authorizer             authorization.RuntimeAuthorizer
-	noAuth                 bool
-	anonymousPrincipal     *principal.Principal
-	publicBaseURL          string
-	managementBaseURL      string
-	secureCookies          bool
-	encryptor              *cryptoutil.AESGCMEncryptor
-	sessionIssuer          []byte
-	stateCodec             *integrationOAuthStateCodec
-	apiTokenTTL            time.Duration
-	now                    func() time.Time
-	readiness              ReadinessChecker
-	prometheusMetrics      http.Handler
-	mcpHandler             http.Handler
-	mountedHTTPBindings    []MountedHTTPBinding
-	mountedWebUIs          []MountedWebUI
-	adminRoute             AdminRouteConfig
-	adminUI                http.Handler
-	routeProfile           RouteProfile
+	router                chi.Router
+	handler               http.Handler
+	auth                  core.AuthenticationProvider
+	authProviders         map[string]core.AuthenticationProvider
+	serverAuthProvider    string
+	auditSink             core.AuditSink
+	users                 *coredata.UserService
+	tokens                *coredata.TokenService
+	apiTokens             *coredata.APITokenService
+	managedIdentities     *coredata.ManagedIdentityService
+	identityMemberships   *coredata.ManagedIdentityMembershipService
+	identityGrants        *coredata.ManagedIdentityGrantService
+	workspaceRoles        *coredata.WorkspaceRoleService
+	identityPluginAccess  *coredata.IdentityPluginAccessService
+	workflowExecutionRefs *coredata.WorkflowExecutionRefService
+	workflowSchedules     *workflowmanager.Manager
+	authorizationProvider core.AuthorizationProvider
+	managedIdentityMu     sync.Mutex
+	providers             *registry.ProviderMap[core.Provider]
+	workflow              bootstrap.WorkflowControl
+	resolver              *principal.Resolver
+	authResolvers         map[string]*principal.Resolver
+	invoker               invocation.Invoker
+	defaultConnection     map[string]string
+	catalogConnection     map[string]string
+	connectionAuth        func() map[string]map[string]bootstrap.OAuthHandler
+	pluginDefs            map[string]*config.ProviderEntry
+	authorizer            authorization.RuntimeAuthorizer
+	noAuth                bool
+	anonymousPrincipal    *principal.Principal
+	publicBaseURL         string
+	managementBaseURL     string
+	secureCookies         bool
+	encryptor             *cryptoutil.AESGCMEncryptor
+	sessionIssuer         []byte
+	stateCodec            *integrationOAuthStateCodec
+	apiTokenTTL           time.Duration
+	now                   func() time.Time
+	readiness             ReadinessChecker
+	prometheusMetrics     http.Handler
+	mcpHandler            http.Handler
+	mountedHTTPBindings   []MountedHTTPBinding
+	mountedUIs            []MountedUI
+	adminRoute            AdminRouteConfig
+	adminUI               http.Handler
+	routeProfile          RouteProfile
 	httpBindingReplayStore httpBindingReplayStore
 }
 
@@ -156,7 +156,7 @@ type Config struct {
 	Readiness             ReadinessChecker
 	PrometheusMetrics     http.Handler
 	MCPHandler            http.Handler
-	MountedWebUIs         []MountedWebUI
+	MountedUIs            []MountedUI
 	Admin                 AdminRouteConfig
 	AdminUI               http.Handler
 	BuiltinAdminUI        *BuiltinAdminUIOptions
@@ -204,18 +204,18 @@ func New(cfg Config) (*Server, error) {
 	if err := validateAdminRouteRuntime(adminRoute, noAuth, cfg.PublicBaseURL, cfg.ManagementBaseURL, cfg.RouteProfile); err != nil {
 		return nil, fmt.Errorf("validate admin route: %w", err)
 	}
-	mountedWebUIs := cfg.MountedWebUIs
-	if len(mountedWebUIs) == 0 && len(cfg.ProviderUIs) != 0 {
-		mountedWebUIs, err = mountedWebUIsFromEntries(cfg.ProviderUIs)
+	mountedUIs := cfg.MountedUIs
+	if len(mountedUIs) == 0 && len(cfg.ProviderUIs) != 0 {
+		mountedUIs, err = mountedUIsFromEntries(cfg.ProviderUIs)
 		if err != nil {
 			return nil, fmt.Errorf("resolve mounted ui handlers: %w", err)
 		}
 	}
-	mountedWebUIs, err = normalizeMountedWebUIs(mountedWebUIs)
+	mountedUIs, err = normalizeMountedUIs(mountedUIs)
 	if err != nil {
 		return nil, err
 	}
-	mountedHTTPBindings, err := mountedHTTPBindingsFromEntries(cfg.PluginDefs, cfg.Providers, mountedWebUIs)
+	mountedHTTPBindings, err := mountedHTTPBindingsFromEntries(cfg.PluginDefs, cfg.Providers, mountedUIs)
 	if err != nil {
 		return nil, err
 	}
@@ -260,49 +260,49 @@ func New(cfg Config) (*Server, error) {
 		otelOptions = append(otelOptions, otelhttp.WithMeterProvider(cfg.MeterProvider))
 	}
 	s := &Server{
-		router:                 router,
-		handler:                withRequestMeterProvider(otelhttp.NewHandler(router, "gestaltd", otelOptions...), cfg.MeterProvider),
-		auth:                   cfg.Auth,
-		authProviders:          authProviders,
-		serverAuthProvider:     serverAuthProvider,
-		auditSink:              cfg.AuditSink,
-		users:                  users,
-		tokens:                 tokens,
-		apiTokens:              apiTokens,
-		managedIdentities:      managedIdentities,
-		identityMemberships:    identityMemberships,
-		identityGrants:         identityGrants,
-		workspaceRoles:         workspaceRoles,
-		identityPluginAccess:   identityPluginAccess,
-		workflowExecutionRefs:  workflowExecutionRefs,
-		authorizationProvider:  cfg.AuthorizationProvider,
-		providers:              cfg.Providers,
-		workflow:               cfg.Workflow,
-		resolver:               resolver,
-		authResolvers:          authResolvers,
-		invoker:                cfg.Invoker,
-		defaultConnection:      cfg.DefaultConnection,
-		catalogConnection:      cfg.CatalogConnection,
-		connectionAuth:         cfg.ConnectionAuth,
-		pluginDefs:             cfg.PluginDefs,
-		authorizer:             cfg.Authorizer,
-		noAuth:                 noAuth,
-		publicBaseURL:          strings.TrimRight(cfg.PublicBaseURL, "/"),
-		managementBaseURL:      strings.TrimRight(cfg.ManagementBaseURL, "/"),
-		secureCookies:          cfg.SecureCookies,
-		encryptor:              encryptor,
-		sessionIssuer:          cfg.StateSecret,
-		stateCodec:             stateCodec,
-		apiTokenTTL:            cfg.APITokenTTL,
-		now:                    now,
-		readiness:              cfg.Readiness,
-		prometheusMetrics:      cfg.PrometheusMetrics,
-		mcpHandler:             cfg.MCPHandler,
-		mountedHTTPBindings:    mountedHTTPBindings,
-		mountedWebUIs:          mountedWebUIs,
-		adminRoute:             adminRoute,
-		adminUI:                adminUI,
-		routeProfile:           cfg.RouteProfile,
+		router:                router,
+		handler:               withRequestMeterProvider(otelhttp.NewHandler(router, "gestaltd", otelOptions...), cfg.MeterProvider),
+		auth:                  cfg.Auth,
+		authProviders:         authProviders,
+		serverAuthProvider:    serverAuthProvider,
+		auditSink:             cfg.AuditSink,
+		users:                 users,
+		tokens:                tokens,
+		apiTokens:             apiTokens,
+		managedIdentities:     managedIdentities,
+		identityMemberships:   identityMemberships,
+		identityGrants:        identityGrants,
+		workspaceRoles:        workspaceRoles,
+		identityPluginAccess:  identityPluginAccess,
+		workflowExecutionRefs: workflowExecutionRefs,
+		authorizationProvider: cfg.AuthorizationProvider,
+		providers:             cfg.Providers,
+		workflow:              cfg.Workflow,
+		resolver:              resolver,
+		authResolvers:         authResolvers,
+		invoker:               cfg.Invoker,
+		defaultConnection:     cfg.DefaultConnection,
+		catalogConnection:     cfg.CatalogConnection,
+		connectionAuth:        cfg.ConnectionAuth,
+		pluginDefs:            cfg.PluginDefs,
+		authorizer:            cfg.Authorizer,
+		noAuth:                noAuth,
+		publicBaseURL:         strings.TrimRight(cfg.PublicBaseURL, "/"),
+		managementBaseURL:     strings.TrimRight(cfg.ManagementBaseURL, "/"),
+		secureCookies:         cfg.SecureCookies,
+		encryptor:             encryptor,
+		sessionIssuer:         cfg.StateSecret,
+		stateCodec:            stateCodec,
+		apiTokenTTL:           cfg.APITokenTTL,
+		now:                   now,
+		readiness:             cfg.Readiness,
+		prometheusMetrics:     cfg.PrometheusMetrics,
+		mcpHandler:            cfg.MCPHandler,
+		mountedHTTPBindings:   mountedHTTPBindings,
+		mountedUIs:            mountedUIs,
+		adminRoute:            adminRoute,
+		adminUI:               adminUI,
+		routeProfile:          cfg.RouteProfile,
 		httpBindingReplayStore: newMemoryHTTPBindingReplayStore(),
 	}
 	s.workflowSchedules = workflowmanager.New(workflowmanager.Config{

--- a/gestaltd/internal/server/server.go
+++ b/gestaltd/internal/server/server.go
@@ -73,52 +73,52 @@ type BuiltinAdminUIOptions struct {
 }
 
 type Server struct {
-	router                chi.Router
-	handler               http.Handler
-	auth                  core.AuthenticationProvider
-	authProviders         map[string]core.AuthenticationProvider
-	serverAuthProvider    string
-	auditSink             core.AuditSink
-	users                 *coredata.UserService
-	tokens                *coredata.TokenService
-	apiTokens             *coredata.APITokenService
-	managedIdentities     *coredata.ManagedIdentityService
-	identityMemberships   *coredata.ManagedIdentityMembershipService
-	identityGrants        *coredata.ManagedIdentityGrantService
-	workspaceRoles        *coredata.WorkspaceRoleService
-	identityPluginAccess  *coredata.IdentityPluginAccessService
-	workflowExecutionRefs *coredata.WorkflowExecutionRefService
-	workflowSchedules     *workflowmanager.Manager
-	authorizationProvider core.AuthorizationProvider
-	managedIdentityMu     sync.Mutex
-	providers             *registry.ProviderMap[core.Provider]
-	workflow              bootstrap.WorkflowControl
-	resolver              *principal.Resolver
-	authResolvers         map[string]*principal.Resolver
-	invoker               invocation.Invoker
-	defaultConnection     map[string]string
-	catalogConnection     map[string]string
-	connectionAuth        func() map[string]map[string]bootstrap.OAuthHandler
-	pluginDefs            map[string]*config.ProviderEntry
-	authorizer            authorization.RuntimeAuthorizer
-	noAuth                bool
-	anonymousPrincipal    *principal.Principal
-	publicBaseURL         string
-	managementBaseURL     string
-	secureCookies         bool
-	encryptor             *cryptoutil.AESGCMEncryptor
-	sessionIssuer         []byte
-	stateCodec            *integrationOAuthStateCodec
-	apiTokenTTL           time.Duration
-	now                   func() time.Time
-	readiness             ReadinessChecker
-	prometheusMetrics     http.Handler
-	mcpHandler            http.Handler
-	mountedHTTPBindings   []MountedHTTPBinding
-	mountedUIs            []MountedUI
-	adminRoute            AdminRouteConfig
-	adminUI               http.Handler
-	routeProfile          RouteProfile
+	router                 chi.Router
+	handler                http.Handler
+	auth                   core.AuthenticationProvider
+	authProviders          map[string]core.AuthenticationProvider
+	serverAuthProvider     string
+	auditSink              core.AuditSink
+	users                  *coredata.UserService
+	tokens                 *coredata.TokenService
+	apiTokens              *coredata.APITokenService
+	managedIdentities      *coredata.ManagedIdentityService
+	identityMemberships    *coredata.ManagedIdentityMembershipService
+	identityGrants         *coredata.ManagedIdentityGrantService
+	workspaceRoles         *coredata.WorkspaceRoleService
+	identityPluginAccess   *coredata.IdentityPluginAccessService
+	workflowExecutionRefs  *coredata.WorkflowExecutionRefService
+	workflowSchedules      *workflowmanager.Manager
+	authorizationProvider  core.AuthorizationProvider
+	managedIdentityMu      sync.Mutex
+	providers              *registry.ProviderMap[core.Provider]
+	workflow               bootstrap.WorkflowControl
+	resolver               *principal.Resolver
+	authResolvers          map[string]*principal.Resolver
+	invoker                invocation.Invoker
+	defaultConnection      map[string]string
+	catalogConnection      map[string]string
+	connectionAuth         func() map[string]map[string]bootstrap.OAuthHandler
+	pluginDefs             map[string]*config.ProviderEntry
+	authorizer             authorization.RuntimeAuthorizer
+	noAuth                 bool
+	anonymousPrincipal     *principal.Principal
+	publicBaseURL          string
+	managementBaseURL      string
+	secureCookies          bool
+	encryptor              *cryptoutil.AESGCMEncryptor
+	sessionIssuer          []byte
+	stateCodec             *integrationOAuthStateCodec
+	apiTokenTTL            time.Duration
+	now                    func() time.Time
+	readiness              ReadinessChecker
+	prometheusMetrics      http.Handler
+	mcpHandler             http.Handler
+	mountedHTTPBindings    []MountedHTTPBinding
+	mountedUIs             []MountedUI
+	adminRoute             AdminRouteConfig
+	adminUI                http.Handler
+	routeProfile           RouteProfile
 	httpBindingReplayStore httpBindingReplayStore
 }
 
@@ -260,49 +260,49 @@ func New(cfg Config) (*Server, error) {
 		otelOptions = append(otelOptions, otelhttp.WithMeterProvider(cfg.MeterProvider))
 	}
 	s := &Server{
-		router:                router,
-		handler:               withRequestMeterProvider(otelhttp.NewHandler(router, "gestaltd", otelOptions...), cfg.MeterProvider),
-		auth:                  cfg.Auth,
-		authProviders:         authProviders,
-		serverAuthProvider:    serverAuthProvider,
-		auditSink:             cfg.AuditSink,
-		users:                 users,
-		tokens:                tokens,
-		apiTokens:             apiTokens,
-		managedIdentities:     managedIdentities,
-		identityMemberships:   identityMemberships,
-		identityGrants:        identityGrants,
-		workspaceRoles:        workspaceRoles,
-		identityPluginAccess:  identityPluginAccess,
-		workflowExecutionRefs: workflowExecutionRefs,
-		authorizationProvider: cfg.AuthorizationProvider,
-		providers:             cfg.Providers,
-		workflow:              cfg.Workflow,
-		resolver:              resolver,
-		authResolvers:         authResolvers,
-		invoker:               cfg.Invoker,
-		defaultConnection:     cfg.DefaultConnection,
-		catalogConnection:     cfg.CatalogConnection,
-		connectionAuth:        cfg.ConnectionAuth,
-		pluginDefs:            cfg.PluginDefs,
-		authorizer:            cfg.Authorizer,
-		noAuth:                noAuth,
-		publicBaseURL:         strings.TrimRight(cfg.PublicBaseURL, "/"),
-		managementBaseURL:     strings.TrimRight(cfg.ManagementBaseURL, "/"),
-		secureCookies:         cfg.SecureCookies,
-		encryptor:             encryptor,
-		sessionIssuer:         cfg.StateSecret,
-		stateCodec:            stateCodec,
-		apiTokenTTL:           cfg.APITokenTTL,
-		now:                   now,
-		readiness:             cfg.Readiness,
-		prometheusMetrics:     cfg.PrometheusMetrics,
-		mcpHandler:            cfg.MCPHandler,
-		mountedHTTPBindings:   mountedHTTPBindings,
-		mountedUIs:            mountedUIs,
-		adminRoute:            adminRoute,
-		adminUI:               adminUI,
-		routeProfile:          cfg.RouteProfile,
+		router:                 router,
+		handler:                withRequestMeterProvider(otelhttp.NewHandler(router, "gestaltd", otelOptions...), cfg.MeterProvider),
+		auth:                   cfg.Auth,
+		authProviders:          authProviders,
+		serverAuthProvider:     serverAuthProvider,
+		auditSink:              cfg.AuditSink,
+		users:                  users,
+		tokens:                 tokens,
+		apiTokens:              apiTokens,
+		managedIdentities:      managedIdentities,
+		identityMemberships:    identityMemberships,
+		identityGrants:         identityGrants,
+		workspaceRoles:         workspaceRoles,
+		identityPluginAccess:   identityPluginAccess,
+		workflowExecutionRefs:  workflowExecutionRefs,
+		authorizationProvider:  cfg.AuthorizationProvider,
+		providers:              cfg.Providers,
+		workflow:               cfg.Workflow,
+		resolver:               resolver,
+		authResolvers:          authResolvers,
+		invoker:                cfg.Invoker,
+		defaultConnection:      cfg.DefaultConnection,
+		catalogConnection:      cfg.CatalogConnection,
+		connectionAuth:         cfg.ConnectionAuth,
+		pluginDefs:             cfg.PluginDefs,
+		authorizer:             cfg.Authorizer,
+		noAuth:                 noAuth,
+		publicBaseURL:          strings.TrimRight(cfg.PublicBaseURL, "/"),
+		managementBaseURL:      strings.TrimRight(cfg.ManagementBaseURL, "/"),
+		secureCookies:          cfg.SecureCookies,
+		encryptor:              encryptor,
+		sessionIssuer:          cfg.StateSecret,
+		stateCodec:             stateCodec,
+		apiTokenTTL:            cfg.APITokenTTL,
+		now:                    now,
+		readiness:              cfg.Readiness,
+		prometheusMetrics:      cfg.PrometheusMetrics,
+		mcpHandler:             cfg.MCPHandler,
+		mountedHTTPBindings:    mountedHTTPBindings,
+		mountedUIs:             mountedUIs,
+		adminRoute:             adminRoute,
+		adminUI:                adminUI,
+		routeProfile:           cfg.RouteProfile,
 		httpBindingReplayStore: newMemoryHTTPBindingReplayStore(),
 	}
 	s.workflowSchedules = workflowmanager.New(workflowmanager.Config{

--- a/gestaltd/internal/server/server_test.go
+++ b/gestaltd/internal/server/server_test.go
@@ -52,7 +52,7 @@ import (
 	"github.com/valon-technologies/gestalt/server/internal/registry"
 	"github.com/valon-technologies/gestalt/server/internal/server"
 	"github.com/valon-technologies/gestalt/server/internal/testutil"
-	"github.com/valon-technologies/gestalt/server/internal/webui"
+	"github.com/valon-technologies/gestalt/server/internal/ui"
 	providermanifestv1 "github.com/valon-technologies/gestalt/server/sdk/providermanifest/v1"
 	"google.golang.org/grpc/codes"
 	grpcstatus "google.golang.org/grpc/status"
@@ -1098,7 +1098,7 @@ func TestHealthCheck(t *testing.T) {
 	}
 }
 
-func TestMountedWebUIRoutes(t *testing.T) {
+func TestMountedUIRoutes(t *testing.T) {
 	t.Parallel()
 
 	dir := t.TempDir()
@@ -1111,13 +1111,13 @@ func TestMountedWebUIRoutes(t *testing.T) {
 	if err := os.WriteFile(filepath.Join(dir, "assets", "app.js"), []byte("console.log('sample')"), 0o644); err != nil {
 		t.Fatalf("WriteFile app.js: %v", err)
 	}
-	handler, err := testutilWebUIHandler(dir)
+	handler, err := testutilUIHandler(dir)
 	if err != nil {
-		t.Fatalf("webui handler: %v", err)
+		t.Fatalf("ui handler: %v", err)
 	}
 
 	ts := newTestServer(t, func(cfg *server.Config) {
-		cfg.MountedWebUIs = []server.MountedWebUI{{
+		cfg.MountedUIs = []server.MountedUI{{
 			Path:    "/sample-portal",
 			Handler: handler,
 		}}
@@ -1184,7 +1184,7 @@ func TestMountedWebUIRoutes(t *testing.T) {
 	}
 }
 
-func TestMountedWebUIRoutes_PrefersNestedMount(t *testing.T) {
+func TestMountedUIRoutes_PrefersNestedMount(t *testing.T) {
 	t.Parallel()
 
 	parentDir := t.TempDir()
@@ -1196,17 +1196,17 @@ func TestMountedWebUIRoutes_PrefersNestedMount(t *testing.T) {
 		t.Fatalf("WriteFile child index.html: %v", err)
 	}
 
-	parentHandler, err := testutilWebUIHandler(parentDir)
+	parentHandler, err := testutilUIHandler(parentDir)
 	if err != nil {
-		t.Fatalf("parent webui handler: %v", err)
+		t.Fatalf("parent ui handler: %v", err)
 	}
-	childHandler, err := testutilWebUIHandler(childDir)
+	childHandler, err := testutilUIHandler(childDir)
 	if err != nil {
-		t.Fatalf("child webui handler: %v", err)
+		t.Fatalf("child ui handler: %v", err)
 	}
 
 	ts := newTestServer(t, func(cfg *server.Config) {
-		cfg.MountedWebUIs = []server.MountedWebUI{
+		cfg.MountedUIs = []server.MountedUI{
 			{
 				Path:    "/workplace-hub",
 				Handler: parentHandler,
@@ -1252,7 +1252,7 @@ func TestMountedWebUIRoutes_PrefersNestedMount(t *testing.T) {
 	}
 }
 
-func TestMountedWebUIRoutes_HumanAuthorization(t *testing.T) {
+func TestMountedUIRoutes_HumanAuthorization(t *testing.T) {
 	t.Parallel()
 
 	dir := t.TempDir()
@@ -1265,9 +1265,9 @@ func TestMountedWebUIRoutes_HumanAuthorization(t *testing.T) {
 	if err := os.WriteFile(filepath.Join(dir, "assets", "app.js"), []byte("console.log('protected-sample')"), 0o644); err != nil {
 		t.Fatalf("WriteFile app.js: %v", err)
 	}
-	handler, err := testutilWebUIHandler(dir)
+	handler, err := testutilUIHandler(dir)
 	if err != nil {
-		t.Fatalf("webui handler: %v", err)
+		t.Fatalf("ui handler: %v", err)
 	}
 
 	svc := coretesting.NewStubServices(t)
@@ -1299,11 +1299,11 @@ func TestMountedWebUIRoutes_HumanAuthorization(t *testing.T) {
 		}
 		cfg.Services = svc
 		cfg.Authorizer = legacy
-		cfg.MountedWebUIs = []server.MountedWebUI{{
+		cfg.MountedUIs = []server.MountedUI{{
 			Name:                "sample_portal",
 			Path:                "/sample-portal",
 			AuthorizationPolicy: "sample_policy",
-			Routes: []server.MountedWebUIRoute{
+			Routes: []server.MountedUIRoute{
 				{Path: "/admin/*", AllowedRoles: []string{"admin"}},
 				{Path: "/*", AllowedRoles: []string{"viewer", "admin"}},
 			},
@@ -1387,16 +1387,16 @@ func TestMountedWebUIRoutes_HumanAuthorization(t *testing.T) {
 	}
 }
 
-func TestMountedWebUIRoutes_HumanAuthorization_UsesPluginRouteAuthOverride(t *testing.T) {
+func TestMountedUIRoutes_HumanAuthorization_UsesPluginRouteAuthOverride(t *testing.T) {
 	t.Parallel()
 
 	dir := t.TempDir()
 	if err := os.WriteFile(filepath.Join(dir, "index.html"), []byte("<html>protected-sample-shell</html>"), 0o644); err != nil {
 		t.Fatalf("WriteFile index.html: %v", err)
 	}
-	handler, err := testutilWebUIHandler(dir)
+	handler, err := testutilUIHandler(dir)
 	if err != nil {
-		t.Fatalf("webui handler: %v", err)
+		t.Fatalf("ui handler: %v", err)
 	}
 
 	svc := coretesting.NewStubServices(t)
@@ -1452,12 +1452,12 @@ func TestMountedWebUIRoutes_HumanAuthorization_UsesPluginRouteAuthOverride(t *te
 				RouteAuth:           &config.RouteAuthDef{Provider: "alt"},
 			},
 		}
-		cfg.MountedWebUIs = []server.MountedWebUI{{
+		cfg.MountedUIs = []server.MountedUI{{
 			Name:                "sample_portal",
 			Path:                "/sample-portal",
 			PluginName:          "sample_portal",
 			AuthorizationPolicy: "sample_policy",
-			Routes: []server.MountedWebUIRoute{
+			Routes: []server.MountedUIRoute{
 				{Path: "/*", AllowedRoles: []string{"viewer", "admin"}},
 			},
 			Handler: handler,
@@ -1535,16 +1535,16 @@ func TestMountedWebUIRoutes_HumanAuthorization_UsesPluginRouteAuthOverride(t *te
 	}
 }
 
-func TestMountedWebUIRoutes_HumanAuthorization_DefaultAllowTreatsAuthenticatedUsersAsViewerWithPluginName(t *testing.T) {
+func TestMountedUIRoutes_HumanAuthorization_DefaultAllowTreatsAuthenticatedUsersAsViewerWithPluginName(t *testing.T) {
 	t.Parallel()
 
 	dir := t.TempDir()
 	if err := os.WriteFile(filepath.Join(dir, "index.html"), []byte("<html>protected-sample-shell</html>"), 0o644); err != nil {
 		t.Fatalf("WriteFile index.html: %v", err)
 	}
-	handler, err := testutilWebUIHandler(dir)
+	handler, err := testutilUIHandler(dir)
 	if err != nil {
-		t.Fatalf("webui handler: %v", err)
+		t.Fatalf("ui handler: %v", err)
 	}
 
 	svc := coretesting.NewStubServices(t)
@@ -1577,12 +1577,12 @@ func TestMountedWebUIRoutes_HumanAuthorization_DefaultAllowTreatsAuthenticatedUs
 		}
 		cfg.Services = svc
 		cfg.Authorizer = legacy
-		cfg.MountedWebUIs = []server.MountedWebUI{{
+		cfg.MountedUIs = []server.MountedUI{{
 			Name:                "sample_portal",
 			Path:                "/sample-portal",
 			PluginName:          "sample_portal",
 			AuthorizationPolicy: "sample_policy",
-			Routes: []server.MountedWebUIRoute{
+			Routes: []server.MountedUIRoute{
 				{Path: "/admin/*", AllowedRoles: []string{"admin"}},
 				{Path: "/*", AllowedRoles: []string{"viewer", "admin"}},
 			},
@@ -1639,16 +1639,16 @@ func TestMountedWebUIRoutes_HumanAuthorization_DefaultAllowTreatsAuthenticatedUs
 	}
 }
 
-func TestMountedWebUIRoutes_HumanAuthorization_DynamicGrant(t *testing.T) {
+func TestMountedUIRoutes_HumanAuthorization_DynamicGrant(t *testing.T) {
 	t.Parallel()
 
 	dir := t.TempDir()
 	if err := os.WriteFile(filepath.Join(dir, "index.html"), []byte("<html>protected-sample-shell</html>"), 0o644); err != nil {
 		t.Fatalf("WriteFile index.html: %v", err)
 	}
-	handler, err := testutilWebUIHandler(dir)
+	handler, err := testutilUIHandler(dir)
 	if err != nil {
-		t.Fatalf("webui handler: %v", err)
+		t.Fatalf("ui handler: %v", err)
 	}
 
 	svc := coretesting.NewStubServices(t)
@@ -1688,12 +1688,12 @@ func TestMountedWebUIRoutes_HumanAuthorization_DynamicGrant(t *testing.T) {
 		}
 		cfg.Services = svc
 		cfg.Authorizer = authz
-		cfg.MountedWebUIs = []server.MountedWebUI{{
+		cfg.MountedUIs = []server.MountedUI{{
 			Name:                "sample_portal",
 			Path:                "/sample-portal",
 			PluginName:          "sample_portal",
 			AuthorizationPolicy: "sample_policy",
-			Routes: []server.MountedWebUIRoute{
+			Routes: []server.MountedUIRoute{
 				{Path: "/admin/*", AllowedRoles: []string{"admin"}},
 				{Path: "/*", AllowedRoles: []string{"viewer", "admin"}},
 			},
@@ -1750,16 +1750,16 @@ func TestMountedWebUIRoutes_HumanAuthorization_DynamicGrant(t *testing.T) {
 	}
 }
 
-func TestMountedWebUIRoutes_HumanAuthorization_DefaultAllowTreatsAuthenticatedUsersAsViewerWithoutPluginName(t *testing.T) {
+func TestMountedUIRoutes_HumanAuthorization_DefaultAllowTreatsAuthenticatedUsersAsViewerWithoutPluginName(t *testing.T) {
 	t.Parallel()
 
 	dir := t.TempDir()
 	if err := os.WriteFile(filepath.Join(dir, "index.html"), []byte("<html>protected-sample-shell</html>"), 0o644); err != nil {
 		t.Fatalf("WriteFile index.html: %v", err)
 	}
-	handler, err := testutilWebUIHandler(dir)
+	handler, err := testutilUIHandler(dir)
 	if err != nil {
-		t.Fatalf("webui handler: %v", err)
+		t.Fatalf("ui handler: %v", err)
 	}
 
 	svc := coretesting.NewStubServices(t)
@@ -1790,11 +1790,11 @@ func TestMountedWebUIRoutes_HumanAuthorization_DefaultAllowTreatsAuthenticatedUs
 		}
 		cfg.Services = svc
 		cfg.Authorizer = legacy
-		cfg.MountedWebUIs = []server.MountedWebUI{{
+		cfg.MountedUIs = []server.MountedUI{{
 			Name:                "sample_portal",
 			Path:                "/sample-portal",
 			AuthorizationPolicy: "sample_policy",
-			Routes: []server.MountedWebUIRoute{
+			Routes: []server.MountedUIRoute{
 				{Path: "/admin/*", AllowedRoles: []string{"admin"}},
 				{Path: "/*", AllowedRoles: []string{"viewer", "admin"}},
 			},
@@ -1832,9 +1832,9 @@ func TestBuiltInAdminRoute_HumanAuthorization(t *testing.T) {
 	if err := os.WriteFile(filepath.Join(dir, "theme.css"), []byte("body{background:#eee;}"), 0o644); err != nil {
 		t.Fatalf("WriteFile theme.css: %v", err)
 	}
-	handler, err := testutilWebUIHandler(dir)
+	handler, err := testutilUIHandler(dir)
 	if err != nil {
-		t.Fatalf("webui handler: %v", err)
+		t.Fatalf("ui handler: %v", err)
 	}
 
 	svc := coretesting.NewStubServices(t)
@@ -1971,9 +1971,9 @@ func TestBuiltInAdminRoute_HumanAuthorizationOnManagementProfile(t *testing.T) {
 	if err := os.WriteFile(filepath.Join(dir, "index.html"), []byte("<html>protected-admin-shell</html>"), 0o644); err != nil {
 		t.Fatalf("WriteFile index.html: %v", err)
 	}
-	handler, err := testutilWebUIHandler(dir)
+	handler, err := testutilUIHandler(dir)
 	if err != nil {
-		t.Fatalf("webui handler: %v", err)
+		t.Fatalf("ui handler: %v", err)
 	}
 
 	svc := coretesting.NewStubServices(t)
@@ -2095,9 +2095,9 @@ func TestBuiltInAdminRoute_HumanAuthorizationSplitManagementLoginFlow(t *testing
 	if err := os.WriteFile(filepath.Join(dir, "index.html"), []byte("<html>protected-admin-shell</html>"), 0o644); err != nil {
 		t.Fatalf("WriteFile index.html: %v", err)
 	}
-	handler, err := testutilWebUIHandler(dir)
+	handler, err := testutilUIHandler(dir)
 	if err != nil {
-		t.Fatalf("webui handler: %v", err)
+		t.Fatalf("ui handler: %v", err)
 	}
 
 	secret := []byte("0123456789abcdef0123456789abcdef")
@@ -3799,12 +3799,12 @@ func TestAdminAPI_AdminAuthorizationPutFailureReturnsServerError(t *testing.T) {
 	}
 }
 
-func TestMountedWebUIRoutesHiddenOnManagementProfile(t *testing.T) {
+func TestMountedUIRoutesHiddenOnManagementProfile(t *testing.T) {
 	t.Parallel()
 
 	ts := newTestServer(t, func(cfg *server.Config) {
 		cfg.RouteProfile = server.RouteProfileManagement
-		cfg.MountedWebUIs = []server.MountedWebUI{{
+		cfg.MountedUIs = []server.MountedUI{{
 			Path:    "/sample-portal",
 			Handler: http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) { _, _ = w.Write([]byte("unexpected")) }),
 		}}
@@ -3821,10 +3821,10 @@ func TestMountedWebUIRoutesHiddenOnManagementProfile(t *testing.T) {
 	}
 }
 
-func TestMountedWebUIAuthorizationPolicyRequiresExplicitRouteCoverage(t *testing.T) {
+func TestMountedUIAuthorizationPolicyRequiresExplicitRouteCoverage(t *testing.T) {
 	t.Parallel()
 
-	makeConfig := func(mounted server.MountedWebUI) server.Config {
+	makeConfig := func(mounted server.MountedUI) server.Config {
 		svc := coretesting.NewStubServices(t)
 		authz := mustAuthorizer(t, config.AuthorizationConfig{
 			Policies: map[string]config.HumanPolicyDef{
@@ -3839,12 +3839,12 @@ func TestMountedWebUIAuthorizationPolicyRequiresExplicitRouteCoverage(t *testing
 			"sample_portal": {AuthorizationPolicy: "sample_policy"},
 		}, nil)
 		return server.Config{
-			Auth:          &coretesting.StubAuthProvider{N: "test"},
-			Services:      svc,
-			Invoker:       &testutil.StubInvoker{},
-			Authorizer:    authz,
-			StateSecret:   []byte("0123456789abcdef0123456789abcdef"),
-			MountedWebUIs: []server.MountedWebUI{mounted},
+			Auth:        &coretesting.StubAuthProvider{N: "test"},
+			Services:    svc,
+			Invoker:     &testutil.StubInvoker{},
+			Authorizer:  authz,
+			StateSecret: []byte("0123456789abcdef0123456789abcdef"),
+			MountedUIs:  []server.MountedUI{mounted},
 			Providers: func() *registry.ProviderMap[core.Provider] {
 				reg := registry.New()
 				return &reg.Providers
@@ -3854,12 +3854,12 @@ func TestMountedWebUIAuthorizationPolicyRequiresExplicitRouteCoverage(t *testing
 
 	tests := []struct {
 		name    string
-		mounted server.MountedWebUI
+		mounted server.MountedUI
 		want    string
 	}{
 		{
 			name: "missing routes",
-			mounted: server.MountedWebUI{
+			mounted: server.MountedUI{
 				Name:                "sample_portal",
 				Path:                "/sample-portal",
 				AuthorizationPolicy: "sample_policy",
@@ -3869,11 +3869,11 @@ func TestMountedWebUIAuthorizationPolicyRequiresExplicitRouteCoverage(t *testing
 		},
 		{
 			name: "missing root coverage",
-			mounted: server.MountedWebUI{
+			mounted: server.MountedUI{
 				Name:                "sample_portal",
 				Path:                "/sample-portal",
 				AuthorizationPolicy: "sample_policy",
-				Routes: []server.MountedWebUIRoute{
+				Routes: []server.MountedUIRoute{
 					{Path: "/sync/*", AllowedRoles: []string{"viewer", "admin"}},
 				},
 				Handler: http.NotFoundHandler(),
@@ -3895,16 +3895,16 @@ func TestMountedWebUIAuthorizationPolicyRequiresExplicitRouteCoverage(t *testing
 	}
 }
 
-func TestMountedWebUIAuthorizationPolicyNamedBuiltinAdminDoesNotUseAdminResolver(t *testing.T) {
+func TestMountedUIAuthorizationPolicyNamedBuiltinAdminDoesNotUseAdminResolver(t *testing.T) {
 	t.Parallel()
 
 	dir := t.TempDir()
 	if err := os.WriteFile(filepath.Join(dir, "index.html"), []byte("<html>custom-builtin-admin-name</html>"), 0o644); err != nil {
 		t.Fatalf("WriteFile index.html: %v", err)
 	}
-	handler, err := testutilWebUIHandler(dir)
+	handler, err := testutilUIHandler(dir)
 	if err != nil {
-		t.Fatalf("webui handler: %v", err)
+		t.Fatalf("ui handler: %v", err)
 	}
 
 	svc := coretesting.NewStubServices(t)
@@ -3940,11 +3940,11 @@ func TestMountedWebUIAuthorizationPolicyNamedBuiltinAdminDoesNotUseAdminResolver
 			AuthorizationPolicy: "admin_policy",
 			AllowedRoles:        []string{"admin"},
 		}
-		cfg.MountedWebUIs = []server.MountedWebUI{{
+		cfg.MountedUIs = []server.MountedUI{{
 			Name:                "builtin_admin",
 			Path:                "/sample-portal",
 			AuthorizationPolicy: "sample_policy",
-			Routes: []server.MountedWebUIRoute{
+			Routes: []server.MountedUIRoute{
 				{Path: "/*", AllowedRoles: []string{"admin"}},
 			},
 			Handler: handler,
@@ -3965,16 +3965,16 @@ func TestMountedWebUIAuthorizationPolicyNamedBuiltinAdminDoesNotUseAdminResolver
 	}
 }
 
-func TestMountedWebUIAuthorizationPolicyDeniesUnmatchedNavigationRoute(t *testing.T) {
+func TestMountedUIAuthorizationPolicyDeniesUnmatchedNavigationRoute(t *testing.T) {
 	t.Parallel()
 
 	dir := t.TempDir()
 	if err := os.WriteFile(filepath.Join(dir, "index.html"), []byte("<html>protected-sample-shell</html>"), 0o644); err != nil {
 		t.Fatalf("WriteFile index.html: %v", err)
 	}
-	handler, err := testutilWebUIHandler(dir)
+	handler, err := testutilUIHandler(dir)
 	if err != nil {
-		t.Fatalf("webui handler: %v", err)
+		t.Fatalf("ui handler: %v", err)
 	}
 
 	svc := coretesting.NewStubServices(t)
@@ -4004,11 +4004,11 @@ func TestMountedWebUIAuthorizationPolicyDeniesUnmatchedNavigationRoute(t *testin
 		}
 		cfg.Services = svc
 		cfg.Authorizer = authz
-		cfg.MountedWebUIs = []server.MountedWebUI{{
+		cfg.MountedUIs = []server.MountedUI{{
 			Name:                "sample_portal",
 			Path:                "/sample-portal",
 			AuthorizationPolicy: "sample_policy",
-			Routes: []server.MountedWebUIRoute{
+			Routes: []server.MountedUIRoute{
 				{Path: "/", AllowedRoles: []string{"viewer", "admin"}},
 				{Path: "/sync/*", AllowedRoles: []string{"viewer", "admin"}},
 			},
@@ -4029,7 +4029,7 @@ func TestMountedWebUIAuthorizationPolicyDeniesUnmatchedNavigationRoute(t *testin
 	}
 }
 
-func TestMountedWebUIAuthorizationPolicyUsesCanonicalNavigationPaths(t *testing.T) {
+func TestMountedUIAuthorizationPolicyUsesCanonicalNavigationPaths(t *testing.T) {
 	t.Parallel()
 
 	dir := t.TempDir()
@@ -4048,9 +4048,9 @@ func TestMountedWebUIAuthorizationPolicyUsesCanonicalNavigationPaths(t *testing.
 	if err := os.WriteFile(filepath.Join(dir, "reports", "index.html"), []byte("<html>reports</html>"), 0o644); err != nil {
 		t.Fatalf("WriteFile reports/index.html: %v", err)
 	}
-	handler, err := testutilWebUIHandler(dir)
+	handler, err := testutilUIHandler(dir)
 	if err != nil {
-		t.Fatalf("webui handler: %v", err)
+		t.Fatalf("ui handler: %v", err)
 	}
 
 	svc := coretesting.NewStubServices(t)
@@ -4080,11 +4080,11 @@ func TestMountedWebUIAuthorizationPolicyUsesCanonicalNavigationPaths(t *testing.
 		}
 		cfg.Services = svc
 		cfg.Authorizer = authz
-		cfg.MountedWebUIs = []server.MountedWebUI{{
+		cfg.MountedUIs = []server.MountedUI{{
 			Name:                "sample_portal",
 			Path:                "/sample-portal",
 			AuthorizationPolicy: "sample_policy",
-			Routes: []server.MountedWebUIRoute{
+			Routes: []server.MountedUIRoute{
 				{Path: "/", AllowedRoles: []string{"viewer", "admin"}},
 				{Path: "/reports", AllowedRoles: []string{"viewer", "admin"}},
 			},
@@ -4116,7 +4116,7 @@ func TestMountedWebUIAuthorizationPolicyUsesCanonicalNavigationPaths(t *testing.
 	}
 }
 
-func TestMountedWebUIAuthorizationPolicyUsesNearestAncestorRouteForNestedAssets(t *testing.T) {
+func TestMountedUIAuthorizationPolicyUsesNearestAncestorRouteForNestedAssets(t *testing.T) {
 	t.Parallel()
 
 	dir := t.TempDir()
@@ -4129,9 +4129,9 @@ func TestMountedWebUIAuthorizationPolicyUsesNearestAncestorRouteForNestedAssets(
 	if err := os.WriteFile(filepath.Join(dir, "reports", "assets", "app.js"), []byte("console.log('reports-only')"), 0o644); err != nil {
 		t.Fatalf("WriteFile reports/assets/app.js: %v", err)
 	}
-	handler, err := testutilWebUIHandler(dir)
+	handler, err := testutilUIHandler(dir)
 	if err != nil {
-		t.Fatalf("webui handler: %v", err)
+		t.Fatalf("ui handler: %v", err)
 	}
 
 	svc := coretesting.NewStubServices(t)
@@ -4161,11 +4161,11 @@ func TestMountedWebUIAuthorizationPolicyUsesNearestAncestorRouteForNestedAssets(
 		}
 		cfg.Services = svc
 		cfg.Authorizer = authz
-		cfg.MountedWebUIs = []server.MountedWebUI{{
+		cfg.MountedUIs = []server.MountedUI{{
 			Name:                "sample_portal",
 			Path:                "/sample-portal",
 			AuthorizationPolicy: "sample_policy",
-			Routes: []server.MountedWebUIRoute{
+			Routes: []server.MountedUIRoute{
 				{Path: "/", AllowedRoles: []string{"viewer", "admin"}},
 				{Path: "/reports", AllowedRoles: []string{"admin"}},
 			},
@@ -4186,7 +4186,7 @@ func TestMountedWebUIAuthorizationPolicyUsesNearestAncestorRouteForNestedAssets(
 	}
 }
 
-func TestMountedWebUIAuthorizationPolicyAllowsExplicitCatchAllAndDottedRoutes(t *testing.T) {
+func TestMountedUIAuthorizationPolicyAllowsExplicitCatchAllAndDottedRoutes(t *testing.T) {
 	t.Parallel()
 
 	dir := t.TempDir()
@@ -4199,9 +4199,9 @@ func TestMountedWebUIAuthorizationPolicyAllowsExplicitCatchAllAndDottedRoutes(t 
 	if err := os.WriteFile(filepath.Join(dir, "admin", "widget.js"), []byte("console.log('admin-only')"), 0o644); err != nil {
 		t.Fatalf("WriteFile admin/widget.js: %v", err)
 	}
-	handler, err := testutilWebUIHandler(dir)
+	handler, err := testutilUIHandler(dir)
 	if err != nil {
-		t.Fatalf("webui handler: %v", err)
+		t.Fatalf("ui handler: %v", err)
 	}
 
 	svc := coretesting.NewStubServices(t)
@@ -4231,11 +4231,11 @@ func TestMountedWebUIAuthorizationPolicyAllowsExplicitCatchAllAndDottedRoutes(t 
 		}
 		cfg.Services = svc
 		cfg.Authorizer = authz
-		cfg.MountedWebUIs = []server.MountedWebUI{{
+		cfg.MountedUIs = []server.MountedUI{{
 			Name:                "sample_portal",
 			Path:                "/sample-portal",
 			AuthorizationPolicy: "sample_policy",
-			Routes: []server.MountedWebUIRoute{
+			Routes: []server.MountedUIRoute{
 				{Path: "/admin/widget.js", AllowedRoles: []string{"admin"}},
 				{Path: "/*", AllowedRoles: []string{"viewer", "admin"}},
 			},
@@ -4267,16 +4267,16 @@ func TestMountedWebUIAuthorizationPolicyAllowsExplicitCatchAllAndDottedRoutes(t 
 	}
 }
 
-func TestMountedWebUIAuthorizationPolicyPrefersExactRoutesOverWildcards(t *testing.T) {
+func TestMountedUIAuthorizationPolicyPrefersExactRoutesOverWildcards(t *testing.T) {
 	t.Parallel()
 
 	dir := t.TempDir()
 	if err := os.WriteFile(filepath.Join(dir, "index.html"), []byte("<html>protected-sample-shell</html>"), 0o644); err != nil {
 		t.Fatalf("WriteFile index.html: %v", err)
 	}
-	handler, err := testutilWebUIHandler(dir)
+	handler, err := testutilUIHandler(dir)
 	if err != nil {
-		t.Fatalf("webui handler: %v", err)
+		t.Fatalf("ui handler: %v", err)
 	}
 
 	svc := coretesting.NewStubServices(t)
@@ -4306,11 +4306,11 @@ func TestMountedWebUIAuthorizationPolicyPrefersExactRoutesOverWildcards(t *testi
 		}
 		cfg.Services = svc
 		cfg.Authorizer = authz
-		cfg.MountedWebUIs = []server.MountedWebUI{{
+		cfg.MountedUIs = []server.MountedUI{{
 			Name:                "sample_portal",
 			Path:                "/sample-portal",
 			AuthorizationPolicy: "sample_policy",
-			Routes: []server.MountedWebUIRoute{
+			Routes: []server.MountedUIRoute{
 				{Path: "/admin/settings", AllowedRoles: []string{"admin"}},
 				{Path: "/admin/*", AllowedRoles: []string{"viewer", "admin"}},
 				{Path: "/*", AllowedRoles: []string{"viewer", "admin"}},
@@ -4343,16 +4343,16 @@ func TestMountedWebUIAuthorizationPolicyPrefersExactRoutesOverWildcards(t *testi
 	}
 }
 
-func TestMountedWebUIAuthorizationPolicyExactRoutesDoNotMatchDescendants(t *testing.T) {
+func TestMountedUIAuthorizationPolicyExactRoutesDoNotMatchDescendants(t *testing.T) {
 	t.Parallel()
 
 	dir := t.TempDir()
 	if err := os.WriteFile(filepath.Join(dir, "index.html"), []byte("<html>protected-sample-shell</html>"), 0o644); err != nil {
 		t.Fatalf("WriteFile index.html: %v", err)
 	}
-	handler, err := testutilWebUIHandler(dir)
+	handler, err := testutilUIHandler(dir)
 	if err != nil {
-		t.Fatalf("webui handler: %v", err)
+		t.Fatalf("ui handler: %v", err)
 	}
 
 	svc := coretesting.NewStubServices(t)
@@ -4382,11 +4382,11 @@ func TestMountedWebUIAuthorizationPolicyExactRoutesDoNotMatchDescendants(t *test
 		}
 		cfg.Services = svc
 		cfg.Authorizer = authz
-		cfg.MountedWebUIs = []server.MountedWebUI{{
+		cfg.MountedUIs = []server.MountedUI{{
 			Name:                "sample_portal",
 			Path:                "/sample-portal",
 			AuthorizationPolicy: "sample_policy",
-			Routes: []server.MountedWebUIRoute{
+			Routes: []server.MountedUIRoute{
 				{Path: "/admin", AllowedRoles: []string{"viewer", "admin"}},
 				{Path: "/admin/*", AllowedRoles: []string{"admin"}},
 				{Path: "/*", AllowedRoles: []string{"viewer", "admin"}},
@@ -4430,7 +4430,7 @@ func TestMountedWebUIAuthorizationPolicyExactRoutesDoNotMatchDescendants(t *test
 	}
 }
 
-func TestMountedRootWebUIRoutes(t *testing.T) {
+func TestMountedRootUIRoutes(t *testing.T) {
 	t.Parallel()
 
 	dir := t.TempDir()
@@ -4443,13 +4443,13 @@ func TestMountedRootWebUIRoutes(t *testing.T) {
 	if err := os.WriteFile(filepath.Join(dir, "assets", "app.js"), []byte("console.log('root-ui')"), 0o644); err != nil {
 		t.Fatalf("WriteFile app.js: %v", err)
 	}
-	handler, err := testutilWebUIHandler(dir)
+	handler, err := testutilUIHandler(dir)
 	if err != nil {
-		t.Fatalf("webui handler: %v", err)
+		t.Fatalf("ui handler: %v", err)
 	}
 
 	ts := newTestServer(t, func(cfg *server.Config) {
-		cfg.MountedWebUIs = []server.MountedWebUI{{
+		cfg.MountedUIs = []server.MountedUI{{
 			Path:    "/",
 			Handler: handler,
 		}}
@@ -4521,12 +4521,12 @@ func TestMountedRootWebUIRoutes(t *testing.T) {
 	}
 }
 
-func TestMountedRootWebUIRoutesHiddenOnManagementProfile(t *testing.T) {
+func TestMountedRootUIRoutesHiddenOnManagementProfile(t *testing.T) {
 	t.Parallel()
 
 	ts := newTestServer(t, func(cfg *server.Config) {
 		cfg.RouteProfile = server.RouteProfileManagement
-		cfg.MountedWebUIs = []server.MountedWebUI{{
+		cfg.MountedUIs = []server.MountedUI{{
 			Path:    "/",
 			Handler: http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) { _, _ = w.Write([]byte("unexpected")) }),
 		}}
@@ -4543,8 +4543,8 @@ func TestMountedRootWebUIRoutesHiddenOnManagementProfile(t *testing.T) {
 	}
 }
 
-func testutilWebUIHandler(dir string) (http.Handler, error) {
-	return webui.DirHandler(dir)
+func testutilUIHandler(dir string) (http.Handler, error) {
+	return ui.DirHandler(dir)
 }
 
 func TestSecurityHeaders(t *testing.T) {
@@ -5211,7 +5211,7 @@ func TestListIntegrations_IncludesMountedPath(t *testing.T) {
 				MountPath: "/github",
 			},
 		}
-		cfg.MountedWebUIs = []server.MountedWebUI{{
+		cfg.MountedUIs = []server.MountedUI{{
 			Name:       "github",
 			PluginName: "github",
 			Path:       "/github",
@@ -5329,13 +5329,13 @@ func TestListIntegrations_HumanAuthorizationFiltersByMountedUIAccessAndVisibleOp
 		cfg.PluginDefs = pluginDefs
 		cfg.Services = svc
 		cfg.Authorizer = authz
-		cfg.MountedWebUIs = []server.MountedWebUI{
+		cfg.MountedUIs = []server.MountedUI{
 			{
 				Name:                "ops-visible",
 				PluginName:          "ops-visible",
 				Path:                "/ops-visible",
 				AuthorizationPolicy: "sample_policy",
-				Routes: []server.MountedWebUIRoute{
+				Routes: []server.MountedUIRoute{
 					{Path: "/*", AllowedRoles: []string{"admin"}},
 				},
 				Handler: handler,
@@ -5345,7 +5345,7 @@ func TestListIntegrations_HumanAuthorizationFiltersByMountedUIAccessAndVisibleOp
 				PluginName:          "settings-visible",
 				Path:                "/settings-visible",
 				AuthorizationPolicy: "sample_policy",
-				Routes: []server.MountedWebUIRoute{
+				Routes: []server.MountedUIRoute{
 					{Path: "/*", AllowedRoles: []string{"admin"}},
 				},
 				Handler: handler,
@@ -5355,7 +5355,7 @@ func TestListIntegrations_HumanAuthorizationFiltersByMountedUIAccessAndVisibleOp
 				PluginName:          "ui-visible",
 				Path:                "/ui-visible",
 				AuthorizationPolicy: "sample_policy",
-				Routes: []server.MountedWebUIRoute{
+				Routes: []server.MountedUIRoute{
 					{Path: "/*", AllowedRoles: []string{"viewer"}},
 				},
 				Handler: handler,
@@ -5365,7 +5365,7 @@ func TestListIntegrations_HumanAuthorizationFiltersByMountedUIAccessAndVisibleOp
 				PluginName:          "hidden",
 				Path:                "/hidden",
 				AuthorizationPolicy: "sample_policy",
-				Routes: []server.MountedWebUIRoute{
+				Routes: []server.MountedUIRoute{
 					{Path: "/*", AllowedRoles: []string{"admin"}},
 				},
 				Handler: handler,
@@ -6399,7 +6399,7 @@ func TestListIntegrations_ConnectionInfosUseResolvedConnectionDefs(t *testing.T)
 				"clickhouse": plugin,
 			}
 			cfg.Services = coretesting.NewStubServices(t)
-			cfg.MountedWebUIs = []server.MountedWebUI{{
+			cfg.MountedUIs = []server.MountedUI{{
 				Name:       "clickhouse",
 				PluginName: "clickhouse",
 				Path:       "/clickhouse",
@@ -10133,7 +10133,7 @@ func TestStartBrowserLogin_MissingPluginRouteAuthProviderAuditsAttemptedProvider
 		cfg.Auth = &stubHostIssuedSessionAuth{name: "server"}
 		cfg.SelectedAuthProvider = "server"
 		cfg.AuditSink = auditSink
-		cfg.MountedWebUIs = []server.MountedWebUI{{
+		cfg.MountedUIs = []server.MountedUI{{
 			Name:       "sample_portal",
 			Path:       "/sample-portal",
 			PluginName: "sample_portal",
@@ -10275,7 +10275,7 @@ func TestLoginCallback_MissingPluginRouteAuthProviderAuditsAttemptedProvider(t *
 		cfg.AuthProviders = map[string]core.AuthenticationProvider{
 			"alt": &stubHostIssuedSessionAuth{name: "alt"},
 		}
-		cfg.MountedWebUIs = []server.MountedWebUI{{
+		cfg.MountedUIs = []server.MountedUI{{
 			Name:       "sample_portal",
 			Path:       "/sample-portal",
 			PluginName: "sample_portal",

--- a/gestaltd/internal/ui/ui.go
+++ b/gestaltd/internal/ui/ui.go
@@ -1,5 +1,5 @@
-// Package webui serves the client UI static assets from a prepared directory.
-package webui
+// Package ui serves the client UI static assets from a prepared directory.
+package ui
 
 import (
 	"fmt"
@@ -15,7 +15,7 @@ func DirHandler(path string) (http.Handler, error) {
 		DynamicIndex: true,
 	})
 	if err != nil {
-		return nil, fmt.Errorf("webui: %s: %w", path, err)
+		return nil, fmt.Errorf("ui: %s: %w", path, err)
 	}
 	return handler, nil
 }

--- a/gestaltd/internal/ui/ui_test.go
+++ b/gestaltd/internal/ui/ui_test.go
@@ -1,4 +1,4 @@
-package webui
+package ui
 
 import (
 	"io"

--- a/gestaltd/sdk/providermanifest/v1/manifest.jsonschema.json
+++ b/gestaltd/sdk/providermanifest/v1/manifest.jsonschema.json
@@ -19,7 +19,7 @@
         "cache",
         "s3",
         "secrets",
-        "webui"
+        "ui"
       ]
     },
     "source": {
@@ -165,7 +165,7 @@
         "routes": {
           "type": "array",
           "items": {
-            "$ref": "#/$defs/webuiRoute"
+            "$ref": "#/$defs/uiRoute"
           }
         }
       }
@@ -832,7 +832,7 @@
         }
       }
     },
-    "webuiRoute": {
+    "uiRoute": {
       "type": "object",
       "additionalProperties": false,
       "required": [

--- a/gestaltd/sdk/providermanifest/v1/types.go
+++ b/gestaltd/sdk/providermanifest/v1/types.go
@@ -26,6 +26,8 @@ const (
 
 func NormalizeKind(kind string) string {
 	switch strings.TrimSpace(strings.ToLower(kind)) {
+	case "auth":
+		return KindAuthentication
 	case KindAuthentication:
 		return KindAuthentication
 	case KindPlugin:
@@ -42,6 +44,8 @@ func NormalizeKind(kind string) string {
 		return KindWorkflow
 	case KindSecrets:
 		return KindSecrets
+	case "webui":
+		return KindUI
 	case KindUI:
 		return KindUI
 	default:

--- a/gestaltd/sdk/providermanifest/v1/types.go
+++ b/gestaltd/sdk/providermanifest/v1/types.go
@@ -21,7 +21,7 @@ const (
 	KindS3             = "s3"
 	KindWorkflow       = "workflow"
 	KindSecrets        = "secrets"
-	KindWebUI          = "webui"
+	KindUI             = "ui"
 )
 
 func NormalizeKind(kind string) string {
@@ -42,8 +42,8 @@ func NormalizeKind(kind string) string {
 		return KindWorkflow
 	case KindSecrets:
 		return KindSecrets
-	case KindWebUI:
-		return KindWebUI
+	case KindUI:
+		return KindUI
 	default:
 		return strings.TrimSpace(kind)
 	}
@@ -73,7 +73,7 @@ type ReleaseBuild struct {
 
 // Spec is a union type validated per kind. For auth/datastore/secrets only
 // ConfigSchemaPath is valid. For plugins all surface/connection fields are
-// valid. For webui AssetRoot + ConfigSchemaPath.
+// valid. For ui AssetRoot + ConfigSchemaPath.
 type Spec struct {
 	ConfigSchemaPath string `json:"configSchemaPath,omitempty" yaml:"configSchemaPath,omitempty"`
 
@@ -93,9 +93,9 @@ type Spec struct {
 	Requires          []string                              `json:"requires,omitempty" yaml:"requires,omitempty"`
 	UI                *OwnedUI                              `json:"ui,omitempty" yaml:"ui,omitempty"`
 
-	// WebUI-specific fields
-	AssetRoot string       `json:"assetRoot,omitempty" yaml:"assetRoot,omitempty"`
-	Routes    []WebUIRoute `json:"routes,omitempty" yaml:"routes,omitempty"`
+	// UI-specific fields
+	AssetRoot string    `json:"assetRoot,omitempty" yaml:"assetRoot,omitempty"`
+	Routes    []UIRoute `json:"routes,omitempty" yaml:"routes,omitempty"`
 }
 
 type RouteAuthRef struct {
@@ -359,7 +359,7 @@ type ManifestConnectionDef struct {
 	Discovery   *ProviderDiscovery                 `json:"discovery,omitempty" yaml:"discovery,omitempty"`
 }
 
-type WebUIRoute struct {
+type UIRoute struct {
 	Path         string   `json:"path" yaml:"path"`
 	AllowedRoles []string `json:"allowedRoles,omitempty" yaml:"allowedRoles,omitempty"`
 }
@@ -493,7 +493,7 @@ type specJSONWire struct {
 	Requires          []string                              `json:"requires,omitempty"`
 	UI                *OwnedUI                              `json:"ui,omitempty"`
 	AssetRoot         string                                `json:"assetRoot,omitempty"`
-	Routes            []WebUIRoute                          `json:"routes,omitempty"`
+	Routes            []UIRoute                             `json:"routes,omitempty"`
 }
 
 type specYAMLWire struct {
@@ -513,7 +513,7 @@ type specYAMLWire struct {
 	Requires          []string                              `yaml:"requires,omitempty"`
 	UI                *OwnedUI                              `yaml:"ui,omitempty"`
 	AssetRoot         string                                `yaml:"assetRoot,omitempty"`
-	Routes            []WebUIRoute                          `yaml:"routes,omitempty"`
+	Routes            []UIRoute                             `yaml:"routes,omitempty"`
 }
 
 type specWire struct {
@@ -533,7 +533,7 @@ type specWire struct {
 	Requires          []string                              `json:"requires,omitempty" yaml:"requires,omitempty"`
 	UI                *OwnedUI                              `json:"ui,omitempty" yaml:"ui,omitempty"`
 	AssetRoot         string                                `json:"assetRoot,omitempty" yaml:"assetRoot,omitempty"`
-	Routes            []WebUIRoute                          `json:"routes,omitempty" yaml:"routes,omitempty"`
+	Routes            []UIRoute                             `json:"routes,omitempty" yaml:"routes,omitempty"`
 }
 
 func (s *Spec) UnmarshalJSON(data []byte) error {


### PR DESCRIPTION
## Summary
This renames the UI provider surface from `webui` to `ui` and cleans up the provider docs so the naming and product semantics are consistent.

It also adds product-facing authorization guidance to the provider docs, including how authorization applies to plugins, workflows, and UI routes.

## What changed
- rename provider manifests and runtime naming from `webui` to `ui`
- rename internal UI package paths and route helpers to match
- rename the provider and custom-provider docs routes from `/providers/web-uis` and `/custom-providers/web-uis` to `/providers/ui` and `/custom-providers/ui`
- make provider page titles singular, such as `Plugin`, `Secret`, and `UI`
- document product authorization semantics in the Authorization, Plugin, Workflow, and UI pages
- standardize provider docs sections and examples, including the cache, IndexedDB, and S3 pages

## Breaking change
Yes. This is backward incompatible.

Existing provider manifests and any code or tooling that still use `kind: webui` must be updated to `kind: ui`.

Docs links that still point at the old `web-uis` routes will also need to be updated.

## Validation
- `npm run typecheck`
- `npm run build`
- `go test -run '^$' ./sdk/providermanifest/v1 ./internal/providerpkg ./internal/server ./internal/operator ./internal/config ./cmd/gestaltd`
- `git diff --check`

## Examples
Provider manifest kind:
```yaml
kind: ui
```

Provider docs routes:
- `/providers/ui`
- `/custom-providers/ui`
