### PR TITLE
Add runtime planning profiles for hosted plugin bootstrap

### DIFF
--- a/gestaltd/internal/bootstrap/executable_plugin_test.go
+++ b/gestaltd/internal/bootstrap/executable_plugin_test.go
@@ -6618,8 +6618,70 @@ func TestPluginRuntimeConfigRejectsMissingHostnameEgressCapability(t *testing.T)
 	_, _, err := buildProvidersStrict(context.Background(), cfg, factories, Deps{
 		PluginRuntimeRegistry: newPluginRuntimeRegistry(cfg, factories.Runtime, Deps{}),
 	})
-	if err == nil || !strings.Contains(err.Error(), "hostname-based egress controls") {
-		t.Fatalf("buildProvidersStrict error = %v, want missing hostname-based egress controls", err)
+	if err == nil || !strings.Contains(err.Error(), "cannot preserve hostname-based egress required by this plugin") {
+		t.Fatalf("buildProvidersStrict error = %v, want hostname-based egress requirement failure", err)
+	}
+}
+
+func TestPluginRuntimeConfigRejectsMissingHostServiceAccess(t *testing.T) {
+	t.Parallel()
+
+	bin := buildEchoPluginBinary(t)
+	manifestRoot := writeStaticCatalog(t, &catalog.Catalog{
+		Name: "echoext",
+		Operations: []catalog.CatalogOperation{
+			{ID: "read_env", Method: http.MethodGet, Parameters: []catalog.CatalogParameter{{Name: "name", Type: "string", Required: true}}},
+		},
+	})
+	manifest := newExecutableManifest("Echo", "Echoes back the input parameters")
+	runtimeProvider := &staticCapabilityPluginRuntime{
+		inner: pluginruntime.NewLocalProvider(),
+		capabilities: pluginruntime.Capabilities{
+			HostedPluginRuntime: true,
+			ProviderGRPCTunnel:  true,
+			HostPathExecution:   true,
+		},
+	}
+	factories := NewFactoryRegistry()
+	factories.Runtime = func(context.Context, string, *config.RuntimeProviderEntry, Deps) (pluginruntime.Provider, error) {
+		return runtimeProvider, nil
+	}
+	cfg := &config.Config{
+		Server: config.ServerConfig{
+			Runtime: config.ServerRuntimeConfig{Provider: "hosted"},
+		},
+		Runtime: config.RuntimeConfig{
+			Providers: map[string]*config.RuntimeProviderEntry{
+				"hosted": {
+					Driver: config.RuntimeProviderDriver("capture"),
+				},
+			},
+		},
+		Plugins: map[string]*config.ProviderEntry{
+			"echoext": {
+				Command:              bin,
+				Args:                 []string{"provider"},
+				ResolvedManifest:     manifest,
+				ResolvedManifestPath: filepath.Join(manifestRoot, "manifest.yaml"),
+				Runtime:              &config.PluginRuntimeConfig{},
+				Cache:                []string{"session"},
+			},
+		},
+	}
+
+	deps := Deps{
+		CacheDefs: map[string]*config.ProviderEntry{
+			"session": {Config: mustNode(t, map[string]any{"namespace": "session"})},
+		},
+		CacheFactory: func(yaml.Node) (corecache.Cache, error) {
+			return coretesting.NewStubCache(), nil
+		},
+	}
+	deps.PluginRuntimeRegistry = newPluginRuntimeRegistry(cfg, factories.Runtime, deps)
+
+	_, _, err := buildProvidersStrict(context.Background(), cfg, factories, deps)
+	if err == nil || !strings.Contains(err.Error(), "cannot provide host service access required by this plugin") {
+		t.Fatalf("buildProvidersStrict error = %v, want host service access failure", err)
 	}
 }
 
@@ -7220,6 +7282,163 @@ func TestPluginRuntimeConfigInjectsPublicEgressProxyWithoutHostServiceTunnelCapa
 	}
 }
 
