### PR TITLE
Expose advertised and effective runtime profiles in admin inspection

### DIFF
--- a/docs/content/configuration.mdx
+++ b/docs/content/configuration.mdx
@@ -246,11 +246,14 @@ The built-in runtime drivers are:
 - installable `kind: runtime` providers such as Modal for hosted execution
 
 The current Modal backend requires `runtime.providers.<name>.config.app` and
-`plugins.<name>.runtime.image`. It does not currently support host-service
-tunnels (`indexeddb`, `cache`, `s3`, workflow-manager access when workflows are
-configured, nested `invokes`) or Gestalt's
-hostname-based egress model, so Gestalt rejects Modal for plugins that require
-those capabilities.
+`plugins.<name>.runtime.image`. Modal does not expose generic direct
+host-service tunnels, but it can still satisfy plugins that need relay-backed
+host services or Gestalt's hostname-based egress model when the host is
+configured for the public relay and proxy path. In practice that means
+`server.baseURL` and `server.encryptionKey` must be set, and the runtime
+provider must advertise the matching capabilities. Without those prerequisites,
+Gestalt rejects Modal for plugins that require relay-backed host services or
+hostname-based egress.
 
 For the runtime-provider lifecycle and capability model, see
 [Providers > Runtime](/providers/runtime).

--- a/docs/content/custom-providers/runtime.mdx
+++ b/docs/content/custom-providers/runtime.mdx
@@ -11,18 +11,16 @@ they expose a control plane for starting and managing hosted plugins.
 
 ## What a runtime provider does
 
-A runtime provider answers questions like:
-
-- Can this backend host plugins at all?
-- Does it support host-service tunnels?
-- Can it preserve Gestalt's hostname-based egress model?
-- How does Gestalt create a session in this backend?
-- How does Gestalt inject host-local sockets into that session?
-- How does Gestalt start the hosted plugin and dial it back?
+A runtime provider answers a small set of control-plane questions for
+`gestaltd`. Can this backend host executable plugins at all. How does Gestalt
+create and observe a runtime session there. How does a hosted plugin reach
+Gestalt-owned services. How is hostname-based egress preserved. How does the
+host dial the hosted plugin back once it starts.
 
 It does **not** replace the host-local authentication, authorization,
 IndexedDB, cache, S3, secrets, or workflow providers. Those remain on the
-`gestaltd` host.
+`gestaltd` host. A runtime provider only changes where the plugin process runs
+and how the host reaches it.
 
 ## Manifest
 
