### PR TITLE
Server: add user-scoped external identity linking API

### DIFF
--- a/gestaltd/internal/authorization/provider_backed.go
+++ b/gestaltd/internal/authorization/provider_backed.go
@@ -587,6 +587,12 @@ func (a *ProviderBackedAuthorizer) buildDesiredRelationships(existing map[string
 			}
 			addDesiredRelationship(desired, rel)
 			adminDynamicRoles[relation] = struct{}{}
+		case resourceTypeExternalIdentity:
+			relation := strings.TrimSpace(rel.GetRelation())
+			if relation != relationExternalIdentityAssume || rel.GetSubject() == nil || strings.TrimSpace(rel.GetSubject().GetType()) != subjectTypeUser || strings.TrimSpace(rel.GetSubject().GetId()) == "" {
+				continue
+			}
+			addDesiredRelationship(desired, rel)
 		}
 	}
 

--- a/gestaltd/internal/authorization/provider_schema.go
+++ b/gestaltd/internal/authorization/provider_schema.go
@@ -8,25 +8,31 @@ import (
 )
 
 const (
-	ProviderResourceTypePolicyStatic      = "policy_static"
-	ProviderResourceTypePluginStatic      = "plugin_static"
-	ProviderResourceTypePluginDynamic     = "plugin_dynamic"
-	ProviderResourceTypeAdminPolicyStatic = "admin_policy_static"
-	ProviderResourceTypeAdminDynamic      = "admin_dynamic"
-	ProviderResourceIDAdminDynamicGlobal  = "global"
+	ProviderResourceTypePolicyStatic       = "policy_static"
+	ProviderResourceTypePluginStatic       = "plugin_static"
+	ProviderResourceTypePluginDynamic      = "plugin_dynamic"
+	ProviderResourceTypeAdminPolicyStatic  = "admin_policy_static"
+	ProviderResourceTypeAdminDynamic       = "admin_dynamic"
+	ProviderResourceTypeExternalIdentity   = "external_identity"
+	ProviderResourceIDAdminDynamicGlobal   = "global"
+	ProviderExternalIdentityRelationAssume = "assume"
 
 	ProviderSubjectTypeSubject = "subject"
+	ProviderSubjectTypeUser    = "user"
 )
 
 const (
-	resourceTypePolicyStatic      = ProviderResourceTypePolicyStatic
-	resourceTypePluginStatic      = ProviderResourceTypePluginStatic
-	resourceTypePluginDynamic     = ProviderResourceTypePluginDynamic
-	resourceTypeAdminPolicyStatic = ProviderResourceTypeAdminPolicyStatic
-	resourceTypeAdminDynamic      = ProviderResourceTypeAdminDynamic
-	resourceIDAdminDynamicGlobal  = ProviderResourceIDAdminDynamicGlobal
+	resourceTypePolicyStatic       = ProviderResourceTypePolicyStatic
+	resourceTypePluginStatic       = ProviderResourceTypePluginStatic
+	resourceTypePluginDynamic      = ProviderResourceTypePluginDynamic
+	resourceTypeAdminPolicyStatic  = ProviderResourceTypeAdminPolicyStatic
+	resourceTypeAdminDynamic       = ProviderResourceTypeAdminDynamic
+	resourceTypeExternalIdentity   = ProviderResourceTypeExternalIdentity
+	resourceIDAdminDynamicGlobal   = ProviderResourceIDAdminDynamicGlobal
+	relationExternalIdentityAssume = ProviderExternalIdentityRelationAssume
 
 	subjectTypeSubject = ProviderSubjectTypeSubject
+	subjectTypeUser    = ProviderSubjectTypeUser
 )
 
 func IsManagedProviderRelationship(rel *core.Relationship) bool {
@@ -38,7 +44,8 @@ func IsManagedProviderRelationship(rel *core.Relationship) bool {
 		ProviderResourceTypePluginStatic,
 		ProviderResourceTypePluginDynamic,
 		ProviderResourceTypeAdminPolicyStatic,
-		ProviderResourceTypeAdminDynamic:
+		ProviderResourceTypeAdminDynamic,
+		ProviderResourceTypeExternalIdentity:
 		return true
 	default:
 		return false
@@ -84,6 +91,19 @@ func buildProviderAuthorizationModel(state providerBackedRoleState) *core.Author
 			resourceTypesForRoles(state.adminDynamicRoles, subjectTypeSubject),
 			state.adminDynamicRoles,
 		),
+	)
+	model.ResourceTypes = appendIfModelResourceType(model.ResourceTypes,
+		&core.AuthorizationModelResourceType{
+			Name: resourceTypeExternalIdentity,
+			Relations: []*core.AuthorizationModelRelation{{
+				Name:         relationExternalIdentityAssume,
+				SubjectTypes: []string{subjectTypeUser},
+			}},
+			Actions: []*core.AuthorizationModelAction{{
+				Name:      relationExternalIdentityAssume,
+				Relations: []string{relationExternalIdentityAssume},
+			}},
+		},
 	)
 
 	slices.SortFunc(model.ResourceTypes, func(left, right *core.AuthorizationModelResourceType) int {

--- a/gestaltd/internal/server/audit.go
+++ b/gestaltd/internal/server/audit.go
@@ -15,6 +15,7 @@ const (
 	auditTargetKindAPIToken              = "api_token"
 	auditTargetKindAPITokenCollection    = "api_token_collection"
 	auditTargetKindConnection            = "connection"
+	auditTargetKindExternalIdentity      = "external_identity"
 	auditTargetKindManagedIdentity       = "managed_identity"
 	auditTargetKindManagedIdentityMember = "managed_identity_member"
 	auditTargetKindManagedIdentityGrant  = "managed_identity_grant"
@@ -156,6 +157,24 @@ func connectionAuditTarget(provider, connection, instance string) auditTarget {
 		ID:   strings.Join(idParts, "/"),
 		Kind: auditTargetKindConnection,
 		Name: connection + "/" + instance,
+	}
+}
+
+func externalIdentityAuditTarget(identityType, identityID string) auditTarget {
+	identityType = strings.TrimSpace(identityType)
+	identityID = strings.TrimSpace(identityID)
+	id := identityID
+	if identityType != "" && identityID != "" {
+		id = identityType + "/" + identityID
+	}
+	name := identityID
+	if identityType != "" && identityID != "" {
+		name = identityType + ":" + identityID
+	}
+	return auditTarget{
+		ID:   id,
+		Kind: auditTargetKindExternalIdentity,
+		Name: name,
 	}
 }
 

--- a/gestaltd/internal/server/external_identity_link_state.go
+++ b/gestaltd/internal/server/external_identity_link_state.go
@@ -1,0 +1,109 @@
+package server
+
+import (
+	"encoding/base64"
+	"fmt"
+	"strings"
+	"time"
+
+	cryptoutil "github.com/valon-technologies/gestalt/server/core/crypto"
+	"github.com/valon-technologies/gestalt/server/internal/authorization"
+	"github.com/valon-technologies/gestalt/server/internal/principal"
+)
+
+const (
+	externalIdentityLinkRelation = authorization.ProviderExternalIdentityRelationAssume
+	externalIdentityLinkTokenTTL = 30 * time.Minute
+)
+
+type externalIdentityRef struct {
+	Type string `json:"type"`
+	ID   string `json:"id"`
+}
+
+type externalIdentityLinkTokenState struct {
+	ExternalIdentity externalIdentityRef `json:"externalIdentity"`
+	SubjectID        string              `json:"subjectId"`
+	ExpiresAt        int64               `json:"exp"`
+}
+
+func normalizeExternalIdentityRef(ref externalIdentityRef) externalIdentityRef {
+	return externalIdentityRef{
+		Type: strings.TrimSpace(ref.Type),
+		ID:   strings.TrimSpace(ref.ID),
+	}
+}
+
+func validateExternalIdentityRef(ref externalIdentityRef) error {
+	ref = normalizeExternalIdentityRef(ref)
+	if ref.Type == "" {
+		return fmt.Errorf("external identity type is required")
+	}
+	if ref.ID == "" {
+		return fmt.Errorf("external identity id is required")
+	}
+	return nil
+}
+
+func validateExternalIdentityLinkTokenState(state *externalIdentityLinkTokenState, now time.Time) error {
+	if state == nil {
+		return fmt.Errorf("external identity link token is required")
+	}
+	if err := validateExternalIdentityRef(state.ExternalIdentity); err != nil {
+		return fmt.Errorf("external identity link token invalid identity: %w", err)
+	}
+	if strings.TrimSpace(principal.UserIDFromSubjectID(state.SubjectID)) == "" {
+		return fmt.Errorf("external identity link token missing subject ID")
+	}
+	if state.ExpiresAt == 0 {
+		return fmt.Errorf("external identity link token missing expiration")
+	}
+	if now.Unix() > state.ExpiresAt {
+		return fmt.Errorf("external identity link token expired")
+	}
+	return nil
+}
+
+func decodeExternalIdentityLinkToken(enc *cryptoutil.AESGCMEncryptor, encoded string, now time.Time) (*externalIdentityLinkTokenState, error) {
+	state, err := decodeEncryptedState[externalIdentityLinkTokenState](enc, "external identity link token", encoded)
+	if err != nil {
+		return nil, err
+	}
+	if err := validateExternalIdentityLinkTokenState(state, now); err != nil {
+		return nil, err
+	}
+	state.ExternalIdentity = normalizeExternalIdentityRef(state.ExternalIdentity)
+	state.SubjectID = strings.TrimSpace(state.SubjectID)
+	return state, nil
+}
+
+func externalIdentityLinkID(ref externalIdentityRef) string {
+	ref = normalizeExternalIdentityRef(ref)
+	if ref.Type == "" || ref.ID == "" {
+		return ""
+	}
+	return base64.RawURLEncoding.EncodeToString([]byte(ref.Type + "\x00" + ref.ID))
+}
+
+func decodeExternalIdentityLinkID(linkID string) (externalIdentityRef, error) {
+	linkID = strings.TrimSpace(linkID)
+	if linkID == "" {
+		return externalIdentityRef{}, fmt.Errorf("external identity link ID is required")
+	}
+	raw, err := base64.RawURLEncoding.DecodeString(linkID)
+	if err != nil {
+		return externalIdentityRef{}, fmt.Errorf("decode external identity link ID: %w", err)
+	}
+	parts := strings.SplitN(string(raw), "\x00", 2)
+	if len(parts) != 2 {
+		return externalIdentityRef{}, fmt.Errorf("external identity link ID is invalid")
+	}
+	ref := normalizeExternalIdentityRef(externalIdentityRef{
+		Type: parts[0],
+		ID:   parts[1],
+	})
+	if err := validateExternalIdentityRef(ref); err != nil {
+		return externalIdentityRef{}, err
+	}
+	return ref, nil
+}

--- a/gestaltd/internal/server/handlers_external_identities.go
+++ b/gestaltd/internal/server/handlers_external_identities.go
@@ -1,0 +1,317 @@
+package server
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"net/http"
+	"sort"
+	"strings"
+
+	"github.com/go-chi/chi/v5"
+	"github.com/valon-technologies/gestalt/server/core"
+	"github.com/valon-technologies/gestalt/server/internal/authorization"
+	"github.com/valon-technologies/gestalt/server/internal/principal"
+)
+
+type createCurrentUserExternalIdentityRequest struct {
+	LinkToken string `json:"linkToken"`
+}
+
+type externalIdentityLinkInfo struct {
+	ID               string              `json:"id"`
+	ExternalIdentity externalIdentityRef `json:"externalIdentity"`
+}
+
+func (s *Server) listCurrentUserExternalIdentities(w http.ResponseWriter, r *http.Request) {
+	auditAllowed := false
+	auditErr := errors.New("external identity list failed")
+	defer func() {
+		s.auditHTTPEvent(r.Context(), PrincipalFromContext(r.Context()), "", "external_identity.list", auditAllowed, auditErr)
+	}()
+
+	userID, ok := s.resolveCurrentUserExternalIdentityUserID(w, r)
+	if !ok {
+		return
+	}
+
+	links, err := s.currentUserExternalIdentityLinks(r.Context(), userID)
+	if err != nil {
+		auditErr = err
+		writeError(w, http.StatusInternalServerError, "failed to list external identities")
+		return
+	}
+
+	auditAllowed = true
+	auditErr = nil
+	writeJSON(w, http.StatusOK, links)
+}
+
+func (s *Server) createCurrentUserExternalIdentity(w http.ResponseWriter, r *http.Request) {
+	auditAllowed := false
+	auditErr := errors.New("external identity link failed")
+	auditTarget := auditTarget{Kind: auditTargetKindExternalIdentity}
+	defer func() {
+		s.auditHTTPEventWithTarget(r.Context(), PrincipalFromContext(r.Context()), "", "external_identity.link", auditAllowed, auditErr, auditTarget)
+	}()
+
+	userID, ok := s.resolveCurrentUserExternalIdentityUserID(w, r)
+	if !ok {
+		return
+	}
+	if s.encryptor == nil {
+		auditErr = errors.New("external identity link tokens are unavailable")
+		writeError(w, http.StatusServiceUnavailable, "external identity link tokens are unavailable")
+		return
+	}
+
+	var req createCurrentUserExternalIdentityRequest
+	if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
+		auditErr = errors.New("invalid JSON body")
+		writeError(w, http.StatusBadRequest, "invalid JSON body")
+		return
+	}
+	req.LinkToken = strings.TrimSpace(req.LinkToken)
+	if req.LinkToken == "" {
+		auditErr = errors.New("linkToken is required")
+		writeError(w, http.StatusBadRequest, "linkToken is required")
+		return
+	}
+
+	state, err := decodeExternalIdentityLinkToken(s.encryptor, req.LinkToken, s.now())
+	if err != nil {
+		auditErr = err
+		writeError(w, http.StatusBadRequest, "linkToken is invalid or expired")
+		return
+	}
+	currentSubjectID := principal.UserSubjectID(userID)
+	if state.SubjectID != currentSubjectID {
+		auditErr = errors.New("linkToken does not match the current user")
+		writeError(w, http.StatusForbidden, "linkToken does not match the current user")
+		return
+	}
+	ref := externalIdentityLinkInfo{
+		ID:               externalIdentityLinkID(state.ExternalIdentity),
+		ExternalIdentity: state.ExternalIdentity,
+	}
+	auditTarget = externalIdentityAuditTarget(ref.ExternalIdentity.Type, ref.ExternalIdentity.ID)
+
+	status, err := s.linkCurrentUserExternalIdentity(r.Context(), userID, ref.ExternalIdentity)
+	if err != nil {
+		auditErr = err
+		switch {
+		case errors.Is(err, errExternalIdentityAlreadyLinked):
+			writeError(w, http.StatusConflict, "external identity is already linked")
+		default:
+			writeError(w, http.StatusInternalServerError, "failed to link external identity")
+		}
+		return
+	}
+
+	auditAllowed = true
+	auditErr = nil
+	writeJSON(w, status, ref)
+}
+
+func (s *Server) deleteCurrentUserExternalIdentity(w http.ResponseWriter, r *http.Request) {
+	linkID := strings.TrimSpace(chi.URLParam(r, "linkID"))
+	auditAllowed := false
+	auditErr := errors.New("external identity unlink failed")
+	auditTarget := auditTarget{Kind: auditTargetKindExternalIdentity, ID: linkID}
+	defer func() {
+		s.auditHTTPEventWithTarget(r.Context(), PrincipalFromContext(r.Context()), "", "external_identity.unlink", auditAllowed, auditErr, auditTarget)
+	}()
+
+	userID, ok := s.resolveCurrentUserExternalIdentityUserID(w, r)
+	if !ok {
+		return
+	}
+	ref, err := decodeExternalIdentityLinkID(linkID)
+	if err != nil {
+		auditErr = err
+		writeError(w, http.StatusBadRequest, "linkID is invalid")
+		return
+	}
+	auditTarget = externalIdentityAuditTarget(ref.Type, ref.ID)
+
+	if err := s.unlinkCurrentUserExternalIdentity(r.Context(), userID, ref); err != nil {
+		auditErr = err
+		switch {
+		case errors.Is(err, core.ErrNotFound):
+			writeError(w, http.StatusNotFound, "external identity not found")
+		default:
+			writeError(w, http.StatusInternalServerError, "failed to unlink external identity")
+		}
+		return
+	}
+
+	auditAllowed = true
+	auditErr = nil
+	writeJSON(w, http.StatusOK, map[string]string{"status": "deleted"})
+}
+
+func (s *Server) resolveCurrentUserExternalIdentityUserID(w http.ResponseWriter, r *http.Request) (string, bool) {
+	if s.authorizationProvider == nil {
+		writeError(w, http.StatusServiceUnavailable, "external identities require an authorization provider")
+		return "", false
+	}
+	userID, err := s.resolveUserID(w, r)
+	if err != nil {
+		return "", false
+	}
+	return strings.TrimSpace(userID), true
+}
+
+func (s *Server) currentUserExternalIdentityLinks(ctx context.Context, userID string) ([]externalIdentityLinkInfo, error) {
+	relationships, err := s.readAllAuthorizationRelationships(ctx, &core.ReadRelationshipsRequest{
+		PageSize: adminAuthorizationProviderReadPageSize,
+		Subject: &core.SubjectRef{
+			Type: "user",
+			Id:   principal.UserSubjectID(userID),
+		},
+		Relation: externalIdentityLinkRelation,
+	})
+	if err != nil {
+		return nil, err
+	}
+	links := make([]externalIdentityLinkInfo, 0, len(relationships))
+	seen := make(map[string]struct{}, len(relationships))
+	for _, rel := range relationships {
+		if rel == nil || rel.GetResource() == nil {
+			continue
+		}
+		if strings.TrimSpace(rel.GetResource().GetType()) != authorization.ProviderResourceTypeExternalIdentity {
+			continue
+		}
+		ref, err := decodeExternalIdentityLinkID(strings.TrimSpace(rel.GetResource().GetId()))
+		if err != nil {
+			continue
+		}
+		link := externalIdentityLinkInfo{
+			ID:               externalIdentityLinkID(ref),
+			ExternalIdentity: ref,
+		}
+		if link.ID == "" {
+			continue
+		}
+		key := link.ID
+		if _, ok := seen[key]; ok {
+			continue
+		}
+		seen[key] = struct{}{}
+		links = append(links, link)
+	}
+	sort.Slice(links, func(i, j int) bool {
+		if links[i].ExternalIdentity.Type != links[j].ExternalIdentity.Type {
+			return links[i].ExternalIdentity.Type < links[j].ExternalIdentity.Type
+		}
+		if links[i].ExternalIdentity.ID != links[j].ExternalIdentity.ID {
+			return links[i].ExternalIdentity.ID < links[j].ExternalIdentity.ID
+		}
+		return links[i].ID < links[j].ID
+	})
+	return links, nil
+}
+
+var errExternalIdentityAlreadyLinked = errors.New("external identity already linked")
+
+func (s *Server) linkCurrentUserExternalIdentity(ctx context.Context, userID string, ref externalIdentityRef) (int, error) {
+	linkID := externalIdentityLinkID(ref)
+	if linkID == "" {
+		return 0, errors.New("external identity is invalid")
+	}
+	relationships, err := s.readAllAuthorizationRelationships(ctx, &core.ReadRelationshipsRequest{
+		PageSize: adminAuthorizationProviderReadPageSize,
+		Relation: externalIdentityLinkRelation,
+		Resource: &core.ResourceRef{
+			Type: authorization.ProviderResourceTypeExternalIdentity,
+			Id:   linkID,
+		},
+	})
+	if err != nil {
+		return 0, err
+	}
+
+	subjectID := principal.UserSubjectID(userID)
+	currentUserLinked := false
+	otherUserLinked := false
+	for _, rel := range relationships {
+		if rel == nil || rel.GetSubject() == nil {
+			continue
+		}
+		if strings.TrimSpace(rel.GetSubject().GetType()) == "user" && strings.TrimSpace(rel.GetSubject().GetId()) == subjectID {
+			currentUserLinked = true
+			continue
+		}
+		otherUserLinked = true
+	}
+	if currentUserLinked {
+		return http.StatusOK, nil
+	}
+	if otherUserLinked {
+		return 0, errExternalIdentityAlreadyLinked
+	}
+
+	modelID, err := s.managedAuthorizationModelID(ctx)
+	if err != nil {
+		return 0, err
+	}
+	if err := s.authorizationProvider.WriteRelationships(ctx, &core.WriteRelationshipsRequest{
+		Writes: []*core.Relationship{{
+			Subject: &core.SubjectRef{
+				Type: "user",
+				Id:   subjectID,
+			},
+			Relation: externalIdentityLinkRelation,
+			Resource: &core.ResourceRef{
+				Type: authorization.ProviderResourceTypeExternalIdentity,
+				Id:   linkID,
+			},
+		}},
+		ModelId: modelID,
+	}); err != nil {
+		return 0, err
+	}
+	return http.StatusCreated, nil
+}
+
+func (s *Server) unlinkCurrentUserExternalIdentity(ctx context.Context, userID string, ref externalIdentityRef) error {
+	linkID := externalIdentityLinkID(ref)
+	if linkID == "" {
+		return errors.New("external identity is invalid")
+	}
+	relationships, err := s.readAllAuthorizationRelationships(ctx, &core.ReadRelationshipsRequest{
+		PageSize: adminAuthorizationProviderReadPageSize,
+		Relation: externalIdentityLinkRelation,
+		Resource: &core.ResourceRef{
+			Type: authorization.ProviderResourceTypeExternalIdentity,
+			Id:   linkID,
+		},
+	})
+	if err != nil {
+		return err
+	}
+
+	subjectID := principal.UserSubjectID(userID)
+	target := make([]*core.Relationship, 0, 1)
+	for _, rel := range relationships {
+		if rel == nil || rel.GetSubject() == nil {
+			continue
+		}
+		if strings.TrimSpace(rel.GetSubject().GetType()) == "user" && strings.TrimSpace(rel.GetSubject().GetId()) == subjectID {
+			target = append(target, rel)
+		}
+	}
+	if len(target) == 0 {
+		return core.ErrNotFound
+	}
+
+	modelID, err := s.managedAuthorizationModelID(ctx)
+	if err != nil {
+		return err
+	}
+	return s.authorizationProvider.WriteRelationships(ctx, &core.WriteRelationshipsRequest{
+		Deletes: relationshipKeys(target),
+		ModelId: modelID,
+	})
+}

