### PR TITLE
Add agent docs plus HTTP and CLI run surfaces

### DIFF
--- a/docs/content/client/cli/index.mdx
+++ b/docs/content/client/cli/index.mdx
@@ -32,6 +32,7 @@ asIndexPage: true
 | `gestalt workflows triggers ...` | Create, list, inspect, update, pause, resume, or delete workflow triggers. |
 | `gestalt workflows events publish ...` | Publish an event into the workflow system. |
 | `gestalt workflows runs ...` | List, inspect, and cancel workflow runs. |
+| `gestalt agent runs ...` | Create, list, inspect, and cancel global agent runs. |
 | `gestalt tokens create\|list\|revoke` | Manage Gestalt API tokens. |
 
 ## URL resolution
@@ -243,3 +244,47 @@ gestalt workflows runs list --plugin github --status failed
 gestalt workflows runs get <run-id>
 gestalt workflows runs cancel <run-id> --reason "operator requested"
 ```
+
+### Agent Runs
+
+```sh
+gestalt agent runs create \
+  --provider managed \
+  --model gpt-5.4 \
+  --system "Be concise." \
+  --message "Summarize the roadmap risk." \
+  --tool roadmap:sync \
+  --idempotency-key agent-run-1
+
+gestalt agent runs list --provider managed --status running
+gestalt agent runs get <run-id>
+gestalt agent runs cancel <run-id> --reason "operator requested"
+
+# advanced fields such as responseSchema, metadata, or providerOptions
+# go through --request-file, which also accepts "-" for stdin:
+cat <<'JSON' | gestalt --format json agent runs create --request-file -
+{
+  "provider": "managed",
+  "model": "gpt-5.4",
+  "sessionRef": "session-1",
+  "messages": [
+    {"role": "user", "text": "Summarize the roadmap risk."}
+  ],
+  "toolRefs": [
+    {"pluginName": "roadmap", "operation": "sync"}
+  ],
+  "responseSchema": {
+    "type": "object",
+    "properties": {
+      "summary": {"type": "string"}
+    },
+    "required": ["summary"]
+  }
+}
+JSON
+```
+
+`gestalt agent runs create` supports repeated `--system`, repeated `--message`,
+repeated `--tool plugin:operation`, `--session-ref`, `--idempotency-key`, and
+`--request-file`. Use `--format json` when you want the raw HTTP response shape
+instead of the default table view.

--- a/docs/content/configuration.mdx
+++ b/docs/content/configuration.mdx
@@ -538,6 +538,47 @@ Workflow targets are always explicit: `plugin`, `operation`, and optional
 triggers are reconciled into the provider at startup. See
 [Workflow](/providers/workflow) for the user-facing and provider model.
 
+## Configuring agent providers
+
+The `providers.agent` block declares the global pool of agent backends. There
+is no `server.providers.agent`: a run request either names a provider
+explicitly or inherits the sole/default `providers.agent` entry when it omits
+`provider`.
+
+```yaml
+providers:
+  agent:
+    openai:
+      source: ./providers/agent/openai/manifest.yaml
+      default: true
+      config:
+        model: gpt-5.4
+        apiKey:
+          secret:
+            provider: default
+            name: openai-api-key
+
+    claude:
+      source: ./providers/agent/claude/manifest.yaml
+      config:
+        model: claude-sonnet
+        apiKey:
+          secret:
+            provider: default
+            name: anthropic-api-key
+```
+
+Agent providers receive neutral run requests with `messages`, optional tools,
+optional structured-output schema, and optional `sessionRef`. The same
+provider pool is used by the global agent runs API/CLI and by plugins that use
+the host agent manager surface. In V1 there is no standardized storage binding
+for agent providers, so provider-owned persistence should be declared in the
+provider's own `config`.
+
+See [Agent](/providers/agent) for the provider model and
+[Custom Providers > Agent](/custom-providers/agent) if you need to implement
+your own backend.
+
 ## Telemetry and audit
 
 Gestalt ships with builtin telemetry and audit providers that work without any configuration. The defaults emit to stdout:

--- a/docs/content/custom-providers/_meta.ts
+++ b/docs/content/custom-providers/_meta.ts
@@ -3,6 +3,7 @@ export default {
   runtime: "Runtime",
   authentication: "Authentication",
   authorization: "Authorization",
+  agent: "Agent",
   cache: "Cache",
   indexeddb: "IndexedDB",
   s3: "S3",

--- a/docs/content/custom-providers/agent.mdx
+++ b/docs/content/custom-providers/agent.mdx
@@ -1,0 +1,196 @@
+import { Tabs } from 'nextra/components'
+
+# Agent
+
+This page covers building custom agent providers. If you only need to
+configure an agent backend for a deployment, use
+[Providers > Agent](/providers/agent).
+
+Agent providers implement a neutral run lifecycle over messages, tools, and
+optional session continuation state. They are a good fit when you want Gestalt
+to select between OpenAI-, Anthropic-, or custom-backed agent engines without
+hard-coding those SDKs into every caller.
+
+## Manifest
+
+An agent provider manifest declares `kind: agent`:
+
+```yaml
+kind: agent
+source: github.com/your-org/agent/example
+version: 0.0.1
+displayName: Example Agent
+description: Neutral agent provider that queues runs onto a vendor backend.
+spec:
+  configSchemaPath: ./agent_config.json
+```
+
+## Provider interface
+
+The agent service includes four run methods:
+
+| Method | Purpose |
+| --- | --- |
+| `StartRun` | Create or queue a run from messages, resolved tools, and optional session state |
+| `GetRun` | Inspect one run by `run_id` |
+| `ListRuns` | Return currently known runs for this provider |
+| `CancelRun` | Request cancellation for one run |
+
+Providers can also call back into Gestalt through `AgentHost.ExecuteTool` when
+they want the host to execute a bound plugin operation during a run.
+
+## Run shape
+
+```json
+{
+  "runId": "run-123",
+  "providerName": "openai",
+  "model": "gpt-5.4",
+  "messages": [
+    { "role": "system", "text": "Be concise." },
+    { "role": "user", "text": "Summarize the roadmap risk." }
+  ],
+  "tools": [
+    {
+      "id": "roadmap/sync",
+      "name": "sync_roadmap",
+      "description": "Sync the roadmap plugin operation",
+      "target": { "pluginName": "roadmap", "operation": "sync" }
+    }
+  ],
+  "sessionRef": "session-123",
+  "executionRef": "run-123"
+}
+```
+
+<Tabs items={['Go', 'TypeScript']}>
+  <Tabs.Tab>
+    ```go
+    package main
+
+    import (
+    	"context"
+    	"log"
+
+    	gestalt "github.com/valon-technologies/gestalt/sdk/go"
+    	proto "github.com/valon-technologies/gestalt/sdk/go/gen/v1"
+    )
+
+    type provider struct {
+    	proto.UnimplementedAgentProviderServer
+    }
+
+    func (p *provider) StartRun(ctx context.Context, req *proto.StartAgentProviderRunRequest) (*proto.BoundAgentRun, error) {
+    	return &proto.BoundAgentRun{
+    		Id:           req.GetRunId(),
+    		ProviderName: req.GetProviderName(),
+    		Model:        req.GetModel(),
+    		Status:       proto.AgentRunStatus_AGENT_RUN_STATUS_PENDING,
+    		Messages:     req.GetMessages(),
+    		SessionRef:   req.GetSessionRef(),
+    		ExecutionRef: req.GetExecutionRef(),
+    	}, nil
+    }
+
+    func (p *provider) GetRun(_ context.Context, req *proto.GetAgentProviderRunRequest) (*proto.BoundAgentRun, error) {
+    	return &proto.BoundAgentRun{Id: req.GetRunId()}, nil
+    }
+
+    func (p *provider) ListRuns(context.Context, *proto.ListAgentProviderRunsRequest) (*proto.ListAgentProviderRunsResponse, error) {
+    	return &proto.ListAgentProviderRunsResponse{}, nil
+    }
+
+    func (p *provider) CancelRun(_ context.Context, req *proto.CancelAgentProviderRunRequest) (*proto.BoundAgentRun, error) {
+    	return &proto.BoundAgentRun{
+    		Id:     req.GetRunId(),
+    		Status: proto.AgentRunStatus_AGENT_RUN_STATUS_CANCELED,
+    	}, nil
+    }
+
+    func main() {
+    	if err := gestalt.ServeAgentProvider(context.Background(), &provider{}); err != nil {
+    		log.Fatal(err)
+    	}
+    }
+    ```
+  </Tabs.Tab>
+  <Tabs.Tab>
+    ```ts
+    import {
+      AgentHost,
+      AgentRunStatus,
+      defineAgentProvider,
+    } from "@valon-technologies/gestalt";
+
+    const host = new AgentHost();
+
+    export const provider = defineAgentProvider({
+      displayName: "Example Agent",
+      description: "Neutral run-based agent provider",
+      async startRun(request) {
+        if (request.tools.length > 0) {
+          await host.executeTool({
+            runId: request.runId,
+            toolCallId: "call-1",
+            toolId: request.tools[0].id,
+            arguments: { taskId: "task-123" },
+          });
+        }
+
+        return {
+          id: request.runId,
+          providerName: request.providerName || "example",
+          model: request.model,
+          status: AgentRunStatus.PENDING,
+          messages: request.messages,
+          sessionRef: request.sessionRef,
+          executionRef: request.executionRef,
+        };
+      },
+      async getRun(request) {
+        return { id: request.runId, providerName: "example", status: AgentRunStatus.RUNNING };
+      },
+      async listRuns() {
+        return [];
+      },
+      async cancelRun(request) {
+        return { id: request.runId, providerName: "example", status: AgentRunStatus.CANCELED };
+      },
+    });
+    ```
+  </Tabs.Tab>
+</Tabs>
+
+## Tool callbacks
+
+When the provider wants Gestalt to execute a bound plugin operation, it calls
+`AgentHost.ExecuteTool`:
+
+```json
+{
+  "runId": "run-123",
+  "toolCallId": "call-1",
+  "toolId": "roadmap/sync",
+  "arguments": {
+    "taskId": "task-123"
+  }
+}
+```
+
+Gestalt returns an HTTP-like envelope:
+
+```json
+{
+  "status": 200,
+  "body": "{\"ok\":true,\"taskId\":\"task-123\",\"synced\":true}"
+}
+```
+
+In V1 there is no standardized IndexedDB or general storage binding for agent
+providers. If your provider needs durable state, define it in your own config
+schema and manage it behind the provider.
+
+## What to read next
+
+- [Providers > Agent](/providers/agent): operator-facing configuration model
+- [Custom Providers > Releasing](/custom-providers/releasing): packaging and publishing provider releases

--- a/docs/content/custom-providers/index.mdx
+++ b/docs/content/custom-providers/index.mdx
@@ -12,6 +12,7 @@ deployment, start with [Providers](/providers).
 
 - Implementing executable or declarative plugin providers
 - Implementing custom runtime providers for hosted executable-plugin execution
+- Implementing custom agent providers for run-based reasoning backends
 - Building custom authentication, authorization, cache, IndexedDB, S3, secrets,
   workflow, and UI providers
 - Testing providers from local source with `source: ./manifest.yaml`
@@ -38,6 +39,7 @@ providers:
 
 - [Plugin](/custom-providers/plugins): custom tool providers, executable
   operations, declarative surfaces, and hybrid catalogs
+- [Agent](/custom-providers/agent): custom run-based agent providers and tool callbacks
 - [Runtime](/custom-providers/runtime): hosted runtime backends for executable plugins
 - [Authentication](/custom-providers/authentication): platform login providers and optional bearer
   token validation

--- a/docs/content/providers/_meta.ts
+++ b/docs/content/providers/_meta.ts
@@ -1,6 +1,7 @@
 export default {
   authentication: "Authentication",
   authorization: "Authorization",
+  agent: "Agent",
   cache: "Cache",
   indexeddb: "IndexedDB",
   plugins: "Plugin",

--- a/docs/content/providers/agent.mdx
+++ b/docs/content/providers/agent.mdx
@@ -1,0 +1,102 @@
+import { Callout } from 'nextra/components'
+
+# Agent
+
+Gestalt agents are a standalone global provider primitive for run-based
+reasoning. An agent provider accepts messages, optional tools, optional
+structured-output contracts, and optional session continuation state, then
+returns a run object you can inspect or cancel later.
+
+<Callout type="info">
+  Agent providers are global, not plugin-scoped. A run either selects a named
+  `providers.agent` entry explicitly or inherits the sole/default provider when
+  it omits `provider`.
+</Callout>
+
+## Mental model
+
+Use an agent provider when you want a neutral backend that can reason over
+messages and tools without baking a specific vendor SDK into every plugin or
+HTTP client.
+
+- `providers.agent.<name>` defines the backend pool.
+- The provider owns the agent-side run lifecycle and any provider-specific
+  session continuation state.
+- Gestalt can pass resolved tool definitions into the provider and receive tool
+  callbacks back through the host agent socket.
+- The same provider pool is used by the global agent runs surfaces and by
+  plugins calling the host agent manager.
+
+This is intentionally different from `runtime`, which decides where executable
+plugins run, and from `workflow`, which decides when a target runs.
+
+## Configuring `providers.agent`
+
+```yaml
+providers:
+  agent:
+    openai:
+      source: ./providers/agent/openai/manifest.yaml
+      default: true
+      config:
+        model: gpt-5.4
+        baseURL: https://api.openai.com/v1
+        apiKey:
+          secret:
+            provider: default
+            name: openai-api-key
+
+    claude:
+      source: ./providers/agent/claude/manifest.yaml
+      config:
+        model: claude-sonnet
+        apiKey:
+          secret:
+            provider: default
+            name: anthropic-api-key
+```
+
+If exactly one agent provider is configured, or one is marked `default: true`,
+then run requests may omit `provider`.
+
+## Request shape
+
+The neutral agent run shape is intentionally small:
+
+```json
+{
+  "provider": "openai",
+  "model": "gpt-5.4",
+  "messages": [
+    { "role": "system", "text": "Be concise." },
+    { "role": "user", "text": "Summarize the roadmap risk." }
+  ],
+  "toolRefs": [
+    { "pluginName": "roadmap", "operation": "sync" }
+  ],
+  "responseSchema": {
+    "type": "object",
+    "properties": {
+      "summary": { "type": "string" }
+    },
+    "required": ["summary"]
+  },
+  "sessionRef": "session-123"
+}
+```
+
+In V1 there is no standardized host IndexedDB or general storage binding for
+agent providers. If a backend needs durable state, define that in the
+provider's own `config` schema.
+
+## First-party agent providers
+
+There is not yet a first-party agent provider published from
+`valon-technologies/gestalt-providers`. If you need one today, implement a
+custom provider against the neutral protocol.
+
+## What to read next
+
+- [Custom Providers > Agent](/custom-providers/agent): implementing your own agent backend
+- [HTTP API](/reference/http-api): global agent runs routes
+- [CLI](/client/cli): `gestalt agent runs ...`

--- a/docs/content/providers/index.mdx
+++ b/docs/content/providers/index.mdx
@@ -6,8 +6,9 @@ asIndexPage: true
 
 Gestalt loads most integration and platform surfaces as providers instead of
 compiling them into `gestaltd`. Plugins, authentication backends, IndexedDB backends,
-authorization backends, workflow backends, runtime backends, cache backends, S3 object stores,
-external secret managers, and public UIs all use the same provider model:
+authorization backends, agent backends, workflow backends, runtime backends,
+cache backends, S3 object stores, external secret managers, and public UIs all
+use the same provider model:
 you reference a package in config, the host resolves it, validates it, and
 starts it with the permissions and request context it needs.
 
@@ -18,6 +19,7 @@ starts it with the permissions and request context it needs.
 | `plugin` | Tool providers that expose operations over CLI, HTTP API, and MCP | `plugins.<name>` |
 | `auth` | Platform authentication backends | `providers.authentication.<name>` |
 | `authorization` | Dynamic human authorization backends | `providers.authorization.<name>` |
+| `agent` | Global agent run backends that reason over messages and tools | `providers.agent.<name>` |
 | `cache` | Plugin-bound cache backends | `providers.cache.<name>` |
 | `indexeddb` | Persistent state backends for users, sessions, tokens, and credentials | `providers.indexeddb.<name>` |
 | `runtime` | Hosted execution backends for executable plugins | `runtime.providers.<name>` |
@@ -61,6 +63,11 @@ The repository is organized by provider type:
 | Secret | [`secrets/`](https://github.com/valon-technologies/gestalt-providers/tree/main/secrets) | `providers.secrets.<name>` |
 | Workflow | [`workflow/`](https://github.com/valon-technologies/gestalt-providers/tree/main/workflow) | `providers.workflow.<name>` |
 | UI | [`web/`](https://github.com/valon-technologies/gestalt-providers/tree/main/web) | `providers.ui` |
+
+There is not yet a first-party agent provider published from
+`valon-technologies/gestalt-providers`. If you need one today, implement it as
+a custom provider with the neutral agent protocol described in
+[Custom Providers > Agent](/custom-providers/agent).
 
 ## Using providers
 
@@ -131,6 +138,7 @@ release workflow now lives under [Custom Providers](/custom-providers).
 
 - [Authentication](/providers/authentication): platform login providers
 - [Authorization](/providers/authorization): human authorization providers
+- [Agent](/providers/agent): global agent-provider pool and selection model
 - [Cache](/providers/cache): plugin-bound cache backends
 - [IndexedDB](/providers/indexeddb): storage backends
 - [Plugin](/providers/plugins): choosing and configuring plugin providers

--- a/docs/content/reference/built-in-providers.mdx
+++ b/docs/content/reference/built-in-providers.mdx
@@ -1,6 +1,6 @@
 # First-Party Providers
 
-Gestalt does not compile authentication, authorization, workflow, runtime,
+Gestalt does not compile authentication, authorization, agent, workflow, runtime,
 IndexedDB, or S3 providers into the `gestaltd` binary. They are loaded at
 startup as external provider processes through the same runtime model that also
 powers plugins. The first-party implementations are published from
@@ -149,6 +149,15 @@ workflows:
 | Name | Purpose |
 | --- | --- |
 | `indexeddb` | Stores workflow runs, schedules, and triggers in IndexedDB and invokes plugin operations through the workflow host. |
+
+## Agent Providers
+
+Agent providers are configured under `providers.agent.<name>`, but there is
+not yet a first-party agent provider published from
+`valon-technologies/gestalt-providers`.
+
+If you need one today, implement it with
+[Custom Providers > Agent](/custom-providers/agent).
 
 ## S3 Providers
 

--- a/docs/content/reference/config-file.mdx
+++ b/docs/content/reference/config-file.mdx
@@ -464,6 +464,54 @@ allowlist logical stores exposed through that binding.
 | `env` | Extra environment variables passed to the provider process. |
 | `allowedHosts` | Outbound host allowlist. For executable plugins, this is only a complete boundary when a supported sandboxed runtime is active. |
 
+## `providers.agent`
+
+Agent providers back global agent runs. Configure one or more named entries
+under `providers.agent`. There is no `server.providers.agent`: each run request
+either selects a provider explicitly or inherits the sole/default
+`providers.agent` entry when `provider` is omitted. The same provider pool is
+used by the global agent runs API/CLI and by plugins that call the host agent
+manager.
+
+```yaml
+providers:
+  agent:
+    openai:
+      source: ./providers/agent/openai/manifest.yaml
+      default: true
+      config:
+        model: gpt-5.4
+        baseURL: https://api.openai.com/v1
+        apiKey:
+          secret:
+            provider: default
+            name: openai-api-key
+
+    claude:
+      source: ./providers/agent/claude/manifest.yaml
+      config:
+        model: claude-sonnet
+        apiKey:
+          secret:
+            provider: default
+            name: anthropic-api-key
+```
+
+Agent providers receive neutral run requests with `messages`, optional
+resolved `tools`, optional `responseSchema`, optional `sessionRef`, and
+provider-specific `config`. In V1 there is no standardized host IndexedDB or
+other storage binding for agent providers. If an agent backend needs durable
+state, define that in the provider's own `config` schema.
+
+| Field | Description |
+| --- | --- |
+| `default` | Marks this named agent entry as the default selection when a run request omits `provider`. |
+| `source` | Either a local provider manifest path, a published `provider-release.yaml` metadata URL, or `source.githubRelease` for a GitHub-hosted release asset. |
+| `auth` | Optional inline source auth for remote release sources, including direct metadata URLs and `source.githubRelease`. |
+| `config` | Provider-specific config passed into the agent provider. |
+| `env` | Extra environment variables passed to the provider process. |
+| `allowedHosts` | Outbound host allowlist. For executable providers, this is only a complete boundary when a supported sandboxed runtime is active. |
+
 ## `workflows`
 
 Top-level `workflows` declares config-managed schedules and triggers.

--- a/docs/content/reference/go-sdk.mdx
+++ b/docs/content/reference/go-sdk.mdx
@@ -44,3 +44,33 @@ var Router = gestalt.MustRouter(
 
 `pkg.go.dev` renders the source comments directly, so package and symbol docs
 there are the primary Go reference surface.
+
+The same module also exposes the agent-provider runtime:
+
+```go
+package exampleagent
+
+import (
+	"context"
+
+	gestalt "github.com/valon-technologies/gestalt/sdk/go"
+	proto "github.com/valon-technologies/gestalt/sdk/go/gen/v1"
+)
+
+type Agent struct {
+	proto.UnimplementedAgentProviderServer
+}
+
+func (a *Agent) StartRun(_ context.Context, req *proto.StartAgentProviderRunRequest) (*proto.BoundAgentRun, error) {
+	return &proto.BoundAgentRun{
+		Id:           req.GetRunId(),
+		ProviderName: req.GetProviderName(),
+		Model:        req.GetModel(),
+		Status:       proto.AgentRunStatus_AGENT_RUN_STATUS_PENDING,
+	}, nil
+}
+
+func main() {
+	_ = gestalt.ServeAgentProvider(context.Background(), &Agent{})
+}
+```

--- a/docs/content/reference/http-api.mdx
+++ b/docs/content/reference/http-api.mdx
@@ -63,6 +63,23 @@ Authenticated routes accept a `session_token` cookie or an `Authorization: Beare
 | `GET` | `/api/v1/workflow/runs/{runID}` | Inspect one workflow run. |
 | `POST` | `/api/v1/workflow/runs/{runID}/cancel` | Cancel one workflow run. The request body may include an optional `reason`. |
 
