### PR TITLE
Add plugin-local HTTP subject resolution for hosted bindings

### DIFF
--- a/gestaltd/cmd/gestaltd/e2e_test.go
+++ b/gestaltd/cmd/gestaltd/e2e_test.go
@@ -621,6 +621,96 @@ func setupPluginDirWithHostedHTTPBinding(t *testing.T, baseDir string) string {
 	return pluginDir
 }
 
+func setupPluginDirWithHTTPSubjectResolution(t *testing.T, baseDir string) string {
+	t.Helper()
+
+	pluginDir := setupPluginDir(t, baseDir)
+	providerPath := filepath.Join(pluginDir, "provider.go")
+	source, err := os.ReadFile(providerPath)
+	if err != nil {
+		t.Fatalf("read %s: %v", providerPath, err)
+	}
+
+	const routerReplacement = `	).WithManifestMetadata(gestalt.ManifestMetadata{
+		SecuritySchemes: map[string]gestalt.HTTPSecurityScheme{
+			"public": {
+				Type: gestalt.HTTPSecuritySchemeTypeNone,
+			},
+		},
+		HTTP: map[string]gestalt.HTTPBinding{
+			"resolve_subject": {
+				Path:     "/resolve-subject",
+				Method:   http.MethodPost,
+				Security: "public",
+				Target:   "invoke_request_context",
+				RequestBody: &gestalt.HTTPRequestBody{
+					Required: true,
+					Content: map[string]gestalt.HTTPMediaType{
+						"application/x-www-form-urlencoded": {},
+					},
+				},
+			},
+		},
+	})
+)`
+	updated := strings.Replace(string(source), "\t)\n)", routerReplacement, 1)
+	if updated == string(source) {
+		t.Fatalf("failed to inject hosted HTTP subject metadata into %s", providerPath)
+	}
+
+	const resolverMethod = `
+func (p *Provider) ResolveHTTPSubject(ctx context.Context, req gestalt.HTTPSubjectRequest) (*gestalt.Subject, error) {
+	if req.Binding != "resolve_subject" {
+		return nil, nil
+	}
+
+	teamID, _ := req.Params["team_id"].(string)
+	userID, _ := req.Params["user_id"].(string)
+	if teamID == "" || userID == "" {
+		return nil, gestalt.Error(http.StatusBadRequest, "missing slack subject fields")
+	}
+
+	authz, err := gestalt.Authorization()
+	if err != nil {
+		return nil, err
+	}
+	defer func() { _ = authz.Close() }()
+
+	resp, err := authz.SearchSubjects(ctx, &gestalt.SubjectSearchRequest{
+		SubjectType: "user",
+		Resource: &gestalt.AuthorizationResource{
+			Type: "slack_identity",
+			Id:   fmt.Sprintf("team:%s:user:%s", teamID, userID),
+		},
+	})
+	if err != nil {
+		return nil, err
+	}
+	if len(resp.GetSubjects()) == 0 {
+		return nil, gestalt.Error(http.StatusForbidden, "unmapped slack subject")
+	}
+
+	subject := resp.GetSubjects()[0]
+	return &gestalt.Subject{
+		ID:   subject.GetId(),
+		Kind: subject.GetType(),
+	}, nil
+}
+
+`
+	withResolver := strings.Replace(updated, "func (p *Provider) greet(", resolverMethod+"func (p *Provider) greet(", 1)
+	if withResolver == updated {
+		t.Fatalf("failed to inject ResolveHTTPSubject into %s", providerPath)
+	}
+	updated = withResolver
+
+	if err := os.WriteFile(providerPath, []byte(updated), 0o644); err != nil {
+		t.Fatalf("write %s: %v", providerPath, err)
+	}
+
+	return pluginDir
+}
+
 func setupPluginDirWithVersion(t *testing.T, baseDir, version string) string {
 	t.Helper()
 
@@ -661,6 +751,38 @@ func setupAuthProviderDir(t *testing.T, baseDir, name string) string {
 		Source:      "github.com/test/providers/auth/" + name,
 		Version:     "0.0.1-alpha.1",
 		DisplayName: "Test Auth " + name,
+		Spec:        &providermanifestv1.Spec{},
+		Artifacts: []providermanifestv1.Artifact{
+			{OS: runtime.GOOS, Arch: runtime.GOARCH, Path: artifactRel},
+		},
+		Entrypoint: &providermanifestv1.Entrypoint{ArtifactPath: artifactRel},
+	})
+	return providerDir
+}
+
+func setupAuthorizationProviderDir(t *testing.T, baseDir, name string) string {
+	t.Helper()
+
+	providerDir := filepath.Join(baseDir, "authorization", name)
+	if err := os.MkdirAll(providerDir, 0o755); err != nil {
+		t.Fatalf("MkdirAll(%s): %v", providerDir, err)
+	}
+	writeTestFile(t, providerDir, "go.mod", []byte(testutil.GeneratedProviderModuleSource(t, "example.com/providers/authorization/"+name)), 0o644)
+	writeTestFile(t, providerDir, "go.sum", testutil.GeneratedProviderModuleSum(t), 0o644)
+	writeTestFile(t, providerDir, "authorization.go", []byte(httpSubjectAuthorizationProviderSource(name)), 0o644)
+	artifactRel := filepath.ToSlash(filepath.Join("artifacts", runtime.GOOS, runtime.GOARCH, "authorization-provider"))
+	artifactPath := filepath.Join(providerDir, filepath.FromSlash(artifactRel))
+	if err := os.MkdirAll(filepath.Dir(artifactPath), 0o755); err != nil {
+		t.Fatalf("MkdirAll(%s): %v", filepath.Dir(artifactPath), err)
+	}
+	if _, err := providerpkg.BuildSourceComponentReleaseBinary(providerDir, artifactPath, providermanifestv1.KindAuthorization, runtime.GOOS, runtime.GOARCH); err != nil {
+		t.Fatalf("BuildSourceComponentReleaseBinary(%s): %v", providerDir, err)
+	}
+	writeManifestFile(t, providerDir, &providermanifestv1.Manifest{
+		Kind:        providermanifestv1.KindAuthorization,
+		Source:      "github.com/test/providers/authorization/" + name,
+		Version:     "0.0.1-alpha.1",
+		DisplayName: "Test Authorization " + name,
 		Spec:        &providermanifestv1.Spec{},
 		Artifacts: []providermanifestv1.Artifact{
 			{OS: runtime.GOOS, Arch: runtime.GOARCH, Path: artifactRel},
@@ -711,6 +833,101 @@ func authProviderSource(name string) string {
 	source = strings.Replace(source, `Name:        "generated-auth"`, fmt.Sprintf(`Name:        %q`, name), 1)
 	source = strings.Replace(source, `DisplayName: "Generated Auth"`, fmt.Sprintf(`DisplayName: %q`, displayName), 1)
 	return source
+}
+
+func httpSubjectAuthorizationProviderSource(name string) string {
+	displayName := name
+	if name != "" {
+		displayName = strings.ToUpper(name[:1]) + name[1:]
+	}
+	return fmt.Sprintf(`package authorization
+
+import (
+	"context"
+
+	gestalt "github.com/valon-technologies/gestalt/sdk/go"
+)
+
+type Provider struct{}
+
+func New() *Provider { return &Provider{} }
+
+func (p *Provider) Configure(context.Context, string, map[string]any) error { return nil }
+
+func (p *Provider) Metadata() gestalt.ProviderMetadata {
+	return gestalt.ProviderMetadata{
+		Kind:        gestalt.ProviderKindAuthorization,
+		Name:        %q,
+		DisplayName: %q,
+	}
+}
+
+func (p *Provider) Evaluate(_ context.Context, _ *gestalt.AccessEvaluationRequest) (*gestalt.AccessDecision, error) {
+	return &gestalt.AccessDecision{Allowed: true, ModelId: "model-v1"}, nil
+}
+
+func (p *Provider) EvaluateMany(_ context.Context, req *gestalt.AccessEvaluationsRequest) (*gestalt.AccessEvaluationsResponse, error) {
+	decisions := make([]*gestalt.AccessDecision, 0, len(req.GetRequests()))
+	for range req.GetRequests() {
+		decisions = append(decisions, &gestalt.AccessDecision{Allowed: true, ModelId: "model-v1"})
+	}
+	return &gestalt.AccessEvaluationsResponse{Decisions: decisions}, nil
+}
+
+func (p *Provider) SearchResources(_ context.Context, _ *gestalt.ResourceSearchRequest) (*gestalt.ResourceSearchResponse, error) {
+	return &gestalt.ResourceSearchResponse{ModelId: "model-v1"}, nil
+}
+
+func (p *Provider) SearchSubjects(_ context.Context, req *gestalt.SubjectSearchRequest) (*gestalt.SubjectSearchResponse, error) {
+	resource := req.GetResource()
+	if resource != nil && resource.GetType() == "slack_identity" && resource.GetId() == "team:T123:user:U456" {
+		return &gestalt.SubjectSearchResponse{
+			Subjects: []*gestalt.AuthorizationSubject{{
+				Type: "user",
+				Id:   "user:slack-user",
+			}},
+			ModelId: "model-v1",
+		}, nil
+	}
+	return &gestalt.SubjectSearchResponse{ModelId: "model-v1"}, nil
+}
+
+func (p *Provider) SearchActions(_ context.Context, _ *gestalt.ActionSearchRequest) (*gestalt.ActionSearchResponse, error) {
+	return &gestalt.ActionSearchResponse{
+		Actions: []*gestalt.AuthorizationAction{{Name: "invoke"}},
+		ModelId: "model-v1",
+	}, nil
+}
+
+func (p *Provider) GetMetadata(context.Context) (*gestalt.AuthorizationMetadata, error) {
+	return &gestalt.AuthorizationMetadata{
+		Capabilities:  []string{"evaluate", "relationships", "models"},
+		ActiveModelId: "model-v1",
+	}, nil
+}
+
+func (p *Provider) ReadRelationships(_ context.Context, _ *gestalt.ReadRelationshipsRequest) (*gestalt.ReadRelationshipsResponse, error) {
+	return &gestalt.ReadRelationshipsResponse{ModelId: "model-v1"}, nil
+}
+
+func (p *Provider) WriteRelationships(context.Context, *gestalt.WriteRelationshipsRequest) error { return nil }
+
+func (p *Provider) GetActiveModel(context.Context) (*gestalt.GetActiveModelResponse, error) {
+	return &gestalt.GetActiveModelResponse{
+		Model: &gestalt.AuthorizationModelRef{Id: "model-v1", Version: "v1"},
+	}, nil
+}
+
+func (p *Provider) ListModels(_ context.Context, _ *gestalt.ListModelsRequest) (*gestalt.ListModelsResponse, error) {
+	return &gestalt.ListModelsResponse{
+		Models: []*gestalt.AuthorizationModelRef{{Id: "model-v1", Version: "v1"}},
+	}, nil
+}
+
+func (p *Provider) WriteModel(context.Context, *gestalt.WriteModelRequest) (*gestalt.AuthorizationModelRef, error) {
+	return &gestalt.AuthorizationModelRef{Id: "model-v2", Version: "v2"}, nil
+}
+`, name, displayName)
 }
 
 func componentProviderManifestPath(t *testing.T, providerDir string) string {
@@ -1562,6 +1779,88 @@ func TestE2EServeMountsGeneratedHostedHTTPBindingsForLocalSourcePlugin(t *testin
 	}
 	if got, want := result["echo"], "hello"; got != want {
 		t.Fatalf("response echo = %#v, want %q", got, want)
+	}
+}
+
+func TestE2EHostedHTTPSubjectResolutionUsesAuthorizationAndInheritedInvocation(t *testing.T) {
+	t.Parallel()
+
+	if testing.Short() {
+		t.Skip("skipping hosted HTTP subject resolution serve test in short mode")
+	}
+
+	dir := t.TempDir()
+	pluginDir := setupPluginDirWithHTTPSubjectResolution(t, dir)
+	authorizationManifest := componentProviderManifestPath(t, setupAuthorizationProviderDir(t, dir, "local"))
+	indexedDBManifest := componentProviderManifestPath(t, setupIndexedDBProviderDir(t, dir))
+	pluginManifest := componentProviderManifestPath(t, pluginDir)
+
+	port, holder := reservePort(t)
+	baseURL := fmt.Sprintf("http://127.0.0.1:%d", port)
+	cfgPath := filepath.Join(dir, "config-subject-resolution.yaml")
+	cfg := fmt.Sprintf(`server:
+  public:
+    port: %d
+  encryptionKey: test-http-subject-resolution-key
+  providers:
+    indexeddb: sqlite
+    authorization: local
+providers:
+  indexeddb:
+    sqlite:
+      source:
+        path: %s
+      config:
+        dsn: %q
+  authorization:
+    local:
+      source:
+        path: %s
+plugins:
+  example:
+    source:
+      path: %s
+    invokes:
+      - plugin: example
+        operation: request_context
+`, port, indexedDBManifest, "sqlite://"+filepath.Join(dir, "gestalt.db"), authorizationManifest, pluginManifest)
+	if err := os.WriteFile(cfgPath, []byte(cfg), 0o644); err != nil {
+		t.Fatalf("write config: %v", err)
+	}
+	_ = holder.Close()
+
+	cmd := exec.Command(gestaltdBin, "serve", "--config", cfgPath)
+	startCommandAndWaitReady(t, cmd, baseURL)
+
+	req, err := http.NewRequest(http.MethodPost, baseURL+"/api/v1/example/resolve-subject", strings.NewReader("team_id=T123&user_id=U456"))
+	if err != nil {
+		t.Fatalf("NewRequest: %v", err)
+	}
+	req.Header.Set("Content-Type", "application/x-www-form-urlencoded")
+
+	resp, err := (&http.Client{Timeout: 2 * time.Second}).Do(req)
+	if err != nil {
+		t.Fatalf("POST /api/v1/example/resolve-subject: %v", err)
+	}
+	defer func() { _ = resp.Body.Close() }()
+	body, _ := io.ReadAll(resp.Body)
+	if resp.StatusCode != http.StatusOK {
+		t.Fatalf("expected /api/v1/example/resolve-subject 200, got %d: %s", resp.StatusCode, body)
+	}
+
+	var result map[string]any
+	if err := json.Unmarshal(body, &result); err != nil {
+		t.Fatalf("decode subject resolution response: %v (body: %s)", err, body)
+	}
+	subject, _ := result["subject"].(map[string]any)
+	if got, want := subject["id"], "user:slack-user"; got != want {
+		t.Fatalf("response subject.id = %#v, want %q", got, want)
+	}
+	if got, want := subject["kind"], "user"; got != want {
+		t.Fatalf("response subject.kind = %#v, want %q", got, want)
+	}
+	if got, _ := result["invocation_token"].(string); got == "" {
+		t.Fatalf("response invocation_token = %q, want non-empty", got)
 	}
 }
 

--- a/gestaltd/core/http_subject.go
+++ b/gestaltd/core/http_subject.go
@@ -1,0 +1,71 @@
+package core
+
+import (
+	"context"
+	"fmt"
+	"net/http"
+	"net/url"
+)
+
+// HTTPSubjectResolveRequest carries the verified inbound hosted HTTP request
+// shape into optional provider-local subject resolution hooks.
+type HTTPSubjectResolveRequest struct {
+	Binding         string
+	Method          string
+	Path            string
+	ContentType     string
+	Headers         http.Header
+	Query           url.Values
+	Params          map[string]any
+	RawBody         []byte
+	SecurityScheme  string
+	VerifiedSubject string
+	VerifiedClaims  map[string]string
+}
+
+// HTTPResolvedSubject identifies the concrete subject a hosted HTTP request
+// should execute as.
+type HTTPResolvedSubject struct {
+	ID          string
+	Kind        string
+	DisplayName string
+	AuthSource  string
+}
+
+// HTTPSubjectResolver is implemented by providers that can map a verified
+// hosted HTTP request to a concrete Gestalt subject before normal operation
+// authorization runs.
+type HTTPSubjectResolver interface {
+	ResolveHTTPSubject(ctx context.Context, req *HTTPSubjectResolveRequest) (*HTTPResolvedSubject, error)
+}
+
+// HTTPSubjectResolveError reports a provider-defined HTTP rejection produced
+// while resolving a hosted HTTP subject.
+type HTTPSubjectResolveError struct {
+	Status  int
+	Message string
+	Cause   error
+}
+
+func (e *HTTPSubjectResolveError) Error() string {
+	if e == nil {
+		return ""
+	}
+	if e.Cause != nil {
+		return e.Cause.Error()
+	}
+	if e.Message != "" {
+		return e.Message
+	}
+	if e.Status > 0 {
+		return fmt.Sprintf("http subject resolution failed with status %d", e.Status)
+	}
+	return "http subject resolution failed"
+}
+
+func (e *HTTPSubjectResolveError) Unwrap() error {
+	if e == nil {
+		return nil
+	}
+	return e.Cause
+}

--- a/gestaltd/internal/bootstrap/bootstrap.go
+++ b/gestaltd/internal/bootstrap/bootstrap.go
@@ -145,6 +145,7 @@ type Deps struct {
 	WorkflowRuntime       *workflowRuntime
 	WorkflowManager       workflowmanager.Service
 	Egress                EgressDeps
+	AuthorizationProvider core.AuthorizationProvider
 	PluginInvoker         invocation.Invoker
 	PluginRuntime         pluginruntime.Provider
 	PluginRuntimeRegistry *pluginRuntimeRegistry
@@ -601,6 +602,7 @@ func prepareCore(ctx context.Context, cfg *config.Config, factories *FactoryRegi
 		_ = closeAuthProviders(authProviders)
 		return nil, err
 	}
+	deps.AuthorizationProvider = authzProvider
 	runtimeRegistry := newPluginRuntimeRegistry(cfg, factories.Runtime, deps)
 	deps.PluginRuntimeRegistry = runtimeRegistry
 

--- a/gestaltd/internal/bootstrap/executable_plugin_test.go
+++ b/gestaltd/internal/bootstrap/executable_plugin_test.go
@@ -90,6 +90,54 @@ type nestedInvokeHarness struct {
 	services *coredata.Services
 }
 
+type hostedHTTPAuthorizationProvider struct{}
+
+func (p *hostedHTTPAuthorizationProvider) Name() string { return "authz" }
+
+func (p *hostedHTTPAuthorizationProvider) Evaluate(context.Context, *core.AccessEvaluationRequest) (*core.AccessDecision, error) {
+	return &core.AccessDecision{}, nil
+}
+
+func (p *hostedHTTPAuthorizationProvider) EvaluateMany(context.Context, *core.AccessEvaluationsRequest) (*core.AccessEvaluationsResponse, error) {
+	return &core.AccessEvaluationsResponse{}, nil
+}
+
+func (p *hostedHTTPAuthorizationProvider) SearchResources(context.Context, *core.ResourceSearchRequest) (*core.ResourceSearchResponse, error) {
+	return &core.ResourceSearchResponse{}, nil
+}
+
+func (p *hostedHTTPAuthorizationProvider) SearchSubjects(context.Context, *core.SubjectSearchRequest) (*core.SubjectSearchResponse, error) {
+	return &core.SubjectSearchResponse{}, nil
+}
+
+func (p *hostedHTTPAuthorizationProvider) SearchActions(context.Context, *core.ActionSearchRequest) (*core.ActionSearchResponse, error) {
+	return &core.ActionSearchResponse{}, nil
+}
+
+func (p *hostedHTTPAuthorizationProvider) GetMetadata(context.Context) (*core.AuthorizationMetadata, error) {
+	return &core.AuthorizationMetadata{}, nil
+}
+
+func (p *hostedHTTPAuthorizationProvider) ReadRelationships(context.Context, *core.ReadRelationshipsRequest) (*core.ReadRelationshipsResponse, error) {
+	return &core.ReadRelationshipsResponse{}, nil
+}
+
+func (p *hostedHTTPAuthorizationProvider) WriteRelationships(context.Context, *core.WriteRelationshipsRequest) error {
+	return nil
+}
+
+func (p *hostedHTTPAuthorizationProvider) GetActiveModel(context.Context) (*core.GetActiveModelResponse, error) {
+	return &core.GetActiveModelResponse{}, nil
+}
+
+func (p *hostedHTTPAuthorizationProvider) ListModels(context.Context, *core.ListModelsRequest) (*core.ListModelsResponse, error) {
+	return &core.ListModelsResponse{}, nil
+}
+
+func (p *hostedHTTPAuthorizationProvider) WriteModel(context.Context, *core.WriteModelRequest) (*core.AuthorizationModelRef, error) {
+	return &core.AuthorizationModelRef{}, nil
+}
+
 type capturingPluginRuntime struct {
 	provider *pluginruntime.LocalProvider
 
@@ -2620,6 +2668,77 @@ func TestPluginWorkflowManagerExposeHostSocketEnv(t *testing.T) {
 	}
 }
 
+func TestPluginHostedHTTPBindingsExposeAuthorizationSocketEnv(t *testing.T) {
+	t.Parallel()
+
+	bin := buildEchoPluginBinary(t)
+	manifestRoot := writeStaticCatalog(t, &catalog.Catalog{
+		Name: "echo",
+		Operations: []catalog.CatalogOperation{
+			{ID: "read_env", Method: http.MethodGet, Parameters: []catalog.CatalogParameter{{Name: "name", Type: "string", Required: true}}},
+		},
+	})
+	manifest := newExecutableManifest("Echo", "Hosted HTTP subject resolution env")
+	manifest.Spec.SecuritySchemes = map[string]*providermanifestv1.HTTPSecurityScheme{
+		"public": {
+			Type: providermanifestv1.HTTPSecuritySchemeTypeNone,
+		},
+	}
+	manifest.Spec.HTTP = map[string]*providermanifestv1.HTTPBinding{
+		"command": {
+			Path:     "/command",
+			Method:   http.MethodPost,
+			Security: "public",
+			Target:   "read_env",
+			RequestBody: &providermanifestv1.HTTPRequestBody{
+				Content: map[string]*providermanifestv1.HTTPMediaType{
+					"application/x-www-form-urlencoded": {},
+				},
+			},
+		},
+	}
+
+	cfg := &config.Config{
+		Plugins: map[string]*config.ProviderEntry{
+			"echo": {
+				Command:              bin,
+				Args:                 []string{"provider"},
+				ResolvedManifest:     manifest,
+				ResolvedManifestPath: filepath.Join(manifestRoot, "manifest.yaml"),
+			},
+		},
+	}
+
+	providers, _, err := buildProvidersStrict(context.Background(), cfg, NewFactoryRegistry(), Deps{
+		AuthorizationProvider: &hostedHTTPAuthorizationProvider{},
+	})
+	if err != nil {
+		t.Fatalf("buildProvidersStrict: %v", err)
+	}
+	defer func() { _ = CloseProviders(providers) }()
+
+	prov, err := providers.Get("echo")
+	if err != nil {
+		t.Fatalf("providers.Get(echo): %v", err)
+	}
+
+	result, err := prov.Execute(context.Background(), "read_env", map[string]any{"name": providerhost.DefaultAuthorizationSocketEnv}, "")
+	if err != nil {
+		t.Fatalf("Execute read_env: %v", err)
+	}
+
+	var env struct {
+		Value string `json:"value"`
+		Found bool   `json:"found"`
+	}
+	if err := json.Unmarshal([]byte(result.Body), &env); err != nil {
+		t.Fatalf("json.Unmarshal: %v", err)
+	}
+	if !env.Found || env.Value == "" {
+		t.Fatalf("authorization env %q should be set for executable plugins with hosted HTTP bindings", providerhost.DefaultAuthorizationSocketEnv)
+	}
+}
+
 func TestPluginWorkflowManagerCRUDUsesRequestContext(t *testing.T) {
 	t.Parallel()
 
@@ -4503,14 +4622,8 @@ func TestPluginRuntimeConfigRejectsMissingHostServiceTunnelCapability(t *testing
 		},
 	})
 	manifest := newExecutableManifest("Echo", "Echoes back the input parameters")
-	runtimeProvider := &staticCapabilityPluginRuntime{
-		inner: pluginruntime.NewLocalProvider(),
-		capabilities: pluginruntime.Capabilities{
-			HostedPluginRuntime: true,
-			ProviderGRPCTunnel:  true,
-			HostnameProxyEgress: true,
-		},
-	}
+	runtimeProvider := newCapturingBundlePluginRuntime()
+	runtimeProvider.capabilities.HostnameProxyEgress = true
 	factories := NewFactoryRegistry()
 	factories.Runtime = func(context.Context, string, *config.RuntimeProviderEntry, Deps) (pluginruntime.Provider, error) {
 		return runtimeProvider, nil
@@ -4546,6 +4659,122 @@ func TestPluginRuntimeConfigRejectsMissingHostServiceTunnelCapability(t *testing
 	})
 	if err == nil || !strings.Contains(err.Error(), "host service tunnels") {
 		t.Fatalf("buildProvidersStrict error = %v, want missing host service tunnels", err)
+	}
+}
+
+func TestPluginRuntimeHostedHTTPDoesNotRequireHostServiceTunnelCapabilityForAuthorizationLookup(t *testing.T) {
+	t.Parallel()
+
+	bin := buildEchoPluginBinary(t)
+	manifestRoot := writeStaticCatalog(t, &catalog.Catalog{
+		Name: "echoext",
+		Operations: []catalog.CatalogOperation{
+			{ID: "read_env", Method: http.MethodGet, Parameters: []catalog.CatalogParameter{{Name: "name", Type: "string", Required: true}}},
+		},
+	})
+	manifest := newExecutableManifest("Echo", "Hosted HTTP auth lookup env")
+	manifest.Spec.SecuritySchemes = map[string]*providermanifestv1.HTTPSecurityScheme{
+		"public": {
+			Type: providermanifestv1.HTTPSecuritySchemeTypeNone,
+		},
+	}
+	manifest.Spec.HTTP = map[string]*providermanifestv1.HTTPBinding{
+		"command": {
+			Path:     "/command",
+			Method:   http.MethodPost,
+			Security: "public",
+			Target:   "read_env",
+			RequestBody: &providermanifestv1.HTTPRequestBody{
+				Content: map[string]*providermanifestv1.HTTPMediaType{
+					"application/x-www-form-urlencoded": {},
+				},
+			},
+		},
+	}
+	artifactPath := filepath.Join(manifestRoot, filepath.Base(bin))
+	artifactBytes, err := os.ReadFile(bin)
+	if err != nil {
+		t.Fatalf("os.ReadFile(bin): %v", err)
+	}
+	if err := os.WriteFile(artifactPath, artifactBytes, 0o755); err != nil {
+		t.Fatalf("os.WriteFile(artifact): %v", err)
+	}
+	digest, err := providerpkg.FileSHA256(artifactPath)
+	if err != nil {
+		t.Fatalf("providerpkg.FileSHA256(artifact): %v", err)
+	}
+	manifest.Artifacts = []providermanifestv1.Artifact{{
+		OS:     runtime.GOOS,
+		Arch:   runtime.GOARCH,
+		Path:   filepath.Base(artifactPath),
+		SHA256: digest,
+	}}
+	manifest.Entrypoint = &providermanifestv1.Entrypoint{ArtifactPath: filepath.Base(artifactPath)}
+	manifestData, err := providerpkg.EncodeManifestFormat(manifest, providerpkg.ManifestFormatYAML)
+	if err != nil {
+		t.Fatalf("providerpkg.EncodeManifestFormat(manifest): %v", err)
+	}
+	manifestPath := filepath.Join(manifestRoot, "manifest.yaml")
+	if err := os.WriteFile(manifestPath, manifestData, 0o644); err != nil {
+		t.Fatalf("os.WriteFile(manifest): %v", err)
+	}
+
+	runtimeProvider := newCapturingBundlePluginRuntime()
+	runtimeProvider.capabilities.HostnameProxyEgress = true
+	factories := NewFactoryRegistry()
+	factories.Runtime = func(context.Context, string, *config.RuntimeProviderEntry, Deps) (pluginruntime.Provider, error) {
+		return runtimeProvider, nil
+	}
+	cfg := &config.Config{
+		Server: config.ServerConfig{
+			Runtime: config.ServerRuntimeConfig{Provider: "hosted"},
+		},
+		Runtime: config.RuntimeConfig{
+			Providers: map[string]*config.RuntimeProviderEntry{
+				"hosted": {
+					Driver: config.RuntimeProviderDriver("capture"),
+				},
+			},
+		},
+		Plugins: map[string]*config.ProviderEntry{
+			"echoext": {
+				Command:              bin,
+				Args:                 []string{"provider"},
+				ResolvedManifest:     manifest,
+				ResolvedManifestPath: manifestPath,
+				Runtime:              &config.PluginRuntimeConfig{},
+			},
+		},
+	}
+
+	providers, _, err := buildProvidersStrict(context.Background(), cfg, factories, Deps{
+		AuthorizationProvider: &hostedHTTPAuthorizationProvider{},
+		PluginRuntimeRegistry: newPluginRuntimeRegistry(cfg, factories.Runtime, Deps{}),
+	})
+	if err != nil {
+		t.Fatalf("buildProvidersStrict: %v", err)
+	}
+	defer func() { _ = CloseProviders(providers) }()
+
+	prov, err := providers.Get("echoext")
+	if err != nil {
+		t.Fatalf("providers.Get(echoext): %v", err)
+	}
+
+	result, err := prov.Execute(context.Background(), "read_env", map[string]any{"name": providerhost.DefaultAuthorizationSocketEnv}, "")
+	if err != nil {
+		t.Fatalf("Execute read_env: %v", err)
+	}
+
+	var env struct {
+		Value string `json:"value"`
+		Found bool   `json:"found"`
+	}
+	if err := json.Unmarshal([]byte(result.Body), &env); err != nil {
+		t.Fatalf("json.Unmarshal: %v", err)
+	}
+	if env.Found || env.Value != "" {
+		t.Fatalf("authorization env %q should not be set when the runtime lacks host service tunnels", providerhost.DefaultAuthorizationSocketEnv)
 	}
 }
 

--- a/gestaltd/internal/bootstrap/provider_build.go
+++ b/gestaltd/internal/bootstrap/provider_build.go
@@ -1128,6 +1128,9 @@ func buildPluginRuntimeHostServices(name string, entry *config.ProviderEntry, de
 		}
 		hostServices = append(hostServices, services...)
 	}
+	if deps.AuthorizationProvider != nil && len(entry.EffectiveHTTPBindings()) > 0 {
+		hostServices = append(hostServices, buildPluginAuthorizationHostService(deps.AuthorizationProvider))
+	}
 	hostServices = append(hostServices, buildPluginWorkflowManagerHostService(name, deps, invTokens))
 	if len(entry.Invokes) > 0 {
 		hostServices = append(hostServices, buildPluginInvokerHostService(name, entry, deps, invTokens))
@@ -1388,6 +1391,15 @@ func buildPluginWorkflowManagerHostService(pluginName string, deps Deps, tokens 
 		EnvVar: providerhost.DefaultWorkflowManagerSocketEnv,
 		Register: func(srv *grpc.Server) {
 			proto.RegisterWorkflowManagerHostServer(srv, providerhost.NewWorkflowManagerServer(pluginName, manager, tokens))
+		},
+	}
+}
+
+func buildPluginAuthorizationHostService(provider core.AuthorizationProvider) providerhost.HostService {
+	return providerhost.HostService{
+		EnvVar: providerhost.DefaultAuthorizationSocketEnv,
+		Register: func(srv *grpc.Server) {
+			proto.RegisterAuthorizationProviderServer(srv, providerhost.NewAuthorizationProviderServer(provider))
 		},
 	}
 }

--- a/gestaltd/internal/providerhost/authorization_server.go
+++ b/gestaltd/internal/providerhost/authorization_server.go
@@ -1,0 +1,42 @@
+package providerhost
+
+import (
+	"context"
+
+	proto "github.com/valon-technologies/gestalt/sdk/go/gen/v1"
+	"github.com/valon-technologies/gestalt/server/core"
+	"google.golang.org/grpc/codes"
+	"google.golang.org/grpc/status"
+	"google.golang.org/protobuf/types/known/emptypb"
+)
+
+const DefaultAuthorizationSocketEnv = "GESTALT_AUTHORIZATION_SOCKET"
+
+type authorizationProviderServer struct {
+	proto.UnimplementedAuthorizationProviderServer
+	provider core.AuthorizationProvider
+}
+
+func NewAuthorizationProviderServer(provider core.AuthorizationProvider) proto.AuthorizationProviderServer {
+	return &authorizationProviderServer{provider: provider}
+}
+
+func (s *authorizationProviderServer) SearchSubjects(ctx context.Context, req *proto.SubjectSearchRequest) (*proto.SubjectSearchResponse, error) {
+	if req == nil {
+		return nil, status.Error(codes.InvalidArgument, "request is required")
+	}
+	resp, err := s.provider.SearchSubjects(ctx, req)
+	if err != nil {
+		return nil, status.Errorf(codes.Unknown, "search subjects: %v", err)
+	}
+	if resp == nil {
+		return nil, status.Error(codes.Internal, "authorization provider returned nil response")
+	}
+	return resp, nil
+}
+
+func (s *authorizationProviderServer) GetMetadata(context.Context, *emptypb.Empty) (*proto.AuthorizationMetadata, error) {
+	return &proto.AuthorizationMetadata{
+		Capabilities: []string{"search_subjects"},
+	}, nil
+}

--- a/gestaltd/internal/providerhost/http_subject_client.go
+++ b/gestaltd/internal/providerhost/http_subject_client.go
@@ -1,0 +1,104 @@
+package providerhost
+
+import (
+	"context"
+	"encoding/base64"
+	"encoding/json"
+	"fmt"
+	"net/http"
+
+	proto "github.com/valon-technologies/gestalt/sdk/go/gen/v1"
+	"github.com/valon-technologies/gestalt/server/core"
+)
+
+var _ core.HTTPSubjectResolver = (*remoteProviderBase)(nil)
+
+func (p *remoteProviderBase) ResolveHTTPSubject(ctx context.Context, req *core.HTTPSubjectResolveRequest) (*core.HTTPResolvedSubject, error) {
+	if p == nil || p.client == nil || req == nil {
+		return nil, nil
+	}
+
+	params, err := structFromMap(map[string]any{
+		"binding":          req.Binding,
+		"method":           req.Method,
+		"path":             req.Path,
+		"content_type":     req.ContentType,
+		"headers":          mapStringSlices(req.Headers),
+		"query":            mapStringSlices(req.Query),
+		"params":           req.Params,
+		"raw_body_base64":  base64.StdEncoding.EncodeToString(req.RawBody),
+		"security_scheme":  req.SecurityScheme,
+		"verified_subject": req.VerifiedSubject,
+		"verified_claims":  req.VerifiedClaims,
+	})
+	if err != nil {
+		return nil, err
+	}
+
+	reqCtx, err := requestContextProto(ctx)
+	if err != nil {
+		return nil, err
+	}
+
+	resp, err := p.client.Execute(ctx, &proto.ExecuteRequest{
+		Operation: proto.InternalResolveHTTPSubjectOperation,
+		Params:    params,
+		Context:   reqCtx,
+	})
+	if err != nil {
+		return nil, err
+	}
+
+	switch status := int(resp.GetStatus()); {
+	case status == http.StatusNotFound && isUnknownOperationBody(resp.GetBody()):
+		return nil, nil
+	case status == http.StatusNoContent:
+		return nil, nil
+	case status != http.StatusOK:
+		return nil, &core.HTTPSubjectResolveError{
+			Status:  status,
+			Message: operationErrorMessage(resp.GetBody()),
+		}
+	}
+
+	var subject core.HTTPResolvedSubject
+	if err := json.Unmarshal([]byte(resp.GetBody()), &subject); err != nil {
+		return nil, fmt.Errorf("decode resolved http subject: %w", err)
+	}
+	if subject.ID == "" {
+		return nil, nil
+	}
+	return &subject, nil
+}
+
+func mapStringSlices[V ~map[string][]string](values V) map[string]any {
+	if len(values) == 0 {
+		return nil
+	}
+	out := make(map[string]any, len(values))
+	for key, item := range values {
+		copied := make([]string, len(item))
+		copy(copied, item)
+		out[key] = copied
+	}
+	return out
+}
+
+func isUnknownOperationBody(body string) bool {
+	var payload map[string]string
+	if err := json.Unmarshal([]byte(body), &payload); err != nil {
+		return false
+	}
+	return payload["error"] == "unknown operation"
+}
+
+func operationErrorMessage(body string) string {
+	var payload map[string]string
+	if err := json.Unmarshal([]byte(body), &payload); err != nil {
+		return body
+	}
+	if msg := payload["error"]; msg != "" {
+		return msg
+	}
+	return body
+}

--- a/gestaltd/internal/server/http_binding_dispatch.go
+++ b/gestaltd/internal/server/http_binding_dispatch.go
@@ -56,12 +56,14 @@ func httpBindingContextValue(binding MountedHTTPBinding, verified *verifiedHTTPB
 	return map[string]any{"http": value}
 }
 
-func (s *Server) httpBindingOperationInvocation(ctx context.Context, binding MountedHTTPBinding, verified *verifiedHTTPBindingSender, parsed *parsedHTTPBindingRequest) (*core.OperationResult, error) {
+func (s *Server) httpBindingOperationInvocation(ctx context.Context, binding MountedHTTPBinding, p *principal.Principal, verified *verifiedHTTPBindingSender, parsed *parsedHTTPBindingRequest) (*core.OperationResult, error) {
 	params := map[string]any{}
 	if parsed != nil && parsed.Params != nil {
 		params = cloneAnyMap(parsed.Params)
 	}
-	p := s.httpBindingPrincipal(binding, verified)
+	if p == nil {
+		p = s.httpBindingPrincipal(binding, verified)
+	}
 	ctx = principal.WithPrincipal(ctx, p)
 	ctx = invocation.WithAccessContext(ctx, s.providerAccessContextWithContext(ctx, p, binding.PluginName))
 	ctx = invocation.WithWorkflowContext(ctx, httpBindingContextValue(binding, verified, parsed))
@@ -69,10 +71,10 @@ func (s *Server) httpBindingOperationInvocation(ctx context.Context, binding Mou
 	return s.invoker.Invoke(ctx, p, binding.PluginName, "", binding.Target, params)
 }
 
-func (s *Server) dispatchHTTPBindingAsync(binding MountedHTTPBinding, verified *verifiedHTTPBindingSender, parsed *parsedHTTPBindingRequest, requestMeta invocation.RequestMeta) {
+func (s *Server) dispatchHTTPBindingAsync(binding MountedHTTPBinding, p *principal.Principal, verified *verifiedHTTPBindingSender, parsed *parsedHTTPBindingRequest, requestMeta invocation.RequestMeta) {
 	go func() {
 		ctx := invocation.WithRequestMeta(context.Background(), requestMeta)
-		if _, err := s.httpBindingOperationInvocation(ctx, binding, verified, parsed); err != nil {
+		if _, err := s.httpBindingOperationInvocation(ctx, binding, p, verified, parsed); err != nil {
 			slog.Error("http binding async operation failed", "plugin", binding.PluginName, "binding", binding.Name, "operation", binding.Target, "error", err)
 		}
 	}()

--- a/gestaltd/internal/server/http_binding_handler.go
+++ b/gestaltd/internal/server/http_binding_handler.go
@@ -53,17 +53,34 @@ func (s *Server) handleHTTPBinding(binding MountedHTTPBinding, w http.ResponseWr
 		return
 	}
 
+	resolvedPrincipal, err := s.resolveHTTPBindingPrincipal(r.Context(), binding, r, verified, parsed)
+	if err != nil {
+		var requestErr *httpBindingRequestError
+		if errors.As(err, &requestErr) {
+			if requestErr.status >= 500 {
+				slog.ErrorContext(r.Context(), "http binding subject resolution failed", "plugin", binding.PluginName, "binding", binding.Name, "error", err)
+			} else {
+				slog.WarnContext(r.Context(), "http binding subject resolution rejected request", "plugin", binding.PluginName, "binding", binding.Name, "error", err)
+			}
+			writeError(w, requestErr.status, requestErr.message)
+			return
+		}
+		slog.ErrorContext(r.Context(), "http binding subject resolution failed", "plugin", binding.PluginName, "binding", binding.Name, "error", err)
+		writeError(w, http.StatusInternalServerError, "failed to resolve http binding subject")
+		return
+	}
+
 	if binding.Ack != nil {
 		if err := writeHTTPBindingAck(w, binding.Ack); err != nil {
 			slog.ErrorContext(r.Context(), "write http binding ack", "plugin", binding.PluginName, "binding", binding.Name, "error", err)
 			writeError(w, http.StatusInternalServerError, "failed to write http binding response")
 			return
 		}
-		s.dispatchHTTPBindingAsync(binding, verified, parsed, invocation.RequestMetaFromContext(r.Context()))
+		s.dispatchHTTPBindingAsync(binding, resolvedPrincipal, verified, parsed, invocation.RequestMetaFromContext(r.Context()))
 		return
 	}
 
-	result, err := s.httpBindingOperationInvocation(r.Context(), binding, verified, parsed)
+	result, err := s.httpBindingOperationInvocation(r.Context(), binding, resolvedPrincipal, verified, parsed)
 	if err != nil {
 		s.writeInvocationError(w, r, binding.PluginName, binding.Target, err)
 		return

--- a/gestaltd/internal/server/http_binding_subject.go
+++ b/gestaltd/internal/server/http_binding_subject.go
@@ -1,0 +1,164 @@
+package server
+
+import (
+	"context"
+	"errors"
+	"net/http"
+	"net/url"
+	"strings"
+
+	"github.com/valon-technologies/gestalt/server/core"
+	"github.com/valon-technologies/gestalt/server/internal/invocation"
+	"github.com/valon-technologies/gestalt/server/internal/principal"
+)
+
+func (s *Server) resolveHTTPBindingPrincipal(ctx context.Context, binding MountedHTTPBinding, r *http.Request, verified *verifiedHTTPBindingSender, parsed *parsedHTTPBindingRequest) (*principal.Principal, error) {
+	bindingPrincipal := s.httpBindingPrincipal(binding, verified)
+
+	prov, err := s.providers.Get(binding.PluginName)
+	if err != nil {
+		return nil, err
+	}
+	resolver, ok := prov.(core.HTTPSubjectResolver)
+	if !ok {
+		return bindingPrincipal, nil
+	}
+
+	resolveCtx := principal.WithPrincipal(ctx, bindingPrincipal)
+	resolveCtx = invocation.WithAccessContext(resolveCtx, s.providerAccessContextWithContext(resolveCtx, bindingPrincipal, binding.PluginName))
+	resolveCtx = invocation.WithWorkflowContext(resolveCtx, httpBindingContextValue(binding, verified, parsed))
+	resolveCtx = invocation.WithInvocationSurface(resolveCtx, invocation.InvocationSurfaceHTTP)
+
+	resolved, err := resolver.ResolveHTTPSubject(resolveCtx, &core.HTTPSubjectResolveRequest{
+		Binding:         binding.Name,
+		Method:          requestMethod(r, binding),
+		Path:            requestPath(r, binding),
+		ContentType:     parsedContentType(parsed),
+		Headers:         requestHeaders(r),
+		Query:           requestQuery(r),
+		Params:          parsedParams(parsed),
+		RawBody:         parsedRawBody(parsed),
+		SecurityScheme:  verifiedScheme(verified),
+		VerifiedSubject: verifiedSubject(verified),
+		VerifiedClaims:  verifiedClaims(verified),
+	})
+	if err != nil {
+		var resolveErr *core.HTTPSubjectResolveError
+		if errors.As(err, &resolveErr) {
+			status := resolveErr.Status
+			if status < http.StatusBadRequest {
+				status = http.StatusBadRequest
+			}
+			return nil, newHTTPBindingRequestError(status, resolveErr.Message, err)
+		}
+		return nil, newHTTPBindingRequestError(http.StatusInternalServerError, "failed to resolve http subject", err)
+	}
+	if resolved == nil || strings.TrimSpace(resolved.ID) == "" {
+		return bindingPrincipal, nil
+	}
+	if principal.IsSystemSubjectID(strings.TrimSpace(resolved.ID)) {
+		return nil, newHTTPBindingRequestError(http.StatusInternalServerError, "invalid resolved http subject", errors.New("resolved subject uses reserved system namespace"))
+	}
+
+	p := principal.Canonicalize(&principal.Principal{
+		SubjectID:   strings.TrimSpace(resolved.ID),
+		DisplayName: strings.TrimSpace(resolved.DisplayName),
+		Source:      principal.ParseSource(strings.TrimSpace(resolved.AuthSource)),
+	})
+	switch strings.TrimSpace(resolved.Kind) {
+	case string(principal.KindUser):
+		p.Kind = principal.KindUser
+	case string(principal.KindWorkload):
+		p.Kind = principal.KindWorkload
+	}
+	return p, nil
+}
+
+func requestMethod(r *http.Request, binding MountedHTTPBinding) string {
+	if r != nil && strings.TrimSpace(r.Method) != "" {
+		return r.Method
+	}
+	return binding.Method
+}
+
+func requestPath(r *http.Request, binding MountedHTTPBinding) string {
+	if r != nil && r.URL != nil && strings.TrimSpace(r.URL.Path) != "" {
+		return r.URL.Path
+	}
+	return binding.Path
+}
+
+func requestHeaders(r *http.Request) http.Header {
+	if r == nil {
+		return nil
+	}
+	return r.Header.Clone()
+}
+
+func requestQuery(r *http.Request) url.Values {
+	if r == nil || r.URL == nil {
+		return nil
+	}
+	return cloneURLValues(r.URL.Query())
+}
+
+func parsedContentType(parsed *parsedHTTPBindingRequest) string {
+	if parsed == nil {
+		return ""
+	}
+	return parsed.ContentType
+}
+
+func parsedParams(parsed *parsedHTTPBindingRequest) map[string]any {
+	if parsed == nil {
+		return nil
+	}
+	return cloneAnyMap(parsed.Params)
+}
+
+func parsedRawBody(parsed *parsedHTTPBindingRequest) []byte {
+	if parsed == nil || len(parsed.RawBody) == 0 {
+		return nil
+	}
+	body := make([]byte, len(parsed.RawBody))
+	copy(body, parsed.RawBody)
+	return body
+}
+
+func verifiedScheme(verified *verifiedHTTPBindingSender) string {
+	if verified == nil {
+		return ""
+	}
+	return verified.Scheme
+}
+
+func verifiedSubject(verified *verifiedHTTPBindingSender) string {
+	if verified == nil {
+		return ""
+	}
+	return verified.Subject
+}
+
+func verifiedClaims(verified *verifiedHTTPBindingSender) map[string]string {
+	if verified == nil || len(verified.Claims) == 0 {
+		return nil
+	}
+	claims := make(map[string]string, len(verified.Claims))
+	for key, value := range verified.Claims {
+		claims[key] = value
+	}
+	return claims
+}
+
+func cloneURLValues(src url.Values) url.Values {
+	if len(src) == 0 {
+		return nil
+	}
+	dst := make(url.Values, len(src))
+	for key, values := range src {
+		copied := make([]string, len(values))
+		copy(copied, values)
+		dst[key] = copied
+	}
+	return dst
+}

--- a/gestaltd/internal/server/server_test.go
+++ b/gestaltd/internal/server/server_test.go
@@ -12652,6 +12652,69 @@ func TestHostedHTTPBinding_APIKeyQueryDoesNotLeakCredentialParam(t *testing.T) {
 	}
 }
 
+func TestHostedHTTPBinding_RejectsReservedSystemResolvedSubject(t *testing.T) {
+	t.Parallel()
+
+	invoked := make(chan struct{}, 1)
+	provider := &stubIntegrationWithResolvedSubject{
+		stubIntegrationWithOps: stubIntegrationWithOps{
+			StubIntegration: coretesting.StubIntegration{
+				N:        "events",
+				ConnMode: core.ConnectionModeNone,
+				ExecuteFn: func(_ context.Context, op string, params map[string]any, _ string) (*core.OperationResult, error) {
+					invoked <- struct{}{}
+					return &core.OperationResult{Status: http.StatusOK, Body: `{"accepted":true}`}, nil
+				},
+			},
+			ops: []core.Operation{{Name: "handle_event", Method: http.MethodPost}},
+		},
+		resolveFn: func(context.Context, *core.HTTPSubjectResolveRequest) (*core.HTTPResolvedSubject, error) {
+			return &core.HTTPResolvedSubject{ID: "system:admin"}, nil
+		},
+	}
+
+	ts := newTestServer(t, func(cfg *server.Config) {
+		cfg.Providers = testutil.NewProviderRegistry(t, provider)
+		cfg.PluginDefs = map[string]*config.ProviderEntry{
+			"events": {
+				SecuritySchemes: map[string]*config.HTTPSecurityScheme{
+					"public": {Type: providermanifestv1.HTTPSecuritySchemeTypeNone},
+				},
+				HTTP: map[string]*config.HTTPBinding{
+					"event": {
+						Path:     "/event",
+						Method:   http.MethodPost,
+						Security: "public",
+						Target:   "handle_event",
+					},
+				},
+			},
+		}
+		cfg.Authorizer = mustAuthorizer(t, config.AuthorizationConfig{}, cfg.Providers, cfg.PluginDefs, nil)
+	})
+	testutil.CloseOnCleanup(t, ts)
+
+	req, err := http.NewRequest(http.MethodPost, ts.URL+"/api/v1/events/event", nil)
+	if err != nil {
+		t.Fatalf("NewRequest: %v", err)
+	}
+
+	resp, err := http.DefaultClient.Do(req)
+	if err != nil {
+		t.Fatalf("http binding request: %v", err)
+	}
+	defer func() { _ = resp.Body.Close() }()
+	if resp.StatusCode != http.StatusInternalServerError {
+		t.Fatalf("status = %d, want %d", resp.StatusCode, http.StatusInternalServerError)
+	}
+
+	select {
+	case <-invoked:
+		t.Fatal("operation should not execute when resolver returns a reserved system subject")
+	case <-time.After(200 * time.Millisecond):
+	}
+}
+
 func TestHostedHTTPBinding_RejectsGenericOperationRouteConflicts(t *testing.T) {
 	t.Parallel()
 
@@ -13031,6 +13094,18 @@ type stubIntegrationWithOps struct {
 
 func (s *stubIntegrationWithOps) Catalog() *catalog.Catalog {
 	return serverTestCatalogFromOperations(s.N, s.ops)
+}
+
+type stubIntegrationWithResolvedSubject struct {
+	stubIntegrationWithOps
+	resolveFn func(context.Context, *core.HTTPSubjectResolveRequest) (*core.HTTPResolvedSubject, error)
+}
+
+func (s *stubIntegrationWithResolvedSubject) ResolveHTTPSubject(ctx context.Context, req *core.HTTPSubjectResolveRequest) (*core.HTTPResolvedSubject, error) {
+	if s.resolveFn != nil {
+		return s.resolveFn(ctx, req)
+	}
+	return nil, nil
 }
 
 type stubIntegrationWithCatalog struct {

--- a/sdk/go/authorization_client.go
+++ b/sdk/go/authorization_client.go
@@ -1,0 +1,98 @@
+package gestalt
+
+import (
+	"context"
+	"fmt"
+	"os"
+	"sync"
+	"time"
+
+	proto "github.com/valon-technologies/gestalt/sdk/go/gen/v1"
+	"google.golang.org/grpc"
+	"google.golang.org/grpc/credentials/insecure"
+	"google.golang.org/protobuf/types/known/emptypb"
+)
+
+const EnvAuthorizationSocket = "GESTALT_AUTHORIZATION_SOCKET"
+
+type AuthorizationClient struct {
+	client proto.AuthorizationProviderClient
+}
+
+var sharedAuthorizationTransport struct {
+	mu         sync.Mutex
+	socketPath string
+	conn       *grpc.ClientConn
+	client     proto.AuthorizationProviderClient
+}
+
+func Authorization() (*AuthorizationClient, error) {
+	socketPath := os.Getenv(EnvAuthorizationSocket)
+	if socketPath == "" {
+		return nil, fmt.Errorf("authorization: %s is not set", EnvAuthorizationSocket)
+	}
+
+	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	defer cancel()
+
+	client, err := sharedAuthorizationClient(ctx, socketPath)
+	if err != nil {
+		return nil, err
+	}
+	return &AuthorizationClient{client: client}, nil
+}
+
+func sharedAuthorizationClient(ctx context.Context, socketPath string) (proto.AuthorizationProviderClient, error) {
+	sharedAuthorizationTransport.mu.Lock()
+	if sharedAuthorizationTransport.conn != nil && sharedAuthorizationTransport.socketPath == socketPath {
+		client := sharedAuthorizationTransport.client
+		sharedAuthorizationTransport.mu.Unlock()
+		return client, nil
+	}
+	sharedAuthorizationTransport.mu.Unlock()
+
+	conn, err := grpc.DialContext(ctx, "unix:"+socketPath,
+		grpc.WithTransportCredentials(insecure.NewCredentials()),
+		grpc.WithBlock(),
+	)
+	if err != nil {
+		return nil, fmt.Errorf("authorization: connect to host: %w", err)
+	}
+
+	client := proto.NewAuthorizationProviderClient(conn)
+
+	sharedAuthorizationTransport.mu.Lock()
+	defer sharedAuthorizationTransport.mu.Unlock()
+
+	if sharedAuthorizationTransport.conn != nil && sharedAuthorizationTransport.socketPath == socketPath {
+		_ = conn.Close()
+		return sharedAuthorizationTransport.client, nil
+	}
+	if sharedAuthorizationTransport.conn != nil {
+		_ = sharedAuthorizationTransport.conn.Close()
+	}
+
+	sharedAuthorizationTransport.socketPath = socketPath
+	sharedAuthorizationTransport.conn = conn
+	sharedAuthorizationTransport.client = client
+	return client, nil
+}
+
+func (c *AuthorizationClient) Close() error { return nil }
+
+func (c *AuthorizationClient) SearchSubjects(ctx context.Context, req *SubjectSearchRequest) (*SubjectSearchResponse, error) {
+	if c == nil || c.client == nil {
+		return nil, fmt.Errorf("authorization: client is not initialized")
+	}
+	if req == nil {
+		return nil, fmt.Errorf("authorization: request is required")
+	}
+	return c.client.SearchSubjects(ctx, req)
+}
+
+func (c *AuthorizationClient) GetMetadata(ctx context.Context) (*AuthorizationMetadata, error) {
+	if c == nil || c.client == nil {
+		return nil, fmt.Errorf("authorization: client is not initialized")
+	}
+	return c.client.GetMetadata(ctx, &emptypb.Empty{})
+}

--- a/sdk/go/gen/v1/internal_operations.go
+++ b/sdk/go/gen/v1/internal_operations.go
@@ -1,0 +1,3 @@
+package proto
+
+const InternalResolveHTTPSubjectOperation = "__gestalt_internal_resolve_http_subject__"

--- a/sdk/go/http_subject.go
+++ b/sdk/go/http_subject.go
@@ -1,0 +1,30 @@
+package gestalt
+
+import (
+	"context"
+	"net/http"
+	"net/url"
+)
+
+// HTTPSubjectRequest carries one verified hosted HTTP request into an optional
+// plugin-local subject resolution hook.
+type HTTPSubjectRequest struct {
+	Binding         string
+	Method          string
+	Path            string
+	ContentType     string
+	Headers         http.Header
+	Query           url.Values
+	Params          map[string]any
+	RawBody         []byte
+	SecurityScheme  string
+	VerifiedSubject string
+	VerifiedClaims  map[string]string
+}
+
+// HTTPSubjectResolver is implemented by providers that can map a verified
+// hosted HTTP request to a concrete Gestalt subject before the target
+// operation is authorized and executed.
+type HTTPSubjectResolver interface {
+	ResolveHTTPSubject(ctx context.Context, req HTTPSubjectRequest) (*Subject, error)
+}

--- a/sdk/go/provider_server.go
+++ b/sdk/go/provider_server.go
@@ -2,8 +2,11 @@ package gestalt
 
 import (
 	"context"
+	"encoding/base64"
+	"encoding/json"
 	"fmt"
 	"net/http"
+	"net/url"
 
 	proto "github.com/valon-technologies/gestalt/sdk/go/gen/v1"
 	"google.golang.org/grpc/codes"
@@ -79,6 +82,9 @@ func (s *ProviderServer) Execute(ctx context.Context, req *proto.ExecuteRequest)
 	if len(req.GetConnectionParams()) > 0 {
 		ctx = WithConnectionParams(ctx, req.GetConnectionParams())
 	}
+	if req.GetOperation() == proto.InternalResolveHTTPSubjectOperation {
+		return s.resolveHTTPSubject(ctx, req.GetParams().AsMap()), nil
+	}
 	result, err := s.executeFn(ctx, req.GetOperation(), req.GetParams().AsMap(), req.GetToken())
 	if err != nil {
 		return operationResultProto(operationResultFromError(err)), nil
@@ -87,6 +93,72 @@ func (s *ProviderServer) Execute(ctx context.Context, req *proto.ExecuteRequest)
 		return operationResultProto(operationResult(http.StatusInternalServerError, nilResultMessage)), nil
 	}
 	return operationResultProto(result), nil
+}
+
+type httpSubjectExecuteRequest struct {
+	Binding         string              `json:"binding"`
+	Method          string              `json:"method"`
+	Path            string              `json:"path"`
+	ContentType     string              `json:"content_type"`
+	Headers         map[string][]string `json:"headers"`
+	Query           map[string][]string `json:"query"`
+	Params          map[string]any      `json:"params"`
+	RawBodyBase64   string              `json:"raw_body_base64"`
+	SecurityScheme  string              `json:"security_scheme"`
+	VerifiedSubject string              `json:"verified_subject"`
+	VerifiedClaims  map[string]string   `json:"verified_claims"`
+}
+
+func (s *ProviderServer) resolveHTTPSubject(ctx context.Context, rawParams map[string]any) *proto.OperationResult {
+	return operationResultProto(protectedOperationResult(proto.InternalResolveHTTPSubjectOperation, func() (*OperationResult, error) {
+		resolver, ok := s.provider.(HTTPSubjectResolver)
+		if !ok {
+			return operationResult(http.StatusNotFound, unknownOperationMessage), nil
+		}
+
+		var payload httpSubjectExecuteRequest
+		if err := decodeParams(rawParams, &payload); err != nil {
+			return nil, newOperationError(http.StatusBadRequest, "decode http subject request", err)
+		}
+
+		var rawBody []byte
+		if payload.RawBodyBase64 != "" {
+			decoded, err := base64.StdEncoding.DecodeString(payload.RawBodyBase64)
+			if err != nil {
+				return nil, newOperationError(http.StatusBadRequest, "decode http subject raw body", err)
+			}
+			rawBody = decoded
+		}
+
+		subject, err := resolver.ResolveHTTPSubject(ctx, HTTPSubjectRequest{
+			Binding:         payload.Binding,
+			Method:          payload.Method,
+			Path:            payload.Path,
+			ContentType:     payload.ContentType,
+			Headers:         http.Header(payload.Headers),
+			Query:           url.Values(payload.Query),
+			Params:          payload.Params,
+			RawBody:         rawBody,
+			SecurityScheme:  payload.SecurityScheme,
+			VerifiedSubject: payload.VerifiedSubject,
+			VerifiedClaims:  payload.VerifiedClaims,
+		})
+		if err != nil {
+			return nil, err
+		}
+		if subject == nil {
+			return &OperationResult{Status: http.StatusNoContent}, nil
+		}
+
+		body, err := json.Marshal(subject)
+		if err != nil {
+			return nil, newOperationError(http.StatusInternalServerError, "marshal http subject response", err)
+		}
+		return &OperationResult{
+			Status: http.StatusOK,
+			Body:   string(body),
+		}, nil
+	}))
 }
 
 func (s *ProviderServer) GetSessionCatalog(ctx context.Context, req *proto.GetSessionCatalogRequest) (*proto.GetSessionCatalogResponse, error) {

--- a/sdk/go/router.go
+++ b/sdk/go/router.go
@@ -46,6 +46,10 @@ func (r Request) WorkflowManager() (*WorkflowManagerClient, error) {
 	return WorkflowManager(r.invocationToken)
 }
 
+func (r Request) Authorization() (*AuthorizationClient, error) {
+	return Authorization()
+}
+
 // Response is the typed handler result marshaled into the provider response body.
 // A zero Status defaults to 200.
 type Response[T any] struct {

--- a/sdk/go/serve_test.go
+++ b/sdk/go/serve_test.go
@@ -113,6 +113,10 @@ type sessionCatalogStubProvider struct {
 	sessionCatalog *proto.Catalog
 }
 
+type panicHTTPSubjectProvider struct {
+	stubProvider
+}
+
 func (p *sessionCatalogStubProvider) CatalogForRequest(ctx context.Context, _ string) (*proto.Catalog, error) {
 	cat := protoutil.Clone(p.sessionCatalog).(*proto.Catalog)
 	if cat != nil {
@@ -122,6 +126,14 @@ func (p *sessionCatalogStubProvider) CatalogForRequest(ctx context.Context, _ st
 		cat.DisplayName = subject.ID + "|" + credential.Mode + "|" + access.Policy + "|" + access.Role
 	}
 	return cat, nil
+}
+
+func (p *panicHTTPSubjectProvider) testOp(ctx context.Context, input stubInput, req gestalt.Request) (gestalt.Response[stubOutput], error) {
+	return p.stubProvider.testOp(ctx, input, req)
+}
+
+func (p *panicHTTPSubjectProvider) ResolveHTTPSubject(_ context.Context, _ gestalt.HTTPSubjectRequest) (*gestalt.Subject, error) {
+	panic("boom")
 }
 
 func TestProviderServerGetMetadata(t *testing.T) {
@@ -345,6 +357,37 @@ func TestProviderServerExecute(t *testing.T) {
 			}
 		})
 	}
+
+	t.Run("internal http subject panic", func(t *testing.T) {
+		panicHTTPSubjectRouter := gestalt.MustRouter(
+			gestalt.Register(
+				gestalt.Operation[stubInput, stubOutput]{
+					ID:     "test_op",
+					Method: http.MethodPost,
+				},
+				(*panicHTTPSubjectProvider).testOp,
+			),
+		)
+		client := newIntegrationProviderClient(t, &panicHTTPSubjectProvider{}, panicHTTPSubjectRouter)
+		params, err := structpb.NewStruct(map[string]any{"binding": "command"})
+		if err != nil {
+			t.Fatalf("NewStruct: %v", err)
+		}
+
+		resp, err := client.Execute(context.Background(), &proto.ExecuteRequest{
+			Operation: proto.InternalResolveHTTPSubjectOperation,
+			Params:    params,
+		})
+		if err != nil {
+			t.Fatalf("Execute: %v", err)
+		}
+		if resp.GetStatus() != http.StatusInternalServerError {
+			t.Fatalf("Status = %d, want %d", resp.GetStatus(), http.StatusInternalServerError)
+		}
+		if resp.GetBody() != `{"error":"internal error"}` {
+			t.Fatalf("Body = %q, want %q", resp.GetBody(), `{"error":"internal error"}`)
+		}
+	})
 }
 
 func TestProviderServerStartProvider(t *testing.T) {


### PR DESCRIPTION
## Summary
This adds the smallest host-supported path for running hosted HTTP bindings as a real subject without introducing a new shared `SubjectResolverProvider` or a new manifest knob.

Hosted HTTP now:
- calls a plugin-local Go hook before dispatch when the executable plugin implements it
- falls back to the existing binding principal when the hook is absent or returns `nil`
- lets the hook resolve subjects through the existing `AuthorizationProvider`
- runs the target operation and any downstream `Invoker` calls as the resolved subject

## New Interfaces
Go SDK:
```go
type HTTPSubjectRequest struct {
    Binding         string
    Method          string
    Path            string
    ContentType     string
    Headers         http.Header
    Query           url.Values
    Params          map[string]any
    RawBody         []byte
    SecurityScheme  string
    VerifiedSubject string
    VerifiedClaims  map[string]string
}

type HTTPSubjectResolver interface {
    ResolveHTTPSubject(ctx context.Context, req HTTPSubjectRequest) (*Subject, error)
}

func Authorization() (*AuthorizationClient, error)
```

Host/runtime plumbing:
- executable plugins with hosted HTTP bindings now receive `GESTALT_AUTHORIZATION_SOCKET`
- the host uses the internal execute operation `__gestalt_internal_resolve_http_subject__` to invoke the hook without changing the public provider RPC surface

## Example Usage
Plugin code:
```go
func (p *Provider) ResolveHTTPSubject(ctx context.Context, req gestalt.HTTPSubjectRequest) (*gestalt.Subject, error) {
    teamID, _ := req.Params["team_id"].(string)
    userID, _ := req.Params["user_id"].(string)
    if teamID == "" || userID == "" {
        return nil, gestalt.Error(http.StatusBadRequest, "missing slack subject fields")
    }

    authz, err := gestalt.Authorization()
    if err != nil {
        return nil, err
    }
    defer func() { _ = authz.Close() }()

    resp, err := authz.SearchSubjects(ctx, &gestalt.SubjectSearchRequest{
        SubjectType: "user",
        Resource: &gestalt.AuthorizationResource{
            Type: "slack_identity",
            Id:   fmt.Sprintf("team:%s:user:%s", teamID, userID),
        },
    })
    if err != nil {
        return nil, err
    }
    if len(resp.GetSubjects()) == 0 {
        return nil, gestalt.Error(http.StatusForbidden, "unmapped slack subject")
    }

    subject := resp.GetSubjects()[0]
    return &gestalt.Subject{ID: subject.GetId(), Kind: subject.GetType()}, nil
}
```

Hosted HTTP metadata remains code-first and unchanged:
```go
Router = gestalt.MustRouter(
    gestalt.Register(invokeRequestContextOperation, (*Provider).invokeRequestContext),
).WithManifestMetadata(gestalt.ManifestMetadata{
    SecuritySchemes: map[string]gestalt.HTTPSecurityScheme{
        "public": {Type: gestalt.HTTPSecuritySchemeTypeNone},
    },
    HTTP: map[string]gestalt.HTTPBinding{
        "resolve_subject": {
            Path:     "/resolve-subject",
            Method:   http.MethodPost,
            Security: "public",
            Target:   "invoke_request_context",
            RequestBody: &gestalt.HTTPRequestBody{
                Required: true,
                Content: map[string]gestalt.HTTPMediaType{
                    "application/x-www-form-urlencoded": {},
                },
            },
        },
    },
})
```

## Tests
Augmented existing similar test surfaces instead of adding isolated unit coverage:
- `go test ./internal/bootstrap -run TestPluginHostedHTTPBindingsExposeAuthorizationSocketEnv -count=1`
- `go test ./internal/providerhost ./internal/server ./internal/bootstrap -count=1`
- `go test ./cmd/gestaltd -run 'TestE2EServe(MountsGeneratedHostedHTTPBindingsForLocalSourcePlugin|HostedHTTPSubjectResolutionUsesAuthorizationAndInheritedInvocation)' -count=1`
- `go test ./...` in `sdk/go`

The new end-to-end case proves:
1. a hosted HTTP request enters a source plugin
2. the plugin resolves a real subject through the configured `AuthorizationProvider`
3. the target operation runs as that subject
4. a nested `Invoker` call inherits the same subject