### PR TITLE
Add public workflow event publishing

### DIFF
--- a/docs/content/client/cli/index.mdx
+++ b/docs/content/client/cli/index.mdx
@@ -28,7 +28,8 @@ asIndexPage: true
 | `gestalt plugins invoke NAME [OPERATION]` | Invoke an operation or list operations when omitted. |
 | `gestalt plugins describe NAME OPERATION` | Show one operation's parameter contract. |
 | `gestalt workflows schedules ...` | Create, list, inspect, update, pause, resume, or delete workflow schedules. |
-| `gestalt workflows triggers ...` | Create, list, inspect, update, pause, resume, or delete workflow event triggers. |
+| `gestalt workflows triggers ...` | Create, list, inspect, update, pause, resume, or delete workflow triggers. |
+| `gestalt workflows events publish ...` | Publish an event into the workflow system. |
 | `gestalt workflows runs ...` | List, inspect, and cancel workflow runs. |
 | `gestalt tokens create\|list\|revoke` | Manage Gestalt API tokens. |
 
@@ -105,13 +106,19 @@ gestalt workflows triggers create \
   --operation chat.postMessage \
   -p channel=C123 \
   -p text='Roadmap item updated'
+gestalt workflows events publish \
+  --type roadmap.item.updated \
+  --source roadmap \
+  --subject item \
+  -p id=item-1 \
+  -e traceId=trace-1
 gestalt workflows runs list --plugin github --status failed
 gestalt tokens create --name automation
 ```
 
 ## Workflow commands
 
-The workflow CLI currently covers global schedules, global event triggers, and
+The workflow CLI currently covers global schedules, global triggers, and
 workflow runs.
 
 ### Schedules
@@ -139,7 +146,7 @@ gestalt workflows schedules delete <schedule-id>
 Use `-p key=value` for strings and `-p key:=json` for structured values. Use
 `--input-file file.json` to load the target input from JSON instead of flags.
 
-### Event triggers
+### Triggers
 
 ```sh
 gestalt workflows triggers list
@@ -162,9 +169,24 @@ gestalt workflows triggers delete <trigger-id>
 
 The create and update commands use the same target input conventions as
 schedules. `--type` is required. `--source` and `--subject` are optional exact
-match fields. There is still no generic public event-publish endpoint, so a
-trigger only fires when some provider or internal component publishes matching
-events into the workflow provider.
+match fields.
+
+### Event publishing
+
+```sh
+gestalt workflows events publish \
+  --type roadmap.item.updated \
+  --source roadmap \
+  --subject item \
+  --data-content-type application/json \
+  -p id=item-1 \
+  -e traceId=trace-1
+```
+
+The publish command sends one event to `POST /api/v1/workflow/events`. Gestalt
+fills in the event ID, spec version, and timestamp when you omit them, then
+fans the event out across the configured workflow providers so matching
+triggers can create runs.
 
 ### Runs
 

--- a/docs/content/client/web.mdx
+++ b/docs/content/client/web.mdx
@@ -21,7 +21,7 @@ It currently focuses on workflow runs:
 it shows recent run history, supports search and status filtering, lets you
 inspect run details, and lets you cancel pending runs.
 
-Schedules and event triggers are still configured through the workflow HTTP
+Schedules and triggers are still configured through the workflow HTTP
 API, CLI, or YAML config rather than the default UI.
 
 ## Plugins

--- a/docs/content/configuration.mdx
+++ b/docs/content/configuration.mdx
@@ -4,7 +4,7 @@ Gestalt is configured from one or more YAML files. This page covers the key conc
 
 ## Config file structure
 
-A Gestalt config has five top-level keys: `server` for host settings and host-provider selection, `authorization` for shared human/workload access policy, `providers` for named host-scoped providers and UIs, `workflows` for config-managed schedules and event triggers, and `plugins` for executable integrations and optional plugin-backed UI mounts.
+A Gestalt config has five top-level keys: `server` for host settings and host-provider selection, `authorization` for shared human/workload access policy, `providers` for named host-scoped providers and UIs, `workflows` for config-managed schedules and triggers, and `plugins` for executable integrations and optional plugin-backed UI mounts.
 
 ```yaml
 authorization:
@@ -60,7 +60,7 @@ providers:
 
 workflows:
   schedules: {}             # config-managed schedules
-  eventTriggers: {}         # config-managed event triggers
+  eventTriggers: {}         # config-managed triggers
 
 server:
   # public URL for OAuth callbacks
@@ -106,7 +106,7 @@ Gestalt has nine core concepts you configure in YAML:
 - **[S3.](/providers/s3)** Plugin-bound object storage. The provider config chooses the backend, credentials, and endpoint; plugin code chooses buckets, keys, and versions at runtime.
 - **[Authentication.](/providers/authentication)** Platform login for the Gestalt server. Separate from connection authentication, which is per-plugin and per-upstream.
 - **[Secrets.](/providers/secrets)** Resolves structured secret refs in the config at startup. Backed by environment variables, files, or cloud secret managers.
-- **[Workflow.](/providers/workflow)** Global workflow runs, schedules, and event triggers backed by a workflow provider and optional host IndexedDB storage.
+- **[Workflow.](/providers/workflow)** Global workflow runs, schedules, and triggers backed by a workflow provider and optional host IndexedDB storage.
 - **[UI.](/providers/ui)** Public static UI bundles served under configured path prefixes, either directly from `providers.ui` or through `plugins.<name>.mountPath`. Omit `providers.ui` to run headless.
 
 ## Adding a plugin

--- a/docs/content/custom-providers/workflow.mdx
+++ b/docs/content/custom-providers/workflow.mdx
@@ -6,7 +6,7 @@ This page covers building custom workflow providers. If you only need to
 configure workflow storage for a deployment, use
 [Providers > Workflow](/providers/workflow).
 
-Workflow providers back global workflow runs, schedules, and event triggers.
+Workflow providers back global workflow runs, schedules, and triggers.
 Gestalt uses them to persist workflow state and to call back into target plugin
 operations through the workflow host socket.
 
@@ -32,7 +32,7 @@ The workflow service includes:
 | --- | --- |
 | `StartRun` / `GetRun` / `ListRuns` / `CancelRun` | Manage workflow runs |
 | `UpsertSchedule` / `GetSchedule` / `ListSchedules` / `DeleteSchedule` / `PauseSchedule` / `ResumeSchedule` | Manage schedules |
-| `UpsertEventTrigger` / `GetEventTrigger` / `ListEventTriggers` / `DeleteEventTrigger` / `PauseEventTrigger` / `ResumeEventTrigger` | Manage event triggers |
+| `UpsertEventTrigger` / `GetEventTrigger` / `ListEventTriggers` / `DeleteEventTrigger` / `PauseEventTrigger` / `ResumeEventTrigger` | Manage triggers |
 | `PublishEvent` | Deliver an event into the provider |
 
 The examples below show the core methods. The remaining methods follow the same

--- a/docs/content/index.mdx
+++ b/docs/content/index.mdx
@@ -47,7 +47,7 @@ Gestalt does not replace your existing APIs. It sits between agents and upstream
     The config model, plugin setup, authentication, connections, and MCP.
   </Cards.Card>
   <Cards.Card title="Workflows" href="/providers/workflow">
-    Schedules, runs, event triggers, and the current workflow API surface.
+    Schedules, runs, triggers, and the current workflow API surface.
   </Cards.Card>
   <Cards.Card title="Providers" href="/providers">
     Plugins, authentication backends, datastores, and custom UIs as provider packages.

--- a/docs/content/providers/workflow.mdx
+++ b/docs/content/providers/workflow.mdx
@@ -3,15 +3,14 @@ import { Callout, Tabs } from 'nextra/components'
 # Workflow
 
 Gestalt workflows let you invoke a plugin operation later instead of right now.
-Today that primarily means cron-based schedules, event triggers, workflow run
+Today that primarily means cron-based schedules, triggers, workflow run
 history, and run cancelation. The workflow model is global. A workflow target
 is always explicit: `plugin`, `operation`, and optional `connection`,
 `instance`, and `input`.
 
 <Callout type="info">
-  The public workflow surface now covers schedules, event triggers, and runs.
-  What still does not exist is a generic public event-publish endpoint such as
-  `/api/v1/workflow/events`.
+  The public workflow surface now covers schedules, triggers, event publishing,
+  and runs.
 </Callout>
 
 ## Mental model
@@ -19,7 +18,7 @@ is always explicit: `plugin`, `operation`, and optional `connection`,
 Start by configuring at least one workflow provider under
 `providers.workflow`, then define a workflow target for the plugin operation
 you want Gestalt to invoke. From there you create either a schedule, which runs
-on a cron expression, or an event trigger, which runs when a published event
+on a cron expression, or a trigger, which runs when a published event
 matches. The workflow provider persists that object, creates workflow runs, and
 calls back into Gestalt when a run should execute. Gestalt then invokes the
 target plugin operation, and you inspect or cancel the resulting runs through
@@ -27,7 +26,7 @@ the global workflow runs surface.
 
 There are two ownership modes. Config-managed workflows live in YAML under
 top-level `workflows:` and execute as the system config actor. User-owned
-schedules and event triggers are created through the global API or CLI and
+schedules and triggers are created through the global API or CLI and
 execute as the subject that created them.
 
 ## How workflow providers work
@@ -35,7 +34,7 @@ execute as the subject that created them.
 Workflow provider selection is global, not plugin-scoped. A config-managed
 workflow object chooses a provider with `provider`, or inherits the
 sole/default `providers.workflow` entry when that field is omitted.
-User-owned schedules and event triggers use the same provider pool through the
+User-owned schedules and triggers use the same provider pool through the
 global HTTP API and CLI. In every case the target is explicit, and a workflow
 provider may bind a host IndexedDB provider through
 `providers.workflow.<name>.indexeddb`.
@@ -63,7 +62,7 @@ First-party workflow providers live under
 
 | Provider | Use case |
 | --- | --- |
-| [`github.com/valon-technologies/gestalt-providers/workflow/indexeddb`](https://github.com/valon-technologies/gestalt-providers/tree/main/workflow/indexeddb) | Stores workflow runs, schedules, and event triggers in IndexedDB and invokes target plugin operations through the workflow host |
+| [`github.com/valon-technologies/gestalt-providers/workflow/indexeddb`](https://github.com/valon-technologies/gestalt-providers/tree/main/workflow/indexeddb) | Stores workflow runs, schedules, and triggers in IndexedDB and invokes target plugin operations through the workflow host |
 
 ## Configuring `providers.workflow`
 
@@ -90,7 +89,7 @@ providers:
 ```
 
 If you configure exactly one workflow provider, or mark one as `default: true`,
