### PR TITLE
[codex] gestaltd: fix MCP auth discovery

### DIFF
--- a/gestaltd/internal/server/handlers_mcp_oauth.go
+++ b/gestaltd/internal/server/handlers_mcp_oauth.go
@@ -1,0 +1,100 @@
+package server
+
+import (
+	"net/http"
+	"net/url"
+	"strings"
+)
+
+const (
+	mcpPath                          = "/mcp"
+	mcpProtectedResourceMetadataPath = "/.well-known/oauth-protected-resource/mcp"
+	mcpMetadataProbeState            = "mcp-resource-metadata"
+)
+
+type mcpProtectedResourceMetadataResponse struct {
+	Resource               string   `json:"resource"`
+	AuthorizationServers   []string `json:"authorization_servers,omitempty"`
+	ScopesSupported        []string `json:"scopes_supported,omitempty"`
+	BearerMethodsSupported []string `json:"bearer_methods_supported,omitempty"`
+}
+
+func (s *Server) mcpProtectedResourceMetadata(w http.ResponseWriter, r *http.Request) {
+	resp, err := s.mcpProtectedResourceMetadataResponse(r)
+	if err != nil {
+		writeError(w, http.StatusInternalServerError, "failed to resolve MCP metadata")
+		return
+	}
+	writeJSON(w, http.StatusOK, resp)
+}
+
+func (s *Server) mcpProtectedResourceMetadataResponse(r *http.Request) (mcpProtectedResourceMetadataResponse, error) {
+	resourceURL, err := s.resolvePublicURL(r, mcpPath)
+	if err != nil {
+		return mcpProtectedResourceMetadataResponse{}, err
+	}
+
+	authorizationServers, scopes := s.mcpAuthorizationMetadata(r)
+	resp := mcpProtectedResourceMetadataResponse{
+		Resource:               resourceURL,
+		AuthorizationServers:   authorizationServers,
+		ScopesSupported:        scopes,
+		BearerMethodsSupported: []string{"header"},
+	}
+	return resp, nil
+}
+
+func (s *Server) mcpAuthorizationMetadata(r *http.Request) ([]string, []string) {
+	auth := s.serverAuthRuntime()
+	if auth.noAuth || auth.provider == nil {
+		return nil, nil
+	}
+
+	loginURLRaw, err := loginURLForRequest(r.Context(), auth.provider, mcpMetadataProbeState)
+	if err != nil {
+		return nil, nil
+	}
+	loginURLResolved, err := s.resolvePublicURL(r, loginURLRaw)
+	if err != nil {
+		return nil, nil
+	}
+	loginURL, err := url.Parse(loginURLResolved)
+	if err != nil || !loginURL.IsAbs() || loginURL.Host == "" {
+		return nil, nil
+	}
+
+	authorizationServer := (&url.URL{
+		Scheme: loginURL.Scheme,
+		Host:   loginURL.Host,
+	}).String()
+	return []string{authorizationServer}, splitOAuthScopes(loginURL.Query().Get("scope"))
+}
+
+func splitOAuthScopes(raw string) []string {
+	fields := strings.Fields(strings.TrimSpace(raw))
+	if len(fields) == 0 {
+		return nil
+	}
+
+	out := make([]string, 0, len(fields))
+	seen := make(map[string]struct{}, len(fields))
+	for _, scope := range fields {
+		if _, ok := seen[scope]; ok {
+			continue
+		}
+		seen[scope] = struct{}{}
+		out = append(out, scope)
+	}
+	return out
+}
+
+func (s *Server) maybeSetMCPResourceMetadataHeader(w http.ResponseWriter, r *http.Request) {
+	if r.URL.Path != mcpPath {
+		return
+	}
+	resourceMetadataURL, err := s.resolvePublicURL(r, mcpProtectedResourceMetadataPath)
+	if err != nil || resourceMetadataURL == "" {
+		return
+	}
+	w.Header().Set("WWW-Authenticate", `Bearer resource_metadata="`+resourceMetadataURL+`"`)
+}

