### PR TITLE
Use generic HMAC hosted HTTP security schemes

### DIFF
--- a/docs/content/custom-providers/releasing.mdx
+++ b/docs/content/custom-providers/releasing.mdx
@@ -218,15 +218,20 @@ been authored declaratively:
 ```yaml
 spec:
   securitySchemes:
-    slack:
-      type: slack_signature
+    signed:
+      type: hmac
       secret:
-        env: SLACK_SIGNING_SECRET
+        env: REQUEST_SIGNING_SECRET
+      signatureHeader: X-Request-Signature
+      signaturePrefix: v0=
+      payloadTemplate: "v0:{header:X-Request-Timestamp}:{raw_body}"
+      timestampHeader: X-Request-Timestamp
+      maxAgeSeconds: 300
   http:
     command:
       path: /command
       method: POST
-      security: slack
+      security: signed
       target: handle_command
       requestBody:
         required: true
@@ -235,8 +240,7 @@ spec:
       ack:
         status: 200
         body:
-          response_type: ephemeral
-          text: Working on it...
+          status: accepted
 ```
 
 For non-host Python targets, point Gestalt at a matching interpreter with

--- a/docs/content/reference/plugin-manifests.mdx
+++ b/docs/content/reference/plugin-manifests.mdx
@@ -221,15 +221,20 @@ not replace the generic `/api/v1/{plugin}/{operation}` facade; use them when a
 plugin needs a stable custom path, form-encoded request bodies, hosted request
 verification, or an immediate host-managed acknowledgment response.
 
-`spec.http.<name>.path` is plugin-relative. For plugin `slack`, `path: /command`
-mounts at `/api/v1/slack/command`.
+`spec.http.<name>.path` is plugin-relative. For plugin `example`, `path: /command`
+mounts at `/api/v1/example/command`.
 
 #### `spec.securitySchemes`
 
 | Field | Type | Purpose |
 | --- | --- | --- |
-| `type` | string | One of `slack_signature`, `apiKey`, `http`, or `none`. |
+| `type` | string | One of `hmac`, `apiKey`, `http`, or `none`. |
 | `description` | string | Optional human-readable description. |
+| `signatureHeader` | string | Header carrying the transmitted HMAC digest for `type: hmac`. |
+| `signaturePrefix` | string | Optional static prefix prepended to the computed digest before comparison. |
+| `payloadTemplate` | string | Template used to build the signed payload for `type: hmac`. Supports `{raw_body}` and `{header:Header-Name}` placeholders. |
+| `timestampHeader` | string | Optional header carrying a Unix-seconds timestamp for freshness and replay checks. |
+| `maxAgeSeconds` | integer | Maximum accepted request age, in seconds, when `timestampHeader` is configured. |
 | `name` | string | Header or query parameter name for `apiKey`. |
 | `in` | string | `header` or `query` for `type: apiKey`. |
 | `scheme` | string | `basic` or `bearer` for `type: http`. |
@@ -251,15 +256,20 @@ Example:
 ```yaml
 spec:
   securitySchemes:
-    slack:
-      type: slack_signature
+    signed:
+      type: hmac
       secret:
-        env: SLACK_SIGNING_SECRET
+        env: REQUEST_SIGNING_SECRET
+      signatureHeader: X-Request-Signature
+      signaturePrefix: v0=
+      payloadTemplate: "v0:{header:X-Request-Timestamp}:{raw_body}"
+      timestampHeader: X-Request-Timestamp
+      maxAgeSeconds: 300
   http:
     command:
       path: /command
       method: POST
-      security: slack
+      security: signed
       target: handle_command
       requestBody:
         required: true
@@ -268,8 +278,7 @@ spec:
       ack:
         status: 200
         body:
-          response_type: ephemeral
-          text: Working on it...
+          status: accepted
 ```
 
 Source plugins written in Go, Python, Rust, or TypeScript may generate these

--- a/gestaltd/cmd/gestaltd/provider_test.go
+++ b/gestaltd/cmd/gestaltd/provider_test.go
@@ -586,15 +586,20 @@ func TestRun_ProviderReleaseBuildsRustSourcePluginForCurrentPlatform(t *testing.
 		ExpectedCatalogWrite: true,
 		GeneratedCatalog:     rustReleasePluginName,
 		GeneratedManifestMetadata: `securitySchemes:
-  slack:
-    type: slack_signature
+  signed:
+    type: hmac
     secret:
-      env: SLACK_SIGNING_SECRET
+      env: REQUEST_SIGNING_SECRET
+    signatureHeader: X-Request-Signature
+    signaturePrefix: v0=
+    payloadTemplate: "v0:{header:X-Request-Timestamp}:{raw_body}"
+    timestampHeader: X-Request-Timestamp
+    maxAgeSeconds: 300
 http:
   command:
     path: /command
     method: POST
-    security: slack
+    security: signed
     target: greet
     requestBody:
       required: true
@@ -603,8 +608,7 @@ http:
     ack:
       status: 200
       body:
-        response_type: ephemeral
-        text: Working on it...`,
+        status: accepted`,
 		DelegateBinary: pluginBin,
 		AllowedTargets: []string{hostTarget},
 	})
@@ -697,15 +701,20 @@ func TestRun_ProviderReleaseBuildsRustSourcePluginForExplicitLinuxTarget(t *test
 		ExpectedCatalogWrite: true,
 		GeneratedCatalog:     rustReleasePluginName,
 		GeneratedManifestMetadata: `securitySchemes:
-  slack:
-    type: slack_signature
+  signed:
+    type: hmac
     secret:
-      env: SLACK_SIGNING_SECRET
+      env: REQUEST_SIGNING_SECRET
+    signatureHeader: X-Request-Signature
+    signaturePrefix: v0=
+    payloadTemplate: "v0:{header:X-Request-Timestamp}:{raw_body}"
+    timestampHeader: X-Request-Timestamp
+    maxAgeSeconds: 300
 http:
   command:
     path: /command
     method: POST
-    security: slack
+    security: signed
     target: greet
     requestBody:
       required: true
@@ -714,8 +723,7 @@ http:
     ack:
       status: 200
       body:
-        response_type: ephemeral
-        text: Working on it...`,
+        status: accepted`,
 		DelegateBinary: pluginBin,
 		AllowedTargets: []string{hostTarget, explicitTarget},
 	})
