### PR TITLE
Support v4 local runtime provider releases

### DIFF
--- a/gestaltd/internal/config/config.go
+++ b/gestaltd/internal/config/config.go
@@ -2145,6 +2145,11 @@ func normalizeProviderSourceShapes(cfg *Config) {
 			normalizeEntry(collection.kind, entry)
 		}
 	}
+	for _, entry := range cfg.Runtime.Providers {
+		if entry != nil {
+			normalizeEntry(providermanifestv1.KindRuntime, &entry.ProviderEntry)
+		}
+	}
 	for _, entry := range cfg.Providers.UI {
 		if entry != nil {
 			normalizeEntry(providermanifestv1.KindUI, &entry.ProviderEntry)
@@ -2481,6 +2486,11 @@ func resolveRelativePathsInValue(configPath string, root map[string]any, sourceS
 			}
 		}
 	}
+	if runtimeConfig := nestedMap(root, "runtime"); runtimeConfig != nil {
+		for _, entry := range mapValues(nestedMap(runtimeConfig, "providers")) {
+			resolveRelativePathsInEntry(providermanifestv1.KindRuntime, entry, baseDir, sourceSyntax)
+		}
+	}
 
 	for _, entry := range mapValues(nestedMap(root, "plugins")) {
 		resolveRelativePathsInEntry(providermanifestv1.KindPlugin, entry, baseDir, sourceSyntax)
@@ -2556,6 +2566,7 @@ func resolveRelativePaths(configPath string, cfg *Config) {
 		}
 		entry.IconFile = resolveRelativePath(baseDir, entry.IconFile)
 		entry.Source.Path = resolveRelativePath(baseDir, entry.Source.Path)
+		entry.Source.metadataPath = resolveRelativePath(baseDir, entry.Source.metadataPath)
 	}
 
 	for _, entry := range cfg.Providers.Authentication {
@@ -2586,6 +2597,11 @@ func resolveRelativePaths(configPath string, cfg *Config) {
 	}
 	for _, entry := range cfg.Providers.Workflow {
 		resolveEntry(entry)
+	}
+	for _, entry := range cfg.Runtime.Providers {
+		if entry != nil {
+			resolveEntry(&entry.ProviderEntry)
+		}
 	}
 	for _, entry := range cfg.Plugins {
 		resolveEntry(entry)

--- a/gestaltd/internal/config/config_test.go
+++ b/gestaltd/internal/config/config_test.go
@@ -163,10 +163,12 @@ plugins:
 	entry := cfg.Plugins["signed"]
 	if entry == nil {
 		t.Fatal("Plugins[signed] = nil")
+		return
 	}
 	scheme := entry.SecuritySchemes["signed"]
 	if scheme == nil || scheme.Type != providermanifestv1.HTTPSecuritySchemeTypeHMAC {
 		t.Fatalf("SecuritySchemes[signed] = %#v", entry.SecuritySchemes["signed"])
+		return
 	}
 	if got, want := scheme.SignatureHeader, "X-Request-Signature"; got != want {
 		t.Fatalf("SecuritySchemes[signed].SignatureHeader = %q, want %q", got, want)
@@ -229,6 +231,7 @@ func TestProviderEntryEffectiveHTTPSecuritySchemes_MergesHMACFields(t *testing.T
 	scheme := effective["signed"]
 	if scheme == nil {
 		t.Fatal("EffectiveHTTPSecuritySchemes()[signed] = nil")
+		return
 	}
 	if got, want := scheme.SignatureHeader, "X-Request-Signature"; got != want {
 		t.Fatalf("SignatureHeader = %q, want %q", got, want)
@@ -451,10 +454,11 @@ plugins:
 		t.Fatalf("Server.Public.Port = %d, want 8080", cfg.Server.Public.Port)
 	}
 	_, secrets := mustSelectedProvider(t, cfg, HostProviderKindSecrets)
-	if secrets == nil || secrets.Source.Builtin != "env" {
-		if secrets == nil {
-			t.Fatal("SelectedSecretsProvider = nil, want env builtin")
-		}
+	if secrets == nil {
+		t.Fatal("SelectedSecretsProvider = nil, want env builtin")
+		return
+	}
+	if secrets.Source.Builtin != "env" {
 		t.Fatalf("Secrets.Source.Builtin = %q, want env", secrets.Source.Builtin)
 	}
 	if cfg.Server.EncryptionKey != "encryption-from-env" {

--- a/gestaltd/internal/operator/lifecycle.go
+++ b/gestaltd/internal/operator/lifecycle.go
@@ -299,6 +299,11 @@ func buildSourceTokenMap(cfg *config.Config) map[string]string {
 	for _, entry := range cfg.Plugins {
 		addEntry(entry)
 	}
+	for _, entry := range cfg.Runtime.Providers {
+		if entry != nil {
+			addEntry(&entry.ProviderEntry)
+		}
+	}
 	for _, collection := range hostProviderCollections(cfg) {
 		for _, entry := range collection.entries {
 			addEntry(entry)

--- a/gestaltd/internal/operator/release_metadata.go
+++ b/gestaltd/internal/operator/release_metadata.go
@@ -104,7 +104,7 @@ func validateProviderReleaseMetadata(metadata *providerReleaseMetadata) error {
 		return fmt.Errorf("provider release version: %w", err)
 	}
 	switch metadata.Kind {
-	case providermanifestv1.KindPlugin, providermanifestv1.KindAuthentication, providermanifestv1.KindAuthorization, providermanifestv1.KindIndexedDB, providermanifestv1.KindCache, providermanifestv1.KindS3, providermanifestv1.KindWorkflow, providermanifestv1.KindSecrets, providermanifestv1.KindUI:
+	case providermanifestv1.KindPlugin, providermanifestv1.KindAuthentication, providermanifestv1.KindAuthorization, providermanifestv1.KindIndexedDB, providermanifestv1.KindCache, providermanifestv1.KindS3, providermanifestv1.KindWorkflow, providermanifestv1.KindSecrets, providermanifestv1.KindRuntime, providermanifestv1.KindUI:
 	default:
 		return fmt.Errorf("provider release kind %q is not supported", metadata.Kind)
 	}


### PR DESCRIPTION
## Summary
This teaches `gestaltd` to treat `runtime.providers.*` like the other provider kinds when a local `apiVersion: gestaltd.config/v4` config points at `provider-release.yaml` metadata.

## New Interfaces
- `apiVersion: gestaltd.config/v4`
- `runtime.providers.<name>.source: ./dist/provider-release.yaml`
- `runtime.providers.<name>.source.path: ./dist/provider-release.yaml`
- runtime provider release metadata now accepts `kind: runtime`
- runtime provider release sources now participate in source-auth token propagation for `init --platform ...`

## Examples
```yaml
apiVersion: gestaltd.config/v4
runtime:
  providers:
    modal:
      source: ./dist/provider-release.yaml
      config:
        app: gestalt-runtime
        environment: main
```

```yaml
apiVersion: gestaltd.config/v4
runtime:
  providers:
    modal:
      source:
        githubRelease:
          repo: valon-technologies/gestalt-providers
          tag: runtime/modal/v0.0.1-alpha.1
          asset: provider-release.yaml
```

## What Changed
- normalize and resolve relative runtime-provider source paths in the same passes used for plugins and host providers
- allow `kind: runtime` in provider-release metadata validation
- include `runtime.providers.*` in the source-auth token map used during release hashing/download flows

## Validation
- `go test ./internal/config ./internal/operator -count=1`
- `/tmp/gestaltd-agent-fixed validate --config /Users/hugh/src/toolshed/valon-tools/.worktrees/agent-modal-provider/valon-tools/deploy/agent/config.standalone.modal.example.yaml`