-then schedules and event triggers may omit `provider`.
+then schedules and triggers may omit `provider`.
 
 ## Defining config-managed workflows
 
@@ -117,7 +116,7 @@ workflows:
 This creates a durable schedule named `nightly_sync` that invokes
 `roadmap.sync` every day at 3:00 AM New York time.
 
-### Event triggers
+### Triggers
 
 ```yaml
 workflows:
@@ -137,7 +136,7 @@ workflows:
         text: "A roadmap item changed."
 ```
 
-This creates a durable event trigger that listens for published events with:
+This creates a durable trigger that listens for published events with:
 `type = "roadmap.item.updated"`, plus optional exact matches for
 `source = "roadmap"` and `subject = "item"`. When an event matches, Gestalt
 invokes `slack.chat.postMessage` with the static input above and records a
@@ -145,7 +144,7 @@ workflow run.
 
 ### Match semantics
 
-Event trigger matching is exact string matching. `match.type` is required.
+Trigger matching is exact string matching. `match.type` is required.
 `match.source` and `match.subject` are optional. If `source` or `subject` is
 omitted, that field is ignored during matching.
 
@@ -239,9 +238,9 @@ The `provider` field is available on the HTTP API. Omit it when you have a
 sole/default workflow provider; include it when you need to select a specific
 workflow backend.
 
-## Creating user-owned event triggers
+## Creating user-owned triggers
 
-User-owned event triggers are global resources exposed through
+User-owned triggers are global resources exposed through
 `POST /api/v1/workflow/event-triggers` and
 `gestalt workflows triggers ...`. These triggers execute as the creating
 subject, not as a plugin-local or synthetic workflow workload.
@@ -329,9 +328,55 @@ The `provider` field is available on the HTTP API here too. Omit it when you
 have a sole/default workflow provider; include it when you need to select a
 specific workflow backend.
 
+## Publishing workflow events
+
+Triggers become useful once something can publish matching events into
+the workflow system. Gestalt now exposes a public event-ingress route at
+`POST /api/v1/workflow/events` and the matching CLI command
+`gestalt workflows events publish`.
+
+When you publish an event, Gestalt normalizes the event ID, spec version, and
+timestamp if you omit them, then fans that event out across the configured
+workflow providers. Triggers match on the event payload itself. In practice,
+that means `type` is required, while `source` and `subject` remain optional
+exact-match fields.
+
+<Tabs items={['CLI', 'HTTP']}>
+  <Tabs.Tab>
+    ```sh
+    gestalt workflows events publish \
+      --type roadmap.item.updated \
+      --source roadmap \
+      --subject item \
+      --data-content-type application/json \
+      -p id=item-1 \
+      -e traceId=trace-1
+    ```
+  </Tabs.Tab>
+  <Tabs.Tab>
+    ```sh
+    curl -X POST "$GESTALT_URL/api/v1/workflow/events" \
+      -H "Authorization: Bearer $GESTALT_API_KEY" \
+      -H "Content-Type: application/json" \
+      -d '{
+        "type": "roadmap.item.updated",
+        "source": "roadmap",
+        "subject": "item",
+        "dataContentType": "application/json",
+        "data": {
+          "id": "item-1"
+        },
+        "extensions": {
+          "traceId": "trace-1"
+        }
+      }'
+    ```
+  </Tabs.Tab>
+</Tabs>
+
 ## Inspecting and canceling workflow runs
 
-Runs are the execution records produced by schedules, event triggers, or other
+Runs are the execution records produced by schedules, triggers, or other
 workflow-provider actions. The global run surface is
 `GET /api/v1/workflow/runs`, `GET /api/v1/workflow/runs/{runID}`,
 `POST /api/v1/workflow/runs/{runID}/cancel`, and
@@ -374,17 +419,9 @@ Run responses include `id`, `provider`, `status`, `target`, `trigger`,
 `createdBy`, `createdAt`, `startedAt`, `completedAt`, `statusMessage`, and
 `resultBody`. The `trigger.kind` value is `schedule`, `event`, or `manual`.
 
-## Event publishing today
-
-Event triggers are now manageable through the global API and CLI, but Gestalt
-still does not expose a generic public event-publish endpoint. In practice,
-that means event triggers are most useful when deployment-managed automation,
-custom workflow providers, or internal components already publish events into
-the workflow provider.
-
 If you are implementing a provider or another event producer, see
 [Custom Providers > Workflow](/custom-providers/workflow) for the
-`PublishEvent` interface.
+`PublishEvent` interface and the provider-side contract.
 
 ## How execution works
 
@@ -393,8 +430,8 @@ Gestalt through the workflow host. Gestalt invokes the target plugin operation,
 then the run is updated to `succeeded`, `failed`, or `canceled`.
 
 The execution identity depends on how the workflow was created. Config-managed
-schedules and event triggers execute as `system:config`, while user-owned
-schedules and event triggers execute as the creating subject.
+schedules and triggers execute as `system:config`, while user-owned schedules
+and triggers execute as the creating subject.
 
 ## Building your own workflow provider
 

--- a/docs/content/reference/built-in-providers.mdx
+++ b/docs/content/reference/built-in-providers.mdx
@@ -89,7 +89,7 @@ providers:
 
 ## Workflow Providers
 
-Workflow providers back global runs, schedules, and event triggers. They are
+Workflow providers back global runs, schedules, and triggers. They are
 configured under `providers.workflow.<name>`, then referenced by top-level
 `workflows.*` config or the global workflow API/CLI.
 
@@ -121,7 +121,7 @@ workflows:
 
 | Name | Purpose |
 | --- | --- |
-| `indexeddb` | Stores workflow runs, schedules, and event triggers in IndexedDB and invokes plugin operations through the workflow host. |
+| `indexeddb` | Stores workflow runs, schedules, and triggers in IndexedDB and invokes plugin operations through the workflow host. |
 
 ## S3 Providers
 

--- a/docs/content/reference/config-file.mdx
+++ b/docs/content/reference/config-file.mdx
@@ -8,7 +8,7 @@ and bootstrap. The top-level keys are `server` (listener, encryption, egress,
 and host-provider selection), `authorization` (shared human/workload access
 policy), `providers` (named authentication, secrets, telemetry, audit, UI,
 indexeddb, authorization, workflow, cache, and s3 entries), `workflows`
