### PR TITLE
Formalize `gestalt identities` as a first-class CLI surface

### DIFF
--- a/README.md
+++ b/README.md
@@ -56,6 +56,17 @@ gestalt plugins list
 gestalt plugins invoke httpbin get_ip
 ```
 
+Managed identities are available from the same client CLI via the top-level
+`gestalt identities` command:
+
+```sh
+gestalt identities list
+gestalt identities create --name "Release Bot"
+```
+
+See [CLI docs](https://gestaltd.ai/client/cli) for identity members, grants,
+and identity-owned token commands.
+
 For the full walkthrough, see [Getting Started](https://gestaltd.ai/getting-started).
 
 ## Repository Layout
@@ -63,6 +74,6 @@ For the full walkthrough, see [Getting Started](https://gestaltd.ai/getting-star
 | Path | Description |
 | --- | --- |
 | [`gestaltd`](./gestaltd) | Go server daemon, config loading, provider bootstrap, HTTP API, MCP surface, deployment assets, and admin UI serving code. |
-| [`gestalt`](./gestalt) | Rust CLI client for setup, auth, invocation, and token management. |
+| [`gestalt`](./gestalt) | Rust CLI client for setup, auth, managed identity operations, invocation, and token management. |
 | [`sdk`](./sdk) | Go, Python, Rust, and TypeScript SDKs plus shared protocol definitions. |
 | [`docs`](./docs) | Source for the public documentation site at [gestaltd.ai](https://gestaltd.ai). |

--- a/docs/content/client/cli/index.mdx
+++ b/docs/content/client/cli/index.mdx
@@ -4,7 +4,7 @@ asIndexPage: true
 
 # CLI
 
-`gestalt` is the client CLI for interacting with a running `gestaltd` server. It handles authentication, plugin connections, operation invocation, and API token management. A [Docker image](/client/cli/docker) is also available for CI and containerized environments.
+`gestalt` is the client CLI for interacting with a running `gestaltd` server. It handles authentication, managed identity resources, plugin connections, operation invocation, and API token management. A [Docker image](/client/cli/docker) is also available for CI and containerized environments.
 
 ## Global flags
 
@@ -27,6 +27,7 @@ asIndexPage: true
 | `gestalt plugins disconnect NAME` | Disconnect a plugin, removing stored credentials. |
 | `gestalt plugins invoke NAME [OPERATION]` | Invoke an operation or list operations when omitted. |
 | `gestalt plugins describe NAME OPERATION` | Show one operation's parameter contract. |
+| `gestalt identities ...` | Manage workspace-owned managed identities, members, grants, and identity-owned API tokens. |
 | `gestalt workflows schedules ...` | Create, list, inspect, update, pause, resume, or delete workflow schedules. |
 | `gestalt workflows triggers ...` | Create, list, inspect, update, pause, resume, or delete workflow event triggers. |
 | `gestalt workflows runs ...` | List, inspect, and cancel workflow runs. |
@@ -107,6 +108,49 @@ gestalt workflows triggers create \
   -p text='Roadmap item updated'
 gestalt workflows runs list --plugin github --status failed
 gestalt tokens create --name automation
+```
+
+## Managed identities
+
+`gestalt identities` is the first-class CLI surface for the managed identity HTTP API at `/api/v1/identities`.
+
+| Command | Purpose |
+| --- | --- |
+| `gestalt identities list` | List managed identities you can access. |
+| `gestalt identities create\|get\|update\|delete ...` | Create, inspect, rename, or delete one managed identity. |
+| `gestalt identities members list\|add\|update\|remove ID ...` | Manage identity membership by email. `--role` accepts `viewer`, `editor`, or `admin`. |
+| `gestalt identities grants list\|set\|revoke ID ...` | Manage plugin grants. Repeat `--operation` to scope access; omit it for plugin-wide access. |
+| `gestalt identities tokens list\|create\|revoke ID ...` | Manage identity-owned API tokens. Repeat `--permission plugin` or `--permission plugin:op1,op2`. |
+
+Token permissions cannot exceed the identity's own grants. For grants, omitting `--operation` means plugin-wide access.
+
+### Examples
+
+```sh
+gestalt identities list
+gestalt identities create --name "Release Bot"
+gestalt identities get <identity-id>
+gestalt identities update <identity-id> --name "Release Bot CI"
+gestalt identities delete <identity-id>
+
+gestalt identities members list <identity-id>
+gestalt identities members add <identity-id> viewer@example.com --role viewer
+gestalt identities members update <identity-id> operator@example.com --role admin
+gestalt identities members remove <identity-id> viewer@example.com
+
+gestalt identities grants list <identity-id>
+gestalt identities grants set <identity-id> github
+gestalt identities grants set <identity-id> slack \
+  --operation chat.postMessage \
+  --operation channels.history
+gestalt identities grants revoke <identity-id> slack
+
+gestalt identities tokens list <identity-id>
+gestalt identities tokens create <identity-id> \
+  --name deploy-bot \
+  --permission github \
+  --permission slack:chat.postMessage,channels.history
+gestalt identities tokens revoke <identity-id> <token-id>
 ```
 
 ## Workflow commands

--- a/docs/dockerhub/gestalt.md
+++ b/docs/dockerhub/gestalt.md
@@ -1,8 +1,9 @@
 # gestalt Docker image
 
 `gestalt` is a CLI client for the Gestalt API. It connects to a running
-`gestaltd` server and provides commands for authenticating, listing plugins,
-invoking integration operations, and managing credentials.
+`gestaltd` server and provides commands for authenticating, managing workspace
+identities, listing plugins, invoking integration operations, and managing
+credentials.
 
 > **Alpha.** Gestalt is under active development. Images are tagged
 > with alpha versions and may introduce breaking changes. See the
