### PR TITLE
remove legacy webui compatibility

### DIFF
--- a/docs/content/custom-providers/releasing.mdx
+++ b/docs/content/custom-providers/releasing.mdx
@@ -173,7 +173,7 @@ UI packages use the same manifest system:
 
 ```yaml
 kind: ui
-source: github.com/acme/plugins/web/default
+source: github.com/acme/plugins/ui/default
 version: 1.2.0
 spec:
   assetRoot: ui/out

--- a/docs/content/custom-providers/ui.mdx
+++ b/docs/content/custom-providers/ui.mdx
@@ -21,7 +21,7 @@ The Default UI manifest declares `spec.assetRoot`, which points to the directory
 
 ```yaml
 kind: ui
-source: github.com/valon-technologies/gestalt-providers/web/default
+source: github.com/valon-technologies/gestalt-providers/ui/default
 version: 0.0.1
 displayName: Default UI
 description: Default Gestalt UI bundle.
@@ -55,7 +55,7 @@ The Default UI uses a shell script that runs `npm ci && npm run build` to produc
 
 ```yaml
 kind: ui
-source: github.com/valon-technologies/gestalt-providers/web/default
+source: github.com/valon-technologies/gestalt-providers/ui/default
 version: 0.0.1
 release:
   build:

--- a/docs/content/getting-started.mdx
+++ b/docs/content/getting-started.mdx
@@ -16,7 +16,7 @@ Run `gestaltd` with no arguments:
 gestaltd
 ```
 
