### PR TITLE
remove workload principal kind from runtime context

### DIFF
--- a/gestaltd/internal/authorization/authorizer.go
+++ b/gestaltd/internal/authorization/authorizer.go
@@ -186,7 +186,7 @@ func (a *Authorizer) ResolveWorkloadToken(token string) (*principal.ResolvedWork
 }
 
 func (a *Authorizer) IsWorkload(p *principal.Principal) bool {
-	return p != nil && p.Kind == principal.KindWorkload
+	return p != nil && (p.IsStaticWorkloadToken() || a.isManagedIdentityPrincipal(p))
 }
 
 func (a *Authorizer) AllowProvider(ctx context.Context, p *principal.Principal, provider string) bool {
@@ -537,7 +537,7 @@ func normalizeAllowedOperations(ops []string) map[string]struct{} {
 }
 
 func (a *Authorizer) isManagedIdentityPrincipal(p *principal.Principal) bool {
-	return a.IsWorkload(p) && principal.ManagedIdentityIDFromSubjectID(strings.TrimSpace(p.SubjectID)) != ""
+	return p != nil && principal.ManagedIdentityIDFromSubjectID(strings.TrimSpace(p.SubjectID)) != ""
 }
 
 func (a *Authorizer) allowManagedIdentityProvider(p *principal.Principal, provider string) bool {

--- a/gestaltd/internal/bootstrap/bootstrap_test.go
+++ b/gestaltd/internal/bootstrap/bootstrap_test.go
@@ -4377,6 +4377,7 @@ func TestBootstrapSecretResolution(t *testing.T) {
 		workloadPrincipal := &principal.Principal{
 			SubjectID: principal.WorkloadSubjectID("triage-bot"),
 			Kind:      principal.KindWorkload,
+			Source:    principal.SourceWorkloadToken,
 		}
 		access, allowed := result.Authorizer.ResolveAccess(ctx, workloadPrincipal, "roadmap")
 		if allowed {

--- a/gestaltd/internal/bootstrap/workflow_runtime.go
+++ b/gestaltd/internal/bootstrap/workflow_runtime.go
@@ -252,11 +252,15 @@ func workflowExecutionPrincipal(ref *coreworkflow.ExecutionReference) *principal
 		return nil
 	}
 	permissions := principal.CompilePermissions(ref.Permissions)
-	return principal.Canonicalize(&principal.Principal{
+	value := &principal.Principal{
 		SubjectID:        strings.TrimSpace(ref.SubjectID),
 		Scopes:           principal.PermissionPlugins(permissions),
 		TokenPermissions: permissions,
-	})
+	}
+	if strings.HasPrefix(value.SubjectID, principal.WorkloadSubjectID("")) {
+		value.Source = principal.SourceWorkloadToken
+	}
+	return principal.Canonicalize(value)
 }
 
 func workflowRequestPrincipal(req coreworkflow.InvokeOperationRequest) *principal.Principal {

--- a/gestaltd/internal/bootstrap/workflow_runtime_test.go
+++ b/gestaltd/internal/bootstrap/workflow_runtime_test.go
@@ -449,8 +449,11 @@ func TestWorkflowRuntimeInvokeExecutionRefUsesStoredWorkloadPrincipal(t *testing
 	if gotPrincipal == nil {
 		t.Fatal("principal = nil")
 	}
-	if gotPrincipal.Kind != principal.KindWorkload {
-		t.Fatalf("principal kind = %q, want %q", gotPrincipal.Kind, principal.KindWorkload)
+	if gotPrincipal.Kind != "" {
+		t.Fatalf("principal kind = %q, want empty", gotPrincipal.Kind)
+	}
+	if gotPrincipal.Source != principal.SourceWorkloadToken {
+		t.Fatalf("principal source = %q, want %q", gotPrincipal.Source, principal.SourceWorkloadToken)
 	}
 	if gotPrincipal.SubjectID != principal.WorkloadSubjectID("scheduler") {
 		t.Fatalf("subjectID = %q, want %q", gotPrincipal.SubjectID, principal.WorkloadSubjectID("scheduler"))

--- a/gestaltd/internal/invocation/audit.go
+++ b/gestaltd/internal/invocation/audit.go
@@ -65,8 +65,8 @@ func buildAuditEntry(ctx context.Context, p *principal.Principal, source, provid
 		entry.UserID = p.UserID
 		entry.AuthSource = p.AuthSource()
 		entry.SubjectID = p.SubjectID
-		if p.Kind != "" {
-			entry.SubjectKind = string(p.Kind)
+		if subjectKind := p.LegacySubjectKind(); subjectKind != "" {
+			entry.SubjectKind = subjectKind
 		}
 	}
 	access := AccessContextFromContext(ctx)

--- a/gestaltd/internal/invocation/broker.go
+++ b/gestaltd/internal/invocation/broker.go
@@ -490,7 +490,7 @@ func (b *Broker) resolveToken(ctx context.Context, prov core.Provider, p *princi
 }
 
 func (b *Broker) resolveUserPrincipal(ctx context.Context, p *principal.Principal) error {
-	if p == nil || p.UserID != "" || p.Kind == principal.KindWorkload || p.Identity == nil || p.Identity.Email == "" {
+	if p == nil || p.UserID != "" || !p.HasUserContext() {
 		return nil
 	}
 	if b.users == nil {
@@ -557,7 +557,7 @@ func (b *Broker) resolveBoundToken(ctx context.Context, prov core.Provider, p *p
 			subjectID,
 		)
 	default:
-		return ctx, "", fmt.Errorf("%w: workloads may only use credentialed or none providers", ErrAuthorizationDenied)
+		return ctx, "", fmt.Errorf("%w: callers with bound credentials may only use credentialed or none providers", ErrAuthorizationDenied)
 	}
 }
 

--- a/gestaltd/internal/invocation/broker_test.go
+++ b/gestaltd/internal/invocation/broker_test.go
@@ -119,7 +119,7 @@ func TestBrokerResolveToken_WorkflowContextDoesNotBypassWorkloadIdentityBinding(
 	if err == nil {
 		t.Fatal("expected binding override to be rejected")
 	}
-	if got, want := err.Error(), "workloads may not override connection or instance bindings"; got == "" || !strings.Contains(got, want) {
+	if got, want := err.Error(), "callers with bound credentials may not override connection or instance bindings"; got == "" || !strings.Contains(got, want) {
 		t.Fatalf("ResolveToken error = %q, want substring %q", got, want)
 	}
 }
@@ -146,7 +146,7 @@ func TestBrokerResolveToken_ManagedIdentityDoesNotBypassSelectorBinding(t *testi
 	if err == nil {
 		t.Fatal("expected managed identity selector override to be rejected")
 	}
-	if got, want := err.Error(), "workloads may not override connection or instance bindings"; got == "" || !strings.Contains(got, want) {
+	if got, want := err.Error(), "callers with bound credentials may not override connection or instance bindings"; got == "" || !strings.Contains(got, want) {
 		t.Fatalf("ResolveToken error = %q, want substring %q", got, want)
 	}
 }

--- a/gestaltd/internal/invocation/credential_binding.go
+++ b/gestaltd/internal/invocation/credential_binding.go
@@ -89,7 +89,7 @@ func resolveCredentialBinding(authz authorization.RuntimeAuthorizer, p *principa
 }
 
 func bindingSelectorOverrideError() error {
-	return fmt.Errorf("%w: workloads may not override connection or instance bindings", ErrAuthorizationDenied)
+	return fmt.Errorf("%w: callers with bound credentials may not override connection or instance bindings", ErrAuthorizationDenied)
 }
 
 func ResolveTokenForBinding(ctx context.Context, resolver TokenResolver, p *principal.Principal, providerName, connection, instance string, boundCredential CredentialBindingResolution) (context.Context, string, error) {

--- a/gestaltd/internal/mcp/binding_test.go
+++ b/gestaltd/internal/mcp/binding_test.go
@@ -1977,7 +1977,7 @@ func TestNewServer_WorkloadCallToolRejectsInstanceOverride(t *testing.T) {
 		t.Fatalf("expected MCP error result, got %+v", result)
 	}
 	text, ok := result.Content[0].(mcpgo.TextContent)
-	if !ok || text.Text != "workload callers may not override connection or instance bindings" {
+	if !ok || text.Text != "callers with bound credentials may not override connection or instance bindings" {
 		t.Fatalf("unexpected MCP error content: %+v", result.Content)
 	}
 	if called {

--- a/gestaltd/internal/mcp/handlers.go
+++ b/gestaltd/internal/mcp/handlers.go
@@ -24,7 +24,7 @@ func makeHandler(cfg Config, provName, opName, connection string) mcpserver.Tool
 		rawArgs := req.GetArguments()
 		instance := normalizedSessionCatalogInstance(rawArgs["_instance"])
 		if workloadInstanceOverrideRequested(cfg.Authorizer, p, provName, instance) {
-			return mcpgo.NewToolResultError("workload callers may not override connection or instance bindings"), nil
+			return mcpgo.NewToolResultError("callers with bound credentials may not override connection or instance bindings"), nil
 		}
 		args := make(map[string]any, len(rawArgs))
 		for key, value := range rawArgs {

--- a/gestaltd/internal/principal/principal.go
+++ b/gestaltd/internal/principal/principal.go
@@ -20,6 +20,7 @@ const (
 
 const IdentityPrincipal = "__identity__"
 const managedIdentitySubjectPrefix = "managed_identity:"
+const workloadSubjectPrefix = "workload:"
 
 type Kind string
 
@@ -82,6 +83,41 @@ func (p *Principal) AuthSource() string {
 	return p.Source.String()
 }
 
+func (p *Principal) HasUserContext() bool {
+	if p == nil {
+		return false
+	}
+	if strings.TrimSpace(p.UserID) != "" {
+		return true
+	}
+	return p.Identity != nil && strings.TrimSpace(p.Identity.Email) != ""
+}
+
+func (p *Principal) IsStaticWorkloadToken() bool {
+	return p != nil && p.Source == SourceWorkloadToken
+}
+
+func (p *Principal) LegacySubjectKind() string {
+	if p == nil {
+		return ""
+	}
+	if p.Kind != "" {
+		return string(p.Kind)
+	}
+	switch {
+	case p.IsStaticWorkloadToken(),
+		strings.HasPrefix(strings.TrimSpace(p.SubjectID), workloadSubjectPrefix),
+		ManagedIdentityIDFromSubjectID(strings.TrimSpace(p.SubjectID)) != "":
+		return string(KindWorkload)
+	case strings.TrimSpace(p.UserID) != "",
+		p.Identity != nil,
+		strings.HasPrefix(strings.TrimSpace(p.SubjectID), string(KindUser)+":"):
+		return string(KindUser)
+	default:
+		return ""
+	}
+}
+
 func UserSubjectID(userID string) string {
 	if userID == "" {
 		return ""
@@ -100,7 +136,7 @@ func WorkloadSubjectID(workloadID string) string {
 	if workloadID == "" {
 		return ""
 	}
-	return string(KindWorkload) + ":" + workloadID
+	return workloadSubjectPrefix + workloadID
 }
 
 func IdentitySubjectID() string {
@@ -367,14 +403,6 @@ func Canonicalize(p *Principal) *Principal {
 			if p.Kind == "" {
 				p.Kind = KindUser
 			}
-		}
-	}
-	if p.Kind == "" {
-		switch {
-		case strings.HasPrefix(p.SubjectID, string(KindWorkload)+":"),
-			ManagedIdentityIDFromSubjectID(p.SubjectID) != "",
-			p.SubjectID == IdentitySubjectID():
-			p.Kind = KindWorkload
 		}
 	}
 	if p.SubjectID == "" && p.UserID != "" {

--- a/gestaltd/internal/principal/resolver.go
+++ b/gestaltd/internal/principal/resolver.go
@@ -205,7 +205,6 @@ func (r *Resolver) resolveManagedIdentityAPIToken(ctx context.Context, apiToken 
 		SubjectID:           ManagedIdentitySubjectID(identity.ID),
 		CredentialSubjectID: apiToken.CredentialSubjectID,
 		DisplayName:         identity.DisplayName,
-		Kind:                KindWorkload,
 		Source:              SourceAPIToken,
 		Scopes:              PermissionPlugins(effectivePerms),
 		TokenPermissions:    effectivePerms,
@@ -221,7 +220,6 @@ func (r *Resolver) resolveWorkloadToken(token string) (*Principal, error) {
 		return nil, ErrInvalidToken
 	}
 	return &Principal{
-		Kind:        KindWorkload,
 		SubjectID:   WorkloadSubjectID(workload.ID),
 		DisplayName: workload.DisplayName,
 		Source:      SourceWorkloadToken,

--- a/gestaltd/internal/providerhost/invocation_token.go
+++ b/gestaltd/internal/providerhost/invocation_token.go
@@ -254,7 +254,7 @@ func claimsFromContext(ctx context.Context, pluginName string, grants map[string
 		},
 		DelegationExpiresAt: jwt.NewNumericDate(delegationExpiresAt),
 		CallerPlugin:        strings.TrimSpace(pluginName),
-		SubjectKind:         string(subjectKindForInvocationClaims(p)),
+		SubjectKind:         subjectKindForInvocationClaims(p),
 		Email:               emailForInvocationClaims(p),
 		DisplayName:         displayNameForInvocationClaims(p),
 		AuthSource:          authSourceForInvocationClaims(p),
@@ -320,7 +320,7 @@ func restoreInvocationTokenContext(ctx context.Context, tokenCtx invocationToken
 }
 
 func shouldInheritCredentialSelectors(p *principal.Principal) bool {
-	return p == nil || p.Kind != principal.KindWorkload
+	return p == nil || !p.IsStaticWorkloadToken()
 }
 
 func subjectIDForInvocationClaims(p *principal.Principal) string {
@@ -336,20 +336,11 @@ func subjectIDForInvocationClaims(p *principal.Principal) string {
 	return ""
 }
 
-func subjectKindForInvocationClaims(p *principal.Principal) principal.Kind {
+func subjectKindForInvocationClaims(p *principal.Principal) string {
 	if p == nil {
 		return ""
 	}
-	if p.Kind != "" {
-		return p.Kind
-	}
-	if strings.HasPrefix(strings.TrimSpace(p.SubjectID), string(principal.KindUser)+":") {
-		return principal.KindUser
-	}
-	if strings.HasPrefix(strings.TrimSpace(p.SubjectID), string(principal.KindWorkload)+":") {
-		return principal.KindWorkload
-	}
-	return ""
+	return p.LegacySubjectKind()
 }
 
 func displayNameForInvocationClaims(p *principal.Principal) string {
@@ -414,9 +405,11 @@ func principalFromInvocationClaims(claims *invocationTokenClaims) *principal.Pri
 		SubjectID:           strings.TrimSpace(claims.Subject),
 		CredentialSubjectID: strings.TrimSpace(claims.CredentialSubjectID),
 		DisplayName:         strings.TrimSpace(claims.DisplayName),
-		Kind:                principal.Kind(strings.TrimSpace(claims.SubjectKind)),
 		Source:              source,
 		TokenPermissions:    tokenPerms,
+	}
+	if strings.TrimSpace(claims.SubjectKind) == string(principal.KindUser) {
+		p.Kind = principal.KindUser
 	}
 	if strings.TrimSpace(claims.Email) != "" || strings.TrimSpace(claims.DisplayName) != "" {
 		p.Identity = &core.UserIdentity{

--- a/gestaltd/internal/providerhost/plugin_invoker.go
+++ b/gestaltd/internal/providerhost/plugin_invoker.go
@@ -10,7 +10,6 @@ import (
 	proto "github.com/valon-technologies/gestalt/sdk/go/gen/v1"
 	"github.com/valon-technologies/gestalt/server/internal/config"
 	"github.com/valon-technologies/gestalt/server/internal/invocation"
-	"github.com/valon-technologies/gestalt/server/internal/principal"
 	"google.golang.org/grpc/codes"
 	"google.golang.org/grpc/status"
 )
@@ -84,8 +83,8 @@ func (s *PluginInvokerServer) Invoke(ctx context.Context, req *proto.PluginInvok
 	}
 
 	instance := strings.TrimSpace(req.GetInstance())
-	if tokenCtx.principal != nil && tokenCtx.principal.Kind == principal.KindWorkload && (connection != "" || instance != "") {
-		return nil, status.Error(codes.PermissionDenied, "workloads may not override connection or instance bindings")
+	if tokenCtx.principal != nil && tokenCtx.principal.IsStaticWorkloadToken() && (connection != "" || instance != "") {
+		return nil, status.Error(codes.PermissionDenied, "callers with bound credentials may not override connection or instance bindings")
 	}
 	if instance == "" && connection == "" && shouldInheritCredentialSelectors(tokenCtx.principal) {
 		instance = tokenCtx.credential.Instance

--- a/gestaltd/internal/providerhost/provider_client.go
+++ b/gestaltd/internal/providerhost/provider_client.go
@@ -339,19 +339,7 @@ func subjectKindForPrincipal(p *principal.Principal) string {
 	if p == nil {
 		return ""
 	}
-	if p.Kind != "" {
-		return string(p.Kind)
-	}
-	switch {
-	case strings.HasPrefix(p.SubjectID, string(principal.KindUser)+":"):
-		return string(principal.KindUser)
-	case strings.HasPrefix(p.SubjectID, string(principal.KindWorkload)+":"):
-		return string(principal.KindWorkload)
-	}
-	if p.UserID != "" || p.Identity != nil {
-		return string(principal.KindUser)
-	}
-	return ""
+	return p.LegacySubjectKind()
 }
 
 func subjectDisplayName(p *principal.Principal) string {

--- a/gestaltd/internal/providerhost/provider_server.go
+++ b/gestaltd/internal/providerhost/provider_server.go
@@ -112,16 +112,15 @@ func principalFromProto(subject *proto.SubjectContext) *principal.Principal {
 	switch subject.GetKind() {
 	case string(principal.KindUser):
 		p.Kind = principal.KindUser
-	case string(principal.KindWorkload):
-		p.Kind = principal.KindWorkload
+	case "workload":
+		// Backward-compatible read of older snapshots. Current runtimes rely on
+		// subject ID and auth source instead of a workload kind.
 	}
 	if strings.HasPrefix(subject.GetId(), "user:") {
 		p.UserID = strings.TrimPrefix(subject.GetId(), "user:")
 		if p.Kind == "" {
 			p.Kind = principal.KindUser
 		}
-	} else if strings.HasPrefix(subject.GetId(), "workload:") && p.Kind == "" {
-		p.Kind = principal.KindWorkload
 	}
 	if p.Kind == principal.KindUser && subject.GetDisplayName() != "" {
 		p.Identity = &core.UserIdentity{

--- a/gestaltd/internal/providerhost/provider_test.go
+++ b/gestaltd/internal/providerhost/provider_test.go
@@ -215,8 +215,8 @@ func TestRemoteProviderRoundTrip(t *testing.T) {
 				Kind:        principal.KindWorkload,
 				Source:      principal.SourceWorkloadToken,
 			},
-			wantExecuteBody:    "echo|secret-token|hi|acme|workload:triage-bot|workload|Triage Bot|false|workload_token|user|workload:triage-bot|roadmap|admin",
-			wantSessionCatalog: "token-123|workload:triage-bot|workload|Triage Bot|false|workload_token|user|roadmap|admin",
+			wantExecuteBody:    "echo|secret-token|hi|acme|workload:triage-bot||Triage Bot|false|workload_token|user|workload:triage-bot|roadmap|admin",
+			wantSessionCatalog: "token-123|workload:triage-bot||Triage Bot|false|workload_token|user|roadmap|admin",
 		},
 	}
 
@@ -355,6 +355,9 @@ func TestPrincipalFromProto_WorkloadDisplayNameDoesNotCreateIdentity(t *testing.
 	}
 	if p.DisplayName != "Triage Bot" {
 		t.Fatalf("display name = %q, want %q", p.DisplayName, "Triage Bot")
+	}
+	if p.Kind != "" {
+		t.Fatalf("principal kind = %q, want empty", p.Kind)
 	}
 	if p.Identity != nil {
 		t.Fatalf("expected workload identity to remain nil, got %#v", p.Identity)

--- a/gestaltd/internal/server/audit.go
+++ b/gestaltd/internal/server/audit.go
@@ -40,13 +40,10 @@ func (s *Server) resolvePrincipalUserID(ctx context.Context, p *principal.Princi
 	if p == nil {
 		return nil, nil
 	}
-	if p.Kind == principal.KindWorkload {
+	if !p.HasUserContext() {
 		return p, nil
 	}
 	if p.UserID != "" {
-		return p, nil
-	}
-	if p.Identity == nil || p.Identity.Email == "" {
 		return p, nil
 	}
 

--- a/gestaltd/internal/server/authorization.go
+++ b/gestaltd/internal/server/authorization.go
@@ -41,7 +41,7 @@ func (s *Server) workloadBinding(p *principal.Principal, provider string) (autho
 }
 
 func rejectWorkloadSelectors(w http.ResponseWriter, p *principal.Principal, connection, instance string) error {
-	if p == nil || p.Kind != principal.KindWorkload {
+	if p == nil || !p.IsStaticWorkloadToken() {
 		return nil
 	}
 	if connection == "" && instance == "" {

--- a/gestaltd/internal/server/catalog_resolution_test.go
+++ b/gestaltd/internal/server/catalog_resolution_test.go
@@ -292,7 +292,7 @@ func TestResolveCatalog_ModeNoneBoundPrincipalUsesEffectiveBindingSelectors(t *t
 		prov,
 		"bound-none-api",
 		resolver,
-		&principal.Principal{Kind: principal.KindWorkload, SubjectID: principal.WorkloadSubjectID("triage-bot")},
+		&principal.Principal{Kind: principal.KindWorkload, SubjectID: principal.WorkloadSubjectID("triage-bot"), Source: principal.SourceWorkloadToken},
 		"workspace",
 		"team-a",
 	)
@@ -616,6 +616,7 @@ func TestFilterCatalogForPrincipal_WorkloadFilteringUsesMergedCatalog(t *testing
 	p := &principal.Principal{
 		Kind:      principal.KindWorkload,
 		SubjectID: principal.WorkloadSubjectID("triage-bot"),
+		Source:    principal.SourceWorkloadToken,
 	}
 	cat, err := invocation.ResolveCatalog(context.Background(), prov, "clash-api", &stubTokenResolver{token: "tok_456"}, p, "default", "")
 	if err != nil {

--- a/gestaltd/internal/server/handlers.go
+++ b/gestaltd/internal/server/handlers.go
@@ -41,9 +41,9 @@ const defaultSessionCookieTTL = 24 * time.Hour
 var (
 	errNotAuthenticated  = errors.New("not authenticated")
 	errResolveUser       = errors.New("failed to resolve user")
-	errWorkloadForbidden = errors.New("workload callers are not allowed on this route")
+	errWorkloadForbidden = errors.New("headless callers are not allowed on this route")
 	errOperationAccess   = errors.New("operation access denied")
-	errWorkloadSelector  = errors.New("workload callers may not override connection or instance bindings")
+	errWorkloadSelector  = errors.New("callers with bound credentials may not override connection or instance bindings")
 )
 
 var (
@@ -90,8 +90,8 @@ type connectionParamInfo struct {
 }
 
 func (s *Server) resolveUserID(w http.ResponseWriter, r *http.Request) (string, error) {
-	if p := PrincipalFromContext(r.Context()); p != nil && p.Kind == principal.KindWorkload {
-		writeError(w, http.StatusForbidden, "workload callers are not allowed on this route")
+	if p := PrincipalFromContext(r.Context()); p != nil && !p.HasUserContext() {
+		writeError(w, http.StatusForbidden, errWorkloadForbidden.Error())
 		return "", errWorkloadForbidden
 	}
 	user := UserFromContext(r.Context())
@@ -127,7 +127,7 @@ func (s *Server) readinessCheck(w http.ResponseWriter, _ *http.Request) {
 func (s *Server) listIntegrations(w http.ResponseWriter, r *http.Request) {
 	p := PrincipalFromContext(r.Context())
 	connected := map[string][]instanceInfo{}
-	if p == nil || p.Kind != principal.KindWorkload {
+	if p == nil || p.HasUserContext() {
 		var err error
 		connected, err = s.userConnectedIntegrations(r)
 		if err != nil {
@@ -164,7 +164,7 @@ func (s *Server) listIntegrations(w http.ResponseWriter, r *http.Request) {
 		if entry, ok := s.pluginDefs[name]; ok && entry != nil {
 			info.MountedPath = strings.TrimSpace(entry.MountPath)
 		}
-		if p != nil && p.Kind == principal.KindWorkload {
+		if p != nil && !p.HasUserContext() {
 			if binding, ok := s.workloadBinding(p, name); ok {
 				bindingConnected, err := s.workloadBindingConnected(r.Context(), binding, name)
 				if err != nil {

--- a/gestaltd/internal/server/handlers_admin_authorization.go
+++ b/gestaltd/internal/server/handlers_admin_authorization.go
@@ -78,8 +78,8 @@ func (s *Server) adminAPIAuthMiddleware(next http.Handler) http.Handler {
 			writeError(w, http.StatusUnauthorized, "missing authorization")
 			return
 		}
-		if p.Kind == principal.KindWorkload {
-			writeError(w, http.StatusForbidden, "workload callers are not allowed on this route")
+		if !p.HasUserContext() {
+			writeError(w, http.StatusForbidden, errWorkloadForbidden.Error())
 			return
 		}
 

--- a/gestaltd/internal/server/handlers_auth.go
+++ b/gestaltd/internal/server/handlers_auth.go
@@ -573,9 +573,9 @@ func (s *Server) logout(w http.ResponseWriter, r *http.Request) {
 	defer func() {
 		s.auditHTTPEvent(r.Context(), auditPrincipal, s.authProviderName(), "auth.logout", auditAllowed, auditErr)
 	}()
-	if auditPrincipal != nil && auditPrincipal.Kind == principal.KindWorkload {
+	if auditPrincipal != nil && !auditPrincipal.HasUserContext() {
 		auditErr = errWorkloadForbidden
-		writeError(w, http.StatusForbidden, "workload callers are not allowed on this route")
+		writeError(w, http.StatusForbidden, errWorkloadForbidden.Error())
 		return
 	}
 

--- a/gestaltd/internal/server/handlers_connect.go
+++ b/gestaltd/internal/server/handlers_connect.go
@@ -38,9 +38,9 @@ func (s *Server) connectManual(w http.ResponseWriter, r *http.Request) {
 		metricutil.RecordConnectionAuthMetrics(r.Context(), startedAt, metricProviderName, "manual", "complete", connectionMode, auditErr != nil)
 		s.auditHTTPEventWithTarget(r.Context(), PrincipalFromContext(r.Context()), providerName, "connection.manual.connect", auditAllowed, auditErr, auditTarget)
 	}()
-	if p := PrincipalFromContext(r.Context()); p != nil && p.Kind == principal.KindWorkload {
+	if p := PrincipalFromContext(r.Context()); p != nil && !p.HasUserContext() {
 		auditErr = errWorkloadForbidden
-		writeError(w, http.StatusForbidden, "workload callers are not allowed on this route")
+		writeError(w, http.StatusForbidden, errWorkloadForbidden.Error())
 		return
 	}
 

--- a/gestaltd/internal/server/handlers_identities.go
+++ b/gestaltd/internal/server/handlers_identities.go
@@ -1112,7 +1112,7 @@ func (s *Server) managedIdentityGrantCatalogTargets(ctx context.Context, plugin 
 			subjectID = principal.UserSubjectID(p.UserID)
 		}
 	}
-	if p == nil || p.Kind == principal.KindWorkload || subjectID == "" {
+	if p == nil || !p.HasUserContext() || subjectID == "" {
 		if len(targets) == 0 {
 			addTarget("", "")
 		}

--- a/gestaltd/internal/server/handlers_oauth.go
+++ b/gestaltd/internal/server/handlers_oauth.go
@@ -13,7 +13,6 @@ import (
 	"github.com/valon-technologies/gestalt/server/internal/metricutil"
 	"github.com/valon-technologies/gestalt/server/internal/oauth"
 	"github.com/valon-technologies/gestalt/server/internal/paraminterp"
-	"github.com/valon-technologies/gestalt/server/internal/principal"
 )
 
 type startOAuthRequest struct {
@@ -36,9 +35,9 @@ func (s *Server) startIntegrationOAuth(w http.ResponseWriter, r *http.Request) {
 		metricutil.RecordConnectionAuthMetrics(r.Context(), startedAt, metricProviderName, "oauth", "start", connectionMode, auditErr != nil)
 		s.auditHTTPEventWithTarget(r.Context(), PrincipalFromContext(r.Context()), providerName, "connection.oauth.start", auditAllowed, auditErr, auditTarget)
 	}()
-	if p := PrincipalFromContext(r.Context()); p != nil && p.Kind == principal.KindWorkload {
+	if p := PrincipalFromContext(r.Context()); p != nil && !p.HasUserContext() {
 		auditErr = errWorkloadForbidden
-		writeError(w, http.StatusForbidden, "workload callers are not allowed on this route")
+		writeError(w, http.StatusForbidden, errWorkloadForbidden.Error())
 		return
 	}
 

--- a/gestaltd/internal/server/integration_visibility.go
+++ b/gestaltd/internal/server/integration_visibility.go
@@ -20,7 +20,7 @@ func (s *Server) integrationHasUsableSurfaceContext(ctx context.Context, p *prin
 }
 
 func (s *Server) integrationHasSettingsSurface(p *principal.Principal, info integrationInfo) bool {
-	if p != nil && p.Kind == principal.KindWorkload {
+	if p != nil && !p.HasUserContext() {
 		return false
 	}
 	return info.Connected || len(info.AuthTypes) > 0 || len(info.Connections) > 0
@@ -69,7 +69,7 @@ func (s *Server) mountedUIRootAccessibleContext(ctx context.Context, p *principa
 	if mounted.AuthorizationPolicy == "" {
 		return true
 	}
-	if s.authorizer == nil || p == nil || p.Kind == principal.KindWorkload {
+	if s.authorizer == nil || p == nil || !p.HasUserContext() {
 		return false
 	}
 

--- a/gestaltd/internal/server/middleware.go
+++ b/gestaltd/internal/server/middleware.go
@@ -133,10 +133,10 @@ func (s *Server) resolveRequestPrincipalWithResolver(r *http.Request, resolver *
 
 	if c, err := r.Cookie(sessionCookieName); err == nil && c.Value != "" {
 		p, err := resolver.ResolveToken(r.Context(), c.Value)
-		if p != nil && p.Kind != principal.KindWorkload {
+		if p != nil && p.HasUserContext() {
 			return p, nil
 		}
-		if p != nil && p.Kind == principal.KindWorkload {
+		if p != nil && !p.HasUserContext() {
 			lastErr = principal.ErrInvalidToken
 		} else {
 			lastErr = err

--- a/gestaltd/internal/server/mounted_ui.go
+++ b/gestaltd/internal/server/mounted_ui.go
@@ -315,8 +315,8 @@ func (s *Server) authorizeProtectedUIRequest(w http.ResponseWriter, r *http.Requ
 		}
 		return nil, false
 	}
-	if p != nil && p.Kind == principal.KindWorkload {
-		writeError(w, http.StatusForbidden, "workload callers are not allowed on this route")
+	if p != nil && !p.HasUserContext() {
+		writeError(w, http.StatusForbidden, errWorkloadForbidden.Error())
 		return nil, false
 	}
 

--- a/gestaltd/internal/server/pending_connection.go
+++ b/gestaltd/internal/server/pending_connection.go
@@ -257,7 +257,7 @@ func (s *Server) resolvePendingConnectionUserID(r *http.Request) (string, bool, 
 	if p == nil {
 		return "", false, nil
 	}
-	if p.Kind == principal.KindWorkload {
+	if !p.HasUserContext() {
 		return "", true, errWorkloadForbidden
 	}
 	subjectID := strings.TrimSpace(p.SubjectID)
@@ -295,7 +295,7 @@ func (s *Server) authorizePendingConnection(w http.ResponseWriter, r *http.Reque
 	subjectID, authenticated, err := s.resolvePendingConnectionUserID(r)
 	if err != nil {
 		if errors.Is(err, errWorkloadForbidden) {
-			writeError(w, http.StatusForbidden, "workload callers are not allowed on this route")
+			writeError(w, http.StatusForbidden, errWorkloadForbidden.Error())
 			return false
 		}
 		if errors.Is(err, principal.ErrInvalidToken) {

--- a/gestaltd/internal/server/server_test.go
+++ b/gestaltd/internal/server/server_test.go
@@ -5657,7 +5657,7 @@ func TestWorkloadAuthorization_ListOperationsFiltersAndRejectsSelectors(t *testi
 	if auditRecord["subject_id"] != "workload:triage-bot" {
 		t.Fatalf("expected workload subject_id, got %v", auditRecord["subject_id"])
 	}
-	if auditRecord["error"] != "workload callers may not override connection or instance bindings" {
+	if auditRecord["error"] != "callers with bound credentials may not override connection or instance bindings" {
 		t.Fatalf("unexpected audit error: %v", auditRecord["error"])
 	}
 
@@ -8866,7 +8866,7 @@ func TestWorkloadAuthorization_ExecuteOperation_UsesBoundIdentityAndRejectsSelec
 	if selectorAudit["subject_id"] != "workload:triage-bot" {
 		t.Fatalf("expected selector audit subject_id workload:triage-bot, got %v", selectorAudit["subject_id"])
 	}
-	if selectorAudit["error"] != "workload callers may not override connection or instance bindings" {
+	if selectorAudit["error"] != "callers with bound credentials may not override connection or instance bindings" {
 		t.Fatalf("unexpected selector audit error: %v", selectorAudit["error"])
 	}
 }

--- a/gestaltd/internal/workflowmanager/manager.go
+++ b/gestaltd/internal/workflowmanager/manager.go
@@ -468,7 +468,7 @@ func (m *Manager) resolveTarget(ctx context.Context, p *principal.Principal, tar
 		return coreworkflow.Target{}, fmt.Errorf("instance name contains invalid characters")
 	}
 	if m.authorizer != nil && m.authorizer.IsWorkload(p) && (connection != "" || instance != "") {
-		return coreworkflow.Target{}, fmt.Errorf("%w: workloads may not override connection or instance bindings", invocation.ErrAuthorizationDenied)
+		return coreworkflow.Target{}, fmt.Errorf("%w: callers with bound credentials may not override connection or instance bindings", invocation.ErrAuthorizationDenied)
 	}
 
 	ctx = invocation.WithAccessContext(ctx, m.providerAccessContext(ctx, p, pluginName))
@@ -742,7 +742,7 @@ func workflowActorFromPrincipal(p *principal.Principal) coreworkflow.Actor {
 	}
 	return coreworkflow.Actor{
 		SubjectID:   strings.TrimSpace(p.SubjectID),
-		SubjectKind: string(p.Kind),
+		SubjectKind: p.LegacySubjectKind(),
 		DisplayName: workflowActorDisplayName(p),
 		AuthSource:  p.AuthSource(),
 	}


### PR DESCRIPTION
## Summary

This rebuild supersedes the closed `#1214` branch shape and reapplies the deletive core on top of the latest `origin/main`.

The change removes `principal.KindWorkload` as the internal runtime discriminator for static workload tokens and managed-identity API tokens. Runtime code now keys off explicit predicates:
- `p.HasUserContext()` for user-capable routes and UI surfaces
- `p.IsStaticWorkloadToken()` for static workload-token selector restrictions
- `p.LegacySubjectKind()` for audit/providerhost compatibility payloads

`authorization.workloads` remains the compatibility YAML surface in this PR.

## Old Interfaces

### Go

```go
p := &principal.Principal{
    Kind:      principal.KindWorkload,
    SubjectID: principal.WorkloadSubjectID("triage-bot"),
}

if p.Kind == principal.KindWorkload {
    // route gating / selector rejection / providerhost compatibility
}
```

Workflow execution refs restored `workload:<id>` subjects without restoring `SourceWorkloadToken`.

### YAML

```yaml
authorization:
  workloads:
    triage-bot:
      token: gst_wld_triage-bot-token
      providers:
        roadmap:
          connection: workspace
          instance: default
          allow:
            - sync
```

## New Interfaces

### Go

```go
p := &principal.Principal{
    SubjectID: principal.WorkloadSubjectID("triage-bot"),
    Source:    principal.SourceWorkloadToken,
}

if !p.HasUserContext() {
    // headless-only route gating
}

if p.IsStaticWorkloadToken() {
    // static workload-token selector restriction
}

subjectKind := p.LegacySubjectKind()
```

Workflow execution refs now restore `SourceWorkloadToken` when the stored subject is `workload:<id>`.

### YAML

The compatibility YAML surface is unchanged in this PR:

```yaml
authorization:
  workloads:
    triage-bot:
      token: gst_wld_triage-bot-token
      providers:
        roadmap:
          connection: workspace
          instance: default
          allow:
            - sync
```

## Behavioral Notes

- Static workload tokens and managed-identity API tokens no longer need `KindWorkload` set on the in-process principal.
- Providerhost and audit payloads still emit legacy `workload` subject kinds through `LegacySubjectKind()`.
- Headless route gating now uses user-context presence instead of `KindWorkload` checks.
- Selector override errors now describe bound-credential callers rather than workload callers.

## Validation

```bash
go test ./internal/bootstrap ./internal/invocation ./internal/providerhost ./internal/server ./internal/mcp ./internal/workflowmanager -count=1
go test ./... -run '^$'
golangci-lint run
```