### PR TITLE
[codex] Prefer named default connection fallback

### DIFF
--- a/gestaltd/internal/config/connection_plan.go
+++ b/gestaltd/internal/config/connection_plan.go
@@ -210,6 +210,9 @@ func (plan StaticConnectionPlan) fallbackConnection() string {
 	if plan.defaultConnection != "" {
 		return plan.defaultConnection
 	}
+	if _, ok := plan.namedConnections["default"]; ok {
+		return "default"
+	}
 	if len(plan.namedConnections) == 0 {
 		return PluginConnectionName
 	}
@@ -227,6 +230,9 @@ func (plan StaticConnectionPlan) resolveSurfaceConnectionName(raw string) string
 	}
 	if plan.defaultConnection != "" {
 		return plan.defaultConnection
+	}
+	if _, ok := plan.namedConnections["default"]; ok {
+		return "default"
 	}
 	if len(plan.namedConnections) == 1 {
 		for name := range plan.namedConnections {

--- a/gestaltd/internal/config/connection_plan_test.go
+++ b/gestaltd/internal/config/connection_plan_test.go
@@ -1,0 +1,36 @@
+package config
+
+import (
+	"testing"
+
+	providermanifestv1 "github.com/valon-technologies/gestalt/server/sdk/providermanifest/v1"
+)
+
+func TestBuildStaticConnectionPlan_PrefersNamedDefaultConnection(t *testing.T) {
+	t.Parallel()
+
+	plan, err := BuildStaticConnectionPlan(&ProviderEntry{}, &providermanifestv1.Spec{
+		Connections: map[string]*providermanifestv1.ManifestConnectionDef{
+			"default": {Mode: providermanifestv1.ConnectionModeUser},
+			"bot":     {Mode: providermanifestv1.ConnectionModeUser},
+		},
+		Surfaces: &providermanifestv1.ProviderSurfaces{
+			REST: &providermanifestv1.RESTSurface{
+				BaseURL: "https://slack.com",
+			},
+		},
+	})
+	if err != nil {
+		t.Fatalf("BuildStaticConnectionPlan() error = %v", err)
+	}
+
+	if got := plan.AuthDefaultConnection(); got != "default" {
+		t.Fatalf("AuthDefaultConnection() = %q, want %q", got, "default")
+	}
+	if got := plan.APIConnection(); got != "default" {
+		t.Fatalf("APIConnection() = %q, want %q", got, "default")
+	}
+	if got := plan.MCPConnection(); got != "default" {
+		t.Fatalf("MCPConnection() = %q, want %q", got, "default")
+	}
+}


### PR DESCRIPTION
## What changed
When a plugin has multiple named connections and one of them is literally named `default`, Gestalt now prefers that named connection as the implicit fallback before falling back to the internal plugin connection.

This also adds a regression test covering the Slack-shaped case:
- multiple named user connections
- no explicit `defaultConnection`
- REST surface without an explicit connection

## Root cause
Slack was reported as connected in `/api/v1/integrations`, but unnamed invokes like `GET /api/v1/slack/conversations.list` still failed with `not_connected`.

The connection planning logic treated the plugin as having multiple named connections with no explicit default, so the implicit fallback resolved to the internal plugin connection instead of the user-owned `default` connection. User tokens were stored on `default` and `bot`, not on the plugin connection, so invocation failed before any upstream Slack call was attempted.

## Impact
This fixes unnamed invokes for Slack-like providers that expose multiple named user connections and rely on the conventional `default` connection name.

## Validation
- `go test ./internal/config -run 'TestBuildStaticConnectionPlan_PrefersNamedDefaultConnection|TestProviderSurfaceURLOverride|TestEffectiveProviderSpecBaseURL'`
- Reproduced the prod behavior before the change:
  - `/api/v1/integrations` showed Slack connected
  - `/api/v1/slack/conversations.list` returned `not_connected`
  - `/api/v1/slack/conversations.list?_connection=default` succeeded