+### Agents
+
+| Method | Path | Purpose |
+| --- | --- | --- |
+| `POST` | `/api/v1/agent/runs` | Create one agent run. Accepts an optional `idempotencyKey` field and optional `Idempotency-Key` header. |
+| `GET` | `/api/v1/agent/runs` | List agent runs. Supports optional `provider` and `status` query filters. |
+| `GET` | `/api/v1/agent/runs/{runID}` | Inspect one agent run. |
+| `POST` | `/api/v1/agent/runs/{runID}/cancel` | Cancel one agent run. The request body may include an optional `reason`. |
+
+Agent run creation accepts `provider`, `model`, `messages`, `toolRefs`,
+optional `toolSource`, optional `responseSchema`, optional `sessionRef`,
+optional `metadata`, optional `providerOptions`, and optional
+`idempotencyKey`. Missing `toolRefs[].pluginName` or `toolRefs[].operation`
+returns `400`. Conflicting header/body idempotency keys also return `400`, an
+in-progress idempotent create returns `409`, and an unconfigured agent surface
+returns `412`.
+
 ### API Tokens
 
 | Method | Path | Purpose |
@@ -208,6 +225,64 @@ curl -X POST http://localhost:8080/api/v1/workflow/events \
 # List failed workflow runs for one plugin
 curl 'http://localhost:8080/api/v1/workflow/runs?plugin=github&status=failed' \
   -H 'Authorization: Bearer gst_api_...'
