### PR TITLE
Export source-plugin HTTP metadata from TypeScript providers

### DIFF
--- a/gestaltd/internal/providerpkg/source_manifest_metadata.go
+++ b/gestaltd/internal/providerpkg/source_manifest_metadata.go
@@ -1,0 +1,274 @@
+package providerpkg
+
+import (
+	"fmt"
+	"os"
+	"reflect"
+
+	providermanifestv1 "github.com/valon-technologies/gestalt/server/sdk/providermanifest/v1"
+)
+
+type generatedSourceManifestMetadata struct {
+	SecuritySchemes map[string]*providermanifestv1.HTTPSecurityScheme `json:"securitySchemes,omitempty" yaml:"securitySchemes,omitempty"`
+	HTTP            map[string]*providermanifestv1.HTTPBinding        `json:"http,omitempty" yaml:"http,omitempty"`
+}
+
+func readGeneratedSourceManifestMetadata(path string) (*generatedSourceManifestMetadata, error) {
+	data, err := os.ReadFile(path)
+	if err != nil {
+		return nil, fmt.Errorf("read generated source manifest metadata %q: %w", path, err)
+	}
+	var metadata generatedSourceManifestMetadata
+	if err := decodeStrict(data, ManifestFormatFromPath(path), "generated source manifest metadata", &metadata); err != nil {
+		return nil, err
+	}
+	return &metadata, nil
+}
+
+func mergeGeneratedSourceManifestMetadata(spec *providermanifestv1.Spec, metadata *generatedSourceManifestMetadata) {
+	if spec == nil || metadata == nil {
+		return
+	}
+	if len(metadata.SecuritySchemes) > 0 {
+		merged := cloneGeneratedHTTPSecuritySchemes(metadata.SecuritySchemes)
+		for name, scheme := range spec.SecuritySchemes {
+			merged[name] = mergeGeneratedHTTPSecurityScheme(merged[name], scheme)
+		}
+		spec.SecuritySchemes = merged
+	}
+	if len(metadata.HTTP) > 0 {
+		merged := cloneGeneratedHTTPBindings(metadata.HTTP)
+		for name, binding := range spec.HTTP {
+			merged[name] = mergeGeneratedHTTPBinding(merged[name], binding)
+		}
+		spec.HTTP = merged
+	}
+}
+
+func cloneGeneratedHTTPSecuritySchemes(src map[string]*providermanifestv1.HTTPSecurityScheme) map[string]*providermanifestv1.HTTPSecurityScheme {
+	if src == nil {
+		return nil
+	}
+	cloned := make(map[string]*providermanifestv1.HTTPSecurityScheme, len(src))
+	for name, scheme := range src {
+		cloned[name] = cloneGeneratedHTTPSecurityScheme(scheme)
+	}
+	return cloned
+}
+
+func cloneGeneratedHTTPSecurityScheme(src *providermanifestv1.HTTPSecurityScheme) *providermanifestv1.HTTPSecurityScheme {
+	if src == nil {
+		return nil
+	}
+	cloned := *src
+	cloned.Secret = cloneGeneratedHTTPSecretRef(src.Secret)
+	return &cloned
+}
+
+func cloneGeneratedHTTPSecretRef(src *providermanifestv1.HTTPSecretRef) *providermanifestv1.HTTPSecretRef {
+	if src == nil {
+		return nil
+	}
+	cloned := *src
+	return &cloned
+}
+
+func cloneGeneratedHTTPBindings(src map[string]*providermanifestv1.HTTPBinding) map[string]*providermanifestv1.HTTPBinding {
+	if src == nil {
+		return nil
+	}
+	cloned := make(map[string]*providermanifestv1.HTTPBinding, len(src))
+	for name, binding := range src {
+		cloned[name] = cloneGeneratedHTTPBinding(binding)
+	}
+	return cloned
+}
+
+func cloneGeneratedHTTPBinding(src *providermanifestv1.HTTPBinding) *providermanifestv1.HTTPBinding {
+	if src == nil {
+		return nil
+	}
+	cloned := *src
+	cloned.RequestBody = cloneGeneratedHTTPRequestBody(src.RequestBody)
+	cloned.Ack = cloneGeneratedHTTPAck(src.Ack)
+	return &cloned
+}
+
+func cloneGeneratedHTTPRequestBody(src *providermanifestv1.HTTPRequestBody) *providermanifestv1.HTTPRequestBody {
+	if src == nil {
+		return nil
+	}
+	cloned := *src
+	if src.Content != nil {
+		cloned.Content = make(map[string]*providermanifestv1.HTTPMediaType, len(src.Content))
+		for name, mediaType := range src.Content {
+			cloned.Content[name] = cloneGeneratedHTTPMediaType(mediaType)
+		}
+	}
+	return &cloned
+}
+
+func cloneGeneratedHTTPMediaType(src *providermanifestv1.HTTPMediaType) *providermanifestv1.HTTPMediaType {
+	if src == nil {
+		return nil
+	}
+	cloned := *src
+	return &cloned
+}
+
+func cloneGeneratedHTTPAck(src *providermanifestv1.HTTPAck) *providermanifestv1.HTTPAck {
+	if src == nil {
+		return nil
+	}
+	cloned := *src
+	if src.Headers != nil {
+		cloned.Headers = make(map[string]string, len(src.Headers))
+		for name, value := range src.Headers {
+			cloned.Headers[name] = value
+		}
+	}
+	cloned.Body = cloneGeneratedHTTPBodyValue(src.Body)
+	return &cloned
+}
+
+func cloneGeneratedHTTPBodyValue(src any) any {
+	if src == nil {
+		return nil
+	}
+	return cloneGeneratedHTTPBodyReflectValue(reflect.ValueOf(src)).Interface()
+}
+
+func cloneGeneratedHTTPBodyReflectValue(value reflect.Value) reflect.Value {
+	if !value.IsValid() {
+		return reflect.Value{}
+	}
+	switch value.Kind() {
+	case reflect.Interface:
+		if value.IsNil() {
+			return reflect.Zero(value.Type())
+		}
+		return cloneGeneratedHTTPBodyReflectValue(value.Elem())
+	case reflect.Pointer:
+		if value.IsNil() {
+			return reflect.Zero(value.Type())
+		}
+		cloned := reflect.New(value.Type().Elem())
+		cloned.Elem().Set(cloneGeneratedHTTPBodyReflectValue(value.Elem()))
+		return cloned
+	case reflect.Map:
+		if value.IsNil() {
+			return reflect.Zero(value.Type())
+		}
+		cloned := reflect.MakeMapWithSize(value.Type(), value.Len())
+		iter := value.MapRange()
+		for iter.Next() {
+			cloned.SetMapIndex(cloneGeneratedHTTPBodyReflectValue(iter.Key()), cloneGeneratedHTTPBodyReflectValue(iter.Value()))
+		}
+		return cloned
+	case reflect.Slice:
+		if value.IsNil() {
+			return reflect.Zero(value.Type())
+		}
+		cloned := reflect.MakeSlice(value.Type(), value.Len(), value.Len())
+		for i := 0; i < value.Len(); i++ {
+			cloned.Index(i).Set(cloneGeneratedHTTPBodyReflectValue(value.Index(i)))
+		}
+		return cloned
+	case reflect.Array:
+		cloned := reflect.New(value.Type()).Elem()
+		for i := 0; i < value.Len(); i++ {
+			cloned.Index(i).Set(cloneGeneratedHTTPBodyReflectValue(value.Index(i)))
+		}
+		return cloned
+	default:
+		return value
+	}
+}
+
+func mergeGeneratedHTTPSecurityScheme(base, override *providermanifestv1.HTTPSecurityScheme) *providermanifestv1.HTTPSecurityScheme {
+	if base == nil {
+		return cloneGeneratedHTTPSecurityScheme(override)
+	}
+	if override == nil {
+		return cloneGeneratedHTTPSecurityScheme(base)
+	}
+	merged := *base
+	if override.Type != "" {
+		merged.Type = override.Type
+	}
+	if override.Description != "" {
+		merged.Description = override.Description
+	}
+	if override.Name != "" {
+		merged.Name = override.Name
+	}
+	if override.In != "" {
+		merged.In = override.In
+	}
+	if override.Scheme != "" {
+		merged.Scheme = override.Scheme
+	}
+	if override.Secret != nil {
+		merged.Secret = cloneGeneratedHTTPSecretRef(override.Secret)
+	}
+	return &merged
+}
+
+func mergeGeneratedHTTPBinding(base, override *providermanifestv1.HTTPBinding) *providermanifestv1.HTTPBinding {
+	if base == nil {
+		return cloneGeneratedHTTPBinding(override)
+	}
+	if override == nil {
+		return cloneGeneratedHTTPBinding(base)
+	}
+	merged := *base
+	if override.Path != "" {
+		merged.Path = override.Path
+	}
+	if override.Method != "" {
+		merged.Method = override.Method
+	}
+	if override.Security != "" {
+		merged.Security = override.Security
+	}
+	if override.Target != "" {
+		merged.Target = override.Target
+	}
+	if override.RequestBody != nil {
+		if merged.RequestBody == nil {
+			merged.RequestBody = cloneGeneratedHTTPRequestBody(override.RequestBody)
+		} else {
+			requestBody := *merged.RequestBody
+			if override.RequestBody.Required {
+				requestBody.Required = true
+			}
+			if override.RequestBody.Content != nil {
+				requestBody.Content = cloneGeneratedHTTPRequestBody(override.RequestBody).Content
+			}
+			merged.RequestBody = &requestBody
+		}
+	}
+	if override.Ack != nil {
+		if merged.Ack == nil {
+			merged.Ack = cloneGeneratedHTTPAck(override.Ack)
+		} else {
+			ack := cloneGeneratedHTTPAck(merged.Ack)
+			if override.Ack.Status != 0 {
+				ack.Status = override.Ack.Status
+			}
+			if override.Ack.Headers != nil {
+				if ack.Headers == nil {
+					ack.Headers = map[string]string{}
+				}
+				for key, value := range override.Ack.Headers {
+					ack.Headers[key] = value
+				}
+			}
+			if override.Ack.Body != nil {
+				ack.Body = cloneGeneratedHTTPBodyValue(override.Ack.Body)
+			}
+			merged.Ack = ack
+		}
+	}
+	return &merged
+}