-When no config file exists, `gestaltd` generates one at `~/.gestaltd/config.yaml` and starts immediately with SQLite storage via the [RelationalDB](https://github.com/valon-technologies/gestalt-providers/tree/main/indexeddb/relationaldb) implementation of the [IndexedDB provider](/providers/indexeddb), the [default UI](https://github.com/valon-technologies/gestalt-providers/tree/main/web/default) mounted at `/`, no authentication, and an [HTTPBin](https://github.com/valon-technologies/gestalt-providers/tree/main/plugins/httpbin) implementation of the [plugin provider](/providers/plugins) on port 8080.
+When no config file exists, `gestaltd` generates one at `~/.gestaltd/config.yaml` and starts immediately with SQLite storage via the [RelationalDB](https://github.com/valon-technologies/gestalt-providers/tree/main/indexeddb/relationaldb) implementation of the [IndexedDB provider](/providers/indexeddb), the [default UI](https://github.com/valon-technologies/gestalt-providers/tree/main/ui/default) mounted at `/`, no authentication, and an [HTTPBin](https://github.com/valon-technologies/gestalt-providers/tree/main/plugins/httpbin) implementation of the [plugin provider](/providers/plugins) on port 8080.
 
 ```
 2026/04/10 10:00:00 INFO generated default config path=~/.gestaltd/config.yaml

--- a/docs/content/providers/ui.mdx
+++ b/docs/content/providers/ui.mdx
@@ -32,7 +32,7 @@ First-party UI bundles live under
 
 | Provider |
 | --- |
-| [`github.com/valon-technologies/gestalt-providers/web/default`](https://github.com/valon-technologies/gestalt-providers/tree/main/web/default) |
+| [`github.com/valon-technologies/gestalt-providers/ui/default`](https://github.com/valon-technologies/gestalt-providers/tree/main/ui/default) |
 
 ## Configuring `providers.ui`
 

--- a/docs/internal/managed-agent-identities-implementation-plan.md
+++ b/docs/internal/managed-agent-identities-implementation-plan.md
@@ -10,7 +10,7 @@ Implement runtime-managed non-human identities across:
 
 - `gestaltd` backend + HTTP API
 - CLI
-- default web client in `~/src/gestalt-providers/web/default`
+- default UI client in `~/src/gestalt-providers/ui/default`
 
 The implementation should be additive and preserve existing behavior for:
 

--- a/gestaltd/internal/config/config.go
+++ b/gestaltd/internal/config/config.go
@@ -33,7 +33,7 @@ const (
 
 	DefaultIndexedDBProvider = DefaultProviderRepo + "/indexeddb/relationaldb"
 	DefaultIndexedDBVersion  = "0.0.1-alpha.1"
-	DefaultUIProvider        = DefaultProviderRepo + "/web/default"
+	DefaultUIProvider        = DefaultProviderRepo + "/ui/default"
 	DefaultUIVersion         = "0.0.1-alpha.12"
 	DefaultProviderInstance  = "default"
 )

--- a/gestaltd/internal/config/config_test.go
+++ b/gestaltd/internal/config/config_test.go
@@ -1714,7 +1714,7 @@ providers:
   ui:
     roadmap:
       source:
-        path: ./web/default/provider.yaml
+        path: ./ui/default/provider.yaml
       path: /create-customer-roadmap-review
   indexeddb:
     sqlite:
@@ -1734,7 +1734,7 @@ server:
 		if entry == nil {
 			t.Fatal(`Providers.UI["roadmap"] = nil`)
 		}
-		wantPath := filepath.Join(filepath.Dir(path), "web", "default", "provider.yaml")
+		wantPath := filepath.Join(filepath.Dir(path), "ui", "default", "provider.yaml")
 		if got := entry.Source.Path; got != wantPath {
 			t.Fatalf(`Providers.UI["roadmap"].Source.Path = %q, want %q`, got, wantPath)
 		}

--- a/gestaltd/internal/operator/lifecycle_test.go
+++ b/gestaltd/internal/operator/lifecycle_test.go
@@ -3611,54 +3611,6 @@ func TestReadLockfile_RejectsSchemaV1PortableEntries(t *testing.T) {
 	}
 }
 
-func TestReadLockfile_PreservesLegacyPortableWebUILockEntries(t *testing.T) {
-	t.Parallel()
-
-	dir := t.TempDir()
-	lockPath := filepath.Join(dir, InitLockfileName)
-	legacy := `{
-  "schema": "gestaltd-provider-lock",
-  "schemaVersion": 3,
-  "revision": 0,
-  "providers": {
-    "webui": {
-      "admin": {
-        "inputDigest": "ui-fp",
-        "package": "github.com/test-org/test-repo/test-ui",
-        "kind": "webui",
-        "runtime": "ui",
-        "version": "2.0.0"
-      }
-    }
-  }
-}
-`
-	if err := os.WriteFile(lockPath, []byte(legacy), 0o644); err != nil {
-		t.Fatalf("WriteFile: %v", err)
-	}
-
-	lock, err := ReadLockfile(lockPath)
-	if err != nil {
-		t.Fatalf("ReadLockfile: %v", err)
-	}
-	entry, ok := lock.UIs["admin"]
-	if !ok {
-		t.Fatal("expected legacy webui portable entry to be preserved in ui lock entries")
-	}
-	if got, want := entry.Fingerprint, "ui-fp"; got != want {
-		t.Fatalf("Fingerprint = %q, want %q", got, want)
-	}
-	if got, want := entry.Source, "github.com/test-org/test-repo/test-ui"; got != want {
-		t.Fatalf("Source = %q, want %q", got, want)
-	}
-	if got, want := entry.Runtime, "ui"; got != want {
-		t.Fatalf("Runtime = %q, want %q", got, want)
-	}
-	if got, want := entry.Kind, providermanifestv1.KindUI; got != want {
-		t.Fatalf("Kind = %q, want %q", got, want)
-	}
-}
-
 func mustBuildManagedProviderPackage(t *testing.T, dir string, manifest *providermanifestv1.Manifest, artifacts map[string]string, includeCatalog bool) string {
 	t.Helper()
 

--- a/gestaltd/internal/operator/lockschema.go
+++ b/gestaltd/internal/operator/lockschema.go
@@ -42,7 +42,6 @@ type providerLockBuckets struct {
 	Telemetry      map[string]portableLockEntry `json:"telemetry,omitempty"`
 	Audit          map[string]portableLockEntry `json:"audit,omitempty"`
 	UI             map[string]portableLockEntry `json:"ui,omitempty"`
-	LegacyWebUI    map[string]portableLockEntry `json:"webui,omitempty"`
 }
 
 type portableLockEntry struct {
@@ -240,7 +239,7 @@ func (lock *providerLockfile) toLockfile() *Lockfile {
 	runtimeLock.Secrets = lockEntriesFromPortableEntries(lock.Providers.Secrets)
 	runtimeLock.Telemetry = lockEntriesFromPortableEntries(lock.Providers.Telemetry)
 	runtimeLock.Audit = lockEntriesFromPortableEntries(lock.Providers.Audit)
-	runtimeLock.UIs = lockEntriesFromPortableEntries(mergePortableLockEntries(lock.Providers.UI, lock.Providers.LegacyWebUI))
+	runtimeLock.UIs = lockEntriesFromPortableEntries(lock.Providers.UI)
 	return runtimeLock
 }
 

--- a/gestaltd/sdk/providermanifest/v1/types.go
+++ b/gestaltd/sdk/providermanifest/v1/types.go
@@ -44,8 +44,6 @@ func NormalizeKind(kind string) string {
 		return KindWorkflow
 	case KindSecrets:
 		return KindSecrets
-	case "webui":
-		return KindUI
 	case KindUI:
 		return KindUI
 	default:


### PR DESCRIPTION
## Summary
This removes the temporary `webui` compatibility bridge now that the downstream repos are updated to use the canonical `ui` naming.

## What changed
- remove the `webui` kind alias from `providermanifestv1.NormalizeKind`
- remove the legacy `providers.webui` portable lock bucket from the provider lock schema
- remove the regression test that preserved old `providers.webui` lock entries
- update the built-in default UI provider path from `gestalt-providers/web/default` to `gestalt-providers/ui/default`
- update docs and config test fixtures that still referenced `web/default`

## Dependency
This should merge after:
- `gestalt-providers#159`
- `toolshed#755`

## Breaking change
Yes.

After this branch, `gestalt` no longer accepts legacy `webui` compatibility in the provider manifest kind normalizer or portable provider lock schema. Callers must use `kind: ui` and the `ui/...` package path.

## Validation
- `go test ./internal/operator ./internal/config ./sdk/providermanifest/v1 -count=1`
- `golangci-lint run ./internal/operator ./internal/config ./sdk/providermanifest/v1`
- `npm run typecheck && npm run build`
- `git diff --check`

## Example
```yaml
providers:
  ui:
    default:
      source: github.com/valon-technologies/gestalt-providers/ui/default
      path: /
```

```yaml
kind: ui
```