### PR TITLE
Delete one-use server workload helpers

### DIFF
--- a/gestaltd/internal/server/audit.go
+++ b/gestaltd/internal/server/audit.go
@@ -40,7 +40,7 @@ func (s *Server) resolvePrincipalUserID(ctx context.Context, p *principal.Princi
 	if p == nil {
 		return nil, nil
 	}
-	if isWorkloadPrincipal(p) {
+	if principal.IsWorkloadPrincipal(p) {
 		return p, nil
 	}
 	if p.UserID != "" {

--- a/gestaltd/internal/server/authorization.go
+++ b/gestaltd/internal/server/authorization.go
@@ -2,11 +2,8 @@ package server
 
 import (
 	"context"
-	"errors"
 	"net/http"
 
-	"github.com/valon-technologies/gestalt/server/core"
-	"github.com/valon-technologies/gestalt/server/internal/authorization"
 	"github.com/valon-technologies/gestalt/server/internal/invocation"
 	"github.com/valon-technologies/gestalt/server/internal/principal"
 )
@@ -33,19 +30,8 @@ func (s *Server) providerAccessContextWithContext(ctx context.Context, p *princi
 	return access
 }
 
-func (s *Server) workloadBinding(p *principal.Principal, provider string) (authorization.CredentialBinding, bool) {
-	if s.authorizer == nil {
-		return authorization.CredentialBinding{}, false
-	}
-	return s.authorizer.Binding(p, provider)
-}
-
-func isWorkloadPrincipal(p *principal.Principal) bool {
-	return principal.IsWorkloadPrincipal(p)
-}
-
 func rejectWorkloadCaller(w http.ResponseWriter, p *principal.Principal) error {
-	if !isWorkloadPrincipal(p) {
+	if !principal.IsWorkloadPrincipal(p) {
 		return nil
 	}
 	writeError(w, http.StatusForbidden, errWorkloadForbidden.Error())
@@ -53,7 +39,7 @@ func rejectWorkloadCaller(w http.ResponseWriter, p *principal.Principal) error {
 }
 
 func rejectWorkloadSelectors(w http.ResponseWriter, p *principal.Principal, connection, instance string) error {
-	if !isWorkloadPrincipal(p) {
+	if !principal.IsWorkloadPrincipal(p) {
 		return nil
 	}
 	if connection == "" && instance == "" {
@@ -61,27 +47,4 @@ func rejectWorkloadSelectors(w http.ResponseWriter, p *principal.Principal, conn
 	}
 	writeError(w, http.StatusForbidden, errWorkloadSelector.Error())
 	return errWorkloadSelector
-}
-
-func (s *Server) workloadBindingSelectors(p *principal.Principal, provider, connection, instance string) (string, string) {
-	return s.catalogSelectorConfig().WorkloadBindingSelectors(p, provider, connection, instance)
-}
-
-func (s *Server) workloadBindingConnected(ctx context.Context, binding authorization.CredentialBinding, provider string) (bool, error) {
-	switch binding.Mode {
-	case core.ConnectionModeNone:
-		return true, nil
-	case core.ConnectionModeUser:
-		_, err := s.tokens.Token(ctx, binding.CredentialSubjectID, provider, binding.Connection, binding.Instance)
-		switch {
-		case err == nil:
-			return true, nil
-		case errors.Is(err, core.ErrNotFound):
-			return false, nil
-		default:
-			return false, err
-		}
-	default:
-		return false, nil
-	}
 }

--- a/gestaltd/internal/server/handlers.go
+++ b/gestaltd/internal/server/handlers.go
@@ -126,7 +126,7 @@ func (s *Server) readinessCheck(w http.ResponseWriter, _ *http.Request) {
 func (s *Server) listIntegrations(w http.ResponseWriter, r *http.Request) {
 	p := PrincipalFromContext(r.Context())
 	connected := map[string][]instanceInfo{}
-	if !isWorkloadPrincipal(p) {
+	if !principal.IsWorkloadPrincipal(p) {
 		var err error
 		connected, err = s.userConnectedIntegrations(r)
 		if err != nil {
@@ -163,15 +163,25 @@ func (s *Server) listIntegrations(w http.ResponseWriter, r *http.Request) {
 		if entry, ok := s.pluginDefs[name]; ok && entry != nil {
 			info.MountedPath = strings.TrimSpace(entry.MountPath)
 		}
-		if isWorkloadPrincipal(p) {
-			if binding, ok := s.workloadBinding(p, name); ok {
-				bindingConnected, err := s.workloadBindingConnected(r.Context(), binding, name)
-				if err != nil {
-					slog.ErrorContext(r.Context(), "checking workload integration status", "provider", name, "error", err)
-					writeError(w, http.StatusInternalServerError, "failed to check integration status")
-					return
+		if principal.IsWorkloadPrincipal(p) {
+			if s.authorizer != nil {
+				if binding, ok := s.authorizer.Binding(p, name); ok {
+					switch binding.Mode {
+					case core.ConnectionModeNone:
+						info.Connected = true
+					case core.ConnectionModeUser:
+						_, err := s.tokens.Token(r.Context(), binding.CredentialSubjectID, name, binding.Connection, binding.Instance)
+						switch {
+						case err == nil:
+							info.Connected = true
+						case errors.Is(err, core.ErrNotFound):
+						default:
+							slog.ErrorContext(r.Context(), "checking workload integration status", "provider", name, "error", err)
+							writeError(w, http.StatusInternalServerError, "failed to check integration status")
+							return
+						}
+					}
 				}
-				info.Connected = bindingConnected
 			}
 			info.MountedPath = s.integrationMountedPathForPrincipalContext(r.Context(), p, name, info.MountedPath)
 			if !s.integrationHasUsableSurfaceContext(r.Context(), p, name, prov, info) {

--- a/gestaltd/internal/server/handlers_identities.go
+++ b/gestaltd/internal/server/handlers_identities.go
@@ -1100,7 +1100,7 @@ func (s *Server) managedIdentityGrantCatalogTargets(ctx context.Context, plugin 
 	}
 
 	for _, connection := range s.sessionCatalogConnections(plugin, p, "") {
-		connection, instance := s.workloadBindingSelectors(p, plugin, connection, "")
+		connection, instance := s.catalogSelectorConfig().WorkloadBindingSelectors(p, plugin, connection, "")
 		addTarget(connection, instance)
 	}
 	subjectID := ""
@@ -1110,7 +1110,7 @@ func (s *Server) managedIdentityGrantCatalogTargets(ctx context.Context, plugin 
 			subjectID = principal.UserSubjectID(p.UserID)
 		}
 	}
-	if p == nil || isWorkloadPrincipal(p) || subjectID == "" {
+	if p == nil || principal.IsWorkloadPrincipal(p) || subjectID == "" {
 		if len(targets) == 0 {
 			addTarget("", "")
 		}

--- a/gestaltd/internal/server/integration_visibility.go
+++ b/gestaltd/internal/server/integration_visibility.go
@@ -20,7 +20,7 @@ func (s *Server) integrationHasUsableSurfaceContext(ctx context.Context, p *prin
 }
 
 func (s *Server) integrationHasSettingsSurface(p *principal.Principal, info integrationInfo) bool {
-	if isWorkloadPrincipal(p) {
+	if principal.IsWorkloadPrincipal(p) {
 		return false
 	}
 	return info.Connected || len(info.AuthTypes) > 0 || len(info.Connections) > 0
@@ -69,7 +69,7 @@ func (s *Server) mountedUIRootAccessibleContext(ctx context.Context, p *principa
 	if mounted.AuthorizationPolicy == "" {
 		return true
 	}
-	if s.authorizer == nil || p == nil || isWorkloadPrincipal(p) {
+	if s.authorizer == nil || p == nil || principal.IsWorkloadPrincipal(p) {
 		return false
 	}
 

--- a/gestaltd/internal/server/middleware.go
+++ b/gestaltd/internal/server/middleware.go
@@ -133,10 +133,10 @@ func (s *Server) resolveRequestPrincipalWithResolver(r *http.Request, resolver *
 
 	if c, err := r.Cookie(sessionCookieName); err == nil && c.Value != "" {
 		p, err := resolver.ResolveToken(r.Context(), c.Value)
-		if p != nil && !isWorkloadPrincipal(p) {
+		if p != nil && !principal.IsWorkloadPrincipal(p) {
 			return p, nil
 		}
-		if isWorkloadPrincipal(p) {
+		if principal.IsWorkloadPrincipal(p) {
 			lastErr = principal.ErrInvalidToken
 		} else {
 			lastErr = err

--- a/gestaltd/internal/server/pending_connection.go
+++ b/gestaltd/internal/server/pending_connection.go
@@ -257,7 +257,7 @@ func (s *Server) resolvePendingConnectionUserID(r *http.Request) (string, bool, 
 	if p == nil {
 		return "", false, nil
 	}
-	if isWorkloadPrincipal(p) {
+	if principal.IsWorkloadPrincipal(p) {
 		return "", true, errWorkloadForbidden
 	}
 	subjectID := strings.TrimSpace(p.SubjectID)


### PR DESCRIPTION
## Summary
- delete one-use workload helper wrappers from `internal/server/authorization.go`
- inline workload binding status and selector handling into the two remaining server callsites
- use `principal.IsWorkloadPrincipal(...)` directly across server code instead of a local pass-through helper

## Verification
- `go test ./internal/server ./internal/invocation ./internal/mcp ./internal/workflowmanager`
- `golangci-lint run ./internal/server ./internal/invocation ./internal/mcp ./internal/workflowmanager`