### PR TITLE
Add authorization.callers as the preferred alias for authorization.workloads

### DIFF
--- a/docs/content/configuration.mdx
+++ b/docs/content/configuration.mdx
@@ -4,15 +4,15 @@ Gestalt is configured from one or more YAML files. This page covers the key conc
 
 ## Config file structure
 
-A Gestalt config has six top-level keys: `server` for host settings and host-provider selection, `authorization` for shared human/workload access policy, `providers` for named host-scoped providers and UIs, `runtime` for named plugin runtime backends, `workflows` for config-managed schedules and event triggers, and `plugins` for executable integrations and optional plugin-backed UI mounts.
+A Gestalt config has six top-level keys: `server` for host settings and host-provider selection, `authorization` for shared human/configured-caller access policy, `providers` for named host-scoped providers and UIs, `runtime` for named plugin runtime backends, `workflows` for config-managed schedules and event triggers, and `plugins` for executable integrations and optional plugin-backed UI mounts.
 
 ```yaml
 authorization:
   # shared human access policies
   policies: ...
 
-  # workload bearer-token policy
-  workloads: ...
+  # configured caller bearer-token policy
+  callers: ...
 
 plugins:
   <name>: ...               # each is a ProviderEntry
@@ -305,7 +305,7 @@ plugins:
 | Mode | Behavior |
 | --- | --- |
 | `none` | No upstream credential needed. |
-| `user` | Credentials are stored for the calling subject (for example `user:<id>`, `workload:<id>`, or a managed identity subject). |
+| `user` | Credentials are stored for the calling subject (for example `user:<id>`, the current configured-caller runtime subject `workload:<id>`, or a managed identity subject). |
 
 ### Authentication Types
 

--- a/docs/content/reference/config-file.mdx
+++ b/docs/content/reference/config-file.mdx
@@ -5,7 +5,7 @@ import { Tabs } from 'nextra/components'
 Every `gestaltd` deployment reads one or more YAML config files. When you pass
 multiple `--config` flags, Gestalt merges them left-to-right before validation
 and bootstrap. The top-level keys are `server` (listener, encryption, egress,
-and host-provider selection), `authorization` (shared human/workload access
+and host-provider selection), `authorization` (shared human/configured-caller access
 policy), `providers` (named authentication, secrets, telemetry, audit, UI,
 indexeddb, authorization, workflow, cache, and s3 entries), `workflows`
 (config-managed schedules and triggers), and `plugins` (executable
@@ -16,7 +16,7 @@ server:
   # listener, encryption, egress, host-provider selectors
 authorization:
   policies: {}
-  workloads: {}
+  callers: {}
 providers:
   audit: {}
   authentication: {}
@@ -52,7 +52,7 @@ and, by default, artifact directories stay rooted at the leftmost config file.
 
 Several fields carry defaults when omitted: `server.public.port` defaults to `8080`; the runtime secrets manager defaults to builtin `env` when `providers.secrets` is omitted; `providers.telemetry.default` defaults to builtin `stdout`; and `providers.audit.default` defaults to builtin `inherit`. Structured secret refs are resolved during bootstrap, not during YAML parsing.
 
-`authorization` configures shared human and workload access policy at the top level.
+`authorization` configures shared human and configured-caller access policy at the top level.
 
 ### Layered example
 
@@ -125,7 +125,7 @@ authorization:
           role: viewer
         - subjectID: user:admin-user
           role: admin
-  workloads:
+  callers:
     triage-bot:
       displayName: Triage Bot
       token:
@@ -162,7 +162,9 @@ authorization:
 
 Dynamic human grants are plugin-scoped, not policy-scoped. When a plugin sets `authorizationPolicy`, operators can manage additional dynamic members for that plugin from the built-in admin UI at `/admin/?tab=members` or through `/admin/api/v1/authorization/...`. Static policy members always win over dynamic grants, and Gestalt rejects dynamic writes for users who already have static authorization on that plugin.
 
-`authorization.workloads` configures non-human workload callers. Each workload uses a dedicated bearer token with the `gst_wld_` prefix and a per-provider allowlist. In the current runtime, workloads may bind only to `user` or `none` providers. For `user` providers, `connection` and `instance` resolve the exact stored workload credential the workload may use under its own subject (`workload:<id>`); `instance` defaults to `default` and `connection` falls back to the provider's default connection when omitted. For `none` providers, omit `connection` and `instance`.
+`authorization.callers` configures non-human configured callers. Each caller uses a dedicated bearer token with the legacy `gst_wld_` prefix and a per-provider allowlist. In the current runtime, callers may bind only to `user` or `none` providers. For `user` providers, `connection` and `instance` resolve the exact stored caller credential the caller may use under its current runtime subject (`workload:<id>`); `instance` defaults to `default` and `connection` falls back to the provider's default connection when omitted. For `none` providers, omit `connection` and `instance`.
+
+`authorization.workloads` remains supported as a backward-compatible alias for `authorization.callers`. When both keys are present after layered config merge, `authorization.callers` wins for the same caller name.
 
 | Field | Default | Description |
 | --- | --- | --- |
@@ -180,7 +182,8 @@ Dynamic human grants are plugin-scoped, not policy-scoped. When a plugin sets `a
 | `admin.authorizationPolicy` | | Shared human access policy applied to the built-in `/admin` route. |
 | `admin.allowedRoles` | `[admin]` | Roles allowed to load the built-in `/admin` route when `admin.authorizationPolicy` is set. |
 | `authorization.policies` | | Shared human access policies resolved by canonical `subjectID`. |
