### PR TITLE
Deduplicate hosted HTTP security scheme validation

### DIFF
--- a/gestaltd/internal/httpbinding/security.go
+++ b/gestaltd/internal/httpbinding/security.go
@@ -1,0 +1,63 @@
+package httpbinding
+
+import (
+	"fmt"
+	"strings"
+
+	providermanifestv1 "github.com/valon-technologies/gestalt/server/sdk/providermanifest/v1"
+)
+
+func ValidateHTTPSecurityScheme(path string, scheme *providermanifestv1.HTTPSecurityScheme) error {
+	if scheme == nil {
+		return fmt.Errorf("%s is required", path)
+	}
+	switch scheme.Type {
+	case providermanifestv1.HTTPSecuritySchemeTypeHMAC:
+		if strings.TrimSpace(scheme.SignatureHeader) == "" {
+			return fmt.Errorf("%s.signatureHeader is required", path)
+		}
+		if strings.TrimSpace(scheme.PayloadTemplate) == "" {
+			return fmt.Errorf("%s.payloadTemplate is required", path)
+		}
+		if scheme.Secret == nil {
+			return fmt.Errorf("%s.secret is required", path)
+		}
+		if strings.TrimSpace(scheme.TimestampHeader) == "" && scheme.MaxAgeSeconds != 0 {
+			return fmt.Errorf("%s.maxAgeSeconds requires %s.timestampHeader to be set", path, path)
+		}
+		if strings.TrimSpace(scheme.TimestampHeader) != "" && scheme.MaxAgeSeconds <= 0 {
+			return fmt.Errorf("%s.timestampHeader requires %s.maxAgeSeconds to be greater than zero", path, path)
+		}
+		if err := ValidatePayloadTemplate(scheme.PayloadTemplate, scheme.TimestampHeader); err != nil {
+			return fmt.Errorf("%s.payloadTemplate %s", path, err)
+		}
+	case providermanifestv1.HTTPSecuritySchemeTypeAPIKey:
+		if strings.TrimSpace(scheme.Name) == "" {
+			return fmt.Errorf("%s.name is required", path)
+		}
+		switch scheme.In {
+		case providermanifestv1.HTTPInHeader, providermanifestv1.HTTPInQuery:
+		default:
+			return fmt.Errorf("%s.in %q is not supported", path, scheme.In)
+		}
+		if scheme.Secret == nil {
+			return fmt.Errorf("%s.secret is required", path)
+		}
+	case providermanifestv1.HTTPSecuritySchemeTypeHTTP:
+		switch scheme.Scheme {
+		case providermanifestv1.HTTPAuthSchemeBasic, providermanifestv1.HTTPAuthSchemeBearer:
+		default:
+			return fmt.Errorf("%s.scheme %q is not supported", path, scheme.Scheme)
+		}
+		if scheme.Secret == nil {
+			return fmt.Errorf("%s.secret is required", path)
+		}
+	case providermanifestv1.HTTPSecuritySchemeTypeNone:
+	default:
+		return fmt.Errorf("%s.type %q is not supported", path, scheme.Type)
+	}
+	if scheme.Secret != nil && strings.TrimSpace(scheme.Secret.Env) == "" && strings.TrimSpace(scheme.Secret.Secret) == "" {
+		return fmt.Errorf("%s.secret must set env or secret", path)
+	}
+	return nil
+}