--- a/gestaltd/internal/providerpkg/source_prepare.go
+++ b/gestaltd/internal/providerpkg/source_prepare.go
@@ -13,14 +13,31 @@ import (
 )
 
 const envWriteCatalog = "GESTALT_PLUGIN_WRITE_CATALOG"
+const envWriteManifestMetadata = "GESTALT_PLUGIN_WRITE_MANIFEST_METADATA"
 
 func PrepareSourceManifest(manifestPath string) ([]byte, *providermanifestv1.Manifest, error) {
 	data, manifest, err := ReadSourceManifestFile(manifestPath)
 	if err != nil {
 		return nil, nil, err
 	}
+	format := ManifestFormatFromPath(manifestPath)
+	originalManifest, err := DecodeSourceManifestFormat(data, format)
+	if err != nil {
+		return nil, nil, err
+	}
+	originalEncoded, err := EncodeSourceManifestFormat(originalManifest, format)
+	if err != nil {
+		return nil, nil, err
+	}
 	if err := EnsureSourceStaticCatalog(manifestPath, manifest); err != nil {
 		return nil, nil, err
+	}
+	updatedEncoded, err := EncodeSourceManifestFormat(manifest, format)
+	if err != nil {
+		return nil, nil, err
+	}
+	if !bytes.Equal(originalEncoded, updatedEncoded) {
+		data = updatedEncoded
 	}
 	return data, manifest, nil
 }
