### PR TITLE
Add agent manager, run metadata, and tool callbacks

### DIFF
--- a/gestaltd/core/agent/agent.go
+++ b/gestaltd/core/agent/agent.go
@@ -123,16 +123,17 @@ type ManagedRun struct {
 }
 
 type ManagerRunRequest struct {
-	IdempotencyKey  string
-	ProviderName    string
-	Model           string
-	Messages        []Message
-	ToolRefs        []ToolRef
-	ToolSource      ToolSourceMode
-	ResponseSchema  map[string]any
-	SessionRef      string
-	Metadata        map[string]any
-	ProviderOptions map[string]any
+	CallerPluginName string
+	IdempotencyKey   string
+	ProviderName     string
+	Model            string
+	Messages         []Message
+	ToolRefs         []ToolRef
+	ToolSource       ToolSourceMode
+	ResponseSchema   map[string]any
+	SessionRef       string
+	Metadata         map[string]any
+	ProviderOptions  map[string]any
 }
 
 type ManagerGetRunRequest struct {

--- a/gestaltd/internal/agentmanager/manager.go
+++ b/gestaltd/internal/agentmanager/manager.go
@@ -1,0 +1,694 @@
+package agentmanager
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"maps"
+	"sort"
+	"strings"
+	"time"
+
+	"github.com/google/uuid"
+	"github.com/valon-technologies/gestalt/server/core"
+	coreagent "github.com/valon-technologies/gestalt/server/core/agent"
+	"github.com/valon-technologies/gestalt/server/core/catalog"
+	"github.com/valon-technologies/gestalt/server/core/indexeddb"
+	"github.com/valon-technologies/gestalt/server/internal/authorization"
+	"github.com/valon-technologies/gestalt/server/internal/config"
+	"github.com/valon-technologies/gestalt/server/internal/coredata"
+	"github.com/valon-technologies/gestalt/server/internal/invocation"
+	"github.com/valon-technologies/gestalt/server/internal/principal"
+	"github.com/valon-technologies/gestalt/server/internal/registry"
+)
+
+var (
+	ErrAgentNotConfigured            = errors.New("agent is not configured")
+	ErrAgentRunMetadataNotConfigured = errors.New("agent run metadata is not configured")
+	ErrAgentSubjectRequired          = errors.New("agent subject is required")
+	ErrAgentCallerPluginRequired     = errors.New("agent caller plugin is required for inherited tools")
+	ErrAgentInheritedSurfaceTool     = errors.New("agent inherited surface tools are not supported")
+	ErrAgentRunCreationInProgress    = errors.New("agent run creation is already in progress for this idempotency key")
+)
+
+type AgentControl interface {
+	ResolveProvider(name string) (coreagent.Provider, error)
+	ResolveProviderSelection(name string) (providerName string, provider coreagent.Provider, err error)
+	ProviderNames() []string
+}
+
+type Service interface {
+	Run(ctx context.Context, p *principal.Principal, req coreagent.ManagerRunRequest) (*coreagent.ManagedRun, error)
+	GetRun(ctx context.Context, p *principal.Principal, runID string) (*coreagent.ManagedRun, error)
+	ListRuns(ctx context.Context, p *principal.Principal) ([]*coreagent.ManagedRun, error)
+	CancelRun(ctx context.Context, p *principal.Principal, runID, reason string) (*coreagent.ManagedRun, error)
+}
+
+type Config struct {
+	Providers         *registry.ProviderMap[core.Provider]
+	Agent             AgentControl
+	RunMetadata       *coredata.AgentRunMetadataService
+	Invoker           invocation.Invoker
+	Authorizer        authorization.RuntimeAuthorizer
+	DefaultConnection map[string]string
+	CatalogConnection map[string]string
+	PluginInvokes     map[string][]config.PluginInvocationDependency
+	Now               func() time.Time
+}
+
+type Manager struct {
+	providers         *registry.ProviderMap[core.Provider]
+	agent             AgentControl
+	runMetadata       *coredata.AgentRunMetadataService
+	invoker           invocation.Invoker
+	authorizer        authorization.RuntimeAuthorizer
+	defaultConnection map[string]string
+	catalogConnection map[string]string
+	pluginInvokes     map[string][]config.PluginInvocationDependency
+	now               func() time.Time
+}
+
+func New(cfg Config) *Manager {
+	now := cfg.Now
+	if now == nil {
+		now = time.Now
+	}
+	pluginInvokes := make(map[string][]config.PluginInvocationDependency, len(cfg.PluginInvokes))
+	for pluginName, deps := range cfg.PluginInvokes {
+		pluginInvokes[pluginName] = append([]config.PluginInvocationDependency(nil), deps...)
+	}
+	return &Manager{
+		providers:         cfg.Providers,
+		agent:             cfg.Agent,
+		runMetadata:       cfg.RunMetadata,
+		invoker:           cfg.Invoker,
+		authorizer:        cfg.Authorizer,
+		defaultConnection: maps.Clone(cfg.DefaultConnection),
+		catalogConnection: maps.Clone(cfg.CatalogConnection),
+		pluginInvokes:     pluginInvokes,
+		now:               now,
+	}
+}
+
+func (m *Manager) Run(ctx context.Context, p *principal.Principal, req coreagent.ManagerRunRequest) (*coreagent.ManagedRun, error) {
+	p = principal.Canonicalized(p)
+	if m == nil || m.runMetadata == nil {
+		return nil, ErrAgentRunMetadataNotConfigured
+	}
+	subjectID := strings.TrimSpace(principalSubjectID(p))
+	if subjectID == "" {
+		return nil, ErrAgentSubjectRequired
+	}
+	providerName, provider, err := m.resolveProviderSelection(req.ProviderName)
+	if err != nil {
+		return nil, err
+	}
+	idempotencyKey := strings.TrimSpace(req.IdempotencyKey)
+
+	tools, err := m.resolveTools(ctx, p, req.CallerPluginName, req.ToolRefs, req.ToolSource)
+	if err != nil {
+		return nil, err
+	}
+	runID := uuid.NewString()
+	if idempotencyKey != "" {
+		for {
+			claimedRunID, claimed, err := m.runMetadata.ClaimIdempotency(ctx, subjectID, providerName, idempotencyKey, runID, m.now())
+			if err != nil {
+				return nil, err
+			}
+			if claimed {
+				break
+			}
+			existing, err := m.runMetadata.Get(ctx, claimedRunID)
+			if err != nil {
+				if errors.Is(err, indexeddb.ErrNotFound) {
+					return nil, ErrAgentRunCreationInProgress
+				}
+				return nil, err
+			}
+			if !executionRefOwnedBy(existing, p) || !m.allowRun(ctx, p, existing) {
+				return nil, core.ErrNotFound
+			}
+			managed, err := m.getManagedRunByMetadata(ctx, p, existing)
+			if err == nil {
+				return managed, nil
+			}
+			if !errors.Is(err, core.ErrNotFound) {
+				return nil, err
+			}
+			if deleteErr := m.runMetadata.Delete(ctx, existing.ID); deleteErr != nil {
+				return nil, deleteErr
+			}
+			runID = uuid.NewString()
+		}
+	}
+	ref, err := m.runMetadata.Put(ctx, &coreagent.ExecutionReference{
+		ID:             runID,
+		ProviderName:   providerName,
+		SubjectID:      subjectID,
+		IdempotencyKey: idempotencyKey,
+		Permissions:    principal.PermissionsToAccessPermissions(p.TokenPermissions),
+		Tools:          tools,
+	})
+	if err != nil {
+		if idempotencyKey != "" {
+			if releaseErr := m.runMetadata.ReleaseIdempotency(ctx, subjectID, providerName, idempotencyKey); releaseErr != nil {
+				err = errors.Join(err, releaseErr)
+			}
+		}
+		return nil, err
+	}
+
+	run, err := provider.StartRun(ctx, coreagent.StartRunRequest{
+		RunID:           runID,
+		IdempotencyKey:  idempotencyKey,
+		ProviderName:    providerName,
+		Model:           strings.TrimSpace(req.Model),
+		Messages:        append([]coreagent.Message(nil), req.Messages...),
+		Tools:           append([]coreagent.Tool(nil), tools...),
+		ResponseSchema:  maps.Clone(req.ResponseSchema),
+		SessionRef:      strings.TrimSpace(req.SessionRef),
+		Metadata:        maps.Clone(req.Metadata),
+		ProviderOptions: maps.Clone(req.ProviderOptions),
+		CreatedBy:       agentActorFromPrincipal(p),
+		ExecutionRef:    runID,
+	})
+	if err != nil {
+		fallback, getErr := provider.GetRun(ctx, coreagent.GetRunRequest{RunID: runID})
+		if getErr == nil {
+			run = fallback
+		} else {
+			_ = m.runMetadata.Delete(ctx, ref.ID)
+			return nil, err
+		}
+	}
+	normalized, err := normalizeProviderRun(providerName, runID, run)
+	if err != nil {
+		_ = m.runMetadata.Delete(ctx, ref.ID)
+		return nil, err
+	}
+	return &coreagent.ManagedRun{
+		ProviderName: providerName,
+		Run:          normalized,
+	}, nil
+}
+
+func (m *Manager) GetRun(ctx context.Context, p *principal.Principal, runID string) (*coreagent.ManagedRun, error) {
+	ref, err := m.requireOwnedRunMetadata(ctx, runID, p)
+	if err != nil {
+		return nil, err
+	}
+	return m.getManagedRunByMetadata(ctx, p, ref)
+}
+
+func (m *Manager) ListRuns(ctx context.Context, p *principal.Principal) ([]*coreagent.ManagedRun, error) {
+	refs, err := m.listOwnedRunMetadata(ctx, p, false)
+	if err != nil {
+		return nil, err
+	}
+	refsByProvider := executionRefsByProvider(refs)
+	out := make([]*coreagent.ManagedRun, 0, len(refs))
+	for providerName, providerRefs := range refsByProvider {
+		provider, err := m.resolveProviderByName(providerName)
+		if err != nil {
+			return nil, err
+		}
+		runs, err := provider.ListRuns(ctx, coreagent.ListRunsRequest{})
+		if err != nil {
+			return nil, err
+		}
+		refIndex := executionRefsByID(providerRefs)
+		for _, run := range runs {
+			if run == nil {
+				continue
+			}
+			ref := refIndex[strings.TrimSpace(run.ID)]
+			if ref == nil || !m.allowRun(ctx, p, ref) {
+				continue
+			}
+			normalized, err := normalizeProviderRun(providerName, ref.ID, run)
+			if err != nil {
+				return nil, err
+			}
+			out = append(out, &coreagent.ManagedRun{
+				ProviderName: providerName,
+				Run:          normalized,
+			})
+		}
+	}
+	sort.Slice(out, func(i, j int) bool {
+		left := out[i]
+		right := out[j]
+		if left.Run != nil && right.Run != nil && left.Run.CreatedAt != nil && right.Run.CreatedAt != nil && !left.Run.CreatedAt.Equal(*right.Run.CreatedAt) {
+			return left.Run.CreatedAt.After(*right.Run.CreatedAt)
+		}
+		leftID := ""
+		rightID := ""
+		if left.Run != nil {
+			leftID = left.Run.ID
+		}
+		if right.Run != nil {
+			rightID = right.Run.ID
+		}
+		return leftID < rightID
+	})
+	return out, nil
+}
+
+func (m *Manager) CancelRun(ctx context.Context, p *principal.Principal, runID, reason string) (*coreagent.ManagedRun, error) {
+	ref, err := m.requireOwnedRunMetadata(ctx, runID, p)
+	if err != nil {
+		return nil, err
+	}
+	provider, err := m.resolveProviderByName(ref.ProviderName)
+	if err != nil {
+		return nil, err
+	}
+	run, err := provider.CancelRun(ctx, coreagent.CancelRunRequest{
+		RunID:  strings.TrimSpace(runID),
+		Reason: strings.TrimSpace(reason),
+	})
+	if err != nil {
+		return nil, err
+	}
+	normalized, err := normalizeProviderRun(ref.ProviderName, strings.TrimSpace(runID), run)
+	if err != nil {
+		return nil, err
+	}
+	return &coreagent.ManagedRun{
+		ProviderName: ref.ProviderName,
+		Run:          normalized,
+	}, nil
+}
+
+func (m *Manager) getManagedRunByMetadata(ctx context.Context, p *principal.Principal, ref *coreagent.ExecutionReference) (*coreagent.ManagedRun, error) {
+	if ref == nil {
+		return nil, core.ErrNotFound
+	}
+	if !m.allowRun(ctx, p, ref) {
+		return nil, core.ErrNotFound
+	}
+	provider, err := m.resolveProviderByName(ref.ProviderName)
+	if err != nil {
+		return nil, err
+	}
+	run, err := provider.GetRun(ctx, coreagent.GetRunRequest{RunID: strings.TrimSpace(ref.ID)})
+	if err != nil {
+		return nil, err
+	}
+	normalized, err := normalizeProviderRun(ref.ProviderName, ref.ID, run)
+	if err != nil {
+		return nil, err
+	}
+	return &coreagent.ManagedRun{
+		ProviderName: ref.ProviderName,
+		Run:          normalized,
+	}, nil
+}
+
+func (m *Manager) resolveProviderSelection(providerName string) (string, coreagent.Provider, error) {
+	if m == nil || m.agent == nil {
+		return "", nil, ErrAgentNotConfigured
+	}
+	return m.agent.ResolveProviderSelection(strings.TrimSpace(providerName))
+}
+
+func (m *Manager) resolveProviderByName(providerName string) (coreagent.Provider, error) {
+	if m == nil || m.agent == nil {
+		return nil, ErrAgentNotConfigured
+	}
+	return m.agent.ResolveProvider(strings.TrimSpace(providerName))
+}
+
+func (m *Manager) listOwnedRunMetadata(ctx context.Context, p *principal.Principal, activeOnly bool) ([]*coreagent.ExecutionReference, error) {
+	if m == nil || m.runMetadata == nil {
+		return nil, ErrAgentRunMetadataNotConfigured
+	}
+	subjectID := strings.TrimSpace(principalSubjectID(principal.Canonicalized(p)))
+	if subjectID == "" {
+		return nil, ErrAgentSubjectRequired
+	}
+	refs, err := m.runMetadata.ListBySubject(ctx, subjectID)
+	if err != nil {
+		return nil, err
+	}
+	out := make([]*coreagent.ExecutionReference, 0, len(refs))
+	for _, ref := range refs {
+		if !executionRefOwnedBy(ref, p) || (activeOnly && !executionRefActive(ref)) {
+			continue
+		}
+		out = append(out, ref)
+	}
+	return out, nil
+}
+
+func (m *Manager) requireOwnedRunMetadata(ctx context.Context, runID string, p *principal.Principal) (*coreagent.ExecutionReference, error) {
+	runID = strings.TrimSpace(runID)
+	if runID == "" {
+		return nil, core.ErrNotFound
+	}
+	if m == nil || m.runMetadata == nil {
+		return nil, ErrAgentRunMetadataNotConfigured
+	}
+	ref, err := m.runMetadata.Get(ctx, runID)
+	if err != nil {
+		if errors.Is(err, indexeddb.ErrNotFound) {
+			return nil, core.ErrNotFound
+		}
+		return nil, err
+	}
+	if !executionRefOwnedBy(ref, p) || !m.allowRun(ctx, p, ref) {
+		return nil, core.ErrNotFound
+	}
+	return ref, nil
+}
+
+func (m *Manager) resolveTools(ctx context.Context, p *principal.Principal, callerPluginName string, explicit []coreagent.ToolRef, source coreagent.ToolSourceMode) ([]coreagent.Tool, error) {
+	refs := make([]coreagent.ToolRef, 0, len(explicit)+4)
+	refs = append(refs, explicit...)
+	if source == coreagent.ToolSourceModeInheritInvokes {
+		callerPluginName = strings.TrimSpace(callerPluginName)
+		if callerPluginName == "" {
+			return nil, ErrAgentCallerPluginRequired
+		}
+		for _, invoke := range m.pluginInvokes[callerPluginName] {
+			if strings.TrimSpace(invoke.Surface) != "" {
+				return nil, fmt.Errorf("%w: %s.%s", ErrAgentInheritedSurfaceTool, callerPluginName, invoke.Surface)
+			}
+			refs = append(refs, coreagent.ToolRef{
+				PluginName: invoke.Plugin,
+				Operation:  invoke.Operation,
+			})
+		}
+	}
+	if len(refs) == 0 {
+		return nil, nil
+	}
+	out := make([]coreagent.Tool, 0, len(refs))
+	seen := make(map[string]struct{}, len(refs))
+	for _, ref := range refs {
+		tool, err := m.resolveTool(ctx, p, ref)
+		if err != nil {
+			return nil, err
+		}
+		if _, ok := seen[tool.ID]; ok {
+			continue
+		}
+		seen[tool.ID] = struct{}{}
+		out = append(out, tool)
+	}
+	return out, nil
+}
+
+func (m *Manager) resolveTool(ctx context.Context, p *principal.Principal, ref coreagent.ToolRef) (coreagent.Tool, error) {
+	if m == nil || m.providers == nil {
+		return coreagent.Tool{}, fmt.Errorf("%w: agent providers are not configured", invocation.ErrInternal)
+	}
+	pluginName := strings.TrimSpace(ref.PluginName)
+	if pluginName == "" {
+		return coreagent.Tool{}, fmt.Errorf("%w: agent tool plugin is required", invocation.ErrProviderNotFound)
+	}
+	prov, err := m.providers.Get(pluginName)
+	if err != nil {
+		if errors.Is(err, core.ErrNotFound) {
+			return coreagent.Tool{}, fmt.Errorf("%w: %q", invocation.ErrProviderNotFound, pluginName)
+		}
+		return coreagent.Tool{}, fmt.Errorf("%w: looking up provider: %v", invocation.ErrInternal, err)
+	}
+	operation := strings.TrimSpace(ref.Operation)
+	if operation == "" {
+		return coreagent.Tool{}, fmt.Errorf("%w: agent tool operation is required", invocation.ErrOperationNotFound)
+	}
+	if !m.allowProvider(ctx, p, pluginName) || !m.allowOperation(ctx, p, pluginName, operation) {
+		return coreagent.Tool{}, invocation.ErrAuthorizationDenied
+	}
+
+	connection := strings.TrimSpace(ref.Connection)
+	if connection != "" && !config.SafeConnectionValue(connection) {
+		return coreagent.Tool{}, fmt.Errorf("connection name contains invalid characters")
+	}
+	connection = config.ResolveConnectionAlias(connection)
+	instance := strings.TrimSpace(ref.Instance)
+	if instance != "" && !config.SafeInstanceValue(instance) {
+		return coreagent.Tool{}, fmt.Errorf("instance name contains invalid characters")
+	}
+	if m.authorizer != nil && principal.IsWorkloadPrincipal(p) && (connection != "" || instance != "") {
+		return coreagent.Tool{}, fmt.Errorf("%w: workloads may not override connection or instance bindings", invocation.ErrAuthorizationDenied)
+	}
+
+	ctx = invocation.WithAccessContext(ctx, m.providerAccessContext(ctx, p, pluginName))
+	var resolver invocation.TokenResolver
+	if tr, ok := m.invoker.(invocation.TokenResolver); ok {
+		resolver = tr
+	}
+	boundCredential := invocation.CredentialBindingResolution{}
+	if bindingResolver, ok := m.invoker.(invocation.EffectiveCredentialBindingResolver); ok {
+		boundCredential, err = bindingResolver.ResolveEffectiveCredentialBinding(p, pluginName, connection, instance)
+		if err != nil {
+			return coreagent.Tool{}, err
+		}
+	}
+	boundConnections, sessionInstance := m.catalogSelectorConfig().BoundSessionCatalogConnections(pluginName, p, connection, instance)
+	opMeta, _, resolvedConnection, err := invocation.ResolveOperation(ctx, prov, pluginName, resolver, p, operation, boundConnections, sessionInstance)
+	if err != nil {
+		return coreagent.Tool{}, err
+	}
+	if !principal.AllowsOperationPermission(p, pluginName, opMeta.ID) {
+		return coreagent.Tool{}, fmt.Errorf("%w: %s.%s", invocation.ErrAuthorizationDenied, pluginName, opMeta.ID)
+	}
+	if m.authorizer != nil && !m.authorizer.AllowCatalogOperation(ctx, p, pluginName, opMeta) {
+		return coreagent.Tool{}, fmt.Errorf("%w: %s.%s", invocation.ErrAuthorizationDenied, pluginName, opMeta.ID)
+	}
+	if connection == "" {
+		connection = resolvedConnection
+	}
+	if resolver != nil && sessionInstance == "" {
+		resolvedCtx, _, err := invocation.ResolveTokenForBinding(ctx, resolver, p, pluginName, connection, sessionInstance, boundCredential)
+		if err != nil {
+			return coreagent.Tool{}, err
+		}
+		cred := invocation.CredentialContextFromContext(resolvedCtx)
+		if cred.Connection != "" {
+			connection = cred.Connection
+		}
+		if cred.Instance != "" {
+			sessionInstance = cred.Instance
+		}
+	}
+
+	parametersSchema, err := operationInputSchema(opMeta)
+	if err != nil {
+		return coreagent.Tool{}, err
+	}
+	name := strings.TrimSpace(ref.Title)
+	if name == "" {
+		name = strings.TrimSpace(opMeta.Title)
+	}
+	if name == "" {
+		name = pluginName + "." + opMeta.ID
+	}
+	description := strings.TrimSpace(ref.Description)
+	if description == "" {
+		description = strings.TrimSpace(opMeta.Description)
+	}
+	return coreagent.Tool{
+		ID:               agentToolID(pluginName, opMeta.ID, connection, sessionInstance),
+		Name:             name,
+		Description:      description,
+		ParametersSchema: parametersSchema,
+		Target: coreagent.ToolTarget{
+			PluginName: pluginName,
+			Operation:  opMeta.ID,
+			Connection: connection,
+			Instance:   sessionInstance,
+		},
+	}, nil
+}
+
+func (m *Manager) allowProvider(ctx context.Context, p *principal.Principal, provider string) bool {
+	if m == nil || m.authorizer == nil {
+		return true
+	}
+	return m.authorizer.AllowProvider(ctx, p, provider)
+}
+
+func (m *Manager) allowOperation(ctx context.Context, p *principal.Principal, provider, operation string) bool {
+	if m == nil || m.authorizer == nil {
+		return true
+	}
+	return m.authorizer.AllowOperation(ctx, p, provider, operation)
+}
+
+func (m *Manager) providerAccessContext(ctx context.Context, p *principal.Principal, provider string) invocation.AccessContext {
+	if m == nil || m.authorizer == nil {
+		return invocation.AccessContext{}
+	}
+	access, _ := m.authorizer.ResolveAccess(ctx, p, provider)
+	return access
+}
+
+func (m *Manager) allowRun(ctx context.Context, p *principal.Principal, ref *coreagent.ExecutionReference) bool {
+	if ref == nil {
+		return false
+	}
+	if !executionRefOwnedBy(ref, p) {
+		return false
+	}
+	if len(ref.Tools) == 0 {
+		return true
+	}
+	for _, tool := range ref.Tools {
+		if !m.allowTool(ctx, p, tool) {
+			return false
+		}
+	}
+	return true
+}
+
+func (m *Manager) allowTool(ctx context.Context, p *principal.Principal, tool coreagent.Tool) bool {
+	pluginName := strings.TrimSpace(tool.Target.PluginName)
+	operation := strings.TrimSpace(tool.Target.Operation)
+	if pluginName == "" || operation == "" {
+		return false
+	}
+	if !m.allowProvider(ctx, p, pluginName) || !m.allowOperation(ctx, p, pluginName, operation) {
+		return false
+	}
+	return principal.AllowsOperationPermission(p, pluginName, operation)
+}
+
+func (m *Manager) catalogSelectorConfig() invocation.CatalogSelectorConfig {
+	return invocation.CatalogSelectorConfig{
+		Authorizer:        m.authorizer,
+		Invoker:           m.invoker,
+		CatalogConnection: m.catalogConnection,
+		DefaultConnection: m.defaultConnection,
+	}
+}
+
+func executionRefOwnedBy(ref *coreagent.ExecutionReference, p *principal.Principal) bool {
+	if ref == nil || p == nil {
+		return false
+	}
+	subjectID := strings.TrimSpace(principalSubjectID(principal.Canonicalized(p)))
+	return subjectID != "" && strings.TrimSpace(ref.SubjectID) == subjectID
+}
+
+func executionRefActive(ref *coreagent.ExecutionReference) bool {
+	return ref != nil && (ref.RevokedAt == nil || ref.RevokedAt.IsZero())
+}
+
+func executionRefsByProvider(refs []*coreagent.ExecutionReference) map[string][]*coreagent.ExecutionReference {
+	if len(refs) == 0 {
+		return nil
+	}
+	out := make(map[string][]*coreagent.ExecutionReference)
+	for _, ref := range refs {
+		if ref == nil {
+			continue
+		}
+		providerName := strings.TrimSpace(ref.ProviderName)
+		if providerName == "" {
+			continue
+		}
+		out[providerName] = append(out[providerName], ref)
+	}
+	return out
+}
+
+func executionRefsByID(refs []*coreagent.ExecutionReference) map[string]*coreagent.ExecutionReference {
+	if len(refs) == 0 {
+		return nil
+	}
+	out := make(map[string]*coreagent.ExecutionReference, len(refs))
+	for _, ref := range refs {
+		if ref == nil {
+			continue
+		}
+		id := strings.TrimSpace(ref.ID)
+		if id == "" {
+			continue
+		}
+		out[id] = ref
+	}
+	return out
+}
+
+func normalizeProviderRun(providerName, runID string, run *coreagent.Run) (*coreagent.Run, error) {
+	if run == nil {
+		return nil, core.ErrNotFound
+	}
+	cloned := *run
+	if strings.TrimSpace(cloned.ID) == "" {
+		cloned.ID = strings.TrimSpace(runID)
+	}
+	if strings.TrimSpace(cloned.ID) != strings.TrimSpace(runID) {
+		return nil, fmt.Errorf("agent provider returned run id %q, want %q", cloned.ID, runID)
+	}
+	if strings.TrimSpace(cloned.ProviderName) == "" {
+		cloned.ProviderName = strings.TrimSpace(providerName)
+	}
+	return &cloned, nil
+}
+
+func operationInputSchema(op catalog.CatalogOperation) (map[string]any, error) {
+	if len(op.InputSchema) == 0 {
+		return nil, nil
+	}
+	var out map[string]any
+	if err := json.Unmarshal(op.InputSchema, &out); err != nil {
+		return nil, fmt.Errorf("decode %s input schema: %w", op.ID, err)
+	}
+	return out, nil
+}
+
+func agentToolID(pluginName, operation, connection, instance string) string {
+	id := strings.TrimSpace(pluginName) + "/" + strings.TrimSpace(operation)
+	if strings.TrimSpace(connection) != "" {
+		id += "?connection=" + strings.TrimSpace(connection)
+	}
+	if strings.TrimSpace(instance) != "" {
+		sep := "?"
+		if strings.Contains(id, "?") {
+			sep = "&"
+		}
+		id += sep + "instance=" + strings.TrimSpace(instance)
+	}
+	return id
+}
+
+func agentActorFromPrincipal(p *principal.Principal) coreagent.Actor {
+	p = principal.Canonicalized(p)
+	if p == nil {
+		return coreagent.Actor{}
+	}
+	return coreagent.Actor{
+		SubjectID:   strings.TrimSpace(p.SubjectID),
+		SubjectKind: string(p.Kind),
+		DisplayName: agentActorDisplayName(p),
+		AuthSource:  p.AuthSource(),
+	}
+}
+
+func agentActorDisplayName(p *principal.Principal) string {
+	if p == nil {
+		return ""
+	}
+	if value := strings.TrimSpace(p.DisplayName); value != "" {
+		return value
+	}
+	if p.Identity != nil {
+		return strings.TrimSpace(p.Identity.DisplayName)
+	}
+	return ""
+}
+
+func principalSubjectID(p *principal.Principal) string {
+	if p == nil {
+		return ""
+	}
+	return p.SubjectID
+}
+
+var _ Service = (*Manager)(nil)

