### PR TITLE
Require execution refs for workflow host callbacks

### DIFF
--- a/gestaltd/internal/bootstrap/bootstrap_test.go
+++ b/gestaltd/internal/bootstrap/bootstrap_test.go
@@ -45,11 +45,22 @@ import (
 	"gopkg.in/yaml.v3"
 )
 
-func explicitStartupWorkflowActor() *proto.WorkflowActor {
-	return &proto.WorkflowActor{
-		SubjectId:   "system:workflow-startup",
-		SubjectKind: "system",
+func storeWorkflowExecutionRefForTarget(t *testing.T, deps bootstrap.Deps, providerName string, target coreworkflow.Target) string {
+	t.Helper()
+	ref, err := deps.Services.WorkflowExecutionRefs.Put(context.Background(), &coreworkflow.ExecutionReference{
+		ID:           fmt.Sprintf("test:%s:%s:%s", strings.ReplaceAll(t.Name(), "/", "_"), providerName, target.Operation),
+		ProviderName: providerName,
+		Target:       target,
+		SubjectID:    "system:config",
+		Permissions: []core.AccessPermission{{
+			Plugin:     target.PluginName,
+			Operations: []string{target.Operation},
+		}},
+	})
+	if err != nil {
+		t.Fatalf("store workflow execution ref: %v", err)
 	}
+	return ref.ID
 }
 
 func bootstrapGraphQLStringPtr(value string) *string {
@@ -3074,12 +3085,16 @@ func TestBootstrapStartsWorkflowProvidersAfterInvokerIsReady(t *testing.T) {
 		}); err != nil {
 			return nil, fmt.Errorf("store identity token: %w", err)
 		}
+		executionRef := storeWorkflowExecutionRefForTarget(t, deps, name, coreworkflow.Target{
+			PluginName: "roadmap",
+			Operation:  "sync",
+		})
 		resp, err := invokeWorkflowHostCallback(t, hostServices, &proto.InvokeWorkflowOperationRequest{
 			Target: &proto.BoundWorkflowTarget{
 				PluginName: "roadmap",
 				Operation:  "sync",
 			},
-			CreatedBy: explicitStartupWorkflowActor(),
+			ExecutionRef: executionRef,
 		})
 		if err != nil {
 			return nil, fmt.Errorf("startup callback: %w", err)
@@ -3129,12 +3144,16 @@ func TestValidateStartsWorkflowProvidersAfterInvokerIsReady(t *testing.T) {
 		}); err != nil {
 			return nil, fmt.Errorf("store identity token: %w", err)
 		}
+		executionRef := storeWorkflowExecutionRefForTarget(t, deps, name, coreworkflow.Target{
+			PluginName: "roadmap",
+			Operation:  "sync",
+		})
 		resp, err := invokeWorkflowHostCallback(t, hostServices, &proto.InvokeWorkflowOperationRequest{
 			Target: &proto.BoundWorkflowTarget{
 				PluginName: "roadmap",
 				Operation:  "sync",
 			},
-			CreatedBy: explicitStartupWorkflowActor(),
+			ExecutionRef: executionRef,
 		})
 		if err != nil {
 			return nil, fmt.Errorf("startup callback: %w", err)
@@ -3153,90 +3172,63 @@ func TestValidateStartsWorkflowProvidersAfterInvokerIsReady(t *testing.T) {
 	}
 }
 
-func TestBootstrapStartupWorkflowCallbackRejectsNonStartupCreatedByForAuthorization(t *testing.T) {
+func TestBootstrapStartupWorkflowCallbackRequiresExecutionRef(t *testing.T) {
 	t.Parallel()
-	for _, tc := range []struct {
-		name  string
-		actor *proto.WorkflowActor
-	}{
-		{
-			name: "spoofed user actor",
-			actor: &proto.WorkflowActor{
-				SubjectId:   principal.UserSubjectID("spoofed-user"),
-				SubjectKind: string(principal.KindUser),
-				DisplayName: "Spoofed User",
-			},
+
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(http.StatusAccepted)
+		_, _ = w.Write([]byte(`{"ok":true}`))
+	}))
+	defer srv.Close()
+
+	cfg := workflowStartupCallbackConfig(srv.URL)
+	cfg.Plugins["roadmap"].ConnectionMode = providermanifestv1.ConnectionModeUser
+	cfg.Plugins["roadmap"].AuthorizationPolicy = "roadmap-policy"
+	cfg.Plugins["roadmap"].ResolvedManifest.Spec.Surfaces.REST.Operations[0].AllowedRoles = []string{"viewer"}
+	cfg.Authorization.Policies = map[string]config.HumanPolicyDef{
+		"roadmap-policy": {
+			Members: []config.HumanPolicyMemberDef{{
+				SubjectID: principal.UserSubjectID("viewer-user"),
+				Role:      "viewer",
+			}},
 		},
-		{
-			name: "spoofed system actor",
-			actor: &proto.WorkflowActor{
-				SubjectId:   "system:config",
-				SubjectKind: "system",
-				DisplayName: "Config",
-			},
-		},
-	} {
-		tc := tc
-		t.Run(tc.name, func(t *testing.T) {
-			t.Parallel()
-
-			srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-				w.Header().Set("Content-Type", "application/json")
-				w.WriteHeader(http.StatusAccepted)
-				_, _ = w.Write([]byte(`{"ok":true}`))
-			}))
-			defer srv.Close()
-
-			cfg := workflowStartupCallbackConfig(srv.URL)
-			cfg.Plugins["roadmap"].ConnectionMode = providermanifestv1.ConnectionModeUser
-			cfg.Plugins["roadmap"].AuthorizationPolicy = "roadmap-policy"
-			cfg.Plugins["roadmap"].ResolvedManifest.Spec.Surfaces.REST.Operations[0].AllowedRoles = []string{"viewer"}
-			cfg.Authorization.Policies = map[string]config.HumanPolicyDef{
-				"roadmap-policy": {
-					Members: []config.HumanPolicyMemberDef{{
-						SubjectID: principal.UserSubjectID("viewer-user"),
-						Role:      "viewer",
-					}},
-				},
-			}
-
-			factories := validFactories()
-			factories.Workflow = func(_ context.Context, name string, _ yaml.Node, hostServices []providerhost.HostService, deps bootstrap.Deps) (coreworkflow.Provider, error) {
-				if name != "temporal" {
-					return nil, fmt.Errorf("workflow name = %q, want %q", name, "temporal")
-				}
-				if err := deps.Services.Tokens.StoreToken(context.Background(), &core.IntegrationToken{
-					SubjectID:   principal.IdentitySubjectID(),
-					Integration: "roadmap",
-					Connection:  config.PluginConnectionName,
-					Instance:    "default",
-					AccessToken: "workflow-startup-token",
-				}); err != nil {
-					return nil, fmt.Errorf("store identity token: %w", err)
-				}
-				_, err := invokeWorkflowHostCallback(t, hostServices, &proto.InvokeWorkflowOperationRequest{
-					Target: &proto.BoundWorkflowTarget{
-						PluginName: "roadmap",
-						Operation:  "sync",
-					},
-					CreatedBy: tc.actor,
-				})
-				if err == nil {
-					return nil, fmt.Errorf("expected startup callback authorization failure")
-				}
-				if status.Code(err) != codes.InvalidArgument {
-					return nil, fmt.Errorf("startup callback status = %s, want %s", status.Code(err), codes.InvalidArgument)
-				}
-				return &stubWorkflowProvider{}, nil
-			}
-
-			result, err := bootstrap.Bootstrap(context.Background(), cfg, factories)
-			if err != nil {
-				t.Fatalf("Bootstrap: %v", err)
-			}
-			defer func() { _ = result.Close(context.Background()) }()
-		})
 	}
