### PR TITLE
Make audit and managed-identity paths subject-only

### DIFF
--- a/gestaltd/core/audit.go
+++ b/gestaltd/core/audit.go
@@ -10,7 +10,6 @@ type AuditEntry struct {
 	RequestID                    string
 	Source                       string
 	AuthSource                   string
-	UserID                       string
 	SubjectID                    string
 	SubjectKind                  string
 	AccessPolicy                 string

--- a/gestaltd/internal/invocation/audit.go
+++ b/gestaltd/internal/invocation/audit.go
@@ -62,7 +62,6 @@ func buildAuditEntry(ctx context.Context, p *principal.Principal, source, provid
 		UserAgent:  reqMeta.UserAgent,
 	}
 	if p != nil {
-		entry.UserID = p.UserID
 		entry.AuthSource = p.AuthSource()
 		entry.SubjectID = p.SubjectID
 		if p.Kind != "" {
@@ -110,7 +109,6 @@ func SetCredentialAudit(ctx context.Context, mode core.ConnectionMode, subjectID
 
 func (s *SlogAuditSink) Log(ctx context.Context, entry core.AuditEntry) {
 	auditPrincipal := principal.Canonicalized(&principal.Principal{
-		UserID:    strings.TrimSpace(entry.UserID),
 		SubjectID: strings.TrimSpace(entry.SubjectID),
 		Kind:      principal.Kind(strings.TrimSpace(entry.SubjectKind)),
 	})

--- a/gestaltd/internal/invocation/audit_test.go
+++ b/gestaltd/internal/invocation/audit_test.go
@@ -24,14 +24,15 @@ func TestSlogAuditSink_AllowedEntry(t *testing.T) {
 
 	eventTime := time.Date(2026, 3, 15, 12, 30, 0, 0, time.UTC)
 	entry := core.AuditEntry{
-		Timestamp: eventTime,
-		RequestID: "req-abc-123",
-		Source:    "binding:test-hook",
-		UserID:    "user-42",
-		Provider:  "alpha",
-		Operation: "fetch",
-		Depth:     1,
-		Allowed:   true,
+		Timestamp:   eventTime,
+		RequestID:   "req-abc-123",
+		Source:      "binding:test-hook",
+		SubjectID:   principal.UserSubjectID("user-42"),
+		SubjectKind: string(principal.KindUser),
+		Provider:    "alpha",
+		Operation:   "fetch",
+		Depth:       1,
+		Allowed:     true,
 	}
 
 	sink.Log(context.Background(), entry)
@@ -93,15 +94,16 @@ func TestSlogAuditSink_DeniedEntry(t *testing.T) {
 	sink := invocation.NewSlogAuditSink(&buf)
 
 	entry := core.AuditEntry{
-		Timestamp: time.Now(),
-		RequestID: "req-deny-456",
-		Source:    "binding:test-hook",
-		UserID:    "user-99",
-		Provider:  "beta",
-		Operation: "write",
-		Depth:     2,
-		Allowed:   false,
-		Error:     "provider \"beta\" is not available in this scope",
+		Timestamp:   time.Now(),
+		RequestID:   "req-deny-456",
+		Source:      "binding:test-hook",
+		SubjectID:   principal.UserSubjectID("user-99"),
+		SubjectKind: string(principal.KindUser),
+		Provider:    "beta",
+		Operation:   "write",
+		Depth:       2,
+		Allowed:     false,
+		Error:       "provider \"beta\" is not available in this scope",
 	}
 
 	sink.Log(context.Background(), entry)

--- a/gestaltd/internal/providerhost/invocation_token.go
+++ b/gestaltd/internal/providerhost/invocation_token.go
@@ -324,19 +324,15 @@ func shouldInheritCredentialSelectors(p *principal.Principal) bool {
 }
 
 func subjectIDForInvocationClaims(p *principal.Principal) string {
+	p = principal.Canonicalized(p)
 	if p == nil {
 		return ""
 	}
-	if subjectID := strings.TrimSpace(p.SubjectID); subjectID != "" {
-		return subjectID
-	}
-	if userID := strings.TrimSpace(p.UserID); userID != "" {
-		return principal.UserSubjectID(userID)
-	}
-	return ""
+	return strings.TrimSpace(p.SubjectID)
 }
 
 func subjectKindForInvocationClaims(p *principal.Principal) principal.Kind {
+	p = principal.Canonicalized(p)
 	if p == nil {
 		return ""
 	}

--- a/gestaltd/internal/providerhost/provider_client.go
+++ b/gestaltd/internal/providerhost/provider_client.go
@@ -323,19 +323,15 @@ func requestContextProto(ctx context.Context) (*proto.RequestContext, error) {
 }
 
 func subjectIDForPrincipal(p *principal.Principal) string {
+	p = principal.Canonicalized(p)
 	if p == nil {
 		return ""
 	}
-	if p.SubjectID != "" {
-		return p.SubjectID
-	}
-	if p.UserID != "" {
-		return principal.UserSubjectID(p.UserID)
-	}
-	return ""
+	return p.SubjectID
 }
 
 func subjectKindForPrincipal(p *principal.Principal) string {
+	p = principal.Canonicalized(p)
 	if p == nil {
 		return ""
 	}
@@ -348,7 +344,7 @@ func subjectKindForPrincipal(p *principal.Principal) string {
 	case strings.HasPrefix(p.SubjectID, string(principal.KindWorkload)+":"):
 		return string(principal.KindWorkload)
 	}
-	if p.UserID != "" || p.Identity != nil {
+	if p.Identity != nil {
 		return string(principal.KindUser)
 	}
 	return ""

--- a/gestaltd/internal/providerhost/provider_test.go
+++ b/gestaltd/internal/providerhost/provider_test.go
@@ -42,10 +42,7 @@ func (p *roundTripProvider) Execute(ctx context.Context, operation string, param
 	displayName := ""
 	identityPresent := "false"
 	if p := principal.FromContext(ctx); p != nil {
-		subjectID = p.SubjectID
-		if subjectID == "" && p.UserID != "" {
-			subjectID = principal.UserSubjectID(p.UserID)
-		}
+		subjectID = principal.Canonicalized(p).SubjectID
 		subjectKind = string(p.Kind)
 		authSource = p.AuthSource()
 		displayName = p.DisplayName
@@ -79,10 +76,7 @@ func (p *roundTripProvider) CatalogForRequest(ctx context.Context, token string)
 	displayName := ""
 	identityPresent := "false"
 	if p := principal.FromContext(ctx); p != nil {
-		subjectID = p.SubjectID
-		if subjectID == "" && p.UserID != "" {
-			subjectID = principal.UserSubjectID(p.UserID)
-		}
+		subjectID = principal.Canonicalized(p).SubjectID
 		subjectKind = string(p.Kind)
 		authSource = p.AuthSource()
 		displayName = p.DisplayName

--- a/gestaltd/internal/server/handlers_identities.go
+++ b/gestaltd/internal/server/handlers_identities.go
@@ -76,14 +76,13 @@ type putManagedIdentityGrantRequest struct {
 }
 
 type managedIdentityActor struct {
-	UserID     string
 	SubjectID  string
 	Identity   *core.ManagedIdentity
 	Membership *core.ManagedIdentityMembership
 }
 
 func (s *Server) listManagedIdentities(w http.ResponseWriter, r *http.Request) {
-	_, subjectID, _, ok := s.resolveManagedIdentityUser(w, r)
+	_, subjectID, ok := s.resolveManagedIdentityUser(w, r)
 	if !ok {
 		return
 	}
@@ -135,7 +134,7 @@ func (s *Server) createManagedIdentity(w http.ResponseWriter, r *http.Request) {
 		s.auditHTTPEventWithTarget(r.Context(), PrincipalFromContext(r.Context()), "", "identity.create", auditAllowed, auditErr, auditTarget)
 	}()
 
-	userID, subjectID, user, ok := s.resolveManagedIdentityUser(w, r)
+	user, subjectID, ok := s.resolveManagedIdentityUser(w, r)
 	if !ok {
 		return
 	}
@@ -160,7 +159,7 @@ func (s *Server) createManagedIdentity(w http.ResponseWriter, r *http.Request) {
 	identity := &core.ManagedIdentity{
 		ID:                  uuid.NewString(),
 		DisplayName:         req.DisplayName,
-		CreatedByIdentityID: userID,
+		CreatedByIdentityID: user.ID,
 		CreatedAt:           now,
 		UpdatedAt:           now,
 	}
@@ -655,7 +654,7 @@ func (s *Server) putManagedIdentityGrant(w http.ResponseWriter, r *http.Request)
 		return
 	}
 
-	p := managedIdentityGrantValidationPrincipal(PrincipalFromContext(r.Context()), actor.UserID)
+	p := managedIdentityGrantValidationPrincipal(PrincipalFromContext(r.Context()), actor.SubjectID)
 	if !s.managedIdentityGrantPluginVisible(r.Context(), plugin, p) {
 		auditErr = errors.New("plugin not found")
 		writeError(w, http.StatusNotFound, "plugin not found")
@@ -765,24 +764,24 @@ func (s *Server) deleteManagedIdentityGrant(w http.ResponseWriter, r *http.Reque
 	writeJSON(w, http.StatusOK, map[string]string{"status": "deleted"})
 }
 
-func (s *Server) resolveManagedIdentityUser(w http.ResponseWriter, r *http.Request) (string, string, *core.User, bool) {
+func (s *Server) resolveManagedIdentityUser(w http.ResponseWriter, r *http.Request) (*core.User, string, bool) {
 	if !s.ensureManagedIdentityRoutesAvailable(w) {
-		return "", "", nil, false
+		return nil, "", false
 	}
 	userID, err := s.resolveUserID(w, r)
 	if err != nil {
-		return "", "", nil, false
+		return nil, "", false
 	}
 	user, err := s.users.GetUser(r.Context(), userID)
 	if err != nil {
 		writeError(w, http.StatusInternalServerError, "failed to resolve user")
-		return "", "", nil, false
+		return nil, "", false
 	}
-	return userID, principal.UserSubjectID(userID), user, true
+	return user, principal.UserSubjectID(userID), true
 }
 
 func (s *Server) resolveManagedIdentityActor(w http.ResponseWriter, r *http.Request, requiredRole string) (*managedIdentityActor, bool) {
-	userID, subjectID, _, ok := s.resolveManagedIdentityUser(w, r)
+	_, subjectID, ok := s.resolveManagedIdentityUser(w, r)
 	if !ok {
 		return nil, false
 	}
@@ -815,7 +814,6 @@ func (s *Server) resolveManagedIdentityActor(w http.ResponseWriter, r *http.Requ
 		return nil, false
 	}
 	return &managedIdentityActor{
-		UserID:     userID,
 		SubjectID:  subjectID,
 		Identity:   identity,
 		Membership: membership,
@@ -1216,22 +1214,22 @@ func (s *Server) managedIdentityGrantSessionCatalog(
 	return cat, true, err
 }
 
-func managedIdentityGrantValidationPrincipal(p *principal.Principal, userID string) *principal.Principal {
-	userID = strings.TrimSpace(userID)
-	if userID == "" {
+func managedIdentityGrantValidationPrincipal(p *principal.Principal, subjectID string) *principal.Principal {
+	subjectID = strings.TrimSpace(subjectID)
+	if subjectID == "" {
 		return p
 	}
 	if p == nil {
 		return principal.Canonicalize(&principal.Principal{
-			Kind:   principal.KindUser,
-			UserID: userID,
+			Kind:      principal.KindUser,
+			SubjectID: subjectID,
 		})
 	}
-	if p.UserID == userID {
+	if strings.TrimSpace(p.SubjectID) == subjectID {
 		return principal.Canonicalized(p)
 	}
 	clone := *p
-	clone.UserID = userID
+	clone.SubjectID = subjectID
 	return principal.Canonicalize(&clone)
 }
 

--- a/gestaltd/internal/server/handlers_identity_tokens.go
+++ b/gestaltd/internal/server/handlers_identity_tokens.go
@@ -37,7 +37,7 @@ func (s *Server) listManagedIdentityTokens(w http.ResponseWriter, r *http.Reques
 	}
 	grantPermissions := principal.CompileManagedIdentityGrants(grants)
 
-	viewer := managedIdentityGrantValidationPrincipal(PrincipalFromContext(r.Context()), actor.UserID)
+	viewer := managedIdentityGrantValidationPrincipal(PrincipalFromContext(r.Context()), actor.SubjectID)
 	out := make([]apiTokenInfo, 0, len(tokens))
 	for _, token := range tokens {
 		info := apiTokenInfoFromCore(token)
@@ -93,7 +93,7 @@ func (s *Server) createManagedIdentityToken(w http.ResponseWriter, r *http.Reque
 		return
 	}
 
-	viewer := managedIdentityGrantValidationPrincipal(PrincipalFromContext(r.Context()), actor.UserID)
+	viewer := managedIdentityGrantValidationPrincipal(PrincipalFromContext(r.Context()), actor.SubjectID)
 	s.managedIdentityMu.Lock()
 	defer s.managedIdentityMu.Unlock()
 


### PR DESCRIPTION
## Summary

This removes the remaining internal `user_id` ballast from the audit path, managed-identity grant/session helpers, and providerhost subject derivation.

This PR is intentionally small and deletive.

- audit entries no longer carry `UserID`
- managed-identity validation helpers now take canonical `subjectId`
- providerhost/request-token subject derivation canonicalizes `principal.SubjectID` instead of rebuilding `user:<id>` from `principal.UserID`

## Old Interfaces

```go
entry.UserID = p.UserID
```

```go
userID, subjectID, user, ok := s.resolveManagedIdentityUser(ctx, pendingToken, identityID)
```

```go
viewer := managedIdentityGrantValidationPrincipal(principalForRequest(r), actor.UserID)
```

```go
subjectID := p.SubjectID
if subjectID == "" && p.UserID != "" {
    subjectID = principal.UserSubjectID(p.UserID)
}
```

## New Interfaces

```go
user, subjectID, ok := s.resolveManagedIdentityUser(ctx, pendingToken, identityID)
```

```go
viewer := managedIdentityGrantValidationPrincipal(principalForRequest(r), actor.SubjectID)
```

```go
subjectID := principal.Canonicalized(p).SubjectID
```

## Examples

New managed-identity flow:

```go
user, subjectID, ok := s.resolveManagedIdentityUser(ctx, pendingToken, identityID)
if !ok {
    return managedIdentityActor{}, false
}
viewer := managedIdentityGrantValidationPrincipal(principalForRequest(r), subjectID)
```

New providerhost subject derivation:

```go
func subjectIDForPrincipal(p *core.Principal) string {
    p = principal.Canonicalized(p)
    return p.SubjectID
}
```

## Why

`subject_id` is already canonical throughout the authz/token model. These remaining helpers were still threading `user_id` through internal boundaries and then reconstructing `subject_id` again. This removes that redundant conversion layer.

## Rollout

No DB migration.
No production data change.

## Verification

```bash
cd gestaltd && go test ./internal/invocation ./internal/providerhost ./internal/server
cd gestaltd && golangci-lint run ./internal/invocation ./internal/providerhost ./internal/server
```
