### PR TITLE
runtime: finish hosted relay followups

### DIFF
--- a/gestaltd/internal/bootstrap/executable_plugin_test.go
+++ b/gestaltd/internal/bootstrap/executable_plugin_test.go
@@ -1,10 +1,13 @@
 package bootstrap
 
 import (
+	"bytes"
 	"context"
 	"crypto/tls"
 	"encoding/json"
+	"errors"
 	"fmt"
+	"io"
 	"maps"
 	"net"
 	"net/http"
@@ -388,12 +391,26 @@ func (r *capturingBundlePluginRuntime) startFakeHostedPlugin(req pluginruntime.S
 					},
 				},
 				{
+					ID:     "s3_roundtrip",
+					Method: http.MethodPost,
+					Parameters: []catalog.CatalogParameter{
+						{Name: "binding", Type: "string"},
+						{Name: "bucket", Type: "string", Required: true},
+						{Name: "key", Type: "string", Required: true},
+						{Name: "value", Type: "string", Required: true},
+					},
+				},
+				{
 					ID:     "invoke_plugin",
 					Method: http.MethodPost,
 					Parameters: []catalog.CatalogParameter{
 						{Name: "plugin", Type: "string", Required: true},
 						{Name: "operation", Type: "string", Required: true},
 					},
+				},
+				{
+					ID:     "workflow_manager_roundtrip",
+					Method: http.MethodPost,
 				},
 			},
 		},
@@ -437,6 +454,20 @@ func (r *capturingBundlePluginRuntime) startFakeHostedPlugin(req pluginruntime.S
 					return nil, err
 				}
 				return &core.OperationResult{Status: http.StatusOK, Body: string(body)}, nil
+			case "s3_roundtrip":
+				bucket, _ := params["bucket"].(string)
+				key, _ := params["key"].(string)
+				value, _ := params["value"].(string)
+				binding, _ := params["binding"].(string)
+				record, err := fakeHostedS3RoundTrip(bucket, key, value, binding, env)
+				if err != nil {
+					return nil, err
+				}
+				body, err := json.Marshal(record)
+				if err != nil {
+					return nil, err
+				}
+				return &core.OperationResult{Status: http.StatusOK, Body: string(body)}, nil
 			case "invoke_plugin":
 				targetPlugin, _ := params["plugin"].(string)
 				targetOperation, _ := params["operation"].(string)
@@ -450,6 +481,16 @@ func (r *capturingBundlePluginRuntime) startFakeHostedPlugin(req pluginruntime.S
 					}
 				}
 				body, err := json.Marshal(envelope)
+				if err != nil {
+					return nil, err
+				}
+				return &core.OperationResult{Status: http.StatusOK, Body: string(body)}, nil
+			case "workflow_manager_roundtrip":
+				record, err := fakeHostedWorkflowManagerRoundTrip(providerhost.InvocationTokenFromContext(ctx), env)
+				if err != nil {
+					return nil, err
+				}
+				body, err := json.Marshal(record)
 				if err != nil {
 					return nil, err
 				}
@@ -601,6 +642,189 @@ func fakeHostedCacheRoundTrip(key, value, binding string, env map[string]string)
 	return map[string]any{
 		"found": resp.GetFound(),
 		"value": string(resp.GetValue()),
+	}, nil
+}
+
+func fakeHostedS3RoundTrip(bucket, key, value, binding string, env map[string]string) (map[string]any, error) {
+	envName := providerhost.DefaultS3SocketEnv
+	tokenEnvName := providerhost.S3SocketTokenEnv("")
+	if strings.TrimSpace(binding) != "" {
+		envName = providerhost.S3SocketEnv(binding)
+		tokenEnvName = providerhost.S3SocketTokenEnv(binding)
+	}
+	target := strings.TrimSpace(env[envName])
+	if target == "" {
+		return nil, fmt.Errorf("missing s3 relay target in %s", envName)
+	}
+	token := strings.TrimSpace(env[tokenEnvName])
+	if token == "" {
+		return nil, fmt.Errorf("missing s3 relay token in %s", tokenEnvName)
+	}
+	address := strings.TrimSpace(strings.TrimPrefix(target, "tls://"))
+	if address == "" || address == target {
+		return nil, fmt.Errorf("unsupported s3 relay target %q", target)
+	}
+
+	conn, err := grpc.NewClient(
+		address,
+		grpc.WithTransportCredentials(credentials.NewTLS(&tls.Config{
+			InsecureSkipVerify: true,
+			MinVersion:         tls.VersionTLS12,
+			NextProtos:         []string{"h2"},
+		})),
+	)
+	if err != nil {
+		return nil, fmt.Errorf("connect s3 relay: %w", err)
+	}
+	defer func() { _ = conn.Close() }()
+
+	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	defer cancel()
+	ctx = metadata.NewOutgoingContext(ctx, metadata.Pairs(providerhost.HostServiceRelayTokenHeader, token))
+
+	client := proto.NewS3Client(conn)
+	writeStream, err := client.WriteObject(ctx)
+	if err != nil {
+		return nil, fmt.Errorf("open s3 write stream: %w", err)
+	}
+	if err := writeStream.Send(&proto.WriteObjectRequest{
+		Msg: &proto.WriteObjectRequest_Open{
+			Open: &proto.WriteObjectOpen{
+				Ref:         &proto.S3ObjectRef{Bucket: bucket, Key: key},
+				ContentType: "text/plain",
+			},
+		},
+	}); err != nil {
+		return nil, fmt.Errorf("send s3 open frame: %w", err)
+	}
+	if err := writeStream.Send(&proto.WriteObjectRequest{
+		Msg: &proto.WriteObjectRequest_Data{Data: []byte(value)},
+	}); err != nil {
+		return nil, fmt.Errorf("send s3 data frame: %w", err)
+	}
+	writeResp, err := writeStream.CloseAndRecv()
+	if err != nil {
+		return nil, fmt.Errorf("close s3 write stream: %w", err)
+	}
+
+	headResp, err := client.HeadObject(ctx, &proto.HeadObjectRequest{
+		Ref: &proto.S3ObjectRef{Bucket: bucket, Key: key},
+	})
+	if err != nil {
+		return nil, fmt.Errorf("head s3 object: %w", err)
+	}
+
+	readStream, err := client.ReadObject(ctx, &proto.ReadObjectRequest{
+		Ref: &proto.S3ObjectRef{Bucket: bucket, Key: key},
+	})
+	if err != nil {
+		return nil, fmt.Errorf("open s3 read stream: %w", err)
+	}
+	first, err := readStream.Recv()
+	if err != nil {
+		return nil, fmt.Errorf("read s3 metadata frame: %w", err)
+	}
+	if first.GetMeta() == nil {
+		return nil, fmt.Errorf("s3 read stream did not start with metadata")
+	}
+	var body bytes.Buffer
+	for {
+		chunk, err := readStream.Recv()
+		if errors.Is(err, io.EOF) {
+			break
+		}
+		if err != nil {
+			return nil, fmt.Errorf("read s3 data frame: %w", err)
+		}
+		if data := chunk.GetData(); len(data) > 0 {
+			body.Write(data)
+		}
+	}
+
+	listResp, err := client.ListObjects(ctx, &proto.ListObjectsRequest{
+		Bucket: bucket,
+		Prefix: key,
+	})
+	if err != nil {
+		return nil, fmt.Errorf("list s3 objects: %w", err)
+	}
+	keys := make([]string, 0, len(listResp.GetObjects()))
+	for _, obj := range listResp.GetObjects() {
+		keys = append(keys, obj.GetRef().GetKey())
+	}
+
+	return map[string]any{
+		"body":  body.String(),
+		"key":   key,
+		"keys":  keys,
+		"type":  headResp.GetMeta().GetContentType(),
+		"size":  writeResp.GetMeta().GetSize(),
+		"found": len(keys) > 0,
+	}, nil
+}
+
+func fakeHostedWorkflowManagerRoundTrip(invocationToken string, env map[string]string) (map[string]any, error) {
+	target := strings.TrimSpace(env[providerhost.DefaultWorkflowManagerSocketEnv])
+	if target == "" {
+		return nil, fmt.Errorf("missing workflow manager relay target in %s", providerhost.DefaultWorkflowManagerSocketEnv)
+	}
+	token := strings.TrimSpace(env[providerhost.WorkflowManagerSocketTokenEnv()])
+	if token == "" {
+		return nil, fmt.Errorf("missing workflow manager relay token in %s", providerhost.WorkflowManagerSocketTokenEnv())
+	}
+	address := strings.TrimSpace(strings.TrimPrefix(target, "tls://"))
+	if address == "" || address == target {
+		return nil, fmt.Errorf("unsupported workflow manager relay target %q", target)
+	}
+
+	conn, err := grpc.NewClient(
+		address,
+		grpc.WithTransportCredentials(credentials.NewTLS(&tls.Config{
+			InsecureSkipVerify: true,
+			MinVersion:         tls.VersionTLS12,
+			NextProtos:         []string{"h2"},
+		})),
+	)
+	if err != nil {
+		return nil, fmt.Errorf("connect workflow manager relay: %w", err)
+	}
+	defer func() { _ = conn.Close() }()
+
+	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	defer cancel()
+	ctx = metadata.NewOutgoingContext(ctx, metadata.Pairs(providerhost.HostServiceRelayTokenHeader, token))
+
+	client := proto.NewWorkflowManagerHostClient(conn)
+	created, err := client.CreateSchedule(ctx, &proto.WorkflowManagerCreateScheduleRequest{
+		InvocationToken: invocationToken,
+		ProviderName:    "managed",
+		Cron:            "*/5 * * * *",
+		Timezone:        "UTC",
+		Target: &proto.BoundWorkflowTarget{
+			PluginName: "roadmap",
+			Operation:  "sync",
+		},
+	})
+	if err != nil {
+		return nil, fmt.Errorf("create workflow schedule: %w", err)
+	}
+	scheduleID := strings.TrimSpace(created.GetSchedule().GetId())
+	if scheduleID == "" {
+		return nil, fmt.Errorf("workflow manager create did not return a schedule id")
+	}
+	fetched, err := client.GetSchedule(ctx, &proto.WorkflowManagerGetScheduleRequest{
+		InvocationToken: invocationToken,
+		ScheduleId:      scheduleID,
+	})
+	if err != nil {
+		return nil, fmt.Errorf("get workflow schedule: %w", err)
+	}
+
+	return map[string]any{
+		"provider_name": created.GetProviderName(),
+		"schedule_id":   scheduleID,
+		"cron":          fetched.GetSchedule().GetCron(),
+		"operation":     fetched.GetSchedule().GetTarget().GetOperation(),
 	}, nil
 }
 
@@ -4611,7 +4835,7 @@ func TestPluginRuntimeRewritesHostPathArgsForNonHostPathExecution(t *testing.T) 
 	}
 }
 