+
+	factories := validFactories()
+	factories.Workflow = func(_ context.Context, name string, _ yaml.Node, hostServices []providerhost.HostService, deps bootstrap.Deps) (coreworkflow.Provider, error) {
+		if name != "temporal" {
+			return nil, fmt.Errorf("workflow name = %q, want %q", name, "temporal")
+		}
+		if err := deps.Services.Tokens.StoreToken(context.Background(), &core.IntegrationToken{
+			SubjectID:   principal.IdentitySubjectID(),
+			Integration: "roadmap",
+			Connection:  config.PluginConnectionName,
+			Instance:    "default",
+			AccessToken: "workflow-startup-token",
+		}); err != nil {
+			return nil, fmt.Errorf("store identity token: %w", err)
+		}
+		_, err := invokeWorkflowHostCallback(t, hostServices, &proto.InvokeWorkflowOperationRequest{
+			Target: &proto.BoundWorkflowTarget{
+				PluginName: "roadmap",
+				Operation:  "sync",
+			},
+		})
+		if err == nil {
+			return nil, fmt.Errorf("expected startup callback execution_ref failure")
+		}
+		if status.Code(err) != codes.InvalidArgument {
+			return nil, fmt.Errorf("startup callback status = %s, want %s", status.Code(err), codes.InvalidArgument)
+		}
+		return &stubWorkflowProvider{}, nil
+	}
+
+	result, err := bootstrap.Bootstrap(context.Background(), cfg, factories)
+	if err != nil {
+		t.Fatalf("Bootstrap: %v", err)
+	}
+	defer func() { _ = result.Close(context.Background()) }()
 }
 
 func TestBootstrapConfiguredWorkflowScheduleExecutionRefInvokesPolicyProtectedPlugin(t *testing.T) {
@@ -3378,12 +3370,16 @@ func TestValidateManagedWorkflowStartupCallbackUsesPreparedProviderStub(t *testi
 				}); err != nil {
 					return nil, fmt.Errorf("store identity token: %w", err)
 				}