--- a/gestaltd/internal/providerpkg/manifest.go
+++ b/gestaltd/internal/providerpkg/manifest.go
@@ -447,58 +447,7 @@ func normalizeHTTPContentType(field, value string) (string, error) {
 }
 
 func validateHTTPSecurityScheme(path string, scheme *providermanifestv1.HTTPSecurityScheme) error {
-	if scheme == nil {
-		return fmt.Errorf("%s is required", path)
-	}
-	switch scheme.Type {
-	case providermanifestv1.HTTPSecuritySchemeTypeHMAC:
-		if strings.TrimSpace(scheme.SignatureHeader) == "" {
-			return fmt.Errorf("%s.signatureHeader is required", path)
-		}
-		if strings.TrimSpace(scheme.PayloadTemplate) == "" {
-			return fmt.Errorf("%s.payloadTemplate is required", path)
-		}
-		if scheme.Secret == nil {
-			return fmt.Errorf("%s.secret is required", path)
-		}
-		if strings.TrimSpace(scheme.TimestampHeader) == "" && scheme.MaxAgeSeconds != 0 {
-			return fmt.Errorf("%s.maxAgeSeconds requires %s.timestampHeader to be set", path, path)
-		}
-		if strings.TrimSpace(scheme.TimestampHeader) != "" && scheme.MaxAgeSeconds <= 0 {
-			return fmt.Errorf("%s.timestampHeader requires %s.maxAgeSeconds to be greater than zero", path, path)
-		}
-		if err := httpbinding.ValidatePayloadTemplate(scheme.PayloadTemplate, scheme.TimestampHeader); err != nil {
-			return fmt.Errorf("%s.payloadTemplate %s", path, err)
-		}
-	case providermanifestv1.HTTPSecuritySchemeTypeAPIKey:
-		if strings.TrimSpace(scheme.Name) == "" {
-			return fmt.Errorf("%s.name is required", path)
-		}
-		switch scheme.In {
-		case providermanifestv1.HTTPInHeader, providermanifestv1.HTTPInQuery:
-		default:
-			return fmt.Errorf("%s.in %q is not supported", path, scheme.In)
-		}
-		if scheme.Secret == nil {
-			return fmt.Errorf("%s.secret is required", path)
-		}
-	case providermanifestv1.HTTPSecuritySchemeTypeHTTP:
-		switch scheme.Scheme {
-		case providermanifestv1.HTTPAuthSchemeBasic, providermanifestv1.HTTPAuthSchemeBearer:
-		default:
-			return fmt.Errorf("%s.scheme %q is not supported", path, scheme.Scheme)
-		}
-		if scheme.Secret == nil {
-			return fmt.Errorf("%s.secret is required", path)
-		}
-	case providermanifestv1.HTTPSecuritySchemeTypeNone:
-	default:
-		return fmt.Errorf("%s.type %q is not supported", path, scheme.Type)
-	}
-	if scheme.Secret != nil && strings.TrimSpace(scheme.Secret.Env) == "" && strings.TrimSpace(scheme.Secret.Secret) == "" {
-		return fmt.Errorf("%s.secret must set env or secret", path)
-	}
-	return nil
+	return httpbinding.ValidateHTTPSecurityScheme(path, scheme)
 }
 
 func validateHTTPBinding(path string, binding *providermanifestv1.HTTPBinding, schemes map[string]*providermanifestv1.HTTPSecurityScheme) error {

--- a/gestaltd/internal/providerpkg/manifest_workflow_test.go
+++ b/gestaltd/internal/providerpkg/manifest_workflow_test.go
@@ -1,6 +1,7 @@
 package providerpkg
 
 import (
+	"fmt"
 	"os"
 	"path/filepath"
 	"strings"
@@ -679,6 +680,105 @@ spec:
 			}
 			if !strings.Contains(err.Error(), tt.want) {
 				t.Fatalf("error = %v, want substring %q", err, tt.want)
+			}
+		})
+	}
+}
+
+func TestManifestWorkflow_RejectsInvalidHTTPSecuritySchemes(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name        string
+		schemeYAML  string
+		wantErrPart string
+	}{
+		{
+			name: "unsupported type",
+			schemeYAML: `
+      type: bogus
+`,
+			wantErrPart: `provider.securitySchemes.bad.type "bogus" is not supported`,
+		},
+		{
+			name: "invalid api key location",
+			schemeYAML: `
+      type: apiKey
+      name: X-Webhook-Key
+      in: cookie
+      secret:
+        secret: shared-key
+`,
+			wantErrPart: `provider.securitySchemes.bad.in "cookie" is not supported`,
+		},
+		{
+			name: "invalid http scheme",
+			schemeYAML: `
+      type: http
+      scheme: digest
+      secret:
+        secret: shared-key
+`,
+			wantErrPart: `provider.securitySchemes.bad.scheme "digest" is not supported`,
+		},
+		{
+			name: "missing secret",
+			schemeYAML: `
+      type: apiKey
+      name: X-Webhook-Key
+      in: header
+`,
+			wantErrPart: `provider.securitySchemes.bad.secret is required`,
+		},
+		{
+			name: "blank secret ref",
+			schemeYAML: `
+      type: apiKey
+      name: X-Webhook-Key
+      in: header
+      secret: {}
+`,
+			wantErrPart: `provider.securitySchemes.bad.secret must set env or secret`,
+		},
+		{
+			name: "missing hmac signature header",
+			schemeYAML: `
+      type: hmac
+      secret:
+        secret: shared-key
+      payloadTemplate: "{raw_body}"
+`,
+			wantErrPart: `provider.securitySchemes.bad.signatureHeader is required`,
+		},
+	}
+
+	for _, tt := range tests {
+		tt := tt
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			dir := t.TempDir()
+			manifestPath := mustWriteManifestData(t, dir, "manifest.yaml", []byte(fmt.Sprintf(`
+kind: plugin
+source: github.com/acme/plugins/bad-http-security
+version: 1.0.0
+spec:
+  securitySchemes:
+    bad:%s
+  http:
+    command:
+      path: /command
+      method: POST
+      security: bad
+      target: handle_command
+`, tt.schemeYAML)))
+
+			_, _, err := ReadSourceManifestFile(manifestPath)
+			if err == nil {
+				t.Fatal("expected invalid manifest")
+			}
+			if !strings.Contains(err.Error(), tt.wantErrPart) {
+				t.Fatalf("error = %v", err)
 			}
 		})
 	}