-func TestPluginRuntimeConfigRejectsMissingHostServiceTunnelCapability(t *testing.T) {
+func TestPluginRuntimeConfigUsesPublicS3RelayWithoutHostServiceTunnelCapability(t *testing.T) {
 	t.Parallel()
 
 	bin := buildEchoPluginBinary(t)
@@ -4624,6 +4848,8 @@ func TestPluginRuntimeConfigRejectsMissingHostServiceTunnelCapability(t *testing
 	manifest := newExecutableManifest("Echo", "Echoes back the input parameters")
 	runtimeProvider := newCapturingBundlePluginRuntime()
 	runtimeProvider.capabilities.HostnameProxyEgress = true
+	runtimeProvider.capabilities.HostPathExecution = true
+	runtimeProvider.fakeHosted = true
 	factories := NewFactoryRegistry()
 	factories.Runtime = func(context.Context, string, *config.RuntimeProviderEntry, Deps) (pluginruntime.Provider, error) {
 		return runtimeProvider, nil
@@ -4631,6 +4857,7 @@ func TestPluginRuntimeConfigRejectsMissingHostServiceTunnelCapability(t *testing
 	cfg := &config.Config{
 		Server: config.ServerConfig{
 			Runtime: config.ServerRuntimeConfig{Provider: "hosted"},
+			Egress:  config.EgressConfig{DefaultAction: string(egress.PolicyDeny)},
 		},
 		Runtime: config.RuntimeConfig{
 			Providers: map[string]*config.RuntimeProviderEntry{
@@ -4651,14 +4878,80 @@ func TestPluginRuntimeConfigRejectsMissingHostServiceTunnelCapability(t *testing
 		},
 	}
 
-	_, _, err := buildProvidersStrict(context.Background(), cfg, factories, Deps{
+	deps := Deps{
+		BaseURL:       "https://gestalt.example.test",
+		EncryptionKey: []byte("0123456789abcdef0123456789abcdef"),
 		S3: map[string]s3store.Client{
-			"main": &coretesting.StubS3{},
+			"main":    &coretesting.StubS3{},
+			"archive": &coretesting.StubS3{},
 		},
-		PluginRuntimeRegistry: newPluginRuntimeRegistry(cfg, factories.Runtime, Deps{}),
-	})
-	if err == nil || !strings.Contains(err.Error(), "host service tunnels") {
-		t.Fatalf("buildProvidersStrict error = %v, want missing host service tunnels", err)
+	}
+	deps.PluginRuntimeRegistry = newPluginRuntimeRegistry(cfg, factories.Runtime, deps)
+
+	providers, _, err := buildProvidersStrict(context.Background(), cfg, factories, deps)
+	if err != nil {
+		t.Fatalf("buildProvidersStrict: %v", err)
+	}
+	t.Cleanup(func() { _ = CloseProviders(providers) })
+
+	prov, err := providers.Get("echoext")
+	if err != nil {
+		t.Fatalf("providers.Get: %v", err)
+	}
+	checkEnv := func(envName string) (string, bool) {
+		t.Helper()
+		result, err := prov.Execute(context.Background(), "read_env", map[string]any{"name": envName}, "")
+		if err != nil {
+			t.Fatalf("Execute read_env(%s): %v", envName, err)
+		}
+		var env struct {
+			Value string `json:"value"`
+			Found bool   `json:"found"`
+		}
+		if err := json.Unmarshal([]byte(result.Body), &env); err != nil {
+			t.Fatalf("unmarshal env result for %s: %v", envName, err)
+		}
+		return env.Value, env.Found
+	}
+
+	if got, found := checkEnv(providerhost.DefaultS3SocketEnv); !found || got != "tls://gestalt.example.test:443" {
+		t.Fatalf("plugin s3 env %s = (%q, %v), want (%q, true)", providerhost.DefaultS3SocketEnv, got, found, "tls://gestalt.example.test:443")
+	}
+	for _, binding := range []string{"main"} {
+		envName := providerhost.S3SocketEnv(binding)
+		if got, found := checkEnv(envName); !found || got != "tls://gestalt.example.test:443" {
+			t.Fatalf("plugin s3 env %s = (%q, %v), want (%q, true)", envName, got, found, "tls://gestalt.example.test:443")
+		}
+		tokenEnvName := providerhost.S3SocketTokenEnv(binding)
+		if got, found := checkEnv(tokenEnvName); !found || got == "" {
+			t.Fatalf("plugin s3 token env %s = (%q, %v), want non-empty token", tokenEnvName, got, found)
+		}
+	}
+	if got, found := checkEnv(providerhost.S3SocketTokenEnv("")); !found || got == "" {
+		t.Fatalf("plugin s3 token env %s = (%q, %v), want non-empty token", providerhost.S3SocketTokenEnv(""), got, found)
+	}
+
+	bindRequests := runtimeProvider.bindHostServiceRequests()
+	if len(bindRequests) != 2 {
+		t.Fatalf("BindHostService requests = %d, want 2", len(bindRequests))
+	}
+	for _, req := range bindRequests {
+		if got := req.Relay.DialTarget; got != "tls://gestalt.example.test:443" {
+			t.Fatalf("BindHostService(%s) relay target = %q, want %q", req.EnvVar, got, "tls://gestalt.example.test:443")
+		}
+	}
+
+	startRequests := runtimeProvider.startPluginRequestsCopy()
+	if len(startRequests) != 1 {
+		t.Fatalf("StartPlugin requests = %d, want 1", len(startRequests))
+	}
+	for _, binding := range []string{"", "main"} {
+		if got := startRequests[0].Env[providerhost.S3SocketTokenEnv(binding)]; got == "" {
+			t.Fatalf("StartPlugin env should include s3 relay token %s", providerhost.S3SocketTokenEnv(binding))
+		}
+	}
+	if !slices.Contains(startRequests[0].AllowedHosts, "gestalt.example.test") {
+		t.Fatalf("StartPlugin allowed hosts = %#v, want relay host gestalt.example.test", startRequests[0].AllowedHosts)
 	}
 }
 
@@ -5265,6 +5558,150 @@ func TestPluginRuntimePublicCacheRelayRoundTripsThroughHostedPlugin(t *testing.T
 	}
 }
 
+func TestPluginRuntimePublicS3RelayRoundTripsThroughHostedPlugin(t *testing.T) {
+	t.Parallel()
+
+	secret := []byte("0123456789abcdef0123456789abcdef")
+	relaySrv := httptest.NewUnstartedServer(newRuntimeRelayTestHandler(t, secret))
+	relaySrv.EnableHTTP2 = true
+	relaySrv.StartTLS()
+	testutil.CloseOnCleanup(t, relaySrv)
+
+	bin := buildEchoPluginBinary(t)
+	manifestRoot := writeStaticCatalog(t, &catalog.Catalog{
+		Name: "echoext",
+		Operations: []catalog.CatalogOperation{
+			{
+				ID:     "s3_roundtrip",
+				Method: http.MethodPost,
+				Parameters: []catalog.CatalogParameter{
+					{Name: "bucket", Type: "string", Required: true},
+					{Name: "key", Type: "string", Required: true},
+					{Name: "value", Type: "string", Required: true},
+				},
+			},
+		},
+	})
+	manifest := newExecutableManifest("Echo", "Echoes back the input parameters")
+	runtimeProvider := newCapturingBundlePluginRuntime()
+	runtimeProvider.capabilities.HostnameProxyEgress = true
+	runtimeProvider.capabilities.HostPathExecution = true
+	runtimeProvider.fakeHosted = true
+
+	factories := NewFactoryRegistry()
+	factories.Runtime = func(context.Context, string, *config.RuntimeProviderEntry, Deps) (pluginruntime.Provider, error) {
+		return runtimeProvider, nil
+	}
+
+	cfg := &config.Config{
+		Server: config.ServerConfig{
+			Runtime: config.ServerRuntimeConfig{Provider: "hosted"},
+		},
+		Runtime: config.RuntimeConfig{
+			Providers: map[string]*config.RuntimeProviderEntry{
+				"hosted": {Driver: config.RuntimeProviderDriver("capture")},
+			},
+		},
+		Plugins: map[string]*config.ProviderEntry{
+			"echoext": {
+				Command:              bin,
+				Args:                 []string{"provider"},
+				ResolvedManifest:     manifest,
+				ResolvedManifestPath: filepath.Join(manifestRoot, "manifest.yaml"),
+				Runtime:              &config.PluginRuntimeConfig{},
+				S3:                   []string{"main"},
+			},
+		},
+	}
+
+	boundS3 := &coretesting.StubS3{}
+	deps := Deps{
+		BaseURL:       relaySrv.URL,
+		EncryptionKey: secret,
+		S3: map[string]s3store.Client{
+			"main": boundS3,
+		},
+	}
+	deps.PluginRuntimeRegistry = newPluginRuntimeRegistry(cfg, factories.Runtime, deps)
+
+	providers, _, err := buildProvidersStrict(context.Background(), cfg, factories, deps)
+	if err != nil {
+		t.Fatalf("buildProvidersStrict: %v", err)
+	}
+	t.Cleanup(func() { _ = CloseProviders(providers) })
+
+	prov, err := providers.Get("echoext")
+	if err != nil {
+		t.Fatalf("providers.Get: %v", err)
+	}
+
+	result, err := prov.Execute(context.Background(), "s3_roundtrip", map[string]any{
+		"bucket": "assets",
+		"key":    "plans/q3.txt",
+		"value":  "ship-it",
+	}, "")
+	if err != nil {
+		t.Fatalf("Execute s3_roundtrip: %v", err)
+	}
+
+	var body struct {
+		Body  string   `json:"body"`
+		Key   string   `json:"key"`
+		Keys  []string `json:"keys"`
+		Type  string   `json:"type"`
+		Size  int64    `json:"size"`
+		Found bool     `json:"found"`
+	}
+	if err := json.Unmarshal([]byte(result.Body), &body); err != nil {
+		t.Fatalf("unmarshal s3_roundtrip: %v", err)
+	}
+	if body.Body != "ship-it" {
+		t.Fatalf("body = %q, want %q", body.Body, "ship-it")
+	}
+	if body.Key != "plans/q3.txt" {
+		t.Fatalf("key = %q, want %q", body.Key, "plans/q3.txt")
+	}
+	if !slices.Equal(body.Keys, []string{"plans/q3.txt"}) {
+		t.Fatalf("keys = %#v, want %#v", body.Keys, []string{"plans/q3.txt"})
+	}
+	if body.Type != "text/plain" {
+		t.Fatalf("content type = %q, want %q", body.Type, "text/plain")
+	}
+	if body.Size != int64(len("ship-it")) {
+		t.Fatalf("size = %d, want %d", body.Size, len("ship-it"))
+	}
+	if !body.Found {
+		t.Fatal("expected s3 list operation to find the written object")
+	}
+
+	if _, err := boundS3.HeadObject(context.Background(), s3store.ObjectRef{
+		Bucket: "assets",
+		Key:    testPluginS3NamespacePrefix("echoext") + "plans/q3.txt",
+	}); err != nil {
+		t.Fatalf("expected namespaced backing key: %v", err)
+	}
+
+	startRequests := runtimeProvider.startPluginRequestsCopy()
+	if len(startRequests) != 1 {
+		t.Fatalf("StartPlugin requests = %d, want 1", len(startRequests))
+	}
+	if got := startRequests[0].Env[providerhost.S3SocketTokenEnv("")]; got == "" {
+		t.Fatal("StartPlugin env should include the default s3 relay token")
+	}
+	if got := startRequests[0].Env[providerhost.S3SocketTokenEnv("main")]; got == "" {
+		t.Fatal("StartPlugin env should include the named s3 relay token")
+	}
+	bindRequests := runtimeProvider.bindHostServiceRequests()
+	if len(bindRequests) != 2 {
+		t.Fatalf("BindHostService requests = %d, want 2", len(bindRequests))
+	}
+	for _, req := range bindRequests {
+		if got := req.Relay.DialTarget; !strings.HasPrefix(got, "tls://") {
+			t.Fatalf("BindHostService(%s) relay target = %q, want tls relay target", req.EnvVar, got)
+		}
+	}
+}
+
 func TestPluginRuntimePublicPluginInvokerRelayRoundTripsThroughHostedPlugin(t *testing.T) {
 	t.Parallel()
 
@@ -5448,6 +5885,111 @@ func TestPluginRuntimePublicPluginInvokerRelayRoundTripsThroughHostedPlugin(t *t
 	}
 }
 
+func TestPluginRuntimeConfigUsesPublicWorkflowManagerRelayWithoutHostServiceTunnelCapability(t *testing.T) {
+	t.Parallel()
+
+	bin := buildEchoPluginBinary(t)
+	manifestRoot := writeStaticCatalog(t, &catalog.Catalog{
+		Name: "echoext",
+		Operations: []catalog.CatalogOperation{
+			{ID: "read_env", Method: http.MethodGet, Parameters: []catalog.CatalogParameter{{Name: "name", Type: "string", Required: true}}},
+		},
+	})
+	manifest := newExecutableManifest("Echo", "Echoes back the input parameters")
+	runtimeProvider := newCapturingBundlePluginRuntime()
+	runtimeProvider.capabilities.HostnameProxyEgress = true
+	runtimeProvider.capabilities.HostPathExecution = true
+	runtimeProvider.fakeHosted = true
+	factories := NewFactoryRegistry()
+	factories.Runtime = func(context.Context, string, *config.RuntimeProviderEntry, Deps) (pluginruntime.Provider, error) {
+		return runtimeProvider, nil
+	}
+	cfg := &config.Config{
+		Server: config.ServerConfig{
+			Runtime: config.ServerRuntimeConfig{Provider: "hosted"},
+			Egress:  config.EgressConfig{DefaultAction: string(egress.PolicyDeny)},
+		},
+		Runtime: config.RuntimeConfig{
+			Providers: map[string]*config.RuntimeProviderEntry{
+				"hosted": {
+					Driver: config.RuntimeProviderDriver("capture"),
+				},
+			},
+		},
+		Plugins: map[string]*config.ProviderEntry{
+			"echoext": {
+				Command:              bin,
+				Args:                 []string{"provider"},
+				ResolvedManifest:     manifest,
+				ResolvedManifestPath: filepath.Join(manifestRoot, "manifest.yaml"),
+				Runtime:              &config.PluginRuntimeConfig{},
+			},
+		},
+	}
+
+	deps := Deps{
+		BaseURL:         "https://gestalt.example.test",
+		EncryptionKey:   []byte("0123456789abcdef0123456789abcdef"),
+		WorkflowManager: newStubWorkflowManager(),
+	}
+	deps.PluginRuntimeRegistry = newPluginRuntimeRegistry(cfg, factories.Runtime, deps)
+
+	providers, _, err := buildProvidersStrict(context.Background(), cfg, factories, deps)
+	if err != nil {
+		t.Fatalf("buildProvidersStrict: %v", err)
+	}
+	t.Cleanup(func() { _ = CloseProviders(providers) })
+
+	prov, err := providers.Get("echoext")
+	if err != nil {
+		t.Fatalf("providers.Get: %v", err)
+	}
+	checkEnv := func(envName string) (string, bool) {
+		t.Helper()
+		result, err := prov.Execute(context.Background(), "read_env", map[string]any{"name": envName}, "")
+		if err != nil {
+			t.Fatalf("Execute read_env(%s): %v", envName, err)
+		}
+		var env struct {
+			Value string `json:"value"`
+			Found bool   `json:"found"`
+		}
+		if err := json.Unmarshal([]byte(result.Body), &env); err != nil {
+			t.Fatalf("unmarshal env result for %s: %v", envName, err)
+		}
+		return env.Value, env.Found
+	}
+
+	if got, found := checkEnv(providerhost.DefaultWorkflowManagerSocketEnv); !found || got != "tls://gestalt.example.test:443" {
+		t.Fatalf("plugin workflow manager env %s = (%q, %v), want (%q, true)", providerhost.DefaultWorkflowManagerSocketEnv, got, found, "tls://gestalt.example.test:443")
+	}
+	if got, found := checkEnv(providerhost.WorkflowManagerSocketTokenEnv()); !found || got == "" {
+		t.Fatalf("plugin workflow manager token env %s = (%q, %v), want non-empty token", providerhost.WorkflowManagerSocketTokenEnv(), got, found)
+	}
+
+	bindRequests := runtimeProvider.bindHostServiceRequests()
+	if len(bindRequests) != 1 {
+		t.Fatalf("BindHostService requests = %d, want 1", len(bindRequests))
+	}
+	if bindRequests[0].EnvVar != providerhost.DefaultWorkflowManagerSocketEnv {
+		t.Fatalf("BindHostService env = %q, want %q", bindRequests[0].EnvVar, providerhost.DefaultWorkflowManagerSocketEnv)
+	}
+	if got := bindRequests[0].Relay.DialTarget; got != "tls://gestalt.example.test:443" {
+		t.Fatalf("BindHostService(%s) relay target = %q, want %q", bindRequests[0].EnvVar, got, "tls://gestalt.example.test:443")
+	}
+
+	startRequests := runtimeProvider.startPluginRequestsCopy()
+	if len(startRequests) != 1 {
+		t.Fatalf("StartPlugin requests = %d, want 1", len(startRequests))
+	}
+	if got := startRequests[0].Env[providerhost.WorkflowManagerSocketTokenEnv()]; got == "" {
+		t.Fatal("StartPlugin env should include the workflow manager relay token")
+	}
+	if !slices.Contains(startRequests[0].AllowedHosts, "gestalt.example.test") {
+		t.Fatalf("StartPlugin allowed hosts = %#v, want relay host gestalt.example.test", startRequests[0].AllowedHosts)
+	}
+}
+
 func TestPluginRuntimeConfigRejectsMissingHostnameEgressCapability(t *testing.T) {
 	t.Parallel()
 
@@ -5574,24 +6116,27 @@ func writeRuntimeRelayGRPCTrailersOnly(w http.ResponseWriter, code codes.Code, m
 	w.WriteHeader(http.StatusOK)
 }
 
-func TestPluginRuntimeConfigRejectsMissingHostServiceTunnelCapabilityWithWorkflowProvider(t *testing.T) {
+func TestPluginRuntimePublicWorkflowManagerRelayRoundTripsThroughHostedPlugin(t *testing.T) {
 	t.Parallel()
+
+	secret := []byte("0123456789abcdef0123456789abcdef")
+	relaySrv := httptest.NewUnstartedServer(newRuntimeRelayTestHandler(t, secret))
+	relaySrv.EnableHTTP2 = true
+	relaySrv.StartTLS()
+	testutil.CloseOnCleanup(t, relaySrv)
 
 	bin := buildEchoPluginBinary(t)
 	manifestRoot := writeStaticCatalog(t, &catalog.Catalog{
 		Name: "echoext",
 		Operations: []catalog.CatalogOperation{
-			{ID: "read_env", Method: http.MethodGet, Parameters: []catalog.CatalogParameter{{Name: "name", Type: "string", Required: true}}},
+			{ID: "workflow_manager_roundtrip", Method: http.MethodPost},
 		},
 	})
 	manifest := newExecutableManifest("Echo", "Echoes back the input parameters")
-	runtimeProvider := &staticCapabilityPluginRuntime{
-		inner: pluginruntime.NewLocalProvider(),
-		capabilities: pluginruntime.Capabilities{
-			HostedPluginRuntime: true,
-			ProviderGRPCTunnel:  true,
-		},
-	}
+	runtimeProvider := newCapturingBundlePluginRuntime()
+	runtimeProvider.capabilities.HostnameProxyEgress = true
+	runtimeProvider.capabilities.HostPathExecution = true
+	runtimeProvider.fakeHosted = true
 	factories := NewFactoryRegistry()
 	factories.Runtime = func(context.Context, string, *config.RuntimeProviderEntry, Deps) (pluginruntime.Provider, error) {
 		return runtimeProvider, nil
@@ -5618,17 +6163,87 @@ func TestPluginRuntimeConfigRejectsMissingHostServiceTunnelCapabilityWithWorkflo
 		},
 	}
 
-	workflowRuntime := &workflowRuntime{
-		providers: map[string]coreworkflow.Provider{
-			"managed": nil,
-		},
+	manager := newStubWorkflowManager()
+	deps := Deps{
+		BaseURL:         relaySrv.URL,
+		EncryptionKey:   secret,
+		WorkflowManager: manager,
 	}
-	_, _, err := buildProvidersStrict(context.Background(), cfg, factories, Deps{
-		WorkflowRuntime:       workflowRuntime,
-		PluginRuntimeRegistry: newPluginRuntimeRegistry(cfg, factories.Runtime, Deps{WorkflowRuntime: workflowRuntime}),
+	deps.PluginRuntimeRegistry = newPluginRuntimeRegistry(cfg, factories.Runtime, deps)
+
+	providers, _, err := buildProvidersStrict(context.Background(), cfg, factories, deps)
+	if err != nil {
+		t.Fatalf("buildProvidersStrict: %v", err)
+	}
+	t.Cleanup(func() { _ = CloseProviders(providers) })
+
+	prov, err := providers.Get("echoext")
+	if err != nil {
+		t.Fatalf("providers.Get: %v", err)
+	}
+
+	ctx := principal.WithPrincipal(context.Background(), &principal.Principal{
+		SubjectID: "user:user-123",
+		UserID:    "user-123",
+		Kind:      principal.KindUser,
+		Source:    principal.SourceSession,
+		Scopes:    []string{"echoext"},
 	})
-	if err == nil || !strings.Contains(err.Error(), "host service tunnels") {
-		t.Fatalf("buildProvidersStrict error = %v, want missing host service tunnels", err)
+
+	result, err := prov.Execute(ctx, "workflow_manager_roundtrip", nil, "")
+	if err != nil {
+		t.Fatalf("Execute workflow_manager_roundtrip: %v", err)
+	}
+
+	var body struct {
+		ProviderName string `json:"provider_name"`
+		ScheduleID   string `json:"schedule_id"`
+		Cron         string `json:"cron"`
+		Operation    string `json:"operation"`
+	}
+	if err := json.Unmarshal([]byte(result.Body), &body); err != nil {
+		t.Fatalf("unmarshal workflow_manager_roundtrip: %v", err)
+	}
+	if body.ProviderName != "managed" {
+		t.Fatalf("provider_name = %q, want %q", body.ProviderName, "managed")
+	}
+	if body.ScheduleID == "" {
+		t.Fatal("workflow_manager_roundtrip should return a schedule id")
+	}
+	if body.Cron != "*/5 * * * *" {
+		t.Fatalf("cron = %q, want %q", body.Cron, "*/5 * * * *")
+	}
+	if body.Operation != "sync" {
+		t.Fatalf("operation = %q, want %q", body.Operation, "sync")
+	}
+
+	schedules, err := manager.ListSchedules(context.Background(), nil)
+	if err != nil {
+		t.Fatalf("manager.ListSchedules: %v", err)
+	}
+	if len(schedules) != 1 {
+		t.Fatalf("manager schedules len = %d, want 1", len(schedules))
+	}
+	if got := schedules[0].Schedule.Target.Operation; got != "sync" {
+		t.Fatalf("stored target operation = %q, want %q", got, "sync")
+	}
+	if got := manager.Subjects(); !slices.Equal(got, []string{"user:user-123", "user:user-123"}) {
+		t.Fatalf("manager subjects = %v, want two user:user-123 entries", got)
+	}
+
+	startRequests := runtimeProvider.startPluginRequestsCopy()
+	if len(startRequests) != 1 {
+		t.Fatalf("StartPlugin requests = %d, want 1", len(startRequests))
+	}
+	if got := startRequests[0].Env[providerhost.WorkflowManagerSocketTokenEnv()]; got == "" {
+		t.Fatal("StartPlugin env should include the workflow manager relay token")
+	}
+	bindRequests := runtimeProvider.bindHostServiceRequests()
+	if len(bindRequests) != 1 {
+		t.Fatalf("BindHostService requests = %d, want 1", len(bindRequests))
+	}
+	if got := bindRequests[0].Relay.DialTarget; !strings.HasPrefix(got, "tls://") {
+		t.Fatalf("BindHostService(%s) relay target = %q, want tls relay target", bindRequests[0].EnvVar, got)
 	}
 }
 

--- a/gestaltd/internal/bootstrap/provider_build.go
+++ b/gestaltd/internal/bootstrap/provider_build.go
@@ -944,7 +944,6 @@ func effectivePluginRuntime(ctx context.Context, name string, entry *config.Prov
 }
 
 type pluginRuntimeCapabilityRequirements struct {
-	HostServiceTunnels  bool
 	HostnameProxyEgress bool
 }
 
@@ -955,7 +954,6 @@ func pluginRuntimeRequirementsForPlugin(name string, entry *config.ProviderEntry
 		return pluginRuntimeCapabilityRequirements{}, nil
 	}
 	return pluginRuntimeCapabilityRequirements{
-		HostServiceTunnels:  len(entry.S3) > 0 || (deps.WorkflowRuntime != nil && deps.WorkflowRuntime.HasConfiguredProviders()),
 		HostnameProxyEgress: len(entry.AllowedHosts) > 0 || deps.Egress.DefaultAction == egress.PolicyDeny,
 	}, nil
 }
@@ -974,9 +972,6 @@ func validatePluginRuntimeCapabilities(label string, caps pluginruntime.Capabili
 	}
 	if !caps.ProviderGRPCTunnel {
 		missing = append(missing, "provider gRPC tunneling")
-	}
-	if req.HostServiceTunnels && !caps.HostServiceTunnels {
-		missing = append(missing, "host service tunnels")
 	}
 	if req.HostnameProxyEgress && !caps.HostnameProxyEgress {
 		missing = append(missing, "hostname-based egress controls")
@@ -1108,19 +1103,6 @@ func buildPluginRuntimeHostServices(name string, entry *config.ProviderEntry, de
 		hostServices = append(hostServices, services...)
 		cleanup = chainCleanup(cleanup, cacheCleanup)
 	}
-	needInvocationTokens := includeHostServices || len(entry.Invokes) > 0
-	if needInvocationTokens {
-		invTokens, err = providerhost.NewInvocationTokenManager(deps.EncryptionKey)
-		if err != nil {
-			return fail(err)
-		}
-	}
-	if !includeHostServices {
-		if len(entry.Invokes) > 0 {
-			hostServices = append(hostServices, buildPluginInvokerHostService(name, entry, deps, invTokens))
-		}
-		return hostServices, invTokens, cleanup, nil
-	}
 	if len(entry.S3) > 0 {
 		services, err := buildPluginS3HostServices(name, entry, deps)
 		if err != nil {
@@ -1128,10 +1110,29 @@ func buildPluginRuntimeHostServices(name string, entry *config.ProviderEntry, de
 		}
 		hostServices = append(hostServices, services...)
 	}
+	includeWorkflowManager := deps.WorkflowManager != nil || (deps.WorkflowRuntime != nil && deps.WorkflowRuntime.HasConfiguredProviders())
+	needInvocationTokens := includeHostServices || len(entry.Invokes) > 0
+	if includeWorkflowManager {
+		needInvocationTokens = true
+	}
+	if needInvocationTokens {
+		invTokens, err = providerhost.NewInvocationTokenManager(deps.EncryptionKey)
+		if err != nil {
+			return fail(err)
+		}
+	}
+	if includeWorkflowManager {
+		hostServices = append(hostServices, buildPluginWorkflowManagerHostService(name, deps, invTokens))
+	}
+	if !includeHostServices {
+		if len(entry.Invokes) > 0 {
+			hostServices = append(hostServices, buildPluginInvokerHostService(name, entry, deps, invTokens))
+		}
+		return hostServices, invTokens, cleanup, nil
+	}
 	if deps.AuthorizationProvider != nil && len(entry.EffectiveHTTPBindings()) > 0 {
 		hostServices = append(hostServices, buildPluginAuthorizationHostService(deps.AuthorizationProvider))
 	}
-	hostServices = append(hostServices, buildPluginWorkflowManagerHostService(name, deps, invTokens))
 	if len(entry.Invokes) > 0 {
 		hostServices = append(hostServices, buildPluginInvokerHostService(name, entry, deps, invTokens))
 	}
@@ -1154,6 +1155,14 @@ func buildPluginRuntimeHostServiceBinding(pluginName, sessionID string, hostServ
 			serviceKey = "cache"
 			serviceLabel = "cache"
 			methodPrefix = "/" + proto.Cache_ServiceDesc.ServiceName + "/"
+		case isS3HostServiceEnv(hostService.EnvVar):
+			serviceKey = "s3"
+			serviceLabel = "S3"
+			methodPrefix = "/" + proto.S3_ServiceDesc.ServiceName + "/"
+		case hostService.EnvVar == providerhost.DefaultWorkflowManagerSocketEnv:
+			serviceKey = "workflow_manager"
+			serviceLabel = "workflow manager"
+			methodPrefix = "/" + proto.WorkflowManagerHost_ServiceDesc.ServiceName + "/"
 		case hostService.EnvVar == providerhost.DefaultPluginInvokerSocketEnv:
 			serviceKey = "plugin_invoker"
 			serviceLabel = "plugin invoker"
@@ -1247,6 +1256,11 @@ func isIndexedDBHostServiceEnv(envVar string) bool {
 func isCacheHostServiceEnv(envVar string) bool {
 	envVar = strings.TrimSpace(envVar)
 	return envVar == providerhost.DefaultCacheSocketEnv || strings.HasPrefix(envVar, providerhost.DefaultCacheSocketEnv+"_")
+}
+
+func isS3HostServiceEnv(envVar string) bool {
+	envVar = strings.TrimSpace(envVar)
+	return envVar == providerhost.DefaultS3SocketEnv || strings.HasPrefix(envVar, providerhost.DefaultS3SocketEnv+"_")
 }
 
 func appendAllowedHost(allowedHosts []string, host string) []string {

--- a/gestaltd/internal/providerenv/s3_socket_env.go
+++ b/gestaltd/internal/providerenv/s3_socket_env.go
@@ -3,6 +3,7 @@ package providerenv
 import "strings"
 
 const DefaultS3SocketEnv = "GESTALT_S3_SOCKET"
+const defaultS3SocketTokenSuffix = "_TOKEN"
 
 func S3SocketEnv(name string) string {
 	name = strings.TrimSpace(name)
@@ -23,4 +24,8 @@ func S3SocketEnv(name string) string {
 		}
 	}
 	return b.String()
+}
+
+func S3SocketTokenEnv(name string) string {
+	return S3SocketEnv(name) + defaultS3SocketTokenSuffix
 }

--- a/gestaltd/internal/providerhost/s3_env.go
+++ b/gestaltd/internal/providerhost/s3_env.go
@@ -7,3 +7,7 @@ const DefaultS3SocketEnv = providerenv.DefaultS3SocketEnv
 func S3SocketEnv(name string) string {
 	return providerenv.S3SocketEnv(name)
 }
+
+func S3SocketTokenEnv(name string) string {
+	return providerenv.S3SocketTokenEnv(name)
+}

--- a/gestaltd/internal/providerhost/workflow_env.go
+++ b/gestaltd/internal/providerhost/workflow_env.go
@@ -4,3 +4,7 @@ const (
 	DefaultWorkflowHostSocketEnv    = "GESTALT_WORKFLOW_HOST_SOCKET"
 	DefaultWorkflowManagerSocketEnv = "GESTALT_WORKFLOW_MANAGER_SOCKET"
 )
+
+func WorkflowManagerSocketTokenEnv() string {
+	return DefaultWorkflowManagerSocketEnv + "_TOKEN"
+}

--- a/gestaltd/internal/testutil/cmd/s3transportd/main.go
+++ b/gestaltd/internal/testutil/cmd/s3transportd/main.go
@@ -8,6 +8,7 @@ import (
 	"fmt"
 	"os"
 	"os/signal"
+	"strings"
 	"syscall"
 
 	"github.com/valon-technologies/gestalt/server/internal/testutil/s3transport"
@@ -15,13 +16,21 @@ import (
 
 func main() {
 	socket := flag.String("socket", "", "Unix socket path to listen on")
+	tcp := flag.String("tcp", "", "TCP host:port to listen on")
+	expectToken := flag.String("expect-token", "", "Require the relay token header to match this value")
 	flag.Parse()
-	if *socket == "" {
-		fmt.Fprintln(os.Stderr, "usage: s3transportd --socket <path>")
+	target := *socket
+	if strings.TrimSpace(*tcp) != "" {
+		target = "tcp://" + strings.TrimSpace(*tcp)
+	}
+	if strings.TrimSpace(target) == "" {
+		fmt.Fprintln(os.Stderr, "usage: s3transportd --socket <path> | --tcp <host:port>")
 		os.Exit(1)
 	}
 
-	srv, err := s3transport.Start(*socket)
+	srv, err := s3transport.Start(target, s3transport.Options{
+		ExpectRelayToken: strings.TrimSpace(*expectToken),
+	})
 	if err != nil {
 		fmt.Fprintf(os.Stderr, "failed to start: %v\n", err)
 		os.Exit(1)

--- a/gestaltd/internal/testutil/s3transport/server.go
+++ b/gestaltd/internal/testutil/s3transport/server.go
@@ -3,40 +3,124 @@
 package s3transport
 
 import (
+	"context"
+	"fmt"
 	"net"
 	"os"
+	"path/filepath"
+	"strings"
 
 	proto "github.com/valon-technologies/gestalt/sdk/go/gen/v1"
 	coretesting "github.com/valon-technologies/gestalt/server/core/testing"
 	"github.com/valon-technologies/gestalt/server/internal/providerhost"
 	"google.golang.org/grpc"
+	"google.golang.org/grpc/codes"
+	"google.golang.org/grpc/metadata"
+	"google.golang.org/grpc/status"
 )
 
-// Server wraps a gRPC server backed by StubS3 on a Unix socket.
+// Server wraps a gRPC server backed by StubS3 on a transport target.
 type Server struct {
 	srv    *grpc.Server
 	lis    net.Listener
-	Socket string
+	target string
 }
 
-// Start creates a new S3 gRPC server on the given Unix socket path.
+type Options struct {
+	ExpectRelayToken string
+}
+
+// Start creates a new S3 gRPC server on the supplied transport target. The
+// target can be a plain Unix socket path, unix:///path, or tcp://host:port.
 // The server starts empty; tests seed data through the SDK client.
-func Start(socketPath string) (*Server, error) {
-	_ = os.Remove(socketPath)
-	lis, err := net.Listen("unix", socketPath)
+func Start(target string, opts Options) (*Server, error) {
+	network, address, err := parseTarget(target)
+	if err != nil {
+		return nil, err
+	}
+	if network == "unix" {
+		_ = os.Remove(address)
+	}
+	lis, err := net.Listen(network, address)
 	if err != nil {
 		return nil, err
 	}
 	stub := &coretesting.StubS3{}
-	srv := grpc.NewServer()
+	srv := grpc.NewServer(
+		grpc.ChainUnaryInterceptor(requireRelayTokenUnary(opts.ExpectRelayToken)),
+		grpc.ChainStreamInterceptor(requireRelayTokenStream(opts.ExpectRelayToken)),
+	)
 	proto.RegisterS3Server(srv, providerhost.NewS3Server(stub, ""))
 	go func() { _ = srv.Serve(lis) }()
-	return &Server{srv: srv, lis: lis, Socket: socketPath}, nil
+	return &Server{srv: srv, lis: lis, target: target}, nil
+}
+
+func requireRelayTokenUnary(expected string) grpc.UnaryServerInterceptor {
+	expected = strings.TrimSpace(expected)
+	return func(ctx context.Context, req any, _ *grpc.UnaryServerInfo, handler grpc.UnaryHandler) (any, error) {
+		if err := validateRelayToken(ctx, expected); err != nil {
+			return nil, err
+		}
+		return handler(ctx, req)
+	}
+}
+
+func requireRelayTokenStream(expected string) grpc.StreamServerInterceptor {
+	expected = strings.TrimSpace(expected)
+	return func(srv any, stream grpc.ServerStream, _ *grpc.StreamServerInfo, handler grpc.StreamHandler) error {
+		if err := validateRelayToken(stream.Context(), expected); err != nil {
+			return err
+		}
+		return handler(srv, stream)
+	}
+}
+
+func validateRelayToken(ctx context.Context, expected string) error {
+	if expected == "" {
+		return nil
+	}
+	md, ok := metadata.FromIncomingContext(ctx)
+	if !ok {
+		return status.Error(codes.Unauthenticated, "missing relay token metadata")
+	}
+	values := md.Get(providerhost.HostServiceRelayTokenHeader)
+	if len(values) == 0 || strings.TrimSpace(values[0]) != expected {
+		return status.Error(codes.Unauthenticated, "invalid relay token metadata")
+	}
+	return nil
 }
 
 // Stop gracefully shuts down the server.
 func (s *Server) Stop() {
 	s.srv.GracefulStop()
 	_ = s.lis.Close()
-	_ = os.Remove(s.Socket)
+	network, address, err := parseTarget(s.target)
+	if err == nil && network == "unix" {
+		_ = os.Remove(address)
+	}
+}
+
+func parseTarget(raw string) (network string, address string, err error) {
+	target := strings.TrimSpace(raw)
+	if target == "" {
+		return "", "", fmt.Errorf("s3 transport target is required")
+	}
+	switch {
+	case strings.HasPrefix(target, "tcp://"):
+		address = strings.TrimSpace(strings.TrimPrefix(target, "tcp://"))
+		if address == "" {
+			return "", "", fmt.Errorf("s3 tcp target %q is missing host:port", raw)
+		}
+		return "tcp", address, nil
+	case strings.HasPrefix(target, "unix://"):
+		address = strings.TrimSpace(strings.TrimPrefix(target, "unix://"))
+		if address == "" {
+			return "", "", fmt.Errorf("s3 unix target %q is missing a socket path", raw)
+		}
+		return "unix", address, nil
+	case strings.Contains(target, "://"):
+		return "", "", fmt.Errorf("unsupported s3 transport target %q", raw)
+	default:
+		return "unix", filepath.Clean(target), nil
+	}
 }

--- a/sdk/go/s3.go
+++ b/sdk/go/s3.go
@@ -3,16 +3,21 @@ package gestalt
 import (
 	"bytes"
 	"context"
+	"crypto/tls"
 	"encoding/json"
 	"fmt"
 	"io"
+	"net"
+	"net/url"
 	"os"
+	"path/filepath"
 	"strings"
 	"time"
 
 	proto "github.com/valon-technologies/gestalt/sdk/go/gen/v1"
 	"google.golang.org/grpc"
 	"google.golang.org/grpc/codes"
+	"google.golang.org/grpc/credentials"
 	"google.golang.org/grpc/credentials/insecure"
 	"google.golang.org/grpc/status"
 	"google.golang.org/protobuf/types/known/timestamppb"
@@ -20,6 +25,7 @@ import (
 
 // EnvS3Socket is the default Unix-socket environment variable used by [S3].
 const EnvS3Socket = "GESTALT_S3_SOCKET"
+const s3SocketTokenSuffix = "_TOKEN"
 
 // S3SocketEnv returns the environment variable name used for a named S3
 // transport socket.
@@ -42,6 +48,12 @@ func S3SocketEnv(name string) string {
 		}
 	}
 	return b.String()
+}
+
+// S3SocketTokenEnv returns the environment variable name used for a named S3
+// relay token.
+func S3SocketTokenEnv(name string) string {
+	return S3SocketEnv(name) + s3SocketTokenSuffix
 }
 
 var (
@@ -154,28 +166,71 @@ type PresignResult struct {
 	Headers   map[string]string
 }
 
-// S3Client speaks to a running S3 provider over a Unix socket.
+// S3Client speaks to a running S3 provider over a transport target.
 type S3Client struct {
 	client proto.S3Client
 	conn   *grpc.ClientConn
 }
 
-// S3 connects to the S3 provider exposed by gestaltd.
+// S3 connects to the S3 provider exposed by gestaltd. The target can be a
+// plain Unix socket path, a unix:///path URI, or a tcp://host:port or
+// tls://host:port URI.
 func S3(name ...string) (*S3Client, error) {
 	envName := EnvS3Socket
 	if len(name) > 0 {
 		envName = S3SocketEnv(name[0])
 	}
-	socketPath := os.Getenv(envName)
-	if socketPath == "" {
+	target := os.Getenv(envName)
+	if target == "" {
 		return nil, fmt.Errorf("s3: %s is not set", envName)
 	}
+	network, address, err := parseS3Target(target)
+	if err != nil {
+		return nil, err
+	}
+	token := os.Getenv(S3SocketTokenEnv(firstS3Name(name)))
 	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
 	defer cancel()
-	conn, err := grpc.DialContext(ctx, "unix:"+socketPath,
-		grpc.WithTransportCredentials(insecure.NewCredentials()),
-		grpc.WithBlock(),
-	)
+	var conn *grpc.ClientConn
+	opts := s3DialOptions(token)
+	switch network {
+	case "unix":
+		conn, err = grpc.DialContext(ctx, "passthrough:///localhost",
+			append([]grpc.DialOption{
+				grpc.WithTransportCredentials(insecure.NewCredentials()),
+				grpc.WithContextDialer(func(ctx context.Context, _ string) (net.Conn, error) {
+					var d net.Dialer
+					return d.DialContext(ctx, "unix", address)
+				}),
+				grpc.WithAuthority("localhost"),
+				grpc.WithBlock(),
+			}, opts...)...,
+		)
+	case "tcp":
+		conn, err = grpc.DialContext(ctx, address,
+			append([]grpc.DialOption{
+				grpc.WithTransportCredentials(insecure.NewCredentials()),
+				grpc.WithBlock(),
+			}, opts...)...,
+		)
+	case "tls":
+		host, _, splitErr := net.SplitHostPort(address)
+		if splitErr != nil {
+			return nil, fmt.Errorf("s3: parse tls target %q: %w", address, splitErr)
+		}
+		conn, err = grpc.DialContext(ctx, address,
+			append([]grpc.DialOption{
+				grpc.WithTransportCredentials(credentials.NewTLS(&tls.Config{
+					MinVersion: tls.VersionTLS12,
+					ServerName: host,
+					NextProtos: []string{"h2"},
+				})),
+				grpc.WithBlock(),
+			}, opts...)...,
+		)
+	default:
+		return nil, fmt.Errorf("s3: unsupported transport network %q", network)
+	}
 	if err != nil {
 		return nil, fmt.Errorf("s3: connect to host: %w", err)
 	}
@@ -625,6 +680,68 @@ func cloneStringMap(values map[string]string) map[string]string {
 		out[key] = value
 	}
 	return out
+}
+
+func s3DialOptions(token string) []grpc.DialOption {
+	token = strings.TrimSpace(token)
+	if token == "" {
+		return nil
+	}
+	return []grpc.DialOption{grpc.WithPerRPCCredentials(s3RelayPerRPCCredentials{token: token})}
+}
+
+func firstS3Name(name []string) string {
+	if len(name) == 0 {
+		return ""
+	}
+	return name[0]
+}
+
+type s3RelayPerRPCCredentials struct {
+	token string
+}
+
+func (c s3RelayPerRPCCredentials) GetRequestMetadata(context.Context, ...string) (map[string]string, error) {
+	return map[string]string{
+		"x-gestalt-host-service-relay-token": c.token,
+	}, nil
+}
+
+func (s3RelayPerRPCCredentials) RequireTransportSecurity() bool { return false }
+
+func parseS3Target(raw string) (network string, address string, err error) {
+	target := strings.TrimSpace(raw)
+	if target == "" {
+		return "", "", fmt.Errorf("s3: transport target is required")
+	}
+	switch {
+	case strings.HasPrefix(target, "tcp://"):
+		address = strings.TrimSpace(strings.TrimPrefix(target, "tcp://"))
+		if address == "" {
+			return "", "", fmt.Errorf("s3: tcp target %q is missing host:port", raw)
+		}
+		return "tcp", address, nil
+	case strings.HasPrefix(target, "tls://"):
+		address = strings.TrimSpace(strings.TrimPrefix(target, "tls://"))
+		if address == "" {
+			return "", "", fmt.Errorf("s3: tls target %q is missing host:port", raw)
+		}
+		return "tls", address, nil
+	case strings.HasPrefix(target, "unix://"):
+		address = strings.TrimSpace(strings.TrimPrefix(target, "unix://"))
+		if address == "" {
+			return "", "", fmt.Errorf("s3: unix target %q is missing a socket path", raw)
+		}
+		return "unix", address, nil
+	case strings.Contains(target, "://"):
+		parsed, parseErr := url.Parse(target)
+		if parseErr != nil {
+			return "", "", fmt.Errorf("s3: parse target %q: %w", raw, parseErr)
+		}
+		return "", "", fmt.Errorf("s3: unsupported target scheme %q", parsed.Scheme)
+	default:
+		return "unix", filepath.Clean(target), nil
+	}
 }
 
 func grpcS3Err(err error) error {

--- a/sdk/go/s3_transport_test.go
+++ b/sdk/go/s3_transport_test.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"errors"
 	"io"
+	"os"
 	"strings"
 	"testing"
 	"time"
@@ -29,6 +30,66 @@ func TestS3Transport_NamedSocketEnv(t *testing.T) {
 	}
 	if got != "ok" {
 		t.Fatalf("Text = %q, want ok", got)
+	}
+}
+
+func TestS3Transport_TCPTargetEnv(t *testing.T) {
+	bin, target, cmd := buildAndStartTCPHarness("s3transportd", "")
+	t.Cleanup(func() {
+		_ = cmd.Process.Kill()
+		_ = cmd.Wait()
+		_ = os.Remove(bin)
+	})
+
+	t.Setenv(gestalt.EnvS3Socket, target)
+	client, err := gestalt.S3()
+	if err != nil {
+		t.Fatalf("connect tcp s3: %v", err)
+	}
+	defer func() { _ = client.Close() }()
+
+	ctx := context.Background()
+	obj := client.Object("tcp", "checks/ok.txt")
+	if _, err := obj.WriteString(ctx, "ok", nil); err != nil {
+		t.Fatalf("WriteString: %v", err)
+	}
+	got, err := obj.Text(ctx, nil)
+	if err != nil {
+		t.Fatalf("Text: %v", err)
+	}
+	if got != "ok" {
+		t.Fatalf("Text = %q, want ok", got)
+	}
+}
+
+func TestS3Transport_TCPTargetTokenEnv(t *testing.T) {
+	const token = "relay-token-go"
+	bin, target, cmd := buildAndStartTCPHarness("s3transportd", token)
+	t.Cleanup(func() {
+		_ = cmd.Process.Kill()
+		_ = cmd.Wait()
+		_ = os.Remove(bin)
+	})
+
+	t.Setenv(gestalt.EnvS3Socket, target)
+	t.Setenv(gestalt.S3SocketTokenEnv(""), token)
+	client, err := gestalt.S3()
+	if err != nil {
+		t.Fatalf("connect tcp s3 with token: %v", err)
+	}
+	defer func() { _ = client.Close() }()
+
+	ctx := context.Background()
+	obj := client.Object("tcp-token", "checks/token.txt")
+	if _, err := obj.WriteString(ctx, "relay", nil); err != nil {
+		t.Fatalf("WriteString: %v", err)
+	}
+	got, err := obj.Text(ctx, nil)
+	if err != nil {
+		t.Fatalf("Text: %v", err)
+	}
+	if got != "relay" {
+		t.Fatalf("Text = %q, want relay", got)
 	}
 }
 

--- a/sdk/go/workflow_manager.go
+++ b/sdk/go/workflow_manager.go
@@ -2,19 +2,25 @@ package gestalt
 
 import (
 	"context"
+	"crypto/tls"
 	"fmt"
+	"net"
+	"net/url"
 	"os"
+	"path/filepath"
 	"strings"
 	"sync"
 	"time"
 
 	proto "github.com/valon-technologies/gestalt/sdk/go/gen/v1"
 	"google.golang.org/grpc"
+	"google.golang.org/grpc/credentials"
 	"google.golang.org/grpc/credentials/insecure"
 	gproto "google.golang.org/protobuf/proto"
 )
 
 const EnvWorkflowManagerSocket = proto.EnvWorkflowManagerSocket
+const EnvWorkflowManagerSocketToken = EnvWorkflowManagerSocket + "_TOKEN"
 
 type WorkflowManagerClient struct {
 	client          proto.WorkflowManagerHostClient
@@ -22,48 +28,87 @@ type WorkflowManagerClient struct {
 }
 
 var sharedWorkflowManagerTransport struct {
-	mu         sync.Mutex
-	socketPath string
-	conn       *grpc.ClientConn
-	client     proto.WorkflowManagerHostClient
+	mu     sync.Mutex
+	target string
+	token  string
+	conn   *grpc.ClientConn
+	client proto.WorkflowManagerHostClient
 }
 
 func WorkflowManager(invocationToken string) (*WorkflowManagerClient, error) {
 	if strings.TrimSpace(invocationToken) == "" {
 		return nil, fmt.Errorf("workflow manager: invocation token is not available")
 	}
-	socketPath := os.Getenv(EnvWorkflowManagerSocket)
-	if socketPath == "" {
+	target := os.Getenv(EnvWorkflowManagerSocket)
+	if target == "" {
 		return nil, fmt.Errorf("workflow manager: %s is not set", EnvWorkflowManagerSocket)
 	}
+	token := os.Getenv(EnvWorkflowManagerSocketToken)
 
 	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
 	defer cancel()
 
-	client, err := sharedWorkflowManagerClient(ctx, socketPath)
+	client, err := sharedWorkflowManagerClient(ctx, target, token)
 	if err != nil {
 		return nil, err
 	}
 
-	return &WorkflowManagerClient{
-		client:          client,
-		invocationToken: strings.TrimSpace(invocationToken),
-	}, nil
+	return &WorkflowManagerClient{client: client, invocationToken: strings.TrimSpace(invocationToken)}, nil
 }
 
-func sharedWorkflowManagerClient(ctx context.Context, socketPath string) (proto.WorkflowManagerHostClient, error) {
+func sharedWorkflowManagerClient(ctx context.Context, target, token string) (proto.WorkflowManagerHostClient, error) {
 	sharedWorkflowManagerTransport.mu.Lock()
-	if sharedWorkflowManagerTransport.conn != nil && sharedWorkflowManagerTransport.socketPath == socketPath {
+	if sharedWorkflowManagerTransport.conn != nil && sharedWorkflowManagerTransport.target == target && sharedWorkflowManagerTransport.token == token {
 		client := sharedWorkflowManagerTransport.client
 		sharedWorkflowManagerTransport.mu.Unlock()
 		return client, nil
 	}
 	sharedWorkflowManagerTransport.mu.Unlock()
 
-	conn, err := grpc.DialContext(ctx, "unix:"+socketPath,
-		grpc.WithTransportCredentials(insecure.NewCredentials()),
-		grpc.WithBlock(),
-	)
+	network, address, err := parseWorkflowManagerTarget(target)
+	if err != nil {
+		return nil, err
+	}
+	opts := workflowManagerDialOptions(token)
+	var conn *grpc.ClientConn
+	switch network {
+	case "unix":
+		conn, err = grpc.DialContext(ctx, "passthrough:///localhost",
+			append([]grpc.DialOption{
+				grpc.WithTransportCredentials(insecure.NewCredentials()),
+				grpc.WithContextDialer(func(ctx context.Context, _ string) (net.Conn, error) {
+					var d net.Dialer
+					return d.DialContext(ctx, "unix", address)
+				}),
+				grpc.WithAuthority("localhost"),
+				grpc.WithBlock(),
+			}, opts...)...,
+		)
+	case "tcp":
+		conn, err = grpc.DialContext(ctx, address,
+			append([]grpc.DialOption{
+				grpc.WithTransportCredentials(insecure.NewCredentials()),
+				grpc.WithBlock(),
+			}, opts...)...,
+		)
+	case "tls":
+		host, _, splitErr := net.SplitHostPort(address)
+		if splitErr != nil {
+			return nil, fmt.Errorf("workflow manager: parse tls target %q: %w", address, splitErr)
+		}
+		conn, err = grpc.DialContext(ctx, address,
+			append([]grpc.DialOption{
+				grpc.WithTransportCredentials(credentials.NewTLS(&tls.Config{
+					MinVersion: tls.VersionTLS12,
+					ServerName: host,
+					NextProtos: []string{"h2"},
+				})),
+				grpc.WithBlock(),
+			}, opts...)...,
+		)
+	default:
+		return nil, fmt.Errorf("workflow manager: unsupported transport network %q", network)
+	}
 	if err != nil {
 		return nil, fmt.Errorf("workflow manager: connect to host: %w", err)
 	}
@@ -73,7 +118,7 @@ func sharedWorkflowManagerClient(ctx context.Context, socketPath string) (proto.
 	sharedWorkflowManagerTransport.mu.Lock()
 	defer sharedWorkflowManagerTransport.mu.Unlock()
 
-	if sharedWorkflowManagerTransport.conn != nil && sharedWorkflowManagerTransport.socketPath == socketPath {
+	if sharedWorkflowManagerTransport.conn != nil && sharedWorkflowManagerTransport.target == target && sharedWorkflowManagerTransport.token == token {
 		_ = conn.Close()
 		return sharedWorkflowManagerTransport.client, nil
 	}
@@ -81,10 +126,66 @@ func sharedWorkflowManagerClient(ctx context.Context, socketPath string) (proto.
 		_ = sharedWorkflowManagerTransport.conn.Close()
 	}
 
-	sharedWorkflowManagerTransport.socketPath = socketPath
+	sharedWorkflowManagerTransport.target = target
+	sharedWorkflowManagerTransport.token = token
 	sharedWorkflowManagerTransport.conn = conn
 	sharedWorkflowManagerTransport.client = client
 	return client, nil
+}
+
+func workflowManagerDialOptions(token string) []grpc.DialOption {
+	token = strings.TrimSpace(token)
+	if token == "" {
+		return nil
+	}
+	return []grpc.DialOption{grpc.WithPerRPCCredentials(workflowManagerRelayPerRPCCredentials{token: token})}
+}
+
+type workflowManagerRelayPerRPCCredentials struct {
+	token string
+}
+
+func (c workflowManagerRelayPerRPCCredentials) GetRequestMetadata(context.Context, ...string) (map[string]string, error) {
+	return map[string]string{
+		"x-gestalt-host-service-relay-token": c.token,
+	}, nil
+}
+
+func (workflowManagerRelayPerRPCCredentials) RequireTransportSecurity() bool { return false }
+
+func parseWorkflowManagerTarget(raw string) (network string, address string, err error) {
+	target := strings.TrimSpace(raw)
+	if target == "" {
+		return "", "", fmt.Errorf("workflow manager: transport target is required")
+	}
+	switch {
+	case strings.HasPrefix(target, "tcp://"):
+		address = strings.TrimSpace(strings.TrimPrefix(target, "tcp://"))
+		if address == "" {
+			return "", "", fmt.Errorf("workflow manager: tcp target %q is missing host:port", raw)
+		}
+		return "tcp", address, nil
+	case strings.HasPrefix(target, "tls://"):
+		address = strings.TrimSpace(strings.TrimPrefix(target, "tls://"))
+		if address == "" {
+			return "", "", fmt.Errorf("workflow manager: tls target %q is missing host:port", raw)
+		}
+		return "tls", address, nil
+	case strings.HasPrefix(target, "unix://"):
+		address = strings.TrimSpace(strings.TrimPrefix(target, "unix://"))
+		if address == "" {
+			return "", "", fmt.Errorf("workflow manager: unix target %q is missing a socket path", raw)
+		}
+		return "unix", address, nil
+	case strings.Contains(target, "://"):
+		parsed, parseErr := url.Parse(target)
+		if parseErr != nil {
+			return "", "", fmt.Errorf("workflow manager: parse target %q: %w", raw, parseErr)
+		}
+		return "", "", fmt.Errorf("workflow manager: unsupported target scheme %q", parsed.Scheme)
+	default:
+		return "unix", filepath.Clean(target), nil
+	}
 }
 
 func WorkflowManagerFromContext(ctx context.Context) (*WorkflowManagerClient, error) {

--- a/sdk/go/workflow_manager_transport_test.go
+++ b/sdk/go/workflow_manager_transport_test.go
@@ -1,0 +1,96 @@
+package gestalt_test
+
+import (
+	"context"
+	"net"
+	"sync"
+	"testing"
+
+	gestalt "github.com/valon-technologies/gestalt/sdk/go"
+	proto "github.com/valon-technologies/gestalt/sdk/go/gen/v1"
+	"google.golang.org/grpc"
+	"google.golang.org/grpc/metadata"
+	gproto "google.golang.org/protobuf/proto"
+)
+
+type workflowManagerTransportHarness struct {
+	proto.UnimplementedWorkflowManagerHostServer
+
+	mu       sync.Mutex
+	requests []*proto.WorkflowManagerCreateScheduleRequest
+	tokens   []string
+}
+
+func (h *workflowManagerTransportHarness) CreateSchedule(ctx context.Context, req *proto.WorkflowManagerCreateScheduleRequest) (*proto.ManagedWorkflowSchedule, error) {
+	md, _ := metadata.FromIncomingContext(ctx)
+
+	h.mu.Lock()
+	if values := md.Get("x-gestalt-host-service-relay-token"); len(values) > 0 {
+		h.tokens = append(h.tokens, values...)
+	}
+	h.requests = append(h.requests, gproto.Clone(req).(*proto.WorkflowManagerCreateScheduleRequest))
+	h.mu.Unlock()
+
+	return &proto.ManagedWorkflowSchedule{
+		ProviderName: req.GetProviderName(),
+		Schedule: &proto.BoundWorkflowSchedule{
+			Id:   "sched-1",
+			Cron: req.GetCron(),
+		},
+	}, nil
+}
+
+func TestTransport_WorkflowManagerTCPTargetTokenEnv(t *testing.T) {
+	address := reserveTCPAddress()
+	lis, err := net.Listen("tcp", address)
+	if err != nil {
+		t.Fatalf("net.Listen: %v", err)
+	}
+	t.Cleanup(func() { _ = lis.Close() })
+
+	harness := &workflowManagerTransportHarness{}
+	srv := grpc.NewServer()
+	proto.RegisterWorkflowManagerHostServer(srv, harness)
+	go func() {
+		_ = srv.Serve(lis)
+	}()
+	t.Cleanup(srv.Stop)
+
+	t.Setenv(gestalt.EnvWorkflowManagerSocket, "tcp://"+address)
+	t.Setenv(gestalt.EnvWorkflowManagerSocketToken, "relay-token-go")
+
+	client, err := gestalt.WorkflowManager("parent-token")
+	if err != nil {
+		t.Fatalf("WorkflowManager: %v", err)
+	}
+	defer func() { _ = client.Close() }()
+
+	created, err := client.CreateSchedule(context.Background(), &proto.WorkflowManagerCreateScheduleRequest{
+		ProviderName: "managed",
+		Cron:         "*/5 * * * *",
+	})
+	if err != nil {
+		t.Fatalf("CreateSchedule: %v", err)
+	}
+	if created.GetProviderName() != "managed" {
+		t.Fatalf("provider_name = %q, want %q", created.GetProviderName(), "managed")
+	}
+	if created.GetSchedule().GetId() != "sched-1" {
+		t.Fatalf("schedule id = %q, want %q", created.GetSchedule().GetId(), "sched-1")
+	}
+
+	harness.mu.Lock()
+	defer harness.mu.Unlock()
+	if len(harness.tokens) != 1 || harness.tokens[0] != "relay-token-go" {
+		t.Fatalf("relay tokens = %#v, want [relay-token-go]", harness.tokens)
+	}
+	if len(harness.requests) != 1 {
+		t.Fatalf("create schedule requests len = %d, want 1", len(harness.requests))
+	}
+	if harness.requests[0].GetInvocationToken() != "parent-token" {
+		t.Fatalf("invocation token = %q, want %q", harness.requests[0].GetInvocationToken(), "parent-token")
+	}
+	if harness.requests[0].GetProviderName() != "managed" || harness.requests[0].GetCron() != "*/5 * * * *" {
+		t.Fatalf("create schedule request = %+v, want provider_name=managed cron=*/5 * * * *", harness.requests[0])
+	}
+}

--- a/sdk/python/gestalt/__init__.py
+++ b/sdk/python/gestalt/__init__.py
@@ -69,6 +69,7 @@ _LAZY_EXPORTS = {
     "ENV_PLUGIN_INVOKER_SOCKET": ("._invoker", "ENV_PLUGIN_INVOKER_SOCKET"),
     "ENV_PLUGIN_INVOKER_SOCKET_TOKEN": ("._invoker", "ENV_PLUGIN_INVOKER_SOCKET_TOKEN"),
     "ENV_S3_SOCKET": ("._s3", "ENV_S3_SOCKET"),
+    "ENV_S3_SOCKET_TOKEN": ("._s3", "ENV_S3_SOCKET_TOKEN"),
     "ENV_WORKFLOW_HOST_SOCKET": ("._workflow", "ENV_WORKFLOW_HOST_SOCKET"),
     "ExternalTokenValidator": ("._providers", "ExternalTokenValidator"),
     "HealthChecker": ("._providers", "HealthChecker"),
@@ -115,6 +116,7 @@ _LAZY_EXPORTS = {
     "indexeddb_socket_token_env": ("._indexeddb", "indexeddb_socket_token_env"),
     "operation": ("._plugin", "operation"),
     "s3_socket_env": ("._s3", "s3_socket_env"),
+    "s3_socket_token_env": ("._s3", "s3_socket_token_env"),
     "session_catalog": ("._plugin", "session_catalog"),
 }
 
@@ -152,6 +154,7 @@ __all__ = [
     "Cursor",
     "Error",
     "ENV_S3_SOCKET",
+    "ENV_S3_SOCKET_TOKEN",
     "ENV_PLUGIN_INVOKER_SOCKET",
     "ENV_PLUGIN_INVOKER_SOCKET_TOKEN",
     "ENV_WORKFLOW_HOST_SOCKET",
@@ -215,5 +218,6 @@ __all__ = [
     "indexeddb_socket_token_env",
     "operation",
     "s3_socket_env",
+    "s3_socket_token_env",
     "session_catalog",
 ]

--- a/sdk/python/gestalt/_s3.py
+++ b/sdk/python/gestalt/_s3.py
@@ -8,7 +8,8 @@ import json
 import os
 from dataclasses import dataclass, field
 from enum import Enum
-from typing import Any, BinaryIO, Iterable, Iterator
+from typing import Any, BinaryIO, Iterable, Iterator, Protocol, cast
+from urllib import parse as _urlparse
 
 import grpc
 from google.protobuf import timestamp_pb2 as _timestamp_pb2
@@ -22,6 +23,9 @@ timestamp_pb2: Any = _timestamp_pb2
 
 #: Base environment variable for discovering S3 runtime sockets.
 ENV_S3_SOCKET = "GESTALT_S3_SOCKET"
+_S3_SOCKET_TOKEN_SUFFIX = "_TOKEN"
+_S3_RELAY_TOKEN_HEADER = "x-gestalt-host-service-relay-token"
+ENV_S3_SOCKET_TOKEN = f"{ENV_S3_SOCKET}{_S3_SOCKET_TOKEN_SUFFIX}"
 _WRITE_CHUNK_SIZE = 64 * 1024
 _UTC = _dt.timezone.utc
 BytesData = bytes
@@ -40,6 +44,12 @@ def s3_socket_env(name: str | None = None) -> str:
         for ch in trimmed
     )
     return f"{ENV_S3_SOCKET}_{normalized}"
+
+
+def s3_socket_token_env(name: str | None = None) -> str:
+    """Return the environment variable name for an S3 relay token."""
+
+    return f"{s3_socket_env(name)}{_S3_SOCKET_TOKEN_SUFFIX}"
 
 
 class S3NotFoundError(Exception):
@@ -266,15 +276,130 @@ class S3ReadStream:
         return bytes(msg.data)
 
 
+class _ClientCallDetails(grpc.ClientCallDetails):
+    def __init__(
+        self,
+        method: str,
+        timeout: float | None,
+        metadata: Any,
+        credentials: Any,
+        wait_for_ready: bool | None,
+        compression: Any,
+    ) -> None:
+        self.method = method
+        self.timeout = timeout
+        self.metadata = metadata
+        self.credentials = credentials
+        self.wait_for_ready = wait_for_ready
+        self.compression = compression
+
+
+class _ClientCallDetailsFields(Protocol):
+    method: str
+    timeout: float | None
+    metadata: Any
+    credentials: Any
+    wait_for_ready: bool | None
+    compression: Any
+
+
+class _RelayTokenInterceptor(
+    grpc.UnaryUnaryClientInterceptor,
+    grpc.UnaryStreamClientInterceptor,
+    grpc.StreamUnaryClientInterceptor,
+):
+    def __init__(self, token: str) -> None:
+        self._token = token
+
+    def _details(self, client_call_details: grpc.ClientCallDetails) -> grpc.ClientCallDetails:
+        details = cast(_ClientCallDetailsFields, client_call_details)
+        metadata = list(details.metadata or [])
+        metadata.append((_S3_RELAY_TOKEN_HEADER, self._token))
+        return _ClientCallDetails(
+            details.method,
+            details.timeout,
+            metadata,
+            details.credentials,
+            details.wait_for_ready,
+            details.compression,
+        )
+
+    def intercept_unary_unary(
+        self,
+        continuation: Any,
+        client_call_details: grpc.ClientCallDetails,
+        request: Any,
+    ) -> Any:
+        return continuation(self._details(client_call_details), request)
+
+    def intercept_unary_stream(
+        self,
+        continuation: Any,
+        client_call_details: grpc.ClientCallDetails,
+        request: Any,
+    ) -> Any:
+        return continuation(self._details(client_call_details), request)
+
+    def intercept_stream_unary(
+        self,
+        continuation: Any,
+        client_call_details: grpc.ClientCallDetails,
+        request_iterator: Any,
+    ) -> Any:
+        return continuation(self._details(client_call_details), request_iterator)
+
+
+def _s3_channel(target: str, *, token: str = "") -> Any:
+    scheme, address = _parse_s3_target(target)
+    if scheme == "unix":
+        channel = grpc.insecure_channel(f"unix:{address}")
+    elif scheme == "tcp":
+        channel = grpc.insecure_channel(address)
+    elif scheme == "tls":
+        channel = grpc.secure_channel(address, grpc.ssl_channel_credentials())
+    else:
+        raise RuntimeError(f"unsupported s3 transport scheme {scheme!r}")
+    token = token.strip()
+    if not token:
+        return channel
+    return grpc.intercept_channel(channel, _RelayTokenInterceptor(token))
+
+
+def _parse_s3_target(raw: str) -> tuple[str, str]:
+    target = raw.strip()
+    if not target:
+        raise RuntimeError("s3 transport target is required")
+    if target.startswith("tcp://"):
+        address = target.removeprefix("tcp://").strip()
+        if not address:
+            raise RuntimeError(f"s3 tcp target {raw!r} is missing host:port")
+        return "tcp", address
+    if target.startswith("tls://"):
+        address = target.removeprefix("tls://").strip()
+        if not address:
+            raise RuntimeError(f"s3 tls target {raw!r} is missing host:port")
+        return "tls", address
+    if target.startswith("unix://"):
+        address = target.removeprefix("unix://").strip()
+        if not address:
+            raise RuntimeError(f"s3 unix target {raw!r} is missing a socket path")
+        return "unix", address
+    if "://" in target:
+        parsed = _urlparse.urlparse(target)
+        raise RuntimeError(f"unsupported s3 target scheme {parsed.scheme!r}")
+    return "unix", target
+
+
 class S3:
     """Client for a host-provided Gestalt S3 runtime."""
 
     def __init__(self, name: str | None = None) -> None:
         env_name = s3_socket_env(name)
-        socket_path = os.environ.get(env_name, "")
-        if not socket_path:
+        target = os.environ.get(env_name, "")
+        if not target:
             raise RuntimeError(f"{env_name} is not set")
-        self._channel = grpc.insecure_channel(f"unix:{socket_path}")
+        token = os.environ.get(s3_socket_token_env(name), "")
+        self._channel = _s3_channel(target, token=token)
         self._stub = pb_grpc.S3Stub(self._channel)
 
     def close(self) -> None:

--- a/sdk/python/tests/test_s3_transport.py
+++ b/sdk/python/tests/test_s3_transport.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 import datetime as dt
 import io
 import os
+import socket
 import subprocess
 import tempfile
 import unittest
@@ -22,6 +23,7 @@ from gestalt import (
     S3PreconditionFailedError,
     WriteOptions,
     s3_socket_env,
+    s3_socket_token_env,
 )
 
 
@@ -77,6 +79,32 @@ def tearDownModule() -> None:
         os.remove(_socket_path)
 
 
+def _reserve_tcp_address() -> str:
+    with socket.socket(socket.AF_INET, socket.SOCK_STREAM) as sock:
+        sock.bind(("127.0.0.1", 0))
+        host, port = sock.getsockname()
+    return f"{host}:{port}"
+
+
+def _start_tcp_harness(expect_token: str = "") -> tuple[subprocess.Popen[bytes], str]:
+    harness_bin = _build_harness()
+    address = _reserve_tcp_address()
+    args = [harness_bin, "--tcp", address]
+    if expect_token:
+        args.extend(["--expect-token", expect_token])
+    proc = subprocess.Popen(
+        args,
+        stdout=subprocess.PIPE,
+    )
+    assert proc.stdout is not None
+    line = proc.stdout.readline().decode().strip()
+    proc.stdout.close()
+    if line != "READY":
+        proc.kill()
+        raise RuntimeError(f"tcp harness did not print READY, got: {line!r}")
+    return proc, f"tcp://{address}"
+
+
 def _client() -> S3:
     return S3()
 
@@ -91,6 +119,62 @@ class TestNamedSocketEnv(unittest.TestCase):
 
     def test_named_socket_env_matches_host_ascii_normalization(self) -> None:
         self.assertEqual(s3_socket_env("sø3"), "GESTALT_S3_SOCKET_S_3")
+
+
+class TestTCPTargetEnv(unittest.TestCase):
+    def test_tcp_target_roundtrip(self) -> None:
+        proc, target = _start_tcp_harness()
+        self.addCleanup(proc.wait)
+        self.addCleanup(proc.kill)
+
+        env_name = s3_socket_env()
+        previous_target = os.environ.get(env_name)
+
+        def restore_target() -> None:
+            if previous_target is None:
+                os.environ.pop(env_name, None)
+            else:
+                os.environ[env_name] = previous_target
+
+        os.environ[env_name] = target
+        self.addCleanup(restore_target)
+
+        client = _client()
+        obj = client.object("docs", "tcp.txt")
+        obj.write_text("tcp")
+        self.assertEqual(obj.text(), "tcp")
+        client.close()
+
+    def test_tcp_target_token_roundtrip(self) -> None:
+        token = "relay-token-python"
+        proc, target = _start_tcp_harness(expect_token=token)
+        self.addCleanup(proc.wait)
+        self.addCleanup(proc.kill)
+
+        target_env = s3_socket_env()
+        token_env = s3_socket_token_env()
+        previous_target = os.environ.get(target_env)
+        previous_token = os.environ.get(token_env)
+
+        def restore_env() -> None:
+            if previous_target is None:
+                os.environ.pop(target_env, None)
+            else:
+                os.environ[target_env] = previous_target
+            if previous_token is None:
+                os.environ.pop(token_env, None)
+            else:
+                os.environ[token_env] = previous_token
+
+        os.environ[target_env] = target
+        os.environ[token_env] = token
+        self.addCleanup(restore_env)
+
+        client = _client()
+        obj = client.object("docs", "tcp-token.txt")
+        obj.write_text("token")
+        self.assertEqual(obj.text(), "token")
+        client.close()
 
 
 class TestWriteReadRoundTrip(unittest.TestCase):

--- a/sdk/rust/src/lib.rs
+++ b/sdk/rust/src/lib.rs
@@ -59,11 +59,16 @@ pub use manifest_metadata::{
 #[doc(hidden)]
 pub use provider_server::{OperationResult, ProviderServer};
 pub use router::{Operation, Router};
-pub use s3::{S3, S3Error, S3Provider};
+pub use s3::{
+    ENV_S3_SOCKET, ENV_S3_SOCKET_TOKEN, S3, S3Error, S3Provider, s3_socket_env, s3_socket_token_env,
+};
 pub use secrets::SecretsProvider;
 pub use tonic::codegen::async_trait;
 pub use workflow::{ENV_WORKFLOW_HOST_SOCKET, WorkflowHost, WorkflowHostError, WorkflowProvider};
-pub use workflow_manager::{ENV_WORKFLOW_MANAGER_SOCKET, WorkflowManager, WorkflowManagerError};
+pub use workflow_manager::{
+    ENV_WORKFLOW_MANAGER_SOCKET, ENV_WORKFLOW_MANAGER_SOCKET_TOKEN, WorkflowManager,
+    WorkflowManagerError,
+};
 
 #[doc(hidden)]
 pub trait IntoRouterResult<P> {

--- a/sdk/rust/src/s3.rs
+++ b/sdk/rust/src/s3.rs
@@ -6,6 +6,9 @@ use hyper_util::rt::TokioIo;
 use serde::de::DeserializeOwned;
 use tokio_stream::iter;
 use tonic::codegen::async_trait;
+use tonic::metadata::MetadataValue;
+use tonic::service::Interceptor;
+use tonic::service::interceptor::InterceptedService;
 use tonic::transport::{Channel, Endpoint, Uri};
 use tower::service_fn;
 
@@ -14,9 +17,13 @@ use crate::error::Result as ProviderResult;
 use crate::generated::v1::{self as pb, s3_client::S3Client as ProtoS3Client};
 
 type ClientResult<T> = std::result::Result<T, S3Error>;
+type S3Transport = InterceptedService<Channel, RelayTokenInterceptor>;
 
 /// Default Unix-socket environment variable used by [`S3::connect`].
 pub const ENV_S3_SOCKET: &str = "GESTALT_S3_SOCKET";
+pub const ENV_S3_SOCKET_TOKEN_SUFFIX: &str = "_TOKEN";
+pub const ENV_S3_SOCKET_TOKEN: &str = "GESTALT_S3_SOCKET_TOKEN";
+const S3_RELAY_TOKEN_HEADER: &str = "x-gestalt-host-service-relay-token";
 const WRITE_CHUNK_SIZE: usize = 64 * 1024;
 
 #[derive(Debug, thiserror::Error)]
@@ -241,7 +248,7 @@ where
 
 /// Client for a running S3 provider.
 pub struct S3 {
-    client: ProtoS3Client<Channel>,
+    client: ProtoS3Client<S3Transport>,
 }
 
 impl S3 {
@@ -253,22 +260,40 @@ impl S3 {
     /// Connects to a named S3 transport socket.
     pub async fn connect_named(name: &str) -> ClientResult<Self> {
         let env_name = s3_socket_env(name);
-        let socket_path =
+        let target =
             std::env::var(&env_name).map_err(|_| S3Error::Env(format!("{env_name} is not set")))?;
+        let token = std::env::var(s3_socket_token_env(name)).unwrap_or_default();
 
-        let channel = Endpoint::try_from("http://[::]:50051")?
-            .connect_with_connector(service_fn(move |_: Uri| {
-                let path = socket_path.clone();
-                async move {
-                    tokio::net::UnixStream::connect(path)
-                        .await
-                        .map(TokioIo::new)
-                }
-            }))
-            .await?;
+        let channel = match parse_s3_target(&target)? {
+            S3Target::Unix(path) => {
+                Endpoint::try_from("http://[::]:50051")?
+                    .connect_with_connector(service_fn(move |_: Uri| {
+                        let path = path.clone();
+                        async move {
+                            tokio::net::UnixStream::connect(path)
+                                .await
+                                .map(TokioIo::new)
+                        }
+                    }))
+                    .await?
+            }
+            S3Target::Tcp(address) => {
+                Endpoint::from_shared(format!("http://{address}"))?
+                    .connect()
+                    .await?
+            }
+            S3Target::Tls(address) => {
+                Endpoint::from_shared(format!("https://{address}"))?
+                    .connect()
+                    .await?
+            }
+        };
 
         Ok(Self {
-            client: ProtoS3Client::new(channel),
+            client: ProtoS3Client::with_interceptor(
+                channel,
+                relay_token_interceptor(token.trim())?,
+            ),
         })
     }
 
@@ -528,7 +553,7 @@ impl S3 {
 
 /// Convenience wrapper around repeated operations on one object key.
 pub struct Object {
-    client: ProtoS3Client<Channel>,
+    client: ProtoS3Client<S3Transport>,
     reference: ObjectRef,
 }
 
@@ -755,6 +780,90 @@ pub fn s3_socket_env(name: &str) -> String {
         }
     }
     env
+}
+
+/// Returns the environment variable used for a named S3 relay token.
+pub fn s3_socket_token_env(name: &str) -> String {
+    if name.trim().is_empty() {
+        return ENV_S3_SOCKET_TOKEN.to_string();
+    }
+    format!("{}{}", s3_socket_env(name), ENV_S3_SOCKET_TOKEN_SUFFIX)
+}
+
+enum S3Target {
+    Unix(String),
+    Tcp(String),
+    Tls(String),
+}
+
+fn parse_s3_target(raw_target: &str) -> Result<S3Target, S3Error> {
+    let target = raw_target.trim();
+    if target.is_empty() {
+        return Err(S3Error::Env("S3 transport target is required".to_string()));
+    }
+    if let Some(address) = target.strip_prefix("tcp://") {
+        let address = address.trim();
+        if address.is_empty() {
+            return Err(S3Error::Env(format!(
+                "S3 tcp target {raw_target:?} is missing host:port"
+            )));
+        }
+        return Ok(S3Target::Tcp(address.to_string()));
+    }
+    if let Some(address) = target.strip_prefix("tls://") {
+        let address = address.trim();
+        if address.is_empty() {
+            return Err(S3Error::Env(format!(
+                "S3 tls target {raw_target:?} is missing host:port"
+            )));
+        }
+        return Ok(S3Target::Tls(address.to_string()));
+    }
+    if let Some(path) = target.strip_prefix("unix://") {
+        let path = path.trim();
+        if path.is_empty() {
+            return Err(S3Error::Env(format!(
+                "S3 unix target {raw_target:?} is missing a socket path"
+            )));
+        }
+        return Ok(S3Target::Unix(path.to_string()));
+    }
+    if target.contains("://") {
+        let scheme = target.split("://").next().unwrap_or_default();
+        return Err(S3Error::Env(format!(
+            "unsupported S3 target scheme {scheme:?}"
+        )));
+    }
+    Ok(S3Target::Unix(target.to_string()))
+}
+
+fn relay_token_interceptor(token: &str) -> Result<RelayTokenInterceptor, S3Error> {
+    let header = if token.trim().is_empty() {
+        None
+    } else {
+        Some(
+            MetadataValue::try_from(token.to_string())
+                .map_err(|err| S3Error::Env(format!("invalid S3 relay token metadata: {err}")))?,
+        )
+    };
+    Ok(RelayTokenInterceptor { header })
+}
+
+#[derive(Clone)]
+struct RelayTokenInterceptor {
+    header: Option<MetadataValue<tonic::metadata::Ascii>>,
+}
+
+impl Interceptor for RelayTokenInterceptor {
+    fn call(
+        &mut self,
+        mut request: tonic::Request<()>,
+    ) -> std::result::Result<tonic::Request<()>, tonic::Status> {
+        if let Some(header) = self.header.clone() {
+            request.metadata_mut().insert(S3_RELAY_TOKEN_HEADER, header);
+        }
+        Ok(request)
+    }
 }
 
 fn map_status(err: tonic::Status) -> S3Error {

--- a/sdk/rust/src/workflow_manager.rs
+++ b/sdk/rust/src/workflow_manager.rs
@@ -1,5 +1,9 @@
 use hyper_util::rt::TokioIo;
 use tokio::net::UnixStream;
+use tonic::Request;
+use tonic::metadata::MetadataValue;
+use tonic::service::Interceptor;
+use tonic::service::interceptor::InterceptedService;
 use tonic::transport::{Channel, Endpoint, Uri};
 use tower::service_fn;
 
@@ -8,7 +12,11 @@ use crate::generated::v1::{
     workflow_manager_host_client::WorkflowManagerHostClient as ProtoWorkflowManagerHostClient,
 };
 
+type WorkflowManagerTransport = InterceptedService<Channel, RelayTokenInterceptor>;
+
 pub const ENV_WORKFLOW_MANAGER_SOCKET: &str = "GESTALT_WORKFLOW_MANAGER_SOCKET";
+pub const ENV_WORKFLOW_MANAGER_SOCKET_TOKEN: &str = "GESTALT_WORKFLOW_MANAGER_SOCKET_TOKEN";
+const WORKFLOW_MANAGER_RELAY_TOKEN_HEADER: &str = "x-gestalt-host-service-relay-token";
 
 #[derive(Debug, thiserror::Error)]
 pub enum WorkflowManagerError {
@@ -23,7 +31,7 @@ pub enum WorkflowManagerError {
 }
 
 pub struct WorkflowManager {
-    client: ProtoWorkflowManagerHostClient<Channel>,
+    client: ProtoWorkflowManagerHostClient<WorkflowManagerTransport>,
     invocation_token: String,
 }
 
@@ -39,15 +47,33 @@ impl WorkflowManager {
         let socket_path = std::env::var(ENV_WORKFLOW_MANAGER_SOCKET).map_err(|_| {
             WorkflowManagerError::Env(format!("{ENV_WORKFLOW_MANAGER_SOCKET} is not set"))
         })?;
-        let channel = Endpoint::try_from("http://[::]:50051")?
-            .connect_with_connector(service_fn(move |_: Uri| {
-                let path = socket_path.clone();
-                async move { UnixStream::connect(path).await.map(TokioIo::new) }
-            }))
-            .await?;
+        let relay_token = std::env::var(ENV_WORKFLOW_MANAGER_SOCKET_TOKEN).unwrap_or_default();
+        let channel = match parse_workflow_manager_target(&socket_path)? {
+            WorkflowManagerTarget::Unix(path) => {
+                Endpoint::try_from("http://[::]:50051")?
+                    .connect_with_connector(service_fn(move |_: Uri| {
+                        let path = path.clone();
+                        async move { UnixStream::connect(path).await.map(TokioIo::new) }
+                    }))
+                    .await?
+            }
+            WorkflowManagerTarget::Tcp(address) => {
+                Endpoint::from_shared(format!("http://{address}"))?
+                    .connect()
+                    .await?
+            }
+            WorkflowManagerTarget::Tls(address) => {
+                Endpoint::from_shared(format!("https://{address}"))?
+                    .connect()
+                    .await?
+            }
+        };
 
         Ok(Self {
-            client: ProtoWorkflowManagerHostClient::new(channel),
+            client: ProtoWorkflowManagerHostClient::with_interceptor(
+                channel,
+                relay_token_interceptor(relay_token.trim())?,
+            ),
             invocation_token,
         })
     }
@@ -169,4 +195,89 @@ impl WorkflowManager {
         request.invocation_token = self.invocation_token.clone();
         Ok(self.client.publish_event(request).await?.into_inner())
     }
+}
+
+#[derive(Clone)]
+struct RelayTokenInterceptor {
+    token: Option<MetadataValue<tonic::metadata::Ascii>>,
+}
+
+impl Interceptor for RelayTokenInterceptor {
+    fn call(
+        &mut self,
+        mut request: Request<()>,
+    ) -> std::result::Result<Request<()>, tonic::Status> {
+        if let Some(token) = self.token.clone() {
+            request
+                .metadata_mut()
+                .insert(WORKFLOW_MANAGER_RELAY_TOKEN_HEADER, token);
+        }
+        Ok(request)
+    }
+}
+
+fn relay_token_interceptor(
+    token: &str,
+) -> std::result::Result<RelayTokenInterceptor, WorkflowManagerError> {
+    let trimmed = token.trim();
+    let token = if trimmed.is_empty() {
+        None
+    } else {
+        Some(MetadataValue::try_from(trimmed).map_err(|err| {
+            WorkflowManagerError::Env(format!(
+                "workflow manager: invalid relay token metadata: {err}"
+            ))
+        })?)
+    };
+    Ok(RelayTokenInterceptor { token })
+}
+
+enum WorkflowManagerTarget {
+    Unix(String),
+    Tcp(String),
+    Tls(String),
+}
+
+fn parse_workflow_manager_target(
+    raw: &str,
+) -> std::result::Result<WorkflowManagerTarget, WorkflowManagerError> {
+    let target = raw.trim();
+    if target.is_empty() {
+        return Err(WorkflowManagerError::Env(
+            "workflow manager: transport target is required".to_string(),
+        ));
+    }
+    if let Some(address) = target.strip_prefix("tcp://") {
+        let address = address.trim();
+        if address.is_empty() {
+            return Err(WorkflowManagerError::Env(format!(
+                "workflow manager: tcp target {raw:?} is missing host:port"
+            )));
+        }
+        return Ok(WorkflowManagerTarget::Tcp(address.to_string()));
+    }
+    if let Some(address) = target.strip_prefix("tls://") {
+        let address = address.trim();
+        if address.is_empty() {
+            return Err(WorkflowManagerError::Env(format!(
+                "workflow manager: tls target {raw:?} is missing host:port"
+            )));
+        }
+        return Ok(WorkflowManagerTarget::Tls(address.to_string()));
+    }
+    if let Some(path) = target.strip_prefix("unix://") {
+        let path = path.trim();
+        if path.is_empty() {
+            return Err(WorkflowManagerError::Env(format!(
+                "workflow manager: unix target {raw:?} is missing a socket path"
+            )));
+        }
+        return Ok(WorkflowManagerTarget::Unix(path.to_string()));
+    }
+    if target.contains("://") {
+        return Err(WorkflowManagerError::Env(format!(
+            "workflow manager: unsupported target scheme in {raw:?}"
+        )));
+    }
+    Ok(WorkflowManagerTarget::Unix(target.to_string()))
 }

--- a/sdk/rust/tests/s3_transport.rs
+++ b/sdk/rust/tests/s3_transport.rs
@@ -3,12 +3,13 @@ mod helpers;
 
 use std::collections::BTreeMap;
 use std::io::{BufRead, BufReader};
+use std::net::TcpListener;
 use std::process::{Command, Stdio};
 use std::time::Duration;
 
 use gestalt::s3::{
-    ByteRange, ENV_S3_SOCKET, ListOptions, PresignMethod, PresignOptions, ReadOptions, S3, S3Error,
-    WriteOptions, s3_socket_env,
+    ByteRange, ENV_S3_SOCKET, ENV_S3_SOCKET_TOKEN, ListOptions, PresignMethod, PresignOptions,
+    ReadOptions, S3, S3Error, WriteOptions, s3_socket_env, s3_socket_token_env,
 };
 
 struct Harness {
@@ -67,6 +68,62 @@ async fn start_harness(socket_name: &str, env_name: &str) -> Harness {
     );
 
     let env_guard = helpers::EnvGuard::set(env_name.to_string(), socket.as_os_str());
+    Harness {
+        child,
+        _env_guard: env_guard,
+    }
+}
+
+async fn start_tcp_harness(expect_token: Option<&str>, env_name: &str) -> Harness {
+    let repo_root = std::path::Path::new(env!("CARGO_MANIFEST_DIR"))
+        .parent()
+        .unwrap()
+        .parent()
+        .unwrap();
+
+    let tmp = std::env::temp_dir();
+    let binary = tmp.join("s3transportd");
+
+    let build = Command::new("go")
+        .arg("build")
+        .arg("-o")
+        .arg(&binary)
+        .arg("./internal/testutil/cmd/s3transportd/")
+        .current_dir(repo_root.join("gestaltd"))
+        .output()
+        .expect("go build");
+    assert!(
+        build.status.success(),
+        "go build failed: {}",
+        String::from_utf8_lossy(&build.stderr)
+    );
+
+    let listener = TcpListener::bind("127.0.0.1:0").expect("bind tcp listener");
+    let address = listener.local_addr().expect("tcp local addr");
+    drop(listener);
+
+    let mut command = Command::new(&binary);
+    command.arg("--tcp").arg(address.to_string());
+    if let Some(token) = expect_token {
+        command.arg("--expect-token").arg(token);
+    }
+    let mut child = command
+        .stdout(Stdio::piped())
+        .stderr(Stdio::inherit())
+        .spawn()
+        .expect("spawn tcp harness");
+
+    let stdout = child.stdout.take().unwrap();
+    let mut reader = BufReader::new(stdout);
+    let mut line = String::new();
+    reader.read_line(&mut line).expect("read READY");
+    assert!(
+        line.trim() == "READY",
+        "expected READY, got: {:?}",
+        line.trim()
+    );
+
+    let env_guard = helpers::EnvGuard::set(env_name.to_string(), format!("tcp://{address}"));
     Harness {
         child,
         _env_guard: env_guard,
@@ -165,6 +222,61 @@ async fn named_socket_json_and_preconditions() {
         Err(S3Error::PreconditionFailed) => {}
         other => panic!("expected PreconditionFailed, got: {other:?}"),
     }
+}
+
+#[tokio::test]
+async fn tcp_target_round_trip() {
+    let _lock = helpers::env_lock().lock().await;
+    let _harness = start_tcp_harness(None, ENV_S3_SOCKET).await;
+
+    let s3 = S3::connect().await.expect("connect");
+    let mut object = s3.object("bucket", "docs/tcp.txt");
+    object
+        .write_string("tcp", None)
+        .await
+        .expect("write tcp target");
+
+    assert_eq!(object.text(None).await.expect("read tcp target"), "tcp");
+}
+
+#[tokio::test]
+async fn tcp_target_with_token_round_trip() {
+    let _lock = helpers::env_lock().lock().await;
+    let _harness = start_tcp_harness(Some("relay-token-rust"), ENV_S3_SOCKET).await;
+    let _token_env = helpers::EnvGuard::set(ENV_S3_SOCKET_TOKEN, "relay-token-rust");
+
+    let s3 = S3::connect().await.expect("connect");
+    let mut object = s3.object("bucket", "docs/tcp-token.txt");
+    object
+        .write_string("tcp-token", None)
+        .await
+        .expect("write tcp token target");
+
+    assert_eq!(
+        object.text(None).await.expect("read tcp token target"),
+        "tcp-token"
+    );
+}
+
+#[tokio::test]
+async fn named_tcp_target_uses_named_token_env() {
+    let _lock = helpers::env_lock().lock().await;
+    let env_name = s3_socket_env("reports");
+    let _harness = start_tcp_harness(Some("named-relay-token-rust"), &env_name).await;
+    let _token_env =
+        helpers::EnvGuard::set(s3_socket_token_env("reports"), "named-relay-token-rust");
+
+    let s3 = S3::connect_named("reports").await.expect("connect");
+    let mut object = s3.object("bucket", "reports/named-tcp.txt");
+    object
+        .write_string("named-tcp", None)
+        .await
+        .expect("write named tcp target");
+
+    assert_eq!(
+        object.text(None).await.expect("read named tcp target"),
+        "named-tcp"
+    );
 }
 
 #[tokio::test]

--- a/sdk/rust/tests/workflow_manager_transport.rs
+++ b/sdk/rust/tests/workflow_manager_transport.rs
@@ -18,9 +18,11 @@ use gestalt::proto::v1::{
     WorkflowManagerResumeScheduleRequest, WorkflowManagerUpdateEventTriggerRequest,
     WorkflowManagerUpdateScheduleRequest,
 };
-use gestalt::{ENV_WORKFLOW_MANAGER_SOCKET, Request, WorkflowManager};
-use tokio::net::UnixListener;
-use tokio_stream::wrappers::UnixListenerStream;
+use gestalt::{
+    ENV_WORKFLOW_MANAGER_SOCKET, ENV_WORKFLOW_MANAGER_SOCKET_TOKEN, Request, WorkflowManager,
+};
+use tokio::net::{TcpListener, UnixListener};
+use tokio_stream::wrappers::{TcpListenerStream, UnixListenerStream};
 use tonic::codegen::async_trait;
 use tonic::transport::Server;
 use tonic::{Request as GrpcRequest, Response as GrpcResponse, Status};
@@ -37,6 +39,7 @@ struct SeenRequest {
 #[derive(Clone, Default)]
 struct TestWorkflowManagerServer {
     seen: Arc<Mutex<Vec<SeenRequest>>>,
+    relay_tokens: Arc<Mutex<Vec<String>>>,
 }
 
 #[async_trait]
@@ -45,6 +48,12 @@ impl ProtoWorkflowManagerHost for TestWorkflowManagerServer {
         &self,
         request: GrpcRequest<WorkflowManagerCreateScheduleRequest>,
     ) -> std::result::Result<GrpcResponse<ManagedWorkflowSchedule>, Status> {
+        if let Some(token) = request.metadata().get("x-gestalt-host-service-relay-token") {
+            self.relay_tokens
+                .lock()
+                .expect("lock relay tokens")
+                .push(token.to_str().expect("relay token ascii").to_string());
+        }
         let request = request.into_inner();
         self.seen.lock().expect("lock seen").push(SeenRequest {
             method: "create".to_string(),
@@ -337,6 +346,53 @@ impl ProtoWorkflowManagerHost for TestWorkflowManagerServer {
         }
         Ok(GrpcResponse::new(event))
     }
+}
+
+#[tokio::test]
+async fn workflow_manager_connects_over_tcp_and_sends_relay_token() {
+    let _env_lock = helpers::env_lock().lock().await;
+
+    let listener = TcpListener::bind("127.0.0.1:0")
+        .await
+        .expect("bind tcp listener");
+    let address = listener.local_addr().expect("local addr");
+    let _socket_guard =
+        helpers::EnvGuard::set(ENV_WORKFLOW_MANAGER_SOCKET, format!("tcp://{address}"));
+    let _token_guard =
+        helpers::EnvGuard::set(ENV_WORKFLOW_MANAGER_SOCKET_TOKEN, "relay-token-rust");
+
+    let server = TestWorkflowManagerServer::default();
+    let serve_server = server.clone();
+    let serve_task = tokio::spawn(async move {
+        serve_workflow_manager_tcp(serve_server, listener)
+            .await
+            .expect("serve workflow manager");
+    });
+
+    let mut manager = WorkflowManager::connect("token-123")
+        .await
+        .expect("connect workflow manager");
+    let created = manager
+        .create_schedule(WorkflowManagerCreateScheduleRequest {
+            provider_name: "managed".to_string(),
+            cron: "*/5 * * * *".to_string(),
+            ..Default::default()
+        })
+        .await
+        .expect("create schedule");
+
+    assert_eq!(created.provider_name, "managed");
+    assert_eq!(created.schedule.expect("created schedule").id, "sched-1");
+
+    let relay_tokens = server
+        .relay_tokens
+        .lock()
+        .expect("lock relay tokens")
+        .clone();
+    assert_eq!(relay_tokens, vec!["relay-token-rust".to_string()]);
+
+    serve_task.abort();
+    let _ = serve_task.await;
 }
 
 #[tokio::test]
@@ -672,5 +728,15 @@ async fn serve_workflow_manager(
     Server::builder()
         .add_service(WorkflowManagerHostServer::new(server))
         .serve_with_incoming(UnixListenerStream::new(listener))
+        .await
+}
+
+async fn serve_workflow_manager_tcp(
+    server: TestWorkflowManagerServer,
+    listener: TcpListener,
+) -> std::result::Result<(), tonic::transport::Error> {
+    Server::builder()
+        .add_service(WorkflowManagerHostServer::new(server))
+        .serve_with_incoming(TcpListenerStream::new(listener))
         .await
 }

--- a/sdk/typescript/src/index.ts
+++ b/sdk/typescript/src/index.ts
@@ -107,6 +107,7 @@ export {
 } from "./invoker.ts";
 export {
   ENV_WORKFLOW_MANAGER_SOCKET,
+  ENV_WORKFLOW_MANAGER_SOCKET_TOKEN,
   WorkflowManager,
   type ManagedWorkflowEventTriggerMessage,
   type ManagedWorkflowScheduleMessage,
@@ -255,7 +256,10 @@ export {
   createS3Service,
   defineS3Provider,
   isS3Provider,
+  ENV_S3_SOCKET,
+  ENV_S3_SOCKET_TOKEN,
   s3SocketEnv,
+  s3SocketTokenEnv,
   type ByteRange,
   type CopyOptions,
   type ListOptions,

--- a/sdk/typescript/src/s3.ts
+++ b/sdk/typescript/src/s3.ts
@@ -1,3 +1,5 @@
+import { connect } from "node:net";
+
 import { create } from "@bufbuild/protobuf";
 import { EmptySchema } from "@bufbuild/protobuf/wkt";
 import {
@@ -5,6 +7,7 @@ import {
   ConnectError,
   createClient,
   type Client,
+  type Interceptor,
   type ServiceImpl,
 } from "@connectrpc/connect";
 import { createGrpcTransport } from "@connectrpc/connect-node";
@@ -22,7 +25,10 @@ import {
 import { errorMessage, type MaybePromise } from "./api.ts";
 import { RuntimeProvider, type RuntimeProviderOptions } from "./provider.ts";
 
-const ENV_S3_SOCKET = "GESTALT_S3_SOCKET";
+export const ENV_S3_SOCKET = "GESTALT_S3_SOCKET";
+const S3_SOCKET_TOKEN_SUFFIX = "_TOKEN";
+const S3_RELAY_TOKEN_HEADER = "x-gestalt-host-service-relay-token";
+export const ENV_S3_SOCKET_TOKEN = `${ENV_S3_SOCKET}${S3_SOCKET_TOKEN_SUFFIX}`;
 const WRITE_CHUNK_SIZE = 64 * 1024;
 const textEncoder = new TextEncoder();
 
@@ -33,6 +39,13 @@ export function s3SocketEnv(name?: string): string {
   const trimmed = name?.trim() ?? "";
   if (!trimmed) return ENV_S3_SOCKET;
   return `${ENV_S3_SOCKET}_${trimmed.replace(/[^A-Za-z0-9]/g, "_").toUpperCase()}`;
+}
+
+/**
+ * Returns the environment variable name used to discover an S3 relay token.
+ */
+export function s3SocketTokenEnv(name?: string): string {
+  return `${s3SocketEnv(name)}${S3_SOCKET_TOKEN_SUFFIX}`;
 }
 
 /**
@@ -496,15 +509,30 @@ export class S3 {
 
   constructor(name?: string) {
     const envName = s3SocketEnv(name);
-    const socketPath = process.env[envName];
-    if (!socketPath) {
+    const target = process.env[envName];
+    if (!target) {
       throw new Error(`${envName} is not set`);
     }
+    const relayToken = process.env[s3SocketTokenEnv(name)]?.trim() ?? "";
+    const transportOptions = s3TransportOptions(target);
+    const interceptors: Interceptor[] = relayToken
+      ? [
+          (next) => async (req) => {
+            req.header.set(S3_RELAY_TOKEN_HEADER, relayToken);
+            return await next(req);
+          },
+        ]
+      : [];
     const transport = createGrpcTransport({
-      baseUrl: unixSocketBaseUrl(socketPath),
-      nodeOptions: {
-        path: socketPath,
-      },
+      ...transportOptions,
+      ...(transportOptions.nodeOptions
+        ? {
+            nodeOptions: {
+              createConnection: () => connect(transportOptions.nodeOptions!.path),
+            },
+          }
+        : {}),
+      interceptors,
     });
     this.client = createClient(S3Service, transport);
   }
@@ -745,6 +773,48 @@ function unixSocketBaseUrl(socketPath: string): string {
     hash = Math.imul(hash, 0x01000193);
   }
   return `http://unix-${(hash >>> 0).toString(16)}.local`;
+}
+
+function s3TransportOptions(rawTarget: string): {
+  baseUrl: string;
+  nodeOptions?: { path: string };
+} {
+  const target = rawTarget.trim();
+  if (!target) {
+    throw new Error("s3 transport target is required");
+  }
+  if (target.startsWith("tcp://")) {
+    const address = target.slice("tcp://".length).trim();
+    if (!address) {
+      throw new Error(`s3 tcp target ${JSON.stringify(rawTarget)} is missing host:port`);
+    }
+    return { baseUrl: `http://${address}` };
+  }
+  if (target.startsWith("tls://")) {
+    const address = target.slice("tls://".length).trim();
+    if (!address) {
+      throw new Error(`s3 tls target ${JSON.stringify(rawTarget)} is missing host:port`);
+    }
+    return { baseUrl: `https://${address}` };
+  }
+  if (target.startsWith("unix://")) {
+    const socketPath = target.slice("unix://".length).trim();
+    if (!socketPath) {
+      throw new Error(`s3 unix target ${JSON.stringify(rawTarget)} is missing a socket path`);
+    }
+    return {
+      baseUrl: unixSocketBaseUrl(socketPath),
+      nodeOptions: { path: socketPath },
+    };
+  }
+  if (target.includes("://")) {
+    const parsed = new URL(target);
+    throw new Error(`Unsupported s3 target scheme ${JSON.stringify(parsed.protocol.replace(/:$/, ""))}`);
+  }
+  return {
+    baseUrl: unixSocketBaseUrl(target),
+    nodeOptions: { path: target },
+  };
 }
 
 async function invokeS3Provider<T>(label: string, fn: () => Promise<T>): Promise<T> {

--- a/sdk/typescript/src/workflow-manager.ts
+++ b/sdk/typescript/src/workflow-manager.ts
@@ -1,7 +1,9 @@
-import { connect } from "node:net";
-
 import type { MessageInitShape } from "@bufbuild/protobuf";
-import { createClient, type Client } from "@connectrpc/connect";
+import {
+  createClient,
+  type Client,
+  type Interceptor,
+} from "@connectrpc/connect";
 import { createGrpcTransport } from "@connectrpc/connect-node";
 
 import {
@@ -26,6 +28,9 @@ import {
 import type { Request } from "./api.ts";
 
 export const ENV_WORKFLOW_MANAGER_SOCKET = "GESTALT_WORKFLOW_MANAGER_SOCKET";
+export const ENV_WORKFLOW_MANAGER_SOCKET_TOKEN = `${ENV_WORKFLOW_MANAGER_SOCKET}_TOKEN`;
+const WORKFLOW_MANAGER_RELAY_TOKEN_HEADER =
+  "x-gestalt-host-service-relay-token";
 
 export type ManagedWorkflowScheduleMessage = ManagedWorkflowSchedule;
 export type ManagedWorkflowEventTriggerMessage = ManagedWorkflowEventTrigger;
@@ -79,18 +84,20 @@ export class WorkflowManager {
   constructor(requestOrToken: Request | string) {
     this.invocationToken = normalizeInvocationToken(requestOrToken);
 
-    const socketPath = process.env[ENV_WORKFLOW_MANAGER_SOCKET];
-    if (!socketPath) {
+    const target = process.env[ENV_WORKFLOW_MANAGER_SOCKET];
+    if (!target) {
       throw new Error(
         `workflow manager: ${ENV_WORKFLOW_MANAGER_SOCKET} is not set`,
       );
     }
+    const relayToken =
+      process.env[ENV_WORKFLOW_MANAGER_SOCKET_TOKEN]?.trim() ?? "";
 
     const transport = createGrpcTransport({
-      baseUrl: "http://localhost",
-      nodeOptions: {
-        createConnection: () => connect(socketPath),
-      },
+      ...workflowManagerTransportOptions(target),
+      interceptors: relayToken
+        ? [workflowManagerRelayTokenInterceptor(relayToken)]
+        : [],
     });
     this.client = createClient(WorkflowManagerHostService, transport);
   }
@@ -223,4 +230,55 @@ function normalizeInvocationToken(requestOrToken: Request | string): string {
     throw new Error("workflow manager: invocation token is not available");
   }
   return trimmed;
+}
+
+function workflowManagerTransportOptions(rawTarget: string): {
+  baseUrl: string;
+  nodeOptions?: { path: string };
+} {
+  const target = rawTarget.trim();
+  if (!target) {
+    throw new Error("workflow manager: transport target is required");
+  }
+  if (target.startsWith("tcp://")) {
+    const address = target.slice("tcp://".length).trim();
+    if (!address) {
+      throw new Error(
+        `workflow manager: tcp target ${JSON.stringify(rawTarget)} is missing host:port`,
+      );
+    }
+    return { baseUrl: `http://${address}` };
+  }
+  if (target.startsWith("tls://")) {
+    const address = target.slice("tls://".length).trim();
+    if (!address) {
+      throw new Error(
+        `workflow manager: tls target ${JSON.stringify(rawTarget)} is missing host:port`,
+      );
+    }
+    return { baseUrl: `https://${address}` };
+  }
+  if (target.startsWith("unix://")) {
+    const socketPath = target.slice("unix://".length).trim();
+    if (!socketPath) {
+      throw new Error(
+        `workflow manager: unix target ${JSON.stringify(rawTarget)} is missing a socket path`,
+      );
+    }
+    return { baseUrl: "http://localhost", nodeOptions: { path: socketPath } };
+  }
+  if (target.includes("://")) {
+    const parsed = new URL(target);
+    throw new Error(
+      `workflow manager: unsupported target scheme ${JSON.stringify(parsed.protocol.replace(/:$/, ""))}`,
+    );
+  }
+  return { baseUrl: "http://localhost", nodeOptions: { path: target } };
+}
+
+function workflowManagerRelayTokenInterceptor(token: string): Interceptor {
+  return (next) => async (req) => {
+    req.header.set(WORKFLOW_MANAGER_RELAY_TOKEN_HEADER, token);
+    return next(req);
+  };
 }

--- a/sdk/typescript/tests/s3.transport.test.ts
+++ b/sdk/typescript/tests/s3.transport.test.ts
@@ -1,4 +1,5 @@
 import { mkdtempSync, rmSync } from "node:fs";
+import { createServer } from "node:net";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 import { spawn, type Subprocess } from "bun";
@@ -11,22 +12,24 @@ import {
   S3NotFoundError,
   S3PreconditionFailedError,
   s3SocketEnv,
+  s3SocketTokenEnv,
 } from "../src/index.ts";
 
 const REPO_ROOT = join(import.meta.dir, "..", "..", "..");
 const GESTALTD_DIR = join(REPO_ROOT, "gestaltd");
 
 let tmpDir: string;
+let harnessBinPath: string;
 let socketPath: string;
 let proc: Subprocess;
 
 beforeAll(async () => {
   tmpDir = mkdtempSync(join(tmpdir(), "s3-transport-test-"));
-  const binPath = join(tmpDir, "s3transportd");
+  harnessBinPath = join(tmpDir, "s3transportd");
   socketPath = join(tmpDir, "s3.sock");
 
   const build = spawn(
-    ["go", "build", "-o", binPath, "./internal/testutil/cmd/s3transportd/"],
+    ["go", "build", "-o", harnessBinPath, "./internal/testutil/cmd/s3transportd/"],
     { cwd: GESTALTD_DIR, stdout: "pipe", stderr: "pipe" },
   );
   const buildExit = await build.exited;
@@ -35,7 +38,7 @@ beforeAll(async () => {
     throw new Error(`go build failed (exit ${buildExit}): ${stderr}`);
   }
 
-  proc = spawn([binPath, "--socket", socketPath], {
+  proc = spawn([harnessBinPath, "--socket", socketPath], {
     stdout: "pipe",
     stderr: "inherit",
   });
@@ -56,10 +59,58 @@ beforeAll(async () => {
   process.env[s3SocketEnv("named")] = socketPath;
 }, 60_000);
 
+async function reserveTCPAddress(): Promise<string> {
+  return await new Promise((resolve, reject) => {
+    const server = createServer();
+    server.once("error", reject);
+    server.listen(0, "127.0.0.1", () => {
+      const address = server.address();
+      if (!address || typeof address === "string") {
+        server.close();
+        reject(new Error("failed to reserve tcp address"));
+        return;
+      }
+      const result = `${address.address}:${address.port}`;
+      server.close((err) => {
+        if (err) {
+          reject(err);
+          return;
+        }
+        resolve(result);
+      });
+    });
+  });
+}
+
+async function startTCPHarness(expectToken?: string): Promise<{ proc: Subprocess; target: string }> {
+  const address = await reserveTCPAddress();
+  const args = [harnessBinPath, "--tcp", address];
+  if (expectToken) {
+    args.push("--expect-token", expectToken);
+  }
+  const tcpProc = spawn(args, {
+    stdout: "pipe",
+    stderr: "inherit",
+  });
+  const stdout = tcpProc.stdout;
+  if (!stdout || typeof stdout === "number") {
+    throw new Error("expected tcp harness stdout to be piped");
+  }
+  const reader = stdout.getReader();
+  const { value } = await reader.read();
+  const line = new TextDecoder().decode(value).trim();
+  if (!line.includes("READY")) {
+    throw new Error(`expected READY from tcp harness, got: ${line}`);
+  }
+  reader.releaseLock();
+  return { proc: tcpProc, target: `tcp://${address}` };
+}
+
 afterAll(() => {
   proc?.kill();
   delete process.env.GESTALT_S3_SOCKET;
   delete process.env[s3SocketEnv("named")];
+  delete process.env[s3SocketTokenEnv()];
   if (tmpDir) {
     rmSync(tmpDir, { recursive: true, force: true });
   }
@@ -77,6 +128,37 @@ describe("S3 transport", () => {
     });
 
     expect(await object.text()).toBe("named binding");
+  });
+
+  test("tcp target env selects the requested binding", async () => {
+    const { proc: tcpProc, target } = await startTCPHarness();
+    process.env.GESTALT_S3_SOCKET = target;
+    try {
+      const object = new S3().object("tcp-bucket", "hello.txt");
+      await object.writeString("tcp binding");
+      expect(await object.text()).toBe("tcp binding");
+    } finally {
+      tcpProc.kill();
+      delete process.env.GESTALT_S3_SOCKET;
+      process.env.GESTALT_S3_SOCKET = socketPath;
+    }
+  });
+
+  test("tcp target token env selects the requested binding", async () => {
+    const token = "relay-token-typescript";
+    const { proc: tcpProc, target } = await startTCPHarness(token);
+    process.env.GESTALT_S3_SOCKET = target;
+    process.env[s3SocketTokenEnv()] = token;
+    try {
+      const object = new S3().object("tcp-token-bucket", "hello.txt");
+      await object.writeString("token binding");
+      expect(await object.text()).toBe("token binding");
+    } finally {
+      tcpProc.kill();
+      delete process.env.GESTALT_S3_SOCKET;
+      delete process.env[s3SocketTokenEnv()];
+      process.env.GESTALT_S3_SOCKET = socketPath;
+    }
   });
 
   test("write, stat, read, and json round-trip", async () => {

--- a/sdk/typescript/tests/workflow-manager.transport.test.ts
+++ b/sdk/typescript/tests/workflow-manager.transport.test.ts
@@ -1,5 +1,6 @@
 import { mkdtempSync } from "node:fs";
 import { createServer } from "node:http2";
+import { createServer as createNetServer } from "node:net";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 
@@ -19,6 +20,7 @@ import {
 } from "../gen/v1/workflow_pb.ts";
 import {
   ENV_WORKFLOW_MANAGER_SOCKET,
+  ENV_WORKFLOW_MANAGER_SOCKET_TOKEN,
   WorkflowManager,
   request,
 } from "../src/index.ts";
@@ -41,186 +43,183 @@ test("WorkflowManager forwards invocation tokens from strings and Request object
     grpcWeb: false,
     connect: false,
     routes(router) {
-      router.service(
-        WorkflowManagerHostService,
-        {
-          async createSchedule(input) {
-            calls.push({
-              method: "create",
-              invocationToken: input.invocationToken,
-            });
-            return create(ManagedWorkflowScheduleSchema, {
-              providerName: input.providerName || "basic",
-              schedule: create(BoundWorkflowScheduleSchema, {
-                id: "sched-1",
-                cron: input.cron,
-                timezone: input.timezone,
-                paused: input.paused,
-                ...(input.target ? { target: input.target } : {}),
-              }),
-            });
-          },
-          async getSchedule(input) {
-            calls.push({
-              method: "get",
-              invocationToken: input.invocationToken,
-              scheduleId: input.scheduleId,
-            });
-            return create(ManagedWorkflowScheduleSchema, {
-              providerName: "basic",
-              schedule: create(BoundWorkflowScheduleSchema, {
-                id: input.scheduleId,
-              }),
-            });
-          },
-          async updateSchedule(input) {
-            calls.push({
-              method: "update",
-              invocationToken: input.invocationToken,
-              scheduleId: input.scheduleId,
-            });
-            return create(ManagedWorkflowScheduleSchema, {
-              providerName: input.providerName || "basic",
-              schedule: create(BoundWorkflowScheduleSchema, {
-                id: input.scheduleId,
-                cron: input.cron,
-                timezone: input.timezone,
-                paused: input.paused,
-                ...(input.target ? { target: input.target } : {}),
-              }),
-            });
-          },
-          async deleteSchedule(input) {
-            calls.push({
-              method: "delete",
-              invocationToken: input.invocationToken,
-              scheduleId: input.scheduleId,
-            });
-            return create(EmptySchema, {});
-          },
-          async pauseSchedule(input) {
-            calls.push({
-              method: "pause",
-              invocationToken: input.invocationToken,
-              scheduleId: input.scheduleId,
-            });
-            return create(ManagedWorkflowScheduleSchema, {
-              providerName: "basic",
-              schedule: create(BoundWorkflowScheduleSchema, {
-                id: input.scheduleId,
-                paused: true,
-              }),
-            });
-          },
-          async resumeSchedule(input) {
-            calls.push({
-              method: "resume",
-              invocationToken: input.invocationToken,
-              scheduleId: input.scheduleId,
-            });
-            return create(ManagedWorkflowScheduleSchema, {
-              providerName: "basic",
-              schedule: create(BoundWorkflowScheduleSchema, {
-                id: input.scheduleId,
-                paused: false,
-              }),
-            });
-          },
-          async createEventTrigger(input) {
-            calls.push({
-              method: "create-trigger",
-              invocationToken: input.invocationToken,
-            });
-            return create(ManagedWorkflowEventTriggerSchema, {
-              providerName: input.providerName || "basic",
-              trigger: create(BoundWorkflowEventTriggerSchema, {
-                id: "trg-1",
-                paused: input.paused,
-                ...(input.match ? { match: input.match } : {}),
-                ...(input.target ? { target: input.target } : {}),
-              }),
-            });
-          },
-          async getEventTrigger(input) {
-            calls.push({
-              method: "get-trigger",
-              invocationToken: input.invocationToken,
-              triggerId: input.triggerId,
-            });
-            return create(ManagedWorkflowEventTriggerSchema, {
-              providerName: "basic",
-              trigger: create(BoundWorkflowEventTriggerSchema, {
-                id: input.triggerId,
-              }),
-            });
-          },
-          async updateEventTrigger(input) {
-            calls.push({
-              method: "update-trigger",
-              invocationToken: input.invocationToken,
-              triggerId: input.triggerId,
-            });
-            return create(ManagedWorkflowEventTriggerSchema, {
-              providerName: input.providerName || "basic",
-              trigger: create(BoundWorkflowEventTriggerSchema, {
-                id: input.triggerId,
-                paused: input.paused,
-                ...(input.match ? { match: input.match } : {}),
-                ...(input.target ? { target: input.target } : {}),
-              }),
-            });
-          },
-          async deleteEventTrigger(input) {
-            calls.push({
-              method: "delete-trigger",
-              invocationToken: input.invocationToken,
-              triggerId: input.triggerId,
-            });
-            return create(EmptySchema, {});
-          },
-          async pauseEventTrigger(input) {
-            calls.push({
-              method: "pause-trigger",
-              invocationToken: input.invocationToken,
-              triggerId: input.triggerId,
-            });
-            return create(ManagedWorkflowEventTriggerSchema, {
-              providerName: "basic",
-              trigger: create(BoundWorkflowEventTriggerSchema, {
-                id: input.triggerId,
-                paused: true,
-              }),
-            });
-          },
-          async resumeEventTrigger(input) {
-            calls.push({
-              method: "resume-trigger",
-              invocationToken: input.invocationToken,
-              triggerId: input.triggerId,
-            });
-            return create(ManagedWorkflowEventTriggerSchema, {
-              providerName: "basic",
-              trigger: create(BoundWorkflowEventTriggerSchema, {
-                id: input.triggerId,
-                paused: false,
-              }),
-            });
-          },
-          async publishEvent(input) {
-            calls.push({
-              method: "publish-event",
-              invocationToken: input.invocationToken,
-              ...(input.event?.type ? { eventType: input.event.type } : {}),
-            });
-            return create(WorkflowEventSchema, {
-              id: input.event?.id || "evt-1",
-              type: input.event?.type || "dummy.event",
-              source: input.event?.source || "tests",
-              subject: input.event?.subject || "subject",
-            });
-          },
-        } satisfies Partial<ServiceImpl<typeof WorkflowManagerHostService>>,
-      );
+      router.service(WorkflowManagerHostService, {
+        async createSchedule(input) {
+          calls.push({
+            method: "create",
+            invocationToken: input.invocationToken,
+          });
+          return create(ManagedWorkflowScheduleSchema, {
+            providerName: input.providerName || "basic",
+            schedule: create(BoundWorkflowScheduleSchema, {
+              id: "sched-1",
+              cron: input.cron,
+              timezone: input.timezone,
+              paused: input.paused,
+              ...(input.target ? { target: input.target } : {}),
+            }),
+          });
+        },
+        async getSchedule(input) {
+          calls.push({
+            method: "get",
+            invocationToken: input.invocationToken,
+            scheduleId: input.scheduleId,
+          });
+          return create(ManagedWorkflowScheduleSchema, {
+            providerName: "basic",
+            schedule: create(BoundWorkflowScheduleSchema, {
+              id: input.scheduleId,
+            }),
+          });
+        },
+        async updateSchedule(input) {
+          calls.push({
+            method: "update",
+            invocationToken: input.invocationToken,
+            scheduleId: input.scheduleId,
+          });
+          return create(ManagedWorkflowScheduleSchema, {
+            providerName: input.providerName || "basic",
+            schedule: create(BoundWorkflowScheduleSchema, {
+              id: input.scheduleId,
+              cron: input.cron,
+              timezone: input.timezone,
+              paused: input.paused,
+              ...(input.target ? { target: input.target } : {}),
+            }),
+          });
+        },
+        async deleteSchedule(input) {
+          calls.push({
+            method: "delete",
+            invocationToken: input.invocationToken,
+            scheduleId: input.scheduleId,
+          });
+          return create(EmptySchema, {});
+        },
+        async pauseSchedule(input) {
+          calls.push({
+            method: "pause",
+            invocationToken: input.invocationToken,
+            scheduleId: input.scheduleId,
+          });
+          return create(ManagedWorkflowScheduleSchema, {
+            providerName: "basic",
+            schedule: create(BoundWorkflowScheduleSchema, {
+              id: input.scheduleId,
+              paused: true,
+            }),
+          });
+        },
+        async resumeSchedule(input) {
+          calls.push({
+            method: "resume",
+            invocationToken: input.invocationToken,
+            scheduleId: input.scheduleId,
+          });
+          return create(ManagedWorkflowScheduleSchema, {
+            providerName: "basic",
+            schedule: create(BoundWorkflowScheduleSchema, {
+              id: input.scheduleId,
+              paused: false,
+            }),
+          });
+        },
+        async createEventTrigger(input) {
+          calls.push({
+            method: "create-trigger",
+            invocationToken: input.invocationToken,
+          });
+          return create(ManagedWorkflowEventTriggerSchema, {
+            providerName: input.providerName || "basic",
+            trigger: create(BoundWorkflowEventTriggerSchema, {
+              id: "trg-1",
+              paused: input.paused,
+              ...(input.match ? { match: input.match } : {}),
+              ...(input.target ? { target: input.target } : {}),
+            }),
+          });
+        },
+        async getEventTrigger(input) {
+          calls.push({
+            method: "get-trigger",
+            invocationToken: input.invocationToken,
+            triggerId: input.triggerId,
+          });
+          return create(ManagedWorkflowEventTriggerSchema, {
+            providerName: "basic",
+            trigger: create(BoundWorkflowEventTriggerSchema, {
+              id: input.triggerId,
+            }),
+          });
+        },
+        async updateEventTrigger(input) {
+          calls.push({
+            method: "update-trigger",
+            invocationToken: input.invocationToken,
+            triggerId: input.triggerId,
+          });
+          return create(ManagedWorkflowEventTriggerSchema, {
+            providerName: input.providerName || "basic",
+            trigger: create(BoundWorkflowEventTriggerSchema, {
+              id: input.triggerId,
+              paused: input.paused,
+              ...(input.match ? { match: input.match } : {}),
+              ...(input.target ? { target: input.target } : {}),
+            }),
+          });
+        },
+        async deleteEventTrigger(input) {
+          calls.push({
+            method: "delete-trigger",
+            invocationToken: input.invocationToken,
+            triggerId: input.triggerId,
+          });
+          return create(EmptySchema, {});
+        },
+        async pauseEventTrigger(input) {
+          calls.push({
+            method: "pause-trigger",
+            invocationToken: input.invocationToken,
+            triggerId: input.triggerId,
+          });
+          return create(ManagedWorkflowEventTriggerSchema, {
+            providerName: "basic",
+            trigger: create(BoundWorkflowEventTriggerSchema, {
+              id: input.triggerId,
+              paused: true,
+            }),
+          });
+        },
+        async resumeEventTrigger(input) {
+          calls.push({
+            method: "resume-trigger",
+            invocationToken: input.invocationToken,
+            triggerId: input.triggerId,
+          });
+          return create(ManagedWorkflowEventTriggerSchema, {
+            providerName: "basic",
+            trigger: create(BoundWorkflowEventTriggerSchema, {
+              id: input.triggerId,
+              paused: false,
+            }),
+          });
+        },
+        async publishEvent(input) {
+          calls.push({
+            method: "publish-event",
+            invocationToken: input.invocationToken,
+            ...(input.event?.type ? { eventType: input.event.type } : {}),
+          });
+          return create(WorkflowEventSchema, {
+            id: input.event?.id || "evt-1",
+            type: input.event?.type || "dummy.event",
+            source: input.event?.source || "tests",
+            subject: input.event?.subject || "subject",
+          });
+        },
+      } satisfies Partial<ServiceImpl<typeof WorkflowManagerHostService>>);
     },
   });
   const server = createServer(handler);
@@ -294,8 +293,12 @@ test("WorkflowManager forwards invocation tokens from strings and Request object
       },
       paused: true,
     });
-    const pausedTrigger = await fromRequest.pauseTrigger({ triggerId: "trg-1" });
-    const resumedTrigger = await fromRequest.resumeTrigger({ triggerId: "trg-1" });
+    const pausedTrigger = await fromRequest.pauseTrigger({
+      triggerId: "trg-1",
+    });
+    const resumedTrigger = await fromRequest.resumeTrigger({
+      triggerId: "trg-1",
+    });
     await fromRequest.deleteTrigger({ triggerId: "trg-1" });
     const publishedEvent = await fromRequest.publishEvent({
       event: {
@@ -319,18 +322,62 @@ test("WorkflowManager forwards invocation tokens from strings and Request object
     expect(publishedEvent.type).toBe("roadmap.item.updated");
     expect(calls).toEqual([
       { method: "create", invocationToken: "invocation-token-123" },
-      { method: "get", invocationToken: "invocation-token-456", scheduleId: "sched-1" },
-      { method: "update", invocationToken: "invocation-token-456", scheduleId: "sched-1" },
-      { method: "pause", invocationToken: "invocation-token-456", scheduleId: "sched-1" },
-      { method: "resume", invocationToken: "invocation-token-456", scheduleId: "sched-1" },
-      { method: "delete", invocationToken: "invocation-token-456", scheduleId: "sched-1" },
+      {
+        method: "get",
+        invocationToken: "invocation-token-456",
+        scheduleId: "sched-1",
+      },
+      {
+        method: "update",
+        invocationToken: "invocation-token-456",
+        scheduleId: "sched-1",
+      },
+      {
+        method: "pause",
+        invocationToken: "invocation-token-456",
+        scheduleId: "sched-1",
+      },
+      {
+        method: "resume",
+        invocationToken: "invocation-token-456",
+        scheduleId: "sched-1",
+      },
+      {
+        method: "delete",
+        invocationToken: "invocation-token-456",
+        scheduleId: "sched-1",
+      },
       { method: "create-trigger", invocationToken: "invocation-token-456" },
-      { method: "get-trigger", invocationToken: "invocation-token-456", triggerId: "trg-1" },
-      { method: "update-trigger", invocationToken: "invocation-token-456", triggerId: "trg-1" },
-      { method: "pause-trigger", invocationToken: "invocation-token-456", triggerId: "trg-1" },
-      { method: "resume-trigger", invocationToken: "invocation-token-456", triggerId: "trg-1" },
-      { method: "delete-trigger", invocationToken: "invocation-token-456", triggerId: "trg-1" },
-      { method: "publish-event", invocationToken: "invocation-token-456", eventType: "roadmap.item.updated" },
+      {
+        method: "get-trigger",
+        invocationToken: "invocation-token-456",
+        triggerId: "trg-1",
+      },
+      {
+        method: "update-trigger",
+        invocationToken: "invocation-token-456",
+        triggerId: "trg-1",
+      },
+      {
+        method: "pause-trigger",
+        invocationToken: "invocation-token-456",
+        triggerId: "trg-1",
+      },
+      {
+        method: "resume-trigger",
+        invocationToken: "invocation-token-456",
+        triggerId: "trg-1",
+      },
+      {
+        method: "delete-trigger",
+        invocationToken: "invocation-token-456",
+        triggerId: "trg-1",
+      },
+      {
+        method: "publish-event",
+        invocationToken: "invocation-token-456",
+        eventType: "roadmap.item.updated",
+      },
     ]);
   } finally {
     if (previousSocket === undefined) {
@@ -360,6 +407,101 @@ test("WorkflowManager prioritizes invocation-token validation over socket config
       delete process.env[ENV_WORKFLOW_MANAGER_SOCKET];
     } else {
       process.env[ENV_WORKFLOW_MANAGER_SOCKET] = previousSocket;
+    }
+  }
+});
+
+async function reserveTCPAddress(): Promise<string> {
+  return await new Promise((resolve, reject) => {
+    const server = createNetServer();
+    server.once("error", reject);
+    server.listen(0, "127.0.0.1", () => {
+      const address = server.address();
+      if (!address || typeof address === "string") {
+        server.close();
+        reject(new Error("failed to reserve tcp address"));
+        return;
+      }
+      const result = `${address.address}:${address.port}`;
+      server.close((err) => {
+        if (err) {
+          reject(err);
+          return;
+        }
+        resolve(result);
+      });
+    });
+  });
+}
+
+test("WorkflowManager honors tcp target env and relay token env", async () => {
+  const previousSocket = process.env[ENV_WORKFLOW_MANAGER_SOCKET];
+  const previousToken = process.env[ENV_WORKFLOW_MANAGER_SOCKET_TOKEN];
+  const seenTokens: string[] = [];
+  const address = await reserveTCPAddress();
+
+  const handler = connectNodeAdapter({
+    grpc: true,
+    grpcWeb: false,
+    connect: false,
+    routes(router) {
+      router.service(WorkflowManagerHostService, {
+        async createSchedule(input) {
+          return create(ManagedWorkflowScheduleSchema, {
+            providerName: input.providerName || "basic",
+            schedule: create(BoundWorkflowScheduleSchema, {
+              id: "sched-1",
+              cron: input.cron,
+            }),
+          });
+        },
+      } satisfies Partial<ServiceImpl<typeof WorkflowManagerHostService>>);
+    },
+  });
+  const server = createServer((req, res) => {
+    const tokenHeader = req.headers["x-gestalt-host-service-relay-token"];
+    if (typeof tokenHeader === "string") {
+      seenTokens.push(tokenHeader);
+    }
+    handler(req, res);
+  });
+
+  try {
+    await new Promise<void>((resolve, reject) => {
+      server.once("error", reject);
+      server.listen(Number(address.split(":").at(-1)), "127.0.0.1", () => {
+        server.off("error", reject);
+        resolve();
+      });
+    });
+
+    process.env[ENV_WORKFLOW_MANAGER_SOCKET] = `tcp://${address}`;
+    process.env[ENV_WORKFLOW_MANAGER_SOCKET_TOKEN] = "relay-token-typescript";
+
+    const manager = new WorkflowManager("invoke-token");
+    const created = await manager.createSchedule({
+      providerName: "basic",
+      cron: "*/5 * * * *",
+    });
+
+    expect(created.providerName).toBe("basic");
+    expect(created.schedule?.id).toBe("sched-1");
+    expect(seenTokens).toEqual(["relay-token-typescript"]);
+  } finally {
+    if (previousSocket === undefined) {
+      delete process.env[ENV_WORKFLOW_MANAGER_SOCKET];
+    } else {
+      process.env[ENV_WORKFLOW_MANAGER_SOCKET] = previousSocket;
+    }
+    if (previousToken === undefined) {
+      delete process.env[ENV_WORKFLOW_MANAGER_SOCKET_TOKEN];
+    } else {
+      process.env[ENV_WORKFLOW_MANAGER_SOCKET_TOKEN] = previousToken;
+    }
+    if (server.listening) {
+      await new Promise<void>((resolve) => {
+        server.close(() => resolve());
+      });
     }
   }
 });


### PR DESCRIPTION
## Summary

This finishes the remaining hosted-runtime relay followups on top of the original `s3:` relay work.

Hosted runtimes no longer need generic `HostServiceTunnels` for the relay-backed host services covered here. `gestaltd` now emits public relay bindings for both `s3:` and workflow-manager, and the Go, TypeScript, and Rust workflow-manager clients accept the same relay target/token shapes as the other relay-backed SDK clients.

## New interfaces

- `GESTALT_S3_SOCKET` accepts:
  - raw unix path
  - `unix:///path`
  - `tcp://host:port`
  - `tls://host:port`
- `GESTALT_S3_SOCKET_TOKEN` forwards `x-gestalt-host-service-relay-token`
- `GESTALT_WORKFLOW_MANAGER_SOCKET` accepts:
  - raw unix path
  - `unix:///path`
  - `tcp://host:port`
  - `tls://host:port`
- `GESTALT_WORKFLOW_MANAGER_SOCKET_TOKEN` forwards `x-gestalt-host-service-relay-token`

## Examples

```text
GESTALT_S3_SOCKET=tls://gestalt.example.test:443
GESTALT_S3_SOCKET_TOKEN=relay-token
GESTALT_WORKFLOW_MANAGER_SOCKET=tls://gestalt.example.test:443
GESTALT_WORKFLOW_MANAGER_SOCKET_TOKEN=relay-token
```

```yaml
plugins:
  reports:
    s3:
      - archive
    runtime:
      provider: hosted
```

A hosted executable plugin can then use the workflow-manager SDK helper normally; the runtime now injects a relay-backed `GESTALT_WORKFLOW_MANAGER_SOCKET` and token env when the workflow manager is available.

## What changed

- `gestaltd` now relays workflow-manager host services through the public hosted-runtime relay path
- runtime capability validation no longer treats these relay-backed services as a generic `HostServiceTunnels` requirement
- workflow-manager relay env/token plumbing was added in `gestaltd/internal/providerhost/workflow_env.go`
- Go, TypeScript, and Rust workflow-manager clients now accept unix, tcp, and tls relay targets plus relay-token env vars
- the rebased S3 relay tests were aligned with current single-binding default-env behavior on `main`
- hosted bootstrap coverage now proves:
  - workflow-manager relay config/env injection without host-service tunnels
  - workflow-manager relay round-trips through a hosted plugin
  - the rebased S3 relay behavior still works on current `main`

## Validation

- `cd gestaltd && go test ./internal/bootstrap ./internal/pluginruntime ./internal/providerhost -count=1`
- `cd gestaltd && golangci-lint run ./internal/bootstrap ./internal/pluginruntime ./internal/providerhost`
- `cd sdk/go && go test ./... -count=1`
- `cd sdk/typescript && bun run check`
- `cd sdk/rust && cargo fmt --check && cargo test --test workflow_manager_transport`