--- a/gestaltd/internal/bootstrap/agent_runtime.go
+++ b/gestaltd/internal/bootstrap/agent_runtime.go
@@ -133,7 +133,6 @@ func (r *agentRuntime) DeleteTrackedRun(ctx context.Context, runID string) error
 	}
 	return runMetadata.Delete(ctx, runID)
 }
-
 func (r *agentRuntime) ResolveProvider(name string) (coreagent.Provider, error) {
 	if r == nil {
 		return nil, fmt.Errorf("agent runtime is not configured")

--- a/gestaltd/internal/bootstrap/bootstrap.go
+++ b/gestaltd/internal/bootstrap/bootstrap.go
@@ -18,6 +18,7 @@ import (
 	"github.com/valon-technologies/gestalt/server/core/indexeddb"
 	s3store "github.com/valon-technologies/gestalt/server/core/s3"
 	coreworkflow "github.com/valon-technologies/gestalt/server/core/workflow"
+	"github.com/valon-technologies/gestalt/server/internal/agentmanager"
 	"github.com/valon-technologies/gestalt/server/internal/authorization"
 	"github.com/valon-technologies/gestalt/server/internal/config"
 	"github.com/valon-technologies/gestalt/server/internal/coredata"
@@ -146,6 +147,7 @@ type Deps struct {
 	WorkflowRuntime       *workflowRuntime
 	AgentRuntime          *agentRuntime
 	WorkflowManager       workflowmanager.Service
+	AgentManager          agentmanager.Service
 	Egress                EgressDeps
 	AuthorizationProvider core.AuthorizationProvider
 	PluginInvoker         invocation.Invoker
@@ -201,6 +203,7 @@ type Result struct {
 	Providers             *registry.ProviderMap[core.Provider]
 	WorkflowControl       WorkflowControl
 	AgentControl          AgentControl
+	AgentManager          agentmanager.Service
 	ProvidersReady        <-chan struct{}
 	Authorizer            authorization.RuntimeAuthorizer
 	ConnectionAuth        func() map[string]map[string]OAuthHandler
@@ -816,8 +819,10 @@ func Bootstrap(ctx context.Context, cfg *config.Config, factories *FactoryRegist
 
 	pluginInvoker := newLazyInvoker()
 	workflowManager := newLazyWorkflowManager()
+	agentManager := newLazyAgentManager()
 	prepared.Deps.PluginInvoker = pluginInvoker
 	prepared.Deps.WorkflowManager = workflowManager
+	prepared.Deps.AgentManager = agentManager
 
 	providers, providersReady, connAuthResolver, err := buildProviders(ctx, cfg, factories, prepared.Deps)
 	if err != nil {
@@ -873,6 +878,16 @@ func Bootstrap(ctx context.Context, cfg *config.Config, factories *FactoryRegist
 		Authorizer:            authz,
 		DefaultConnection:     connMaps.DefaultConnection,
 		CatalogConnection:     connMaps.APIConnection,
+	}))
+	agentManager.SetTarget(agentmanager.New(agentmanager.Config{
+		Providers:         providers,
+		Agent:             prepared.Deps.AgentRuntime,
+		RunMetadata:       prepared.Services.AgentRunMetadata,
+		Invoker:           sharedInvoker,
+		Authorizer:        authz,
+		DefaultConnection: connMaps.DefaultConnection,
+		CatalogConnection: connMaps.APIConnection,
+		PluginInvokes:     agentPluginInvokes(cfg),
 	}))
 	extraWorkflows, err := buildWorkflows(ctx, cfg, factories, prepared.Deps)
 	if err != nil {
@@ -931,6 +946,7 @@ func Bootstrap(ctx context.Context, cfg *config.Config, factories *FactoryRegist
 		Providers:             providers,
 		WorkflowControl:       prepared.Deps.WorkflowRuntime,
 		AgentControl:          prepared.Deps.AgentRuntime,
+		AgentManager:          prepared.Deps.AgentManager,
 		ProvidersReady:        providersReady,
 		Authorizer:            authz,
 		ConnectionAuth:        connAuthResolver,
@@ -988,6 +1004,20 @@ func buildAgents(ctx context.Context, cfg *config.Config, factories *FactoryRegi
 		extraAgents = append(extraAgents, value)
 	}
 	return extraAgents, nil
+}
+
+func agentPluginInvokes(cfg *config.Config) map[string][]config.PluginInvocationDependency {
+	if cfg == nil || len(cfg.Plugins) == 0 {
+		return nil
+	}
+	out := make(map[string][]config.PluginInvocationDependency, len(cfg.Plugins))
+	for pluginName, entry := range cfg.Plugins {
+		if entry == nil || len(entry.Invokes) == 0 {
+			continue
+		}
+		out[pluginName] = append([]config.PluginInvocationDependency(nil), entry.Invokes...)
+	}
+	return out
 }
 
 func buildTelemetry(cfg *config.Config, factories *FactoryRegistry) (core.TelemetryProvider, error) {

--- a/gestaltd/internal/bootstrap/bootstrap_test.go
+++ b/gestaltd/internal/bootstrap/bootstrap_test.go
@@ -6,6 +6,7 @@ import (
 	"encoding/base64"
 	"encoding/hex"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"io"
 	"maps"
@@ -20,6 +21,7 @@ import (
 	"sync"
 	"sync/atomic"
 	"testing"
+	"time"
 
 	gestalt "github.com/valon-technologies/gestalt/sdk/go"
 	proto "github.com/valon-technologies/gestalt/sdk/go/gen/v1"
@@ -30,6 +32,7 @@ import (
 	s3store "github.com/valon-technologies/gestalt/server/core/s3"
 	coretesting "github.com/valon-technologies/gestalt/server/core/testing"
 	coreworkflow "github.com/valon-technologies/gestalt/server/core/workflow"
+	"github.com/valon-technologies/gestalt/server/internal/agentmanager"
 	"github.com/valon-technologies/gestalt/server/internal/authorization"
 	"github.com/valon-technologies/gestalt/server/internal/bootstrap"
 	"github.com/valon-technologies/gestalt/server/internal/config"
@@ -606,6 +609,202 @@ func (s *stubAgentProvider) CancelRequests() []coreagent.CancelRunRequest {
 	s.mu.Lock()
 	defer s.mu.Unlock()
 	return append([]coreagent.CancelRunRequest(nil), s.cancelRequests...)
+}
+
+type recordingAgentProvider struct {
+	mu               sync.Mutex
+	startRunRequests []coreagent.StartRunRequest
+	cancelRequests   []coreagent.CancelRunRequest
+	runs             map[string]*coreagent.Run
+}
+
+func newRecordingAgentProvider() *recordingAgentProvider {
+	return &recordingAgentProvider{runs: map[string]*coreagent.Run{}}
+}
+
+func (p *recordingAgentProvider) StartRun(_ context.Context, req coreagent.StartRunRequest) (*coreagent.Run, error) {
+	p.mu.Lock()
+	defer p.mu.Unlock()
+	p.startRunRequests = append(p.startRunRequests, req)
+	run := &coreagent.Run{
+		ID:           req.RunID,
+		ProviderName: req.ProviderName,
+		Status:       coreagent.RunStatusRunning,
+		ExecutionRef: req.ExecutionRef,
+		CreatedBy:    req.CreatedBy,
+	}
+	p.runs[req.RunID] = run
+	return run, nil
+}
+
+func (p *recordingAgentProvider) GetRun(_ context.Context, req coreagent.GetRunRequest) (*coreagent.Run, error) {
+	p.mu.Lock()
+	defer p.mu.Unlock()
+	run, ok := p.runs[req.RunID]
+	if !ok {
+		return nil, core.ErrNotFound
+	}
+	cloned := *run
+	return &cloned, nil
+}
+
+func (p *recordingAgentProvider) ListRuns(context.Context, coreagent.ListRunsRequest) ([]*coreagent.Run, error) {
+	p.mu.Lock()
+	defer p.mu.Unlock()
+	out := make([]*coreagent.Run, 0, len(p.runs))
+	for _, run := range p.runs {
+		cloned := *run
+		out = append(out, &cloned)
+	}
+	return out, nil
+}
+
+func (p *recordingAgentProvider) CancelRun(_ context.Context, req coreagent.CancelRunRequest) (*coreagent.Run, error) {
+	p.mu.Lock()
+	defer p.mu.Unlock()
+	p.cancelRequests = append(p.cancelRequests, req)
+	run, ok := p.runs[req.RunID]
+	if !ok {
+		return nil, core.ErrNotFound
+	}
+	cloned := *run
+	cloned.Status = coreagent.RunStatusCanceled
+	p.runs[req.RunID] = &cloned
+	return &cloned, nil
+}
+
+func (p *recordingAgentProvider) Ping(context.Context) error { return nil }
+func (p *recordingAgentProvider) Close() error               { return nil }
+
+type callbackAgentProvider struct {
+	mu               sync.Mutex
+	started          *providerhost.StartedHostServices
+	socketPath       string
+	startRunRequests []coreagent.StartRunRequest
+	cancelRequests   []coreagent.CancelRunRequest
+	toolBodies       []string
+	runs             map[string]*coreagent.Run
+}
+
+func newCallbackAgentProvider(started *providerhost.StartedHostServices) (*callbackAgentProvider, error) {
+	if started == nil {
+		return nil, fmt.Errorf("started host services are required")
+	}
+	var socketPath string
+	for _, binding := range started.Bindings() {
+		if binding.EnvVar == providerhost.DefaultAgentHostSocketEnv {
+			socketPath = binding.SocketPath
+			break
+		}
+	}
+	if strings.TrimSpace(socketPath) == "" {
+		return nil, fmt.Errorf("agent host socket binding is missing")
+	}
+	return &callbackAgentProvider{
+		started:    started,
+		socketPath: socketPath,
+		runs:       map[string]*coreagent.Run{},
+	}, nil
+}
+
+func (p *callbackAgentProvider) StartRun(ctx context.Context, req coreagent.StartRunRequest) (*coreagent.Run, error) {
+	p.mu.Lock()
+	p.startRunRequests = append(p.startRunRequests, req)
+	p.mu.Unlock()
+
+	outputBody := ""
+	if len(req.Tools) > 0 {
+		conn, err := grpc.NewClient(
+			"passthrough:///localhost",
+			grpc.WithContextDialer(func(ctx context.Context, _ string) (net.Conn, error) {
+				var d net.Dialer
+				return d.DialContext(ctx, "unix", p.socketPath)
+			}),
+			grpc.WithTransportCredentials(insecure.NewCredentials()),
+		)
+		if err != nil {
+			return nil, fmt.Errorf("dial agent host: %w", err)
+		}
+		defer func() { _ = conn.Close() }()
+
+		resp, err := proto.NewAgentHostClient(conn).ExecuteTool(ctx, &proto.ExecuteAgentToolRequest{
+			RunId:      req.RunID,
+			ToolCallId: "tool-call-1",
+			ToolId:     req.Tools[0].ID,
+			Arguments: func() *structpb.Struct {
+				value, err := structpb.NewStruct(map[string]any{"taskId": "task-123"})
+				if err != nil {
+					panic(err)
+				}
+				return value
+			}(),
+		})
+		if err != nil {
+			return nil, err
+		}
+		outputBody = resp.GetBody()
+		p.mu.Lock()
+		p.toolBodies = append(p.toolBodies, outputBody)
+		p.mu.Unlock()
+	}
+
+	run := &coreagent.Run{
+		ID:           req.RunID,
+		ProviderName: req.ProviderName,
+		Status:       coreagent.RunStatusSucceeded,
+		OutputText:   outputBody,
+		ExecutionRef: req.ExecutionRef,
+		CreatedBy:    req.CreatedBy,
+	}
+	p.mu.Lock()
+	p.runs[req.RunID] = run
+	p.mu.Unlock()
+	return run, nil
+}
+
+func (p *callbackAgentProvider) GetRun(_ context.Context, req coreagent.GetRunRequest) (*coreagent.Run, error) {
+	p.mu.Lock()
+	defer p.mu.Unlock()
+	run, ok := p.runs[req.RunID]
+	if !ok {
+		return nil, core.ErrNotFound
+	}
+	cloned := *run
+	return &cloned, nil
+}
+
+func (p *callbackAgentProvider) ListRuns(context.Context, coreagent.ListRunsRequest) ([]*coreagent.Run, error) {
+	p.mu.Lock()
+	defer p.mu.Unlock()
+	out := make([]*coreagent.Run, 0, len(p.runs))
+	for _, run := range p.runs {
+		cloned := *run
+		out = append(out, &cloned)
+	}
+	return out, nil
+}
+
+func (p *callbackAgentProvider) CancelRun(_ context.Context, req coreagent.CancelRunRequest) (*coreagent.Run, error) {
+	p.mu.Lock()
+	defer p.mu.Unlock()
+	p.cancelRequests = append(p.cancelRequests, req)
+	run, ok := p.runs[req.RunID]
+	if !ok {
+		return nil, core.ErrNotFound
+	}
+	cloned := *run
+	cloned.Status = coreagent.RunStatusCanceled
+	p.runs[req.RunID] = &cloned
+	return &cloned, nil
+}
+
+func (p *callbackAgentProvider) Ping(context.Context) error { return nil }
+
+func (p *callbackAgentProvider) Close() error {
+	if p == nil || p.started == nil {
+		return nil
+	}
+	return p.started.Close()
 }
 
 type generatedIDAgentProvider struct {
@@ -1555,6 +1754,308 @@ func TestBootstrapPassesConfiguredAgentResourceNamesToProviders(t *testing.T) {
 	}
 	if run == nil || run.ID != "run-1" {
 		t.Fatalf("run = %#v, want ID run-1", run)
+	}
+}
+
+func TestBootstrapAgentManagerRunPersistsMetadataForToolCallbacks(t *testing.T) {
+	t.Parallel()
+
+	cfg := validConfig()
+	cfg.Providers.Agent = map[string]*config.ProviderEntry{
+		"managed": {
+			Source:  config.ProviderSource{Path: "stub"},
+			Default: true,
+		},
+	}
+
+	factories := validFactories()
+	factories.Builtins = append(factories.Builtins, &coretesting.StubIntegration{
+		N:        "roadmap",
+		ConnMode: core.ConnectionModeNone,
+		CatalogVal: &catalog.Catalog{
+			Name: "roadmap",
+			Operations: []catalog.CatalogOperation{{
+				ID:          "sync",
+				Method:      http.MethodPost,
+				Title:       "Sync roadmap",
+				Description: "Sync the roadmap state",
+				InputSchema: json.RawMessage(`{"type":"object","properties":{"taskId":{"type":"string"}}}`),
+			}},
+		},
+		ExecuteFn: func(ctx context.Context, operation string, params map[string]any, _ string) (*core.OperationResult, error) {
+			body, err := json.Marshal(map[string]any{
+				"operation": operation,
+				"subject":   principal.FromContext(ctx).SubjectID,
+				"taskId":    params["taskId"],
+			})
+			if err != nil {
+				return nil, err
+			}
+			return &core.OperationResult{Status: http.StatusAccepted, Body: string(body)}, nil
+		},
+	})
+
+	var provider *callbackAgentProvider
+	factories.Agent = func(_ context.Context, _ string, _ yaml.Node, hostServices []providerhost.HostService, _ bootstrap.Deps) (coreagent.Provider, error) {
+		started, err := providerhost.StartHostServices(hostServices)
+		if err != nil {
+			return nil, err
+		}
+		value, err := newCallbackAgentProvider(started)
+		if err != nil {
+			_ = started.Close()
+			return nil, err
+		}
+		provider = value
+		return value, nil
+	}
+
+	result, err := bootstrap.Bootstrap(context.Background(), cfg, factories)
+	if err != nil {
+		t.Fatalf("Bootstrap: %v", err)
+	}
+	defer func() { _ = result.Close(context.Background()) }()
+	<-result.ProvidersReady
+
+	perms := principal.CompilePermissions([]core.AccessPermission{{
+		Plugin:     "roadmap",
+		Operations: []string{"sync"},
+	}})
+	p := &principal.Principal{
+		SubjectID:        "user:user-123",
+		UserID:           "user-123",
+		Kind:             principal.KindUser,
+		Source:           principal.SourceSession,
+		TokenPermissions: perms,
+		Scopes:           principal.PermissionPlugins(perms),
+	}
+	ctx := principal.WithPrincipal(context.Background(), p)
+
+	req := coreagent.ManagerRunRequest{
+		ProviderName:   "managed",
+		IdempotencyKey: "demo-idempotency-key",
+		Messages:       []coreagent.Message{{Role: "user", Text: "sync it"}},
+		ToolRefs: []coreagent.ToolRef{{
+			PluginName: "roadmap",
+			Operation:  "sync",
+			Title:      "Roadmap sync",
+		}},
+	}
+
+	first, err := result.AgentManager.Run(ctx, p, req)
+	if err != nil {
+		t.Fatalf("AgentManager.Run(first): %v", err)
+	}
+	second, err := result.AgentManager.Run(ctx, p, req)
+	if err != nil {
+		t.Fatalf("AgentManager.Run(second): %v", err)
+	}
+	if first.Run == nil || second.Run == nil {
+		t.Fatalf("managed runs = %#v / %#v", first, second)
+	}
+	if first.Run.ID != second.Run.ID {
+		t.Fatalf("idempotent run ids = (%q, %q), want identical ids", first.Run.ID, second.Run.ID)
+	}
+
+	provider.mu.Lock()
+	startRunCount := len(provider.startRunRequests)
+	startReq := provider.startRunRequests[0]
+	toolBodies := append([]string(nil), provider.toolBodies...)
+	provider.mu.Unlock()
+
+	if startRunCount != 1 {
+		t.Fatalf("StartRun count = %d, want 1", startRunCount)
+	}
+	if startReq.RunID != first.Run.ID {
+		t.Fatalf("StartRun run_id = %q, want %q", startReq.RunID, first.Run.ID)
+	}
+	if startReq.ExecutionRef != first.Run.ID {
+		t.Fatalf("StartRun execution_ref = %q, want %q", startReq.ExecutionRef, first.Run.ID)
+	}
+	if startReq.CreatedBy.SubjectID != p.SubjectID {
+		t.Fatalf("StartRun created_by.subject_id = %q, want %q", startReq.CreatedBy.SubjectID, p.SubjectID)
+	}
+	if len(startReq.Tools) != 1 {
+		t.Fatalf("StartRun tools = %#v, want 1 tool", startReq.Tools)
+	}
+	if startReq.Tools[0].Target.PluginName != "roadmap" || startReq.Tools[0].Target.Operation != "sync" {
+		t.Fatalf("StartRun tool target = %#v", startReq.Tools[0].Target)
+	}
+	if len(toolBodies) != 1 || !strings.Contains(toolBodies[0], `"subject":"user:user-123"`) || !strings.Contains(toolBodies[0], `"taskId":"task-123"`) {
+		t.Fatalf("tool callback bodies = %#v", toolBodies)
+	}
+
+	ref, err := result.Services.AgentRunMetadata.Get(context.Background(), first.Run.ID)
+	if err != nil {
+		t.Fatalf("AgentRunMetadata.Get: %v", err)
+	}
+	if ref.IdempotencyKey != "demo-idempotency-key" {
+		t.Fatalf("stored idempotency key = %q, want %q", ref.IdempotencyKey, "demo-idempotency-key")
+	}
+	if len(ref.Tools) != 1 || ref.Tools[0].ID != startReq.Tools[0].ID {
+		t.Fatalf("stored tools = %#v, want tool id %q", ref.Tools, startReq.Tools[0].ID)
+	}
+}
+
+func TestBootstrapAgentManagerRunReturnsInProgressForClaimedIdempotencyWithoutMetadata(t *testing.T) {
+	t.Parallel()
+
+	cfg := validConfig()
+	cfg.Providers.Agent = map[string]*config.ProviderEntry{
+		"managed": {
+			Source:  config.ProviderSource{Path: "stub"},
+			Default: true,
+		},
+	}
+
+	provider := newRecordingAgentProvider()
+	factories := validFactories()
+	factories.Agent = func(context.Context, string, yaml.Node, []providerhost.HostService, bootstrap.Deps) (coreagent.Provider, error) {
+		return provider, nil
+	}
+
+	result, err := bootstrap.Bootstrap(context.Background(), cfg, factories)
+	if err != nil {
+		t.Fatalf("Bootstrap: %v", err)
+	}
+	defer func() { _ = result.Close(context.Background()) }()
+	<-result.ProvidersReady
+
+	p := &principal.Principal{
+		SubjectID: "user:user-123",
+		UserID:    "user-123",
+		Kind:      principal.KindUser,
+		Source:    principal.SourceSession,
+	}
+	ctx := principal.WithPrincipal(context.Background(), p)
+
+	const runID = "pending-run"
+	claimedRunID, claimed, err := result.Services.AgentRunMetadata.ClaimIdempotency(context.Background(), p.SubjectID, "managed", "pending-key", runID, time.Now())
+	if err != nil {
+		t.Fatalf("ClaimIdempotency: %v", err)
+	}
+	if !claimed || claimedRunID != runID {
+		t.Fatalf("ClaimIdempotency = (%q, %t), want (%q, true)", claimedRunID, claimed, runID)
+	}
+
+	_, err = result.AgentManager.Run(ctx, p, coreagent.ManagerRunRequest{
+		ProviderName:   "managed",
+		IdempotencyKey: "pending-key",
+		Messages:       []coreagent.Message{{Role: "user", Text: "continue"}},
+	})
+	if !errors.Is(err, agentmanager.ErrAgentRunCreationInProgress) {
+		t.Fatalf("AgentManager.Run error = %v, want %v", err, agentmanager.ErrAgentRunCreationInProgress)
+	}
+
+	provider.mu.Lock()
+	startRunCount := len(provider.startRunRequests)
+	provider.mu.Unlock()
+	if startRunCount != 0 {
+		t.Fatalf("StartRun count = %d, want 0", startRunCount)
+	}
+}
+
+func TestBootstrapAgentManagerIdempotentReplayDoesNotDeleteMetadataWhenCallerLosesToolAccess(t *testing.T) {
+	t.Parallel()
+
+	cfg := validConfig()
+	cfg.Providers.Agent = map[string]*config.ProviderEntry{
+		"managed": {
+			Source:  config.ProviderSource{Path: "stub"},
+			Default: true,
+		},
+	}
+
+	factories := validFactories()
+	factories.Builtins = append(factories.Builtins, &coretesting.StubIntegration{
+		N:        "roadmap",
+		ConnMode: core.ConnectionModeNone,
+		CatalogVal: &catalog.Catalog{
+			Name: "roadmap",
+			Operations: []catalog.CatalogOperation{{
+				ID:     "sync",
+				Method: http.MethodPost,
+			}},
+		},
+		ExecuteFn: func(context.Context, string, map[string]any, string) (*core.OperationResult, error) {
+			return &core.OperationResult{Status: http.StatusAccepted}, nil
+		},
+	})
+
+	provider := newRecordingAgentProvider()
+	factories.Agent = func(context.Context, string, yaml.Node, []providerhost.HostService, bootstrap.Deps) (coreagent.Provider, error) {
+		return provider, nil
+	}
+
+	result, err := bootstrap.Bootstrap(context.Background(), cfg, factories)
+	if err != nil {
+		t.Fatalf("Bootstrap: %v", err)
+	}
+	defer func() { _ = result.Close(context.Background()) }()
+	<-result.ProvidersReady
+
+	perms := principal.CompilePermissions([]core.AccessPermission{{
+		Plugin:     "roadmap",
+		Operations: []string{"sync"},
+	}})
+	full := &principal.Principal{
+		SubjectID:        "user:user-123",
+		UserID:           "user-123",
+		Kind:             principal.KindUser,
+		Source:           principal.SourceSession,
+		TokenPermissions: perms,
+		Scopes:           principal.PermissionPlugins(perms),
+	}
+	fullCtx := principal.WithPrincipal(context.Background(), full)
+
+	first, err := result.AgentManager.Run(fullCtx, full, coreagent.ManagerRunRequest{
+		ProviderName:   "managed",
+		IdempotencyKey: "same-run",
+		Messages:       []coreagent.Message{{Role: "user", Text: "sync it"}},
+		ToolRefs: []coreagent.ToolRef{{
+			PluginName: "roadmap",
+			Operation:  "sync",
+		}},
+	})
+	if err != nil {
+		t.Fatalf("AgentManager.Run(first): %v", err)
+	}
+	if first.Run == nil {
+		t.Fatalf("AgentManager.Run(first) returned nil run: %#v", first)
+	}
+
+	restricted := &principal.Principal{
+		SubjectID:        "user:user-123",
+		UserID:           "user-123",
+		Kind:             principal.KindUser,
+		Source:           principal.SourceSession,
+		TokenPermissions: principal.PermissionSet{},
+		Scopes:           []string{},
+	}
+	restrictedCtx := principal.WithPrincipal(context.Background(), restricted)
+
+	_, err = result.AgentManager.Run(restrictedCtx, restricted, coreagent.ManagerRunRequest{
+		ProviderName:   "managed",
+		IdempotencyKey: "same-run",
+		Messages:       []coreagent.Message{{Role: "user", Text: "sync it"}},
+	})
+	if !errors.Is(err, core.ErrNotFound) {
+		t.Fatalf("AgentManager.Run(replay) error = %v, want %v", err, core.ErrNotFound)
+	}
+
+	ref, err := result.Services.AgentRunMetadata.Get(context.Background(), first.Run.ID)
+	if err != nil {
+		t.Fatalf("AgentRunMetadata.Get: %v", err)
+	}
+	if ref.ID != first.Run.ID {
+		t.Fatalf("stored run id = %q, want %q", ref.ID, first.Run.ID)
+	}
+
+	provider.mu.Lock()
+	startRunCount := len(provider.startRunRequests)
+	provider.mu.Unlock()
+	if startRunCount != 1 {
+		t.Fatalf("StartRun count = %d, want 1", startRunCount)
 	}
 }
 

--- a/gestaltd/internal/bootstrap/executable_plugin_test.go
+++ b/gestaltd/internal/bootstrap/executable_plugin_test.go
@@ -31,6 +31,7 @@ import (
 	gestalt "github.com/valon-technologies/gestalt/sdk/go"
 	proto "github.com/valon-technologies/gestalt/sdk/go/gen/v1"
 	"github.com/valon-technologies/gestalt/server/core"
+	coreagent "github.com/valon-technologies/gestalt/server/core/agent"
 	corecache "github.com/valon-technologies/gestalt/server/core/cache"
 	"github.com/valon-technologies/gestalt/server/core/catalog"
 	corecrypto "github.com/valon-technologies/gestalt/server/core/crypto"
@@ -38,6 +39,7 @@ import (
 	s3store "github.com/valon-technologies/gestalt/server/core/s3"
 	coretesting "github.com/valon-technologies/gestalt/server/core/testing"
 	coreworkflow "github.com/valon-technologies/gestalt/server/core/workflow"
+	"github.com/valon-technologies/gestalt/server/internal/agentmanager"
 	"github.com/valon-technologies/gestalt/server/internal/authorization"
 	"github.com/valon-technologies/gestalt/server/internal/config"
 	"github.com/valon-technologies/gestalt/server/internal/coredata"
@@ -48,6 +50,7 @@ import (
 	"github.com/valon-technologies/gestalt/server/internal/principal"
 	"github.com/valon-technologies/gestalt/server/internal/providerhost"
 	"github.com/valon-technologies/gestalt/server/internal/providerpkg"
+	"github.com/valon-technologies/gestalt/server/internal/registry"
 	"github.com/valon-technologies/gestalt/server/internal/testutil"
 	"github.com/valon-technologies/gestalt/server/internal/workflowmanager"
 	providermanifestv1 "github.com/valon-technologies/gestalt/server/sdk/providermanifest/v1"
@@ -462,6 +465,10 @@ func (r *capturingBundlePluginRuntime) startFakeHostedPlugin(req pluginruntime.S
 					Method: http.MethodPost,
 				},
 				{
+					ID:     "agent_manager_roundtrip",
+					Method: http.MethodPost,
+				},
+				{
 					ID:     "authorization_roundtrip",
 					Method: http.MethodPost,
 				},
@@ -547,6 +554,16 @@ func (r *capturingBundlePluginRuntime) startFakeHostedPlugin(req pluginruntime.S
 				return &core.OperationResult{Status: http.StatusOK, Body: string(body)}, nil
 			case "workflow_manager_roundtrip":
 				record, err := fakeHostedWorkflowManagerRoundTrip(providerhost.InvocationTokenFromContext(ctx), env)
+				if err != nil {
+					return nil, err
+				}
+				body, err := json.Marshal(record)
+				if err != nil {
+					return nil, err
+				}
+				return &core.OperationResult{Status: http.StatusOK, Body: string(body)}, nil
+			case "agent_manager_roundtrip":
+				record, err := fakeHostedAgentManagerRoundTrip(providerhost.InvocationTokenFromContext(ctx), env)
 				if err != nil {
 					return nil, err
 				}
@@ -993,6 +1010,70 @@ func fakeHostedAuthorizationRoundTrip(env map[string]string) (map[string]any, er
 		"subject_id":   resp.GetSubjects()[0].GetId(),
 		"subject_type": resp.GetSubjects()[0].GetType(),
 		"capabilities": meta.GetCapabilities(),
+	}, nil
+}
+
+func fakeHostedAgentManagerRoundTrip(invocationToken string, env map[string]string) (map[string]any, error) {
+	target := strings.TrimSpace(env[providerhost.DefaultAgentManagerSocketEnv])
+	if target == "" {
+		return nil, fmt.Errorf("missing agent manager relay target in %s", providerhost.DefaultAgentManagerSocketEnv)
+	}
+	token := strings.TrimSpace(env[providerhost.AgentManagerSocketTokenEnv()])
+	if token == "" {
+		return nil, fmt.Errorf("missing agent manager relay token in %s", providerhost.AgentManagerSocketTokenEnv())
+	}
+	address := strings.TrimSpace(strings.TrimPrefix(target, "tls://"))
+	if address == "" || address == target {
+		return nil, fmt.Errorf("unsupported agent manager relay target %q", target)
+	}
+
+	conn, err := grpc.NewClient(
+		address,
+		grpc.WithTransportCredentials(credentials.NewTLS(&tls.Config{
+			InsecureSkipVerify: true,
+			MinVersion:         tls.VersionTLS12,
+			NextProtos:         []string{"h2"},
+		})),
+	)
+	if err != nil {
+		return nil, fmt.Errorf("connect agent manager relay: %w", err)
+	}
+	defer func() { _ = conn.Close() }()
+
+	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	defer cancel()
+	ctx = metadata.NewOutgoingContext(ctx, metadata.Pairs(providerhost.HostServiceRelayTokenHeader, token))
+
+	client := proto.NewAgentManagerHostClient(conn)
+	created, err := client.Run(ctx, &proto.AgentManagerRunRequest{
+		InvocationToken: invocationToken,
+		ProviderName:    "managed",
+		IdempotencyKey:  "plugin-agent-run",
+		ToolSource:      proto.AgentToolSourceMode_AGENT_TOOL_SOURCE_MODE_INHERIT_INVOKES,
+		Messages: []*proto.AgentMessage{{
+			Role: "user",
+			Text: "sync it",
+		}},
+	})
+	if err != nil {
+		return nil, fmt.Errorf("create agent run: %w", err)
+	}
+	runID := strings.TrimSpace(created.GetRun().GetId())
+	if runID == "" {
+		return nil, fmt.Errorf("agent manager create did not return a run id")
+	}
+	fetched, err := client.GetRun(ctx, &proto.AgentManagerGetRunRequest{
+		InvocationToken: invocationToken,
+		RunId:           runID,
+	})
+	if err != nil {
+		return nil, fmt.Errorf("get agent run: %w", err)
+	}
+
+	return map[string]any{
+		"provider_name": created.GetProviderName(),
+		"run_id":        runID,
+		"status":        fetched.GetRun().GetStatus().String(),
 	}, nil
 }
 
@@ -1449,6 +1530,72 @@ func (m *stubWorkflowManager) Subjects() []string {
 	defer m.mu.Unlock()
 	return append([]string(nil), m.subjects...)
 }
+
+type stubAgentRunManagerProvider struct {
+	mu               sync.Mutex
+	startRunRequests []coreagent.StartRunRequest
+	runs             map[string]*coreagent.Run
+}
+
+func newStubAgentRunManagerProvider() *stubAgentRunManagerProvider {
+	return &stubAgentRunManagerProvider{
+		runs: map[string]*coreagent.Run{},
+	}
+}
+
+func (p *stubAgentRunManagerProvider) StartRun(_ context.Context, req coreagent.StartRunRequest) (*coreagent.Run, error) {
+	p.mu.Lock()
+	defer p.mu.Unlock()
+	p.startRunRequests = append(p.startRunRequests, req)
+	run := &coreagent.Run{
+		ID:           req.RunID,
+		ProviderName: req.ProviderName,
+		Status:       coreagent.RunStatusRunning,
+		ExecutionRef: req.ExecutionRef,
+		CreatedBy:    req.CreatedBy,
+	}
+	p.runs[req.RunID] = run
+	cloned := *run
+	return &cloned, nil
+}
+
+func (p *stubAgentRunManagerProvider) GetRun(_ context.Context, req coreagent.GetRunRequest) (*coreagent.Run, error) {
+	p.mu.Lock()
+	defer p.mu.Unlock()
+	run, ok := p.runs[req.RunID]
+	if !ok {
+		return nil, core.ErrNotFound
+	}
+	cloned := *run
+	return &cloned, nil
+}
+
+func (p *stubAgentRunManagerProvider) ListRuns(context.Context, coreagent.ListRunsRequest) ([]*coreagent.Run, error) {
+	p.mu.Lock()
+	defer p.mu.Unlock()
+	out := make([]*coreagent.Run, 0, len(p.runs))
+	for _, run := range p.runs {
+		cloned := *run
+		out = append(out, &cloned)
+	}
+	return out, nil
+}
+
+func (p *stubAgentRunManagerProvider) CancelRun(_ context.Context, req coreagent.CancelRunRequest) (*coreagent.Run, error) {
+	p.mu.Lock()
+	defer p.mu.Unlock()
+	run, ok := p.runs[req.RunID]
+	if !ok {
+		return nil, core.ErrNotFound
+	}
+	cloned := *run
+	cloned.Status = coreagent.RunStatusCanceled
+	p.runs[req.RunID] = &cloned
+	return &cloned, nil
+}
+
+func (p *stubAgentRunManagerProvider) Ping(context.Context) error { return nil }
+func (p *stubAgentRunManagerProvider) Close() error               { return nil }
 
 func cloneManagedSchedule(value *workflowmanager.ManagedSchedule) *workflowmanager.ManagedSchedule {
 	if value == nil {
@@ -3057,6 +3204,231 @@ func TestPluginWorkflowManagerExposeHostSocketEnv(t *testing.T) {
 	}
 	if !env.Found || env.Value == "" {
 		t.Fatalf("workflow manager env %q should be set for executable plugins", providerhost.DefaultWorkflowManagerSocketEnv)
+	}
+}
+
+func TestPluginAgentManagerExposeHostSocketEnv(t *testing.T) {
+	t.Parallel()
+
+	bin := buildEchoPluginBinary(t)
+	manifestRoot := writeStaticCatalog(t, &catalog.Catalog{
+		Name: "echo",
+		Operations: []catalog.CatalogOperation{
+			{ID: "read_env", Method: http.MethodGet, Parameters: []catalog.CatalogParameter{{Name: "name", Type: "string", Required: true}}},
+		},
+	})
+	manifest := newExecutableManifest("Echo", "Agent manager host env")
+
+	cfg := &config.Config{
+		Plugins: map[string]*config.ProviderEntry{
+			"echo": {
+				Command:              bin,
+				Args:                 []string{"provider"},
+				ResolvedManifest:     manifest,
+				ResolvedManifestPath: filepath.Join(manifestRoot, "manifest.yaml"),
+			},
+		},
+	}
+
+	providers, _, err := buildProvidersStrict(context.Background(), cfg, NewFactoryRegistry(), Deps{
+		AgentRuntime: &agentRuntime{providers: map[string]coreagent.Provider{}},
+	})
+	if err != nil {
+		t.Fatalf("buildProvidersStrict: %v", err)
+	}
+	defer func() { _ = CloseProviders(providers) }()
+
+	prov, err := providers.Get("echo")
+	if err != nil {
+		t.Fatalf("providers.Get(echo): %v", err)
+	}
+
+	result, err := prov.Execute(context.Background(), "read_env", map[string]any{"name": providerhost.DefaultAgentManagerSocketEnv}, "")
+	if err != nil {
+		t.Fatalf("Execute read_env: %v", err)
+	}
+
+	var env struct {
+		Value string `json:"value"`
+		Found bool   `json:"found"`
+	}
+	if err := json.Unmarshal([]byte(result.Body), &env); err != nil {
+		t.Fatalf("json.Unmarshal: %v", err)
+	}
+	if !env.Found || env.Value == "" {
+		t.Fatalf("agent manager env %q should be set for executable plugins", providerhost.DefaultAgentManagerSocketEnv)
+	}
+}
+
+func TestPluginAgentManagerRunUsesInheritedInvokesAndRequestContext(t *testing.T) {
+	t.Parallel()
+
+	secret := []byte("0123456789abcdef0123456789abcdef")
+	relaySrv := httptest.NewUnstartedServer(newRuntimeRelayTestHandler(t, secret))
+	relaySrv.EnableHTTP2 = true
+	relaySrv.StartTLS()
+	testutil.CloseOnCleanup(t, relaySrv)
+
+	bin := buildEchoPluginBinary(t)
+	manifestRoot := writeStaticCatalog(t, &catalog.Catalog{
+		Name: "echoext",
+		Operations: []catalog.CatalogOperation{
+			{ID: "agent_manager_roundtrip", Method: http.MethodPost},
+		},
+	})
+	manifest := newExecutableManifest("Echo", "Agent manager run roundtrip")
+	services := coretesting.NewStubServices(t)
+
+	pluginProviders := registry.New()
+	if err := pluginProviders.Providers.Register("roadmap", &coretesting.StubIntegration{
+		N:        "roadmap",
+		ConnMode: core.ConnectionModeNone,
+		CatalogVal: &catalog.Catalog{
+			Name: "roadmap",
+			Operations: []catalog.CatalogOperation{{
+				ID:          "sync",
+				Method:      http.MethodPost,
+				Title:       "Sync roadmap",
+				Description: "Sync the roadmap state",
+			}},
+		},
+		ExecuteFn: func(ctx context.Context, operation string, params map[string]any, _ string) (*core.OperationResult, error) {
+			body, err := json.Marshal(map[string]any{
+				"operation": operation,
+				"subject":   principal.FromContext(ctx).SubjectID,
+				"taskId":    params["taskId"],
+			})
+			if err != nil {
+				return nil, err
+			}
+			return &core.OperationResult{Status: http.StatusAccepted, Body: string(body)}, nil
+		},
+	}); err != nil {
+		t.Fatalf("Register roadmap provider: %v", err)
+	}
+
+	agentProvider := newStubAgentRunManagerProvider()
+	agentRuntime := &agentRuntime{defaultProviderName: "managed", providers: map[string]coreagent.Provider{"managed": agentProvider}}
+	broker := invocation.NewBroker(&pluginProviders.Providers, services.Users, services.Tokens)
+	agentRuntime.SetRunMetadata(services.AgentRunMetadata)
+	agentRuntime.SetInvoker(broker)
+	manager := agentmanager.New(agentmanager.Config{
+		Providers:   &pluginProviders.Providers,
+		Agent:       agentRuntime,
+		RunMetadata: services.AgentRunMetadata,
+		Invoker:     broker,
+		PluginInvokes: map[string][]config.PluginInvocationDependency{
+			"echoext": {{
+				Plugin:    "roadmap",
+				Operation: "sync",
+			}},
+		},
+	})
+
+	runtimeProvider := newCapturingBundlePluginRuntime()
+	runtimeProvider.capabilities.HostnameProxyEgress = true
+	runtimeProvider.capabilities.HostPathExecution = true
+	runtimeProvider.fakeHosted = true
+	factories := NewFactoryRegistry()
+	factories.Runtime = func(context.Context, string, *config.RuntimeProviderEntry, Deps) (pluginruntime.Provider, error) {
+		return runtimeProvider, nil
+	}
+
+	cfg := &config.Config{
+		Server: config.ServerConfig{
+			Runtime: config.ServerRuntimeConfig{Provider: "hosted"},
+		},
+		Runtime: config.RuntimeConfig{
+			Providers: map[string]*config.RuntimeProviderEntry{
+				"hosted": {
+					Driver: config.RuntimeProviderDriver("capture"),
+				},
+			},
+		},
+		Plugins: map[string]*config.ProviderEntry{
+			"echoext": {
+				Command:              bin,
+				Args:                 []string{"provider"},
+				ResolvedManifest:     manifest,
+				ResolvedManifestPath: filepath.Join(manifestRoot, "manifest.yaml"),
+				Runtime:              &config.PluginRuntimeConfig{},
+				Invokes: []config.PluginInvocationDependency{{
+					Plugin:    "roadmap",
+					Operation: "sync",
+				}},
+			},
+		},
+	}
+
+	deps := Deps{
+		BaseURL:       relaySrv.URL,
+		EncryptionKey: secret,
+		Services:      services,
+		AgentRuntime:  agentRuntime,
+		AgentManager:  manager,
+	}
+	deps.PluginRuntimeRegistry = newPluginRuntimeRegistry(cfg, factories.Runtime, deps)
+
+	providers, _, err := buildProvidersStrict(context.Background(), cfg, factories, deps)
+	if err != nil {
+		t.Fatalf("buildProvidersStrict: %v", err)
+	}
+	defer func() { _ = CloseProviders(providers) }()
+
+	prov, err := providers.Get("echoext")
+	if err != nil {
+		t.Fatalf("providers.Get(echoext): %v", err)
+	}
+
+	perms := principal.CompilePermissions([]core.AccessPermission{{
+		Plugin:     "roadmap",
+		Operations: []string{"sync"},
+	}})
+	ctx := principal.WithPrincipal(context.Background(), &principal.Principal{
+		SubjectID:        "user:user-123",
+		UserID:           "user-123",
+		Kind:             principal.KindUser,
+		Source:           principal.SourceSession,
+		TokenPermissions: perms,
+		Scopes:           append([]string{"echoext"}, principal.PermissionPlugins(perms)...),
+	})
+
+	result, err := prov.Execute(ctx, "agent_manager_roundtrip", nil, "")
+	if err != nil {
+		t.Fatalf("Execute(agent_manager_roundtrip): %v", err)
+	}
+
+	var roundTrip struct {
+		ProviderName string `json:"provider_name"`
+		RunID        string `json:"run_id"`
+		Status       string `json:"status"`
+	}
+	if err := json.Unmarshal([]byte(result.Body), &roundTrip); err != nil {
+		t.Fatalf("json.Unmarshal: %v", err)
+	}
+	if roundTrip.ProviderName != "managed" || roundTrip.RunID == "" {
+		t.Fatalf("agent roundtrip result = %+v", roundTrip)
+	}
+
+	agentProvider.mu.Lock()
+	startRunCount := len(agentProvider.startRunRequests)
+	startReq := agentProvider.startRunRequests[0]
+	agentProvider.mu.Unlock()
+
+	if startRunCount != 1 {
+		t.Fatalf("StartRun count = %d, want 1", startRunCount)
+	}
+	if startReq.IdempotencyKey != "plugin-agent-run" {
+		t.Fatalf("StartRun idempotency_key = %q, want %q", startReq.IdempotencyKey, "plugin-agent-run")
+	}
+	if startReq.CreatedBy.SubjectID != "user:user-123" {
+		t.Fatalf("StartRun created_by.subject_id = %q, want %q", startReq.CreatedBy.SubjectID, "user:user-123")
+	}
+	if len(startReq.Tools) != 1 {
+		t.Fatalf("StartRun tools = %#v, want 1 inherited tool", startReq.Tools)
+	}
+	if startReq.Tools[0].Target.PluginName != "roadmap" || startReq.Tools[0].Target.Operation != "sync" {
+		t.Fatalf("StartRun tool target = %#v", startReq.Tools[0].Target)
 	}
 }
 

--- a/gestaltd/internal/bootstrap/lazy_agent_manager.go
+++ b/gestaltd/internal/bootstrap/lazy_agent_manager.go
@@ -1,0 +1,70 @@
+package bootstrap
+
+import (
+	"context"
+	"fmt"
+	"sync"
+
+	coreagent "github.com/valon-technologies/gestalt/server/core/agent"
+	"github.com/valon-technologies/gestalt/server/internal/agentmanager"
+	"github.com/valon-technologies/gestalt/server/internal/principal"
+)
+
+type lazyAgentManager struct {
+	mu     sync.RWMutex
+	target agentmanager.Service
+}
+
+func newLazyAgentManager() *lazyAgentManager {
+	return &lazyAgentManager{}
+}
+
+func (l *lazyAgentManager) SetTarget(target agentmanager.Service) {
+	l.mu.Lock()
+	defer l.mu.Unlock()
+	l.target = target
+}
+
+func (l *lazyAgentManager) Run(ctx context.Context, p *principal.Principal, req coreagent.ManagerRunRequest) (*coreagent.ManagedRun, error) {
+	target, err := l.current()
+	if err != nil {
+		return nil, err
+	}
+	return target.Run(ctx, p, req)
+}
+
+func (l *lazyAgentManager) GetRun(ctx context.Context, p *principal.Principal, runID string) (*coreagent.ManagedRun, error) {
+	target, err := l.current()
+	if err != nil {
+		return nil, err
+	}
+	return target.GetRun(ctx, p, runID)
+}
+
+func (l *lazyAgentManager) ListRuns(ctx context.Context, p *principal.Principal) ([]*coreagent.ManagedRun, error) {
+	target, err := l.current()
+	if err != nil {
+		return nil, err
+	}
+	return target.ListRuns(ctx, p)
+}
+
+func (l *lazyAgentManager) CancelRun(ctx context.Context, p *principal.Principal, runID, reason string) (*coreagent.ManagedRun, error) {
+	target, err := l.current()
+	if err != nil {
+		return nil, err
+	}
+	return target.CancelRun(ctx, p, runID, reason)
+}
+
+func (l *lazyAgentManager) current() (agentmanager.Service, error) {
+	l.mu.RLock()
+	target := l.target
+	l.mu.RUnlock()
+	if target == nil {
+		return nil, fmt.Errorf("agent manager is not available")
+	}
+	return target, nil
+}
+
+var _ agentmanager.Service = (*lazyAgentManager)(nil)

--- a/gestaltd/internal/bootstrap/provider_build.go
+++ b/gestaltd/internal/bootstrap/provider_build.go
@@ -19,6 +19,7 @@ import (
 
 	proto "github.com/valon-technologies/gestalt/sdk/go/gen/v1"
 	"github.com/valon-technologies/gestalt/server/core"
+	coreagent "github.com/valon-technologies/gestalt/server/core/agent"
 	corecache "github.com/valon-technologies/gestalt/server/core/cache"
 	"github.com/valon-technologies/gestalt/server/core/catalog"
 	"github.com/valon-technologies/gestalt/server/core/indexeddb"
@@ -1126,8 +1127,9 @@ func buildPluginRuntimeHostServices(name string, entry *config.ProviderEntry, de
 		hostServices = append(hostServices, services...)
 	}
 	includeWorkflowManager := deps.WorkflowManager != nil || (deps.WorkflowRuntime != nil && deps.WorkflowRuntime.HasConfiguredProviders())
+	includeAgentManager := deps.AgentManager != nil || deps.AgentRuntime != nil
 	needInvocationTokens := includeHostServices || len(entry.Invokes) > 0
-	if includeWorkflowManager {
+	if includeWorkflowManager || includeAgentManager {
 		needInvocationTokens = true
 	}
 	if needInvocationTokens {
@@ -1138,6 +1140,9 @@ func buildPluginRuntimeHostServices(name string, entry *config.ProviderEntry, de
 	}
 	if includeWorkflowManager {
 		hostServices = append(hostServices, buildPluginWorkflowManagerHostService(name, deps, invTokens))
+	}
+	if includeAgentManager {
+		hostServices = append(hostServices, buildPluginAgentManagerHostService(name, deps, invTokens))
 	}
 	if deps.AuthorizationProvider != nil && len(entry.EffectiveHTTPBindings()) > 0 {
 		hostServices = append(hostServices, buildPluginAuthorizationHostService(deps.AuthorizationProvider))
@@ -1481,6 +1486,19 @@ func buildPluginWorkflowManagerHostService(pluginName string, deps Deps, tokens 
 	}
 }
 
+func buildPluginAgentManagerHostService(pluginName string, deps Deps, tokens *providerhost.InvocationTokenManager) providerhost.HostService {
+	manager := deps.AgentManager
+	if manager == nil {
+		manager = unavailableAgentManager{}
+	}
+	return providerhost.HostService{
+		EnvVar: providerhost.DefaultAgentManagerSocketEnv,
+		Register: func(srv *grpc.Server) {
+			proto.RegisterAgentManagerHostServer(srv, providerhost.NewAgentManagerServer(pluginName, manager, tokens))
+		},
+	}
+}
+
 func buildPluginAuthorizationHostService(provider core.AuthorizationProvider) providerhost.HostService {
 	return providerhost.HostService{
 		EnvVar: providerhost.DefaultAuthorizationSocketEnv,
@@ -1585,6 +1603,24 @@ func (unavailableWorkflowManager) CancelRun(context.Context, *principal.Principa
 
 func (unavailableWorkflowManager) PublishEvent(context.Context, *principal.Principal, coreworkflow.Event) (coreworkflow.Event, error) {
 	return coreworkflow.Event{}, fmt.Errorf("workflow manager is not available")
+}
+
+type unavailableAgentManager struct{}
+
+func (unavailableAgentManager) Run(context.Context, *principal.Principal, coreagent.ManagerRunRequest) (*coreagent.ManagedRun, error) {
+	return nil, fmt.Errorf("agent manager is not available")
+}
+
+func (unavailableAgentManager) GetRun(context.Context, *principal.Principal, string) (*coreagent.ManagedRun, error) {
+	return nil, fmt.Errorf("agent manager is not available")
+}
+
+func (unavailableAgentManager) ListRuns(context.Context, *principal.Principal) ([]*coreagent.ManagedRun, error) {
+	return nil, fmt.Errorf("agent manager is not available")
+}
+
+func (unavailableAgentManager) CancelRun(context.Context, *principal.Principal, string, string) (*coreagent.ManagedRun, error) {
+	return nil, fmt.Errorf("agent manager is not available")
 }
 
 func buildPluginScopedIndexedDB(pluginName string, effective config.EffectivePluginIndexedDB, deps Deps) (indexeddb.IndexedDB, error) {

--- a/gestaltd/internal/coredata/agent_run_metadata.go
+++ b/gestaltd/internal/coredata/agent_run_metadata.go
@@ -261,6 +261,9 @@ func marshalJSON(value any) (string, error) {
 	if err != nil {
 		return "", err
 	}
+	if string(raw) == "null" {
+		return "", nil
+	}
 	return string(raw), nil
 }
 

--- a/gestaltd/internal/providerhost/agent_manager_server.go
+++ b/gestaltd/internal/providerhost/agent_manager_server.go
@@ -2,10 +2,14 @@ package providerhost
 
 import (
 	"context"
+	"errors"
 	"strings"
 
 	proto "github.com/valon-technologies/gestalt/sdk/go/gen/v1"
+	"github.com/valon-technologies/gestalt/server/core"
 	coreagent "github.com/valon-technologies/gestalt/server/core/agent"
+	"github.com/valon-technologies/gestalt/server/internal/agentmanager"
+	"github.com/valon-technologies/gestalt/server/internal/invocation"
 	"github.com/valon-technologies/gestalt/server/internal/principal"
 	"google.golang.org/grpc/codes"
 	"google.golang.org/grpc/status"
@@ -46,16 +50,17 @@ func (s *AgentManagerServer) Run(ctx context.Context, req *proto.AgentManagerRun
 		return nil, err
 	}
 	managed, err := s.manager.Run(restoreInvocationTokenContext(ctx, tokenCtx, ""), tokenCtx.principal, coreagent.ManagerRunRequest{
-		ProviderName:    strings.TrimSpace(req.GetProviderName()),
-		Model:           strings.TrimSpace(req.GetModel()),
-		Messages:        agentMessagesFromProto(req.GetMessages()),
-		ToolRefs:        agentToolRefsFromProto(req.GetToolRefs()),
-		ToolSource:      agentToolSourceModeFromProto(req.GetToolSource()),
-		ResponseSchema:  mapFromStruct(req.GetResponseSchema()),
-		SessionRef:      strings.TrimSpace(req.GetSessionRef()),
-		Metadata:        mapFromStruct(req.GetMetadata()),
-		ProviderOptions: mapFromStruct(req.GetProviderOptions()),
-		IdempotencyKey:  strings.TrimSpace(req.GetIdempotencyKey()),
+		CallerPluginName: strings.TrimSpace(s.pluginName),
+		ProviderName:     strings.TrimSpace(req.GetProviderName()),
+		Model:            strings.TrimSpace(req.GetModel()),
+		Messages:         agentMessagesFromProto(req.GetMessages()),
+		ToolRefs:         agentToolRefsFromProto(req.GetToolRefs()),
+		ToolSource:       agentToolSourceModeFromProto(req.GetToolSource()),
+		ResponseSchema:   mapFromStruct(req.GetResponseSchema()),
+		SessionRef:       strings.TrimSpace(req.GetSessionRef()),
+		Metadata:         mapFromStruct(req.GetMetadata()),
+		ProviderOptions:  mapFromStruct(req.GetProviderOptions()),
+		IdempotencyKey:   strings.TrimSpace(req.GetIdempotencyKey()),
 	})
 	if err != nil {
 		return nil, agentManagerStatusError(err)
@@ -167,7 +172,24 @@ func agentManagerStatusError(err error) error {
 	if existing, ok := status.FromError(err); ok {
 		return existing.Err()
 	}
-	return status.Error(codes.Unknown, err.Error())
+	switch {
+	case errors.Is(err, agentmanager.ErrAgentRunCreationInProgress):
+		return status.Error(codes.Aborted, err.Error())
+	case errors.Is(err, agentmanager.ErrAgentNotConfigured), errors.Is(err, agentmanager.ErrAgentRunMetadataNotConfigured), errors.Is(err, invocation.ErrNoToken), errors.Is(err, invocation.ErrAmbiguousInstance), errors.Is(err, invocation.ErrUserResolution):
+		return status.Error(codes.FailedPrecondition, err.Error())
+	case errors.Is(err, agentmanager.ErrAgentCallerPluginRequired), errors.Is(err, agentmanager.ErrAgentInheritedSurfaceTool):
+		return status.Error(codes.InvalidArgument, err.Error())
+	case errors.Is(err, agentmanager.ErrAgentSubjectRequired), errors.Is(err, invocation.ErrNotAuthenticated):
+		return status.Error(codes.Unauthenticated, err.Error())
+	case errors.Is(err, invocation.ErrInternal):
+		return status.Error(codes.Internal, err.Error())
+	case errors.Is(err, invocation.ErrAuthorizationDenied), errors.Is(err, invocation.ErrScopeDenied):
+		return status.Error(codes.PermissionDenied, err.Error())
+	case errors.Is(err, invocation.ErrProviderNotFound), errors.Is(err, invocation.ErrOperationNotFound), errors.Is(err, core.ErrNotFound):
+		return status.Error(codes.NotFound, err.Error())
+	default:
+		return status.Error(codes.Unknown, err.Error())
+	}
 }
 
 var _ proto.AgentManagerHostServer = (*AgentManagerServer)(nil)


### PR DESCRIPTION
## Summary
This turns `agent` into a usable host primitive on top of the provider/runtime work from PR #1286:
- adds a daemon-side manager over host-owned run metadata
- makes run creation idempotent
- resolves explicit tools plus inherited plugin `invokes`
- authorizes provider -> host tool callbacks against the stored run ceiling

## New Interfaces
- `core/agent.ManagerRunRequest`
  - adds `caller_plugin_name`, `idempotency_key`, `tool_refs`, and `tool_source`
- `internal/agentmanager.Service`
  - `Run(ctx, principal, req)`
  - `GetRun(ctx, principal, runID)`
  - `ListRuns(ctx, principal)`
  - `CancelRun(ctx, principal, runID, reason)`
- `internal/coredata.AgentRunMetadataService`
  - durable `run_id -> provider + subject + permissions + tools + idempotency_key`
- `bootstrap.agentRuntime.ExecuteTool(ctx, req)`
  - validates `provider_name`, `run_id`, and `tool_id` before invoking the bound plugin operation
- `providerhost.AgentManagerServer`
  - forwards `tool_refs` and `tool_source` across the host socket

## Examples
### YAML
```yaml
plugins:
  release_agent:
    invokes:
      - plugin: roadmap
        operation: sync
      - plugin: incidents
        operation: summarize
```

### JSON: manager run input
```json
{
  "providerName": "managed",
  "model": "gpt-5.4",
  "toolSource": "inherit_invokes",
  "toolRefs": [
    { "pluginName": "slack", "operation": "post_message" }
  ],
  "idempotencyKey": "release-agent-42",
  "messages": [
    { "role": "system", "text": "Keep it terse." },
    { "role": "user", "text": "Sync the roadmap and summarize incidents." }
  ]
}
```

### JSON: provider tool callback
```json
{
  "providerName": "managed",
  "runId": "run-123",
  "toolCallId": "call-1",
  "toolId": "roadmap/sync",
  "arguments": {
    "taskId": "task-123"
  }
}
```

### JSON: tool callback response
```json
{
  "status": 200,
  "body": "{\"ok\":true,\"taskId\":\"task-123\",\"synced\":true}"
}
```

### Golang
```go
client, err := req.AgentManager()
if err != nil {
	return err
}

run, err := client.Run(ctx, &proto.AgentManagerRunRequest{
	ProviderName:   "managed",
	Model:          "gpt-5.4",
	IdempotencyKey: "release-agent-42",
	ToolSource:     proto.AgentToolSourceMode_AGENT_TOOL_SOURCE_MODE_INHERIT_INVOKES,
	Messages: []*proto.AgentMessage{
		{Role: "user", Text: "Sync the roadmap and summarize incidents."},
	},
	ToolRefs: []*proto.AgentToolRef{
		{PluginName: "slack", Operation: "post_message"},
	},
})
if err != nil {
	return err
}

log.Printf("run=%s provider=%s status=%s", run.GetRun().GetId(), run.GetProviderName(), run.GetRun().GetStatus().String())
```

### TypeScript
```ts
import { AgentManager, AgentToolSourceMode } from "@valon-technologies/gestalt";

const manager = new AgentManager(request);
const run = await manager.run({
  providerName: "managed",
  model: "gpt-5.4",
  idempotencyKey: "release-agent-42",
  toolSource: AgentToolSourceMode.INHERIT_INVOKES,
  messages: [
    { role: "user", text: "Sync the roadmap and summarize incidents." },
  ],
  toolRefs: [
    { pluginName: "slack", operation: "post_message" },
  ],
});

console.log(run.run?.id, run.providerName, run.run?.status);
```

No `stdin`/`stdout` example here because the manager and tool callback contracts are host-socket RPC interfaces.

## What Changed
- Added `internal/agentmanager` with provider selection, run metadata persistence, idempotency handling, inherited `invokes` resolution, and run inspection/cancel support.
- Added durable agent run metadata storage in `internal/coredata`.
- Wired `bootstrap` to create a lazy agent manager, attach shared invoker + metadata to the agent runtime, and expose a real `AgentManagerHost` socket to plugins.
- Wired `AgentHost.ExecuteTool` through the runtime so providers can synchronously call bound plugin operations during `StartRun`.
- Added integration-style bootstrap coverage for:
  - manager-created run metadata surviving synchronous provider tool callbacks
  - idempotent `Run` collapsing duplicate creation
  - hosted plugin access to `AgentManagerHost` with inherited `invokes`

## Verification
- `go test ./internal/bootstrap -run 'TestBootstrapAgentManagerRunPersistsMetadataForToolCallbacks|TestPluginAgentManagerExposeHostSocketEnv|TestPluginAgentManagerRunUsesInheritedInvokesAndRequestContext'`
- `go test ./internal/providerhost ./internal/coredata ./internal/agentmanager`
- `go test ./internal/bootstrap ./internal/providerhost ./internal/coredata ./cmd/gestaltd`