@@ -2219,16 +2227,21 @@ class GreetOutput(gestalt.Model):
 plugin = gestalt.Plugin(
     "python-release",
     securitySchemes={
-        "slack": {
-            "type": "slack_signature",
-            "secret": {"env": "SLACK_SIGNING_SECRET"},
+        "signed": {
+            "type": "hmac",
+            "secret": {"env": "REQUEST_SIGNING_SECRET"},
+            "signatureHeader": "X-Request-Signature",
+            "signaturePrefix": "v0=",
+            "payloadTemplate": "v0:{header:X-Request-Timestamp}:{raw_body}",
+            "timestampHeader": "X-Request-Timestamp",
+            "maxAgeSeconds": 300,
         }
     },
     http={
         "command": {
             "path": "/command",
             "method": "POST",
-            "security": "slack",
+            "security": "signed",
             "target": "greet",
             "requestBody": {
                 "required": True,
@@ -2239,8 +2252,7 @@ plugin = gestalt.Plugin(
             "ack": {
                 "status": 200,
                 "body": {
-                    "response_type": "ephemeral",
-                    "text": "Working on it...",
+                    "status": "accepted",
                 },
             },
         }
@@ -2507,15 +2519,20 @@ EOF
     if [ -n "${GESTALT_PLUGIN_WRITE_MANIFEST_METADATA:-}" ]; then
       cat > "$GESTALT_PLUGIN_WRITE_MANIFEST_METADATA" <<'EOF'
 securitySchemes:
-  slack:
-    type: slack_signature
+  signed:
+    type: hmac
     secret:
-      env: SLACK_SIGNING_SECRET
+      env: REQUEST_SIGNING_SECRET
+    signatureHeader: X-Request-Signature
+    signaturePrefix: v0=
+    payloadTemplate: "v0:{header:X-Request-Timestamp}:{raw_body}"
+    timestampHeader: X-Request-Timestamp
+    maxAgeSeconds: 300
 http:
   command:
     path: /command
     method: POST
-    security: slack
+    security: signed
     target: greet
     requestBody:
       required: true
@@ -2524,8 +2541,7 @@ http:
     ack:
       status: 200
       body:
-        response_type: ephemeral
-        text: Working on it...
+        status: accepted
 EOF
     fi
     exit 0
@@ -2678,15 +2694,20 @@ EOF
   if [ -n "${GESTALT_PLUGIN_WRITE_MANIFEST_METADATA:-}" ]; then
     cat > "$GESTALT_PLUGIN_WRITE_MANIFEST_METADATA" <<'EOF'
 securitySchemes:
-  slack:
-    type: slack_signature
+  signed:
+    type: hmac
     secret:
-      env: SLACK_SIGNING_SECRET
+      env: REQUEST_SIGNING_SECRET
+    signatureHeader: X-Request-Signature
+    signaturePrefix: v0=
+    payloadTemplate: "v0:{header:X-Request-Timestamp}:{raw_body}"
+    timestampHeader: X-Request-Timestamp
+    maxAgeSeconds: 300
 http:
   command:
     path: /command
     method: POST
-    security: slack
+    security: signed
     target: greet
     requestBody:
       required: true
@@ -2695,8 +2716,7 @@ http:
     ack:
       status: 200
       body:
-        response_type: ephemeral
-        text: Working on it...
+        status: accepted
 EOF
   fi
   exit 0
@@ -2850,15 +2870,30 @@ func assertReleasedManifestHasHostedHTTPMetadata(t *testing.T, manifest *provide
 		t.Fatalf("manifest = %+v, want populated spec", manifest)
 	}
 
-	scheme := manifest.Spec.SecuritySchemes["slack"]
+	scheme := manifest.Spec.SecuritySchemes["signed"]
 	if scheme == nil {
-		t.Fatal(`manifest.Spec.SecuritySchemes["slack"] = nil, want generated scheme`)
+		t.Fatal(`manifest.Spec.SecuritySchemes["signed"] = nil, want generated scheme`)
 	}
-	if scheme.Type != providermanifestv1.HTTPSecuritySchemeTypeSlackSignature {
-		t.Fatalf("scheme.Type = %q, want %q", scheme.Type, providermanifestv1.HTTPSecuritySchemeTypeSlackSignature)
+	if scheme.Type != providermanifestv1.HTTPSecuritySchemeTypeHMAC {
+		t.Fatalf("scheme.Type = %q, want %q", scheme.Type, providermanifestv1.HTTPSecuritySchemeTypeHMAC)
 	}
-	if scheme.Secret == nil || scheme.Secret.Env != "SLACK_SIGNING_SECRET" {
+	if scheme.Secret == nil || scheme.Secret.Env != "REQUEST_SIGNING_SECRET" {
 		t.Fatalf("scheme.Secret = %+v, want env-backed secret", scheme.Secret)
+	}
+	if scheme.SignatureHeader != "X-Request-Signature" {
+		t.Fatalf("scheme.SignatureHeader = %q, want %q", scheme.SignatureHeader, "X-Request-Signature")
+	}
+	if scheme.SignaturePrefix != "v0=" {
+		t.Fatalf("scheme.SignaturePrefix = %q, want %q", scheme.SignaturePrefix, "v0=")
+	}
+	if scheme.PayloadTemplate != "v0:{header:X-Request-Timestamp}:{raw_body}" {
+		t.Fatalf("scheme.PayloadTemplate = %q, want %q", scheme.PayloadTemplate, "v0:{header:X-Request-Timestamp}:{raw_body}")
+	}
+	if scheme.TimestampHeader != "X-Request-Timestamp" {
+		t.Fatalf("scheme.TimestampHeader = %q, want %q", scheme.TimestampHeader, "X-Request-Timestamp")
+	}
+	if scheme.MaxAgeSeconds != 300 {
+		t.Fatalf("scheme.MaxAgeSeconds = %d, want %d", scheme.MaxAgeSeconds, 300)
 	}
 
 	binding := manifest.Spec.HTTP["command"]
@@ -2871,8 +2906,8 @@ func assertReleasedManifestHasHostedHTTPMetadata(t *testing.T, manifest *provide
 	if binding.Method != http.MethodPost {
 		t.Fatalf("binding.Method = %q, want %q", binding.Method, http.MethodPost)
 	}
-	if binding.Security != "slack" {
-		t.Fatalf("binding.Security = %q, want %q", binding.Security, "slack")
+	if binding.Security != "signed" {
+		t.Fatalf("binding.Security = %q, want %q", binding.Security, "signed")
 	}
 	if binding.Target != target {
 		t.Fatalf("binding.Target = %q, want %q", binding.Target, target)
@@ -2893,8 +2928,8 @@ func assertReleasedManifestHasHostedHTTPMetadata(t *testing.T, manifest *provide
 	if !ok {
 		t.Fatalf("binding.Ack.Body type = %T, want map[string]any", binding.Ack.Body)
 	}
-	if got := body["response_type"]; got != "ephemeral" {
-		t.Fatalf("binding.Ack.Body[response_type] = %#v, want %#v", got, "ephemeral")
+	if got := body["status"]; got != "accepted" {
+		t.Fatalf("binding.Ack.Body[status] = %#v, want %#v", got, "accepted")
 	}
 }
 
@@ -3169,18 +3204,23 @@ func newTypeScriptSourceReleaseFixture(t *testing.T, dir string) string {
 
 export const provider = definePlugin({
   securitySchemes: {
-    slack: {
-      type: "slack_signature",
+    signed: {
+      type: "hmac",
       secret: {
-        env: "SLACK_SIGNING_SECRET",
+        env: "REQUEST_SIGNING_SECRET",
       },
+      signatureHeader: "X-Request-Signature",
+      signaturePrefix: "v0=",
+      payloadTemplate: "v0:{header:X-Request-Timestamp}:{raw_body}",
+      timestampHeader: "X-Request-Timestamp",
+      maxAgeSeconds: 300,
     },
   },
   http: {
     command: {
       path: "/command",
       method: "POST",
-      security: "slack",
+      security: "signed",
       target: "greet",
       requestBody: {
         required: true,
@@ -3191,8 +3231,7 @@ export const provider = definePlugin({
       ack: {
         status: 200,
         body: {
-          response_type: "ephemeral",
-          text: "Working on it...",
+          status: "accepted",
         },
       },
     },
@@ -3271,7 +3310,7 @@ func injectGoManifestMetadata(t *testing.T, providerPath string) {
 		t.Fatalf("ReadFile(%s): %v", providerPath, err)
 	}
 	old := "\t)\n)"
-	new := "\t).WithManifestMetadata(gestalt.ManifestMetadata{\n\t\tSecuritySchemes: map[string]gestalt.HTTPSecurityScheme{\n\t\t\t\"slack\": {\n\t\t\t\tType: gestalt.HTTPSecuritySchemeTypeSlackSignature,\n\t\t\t\tSecret: &gestalt.HTTPSecretRef{Env: \"SLACK_SIGNING_SECRET\"},\n\t\t\t},\n\t\t},\n\t\tHTTP: map[string]gestalt.HTTPBinding{\n\t\t\t\"command\": {\n\t\t\t\tPath:     \"/command\",\n\t\t\t\tMethod:   http.MethodPost,\n\t\t\t\tSecurity: \"slack\",\n\t\t\t\tTarget:   \"echo\",\n\t\t\t\tRequestBody: &gestalt.HTTPRequestBody{\n\t\t\t\t\tRequired: true,\n\t\t\t\t\tContent: map[string]gestalt.HTTPMediaType{\n\t\t\t\t\t\t\"application/x-www-form-urlencoded\": {},\n\t\t\t\t\t},\n\t\t\t\t},\n\t\t\t\tAck: &gestalt.HTTPAck{\n\t\t\t\t\tStatus: 200,\n\t\t\t\t\tBody: map[string]any{\n\t\t\t\t\t\t\"response_type\": \"ephemeral\",\n\t\t\t\t\t\t\"text\":          \"Working on it...\",\n\t\t\t\t\t},\n\t\t\t\t},\n\t\t\t},\n\t\t},\n\t})\n)"
+	new := "\t).WithManifestMetadata(gestalt.ManifestMetadata{\n\t\tSecuritySchemes: map[string]gestalt.HTTPSecurityScheme{\n\t\t\t\"signed\": {\n\t\t\t\tType:            gestalt.HTTPSecuritySchemeTypeHMAC,\n\t\t\t\tSecret:          &gestalt.HTTPSecretRef{Env: \"REQUEST_SIGNING_SECRET\"},\n\t\t\t\tSignatureHeader: \"X-Request-Signature\",\n\t\t\t\tSignaturePrefix: \"v0=\",\n\t\t\t\tPayloadTemplate: \"v0:{header:X-Request-Timestamp}:{raw_body}\",\n\t\t\t\tTimestampHeader: \"X-Request-Timestamp\",\n\t\t\t\tMaxAgeSeconds:   300,\n\t\t\t},\n\t\t},\n\t\tHTTP: map[string]gestalt.HTTPBinding{\n\t\t\t\"command\": {\n\t\t\t\tPath:     \"/command\",\n\t\t\t\tMethod:   http.MethodPost,\n\t\t\t\tSecurity: \"signed\",\n\t\t\t\tTarget:   \"echo\",\n\t\t\t\tRequestBody: &gestalt.HTTPRequestBody{\n\t\t\t\t\tRequired: true,\n\t\t\t\t\tContent: map[string]gestalt.HTTPMediaType{\n\t\t\t\t\t\t\"application/x-www-form-urlencoded\": {},\n\t\t\t\t\t},\n\t\t\t\t},\n\t\t\t\tAck: &gestalt.HTTPAck{\n\t\t\t\t\tStatus: 200,\n\t\t\t\t\tBody: map[string]any{\n\t\t\t\t\t\t\"status\": \"accepted\",\n\t\t\t\t\t},\n\t\t\t\t},\n\t\t\t},\n\t\t},\n\t})\n)"
 	updated := strings.Replace(string(data), old, new, 1)
 	if updated == string(data) {
 		t.Fatalf("provider fixture %s missing router terminator %q", providerPath, old)

--- a/gestaltd/internal/config/config.go
+++ b/gestaltd/internal/config/config.go
@@ -701,6 +701,21 @@ func mergeHTTPSecurityScheme(base, override *HTTPSecurityScheme) *HTTPSecuritySc
 	if override.Description != "" {
 		merged.Description = override.Description
 	}
+	if override.SignatureHeader != "" {
+		merged.SignatureHeader = override.SignatureHeader
+	}
+	if override.SignaturePrefix != "" {
+		merged.SignaturePrefix = override.SignaturePrefix
+	}
+	if override.PayloadTemplate != "" {
+		merged.PayloadTemplate = override.PayloadTemplate
+	}
+	if override.TimestampHeader != "" {
+		merged.TimestampHeader = override.TimestampHeader
+	}
+	if override.MaxAgeSeconds != 0 {
+		merged.MaxAgeSeconds = override.MaxAgeSeconds
+	}
 	if override.Name != "" {
 		merged.Name = override.Name
 	}

--- a/gestaltd/internal/config/config_test.go
+++ b/gestaltd/internal/config/config_test.go
@@ -128,19 +128,24 @@ func TestLoadConfigParsesPluginHTTPSecuritySchemesAndBindings(t *testing.T) {
 server:
   encryptionKey: server-key
 plugins:
-  slack:
+  signed:
     source:
       path: /tmp/manifest.yaml
     securitySchemes:
-      slack:
-        type: slack_signature
+      signed:
+        type: hmac
         secret:
-          env: SLACK_SIGNING_SECRET
+          env: REQUEST_SIGNING_SECRET
+        signatureHeader: X-Request-Signature
+        signaturePrefix: v0=
+        payloadTemplate: "v0:{header:X-Request-Timestamp}:{raw_body}"
+        timestampHeader: X-Request-Timestamp
+        maxAgeSeconds: 300
     http:
       command:
         path: /command
         method: POST
-        security: slack
+        security: signed
         requestBody:
           required: true
           content:
@@ -148,20 +153,32 @@ plugins:
         target: handle_command
         ack:
           body:
-            response_type: ephemeral
-            text: Working on it...
+            status: accepted
 `)
 
 	cfg, err := Load(path)
 	if err != nil {
 		t.Fatalf("Load: %v", err)
 	}
-	entry := cfg.Plugins["slack"]
+	entry := cfg.Plugins["signed"]
 	if entry == nil {
-		t.Fatal("Plugins[slack] = nil")
+		t.Fatal("Plugins[signed] = nil")
 	}
-	if entry.SecuritySchemes["slack"] == nil || entry.SecuritySchemes["slack"].Type != providermanifestv1.HTTPSecuritySchemeTypeSlackSignature {
-		t.Fatalf("SecuritySchemes[slack] = %#v", entry.SecuritySchemes["slack"])
+	scheme := entry.SecuritySchemes["signed"]
+	if scheme == nil || scheme.Type != providermanifestv1.HTTPSecuritySchemeTypeHMAC {
+		t.Fatalf("SecuritySchemes[signed] = %#v", entry.SecuritySchemes["signed"])
+	}
+	if got, want := scheme.SignatureHeader, "X-Request-Signature"; got != want {
+		t.Fatalf("SecuritySchemes[signed].SignatureHeader = %q, want %q", got, want)
+	}
+	if got, want := scheme.PayloadTemplate, "v0:{header:X-Request-Timestamp}:{raw_body}"; got != want {
+		t.Fatalf("SecuritySchemes[signed].PayloadTemplate = %q, want %q", got, want)
+	}
+	if got, want := scheme.TimestampHeader, "X-Request-Timestamp"; got != want {
+		t.Fatalf("SecuritySchemes[signed].TimestampHeader = %q, want %q", got, want)
+	}
+	if got, want := scheme.MaxAgeSeconds, 300; got != want {
+		t.Fatalf("SecuritySchemes[signed].MaxAgeSeconds = %d, want %d", got, want)
 	}
 	if entry.HTTP["command"] == nil {
 		t.Fatal("HTTP[command] = nil")
@@ -177,6 +194,62 @@ plugins:
 	}
 }
 
+func TestProviderEntryEffectiveHTTPSecuritySchemes_MergesHMACFields(t *testing.T) {
+	t.Parallel()
+
+	entry := &ProviderEntry{
+		ResolvedManifest: &providermanifestv1.Manifest{
+			Spec: &providermanifestv1.Spec{
+				SecuritySchemes: map[string]*providermanifestv1.HTTPSecurityScheme{
+					"signed": {
+						Type:            providermanifestv1.HTTPSecuritySchemeTypeHMAC,
+						SignatureHeader: "X-Old-Signature",
+						SignaturePrefix: "v1=",
+						PayloadTemplate: "{raw_body}",
+						TimestampHeader: "X-Old-Timestamp",
+						MaxAgeSeconds:   30,
+						Secret:          &providermanifestv1.HTTPSecretRef{Env: "OLD_SIGNING_SECRET"},
+					},
+				},
+			},
+		},
+		SecuritySchemes: map[string]*HTTPSecurityScheme{
+			"signed": {
+				SignatureHeader: "X-Request-Signature",
+				SignaturePrefix: "v0=",
+				PayloadTemplate: "v0:{header:X-Request-Timestamp}:{raw_body}",
+				TimestampHeader: "X-Request-Timestamp",
+				MaxAgeSeconds:   300,
+				Secret:          &providermanifestv1.HTTPSecretRef{Env: "REQUEST_SIGNING_SECRET"},
+			},
+		},
+	}
+
+	effective := entry.EffectiveHTTPSecuritySchemes()
+	scheme := effective["signed"]
+	if scheme == nil {
+		t.Fatal("EffectiveHTTPSecuritySchemes()[signed] = nil")
+	}
+	if got, want := scheme.SignatureHeader, "X-Request-Signature"; got != want {
+		t.Fatalf("SignatureHeader = %q, want %q", got, want)
+	}
+	if got, want := scheme.SignaturePrefix, "v0="; got != want {
+		t.Fatalf("SignaturePrefix = %q, want %q", got, want)
+	}
+	if got, want := scheme.PayloadTemplate, "v0:{header:X-Request-Timestamp}:{raw_body}"; got != want {
+		t.Fatalf("PayloadTemplate = %q, want %q", got, want)
+	}
+	if got, want := scheme.TimestampHeader, "X-Request-Timestamp"; got != want {
+		t.Fatalf("TimestampHeader = %q, want %q", got, want)
+	}
+	if got, want := scheme.MaxAgeSeconds, 300; got != want {
+		t.Fatalf("MaxAgeSeconds = %d, want %d", got, want)
+	}
+	if scheme.Secret == nil || scheme.Secret.Env != "REQUEST_SIGNING_SECRET" {
+		t.Fatalf("Secret = %#v, want REQUEST_SIGNING_SECRET", scheme.Secret)
+	}
+}
+
 func TestProviderEntryEffectiveHTTPBindings_ClonesAckBody(t *testing.T) {
 	t.Parallel()
 
@@ -187,7 +260,7 @@ func TestProviderEntryEffectiveHTTPBindings_ClonesAckBody(t *testing.T) {
 					"command": {
 						Path:     "/command",
 						Method:   "POST",
-						Security: "slack",
+						Security: "signed",
 						Target:   "handle_command",
 						Ack: &providermanifestv1.HTTPAck{
 							Headers: map[string]string{"Content-Type": "application/json"},

--- a/gestaltd/internal/httpbinding/payload_template.go
+++ b/gestaltd/internal/httpbinding/payload_template.go
@@ -1,0 +1,97 @@
+package httpbinding
+
+import (
+	"fmt"
+	"net/http"
+	"strings"
+)
+
+func ValidatePayloadTemplate(template, timestampHeader string) error {
+	template = strings.TrimSpace(template)
+	if template == "" {
+		return fmt.Errorf("must not be empty")
+	}
+
+	requireTimestamp := strings.TrimSpace(timestampHeader) != ""
+	sawTimestamp := !requireTimestamp
+	err := visitPayloadTemplate(template, func(string) error {
+		return nil
+	}, func(token string) error {
+		switch {
+		case token == "raw_body":
+			return nil
+		case strings.HasPrefix(strings.ToLower(token), "header:"):
+			headerName := strings.TrimSpace(token[len("header:"):])
+			if headerName == "" {
+				return fmt.Errorf("contains an empty header placeholder")
+			}
+			if requireTimestamp && strings.EqualFold(headerName, timestampHeader) {
+				sawTimestamp = true
+			}
+			return nil
+		default:
+			return fmt.Errorf("placeholder %q is not supported", token)
+		}
+	})
+	if err != nil {
+		return err
+	}
+	if !sawTimestamp {
+		return fmt.Errorf("must include a header placeholder for %q", timestampHeader)
+	}
+	return nil
+}
+
+func RenderPayloadTemplate(template string, headers http.Header, rawBody []byte) (string, error) {
+	var out strings.Builder
+	err := visitPayloadTemplate(strings.TrimSpace(template), func(literal string) error {
+		out.WriteString(literal)
+		return nil
+	}, func(token string) error {
+		switch {
+		case token == "raw_body":
+			_, _ = out.Write(rawBody)
+			return nil
+		case strings.HasPrefix(strings.ToLower(token), "header:"):
+			headerName := strings.TrimSpace(token[len("header:"):])
+			if headerName == "" {
+				return fmt.Errorf("contains an empty header placeholder")
+			}
+			out.WriteString(headers.Get(headerName))
+			return nil
+		default:
+			return fmt.Errorf("placeholder %q is not supported", token)
+		}
+	})
+	if err != nil {
+		return "", err
+	}
+	return out.String(), nil
+}
+
+func visitPayloadTemplate(template string, literalFn func(string) error, tokenFn func(string) error) error {
+	if template == "" {
+		return fmt.Errorf("must not be empty")
+	}
+	for i := 0; i < len(template); {
+		start := strings.IndexByte(template[i:], '{')
+		if start < 0 {
+			return literalFn(template[i:])
+		}
+		start += i
+		end := strings.IndexByte(template[start+1:], '}')
+		if end < 0 {
+			return fmt.Errorf("contains an unterminated placeholder")
+		}
+		end += start + 1
+		if err := literalFn(template[i:start]); err != nil {
+			return err
+		}
+		token := strings.TrimSpace(template[start+1 : end])
+		if err := tokenFn(token); err != nil {
+			return err
+		}
+		i = end + 1
+	}
+	return nil
+}

--- a/gestaltd/internal/providerpkg/go_provider_test.go
+++ b/gestaltd/internal/providerpkg/go_provider_test.go
@@ -32,14 +32,14 @@ func TestPrepareSourceManifest_MergesGeneratedGoManifestMetadata(t *testing.T) {
 		t.Fatalf("prepared manifest data = %q, want merged HTTP binding metadata", string(preparedData))
 	}
 
-	scheme := preparedManifest.Spec.SecuritySchemes["slack"]
+	scheme := preparedManifest.Spec.SecuritySchemes["signed"]
 	if scheme == nil {
-		t.Fatal(`manifest.Spec.SecuritySchemes["slack"] = nil, want generated scheme`)
+		t.Fatal(`manifest.Spec.SecuritySchemes["signed"] = nil, want generated scheme`)
 	}
-	if scheme.Type != providermanifestv1.HTTPSecuritySchemeTypeSlackSignature {
-		t.Fatalf("scheme.Type = %q, want %q", scheme.Type, providermanifestv1.HTTPSecuritySchemeTypeSlackSignature)
+	if scheme.Type != providermanifestv1.HTTPSecuritySchemeTypeHMAC {
+		t.Fatalf("scheme.Type = %q, want %q", scheme.Type, providermanifestv1.HTTPSecuritySchemeTypeHMAC)
 	}
-	if scheme.Secret == nil || scheme.Secret.Env != "SLACK_SIGNING_SECRET" {
+	if scheme.Secret == nil || scheme.Secret.Env != "REQUEST_SIGNING_SECRET" {
 		t.Fatalf("scheme.Secret = %+v, want env-backed secret", scheme.Secret)
 	}
 
@@ -53,8 +53,8 @@ func TestPrepareSourceManifest_MergesGeneratedGoManifestMetadata(t *testing.T) {
 	if binding.Method != "POST" {
 		t.Fatalf("binding.Method = %q, want %q", binding.Method, "POST")
 	}
-	if binding.Security != "slack" {
-		t.Fatalf("binding.Security = %q, want %q", binding.Security, "slack")
+	if binding.Security != "signed" {
+		t.Fatalf("binding.Security = %q, want %q", binding.Security, "signed")
 	}
 	if binding.Target != "echo" {
 		t.Fatalf("binding.Target = %q, want %q", binding.Target, "echo")
@@ -78,7 +78,7 @@ func injectGoManifestMetadata(t *testing.T, providerPath string) {
 		t.Fatalf("ReadFile(%s): %v", providerPath, err)
 	}
 	old := "\t)\n)"
-	new := "\t).WithManifestMetadata(gestalt.ManifestMetadata{\n\t\tSecuritySchemes: map[string]gestalt.HTTPSecurityScheme{\n\t\t\t\"slack\": {\n\t\t\t\tType: gestalt.HTTPSecuritySchemeTypeSlackSignature,\n\t\t\t\tSecret: &gestalt.HTTPSecretRef{Env: \"SLACK_SIGNING_SECRET\"},\n\t\t\t},\n\t\t},\n\t\tHTTP: map[string]gestalt.HTTPBinding{\n\t\t\t\"command\": {\n\t\t\t\tPath:     \"/command\",\n\t\t\t\tMethod:   http.MethodPost,\n\t\t\t\tSecurity: \"slack\",\n\t\t\t\tTarget:   \"echo\",\n\t\t\t\tRequestBody: &gestalt.HTTPRequestBody{\n\t\t\t\t\tRequired: true,\n\t\t\t\t\tContent: map[string]gestalt.HTTPMediaType{\n\t\t\t\t\t\t\"application/x-www-form-urlencoded\": {},\n\t\t\t\t\t},\n\t\t\t\t},\n\t\t\t\tAck: &gestalt.HTTPAck{\n\t\t\t\t\tStatus: 200,\n\t\t\t\t\tBody: map[string]any{\n\t\t\t\t\t\t\"response_type\": \"ephemeral\",\n\t\t\t\t\t\t\"text\":          \"Working on it...\",\n\t\t\t\t\t},\n\t\t\t\t},\n\t\t\t},\n\t\t},\n\t})\n)"
+	new := "\t).WithManifestMetadata(gestalt.ManifestMetadata{\n\t\tSecuritySchemes: map[string]gestalt.HTTPSecurityScheme{\n\t\t\t\"signed\": {\n\t\t\t\tType: gestalt.HTTPSecuritySchemeTypeHMAC,\n\t\t\t\tSecret: &gestalt.HTTPSecretRef{Env: \"REQUEST_SIGNING_SECRET\"},\n\t\t\t\tSignatureHeader: \"X-Request-Signature\",\n\t\t\t\tSignaturePrefix: \"v0=\",\n\t\t\t\tPayloadTemplate: \"v0:{header:X-Request-Timestamp}:{raw_body}\",\n\t\t\t\tTimestampHeader: \"X-Request-Timestamp\",\n\t\t\t\tMaxAgeSeconds: 300,\n\t\t\t},\n\t\t},\n\t\tHTTP: map[string]gestalt.HTTPBinding{\n\t\t\t\"command\": {\n\t\t\t\tPath:     \"/command\",\n\t\t\t\tMethod:   http.MethodPost,\n\t\t\t\tSecurity: \"signed\",\n\t\t\t\tTarget:   \"echo\",\n\t\t\t\tRequestBody: &gestalt.HTTPRequestBody{\n\t\t\t\t\tRequired: true,\n\t\t\t\t\tContent: map[string]gestalt.HTTPMediaType{\n\t\t\t\t\t\t\"application/x-www-form-urlencoded\": {},\n\t\t\t\t\t},\n\t\t\t\t},\n\t\t\t\tAck: &gestalt.HTTPAck{\n\t\t\t\t\tStatus: 200,\n\t\t\t\t\tBody: map[string]any{\n\t\t\t\t\t\t\"status\": \"accepted\",\n\t\t\t\t\t},\n\t\t\t\t},\n\t\t\t},\n\t\t},\n\t})\n)"
 	updated := strings.Replace(string(data), old, new, 1)
 	if updated == string(data) {
 		t.Fatalf("provider fixture %s missing router terminator %q", providerPath, old)

--- a/gestaltd/internal/providerpkg/manifest.go
+++ b/gestaltd/internal/providerpkg/manifest.go
@@ -12,6 +12,7 @@ import (
 	"slices"
 	"strings"
 
+	"github.com/valon-technologies/gestalt/server/internal/httpbinding"
 	"github.com/valon-technologies/gestalt/server/internal/pluginsource"
 	providermanifestv1 "github.com/valon-technologies/gestalt/server/sdk/providermanifest/v1"
 	"gopkg.in/yaml.v3"
@@ -449,9 +450,24 @@ func validateHTTPSecurityScheme(path string, scheme *providermanifestv1.HTTPSecu
 		return fmt.Errorf("%s is required", path)
 	}
 	switch scheme.Type {
-	case providermanifestv1.HTTPSecuritySchemeTypeSlackSignature:
+	case providermanifestv1.HTTPSecuritySchemeTypeHMAC:
+		if strings.TrimSpace(scheme.SignatureHeader) == "" {
+			return fmt.Errorf("%s.signatureHeader is required", path)
+		}
+		if strings.TrimSpace(scheme.PayloadTemplate) == "" {
+			return fmt.Errorf("%s.payloadTemplate is required", path)
+		}
 		if scheme.Secret == nil {
 			return fmt.Errorf("%s.secret is required", path)
+		}
+		if strings.TrimSpace(scheme.TimestampHeader) == "" && scheme.MaxAgeSeconds != 0 {
+			return fmt.Errorf("%s.maxAgeSeconds requires %s.timestampHeader to be set", path, path)
+		}
+		if strings.TrimSpace(scheme.TimestampHeader) != "" && scheme.MaxAgeSeconds <= 0 {
+			return fmt.Errorf("%s.timestampHeader requires %s.maxAgeSeconds to be greater than zero", path, path)
+		}
+		if err := httpbinding.ValidatePayloadTemplate(scheme.PayloadTemplate, scheme.TimestampHeader); err != nil {
+			return fmt.Errorf("%s.payloadTemplate %s", path, err)
 		}
 	case providermanifestv1.HTTPSecuritySchemeTypeAPIKey:
 		if strings.TrimSpace(scheme.Name) == "" {

--- a/gestaltd/internal/providerpkg/manifest_workflow_test.go
+++ b/gestaltd/internal/providerpkg/manifest_workflow_test.go
@@ -502,19 +502,24 @@ func TestManifestWorkflow_AcceptsHostedHTTPBindingsAndSecuritySchemes(t *testing
 	dir := t.TempDir()
 	manifestPath := mustWriteManifestData(t, dir, "manifest.yaml", []byte(`
 kind: plugin
-source: github.com/acme/plugins/slack
+source: github.com/acme/plugins/signed
 version: 1.0.0
 spec:
   securitySchemes:
-    slack:
-      type: slack_signature
+    signed:
+      type: hmac
       secret:
-        env: SLACK_SIGNING_SECRET
+        env: REQUEST_SIGNING_SECRET
+      signatureHeader: X-Request-Signature
+      signaturePrefix: v0=
+      payloadTemplate: "v0:{header:X-Request-Timestamp}:{raw_body}"
+      timestampHeader: X-Request-Timestamp
+      maxAgeSeconds: 300
   http:
     command:
       path: /command
       method: POST
-      security: slack
+      security: signed
       requestBody:
         required: true
         content:
@@ -522,8 +527,7 @@ spec:
       target: handle_command
       ack:
         body:
-          response_type: ephemeral
-          text: Working on it...
+          status: accepted
 `))
 
 	_, manifest, err := ReadSourceManifestFile(manifestPath)
@@ -533,8 +537,8 @@ spec:
 	if manifest.Spec == nil {
 		t.Fatal("expected plugin metadata")
 	}
-	if manifest.Spec.SecuritySchemes["slack"] == nil || manifest.Spec.SecuritySchemes["slack"].Type != providermanifestv1.HTTPSecuritySchemeTypeSlackSignature {
-		t.Fatalf("unexpected security scheme: %#v", manifest.Spec.SecuritySchemes["slack"])
+	if manifest.Spec.SecuritySchemes["signed"] == nil || manifest.Spec.SecuritySchemes["signed"].Type != providermanifestv1.HTTPSecuritySchemeTypeHMAC {
+		t.Fatalf("unexpected security scheme: %#v", manifest.Spec.SecuritySchemes["signed"])
 	}
 	if manifest.Spec.HTTP["command"] == nil {
 		t.Fatal("expected http binding")
@@ -617,6 +621,66 @@ spec:
 	}
 	if !strings.Contains(err.Error(), `provider.http.command.requestBody.content "application/json" is duplicated after normalization`) {
 		t.Fatalf("error = %v", err)
+	}
+}
+
+func TestManifestWorkflow_RejectsInvalidHMACPayloadTemplates(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name            string
+		payloadTemplate string
+		want            string
+	}{
+		{
+			name:            "missing timestamp placeholder",
+			payloadTemplate: "{raw_body}",
+			want:            `provider.securitySchemes.signed.payloadTemplate must include a header placeholder for "X-Request-Timestamp"`,
+		},
+		{
+			name:            "unsupported placeholder",
+			payloadTemplate: "v0:{query:id}:{raw_body}",
+			want:            `provider.securitySchemes.signed.payloadTemplate placeholder "query:id" is not supported`,
+		},
+	}
+
+	for _, tt := range tests {
+		tt := tt
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			dir := t.TempDir()
+			manifestPath := mustWriteManifestData(t, dir, "manifest.yaml", []byte(`
+kind: plugin
+source: github.com/acme/plugins/bad-http-template
+version: 1.0.0
+spec:
+  securitySchemes:
+    signed:
+      type: hmac
+      secret:
+        env: REQUEST_SIGNING_SECRET
+      signatureHeader: X-Request-Signature
+      signaturePrefix: v0=
+      payloadTemplate: "`+tt.payloadTemplate+`"
+      timestampHeader: X-Request-Timestamp
+      maxAgeSeconds: 300
+  http:
+    command:
+      path: /command
+      method: POST
+      security: signed
+      target: handle_command
+`))
+
+			_, _, err := ReadSourceManifestFile(manifestPath)
+			if err == nil {
+				t.Fatal("expected invalid manifest")
+			}
+			if !strings.Contains(err.Error(), tt.want) {
+				t.Fatalf("error = %v, want substring %q", err, tt.want)
+			}
+		})
 	}
 }
 

--- a/gestaltd/internal/providerpkg/python_provider_test.go
+++ b/gestaltd/internal/providerpkg/python_provider_test.go
@@ -248,16 +248,21 @@ provider = "provider:plugin"
 plugin = Plugin(
     "python-release",
     securitySchemes={
-        "slack": {
-            "type": "slack_signature",
-            "secret": {"env": "SLACK_SIGNING_SECRET"},
+        "signed": {
+            "type": "hmac",
+            "secret": {"env": "REQUEST_SIGNING_SECRET"},
+            "signatureHeader": "X-Request-Signature",
+            "signaturePrefix": "v0=",
+            "payloadTemplate": "v0:{header:X-Request-Timestamp}:{raw_body}",
+            "timestampHeader": "X-Request-Timestamp",
+            "maxAgeSeconds": 300,
         }
     },
     http={
         "command": {
             "path": "/command",
             "method": "POST",
-            "security": "slack",
+            "security": "signed",
             "target": "handle_command",
             "requestBody": {
                 "required": True,
@@ -268,8 +273,7 @@ plugin = Plugin(
             "ack": {
                 "status": 200,
                 "body": {
-                    "response_type": "ephemeral",
-                    "text": "Working on it...",
+                    "status": "accepted",
                 },
             },
         }
@@ -301,14 +305,14 @@ def handle_command() -> dict[str, str]:
 		t.Fatalf("prepared manifest data = %q, want merged HTTP binding metadata", string(preparedData))
 	}
 
-	scheme := preparedManifest.Spec.SecuritySchemes["slack"]
+	scheme := preparedManifest.Spec.SecuritySchemes["signed"]
 	if scheme == nil {
-		t.Fatal(`manifest.Spec.SecuritySchemes["slack"] = nil, want generated scheme`)
+		t.Fatal(`manifest.Spec.SecuritySchemes["signed"] = nil, want generated scheme`)
 	}
-	if scheme.Type != providermanifestv1.HTTPSecuritySchemeTypeSlackSignature {
-		t.Fatalf("scheme.Type = %q, want %q", scheme.Type, providermanifestv1.HTTPSecuritySchemeTypeSlackSignature)
+	if scheme.Type != providermanifestv1.HTTPSecuritySchemeTypeHMAC {
+		t.Fatalf("scheme.Type = %q, want %q", scheme.Type, providermanifestv1.HTTPSecuritySchemeTypeHMAC)
 	}
-	if scheme.Secret == nil || scheme.Secret.Env != "SLACK_SIGNING_SECRET" {
+	if scheme.Secret == nil || scheme.Secret.Env != "REQUEST_SIGNING_SECRET" {
 		t.Fatalf("scheme.Secret = %+v, want env-backed secret", scheme.Secret)
 	}
 
@@ -322,8 +326,8 @@ def handle_command() -> dict[str, str]:
 	if binding.Method != "POST" {
 		t.Fatalf("binding.Method = %q, want %q", binding.Method, "POST")
 	}
-	if binding.Security != "slack" {
-		t.Fatalf("binding.Security = %q, want %q", binding.Security, "slack")
+	if binding.Security != "signed" {
+		t.Fatalf("binding.Security = %q, want %q", binding.Security, "signed")
 	}
 	if binding.Target != "handle_command" {
 		t.Fatalf("binding.Target = %q, want %q", binding.Target, "handle_command")

--- a/gestaltd/internal/providerpkg/rust_provider_test.go
+++ b/gestaltd/internal/providerpkg/rust_provider_test.go
@@ -298,15 +298,20 @@ func TestPrepareSourceManifest_MergesGeneratedRustManifestMetadata(t *testing.T)
 		ExpectedCatalogWrite: true,
 		GeneratedCatalog:     "provider-rust",
 		GeneratedManifestMetadata: `securitySchemes:
-  slack:
-    type: slack_signature
+  signed:
+    type: hmac
     secret:
-      env: SLACK_SIGNING_SECRET
+      env: REQUEST_SIGNING_SECRET
+    signatureHeader: X-Request-Signature
+    signaturePrefix: v0=
+    payloadTemplate: "v0:{header:X-Request-Timestamp}:{raw_body}"
+    timestampHeader: X-Request-Timestamp
+    maxAgeSeconds: 300
 http:
   command:
     path: /command
     method: POST
-    security: slack
+    security: signed
     target: handle_command
     requestBody:
       required: true
@@ -315,8 +320,7 @@ http:
     ack:
       status: 200
       body:
-        response_type: ephemeral
-        text: Working on it...`,
+        status: accepted`,
 	})
 	t.Setenv("PATH", fakeCargoDir+string(os.PathListSeparator)+os.Getenv("PATH"))
 
@@ -335,14 +339,14 @@ http:
 		t.Fatalf("prepared manifest data = %q, want merged HTTP binding metadata", string(preparedData))
 	}
 
-	scheme := preparedManifest.Spec.SecuritySchemes["slack"]
+	scheme := preparedManifest.Spec.SecuritySchemes["signed"]
 	if scheme == nil {
-		t.Fatal(`manifest.Spec.SecuritySchemes["slack"] = nil, want generated scheme`)
+		t.Fatal(`manifest.Spec.SecuritySchemes["signed"] = nil, want generated scheme`)
 	}
-	if scheme.Type != providermanifestv1.HTTPSecuritySchemeTypeSlackSignature {
-		t.Fatalf("scheme.Type = %q, want %q", scheme.Type, providermanifestv1.HTTPSecuritySchemeTypeSlackSignature)
+	if scheme.Type != providermanifestv1.HTTPSecuritySchemeTypeHMAC {
+		t.Fatalf("scheme.Type = %q, want %q", scheme.Type, providermanifestv1.HTTPSecuritySchemeTypeHMAC)
 	}
-	if scheme.Secret == nil || scheme.Secret.Env != "SLACK_SIGNING_SECRET" {
+	if scheme.Secret == nil || scheme.Secret.Env != "REQUEST_SIGNING_SECRET" {
 		t.Fatalf("scheme.Secret = %+v, want env-backed secret", scheme.Secret)
 	}
 
@@ -356,8 +360,8 @@ http:
 	if binding.Method != "POST" {
 		t.Fatalf("binding.Method = %q, want %q", binding.Method, "POST")
 	}
-	if binding.Security != "slack" {
-		t.Fatalf("binding.Security = %q, want %q", binding.Security, "slack")
+	if binding.Security != "signed" {
+		t.Fatalf("binding.Security = %q, want %q", binding.Security, "signed")
 	}
 	if binding.Target != "handle_command" {
 		t.Fatalf("binding.Target = %q, want %q", binding.Target, "handle_command")

--- a/gestaltd/internal/providerpkg/source_manifest_metadata.go
+++ b/gestaltd/internal/providerpkg/source_manifest_metadata.go
@@ -199,6 +199,21 @@ func mergeGeneratedHTTPSecurityScheme(base, override *providermanifestv1.HTTPSec
 	if override.Description != "" {
 		merged.Description = override.Description
 	}
+	if override.SignatureHeader != "" {
+		merged.SignatureHeader = override.SignatureHeader
+	}
+	if override.SignaturePrefix != "" {
+		merged.SignaturePrefix = override.SignaturePrefix
+	}
+	if override.PayloadTemplate != "" {
+		merged.PayloadTemplate = override.PayloadTemplate
+	}
+	if override.TimestampHeader != "" {
+		merged.TimestampHeader = override.TimestampHeader
+	}
+	if override.MaxAgeSeconds != 0 {
+		merged.MaxAgeSeconds = override.MaxAgeSeconds
+	}
 	if override.Name != "" {
 		merged.Name = override.Name
 	}

--- a/gestaltd/internal/providerpkg/typescript_provider_test.go
+++ b/gestaltd/internal/providerpkg/typescript_provider_test.go
@@ -448,11 +448,16 @@ func TestPrepareSourceManifest_MergesGeneratedTypeScriptManifestMetadata(t *test
 				},
 			},
 			SecuritySchemes: map[string]*providermanifestv1.HTTPSecurityScheme{
-				"slack": {
-					Type: providermanifestv1.HTTPSecuritySchemeTypeSlackSignature,
+				"signed": {
+					Type: providermanifestv1.HTTPSecuritySchemeTypeHMAC,
 					Secret: &providermanifestv1.HTTPSecretRef{
-						Env: "SLACK_SIGNING_SECRET",
+						Env: "OLD_SIGNING_SECRET",
 					},
+					SignatureHeader: "X-Old-Signature",
+					SignaturePrefix: "v1=",
+					PayloadTemplate: "v1:{header:X-Old-Timestamp}:{raw_body}",
+					TimestampHeader: "X-Old-Timestamp",
+					MaxAgeSeconds:   30,
 				},
 			},
 		},
@@ -481,15 +486,30 @@ func TestPrepareSourceManifest_MergesGeneratedTypeScriptManifestMetadata(t *test
 		t.Fatalf("prepared manifest data = %q, want merged HTTP binding metadata", string(preparedData))
 	}
 
-	scheme := preparedManifest.Spec.SecuritySchemes["slack"]
+	scheme := preparedManifest.Spec.SecuritySchemes["signed"]
 	if scheme == nil {
-		t.Fatal(`manifest.Spec.SecuritySchemes["slack"] = nil, want generated scheme`)
+		t.Fatal(`manifest.Spec.SecuritySchemes["signed"] = nil, want generated scheme`)
 	}
-	if scheme.Type != providermanifestv1.HTTPSecuritySchemeTypeSlackSignature {
-		t.Fatalf("scheme.Type = %q, want %q", scheme.Type, providermanifestv1.HTTPSecuritySchemeTypeSlackSignature)
+	if scheme.Type != providermanifestv1.HTTPSecuritySchemeTypeHMAC {
+		t.Fatalf("scheme.Type = %q, want %q", scheme.Type, providermanifestv1.HTTPSecuritySchemeTypeHMAC)
 	}
-	if scheme.Secret == nil || scheme.Secret.Env != "SLACK_SIGNING_SECRET" {
-		t.Fatalf("scheme.Secret = %+v, want env-backed secret", scheme.Secret)
+	if scheme.Secret == nil || scheme.Secret.Env != "OLD_SIGNING_SECRET" {
+		t.Fatalf("scheme.Secret = %+v, want manifest override secret", scheme.Secret)
+	}
+	if scheme.SignatureHeader != "X-Old-Signature" {
+		t.Fatalf("scheme.SignatureHeader = %q, want %q", scheme.SignatureHeader, "X-Old-Signature")
+	}
+	if scheme.SignaturePrefix != "v1=" {
+		t.Fatalf("scheme.SignaturePrefix = %q, want %q", scheme.SignaturePrefix, "v1=")
+	}
+	if scheme.PayloadTemplate != "v1:{header:X-Old-Timestamp}:{raw_body}" {
+		t.Fatalf("scheme.PayloadTemplate = %q, want %q", scheme.PayloadTemplate, "v1:{header:X-Old-Timestamp}:{raw_body}")
+	}
+	if scheme.TimestampHeader != "X-Old-Timestamp" {
+		t.Fatalf("scheme.TimestampHeader = %q, want %q", scheme.TimestampHeader, "X-Old-Timestamp")
+	}
+	if scheme.MaxAgeSeconds != 30 {
+		t.Fatalf("scheme.MaxAgeSeconds = %d, want %d", scheme.MaxAgeSeconds, 30)
 	}
 
 	binding := preparedManifest.Spec.HTTP["command"]
@@ -502,8 +522,8 @@ func TestPrepareSourceManifest_MergesGeneratedTypeScriptManifestMetadata(t *test
 	if binding.Method != "POST" {
 		t.Fatalf("binding.Method = %q, want %q", binding.Method, "POST")
 	}
-	if binding.Security != "slack" {
-		t.Fatalf("binding.Security = %q, want %q", binding.Security, "slack")
+	if binding.Security != "signed" {
+		t.Fatalf("binding.Security = %q, want %q", binding.Security, "signed")
 	}
 	if binding.Target != "handle_command" {
 		t.Fatalf("binding.Target = %q, want %q", binding.Target, "handle_command")
@@ -817,15 +837,20 @@ EOF
     if [ -n "${GESTALT_PLUGIN_WRITE_MANIFEST_METADATA:-}" ]; then
       cat > "$GESTALT_PLUGIN_WRITE_MANIFEST_METADATA" <<'EOF'
 securitySchemes:
-  slack:
-    type: slack_signature
+  signed:
+    type: hmac
     secret:
-      env: SLACK_SIGNING_SECRET
+      env: REQUEST_SIGNING_SECRET
+    signatureHeader: X-Request-Signature
+    signaturePrefix: v0=
+    payloadTemplate: "v0:{header:X-Request-Timestamp}:{raw_body}"
+    timestampHeader: X-Request-Timestamp
+    maxAgeSeconds: 300
 http:
   command:
     path: /command
     method: POST
-    security: slack
+    security: signed
     target: handle_command
     requestBody:
       required: true

--- a/gestaltd/internal/server/http_binding_verify.go
+++ b/gestaltd/internal/server/http_binding_verify.go
@@ -11,6 +11,7 @@ import (
 	"strings"
 	"time"
 
+	"github.com/valon-technologies/gestalt/server/internal/httpbinding"
 	providermanifestv1 "github.com/valon-technologies/gestalt/server/sdk/providermanifest/v1"
 )
 
@@ -52,8 +53,8 @@ func (s *Server) verifyHTTPBindingRequest(r *http.Request, binding MountedHTTPBi
 		return nil, newHTTPBindingRequestError(http.StatusInternalServerError, "http binding security is not configured", nil)
 	}
 	switch binding.Security.Type {
-	case providermanifestv1.HTTPSecuritySchemeTypeSlackSignature:
-		return s.verifySlackSignatureRequest(r, binding, rawBody)
+	case providermanifestv1.HTTPSecuritySchemeTypeHMAC:
+		return s.verifyHTTPBindingHMACRequest(r, binding, rawBody)
 	case providermanifestv1.HTTPSecuritySchemeTypeAPIKey:
 		return verifyHTTPBindingAPIKey(r, binding)
 	case providermanifestv1.HTTPSecuritySchemeTypeHTTP:
@@ -71,40 +72,47 @@ func (s *Server) verifyHTTPBindingRequest(r *http.Request, binding MountedHTTPBi
 	}
 }
 
-func (s *Server) verifySlackSignatureRequest(r *http.Request, binding MountedHTTPBinding, rawBody []byte) (*verifiedHTTPBindingSender, error) {
+func (s *Server) verifyHTTPBindingHMACRequest(r *http.Request, binding MountedHTTPBinding, rawBody []byte) (*verifiedHTTPBindingSender, error) {
 	secret, err := resolveHTTPBindingSecret(binding.Security.Secret)
 	if err != nil {
 		return nil, newHTTPBindingRequestError(http.StatusInternalServerError, "http binding secret is not configured", err)
 	}
-	timestamp := strings.TrimSpace(r.Header.Get("X-Slack-Request-Timestamp"))
-	if timestamp == "" {
-		return nil, newHTTPBindingRequestError(http.StatusUnauthorized, "missing Slack request timestamp", nil)
-	}
-	requestTime, err := parseUnixTimestamp(timestamp)
-	if err != nil {
-		return nil, newHTTPBindingRequestError(http.StatusUnauthorized, "invalid Slack request timestamp", err)
-	}
-	now := time.Now()
-	if s != nil && s.now != nil {
-		now = s.now()
-	}
-	if delta := now.Sub(requestTime); delta > 5*time.Minute || delta < -5*time.Minute {
-		return nil, newHTTPBindingRequestError(http.StatusUnauthorized, "stale Slack request timestamp", nil)
-	}
-	signature := strings.TrimSpace(r.Header.Get("X-Slack-Signature"))
+	signature := strings.TrimSpace(r.Header.Get(strings.TrimSpace(binding.Security.SignatureHeader)))
 	if signature == "" {
-		return nil, newHTTPBindingRequestError(http.StatusUnauthorized, "missing Slack signature", nil)
+		return nil, newHTTPBindingRequestError(http.StatusUnauthorized, "missing request signature", nil)
+	}
+	if strings.TrimSpace(binding.Security.TimestampHeader) != "" {
+		timestamp := strings.TrimSpace(r.Header.Get(strings.TrimSpace(binding.Security.TimestampHeader)))
+		if timestamp == "" {
+			return nil, newHTTPBindingRequestError(http.StatusUnauthorized, "missing request timestamp", nil)
+		}
+		requestTime, err := parseUnixTimestamp(timestamp)
+		if err != nil {
+			return nil, newHTTPBindingRequestError(http.StatusUnauthorized, "invalid request timestamp", err)
+		}
+		now := time.Now()
+		if s != nil && s.now != nil {
+			now = s.now()
+		}
+		maxAge := time.Duration(binding.Security.MaxAgeSeconds) * time.Second
+		if delta := now.Sub(requestTime); delta > maxAge || delta < -maxAge {
+			return nil, newHTTPBindingRequestError(http.StatusUnauthorized, "stale request timestamp", nil)
+		}
+	}
+	payload, err := httpbinding.RenderPayloadTemplate(binding.Security.PayloadTemplate, r.Header, rawBody)
+	if err != nil {
+		return nil, newHTTPBindingRequestError(http.StatusInternalServerError, "invalid http binding payload template", err)
 	}
 	mac := hmac.New(sha256.New, []byte(secret))
-	_, _ = mac.Write([]byte("v0:" + timestamp + ":" + string(rawBody)))
-	expected := "v0=" + fmt.Sprintf("%x", mac.Sum(nil))
+	_, _ = mac.Write([]byte(payload))
+	expected := strings.TrimSpace(binding.Security.SignaturePrefix) + fmt.Sprintf("%x", mac.Sum(nil))
 	if subtle.ConstantTimeCompare([]byte(expected), []byte(signature)) != 1 {
-		return nil, newHTTPBindingRequestError(http.StatusUnauthorized, "invalid Slack signature", nil)
+		return nil, newHTTPBindingRequestError(http.StatusUnauthorized, "invalid request signature", nil)
 	}
-	if binding.Ack != nil {
+	if binding.Ack != nil && strings.TrimSpace(binding.Security.TimestampHeader) != "" && binding.Security.MaxAgeSeconds > 0 {
 		replayKey := binding.PluginName + "\x00" + binding.Name + "\x00" + binding.SecurityName + "\x00sig:" + signature
-		if !s.httpBindingReplayStore.MarkIfNew(replayKey, 5*time.Minute) {
-			return nil, newHTTPBindingRequestError(http.StatusOK, "duplicate Slack delivery", nil)
+		if !s.httpBindingReplayStore.MarkIfNew(replayKey, time.Duration(binding.Security.MaxAgeSeconds)*time.Second) {
+			return nil, newHTTPBindingRequestError(http.StatusOK, "duplicate signed delivery", nil)
 		}
 	}
 	return &verifiedHTTPBindingSender{

--- a/gestaltd/internal/server/http_bindings.go
+++ b/gestaltd/internal/server/http_bindings.go
@@ -11,6 +11,7 @@ import (
 	"github.com/valon-technologies/gestalt/server/core"
 	"github.com/valon-technologies/gestalt/server/core/catalog"
 	"github.com/valon-technologies/gestalt/server/internal/config"
+	"github.com/valon-technologies/gestalt/server/internal/httpbinding"
 	"github.com/valon-technologies/gestalt/server/internal/registry"
 	providermanifestv1 "github.com/valon-technologies/gestalt/server/sdk/providermanifest/v1"
 )
@@ -175,9 +176,24 @@ func validateMountedHTTPSecurityScheme(pluginName, schemeName string, scheme *co
 		return fmt.Errorf("%s is required", path)
 	}
 	switch scheme.Type {
-	case providermanifestv1.HTTPSecuritySchemeTypeSlackSignature:
+	case providermanifestv1.HTTPSecuritySchemeTypeHMAC:
+		if strings.TrimSpace(scheme.SignatureHeader) == "" {
+			return fmt.Errorf("%s.signatureHeader is required", path)
+		}
+		if strings.TrimSpace(scheme.PayloadTemplate) == "" {
+			return fmt.Errorf("%s.payloadTemplate is required", path)
+		}
 		if scheme.Secret == nil {
 			return fmt.Errorf("%s.secret is required", path)
+		}
+		if strings.TrimSpace(scheme.TimestampHeader) == "" && scheme.MaxAgeSeconds != 0 {
+			return fmt.Errorf("%s.maxAgeSeconds requires %s.timestampHeader to be set", path, path)
+		}
+		if strings.TrimSpace(scheme.TimestampHeader) != "" && scheme.MaxAgeSeconds <= 0 {
+			return fmt.Errorf("%s.timestampHeader requires %s.maxAgeSeconds to be greater than zero", path, path)
+		}
+		if err := httpbinding.ValidatePayloadTemplate(scheme.PayloadTemplate, scheme.TimestampHeader); err != nil {
+			return fmt.Errorf("%s.payloadTemplate %s", path, err)
 		}
 	case providermanifestv1.HTTPSecuritySchemeTypeAPIKey:
 		if strings.TrimSpace(scheme.Name) == "" {

--- a/gestaltd/internal/server/server_test.go
+++ b/gestaltd/internal/server/server_test.go
@@ -11619,8 +11619,8 @@ func TestExecuteOperation_POST(t *testing.T) {
 	}
 }
 
-func TestHostedHTTPBinding_SlackSignatureAckDispatchesOperationAndRejectsReplay(t *testing.T) {
-	t.Setenv("SLACK_SIGNING_SECRET", "super-secret")
+func TestHostedHTTPBinding_HMACAckDispatchesOperationAndRejectsReplay(t *testing.T) {
+	t.Setenv("REQUEST_SIGNING_SECRET", "super-secret")
 
 	type bindingInvocation struct {
 		Params   map[string]any
@@ -11630,7 +11630,7 @@ func TestHostedHTTPBinding_SlackSignatureAckDispatchesOperationAndRejectsReplay(
 	invocations := make(chan bindingInvocation, 1)
 	provider := &stubIntegrationWithOps{
 		StubIntegration: coretesting.StubIntegration{
-			N:        "slack",
+			N:        "signed",
 			ConnMode: core.ConnectionModeNone,
 			ExecuteFn: func(ctx context.Context, op string, params map[string]any, _ string) (*core.OperationResult, error) {
 				if op != "handle_command" {
@@ -11649,13 +11649,18 @@ func TestHostedHTTPBinding_SlackSignatureAckDispatchesOperationAndRejectsReplay(
 	ts := newTestServer(t, func(cfg *server.Config) {
 		cfg.Providers = testutil.NewProviderRegistry(t, provider)
 		cfg.PluginDefs = map[string]*config.ProviderEntry{
-			"slack": {
+			"signed": {
 				SecuritySchemes: map[string]*config.HTTPSecurityScheme{
-					"slack": {
-						Type: providermanifestv1.HTTPSecuritySchemeTypeSlackSignature,
+					"signed": {
+						Type: providermanifestv1.HTTPSecuritySchemeTypeHMAC,
 						Secret: &providermanifestv1.HTTPSecretRef{
-							Env: "SLACK_SIGNING_SECRET",
+							Env: "REQUEST_SIGNING_SECRET",
 						},
+						SignatureHeader: "X-Request-Signature",
+						SignaturePrefix: "v0=",
+						PayloadTemplate: "v0:{header:X-Request-Timestamp}:{raw_body}",
+						TimestampHeader: "X-Request-Timestamp",
+						MaxAgeSeconds:   300,
 					},
 				},
 				HTTP: map[string]*config.HTTPBinding{
@@ -11668,12 +11673,11 @@ func TestHostedHTTPBinding_SlackSignatureAckDispatchesOperationAndRejectsReplay(
 								"application/x-www-form-urlencoded": {},
 							},
 						},
-						Security: "slack",
+						Security: "signed",
 						Target:   "handle_command",
 						Ack: &providermanifestv1.HTTPAck{
 							Body: map[string]any{
-								"response_type": "ephemeral",
-								"text":          "Working on it...",
+								"status": "accepted",
 							},
 						},
 					},
@@ -11684,18 +11688,18 @@ func TestHostedHTTPBinding_SlackSignatureAckDispatchesOperationAndRejectsReplay(
 	})
 	testutil.CloseOnCleanup(t, ts)
 
-	body := "text=hello&response_url=https%3A%2F%2Fhooks.example.test%2Fresponse"
+	body := "text=hello&callback_url=https%3A%2F%2Fhooks.example.test%2Fresponse"
 	timestamp := strconv.FormatInt(time.Now().Unix(), 10)
 	signature := httpBindingTestSignature("super-secret", "v0:"+timestamp+":"+body)
 
 	makeRequest := func() *http.Request {
-		req, err := http.NewRequest(http.MethodPost, ts.URL+"/api/v1/slack/command?source=query", strings.NewReader(body))
+		req, err := http.NewRequest(http.MethodPost, ts.URL+"/api/v1/signed/command?source=query", strings.NewReader(body))
 		if err != nil {
 			t.Fatalf("NewRequest: %v", err)
 		}
 		req.Header.Set("Content-Type", "application/x-www-form-urlencoded")
-		req.Header.Set("X-Slack-Request-Timestamp", timestamp)
-		req.Header.Set("X-Slack-Signature", signature)
+		req.Header.Set("X-Request-Timestamp", timestamp)
+		req.Header.Set("X-Request-Signature", signature)
 		return req
 	}
 
@@ -11711,11 +11715,8 @@ func TestHostedHTTPBinding_SlackSignatureAckDispatchesOperationAndRejectsReplay(
 	if err := json.NewDecoder(resp.Body).Decode(&ack); err != nil {
 		t.Fatalf("decode ack: %v", err)
 	}
-	if got, want := ack["response_type"], "ephemeral"; got != want {
-		t.Fatalf("response_type = %#v, want %q", got, want)
-	}
-	if got, want := ack["text"], "Working on it..."; got != want {
-		t.Fatalf("text = %#v, want %q", got, want)
+	if got, want := ack["status"], "accepted"; got != want {
+		t.Fatalf("status = %#v, want %q", got, want)
 	}
 
 	select {
@@ -11723,8 +11724,8 @@ func TestHostedHTTPBinding_SlackSignatureAckDispatchesOperationAndRejectsReplay(
 		if got, want := invocation.Params["text"], "hello"; got != want {
 			t.Fatalf("params[text] = %#v, want %q", got, want)
 		}
-		if got, want := invocation.Params["response_url"], "https://hooks.example.test/response"; got != want {
-			t.Fatalf("params[response_url] = %#v, want %q", got, want)
+		if got, want := invocation.Params["callback_url"], "https://hooks.example.test/response"; got != want {
+			t.Fatalf("params[callback_url] = %#v, want %q", got, want)
 		}
 		if got, want := invocation.Params["source"], "query"; got != want {
 			t.Fatalf("params[source] = %#v, want %q", got, want)
@@ -11736,10 +11737,10 @@ func TestHostedHTTPBinding_SlackSignatureAckDispatchesOperationAndRejectsReplay(
 		if got, want := httpCtx["name"], "command"; got != want {
 			t.Fatalf("http context name = %#v, want %q", got, want)
 		}
-		if got, want := httpCtx["path"], "/api/v1/slack/command"; got != want {
+		if got, want := httpCtx["path"], "/api/v1/signed/command"; got != want {
 			t.Fatalf("http context path = %#v, want %q", got, want)
 		}
-		if got, want := httpCtx["security"], "slack"; got != want {
+		if got, want := httpCtx["security"], "signed"; got != want {
 			t.Fatalf("http context security = %#v, want %q", got, want)
 		}
 	case <-time.After(2 * time.Second):
@@ -11758,8 +11759,8 @@ func TestHostedHTTPBinding_SlackSignatureAckDispatchesOperationAndRejectsReplay(
 	if err := json.NewDecoder(resp.Body).Decode(&duplicateAck); err != nil {
 		t.Fatalf("decode duplicate ack: %v", err)
 	}
-	if got, want := duplicateAck["response_type"], "ephemeral"; got != want {
-		t.Fatalf("duplicate response_type = %#v, want %q", got, want)
+	if got, want := duplicateAck["status"], "accepted"; got != want {
+		t.Fatalf("duplicate status = %#v, want %q", got, want)
 	}
 	select {
 	case invocation := <-invocations:
@@ -11769,12 +11770,12 @@ func TestHostedHTTPBinding_SlackSignatureAckDispatchesOperationAndRejectsReplay(
 }
 
 func TestHostedHTTPBinding_MergesManifestAndConfigOverrides(t *testing.T) {
-	t.Setenv("SLACK_SIGNING_SECRET", "super-secret")
+	t.Setenv("REQUEST_SIGNING_SECRET", "super-secret")
 
 	invocations := make(chan map[string]any, 1)
 	provider := &stubIntegrationWithOps{
 		StubIntegration: coretesting.StubIntegration{
-			N:        "slack",
+			N:        "signed",
 			ConnMode: core.ConnectionModeNone,
 			ExecuteFn: func(_ context.Context, op string, params map[string]any, _ string) (*core.OperationResult, error) {
 				if op != "handle_command" {
@@ -11790,11 +11791,18 @@ func TestHostedHTTPBinding_MergesManifestAndConfigOverrides(t *testing.T) {
 	ts := newTestServer(t, func(cfg *server.Config) {
 		cfg.Providers = testutil.NewProviderRegistry(t, provider)
 		cfg.PluginDefs = map[string]*config.ProviderEntry{
-			"slack": {
+			"signed": {
 				ResolvedManifest: &providermanifestv1.Manifest{
 					Spec: &providermanifestv1.Spec{
 						SecuritySchemes: map[string]*providermanifestv1.HTTPSecurityScheme{
-							"slack": {Type: providermanifestv1.HTTPSecuritySchemeTypeSlackSignature},
+							"signed": {
+								Type:            providermanifestv1.HTTPSecuritySchemeTypeHMAC,
+								SignatureHeader: "X-Request-Signature",
+								SignaturePrefix: "v0=",
+								PayloadTemplate: "v0:{header:X-Request-Timestamp}:{raw_body}",
+								TimestampHeader: "X-Request-Timestamp",
+								MaxAgeSeconds:   300,
+							},
 						},
 						HTTP: map[string]*providermanifestv1.HTTPBinding{
 							"command": {
@@ -11806,23 +11814,22 @@ func TestHostedHTTPBinding_MergesManifestAndConfigOverrides(t *testing.T) {
 										"application/x-www-form-urlencoded": {},
 									},
 								},
-								Security: "slack",
+								Security: "signed",
 								Target:   "handle_command",
 							},
 						},
 					},
 				},
 				SecuritySchemes: map[string]*config.HTTPSecurityScheme{
-					"slack": {
-						Secret: &providermanifestv1.HTTPSecretRef{Env: "SLACK_SIGNING_SECRET"},
+					"signed": {
+						Secret: &providermanifestv1.HTTPSecretRef{Env: "REQUEST_SIGNING_SECRET"},
 					},
 				},
 				HTTP: map[string]*config.HTTPBinding{
 					"command": {
 						Ack: &providermanifestv1.HTTPAck{
 							Body: map[string]any{
-								"response_type": "ephemeral",
-								"text":          "Merged from config",
+								"status": "queued",
 							},
 						},
 					},
@@ -11837,13 +11844,13 @@ func TestHostedHTTPBinding_MergesManifestAndConfigOverrides(t *testing.T) {
 	timestamp := strconv.FormatInt(time.Now().Unix(), 10)
 	signature := httpBindingTestSignature("super-secret", "v0:"+timestamp+":"+body)
 
-	req, err := http.NewRequest(http.MethodPost, ts.URL+"/api/v1/slack/command", strings.NewReader(body))
+	req, err := http.NewRequest(http.MethodPost, ts.URL+"/api/v1/signed/command", strings.NewReader(body))
 	if err != nil {
 		t.Fatalf("NewRequest: %v", err)
 	}
 	req.Header.Set("Content-Type", "application/x-www-form-urlencoded")
-	req.Header.Set("X-Slack-Request-Timestamp", timestamp)
-	req.Header.Set("X-Slack-Signature", signature)
+	req.Header.Set("X-Request-Timestamp", timestamp)
+	req.Header.Set("X-Request-Signature", signature)
 
 	resp, err := http.DefaultClient.Do(req)
 	if err != nil {
@@ -11857,8 +11864,8 @@ func TestHostedHTTPBinding_MergesManifestAndConfigOverrides(t *testing.T) {
 	if err := json.NewDecoder(resp.Body).Decode(&ack); err != nil {
 		t.Fatalf("decode ack: %v", err)
 	}
-	if got, want := ack["text"], "Merged from config"; got != want {
-		t.Fatalf("ack text = %#v, want %q", got, want)
+	if got, want := ack["status"], "queued"; got != want {
+		t.Fatalf("ack status = %#v, want %q", got, want)
 	}
 
 	select {
@@ -11871,13 +11878,13 @@ func TestHostedHTTPBinding_MergesManifestAndConfigOverrides(t *testing.T) {
 	}
 }
 
-func TestHostedHTTPBinding_SlackSignatureSyncRetriesReinvokeOperation(t *testing.T) {
-	t.Setenv("SLACK_SIGNING_SECRET", "super-secret")
+func TestHostedHTTPBinding_HMACSyncRetriesReinvokeOperation(t *testing.T) {
+	t.Setenv("REQUEST_SIGNING_SECRET", "super-secret")
 
 	invocations := make(chan map[string]any, 2)
 	provider := &stubIntegrationWithOps{
 		StubIntegration: coretesting.StubIntegration{
-			N:        "slack",
+			N:        "signed",
 			ConnMode: core.ConnectionModeNone,
 			ExecuteFn: func(_ context.Context, op string, params map[string]any, _ string) (*core.OperationResult, error) {
 				if op != "handle_command" {
@@ -11893,11 +11900,16 @@ func TestHostedHTTPBinding_SlackSignatureSyncRetriesReinvokeOperation(t *testing
 	ts := newTestServer(t, func(cfg *server.Config) {
 		cfg.Providers = testutil.NewProviderRegistry(t, provider)
 		cfg.PluginDefs = map[string]*config.ProviderEntry{
-			"slack": {
+			"signed": {
 				SecuritySchemes: map[string]*config.HTTPSecurityScheme{
-					"slack": {
-						Type:   providermanifestv1.HTTPSecuritySchemeTypeSlackSignature,
-						Secret: &providermanifestv1.HTTPSecretRef{Env: "SLACK_SIGNING_SECRET"},
+					"signed": {
+						Type:            providermanifestv1.HTTPSecuritySchemeTypeHMAC,
+						Secret:          &providermanifestv1.HTTPSecretRef{Env: "REQUEST_SIGNING_SECRET"},
+						SignatureHeader: "X-Request-Signature",
+						SignaturePrefix: "v0=",
+						PayloadTemplate: "v0:{header:X-Request-Timestamp}:{raw_body}",
+						TimestampHeader: "X-Request-Timestamp",
+						MaxAgeSeconds:   300,
 					},
 				},
 				HTTP: map[string]*config.HTTPBinding{
@@ -11910,7 +11922,7 @@ func TestHostedHTTPBinding_SlackSignatureSyncRetriesReinvokeOperation(t *testing
 								"application/x-www-form-urlencoded": {},
 							},
 						},
-						Security: "slack",
+						Security: "signed",
 						Target:   "handle_command",
 					},
 				},
@@ -11925,20 +11937,20 @@ func TestHostedHTTPBinding_SlackSignatureSyncRetriesReinvokeOperation(t *testing
 	signature := httpBindingTestSignature("super-secret", "v0:"+timestamp+":"+body)
 
 	makeRequest := func() *http.Request {
-		req, err := http.NewRequest(http.MethodPost, ts.URL+"/api/v1/slack/command", strings.NewReader(body))
+		req, err := http.NewRequest(http.MethodPost, ts.URL+"/api/v1/signed/command", strings.NewReader(body))
 		if err != nil {
 			t.Fatalf("NewRequest: %v", err)
 		}
 		req.Header.Set("Content-Type", "application/x-www-form-urlencoded")
-		req.Header.Set("X-Slack-Request-Timestamp", timestamp)
-		req.Header.Set("X-Slack-Signature", signature)
+		req.Header.Set("X-Request-Timestamp", timestamp)
+		req.Header.Set("X-Request-Signature", signature)
 		return req
 	}
 
 	for i := 0; i < 2; i++ {
 		resp, err := http.DefaultClient.Do(makeRequest())
 		if err != nil {
-			t.Fatalf("sync slack request %d: %v", i, err)
+			t.Fatalf("sync hmac request %d: %v", i, err)
 		}
 		var result map[string]any
 		if err := json.NewDecoder(resp.Body).Decode(&result); err != nil {

--- a/gestaltd/sdk/providermanifest/v1/manifest.jsonschema.json
+++ b/gestaltd/sdk/providermanifest/v1/manifest.jsonschema.json
@@ -204,10 +204,10 @@
         "type"
       ],
       "properties": {
-        "type": {
-          "type": "string",
-          "enum": [
-            "slack_signature",
+          "type": {
+            "type": "string",
+            "enum": [
+            "hmac",
             "apiKey",
             "http",
             "none"
@@ -215,6 +215,25 @@
         },
         "description": {
           "type": "string"
+        },
+        "signatureHeader": {
+          "type": "string",
+          "minLength": 1
+        },
+        "signaturePrefix": {
+          "type": "string"
+        },
+        "payloadTemplate": {
+          "type": "string",
+          "minLength": 1
+        },
+        "timestampHeader": {
+          "type": "string",
+          "minLength": 1
+        },
+        "maxAgeSeconds": {
+          "type": "integer",
+          "minimum": 1
         },
         "name": {
           "type": "string",

--- a/gestaltd/sdk/providermanifest/v1/types.go
+++ b/gestaltd/sdk/providermanifest/v1/types.go
@@ -107,10 +107,10 @@ type RouteAuthRef struct {
 type HTTPSecuritySchemeType string
 
 const (
-	HTTPSecuritySchemeTypeSlackSignature HTTPSecuritySchemeType = "slack_signature"
-	HTTPSecuritySchemeTypeAPIKey         HTTPSecuritySchemeType = "apiKey"
-	HTTPSecuritySchemeTypeHTTP           HTTPSecuritySchemeType = "http"
-	HTTPSecuritySchemeTypeNone           HTTPSecuritySchemeType = "none"
+	HTTPSecuritySchemeTypeHMAC   HTTPSecuritySchemeType = "hmac"
+	HTTPSecuritySchemeTypeAPIKey HTTPSecuritySchemeType = "apiKey"
+	HTTPSecuritySchemeTypeHTTP   HTTPSecuritySchemeType = "http"
+	HTTPSecuritySchemeTypeNone   HTTPSecuritySchemeType = "none"
 )
 
 type HTTPIn string
@@ -151,12 +151,17 @@ type HTTPAck struct {
 }
 
 type HTTPSecurityScheme struct {
-	Type        HTTPSecuritySchemeType `json:"type,omitempty" yaml:"type,omitempty"`
-	Description string                 `json:"description,omitempty" yaml:"description,omitempty"`
-	Name        string                 `json:"name,omitempty" yaml:"name,omitempty"`
-	In          HTTPIn                 `json:"in,omitempty" yaml:"in,omitempty"`
-	Scheme      HTTPAuthScheme         `json:"scheme,omitempty" yaml:"scheme,omitempty"`
-	Secret      *HTTPSecretRef         `json:"secret,omitempty" yaml:"secret,omitempty"`
+	Type            HTTPSecuritySchemeType `json:"type,omitempty" yaml:"type,omitempty"`
+	Description     string                 `json:"description,omitempty" yaml:"description,omitempty"`
+	SignatureHeader string                 `json:"signatureHeader,omitempty" yaml:"signatureHeader,omitempty"`
+	SignaturePrefix string                 `json:"signaturePrefix,omitempty" yaml:"signaturePrefix,omitempty"`
+	PayloadTemplate string                 `json:"payloadTemplate,omitempty" yaml:"payloadTemplate,omitempty"`
+	TimestampHeader string                 `json:"timestampHeader,omitempty" yaml:"timestampHeader,omitempty"`
+	MaxAgeSeconds   int                    `json:"maxAgeSeconds,omitempty" yaml:"maxAgeSeconds,omitempty"`
+	Name            string                 `json:"name,omitempty" yaml:"name,omitempty"`
+	In              HTTPIn                 `json:"in,omitempty" yaml:"in,omitempty"`
+	Scheme          HTTPAuthScheme         `json:"scheme,omitempty" yaml:"scheme,omitempty"`
+	Secret          *HTTPSecretRef         `json:"secret,omitempty" yaml:"secret,omitempty"`
 }
 
 type HTTPSecretRef struct {

--- a/sdk/go/manifest_metadata.go
+++ b/sdk/go/manifest_metadata.go
@@ -20,10 +20,10 @@ type ManifestMetadata struct {
 type HTTPSecuritySchemeType string
 
 const (
-	HTTPSecuritySchemeTypeSlackSignature HTTPSecuritySchemeType = "slack_signature"
-	HTTPSecuritySchemeTypeAPIKey         HTTPSecuritySchemeType = "apiKey"
-	HTTPSecuritySchemeTypeHTTP           HTTPSecuritySchemeType = "http"
-	HTTPSecuritySchemeTypeNone           HTTPSecuritySchemeType = "none"
+	HTTPSecuritySchemeTypeHMAC   HTTPSecuritySchemeType = "hmac"
+	HTTPSecuritySchemeTypeAPIKey HTTPSecuritySchemeType = "apiKey"
+	HTTPSecuritySchemeTypeHTTP   HTTPSecuritySchemeType = "http"
+	HTTPSecuritySchemeTypeNone   HTTPSecuritySchemeType = "none"
 )
 
 // HTTPIn identifies where an HTTP auth value is supplied.
@@ -50,12 +50,17 @@ type HTTPSecretRef struct {
 
 // HTTPSecurityScheme describes one named hosted HTTP security scheme.
 type HTTPSecurityScheme struct {
-	Type        HTTPSecuritySchemeType `json:"type,omitempty" yaml:"type,omitempty"`
-	Description string                 `json:"description,omitempty" yaml:"description,omitempty"`
-	Name        string                 `json:"name,omitempty" yaml:"name,omitempty"`
-	In          HTTPIn                 `json:"in,omitempty" yaml:"in,omitempty"`
-	Scheme      HTTPAuthScheme         `json:"scheme,omitempty" yaml:"scheme,omitempty"`
-	Secret      *HTTPSecretRef         `json:"secret,omitempty" yaml:"secret,omitempty"`
+	Type            HTTPSecuritySchemeType `json:"type,omitempty" yaml:"type,omitempty"`
+	Description     string                 `json:"description,omitempty" yaml:"description,omitempty"`
+	SignatureHeader string                 `json:"signatureHeader,omitempty" yaml:"signatureHeader,omitempty"`
+	SignaturePrefix string                 `json:"signaturePrefix,omitempty" yaml:"signaturePrefix,omitempty"`
+	PayloadTemplate string                 `json:"payloadTemplate,omitempty" yaml:"payloadTemplate,omitempty"`
+	TimestampHeader string                 `json:"timestampHeader,omitempty" yaml:"timestampHeader,omitempty"`
+	MaxAgeSeconds   int                    `json:"maxAgeSeconds,omitempty" yaml:"maxAgeSeconds,omitempty"`
+	Name            string                 `json:"name,omitempty" yaml:"name,omitempty"`
+	In              HTTPIn                 `json:"in,omitempty" yaml:"in,omitempty"`
+	Scheme          HTTPAuthScheme         `json:"scheme,omitempty" yaml:"scheme,omitempty"`
+	Secret          *HTTPSecretRef         `json:"secret,omitempty" yaml:"secret,omitempty"`
 }
 
 // HTTPBinding describes one hosted HTTP endpoint bound to a registered

--- a/sdk/go/router_test.go
+++ b/sdk/go/router_test.go
@@ -266,18 +266,23 @@ func TestRouterManifestMetadata(t *testing.T) {
 		),
 	).WithManifestMetadata(gestalt.ManifestMetadata{
 		SecuritySchemes: map[string]gestalt.HTTPSecurityScheme{
-			"slack": {
-				Type: gestalt.HTTPSecuritySchemeTypeSlackSignature,
+			"signed": {
+				Type: gestalt.HTTPSecuritySchemeTypeHMAC,
 				Secret: &gestalt.HTTPSecretRef{
-					Env: "SLACK_SIGNING_SECRET",
+					Env: "REQUEST_SIGNING_SECRET",
 				},
+				SignatureHeader: "X-Request-Signature",
+				SignaturePrefix: "v0=",
+				PayloadTemplate: "v0:{header:X-Request-Timestamp}:{raw_body}",
+				TimestampHeader: "X-Request-Timestamp",
+				MaxAgeSeconds:   300,
 			},
 		},
 		HTTP: map[string]gestalt.HTTPBinding{
 			"command": {
 				Path:     "/command",
 				Method:   http.MethodPost,
-				Security: "slack",
+				Security: "signed",
 				Target:   "echo",
 				RequestBody: &gestalt.HTTPRequestBody{
 					Required: true,
@@ -291,9 +296,9 @@ func TestRouterManifestMetadata(t *testing.T) {
 						"content-type": "application/json",
 					},
 					Body: map[string]any{
-						"response_type": "ephemeral",
+						"status": "accepted",
 						"attachments": []any{
-							map[string]any{"text": "Working on it"},
+							map[string]any{"text": "Queued"},
 						},
 					},
 				},
@@ -302,8 +307,8 @@ func TestRouterManifestMetadata(t *testing.T) {
 	})
 
 	metadata := router.ManifestMetadata()
-	if got := metadata.SecuritySchemes["slack"].Type; got != gestalt.HTTPSecuritySchemeTypeSlackSignature {
-		t.Fatalf("security scheme type = %q, want %q", got, gestalt.HTTPSecuritySchemeTypeSlackSignature)
+	if got := metadata.SecuritySchemes["signed"].Type; got != gestalt.HTTPSecuritySchemeTypeHMAC {
+		t.Fatalf("security scheme type = %q, want %q", got, gestalt.HTTPSecuritySchemeTypeHMAC)
 	}
 	binding, ok := metadata.HTTP["command"]
 	if !ok {
@@ -324,14 +329,14 @@ func TestRouterManifestMetadata(t *testing.T) {
 		t.Fatalf("binding attachments = %#v, want one attachment", body["attachments"])
 	}
 
-	metadata.SecuritySchemes["slack"] = gestalt.HTTPSecurityScheme{Type: gestalt.HTTPSecuritySchemeTypeNone}
+	metadata.SecuritySchemes["signed"] = gestalt.HTTPSecurityScheme{Type: gestalt.HTTPSecuritySchemeTypeNone}
 	binding.Ack.Headers["content-type"] = "text/plain"
-	body["response_type"] = "changed"
+	body["status"] = "changed"
 	attachments[0].(map[string]any)["text"] = "changed"
 
 	original := router.ManifestMetadata()
-	if got := original.SecuritySchemes["slack"].Type; got != gestalt.HTTPSecuritySchemeTypeSlackSignature {
-		t.Fatalf("original security scheme type = %q, want %q", got, gestalt.HTTPSecuritySchemeTypeSlackSignature)
+	if got := original.SecuritySchemes["signed"].Type; got != gestalt.HTTPSecuritySchemeTypeHMAC {
+		t.Fatalf("original security scheme type = %q, want %q", got, gestalt.HTTPSecuritySchemeTypeHMAC)
 	}
 	originalBinding := original.HTTP["command"]
 	if got := originalBinding.Ack.Headers["content-type"]; got != "application/json" {
@@ -341,14 +346,14 @@ func TestRouterManifestMetadata(t *testing.T) {
 	if !ok {
 		t.Fatalf("original ack body type = %T, want map[string]any", originalBinding.Ack.Body)
 	}
-	if got := originalBody["response_type"]; got != "ephemeral" {
-		t.Fatalf("original ack response_type = %#v, want %#v", got, "ephemeral")
+	if got := originalBody["status"]; got != "accepted" {
+		t.Fatalf("original ack status = %#v, want %#v", got, "accepted")
 	}
 	originalAttachments, ok := originalBody["attachments"].([]any)
 	if !ok || len(originalAttachments) != 1 {
 		t.Fatalf("original attachments = %#v, want one attachment", originalBody["attachments"])
 	}
-	if got := originalAttachments[0].(map[string]any)["text"]; got != "Working on it" {
-		t.Fatalf("original attachment text = %#v, want %#v", got, "Working on it")
+	if got := originalAttachments[0].(map[string]any)["text"]; got != "Queued" {
+		t.Fatalf("original attachment text = %#v, want %#v", got, "Queued")
 	}
 }

--- a/sdk/go/serve_transport_test.go
+++ b/sdk/go/serve_transport_test.go
@@ -100,18 +100,23 @@ func TestServeProviderWritesStaticArtifacts(t *testing.T) {
 
 		router := stubRouter.WithManifestMetadata(gestalt.ManifestMetadata{
 			SecuritySchemes: map[string]gestalt.HTTPSecurityScheme{
-				"slack": {
-					Type: gestalt.HTTPSecuritySchemeTypeSlackSignature,
+				"signed": {
+					Type: gestalt.HTTPSecuritySchemeTypeHMAC,
 					Secret: &gestalt.HTTPSecretRef{
-						Env: "SLACK_SIGNING_SECRET",
+						Env: "REQUEST_SIGNING_SECRET",
 					},
+					SignatureHeader: "X-Request-Signature",
+					SignaturePrefix: "v0=",
+					PayloadTemplate: "v0:{header:X-Request-Timestamp}:{raw_body}",
+					TimestampHeader: "X-Request-Timestamp",
+					MaxAgeSeconds:   300,
 				},
 			},
 			HTTP: map[string]gestalt.HTTPBinding{
 				"command": {
 					Path:     "/command",
 					Method:   "POST",
-					Security: "slack",
+					Security: "signed",
 					Target:   "test_op",
 					RequestBody: &gestalt.HTTPRequestBody{
 						Required: true,
@@ -122,8 +127,7 @@ func TestServeProviderWritesStaticArtifacts(t *testing.T) {
 					Ack: &gestalt.HTTPAck{
 						Status: 200,
 						Body: map[string]any{
-							"response_type": "ephemeral",
-							"text":          "Working on it...",
+							"status": "accepted",
 						},
 					},
 				},
@@ -156,13 +160,14 @@ func TestServeProviderWritesStaticArtifacts(t *testing.T) {
 		metadataYAML := string(metadataData)
 		for _, want := range []string{
 			"securitySchemes:",
-			"type: slack_signature",
-			"env: SLACK_SIGNING_SECRET",
+			"type: hmac",
+			"env: REQUEST_SIGNING_SECRET",
+			"signatureHeader: X-Request-Signature",
 			"http:",
 			"path: /command",
 			"target: test_op",
 			"application/x-www-form-urlencoded",
-			"response_type: ephemeral",
+			"status: accepted",
 		} {
 			if !strings.Contains(metadataYAML, want) {
 				t.Fatalf("manifest metadata YAML missing %q:\n%s", want, metadataYAML)

--- a/sdk/python/gestalt/_manifest_metadata.py
+++ b/sdk/python/gestalt/_manifest_metadata.py
@@ -19,6 +19,11 @@ HTTPSecurityScheme = TypedDict(
     {
         "type": str,
         "description": str,
+        "signatureHeader": str,
+        "signaturePrefix": str,
+        "payloadTemplate": str,
+        "timestampHeader": str,
+        "maxAgeSeconds": int,
         "name": str,
         "in": str,
         "scheme": str,

--- a/sdk/python/tests/test_plugin.py
+++ b/sdk/python/tests/test_plugin.py
@@ -238,16 +238,21 @@ class PluginCatalogTests(unittest.TestCase):
         plugin = Plugin(
             "test-plugin",
             securitySchemes={
-                "slack": {
-                    "type": "slack_signature",
-                    "secret": {"env": "SLACK_SIGNING_SECRET"},
+                "signed": {
+                    "type": "hmac",
+                    "secret": {"env": "REQUEST_SIGNING_SECRET"},
+                    "signatureHeader": "X-Request-Signature",
+                    "signaturePrefix": "v0=",
+                    "payloadTemplate": "v0:{header:X-Request-Timestamp}:{raw_body}",
+                    "timestampHeader": "X-Request-Timestamp",
+                    "maxAgeSeconds": 300,
                 }
             },
             http={
                 "command": {
                     "path": "/command",
                     "method": "POST",
-                    "security": "slack",
+                    "security": "signed",
                     "target": "handle_command",
                     "requestBody": {
                         "required": True,
@@ -258,8 +263,7 @@ class PluginCatalogTests(unittest.TestCase):
                     "ack": {
                         "status": 200,
                         "body": {
-                            "response_type": "ephemeral",
-                            "text": "Working on it...",
+                            "status": "accepted",
                         },
                     },
                 }
@@ -268,22 +272,22 @@ class PluginCatalogTests(unittest.TestCase):
 
         self.assertTrue(plugin.supports_manifest_metadata())
         self.assertEqual(
-            plugin.securitySchemes["slack"]["secret"]["env"],
-            "SLACK_SIGNING_SECRET",
+            plugin.securitySchemes["signed"]["secret"]["env"],
+            "REQUEST_SIGNING_SECRET",
         )
         self.assertEqual(plugin.http["command"]["path"], "/command")
 
         metadata = plugin.static_manifest_metadata()
         self.assertEqual(
-            metadata["securitySchemes"]["slack"]["type"],
-            "slack_signature",
+            metadata["securitySchemes"]["signed"]["type"],
+            "hmac",
         )
         self.assertEqual(metadata["http"]["command"]["target"], "handle_command")
 
-        metadata["securitySchemes"]["slack"]["type"] = "none"
+        metadata["securitySchemes"]["signed"]["type"] = "none"
         self.assertEqual(
-            plugin.static_manifest_metadata()["securitySchemes"]["slack"]["type"],
-            "slack_signature",
+            plugin.static_manifest_metadata()["securitySchemes"]["signed"]["type"],
+            "hmac",
         )
 
 

--- a/sdk/python/tests/test_runtime.py
+++ b/sdk/python/tests/test_runtime.py
@@ -227,16 +227,21 @@ class MainEntrypointTests(unittest.TestCase):
         plugin = Plugin(
             "test-plugin",
             securitySchemes={
-                "slack": {
-                    "type": "slack_signature",
-                    "secret": {"env": "SLACK_SIGNING_SECRET"},
+                "signed": {
+                    "type": "hmac",
+                    "secret": {"env": "REQUEST_SIGNING_SECRET"},
+                    "signatureHeader": "X-Request-Signature",
+                    "signaturePrefix": "v0=",
+                    "payloadTemplate": "v0:{header:X-Request-Timestamp}:{raw_body}",
+                    "timestampHeader": "X-Request-Timestamp",
+                    "maxAgeSeconds": 300,
                 }
             },
             http={
                 "command": {
                     "path": "/command",
                     "method": "POST",
-                    "security": "slack",
+                    "security": "signed",
                     "target": "noop",
                     "requestBody": {
                         "required": True,
@@ -247,8 +252,7 @@ class MainEntrypointTests(unittest.TestCase):
                     "ack": {
                         "status": 200,
                         "body": {
-                            "response_type": "ephemeral",
-                            "text": "Working on it...",
+                            "status": "accepted",
                         },
                     },
                 }
@@ -280,13 +284,14 @@ class MainEntrypointTests(unittest.TestCase):
             self.assertTrue(metadata_path.exists())
             metadata = metadata_path.read_text(encoding="utf-8")
             self.assertIn("securitySchemes:", metadata)
-            self.assertIn("type: slack_signature", metadata)
-            self.assertIn("env: SLACK_SIGNING_SECRET", metadata)
+            self.assertIn("type: hmac", metadata)
+            self.assertIn("env: REQUEST_SIGNING_SECRET", metadata)
+            self.assertIn("signatureHeader: X-Request-Signature", metadata)
             self.assertIn("http:", metadata)
             self.assertIn("path: /command", metadata)
             self.assertIn("target: noop", metadata)
             self.assertIn("application/x-www-form-urlencoded", metadata)
-            self.assertIn("response_type: ephemeral", metadata)
+            self.assertIn("status: accepted", metadata)
 
     def test_returns_usage_error_for_bad_args(self) -> None:
         result = _runtime.main(["/only-one-arg"])

--- a/sdk/rust/src/manifest_metadata.rs
+++ b/sdk/rust/src/manifest_metadata.rs
@@ -52,8 +52,8 @@ impl PluginManifestMetadata {
 /// Supported manifest HTTP security scheme kinds.
 #[derive(Clone, Copy, Debug, Eq, PartialEq, Serialize, Deserialize)]
 pub enum HTTPSecuritySchemeType {
-    #[serde(rename = "slack_signature")]
-    SlackSignature,
+    #[serde(rename = "hmac")]
+    Hmac,
     #[serde(rename = "apiKey")]
     ApiKey,
     #[serde(rename = "http")]
@@ -119,6 +119,16 @@ pub struct HTTPSecurityScheme {
     pub kind: Option<HTTPSecuritySchemeType>,
     #[serde(skip_serializing_if = "Option::is_none")]
     pub description: Option<String>,
+    #[serde(rename = "signatureHeader", skip_serializing_if = "Option::is_none")]
+    pub signature_header: Option<String>,
+    #[serde(rename = "signaturePrefix", skip_serializing_if = "Option::is_none")]
+    pub signature_prefix: Option<String>,
+    #[serde(rename = "payloadTemplate", skip_serializing_if = "Option::is_none")]
+    pub payload_template: Option<String>,
+    #[serde(rename = "timestampHeader", skip_serializing_if = "Option::is_none")]
+    pub timestamp_header: Option<String>,
+    #[serde(rename = "maxAgeSeconds", skip_serializing_if = "Option::is_none")]
+    pub max_age_seconds: Option<u64>,
     #[serde(skip_serializing_if = "Option::is_none")]
     pub name: Option<String>,
     #[serde(rename = "in", skip_serializing_if = "Option::is_none")]
@@ -135,9 +145,9 @@ impl HTTPSecurityScheme {
         Self::default()
     }
 
-    /// Creates a Slack request-signing scheme.
-    pub fn slack_signature() -> Self {
-        Self::new().kind(HTTPSecuritySchemeType::SlackSignature)
+    /// Creates an HMAC request-signing scheme.
+    pub fn hmac() -> Self {
+        Self::new().kind(HTTPSecuritySchemeType::Hmac)
     }
 
     /// Creates an API key scheme.
@@ -171,6 +181,50 @@ impl HTTPSecurityScheme {
         let description = description.into().trim().to_owned();
         if !description.is_empty() {
             self.description = Some(description);
+        }
+        self
+    }
+
+    /// Sets the header carrying the transmitted request signature.
+    pub fn signature_header(mut self, header: impl Into<String>) -> Self {
+        let header = header.into().trim().to_owned();
+        if !header.is_empty() {
+            self.signature_header = Some(header);
+        }
+        self
+    }
+
+    /// Sets the static prefix prepended to the computed signature.
+    pub fn signature_prefix(mut self, prefix: impl Into<String>) -> Self {
+        let prefix = prefix.into();
+        if !prefix.is_empty() {
+            self.signature_prefix = Some(prefix);
+        }
+        self
+    }
+
+    /// Sets the template used to build the signed payload.
+    pub fn payload_template(mut self, template: impl Into<String>) -> Self {
+        let template = template.into().trim().to_owned();
+        if !template.is_empty() {
+            self.payload_template = Some(template);
+        }
+        self
+    }
+
+    /// Sets the header carrying the request timestamp.
+    pub fn timestamp_header(mut self, header: impl Into<String>) -> Self {
+        let header = header.into().trim().to_owned();
+        if !header.is_empty() {
+            self.timestamp_header = Some(header);
+        }
+        self
+    }
+
+    /// Sets the maximum accepted request age in seconds.
+    pub fn max_age_seconds(mut self, seconds: u64) -> Self {
+        if seconds > 0 {
+            self.max_age_seconds = Some(seconds);
         }
         self
     }

--- a/sdk/rust/tests/router.rs
+++ b/sdk/rust/tests/router.rs
@@ -37,20 +37,25 @@ struct EchoOutput {
 fn http_manifest_router() -> gestalt::Result<gestalt::Router<TestProvider>> {
     gestalt::Router::new()
         .security_scheme(
-            "slack",
-            gestalt::HTTPSecurityScheme::slack_signature().secret_env("SLACK_SIGNING_SECRET"),
+            "signed",
+            gestalt::HTTPSecurityScheme::hmac()
+                .secret_env("REQUEST_SIGNING_SECRET")
+                .signature_header("X-Request-Signature")
+                .signature_prefix("v0=")
+                .payload_template("v0:{header:X-Request-Timestamp}:{raw_body}")
+                .timestamp_header("X-Request-Timestamp")
+                .max_age_seconds(300),
         )
         .http_binding(
             "command",
-            gestalt::HTTPBinding::new("/command", "post", "slack", "echo")
+            gestalt::HTTPBinding::new("/command", "post", "signed", "echo")
                 .request_body(
                     gestalt::HTTPRequestBody::new()
                         .required(true)
                         .content_type("application/x-www-form-urlencoded"),
                 )
                 .ack(gestalt::HTTPAck::new().status(200).body(json!({
-                    "response_type": "ephemeral",
-                    "text": "Working on it...",
+                    "status": "accepted",
                 }))),
         )
         .register(
@@ -127,12 +132,12 @@ fn router_includes_manifest_metadata() {
     let metadata = router.manifest_metadata();
 
     assert_eq!(
-        metadata.security_schemes["slack"].kind,
-        Some(gestalt::HTTPSecuritySchemeType::SlackSignature)
+        metadata.security_schemes["signed"].kind,
+        Some(gestalt::HTTPSecuritySchemeType::Hmac)
     );
     assert_eq!(metadata.http["command"].path, "/command");
     assert_eq!(metadata.http["command"].method, "POST");
-    assert_eq!(metadata.http["command"].security, "slack");
+    assert_eq!(metadata.http["command"].security, "signed");
     assert_eq!(metadata.http["command"].target, "echo");
     assert_eq!(
         metadata.http["command"]
@@ -168,8 +173,9 @@ async fn serve_provider_writes_catalog_and_manifest_metadata_when_requested() {
 
     let metadata = fs::read_to_string(&metadata_path).expect("read manifest metadata");
     assert!(metadata.contains("securitySchemes:"));
-    assert!(metadata.contains("type: slack_signature"));
-    assert!(metadata.contains("env: SLACK_SIGNING_SECRET"));
+    assert!(metadata.contains("type: hmac"));
+    assert!(metadata.contains("env: REQUEST_SIGNING_SECRET"));
+    assert!(metadata.contains("signatureHeader: X-Request-Signature"));
     assert!(metadata.contains("http:"));
     assert!(metadata.contains("path: /command"));
     assert!(metadata.contains("target: echo"));

--- a/sdk/typescript/src/manifest-metadata.ts
+++ b/sdk/typescript/src/manifest-metadata.ts
@@ -3,7 +3,7 @@ import { writeFileSync } from "node:fs";
 import YAML from "yaml";
 
 export type HTTPSecuritySchemeType =
-  | "slack_signature"
+  | "hmac"
   | "apiKey"
   | "http"
   | "none";
@@ -20,6 +20,11 @@ export interface HTTPSecretRef {
 export interface HTTPSecurityScheme {
   type?: HTTPSecuritySchemeType;
   description?: string;
+  signatureHeader?: string;
+  signaturePrefix?: string;
+  payloadTemplate?: string;
+  timestampHeader?: string;
+  maxAgeSeconds?: number;
   name?: string;
   in?: HTTPIn;
   scheme?: HTTPAuthScheme;

--- a/sdk/typescript/src/plugin.ts
+++ b/sdk/typescript/src/plugin.ts
@@ -424,6 +424,21 @@ function cloneHTTPSecurityScheme(value: HTTPSecurityScheme): HTTPSecurityScheme 
   if (value.description !== undefined) {
     output.description = value.description;
   }
+  if (value.signatureHeader !== undefined) {
+    output.signatureHeader = value.signatureHeader;
+  }
+  if (value.signaturePrefix !== undefined) {
+    output.signaturePrefix = value.signaturePrefix;
+  }
+  if (value.payloadTemplate !== undefined) {
+    output.payloadTemplate = value.payloadTemplate;
+  }
+  if (value.timestampHeader !== undefined) {
+    output.timestampHeader = value.timestampHeader;
+  }
+  if (value.maxAgeSeconds !== undefined) {
+    output.maxAgeSeconds = value.maxAgeSeconds;
+  }
   if (value.name !== undefined) {
     output.name = value.name;
   }

--- a/sdk/typescript/tests/runtime.test.ts
+++ b/sdk/typescript/tests/runtime.test.ts
@@ -197,18 +197,23 @@ test("runtime main writes generated manifest metadata when requested", async () 
 
 export const plugin = definePlugin({
   securitySchemes: {
-    slack: {
-      type: "slack_signature",
+    signed: {
+      type: "hmac",
       secret: {
-        env: "SLACK_SIGNING_SECRET",
+        env: "REQUEST_SIGNING_SECRET",
       },
+      signatureHeader: "X-Request-Signature",
+      signaturePrefix: "v0=",
+      payloadTemplate: "v0:{header:X-Request-Timestamp}:{raw_body}",
+      timestampHeader: "X-Request-Timestamp",
+      maxAgeSeconds: 300,
     },
   },
   http: {
     command: {
       path: "/command",
       method: "POST",
-      security: "slack",
+      security: "signed",
       target: "handle_command",
       requestBody: {
         required: true,
@@ -219,8 +224,7 @@ export const plugin = definePlugin({
       ack: {
         status: 200,
         body: {
-          response_type: "ephemeral",
-          text: "Working on it...",
+          status: "accepted",
         },
       },
     },
@@ -243,13 +247,14 @@ export const plugin = definePlugin({
     expect(code).toBe(0);
     const metadata = readFileSync(metadataPath, "utf8");
     expect(metadata).toContain("securitySchemes:");
-    expect(metadata).toContain("type: slack_signature");
-    expect(metadata).toContain("env: SLACK_SIGNING_SECRET");
+    expect(metadata).toContain("type: hmac");
+    expect(metadata).toContain("env: REQUEST_SIGNING_SECRET");
+    expect(metadata).toContain("signatureHeader: X-Request-Signature");
     expect(metadata).toContain("http:");
     expect(metadata).toContain("path: /command");
     expect(metadata).toContain("target: handle_command");
     expect(metadata).toContain("application/x-www-form-urlencoded");
-    expect(metadata).toContain("response_type: ephemeral");
+    expect(metadata).toContain("status: accepted");
   } finally {
     if (previousManifestMetadata === undefined) {
       delete process.env[ENV_WRITE_MANIFEST_METADATA];


### PR DESCRIPTION
## Summary
This removes the vendor-specific hosted HTTP `slack_signature` primitive from core and replaces it with a pure generic `hmac` security scheme.

Core now exposes only generic hosted HTTP primitives here:
- `spec.securitySchemes.<name>.type: hmac`
- `signatureHeader`
- `signaturePrefix`
- `payloadTemplate`
- `timestampHeader`
- `maxAgeSeconds`
- existing `secret`
- `spec.http` bindings remain unchanged apart from pointing at the generic scheme name

This updates:
- manifest schema and provider metadata types
- server-side hosted HTTP validation and request verification
- release-path fixtures and provider packaging tests
- SDK manifest-metadata surfaces in Go, Python, TypeScript, and Rust
- generic docs/examples so they no longer describe Slack-specific hosted HTTP auth in core

## New Interface
```yaml
spec:
  securitySchemes:
    signed:
      type: hmac
      secret:
        env: REQUEST_SIGNING_SECRET
      signatureHeader: X-Request-Signature
      signaturePrefix: v0=
      payloadTemplate: "v0:{header:X-Request-Timestamp}:{raw_body}"
      timestampHeader: X-Request-Timestamp
      maxAgeSeconds: 300

  http:
    command:
      path: /command
      method: POST
      security: signed
      target: handle_command
      requestBody:
        required: true
        content:
          application/x-www-form-urlencoded: {}
      ack:
        status: 200
        body:
          status: accepted
```

## SDK Example
```ts
export const plugin = definePlugin({
  securitySchemes: {
    signed: {
      type: "hmac",
      secret: { env: "REQUEST_SIGNING_SECRET" },
      signatureHeader: "X-Request-Signature",
      signaturePrefix: "v0=",
      payloadTemplate: "v0:{header:X-Request-Timestamp}:{raw_body}",
      timestampHeader: "X-Request-Timestamp",
      maxAgeSeconds: 300,
    },
  },
  http: {
    command: {
      path: "/command",
      method: "POST",
      security: "signed",
      target: "handle_command",
      requestBody: {
        required: true,
        content: {
          "application/x-www-form-urlencoded": {},
        },
      },
      ack: {
        status: 200,
        body: { status: "accepted" },
      },
    },
  },
  operations: [
    {
      id: "handle_command",
      handler() {
        return { ok: true };
      },
    },
  ],
});
```

## Validation
- `go test ./internal/server -run 'TestHostedHTTPBinding_|TestPluginRouteAuth_HTTPRoutesUseNamedProviderOverride' -count=1`
- `go test ./internal/providerpkg -run 'TestPrepareSourceManifest_(MergesGeneratedGoManifestMetadata|MergesGeneratedPythonManifestMetadata|MergesGeneratedTypeScriptManifestMetadata|MergesGeneratedRustManifestMetadata)|TestManifestWorkflow_(AcceptsHostedHTTPBindingsAndSecuritySchemes|RejectsNon2xxHTTPAckStatus|RejectsDuplicateNormalizedHTTPContentTypes|AcceptsPluginRouteAuthReference|AcceptsProviderWireSurfaceManifest)' -count=1`
- `go test ./internal/config -run 'TestLoadConfigParsesPluginHTTPSecuritySchemesAndBindings|TestProviderEntryEffectiveHTTPBindings_ClonesAckBody|TestLoadConfigParsesPluginMCPFlag|TestLoadConfigGenericFixture' -count=1`
- `go test ./cmd/gestaltd -run 'TestRun_ProviderReleaseBuilds(Python|TypeScript|Rust)SourcePluginForCurrentPlatform|TestRun_ProviderReleaseDefaultsSourcePluginToHostPlatform|TestRun_ProviderReleaseBuildsExecutableAuthProviders|TestRun_ProviderReleaseBuildsRustSourcePluginForExplicitLinuxTarget|TestE2EServeMountsGeneratedHostedHTTPBindingsForLocalSourcePlugin' -count=1`
- `go test ./... -run 'TestRouterManifestMetadata|TestServeProviderWritesStaticArtifacts' -count=1` in `sdk/go`
- `PYTHONPATH=. python3 -m unittest tests.test_plugin tests.test_runtime` in `sdk/python`
- `uv run ruff check gestalt/_manifest_metadata.py tests/test_plugin.py tests/test_runtime.py` in `sdk/python`
- `bun test tests/runtime.test.ts`
- `bunx tsc --noEmit`
- `bunx eslint --max-warnings=0 src/index.ts src/plugin.ts src/runtime.ts src/manifest-metadata.ts`
- `cargo test --test router`
- `cargo fmt --all --check`
- `golangci-lint run ./internal/server/... ./internal/providerpkg/... ./internal/config/... ./cmd/gestaltd/...`

## Scope note
This intentionally does not try to redesign the older connection/auth/integration architecture in the same PR. It only removes vendor-specific hosted HTTP auth from the new core primitive so vendor adapters can live in plugins/SDKs instead.