### PR TITLE
runtime: relay authorization host service for hosted providers

### DIFF
--- a/gestaltd/internal/bootstrap/executable_plugin_test.go
+++ b/gestaltd/internal/bootstrap/executable_plugin_test.go
@@ -55,6 +55,7 @@ import (
 	"google.golang.org/grpc/codes"
 	"google.golang.org/grpc/credentials"
 	"google.golang.org/grpc/metadata"
+	"google.golang.org/protobuf/types/known/emptypb"
 	"gopkg.in/yaml.v3"
 )
 
@@ -139,6 +140,53 @@ func (p *hostedHTTPAuthorizationProvider) ListModels(context.Context, *core.List
 
 func (p *hostedHTTPAuthorizationProvider) WriteModel(context.Context, *core.WriteModelRequest) (*core.AuthorizationModelRef, error) {
 	return &core.AuthorizationModelRef{}, nil
+}
+
+type authorizationSearchCall struct {
+	SubjectType  string
+	ResourceType string
+	ResourceID   string
+	ActionName   string
+	PageSize     int32
+}
+
+type recordingHostedAuthorizationProvider struct {
+	hostedHTTPAuthorizationProvider
+
+	mu          sync.Mutex
+	searchCalls []authorizationSearchCall
+}
+
+func (p *recordingHostedAuthorizationProvider) SearchSubjects(_ context.Context, req *core.SubjectSearchRequest) (*core.SubjectSearchResponse, error) {
+	call := authorizationSearchCall{
+		SubjectType: req.GetSubjectType(),
+		PageSize:    req.GetPageSize(),
+	}
+	if resource := req.GetResource(); resource != nil {
+		call.ResourceType = resource.GetType()
+		call.ResourceID = resource.GetId()
+	}
+	if action := req.GetAction(); action != nil {
+		call.ActionName = action.GetName()
+	}
+
+	p.mu.Lock()
+	p.searchCalls = append(p.searchCalls, call)
+	p.mu.Unlock()
+
+	return &core.SubjectSearchResponse{
+		Subjects: []*core.SubjectRef{{
+			Type: "user",
+			Id:   "user:user-123",
+		}},
+		ModelId: "authz-model-1",
+	}, nil
+}
+
+func (p *recordingHostedAuthorizationProvider) Calls() []authorizationSearchCall {
+	p.mu.Lock()
+	defer p.mu.Unlock()
+	return slices.Clone(p.searchCalls)
 }
 
 type capturingPluginRuntime struct {
@@ -412,6 +460,10 @@ func (r *capturingBundlePluginRuntime) startFakeHostedPlugin(req pluginruntime.S
 					ID:     "workflow_manager_roundtrip",
 					Method: http.MethodPost,
 				},
+				{
+					ID:     "authorization_roundtrip",
+					Method: http.MethodPost,
+				},
 			},
 		},
 		ExecuteFn: func(ctx context.Context, operation string, params map[string]any, _ string) (*core.OperationResult, error) {
@@ -487,6 +539,16 @@ func (r *capturingBundlePluginRuntime) startFakeHostedPlugin(req pluginruntime.S
 				return &core.OperationResult{Status: http.StatusOK, Body: string(body)}, nil
 			case "workflow_manager_roundtrip":
 				record, err := fakeHostedWorkflowManagerRoundTrip(providerhost.InvocationTokenFromContext(ctx), env)
+				if err != nil {
+					return nil, err
+				}
+				body, err := json.Marshal(record)
+				if err != nil {
+					return nil, err
+				}
+				return &core.OperationResult{Status: http.StatusOK, Body: string(body)}, nil
+			case "authorization_roundtrip":
+				record, err := fakeHostedAuthorizationRoundTrip(env)
 				if err != nil {
 					return nil, err
 				}
@@ -825,6 +887,66 @@ func fakeHostedWorkflowManagerRoundTrip(invocationToken string, env map[string]s
 		"schedule_id":   scheduleID,
 		"cron":          fetched.GetSchedule().GetCron(),
 		"operation":     fetched.GetSchedule().GetTarget().GetOperation(),
+	}, nil
+}
+
+func fakeHostedAuthorizationRoundTrip(env map[string]string) (map[string]any, error) {
+	target := strings.TrimSpace(env[providerhost.DefaultAuthorizationSocketEnv])
+	if target == "" {
+		return nil, fmt.Errorf("missing authorization relay target in %s", providerhost.DefaultAuthorizationSocketEnv)
+	}
+	token := strings.TrimSpace(env[providerhost.AuthorizationSocketTokenEnv()])
+	if token == "" {
+		return nil, fmt.Errorf("missing authorization relay token in %s", providerhost.AuthorizationSocketTokenEnv())
+	}
+	address := strings.TrimSpace(strings.TrimPrefix(target, "tls://"))
+	if address == "" || address == target {
+		return nil, fmt.Errorf("unsupported authorization relay target %q", target)
+	}
+
+	conn, err := grpc.NewClient(
+		address,
+		grpc.WithTransportCredentials(credentials.NewTLS(&tls.Config{
+			InsecureSkipVerify: true,
+			MinVersion:         tls.VersionTLS12,
+			NextProtos:         []string{"h2"},
+		})),
+	)
+	if err != nil {
+		return nil, fmt.Errorf("connect authorization relay: %w", err)
+	}
+	defer func() { _ = conn.Close() }()
+
+	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	defer cancel()
+	ctx = metadata.NewOutgoingContext(ctx, metadata.Pairs(providerhost.HostServiceRelayTokenHeader, token))
+
+	client := proto.NewAuthorizationProviderClient(conn)
+	meta, err := client.GetMetadata(ctx, &emptypb.Empty{})
+	if err != nil {
+		return nil, fmt.Errorf("get authorization metadata: %w", err)
+	}
+	resp, err := client.SearchSubjects(ctx, &proto.SubjectSearchRequest{
+		SubjectType: "user",
+		Resource: &proto.Resource{
+			Type: "slack_identity",
+			Id:   "team:T123:user:U456",
+		},
+		Action:   &proto.Action{Name: "assume"},
+		PageSize: 1,
+	})
+	if err != nil {
+		return nil, fmt.Errorf("search authorization subjects: %w", err)
+	}
+	if len(resp.GetSubjects()) == 0 {
+		return nil, fmt.Errorf("authorization search did not return any subjects")
+	}
+
+	return map[string]any{
+		"model_id":     resp.GetModelId(),
+		"subject_id":   resp.GetSubjects()[0].GetId(),
+		"subject_type": resp.GetSubjects()[0].GetType(),
+		"capabilities": meta.GetCapabilities(),
 	}, nil
 }
 
@@ -4955,7 +5077,7 @@ func TestPluginRuntimeConfigUsesPublicS3RelayWithoutHostServiceTunnelCapability(
 	}
 }
 
