### PR TITLE
runtime: add public hostname egress proxy for hosted runtimes

### DIFF
--- a/gestaltd/internal/bootstrap/executable_plugin_test.go
+++ b/gestaltd/internal/bootstrap/executable_plugin_test.go
@@ -4,6 +4,7 @@ import (
 	"bytes"
 	"context"
 	"crypto/tls"
+	"encoding/base64"
 	"encoding/json"
 	"errors"
 	"fmt"
@@ -464,6 +465,13 @@ func (r *capturingBundlePluginRuntime) startFakeHostedPlugin(req pluginruntime.S
 					ID:     "authorization_roundtrip",
 					Method: http.MethodPost,
 				},
+				{
+					ID:     "make_http_request",
+					Method: http.MethodGet,
+					Parameters: []catalog.CatalogParameter{
+						{Name: "url", Type: "string", Required: true},
+					},
+				},
 			},
 		},
 		ExecuteFn: func(ctx context.Context, operation string, params map[string]any, _ string) (*core.OperationResult, error) {
@@ -549,6 +557,17 @@ func (r *capturingBundlePluginRuntime) startFakeHostedPlugin(req pluginruntime.S
 				return &core.OperationResult{Status: http.StatusOK, Body: string(body)}, nil
 			case "authorization_roundtrip":
 				record, err := fakeHostedAuthorizationRoundTrip(env)
+				if err != nil {
+					return nil, err
+				}
+				body, err := json.Marshal(record)
+				if err != nil {
+					return nil, err
+				}
+				return &core.OperationResult{Status: http.StatusOK, Body: string(body)}, nil
+			case "make_http_request":
+				targetURL, _ := params["url"].(string)
+				record, err := fakeHostedMakeHTTPRequest(targetURL, env)
 				if err != nil {
 					return nil, err
 				}
@@ -704,6 +723,33 @@ func fakeHostedCacheRoundTrip(key, value, binding string, env map[string]string)
 	return map[string]any{
 		"found": resp.GetFound(),
 		"value": string(resp.GetValue()),
+	}, nil
+}
+
+func fakeHostedMakeHTTPRequest(targetURL string, env map[string]string) (map[string]any, error) {
+	client := &http.Client{}
+	if proxyURL := strings.TrimSpace(env["HTTP_PROXY"]); proxyURL != "" {
+		parsed, err := url.Parse(proxyURL)
+		if err != nil {
+			return nil, fmt.Errorf("parse HTTP_PROXY: %w", err)
+		}
+		client.Transport = &http.Transport{
+			Proxy:           http.ProxyURL(parsed),
+			TLSClientConfig: &tls.Config{InsecureSkipVerify: true, MinVersion: tls.VersionTLS12},
+		}
+	}
+	resp, err := client.Get(targetURL)
+	if err != nil {
+		return nil, fmt.Errorf("get via proxy: %w", err)
+	}
+	defer func() { _ = resp.Body.Close() }()
+	body, err := io.ReadAll(resp.Body)
+	if err != nil {
+		return nil, fmt.Errorf("read response body: %w", err)
+	}
+	return map[string]any{
+		"status": resp.StatusCode,
+		"body":   string(body),
 	}, nil
 }
 
@@ -4972,6 +5018,10 @@ func TestPluginRuntimeConfigUsesPublicS3RelayWithoutHostServiceTunnelCapability(
 	runtimeProvider.capabilities.HostnameProxyEgress = true
 	runtimeProvider.capabilities.HostPathExecution = true
 	runtimeProvider.fakeHosted = true
+	runtimeProvider.capabilities.HostPathExecution = true
+	runtimeProvider.fakeHosted = true
+	runtimeProvider.capabilities.HostPathExecution = true
+	runtimeProvider.fakeHosted = true
 	factories := NewFactoryRegistry()
 	factories.Runtime = func(context.Context, string, *config.RuntimeProviderEntry, Deps) (pluginruntime.Provider, error) {
 		return runtimeProvider, nil
@@ -6223,6 +6273,168 @@ func newRuntimeRelayTestHandler(t *testing.T, stateSecret []byte) http.Handler {
 	})
 }
 
+func newRuntimeEgressProxyTestHandler(t *testing.T, stateSecret []byte) http.Handler {
+	t.Helper()
+
+	tokenManager, err := providerhost.NewEgressProxyTokenManager(stateSecret)
+	if err != nil {
+		t.Fatalf("NewEgressProxyTokenManager: %v", err)
+	}
+	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		token := extractRuntimeProxyAuthorizationToken(r.Header.Get("Proxy-Authorization"))
+		target, err := tokenManager.ResolveToken(token)
+		if err != nil {
+			http.Error(w, "invalid egress proxy token", http.StatusProxyAuthRequired)
+			return
+		}
+		host := runtimeProxyTargetHost(r)
+		if host == "" {
+			http.Error(w, "proxy target host is required", http.StatusBadRequest)
+			return
+		}
+		if err := egress.CheckHost(target.AllowedHosts, host, target.DefaultAction); err != nil {
+			http.Error(w, err.Error(), http.StatusForbidden)
+			return
+		}
+		newRuntimeEgressProxy().ServeHTTP(w, r)
+	})
+}
+
+func extractRuntimeProxyAuthorizationToken(header string) string {
+	header = strings.TrimSpace(header)
+	if header == "" {
+		return ""
+	}
+	if token, ok := strings.CutPrefix(header, "Basic "); ok {
+		decoded, err := base64.StdEncoding.DecodeString(strings.TrimSpace(token))
+		if err != nil {
+			return ""
+		}
+		user, pass, found := strings.Cut(string(decoded), ":")
+		if found && strings.TrimSpace(pass) != "" {
+			return strings.TrimSpace(pass)
+		}
+		return strings.TrimSpace(user)
+	}
+	return ""
+}
+
+func runtimeProxyTargetHost(r *http.Request) string {
+	if r == nil {
+		return ""
+	}
+	var host string
+	switch {
+	case r.Method == http.MethodConnect:
+		host = strings.TrimSpace(r.Host)
+	case r.URL != nil && r.URL.Host != "":
+		host = strings.TrimSpace(r.URL.Hostname())
+	default:
+		host = strings.TrimSpace(r.Host)
+	}
+	if host == "" {
+		return ""
+	}
+	if h, _, err := net.SplitHostPort(host); err == nil {
+		return h
+	}
+	return host
+}
+
+func newRuntimeEgressProxy() http.Handler {
+	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.Method == http.MethodConnect {
+			runtimeHandleProxyConnect(w, r)
+			return
+		}
+		runtimeHandleProxyHTTP(w, r)
+	})
+}
+
+func runtimeHandleProxyHTTP(w http.ResponseWriter, r *http.Request) {
+	transport := &http.Transport{}
+	defer transport.CloseIdleConnections()
+
+	out := r.Clone(r.Context())
+	out.RequestURI = ""
+	out.Header = out.Header.Clone()
+	out.Header.Del("Proxy-Authorization")
+	if out.URL == nil || !out.URL.IsAbs() {
+		http.Error(w, "proxy target URL is required", http.StatusBadRequest)
+		return
+	}
+	out.Host = out.URL.Host
+
+	resp, err := transport.RoundTrip(out)
+	if err != nil {
+		http.Error(w, err.Error(), http.StatusBadGateway)
+		return
+	}
+	defer func() { _ = resp.Body.Close() }()
+
+	for k, vv := range resp.Header {
+		for _, v := range vv {
+			w.Header().Add(k, v)
+		}
+	}
+	w.WriteHeader(resp.StatusCode)
+	_, _ = io.Copy(w, resp.Body)
+}
+
+func runtimeHandleProxyConnect(w http.ResponseWriter, r *http.Request) {
+	hijacker, ok := w.(http.Hijacker)
+	if !ok {
+		http.Error(w, "hijacking not supported", http.StatusInternalServerError)
+		return
+	}
+
+	targetAddr := strings.TrimSpace(r.Host)
+	if targetAddr == "" {
+		http.Error(w, "proxy target address is required", http.StatusBadRequest)
+		return
+	}
+	if _, _, err := net.SplitHostPort(targetAddr); err != nil {
+		targetAddr = net.JoinHostPort(targetAddr, "443")
+	}
+	targetConn, err := net.DialTimeout("tcp", targetAddr, 10*time.Second)
+	if err != nil {
+		http.Error(w, err.Error(), http.StatusBadGateway)
+		return
+	}
+
+	w.WriteHeader(http.StatusOK)
+	clientConn, _, err := hijacker.Hijack()
+	if err != nil {
+		_ = targetConn.Close()
+		return
+	}
+	deadline := time.Now().Add(10 * time.Minute)
+	_ = clientConn.SetDeadline(deadline)
+	_ = targetConn.SetDeadline(deadline)
+
+	done := make(chan struct{}, 2)
+	go func() {
+		_, _ = io.Copy(targetConn, clientConn)
+		closeRuntimeProxyWrite(targetConn)
+		done <- struct{}{}
+	}()
+	go func() {
+		_, _ = io.Copy(clientConn, targetConn)
+		closeRuntimeProxyWrite(clientConn)
+		done <- struct{}{}
+	}()
+	<-done
+	<-done
+	_ = clientConn.Close()
+	_ = targetConn.Close()
+}
+
+func closeRuntimeProxyWrite(c net.Conn) {
+	if closeWriter, ok := c.(interface{ CloseWrite() error }); ok {
+		_ = closeWriter.CloseWrite()
+	}
+}
+
 func runtimeRelayMethodAllowed(path, methodPrefix string) bool {
 	methodPrefix = strings.TrimSpace(methodPrefix)
 	if methodPrefix == "" {
@@ -6545,6 +6757,196 @@ func TestPluginRuntimePublicAuthorizationRelayRoundTripsThroughHostedPlugin(t *t
 	}
 	if got := bindRequests[0].Relay.DialTarget; !strings.HasPrefix(got, "tls://") {
 		t.Fatalf("BindHostService(%s) relay target = %q, want tls relay target", bindRequests[0].EnvVar, got)
+	}
+}
+
+func TestPluginRuntimeConfigInjectsPublicEgressProxyWithoutHostServiceTunnelCapability(t *testing.T) {
+	t.Parallel()
+
+	bin := buildEchoPluginBinary(t)
+	manifestRoot := writeStaticCatalog(t, &catalog.Catalog{
+		Name: "echoext",
+		Operations: []catalog.CatalogOperation{
+			{ID: "read_env", Method: http.MethodGet, Parameters: []catalog.CatalogParameter{{Name: "name", Type: "string", Required: true}}},
+		},
+	})
+	manifest := newExecutableManifest("Echo", "Echoes back the input parameters")
+	runtimeProvider := newCapturingBundlePluginRuntime()
+	runtimeProvider.capabilities.HostnameProxyEgress = true
+	runtimeProvider.capabilities.HostPathExecution = true
+	runtimeProvider.fakeHosted = true
+	factories := NewFactoryRegistry()
+	factories.Runtime = func(context.Context, string, *config.RuntimeProviderEntry, Deps) (pluginruntime.Provider, error) {
+		return runtimeProvider, nil
+	}
+	cfg := &config.Config{
+		Server: config.ServerConfig{
+			Runtime: config.ServerRuntimeConfig{Provider: "hosted"},
+			Egress:  config.EgressConfig{DefaultAction: string(egress.PolicyDeny)},
+		},
+		Runtime: config.RuntimeConfig{
+			Providers: map[string]*config.RuntimeProviderEntry{
+				"hosted": {
+					Driver: config.RuntimeProviderDriver("capture"),
+				},
+			},
+		},
+		Plugins: map[string]*config.ProviderEntry{
+			"echoext": {
+				Command:              bin,
+				Args:                 []string{"provider"},
+				ResolvedManifest:     manifest,
+				ResolvedManifestPath: filepath.Join(manifestRoot, "manifest.yaml"),
+				Runtime:              &config.PluginRuntimeConfig{},
+				AllowedHosts:         []string{"api.github.com"},
+			},
+		},
+	}
+	deps := Deps{
+		BaseURL:       "https://gestalt.example.test",
+		EncryptionKey: []byte("0123456789abcdef0123456789abcdef"),
+		Egress:        EgressDeps{DefaultAction: egress.PolicyDeny},
+	}
+	deps.PluginRuntimeRegistry = newPluginRuntimeRegistry(cfg, factories.Runtime, deps)
+
+	providers, _, err := buildProvidersStrict(context.Background(), cfg, factories, deps)
+	if err != nil {
+		t.Fatalf("buildProvidersStrict: %v", err)
+	}
+	t.Cleanup(func() { _ = CloseProviders(providers) })
+
+	startRequests := runtimeProvider.startPluginRequestsCopy()
+	if len(startRequests) != 1 {
+		t.Fatalf("StartPlugin requests = %d, want 1", len(startRequests))
+	}
+	httpProxy := startRequests[0].Env["HTTP_PROXY"]
+	httpsProxy := startRequests[0].Env["HTTPS_PROXY"]
+	if httpProxy == "" {
+		t.Fatal("StartPlugin env should include HTTP_PROXY")
+	}
+	if httpsProxy == "" {
+		t.Fatal("StartPlugin env should include HTTPS_PROXY")
+	}
+	if httpProxy != httpsProxy {
+		t.Fatalf("HTTP_PROXY = %q, HTTPS_PROXY = %q, want matching values", httpProxy, httpsProxy)
+	}
+	parsed, err := url.Parse(httpProxy)
+	if err != nil {
+		t.Fatalf("parse HTTP_PROXY: %v", err)
+	}
+	if parsed.Scheme != "https" {
+		t.Fatalf("HTTP_PROXY scheme = %q, want https", parsed.Scheme)
+	}
+	if parsed.Host != "gestalt.example.test" {
+		t.Fatalf("HTTP_PROXY host = %q, want gestalt.example.test", parsed.Host)
+	}
+	if parsed.User == nil {
+		t.Fatal("HTTP_PROXY should include relay credentials")
+	}
+	if got := startRequests[0].AllowedHosts; !slices.Equal(got, []string{"api.github.com"}) {
+		t.Fatalf("StartPlugin allowed hosts = %#v, want original allowedHosts only", got)
+	}
+}
+
+func TestPluginRuntimePublicEgressProxyRoundTripsThroughHostedPlugin(t *testing.T) {
+	t.Parallel()
+
+	secret := []byte("0123456789abcdef0123456789abcdef")
+	proxySrv := httptest.NewUnstartedServer(newRuntimeEgressProxyTestHandler(t, secret))
+	proxySrv.EnableHTTP2 = true
+	proxySrv.StartTLS()
+	testutil.CloseOnCleanup(t, proxySrv)
+
+	targetSrv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if got := r.URL.Path; got != "/proxy-test" {
+			t.Fatalf("target path = %q, want /proxy-test", got)
+		}
+		_, _ = io.WriteString(w, "egress-proxy-ok")
+	}))
+	testutil.CloseOnCleanup(t, targetSrv)
+
+	bin := buildEchoPluginBinary(t)
+	manifestRoot := writeStaticCatalog(t, &catalog.Catalog{
+		Name: "echoext",
+		Operations: []catalog.CatalogOperation{
+			{ID: "make_http_request", Method: http.MethodGet, Parameters: []catalog.CatalogParameter{{Name: "url", Type: "string", Required: true}}},
+		},
+	})
+	manifest := newExecutableManifest("Echo", "Hosted egress proxy roundtrip")
+	runtimeProvider := newCapturingBundlePluginRuntime()
+	runtimeProvider.capabilities.HostnameProxyEgress = true
+	runtimeProvider.capabilities.HostPathExecution = true
+	runtimeProvider.fakeHosted = true
+	factories := NewFactoryRegistry()
+	factories.Runtime = func(context.Context, string, *config.RuntimeProviderEntry, Deps) (pluginruntime.Provider, error) {
+		return runtimeProvider, nil
+	}
+	cfg := &config.Config{
+		Server: config.ServerConfig{
+			Runtime: config.ServerRuntimeConfig{Provider: "hosted"},
+		},
+		Runtime: config.RuntimeConfig{
+			Providers: map[string]*config.RuntimeProviderEntry{
+				"hosted": {
+					Driver: config.RuntimeProviderDriver("capture"),
+				},
+			},
+		},
+		Plugins: map[string]*config.ProviderEntry{
+			"echoext": {
+				Command:              bin,
+				Args:                 []string{"provider"},
+				ResolvedManifest:     manifest,
+				ResolvedManifestPath: filepath.Join(manifestRoot, "manifest.yaml"),
+				Runtime:              &config.PluginRuntimeConfig{},
+				AllowedHosts:         []string{"127.0.0.1", "localhost"},
+			},
+		},
+	}
+	deps := Deps{
+		BaseURL:       proxySrv.URL,
+		EncryptionKey: secret,
+	}
+	deps.PluginRuntimeRegistry = newPluginRuntimeRegistry(cfg, factories.Runtime, deps)
+
+	providers, _, err := buildProvidersStrict(context.Background(), cfg, factories, deps)
+	if err != nil {
+		t.Fatalf("buildProvidersStrict: %v", err)
+	}
+	t.Cleanup(func() { _ = CloseProviders(providers) })
+
+	prov, err := providers.Get("echoext")
+	if err != nil {
+		t.Fatalf("providers.Get: %v", err)
+	}
+	result, err := prov.Execute(context.Background(), "make_http_request", map[string]any{"url": targetSrv.URL + "/proxy-test"}, "")
+	if err != nil {
+		t.Fatalf("Execute make_http_request: %v", err)
+	}
+
+	var body struct {
+		Status int    `json:"status"`
+		Body   string `json:"body"`
+	}
+	if err := json.Unmarshal([]byte(result.Body), &body); err != nil {
+		t.Fatalf("unmarshal make_http_request: %v", err)
+	}
+	if body.Status != http.StatusOK {
+		t.Fatalf("result status = %d, want %d (body=%s)", body.Status, http.StatusOK, body.Body)
+	}
+	if body.Body != "egress-proxy-ok" {
+		t.Fatalf("result body = %q, want %q", body.Body, "egress-proxy-ok")
+	}
+
+	startRequests := runtimeProvider.startPluginRequestsCopy()
+	if len(startRequests) != 1 {
+		t.Fatalf("StartPlugin requests = %d, want 1", len(startRequests))
+	}
+	if got := startRequests[0].Env["HTTP_PROXY"]; got == "" {
+		t.Fatal("StartPlugin env should include HTTP_PROXY")
+	}
+	if got := startRequests[0].Env["HTTPS_PROXY"]; got == "" {
+		t.Fatal("StartPlugin env should include HTTPS_PROXY")
 	}
 }
 