--- a/gestaltd/internal/server/middleware.go
+++ b/gestaltd/internal/server/middleware.go
@@ -198,15 +198,18 @@ func (s *Server) serveAuthenticated(w http.ResponseWriter, r *http.Request, next
 	switch {
 	case err == nil:
 		s.auditRequestEventWithAuthSource(r, authSource, auditProvider, "auth.authenticate", false, errors.New("missing authorization"))
+		s.maybeSetMCPResourceMetadataHeader(w, r)
 		writeError(w, http.StatusUnauthorized, "missing authorization")
 		return
 	case errors.Is(err, errInvalidAuthorizationHeader):
 		s.auditRequestEventWithAuthSource(r, authSource, auditProvider, "auth.authenticate", false, errInvalidAuthorizationHeader)
+		s.maybeSetMCPResourceMetadataHeader(w, r)
 		writeError(w, http.StatusUnauthorized, "invalid authorization header format")
 		return
 	case errors.Is(err, principal.ErrInvalidToken):
 		slog.InfoContext(r.Context(), "auth: invalid token", "remote_addr", r.RemoteAddr)
 		s.auditRequestEventWithAuthSource(r, authSource, auditProvider, "auth.authenticate", false, principal.ErrInvalidToken)
+		s.maybeSetMCPResourceMetadataHeader(w, r)
 		writeError(w, http.StatusUnauthorized, "invalid token")
 		return
 	default:

--- a/gestaltd/internal/server/routes.go
+++ b/gestaltd/internal/server/routes.go
@@ -135,9 +135,10 @@ func (s *Server) mountMCPRoutes(r chi.Router) {
 	if s.mcpHandler == nil {
 		return
 	}
+	r.Get(mcpProtectedResourceMetadataPath, s.mcpProtectedResourceMetadata)
 	r.Group(func(r chi.Router) {
 		r.Use(s.authMiddleware)
-		r.Handle("/mcp", s.mcpHandler)
+		r.Handle(mcpPath, s.mcpHandler)
 	})
 }
 

--- a/gestaltd/internal/server/server_test.go
+++ b/gestaltd/internal/server/server_test.go
@@ -15265,6 +15265,115 @@ func TestMCPEndpoint_RequiresAuth(t *testing.T) {
 	if resp.StatusCode != http.StatusUnauthorized {
 		t.Fatalf("expected 401 without auth, got %d", resp.StatusCode)
 	}
+	wantAuth := `Bearer resource_metadata="` + ts.URL + `/.well-known/oauth-protected-resource/mcp"`
+	if got := resp.Header.Get("WWW-Authenticate"); got != wantAuth {
+		t.Fatalf("WWW-Authenticate = %q, want %q", got, wantAuth)
+	}
+}
+
+func TestMCPProtectedResourceMetadata(t *testing.T) {
+	t.Parallel()
+
+	svc := coretesting.NewStubServices(t)
+	mcpHandler := newMCPHandler(t, func() *registry.ProviderMap[core.Provider] {
+		reg := registry.New()
+		return &reg.Providers
+	}(), svc, nil, nil)
+
+	ts := newTestServer(t, func(cfg *server.Config) {
+		cfg.Auth = &stubAuthWithLoginURL{
+			StubAuthProvider: coretesting.StubAuthProvider{N: "oidc"},
+			loginURL:         "https://accounts.example.test/authorize?scope=openid+email+profile",
+		}
+		cfg.MCPHandler = mcpHandler
+	})
+	testutil.CloseOnCleanup(t, ts)
+
+	resp, err := http.Get(ts.URL + "/.well-known/oauth-protected-resource/mcp")
+	if err != nil {
+		t.Fatalf("GET protected resource metadata: %v", err)
+	}
+	defer func() { _ = resp.Body.Close() }()
+
+	if resp.StatusCode != http.StatusOK {
+		t.Fatalf("status = %d, want %d", resp.StatusCode, http.StatusOK)
+	}
+	if got := resp.Header.Get("Content-Type"); got != "application/json" {
+		t.Fatalf("Content-Type = %q, want %q", got, "application/json")
+	}
+
+	var body map[string]any
+	if err := json.NewDecoder(resp.Body).Decode(&body); err != nil {
+		t.Fatalf("decode JSON: %v", err)
+	}
+
+	if got := body["resource"]; got != ts.URL+"/mcp" {
+		t.Fatalf("resource = %v, want %q", got, ts.URL+"/mcp")
+	}
+	authServers, _ := body["authorization_servers"].([]any)
+	if len(authServers) != 1 || authServers[0] != "https://accounts.example.test" {
+		t.Fatalf("authorization_servers = %v, want [https://accounts.example.test]", authServers)
+	}
+	scopes, _ := body["scopes_supported"].([]any)
+	if !reflect.DeepEqual(scopes, []any{"openid", "email", "profile"}) {
+		t.Fatalf("scopes_supported = %v, want [openid email profile]", scopes)
+	}
+	bearerMethods, _ := body["bearer_methods_supported"].([]any)
+	if !reflect.DeepEqual(bearerMethods, []any{"header"}) {
+		t.Fatalf("bearer_methods_supported = %v, want [header]", bearerMethods)
+	}
+}
+
+func TestMCPProtectedResourceMetadataRoute_PrecedesRootMountedUIFallback(t *testing.T) {
+	t.Parallel()
+
+	dir := t.TempDir()
+	if err := os.WriteFile(filepath.Join(dir, "index.html"), []byte("<html>root-shell</html>"), 0o644); err != nil {
+		t.Fatalf("WriteFile index.html: %v", err)
+	}
+	handler, err := testutilUIHandler(dir)
+	if err != nil {
+		t.Fatalf("ui handler: %v", err)
+	}
+
+	svc := coretesting.NewStubServices(t)
+	mcpHandler := newMCPHandler(t, func() *registry.ProviderMap[core.Provider] {
+		reg := registry.New()
+		return &reg.Providers
+	}(), svc, nil, nil)
+
+	ts := newTestServer(t, func(cfg *server.Config) {
+		cfg.Auth = &stubAuthWithLoginURL{
+			StubAuthProvider: coretesting.StubAuthProvider{N: "oidc"},
+			loginURL:         "https://accounts.example.test/authorize",
+		}
+		cfg.MountedUIs = []server.MountedUI{{
+			Path:    "/",
+			Handler: handler,
+		}}
+		cfg.MCPHandler = mcpHandler
+	})
+	testutil.CloseOnCleanup(t, ts)
+
+	resp, err := http.Get(ts.URL + "/.well-known/oauth-protected-resource/mcp")
+	if err != nil {
+		t.Fatalf("GET protected resource metadata with root UI: %v", err)
+	}
+	defer func() { _ = resp.Body.Close() }()
+
+	body, err := io.ReadAll(resp.Body)
+	if err != nil {
+		t.Fatalf("ReadAll metadata response: %v", err)
+	}
+	if resp.StatusCode != http.StatusOK {
+		t.Fatalf("status = %d, want %d", resp.StatusCode, http.StatusOK)
+	}
+	if got := resp.Header.Get("Content-Type"); got != "application/json" {
+		t.Fatalf("Content-Type = %q, want %q", got, "application/json")
+	}
+	if strings.Contains(string(body), "root-shell") {
+		t.Fatalf("body = %q, want JSON metadata instead of root UI shell", body)
+	}
 }
 
 func TestMCPEndpoint_DirectPassthrough(t *testing.T) {


### PR DESCRIPTION
## Summary
Fix MCP auth discovery for hosted Gestalt servers by serving protected resource metadata for `/mcp` and advertising it from unauthenticated MCP responses.

## Root Cause
`/mcp` returned `401` without a `WWW-Authenticate` header, so MCP clients fell back to `/.well-known/oauth-protected-resource/mcp`.

On deployments that mount a UI at `/`, unknown paths fall through to the root UI shell. That meant the well-known MCP metadata URL returned HTML instead of JSON, leaving clients stuck in a connected but unauthenticated state.

## What Changed
- add an explicit `/.well-known/oauth-protected-resource/mcp` route that returns JSON protected resource metadata
- include `WWW-Authenticate: Bearer resource_metadata="..."` on unauthenticated `/mcp` responses
- derive advertised authorization server and scopes from the configured login URL
- add regression coverage to ensure the metadata route wins over the root mounted-UI fallback

## Impact
MCP clients can now discover the server's OAuth metadata correctly instead of receiving the default UI shell from the well-known path.

## Validation
- `go test ./internal/server`