+
+# Create an agent run
+curl -X POST http://localhost:8080/api/v1/agent/runs \
+  -H 'Authorization: Bearer gst_api_...' \
+  -H 'Content-Type: application/json' \
+  -H 'Idempotency-Key: agent-run-1' \
+  -d '{
+    "provider": "managed",
+    "model": "gpt-5.4",
+    "messages": [
+      {"role": "system", "text": "Be concise."},
+      {"role": "user", "text": "Summarize the roadmap risk."}
+    ],
+    "toolRefs": [
+      {"pluginName": "roadmap", "operation": "sync"}
+    ],
+    "toolSource": "explicit",
+    "responseSchema": {
+      "type": "object",
+      "properties": {
+        "summary": {"type": "string"}
+      },
+      "required": ["summary"]
+    },
+    "sessionRef": "session-1",
+    "metadata": {
+      "ticket": "RD-42"
+    }
+  }'
+
+# Inspect a run
+curl -H 'Authorization: Bearer gst_api_...' \
+  http://localhost:8080/api/v1/agent/runs/run-123
+
+# List filtered runs
+curl -H 'Authorization: Bearer gst_api_...' \
+  'http://localhost:8080/api/v1/agent/runs?provider=managed&status=running'
+
+# Cancel an agent run
+curl -X POST http://localhost:8080/api/v1/agent/runs/run-123/cancel \
+  -H 'Authorization: Bearer gst_api_...' \
+  -H 'Content-Type: application/json' \
+  -d '{"reason":"operator requested"}'
+
+# Typical create response
+# {
+#   "id": "run-123",
+#   "provider": "managed",
+#   "model": "gpt-5.4",
+#   "status": "pending",
+#   "messages": [
+#     {"role":"system","text":"Be concise."},
+#     {"role":"user","text":"Summarize the roadmap risk."}
+#   ],
+#   "sessionRef": "session-1",
+#   "createdAt": "2026-04-22T00:00:00Z",
+#   "executionRef": "run-123"
+# }
 
 # Add a dynamic plugin member from the management/admin surface by email alias
 curl -X PUT http://localhost:9090/admin/api/v1/authorization/plugins/sample_plugin/members \

--- a/docs/content/reference/plugin-manifests.mdx
+++ b/docs/content/reference/plugin-manifests.mdx
@@ -5,7 +5,7 @@ import { Tabs } from "nextra/components";
 Gestalt provider packages and release archives are described by a manifest file: `manifest.yaml`, `manifest.yml`, or `manifest.json`. YAML is the easiest format to author by hand.
 
 Providers are the umbrella concept in Gestalt. Authentication, authorization,
-cache, indexeddb, runtime, S3, secrets, workflow, and plugin packages all use
+agent, cache, indexeddb, runtime, S3, secrets, workflow, and plugin packages all use
 this manifest format. The `plugin` manifest kind is reserved for providers that
 expose callable operations.
 
@@ -18,6 +18,7 @@ Every manifest defines exactly one provider kind, set by the `kind` field:
 | `plugin` | Plugin (REST, OpenAPI, GraphQL, MCP, or executable). |
 | `authentication` | Platform authentication provider. |
 | `authorization` | Human authorization decision and control-plane provider. |
+| `agent` | Global run-based agent provider. |
 | `cache` | Cache backend for plugin-bound cache bindings. |
 | `indexeddb` | Persistence backend. |
 | `runtime` | Hosted execution backend for executable plugins. |
@@ -34,7 +35,7 @@ These fields appear at the top level of every manifest regardless of kind.
 
 | Field         | Type       | Required | Purpose                                                                                                                                                                                              |
 | ------------- | ---------- | -------- | ---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| `kind`        | string     | yes      | The provider kind (`plugin`, `authentication`, `authorization`, `cache`, `indexeddb`, `runtime`, `s3`, `secrets`, `ui`, `workflow`).                                                                                                                |
+| `kind`        | string     | yes      | The provider kind (`plugin`, `authentication`, `authorization`, `agent`, `cache`, `indexeddb`, `runtime`, `s3`, `secrets`, `ui`, `workflow`).                                                                                                                |
 | `source`      | string     | yes      | Canonical provider source identifier. Use `github.com/<org>/<repo>/<path>`. The final path segment is the provider package name; preceding segments are used for release tags and source resolution. |
 | `version`     | string     | yes      | Semver version. Pre-release suffixes like `-alpha.1` are allowed.                                                                                                                                    |
 | `displayName` | string     | no       | Human-readable label shown in the UI.                                                                                                                                                                |

--- a/docs/content/reference/python-sdk.mdx
+++ b/docs/content/reference/python-sdk.mdx
@@ -31,3 +31,20 @@ The generated API reference is published separately as static HTML:
 Those pages focus on the handwritten SDK surface. Generated protobuf bindings
 under `gestalt.gen` remain available to provider code, but they are not
 expanded as authored reference pages.
+
+The Python SDK also exposes agent-provider helpers:
+
+```python
+import gestalt
+
+
+class ExampleAgent(gestalt.AgentProvider):
+    def StartRun(self, request, context):
+        return gestalt.pb.BoundAgentRun(
+            id=request.run_id,
+            provider_name=request.provider_name,
+            model=request.model,
+            status=gestalt.pb.AGENT_RUN_STATUS_PENDING,
+            messages=request.messages,
+        )
+```

--- a/docs/content/reference/rust-sdk.mdx
+++ b/docs/content/reference/rust-sdk.mdx
@@ -48,3 +48,23 @@ gestalt::export_provider!(constructor = EchoProvider::default, router = router);
 
 `docs.rs` renders the crate docs, module docs, and symbol docs from the source
 and checked-in generated bindings.
+
+Agent host and provider utilities are also part of the crate:
+
+```rust
+use gestalt::generated::v1 as pb;
+
+async fn execute_bound_tool() -> Result<(), Box<dyn std::error::Error>> {
+    let mut host = gestalt::AgentHost::connect().await?;
+    let response = host
+        .execute_tool(pb::ExecuteAgentToolRequest {
+            run_id: "run-123".into(),
+            tool_call_id: "call-1".into(),
+            tool_id: "roadmap/sync".into(),
+            arguments: None,
+        })
+        .await?;
+    println!("{}", response.status);
+    Ok(())
+}
+```

