### PR TITLE
gestaltd: reuse canonical principal inference

### DIFF
--- a/gestaltd/internal/authorization/authorizer.go
+++ b/gestaltd/internal/authorization/authorizer.go
@@ -186,6 +186,7 @@ func (a *Authorizer) ResolveWorkloadToken(token string) (*principal.ResolvedWork
 }
 
 func (a *Authorizer) IsWorkload(p *principal.Principal) bool {
+	p = principal.Canonicalized(p)
 	return p != nil && p.Kind == principal.KindWorkload
 }
 

--- a/gestaltd/internal/invocation/broker.go
+++ b/gestaltd/internal/invocation/broker.go
@@ -626,6 +626,7 @@ func (b *Broker) resolveToken(ctx context.Context, prov core.Provider, p *princi
 }
 
 func (b *Broker) resolveUserPrincipal(ctx context.Context, p *principal.Principal) error {
+	p = principal.Canonicalize(p)
 	if p == nil || p.UserID != "" || p.Kind == principal.KindWorkload || p.Identity == nil || p.Identity.Email == "" {
 		return nil
 	}

--- a/gestaltd/internal/providerhost/invocation_token.go
+++ b/gestaltd/internal/providerhost/invocation_token.go
@@ -320,6 +320,7 @@ func restoreInvocationTokenContext(ctx context.Context, tokenCtx invocationToken
 }
 
 func shouldInheritCredentialSelectors(p *principal.Principal) bool {
+	p = principal.Canonicalized(p)
 	return p == nil || p.Kind != principal.KindWorkload
 }
 
@@ -339,11 +340,8 @@ func subjectKindForInvocationClaims(p *principal.Principal) principal.Kind {
 	if p.Kind != "" {
 		return p.Kind
 	}
-	if strings.HasPrefix(strings.TrimSpace(p.SubjectID), string(principal.KindUser)+":") {
+	if p.Identity != nil {
 		return principal.KindUser
-	}
-	if strings.HasPrefix(strings.TrimSpace(p.SubjectID), string(principal.KindWorkload)+":") {
-		return principal.KindWorkload
 	}
 	return ""
 }

--- a/gestaltd/internal/providerhost/provider_client.go
+++ b/gestaltd/internal/providerhost/provider_client.go
@@ -338,12 +338,6 @@ func subjectKindForPrincipal(p *principal.Principal) string {
 	if p.Kind != "" {
 		return string(p.Kind)
 	}
-	switch {
-	case strings.HasPrefix(p.SubjectID, string(principal.KindUser)+":"):
-		return string(principal.KindUser)
-	case strings.HasPrefix(p.SubjectID, string(principal.KindWorkload)+":"):
-		return string(principal.KindWorkload)
-	}
 	if p.Identity != nil {
 		return string(principal.KindUser)
 	}

--- a/gestaltd/internal/providerhost/provider_server.go
+++ b/gestaltd/internal/providerhost/provider_server.go
@@ -2,7 +2,6 @@ package providerhost
 
 import (
 	"context"
-	"strings"
 
 	proto "github.com/valon-technologies/gestalt/sdk/go/gen/v1"
 	"github.com/valon-technologies/gestalt/server/core"
@@ -115,14 +114,8 @@ func principalFromProto(subject *proto.SubjectContext) *principal.Principal {
 	case string(principal.KindWorkload):
 		p.Kind = principal.KindWorkload
 	}
-	if strings.HasPrefix(subject.GetId(), "user:") {
-		p.UserID = strings.TrimPrefix(subject.GetId(), "user:")
-		if p.Kind == "" {
-			p.Kind = principal.KindUser
-		}
-	} else if strings.HasPrefix(subject.GetId(), "workload:") && p.Kind == "" {
-		p.Kind = principal.KindWorkload
-	}
+	p.UserID = principal.UserIDFromSubjectID(p.SubjectID)
+	p = principal.Canonicalized(p)
 	if p.Kind == principal.KindUser && subject.GetDisplayName() != "" {
 		p.Identity = &core.UserIdentity{
 			DisplayName: subject.GetDisplayName(),

--- a/gestaltd/internal/server/authorization.go
+++ b/gestaltd/internal/server/authorization.go
@@ -41,6 +41,7 @@ func (s *Server) workloadBinding(p *principal.Principal, provider string) (autho
 }
 
 func isWorkloadPrincipal(p *principal.Principal) bool {
+	p = principal.Canonicalized(p)
 	return p != nil && p.Kind == principal.KindWorkload
 }
 


### PR DESCRIPTION
## Summary
- replace providerhost prefix parsing with `principal.Canonicalized(...)`
- make workload checks operate on canonicalized principals instead of raw `Kind` fields
- keep `resolveUserPrincipal(...)` mutating the original principal so downstream user resolution behavior stays unchanged

## Why
We still had a few places inferring principal kind from `user:` / `workload:` prefixes by hand, even though `principal.Canonicalize` already owns that logic.

This was mostly duplication, but it also meant providerhost helpers could drift from the canonical behavior for subjects like `managed_identity:...` if `Kind` was not already set.

This PR deletes the duplicate prefix parsing and reuses the shared canonicalization path instead.

## Verification
- `go test ./internal/authorization ./internal/invocation ./internal/providerhost ./internal/server ./internal/mcp`
- `golangci-lint run ./internal/authorization ./internal/invocation ./internal/providerhost ./internal/server ./internal/mcp`