-(config-managed schedules and event triggers), and `plugins` (executable
+(config-managed schedules and triggers), and `plugins` (executable
 integrations and optional plugin-backed UI mounts):
 
 ```yaml
@@ -325,13 +325,13 @@ The exact config fields depend on the selected authorization provider package. T
 
 ## `providers.workflow`
 
-Workflow providers back global runs, schedules, and event triggers. Configure
+Workflow providers back global runs, schedules, and triggers. Configure
 one or more named entries under `providers.workflow`, then reference them from
 top-level `workflows.schedules.*.provider` or
 `workflows.eventTriggers.*.provider`. There is no
 `server.providers.workflow`: config-managed workflow objects choose a provider
 explicitly, or inherit the sole/default workflow provider when `provider` is
-omitted. User-owned schedules and event triggers use the same provider pool
+omitted. User-owned schedules and triggers use the same provider pool
 through `/api/v1/workflow/schedules`,
 `/api/v1/workflow/event-triggers`, and `gestalt workflows ...`.
 
@@ -390,7 +390,7 @@ allowlist logical stores exposed through that binding.
 
 ## `workflows`
 
-Top-level `workflows` declares config-managed schedules and event triggers.
+Top-level `workflows` declares config-managed schedules and triggers.
 These objects are reconciled into the selected workflow provider at startup and
 invoke explicit workflow targets: `plugin`, `operation`, and optional
 `connection`, `instance`, and `input`.

--- a/docs/content/reference/http-api.mdx
+++ b/docs/content/reference/http-api.mdx
@@ -51,19 +51,17 @@ Authenticated routes accept a `session_token` cookie or an `Authorization: Beare
 | `DELETE` | `/api/v1/workflow/schedules/{scheduleID}` | Delete one workflow schedule. |
 | `POST` | `/api/v1/workflow/schedules/{scheduleID}/pause` | Pause one workflow schedule. |
 | `POST` | `/api/v1/workflow/schedules/{scheduleID}/resume` | Resume one workflow schedule. |
-| `GET` | `/api/v1/workflow/event-triggers` | List user-owned workflow event triggers. |
-| `POST` | `/api/v1/workflow/event-triggers` | Create a user-owned workflow event trigger. |
-| `GET` | `/api/v1/workflow/event-triggers/{triggerID}` | Inspect one workflow event trigger. |
-| `PUT` | `/api/v1/workflow/event-triggers/{triggerID}` | Update one workflow event trigger. |
-| `DELETE` | `/api/v1/workflow/event-triggers/{triggerID}` | Delete one workflow event trigger. |
-| `POST` | `/api/v1/workflow/event-triggers/{triggerID}/pause` | Pause one workflow event trigger. |
-| `POST` | `/api/v1/workflow/event-triggers/{triggerID}/resume` | Resume one workflow event trigger. |
+| `GET` | `/api/v1/workflow/event-triggers` | List user-owned workflow triggers. |
+| `POST` | `/api/v1/workflow/event-triggers` | Create a user-owned workflow trigger. |
+| `GET` | `/api/v1/workflow/event-triggers/{triggerID}` | Inspect one workflow trigger. |
+| `PUT` | `/api/v1/workflow/event-triggers/{triggerID}` | Update one workflow trigger. |
+| `DELETE` | `/api/v1/workflow/event-triggers/{triggerID}` | Delete one workflow trigger. |
+| `POST` | `/api/v1/workflow/event-triggers/{triggerID}/pause` | Pause one workflow trigger. |
+| `POST` | `/api/v1/workflow/event-triggers/{triggerID}/resume` | Resume one workflow trigger. |
+| `POST` | `/api/v1/workflow/events` | Publish one workflow event. Gestalt normalizes the event and fans it out across the configured workflow providers. |
 | `GET` | `/api/v1/workflow/runs` | List workflow runs. Supports optional `plugin` and `status` query filters. |
 | `GET` | `/api/v1/workflow/runs/{runID}` | Inspect one workflow run. |
 | `POST` | `/api/v1/workflow/runs/{runID}/cancel` | Cancel one workflow run. The request body may include an optional `reason`. |
-
-Gestalt still does not expose a generic public event-publish endpoint such as
-`/api/v1/workflow/events`.
 
 ### API Tokens
 
@@ -170,7 +168,7 @@ curl -X POST http://localhost:8080/api/v1/workflow/schedules \
     }
   }'
 
-# Create a workflow event trigger
+# Create a workflow trigger
 curl -X POST http://localhost:8080/api/v1/workflow/event-triggers \
   -H 'Authorization: Bearer gst_api_...' \
   -H 'Content-Type: application/json' \
@@ -187,6 +185,23 @@ curl -X POST http://localhost:8080/api/v1/workflow/event-triggers \
         "channel": "C123",
         "text": "Roadmap item updated"
       }
+    }
+  }'
+
+# Publish a workflow event
+curl -X POST http://localhost:8080/api/v1/workflow/events \
+  -H 'Authorization: Bearer gst_api_...' \
+  -H 'Content-Type: application/json' \
+  -d '{
+    "type": "roadmap.item.updated",
+    "source": "roadmap",
+    "subject": "item",
+    "dataContentType": "application/json",
+    "data": {
+      "id": "item-1"
+    },
+    "extensions": {
+      "traceId": "trace-1"
     }
   }'
 

--- a/gestalt/cli/src/cli.rs
+++ b/gestalt/cli/src/cli.rs
@@ -374,10 +374,15 @@ pub enum WorkflowCommands {
         #[command(subcommand)]
         command: WorkflowScheduleCommands,
     },
