### PR TITLE
Export source-plugin HTTP metadata from Go, Python, and Rust providers

### DIFF
--- a/gestaltd/internal/providerpkg/go_provider_test.go
+++ b/gestaltd/internal/providerpkg/go_provider_test.go
@@ -1,36 +1,89 @@
 package providerpkg
 
 import (
+	"os"
 	"path/filepath"
+	"strings"
 	"testing"
+
+	"github.com/valon-technologies/gestalt/server/internal/testutil"
+	providermanifestv1 "github.com/valon-technologies/gestalt/server/sdk/providermanifest/v1"
 )
 
-func TestGoModulePathFromFile(t *testing.T) {
+func TestPrepareSourceManifest_MergesGeneratedGoManifestMetadata(t *testing.T) {
 	t.Parallel()
 
 	root := t.TempDir()
-	mustWriteFile(t, filepath.Join(root, "go.mod"), []byte("module example.com/provider\n\ngo 1.26\n"), 0o644)
+	testutil.CopyExampleProviderPlugin(t, root)
+	injectGoManifestMetadata(t, filepath.Join(root, "provider.go"))
 
-	got, err := goModulePathFromFile(root)
+	manifestPath := filepath.Join(root, "manifest.yaml")
+	preparedData, preparedManifest, err := PrepareSourceManifest(manifestPath)
 	if err != nil {
-		t.Fatalf("goModulePathFromFile: %v", err)
+		t.Fatalf("PrepareSourceManifest: %v", err)
 	}
-	if got != "example.com/provider" {
-		t.Fatalf("module path = %q, want %q", got, "example.com/provider")
+	if preparedManifest == nil || preparedManifest.Spec == nil {
+		t.Fatalf("prepared manifest = %+v, want provider metadata", preparedManifest)
+	}
+	if !containsString(string(preparedData), "securitySchemes:") {
+		t.Fatalf("prepared manifest data = %q, want merged security scheme metadata", string(preparedData))
+	}
+	if !containsString(string(preparedData), "path: /command") {
+		t.Fatalf("prepared manifest data = %q, want merged HTTP binding metadata", string(preparedData))
+	}
+
+	scheme := preparedManifest.Spec.SecuritySchemes["slack"]
+	if scheme == nil {
+		t.Fatal(`manifest.Spec.SecuritySchemes["slack"] = nil, want generated scheme`)
+	}
+	if scheme.Type != providermanifestv1.HTTPSecuritySchemeTypeSlackSignature {
+		t.Fatalf("scheme.Type = %q, want %q", scheme.Type, providermanifestv1.HTTPSecuritySchemeTypeSlackSignature)
+	}
+	if scheme.Secret == nil || scheme.Secret.Env != "SLACK_SIGNING_SECRET" {
+		t.Fatalf("scheme.Secret = %+v, want env-backed secret", scheme.Secret)
+	}
+
+	binding := preparedManifest.Spec.HTTP["command"]
+	if binding == nil {
+		t.Fatal(`manifest.Spec.HTTP["command"] = nil, want generated binding`)
+	}
+	if binding.Path != "/command" {
+		t.Fatalf("binding.Path = %q, want %q", binding.Path, "/command")
+	}
+	if binding.Method != "POST" {
+		t.Fatalf("binding.Method = %q, want %q", binding.Method, "POST")
+	}
+	if binding.Security != "slack" {
+		t.Fatalf("binding.Security = %q, want %q", binding.Security, "slack")
+	}
+	if binding.Target != "echo" {
+		t.Fatalf("binding.Target = %q, want %q", binding.Target, "echo")
+	}
+	if binding.RequestBody == nil {
+		t.Fatal("binding.RequestBody = nil, want request body metadata")
+	}
+	if _, ok := binding.RequestBody.Content["application/x-www-form-urlencoded"]; !ok {
+		t.Fatalf("binding.RequestBody.Content = %#v, want form content type", binding.RequestBody.Content)
+	}
+	if binding.Ack == nil || binding.Ack.Status != 200 {
+		t.Fatalf("binding.Ack = %+v, want 200 ack metadata", binding.Ack)
 	}
 }
 
-func TestGoModulePathFromFileStripsComments(t *testing.T) {
-	t.Parallel()
+func injectGoManifestMetadata(t *testing.T, providerPath string) {
+	t.Helper()
 
-	root := t.TempDir()
-	mustWriteFile(t, filepath.Join(root, "go.mod"), []byte("module example.com/provider // comment\n"), 0o644)
-
-	got, err := goModulePathFromFile(root)
+	data, err := os.ReadFile(providerPath)
 	if err != nil {
-		t.Fatalf("goModulePathFromFile: %v", err)
+		t.Fatalf("ReadFile(%s): %v", providerPath, err)
 	}
-	if got != "example.com/provider" {
-		t.Fatalf("module path = %q, want %q", got, "example.com/provider")
+	old := "\t)\n)"
+	new := "\t).WithManifestMetadata(gestalt.ManifestMetadata{\n\t\tSecuritySchemes: map[string]gestalt.HTTPSecurityScheme{\n\t\t\t\"slack\": {\n\t\t\t\tType: gestalt.HTTPSecuritySchemeTypeSlackSignature,\n\t\t\t\tSecret: &gestalt.HTTPSecretRef{Env: \"SLACK_SIGNING_SECRET\"},\n\t\t\t},\n\t\t},\n\t\tHTTP: map[string]gestalt.HTTPBinding{\n\t\t\t\"command\": {\n\t\t\t\tPath:     \"/command\",\n\t\t\t\tMethod:   http.MethodPost,\n\t\t\t\tSecurity: \"slack\",\n\t\t\t\tTarget:   \"echo\",\n\t\t\t\tRequestBody: &gestalt.HTTPRequestBody{\n\t\t\t\t\tRequired: true,\n\t\t\t\t\tContent: map[string]gestalt.HTTPMediaType{\n\t\t\t\t\t\t\"application/x-www-form-urlencoded\": {},\n\t\t\t\t\t},\n\t\t\t\t},\n\t\t\t\tAck: &gestalt.HTTPAck{\n\t\t\t\t\tStatus: 200,\n\t\t\t\t\tBody: map[string]any{\n\t\t\t\t\t\t\"response_type\": \"ephemeral\",\n\t\t\t\t\t\t\"text\":          \"Working on it...\",\n\t\t\t\t\t},\n\t\t\t\t},\n\t\t\t},\n\t\t},\n\t})\n)"
+	updated := strings.Replace(string(data), old, new, 1)
+	if updated == string(data) {
+		t.Fatalf("provider fixture %s missing router terminator %q", providerPath, old)
+	}
+	if err := os.WriteFile(providerPath, []byte(updated), 0o644); err != nil {
+		t.Fatalf("WriteFile(%s): %v", providerPath, err)
 	}
 }

--- a/gestaltd/internal/providerpkg/python_provider_test.go
+++ b/gestaltd/internal/providerpkg/python_provider_test.go
@@ -1,7 +1,9 @@
 package providerpkg
 
 import (
+	"fmt"
 	"os"
+	"os/exec"
 	"path/filepath"
 	"runtime"
 	"strings"
@@ -235,6 +237,111 @@ provider = "provider"
 	}
 }
 
+func TestPrepareSourceManifest_MergesGeneratedPythonManifestMetadata(t *testing.T) {
+	root := t.TempDir()
+	manifestPath := mustWritePythonSourceManifest(t, root, "python-release")
+	mustWriteFile(t, filepath.Join(root, pythonProjectFile), []byte(`[tool.gestalt]
+provider = "provider:plugin"
+`), 0o644)
+	mustWriteFile(t, filepath.Join(root, "provider.py"), []byte(`from gestalt import Plugin
+
+plugin = Plugin(
+    "python-release",
+    securitySchemes={
+        "slack": {
+            "type": "slack_signature",
+            "secret": {"env": "SLACK_SIGNING_SECRET"},
+        }
+    },
+    http={
+        "command": {
+            "path": "/command",
+            "method": "POST",
+            "security": "slack",
+            "target": "handle_command",
+            "requestBody": {
+                "required": True,
+                "content": {
+                    "application/x-www-form-urlencoded": {},
+                },
+            },
+            "ack": {
+                "status": 200,
+                "body": {
+                    "response_type": "ephemeral",
+                    "text": "Working on it...",
+                },
+            },
+        }
+    },
+)
+
+@plugin.operation(id="handle_command")
+def handle_command() -> dict[str, str]:
+    return {"status": "ok"}
+`), 0o644)
+
+	pythonPath, err := pythonTestRuntimePath()
+	if err != nil {
+		t.Skipf("python runtime unavailable: %v", err)
+	}
+	t.Setenv("GESTALT_PYTHON", mustWritePythonWithoutGRPCWrapper(t, root, pythonPath))
+
+	preparedData, preparedManifest, err := PrepareSourceManifest(manifestPath)
+	if err != nil {
+		t.Fatalf("PrepareSourceManifest: %v", err)
+	}
+	if preparedManifest == nil || preparedManifest.Spec == nil {
+		t.Fatalf("prepared manifest = %+v, want provider metadata", preparedManifest)
+	}
+	if !containsString(string(preparedData), "securitySchemes:") {
+		t.Fatalf("prepared manifest data = %q, want merged security scheme metadata", string(preparedData))
+	}
+	if !containsString(string(preparedData), "path: /command") {
+		t.Fatalf("prepared manifest data = %q, want merged HTTP binding metadata", string(preparedData))
+	}
+
+	scheme := preparedManifest.Spec.SecuritySchemes["slack"]
+	if scheme == nil {
+		t.Fatal(`manifest.Spec.SecuritySchemes["slack"] = nil, want generated scheme`)
+	}
+	if scheme.Type != providermanifestv1.HTTPSecuritySchemeTypeSlackSignature {
+		t.Fatalf("scheme.Type = %q, want %q", scheme.Type, providermanifestv1.HTTPSecuritySchemeTypeSlackSignature)
+	}
+	if scheme.Secret == nil || scheme.Secret.Env != "SLACK_SIGNING_SECRET" {
+		t.Fatalf("scheme.Secret = %+v, want env-backed secret", scheme.Secret)
+	}
+
+	binding := preparedManifest.Spec.HTTP["command"]
+	if binding == nil {
+		t.Fatal(`manifest.Spec.HTTP["command"] = nil, want generated binding`)
+	}
+	if binding.Path != "/command" {
+		t.Fatalf("binding.Path = %q, want %q", binding.Path, "/command")
+	}
+	if binding.Method != "POST" {
+		t.Fatalf("binding.Method = %q, want %q", binding.Method, "POST")
+	}
+	if binding.Security != "slack" {
+		t.Fatalf("binding.Security = %q, want %q", binding.Security, "slack")
+	}
+	if binding.Target != "handle_command" {
+		t.Fatalf("binding.Target = %q, want %q", binding.Target, "handle_command")
+	}
+	if binding.RequestBody == nil {
+		t.Fatal("binding.RequestBody = nil, want request body metadata")
+	}
+	if _, ok := binding.RequestBody.Content["application/x-www-form-urlencoded"]; !ok {
+		t.Fatalf("binding.RequestBody.Content = %#v, want form content type", binding.RequestBody.Content)
+	}
+	if binding.Ack == nil {
+		t.Fatal("binding.Ack = nil, want ack metadata")
+	}
+	if binding.Ack.Status != 200 {
+		t.Fatalf("binding.Ack.Status = %d, want %d", binding.Ack.Status, 200)
+	}
+}
+
 func pythonTestOtherPlatform() (string, string) {
 	if runtime.GOOS != "darwin" || runtime.GOARCH != "arm64" {
 		return "darwin", "arm64"
@@ -242,11 +349,58 @@ func pythonTestOtherPlatform() (string, string) {
 	return "linux", "amd64"
 }
 
+func pythonTestRuntimePath() (string, error) {
+	if value := os.Getenv("GESTALT_PYTHON"); value != "" {
+		if resolved, err := exec.LookPath(value); err == nil {
+			return resolved, nil
+		}
+		if info, err := os.Stat(value); err == nil && !info.IsDir() {
+			return value, nil
+		}
+	}
+	for _, candidate := range []string{"python3", "python"} {
+		if resolved, err := exec.LookPath(candidate); err == nil {
+			return resolved, nil
+		}
+	}
+	return "", exec.ErrNotFound
+}
+
 func pythonTestInterpreterPath(root, goos, suffix string) string {
 	if goos == "windows" {
 		return filepath.Join(root, suffix, "Scripts", "python.exe")
 	}
 	return filepath.Join(root, suffix, "bin", "python")
+}
+
+func mustWritePythonWithoutGRPCWrapper(t *testing.T, root, pythonPath string) string {
+	t.Helper()
+
+	path := filepath.Join(root, "python-no-grpc")
+	script := fmt.Sprintf(`#!%s
+import importlib.abc
+import runpy
+import sys
+
+class _BlockGRPC(importlib.abc.MetaPathFinder):
+    def find_spec(self, fullname, path=None, target=None):
+        if fullname == "grpc" or fullname.startswith("grpc."):
+            error = ModuleNotFoundError("No module named 'grpc'")
+            error.name = "grpc"
+            raise error
+        return None
+
+sys.meta_path.insert(0, _BlockGRPC())
+
+if len(sys.argv) < 3 or sys.argv[1] != "-m":
+    raise SystemExit("unsupported invocation")
+
+module_name = sys.argv[2]
+sys.argv = [sys.argv[0], *sys.argv[3:]]
+runpy.run_module(module_name, run_name="__main__")
+`, pythonPath)
+	mustWriteFile(t, path, []byte(script), 0o755)
+	return path
 }
 
 func mustWritePythonInterpreter(t *testing.T, path string) {
@@ -258,6 +412,30 @@ func mustWritePythonInterpreter(t *testing.T, path string) {
 	if err := os.WriteFile(path, []byte("#!/bin/sh\nexit 0\n"), 0o755); err != nil {
 		t.Fatalf("WriteFile(%s): %v", path, err)
 	}
+}
+
+func mustWritePythonSourceManifest(t *testing.T, root, pluginName string) string {
+	t.Helper()
+
+	data, err := EncodeSourceManifestFormat(&providermanifestv1.Manifest{
+		Kind:    providermanifestv1.KindPlugin,
+		Source:  "github.com/testowner/plugins/" + pluginName,
+		Version: "0.0.1",
+		Spec: &providermanifestv1.Spec{
+			Connections: map[string]*providermanifestv1.ManifestConnectionDef{
+				"default": {
+					Auth: &providermanifestv1.ProviderAuth{Type: providermanifestv1.AuthTypeNone},
+				},
+			},
+		},
+	}, ManifestFormatYAML)
+	if err != nil {
+		t.Fatalf("EncodeSourceManifestFormat: %v", err)
+	}
+
+	path := filepath.Join(root, "manifest.yaml")
+	mustWriteFile(t, path, data, 0o644)
+	return path
 }
 
 func containsString(haystack, needle string) bool {

--- a/gestaltd/internal/providerpkg/rust_provider_test.go
+++ b/gestaltd/internal/providerpkg/rust_provider_test.go
@@ -277,6 +277,102 @@ func TestPrepareSourceManifest_GeneratesStaticCatalogForRustProvider(t *testing.
 	}
 }
 
+func TestPrepareSourceManifest_MergesGeneratedRustManifestMetadata(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("fake cargo test fixture is POSIX-only")
+	}
+
+	root := t.TempDir()
+	copyRustProviderFixture(t, root)
+
+	targetTriple, err := rustTargetTriple(runtime.GOOS, runtime.GOARCH)
+	if err != nil {
+		t.Fatalf("rustTargetTriple(host): %v", err)
+	}
+
+	fakeCargoDir := t.TempDir()
+	writeFakeCargo(t, filepath.Join(fakeCargoDir, "cargo"), fakeCargoConfig{
+		ExpectedPluginName:   "provider-rust",
+		ExpectedTarget:       targetTriple,
+		ExpectedServeExport:  "__gestalt_serve",
+		ExpectedCatalogWrite: true,
+		GeneratedCatalog:     "provider-rust",
+		GeneratedManifestMetadata: `securitySchemes:
+  slack:
+    type: slack_signature
+    secret:
+      env: SLACK_SIGNING_SECRET
+http:
+  command:
+    path: /command
+    method: POST
+    security: slack
+    target: handle_command
+    requestBody:
+      required: true
+      content:
+        application/x-www-form-urlencoded: {}
+    ack:
+      status: 200
+      body:
+        response_type: ephemeral
+        text: Working on it...`,
+	})
+	t.Setenv("PATH", fakeCargoDir+string(os.PathListSeparator)+os.Getenv("PATH"))
+
+	manifestPath := filepath.Join(root, "manifest.yaml")
+	preparedData, preparedManifest, err := PrepareSourceManifest(manifestPath)
+	if err != nil {
+		t.Fatalf("PrepareSourceManifest: %v", err)
+	}
+	if preparedManifest == nil || preparedManifest.Spec == nil {
+		t.Fatalf("prepared manifest = %+v, want provider metadata", preparedManifest)
+	}
+	if !containsString(string(preparedData), "securitySchemes:") {
+		t.Fatalf("prepared manifest data = %q, want merged security scheme metadata", string(preparedData))
+	}
+	if !containsString(string(preparedData), "path: /command") {
+		t.Fatalf("prepared manifest data = %q, want merged HTTP binding metadata", string(preparedData))
+	}
+
+	scheme := preparedManifest.Spec.SecuritySchemes["slack"]
+	if scheme == nil {
+		t.Fatal(`manifest.Spec.SecuritySchemes["slack"] = nil, want generated scheme`)
+	}
+	if scheme.Type != providermanifestv1.HTTPSecuritySchemeTypeSlackSignature {
+		t.Fatalf("scheme.Type = %q, want %q", scheme.Type, providermanifestv1.HTTPSecuritySchemeTypeSlackSignature)
+	}
+	if scheme.Secret == nil || scheme.Secret.Env != "SLACK_SIGNING_SECRET" {
+		t.Fatalf("scheme.Secret = %+v, want env-backed secret", scheme.Secret)
+	}
+
+	binding := preparedManifest.Spec.HTTP["command"]
+	if binding == nil {
+		t.Fatal(`manifest.Spec.HTTP["command"] = nil, want generated binding`)
+	}
+	if binding.Path != "/command" {
+		t.Fatalf("binding.Path = %q, want %q", binding.Path, "/command")
+	}
+	if binding.Method != "POST" {
+		t.Fatalf("binding.Method = %q, want %q", binding.Method, "POST")
+	}
+	if binding.Security != "slack" {
+		t.Fatalf("binding.Security = %q, want %q", binding.Security, "slack")
+	}
+	if binding.Target != "handle_command" {
+		t.Fatalf("binding.Target = %q, want %q", binding.Target, "handle_command")
+	}
+	if binding.RequestBody == nil {
+		t.Fatal("binding.RequestBody = nil, want request body metadata")
+	}
+	if _, ok := binding.RequestBody.Content["application/x-www-form-urlencoded"]; !ok {
+		t.Fatalf("binding.RequestBody.Content = %#v, want form content type", binding.RequestBody.Content)
+	}
+	if binding.Ack == nil || binding.Ack.Status != 200 {
+		t.Fatalf("binding.Ack = %+v, want 200 ack metadata", binding.Ack)
+	}
+}
+
 func TestRustTargetTriple(t *testing.T) {
 	t.Parallel()
 
@@ -331,11 +427,12 @@ members = ["provider"]
 }
 
 type fakeCargoConfig struct {
-	ExpectedPluginName   string
-	ExpectedTarget       string
-	ExpectedServeExport  string
-	ExpectedCatalogWrite bool
-	GeneratedCatalog     string
+	ExpectedPluginName        string
+	ExpectedTarget            string
+	ExpectedServeExport       string
+	ExpectedCatalogWrite      bool
+	GeneratedCatalog          string
+	GeneratedManifestMetadata string
 }
 
 func writeFakeCargo(t *testing.T, path string, cfg fakeCargoConfig) {
@@ -405,6 +502,7 @@ operations:
     method: GET
 YAML
 fi
+` + fakeCargoManifestMetadataWrite(cfg.GeneratedManifestMetadata) + `
 exit 0
 EOF
 chmod +x "$binary"
@@ -454,6 +552,17 @@ fi`
 	return `if grep -Fq 'provider_plugin::__gestalt_write_catalog(PLUGIN_NAME, &path)?' "$main_rs"; then
   echo "unexpected write-catalog export in wrapper source" >&2
   exit 1
+fi`
+}
+
+func fakeCargoManifestMetadataWrite(metadata string) string {
+	if strings.TrimSpace(metadata) == "" {
+		return ""
+	}
+	return `if [ -n "${GESTALT_PLUGIN_WRITE_MANIFEST_METADATA:-}" ]; then
+  cat > "$GESTALT_PLUGIN_WRITE_MANIFEST_METADATA" <<'YAML'
+` + metadata + `
+YAML
 fi`
 }
 

--- a/sdk/go/doc.go
+++ b/sdk/go/doc.go
@@ -12,7 +12,9 @@
 //  1. Implement [Provider.Configure].
 //  2. Define typed operations and handlers in Go with [Operation], [Register],
 //     and [Router].
-//  3. Export `New()` plus `Router` from the provider package.
+//  3. Optionally attach hosted HTTP/security metadata with
+//     [Router.WithManifestMetadata].
+//  4. Export `New()` plus `Router` from the provider package.
 //
 // This keeps the runtime contract single-source and manifest-backed while still
 // giving provider authors typed Go definitions for executable helper

--- a/sdk/go/manifest_metadata.go
+++ b/sdk/go/manifest_metadata.go
@@ -1,0 +1,243 @@
+package gestalt
+
+import (
+	"bytes"
+	"fmt"
+	"os"
+	"reflect"
+
+	"gopkg.in/yaml.v3"
+)
+
+// ManifestMetadata describes optional manifest-backed metadata generated from
+// Go-defined plugin routers.
+type ManifestMetadata struct {
+	SecuritySchemes map[string]HTTPSecurityScheme `json:"securitySchemes,omitempty" yaml:"securitySchemes,omitempty"`
+	HTTP            map[string]HTTPBinding        `json:"http,omitempty" yaml:"http,omitempty"`
+}
+
+// HTTPSecuritySchemeType identifies the supported hosted HTTP auth schemes.
+type HTTPSecuritySchemeType string
+
+const (
+	HTTPSecuritySchemeTypeSlackSignature HTTPSecuritySchemeType = "slack_signature"
+	HTTPSecuritySchemeTypeAPIKey         HTTPSecuritySchemeType = "apiKey"
+	HTTPSecuritySchemeTypeHTTP           HTTPSecuritySchemeType = "http"
+	HTTPSecuritySchemeTypeNone           HTTPSecuritySchemeType = "none"
+)
+
+// HTTPIn identifies where an HTTP auth value is supplied.
+type HTTPIn string
+
+const (
+	HTTPInHeader HTTPIn = "header"
+	HTTPInQuery  HTTPIn = "query"
+)
+
+// HTTPAuthScheme identifies the HTTP auth scheme for `type: http`.
+type HTTPAuthScheme string
+
+const (
+	HTTPAuthSchemeBasic  HTTPAuthScheme = "basic"
+	HTTPAuthSchemeBearer HTTPAuthScheme = "bearer"
+)
+
+// HTTPSecretRef points at the secret backing a hosted HTTP security scheme.
+type HTTPSecretRef struct {
+	Env    string `json:"env,omitempty" yaml:"env,omitempty"`
+	Secret string `json:"secret,omitempty" yaml:"secret,omitempty"`
+}
+
+// HTTPSecurityScheme describes one named hosted HTTP security scheme.
+type HTTPSecurityScheme struct {
+	Type        HTTPSecuritySchemeType `json:"type,omitempty" yaml:"type,omitempty"`
+	Description string                 `json:"description,omitempty" yaml:"description,omitempty"`
+	Name        string                 `json:"name,omitempty" yaml:"name,omitempty"`
+	In          HTTPIn                 `json:"in,omitempty" yaml:"in,omitempty"`
+	Scheme      HTTPAuthScheme         `json:"scheme,omitempty" yaml:"scheme,omitempty"`
+	Secret      *HTTPSecretRef         `json:"secret,omitempty" yaml:"secret,omitempty"`
+}
+
+// HTTPBinding describes one hosted HTTP endpoint bound to a registered
+// operation target.
+type HTTPBinding struct {
+	Path        string           `json:"path" yaml:"path"`
+	Method      string           `json:"method" yaml:"method"`
+	RequestBody *HTTPRequestBody `json:"requestBody,omitempty" yaml:"requestBody,omitempty"`
+	Security    string           `json:"security,omitempty" yaml:"security,omitempty"`
+	Target      string           `json:"target" yaml:"target"`
+	Ack         *HTTPAck         `json:"ack,omitempty" yaml:"ack,omitempty"`
+}
+
+// HTTPRequestBody describes the accepted content types for a hosted HTTP
+// binding.
+type HTTPRequestBody struct {
+	Required bool                     `json:"required,omitempty" yaml:"required,omitempty"`
+	Content  map[string]HTTPMediaType `json:"content,omitempty" yaml:"content,omitempty"`
+}
+
+// HTTPMediaType reserves per-content-type metadata for future expansion.
+type HTTPMediaType struct{}
+
+// HTTPAck describes the immediate host-managed response for a hosted HTTP
+// binding.
+type HTTPAck struct {
+	Status  int               `json:"status,omitempty" yaml:"status,omitempty"`
+	Headers map[string]string `json:"headers,omitempty" yaml:"headers,omitempty"`
+	Body    any               `json:"body,omitempty" yaml:"body,omitempty"`
+}
+
+func hasManifestMetadata(metadata ManifestMetadata) bool {
+	return len(metadata.SecuritySchemes) > 0 || len(metadata.HTTP) > 0
+}
+
+func cloneManifestMetadataValue(metadata ManifestMetadata) *ManifestMetadata {
+	return cloneManifestMetadata(&metadata)
+}
+
+func cloneManifestMetadata(metadata *ManifestMetadata) *ManifestMetadata {
+	if metadata == nil {
+		return nil
+	}
+	cloned := &ManifestMetadata{}
+	if len(metadata.SecuritySchemes) > 0 {
+		cloned.SecuritySchemes = make(map[string]HTTPSecurityScheme, len(metadata.SecuritySchemes))
+		for name, scheme := range metadata.SecuritySchemes {
+			cloned.SecuritySchemes[name] = cloneHTTPSecurityScheme(scheme)
+		}
+	}
+	if len(metadata.HTTP) > 0 {
+		cloned.HTTP = make(map[string]HTTPBinding, len(metadata.HTTP))
+		for name, binding := range metadata.HTTP {
+			cloned.HTTP[name] = cloneHTTPBinding(binding)
+		}
+	}
+	if !hasManifestMetadata(*cloned) {
+		return nil
+	}
+	return cloned
+}
+
+func cloneHTTPSecurityScheme(scheme HTTPSecurityScheme) HTTPSecurityScheme {
+	cloned := scheme
+	cloned.Secret = cloneHTTPSecretRef(scheme.Secret)
+	return cloned
+}
+
+func cloneHTTPSecretRef(secret *HTTPSecretRef) *HTTPSecretRef {
+	if secret == nil {
+		return nil
+	}
+	cloned := *secret
+	return &cloned
+}
+
+func cloneHTTPBinding(binding HTTPBinding) HTTPBinding {
+	cloned := binding
+	cloned.RequestBody = cloneHTTPRequestBody(binding.RequestBody)
+	cloned.Ack = cloneHTTPAck(binding.Ack)
+	return cloned
+}
+
+func cloneHTTPRequestBody(body *HTTPRequestBody) *HTTPRequestBody {
+	if body == nil {
+		return nil
+	}
+	cloned := &HTTPRequestBody{
+		Required: body.Required,
+	}
+	if len(body.Content) > 0 {
+		cloned.Content = make(map[string]HTTPMediaType, len(body.Content))
+		for name, mediaType := range body.Content {
+			cloned.Content[name] = mediaType
+		}
+	}
+	return cloned
+}
+
+func cloneHTTPAck(ack *HTTPAck) *HTTPAck {
+	if ack == nil {
+		return nil
+	}
+	cloned := &HTTPAck{
+		Status: ack.Status,
+		Body:   cloneHTTPBodyValue(ack.Body),
+	}
+	if len(ack.Headers) > 0 {
+		cloned.Headers = make(map[string]string, len(ack.Headers))
+		for name, value := range ack.Headers {
+			cloned.Headers[name] = value
+		}
+	}
+	return cloned
+}
+
+func cloneHTTPBodyValue(value any) any {
+	if value == nil {
+		return nil
+	}
+	return cloneHTTPBodyReflectValue(reflect.ValueOf(value)).Interface()
+}
+
+func cloneHTTPBodyReflectValue(value reflect.Value) reflect.Value {
+	if !value.IsValid() {
+		return reflect.Value{}
+	}
+	switch value.Kind() {
+	case reflect.Interface:
+		if value.IsNil() {
+			return reflect.Zero(value.Type())
+		}
+		return cloneHTTPBodyReflectValue(value.Elem())
+	case reflect.Pointer:
+		if value.IsNil() {
+			return reflect.Zero(value.Type())
+		}
+		cloned := reflect.New(value.Type().Elem())
+		cloned.Elem().Set(cloneHTTPBodyReflectValue(value.Elem()))
+		return cloned
+	case reflect.Map:
+		if value.IsNil() {
+			return reflect.Zero(value.Type())
+		}
+		cloned := reflect.MakeMapWithSize(value.Type(), value.Len())
+		iter := value.MapRange()
+		for iter.Next() {
+			cloned.SetMapIndex(cloneHTTPBodyReflectValue(iter.Key()), cloneHTTPBodyReflectValue(iter.Value()))
+		}
+		return cloned
+	case reflect.Slice:
+		if value.IsNil() {
+			return reflect.Zero(value.Type())
+		}
+		cloned := reflect.MakeSlice(value.Type(), value.Len(), value.Len())
+		for i := 0; i < value.Len(); i++ {
+			cloned.Index(i).Set(cloneHTTPBodyReflectValue(value.Index(i)))
+		}
+		return cloned
+	case reflect.Array:
+		cloned := reflect.New(value.Type()).Elem()
+		for i := 0; i < value.Len(); i++ {
+			cloned.Index(i).Set(cloneHTTPBodyReflectValue(value.Index(i)))
+		}
+		return cloned
+	default:
+		return value
+	}
+}
+
+func writeManifestMetadataYAML(metadata ManifestMetadata, path string) error {
+	if !hasManifestMetadata(metadata) {
+		return nil
+	}
+	var buf bytes.Buffer
+	enc := yaml.NewEncoder(&buf)
+	enc.SetIndent(2)
+	if err := enc.Encode(metadata); err != nil {
+		return fmt.Errorf("encode manifest metadata YAML: %w", err)
+	}
+	if err := enc.Close(); err != nil {
+		return fmt.Errorf("close YAML encoder: %w", err)
+	}
+	return os.WriteFile(path, buf.Bytes(), 0o644)
+}

--- a/sdk/go/router.go
+++ b/sdk/go/router.go
@@ -121,8 +121,9 @@ func Register[P any, In any, Out any](
 // Router dispatches provider Execute calls against typed handlers and derives
 // the corresponding static executable catalog.
 type Router[P any] struct {
-	catalog  *proto.Catalog
-	handlers map[string]func(context.Context, *P, map[string]any, Request) (*OperationResult, error)
+	catalog          *proto.Catalog
+	manifestMetadata *ManifestMetadata
+	handlers         map[string]func(context.Context, *P, map[string]any, Request) (*OperationResult, error)
 }
 
 // NewRouter constructs a typed router from registrations. Source-provider flows
@@ -171,6 +172,19 @@ func (r *Router[P]) Catalog() *proto.Catalog {
 	return cloneCatalog(r.catalog)
 }
 
+// ManifestMetadata returns a defensive copy of the router's generated manifest
+// metadata.
+func (r *Router[P]) ManifestMetadata() ManifestMetadata {
+	if r == nil || r.manifestMetadata == nil {
+		return ManifestMetadata{}
+	}
+	cloned := cloneManifestMetadata(r.manifestMetadata)
+	if cloned == nil {
+		return ManifestMetadata{}
+	}
+	return *cloned
+}
+
 // WithName returns a copy of r with the catalog name overridden.
 func (r *Router[P]) WithName(name string) *Router[P] {
 	if r == nil {
@@ -185,8 +199,27 @@ func (r *Router[P]) WithName(name string) *Router[P] {
 		handlers[opID] = handler
 	}
 	return &Router[P]{
-		catalog:  cat,
-		handlers: handlers,
+		catalog:          cat,
+		manifestMetadata: cloneManifestMetadata(r.manifestMetadata),
+		handlers:         handlers,
+	}
+}
+
+// WithManifestMetadata returns a copy of r with hosted HTTP/security metadata
+// attached for manifest export.
+func (r *Router[P]) WithManifestMetadata(metadata ManifestMetadata) *Router[P] {
+	if r == nil {
+		return nil
+	}
+	cat := cloneCatalog(r.catalog)
+	handlers := make(map[string]func(context.Context, *P, map[string]any, Request) (*OperationResult, error), len(r.handlers))
+	for opID, handler := range r.handlers {
+		handlers[opID] = handler
+	}
+	return &Router[P]{
+		catalog:          cat,
+		manifestMetadata: cloneManifestMetadataValue(metadata),
+		handlers:         handlers,
 	}
 }
 

--- a/sdk/go/router_test.go
+++ b/sdk/go/router_test.go
@@ -252,3 +252,103 @@ func TestRouterCatalogName(t *testing.T) {
 		t.Fatalf("original catalog name = %q, want %q", router.Catalog().GetName(), "original-name")
 	}
 }
+
+func TestRouterManifestMetadata(t *testing.T) {
+	t.Parallel()
+
+	router := gestalt.MustRouter(
+		gestalt.Register(
+			gestalt.Operation[execInput, execOutput]{
+				ID:     "echo",
+				Method: http.MethodPost,
+			},
+			(*execProvider).echo,
+		),
+	).WithManifestMetadata(gestalt.ManifestMetadata{
+		SecuritySchemes: map[string]gestalt.HTTPSecurityScheme{
+			"slack": {
+				Type: gestalt.HTTPSecuritySchemeTypeSlackSignature,
+				Secret: &gestalt.HTTPSecretRef{
+					Env: "SLACK_SIGNING_SECRET",
+				},
+			},
+		},
+		HTTP: map[string]gestalt.HTTPBinding{
+			"command": {
+				Path:     "/command",
+				Method:   http.MethodPost,
+				Security: "slack",
+				Target:   "echo",
+				RequestBody: &gestalt.HTTPRequestBody{
+					Required: true,
+					Content: map[string]gestalt.HTTPMediaType{
+						"application/x-www-form-urlencoded": {},
+					},
+				},
+				Ack: &gestalt.HTTPAck{
+					Status: 200,
+					Headers: map[string]string{
+						"content-type": "application/json",
+					},
+					Body: map[string]any{
+						"response_type": "ephemeral",
+						"attachments": []any{
+							map[string]any{"text": "Working on it"},
+						},
+					},
+				},
+			},
+		},
+	})
+
+	metadata := router.ManifestMetadata()
+	if got := metadata.SecuritySchemes["slack"].Type; got != gestalt.HTTPSecuritySchemeTypeSlackSignature {
+		t.Fatalf("security scheme type = %q, want %q", got, gestalt.HTTPSecuritySchemeTypeSlackSignature)
+	}
+	binding, ok := metadata.HTTP["command"]
+	if !ok {
+		t.Fatal("manifest metadata missing command binding")
+	}
+	if binding.Target != "echo" {
+		t.Fatalf("binding target = %q, want %q", binding.Target, "echo")
+	}
+	if binding.Ack == nil {
+		t.Fatal("binding ack is nil")
+	}
+	body, ok := binding.Ack.Body.(map[string]any)
+	if !ok {
+		t.Fatalf("binding ack body type = %T, want map[string]any", binding.Ack.Body)
+	}
+	attachments, ok := body["attachments"].([]any)
+	if !ok || len(attachments) != 1 {
+		t.Fatalf("binding attachments = %#v, want one attachment", body["attachments"])
+	}
+
+	metadata.SecuritySchemes["slack"] = gestalt.HTTPSecurityScheme{Type: gestalt.HTTPSecuritySchemeTypeNone}
+	binding.Ack.Headers["content-type"] = "text/plain"
+	body["response_type"] = "changed"
+	attachments[0].(map[string]any)["text"] = "changed"
+
+	original := router.ManifestMetadata()
+	if got := original.SecuritySchemes["slack"].Type; got != gestalt.HTTPSecuritySchemeTypeSlackSignature {
+		t.Fatalf("original security scheme type = %q, want %q", got, gestalt.HTTPSecuritySchemeTypeSlackSignature)
+	}
+	originalBinding := original.HTTP["command"]
+	if got := originalBinding.Ack.Headers["content-type"]; got != "application/json" {
+		t.Fatalf("original ack header = %q, want %q", got, "application/json")
+	}
+	originalBody, ok := originalBinding.Ack.Body.(map[string]any)
+	if !ok {
+		t.Fatalf("original ack body type = %T, want map[string]any", originalBinding.Ack.Body)
+	}
+	if got := originalBody["response_type"]; got != "ephemeral" {
+		t.Fatalf("original ack response_type = %#v, want %#v", got, "ephemeral")
+	}
+	originalAttachments, ok := originalBody["attachments"].([]any)
+	if !ok || len(originalAttachments) != 1 {
+		t.Fatalf("original attachments = %#v, want one attachment", originalBody["attachments"])
+	}
+	if got := originalAttachments[0].(map[string]any)["text"]; got != "Working on it" {
+		t.Fatalf("original attachment text = %#v, want %#v", got, "Working on it")
+	}
+}

--- a/sdk/go/serve.go
+++ b/sdk/go/serve.go
@@ -15,6 +15,7 @@ import (
 )
 
 const envWriteCatalog = "GESTALT_PLUGIN_WRITE_CATALOG"
+const envWriteManifestMetadata = "GESTALT_PLUGIN_WRITE_MANIFEST_METADATA"
 
 type providerCloserContextKey struct{}
 
@@ -27,22 +28,52 @@ func ServeProvider[P any, PP interface {
 	*P
 	Provider
 }](ctx context.Context, provider PP, router *Router[P]) error {
-	if catalogPath := os.Getenv(envWriteCatalog); catalogPath != "" {
-		cat := router.Catalog()
-		if cat == nil {
-			cat = &proto.Catalog{}
-		}
-		if dir := filepath.Dir(catalogPath); dir != "." && dir != "" {
-			if err := os.MkdirAll(dir, 0o755); err != nil {
-				return fmt.Errorf("create catalog directory %q: %w", dir, err)
+	catalogPath := os.Getenv(envWriteCatalog)
+	manifestMetadataPath := os.Getenv(envWriteManifestMetadata)
+	if catalogPath != "" || manifestMetadataPath != "" {
+		if catalogPath != "" {
+			cat := router.Catalog()
+			if cat == nil {
+				cat = &proto.Catalog{}
+			}
+			if err := ensureOutputDir("catalog", catalogPath); err != nil {
+				return err
+			}
+			if err := writeCatalogYAML(cat, catalogPath); err != nil {
+				return err
 			}
 		}
-		return writeCatalogYAML(cat, catalogPath)
+		if manifestMetadataPath != "" {
+			var metadata ManifestMetadata
+			if router != nil {
+				metadata = router.ManifestMetadata()
+			}
+			if hasManifestMetadata(metadata) {
+				if err := ensureOutputDir("manifest metadata", manifestMetadataPath); err != nil {
+					return err
+				}
+				if err := writeManifestMetadataYAML(metadata, manifestMetadataPath); err != nil {
+					return err
+				}
+			}
+		}
+		return nil
 	}
 	ctx = withProviderCloser(ctx, provider)
 	return serveProvider(ctx, func(srv *grpc.Server) {
 		proto.RegisterIntegrationProviderServer(srv, NewProviderServer(provider, router))
 	})
+}
+
+func ensureOutputDir(label, path string) error {
+	dir := filepath.Dir(path)
+	if dir == "." || dir == "" {
+		return nil
+	}
+	if err := os.MkdirAll(dir, 0o755); err != nil {
+		return fmt.Errorf("create %s directory %q: %w", label, dir, err)
+	}
+	return nil
 }
 
 func withProviderCloser(ctx context.Context, provider any) context.Context {

--- a/sdk/go/serve_transport_test.go
+++ b/sdk/go/serve_transport_test.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"os"
 	"path/filepath"
+	"strings"
 	"sync/atomic"
 	"testing"
 	"time"
@@ -87,6 +88,100 @@ func TestServeAuthenticationProviderClosesProviderOnShutdown(t *testing.T) {
 	if resp.GetAuthorizationUrl() == "" {
 		t.Fatal("BeginLogin returned empty authorization URL")
 	}
+}
+
+func TestServeProviderWritesStaticArtifacts(t *testing.T) {
+	t.Run("catalog and manifest metadata", func(t *testing.T) {
+		outputDir := filepath.Join(t.TempDir(), "generated")
+		catalogPath := filepath.Join(outputDir, "catalog.yaml")
+		metadataPath := filepath.Join(outputDir, "manifest-metadata.yaml")
+		t.Setenv("GESTALT_PLUGIN_WRITE_CATALOG", catalogPath)
+		t.Setenv("GESTALT_PLUGIN_WRITE_MANIFEST_METADATA", metadataPath)
+
+		router := stubRouter.WithManifestMetadata(gestalt.ManifestMetadata{
+			SecuritySchemes: map[string]gestalt.HTTPSecurityScheme{
+				"slack": {
+					Type: gestalt.HTTPSecuritySchemeTypeSlackSignature,
+					Secret: &gestalt.HTTPSecretRef{
+						Env: "SLACK_SIGNING_SECRET",
+					},
+				},
+			},
+			HTTP: map[string]gestalt.HTTPBinding{
+				"command": {
+					Path:     "/command",
+					Method:   "POST",
+					Security: "slack",
+					Target:   "test_op",
+					RequestBody: &gestalt.HTTPRequestBody{
+						Required: true,
+						Content: map[string]gestalt.HTTPMediaType{
+							"application/x-www-form-urlencoded": {},
+						},
+					},
+					Ack: &gestalt.HTTPAck{
+						Status: 200,
+						Body: map[string]any{
+							"response_type": "ephemeral",
+							"text":          "Working on it...",
+						},
+					},
+				},
+			},
+		})
+
+		if err := gestalt.ServeProvider(context.Background(), &stubProvider{}, router); err != nil {
+			t.Fatalf("ServeProvider: %v", err)
+		}
+
+		catalogData, err := os.ReadFile(catalogPath)
+		if err != nil {
+			t.Fatalf("ReadFile(catalog): %v", err)
+		}
+		catalogYAML := string(catalogData)
+		for _, want := range []string{
+			"operations:",
+			"id: test_op",
+			"method: POST",
+		} {
+			if !strings.Contains(catalogYAML, want) {
+				t.Fatalf("catalog YAML missing %q:\n%s", want, catalogYAML)
+			}
+		}
+
+		metadataData, err := os.ReadFile(metadataPath)
+		if err != nil {
+			t.Fatalf("ReadFile(manifest metadata): %v", err)
+		}
+		metadataYAML := string(metadataData)
+		for _, want := range []string{
+			"securitySchemes:",
+			"type: slack_signature",
+			"env: SLACK_SIGNING_SECRET",
+			"http:",
+			"path: /command",
+			"target: test_op",
+			"application/x-www-form-urlencoded",
+			"response_type: ephemeral",
+		} {
+			if !strings.Contains(metadataYAML, want) {
+				t.Fatalf("manifest metadata YAML missing %q:\n%s", want, metadataYAML)
+			}
+		}
+	})
+
+	t.Run("manifest metadata omitted when unset on router", func(t *testing.T) {
+		metadataPath := filepath.Join(t.TempDir(), "manifest-metadata.yaml")
+		t.Setenv("GESTALT_PLUGIN_WRITE_MANIFEST_METADATA", metadataPath)
+
+		if err := gestalt.ServeProvider(context.Background(), &stubProvider{}, stubRouter); err != nil {
+			t.Fatalf("ServeProvider: %v", err)
+		}
+
+		if _, err := os.Stat(metadataPath); !os.IsNotExist(err) {
+			t.Fatalf("manifest metadata file exists, err = %v, want not exists", err)
+		}
+	})
 }
 
 type closeTracker struct {

--- a/sdk/python/gestalt/__init__.py
+++ b/sdk/python/gestalt/__init__.py
@@ -21,6 +21,8 @@ Generated protobuf bindings remain available under :mod:`gestalt.gen`, but the
 authored reference documentation focuses on the handwritten SDK surface.
 """
 
+from importlib import import_module
+
 from ._api import (
     OK,
     Access,
@@ -32,7 +34,6 @@ from ._api import (
     Subject,
     field,
 )
-from ._cache import Cache, CacheEntry, cache_socket_env
 from ._catalog import (
     Catalog,
     CatalogOperation,
@@ -40,23 +41,15 @@ from ._catalog import (
     OperationAnnotations,
     SessionCatalogProvider,
 )
-from ._indexeddb import (
-    CURSOR_NEXT,
-    CURSOR_NEXT_UNIQUE,
-    CURSOR_PREV,
-    CURSOR_PREV_UNIQUE,
-    AlreadyExistsError,
-    Cursor,
-    Index,
-    IndexedDB,
-    IndexSchema,
-    KeyRange,
-    NotFoundError,
-    ObjectStore,
-    ObjectStoreSchema,
-    indexeddb_socket_env,
+from ._manifest_metadata import (
+    HTTPAck,
+    HTTPBinding,
+    HTTPMediaType,
+    HTTPRequestBody,
+    HTTPSecretRef,
+    HTTPSecurityScheme,
+    PluginManifestMetadata,
 )
-from ._invoker import ENV_PLUGIN_INVOKER_SOCKET, PluginInvoker
 from ._plugin import Plugin, operation, session_catalog
 from ._providers import (
     AuthenticatedUser,
@@ -79,31 +72,59 @@ from ._providers import (
     WarningsProvider,
     WorkflowProvider,
 )
-from ._s3 import (
-    ENV_S3_SOCKET,
-    S3,
-    ByteRange,
-    CopyOptions,
-    ListOptions,
-    ListPage,
-    ObjectMeta,
-    ObjectRef,
-    PresignMethod,
-    PresignOptions,
-    PresignResult,
-    ReadOptions,
-    S3InvalidRangeError,
-    S3NotFoundError,
-    S3Object,
-    S3PreconditionFailedError,
-    S3ReadStream,
-    WriteOptions,
-    s3_socket_env,
-)
-from ._workflow import (
-    ENV_WORKFLOW_HOST_SOCKET,
-    WorkflowHost,
-)
+
+_LAZY_EXPORTS = {
+    "AlreadyExistsError": ("._indexeddb", "AlreadyExistsError"),
+    "ByteRange": ("._s3", "ByteRange"),
+    "CURSOR_NEXT": ("._indexeddb", "CURSOR_NEXT"),
+    "CURSOR_NEXT_UNIQUE": ("._indexeddb", "CURSOR_NEXT_UNIQUE"),
+    "CURSOR_PREV": ("._indexeddb", "CURSOR_PREV"),
+    "CURSOR_PREV_UNIQUE": ("._indexeddb", "CURSOR_PREV_UNIQUE"),
+    "Cache": ("._cache", "Cache"),
+    "CacheEntry": ("._cache", "CacheEntry"),
+    "CopyOptions": ("._s3", "CopyOptions"),
+    "Cursor": ("._indexeddb", "Cursor"),
+    "ENV_PLUGIN_INVOKER_SOCKET": ("._invoker", "ENV_PLUGIN_INVOKER_SOCKET"),
+    "ENV_S3_SOCKET": ("._s3", "ENV_S3_SOCKET"),
+    "ENV_WORKFLOW_HOST_SOCKET": ("._workflow", "ENV_WORKFLOW_HOST_SOCKET"),
+    "Index": ("._indexeddb", "Index"),
+    "IndexedDB": ("._indexeddb", "IndexedDB"),
+    "IndexSchema": ("._indexeddb", "IndexSchema"),
+    "KeyRange": ("._indexeddb", "KeyRange"),
+    "ListOptions": ("._s3", "ListOptions"),
+    "ListPage": ("._s3", "ListPage"),
+    "NotFoundError": ("._indexeddb", "NotFoundError"),
+    "ObjectMeta": ("._s3", "ObjectMeta"),
+    "ObjectRef": ("._s3", "ObjectRef"),
+    "ObjectStore": ("._indexeddb", "ObjectStore"),
+    "ObjectStoreSchema": ("._indexeddb", "ObjectStoreSchema"),
+    "PluginInvoker": ("._invoker", "PluginInvoker"),
+    "PresignMethod": ("._s3", "PresignMethod"),
+    "PresignOptions": ("._s3", "PresignOptions"),
+    "PresignResult": ("._s3", "PresignResult"),
+    "ReadOptions": ("._s3", "ReadOptions"),
+    "S3": ("._s3", "S3"),
+    "S3InvalidRangeError": ("._s3", "S3InvalidRangeError"),
+    "S3NotFoundError": ("._s3", "S3NotFoundError"),
+    "S3Object": ("._s3", "S3Object"),
+    "S3PreconditionFailedError": ("._s3", "S3PreconditionFailedError"),
+    "S3ReadStream": ("._s3", "S3ReadStream"),
+    "WorkflowHost": ("._workflow", "WorkflowHost"),
+    "WriteOptions": ("._s3", "WriteOptions"),
+    "cache_socket_env": ("._cache", "cache_socket_env"),
+    "indexeddb_socket_env": ("._indexeddb", "indexeddb_socket_env"),
+    "s3_socket_env": ("._s3", "s3_socket_env"),
+}
+
+
+def __getattr__(name: str):
+    export = _LAZY_EXPORTS.get(name)
+    if export is None:
+        raise AttributeError(f"module {__name__!r} has no attribute {name!r}")
+    module_name, attr_name = export
+    value = getattr(import_module(module_name, __name__), attr_name)
+    globals()[name] = value
+    return value
 
 __all__ = [
     "AlreadyExistsError",
@@ -132,6 +153,12 @@ __all__ = [
     "ENV_WORKFLOW_HOST_SOCKET",
     "ExternalTokenValidator",
     "HealthChecker",
+    "HTTPAck",
+    "HTTPBinding",
+    "HTTPMediaType",
+    "HTTPRequestBody",
+    "HTTPSecretRef",
+    "HTTPSecurityScheme",
     "Index",
     "IndexedDB",
     "IndexSchema",
@@ -155,6 +182,7 @@ __all__ = [
     "PresignOptions",
     "PresignResult",
     "ProviderKind",
+    "PluginManifestMetadata",
     "ProviderMetadata",
     "Request",
     "Response",

--- a/sdk/python/gestalt/_manifest_metadata.py
+++ b/sdk/python/gestalt/_manifest_metadata.py
@@ -1,0 +1,108 @@
+"""Generated manifest metadata helpers for integration plugins."""
+
+import copy
+import pathlib
+from collections.abc import Mapping
+from typing import Any
+
+import yaml
+from typing_extensions import NotRequired, TypedDict
+
+
+class HTTPSecretRef(TypedDict, total=False):
+    env: str
+    secret: str
+
+
+HTTPSecurityScheme = TypedDict(
+    "HTTPSecurityScheme",
+    {
+        "type": str,
+        "description": str,
+        "name": str,
+        "in": str,
+        "scheme": str,
+        "secret": HTTPSecretRef,
+    },
+    total=False,
+)
+
+
+class HTTPMediaType(TypedDict, total=False):
+    pass
+
+
+class HTTPRequestBody(TypedDict, total=False):
+    required: bool
+    content: dict[str, HTTPMediaType]
+
+
+class HTTPAck(TypedDict, total=False):
+    status: int
+    headers: dict[str, str]
+    body: Any
+
+
+class HTTPBinding(TypedDict):
+    path: str
+    method: str
+    security: str
+    target: str
+    requestBody: NotRequired[HTTPRequestBody]
+    ack: NotRequired[HTTPAck]
+
+
+class PluginManifestMetadata(TypedDict, total=False):
+    securitySchemes: dict[str, HTTPSecurityScheme]
+    http: dict[str, HTTPBinding]
+
+
+def has_plugin_manifest_metadata(
+    metadata: PluginManifestMetadata | Mapping[str, Any] | None,
+) -> bool:
+    """Report whether manifest metadata contains HTTP bindings or security schemes."""
+
+    return bool(
+        metadata
+        and (
+            bool(metadata.get("securitySchemes"))
+            or bool(metadata.get("http"))
+        )
+    )
+
+
+def manifest_metadata_to_dict(
+    metadata: PluginManifestMetadata | Mapping[str, Any],
+) -> dict[str, Any]:
+    """Normalize manifest metadata to plain Python data."""
+
+    if "securitySchemes" not in metadata and "http" not in metadata:
+        return copy.deepcopy({key: value for key, value in metadata.items()})
+
+    output: dict[str, Any] = {}
+    security_schemes = metadata.get("securitySchemes")
+    if security_schemes:
+        output["securitySchemes"] = copy.deepcopy(dict(security_schemes))
+
+    http_bindings = metadata.get("http")
+    if http_bindings:
+        output["http"] = copy.deepcopy(dict(http_bindings))
+
+    return output
+
+
+def write_manifest_metadata(
+    path: str | pathlib.Path,
+    *,
+    metadata: PluginManifestMetadata | Mapping[str, Any],
+) -> None:
+    """Write manifest metadata to YAML on disk."""
+
+    manifest_path = pathlib.Path(path)
+    manifest_path.parent.mkdir(parents=True, exist_ok=True)
+    data = yaml.dump(
+        manifest_metadata_to_dict(metadata),
+        default_flow_style=False,
+        sort_keys=False,
+    )
+    manifest_path.write_text(data, encoding="utf-8")

--- a/sdk/python/gestalt/_plugin.py
+++ b/sdk/python/gestalt/_plugin.py
@@ -1,11 +1,13 @@
 """Plugin registration and decorator helpers for integration providers."""
 
+import copy
 import inspect
 import json
 import pathlib
 import re
 import sys
 import types
+from collections.abc import Mapping
 from typing import Any, Final
 
 import yaml
@@ -17,6 +19,13 @@ from ._catalog import (
     build_catalog,
     catalog_to_dict,
     write_catalog,
+)
+from ._manifest_metadata import (
+    HTTPBinding,
+    HTTPSecurityScheme,
+    PluginManifestMetadata,
+    has_plugin_manifest_metadata,
+    write_manifest_metadata,
 )
 from ._operations import (
     OperationDefinition,
@@ -49,12 +58,51 @@ class Plugin(SessionCatalogProvider):
             return {"query": params.query}
     """
 
-    def __init__(self, name: str, *, module_name: str | None = None) -> None:
+    def __init__(
+        self,
+        name: str,
+        *,
+        module_name: str | None = None,
+        security_schemes: Mapping[str, HTTPSecurityScheme] | None = None,
+        securitySchemes: Mapping[str, HTTPSecurityScheme] | None = None,
+        http: Mapping[str, HTTPBinding] | None = None,
+    ) -> None:
+        if security_schemes is not None and securitySchemes is not None:
+            raise ValueError(
+                "security_schemes and securitySchemes cannot both be provided"
+            )
+
         self.name = _slug_name(name)
         self._module_name = module_name
         self._operations: dict[str, OperationDefinition] = {}
         self._configure_handler: Any = None
         self._session_catalog_handler: tuple[Any, bool] | None = None
+        self._security_schemes = copy.deepcopy(
+            dict(
+                security_schemes
+                if security_schemes is not None
+                else securitySchemes or {}
+            )
+        )
+        self._http = copy.deepcopy(dict(http or {}))
+
+    @property
+    def security_schemes(self) -> dict[str, HTTPSecurityScheme]:
+        """Return generated manifest security schemes."""
+
+        return copy.deepcopy(self._security_schemes)
+
+    @property
+    def securitySchemes(self) -> dict[str, HTTPSecurityScheme]:
+        """TypeScript-shaped alias for generated manifest security schemes."""
+
+        return self.security_schemes
+
+    @property
+    def http(self) -> dict[str, HTTPBinding]:
+        """Return generated hosted HTTP binding metadata."""
+
+        return copy.deepcopy(self._http)
 
     @classmethod
     def from_manifest(
@@ -160,6 +208,29 @@ class Plugin(SessionCatalogProvider):
         """Write the static plugin catalog to disk."""
 
         write_catalog(path, catalog=self._static_catalog())
+
+    def static_manifest_metadata(self) -> PluginManifestMetadata:
+        """Return generated manifest-backed HTTP/security metadata."""
+
+        metadata: PluginManifestMetadata = {}
+        if self._security_schemes:
+            metadata["securitySchemes"] = copy.deepcopy(self._security_schemes)
+        if self._http:
+            metadata["http"] = copy.deepcopy(self._http)
+        return metadata
+
+    def supports_manifest_metadata(self) -> bool:
+        """Report whether the plugin exposes generated manifest metadata."""
+
+        return has_plugin_manifest_metadata(self.static_manifest_metadata())
+
+    def write_manifest_metadata(self, path: str | pathlib.Path) -> None:
+        """Write generated manifest metadata to disk as YAML."""
+
+        metadata = self.static_manifest_metadata()
+        if not has_plugin_manifest_metadata(metadata):
+            return
+        write_manifest_metadata(path, metadata=metadata)
 
     def supports_session_catalog(self) -> bool:
         """Report whether the plugin exposes a session catalog hook."""

--- a/sdk/python/gestalt/_providers.py
+++ b/sdk/python/gestalt/_providers.py
@@ -6,19 +6,44 @@ these helpers document the handwritten provider interfaces that wrap those
 messages.
 """
 
+from __future__ import annotations
+
 import datetime as dt
 from enum import Enum
-from typing import Any, Callable
+from importlib import import_module
+from typing import TYPE_CHECKING, Any, Callable
 
-from ._cache import CacheEntry
 from .gen.v1 import authentication_pb2 as _authentication_pb2
-from .gen.v1 import s3_pb2_grpc as _s3_pb2_grpc
-from .gen.v1 import workflow_pb2_grpc as _workflow_pb2_grpc
+
+if TYPE_CHECKING:
+    from ._cache import CacheEntry
+
+_s3_pb2_grpc: Any | None
+_workflow_pb2_grpc: Any | None
+
+try:
+    _s3_pb2_grpc = import_module(".gen.v1.s3_pb2_grpc", __package__)
+    _workflow_pb2_grpc = import_module(".gen.v1.workflow_pb2_grpc", __package__)
+except ModuleNotFoundError as exc:
+    if exc.name != "grpc":
+        raise
+    _s3_pb2_grpc = None
+    _workflow_pb2_grpc = None
 
 AuthenticatedUser: Any = _authentication_pb2.AuthenticatedUser  # ty: ignore[unresolved-attribute]
 BeginLoginRequest: Any = _authentication_pb2.BeginLoginRequest  # ty: ignore[unresolved-attribute]
 BeginLoginResponse: Any = _authentication_pb2.BeginLoginResponse  # ty: ignore[unresolved-attribute]
 CompleteLoginRequest: Any = _authentication_pb2.CompleteLoginRequest  # ty: ignore[unresolved-attribute]
+
+if _s3_pb2_grpc is None:
+    _S3ServicerBase = object
+else:
+    _S3ServicerBase = _s3_pb2_grpc.S3Servicer
+
+if _workflow_pb2_grpc is None:
+    _WorkflowProviderServicerBase = object
+else:
+    _WorkflowProviderServicerBase = _workflow_pb2_grpc.WorkflowProviderServicer
 
 
 class ProviderKind(str, Enum):
@@ -238,7 +263,7 @@ class CacheProvider(PluginProvider):
         _runtime.serve(self, runtime_kind=ProviderKind.CACHE)
 
 
-class S3Provider(PluginProvider, _s3_pb2_grpc.S3Servicer):
+class S3Provider(PluginProvider, _S3ServicerBase):
     """Base class for S3-compatible object store runtimes."""
 
     def serve(self) -> None:
@@ -249,7 +274,7 @@ class S3Provider(PluginProvider, _s3_pb2_grpc.S3Servicer):
         _runtime.serve(self, runtime_kind=ProviderKind.S3)
 
 
-class WorkflowProvider(PluginProvider, _workflow_pb2_grpc.WorkflowProviderServicer):
+class WorkflowProvider(PluginProvider, _WorkflowProviderServicerBase):
     def serve(self) -> None:
         from . import _runtime
 

--- a/sdk/python/gestalt/_runtime.py
+++ b/sdk/python/gestalt/_runtime.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 import datetime as dt
 import functools
 import importlib
@@ -11,14 +13,10 @@ from dataclasses import dataclass
 from http import HTTPStatus
 from typing import Any, Final, cast
 
-import grpc
-from google.protobuf import duration_pb2 as _duration_pb2
-from google.protobuf import empty_pb2 as _empty_pb2
 from google.protobuf import json_format
 
 from ._api import Access, Credential, Request, Subject
 from ._bootstrap import parse_plugin_target, read_bundled_plugin_config
-from ._cache import CacheEntry
 from ._catalog import catalog_to_proto
 from ._operations import INTERNAL_ERROR_MESSAGE
 from ._plugin import Plugin, _module_plugin
@@ -40,43 +38,90 @@ from ._providers import (
     WorkflowProvider,
 )
 from ._serialization import json_body
-from .gen.v1 import authentication_pb2 as _authentication_pb2
-from .gen.v1 import authentication_pb2_grpc as _authentication_pb2_grpc
-from .gen.v1 import cache_pb2 as _cache_pb2
-from .gen.v1 import cache_pb2_grpc as _cache_pb2_grpc
-from .gen.v1 import plugin_pb2 as _plugin_pb2
-from .gen.v1 import plugin_pb2_grpc as _plugin_pb2_grpc
-from .gen.v1 import runtime_pb2 as _runtime_pb2
-from .gen.v1 import runtime_pb2_grpc as _runtime_pb2_grpc
-from .gen.v1 import s3_pb2_grpc as _s3_pb2_grpc
-from .gen.v1 import secrets_pb2 as _secrets_pb2
-from .gen.v1 import secrets_pb2_grpc as _secrets_pb2_grpc
-from .gen.v1 import workflow_pb2 as _workflow_pb2
-from .gen.v1 import workflow_pb2_grpc as _workflow_pb2_grpc
 
-empty_pb2: Any = _empty_pb2
-duration_pb2: Any = _duration_pb2
-plugin_pb2: Any = _plugin_pb2
-plugin_pb2_grpc: Any = _plugin_pb2_grpc
-runtime_pb2: Any = _runtime_pb2
-runtime_pb2_grpc: Any = _runtime_pb2_grpc
-authentication_pb2: Any = _authentication_pb2
-cache_pb2: Any = _cache_pb2
-cache_pb2_grpc: Any = _cache_pb2_grpc
-s3_pb2_grpc: Any = _s3_pb2_grpc
-secrets_pb2: Any = _secrets_pb2
-secrets_pb2_grpc: Any = _secrets_pb2_grpc
-workflow_pb2: Any = _workflow_pb2
-workflow_pb2_grpc: Any = _workflow_pb2_grpc
+grpc: Any = None
+empty_pb2: Any = None
+duration_pb2: Any = None
+plugin_pb2: Any = None
+plugin_pb2_grpc: Any = None
+runtime_pb2: Any = None
+runtime_pb2_grpc: Any = None
+authentication_pb2: Any = None
+authentication_pb2_grpc: Any = None
+cache_pb2: Any = None
+cache_pb2_grpc: Any = None
+s3_pb2_grpc: Any = None
+secrets_pb2: Any = None
+secrets_pb2_grpc: Any = None
+workflow_pb2: Any = None
+workflow_pb2_grpc: Any = None
 
 ENV_PROVIDER_SOCKET: Final[str] = "GESTALT_PLUGIN_SOCKET"
 ENV_WRITE_CATALOG: Final[str] = "GESTALT_PLUGIN_WRITE_CATALOG"
+ENV_WRITE_MANIFEST_METADATA: Final[str] = "GESTALT_PLUGIN_WRITE_MANIFEST_METADATA"
 CURRENT_PROTOCOL_VERSION: Final[int] = 3
 GRPC_SERVER_MAX_WORKERS: Final[int] = 4
 GRPC_SHUTDOWN_GRACE_SECONDS: Final[int] = 2
 USAGE: Final[str] = (
     "usage: python -m gestalt._runtime ROOT MODULE[:ATTRIBUTE] [RUNTIME_KIND]"
 )
+
+
+def _ensure_grpc_runtime() -> None:
+    global authentication_pb2
+    global authentication_pb2_grpc
+    global cache_pb2
+    global cache_pb2_grpc
+    global duration_pb2
+    global empty_pb2
+    global grpc
+    global plugin_pb2
+    global plugin_pb2_grpc
+    global runtime_pb2
+    global runtime_pb2_grpc
+    global s3_pb2_grpc
+    global secrets_pb2
+    global secrets_pb2_grpc
+    global workflow_pb2
+    global workflow_pb2_grpc
+
+    if grpc is not None:
+        return
+
+    import grpc as _grpc
+    from google.protobuf import duration_pb2 as _duration_pb2
+    from google.protobuf import empty_pb2 as _empty_pb2
+
+    from .gen.v1 import authentication_pb2 as _authentication_pb2
+    from .gen.v1 import authentication_pb2_grpc as _authentication_pb2_grpc
+    from .gen.v1 import cache_pb2 as _cache_pb2
+    from .gen.v1 import cache_pb2_grpc as _cache_pb2_grpc
+    from .gen.v1 import plugin_pb2 as _plugin_pb2
+    from .gen.v1 import plugin_pb2_grpc as _plugin_pb2_grpc
+    from .gen.v1 import runtime_pb2 as _runtime_pb2
+    from .gen.v1 import runtime_pb2_grpc as _runtime_pb2_grpc
+    from .gen.v1 import s3_pb2_grpc as _s3_pb2_grpc
+    from .gen.v1 import secrets_pb2 as _secrets_pb2
+    from .gen.v1 import secrets_pb2_grpc as _secrets_pb2_grpc
+    from .gen.v1 import workflow_pb2 as _workflow_pb2
+    from .gen.v1 import workflow_pb2_grpc as _workflow_pb2_grpc
+
+    grpc = _grpc
+    duration_pb2 = _duration_pb2
+    empty_pb2 = _empty_pb2
+    plugin_pb2 = _plugin_pb2
+    plugin_pb2_grpc = _plugin_pb2_grpc
+    runtime_pb2 = _runtime_pb2
+    runtime_pb2_grpc = _runtime_pb2_grpc
+    authentication_pb2 = _authentication_pb2
+    authentication_pb2_grpc = _authentication_pb2_grpc
+    cache_pb2 = _cache_pb2
+    cache_pb2_grpc = _cache_pb2_grpc
+    s3_pb2_grpc = _s3_pb2_grpc
+    secrets_pb2 = _secrets_pb2
+    secrets_pb2_grpc = _secrets_pb2_grpc
+    workflow_pb2 = _workflow_pb2
+    workflow_pb2_grpc = _workflow_pb2_grpc
 
 
 @dataclass(frozen=True)
@@ -91,6 +136,7 @@ def _grpc_handler(label: str):
     def decorator(fn):
         @functools.wraps(fn)
         def wrapper(self, request, context):
+            _ensure_grpc_runtime()
             try:
                 return fn(self, request, context)
             except Exception as error:
@@ -108,6 +154,7 @@ def _abort_if_protocol_version_mismatch(
     protocol_version: int,
     context: Any,
 ) -> bool:
+    _ensure_grpc_runtime()
     if protocol_version == CURRENT_PROTOCOL_VERSION:
         return False
     context.abort(
@@ -122,6 +169,7 @@ def serve(
     *,
     runtime_kind: ProviderKind | str | None = None,
 ) -> None:
+    _ensure_grpc_runtime()
     socket_path = _socket_path_from_env()
     _remove_stale_socket(socket_path)
 
@@ -151,12 +199,16 @@ def main(argv: list[str] | None = None) -> int:
         target.name = runtime_args.plugin_name
 
     catalog_path = os.environ.get(ENV_WRITE_CATALOG)
-    if catalog_path:
+    manifest_metadata_path = os.environ.get(ENV_WRITE_MANIFEST_METADATA)
+    if catalog_path or manifest_metadata_path:
         if not isinstance(target, Plugin):
             raise RuntimeError(
-                "catalog export is only supported for integration plugins"
+                "catalog and manifest metadata export are only supported for integration plugins"
             )
-        target.write_catalog(catalog_path)
+        if catalog_path:
+            target.write_catalog(catalog_path)
+        if manifest_metadata_path:
+            target.write_manifest_metadata(manifest_metadata_path)
         return 0
 
     serve(target, runtime_kind=runtime_args.runtime_kind)
@@ -269,6 +321,7 @@ def _register_shutdown_handlers(server: Any, close_provider: Any) -> None:
 def _register_services(
     *, server: Any, servable: Plugin | PluginProviderAdapter
 ) -> None:
+    _ensure_grpc_runtime()
     if isinstance(servable, Plugin):
         plugin_pb2_grpc.add_IntegrationProviderServicer_to_server(
             _provider_servicer(plugin=servable),
@@ -329,11 +382,12 @@ def _authentication_runtime_plugin(
 
 
 def _register_authentication_services(server: Any, provider: PluginProvider) -> None:
+    _ensure_grpc_runtime()
     runtime_pb2_grpc.add_ProviderLifecycleServicer_to_server(
         _runtime_servicer(provider=provider, kind=ProviderKind.AUTHENTICATION),
         server,
     )
-    _authentication_pb2_grpc.add_AuthenticationProviderServicer_to_server(
+    authentication_pb2_grpc.add_AuthenticationProviderServicer_to_server(
         _authentication_servicer(provider=provider),
         server,
     )
@@ -348,6 +402,7 @@ def _s3_runtime_plugin(provider: S3Provider) -> PluginProviderAdapter:
 
 
 def _register_s3_services(server: Any, provider: PluginProvider) -> None:
+    _ensure_grpc_runtime()
     runtime_pb2_grpc.add_ProviderLifecycleServicer_to_server(
         _runtime_servicer(provider=provider, kind=ProviderKind.S3),
         server,
@@ -364,6 +419,7 @@ def _workflow_runtime_plugin(provider: WorkflowProvider) -> PluginProviderAdapte
 
 
 def _register_workflow_services(server: Any, provider: PluginProvider) -> None:
+    _ensure_grpc_runtime()
     runtime_pb2_grpc.add_ProviderLifecycleServicer_to_server(
         _runtime_servicer(provider=provider, kind=ProviderKind.WORKFLOW),
         server,
@@ -380,6 +436,7 @@ def _secrets_runtime_plugin(provider: SecretsProvider) -> PluginProviderAdapter:
 
 
 def _register_secrets_services(server: Any, provider: PluginProvider) -> None:
+    _ensure_grpc_runtime()
     runtime_pb2_grpc.add_ProviderLifecycleServicer_to_server(
         _runtime_servicer(provider=provider, kind=ProviderKind.SECRETS),
         server,
@@ -399,6 +456,7 @@ def _cache_runtime_plugin(provider: CacheProvider) -> PluginProviderAdapter:
 
 
 def _register_cache_services(server: Any, provider: PluginProvider) -> None:
+    _ensure_grpc_runtime()
     runtime_pb2_grpc.add_ProviderLifecycleServicer_to_server(
         _runtime_servicer(provider=provider, kind=ProviderKind.CACHE),
         server,
@@ -410,6 +468,7 @@ def _register_cache_services(server: Any, provider: PluginProvider) -> None:
 
 
 def _provider_servicer(*, plugin: Plugin) -> Any:
+    _ensure_grpc_runtime()
     class ProviderServicer(plugin_pb2_grpc.IntegrationProviderServicer):
         def GetMetadata(self, _request: Any, _context: Any) -> Any:
             return plugin_pb2.ProviderMetadata(
@@ -481,6 +540,7 @@ def _provider_servicer(*, plugin: Plugin) -> Any:
 
 
 def _runtime_servicer(*, provider: PluginProvider, kind: ProviderKind) -> Any:
+    _ensure_grpc_runtime()
     class RuntimeServicer(runtime_pb2_grpc.ProviderLifecycleServicer):
         def GetProviderIdentity(self, _request: Any, _context: Any) -> Any:
             metadata = _provider_metadata(provider=provider, kind=kind)
@@ -525,9 +585,10 @@ def _runtime_servicer(*, provider: PluginProvider, kind: ProviderKind) -> Any:
 
 
 def _authentication_servicer(*, provider: PluginProvider) -> Any:
+    _ensure_grpc_runtime()
     auth_provider = cast(AuthenticationProvider, provider)
 
-    class AuthenticationServicer(_authentication_pb2_grpc.AuthenticationProviderServicer):
+    class AuthenticationServicer(authentication_pb2_grpc.AuthenticationProviderServicer):
         @_grpc_handler("begin login")
         def BeginLogin(self, request: Any, context: Any) -> Any:
             response = auth_provider.begin_login(request)
@@ -585,6 +646,7 @@ def _authentication_servicer(*, provider: PluginProvider) -> Any:
 
 
 def _secrets_servicer(*, provider: PluginProvider) -> Any:
+    _ensure_grpc_runtime()
     secrets_provider = cast(SecretsProvider, provider)
 
     class SecretsServicer(secrets_pb2_grpc.SecretsProviderServicer):
@@ -597,6 +659,9 @@ def _secrets_servicer(*, provider: PluginProvider) -> Any:
 
 
 def _cache_servicer(*, provider: PluginProvider) -> Any:
+    _ensure_grpc_runtime()
+    from ._cache import CacheEntry
+
     cache_provider = cast(CacheProvider, provider)
 
     class CacheServicer(cache_pb2_grpc.CacheServicer):
@@ -765,6 +830,7 @@ def _provider_warnings(provider: PluginProvider) -> list[str]:
 
 
 def _provider_kind_to_proto(kind: ProviderKind | str) -> Any:
+    _ensure_grpc_runtime()
     normalized = _normalized_runtime_kind(kind)
     return {
         ProviderKind.INTEGRATION: runtime_pb2.ProviderKind.PROVIDER_KIND_INTEGRATION,

--- a/sdk/python/gestalt/gen/v1/__init__.py
+++ b/sdk/python/gestalt/gen/v1/__init__.py
@@ -1,23 +1,6 @@
 # Generated Python protobuf modules for gestalt.provider.v1.
 
-from . import (
-    authentication_pb2,
-    authentication_pb2_grpc,
-    cache_pb2,
-    cache_pb2_grpc,
-    datastore_pb2,
-    datastore_pb2_grpc,
-    plugin_pb2,
-    plugin_pb2_grpc,
-    runtime_pb2,
-    runtime_pb2_grpc,
-    s3_pb2,
-    s3_pb2_grpc,
-    secrets_pb2,
-    secrets_pb2_grpc,
-    workflow_pb2,
-    workflow_pb2_grpc,
-)
+from importlib import import_module
 
 __all__ = [
     "authentication_pb2",
@@ -37,3 +20,11 @@ __all__ = [
     "workflow_pb2",
     "workflow_pb2_grpc",
 ]
+
+
+def __getattr__(name: str):
+    if name not in __all__:
+        raise AttributeError(f"module {__name__!r} has no attribute {name!r}")
+    module = import_module(f".{name}", __name__)
+    globals()[name] = module
+    return module

--- a/sdk/python/tests/test_plugin.py
+++ b/sdk/python/tests/test_plugin.py
@@ -234,6 +234,58 @@ class PluginCatalogTests(unittest.TestCase):
             content = path.read_text(encoding="utf-8")
             self.assertIn("test-plugin", content)
 
+    def test_static_manifest_metadata(self) -> None:
+        plugin = Plugin(
+            "test-plugin",
+            securitySchemes={
+                "slack": {
+                    "type": "slack_signature",
+                    "secret": {"env": "SLACK_SIGNING_SECRET"},
+                }
+            },
+            http={
+                "command": {
+                    "path": "/command",
+                    "method": "POST",
+                    "security": "slack",
+                    "target": "handle_command",
+                    "requestBody": {
+                        "required": True,
+                        "content": {
+                            "application/x-www-form-urlencoded": {},
+                        },
+                    },
+                    "ack": {
+                        "status": 200,
+                        "body": {
+                            "response_type": "ephemeral",
+                            "text": "Working on it...",
+                        },
+                    },
+                }
+            },
+        )
+
+        self.assertTrue(plugin.supports_manifest_metadata())
+        self.assertEqual(
+            plugin.securitySchemes["slack"]["secret"]["env"],
+            "SLACK_SIGNING_SECRET",
+        )
+        self.assertEqual(plugin.http["command"]["path"], "/command")
+
+        metadata = plugin.static_manifest_metadata()
+        self.assertEqual(
+            metadata["securitySchemes"]["slack"]["type"],
+            "slack_signature",
+        )
+        self.assertEqual(metadata["http"]["command"]["target"], "handle_command")
+
+        metadata["securitySchemes"]["slack"]["type"] = "none"
+        self.assertEqual(
+            plugin.static_manifest_metadata()["securitySchemes"]["slack"]["type"],
+            "slack_signature",
+        )
+
 
 class PluginNameTests(unittest.TestCase):
     """Tests for plugin name normalization."""

--- a/sdk/python/tests/test_runtime.py
+++ b/sdk/python/tests/test_runtime.py
@@ -223,8 +223,37 @@ class RequestTests(unittest.TestCase):
 
 
 class MainEntrypointTests(unittest.TestCase):
-    def test_writes_catalog_when_env_is_set(self) -> None:
-        plugin = Plugin("test-plugin")
+    def test_writes_catalog_and_manifest_metadata_when_envs_are_set(self) -> None:
+        plugin = Plugin(
+            "test-plugin",
+            securitySchemes={
+                "slack": {
+                    "type": "slack_signature",
+                    "secret": {"env": "SLACK_SIGNING_SECRET"},
+                }
+            },
+            http={
+                "command": {
+                    "path": "/command",
+                    "method": "POST",
+                    "security": "slack",
+                    "target": "noop",
+                    "requestBody": {
+                        "required": True,
+                        "content": {
+                            "application/x-www-form-urlencoded": {},
+                        },
+                    },
+                    "ack": {
+                        "status": 200,
+                        "body": {
+                            "response_type": "ephemeral",
+                            "text": "Working on it...",
+                        },
+                    },
+                }
+            },
+        )
 
         @plugin.operation
         def noop() -> str:
@@ -232,11 +261,15 @@ class MainEntrypointTests(unittest.TestCase):
 
         with tempfile.TemporaryDirectory() as tmpdir:
             catalog_path = pathlib.Path(tmpdir) / "catalog.yaml"
+            metadata_path = pathlib.Path(tmpdir) / "manifest-metadata.yaml"
             with (
                 mock.patch.object(_runtime, "_load_target", return_value=plugin),
                 mock.patch.dict(
                     _runtime.os.environ,
-                    {_runtime.ENV_WRITE_CATALOG: str(catalog_path)},
+                    {
+                        _runtime.ENV_WRITE_CATALOG: str(catalog_path),
+                        _runtime.ENV_WRITE_MANIFEST_METADATA: str(metadata_path),
+                    },
                     clear=True,
                 ),
             ):
@@ -244,6 +277,16 @@ class MainEntrypointTests(unittest.TestCase):
 
             self.assertEqual(result, 0)
             self.assertTrue(catalog_path.exists())
+            self.assertTrue(metadata_path.exists())
+            metadata = metadata_path.read_text(encoding="utf-8")
+            self.assertIn("securitySchemes:", metadata)
+            self.assertIn("type: slack_signature", metadata)
+            self.assertIn("env: SLACK_SIGNING_SECRET", metadata)
+            self.assertIn("http:", metadata)
+            self.assertIn("path: /command", metadata)
+            self.assertIn("target: noop", metadata)
+            self.assertIn("application/x-www-form-urlencoded", metadata)
+            self.assertIn("response_type: ephemeral", metadata)
 
     def test_returns_usage_error_for_bad_args(self) -> None:
         result = _runtime.main(["/only-one-arg"])

--- a/sdk/rust/Cargo.toml
+++ b/sdk/rust/Cargo.toml
@@ -20,6 +20,7 @@ prost-types = "0.14"
 schemars = { version = "0.8", features = ["derive"] }
 serde = { version = "1", features = ["derive"] }
 serde_json = "1"
+serde_yaml = "0.9"
 thiserror = "2"
 tokio = { version = "1", features = ["macros", "net", "rt-multi-thread", "signal", "time"] }
 tokio-stream = { version = "0.1", features = ["net"] }

--- a/sdk/rust/src/env.rs
+++ b/sdk/rust/src/env.rs
@@ -5,6 +5,8 @@ pub const ENV_PROVIDER_SOCKET: &str = "GESTALT_PLUGIN_SOCKET";
 pub const ENV_PROVIDER_PARENT_PID: &str = "GESTALT_PLUGIN_PARENT_PID";
 /// Optional path where the runtime should write the derived static catalog.
 pub const ENV_WRITE_CATALOG: &str = "GESTALT_PLUGIN_WRITE_CATALOG";
+/// Optional path where the runtime should write generated manifest metadata.
+pub const ENV_WRITE_MANIFEST_METADATA: &str = "GESTALT_PLUGIN_WRITE_MANIFEST_METADATA";
 /// Provider name override supplied by the host runtime.
 pub const ENV_PROVIDER_NAME: &str = "GESTALT_PLUGIN_NAME";
 /// Current Gestalt provider protocol version spoken by this SDK.

--- a/sdk/rust/src/lib.rs
+++ b/sdk/rust/src/lib.rs
@@ -13,6 +13,7 @@ mod generated;
 /// IndexedDB-style datastore client and provider helpers.
 pub mod indexeddb;
 mod invoker;
+mod manifest_metadata;
 mod provider_server;
 mod router;
 mod rpc_status;
@@ -41,11 +42,15 @@ pub use cache::{
     cache_socket_env,
 };
 pub use catalog::{Catalog, CatalogOperation};
-pub use env::{CURRENT_PROTOCOL_VERSION, ENV_PROVIDER_SOCKET};
+pub use env::{CURRENT_PROTOCOL_VERSION, ENV_PROVIDER_SOCKET, ENV_WRITE_MANIFEST_METADATA};
 pub use error::{Error, Result};
 pub use indexeddb::{Cursor, CursorDirection, IndexedDB, IndexedDBError};
 pub use invoker::{
     ENV_PLUGIN_INVOKER_SOCKET, InvocationGrant, InvokeOptions, PluginInvoker, PluginInvokerError,
+};
+pub use manifest_metadata::{
+    HTTPAck, HTTPAuthScheme, HTTPBinding, HTTPIn, HTTPMediaType, HTTPRequestBody, HTTPSecretRef,
+    HTTPSecurityScheme, HTTPSecuritySchemeType, PluginManifestMetadata,
 };
 #[doc(hidden)]
 pub use provider_server::{OperationResult, ProviderServer};
@@ -94,7 +99,14 @@ macro_rules! export_provider {
 
         pub fn __gestalt_write_catalog(name: &str, path: &str) -> $crate::Result<()> {
             let router = $crate::into_router_result($router())?.with_name(name);
-            $crate::runtime::write_catalog_path(&router, path)
+            $crate::runtime::write_catalog_path(&router, path)?;
+            $crate::runtime::maybe_write_manifest_metadata(&router)?;
+            Ok(())
+        }
+
+        pub fn __gestalt_write_manifest_metadata(_name: &str, path: &str) -> $crate::Result<()> {
+            let router = $crate::into_router_result($router())?;
+            $crate::runtime::write_manifest_metadata_path(&router, path)
         }
     };
 }

--- a/sdk/rust/src/manifest_metadata.rs
+++ b/sdk/rust/src/manifest_metadata.rs
@@ -1,0 +1,369 @@
+use std::collections::BTreeMap;
+use std::path::Path;
+
+use serde::{Deserialize, Serialize};
+use serde_json::Value as JsonValue;
+
+use crate::error::{Error, Result};
+
+/// Optional manifest metadata emitted for code-defined hosted HTTP bindings.
+#[derive(Clone, Debug, Default, Eq, PartialEq, Serialize, Deserialize)]
+pub struct PluginManifestMetadata {
+    #[serde(
+        rename = "securitySchemes",
+        default,
+        skip_serializing_if = "BTreeMap::is_empty"
+    )]
+    pub security_schemes: BTreeMap<String, HTTPSecurityScheme>,
+    #[serde(default, skip_serializing_if = "BTreeMap::is_empty")]
+    pub http: BTreeMap<String, HTTPBinding>,
+}
+
+impl PluginManifestMetadata {
+    /// Creates empty manifest metadata.
+    pub fn new() -> Self {
+        Self::default()
+    }
+
+    /// Returns `true` when no manifest metadata has been configured.
+    pub fn is_empty(&self) -> bool {
+        self.security_schemes.is_empty() && self.http.is_empty()
+    }
+
+    /// Inserts or replaces one named HTTP security scheme.
+    pub fn security_scheme(mut self, name: impl Into<String>, scheme: HTTPSecurityScheme) -> Self {
+        let name = name.into().trim().to_owned();
+        if !name.is_empty() {
+            self.security_schemes.insert(name, scheme);
+        }
+        self
+    }
+
+    /// Inserts or replaces one named hosted HTTP binding.
+    pub fn http_binding(mut self, name: impl Into<String>, binding: HTTPBinding) -> Self {
+        let name = name.into().trim().to_owned();
+        if !name.is_empty() {
+            self.http.insert(name, binding);
+        }
+        self
+    }
+}
+
+/// Supported manifest HTTP security scheme kinds.
+#[derive(Clone, Copy, Debug, Eq, PartialEq, Serialize, Deserialize)]
+pub enum HTTPSecuritySchemeType {
+    #[serde(rename = "slack_signature")]
+    SlackSignature,
+    #[serde(rename = "apiKey")]
+    ApiKey,
+    #[serde(rename = "http")]
+    Http,
+    #[serde(rename = "none")]
+    None,
+}
+
+/// Location for HTTP API key credentials.
+#[derive(Clone, Copy, Debug, Eq, PartialEq, Serialize, Deserialize)]
+#[serde(rename_all = "lowercase")]
+pub enum HTTPIn {
+    Header,
+    Query,
+}
+
+/// HTTP authorization scheme kinds supported by hosted bindings.
+#[derive(Clone, Copy, Debug, Eq, PartialEq, Serialize, Deserialize)]
+#[serde(rename_all = "lowercase")]
+pub enum HTTPAuthScheme {
+    Basic,
+    Bearer,
+}
+
+/// Secret reference used by generated hosted HTTP bindings.
+#[derive(Clone, Debug, Default, Eq, PartialEq, Serialize, Deserialize)]
+pub struct HTTPSecretRef {
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub env: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub secret: Option<String>,
+}
+
+impl HTTPSecretRef {
+    /// Creates an empty secret reference.
+    pub fn new() -> Self {
+        Self::default()
+    }
+
+    /// References a process environment variable.
+    pub fn env(mut self, env: impl Into<String>) -> Self {
+        let env = env.into().trim().to_owned();
+        if !env.is_empty() {
+            self.env = Some(env);
+        }
+        self
+    }
+
+    /// References a named host secret.
+    pub fn secret(mut self, secret: impl Into<String>) -> Self {
+        let secret = secret.into().trim().to_owned();
+        if !secret.is_empty() {
+            self.secret = Some(secret);
+        }
+        self
+    }
+}
+
+/// One hosted HTTP security scheme definition.
+#[derive(Clone, Debug, Default, Eq, PartialEq, Serialize, Deserialize)]
+pub struct HTTPSecurityScheme {
+    #[serde(rename = "type", skip_serializing_if = "Option::is_none")]
+    pub kind: Option<HTTPSecuritySchemeType>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub description: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub name: Option<String>,
+    #[serde(rename = "in", skip_serializing_if = "Option::is_none")]
+    pub location: Option<HTTPIn>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub scheme: Option<HTTPAuthScheme>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub secret: Option<HTTPSecretRef>,
+}
+
+impl HTTPSecurityScheme {
+    /// Creates an empty security scheme definition.
+    pub fn new() -> Self {
+        Self::default()
+    }
+
+    /// Creates a Slack request-signing scheme.
+    pub fn slack_signature() -> Self {
+        Self::new().kind(HTTPSecuritySchemeType::SlackSignature)
+    }
+
+    /// Creates an API key scheme.
+    pub fn api_key(name: impl Into<String>, location: HTTPIn) -> Self {
+        Self::new()
+            .kind(HTTPSecuritySchemeType::ApiKey)
+            .name(name)
+            .location(location)
+    }
+
+    /// Creates an HTTP auth scheme like bearer or basic auth.
+    pub fn http(scheme: HTTPAuthScheme) -> Self {
+        Self::new()
+            .kind(HTTPSecuritySchemeType::Http)
+            .scheme(scheme)
+    }
+
+    /// Creates a no-auth scheme.
+    pub fn none() -> Self {
+        Self::new().kind(HTTPSecuritySchemeType::None)
+    }
+
+    /// Sets the scheme kind.
+    pub fn kind(mut self, kind: HTTPSecuritySchemeType) -> Self {
+        self.kind = Some(kind);
+        self
+    }
+
+    /// Sets a human-readable description.
+    pub fn description(mut self, description: impl Into<String>) -> Self {
+        let description = description.into().trim().to_owned();
+        if !description.is_empty() {
+            self.description = Some(description);
+        }
+        self
+    }
+
+    /// Sets the HTTP parameter name used by the scheme.
+    pub fn name(mut self, name: impl Into<String>) -> Self {
+        let name = name.into().trim().to_owned();
+        if !name.is_empty() {
+            self.name = Some(name);
+        }
+        self
+    }
+
+    /// Sets the location used by API key auth.
+    pub fn location(mut self, location: HTTPIn) -> Self {
+        self.location = Some(location);
+        self
+    }
+
+    /// Sets the HTTP auth scheme keyword.
+    pub fn scheme(mut self, scheme: HTTPAuthScheme) -> Self {
+        self.scheme = Some(scheme);
+        self
+    }
+
+    /// Attaches a secret reference.
+    pub fn secret(mut self, secret: HTTPSecretRef) -> Self {
+        self.secret = Some(secret);
+        self
+    }
+
+    /// Attaches an environment-variable secret reference.
+    pub fn secret_env(mut self, env: impl Into<String>) -> Self {
+        self.secret = Some(HTTPSecretRef::new().env(env));
+        self
+    }
+
+    /// Attaches a named secret reference.
+    pub fn secret_name(mut self, secret: impl Into<String>) -> Self {
+        self.secret = Some(HTTPSecretRef::new().secret(secret));
+        self
+    }
+}
+
+/// Marker object for a supported request media type.
+#[derive(Clone, Debug, Default, Eq, PartialEq, Serialize, Deserialize)]
+pub struct HTTPMediaType {}
+
+/// Hosted HTTP request-body description.
+#[derive(Clone, Debug, Default, Eq, PartialEq, Serialize, Deserialize)]
+pub struct HTTPRequestBody {
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub required: Option<bool>,
+    #[serde(default, skip_serializing_if = "BTreeMap::is_empty")]
+    pub content: BTreeMap<String, HTTPMediaType>,
+}
+
+impl HTTPRequestBody {
+    /// Creates an empty request-body definition.
+    pub fn new() -> Self {
+        Self::default()
+    }
+
+    /// Marks whether the request body is required.
+    pub fn required(mut self, required: bool) -> Self {
+        self.required = Some(required);
+        self
+    }
+
+    /// Adds a media type entry with an empty schema marker.
+    pub fn content_type(self, content_type: impl Into<String>) -> Self {
+        self.media_type(content_type, HTTPMediaType::default())
+    }
+
+    /// Adds a media type entry.
+    pub fn media_type(
+        mut self,
+        content_type: impl Into<String>,
+        media_type: HTTPMediaType,
+    ) -> Self {
+        let content_type = content_type.into().trim().to_owned();
+        if !content_type.is_empty() {
+            self.content.insert(content_type, media_type);
+        }
+        self
+    }
+}
+
+/// Immediate acknowledgement for a hosted HTTP binding.
+#[derive(Clone, Debug, Default, Eq, PartialEq, Serialize, Deserialize)]
+pub struct HTTPAck {
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub status: Option<u16>,
+    #[serde(default, skip_serializing_if = "BTreeMap::is_empty")]
+    pub headers: BTreeMap<String, String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub body: Option<JsonValue>,
+}
+
+impl HTTPAck {
+    /// Creates an empty acknowledgement response.
+    pub fn new() -> Self {
+        Self::default()
+    }
+
+    /// Sets the acknowledgement HTTP status.
+    pub fn status(mut self, status: u16) -> Self {
+        self.status = Some(status);
+        self
+    }
+
+    /// Adds a response header.
+    pub fn header(mut self, name: impl Into<String>, value: impl Into<String>) -> Self {
+        let name = name.into().trim().to_owned();
+        let value = value.into();
+        if !name.is_empty() {
+            self.headers.insert(name, value);
+        }
+        self
+    }
+
+    /// Sets the acknowledgement body.
+    pub fn body(mut self, body: JsonValue) -> Self {
+        self.body = Some(body);
+        self
+    }
+}
+
+/// Hosted HTTP binding definition.
+#[derive(Clone, Debug, Eq, PartialEq, Serialize, Deserialize)]
+pub struct HTTPBinding {
+    pub path: String,
+    pub method: String,
+    #[serde(rename = "requestBody", skip_serializing_if = "Option::is_none")]
+    pub request_body: Option<HTTPRequestBody>,
+    pub security: String,
+    pub target: String,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub ack: Option<HTTPAck>,
+}
+
+impl HTTPBinding {
+    /// Creates one hosted HTTP binding.
+    pub fn new(
+        path: impl Into<String>,
+        method: impl AsRef<str>,
+        security: impl Into<String>,
+        target: impl Into<String>,
+    ) -> Self {
+        Self {
+            path: path.into().trim().to_owned(),
+            method: normalize_method(method.as_ref()),
+            request_body: None,
+            security: security.into().trim().to_owned(),
+            target: target.into().trim().to_owned(),
+            ack: None,
+        }
+    }
+
+    /// Attaches request-body metadata.
+    pub fn request_body(mut self, request_body: HTTPRequestBody) -> Self {
+        self.request_body = Some(request_body);
+        self
+    }
+
+    /// Attaches an acknowledgement response.
+    pub fn ack(mut self, ack: HTTPAck) -> Self {
+        self.ack = Some(ack);
+        self
+    }
+}
+
+pub(crate) fn write_manifest_metadata(
+    metadata: &PluginManifestMetadata,
+    path: impl AsRef<Path>,
+) -> Result<()> {
+    let path = path.as_ref();
+    if let Some(parent) = path.parent()
+        && !parent.as_os_str().is_empty()
+    {
+        std::fs::create_dir_all(parent)?;
+    }
+    let yaml = serde_yaml::to_string(metadata)
+        .map_err(|error| Error::hidden_internal(error.to_string()))?;
+    std::fs::write(path, yaml)?;
+    Ok(())
+}
+
+fn normalize_method(method: &str) -> String {
+    let method = method.trim().to_ascii_uppercase();
+    if method.is_empty() {
+        "POST".to_owned()
+    } else {
+        method
+    }
+}

--- a/sdk/rust/src/router.rs
+++ b/sdk/rust/src/router.rs
@@ -13,6 +13,7 @@ use serde_json::Value;
 use crate::api::{IntoResponse, Request};
 use crate::catalog::{Catalog, CatalogOperation, schema_json, schema_parameters};
 use crate::error::{Error, INTERNAL_ERROR_MESSAGE, Result};
+use crate::manifest_metadata::{HTTPBinding, HTTPSecurityScheme, PluginManifestMetadata};
 use crate::provider_server::OperationResult;
 
 #[derive(Clone, Debug)]
@@ -104,6 +105,7 @@ type Handler<P> = Arc<
 /// Dispatches typed operations and exposes the corresponding static catalog.
 pub struct Router<P> {
     catalog: Catalog,
+    manifest_metadata: PluginManifestMetadata,
     handlers: BTreeMap<String, Handler<P>>,
 }
 
@@ -111,6 +113,7 @@ impl<P> Clone for Router<P> {
     fn clone(&self) -> Self {
         Self {
             catalog: self.catalog.clone(),
+            manifest_metadata: self.manifest_metadata.clone(),
             handlers: self.handlers.clone(),
         }
     }
@@ -127,6 +130,7 @@ impl<P> Router<P> {
     pub fn new() -> Self {
         Self {
             catalog: Catalog::default(),
+            manifest_metadata: PluginManifestMetadata::default(),
             handlers: BTreeMap::new(),
         }
     }
@@ -143,6 +147,29 @@ impl<P> Router<P> {
     /// Returns the router's derived static catalog.
     pub fn catalog(&self) -> &Catalog {
         &self.catalog
+    }
+
+    /// Returns the router's generated manifest metadata.
+    pub fn manifest_metadata(&self) -> &PluginManifestMetadata {
+        &self.manifest_metadata
+    }
+
+    /// Replaces the router's generated manifest metadata.
+    pub fn with_manifest_metadata(mut self, manifest_metadata: PluginManifestMetadata) -> Self {
+        self.manifest_metadata = manifest_metadata;
+        self
+    }
+
+    /// Inserts or replaces one named HTTP security scheme.
+    pub fn security_scheme(mut self, name: impl Into<String>, scheme: HTTPSecurityScheme) -> Self {
+        self.manifest_metadata = self.manifest_metadata.security_scheme(name, scheme);
+        self
+    }
+
+    /// Inserts or replaces one named hosted HTTP binding.
+    pub fn http_binding(mut self, name: impl Into<String>, binding: HTTPBinding) -> Self {
+        self.manifest_metadata = self.manifest_metadata.http_binding(name, binding);
+        self
     }
 
     /// Executes one named operation against provider.

--- a/sdk/rust/src/runtime.rs
+++ b/sdk/rust/src/runtime.rs
@@ -19,6 +19,7 @@ use tonic::transport::Server;
 use crate::catalog::write_catalog;
 use crate::env::{
     ENV_PROVIDER_NAME, ENV_PROVIDER_PARENT_PID, ENV_PROVIDER_SOCKET, ENV_WRITE_CATALOG,
+    ENV_WRITE_MANIFEST_METADATA,
 };
 use crate::error::{Error, Result};
 #[cfg(unix)]
@@ -35,6 +36,7 @@ use crate::generated::v1::s3_server::S3Server;
 use crate::generated::v1::secrets_provider_server::SecretsProviderServer;
 #[cfg(unix)]
 use crate::generated::v1::workflow_provider_server::WorkflowProviderServer as WorkflowRpcServer;
+use crate::manifest_metadata::write_manifest_metadata;
 use crate::provider_server::ProviderServer;
 use crate::{
     AuthenticationProvider, CacheProvider, Provider, Router, S3Provider, SecretsProvider,
@@ -93,6 +95,14 @@ pub fn write_catalog_path<P>(router: &Router<P>, path: impl AsRef<Path>) -> Resu
     write_catalog(router.catalog(), path)
 }
 
+/// Writes the router's generated manifest metadata to path when configured.
+pub fn write_manifest_metadata_path<P>(router: &Router<P>, path: impl AsRef<Path>) -> Result<()> {
+    if router.manifest_metadata().is_empty() {
+        return Ok(());
+    }
+    write_manifest_metadata(router.manifest_metadata(), path)
+}
+
 /// Writes the router's derived catalog when `GESTALT_PLUGIN_WRITE_CATALOG` is
 /// set, returning whether anything was written.
 pub fn maybe_write_catalog<P>(router: &Router<P>) -> Result<bool> {
@@ -110,13 +120,31 @@ pub fn maybe_write_catalog<P>(router: &Router<P>) -> Result<bool> {
     Ok(true)
 }
 
+/// Writes generated manifest metadata when
+/// `GESTALT_PLUGIN_WRITE_MANIFEST_METADATA` is set, returning whether the
+/// export path was requested.
+#[doc(hidden)]
+pub fn maybe_write_manifest_metadata<P>(router: &Router<P>) -> Result<bool> {
+    let Some(path) = env::var_os(ENV_WRITE_MANIFEST_METADATA) else {
+        return Ok(false);
+    };
+    write_manifest_metadata_path(router, PathBuf::from(path))?;
+    Ok(true)
+}
+
+fn maybe_write_generated_metadata<P>(router: &Router<P>) -> Result<bool> {
+    let wrote_catalog = maybe_write_catalog(router)?;
+    let wrote_manifest_metadata = maybe_write_manifest_metadata(router)?;
+    Ok(wrote_catalog || wrote_manifest_metadata)
+}
+
 #[cfg(unix)]
 /// Serves an integration provider over the configured Unix socket.
 pub async fn serve_provider<P>(provider: Arc<P>, router: Router<P>) -> Result<()>
 where
     P: Provider,
 {
-    if maybe_write_catalog(&router)? {
+    if maybe_write_generated_metadata(&router)? {
         return Ok(());
     }
     let server = ProviderServer::new(Arc::clone(&provider), router);
@@ -259,7 +287,7 @@ pub async fn serve_provider<P>(_provider: Arc<P>, router: Router<P>) -> Result<(
 where
     P: Provider,
 {
-    if maybe_write_catalog(&router)? {
+    if maybe_write_generated_metadata(&router)? {
         return Ok(());
     }
     Err(Error::internal(

--- a/sdk/rust/tests/router.rs
+++ b/sdk/rust/tests/router.rs
@@ -2,6 +2,7 @@
 mod helpers;
 
 use std::collections::BTreeMap;
+use std::fs;
 use std::sync::{Arc, Mutex};
 
 use gestalt::proto::v1::integration_provider_server::IntegrationProvider;
@@ -32,6 +33,40 @@ struct EchoInput {
 struct EchoOutput {
     message: String,
 }
+
+fn http_manifest_router() -> gestalt::Result<gestalt::Router<TestProvider>> {
+    gestalt::Router::new()
+        .security_scheme(
+            "slack",
+            gestalt::HTTPSecurityScheme::slack_signature().secret_env("SLACK_SIGNING_SECRET"),
+        )
+        .http_binding(
+            "command",
+            gestalt::HTTPBinding::new("/command", "post", "slack", "echo")
+                .request_body(
+                    gestalt::HTTPRequestBody::new()
+                        .required(true)
+                        .content_type("application/x-www-form-urlencoded"),
+                )
+                .ack(gestalt::HTTPAck::new().status(200).body(json!({
+                    "response_type": "ephemeral",
+                    "text": "Working on it...",
+                }))),
+        )
+        .register(
+            Operation::<EchoInput, EchoOutput>::new("echo"),
+            |_: Arc<TestProvider>, input: EchoInput, _request: Request| async move {
+                Ok::<Response<EchoOutput>, std::convert::Infallible>(ok(EchoOutput {
+                    message: input.message,
+                }))
+            },
+        )
+}
+
+gestalt::export_provider!(
+    constructor = TestProvider::default,
+    router = http_manifest_router
+);
 
 #[tokio::test]
 async fn executes_registered_operation() {
@@ -84,6 +119,91 @@ fn catalog_includes_parameters() {
     assert_eq!(catalog.operations[0].parameters[0].name, "message");
     assert!(catalog.operations[0].read_only);
     assert_eq!(catalog.operations[0].allowed_roles, vec!["viewer", "admin"]);
+}
+
+#[test]
+fn router_includes_manifest_metadata() {
+    let router = http_manifest_router().expect("router");
+    let metadata = router.manifest_metadata();
+
+    assert_eq!(
+        metadata.security_schemes["slack"].kind,
+        Some(gestalt::HTTPSecuritySchemeType::SlackSignature)
+    );
+    assert_eq!(metadata.http["command"].path, "/command");
+    assert_eq!(metadata.http["command"].method, "POST");
+    assert_eq!(metadata.http["command"].security, "slack");
+    assert_eq!(metadata.http["command"].target, "echo");
+    assert_eq!(
+        metadata.http["command"]
+            .request_body
+            .as_ref()
+            .expect("request body")
+            .content
+            .len(),
+        1
+    );
+}
+
+#[tokio::test]
+async fn serve_provider_writes_catalog_and_manifest_metadata_when_requested() {
+    let _env_lock = helpers::env_lock().lock().await;
+    let catalog_path = helpers::temp_socket("router-catalog.json");
+    let metadata_path = helpers::temp_socket("router-manifest-metadata.yaml");
+    let _catalog_guard = helpers::EnvGuard::set("GESTALT_PLUGIN_WRITE_CATALOG", &catalog_path);
+    let _metadata_guard =
+        helpers::EnvGuard::set(gestalt::ENV_WRITE_MANIFEST_METADATA, &metadata_path);
+    let _name_guard = helpers::EnvGuard::set("GESTALT_PLUGIN_NAME", "manifest-provider");
+
+    gestalt::runtime::serve_provider(
+        Arc::new(TestProvider),
+        http_manifest_router().expect("router"),
+    )
+    .await
+    .expect("serve provider");
+
+    let catalog = fs::read_to_string(&catalog_path).expect("read catalog");
+    assert!(catalog.contains("\"name\": \"manifest-provider\""));
+    assert!(catalog.contains("\"id\": \"echo\""));
+
+    let metadata = fs::read_to_string(&metadata_path).expect("read manifest metadata");
+    assert!(metadata.contains("securitySchemes:"));
+    assert!(metadata.contains("type: slack_signature"));
+    assert!(metadata.contains("env: SLACK_SIGNING_SECRET"));
+    assert!(metadata.contains("http:"));
+    assert!(metadata.contains("path: /command"));
+    assert!(metadata.contains("target: echo"));
+}
+
+#[tokio::test]
+async fn export_provider_writes_manifest_metadata_with_catalog_exports() {
+    let _env_lock = helpers::env_lock().lock().await;
+    let catalog_path = helpers::temp_socket("macro-catalog.json");
+    let metadata_path = helpers::temp_socket("macro-manifest-metadata.yaml");
+    let direct_metadata_path = helpers::temp_socket("direct-manifest-metadata.yaml");
+    let _metadata_guard =
+        helpers::EnvGuard::set(gestalt::ENV_WRITE_MANIFEST_METADATA, &metadata_path);
+
+    __gestalt_write_catalog("macro-provider", catalog_path.to_str().expect("utf8 path"))
+        .expect("write catalog");
+
+    let catalog = fs::read_to_string(&catalog_path).expect("read macro catalog");
+    assert!(catalog.contains("\"name\": \"macro-provider\""));
+
+    let metadata = fs::read_to_string(&metadata_path).expect("read macro metadata");
+    assert!(metadata.contains("securitySchemes:"));
+    assert!(metadata.contains("target: echo"));
+
+    __gestalt_write_manifest_metadata(
+        "macro-provider",
+        direct_metadata_path.to_str().expect("utf8 path"),
+    )
+    .expect("write direct manifest metadata");
+
+    let direct_metadata =
+        fs::read_to_string(&direct_metadata_path).expect("read direct manifest metadata");
+    assert!(direct_metadata.contains("securitySchemes:"));
+    assert!(direct_metadata.contains("application/x-www-form-urlencoded"));
 }
 
 #[derive(Default)]


### PR DESCRIPTION
## Summary

This extends the remaining source-built SDKs so code-defined plugins can emit manifest-backed `securitySchemes` and `http` metadata alongside `catalog.yaml` when `gestaltd` asks for `GESTALT_PLUGIN_WRITE_MANIFEST_METADATA`.

It covers:
- Go SDK router/runtime support
- Python SDK plugin/runtime support
- Rust SDK router/runtime/macro support
- providerpkg `PrepareSourceManifest(...)` coverage for Go, Python, and Rust source builds

## New Interfaces

### Go

```go
router := gestalt.MustRouter(
    gestalt.Register(handleCommandOp, (*Provider).handleCommand),
).WithManifestMetadata(gestalt.ManifestMetadata{
    SecuritySchemes: map[string]gestalt.HTTPSecurityScheme{
        "slack": {
            Type: gestalt.HTTPSecuritySchemeTypeSlackSignature,
            Secret: &gestalt.HTTPSecretRef{Env: "SLACK_SIGNING_SECRET"},
        },
    },
    HTTP: map[string]gestalt.HTTPBinding{
        "command": {
            Path:     "/command",
            Method:   http.MethodPost,
            Security: "slack",
            Target:   "handle_command",
            RequestBody: &gestalt.HTTPRequestBody{
                Required: true,
                Content: map[string]gestalt.HTTPMediaType{
                    "application/x-www-form-urlencoded": {},
                },
            },
            Ack: &gestalt.HTTPAck{
                Status: 200,
                Body: map[string]any{
                    "response_type": "ephemeral",
                    "text":          "Working on it...",
                },
            },
        },
    },
})
```

### Python

```py
plugin = Plugin(
    "slack-agent",
    securitySchemes={
        "slack": {
            "type": "slack_signature",
            "secret": {"env": "SLACK_SIGNING_SECRET"},
        },
    },
    http={
        "command": {
            "path": "/command",
            "method": "POST",
            "security": "slack",
            "target": "handle_command",
            "requestBody": {
                "required": True,
                "content": {
                    "application/x-www-form-urlencoded": {},
                },
            },
            "ack": {
                "status": 200,
                "body": {
                    "response_type": "ephemeral",
                    "text": "Working on it...",
                },
            },
        },
    },
)
```

### Rust

```rust
let router = Router::new()
    .security_scheme(
        "slack",
        HTTPSecurityScheme::slack_signature().secret_env("SLACK_SIGNING_SECRET"),
    )
    .http_binding(
        "command",
        HTTPBinding::new("/command", "post", "slack", "handle_command")
            .request_body(
                HTTPRequestBody::new()
                    .required(true)
                    .content_type("application/x-www-form-urlencoded"),
            )
            .ack(
                HTTPAck::new().status(200).body(serde_json::json!({
                    "response_type": "ephemeral",
                    "text": "Working on it...",
                })),
            ),
    )
    .register(Operation::<Input, Output>::new("handle_command"), handler)?;
```

## Runtime Behavior

- Go `ServeProvider`, Python `gestalt._runtime`, and Rust `runtime::serve_provider` now honor `GESTALT_PLUGIN_WRITE_MANIFEST_METADATA`.
- Catalog export and manifest metadata export can be requested together in the same run.
- Rust `export_provider!` also exposes a direct `__gestalt_write_manifest_metadata(...)` entrypoint, although the current providerpkg flow can keep using `__gestalt_write_catalog(...)`.

## Validation

- `go test ./internal/providerpkg -run 'TestPrepareSourceManifest_(MergesGeneratedPythonManifestMetadata|MergesGeneratedGoManifestMetadata|GeneratesStaticCatalogForRustProvider|MergesGeneratedRustManifestMetadata)' -count=1`
- `cd sdk/go && go test ./... -run 'TestRouter|TestProviderServer|TestServeProvider'`
- `cd sdk/python && PYTHONPATH=. python3 -m unittest tests.test_plugin tests.test_runtime`
- `cd sdk/python && uv run ruff check gestalt/__init__.py gestalt/_manifest_metadata.py gestalt/_plugin.py gestalt/_runtime.py tests/test_plugin.py tests/test_runtime.py`
- `cd sdk/rust && cargo test --test router`

## Notes

This supersedes leaving TypeScript as the only code-first SDK that can emit hosted HTTP manifest metadata during source builds.