--- a/docs/content/reference/typescript-sdk.mdx
+++ b/docs/content/reference/typescript-sdk.mdx
@@ -30,3 +30,34 @@ import { parseRuntimeArgs, serve } from "@valon-technologies/gestalt/runtime";
 
 const args = parseRuntimeArgs(process.argv.slice(2));
 ```
+
+Agent-provider surfaces are part of the same package:
+
+```ts
+import {
+  AgentRunStatus,
+  defineAgentProvider,
+} from "@valon-technologies/gestalt";
+
+export const provider = defineAgentProvider({
+  displayName: "Example Agent",
+  async startRun(request) {
+    return {
+      id: request.runId,
+      providerName: request.providerName || "example",
+      model: request.model,
+      status: AgentRunStatus.PENDING,
+      messages: request.messages,
+    };
+  },
+  async getRun(request) {
+    return { id: request.runId, providerName: "example", status: AgentRunStatus.RUNNING };
+  },
+  async listRuns() {
+    return [];
+  },
+  async cancelRun(request) {
+    return { id: request.runId, providerName: "example", status: AgentRunStatus.CANCELED };
+  },
+});
+```

--- a/gestalt/cli/src/cli.rs
+++ b/gestalt/cli/src/cli.rs
@@ -69,6 +69,12 @@ pub enum Commands {
         #[command(subcommand)]
         command: WorkflowCommands,
     },
+
+    /// Manage global agent runs
+    Agent {
+        #[command(subcommand)]
+        command: AgentCommands,
+    },
 }
 
 #[derive(Subcommand)]
@@ -392,6 +398,15 @@ pub enum WorkflowCommands {
 }
 
 #[derive(Subcommand)]
+pub enum AgentCommands {
+    /// Inspect and control agent runs
+    Runs {
+        #[command(subcommand)]
+        command: AgentRunCommands,
+    },
+}
+
+#[derive(Subcommand)]
 pub enum WorkflowScheduleCommands {
     /// List workflow schedules
     List {
@@ -489,6 +504,34 @@ pub enum WorkflowRunCommands {
 }
 
 #[derive(Subcommand)]
+pub enum AgentRunCommands {
+    /// Create an agent run
+    Create(AgentRunCreateArgs),
+    /// List agent runs
+    List {
+        /// Filter runs by provider
+        #[arg(long)]
+        provider: Option<String>,
+        /// Filter runs by status
+        #[arg(long)]
+        status: Option<String>,
+    },
+    /// Show a single agent run
+    Get {
+        /// Run ID
+        id: String,
+    },
+    /// Cancel an agent run
+    Cancel {
+        /// Run ID
+        id: String,
+        /// Optional cancellation reason
+        #[arg(long)]
+        reason: Option<String>,
+    },
+}
+
+#[derive(Subcommand)]
 pub enum WorkflowEventCommands {
     /// Publish a workflow event
     Publish(WorkflowEventPublishArgs),
@@ -531,6 +574,70 @@ pub struct WorkflowScheduleCreateArgs {
     /// Load target input from a JSON file (use "-" for stdin)
     #[arg(long = "input-file")]
     pub input_file: Option<String>,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct AgentToolArg {
+    pub plugin: String,
+    pub operation: String,
+}
+
+impl AgentToolArg {
+    pub fn parse(input: &str) -> Result<Self, String> {
+        let trimmed = input.trim();
+        if trimmed.is_empty() {
+            return Err("tool cannot be empty".to_string());
+        }
+        let (plugin, operation) = trimmed
+            .split_once(':')
+            .ok_or_else(|| format!("tool '{trimmed}' must use plugin:operation"))?;
+        let plugin = plugin.trim();
+        let operation = operation.trim();
+        if plugin.is_empty() || operation.is_empty() {
+            return Err(format!(
+                "tool '{trimmed}' must include both plugin and operation"
+            ));
+        }
+        Ok(Self {
+            plugin: plugin.to_string(),
+            operation: operation.to_string(),
+        })
+    }
+}
+
+#[derive(Args)]
+pub struct AgentRunCreateArgs {
+    /// Agent provider name
+    #[arg(long)]
+    pub provider: Option<String>,
+
+    /// Model name override
+    #[arg(long)]
+    pub model: Option<String>,
+
+    /// Add a system message
+    #[arg(long = "system")]
+    pub system: Vec<String>,
+
+    /// Add a user message
+    #[arg(long = "message")]
+    pub messages: Vec<String>,
+
+    /// Attach a tool reference in plugin:operation form
+    #[arg(long = "tool", value_parser = AgentToolArg::parse)]
+    pub tools: Vec<AgentToolArg>,
+
+    /// Continue an existing provider session reference
+    #[arg(long = "session-ref")]
+    pub session_ref: Option<String>,
+
+    /// Idempotency key for safe retries
+    #[arg(long = "idempotency-key")]
+    pub idempotency_key: Option<String>,
+
+    /// Load the JSON request body from a file (use "-" for stdin)
+    #[arg(long = "request-file")]
+    pub request_file: Option<String>,
 }
 
 #[derive(Args)]

--- a/gestalt/cli/src/commands/agents.rs
+++ b/gestalt/cli/src/commands/agents.rs
@@ -1,0 +1,165 @@
+use anyhow::{Context, Result};
+use serde_json::{Map, Value, json};
+
+use crate::api::ApiClient;
+use crate::cli::{AgentRunCreateArgs, AgentToolArg};
+use crate::output::{self, Format};
+use crate::params;
+
+const RUNS_PATH: &str = "/api/v1/agent/runs";
+
+pub fn create_run(client: &ApiClient, args: &AgentRunCreateArgs, format: Format) -> Result<()> {
+    let body = build_create_body(args)?;
+    let resp = client
+        .post(RUNS_PATH, &body)
+        .context("failed to create agent run")?;
+    print_run(&resp, format);
+    Ok(())
+}
+
+pub fn list_runs(
+    client: &ApiClient,
+    provider: Option<&str>,
+    status: Option<&str>,
+    format: Format,
+) -> Result<()> {
+    let resp = client
+        .get(&runs_path(provider, status))
+        .context("failed to list agent runs")?;
+    print_runs(&resp, format);
+    Ok(())
+}
+
+pub fn get_run(client: &ApiClient, id: &str, format: Format) -> Result<()> {
+    let resp = client
+        .get(&format!("{RUNS_PATH}/{id}"))
+        .with_context(|| format!("failed to get agent run {id}"))?;
+    print_run(&resp, format);
+    Ok(())
+}
+
+pub fn cancel_run(
+    client: &ApiClient,
+    id: &str,
+    reason: Option<&str>,
+    format: Format,
+) -> Result<()> {
+    let body = match reason {
+        Some(reason) => json!({ "reason": reason }),
+        None => json!({}),
+    };
+    let resp = client
+        .post(&format!("{RUNS_PATH}/{id}/cancel"), &body)
+        .with_context(|| format!("failed to cancel agent run {id}"))?;
+    print_run(&resp, format);
+    Ok(())
+}
+
+fn build_create_body(args: &AgentRunCreateArgs) -> Result<Value> {
+    let mut body = match args.request_file.as_deref() {
+        Some(path) => params::load_input_file(path)?,
+        None => Map::new(),
+    };
+
+    if let Some(provider) = args.provider.as_deref() {
+        body.insert("provider".to_string(), Value::String(provider.to_string()));
+    }
+    if let Some(model) = args.model.as_deref() {
+        body.insert("model".to_string(), Value::String(model.to_string()));
+    }
+    if let Some(session_ref) = args.session_ref.as_deref() {
+        body.insert(
+            "sessionRef".to_string(),
+            Value::String(session_ref.to_string()),
+        );
+    }
+    if let Some(idempotency_key) = args.idempotency_key.as_deref() {
+        body.insert(
+            "idempotencyKey".to_string(),
+            Value::String(idempotency_key.to_string()),
+        );
+    }
+
+    let messages = build_messages(args);
+    if !messages.is_empty() {
+        body.insert("messages".to_string(), Value::Array(messages));
+    }
+    if !args.tools.is_empty() {
+        body.insert(
+            "toolRefs".to_string(),
+            Value::Array(args.tools.iter().map(agent_tool_ref_value).collect()),
+        );
+    }
+
+    Ok(Value::Object(body))
+}
+
+fn build_messages(args: &AgentRunCreateArgs) -> Vec<Value> {
+    let mut messages = Vec::with_capacity(args.system.len() + args.messages.len());
+    for text in &args.system {
+        messages.push(json!({ "role": "system", "text": text }));
+    }
+    for text in &args.messages {
+        messages.push(json!({ "role": "user", "text": text }));
+    }
+    messages
+}
+
+fn agent_tool_ref_value(tool: &AgentToolArg) -> Value {
+    json!({
+        "pluginName": tool.plugin,
+        "operation": tool.operation,
+    })
+}
+
+fn runs_path(provider: Option<&str>, status: Option<&str>) -> String {
+    let mut serializer = url::form_urlencoded::Serializer::new(String::new());
+    if let Some(provider) = provider {
+        serializer.append_pair("provider", provider);
+    }
+    if let Some(status) = status {
+        serializer.append_pair("status", status);
+    }
+    let query = serializer.finish();
+    if query.is_empty() {
+        RUNS_PATH.to_string()
+    } else {
+        format!("{RUNS_PATH}?{query}")
+    }
+}
+
+fn print_run(value: &Value, format: Format) {
+    match format {
+        Format::Json => output::print_json(value),
+        Format::Table => {
+            let rows = vec![run_row(value)];
+            output::print_table(&run_headers(), &rows);
+        }
+    }
+}
+
+fn print_runs(value: &Value, format: Format) {
+    match format {
+        Format::Json => output::print_json(value),
+        Format::Table => {
+            let items = value.as_array().cloned().unwrap_or_default();
+            let rows: Vec<Vec<String>> = items.iter().map(run_row).collect();
+            output::print_table(&run_headers(), &rows);
+        }
+    }
+}
+
+fn run_headers() -> [&'static str; 6] {
+    ["ID", "Provider", "Model", "Status", "Session", "Created"]
+}
+
+fn run_row(value: &Value) -> Vec<String> {
+    vec![
+        value["id"].as_str().unwrap_or("-").to_string(),
+        value["provider"].as_str().unwrap_or("-").to_string(),
+        value["model"].as_str().unwrap_or("-").to_string(),
+        value["status"].as_str().unwrap_or("-").to_string(),
+        value["sessionRef"].as_str().unwrap_or("-").to_string(),
+        value["createdAt"].as_str().unwrap_or("-").to_string(),
+    ]
+}

--- a/gestalt/cli/src/commands/mod.rs
+++ b/gestalt/cli/src/commands/mod.rs
@@ -1,3 +1,4 @@
+pub mod agents;
 pub mod auth;
 pub mod config;
 pub mod describe;

--- a/gestalt/cli/src/main.rs
+++ b/gestalt/cli/src/main.rs
@@ -1,10 +1,10 @@
 use clap::{CommandFactory, Parser};
 use gestalt::api::{self, ApiClient};
 use gestalt::cli::{
-    AuthCommands, Cli, Commands, ConfigCommands, DescribeArgs, IdentityCommands,
-    IdentityGrantCommands, IdentityMemberCommands, IdentityTokenCommands, InvokeArgs,
-    PluginCommands, TokenCommands, WorkflowCommands, WorkflowEventCommands, WorkflowRunCommands,
-    WorkflowScheduleCommands, WorkflowTriggerCommands,
+    AgentCommands, AgentRunCommands, AuthCommands, Cli, Commands, ConfigCommands, DescribeArgs,
+    IdentityCommands, IdentityGrantCommands, IdentityMemberCommands, IdentityTokenCommands,
+    InvokeArgs, PluginCommands, TokenCommands, WorkflowCommands, WorkflowEventCommands,
+    WorkflowRunCommands, WorkflowScheduleCommands, WorkflowTriggerCommands,
 };
 use gestalt::commands;
 use gestalt::output;
@@ -198,6 +198,26 @@ fn run() -> anyhow::Result<()> {
                 WorkflowCommands::Events { command } => match command {
                     WorkflowEventCommands::Publish(args) => {
                         commands::workflows::publish_event(&client, &args, format)
+                    }
+                },
+            }
+        }
+        Commands::Agent { command } => {
+            let client = ApiClient::from_env(url)?;
+            match command {
+                AgentCommands::Runs { command } => match command {
+                    AgentRunCommands::Create(args) => {
+                        commands::agents::create_run(&client, &args, format)
+                    }
+                    AgentRunCommands::List { provider, status } => commands::agents::list_runs(
+                        &client,
+                        provider.as_deref(),
+                        status.as_deref(),
+                        format,
+                    ),
+                    AgentRunCommands::Get { id } => commands::agents::get_run(&client, &id, format),
+                    AgentRunCommands::Cancel { id, reason } => {
+                        commands::agents::cancel_run(&client, &id, reason.as_deref(), format)
                     }
                 },
             }

--- a/gestalt/cli/tests/agents_cli.rs
+++ b/gestalt/cli/tests/agents_cli.rs
@@ -1,0 +1,153 @@
+mod support;
+
+use support::*;
+
+const RUN_JSON: &str = r#"{
+    "id":"run-1",
+    "provider":"managed",
+    "model":"gpt-5.4",
+    "status":"running",
+    "messages":[
+        {"role":"system","text":"Be concise."},
+        {"role":"user","text":"Summarize the roadmap risk."}
+    ],
+    "sessionRef":"session-1",
+    "createdAt":"2026-04-22T00:00:00Z",
+    "executionRef":"run-1"
+}"#;
+
+#[test]
+fn test_cli_creates_agent_run() {
+    let mut server = Server::new();
+    let _mock = authed_json_mock!(
+        server,
+        Method::POST,
+        "/api/v1/agent/runs",
+        StatusCode::CREATED
+    )
+    .match_header(header::CONTENT_TYPE.as_str(), http::APPLICATION_JSON)
+    .match_body(Matcher::JsonString(
+        r#"{
+                "provider":"managed",
+                "model":"gpt-5.4",
+                "idempotencyKey":"agent-create-1",
+                "messages":[
+                    {"role":"system","text":"Be concise."},
+                    {"role":"user","text":"Summarize the roadmap risk."}
+                ],
+                "toolRefs":[
+                    {"pluginName":"roadmap","operation":"sync"}
+                ]
+            }"#
+        .to_string(),
+    ))
+    .with_body(RUN_JSON)
+    .create();
+
+    let home = tempfile::tempdir().unwrap();
+    cli_command_for_server(home.path(), &server)
+        .args([
+            "agent",
+            "runs",
+            "create",
+            "--provider",
+            "managed",
+            "--model",
+            "gpt-5.4",
+            "--system",
+            "Be concise.",
+            "--message",
+            "Summarize the roadmap risk.",
+            "--tool",
+            "roadmap:sync",
+            "--idempotency-key",
+            "agent-create-1",
+        ])
+        .assert()
+        .success()
+        .stdout(predicate::str::contains("run-1"))
+        .stdout(predicate::str::contains("managed"));
+}
+
+#[test]
+fn test_cli_lists_agent_runs_with_server_side_filters() {
+    let mut server = Server::new();
+    let _mock = authed_json_mock!(
+        server,
+        Method::GET,
+        "/api/v1/agent/runs?provider=managed&status=running",
+        StatusCode::OK
+    )
+        .with_body(
+            r#"[
+                {"id":"run-a","provider":"managed","model":"gpt-5.4","status":"running","createdAt":"2026-04-22T00:00:00Z"}
+            ]"#,
+        )
+        .create();
+
+    let home = tempfile::tempdir().unwrap();
+    cli_command_for_server(home.path(), &server)
+        .args([
+            "agent",
+            "runs",
+            "list",
+            "--provider",
+            "managed",
+            "--status",
+            "running",
+        ])
+        .assert()
+        .success()
+        .stdout(predicate::str::contains("run-a"));
+}
+
+#[test]
+fn test_cli_gets_agent_run() {
+    let mut server = Server::new();
+    let _mock = authed_json_mock!(
+        server,
+        Method::GET,
+        "/api/v1/agent/runs/run-1",
+        StatusCode::OK
+    )
+    .with_body(RUN_JSON)
+    .create();
+
+    let home = tempfile::tempdir().unwrap();
+    cli_command_for_server(home.path(), &server)
+        .args(["agent", "runs", "get", "run-1"])
+        .assert()
+        .success()
+        .stdout(predicate::str::contains("run-1"))
+        .stdout(predicate::str::contains("gpt-5.4"));
+}
+
+#[test]
+fn test_cli_cancels_agent_run() {
+    let mut server = Server::new();
+    let _mock = authed_json_mock!(
+        server,
+        Method::POST,
+        "/api/v1/agent/runs/run-1/cancel",
+        StatusCode::OK
+    )
+    .match_header(header::CONTENT_TYPE.as_str(), http::APPLICATION_JSON)
+    .match_body(Matcher::JsonString(r#"{"reason":"stop now"}"#.to_string()))
+    .with_body(
+        r#"{
+                    "id":"run-1",
+                    "provider":"managed",
+                    "model":"gpt-5.4",
+                    "status":"canceled",
+                    "createdAt":"2026-04-22T00:00:00Z"
+                }"#,
+    )
+    .create();
+
+    let home = tempfile::tempdir().unwrap();
+    cli_command_for_server(home.path(), &server)
+        .args(["agent", "runs", "cancel", "run-1", "--reason", "stop now"])
+        .assert()
+        .success()
+        .stdout(predicate::str::contains("canceled"));
+}

--- a/gestaltd/internal/agentmanager/manager.go
+++ b/gestaltd/internal/agentmanager/manager.go
@@ -42,6 +42,7 @@ type Service interface {
 	Run(ctx context.Context, p *principal.Principal, req coreagent.ManagerRunRequest) (*coreagent.ManagedRun, error)
 	GetRun(ctx context.Context, p *principal.Principal, runID string) (*coreagent.ManagedRun, error)
 	ListRuns(ctx context.Context, p *principal.Principal) ([]*coreagent.ManagedRun, error)
+	ListRunsByProvider(ctx context.Context, p *principal.Principal, providerName string) ([]*coreagent.ManagedRun, error)
 	CancelRun(ctx context.Context, p *principal.Principal, runID, reason string) (*coreagent.ManagedRun, error)
 }
 
@@ -203,11 +204,27 @@ func (m *Manager) GetRun(ctx context.Context, p *principal.Principal, runID stri
 }
 
 func (m *Manager) ListRuns(ctx context.Context, p *principal.Principal) ([]*coreagent.ManagedRun, error) {
+	return m.listRuns(ctx, p, "")
+}
+
+func (m *Manager) ListRunsByProvider(ctx context.Context, p *principal.Principal, providerName string) ([]*coreagent.ManagedRun, error) {
+	return m.listRuns(ctx, p, providerName)
+}
+
+func (m *Manager) listRuns(ctx context.Context, p *principal.Principal, providerName string) ([]*coreagent.ManagedRun, error) {
 	refs, err := m.listOwnedRunMetadata(ctx, p, false)
 	if err != nil {
 		return nil, err
 	}
 	refsByProvider := executionRefsByProvider(refs)
+	providerName = strings.TrimSpace(providerName)
+	if providerName != "" {
+		if providerRefs, ok := refsByProvider[providerName]; ok {
+			refsByProvider = map[string][]*coreagent.ExecutionReference{providerName: providerRefs}
+		} else {
+			refsByProvider = map[string][]*coreagent.ExecutionReference{}
+		}
+	}
 	out := make([]*coreagent.ManagedRun, 0, len(refs))
 	for providerName, providerRefs := range refsByProvider {
 		provider, err := m.resolveProviderByName(providerName)

--- a/gestaltd/internal/bootstrap/lazy_agent_manager.go
+++ b/gestaltd/internal/bootstrap/lazy_agent_manager.go
@@ -49,6 +49,14 @@ func (l *lazyAgentManager) ListRuns(ctx context.Context, p *principal.Principal)
 	return target.ListRuns(ctx, p)
 }
 
+func (l *lazyAgentManager) ListRunsByProvider(ctx context.Context, p *principal.Principal, providerName string) ([]*coreagent.ManagedRun, error) {
+	target, err := l.current()
+	if err != nil {
+		return nil, err
+	}
+	return target.ListRunsByProvider(ctx, p, providerName)
+}
+
 func (l *lazyAgentManager) CancelRun(ctx context.Context, p *principal.Principal, runID, reason string) (*coreagent.ManagedRun, error) {
 	target, err := l.current()
 	if err != nil {

--- a/gestaltd/internal/bootstrap/provider_build.go
+++ b/gestaltd/internal/bootstrap/provider_build.go
@@ -1619,6 +1619,10 @@ func (unavailableAgentManager) ListRuns(context.Context, *principal.Principal) (
 	return nil, fmt.Errorf("agent manager is not available")
 }
 
+func (unavailableAgentManager) ListRunsByProvider(context.Context, *principal.Principal, string) ([]*coreagent.ManagedRun, error) {
+	return nil, fmt.Errorf("agent manager is not available")
+}
+
 func (unavailableAgentManager) CancelRun(context.Context, *principal.Principal, string, string) (*coreagent.ManagedRun, error) {
 	return nil, fmt.Errorf("agent manager is not available")
 }

--- a/gestaltd/internal/server/agent_run_test.go
+++ b/gestaltd/internal/server/agent_run_test.go
@@ -1,0 +1,493 @@
+package server_test
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"errors"
+	"maps"
+	"net/http"
+	"slices"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/valon-technologies/gestalt/server/core"
+	coreagent "github.com/valon-technologies/gestalt/server/core/agent"
+	coretesting "github.com/valon-technologies/gestalt/server/core/testing"
+	"github.com/valon-technologies/gestalt/server/internal/agentmanager"
+	"github.com/valon-technologies/gestalt/server/internal/principal"
+	"github.com/valon-technologies/gestalt/server/internal/server"
+	"github.com/valon-technologies/gestalt/server/internal/testutil"
+)
+
+type stubAgentControl struct {
+	defaultProviderName string
+	provider            coreagent.Provider
+	providers           map[string]coreagent.Provider
+	selectionErr        error
+	providerErr         error
+}
+
+func (s *stubAgentControl) ResolveProviderSelection(name string) (string, coreagent.Provider, error) {
+	if s.selectionErr != nil {
+		return "", nil, s.selectionErr
+	}
+	name = strings.TrimSpace(name)
+	if name == "" {
+		name = s.defaultProviderName
+	}
+	if name == "" {
+		return "", nil, errors.New("provider not found")
+	}
+	provider, err := s.ResolveProvider(name)
+	if err != nil {
+		return "", nil, err
+	}
+	return name, provider, nil
+}
+
+func (s *stubAgentControl) ResolveProvider(name string) (coreagent.Provider, error) {
+	if s.providerErr != nil {
+		return nil, s.providerErr
+	}
+	if s.providers != nil {
+		provider, ok := s.providers[name]
+		if !ok {
+			return nil, errors.New("provider not found")
+		}
+		return provider, nil
+	}
+	return s.provider, nil
+}
+
+func (s *stubAgentControl) ProviderNames() []string {
+	if s.providers != nil {
+		names := make([]string, 0, len(s.providers))
+		for name := range s.providers {
+			names = append(names, name)
+		}
+		slices.Sort(names)
+		return names
+	}
+	if strings.TrimSpace(s.defaultProviderName) != "" {
+		return []string{strings.TrimSpace(s.defaultProviderName)}
+	}
+	if s.provider != nil {
+		return []string{"default"}
+	}
+	return nil
+}
+
+type memoryAgentProvider struct {
+	startRunRequests []coreagent.StartRunRequest
+	cancelRequests   []coreagent.CancelRunRequest
+	runs             map[string]*coreagent.Run
+	getRunErr        error
+	listRunsErr      error
+	cancelRunErr     error
+}
+
+func newMemoryAgentProvider() *memoryAgentProvider {
+	return &memoryAgentProvider{runs: map[string]*coreagent.Run{}}
+}
+
+func (p *memoryAgentProvider) StartRun(_ context.Context, req coreagent.StartRunRequest) (*coreagent.Run, error) {
+	p.startRunRequests = append(p.startRunRequests, req)
+	now := time.Now().UTC().Truncate(time.Second)
+	run := &coreagent.Run{
+		ID:           req.RunID,
+		ProviderName: req.ProviderName,
+		Model:        req.Model,
+		Status:       coreagent.RunStatusRunning,
+		Messages:     append([]coreagent.Message(nil), req.Messages...),
+		SessionRef:   req.SessionRef,
+		CreatedBy:    req.CreatedBy,
+		CreatedAt:    &now,
+		StartedAt:    &now,
+		ExecutionRef: req.ExecutionRef,
+	}
+	p.runs[req.RunID] = run
+	return cloneAgentRun(run), nil
+}
+
+func (p *memoryAgentProvider) GetRun(_ context.Context, req coreagent.GetRunRequest) (*coreagent.Run, error) {
+	if p.getRunErr != nil {
+		return nil, p.getRunErr
+	}
+	run, ok := p.runs[req.RunID]
+	if !ok || run == nil {
+		return nil, core.ErrNotFound
+	}
+	return cloneAgentRun(run), nil
+}
+
+func (p *memoryAgentProvider) ListRuns(_ context.Context, _ coreagent.ListRunsRequest) ([]*coreagent.Run, error) {
+	if p.listRunsErr != nil {
+		return nil, p.listRunsErr
+	}
+	out := make([]*coreagent.Run, 0, len(p.runs))
+	for _, run := range p.runs {
+		if run != nil {
+			out = append(out, cloneAgentRun(run))
+		}
+	}
+	return out, nil
+}
+
+func (p *memoryAgentProvider) CancelRun(_ context.Context, req coreagent.CancelRunRequest) (*coreagent.Run, error) {
+	if p.cancelRunErr != nil {
+		return nil, p.cancelRunErr
+	}
+	run, ok := p.runs[req.RunID]
+	if !ok || run == nil {
+		return nil, core.ErrNotFound
+	}
+	now := time.Now().UTC().Truncate(time.Second)
+	run.Status = coreagent.RunStatusCanceled
+	run.CompletedAt = &now
+	run.StatusMessage = strings.TrimSpace(req.Reason)
+	p.cancelRequests = append(p.cancelRequests, req)
+	return cloneAgentRun(run), nil
+}
+
+func (p *memoryAgentProvider) Ping(context.Context) error { return nil }
+func (p *memoryAgentProvider) Close() error               { return nil }
+
+func cloneAgentRun(run *coreagent.Run) *coreagent.Run {
+	if run == nil {
+		return nil
+	}
+	cloned := *run
+	cloned.Messages = append([]coreagent.Message(nil), run.Messages...)
+	cloned.StructuredOutput = maps.Clone(run.StructuredOutput)
+	return &cloned
+}
+
+type agentRunMessageResponse struct {
+	Role string `json:"role"`
+	Text string `json:"text"`
+}
+
+type agentRunResponse struct {
+	ID           string                    `json:"id"`
+	Provider     string                    `json:"provider"`
+	Model        string                    `json:"model"`
+	Status       string                    `json:"status"`
+	Messages     []agentRunMessageResponse `json:"messages"`
+	ExecutionRef string                    `json:"executionRef"`
+}
+
+func TestGlobalAgentRunLifecycleSupportsCreateListGetAndCancel(t *testing.T) {
+	t.Parallel()
+
+	services := coretesting.NewStubServices(t)
+	user := seedUser(t, services, "ada@example.test")
+	provider := newMemoryAgentProvider()
+	manager := agentmanager.New(agentmanager.Config{
+		Providers:   testutil.NewProviderRegistry(t),
+		Agent:       &stubAgentControl{defaultProviderName: "managed", provider: provider},
+		RunMetadata: services.AgentRunMetadata,
+	})
+
+	ts := newTestServer(t, func(cfg *server.Config) {
+		cfg.Auth = &coretesting.StubAuthProvider{
+			N: "stub",
+			ValidateTokenFn: func(_ context.Context, token string) (*core.UserIdentity, error) {
+				if token != "ada-session" {
+					return nil, core.ErrNotFound
+				}
+				return &core.UserIdentity{Email: user.Email, DisplayName: "Ada"}, nil
+			},
+		}
+		cfg.Services = services
+		cfg.AgentManager = manager
+	})
+	testutil.CloseOnCleanup(t, ts)
+
+	createBody := []byte(`{
+		"provider":"managed",
+		"model":"gpt-5.4",
+		"messages":[
+			{"role":"system","text":"Be concise."},
+			{"role":"user","text":"Summarize the roadmap risk."}
+		]
+	}`)
+	createReq, _ := http.NewRequest(http.MethodPost, ts.URL+"/api/v1/agent/runs/", bytes.NewReader(createBody))
+	createReq.Header.Set("Content-Type", "application/json")
+	createReq.Header.Set("Idempotency-Key", "agent-http-create-1")
+	createReq.AddCookie(&http.Cookie{Name: "session_token", Value: "ada-session"})
+	createResp, err := http.DefaultClient.Do(createReq)
+	if err != nil {
+		t.Fatalf("create request: %v", err)
+	}
+	defer func() { _ = createResp.Body.Close() }()
+	if createResp.StatusCode != http.StatusCreated {
+		t.Fatalf("expected 201, got %d", createResp.StatusCode)
+	}
+	var created agentRunResponse
+	if err := json.NewDecoder(createResp.Body).Decode(&created); err != nil {
+		t.Fatalf("decode create response: %v", err)
+	}
+	if created.Provider != "managed" || created.Model != "gpt-5.4" || created.Status != string(coreagent.RunStatusRunning) {
+		t.Fatalf("created run = %#v", created)
+	}
+	if len(created.Messages) != 2 || created.Messages[1].Text != "Summarize the roadmap risk." {
+		t.Fatalf("created messages = %#v", created.Messages)
+	}
+	if created.ExecutionRef != created.ID {
+		t.Fatalf("execution ref = %q, want %q", created.ExecutionRef, created.ID)
+	}
+	if len(provider.startRunRequests) != 1 {
+		t.Fatalf("StartRun count = %d, want 1", len(provider.startRunRequests))
+	}
+	if got := provider.startRunRequests[0].IdempotencyKey; got != "agent-http-create-1" {
+		t.Fatalf("StartRun idempotency key = %q, want %q", got, "agent-http-create-1")
+	}
+
+	listReq, _ := http.NewRequest(http.MethodGet, ts.URL+"/api/v1/agent/runs/?provider=managed&status=running", nil)
+	listReq.AddCookie(&http.Cookie{Name: "session_token", Value: "ada-session"})
+	listResp, err := http.DefaultClient.Do(listReq)
+	if err != nil {
+		t.Fatalf("list request: %v", err)
+	}
+	defer func() { _ = listResp.Body.Close() }()
+	if listResp.StatusCode != http.StatusOK {
+		t.Fatalf("expected 200, got %d", listResp.StatusCode)
+	}
+	var listed []agentRunResponse
+	if err := json.NewDecoder(listResp.Body).Decode(&listed); err != nil {
+		t.Fatalf("decode list response: %v", err)
+	}
+	if len(listed) != 1 || listed[0].ID != created.ID {
+		t.Fatalf("listed runs = %#v, want %q", listed, created.ID)
+	}
+
+	getReq, _ := http.NewRequest(http.MethodGet, ts.URL+"/api/v1/agent/runs/"+created.ID, nil)
+	getReq.AddCookie(&http.Cookie{Name: "session_token", Value: "ada-session"})
+	getResp, err := http.DefaultClient.Do(getReq)
+	if err != nil {
+		t.Fatalf("get request: %v", err)
+	}
+	defer func() { _ = getResp.Body.Close() }()
+	if getResp.StatusCode != http.StatusOK {
+		t.Fatalf("expected 200, got %d", getResp.StatusCode)
+	}
+	var fetched agentRunResponse
+	if err := json.NewDecoder(getResp.Body).Decode(&fetched); err != nil {
+		t.Fatalf("decode get response: %v", err)
+	}
+	if fetched.ID != created.ID || fetched.Status != string(coreagent.RunStatusRunning) {
+		t.Fatalf("fetched run = %#v", fetched)
+	}
+
+	cancelReq, _ := http.NewRequest(http.MethodPost, ts.URL+"/api/v1/agent/runs/"+created.ID+"/cancel", bytes.NewBufferString(`{"reason":"stop now"}`))
+	cancelReq.Header.Set("Content-Type", "application/json")
+	cancelReq.AddCookie(&http.Cookie{Name: "session_token", Value: "ada-session"})
+	cancelResp, err := http.DefaultClient.Do(cancelReq)
+	if err != nil {
+		t.Fatalf("cancel request: %v", err)
+	}
+	defer func() { _ = cancelResp.Body.Close() }()
+	if cancelResp.StatusCode != http.StatusOK {
+		t.Fatalf("expected 200, got %d", cancelResp.StatusCode)
+	}
+	var canceled agentRunResponse
+	if err := json.NewDecoder(cancelResp.Body).Decode(&canceled); err != nil {
+		t.Fatalf("decode cancel response: %v", err)
+	}
+	if canceled.Status != string(coreagent.RunStatusCanceled) {
+		t.Fatalf("canceled run = %#v", canceled)
+	}
+	if len(provider.cancelRequests) != 1 || provider.cancelRequests[0].Reason != "stop now" {
+		t.Fatalf("cancel requests = %#v", provider.cancelRequests)
+	}
+}
+
+func TestGlobalAgentRunListProviderFilterAvoidsUnhealthyProviders(t *testing.T) {
+	t.Parallel()
+
+	services := coretesting.NewStubServices(t)
+	user := seedUser(t, services, "ada@example.test")
+	managedProvider := newMemoryAgentProvider()
+	brokenProvider := newMemoryAgentProvider()
+	brokenProvider.listRunsErr = errors.New("provider is unavailable")
+
+	now := time.Now().UTC().Truncate(time.Second)
+	managedProvider.runs["run-managed"] = &coreagent.Run{
+		ID:           "run-managed",
+		ProviderName: "managed",
+		Model:        "gpt-5.4",
+		Status:       coreagent.RunStatusRunning,
+		CreatedAt:    &now,
+		ExecutionRef: "run-managed",
+	}
+	brokenProvider.runs["run-broken"] = &coreagent.Run{
+		ID:           "run-broken",
+		ProviderName: "broken",
+		Model:        "claude",
+		Status:       coreagent.RunStatusFailed,
+		CreatedAt:    &now,
+		ExecutionRef: "run-broken",
+	}
+
+	subjectID := principal.UserSubjectID(user.ID)
+	for _, ref := range []*coreagent.ExecutionReference{
+		{
+			ID:           "run-managed",
+			ProviderName: "managed",
+			SubjectID:    subjectID,
+		},
+		{
+			ID:           "run-broken",
+			ProviderName: "broken",
+			SubjectID:    subjectID,
+		},
+	} {
+		if _, err := services.AgentRunMetadata.Put(context.Background(), ref); err != nil {
+			t.Fatalf("Put agent run metadata %q: %v", ref.ID, err)
+		}
+	}
+
+	manager := agentmanager.New(agentmanager.Config{
+		Providers: testutil.NewProviderRegistry(t),
+		Agent: &stubAgentControl{
+			defaultProviderName: "managed",
+			providers: map[string]coreagent.Provider{
+				"managed": managedProvider,
+				"broken":  brokenProvider,
+			},
+		},
+		RunMetadata: services.AgentRunMetadata,
+	})
+
+	ts := newTestServer(t, func(cfg *server.Config) {
+		cfg.Auth = &coretesting.StubAuthProvider{
+			N: "stub",
+			ValidateTokenFn: func(_ context.Context, token string) (*core.UserIdentity, error) {
+				if token != "ada-session" {
+					return nil, core.ErrNotFound
+				}
+				return &core.UserIdentity{Email: user.Email, DisplayName: "Ada"}, nil
+			},
+		}
+		cfg.Services = services
+		cfg.AgentManager = manager
+	})
+	testutil.CloseOnCleanup(t, ts)
+
+	req, _ := http.NewRequest(http.MethodGet, ts.URL+"/api/v1/agent/runs/?provider=managed", nil)
+	req.AddCookie(&http.Cookie{Name: "session_token", Value: "ada-session"})
+	resp, err := http.DefaultClient.Do(req)
+	if err != nil {
+		t.Fatalf("list request: %v", err)
+	}
+	defer func() { _ = resp.Body.Close() }()
+	if resp.StatusCode != http.StatusOK {
+		t.Fatalf("expected 200, got %d", resp.StatusCode)
+	}
+	var listed []agentRunResponse
+	if err := json.NewDecoder(resp.Body).Decode(&listed); err != nil {
+		t.Fatalf("decode list response: %v", err)
+	}
+	if len(listed) != 1 || listed[0].ID != "run-managed" {
+		t.Fatalf("listed runs = %#v, want only run-managed", listed)
+	}
+}
+
+func TestGlobalAgentRunCreateRejectsMismatchedIdempotencyKeySources(t *testing.T) {
+	t.Parallel()
+
+	services := coretesting.NewStubServices(t)
+	user := seedUser(t, services, "ada@example.test")
+	provider := newMemoryAgentProvider()
+	manager := agentmanager.New(agentmanager.Config{
+		Providers:   testutil.NewProviderRegistry(t),
+		Agent:       &stubAgentControl{defaultProviderName: "managed", provider: provider},
+		RunMetadata: services.AgentRunMetadata,
+	})
+
+	ts := newTestServer(t, func(cfg *server.Config) {
+		cfg.Auth = &coretesting.StubAuthProvider{
+			N: "stub",
+			ValidateTokenFn: func(_ context.Context, token string) (*core.UserIdentity, error) {
+				if token != "ada-session" {
+					return nil, core.ErrNotFound
+				}
+				return &core.UserIdentity{Email: user.Email, DisplayName: "Ada"}, nil
+			},
+		}
+		cfg.Services = services
+		cfg.AgentManager = manager
+	})
+	testutil.CloseOnCleanup(t, ts)
+
+	req, _ := http.NewRequest(http.MethodPost, ts.URL+"/api/v1/agent/runs/", bytes.NewBufferString(`{"idempotencyKey":"body-key"}`))
+	req.Header.Set("Content-Type", "application/json")
+	req.Header.Set("Idempotency-Key", "header-key")
+	req.AddCookie(&http.Cookie{Name: "session_token", Value: "ada-session"})
+	resp, err := http.DefaultClient.Do(req)
+	if err != nil {
+		t.Fatalf("create request: %v", err)
+	}
+	defer func() { _ = resp.Body.Close() }()
+	if resp.StatusCode != http.StatusBadRequest {
+		t.Fatalf("expected 400, got %d", resp.StatusCode)
+	}
+	if len(provider.startRunRequests) != 0 {
+		t.Fatalf("unexpected StartRun requests = %#v", provider.startRunRequests)
+	}
+}
+
+func TestGlobalAgentRunCreateReturnsConflictWhileIdempotentRunIsInitializing(t *testing.T) {
+	t.Parallel()
+
+	services := coretesting.NewStubServices(t)
+	user := seedUser(t, services, "ada@example.test")
+	provider := newMemoryAgentProvider()
+	manager := agentmanager.New(agentmanager.Config{
+		Providers:   testutil.NewProviderRegistry(t),
+		Agent:       &stubAgentControl{defaultProviderName: "managed", provider: provider},
+		RunMetadata: services.AgentRunMetadata,
+	})
+
+	subjectID := principal.UserSubjectID(user.ID)
+	claimedRunID, claimed, err := services.AgentRunMetadata.ClaimIdempotency(context.Background(), subjectID, "managed", "pending-key", "pending-run", time.Now())
+	if err != nil {
+		t.Fatalf("ClaimIdempotency: %v", err)
+	}
+	if !claimed || claimedRunID != "pending-run" {
+		t.Fatalf("ClaimIdempotency = (%q, %t), want (%q, true)", claimedRunID, claimed, "pending-run")
+	}
+
+	ts := newTestServer(t, func(cfg *server.Config) {
+		cfg.Auth = &coretesting.StubAuthProvider{
+			N: "stub",
+			ValidateTokenFn: func(_ context.Context, token string) (*core.UserIdentity, error) {
+				if token != "ada-session" {
+					return nil, core.ErrNotFound
+				}
+				return &core.UserIdentity{Email: user.Email, DisplayName: "Ada"}, nil
+			},
+		}
+		cfg.Services = services
+		cfg.AgentManager = manager
+	})
+	testutil.CloseOnCleanup(t, ts)
+
+	req, _ := http.NewRequest(http.MethodPost, ts.URL+"/api/v1/agent/runs/", bytes.NewBufferString(`{"messages":[{"role":"user","text":"Continue"}]}`))
+	req.Header.Set("Content-Type", "application/json")
+	req.Header.Set("Idempotency-Key", "pending-key")
+	req.AddCookie(&http.Cookie{Name: "session_token", Value: "ada-session"})
+	resp, err := http.DefaultClient.Do(req)
+	if err != nil {
+		t.Fatalf("create request: %v", err)
+	}
+	defer func() { _ = resp.Body.Close() }()
+	if resp.StatusCode != http.StatusConflict {
+		t.Fatalf("expected 409, got %d", resp.StatusCode)
+	}
+	if len(provider.startRunRequests) != 0 {
+		t.Fatalf("unexpected StartRun requests = %#v", provider.startRunRequests)
+	}
+}

--- a/gestaltd/internal/server/handlers_agent_runs.go
+++ b/gestaltd/internal/server/handlers_agent_runs.go
@@ -1,0 +1,396 @@
+package server
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"io"
+	"log/slog"
+	"maps"
+	"net/http"
+	"strings"
+	"time"
+
+	"github.com/go-chi/chi/v5"
+	"github.com/valon-technologies/gestalt/server/core"
+	coreagent "github.com/valon-technologies/gestalt/server/core/agent"
+	"github.com/valon-technologies/gestalt/server/internal/agentmanager"
+	"github.com/valon-technologies/gestalt/server/internal/invocation"
+	"github.com/valon-technologies/gestalt/server/internal/principal"
+)
+
+const agentIdempotencyKeyHeader = "Idempotency-Key"
+
+type agentMessageRequest struct {
+	Role string `json:"role,omitempty"`
+	Text string `json:"text,omitempty"`
+}
+
+type agentToolRefRequest struct {
+	PluginName  string `json:"pluginName,omitempty"`
+	Operation   string `json:"operation,omitempty"`
+	Connection  string `json:"connection,omitempty"`
+	Instance    string `json:"instance,omitempty"`
+	Title       string `json:"title,omitempty"`
+	Description string `json:"description,omitempty"`
+}
+
+type agentRunCreateRequest struct {
+	ProviderName    string                `json:"provider,omitempty"`
+	Model           string                `json:"model,omitempty"`
+	Messages        []agentMessageRequest `json:"messages,omitempty"`
+	ToolRefs        []agentToolRefRequest `json:"toolRefs,omitempty"`
+	ToolSource      string                `json:"toolSource,omitempty"`
+	ResponseSchema  map[string]any        `json:"responseSchema,omitempty"`
+	SessionRef      string                `json:"sessionRef,omitempty"`
+	Metadata        map[string]any        `json:"metadata,omitempty"`
+	ProviderOptions map[string]any        `json:"providerOptions,omitempty"`
+	IdempotencyKey  string                `json:"idempotencyKey,omitempty"`
+}
+
+type agentRunCancelRequest struct {
+	Reason string `json:"reason,omitempty"`
+}
+
+type agentRunInfo struct {
+	ID               string                `json:"id"`
+	Provider         string                `json:"provider"`
+	Model            string                `json:"model,omitempty"`
+	Status           string                `json:"status,omitempty"`
+	Messages         []agentMessageRequest `json:"messages,omitempty"`
+	OutputText       string                `json:"outputText,omitempty"`
+	StructuredOutput map[string]any        `json:"structuredOutput,omitempty"`
+	StatusMessage    string                `json:"statusMessage,omitempty"`
+	SessionRef       string                `json:"sessionRef,omitempty"`
+	CreatedBy        *workflowActorInfo    `json:"createdBy,omitempty"`
+	CreatedAt        *time.Time            `json:"createdAt,omitempty"`
+	StartedAt        *time.Time            `json:"startedAt,omitempty"`
+	CompletedAt      *time.Time            `json:"completedAt,omitempty"`
+	ExecutionRef     string                `json:"executionRef,omitempty"`
+}
+
+func (s *Server) createGlobalAgentRun(w http.ResponseWriter, r *http.Request) {
+	p, ok := s.resolveAgentRunActor(w, r)
+	if !ok {
+		return
+	}
+	if s == nil || s.agentRuns == nil {
+		writeError(w, http.StatusPreconditionFailed, agentmanager.ErrAgentNotConfigured.Error())
+		return
+	}
+	var req agentRunCreateRequest
+	if r.Body != nil {
+		defer func() { _ = r.Body.Close() }()
+		if err := json.NewDecoder(r.Body).Decode(&req); err != nil && !errors.Is(err, io.EOF) {
+			writeError(w, http.StatusBadRequest, "invalid JSON body")
+			return
+		}
+	}
+	idempotencyKey := strings.TrimSpace(req.IdempotencyKey)
+	if headerKey := strings.TrimSpace(r.Header.Get(agentIdempotencyKeyHeader)); headerKey != "" {
+		if idempotencyKey != "" && idempotencyKey != headerKey {
+			writeError(w, http.StatusBadRequest, "idempotency key header and body must match")
+			return
+		}
+		idempotencyKey = headerKey
+	}
+	if err := validateAgentToolRefs(req.ToolRefs); err != nil {
+		writeError(w, http.StatusBadRequest, err.Error())
+		return
+	}
+	toolSource, err := agentToolSourceModeFromRequest(req.ToolSource)
+	if err != nil {
+		writeError(w, http.StatusBadRequest, err.Error())
+		return
+	}
+	managed, err := s.agentRuns.Run(r.Context(), p, coreagent.ManagerRunRequest{
+		ProviderName:    strings.TrimSpace(req.ProviderName),
+		Model:           strings.TrimSpace(req.Model),
+		Messages:        agentMessagesFromRequest(req.Messages),
+		ToolRefs:        agentToolRefsFromRequest(req.ToolRefs),
+		ToolSource:      toolSource,
+		ResponseSchema:  maps.Clone(req.ResponseSchema),
+		SessionRef:      strings.TrimSpace(req.SessionRef),
+		Metadata:        maps.Clone(req.Metadata),
+		ProviderOptions: maps.Clone(req.ProviderOptions),
+		IdempotencyKey:  idempotencyKey,
+	})
+	if err != nil {
+		s.writeAgentRunManagerError(w, r, "", req, err)
+		return
+	}
+	writeJSON(w, http.StatusCreated, agentRunInfoFromManaged(managed))
+}
+
+func (s *Server) listGlobalAgentRuns(w http.ResponseWriter, r *http.Request) {
+	p, ok := s.resolveAgentRunActor(w, r)
+	if !ok {
+		return
+	}
+	if s == nil || s.agentRuns == nil {
+		writeError(w, http.StatusPreconditionFailed, agentmanager.ErrAgentNotConfigured.Error())
+		return
+	}
+	providerFilter := strings.TrimSpace(r.URL.Query().Get("provider"))
+	var (
+		err  error
+		runs []*coreagent.ManagedRun
+	)
+	if providerFilter != "" {
+		runs, err = s.agentRuns.ListRunsByProvider(r.Context(), p, providerFilter)
+	} else {
+		runs, err = s.agentRuns.ListRuns(r.Context(), p)
+	}
+	if err != nil {
+		s.writeAgentRunManagerError(w, r, "", agentRunCreateRequest{}, err)
+		return
+	}
+	statusFilter := strings.TrimSpace(r.URL.Query().Get("status"))
+	out := make([]agentRunInfo, 0, len(runs))
+	for _, managed := range runs {
+		if managed == nil || managed.Run == nil {
+			continue
+		}
+		if providerFilter != "" && strings.TrimSpace(managed.ProviderName) != providerFilter {
+			continue
+		}
+		if statusFilter != "" && strings.TrimSpace(string(managed.Run.Status)) != statusFilter {
+			continue
+		}
+		out = append(out, agentRunInfoFromManaged(managed))
+	}
+	writeJSON(w, http.StatusOK, out)
+}
+
+func (s *Server) getGlobalAgentRun(w http.ResponseWriter, r *http.Request) {
+	p, ok := s.resolveAgentRunActor(w, r)
+	if !ok {
+		return
+	}
+	if s == nil || s.agentRuns == nil {
+		writeError(w, http.StatusPreconditionFailed, agentmanager.ErrAgentNotConfigured.Error())
+		return
+	}
+	runID := chi.URLParam(r, "runID")
+	managed, err := s.agentRuns.GetRun(r.Context(), p, runID)
+	if err != nil {
+		s.writeAgentRunManagerError(w, r, runID, agentRunCreateRequest{}, err)
+		return
+	}
+	writeJSON(w, http.StatusOK, agentRunInfoFromManaged(managed))
+}
+
+func (s *Server) cancelGlobalAgentRun(w http.ResponseWriter, r *http.Request) {
+	p, ok := s.resolveAgentRunActor(w, r)
+	if !ok {
+		return
+	}
+	if s == nil || s.agentRuns == nil {
+		writeError(w, http.StatusPreconditionFailed, agentmanager.ErrAgentNotConfigured.Error())
+		return
+	}
+	var req agentRunCancelRequest
+	if r.Body != nil {
+		defer func() { _ = r.Body.Close() }()
+		if err := json.NewDecoder(r.Body).Decode(&req); err != nil && !errors.Is(err, io.EOF) {
+			writeError(w, http.StatusBadRequest, "invalid JSON body")
+			return
+		}
+	}
+	runID := chi.URLParam(r, "runID")
+	managed, err := s.agentRuns.CancelRun(r.Context(), p, runID, req.Reason)
+	if err != nil {
+		s.writeAgentRunManagerError(w, r, runID, agentRunCreateRequest{}, err)
+		return
+	}
+	writeJSON(w, http.StatusOK, agentRunInfoFromManaged(managed))
+}
+
+func (s *Server) resolveAgentRunActor(w http.ResponseWriter, r *http.Request) (*principal.Principal, bool) {
+	return s.resolveWorkflowScheduleActor(w, r)
+}
+
+func agentMessagesFromRequest(messages []agentMessageRequest) []coreagent.Message {
+	if len(messages) == 0 {
+		return nil
+	}
+	out := make([]coreagent.Message, 0, len(messages))
+	for _, message := range messages {
+		out = append(out, coreagent.Message{
+			Role: strings.TrimSpace(message.Role),
+			Text: message.Text,
+		})
+	}
+	return out
+}
+
+func agentToolRefsFromRequest(refs []agentToolRefRequest) []coreagent.ToolRef {
+	if len(refs) == 0 {
+		return nil
+	}
+	out := make([]coreagent.ToolRef, 0, len(refs))
+	for _, ref := range refs {
+		out = append(out, coreagent.ToolRef{
+			PluginName:  strings.TrimSpace(ref.PluginName),
+			Operation:   strings.TrimSpace(ref.Operation),
+			Connection:  strings.TrimSpace(ref.Connection),
+			Instance:    strings.TrimSpace(ref.Instance),
+			Title:       strings.TrimSpace(ref.Title),
+			Description: strings.TrimSpace(ref.Description),
+		})
+	}
+	return out
+}
+
+func validateAgentToolRefs(refs []agentToolRefRequest) error {
+	for idx, ref := range refs {
+		if strings.TrimSpace(ref.PluginName) == "" {
+			return fmt.Errorf("toolRefs[%d].pluginName is required", idx)
+		}
+		if strings.TrimSpace(ref.Operation) == "" {
+			return fmt.Errorf("toolRefs[%d].operation is required", idx)
+		}
+	}
+	return nil
+}
+
+func agentToolSourceModeFromRequest(value string) (coreagent.ToolSourceMode, error) {
+	switch strings.TrimSpace(value) {
+	case "":
+		return coreagent.ToolSourceModeUnspecified, nil
+	case string(coreagent.ToolSourceModeExplicit):
+		return coreagent.ToolSourceModeExplicit, nil
+	case string(coreagent.ToolSourceModeInheritInvokes):
+		return coreagent.ToolSourceModeInheritInvokes, nil
+	default:
+		return "", fmt.Errorf("unsupported agent tool source %q", value)
+	}
+}
+
+func agentRunInfoFromManaged(managed *coreagent.ManagedRun) agentRunInfo {
+	if managed == nil {
+		return agentRunInfo{}
+	}
+	return agentRunInfoFromCore(managed.Run, strings.TrimSpace(managed.ProviderName))
+}
+
+func agentRunInfoFromCore(run *coreagent.Run, providerName string) agentRunInfo {
+	info := agentRunInfo{Provider: providerName}
+	if run == nil {
+		return info
+	}
+	info.ID = run.ID
+	info.Model = strings.TrimSpace(run.Model)
+	info.Status = strings.TrimSpace(string(run.Status))
+	info.Messages = agentMessageInfoFromCore(run.Messages)
+	info.OutputText = run.OutputText
+	info.StructuredOutput = maps.Clone(run.StructuredOutput)
+	info.StatusMessage = run.StatusMessage
+	info.SessionRef = run.SessionRef
+	info.CreatedBy = agentActorInfoFromCore(run.CreatedBy)
+	info.CreatedAt = run.CreatedAt
+	info.StartedAt = run.StartedAt
+	info.CompletedAt = run.CompletedAt
+	info.ExecutionRef = strings.TrimSpace(run.ExecutionRef)
+	return info
+}
+
+func agentMessageInfoFromCore(messages []coreagent.Message) []agentMessageRequest {
+	if len(messages) == 0 {
+		return nil
+	}
+	out := make([]agentMessageRequest, 0, len(messages))
+	for _, message := range messages {
+		out = append(out, agentMessageRequest{
+			Role: strings.TrimSpace(message.Role),
+			Text: message.Text,
+		})
+	}
+	return out
+}
+
+func agentActorInfoFromCore(actor coreagent.Actor) *workflowActorInfo {
+	if actor == (coreagent.Actor{}) {
+		return nil
+	}
+	return &workflowActorInfo{
+		SubjectID:   actor.SubjectID,
+		SubjectKind: actor.SubjectKind,
+		DisplayName: actor.DisplayName,
+		AuthSource:  actor.AuthSource,
+	}
+}
+
+func (s *Server) writeAgentRunManagerError(w http.ResponseWriter, r *http.Request, runID string, req agentRunCreateRequest, err error) {
+	pluginName, operation := firstAgentToolTarget(req.ToolRefs)
+	switch {
+	case errors.Is(err, agentmanager.ErrAgentNotConfigured),
+		errors.Is(err, agentmanager.ErrAgentRunMetadataNotConfigured):
+		writeError(w, http.StatusPreconditionFailed, err.Error())
+	case errors.Is(err, agentmanager.ErrAgentSubjectRequired):
+		writeError(w, http.StatusUnauthorized, err.Error())
+	case errors.Is(err, agentmanager.ErrAgentRunCreationInProgress):
+		writeError(w, http.StatusConflict, err.Error())
+	case errors.Is(err, agentmanager.ErrAgentCallerPluginRequired),
+		errors.Is(err, agentmanager.ErrAgentInheritedSurfaceTool):
+		writeError(w, http.StatusBadRequest, err.Error())
+	case errors.Is(err, invocation.ErrProviderNotFound),
+		errors.Is(err, invocation.ErrOperationNotFound),
+		errors.Is(err, invocation.ErrNotAuthenticated),
+		errors.Is(err, invocation.ErrAuthorizationDenied),
+		errors.Is(err, invocation.ErrScopeDenied),
+		errors.Is(err, invocation.ErrNoToken),
+		errors.Is(err, invocation.ErrReconnectRequired),
+		errors.Is(err, invocation.ErrAmbiguousInstance),
+		errors.Is(err, invocation.ErrUserResolution),
+		errors.Is(err, invocation.ErrInternal),
+		errors.Is(err, core.ErrMCPOnly):
+		s.writeAgentRunTargetError(w, r, pluginName, operation, err)
+	case errors.Is(err, core.ErrNotFound):
+		s.writeAgentRunProviderError(r.Context(), w, runID, err)
+	default:
+		s.writeAgentRunProviderError(r.Context(), w, runID, err)
+	}
+}
+
+func (s *Server) writeAgentRunTargetError(w http.ResponseWriter, r *http.Request, pluginName, operation string, err error) {
+	switch {
+	case errors.Is(err, invocation.ErrProviderNotFound),
+		errors.Is(err, invocation.ErrOperationNotFound),
+		errors.Is(err, invocation.ErrNotAuthenticated),
+		errors.Is(err, invocation.ErrAuthorizationDenied),
+		errors.Is(err, invocation.ErrScopeDenied),
+		errors.Is(err, invocation.ErrNoToken),
+		errors.Is(err, invocation.ErrReconnectRequired),
+		errors.Is(err, invocation.ErrAmbiguousInstance),
+		errors.Is(err, invocation.ErrUserResolution),
+		errors.Is(err, invocation.ErrInternal),
+		errors.Is(err, core.ErrMCPOnly):
+		s.writeInvocationError(w, r, pluginName, operation, err)
+	default:
+		writeError(w, http.StatusBadRequest, err.Error())
+	}
+}
+
+func (s *Server) writeAgentRunProviderError(ctx context.Context, w http.ResponseWriter, runID string, err error) {
+	switch {
+	case errors.Is(err, core.ErrNotFound):
+		writeError(w, http.StatusNotFound, fmt.Sprintf("agent run %q not found", runID))
+	default:
+		slog.ErrorContext(ctx, "agent run provider error", "run_id", runID, "error", err)
+		writeError(w, http.StatusInternalServerError, "agent run request failed")
+	}
+}
+
+func firstAgentToolTarget(refs []agentToolRefRequest) (string, string) {
+	for _, ref := range refs {
+		pluginName := strings.TrimSpace(ref.PluginName)
+		operation := strings.TrimSpace(ref.Operation)
+		if pluginName == "" && operation == "" {
+			continue
+		}
+		return pluginName, operation
+	}
+	return "", ""
+}

--- a/gestaltd/internal/server/routes_user.go
+++ b/gestaltd/internal/server/routes_user.go
@@ -33,6 +33,12 @@ func (s *Server) mountAuthenticatedRoutes(r chi.Router) {
 			r.Get("/{runID}", s.getGlobalWorkflowRun)
 			r.Post("/{runID}/cancel", s.cancelGlobalWorkflowRun)
 		})
+		r.Route("/agent/runs", func(r chi.Router) {
+			r.Post("/", s.createGlobalAgentRun)
+			r.Get("/", s.listGlobalAgentRuns)
+			r.Get("/{runID}", s.getGlobalAgentRun)
+			r.Post("/{runID}/cancel", s.cancelGlobalAgentRun)
+		})
 
 		r.Post("/auth/start-oauth", s.startIntegrationOAuth)
 		r.Post("/auth/connect-manual", s.connectManual)

--- a/gestaltd/internal/server/runtime.go
+++ b/gestaltd/internal/server/runtime.go
@@ -67,6 +67,7 @@ func Run(ctx context.Context, cfg *config.Config, result *bootstrap.Result) erro
 		AuditSink:            result.AuditSink,
 		Services:             result.Services,
 		Providers:            result.Providers,
+		AgentManager:         result.AgentManager,
 		Workflow:             result.WorkflowControl,
 		PluginRuntimes:       result.PluginRuntimes,
 		Invoker:              httpInvoker,

--- a/gestaltd/internal/server/server.go
+++ b/gestaltd/internal/server/server.go
@@ -11,6 +11,7 @@ import (
 	"github.com/valon-technologies/gestalt/server/core"
 	cryptoutil "github.com/valon-technologies/gestalt/server/core/crypto"
 	"github.com/valon-technologies/gestalt/server/core/session"
+	"github.com/valon-technologies/gestalt/server/internal/agentmanager"
 	"github.com/valon-technologies/gestalt/server/internal/authorization"
 	"github.com/valon-technologies/gestalt/server/internal/bootstrap"
 	"github.com/valon-technologies/gestalt/server/internal/config"
@@ -90,6 +91,7 @@ type Server struct {
 	identityPluginAccess   *coredata.IdentityPluginAccessService
 	workflowExecutionRefs  *coredata.WorkflowExecutionRefService
 	workflowSchedules      *workflowmanager.Manager
+	agentRuns              agentmanager.Service
 	authorizationProvider  core.AuthorizationProvider
 	managedIdentityMu      sync.Mutex
 	providers              *registry.ProviderMap[core.Provider]
@@ -142,6 +144,7 @@ type Config struct {
 	AuditSink             core.AuditSink
 	Services              *coredata.Services
 	Providers             *registry.ProviderMap[core.Provider]
+	AgentManager          agentmanager.Service
 	Workflow              bootstrap.WorkflowControl
 	PluginRuntimes        bootstrap.RuntimeInspector
 	Invoker               invocation.Invoker
@@ -292,6 +295,7 @@ func New(cfg Config) (*Server, error) {
 		workspaceRoles:         workspaceRoles,
 		identityPluginAccess:   identityPluginAccess,
 		workflowExecutionRefs:  workflowExecutionRefs,
+		agentRuns:              cfg.AgentManager,
 		authorizationProvider:  cfg.AuthorizationProvider,
 		providers:              cfg.Providers,
 		workflow:               cfg.Workflow,


### PR DESCRIPTION
## Summary
This adds the first user-facing agent run surface on top of the new primitive:
- HTTP routes under `/api/v1/agent/runs`
- `gestalt agent runs ...` CLI commands
- provider-scoped list filtering so filtered requests do not fan out across unrelated providers
- operator and authoring docs for `providers.agent`, `kind: agent`, and SDK agent entrypoints

## New Interfaces
- HTTP:
  - `POST /api/v1/agent/runs`
  - `GET /api/v1/agent/runs`
  - `GET /api/v1/agent/runs/{runID}`
  - `POST /api/v1/agent/runs/{runID}/cancel`
- CLI:
  - `gestalt agent runs create`
  - `gestalt agent runs list`
  - `gestalt agent runs get`
  - `gestalt agent runs cancel`
- Docs:
  - `/providers/agent`
  - `/custom-providers/agent`
  - `providers.agent` in config reference
  - `kind: agent` in provider manifest reference
  - agent examples in SDK landing pages

## Examples
### YAML
```yaml
providers:
  agent:
    managed:
      source: ./providers/agent/openai/manifest.yaml
      default: true
      config:
        model: gpt-5.4
