### PR TITLE
Centralize workload caller guards in server and providerhost

### DIFF
--- a/gestaltd/internal/providerhost/plugin_invoker.go
+++ b/gestaltd/internal/providerhost/plugin_invoker.go
@@ -77,19 +77,13 @@ func (s *PluginInvokerServer) Invoke(ctx context.Context, req *proto.PluginInvok
 		return nil, err
 	}
 
-	connection := strings.TrimSpace(req.GetConnection())
-	invokeCtx := restoreInvocationTokenContext(ctx, tokenCtx, connection)
+	invokeCtx, instance, err := prepareInvocationSelectors(ctx, tokenCtx, req.GetConnection(), req.GetInstance())
+	if err != nil {
+		return nil, err
+	}
 	params := map[string]any{}
 	if raw := req.GetParams(); raw != nil {
 		params = raw.AsMap()
-	}
-
-	instance := strings.TrimSpace(req.GetInstance())
-	if tokenCtx.principal != nil && tokenCtx.principal.Kind == principal.KindWorkload && (connection != "" || instance != "") {
-		return nil, status.Error(codes.PermissionDenied, "workloads may not override connection or instance bindings")
-	}
-	if instance == "" && connection == "" && shouldInheritCredentialSelectors(tokenCtx.principal) {
-		instance = tokenCtx.credential.Instance
 	}
 
 	result, err := s.invoker.Invoke(invokeCtx, tokenCtx.principal, targetPlugin, instance, targetOperation, params)
@@ -130,14 +124,9 @@ func (s *PluginInvokerServer) InvokeGraphQL(ctx context.Context, req *proto.Plug
 		return nil, status.Error(codes.Unimplemented, "plugin graphql invocation is not available")
 	}
 