-| `authorization.workloads` | | Workload bearer tokens, per-provider allowlists, and workload-owned credential bindings. |
+| `authorization.callers` | | Preferred key for configured caller bearer tokens, per-provider allowlists, and caller-owned credential bindings. |
+| `authorization.workloads` | | Backward-compatible alias for `authorization.callers`. |
 
 When `server.management` is configured, Gestalt serves `/`, `/api/v1/*`, auth routes, and `/mcp` on the public listener, while `/admin`, `/admin/api/v1/*`, `/metrics`, `/health`, and `/ready` move to the management listener. The management listener is intended to be protected by deployment infrastructure such as private networking, VPN, or an internal-only reverse proxy. Gestalt does not apply its own session or API-token auth to `/metrics` on the management listener. When `server.admin.authorizationPolicy` is set, Gestalt does apply browser session auth plus role-based policy checks to `/admin` and `/admin/api/v1/*`.
 
@@ -1041,7 +1044,7 @@ connections:
       type: mcp_oauth
 ```
 
-Connection `mode` determines how credentials are managed: `none` requires no credentials, and `user` stores credentials for the caller's effective subject. For humans that is typically `user:<id>`; for workloads it is `workload:<id>`; for managed identities it is the managed identity subject. All connections in a single plugin must share the same mode.
+Connection `mode` determines how credentials are managed: `none` requires no credentials, and `user` stores credentials for the caller's effective subject. For humans that is typically `user:<id>`; for configured callers that is still `workload:<id>` in the current runtime; for managed identities it is the managed identity subject. All connections in a single plugin must share the same mode.
 
 #### Authentication Shapes
 

--- a/gestaltd/internal/config/config.go
+++ b/gestaltd/internal/config/config.go
@@ -948,6 +948,7 @@ type EgressConfig struct {
 }
 
 type AuthorizationConfig struct {
+	Callers   map[string]WorkloadDef    `yaml:"callers,omitempty"`
 	Workloads map[string]WorkloadDef    `yaml:"workloads,omitempty"`
 	Policies  map[string]HumanPolicyDef `yaml:"policies,omitempty"`
 }
@@ -1586,6 +1587,7 @@ func loadMergedConfigRoot(paths []string, lookup func(string) (string, bool), mo
 	if merged == nil {
 		return yaml.Node{}, nil
 	}
+	merged = normalizeAuthorizationAliases(merged)
 
 	data, err := yaml.Marshal(merged)
 	if err != nil {
@@ -1800,6 +1802,29 @@ func mergeConfigValues(base, overlay any) any {
 	}
 
 	return cloneConfigValue(overlay)
+}
+
+func normalizeAuthorizationAliases(value any) any {
+	root, ok := value.(map[string]any)
+	if !ok {
+		return value
+	}
+	authorization, ok := root["authorization"].(map[string]any)
+	if !ok {
+		return value
+	}
+	callers, ok := authorization["callers"]
+	if !ok {
+		return value
+	}
+	workloads := mergeConfigValues(authorization["workloads"], callers)
+	if workloads == nil {
+		delete(authorization, "workloads")
+	} else {
+		authorization["workloads"] = workloads
+	}
+	delete(authorization, "callers")
+	return value
 }
 
 func cloneConfigValue(value any) any {

--- a/gestaltd/internal/config/config_test.go
+++ b/gestaltd/internal/config/config_test.go
@@ -99,6 +99,203 @@ plugins:
 	}
 }
 
+func TestLoadAuthorizationCallersAlias(t *testing.T) {
+	t.Parallel()
+
+	path := mustWriteConfigFile(t, `
+server:
+  providers:
+    indexeddb: sqlite
+  encryptionKey: server-key
+authorization:
+  callers:
+    triage-bot:
+      displayName: Triage Bot
+      token: gst_wld_triage-bot-token
+      providers:
+        github:
+          connection: default
+          allow:
+            - list_issues
+providers:
+  indexeddb:
+    sqlite:
+      source:
+        path: ./providers/datastore/sqlite
+`)
+
+	cfg, err := Load(path)
+	if err != nil {
+		t.Fatalf("Load: %v", err)
+	}
+
+	workload, ok := cfg.Authorization.Workloads["triage-bot"]
+	if !ok {
+		t.Fatalf("Authorization.Workloads missing callers alias entry: %#v", cfg.Authorization.Workloads)
+	}
+	if workload.DisplayName != "Triage Bot" {
+		t.Fatalf("Authorization.Workloads[triage-bot].DisplayName = %q, want %q", workload.DisplayName, "Triage Bot")
+	}
+}
+
+func TestLoadAuthorizationCallersAliasPrefersCallersOverWorkloads(t *testing.T) {
+	t.Parallel()
+
+	path := mustWriteConfigFile(t, `
+server:
+  providers:
+    indexeddb: sqlite
+  encryptionKey: server-key
+authorization:
+  callers:
+    triage-bot:
+      token: gst_wld_triage-bot-token
+      providers:
+        github:
+          connection: default
+          allow:
+            - list_issues
+  workloads:
+    triage-bot:
+      token: gst_wld_triage-bot-token-2
+      providers:
+        github:
+          connection: default
+          allow:
+            - get_issue
+providers:
+  indexeddb:
+    sqlite:
+      source:
+        path: ./providers/datastore/sqlite
+`)
+
+	cfg, err := Load(path)
+	if err != nil {
+		t.Fatalf("Load: %v", err)
+	}
+	workload, ok := cfg.Authorization.Workloads["triage-bot"]
+	if !ok {
+		t.Fatalf("Authorization.Workloads missing merged caller entry: %#v", cfg.Authorization.Workloads)
+	}
+	if workload.Token != "gst_wld_triage-bot-token" {
+		t.Fatalf("Authorization.Workloads[triage-bot].Token = %q, want callers alias to win", workload.Token)
+	}
+	if got := workload.Providers["github"].Allow; len(got) != 1 || got[0] != "list_issues" {
+		t.Fatalf("Authorization.Workloads[triage-bot].Providers[github].Allow = %#v, want callers alias value", got)
+	}
+}
+
+func TestLoadAuthorizationCallersAliasMergesPartialCallerOverride(t *testing.T) {
+	t.Parallel()
+
+	path := mustWriteConfigFile(t, `
+server:
+  providers:
+    indexeddb: sqlite
+  encryptionKey: server-key
+authorization:
+  callers:
+    triage-bot:
+      displayName: Triage Bot
+      providers:
+        github:
+          connection: alternate
+  workloads:
+    triage-bot:
+      token: gst_wld_triage-bot-token
+      providers:
+        github:
+          connection: default
+          allow:
+            - list_issues
+providers:
+  indexeddb:
+    sqlite:
+      source:
+        path: ./providers/datastore/sqlite
+`)
+
+	cfg, err := Load(path)
+	if err != nil {
+		t.Fatalf("Load: %v", err)
+	}
+
+	workload, ok := cfg.Authorization.Workloads["triage-bot"]
+	if !ok {
+		t.Fatalf("Authorization.Workloads missing merged caller entry: %#v", cfg.Authorization.Workloads)
+	}
+	if workload.DisplayName != "Triage Bot" {
+		t.Fatalf("Authorization.Workloads[triage-bot].DisplayName = %q, want %q", workload.DisplayName, "Triage Bot")
+	}
+	if workload.Token != "gst_wld_triage-bot-token" {
+		t.Fatalf("Authorization.Workloads[triage-bot].Token = %q, want inherited workload token", workload.Token)
+	}
+	provider, ok := workload.Providers["github"]
+	if !ok {
+		t.Fatalf("Authorization.Workloads[triage-bot].Providers missing github entry: %#v", workload.Providers)
+	}
+	if provider.Connection != "alternate" {
+		t.Fatalf("Authorization.Workloads[triage-bot].Providers[github].Connection = %q, want %q", provider.Connection, "alternate")
+	}
+	if got := provider.Allow; len(got) != 1 || got[0] != "list_issues" {
+		t.Fatalf("Authorization.Workloads[triage-bot].Providers[github].Allow = %#v, want inherited workload allowlist", got)
+	}
+}
+
+func TestLoadAuthorizationCallersAliasHonorsNullDeletesAcrossMixedKeys(t *testing.T) {
+	t.Parallel()
+
+	basePath := mustWriteConfigFile(t, `
+server:
+  providers:
+    indexeddb: sqlite
+  encryptionKey: server-key
+authorization:
+  workloads:
+    triage-bot:
+      displayName: Legacy Bot
+      token: gst_wld_triage-bot-token
+      providers:
+        github:
+          connection: default
+          allow:
+            - list_issues
+providers:
+  indexeddb:
+    sqlite:
+      source:
+        path: ./providers/datastore/sqlite
+`)
+	overridePath := mustWriteConfigFile(t, `
+authorization:
+  callers:
+    triage-bot:
+      displayName: null
+      providers:
+        github: null
+`)
+
+	cfg, err := LoadPaths([]string{basePath, overridePath})
+	if err != nil {
+		t.Fatalf("LoadPaths: %v", err)
+	}
+
+	workload, ok := cfg.Authorization.Workloads["triage-bot"]
+	if !ok {
+		t.Fatalf("Authorization.Workloads missing merged caller entry: %#v", cfg.Authorization.Workloads)
+	}
+	if workload.DisplayName != "" {
+		t.Fatalf("Authorization.Workloads[triage-bot].DisplayName = %q, want empty after null delete", workload.DisplayName)
+	}
+	if workload.Token != "gst_wld_triage-bot-token" {
+		t.Fatalf("Authorization.Workloads[triage-bot].Token = %q, want inherited workload token", workload.Token)
+	}
+	if workload.Providers != nil {
+		t.Fatalf("Authorization.Workloads[triage-bot].Providers = %#v, want nil after null delete", workload.Providers)
+	}
+}
+
 func TestLoadConfigParsesPluginMCPFlag(t *testing.T) {
 	t.Parallel()
 


### PR DESCRIPTION
## Summary

This is the alias-and-docs phase of the workload naming cleanup.

It adds `authorization.callers` as the preferred config key for configured bearer-token callers while keeping `authorization.workloads` as a backward-compatible alias. This change does **not** rename runtime subjects, token prefixes, or auth-source values.

## Old interface

```yaml
authorization:
  workloads:
    triage-bot:
      displayName: Triage Bot
      token: gst_wld_triage-bot-token
      providers:
        github:
          connection: default
          allow:
            - list_issues
