### PR TITLE
gestaltd: delete runtime workload wrappers

### DIFF
--- a/gestaltd/cmd/gestaltd/provider_test.go
+++ b/gestaltd/cmd/gestaltd/provider_test.go
@@ -2873,6 +2873,7 @@ func assertReleasedManifestHasHostedHTTPMetadata(t *testing.T, manifest *provide
 	scheme := manifest.Spec.SecuritySchemes["signed"]
 	if scheme == nil {
 		t.Fatal(`manifest.Spec.SecuritySchemes["signed"] = nil, want generated scheme`)
+		return
 	}
 	if scheme.Type != providermanifestv1.HTTPSecuritySchemeTypeHMAC {
 		t.Fatalf("scheme.Type = %q, want %q", scheme.Type, providermanifestv1.HTTPSecuritySchemeTypeHMAC)
@@ -2899,6 +2900,7 @@ func assertReleasedManifestHasHostedHTTPMetadata(t *testing.T, manifest *provide
 	binding := manifest.Spec.HTTP["command"]
 	if binding == nil {
 		t.Fatal(`manifest.Spec.HTTP["command"] = nil, want generated HTTP binding`)
+		return
 	}
 	if binding.Path != "/command" {
 		t.Fatalf("binding.Path = %q, want %q", binding.Path, "/command")

--- a/gestaltd/core/integration/restricted_test.go
+++ b/gestaltd/core/integration/restricted_test.go
@@ -105,6 +105,7 @@ func TestCatalogFiltersCanOverrideAllowedRoles(t *testing.T) {
 	cat := r.Catalog()
 	if cat == nil {
 		t.Fatal("Catalog() returned nil")
+		return
 	}
 	if len(cat.Operations) != 2 {
 		t.Fatalf("Catalog().Operations: got %d, want 2", len(cat.Operations))

--- a/gestaltd/internal/authorization/authorizer.go
+++ b/gestaltd/internal/authorization/authorizer.go
@@ -185,16 +185,11 @@ func (a *Authorizer) ResolveWorkloadToken(token string) (*principal.ResolvedWork
 	return &principal.ResolvedWorkload{ID: workload.ID, DisplayName: workload.DisplayName}, true
 }
 
-func (a *Authorizer) IsWorkload(p *principal.Principal) bool {
-	p = principal.Canonicalized(p)
-	return p != nil && p.Kind == principal.KindWorkload
-}
-
 func (a *Authorizer) AllowProvider(ctx context.Context, p *principal.Principal, provider string) bool {
 	if principal.IsSystemPrincipal(p) {
 		return principal.AllowsProviderPermission(p, provider)
 	}
-	if !a.IsWorkload(p) {
+	if !principal.IsWorkloadPrincipal(p) {
 		_, allowed := a.ResolveAccess(ctx, p, provider)
 		return allowed
 	}
@@ -206,7 +201,7 @@ func (a *Authorizer) AllowOperation(ctx context.Context, p *principal.Principal,
 	if principal.IsSystemPrincipal(p) {
 		return principal.AllowsOperationPermission(p, provider, operation)
 	}
-	if !a.IsWorkload(p) {
+	if !principal.IsWorkloadPrincipal(p) {
 		return a.AllowProvider(ctx, p, provider)
 	}
 	binding, ok := a.bindingForPrincipal(p, provider)
@@ -221,7 +216,7 @@ func (a *Authorizer) AllowOperation(ctx context.Context, p *principal.Principal,
 }
 
 func (a *Authorizer) Binding(p *principal.Principal, provider string) (CredentialBinding, bool) {
-	if !a.IsWorkload(p) {
+	if !principal.IsWorkloadPrincipal(p) {
 		return CredentialBinding{}, false
 	}
 	binding, ok := a.bindingForPrincipal(p, provider)
@@ -238,7 +233,7 @@ func (a *Authorizer) ResolveAccess(_ context.Context, p *principal.Principal, pr
 	if principal.IsSystemPrincipal(p) {
 		return AccessContext{}, principal.AllowsProviderPermission(p, provider)
 	}
-	if a.IsWorkload(p) {
+	if principal.IsWorkloadPrincipal(p) {
 		if _, ok := a.bindingForSubject(p, provider); ok {
 			policyName := strings.TrimSpace(a.providerPolicies[provider])
 			if policyName == "" {
@@ -350,7 +345,7 @@ func (a *Authorizer) ResolvePolicyAccess(_ context.Context, p *principal.Princip
 	if policyName == "" {
 		return AccessContext{}, true
 	}
-	if a.IsWorkload(p) {
+	if principal.IsWorkloadPrincipal(p) {
 		return AccessContext{Policy: policyName}, false
 	}
 	policy := a.policies[policyName]
@@ -377,7 +372,7 @@ func (a *Authorizer) ResolveAdminAccess(_ context.Context, p *principal.Principa
 	if policyName == "" {
 		return AccessContext{}, true
 	}
-	if a.IsWorkload(p) {
+	if principal.IsWorkloadPrincipal(p) {
 		return AccessContext{Policy: policyName}, false
 	}
 	policy := a.policies[policyName]
@@ -400,7 +395,7 @@ func (a *Authorizer) AllowCatalogOperation(ctx context.Context, p *principal.Pri
 	if principal.IsSystemPrincipal(p) {
 		return principal.AllowsOperationPermission(p, provider, op.ID)
 	}
-	if a.IsWorkload(p) {
+	if principal.IsWorkloadPrincipal(p) {
 		return a.AllowOperation(ctx, p, provider, op.ID)
 	}
 	access, allowed := a.ResolveAccess(ctx, p, provider)
@@ -426,7 +421,7 @@ func (a *Authorizer) AllowCatalogOperation(ctx context.Context, p *principal.Pri
 }
 
 func (a *Authorizer) bindingForPrincipal(p *principal.Principal, provider string) (WorkloadProviderBinding, bool) {
-	if !a.IsWorkload(p) {
+	if !principal.IsWorkloadPrincipal(p) {
 		return WorkloadProviderBinding{}, false
 	}
 	if binding, ok := a.bindingForSubject(p, provider); ok {

--- a/gestaltd/internal/authorization/provider_backed.go
+++ b/gestaltd/internal/authorization/provider_backed.go
@@ -201,18 +201,11 @@ func (a *ProviderBackedAuthorizer) ResolveWorkloadToken(token string) (*principa
 	return a.base.ResolveWorkloadToken(token)
 }
 
-func (a *ProviderBackedAuthorizer) IsWorkload(p *principal.Principal) bool {
-	if a == nil {
-		return false
-	}
-	return a.base.IsWorkload(p)
-}
-
 func (a *ProviderBackedAuthorizer) AllowProvider(ctx context.Context, p *principal.Principal, provider string) bool {
 	if a == nil {
 		return true
 	}
-	if a.base.IsWorkload(p) || principal.IsSystemPrincipal(p) {
+	if principal.IsWorkloadPrincipal(p) || principal.IsSystemPrincipal(p) {
 		return a.base.AllowProvider(ctx, p, provider)
 	}
 	_, allowed := a.ResolveAccess(ctx, p, provider)
@@ -223,7 +216,7 @@ func (a *ProviderBackedAuthorizer) AllowOperation(ctx context.Context, p *princi
 	if a == nil {
 		return true
 	}
-	if a.base.IsWorkload(p) || principal.IsSystemPrincipal(p) {
+	if principal.IsWorkloadPrincipal(p) || principal.IsSystemPrincipal(p) {
 		return a.base.AllowOperation(ctx, p, provider, operation)
 	}
 	return a.AllowProvider(ctx, p, provider)
@@ -240,7 +233,7 @@ func (a *ProviderBackedAuthorizer) ResolveAccess(ctx context.Context, p *princip
 	if a == nil {
 		return AccessContext{}, true
 	}
-	if a.base.IsWorkload(p) || principal.IsSystemPrincipal(p) {
+	if principal.IsWorkloadPrincipal(p) || principal.IsSystemPrincipal(p) {
 		return a.base.ResolveAccess(ctx, p, provider)
 	}
 
@@ -278,7 +271,7 @@ func (a *ProviderBackedAuthorizer) ResolvePolicyAccess(ctx context.Context, p *p
 	if a == nil {
 		return AccessContext{}, true
 	}
-	if a.base.IsWorkload(p) {
+	if principal.IsWorkloadPrincipal(p) {
 		return a.base.ResolvePolicyAccess(ctx, p, policyName)
 	}
 	policyName = strings.TrimSpace(policyName)
@@ -315,7 +308,7 @@ func (a *ProviderBackedAuthorizer) ResolveAdminAccess(ctx context.Context, p *pr
 	if a == nil {
 		return AccessContext{}, true
 	}
-	if a.base.IsWorkload(p) {
+	if principal.IsWorkloadPrincipal(p) {
 		return a.base.ResolveAdminAccess(ctx, p, policyName)
 	}
 	policyName = strings.TrimSpace(policyName)
@@ -365,7 +358,7 @@ func (a *ProviderBackedAuthorizer) AllowCatalogOperation(ctx context.Context, p 
 	if a == nil {
 		return true
 	}
-	if a.base.IsWorkload(p) || principal.IsSystemPrincipal(p) {
+	if principal.IsWorkloadPrincipal(p) || principal.IsSystemPrincipal(p) {
 		return a.base.AllowCatalogOperation(ctx, p, provider, op)
 	}
 

--- a/gestaltd/internal/authorization/runtime.go
+++ b/gestaltd/internal/authorization/runtime.go
@@ -18,7 +18,6 @@ type RuntimeAuthorizer interface {
 
 	ReloadAuthorizationState(ctx context.Context) error
 
-	IsWorkload(p *principal.Principal) bool
 	AllowProvider(ctx context.Context, p *principal.Principal, provider string) bool
 	AllowOperation(ctx context.Context, p *principal.Principal, provider, operation string) bool
 	Binding(p *principal.Principal, provider string) (CredentialBinding, bool)

--- a/gestaltd/internal/invocation/broker.go
+++ b/gestaltd/internal/invocation/broker.go
@@ -256,7 +256,7 @@ func (b *Broker) Invoke(ctx context.Context, p *principal.Principal, providerNam
 		conn = boundCredential.Connection
 		instance = boundCredential.Instance
 	}
-	if b.authorizer != nil && b.authorizer.IsWorkload(p) && !b.authorizer.AllowOperation(ctx, p, providerName, operation) {
+	if b.authorizer != nil && principal.IsWorkloadPrincipal(p) && !b.authorizer.AllowOperation(ctx, p, providerName, operation) {
 		return fail(fmt.Errorf("%w: %s.%s", ErrAuthorizationDenied, providerName, operation))
 	}
 
@@ -429,7 +429,7 @@ func (b *Broker) InvokeGraphQL(ctx context.Context, p *principal.Principal, prov
 		conn = boundCredential.Connection
 		instance = boundCredential.Instance
 	}
-	if b.authorizer != nil && b.authorizer.IsWorkload(p) && !b.authorizer.AllowOperation(ctx, p, providerName, graphQLOperationID) {
+	if b.authorizer != nil && principal.IsWorkloadPrincipal(p) && !b.authorizer.AllowOperation(ctx, p, providerName, graphQLOperationID) {
 		return fail(fmt.Errorf("%w: %s.%s", ErrAuthorizationDenied, providerName, graphQLOperationID))
 	}
 	if conn == "" && b.connMapper != nil {

--- a/gestaltd/internal/invocation/catalog_selectors.go
+++ b/gestaltd/internal/invocation/catalog_selectors.go
@@ -90,5 +90,5 @@ func (cfg CatalogSelectorConfig) WorkloadBindingSelectors(p *principal.Principal
 }
 
 func (cfg CatalogSelectorConfig) isWorkload(p *principal.Principal) bool {
-	return cfg.Authorizer != nil && cfg.Authorizer.IsWorkload(p)
+	return cfg.Authorizer != nil && principal.IsWorkloadPrincipal(p)
 }

--- a/gestaltd/internal/invocation/credential_binding.go
+++ b/gestaltd/internal/invocation/credential_binding.go
@@ -56,7 +56,7 @@ func resolveCredentialBinding(authz authorization.RuntimeAuthorizer, p *principa
 		Instance:            strings.TrimSpace(binding.Instance),
 	}
 
-	if enforceRequested && authz.IsWorkload(p) {
+	if enforceRequested && principal.IsWorkloadPrincipal(p) {
 		if connection != "" && connection != resolved.Connection {
 			return CredentialBindingResolution{}, bindingSelectorOverrideError()
 		}

--- a/gestaltd/internal/mcp/authorization.go
+++ b/gestaltd/internal/mcp/authorization.go
@@ -16,7 +16,7 @@ func allowOperation(ctx context.Context, cfg Config, p *principal.Principal, pro
 	if cfg.Authorizer == nil {
 		return true
 	}
-	if cfg.Authorizer.IsWorkload(p) {
+	if principal.IsWorkloadPrincipal(p) {
 		return cfg.Authorizer.AllowOperation(ctx, p, provider, operation)
 	}
 	op, ok := catalogOperationForTool(ctx, cfg, provider, operation)

--- a/gestaltd/internal/mcp/session_tools.go
+++ b/gestaltd/internal/mcp/session_tools.go
@@ -150,7 +150,7 @@ func withSessionAccessContext(ctx context.Context, cfg Config, provName string) 
 		return ctx
 	}
 	p := principal.FromContext(ctx)
-	if p == nil || cfg.Authorizer.IsWorkload(p) {
+	if p == nil || principal.IsWorkloadPrincipal(p) {
 		return ctx
 	}
 	access, allowed := cfg.Authorizer.ResolveAccess(ctx, p, provName)

--- a/gestaltd/internal/principal/principal.go
+++ b/gestaltd/internal/principal/principal.go
@@ -110,6 +110,11 @@ func IsSystemPrincipal(p *Principal) bool {
 	return p != nil && IsSystemSubjectID(p.SubjectID)
 }
 
+func IsWorkloadPrincipal(p *Principal) bool {
+	p = Canonicalized(p)
+	return p != nil && p.Kind == KindWorkload
+}
+
 func EffectiveCredentialSubjectID(p *Principal) string {
 	if p == nil {
 		return ""

--- a/gestaltd/internal/server/authorization.go
+++ b/gestaltd/internal/server/authorization.go
@@ -41,8 +41,7 @@ func (s *Server) workloadBinding(p *principal.Principal, provider string) (autho
 }
 
 func isWorkloadPrincipal(p *principal.Principal) bool {
-	p = principal.Canonicalized(p)
-	return p != nil && p.Kind == principal.KindWorkload
+	return principal.IsWorkloadPrincipal(p)
 }
 
 func rejectWorkloadCaller(w http.ResponseWriter, p *principal.Principal) error {

--- a/gestaltd/internal/workflowmanager/manager.go
+++ b/gestaltd/internal/workflowmanager/manager.go
@@ -737,7 +737,7 @@ func (m *Manager) resolveTarget(ctx context.Context, p *principal.Principal, tar
 	if instance != "" && !config.SafeInstanceValue(instance) {
 		return coreworkflow.Target{}, fmt.Errorf("instance name contains invalid characters")
 	}
-	if m.authorizer != nil && m.authorizer.IsWorkload(p) && (connection != "" || instance != "") {
+	if m.authorizer != nil && principal.IsWorkloadPrincipal(p) && (connection != "" || instance != "") {
 		return coreworkflow.Target{}, fmt.Errorf("%w: workloads may not override connection or instance bindings", invocation.ErrAuthorizationDenied)
 	}
 


### PR DESCRIPTION
## Summary
- remove `IsWorkload(...)` from the runtime authorizer interface
- stop bouncing principal-kind checks through `Authorizer` / `ProviderBackedAuthorizer`
- reuse `principal.IsWorkloadPrincipal(...)` everywhere those runtime paths just need canonical principal kind

## Why
`IsWorkload(...)` was not really an authorization decision. It was just a wrapper around principal kind, but it lived on the runtime authorizer interface and forced pass-through implementations in the authorizer layer.

This PR deletes that wrapper surface and uses the canonical principal helper directly.

## Verification
- `go test ./internal/principal ./internal/authorization ./internal/invocation ./internal/providerhost ./internal/server ./internal/mcp ./internal/workflowmanager`
- `golangci-lint run ./internal/principal ./internal/authorization ./internal/invocation ./internal/providerhost ./internal/server ./internal/mcp ./internal/workflowmanager`