@@ -49,6 +50,42 @@ docker run --rm \
   plugins invoke github search_code -p "query=gestalt org:my-org"
 ```
 
+### Manage managed identities
+
+The same image exposes the top-level `identities` command surface:
+
+```sh
+docker run --rm \
+  -e GESTALT_URL=https://gestalt.example.com \
+  -e GESTALT_API_KEY=gst_api_... \
+  valontechnologies/gestalt:latest \
+  identities list
+
+docker run --rm \
+  -e GESTALT_URL=https://gestalt.example.com \
+  -e GESTALT_API_KEY=gst_api_... \
+  valontechnologies/gestalt:latest \
+  identities create --name "Release Bot"
+
+docker run --rm \
+  -e GESTALT_URL=https://gestalt.example.com \
+  -e GESTALT_API_KEY=gst_api_... \
+  valontechnologies/gestalt:latest \
+  identities members add <identity-id> deployer@example.com --role editor
+
+docker run --rm \
+  -e GESTALT_URL=https://gestalt.example.com \
+  -e GESTALT_API_KEY=gst_api_... \
+  valontechnologies/gestalt:latest \
+  identities grants set <identity-id> github --operation issues.list
+
+docker run --rm \
+  -e GESTALT_URL=https://gestalt.example.com \
+  -e GESTALT_API_KEY=gst_api_... \
+  valontechnologies/gestalt:latest \
+  identities tokens create <identity-id> --name ci --permission github:issues.list
+```
+
 ### Use in CI pipelines
 
 The Docker image works well in CI environments where installing the native
@@ -75,10 +112,11 @@ jobs:
 | `plugins connect NAME` | Connect a plugin via OAuth or manual authentication |
 | `plugins disconnect NAME` | Disconnect a plugin |
 | `plugins invoke NAME OP` | Execute a plugin operation |
+| `identities ...` | Manage managed identities, members, grants, and identity-owned tokens |
 | `tokens create/list/revoke` | Manage API tokens |
 
 Use `--format json` or `--format table` to control output format. See the
-[CLI reference](https://gestaltd.ai/reference/cli) for the full command list.
+[CLI guide](https://gestaltd.ai/client/cli) for the full command list.
 
 ## Environment variables
 
@@ -103,5 +141,5 @@ of the Docker image.
 ## Learn more
 
 - Docs: https://gestaltd.ai
-- CLI reference: https://gestaltd.ai/reference/cli
+- CLI guide: https://gestaltd.ai/client/cli
 - Source: https://github.com/valon-technologies/gestalt

--- a/gestalt/cli/src/api.rs
+++ b/gestalt/cli/src/api.rs
@@ -3,7 +3,7 @@ use reqwest::Method;
 use reqwest::StatusCode;
 use reqwest::blocking::Client;
 use reqwest::header::{self, HeaderValue};
-use serde::{Deserialize, Serialize};
+use serde::{Deserialize, Serialize, de::DeserializeOwned};
 use std::collections::BTreeMap;
 use std::fmt;
 use std::path::{Path, PathBuf};
@@ -32,6 +32,109 @@ pub struct TokenPermission {
     pub plugin: String,
     #[serde(default, skip_serializing_if = "Vec::is_empty")]
     pub operations: Vec<String>,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+#[serde(rename_all = "camelCase")]
+pub struct IdentityDisplayNameRequest {
+    pub display_name: String,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+#[serde(rename_all = "camelCase")]
+pub struct IdentityMemberRequest {
+    pub email: String,
+    pub role: String,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+#[serde(rename_all = "camelCase")]
+pub struct IdentityGrantRequest {
+    pub operations: Vec<String>,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+#[serde(rename_all = "camelCase")]
+pub struct IdentityTokenCreateRequest {
+    pub name: String,
+    pub permissions: Vec<TokenPermission>,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+#[serde(rename_all = "camelCase")]
+pub struct IdentityRecord {
+    pub id: String,
+    pub display_name: String,
+    pub role: String,
+    #[serde(alias = "created_at")]
+    pub created_at: String,
+    #[serde(alias = "updated_at")]
+    pub updated_at: String,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+#[serde(rename_all = "camelCase")]
+pub struct IdentityMemberRecord {
+    pub subject_id: String,
+    pub email: String,
+    pub role: String,
+    #[serde(alias = "created_at")]
+    pub created_at: String,
+    #[serde(alias = "updated_at")]
+    pub updated_at: String,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+#[serde(rename_all = "camelCase")]
+pub struct IdentityGrantRecord {
+    pub plugin: String,
+    #[serde(default)]
+    pub operations: Vec<String>,
+    #[serde(alias = "created_at")]
+    pub created_at: String,
+    #[serde(alias = "updated_at")]
+    pub updated_at: String,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+#[serde(rename_all = "camelCase")]
+pub struct IdentityTokenRecord {
+    pub id: String,
+    pub name: String,
+    #[serde(default)]
+    pub scopes: String,
+    #[serde(default)]
+    pub permissions: Vec<TokenPermission>,
+    #[serde(alias = "created_at")]
+    pub created_at: String,
+    #[serde(default, alias = "expires_at", skip_serializing_if = "Option::is_none")]
+    pub expires_at: Option<String>,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+#[serde(rename_all = "camelCase")]
+pub struct IdentityTokenCreateResponse {
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub id: Option<String>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub name: Option<String>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub token: Option<String>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub permissions: Option<Vec<TokenPermission>>,
+    #[serde(default, alias = "created_at", skip_serializing_if = "Option::is_none")]
+    pub created_at: Option<String>,
+    #[serde(default, alias = "expires_at", skip_serializing_if = "Option::is_none")]
+    pub expires_at: Option<String>,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+pub struct StatusResponse {
+    pub status: String,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub cleanup: Option<String>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub warnings: Option<Vec<String>>,
 }
 
 pub fn normalize_url(url: &str) -> String {
@@ -343,23 +446,63 @@ impl ApiClient {
         self.delete(&format!("/api/v1/tokens/{id}"))
     }
 
+    pub fn list_identities(&self) -> Result<Vec<IdentityRecord>> {
+        self.parse_response(self.get("/api/v1/identities")?)
+    }
+
+    pub fn create_identity(&self, request: &IdentityDisplayNameRequest) -> Result<IdentityRecord> {
+        self.parse_response(self.post("/api/v1/identities", request)?)
+    }
+
+    pub fn list_identity_members(&self, identity: &str) -> Result<Vec<IdentityMemberRecord>> {
+        self.parse_response(self.get(&format!("/api/v1/identities/{identity}/members"))?)
+    }
+
+    pub fn put_identity_member(
+        &self,
+        identity: &str,
+        request: &IdentityMemberRequest,
+    ) -> Result<IdentityMemberRecord> {
+        self.parse_response(self.put(&format!("/api/v1/identities/{identity}/members"), request)?)
+    }
+
+    pub fn delete_identity_member(&self, identity: &str, email: &str) -> Result<StatusResponse> {
+        let encoded_email = encode_path_segment(email);
+        self.parse_response(self.delete(&format!(
+            "/api/v1/identities/{identity}/members/{encoded_email}"
+        ))?)
+    }
+
+    pub fn list_identity_grants(&self, identity: &str) -> Result<Vec<IdentityGrantRecord>> {
+        self.parse_response(self.get(&format!("/api/v1/identities/{identity}/grants"))?)
+    }
+
+    pub fn put_identity_grant(
+        &self,
+        identity: &str,
+        plugin: &str,
+        request: &IdentityGrantRequest,
+    ) -> Result<IdentityGrantRecord> {
+        self.parse_response(self.put(
+            &format!("/api/v1/identities/{identity}/grants/{plugin}"),
+            request,
+        )?)
+    }
+
+    pub fn delete_identity_grant(&self, identity: &str, plugin: &str) -> Result<StatusResponse> {
+        self.parse_response(self.delete(&format!("/api/v1/identities/{identity}/grants/{plugin}"))?)
+    }
+
     pub fn create_identity_api_token(
         &self,
         identity: &str,
-        name: &str,
-        permissions: &[TokenPermission],
-    ) -> Result<serde_json::Value> {
-        self.post(
-            &format!("/api/v1/identities/{identity}/tokens"),
-            &serde_json::json!({
-                "name": name,
-                "permissions": permissions,
-            }),
-        )
+        request: &IdentityTokenCreateRequest,
+    ) -> Result<IdentityTokenCreateResponse> {
+        self.parse_response(self.post(&format!("/api/v1/identities/{identity}/tokens"), request)?)
     }
 
-    pub fn revoke_identity_api_token(&self, identity: &str, id: &str) -> Result<serde_json::Value> {
-        self.delete(&format!("/api/v1/identities/{identity}/tokens/{id}"))
+    pub fn revoke_identity_api_token(&self, identity: &str, id: &str) -> Result<StatusResponse> {
+        self.parse_response(self.delete(&format!("/api/v1/identities/{identity}/tokens/{id}"))?)
     }
 
     fn send(&self, method: Method, path: &str) -> Result<serde_json::Value> {
@@ -483,6 +626,13 @@ impl ApiClient {
         }
         Ok(())
     }
+
+    fn parse_response<T>(&self, value: serde_json::Value) -> Result<T>
+    where
+        T: DeserializeOwned,
+    {
+        serde_json::from_value(value).context("failed to parse response JSON")
+    }
 }
 
 fn extract_api_error(value: &serde_json::Value) -> Option<ApiError> {
@@ -532,4 +682,16 @@ fn extract_api_error(value: &serde_json::Value) -> Option<ApiError> {
         }
         _ => None,
     }
+}
+
+fn encode_path_segment(value: &str) -> String {
+    let mut url = url::Url::parse("https://managed-identities.invalid/").expect("static URL");
+    {
+        let mut segments = url
+            .path_segments_mut()
+            .expect("static URL should support path segments");
+        segments.pop_if_empty();
+        segments.push(value);
+    }
+    url.path().trim_start_matches('/').to_string()
 }

--- a/gestalt/cli/src/commands/identities.rs
+++ b/gestalt/cli/src/commands/identities.rs
@@ -1,66 +1,81 @@
 use anyhow::{Context, Result};
-use serde_json::json;
+use serde::de::DeserializeOwned;
 
-use crate::api::{ApiClient, TokenPermission};
+use crate::api::{self, ApiClient, TokenPermission};
 use crate::cli::IdentityPermissionArg;
 use crate::output::{self, Format};
 
 pub fn list(client: &ApiClient, format: Format) -> Result<()> {
     let resp = client
-        .get("/api/v1/identities")
+        .list_identities()
         .context("failed to list identities")?;
     print_identities(&resp, format);
     Ok(())
 }
 
 pub fn get(client: &ApiClient, id: &str, format: Format) -> Result<()> {
-    let resp = client
+    let raw = client
         .get(&format!("/api/v1/identities/{id}"))
         .with_context(|| format!("failed to get identity {id}"))?;
-    print_identity(&resp, format);
+    if format == Format::Json {
+        output::print_json(&raw);
+        return Ok(());
+    }
+    match parse_raw::<api::IdentityRecord>(&raw) {
+        Ok(resp) => print_identity(&resp, format),
+        Err(_) => output::print_json_table(&raw),
+    }
     Ok(())
 }
 
 pub fn create(client: &ApiClient, display_name: &str, format: Format) -> Result<()> {
     let resp = client
-        .post(
-            "/api/v1/identities",
-            &json!({
-                "displayName": display_name,
-            }),
-        )
+        .create_identity(&api::IdentityDisplayNameRequest {
+            display_name: display_name.to_string(),
+        })
         .context("failed to create identity")?;
     print_identity(&resp, format);
     Ok(())
 }
 
 pub fn update(client: &ApiClient, id: &str, display_name: &str, format: Format) -> Result<()> {
-    let resp = client
+    let raw = client
         .patch(
             &format!("/api/v1/identities/{id}"),
-            &json!({
-                "displayName": display_name,
-            }),
+            &api::IdentityDisplayNameRequest {
+                display_name: display_name.to_string(),
+            },
         )
         .with_context(|| format!("failed to update identity {id}"))?;
-    print_identity(&resp, format);
+    if format == Format::Json {
+        output::print_json(&raw);
+        return Ok(());
+    }
+    match parse_raw::<api::IdentityRecord>(&raw) {
+        Ok(resp) => print_identity(&resp, format),
+        Err(_) => output::print_json_table(&raw),
+    }
     Ok(())
 }
 
 pub fn delete(client: &ApiClient, id: &str, format: Format) -> Result<()> {
-    let resp = client
+    let raw = client
         .delete(&format!("/api/v1/identities/{id}"))
         .with_context(|| format!("failed to delete identity {id}"))?;
-    match format {
-        Format::Json => output::print_json(&resp),
-        Format::Table => output::print_success(&format!("Identity {id} deleted.")),
+    if format == Format::Json {
+        output::print_json(&raw);
+        return Ok(());
+    }
+    match parse_raw::<api::StatusResponse>(&raw) {
+        Ok(resp) => print_status(&resp, format, &format!("Identity {id} deleted.")),
+        Err(_) => output::print_json_table(&raw),
     }
     Ok(())
 }
 
 pub fn list_members(client: &ApiClient, identity: &str, format: Format) -> Result<()> {
     let resp = client
-        .get(&format!("/api/v1/identities/{identity}/members"))
+        .list_identity_members(identity)
         .with_context(|| format!("failed to list members for identity {identity}"))?;
     print_members(&resp, format);
     Ok(())
@@ -74,12 +89,12 @@ pub fn upsert_member(
     format: Format,
 ) -> Result<()> {
     let resp = client
-        .put(
-            &format!("/api/v1/identities/{identity}/members"),
-            &json!({
-                "email": email,
-                "role": role,
-            }),
+        .put_identity_member(
+            identity,
+            &api::IdentityMemberRequest {
+                email: email.to_string(),
+                role: role.to_string(),
+            },
         )
         .with_context(|| format!("failed to update member {email} on identity {identity}"))?;
     print_member(&resp, format);
@@ -92,24 +107,20 @@ pub fn remove_member(
     email: &str,
     format: Format,
 ) -> Result<()> {
-    let encoded_email = encode_path_segment(email);
     let resp = client
-        .delete(&format!(
-            "/api/v1/identities/{identity}/members/{encoded_email}"
-        ))
+        .delete_identity_member(identity, email)
         .with_context(|| format!("failed to remove member {email} from identity {identity}"))?;
-    match format {
-        Format::Json => output::print_json(&resp),
-        Format::Table => {
-            output::print_success(&format!("Removed member {email} from identity {identity}."))
-        }
-    }
+    print_status(
+        &resp,
+        format,
+        &format!("Removed member {email} from identity {identity}."),
+    );
     Ok(())
 }
 
 pub fn list_grants(client: &ApiClient, identity: &str, format: Format) -> Result<()> {
     let resp = client
-        .get(&format!("/api/v1/identities/{identity}/grants"))
+        .list_identity_grants(identity)
         .with_context(|| format!("failed to list grants for identity {identity}"))?;
     print_grants(&resp, format);
     Ok(())
@@ -123,11 +134,12 @@ pub fn set_grant(
     format: Format,
 ) -> Result<()> {
     let resp = client
-        .put(
-            &format!("/api/v1/identities/{identity}/grants/{plugin}"),
-            &json!({
-                "operations": operations,
-            }),
+        .put_identity_grant(
+            identity,
+            plugin,
+            &api::IdentityGrantRequest {
+                operations: operations.to_vec(),
+            },
         )
         .with_context(|| {
             format!("failed to set grant for plugin {plugin} on identity {identity}")
@@ -143,24 +155,30 @@ pub fn revoke_grant(
     format: Format,
 ) -> Result<()> {
     let resp = client
-        .delete(&format!("/api/v1/identities/{identity}/grants/{plugin}"))
+        .delete_identity_grant(identity, plugin)
         .with_context(|| {
             format!("failed to revoke grant for plugin {plugin} on identity {identity}")
         })?;
-    match format {
-        Format::Json => output::print_json(&resp),
-        Format::Table => output::print_success(&format!(
-            "Revoked plugin {plugin} from identity {identity}."
-        )),
-    }
+    print_status(
+        &resp,
+        format,
+        &format!("Revoked plugin {plugin} from identity {identity}."),
+    );
     Ok(())
 }
 
 pub fn list_tokens(client: &ApiClient, identity: &str, format: Format) -> Result<()> {
-    let resp = client
+    let raw = client
         .get(&format!("/api/v1/identities/{identity}/tokens"))
         .with_context(|| format!("failed to list tokens for identity {identity}"))?;
-    print_tokens(&resp, format);
+    if format == Format::Json {
+        output::print_json(&raw);
+        return Ok(());
+    }
+    match parse_raw::<Vec<api::IdentityTokenRecord>>(&raw) {
+        Ok(resp) => print_tokens(&resp, format),
+        Err(_) => output::print_json_table(&raw),
+    }
     Ok(())
 }
 
@@ -180,13 +198,19 @@ pub fn create_token(
         })
         .collect();
     let resp = client
-        .create_identity_api_token(identity, token_name, &permissions)
+        .create_identity_api_token(
+            identity,
+            &api::IdentityTokenCreateRequest {
+                name: token_name.to_string(),
+                permissions,
+            },
+        )
         .with_context(|| format!("failed to create token for identity {identity}"))?;
 
     match format {
         Format::Json => output::print_json(&resp),
         Format::Table => {
-            if let Some(token) = resp["token"].as_str() {
+            if let Some(token) = resp.token.as_deref() {
                 output::print_success("Token created. Save it now; it won't be shown again.");
                 println!("{token}");
             } else {
@@ -202,47 +226,50 @@ pub fn revoke_token(client: &ApiClient, identity: &str, id: &str, format: Format
     let resp = client
         .revoke_identity_api_token(identity, id)
         .with_context(|| format!("failed to revoke token {id} for identity {identity}"))?;
-
-    match format {
-        Format::Json => output::print_json(&resp),
-        Format::Table => {
-            output::print_success(&format!("Token {id} for identity {identity} revoked."))
-        }
-    }
-
+    print_status(
+        &resp,
+        format,
+        &format!("Token {id} for identity {identity} revoked."),
+    );
     Ok(())
 }
 
-fn print_identity(value: &serde_json::Value, format: Format) {
+fn print_status(value: &api::StatusResponse, format: Format, table_message: &str) {
+    match format {
+        Format::Json => output::print_json(value),
+        Format::Table => output::print_success(table_message),
+    }
+}
+
+fn print_identity(value: &api::IdentityRecord, format: Format) {
     match format {
         Format::Json => output::print_json(value),
         Format::Table => {
             let row = vec![vec![
-                value["id"].as_str().unwrap_or("-").to_string(),
-                value["displayName"].as_str().unwrap_or("-").to_string(),
-                value["role"].as_str().unwrap_or("-").to_string(),
-                value["createdAt"].as_str().unwrap_or("-").to_string(),
-                value["updatedAt"].as_str().unwrap_or("-").to_string(),
+                value.id.clone(),
+                value.display_name.clone(),
+                value.role.clone(),
+                value.created_at.clone(),
+                value.updated_at.clone(),
             ]];
             output::print_table(&["ID", "Name", "Role", "Created", "Updated"], &row);
         }
     }
 }
 
-fn print_identities(value: &serde_json::Value, format: Format) {
+fn print_identities(value: &[api::IdentityRecord], format: Format) {
     match format {
         Format::Json => output::print_json(value),
         Format::Table => {
-            let items = value.as_array().unwrap_or(&Vec::new()).clone();
-            let rows: Vec<Vec<String>> = items
+            let rows: Vec<Vec<String>> = value
                 .iter()
                 .map(|item| {
                     vec![
-                        item["id"].as_str().unwrap_or("-").to_string(),
-                        item["displayName"].as_str().unwrap_or("-").to_string(),
-                        item["role"].as_str().unwrap_or("-").to_string(),
-                        item["createdAt"].as_str().unwrap_or("-").to_string(),
-                        item["updatedAt"].as_str().unwrap_or("-").to_string(),
+                        item.id.clone(),
+                        item.display_name.clone(),
+                        item.role.clone(),
+                        item.created_at.clone(),
+                        item.updated_at.clone(),
                     ]
                 })
                 .collect();
@@ -251,36 +278,35 @@ fn print_identities(value: &serde_json::Value, format: Format) {
     }
 }
 
-fn print_member(value: &serde_json::Value, format: Format) {
+fn print_member(value: &api::IdentityMemberRecord, format: Format) {
     match format {
         Format::Json => output::print_json(value),
         Format::Table => {
             let row = vec![vec![
-                value["subjectId"].as_str().unwrap_or("-").to_string(),
-                value["email"].as_str().unwrap_or("-").to_string(),
-                value["role"].as_str().unwrap_or("-").to_string(),
-                value["createdAt"].as_str().unwrap_or("-").to_string(),
-                value["updatedAt"].as_str().unwrap_or("-").to_string(),
+                value.subject_id.clone(),
+                value.email.clone(),
+                value.role.clone(),
+                value.created_at.clone(),
+                value.updated_at.clone(),
             ]];
             output::print_table(&["Subject ID", "Email", "Role", "Created", "Updated"], &row);
         }
     }
 }
 
-fn print_members(value: &serde_json::Value, format: Format) {
+fn print_members(value: &[api::IdentityMemberRecord], format: Format) {
     match format {
         Format::Json => output::print_json(value),
         Format::Table => {
-            let items = value.as_array().unwrap_or(&Vec::new()).clone();
-            let rows: Vec<Vec<String>> = items
+            let rows: Vec<Vec<String>> = value
                 .iter()
                 .map(|item| {
                     vec![
-                        item["subjectId"].as_str().unwrap_or("-").to_string(),
-                        item["email"].as_str().unwrap_or("-").to_string(),
-                        item["role"].as_str().unwrap_or("-").to_string(),
-                        item["createdAt"].as_str().unwrap_or("-").to_string(),
-                        item["updatedAt"].as_str().unwrap_or("-").to_string(),
+                        item.subject_id.clone(),
+                        item.email.clone(),
+                        item.role.clone(),
+                        item.created_at.clone(),
+                        item.updated_at.clone(),
                     ]
                 })
                 .collect();
@@ -292,36 +318,33 @@ fn print_members(value: &serde_json::Value, format: Format) {
     }
 }
 
-fn print_grant(value: &serde_json::Value, format: Format) {
+fn print_grant(value: &api::IdentityGrantRecord, format: Format) {
     match format {
         Format::Json => output::print_json(value),
         Format::Table => {
-            let operations = render_operations_cell(value.get("operations"));
             let row = vec![vec![
-                value["plugin"].as_str().unwrap_or("-").to_string(),
-                operations,
-                value["createdAt"].as_str().unwrap_or("-").to_string(),
-                value["updatedAt"].as_str().unwrap_or("-").to_string(),
+                value.plugin.clone(),
+                render_operations_cell(Some(value.operations.as_slice())),
+                value.created_at.clone(),
+                value.updated_at.clone(),
             ]];
             output::print_table(&["Plugin", "Operations", "Created", "Updated"], &row);
         }
     }
 }
 
-fn print_grants(value: &serde_json::Value, format: Format) {
+fn print_grants(value: &[api::IdentityGrantRecord], format: Format) {
     match format {
         Format::Json => output::print_json(value),
         Format::Table => {
-            let items = value.as_array().unwrap_or(&Vec::new()).clone();
-            let rows: Vec<Vec<String>> = items
+            let rows: Vec<Vec<String>> = value
                 .iter()
                 .map(|item| {
-                    let operations = render_operations_cell(item.get("operations"));
                     vec![
-                        item["plugin"].as_str().unwrap_or("-").to_string(),
-                        operations,
-                        item["createdAt"].as_str().unwrap_or("-").to_string(),
-                        item["updatedAt"].as_str().unwrap_or("-").to_string(),
+                        item.plugin.clone(),
+                        render_operations_cell(Some(item.operations.as_slice())),
+                        item.created_at.clone(),
+                        item.updated_at.clone(),
                     ]
                 })
                 .collect();
@@ -330,14 +353,16 @@ fn print_grants(value: &serde_json::Value, format: Format) {
     }
 }
 
-fn render_operations_cell(operations: Option<&serde_json::Value>) -> String {
-    match operations.and_then(|value| value.as_array()) {
+fn render_operations_cell(operations: Option<&[String]>) -> String {
+    match operations {
         None => "all".to_string(),
-        Some(ops) if ops.is_empty() => "all".to_string(),
+        Some([]) => "all".to_string(),
         Some(ops) => {
             let joined = ops
                 .iter()
-                .filter_map(|op| op.as_str())
+                .map(String::as_str)
+                .map(str::trim)
+                .filter(|op| !op.is_empty())
                 .collect::<Vec<_>>()
                 .join(",");
             if joined.is_empty() {
@@ -349,24 +374,19 @@ fn render_operations_cell(operations: Option<&serde_json::Value>) -> String {
     }
 }
 
-fn print_tokens(value: &serde_json::Value, format: Format) {
+fn print_tokens(value: &[api::IdentityTokenRecord], format: Format) {
     match format {
         Format::Json => output::print_json(value),
         Format::Table => {
-            let items = value.as_array().unwrap_or(&Vec::new()).clone();
-            let rows: Vec<Vec<String>> = items
+            let rows: Vec<Vec<String>> = value
                 .iter()
                 .map(|item| {
                     vec![
-                        item["id"].as_str().unwrap_or("-").to_string(),
-                        item["name"].as_str().unwrap_or("-").to_string(),
-                        format_permissions(item),
-                        string_field(item, &["createdAt", "created_at"])
-                            .unwrap_or("-")
-                            .to_string(),
-                        string_field(item, &["expiresAt", "expires_at"])
-                            .unwrap_or("never")
-                            .to_string(),
+                        item.id.clone(),
+                        item.name.clone(),
+                        format_permissions(Some(item.permissions.as_slice())),
+                        item.created_at.clone(),
+                        display_cell(item.expires_at.as_deref(), "never"),
                     ]
                 })
                 .collect();
@@ -375,42 +395,50 @@ fn print_tokens(value: &serde_json::Value, format: Format) {
     }
 }
 
-fn string_field<'a>(value: &'a serde_json::Value, keys: &[&str]) -> Option<&'a str> {
-    keys.iter().find_map(|key| value[*key].as_str())
-}
-
-fn format_permissions(value: &serde_json::Value) -> String {
-    let Some(permissions) = value["permissions"].as_array() else {
+fn format_permissions(permissions: Option<&[TokenPermission]>) -> String {
+    let Some(permissions) = permissions else {
         return "-".to_string();
     };
     if permissions.is_empty() {
         return "-".to_string();
     }
-    permissions
+
+    let rendered = permissions
         .iter()
         .filter_map(|permission| {
-            let plugin = permission["plugin"].as_str()?;
-            let operations: Vec<&str> = permission["operations"]
-                .as_array()
-                .map(|items| items.iter().filter_map(|item| item.as_str()).collect())
-                .unwrap_or_default();
+            let plugin = permission.plugin.trim();
+            if plugin.is_empty() {
+                return None;
+            }
+            let operations = permission
+                .operations
+                .iter()
+                .map(String::as_str)
+                .map(str::trim)
+                .filter(|operation| !operation.is_empty())
+                .collect::<Vec<_>>();
             if operations.is_empty() {
                 Some(plugin.to_string())
             } else {
                 Some(format!("{plugin}:{}", operations.join(",")))
             }
         })
-        .collect::<Vec<_>>()
-        .join("; ")
-}
-fn encode_path_segment(value: &str) -> String {
-    let mut url = url::Url::parse("https://managed-identities.invalid/").expect("static URL");
-    {
-        let mut segments = url
-            .path_segments_mut()
-            .expect("static URL should support path segments");
-        segments.pop_if_empty();
-        segments.push(value);
+        .collect::<Vec<_>>();
+
+    if rendered.is_empty() {
+        "-".to_string()
+    } else {
+        rendered.join("; ")
     }
-    url.path().trim_start_matches('/').to_string()
+}
+
+fn parse_raw<T>(value: &serde_json::Value) -> Result<T, serde_json::Error>
+where
+    T: DeserializeOwned,
+{
+    serde_json::from_value(value.clone())
+}
+
+fn display_cell(value: Option<&str>, fallback: &str) -> String {
+    value.unwrap_or(fallback).to_string()
 }

--- a/gestalt/cli/src/output.rs
+++ b/gestalt/cli/src/output.rs
@@ -6,6 +6,7 @@ use comfy_table::{
     modifiers::UTF8_ROUND_CORNERS,
     presets::{UTF8_BORDERS_ONLY, UTF8_FULL_CONDENSED},
 };
+use serde::Serialize;
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq, clap::ValueEnum)]
 pub enum Format {
@@ -13,8 +14,13 @@ pub enum Format {
     Table,
 }
 
-pub fn print_json(value: &serde_json::Value) {
-    let output = serde_json::to_string_pretty(value).unwrap_or_else(|_| value.to_string());
+pub fn print_json<T>(value: &T)
+where
+    T: Serialize + ?Sized,
+{
+    let output = serde_json::to_string_pretty(value)
+        .or_else(|_| serde_json::to_string(value))
+        .unwrap_or_else(|_| "null".to_string());
     println!("{}", output);
 }
 

--- a/gestalt/cli/tests/identities_cli.rs
+++ b/gestalt/cli/tests/identities_cli.rs
@@ -57,6 +57,154 @@ fn test_cli_creates_identity() {
 }
 
 #[test]
+fn test_cli_gets_identity() {
+    let mut server = Server::new();
+    let _get = authed_json_mock!(server, Method::GET, "/api/v1/identities/id-1", StatusCode::OK)
+        .with_body(
+            r#"{"id":"id-1","displayName":"Release Bot","role":"admin","createdAt":"2026-04-15T00:00:00Z","updatedAt":"2026-04-16T00:00:00Z"}"#,
+        )
+        .create();
+
+    let home = tempfile::tempdir().unwrap();
+    cli_command_for_server(home.path(), &server)
+        .args(["identities", "get", "id-1"])
+        .assert()
+        .success()
+        .stdout(predicate::str::contains("Release Bot"))
+        .stdout(predicate::str::contains("2026-04-16T00:00:00Z"));
+}
+
+#[test]
+fn test_cli_get_identity_preserves_provider_passthrough_json() {
+    let mut server = Server::new();
+    let _get = authed_json_mock!(
+        server,
+        Method::GET,
+        "/api/v1/identities/read",
+        StatusCode::OK
+    )
+    .with_body(r#"{"operation":"read","ok":true}"#)
+    .create();
+
+    let home = tempfile::tempdir().unwrap();
+    cli_command_for_server(home.path(), &server)
+        .args(["--format", "json", "identities", "get", "read"])
+        .assert()
+        .success()
+        .stdout(predicate::str::contains(r#""operation": "read""#))
+        .stdout(predicate::str::contains(r#""ok": true"#));
+}
+
+#[test]
+fn test_cli_updates_identity() {
+    let mut server = Server::new();
+    let _update = authed_json_mock!(server, Method::PATCH, "/api/v1/identities/id-1", StatusCode::OK)
+        .match_header(header::CONTENT_TYPE.as_str(), http::APPLICATION_JSON)
+        .match_body(Matcher::JsonString(
+            r#"{"displayName":"Release Automation"}"#.to_string(),
+        ))
+        .with_body(
+            r#"{"id":"id-1","displayName":"Release Automation","role":"admin","createdAt":"2026-04-15T00:00:00Z","updatedAt":"2026-04-16T00:00:00Z"}"#,
+        )
+        .create();
+
+    let home = tempfile::tempdir().unwrap();
+    cli_command_for_server(home.path(), &server)
+        .args([
+            "--format",
+            "json",
+            "identities",
+            "update",
+            "id-1",
+            "--name",
+            "Release Automation",
+        ])
+        .assert()
+        .success()
+        .stdout(predicate::str::contains(
+            r#""displayName": "Release Automation""#,
+        ))
+        .stdout(predicate::str::contains(
+            r#""updatedAt": "2026-04-16T00:00:00Z""#,
+        ));
+}
+
+#[test]
+fn test_cli_update_identity_preserves_provider_passthrough_json() {
+    let mut server = Server::new();
+    let _update = authed_json_mock!(
+        server,
+        Method::PATCH,
+        "/api/v1/identities/update",
+        StatusCode::OK
+    )
+    .match_header(header::CONTENT_TYPE.as_str(), http::APPLICATION_JSON)
+    .match_body(Matcher::JsonString(
+        r#"{"displayName":"Updated"}"#.to_string(),
+    ))
+    .with_body(r#"{"operation":"update","accepted":true}"#)
+    .create();
+
+    let home = tempfile::tempdir().unwrap();
+    cli_command_for_server(home.path(), &server)
+        .args([
+            "--format",
+            "json",
+            "identities",
+            "update",
+            "update",
+            "--name",
+            "Updated",
+        ])
+        .assert()
+        .success()
+        .stdout(predicate::str::contains(r#""operation": "update""#))
+        .stdout(predicate::str::contains(r#""accepted": true"#));
+}
+
+#[test]
+fn test_cli_deletes_identity() {
+    let mut server = Server::new();
+    let _delete = authed_json_mock!(
+        server,
+        Method::DELETE,
+        "/api/v1/identities/id-1",
+        StatusCode::OK
+    )
+    .with_body(r#"{"status":"deleted"}"#)
+    .create();
+
+    let home = tempfile::tempdir().unwrap();
+    cli_command_for_server(home.path(), &server)
+        .args(["identities", "delete", "id-1"])
+        .assert()
+        .success()
+        .stderr(predicate::str::contains("Identity id-1 deleted."));
+}
+
+#[test]
+fn test_cli_delete_identity_falls_back_for_provider_passthrough_table_output() {
+    let mut server = Server::new();
+    let _delete = authed_json_mock!(
+        server,
+        Method::DELETE,
+        "/api/v1/identities/delete",
+        StatusCode::OK
+    )
+    .with_body(r#"{"operation":"delete","ok":true}"#)
+    .create();
+
+    let home = tempfile::tempdir().unwrap();
+    cli_command_for_server(home.path(), &server)
+        .args(["identities", "delete", "delete"])
+        .assert()
+        .success()
+        .stdout(predicate::str::contains("operation"))
+        .stdout(predicate::str::contains("delete"))
+        .stderr(predicate::str::contains("Identity delete deleted.").not());
+}
+
+#[test]
 fn test_cli_adds_identity_member() {
     let mut server = Server::new();
     let _member = authed_json_mock!(
@@ -185,6 +333,24 @@ fn test_cli_lists_explicit_empty_grant_operations_as_plugin_wide_access() {
 }
 
 #[test]
+fn test_cli_identities_help_lists_first_class_subcommands() {
+    let home = tempfile::tempdir().unwrap();
+    cli_command(home.path())
+        .args(["identities", "--help"])
+        .assert()
+        .success()
+        .stdout(predicate::str::contains(
+            "Manage workspace-owned identities",
+        ))
+        .stdout(predicate::str::contains("list"))
+        .stdout(predicate::str::contains("get"))
+        .stdout(predicate::str::contains("update"))
+        .stdout(predicate::str::contains("members"))
+        .stdout(predicate::str::contains("grants"))
+        .stdout(predicate::str::contains("tokens"));
+}
+
+#[test]
 fn test_cli_lists_identity_tokens() {
     let mut server = Server::new();
     let _tokens = authed_json_mock!(
@@ -207,6 +373,57 @@ fn test_cli_lists_identity_tokens() {
         .stdout(predicate::str::contains("github"))
         .stdout(predicate::str::contains("slack:chat.po"))
         .stdout(predicate::str::contains("channels.hi"));
+}
+
+#[test]
+fn test_cli_list_identity_tokens_json_preserves_scopes() {
+    let mut server = Server::new();
+    let _tokens = authed_json_mock!(
+        server,
+        Method::GET,
+        "/api/v1/identities/agent-1/tokens",
+        StatusCode::OK
+    )
+    .with_body(
+        r#"[{"id":"itok-1","name":"deploy-bot","scopes":"github slack","permissions":[{"plugin":"github"}],"createdAt":"2026-04-15T00:00:00Z"}]"#,
+    )
+    .create();
+
+    let home = tempfile::tempdir().unwrap();
+    cli_command_for_server(home.path(), &server)
+        .args([
+            "--format",
+            "json",
+            "identities",
+            "tokens",
+            "list",
+            "agent-1",
+        ])
+        .assert()
+        .success()
+        .stdout(predicate::str::contains(r#""scopes": "github slack""#))
+        .stdout(predicate::str::contains(r#""plugin": "github""#));
+}
+
+#[test]
+fn test_cli_list_identity_tokens_falls_back_for_provider_passthrough_table_output() {
+    let mut server = Server::new();
+    let _tokens = authed_json_mock!(
+        server,
+        Method::GET,
+        "/api/v1/identities/agent-1/tokens",
+        StatusCode::OK
+    )
+    .with_body(r#"{"operation":"list_tokens","ok":true}"#)
+    .create();
+
+    let home = tempfile::tempdir().unwrap();
+    cli_command_for_server(home.path(), &server)
+        .args(["identities", "tokens", "list", "agent-1"])
+        .assert()
+        .success()
+        .stdout(predicate::str::contains("operation"))
+        .stdout(predicate::str::contains("list_tokens"));
 }
 
 #[test]


### PR DESCRIPTION
## Summary

This PR makes the existing top-level `gestalt identities` command an official first-class CLI surface instead of an implemented-but-underdocumented feature.

It does three things:
- replaces ad hoc identity response handling in the Rust CLI with typed request/response models at the API boundary
- expands the existing integration-test slice for identities without adding redundant new unit-test-only coverage
- documents `gestalt identities` in the public client CLI docs, Docker docs, and README with exact examples

## Public interfaces

Top-level CLI:
```text
gestalt identities list
gestalt identities create --name <display-name>
gestalt identities get <identity-id>
gestalt identities update <identity-id> --name <display-name>
gestalt identities delete <identity-id>
```

Members:
```text
gestalt identities members list <identity-id>
gestalt identities members add <identity-id> <email> --role <viewer|editor|admin>
gestalt identities members update <identity-id> <email> --role <viewer|editor|admin>
gestalt identities members remove <identity-id> <email>
```

Grants:
```text
gestalt identities grants list <identity-id>
gestalt identities grants set <identity-id> <plugin> [--operation <operation>]...
gestalt identities grants revoke <identity-id> <plugin>
```

Tokens:
```text
gestalt identities tokens list <identity-id>
gestalt identities tokens create <identity-id> --name <token-name> --permission <plugin[:op1,op2]>...
gestalt identities tokens revoke <identity-id> <token-id>
```

Typed CLI models:
```rust
pub struct IdentityDisplayNameRequest { pub display_name: String }
pub struct IdentityMemberRequest { pub email: String, pub role: String }
pub struct IdentityGrantRequest { pub operations: Vec<String> }
pub struct IdentityTokenCreateRequest { pub name: String, pub permissions: Vec<TokenPermission> }

