### PR TITLE
Bump Gestalt's default UI to ui/default v0.0.1-alpha.13

### DIFF
--- a/README.md
+++ b/README.md
@@ -46,7 +46,7 @@ Start the server:
 gestaltd
 ```
 
-When no config file exists, `gestaltd` generates `~/.gestaltd/config.yaml`, starts with SQLite storage via the first-party [RelationalDB](https://github.com/valon-technologies/gestalt-providers/tree/main/indexeddb/relationaldb) provider, enables a default HTTPBin plugin, and listens on `http://localhost:8080`.
+When no config file exists, `gestaltd` generates `~/.gestaltd/config.yaml`, starts with SQLite storage via the first-party [RelationalDB](https://github.com/valon-technologies/gestalt-providers/tree/main/indexeddb/relationaldb) provider, mounts the default UI at `/`, enables a default HTTPBin plugin, and listens on `http://localhost:8080`.
 
 In a second terminal, connect the CLI to the server:
 

--- a/docs/content/client/web.mdx
+++ b/docs/content/client/web.mdx
@@ -3,12 +3,14 @@
 Open your Gestalt server's base URL in a browser to access the web client. For a local server, that's `http://localhost:8080`.
 
 The UI lets you browse plugins, connect to upstream services through OAuth or
-manual authentication, invoke operations, and manage API tokens. It uses the
-same HTTP API and authentication model as the CLI.
+manual authentication, invoke operations, and manage personal tokens plus
+managed identities. It uses the same HTTP API and authentication model as the
+CLI.
 
 ## Dashboard
 
-The dashboard shows an overview of the workspace with plugin and API token counts.
+The dashboard shows an overview of the workspace with authorization, plugin,
+and workflow counts.
 
 ![Dashboard](/images/web-dashboard.png)
 
@@ -17,12 +19,9 @@ The dashboard shows an overview of the workspace with plugin and API token count
 When the default web bundle is mounted, the workflow UI is available at
 `/workflows`.
 
-It currently focuses on workflow runs:
-it shows recent run history, supports search and status filtering, lets you
-inspect run details, and lets you cancel pending runs.
-
-Schedules and triggers are still configured through the workflow HTTP
-API, CLI, or YAML config rather than the default UI.
+It shows workflow schedules, event triggers, and recent run history in one
+place. You can inspect individual runs, filter by status, search recent
+activity, and cancel pending runs.
 
 ## Plugins
 
@@ -30,11 +29,12 @@ The plugins page lists all configured providers. Connected plugins show a green 
 
 ![Integrations](/images/web-integrations.png)
 
-## API Tokens
+## Authorization
 
-Create and revoke API tokens for programmatic access. Each token shows its name, scopes, creation date, and expiry. Tokens prefixed with `gst_api_` are shown once at creation and cannot be retrieved later.
-
-![API Tokens](/images/web-tokens.png)
+The authorization page combines personal API tokens and managed identities.
+Use it to create tokens for your current user, create shared automation
+identities, and then open those identities to manage members, grants, tokens,
+and plugin connections separately from a personal login.
 
 ## Authentication
 

--- a/gestaltd/internal/config/config.go
+++ b/gestaltd/internal/config/config.go
@@ -34,7 +34,7 @@ const (
 	DefaultIndexedDBProvider = DefaultProviderRepo + "/indexeddb/relationaldb"
 	DefaultIndexedDBVersion  = "0.0.1-alpha.1"
 	DefaultUIProvider        = DefaultProviderRepo + "/ui/default"
-	DefaultUIVersion         = "0.0.1-alpha.12"
+	DefaultUIVersion         = "0.0.1-alpha.13"
 	DefaultProviderInstance  = "default"
 )
 


### PR DESCRIPTION
## Summary
- bump the built-in default UI version from `ui/default/v0.0.1-alpha.12` to `ui/default/v0.0.1-alpha.13`
- update the top-level README bootstrap text to mention that fresh local config mounts the default UI at `/`
- refresh the public web-client docs so they match the merged authorization and workflows UI

## Release Context
- cut and pushed `ui/default/v0.0.1-alpha.13` from `valon-technologies/gestalt-providers` at `1ec222b5db845695db558daa06aba56a6480bd45`
- release workflow completed successfully for that tag

## Validation
- `go test ./internal/config ./internal/operator` (from `gestaltd/`)