```

### JSON: HTTP create request
```json
{
  "provider": "managed",
  "model": "gpt-5.4",
  "idempotencyKey": "agent-run-1",
  "messages": [
    { "role": "system", "text": "Be concise." },
    { "role": "user", "text": "Summarize the roadmap risk." }
  ],
  "toolRefs": [
    { "pluginName": "roadmap", "operation": "sync" }
  ],
  "toolSource": "explicit",
  "sessionRef": "session-1"
}
```

### JSON: HTTP create response
```json
{
  "id": "run-1",
  "provider": "managed",
  "model": "gpt-5.4",
  "status": "pending",
  "messages": [
    { "role": "system", "text": "Be concise." },
    { "role": "user", "text": "Summarize the roadmap risk." }
  ],
  "sessionRef": "session-1",
  "createdAt": "2026-04-22T00:00:00Z",
  "executionRef": "run-1"
}
```

### stdin/stdout
```sh
cat <<'JSON' | gestalt --format json agent runs create --request-file -
{
  "provider": "managed",
  "model": "gpt-5.4",
  "idempotencyKey": "agent-run-stdin-1",
  "messages": [
    { "role": "user", "text": "Summarize the roadmap risk." }
  ],
  "toolRefs": [
    { "pluginName": "roadmap", "operation": "sync" }
  ],
  "responseSchema": {
    "type": "object",
    "properties": {
      "summary": { "type": "string" }
    },
    "required": ["summary"]
  }
}
JSON
```

### Golang
```go
payload := map[string]any{
	"provider": "managed",
	"model": "gpt-5.4",
	"messages": []map[string]string{
		{"role": "user", "text": "Summarize the roadmap risk."},
	},
	"toolRefs": []map[string]string{
		{"pluginName": "roadmap", "operation": "sync"},
	},
}

