### PR TITLE
indexeddb: accept transport targets in GESTALT_INDEXEDDB_SOCKET

### DIFF
--- a/gestaltd/internal/testutil/cmd/indexeddbtransportd/main.go
+++ b/gestaltd/internal/testutil/cmd/indexeddbtransportd/main.go
@@ -1,6 +1,6 @@
-// Command indexeddbtransportd runs a minimal IndexedDB gRPC server on a Unix
-// socket for SDK transport tests. It prints READY to stdout when listening and
-// serves until killed.
+// Command indexeddbtransportd runs a minimal IndexedDB gRPC server for SDK
+// transport tests. It prints READY to stdout when listening and serves until
+// killed.
 package main
 
 import (
@@ -8,6 +8,7 @@ import (
 	"fmt"
 	"os"
 	"os/signal"
+	"strings"
 	"syscall"
 
 	"github.com/valon-technologies/gestalt/server/internal/testutil/indexeddbtransport"
@@ -15,13 +16,18 @@ import (
 
 func main() {
 	socket := flag.String("socket", "", "Unix socket path to listen on")
+	tcp := flag.String("tcp", "", "TCP host:port to listen on")
 	flag.Parse()
-	if *socket == "" {
-		fmt.Fprintln(os.Stderr, "usage: indexeddbtransportd --socket <path>")
+	target := *socket
+	if strings.TrimSpace(*tcp) != "" {
+		target = "tcp://" + strings.TrimSpace(*tcp)
+	}
+	if strings.TrimSpace(target) == "" {
+		fmt.Fprintln(os.Stderr, "usage: indexeddbtransportd --socket <path> | --tcp <host:port>")
 		os.Exit(1)
 	}
 
-	srv, err := indexeddbtransport.Start(*socket)
+	srv, err := indexeddbtransport.Start(target)
 	if err != nil {
 		fmt.Fprintf(os.Stderr, "failed to start: %v\n", err)
 		os.Exit(1)

--- a/gestaltd/internal/testutil/indexeddbtransport/server.go
+++ b/gestaltd/internal/testutil/indexeddbtransport/server.go
@@ -3,8 +3,11 @@
 package indexeddbtransport
 
 import (
+	"fmt"
 	"net"
 	"os"
+	"path/filepath"
+	"strings"
 
 	proto "github.com/valon-technologies/gestalt/sdk/go/gen/v1"
 	coretesting "github.com/valon-technologies/gestalt/server/core/testing"
@@ -16,14 +19,21 @@ import (
 type Server struct {
 	srv    *grpc.Server
 	lis    net.Listener
-	Socket string
+	target string
 }
 
-// Start creates a new IndexedDB gRPC server on the given Unix socket path.
+// Start creates a new IndexedDB gRPC server on the supplied transport target.
+// Supported forms are a plain Unix socket path, unix:///path, or tcp://host:port.
 // The server starts empty; tests seed data through the SDK client.
-func Start(socketPath string) (*Server, error) {
-	_ = os.Remove(socketPath)
-	lis, err := net.Listen("unix", socketPath)
+func Start(target string) (*Server, error) {
+	network, address, err := parseTarget(target)
+	if err != nil {
+		return nil, err
+	}
+	if network == "unix" {
+		_ = os.Remove(address)
+	}
+	lis, err := net.Listen(network, address)
 	if err != nil {
 		return nil, err
 	}
@@ -31,12 +41,40 @@ func Start(socketPath string) (*Server, error) {
 	srv := grpc.NewServer()
 	proto.RegisterIndexedDBServer(srv, providerhost.NewIndexedDBServer(stub, "", providerhost.IndexedDBServerOptions{}))
 	go func() { _ = srv.Serve(lis) }()
-	return &Server{srv: srv, lis: lis, Socket: socketPath}, nil
+	return &Server{srv: srv, lis: lis, target: target}, nil
 }
 
 // Stop gracefully shuts down the server.
 func (s *Server) Stop() {
 	s.srv.GracefulStop()
 	_ = s.lis.Close()
-	_ = os.Remove(s.Socket)
+	network, address, err := parseTarget(s.target)
+	if err == nil && network == "unix" {
+		_ = os.Remove(address)
+	}
+}
+
+func parseTarget(raw string) (network string, address string, err error) {
+	target := strings.TrimSpace(raw)
+	if target == "" {
+		return "", "", fmt.Errorf("indexeddb transport target is required")
+	}
+	switch {
+	case strings.HasPrefix(target, "tcp://"):
+		address = strings.TrimSpace(strings.TrimPrefix(target, "tcp://"))
+		if address == "" {
+			return "", "", fmt.Errorf("indexeddb tcp target %q is missing host:port", raw)
+		}
+		return "tcp", address, nil
+	case strings.HasPrefix(target, "unix://"):
+		address = strings.TrimSpace(strings.TrimPrefix(target, "unix://"))
+		if address == "" {
+			return "", "", fmt.Errorf("indexeddb unix target %q is missing a socket path", raw)
+		}
+		return "unix", address, nil
+	case strings.Contains(target, "://"):
+		return "", "", fmt.Errorf("unsupported indexeddb transport target %q", raw)
+	default:
+		return "unix", filepath.Clean(target), nil
+	}
 }

--- a/sdk/go/indexeddb.go
+++ b/sdk/go/indexeddb.go
@@ -2,14 +2,19 @@ package gestalt
 
 import (
 	"context"
+	"crypto/tls"
 	"fmt"
+	"net"
+	"net/url"
 	"os"
+	"path/filepath"
 	"strings"
 	"time"
 
 	proto "github.com/valon-technologies/gestalt/sdk/go/gen/v1"
 	"google.golang.org/grpc"
 	"google.golang.org/grpc/codes"
+	"google.golang.org/grpc/credentials"
 	"google.golang.org/grpc/credentials/insecure"
 	"google.golang.org/grpc/status"
 )
@@ -89,28 +94,64 @@ type ObjectStoreSchema struct {
 	Indexes []IndexSchema
 }
 
-// IndexedDBClient speaks to a running IndexedDB provider over a Unix socket.
+// IndexedDBClient speaks to a running IndexedDB provider over a host-provided
+// transport target.
 type IndexedDBClient struct {
 	client proto.IndexedDBClient
 	conn   *grpc.ClientConn
 }
 
-// IndexedDB connects to the IndexedDB provider exposed by gestaltd.
+// IndexedDB connects to the IndexedDB provider exposed by gestaltd. The target
+// can be a plain Unix socket path, a unix:///path URI, or a tcp://host:port or
+// tls://host:port URI.
 func IndexedDB(name ...string) (*IndexedDBClient, error) {
 	envName := EnvIndexedDBSocket
 	if len(name) > 0 {
 		envName = IndexedDBSocketEnv(name[0])
 	}
-	socketPath := os.Getenv(envName)
-	if socketPath == "" {
+	target := os.Getenv(envName)
+	if target == "" {
 		return nil, fmt.Errorf("indexeddb: %s is not set", envName)
+	}
+	network, address, err := parseIndexedDBTarget(target)
+	if err != nil {
+		return nil, err
 	}
 	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
 	defer cancel()
-	conn, err := grpc.DialContext(ctx, "unix:"+socketPath,
-		grpc.WithTransportCredentials(insecure.NewCredentials()),
-		grpc.WithBlock(),
-	)
+	var conn *grpc.ClientConn
+	switch network {
+	case "unix":
+		conn, err = grpc.DialContext(ctx, "passthrough:///localhost",
+			grpc.WithTransportCredentials(insecure.NewCredentials()),
+			grpc.WithContextDialer(func(ctx context.Context, _ string) (net.Conn, error) {
+				var d net.Dialer
+				return d.DialContext(ctx, "unix", address)
+			}),
+			grpc.WithAuthority("localhost"),
+			grpc.WithBlock(),
+		)
+	case "tcp":
+		conn, err = grpc.DialContext(ctx, address,
+			grpc.WithTransportCredentials(insecure.NewCredentials()),
+			grpc.WithBlock(),
+		)
+	case "tls":
+		host, _, splitErr := net.SplitHostPort(address)
+		if splitErr != nil {
+			return nil, fmt.Errorf("indexeddb: parse tls target %q: %w", address, splitErr)
+		}
+		conn, err = grpc.DialContext(ctx, address,
+			grpc.WithTransportCredentials(credentials.NewTLS(&tls.Config{
+				MinVersion: tls.VersionTLS12,
+				ServerName: host,
+				NextProtos: []string{"h2"},
+			})),
+			grpc.WithBlock(),
+		)
+	default:
+		return nil, fmt.Errorf("indexeddb: unsupported transport network %q", network)
+	}
 	if err != nil {
 		return nil, fmt.Errorf("indexeddb: connect to host: %w", err)
 	}
@@ -118,6 +159,41 @@ func IndexedDB(name ...string) (*IndexedDBClient, error) {
 		client: proto.NewIndexedDBClient(conn),
 		conn:   conn,
 	}, nil
+}
+
+func parseIndexedDBTarget(raw string) (network string, address string, err error) {
+	target := strings.TrimSpace(raw)
+	if target == "" {
+		return "", "", fmt.Errorf("indexeddb: transport target is required")
+	}
+	switch {
+	case strings.HasPrefix(target, "tcp://"):
+		address = strings.TrimSpace(strings.TrimPrefix(target, "tcp://"))
+		if address == "" {
+			return "", "", fmt.Errorf("indexeddb: tcp target %q is missing host:port", raw)
+		}
+		return "tcp", address, nil
+	case strings.HasPrefix(target, "tls://"):
+		address = strings.TrimSpace(strings.TrimPrefix(target, "tls://"))
+		if address == "" {
+			return "", "", fmt.Errorf("indexeddb: tls target %q is missing host:port", raw)
+		}
+		return "tls", address, nil
+	case strings.HasPrefix(target, "unix://"):
+		address = strings.TrimSpace(strings.TrimPrefix(target, "unix://"))
+		if address == "" {
+			return "", "", fmt.Errorf("indexeddb: unix target %q is missing a socket path", raw)
+		}
+		return "unix", address, nil
+	case strings.Contains(target, "://"):
+		parsed, parseErr := url.Parse(target)
+		if parseErr != nil {
+			return "", "", fmt.Errorf("indexeddb: parse target %q: %w", raw, parseErr)
+		}
+		return "", "", fmt.Errorf("indexeddb: unsupported target scheme %q", parsed.Scheme)
+	default:
+		return "unix", filepath.Clean(target), nil
+	}
 }
 
 // Close closes the underlying gRPC transport.

--- a/sdk/go/indexeddb_transport_test.go
+++ b/sdk/go/indexeddb_transport_test.go
@@ -4,6 +4,7 @@ import (
 	"bufio"
 	"context"
 	"errors"
+	"net"
 	"os"
 	"os/exec"
 	"path/filepath"
@@ -31,7 +32,7 @@ func TestMain(m *testing.M) {
 	s3Bin, s3Sock, s3Cmd := buildAndStartHarness("s3transportd", "go-sdk-s3-test.sock")
 
 	os.Setenv(gestalt.EnvIndexedDBSocket, idbSock)
-	os.Setenv(gestalt.IndexedDBSocketEnv("test"), idbSock)
+	os.Setenv(gestalt.IndexedDBSocketEnv("test"), "unix://"+idbSock)
 	client, err := gestalt.IndexedDB()
 	if err != nil {
 		_ = idbCmd.Process.Kill()
@@ -112,6 +113,43 @@ func buildAndStartHarness(binaryName, socketName string) (string, string, *exec.
 	return bin, sock, cmd
 }
 
+func buildAndStartTCPHarness(binaryName string) (string, string, *exec.Cmd) {
+	harnessDir := filepath.Join("..", "..", "gestaltd", "internal", "testutil", "cmd", binaryName)
+	bin := filepath.Join(os.TempDir(), binaryName+"-tcp")
+	build := exec.Command("go", "build", "-o", bin, ".")
+	build.Dir = harnessDir
+	if out, err := build.CombinedOutput(); err != nil {
+		panic("build harness: " + string(out))
+	}
+
+	address := reserveTCPAddress()
+	host, port, err := net.SplitHostPort(address)
+	if err != nil {
+		panic("split tcp address: " + err.Error())
+	}
+	cmd := exec.Command(bin, "--tcp", net.JoinHostPort(host, port))
+	stdout, _ := cmd.StdoutPipe()
+	if err := cmd.Start(); err != nil {
+		panic("start tcp harness: " + err.Error())
+	}
+
+	scanner := bufio.NewScanner(stdout)
+	if !scanner.Scan() || scanner.Text() != "READY" {
+		_ = cmd.Process.Kill()
+		panic("tcp harness did not print READY")
+	}
+	return bin, "tcp://" + address, cmd
+}
+
+func reserveTCPAddress() string {
+	lis, err := net.Listen("tcp", "127.0.0.1:0")
+	if err != nil {
+		panic("reserve tcp address: " + err.Error())
+	}
+	defer func() { _ = lis.Close() }()
+	return lis.Addr().String()
+}
+
 func TestTransport_NamedSocketEnv(t *testing.T) {
 	client, err := gestalt.IndexedDB("test")
 	if err != nil {
@@ -129,6 +167,38 @@ func TestTransport_NamedSocketEnv(t *testing.T) {
 		t.Fatalf("Put: %v", err)
 	}
 	got, err := s.Get(ctx, "named")
+	if err != nil {
+		t.Fatalf("Get: %v", err)
+	}
+	if got["value"] != "ok" {
+		t.Fatalf("value = %v, want ok", got["value"])
+	}
+}
+
+func TestTransport_TCPTargetEnv(t *testing.T) {
+	bin, target, cmd := buildAndStartTCPHarness("indexeddbtransportd")
+	t.Cleanup(func() {
+		_ = cmd.Process.Kill()
+		_ = cmd.Wait()
+		_ = os.Remove(bin)
+	})
+
+	t.Setenv(gestalt.EnvIndexedDBSocket, target)
+	client, err := gestalt.IndexedDB()
+	if err != nil {
+		t.Fatalf("connect tcp indexeddb: %v", err)
+	}
+	defer func() { _ = client.Close() }()
+
+	ctx := context.Background()
+	store := "tcp_target_" + t.Name()
+	if err := client.CreateObjectStore(ctx, store, gestalt.ObjectStoreSchema{}); err != nil {
+		t.Fatalf("CreateObjectStore: %v", err)
+	}
+	if err := client.ObjectStore(store).Put(ctx, gestalt.Record{"id": "tcp", "value": "ok"}); err != nil {
+		t.Fatalf("Put: %v", err)
+	}
+	got, err := client.ObjectStore(store).Get(ctx, "tcp")
 	if err != nil {
 		t.Fatalf("Get: %v", err)
 	}

--- a/sdk/python/gestalt/_indexeddb.py
+++ b/sdk/python/gestalt/_indexeddb.py
@@ -7,6 +7,7 @@ import os
 import queue
 from dataclasses import dataclass, field
 from typing import Any, Iterator
+from urllib import parse as _urlparse
 
 import grpc
 from google.protobuf import struct_pb2 as _struct_pb2
@@ -85,10 +86,10 @@ class IndexedDB:
 
     def __init__(self, name: str | None = None) -> None:
         env_name = indexeddb_socket_env(name)
-        socket_path = os.environ.get(env_name, "")
-        if not socket_path:
+        target = os.environ.get(env_name, "")
+        if not target:
             raise RuntimeError(f"{env_name} is not set")
-        self._channel = grpc.insecure_channel(f"unix:{socket_path}")
+        self._channel = _indexeddb_channel(target)
         self._stub = pb_grpc.IndexedDBStub(self._channel)
 
     def close(self) -> None:
@@ -317,6 +318,31 @@ class Index:
             values=[_to_typed_value(v) for v in values],
             range=_kr_to_proto(key_range),
         )
+
+
+def _indexeddb_channel(raw_target: str) -> grpc.Channel:
+    target = raw_target.strip()
+    if not target:
+        raise RuntimeError("IndexedDB transport target is required")
+    if target.startswith("tcp://"):
+        address = target[len("tcp://") :].strip()
+        if not address:
+            raise RuntimeError(f"IndexedDB tcp target {raw_target!r} is missing host:port")
+        return grpc.insecure_channel(f"dns:///{address}")
+    if target.startswith("tls://"):
+        address = target[len("tls://") :].strip()
+        if not address:
+            raise RuntimeError(f"IndexedDB tls target {raw_target!r} is missing host:port")
+        return grpc.secure_channel(f"dns:///{address}", grpc.ssl_channel_credentials())
+    if target.startswith("unix://"):
+        socket_path = target[len("unix://") :].strip()
+        if not socket_path:
+            raise RuntimeError(f"IndexedDB unix target {raw_target!r} is missing a socket path")
+        return grpc.insecure_channel(f"unix:{socket_path}")
+    if "://" in target:
+        parsed = _urlparse.urlparse(target)
+        raise RuntimeError(f"unsupported IndexedDB target scheme {parsed.scheme!r}")
+    return grpc.insecure_channel(f"unix:{target}")
 
 
 class _RequestIterator:

--- a/sdk/python/tests/test_indexeddb_transport.py
+++ b/sdk/python/tests/test_indexeddb_transport.py
@@ -2,6 +2,7 @@
 from __future__ import annotations
 
 import os
+import socket
 import subprocess
 import tempfile
 import unittest
@@ -57,11 +58,12 @@ def setUpModule() -> None:
     )
     assert _harness_proc.stdout is not None
     line = _harness_proc.stdout.readline().decode().strip()
+    _harness_proc.stdout.close()
     if line != "READY":
         _harness_proc.kill()
         raise RuntimeError(f"harness did not print READY, got: {line!r}")
     os.environ["GESTALT_INDEXEDDB_SOCKET"] = _socket_path
-    os.environ[indexeddb_socket_env("named")] = _socket_path
+    os.environ[indexeddb_socket_env("named")] = f"unix://{_socket_path}"
 
 
 def tearDownModule() -> None:
@@ -70,6 +72,29 @@ def tearDownModule() -> None:
         _harness_proc.wait()
     if _socket_path and os.path.exists(_socket_path):
         os.remove(_socket_path)
+
+
+def _reserve_tcp_address() -> str:
+    with socket.socket(socket.AF_INET, socket.SOCK_STREAM) as sock:
+        sock.bind(("127.0.0.1", 0))
+        host, port = sock.getsockname()
+    return f"{host}:{port}"
+
+
+def _start_tcp_harness() -> tuple[subprocess.Popen[bytes], str]:
+    harness_bin = _build_harness()
+    address = _reserve_tcp_address()
+    proc = subprocess.Popen(
+        [harness_bin, "--tcp", address],
+        stdout=subprocess.PIPE,
+    )
+    assert proc.stdout is not None
+    line = proc.stdout.readline().decode().strip()
+    proc.stdout.close()
+    if line != "READY":
+        proc.kill()
+        raise RuntimeError(f"tcp harness did not print READY, got: {line!r}")
+    return proc, f"tcp://{address}"
 
 
 def _client() -> IndexedDB:
@@ -113,6 +138,23 @@ class TestNamedSocketEnv(unittest.TestCase):
         s.put({"id": "row-1", "value": "named"})
         got = s.get("row-1")
         self.assertEqual(got["value"], "named")
+        c.close()
+
+
+class TestTCPTarget(unittest.TestCase):
+    def test_tcp_target_roundtrip(self) -> None:
+        proc, target = _start_tcp_harness()
+        self.addCleanup(proc.wait)
+        self.addCleanup(proc.kill)
+        os.environ["GESTALT_INDEXEDDB_SOCKET"] = target
+        self.addCleanup(os.environ.pop, "GESTALT_INDEXEDDB_SOCKET", None)
+
+        c = _client()
+        c.create_object_store("tcp_target_env")
+        s = c.object_store("tcp_target_env")
+        s.put({"id": "row-1", "value": "tcp"})
+        got = s.get("row-1")
+        self.assertEqual(got["value"], "tcp")
         c.close()
 
 

--- a/sdk/rust/src/indexeddb.rs
+++ b/sdk/rust/src/indexeddb.rs
@@ -322,19 +322,32 @@ impl IndexedDB {
     /// Connects to a named IndexedDB transport socket.
     pub async fn connect_named(name: &str) -> Result<Self, IndexedDBError> {
         let env_name = indexeddb_socket_env(name);
-        let socket_path = std::env::var(&env_name)
+        let target = std::env::var(&env_name)
             .map_err(|_| IndexedDBError::Env(format!("{env_name} is not set")))?;
-
-        let channel = Endpoint::try_from("http://[::]:50051")?
-            .connect_with_connector(service_fn(move |_: Uri| {
-                let path = socket_path.clone();
-                async move {
-                    tokio::net::UnixStream::connect(path)
-                        .await
-                        .map(TokioIo::new)
-                }
-            }))
-            .await?;
+        let channel = match parse_indexeddb_target(&target)? {
+            IndexedDBTarget::Unix(path) => {
+                Endpoint::try_from("http://[::]:50051")?
+                    .connect_with_connector(service_fn(move |_: Uri| {
+                        let path = path.clone();
+                        async move {
+                            tokio::net::UnixStream::connect(path)
+                                .await
+                                .map(TokioIo::new)
+                        }
+                    }))
+                    .await?
+            }
+            IndexedDBTarget::Tcp(address) => {
+                Endpoint::from_shared(format!("http://{address}"))?
+                    .connect()
+                    .await?
+            }
+            IndexedDBTarget::Tls(address) => {
+                Endpoint::from_shared(format!("https://{address}"))?
+                    .connect()
+                    .await?
+            }
+        };
 
         Ok(Self {
             client: IndexedDbClient::new(channel),
@@ -387,6 +400,55 @@ impl IndexedDB {
             store: name.to_string(),
         }
     }
+}
+
+enum IndexedDBTarget {
+    Unix(String),
+    Tcp(String),
+    Tls(String),
+}
+
+fn parse_indexeddb_target(raw_target: &str) -> Result<IndexedDBTarget, IndexedDBError> {
+    let target = raw_target.trim();
+    if target.is_empty() {
+        return Err(IndexedDBError::Env(
+            "IndexedDB transport target is required".to_string(),
+        ));
+    }
+    if let Some(address) = target.strip_prefix("tcp://") {
+        let address = address.trim();
+        if address.is_empty() {
+            return Err(IndexedDBError::Env(format!(
+                "IndexedDB tcp target {raw_target:?} is missing host:port"
+            )));
+        }
+        return Ok(IndexedDBTarget::Tcp(address.to_string()));
+    }
+    if let Some(address) = target.strip_prefix("tls://") {
+        let address = address.trim();
+        if address.is_empty() {
+            return Err(IndexedDBError::Env(format!(
+                "IndexedDB tls target {raw_target:?} is missing host:port"
+            )));
+        }
+        return Ok(IndexedDBTarget::Tls(address.to_string()));
+    }
+    if let Some(path) = target.strip_prefix("unix://") {
+        let path = path.trim();
+        if path.is_empty() {
+            return Err(IndexedDBError::Env(format!(
+                "IndexedDB unix target {raw_target:?} is missing a socket path"
+            )));
+        }
+        return Ok(IndexedDBTarget::Unix(path.to_string()));
+    }
+    if target.contains("://") {
+        let scheme = target.split("://").next().unwrap_or_default();
+        return Err(IndexedDBError::Env(format!(
+            "unsupported IndexedDB target scheme {scheme:?}"
+        )));
+    }
+    Ok(IndexedDBTarget::Unix(target.to_string()))
 }
 
 /// CRUD, range-query, and cursor access for one object store.

--- a/sdk/rust/tests/indexeddb_transport.rs
+++ b/sdk/rust/tests/indexeddb_transport.rs
@@ -2,11 +2,12 @@
 mod helpers;
 
 use std::io::{BufRead, BufReader};
+use std::net::TcpListener;
 use std::process::{Command, Stdio};
 
 use gestalt::indexeddb::{
     CursorDirection, ENV_INDEXEDDB_SOCKET, IndexSchema, IndexedDB, IndexedDBError, KeyRange,
-    ObjectStoreSchema, Record,
+    ObjectStoreSchema, Record, indexeddb_socket_env,
 };
 
 struct Harness {
@@ -71,6 +72,59 @@ async fn start_harness(socket_name: &str) -> Harness {
     }
 }
 
+async fn start_tcp_harness() -> Harness {
+    let repo_root = std::path::Path::new(env!("CARGO_MANIFEST_DIR"))
+        .parent()
+        .unwrap()
+        .parent()
+        .unwrap();
+
+    let tmp = std::env::temp_dir();
+    let binary = tmp.join("indexeddbtransportd-tcp");
+
+    let build = Command::new("go")
+        .arg("build")
+        .arg("-o")
+        .arg(&binary)
+        .arg("./internal/testutil/cmd/indexeddbtransportd/")
+        .current_dir(repo_root.join("gestaltd"))
+        .output()
+        .expect("go build");
+    assert!(
+        build.status.success(),
+        "go build failed: {}",
+        String::from_utf8_lossy(&build.stderr)
+    );
+
+    let listener = TcpListener::bind("127.0.0.1:0").expect("reserve tcp address");
+    let address = listener.local_addr().expect("tcp local addr");
+    drop(listener);
+
+    let mut child = Command::new(&binary)
+        .arg("--tcp")
+        .arg(address.to_string())
+        .stdout(Stdio::piped())
+        .stderr(Stdio::inherit())
+        .spawn()
+        .expect("spawn tcp harness");
+
+    let stdout = child.stdout.take().unwrap();
+    let mut reader = BufReader::new(stdout);
+    let mut line = String::new();
+    reader.read_line(&mut line).expect("read READY");
+    assert!(
+        line.trim() == "READY",
+        "expected READY, got: {:?}",
+        line.trim()
+    );
+
+    let env_guard = helpers::EnvGuard::set(ENV_INDEXEDDB_SOCKET, format!("tcp://{address}"));
+    Harness {
+        child,
+        _env_guard: env_guard,
+    }
+}
+
 fn make_record(pairs: &[(&str, serde_json::Value)]) -> Record {
     pairs
         .iter()
@@ -109,6 +163,36 @@ async fn nested_json_round_trip() {
         got["tags"]
     );
     assert_eq!(got["tags"][0], serde_json::json!("alpha"));
+}
+
+#[tokio::test]
+async fn named_unix_target_round_trip() {
+    let _lock = helpers::env_lock().lock().await;
+    let _harness = start_harness("idb-named.sock").await;
+    let _named_env = helpers::EnvGuard::set(
+        indexeddb_socket_env("named"),
+        format!(
+            "unix://{}",
+            std::env::var(ENV_INDEXEDDB_SOCKET).expect("default socket")
+        ),
+    );
+
+    let mut db = IndexedDB::connect_named("named").await.expect("connect");
+    db.create_object_store("named_socket_env", ObjectStoreSchema { indexes: vec![] })
+        .await
+        .expect("create store");
+
+    let mut store = db.object_store("named_socket_env");
+    store
+        .put(make_record(&[
+            ("id", serde_json::json!("row-1")),
+            ("value", serde_json::json!("named")),
+        ]))
+        .await
+        .expect("put");
+
+    let got = store.get("row-1").await.expect("get");
+    assert_eq!(got["value"], serde_json::json!("named"));
 }
 
 #[tokio::test]
@@ -177,6 +261,29 @@ async fn object_store_bulk_helpers() {
         store.get_all_keys(None).await.expect("remaining keys"),
         vec!["a", "d"]
     );
+}
+
+#[tokio::test]
+async fn tcp_target_round_trip() {
+    let _lock = helpers::env_lock().lock().await;
+    let _harness = start_tcp_harness().await;
+
+    let mut db = IndexedDB::connect().await.expect("connect");
+    db.create_object_store("tcp_target_env", ObjectStoreSchema { indexes: vec![] })
+        .await
+        .expect("create store");
+
+    let mut store = db.object_store("tcp_target_env");
+    store
+        .put(make_record(&[
+            ("id", serde_json::json!("row-1")),
+            ("value", serde_json::json!("tcp")),
+        ]))
+        .await
+        .expect("put");
+
+    let got = store.get("row-1").await.expect("get");
+    assert_eq!(got["value"], serde_json::json!("tcp"));
 }
 
 #[tokio::test]

--- a/sdk/typescript/src/indexeddb.ts
+++ b/sdk/typescript/src/indexeddb.ts
@@ -16,6 +16,42 @@ export function indexedDBSocketEnv(name?: string): string {
   return `${ENV_INDEXEDDB_SOCKET}_${trimmed.replace(/[^A-Za-z0-9]/g, "_").toUpperCase()}`;
 }
 
+function indexedDBTransportOptions(rawTarget: string): {
+  baseUrl: string;
+  nodeOptions?: { path: string };
+} {
+  const target = rawTarget.trim();
+  if (!target) {
+    throw new Error("IndexedDB transport target is required");
+  }
+  if (target.startsWith("tcp://")) {
+    const address = target.slice("tcp://".length).trim();
+    if (!address) {
+      throw new Error(`IndexedDB tcp target ${JSON.stringify(rawTarget)} is missing host:port`);
+    }
+    return { baseUrl: `http://${address}` };
+  }
+  if (target.startsWith("tls://")) {
+    const address = target.slice("tls://".length).trim();
+    if (!address) {
+      throw new Error(`IndexedDB tls target ${JSON.stringify(rawTarget)} is missing host:port`);
+    }
+    return { baseUrl: `https://${address}` };
+  }
+  if (target.startsWith("unix://")) {
+    const socketPath = target.slice("unix://".length).trim();
+    if (!socketPath) {
+      throw new Error(`IndexedDB unix target ${JSON.stringify(rawTarget)} is missing a socket path`);
+    }
+    return { baseUrl: "http://localhost", nodeOptions: { path: socketPath } };
+  }
+  if (target.includes("://")) {
+    const parsed = new URL(target);
+    throw new Error(`Unsupported IndexedDB target scheme ${JSON.stringify(parsed.protocol.replace(/:$/, ""))}`);
+  }
+  return { baseUrl: "http://localhost", nodeOptions: { path: target } };
+}
+
 class AsyncQueue<T> implements AsyncIterable<T> {
   private queue: T[] = [];
   private waiting: ((result: IteratorResult<T>) => void) | null = null;
@@ -447,16 +483,13 @@ export interface ObjectStoreSchema {
 export class IndexedDB {
   private client: Client<typeof IndexedDBService>;
 
-  constructor(name?: string) {
+ constructor(name?: string) {
     const envName = indexedDBSocketEnv(name);
-    const socketPath = process.env[envName];
-    if (!socketPath) {
+    const target = process.env[envName];
+    if (!target) {
       throw new Error(`${envName} is not set`);
     }
-    const transport = createGrpcTransport({
-      baseUrl: `http://localhost`,
-      nodeOptions: { path: socketPath },
-    });
+    const transport = createGrpcTransport(indexedDBTransportOptions(target));
     this.client = createClient(IndexedDBService, transport);
   }
 

--- a/sdk/typescript/tests/indexeddb.transport.test.ts
+++ b/sdk/typescript/tests/indexeddb.transport.test.ts
@@ -1,4 +1,5 @@
 import { mkdtempSync, rmSync } from "node:fs";
+import { createServer } from "node:net";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 import { spawn, type Subprocess } from "bun";
@@ -17,17 +18,18 @@ const REPO_ROOT = join(import.meta.dir, "..", "..", "..");
 const GESTALTD_DIR = join(REPO_ROOT, "gestaltd");
 
 let tmpDir: string;
+let harnessBinPath: string;
 let socketPath: string;
 let proc: Subprocess;
 let db: IndexedDB;
 
 beforeAll(async () => {
   tmpDir = mkdtempSync(join(tmpdir(), "indexeddb-transport-test-"));
-  const binPath = join(tmpDir, "indexeddbtransportd");
+  harnessBinPath = join(tmpDir, "indexeddbtransportd");
   socketPath = join(tmpDir, "indexeddb.sock");
 
   const build = spawn(
-    ["go", "build", "-o", binPath, "./internal/testutil/cmd/indexeddbtransportd/"],
+    ["go", "build", "-o", harnessBinPath, "./internal/testutil/cmd/indexeddbtransportd/"],
     { cwd: GESTALTD_DIR, stdout: "pipe", stderr: "pipe" },
   );
   const buildExit = await build.exited;
@@ -36,7 +38,7 @@ beforeAll(async () => {
     throw new Error(`go build failed (exit ${buildExit}): ${stderr}`);
   }
 
-  proc = spawn([binPath, "--socket", socketPath], {
+  proc = spawn([harnessBinPath, "--socket", socketPath], {
     stdout: "pipe",
     stderr: "inherit",
   });
@@ -54,9 +56,52 @@ beforeAll(async () => {
   reader.releaseLock();
 
   process.env.GESTALT_INDEXEDDB_SOCKET = socketPath;
-  process.env[indexedDBSocketEnv("named")] = socketPath;
+  process.env[indexedDBSocketEnv("named")] = `unix://${socketPath}`;
   db = new IndexedDB();
 }, 60_000);
+
+async function reserveTCPAddress(): Promise<string> {
+  return await new Promise((resolve, reject) => {
+    const server = createServer();
+    server.once("error", reject);
+    server.listen(0, "127.0.0.1", () => {
+      const address = server.address();
+      if (!address || typeof address === "string") {
+        server.close();
+        reject(new Error("failed to reserve tcp address"));
+        return;
+      }
+      const result = `${address.address}:${address.port}`;
+      server.close((err) => {
+        if (err) {
+          reject(err);
+          return;
+        }
+        resolve(result);
+      });
+    });
+  });
+}
+
+async function startTCPHarness(): Promise<{ proc: Subprocess; target: string }> {
+  const address = await reserveTCPAddress();
+  const tcpProc = spawn([harnessBinPath, "--tcp", address], {
+    stdout: "pipe",
+    stderr: "inherit",
+  });
+  const stdout = tcpProc.stdout;
+  if (!stdout || typeof stdout === "number") {
+    throw new Error("expected tcp harness stdout to be piped");
+  }
+  const reader = stdout.getReader();
+  const { value } = await reader.read();
+  const line = new TextDecoder().decode(value).trim();
+  if (!line.includes("READY")) {
+    throw new Error(`expected READY from tcp harness, got: ${line}`);
+  }
+  reader.releaseLock();
+  return { proc: tcpProc, target: `tcp://${address}` };
+}
 
 afterAll(() => {
   proc?.kill();
@@ -156,6 +201,23 @@ describe("IndexedDB transport", () => {
     await namedDb.objectStore(store).put({ id: "row-1", value: "named" });
     const got = await namedDb.objectStore(store).get("row-1");
     expect(got.value).toBe("named");
+  });
+
+  test("tcp target env selects the requested binding", async () => {
+    const { proc: tcpProc, target } = await startTCPHarness();
+    process.env.GESTALT_INDEXEDDB_SOCKET = target;
+    try {
+      const tcpDb = new IndexedDB();
+      const store = "tcp_target_env";
+      await tcpDb.createObjectStore(store);
+      await tcpDb.objectStore(store).put({ id: "row-1", value: "tcp" });
+      const got = await tcpDb.objectStore(store).get("row-1");
+      expect(got.value).toBe("tcp");
+    } finally {
+      tcpProc.kill();
+      delete process.env.GESTALT_INDEXEDDB_SOCKET;
+      process.env.GESTALT_INDEXEDDB_SOCKET = socketPath;
+    }
   });
 
   test("cursor happy path: 4 records in order", async () => {


### PR DESCRIPTION
## Summary
This is the transport-groundwork slice for remote runtime host services. It keeps the plugin-facing IndexedDB env var stable, but widens the accepted value from only a raw Unix socket path to a transport target.

## New interface
`GESTALT_INDEXEDDB_SOCKET` now accepts:
- plain socket path: `/tmp/indexeddb.sock`
- explicit Unix target: `unix:///tmp/indexeddb.sock`
- TCP target: `tcp://127.0.0.1:50051`

The same parsing is now implemented in the Go, TypeScript, Python, and Rust SDK clients.

## Examples
```bash
export GESTALT_INDEXEDDB_SOCKET=/tmp/indexeddb.sock
export GESTALT_INDEXEDDB_SOCKET=unix:///tmp/indexeddb.sock
export GESTALT_INDEXEDDB_SOCKET=tcp://127.0.0.1:50051
```

Go:
```go
db, err := gestalt.IndexedDB()
```

TypeScript:
```ts
const db = new IndexedDB();
```

Python:
```py
db = IndexedDB()
```

Rust:
```rust
let mut db = IndexedDB::connect().await?;
```

## What changed
- updated the IndexedDB transport harness to listen on Unix sockets or TCP
- updated the Go/TypeScript/Python/Rust IndexedDB SDKs to parse transport targets
- extended the existing cross-SDK IndexedDB transport suites with TCP-target coverage instead of creating a new test family

## Validation
- `cd sdk/go && go test ./... -run 'TestTransport_' -count=1`
- `cd sdk/python && uv run python -m unittest tests.test_indexeddb_transport -q`
- `cd sdk/typescript && bun install --frozen-lockfile && bun test tests/indexeddb.transport.test.ts`
- `cd sdk/rust && cargo test --test indexeddb_transport`
