### PR TITLE
runtime: bump default web UI to 0.0.1-alpha.12

### DIFF
--- a/gestaltd/internal/config/config.go
+++ b/gestaltd/internal/config/config.go
@@ -34,7 +34,7 @@ const (
 	DefaultIndexedDBProvider = DefaultProviderRepo + "/indexeddb/relationaldb"
 	DefaultIndexedDBVersion  = "0.0.1-alpha.1"
 	DefaultUIProvider        = DefaultProviderRepo + "/web/default"
-	DefaultUIVersion         = "0.0.1-alpha.11"
+	DefaultUIVersion         = "0.0.1-alpha.12"
 	DefaultProviderInstance  = "default"
 )
 


### PR DESCRIPTION
## Summary
Bumps `DefaultWebUIVersion` in `gestaltd/internal/config/config.go` from `0.0.1-alpha.11` to `0.0.1-alpha.12` so gestaltd invoked without a config-driven web UI override now serves the latest default bundle — which picks up the workflow run inspection UI ([gestalt-providers#154](https://github.com/valon-technologies/gestalt-providers/pull/154)) and the workflow run UX expansion ([#156](https://github.com/valon-technologies/gestalt-providers/pull/156)).

## Test plan
- [x] Compiles (go build ./...)
- [ ] Spin up a gestaltd with no web UI config and verify the workflows tab renders.

🤖 Generated with [Claude Code](https://claude.com/claude-code)