+func TestPluginRuntimeConfigSkipsPublicEgressProxyWhenHostnameEgressIsNotRequired(t *testing.T) {
+	t.Parallel()
+
+	bin := buildEchoPluginBinary(t)
+	manifestRoot := writeStaticCatalog(t, &catalog.Catalog{
+		Name: "echoext",
+		Operations: []catalog.CatalogOperation{
+			{ID: "read_env", Method: http.MethodGet, Parameters: []catalog.CatalogParameter{{Name: "name", Type: "string", Required: true}}},
+		},
+	})
+	manifest := newExecutableManifest("Echo", "Echoes back the input parameters")
+	runtimeProvider := newCapturingBundlePluginRuntime()
+	runtimeProvider.capabilities.HostnameProxyEgress = true
+	runtimeProvider.capabilities.HostPathExecution = true
+	runtimeProvider.fakeHosted = true
+	factories := NewFactoryRegistry()
+	factories.Runtime = func(context.Context, string, *config.RuntimeProviderEntry, Deps) (pluginruntime.Provider, error) {
+		return runtimeProvider, nil
+	}
+	cfg := &config.Config{
+		Server: config.ServerConfig{
+			Runtime: config.ServerRuntimeConfig{Provider: "hosted"},
+			Egress:  config.EgressConfig{DefaultAction: string(egress.PolicyAllow)},
+		},
+		Runtime: config.RuntimeConfig{
+			Providers: map[string]*config.RuntimeProviderEntry{
+				"hosted": {
+					Driver: config.RuntimeProviderDriver("capture"),
+				},
+			},
+		},
+		Plugins: map[string]*config.ProviderEntry{
+			"echoext": {
+				Command:              bin,
+				Args:                 []string{"provider"},
+				ResolvedManifest:     manifest,
+				ResolvedManifestPath: filepath.Join(manifestRoot, "manifest.yaml"),
+				Runtime:              &config.PluginRuntimeConfig{},
+			},
+		},
+	}
+	deps := Deps{
+		BaseURL:       "https://gestalt.example.test",
+		EncryptionKey: []byte("0123456789abcdef0123456789abcdef"),
+		Egress:        EgressDeps{DefaultAction: egress.PolicyAllow},
+	}
+	deps.PluginRuntimeRegistry = newPluginRuntimeRegistry(cfg, factories.Runtime, deps)
+
+	providers, _, err := buildProvidersStrict(context.Background(), cfg, factories, deps)
+	if err != nil {
+		t.Fatalf("buildProvidersStrict: %v", err)
+	}
+	t.Cleanup(func() { _ = CloseProviders(providers) })
+
+	startRequests := runtimeProvider.startPluginRequestsCopy()
+	if len(startRequests) != 1 {
+		t.Fatalf("StartPlugin requests = %d, want 1", len(startRequests))
+	}
+	if got := startRequests[0].Env["HTTP_PROXY"]; got != "" {
+		t.Fatalf("StartPlugin HTTP_PROXY = %q, want empty when hostname egress is not required", got)
+	}
+	if got := startRequests[0].Env["HTTPS_PROXY"]; got != "" {
+		t.Fatalf("StartPlugin HTTPS_PROXY = %q, want empty when hostname egress is not required", got)
+	}
+}
+
+func TestPluginRuntimeConfigUsesDirectHostServiceBindingsAndSkipsPublicEgressProxy(t *testing.T) {
+	t.Parallel()
+
+	bin := buildEchoPluginBinary(t)
+	manifestRoot := writeStaticCatalog(t, &catalog.Catalog{
+		Name: "echoext",
+		Operations: []catalog.CatalogOperation{
+			{ID: "read_env", Method: http.MethodGet, Parameters: []catalog.CatalogParameter{{Name: "name", Type: "string", Required: true}}},
+		},
+	})
+	manifest := newExecutableManifest("Echo", "Echoes back the input parameters")
+	runtimeProvider := newCapturingBundlePluginRuntime()
+	runtimeProvider.capabilities.HostServiceTunnels = true
+	runtimeProvider.capabilities.HostnameProxyEgress = true
+	runtimeProvider.capabilities.HostPathExecution = true
+	runtimeProvider.fakeHosted = true
+	factories := NewFactoryRegistry()
+	factories.Runtime = func(context.Context, string, *config.RuntimeProviderEntry, Deps) (pluginruntime.Provider, error) {
+		return runtimeProvider, nil
+	}
+	cfg := &config.Config{
+		Server: config.ServerConfig{
+			Runtime: config.ServerRuntimeConfig{Provider: "hosted"},
+			Egress:  config.EgressConfig{DefaultAction: string(egress.PolicyDeny)},
+		},
+		Runtime: config.RuntimeConfig{
+			Providers: map[string]*config.RuntimeProviderEntry{
+				"hosted": {
+					Driver: config.RuntimeProviderDriver("capture"),
+				},
+			},
+		},
+		Plugins: map[string]*config.ProviderEntry{
+			"echoext": {
+				Command:              bin,
+				Args:                 []string{"provider"},
+				ResolvedManifest:     manifest,
+				ResolvedManifestPath: filepath.Join(manifestRoot, "manifest.yaml"),
+				Runtime:              &config.PluginRuntimeConfig{},
+				AllowedHosts:         []string{"api.github.com"},
+				Cache:                []string{"session"},
+			},
+		},
+	}
+	deps := Deps{
+		BaseURL:       "https://gestalt.example.test",
+		EncryptionKey: []byte("0123456789abcdef0123456789abcdef"),
+		Egress:        EgressDeps{DefaultAction: egress.PolicyDeny},
+		CacheDefs: map[string]*config.ProviderEntry{
+			"session": {Config: mustNode(t, map[string]any{"namespace": "session"})},
+		},
+		CacheFactory: func(yaml.Node) (corecache.Cache, error) {
+			return coretesting.NewStubCache(), nil
+		},
+	}
+	deps.PluginRuntimeRegistry = newPluginRuntimeRegistry(cfg, factories.Runtime, deps)
+
+	providers, _, err := buildProvidersStrict(context.Background(), cfg, factories, deps)
+	if err != nil {
+		t.Fatalf("buildProvidersStrict: %v", err)
+	}
+	t.Cleanup(func() { _ = CloseProviders(providers) })
+
+	startRequests := runtimeProvider.startPluginRequestsCopy()
+	if len(startRequests) != 1 {
+		t.Fatalf("StartPlugin requests = %d, want 1", len(startRequests))
+	}
+	if got := startRequests[0].Env["HTTP_PROXY"]; got != "" {
+		t.Fatalf("StartPlugin HTTP_PROXY = %q, want empty when direct host service bindings are available", got)
+	}
+	if got := startRequests[0].Env["HTTPS_PROXY"]; got != "" {
+		t.Fatalf("StartPlugin HTTPS_PROXY = %q, want empty when direct host service bindings are available", got)
+	}
+	if got := startRequests[0].Env[providerhost.CacheSocketTokenEnv("session")]; got != "" {
+		t.Fatalf("StartPlugin cache token env = %q, want empty for direct host service bindings", got)
+	}
+	if got := startRequests[0].AllowedHosts; !slices.Equal(got, []string{"api.github.com"}) {
+		t.Fatalf("StartPlugin allowed hosts = %#v, want original allowedHosts only", got)
+	}
+
+	bindRequests := runtimeProvider.bindHostServiceRequests()
+	if len(bindRequests) == 0 {
+		t.Fatal("BindHostService requests = 0, want at least one direct host service binding")
+	}
+	for _, req := range bindRequests {
+		if got := req.Relay.DialTarget; !strings.HasPrefix(got, "unix://") {
+			t.Fatalf("BindHostService(%s) relay target = %q, want unix direct dial target", req.EnvVar, got)
+		}
+	}
+}
+
 func TestPluginRuntimePublicEgressProxyRoundTripsThroughHostedPlugin(t *testing.T) {
 	t.Parallel()
 
@@ -7374,8 +7593,8 @@ func TestPluginRuntimeConfigRejectsDefaultDenyWithoutHostnameEgressCapability(t 
 		}),
 		Egress: EgressDeps{DefaultAction: egress.PolicyDeny},
 	})
