### PR TITLE
Load GraphQL catalogs lazily under request credentials

### DIFF
--- a/docs/content/reference/plugin-manifests.mdx
+++ b/docs/content/reference/plugin-manifests.mdx
@@ -182,6 +182,8 @@ Surfaces load operation catalogs from external specifications. They are configur
 | `url`        | string | URL of the upstream GraphQL endpoint.   |
 | `connection` | string | Connection name used for GraphQL calls. |
 
+GraphQL surfaces expose a raw GraphQL passthrough immediately. Generated GraphQL operation catalogs are resolved lazily from the upstream schema when a real request runs under that surface's connection. Gestalt does not introspect GraphQL endpoints during package build, `gestaltd init`, or config validation.
+
 #### `spec.surfaces.mcp`
 
 | Field        | Type   | Purpose                             |
@@ -338,7 +340,7 @@ spec:
 
 ### Allowed Operations
 
-The `allowedOperations` map selectively exposes and customizes operations from a spec-loaded surface. Keys are the original operation IDs from the OpenAPI/GraphQL/MCP spec.
+The `allowedOperations` map selectively exposes and customizes operations from a spec-loaded surface. Keys are the original operation IDs from the OpenAPI or MCP spec. For GraphQL, they apply to the lazily resolved session catalog and use the original upstream field names.
 
 | Field          | Type                     | Purpose                                                                                                                                                                        |
 | -------------- | ------------------------ | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------ |

--- a/gestaltd/internal/bootstrap/bootstrap_test.go
+++ b/gestaltd/internal/bootstrap/bootstrap_test.go
@@ -3855,6 +3855,29 @@ func TestValidate(t *testing.T) {
 		}
 	})
 
