### PR TITLE
[codex] gestaltd: host MCP OAuth endpoints

### DIFF
--- a/gestaltd/internal/server/handlers_mcp_authorization_server.go
+++ b/gestaltd/internal/server/handlers_mcp_authorization_server.go
@@ -1,0 +1,596 @@
+package server
+
+import (
+	"crypto/hmac"
+	"crypto/sha256"
+	"encoding/base64"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"net/http"
+	"net/url"
+	"strings"
+
+	"github.com/valon-technologies/gestalt/server/core"
+	"github.com/valon-technologies/gestalt/server/internal/oauth"
+	"github.com/valon-technologies/gestalt/server/internal/principal"
+)
+
+const (
+	mcpAuthorizationServerMetadataPath       = "/.well-known/oauth-authorization-server"
+	mcpAuthorizationServerMetadataMCPPath    = "/.well-known/oauth-authorization-server/mcp"
+	mcpAuthorizationEndpointPath             = "/oauth/authorize"
+	mcpTokenEndpointPath                     = "/oauth/token"
+	mcpRegistrationEndpointPath              = "/oauth/register"
+	mcpOAuthTokenAuthMethodNone              = "none"
+	mcpOAuthTokenAuthMethodClientSecretPost  = "client_secret_post"
+	mcpOAuthTokenAuthMethodClientSecretBasic = "client_secret_basic"
+)
+
+var errMCPOAuthDisabled = errors.New("mcp oauth is disabled")
+
+type mcpAuthorizationServerConfig struct {
+	Issuer                            string
+	AuthorizationEndpoint             string
+	TokenEndpoint                     string
+	RegistrationEndpoint              string
+	ScopesSupported                   []string
+	CodeChallengeMethodsSupported     []string
+	TokenEndpointAuthMethodsSupported []string
+}
+
+type mcpAuthorizationServerMetadataResponse struct {
+	Issuer                            string   `json:"issuer"`
+	AuthorizationEndpoint             string   `json:"authorization_endpoint"`
+	TokenEndpoint                     string   `json:"token_endpoint"`
+	RegistrationEndpoint              string   `json:"registration_endpoint"`
+	ResponseTypesSupported            []string `json:"response_types_supported,omitempty"`
+	GrantTypesSupported               []string `json:"grant_types_supported,omitempty"`
+	ScopesSupported                   []string `json:"scopes_supported,omitempty"`
+	CodeChallengeMethodsSupported     []string `json:"code_challenge_methods_supported,omitempty"`
+	TokenEndpointAuthMethodsSupported []string `json:"token_endpoint_auth_methods_supported,omitempty"`
+}
+
+type mcpDynamicClientRegistrationRequest struct {
+	ClientName              string   `json:"client_name,omitempty"`
+	RedirectURIs            []string `json:"redirect_uris"`
+	GrantTypes              []string `json:"grant_types,omitempty"`
+	ResponseTypes           []string `json:"response_types,omitempty"`
+	TokenEndpointAuthMethod string   `json:"token_endpoint_auth_method,omitempty"`
+}
+
+type mcpDynamicClientRegistrationResponse struct {
+	ClientID                string   `json:"client_id"`
+	ClientIDIssuedAt        int64    `json:"client_id_issued_at"`
+	ClientSecret            string   `json:"client_secret,omitempty"`
+	ClientSecretExpiresAt   int64    `json:"client_secret_expires_at,omitempty"`
+	ClientName              string   `json:"client_name,omitempty"`
+	RedirectURIs            []string `json:"redirect_uris"`
+	GrantTypes              []string `json:"grant_types,omitempty"`
+	ResponseTypes           []string `json:"response_types,omitempty"`
+	TokenEndpointAuthMethod string   `json:"token_endpoint_auth_method,omitempty"`
+}
+
+type mcpOAuthTokenResponse struct {
+	AccessToken  string `json:"access_token"`
+	TokenType    string `json:"token_type"`
+	ExpiresIn    int    `json:"expires_in,omitempty"`
+	RefreshToken string `json:"refresh_token,omitempty"`
+	Scope        string `json:"scope,omitempty"`
+}
+
+type mcpOAuthErrorResponse struct {
+	Error            string `json:"error"`
+	ErrorDescription string `json:"error_description,omitempty"`
+}
+
+func (s *Server) mcpAuthorizationServerConfig(r *http.Request) (mcpAuthorizationServerConfig, error) {
+	auth := s.serverAuthRuntime()
+	if auth.noAuth || auth.provider == nil {
+		return mcpAuthorizationServerConfig{}, errMCPOAuthDisabled
+	}
+
+	issuer, err := s.resolvePublicURL(r, "/")
+	if err != nil {
+		return mcpAuthorizationServerConfig{}, err
+	}
+	authorizationEndpoint, err := s.resolvePublicURL(r, mcpAuthorizationEndpointPath)
+	if err != nil {
+		return mcpAuthorizationServerConfig{}, err
+	}
+	tokenEndpoint, err := s.resolvePublicURL(r, mcpTokenEndpointPath)
+	if err != nil {
+		return mcpAuthorizationServerConfig{}, err
+	}
+	registrationEndpoint, err := s.resolvePublicURL(r, mcpRegistrationEndpointPath)
+	if err != nil {
+		return mcpAuthorizationServerConfig{}, err
+	}
+
+	return mcpAuthorizationServerConfig{
+		Issuer:                            strings.TrimRight(issuer, "/"),
+		AuthorizationEndpoint:             authorizationEndpoint,
+		TokenEndpoint:                     tokenEndpoint,
+		RegistrationEndpoint:              registrationEndpoint,
+		ScopesSupported:                   s.mcpAuthorizationScopes(r),
+		CodeChallengeMethodsSupported:     []string{"S256"},
+		TokenEndpointAuthMethodsSupported: []string{mcpOAuthTokenAuthMethodNone, mcpOAuthTokenAuthMethodClientSecretPost, mcpOAuthTokenAuthMethodClientSecretBasic},
+	}, nil
+}
+
+func (s *Server) mcpAuthorizationServerMetadata(w http.ResponseWriter, r *http.Request) {
+	cfg, err := s.mcpAuthorizationServerConfig(r)
+	if err != nil {
+		if errors.Is(err, errMCPOAuthDisabled) {
+			writeError(w, http.StatusNotFound, "auth is disabled")
+			return
+		}
+		writeError(w, http.StatusInternalServerError, "failed to resolve MCP authorization server metadata")
+		return
+	}
+	writeJSON(w, http.StatusOK, mcpAuthorizationServerMetadataResponse{
+		Issuer:                            cfg.Issuer,
+		AuthorizationEndpoint:             cfg.AuthorizationEndpoint,
+		TokenEndpoint:                     cfg.TokenEndpoint,
+		RegistrationEndpoint:              cfg.RegistrationEndpoint,
+		ResponseTypesSupported:            []string{"code"},
+		GrantTypesSupported:               []string{"authorization_code", "refresh_token"},
+		ScopesSupported:                   cfg.ScopesSupported,
+		CodeChallengeMethodsSupported:     cfg.CodeChallengeMethodsSupported,
+		TokenEndpointAuthMethodsSupported: cfg.TokenEndpointAuthMethodsSupported,
+	})
+}
+
+func (s *Server) mcpRegisterOAuthClient(w http.ResponseWriter, r *http.Request) {
+	if _, err := s.mcpAuthorizationServerConfig(r); err != nil {
+		if errors.Is(err, errMCPOAuthDisabled) {
+			writeMCPOAuthError(w, http.StatusNotFound, "server_error", "auth is disabled")
+			return
+		}
+		writeMCPOAuthError(w, http.StatusInternalServerError, "server_error", "MCP OAuth client registration is unavailable")
+		return
+	}
+	if s.encryptor == nil {
+		writeMCPOAuthError(w, http.StatusServiceUnavailable, "server_error", "MCP OAuth client registration is unavailable")
+		return
+	}
+
+	var req mcpDynamicClientRegistrationRequest
+	if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
+		writeMCPOAuthError(w, http.StatusBadRequest, "invalid_client_metadata", "invalid JSON body")
+		return
+	}
+	if len(req.RedirectURIs) == 0 {
+		writeMCPOAuthError(w, http.StatusBadRequest, "invalid_redirect_uri", "redirect_uris must contain at least one absolute URI")
+		return
+	}
+	for _, redirectURI := range req.RedirectURIs {
+		if err := validateMCPOAuthRedirectURI(redirectURI); err != nil {
+			writeMCPOAuthError(w, http.StatusBadRequest, "invalid_redirect_uri", err.Error())
+			return
+		}
+	}
+
+	authMethod := normalizeMCPOAuthTokenEndpointAuthMethod(req.TokenEndpointAuthMethod)
+	if !isSupportedMCPOAuthTokenEndpointAuthMethod(authMethod) {
+		writeMCPOAuthError(w, http.StatusBadRequest, "invalid_client_metadata", "unsupported token_endpoint_auth_method")
+		return
+	}
+
+	clientID, err := encodeMCPOAuthClientRegistration(s.encryptor, mcpOAuthClientRegistrationState{
+		RedirectURIs:            req.RedirectURIs,
+		ClientName:              strings.TrimSpace(req.ClientName),
+		TokenEndpointAuthMethod: authMethod,
+		ExpiresAt:               s.now().Add(mcpOAuthClientRegistrationTTL).Unix(),
+	})
+	if err != nil {
+		writeMCPOAuthError(w, http.StatusInternalServerError, "server_error", "failed to register client")
+		return
+	}
+
+	resp := mcpDynamicClientRegistrationResponse{
+		ClientID:                clientID,
+		ClientIDIssuedAt:        s.now().Unix(),
+		ClientName:              strings.TrimSpace(req.ClientName),
+		RedirectURIs:            req.RedirectURIs,
+		GrantTypes:              []string{"authorization_code", "refresh_token"},
+		ResponseTypes:           []string{"code"},
+		TokenEndpointAuthMethod: authMethod,
+	}
+	if authMethod != mcpOAuthTokenAuthMethodNone {
+		resp.ClientSecret = s.mcpOAuthClientSecret(clientID)
+		resp.ClientSecretExpiresAt = s.now().Add(mcpOAuthClientRegistrationTTL).Unix()
+	}
+
+	setMCPOAuthNoStoreHeaders(w)
+	writeJSON(w, http.StatusCreated, resp)
+}
+
+func (s *Server) mcpOAuthAuthorize(w http.ResponseWriter, r *http.Request) {
+	auth := s.serverAuthRuntime()
+	if auth.noAuth || auth.provider == nil {
+		writeMCPOAuthError(w, http.StatusNotFound, "server_error", "auth is disabled")
+		return
+	}
+	if s.encryptor == nil {
+		writeMCPOAuthError(w, http.StatusServiceUnavailable, "server_error", "MCP OAuth authorization is unavailable")
+		return
+	}
+
+	query := r.URL.Query()
+	state := query.Get("state")
+	clientID := strings.TrimSpace(query.Get("client_id"))
+	if clientID == "" {
+		writeMCPOAuthError(w, http.StatusBadRequest, "invalid_request", "client_id is required")
+		return
+	}
+	client, err := decodeMCPOAuthClientRegistration(s.encryptor, clientID, s.now())
+	if err != nil {
+		writeMCPOAuthError(w, http.StatusBadRequest, "invalid_client", "client registration is invalid")
+		return
+	}
+	redirectURI, err := resolveRegisteredMCPOAuthRedirectURI(client.RedirectURIs, query.Get("redirect_uri"))
+	if err != nil {
+		writeMCPOAuthError(w, http.StatusBadRequest, "invalid_request", err.Error())
+		return
+	}
+	if responseType := strings.TrimSpace(query.Get("response_type")); responseType != "code" {
+		redirectMCPOAuthError(w, r, redirectURI, state, "unsupported_response_type", "only response_type=code is supported")
+		return
+	}
+	codeChallenge := strings.TrimSpace(query.Get("code_challenge"))
+	if codeChallenge == "" {
+		redirectMCPOAuthError(w, r, redirectURI, state, "invalid_request", "code_challenge is required")
+		return
+	}
+	codeChallengeMethod := normalizeMCPOAuthCodeChallengeMethod(query.Get("code_challenge_method"))
+	if codeChallengeMethod != "S256" {
+		redirectMCPOAuthError(w, r, redirectURI, state, "invalid_request", "only code_challenge_method=S256 is supported")
+		return
+	}
+
+	p, err := s.resolveRequestPrincipalWithResolver(r, auth.resolver)
+	if err != nil || p == nil || p.Identity == nil || p.Identity.Email == "" || principal.IsWorkloadPrincipal(p) {
+		if strings.EqualFold(strings.TrimSpace(query.Get("prompt")), "none") {
+			redirectMCPOAuthError(w, r, redirectURI, state, "login_required", "user login is required")
+			return
+		}
+		http.Redirect(w, r, "/api/v1/auth/login?next="+url.QueryEscape(r.URL.RequestURI()), http.StatusFound)
+		return
+	}
+
+	code, err := encodeMCPOAuthAuthorizationCode(s.encryptor, mcpOAuthAuthorizationCodeState{
+		ClientID:            clientID,
+		RedirectURI:         redirectURI,
+		Email:               p.Identity.Email,
+		DisplayName:         p.Identity.DisplayName,
+		AvatarURL:           p.Identity.AvatarURL,
+		Scope:               strings.TrimSpace(query.Get("scope")),
+		CodeChallenge:       codeChallenge,
+		CodeChallengeMethod: codeChallengeMethod,
+		ExpiresAt:           s.now().Add(mcpOAuthAuthorizationCodeTTL).Unix(),
+	})
+	if err != nil {
+		writeMCPOAuthError(w, http.StatusInternalServerError, "server_error", "failed to issue authorization code")
+		return
+	}
+
+	redirectMCPOAuthSuccess(w, r, redirectURI, map[string]string{
+		"code":  code,
+		"state": state,
+	})
+}
+
+func (s *Server) mcpOAuthToken(w http.ResponseWriter, r *http.Request) {
+	if _, err := s.mcpAuthorizationServerConfig(r); err != nil {
+		if errors.Is(err, errMCPOAuthDisabled) {
+			writeMCPOAuthError(w, http.StatusNotFound, "server_error", "auth is disabled")
+			return
+		}
+		writeMCPOAuthError(w, http.StatusInternalServerError, "server_error", "MCP OAuth token exchange is unavailable")
+		return
+	}
+	if s.encryptor == nil {
+		writeMCPOAuthError(w, http.StatusServiceUnavailable, "server_error", "MCP OAuth token exchange is unavailable")
+		return
+	}
+
+	if err := r.ParseForm(); err != nil {
+		writeMCPOAuthError(w, http.StatusBadRequest, "invalid_request", "invalid token request body")
+		return
+	}
+
+	clientID, clientSecret, presentedAuthMethod, err := parseMCPOAuthClientAuthentication(r)
+	if err != nil {
+		writeMCPOAuthError(w, http.StatusUnauthorized, "invalid_client", err.Error())
+		return
+	}
+	if clientID == "" {
+		writeMCPOAuthError(w, http.StatusUnauthorized, "invalid_client", "client_id is required")
+		return
+	}
+
+	client, err := decodeMCPOAuthClientRegistration(s.encryptor, clientID, s.now())
+	if err != nil {
+		writeMCPOAuthError(w, http.StatusUnauthorized, "invalid_client", "client registration is invalid")
+		return
+	}
+	if err := s.validateMCPOAuthClientAuthentication(clientID, client.TokenEndpointAuthMethod, presentedAuthMethod, clientSecret); err != nil {
+		writeMCPOAuthError(w, http.StatusUnauthorized, "invalid_client", err.Error())
+		return
+	}
+
+	switch grantType := strings.TrimSpace(r.Form.Get("grant_type")); grantType {
+	case "authorization_code":
+		s.mcpOAuthExchangeAuthorizationCode(w, r, clientID)
+	case "refresh_token":
+		s.mcpOAuthRefreshAccessToken(w, r, clientID)
+	default:
+		writeMCPOAuthError(w, http.StatusBadRequest, "unsupported_grant_type", "unsupported grant_type")
+	}
+}
+
+func (s *Server) mcpOAuthExchangeAuthorizationCode(w http.ResponseWriter, r *http.Request, clientID string) {
+	codeState, err := decodeMCPOAuthAuthorizationCode(s.encryptor, r.Form.Get("code"), s.now())
+	if err != nil {
+		writeMCPOAuthError(w, http.StatusBadRequest, "invalid_grant", "authorization code is invalid")
+		return
+	}
+	if codeState.ClientID != clientID {
+		writeMCPOAuthError(w, http.StatusBadRequest, "invalid_grant", "authorization code was not issued to this client")
+		return
+	}
+
+	redirectURI, err := resolveRegisteredMCPOAuthRedirectURI([]string{codeState.RedirectURI}, r.Form.Get("redirect_uri"))
+	if err != nil {
+		writeMCPOAuthError(w, http.StatusBadRequest, "invalid_grant", "redirect_uri does not match authorization code")
+		return
+	}
+	if redirectURI != codeState.RedirectURI {
+		writeMCPOAuthError(w, http.StatusBadRequest, "invalid_grant", "redirect_uri does not match authorization code")
+		return
+	}
+
+	verifier := strings.TrimSpace(r.Form.Get("code_verifier"))
+	if verifier == "" {
+		writeMCPOAuthError(w, http.StatusBadRequest, "invalid_request", "code_verifier is required")
+		return
+	}
+	if method := normalizeMCPOAuthCodeChallengeMethod(codeState.CodeChallengeMethod); method != "S256" {
+		writeMCPOAuthError(w, http.StatusBadRequest, "invalid_grant", "authorization code challenge method is unsupported")
+		return
+	}
+	if oauth.ComputeS256Challenge(verifier) != codeState.CodeChallenge {
+		writeMCPOAuthError(w, http.StatusBadRequest, "invalid_grant", "code_verifier is invalid")
+		return
+	}
+
+	refreshToken, err := encodeMCPOAuthRefreshToken(s.encryptor, mcpOAuthRefreshTokenState{
+		ClientID:    clientID,
+		Email:       codeState.Email,
+		DisplayName: codeState.DisplayName,
+		AvatarURL:   codeState.AvatarURL,
+		Scope:       codeState.Scope,
+		ExpiresAt:   s.now().Add(mcpOAuthRefreshTokenTTL).Unix(),
+	})
+	if err != nil {
+		writeMCPOAuthError(w, http.StatusInternalServerError, "server_error", "failed to issue refresh token")
+		return
+	}
+
+	identity := &core.UserIdentity{
+		Email:       codeState.Email,
+		DisplayName: codeState.DisplayName,
+		AvatarURL:   codeState.AvatarURL,
+	}
+	s.writeMCPOAuthTokenResponse(w, identity, codeState.Scope, refreshToken)
+}
+
+func (s *Server) mcpOAuthRefreshAccessToken(w http.ResponseWriter, r *http.Request, clientID string) {
+	refreshState, err := decodeMCPOAuthRefreshToken(s.encryptor, r.Form.Get("refresh_token"), s.now())
+	if err != nil {
+		writeMCPOAuthError(w, http.StatusBadRequest, "invalid_grant", "refresh token is invalid")
+		return
+	}
+	if refreshState.ClientID != clientID {
+		writeMCPOAuthError(w, http.StatusBadRequest, "invalid_grant", "refresh token was not issued to this client")
+		return
+	}
+
+	refreshToken, err := encodeMCPOAuthRefreshToken(s.encryptor, mcpOAuthRefreshTokenState{
+		ClientID:    clientID,
+		Email:       refreshState.Email,
+		DisplayName: refreshState.DisplayName,
+		AvatarURL:   refreshState.AvatarURL,
+		Scope:       refreshState.Scope,
+		ExpiresAt:   s.now().Add(mcpOAuthRefreshTokenTTL).Unix(),
+	})
+	if err != nil {
+		writeMCPOAuthError(w, http.StatusInternalServerError, "server_error", "failed to rotate refresh token")
+		return
+	}
+
+	identity := &core.UserIdentity{
+		Email:       refreshState.Email,
+		DisplayName: refreshState.DisplayName,
+		AvatarURL:   refreshState.AvatarURL,
+	}
+	s.writeMCPOAuthTokenResponse(w, identity, refreshState.Scope, refreshToken)
+}
+
+func (s *Server) writeMCPOAuthTokenResponse(w http.ResponseWriter, identity *core.UserIdentity, scope, refreshToken string) {
+	auth := s.serverAuthRuntime()
+	accessToken, err := s.issueSessionToken(auth.provider, identity)
+	if err != nil {
+		writeMCPOAuthError(w, http.StatusInternalServerError, "server_error", "failed to issue access token")
+		return
+	}
+
+	ttl := defaultSessionCookieTTL
+	if auth.provider != nil {
+		if providerWithTTL, ok := auth.provider.(SessionTokenTTLProvider); ok {
+			ttl = providerWithTTL.SessionTokenTTL()
+		}
+	}
+
+	setMCPOAuthNoStoreHeaders(w)
+	writeJSON(w, http.StatusOK, mcpOAuthTokenResponse{
+		AccessToken:  accessToken,
+		TokenType:    "Bearer",
+		ExpiresIn:    int(ttl.Seconds()),
+		RefreshToken: refreshToken,
+		Scope:        scope,
+	})
+}
+
+func writeMCPOAuthError(w http.ResponseWriter, status int, code, description string) {
+	setMCPOAuthNoStoreHeaders(w)
+	writeJSON(w, status, mcpOAuthErrorResponse{
+		Error:            code,
+		ErrorDescription: description,
+	})
+}
+
+func setMCPOAuthNoStoreHeaders(w http.ResponseWriter) {
+	w.Header().Set("Cache-Control", "no-store")
+	w.Header().Set("Pragma", "no-cache")
+}
+
+func redirectMCPOAuthError(w http.ResponseWriter, r *http.Request, redirectURI, state, code, description string) {
+	params := map[string]string{
+		"error":             code,
+		"error_description": description,
+	}
+	if state != "" {
+		params["state"] = state
+	}
+	redirectMCPOAuthSuccess(w, r, redirectURI, params)
+}
+
+func redirectMCPOAuthSuccess(w http.ResponseWriter, r *http.Request, redirectURI string, params map[string]string) {
+	target, err := url.Parse(redirectURI)
+	if err != nil {
+		writeMCPOAuthError(w, http.StatusBadRequest, "invalid_request", "redirect_uri is invalid")
+		return
+	}
+	query := target.Query()
+	for key, value := range params {
+		if strings.TrimSpace(value) == "" {
+			continue
+		}
+		query.Set(key, value)
+	}
+	target.RawQuery = query.Encode()
+	http.Redirect(w, r, target.String(), http.StatusFound)
+}
+
+func normalizeMCPOAuthCodeChallengeMethod(raw string) string {
+	raw = strings.TrimSpace(raw)
+	if raw == "" {
+		return "S256"
+	}
+	return raw
+}
+
+func normalizeMCPOAuthTokenEndpointAuthMethod(raw string) string {
+	raw = strings.TrimSpace(raw)
+	if raw == "" {
+		return mcpOAuthTokenAuthMethodNone
+	}
+	return raw
+}
+
+func isSupportedMCPOAuthTokenEndpointAuthMethod(method string) bool {
+	switch normalizeMCPOAuthTokenEndpointAuthMethod(method) {
+	case mcpOAuthTokenAuthMethodNone, mcpOAuthTokenAuthMethodClientSecretPost, mcpOAuthTokenAuthMethodClientSecretBasic:
+		return true
+	default:
+		return false
+	}
+}
+
+func validateMCPOAuthRedirectURI(raw string) error {
+	raw = strings.TrimSpace(raw)
+	if raw == "" {
+		return errors.New("redirect_uri is required")
+	}
+	parsed, err := url.Parse(raw)
+	if err != nil || !parsed.IsAbs() {
+		return errors.New("redirect_uri must be an absolute URI")
+	}
+	if parsed.Fragment != "" {
+		return errors.New("redirect_uri must not include a fragment")
+	}
+	return nil
+}
+
+func resolveRegisteredMCPOAuthRedirectURI(registered []string, requested string) (string, error) {
+	requested = strings.TrimSpace(requested)
+	if requested == "" {
+		if len(registered) == 1 {
+			return registered[0], nil
+		}
+		return "", errors.New("redirect_uri is required")
+	}
+	for _, candidate := range registered {
+		if candidate == requested {
+			return requested, nil
+		}
+	}
+	return "", errors.New("redirect_uri is not registered")
+}
+
+func parseMCPOAuthClientAuthentication(r *http.Request) (clientID, clientSecret, method string, err error) {
+	if authHeader := strings.TrimSpace(r.Header.Get("Authorization")); authHeader != "" {
+		clientID, clientSecret, ok := r.BasicAuth()
+		if !ok {
+			return "", "", "", errors.New("unsupported client authentication")
+		}
+		if decoded, decodeErr := url.QueryUnescape(clientID); decodeErr == nil {
+			clientID = decoded
+		}
+		if decoded, decodeErr := url.QueryUnescape(clientSecret); decodeErr == nil {
+			clientSecret = decoded
+		}
+		return clientID, clientSecret, mcpOAuthTokenAuthMethodClientSecretBasic, nil
+	}
+	clientID = strings.TrimSpace(r.Form.Get("client_id"))
+	clientSecret = strings.TrimSpace(r.Form.Get("client_secret"))
+	if clientSecret != "" {
+		return clientID, clientSecret, mcpOAuthTokenAuthMethodClientSecretPost, nil
+	}
+	return clientID, "", mcpOAuthTokenAuthMethodNone, nil
+}
+
+func (s *Server) validateMCPOAuthClientAuthentication(clientID, registeredAuthMethod, presentedAuthMethod, clientSecret string) error {
+	registeredAuthMethod = normalizeMCPOAuthTokenEndpointAuthMethod(registeredAuthMethod)
+	presentedAuthMethod = normalizeMCPOAuthTokenEndpointAuthMethod(presentedAuthMethod)
+	if registeredAuthMethod != presentedAuthMethod {
+		return fmt.Errorf("client authentication method does not match registration")
+	}
+	switch registeredAuthMethod {
+	case mcpOAuthTokenAuthMethodNone:
+		return nil
+	case mcpOAuthTokenAuthMethodClientSecretPost, mcpOAuthTokenAuthMethodClientSecretBasic:
+		expected := s.mcpOAuthClientSecret(clientID)
+		if expected == "" {
+			return fmt.Errorf("client authentication is unavailable")
+		}
+		if !hmac.Equal([]byte(expected), []byte(clientSecret)) {
+			return fmt.Errorf("client_secret is invalid")
+		}
+		return nil
+	default:
+		return fmt.Errorf("client authentication method is unsupported")
+	}
+}
+
+func (s *Server) mcpOAuthClientSecret(clientID string) string {
+	if len(s.sessionIssuer) == 0 || clientID == "" {
+		return ""
+	}
+	mac := hmac.New(sha256.New, s.sessionIssuer)
+	_, _ = mac.Write([]byte("mcp-oauth-client-secret\x00"))
+	_, _ = mac.Write([]byte(clientID))
+	return base64.RawURLEncoding.EncodeToString(mac.Sum(nil))
+}

