### PR TITLE
[codex] Skip arg-bearing nested GraphQL fields

### DIFF
--- a/gestaltd/internal/graphql/query.go
+++ b/gestaltd/internal/graphql/query.go
@@ -91,6 +91,11 @@ func buildSelectionSet(schema *Schema, ref TypeRef, depth int, ancestors map[str
 		if strings.HasPrefix(f.Name, "__") {
 			continue
 		}
+		// Generated selection sets cannot synthesize values for nested field
+		// arguments, so arg-bearing nested fields must be opt-in via overrides.
+		if len(f.Args) > 0 {
+			continue
+		}
 
 		fieldInner := f.Type.innerType()
 		fieldTypeName := fieldInner.namedType()

--- a/gestaltd/internal/graphql/query_test.go
+++ b/gestaltd/internal/graphql/query_test.go
@@ -197,6 +197,60 @@ func TestSelectionSetCyclePrevention(t *testing.T) {
 	}
 }
 
+func TestSelectionSetSkipsNestedFieldsWithArgs(t *testing.T) {
+	t.Parallel()
+
+	schema := &Schema{
+		Types: []FullType{
+			{Kind: "OBJECT", Name: "Membership", Fields: []Field{
+				{Name: "owner", Type: TypeRef{Kind: "SCALAR", Name: strPtr("Boolean")}},
+			}},
+			{Kind: "OBJECT", Name: "Team", Fields: []Field{
+				{Name: "id", Type: TypeRef{Kind: "SCALAR", Name: strPtr("ID")}},
+				{
+					Name: "membership",
+					Args: []InputValue{
+						{Name: "userId", Type: TypeRef{Kind: "NON_NULL", OfType: &TypeRef{Kind: "SCALAR", Name: strPtr("String")}}},
+					},
+					Type: TypeRef{Kind: "OBJECT", Name: strPtr("Membership")},
+				},
+				{
+					Name: "formattedName",
+					Args: []InputValue{
+						{Name: "style", Type: TypeRef{Kind: "SCALAR", Name: strPtr("String")}},
+					},
+					Type: TypeRef{Kind: "SCALAR", Name: strPtr("String")},
+				},
+			}},
+			{Kind: "OBJECT", Name: "Issue", Fields: []Field{
+				{Name: "id", Type: TypeRef{Kind: "SCALAR", Name: strPtr("ID")}},
+				{Name: "team", Type: TypeRef{Kind: "OBJECT", Name: strPtr("Team")}},
+			}},
+		},
+	}
+	schema.buildIndex()
+
+	field := Field{
+		Name: "issue",
+		Args: []InputValue{
+			{Name: "id", Type: TypeRef{Kind: "NON_NULL", OfType: &TypeRef{Kind: "SCALAR", Name: strPtr("String")}}},
+		},
+		Type: TypeRef{Kind: "OBJECT", Name: strPtr("Issue")},
+	}
+
+	query := generateQuery(schema, field, false, "")
+
+	if !strings.Contains(query, "team { id }") {
+		t.Errorf("should keep nested fields that do not require arguments: %s", query)
+	}
+	if strings.Contains(query, "membership") {
+		t.Errorf("should skip nested object fields with arguments: %s", query)
+	}
+	if strings.Contains(query, "formattedName") {
+		t.Errorf("should skip nested scalar fields with arguments: %s", query)
+	}
+}
+
 func TestFormatTypeRef(t *testing.T) {
 	t.Parallel()
 


### PR DESCRIPTION
## What changed
This updates Gestalt's GraphQL selection-set generator to skip nested fields that declare arguments, and adds a regression test covering both required and optional nested arguments.

## Why
`linear.issue` was failing because the generated query auto-selected `team.membership { ... }` without supplying the required `userId` argument. More generally, the generator cannot synthesize valid values for nested field arguments.

## Impact
GraphQL passthrough providers will stop emitting invalid auto-generated queries for nested arg-bearing fields. Richer selections can still be requested explicitly through selection overrides.

## Root cause
`buildSelectionSet` recursed into nested object fields without checking whether those fields required arguments.

## Validation
- `go test ./internal/graphql`