### PR TITLE
docs: explain event-driven workflow composition

### DIFF
--- a/docs/content/client/cli/index.mdx
+++ b/docs/content/client/cli/index.mdx
@@ -231,7 +231,9 @@ gestalt workflows events publish \
 The publish command sends one event to `POST /api/v1/workflow/events`. Gestalt
 fills in the event ID, spec version, and timestamp when you omit them, then
 fans the event out across the configured workflow providers so matching
-triggers can create runs.
+triggers can create runs. In practice, this is how multi-step workflows are
+composed today: one operation publishes a domain event, and later triggers
+start the next operations.
 
 ### Runs
 

--- a/docs/content/custom-providers/workflow.mdx
+++ b/docs/content/custom-providers/workflow.mdx
@@ -10,6 +10,12 @@ Workflow providers back global workflow runs, schedules, and triggers.
 Gestalt uses them to persist workflow state and to call back into target plugin
 operations through the workflow host socket.
 
+This runtime is not a declarative DAG planner. Gestalt does not hand a workflow
+provider a graph of named steps. A provider stores schedules, triggers, runs,
+and events, then asks Gestalt to invoke one explicit target operation at a
+time. Larger flows are composed above this layer by publishing events and
+attaching more triggers to those events.
+
 ## Manifest
 
 A workflow provider manifest declares `kind: workflow`:

--- a/docs/content/providers/workflow.mdx
+++ b/docs/content/providers/workflow.mdx
@@ -439,17 +439,6 @@ workflow manager `PublishEvent` call. External publishing is useful when some
 other system already knows the step finished. Plugin-side publishing is useful
 when the operation itself owns the next handoff.
 
-If you need fan-in, joins, or barrier-style behavior, add a coordinator step.
-Let each branch publish its own completion event, have a coordinator operation
-record progress in IndexedDB or another durable store, and publish a final
-event only after it sees all required completions. That gives you DAG-like
-behavior, but the join logic lives in plugin code rather than in workflow
-configuration.
-
-This means Gestalt is best described today as event-driven orchestration and
-delayed execution. It does not yet expose first-class DAG nodes, built-in join
-semantics, a `run now` endpoint, or a retry endpoint for failed runs.
-
 ## Inspecting and canceling workflow runs
 
 Runs are the execution records produced by schedules, triggers, or other

--- a/docs/content/providers/workflow.mdx
+++ b/docs/content/providers/workflow.mdx
@@ -4,9 +4,9 @@ import { Callout, Tabs } from 'nextra/components'
 
 Gestalt workflows let you invoke a plugin operation later instead of right now.
 Today that primarily means cron-based schedules, triggers, workflow run
-history, and run cancelation. The workflow model is global. A workflow target
-is always explicit: `plugin`, `operation`, and optional `connection`,
-`instance`, and `input`.
+history, event publishing, and run cancelation. The workflow model is global.
+A workflow target is always explicit: `plugin`, `operation`, and optional
+`connection`, `instance`, and `input`.
 
 <Callout type="info">
   The public workflow surface now covers schedules, triggers, event publishing,
@@ -28,6 +28,10 @@ There are two ownership modes. Config-managed workflows live in YAML under
 top-level `workflows:` and execute as the system config actor. User-owned
 schedules and triggers are created through the global API or CLI and
 execute as the subject that created them.
+
+Each schedule or trigger points at exactly one target operation. If you want a
+larger flow, the usual pattern is to let one step publish an event and then let
+later triggers match that event and start the next steps.
 
 ## How workflow providers work
 
@@ -339,7 +343,8 @@ When you publish an event, Gestalt normalizes the event ID, spec version, and
 timestamp if you omit them, then fans that event out across the configured
 workflow providers. Triggers match on the event payload itself. In practice,
 that means `type` is required, while `source` and `subject` remain optional
-exact-match fields.
+exact-match fields. This is also the main handoff mechanism for multi-step
+workflows.
 
 <Tabs items={['CLI', 'HTTP']}>
   <Tabs.Tab>
@@ -373,6 +378,77 @@ exact-match fields.
     ```
   </Tabs.Tab>
 </Tabs>
+
+## Composing larger workflows
+
+Gestalt does not currently let you declare a graph of named steps inside one
+workflow object. A schedule or trigger always invokes one target. The way to
+build something that feels like a DAG is to compose small targets with workflow
+events.
+
+One common pattern is to use a schedule to start the first step, then have that
+operation publish a completion event. Other triggers listen for that event and
+start the next steps.
+
+```yaml
+workflows:
+  schedules:
+    nightly_sync:
+      provider: local
+      plugin: roadmap
+      operation: sync
+      cron: "0 3 * * *"
+      timezone: UTC
+      input:
+        mode: incremental
+
+  eventTriggers:
+    notify_sync_completed:
+      provider: local
+      match:
+        type: roadmap.sync.completed
+        source: roadmap
+      plugin: slack
+      operation: chat.postMessage
+      connection: alerts
+      input:
+        channel: C123456
+        text: "Nightly roadmap sync completed."
+
+    refresh_search_index:
+      provider: local
+      match:
+        type: roadmap.sync.completed
+        source: roadmap
+      plugin: search
+      operation: reindex
+      connection: default
+      input:
+        scope: roadmap
+```
+
+In that example, `nightly_sync` only starts the first step. The
+`roadmap.sync` operation is responsible for publishing
+`roadmap.sync.completed` when it finishes successfully. Once that event exists,
+both triggers match it and the flow fans out into Slack notification and search
+reindexing.
+
+You can publish that handoff event from outside Gestalt through
+`POST /api/v1/workflow/events`, or from plugin code through the plugin-facing
+workflow manager `PublishEvent` call. External publishing is useful when some
+other system already knows the step finished. Plugin-side publishing is useful
+when the operation itself owns the next handoff.
+
+If you need fan-in, joins, or barrier-style behavior, add a coordinator step.
+Let each branch publish its own completion event, have a coordinator operation
+record progress in IndexedDB or another durable store, and publish a final
+event only after it sees all required completions. That gives you DAG-like
+behavior, but the join logic lives in plugin code rather than in workflow
+configuration.
+
+This means Gestalt is best described today as event-driven orchestration and
+delayed execution. It does not yet expose first-class DAG nodes, built-in join
+semantics, a `run now` endpoint, or a retry endpoint for failed runs.
 
 ## Inspecting and canceling workflow runs
 


### PR DESCRIPTION
## Summary
This updates the workflow docs so they explain how larger workflows are actually built today.

The current workflow surface exposes schedules, triggers, event publishing, and runs, but the docs did not make the orchestration model explicit enough. This PR explains that Gestalt is event-driven orchestration rather than a first-class declarative DAG engine, and shows how to compose larger flows by publishing events and matching later triggers.

## Changes
- clarify in `Providers > Workflow` that each schedule or trigger has one target
- add a new composition section that shows how to chain steps with published events
- add an end-to-end fan-out example using a scheduled sync and follow-up triggers
- explain how to model fan-in through a coordinator step
- document the current limits more directly: no first-class DAG nodes, joins, `run now`, or retry surface
- add matching clarification in the custom workflow-provider page
- add a short CLI note tying `workflows events publish` to multi-step composition

## Verification
- `cd docs && npm run build`
- `cd docs && npm run typecheck`
- `git diff --check`