### PR TITLE
gestaltd: remove identity:__identity__ from startup credentials

### DIFF
--- a/docs/internal/remove-identity-singleton-rollout.md
+++ b/docs/internal/remove-identity-singleton-rollout.md
@@ -1,0 +1,159 @@
+# Remove `identity:__identity__` Rollout
+
+This change deletes the shared startup credential subject from runtime use.
+
+New behavior:
+- workflow execution refs keep their actual system subject as both `subject_id` and `credential_subject_id`
+- canonical `external_credentials` rows are keyed by `subject_id`, not `identity_id`
+
+Examples:
+
+```go
+// Old startup runtime shape.
+&principal.Principal{
+    SubjectID:           "system:config",
+    CredentialSubjectID: "identity:__identity__",
+}
+
+// New startup runtime shape.
+&principal.Principal{
+    SubjectID:           "system:config",
+    CredentialSubjectID: "system:config",
+}
+```
+
+```sql
+-- Old canonical credential lookup key.
+(identity_id, plugin, connection, instance)
+
+-- New canonical credential lookup key.
+(subject_id, plugin, connection, instance)
+```
+
+## Rollout shape
+
+This is a cutover-style deploy for `external_credentials`.
+
+Why:
+- old code reads and writes `external_credentials.identity_id`
+- new code reads and writes `external_credentials.subject_id`
+- mixed old/new overlap after the schema flip is not safe
+
+## Required precheck
+
+Abort the rollout if any legacy startup token rows still exist:
+
+```sql
+SELECT COUNT(*) AS legacy_startup_tokens
+FROM integration_tokens
+WHERE subject_id = 'identity:__identity__';
+```
+
+This branch does not rewrite those rows in code. The rollout is only safe if that count is `0`.
+
+If the count is not `0`, do not deploy this branch as-is. Those rows will become unreachable after startup/system workflow credentials switch to `subject_id='system:config'`.
+
+Required manual rewrite before deploy if the count is nonzero:
+
+```sql
+UPDATE integration_tokens
+SET subject_id = 'system:config'
+WHERE subject_id = 'identity:__identity__';
+```
+
+After that rewrite, rerun the precheck and make sure it returns `0`.
+
+## Deploy steps
+
+1. Take a snapshot / backup of the `external_credentials` table.
+2. Drain old app revisions so old code is no longer serving against the store.
+   No rolling old/new overlap after the schema flip.
+3. Deploy the new revision.
+4. Let startup rebuild canonical `external_credentials` from `integration_tokens`.
+
+## Exact cutover SQL
+
+Run this only after old revisions are drained and immediately before the new
+revision is deployed.
+
+```sql
+RENAME TABLE external_credentials TO external_credentials_backup_20260422_1237;
+
+CREATE TABLE external_credentials (
+  id varchar(255) NOT NULL,
+  subject_id varchar(255) NOT NULL,
+  plugin varchar(255) NOT NULL,
+  connection varchar(255) NOT NULL,
+  instance varchar(255) NOT NULL,
+  auth_type longtext NOT NULL,
+  payload_encrypted longtext,
+  scopes longtext,
+  expires_at datetime(6) DEFAULT NULL,
+  last_refreshed_at datetime(6) DEFAULT NULL,
+  refresh_error_count bigint DEFAULT NULL,
+  metadata_json longtext,
+  created_at datetime(6) DEFAULT NULL,
+  updated_at datetime(6) DEFAULT NULL,
+  PRIMARY KEY (id),
+  UNIQUE KEY idx_external_credentials_by_lookup (subject_id(128), plugin(128), connection(128), instance(128)),
+  KEY idx_external_credentials_by_subject (subject_id),
+  KEY idx_external_credentials_by_subject_plugin (subject_id(128), plugin(128)),
+  KEY idx_external_credentials_by_subject_connection (subject_id(128), plugin(128), connection(128))
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_0900_ai_ci;
+```
+
+The backup table is expected to keep the pre-cutover rows and indexes exactly as
+they were. The new `external_credentials` table must start empty; startup will
+clear and repopulate it canonically from `integration_tokens`.
+
+## Required verification
+
+Check that canonical rows match the deduped readable source rows:
+
+```sql
+WITH ranked_tokens AS (
+  SELECT
+    subject_id,
+    integration,
+    connection,
+    instance,
+    access_token_encrypted,
+    refresh_token_encrypted,
+    ROW_NUMBER() OVER (
+      PARTITION BY subject_id, integration, connection, instance
+      ORDER BY updated_at DESC, created_at DESC, id ASC
+    ) AS rn
+  FROM integration_tokens
+),
+deduped_tokens AS (
+  SELECT *
+  FROM ranked_tokens
+  WHERE rn = 1
+),
+readable_tokens AS (
+  SELECT COUNT(*) AS n
+  FROM deduped_tokens
+  WHERE access_token_encrypted IS NOT NULL
+)
+SELECT
+  (SELECT n FROM readable_tokens) AS readable_tokens,
+  (SELECT COUNT(*) FROM external_credentials) AS canonical_external_credentials;
+```
+
+Those counts should match.
+
+Also verify that startup-owned credentials are now subject-owned:
+
+```sql
+SELECT subject_id, plugin, connection, instance
+FROM external_credentials
+WHERE subject_id LIKE 'system:%'
+ORDER BY subject_id, plugin, connection, instance;
+```
+
+## Rollback
+
+If verification fails:
+- restore the `external_credentials` backup
+- redeploy the previous revision
+- do not leave the new schema live while old and new revisions overlap

--- a/gestaltd/cmd/gestaltd/e2e_test.go
+++ b/gestaltd/cmd/gestaltd/e2e_test.go
@@ -568,7 +568,7 @@ plugins:
 	if err == nil {
 		t.Fatalf("expected validate to fail, got success:\n%s", out)
 	}