--- a/gestaltd/internal/server/routes_user.go
+++ b/gestaltd/internal/server/routes_user.go
@@ -59,6 +59,12 @@ func (s *Server) mountAuthenticatedRoutes(r chi.Router) {
 			r.Post("/{identityID}/tokens", s.createManagedIdentityToken)
 			r.Delete("/{identityID}/tokens/{id}", s.revokeManagedIdentityToken)
 		})
+
+		r.Route("/users/me/external-identities", func(r chi.Router) {
+			r.Get("/", s.listCurrentUserExternalIdentities)
+			r.Post("/", s.createCurrentUserExternalIdentity)
+			r.Delete("/{linkID}", s.deleteCurrentUserExternalIdentity)
+		})
 	})
 
 	r.With(s.pluginRouteAuthMiddleware("name")).Get("/integrations/{name}/operations", s.listOperations)

--- a/gestaltd/internal/server/server_test.go
+++ b/gestaltd/internal/server/server_test.go
@@ -17891,6 +17891,228 @@ func TestManagedIdentityCRUDAndMemberships(t *testing.T) {
 	}
 }
 
+func TestCurrentUserExternalIdentityLinks(t *testing.T) {
+	t.Parallel()
+
+	svc := coretesting.NewStubServices(t)
+	admin := seedUser(t, svc, "admin@example.test")
+	viewer := seedUser(t, svc, "viewer@example.test")
+	provider := newMemoryAuthorizationProvider("memory-authorization")
+	base, err := authorization.New(config.AuthorizationConfig{}, map[string]*config.ProviderEntry{}, nil, nil)
+	if err != nil {
+		t.Fatalf("authorization.New: %v", err)
+	}
+	authz := mustProviderBackedAuthorizer(t, base, provider)
+
+	secret := []byte("0123456789abcdef0123456789abcdef")
+	ts := newTestServer(t, func(cfg *server.Config) {
+		cfg.Auth = &coretesting.StubAuthProvider{
+			N: "test",
+			ValidateTokenFn: func(_ context.Context, token string) (*core.UserIdentity, error) {
+				switch token {
+				case "admin-session":
+					return &core.UserIdentity{Email: "admin@example.test"}, nil
+				case "viewer-session":
+					return &core.UserIdentity{Email: "viewer@example.test"}, nil
+				default:
+					return nil, fmt.Errorf("unknown session %q", token)
+				}
+			},
+		}
+		cfg.Services = svc
+		cfg.Authorizer = authz
+		cfg.AuthorizationProvider = provider
+		cfg.StateSecret = secret
+	})
+	testutil.CloseOnCleanup(t, ts)
+
+	adminToken := mustEncodeExternalIdentityLinkToken(t, secret, principal.UserSubjectID(admin.ID), "slack_identity", "team:T123:user:U456")
+
+	var createResp struct {
+		ID               string `json:"id"`
+		ExternalIdentity struct {
+			Type string `json:"type"`
+			ID   string `json:"id"`
+		} `json:"externalIdentity"`
+	}
+	doJSONRequestAndDecode(
+		t,
+		http.MethodPost,
+		ts.URL+"/api/v1/users/me/external-identities",
+		"admin-session",
+		fmt.Sprintf(`{"linkToken":%q}`, adminToken),
+		http.StatusCreated,
+		&createResp,
+	)
+	if createResp.ExternalIdentity.Type != "slack_identity" || createResp.ExternalIdentity.ID != "team:T123:user:U456" {
+		t.Fatalf("create response = %+v, want slack_identity/team:T123:user:U456", createResp)
+	}
+	if createResp.ID == "" {
+		t.Fatalf("create response ID is empty: %+v", createResp)
+	}
+
+	resp, err := provider.ReadRelationships(context.Background(), &core.ReadRelationshipsRequest{
+		Relation: "assume",
+		Resource: &core.ResourceRef{Type: authorization.ProviderResourceTypeExternalIdentity, Id: createResp.ID},
+	})
+	if err != nil {
+		t.Fatalf("ReadRelationships after link: %v", err)
+	}
+	if len(resp.GetRelationships()) != 1 {
+		t.Fatalf("linked relationships = %+v, want one", resp.GetRelationships())
+	}
+	if got := resp.GetRelationships()[0].GetSubject().GetId(); got != principal.UserSubjectID(admin.ID) {
+		t.Fatalf("linked subject = %q, want %q", got, principal.UserSubjectID(admin.ID))
+	}
+	if err := authz.ReloadAuthorizationState(context.Background()); err != nil {
+		t.Fatalf("ReloadAuthorizationState after link: %v", err)
+	}
+	resp, err = provider.ReadRelationships(context.Background(), &core.ReadRelationshipsRequest{
+		Relation: "assume",
+		Resource: &core.ResourceRef{Type: authorization.ProviderResourceTypeExternalIdentity, Id: createResp.ID},
+	})
+	if err != nil {
+		t.Fatalf("ReadRelationships after reload: %v", err)
+	}
+	if len(resp.GetRelationships()) != 1 {
+		t.Fatalf("relationships after reload = %+v, want one", resp.GetRelationships())
+	}
+
+	var listResp []struct {
+		ID               string `json:"id"`
+		ExternalIdentity struct {
+			Type string `json:"type"`
+			ID   string `json:"id"`
+		} `json:"externalIdentity"`
+	}
+	doJSONRequestAndDecode(t, http.MethodGet, ts.URL+"/api/v1/users/me/external-identities", "admin-session", "", http.StatusOK, &listResp)
+	if len(listResp) != 1 || listResp[0].ID != createResp.ID || listResp[0].ExternalIdentity.Type != "slack_identity" || listResp[0].ExternalIdentity.ID != "team:T123:user:U456" {
+		t.Fatalf("list response = %+v, want one slack identity", listResp)
+	}
+
+	doJSONRequestAndDecode(
+		t,
+		http.MethodPost,
+		ts.URL+"/api/v1/users/me/external-identities",
+		"admin-session",
+		fmt.Sprintf(`{"linkToken":%q}`, adminToken),
+		http.StatusOK,
+		&createResp,
+	)
+
+	conflictingRel := &core.Relationship{
+		Subject: &core.SubjectRef{
+			Type: "user",
+			Id:   "user:0000-conflict",
+		},
+		Relation: "assume",
+		Resource: &core.ResourceRef{
+			Type: authorization.ProviderResourceTypeExternalIdentity,
+			Id:   createResp.ID,
+		},
+	}
+	modelID, err := authz.ManagedModelID(context.Background())
+	if err != nil {
+		t.Fatalf("ManagedModelID after link: %v", err)
+	}
+	if err := provider.WriteRelationships(context.Background(), &core.WriteRelationshipsRequest{
+		Writes:  []*core.Relationship{conflictingRel},
+		ModelId: modelID,
+	}); err != nil {
+		t.Fatalf("WriteRelationships conflicting rel: %v", err)
+	}
+	doJSONRequestAndDecode(
+		t,
+		http.MethodPost,
+		ts.URL+"/api/v1/users/me/external-identities",
+		"admin-session",
+		fmt.Sprintf(`{"linkToken":%q}`, adminToken),
+		http.StatusOK,
+		&createResp,
+	)
+	if err := provider.WriteRelationships(context.Background(), &core.WriteRelationshipsRequest{
+		Deletes: []*core.RelationshipKey{{
+			Subject: &core.SubjectRef{
+				Type: conflictingRel.GetSubject().GetType(),
+				Id:   conflictingRel.GetSubject().GetId(),
+			},
+			Relation: conflictingRel.GetRelation(),
+			Resource: &core.ResourceRef{
+				Type: conflictingRel.GetResource().GetType(),
+				Id:   conflictingRel.GetResource().GetId(),
+			},
+		}},
+		ModelId: modelID,
+	}); err != nil {
+		t.Fatalf("DeleteRelationships conflicting rel: %v", err)
+	}
+
+	mismatchReq, _ := http.NewRequest(http.MethodPost, ts.URL+"/api/v1/users/me/external-identities", bytes.NewBufferString(fmt.Sprintf(`{"linkToken":%q}`, adminToken)))
+	mismatchReq.Header.Set("Content-Type", "application/json")
+	mismatchReq.AddCookie(&http.Cookie{Name: "session_token", Value: "viewer-session"})
+	mismatchResp, err := http.DefaultClient.Do(mismatchReq)
+	if err != nil {
+		t.Fatalf("viewer mismatch link request: %v", err)
+	}
+	defer func() { _ = mismatchResp.Body.Close() }()
+	if mismatchResp.StatusCode != http.StatusForbidden {
+		payload, _ := io.ReadAll(mismatchResp.Body)
+		t.Fatalf("viewer mismatch status = %d, want %d: %s", mismatchResp.StatusCode, http.StatusForbidden, strings.TrimSpace(string(payload)))
+	}
+
+	viewerToken := mustEncodeExternalIdentityLinkToken(t, secret, principal.UserSubjectID(viewer.ID), "slack_identity", "team:T123:user:U456")
+	conflictReq, _ := http.NewRequest(http.MethodPost, ts.URL+"/api/v1/users/me/external-identities", bytes.NewBufferString(fmt.Sprintf(`{"linkToken":%q}`, viewerToken)))
+	conflictReq.Header.Set("Content-Type", "application/json")
+	conflictReq.AddCookie(&http.Cookie{Name: "session_token", Value: "viewer-session"})
+	conflictResp, err := http.DefaultClient.Do(conflictReq)
+	if err != nil {
+		t.Fatalf("viewer link request: %v", err)
+	}
+	defer func() { _ = conflictResp.Body.Close() }()
+	if conflictResp.StatusCode != http.StatusConflict {
+		payload, _ := io.ReadAll(conflictResp.Body)
+		t.Fatalf("viewer link status = %d, want %d: %s", conflictResp.StatusCode, http.StatusConflict, strings.TrimSpace(string(payload)))
+	}
+
+	var viewerList []struct {
+		ID               string `json:"id"`
+		ExternalIdentity struct {
+			Type string `json:"type"`
+			ID   string `json:"id"`
+		} `json:"externalIdentity"`
+	}
+	doJSONRequestAndDecode(t, http.MethodGet, ts.URL+"/api/v1/users/me/external-identities", "viewer-session", "", http.StatusOK, &viewerList)
+	if len(viewerList) != 0 {
+		t.Fatalf("viewer list = %+v, want empty", viewerList)
+	}
+
+	doJSONRequestAndDecode(
+		t,
+		http.MethodDelete,
+		ts.URL+"/api/v1/users/me/external-identities/"+url.PathEscape(createResp.ID),
+		"admin-session",
+		"",
+		http.StatusOK,
+		nil,
+	)
+
+	resp, err = provider.ReadRelationships(context.Background(), &core.ReadRelationshipsRequest{
+		Relation: "assume",
+		Resource: &core.ResourceRef{Type: authorization.ProviderResourceTypeExternalIdentity, Id: createResp.ID},
+	})
+	if err != nil {
+		t.Fatalf("ReadRelationships after unlink: %v", err)
+	}
+	if len(resp.GetRelationships()) != 0 {
+		t.Fatalf("relationships after unlink = %+v, want none", resp.GetRelationships())
+	}
+
+	doJSONRequestAndDecode(t, http.MethodGet, ts.URL+"/api/v1/users/me/external-identities", "admin-session", "", http.StatusOK, &listResp)
+	if len(listResp) != 0 {
+		t.Fatalf("list after unlink = %+v, want empty", listResp)
+	}
+}
+
 func TestManagedIdentityCreateRecoversWhenMembershipCreateFails(t *testing.T) {
 	t.Parallel()
 
@@ -20209,4 +20431,39 @@ func doJSONRequestAndDecode(t *testing.T, method, url, sessionToken, body string
 	if err := json.NewDecoder(resp.Body).Decode(dst); err != nil {
 		t.Fatalf("%s %s decode: %v", method, url, err)
 	}
+}
+
+func mustEncodeExternalIdentityLinkToken(t *testing.T, secret []byte, subjectID, identityType, identityID string) string {
+	t.Helper()
+
+	enc, err := corecrypto.NewAESGCM(secret)
+	if err != nil {
+		t.Fatalf("NewAESGCM: %v", err)
+	}
+	payload, err := json.Marshal(struct {
+		ExternalIdentity struct {
+			Type string `json:"type"`
+			ID   string `json:"id"`
+		} `json:"externalIdentity"`
+		SubjectID string `json:"subjectId"`
+		ExpiresAt int64  `json:"exp"`
+	}{
+		ExternalIdentity: struct {
+			Type string `json:"type"`
+			ID   string `json:"id"`
+		}{
+			Type: identityType,
+			ID:   identityID,
+		},
+		SubjectID: subjectID,
+		ExpiresAt: time.Now().Add(30 * time.Minute).Unix(),
+	})
+	if err != nil {
+		t.Fatalf("Marshal link token: %v", err)
+	}
+	token, err := enc.EncryptURLSafe(string(payload))
+	if err != nil {
+		t.Fatalf("EncryptURLSafe: %v", err)
+	}
+	return token
 }


### PR DESCRIPTION
## Summary
Adds a host-owned API for linking external identities to the current Gestalt user through the configured `AuthorizationProvider`, using a managed generic `external_identity` resource model.

## Interfaces
- `GET /api/v1/users/me/external-identities`
- `POST /api/v1/users/me/external-identities`
- `DELETE /api/v1/users/me/external-identities/{linkID}`

`POST` request body:
```json
{
  "linkToken": "..."
}
```

`GET` / `POST` response item:
```json
{
  "id": "<opaque-link-id>",
  "externalIdentity": {
    "type": "slack_identity",
    "id": "team:T123:user:U456"
  }
}
```

## Authorization Model
This change extends the managed provider-backed authorization model with:
- resource type: `external_identity`
- relation/action: `assume`
- subject type: `user`

External identity links are persisted as provider-managed relationships and survive `ProviderBackedAuthorizer.ReloadAuthorizationState()`.

## Examples
Link a Slack identity for the current user:
```http
POST /api/v1/users/me/external-identities
Content-Type: application/json

{"linkToken":"<host-issued-token-bound-to-user:user-123>"}
```

List linked external identities:
```http
GET /api/v1/users/me/external-identities
```

Remove a link:
```http
DELETE /api/v1/users/me/external-identities/<opaque-link-id>
```

## Tests
Extended the existing authenticated HTTP server lifecycle coverage with a functional external identity flow that verifies:
- link
- list
- user-bound token enforcement
- conflict on an already-linked identity
- survival across provider-backed authorization reload
- unlink

## Notes
The remaining concurrency risk is backend-dependent: `AuthorizationProvider` does not currently expose a compare-and-swap or uniqueness primitive for cross-request exclusive claims.