--- a/gestaltd/internal/server/handlers_mcp_authorization_server.go
+++ b/gestaltd/internal/server/handlers_mcp_authorization_server.go
@@ -475,7 +475,7 @@ func redirectMCPOAuthSuccess(w http.ResponseWriter, r *http.Request, redirectURI
 	}
 	query := target.Query()
 	for key, value := range params {
-		if strings.TrimSpace(value) == "" {
+		if value == "" {
 			continue
 		}
 		query.Set(key, value)

--- a/gestaltd/internal/server/handlers_mcp_oauth.go
+++ b/gestaltd/internal/server/handlers_mcp_oauth.go
@@ -1,6 +1,7 @@
 package server
 
 import (
+	"errors"
 	"net/http"
 	"net/url"
 	"strings"
@@ -13,10 +14,15 @@ const (
 )
 
 type mcpProtectedResourceMetadataResponse struct {
-	Resource               string   `json:"resource"`
-	AuthorizationServers   []string `json:"authorization_servers,omitempty"`
-	ScopesSupported        []string `json:"scopes_supported,omitempty"`
-	BearerMethodsSupported []string `json:"bearer_methods_supported,omitempty"`
+	Resource                          string   `json:"resource"`
+	AuthorizationServers              []string `json:"authorization_servers,omitempty"`
+	AuthorizationEndpoint             string   `json:"authorization_endpoint,omitempty"`
+	TokenEndpoint                     string   `json:"token_endpoint,omitempty"`
+	RegistrationEndpoint              string   `json:"registration_endpoint,omitempty"`
+	ScopesSupported                   []string `json:"scopes_supported,omitempty"`
+	BearerMethodsSupported            []string `json:"bearer_methods_supported,omitempty"`
+	CodeChallengeMethodsSupported     []string `json:"code_challenge_methods_supported,omitempty"`
+	TokenEndpointAuthMethodsSupported []string `json:"token_endpoint_auth_methods_supported,omitempty"`
 }
 
 func (s *Server) mcpProtectedResourceMetadata(w http.ResponseWriter, r *http.Request) {
@@ -34,40 +40,48 @@ func (s *Server) mcpProtectedResourceMetadataResponse(r *http.Request) (mcpProte
 		return mcpProtectedResourceMetadataResponse{}, err
 	}
 
-	authorizationServers, scopes := s.mcpAuthorizationMetadata(r)
+	authServer, err := s.mcpAuthorizationServerConfig(r)
+	if err != nil {
+		if errors.Is(err, errMCPOAuthDisabled) {
+			return mcpProtectedResourceMetadataResponse{
+				Resource: resourceURL,
+			}, nil
+		}
+		return mcpProtectedResourceMetadataResponse{}, err
+	}
 	resp := mcpProtectedResourceMetadataResponse{
-		Resource:               resourceURL,
-		AuthorizationServers:   authorizationServers,
-		ScopesSupported:        scopes,
-		BearerMethodsSupported: []string{"header"},
+		Resource:                          resourceURL,
+		AuthorizationServers:              []string{authServer.Issuer},
+		AuthorizationEndpoint:             authServer.AuthorizationEndpoint,
+		TokenEndpoint:                     authServer.TokenEndpoint,
+		RegistrationEndpoint:              authServer.RegistrationEndpoint,
+		ScopesSupported:                   authServer.ScopesSupported,
+		BearerMethodsSupported:            []string{"header"},
+		CodeChallengeMethodsSupported:     authServer.CodeChallengeMethodsSupported,
+		TokenEndpointAuthMethodsSupported: authServer.TokenEndpointAuthMethodsSupported,
 	}
 	return resp, nil
 }
 
-func (s *Server) mcpAuthorizationMetadata(r *http.Request) ([]string, []string) {
+func (s *Server) mcpAuthorizationScopes(r *http.Request) []string {
 	auth := s.serverAuthRuntime()
 	if auth.noAuth || auth.provider == nil {
-		return nil, nil
+		return nil
 	}
 
 	loginURLRaw, err := loginURLForRequest(r.Context(), auth.provider, mcpMetadataProbeState)
 	if err != nil {
-		return nil, nil
+		return nil
 	}
 	loginURLResolved, err := s.resolvePublicURL(r, loginURLRaw)
 	if err != nil {
-		return nil, nil
+		return nil
 	}
 	loginURL, err := url.Parse(loginURLResolved)
 	if err != nil || !loginURL.IsAbs() || loginURL.Host == "" {
-		return nil, nil
+		return nil
 	}
-
-	authorizationServer := (&url.URL{
-		Scheme: loginURL.Scheme,
-		Host:   loginURL.Host,
-	}).String()
-	return []string{authorizationServer}, splitOAuthScopes(loginURL.Query().Get("scope"))
+	return splitOAuthScopes(loginURL.Query().Get("scope"))
 }
 
 func splitOAuthScopes(raw string) []string {

--- a/gestaltd/internal/server/oauth_state.go
+++ b/gestaltd/internal/server/oauth_state.go
@@ -5,6 +5,7 @@ import (
 	"errors"
 	"fmt"
 	"net/url"
+	"strings"
 	"time"
 
 	"github.com/valon-technologies/gestalt/server/core"
@@ -97,6 +98,15 @@ func (c *integrationOAuthStateCodec) Decode(encoded string, now time.Time) (*int
 
 const loginStateTTL = 10 * time.Minute
 const loginStateCookieName = "login_state"
+const mcpOAuthClientRegistrationTTL = 365 * 24 * time.Hour
+const mcpOAuthAuthorizationCodeTTL = 5 * time.Minute
+const mcpOAuthRefreshTokenTTL = 30 * 24 * time.Hour
+
+const (
+	mcpOAuthClientIDPrefix          = "gst_mcp_client_"
+	mcpOAuthAuthorizationCodePrefix = "gst_mcp_code_"
+	mcpOAuthRefreshTokenPrefix      = "gst_mcp_refresh_"
+)
 
 type loginState struct {
 	State     string `json:"s"`
@@ -115,6 +125,34 @@ type pendingConnectionState struct {
 type pendingConnectionBindingState struct {
 	BindingKey string `json:"bind"`
 	ExpiresAt  int64  `json:"exp"`
+}
+
+type mcpOAuthClientRegistrationState struct {
+	RedirectURIs            []string `json:"ru"`
+	ClientName              string   `json:"cn,omitempty"`
+	TokenEndpointAuthMethod string   `json:"tm,omitempty"`
+	ExpiresAt               int64    `json:"exp"`
+}
+
+type mcpOAuthAuthorizationCodeState struct {
+	ClientID            string `json:"cid"`
+	RedirectURI         string `json:"ru"`
+	Email               string `json:"em"`
+	DisplayName         string `json:"dn,omitempty"`
+	AvatarURL           string `json:"av,omitempty"`
+	Scope               string `json:"sc,omitempty"`
+	CodeChallenge       string `json:"cc"`
+	CodeChallengeMethod string `json:"cm,omitempty"`
+	ExpiresAt           int64  `json:"exp"`
+}
+
+type mcpOAuthRefreshTokenState struct {
+	ClientID    string `json:"cid"`
+	Email       string `json:"em"`
+	DisplayName string `json:"dn,omitempty"`
+	AvatarURL   string `json:"av,omitempty"`
+	Scope       string `json:"sc,omitempty"`
+	ExpiresAt   int64  `json:"exp"`
 }
 
 func encodeLoginState(enc *cryptoutil.AESGCMEncryptor, state loginState) (string, error) {
@@ -205,6 +243,126 @@ func decodePendingConnectionBindingState(enc *cryptoutil.AESGCMEncryptor, encode
 		return nil, err
 	}
 	if err := validatePendingConnectionBindingState(state, now); err != nil {
+		return nil, err
+	}
+	return state, nil
+}
+
+func encodeMCPOAuthClientRegistration(enc *cryptoutil.AESGCMEncryptor, state mcpOAuthClientRegistrationState) (string, error) {
+	encoded, err := encodeEncryptedState(enc, "mcp oauth client registration", state)
+	if err != nil {
+		return "", err
+	}
+	return mcpOAuthClientIDPrefix + encoded, nil
+}
+
+func validateMCPOAuthClientRegistration(state *mcpOAuthClientRegistrationState, now time.Time) error {
+	if len(state.RedirectURIs) == 0 {
+		return fmt.Errorf("mcp oauth client registration missing redirect URIs")
+	}
+	if state.ExpiresAt == 0 {
+		return fmt.Errorf("mcp oauth client registration missing expiration")
+	}
+	if now.Unix() > state.ExpiresAt {
+		return fmt.Errorf("mcp oauth client registration expired")
+	}
+	return nil
+}
+
+func decodeMCPOAuthClientRegistration(enc *cryptoutil.AESGCMEncryptor, encoded string, now time.Time) (*mcpOAuthClientRegistrationState, error) {
+	encoded = strings.TrimSpace(encoded)
+	if !strings.HasPrefix(encoded, mcpOAuthClientIDPrefix) {
+		return nil, fmt.Errorf("mcp oauth client registration token is malformed")
+	}
+	state, err := decodeEncryptedState[mcpOAuthClientRegistrationState](enc, "mcp oauth client registration", strings.TrimPrefix(encoded, mcpOAuthClientIDPrefix))
+	if err != nil {
+		return nil, err
+	}
+	if err := validateMCPOAuthClientRegistration(state, now); err != nil {
+		return nil, err
+	}
+	return state, nil
+}
+
+func encodeMCPOAuthAuthorizationCode(enc *cryptoutil.AESGCMEncryptor, state mcpOAuthAuthorizationCodeState) (string, error) {
+	encoded, err := encodeEncryptedState(enc, "mcp oauth authorization code", state)
+	if err != nil {
+		return "", err
+	}
+	return mcpOAuthAuthorizationCodePrefix + encoded, nil
+}
+
+func validateMCPOAuthAuthorizationCode(state *mcpOAuthAuthorizationCodeState, now time.Time) error {
+	if state.ClientID == "" {
+		return fmt.Errorf("mcp oauth authorization code missing client ID")
+	}
+	if state.RedirectURI == "" {
+		return fmt.Errorf("mcp oauth authorization code missing redirect URI")
+	}
+	if state.Email == "" {
+		return fmt.Errorf("mcp oauth authorization code missing email")
+	}
+	if state.CodeChallenge == "" {
+		return fmt.Errorf("mcp oauth authorization code missing code challenge")
+	}
+	if state.ExpiresAt == 0 {
+		return fmt.Errorf("mcp oauth authorization code missing expiration")
+	}
+	if now.Unix() > state.ExpiresAt {
+		return fmt.Errorf("mcp oauth authorization code expired")
+	}
+	return nil
+}
+
+func decodeMCPOAuthAuthorizationCode(enc *cryptoutil.AESGCMEncryptor, encoded string, now time.Time) (*mcpOAuthAuthorizationCodeState, error) {
+	encoded = strings.TrimSpace(encoded)
+	if !strings.HasPrefix(encoded, mcpOAuthAuthorizationCodePrefix) {
+		return nil, fmt.Errorf("mcp oauth authorization code is malformed")
+	}
+	state, err := decodeEncryptedState[mcpOAuthAuthorizationCodeState](enc, "mcp oauth authorization code", strings.TrimPrefix(encoded, mcpOAuthAuthorizationCodePrefix))
+	if err != nil {
+		return nil, err
+	}
+	if err := validateMCPOAuthAuthorizationCode(state, now); err != nil {
+		return nil, err
+	}
+	return state, nil
+}
+
+func encodeMCPOAuthRefreshToken(enc *cryptoutil.AESGCMEncryptor, state mcpOAuthRefreshTokenState) (string, error) {
+	encoded, err := encodeEncryptedState(enc, "mcp oauth refresh token", state)
+	if err != nil {
+		return "", err
+	}
+	return mcpOAuthRefreshTokenPrefix + encoded, nil
+}
+
+func validateMCPOAuthRefreshToken(state *mcpOAuthRefreshTokenState, now time.Time) error {
+	if state.ClientID == "" {
+		return fmt.Errorf("mcp oauth refresh token missing client ID")
+	}
+	if state.Email == "" {
+		return fmt.Errorf("mcp oauth refresh token missing email")
+	}
+	if state.ExpiresAt == 0 {
+		return fmt.Errorf("mcp oauth refresh token missing expiration")
+	}
+	if now.Unix() > state.ExpiresAt {
+		return fmt.Errorf("mcp oauth refresh token expired")
+	}
+	return nil
+}
+
+func decodeMCPOAuthRefreshToken(enc *cryptoutil.AESGCMEncryptor, encoded string, now time.Time) (*mcpOAuthRefreshTokenState, error) {
+	encoded = strings.TrimSpace(encoded)
+	if !strings.HasPrefix(encoded, mcpOAuthRefreshTokenPrefix) {
+		return nil, fmt.Errorf("mcp oauth refresh token is malformed")
+	}
+	state, err := decodeEncryptedState[mcpOAuthRefreshTokenState](enc, "mcp oauth refresh token", strings.TrimPrefix(encoded, mcpOAuthRefreshTokenPrefix))
+	if err != nil {
+		return nil, err
+	}
+	if err := validateMCPOAuthRefreshToken(state, now); err != nil {
 		return nil, err
 	}
 	return state, nil

--- a/gestaltd/internal/server/routes.go
+++ b/gestaltd/internal/server/routes.go
@@ -136,6 +136,11 @@ func (s *Server) mountMCPRoutes(r chi.Router) {
 		return
 	}
 	r.Get(mcpProtectedResourceMetadataPath, s.mcpProtectedResourceMetadata)
+	r.Get(mcpAuthorizationServerMetadataPath, s.mcpAuthorizationServerMetadata)
+	r.Get(mcpAuthorizationServerMetadataMCPPath, s.mcpAuthorizationServerMetadata)
+	r.Post(mcpRegistrationEndpointPath, s.mcpRegisterOAuthClient)
+	r.Get(mcpAuthorizationEndpointPath, s.mcpOAuthAuthorize)
+	r.Post(mcpTokenEndpointPath, s.mcpOAuthToken)
 	r.Group(func(r chi.Router) {
 		r.Use(s.authMiddleware)
 		r.Handle(mcpPath, s.mcpHandler)

--- a/gestaltd/internal/server/server_test.go
+++ b/gestaltd/internal/server/server_test.go
@@ -15386,8 +15386,17 @@ func TestMCPProtectedResourceMetadata(t *testing.T) {
 		t.Fatalf("resource = %v, want %q", got, ts.URL+"/mcp")
 	}
 	authServers, _ := body["authorization_servers"].([]any)
-	if len(authServers) != 1 || authServers[0] != "https://accounts.example.test" {
-		t.Fatalf("authorization_servers = %v, want [https://accounts.example.test]", authServers)
+	if len(authServers) != 1 || authServers[0] != ts.URL {
+		t.Fatalf("authorization_servers = %v, want [%s]", authServers, ts.URL)
+	}
+	if got := body["authorization_endpoint"]; got != ts.URL+"/oauth/authorize" {
+		t.Fatalf("authorization_endpoint = %v, want %q", got, ts.URL+"/oauth/authorize")
+	}
+	if got := body["token_endpoint"]; got != ts.URL+"/oauth/token" {
+		t.Fatalf("token_endpoint = %v, want %q", got, ts.URL+"/oauth/token")
+	}
+	if got := body["registration_endpoint"]; got != ts.URL+"/oauth/register" {
+		t.Fatalf("registration_endpoint = %v, want %q", got, ts.URL+"/oauth/register")
 	}
 	scopes, _ := body["scopes_supported"].([]any)
 	if !reflect.DeepEqual(scopes, []any{"openid", "email", "profile"}) {
@@ -15396,6 +15405,14 @@ func TestMCPProtectedResourceMetadata(t *testing.T) {
 	bearerMethods, _ := body["bearer_methods_supported"].([]any)
 	if !reflect.DeepEqual(bearerMethods, []any{"header"}) {
 		t.Fatalf("bearer_methods_supported = %v, want [header]", bearerMethods)
+	}
+	challengeMethods, _ := body["code_challenge_methods_supported"].([]any)
+	if !reflect.DeepEqual(challengeMethods, []any{"S256"}) {
+		t.Fatalf("code_challenge_methods_supported = %v, want [S256]", challengeMethods)
+	}
+	authMethods, _ := body["token_endpoint_auth_methods_supported"].([]any)
+	if !reflect.DeepEqual(authMethods, []any{"none", "client_secret_post", "client_secret_basic"}) {
+		t.Fatalf("token_endpoint_auth_methods_supported = %v, want [none client_secret_post client_secret_basic]", authMethods)
 	}
 }
 
@@ -15448,6 +15465,336 @@ func TestMCPProtectedResourceMetadataRoute_PrecedesRootMountedUIFallback(t *test
 	}
 	if strings.Contains(string(body), "root-shell") {
 		t.Fatalf("body = %q, want JSON metadata instead of root UI shell", body)
+	}
+}
+
+func TestMCPAuthorizationServerMetadata(t *testing.T) {
+	t.Parallel()
+
+	svc := coretesting.NewStubServices(t)
+	mcpHandler := newMCPHandler(t, func() *registry.ProviderMap[core.Provider] {
+		reg := registry.New()
+		return &reg.Providers
+	}(), svc, nil, nil)
+
+	ts := newTestServer(t, func(cfg *server.Config) {
+		cfg.Auth = &stubAuthWithLoginURL{
+			StubAuthProvider: coretesting.StubAuthProvider{N: "oidc"},
+			loginURL:         "https://accounts.example.test/authorize?scope=openid+email+profile",
+		}
+		cfg.MCPHandler = mcpHandler
+	})
+	testutil.CloseOnCleanup(t, ts)
+
+	for _, path := range []string{"/.well-known/oauth-authorization-server", "/.well-known/oauth-authorization-server/mcp"} {
+		resp, err := http.Get(ts.URL + path)
+		if err != nil {
+			t.Fatalf("GET %s: %v", path, err)
+		}
+		if resp.StatusCode != http.StatusOK {
+			_ = resp.Body.Close()
+			t.Fatalf("%s status = %d, want %d", path, resp.StatusCode, http.StatusOK)
+		}
+
+		var body map[string]any
+		if err := json.NewDecoder(resp.Body).Decode(&body); err != nil {
+			_ = resp.Body.Close()
+			t.Fatalf("decode %s JSON: %v", path, err)
+		}
+		_ = resp.Body.Close()
+
+		if got := body["issuer"]; got != ts.URL {
+			t.Fatalf("%s issuer = %v, want %q", path, got, ts.URL)
+		}
+		if got := body["authorization_endpoint"]; got != ts.URL+"/oauth/authorize" {
+			t.Fatalf("%s authorization_endpoint = %v, want %q", path, got, ts.URL+"/oauth/authorize")
+		}
+		if got := body["token_endpoint"]; got != ts.URL+"/oauth/token" {
+			t.Fatalf("%s token_endpoint = %v, want %q", path, got, ts.URL+"/oauth/token")
+		}
+		if got := body["registration_endpoint"]; got != ts.URL+"/oauth/register" {
+			t.Fatalf("%s registration_endpoint = %v, want %q", path, got, ts.URL+"/oauth/register")
+		}
+	}
+}
+
+func TestMCPAuthorizationServerMetadataRoute_PrecedesRootMountedUIFallback(t *testing.T) {
+	t.Parallel()
+
+	dir := t.TempDir()
+	if err := os.WriteFile(filepath.Join(dir, "index.html"), []byte("<html>root-shell</html>"), 0o644); err != nil {
+		t.Fatalf("WriteFile index.html: %v", err)
+	}
+	handler, err := testutilUIHandler(dir)
+	if err != nil {
+		t.Fatalf("ui handler: %v", err)
+	}
+
+	svc := coretesting.NewStubServices(t)
+	mcpHandler := newMCPHandler(t, func() *registry.ProviderMap[core.Provider] {
+		reg := registry.New()
+		return &reg.Providers
+	}(), svc, nil, nil)
+
+	ts := newTestServer(t, func(cfg *server.Config) {
+		cfg.Auth = &stubAuthWithLoginURL{
+			StubAuthProvider: coretesting.StubAuthProvider{N: "oidc"},
+			loginURL:         "https://accounts.example.test/authorize",
+		}
+		cfg.MountedUIs = []server.MountedUI{{
+			Path:    "/",
+			Handler: handler,
+		}}
+		cfg.MCPHandler = mcpHandler
+	})
+	testutil.CloseOnCleanup(t, ts)
+
+	resp, err := http.Get(ts.URL + "/.well-known/oauth-authorization-server")
+	if err != nil {
+		t.Fatalf("GET auth server metadata with root UI: %v", err)
+	}
+	defer func() { _ = resp.Body.Close() }()
+
+	body, err := io.ReadAll(resp.Body)
+	if err != nil {
+		t.Fatalf("ReadAll metadata response: %v", err)
+	}
+	if resp.StatusCode != http.StatusOK {
+		t.Fatalf("status = %d, want %d", resp.StatusCode, http.StatusOK)
+	}
+	if got := resp.Header.Get("Content-Type"); got != "application/json" {
+		t.Fatalf("Content-Type = %q, want %q", got, "application/json")
+	}
+	if strings.Contains(string(body), "root-shell") {
+		t.Fatalf("body = %q, want JSON metadata instead of root UI shell", body)
+	}
+}
+
+func TestMCPOAuthAuthorizationCodeFlow(t *testing.T) {
+	t.Parallel()
+
+	secret := []byte("0123456789abcdef0123456789abcdef")
+	svc := coretesting.NewStubServices(t)
+	providers := func() *registry.ProviderMap[core.Provider] {
+		reg := registry.New()
+		return &reg.Providers
+	}()
+	mcpHandler := newMCPHandler(t, providers, svc, nil, nil)
+
+	ts := newTestServer(t, func(cfg *server.Config) {
+		cfg.Auth = &stubHostIssuedSessionAuth{secret: secret, name: "oidc"}
+		cfg.StateSecret = secret
+		cfg.MCPHandler = mcpHandler
+		cfg.Services = svc
+	})
+	testutil.CloseOnCleanup(t, ts)
+
+	registrationResp, err := http.Post(ts.URL+"/oauth/register", "application/json", strings.NewReader(`{
+		"client_name":"Claude",
+		"redirect_uris":["http://127.0.0.1:4318/callback"],
+		"grant_types":["authorization_code","refresh_token"],
+		"response_types":["code"],
+		"token_endpoint_auth_method":"none"
+	}`))
+	if err != nil {
+		t.Fatalf("POST /oauth/register: %v", err)
+	}
+	defer func() { _ = registrationResp.Body.Close() }()
+
+	if registrationResp.StatusCode != http.StatusCreated {
+		body, _ := io.ReadAll(registrationResp.Body)
+		t.Fatalf("register status = %d, want %d: %s", registrationResp.StatusCode, http.StatusCreated, body)
+	}
+
+	var registration map[string]any
+	if err := json.NewDecoder(registrationResp.Body).Decode(&registration); err != nil {
+		t.Fatalf("decode registration response: %v", err)
+	}
+	clientID, _ := registration["client_id"].(string)
+	if clientID == "" {
+		t.Fatal("registration response missing client_id")
+	}
+
+	jar, err := cookiejar.New(nil)
+	if err != nil {
+		t.Fatalf("cookiejar.New: %v", err)
+	}
+	noRedirect := &http.Client{
+		Jar: jar,
+		CheckRedirect: func(*http.Request, []*http.Request) error {
+			return http.ErrUseLastResponse
+		},
+	}
+
+	redirectURI := "http://127.0.0.1:4318/callback"
+	verifier := oauth.GenerateVerifier()
+	challenge := oauth.ComputeS256Challenge(verifier)
+	authState := "state-123"
+	authorizeURL := ts.URL + "/oauth/authorize?response_type=code" +
+		"&client_id=" + url.QueryEscape(clientID) +
+		"&redirect_uri=" + url.QueryEscape(redirectURI) +
+		"&scope=" + url.QueryEscape("openid email profile") +
+		"&state=" + url.QueryEscape(authState) +
+		"&code_challenge=" + url.QueryEscape(challenge) +
+		"&code_challenge_method=S256"
+
+	resp, err := noRedirect.Get(authorizeURL)
+	if err != nil {
+		t.Fatalf("GET /oauth/authorize: %v", err)
+	}
+	defer func() { _ = resp.Body.Close() }()
+
+	if resp.StatusCode != http.StatusFound {
+		body, _ := io.ReadAll(resp.Body)
+		t.Fatalf("authorize status = %d, want %d: %s", resp.StatusCode, http.StatusFound, body)
+	}
+	loginURL := ts.URL + resp.Header.Get("Location")
+	if !strings.Contains(loginURL, "/api/v1/auth/login?next=") {
+		t.Fatalf("authorize redirect = %q, want /api/v1/auth/login?next=...", loginURL)
+	}
+
+	loginResp, err := noRedirect.Get(loginURL)
+	if err != nil {
+		t.Fatalf("GET login redirect: %v", err)
+	}
+	defer func() { _ = loginResp.Body.Close() }()
+
+	if loginResp.StatusCode != http.StatusFound {
+		body, _ := io.ReadAll(loginResp.Body)
+		t.Fatalf("login status = %d, want %d: %s", loginResp.StatusCode, http.StatusFound, body)
+	}
+	idpURL := loginResp.Header.Get("Location")
+	idpParsed, err := url.Parse(idpURL)
+	if err != nil {
+		t.Fatalf("parse IDP redirect: %v", err)
+	}
+	idpState := idpParsed.Query().Get("state")
+	if idpState == "" {
+		t.Fatal("IDP redirect missing state")
+	}
+
+	callbackResp, err := noRedirect.Get(ts.URL + "/api/v1/auth/login/callback?code=good-code&state=" + url.QueryEscape(idpState))
+	if err != nil {
+		t.Fatalf("GET login callback: %v", err)
+	}
+	defer func() { _ = callbackResp.Body.Close() }()
+
+	if callbackResp.StatusCode != http.StatusFound {
+		body, _ := io.ReadAll(callbackResp.Body)
+		t.Fatalf("callback status = %d, want %d: %s", callbackResp.StatusCode, http.StatusFound, body)
+	}
+
+	resumeAuthorizeURL, err := url.Parse(callbackResp.Header.Get("Location"))
+	if err != nil {
+		t.Fatalf("parse callback redirect: %v", err)
+	}
+	resumeAuthorize := callbackResp.Request.URL.ResolveReference(resumeAuthorizeURL).String()
+
+	authorizedResp, err := noRedirect.Get(resumeAuthorize)
+	if err != nil {
+		t.Fatalf("GET resumed authorize: %v", err)
+	}
+	defer func() { _ = authorizedResp.Body.Close() }()
+
+	if authorizedResp.StatusCode != http.StatusFound {
+		body, _ := io.ReadAll(authorizedResp.Body)
+		t.Fatalf("resumed authorize status = %d, want %d: %s", authorizedResp.StatusCode, http.StatusFound, body)
+	}
+	finalRedirect, err := url.Parse(authorizedResp.Header.Get("Location"))
+	if err != nil {
+		t.Fatalf("parse final redirect: %v", err)
+	}
+	if got := finalRedirect.Scheme + "://" + finalRedirect.Host + finalRedirect.Path; got != redirectURI {
+		t.Fatalf("final redirect target = %q, want %q", got, redirectURI)
+	}
+	if got := finalRedirect.Query().Get("state"); got != authState {
+		t.Fatalf("final state = %q, want %q", got, authState)
+	}
+	code := finalRedirect.Query().Get("code")
+	if code == "" {
+		t.Fatal("final redirect missing code")
+	}
+
+	tokenResp, err := http.PostForm(ts.URL+"/oauth/token", url.Values{
+		"grant_type":    {"authorization_code"},
+		"client_id":     {clientID},
+		"code":          {code},
+		"redirect_uri":  {redirectURI},
+		"code_verifier": {verifier},
+	})
+	if err != nil {
+		t.Fatalf("POST /oauth/token (authorization_code): %v", err)
+	}
+	defer func() { _ = tokenResp.Body.Close() }()
+
+	if tokenResp.StatusCode != http.StatusOK {
+		body, _ := io.ReadAll(tokenResp.Body)
+		t.Fatalf("token status = %d, want %d: %s", tokenResp.StatusCode, http.StatusOK, body)
+	}
+
+	var tokenBody map[string]any
+	if err := json.NewDecoder(tokenResp.Body).Decode(&tokenBody); err != nil {
+		t.Fatalf("decode token response: %v", err)
+	}
+	accessToken, _ := tokenBody["access_token"].(string)
+	refreshToken, _ := tokenBody["refresh_token"].(string)
+	if accessToken == "" {
+		t.Fatal("token response missing access_token")
+	}
+	if refreshToken == "" {
+		t.Fatal("token response missing refresh_token")
+	}
+
+	status, _ := mcpJSONRPC(t, ts, map[string]string{"Authorization": "Bearer " + accessToken}, map[string]any{
+		"jsonrpc": "2.0",
+		"id":      1,
+		"method":  "initialize",
+		"params": map[string]any{
+			"protocolVersion": "2025-03-26",
+			"capabilities":    map[string]any{},
+			"clientInfo":      map[string]any{"name": "test", "version": "1.0"},
+		},
+	})
+	if status != http.StatusOK {
+		t.Fatalf("initialize with access token: expected 200, got %d", status)
+	}
+
+	refreshResp, err := http.PostForm(ts.URL+"/oauth/token", url.Values{
+		"grant_type":    {"refresh_token"},
+		"client_id":     {clientID},
+		"refresh_token": {refreshToken},
+	})
+	if err != nil {
+		t.Fatalf("POST /oauth/token (refresh_token): %v", err)
+	}
+	defer func() { _ = refreshResp.Body.Close() }()
+
+	if refreshResp.StatusCode != http.StatusOK {
+		body, _ := io.ReadAll(refreshResp.Body)
+		t.Fatalf("refresh status = %d, want %d: %s", refreshResp.StatusCode, http.StatusOK, body)
+	}
+
+	var refreshBody map[string]any
+	if err := json.NewDecoder(refreshResp.Body).Decode(&refreshBody); err != nil {
+		t.Fatalf("decode refresh response: %v", err)
+	}
+	refreshedAccessToken, _ := refreshBody["access_token"].(string)
+	if refreshedAccessToken == "" {
+		t.Fatal("refresh response missing access_token")
+	}
+
+	status, _ = mcpJSONRPC(t, ts, map[string]string{"Authorization": "Bearer " + refreshedAccessToken}, map[string]any{
+		"jsonrpc": "2.0",
+		"id":      2,
+		"method":  "initialize",
+		"params": map[string]any{
+			"protocolVersion": "2025-03-26",
+			"capabilities":    map[string]any{},
+			"clientInfo":      map[string]any{"name": "test", "version": "1.0"},
+		},
+	})
+	if status != http.StatusOK {
+		t.Fatalf("initialize with refreshed access token: expected 200, got %d", status)
 	}
 }
 

--- a/gestaltd/internal/server/server_test.go
+++ b/gestaltd/internal/server/server_test.go
@@ -15629,7 +15629,7 @@ func TestMCPOAuthAuthorizationCodeFlow(t *testing.T) {
 	redirectURI := "http://127.0.0.1:4318/callback"
 	verifier := oauth.GenerateVerifier()
 	challenge := oauth.ComputeS256Challenge(verifier)
-	authState := "state-123"
+	authState := "   "
 	authorizeURL := ts.URL + "/oauth/authorize?response_type=code" +
 		"&client_id=" + url.QueryEscape(clientID) +
 		"&redirect_uri=" + url.QueryEscape(redirectURI) +


### PR DESCRIPTION
## Summary
- advertise a Gestalt-hosted OAuth authorization server from MCP protected-resource metadata
- add MCP OAuth metadata, dynamic client registration, authorize, and token endpoints backed by the existing browser login/session flow
- issue MCP access and refresh tokens without server-side registration storage, and cover the end-to-end Claude-style PKCE flow in server tests

## Testing
- go test ./internal/server