-	connection := strings.TrimSpace(req.GetConnection())
-	invokeCtx := restoreInvocationTokenContext(ctx, tokenCtx, connection)
-	instance := strings.TrimSpace(req.GetInstance())
-	if tokenCtx.principal != nil && tokenCtx.principal.Kind == principal.KindWorkload && (connection != "" || instance != "") {
-		return nil, status.Error(codes.PermissionDenied, "workloads may not override connection or instance bindings")
-	}
-	if instance == "" && connection == "" && shouldInheritCredentialSelectors(tokenCtx.principal) {
-		instance = tokenCtx.credential.Instance
+	invokeCtx, instance, err := prepareInvocationSelectors(ctx, tokenCtx, req.GetConnection(), req.GetInstance())
+	if err != nil {
+		return nil, err
 	}
 
 	variables := map[string]any{}
@@ -203,6 +192,28 @@ func (s *PluginInvokerServer) tokenContextForSurfaceInvoke(req *proto.PluginInvo
 		return invocationTokenContext{}, status.Errorf(codes.PermissionDenied, "plugin %q may not invoke %s surface %q", s.pluginName, targetPlugin, surface)
 	}
 	return tokenCtx, nil
+}
+
+func prepareInvocationSelectors(ctx context.Context, tokenCtx invocationTokenContext, rawConnection, rawInstance string) (context.Context, string, error) {
+	connection := strings.TrimSpace(rawConnection)
+	instance := strings.TrimSpace(rawInstance)
+	if err := rejectWorkloadSelectorOverride(tokenCtx.principal, connection, instance); err != nil {
+		return nil, "", err
+	}
+	if instance == "" && connection == "" && shouldInheritCredentialSelectors(tokenCtx.principal) {
+		instance = tokenCtx.credential.Instance
+	}
+	return restoreInvocationTokenContext(ctx, tokenCtx, connection), instance, nil
+}
+
+func rejectWorkloadSelectorOverride(p *principal.Principal, connection, instance string) error {
+	if shouldInheritCredentialSelectors(p) {
+		return nil
+	}
+	if connection == "" && instance == "" {
+		return nil
+	}
+	return status.Error(codes.PermissionDenied, "workloads may not override connection or instance bindings")
 }
 
 func invocationStatusError(err error) error {

--- a/gestaltd/internal/server/audit.go
+++ b/gestaltd/internal/server/audit.go
@@ -40,7 +40,7 @@ func (s *Server) resolvePrincipalUserID(ctx context.Context, p *principal.Princi
 	if p == nil {
 		return nil, nil
 	}
-	if p.Kind == principal.KindWorkload {
+	if isWorkloadPrincipal(p) {
 		return p, nil
 	}
 	if p.UserID != "" {

--- a/gestaltd/internal/server/authorization.go
+++ b/gestaltd/internal/server/authorization.go
@@ -40,8 +40,20 @@ func (s *Server) workloadBinding(p *principal.Principal, provider string) (autho
 	return s.authorizer.Binding(p, provider)
 }
 
+func isWorkloadPrincipal(p *principal.Principal) bool {
+	return p != nil && p.Kind == principal.KindWorkload
+}
+
+func rejectWorkloadCaller(w http.ResponseWriter, p *principal.Principal) error {
+	if !isWorkloadPrincipal(p) {
+		return nil
+	}
+	writeError(w, http.StatusForbidden, errWorkloadForbidden.Error())
+	return errWorkloadForbidden
+}
+
 func rejectWorkloadSelectors(w http.ResponseWriter, p *principal.Principal, connection, instance string) error {
-	if p == nil || p.Kind != principal.KindWorkload {
+	if !isWorkloadPrincipal(p) {
 		return nil
 	}
 	if connection == "" && instance == "" {

--- a/gestaltd/internal/server/handlers.go
+++ b/gestaltd/internal/server/handlers.go
@@ -90,8 +90,7 @@ type connectionParamInfo struct {
 }
 
 func (s *Server) resolveUserID(w http.ResponseWriter, r *http.Request) (string, error) {
-	if p := PrincipalFromContext(r.Context()); p != nil && p.Kind == principal.KindWorkload {
-		writeError(w, http.StatusForbidden, "workload callers are not allowed on this route")
+	if err := rejectWorkloadCaller(w, PrincipalFromContext(r.Context())); err != nil {
 		return "", errWorkloadForbidden
 	}
 	user := UserFromContext(r.Context())
@@ -127,7 +126,7 @@ func (s *Server) readinessCheck(w http.ResponseWriter, _ *http.Request) {
 func (s *Server) listIntegrations(w http.ResponseWriter, r *http.Request) {
 	p := PrincipalFromContext(r.Context())
 	connected := map[string][]instanceInfo{}
-	if p == nil || p.Kind != principal.KindWorkload {
+	if !isWorkloadPrincipal(p) {
 		var err error
 		connected, err = s.userConnectedIntegrations(r)
 		if err != nil {
@@ -164,7 +163,7 @@ func (s *Server) listIntegrations(w http.ResponseWriter, r *http.Request) {
 		if entry, ok := s.pluginDefs[name]; ok && entry != nil {
 			info.MountedPath = strings.TrimSpace(entry.MountPath)
 		}
-		if p != nil && p.Kind == principal.KindWorkload {
+		if isWorkloadPrincipal(p) {
 			if binding, ok := s.workloadBinding(p, name); ok {
 				bindingConnected, err := s.workloadBindingConnected(r.Context(), binding, name)
 				if err != nil {

--- a/gestaltd/internal/server/handlers_admin_authorization.go
+++ b/gestaltd/internal/server/handlers_admin_authorization.go
@@ -78,8 +78,7 @@ func (s *Server) adminAPIAuthMiddleware(next http.Handler) http.Handler {
 			writeError(w, http.StatusUnauthorized, "missing authorization")
 			return
 		}
-		if p.Kind == principal.KindWorkload {
-			writeError(w, http.StatusForbidden, "workload callers are not allowed on this route")
+		if err := rejectWorkloadCaller(w, p); err != nil {
 			return
 		}
 

--- a/gestaltd/internal/server/handlers_auth.go
+++ b/gestaltd/internal/server/handlers_auth.go
@@ -573,9 +573,8 @@ func (s *Server) logout(w http.ResponseWriter, r *http.Request) {
 	defer func() {
 		s.auditHTTPEvent(r.Context(), auditPrincipal, s.authProviderName(), "auth.logout", auditAllowed, auditErr)
 	}()
-	if auditPrincipal != nil && auditPrincipal.Kind == principal.KindWorkload {
-		auditErr = errWorkloadForbidden
-		writeError(w, http.StatusForbidden, "workload callers are not allowed on this route")
+	if err := rejectWorkloadCaller(w, auditPrincipal); err != nil {
+		auditErr = err
 		return
 	}
 

--- a/gestaltd/internal/server/handlers_connect.go
+++ b/gestaltd/internal/server/handlers_connect.go
@@ -38,9 +38,8 @@ func (s *Server) connectManual(w http.ResponseWriter, r *http.Request) {
 		metricutil.RecordConnectionAuthMetrics(r.Context(), startedAt, metricProviderName, "manual", "complete", connectionMode, auditErr != nil)
 		s.auditHTTPEventWithTarget(r.Context(), PrincipalFromContext(r.Context()), providerName, "connection.manual.connect", auditAllowed, auditErr, auditTarget)
 	}()
-	if p := PrincipalFromContext(r.Context()); p != nil && p.Kind == principal.KindWorkload {
-		auditErr = errWorkloadForbidden
-		writeError(w, http.StatusForbidden, "workload callers are not allowed on this route")
+	if err := rejectWorkloadCaller(w, PrincipalFromContext(r.Context())); err != nil {
+		auditErr = err
 		return
 	}
 

--- a/gestaltd/internal/server/handlers_identities.go
+++ b/gestaltd/internal/server/handlers_identities.go
@@ -1110,7 +1110,7 @@ func (s *Server) managedIdentityGrantCatalogTargets(ctx context.Context, plugin 
 			subjectID = principal.UserSubjectID(p.UserID)
 		}
 	}
-	if p == nil || p.Kind == principal.KindWorkload || subjectID == "" {
+	if p == nil || isWorkloadPrincipal(p) || subjectID == "" {
 		if len(targets) == 0 {
 			addTarget("", "")
 		}

--- a/gestaltd/internal/server/handlers_oauth.go
+++ b/gestaltd/internal/server/handlers_oauth.go
@@ -13,7 +13,6 @@ import (
 	"github.com/valon-technologies/gestalt/server/internal/metricutil"
 	"github.com/valon-technologies/gestalt/server/internal/oauth"
 	"github.com/valon-technologies/gestalt/server/internal/paraminterp"
-	"github.com/valon-technologies/gestalt/server/internal/principal"
 )
 
 type startOAuthRequest struct {
@@ -36,9 +35,8 @@ func (s *Server) startIntegrationOAuth(w http.ResponseWriter, r *http.Request) {
 		metricutil.RecordConnectionAuthMetrics(r.Context(), startedAt, metricProviderName, "oauth", "start", connectionMode, auditErr != nil)
 		s.auditHTTPEventWithTarget(r.Context(), PrincipalFromContext(r.Context()), providerName, "connection.oauth.start", auditAllowed, auditErr, auditTarget)
 	}()
-	if p := PrincipalFromContext(r.Context()); p != nil && p.Kind == principal.KindWorkload {
-		auditErr = errWorkloadForbidden
-		writeError(w, http.StatusForbidden, "workload callers are not allowed on this route")
+	if err := rejectWorkloadCaller(w, PrincipalFromContext(r.Context())); err != nil {
+		auditErr = err
 		return
 	}
 

--- a/gestaltd/internal/server/integration_visibility.go
+++ b/gestaltd/internal/server/integration_visibility.go
@@ -20,7 +20,7 @@ func (s *Server) integrationHasUsableSurfaceContext(ctx context.Context, p *prin
 }
 
 func (s *Server) integrationHasSettingsSurface(p *principal.Principal, info integrationInfo) bool {
-	if p != nil && p.Kind == principal.KindWorkload {
+	if isWorkloadPrincipal(p) {
 		return false
 	}
 	return info.Connected || len(info.AuthTypes) > 0 || len(info.Connections) > 0
@@ -69,7 +69,7 @@ func (s *Server) mountedUIRootAccessibleContext(ctx context.Context, p *principa
 	if mounted.AuthorizationPolicy == "" {
 		return true
 	}
-	if s.authorizer == nil || p == nil || p.Kind == principal.KindWorkload {
+	if s.authorizer == nil || p == nil || isWorkloadPrincipal(p) {
 		return false
 	}
 

--- a/gestaltd/internal/server/middleware.go
+++ b/gestaltd/internal/server/middleware.go
@@ -133,10 +133,10 @@ func (s *Server) resolveRequestPrincipalWithResolver(r *http.Request, resolver *
 
 	if c, err := r.Cookie(sessionCookieName); err == nil && c.Value != "" {
 		p, err := resolver.ResolveToken(r.Context(), c.Value)
-		if p != nil && p.Kind != principal.KindWorkload {
+		if p != nil && !isWorkloadPrincipal(p) {
 			return p, nil
 		}
-		if p != nil && p.Kind == principal.KindWorkload {
+		if isWorkloadPrincipal(p) {
 			lastErr = principal.ErrInvalidToken
 		} else {
 			lastErr = err

--- a/gestaltd/internal/server/mounted_ui.go
+++ b/gestaltd/internal/server/mounted_ui.go
@@ -315,8 +315,7 @@ func (s *Server) authorizeProtectedUIRequest(w http.ResponseWriter, r *http.Requ
 		}
 		return nil, false
 	}
-	if p != nil && p.Kind == principal.KindWorkload {
-		writeError(w, http.StatusForbidden, "workload callers are not allowed on this route")
+	if err := rejectWorkloadCaller(w, p); err != nil {
 		return nil, false
 	}
 

--- a/gestaltd/internal/server/pending_connection.go
+++ b/gestaltd/internal/server/pending_connection.go
@@ -257,7 +257,7 @@ func (s *Server) resolvePendingConnectionUserID(r *http.Request) (string, bool, 
 	if p == nil {
 		return "", false, nil
 	}
-	if p.Kind == principal.KindWorkload {
+	if isWorkloadPrincipal(p) {
 		return "", true, errWorkloadForbidden
 	}
 	subjectID := strings.TrimSpace(p.SubjectID)
@@ -295,7 +295,7 @@ func (s *Server) authorizePendingConnection(w http.ResponseWriter, r *http.Reque
 	subjectID, authenticated, err := s.resolvePendingConnectionUserID(r)
 	if err != nil {
 		if errors.Is(err, errWorkloadForbidden) {
-			writeError(w, http.StatusForbidden, "workload callers are not allowed on this route")
+			writeError(w, http.StatusForbidden, errWorkloadForbidden.Error())
 			return false
 		}
 		if errors.Is(err, principal.ErrInvalidToken) {


### PR DESCRIPTION
## Summary
This is the first deletive cleanup follow-up after `#1244`.

It does **not** rename `workload` yet, and it does **not** change storage or wire values.
It just centralizes the remaining repeated workload-caller guard logic in `server` and `providerhost`.

## Old internal path
The same checks were still hand-coded in multiple places.

Server repeated the same human-only route guard:

```go
if p := PrincipalFromContext(r.Context()); p != nil && p.Kind == principal.KindWorkload {
    writeError(w, http.StatusForbidden, "workload callers are not allowed on this route")
    return
}
```

Providerhost repeated the same selector-prep block in both `Invoke` and `InvokeGraphQL`:

```go
connection := strings.TrimSpace(req.GetConnection())
invokeCtx := restoreInvocationTokenContext(ctx, tokenCtx, connection)
instance := strings.TrimSpace(req.GetInstance())
if tokenCtx.principal != nil && tokenCtx.principal.Kind == principal.KindWorkload && (connection != "" || instance != "") {
    return nil, status.Error(codes.PermissionDenied, "workloads may not override connection or instance bindings")
}
if instance == "" && connection == "" && shouldInheritCredentialSelectors(tokenCtx.principal) {
    instance = tokenCtx.credential.Instance
}
```

## New internal path
Server route guards now share one local helper path:

```go
if err := rejectWorkloadCaller(w, PrincipalFromContext(r.Context())); err != nil {
    return
}
```

with the common predicate:

```go
isWorkloadPrincipal(p)
```

Providerhost selector prep now shares one helper:

```go
invokeCtx, instance, err := prepareInvocationSelectors(ctx, tokenCtx, req.GetConnection(), req.GetInstance())
```

## What changed
- added `isWorkloadPrincipal(...)` in `server`
- added `rejectWorkloadCaller(...)` in `server`
- reused those helpers across the repeated human-only route guards
- centralized providerhost selector trimming / override rejection / inherited-instance behavior into `prepareInvocationSelectors(...)`
- kept the existing public names and semantics unchanged

## Examples
Human-only route example:

- old: `resolveUserID`, `connectManual`, `startIntegrationOAuth`, `logout`, mounted UI auth, and admin auth all open-coded the same workload rejection
- new: they call the same `rejectWorkloadCaller(...)` helper

Plugin invoker example:

- old: `Invoke` and `InvokeGraphQL` each repeated the same selector-prep logic
- new: both call `prepareInvocationSelectors(...)`

## Risk
Low to medium runtime risk, low rollout risk.

This changes shared guard plumbing, but it does not change any public config names, token prefixes, subject formats, or database state.

## Verification
```bash
cd gestaltd && go test ./internal/server ./internal/providerhost ./internal/mcp ./internal/bootstrap
cd gestaltd && golangci-lint run ./internal/server ./internal/providerhost ./internal/mcp ./internal/bootstrap
```

## Reviewer pass
I also ran a separate reviewer agent on the diff before opening this PR. It reported no concrete findings.