pub struct IdentityRecord { ... }
pub struct IdentityMemberRecord { ... }
pub struct IdentityGrantRecord { ... }
pub struct IdentityTokenRecord { ... }
pub struct IdentityTokenCreateResponse { ... }
pub struct StatusResponse { ... }
```

## Examples

CLI:
```sh
gestalt identities create --name "Release Bot"
gestalt identities members add <identity-id> deployer@example.com --role editor
gestalt identities grants set <identity-id> github --operation issues.list
gestalt identities tokens create <identity-id> --name ci --permission github:issues.list
```

Docker image:
```sh
docker run --rm \
  -e GESTALT_URL=https://gestalt.example.com \
  -e GESTALT_API_KEY=gst_api_... \
  valontechnologies/gestalt:latest \
  identities list
```

## Implementation notes

- `gestalt/cli/src/api.rs` now owns the identity request/response models and explicit identity API helpers.
- `gestalt/cli/src/commands/identities.rs` now uses those typed helpers instead of manual `serde_json::Value` request construction and indexing.
- member email path-segment encoding moved down into the API client so the command layer stays resource-oriented.
- `gestalt/cli/src/output.rs` now allows `print_json` for any `Serialize`, which lets the typed identity responses print directly without converting back to raw JSON values.
- integration coverage in `gestalt/cli/tests/identities_cli.rs` now covers `get`, `update`, `delete`, and `identities --help`, extending the existing mockito-based test style.
- public client docs now present `identities` alongside `plugins`, `workflows`, and `tokens`.

## Verification

```sh
cd gestalt && cargo test --test identities_cli
cd gestalt && cargo test -p gestalt
cd gestalt && cargo fmt --all --check
cd docs && npm run typecheck
cd docs && npm run build
git diff --check
```