### PR TITLE
Hide internal provider export env vars from public SDK surfaces

### DIFF
--- a/sdk/rust/src/env.rs
+++ b/sdk/rust/src/env.rs
@@ -4,9 +4,9 @@ pub const ENV_PROVIDER_SOCKET: &str = "GESTALT_PLUGIN_SOCKET";
 /// Parent process id used for lifecycle shutdown detection.
 pub const ENV_PROVIDER_PARENT_PID: &str = "GESTALT_PLUGIN_PARENT_PID";
 /// Optional path where the runtime should write the derived static catalog.
-pub const ENV_WRITE_CATALOG: &str = "GESTALT_PLUGIN_WRITE_CATALOG";
+pub(crate) const ENV_WRITE_CATALOG: &str = "GESTALT_PLUGIN_WRITE_CATALOG";
 /// Optional path where the runtime should write generated manifest metadata.
-pub const ENV_WRITE_MANIFEST_METADATA: &str = "GESTALT_PLUGIN_WRITE_MANIFEST_METADATA";
+pub(crate) const ENV_WRITE_MANIFEST_METADATA: &str = "GESTALT_PLUGIN_WRITE_MANIFEST_METADATA";
 /// Provider name override supplied by the host runtime.
 pub const ENV_PROVIDER_NAME: &str = "GESTALT_PLUGIN_NAME";
 /// Current Gestalt provider protocol version spoken by this SDK.

--- a/sdk/rust/src/lib.rs
+++ b/sdk/rust/src/lib.rs
@@ -42,7 +42,7 @@ pub use cache::{
     cache_socket_env,
 };
 pub use catalog::{Catalog, CatalogOperation};
