### PR TITLE
Delete thin server catalog selector helpers

### DIFF
--- a/gestaltd/internal/server/authorization.go
+++ b/gestaltd/internal/server/authorization.go
@@ -15,13 +15,6 @@ func (s *Server) allowProviderContext(ctx context.Context, p *principal.Principa
 	return s.authorizer.AllowProvider(ctx, p, provider)
 }
 
-func (s *Server) allowOperationContext(ctx context.Context, p *principal.Principal, provider, operation string) bool {
-	if s.authorizer == nil {
-		return true
-	}
-	return s.authorizer.AllowOperation(ctx, p, provider, operation)
-}
-
 func (s *Server) providerAccessContextWithContext(ctx context.Context, p *principal.Principal, provider string) invocation.AccessContext {
 	if s.authorizer == nil {
 		return invocation.AccessContext{}

--- a/gestaltd/internal/server/handlers.go
+++ b/gestaltd/internal/server/handlers.go
@@ -484,7 +484,7 @@ func (s *Server) listOperations(w http.ResponseWriter, r *http.Request) {
 		name,
 		resolver,
 		p,
-		s.boundSessionCatalogTargets(name, p, requestedConnection, requestedInstance),
+		s.catalogSelectorConfig().BoundSessionCatalogTargets(name, p, requestedConnection, requestedInstance),
 		strictCatalog,
 	)
 	discoveryFailed = metadata.SessionFailed
@@ -517,7 +517,7 @@ func (s *Server) executeOperation(w http.ResponseWriter, r *http.Request) {
 	}
 	access := s.providerAccessContextWithContext(r.Context(), p, providerName)
 	providerAllowed := s.allowProviderContext(r.Context(), p, providerName)
-	operationAllowed := s.allowOperationContext(r.Context(), p, providerName, operationName)
+	operationAllowed := s.authorizer == nil || s.authorizer.AllowOperation(r.Context(), p, providerName, operationName)
 	if !providerAllowed || !operationAllowed {
 		authz := auditAuthorization{
 			Policy: access.Policy,
@@ -618,7 +618,7 @@ func (s *Server) executeOperation(w http.ResponseWriter, r *http.Request) {
 	if tr, ok := s.invoker.(invocation.TokenResolver); ok {
 		resolver = tr
 	}
-	boundSessionConnections, sessionInstance := s.boundSessionCatalogConnections(providerName, p, connection, instance)
+	boundSessionConnections, sessionInstance := s.catalogSelectorConfig().BoundSessionCatalogConnections(providerName, p, connection, instance)
 	opMeta, _, resolvedConnection, err := invocation.ResolveOperation(ctx, prov, providerName, resolver, p, operationName, boundSessionConnections, sessionInstance)
 	if err != nil {
 		s.writeInvocationError(w, r, providerName, operationName, err)
@@ -719,18 +719,6 @@ func (s *Server) writeInvocationError(w http.ResponseWriter, r *http.Request, pr
 		slog.ErrorContext(r.Context(), "operation failed", "provider", providerName, "operation", operationName, "error", err)
 		writeError(w, http.StatusBadGateway, "operation failed")
 	}
-}
-
-func (s *Server) sessionCatalogConnections(providerName string, p *principal.Principal, explicit string) []string {
-	return s.catalogSelectorConfig().SessionCatalogConnections(providerName, p, explicit)
-}
-
-func (s *Server) boundSessionCatalogConnections(providerName string, p *principal.Principal, explicit, instance string) ([]string, string) {
-	return s.catalogSelectorConfig().BoundSessionCatalogConnections(providerName, p, explicit, instance)
-}
-
-func (s *Server) boundSessionCatalogTargets(providerName string, p *principal.Principal, explicit, instance string) []invocation.CatalogResolutionTarget {
-	return s.catalogSelectorConfig().BoundSessionCatalogTargets(providerName, p, explicit, instance)
 }
 
 func httpVisibleCatalogOperations(ops []catalog.CatalogOperation) []catalog.CatalogOperation {

--- a/gestaltd/internal/server/handlers_identities.go
+++ b/gestaltd/internal/server/handlers_identities.go
@@ -615,7 +615,11 @@ func (s *Server) listManagedIdentityGrants(w http.ResponseWriter, r *http.Reques
 	p := PrincipalFromContext(r.Context())
 	out := make([]managedIdentityGrantInfo, 0, len(grants))
 	for _, grant := range grants {
-		if !s.managedIdentityGrantVisibleToActor(r.Context(), grant.Plugin, p, actor.Membership.Role) {
+		if _, err := s.providers.Get(grant.Plugin); err != nil {
+			if !errors.Is(err, core.ErrNotFound) || !managedIdentityRoleAllows(actor.Membership.Role, managedIdentityRoleEditor) {
+				continue
+			}
+		} else if !s.allowProviderContext(r.Context(), p, grant.Plugin) {
 			continue
 		}
 		out = append(out, managedIdentityGrantInfo{
@@ -1044,12 +1048,6 @@ func (s *Server) managedIdentityGrantPluginVisible(ctx context.Context, plugin s
 	return s.allowProviderContext(ctx, p, plugin)
 }
 
-func (s *Server) managedIdentityGrantVisibleToActor(ctx context.Context, plugin string, p *principal.Principal, role string) bool {
-	if _, err := s.providers.Get(plugin); err != nil {
-		return errors.Is(err, core.ErrNotFound) && managedIdentityRoleAllows(role, managedIdentityRoleEditor)
-	}
-	return s.allowProviderContext(ctx, p, plugin)
-}
 func (s *Server) managedIdentityGrantCatalog(ctx context.Context, plugin string, p *principal.Principal) (*catalog.Catalog, error) {
 	prov, err := s.providers.Get(plugin)
 	if err != nil {
@@ -1099,7 +1097,7 @@ func (s *Server) managedIdentityGrantCatalogTargets(ctx context.Context, plugin 
 		})
 	}
 
-	for _, connection := range s.sessionCatalogConnections(plugin, p, "") {
+	for _, connection := range s.catalogSelectorConfig().SessionCatalogConnections(plugin, p, "") {
 		connection, instance := s.catalogSelectorConfig().WorkloadBindingSelectors(p, plugin, connection, "")
 		addTarget(connection, instance)
 	}


### PR DESCRIPTION
## Summary
- delete thin `internal/server` pass-through helpers around bound session catalog selectors and operation authz
- inline the remaining single-callsite managed-identity grant visibility logic
- call `catalogSelectorConfig()` directly from the server callsites that still need session catalog selector behavior

## Verification
- `go test ./internal/server ./internal/invocation ./internal/mcp ./internal/workflowmanager`
- `golangci-lint run ./internal/server ./internal/invocation ./internal/mcp ./internal/workflowmanager`