### PR TITLE
Add global workflow event trigger API and CLI

### DIFF
--- a/docs/content/client/cli/index.mdx
+++ b/docs/content/client/cli/index.mdx
@@ -28,6 +28,7 @@ asIndexPage: true
 | `gestalt plugins invoke NAME [OPERATION]` | Invoke an operation or list operations when omitted. |
 | `gestalt plugins describe NAME OPERATION` | Show one operation's parameter contract. |
 | `gestalt workflows schedules ...` | Create, list, inspect, update, pause, resume, or delete workflow schedules. |
+| `gestalt workflows triggers ...` | Create, list, inspect, update, pause, resume, or delete workflow event triggers. |
 | `gestalt workflows runs ...` | List, inspect, and cancel workflow runs. |
 | `gestalt tokens create\|list\|revoke` | Manage Gestalt API tokens. |
 
@@ -96,13 +97,22 @@ gestalt workflows schedules create \
   --operation issues.list \
   -p owner=valon-technologies \
   -p repo=gestalt
+gestalt workflows triggers create \
+  --type roadmap.item.updated \
+  --source roadmap \
+  --subject item \
+  --plugin slack \
+  --operation chat.postMessage \
+  -p channel=C123 \
+  -p text='Roadmap item updated'
 gestalt workflows runs list --plugin github --status failed
 gestalt tokens create --name automation
 ```
 
 ## Workflow commands
 
-The workflow CLI currently covers global schedules and workflow runs.
+The workflow CLI currently covers global schedules, global event triggers, and
+workflow runs.
 
 ### Schedules
 
@@ -129,6 +139,33 @@ gestalt workflows schedules delete <schedule-id>
 Use `-p key=value` for strings and `-p key:=json` for structured values. Use
 `--input-file file.json` to load the target input from JSON instead of flags.
 
+### Event triggers
+
+```sh
+gestalt workflows triggers list
+gestalt workflows triggers list --plugin slack --type roadmap.item.updated
+gestalt workflows triggers get <trigger-id>
+gestalt workflows triggers create \
+  --type roadmap.item.updated \
+  --source roadmap \
+  --subject item \
+  --plugin slack \
+  --operation chat.postMessage \
+  --connection default \
+  -p channel=C123 \
+  -p text='Roadmap item updated'
+gestalt workflows triggers update <trigger-id> --type roadmap.item.synced
+gestalt workflows triggers pause <trigger-id>
+gestalt workflows triggers resume <trigger-id>
+gestalt workflows triggers delete <trigger-id>
+```
+
+The create and update commands use the same target input conventions as
+schedules. `--type` is required. `--source` and `--subject` are optional exact
+match fields. There is still no generic public event-publish endpoint, so a
+trigger only fires when some provider or internal component publishes matching
+events into the workflow provider.
+
 ### Runs
 
 ```sh
@@ -137,9 +174,3 @@ gestalt workflows runs list --plugin github --status failed
 gestalt workflows runs get <run-id>
 gestalt workflows runs cancel <run-id> --reason "operator requested"
 ```
-
-### Event triggers
-
-Event triggers are not exposed as a CLI CRUD surface yet. Define them in the
-server config under top-level `workflows.eventTriggers`. See
-[Workflow](/providers/workflow) for examples.

--- a/docs/content/providers/workflow.mdx
+++ b/docs/content/providers/workflow.mdx
@@ -3,15 +3,15 @@ import { Callout, Tabs } from 'nextra/components'
 # Workflow
 
 Gestalt workflows let you invoke a plugin operation later instead of right now.
-Today that primarily means cron-based schedules, workflow run history and run
-cancelation, and config-managed event triggers. The workflow model is global.
-A workflow target is always explicit: `plugin`, `operation`, and optional
-`connection`, `instance`, and `input`.
+Today that primarily means cron-based schedules, event triggers, workflow run
+history, and run cancelation. The workflow model is global. A workflow target
+is always explicit: `plugin`, `operation`, and optional `connection`,
+`instance`, and `input`.
 
 <Callout type="info">
-  Event triggers exist today, but only as config-managed objects under
-  top-level `workflows.eventTriggers`. There is not yet a public HTTP or CLI
-  CRUD surface for event triggers or a generic public event-publish endpoint.
+  The public workflow surface now covers schedules, event triggers, and runs.
+  What still does not exist is a generic public event-publish endpoint such as
+  `/api/v1/workflow/events`.
 </Callout>
 
 ## Mental model
@@ -27,17 +27,18 @@ the global workflow runs surface.
 
 There are two ownership modes. Config-managed workflows live in YAML under
 top-level `workflows:` and execute as the system config actor. User-owned
-schedules are created through the global API or CLI and execute as the subject
-that created them.
+schedules and event triggers are created through the global API or CLI and
+execute as the subject that created them.
 
 ## How workflow providers work
 
 Workflow provider selection is global, not plugin-scoped. A config-managed
 workflow object chooses a provider with `provider`, or inherits the
 sole/default `providers.workflow` entry when that field is omitted.
-User-owned schedules use the same provider pool through the global HTTP API and
-CLI. In every case the target is explicit, and a workflow provider may bind a
-host IndexedDB provider through `providers.workflow.<name>.indexeddb`.
+User-owned schedules and event triggers use the same provider pool through the
+global HTTP API and CLI. In every case the target is explicit, and a workflow
+provider may bind a host IndexedDB provider through
+`providers.workflow.<name>.indexeddb`.
 
 ## How workflow execution uses authorization
 
@@ -238,6 +239,96 @@ The `provider` field is available on the HTTP API. Omit it when you have a
 sole/default workflow provider; include it when you need to select a specific
 workflow backend.
 
+## Creating user-owned event triggers
+
+User-owned event triggers are global resources exposed through
+`POST /api/v1/workflow/event-triggers` and
+`gestalt workflows triggers ...`. These triggers execute as the creating
+subject, not as a plugin-local or synthetic workflow workload.
+
+<Tabs items={['CLI', 'HTTP']}>
+  <Tabs.Tab>
+    ```sh
+    gestalt workflows triggers create \
+      --type roadmap.item.updated \
+      --source roadmap \
+      --subject item \
+      --plugin slack \
+      --operation chat.postMessage \
+      --connection default \
+      -p channel=C123 \
+      -p text='Roadmap item updated'
+    ```
+
+    List triggers:
+
+    ```sh
+    gestalt workflows triggers list
+    gestalt workflows triggers list --plugin slack --type roadmap.item.updated
+    ```
+
+    Inspect, update, pause, resume, or delete a trigger:
+
+    ```sh
+    gestalt workflows triggers get <trigger-id>
+    gestalt workflows triggers update <trigger-id> --type roadmap.item.synced
+    gestalt workflows triggers pause <trigger-id>
+    gestalt workflows triggers resume <trigger-id>
+    gestalt workflows triggers delete <trigger-id>
+    ```
+  </Tabs.Tab>
+  <Tabs.Tab>
+    ```sh
+    curl -X POST "$GESTALT_URL/api/v1/workflow/event-triggers" \
+      -H "Authorization: Bearer $GESTALT_API_KEY" \
+      -H "Content-Type: application/json" \
+      -d '{
+        "match": {
+          "type": "roadmap.item.updated",
+          "source": "roadmap",
+          "subject": "item"
+        },
+        "target": {
+          "plugin": "slack",
+          "operation": "chat.postMessage",
+          "connection": "default",
+          "input": {
+            "channel": "C123",
+            "text": "Roadmap item updated"
+          }
+        }
+      }'
+    ```
+
+    List or inspect triggers:
+
+    ```sh
+    curl -H "Authorization: Bearer $GESTALT_API_KEY" \
+      "$GESTALT_URL/api/v1/workflow/event-triggers"
+
+    curl -H "Authorization: Bearer $GESTALT_API_KEY" \
+      "$GESTALT_URL/api/v1/workflow/event-triggers/<trigger-id>"
+    ```
+
+    Pause, resume, or delete:
+
+    ```sh
+    curl -X POST -H "Authorization: Bearer $GESTALT_API_KEY" \
+      "$GESTALT_URL/api/v1/workflow/event-triggers/<trigger-id>/pause"
+
+    curl -X POST -H "Authorization: Bearer $GESTALT_API_KEY" \
+      "$GESTALT_URL/api/v1/workflow/event-triggers/<trigger-id>/resume"
+
+    curl -X DELETE -H "Authorization: Bearer $GESTALT_API_KEY" \
+      "$GESTALT_URL/api/v1/workflow/event-triggers/<trigger-id>"
+    ```
+  </Tabs.Tab>
+</Tabs>
+
+The `provider` field is available on the HTTP API here too. Omit it when you
+have a sole/default workflow provider; include it when you need to select a
+specific workflow backend.
+
 ## Inspecting and canceling workflow runs
 
 Runs are the execution records produced by schedules, event triggers, or other
@@ -283,19 +374,13 @@ Run responses include `id`, `provider`, `status`, `target`, `trigger`,
 `createdBy`, `createdAt`, `startedAt`, `completedAt`, `statusMessage`, and
 `resultBody`. The `trigger.kind` value is `schedule`, `event`, or `manual`.
 
-## Event triggers today
+## Event publishing today
 
-Event triggers are usable today, but they are more primitive than schedules
-from a product-surface perspective. What exists today is top-level config under
-`workflows.eventTriggers`, durable storage in the workflow provider, matching
-against published events, and normal workflow run records once a trigger fires.
-What does not exist yet is `gestalt workflows triggers ...`,
-`/api/v1/workflow/event-triggers`, or a generic public
-`/api/v1/workflow/events` publish endpoint.
-
-In practice, that makes event triggers most useful for deployment-managed
-automation defined in YAML, or for custom workflow providers and internal
-components that can publish events into the workflow provider.
+Event triggers are now manageable through the global API and CLI, but Gestalt
+still does not expose a generic public event-publish endpoint. In practice,
+that means event triggers are most useful when deployment-managed automation,
+custom workflow providers, or internal components already publish events into
+the workflow provider.
 
 If you are implementing a provider or another event producer, see
 [Custom Providers > Workflow](/custom-providers/workflow) for the
@@ -309,7 +394,7 @@ then the run is updated to `succeeded`, `failed`, or `canceled`.
 
 The execution identity depends on how the workflow was created. Config-managed
 schedules and event triggers execute as `system:config`, while user-owned
-schedules execute as the creating subject.
+schedules and event triggers execute as the creating subject.
 
 ## Building your own workflow provider
 

--- a/docs/content/reference/config-file.mdx
+++ b/docs/content/reference/config-file.mdx
@@ -331,8 +331,9 @@ top-level `workflows.schedules.*.provider` or
 `workflows.eventTriggers.*.provider`. There is no
 `server.providers.workflow`: config-managed workflow objects choose a provider
 explicitly, or inherit the sole/default workflow provider when `provider` is
-omitted. User-owned schedules use the same provider pool through
-`/api/v1/workflow/schedules` and `gestalt workflows ...`.
+omitted. User-owned schedules and event triggers use the same provider pool
+through `/api/v1/workflow/schedules`,
+`/api/v1/workflow/event-triggers`, and `gestalt workflows ...`.
 
 ```yaml
 providers:

--- a/docs/content/reference/http-api.mdx
+++ b/docs/content/reference/http-api.mdx
@@ -51,12 +51,19 @@ Authenticated routes accept a `session_token` cookie or an `Authorization: Beare
 | `DELETE` | `/api/v1/workflow/schedules/{scheduleID}` | Delete one workflow schedule. |
 | `POST` | `/api/v1/workflow/schedules/{scheduleID}/pause` | Pause one workflow schedule. |
 | `POST` | `/api/v1/workflow/schedules/{scheduleID}/resume` | Resume one workflow schedule. |
+| `GET` | `/api/v1/workflow/event-triggers` | List user-owned workflow event triggers. |
+| `POST` | `/api/v1/workflow/event-triggers` | Create a user-owned workflow event trigger. |
+| `GET` | `/api/v1/workflow/event-triggers/{triggerID}` | Inspect one workflow event trigger. |
+| `PUT` | `/api/v1/workflow/event-triggers/{triggerID}` | Update one workflow event trigger. |
+| `DELETE` | `/api/v1/workflow/event-triggers/{triggerID}` | Delete one workflow event trigger. |
+| `POST` | `/api/v1/workflow/event-triggers/{triggerID}/pause` | Pause one workflow event trigger. |
+| `POST` | `/api/v1/workflow/event-triggers/{triggerID}/resume` | Resume one workflow event trigger. |
 | `GET` | `/api/v1/workflow/runs` | List workflow runs. Supports optional `plugin` and `status` query filters. |
 | `GET` | `/api/v1/workflow/runs/{runID}` | Inspect one workflow run. |
 | `POST` | `/api/v1/workflow/runs/{runID}/cancel` | Cancel one workflow run. The request body may include an optional `reason`. |
 
-Event triggers are not exposed as a public HTTP CRUD surface yet. Today they
-are config-managed under top-level `workflows.eventTriggers`.
+Gestalt still does not expose a generic public event-publish endpoint such as
+`/api/v1/workflow/events`.
 
 ### API Tokens
 
@@ -159,6 +166,26 @@ curl -X POST http://localhost:8080/api/v1/workflow/schedules \
       "input": {
         "owner": "valon-technologies",
         "repo": "gestalt"
+      }
+    }
+  }'
+
+# Create a workflow event trigger
+curl -X POST http://localhost:8080/api/v1/workflow/event-triggers \
+  -H 'Authorization: Bearer gst_api_...' \
+  -H 'Content-Type: application/json' \
+  -d '{
+    "match": {
+      "type": "roadmap.item.updated",
+      "source": "roadmap",
+      "subject": "item"
+    },
+    "target": {
+      "plugin": "slack",
+      "operation": "chat.postMessage",
+      "input": {
+        "channel": "C123",
+        "text": "Roadmap item updated"
       }
     }
   }'

--- a/gestalt/cli/src/cli.rs
+++ b/gestalt/cli/src/cli.rs
@@ -64,7 +64,7 @@ pub enum Commands {
         command: IdentityCommands,
     },
 
-    /// Manage workflow resources (schedules)
+    /// Manage workflow resources
     Workflows {
         #[command(subcommand)]
         command: WorkflowCommands,
@@ -374,6 +374,11 @@ pub enum WorkflowCommands {
         #[command(subcommand)]
         command: WorkflowScheduleCommands,
     },
+    /// Manage workflow event triggers
+    Triggers {
+        #[command(subcommand)]
+        command: WorkflowTriggerCommands,
+    },
     /// Inspect workflow runs
     Runs {
         #[command(subcommand)]
@@ -411,6 +416,43 @@ pub enum WorkflowScheduleCommands {
     /// Resume a paused workflow schedule
     Resume {
         /// Schedule ID
+        id: String,
+    },
+}
+
+#[derive(Subcommand)]
+pub enum WorkflowTriggerCommands {
+    /// List workflow event triggers
+    List {
+        /// Filter event triggers by target plugin
+        #[arg(long)]
+        plugin: Option<String>,
+        /// Filter event triggers by event type
+        #[arg(long = "type")]
+        event_type: Option<String>,
+    },
+    /// Show a single workflow event trigger
+    Get {
+        /// Trigger ID
+        id: String,
+    },
+    /// Create a workflow event trigger
+    Create(WorkflowTriggerCreateArgs),
+    /// Update an existing workflow event trigger
+    Update(WorkflowTriggerUpdateArgs),
+    /// Delete a workflow event trigger
+    Delete {
+        /// Trigger ID
+        id: String,
+    },
+    /// Pause a workflow event trigger
+    Pause {
+        /// Trigger ID
+        id: String,
+    },
+    /// Resume a paused workflow event trigger
+    Resume {
+        /// Trigger ID
         id: String,
     },
 }
@@ -481,6 +523,49 @@ pub struct WorkflowScheduleCreateArgs {
 }
 
 #[derive(Args)]
+pub struct WorkflowTriggerCreateArgs {
+    /// Event type to match exactly
+    #[arg(long = "type")]
+    pub event_type: String,
+
+    /// Optional event source to match exactly
+    #[arg(long)]
+    pub source: Option<String>,
+
+    /// Optional event subject to match exactly
+    #[arg(long)]
+    pub subject: Option<String>,
+
+    /// Target plugin (e.g. "slack", "github")
+    #[arg(long)]
+    pub plugin: String,
+
+    /// Target operation (e.g. "chat.postMessage")
+    #[arg(long)]
+    pub operation: String,
+
+    /// Select a named connection
+    #[arg(long)]
+    pub connection: Option<String>,
+
+    /// Select a stored connection instance
+    #[arg(long)]
+    pub instance: Option<String>,
+
+    /// Create the trigger in paused state
+    #[arg(long)]
+    pub paused: bool,
+
+    /// Target input parameters as key=value or key:=json
+    #[arg(short = 'p', long = "param", value_parser = params::parse_param_entry)]
+    pub params: Vec<params::ParamEntry>,
+
+    /// Load target input from a JSON file (use "-" for stdin)
+    #[arg(long = "input-file")]
+    pub input_file: Option<String>,
+}
+
+#[derive(Args)]
 pub struct WorkflowScheduleUpdateArgs {
     /// Schedule ID
     pub id: String,
@@ -514,6 +599,60 @@ pub struct WorkflowScheduleUpdateArgs {
     pub paused: bool,
 
     /// Mark the schedule as not paused
+    #[arg(long = "no-paused", action = clap::ArgAction::SetTrue)]
+    pub unpaused: bool,
+
+    /// Replace target input with these key=value / key:=json entries
+    #[arg(short = 'p', long = "param", value_parser = params::parse_param_entry)]
+    pub params: Vec<params::ParamEntry>,
+
+    /// Replace target input with the contents of this JSON file ("-" for stdin)
+    #[arg(long = "input-file")]
+    pub input_file: Option<String>,
+
+    /// Clear the target input instead of keeping the existing value
+    #[arg(long = "clear-input", conflicts_with_all = ["params", "input_file"])]
+    pub clear_input: bool,
+}
+
+#[derive(Args)]
+pub struct WorkflowTriggerUpdateArgs {
+    /// Trigger ID
+    pub id: String,
+
+    /// Event type (leave unset to keep existing)
+    #[arg(long = "type")]
+    pub event_type: Option<String>,
+
+    /// Event source (leave unset to keep existing; pass empty string to clear)
+    #[arg(long)]
+    pub source: Option<String>,
+
+    /// Event subject (leave unset to keep existing; pass empty string to clear)
+    #[arg(long)]
+    pub subject: Option<String>,
+
+    /// Target plugin (leave unset to keep existing)
+    #[arg(long)]
+    pub plugin: Option<String>,
+
+    /// Target operation (leave unset to keep existing)
+    #[arg(long)]
+    pub operation: Option<String>,
+
+    /// Named connection (leave unset to keep existing; pass empty string to clear)
+    #[arg(long)]
+    pub connection: Option<String>,
+
+    /// Stored connection instance (leave unset to keep existing; pass empty string to clear)
+    #[arg(long)]
+    pub instance: Option<String>,
+
+    /// Mark the event trigger as paused
+    #[arg(long, conflicts_with = "unpaused", action = clap::ArgAction::SetTrue)]
+    pub paused: bool,
+
+    /// Mark the event trigger as not paused
     #[arg(long = "no-paused", action = clap::ArgAction::SetTrue)]
     pub unpaused: bool,
 

--- a/gestalt/cli/src/commands/workflows.rs
+++ b/gestalt/cli/src/commands/workflows.rs
@@ -2,11 +2,15 @@ use anyhow::{Context, Result, anyhow};
 use serde_json::{Map, Value, json};
 
 use crate::api::ApiClient;
-use crate::cli::{WorkflowScheduleCreateArgs, WorkflowScheduleUpdateArgs};
+use crate::cli::{
+    WorkflowScheduleCreateArgs, WorkflowScheduleUpdateArgs, WorkflowTriggerCreateArgs,
+    WorkflowTriggerUpdateArgs,
+};
 use crate::output::{self, Format};
 use crate::params::{self, ParamEntry};
 
 const SCHEDULES_PATH: &str = "/api/v1/workflow/schedules";
+const TRIGGERS_PATH: &str = "/api/v1/workflow/event-triggers";
 const RUNS_PATH: &str = "/api/v1/workflow/runs";
 
 pub fn list(client: &ApiClient, plugin: Option<&str>, format: Format) -> Result<()> {
@@ -86,6 +90,98 @@ pub fn resume(client: &ApiClient, id: &str, format: Format) -> Result<()> {
     Ok(())
 }
 
+pub fn list_triggers(
+    client: &ApiClient,
+    plugin: Option<&str>,
+    event_type: Option<&str>,
+    format: Format,
+) -> Result<()> {
+    let resp = client
+        .get(TRIGGERS_PATH)
+        .context("failed to list workflow event triggers")?;
+    let filtered = filter_triggers(resp, plugin, event_type);
+    print_triggers(&filtered, format);
+    Ok(())
+}
+
+pub fn get_trigger(client: &ApiClient, id: &str, format: Format) -> Result<()> {
+    let resp = client
+        .get(&format!("{TRIGGERS_PATH}/{id}"))
+        .with_context(|| format!("failed to get workflow event trigger {id}"))?;
+    print_trigger(&resp, format);
+    Ok(())
+}
+
+pub fn create_trigger(
+    client: &ApiClient,
+    args: &WorkflowTriggerCreateArgs,
+    format: Format,
+) -> Result<()> {
+    let input = build_target_input(&args.params, args.input_file.as_deref())?;
+    let body = build_trigger_upsert_body(
+        None,
+        &args.event_type,
+        args.source.as_deref(),
+        args.subject.as_deref(),
+        &args.plugin,
+        &args.operation,
+        args.connection.as_deref(),
+        args.instance.as_deref(),
+        input.as_ref(),
+        args.paused,
+    );
+
+    let resp = client
+        .post(TRIGGERS_PATH, &body)
+        .context("failed to create workflow event trigger")?;
+    print_trigger(&resp, format);
+    Ok(())
+}
+
+pub fn update_trigger(
+    client: &ApiClient,
+    args: &WorkflowTriggerUpdateArgs,
+    format: Format,
+) -> Result<()> {
+    let existing = client
+        .get(&format!("{TRIGGERS_PATH}/{id}", id = args.id))
+        .with_context(|| format!("failed to load workflow event trigger {}", args.id))?;
+
+    let body = merge_trigger_update(args, &existing)?;
+    let resp = client
+        .put(&format!("{TRIGGERS_PATH}/{id}", id = args.id), &body)
+        .with_context(|| format!("failed to update workflow event trigger {}", args.id))?;
+    print_trigger(&resp, format);
+    Ok(())
+}
+
+pub fn delete_trigger(client: &ApiClient, id: &str, format: Format) -> Result<()> {
+    let resp = client
+        .delete(&format!("{TRIGGERS_PATH}/{id}"))
+        .with_context(|| format!("failed to delete workflow event trigger {id}"))?;
+    match format {
+        Format::Json => output::print_json(&resp),
+        Format::Table => output::print_success(&format!("Workflow event trigger {id} deleted.")),
+    }
+    Ok(())
+}
+
+pub fn pause_trigger(client: &ApiClient, id: &str, format: Format) -> Result<()> {
+    let resp = client
+        .post(&format!("{TRIGGERS_PATH}/{id}/pause"), &json!({}))
+        .with_context(|| format!("failed to pause workflow event trigger {id}"))?;
+    print_trigger(&resp, format);
+    Ok(())
+}
+
+pub fn resume_trigger(client: &ApiClient, id: &str, format: Format) -> Result<()> {
+    let resp = client
+        .post(&format!("{TRIGGERS_PATH}/{id}/resume"), &json!({}))
+        .with_context(|| format!("failed to resume workflow event trigger {id}"))?;
+    print_trigger(&resp, format);
+    Ok(())
+}
+
 pub fn list_runs(
     client: &ApiClient,
     plugin: Option<&str>,
@@ -159,6 +255,25 @@ fn filter_runs(value: Value, plugin: Option<&str>, status: Option<&str>) -> Valu
     )
 }
 
+fn filter_triggers(value: Value, plugin: Option<&str>, event_type: Option<&str>) -> Value {
+    let Value::Array(items) = value else {
+        return value;
+    };
+    Value::Array(
+        items
+            .into_iter()
+            .filter(|item| {
+                plugin
+                    .map(|plugin| item["target"]["plugin"].as_str() == Some(plugin))
+                    .unwrap_or(true)
+                    && event_type
+                        .map(|event_type| item["match"]["type"].as_str() == Some(event_type))
+                        .unwrap_or(true)
+            })
+            .collect(),
+    )
+}
+
 fn build_target_input(
     params: &[ParamEntry],
     input_file: Option<&str>,
@@ -194,31 +309,47 @@ fn build_upsert_body(
     input: Option<&Map<String, Value>>,
     paused: bool,
 ) -> Value {
-    let mut target = Map::new();
-    target.insert("plugin".to_string(), Value::String(plugin.to_string()));
-    target.insert(
-        "operation".to_string(),
-        Value::String(operation.to_string()),
-    );
-    if let Some(connection) = connection {
-        target.insert(
-            "connection".to_string(),
-            Value::String(connection.to_string()),
-        );
-    }
-    if let Some(instance) = instance {
-        target.insert("instance".to_string(), Value::String(instance.to_string()));
-    }
-    if let Some(input) = input {
-        target.insert("input".to_string(), Value::Object(input.clone()));
-    }
-
     let mut body = Map::new();
     body.insert("cron".to_string(), Value::String(cron.to_string()));
     if let Some(timezone) = timezone {
         body.insert("timezone".to_string(), Value::String(timezone.to_string()));
     }
-    body.insert("target".to_string(), Value::Object(target));
+    body.insert(
+        "target".to_string(),
+        build_target_object(plugin, operation, connection, instance, input),
+    );
+    body.insert("paused".to_string(), Value::Bool(paused));
+    Value::Object(body)
+}
+
+#[allow(clippy::too_many_arguments)]
+fn build_trigger_upsert_body(
+    provider: Option<&str>,
+    event_type: &str,
+    source: Option<&str>,
+    subject: Option<&str>,
+    plugin: &str,
+    operation: &str,
+    connection: Option<&str>,
+    instance: Option<&str>,
+    input: Option<&Map<String, Value>>,
+    paused: bool,
+) -> Value {
+    let mut body = Map::new();
+    if let Some(provider) = provider {
+        let provider = provider.trim();
+        if !provider.is_empty() {
+            body.insert("provider".to_string(), Value::String(provider.to_string()));
+        }
+    }
+    body.insert(
+        "match".to_string(),
+        build_event_match(event_type, source, subject),
+    );
+    body.insert(
+        "target".to_string(),
+        build_target_object(plugin, operation, connection, instance, input),
+    );
     body.insert("paused".to_string(), Value::Bool(paused));
     Value::Object(body)
 }
@@ -287,12 +418,123 @@ fn merge_update(args: &WorkflowScheduleUpdateArgs, existing: &Value) -> Result<V
     ))
 }
 
+fn merge_trigger_update(args: &WorkflowTriggerUpdateArgs, existing: &Value) -> Result<Value> {
+    let event_type = match args.event_type.as_deref() {
+        Some(value) => value.to_string(),
+        None => existing["match"]["type"]
+            .as_str()
+            .ok_or_else(|| anyhow!("existing event trigger is missing match.type; pass --type"))?
+            .to_string(),
+    };
+    let source =
+        resolve_optional_string(args.source.as_deref(), existing["match"]["source"].as_str());
+    let subject = resolve_optional_string(
+        args.subject.as_deref(),
+        existing["match"]["subject"].as_str(),
+    );
+    let plugin = match args.plugin.as_deref() {
+        Some(value) => value.to_string(),
+        None => existing["target"]["plugin"]
+            .as_str()
+            .ok_or_else(|| {
+                anyhow!("existing event trigger is missing target.plugin; pass --plugin")
+            })?
+            .to_string(),
+    };
+    let operation = match args.operation.as_deref() {
+        Some(value) => value.to_string(),
+        None => existing["target"]["operation"]
+            .as_str()
+            .ok_or_else(|| {
+                anyhow!("existing event trigger is missing target.operation; pass --operation")
+            })?
+            .to_string(),
+    };
+    let connection = resolve_optional_string(
+        args.connection.as_deref(),
+        existing["target"]["connection"].as_str(),
+    );
+    let instance = resolve_optional_string(
+        args.instance.as_deref(),
+        existing["target"]["instance"].as_str(),
+    );
+
+    let input = if args.clear_input {
+        None
+    } else if !args.params.is_empty() || args.input_file.is_some() {
+        build_target_input(&args.params, args.input_file.as_deref())?
+    } else {
+        existing["target"]["input"].as_object().cloned()
+    };
+
+    let paused = if args.paused {
+        true
+    } else if args.unpaused {
+        false
+    } else {
+        existing["paused"].as_bool().unwrap_or(false)
+    };
+
+    Ok(build_trigger_upsert_body(
+        existing["provider"].as_str(),
+        &event_type,
+        source.as_deref(),
+        subject.as_deref(),
+        &plugin,
+        &operation,
+        connection.as_deref(),
+        instance.as_deref(),
+        input.as_ref(),
+        paused,
+    ))
+}
+
 fn resolve_optional_string(arg: Option<&str>, existing: Option<&str>) -> Option<String> {
     match arg {
         Some("") => None,
         Some(value) => Some(value.to_string()),
         None => existing.map(str::to_string),
     }
+}
+
+fn build_target_object(
+    plugin: &str,
+    operation: &str,
+    connection: Option<&str>,
+    instance: Option<&str>,
+    input: Option<&Map<String, Value>>,
+) -> Value {
+    let mut target = Map::new();
+    target.insert("plugin".to_string(), Value::String(plugin.to_string()));
+    target.insert(
+        "operation".to_string(),
+        Value::String(operation.to_string()),
+    );
+    if let Some(connection) = connection {
+        target.insert(
+            "connection".to_string(),
+            Value::String(connection.to_string()),
+        );
+    }
+    if let Some(instance) = instance {
+        target.insert("instance".to_string(), Value::String(instance.to_string()));
+    }
+    if let Some(input) = input {
+        target.insert("input".to_string(), Value::Object(input.clone()));
+    }
+    Value::Object(target)
+}
+
+fn build_event_match(event_type: &str, source: Option<&str>, subject: Option<&str>) -> Value {
+    let mut match_body = Map::new();
+    match_body.insert("type".to_string(), Value::String(event_type.to_string()));
+    if let Some(source) = source {
+        match_body.insert("source".to_string(), Value::String(source.to_string()));
+    }
+    if let Some(subject) = subject {
+        match_body.insert("subject".to_string(), Value::String(subject.to_string()));
+    }
+    Value::Object(match_body)
 }
 
 fn print_schedule(value: &Value, format: Format) {
@@ -316,6 +558,27 @@ fn print_schedules(value: &Value, format: Format) {
     }
 }
 
+fn print_trigger(value: &Value, format: Format) {
+    match format {
+        Format::Json => output::print_json(value),
+        Format::Table => {
+            let rows = vec![trigger_row(value)];
+            output::print_table(&trigger_headers(), &rows);
+        }
+    }
+}
+
+fn print_triggers(value: &Value, format: Format) {
+    match format {
+        Format::Json => output::print_json(value),
+        Format::Table => {
+            let items = value.as_array().cloned().unwrap_or_default();
+            let rows: Vec<Vec<String>> = items.iter().map(trigger_row).collect();
+            output::print_table(&trigger_headers(), &rows);
+        }
+    }
+}
+
 fn print_run(value: &Value, format: Format) {
     match format {
         Format::Json => output::print_json(value),
@@ -335,6 +598,41 @@ fn print_runs(value: &Value, format: Format) {
             output::print_table(&run_headers(), &rows);
         }
     }
+}
+
+fn trigger_headers() -> [&'static str; 8] {
+    [
+        "ID",
+        "Type",
+        "Source",
+        "Subject",
+        "Plugin",
+        "Operation",
+        "Paused",
+        "Created",
+    ]
+}
+
+fn trigger_row(value: &Value) -> Vec<String> {
+    vec![
+        value["id"].as_str().unwrap_or("-").to_string(),
+        value["match"]["type"].as_str().unwrap_or("-").to_string(),
+        value["match"]["source"].as_str().unwrap_or("-").to_string(),
+        value["match"]["subject"]
+            .as_str()
+            .unwrap_or("-")
+            .to_string(),
+        value["target"]["plugin"]
+            .as_str()
+            .unwrap_or("-")
+            .to_string(),
+        value["target"]["operation"]
+            .as_str()
+            .unwrap_or("-")
+            .to_string(),
+        format_bool(value["paused"].as_bool()),
+        value["createdAt"].as_str().unwrap_or("-").to_string(),
+    ]
 }
 
 fn schedule_headers() -> [&'static str; 8] {

--- a/gestalt/cli/src/main.rs
+++ b/gestalt/cli/src/main.rs
@@ -4,6 +4,7 @@ use gestalt::cli::{
     AuthCommands, Cli, Commands, ConfigCommands, DescribeArgs, IdentityCommands,
     IdentityGrantCommands, IdentityMemberCommands, IdentityTokenCommands, InvokeArgs,
     PluginCommands, TokenCommands, WorkflowCommands, WorkflowRunCommands, WorkflowScheduleCommands,
+    WorkflowTriggerCommands,
 };
 use gestalt::commands;
 use gestalt::output;
@@ -150,6 +151,34 @@ fn run() -> anyhow::Result<()> {
                     }
                     WorkflowScheduleCommands::Resume { id } => {
                         commands::workflows::resume(&client, &id, format)
+                    }
+                },
+                WorkflowCommands::Triggers { command } => match command {
+                    WorkflowTriggerCommands::List { plugin, event_type } => {
+                        commands::workflows::list_triggers(
+                            &client,
+                            plugin.as_deref(),
+                            event_type.as_deref(),
+                            format,
+                        )
+                    }
+                    WorkflowTriggerCommands::Get { id } => {
+                        commands::workflows::get_trigger(&client, &id, format)
+                    }
+                    WorkflowTriggerCommands::Create(args) => {
+                        commands::workflows::create_trigger(&client, &args, format)
+                    }
+                    WorkflowTriggerCommands::Update(args) => {
+                        commands::workflows::update_trigger(&client, &args, format)
+                    }
+                    WorkflowTriggerCommands::Delete { id } => {
+                        commands::workflows::delete_trigger(&client, &id, format)
+                    }
+                    WorkflowTriggerCommands::Pause { id } => {
+                        commands::workflows::pause_trigger(&client, &id, format)
+                    }
+                    WorkflowTriggerCommands::Resume { id } => {
+                        commands::workflows::resume_trigger(&client, &id, format)
                     }
                 },
                 WorkflowCommands::Runs { command } => match command {

--- a/gestalt/cli/tests/workflows_cli.rs
+++ b/gestalt/cli/tests/workflows_cli.rs
@@ -18,6 +18,20 @@ const SCHEDULE_JSON: &str = r#"{
     "nextRunAt":"2026-04-21T00:00:00Z"
 }"#;
 
+const TRIGGER_JSON: &str = r#"{
+    "id":"trg-1",
+    "provider":"test-provider",
+    "match":{"type":"dummy.event","source":"dummy","subject":"item"},
+    "target":{
+        "plugin":"dummy",
+        "operation":"doit",
+        "input":{"k":"v"}
+    },
+    "paused":false,
+    "createdAt":"2026-04-20T00:00:00Z",
+    "updatedAt":"2026-04-20T00:00:00Z"
+}"#;
+
 const RUN_JSON: &str = r#"{
     "id":"run-1",
     "provider":"test-provider",
@@ -276,6 +290,237 @@ fn test_cli_list_schedules_json_format() {
         .success()
         .stdout(predicate::str::contains(r#""id": "sched-1""#))
         .stdout(predicate::str::contains(r#""plugin": "dummy""#));
+}
+
+#[test]
+fn test_cli_lists_event_triggers() {
+    let mut server = Server::new();
+    let _mock = authed_json_mock!(
+        server,
+        Method::GET,
+        "/api/v1/workflow/event-triggers",
+        StatusCode::OK
+    )
+    .with_body(format!("[{TRIGGER_JSON}]"))
+    .create();
+
+    let home = tempfile::tempdir().unwrap();
+    cli_command_for_server(home.path(), &server)
+        .args(["workflows", "triggers", "list"])
+        .assert()
+        .success()
+        .stdout(predicate::str::contains("trg-1"))
+        .stdout(predicate::str::contains("dummy"))
+        .stdout(predicate::str::contains("doit"));
+}
+
+#[test]
+fn test_cli_list_event_triggers_filters() {
+    let body = r#"[
+        {"id":"trg-a","match":{"type":"alpha.created"},"target":{"plugin":"alpha","operation":"x"},"paused":false},
+        {"id":"trg-b","match":{"type":"beta.failed"},"target":{"plugin":"beta","operation":"y"},"paused":false}
+    ]"#;
+    let mut server = Server::new();
+    let _mock = authed_json_mock!(
+        server,
+        Method::GET,
+        "/api/v1/workflow/event-triggers",
+        StatusCode::OK
+    )
+    .with_body(body)
+    .create();
+
+    let home = tempfile::tempdir().unwrap();
+    cli_command_for_server(home.path(), &server)
+        .args([
+            "workflows",
+            "triggers",
+            "list",
+            "--plugin",
+            "beta",
+            "--type",
+            "beta.failed",
+        ])
+        .assert()
+        .success()
+        .stdout(predicate::str::contains("trg-b"))
+        .stdout(predicate::str::contains("trg-a").not());
+}
+
+#[test]
+fn test_cli_gets_event_trigger() {
+    let mut server = Server::new();
+    let _mock = authed_json_mock!(
+        server,
+        Method::GET,
+        "/api/v1/workflow/event-triggers/trg-1",
+        StatusCode::OK
+    )
+    .with_body(TRIGGER_JSON)
+    .create();
+
+    let home = tempfile::tempdir().unwrap();
+    cli_command_for_server(home.path(), &server)
+        .args(["workflows", "triggers", "get", "trg-1"])
+        .assert()
+        .success()
+        .stdout(predicate::str::contains("trg-1"))
+        .stdout(predicate::str::contains("dummy"));
+}
+
+#[test]
+fn test_cli_creates_event_trigger() {
+    let mut server = Server::new();
+    let _mock = authed_json_mock!(
+        server,
+        Method::POST,
+        "/api/v1/workflow/event-triggers",
+        StatusCode::CREATED
+    )
+    .match_header(header::CONTENT_TYPE.as_str(), http::APPLICATION_JSON)
+    .match_body(Matcher::JsonString(
+        r#"{
+            "match":{"type":"dummy.event","source":"dummy","subject":"item"},
+            "target":{"plugin":"dummy","operation":"doit","input":{"channel":"C1","text":"hi"}},
+            "paused":false
+        }"#
+        .to_string(),
+    ))
+    .with_body(TRIGGER_JSON)
+    .create();
+
+    let home = tempfile::tempdir().unwrap();
+    cli_command_for_server(home.path(), &server)
+        .args([
+            "workflows",
+            "triggers",
+            "create",
+            "--type",
+            "dummy.event",
+            "--source",
+            "dummy",
+            "--subject",
+            "item",
+            "--plugin",
+            "dummy",
+            "--operation",
+            "doit",
+            "-p",
+            "channel=C1",
+            "-p",
+            "text=hi",
+        ])
+        .assert()
+        .success()
+        .stdout(predicate::str::contains("trg-1"));
+}
+
+#[test]
+fn test_cli_updates_event_trigger_merges_existing_fields() {
+    let mut server = Server::new();
+    let _get = authed_json_mock!(
+        server,
+        Method::GET,
+        "/api/v1/workflow/event-triggers/trg-1",
+        StatusCode::OK
+    )
+    .with_body(TRIGGER_JSON)
+    .create();
+
+    let _put = authed_json_mock!(
+        server,
+        Method::PUT,
+        "/api/v1/workflow/event-triggers/trg-1",
+        StatusCode::OK
+    )
+    .match_header(header::CONTENT_TYPE.as_str(), http::APPLICATION_JSON)
+    .match_body(Matcher::JsonString(
+        r#"{
+            "provider":"test-provider",
+            "match":{"type":"dummy.event.updated","source":"dummy","subject":"item"},
+            "target":{"plugin":"dummy","operation":"doit","input":{"k":"v"}},
+            "paused":true
+        }"#
+        .to_string(),
+    ))
+    .with_body(TRIGGER_JSON)
+    .create();
+
+    let home = tempfile::tempdir().unwrap();
+    cli_command_for_server(home.path(), &server)
+        .args([
+            "workflows",
+            "triggers",
+            "update",
+            "trg-1",
+            "--type",
+            "dummy.event.updated",
+            "--paused",
+        ])
+        .assert()
+        .success();
+}
+
+#[test]
+fn test_cli_deletes_event_trigger() {
+    let mut server = Server::new();
+    let _mock = authed_json_mock!(
+        server,
+        Method::DELETE,
+        "/api/v1/workflow/event-triggers/trg-1",
+        StatusCode::OK
+    )
+    .with_body(r#"{"status":"deleted"}"#)
+    .create();
+
+    let home = tempfile::tempdir().unwrap();
+    cli_command_for_server(home.path(), &server)
+        .args(["workflows", "triggers", "delete", "trg-1"])
+        .assert()
+        .success()
+        .stderr(predicate::str::contains(
+            "Workflow event trigger trg-1 deleted.",
+        ));
+}
+
+#[test]
+fn test_cli_pauses_event_trigger() {
+    let mut server = Server::new();
+    let _mock = authed_json_mock!(
+        server,
+        Method::POST,
+        "/api/v1/workflow/event-triggers/trg-1/pause",
+        StatusCode::OK
+    )
+    .with_body(TRIGGER_JSON)
+    .create();
+
+    let home = tempfile::tempdir().unwrap();
+    cli_command_for_server(home.path(), &server)
+        .args(["workflows", "triggers", "pause", "trg-1"])
+        .assert()
+        .success()
+        .stdout(predicate::str::contains("trg-1"));
+}
+
+#[test]
+fn test_cli_resumes_event_trigger() {
+    let mut server = Server::new();
+    let _mock = authed_json_mock!(
+        server,
+        Method::POST,
+        "/api/v1/workflow/event-triggers/trg-1/resume",
+        StatusCode::OK
+    )
+    .with_body(TRIGGER_JSON)
+    .create();
+
+    let home = tempfile::tempdir().unwrap();
+    cli_command_for_server(home.path(), &server)
+        .args(["workflows", "triggers", "resume", "trg-1"])
+        .assert()
+        .success()
+        .stdout(predicate::str::contains("trg-1"));
 }
 
 #[test]

--- a/gestaltd/internal/bootstrap/executable_plugin_test.go
+++ b/gestaltd/internal/bootstrap/executable_plugin_test.go
@@ -354,6 +354,34 @@ func (m *stubWorkflowManager) ResumeSchedule(_ context.Context, p *principal.Pri
 	return cloneManagedSchedule(value), nil
 }
 
+func (m *stubWorkflowManager) ListEventTriggers(context.Context, *principal.Principal) ([]*workflowmanager.ManagedEventTrigger, error) {
+	return nil, nil
+}
+
+func (m *stubWorkflowManager) CreateEventTrigger(context.Context, *principal.Principal, workflowmanager.EventTriggerUpsert) (*workflowmanager.ManagedEventTrigger, error) {
+	return nil, fmt.Errorf("event triggers are not implemented in this test stub")
+}
+
+func (m *stubWorkflowManager) GetEventTrigger(context.Context, *principal.Principal, string) (*workflowmanager.ManagedEventTrigger, error) {
+	return nil, core.ErrNotFound
+}
+
+func (m *stubWorkflowManager) UpdateEventTrigger(context.Context, *principal.Principal, string, workflowmanager.EventTriggerUpsert) (*workflowmanager.ManagedEventTrigger, error) {
+	return nil, core.ErrNotFound
+}
+
+func (m *stubWorkflowManager) DeleteEventTrigger(context.Context, *principal.Principal, string) error {
+	return core.ErrNotFound
+}
+
+func (m *stubWorkflowManager) PauseEventTrigger(context.Context, *principal.Principal, string) (*workflowmanager.ManagedEventTrigger, error) {
+	return nil, core.ErrNotFound
+}
+
+func (m *stubWorkflowManager) ResumeEventTrigger(context.Context, *principal.Principal, string) (*workflowmanager.ManagedEventTrigger, error) {
+	return nil, core.ErrNotFound
+}
+
 func (m *stubWorkflowManager) ListRuns(context.Context, *principal.Principal) ([]*workflowmanager.ManagedRun, error) {
 	return nil, nil
 }

--- a/gestaltd/internal/bootstrap/lazy_workflow_manager.go
+++ b/gestaltd/internal/bootstrap/lazy_workflow_manager.go
@@ -80,6 +80,62 @@ func (l *lazyWorkflowManager) ResumeSchedule(ctx context.Context, p *principal.P
 	return target.ResumeSchedule(ctx, p, scheduleID)
 }
 
+func (l *lazyWorkflowManager) ListEventTriggers(ctx context.Context, p *principal.Principal) ([]*workflowmanager.ManagedEventTrigger, error) {
+	target, err := l.current()
+	if err != nil {
+		return nil, err
+	}
+	return target.ListEventTriggers(ctx, p)
+}
+
+func (l *lazyWorkflowManager) CreateEventTrigger(ctx context.Context, p *principal.Principal, req workflowmanager.EventTriggerUpsert) (*workflowmanager.ManagedEventTrigger, error) {
+	target, err := l.current()
+	if err != nil {
+		return nil, err
+	}
+	return target.CreateEventTrigger(ctx, p, req)
+}
+
+func (l *lazyWorkflowManager) GetEventTrigger(ctx context.Context, p *principal.Principal, triggerID string) (*workflowmanager.ManagedEventTrigger, error) {
+	target, err := l.current()
+	if err != nil {
+		return nil, err
+	}
+	return target.GetEventTrigger(ctx, p, triggerID)
+}
+
+func (l *lazyWorkflowManager) UpdateEventTrigger(ctx context.Context, p *principal.Principal, triggerID string, req workflowmanager.EventTriggerUpsert) (*workflowmanager.ManagedEventTrigger, error) {
+	target, err := l.current()
+	if err != nil {
+		return nil, err
+	}
+	return target.UpdateEventTrigger(ctx, p, triggerID, req)
+}
+
+func (l *lazyWorkflowManager) DeleteEventTrigger(ctx context.Context, p *principal.Principal, triggerID string) error {
+	target, err := l.current()
+	if err != nil {
+		return err
+	}
+	return target.DeleteEventTrigger(ctx, p, triggerID)
+}
+
+func (l *lazyWorkflowManager) PauseEventTrigger(ctx context.Context, p *principal.Principal, triggerID string) (*workflowmanager.ManagedEventTrigger, error) {
+	target, err := l.current()
+	if err != nil {
+		return nil, err
+	}
+	return target.PauseEventTrigger(ctx, p, triggerID)
+}
+
+func (l *lazyWorkflowManager) ResumeEventTrigger(ctx context.Context, p *principal.Principal, triggerID string) (*workflowmanager.ManagedEventTrigger, error) {
+	target, err := l.current()
+	if err != nil {
+		return nil, err
+	}
+	return target.ResumeEventTrigger(ctx, p, triggerID)
+}
+
 func (l *lazyWorkflowManager) ListRuns(ctx context.Context, p *principal.Principal) ([]*workflowmanager.ManagedRun, error) {
 	target, err := l.current()
 	if err != nil {

--- a/gestaltd/internal/bootstrap/provider_build.go
+++ b/gestaltd/internal/bootstrap/provider_build.go
@@ -1179,6 +1179,34 @@ func (unavailableWorkflowManager) ResumeSchedule(context.Context, *principal.Pri
 	return nil, fmt.Errorf("workflow manager is not available")
 }
 
+func (unavailableWorkflowManager) ListEventTriggers(context.Context, *principal.Principal) ([]*workflowmanager.ManagedEventTrigger, error) {
+	return nil, fmt.Errorf("workflow manager is not available")
+}
+
+func (unavailableWorkflowManager) CreateEventTrigger(context.Context, *principal.Principal, workflowmanager.EventTriggerUpsert) (*workflowmanager.ManagedEventTrigger, error) {
+	return nil, fmt.Errorf("workflow manager is not available")
+}
+
+func (unavailableWorkflowManager) GetEventTrigger(context.Context, *principal.Principal, string) (*workflowmanager.ManagedEventTrigger, error) {
+	return nil, fmt.Errorf("workflow manager is not available")
+}
+
+func (unavailableWorkflowManager) UpdateEventTrigger(context.Context, *principal.Principal, string, workflowmanager.EventTriggerUpsert) (*workflowmanager.ManagedEventTrigger, error) {
+	return nil, fmt.Errorf("workflow manager is not available")
+}
+
+func (unavailableWorkflowManager) DeleteEventTrigger(context.Context, *principal.Principal, string) error {
+	return fmt.Errorf("workflow manager is not available")
+}
+
+func (unavailableWorkflowManager) PauseEventTrigger(context.Context, *principal.Principal, string) (*workflowmanager.ManagedEventTrigger, error) {
+	return nil, fmt.Errorf("workflow manager is not available")
+}
+
+func (unavailableWorkflowManager) ResumeEventTrigger(context.Context, *principal.Principal, string) (*workflowmanager.ManagedEventTrigger, error) {
+	return nil, fmt.Errorf("workflow manager is not available")
+}
+
 func (unavailableWorkflowManager) ListRuns(context.Context, *principal.Principal) ([]*workflowmanager.ManagedRun, error) {
 	return nil, fmt.Errorf("workflow manager is not available")
 }

--- a/gestaltd/internal/providerhost/workflow_manager_server.go
+++ b/gestaltd/internal/providerhost/workflow_manager_server.go
@@ -220,6 +220,8 @@ func workflowManagerStatusError(err error) error {
 	switch {
 	case errors.Is(err, workflowmanager.ErrWorkflowNotConfigured), errors.Is(err, workflowmanager.ErrExecutionRefsNotConfigured), errors.Is(err, invocation.ErrNoToken), errors.Is(err, invocation.ErrAmbiguousInstance), errors.Is(err, invocation.ErrUserResolution):
 		return status.Error(codes.FailedPrecondition, err.Error())
+	case errors.Is(err, workflowmanager.ErrWorkflowEventMatchRequired):
+		return status.Error(codes.InvalidArgument, err.Error())
 	case errors.Is(err, workflowmanager.ErrWorkflowScheduleSubject), errors.Is(err, invocation.ErrNotAuthenticated):
 		return status.Error(codes.Unauthenticated, err.Error())
 	case errors.Is(err, workflowmanager.ErrDuplicateExecutionRefs), errors.Is(err, invocation.ErrInternal):

--- a/gestaltd/internal/server/handlers_workflow_event_triggers.go
+++ b/gestaltd/internal/server/handlers_workflow_event_triggers.go
@@ -1,0 +1,273 @@
+package server
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"log/slog"
+	"maps"
+	"net/http"
+	"strings"
+	"time"
+
+	"github.com/go-chi/chi/v5"
+	"github.com/valon-technologies/gestalt/server/core"
+	coreworkflow "github.com/valon-technologies/gestalt/server/core/workflow"
+	"github.com/valon-technologies/gestalt/server/internal/invocation"
+	"github.com/valon-technologies/gestalt/server/internal/workflowmanager"
+)
+
+type workflowEventTriggerMatchRequest struct {
+	Type    string `json:"type"`
+	Source  string `json:"source,omitempty"`
+	Subject string `json:"subject,omitempty"`
+}
+
+type workflowEventTriggerUpsertRequest struct {
+	Provider string                           `json:"provider,omitempty"`
+	Match    workflowEventTriggerMatchRequest `json:"match"`
+	Target   workflowScheduleTargetRequest    `json:"target"`
+	Paused   bool                             `json:"paused,omitempty"`
+}
+
+type workflowEventTriggerMatchInfo struct {
+	Type    string `json:"type"`
+	Source  string `json:"source,omitempty"`
+	Subject string `json:"subject,omitempty"`
+}
+
+type workflowEventTriggerInfo struct {
+	ID        string                        `json:"id"`
+	Provider  string                        `json:"provider"`
+	Match     workflowEventTriggerMatchInfo `json:"match"`
+	Target    workflowScheduleTargetInfo    `json:"target"`
+	Paused    bool                          `json:"paused"`
+	CreatedAt *time.Time                    `json:"createdAt,omitempty"`
+	UpdatedAt *time.Time                    `json:"updatedAt,omitempty"`
+}
+
+func (s *Server) listGlobalWorkflowEventTriggers(w http.ResponseWriter, r *http.Request) {
+	p, ok := s.resolveWorkflowScheduleActor(w, r)
+	if !ok {
+		return
+	}
+	triggers, err := s.workflowSchedules.ListEventTriggers(r.Context(), p)
+	if err != nil {
+		s.writeWorkflowEventTriggerManagerError(w, r, "", "", "", err)
+		return
+	}
+	out := make([]workflowEventTriggerInfo, 0, len(triggers))
+	for _, managed := range triggers {
+		out = append(out, workflowEventTriggerInfoFromManaged(managed))
+	}
+	writeJSON(w, http.StatusOK, out)
+}
+
+func (s *Server) createGlobalWorkflowEventTrigger(w http.ResponseWriter, r *http.Request) {
+	p, ok := s.resolveWorkflowScheduleActor(w, r)
+	if !ok {
+		return
+	}
+
+	var req workflowEventTriggerUpsertRequest
+	if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
+		writeError(w, http.StatusBadRequest, "invalid JSON body")
+		return
+	}
+	pluginName := strings.TrimSpace(req.Target.Plugin)
+	if pluginName == "" {
+		writeError(w, http.StatusBadRequest, "workflow target plugin is required")
+		return
+	}
+	if strings.TrimSpace(req.Match.Type) == "" {
+		writeError(w, http.StatusBadRequest, "workflow event trigger match.type is required")
+		return
+	}
+	managed, err := s.workflowSchedules.CreateEventTrigger(r.Context(), p, workflowmanager.EventTriggerUpsert{
+		ProviderName: strings.TrimSpace(req.Provider),
+		Match:        workflowEventMatchFromRequest(req.Match),
+		Target:       workflowScheduleTargetFromRequest(req.Target),
+		Paused:       req.Paused,
+	})
+	if err != nil {
+		s.writeWorkflowEventTriggerManagerError(w, r, pluginName, strings.TrimSpace(req.Target.Operation), "", err)
+		return
+	}
+	writeJSON(w, http.StatusCreated, workflowEventTriggerInfoFromManaged(managed))
+}
+
+func (s *Server) getGlobalWorkflowEventTrigger(w http.ResponseWriter, r *http.Request) {
+	p, ok := s.resolveWorkflowScheduleActor(w, r)
+	if !ok {
+		return
+	}
+	managed, err := s.workflowSchedules.GetEventTrigger(r.Context(), p, chi.URLParam(r, "triggerID"))
+	if err != nil {
+		s.writeWorkflowEventTriggerManagerError(w, r, "", "", chi.URLParam(r, "triggerID"), err)
+		return
+	}
+	writeJSON(w, http.StatusOK, workflowEventTriggerInfoFromManaged(managed))
+}
+
+func (s *Server) updateGlobalWorkflowEventTrigger(w http.ResponseWriter, r *http.Request) {
+	p, ok := s.resolveWorkflowScheduleActor(w, r)
+	if !ok {
+		return
+	}
+	triggerID := chi.URLParam(r, "triggerID")
+
+	var req workflowEventTriggerUpsertRequest
+	if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
+		writeError(w, http.StatusBadRequest, "invalid JSON body")
+		return
+	}
+	pluginName := strings.TrimSpace(req.Target.Plugin)
+	if pluginName == "" {
+		writeError(w, http.StatusBadRequest, "workflow target plugin is required")
+		return
+	}
+	if strings.TrimSpace(req.Match.Type) == "" {
+		writeError(w, http.StatusBadRequest, "workflow event trigger match.type is required")
+		return
+	}
+	managed, err := s.workflowSchedules.UpdateEventTrigger(r.Context(), p, triggerID, workflowmanager.EventTriggerUpsert{
+		ProviderName: strings.TrimSpace(req.Provider),
+		Match:        workflowEventMatchFromRequest(req.Match),
+		Target:       workflowScheduleTargetFromRequest(req.Target),
+		Paused:       req.Paused,
+	})
+	if err != nil {
+		s.writeWorkflowEventTriggerManagerError(w, r, pluginName, strings.TrimSpace(req.Target.Operation), triggerID, err)
+		return
+	}
+	writeJSON(w, http.StatusOK, workflowEventTriggerInfoFromManaged(managed))
+}
+
+func (s *Server) deleteGlobalWorkflowEventTrigger(w http.ResponseWriter, r *http.Request) {
+	p, ok := s.resolveWorkflowScheduleActor(w, r)
+	if !ok {
+		return
+	}
+	triggerID := chi.URLParam(r, "triggerID")
+	if err := s.workflowSchedules.DeleteEventTrigger(r.Context(), p, triggerID); err != nil {
+		s.writeWorkflowEventTriggerManagerError(w, r, "", "", triggerID, err)
+		return
+	}
+	writeJSON(w, http.StatusOK, map[string]string{"status": "deleted"})
+}
+
+func (s *Server) pauseGlobalWorkflowEventTrigger(w http.ResponseWriter, r *http.Request) {
+	p, ok := s.resolveWorkflowScheduleActor(w, r)
+	if !ok {
+		return
+	}
+	triggerID := chi.URLParam(r, "triggerID")
+	managed, err := s.workflowSchedules.PauseEventTrigger(r.Context(), p, triggerID)
+	if err != nil {
+		s.writeWorkflowEventTriggerManagerError(w, r, "", "", triggerID, err)
+		return
+	}
+	writeJSON(w, http.StatusOK, workflowEventTriggerInfoFromManaged(managed))
+}
+
+func (s *Server) resumeGlobalWorkflowEventTrigger(w http.ResponseWriter, r *http.Request) {
+	p, ok := s.resolveWorkflowScheduleActor(w, r)
+	if !ok {
+		return
+	}
+	triggerID := chi.URLParam(r, "triggerID")
+	managed, err := s.workflowSchedules.ResumeEventTrigger(r.Context(), p, triggerID)
+	if err != nil {
+		s.writeWorkflowEventTriggerManagerError(w, r, "", "", triggerID, err)
+		return
+	}
+	writeJSON(w, http.StatusOK, workflowEventTriggerInfoFromManaged(managed))
+}
+
+func workflowEventMatchFromRequest(match workflowEventTriggerMatchRequest) coreworkflow.EventMatch {
+	return coreworkflow.EventMatch{
+		Type:    strings.TrimSpace(match.Type),
+		Source:  strings.TrimSpace(match.Source),
+		Subject: strings.TrimSpace(match.Subject),
+	}
+}
+
+func workflowEventTriggerInfoFromManaged(managed *workflowmanager.ManagedEventTrigger) workflowEventTriggerInfo {
+	if managed == nil {
+		return workflowEventTriggerInfo{}
+	}
+	return workflowEventTriggerInfoFromCore(managed.Trigger, strings.TrimSpace(managed.ProviderName))
+}
+
+func workflowEventTriggerInfoFromCore(trigger *coreworkflow.EventTrigger, providerName string) workflowEventTriggerInfo {
+	info := workflowEventTriggerInfo{Provider: providerName}
+	if trigger == nil {
+		return info
+	}
+	info.ID = trigger.ID
+	info.Match = workflowEventTriggerMatchInfo{
+		Type:    trigger.Match.Type,
+		Source:  trigger.Match.Source,
+		Subject: trigger.Match.Subject,
+	}
+	info.Target = workflowScheduleTargetInfo{
+		Plugin:     trigger.Target.PluginName,
+		Operation:  trigger.Target.Operation,
+		Connection: userFacingConnectionName(trigger.Target.Connection),
+		Instance:   trigger.Target.Instance,
+		Input:      maps.Clone(trigger.Target.Input),
+	}
+	info.Paused = trigger.Paused
+	info.CreatedAt = trigger.CreatedAt
+	info.UpdatedAt = trigger.UpdatedAt
+	return info
+}
+
+func (s *Server) writeWorkflowEventTriggerManagerError(w http.ResponseWriter, r *http.Request, pluginName, operation, triggerID string, err error) {
+	switch {
+	case errors.Is(err, workflowmanager.ErrWorkflowNotConfigured),
+		errors.Is(err, workflowmanager.ErrExecutionRefsNotConfigured):
+		writeError(w, http.StatusPreconditionFailed, err.Error())
+	case errors.Is(err, workflowmanager.ErrWorkflowScheduleSubject):
+		writeError(w, http.StatusUnauthorized, err.Error())
+	case errors.Is(err, workflowmanager.ErrWorkflowEventMatchRequired):
+		writeError(w, http.StatusBadRequest, err.Error())
+	case errors.Is(err, workflowmanager.ErrDuplicateExecutionRefs):
+		writeError(w, http.StatusInternalServerError, err.Error())
+	case errors.Is(err, invocation.ErrProviderNotFound),
+		errors.Is(err, invocation.ErrOperationNotFound),
+		errors.Is(err, invocation.ErrNotAuthenticated),
+		errors.Is(err, invocation.ErrAuthorizationDenied),
+		errors.Is(err, invocation.ErrScopeDenied),
+		errors.Is(err, invocation.ErrNoToken),
+		errors.Is(err, invocation.ErrReconnectRequired),
+		errors.Is(err, invocation.ErrAmbiguousInstance),
+		errors.Is(err, invocation.ErrUserResolution),
+		errors.Is(err, invocation.ErrInternal),
+		errors.Is(err, core.ErrMCPOnly):
+		s.writeWorkflowScheduleTargetError(w, r, pluginName, operation, err)
+	case errors.Is(err, core.ErrNotFound):
+		s.writeWorkflowEventTriggerProviderError(r.Context(), w, pluginName, triggerID, err)
+	default:
+		s.writeWorkflowEventTriggerProviderError(r.Context(), w, pluginName, triggerID, err)
+	}
+}
+
+func (s *Server) writeWorkflowEventTriggerProviderError(ctx context.Context, w http.ResponseWriter, pluginName, triggerID string, err error) {
+	switch {
+	case errors.Is(err, core.ErrNotFound):
+		writeError(w, http.StatusNotFound, fmt.Sprintf("workflow event trigger %q not found", triggerID))
+	default:
+		slog.ErrorContext(ctx, "workflow event trigger provider error",
+			"plugin", pluginName,
+			"trigger_id", triggerID,
+			"error", err,
+		)
+		if strings.TrimSpace(pluginName) == "" {
+			writeError(w, http.StatusInternalServerError, "workflow event trigger request failed")
+			return
+		}
+		writeError(w, http.StatusInternalServerError, fmt.Sprintf("workflow event trigger request failed for integration %q", pluginName))
+	}
+}

--- a/gestaltd/internal/server/routes_user.go
+++ b/gestaltd/internal/server/routes_user.go
@@ -18,6 +18,15 @@ func (s *Server) mountAuthenticatedRoutes(r chi.Router) {
 			r.Post("/{scheduleID}/pause", s.pauseGlobalWorkflowSchedule)
 			r.Post("/{scheduleID}/resume", s.resumeGlobalWorkflowSchedule)
 		})
+		r.Route("/workflow/event-triggers", func(r chi.Router) {
+			r.Get("/", s.listGlobalWorkflowEventTriggers)
+			r.Post("/", s.createGlobalWorkflowEventTrigger)
+			r.Get("/{triggerID}", s.getGlobalWorkflowEventTrigger)
+			r.Put("/{triggerID}", s.updateGlobalWorkflowEventTrigger)
+			r.Delete("/{triggerID}", s.deleteGlobalWorkflowEventTrigger)
+			r.Post("/{triggerID}/pause", s.pauseGlobalWorkflowEventTrigger)
+			r.Post("/{triggerID}/resume", s.resumeGlobalWorkflowEventTrigger)
+		})
 		r.Route("/workflow/runs", func(r chi.Router) {
 			r.Get("/", s.listGlobalWorkflowRuns)
 			r.Get("/{runID}", s.getGlobalWorkflowRun)

--- a/gestaltd/internal/server/workflow_schedule_test.go
+++ b/gestaltd/internal/server/workflow_schedule_test.go
@@ -62,24 +62,33 @@ func (s *stubWorkflowControl) ResolveProvider(name string) (coreworkflow.Provide
 }
 
 type memoryWorkflowProvider struct {
-	schedules     map[string]*coreworkflow.Schedule
-	runs          map[string]*coreworkflow.Run
-	upsertReqs    []coreworkflow.UpsertScheduleRequest
-	deleteReqs    []coreworkflow.DeleteScheduleRequest
-	pauseReqs     []coreworkflow.PauseScheduleRequest
-	resumeReqs    []coreworkflow.ResumeScheduleRequest
-	cancelReqs    []coreworkflow.CancelRunRequest
-	nextUpsertErr error
-	getErr        error
-	listErr       error
-	getRunErr     error
-	listRunsErr   error
-	cancelRunErr  error
+	schedules            map[string]*coreworkflow.Schedule
+	triggers             map[string]*coreworkflow.EventTrigger
+	runs                 map[string]*coreworkflow.Run
+	upsertReqs           []coreworkflow.UpsertScheduleRequest
+	upsertTriggerReqs    []coreworkflow.UpsertEventTriggerRequest
+	deleteReqs           []coreworkflow.DeleteScheduleRequest
+	deleteTriggerReqs    []coreworkflow.DeleteEventTriggerRequest
+	pauseReqs            []coreworkflow.PauseScheduleRequest
+	pauseTriggerReqs     []coreworkflow.PauseEventTriggerRequest
+	resumeReqs           []coreworkflow.ResumeScheduleRequest
+	resumeTriggerReqs    []coreworkflow.ResumeEventTriggerRequest
+	cancelReqs           []coreworkflow.CancelRunRequest
+	nextUpsertErr        error
+	nextUpsertTriggerErr error
+	getErr               error
+	getTriggerErr        error
+	listErr              error
+	listTriggersErr      error
+	getRunErr            error
+	listRunsErr          error
+	cancelRunErr         error
 }
 
 func newMemoryWorkflowProvider() *memoryWorkflowProvider {
 	return &memoryWorkflowProvider{
 		schedules: map[string]*coreworkflow.Schedule{},
+		triggers:  map[string]*coreworkflow.EventTrigger{},
 		runs:      map[string]*coreworkflow.Run{},
 	}
 }
@@ -216,28 +225,89 @@ func (p *memoryWorkflowProvider) ResumeSchedule(_ context.Context, req coreworkf
 	return cloneWorkflowSchedule(schedule), nil
 }
 
-func (p *memoryWorkflowProvider) UpsertEventTrigger(context.Context, coreworkflow.UpsertEventTriggerRequest) (*coreworkflow.EventTrigger, error) {
-	return nil, errors.New("not implemented")
+func (p *memoryWorkflowProvider) UpsertEventTrigger(_ context.Context, req coreworkflow.UpsertEventTriggerRequest) (*coreworkflow.EventTrigger, error) {
+	p.upsertTriggerReqs = append(p.upsertTriggerReqs, req)
+	if p.nextUpsertTriggerErr != nil {
+		err := p.nextUpsertTriggerErr
+		p.nextUpsertTriggerErr = nil
+		return nil, err
+	}
+	now := time.Now().UTC().Truncate(time.Second)
+	existing := p.triggers[req.TriggerID]
+	createdAt := &now
+	if existing != nil && existing.CreatedAt != nil {
+		createdAt = existing.CreatedAt
+	}
+	trigger := &coreworkflow.EventTrigger{
+		ID:           req.TriggerID,
+		Match:        req.Match,
+		Target:       req.Target,
+		Paused:       req.Paused,
+		ExecutionRef: req.ExecutionRef,
+		CreatedBy:    req.RequestedBy,
+		CreatedAt:    createdAt,
+		UpdatedAt:    &now,
+	}
+	p.triggers[req.TriggerID] = cloneWorkflowEventTrigger(trigger)
+	return cloneWorkflowEventTrigger(trigger), nil
 }
 
-func (p *memoryWorkflowProvider) GetEventTrigger(context.Context, coreworkflow.GetEventTriggerRequest) (*coreworkflow.EventTrigger, error) {
-	return nil, errors.New("not implemented")
+func (p *memoryWorkflowProvider) GetEventTrigger(_ context.Context, req coreworkflow.GetEventTriggerRequest) (*coreworkflow.EventTrigger, error) {
+	if p.getTriggerErr != nil {
+		return nil, p.getTriggerErr
+	}
+	trigger, ok := p.triggers[req.TriggerID]
+	if !ok || trigger == nil {
+		return nil, core.ErrNotFound
+	}
+	return cloneWorkflowEventTrigger(trigger), nil
 }
 
-func (p *memoryWorkflowProvider) ListEventTriggers(context.Context, coreworkflow.ListEventTriggersRequest) ([]*coreworkflow.EventTrigger, error) {
-	return nil, nil
+func (p *memoryWorkflowProvider) ListEventTriggers(_ context.Context, _ coreworkflow.ListEventTriggersRequest) ([]*coreworkflow.EventTrigger, error) {
+	if p.listTriggersErr != nil {
+		return nil, p.listTriggersErr
+	}
+	out := make([]*coreworkflow.EventTrigger, 0, len(p.triggers))
+	for _, trigger := range p.triggers {
+		if trigger != nil {
+			out = append(out, cloneWorkflowEventTrigger(trigger))
+		}
+	}
+	return out, nil
 }
 
-func (p *memoryWorkflowProvider) DeleteEventTrigger(context.Context, coreworkflow.DeleteEventTriggerRequest) error {
-	return errors.New("not implemented")
+func (p *memoryWorkflowProvider) DeleteEventTrigger(_ context.Context, req coreworkflow.DeleteEventTriggerRequest) error {
+	trigger, ok := p.triggers[req.TriggerID]
+	if !ok || trigger == nil {
+		return core.ErrNotFound
+	}
+	delete(p.triggers, req.TriggerID)
+	p.deleteTriggerReqs = append(p.deleteTriggerReqs, req)
+	return nil
 }
 
-func (p *memoryWorkflowProvider) PauseEventTrigger(context.Context, coreworkflow.PauseEventTriggerRequest) (*coreworkflow.EventTrigger, error) {
-	return nil, errors.New("not implemented")
+func (p *memoryWorkflowProvider) PauseEventTrigger(_ context.Context, req coreworkflow.PauseEventTriggerRequest) (*coreworkflow.EventTrigger, error) {
+	trigger, ok := p.triggers[req.TriggerID]
+	if !ok || trigger == nil {
+		return nil, core.ErrNotFound
+	}
+	now := time.Now().UTC().Truncate(time.Second)
+	trigger.Paused = true
+	trigger.UpdatedAt = &now
+	p.pauseTriggerReqs = append(p.pauseTriggerReqs, req)
+	return cloneWorkflowEventTrigger(trigger), nil
 }
 
-func (p *memoryWorkflowProvider) ResumeEventTrigger(context.Context, coreworkflow.ResumeEventTriggerRequest) (*coreworkflow.EventTrigger, error) {
-	return nil, errors.New("not implemented")
+func (p *memoryWorkflowProvider) ResumeEventTrigger(_ context.Context, req coreworkflow.ResumeEventTriggerRequest) (*coreworkflow.EventTrigger, error) {
+	trigger, ok := p.triggers[req.TriggerID]
+	if !ok || trigger == nil {
+		return nil, core.ErrNotFound
+	}
+	now := time.Now().UTC().Truncate(time.Second)
+	trigger.Paused = false
+	trigger.UpdatedAt = &now
+	p.resumeTriggerReqs = append(p.resumeTriggerReqs, req)
+	return cloneWorkflowEventTrigger(trigger), nil
 }
 
 func (p *memoryWorkflowProvider) PublishEvent(context.Context, coreworkflow.PublishEventRequest) error {
@@ -307,6 +377,23 @@ func cloneWorkflowRun(run *coreworkflow.Run) *coreworkflow.Run {
 	return &cloned
 }
 
+func cloneWorkflowEventTrigger(trigger *coreworkflow.EventTrigger) *coreworkflow.EventTrigger {
+	if trigger == nil {
+		return nil
+	}
+	cloned := *trigger
+	cloned.Target.Input = cloneMap(trigger.Target.Input)
+	if trigger.CreatedAt != nil {
+		value := *trigger.CreatedAt
+		cloned.CreatedAt = &value
+	}
+	if trigger.UpdatedAt != nil {
+		value := *trigger.UpdatedAt
+		cloned.UpdatedAt = &value
+	}
+	return &cloned
+}
+
 func cloneMap(src map[string]any) map[string]any {
 	if src == nil {
 		return nil
@@ -324,6 +411,24 @@ type workflowScheduleResponse struct {
 	Cron     string `json:"cron"`
 	Timezone string `json:"timezone"`
 	Target   struct {
+		Plugin     string         `json:"plugin"`
+		Operation  string         `json:"operation"`
+		Connection string         `json:"connection"`
+		Instance   string         `json:"instance"`
+		Input      map[string]any `json:"input"`
+	} `json:"target"`
+	Paused bool `json:"paused"`
+}
+
+type workflowEventTriggerResponse struct {
+	ID       string `json:"id"`
+	Provider string `json:"provider"`
+	Match    struct {
+		Type    string `json:"type"`
+		Source  string `json:"source"`
+		Subject string `json:"subject"`
+	} `json:"match"`
+	Target struct {
 		Plugin     string         `json:"plugin"`
 		Operation  string         `json:"operation"`
 		Connection string         `json:"connection"`
@@ -1638,5 +1743,415 @@ func TestGlobalWorkflowScheduleListAndMutationsAreOwnerScopedAcrossProviders(t *
 	}
 	if _, ok := advancedProvider.schedules["sched-grace-advanced"]; !ok {
 		t.Fatal("expected grace schedule to remain after unauthorized global delete")
+	}
+}
+
+func TestGlobalWorkflowEventTriggerCRUDAcrossProviders(t *testing.T) {
+	t.Parallel()
+
+	services := coretesting.NewStubServices(t)
+	ada := seedUser(t, services, "ada@example.test")
+	basicProvider := newMemoryWorkflowProvider()
+	advancedProvider := newMemoryWorkflowProvider()
+
+	ts := newTestServer(t, func(cfg *server.Config) {
+		cfg.Auth = &coretesting.StubAuthProvider{
+			N: "stub",
+			ValidateTokenFn: func(_ context.Context, token string) (*core.UserIdentity, error) {
+				if token != "ada-session" {
+					return nil, core.ErrNotFound
+				}
+				return &core.UserIdentity{Email: ada.Email, DisplayName: "Ada"}, nil
+			},
+		}
+		cfg.Services = services
+		cfg.Providers = testutil.NewProviderRegistry(t,
+			&coretesting.StubIntegration{
+				N:        "roadmap",
+				ConnMode: core.ConnectionModeUser,
+				CatalogVal: &catalog.Catalog{
+					Name: "roadmap",
+					Operations: []catalog.CatalogOperation{
+						{ID: "sync", Method: http.MethodPost},
+					},
+				},
+			},
+			&coretesting.StubIntegration{
+				N:        "analytics",
+				ConnMode: core.ConnectionModeUser,
+				CatalogVal: &catalog.Catalog{
+					Name: "analytics",
+					Operations: []catalog.CatalogOperation{
+						{ID: "sync", Method: http.MethodPost},
+					},
+				},
+			},
+		)
+		cfg.Workflow = &stubWorkflowControl{
+			defaultProviderName: "basic",
+			providers: map[string]coreworkflow.Provider{
+				"basic":    basicProvider,
+				"advanced": advancedProvider,
+			},
+		}
+	})
+	testutil.CloseOnCleanup(t, ts)
+
+	createReq, _ := http.NewRequest(
+		http.MethodPost,
+		ts.URL+"/api/v1/workflow/event-triggers/",
+		bytes.NewBufferString(`{"provider":"basic","match":{"type":"roadmap.item.updated","source":"roadmap","subject":"item"},"target":{"plugin":"roadmap","operation":"sync","connection":"analytics","instance":"tenant-a","input":{"mode":"incremental"}}}`),
+	)
+	createReq.Header.Set("Content-Type", "application/json")
+	createReq.AddCookie(&http.Cookie{Name: "session_token", Value: "ada-session"})
+	createResp, err := http.DefaultClient.Do(createReq)
+	if err != nil {
+		t.Fatalf("create request: %v", err)
+	}
+	defer func() { _ = createResp.Body.Close() }()
+	if createResp.StatusCode != http.StatusCreated {
+		body, _ := io.ReadAll(createResp.Body)
+		t.Fatalf("expected 201, got %d: %s", createResp.StatusCode, body)
+	}
+
+	var created workflowEventTriggerResponse
+	if err := json.NewDecoder(createResp.Body).Decode(&created); err != nil {
+		t.Fatalf("decode create response: %v", err)
+	}
+	if created.Provider != "basic" || created.Match.Type != "roadmap.item.updated" || created.Target.Plugin != "roadmap" || created.Target.Operation != "sync" {
+		t.Fatalf("created trigger = %#v", created)
+	}
+	if len(basicProvider.upsertTriggerReqs) != 1 {
+		t.Fatalf("basic trigger upsert requests = %d, want 1", len(basicProvider.upsertTriggerReqs))
+	}
+	if basicProvider.upsertTriggerReqs[0].Target.PluginName != "roadmap" {
+		t.Fatalf("basic create target = %#v", basicProvider.upsertTriggerReqs[0].Target)
+	}
+	initialExecutionRef := basicProvider.upsertTriggerReqs[0].ExecutionRef
+
+	listReq, _ := http.NewRequest(http.MethodGet, ts.URL+"/api/v1/workflow/event-triggers/", nil)
+	listReq.AddCookie(&http.Cookie{Name: "session_token", Value: "ada-session"})
+	listResp, err := http.DefaultClient.Do(listReq)
+	if err != nil {
+		t.Fatalf("list request: %v", err)
+	}
+	defer func() { _ = listResp.Body.Close() }()
+	if listResp.StatusCode != http.StatusOK {
+		body, _ := io.ReadAll(listResp.Body)
+		t.Fatalf("expected 200, got %d: %s", listResp.StatusCode, body)
+	}
+	var listed []workflowEventTriggerResponse
+	if err := json.NewDecoder(listResp.Body).Decode(&listed); err != nil {
+		t.Fatalf("decode list response: %v", err)
+	}
+	if len(listed) != 1 || listed[0].ID != created.ID || listed[0].Provider != "basic" || listed[0].Match.Type != "roadmap.item.updated" {
+		t.Fatalf("listed triggers = %#v", listed)
+	}
+
+	updateReq, _ := http.NewRequest(
+		http.MethodPut,
+		ts.URL+"/api/v1/workflow/event-triggers/"+created.ID,
+		bytes.NewBufferString(`{"provider":"advanced","match":{"type":"analytics.item.synced","source":"analytics","subject":"sync"},"target":{"plugin":"analytics","operation":"sync","connection":"warehouse","instance":"tenant-b","input":{"mode":"full"}},"paused":true}`),
+	)
+	updateReq.Header.Set("Content-Type", "application/json")
+	updateReq.AddCookie(&http.Cookie{Name: "session_token", Value: "ada-session"})
+	updateResp, err := http.DefaultClient.Do(updateReq)
+	if err != nil {
+		t.Fatalf("update request: %v", err)
+	}
+	defer func() { _ = updateResp.Body.Close() }()
+	if updateResp.StatusCode != http.StatusOK {
+		body, _ := io.ReadAll(updateResp.Body)
+		t.Fatalf("expected 200, got %d: %s", updateResp.StatusCode, body)
+	}
+
+	var updated workflowEventTriggerResponse
+	if err := json.NewDecoder(updateResp.Body).Decode(&updated); err != nil {
+		t.Fatalf("decode update response: %v", err)
+	}
+	if updated.Provider != "advanced" || updated.Match.Type != "analytics.item.synced" || updated.Target.Plugin != "analytics" || !updated.Paused {
+		t.Fatalf("updated trigger = %#v", updated)
+	}
+	if len(advancedProvider.upsertTriggerReqs) != 1 {
+		t.Fatalf("advanced trigger upsert requests = %d, want 1", len(advancedProvider.upsertTriggerReqs))
+	}
+	if len(basicProvider.deleteTriggerReqs) != 1 || basicProvider.deleteTriggerReqs[0].TriggerID != created.ID {
+		t.Fatalf("basic delete trigger requests = %#v", basicProvider.deleteTriggerReqs)
+	}
+	if _, ok := basicProvider.triggers[created.ID]; ok {
+		t.Fatal("expected global update to remove event trigger from old provider")
+	}
+	if _, ok := advancedProvider.triggers[created.ID]; !ok {
+		t.Fatal("expected global update to store event trigger in new provider")
+	}
+	updatedExecutionRef := advancedProvider.upsertTriggerReqs[0].ExecutionRef
+	if updatedExecutionRef == "" || updatedExecutionRef == initialExecutionRef {
+		t.Fatalf("updated execution ref = %q, want rotated from %q", updatedExecutionRef, initialExecutionRef)
+	}
+	oldRef, err := services.WorkflowExecutionRefs.Get(context.Background(), initialExecutionRef)
+	if err != nil {
+		t.Fatalf("Get initial execution ref: %v", err)
+	}
+	if oldRef.RevokedAt == nil || oldRef.RevokedAt.IsZero() {
+		t.Fatalf("expected initial execution ref to be revoked, got %#v", oldRef)
+	}
+
+	pauseReq, _ := http.NewRequest(http.MethodPost, ts.URL+"/api/v1/workflow/event-triggers/"+created.ID+"/pause", nil)
+	pauseReq.AddCookie(&http.Cookie{Name: "session_token", Value: "ada-session"})
+	pauseResp, err := http.DefaultClient.Do(pauseReq)
+	if err != nil {
+		t.Fatalf("pause request: %v", err)
+	}
+	defer func() { _ = pauseResp.Body.Close() }()
+	if pauseResp.StatusCode != http.StatusOK {
+		t.Fatalf("expected 200, got %d", pauseResp.StatusCode)
+	}
+	if len(advancedProvider.pauseTriggerReqs) != 1 {
+		t.Fatalf("advanced pause trigger requests = %d, want 1", len(advancedProvider.pauseTriggerReqs))
+	}
+
+	resumeReq, _ := http.NewRequest(http.MethodPost, ts.URL+"/api/v1/workflow/event-triggers/"+created.ID+"/resume", nil)
+	resumeReq.AddCookie(&http.Cookie{Name: "session_token", Value: "ada-session"})
+	resumeResp, err := http.DefaultClient.Do(resumeReq)
+	if err != nil {
+		t.Fatalf("resume request: %v", err)
+	}
+	defer func() { _ = resumeResp.Body.Close() }()
+	if resumeResp.StatusCode != http.StatusOK {
+		t.Fatalf("expected 200, got %d", resumeResp.StatusCode)
+	}
+	if len(advancedProvider.resumeTriggerReqs) != 1 {
+		t.Fatalf("advanced resume trigger requests = %d, want 1", len(advancedProvider.resumeTriggerReqs))
+	}
+
+	deleteReq, _ := http.NewRequest(http.MethodDelete, ts.URL+"/api/v1/workflow/event-triggers/"+created.ID, nil)
+	deleteReq.AddCookie(&http.Cookie{Name: "session_token", Value: "ada-session"})
+	deleteResp, err := http.DefaultClient.Do(deleteReq)
+	if err != nil {
+		t.Fatalf("delete request: %v", err)
+	}
+	defer func() { _ = deleteResp.Body.Close() }()
+	if deleteResp.StatusCode != http.StatusOK {
+		t.Fatalf("expected 200, got %d", deleteResp.StatusCode)
+	}
+	if _, ok := advancedProvider.triggers[created.ID]; ok {
+		t.Fatal("expected event trigger to be deleted from current global provider")
+	}
+	finalRef, err := services.WorkflowExecutionRefs.Get(context.Background(), updatedExecutionRef)
+	if err != nil {
+		t.Fatalf("Get final execution ref: %v", err)
+	}
+	if finalRef.RevokedAt == nil || finalRef.RevokedAt.IsZero() {
+		t.Fatalf("expected final execution ref to be revoked, got %#v", finalRef)
+	}
+}
+
+func TestGlobalWorkflowEventTriggerListAndMutationsAreOwnerScopedAcrossProviders(t *testing.T) {
+	t.Parallel()
+
+	services := coretesting.NewStubServices(t)
+	ada := seedUser(t, services, "ada@example.test")
+	grace := seedUser(t, services, "grace@example.test")
+	basicProvider := newMemoryWorkflowProvider()
+	advancedProvider := newMemoryWorkflowProvider()
+	now := time.Now().UTC().Truncate(time.Second)
+
+	basicProvider.triggers["trg-ada-basic"] = &coreworkflow.EventTrigger{
+		ID:           "trg-ada-basic",
+		Match:        coreworkflow.EventMatch{Type: "roadmap.item.updated"},
+		Target:       coreworkflow.Target{PluginName: "roadmap", Operation: "sync"},
+		ExecutionRef: "workflow_event_trigger:trg-ada-basic:ref-basic",
+		CreatedAt:    &now,
+		UpdatedAt:    &now,
+	}
+	advancedProvider.triggers["trg-ada-advanced"] = &coreworkflow.EventTrigger{
+		ID:           "trg-ada-advanced",
+		Match:        coreworkflow.EventMatch{Type: "analytics.item.synced"},
+		Target:       coreworkflow.Target{PluginName: "analytics", Operation: "sync"},
+		ExecutionRef: "workflow_event_trigger:trg-ada-advanced:ref-advanced",
+		CreatedAt:    &now,
+		UpdatedAt:    &now,
+	}
+	advancedProvider.triggers["trg-grace-advanced"] = &coreworkflow.EventTrigger{
+		ID:           "trg-grace-advanced",
+		Match:        coreworkflow.EventMatch{Type: "analytics.item.failed"},
+		Target:       coreworkflow.Target{PluginName: "analytics", Operation: "sync"},
+		ExecutionRef: "workflow_event_trigger:trg-grace-advanced:ref-grace-advanced",
+		CreatedAt:    &now,
+		UpdatedAt:    &now,
+	}
+	for _, ref := range []*coreworkflow.ExecutionReference{
+		{
+			ID:           "workflow_event_trigger:trg-ada-basic:ref-basic",
+			ProviderName: "basic",
+			Target:       basicProvider.triggers["trg-ada-basic"].Target,
+			SubjectID:    principal.UserSubjectID(ada.ID),
+		},
+		{
+			ID:           "workflow_event_trigger:trg-ada-advanced:ref-advanced",
+			ProviderName: "advanced",
+			Target:       advancedProvider.triggers["trg-ada-advanced"].Target,
+			SubjectID:    principal.UserSubjectID(ada.ID),
+		},
+		{
+			ID:           "workflow_event_trigger:trg-grace-advanced:ref-grace-advanced",
+			ProviderName: "advanced",
+			Target:       advancedProvider.triggers["trg-grace-advanced"].Target,
+			SubjectID:    principal.UserSubjectID(grace.ID),
+		},
+	} {
+		if _, err := services.WorkflowExecutionRefs.Put(context.Background(), ref); err != nil {
+			t.Fatalf("Put execution ref %q: %v", ref.ID, err)
+		}
+	}
+
+	ts := newTestServer(t, func(cfg *server.Config) {
+		cfg.Auth = &coretesting.StubAuthProvider{
+			N: "stub",
+			ValidateTokenFn: func(_ context.Context, token string) (*core.UserIdentity, error) {
+				switch token {
+				case "ada-session":
+					return &core.UserIdentity{Email: ada.Email, DisplayName: "Ada"}, nil
+				case "grace-session":
+					return &core.UserIdentity{Email: grace.Email, DisplayName: "Grace"}, nil
+				default:
+					return nil, core.ErrNotFound
+				}
+			},
+		}
+		cfg.Services = services
+		cfg.Providers = testutil.NewProviderRegistry(t,
+			&coretesting.StubIntegration{
+				N:        "roadmap",
+				ConnMode: core.ConnectionModeUser,
+				CatalogVal: &catalog.Catalog{
+					Name: "roadmap",
+					Operations: []catalog.CatalogOperation{
+						{ID: "sync", Method: http.MethodPost},
+					},
+				},
+			},
+			&coretesting.StubIntegration{
+				N:        "analytics",
+				ConnMode: core.ConnectionModeUser,
+				CatalogVal: &catalog.Catalog{
+					Name: "analytics",
+					Operations: []catalog.CatalogOperation{
+						{ID: "sync", Method: http.MethodPost},
+					},
+				},
+			},
+		)
+		cfg.Workflow = &stubWorkflowControl{
+			defaultProviderName: "basic",
+			providers: map[string]coreworkflow.Provider{
+				"basic":    basicProvider,
+				"advanced": advancedProvider,
+			},
+		}
+	})
+	testutil.CloseOnCleanup(t, ts)
+
+	listReq, _ := http.NewRequest(http.MethodGet, ts.URL+"/api/v1/workflow/event-triggers/", nil)
+	listReq.AddCookie(&http.Cookie{Name: "session_token", Value: "ada-session"})
+	listResp, err := http.DefaultClient.Do(listReq)
+	if err != nil {
+		t.Fatalf("list request: %v", err)
+	}
+	defer func() { _ = listResp.Body.Close() }()
+	if listResp.StatusCode != http.StatusOK {
+		t.Fatalf("expected 200, got %d", listResp.StatusCode)
+	}
+	var listed []workflowEventTriggerResponse
+	if err := json.NewDecoder(listResp.Body).Decode(&listed); err != nil {
+		t.Fatalf("decode list response: %v", err)
+	}
+	if len(listed) != 2 {
+		t.Fatalf("listed triggers = %#v", listed)
+	}
+	listedIDs := []string{listed[0].ID, listed[1].ID}
+	slices.Sort(listedIDs)
+	if !slices.Equal(listedIDs, []string{"trg-ada-advanced", "trg-ada-basic"}) {
+		t.Fatalf("listed triggers = %#v", listed)
+	}
+
+	getReq, _ := http.NewRequest(http.MethodGet, ts.URL+"/api/v1/workflow/event-triggers/trg-grace-advanced", nil)
+	getReq.AddCookie(&http.Cookie{Name: "session_token", Value: "ada-session"})
+	getResp, err := http.DefaultClient.Do(getReq)
+	if err != nil {
+		t.Fatalf("get request: %v", err)
+	}
+	defer func() { _ = getResp.Body.Close() }()
+	if getResp.StatusCode != http.StatusNotFound {
+		t.Fatalf("expected 404, got %d", getResp.StatusCode)
+	}
+
+	deleteReq, _ := http.NewRequest(http.MethodDelete, ts.URL+"/api/v1/workflow/event-triggers/trg-grace-advanced", nil)
+	deleteReq.AddCookie(&http.Cookie{Name: "session_token", Value: "ada-session"})
+	deleteResp, err := http.DefaultClient.Do(deleteReq)
+	if err != nil {
+		t.Fatalf("delete request: %v", err)
+	}
+	defer func() { _ = deleteResp.Body.Close() }()
+	if deleteResp.StatusCode != http.StatusNotFound {
+		t.Fatalf("expected 404, got %d", deleteResp.StatusCode)
+	}
+	if _, ok := advancedProvider.triggers["trg-grace-advanced"]; !ok {
+		t.Fatal("expected grace trigger to remain after unauthorized global delete")
+	}
+}
+
+func TestWorkflowEventTriggerCreateRequiresMatchType(t *testing.T) {
+	t.Parallel()
+
+	services := coretesting.NewStubServices(t)
+	user := seedUser(t, services, "ada@example.test")
+	provider := newMemoryWorkflowProvider()
+	ts := newTestServer(t, func(cfg *server.Config) {
+		cfg.Auth = &coretesting.StubAuthProvider{
+			N: "stub",
+			ValidateTokenFn: func(_ context.Context, token string) (*core.UserIdentity, error) {
+				if token != "ada-session" {
+					return nil, core.ErrNotFound
+				}
+				return &core.UserIdentity{Email: user.Email, DisplayName: "Ada"}, nil
+			},
+		}
+		cfg.Services = services
+		cfg.Providers = testutil.NewProviderRegistry(t, &coretesting.StubIntegration{
+			N:        "roadmap",
+			ConnMode: core.ConnectionModeUser,
+			CatalogVal: &catalog.Catalog{
+				Name: "roadmap",
+				Operations: []catalog.CatalogOperation{
+					{ID: "sync", Method: http.MethodPost},
+				},
+			},
+		})
+		cfg.Workflow = &stubWorkflowControl{
+			defaultProviderName: "basic",
+			provider:            provider,
+		}
+	})
+	testutil.CloseOnCleanup(t, ts)
+
+	req, _ := http.NewRequest(
+		http.MethodPost,
+		ts.URL+"/api/v1/workflow/event-triggers/",
+		bytes.NewBufferString(`{"match":{"source":"roadmap"},"target":{"plugin":"roadmap","operation":"sync"}}`),
+	)
+	req.Header.Set("Content-Type", "application/json")
+	req.AddCookie(&http.Cookie{Name: "session_token", Value: "ada-session"})
+	resp, err := http.DefaultClient.Do(req)
+	if err != nil {
+		t.Fatalf("create request: %v", err)
+	}
+	defer func() { _ = resp.Body.Close() }()
+	if resp.StatusCode != http.StatusBadRequest {
+		body, _ := io.ReadAll(resp.Body)
+		t.Fatalf("expected 400, got %d: %s", resp.StatusCode, body)
+	}
+	if len(provider.upsertTriggerReqs) != 0 {
+		t.Fatalf("upsert trigger requests = %d, want 0", len(provider.upsertTriggerReqs))
 	}
 }

--- a/gestaltd/internal/workflowmanager/manager.go
+++ b/gestaltd/internal/workflowmanager/manager.go
@@ -25,10 +25,12 @@ var (
 	ErrExecutionRefsNotConfigured = errors.New("workflow execution refs are not configured")
 	ErrWorkflowSubjectRequired    = errors.New("workflow subject is required")
 	ErrWorkflowScheduleSubject    = ErrWorkflowSubjectRequired
-	ErrDuplicateExecutionRefs     = errors.New("workflow schedule matched multiple execution references")
+	ErrDuplicateExecutionRefs     = errors.New("workflow object matched multiple execution references")
+	ErrWorkflowEventMatchRequired = errors.New("workflow event trigger match.type is required")
 )
 
 const workflowScheduleExecutionRefBasePrefix = "workflow_schedule:"
+const workflowEventTriggerExecutionRefBasePrefix = "workflow_event_trigger:"
 
 type WorkflowControl interface {
 	ResolveProvider(name string) (coreworkflow.Provider, error)
@@ -43,6 +45,13 @@ type Service interface {
 	DeleteSchedule(ctx context.Context, p *principal.Principal, scheduleID string) error
 	PauseSchedule(ctx context.Context, p *principal.Principal, scheduleID string) (*ManagedSchedule, error)
 	ResumeSchedule(ctx context.Context, p *principal.Principal, scheduleID string) (*ManagedSchedule, error)
+	ListEventTriggers(ctx context.Context, p *principal.Principal) ([]*ManagedEventTrigger, error)
+	CreateEventTrigger(ctx context.Context, p *principal.Principal, req EventTriggerUpsert) (*ManagedEventTrigger, error)
+	GetEventTrigger(ctx context.Context, p *principal.Principal, triggerID string) (*ManagedEventTrigger, error)
+	UpdateEventTrigger(ctx context.Context, p *principal.Principal, triggerID string, req EventTriggerUpsert) (*ManagedEventTrigger, error)
+	DeleteEventTrigger(ctx context.Context, p *principal.Principal, triggerID string) error
+	PauseEventTrigger(ctx context.Context, p *principal.Principal, triggerID string) (*ManagedEventTrigger, error)
+	ResumeEventTrigger(ctx context.Context, p *principal.Principal, triggerID string) (*ManagedEventTrigger, error)
 	ListRuns(ctx context.Context, p *principal.Principal) ([]*ManagedRun, error)
 	GetRun(ctx context.Context, p *principal.Principal, runID string) (*ManagedRun, error)
 	CancelRun(ctx context.Context, p *principal.Principal, runID, reason string) (*ManagedRun, error)
@@ -78,9 +87,23 @@ type ScheduleUpsert struct {
 	Paused       bool
 }
 
+type EventTriggerUpsert struct {
+	ProviderName string
+	Match        coreworkflow.EventMatch
+	Target       coreworkflow.Target
+	Paused       bool
+}
+
 type ManagedSchedule struct {
 	ProviderName string
 	Schedule     *coreworkflow.Schedule
+	ExecutionRef *coreworkflow.ExecutionReference
+	provider     coreworkflow.Provider
+}
+
+type ManagedEventTrigger struct {
+	ProviderName string
+	Trigger      *coreworkflow.EventTrigger
 	ExecutionRef *coreworkflow.ExecutionReference
 	provider     coreworkflow.Provider
 }
@@ -424,6 +447,213 @@ func (m *Manager) ResumeSchedule(ctx context.Context, p *principal.Principal, sc
 	return value, nil
 }
 
+func (m *Manager) ListEventTriggers(ctx context.Context, p *principal.Principal) ([]*ManagedEventTrigger, error) {
+	refs, err := m.listOwnedExecutionRefs(ctx, p, true)
+	if err != nil {
+		return nil, err
+	}
+	out := make([]*ManagedEventTrigger, 0, len(refs))
+	for _, ref := range refs {
+		if !m.allowTarget(ctx, p, ref.Target) {
+			continue
+		}
+		triggerID := eventTriggerIDFromExecutionRefID(ref.ID)
+		if triggerID == "" {
+			continue
+		}
+		provider, err := m.resolveProviderByName(strings.TrimSpace(ref.ProviderName))
+		if err != nil {
+			return nil, err
+		}
+		trigger, err := provider.GetEventTrigger(ctx, coreworkflow.GetEventTriggerRequest{TriggerID: triggerID})
+		if err != nil {
+			if errors.Is(err, core.ErrNotFound) {
+				continue
+			}
+			return nil, err
+		}
+		if !eventTriggerMatchesExecutionRef(ref.ProviderName, trigger, ref) {
+			continue
+		}
+		out = append(out, &ManagedEventTrigger{
+			ProviderName: strings.TrimSpace(ref.ProviderName),
+			Trigger:      trigger,
+			ExecutionRef: ref,
+			provider:     provider,
+		})
+	}
+	sort.Slice(out, func(i, j int) bool {
+		left := out[i]
+		right := out[j]
+		if left.Trigger != nil && right.Trigger != nil && left.Trigger.CreatedAt != nil && right.Trigger.CreatedAt != nil && !left.Trigger.CreatedAt.Equal(*right.Trigger.CreatedAt) {
+			return left.Trigger.CreatedAt.Before(*right.Trigger.CreatedAt)
+		}
+		leftID := ""
+		rightID := ""
+		if left.Trigger != nil {
+			leftID = left.Trigger.ID
+		}
+		if right.Trigger != nil {
+			rightID = right.Trigger.ID
+		}
+		return leftID < rightID
+	})
+	return out, nil
+}
+
+func (m *Manager) CreateEventTrigger(ctx context.Context, p *principal.Principal, req EventTriggerUpsert) (*ManagedEventTrigger, error) {
+	p = principal.Canonicalized(p)
+	if strings.TrimSpace(principalSubjectID(p)) == "" {
+		return nil, ErrWorkflowSubjectRequired
+	}
+	providerName, provider, err := m.resolveProviderSelection(strings.TrimSpace(req.ProviderName))
+	if err != nil {
+		return nil, err
+	}
+	target, err := m.resolveTarget(ctx, p, req.Target)
+	if err != nil {
+		return nil, err
+	}
+	match := normalizeEventMatch(req.Match)
+	if strings.TrimSpace(match.Type) == "" {
+		return nil, ErrWorkflowEventMatchRequired
+	}
+
+	triggerID := uuid.NewString()
+	executionRefID := eventTriggerExecutionRefID(triggerID)
+	ref, err := m.putExecutionRef(ctx, executionRefID, providerName, target, p)
+	if err != nil {
+		return nil, err
+	}
+	trigger, err := provider.UpsertEventTrigger(ctx, coreworkflow.UpsertEventTriggerRequest{
+		TriggerID:    triggerID,
+		Match:        match,
+		Target:       target,
+		Paused:       req.Paused,
+		RequestedBy:  workflowActorFromPrincipal(p),
+		ExecutionRef: executionRefID,
+	})
+	if err != nil {
+		m.revokeExecutionRef(ctx, ref)
+		return nil, err
+	}
+	return &ManagedEventTrigger{
+		ProviderName: providerName,
+		Trigger:      trigger,
+		ExecutionRef: ref,
+		provider:     provider,
+	}, nil
+}
+
+func (m *Manager) GetEventTrigger(ctx context.Context, p *principal.Principal, triggerID string) (*ManagedEventTrigger, error) {
+	return m.requireOwnedEventTrigger(ctx, triggerID, p)
+}
+
+func (m *Manager) UpdateEventTrigger(ctx context.Context, p *principal.Principal, triggerID string, req EventTriggerUpsert) (*ManagedEventTrigger, error) {
+	p = principal.Canonicalized(p)
+	if strings.TrimSpace(principalSubjectID(p)) == "" {
+		return nil, ErrWorkflowSubjectRequired
+	}
+	existing, err := m.requireOwnedEventTrigger(ctx, triggerID, p)
+	if err != nil {
+		return nil, err
+	}
+	nextProviderName, nextProvider, err := m.resolveProviderSelection(strings.TrimSpace(req.ProviderName))
+	if err != nil {
+		return nil, err
+	}
+	target, err := m.resolveTarget(ctx, p, req.Target)
+	if err != nil {
+		return nil, err
+	}
+	match := normalizeEventMatch(req.Match)
+	if strings.TrimSpace(match.Type) == "" {
+		return nil, ErrWorkflowEventMatchRequired
+	}
+
+	executionRefID := eventTriggerExecutionRefID(strings.TrimSpace(existing.Trigger.ID))
+	nextRef, err := m.putExecutionRef(ctx, executionRefID, nextProviderName, target, p)
+	if err != nil {
+		return nil, err
+	}
+	trigger, err := nextProvider.UpsertEventTrigger(ctx, coreworkflow.UpsertEventTriggerRequest{
+		TriggerID:    strings.TrimSpace(existing.Trigger.ID),
+		Match:        match,
+		Target:       target,
+		Paused:       req.Paused,
+		RequestedBy:  workflowActorFromPrincipal(p),
+		ExecutionRef: executionRefID,
+	})
+	if err != nil {
+		m.revokeExecutionRef(ctx, nextRef)
+		return nil, err
+	}
+	if strings.TrimSpace(existing.ProviderName) != nextProviderName {
+		if err := existingEventTriggerProvider(existing).DeleteEventTrigger(ctx, coreworkflow.DeleteEventTriggerRequest{
+			TriggerID: strings.TrimSpace(existing.Trigger.ID),
+		}); err != nil {
+			_ = nextProvider.DeleteEventTrigger(ctx, coreworkflow.DeleteEventTriggerRequest{
+				TriggerID: strings.TrimSpace(existing.Trigger.ID),
+			})
+			m.revokeExecutionRef(ctx, nextRef)
+			return nil, err
+		}
+	}
+	if existing.ExecutionRef != nil && existing.ExecutionRef.ID != "" && existing.ExecutionRef.ID != executionRefID {
+		m.revokeExecutionRef(ctx, existing.ExecutionRef)
+	}
+	return &ManagedEventTrigger{
+		ProviderName: nextProviderName,
+		Trigger:      trigger,
+		ExecutionRef: nextRef,
+		provider:     nextProvider,
+	}, nil
+}
+
+func (m *Manager) DeleteEventTrigger(ctx context.Context, p *principal.Principal, triggerID string) error {
+	value, err := m.requireOwnedEventTrigger(ctx, triggerID, p)
+	if err != nil {
+		return err
+	}
+	if err := existingEventTriggerProvider(value).DeleteEventTrigger(ctx, coreworkflow.DeleteEventTriggerRequest{
+		TriggerID: strings.TrimSpace(value.Trigger.ID),
+	}); err != nil {
+		return err
+	}
+	m.revokeExecutionRef(ctx, value.ExecutionRef)
+	return nil
+}
+
+func (m *Manager) PauseEventTrigger(ctx context.Context, p *principal.Principal, triggerID string) (*ManagedEventTrigger, error) {
+	value, err := m.requireOwnedEventTrigger(ctx, triggerID, p)
+	if err != nil {
+		return nil, err
+	}
+	trigger, err := existingEventTriggerProvider(value).PauseEventTrigger(ctx, coreworkflow.PauseEventTriggerRequest{
+		TriggerID: strings.TrimSpace(value.Trigger.ID),
+	})
+	if err != nil {
+		return nil, err
+	}
+	value.Trigger = trigger
+	return value, nil
+}
+
+func (m *Manager) ResumeEventTrigger(ctx context.Context, p *principal.Principal, triggerID string) (*ManagedEventTrigger, error) {
+	value, err := m.requireOwnedEventTrigger(ctx, triggerID, p)
+	if err != nil {
+		return nil, err
+	}
+	trigger, err := existingEventTriggerProvider(value).ResumeEventTrigger(ctx, coreworkflow.ResumeEventTriggerRequest{
+		TriggerID: strings.TrimSpace(value.Trigger.ID),
+	})
+	if err != nil {
+		return nil, err
+	}
+	value.Trigger = trigger
+	return value, nil
+}
+
 func (m *Manager) resolveProviderSelection(providerName string) (string, coreworkflow.Provider, error) {
 	if m == nil || m.workflow == nil {
 		return "", nil, ErrWorkflowNotConfigured
@@ -550,6 +780,37 @@ func (m *Manager) requireOwnedSchedule(ctx context.Context, scheduleID string, p
 	}, nil
 }
 
+func (m *Manager) requireOwnedEventTrigger(ctx context.Context, triggerID string, p *principal.Principal) (*ManagedEventTrigger, error) {
+	triggerID = strings.TrimSpace(triggerID)
+	if triggerID == "" {
+		return nil, core.ErrNotFound
+	}
+	ref, err := m.findOwnedEventTriggerExecutionRef(ctx, triggerID, p)
+	if err != nil {
+		return nil, err
+	}
+	if !m.allowTarget(ctx, p, ref.Target) {
+		return nil, core.ErrNotFound
+	}
+	provider, err := m.resolveProviderByName(strings.TrimSpace(ref.ProviderName))
+	if err != nil {
+		return nil, err
+	}
+	trigger, err := provider.GetEventTrigger(ctx, coreworkflow.GetEventTriggerRequest{TriggerID: triggerID})
+	if err != nil {
+		return nil, err
+	}
+	if !eventTriggerMatchesExecutionRef(ref.ProviderName, trigger, ref) {
+		return nil, core.ErrNotFound
+	}
+	return &ManagedEventTrigger{
+		ProviderName: strings.TrimSpace(ref.ProviderName),
+		Trigger:      trigger,
+		ExecutionRef: ref,
+		provider:     provider,
+	}, nil
+}
+
 func (m *Manager) listOwnedExecutionRefs(ctx context.Context, p *principal.Principal, activeOnly bool) ([]*coreworkflow.ExecutionReference, error) {
 	if m == nil || m.workflowExecutionRefs == nil {
 		return nil, ErrExecutionRefsNotConfigured
@@ -585,6 +846,28 @@ func (m *Manager) findOwnedExecutionRef(ctx context.Context, scheduleID string, 
 		}
 		if match != nil {
 			return nil, fmt.Errorf("%w: %s", ErrDuplicateExecutionRefs, scheduleID)
+		}
+		match = ref
+	}
+	if match == nil {
+		return nil, core.ErrNotFound
+	}
+	return match, nil
+}
+
+func (m *Manager) findOwnedEventTriggerExecutionRef(ctx context.Context, triggerID string, p *principal.Principal) (*coreworkflow.ExecutionReference, error) {
+	refs, err := m.listOwnedExecutionRefs(ctx, p, true)
+	if err != nil {
+		return nil, err
+	}
+	prefix := eventTriggerExecutionRefPrefix(triggerID)
+	var match *coreworkflow.ExecutionReference
+	for _, ref := range refs {
+		if !strings.HasPrefix(strings.TrimSpace(ref.ID), prefix) {
+			continue
+		}
+		if match != nil {
+			return nil, fmt.Errorf("%w: %s", ErrDuplicateExecutionRefs, triggerID)
 		}
 		match = ref
 	}
@@ -722,6 +1005,19 @@ func scheduleMatchesExecutionRef(providerName string, schedule *coreworkflow.Sch
 		strings.TrimSpace(schedule.Target.Instance) == strings.TrimSpace(ref.Target.Instance)
 }
 
+func eventTriggerMatchesExecutionRef(providerName string, trigger *coreworkflow.EventTrigger, ref *coreworkflow.ExecutionReference) bool {
+	if trigger == nil || ref == nil {
+		return false
+	}
+	if providerName = strings.TrimSpace(providerName); providerName != "" && strings.TrimSpace(ref.ProviderName) != providerName {
+		return false
+	}
+	return strings.TrimSpace(trigger.Target.PluginName) == strings.TrimSpace(ref.Target.PluginName) &&
+		strings.TrimSpace(trigger.Target.Operation) == strings.TrimSpace(ref.Target.Operation) &&
+		strings.TrimSpace(trigger.Target.Connection) == strings.TrimSpace(ref.Target.Connection) &&
+		strings.TrimSpace(trigger.Target.Instance) == strings.TrimSpace(ref.Target.Instance)
+}
+
 func runMatchesExecutionRef(providerName string, run *coreworkflow.Run, ref *coreworkflow.ExecutionReference) bool {
 	if run == nil || ref == nil {
 		return false
@@ -733,6 +1029,14 @@ func runMatchesExecutionRef(providerName string, run *coreworkflow.Run, ref *cor
 		strings.TrimSpace(run.Target.Operation) == strings.TrimSpace(ref.Target.Operation) &&
 		strings.TrimSpace(run.Target.Connection) == strings.TrimSpace(ref.Target.Connection) &&
 		strings.TrimSpace(run.Target.Instance) == strings.TrimSpace(ref.Target.Instance)
+}
+
+func normalizeEventMatch(match coreworkflow.EventMatch) coreworkflow.EventMatch {
+	return coreworkflow.EventMatch{
+		Type:    strings.TrimSpace(match.Type),
+		Source:  strings.TrimSpace(match.Source),
+		Subject: strings.TrimSpace(match.Subject),
+	}
 }
 
 func workflowActorFromPrincipal(p *principal.Principal) coreworkflow.Actor {
@@ -789,6 +1093,27 @@ func scheduleIDFromExecutionRefID(executionRefID string) string {
 	return rest[:lastColon]
 }
 
+func eventTriggerExecutionRefID(triggerID string) string {
+	return eventTriggerExecutionRefPrefix(triggerID) + uuid.NewString()
+}
+
+func eventTriggerExecutionRefPrefix(triggerID string) string {
+	return workflowEventTriggerExecutionRefBasePrefix + strings.TrimSpace(triggerID) + ":"
+}
+
+func eventTriggerIDFromExecutionRefID(executionRefID string) string {
+	trimmed := strings.TrimSpace(executionRefID)
+	if !strings.HasPrefix(trimmed, workflowEventTriggerExecutionRefBasePrefix) {
+		return ""
+	}
+	rest := strings.TrimPrefix(trimmed, workflowEventTriggerExecutionRefBasePrefix)
+	lastColon := strings.LastIndex(rest, ":")
+	if lastColon <= 0 {
+		return ""
+	}
+	return rest[:lastColon]
+}
+
 func existingProvider(value *ManagedSchedule) coreworkflow.Provider {
 	if value == nil {
 		return nil
@@ -797,6 +1122,13 @@ func existingProvider(value *ManagedSchedule) coreworkflow.Provider {
 }
 
 func existingRunProvider(value *ManagedRun) coreworkflow.Provider {
+	if value == nil {
+		return nil
+	}
+	return value.provider
+}
+
+func existingEventTriggerProvider(value *ManagedEventTrigger) coreworkflow.Provider {
 	if value == nil {
 		return nil
 	}


### PR DESCRIPTION
This adds the missing global event trigger CRUD surface that mirrors the existing workflow schedule flow.

New interfaces:
- `GET /api/v1/workflow/event-triggers`
- `POST /api/v1/workflow/event-triggers`
- `GET /api/v1/workflow/event-triggers/{triggerID}`
- `PUT /api/v1/workflow/event-triggers/{triggerID}`
- `DELETE /api/v1/workflow/event-triggers/{triggerID}`
- `POST /api/v1/workflow/event-triggers/{triggerID}/pause`
- `POST /api/v1/workflow/event-triggers/{triggerID}/resume`
- `gestalt workflows triggers list|get|create|update|delete|pause|resume`

HTTP example:
```sh
curl -X POST "$GESTALT_URL/api/v1/workflow/event-triggers" \
  -H "Authorization: Bearer $GESTALT_API_KEY" \
  -H "Content-Type: application/json" \
  -d '{
    "match": {
      "type": "roadmap.item.updated",
      "source": "roadmap",
      "subject": "item"
    },
    "target": {
      "plugin": "slack",
      "operation": "chat.postMessage",
      "input": {
        "channel": "C123",
        "text": "Roadmap item updated"
      }
    }
  }'
```

CLI example:
```sh
gestalt workflows triggers create \
  --type roadmap.item.updated \
  --source roadmap \
  --subject item \
  --plugin slack \
  --operation chat.postMessage \
  -p channel=C123 \
  -p text="Roadmap item updated"
```

Behavior:
- event triggers now use the same owner-scoped execution-ref model as schedules
- create, get, update, delete, pause, and resume all resolve through owned execution refs
- docs now describe the trigger CRUD surface and examples instead of saying triggers are config-only
- this intentionally does not add a generic public event publish endpoint like `/api/v1/workflow/events`

Verification:
- `cd gestaltd && go test ./internal/server ./internal/workflowmanager ./internal/bootstrap -count=1`
- `cd gestaltd && golangci-lint run ./internal/server ./internal/workflowmanager ./internal/bootstrap`
- `cd gestalt && cargo test --test workflows_cli`
- `cd gestalt && cargo fmt --all --check`
- `cd docs && npm run typecheck`
- `cd docs && npm run build`
- `git diff --check`