--- a/gestaltd/internal/server/http_bindings.go
+++ b/gestaltd/internal/server/http_bindings.go
@@ -171,59 +171,7 @@ func providerOperationIDs(providers *registry.ProviderMap[core.Provider], plugin
 }
 
 func validateMountedHTTPSecurityScheme(pluginName, schemeName string, scheme *config.HTTPSecurityScheme) error {
-	path := fmt.Sprintf("http security scheme %s.%s", pluginName, schemeName)
-	if scheme == nil {
-		return fmt.Errorf("%s is required", path)
-	}
-	switch scheme.Type {
-	case providermanifestv1.HTTPSecuritySchemeTypeHMAC:
-		if strings.TrimSpace(scheme.SignatureHeader) == "" {
-			return fmt.Errorf("%s.signatureHeader is required", path)
-		}
-		if strings.TrimSpace(scheme.PayloadTemplate) == "" {
-			return fmt.Errorf("%s.payloadTemplate is required", path)
-		}
-		if scheme.Secret == nil {
-			return fmt.Errorf("%s.secret is required", path)
-		}
-		if strings.TrimSpace(scheme.TimestampHeader) == "" && scheme.MaxAgeSeconds != 0 {
-			return fmt.Errorf("%s.maxAgeSeconds requires %s.timestampHeader to be set", path, path)
-		}
-		if strings.TrimSpace(scheme.TimestampHeader) != "" && scheme.MaxAgeSeconds <= 0 {
-			return fmt.Errorf("%s.timestampHeader requires %s.maxAgeSeconds to be greater than zero", path, path)
-		}
-		if err := httpbinding.ValidatePayloadTemplate(scheme.PayloadTemplate, scheme.TimestampHeader); err != nil {
-			return fmt.Errorf("%s.payloadTemplate %s", path, err)
-		}
-	case providermanifestv1.HTTPSecuritySchemeTypeAPIKey:
-		if strings.TrimSpace(scheme.Name) == "" {
-			return fmt.Errorf("%s.name is required", path)
-		}
-		switch scheme.In {
-		case providermanifestv1.HTTPInHeader, providermanifestv1.HTTPInQuery:
-		default:
-			return fmt.Errorf("%s.in %q is not supported", path, scheme.In)
-		}
-		if scheme.Secret == nil {
-			return fmt.Errorf("%s.secret is required", path)
-		}
-	case providermanifestv1.HTTPSecuritySchemeTypeHTTP:
-		switch scheme.Scheme {
-		case providermanifestv1.HTTPAuthSchemeBasic, providermanifestv1.HTTPAuthSchemeBearer:
-		default:
-			return fmt.Errorf("%s.scheme %q is not supported", path, scheme.Scheme)
-		}
-		if scheme.Secret == nil {
-			return fmt.Errorf("%s.secret is required", path)
-		}
-	case providermanifestv1.HTTPSecuritySchemeTypeNone:
-	default:
-		return fmt.Errorf("%s.type %q is not supported", path, scheme.Type)
-	}
-	if scheme.Secret != nil && strings.TrimSpace(scheme.Secret.Env) == "" && strings.TrimSpace(scheme.Secret.Secret) == "" {
-		return fmt.Errorf("%s.secret must set env or secret", path)
-	}
-	return nil
+	return httpbinding.ValidateHTTPSecurityScheme(fmt.Sprintf("http security scheme %s.%s", pluginName, schemeName), scheme)
 }
 
 func validateMountedHTTPBinding(pluginName, bindingName string, binding *config.HTTPBinding, schemes map[string]*config.HTTPSecurityScheme) error {

--- a/gestaltd/internal/server/server_test.go
+++ b/gestaltd/internal/server/server_test.go
@@ -12484,6 +12484,111 @@ func TestHostedHTTPBinding_RejectsInvalidConfigBindings(t *testing.T) {
 			wantErr: "secret is required",
 		},
 		{
+			name: "unsupported security scheme type",
+			entry: &config.ProviderEntry{
+				SecuritySchemes: map[string]*config.HTTPSecurityScheme{
+					"eventKey": {
+						Type: "bogus",
+					},
+				},
+				HTTP: map[string]*config.HTTPBinding{
+					"event": {
+						Path:     "/event",
+						Method:   http.MethodPost,
+						Security: "eventKey",
+						Target:   "handle_event",
+					},
+				},
+			},
+			wantErr: `type "bogus" is not supported`,
+		},
+		{
+			name: "invalid api key location",
+			entry: &config.ProviderEntry{
+				SecuritySchemes: map[string]*config.HTTPSecurityScheme{
+					"eventKey": {
+						Type:   providermanifestv1.HTTPSecuritySchemeTypeAPIKey,
+						Name:   "X-Webhook-Key",
+						In:     "cookie",
+						Secret: &providermanifestv1.HTTPSecretRef{Secret: "shared-key"},
+					},
+				},
+				HTTP: map[string]*config.HTTPBinding{
+					"event": {
+						Path:     "/event",
+						Method:   http.MethodPost,
+						Security: "eventKey",
+						Target:   "handle_event",
+					},
+				},
+			},
+			wantErr: `in "cookie" is not supported`,
+		},
+		{
+			name: "invalid http auth scheme",
+			entry: &config.ProviderEntry{
+				SecuritySchemes: map[string]*config.HTTPSecurityScheme{
+					"eventKey": {
+						Type:   providermanifestv1.HTTPSecuritySchemeTypeHTTP,
+						Scheme: "digest",
+						Secret: &providermanifestv1.HTTPSecretRef{Secret: "shared-key"},
+					},
+				},
+				HTTP: map[string]*config.HTTPBinding{
+					"event": {
+						Path:     "/event",
+						Method:   http.MethodPost,
+						Security: "eventKey",
+						Target:   "handle_event",
+					},
+				},
+			},
+			wantErr: `scheme "digest" is not supported`,
+		},
+		{
+			name: "blank secret reference",
+			entry: &config.ProviderEntry{
+				SecuritySchemes: map[string]*config.HTTPSecurityScheme{
+					"eventKey": {
+						Type:   providermanifestv1.HTTPSecuritySchemeTypeAPIKey,
+						Name:   "X-Webhook-Key",
+						In:     providermanifestv1.HTTPInHeader,
+						Secret: &providermanifestv1.HTTPSecretRef{},
+					},
+				},
+				HTTP: map[string]*config.HTTPBinding{
+					"event": {
+						Path:     "/event",
+						Method:   http.MethodPost,
+						Security: "eventKey",
+						Target:   "handle_event",
+					},
+				},
+			},
+			wantErr: "secret must set env or secret",
+		},
+		{
+			name: "missing hmac signature header",
+			entry: &config.ProviderEntry{
+				SecuritySchemes: map[string]*config.HTTPSecurityScheme{
+					"eventKey": {
+						Type:            providermanifestv1.HTTPSecuritySchemeTypeHMAC,
+						Secret:          &providermanifestv1.HTTPSecretRef{Secret: "shared-key"},
+						PayloadTemplate: "{raw_body}",
+					},
+				},
+				HTTP: map[string]*config.HTTPBinding{
+					"event": {
+						Path:     "/event",
+						Method:   http.MethodPost,
+						Security: "eventKey",
+						Target:   "handle_event",
+					},
+				},
+			},
+			wantErr: "signatureHeader is required",
+		},
+		{
 			name: "duplicate normalized content types",
 			entry: &config.ProviderEntry{
 				SecuritySchemes: map[string]*config.HTTPSecurityScheme{


### PR DESCRIPTION
## Summary
This PR removes duplicated hosted HTTP security-scheme validation logic from two places:
- `gestaltd/internal/server/http_bindings.go`
- `gestaltd/internal/providerpkg/manifest.go`

It introduces one shared helper instead:

```go
err := httpbinding.ValidateHTTPSecurityScheme(
    "provider.securitySchemes.slack",
    scheme,
)
```

Both call sites now use that helper, so mounted hosted HTTP bindings and manifest validation stay behaviorally aligned.

## New Interface
Shared internal helper:

```go
package httpbinding

func ValidateHTTPSecurityScheme(path string, scheme *providermanifestv1.HTTPSecurityScheme) error
```

This preserves the existing supported scheme shapes:

```yaml
securitySchemes:
  slack:
    type: slack_signature
    secret:
      env: SLACK_SIGNING_SECRET

  webhookKey:
    type: apiKey
    name: X-Webhook-Key
    in: header
    secret:
      secret: shared-key

  bearer:
    type: http
    scheme: bearer
    secret:
      env: WEBHOOK_BEARER_TOKEN

  public:
    type: none
```

## Why
The two previous validators were effectively copies of each other. Since `config.HTTPSecurityScheme` is a type alias of `providermanifestv1.HTTPSecurityScheme`, a shared helper is the simpler and safer boundary.

## Validation
Existing integration/functional coverage only:
- `go test ./internal/providerpkg -run 'TestManifestWorkflow_(AcceptsHostedHTTPBindingsAndSecuritySchemes|RejectsNon2xxHTTPAckStatus|RejectsDuplicateNormalizedHTTPContentTypes|AcceptsProviderWireSurfaceManifest)' -count=1`
- `go test ./internal/server -run 'TestHostedHTTPBinding_(RejectsInvalidConfigBindings|RejectsGenericOperationRouteConflicts|MergesManifestAndConfigOverrides|APIKeySyncInvokesOperation)' -count=1`
- `go test ./internal/httpbinding ./internal/providerpkg ./internal/server -run TestDoesNotExist -count=1`
- `golangci-lint run ./internal/httpbinding/... ./internal/providerpkg/... ./internal/server/...`
