### PR TITLE
[codex] clarify invoke errors for mismatched connections

### DIFF
--- a/gestalt/cli/src/commands/invoke.rs
+++ b/gestalt/cli/src/commands/invoke.rs
@@ -25,7 +25,16 @@ pub fn run(
 ) -> Result<()> {
     let query = segments.join(".");
     let cat =
-        load_catalog_for_invoke(client, plugin, &query, options.connection, options.instance)?;
+        match load_catalog_for_invoke(client, plugin, &query, options.connection, options.instance)
+        {
+            Ok(cat) => cat,
+            Err(err) => {
+                if should_retry_without_catalog(&err, &query) {
+                    return execute(client, None, plugin, &query, params, options, format);
+                }
+                return Err(err);
+            }
+        };
 
     match cat.resolve(&query)? {
         ResolvedOperation::All(ops) => {
@@ -33,7 +42,7 @@ pub fn run(
             display_operations(ops, format)
         }
         ResolvedOperation::Exact(_) => {
-            execute(client, &cat, plugin, &query, params, options, format)
+            execute(client, Some(&cat), plugin, &query, params, options, format)
         }
         ResolvedOperation::Prefix(matches) => {
             let n = matches.len();
@@ -56,14 +65,30 @@ pub fn invoke(
     options: InvokeOptions<'_>,
     format: Format,
 ) -> Result<()> {
-    let cat = load_catalog_for_invoke(
+    let cat = match load_catalog_for_invoke(
         client,
         plugin,
         operation,
         options.connection,
         options.instance,
-    )?;
-    execute(client, &cat, plugin, operation, params, options, format)
+    ) {
+        Ok(cat) => Some(cat),
+        Err(err) => {
+            if should_retry_without_catalog(&err, operation) {
+                return execute(client, None, plugin, operation, params, options, format);
+            }
+            return Err(err);
+        }
+    };
+    execute(
+        client,
+        cat.as_ref(),
+        plugin,
+        operation,
+        params,
+        options,
+        format,
+    )
 }
 
 pub fn list_operations(client: &ApiClient, plugin: &str, format: Format) -> Result<()> {
@@ -73,14 +98,14 @@ pub fn list_operations(client: &ApiClient, plugin: &str, format: Format) -> Resu
 
 fn execute(
     client: &ApiClient,
-    cat: &OperationsCatalog,
+    cat: Option<&OperationsCatalog>,
     plugin: &str,
     operation: &str,
     params: &[ParamEntry],
     options: InvokeOptions<'_>,
     format: Format,
 ) -> Result<()> {
-    let mut param_map = params::assemble_params(params, Some(cat), operation)?;
+    let mut param_map = params::assemble_params(params, cat, operation)?;
 
     if let Some(file_path) = options.input_file {
         let file_map = params::load_input_file(file_path)?;
@@ -120,6 +145,10 @@ fn execute(
     }
 
     Ok(())
+}
+
+fn should_retry_without_catalog(err: &anyhow::Error, operation: &str) -> bool {
+    !operation.is_empty() && connect_error_kind(err).is_some()
 }
 
 fn display_operations<'a>(
@@ -219,20 +248,25 @@ enum ConnectErrorKind {
 }
 
 fn connect_error_kind(err: &anyhow::Error) -> Option<ConnectErrorKind> {
-    if let Some(api_error) = err.downcast_ref::<ApiError>() {
-        match api_error.code() {
-            Some("not_connected") => return Some(ConnectErrorKind::NotConnected),
-            Some("reconnect_required") => return Some(ConnectErrorKind::ReconnectRequired),
-            _ => {}
+    for cause in err.chain() {
+        if let Some(api_error) = cause.downcast_ref::<ApiError>() {
+            match api_error.code() {
+                Some("not_connected") => return Some(ConnectErrorKind::NotConnected),
+                Some("reconnect_required") => return Some(ConnectErrorKind::ReconnectRequired),
+                _ => {}
+            }
         }
-    }
 
-    let message = err.to_string();
-    if message.contains("no token stored for integration") {
-        return Some(ConnectErrorKind::NotConnected);
-    }
-    if message.contains("expired or was revoked") {
-        return Some(ConnectErrorKind::ReconnectRequired);
+        let message = cause.to_string();
+        if message.contains("no token stored for integration") {
+            return Some(ConnectErrorKind::NotConnected);
+        }
+        if message.contains("is not connected. Connect it first with `") {
+            return Some(ConnectErrorKind::NotConnected);
+        }
+        if message.contains("expired or was revoked") {
+            return Some(ConnectErrorKind::ReconnectRequired);
+        }
     }
     None
 }

--- a/gestalt/cli/tests/invoke_contract.rs
+++ b/gestalt/cli/tests/invoke_contract.rs
@@ -314,6 +314,54 @@ fn test_invoke_with_connection_and_instance() {
 }
 
 #[test]
+fn test_invoke_retries_without_catalog_when_preflight_masks_surface_error() {
+    let mut server = Server::new();
+    let home = TempDir::new().unwrap();
+
+    let _catalog_mock = authed_json_mock!(
+        server,
+        Method::GET,
+        "/api/v1/integrations/sample_svc/operations?_connection=session-conn&_instance=default",
+        StatusCode::PRECONDITION_FAILED
+    )
+    .with_body(r#"{"error":"no token stored for integration \"sample_svc\"; connect via OAuth first","code":"not_connected","integration":"sample_svc"}"#)
+    .create();
+
+    let _invoke_mock = authed_json_mock!(
+        server,
+        Method::POST,
+        "/api/v1/sample_svc/api_get_resource",
+        StatusCode::BAD_REQUEST
+    )
+    .match_header(header::CONTENT_TYPE.as_str(), http::APPLICATION_JSON)
+    .match_body(Matcher::JsonString(
+        r#"{"_connection":"session-conn","_instance":"default"}"#.to_string(),
+    ))
+    .with_body(
+        r#"{"error":"operation \"api_get_resource\" on integration \"sample_svc\" uses connection \"api-conn\"; omit the connection override or use that connection instead of \"session-conn\""}"#,
+    )
+    .create();
+
+    cli_command_for_server(home.path(), &server)
+        .args([
+            "plugins",
+            "invoke",
+            "--connection",
+            "session-conn",
+            "--instance",
+            "default",
+            "sample_svc",
+            "api_get_resource",
+        ])
+        .assert()
+        .failure()
+        .stderr(predicate::str::contains(
+            "operation \"api_get_resource\" on integration \"sample_svc\" uses connection \"api-conn\"",
+        ))
+        .stderr(predicate::str::contains("plugin \"sample_svc\" is not connected").not());
+}
+
+#[test]
 fn test_cli_lists_operations_with_connection_and_instance() {
     let mut server = Server::new();
     let home = TempDir::new().unwrap();

--- a/gestaltd/internal/server/handlers.go
+++ b/gestaltd/internal/server/handlers.go
@@ -523,7 +523,8 @@ func (s *Server) executeOperation(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	requestedConnection := r.URL.Query().Get(httpConnectionParam)
+	requestedConnectionInput := r.URL.Query().Get(httpConnectionParam)
+	requestedConnection := requestedConnectionInput
 	if requestedConnection != "" {
 		var ok bool
 		requestedConnection, ok = s.resolveRequestedConnection(w, providerName, requestedConnection)
@@ -563,7 +564,8 @@ func (s *Server) executeOperation(w http.ResponseWriter, r *http.Request) {
 
 	bodyInstance, _ := params[httpInstanceParam].(string)
 	delete(params, httpInstanceParam)
-	bodyConnection, _ := params[httpConnectionParam].(string)
+	bodyConnectionInput, _ := params[httpConnectionParam].(string)
+	bodyConnection := bodyConnectionInput
 	delete(params, httpConnectionParam)
 
 	if bodyInstance != "" {
@@ -598,8 +600,10 @@ func (s *Server) executeOperation(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 	connection := bodyConnection
+	connectionInput := bodyConnectionInput
 	if connection == "" {
 		connection = requestedConnection
+		connectionInput = requestedConnectionInput
 	}
 	ctx := r.Context()
 	ctx = invocation.WithAccessContext(ctx, access)
@@ -622,6 +626,27 @@ func (s *Server) executeOperation(w http.ResponseWriter, r *http.Request) {
 		})
 		writeError(w, http.StatusForbidden, "operation access denied")
 		return
+	}
+	explicitConnection := connectionInput
+	if explicitConnection != "" {
+		if !safeParamValue.MatchString(explicitConnection) {
+			writeError(w, http.StatusBadRequest, "connection name contains invalid characters")
+			return
+		}
+		if operationConnection := config.ResolveConnectionAlias(prov.ConnectionForOperation(opMeta.ID)); operationConnection != "" && operationConnection != connection {
+			writeError(
+				w,
+				http.StatusBadRequest,
+				fmt.Sprintf(
+					"operation %q on integration %q uses connection %q; omit the connection override or use that connection instead of %q",
+					opMeta.ID,
+					providerName,
+					operationConnection,
+					explicitConnection,
+				),
+			)
+			return
+		}
 	}
 	ctx = invocation.WithCatalogOperation(ctx, providerName, opMeta)
 	if connection == "" {

--- a/gestaltd/internal/server/server_test.go
+++ b/gestaltd/internal/server/server_test.go
@@ -8816,6 +8816,160 @@ func TestExecuteOperation_WrappedProvidersPreserveOperationConnectionRouting(t *
 	}
 }
 
+func TestExecuteOperation_RejectsExplicitConnectionForStaticOperation(t *testing.T) {
+	t.Parallel()
+
+	var called bool
+	apiBackend := &stubIntegrationWithOps{
+		StubIntegration: coretesting.StubIntegration{
+			N:        "sample-api",
+			ConnMode: core.ConnectionModeUser,
+			ExecuteFn: func(_ context.Context, _ string, _ map[string]any, _ string) (*core.OperationResult, error) {
+				called = true
+				return &core.OperationResult{Status: http.StatusOK, Body: `{"ok":true}`}, nil
+			},
+		},
+		ops: []core.Operation{
+			{Name: "api_get_resource", Description: "Get resource", Method: http.MethodGet},
+		},
+	}
+	apiProv, err := composite.NewMergedWithConnections(
+		"sample-api",
+		"Sample API",
+		"",
+		"",
+		composite.BoundProvider{Provider: apiBackend, Connection: "api-conn"},
+	)
+	if err != nil {
+		t.Fatalf("NewMergedWithConnections: %v", err)
+	}
+	prov := composite.New("sample-svc", apiProv, &stubIntegrationWithSessionCatalog{
+		stubIntegrationWithOps: stubIntegrationWithOps{
+			StubIntegration: coretesting.StubIntegration{N: "sample-mcp", ConnMode: core.ConnectionModeUser},
+		},
+	})
+
+	ts := newTestServer(t, func(cfg *server.Config) {
+		cfg.Providers = testutil.NewProviderRegistry(t, prov)
+		cfg.Services = coretesting.NewStubServices(t)
+	})
+	testutil.CloseOnCleanup(t, ts)
+
+	req, _ := http.NewRequest(http.MethodGet, ts.URL+"/api/v1/sample-svc/api_get_resource?_connection="+config.PluginConnectionAlias, nil)
+	resp, err := http.DefaultClient.Do(req)
+	if err != nil {
+		t.Fatalf("request: %v", err)
+	}
+	defer func() { _ = resp.Body.Close() }()
+
+	if resp.StatusCode != http.StatusBadRequest {
+		body, _ := io.ReadAll(resp.Body)
+		t.Fatalf("expected 400, got %d: %s", resp.StatusCode, body)
+	}
+
+	var body map[string]string
+	if err := json.NewDecoder(resp.Body).Decode(&body); err != nil {
+		t.Fatalf("decoding: %v", err)
+	}
+	if !strings.Contains(body["error"], `uses connection "api-conn"`) {
+		t.Fatalf("expected connection mismatch message, got %q", body["error"])
+	}
+	if !strings.Contains(body["error"], `"`+config.PluginConnectionAlias+`"`) {
+		t.Fatalf("expected requested connection in error, got %q", body["error"])
+	}
+	if strings.Contains(body["error"], `"`+config.PluginConnectionName+`"`) {
+		t.Fatalf("expected error to preserve caller input, got %q", body["error"])
+	}
+	if called {
+		t.Fatal("expected provider execution to be skipped")
+	}
+}
+
+func TestExecuteOperation_AllowsExplicitConnectionAliasForStaticOperation(t *testing.T) {
+	t.Parallel()
+
+	svc := coretesting.NewStubServices(t)
+	user, err := svc.Users.FindOrCreateUser(context.Background(), "alias@test.local")
+	if err != nil {
+		t.Fatalf("FindOrCreateUser: %v", err)
+	}
+	seedToken(t, svc, &core.IntegrationToken{
+		ID:          "sample-svc-plugin-default",
+		SubjectID:   principal.UserSubjectID(user.ID),
+		Integration: "sample-svc",
+		Connection:  config.PluginConnectionName,
+		Instance:    "default",
+		AccessToken: "plugin-token",
+	})
+
+	apiBackend := &stubIntegrationWithOps{
+		StubIntegration: coretesting.StubIntegration{
+			N:        "sample-api",
+			ConnMode: core.ConnectionModeUser,
+			ExecuteFn: func(_ context.Context, _ string, _ map[string]any, token string) (*core.OperationResult, error) {
+				return &core.OperationResult{
+					Status: http.StatusOK,
+					Body:   fmt.Sprintf(`{"token":%q}`, token),
+				}, nil
+			},
+		},
+		ops: []core.Operation{
+			{Name: "api_get_resource", Description: "Get resource", Method: http.MethodGet},
+		},
+	}
+	apiProv, err := composite.NewMergedWithConnections(
+		"sample-api",
+		"Sample API",
+		"",
+		"",
+		composite.BoundProvider{Provider: apiBackend, Connection: config.PluginConnectionName},
+	)
+	if err != nil {
+		t.Fatalf("NewMergedWithConnections: %v", err)
+	}
+	prov := composite.New("sample-svc", apiProv, &stubIntegrationWithSessionCatalog{
+		stubIntegrationWithOps: stubIntegrationWithOps{
+			StubIntegration: coretesting.StubIntegration{N: "sample-mcp", ConnMode: core.ConnectionModeNone},
+		},
+	})
+
+	ts := newTestServer(t, func(cfg *server.Config) {
+		cfg.Auth = &coretesting.StubAuthProvider{
+			N: "stub",
+			ValidateTokenFn: func(_ context.Context, token string) (*core.UserIdentity, error) {
+				if token != "user-token" {
+					return nil, fmt.Errorf("bad token")
+				}
+				return &core.UserIdentity{Email: "alias@test.local"}, nil
+			},
+		}
+		cfg.Providers = testutil.NewProviderRegistry(t, prov)
+		cfg.Services = svc
+	})
+	testutil.CloseOnCleanup(t, ts)
+
+	req, _ := http.NewRequest(http.MethodGet, ts.URL+"/api/v1/sample-svc/api_get_resource?_connection="+config.PluginConnectionAlias, nil)
+	req.Header.Set("Authorization", "Bearer user-token")
+	resp, err := http.DefaultClient.Do(req)
+	if err != nil {
+		t.Fatalf("request: %v", err)
+	}
+	defer func() { _ = resp.Body.Close() }()
+
+	if resp.StatusCode != http.StatusOK {
+		body, _ := io.ReadAll(resp.Body)
+		t.Fatalf("expected 200, got %d: %s", resp.StatusCode, body)
+	}
+
+	var body map[string]string
+	if err := json.NewDecoder(resp.Body).Decode(&body); err != nil {
+		t.Fatalf("decoding: %v", err)
+	}
+	if body["token"] != "plugin-token" {
+		t.Fatalf("token = %q, want plugin-token", body["token"])
+	}
+}
+
 func TestExecuteOperation_UnknownIntegration(t *testing.T) {
 	t.Parallel()
 	ts := newTestServer(t, func(cfg *server.Config) {


### PR DESCRIPTION
## What changed
- reject explicit connection overrides when an operation is bound to a different connection, so API-backed operations return a clear connection mismatch error instead of a misleading not-connected error
- let the CLI retry direct operation invocation when catalog preflight fails with a connection-status error, so the real operation-level error can surface
- keep the regression coverage generic rather than coupling the new tests to a specific integration name

## Why
The old flow could fail during catalog preflight on one connection surface before the selected operation executed on its actual bound surface. That could turn a connection-routing problem into a misleading not-connected message.

## Impact
- callers get an accurate error when they force the wrong connection for an operation
- `plugins invoke` no longer collapses some operation failures into a catalog-preflight connect error
- the new regression tests describe the generic behavior instead of a product-specific example

## Root cause
For composite providers, the CLI always fetched the operations catalog before invoke. With an explicit connection override, that preflight could fail before the selected operation executed. Separately, the HTTP invoke path could resolve the correct static operation while still honoring a mismatched explicit connection for credential lookup.

## Validation
- `go test ./internal/server -run 'TestListOperations_|TestExecuteOperation_'`
- `cargo test --manifest-path gestalt/Cargo.toml --test invoke_contract`