+	t.Run("accepts plugin configured with graphql surface without eager introspection", func(t *testing.T) {
+		t.Parallel()
+
+		cfg := validConfig()
+		cfg.Plugins = map[string]*config.ProviderEntry{
+			"linear": {
+				ResolvedManifest: &providermanifestv1.Manifest{
+					Spec: &providermanifestv1.Spec{
+						Surfaces: &providermanifestv1.ProviderSurfaces{
+							GraphQL: &providermanifestv1.GraphQLSurface{
+								URL: "http://127.0.0.1:1/graphql",
+							},
+						},
+					},
+				},
+			},
+		}
+
+		if _, err := bootstrap.Validate(context.Background(), cfg, validFactories()); err != nil {
+			t.Fatalf("Validate: %v", err)
+		}
+	})
+
 	t.Run("workflow managed workloads allow normalized credentialed providers", func(t *testing.T) {
 		t.Parallel()
 
@@ -4072,19 +4095,27 @@ func TestBootstrapAllowsPluginConfiguredWithBothOpenAPIAndGraphQLAPISurfaces(t *
 	if got := prov.ConnectionForOperation("status"); got != "rest" {
 		t.Fatalf("ConnectionForOperation(status) = %q, want %q", got, "rest")
 	}
-	if got := prov.ConnectionForOperation("viewer"); got != "graphql" {
-		t.Fatalf("ConnectionForOperation(viewer) = %q, want %q", got, "graphql")
+	if got := prov.ConnectionForOperation("viewer"); got != "" {
+		t.Fatalf("ConnectionForOperation(viewer) = %q, want empty static connection for lazy graphql op", got)
 	}
 
 	cat := prov.Catalog()
 	if cat == nil {
-		t.Fatal("Catalog() = nil, want mixed API catalog")
+		t.Fatal("Catalog() = nil, want static API catalog")
 	}
 	if got, ok := invocation.CatalogOperationTransport(cat, "status"); !ok || got != catalog.TransportREST {
 		t.Fatalf("status transport = %q, ok=%v, want %q", got, ok, catalog.TransportREST)
 	}
-	if got, ok := invocation.CatalogOperationTransport(cat, "viewer"); !ok || got != "graphql" {
-		t.Fatalf("viewer transport = %q, ok=%v, want %q", got, ok, "graphql")
+	if got, ok := invocation.CatalogOperationTransport(cat, "viewer"); ok {
+		t.Fatalf("viewer should not be in the static catalog; got transport = %q", got)
+	}
+
+	sessionCat, _, err := core.CatalogForRequest(context.Background(), prov, "")
+	if err != nil {
+		t.Fatalf("CatalogForRequest: %v", err)
+	}
+	if got, ok := invocation.CatalogOperationTransport(sessionCat, "viewer"); !ok || got != "graphql" {
+		t.Fatalf("session viewer transport = %q, ok=%v, want %q", got, ok, "graphql")
 	}
 
 	statusResult, err := prov.Execute(context.Background(), "status", nil, "")

--- a/gestaltd/internal/bootstrap/executable_plugin_test.go
+++ b/gestaltd/internal/bootstrap/executable_plugin_test.go
@@ -2914,8 +2914,9 @@ func TestPluginInvokesGraphQLSurface(t *testing.T) {
 	}
 
 	var (
-		mu       sync.Mutex
-		captured []capturedGraphQLRequest
+		mu                 sync.Mutex
+		captured           []capturedGraphQLRequest
+		introspectionCalls atomic.Int32
 	)
 	schema := pluginInvokeGraphQLSchema()
 	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
@@ -2929,6 +2930,7 @@ func TestPluginInvokesGraphQLSurface(t *testing.T) {
 		}
 		w.Header().Set("Content-Type", "application/json")
 		if strings.Contains(payload.Query, "__schema") {
+			introspectionCalls.Add(1)
 			_ = json.NewEncoder(w).Encode(map[string]any{
 				"data": map[string]any{
 					"__schema": schema,
@@ -3029,6 +3031,9 @@ func TestPluginInvokesGraphQLSurface(t *testing.T) {
 	}
 	if variables["team"] != "eng" {
 		t.Fatalf("body.echo.variables.team = %#v, want %q", variables["team"], "eng")
+	}
+	if got := introspectionCalls.Load(); got != 0 {
+		t.Fatalf("introspection calls = %d, want 0", got)
 	}
 
 	mu.Lock()

--- a/gestaltd/internal/bootstrap/graphql_session_provider.go
+++ b/gestaltd/internal/bootstrap/graphql_session_provider.go
@@ -1,0 +1,174 @@
+package bootstrap
+
+import (
+	"context"
+	"fmt"
+	"io"
+
+	"github.com/valon-technologies/gestalt/server/core"
+	"github.com/valon-technologies/gestalt/server/core/catalog"
+	"github.com/valon-technologies/gestalt/server/internal/config"
+	"github.com/valon-technologies/gestalt/server/internal/graphql"
+	"github.com/valon-technologies/gestalt/server/internal/provider"
+)
+
+type graphQLSessionCatalogProvider struct {
+	core.Provider
+	graphQL            core.GraphQLSurfaceInvoker
+	name               string
+	endpoint           string
+	allowedOperations  map[string]*config.OperationOverride
+	selectionOverrides map[string]string
+}
+
+var (
+	_ core.Provider               = (*graphQLSessionCatalogProvider)(nil)
+	_ core.SessionCatalogProvider = (*graphQLSessionCatalogProvider)(nil)
+	_ core.GraphQLSurfaceInvoker  = (*graphQLSessionCatalogProvider)(nil)
+)
+
+func wrapGraphQLSessionCatalogProvider(
+	prov core.Provider,
+	name string,
+	endpoint string,
+	allowedOperations map[string]*config.OperationOverride,
+	selectionOverrides map[string]string,
+) core.Provider {
+	graphQLInvoker, ok := prov.(core.GraphQLSurfaceInvoker)
+	if !ok {
+		return prov
+	}
+
+	wrapped := &graphQLSessionCatalogProvider{
+		Provider:           prov,
+		graphQL:            graphQLInvoker,
+		name:               name,
+		endpoint:           endpoint,
+		allowedOperations:  allowedOperations,
+		selectionOverrides: selectionOverrides,
+	}
+	if auth, ok := prov.(core.OAuthProvider); ok {
+		return &graphQLSessionCatalogOAuthProvider{
+			graphQLSessionCatalogProvider: wrapped,
+			auth:                          auth,
+		}
+	}
+	return wrapped
+}
+
+func (p *graphQLSessionCatalogProvider) SupportsSessionCatalog() bool {
+	return true
+}
+
+func (p *graphQLSessionCatalogProvider) Execute(ctx context.Context, operation string, params map[string]any, token string) (*core.OperationResult, error) {
+	if _, ok := graphQLCatalogOperation(p.Catalog(), operation); ok {
+		return p.Provider.Execute(ctx, operation, params, token)
+	}
+
+	cat, err := p.CatalogForRequest(ctx, token)
+	if err != nil {
+		return nil, err
+	}
+	op, ok := graphQLCatalogOperation(cat, operation)
+	if !ok {
+		return nil, fmt.Errorf("unknown operation: %s", operation)
+	}
+	if op.Query == "" {
+		return nil, fmt.Errorf("graphql operation %q has no query template", operation)
+	}
+	return p.graphQL.InvokeGraphQL(ctx, core.GraphQLRequest{
+		Document:  op.Query,
+		Variables: params,
+	}, token)
+}
+
+func (p *graphQLSessionCatalogProvider) InvokeGraphQL(ctx context.Context, request core.GraphQLRequest, token string) (*core.OperationResult, error) {
+	return p.graphQL.InvokeGraphQL(ctx, request, token)
+}
+
+func (p *graphQLSessionCatalogProvider) CatalogForRequest(ctx context.Context, token string) (*catalog.Catalog, error) {
+	result, err := p.graphQL.InvokeGraphQL(ctx, graphql.IntrospectionRequest(), token)
+	if err != nil {
+		return nil, err
+	}
+	schema, err := graphql.SchemaFromResult(result)
+	if err != nil {
+		return nil, err
+	}
+	def, err := graphql.DefinitionFromSchema(p.name, p.endpoint, schema, p.allowedOperations, p.selectionOverrides)
+	if err != nil {
+		return nil, err
+	}
+	cat := provider.CatalogFromDefinition(def)
+	inheritCatalogMetadata(cat, p.Provider)
+	return cat, nil
+}
+
+func (p *graphQLSessionCatalogProvider) Close() error {
+	if closer, ok := p.Provider.(io.Closer); ok {
+		return closer.Close()
+	}
+	return nil
+}
+
+type graphQLSessionCatalogOAuthProvider struct {
+	*graphQLSessionCatalogProvider
+	auth core.OAuthProvider
+}
+
+func (p *graphQLSessionCatalogOAuthProvider) AuthorizationURL(state string, scopes []string) string {
+	return p.auth.AuthorizationURL(state, scopes)
+}
+
+func (p *graphQLSessionCatalogOAuthProvider) ExchangeCode(ctx context.Context, code string) (*core.TokenResponse, error) {
+	return p.auth.ExchangeCode(ctx, code)
+}
+
+func (p *graphQLSessionCatalogOAuthProvider) RefreshToken(ctx context.Context, refreshToken string) (*core.TokenResponse, error) {
+	return p.auth.RefreshToken(ctx, refreshToken)
+}
+
+func graphQLCatalogOperation(cat *catalog.Catalog, operation string) (catalog.CatalogOperation, bool) {
+	if cat == nil {
+		return catalog.CatalogOperation{}, false
+	}
+	for i := range cat.Operations {
+		if cat.Operations[i].ID == operation {
+			return cat.Operations[i], true
+		}
+	}
+	return catalog.CatalogOperation{}, false
+}
+
+func inheritCatalogMetadata(cat *catalog.Catalog, prov core.Provider) {
+	if cat == nil || prov == nil {
+		return
+	}
+	staticCat := prov.Catalog()
+	if staticCat != nil {
+		if cat.Name == "" {
+			cat.Name = staticCat.Name
+		}
+		if cat.DisplayName == "" {
+			cat.DisplayName = staticCat.DisplayName
+		}
+		if cat.Description == "" {
+			cat.Description = staticCat.Description
+		}
+		if cat.IconSVG == "" {
+			cat.IconSVG = staticCat.IconSVG
+		}
+		if cat.BaseURL == "" {
+			cat.BaseURL = staticCat.BaseURL
+		}
+	}
+	if cat.Name == "" {
+		cat.Name = prov.Name()
+	}
+	if cat.DisplayName == "" {
+		cat.DisplayName = prov.DisplayName()
+	}
+	if cat.Description == "" {
+		cat.Description = prov.Description()
+	}
+}

--- a/gestaltd/internal/bootstrap/graphql_session_provider_test.go
+++ b/gestaltd/internal/bootstrap/graphql_session_provider_test.go
@@ -1,0 +1,129 @@
+package bootstrap
+
+import (
+	"context"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"sync/atomic"
+	"testing"
+
+	"github.com/valon-technologies/gestalt/server/core"
+	"github.com/valon-technologies/gestalt/server/internal/config"
+	"github.com/valon-technologies/gestalt/server/internal/graphql"
+	"github.com/valon-technologies/gestalt/server/internal/provider"
+)
+
+func TestGraphQLSessionCatalogProviderLoadsCatalogOnDemand(t *testing.T) {
+	t.Parallel()
+
+	schema := graphql.Schema{
+		QueryType: &graphql.TypeName{Name: "Query"},
+		Types: []graphql.FullType{
+			{
+				Kind: "OBJECT",
+				Name: "Query",
+				Fields: []graphql.Field{{
+					Name: "viewer",
+					Type: graphql.TypeRef{Kind: "OBJECT", Name: stringPtr("Viewer")},
+				}},
+			},
+			{
+				Kind: "OBJECT",
+				Name: "Viewer",
+				Fields: []graphql.Field{
+					{Name: "id", Type: graphql.TypeRef{Kind: "SCALAR", Name: stringPtr("ID")}},
+				},
+			},
+			{Kind: "SCALAR", Name: "ID"},
+		},
+	}
+
+	var (
+		introspectionCalls atomic.Int32
+		executionCalls     atomic.Int32
+	)
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		var payload struct {
+			Query string `json:"query"`
+		}
+		if err := json.NewDecoder(r.Body).Decode(&payload); err != nil {
+			http.Error(w, err.Error(), http.StatusBadRequest)
+			return
+		}
+		if got := r.Header.Get("Authorization"); got != "Bearer test-token" {
+			http.Error(w, "missing auth", http.StatusUnauthorized)
+			return
+		}
+		w.Header().Set("Content-Type", "application/json")
+		if strings.Contains(payload.Query, "__schema") {
+			introspectionCalls.Add(1)
+			_ = json.NewEncoder(w).Encode(map[string]any{
+				"data": map[string]any{
+					"__schema": schema,
+				},
+			})
+			return
+		}
+		executionCalls.Add(1)
+		_ = json.NewEncoder(w).Encode(map[string]any{
+			"data": map[string]any{
+				"viewer": map[string]any{"id": "user-123"},
+			},
+		})
+	}))
+	t.Cleanup(srv.Close)
+
+	base, err := provider.Build(graphql.StaticDefinition("linear", srv.URL), config.ConnectionDef{})
+	if err != nil {
+		t.Fatalf("provider.Build: %v", err)
+	}
+
+	wrapped := wrapGraphQLSessionCatalogProvider(base, "linear", srv.URL, nil, map[string]string{
+		"viewer": "id",
+	})
+	if got := len(wrapped.Catalog().Operations); got != 0 {
+		t.Fatalf("static catalog ops = %d, want 0", got)
+	}
+	if got := introspectionCalls.Load(); got != 0 {
+		t.Fatalf("introspection calls before request = %d, want 0", got)
+	}
+
+	scp, ok := wrapped.(core.SessionCatalogProvider)
+	if !ok {
+		t.Fatal("expected wrapped provider to implement SessionCatalogProvider")
+	}
+	cat, err := scp.CatalogForRequest(context.Background(), "test-token")
+	if err != nil {
+		t.Fatalf("CatalogForRequest: %v", err)
+	}
+	if got := introspectionCalls.Load(); got != 1 {
+		t.Fatalf("introspection calls after CatalogForRequest = %d, want 1", got)
+	}
+	viewer, ok := graphQLCatalogOperation(cat, "viewer")
+	if !ok {
+		t.Fatalf("session catalog operations = %#v, want viewer", cat.Operations)
+	}
+	if viewer.Transport != "graphql" {
+		t.Fatalf("viewer transport = %q, want %q", viewer.Transport, "graphql")
+	}
+
+	result, err := wrapped.Execute(context.Background(), "viewer", nil, "test-token")
+	if err != nil {
+		t.Fatalf("Execute(viewer): %v", err)
+	}
+	if result.Status != http.StatusOK {
+		t.Fatalf("status = %d, want %d", result.Status, http.StatusOK)
+	}
+	if got := introspectionCalls.Load(); got != 2 {
+		t.Fatalf("introspection calls after Execute = %d, want 2", got)
+	}
+	if got := executionCalls.Load(); got != 1 {
+		t.Fatalf("execution calls after Execute = %d, want 1", got)
+	}
+}
+
+func stringPtr(value string) *string {
+	return &value
+}

--- a/gestaltd/internal/bootstrap/provider_build.go
+++ b/gestaltd/internal/bootstrap/provider_build.go
@@ -673,6 +673,9 @@ func buildConfiguredSpecProvider(ctx context.Context, name string, resolved conf
 		if err != nil {
 			return nil, nil, err
 		}
+		if resolved.Surface == config.SpecSurfaceGraphQL {
+			prov = wrapGraphQLSessionCatalogProvider(prov, name, resolved.URL, cfg.allowedOperations, resolved.GraphQLSelections)
+		}
 		return prov, def, nil
 	case config.SpecSurfaceMCP:
 		connMode := core.ConnectionMode(resolved.Connection.Mode)
@@ -708,7 +711,7 @@ func loadSpecDefinition(ctx context.Context, name string, resolved config.Resolv
 	case config.SpecSurfaceOpenAPI:
 		return openapi.LoadDefinition(ctx, name, resolved.URL, allowedOperations)
 	case config.SpecSurfaceGraphQL:
-		return graphql.LoadDefinition(ctx, name, resolved.URL, allowedOperations, resolved.GraphQLSelections)
+		return graphql.StaticDefinition(name, resolved.URL), nil
 	default:
 		return nil, fmt.Errorf("unsupported spec definition surface %q", resolved.Surface)
 	}

--- a/gestaltd/internal/composite/merged.go
+++ b/gestaltd/internal/composite/merged.go
@@ -27,8 +27,9 @@ type BoundProvider struct {
 }
 
 var (
-	_ core.Provider              = (*MergedProvider)(nil)
-	_ core.GraphQLSurfaceInvoker = (*MergedProvider)(nil)
+	_ core.Provider               = (*MergedProvider)(nil)
+	_ core.GraphQLSurfaceInvoker  = (*MergedProvider)(nil)
+	_ core.SessionCatalogProvider = (*MergedProvider)(nil)
 )
 
 func NewMergedWithConnections(name, displayName, desc, iconSVG string, providers ...BoundProvider) (*MergedProvider, error) {
@@ -132,7 +133,14 @@ func (m *MergedProvider) Catalog() *catalog.Catalog { return m.catalog.Clone() }
 func (m *MergedProvider) Execute(ctx context.Context, op string, params map[string]any, token string) (*core.OperationResult, error) {
 	p, ok := m.route[op]
 	if !ok {
-		return nil, fmt.Errorf("unknown operation %q", op)
+		sessionProvider, err := m.sessionProviderForOperation(ctx, op, token)
+		if err != nil {
+			return nil, err
+		}
+		if sessionProvider == nil {
+			return nil, fmt.Errorf("unknown operation %q", op)
+		}
+		return sessionProvider.Execute(ctx, op, params, token)
 	}
 	return p.Execute(ctx, op, params, token)
 }
@@ -146,6 +154,89 @@ func (m *MergedProvider) InvokeGraphQL(ctx context.Context, request core.GraphQL
 		return invoker.InvokeGraphQL(ctx, request, token)
 	}
 	return nil, fmt.Errorf("graphql surface is not available")
+}
+
+func (m *MergedProvider) SupportsSessionCatalog() bool {
+	for _, provider := range m.owned {
+		if core.SupportsSessionCatalog(provider) {
+			return true
+		}
+	}
+	return false
+}
+
+func (m *MergedProvider) CatalogForRequest(ctx context.Context, token string) (*catalog.Catalog, error) {
+	if !m.SupportsSessionCatalog() {
+		return nil, core.WrapSessionCatalogUnsupported(fmt.Errorf("provider %q does not support session catalogs", m.Name()))
+	}
+
+	merged := m.catalog.Clone()
+	merged.Operations = nil
+	seen := make(map[string]string)
+	for _, provider := range m.owned {
+		if !core.SupportsSessionCatalog(provider) {
+			continue
+		}
+		cat, _, err := core.CatalogForRequest(ctx, provider, token)
+		if err != nil {
+			return nil, err
+		}
+		if cat == nil {
+			continue
+		}
+		for i := range cat.Operations {
+			op := cat.Operations[i]
+			if op.Transport == "" {
+				op.Transport = catalog.TransportREST
+			}
+			if owner, exists := seen[op.ID]; exists {
+				return nil, fmt.Errorf("operation %q provided by both %q and %q", op.ID, owner, provider.Name())
+			}
+			seen[op.ID] = provider.Name()
+			merged.Operations = append(merged.Operations, op)
+		}
+	}
+	integration.CompileSchemas(merged)
+	return merged, nil
+}
+
+func (m *MergedProvider) sessionProviderForOperation(ctx context.Context, operation, token string) (core.Provider, error) {
+	var (
+		match    core.Provider
+		firstErr error
+	)
+	for _, provider := range m.owned {
+		if !core.SupportsSessionCatalog(provider) {
+			continue
+		}
+		cat, _, err := core.CatalogForRequest(ctx, provider, token)
+		if err != nil {
+			if firstErr == nil {
+				firstErr = err
+			}
+			continue
+		}
+		if cat == nil {
+			continue
+		}
+		for i := range cat.Operations {
+			if cat.Operations[i].ID != operation {
+				continue
+			}
+			if match != nil {
+				return nil, fmt.Errorf("operation %q provided by both %q and %q", operation, match.Name(), provider.Name())
+			}
+			match = provider
+			break
+		}
+	}
+	if match != nil {
+		return match, nil
+	}
+	if firstErr != nil {
+		return nil, firstErr
+	}
+	return nil, nil
 }
 
 func (m *MergedProvider) Close() error {

--- a/gestaltd/internal/composite/merged_test.go
+++ b/gestaltd/internal/composite/merged_test.go
@@ -54,6 +54,24 @@ func (p *fakeProvider) Execute(ctx context.Context, op string, params map[string
 
 func (p *fakeProvider) Close() error { p.closed = true; return nil }
 
+type fakeSessionProvider struct {
+	*fakeProvider
+	sessionCat *catalog.Catalog
+	sessionErr error
+}
+
+func (p *fakeSessionProvider) SupportsSessionCatalog() bool { return true }
+
+func (p *fakeSessionProvider) CatalogForRequest(_ context.Context, _ string) (*catalog.Catalog, error) {
+	if p.sessionErr != nil {
+		return nil, p.sessionErr
+	}
+	if p.sessionCat == nil {
+		return nil, nil
+	}
+	return p.sessionCat.Clone(), nil
+}
+
 func TestNewMergedRejectsOperationCollision(t *testing.T) {
 	t.Parallel()
 
@@ -156,4 +174,63 @@ func TestMergedCatalogIncludesConstructorMetadata(t *testing.T) {
 	if cat.IconSVG != "<svg/>" {
 		t.Fatalf("IconSVG = %q, want %q", cat.IconSVG, "<svg/>")
 	}
+}
+
+func TestMergedSessionCatalogRoutesDynamicOperation(t *testing.T) {
+	t.Parallel()
+
+	dynamicHit := false
+	merged, err := composite.NewMergedWithConnections("test", "Test", "desc", "",
+		composite.BoundProvider{Provider: &fakeProvider{name: "rest", ops: []core.Operation{{Name: "status"}}}},
+		composite.BoundProvider{Provider: &fakeSessionProvider{
+			fakeProvider: &fakeProvider{
+				name: "graphql",
+				execFn: func(_ context.Context, op string, _ map[string]any, _ string) (*core.OperationResult, error) {
+					dynamicHit = true
+					return &core.OperationResult{Status: http.StatusOK, Body: `{"operation":"` + op + `"}`}, nil
+				},
+			},
+			sessionCat: &catalog.Catalog{
+				Name: "test",
+				Operations: []catalog.CatalogOperation{{
+					ID:        "viewer",
+					Transport: "graphql",
+					Query:     "query Viewer { viewer { id } }",
+				}},
+			},
+		}},
+	)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !core.SupportsSessionCatalog(merged) {
+		t.Fatal("expected merged provider to support session catalogs")
+	}
+
+	sessionCat, err := merged.CatalogForRequest(context.Background(), "token-123")
+	if err != nil {
+		t.Fatalf("CatalogForRequest: %v", err)
+	}
+	if _, ok := catalogOperation(sessionCat, "viewer"); !ok {
+		t.Fatalf("session catalog operations = %#v, want viewer", sessionCat.Operations)
+	}
+
+	if _, err := merged.Execute(context.Background(), "viewer", nil, "token-123"); err != nil {
+		t.Fatalf("Execute(viewer): %v", err)
+	}
+	if !dynamicHit {
+		t.Fatal("expected dynamic session-backed provider to execute viewer")
+	}
+}
+
+func catalogOperation(cat *catalog.Catalog, id string) (catalog.CatalogOperation, bool) {
+	if cat == nil {
+		return catalog.CatalogOperation{}, false
+	}
+	for i := range cat.Operations {
+		if cat.Operations[i].ID == id {
+			return cat.Operations[i], true
+		}
+	}
+	return catalog.CatalogOperation{}, false
 }

--- a/gestaltd/internal/composite/provider.go
+++ b/gestaltd/internal/composite/provider.go
@@ -87,11 +87,19 @@ func (p *Provider) InvokeGraphQL(ctx context.Context, request core.GraphQLReques
 }
 
 func (p *Provider) CatalogForRequest(ctx context.Context, token string) (*catalog.Catalog, error) {
-	cat, err := p.mcp.CatalogForRequest(ctx, token)
-	if err != nil || cat == nil {
-		return cat, err
+	var apiCat *catalog.Catalog
+	if core.SupportsSessionCatalog(p.api) {
+		var err error
+		apiCat, _, err = core.CatalogForRequest(ctx, p.api, token)
+		if err != nil {
+			return nil, err
+		}
 	}
-	return tagMCPCatalog(cat), nil
+	mcpCat, err := p.mcp.CatalogForRequest(ctx, token)
+	if err != nil {
+		return nil, err
+	}
+	return p.buildCatalogFromSources(apiCat, mcpCat), nil
 }
 
 func (p *Provider) ConnectionForOperation(operation string) string {
@@ -151,9 +159,10 @@ func (p *oauthProvider) RefreshToken(ctx context.Context, refreshToken string) (
 }
 
 func (p *Provider) buildCatalog() *catalog.Catalog {
-	mcpCat := p.mcp.Catalog()
+	return p.buildCatalogFromSources(p.api.Catalog(), p.mcp.Catalog())
+}
 
-	apiCat := p.api.Catalog()
+func (p *Provider) buildCatalogFromSources(apiCat, mcpCat *catalog.Catalog) *catalog.Catalog {
 	if mcpCat == nil && apiCat == nil {
 		return nil
 	}

--- a/gestaltd/internal/composite/provider_session_test.go
+++ b/gestaltd/internal/composite/provider_session_test.go
@@ -1,0 +1,111 @@
+package composite_test
+
+import (
+	"context"
+	"net/http"
+	"testing"
+
+	mcpgo "github.com/mark3labs/mcp-go/mcp"
+	"github.com/valon-technologies/gestalt/server/core"
+	"github.com/valon-technologies/gestalt/server/core/catalog"
+	"github.com/valon-technologies/gestalt/server/internal/composite"
+)
+
+type fakeMCPUpstream struct {
+	*fakeSessionProvider
+}
+
+func (p *fakeMCPUpstream) CallTool(context.Context, string, map[string]any) (*mcpgo.CallToolResult, error) {
+	return &mcpgo.CallToolResult{}, nil
+}
+
+func TestCompositeCatalogForRequestMergesAPISessionAndMCPSession(t *testing.T) {
+	t.Parallel()
+
+	api := &fakeSessionProvider{
+		fakeProvider: &fakeProvider{name: "api"},
+		sessionCat: &catalog.Catalog{
+			Name: "test",
+			Operations: []catalog.CatalogOperation{{
+				ID:        "viewer",
+				Transport: "graphql",
+				Query:     "query Viewer { viewer { id } }",
+			}},
+		},
+	}
+	mcp := &fakeMCPUpstream{
+		fakeSessionProvider: &fakeSessionProvider{
+			fakeProvider: &fakeProvider{name: "mcp", connMode: core.ConnectionModeUser},
+			sessionCat: &catalog.Catalog{
+				Name: "test",
+				Operations: []catalog.CatalogOperation{{
+					ID: "search",
+				}},
+			},
+		},
+	}
+
+	prov := composite.New("test", api, mcp)
+	scp, ok := prov.(core.SessionCatalogProvider)
+	if !ok {
+		t.Fatal("expected composite provider to expose SessionCatalogProvider")
+	}
+
+	cat, err := scp.CatalogForRequest(context.Background(), "token-123")
+	if err != nil {
+		t.Fatalf("CatalogForRequest: %v", err)
+	}
+
+	viewer, ok := catalogOperation(cat, "viewer")
+	if !ok {
+		t.Fatalf("session catalog operations = %#v, want viewer", cat.Operations)
+	}
+	if viewer.Transport != "graphql" {
+		t.Fatalf("viewer transport = %q, want %q", viewer.Transport, "graphql")
+	}
+
+	search, ok := catalogOperation(cat, "search")
+	if !ok {
+		t.Fatalf("session catalog operations = %#v, want search", cat.Operations)
+	}
+	if search.Transport != catalog.TransportMCPPassthrough {
+		t.Fatalf("search transport = %q, want %q", search.Transport, catalog.TransportMCPPassthrough)
+	}
+}
+
+func TestCompositeExecuteDelegatesDynamicAPISessionOperation(t *testing.T) {
+	t.Parallel()
+
+	dynamicHit := false
+	api := &fakeSessionProvider{
+		fakeProvider: &fakeProvider{
+			name: "api",
+			execFn: func(_ context.Context, op string, _ map[string]any, _ string) (*core.OperationResult, error) {
+				dynamicHit = true
+				return &core.OperationResult{Status: http.StatusOK, Body: `{"operation":"` + op + `"}`}, nil
+			},
+		},
+		sessionCat: &catalog.Catalog{
+			Name: "test",
+			Operations: []catalog.CatalogOperation{{
+				ID:        "viewer",
+				Transport: "graphql",
+				Query:     "query Viewer { viewer { id } }",
+			}},
+		},
+	}
+	mcp := &fakeMCPUpstream{
+		fakeSessionProvider: &fakeSessionProvider{
+			fakeProvider: &fakeProvider{name: "mcp"},
+			sessionCat:   &catalog.Catalog{Name: "test"},
+		},
+	}
+
+	prov := composite.New("test", api, mcp)
+	if _, err := prov.Execute(context.Background(), "viewer", nil, "token-123"); err != nil {
+		t.Fatalf("Execute(viewer): %v", err)
+	}
+	if !dynamicHit {
+		t.Fatal("expected API provider to execute dynamic session-backed viewer operation")
+	}
+}

--- a/gestaltd/internal/graphql/introspect.go
+++ b/gestaltd/internal/graphql/introspect.go
@@ -2,7 +2,6 @@ package graphql
 
 import (
 	"context"
-	"encoding/json"
 	"fmt"
 	"net/http"
 	"time"
@@ -150,16 +149,7 @@ func introspect(ctx context.Context, endpoint string) (*Schema, error) {
 	if err != nil {
 		return nil, fmt.Errorf("introspection query: %w", err)
 	}
-
-	var resp struct {
-		Schema Schema `json:"__schema"`
-	}
-	if err := json.Unmarshal([]byte(result.Body), &resp); err != nil {
-		return nil, fmt.Errorf("parsing introspection response: %w", err)
-	}
-
-	resp.Schema.buildIndex()
-	return &resp.Schema, nil
+	return SchemaFromResult(result)
 }
 
 func (ref TypeRef) namedType() string {

--- a/gestaltd/internal/graphql/loader.go
+++ b/gestaltd/internal/graphql/loader.go
@@ -2,9 +2,12 @@ package graphql
 
 import (
 	"context"
+	"encoding/json"
 	"fmt"
+	"net/http"
 	"strings"
 
+	"github.com/valon-technologies/gestalt/server/core"
 	"github.com/valon-technologies/gestalt/server/internal/config"
 	"github.com/valon-technologies/gestalt/server/internal/provider"
 )
@@ -14,12 +17,21 @@ func LoadDefinition(ctx context.Context, name, endpoint string, allowedOps map[s
 	if err != nil {
 		return nil, fmt.Errorf("introspecting %s: %w", endpoint, err)
 	}
+	return DefinitionFromSchema(name, endpoint, schema, allowedOps, selectionOverrides)
+}
 
+func StaticDefinition(name, endpoint string) *provider.Definition {
 	def := &provider.Definition{
-		Provider: name,
-		BaseURL:  strings.TrimRight(endpoint, "/"),
+		Provider:   name,
+		BaseURL:    strings.TrimRight(endpoint, "/"),
+		Operations: map[string]provider.OperationDef{},
 	}
 
+	return def
+}
+
+func DefinitionFromSchema(name, endpoint string, schema *Schema, allowedOps map[string]*config.OperationOverride, selectionOverrides map[string]string) (*provider.Definition, error) {
+	def := StaticDefinition(name, endpoint)
 	def.Operations = make(map[string]provider.OperationDef)
 	addOperations(schema, def, schema.QueryType, false, allowedOps, selectionOverrides)
 	addOperations(schema, def, schema.MutationType, true, allowedOps, selectionOverrides)
@@ -29,6 +41,32 @@ func LoadDefinition(ctx context.Context, name, endpoint string, allowedOps map[s
 	}
 
 	return def, nil
+}
+
+func SchemaFromBody(body []byte) (*Schema, error) {
+	var resp struct {
+		Schema Schema `json:"__schema"`
+	}
+	if err := json.Unmarshal(body, &resp); err != nil {
+		return nil, fmt.Errorf("parsing introspection response: %w", err)
+	}
+
+	resp.Schema.buildIndex()
+	return &resp.Schema, nil
+}
+
+func IntrospectionRequest() core.GraphQLRequest {
+	return core.GraphQLRequest{Document: introspectionQuery}
+}
+
+func SchemaFromResult(result *core.OperationResult) (*Schema, error) {
+	if result == nil {
+		return nil, fmt.Errorf("graphql introspection returned no result")
+	}
+	if result.Status >= http.StatusBadRequest {
+		return nil, fmt.Errorf("graphql introspection returned HTTP %d", result.Status)
+	}
+	return SchemaFromBody([]byte(result.Body))
 }
 
 func addOperations(schema *Schema, def *provider.Definition, root *TypeName, isMutation bool, allowedOps map[string]*config.OperationOverride, selectionOverrides map[string]string) {

--- a/gestaltd/internal/plugininvocation/validation.go
+++ b/gestaltd/internal/plugininvocation/validation.go
@@ -9,7 +9,6 @@ import (
 
 	"github.com/valon-technologies/gestalt/server/core/catalog"
 	"github.com/valon-technologies/gestalt/server/internal/config"
-	"github.com/valon-technologies/gestalt/server/internal/graphql"
 	"github.com/valon-technologies/gestalt/server/internal/openapi"
 	"github.com/valon-technologies/gestalt/server/internal/operationexposure"
 	"github.com/valon-technologies/gestalt/server/internal/provider"
@@ -286,16 +285,14 @@ func loadConfiguredAPICatalog(ctx context.Context, name string, entry *config.Pr
 		if !ok {
 			continue
 		}
+		if surface == config.SpecSurfaceGraphQL {
+			continue
+		}
 		var (
 			def *provider.Definition
 			err error
 		)
-		switch surface {
-		case config.SpecSurfaceOpenAPI:
-			def, err = openapi.LoadDefinition(ctx, name, url, allowed)
-		case config.SpecSurfaceGraphQL:
-			def, err = graphql.LoadDefinition(ctx, name, url, allowed, spec.GraphQLOperationSelections())
-		}
+		def, err = openapi.LoadDefinition(ctx, name, url, allowed)
 		if err != nil {
 			return nil, fmt.Errorf("plugin %q %s catalog: %w", name, surface, err)
 		}


### PR DESCRIPTION
## Summary
- stop eagerly introspecting GraphQL surfaces during validation and bootstrap
- add request-scoped GraphQL session catalogs so named GraphQL operations resolve lazily under real credentials
- keep raw plugin-to-plugin GraphQL invocation working, including merged OpenAPI+GraphQL and API+MCP providers

## Details
This replaces the earlier packaging-token workaround direction. Plain `surfaces.graphql` now loads as a raw GraphQL surface immediately. Generated GraphQL operation catalogs are resolved later from a session catalog when a real request runs under that surface's connection.

That keeps GitHub and GitLab dual-surface plugins packageable without anonymous GraphQL introspection, while still allowing named GraphQL operations to appear under real credentials.

## Verification
- `go test ./internal/graphql ./internal/composite ./internal/bootstrap ./internal/plugininvocation -count=1`
- `go test ./internal/server ./internal/invocation ./internal/bootstrap ./internal/composite ./internal/graphql -count=1`
- `golangci-lint run ./internal/server ./internal/invocation ./internal/bootstrap ./internal/composite ./internal/graphql`

## Notes
- docs reference text is updated too
- local docs typecheck/build could not be rerun in this worktree because the docs toolchain is not installed (`tsc` missing from PATH)