@@ -155,31 +153,43 @@ func main() {
 
 ## Capability guidelines
 
-Advertise capabilities conservatively.
+Advertise capabilities conservatively. The host still receives the raw runtime
+capability flags, but it derives a higher-level runtime profile from them. That
+profile is what operators see in admin inspection, and it is what bootstrap
+uses to decide whether a hosted plugin can start safely on a given backend.
 
-- Only set `host_service_tunnels` if your backend can actually expose
-  host-managed socket bindings inside the runtime session.
-- Only set `hostname_proxy_egress` if you can preserve Gestalt's
-  hostname-based `allowedHosts` model.
-- Do not treat `cidr_egress` as equivalent to `hostname_proxy_egress`.
-- Only set `host_path_execution` if the backend can execute directly from the
-  host paths Gestalt provides. Otherwise Gestalt will stage a runtime bundle.
+In practice that means `host_service_tunnels` should only be true when your
+backend can really expose direct guest-local host-service sockets. If that flag
+is false, Gestalt may still derive an effective relay-backed host-service mode
+when `server.baseURL` and `server.encryptionKey` allow the public relay path.
 
-Gestalt validates these capabilities before it tries to launch a plugin. If
-they are wrong, operators will get either false rejections or late runtime
-failures.
+Likewise, `hostname_proxy_egress` is not just a firewall hint. It means the
+runtime can preserve Gestalt's hostname-based `allowedHosts` semantics. That
+preservation may happen inside the backend itself, or it may happen by routing
+hosted HTTP(S) traffic through Gestalt's public egress proxy. `cidr_egress`
+remains useful metadata, but it is not equivalent to hostname-based policy.
+
+`host_path_execution` should only be true when the backend can execute directly
+from the host paths Gestalt provides. Otherwise Gestalt will derive a bundle
+launch mode and stage a runtime bundle first. When bundle launch is required,
+`execution_goos` and `execution_goarch` must accurately describe the target
+platform so the host can choose or stage the right artifact.
+
+If these capabilities are wrong, operators will see either false compatibility
+rejections or late runtime failures. The safest rule is to advertise the
+smallest truthful surface and let Gestalt derive the rest.
 
 ## Sessions and host services
 
 The critical design point is that `StartPlugin` is **not** the whole runtime
-API. Gestalt needs an explicit session lifecycle because it may need to:
+API. Gestalt needs an explicit session lifecycle because it may need to create
+the session, wait until it is ready, bind host-local services into it, and only
+then start the plugin.
 
-1. create the session
-2. wait until it is ready
-3. bind host-local services into it
-4. then start the plugin
-
-That is why `BindHostService` exists separately from `StartPlugin`.
+That is why `BindHostService` exists separately from `StartPlugin`. A binding
+may be direct, using a guest-local socket path, or relay-backed, in which case
+the provider receives a public dial target and the hosted plugin talks back to
+`gestaltd` through the host-service relay.
 
 ## Dial targets
 

--- a/docs/content/providers/plugins.mdx
+++ b/docs/content/providers/plugins.mdx
@@ -115,9 +115,13 @@ them to choose a sandbox template, container image, or lifecycle labels.
 A built-in `local` runtime is always available for same-machine execution. The
 first installable hosted runtime provider is `modal`. It requires
 `runtime.providers.<name>.config.app` and `plugins.<name>.runtime.image`.
-Gestalt only uses it for plain executable plugins today: Modal does not yet
-support host-service tunnels or Gestalt's hostname-based egress model, so
-plugins that use `indexeddb`, `cache`, `s3`, workflow-manager access when
+Gestalt only uses it for plain executable plugins today. Modal does not expose
+generic direct host-service tunnels, but it can still run plugins that need
+relay-backed host services or Gestalt's hostname-based egress model when the
+host is configured for the public relay and proxy path. In practice that means
+`server.baseURL` and `server.encryptionKey` must be set, and the runtime
+provider must advertise the matching capabilities. Without those prerequisites,
+plugins that need `indexeddb`, `cache`, `s3`, workflow-manager access when
 workflows are configured, nested `invokes`, `allowedHosts`, or
 `server.egress.defaultAction: deny` stay on `local`.
 

--- a/docs/content/providers/runtime.mdx
+++ b/docs/content/providers/runtime.mdx
@@ -81,44 +81,59 @@ Selection is two-step:
 `server.runtime.provider` is only a default selector for plugins that already
 set `plugins.<name>.runtime`.
 
-## Runtime capabilities
+## Runtime profiles
 
-Runtime backends are not interchangeable. Gestalt checks capabilities before it
-tries to use a backend for a plugin.
+Runtime backends are not interchangeable, but most operators should not have to
+reason about a bag of low-level booleans to understand why a runtime is or is
+not compatible with a plugin. Gestalt therefore evaluates a runtime in terms of
+four higher-level questions.
+
+First, can the runtime host executable plugins at all. Second, how do hosted
+plugins reach Gestalt-owned services such as IndexedDB, cache, S3,
+workflow-manager access, authorization, and nested plugin invocation. Gestalt
+describes that as a host-service access mode of `none`, `relay`, or `direct`.
+Third, what kind of egress policy can the runtime preserve: no policy, CIDR or
+firewall style controls, or Gestalt's hostname-based `allowedHosts` model.
+Fourth, how does the plugin launch: directly from host paths or from a staged
+bundle, and on what execution target.
+
+The admin inspection API exposes both the runtime's raw capability flags and
+this derived profile. `GET /admin/api/v1/runtime/providers` returns an
+`advertised` profile, which is what the runtime says it can do, and an
+`effective` profile, which is what the current `gestaltd` deployment can
+actually guarantee once public relay and proxy prerequisites are considered.
+
+The raw capability flags still exist because runtime authors need precise
+contract boundaries. The most important ones are:
 
 | Capability | Meaning |
 | --- | --- |
 | `hosted_plugin_runtime` | The backend can host executable plugins at all. |
-| `host_service_tunnels` | The backend can inject host-local services such as IndexedDB, cache, S3, workflow-manager access, and plugin invocation sockets. |
+| `host_service_tunnels` | The backend can inject guest-local host-service sockets directly. When this is false, Gestalt may still provide relay-backed host services through its public relay path. |
 | `provider_grpc_tunnel` | The backend can return a host-reachable gRPC dial target for the hosted plugin. |
 | `hostname_proxy_egress` | The backend can preserve Gestalt's hostname-based `allowedHosts` model. |
-| `cidr_egress` | The backend supports network controls at CIDR or firewall granularity. This is not equivalent to hostname-based policy. |
+| `cidr_egress` | The backend supports CIDR or firewall style controls. This is useful, but it is not equivalent to hostname-based policy. |
 | `host_path_execution` | The backend can execute directly from host paths instead of requiring bundle staging. |
-| `execution_goos` / `execution_goarch` | The target execution platform the runtime reports to the host. |
+| `execution_goos` / `execution_goarch` | The execution platform the runtime reports to the host when bundle staging is required. |
 
-These flags matter because plugin requirements differ. For example:
-
-- a plugin that uses `indexeddb`, `cache`, `s3`, workflow-manager access when
-  workflows are configured, or nested `invokes` requires `host_service_tunnels`
-- a plugin that uses `allowedHosts` or a server-wide default-deny egress policy
-  requires `hostname_proxy_egress`
-
-Gestalt rejects incompatible runtime/plugin combinations instead of silently
-weakening the security model.
+Gestalt uses those raw flags to derive the higher-level profile, validate a
+plugin's actual needs, and reject incompatible runtime or plugin combinations
+before startup instead of silently weakening the security model.
 
 ## Host services and hosted plugins
 
-Plugins do not talk directly to host-local services over the network. Gestalt
-starts those host services locally, allocates their socket paths, and asks the
-runtime provider to bind them into the runtime session.
+Plugins do not talk directly to host-local services over the public network.
+`gestaltd` starts those services on the host and then gives the runtime one of
+two integration paths. A runtime with direct host-service access can bind
+guest-local sockets straight into the session. A runtime without that direct
+path can still use relay-backed bindings, in which case the hosted plugin talks
+back to `gestaltd` over a scoped public relay target and `gestaltd` forwards
+the request to the real host-local service.
 
-For a hosted plugin, that usually means some combination of:
-
-- IndexedDB socket injection
-- cache socket injection
-- S3 socket injection
-- workflow-manager socket injection
-- plugin-invoker socket injection
+That same split shows up in hostname-based egress. A runtime may preserve
+`allowedHosts` internally, or it may preserve it by routing hosted HTTP(S)
+traffic through Gestalt's public egress proxy. Either way, the contract is that
+the meaning of `allowedHosts` stays the same from the plugin's point of view.
 
 The runtime provider is also responsible for the plugin's own listener endpoint.
 `StartPlugin` must start the plugin, allocate or inject its provider listener,
@@ -132,11 +147,7 @@ Today there are two main runtime choices:
 | Backend | Type | Notes |
 | --- | --- | --- |
 | `local` | Built-in driver | Runs the plugin on the same machine as `gestaltd`. Supports host-path execution and the existing host-local runtime behavior. |
-| `modal` | Installable `kind: runtime` provider | Runs the plugin in a hosted Linux sandbox. Requires `runtime.providers.<name>.config.app` and `plugins.<name>.runtime.image`. |
-
-The current Modal backend does **not** support host-service tunnels or
-Gestalt's hostname-based egress model, so Gestalt rejects plugins that need
-those features when `modal` is selected.
+| `modal` | Installable `kind: runtime` provider | Runs the plugin in a hosted Linux sandbox. Requires `runtime.providers.<name>.config.app` and `plugins.<name>.runtime.image`. When the host is configured for the public relay and proxy path, Modal uses relay-backed host services and Gestalt's public hostname-egress proxy instead of generic direct host-service tunnels. |
 
 ## Bundle staging and host-path execution
 

--- a/docs/content/reference/config-file.mdx
+++ b/docs/content/reference/config-file.mdx
@@ -254,10 +254,13 @@ runtime:
 | `regions` | Optional region allowlist passed through to Modal. |
 
 When a plugin uses the Modal runtime provider, `plugins.<name>.runtime.image` is
-required. The current backend does not support host-service tunnels or
-Gestalt's hostname-based egress model, so Gestalt rejects Modal for plugins
-that need `indexeddb`, `cache`, `s3`, workflow-manager access when workflows
-are configured, nested `invokes`, `allowedHosts`, or a server-wide default-deny
+required. Modal does not expose generic direct host-service tunnels, but it can
+still run hosted plugins that need Gestalt-owned services or hostname-based
+egress when the host is configured for the public relay and proxy path. In
+practice that means `server.baseURL` and `server.encryptionKey` must be set, and
+the runtime provider must advertise the matching runtime capabilities. Without
+those prerequisites, Gestalt will reject Modal for plugins that need
+relay-backed host services, `allowedHosts`, or a server-wide default-deny
 egress policy.
 ## `providers.authentication`
 

--- a/docs/content/reference/http-api.mdx
+++ b/docs/content/reference/http-api.mdx
@@ -113,6 +113,8 @@ returns `412`.
 | Method | Path | Purpose |
 | --- | --- | --- |
 | `GET` | `/metrics` | Prometheus scrape endpoint for emitted metrics. Requires Gestalt authentication only when served on the public listener. The recommended production pattern is to move it to `server.management` and protect that listener at the network or proxy layer. |
+| `GET` | `/admin/api/v1/runtime/providers` | List configured runtime providers. When capability inspection succeeds, loaded providers include raw `capabilities` and a derived `profile` with `advertised` and `effective` runtime behavior. `sessionCount` is present when session inspection also succeeds, and `error` explains any current inspection failure. |
+| `GET` | `/admin/api/v1/runtime/providers/{provider}/sessions` | List active sessions for one runtime provider, including session `id`, lifecycle `state`, and the hosted `plugin` when known. |
 | `GET` | `/admin/api/v1/authorization/plugins` | List plugins that declare `authorizationPolicy`, including the bound policy name and mounted UI path when present. |
 | `GET` | `/admin/api/v1/authorization/plugins/{plugin}/members` | List merged static and dynamic human membership rows for one plugin. Rows include `source`, `effective`, `mutable`, and selector metadata. |
 | `PUT` | `/admin/api/v1/authorization/plugins/{plugin}/members` | Upsert one dynamic human membership row for a plugin by canonical user `subjectId` or by `email` alias and role. Rejects subjects who already have static authorization on that plugin. |

--- a/gestaltd/internal/bootstrap/plugin_runtime_inspect.go
+++ b/gestaltd/internal/bootstrap/plugin_runtime_inspect.go
@@ -14,13 +14,16 @@ type RuntimeInspector interface {
 }
 
 type RuntimeProviderSnapshot struct {
-	Name         string
-	Driver       config.RuntimeProviderDriver
-	Default      bool
-	Loaded       bool
-	Capabilities pluginruntime.Capabilities
-	Sessions     []pluginruntime.Session
-	Error        string
+	Name               string
+	Driver             config.RuntimeProviderDriver
+	Default            bool
+	Loaded             bool
+	CapabilitiesLoaded bool
+	Capabilities       pluginruntime.Capabilities
+	AdvertisedProfile  RuntimeProfile
+	EffectiveProfile   RuntimeProfile
+	Sessions           []pluginruntime.Session
+	Error              string
 }
 
 func (r *pluginRuntimeRegistry) SnapshotPluginRuntimes(ctx context.Context) ([]RuntimeProviderSnapshot, error) {
@@ -78,6 +81,9 @@ func (r *pluginRuntimeRegistry) SnapshotPluginRuntimes(ctx context.Context) ([]R
 				continue
 			}
 			snapshot.Capabilities = caps
+			snapshot.CapabilitiesLoaded = true
+			snapshot.AdvertisedProfile = runtimeAdvertisedProfile(caps)
+			snapshot.EffectiveProfile = runtimeEffectiveProfile(snapshot.AdvertisedProfile, caps, r.deps)
 			sessions, err := item.provider.ListSessions(ctx)
 			if err != nil {
 				snapshot.Error = fmt.Sprintf("list sessions: %v", err)

--- a/gestaltd/internal/server/handlers_admin_runtime.go
+++ b/gestaltd/internal/server/handlers_admin_runtime.go
@@ -15,6 +15,7 @@ type adminRuntimeProviderInfo struct {
 	Loaded       bool                      `json:"loaded"`
 	SessionCount *int                      `json:"sessionCount,omitempty"`
 	Capabilities *adminRuntimeCapabilities `json:"capabilities,omitempty"`
+	Profile      *adminRuntimeProfilePair  `json:"profile,omitempty"`
 	Error        string                    `json:"error,omitempty"`
 }
 
@@ -24,6 +25,24 @@ type adminRuntimeCapabilities struct {
 	ProviderGRPCTunnel  bool `json:"providerGRPCTunnel"`
 	HostnameProxyEgress bool `json:"hostnameProxyEgress"`
 	CIDREgress          bool `json:"cidrEgress"`
+}
+
+type adminRuntimeProfilePair struct {
+	Advertised adminRuntimeProfile `json:"advertised"`
+	Effective  adminRuntimeProfile `json:"effective"`
+}
+
+type adminRuntimeProfile struct {
+	HostedExecution   bool                         `json:"hostedExecution"`
+	HostServiceAccess string                       `json:"hostServiceAccess"`
+	EgressMode        string                       `json:"egressMode"`
+	LaunchMode        string                       `json:"launchMode"`
+	ExecutionTarget   *adminRuntimeExecutionTarget `json:"executionTarget,omitempty"`
+}
+
+type adminRuntimeExecutionTarget struct {
+	GOOS   string `json:"goos"`
+	GOARCH string `json:"goarch"`
 }
 
 type adminRuntimeSessionInfo struct {
@@ -45,7 +64,8 @@ func (s *Server) listAdminRuntimeProviders(w http.ResponseWriter, r *http.Reques
 	}
 
 	out := make([]adminRuntimeProviderInfo, 0, len(snapshots))
-	for _, snapshot := range snapshots {
+	for i := range snapshots {
+		snapshot := &snapshots[i]
 		row := adminRuntimeProviderInfo{
 			Name:    snapshot.Name,
 			Driver:  strings.TrimSpace(string(snapshot.Driver)),
@@ -53,12 +73,13 @@ func (s *Server) listAdminRuntimeProviders(w http.ResponseWriter, r *http.Reques
 			Loaded:  snapshot.Loaded,
 			Error:   strings.TrimSpace(snapshot.Error),
 		}
+		if snapshot.Loaded && snapshot.CapabilitiesLoaded {
+			row.Capabilities = adminRuntimeCapabilitiesFromSnapshot(snapshot)
+			row.Profile = adminRuntimeProfilePairFromSnapshot(snapshot)
+		}
 		if snapshot.Loaded && row.Error == "" {
 			sessionCount := len(snapshot.Sessions)
 			row.SessionCount = &sessionCount
-		}
-		if snapshot.Loaded && row.Error == "" {
-			row.Capabilities = adminRuntimeCapabilitiesFromSnapshot(snapshot)
 		}
 		out = append(out, row)
 	}
@@ -77,7 +98,8 @@ func (s *Server) listAdminRuntimeProviderSessions(w http.ResponseWriter, r *http
 		writeError(w, http.StatusInternalServerError, "failed to inspect runtime providers")
 		return
 	}
-	for _, snapshot := range snapshots {
+	for i := range snapshots {
+		snapshot := &snapshots[i]
 		if snapshot.Name != name {
 			continue
 		}
@@ -107,7 +129,7 @@ func (s *Server) adminRuntimeSnapshots(r *http.Request) ([]bootstrap.RuntimeProv
 	return s.pluginRuntimes.SnapshotPluginRuntimes(r.Context())
 }
 
-func adminRuntimeCapabilitiesFromSnapshot(snapshot bootstrap.RuntimeProviderSnapshot) *adminRuntimeCapabilities {
+func adminRuntimeCapabilitiesFromSnapshot(snapshot *bootstrap.RuntimeProviderSnapshot) *adminRuntimeCapabilities {
 	return &adminRuntimeCapabilities{
 		HostedPluginRuntime: snapshot.Capabilities.HostedPluginRuntime,
 		HostServiceTunnels:  snapshot.Capabilities.HostServiceTunnels,
@@ -115,4 +137,27 @@ func adminRuntimeCapabilitiesFromSnapshot(snapshot bootstrap.RuntimeProviderSnap
 		HostnameProxyEgress: snapshot.Capabilities.HostnameProxyEgress,
 		CIDREgress:          snapshot.Capabilities.CIDREgress,
 	}
+}
+
+func adminRuntimeProfilePairFromSnapshot(snapshot *bootstrap.RuntimeProviderSnapshot) *adminRuntimeProfilePair {
+	return &adminRuntimeProfilePair{
+		Advertised: adminRuntimeProfileFromBootstrap(snapshot.AdvertisedProfile),
+		Effective:  adminRuntimeProfileFromBootstrap(snapshot.EffectiveProfile),
+	}
+}
+
+func adminRuntimeProfileFromBootstrap(profile bootstrap.RuntimeProfile) adminRuntimeProfile {
+	out := adminRuntimeProfile{
+		HostedExecution:   profile.HostedExecution,
+		HostServiceAccess: strings.TrimSpace(string(profile.HostServiceMode)),
+		EgressMode:        strings.TrimSpace(string(profile.EgressMode)),
+		LaunchMode:        strings.TrimSpace(string(profile.LaunchMode)),
+	}
+	if profile.ExecutionTarget.IsSet() {
+		out.ExecutionTarget = &adminRuntimeExecutionTarget{
+			GOOS:   strings.TrimSpace(profile.ExecutionTarget.GOOS),
+			GOARCH: strings.TrimSpace(profile.ExecutionTarget.GOARCH),
+		}
+	}
+	return out
 }

--- a/gestaltd/internal/server/server_test.go
+++ b/gestaltd/internal/server/server_test.go
@@ -2887,13 +2887,36 @@ func TestAdminAPI_RuntimeProviders(t *testing.T) {
 					Default: true,
 				},
 				{
-					Name:   "modal",
-					Driver: config.RuntimeProviderDriver("modal"),
-					Loaded: true,
+					Name:               "modal",
+					Driver:             config.RuntimeProviderDriver("modal"),
+					Loaded:             true,
+					CapabilitiesLoaded: true,
 					Capabilities: pluginruntime.Capabilities{
 						HostedPluginRuntime: true,
 						ProviderGRPCTunnel:  true,
 						CIDREgress:          true,
+						ExecutionGOOS:       "linux",
+						ExecutionGOARCH:     "amd64",
+					},
+					AdvertisedProfile: bootstrap.RuntimeProfile{
+						HostedExecution: true,
+						HostServiceMode: bootstrap.RuntimeHostServiceModeNone,
+						EgressMode:      bootstrap.RuntimeEgressModeCIDR,
+						LaunchMode:      bootstrap.RuntimeLaunchModeBundle,
+						ExecutionTarget: bootstrap.RuntimeExecutionTarget{
+							GOOS:   "linux",
+							GOARCH: "amd64",
+						},
+					},
+					EffectiveProfile: bootstrap.RuntimeProfile{
+						HostedExecution: true,
+						HostServiceMode: bootstrap.RuntimeHostServiceModeRelay,
+						EgressMode:      bootstrap.RuntimeEgressModeCIDR,
+						LaunchMode:      bootstrap.RuntimeLaunchModeBundle,
+						ExecutionTarget: bootstrap.RuntimeExecutionTarget{
+							GOOS:   "linux",
+							GOARCH: "amd64",
+						},
 					},
 					Sessions: []pluginruntime.Session{{
 						ID:    "session-1",
@@ -2953,6 +2976,28 @@ func TestAdminAPI_RuntimeProviders(t *testing.T) {
 	}
 	if caps["hostedPluginRuntime"] != true || caps["providerGRPCTunnel"] != true || caps["cidrEgress"] != true {
 		t.Fatalf("runtime providers[1].capabilities = %#v", caps)
+	}
+	profile, ok := providers[1]["profile"].(map[string]any)
+	if !ok {
+		t.Fatalf("runtime providers[1].profile = %#v, want object", providers[1]["profile"])
+	}
+	advertised, ok := profile["advertised"].(map[string]any)
+	if !ok {
+		t.Fatalf("runtime providers[1].profile.advertised = %#v, want object", profile["advertised"])
+	}
+	effective, ok := profile["effective"].(map[string]any)
+	if !ok {
+		t.Fatalf("runtime providers[1].profile.effective = %#v, want object", profile["effective"])
+	}
+	if advertised["hostedExecution"] != true || advertised["hostServiceAccess"] != "none" || advertised["egressMode"] != "cidr" || advertised["launchMode"] != "bundle" {
+		t.Fatalf("runtime providers[1].profile.advertised = %#v", advertised)
+	}
+	if effective["hostedExecution"] != true || effective["hostServiceAccess"] != "relay" || effective["egressMode"] != "cidr" || effective["launchMode"] != "bundle" {
+		t.Fatalf("runtime providers[1].profile.effective = %#v", effective)
+	}
+	executionTarget, ok := effective["executionTarget"].(map[string]any)
+	if !ok || executionTarget["goos"] != "linux" || executionTarget["goarch"] != "amd64" {
+		t.Fatalf("runtime providers[1].profile.effective.executionTarget = %#v", effective["executionTarget"])
 	}
 }
 
@@ -3044,6 +3089,9 @@ func TestAdminAPI_RuntimeProviderInspectionError(t *testing.T) {
 	if got := providers[0]["error"]; got != "capabilities: boom" {
 		t.Fatalf("runtime providers[0].error = %v, want capabilities: boom", got)
 	}
+	if _, ok := providers[0]["profile"]; ok {
+		t.Fatalf("runtime providers[0].profile unexpectedly present: %#v", providers[0]["profile"])
+	}
 	if _, ok := providers[0]["capabilities"]; ok {
 		t.Fatalf("runtime providers[0].capabilities unexpectedly present: %#v", providers[0]["capabilities"])
 	}
@@ -3059,6 +3107,78 @@ func TestAdminAPI_RuntimeProviderInspectionError(t *testing.T) {
 	if sessionsResp.StatusCode != http.StatusServiceUnavailable {
 		body, _ := io.ReadAll(sessionsResp.Body)
 		t.Fatalf("runtime provider sessions status = %d, want 503: %s", sessionsResp.StatusCode, body)
+	}
+}
+
+func TestAdminAPI_RuntimeProviderSessionInspectionErrorKeepsProfile(t *testing.T) {
+	t.Parallel()
+
+	ts := newTestServer(t, func(cfg *server.Config) {
+		cfg.PluginRuntimes = &staticRuntimeInspector{
+			snapshots: []bootstrap.RuntimeProviderSnapshot{{
+				Name:               "modal",
+				Driver:             config.RuntimeProviderDriver("modal"),
+				Loaded:             true,
+				CapabilitiesLoaded: true,
+				Capabilities: pluginruntime.Capabilities{
+					HostedPluginRuntime: true,
+					ProviderGRPCTunnel:  true,
+					CIDREgress:          true,
+				},
+				AdvertisedProfile: bootstrap.RuntimeProfile{
+					HostedExecution: true,
+					HostServiceMode: bootstrap.RuntimeHostServiceModeNone,
+					EgressMode:      bootstrap.RuntimeEgressModeCIDR,
+					LaunchMode:      bootstrap.RuntimeLaunchModeBundle,
+				},
+				EffectiveProfile: bootstrap.RuntimeProfile{
+					HostedExecution: true,
+					HostServiceMode: bootstrap.RuntimeHostServiceModeRelay,
+					EgressMode:      bootstrap.RuntimeEgressModeCIDR,
+					LaunchMode:      bootstrap.RuntimeLaunchModeBundle,
+				},
+				Error: "list sessions: boom",
+			}},
+		}
+	})
+	testutil.CloseOnCleanup(t, ts)
+
+	resp, err := http.Get(ts.URL + "/admin/api/v1/runtime/providers")
+	if err != nil {
+		t.Fatalf("GET runtime providers with session inspection error: %v", err)
+	}
+	defer func() { _ = resp.Body.Close() }()
+	if resp.StatusCode != http.StatusOK {
+		body, _ := io.ReadAll(resp.Body)
+		t.Fatalf("runtime providers status = %d, want 200: %s", resp.StatusCode, body)
+	}
+
+	var providers []map[string]any
+	if err := json.NewDecoder(resp.Body).Decode(&providers); err != nil {
+		t.Fatalf("decoding runtime providers: %v", err)
+	}
+	if len(providers) != 1 {
+		t.Fatalf("runtime providers len = %d, want 1", len(providers))
+	}
+	if got := providers[0]["error"]; got != "list sessions: boom" {
+		t.Fatalf("runtime providers[0].error = %v, want list sessions: boom", got)
+	}
+	if _, ok := providers[0]["sessionCount"]; ok {
+		t.Fatalf("runtime providers[0].sessionCount unexpectedly present: %#v", providers[0]["sessionCount"])
+	}
+	if _, ok := providers[0]["capabilities"].(map[string]any); !ok {
+		t.Fatalf("runtime providers[0].capabilities = %#v, want object", providers[0]["capabilities"])
+	}
+	profile, ok := providers[0]["profile"].(map[string]any)
+	if !ok {
+		t.Fatalf("runtime providers[0].profile = %#v, want object", providers[0]["profile"])
+	}
+	effective, ok := profile["effective"].(map[string]any)
+	if !ok {
+		t.Fatalf("runtime providers[0].profile.effective = %#v, want object", profile["effective"])
+	}
+	if effective["hostServiceAccess"] != "relay" {
+		t.Fatalf("runtime providers[0].profile.effective = %#v, want relay host-service access", effective)
 	}
 }
 


### PR DESCRIPTION
This PR is the follow-up to merged `#1292`. It exposes the higher-level runtime model through admin inspection and docs.

## Old Interface

Before this PR, the runtime admin endpoint only exposed the raw capability bag plus basic provider state.

A typical `GET /admin/api/v1/runtime/providers` response looked like this:

```json
{
  "name": "modal",
  "driver": "grpc",
  "default": false,
  "loaded": true,
  "sessionCount": 2,
  "capabilities": {
    "hostedPluginRuntime": true,
    "hostServiceTunnels": false,
    "providerGRPCTunnel": true,
    "hostnameProxyEgress": true,
    "cidrEgress": true
  }
}
```

That was useful for debugging the raw runtime-provider contract, but it still made operators translate low-level booleans into the higher-level question they actually care about: what this runtime advertises, and what the current `gestaltd` deployment can really guarantee.

## New Interface

After this PR, the same endpoint still returns the raw `capabilities` object, but it also returns a derived `profile` object with `advertised` and `effective` runtime behavior.

```json
{
  "name": "modal",
  "driver": "grpc",
  "default": false,
  "loaded": true,
  "sessionCount": 2,
  "capabilities": {
    "hostedPluginRuntime": true,
    "providerGRPCTunnel": true,
    "cidrEgress": true
  },
  "profile": {
    "advertised": {
      "hostedExecution": true,
      "hostServiceAccess": "none",
      "egressMode": "cidr",
      "launchMode": "bundle",
      "executionTarget": {"goos": "linux", "goarch": "amd64"}
    },
    "effective": {
      "hostedExecution": true,
      "hostServiceAccess": "relay",
      "egressMode": "cidr",
      "launchMode": "bundle",
      "executionTarget": {"goos": "linux", "goarch": "amd64"}
    }
  }
}
```

When capability inspection succeeds but session inspection fails, the endpoint keeps the known `capabilities` and `profile` data and omits only `sessionCount`, for example:

```json
{
  "name": "modal",
  "error": "list sessions: boom",
  "capabilities": {"hostedPluginRuntime": true},
  "profile": {
    "advertised": {"hostedExecution": true},
    "effective": {"hostedExecution": true}
  }
}
```

## Why The New Interface Is Better

This is the same simplification move as `#1292`, but applied to inspection and docs rather than to bootstrap.

The old admin surface exposed the raw booleans and made operators mentally reconstruct the runtime story from them. The new surface keeps those raw booleans for debugging, but adds the higher-level runtime model directly: host-service access mode, egress mode, launch mode, and execution target, with an explicit distinction between what the runtime advertises and what this host deployment can actually deliver.

That is a better operator interface because it answers the deployment question directly instead of making every reader re-derive it themselves.

## Docs

The docs are updated to describe the same runtime model introduced in `#1292`:
- host-service access mode (`none`, `relay`, `direct`)
- egress mode (`none`, `cidr`, `hostname`)
- launch mode (`host_path`, `bundle`)
- execution target (`goos`, `goarch`)

The Modal docs are also aligned with the shipped behavior: relay-backed host services and hosted hostname egress are available only when the host is configured for the public relay and proxy path, not as an unconditional backend guarantee.

Validation:

```text
cd gestaltd && go test ./internal/server -count=1
cd docs && npm run build
```