### PR TITLE
[codex] gestaltd: sanitize MCP tool names

### DIFF
--- a/gestaltd/internal/mcp/authorization.go
+++ b/gestaltd/internal/mcp/authorization.go
@@ -27,6 +27,10 @@ func allowOperation(ctx context.Context, cfg Config, p *principal.Principal, pro
 }
 
 func toolTarget(cfg Config, providers []string, name string) (provider, operation string, ok bool) {
+	if ref, ok := cfg.ToolTargets.Lookup(name); ok {
+		return ref.provider, ref.operation, true
+	}
+
 	provider = providerNameForTool(cfg.ToolPrefixes, providers, name)
 	if provider == "" {
 		return "", "", false

--- a/gestaltd/internal/mcp/binding.go
+++ b/gestaltd/internal/mcp/binding.go
@@ -27,11 +27,15 @@ type Config struct {
 	Authorizer       authorization.RuntimeAuthorizer
 	AllowedProviders []string
 	ToolPrefixes     map[string]string
+	ToolTargets      *toolTargetIndex
 	IncludeREST      map[string]bool
 	MCPConnection    map[string]string
 }
 
 func NewServer(cfg Config) *mcpserver.MCPServer {
+	if cfg.ToolTargets == nil {
+		cfg.ToolTargets = newToolTargetIndex()
+	}
 	hooks := &mcpserver.Hooks{}
 	srv := mcpserver.NewMCPServer(
 		serverName,

--- a/gestaltd/internal/mcp/binding_test.go
+++ b/gestaltd/internal/mcp/binding_test.go
@@ -417,6 +417,50 @@ func TestNewServer_ToolNameConvention(t *testing.T) {
 	}
 }
 
+func TestNewServer_SanitizesInvalidToolNamesAndRoutesOriginalOperation(t *testing.T) {
+	t.Parallel()
+
+	var invokedOp string
+
+	prov := newCatalogBackedProvider(
+		coretesting.StubIntegration{
+			N: "github",
+			ExecuteFn: func(_ context.Context, op string, _ map[string]any, _ string) (*core.OperationResult, error) {
+				invokedOp = op
+				return &core.OperationResult{Status: http.StatusOK, Body: `{"ok":true}`}, nil
+			},
+		},
+		[]core.Operation{{Name: "github_actions/cancel-workflow-run.v1", Method: http.MethodPost}},
+	)
+
+	providers := testutil.NewProviderRegistry(t, prov)
+	ds, userID := stubServicesWithToken(t, "github")
+	broker := invocation.NewBroker(providers, ds.Users, ds.Tokens)
+
+	srv := gestaltmcp.NewServer(gestaltmcp.Config{
+		Invoker:       broker,
+		TokenResolver: broker,
+		Providers:     providers,
+	})
+
+	session := newTestSessionWithTools()
+	tools := listToolsForSession(t, srv, ctxWithPrincipal(userID), session)
+	if len(tools.Tools) != 1 {
+		t.Fatalf("expected 1 tool, got %d", len(tools.Tools))
+	}
+	if got := tools.Tools[0].Name; got != "github_github_actions_cancel-workflow-run_v1" {
+		t.Fatalf("sanitized tool name = %q", got)
+	}
+
+	result := callToolForSession(t, srv, ctxWithPrincipal(userID), session, "github_github_actions_cancel-workflow-run_v1", nil)
+	if result.IsError {
+		t.Fatalf("expected tool call to succeed, got error result: %v", result.Content)
+	}
+	if invokedOp != "github_actions/cancel-workflow-run.v1" {
+		t.Fatalf("invoked operation = %q", invokedOp)
+	}
+}
+
 func TestNewServer_ToolCallRoutesThrough(t *testing.T) {
 	t.Parallel()
 

--- a/gestaltd/internal/mcp/projection.go
+++ b/gestaltd/internal/mcp/projection.go
@@ -25,6 +25,9 @@ func buildToolMap(cfg Config, provName string, cat *catalog.Catalog) map[string]
 		}
 
 		name := toolName(cfg.ToolPrefixes, provName, op.ID)
+		if cfg.ToolTargets != nil {
+			cfg.ToolTargets.Store(name, provName, op.ID)
+		}
 
 		var tool mcpgo.Tool
 		if len(op.InputSchema) > 0 {
@@ -78,7 +81,21 @@ func providerNameForTool(prefixes map[string]string, providers []string, tool st
 }
 
 func toolName(prefixes map[string]string, provider, operation string) string {
-	return prefixes[provider] + provider + toolNameSep + operation
+	raw := prefixes[provider] + provider + toolNameSep + operation
+	return strings.Map(func(r rune) rune {
+		switch {
+		case r >= 'a' && r <= 'z':
+			return r
+		case r >= 'A' && r <= 'Z':
+			return r
+		case r >= '0' && r <= '9':
+			return r
+		case r == '_' || r == '-' || r == ':':
+			return r
+		default:
+			return '_'
+		}
+	}, raw)
 }
 
 func mapAnnotations(a catalog.OperationAnnotations) mcpgo.ToolAnnotation {

--- a/gestaltd/internal/mcp/tool_targets.go
+++ b/gestaltd/internal/mcp/tool_targets.go
@@ -1,0 +1,36 @@
+package mcp
+
+import "sync"
+
+type toolTargetRef struct {
+	provider  string
+	operation string
+}
+
+type toolTargetIndex struct {
+	mu   sync.RWMutex
+	refs map[string]toolTargetRef
+}
+
+func newToolTargetIndex() *toolTargetIndex {
+	return &toolTargetIndex{refs: map[string]toolTargetRef{}}
+}
+
+func (i *toolTargetIndex) Store(toolName, provider, operation string) {
+	if i == nil || toolName == "" || provider == "" || operation == "" {
+		return
+	}
+	i.mu.Lock()
+	defer i.mu.Unlock()
+	i.refs[toolName] = toolTargetRef{provider: provider, operation: operation}
+}
+
+func (i *toolTargetIndex) Lookup(toolName string) (toolTargetRef, bool) {
+	if i == nil || toolName == "" {
+		return toolTargetRef{}, false
+	}
+	i.mu.RLock()
+	defer i.mu.RUnlock()
+	ref, ok := i.refs[toolName]
+	return ref, ok
+}


### PR DESCRIPTION
## Summary
- sanitize exported MCP tool names so they only use characters allowed by Claude-style MCP clients
- preserve a server-side mapping back to the original provider operation IDs when a tool call comes in
- add regression coverage for invalid operation IDs like `github_actions/cancel-workflow-run.v1`

## Why
The live `tools/list` catalog on `valon.tools` was returning tools, but many names still contained `/` and `.` from provider operation IDs. Claude Code authenticated successfully and fetched the catalog, then effectively dropped it and showed no tools. This change keeps the visible MCP surface client-safe without changing the underlying provider operation IDs.

## Testing
- `go test ./internal/mcp -run 'TestNewServer_(SanitizesInvalidToolNamesAndRoutesOriginalOperation|ToolNameConvention|ToolCallRoutesThrough)'`
- `go test ./internal/server -run 'TestMCPEndpoint_(InitializeAndListTools|MCPPassthroughSessionCatalogAndAudit)'`
