### PR TITLE
[codex] Document runtime provider primitive

### DIFF
--- a/docs/content/custom-providers/plugins.mdx
+++ b/docs/content/custom-providers/plugins.mdx
@@ -379,7 +379,8 @@ The following example defines a `conversations.getMessage` operation that fetche
     The `package.json` field `gestalt.provider` points Gestalt at the provider
     module and optional export. Use a string target such as
     `./provider.ts#plugin` for plugin providers, or an object with `kind` and
-    `target` for authentication and datastore providers.
+    `target` for supported non-plugin TypeScript provider kinds such as
+    authentication or cache.
   </Tabs.Tab>
 </Tabs>
 

--- a/docs/content/custom-providers/releasing.mdx
+++ b/docs/content/custom-providers/releasing.mdx
@@ -12,7 +12,7 @@ the executable artifacts for packaged providers, and optional static assets.
 
 ## What can be released
 
-Gestalt uses the same release system for executable provider packages, authentication and datastore component packages, and packaged UI bundles. Every package is described by a provider manifest file: `manifest.yaml`, `manifest.yml`, or `manifest.json`.
+Gestalt uses the same release system for executable plugin packages, executable component providers such as authentication, authorization, cache, indexeddb, runtime, S3, secrets, and workflow, and packaged UI bundles. Every package is described by a provider manifest file: `manifest.yaml`, `manifest.yml`, or `manifest.json`.
 
 ## Source manifests vs release manifests
 
@@ -120,8 +120,8 @@ packaging.
     }
     ```
 
-    TypeScript authentication and datastore providers use `gestalt.provider` objects
-    such as `{ "kind": "authentication", "target": "./auth.ts#provider" }`.
+    Supported TypeScript source components use `gestalt.provider` objects such
+    as `{ "kind": "authentication", "target": "./auth.ts#provider" }`.
   </Tabs.Tab>
 </Tabs>
 
@@ -129,8 +129,8 @@ packaging.
 
 Source manifests may optionally define a `release.build` command. Gestalt runs
 it before source-manifest preparation, which lets UI packages generate
-static assets and lets provider/authentication/datastore packages generate support files
-such as config schemas before packaging.
+static assets and lets provider packages generate support files such as config
+schemas before packaging.
 
 ```yaml
 kind: ui
@@ -149,8 +149,8 @@ spec:
 
 ### Release manifest for an executable provider
 