-    /// Manage workflow event triggers
+    /// Manage workflow triggers
     Triggers {
         #[command(subcommand)]
         command: WorkflowTriggerCommands,
+    },
+    /// Publish workflow events
+    Events {
+        #[command(subcommand)]
+        command: WorkflowEventCommands,
     },
     /// Inspect workflow runs
     Runs {
@@ -422,35 +427,35 @@ pub enum WorkflowScheduleCommands {
 
 #[derive(Subcommand)]
 pub enum WorkflowTriggerCommands {
-    /// List workflow event triggers
+    /// List workflow triggers
     List {
-        /// Filter event triggers by target plugin
+        /// Filter triggers by target plugin
         #[arg(long)]
         plugin: Option<String>,
-        /// Filter event triggers by event type
+        /// Filter triggers by event type
         #[arg(long = "type")]
         event_type: Option<String>,
     },
-    /// Show a single workflow event trigger
+    /// Show a single workflow trigger
     Get {
         /// Trigger ID
         id: String,
     },
-    /// Create a workflow event trigger
+    /// Create a workflow trigger
     Create(WorkflowTriggerCreateArgs),
-    /// Update an existing workflow event trigger
+    /// Update an existing workflow trigger
     Update(WorkflowTriggerUpdateArgs),
-    /// Delete a workflow event trigger
+    /// Delete a workflow trigger
     Delete {
         /// Trigger ID
         id: String,
     },
-    /// Pause a workflow event trigger
+    /// Pause a workflow trigger
     Pause {
         /// Trigger ID
         id: String,
     },
-    /// Resume a paused workflow event trigger
+    /// Resume a paused workflow trigger
     Resume {
         /// Trigger ID
         id: String,
@@ -481,6 +486,12 @@ pub enum WorkflowRunCommands {
         #[arg(long)]
         reason: Option<String>,
     },
+}
+
+#[derive(Subcommand)]
+pub enum WorkflowEventCommands {
+    /// Publish a workflow event
+    Publish(WorkflowEventPublishArgs),
 }
 
 #[derive(Args)]
@@ -648,11 +659,11 @@ pub struct WorkflowTriggerUpdateArgs {
     #[arg(long)]
     pub instance: Option<String>,
 
-    /// Mark the event trigger as paused
+    /// Mark the trigger as paused
     #[arg(long, conflicts_with = "unpaused", action = clap::ArgAction::SetTrue)]
     pub paused: bool,
 
-    /// Mark the event trigger as not paused
+    /// Mark the trigger as not paused
     #[arg(long = "no-paused", action = clap::ArgAction::SetTrue)]
     pub unpaused: bool,
 
@@ -667,6 +678,49 @@ pub struct WorkflowTriggerUpdateArgs {
     /// Clear the target input instead of keeping the existing value
     #[arg(long = "clear-input", conflicts_with_all = ["params", "input_file"])]
     pub clear_input: bool,
+}
+
+#[derive(Args)]
+pub struct WorkflowEventPublishArgs {
+    /// Event type
+    #[arg(long = "type")]
+    pub event_type: String,
+
+    /// Event source
+    #[arg(long)]
+    pub source: Option<String>,
+
+    /// Event subject
+    #[arg(long)]
+    pub subject: Option<String>,
+
+    /// Explicit event ID
+    #[arg(long)]
+    pub id: Option<String>,
+
+    /// CloudEvents spec version
+    #[arg(long = "spec-version")]
+    pub spec_version: Option<String>,
+
+    /// Event timestamp in RFC 3339 format
+    #[arg(long)]
+    pub time: Option<String>,
+
+    /// Event data content type
+    #[arg(long = "data-content-type")]
+    pub data_content_type: Option<String>,
+
+    /// Event data fields as key=value or key:=json
+    #[arg(short = 'p', long = "data", value_parser = params::parse_param_entry)]
+    pub data: Vec<params::ParamEntry>,
+
+    /// Load event data from a JSON file (use "-" for stdin)
+    #[arg(long = "data-file")]
+    pub data_file: Option<String>,
+
+    /// Event extension fields as key=value or key:=json
+    #[arg(short = 'e', long = "extension", value_parser = params::parse_param_entry)]
+    pub extensions: Vec<params::ParamEntry>,
 }
 
 #[derive(clap::ValueEnum, Clone, Copy, Debug, PartialEq, Eq)]

--- a/gestalt/cli/src/commands/workflows.rs
+++ b/gestalt/cli/src/commands/workflows.rs
@@ -3,12 +3,13 @@ use serde_json::{Map, Value, json};
 
 use crate::api::ApiClient;
 use crate::cli::{
-    WorkflowScheduleCreateArgs, WorkflowScheduleUpdateArgs, WorkflowTriggerCreateArgs,
-    WorkflowTriggerUpdateArgs,
+    WorkflowEventPublishArgs, WorkflowScheduleCreateArgs, WorkflowScheduleUpdateArgs,
+    WorkflowTriggerCreateArgs, WorkflowTriggerUpdateArgs,
 };
 use crate::output::{self, Format};
 use crate::params::{self, ParamEntry};
 
+const EVENTS_PATH: &str = "/api/v1/workflow/events";
 const SCHEDULES_PATH: &str = "/api/v1/workflow/schedules";
 const TRIGGERS_PATH: &str = "/api/v1/workflow/event-triggers";
 const RUNS_PATH: &str = "/api/v1/workflow/runs";
@@ -31,7 +32,7 @@ pub fn get(client: &ApiClient, id: &str, format: Format) -> Result<()> {
 }
 
 pub fn create(client: &ApiClient, args: &WorkflowScheduleCreateArgs, format: Format) -> Result<()> {
-    let input = build_target_input(&args.params, args.input_file.as_deref())?;
+    let input = build_optional_map(&args.params, args.input_file.as_deref())?;
     let body = build_upsert_body(
         &args.cron,
         args.timezone.as_deref(),
@@ -98,7 +99,7 @@ pub fn list_triggers(
 ) -> Result<()> {
     let resp = client
         .get(TRIGGERS_PATH)
-        .context("failed to list workflow event triggers")?;
+        .context("failed to list workflow triggers")?;
     let filtered = filter_triggers(resp, plugin, event_type);
     print_triggers(&filtered, format);
     Ok(())
@@ -107,7 +108,7 @@ pub fn list_triggers(
 pub fn get_trigger(client: &ApiClient, id: &str, format: Format) -> Result<()> {
     let resp = client
         .get(&format!("{TRIGGERS_PATH}/{id}"))
-        .with_context(|| format!("failed to get workflow event trigger {id}"))?;
+        .with_context(|| format!("failed to get workflow trigger {id}"))?;
     print_trigger(&resp, format);
     Ok(())
 }
@@ -117,7 +118,7 @@ pub fn create_trigger(
     args: &WorkflowTriggerCreateArgs,
     format: Format,
 ) -> Result<()> {
-    let input = build_target_input(&args.params, args.input_file.as_deref())?;
+    let input = build_optional_map(&args.params, args.input_file.as_deref())?;
     let body = build_trigger_upsert_body(
         None,
         &args.event_type,
@@ -133,7 +134,7 @@ pub fn create_trigger(
 
     let resp = client
         .post(TRIGGERS_PATH, &body)
-        .context("failed to create workflow event trigger")?;
+        .context("failed to create workflow trigger")?;
     print_trigger(&resp, format);
     Ok(())
 }
@@ -145,12 +146,12 @@ pub fn update_trigger(
 ) -> Result<()> {
     let existing = client
         .get(&format!("{TRIGGERS_PATH}/{id}", id = args.id))
-        .with_context(|| format!("failed to load workflow event trigger {}", args.id))?;
+        .with_context(|| format!("failed to load workflow trigger {}", args.id))?;
 
     let body = merge_trigger_update(args, &existing)?;
     let resp = client
         .put(&format!("{TRIGGERS_PATH}/{id}", id = args.id), &body)
-        .with_context(|| format!("failed to update workflow event trigger {}", args.id))?;
+        .with_context(|| format!("failed to update workflow trigger {}", args.id))?;
     print_trigger(&resp, format);
     Ok(())
 }
@@ -158,10 +159,10 @@ pub fn update_trigger(
 pub fn delete_trigger(client: &ApiClient, id: &str, format: Format) -> Result<()> {
     let resp = client
         .delete(&format!("{TRIGGERS_PATH}/{id}"))
-        .with_context(|| format!("failed to delete workflow event trigger {id}"))?;
+        .with_context(|| format!("failed to delete workflow trigger {id}"))?;
     match format {
         Format::Json => output::print_json(&resp),
-        Format::Table => output::print_success(&format!("Workflow event trigger {id} deleted.")),
+        Format::Table => output::print_success(&format!("Workflow trigger {id} deleted.")),
     }
     Ok(())
 }
@@ -169,7 +170,7 @@ pub fn delete_trigger(client: &ApiClient, id: &str, format: Format) -> Result<()
 pub fn pause_trigger(client: &ApiClient, id: &str, format: Format) -> Result<()> {
     let resp = client
         .post(&format!("{TRIGGERS_PATH}/{id}/pause"), &json!({}))
-        .with_context(|| format!("failed to pause workflow event trigger {id}"))?;
+        .with_context(|| format!("failed to pause workflow trigger {id}"))?;
     print_trigger(&resp, format);
     Ok(())
 }
@@ -177,7 +178,7 @@ pub fn pause_trigger(client: &ApiClient, id: &str, format: Format) -> Result<()>
 pub fn resume_trigger(client: &ApiClient, id: &str, format: Format) -> Result<()> {
     let resp = client
         .post(&format!("{TRIGGERS_PATH}/{id}/resume"), &json!({}))
-        .with_context(|| format!("failed to resume workflow event trigger {id}"))?;
+        .with_context(|| format!("failed to resume workflow trigger {id}"))?;
     print_trigger(&resp, format);
     Ok(())
 }
@@ -218,6 +219,25 @@ pub fn cancel_run(
         .post(&format!("{RUNS_PATH}/{id}/cancel"), &body)
         .with_context(|| format!("failed to cancel workflow run {id}"))?;
     print_run(&resp, format);
+    Ok(())
+}
+
+pub fn publish_event(
+    client: &ApiClient,
+    args: &WorkflowEventPublishArgs,
+    format: Format,
+) -> Result<()> {
+    let data = build_optional_map(&args.data, args.data_file.as_deref())?;
+    let extensions = if args.extensions.is_empty() {
+        None
+    } else {
+        Some(params::assemble_params(&args.extensions, None, "")?)
+    };
+    let body = build_event_publish_body(args, data.as_ref(), extensions.as_ref());
+    let resp = client
+        .post(EVENTS_PATH, &body)
+        .context("failed to publish workflow event")?;
+    print_published_event(&resp, format);
     Ok(())
 }
 
@@ -274,7 +294,7 @@ fn filter_triggers(value: Value, plugin: Option<&str>, event_type: Option<&str>)
     )
 }
 
-fn build_target_input(
+fn build_optional_map(
     params: &[ParamEntry],
     input_file: Option<&str>,
 ) -> Result<Option<Map<String, Value>>> {
@@ -296,6 +316,43 @@ fn build_target_input(
     } else {
         Ok(Some(merged))
     }
+}
+
+fn build_event_publish_body(
+    args: &WorkflowEventPublishArgs,
+    data: Option<&Map<String, Value>>,
+    extensions: Option<&Map<String, Value>>,
+) -> Value {
+    let mut body = Map::new();
+    body.insert("type".to_string(), Value::String(args.event_type.clone()));
+    if let Some(value) = args.source.as_deref() {
+        body.insert("source".to_string(), Value::String(value.to_string()));
+    }
+    if let Some(value) = args.subject.as_deref() {
+        body.insert("subject".to_string(), Value::String(value.to_string()));
+    }
+    if let Some(value) = args.id.as_deref() {
+        body.insert("id".to_string(), Value::String(value.to_string()));
+    }
+    if let Some(value) = args.spec_version.as_deref() {
+        body.insert("specVersion".to_string(), Value::String(value.to_string()));
+    }
+    if let Some(value) = args.time.as_deref() {
+        body.insert("time".to_string(), Value::String(value.to_string()));
+    }
+    if let Some(value) = args.data_content_type.as_deref() {
+        body.insert(
+            "dataContentType".to_string(),
+            Value::String(value.to_string()),
+        );
+    }
+    if let Some(data) = data {
+        body.insert("data".to_string(), Value::Object(data.clone()));
+    }
+    if let Some(extensions) = extensions {
+        body.insert("extensions".to_string(), Value::Object(extensions.clone()));
+    }
+    Value::Object(body)
 }
 
 #[allow(clippy::too_many_arguments)]
@@ -393,7 +450,7 @@ fn merge_update(args: &WorkflowScheduleUpdateArgs, existing: &Value) -> Result<V
     let input = if args.clear_input {
         None
     } else if !args.params.is_empty() || args.input_file.is_some() {
-        build_target_input(&args.params, args.input_file.as_deref())?
+        build_optional_map(&args.params, args.input_file.as_deref())?
     } else {
         existing["target"]["input"].as_object().cloned()
     };
@@ -423,7 +480,7 @@ fn merge_trigger_update(args: &WorkflowTriggerUpdateArgs, existing: &Value) -> R
         Some(value) => value.to_string(),
         None => existing["match"]["type"]
             .as_str()
-            .ok_or_else(|| anyhow!("existing event trigger is missing match.type; pass --type"))?
+            .ok_or_else(|| anyhow!("existing trigger is missing match.type; pass --type"))?
             .to_string(),
     };
     let source =
@@ -436,9 +493,7 @@ fn merge_trigger_update(args: &WorkflowTriggerUpdateArgs, existing: &Value) -> R
         Some(value) => value.to_string(),
         None => existing["target"]["plugin"]
             .as_str()
-            .ok_or_else(|| {
-                anyhow!("existing event trigger is missing target.plugin; pass --plugin")
-            })?
+            .ok_or_else(|| anyhow!("existing trigger is missing target.plugin; pass --plugin"))?
             .to_string(),
     };
     let operation = match args.operation.as_deref() {
@@ -446,7 +501,7 @@ fn merge_trigger_update(args: &WorkflowTriggerUpdateArgs, existing: &Value) -> R
         None => existing["target"]["operation"]
             .as_str()
             .ok_or_else(|| {
-                anyhow!("existing event trigger is missing target.operation; pass --operation")
+                anyhow!("existing trigger is missing target.operation; pass --operation")
             })?
             .to_string(),
     };
@@ -462,7 +517,7 @@ fn merge_trigger_update(args: &WorkflowTriggerUpdateArgs, existing: &Value) -> R
     let input = if args.clear_input {
         None
     } else if !args.params.is_empty() || args.input_file.is_some() {
-        build_target_input(&args.params, args.input_file.as_deref())?
+        build_optional_map(&args.params, args.input_file.as_deref())?
     } else {
         existing["target"]["input"].as_object().cloned()
     };
@@ -600,6 +655,17 @@ fn print_runs(value: &Value, format: Format) {
     }
 }
 
+fn print_published_event(value: &Value, format: Format) {
+    match format {
+        Format::Json => output::print_json(value),
+        Format::Table => {
+            let event = value.get("event").unwrap_or(value);
+            let rows = vec![published_event_row(event)];
+            output::print_table(&published_event_headers(), &rows);
+        }
+    }
+}
+
 fn trigger_headers() -> [&'static str; 8] {
     [
         "ID",
@@ -676,6 +742,20 @@ fn run_headers() -> [&'static str; 7] {
         "Trigger",
         "Started",
         "Created",
+    ]
+}
+
+fn published_event_headers() -> [&'static str; 5] {
+    ["ID", "Type", "Source", "Subject", "Time"]
+}
+
+fn published_event_row(value: &Value) -> Vec<String> {
+    vec![
+        value["id"].as_str().unwrap_or("-").to_string(),
+        value["type"].as_str().unwrap_or("-").to_string(),
+        value["source"].as_str().unwrap_or("-").to_string(),
+        value["subject"].as_str().unwrap_or("-").to_string(),
+        value["time"].as_str().unwrap_or("-").to_string(),
     ]
 }
 

--- a/gestalt/cli/src/main.rs
+++ b/gestalt/cli/src/main.rs
@@ -3,8 +3,8 @@ use gestalt::api::{self, ApiClient};
 use gestalt::cli::{
     AuthCommands, Cli, Commands, ConfigCommands, DescribeArgs, IdentityCommands,
     IdentityGrantCommands, IdentityMemberCommands, IdentityTokenCommands, InvokeArgs,
-    PluginCommands, TokenCommands, WorkflowCommands, WorkflowRunCommands, WorkflowScheduleCommands,
-    WorkflowTriggerCommands,
+    PluginCommands, TokenCommands, WorkflowCommands, WorkflowEventCommands, WorkflowRunCommands,
+    WorkflowScheduleCommands, WorkflowTriggerCommands,
 };
 use gestalt::commands;
 use gestalt::output;
@@ -193,6 +193,11 @@ fn run() -> anyhow::Result<()> {
                     }
                     WorkflowRunCommands::Cancel { id, reason } => {
                         commands::workflows::cancel_run(&client, &id, reason.as_deref(), format)
+                    }
+                },
+                WorkflowCommands::Events { command } => match command {
+                    WorkflowEventCommands::Publish(args) => {
+                        commands::workflows::publish_event(&client, &args, format)
                     }
                 },
             }

--- a/gestalt/cli/tests/workflows_cli.rs
+++ b/gestalt/cli/tests/workflows_cli.rs
@@ -49,6 +49,20 @@ const RUN_JSON: &str = r#"{
     "resultBody":"{\"ok\":true}"
 }"#;
 
+const PUBLISHED_EVENT_JSON: &str = r#"{
+    "status":"published",
+    "event":{
+        "id":"evt-1",
+        "type":"roadmap.item.updated",
+        "source":"roadmap",
+        "subject":"item",
+        "specVersion":"1.0",
+        "time":"2026-04-21T00:00:00Z",
+        "data":{"id":"item-1"},
+        "extensions":{"traceId":"trace-1"}
+    }
+}"#;
+
 #[test]
 fn test_cli_lists_schedules() {
     let mut server = Server::new();
@@ -478,9 +492,7 @@ fn test_cli_deletes_event_trigger() {
         .args(["workflows", "triggers", "delete", "trg-1"])
         .assert()
         .success()
-        .stderr(predicate::str::contains(
-            "Workflow event trigger trg-1 deleted.",
-        ));
+        .stderr(predicate::str::contains("Workflow trigger trg-1 deleted."));
 }
 
 #[test]
@@ -627,4 +639,53 @@ fn test_cli_cancels_run() {
         .success()
         .stdout(predicate::str::contains("run-1"))
         .stdout(predicate::str::contains("canceled"));
+}
+
+#[test]
+fn test_cli_publishes_event() {
+    let mut server = Server::new();
+    let _mock = authed_json_mock!(
+        server,
+        Method::POST,
+        "/api/v1/workflow/events",
+        StatusCode::ACCEPTED
+    )
+    .match_header(header::CONTENT_TYPE.as_str(), http::APPLICATION_JSON)
+    .match_body(Matcher::JsonString(
+        r#"{
+            "type":"roadmap.item.updated",
+            "source":"roadmap",
+            "subject":"item",
+            "dataContentType":"application/json",
+            "data":{"id":"item-1"},
+            "extensions":{"traceId":"trace-1"}
+        }"#
+        .to_string(),
+    ))
+    .with_body(PUBLISHED_EVENT_JSON)
+    .create();
+
+    let home = tempfile::tempdir().unwrap();
+    cli_command_for_server(home.path(), &server)
+        .args([
+            "workflows",
+            "events",
+            "publish",
+            "--type",
+            "roadmap.item.updated",
+            "--source",
+            "roadmap",
+            "--subject",
+            "item",
+            "--data-content-type",
+            "application/json",
+            "-p",
+            "id=item-1",
+            "-e",
+            "traceId=trace-1",
+        ])
+        .assert()
+        .success()
+        .stdout(predicate::str::contains("evt-1"))
+        .stdout(predicate::str::contains("roadmap.item.updated"));
 }

--- a/gestaltd/internal/bootstrap/executable_plugin_test.go
+++ b/gestaltd/internal/bootstrap/executable_plugin_test.go
@@ -394,6 +394,10 @@ func (m *stubWorkflowManager) CancelRun(context.Context, *principal.Principal, s
 	return nil, core.ErrNotFound
 }
 
+func (m *stubWorkflowManager) PublishEvent(context.Context, *principal.Principal, coreworkflow.Event) (coreworkflow.Event, error) {
+	return coreworkflow.Event{}, fmt.Errorf("event publishing is not implemented in this test stub")
+}
+
 func (m *stubWorkflowManager) Subjects() []string {
 	m.mu.Lock()
 	defer m.mu.Unlock()

--- a/gestaltd/internal/bootstrap/lazy_workflow_manager.go
+++ b/gestaltd/internal/bootstrap/lazy_workflow_manager.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 	"sync"
 
+	coreworkflow "github.com/valon-technologies/gestalt/server/core/workflow"
 	"github.com/valon-technologies/gestalt/server/internal/principal"
 	"github.com/valon-technologies/gestalt/server/internal/workflowmanager"
 )
@@ -158,6 +159,14 @@ func (l *lazyWorkflowManager) CancelRun(ctx context.Context, p *principal.Princi
 		return nil, err
 	}
 	return target.CancelRun(ctx, p, runID, reason)
+}
+
+func (l *lazyWorkflowManager) PublishEvent(ctx context.Context, p *principal.Principal, event coreworkflow.Event) (coreworkflow.Event, error) {
+	target, err := l.current()
+	if err != nil {
+		return coreworkflow.Event{}, err
+	}
+	return target.PublishEvent(ctx, p, event)
 }
 
 func (l *lazyWorkflowManager) current() (workflowmanager.Service, error) {

--- a/gestaltd/internal/bootstrap/provider_build.go
+++ b/gestaltd/internal/bootstrap/provider_build.go
@@ -21,6 +21,7 @@ import (
 	"github.com/valon-technologies/gestalt/server/core/catalog"
 	"github.com/valon-technologies/gestalt/server/core/indexeddb"
 	s3store "github.com/valon-technologies/gestalt/server/core/s3"
+	coreworkflow "github.com/valon-technologies/gestalt/server/core/workflow"
 	"github.com/valon-technologies/gestalt/server/internal/composite"
 	"github.com/valon-technologies/gestalt/server/internal/config"
 	"github.com/valon-technologies/gestalt/server/internal/graphql"
@@ -1217,6 +1218,10 @@ func (unavailableWorkflowManager) GetRun(context.Context, *principal.Principal, 
 
 func (unavailableWorkflowManager) CancelRun(context.Context, *principal.Principal, string, string) (*workflowmanager.ManagedRun, error) {
 	return nil, fmt.Errorf("workflow manager is not available")
+}
+
+func (unavailableWorkflowManager) PublishEvent(context.Context, *principal.Principal, coreworkflow.Event) (coreworkflow.Event, error) {
+	return coreworkflow.Event{}, fmt.Errorf("workflow manager is not available")
 }
 
 func buildPluginScopedIndexedDB(pluginName string, effective config.EffectivePluginIndexedDB, deps Deps) (indexeddb.IndexedDB, error) {

--- a/gestaltd/internal/bootstrap/workflow_control.go
+++ b/gestaltd/internal/bootstrap/workflow_control.go
@@ -7,6 +7,7 @@ import coreworkflow "github.com/valon-technologies/gestalt/server/core/workflow"
 type WorkflowControl interface {
 	ResolveProvider(name string) (coreworkflow.Provider, error)
 	ResolveProviderSelection(name string) (providerName string, provider coreworkflow.Provider, err error)
+	ProviderNames() []string
 }
 
 var _ WorkflowControl = (*workflowRuntime)(nil)

--- a/gestaltd/internal/bootstrap/workflow_runtime.go
+++ b/gestaltd/internal/bootstrap/workflow_runtime.go
@@ -5,6 +5,7 @@ import (
 	"errors"
 	"fmt"
 	"maps"
+	"sort"
 	"strings"
 	"sync"
 	"time"
@@ -158,6 +159,23 @@ func (r *workflowRuntime) ResolveProviderSelection(name string) (string, corewor
 		return "", nil, fmt.Errorf("workflow provider %q is not available", selectedName)
 	}
 	return selectedName, provider, nil
+}
+
+func (r *workflowRuntime) ProviderNames() []string {
+	if r == nil {
+		return nil
+	}
+	r.mu.RLock()
+	defer r.mu.RUnlock()
+	names := make([]string, 0, len(r.providers))
+	for name := range r.providers {
+		if strings.TrimSpace(name) == "" {
+			continue
+		}
+		names = append(names, name)
+	}
+	sort.Strings(names)
+	return names
 }
 
 func (r *workflowRuntime) Invoke(ctx context.Context, req coreworkflow.InvokeOperationRequest) (*coreworkflow.InvokeOperationResponse, error) {

--- a/gestaltd/internal/server/handlers_workflow_event_triggers.go
+++ b/gestaltd/internal/server/handlers_workflow_event_triggers.go
@@ -81,7 +81,7 @@ func (s *Server) createGlobalWorkflowEventTrigger(w http.ResponseWriter, r *http
 		return
 	}
 	if strings.TrimSpace(req.Match.Type) == "" {
-		writeError(w, http.StatusBadRequest, "workflow event trigger match.type is required")
+		writeError(w, http.StatusBadRequest, "workflow trigger match.type is required")
 		return
 	}
 	managed, err := s.workflowSchedules.CreateEventTrigger(r.Context(), p, workflowmanager.EventTriggerUpsert{
@@ -128,7 +128,7 @@ func (s *Server) updateGlobalWorkflowEventTrigger(w http.ResponseWriter, r *http
 		return
 	}
 	if strings.TrimSpace(req.Match.Type) == "" {
-		writeError(w, http.StatusBadRequest, "workflow event trigger match.type is required")
+		writeError(w, http.StatusBadRequest, "workflow trigger match.type is required")
 		return
 	}
 	managed, err := s.workflowSchedules.UpdateEventTrigger(r.Context(), p, triggerID, workflowmanager.EventTriggerUpsert{
@@ -257,17 +257,17 @@ func (s *Server) writeWorkflowEventTriggerManagerError(w http.ResponseWriter, r 
 func (s *Server) writeWorkflowEventTriggerProviderError(ctx context.Context, w http.ResponseWriter, pluginName, triggerID string, err error) {
 	switch {
 	case errors.Is(err, core.ErrNotFound):
-		writeError(w, http.StatusNotFound, fmt.Sprintf("workflow event trigger %q not found", triggerID))
+		writeError(w, http.StatusNotFound, fmt.Sprintf("workflow trigger %q not found", triggerID))
 	default:
-		slog.ErrorContext(ctx, "workflow event trigger provider error",
+		slog.ErrorContext(ctx, "workflow trigger provider error",
 			"plugin", pluginName,
 			"trigger_id", triggerID,
 			"error", err,
 		)
 		if strings.TrimSpace(pluginName) == "" {
-			writeError(w, http.StatusInternalServerError, "workflow event trigger request failed")
+			writeError(w, http.StatusInternalServerError, "workflow trigger request failed")
 			return
 		}
-		writeError(w, http.StatusInternalServerError, fmt.Sprintf("workflow event trigger request failed for integration %q", pluginName))
+		writeError(w, http.StatusInternalServerError, fmt.Sprintf("workflow trigger request failed for integration %q", pluginName))
 	}
 }

--- a/gestaltd/internal/server/handlers_workflow_events.go
+++ b/gestaltd/internal/server/handlers_workflow_events.go
@@ -1,0 +1,104 @@
+package server
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"log/slog"
+	"maps"
+	"net/http"
+	"strings"
+	"time"
+
+	coreworkflow "github.com/valon-technologies/gestalt/server/core/workflow"
+	"github.com/valon-technologies/gestalt/server/internal/workflowmanager"
+)
+
+type workflowEventPublishRequest struct {
+	ID              string         `json:"id,omitempty"`
+	Source          string         `json:"source,omitempty"`
+	SpecVersion     string         `json:"specVersion,omitempty"`
+	Type            string         `json:"type"`
+	Subject         string         `json:"subject,omitempty"`
+	Time            *time.Time     `json:"time,omitempty"`
+	DataContentType string         `json:"dataContentType,omitempty"`
+	Data            map[string]any `json:"data,omitempty"`
+	Extensions      map[string]any `json:"extensions,omitempty"`
+}
+
+type workflowEventPublishResponse struct {
+	Status string               `json:"status"`
+	Event  workflowRunEventInfo `json:"event"`
+}
+
+func (s *Server) publishWorkflowEvent(w http.ResponseWriter, r *http.Request) {
+	p, ok := s.resolveWorkflowScheduleActor(w, r)
+	if !ok {
+		return
+	}
+
+	var req workflowEventPublishRequest
+	if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
+		writeError(w, http.StatusBadRequest, "invalid JSON body")
+		return
+	}
+
+	event, err := s.workflowSchedules.PublishEvent(r.Context(), p, workflowEventFromPublishRequest(req))
+	if err != nil {
+		s.writeWorkflowPublishEventError(w, r, err)
+		return
+	}
+
+	writeJSON(w, http.StatusAccepted, workflowEventPublishResponse{
+		Status: "published",
+		Event:  workflowRunEventInfoFromCore(event),
+	})
+}
+
+func workflowEventFromPublishRequest(req workflowEventPublishRequest) coreworkflow.Event {
+	return coreworkflow.Event{
+		ID:              strings.TrimSpace(req.ID),
+		Source:          strings.TrimSpace(req.Source),
+		SpecVersion:     strings.TrimSpace(req.SpecVersion),
+		Type:            strings.TrimSpace(req.Type),
+		Subject:         strings.TrimSpace(req.Subject),
+		Time:            req.Time,
+		DataContentType: strings.TrimSpace(req.DataContentType),
+		Data:            maps.Clone(req.Data),
+		Extensions:      maps.Clone(req.Extensions),
+	}
+}
+
+func workflowRunEventInfoFromCore(event coreworkflow.Event) workflowRunEventInfo {
+	return workflowRunEventInfo{
+		ID:              event.ID,
+		Source:          event.Source,
+		SpecVersion:     event.SpecVersion,
+		Type:            event.Type,
+		Subject:         event.Subject,
+		Time:            event.Time,
+		DataContentType: event.DataContentType,
+		Data:            maps.Clone(event.Data),
+		Extensions:      maps.Clone(event.Extensions),
+	}
+}
+
+func (s *Server) writeWorkflowPublishEventError(w http.ResponseWriter, r *http.Request, err error) {
+	switch {
+	case errors.Is(err, workflowmanager.ErrWorkflowNotConfigured),
+		errors.Is(err, workflowmanager.ErrExecutionRefsNotConfigured):
+		writeError(w, http.StatusPreconditionFailed, err.Error())
+	case errors.Is(err, workflowmanager.ErrWorkflowSubjectRequired),
+		errors.Is(err, workflowmanager.ErrWorkflowScheduleSubject):
+		writeError(w, http.StatusUnauthorized, err.Error())
+	case errors.Is(err, workflowmanager.ErrWorkflowEventTypeRequired):
+		writeError(w, http.StatusBadRequest, err.Error())
+	default:
+		s.writeWorkflowPublishEventProviderError(r.Context(), w, err)
+	}
+}
+
+func (s *Server) writeWorkflowPublishEventProviderError(ctx context.Context, w http.ResponseWriter, err error) {
+	slog.ErrorContext(ctx, "workflow event publish failed", "error", err)
+	writeError(w, http.StatusInternalServerError, "workflow event publish failed")
+}

--- a/gestaltd/internal/server/routes_user.go
+++ b/gestaltd/internal/server/routes_user.go
@@ -27,6 +27,7 @@ func (s *Server) mountAuthenticatedRoutes(r chi.Router) {
 			r.Post("/{triggerID}/pause", s.pauseGlobalWorkflowEventTrigger)
 			r.Post("/{triggerID}/resume", s.resumeGlobalWorkflowEventTrigger)
 		})
+		r.Post("/workflow/events", s.publishWorkflowEvent)
 		r.Route("/workflow/runs", func(r chi.Router) {
 			r.Get("/", s.listGlobalWorkflowRuns)
 			r.Get("/{runID}", s.getGlobalWorkflowRun)

--- a/gestaltd/internal/server/workflow_schedule_test.go
+++ b/gestaltd/internal/server/workflow_schedule_test.go
@@ -61,10 +61,29 @@ func (s *stubWorkflowControl) ResolveProvider(name string) (coreworkflow.Provide
 	return s.provider, nil
 }
 
+func (s *stubWorkflowControl) ProviderNames() []string {
+	if s.providers != nil {
+		names := make([]string, 0, len(s.providers))
+		for name := range s.providers {
+			names = append(names, name)
+		}
+		slices.Sort(names)
+		return names
+	}
+	if strings.TrimSpace(s.defaultProviderName) != "" {
+		return []string{strings.TrimSpace(s.defaultProviderName)}
+	}
+	if s.provider != nil {
+		return []string{"default"}
+	}
+	return nil
+}
+
 type memoryWorkflowProvider struct {
 	schedules            map[string]*coreworkflow.Schedule
 	triggers             map[string]*coreworkflow.EventTrigger
 	runs                 map[string]*coreworkflow.Run
+	publishEventReqs     []coreworkflow.PublishEventRequest
 	upsertReqs           []coreworkflow.UpsertScheduleRequest
 	upsertTriggerReqs    []coreworkflow.UpsertEventTriggerRequest
 	deleteReqs           []coreworkflow.DeleteScheduleRequest
@@ -83,6 +102,7 @@ type memoryWorkflowProvider struct {
 	getRunErr            error
 	listRunsErr          error
 	cancelRunErr         error
+	publishEventErr      error
 }
 
 func newMemoryWorkflowProvider() *memoryWorkflowProvider {
@@ -310,7 +330,12 @@ func (p *memoryWorkflowProvider) ResumeEventTrigger(_ context.Context, req corew
 	return cloneWorkflowEventTrigger(trigger), nil
 }
 
-func (p *memoryWorkflowProvider) PublishEvent(context.Context, coreworkflow.PublishEventRequest) error {
+func (p *memoryWorkflowProvider) PublishEvent(_ context.Context, req coreworkflow.PublishEventRequest) error {
+	if p.publishEventErr != nil {
+		return p.publishEventErr
+	}
+	req.Event = cloneWorkflowEvent(req.Event)
+	p.publishEventReqs = append(p.publishEventReqs, req)
 	return nil
 }
 
@@ -392,6 +417,17 @@ func cloneWorkflowEventTrigger(trigger *coreworkflow.EventTrigger) *coreworkflow
 		cloned.UpdatedAt = &value
 	}
 	return &cloned
+}
+
+func cloneWorkflowEvent(event coreworkflow.Event) coreworkflow.Event {
+	cloned := event
+	cloned.Data = cloneMap(event.Data)
+	cloned.Extensions = cloneMap(event.Extensions)
+	if event.Time != nil {
+		value := *event.Time
+		cloned.Time = &value
+	}
+	return cloned
 }
 
 func cloneMap(src map[string]any) map[string]any {
@@ -2153,5 +2189,173 @@ func TestWorkflowEventTriggerCreateRequiresMatchType(t *testing.T) {
 	}
 	if len(provider.upsertTriggerReqs) != 0 {
 		t.Fatalf("upsert trigger requests = %d, want 0", len(provider.upsertTriggerReqs))
+	}
+}
+
+func TestWorkflowEventPublishFansOutAcrossProvidersAndPlugins(t *testing.T) {
+	t.Parallel()
+
+	services := coretesting.NewStubServices(t)
+	user := seedUser(t, services, "ada@example.test")
+	basicProvider := newMemoryWorkflowProvider()
+	advancedProvider := newMemoryWorkflowProvider()
+	ts := newTestServer(t, func(cfg *server.Config) {
+		cfg.Auth = &coretesting.StubAuthProvider{
+			N: "stub",
+			ValidateTokenFn: func(_ context.Context, token string) (*core.UserIdentity, error) {
+				if token != "ada-session" {
+					return nil, core.ErrNotFound
+				}
+				return &core.UserIdentity{Email: user.Email, DisplayName: "Ada"}, nil
+			},
+		}
+		cfg.Services = services
+		cfg.Providers = testutil.NewProviderRegistry(t, &coretesting.StubIntegration{
+			N:        "roadmap",
+			ConnMode: core.ConnectionModeUser,
+			CatalogVal: &catalog.Catalog{
+				Name:       "roadmap",
+				Operations: []catalog.CatalogOperation{{ID: "sync", Method: http.MethodPost}},
+			},
+		}, &coretesting.StubIntegration{
+			N:        "slack",
+			ConnMode: core.ConnectionModeUser,
+			CatalogVal: &catalog.Catalog{
+				Name:       "slack",
+				Operations: []catalog.CatalogOperation{{ID: "chat.postMessage", Method: http.MethodPost}},
+			},
+		})
+		cfg.Workflow = &stubWorkflowControl{
+			defaultProviderName: "basic",
+			providers: map[string]coreworkflow.Provider{
+				"basic":    basicProvider,
+				"advanced": advancedProvider,
+			},
+		}
+	})
+	testutil.CloseOnCleanup(t, ts)
+
+	req, _ := http.NewRequest(
+		http.MethodPost,
+		ts.URL+"/api/v1/workflow/events",
+		bytes.NewBufferString(`{"type":"roadmap.item.updated","source":"roadmap","subject":"item","data":{"id":"item-1"},"extensions":{"traceId":"trace-1"}}`),
+	)
+	req.Header.Set("Content-Type", "application/json")
+	req.AddCookie(&http.Cookie{Name: "session_token", Value: "ada-session"})
+	resp, err := http.DefaultClient.Do(req)
+	if err != nil {
+		t.Fatalf("publish request: %v", err)
+	}
+	defer func() { _ = resp.Body.Close() }()
+	if resp.StatusCode != http.StatusAccepted {
+		body, _ := io.ReadAll(resp.Body)
+		t.Fatalf("expected 202, got %d: %s", resp.StatusCode, body)
+	}
+
+	var body struct {
+		Status string `json:"status"`
+		Event  struct {
+			ID          string         `json:"id"`
+			Type        string         `json:"type"`
+			Source      string         `json:"source"`
+			Subject     string         `json:"subject"`
+			SpecVersion string         `json:"specVersion"`
+			Time        *time.Time     `json:"time"`
+			Data        map[string]any `json:"data"`
+			Extensions  map[string]any `json:"extensions"`
+		} `json:"event"`
+	}
+	if err := json.NewDecoder(resp.Body).Decode(&body); err != nil {
+		t.Fatalf("decode publish response: %v", err)
+	}
+	if body.Status != "published" {
+		t.Fatalf("publish response status = %q, want published", body.Status)
+	}
+	if body.Event.ID == "" || body.Event.SpecVersion != "1.0" || body.Event.Time == nil {
+		t.Fatalf("published event = %#v", body.Event)
+	}
+	if body.Event.Type != "roadmap.item.updated" || body.Event.Source != "roadmap" || body.Event.Subject != "item" {
+		t.Fatalf("published event = %#v", body.Event)
+	}
+	if got := body.Event.Data["id"]; got != "item-1" {
+		t.Fatalf("published event data = %#v", body.Event.Data)
+	}
+	if got := body.Event.Extensions["traceId"]; got != "trace-1" {
+		t.Fatalf("published event extensions = %#v", body.Event.Extensions)
+	}
+
+	for name, provider := range map[string]*memoryWorkflowProvider{
+		"basic":    basicProvider,
+		"advanced": advancedProvider,
+	} {
+		if len(provider.publishEventReqs) != 2 {
+			t.Fatalf("%s publish requests = %d, want 2", name, len(provider.publishEventReqs))
+		}
+		gotPlugins := []string{
+			provider.publishEventReqs[0].PluginName,
+			provider.publishEventReqs[1].PluginName,
+		}
+		slices.Sort(gotPlugins)
+		if !slices.Equal(gotPlugins, []string{"roadmap", "slack"}) {
+			t.Fatalf("%s publish plugins = %#v", name, gotPlugins)
+		}
+		for _, publishReq := range provider.publishEventReqs {
+			if publishReq.Event.ID != body.Event.ID || publishReq.Event.SpecVersion != "1.0" || publishReq.Event.Time == nil || !publishReq.Event.Time.Equal(*body.Event.Time) {
+				t.Fatalf("%s publish event = %#v, response = %#v", name, publishReq.Event, body.Event)
+			}
+		}
+	}
+}
+
+func TestWorkflowEventPublishRequiresType(t *testing.T) {
+	t.Parallel()
+
+	services := coretesting.NewStubServices(t)
+	user := seedUser(t, services, "ada@example.test")
+	provider := newMemoryWorkflowProvider()
+	ts := newTestServer(t, func(cfg *server.Config) {
+		cfg.Auth = &coretesting.StubAuthProvider{
+			N: "stub",
+			ValidateTokenFn: func(_ context.Context, token string) (*core.UserIdentity, error) {
+				if token != "ada-session" {
+					return nil, core.ErrNotFound
+				}
+				return &core.UserIdentity{Email: user.Email, DisplayName: "Ada"}, nil
+			},
+		}
+		cfg.Services = services
+		cfg.Providers = testutil.NewProviderRegistry(t, &coretesting.StubIntegration{
+			N:        "roadmap",
+			ConnMode: core.ConnectionModeUser,
+			CatalogVal: &catalog.Catalog{
+				Name:       "roadmap",
+				Operations: []catalog.CatalogOperation{{ID: "sync", Method: http.MethodPost}},
+			},
+		})
+		cfg.Workflow = &stubWorkflowControl{
+			defaultProviderName: "basic",
+			provider:            provider,
+		}
+	})
+	testutil.CloseOnCleanup(t, ts)
+
+	req, _ := http.NewRequest(
+		http.MethodPost,
+		ts.URL+"/api/v1/workflow/events",
+		bytes.NewBufferString(`{"source":"roadmap","data":{"id":"item-1"}}`),
+	)
+	req.Header.Set("Content-Type", "application/json")
+	req.AddCookie(&http.Cookie{Name: "session_token", Value: "ada-session"})
+	resp, err := http.DefaultClient.Do(req)
+	if err != nil {
+		t.Fatalf("publish request: %v", err)
+	}
+	defer func() { _ = resp.Body.Close() }()
+	if resp.StatusCode != http.StatusBadRequest {
+		body, _ := io.ReadAll(resp.Body)
+		t.Fatalf("expected 400, got %d: %s", resp.StatusCode, body)
+	}
+	if len(provider.publishEventReqs) != 0 {
+		t.Fatalf("publish event requests = %d, want 0", len(provider.publishEventReqs))
 	}
 }

--- a/gestaltd/internal/workflowmanager/manager.go
+++ b/gestaltd/internal/workflowmanager/manager.go
@@ -26,15 +26,18 @@ var (
 	ErrWorkflowSubjectRequired    = errors.New("workflow subject is required")
 	ErrWorkflowScheduleSubject    = ErrWorkflowSubjectRequired
 	ErrDuplicateExecutionRefs     = errors.New("workflow object matched multiple execution references")
-	ErrWorkflowEventMatchRequired = errors.New("workflow event trigger match.type is required")
+	ErrWorkflowEventMatchRequired = errors.New("workflow trigger match.type is required")
+	ErrWorkflowEventTypeRequired  = errors.New("workflow event type is required")
 )
 
 const workflowScheduleExecutionRefBasePrefix = "workflow_schedule:"
 const workflowEventTriggerExecutionRefBasePrefix = "workflow_event_trigger:"
+const defaultWorkflowEventSpecVersion = "1.0"
 
 type WorkflowControl interface {
 	ResolveProvider(name string) (coreworkflow.Provider, error)
 	ResolveProviderSelection(name string) (providerName string, provider coreworkflow.Provider, err error)
+	ProviderNames() []string
 }
 
 type Service interface {
@@ -55,6 +58,7 @@ type Service interface {
 	ListRuns(ctx context.Context, p *principal.Principal) ([]*ManagedRun, error)
 	GetRun(ctx context.Context, p *principal.Principal, runID string) (*ManagedRun, error)
 	CancelRun(ctx context.Context, p *principal.Principal, runID, reason string) (*ManagedRun, error)
+	PublishEvent(ctx context.Context, p *principal.Principal, event coreworkflow.Event) (coreworkflow.Event, error)
 }
 
 type Config struct {
@@ -244,6 +248,42 @@ func (m *Manager) CancelRun(ctx context.Context, p *principal.Principal, runID, 
 	}
 	value.Run = run
 	return value, nil
+}
+
+func (m *Manager) PublishEvent(ctx context.Context, p *principal.Principal, event coreworkflow.Event) (coreworkflow.Event, error) {
+	p = principal.Canonicalized(p)
+	if strings.TrimSpace(principalSubjectID(p)) == "" {
+		return coreworkflow.Event{}, ErrWorkflowSubjectRequired
+	}
+	if m == nil || m.workflow == nil {
+		return coreworkflow.Event{}, ErrWorkflowNotConfigured
+	}
+
+	event = normalizePublishedEvent(event, m.now())
+	if strings.TrimSpace(event.Type) == "" {
+		return coreworkflow.Event{}, ErrWorkflowEventTypeRequired
+	}
+
+	providerNames := m.workflow.ProviderNames()
+	pluginNames := []string{}
+	if m.providers != nil {
+		pluginNames = m.providers.List()
+	}
+	for _, providerName := range providerNames {
+		provider, err := m.resolveProviderByName(providerName)
+		if err != nil {
+			return coreworkflow.Event{}, err
+		}
+		for _, pluginName := range pluginNames {
+			if err := provider.PublishEvent(ctx, coreworkflow.PublishEventRequest{
+				PluginName: pluginName,
+				Event:      event,
+			}); err != nil {
+				return coreworkflow.Event{}, err
+			}
+		}
+	}
+	return event, nil
 }
 
 func (m *Manager) ListSchedules(ctx context.Context, p *principal.Principal) ([]*ManagedSchedule, error) {
@@ -1133,4 +1173,29 @@ func existingEventTriggerProvider(value *ManagedEventTrigger) coreworkflow.Provi
 		return nil
 	}
 	return value.provider
+}
+
+func normalizePublishedEvent(event coreworkflow.Event, now time.Time) coreworkflow.Event {
+	event.ID = strings.TrimSpace(event.ID)
+	event.Source = strings.TrimSpace(event.Source)
+	event.SpecVersion = strings.TrimSpace(event.SpecVersion)
+	event.Type = strings.TrimSpace(event.Type)
+	event.Subject = strings.TrimSpace(event.Subject)
+	event.DataContentType = strings.TrimSpace(event.DataContentType)
+	event.Data = maps.Clone(event.Data)
+	event.Extensions = maps.Clone(event.Extensions)
+	if event.ID == "" {
+		event.ID = uuid.NewString()
+	}
+	if event.SpecVersion == "" {
+		event.SpecVersion = defaultWorkflowEventSpecVersion
+	}
+	if event.Time == nil || event.Time.IsZero() {
+		value := now.UTC()
+		event.Time = &value
+	} else {
+		value := event.Time.UTC()
+		event.Time = &value
+	}
+	return event
 }


### PR DESCRIPTION
## Summary

This adds a public workflow event-ingress surface so event triggers can be exercised from the product layer instead of only from provider-internal or config-managed publishers.

New interfaces:
- `POST /api/v1/workflow/events`
- `gestalt workflows events publish --type <event-type> [--source <source>] [--subject <subject>] [-p key=value] [-e key=value]`

## HTTP example

```sh
curl -X POST "$GESTALT_URL/api/v1/workflow/events" \
  -H "Authorization: Bearer $GESTALT_API_KEY" \
  -H "Content-Type: application/json" \
  -d '{
    "type": "roadmap.item.updated",
    "source": "roadmap",
    "subject": "item",
    "dataContentType": "application/json",
    "data": {
      "id": "item-1"
    },
    "extensions": {
      "traceId": "trace-1"
    }
  }'
```

## CLI example

```sh
gestalt workflows events publish \
  --type roadmap.item.updated \
  --source roadmap \
  --subject item \
  --data-content-type application/json \
  -p id=item-1 \
  -e traceId=trace-1
```

## Implementation notes

The workflow manager now normalizes the event ID, spec version, and timestamp once, then fans that normalized event out across the configured workflow providers and plugin namespaces. That keeps the public API plugin-less while still matching the current provider-side trigger scoping behavior.

This also updates the workflow docs and CLI reference so the public event-ingress route is documented alongside schedules, event triggers, and runs.

## Verification

```sh
cd gestaltd && go test ./internal/server ./internal/workflowmanager ./internal/bootstrap -count=1
cd gestaltd && golangci-lint run ./internal/server ./internal/workflowmanager ./internal/bootstrap
cd gestalt && cargo test --test workflows_cli
cd gestalt && cargo fmt --all --check
cd docs && npm run typecheck
cd docs && npm run build
git diff --check
```