```

## New preferred interface

```yaml
authorization:
  callers:
    triage-bot:
      displayName: Triage Bot
      token: gst_wld_triage-bot-token
      providers:
        github:
          connection: default
          allow:
            - list_issues
```

## Compatibility

- `authorization.workloads` still works.
- `authorization.callers` is normalized into the existing internal `Authorization.Workloads` map.
- If layered config produces both keys for the same caller name, `authorization.callers` wins.
- Runtime names stay unchanged in this PR:
  - token prefix: `gst_wld_`
  - subject shape: `workload:<id>`
  - existing auth/source terminology remains in the API/runtime

## Examples

Layered merge where the new key overrides the old one for the same caller:

```yaml
# base.yaml
authorization:
  workloads:
    triage-bot:
      token: gst_wld_old-token
      providers:
        github:
          connection: default
          allow:
            - get_issue
```

```yaml
# override.yaml
authorization:
  callers:
    triage-bot:
      token: gst_wld_new-token
      providers:
        github:
          connection: default
          allow:
            - list_issues
```

Result after config merge and normalization:

```yaml
authorization:
  workloads:
    triage-bot:
      token: gst_wld_new-token
      providers:
        github:
          connection: default
          allow:
            - list_issues
```

## Verification

- `cd gestaltd && go test ./internal/config ./internal/bootstrap`
- `cd gestaltd && golangci-lint run ./internal/config ./internal/bootstrap`
- `cd docs && npm run build`

## Migration impact

- No database migration.
- No runtime credential migration.
- Existing configs continue to work unchanged.