-pub use env::{CURRENT_PROTOCOL_VERSION, ENV_PROVIDER_SOCKET, ENV_WRITE_MANIFEST_METADATA};
+pub use env::{CURRENT_PROTOCOL_VERSION, ENV_PROVIDER_SOCKET};
 pub use error::{Error, Result};
 pub use indexeddb::{Cursor, CursorDirection, IndexedDB, IndexedDBError};
 pub use invoker::{

--- a/sdk/rust/tests/router.rs
+++ b/sdk/rust/tests/router.rs
@@ -17,6 +17,8 @@ use tonic::codegen::async_trait;
 
 use gestalt::{Operation, Provider, Request, Response, Router, ok};
 
+const ENV_WRITE_MANIFEST_METADATA: &str = "GESTALT_PLUGIN_WRITE_MANIFEST_METADATA";
+
 #[derive(Default)]
 struct TestProvider;
 
@@ -151,8 +153,7 @@ async fn serve_provider_writes_catalog_and_manifest_metadata_when_requested() {
     let catalog_path = helpers::temp_socket("router-catalog.json");
     let metadata_path = helpers::temp_socket("router-manifest-metadata.yaml");
     let _catalog_guard = helpers::EnvGuard::set("GESTALT_PLUGIN_WRITE_CATALOG", &catalog_path);
-    let _metadata_guard =
-        helpers::EnvGuard::set(gestalt::ENV_WRITE_MANIFEST_METADATA, &metadata_path);
+    let _metadata_guard = helpers::EnvGuard::set(ENV_WRITE_MANIFEST_METADATA, &metadata_path);
     let _name_guard = helpers::EnvGuard::set("GESTALT_PLUGIN_NAME", "manifest-provider");
 
     gestalt::runtime::serve_provider(
@@ -181,8 +182,7 @@ async fn export_provider_writes_manifest_metadata_with_catalog_exports() {
     let catalog_path = helpers::temp_socket("macro-catalog.json");
     let metadata_path = helpers::temp_socket("macro-manifest-metadata.yaml");
     let direct_metadata_path = helpers::temp_socket("direct-manifest-metadata.yaml");
-    let _metadata_guard =
-        helpers::EnvGuard::set(gestalt::ENV_WRITE_MANIFEST_METADATA, &metadata_path);
+    let _metadata_guard = helpers::EnvGuard::set(ENV_WRITE_MANIFEST_METADATA, &metadata_path);
 
     __gestalt_write_catalog("macro-provider", catalog_path.to_str().expect("utf8 path"))
         .expect("write catalog");

--- a/sdk/typescript/src/index.ts
+++ b/sdk/typescript/src/index.ts
@@ -160,8 +160,6 @@ export {
   CURRENT_PROTOCOL_VERSION,
   ENV_PROVIDER_PARENT_PID,
   ENV_PROVIDER_SOCKET,
-  ENV_WRITE_CATALOG,
-  ENV_WRITE_MANIFEST_METADATA,
   createAuthenticationService,
   createCacheService,
   createSecretsService,

--- a/sdk/typescript/src/runtime.ts
+++ b/sdk/typescript/src/runtime.ts
@@ -105,12 +105,11 @@ export const ENV_PROVIDER_PARENT_PID = "GESTALT_PLUGIN_PARENT_PID";
 /**
  * Environment variable used to request static catalog generation.
  */
-export const ENV_WRITE_CATALOG = "GESTALT_PLUGIN_WRITE_CATALOG";
+const ENV_WRITE_CATALOG = "GESTALT_PLUGIN_WRITE_CATALOG";
 /**
  * Environment variable used to request generated manifest metadata export.
  */
-export const ENV_WRITE_MANIFEST_METADATA =
-  "GESTALT_PLUGIN_WRITE_MANIFEST_METADATA";
+const ENV_WRITE_MANIFEST_METADATA = "GESTALT_PLUGIN_WRITE_MANIFEST_METADATA";
 /**
  * Protocol version currently implemented by the TypeScript runtime.
  */

--- a/sdk/typescript/tests/runtime.test.ts
+++ b/sdk/typescript/tests/runtime.test.ts
@@ -48,8 +48,6 @@ import {
 import {
   CURRENT_PROTOCOL_VERSION,
   createCacheService,
-  ENV_WRITE_CATALOG,
-  ENV_WRITE_MANIFEST_METADATA,
   ENV_PROVIDER_SOCKET,
   createAuthenticationService,
   createProviderService,
@@ -78,6 +76,9 @@ import {
   waitForPath,
 } from "./helpers.ts";
 
+const ENV_WRITE_CATALOG = "GESTALT_PLUGIN_WRITE_CATALOG";
+const ENV_WRITE_MANIFEST_METADATA = "GESTALT_PLUGIN_WRITE_MANIFEST_METADATA";
+
 async function expectConnectCode(
   promise: Promise<unknown>,
   code: Code,
@@ -97,6 +98,22 @@ test("runtime arg parsing requires root and target", () => {
     target: "plugin:./provider.ts#plugin",
   });
   expect(parseRuntimeArgs(["root"])).toBeUndefined();
+});
+
+test("catalog export handshake env vars stay out of the public TypeScript API", async () => {
+  const runtimeModule = await import("../src/runtime.ts");
+  const packageModule = await import("../src/index.ts");
+
+  expect(Object.hasOwn(runtimeModule, "ENV_WRITE_CATALOG")).toBe(false);
+  expect(Object.hasOwn(runtimeModule, "ENV_WRITE_MANIFEST_METADATA")).toBe(
+    false,
+  );
+  expect(Object.hasOwn(packageModule, "ENV_WRITE_CATALOG")).toBe(false);
+  expect(Object.hasOwn(packageModule, "ENV_WRITE_MANIFEST_METADATA")).toBe(
+    false,
+  );
+  expect(Object.hasOwn(runtimeModule, "ENV_PROVIDER_SOCKET")).toBe(true);
+  expect(Object.hasOwn(packageModule, "ENV_PROVIDER_SOCKET")).toBe(true);
 });
 
 test("runtime main writes a static catalog in catalog mode", async () => {


### PR DESCRIPTION
## Summary
This PR removes the internal host-runtime export handshake env vars from the public TypeScript and Rust SDK surfaces.

The runtime behavior is unchanged: `gestaltd` can still request catalog and manifest-metadata exports through `GESTALT_PLUGIN_WRITE_CATALOG` and `GESTALT_PLUGIN_WRITE_MANIFEST_METADATA`. The change is only that SDK consumers no longer see those internals as part of the supported public API.

## Public Interface
- TypeScript still publicly exports `CURRENT_PROTOCOL_VERSION`, `ENV_PROVIDER_SOCKET`, `ENV_PROVIDER_PARENT_PID`, `runtimeMain`, and the runtime helpers
- TypeScript no longer exports `ENV_WRITE_CATALOG` or `ENV_WRITE_MANIFEST_METADATA` from either `@valon-technologies/gestalt` or `@valon-technologies/gestalt/runtime`
- Rust still publicly exports `CURRENT_PROTOCOL_VERSION` and `ENV_PROVIDER_SOCKET`
- Rust no longer re-exports `ENV_WRITE_MANIFEST_METADATA` from the crate root; `ENV_WRITE_CATALOG` was already not part of the public crate API
- `GESTALT_PLUGIN_WRITE_CATALOG` and `GESTALT_PLUGIN_WRITE_MANIFEST_METADATA` remain internal host-runtime handshake env vars, not public SDK surface area

## Examples
TypeScript package entrypoint:
```ts
import {
  ENV_PROVIDER_SOCKET,
  CURRENT_PROTOCOL_VERSION,
  runtimeMain,
} from "@valon-technologies/gestalt";
```

TypeScript runtime subpath:
```ts
import { main as runtimeMain, ENV_PROVIDER_SOCKET } from "@valon-technologies/gestalt/runtime";
```

Rust:
```rust
use gestalt::{runtime, CURRENT_PROTOCOL_VERSION, ENV_PROVIDER_SOCKET};
```

Internal host-runtime handshake remains unchanged:
```text
GESTALT_PLUGIN_WRITE_CATALOG
GESTALT_PLUGIN_WRITE_MANIFEST_METADATA
```

## Validation
- `cd sdk/typescript && bun test tests/runtime.test.ts`
- `cd sdk/typescript && bunx tsc --noEmit`
- `cd sdk/typescript && bunx eslint --max-warnings=0 src/index.ts src/runtime.ts`
- `cd sdk/rust && cargo test --test router`
- `cd sdk/rust && cargo fmt --all --check`
