### PR TITLE
Allow plugins to expose both OpenAPI and GraphQL surfaces

### DIFF
--- a/docs/content/reference/plugin-manifests.mdx
+++ b/docs/content/reference/plugin-manifests.mdx
@@ -175,7 +175,7 @@ Surfaces load operation catalogs from external specifications. They are configur
 | `baseUrl`    | string              | Base URL for declarative REST operations.                                         |
 | `operations` | ProviderOperation[] | Declarative REST operations. Presence of this field makes the plugin declarative. |
 
-The `rest`/`openapi`/`graphql` surface types are mutually exclusive (use `surfaces.openapi` or `surfaces.graphql`, not both), but `surfaces.mcp` may be combined with any of them.
+`surfaces.rest` is the declarative REST form. `surfaces.openapi`, `surfaces.graphql`, and `surfaces.mcp` are passthrough surfaces. You may combine `openapi` and `graphql` on the same plugin, and `mcp` may be added alongside any of them.
 
 ### Authentication Types
 
@@ -672,7 +672,7 @@ spec:
 
 Manifest paths must stay inside the package. `kind`, `source`, and `version` are required. A manifest defines exactly one provider kind: `kind: plugin`, `kind: authentication`, `kind: indexeddb`, `kind: secrets`, or `kind: ui`.
 
-`configSchemaPath` validates per-plugin config and may be written in JSON or YAML. Any connection may define `params` and `discovery`. The OpenAPI/GraphQL surface types are mutually exclusive, but MCP may be added alongside either.
+`configSchemaPath` validates per-plugin config and may be written in JSON or YAML. Any connection may define `params` and `discovery`. OpenAPI and GraphQL may be declared together on one plugin, and MCP may be added alongside either or both.
 
 A connection using `mcp_oauth` auth requires the plugin to declare an MCP surface (via `spec.surfaces.mcp` or an equivalent). Manifests that set `auth.type: mcp_oauth` without an MCP surface fail validation.
 

--- a/gestaltd/internal/bootstrap/bootstrap_test.go
+++ b/gestaltd/internal/bootstrap/bootstrap_test.go
@@ -3739,22 +3739,110 @@ func TestValidate(t *testing.T) {
 		}
 	})
 
-	t.Run("rejects plugin configured with both openapi and graphql api surfaces", func(t *testing.T) {
+	t.Run("accepts plugin configured with both openapi and graphql api surfaces", func(t *testing.T) {
 		t.Parallel()
 
-		srv := startBootstrapGraphQLIntrospectionServer(t)
+		schema := map[string]any{
+			"queryType": map[string]any{"name": "Query"},
+			"types": []any{
+				map[string]any{
+					"kind": "OBJECT",
+					"name": "Query",
+					"fields": []any{
+						map[string]any{
+							"name": "viewer",
+							"args": []any{
+								map[string]any{
+									"name": "team",
+									"type": map[string]any{"kind": "SCALAR", "name": "String"},
+								},
+							},
+							"type": map[string]any{"kind": "OBJECT", "name": "Viewer"},
+						},
+					},
+				},
+				map[string]any{
+					"kind": "OBJECT",
+					"name": "Viewer",
+					"fields": []any{
+						map[string]any{"name": "id", "type": map[string]any{"kind": "SCALAR", "name": "ID"}},
+						map[string]any{"name": "name", "type": map[string]any{"kind": "SCALAR", "name": "String"}},
+					},
+				},
+				map[string]any{"kind": "SCALAR", "name": "String"},
+				map[string]any{"kind": "SCALAR", "name": "ID"},
+			},
+		}
+		srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			switch r.URL.Path {
+			case "/openapi.json":
+				w.Header().Set("Content-Type", "application/json")
+				_ = json.NewEncoder(w).Encode(map[string]any{
+					"openapi": "3.1.0",
+					"info": map[string]any{
+						"title":   "Linear API",
+						"version": "1.0.0",
+					},
+					"paths": map[string]any{
+						"/status": map[string]any{
+							"get": map[string]any{
+								"operationId": "status",
+								"responses": map[string]any{
+									"200": map[string]any{"description": "ok"},
+								},
+							},
+						},
+					},
+				})
+			case "/status":
+				w.Header().Set("Content-Type", "application/json")
+				_, _ = w.Write([]byte(`{"ok":true}`))
+			case "/graphql":
+				var payload struct {
+					Query string `json:"query"`
+				}
+				if err := json.NewDecoder(r.Body).Decode(&payload); err != nil {
+					http.Error(w, err.Error(), http.StatusBadRequest)
+					return
+				}
+				w.Header().Set("Content-Type", "application/json")
+				if strings.Contains(payload.Query, "__schema") {
+					_ = json.NewEncoder(w).Encode(map[string]any{"data": map[string]any{"__schema": schema}})
+					return
+				}
+				_ = json.NewEncoder(w).Encode(map[string]any{
+					"data": map[string]any{
+						"viewer": map[string]any{
+							"id":   "user-123",
+							"name": "Platform",
+						},
+					},
+				})
+			default:
+				http.NotFound(w, r)
+			}
+		}))
+		t.Cleanup(srv.Close)
+
 		cfg := validConfig()
 		cfg.Plugins = map[string]*config.ProviderEntry{
 			"linear": {
 				ResolvedManifest: &providermanifestv1.Manifest{
 					Spec: &providermanifestv1.Spec{
+						DefaultConnection: "rest",
+						Connections: map[string]*providermanifestv1.ManifestConnectionDef{
+							"rest":    {Mode: providermanifestv1.ConnectionModeNone},
+							"graphql": {Mode: providermanifestv1.ConnectionModeNone},
+						},
 						Surfaces: &providermanifestv1.ProviderSurfaces{
 							OpenAPI: &providermanifestv1.OpenAPISurface{
-								Document: "https://example.invalid/openapi.json",
-								BaseURL:  "https://example.invalid/api",
+								Document:   srv.URL + "/openapi.json",
+								BaseURL:    srv.URL,
+								Connection: "rest",
 							},
 							GraphQL: &providermanifestv1.GraphQLSurface{
-								URL: srv.URL,
+								URL:        srv.URL + "/graphql",
+								Connection: "graphql",
 							},
 						},
 					},
@@ -3762,9 +3850,8 @@ func TestValidate(t *testing.T) {
 			},
 		}
 
-		_, err := bootstrap.Validate(context.Background(), cfg, validFactories())
-		if err == nil || !strings.Contains(err.Error(), `openapi and graphql surfaces cannot both be configured for the same plugin`) {
-			t.Fatalf("Validate error = %v, want mixed api surface rejection", err)
+		if _, err := bootstrap.Validate(context.Background(), cfg, validFactories()); err != nil {
+			t.Fatalf("Validate: %v", err)
 		}
 	})
 
@@ -3853,6 +3940,168 @@ func TestValidate(t *testing.T) {
 			t.Fatalf("Validate: %v", err)
 		}
 	})