-func TestPluginRuntimeHostedHTTPDoesNotRequireHostServiceTunnelCapabilityForAuthorizationLookup(t *testing.T) {
+func TestPluginRuntimeConfigUsesPublicAuthorizationRelayWithoutHostServiceTunnelCapability(t *testing.T) {
 	t.Parallel()
 
 	bin := buildEchoPluginBinary(t)
@@ -5014,6 +5136,8 @@ func TestPluginRuntimeHostedHTTPDoesNotRequireHostServiceTunnelCapabilityForAuth
 
 	runtimeProvider := newCapturingBundlePluginRuntime()
 	runtimeProvider.capabilities.HostnameProxyEgress = true
+	runtimeProvider.capabilities.HostPathExecution = true
+	runtimeProvider.fakeHosted = true
 	factories := NewFactoryRegistry()
 	factories.Runtime = func(context.Context, string, *config.RuntimeProviderEntry, Deps) (pluginruntime.Provider, error) {
 		return runtimeProvider, nil
@@ -5040,34 +5164,67 @@ func TestPluginRuntimeHostedHTTPDoesNotRequireHostServiceTunnelCapabilityForAuth
 		},
 	}
 
-	providers, _, err := buildProvidersStrict(context.Background(), cfg, factories, Deps{
+	deps := Deps{
+		BaseURL:               "https://gestalt.example.test",
+		EncryptionKey:         []byte("0123456789abcdef0123456789abcdef"),
 		AuthorizationProvider: &hostedHTTPAuthorizationProvider{},
-		PluginRuntimeRegistry: newPluginRuntimeRegistry(cfg, factories.Runtime, Deps{}),
-	})
+	}
+	deps.PluginRuntimeRegistry = newPluginRuntimeRegistry(cfg, factories.Runtime, deps)
+
+	providers, _, err := buildProvidersStrict(context.Background(), cfg, factories, deps)
 	if err != nil {
 		t.Fatalf("buildProvidersStrict: %v", err)
 	}
-	defer func() { _ = CloseProviders(providers) }()
+	t.Cleanup(func() { _ = CloseProviders(providers) })
 
 	prov, err := providers.Get("echoext")
 	if err != nil {
 		t.Fatalf("providers.Get(echoext): %v", err)
 	}
 
-	result, err := prov.Execute(context.Background(), "read_env", map[string]any{"name": providerhost.DefaultAuthorizationSocketEnv}, "")
-	if err != nil {
-		t.Fatalf("Execute read_env: %v", err)
+	checkEnv := func(envName string) (string, bool) {
+		t.Helper()
+		result, err := prov.Execute(context.Background(), "read_env", map[string]any{"name": envName}, "")
+		if err != nil {
+			t.Fatalf("Execute read_env(%s): %v", envName, err)
+		}
+		var env struct {
+			Value string `json:"value"`
+			Found bool   `json:"found"`
+		}
+		if err := json.Unmarshal([]byte(result.Body), &env); err != nil {
+			t.Fatalf("json.Unmarshal(%s): %v", envName, err)
+		}
+		return env.Value, env.Found
 	}
 
-	var env struct {
-		Value string `json:"value"`
-		Found bool   `json:"found"`
+	if got, found := checkEnv(providerhost.DefaultAuthorizationSocketEnv); !found || got != "tls://gestalt.example.test:443" {
+		t.Fatalf("plugin authorization env %s = (%q, %v), want (%q, true)", providerhost.DefaultAuthorizationSocketEnv, got, found, "tls://gestalt.example.test:443")
 	}
-	if err := json.Unmarshal([]byte(result.Body), &env); err != nil {
-		t.Fatalf("json.Unmarshal: %v", err)
+	if got, found := checkEnv(providerhost.AuthorizationSocketTokenEnv()); !found || got == "" {
+		t.Fatalf("plugin authorization token env %s = (%q, %v), want non-empty token", providerhost.AuthorizationSocketTokenEnv(), got, found)
 	}
-	if env.Found || env.Value != "" {
-		t.Fatalf("authorization env %q should not be set when the runtime lacks host service tunnels", providerhost.DefaultAuthorizationSocketEnv)
+
+	bindRequests := runtimeProvider.bindHostServiceRequests()
+	if len(bindRequests) != 1 {
+		t.Fatalf("BindHostService requests = %d, want 1", len(bindRequests))
+	}
+	if bindRequests[0].EnvVar != providerhost.DefaultAuthorizationSocketEnv {
+		t.Fatalf("BindHostService env = %q, want %q", bindRequests[0].EnvVar, providerhost.DefaultAuthorizationSocketEnv)
+	}
+	if got := bindRequests[0].Relay.DialTarget; got != "tls://gestalt.example.test:443" {
+		t.Fatalf("BindHostService(%s) relay target = %q, want %q", bindRequests[0].EnvVar, got, "tls://gestalt.example.test:443")
+	}
+
+	startRequests := runtimeProvider.startPluginRequestsCopy()
+	if len(startRequests) != 1 {
+		t.Fatalf("StartPlugin requests = %d, want 1", len(startRequests))
+	}
+	if got := startRequests[0].Env[providerhost.AuthorizationSocketTokenEnv()]; got == "" {
+		t.Fatal("StartPlugin env should include the authorization relay token")
+	}
+	if !slices.Contains(startRequests[0].AllowedHosts, "gestalt.example.test") {
+		t.Fatalf("StartPlugin allowed hosts = %#v, want relay host gestalt.example.test", startRequests[0].AllowedHosts)
 	}
 }
 
@@ -6237,6 +6394,150 @@ func TestPluginRuntimePublicWorkflowManagerRelayRoundTripsThroughHostedPlugin(t 
 	}
 	if got := startRequests[0].Env[providerhost.WorkflowManagerSocketTokenEnv()]; got == "" {
 		t.Fatal("StartPlugin env should include the workflow manager relay token")
+	}
+	bindRequests := runtimeProvider.bindHostServiceRequests()
+	if len(bindRequests) != 1 {
+		t.Fatalf("BindHostService requests = %d, want 1", len(bindRequests))
+	}
+	if got := bindRequests[0].Relay.DialTarget; !strings.HasPrefix(got, "tls://") {
+		t.Fatalf("BindHostService(%s) relay target = %q, want tls relay target", bindRequests[0].EnvVar, got)
+	}
+}
+
+func TestPluginRuntimePublicAuthorizationRelayRoundTripsThroughHostedPlugin(t *testing.T) {
+	t.Parallel()
+
+	secret := []byte("0123456789abcdef0123456789abcdef")
+	relaySrv := httptest.NewUnstartedServer(newRuntimeRelayTestHandler(t, secret))
+	relaySrv.EnableHTTP2 = true
+	relaySrv.StartTLS()
+	testutil.CloseOnCleanup(t, relaySrv)
+
+	bin := buildEchoPluginBinary(t)
+	manifestRoot := writeStaticCatalog(t, &catalog.Catalog{
+		Name: "echoext",
+		Operations: []catalog.CatalogOperation{
+			{ID: "authorization_roundtrip", Method: http.MethodPost},
+		},
+	})
+	manifest := newExecutableManifest("Echo", "Authorization relay roundtrip")
+	manifest.Spec.SecuritySchemes = map[string]*providermanifestv1.HTTPSecurityScheme{
+		"public": {
+			Type: providermanifestv1.HTTPSecuritySchemeTypeNone,
+		},
+	}
+	manifest.Spec.HTTP = map[string]*providermanifestv1.HTTPBinding{
+		"command": {
+			Path:     "/command",
+			Method:   http.MethodPost,
+			Security: "public",
+			Target:   "authorization_roundtrip",
+			RequestBody: &providermanifestv1.HTTPRequestBody{
+				Content: map[string]*providermanifestv1.HTTPMediaType{
+					"application/x-www-form-urlencoded": {},
+				},
+			},
+		},
+	}
+	runtimeProvider := newCapturingBundlePluginRuntime()
+	runtimeProvider.capabilities.HostnameProxyEgress = true
+	runtimeProvider.capabilities.HostPathExecution = true
+	runtimeProvider.fakeHosted = true
+	factories := NewFactoryRegistry()
+	factories.Runtime = func(context.Context, string, *config.RuntimeProviderEntry, Deps) (pluginruntime.Provider, error) {
+		return runtimeProvider, nil
+	}
+	cfg := &config.Config{
+		Server: config.ServerConfig{
+			Runtime: config.ServerRuntimeConfig{Provider: "hosted"},
+		},
+		Runtime: config.RuntimeConfig{
+			Providers: map[string]*config.RuntimeProviderEntry{
+				"hosted": {
+					Driver: config.RuntimeProviderDriver("capture"),
+				},
+			},
+		},
+		Plugins: map[string]*config.ProviderEntry{
+			"echoext": {
+				Command:              bin,
+				Args:                 []string{"provider"},
+				ResolvedManifest:     manifest,
+				ResolvedManifestPath: filepath.Join(manifestRoot, "manifest.yaml"),
+				Runtime:              &config.PluginRuntimeConfig{},
+			},
+		},
+	}
+
+	authz := &recordingHostedAuthorizationProvider{}
+	deps := Deps{
+		BaseURL:               relaySrv.URL,
+		EncryptionKey:         secret,
+		AuthorizationProvider: authz,
+	}
+	deps.PluginRuntimeRegistry = newPluginRuntimeRegistry(cfg, factories.Runtime, deps)
+
+	providers, _, err := buildProvidersStrict(context.Background(), cfg, factories, deps)
+	if err != nil {
+		t.Fatalf("buildProvidersStrict: %v", err)
+	}
+	t.Cleanup(func() { _ = CloseProviders(providers) })
+
+	prov, err := providers.Get("echoext")
+	if err != nil {
+		t.Fatalf("providers.Get: %v", err)
+	}
+
+	result, err := prov.Execute(context.Background(), "authorization_roundtrip", nil, "")
+	if err != nil {
+		t.Fatalf("Execute authorization_roundtrip: %v", err)
+	}
+
+	var body struct {
+		ModelID      string   `json:"model_id"`
+		SubjectID    string   `json:"subject_id"`
+		SubjectType  string   `json:"subject_type"`
+		Capabilities []string `json:"capabilities"`
+	}
+	if err := json.Unmarshal([]byte(result.Body), &body); err != nil {
+		t.Fatalf("unmarshal authorization_roundtrip: %v", err)
+	}
+	if body.ModelID != "authz-model-1" {
+		t.Fatalf("model_id = %q, want %q", body.ModelID, "authz-model-1")
+	}
+	if body.SubjectID != "user:user-123" {
+		t.Fatalf("subject_id = %q, want %q", body.SubjectID, "user:user-123")
+	}
+	if body.SubjectType != "user" {
+		t.Fatalf("subject_type = %q, want %q", body.SubjectType, "user")
+	}
+	if !slices.Equal(body.Capabilities, []string{"search_subjects"}) {
+		t.Fatalf("capabilities = %#v, want [search_subjects]", body.Capabilities)
+	}
+
+	if got := authz.Calls(); len(got) != 1 {
+		t.Fatalf("authorization search calls = %d, want 1", len(got))
+	} else {
+		if got[0].SubjectType != "user" {
+			t.Fatalf("subject type = %q, want %q", got[0].SubjectType, "user")
+		}
+		if got[0].ResourceType != "slack_identity" || got[0].ResourceID != "team:T123:user:U456" {
+			t.Fatalf("resource = (%q, %q), want (%q, %q)", got[0].ResourceType, got[0].ResourceID, "slack_identity", "team:T123:user:U456")
+		}
+		if got[0].ActionName != "assume" {
+			t.Fatalf("action name = %q, want %q", got[0].ActionName, "assume")
+		}
+		if got[0].PageSize != 1 {
+			t.Fatalf("page size = %d, want 1", got[0].PageSize)
+		}
+	}
+
+	startRequests := runtimeProvider.startPluginRequestsCopy()
+	if len(startRequests) != 1 {
+		t.Fatalf("StartPlugin requests = %d, want 1", len(startRequests))
+	}
+	if got := startRequests[0].Env[providerhost.AuthorizationSocketTokenEnv()]; got == "" {
+		t.Fatal("StartPlugin env should include the authorization relay token")
 	}
 	bindRequests := runtimeProvider.bindHostServiceRequests()
 	if len(bindRequests) != 1 {

--- a/gestaltd/internal/bootstrap/provider_build.go
+++ b/gestaltd/internal/bootstrap/provider_build.go
@@ -1124,14 +1124,14 @@ func buildPluginRuntimeHostServices(name string, entry *config.ProviderEntry, de
 	if includeWorkflowManager {
 		hostServices = append(hostServices, buildPluginWorkflowManagerHostService(name, deps, invTokens))
 	}
+	if deps.AuthorizationProvider != nil && len(entry.EffectiveHTTPBindings()) > 0 {
+		hostServices = append(hostServices, buildPluginAuthorizationHostService(deps.AuthorizationProvider))
+	}
 	if !includeHostServices {
 		if len(entry.Invokes) > 0 {
 			hostServices = append(hostServices, buildPluginInvokerHostService(name, entry, deps, invTokens))
 		}
 		return hostServices, invTokens, cleanup, nil
-	}
-	if deps.AuthorizationProvider != nil && len(entry.EffectiveHTTPBindings()) > 0 {
-		hostServices = append(hostServices, buildPluginAuthorizationHostService(deps.AuthorizationProvider))
 	}
 	if len(entry.Invokes) > 0 {
 		hostServices = append(hostServices, buildPluginInvokerHostService(name, entry, deps, invTokens))
@@ -1163,6 +1163,10 @@ func buildPluginRuntimeHostServiceBinding(pluginName, sessionID string, hostServ
 			serviceKey = "workflow_manager"
 			serviceLabel = "workflow manager"
 			methodPrefix = "/" + proto.WorkflowManagerHost_ServiceDesc.ServiceName + "/"
+		case hostService.EnvVar == providerhost.DefaultAuthorizationSocketEnv:
+			serviceKey = "authorization"
+			serviceLabel = "authorization"
+			methodPrefix = "/" + proto.AuthorizationProvider_ServiceDesc.ServiceName + "/"
 		case hostService.EnvVar == providerhost.DefaultPluginInvokerSocketEnv:
 			serviceKey = "plugin_invoker"
 			serviceLabel = "plugin invoker"

--- a/gestaltd/internal/providerhost/authorization_server.go
+++ b/gestaltd/internal/providerhost/authorization_server.go
@@ -12,6 +12,10 @@ import (
 
 const DefaultAuthorizationSocketEnv = "GESTALT_AUTHORIZATION_SOCKET"
 
+func AuthorizationSocketTokenEnv() string {
+	return DefaultAuthorizationSocketEnv + "_TOKEN"
+}
+
 type authorizationProviderServer struct {
 	proto.UnimplementedAuthorizationProviderServer
 	provider core.AuthorizationProvider

--- a/sdk/go/authorization_client.go
+++ b/sdk/go/authorization_client.go
@@ -2,59 +2,108 @@ package gestalt
 
 import (
 	"context"
+	"crypto/tls"
 	"fmt"
+	"net"
+	"net/url"
 	"os"
+	"path/filepath"
+	"strings"
 	"sync"
 	"time"
 
 	proto "github.com/valon-technologies/gestalt/sdk/go/gen/v1"
 	"google.golang.org/grpc"
+	"google.golang.org/grpc/credentials"
 	"google.golang.org/grpc/credentials/insecure"
 	"google.golang.org/protobuf/types/known/emptypb"
 )
 
 const EnvAuthorizationSocket = "GESTALT_AUTHORIZATION_SOCKET"
+const EnvAuthorizationSocketToken = EnvAuthorizationSocket + "_TOKEN"
 
 type AuthorizationClient struct {
 	client proto.AuthorizationProviderClient
 }
 
 var sharedAuthorizationTransport struct {
-	mu         sync.Mutex
-	socketPath string
-	conn       *grpc.ClientConn
-	client     proto.AuthorizationProviderClient
+	mu     sync.Mutex
+	target string
+	token  string
+	conn   *grpc.ClientConn
+	client proto.AuthorizationProviderClient
 }
 
 func Authorization() (*AuthorizationClient, error) {
-	socketPath := os.Getenv(EnvAuthorizationSocket)
-	if socketPath == "" {
+	target := os.Getenv(EnvAuthorizationSocket)
+	if target == "" {
 		return nil, fmt.Errorf("authorization: %s is not set", EnvAuthorizationSocket)
 	}
+	token := os.Getenv(EnvAuthorizationSocketToken)
 
 	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
 	defer cancel()
 
-	client, err := sharedAuthorizationClient(ctx, socketPath)
+	client, err := sharedAuthorizationClient(ctx, target, token)
 	if err != nil {
 		return nil, err
 	}
 	return &AuthorizationClient{client: client}, nil
 }
 
-func sharedAuthorizationClient(ctx context.Context, socketPath string) (proto.AuthorizationProviderClient, error) {
+func sharedAuthorizationClient(ctx context.Context, target, token string) (proto.AuthorizationProviderClient, error) {
 	sharedAuthorizationTransport.mu.Lock()
-	if sharedAuthorizationTransport.conn != nil && sharedAuthorizationTransport.socketPath == socketPath {
+	if sharedAuthorizationTransport.conn != nil && sharedAuthorizationTransport.target == target && sharedAuthorizationTransport.token == token {
 		client := sharedAuthorizationTransport.client
 		sharedAuthorizationTransport.mu.Unlock()
 		return client, nil
 	}
 	sharedAuthorizationTransport.mu.Unlock()
 
-	conn, err := grpc.DialContext(ctx, "unix:"+socketPath,
-		grpc.WithTransportCredentials(insecure.NewCredentials()),
-		grpc.WithBlock(),
-	)
+	network, address, err := parseAuthorizationTarget(target)
+	if err != nil {
+		return nil, err
+	}
+	opts := authorizationDialOptions(token)
+	var conn *grpc.ClientConn
+	switch network {
+	case "unix":
+		conn, err = grpc.DialContext(ctx, "passthrough:///localhost",
+			append([]grpc.DialOption{
+				grpc.WithTransportCredentials(insecure.NewCredentials()),
+				grpc.WithContextDialer(func(ctx context.Context, _ string) (net.Conn, error) {
+					var d net.Dialer
+					return d.DialContext(ctx, "unix", address)
+				}),
+				grpc.WithAuthority("localhost"),
+				grpc.WithBlock(),
+			}, opts...)...,
+		)
+	case "tcp":
+		conn, err = grpc.DialContext(ctx, address,
+			append([]grpc.DialOption{
+				grpc.WithTransportCredentials(insecure.NewCredentials()),
+				grpc.WithBlock(),
+			}, opts...)...,
+		)
+	case "tls":
+		host, _, splitErr := net.SplitHostPort(address)
+		if splitErr != nil {
+			return nil, fmt.Errorf("authorization: parse tls target %q: %w", address, splitErr)
+		}
+		conn, err = grpc.DialContext(ctx, address,
+			append([]grpc.DialOption{
+				grpc.WithTransportCredentials(credentials.NewTLS(&tls.Config{
+					MinVersion: tls.VersionTLS12,
+					ServerName: host,
+					NextProtos: []string{"h2"},
+				})),
+				grpc.WithBlock(),
+			}, opts...)...,
+		)
+	default:
+		return nil, fmt.Errorf("authorization: unsupported transport network %q", network)
+	}
 	if err != nil {
 		return nil, fmt.Errorf("authorization: connect to host: %w", err)
 	}
@@ -64,7 +113,7 @@ func sharedAuthorizationClient(ctx context.Context, socketPath string) (proto.Au
 	sharedAuthorizationTransport.mu.Lock()
 	defer sharedAuthorizationTransport.mu.Unlock()
 
-	if sharedAuthorizationTransport.conn != nil && sharedAuthorizationTransport.socketPath == socketPath {
+	if sharedAuthorizationTransport.conn != nil && sharedAuthorizationTransport.target == target && sharedAuthorizationTransport.token == token {
 		_ = conn.Close()
 		return sharedAuthorizationTransport.client, nil
 	}
@@ -72,10 +121,66 @@ func sharedAuthorizationClient(ctx context.Context, socketPath string) (proto.Au
 		_ = sharedAuthorizationTransport.conn.Close()
 	}
 
-	sharedAuthorizationTransport.socketPath = socketPath
+	sharedAuthorizationTransport.target = target
+	sharedAuthorizationTransport.token = token
 	sharedAuthorizationTransport.conn = conn
 	sharedAuthorizationTransport.client = client
 	return client, nil
+}
+
+func authorizationDialOptions(token string) []grpc.DialOption {
+	token = strings.TrimSpace(token)
+	if token == "" {
+		return nil
+	}
+	return []grpc.DialOption{grpc.WithPerRPCCredentials(authorizationRelayPerRPCCredentials{token: token})}
+}
+
+type authorizationRelayPerRPCCredentials struct {
+	token string
+}
+
+func (c authorizationRelayPerRPCCredentials) GetRequestMetadata(context.Context, ...string) (map[string]string, error) {
+	return map[string]string{
+		"x-gestalt-host-service-relay-token": c.token,
+	}, nil
+}
+
+func (authorizationRelayPerRPCCredentials) RequireTransportSecurity() bool { return false }
+
+func parseAuthorizationTarget(raw string) (network string, address string, err error) {
+	target := strings.TrimSpace(raw)
+	if target == "" {
+		return "", "", fmt.Errorf("authorization: transport target is required")
+	}
+	switch {
+	case strings.HasPrefix(target, "tcp://"):
+		address = strings.TrimSpace(strings.TrimPrefix(target, "tcp://"))
+		if address == "" {
+			return "", "", fmt.Errorf("authorization: tcp target %q is missing host:port", raw)
+		}
+		return "tcp", address, nil
+	case strings.HasPrefix(target, "tls://"):
+		address = strings.TrimSpace(strings.TrimPrefix(target, "tls://"))
+		if address == "" {
+			return "", "", fmt.Errorf("authorization: tls target %q is missing host:port", raw)
+		}
+		return "tls", address, nil
+	case strings.HasPrefix(target, "unix://"):
+		address = strings.TrimSpace(strings.TrimPrefix(target, "unix://"))
+		if address == "" {
+			return "", "", fmt.Errorf("authorization: unix target %q is missing a socket path", raw)
+		}
+		return "unix", address, nil
+	case strings.Contains(target, "://"):
+		parsed, parseErr := url.Parse(target)
+		if parseErr != nil {
+			return "", "", fmt.Errorf("authorization: parse target %q: %w", raw, parseErr)
+		}
+		return "", "", fmt.Errorf("authorization: unsupported target scheme %q", parsed.Scheme)
+	default:
+		return "unix", filepath.Clean(target), nil
+	}
 }
 
 func (c *AuthorizationClient) Close() error { return nil }

--- a/sdk/go/authorization_transport_test.go
+++ b/sdk/go/authorization_transport_test.go
@@ -1,0 +1,104 @@
+package gestalt_test
+
+import (
+	"context"
+	"net"
+	"sync"
+	"testing"
+
+	gestalt "github.com/valon-technologies/gestalt/sdk/go"
+	proto "github.com/valon-technologies/gestalt/sdk/go/gen/v1"
+	"google.golang.org/grpc"
+	"google.golang.org/grpc/metadata"
+	gproto "google.golang.org/protobuf/proto"
+)
+
+type authorizationTransportHarness struct {
+	proto.UnimplementedAuthorizationProviderServer
+
+	mu       sync.Mutex
+	requests []*proto.SubjectSearchRequest
+	tokens   []string
+}
+
+func (h *authorizationTransportHarness) SearchSubjects(ctx context.Context, req *proto.SubjectSearchRequest) (*proto.SubjectSearchResponse, error) {
+	md, _ := metadata.FromIncomingContext(ctx)
+
+	h.mu.Lock()
+	if values := md.Get("x-gestalt-host-service-relay-token"); len(values) > 0 {
+		h.tokens = append(h.tokens, values...)
+	}
+	h.requests = append(h.requests, gproto.Clone(req).(*proto.SubjectSearchRequest))
+	h.mu.Unlock()
+
+	return &proto.SubjectSearchResponse{
+		Subjects: []*proto.Subject{{
+			Type: "user",
+			Id:   "user:user-123",
+		}},
+		ModelId: "authz-model-1",
+	}, nil
+}
+
+func TestTransport_AuthorizationTCPTargetTokenEnv(t *testing.T) {
+	address := reserveTCPAddress()
+	lis, err := net.Listen("tcp", address)
+	if err != nil {
+		t.Fatalf("net.Listen: %v", err)
+	}
+	t.Cleanup(func() { _ = lis.Close() })
+
+	harness := &authorizationTransportHarness{}
+	srv := grpc.NewServer()
+	proto.RegisterAuthorizationProviderServer(srv, harness)
+	go func() {
+		_ = srv.Serve(lis)
+	}()
+	t.Cleanup(srv.Stop)
+
+	t.Setenv(gestalt.EnvAuthorizationSocket, "tcp://"+address)
+	t.Setenv(gestalt.EnvAuthorizationSocketToken, "relay-token-go")
+
+	client, err := gestalt.Authorization()
+	if err != nil {
+		t.Fatalf("Authorization: %v", err)
+	}
+	defer func() { _ = client.Close() }()
+
+	resp, err := client.SearchSubjects(context.Background(), &proto.SubjectSearchRequest{
+		SubjectType: "user",
+		Resource: &proto.Resource{
+			Type: "slack_identity",
+			Id:   "team:T123:user:U456",
+		},
+		Action:   &proto.Action{Name: "assume"},
+		PageSize: 1,
+	})
+	if err != nil {
+		t.Fatalf("SearchSubjects: %v", err)
+	}
+	if resp.GetModelId() != "authz-model-1" {
+		t.Fatalf("model id = %q, want %q", resp.GetModelId(), "authz-model-1")
+	}
+	if len(resp.GetSubjects()) != 1 || resp.GetSubjects()[0].GetId() != "user:user-123" {
+		t.Fatalf("subjects = %#v, want [user:user-123]", resp.GetSubjects())
+	}
+
+	harness.mu.Lock()
+	defer harness.mu.Unlock()
+	if len(harness.tokens) != 1 || harness.tokens[0] != "relay-token-go" {
+		t.Fatalf("relay tokens = %#v, want [relay-token-go]", harness.tokens)
+	}
+	if len(harness.requests) != 1 {
+		t.Fatalf("search subject requests len = %d, want 1", len(harness.requests))
+	}
+	if harness.requests[0].GetSubjectType() != "user" {
+		t.Fatalf("subject type = %q, want %q", harness.requests[0].GetSubjectType(), "user")
+	}
+	if harness.requests[0].GetResource().GetId() != "team:T123:user:U456" {
+		t.Fatalf("resource id = %q, want %q", harness.requests[0].GetResource().GetId(), "team:T123:user:U456")
+	}
+	if harness.requests[0].GetAction().GetName() != "assume" {
+		t.Fatalf("action name = %q, want %q", harness.requests[0].GetAction().GetName(), "assume")
+	}
+}

--- a/sdk/typescript/src/authorization.ts
+++ b/sdk/typescript/src/authorization.ts
@@ -1,7 +1,11 @@
 import { connect } from "node:net";
 
 import type { MessageInitShape } from "@bufbuild/protobuf";
-import { createClient, type Client } from "@connectrpc/connect";
+import {
+  createClient,
+  type Client,
+  type Interceptor,
+} from "@connectrpc/connect";
 import { createGrpcTransport } from "@connectrpc/connect-node";
 
 import {
@@ -20,10 +24,14 @@ import {
 } from "../gen/v1/authorization_pb.ts";
 
 /**
- * Environment variable containing the Unix socket path for the read-only host
- * authorization client exposed to plugins.
+ * Environment variable containing the Unix socket path or relay target for the
+ * read-only host authorization client exposed to plugins.
  */
 export const ENV_AUTHORIZATION_SOCKET = "GESTALT_AUTHORIZATION_SOCKET";
+export const ENV_AUTHORIZATION_SOCKET_TOKEN =
+  `${ENV_AUTHORIZATION_SOCKET}_TOKEN`;
+const AUTHORIZATION_RELAY_TOKEN_HEADER =
+  "x-gestalt-host-service-relay-token";
 
 export type AuthorizationEvaluateInput = MessageInitShape<
   typeof AccessEvaluationRequestSchema
@@ -49,10 +57,12 @@ export type AuthorizationActionSearchMessage = ActionSearchResponse;
 export type AuthorizationReadRelationshipsMessage = ReadRelationshipsResponse;
 
 const sharedAuthorizationTransport: {
-  socketPath: string;
+  target: string;
+  token: string;
   client: AuthorizationClient | undefined;
 } = {
-  socketPath: "",
+  target: "",
+  token: "",
   client: undefined,
 };
 
@@ -62,13 +72,21 @@ const sharedAuthorizationTransport: {
 export class AuthorizationClient {
   private readonly client: Client<typeof AuthorizationProviderService>;
 
-  constructor(socketPath?: string) {
-    const resolvedSocketPath = resolveAuthorizationSocketPath(socketPath);
+  constructor(socketTarget?: string, relayToken = process.env[ENV_AUTHORIZATION_SOCKET_TOKEN]?.trim() ?? "") {
+    const resolvedTarget = resolveAuthorizationSocketTarget(socketTarget);
+    const transportOptions = authorizationTransportOptions(resolvedTarget);
     const transport = createGrpcTransport({
-      baseUrl: "http://localhost",
-      nodeOptions: {
-        createConnection: () => connect(resolvedSocketPath),
-      },
+      ...transportOptions,
+      ...(transportOptions.nodeOptions
+        ? {
+            nodeOptions: {
+              createConnection: () => connect(transportOptions.nodeOptions!.path),
+            },
+          }
+        : {}),
+      interceptors: relayToken
+        ? [authorizationRelayTokenInterceptor(relayToken)]
+        : [],
     });
     this.client = createClient(AuthorizationProviderService, transport);
   }
@@ -113,26 +131,78 @@ export class AuthorizationClient {
  * client inside authored providers.
  */
 export function Authorization(): AuthorizationClient {
-  const socketPath = resolveAuthorizationSocketPath();
+  const target = resolveAuthorizationSocketTarget();
+  const token = process.env[ENV_AUTHORIZATION_SOCKET_TOKEN]?.trim() ?? "";
   if (
     sharedAuthorizationTransport.client &&
-    sharedAuthorizationTransport.socketPath === socketPath
+    sharedAuthorizationTransport.target === target &&
+    sharedAuthorizationTransport.token === token
   ) {
     return sharedAuthorizationTransport.client;
   }
 
-  const client = new AuthorizationClient(socketPath);
-  sharedAuthorizationTransport.socketPath = socketPath;
+  const client = new AuthorizationClient(target, token);
+  sharedAuthorizationTransport.target = target;
+  sharedAuthorizationTransport.token = token;
   sharedAuthorizationTransport.client = client;
   return client;
 }
 
-function resolveAuthorizationSocketPath(socketPath = process.env[ENV_AUTHORIZATION_SOCKET]): string {
+function resolveAuthorizationSocketTarget(socketPath = process.env[ENV_AUTHORIZATION_SOCKET]): string {
   const trimmed = socketPath?.trim() ?? "";
   if (!trimmed) {
-    throw new Error(
-      `authorization: ${ENV_AUTHORIZATION_SOCKET} is not set`,
-    );
+    throw new Error(`authorization: ${ENV_AUTHORIZATION_SOCKET} is not set`);
   }
   return trimmed;
+}
+
+function authorizationTransportOptions(rawTarget: string): {
+  baseUrl: string;
+  nodeOptions?: { path: string };
+} {
+  const target = rawTarget.trim();
+  if (!target) {
+    throw new Error("authorization: transport target is required");
+  }
+  if (target.startsWith("tcp://")) {
+    const address = target.slice("tcp://".length).trim();
+    if (!address) {
+      throw new Error(
+        `authorization: tcp target ${JSON.stringify(rawTarget)} is missing host:port`,
+      );
+    }
+    return { baseUrl: `http://${address}` };
+  }
+  if (target.startsWith("tls://")) {
+    const address = target.slice("tls://".length).trim();
+    if (!address) {
+      throw new Error(
+        `authorization: tls target ${JSON.stringify(rawTarget)} is missing host:port`,
+      );
+    }
+    return { baseUrl: `https://${address}` };
+  }
+  if (target.startsWith("unix://")) {
+    const socketPath = target.slice("unix://".length).trim();
+    if (!socketPath) {
+      throw new Error(
+        `authorization: unix target ${JSON.stringify(rawTarget)} is missing a socket path`,
+      );
+    }
+    return { baseUrl: "http://localhost", nodeOptions: { path: socketPath } };
+  }
+  if (target.includes("://")) {
+    const parsed = new URL(target);
+    throw new Error(
+      `authorization: unsupported target scheme ${JSON.stringify(parsed.protocol.replace(/:$/, ""))}`,
+    );
+  }
+  return { baseUrl: "http://localhost", nodeOptions: { path: target } };
+}
+
+function authorizationRelayTokenInterceptor(token: string): Interceptor {
+  return (next) => async (req) => {
+    req.header.set(AUTHORIZATION_RELAY_TOKEN_HEADER, token);
+    return next(req);
+  };
 }

--- a/sdk/typescript/src/index.ts
+++ b/sdk/typescript/src/index.ts
@@ -32,6 +32,7 @@ export {
   Authorization,
   AuthorizationClient,
   ENV_AUTHORIZATION_SOCKET,
+  ENV_AUTHORIZATION_SOCKET_TOKEN,
   type AuthorizationActionSearchMessage,
   type AuthorizationDecisionMessage,
   type AuthorizationEvaluateInput,

--- a/sdk/typescript/tests/authorization.transport.test.ts
+++ b/sdk/typescript/tests/authorization.transport.test.ts
@@ -1,5 +1,6 @@
 import { mkdtempSync } from "node:fs";
 import { createServer } from "node:http2";
+import { createServer as createNetServer } from "node:net";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 
@@ -20,6 +21,7 @@ import {
   Authorization,
   AuthorizationClient,
   ENV_AUTHORIZATION_SOCKET,
+  ENV_AUTHORIZATION_SOCKET_TOKEN,
 } from "../src/index.ts";
 import { removeTempDir } from "./helpers.ts";
 
@@ -149,5 +151,110 @@ test("Authorization() forwards read-only authorization requests to the host sock
       process.env[ENV_AUTHORIZATION_SOCKET] = previousSocket;
     }
     removeTempDir(tempDir);
+  }
+});
+
+async function reserveTCPAddress(): Promise<string> {
+  return await new Promise((resolve, reject) => {
+    const server = createNetServer();
+    server.once("error", reject);
+    server.listen(0, "127.0.0.1", () => {
+      const address = server.address();
+      if (!address || typeof address === "string") {
+        server.close();
+        reject(new Error("failed to reserve tcp address"));
+        return;
+      }
+      const result = `${address.address}:${address.port}`;
+      server.close((err) => {
+        if (err) {
+          reject(err);
+          return;
+        }
+        resolve(result);
+      });
+    });
+  });
+}
+
+test("Authorization honors tcp target env and relay token env", async () => {
+  const previousSocket = process.env[ENV_AUTHORIZATION_SOCKET];
+  const previousToken = process.env[ENV_AUTHORIZATION_SOCKET_TOKEN];
+  const seenTokens: string[] = [];
+  const address = await reserveTCPAddress();
+
+  const handler = connectNodeAdapter({
+    grpc: true,
+    grpcWeb: false,
+    connect: false,
+    routes(router) {
+      router.service(
+        AuthorizationProviderService,
+        {
+          async searchSubjects(input) {
+            return create(SubjectSearchResponseSchema, {
+              subjects: [
+                create(SubjectSchema, {
+                  type: input.subjectType || "user",
+                  id: "user:user-123",
+                }),
+              ],
+              modelId: "authz-model-1",
+            });
+          },
+        } satisfies Partial<ServiceImpl<typeof AuthorizationProviderService>>,
+      );
+    },
+  });
+  const server = createServer((req, res) => {
+    const tokenHeader = req.headers["x-gestalt-host-service-relay-token"];
+    if (typeof tokenHeader === "string") {
+      seenTokens.push(tokenHeader);
+    }
+    handler(req, res);
+  });
+
+  try {
+    await new Promise<void>((resolve, reject) => {
+      server.once("error", reject);
+      server.listen(Number(address.split(":").at(-1)), "127.0.0.1", () => {
+        server.off("error", reject);
+        resolve();
+      });
+    });
+
+    process.env[ENV_AUTHORIZATION_SOCKET] = `tcp://${address}`;
+    process.env[ENV_AUTHORIZATION_SOCKET_TOKEN] = "relay-token-typescript";
+
+    const response = await Authorization().searchSubjects({
+      resource: create(ResourceSchema, {
+        type: "slack_identity",
+        id: "team:T123:user:U456",
+      }),
+      action: create(ActionSchema, { name: "assume" }),
+      subjectType: "user",
+      pageSize: 1,
+    });
+
+    expect(response.modelId).toBe("authz-model-1");
+    expect(response.subjects).toHaveLength(1);
+    expect(response.subjects[0]?.id).toBe("user:user-123");
+    expect(seenTokens).toEqual(["relay-token-typescript"]);
+  } finally {
+    if (previousSocket === undefined) {
+      delete process.env[ENV_AUTHORIZATION_SOCKET];
+    } else {
+      process.env[ENV_AUTHORIZATION_SOCKET] = previousSocket;
+    }
+    if (previousToken === undefined) {
+      delete process.env[ENV_AUTHORIZATION_SOCKET_TOKEN];
+    } else {
+      process.env[ENV_AUTHORIZATION_SOCKET_TOKEN] = previousToken;
+    }
+    if (server.listening) {
+      await new Promise<void>((resolve) => {
+        server.close(() => resolve());
+      });
+    }
   }
 });

--- a/sdk/typescript/tests/indexeddb.transport.test.ts
+++ b/sdk/typescript/tests/indexeddb.transport.test.ts
@@ -119,10 +119,10 @@ afterAll(() => {
 
 describe("IndexedDB transport", () => {
   test("createObjectStore forwards declared columns", async () => {
-    const previousSocket = process.env.GESTALT_INDEXEDDB_SOCKET;
-    process.env.GESTALT_INDEXEDDB_SOCKET = "/tmp/fake-indexeddb.sock";
+    const envName = indexedDBSocketEnv("schema");
+    process.env[envName] = "/tmp/fake-indexeddb.sock";
     try {
-      const local = new IndexedDB();
+      const local = new IndexedDB("schema");
       const calls: any[] = [];
       (local as any).client = {
         createObjectStore: async (request: any) => {
@@ -155,11 +155,7 @@ describe("IndexedDB transport", () => {
         },
       });
     } finally {
-      if (previousSocket === undefined) {
-        delete process.env.GESTALT_INDEXEDDB_SOCKET;
-      } else {
-        process.env.GESTALT_INDEXEDDB_SOCKET = previousSocket;
-      }
+      delete process.env[envName];
     }
   });
 
@@ -210,9 +206,10 @@ describe("IndexedDB transport", () => {
 
   test("tcp target env selects the requested binding", async () => {
     const { proc: tcpProc, target } = await startTCPHarness();
-    process.env.GESTALT_INDEXEDDB_SOCKET = target;
+    const envName = indexedDBSocketEnv("tcp");
+    process.env[envName] = target;
     try {
-      const tcpDb = new IndexedDB();
+      const tcpDb = new IndexedDB("tcp");
       const store = "tcp_target_env";
       await tcpDb.createObjectStore(store);
       await tcpDb.objectStore(store).put({ id: "row-1", value: "tcp" });
@@ -220,18 +217,19 @@ describe("IndexedDB transport", () => {
       expect(got.value).toBe("tcp");
     } finally {
       tcpProc.kill();
-      delete process.env.GESTALT_INDEXEDDB_SOCKET;
-      process.env.GESTALT_INDEXEDDB_SOCKET = socketPath;
+      delete process.env[envName];
     }
   });
 
   test("tcp target token env selects the requested binding", async () => {
     const token = "relay-token-typescript";
     const { proc: tcpProc, target } = await startTCPHarness(token);
-    process.env.GESTALT_INDEXEDDB_SOCKET = target;
-    process.env[indexedDBSocketTokenEnv()] = token;
+    const envName = indexedDBSocketEnv("tcp-token");
+    const tokenEnvName = indexedDBSocketTokenEnv("tcp-token");
+    process.env[envName] = target;
+    process.env[tokenEnvName] = token;
     try {
-      const tcpDb = new IndexedDB();
+      const tcpDb = new IndexedDB("tcp-token");
       const store = "tcp_target_token_env";
       await tcpDb.createObjectStore(store);
       await tcpDb.objectStore(store).put({ id: "row-1", value: "token" });
@@ -239,9 +237,8 @@ describe("IndexedDB transport", () => {
       expect(got.value).toBe("token");
     } finally {
       tcpProc.kill();
-      delete process.env.GESTALT_INDEXEDDB_SOCKET;
-      delete process.env[indexedDBSocketTokenEnv()];
-      process.env.GESTALT_INDEXEDDB_SOCKET = socketPath;
+      delete process.env[envName];
+      delete process.env[tokenEnvName];
     }
   });
 

--- a/sdk/typescript/tests/s3.transport.test.ts
+++ b/sdk/typescript/tests/s3.transport.test.ts
@@ -132,32 +132,33 @@ describe("S3 transport", () => {
 
   test("tcp target env selects the requested binding", async () => {
     const { proc: tcpProc, target } = await startTCPHarness();
-    process.env.GESTALT_S3_SOCKET = target;
+    const envName = s3SocketEnv("tcp");
+    process.env[envName] = target;
     try {
-      const object = new S3().object("tcp-bucket", "hello.txt");
+      const object = new S3("tcp").object("tcp-bucket", "hello.txt");
       await object.writeString("tcp binding");
       expect(await object.text()).toBe("tcp binding");
     } finally {
       tcpProc.kill();
-      delete process.env.GESTALT_S3_SOCKET;
-      process.env.GESTALT_S3_SOCKET = socketPath;
+      delete process.env[envName];
     }
   });
 
   test("tcp target token env selects the requested binding", async () => {
     const token = "relay-token-typescript";
     const { proc: tcpProc, target } = await startTCPHarness(token);
-    process.env.GESTALT_S3_SOCKET = target;
-    process.env[s3SocketTokenEnv()] = token;
+    const envName = s3SocketEnv("tcp-token");
+    const tokenEnvName = s3SocketTokenEnv("tcp-token");
+    process.env[envName] = target;
+    process.env[tokenEnvName] = token;
     try {
-      const object = new S3().object("tcp-token-bucket", "hello.txt");
+      const object = new S3("tcp-token").object("tcp-token-bucket", "hello.txt");
       await object.writeString("token binding");
       expect(await object.text()).toBe("token binding");
     } finally {
       tcpProc.kill();
-      delete process.env.GESTALT_S3_SOCKET;
-      delete process.env[s3SocketTokenEnv()];
-      process.env.GESTALT_S3_SOCKET = socketPath;
+      delete process.env[envName];
+      delete process.env[tokenEnvName];
     }
   });
 


### PR DESCRIPTION
## Summary
This finishes the remaining hosted-runtime relay gap for authorization-backed hosted HTTP bindings.

Hosted plugins with HTTP bindings can now consume the authorization host service over the public runtime relay path, even when the runtime does not support generic `HostServiceTunnels`.

## New Interfaces
- `GESTALT_AUTHORIZATION_SOCKET` now accepts:
  - raw unix socket paths
  - `unix:///path/to/socket`
  - `tcp://host:port`
  - `tls://host:port`
- `GESTALT_AUTHORIZATION_SOCKET_TOKEN` forwards the relay bearer for hosted runtime access via `x-gestalt-host-service-relay-token`
- runtime relay binding now supports authorization via:
  - `HostServiceBinding.relay.dial_target`
  - `BindHostServiceRequest.relay.dial_target`

## Examples
Plugin/runtime env inside a hosted runtime:
```text
GESTALT_AUTHORIZATION_SOCKET=tls://gestalt.example.test:443
GESTALT_AUTHORIZATION_SOCKET_TOKEN=eyJhbGciOi...
```

Go plugin usage:
```go
client, err := gestalt.Authorization()
if err != nil {
    return nil, err
}
defer client.Close()

resp, err := client.SearchSubjects(ctx, &gestalt.SubjectSearchRequest{
    SubjectType: "user",
    Resource: &gestalt.AuthorizationResource{
        Type: "slack_identity",
        Id:   "team:T123:user:U456",
    },
    Action: &gestalt.ActionRef{Name: "assume"},
    PageSize: 1,
})
```

TypeScript plugin usage:
```ts
const authz = Authorization();
const resp = await authz.searchSubjects({
  subjectType: "user",
  resource: { type: "slack_identity", id: "team:T123:user:U456" },
  action: { name: "assume" },
  pageSize: 1,
});
```

## Implementation
- includes authorization host services in hosted runtime bootstrap even when generic host-service tunnels are unavailable
- relays authorization through the existing public host-service relay target/token flow
- teaches the Go and TypeScript authorization clients to use unix/tcp/tls targets plus relay-token headers
- replaces the old negative hosted-runtime authorization test with relay-backed config coverage
- adds a hosted authorization relay round-trip coverage test and SDK transport coverage

## Validation
- `cd gestaltd && go test ./internal/bootstrap ./internal/pluginruntime ./internal/providerhost ./internal/server -count=1`
- `cd sdk/go && go test ./... -count=1`
- `cd sdk/typescript && bun run check`

## Review
Reviewer-agent pass: no actionable findings.