+				executionRef := storeWorkflowExecutionRefForTarget(t, deps, name, coreworkflow.Target{
+					PluginName: "roadmap",
+					Operation:  "sync",
+				})
 				resp, err := invokeWorkflowHostCallback(t, hostServices, &proto.InvokeWorkflowOperationRequest{
 					Target: &proto.BoundWorkflowTarget{
 						PluginName: "roadmap",
 						Operation:  "sync",
 					},
-					CreatedBy: explicitStartupWorkflowActor(),
+					ExecutionRef: executionRef,
 				})
 				if err != nil {
 					return nil, fmt.Errorf("startup callback: %w", err)
@@ -3480,17 +3476,17 @@ func TestValidateManagedWorkflowStartupInvokesMCPPassthroughPreparedProviders(t 
 				Operation:  "sync",
 			},
 		}
-		startupPrincipal := &principal.Principal{
-			SubjectID:           "system:workflow-startup",
+		configPrincipal := &principal.Principal{
+			SubjectID:           "system:config",
 			CredentialSubjectID: principal.IdentitySubjectID(),
 			TokenPermissions: principal.CompilePermissions([]core.AccessPermission{{
 				Plugin:     "roadmap",
 				Operations: []string{"sync"},
 			}}),
 		}
-		resp, err := deps.WorkflowRuntime.Invoke(principal.WithPrincipal(context.Background(), startupPrincipal), req)
+		resp, err := deps.WorkflowRuntime.Invoke(principal.WithPrincipal(context.Background(), configPrincipal), req)
 		if err != nil {
-			return nil, fmt.Errorf("startup invoke: %w", err)
+			return nil, fmt.Errorf("workflow runtime invoke: %w", err)
 		}
 		if resp.Status != http.StatusOK || resp.Body != `{}` {
 			return nil, fmt.Errorf("startup invoke response = %#v", resp)
@@ -4496,20 +4492,6 @@ func TestBootstrapSecretResolution(t *testing.T) {
 			t.Fatal("expected config workflow principal to be denied for status catalog operation")
 		}
 
-		startupPrincipal := &principal.Principal{
-			SubjectID:           "system:workflow-startup",
-			CredentialSubjectID: principal.IdentitySubjectID(),
-			TokenPermissions: principal.CompilePermissions([]core.AccessPermission{{
-				Plugin:     "roadmap",
-				Operations: []string{"status"},
-			}}),
-		}
-		if !result.Authorizer.AllowOperation(ctx, startupPrincipal, "roadmap", "status") {
-			t.Fatal("expected workflow startup principal to be allowed for roadmap.status")
-		}
-		if result.Authorizer.AllowOperation(ctx, startupPrincipal, "roadmap", "sync") {
-			t.Fatal("expected workflow startup principal to be denied for roadmap.sync")
-		}
 	})
 
 	t.Run("workload resolve access keeps policy context but does not signal provider allow", func(t *testing.T) {

--- a/gestaltd/internal/bootstrap/validate.go
+++ b/gestaltd/internal/bootstrap/validate.go
@@ -66,6 +66,7 @@ func Validate(ctx context.Context, cfg *config.Config, factories *FactoryRegistr
 		return warnings, err
 	}
 	defer func() { _ = authz.Close() }()
+	prepared.Deps.WorkflowRuntime.SetExecutionRefs(prepared.Services.WorkflowExecutionRefs)
 	sharedInvoker := invocation.NewBroker(providers, prepared.Services.Users, prepared.Services.Tokens,
 		invocation.WithAuthorizer(authz),
 		invocation.WithConnectionMapper(invocation.ConnectionMap(connMaps.APIConnection)),

--- a/gestaltd/internal/bootstrap/workflow_runtime.go
+++ b/gestaltd/internal/bootstrap/workflow_runtime.go
@@ -210,10 +210,7 @@ func (r *workflowRuntime) Invoke(ctx context.Context, req coreworkflow.InvokeOpe
 		invokeConnection = strings.TrimSpace(target.Connection)
 		invokeInstance = strings.TrimSpace(target.Instance)
 	} else if principalValue == nil || strings.TrimSpace(principalValue.SubjectID) == "" {
-		principalValue = workflowRequestPrincipal(req)
-		if principalValue == nil || strings.TrimSpace(principalValue.SubjectID) == "" {
-			return nil, fmt.Errorf("%w: workflow execution principal is required when execution_ref is omitted", invocation.ErrInternal)
-		}
+		return nil, fmt.Errorf("%w: workflow execution principal is required when execution_ref is omitted", invocation.ErrInternal)
 	}
 	if contextValue := workflowInvocationContext(req); len(contextValue) > 0 {
 		ctx = invocation.WithWorkflowContext(ctx, contextValue)
@@ -270,27 +267,14 @@ func workflowExecutionPrincipal(ref *coreworkflow.ExecutionReference) *principal
 		return nil
 	}
 	permissions := principal.CompilePermissions(ref.Permissions)
-	return principal.Canonicalize(&principal.Principal{
+	value := &principal.Principal{
 		SubjectID:        strings.TrimSpace(ref.SubjectID),
 		Scopes:           principal.PermissionPlugins(permissions),
 		TokenPermissions: permissions,
-	})
-}
-
-func workflowRequestPrincipal(req coreworkflow.InvokeOperationRequest) *principal.Principal {
-	subjectID := strings.TrimSpace(req.CreatedBy.SubjectID)
-	if subjectID != "system:workflow-startup" {
-		return nil
 	}
-	permissions := principal.CompilePermissions(workflowExecutionRefPermissionsForTarget(req.Target))
-	value := &principal.Principal{
-		SubjectID:        subjectID,
-		DisplayName:      strings.TrimSpace(req.CreatedBy.DisplayName),
-		Source:           principal.ParseSource(req.CreatedBy.AuthSource),
-		Scopes:           principal.PermissionPlugins(permissions),
-		TokenPermissions: permissions,
+	if principal.IsSystemSubjectID(value.SubjectID) {
+		value.CredentialSubjectID = principal.IdentitySubjectID()
 	}
-	value.CredentialSubjectID = principal.IdentitySubjectID()
 	return principal.Canonicalize(value)
 }
 

--- a/gestaltd/internal/bootstrap/workflow_runtime_test.go
+++ b/gestaltd/internal/bootstrap/workflow_runtime_test.go
@@ -249,21 +249,21 @@ func TestWorkflowRuntimeInvokeMergesConfiguredAndPerRunInput(t *testing.T) {
 			},
 		},
 	}
-	startupPermissions := principal.CompilePermissions(workflowExecutionRefPermissionsForTarget(req.Target))
-	startupPrincipal := principal.Canonicalize(&principal.Principal{
-		SubjectID:           "system:workflow-startup",
+	configPermissions := principal.CompilePermissions(workflowExecutionRefPermissionsForTarget(req.Target))
+	configPrincipal := principal.Canonicalize(&principal.Principal{
+		SubjectID:           "system:config",
 		CredentialSubjectID: principal.IdentitySubjectID(),
-		Scopes:              principal.PermissionPlugins(startupPermissions),
-		TokenPermissions:    startupPermissions,
+		Scopes:              principal.PermissionPlugins(configPermissions),
+		TokenPermissions:    configPermissions,
 	})
-	resp, err := runtime.Invoke(principal.WithPrincipal(context.Background(), startupPrincipal), req)
+	resp, err := runtime.Invoke(principal.WithPrincipal(context.Background(), configPrincipal), req)
 	if err != nil {
 		t.Fatalf("Invoke: %v", err)
 	}
 	if resp.Status != http.StatusAccepted || resp.Body != `{"ok":true}` {
 		t.Fatalf("response = %#v", resp)
 	}
-	if gotPrincipal == nil || gotPrincipal.SubjectID != "system:workflow-startup" {
+	if gotPrincipal == nil || gotPrincipal.SubjectID != "system:config" {
 		t.Fatalf("principal = %#v", gotPrincipal)
 	}
 	if gotPrincipal.CredentialSubjectID != principal.IdentitySubjectID() {

--- a/gestaltd/internal/bootstrap/workflow_startup_test.go
+++ b/gestaltd/internal/bootstrap/workflow_startup_test.go
@@ -222,11 +222,19 @@ func invokeWorkflowHostDuringStartup(t *testing.T, hostServices []providerhost.H
 	return proto.NewWorkflowHostClient(conn).InvokeOperation(context.Background(), req)
 }
 
-func explicitStartupWorkflowActor() *proto.WorkflowActor {
-	return &proto.WorkflowActor{
-		SubjectId:   "system:workflow-startup",
-		SubjectKind: "system",
+func storeStartupExecutionRef(t *testing.T, deps Deps, providerName string, target coreworkflow.Target) string {
+	t.Helper()
+	ref, err := deps.Services.WorkflowExecutionRefs.Put(context.Background(), &coreworkflow.ExecutionReference{
+		ID:           fmt.Sprintf("startup:%s:%s:%s", strings.ReplaceAll(t.Name(), "/", "_"), providerName, target.Operation),
+		ProviderName: providerName,
+		Target:       target,
+		SubjectID:    "system:config",
+		Permissions:  workflowExecutionRefPermissionsForTarget(target),
+	})
+	if err != nil {
+		t.Fatalf("store workflow execution ref: %v", err)
 	}
+	return ref.ID
 }
 
 func TestBootstrapWorkflowStartupCallbackWaitsForDelayedPluginProvider(t *testing.T) {
@@ -268,12 +276,16 @@ func TestBootstrapWorkflowStartupCallbackWaitsForDelayedPluginProvider(t *testin
 		}); err != nil {
 			return nil, fmt.Errorf("store identity token: %w", err)
 		}
+		executionRef := storeStartupExecutionRef(t, deps, name, coreworkflow.Target{
+			PluginName: "roadmap",
+			Operation:  "status",
+		})
 		resp, err := invokeWorkflowHostDuringStartup(t, hostServices, &proto.InvokeWorkflowOperationRequest{
 			Target: &proto.BoundWorkflowTarget{
 				PluginName: "roadmap",
 				Operation:  "status",
 			},
-			CreatedBy: explicitStartupWorkflowActor(),
+			ExecutionRef: executionRef,
 		})
 		if err != nil {
 			return nil, fmt.Errorf("startup callback: %w", err)
@@ -295,7 +307,7 @@ func TestBootstrapWorkflowStartupCallbackWaitsForDelayedPluginProvider(t *testin
 	<-result.ProvidersReady
 }
 
-func TestManagedWorkflowStartupCallbackRequiresExplicitCreatedByWithoutExecutionRef(t *testing.T) {
+func TestManagedWorkflowStartupCallbackRequiresExecutionRef(t *testing.T) {
 	t.Parallel()
 
 	bin, manifestRoot := buildModifiedExampleProviderBinary(t, func(source string) string { return source })
@@ -334,7 +346,7 @@ func TestManagedWorkflowStartupCallbackRequiresExplicitCreatedByWithoutExecution
 			},
 		})
 		if err == nil {
-			return nil, fmt.Errorf("startup callback unexpectedly succeeded without created_by")
+			return nil, fmt.Errorf("startup callback unexpectedly succeeded without execution_ref")
 		}
 		if got, want := status.Code(err), codes.InvalidArgument; got != want {
 			return nil, fmt.Errorf("startup callback code = %v, want %v (err=%v)", got, want, err)

--- a/gestaltd/internal/providerhost/workflow_host_server.go
+++ b/gestaltd/internal/providerhost/workflow_host_server.go
@@ -44,13 +44,7 @@ func (s *WorkflowHostServer) InvokeOperation(ctx context.Context, req *proto.Inv
 		return nil, status.Error(codes.InvalidArgument, "workflow invoke operation: target.operation is required")
 	}
 	if strings.TrimSpace(value.ExecutionRef) == "" {
-		subjectID := strings.TrimSpace(value.CreatedBy.SubjectID)
-		switch {
-		case subjectID == "":
-			return nil, status.Error(codes.InvalidArgument, "workflow invoke operation: created_by.subject_id is required when execution_ref is omitted")
-		case subjectID != "system:workflow-startup":
-			return nil, status.Error(codes.InvalidArgument, "workflow invoke operation: created_by.subject_id must be system:workflow-startup when execution_ref is omitted")
-		}
+		return nil, status.Error(codes.InvalidArgument, "workflow invoke operation: execution_ref is required")
 	}
 	value.ProviderName = s.providerName
 	resp, err := s.invoke(ctx, value)


### PR DESCRIPTION
## Summary
This removes the last startup-only workflow execution fallback.

Workflow host callbacks now require an explicit `execution_ref`. The runtime no longer fabricates a principal from `created_by` when `execution_ref` is omitted. Validation now wires workflow execution refs into the runtime the same way bootstrap does, and system-owned workflow execution refs resolve with the identity credential subject so they still use the identity-bound provider token path.

## New contract
Workflow host callbacks must send `execution_ref`.

Runtime invocation without `execution_ref` must already have a principal in context.

## Examples
Workflow host callback:
```go
resp, err := host.InvokeOperation(ctx, &proto.InvokeWorkflowOperationRequest{
  Target: &proto.BoundWorkflowTarget{PluginName: "roadmap", Operation: "sync"},
  ExecutionRef: executionRef,
})
```

Execution ref creation:
```go
ref, err := services.WorkflowExecutionRefs.Put(ctx, &coreworkflow.ExecutionReference{
  ID:           "startup:temporal:sync",
  ProviderName: "temporal",
  Target:       coreworkflow.Target{PluginName: "roadmap", Operation: "sync"},
  SubjectID:    "system:config",
  Permissions: []core.AccessPermission{{
    Plugin:     "roadmap",
    Operations: []string{"sync"},
  }},
})
```

Direct runtime invocation:
```go
principalValue := &principal.Principal{
  SubjectID:           "system:config",
  CredentialSubjectID: principal.IdentitySubjectID(),
  TokenPermissions: principal.CompilePermissions([]core.AccessPermission{{
    Plugin:     "roadmap",
    Operations: []string{"sync"},
  }}),
}
_, err = runtime.Invoke(principal.WithPrincipal(ctx, principalValue), coreworkflow.InvokeOperationRequest{
  ProviderName: "temporal",
  Target: coreworkflow.Target{PluginName: "roadmap", Operation: "sync"},
})
```

## Verification
- `go test ./internal/bootstrap ./internal/providerhost -count=1`
- `golangci-lint run ./internal/bootstrap ./internal/providerhost`
- `git diff --check`

## Breaking change
This intentionally removes the no-`execution_ref` startup callback path. Providers using `WorkflowHost.InvokeOperation` during startup must now pass an explicit workflow execution reference.