### PR TITLE
Collapse managed-identity authz onto the existing workload path

### DIFF
--- a/gestaltd/core/types.go
+++ b/gestaltd/core/types.go
@@ -57,8 +57,7 @@ const (
 )
 
 const (
-	APITokenKindAPI      = "api"
-	APITokenKindWorkload = "workload"
+	APITokenKindAPI = "api"
 )
 
 type ManagedIdentity struct {

--- a/gestaltd/internal/authorization/authorizer.go
+++ b/gestaltd/internal/authorization/authorizer.go
@@ -190,9 +190,6 @@ func (a *Authorizer) IsWorkload(p *principal.Principal) bool {
 }
 
 func (a *Authorizer) AllowProvider(ctx context.Context, p *principal.Principal, provider string) bool {
-	if a.isManagedIdentityPrincipal(p) {
-		return a.allowManagedIdentityProvider(p, provider)
-	}
 	if principal.IsSystemPrincipal(p) {
 		return principal.AllowsProviderPermission(p, provider)
 	}
@@ -200,53 +197,33 @@ func (a *Authorizer) AllowProvider(ctx context.Context, p *principal.Principal, 
 		_, allowed := a.ResolveAccess(ctx, p, provider)
 		return allowed
 	}
-	_, ok := a.bindingForSubject(p, provider)
+	_, ok := a.bindingForPrincipal(p, provider)
 	return ok
 }
 
 func (a *Authorizer) AllowOperation(ctx context.Context, p *principal.Principal, provider, operation string) bool {
-	if a.isManagedIdentityPrincipal(p) {
-		return a.allowManagedIdentityProvider(p, provider) && principal.AllowsOperationPermission(p, provider, operation)
-	}
 	if principal.IsSystemPrincipal(p) {
 		return principal.AllowsOperationPermission(p, provider, operation)
 	}
 	if !a.IsWorkload(p) {
 		return a.AllowProvider(ctx, p, provider)
 	}
-	binding, ok := a.bindingForSubject(p, provider)
+	binding, ok := a.bindingForPrincipal(p, provider)
 	if !ok {
 		return false
+	}
+	if len(binding.Allow) == 0 {
+		return principal.AllowsOperationPermission(p, provider, operation)
 	}
 	_, ok = binding.Allow[operation]
 	return ok
 }
 
 func (a *Authorizer) Binding(p *principal.Principal, provider string) (CredentialBinding, bool) {
-	if a.isManagedIdentityPrincipal(p) {
-		if !a.allowManagedIdentityProvider(p, provider) {
-			return CredentialBinding{}, false
-		}
-		switch core.NormalizeConnectionMode(a.providerModes[provider]) {
-		case core.ConnectionModeNone:
-			return CredentialBinding{Mode: core.ConnectionModeNone}, true
-		case core.ConnectionModeUser:
-			subjectID := principal.EffectiveCredentialSubjectID(p)
-			if subjectID == "" {
-				return CredentialBinding{}, false
-			}
-			return CredentialBinding{
-				Mode:                core.ConnectionModeUser,
-				CredentialSubjectID: subjectID,
-			}, true
-		default:
-			return CredentialBinding{}, false
-		}
-	}
 	if !a.IsWorkload(p) {
 		return CredentialBinding{}, false
 	}
-	binding, ok := a.bindingForSubject(p, provider)
+	binding, ok := a.bindingForPrincipal(p, provider)
 	if !ok {
 		return CredentialBinding{}, false
 	}
@@ -257,19 +234,21 @@ func (a *Authorizer) ResolveAccess(_ context.Context, p *principal.Principal, pr
 	if a == nil {
 		return AccessContext{}, true
 	}
-	if a.isManagedIdentityPrincipal(p) {
-		return AccessContext{}, a.allowManagedIdentityProvider(p, provider)
-	}
 	if principal.IsSystemPrincipal(p) {
 		return AccessContext{}, principal.AllowsProviderPermission(p, provider)
 	}
-	policyName := strings.TrimSpace(a.providerPolicies[provider])
 	if a.IsWorkload(p) {
-		if policyName == "" {
-			return AccessContext{}, false
+		if _, ok := a.bindingForSubject(p, provider); ok {
+			policyName := strings.TrimSpace(a.providerPolicies[provider])
+			if policyName == "" {
+				return AccessContext{}, false
+			}
+			return AccessContext{Policy: policyName}, false
 		}
-		return AccessContext{Policy: policyName}, false
+		_, ok := a.bindingForPrincipal(p, provider)
+		return AccessContext{}, ok
 	}
+	policyName := strings.TrimSpace(a.providerPolicies[provider])
 	if policyName == "" {
 		return AccessContext{}, true
 	}
@@ -417,9 +396,6 @@ func (a *Authorizer) ResolveAdminAccess(_ context.Context, p *principal.Principa
 }
 
 func (a *Authorizer) AllowCatalogOperation(ctx context.Context, p *principal.Principal, provider string, op catalog.CatalogOperation) bool {
-	if a.isManagedIdentityPrincipal(p) {
-		return a.allowManagedIdentityProvider(p, provider) && principal.AllowsOperationPermission(p, provider, op.ID)
-	}
 	if principal.IsSystemPrincipal(p) {
 		return principal.AllowsOperationPermission(p, provider, op.ID)
 	}
@@ -446,6 +422,44 @@ func (a *Authorizer) AllowCatalogOperation(ctx context.Context, p *principal.Pri
 		}
 	}
 	return false
+}
+
+func (a *Authorizer) bindingForPrincipal(p *principal.Principal, provider string) (WorkloadProviderBinding, bool) {
+	if !a.IsWorkload(p) {
+		return WorkloadProviderBinding{}, false
+	}
+	if binding, ok := a.bindingForSubject(p, provider); ok {
+		return binding, true
+	}
+	if a == nil || p == nil || principal.ManagedIdentityIDFromSubjectID(strings.TrimSpace(p.SubjectID)) == "" {
+		return WorkloadProviderBinding{}, false
+	}
+	if !principal.AllowsProviderPermission(p, provider) {
+		return WorkloadProviderBinding{}, false
+	}
+	mode, ok := a.providerModes[provider]
+	if !ok {
+		return WorkloadProviderBinding{}, false
+	}
+	switch core.NormalizeConnectionMode(mode) {
+	case core.ConnectionModeNone:
+		return WorkloadProviderBinding{
+			CredentialBinding: CredentialBinding{Mode: core.ConnectionModeNone},
+		}, true
+	case core.ConnectionModeUser:
+		subjectID := principal.EffectiveCredentialSubjectID(p)
+		if subjectID == "" {
+			return WorkloadProviderBinding{}, false
+		}
+		return WorkloadProviderBinding{
+			CredentialBinding: CredentialBinding{
+				Mode:                core.ConnectionModeUser,
+				CredentialSubjectID: subjectID,
+			},
+		}, true
+	default:
+		return WorkloadProviderBinding{}, false
+	}
 }
 
 func (a *Authorizer) bindingForSubject(p *principal.Principal, provider string) (WorkloadProviderBinding, bool) {
@@ -534,29 +548,6 @@ func normalizeAllowedOperations(ops []string) map[string]struct{} {
 		allowed[name] = struct{}{}
 	}
 	return allowed
-}
-
-func (a *Authorizer) isManagedIdentityPrincipal(p *principal.Principal) bool {
-	return a.IsWorkload(p) && principal.ManagedIdentityIDFromSubjectID(strings.TrimSpace(p.SubjectID)) != ""
-}
-
-func (a *Authorizer) allowManagedIdentityProvider(p *principal.Principal, provider string) bool {
-	if a == nil || p == nil {
-		return false
-	}
-	if !principal.AllowsProviderPermission(p, provider) {
-		return false
-	}
-	mode, ok := a.providerModes[provider]
-	if !ok {
-		return false
-	}
-	switch core.NormalizeConnectionMode(mode) {
-	case core.ConnectionModeNone, core.ConnectionModeUser:
-		return true
-	default:
-		return false
-	}
 }
 
 func providerMode(provider string, pluginDefs map[string]*config.ProviderEntry, providers *registry.ProviderMap[core.Provider]) (core.ConnectionMode, bool, error) {

--- a/gestaltd/internal/authorization/provider_backed.go
+++ b/gestaltd/internal/authorization/provider_backed.go
@@ -212,7 +212,7 @@ func (a *ProviderBackedAuthorizer) AllowProvider(ctx context.Context, p *princip
 	if a == nil {
 		return true
 	}
-	if a.base.IsWorkload(p) || a.base.isManagedIdentityPrincipal(p) || principal.IsSystemPrincipal(p) {
+	if a.base.IsWorkload(p) || principal.IsSystemPrincipal(p) {
 		return a.base.AllowProvider(ctx, p, provider)
 	}
 	_, allowed := a.ResolveAccess(ctx, p, provider)
@@ -223,7 +223,7 @@ func (a *ProviderBackedAuthorizer) AllowOperation(ctx context.Context, p *princi
 	if a == nil {
 		return true
 	}
-	if a.base.IsWorkload(p) || a.base.isManagedIdentityPrincipal(p) || principal.IsSystemPrincipal(p) {
+	if a.base.IsWorkload(p) || principal.IsSystemPrincipal(p) {
 		return a.base.AllowOperation(ctx, p, provider, operation)
 	}
 	return a.AllowProvider(ctx, p, provider)
@@ -240,7 +240,7 @@ func (a *ProviderBackedAuthorizer) ResolveAccess(ctx context.Context, p *princip
 	if a == nil {
 		return AccessContext{}, true
 	}
-	if a.base.isManagedIdentityPrincipal(p) || a.base.IsWorkload(p) || principal.IsSystemPrincipal(p) {
+	if a.base.IsWorkload(p) || principal.IsSystemPrincipal(p) {
 		return a.base.ResolveAccess(ctx, p, provider)
 	}
 
@@ -365,7 +365,7 @@ func (a *ProviderBackedAuthorizer) AllowCatalogOperation(ctx context.Context, p 
 	if a == nil {
 		return true
 	}
-	if a.base.IsWorkload(p) || a.base.isManagedIdentityPrincipal(p) || principal.IsSystemPrincipal(p) {
+	if a.base.IsWorkload(p) || principal.IsSystemPrincipal(p) {
 		return a.base.AllowCatalogOperation(ctx, p, provider, op)
 	}
 


### PR DESCRIPTION
## Summary
This PR deletes the redundant managed-identity-only authorization branch and collapses it onto the existing external non-user path that `main` already uses today.

It does **not** collapse external callers into `system:*`.
`system:*` remains the trusted internal lane.

## Old internal path
Managed identities and config-issued workload tokens were already both resolved as `KindWorkload` on `main`, but authorization still treated them through two separate branches:

```go
// managed identity
Authorizer.AllowProvider(...)
  -> isManagedIdentityPrincipal(...)
  -> allowManagedIdentityProvider(...)

// config workload
Authorizer.AllowProvider(...)
  -> bindingForSubject(...)

// provider-backed wrapper
ProviderBackedAuthorizer.AllowProvider(...)
  -> IsWorkload(...) || isManagedIdentityPrincipal(...)
```

## New internal path
Both external non-user cases now use one shared `KindWorkload` entry point:

```go
Authorizer.AllowProvider(...)
  -> bindingForPrincipal(...)

bindingForPrincipal(...)
  -> bindingForSubject(...)           // config-issued workload token
  -> managed_identity:* fallback     // managed-identity API token
```

The provider-backed wrapper now just checks:

```go
IsWorkload(...) || principal.IsSystemPrincipal(...)
```

## Examples
Config-issued token example:

```go
subject_id = "workload:roadmap-sync"
```

This still resolves through `bindingForSubject(...)` and keeps its configured provider allowlist.

Managed-identity API token example:

```go
subject_id = "managed_identity:mi_123"
```

This now enters through the same `KindWorkload` path and falls back to the managed-identity binding logic inside `bindingForPrincipal(...)`, preserving:
- provider permission checks
- operation permission checks
- deny-by-default when `providerModes[provider]` has no entry

## What changed
- deleted `isManagedIdentityPrincipal(...)`
- deleted `allowManagedIdentityProvider(...)`
- added one shared helper: `bindingForPrincipal(...)`
- removed the redundant managed-identity checks from `ProviderBackedAuthorizer`
- deleted the unused `APITokenKindWorkload` constant

## Risk
Medium runtime risk, low rollout risk.

This changes shared authorization branching, but does not change storage or require a migration.

## Verification
```bash
cd gestaltd && go test ./internal/authorization ./internal/server ./internal/bootstrap ./internal/invocation ./internal/mcp
cd gestaltd && golangci-lint run ./internal/authorization ./internal/server ./internal/bootstrap ./internal/invocation ./internal/mcp
```