--- a/gestaltd/internal/bootstrap/provider_build.go
+++ b/gestaltd/internal/bootstrap/provider_build.go
@@ -876,6 +876,18 @@ func buildPluginProvider(ctx context.Context, name string, entry *config.Provide
 		}
 		allowedHosts = appendAllowedHost(allowedHosts, relayHost)
 	}
+	if requiresPluginRuntimePublicEgressProxy(entry, deps, runtimeCapabilities) {
+		proxyEnv, err := buildPluginRuntimePublicEgressProxy(name, sessionID, entry.AllowedHosts, deps.Egress.DefaultAction, deps)
+		if err != nil {
+			return nil, err
+		}
+		if len(proxyEnv) > 0 {
+			if startEnv == nil {
+				startEnv = make(map[string]string, len(proxyEnv))
+			}
+			maps.Copy(startEnv, proxyEnv)
+		}
+	}
 
 	hostedPlugin, err := runtimeProvider.StartPlugin(ctx, pluginruntime.StartPluginRequest{
 		SessionID:     sessionID,
@@ -947,7 +959,10 @@ type pluginRuntimeCapabilityRequirements struct {
 	HostnameProxyEgress bool
 }
 
-const pluginRuntimeHostServiceRelayTokenTTL = 30 * 24 * time.Hour
+const (
+	pluginRuntimeHostServiceRelayTokenTTL = 30 * 24 * time.Hour
+	pluginRuntimeEgressProxyTokenTTL      = 30 * 24 * time.Hour
+)
 
 func pluginRuntimeRequirementsForPlugin(name string, entry *config.ProviderEntry, deps Deps) (pluginRuntimeCapabilityRequirements, error) {
 	if entry == nil {
@@ -1197,6 +1212,43 @@ func buildPluginRuntimeHostServiceBinding(pluginName, sessionID string, hostServ
 	}, nil, "", nil
 }
 
+func requiresPluginRuntimePublicEgressProxy(entry *config.ProviderEntry, deps Deps, caps pluginruntime.Capabilities) bool {
+	if caps.HostServiceTunnels {
+		return false
+	}
+	return len(entry.AllowedHosts) > 0 || deps.Egress.DefaultAction == egress.PolicyDeny
+}
+
+func buildPluginRuntimePublicEgressProxy(pluginName, sessionID string, allowedHosts []string, defaultAction egress.PolicyAction, deps Deps) (map[string]string, error) {
+	if strings.TrimSpace(deps.BaseURL) == "" || len(deps.EncryptionKey) == 0 {
+		return nil, fmt.Errorf("plugin %q requires server.baseURL and server.encryptionKey to enforce hostname-based egress on hosted runtimes without host service tunnels", pluginName)
+	}
+	proxyBaseURL, _, err := pluginRuntimePublicProxyBaseURL(deps.BaseURL)
+	if err != nil {
+		return nil, err
+	}
+	tokenManager, err := providerhost.NewEgressProxyTokenManager(deps.EncryptionKey)
+	if err != nil {
+		return nil, fmt.Errorf("init egress proxy tokens: %w", err)
+	}
+	token, err := tokenManager.MintToken(providerhost.EgressProxyTokenRequest{
+		PluginName:    pluginName,
+		SessionID:     sessionID,
+		AllowedHosts:  slices.Clone(allowedHosts),
+		DefaultAction: defaultAction,
+		TTL:           pluginRuntimeEgressProxyTokenTTL,
+	})
+	if err != nil {
+		return nil, fmt.Errorf("mint public egress proxy token: %w", err)
+	}
+	proxyURL := *proxyBaseURL
+	proxyURL.User = url.UserPassword("gestalt-egress-proxy", token)
+	return map[string]string{
+		"HTTP_PROXY":  proxyURL.String(),
+		"HTTPS_PROXY": proxyURL.String(),
+	}, nil
+}
+
 func buildPluginRuntimePublicHostServiceRelay(pluginName, sessionID string, hostService providerhost.StartedHostService, deps Deps, serviceKey, serviceLabel, methodPrefix string) (pluginruntime.HostServiceRelay, map[string]string, string, bool, error) {
 	if strings.TrimSpace(deps.BaseURL) == "" || len(deps.EncryptionKey) == 0 {
 		return pluginruntime.HostServiceRelay{}, nil, "", false, nil
@@ -1228,28 +1280,40 @@ func buildPluginRuntimePublicHostServiceRelay(pluginName, sessionID string, host
 }
 
 func pluginRuntimePublicRelayTarget(baseURL string) (string, string, error) {
-	parsed, err := url.Parse(strings.TrimSpace(baseURL))
+	parsed, host, err := pluginRuntimePublicProxyBaseURL(baseURL)
 	if err != nil {
-		return "", "", fmt.Errorf("parse server.baseURL for host service relay: %w", err)
-	}
-	host := strings.TrimSpace(parsed.Hostname())
-	if host == "" {
-		return "", "", fmt.Errorf("server.baseURL %q is missing a hostname", baseURL)
+		return "", "", err
 	}
 	port := parsed.Port()
-	if path := strings.TrimSpace(parsed.EscapedPath()); path != "" && path != "/" {
-		return "", "", fmt.Errorf("server.baseURL %q must not include a path for host service relay", baseURL)
-	}
-	if parsed.RawQuery != "" || parsed.Fragment != "" {
-		return "", "", fmt.Errorf("server.baseURL %q must not include a query or fragment for host service relay", baseURL)
-	}
-	if !strings.EqualFold(parsed.Scheme, "https") {
-		return "", "", fmt.Errorf("server.baseURL %q must use https for host service relay", baseURL)
-	}
 	if port == "" {
 		port = "443"
 	}
 	return "tls://" + net.JoinHostPort(host, port), host, nil
+}
+
+func pluginRuntimePublicProxyBaseURL(baseURL string) (*url.URL, string, error) {
+	parsed, err := url.Parse(strings.TrimSpace(baseURL))
+	if err != nil {
+		return nil, "", fmt.Errorf("parse server.baseURL for public runtime relay: %w", err)
+	}
+	host := strings.TrimSpace(parsed.Hostname())
+	if host == "" {
+		return nil, "", fmt.Errorf("server.baseURL %q is missing a hostname", baseURL)
+	}
+	if path := strings.TrimSpace(parsed.EscapedPath()); path != "" && path != "/" {
+		return nil, "", fmt.Errorf("server.baseURL %q must not include a path for public runtime relay", baseURL)
+	}
+	if parsed.RawQuery != "" || parsed.Fragment != "" {
+		return nil, "", fmt.Errorf("server.baseURL %q must not include a query or fragment for public runtime relay", baseURL)
+	}
+	if !strings.EqualFold(parsed.Scheme, "https") {
+		return nil, "", fmt.Errorf("server.baseURL %q must use https for public runtime relay", baseURL)
+	}
+	parsed.Path = ""
+	parsed.RawPath = ""
+	parsed.RawQuery = ""
+	parsed.Fragment = ""
+	return parsed, host, nil
 }
 
 func isIndexedDBHostServiceEnv(envVar string) bool {

--- a/gestaltd/internal/providerhost/egress_proxy_token.go
+++ b/gestaltd/internal/providerhost/egress_proxy_token.go
@@ -1,0 +1,170 @@
+package providerhost
+
+import (
+	"crypto/rand"
+	"fmt"
+	"strings"
+	"time"
+
+	"github.com/golang-jwt/jwt/v5"
+	"github.com/google/uuid"
+	"github.com/valon-technologies/gestalt/server/internal/egress"
+)
+
+const (
+	egressProxyTokenIssuer     = "gestaltd"
+	egressProxyTokenAudience   = "gestalt-egress-proxy"
+	defaultEgressProxyTokenTTL = 24 * time.Hour
+	maxEgressProxyTokenTTL     = 30 * 24 * time.Hour
+)
+
+type EgressProxyTokenManager struct {
+	secret     []byte
+	now        func() time.Time
+	defaultTTL time.Duration
+	maxTTL     time.Duration
+}
+
+type EgressProxyTokenRequest struct {
+	PluginName    string
+	SessionID     string
+	AllowedHosts  []string
+	DefaultAction egress.PolicyAction
+	TTL           time.Duration
+}
+
+type EgressProxyTarget struct {
+	PluginName    string
+	SessionID     string
+	AllowedHosts  []string
+	DefaultAction egress.PolicyAction
+}
+
+type egressProxyTokenClaims struct {
+	jwt.RegisteredClaims
+	PluginName    string              `json:"plugin,omitempty"`
+	SessionID     string              `json:"session_id,omitempty"`
+	AllowedHosts  []string            `json:"allowed_hosts,omitempty"`
+	DefaultAction egress.PolicyAction `json:"default_action,omitempty"`
+}
+
+func NewEgressProxyTokenManager(secret []byte) (*EgressProxyTokenManager, error) {
+	if len(secret) == 0 {
+		secret = make([]byte, 32)
+		if _, err := rand.Read(secret); err != nil {
+			return nil, fmt.Errorf("generate egress proxy token secret: %w", err)
+		}
+	}
+	return &EgressProxyTokenManager{
+		secret:     append([]byte(nil), secret...),
+		now:        time.Now,
+		defaultTTL: defaultEgressProxyTokenTTL,
+		maxTTL:     maxEgressProxyTokenTTL,
+	}, nil
+}
+
+func (m *EgressProxyTokenManager) MintToken(req EgressProxyTokenRequest) (string, error) {
+	if m == nil {
+		return "", fmt.Errorf("egress proxy tokens are not available")
+	}
+
+	now := m.now()
+	expiresAt := now.Add(m.tokenTTL(req.TTL))
+	subject := strings.TrimSpace(req.PluginName)
+	if subject == "" {
+		subject = "egress-proxy"
+	}
+
+	return m.signClaims(&egressProxyTokenClaims{
+		RegisteredClaims: jwt.RegisteredClaims{
+			ID:        uuid.NewString(),
+			Issuer:    egressProxyTokenIssuer,
+			Subject:   subject,
+			Audience:  jwt.ClaimStrings{egressProxyTokenAudience},
+			IssuedAt:  jwt.NewNumericDate(now),
+			NotBefore: jwt.NewNumericDate(now),
+			ExpiresAt: jwt.NewNumericDate(expiresAt),
+		},
+		PluginName:    strings.TrimSpace(req.PluginName),
+		SessionID:     strings.TrimSpace(req.SessionID),
+		AllowedHosts:  normalizeAllowedHosts(req.AllowedHosts),
+		DefaultAction: normalizeDefaultAction(req.DefaultAction),
+	})
+}
+
+func (m *EgressProxyTokenManager) ResolveToken(token string) (EgressProxyTarget, error) {
+	if m == nil {
+		return EgressProxyTarget{}, fmt.Errorf("egress proxy tokens are not available")
+	}
+	claims, err := m.parseClaims(token)
+	if err != nil {
+		return EgressProxyTarget{}, err
+	}
+	return EgressProxyTarget{
+		PluginName:    strings.TrimSpace(claims.PluginName),
+		SessionID:     strings.TrimSpace(claims.SessionID),
+		AllowedHosts:  normalizeAllowedHosts(claims.AllowedHosts),
+		DefaultAction: normalizeDefaultAction(claims.DefaultAction),
+	}, nil
+}
+
+func (m *EgressProxyTokenManager) parseClaims(token string) (*egressProxyTokenClaims, error) {
+	token = strings.TrimSpace(token)
+	if token == "" {
+		return nil, fmt.Errorf("egress proxy token is required")
+	}
+	parsed, err := jwt.ParseWithClaims(token, &egressProxyTokenClaims{}, func(t *jwt.Token) (any, error) {
+		if _, ok := t.Method.(*jwt.SigningMethodHMAC); !ok {
+			return nil, fmt.Errorf("unexpected signing method: %v", t.Header["alg"])
+		}
+		return m.secret, nil
+	}, jwt.WithAudience(egressProxyTokenAudience), jwt.WithIssuer(egressProxyTokenIssuer), jwt.WithTimeFunc(m.now))
+	if err != nil {
+		return nil, fmt.Errorf("egress proxy token is invalid or expired")
+	}
+	claims, ok := parsed.Claims.(*egressProxyTokenClaims)
+	if !ok || !parsed.Valid {
+		return nil, fmt.Errorf("egress proxy token is invalid or expired")
+	}
+	return claims, nil
+}
+
+func (m *EgressProxyTokenManager) signClaims(claims *egressProxyTokenClaims) (string, error) {
+	token := jwt.NewWithClaims(jwt.SigningMethodHS256, claims)
+	return token.SignedString(m.secret)
+}
+
+func (m *EgressProxyTokenManager) tokenTTL(ttl time.Duration) time.Duration {
+	if ttl <= 0 {
+		return m.defaultTTL
+	}
+	if ttl > m.maxTTL {
+		return m.maxTTL
+	}
+	return ttl
+}
+
+func normalizeAllowedHosts(hosts []string) []string {
+	if len(hosts) == 0 {
+		return nil
+	}
+	out := make([]string, 0, len(hosts))
+	for _, host := range hosts {
+		host = strings.TrimSpace(host)
+		if host == "" {
+			continue
+		}
+		out = append(out, host)
+	}
+	if len(out) == 0 {
+		return nil
+	}
+	return out
+}
+
+func normalizeDefaultAction(action egress.PolicyAction) egress.PolicyAction {
+	if action == "" {
+		return egress.PolicyAllow
+	}
+	return action
+}

--- a/gestaltd/internal/server/egress_proxy.go
+++ b/gestaltd/internal/server/egress_proxy.go
@@ -1,0 +1,206 @@
+package server
+
+import (
+	"encoding/base64"
+	"io"
+	"net"
+	"net/http"
+	"strings"
+	"time"
+
+	"github.com/valon-technologies/gestalt/server/internal/egress"
+)
+
+const (
+	proxyAuthorizationHeader = "Proxy-Authorization"
+	egressProxyDialTimeout   = 10 * time.Second
+)
+
+func (s *Server) egressProxyMiddleware(next http.Handler) http.Handler {
+	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		token := s.egressProxyToken(r)
+		if token == "" {
+			next.ServeHTTP(w, r)
+			return
+		}
+		if s.routeProfile == RouteProfileManagement || s.egressProxyTokens == nil || !isEgressProxyRequest(r) {
+			next.ServeHTTP(w, r)
+			return
+		}
+
+		target, err := s.egressProxyTokens.ResolveToken(token)
+		if err != nil {
+			http.Error(w, "invalid egress proxy token", http.StatusProxyAuthRequired)
+			return
+		}
+		host := proxyTargetHost(r)
+		if host == "" {
+			http.Error(w, "proxy target host is required", http.StatusBadRequest)
+			return
+		}
+		if err := egress.CheckHost(target.AllowedHosts, host, target.DefaultAction); err != nil {
+			http.Error(w, err.Error(), http.StatusForbidden)
+			return
+		}
+
+		newEgressProxyHandler().ServeHTTP(w, r)
+	})
+}
+
+func (s *Server) egressProxyToken(r *http.Request) string {
+	if s == nil || r == nil {
+		return ""
+	}
+	return extractProxyAuthorizationToken(r.Header.Get(proxyAuthorizationHeader))
+}
+
+func isEgressProxyRequest(r *http.Request) bool {
+	if r == nil {
+		return false
+	}
+	if r.Method == http.MethodConnect {
+		return true
+	}
+	return r.URL != nil && r.URL.IsAbs()
+}
+
+func proxyTargetHost(r *http.Request) string {
+	if r == nil {
+		return ""
+	}
+	var host string
+	switch {
+	case r.Method == http.MethodConnect:
+		host = strings.TrimSpace(r.Host)
+	case r.URL != nil && r.URL.Host != "":
+		host = strings.TrimSpace(r.URL.Hostname())
+	default:
+		host = strings.TrimSpace(r.Host)
+	}
+	if host == "" {
+		return ""
+	}
+	if h, _, err := net.SplitHostPort(host); err == nil {
+		return h
+	}
+	return host
+}
+
+func extractProxyAuthorizationToken(header string) string {
+	header = strings.TrimSpace(header)
+	if header == "" {
+		return ""
+	}
+	if token, ok := strings.CutPrefix(header, "Bearer "); ok {
+		return strings.TrimSpace(token)
+	}
+	if token, ok := strings.CutPrefix(header, "Basic "); ok {
+		decoded, err := base64.StdEncoding.DecodeString(strings.TrimSpace(token))
+		if err != nil {
+			return ""
+		}
+		user, pass, found := strings.Cut(string(decoded), ":")
+		if found && strings.TrimSpace(pass) != "" {
+			return strings.TrimSpace(pass)
+		}
+		return strings.TrimSpace(user)
+	}
+	return ""
+}
+
+func newEgressProxyHandler() http.Handler {
+	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.Method == http.MethodConnect {
+			handleEgressProxyConnect(w, r)
+			return
+		}
+		handleEgressProxyHTTP(w, r)
+	})
+}
+
+func handleEgressProxyHTTP(w http.ResponseWriter, r *http.Request) {
+	transport := &http.Transport{}
+	defer transport.CloseIdleConnections()
+
+	out := r.Clone(r.Context())
+	out.RequestURI = ""
+	out.Header = out.Header.Clone()
+	out.Header.Del(proxyAuthorizationHeader)
+	if out.URL == nil || !out.URL.IsAbs() {
+		http.Error(w, "proxy target URL is required", http.StatusBadRequest)
+		return
+	}
+	out.Host = out.URL.Host
+
+	resp, err := transport.RoundTrip(out)
+	if err != nil {
+		http.Error(w, err.Error(), http.StatusBadGateway)
+		return
+	}
+	defer func() { _ = resp.Body.Close() }()
+
+	for k, vv := range resp.Header {
+		for _, v := range vv {
+			w.Header().Add(k, v)
+		}
+	}
+	w.WriteHeader(resp.StatusCode)
+	_, _ = io.Copy(w, resp.Body)
+}
+
+func handleEgressProxyConnect(w http.ResponseWriter, r *http.Request) {
+	hijacker, ok := w.(http.Hijacker)
+	if !ok {
+		http.Error(w, "hijacking not supported", http.StatusInternalServerError)
+		return
+	}
+
+	targetAddr := strings.TrimSpace(r.Host)
+	if targetAddr == "" {
+		http.Error(w, "proxy target address is required", http.StatusBadRequest)
+		return
+	}
+	if _, _, err := net.SplitHostPort(targetAddr); err != nil {
+		targetAddr = net.JoinHostPort(targetAddr, "443")
+	}
+
+	var dialer net.Dialer
+	targetConn, err := dialer.DialContext(r.Context(), "tcp", targetAddr)
+	if err != nil {
+		http.Error(w, err.Error(), http.StatusBadGateway)
+		return
+	}
+
+	w.WriteHeader(http.StatusOK)
+	clientConn, _, err := hijacker.Hijack()
+	if err != nil {
+		_ = targetConn.Close()
+		return
+	}
+
+	deadline := time.Now().Add(10 * time.Minute)
+	_ = clientConn.SetDeadline(deadline)
+	_ = targetConn.SetDeadline(deadline)
+
+	done := make(chan struct{}, 2)
+	go func() {
+		_, _ = io.Copy(targetConn, clientConn)
+		closeWrite(targetConn)
+		done <- struct{}{}
+	}()
+	go func() {
+		_, _ = io.Copy(clientConn, targetConn)
+		closeWrite(clientConn)
+		done <- struct{}{}
+	}()
+	<-done
+	<-done
+	_ = clientConn.Close()
+	_ = targetConn.Close()
+}
+
+func closeWrite(c net.Conn) {
+	if closeWriter, ok := c.(interface{ CloseWrite() error }); ok {
+		_ = closeWriter.CloseWrite()
+	}
+}

--- a/gestaltd/internal/server/routes.go
+++ b/gestaltd/internal/server/routes.go
@@ -13,6 +13,7 @@ func (s *Server) routes() {
 	r.Use(requestMetaMiddleware)
 	r.Use(s.securityHeadersMiddleware)
 	r.Use(s.hostServiceRelayMiddleware)
+	r.Use(s.egressProxyMiddleware)
 	r.Use(maxBodyMiddleware(1 << 20)) // 1 MB
 
 	switch s.routeProfile {

--- a/gestaltd/internal/server/server.go
+++ b/gestaltd/internal/server/server.go
@@ -117,6 +117,7 @@ type Server struct {
 	prometheusMetrics      http.Handler
 	mcpHandler             http.Handler
 	hostServiceRelayTokens *providerhost.HostServiceRelayTokenManager
+	egressProxyTokens      *providerhost.EgressProxyTokenManager
 	mountedHTTPBindings    []MountedHTTPBinding
 	mountedUIs             []MountedUI
 	adminRoute             AdminRouteConfig
@@ -264,10 +265,15 @@ func New(cfg Config) (*Server, error) {
 		otelOptions = append(otelOptions, otelhttp.WithMeterProvider(cfg.MeterProvider))
 	}
 	var hostServiceRelayTokens *providerhost.HostServiceRelayTokenManager
+	var egressProxyTokens *providerhost.EgressProxyTokenManager
 	if len(cfg.StateSecret) > 0 {
 		hostServiceRelayTokens, err = providerhost.NewHostServiceRelayTokenManager(cfg.StateSecret)
 		if err != nil {
 			return nil, fmt.Errorf("init host service relay tokens: %w", err)
+		}
+		egressProxyTokens, err = providerhost.NewEgressProxyTokenManager(cfg.StateSecret)
+		if err != nil {
+			return nil, fmt.Errorf("init egress proxy tokens: %w", err)
 		}
 	}
 	s := &Server{
@@ -311,6 +317,7 @@ func New(cfg Config) (*Server, error) {
 		prometheusMetrics:      cfg.PrometheusMetrics,
 		mcpHandler:             cfg.MCPHandler,
 		hostServiceRelayTokens: hostServiceRelayTokens,
+		egressProxyTokens:      egressProxyTokens,
 		mountedHTTPBindings:    mountedHTTPBindings,
 		mountedUIs:             mountedUIs,
 		adminRoute:             adminRoute,

--- a/gestaltd/internal/server/server_test.go
+++ b/gestaltd/internal/server/server_test.go
@@ -419,6 +419,142 @@ func TestHostServiceRelaySupportsIndexedDBSDKClient(t *testing.T) {
 	}
 }
 
+func TestEgressProxyProxiesHTTPRequest(t *testing.T) {
+	t.Parallel()
+
+	secret := []byte("relay-test-secret-0123456789abcd")
+	target := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if got := r.URL.Path; got != "/hello" {
+			t.Fatalf("target path = %q, want /hello", got)
+		}
+		_, _ = io.WriteString(w, "proxied-ok")
+	}))
+	testutil.CloseOnCleanup(t, target)
+
+	proxy := httptest.NewUnstartedServer(newTestHandler(t, func(cfg *server.Config) {
+		cfg.RouteProfile = server.RouteProfilePublic
+		cfg.StateSecret = secret
+	}))
+	proxy.EnableHTTP2 = true
+	proxy.StartTLS()
+	testutil.CloseOnCleanup(t, proxy)
+
+	proxyURL := mustEgressProxyURL(t, proxy.URL, secret, providerhost.EgressProxyTokenRequest{
+		PluginName:   "support",
+		SessionID:    "session-1",
+		AllowedHosts: []string{"127.0.0.1", "localhost"},
+	})
+
+	client := &http.Client{
+		Transport: &http.Transport{
+			Proxy:           http.ProxyURL(proxyURL),
+			TLSClientConfig: &tls.Config{InsecureSkipVerify: true, MinVersion: tls.VersionTLS12},
+		},
+	}
+	resp, err := client.Get(target.URL + "/hello")
+	if err != nil {
+		t.Fatalf("GET via egress proxy: %v", err)
+	}
+	defer func() { _ = resp.Body.Close() }()
+	body, err := io.ReadAll(resp.Body)
+	if err != nil {
+		t.Fatalf("ReadAll: %v", err)
+	}
+	if resp.StatusCode != http.StatusOK {
+		t.Fatalf("proxy status = %d, want %d (body=%s)", resp.StatusCode, http.StatusOK, string(body))
+	}
+	if got := string(body); got != "proxied-ok" {
+		t.Fatalf("proxy body = %q, want %q", got, "proxied-ok")
+	}
+}
+
+func TestEgressProxyRejectsDisallowedHost(t *testing.T) {
+	t.Parallel()
+
+	secret := []byte("relay-test-secret-0123456789abcd")
+	proxy := httptest.NewUnstartedServer(newTestHandler(t, func(cfg *server.Config) {
+		cfg.RouteProfile = server.RouteProfilePublic
+		cfg.StateSecret = secret
+	}))
+	proxy.EnableHTTP2 = true
+	proxy.StartTLS()
+	testutil.CloseOnCleanup(t, proxy)
+
+	proxyURL := mustEgressProxyURL(t, proxy.URL, secret, providerhost.EgressProxyTokenRequest{
+		PluginName:   "support",
+		SessionID:    "session-1",
+		AllowedHosts: []string{"api.github.com"},
+	})
+
+	client := &http.Client{
+		Transport: &http.Transport{
+			Proxy:           http.ProxyURL(proxyURL),
+			TLSClientConfig: &tls.Config{InsecureSkipVerify: true, MinVersion: tls.VersionTLS12},
+		},
+	}
+	resp, err := client.Get("http://example.com/blocked")
+	if err != nil {
+		t.Fatalf("GET blocked host via egress proxy: %v", err)
+	}
+	defer func() { _ = resp.Body.Close() }()
+	body, err := io.ReadAll(resp.Body)
+	if err != nil {
+		t.Fatalf("ReadAll: %v", err)
+	}
+	if resp.StatusCode != http.StatusForbidden {
+		t.Fatalf("proxy status = %d, want %d (body=%s)", resp.StatusCode, http.StatusForbidden, string(body))
+	}
+	if !strings.Contains(string(body), "egress denied") {
+		t.Fatalf("proxy body = %q, want egress denied", string(body))
+	}
+}
+
+func TestEgressProxySupportsHTTPSConnect(t *testing.T) {
+	t.Parallel()
+
+	secret := []byte("relay-test-secret-0123456789abcd")
+	target := httptest.NewTLSServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		_, _ = io.WriteString(w, "secure-proxied-ok")
+	}))
+	testutil.CloseOnCleanup(t, target)
+
+	proxy := httptest.NewUnstartedServer(newTestHandler(t, func(cfg *server.Config) {
+		cfg.RouteProfile = server.RouteProfilePublic
+		cfg.StateSecret = secret
+	}))
+	proxy.EnableHTTP2 = true
+	proxy.StartTLS()
+	testutil.CloseOnCleanup(t, proxy)
+
+	proxyURL := mustEgressProxyURL(t, proxy.URL, secret, providerhost.EgressProxyTokenRequest{
+		PluginName:   "support",
+		SessionID:    "session-1",
+		AllowedHosts: []string{"127.0.0.1", "localhost"},
+	})
+
+	client := &http.Client{
+		Transport: &http.Transport{
+			Proxy:           http.ProxyURL(proxyURL),
+			TLSClientConfig: &tls.Config{InsecureSkipVerify: true, MinVersion: tls.VersionTLS12},
+		},
+	}
+	resp, err := client.Get(target.URL)
+	if err != nil {
+		t.Fatalf("GET https target via egress proxy: %v", err)
+	}
+	defer func() { _ = resp.Body.Close() }()
+	body, err := io.ReadAll(resp.Body)
+	if err != nil {
+		t.Fatalf("ReadAll: %v", err)
+	}
+	if resp.StatusCode != http.StatusOK {
+		t.Fatalf("proxy status = %d, want %d (body=%s)", resp.StatusCode, http.StatusOK, string(body))
+	}
+	if got := string(body); got != "secure-proxied-ok" {
+		t.Fatalf("proxy body = %q, want %q", got, "secure-proxied-ok")
+	}
+}
+
 func newRelayGRPCConn(t *testing.T, ts *httptest.Server) *grpc.ClientConn {
 	t.Helper()
 	targetURL, err := url.Parse(ts.URL)
@@ -433,6 +569,26 @@ func newRelayGRPCConn(t *testing.T, ts *httptest.Server) *grpc.ClientConn {
 		t.Fatalf("grpc.NewClient: %v", err)
 	}
 	return conn
+}
+
+func mustEgressProxyURL(t *testing.T, baseURL string, secret []byte, req providerhost.EgressProxyTokenRequest) *url.URL {
+	t.Helper()
+
+	tokenManager, err := providerhost.NewEgressProxyTokenManager(secret)
+	if err != nil {
+		t.Fatalf("NewEgressProxyTokenManager: %v", err)
+	}
+	token, err := tokenManager.MintToken(req)
+	if err != nil {
+		t.Fatalf("MintToken: %v", err)
+	}
+
+	parsed, err := url.Parse(baseURL)
+	if err != nil {
+		t.Fatalf("Parse proxy URL: %v", err)
+	}
+	parsed.User = url.UserPassword("gestalt-egress-proxy", token)
+	return parsed
 }
 
 func (s *stubResolver) ResolveToken(ctx context.Context, _ *principal.Principal, _ string, _ string, _ string) (context.Context, string, error) {


### PR DESCRIPTION
## Summary
This adds the public `gestaltd` relay path for hostname-based egress on hosted runtimes that do not have local host-service tunnels.

## New Interfaces
- Hosted runtimes without `HostServiceTunnels` now receive `HTTP_PROXY` and `HTTPS_PROXY` when hostname-based egress is active.
- `gestaltd` now accepts signed `Proxy-Authorization` relay tokens and proxies both HTTP requests and HTTPS `CONNECT` traffic.
- `providerhost.NewEgressProxyTokenManager(...)` mints scoped egress-proxy tokens for a plugin session.

## Example
```text
HTTP_PROXY=https://gestalt-egress-proxy:<token>@gestalt.example.test
HTTPS_PROXY=https://gestalt-egress-proxy:<token>@gestalt.example.test
```

```yaml
plugins:
  github:
    allowedHosts:
      - api.github.com
    runtime:
      provider: modal
```

## Notes
- The proxy env is only injected for hosted runtimes that do **not** advertise `HostServiceTunnels`, so the local runtime path stays unchanged.
- The hosted bootstrap tests now cover env injection and a real hosted round-trip through the public egress proxy.

## Validation
- `go test ./internal/server -run 'Test(EgressProxy|HostServiceRelay)' -count=1`
- `go test ./internal/bootstrap -run 'TestPluginRuntime(ConfigInjectsPublicEgressProxyWithoutHostServiceTunnelCapability|PublicEgressProxyRoundTripsThroughHostedPlugin|ConfigRejectsDefaultDenyWithoutHostnameEgressCapability)' -count=1`
- `go test ./internal/server ./internal/bootstrap ./internal/providerhost ./internal/pluginruntime -count=1`
- `golangci-lint run ./internal/server ./internal/bootstrap ./internal/providerhost ./internal/pluginruntime`
- `git diff --check`