body, _ := json.Marshal(payload)
req, _ := http.NewRequest(http.MethodPost, baseURL+"/api/v1/agent/runs", bytes.NewReader(body))
req.Header.Set("Authorization", "Bearer "+token)
req.Header.Set("Content-Type", "application/json")
req.Header.Set("Idempotency-Key", "agent-run-1")
```

### TypeScript
```ts
const response = await fetch(`${baseUrl}/api/v1/agent/runs`, {
  method: "POST",
  headers: {
    authorization: `Bearer ${token}`,
    "content-type": "application/json",
    "idempotency-key": "agent-run-1",
  },
  body: JSON.stringify({
    provider: "managed",
    model: "gpt-5.4",
    messages: [{ role: "user", text: "Summarize the roadmap risk." }],
    toolRefs: [{ pluginName: "roadmap", operation: "sync" }],
  }),
});
```

## Verification
- `go test ./internal/server -run 'TestGlobalAgentRunLifecycleSupportsCreateListGetAndCancel|TestGlobalAgentRunListProviderFilterAvoidsUnhealthyProviders|TestGlobalAgentRunCreateRejectsMismatchedIdempotencyKeySources|TestGlobalAgentRunCreateReturnsConflictWhileIdempotentRunIsInitializing|TestGlobalWorkflowRunInspectionIncludesHistoricalRevokedRefs|TestGlobalWorkflowRunInspectionAPITokenScopeFiltersOperations'`
- `cargo test --test agents_cli --test workflows_cli`
- `git diff --check`

## Notes
- I accepted the review feedback around provider-scoped filtered listing and real CLI query params.
- I expanded the docs beyond the route table: provider/config docs, custom-provider authoring docs, manifest-kind docs, richer HTTP/CLI examples, and short agent examples on the SDK landing pages.
- `go test ./cmd/gestaltd` is still flaky here on long-running hosted-runtime E2E cases unrelated to the agent routes themselves. The focused agent/server and CLI coverage passed.