-Released executable plugin providers add concrete `entrypoint` and
-`artifacts` entries:
+Released executable providers, including runtime providers, add concrete
+`entrypoint` and `artifacts` entries:
 
 ```yaml
 kind: plugin
@@ -194,11 +194,12 @@ Run this from the provider source directory. It produces release archives and wr
 
 Release tags are derived from the package path after the repository. For example, `source: github.com/acme/plugins/catalog/support-api` releases from the tag `plugins/catalog/support-api/v0.1.0`.
 
-For executable Go, Rust, Python, and TypeScript source providers,
+For executable source plugins in Go, Rust, Python, and TypeScript,
 `provider release` materializes the executable catalog automatically and builds
-the host-platform artifact by default. Go, Rust, and TypeScript auth/datastore
-source packages use the same release flow without catalog generation. Pass
-`--platform` with a comma-separated list such as
+the host-platform artifact by default. Source component providers use the same
+release flow without catalog generation. Runtime and authorization source
+components are currently Go-only. Pass `--platform` with a comma-separated list
+such as
 `--platform linux/amd64,darwin/arm64` to build explicit targets. Pass `--platform all` in CI release jobs to build the
 full supported platform matrix for source builds.
 

--- a/docs/content/index.mdx
+++ b/docs/content/index.mdx
@@ -28,7 +28,7 @@ Gestalt handles this so individual agents and applications don't have to. A sing
 - Credentials and connection data are encrypted at rest, on infrastructure you control. See [Security](/security).
 - A single YAML config declaratively defines which tools to expose, how users authenticate, and how credentials are managed. See [Configuration](/configuration).
 - The same operations are available over MCP, HTTP, CLI, and optional mounted UIs for cloud agents, local coding assistants, and human operators. See [HTTP API](/reference/http-api).
-- Authentication backends, datastores, secret managers, and the UI are replaceable provider packages. Use the first-party providers or write your own in Go, Python, Rust, or TypeScript. See [Built-in Providers](/reference/built-in-providers).
+- Authentication, authorization, cache, storage, runtime, object-store, secret-manager, workflow, and UI backends are replaceable provider packages. Use the first-party providers or write your own. See [Built-in Providers](/reference/built-in-providers).
 - Deploy on any infrastructure you control with Docker, Helm, or bare containers. See [Deploy](/deploy).
 
 ## What Gestalt is not
@@ -50,7 +50,7 @@ Gestalt does not replace your existing APIs. It sits between agents and upstream
     Schedules, runs, triggers, and the current workflow API surface.
   </Cards.Card>
   <Cards.Card title="Providers" href="/providers">
-    Plugins, authentication backends, datastores, and custom UIs as provider packages.
+    Plugins, runtime backends, authentication backends, datastores, and custom UIs as provider packages.
   </Cards.Card>
   <Cards.Card title="Security" href="/security">
     Trust boundaries, encryption, headers, and token handling.

--- a/docs/content/reference/built-in-providers.mdx
+++ b/docs/content/reference/built-in-providers.mdx
@@ -220,4 +220,4 @@ plugins:
 
 ## Community and Custom Providers
 
-Third-party authentication providers, datastore providers, and plugins use the same provider package model as the first-party packages. Package your implementation with a provider manifest that includes the appropriate `kind` and `spec` block, publish a release with `provider-release.yaml`, and reference that metadata URL in config the same way you would reference any first-party provider.
+Third-party provider packages use the same model as the first-party ones, including authentication, authorization, cache, datastore, runtime, S3, secrets, workflow, UI, and plugin packages. Package your implementation with a provider manifest that includes the appropriate `kind` and `spec` block, publish a release with `provider-release.yaml`, and reference that metadata URL in config the same way you would reference any first-party provider.

--- a/docs/content/reference/index.mdx
+++ b/docs/content/reference/index.mdx
@@ -32,6 +32,6 @@ import { Cards } from 'nextra/components'
     Server lifecycle commands, provider release, and common examples.
   </Cards.Card>
   <Cards.Card title="Built-in Providers" href="/reference/built-in-providers">
-    Authentication providers, datastores, secret managers, and telemetry providers.
+    Authentication, authorization, runtime, storage, workflow, secret-manager, and telemetry providers.
   </Cards.Card>
 </Cards>

--- a/docs/content/reference/plugin-manifests.mdx
+++ b/docs/content/reference/plugin-manifests.mdx
@@ -703,7 +703,7 @@ spec:
 
 ## Authoring Notes
 
-Manifest paths must stay inside the package. `kind`, `source`, and `version` are required. A manifest defines exactly one provider kind: `kind: plugin`, `kind: authentication`, `kind: indexeddb`, `kind: secrets`, or `kind: ui`.
+Manifest paths must stay inside the package. `kind`, `source`, and `version` are required. A manifest defines exactly one provider kind: `kind: plugin`, `kind: authentication`, `kind: authorization`, `kind: cache`, `kind: indexeddb`, `kind: runtime`, `kind: s3`, `kind: secrets`, `kind: ui`, or `kind: workflow`.
 
 `configSchemaPath` validates per-plugin config and may be written in JSON or YAML. Any connection may define `params` and `discovery`. OpenAPI and GraphQL may be declared together on one plugin, and MCP may be added alongside either or both.
 
@@ -714,8 +714,9 @@ TypeScript, Gestalt materializes the executable catalog automatically during
 local source-plugin execution and `provider release`. If the source plugin also
 defines hosted HTTP/security metadata in code, Gestalt merges that generated
 `securitySchemes` / `http` metadata into the effective manifest at the same
-time. Authentication and indexeddb source packages use the same release flow
-for Go, Rust, and TypeScript, but they do not generate catalogs. See
+time. Source component packages use the same release flow, but they do not
+generate catalogs. Runtime and authorization source components are currently
+Go-only. See
 [Plugins](/providers/plugins) for the end-to-end authoring flow.
 
 <Tabs items={['Go', 'Python', 'Rust', 'TypeScript']}>
@@ -812,12 +813,14 @@ catalog automatically before packaging. Python source plugins load the module
 declared in `[tool.gestalt].provider` and materialize the executable catalog
 automatically. TypeScript source providers load the target declared in
 `package.json` under `gestalt.provider`. A string target such as
-`./provider.ts#plugin` defaults to a plugin provider; auth and indexeddb
-providers use an object with `kind` and `target`. If the source plugin defines
+`./provider.ts#plugin` defaults to a plugin provider; supported TypeScript
+source components use an object with `kind` and `target`, for example
+`{ "kind": "authentication", "target": "./auth.ts#provider" }`. If the source plugin defines
 hosted HTTP/security metadata in code, release merges the generated
 `securitySchemes` / `http` blocks into the packaged manifest at the same time.
-Authentication and indexeddb source packages support the same release flow for
-Go, Rust, and TypeScript, but they do not generate catalogs. Source packages
-build the host-platform artifact by default. Pass `--platform` for an explicit
+Source component packages support the same release flow, but they do not
+generate catalogs. Runtime and authorization source components are currently
+Go-only. Source packages build the host-platform artifact by default. Pass
+`--platform` for an explicit
 `os/arch[/libc]` target list, or `--platform all` in CI to build the full
 supported release matrix.


### PR DESCRIPTION
## Summary

This updates the docs to treat runtime providers as a first-class provider kind anywhere we summarize the provider model.

## What changed

- updated high-level overview copy to mention runtime providers alongside the other provider families
- updated the reference landing page and built-in providers page so runtime providers show up in the top-level provider summaries
- fixed the manifest reference to include `kind: runtime` in the supported manifest kinds list
- updated advanced authoring and release docs to describe runtime providers in the same source/release flow as other component providers
- clarified the TypeScript authoring notes so they no longer imply a broader non-plugin provider matrix than the current SDK supports

## Why

The repo already has dedicated runtime-provider docs, but some overview and advanced/reference pages still used older provider summaries that omitted runtime providers or described the source/release flow in outdated auth/datastore-only terms.

## Impact

Operators now see runtime providers in the same places they discover other provider types, and provider authors get a more accurate picture of manifest kinds and current source-provider support.

## Validation

- `npm --prefix docs ci`
- `npm --prefix docs run build`