+}
+
+func TestBootstrapAllowsPluginConfiguredWithBothOpenAPIAndGraphQLAPISurfaces(t *testing.T) {
+	t.Parallel()
+
+	schema := map[string]any{
+		"queryType": map[string]any{"name": "Query"},
+		"types": []any{
+			map[string]any{
+				"kind": "OBJECT",
+				"name": "Query",
+				"fields": []any{
+					map[string]any{
+						"name": "viewer",
+						"args": []any{
+							map[string]any{
+								"name": "team",
+								"type": map[string]any{"kind": "SCALAR", "name": "String"},
+							},
+						},
+						"type": map[string]any{"kind": "OBJECT", "name": "Viewer"},
+					},
+				},
+			},
+			map[string]any{
+				"kind": "OBJECT",
+				"name": "Viewer",
+				"fields": []any{
+					map[string]any{"name": "id", "type": map[string]any{"kind": "SCALAR", "name": "ID"}},
+					map[string]any{"name": "name", "type": map[string]any{"kind": "SCALAR", "name": "String"}},
+				},
+			},
+			map[string]any{"kind": "SCALAR", "name": "String"},
+			map[string]any{"kind": "SCALAR", "name": "ID"},
+		},
+	}
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch r.URL.Path {
+		case "/openapi.json":
+			w.Header().Set("Content-Type", "application/json")
+			_ = json.NewEncoder(w).Encode(map[string]any{
+				"openapi": "3.1.0",
+				"info": map[string]any{
+					"title":   "Linear API",
+					"version": "1.0.0",
+				},
+				"paths": map[string]any{
+					"/status": map[string]any{
+						"get": map[string]any{
+							"operationId": "status",
+							"responses": map[string]any{
+								"200": map[string]any{"description": "ok"},
+							},
+						},
+					},
+				},
+			})
+		case "/status":
+			w.Header().Set("Content-Type", "application/json")
+			_, _ = w.Write([]byte(`{"ok":true}`))
+		case "/graphql":
+			var payload struct {
+				Query string `json:"query"`
+			}
+			if err := json.NewDecoder(r.Body).Decode(&payload); err != nil {
+				http.Error(w, err.Error(), http.StatusBadRequest)
+				return
+			}
+			w.Header().Set("Content-Type", "application/json")
+			if strings.Contains(payload.Query, "__schema") {
+				_ = json.NewEncoder(w).Encode(map[string]any{"data": map[string]any{"__schema": schema}})
+				return
+			}
+			_ = json.NewEncoder(w).Encode(map[string]any{
+				"data": map[string]any{
+					"viewer": map[string]any{
+						"id":   "user-123",
+						"name": "Platform",
+					},
+				},
+			})
+		default:
+			http.NotFound(w, r)
+		}
+	}))
+	t.Cleanup(srv.Close)
+
+	cfg := validConfig()
+	cfg.Plugins = map[string]*config.ProviderEntry{
+		"linear": {
+			ResolvedManifest: &providermanifestv1.Manifest{
+				Spec: &providermanifestv1.Spec{
+					DefaultConnection: "rest",
+					Connections: map[string]*providermanifestv1.ManifestConnectionDef{
+						"rest":    {Mode: providermanifestv1.ConnectionModeNone},
+						"graphql": {Mode: providermanifestv1.ConnectionModeNone},
+					},
+					Surfaces: &providermanifestv1.ProviderSurfaces{
+						OpenAPI: &providermanifestv1.OpenAPISurface{
+							Document:   srv.URL + "/openapi.json",
+							BaseURL:    srv.URL,
+							Connection: "rest",
+						},
+						GraphQL: &providermanifestv1.GraphQLSurface{
+							URL:        srv.URL + "/graphql",
+							Connection: "graphql",
+						},
+					},
+				},
+			},
+		},
+	}
+
+	if _, err := bootstrap.Validate(context.Background(), cfg, validFactories()); err != nil {
+		t.Fatalf("Validate: %v", err)
+	}
+
+	result, err := bootstrap.Bootstrap(context.Background(), cfg, validFactories())
+	if err != nil {
+		t.Fatalf("Bootstrap: %v", err)
+	}
+	t.Cleanup(func() { _ = result.Close(context.Background()) })
+	<-result.ProvidersReady
+
+	prov, err := result.Providers.Get("linear")
+	if err != nil {
+		t.Fatalf("Providers.Get(linear): %v", err)
+	}
+
+	if got := prov.ConnectionForOperation("status"); got != "rest" {
+		t.Fatalf("ConnectionForOperation(status) = %q, want %q", got, "rest")
+	}
+	if got := prov.ConnectionForOperation("viewer"); got != "graphql" {
+		t.Fatalf("ConnectionForOperation(viewer) = %q, want %q", got, "graphql")
+	}
+
+	cat := prov.Catalog()
+	if cat == nil {
+		t.Fatal("Catalog() = nil, want mixed API catalog")
+	}
+	if got, ok := invocation.CatalogOperationTransport(cat, "status"); !ok || got != catalog.TransportREST {
+		t.Fatalf("status transport = %q, ok=%v, want %q", got, ok, catalog.TransportREST)
+	}
+	if got, ok := invocation.CatalogOperationTransport(cat, "viewer"); !ok || got != "graphql" {
+		t.Fatalf("viewer transport = %q, ok=%v, want %q", got, ok, "graphql")
+	}
+
+	statusResult, err := prov.Execute(context.Background(), "status", nil, "")
+	if err != nil {
+		t.Fatalf("Execute(status): %v", err)
+	}
+	if statusResult.Status != http.StatusOK || !strings.Contains(statusResult.Body, `"ok":true`) {
+		t.Fatalf("status result = %+v, want 200 with ok body", statusResult)
+	}
+
+	viewerResult, err := prov.Execute(context.Background(), "viewer", map[string]any{"team": "platform"}, "")
+	if err != nil {
+		t.Fatalf("Execute(viewer): %v", err)
+	}
+	if viewerResult.Status != http.StatusOK || !strings.Contains(viewerResult.Body, `"Platform"`) {
+		t.Fatalf("viewer result = %+v, want 200 with graphql body", viewerResult)
+	}
 }
 
 func TestBootstrapNoIntegrations(t *testing.T) {

--- a/gestaltd/internal/bootstrap/connected_provider.go
+++ b/gestaltd/internal/bootstrap/connected_provider.go
@@ -1,0 +1,151 @@
+package bootstrap
+
+import (
+	"context"
+	"fmt"
+	"io"
+
+	"github.com/valon-technologies/gestalt/server/core"
+	"github.com/valon-technologies/gestalt/server/core/catalog"
+)
+
+func bindProviderConnection(prov core.Provider, connection string) core.Provider {
+	if prov == nil || connection == "" {
+		return prov
+	}
+
+	var wrapped core.Provider = &connectedProvider{
+		inner:      prov,
+		connection: connection,
+	}
+	if session, ok := prov.(core.SessionCatalogProvider); ok {
+		wrapped = &connectedSessionCatalogProvider{
+			Provider: wrapped,
+			session:  session,
+		}
+	}
+	if graphQL, ok := prov.(core.GraphQLSurfaceInvoker); ok {
+		wrapped = &connectedGraphQLProvider{
+			Provider: wrapped,
+			graphQL:  graphQL,
+		}
+	}
+	if auth, ok := prov.(core.OAuthProvider); ok {
+		wrapped = &connectedOAuthProvider{
+			Provider: wrapped,
+			auth:     auth,
+		}
+	}
+	return wrapped
+}
+
+type connectedProvider struct {
+	inner      core.Provider
+	connection string
+}
+
+func (p *connectedProvider) Name() string                        { return p.inner.Name() }
+func (p *connectedProvider) DisplayName() string                 { return p.inner.DisplayName() }
+func (p *connectedProvider) Description() string                 { return p.inner.Description() }
+func (p *connectedProvider) ConnectionMode() core.ConnectionMode { return p.inner.ConnectionMode() }
+func (p *connectedProvider) AuthTypes() []string                 { return p.inner.AuthTypes() }
+func (p *connectedProvider) ConnectionParamDefs() map[string]core.ConnectionParamDef {
+	return p.inner.ConnectionParamDefs()
+}
+func (p *connectedProvider) CredentialFields() []core.CredentialFieldDef {
+	return p.inner.CredentialFields()
+}
+func (p *connectedProvider) DiscoveryConfig() *core.DiscoveryConfig {
+	return p.inner.DiscoveryConfig()
+}
+func (p *connectedProvider) ConnectionForOperation(string) string { return p.connection }
+func (p *connectedProvider) Catalog() *catalog.Catalog            { return p.inner.Catalog() }
+func (p *connectedProvider) Execute(ctx context.Context, operation string, params map[string]any, token string) (*core.OperationResult, error) {
+	return p.inner.Execute(ctx, operation, params, token)
+}
+func (p *connectedProvider) Close() error {
+	if closer, ok := p.inner.(io.Closer); ok {
+		return closer.Close()
+	}
+	return nil
+}
+
+type connectedSessionCatalogProvider struct {
+	core.Provider
+	session core.SessionCatalogProvider
+}
+
+func (p *connectedSessionCatalogProvider) CatalogForRequest(ctx context.Context, token string) (*catalog.Catalog, error) {
+	return p.session.CatalogForRequest(ctx, token)
+}
+
+func (p *connectedSessionCatalogProvider) Close() error {
+	if closer, ok := p.Provider.(io.Closer); ok {
+		return closer.Close()
+	}
+	return nil
+}
+
+type connectedGraphQLProvider struct {
+	core.Provider
+	graphQL core.GraphQLSurfaceInvoker
+}
+
+func (p *connectedGraphQLProvider) InvokeGraphQL(ctx context.Context, request core.GraphQLRequest, token string) (*core.OperationResult, error) {
+	return p.graphQL.InvokeGraphQL(ctx, request, token)
+}
+
+func (p *connectedGraphQLProvider) CatalogForRequest(ctx context.Context, token string) (*catalog.Catalog, error) {
+	session, ok := p.Provider.(core.SessionCatalogProvider)
+	if !ok {
+		return nil, core.WrapSessionCatalogUnsupported(fmt.Errorf("provider %q does not support session catalogs", p.Name()))
+	}
+	return session.CatalogForRequest(ctx, token)
+}
+
+func (p *connectedGraphQLProvider) Close() error {
+	if closer, ok := p.Provider.(io.Closer); ok {
+		return closer.Close()
+	}
+	return nil
+}
+
+type connectedOAuthProvider struct {
+	core.Provider
+	auth core.OAuthProvider
+}
+
+func (p *connectedOAuthProvider) AuthorizationURL(state string, scopes []string) string {
+	return p.auth.AuthorizationURL(state, scopes)
+}
+
+func (p *connectedOAuthProvider) ExchangeCode(ctx context.Context, code string) (*core.TokenResponse, error) {
+	return p.auth.ExchangeCode(ctx, code)
+}
+
+func (p *connectedOAuthProvider) RefreshToken(ctx context.Context, refreshToken string) (*core.TokenResponse, error) {
+	return p.auth.RefreshToken(ctx, refreshToken)
+}
+
+func (p *connectedOAuthProvider) CatalogForRequest(ctx context.Context, token string) (*catalog.Catalog, error) {
+	session, ok := p.Provider.(core.SessionCatalogProvider)
+	if !ok {
+		return nil, core.WrapSessionCatalogUnsupported(fmt.Errorf("provider %q does not support session catalogs", p.Name()))
+	}
+	return session.CatalogForRequest(ctx, token)
+}
+
+func (p *connectedOAuthProvider) InvokeGraphQL(ctx context.Context, request core.GraphQLRequest, token string) (*core.OperationResult, error) {
+	invoker, ok := p.Provider.(core.GraphQLSurfaceInvoker)
+	if !ok {
+		return nil, fmt.Errorf("graphql surface is not available")
+	}
+	return invoker.InvokeGraphQL(ctx, request, token)
+}
+
+func (p *connectedOAuthProvider) Close() error {
+	if closer, ok := p.Provider.(io.Closer); ok {
+		return closer.Close()
+	}
+	return nil
+}

--- a/gestaltd/internal/bootstrap/connections.go
+++ b/gestaltd/internal/bootstrap/connections.go
@@ -60,10 +60,7 @@ func buildConnectionAuthMap(name string, entry *config.ProviderEntry, manifest *
 	}
 
 	specAuthForConnection := func(connectionName string) *provider.Definition {
-		if authFallback == nil || authFallback.definition == nil || authFallback.connectionName != connectionName {
-			return nil
-		}
-		return authFallback.definition
+		return authFallback.definitionFor(connectionName)
 	}
 
 	handlers := make(map[string]OAuthHandler)

--- a/gestaltd/internal/bootstrap/provider_build.go
+++ b/gestaltd/internal/bootstrap/provider_build.go
@@ -240,6 +240,12 @@ func operationConnectionsForCatalog(cat *catalog.Catalog, plan config.StaticConn
 		switch operation.Transport {
 		case catalog.TransportREST:
 			connection = plan.APIConnection()
+		case "graphql":
+			if resolved, ok := plan.ResolvedSurface(config.SpecSurfaceGraphQL); ok {
+				connection = resolved.ConnectionName
+			} else {
+				connection = plan.APIConnection()
+			}
 		case catalog.TransportMCPPassthrough:
 			connection = plan.MCPConnection()
 		}
@@ -341,10 +347,6 @@ func buildExecutablePluginProvider(ctx context.Context, name string, entry *conf
 	if err != nil {
 		return nil, err
 	}
-	mcpURL := ""
-	if resolved, ok := plan.ResolvedSurface(config.SpecSurfaceMCP); ok {
-		mcpURL = resolved.URL
-	}
 	allowedOperations := entry.AllowedOperations
 	if allowedOperations == nil && manifestPlugin != nil {
 		allowedOperations = maps.Clone(manifestPlugin.AllowedOperations)
@@ -389,8 +391,12 @@ func buildExecutablePluginProvider(ctx context.Context, name string, entry *conf
 		return newProviderBuildResult(name, entry, manifest, pluginConfig, merged, nil, deps)
 	}
 
-	resolved, hasSpecSurface := plan.ConfiguredSpecSurface()
-	if !hasSpecSurface {
+	specProv, authFallback, err := buildConfiguredSpecComposite(ctx, name, entry, plan, manifestPlugin, meta, deps, allowedOperations)
+	if err != nil {
+		closeIfPossible(pluginProv)
+		return nil, fmt.Errorf("build hybrid spec provider %q: %w", name, err)
+	}
+	if specProv == nil {
 		restricted, err := applyAllowedOperations(name, allowedOperations, pluginProv)
 		if err != nil {
 			closeIfPossible(pluginProv)
@@ -404,39 +410,17 @@ func buildExecutablePluginProvider(ctx context.Context, name string, entry *conf
 		return nil, err
 	}
 	pluginProv = filteredPluginProv
-
-	specProv, specDef, err := buildConfiguredSpecProvider(ctx, name, resolved, meta, specProviderConfig{
-		manifestPlugin:       manifestPlugin,
-		allowedOperations:    allowedOperations,
-		allowedHosts:         entry.AllowedHosts,
-		baseURL:              config.EffectiveProviderSpecBaseURL(entry, manifestPlugin),
-		applyResponseMapping: true,
-		providerBuildOptions: func(conn config.ConnectionDef) []provider.BuildOption {
-			return mcpOAuthBuildOpts(conn, mcpURL, deps)
-		},
-	}, deps)
-	if err != nil {
-		closeIfPossible(pluginProv)
-		return nil, fmt.Errorf("build hybrid spec provider %q: %w", name, err)
-	}
 	merged, err := composite.NewMergedWithConnections(
 		name,
 		pluginProv.DisplayName(),
 		pluginProv.Description(),
 		firstProviderIconSVG(pluginProv, specProv),
-		composite.BoundProvider{Provider: pluginProv, Connection: hybridPluginOperationConnection(plan, resolved.ConnectionName)},
-		composite.BoundProvider{Provider: specProv, Connection: resolved.ConnectionName},
+		composite.BoundProvider{Provider: pluginProv, Connection: hybridPluginOperationConnection(plan, configuredSpecConnection(plan))},
+		composite.BoundProvider{Provider: specProv},
 	)
 	if err != nil {
 		closeIfPossible(specProv, pluginProv)
 		return nil, err
-	}
-	var authFallback *specAuthFallback
-	if specDef != nil {
-		authFallback = &specAuthFallback{
-			definition:     specDef,
-			connectionName: resolved.ConnectionName,
-		}
 	}
 	return newProviderBuildResult(name, entry, manifest, pluginConfig, merged, authFallback, deps)
 }
@@ -451,8 +435,40 @@ type specProviderConfig struct {
 }
 
 type specAuthFallback struct {
-	definition     *provider.Definition
-	connectionName string
+	definitions map[string]*provider.Definition
+}
+
+func newSpecAuthFallback() *specAuthFallback {
+	return &specAuthFallback{definitions: make(map[string]*provider.Definition)}
+}
+
+func (f *specAuthFallback) add(connectionName string, def *provider.Definition) {
+	if f == nil || def == nil {
+		return
+	}
+	resolvedName := config.ResolveConnectionAlias(connectionName)
+	if resolvedName == "" {
+		resolvedName = config.PluginConnectionName
+	}
+	if _, ok := f.definitions[resolvedName]; ok {
+		return
+	}
+	f.definitions[resolvedName] = def
+}
+
+func (f *specAuthFallback) definitionFor(connectionName string) *provider.Definition {
+	if f == nil {
+		return nil
+	}
+	resolvedName := config.ResolveConnectionAlias(connectionName)
+	if resolvedName == "" {
+		resolvedName = config.PluginConnectionName
+	}
+	return f.definitions[resolvedName]
+}
+
+func (f *specAuthFallback) empty() bool {
+	return f == nil || len(f.definitions) == 0
 }
 
 func newProviderBuildResult(name string, entry *config.ProviderEntry, manifest *providermanifestv1.Manifest, pluginConfig map[string]any, prov core.Provider, authFallback *specAuthFallback, deps Deps) (*ProviderBuildResult, error) {
@@ -466,65 +482,64 @@ func newProviderBuildResult(name string, entry *config.ProviderEntry, manifest *
 	return result, nil
 }
 
+type builtSpecSurface struct {
+	provider   core.Provider
+	resolved   config.ResolvedSpecSurface
+	definition *provider.Definition
+}
+
 func buildSpecLoadedProvider(ctx context.Context, name string, entry *config.ProviderEntry, manifest *providermanifestv1.Manifest, pluginConfig map[string]any, meta providerMetadata, deps Deps, allowedOperations map[string]*config.OperationOverride) (*ProviderBuildResult, error) {
 	mp := manifest.Spec
 	plan, err := config.BuildStaticConnectionPlan(entry, mp)
 	if err != nil {
 		return nil, fmt.Errorf("build spec-loaded provider %q: %w", name, err)
 	}
-	apiResolved, hasAPI := plan.ConfiguredAPISurface()
+
+	prov, authFallback, err := buildConfiguredSpecComposite(ctx, name, entry, plan, mp, meta, deps, allowedOperations)
+	if err != nil {
+		return nil, fmt.Errorf("build spec-loaded provider %q: %w", name, err)
+	}
+	if prov == nil {
+		return nil, fmt.Errorf("build spec-loaded provider %q: no spec URL", name)
+	}
+	return newProviderBuildResult(name, entry, manifest, pluginConfig, prov, authFallback, deps)
+}
+
+func buildConfiguredSpecComposite(ctx context.Context, name string, entry *config.ProviderEntry, plan config.StaticConnectionPlan, manifestPlugin *providermanifestv1.Spec, meta providerMetadata, deps Deps, allowedOperations map[string]*config.OperationOverride) (core.Provider, *specAuthFallback, error) {
 	mcpResolved, hasMCP := plan.ResolvedSurface(config.SpecSurfaceMCP)
 	mcpURL := ""
 	if hasMCP {
 		mcpURL = mcpResolved.URL
 	}
-	if !hasAPI && !hasMCP {
-		return nil, fmt.Errorf("build spec-loaded provider %q: no spec URL", name)
+
+	cfg := specProviderConfig{
+		manifestPlugin:       manifestPlugin,
+		allowedOperations:    allowedOperations,
+		allowedHosts:         entry.AllowedHosts,
+		baseURL:              config.EffectiveProviderSpecBaseURL(entry, manifestPlugin),
+		applyResponseMapping: true,
+		providerBuildOptions: func(conn config.ConnectionDef) []provider.BuildOption {
+			return mcpOAuthBuildOpts(conn, mcpURL, deps)
+		},
 	}
 
-	buildSpec := func(resolved config.ResolvedSpecSurface, allowed map[string]*config.OperationOverride) (core.Provider, *provider.Definition, error) {
-		return buildConfiguredSpecProvider(ctx, name, resolved, meta, specProviderConfig{
-			manifestPlugin:       mp,
-			allowedOperations:    allowed,
-			allowedHosts:         entry.AllowedHosts,
-			baseURL:              config.EffectiveProviderSpecBaseURL(entry, mp),
-			applyResponseMapping: true,
-			providerBuildOptions: func(conn config.ConnectionDef) []provider.BuildOption {
-				return mcpOAuthBuildOpts(conn, mcpURL, deps)
-			},
-		}, deps)
-	}
-
-	if !hasAPI {
-		prov, _, err := buildSpec(mcpResolved, allowedOperations)
-		if err != nil {
-			return nil, fmt.Errorf("build spec-loaded provider %q: %w", name, err)
-		}
-		return newProviderBuildResult(name, entry, manifest, pluginConfig, prov, nil, deps)
-	}
-
-	apiProv, apiDef, err := buildSpec(apiResolved, allowedOperations)
+	apiProv, authFallback, err := buildConfiguredAPIProvider(ctx, name, plan, meta, cfg, deps)
 	if err != nil {
-		return nil, fmt.Errorf("build spec-loaded provider %q: %w", name, err)
+		return nil, nil, err
 	}
-	authFallback := &specAuthFallback{
-		definition:     apiDef,
-		connectionName: apiResolved.ConnectionName,
-	}
-
 	if !hasMCP {
-		return newProviderBuildResult(name, entry, manifest, pluginConfig, apiProv, authFallback, deps)
+		return apiProv, authFallback, nil
 	}
 
-	mcpProv, _, err := buildSpec(mcpResolved, nil)
+	mcpProv, _, err := buildConfiguredSpecProvider(ctx, name, mcpResolved, meta, cfg, deps)
 	if err != nil {
 		closeIfPossible(apiProv)
-		return nil, fmt.Errorf("build spec-loaded provider %q: %w", name, err)
+		return nil, nil, err
 	}
 	mcpUp, ok := mcpProv.(composite.MCPUpstream)
 	if !ok {
 		closeIfPossible(mcpProv, apiProv)
-		return nil, fmt.Errorf("build spec-loaded provider %q: unexpected mcp provider type %T", name, mcpProv)
+		return nil, nil, fmt.Errorf("unexpected mcp provider type %T", mcpProv)
 	}
 
 	filtered := operationexposure.MatchingAllowedOperations(allowedOperations, mcpUp.Catalog())
@@ -534,15 +549,82 @@ func buildSpecLoadedProvider(ctx context.Context, name string, entry *config.Pro
 		})
 		if !ok {
 			closeIfPossible(mcpUp, apiProv)
-			return nil, fmt.Errorf("build spec-loaded provider %q: unexpected non-filterable mcp provider type %T", name, mcpProv)
+			return nil, nil, fmt.Errorf("unexpected non-filterable mcp provider type %T", mcpProv)
 		}
 		if err := filterable.FilterOperations(filtered); err != nil {
 			closeIfPossible(mcpUp, apiProv)
-			return nil, fmt.Errorf("build spec-loaded provider %q: filter mcp operations: %w", name, err)
+			return nil, nil, fmt.Errorf("filter mcp operations: %w", err)
 		}
 	}
 
-	return newProviderBuildResult(name, entry, manifest, pluginConfig, composite.New(name, apiProv, mcpUp), authFallback, deps)
+	if apiProv == nil {
+		return mcpUp, nil, nil
+	}
+	return composite.New(name, apiProv, mcpUp), authFallback, nil
+}
+
+func buildConfiguredAPIProvider(ctx context.Context, name string, plan config.StaticConnectionPlan, meta providerMetadata, cfg specProviderConfig, deps Deps) (core.Provider, *specAuthFallback, error) {
+	resolvedSurfaces := plan.ConfiguredAPISurfaces()
+	if len(resolvedSurfaces) == 0 {
+		return nil, nil, nil
+	}
+
+	built := make([]builtSpecSurface, 0, len(resolvedSurfaces))
+	authFallback := newSpecAuthFallback()
+	for i := range resolvedSurfaces {
+		resolved := resolvedSurfaces[i]
+		prov, def, err := buildConfiguredSpecProvider(ctx, name, resolved, meta, cfg, deps)
+		if err != nil {
+			closeBuiltSpecSurfaces(built)
+			return nil, nil, fmt.Errorf("build %s provider: %w", resolved.Surface, err)
+		}
+		built = append(built, builtSpecSurface{
+			provider:   prov,
+			resolved:   resolved,
+			definition: def,
+		})
+		authFallback.add(resolved.ConnectionName, def)
+	}
+
+	if len(built) == 1 {
+		if authFallback.empty() {
+			authFallback = nil
+		}
+		return bindProviderConnection(built[0].provider, built[0].resolved.ConnectionName), authFallback, nil
+	}
+
+	boundProviders := make([]composite.BoundProvider, 0, len(built))
+	providers := make([]core.Provider, 0, len(built))
+	for i := range built {
+		specSurface := &built[i]
+		boundProviders = append(boundProviders, composite.BoundProvider{
+			Provider:   specSurface.provider,
+			Connection: specSurface.resolved.ConnectionName,
+		})
+		providers = append(providers, specSurface.provider)
+	}
+
+	merged, err := composite.NewMergedWithConnections(
+		name,
+		built[0].provider.DisplayName(),
+		built[0].provider.Description(),
+		firstProviderIconSVG(providers...),
+		boundProviders...,
+	)
+	if err != nil {
+		closeBuiltSpecSurfaces(built)
+		return nil, nil, err
+	}
+	if authFallback.empty() {
+		authFallback = nil
+	}
+	return merged, authFallback, nil
+}
+
+func closeBuiltSpecSurfaces(surfaces []builtSpecSurface) {
+	for i := range surfaces {
+		closeIfPossible(surfaces[i].provider)
+	}
 }
 
 func loadConfiguredAPIDefinition(ctx context.Context, name string, resolved config.ResolvedSpecSurface, meta providerMetadata, cfg specProviderConfig) (*provider.Definition, error) {
@@ -550,7 +632,7 @@ func loadConfiguredAPIDefinition(ctx context.Context, name string, resolved conf
 	if err != nil {
 		return nil, fmt.Errorf("load %s definition: %w", resolved.Surface, err)
 	}
-	if cfg.baseURL != "" {
+	if cfg.baseURL != "" && resolved.Surface == config.SpecSurfaceOpenAPI {
 		def.BaseURL = cfg.baseURL
 	}
 	applyProviderHeaders(def, cfg.manifestPlugin)

--- a/gestaltd/internal/composite/merged.go
+++ b/gestaltd/internal/composite/merged.go
@@ -5,6 +5,8 @@ import (
 	"errors"
 	"fmt"
 	"io"
+	"maps"
+	"slices"
 
 	"github.com/valon-technologies/gestalt/server/core"
 	"github.com/valon-technologies/gestalt/server/core/catalog"
@@ -64,8 +66,11 @@ func NewMergedWithConnections(name, displayName, desc, iconSVG string, providers
 			}
 			m.route[op.ID] = p
 			m.catalog.Operations = append(m.catalog.Operations, *op)
-			if bound.Connection != "" {
+			switch {
+			case bound.Connection != "":
 				m.opConn[op.ID] = bound.Connection
+			case p.ConnectionForOperation(op.ID) != "":
+				m.opConn[op.ID] = p.ConnectionForOperation(op.ID)
 			}
 		}
 	}
@@ -77,12 +82,47 @@ func (m *MergedProvider) Name() string                        { return m.catalog
 func (m *MergedProvider) DisplayName() string                 { return m.catalog.DisplayName }
 func (m *MergedProvider) Description() string                 { return m.catalog.Description }
 func (m *MergedProvider) ConnectionMode() core.ConnectionMode { return m.connMode }
-func (m *MergedProvider) AuthTypes() []string                 { return nil }
-func (m *MergedProvider) ConnectionParamDefs() map[string]core.ConnectionParamDef {
+
+func (m *MergedProvider) AuthTypes() []string {
+	for _, provider := range m.owned {
+		if authTypes := provider.AuthTypes(); len(authTypes) > 0 {
+			return slices.Clone(authTypes)
+		}
+	}
 	return nil
 }
-func (m *MergedProvider) CredentialFields() []core.CredentialFieldDef { return nil }
-func (m *MergedProvider) DiscoveryConfig() *core.DiscoveryConfig      { return nil }
+
+func (m *MergedProvider) ConnectionParamDefs() map[string]core.ConnectionParamDef {
+	for _, provider := range m.owned {
+		if defs := provider.ConnectionParamDefs(); len(defs) > 0 {
+			return maps.Clone(defs)
+		}
+	}
+	return nil
+}
+
+func (m *MergedProvider) CredentialFields() []core.CredentialFieldDef {
+	for _, provider := range m.owned {
+		if fields := provider.CredentialFields(); len(fields) > 0 {
+			return slices.Clone(fields)
+		}
+	}
+	return nil
+}
+
+func (m *MergedProvider) DiscoveryConfig() *core.DiscoveryConfig {
+	for _, provider := range m.owned {
+		if cfg := provider.DiscoveryConfig(); cfg != nil {
+			value := *cfg
+			if len(value.Metadata) > 0 {
+				value.Metadata = maps.Clone(value.Metadata)
+			}
+			return &value
+		}
+	}
+	return nil
+}
+
 func (m *MergedProvider) ConnectionForOperation(op string) string {
 	return m.opConn[op]
 }

--- a/gestaltd/internal/composite/operation_resolution.go
+++ b/gestaltd/internal/composite/operation_resolution.go
@@ -10,7 +10,7 @@ import (
 // for request execution. Composite session catalogs only describe the MCP
 // surface, so static REST ops should not trigger MCP session initialization.
 func (p *Provider) ResolveStaticOperationForRequest(_ context.Context, operation string) (catalog.CatalogOperation, bool) {
-	return taggedCatalogOperation(p.api.Catalog(), operation, catalog.TransportREST)
+	return taggedCatalogOperation(p.api.Catalog(), operation, "")
 }
 
 func taggedCatalogOperation(cat *catalog.Catalog, operation, transport string) (catalog.CatalogOperation, bool) {
@@ -22,7 +22,11 @@ func taggedCatalogOperation(cat *catalog.Catalog, operation, transport string) (
 			continue
 		}
 		op := cat.Operations[i]
-		op.Transport = transport
+		if transport != "" {
+			op.Transport = transport
+		} else if op.Transport == "" {
+			op.Transport = catalog.TransportREST
+		}
 		return op, true
 	}
 	return catalog.CatalogOperation{}, false

--- a/gestaltd/internal/composite/provider.go
+++ b/gestaltd/internal/composite/provider.go
@@ -178,7 +178,9 @@ func (p *Provider) buildCatalog() *catalog.Catalog {
 	}
 	for i := range apiCat.Operations {
 		op := apiCat.Operations[i]
-		op.Transport = catalog.TransportREST
+		if op.Transport == "" {
+			op.Transport = catalog.TransportREST
+		}
 		merged.Operations = append(merged.Operations, op)
 	}
 	return merged

--- a/gestaltd/internal/config/connection_plan.go
+++ b/gestaltd/internal/config/connection_plan.go
@@ -79,12 +79,6 @@ func BuildStaticConnectionPlan(plugin *ProviderEntry, manifestPlugin *providerma
 		resolved.Connection = conn
 		plan.surfaces[surface] = resolved
 	}
-	if _, hasOpenAPI := plan.surfaces[SpecSurfaceOpenAPI]; hasOpenAPI {
-		if _, hasGraphQL := plan.surfaces[SpecSurfaceGraphQL]; hasGraphQL {
-			return StaticConnectionPlan{}, fmt.Errorf("openapi and graphql surfaces cannot both be configured for the same plugin")
-		}
-	}
-
 	if err := plan.validateConnectionModes(); err != nil {
 		return StaticConnectionPlan{}, err
 	}
@@ -119,12 +113,21 @@ func (plan StaticConnectionPlan) LookupConnection(name string) (ConnectionDef, b
 }
 
 func (plan StaticConnectionPlan) ConfiguredAPISurface() (ResolvedSpecSurface, bool) {
-	for _, surface := range []SpecSurface{SpecSurfaceOpenAPI, SpecSurfaceGraphQL} {
-		if resolved, ok := plan.ResolvedSurface(surface); ok {
-			return resolved, true
-		}
+	surfaces := plan.ConfiguredAPISurfaces()
+	if len(surfaces) > 0 {
+		return surfaces[0], true
 	}
 	return ResolvedSpecSurface{}, false
+}
+
+func (plan StaticConnectionPlan) ConfiguredAPISurfaces() []ResolvedSpecSurface {
+	surfaces := make([]ResolvedSpecSurface, 0, 2)
+	for _, surface := range []SpecSurface{SpecSurfaceOpenAPI, SpecSurfaceGraphQL} {
+		if resolved, ok := plan.ResolvedSurface(surface); ok {
+			surfaces = append(surfaces, resolved)
+		}
+	}
+	return surfaces
 }
 
 func (plan StaticConnectionPlan) ConfiguredSpecSurface() (ResolvedSpecSurface, bool) {

--- a/gestaltd/internal/plugininvocation/validation.go
+++ b/gestaltd/internal/plugininvocation/validation.go
@@ -280,11 +280,7 @@ func readStaticCatalog(name string, entry *config.ProviderEntry, manifest *provi
 }
 
 func loadConfiguredAPICatalog(ctx context.Context, name string, entry *config.ProviderEntry, spec *providermanifestv1.Spec, allowed map[string]*config.OperationOverride) (*catalog.Catalog, error) {
-	if _, hasOpenAPI := resolvedSurfaceURL(entry, spec, config.SpecSurfaceOpenAPI); hasOpenAPI {
-		if _, hasGraphQL := resolvedSurfaceURL(entry, spec, config.SpecSurfaceGraphQL); hasGraphQL {
-			return nil, fmt.Errorf("plugin %q openapi and graphql surfaces cannot both be configured for the same plugin", name)
-		}
-	}
+	var merged *catalog.Catalog
 	for _, surface := range []config.SpecSurface{config.SpecSurfaceOpenAPI, config.SpecSurfaceGraphQL} {
 		url, ok := resolvedSurfaceURL(entry, spec, surface)
 		if !ok {
@@ -303,9 +299,12 @@ func loadConfiguredAPICatalog(ctx context.Context, name string, entry *config.Pr
 		if err != nil {
 			return nil, fmt.Errorf("plugin %q %s catalog: %w", name, surface, err)
 		}
-		return provider.CatalogFromDefinition(def), nil
+		merged, err = mergeCatalogs(name, merged, provider.CatalogFromDefinition(def))
+		if err != nil {
+			return nil, err
+		}
 	}
-	return nil, nil
+	return merged, nil
 }
 
 func resolvedSurfaceURL(entry *config.ProviderEntry, spec *providermanifestv1.Spec, surface config.SpecSurface) (string, bool) {
@@ -374,7 +373,7 @@ func mergeCatalogs(name string, first, second *catalog.Catalog) (*catalog.Catalo
 	}
 	for i := range second.Operations {
 		if _, ok := seen[second.Operations[i].ID]; ok {
-			return nil, fmt.Errorf("plugin %q exposes duplicate operation %q across static and API catalogs", name, second.Operations[i].ID)
+			return nil, fmt.Errorf("plugin %q exposes duplicate operation %q across merged catalogs", name, second.Operations[i].ID)
 		}
 		merged.Operations = append(merged.Operations, second.Operations[i])
 	}

--- a/gestaltd/internal/server/catalog_resolution_composite_test.go
+++ b/gestaltd/internal/server/catalog_resolution_composite_test.go
@@ -91,3 +91,65 @@ func TestResolveOperation_CompositeProviderPrefersStaticRESTWithoutSessionLookup
 		t.Fatalf("request catalog calls = %d, want 0", requestCatalogCalls)
 	}
 }
+
+func TestResolveOperation_CompositeProviderPreservesGraphQLTransport(t *testing.T) {
+	t.Parallel()
+
+	apiProv := &stubCatalogProvider{
+		stubProvider: stubProvider{
+			name:     "linear",
+			connMode: core.ConnectionModeUser,
+		},
+		cat: &catalog.Catalog{
+			Name: "linear",
+			Operations: []catalog.CatalogOperation{
+				{ID: "viewer", Transport: "graphql", Query: "query Viewer { viewer { id } }"},
+			},
+		},
+	}
+
+	var requestCatalogCalls int
+	mcpUpstream := &stubCompositeMCPUpstream{
+		stubProvider: stubProvider{
+			name:     "linear",
+			connMode: core.ConnectionModeUser,
+		},
+		cat: &catalog.Catalog{Name: "linear"},
+		catalogForRequestFn: func(context.Context, string) (*catalog.Catalog, error) {
+			requestCatalogCalls++
+			return nil, fmt.Errorf("unexpected session catalog lookup")
+		},
+	}
+
+	prov := composite.New("linear", apiProv, mcpUpstream)
+	cat := prov.Catalog()
+	if got, ok := invocation.CatalogOperationTransport(cat, "viewer"); !ok || got != "graphql" {
+		t.Fatalf("viewer transport = %q, ok=%v, want %q", got, ok, "graphql")
+	}
+
+	op, transport, connection, err := invocation.ResolveOperation(
+		context.Background(),
+		prov,
+		"linear",
+		&stubTokenResolver{err: fmt.Errorf("unexpected token resolution")},
+		&principal.Principal{UserID: "u1"},
+		"viewer",
+		[]string{"MCP"},
+		"",
+	)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if op.ID != "viewer" {
+		t.Fatalf("operation = %q, want %q", op.ID, "viewer")
+	}
+	if transport != "graphql" {
+		t.Fatalf("transport = %q, want %q", transport, "graphql")
+	}
+	if connection != "" {
+		t.Fatalf("connection = %q, want empty", connection)
+	}
+	if requestCatalogCalls != 0 {
+		t.Fatalf("request catalog calls = %d, want 0", requestCatalogCalls)
+	}
+}


### PR DESCRIPTION
## Summary

This lets a single plugin expose both OpenAPI and GraphQL surfaces at the same time.

New interfaces:
- a single plugin manifest may declare both `surfaces.openapi` and `surfaces.graphql`
- OpenAPI and GraphQL operations may use different named connections on the same plugin
- merged providers preserve per-operation transport and connection routing for REST and GraphQL

This unblocks plugins like GitHub and GitLab from shipping both API surfaces in one manifest instead of splitting them just to satisfy the host.

## Example

```yaml
plugins:
  github:
    source: https://example.invalid/github/provider-release.yaml
    defaultConnection: rest
    connections:
      rest:
        mode: none
      graphql:
        mode: none
    surfaces:
      openapi:
        document: https://api.example.com/openapi.json
        baseURL: https://api.example.com
        connection: rest
      graphql:
        url: https://api.example.com/graphql
        connection: graphql
```

Behavior with that config:
- `status` resolves as REST on connection `rest`
- `viewer` resolves as GraphQL on connection `graphql`
- plugin-to-plugin GraphQL invocation keeps using the raw `plugin.graphql` surface

## Implementation notes

- removes the host-side rejection of plugins that configure both OpenAPI and GraphQL
- builds and merges both API surfaces during provider construction
- preserves per-operation transport and connection routing through composite providers
- keeps GraphQL surface invocation available through connection-binding wrappers
- avoids applying the OpenAPI base URL override to GraphQL endpoints
- updates manifest docs to state that OpenAPI and GraphQL may be combined on one plugin

## Validation

- `go test ./internal/bootstrap ./internal/server ./internal/plugininvocation ./internal/composite ./internal/config -count=1`
- `golangci-lint run ./internal/bootstrap ./internal/server ./internal/plugininvocation ./internal/composite ./internal/config`
- focused regression coverage for mixed OpenAPI+GraphQL bootstrap and plugin GraphQL invocation paths