### PR TITLE
gestaltd: bump default UI to alpha.14

### DIFF
--- a/gestaltd/cmd/gestaltd/provider_test.go
+++ b/gestaltd/cmd/gestaltd/provider_test.go
@@ -2868,17 +2868,20 @@ func assertReleasedManifestHasHostedHTTPMetadata(t *testing.T, manifest *provide
 
 	if manifest == nil || manifest.Spec == nil {
 		t.Fatalf("manifest = %+v, want populated spec", manifest)
+		return
 	}
 
 	scheme := manifest.Spec.SecuritySchemes["signed"]
 	if scheme == nil {
 		t.Fatal(`manifest.Spec.SecuritySchemes["signed"] = nil, want generated scheme`)
+		return
 	}
 	if scheme.Type != providermanifestv1.HTTPSecuritySchemeTypeHMAC {
 		t.Fatalf("scheme.Type = %q, want %q", scheme.Type, providermanifestv1.HTTPSecuritySchemeTypeHMAC)
 	}
 	if scheme.Secret == nil || scheme.Secret.Env != "REQUEST_SIGNING_SECRET" {
 		t.Fatalf("scheme.Secret = %+v, want env-backed secret", scheme.Secret)
+		return
 	}
 	if scheme.SignatureHeader != "X-Request-Signature" {
 		t.Fatalf("scheme.SignatureHeader = %q, want %q", scheme.SignatureHeader, "X-Request-Signature")
@@ -2899,6 +2902,7 @@ func assertReleasedManifestHasHostedHTTPMetadata(t *testing.T, manifest *provide
 	binding := manifest.Spec.HTTP["command"]
 	if binding == nil {
 		t.Fatal(`manifest.Spec.HTTP["command"] = nil, want generated HTTP binding`)
+		return
 	}
 	if binding.Path != "/command" {
 		t.Fatalf("binding.Path = %q, want %q", binding.Path, "/command")

--- a/gestaltd/core/integration/restricted_test.go
+++ b/gestaltd/core/integration/restricted_test.go
@@ -105,6 +105,7 @@ func TestCatalogFiltersCanOverrideAllowedRoles(t *testing.T) {
 	cat := r.Catalog()
 	if cat == nil {
 		t.Fatal("Catalog() returned nil")
+		return
 	}
 	if len(cat.Operations) != 2 {
 		t.Fatalf("Catalog().Operations: got %d, want 2", len(cat.Operations))

--- a/gestaltd/core/testing/integration_suite.go
+++ b/gestaltd/core/testing/integration_suite.go
@@ -88,6 +88,7 @@ func RunIntegrationTests(t *testing.T, newIntegration func(t *testing.T, mockURL
 		}
 		if resp == nil {
 			t.Fatal("RefreshToken returned nil")
+			return
 		}
 		if resp.AccessToken == "" {
 			t.Error("AccessToken is empty")
@@ -103,6 +104,7 @@ func RunIntegrationTests(t *testing.T, newIntegration func(t *testing.T, mockURL
 		cat := integration.Catalog()
 		if cat == nil {
 			t.Fatal("Catalog returned nil")
+			return
 		}
 		if len(cat.Operations) == 0 {
 			t.Fatal("Catalog returned empty operations")
@@ -122,10 +124,12 @@ func RunIntegrationTests(t *testing.T, newIntegration func(t *testing.T, mockURL
 		cat := integration.Catalog()
 		if cat == nil || len(cat.Operations) == 0 {
 			t.Skip("no operations to execute")
+			return
 		}
 		firstOp := firstExecutableOperation(cat)
 		if firstOp == nil {
 			t.Skip("no executable operations in catalog")
+			return
 		}
 
 		result, err := integration.Execute(ctx, firstOp.ID, map[string]any{}, "valid-bearer-token")

--- a/gestaltd/core/testing/integration_suite.go
+++ b/gestaltd/core/testing/integration_suite.go
@@ -138,6 +138,7 @@ func RunIntegrationTests(t *testing.T, newIntegration func(t *testing.T, mockURL
 		}
 		if result == nil {
 			t.Fatal("Execute returned nil")
+			return
 		}
 		if result.Status < 100 || result.Status >= 600 {
 			t.Errorf("result.Status: got %d, want valid HTTP status", result.Status)

--- a/gestaltd/internal/bootstrap/bootstrap_test.go
+++ b/gestaltd/internal/bootstrap/bootstrap_test.go
@@ -1699,6 +1699,7 @@ func TestBootstrapAppliesConfiguredWorkflowSchedules(t *testing.T) {
 	recorder := recorders["temporal"]
 	if recorder == nil {
 		t.Fatal("missing workflow recorder for temporal")
+		return
 	}
 	if len(recorder.upsertedSchedules) != 1 {
 		t.Fatalf("upserted schedules = %d, want 1", len(recorder.upsertedSchedules))
@@ -1768,6 +1769,7 @@ func TestValidateDoesNotApplyConfiguredWorkflowSchedules(t *testing.T) {
 	recorder := recorders["temporal"]
 	if recorder == nil {
 		t.Fatal("missing workflow recorder for temporal")
+		return
 	}
 	if len(recorder.upsertedSchedules) != 0 {
 		t.Fatalf("upserted schedules = %d, want 0", len(recorder.upsertedSchedules))

--- a/gestaltd/internal/bootstrap/bootstrap_test.go
+++ b/gestaltd/internal/bootstrap/bootstrap_test.go
@@ -1919,6 +1919,7 @@ func TestBootstrapIgnoresUserSchedulesThatOnlyShareCfgPrefix(t *testing.T) {
 	recorder := recorders["temporal"]
 	if recorder == nil {
 		t.Fatal("missing workflow recorder for temporal")
+		return
 	}
 	if len(recorder.deletedSchedules) != 0 {
 		t.Fatalf("deleted schedules = %d, want 0", len(recorder.deletedSchedules))
@@ -2528,6 +2529,7 @@ func TestBootstrapAppliesConfiguredWorkflowEventTriggers(t *testing.T) {
 	recorder := recorders["temporal"]
 	if recorder == nil {
 		t.Fatal("missing workflow recorder for temporal")
+		return
 	}
 	if len(recorder.upsertedEventTriggers) != 1 {
 		t.Fatalf("upserted event triggers = %d, want 1", len(recorder.upsertedEventTriggers))
@@ -2595,6 +2597,7 @@ func TestValidateDoesNotApplyConfiguredWorkflowEventTriggers(t *testing.T) {
 	recorder := recorders["temporal"]
 	if recorder == nil {
 		t.Fatal("missing workflow recorder for temporal")
+		return
 	}
 	if len(recorder.upsertedEventTriggers) != 0 {
 		t.Fatalf("upserted event triggers = %d, want 0", len(recorder.upsertedEventTriggers))

--- a/gestaltd/internal/config/config.go
+++ b/gestaltd/internal/config/config.go
@@ -34,7 +34,7 @@ const (
 	DefaultIndexedDBProvider = DefaultProviderRepo + "/indexeddb/relationaldb"
 	DefaultIndexedDBVersion  = "0.0.1-alpha.1"
 	DefaultUIProvider        = DefaultProviderRepo + "/ui/default"
-	DefaultUIVersion         = "0.0.1-alpha.13"
+	DefaultUIVersion         = "0.0.1-alpha.14"
 	DefaultProviderInstance  = "default"
 )
 


### PR DESCRIPTION
Bumps the built-in default UI package from `ui/default/v0.0.1-alpha.13` to `ui/default/v0.0.1-alpha.14` so fresh `gestaltd` local configs pick up the latest `/workflows` UI.

This points at the newly published `ui/default` release that includes the schedule and trigger management UI from `gestalt-providers#166`.

Validation:
- `go test ./internal/config ./internal/operator -count=1`