@@ -35,8 +52,31 @@ func EnsureSourceStaticCatalog(manifestPath string, manifest *providermanifestv1
 	if err != nil {
 		return fmt.Errorf("resolve static catalog path %q: %w", catalogPath, err)
 	}
-	if err := generateSourceStaticCatalog(rootDir, absoluteCatalogPath); err != nil {
+	metadataDir, err := os.MkdirTemp("", "gestalt-source-manifest-metadata-")
+	if err != nil {
+		return fmt.Errorf("create generated source manifest metadata dir: %w", err)
+	}
+	defer func() {
+		_ = os.RemoveAll(metadataDir)
+	}()
+	metadataPath := filepath.Join(metadataDir, "manifest-metadata.yaml")
+	if err := generateSourceStaticCatalog(rootDir, absoluteCatalogPath, metadataPath); err != nil {
 		return err
+	}
+	if _, err := os.Stat(metadataPath); err == nil {
+		metadata, readErr := readGeneratedSourceManifestMetadata(metadataPath)
+		if readErr != nil {
+			return readErr
+		}
+		if manifest.Spec == nil {
+			manifest.Spec = &providermanifestv1.Spec{}
+		}
+		mergeGeneratedSourceManifestMetadata(manifest.Spec, metadata)
+		if err := validateExecutableProviderMetadata(manifest.Spec); err != nil {
+			return fmt.Errorf("generated source manifest metadata: %w", err)
+		}
+	} else if !os.IsNotExist(err) {
+		return fmt.Errorf("stat generated source manifest metadata %q: %w", metadataPath, err)
 	}
 	if _, err := os.Stat(absoluteCatalogPath); err != nil {
 		if os.IsNotExist(err) && !StaticCatalogRequired(manifest) {
@@ -47,7 +87,7 @@ func EnsureSourceStaticCatalog(manifestPath string, manifest *providermanifestv1
 	return nil
 }
 
-func generateSourceStaticCatalog(rootDir, catalogPath string) error {
+func generateSourceStaticCatalog(rootDir, catalogPath, manifestMetadataPath string) error {
 	command, args, cleanup, err := SourceProviderExecutionCommand(rootDir, runtime.GOOS, runtime.GOARCH)
 	if err != nil {
 		if errors.Is(err, ErrNoSourceProviderPackage) {
@@ -60,7 +100,11 @@ func generateSourceStaticCatalog(rootDir, catalogPath string) error {
 	}
 
 	cmd := exec.Command(command, args...)
-	cmd.Env = append(os.Environ(), envWriteCatalog+"="+catalogPath)
+	cmd.Env = append(
+		os.Environ(),
+		envWriteCatalog+"="+catalogPath,
+		envWriteManifestMetadata+"="+manifestMetadataPath,
+	)
 	execEnv, err := SourceProviderExecutionEnv(rootDir, runtime.GOOS, runtime.GOARCH)
 	if err != nil {
 		return fmt.Errorf("prepare synthesized source provider environment for static catalog: %w", err)

--- a/gestaltd/internal/providerpkg/typescript_provider_test.go
+++ b/gestaltd/internal/providerpkg/typescript_provider_test.go
@@ -435,6 +435,87 @@ func TestPrepareSourceManifest_GeneratesTypeScriptStaticCatalog(t *testing.T) {
 	}
 }
 
+func TestPrepareSourceManifest_MergesGeneratedTypeScriptManifestMetadata(t *testing.T) {
+	root := t.TempDir()
+	manifest := &providermanifestv1.Manifest{
+		Kind:    providermanifestv1.KindPlugin,
+		Source:  "github.com/testowner/plugins/ts-release",
+		Version: "0.0.1",
+		Spec: &providermanifestv1.Spec{
+			Connections: map[string]*providermanifestv1.ManifestConnectionDef{
+				"default": {
+					Auth: &providermanifestv1.ProviderAuth{Type: providermanifestv1.AuthTypeNone},
+				},
+			},
+			SecuritySchemes: map[string]*providermanifestv1.HTTPSecurityScheme{
+				"slack": {
+					Type: providermanifestv1.HTTPSecuritySchemeTypeSlackSignature,
+					Secret: &providermanifestv1.HTTPSecretRef{
+						Env: "SLACK_SIGNING_SECRET",
+					},
+				},
+			},
+		},
+	}
+	data, err := EncodeSourceManifestFormat(manifest, ManifestFormatYAML)
+	if err != nil {
+		t.Fatalf("EncodeSourceManifestFormat: %v", err)
+	}
+	manifestPath := filepath.Join(root, "manifest.yaml")
+	mustWriteFile(t, manifestPath, data, 0o644)
+	mustWriteTypeScriptProviderPackage(t, root, typeScriptTestPluginTarget)
+	bunPath := writeFakeTypeScriptBun(t, root, "ts-release", typeScriptTestPluginTarget, runtime.GOOS, runtime.GOARCH)
+	t.Setenv(typeScriptBunEnvVar, bunPath)
+
+	preparedData, preparedManifest, err := PrepareSourceManifest(manifestPath)
+	if err != nil {
+		t.Fatalf("PrepareSourceManifest: %v", err)
+	}
+	if preparedManifest == nil || preparedManifest.Spec == nil {
+		t.Fatalf("prepared manifest = %+v, want provider metadata", preparedManifest)
+	}
+	if !containsString(string(preparedData), "securitySchemes:") {
+		t.Fatalf("prepared manifest data = %q, want merged security scheme metadata", string(preparedData))
+	}
+	if !containsString(string(preparedData), "path: /command") {
+		t.Fatalf("prepared manifest data = %q, want merged HTTP binding metadata", string(preparedData))
+	}
+
+	scheme := preparedManifest.Spec.SecuritySchemes["slack"]
+	if scheme == nil {
+		t.Fatal(`manifest.Spec.SecuritySchemes["slack"] = nil, want generated scheme`)
+	}
+	if scheme.Type != providermanifestv1.HTTPSecuritySchemeTypeSlackSignature {
+		t.Fatalf("scheme.Type = %q, want %q", scheme.Type, providermanifestv1.HTTPSecuritySchemeTypeSlackSignature)
+	}
+	if scheme.Secret == nil || scheme.Secret.Env != "SLACK_SIGNING_SECRET" {
+		t.Fatalf("scheme.Secret = %+v, want env-backed secret", scheme.Secret)
+	}
+
+	binding := preparedManifest.Spec.HTTP["command"]
+	if binding == nil {
+		t.Fatal(`manifest.Spec.HTTP["command"] = nil, want generated binding`)
+	}
+	if binding.Path != "/command" {
+		t.Fatalf("binding.Path = %q, want %q", binding.Path, "/command")
+	}
+	if binding.Method != "POST" {
+		t.Fatalf("binding.Method = %q, want %q", binding.Method, "POST")
+	}
+	if binding.Security != "slack" {
+		t.Fatalf("binding.Security = %q, want %q", binding.Security, "slack")
+	}
+	if binding.Target != "handle_command" {
+		t.Fatalf("binding.Target = %q, want %q", binding.Target, "handle_command")
+	}
+	if binding.RequestBody == nil {
+		t.Fatal("binding.RequestBody = nil, want request body metadata")
+	}
+	if _, ok := binding.RequestBody.Content["application/x-www-form-urlencoded"]; !ok {
+		t.Fatalf("binding.RequestBody.Content = %#v, want form content type", binding.RequestBody.Content)
+	}
+}
+
 func TestValidateSourceProviderRelease_TypeScript(t *testing.T) {
 	root := t.TempDir()
 	mustWriteTypeScriptProviderPackage(t, root, typeScriptTestPluginTarget)
@@ -733,6 +814,25 @@ operations:
   - id: greet
     method: GET
 EOF
+    if [ -n "${GESTALT_PLUGIN_WRITE_MANIFEST_METADATA:-}" ]; then
+      cat > "$GESTALT_PLUGIN_WRITE_MANIFEST_METADATA" <<'EOF'
+securitySchemes:
+  slack:
+    type: slack_signature
+    secret:
+      env: SLACK_SIGNING_SECRET
+http:
+  command:
+    path: /command
+    method: POST
+    security: slack
+    target: handle_command
+    requestBody:
+      required: true
+      content:
+        application/x-www-form-urlencoded: {}
+EOF
+    fi
     exit 0
     ;;
   gestalt-ts-build|build.ts)

--- a/sdk/typescript/src/index.ts
+++ b/sdk/typescript/src/index.ts
@@ -54,6 +54,21 @@ export {
   type CatalogSchema,
 } from "./catalog.ts";
 export {
+  hasPluginManifestMetadata,
+  manifestMetadataToYaml,
+  writeManifestMetadataYaml,
+  type HTTPAck,
+  type HTTPAuthScheme,
+  type HTTPBinding,
+  type HTTPIn,
+  type HTTPMediaType,
+  type HTTPRequestBody,
+  type HTTPSecretRef,
+  type HTTPSecurityScheme,
+  type HTTPSecuritySchemeType,
+  type PluginManifestMetadata,
+} from "./manifest-metadata.ts";
+export {
   buildProviderBinary,
   bunBuildCommand,
   bunTarget,
@@ -146,6 +161,7 @@ export {
   ENV_PROVIDER_PARENT_PID,
   ENV_PROVIDER_SOCKET,
   ENV_WRITE_CATALOG,
+  ENV_WRITE_MANIFEST_METADATA,
   createAuthenticationService,
   createCacheService,
   createSecretsService,

--- a/sdk/typescript/src/manifest-metadata.ts
+++ b/sdk/typescript/src/manifest-metadata.ts
@@ -1,0 +1,101 @@
+import { writeFileSync } from "node:fs";
+
+import YAML from "yaml";
+
+export type HTTPSecuritySchemeType =
+  | "slack_signature"
+  | "apiKey"
+  | "http"
+  | "none";
+
+export type HTTPIn = "header" | "query";
+
+export type HTTPAuthScheme = "basic" | "bearer";
+
+export interface HTTPSecretRef {
+  env?: string;
+  secret?: string;
+}
+
+export interface HTTPSecurityScheme {
+  type?: HTTPSecuritySchemeType;
+  description?: string;
+  name?: string;
+  in?: HTTPIn;
+  scheme?: HTTPAuthScheme;
+  secret?: HTTPSecretRef;
+}
+
+export interface HTTPMediaType {}
+
+export interface HTTPRequestBody {
+  required?: boolean;
+  content?: Record<string, HTTPMediaType>;
+}
+
+export interface HTTPAck {
+  status?: number;
+  headers?: Record<string, string>;
+  body?: any;
+}
+
+export interface HTTPBinding {
+  path: string;
+  method: string;
+  requestBody?: HTTPRequestBody;
+  security: string;
+  target: string;
+  ack?: HTTPAck;
+}
+
+export interface PluginManifestMetadata {
+  securitySchemes?: Record<string, HTTPSecurityScheme>;
+  http?: Record<string, HTTPBinding>;
+}
+
+export function hasPluginManifestMetadata(
+  metadata: PluginManifestMetadata | null | undefined,
+): boolean {
+  return !!(
+    metadata &&
+    ((metadata.securitySchemes &&
+      Object.keys(metadata.securitySchemes).length > 0) ||
+      (metadata.http && Object.keys(metadata.http).length > 0))
+  );
+}
+
+export function manifestMetadataToYaml(
+  metadata: PluginManifestMetadata | Record<string, unknown>,
+): string {
+  return YAML.stringify(toManifestMetadataJsonObject(metadata));
+}
+
+export function writeManifestMetadataYaml(
+  path: string,
+  metadata: PluginManifestMetadata | Record<string, unknown>,
+): void {
+  writeFileSync(path, manifestMetadataToYaml(metadata), "utf8");
+}
+
+function toManifestMetadataJsonObject(
+  metadata: PluginManifestMetadata | Record<string, unknown>,
+): Record<string, unknown> {
+  if (!("securitySchemes" in metadata) && !("http" in metadata)) {
+    return {
+      ...metadata,
+    };
+  }
+
+  const typedMetadata = metadata as PluginManifestMetadata;
+  const output: Record<string, unknown> = {};
+  if (
+    typedMetadata.securitySchemes &&
+    Object.keys(typedMetadata.securitySchemes).length > 0
+  ) {
+    output.securitySchemes = typedMetadata.securitySchemes;
+  }
+  if (typedMetadata.http && Object.keys(typedMetadata.http).length > 0) {
+    output.http = typedMetadata.http;
+  }
+  return output;
+}

--- a/sdk/typescript/src/plugin.ts
+++ b/sdk/typescript/src/plugin.ts
@@ -8,6 +8,15 @@ import {
   writeCatalogYaml,
 } from "./catalog.ts";
 import {
+  type HTTPAck,
+  type HTTPBinding,
+  type HTTPRequestBody,
+  type HTTPSecurityScheme,
+  type PluginManifestMetadata,
+  hasPluginManifestMetadata,
+  writeManifestMetadataYaml,
+} from "./manifest-metadata.ts";
+import {
   errorMessage,
   type MaybePromise,
   type OperationResult,
@@ -82,6 +91,8 @@ export interface PluginDefinitionOptions extends RuntimeProviderOptions {
   connectionMode?: ConnectionMode;
   authTypes?: string[];
   connectionParams?: Record<string, ConnectionParamDefinition>;
+  securitySchemes?: Record<string, HTTPSecurityScheme>;
+  http?: Record<string, HTTPBinding>;
   iconSvg?: string;
   operations: Array<OperationDefinition<any, any>>;
   sessionCatalog?: SessionCatalogHandler;
@@ -134,6 +145,8 @@ export class PluginProvider extends RuntimeProvider {
   readonly connectionMode: ConnectionMode;
   readonly authTypes: string[];
   readonly connectionParams: Record<string, ConnectionParamDefinition>;
+  readonly securitySchemes: Record<string, HTTPSecurityScheme>;
+  readonly http: Record<string, HTTPBinding>;
 
   private readonly sessionCatalogHandler: SessionCatalogHandler | undefined;
   private readonly operations = new Map<string, OperationDefinition<any, any>>();
@@ -144,6 +157,8 @@ export class PluginProvider extends RuntimeProvider {
     this.connectionMode = options.connectionMode ?? "unspecified";
     this.authTypes = [...(options.authTypes ?? [])];
     this.connectionParams = normalizeConnectionParams(options.connectionParams);
+    this.securitySchemes = normalizeHTTPSecuritySchemes(options.securitySchemes);
+    this.http = normalizeHTTPBindings(options.http);
     this.sessionCatalogHandler = options.sessionCatalog;
 
     for (const rawEntry of options.operations) {
@@ -256,6 +271,38 @@ export class PluginProvider extends RuntimeProvider {
   }
 
   /**
+   * Returns generated manifest-backed HTTP/security metadata for the provider.
+   */
+  staticManifestMetadata(): PluginManifestMetadata {
+    const metadata: PluginManifestMetadata = {};
+    if (Object.keys(this.securitySchemes).length > 0) {
+      metadata.securitySchemes = cloneHTTPSecuritySchemes(this.securitySchemes);
+    }
+    if (Object.keys(this.http).length > 0) {
+      metadata.http = cloneHTTPBindings(this.http);
+    }
+    return metadata;
+  }
+
+  /**
+   * Reports whether the provider emits manifest metadata in addition to catalog metadata.
+   */
+  supportsManifestMetadata(): boolean {
+    return hasPluginManifestMetadata(this.staticManifestMetadata());
+  }
+
+  /**
+   * Writes generated manifest metadata to disk as YAML.
+   */
+  writeManifestMetadata(path: string): void {
+    const metadata = this.staticManifestMetadata();
+    if (!hasPluginManifestMetadata(metadata)) {
+      return;
+    }
+    writeManifestMetadataYaml(path, metadata);
+  }
+
+  /**
    * Executes an operation against validated input and request metadata.
    */
   async execute(
@@ -347,6 +394,121 @@ function normalizeConnectionParams(
     output[key] = entry;
   }
   return output;
+}
+
+function normalizeHTTPSecuritySchemes(
+  input: Record<string, HTTPSecurityScheme> | undefined,
+): Record<string, HTTPSecurityScheme> {
+  const output: Record<string, HTTPSecurityScheme> = {};
+  for (const [key, value] of Object.entries(input ?? {})) {
+    output[key] = cloneHTTPSecurityScheme(value);
+  }
+  return output;
+}
+
+function cloneHTTPSecuritySchemes(
+  input: Record<string, HTTPSecurityScheme>,
+): Record<string, HTTPSecurityScheme> {
+  const output: Record<string, HTTPSecurityScheme> = {};
+  for (const [key, value] of Object.entries(input)) {
+    output[key] = cloneHTTPSecurityScheme(value);
+  }
+  return output;
+}
+
+function cloneHTTPSecurityScheme(value: HTTPSecurityScheme): HTTPSecurityScheme {
+  const output: HTTPSecurityScheme = {};
+  if (value.type !== undefined) {
+    output.type = value.type;
+  }
+  if (value.description !== undefined) {
+    output.description = value.description;
+  }
+  if (value.name !== undefined) {
+    output.name = value.name;
+  }
+  if (value.in !== undefined) {
+    output.in = value.in;
+  }
+  if (value.scheme !== undefined) {
+    output.scheme = value.scheme;
+  }
+  if (value.secret) {
+    output.secret = {
+      ...value.secret,
+    };
+  }
+  return output;
+}
+
+function normalizeHTTPBindings(
+  input: Record<string, HTTPBinding> | undefined,
+): Record<string, HTTPBinding> {
+  const output: Record<string, HTTPBinding> = {};
+  for (const [key, value] of Object.entries(input ?? {})) {
+    output[key] = cloneHTTPBinding(value);
+  }
+  return output;
+}
+
+function cloneHTTPBindings(
+  input: Record<string, HTTPBinding>,
+): Record<string, HTTPBinding> {
+  const output: Record<string, HTTPBinding> = {};
+  for (const [key, value] of Object.entries(input)) {
+    output[key] = cloneHTTPBinding(value);
+  }
+  return output;
+}
+
+function cloneHTTPBinding(value: HTTPBinding): HTTPBinding {
+  const output: HTTPBinding = {
+    path: value.path,
+    method: value.method,
+    security: value.security,
+    target: value.target,
+  };
+  if (value.requestBody) {
+    output.requestBody = cloneHTTPRequestBody(value.requestBody);
+  }
+  if (value.ack) {
+    output.ack = cloneHTTPAck(value.ack);
+  }
+  return output;
+}
+
+function cloneHTTPRequestBody(value: HTTPRequestBody): HTTPRequestBody {
+  const output: HTTPRequestBody = {};
+  if (value.required !== undefined) {
+    output.required = value.required;
+  }
+  if (value.content) {
+    output.content = {};
+    for (const key of Object.keys(value.content)) {
+      output.content[key] = {};
+    }
+  }
+  return output;
+}
+
+function cloneHTTPAck(value: HTTPAck): HTTPAck {
+  const output: HTTPAck = {};
+  if (value.status !== undefined) {
+    output.status = value.status;
+  }
+  if (value.headers) {
+    output.headers = {
+      ...value.headers,
+    };
+  }
+  if (value.body !== undefined) {
+    output.body = cloneHTTPBodyValue(value.body);
+  }
+  return output;
+}
+
+function cloneHTTPBodyValue<T>(value: T): T {
+  return structuredClone(value);
 }
 
 function isResponse(value: unknown): value is Response<unknown> {

--- a/sdk/typescript/src/runtime.ts
+++ b/sdk/typescript/src/runtime.ts
@@ -107,6 +107,11 @@ export const ENV_PROVIDER_PARENT_PID = "GESTALT_PLUGIN_PARENT_PID";
  */
 export const ENV_WRITE_CATALOG = "GESTALT_PLUGIN_WRITE_CATALOG";
 /**
+ * Environment variable used to request generated manifest metadata export.
+ */
+export const ENV_WRITE_MANIFEST_METADATA =
+  "GESTALT_PLUGIN_WRITE_MANIFEST_METADATA";
+/**
  * Protocol version currently implemented by the TypeScript runtime.
  */
 export const CURRENT_PROTOCOL_VERSION = 3;
@@ -288,13 +293,19 @@ export async function runLoadedProvider(
   }
 
   const catalogPath = process.env[ENV_WRITE_CATALOG];
-  if (catalogPath) {
+  const manifestMetadataPath = process.env[ENV_WRITE_MANIFEST_METADATA];
+  if (catalogPath || manifestMetadataPath) {
     if (!isPluginProvider(provider)) {
       throw new Error(
-        "static catalog generation is only supported for plugin providers",
+        "static catalog and manifest metadata generation are only supported for plugin providers",
       );
     }
-    writeFileSync(catalogPath, catalogToYaml(provider.staticCatalog()), "utf8");
+    if (catalogPath) {
+      writeFileSync(catalogPath, catalogToYaml(provider.staticCatalog()), "utf8");
+    }
+    if (manifestMetadataPath && provider.supportsManifestMetadata()) {
+      provider.writeManifestMetadata(manifestMetadataPath);
+    }
     return;
   }
 

--- a/sdk/typescript/tests/runtime.test.ts
+++ b/sdk/typescript/tests/runtime.test.ts
@@ -49,6 +49,7 @@ import {
   CURRENT_PROTOCOL_VERSION,
   createCacheService,
   ENV_WRITE_CATALOG,
+  ENV_WRITE_MANIFEST_METADATA,
   ENV_PROVIDER_SOCKET,
   createAuthenticationService,
   createProviderService,
@@ -165,6 +166,95 @@ export const plugin = definePlugin({
       delete process.env[ENV_WRITE_CATALOG];
     } else {
       process.env[ENV_WRITE_CATALOG] = previousCatalog;
+    }
+    removeTempDir(root);
+  }
+});
+
+test("runtime main writes generated manifest metadata when requested", async () => {
+  const root = makeTempDir("gestalt-typescript-runtime-manifest-metadata-");
+  const metadataPath = join(root, "manifest-metadata.yaml");
+  const previousManifestMetadata = process.env[ENV_WRITE_MANIFEST_METADATA];
+
+  try {
+    const indexPath = join(import.meta.dir, "..", "src", "index.ts");
+    writeFileSync(
+      join(root, "package.json"),
+      JSON.stringify({
+        name: "@scope/http provider",
+        gestalt: {
+          provider: {
+            kind: "plugin",
+            target: "./provider.ts#plugin",
+          },
+        },
+      }),
+      "utf8",
+    );
+    writeFileSync(
+      join(root, "provider.ts"),
+      `import { definePlugin } from ${JSON.stringify(indexPath)};
+
+export const plugin = definePlugin({
+  securitySchemes: {
+    slack: {
+      type: "slack_signature",
+      secret: {
+        env: "SLACK_SIGNING_SECRET",
+      },
+    },
+  },
+  http: {
+    command: {
+      path: "/command",
+      method: "POST",
+      security: "slack",
+      target: "handle_command",
+      requestBody: {
+        required: true,
+        content: {
+          "application/x-www-form-urlencoded": {},
+        },
+      },
+      ack: {
+        status: 200,
+        body: {
+          response_type: "ephemeral",
+          text: "Working on it...",
+        },
+      },
+    },
+  },
+  operations: [
+    {
+      id: "handle_command",
+      handler() {
+        return { ok: true };
+      },
+    },
+  ],
+});
+`,
+      "utf8",
+    );
+
+    process.env[ENV_WRITE_MANIFEST_METADATA] = metadataPath;
+    const code = await main([root, "plugin:./provider.ts#plugin"]);
+    expect(code).toBe(0);
+    const metadata = readFileSync(metadataPath, "utf8");
+    expect(metadata).toContain("securitySchemes:");
+    expect(metadata).toContain("type: slack_signature");
+    expect(metadata).toContain("env: SLACK_SIGNING_SECRET");
+    expect(metadata).toContain("http:");
+    expect(metadata).toContain("path: /command");
+    expect(metadata).toContain("target: handle_command");
+    expect(metadata).toContain("application/x-www-form-urlencoded");
+    expect(metadata).toContain("response_type: ephemeral");
+  } finally {
+    if (previousManifestMetadata === undefined) {
+      delete process.env[ENV_WRITE_MANIFEST_METADATA];
+    } else {
+      process.env[ENV_WRITE_MANIFEST_METADATA] = previousManifestMetadata;
     }
     removeTempDir(root);
   }


### PR DESCRIPTION
This adds a source-plugin manifest-metadata export contract on top of the existing static catalog generation path.

New host contract:
- Source provider runtimes can now write generated manifest-backed metadata to the path in `GESTALT_PLUGIN_WRITE_MANIFEST_METADATA`.
- `providerpkg.EnsureSourceStaticCatalog(...)` requests both `GESTALT_PLUGIN_WRITE_CATALOG` and `GESTALT_PLUGIN_WRITE_MANIFEST_METADATA` in the same runtime invocation.
- Generated metadata is merged into `manifest.Spec` for `securitySchemes` and `http`, then validated as normal plugin metadata.

New TypeScript authoring surface:
```ts
export const plugin = definePlugin({
  securitySchemes: {
    slack: {
      type: "slack_signature",
      secret: { env: "SLACK_SIGNING_SECRET" },
    },
  },
  http: {
    command: {
      path: "/command",
      method: "POST",
      security: "slack",
      target: "handle_command",
      requestBody: {
        required: true,
        content: {
          "application/x-www-form-urlencoded": {},
        },
      },
      ack: {
        status: 200,
        body: {
          response_type: "ephemeral",
          text: "Working on it...",
        },
      },
    },
  },
  operations: [
    {
      id: "handle_command",
      handler() {
        return { ok: true };
      },
    },
  ],
});
```

Runtime export behavior:
```ts
export const ENV_WRITE_MANIFEST_METADATA =
  "GESTALT_PLUGIN_WRITE_MANIFEST_METADATA";
```
If that env var is set for a plugin provider, the TypeScript runtime now writes generated YAML like:
```yaml
securitySchemes:
  slack:
    type: slack_signature
    secret:
      env: SLACK_SIGNING_SECRET
http:
  command:
    path: /command
    method: POST
    security: slack
    target: handle_command
    requestBody:
      required: true
      content:
        application/x-www-form-urlencoded: {}
    ack:
      status: 200
      body:
        response_type: ephemeral
        text: Working on it...
```

Validation:
- `go test ./internal/providerpkg -run 'TestPrepareSourceManifest_(GeneratesTypeScriptStaticCatalog|MergesGeneratedTypeScriptManifestMetadata)|TestDetectTypeScriptProviderTarget|TestSourceProviderExecutionCommand_TypeScript|TestValidateSourceProviderRelease_TypeScript' -count=1`
- `go test ./internal/providerpkg -run 'TestManifestWorkflow_(AcceptsHostedHTTPBindingsAndSecuritySchemes|RejectsNon2xxHTTPAckStatus|RejectsDuplicateNormalizedHTTPContentTypes|AcceptsPluginRouteAuthReference|AcceptsProviderWireSurfaceManifest)' -count=1`
- `go test ./... -run TestDoesNotExist -count=1`
- `bun test tests/runtime.test.ts`
- `bunx tsc --noEmit`
- `bunx eslint --max-warnings=0 src/index.ts src/plugin.ts src/runtime.ts src/manifest-metadata.ts`
- `golangci-lint run ./internal/providerpkg/...`
