### PR TITLE
fix stale ui ignore path

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -44,8 +44,8 @@ Thumbs.db
 build/
 dist/
 gestaltd/ui/out/
-gestaltd/internal/webui/out/
-!gestaltd/internal/webui/out/.gitkeep
+gestaltd/internal/ui/out/
+!gestaltd/internal/ui/out/.gitkeep
 
 # Exceptions
 !gestaltd/internal/manifest/


### PR DESCRIPTION
## Summary
This updates the stale `.gitignore` entries that still referenced the old `gestaltd/internal/webui/out` path after the UI package rename.

## What changed
- replace `gestaltd/internal/webui/out/` with `gestaltd/internal/ui/out/`
- replace the matching `.gitkeep` exception path

## Why
The code moved from `internal/webui` to `internal/ui`, but the ignore rules were left behind.

## Validation
- `git diff --check`

## Example
```gitignore
gestaltd/internal/ui/out/
!gestaltd/internal/ui/out/.gitkeep
```