### PR TITLE
Document managed identity token role requirements

### DIFF
--- a/docs/content/client/cli/index.mdx
+++ b/docs/content/client/cli/index.mdx
@@ -130,6 +130,7 @@ gestalt tokens create --name automation
 | `gestalt identities tokens list\|create\|revoke ID ...` | Manage identity-owned API tokens. Repeat `--permission plugin` or `--permission plugin:op1,op2`. |
 
 Token permissions cannot exceed the identity's own grants. For grants, omitting `--operation` means plugin-wide access.
+Members with the `viewer` role can list and create identity-owned API tokens. Revoking identity-owned tokens requires `editor` or `admin` membership.
 
 ### Examples
 

--- a/docs/content/reference/http-api.mdx
+++ b/docs/content/reference/http-api.mdx
@@ -87,9 +87,9 @@ Authenticated routes accept a `session_token` cookie or an `Authorization: Beare
 | `GET` | `/api/v1/identities/{identityID}/grants` | List plugin grants for one managed identity. |
 | `PUT` | `/api/v1/identities/{identityID}/grants/{plugin}` | Upsert plugin grant operations for one managed identity. |
 | `DELETE` | `/api/v1/identities/{identityID}/grants/{plugin}` | Remove one plugin grant from a managed identity. |
-| `GET` | `/api/v1/identities/{identityID}/tokens` | List API tokens owned by one managed identity. |
-| `POST` | `/api/v1/identities/{identityID}/tokens` | Create an API token for one managed identity. |
-| `DELETE` | `/api/v1/identities/{identityID}/tokens/{id}` | Revoke one API token owned by a managed identity. |
+| `GET` | `/api/v1/identities/{identityID}/tokens` | List API tokens owned by one managed identity. Requires `viewer` membership or higher. |
+| `POST` | `/api/v1/identities/{identityID}/tokens` | Create an API token for one managed identity. Requires `viewer` membership or higher. |
+| `DELETE` | `/api/v1/identities/{identityID}/tokens/{id}` | Revoke one API token owned by a managed identity. Requires `editor` membership or higher. |
 
 ### Operator Surfaces
 

--- a/docs/dockerhub/gestalt.md
+++ b/docs/dockerhub/gestalt.md
@@ -86,6 +86,8 @@ docker run --rm \
   identities tokens create <identity-id> --name ci --permission github:issues.list
 ```
 
+Members with the `viewer` role can list and create identity-owned API tokens. Revoking identity-owned tokens requires `editor` or `admin` membership.
+
 ### Use in CI pipelines
 
 The Docker image works well in CI environments where installing the native

--- a/gestalt/cli/src/cli.rs
+++ b/gestalt/cli/src/cli.rs
@@ -342,12 +342,12 @@ impl IdentityPermissionArg {
 
 #[derive(Subcommand)]
 pub enum IdentityTokenCommands {
-    /// List API tokens for an identity
+    /// List API tokens for an identity (`viewer` or higher)
     List {
         /// Identity ID
         identity: String,
     },
-    /// Create an API token for an identity
+    /// Create an API token for an identity (`viewer` or higher)
     Create {
         /// Identity ID
         identity: String,
@@ -358,7 +358,7 @@ pub enum IdentityTokenCommands {
         #[arg(long = "permission", required = true, value_parser = IdentityPermissionArg::parse)]
         permissions: Vec<IdentityPermissionArg>,
     },
-    /// Revoke an API token owned by an identity
+    /// Revoke an API token owned by an identity (`editor` or higher)
     Revoke {
         /// Identity ID
         identity: String,

--- a/gestalt/cli/tests/identities_cli.rs
+++ b/gestalt/cli/tests/identities_cli.rs
@@ -351,6 +351,24 @@ fn test_cli_identities_help_lists_first_class_subcommands() {
 }
 
 #[test]
+fn test_cli_identity_tokens_help_calls_out_role_requirements() {
+    let home = tempfile::tempdir().unwrap();
+    cli_command(home.path())
+        .args(["identities", "tokens", "--help"])
+        .assert()
+        .success()
+        .stdout(predicate::str::contains(
+            "List API tokens for an identity (`viewer` or higher)",
+        ))
+        .stdout(predicate::str::contains(
+            "Create an API token for an identity (`viewer` or higher)",
+        ))
+        .stdout(predicate::str::contains(
+            "Revoke an API token owned by an identity (`editor` or higher)",
+        ));
+}
+
+#[test]
 fn test_cli_lists_identity_tokens() {
     let mut server = Server::new();
     let _tokens = authed_json_mock!(


### PR DESCRIPTION
## Summary

This PR documents the existing managed-identity token role semantics that are already enforced by the server but were not called out clearly in the public docs or CLI help.

It does two things:
- documents that `viewer` members can list and create identity-owned API tokens
- documents that revoking identity-owned API tokens requires `editor` or `admin` membership

## Public interfaces

CLI:
```text
gestalt identities tokens list <identity-id>          # viewer or higher
gestalt identities tokens create <identity-id>        # viewer or higher
gestalt identities tokens revoke <identity-id> <id>   # editor or higher
```

HTTP API:
```text
GET /api/v1/identities/{identityID}/tokens            # viewer or higher
POST /api/v1/identities/{identityID}/tokens           # viewer or higher
DELETE /api/v1/identities/{identityID}/tokens/{id}    # editor or higher
```

## Examples

CLI:
```sh
gestalt identities tokens list <identity-id>
gestalt identities tokens create <identity-id> --name ci --permission github:issues.list
gestalt identities tokens revoke <identity-id> <token-id>
```

HTTP:
```sh
curl -X POST "$GESTALT_URL/api/v1/identities/<identity-id>/tokens" \
  -H "Authorization: Bearer $GESTALT_API_KEY" \
  -H "Content-Type: application/json" \
  -d '{"name":"ci","permissions":[{"plugin":"github","operations":["issues.list"]}]}'
```

## Implementation notes

- updates the client CLI guide and Docker docs to call out `viewer` token creation explicitly
- updates the HTTP API reference to show the role threshold on list/create/revoke token routes
- updates `gestalt identities tokens --help` wording so the role requirement is discoverable from the binary
- extends the existing identities CLI integration test slice with a help-text assertion instead of adding new unit-test-only coverage

## Verification

```sh
cd gestalt && cargo fmt --all --check
cd gestalt && cargo test --test identities_cli
cd gestalt && cargo test -p gestalt
cd docs && npm run typecheck
cd docs && npm run build
git diff --check
```