-	if err == nil || !strings.Contains(err.Error(), "hostname-based egress controls") {
-		t.Fatalf("buildProvidersStrict error = %v, want missing hostname-based egress controls", err)
+	if err == nil || !strings.Contains(err.Error(), "cannot preserve hostname-based egress required by this plugin") {
+		t.Fatalf("buildProvidersStrict error = %v, want hostname-based egress requirement failure", err)
 	}
 }
 

--- a/gestaltd/internal/bootstrap/plugin_runtime_launch.go
+++ b/gestaltd/internal/bootstrap/plugin_runtime_launch.go
@@ -22,13 +22,13 @@ type pluginRuntimeLaunch struct {
 	cleanup   func()
 }
 
-func preparePluginRuntimeLaunch(name string, entry *config.ProviderEntry, command string, args []string, cleanup func(), caps pluginruntime.Capabilities) (pluginRuntimeLaunch, error) {
+func preparePluginRuntimeLaunch(name string, entry *config.ProviderEntry, command string, args []string, cleanup func(), profile RuntimeProfile) (pluginRuntimeLaunch, error) {
 	launch := pluginRuntimeLaunch{
 		command: command,
 		args:    slices.Clone(args),
 		cleanup: cleanup,
 	}
-	if caps.HostPathExecution {
+	if profile.LaunchMode == RuntimeLaunchModeHostPath {
 		return launch, nil
 	}
 	if entry == nil {
@@ -39,7 +39,7 @@ func preparePluginRuntimeLaunch(name string, entry *config.ProviderEntry, comman
 		return pluginRuntimeLaunch{}, fmt.Errorf("resolved manifest path is required for non-local plugin runtime")
 	}
 	rootDir := filepath.Dir(manifestPath)
-	if strings.TrimSpace(caps.ExecutionGOOS) == "" || strings.TrimSpace(caps.ExecutionGOARCH) == "" {
+	if !profile.ExecutionTarget.IsSet() {
 		return pluginRuntimeLaunch{}, fmt.Errorf("non-local plugin runtime must declare execution goos/goarch")
 	}
 
@@ -51,7 +51,7 @@ func preparePluginRuntimeLaunch(name string, entry *config.ProviderEntry, comman
 		_ = os.RemoveAll(bundleDir)
 	}
 
-	localCommand, err := stagePluginRuntimeBundle(name, manifestPath, bundleDir, caps.ExecutionGOOS, caps.ExecutionGOARCH)
+	localCommand, err := stagePluginRuntimeBundle(name, manifestPath, bundleDir, profile.ExecutionTarget.GOOS, profile.ExecutionTarget.GOARCH)
 	if err != nil {
 		bundleCleanup()
 		return pluginRuntimeLaunch{}, err

--- a/gestaltd/internal/bootstrap/plugin_runtime_plan.go
+++ b/gestaltd/internal/bootstrap/plugin_runtime_plan.go
@@ -1,0 +1,193 @@
+package bootstrap
+
+import (
+	"fmt"
+	"strings"
+
+	"github.com/valon-technologies/gestalt/server/internal/config"
+	"github.com/valon-technologies/gestalt/server/internal/egress"
+	"github.com/valon-technologies/gestalt/server/internal/pluginruntime"
+)
+
+type RuntimeHostServiceMode string
+
+const (
+	RuntimeHostServiceModeNone   RuntimeHostServiceMode = "none"
+	RuntimeHostServiceModeRelay  RuntimeHostServiceMode = "relay"
+	RuntimeHostServiceModeDirect RuntimeHostServiceMode = "direct"
+)
+
+type RuntimeEgressMode string
+
+const (
+	RuntimeEgressModeNone     RuntimeEgressMode = "none"
+	RuntimeEgressModeCIDR     RuntimeEgressMode = "cidr"
+	RuntimeEgressModeHostname RuntimeEgressMode = "hostname"
+)
+
+type RuntimeHostnameEgressTransport string
+
+const (
+	RuntimeHostnameEgressTransportNone        RuntimeHostnameEgressTransport = "none"
+	RuntimeHostnameEgressTransportRuntime     RuntimeHostnameEgressTransport = "runtime"
+	RuntimeHostnameEgressTransportPublicProxy RuntimeHostnameEgressTransport = "public_proxy"
+)
+
+type RuntimeLaunchMode string
+
+const (
+	RuntimeLaunchModeHostPath RuntimeLaunchMode = "host_path"
+	RuntimeLaunchModeBundle   RuntimeLaunchMode = "bundle"
+)
+
+type RuntimeExecutionTarget struct {
+	GOOS   string
+	GOARCH string
+}
+
+func (t RuntimeExecutionTarget) IsSet() bool {
+	return strings.TrimSpace(t.GOOS) != "" && strings.TrimSpace(t.GOARCH) != ""
+}
+
+type RuntimeProfile struct {
+	HostedExecution bool
+	HostServiceMode RuntimeHostServiceMode
+	EgressMode      RuntimeEgressMode
+	LaunchMode      RuntimeLaunchMode
+	ExecutionTarget RuntimeExecutionTarget
+}
+
+type PluginRuntimePlan struct {
+	Effective                 RuntimeProfile
+	RequiresHostServiceAccess bool
+	RequiresHostnameEgress    bool
+	HostnameEgressTransport   RuntimeHostnameEgressTransport
+}
+
+func buildPluginRuntimePlan(pluginName string, entry *config.ProviderEntry, deps Deps, caps pluginruntime.Capabilities) (PluginRuntimePlan, error) {
+	advertised := runtimeAdvertisedProfile(caps)
+	effective := runtimeEffectiveProfile(advertised, caps, deps)
+	requiresHostServiceAccess, requiresHostnameEgress, err := pluginRuntimeRequirementsForPlugin(pluginName, entry, deps)
+	if err != nil {
+		return PluginRuntimePlan{}, err
+	}
+	return PluginRuntimePlan{
+		Effective:                 effective,
+		RequiresHostServiceAccess: requiresHostServiceAccess,
+		RequiresHostnameEgress:    requiresHostnameEgress,
+		HostnameEgressTransport:   runtimeHostnameEgressTransport(requiresHostnameEgress, caps, effective, deps),
+	}, nil
+}
+
+func runtimeAdvertisedProfile(caps pluginruntime.Capabilities) RuntimeProfile {
+	hostServiceMode := RuntimeHostServiceModeNone
+	if caps.HostServiceTunnels {
+		hostServiceMode = RuntimeHostServiceModeDirect
+	}
+	egressMode := RuntimeEgressModeNone
+	switch {
+	case caps.HostnameProxyEgress:
+		egressMode = RuntimeEgressModeHostname
+	case caps.CIDREgress:
+		egressMode = RuntimeEgressModeCIDR
+	}
+	launchMode := RuntimeLaunchModeBundle
+	if caps.HostPathExecution {
+		launchMode = RuntimeLaunchModeHostPath
+	}
+	return RuntimeProfile{
+		HostedExecution: caps.HostedPluginRuntime && caps.ProviderGRPCTunnel,
+		HostServiceMode: hostServiceMode,
+		EgressMode:      egressMode,
+		LaunchMode:      launchMode,
+		ExecutionTarget: RuntimeExecutionTarget{
+			GOOS:   strings.TrimSpace(caps.ExecutionGOOS),
+			GOARCH: strings.TrimSpace(caps.ExecutionGOARCH),
+		},
+	}
+}
+
+func runtimeEffectiveProfile(advertised RuntimeProfile, caps pluginruntime.Capabilities, deps Deps) RuntimeProfile {
+	effective := advertised
+	if effective.HostServiceMode == RuntimeHostServiceModeNone && hostCanRelayPluginRuntimeHostServices(deps) {
+		effective.HostServiceMode = RuntimeHostServiceModeRelay
+	}
+	if effective.EgressMode == RuntimeEgressModeHostname && !caps.HostServiceTunnels && !hostCanProvideHostedHostnameEgress(deps) {
+		effective.EgressMode = RuntimeEgressModeNone
+	}
+	return effective
+}
+
+func runtimeHostnameEgressTransport(required bool, caps pluginruntime.Capabilities, effective RuntimeProfile, deps Deps) RuntimeHostnameEgressTransport {
+	if !required || effective.EgressMode != RuntimeEgressModeHostname {
+		return RuntimeHostnameEgressTransportNone
+	}
+	if caps.HostServiceTunnels {
+		return RuntimeHostnameEgressTransportRuntime
+	}
+	if hostCanProvideHostedHostnameEgress(deps) {
+		return RuntimeHostnameEgressTransportPublicProxy
+	}
+	return RuntimeHostnameEgressTransportNone
+}
+
+func hostCanRelayPluginRuntimeHostServices(deps Deps) bool {
+	if len(deps.EncryptionKey) == 0 {
+		return false
+	}
+	_, _, err := pluginRuntimePublicProxyBaseURL(deps.BaseURL)
+	return err == nil
+}
+
+func hostCanProvideHostedHostnameEgress(deps Deps) bool {
+	return hostCanRelayPluginRuntimeHostServices(deps)
+}
+
+func pluginRuntimeRequirementsForPlugin(name string, entry *config.ProviderEntry, deps Deps) (bool, bool, error) {
+	if entry == nil {
+		return false, false, nil
+	}
+	requiresHostServiceAccess := false
+	effectiveIndexedDB, err := config.ResolveEffectivePluginIndexedDB(name, entry, deps.SelectedIndexedDBName, deps.IndexedDBDefs)
+	if err != nil {
+		return false, false, err
+	}
+	if effectiveIndexedDB.Enabled {
+		requiresHostServiceAccess = true
+	}
+	if len(entry.Cache) > 0 {
+		requiresHostServiceAccess = true
+	}
+	if len(entry.S3) > 0 {
+		requiresHostServiceAccess = true
+	}
+	if deps.WorkflowManager != nil || (deps.WorkflowRuntime != nil && deps.WorkflowRuntime.HasConfiguredProviders()) {
+		requiresHostServiceAccess = true
+	}
+	if deps.AuthorizationProvider != nil && len(entry.EffectiveHTTPBindings()) > 0 {
+		requiresHostServiceAccess = true
+	}
+	if len(entry.Invokes) > 0 {
+		requiresHostServiceAccess = true
+	}
+	return requiresHostServiceAccess, len(entry.AllowedHosts) > 0 || deps.Egress.DefaultAction == egress.PolicyDeny, nil
+}
+
+func (p PluginRuntimePlan) Validate(label string) error {
+	if label == "" {
+		label = "plugin runtime"
+	}
+	if !p.Effective.HostedExecution {
+		return fmt.Errorf("%s cannot host executable plugins in a host-reachable session", label)
+	}
+	if p.RequiresHostServiceAccess && p.Effective.HostServiceMode == RuntimeHostServiceModeNone {
+		return fmt.Errorf("%s cannot provide host service access required by this plugin", label)
+	}
+	if p.RequiresHostnameEgress && p.Effective.EgressMode != RuntimeEgressModeHostname {
+		return fmt.Errorf("%s cannot preserve hostname-based egress required by this plugin", label)
+	}
+	if p.Effective.LaunchMode == RuntimeLaunchModeBundle && !p.Effective.ExecutionTarget.IsSet() {
+		return fmt.Errorf("%s cannot stage hosted plugin bundles because it does not declare an execution target", label)
+	}
+	return nil
+}

--- a/gestaltd/internal/bootstrap/provider_build.go
+++ b/gestaltd/internal/bootstrap/provider_build.go
@@ -755,13 +755,6 @@ func buildPluginProvider(ctx context.Context, name string, entry *config.Provide
 	if err != nil {
 		return nil, err
 	}
-	runtimeRequirements, err := pluginRuntimeRequirementsForPlugin(name, entry, deps)
-	if err != nil {
-		if runtimeOwned {
-			_ = runtimeProvider.Close()
-		}
-		return nil, err
-	}
 	runtimeCapabilities, err := runtimeProvider.Capabilities(ctx)
 	if err != nil {
 		if runtimeOwned {
@@ -769,13 +762,20 @@ func buildPluginProvider(ctx context.Context, name string, entry *config.Provide
 		}
 		return nil, fmt.Errorf("query %s capabilities: %w", pluginRuntimeLabel(runtimeConfig), err)
 	}
-	if err := validatePluginRuntimeCapabilities(pluginRuntimeLabel(runtimeConfig), runtimeCapabilities, runtimeRequirements); err != nil {
+	runtimePlan, err := buildPluginRuntimePlan(name, entry, deps, runtimeCapabilities)
+	if err != nil {
 		if runtimeOwned {
 			_ = runtimeProvider.Close()
 		}
 		return nil, err
 	}
-	if command == "" && runtimeCapabilities.HostPathExecution {
+	if err := runtimePlan.Validate(pluginRuntimeLabel(runtimeConfig)); err != nil {
+		if runtimeOwned {
+			_ = runtimeProvider.Close()
+		}
+		return nil, err
+	}
+	if command == "" && runtimePlan.Effective.LaunchMode == RuntimeLaunchModeHostPath {
 		if entry.ResolvedManifestPath == "" {
 			if runtimeOwned {
 				_ = runtimeProvider.Close()
@@ -810,10 +810,10 @@ func buildPluginProvider(ctx context.Context, name string, entry *config.Provide
 			maps.Copy(env, execEnv)
 		}
 	}
-	if command == "" && !runtimeCapabilities.HostPathExecution {
+	if command == "" && runtimePlan.Effective.LaunchMode != RuntimeLaunchModeHostPath {
 		args = nil
 	}
-	launch, err := preparePluginRuntimeLaunch(name, entry, command, args, cleanup, runtimeCapabilities)
+	launch, err := preparePluginRuntimeLaunch(name, entry, command, args, cleanup, runtimePlan.Effective)
 	if err != nil {
 		if runtimeOwned {
 			_ = runtimeProvider.Close()
@@ -845,7 +845,7 @@ func buildPluginProvider(ctx context.Context, name string, entry *config.Provide
 		return nil, fmt.Errorf("wait for plugin runtime session %q ready: %w", sessionID, err)
 	}
 
-	hostServices, invTokens, runtimeCleanup, err := buildPluginRuntimeHostServices(name, entry, deps, runtimeCapabilities.HostServiceTunnels)
+	hostServices, invTokens, runtimeCleanup, err := buildPluginRuntimeHostServices(name, entry, deps, runtimePlan.Effective.HostServiceMode == RuntimeHostServiceModeDirect)
 	if err != nil {
 		return nil, err
 	}
@@ -862,7 +862,7 @@ func buildPluginProvider(ctx context.Context, name string, entry *config.Provide
 	startEnv := maps.Clone(env)
 	allowedHosts := slices.Clone(entry.AllowedHosts)
 	for _, hostService := range startedHostServices.Bindings() {
-		bindingReq, bindingEnv, relayHost, err := buildPluginRuntimeHostServiceBinding(name, sessionID, hostService, deps, runtimeCapabilities.HostServiceTunnels)
+		bindingReq, bindingEnv, relayHost, err := buildPluginRuntimeHostServiceBinding(name, sessionID, hostService, deps, runtimePlan.Effective.HostServiceMode == RuntimeHostServiceModeDirect)
 		if err != nil {
 			return nil, err
 		}
@@ -877,7 +877,7 @@ func buildPluginProvider(ctx context.Context, name string, entry *config.Provide
 		}
 		allowedHosts = appendAllowedHost(allowedHosts, relayHost)
 	}
-	if requiresPluginRuntimePublicEgressProxy(entry, deps, runtimeCapabilities) {
+	if runtimePlan.HostnameEgressTransport == RuntimeHostnameEgressTransportPublicProxy {
 		proxyEnv, err := buildPluginRuntimePublicEgressProxy(name, sessionID, entry.AllowedHosts, deps.Egress.DefaultAction, deps)
 		if err != nil {
 			return nil, err
@@ -956,46 +956,16 @@ func effectivePluginRuntime(ctx context.Context, name string, entry *config.Prov
 	return config.EffectivePluginRuntime{}, pluginruntime.NewLocalProvider(), true, nil
 }
 
-type pluginRuntimeCapabilityRequirements struct {
-	HostnameProxyEgress bool
-}
-
 const (
 	pluginRuntimeHostServiceRelayTokenTTL = 30 * 24 * time.Hour
 	pluginRuntimeEgressProxyTokenTTL      = 30 * 24 * time.Hour
 )
-
-func pluginRuntimeRequirementsForPlugin(name string, entry *config.ProviderEntry, deps Deps) (pluginRuntimeCapabilityRequirements, error) {
-	if entry == nil {
-		return pluginRuntimeCapabilityRequirements{}, nil
-	}
-	return pluginRuntimeCapabilityRequirements{
-		HostnameProxyEgress: len(entry.AllowedHosts) > 0 || deps.Egress.DefaultAction == egress.PolicyDeny,
-	}, nil
-}
 
 func pluginRuntimeLabel(runtimeConfig config.EffectivePluginRuntime) string {
 	if name := strings.TrimSpace(runtimeConfig.ProviderName); name != "" {
 		return fmt.Sprintf("runtime provider %q", name)
 	}
 	return "plugin runtime"
-}
-
-func validatePluginRuntimeCapabilities(label string, caps pluginruntime.Capabilities, req pluginRuntimeCapabilityRequirements) error {
-	var missing []string
-	if !caps.HostedPluginRuntime {
-		missing = append(missing, "hosted plugin execution")
-	}
-	if !caps.ProviderGRPCTunnel {
-		missing = append(missing, "provider gRPC tunneling")
-	}
-	if req.HostnameProxyEgress && !caps.HostnameProxyEgress {
-		missing = append(missing, "hostname-based egress controls")
-	}
-	if len(missing) == 0 {
-		return nil
-	}
-	return fmt.Errorf("%s is missing required capabilities: %s", label, strings.Join(missing, ", "))
 }
 
 func buildPluginRuntimeStartSessionRequest(name string, runtimeConfig config.EffectivePluginRuntime) pluginruntime.StartSessionRequest {
@@ -1085,7 +1055,7 @@ func waitForPluginRuntimeSessionReady(ctx context.Context, runtimeProvider plugi
 	}
 }
 
-func buildPluginRuntimeHostServices(name string, entry *config.ProviderEntry, deps Deps, includeHostServices bool) ([]providerhost.HostService, *providerhost.InvocationTokenManager, func(), error) {
+func buildPluginRuntimeHostServices(name string, entry *config.ProviderEntry, deps Deps, allowDirectBindings bool) ([]providerhost.HostService, *providerhost.InvocationTokenManager, func(), error) {
 	var (
 		hostServices []providerhost.HostService
 		cleanup      func()
@@ -1128,7 +1098,7 @@ func buildPluginRuntimeHostServices(name string, entry *config.ProviderEntry, de
 	}
 	includeWorkflowManager := deps.WorkflowManager != nil || (deps.WorkflowRuntime != nil && deps.WorkflowRuntime.HasConfiguredProviders())
 	includeAgentManager := deps.AgentManager != nil || deps.AgentRuntime != nil
-	needInvocationTokens := includeHostServices || len(entry.Invokes) > 0
+	needInvocationTokens := allowDirectBindings || len(entry.Invokes) > 0
 	if includeWorkflowManager || includeAgentManager {
 		needInvocationTokens = true
 	}
@@ -1147,7 +1117,7 @@ func buildPluginRuntimeHostServices(name string, entry *config.ProviderEntry, de
 	if deps.AuthorizationProvider != nil && len(entry.EffectiveHTTPBindings()) > 0 {
 		hostServices = append(hostServices, buildPluginAuthorizationHostService(deps.AuthorizationProvider))
 	}
-	if !includeHostServices {
+	if !allowDirectBindings {
 		if len(entry.Invokes) > 0 {
 			hostServices = append(hostServices, buildPluginInvokerHostService(name, entry, deps, invTokens))
 		}
@@ -1219,13 +1189,6 @@ func buildPluginRuntimeHostServiceBinding(pluginName, sessionID string, hostServ
 			DialTarget: "unix://" + hostService.SocketPath,
 		},
 	}, nil, "", nil
-}
-
-func requiresPluginRuntimePublicEgressProxy(entry *config.ProviderEntry, deps Deps, caps pluginruntime.Capabilities) bool {
-	if caps.HostServiceTunnels {
-		return false
-	}
-	return len(entry.AllowedHosts) > 0 || deps.Egress.DefaultAction == egress.PolicyDeny
 }
 
 func buildPluginRuntimePublicEgressProxy(pluginName, sessionID string, allowedHosts []string, defaultAction egress.PolicyAction, deps Deps) (map[string]string, error) {


### PR DESCRIPTION
## Summary

This PR replaces direct hosted-plugin bootstrap branching on raw runtime capability booleans with one derived planner that captures the runtime behavior bootstrap actually needs.

The point of the change is not to invent a new abstraction layer for its own sake. The point is to stop making bootstrap reason separately about validation, launch shape, host-service access, and hostname-egress delivery from the same low-level bag of booleans.

## Old Interface

Before this PR, the host-side interface was effectively the raw runtime capability bag plus a tiny separate requirement helper.

```go
type Capabilities struct {
    HostedPluginRuntime bool
    ProviderGRPCTunnel  bool
    HostServiceTunnels  bool
    HostnameProxyEgress bool
    CIDREgress          bool
    HostPathExecution   bool
    ExecutionGOOS       string
    ExecutionGOARCH     string
}

type pluginRuntimeCapabilityRequirements struct {
    HostnameProxyEgress bool
}
```

Using it looked like this:

```go
caps, err := runtimeProvider.Capabilities(ctx)
if err != nil {
    return nil, err
}

req, err := pluginRuntimeRequirementsForPlugin(name, entry, deps)
if err != nil {
    return nil, err
}

if err := validatePluginRuntimeCapabilities(label, caps, req); err != nil {
    return nil, err
}

if command == "" && caps.HostPathExecution {
    // synthesize source-provider execution from the host path
}

launch, err := preparePluginRuntimeLaunch(name, entry, command, args, cleanup, caps)
if err != nil {
    return nil, err
}

hostServices, invTokens, runtimeCleanup, err := buildPluginRuntimeHostServices(
    name,
    entry,
    deps,
    caps.HostServiceTunnels,
)
if err != nil {
    return nil, err
}

if requiresPluginRuntimePublicEgressProxy(entry, deps, caps) {
    // inject HTTP_PROXY / HTTPS_PROXY
}
```

That worked, but it scattered one conceptual decision across multiple helpers and multiple raw fields. Bootstrap had to remember how to derive requirements, how to validate them, how to interpret launch shape, how to interpret host-service access, and how to interpret hostname-egress delivery. The logic was correct, but the interface was not very reviewable.

## New Interface

After this PR, bootstrap still queries the raw runtime capabilities once, but it immediately compiles them into one plugin-specific plan.

```go
type RuntimeProfile struct {
    HostedExecution bool
    HostServiceMode RuntimeHostServiceMode
    EgressMode      RuntimeEgressMode
    LaunchMode      RuntimeLaunchMode
    ExecutionTarget RuntimeExecutionTarget
}

type PluginRuntimePlan struct {
    Effective                 RuntimeProfile
    RequiresHostServiceAccess bool
    RequiresHostnameEgress    bool
    HostnameEgressTransport   RuntimeHostnameEgressTransport
}
```

Using it now looks like this:

```go
caps, err := runtimeProvider.Capabilities(ctx)
if err != nil {
    return nil, err
}

plan, err := buildPluginRuntimePlan(name, entry, deps, caps)
if err != nil {
    return nil, err
}

if err := plan.Validate(label); err != nil {
    return nil, err
}

if command == "" && plan.Effective.LaunchMode == RuntimeLaunchModeHostPath {
    // synthesize source-provider execution from the host path
}

launch, err := preparePluginRuntimeLaunch(name, entry, command, args, cleanup, plan.Effective)
if err != nil {
    return nil, err
}

hostServices, invTokens, runtimeCleanup, err := buildPluginRuntimeHostServices(
    name,
    entry,
    deps,
    plan.Effective.HostServiceMode == RuntimeHostServiceModeDirect,
)
if err != nil {
    return nil, err
}

if plan.HostnameEgressTransport == RuntimeHostnameEgressTransportPublicProxy {
    // inject HTTP_PROXY / HTTPS_PROXY
}
```

## Why The New Interface Is Simpler

The new interface is simpler because the callsite no longer has to reconstruct intent from unrelated raw fields. The old path asked bootstrap to make several different decisions from the same capability bag every time it touched runtime launch. The new path asks bootstrap to do one thing first: build a plan. After that, launch code consumes the plan instead of re-deriving semantics.

That simplification shows up in three concrete ways.

First, the validation boundary is clearer. The old flow had one requirement object, one validation helper, and then several later branches that still reasoned directly about raw capability bits. The new flow validates the same plan that launch actually consumes.

Second, the launch path now reads in the same vocabulary reviewers care about: host-service access mode, egress mode, launch mode, execution target, and hostname-egress delivery. Those are the concepts we are actually reasoning about. They are easier to review than a mixture of `HostServiceTunnels`, `ProviderGRPCTunnel`, `HostPathExecution`, and separate helper functions that reinterpret them.

Third, the new interface is smaller at the point of use. The planner does not carry a label, does not carry per-service host-service detail, does not carry an advertised profile that bootstrap never reads, and does not carry a generic stored egress field. The only explicit delivery field left is `HostnameEgressTransport`, because launch still must distinguish runtime-native hostname egress from Gestalt public-proxy hostname egress without silently dropping back to raw booleans.

So the claim is not that the system has fewer real dimensions than before. The claim is that bootstrap now consumes those dimensions through one derived interface instead of rediscovering them ad hoc.

## Coverage

The hosted bootstrap coverage is extended to prove the new planner behavior, including:
- missing host-service access
- missing hostname-preserving egress
- direct host-service runtimes keeping unix relay targets
- relay-backed hostname egress injecting the public proxy only when the planned transport is `public_proxy`
- unrestricted hosted plugins keeping `HTTP_PROXY` and `HTTPS_PROXY` unset even when the runtime could preserve hostname egress