-	if !strings.Contains(string(out), `duplicate operation \"echo\" across static and API catalogs`) {
+	if !strings.Contains(string(out), `duplicate operation \"echo\" across merged catalogs`) {
 		t.Fatalf("expected validate output to mention duplicate effective operation, got: %s", out)
 	}
 }

--- a/gestaltd/cmd/gestaltd/provider_test.go
+++ b/gestaltd/cmd/gestaltd/provider_test.go
@@ -1936,7 +1936,7 @@ paths:
 	if err == nil {
 		t.Fatalf("expected provider release to fail, got output: %s", out)
 	}
-	if !strings.Contains(string(out), `duplicate operation \"generated_op\" across static and API catalogs`) {
+	if !strings.Contains(string(out), `duplicate operation \"generated_op\" across merged catalogs`) {
 		t.Fatalf("expected duplicate effective operation error, got: %s", out)
 	}
 }

--- a/gestaltd/core/types.go
+++ b/gestaltd/core/types.go
@@ -178,7 +178,7 @@ type APITokenAccess struct {
 
 type ExternalCredential struct {
 	ID                string
-	IdentityID        string
+	SubjectID         string
 	Plugin            string
 	Connection        string
 	Instance          string

--- a/gestaltd/internal/bootstrap/bootstrap_test.go
+++ b/gestaltd/internal/bootstrap/bootstrap_test.go
@@ -3077,13 +3077,13 @@ func TestBootstrapStartsWorkflowProvidersAfterInvokerIsReady(t *testing.T) {
 			return nil, fmt.Errorf("workflow name = %q, want %q", name, "temporal")
 		}
 		if err := deps.Services.Tokens.StoreToken(context.Background(), &core.IntegrationToken{
-			SubjectID:   principal.IdentitySubjectID(),
+			SubjectID:   "system:config",
 			Integration: "roadmap",
 			Connection:  config.PluginConnectionName,
 			Instance:    "default",
 			AccessToken: "workflow-bootstrap-token",
 		}); err != nil {
-			return nil, fmt.Errorf("store identity token: %w", err)
+			return nil, fmt.Errorf("store startup token: %w", err)
 		}
 		executionRef := storeWorkflowExecutionRefForTarget(t, deps, name, coreworkflow.Target{
 			PluginName: "roadmap",
@@ -3136,13 +3136,13 @@ func TestValidateStartsWorkflowProvidersAfterInvokerIsReady(t *testing.T) {
 			return nil, fmt.Errorf("workflow name = %q, want %q", name, "temporal")
 		}
 		if err := deps.Services.Tokens.StoreToken(context.Background(), &core.IntegrationToken{
-			SubjectID:   principal.IdentitySubjectID(),
+			SubjectID:   "system:config",
 			Integration: "roadmap",
 			Connection:  config.PluginConnectionName,
 			Instance:    "default",
 			AccessToken: "workflow-validate-token",
 		}); err != nil {
-			return nil, fmt.Errorf("store identity token: %w", err)
+			return nil, fmt.Errorf("store startup token: %w", err)
 		}
 		executionRef := storeWorkflowExecutionRefForTarget(t, deps, name, coreworkflow.Target{
 			PluginName: "roadmap",
@@ -3201,13 +3201,13 @@ func TestBootstrapStartupWorkflowCallbackRequiresExecutionRef(t *testing.T) {
 			return nil, fmt.Errorf("workflow name = %q, want %q", name, "temporal")
 		}
 		if err := deps.Services.Tokens.StoreToken(context.Background(), &core.IntegrationToken{
-			SubjectID:   principal.IdentitySubjectID(),
+			SubjectID:   "system:config",
 			Integration: "roadmap",
 			Connection:  config.PluginConnectionName,
 			Instance:    "default",
 			AccessToken: "workflow-startup-token",
 		}); err != nil {
-			return nil, fmt.Errorf("store identity token: %w", err)
+			return nil, fmt.Errorf("store startup token: %w", err)
 		}
 		_, err := invokeWorkflowHostCallback(t, hostServices, &proto.InvokeWorkflowOperationRequest{
 			Target: &proto.BoundWorkflowTarget{
@@ -3362,13 +3362,13 @@ func TestValidateManagedWorkflowStartupCallbackUsesPreparedProviderStub(t *testi
 					return nil, fmt.Errorf("workflow name = %q, want %q", name, "temporal")
 				}
 				if err := deps.Services.Tokens.StoreToken(context.Background(), &core.IntegrationToken{
-					SubjectID:   principal.IdentitySubjectID(),
+					SubjectID:   "system:config",
 					Integration: "roadmap",
 					Connection:  config.PluginConnectionName,
 					Instance:    "default",
 					AccessToken: "workflow-validate-token",
 				}); err != nil {
-					return nil, fmt.Errorf("store identity token: %w", err)
+					return nil, fmt.Errorf("store startup token: %w", err)
 				}
 				executionRef := storeWorkflowExecutionRefForTarget(t, deps, name, coreworkflow.Target{
 					PluginName: "roadmap",
@@ -3461,13 +3461,13 @@ func TestValidateManagedWorkflowStartupInvokesMCPPassthroughPreparedProviders(t 
 			connection = config.PluginConnectionName
 		}
 		if err := deps.Services.Tokens.StoreToken(context.Background(), &core.IntegrationToken{
-			SubjectID:   principal.IdentitySubjectID(),
+			SubjectID:   "system:config",
 			Integration: "roadmap",
 			Connection:  connection,
 			Instance:    "default",
 			AccessToken: "workflow-validate-token",
 		}); err != nil {
-			return nil, fmt.Errorf("store identity token for connection %q: %w", connection, err)
+			return nil, fmt.Errorf("store startup token for connection %q: %w", connection, err)
 		}
 		req := coreworkflow.InvokeOperationRequest{
 			ProviderName: name,
@@ -3478,7 +3478,7 @@ func TestValidateManagedWorkflowStartupInvokesMCPPassthroughPreparedProviders(t 
 		}
 		configPrincipal := &principal.Principal{
 			SubjectID:           "system:config",
-			CredentialSubjectID: principal.IdentitySubjectID(),
+			CredentialSubjectID: "system:config",
 			TokenPermissions: principal.CompilePermissions([]core.AccessPermission{{
 				Plugin:     "roadmap",
 				Operations: []string{"sync"},
@@ -4719,7 +4719,7 @@ func TestBootstrapSecretResolution(t *testing.T) {
 
 		configPrincipal := &principal.Principal{
 			SubjectID:           "system:config",
-			CredentialSubjectID: principal.IdentitySubjectID(),
+			CredentialSubjectID: "system:config",
 			TokenPermissions: principal.CompilePermissions([]core.AccessPermission{{
 				Plugin:     "roadmap",
 				Operations: []string{"sync"},

--- a/gestaltd/internal/bootstrap/workflow_runtime.go
+++ b/gestaltd/internal/bootstrap/workflow_runtime.go
@@ -282,7 +282,7 @@ func workflowExecutionPrincipal(ref *coreworkflow.ExecutionReference) *principal
 		TokenPermissions: permissions,
 	}
 	if principal.IsSystemSubjectID(value.SubjectID) {
-		value.CredentialSubjectID = principal.IdentitySubjectID()
+		value.CredentialSubjectID = value.SubjectID
 	}
 	return principal.Canonicalize(value)
 }

--- a/gestaltd/internal/bootstrap/workflow_runtime_test.go
+++ b/gestaltd/internal/bootstrap/workflow_runtime_test.go
@@ -252,7 +252,7 @@ func TestWorkflowRuntimeInvokeMergesConfiguredAndPerRunInput(t *testing.T) {
 	configPermissions := principal.CompilePermissions(workflowExecutionRefPermissionsForTarget(req.Target))
 	configPrincipal := principal.Canonicalize(&principal.Principal{
 		SubjectID:           "system:config",
-		CredentialSubjectID: principal.IdentitySubjectID(),
+		CredentialSubjectID: "system:config",
 		Scopes:              principal.PermissionPlugins(configPermissions),
 		TokenPermissions:    configPermissions,
 	})
@@ -266,8 +266,8 @@ func TestWorkflowRuntimeInvokeMergesConfiguredAndPerRunInput(t *testing.T) {
 	if gotPrincipal == nil || gotPrincipal.SubjectID != "system:config" {
 		t.Fatalf("principal = %#v", gotPrincipal)
 	}
-	if gotPrincipal.CredentialSubjectID != principal.IdentitySubjectID() {
-		t.Fatalf("credential subject = %q, want %q", gotPrincipal.CredentialSubjectID, principal.IdentitySubjectID())
+	if gotPrincipal.CredentialSubjectID != "system:config" {
+		t.Fatalf("credential subject = %q, want %q", gotPrincipal.CredentialSubjectID, "system:config")
 	}
 	if !principal.AllowsOperationPermission(gotPrincipal, "roadmap", "sync") {
 		t.Fatalf("principal operation permissions = %#v, want roadmap.sync", gotPrincipal.TokenPermissions)

--- a/gestaltd/internal/bootstrap/workflow_startup_test.go
+++ b/gestaltd/internal/bootstrap/workflow_startup_test.go
@@ -17,7 +17,6 @@ import (
 	coretesting "github.com/valon-technologies/gestalt/server/core/testing"
 	coreworkflow "github.com/valon-technologies/gestalt/server/core/workflow"
 	"github.com/valon-technologies/gestalt/server/internal/config"
-	"github.com/valon-technologies/gestalt/server/internal/principal"
 	"github.com/valon-technologies/gestalt/server/internal/providerhost"
 	"github.com/valon-technologies/gestalt/server/internal/testutil"
 	providermanifestv1 "github.com/valon-technologies/gestalt/server/sdk/providermanifest/v1"
@@ -268,13 +267,13 @@ func TestBootstrapWorkflowStartupCallbackWaitsForDelayedPluginProvider(t *testin
 			return nil, fmt.Errorf("workflow name = %q, want %q", name, "temporal")
 		}
 		if err := deps.Services.Tokens.StoreToken(context.Background(), &core.IntegrationToken{
-			SubjectID:   principal.IdentitySubjectID(),
+			SubjectID:   "system:config",
 			Integration: "roadmap",
 			Connection:  config.PluginConnectionName,
 			Instance:    "default",
 			AccessToken: "workflow-startup-token",
 		}); err != nil {
-			return nil, fmt.Errorf("store identity token: %w", err)
+			return nil, fmt.Errorf("store startup token: %w", err)
 		}
 		executionRef := storeStartupExecutionRef(t, deps, name, coreworkflow.Target{
 			PluginName: "roadmap",
@@ -331,13 +330,13 @@ func TestManagedWorkflowStartupCallbackRequiresExecutionRef(t *testing.T) {
 			return nil, fmt.Errorf("workflow name = %q, want %q", name, "temporal")
 		}
 		if err := deps.Services.Tokens.StoreToken(context.Background(), &core.IntegrationToken{
-			SubjectID:   principal.IdentitySubjectID(),
+			SubjectID:   "system:config",
 			Integration: "roadmap",
 			Connection:  config.PluginConnectionName,
 			Instance:    "default",
 			AccessToken: "workflow-startup-token",
 		}); err != nil {
-			return nil, fmt.Errorf("store identity token: %w", err)
+			return nil, fmt.Errorf("store startup token: %w", err)
 		}
 		_, err := invokeWorkflowHostDuringStartup(t, hostServices, &proto.InvokeWorkflowOperationRequest{
 			Target: &proto.BoundWorkflowTarget{

--- a/gestaltd/internal/coredata/canonical_future.go
+++ b/gestaltd/internal/coredata/canonical_future.go
@@ -109,19 +109,19 @@ func (s *ExternalCredentialService) UpsertCredential(ctx context.Context, creden
 	if credential == nil {
 		return nil, fmt.Errorf("upsert external credential: credential is required")
 	}
-	identityID := strings.TrimSpace(credential.IdentityID)
+	subjectID := strings.TrimSpace(credential.SubjectID)
 	plugin := strings.TrimSpace(credential.Plugin)
 	connection := strings.TrimSpace(credential.Connection)
 	instance := strings.TrimSpace(credential.Instance)
 	authType := strings.TrimSpace(credential.AuthType)
-	if identityID == "" || plugin == "" || connection == "" || authType == "" {
-		return nil, fmt.Errorf("upsert external credential: identity_id, plugin, connection, and auth_type are required")
+	if subjectID == "" || plugin == "" || connection == "" || authType == "" {
+		return nil, fmt.Errorf("upsert external credential: subject_id, plugin, connection, and auth_type are required")
 	}
 
 	now := time.Now()
 	id := credential.ID
 	createdAt := credential.CreatedAt
-	if existing, err := s.store.Index("by_lookup").Get(ctx, identityID, plugin, connection, instance); err == nil {
+	if existing, err := s.store.Index("by_lookup").Get(ctx, subjectID, plugin, connection, instance); err == nil {
 		id = recString(existing, "id")
 		if created := recTime(existing, "created_at"); !created.IsZero() {
 			createdAt = created
@@ -138,7 +138,7 @@ func (s *ExternalCredentialService) UpsertCredential(ctx context.Context, creden
 
 	rec := indexeddb.Record{
 		"id":                  id,
-		"identity_id":         identityID,
+		"subject_id":          subjectID,
 		"plugin":              plugin,
 		"connection":          connection,
 		"instance":            instance,
@@ -158,8 +158,8 @@ func (s *ExternalCredentialService) UpsertCredential(ctx context.Context, creden
 	return recordToExternalCredential(rec), nil
 }
 
-func (s *ExternalCredentialService) DeleteCredential(ctx context.Context, identityID, plugin, connection, instance string) error {
-	deleted, err := s.store.Index("by_lookup").Delete(ctx, strings.TrimSpace(identityID), strings.TrimSpace(plugin), strings.TrimSpace(connection), strings.TrimSpace(instance))
+func (s *ExternalCredentialService) DeleteCredential(ctx context.Context, subjectID, plugin, connection, instance string) error {
+	deleted, err := s.store.Index("by_lookup").Delete(ctx, strings.TrimSpace(subjectID), strings.TrimSpace(plugin), strings.TrimSpace(connection), strings.TrimSpace(instance))
 	if err != nil {
 		return fmt.Errorf("delete external credential: %w", err)
 	}
@@ -169,8 +169,8 @@ func (s *ExternalCredentialService) DeleteCredential(ctx context.Context, identi
 	return nil
 }
 
-func (s *ExternalCredentialService) GetCredential(ctx context.Context, identityID, plugin, connection, instance string) (*core.ExternalCredential, error) {
-	rec, err := s.store.Index("by_lookup").Get(ctx, strings.TrimSpace(identityID), strings.TrimSpace(plugin), strings.TrimSpace(connection), strings.TrimSpace(instance))
+func (s *ExternalCredentialService) GetCredential(ctx context.Context, subjectID, plugin, connection, instance string) (*core.ExternalCredential, error) {
+	rec, err := s.store.Index("by_lookup").Get(ctx, strings.TrimSpace(subjectID), strings.TrimSpace(plugin), strings.TrimSpace(connection), strings.TrimSpace(instance))
 	if err != nil {
 		if err == indexeddb.ErrNotFound {
 			return nil, core.ErrNotFound
@@ -195,7 +195,7 @@ func encodeLegacyCredentialPayload(accessTokenEncrypted, refreshTokenEncrypted s
 func recordToExternalCredential(rec indexeddb.Record) *core.ExternalCredential {
 	return &core.ExternalCredential{
 		ID:                recString(rec, "id"),
-		IdentityID:        recString(rec, "identity_id"),
+		SubjectID:         recString(rec, "subject_id"),
 		Plugin:            recString(rec, "plugin"),
 		Connection:        recString(rec, "connection"),
 		Instance:          recString(rec, "instance"),

--- a/gestaltd/internal/coredata/schemas.go
+++ b/gestaltd/internal/coredata/schemas.go
@@ -247,14 +247,14 @@ var APITokenAccessSchema = indexeddb.ObjectStoreSchema{
 
 var ExternalCredentialsSchema = indexeddb.ObjectStoreSchema{
 	Indexes: []indexeddb.IndexSchema{
-		{Name: "by_identity", KeyPath: []string{"identity_id"}},
-		{Name: "by_identity_plugin", KeyPath: []string{"identity_id", "plugin"}},
-		{Name: "by_identity_connection", KeyPath: []string{"identity_id", "plugin", "connection"}},
-		{Name: "by_lookup", KeyPath: []string{"identity_id", "plugin", "connection", "instance"}, Unique: true},
+		{Name: "by_subject", KeyPath: []string{"subject_id"}},
+		{Name: "by_subject_plugin", KeyPath: []string{"subject_id", "plugin"}},
+		{Name: "by_subject_connection", KeyPath: []string{"subject_id", "plugin", "connection"}},
+		{Name: "by_lookup", KeyPath: []string{"subject_id", "plugin", "connection", "instance"}, Unique: true},
 	},
 	Columns: []indexeddb.ColumnDef{
 		{Name: "id", Type: indexeddb.TypeString, PrimaryKey: true},
-		{Name: "identity_id", Type: indexeddb.TypeString, NotNull: true},
+		{Name: "subject_id", Type: indexeddb.TypeString, NotNull: true},
 		{Name: "plugin", Type: indexeddb.TypeString, NotNull: true},
 		{Name: "connection", Type: indexeddb.TypeString, NotNull: true},
 		{Name: "instance", Type: indexeddb.TypeString, NotNull: true},

--- a/gestaltd/internal/coredata/services.go
+++ b/gestaltd/internal/coredata/services.go
@@ -93,7 +93,7 @@ func New(ds indexeddb.IndexedDB, enc *corecrypto.AESGCMEncryptor) (*Services, er
 	identityMemberships := NewManagedIdentityMembershipService(ds, identityManagementGrants, users)
 	identityGrants := NewManagedIdentityGrantService(ds, identityPluginAccess)
 	apiTokens := NewAPITokenService(ds, apiTokenAccess, users)
-	tokens := NewTokenService(ds, enc, externalCredentials, users)
+	tokens := NewTokenService(ds, enc, externalCredentials)
 
 	if err := rebuildCanonicalIdentityGraph(ctx, identities, authBindings, identityManagementGrants, workspaceRoles, identityPluginAccess, apiTokenAccess, externalCredentials); err != nil {
 		return nil, err

--- a/gestaltd/internal/coredata/services_test.go
+++ b/gestaltd/internal/coredata/services_test.go
@@ -315,6 +315,20 @@ func TestNew(t *testing.T) {
 			t.Fatalf("seed valid integration token: %v", err)
 		}
 		if err := db.ObjectStore(coredata.StoreIntegrationTokens).Add(ctx, indexeddb.Record{
+			"id":                      "startup-token",
+			"subject_id":              "system:config",
+			"integration":             "slack",
+			"connection":              "workspace",
+			"instance":                "default",
+			"access_token_encrypted":  accessEnc,
+			"refresh_token_encrypted": refreshEnc,
+			"scopes":                  "channels:read",
+			"created_at":              createdAt.Add(time.Minute),
+			"updated_at":              createdAt.Add(time.Minute),
+		}); err != nil {
+			t.Fatalf("seed startup integration token: %v", err)
+		}
+		if err := db.ObjectStore(coredata.StoreIntegrationTokens).Add(ctx, indexeddb.Record{
 			"id":                      "bad-token",
 			"subject_id":              principal.UserSubjectID("legacy-user"),
 			"integration":             "github",
@@ -333,14 +347,21 @@ func TestNew(t *testing.T) {
 			t.Fatalf("coredata.New: %v", err)
 		}
 
-		good, err := svc.ExternalCredentials.GetCredential(ctx, "legacy-user", "slack", "workspace", "")
+		good, err := svc.ExternalCredentials.GetCredential(ctx, principal.UserSubjectID("legacy-user"), "slack", "workspace", "")
 		if err != nil {
 			t.Fatalf("GetCredential valid token: %v", err)
 		}
-		if good.IdentityID != "legacy-user" {
-			t.Fatalf("valid credential identity_id = %q, want %q", good.IdentityID, "legacy-user")
+		if good.SubjectID != principal.UserSubjectID("legacy-user") {
+			t.Fatalf("valid credential subject_id = %q, want %q", good.SubjectID, principal.UserSubjectID("legacy-user"))
 		}
-		if _, err := svc.ExternalCredentials.GetCredential(ctx, "legacy-user", "github", "workspace", ""); !errors.Is(err, core.ErrNotFound) {
+		startup, err := svc.ExternalCredentials.GetCredential(ctx, "system:config", "slack", "workspace", "default")
+		if err != nil {
+			t.Fatalf("GetCredential startup token: %v", err)
+		}
+		if startup.SubjectID != "system:config" {
+			t.Fatalf("startup credential subject_id = %q, want %q", startup.SubjectID, "system:config")
+		}
+		if _, err := svc.ExternalCredentials.GetCredential(ctx, principal.UserSubjectID("legacy-user"), "github", "workspace", ""); !errors.Is(err, core.ErrNotFound) {
 			t.Fatalf("GetCredential invalid token err = %v, want ErrNotFound", err)
 		}
 	})
@@ -681,7 +702,7 @@ func TestTokenService(t *testing.T) {
 		if got.MetadataJSON != `{"key":"val"}` {
 			t.Errorf("MetadataJSON = %q, want %q", got.MetadataJSON, `{"key":"val"}`)
 		}
-		credential, err := svc.ExternalCredentials.GetCredential(ctx, user.ID, "test-svc", "default", "inst-1")
+		credential, err := svc.ExternalCredentials.GetCredential(ctx, principal.UserSubjectID(user.ID), "test-svc", "default", "inst-1")
 		if err != nil {
 			t.Fatalf("GetCredential: %v", err)
 		}
@@ -803,7 +824,7 @@ func TestTokenService(t *testing.T) {
 		if err != core.ErrNotFound {
 			t.Fatalf("Token after delete = %v, want ErrNotFound", err)
 		}
-		if _, err := svc.ExternalCredentials.GetCredential(ctx, user.ID, "svc", "default", "i1"); err != core.ErrNotFound {
+		if _, err := svc.ExternalCredentials.GetCredential(ctx, principal.UserSubjectID(user.ID), "svc", "default", "i1"); err != core.ErrNotFound {
 			t.Fatalf("GetCredential after delete = %v, want ErrNotFound", err)
 		}
 	})
@@ -935,7 +956,7 @@ func TestTokenService(t *testing.T) {
 		if err := svc.Tokens.DeleteToken(ctx, newest.ID); err != nil {
 			t.Fatalf("DeleteToken newest: %v", err)
 		}
-		credential, err := svc.ExternalCredentials.GetCredential(ctx, user.ID, "svc", "default", "i1")
+		credential, err := svc.ExternalCredentials.GetCredential(ctx, principal.UserSubjectID(user.ID), "svc", "default", "i1")
 		if err != nil {
 			t.Fatalf("GetCredential after deleting newest duplicate: %v", err)
 		}
@@ -1022,7 +1043,7 @@ func TestTokenService(t *testing.T) {
 			t.Fatalf("reload services for startup backfill: %v", err)
 		}
 
-		credential, err := reloaded.ExternalCredentials.GetCredential(ctx, user.ID, "svc", "default", "i1")
+		credential, err := reloaded.ExternalCredentials.GetCredential(ctx, principal.UserSubjectID(user.ID), "svc", "default", "i1")
 		if err != nil {
 			t.Fatalf("GetCredential after reload: %v", err)
 		}
@@ -1084,7 +1105,7 @@ func TestTokenService(t *testing.T) {
 					t.Fatalf("reload services for startup backfill: %v", err)
 				}
 
-				credential, err := reloaded.ExternalCredentials.GetCredential(ctx, user.ID, "svc", "default", "i1")
+				credential, err := reloaded.ExternalCredentials.GetCredential(ctx, principal.UserSubjectID(user.ID), "svc", "default", "i1")
 				if err != nil {
 					t.Fatalf("GetCredential after reload: %v", err)
 				}

--- a/gestaltd/internal/coredata/tokens.go
+++ b/gestaltd/internal/coredata/tokens.go
@@ -18,17 +18,15 @@ type TokenService struct {
 	store               indexeddb.ObjectStore
 	enc                 *corecrypto.AESGCMEncryptor
 	externalCredentials *ExternalCredentialService
-	users               *UserService
 }
 
 var errUnreadableStoredIntegrationToken = errors.New("unreadable stored integration token")
 
-func NewTokenService(ds indexeddb.IndexedDB, enc *corecrypto.AESGCMEncryptor, externalCredentials *ExternalCredentialService, users *UserService) *TokenService {
+func NewTokenService(ds indexeddb.IndexedDB, enc *corecrypto.AESGCMEncryptor, externalCredentials *ExternalCredentialService) *TokenService {
 	return &TokenService{
 		store:               ds.ObjectStore(StoreIntegrationTokens),
 		enc:                 enc,
 		externalCredentials: externalCredentials,
-		users:               users,
 	}
 }
 
@@ -148,11 +146,8 @@ func (s *TokenService) DeleteToken(ctx context.Context, id string) error {
 				return err
 			}
 		} else {
-			identityID, resolveErr := s.resolveIdentityID(ctx, subjectID)
-			if resolveErr == nil {
-				if err := s.externalCredentials.DeleteCredential(ctx, identityID, recString(rec, "integration"), recString(rec, "connection"), recString(rec, "instance")); err != nil && err != core.ErrNotFound {
-					return fmt.Errorf("delete canonical external credential: %w", err)
-				}
+			if err := s.externalCredentials.DeleteCredential(ctx, subjectID, recString(rec, "integration"), recString(rec, "connection"), recString(rec, "instance")); err != nil && err != core.ErrNotFound {
+				return fmt.Errorf("delete canonical external credential: %w", err)
 			}
 		}
 	}
@@ -297,45 +292,18 @@ func tokenRecordLess(a, b indexeddb.Record) bool {
 	return recString(a, "id") < recString(b, "id")
 }
 
-func (s *TokenService) resolveIdentityID(ctx context.Context, subjectID string) (string, error) {
-	subjectID = strings.TrimSpace(subjectID)
-	switch {
-	case subjectID == "":
-		return "", core.ErrNotFound
-	case subjectID == tokenIdentitySubjectID():
-		return tokenIdentityPrincipal(), nil
-	case tokenManagedIdentityIDFromSubjectID(subjectID) != "":
-		return tokenManagedIdentityIDFromSubjectID(subjectID), nil
-	}
-
-	userID := tokenUserIDFromSubjectID(subjectID)
-	if userID == "" {
-		return "", core.ErrNotFound
-	}
-	if s.users == nil {
-		return userID, nil
-	}
-	return s.users.CanonicalIdentityIDForUser(ctx, userID)
-}
-
 func (s *TokenService) syncExternalCredential(ctx context.Context, token *core.IntegrationToken, accessTokenEncrypted, refreshTokenEncrypted string) error {
 	if s.externalCredentials == nil || token == nil || token.SubjectID == "" || token.Integration == "" || token.Connection == "" {
 		return nil
 	}
-	identityID, resolveErr := s.resolveIdentityID(ctx, token.SubjectID)
-	if resolveErr != nil {
-		if errors.Is(resolveErr, core.ErrNotFound) {
-			return nil
-		}
-		return resolveErr
-	}
+	subjectID := strings.TrimSpace(token.SubjectID)
 	payloadEncrypted, err := encodeLegacyCredentialPayload(accessTokenEncrypted, refreshTokenEncrypted)
 	if err != nil {
 		return err
 	}
 	if _, err := s.externalCredentials.UpsertCredential(ctx, &core.ExternalCredential{
 		ID:                token.ID,
-		IdentityID:        identityID,
+		SubjectID:         subjectID,
 		Plugin:            token.Integration,
 		Connection:        token.Connection,
 		Instance:          token.Instance,
@@ -349,7 +317,7 @@ func (s *TokenService) syncExternalCredential(ctx context.Context, token *core.I
 		CreatedAt:         token.CreatedAt,
 		UpdatedAt:         token.UpdatedAt,
 	}); err != nil {
-		return fmt.Errorf("sync canonical external credential %q/%q/%q/%q: %w", identityID, token.Integration, token.Connection, token.Instance, err)
+		return fmt.Errorf("sync canonical external credential %q/%q/%q/%q: %w", subjectID, token.Integration, token.Connection, token.Instance, err)
 	}
 	return nil
 }
@@ -371,16 +339,10 @@ func (s *TokenService) syncExternalCredentialRecord(ctx context.Context, rec ind
 	if s.externalCredentials == nil {
 		return nil
 	}
-	identityID, resolveErr := s.resolveIdentityID(ctx, tokenRecordSubjectID(rec))
-	if resolveErr != nil {
-		if errors.Is(resolveErr, core.ErrNotFound) {
-			return nil
-		}
-		return resolveErr
-	}
+	subjectID := tokenRecordSubjectID(rec)
 	plugin := recString(rec, "integration")
 	connection := recString(rec, "connection")
-	if identityID == "" || plugin == "" || connection == "" {
+	if subjectID == "" || plugin == "" || connection == "" {
 		return nil
 	}
 	accessTokenEncrypted := recString(rec, "access_token_encrypted")
@@ -391,11 +353,11 @@ func (s *TokenService) syncExternalCredentialRecord(ctx context.Context, rec ind
 	}
 	token, err := s.recordToToken(rec)
 	if err != nil {
-		return fmt.Errorf("decode token for canonical external credential %q/%q/%q/%q: %w", identityID, plugin, connection, recString(rec, "instance"), err)
+		return fmt.Errorf("decode token for canonical external credential %q/%q/%q/%q: %w", subjectID, plugin, connection, recString(rec, "instance"), err)
 	}
 	if _, err := s.externalCredentials.UpsertCredential(ctx, &core.ExternalCredential{
 		ID:                recString(rec, "id"),
-		IdentityID:        identityID,
+		SubjectID:         subjectID,
 		Plugin:            plugin,
 		Connection:        connection,
 		Instance:          recString(rec, "instance"),
@@ -409,31 +371,7 @@ func (s *TokenService) syncExternalCredentialRecord(ctx context.Context, rec ind
 		CreatedAt:         recTime(rec, "created_at"),
 		UpdatedAt:         recTime(rec, "updated_at"),
 	}); err != nil {
-		return fmt.Errorf("sync canonical external credential record %q/%q/%q/%q: %w", identityID, plugin, connection, recString(rec, "instance"), err)
+		return fmt.Errorf("sync canonical external credential record %q/%q/%q/%q: %w", subjectID, plugin, connection, recString(rec, "instance"), err)
 	}
 	return nil
-}
-
-func tokenIdentityPrincipal() string {
-	return "__identity__"
-}
-
-func tokenIdentitySubjectID() string {
-	return "identity:" + tokenIdentityPrincipal()
-}
-
-func tokenManagedIdentityIDFromSubjectID(subjectID string) string {
-	const prefix = "managed_identity:"
-	if !strings.HasPrefix(subjectID, prefix) {
-		return ""
-	}
-	return strings.TrimPrefix(subjectID, prefix)
-}
-
-func tokenUserIDFromSubjectID(subjectID string) string {
-	const prefix = "user:"
-	if !strings.HasPrefix(subjectID, prefix) {
-		return ""
-	}
-	return strings.TrimPrefix(subjectID, prefix)
 }

--- a/gestaltd/internal/invocation/broker_test.go
+++ b/gestaltd/internal/invocation/broker_test.go
@@ -86,8 +86,8 @@ func TestBrokerResolveToken_WorkflowContextDoesNotBypassWorkloadIdentityBinding(
 	broker := NewBroker(providers, svc.Users, svc.Tokens, WithAuthorizer(authz))
 
 	if err := svc.Tokens.StoreToken(context.Background(), &core.IntegrationToken{
-		ID:          "identity-workspace-team-a",
-		SubjectID:   principal.IdentitySubjectID(),
+		ID:          "workload-workspace-team-a",
+		SubjectID:   principal.WorkloadSubjectID("workflow.roadmap"),
 		Integration: "slack",
 		Connection:  "workspace",
 		Instance:    "team-a",
@@ -96,8 +96,8 @@ func TestBrokerResolveToken_WorkflowContextDoesNotBypassWorkloadIdentityBinding(
 		t.Fatalf("StoreToken team-a: %v", err)
 	}
 	if err := svc.Tokens.StoreToken(context.Background(), &core.IntegrationToken{
-		ID:          "identity-workspace-team-b",
-		SubjectID:   principal.IdentitySubjectID(),
+		ID:          "workload-workspace-team-b",
+		SubjectID:   principal.WorkloadSubjectID("workflow.roadmap"),
 		Integration: "slack",
 		Connection:  "workspace",
 		Instance:    "team-b",

--- a/gestaltd/internal/invocation/guarded_test.go
+++ b/gestaltd/internal/invocation/guarded_test.go
@@ -244,7 +244,7 @@ func TestGuardedInvoker_AuditLoggedOnPanic(t *testing.T) {
 	sink := &capturingSink{}
 	guarded := invocation.NewGuarded(funcInvoker{
 		invoke: func(ctx context.Context, _ *principal.Principal, _ string, _ string, _ string, _ map[string]any) (*core.OperationResult, error) {
-			invocation.SetCredentialAudit(ctx, core.ConnectionModeUser, principal.IdentitySubjectID(), "workspace", "team-a")
+			invocation.SetCredentialAudit(ctx, core.ConnectionModeUser, "system:config", "workspace", "team-a")
 			panic("boom")
 		},
 	}, nil, "test", sink, invocation.WithoutRateLimit())
@@ -267,8 +267,8 @@ func TestGuardedInvoker_AuditLoggedOnPanic(t *testing.T) {
 		if entry.CredentialMode != string(core.ConnectionModeUser) {
 			t.Fatalf("expected credential mode identity, got %q", entry.CredentialMode)
 		}
-		if entry.CredentialSubjectID != principal.IdentitySubjectID() {
-			t.Fatalf("expected credential subject %q, got %q", principal.IdentitySubjectID(), entry.CredentialSubjectID)
+		if entry.CredentialSubjectID != "system:config" {
+			t.Fatalf("expected credential subject %q, got %q", "system:config", entry.CredentialSubjectID)
 		}
 		if entry.CredentialConnection != "workspace" {
 			t.Fatalf("expected credential connection workspace, got %q", entry.CredentialConnection)

--- a/gestaltd/internal/mcp/binding_test.go
+++ b/gestaltd/internal/mcp/binding_test.go
@@ -2955,7 +2955,7 @@ func TestNewServer_DirectCallerInvokerReceivesPrincipal(t *testing.T) {
 	req := mcpgo.CallToolRequest{}
 	req.Params.Name = "sample_perform"
 
-	result, err := tool.Handler(ctxWithIdentityPrincipal("identity@example.invalid", principal.IdentityPrincipal), req)
+	result, err := tool.Handler(ctxWithIdentityPrincipal("identity@example.invalid", "identity-user"), req)
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}

--- a/gestaltd/internal/operator/lifecycle_test.go
+++ b/gestaltd/internal/operator/lifecycle_test.go
@@ -871,7 +871,7 @@ server:
 	}
 
 	_, err := NewLifecycle().InitAtPath(cfgPath)
-	if err == nil || !strings.Contains(err.Error(), `duplicate operation "ping" across static and API catalogs`) {
+	if err == nil || !strings.Contains(err.Error(), `duplicate operation "ping" across merged catalogs`) {
 		t.Fatalf("InitAtPath error = %v, want duplicate operation error", err)
 	}
 }

--- a/gestaltd/internal/principal/principal.go
+++ b/gestaltd/internal/principal/principal.go
@@ -18,7 +18,6 @@ const (
 	SourceEnv
 )
 
-const IdentityPrincipal = "__identity__"
 const managedIdentitySubjectPrefix = "managed_identity:"
 
 type Kind string
@@ -101,10 +100,6 @@ func WorkloadSubjectID(workloadID string) string {
 		return ""
 	}
 	return string(KindWorkload) + ":" + workloadID
-}
-
-func IdentitySubjectID() string {
-	return "identity:" + IdentityPrincipal
 }
 
 func IsSystemSubjectID(subjectID string) bool {
@@ -372,8 +367,7 @@ func Canonicalize(p *Principal) *Principal {
 	if p.Kind == "" {
 		switch {
 		case strings.HasPrefix(p.SubjectID, string(KindWorkload)+":"),
-			ManagedIdentityIDFromSubjectID(p.SubjectID) != "",
-			p.SubjectID == IdentitySubjectID():
+			ManagedIdentityIDFromSubjectID(p.SubjectID) != "":
 			p.Kind = KindWorkload
 		}
 	}

--- a/gestaltd/internal/server/server_test.go
+++ b/gestaltd/internal/server/server_test.go
@@ -16146,7 +16146,7 @@ func TestExecuteOperation_ConnectionModeUserDoesNotFallbackToIdentity(t *testing
 		}
 		seedAPIToken(t, svc, apiToken, hashed, "api-user")
 		seedToken(t, svc, &core.IntegrationToken{
-			ID: "tok-identity", SubjectID: principal.IdentitySubjectID(), Integration: "svc",
+			ID: "tok-identity", SubjectID: "identity:__identity__", Integration: "svc",
 			Connection: "", Instance: "default", AccessToken: "identity-tok",
 		})
 


### PR DESCRIPTION
## Summary

This rebuild removes the runtime `identity:__identity__` startup credential path without introducing a replacement singleton.

The actual change is:
- workflow execution refs keep their real system subject as `credential_subject_id`
- canonical `external_credentials` mirror rows are keyed by `subject_id`, not `identity_id`
- startup/system tokens are looked up under their real subject, for example `system:config`

## Old Interfaces

Runtime principal shape:

```go
&principal.Principal{
  SubjectID:           "system:config",
  CredentialSubjectID: "identity:__identity__",
}
```

Canonical credential lookup shape:

```sql
external_credentials(
  identity_id,
  plugin,
  connection,
  instance
)
```

Example lookup:

```text
identity_id=__identity__, plugin=roadmap, connection=workspace, instance=default
```

## New Interfaces

Runtime principal shape:

```go
&principal.Principal{
  SubjectID:           "system:config",
  CredentialSubjectID: "system:config",
}
```

Canonical credential lookup shape:

```sql
external_credentials(
  subject_id,
  plugin,
  connection,
  instance
)
```

Example lookup:

```text
subject_id=system:config, plugin=roadmap, connection=workspace, instance=default
```

## What Changed

- `workflowExecutionPrincipal(...)` no longer rewrites system workflow refs onto `identity:__identity__`
- `TokenService` sync/backfill writes canonical external credentials by token `subject_id` directly
- `ExternalCredential` and `ExternalCredentialService` are subject-owned
- existing startup/bootstrap/invocation tests now store config-owned startup tokens under `system:config`
- the stale no-`execution_ref` startup callback path from the old branch is intentionally not part of this rebuild

## Rollout

This is a cutover-style deploy for `external_credentials`.

Why:
- old code reads and writes `external_credentials.identity_id`
- new code reads and writes `external_credentials.subject_id`
- mixed old/new overlap after the schema flip is not safe

Required precheck before deploy:

```sql
SELECT COUNT(*) AS legacy_startup_tokens
FROM integration_tokens
WHERE subject_id = 'identity:__identity__';
```

If that count is not `0`, do not deploy this branch as-is. Rewrite those rows first:

```sql
UPDATE integration_tokens
SET subject_id = 'system:config'
WHERE subject_id = 'identity:__identity__';
```

Then rerun the precheck and confirm it is `0`.

Detailed steps and parity checks are in:
- `docs/internal/remove-identity-singleton-rollout.md`

## Verification

```bash
cd gestaltd

go test ./internal/coredata ./internal/bootstrap ./internal/invocation ./internal/server ./internal/mcp ./internal/principal

golangci-lint run ./internal/coredata ./internal/bootstrap ./internal/invocation ./internal/server ./internal/mcp ./internal/principal
```
