### PR TITLE
Delete managed identity grant visibility wrapper

### DIFF
--- a/gestaltd/internal/server/handlers_identities.go
+++ b/gestaltd/internal/server/handlers_identities.go
@@ -659,7 +659,7 @@ func (s *Server) putManagedIdentityGrant(w http.ResponseWriter, r *http.Request)
 	}
 
 	p := managedIdentityGrantValidationPrincipal(PrincipalFromContext(r.Context()), actor.SubjectID)
-	if !s.managedIdentityGrantPluginVisible(r.Context(), plugin, p) {
+	if _, err := s.providers.Get(plugin); err != nil || !s.allowProviderContext(r.Context(), p, plugin) {
 		auditErr = errors.New("plugin not found")
 		writeError(w, http.StatusNotFound, "plugin not found")
 		return
@@ -683,7 +683,7 @@ func (s *Server) putManagedIdentityGrant(w http.ResponseWriter, r *http.Request)
 	if !ok {
 		return
 	}
-	if !s.managedIdentityGrantPluginVisible(r.Context(), plugin, p) {
+	if _, err := s.providers.Get(plugin); err != nil || !s.allowProviderContext(r.Context(), p, plugin) {
 		auditErr = errors.New("plugin not found")
 		writeError(w, http.StatusNotFound, "plugin not found")
 		return
@@ -1039,13 +1039,6 @@ func (s *Server) recoverManagedIdentityCreateMembership(ctx context.Context, ide
 			return nil, fmt.Errorf("failed to create identity membership and roll back identity: %w", errors.Join(createErr, restoreErr, deleteErr))
 		}
 	}
-}
-
-func (s *Server) managedIdentityGrantPluginVisible(ctx context.Context, plugin string, p *principal.Principal) bool {
-	if _, err := s.providers.Get(plugin); err != nil {
-		return false
-	}
-	return s.allowProviderContext(ctx, p, plugin)
 }
 
 func (s *Server) managedIdentityGrantCatalog(ctx context.Context, plugin string, p *principal.Principal) (*catalog.Catalog, error) {

--- a/gestaltd/internal/server/handlers_identity_tokens.go
+++ b/gestaltd/internal/server/handlers_identity_tokens.go
@@ -197,7 +197,7 @@ func (s *Server) validateManagedIdentityTokenPermissions(ctx context.Context, id
 	}
 
 	for _, permission := range permissions {
-		if !s.managedIdentityGrantPluginVisible(ctx, permission.Plugin, viewer) {
+		if _, err := s.providers.Get(permission.Plugin); err != nil || !s.allowProviderContext(ctx, viewer, permission.Plugin) {
 			return fmt.Errorf("plugin %q is not available", permission.Plugin)
 		}
 		if len(permission.Operations) > 0 {


### PR DESCRIPTION
## Summary
- delete the last `managedIdentityGrantPluginVisible(...)` server wrapper
- inline the provider existence plus provider-access check at the three remaining grant validation callsites
- keep the same not-found behavior while trimming one more layer of managed-identity-specific indirection

## Verification
- `go test ./internal/server ./internal/invocation ./internal/mcp ./internal/workflowmanager`
- `golangci-lint run ./internal/server ./internal/invocation ./internal/mcp ./internal/workflowmanager`