### PR TITLE
Delete Go manager request boilerplate

### DIFF
--- a/sdk/go/agent_manager.go
+++ b/sdk/go/agent_manager.go
@@ -8,7 +8,6 @@ import (
 	"time"
 
 	proto "github.com/valon-technologies/gestalt/sdk/go/gen/v1"
-	gproto "google.golang.org/protobuf/proto"
 )
 
 const EnvAgentManagerSocket = proto.EnvAgentManagerSocket
@@ -51,49 +50,37 @@ func (c *AgentManagerClient) Close() error {
 }
 
 func (c *AgentManagerClient) Run(ctx context.Context, req *proto.AgentManagerRunRequest) (*proto.ManagedAgentRun, error) {
-	if c == nil || c.client == nil {
-		return nil, fmt.Errorf("agent manager: client is not initialized")
-	}
-	value := &proto.AgentManagerRunRequest{}
-	if req != nil {
-		value = gproto.Clone(req).(*proto.AgentManagerRunRequest)
-	}
-	value.InvocationToken = c.invocationToken
-	return c.client.Run(ctx, value)
+	return managerUnary(ctx, "agent manager", c != nil && c.client != nil, req, &proto.AgentManagerRunRequest{}, c.invocationToken,
+		func(value *proto.AgentManagerRunRequest, token string) { value.InvocationToken = token },
+		func(ctx context.Context, value *proto.AgentManagerRunRequest) (*proto.ManagedAgentRun, error) {
+			return c.client.Run(ctx, value)
+		},
+	)
 }
 
 func (c *AgentManagerClient) GetRun(ctx context.Context, req *proto.AgentManagerGetRunRequest) (*proto.ManagedAgentRun, error) {
-	if c == nil || c.client == nil {
-		return nil, fmt.Errorf("agent manager: client is not initialized")
-	}
-	value := &proto.AgentManagerGetRunRequest{}
-	if req != nil {
-		value = gproto.Clone(req).(*proto.AgentManagerGetRunRequest)
-	}
-	value.InvocationToken = c.invocationToken
-	return c.client.GetRun(ctx, value)
+	return managerUnary(ctx, "agent manager", c != nil && c.client != nil, req, &proto.AgentManagerGetRunRequest{}, c.invocationToken,
+		func(value *proto.AgentManagerGetRunRequest, token string) { value.InvocationToken = token },
+		func(ctx context.Context, value *proto.AgentManagerGetRunRequest) (*proto.ManagedAgentRun, error) {
+			return c.client.GetRun(ctx, value)
+		},
+	)
 }
 
 func (c *AgentManagerClient) ListRuns(ctx context.Context, req *proto.AgentManagerListRunsRequest) (*proto.AgentManagerListRunsResponse, error) {
-	if c == nil || c.client == nil {
-		return nil, fmt.Errorf("agent manager: client is not initialized")
-	}
-	value := &proto.AgentManagerListRunsRequest{}
-	if req != nil {
-		value = gproto.Clone(req).(*proto.AgentManagerListRunsRequest)
-	}
-	value.InvocationToken = c.invocationToken
-	return c.client.ListRuns(ctx, value)
+	return managerUnary(ctx, "agent manager", c != nil && c.client != nil, req, &proto.AgentManagerListRunsRequest{}, c.invocationToken,
+		func(value *proto.AgentManagerListRunsRequest, token string) { value.InvocationToken = token },
+		func(ctx context.Context, value *proto.AgentManagerListRunsRequest) (*proto.AgentManagerListRunsResponse, error) {
+			return c.client.ListRuns(ctx, value)
+		},
+	)
 }
 
 func (c *AgentManagerClient) CancelRun(ctx context.Context, req *proto.AgentManagerCancelRunRequest) (*proto.ManagedAgentRun, error) {
-	if c == nil || c.client == nil {
-		return nil, fmt.Errorf("agent manager: client is not initialized")
-	}
-	value := &proto.AgentManagerCancelRunRequest{}
-	if req != nil {
-		value = gproto.Clone(req).(*proto.AgentManagerCancelRunRequest)
-	}
-	value.InvocationToken = c.invocationToken
-	return c.client.CancelRun(ctx, value)
+	return managerUnary(ctx, "agent manager", c != nil && c.client != nil, req, &proto.AgentManagerCancelRunRequest{}, c.invocationToken,
+		func(value *proto.AgentManagerCancelRunRequest, token string) { value.InvocationToken = token },
+		func(ctx context.Context, value *proto.AgentManagerCancelRunRequest) (*proto.ManagedAgentRun, error) {
+			return c.client.CancelRun(ctx, value)
+		},
+	)
 }

--- a/sdk/go/manager_request.go
+++ b/sdk/go/manager_request.go
@@ -1,0 +1,57 @@
+package gestalt
+
+import (
+	"context"
+	"fmt"
+
+	gproto "google.golang.org/protobuf/proto"
+)
+
+func ensureManagerClient(service string, ready bool) error {
+	if ready {
+		return nil
+	}
+	return fmt.Errorf("%s: client is not initialized", service)
+}
+
+func managerRequestWithToken[Req gproto.Message](req gproto.Message, empty Req, token string, set func(Req, string)) Req {
+	value := empty
+	if req != nil {
+		value = gproto.Clone(req).(Req)
+	}
+	set(value, token)
+	return value
+}
+
+func managerUnary[Req gproto.Message, Resp any](
+	ctx context.Context,
+	service string,
+	ready bool,
+	req gproto.Message,
+	empty Req,
+	token string,
+	set func(Req, string),
+	invoke func(context.Context, Req) (Resp, error),
+) (Resp, error) {
+	var zero Resp
+	if err := ensureManagerClient(service, ready); err != nil {
+		return zero, err
+	}
+	return invoke(ctx, managerRequestWithToken(req, empty, token, set))
+}
+
+func managerUnaryNoResponse[Req gproto.Message](
+	ctx context.Context,
+	service string,
+	ready bool,
+	req gproto.Message,
+	empty Req,
+	token string,
+	set func(Req, string),
+	invoke func(context.Context, Req) error,
+) error {
+	if err := ensureManagerClient(service, ready); err != nil {
+		return err
+	}
+	return invoke(ctx, managerRequestWithToken(req, empty, token, set))
+}

--- a/sdk/go/workflow_manager.go
+++ b/sdk/go/workflow_manager.go
@@ -8,7 +8,6 @@ import (
 	"time"
 
 	proto "github.com/valon-technologies/gestalt/sdk/go/gen/v1"
-	gproto "google.golang.org/protobuf/proto"
 )
 
 const EnvWorkflowManagerSocket = proto.EnvWorkflowManagerSocket
@@ -51,159 +50,130 @@ func (c *WorkflowManagerClient) Close() error {
 }
 
 func (c *WorkflowManagerClient) CreateSchedule(ctx context.Context, req *proto.WorkflowManagerCreateScheduleRequest) (*proto.ManagedWorkflowSchedule, error) {
-	if c == nil || c.client == nil {
-		return nil, fmt.Errorf("workflow manager: client is not initialized")
-	}
-	value := &proto.WorkflowManagerCreateScheduleRequest{}
-	if req != nil {
-		value = gproto.Clone(req).(*proto.WorkflowManagerCreateScheduleRequest)
-	}
-	value.InvocationToken = c.invocationToken
-	return c.client.CreateSchedule(ctx, value)
+	return managerUnary(ctx, "workflow manager", c != nil && c.client != nil, req, &proto.WorkflowManagerCreateScheduleRequest{}, c.invocationToken,
+		func(value *proto.WorkflowManagerCreateScheduleRequest, token string) { value.InvocationToken = token },
+		func(ctx context.Context, value *proto.WorkflowManagerCreateScheduleRequest) (*proto.ManagedWorkflowSchedule, error) {
+			return c.client.CreateSchedule(ctx, value)
+		},
+	)
 }
 
 func (c *WorkflowManagerClient) GetSchedule(ctx context.Context, req *proto.WorkflowManagerGetScheduleRequest) (*proto.ManagedWorkflowSchedule, error) {
-	if c == nil || c.client == nil {
-		return nil, fmt.Errorf("workflow manager: client is not initialized")
-	}
-	value := &proto.WorkflowManagerGetScheduleRequest{}
-	if req != nil {
-		value = gproto.Clone(req).(*proto.WorkflowManagerGetScheduleRequest)
-	}
-	value.InvocationToken = c.invocationToken
-	return c.client.GetSchedule(ctx, value)
+	return managerUnary(ctx, "workflow manager", c != nil && c.client != nil, req, &proto.WorkflowManagerGetScheduleRequest{}, c.invocationToken,
+		func(value *proto.WorkflowManagerGetScheduleRequest, token string) { value.InvocationToken = token },
+		func(ctx context.Context, value *proto.WorkflowManagerGetScheduleRequest) (*proto.ManagedWorkflowSchedule, error) {
+			return c.client.GetSchedule(ctx, value)
+		},
+	)
 }
 
 func (c *WorkflowManagerClient) UpdateSchedule(ctx context.Context, req *proto.WorkflowManagerUpdateScheduleRequest) (*proto.ManagedWorkflowSchedule, error) {
-	if c == nil || c.client == nil {
-		return nil, fmt.Errorf("workflow manager: client is not initialized")
-	}
-	value := &proto.WorkflowManagerUpdateScheduleRequest{}
-	if req != nil {
-		value = gproto.Clone(req).(*proto.WorkflowManagerUpdateScheduleRequest)
-	}
-	value.InvocationToken = c.invocationToken
-	return c.client.UpdateSchedule(ctx, value)
+	return managerUnary(ctx, "workflow manager", c != nil && c.client != nil, req, &proto.WorkflowManagerUpdateScheduleRequest{}, c.invocationToken,
+		func(value *proto.WorkflowManagerUpdateScheduleRequest, token string) { value.InvocationToken = token },
+		func(ctx context.Context, value *proto.WorkflowManagerUpdateScheduleRequest) (*proto.ManagedWorkflowSchedule, error) {
+			return c.client.UpdateSchedule(ctx, value)
+		},
+	)
 }
 
 func (c *WorkflowManagerClient) DeleteSchedule(ctx context.Context, req *proto.WorkflowManagerDeleteScheduleRequest) error {
-	if c == nil || c.client == nil {
-		return fmt.Errorf("workflow manager: client is not initialized")
-	}
-	value := &proto.WorkflowManagerDeleteScheduleRequest{}
-	if req != nil {
-		value = gproto.Clone(req).(*proto.WorkflowManagerDeleteScheduleRequest)
-	}
-	value.InvocationToken = c.invocationToken
-	_, err := c.client.DeleteSchedule(ctx, value)
-	return err
+	return managerUnaryNoResponse(ctx, "workflow manager", c != nil && c.client != nil, req, &proto.WorkflowManagerDeleteScheduleRequest{}, c.invocationToken,
+		func(value *proto.WorkflowManagerDeleteScheduleRequest, token string) { value.InvocationToken = token },
+		func(ctx context.Context, value *proto.WorkflowManagerDeleteScheduleRequest) error {
+			_, err := c.client.DeleteSchedule(ctx, value)
+			return err
+		},
+	)
 }
 
 func (c *WorkflowManagerClient) PauseSchedule(ctx context.Context, req *proto.WorkflowManagerPauseScheduleRequest) (*proto.ManagedWorkflowSchedule, error) {
-	if c == nil || c.client == nil {
-		return nil, fmt.Errorf("workflow manager: client is not initialized")
-	}
-	value := &proto.WorkflowManagerPauseScheduleRequest{}
-	if req != nil {
-		value = gproto.Clone(req).(*proto.WorkflowManagerPauseScheduleRequest)
-	}
-	value.InvocationToken = c.invocationToken
-	return c.client.PauseSchedule(ctx, value)
+	return managerUnary(ctx, "workflow manager", c != nil && c.client != nil, req, &proto.WorkflowManagerPauseScheduleRequest{}, c.invocationToken,
+		func(value *proto.WorkflowManagerPauseScheduleRequest, token string) { value.InvocationToken = token },
+		func(ctx context.Context, value *proto.WorkflowManagerPauseScheduleRequest) (*proto.ManagedWorkflowSchedule, error) {
+			return c.client.PauseSchedule(ctx, value)
+		},
+	)
 }
 
 func (c *WorkflowManagerClient) ResumeSchedule(ctx context.Context, req *proto.WorkflowManagerResumeScheduleRequest) (*proto.ManagedWorkflowSchedule, error) {
-	if c == nil || c.client == nil {
-		return nil, fmt.Errorf("workflow manager: client is not initialized")
-	}
-	value := &proto.WorkflowManagerResumeScheduleRequest{}
-	if req != nil {
-		value = gproto.Clone(req).(*proto.WorkflowManagerResumeScheduleRequest)
-	}
-	value.InvocationToken = c.invocationToken
-	return c.client.ResumeSchedule(ctx, value)
+	return managerUnary(ctx, "workflow manager", c != nil && c.client != nil, req, &proto.WorkflowManagerResumeScheduleRequest{}, c.invocationToken,
+		func(value *proto.WorkflowManagerResumeScheduleRequest, token string) { value.InvocationToken = token },
+		func(ctx context.Context, value *proto.WorkflowManagerResumeScheduleRequest) (*proto.ManagedWorkflowSchedule, error) {
+			return c.client.ResumeSchedule(ctx, value)
+		},
+	)
 }
 
 func (c *WorkflowManagerClient) CreateTrigger(ctx context.Context, req *proto.WorkflowManagerCreateEventTriggerRequest) (*proto.ManagedWorkflowEventTrigger, error) {
-	if c == nil || c.client == nil {
-		return nil, fmt.Errorf("workflow manager: client is not initialized")
-	}
-	value := &proto.WorkflowManagerCreateEventTriggerRequest{}
-	if req != nil {
-		value = gproto.Clone(req).(*proto.WorkflowManagerCreateEventTriggerRequest)
-	}
-	value.InvocationToken = c.invocationToken
-	return c.client.CreateEventTrigger(ctx, value)
+	return managerUnary(ctx, "workflow manager", c != nil && c.client != nil, req, &proto.WorkflowManagerCreateEventTriggerRequest{}, c.invocationToken,
+		func(value *proto.WorkflowManagerCreateEventTriggerRequest, token string) {
+			value.InvocationToken = token
+		},
+		func(ctx context.Context, value *proto.WorkflowManagerCreateEventTriggerRequest) (*proto.ManagedWorkflowEventTrigger, error) {
+			return c.client.CreateEventTrigger(ctx, value)
+		},
+	)
 }
 
 func (c *WorkflowManagerClient) GetTrigger(ctx context.Context, req *proto.WorkflowManagerGetEventTriggerRequest) (*proto.ManagedWorkflowEventTrigger, error) {
-	if c == nil || c.client == nil {
-		return nil, fmt.Errorf("workflow manager: client is not initialized")
-	}
-	value := &proto.WorkflowManagerGetEventTriggerRequest{}
-	if req != nil {
-		value = gproto.Clone(req).(*proto.WorkflowManagerGetEventTriggerRequest)
-	}
-	value.InvocationToken = c.invocationToken
-	return c.client.GetEventTrigger(ctx, value)
+	return managerUnary(ctx, "workflow manager", c != nil && c.client != nil, req, &proto.WorkflowManagerGetEventTriggerRequest{}, c.invocationToken,
+		func(value *proto.WorkflowManagerGetEventTriggerRequest, token string) { value.InvocationToken = token },
+		func(ctx context.Context, value *proto.WorkflowManagerGetEventTriggerRequest) (*proto.ManagedWorkflowEventTrigger, error) {
+			return c.client.GetEventTrigger(ctx, value)
+		},
+	)
 }
 
 func (c *WorkflowManagerClient) UpdateTrigger(ctx context.Context, req *proto.WorkflowManagerUpdateEventTriggerRequest) (*proto.ManagedWorkflowEventTrigger, error) {
-	if c == nil || c.client == nil {
-		return nil, fmt.Errorf("workflow manager: client is not initialized")
-	}
-	value := &proto.WorkflowManagerUpdateEventTriggerRequest{}
-	if req != nil {
-		value = gproto.Clone(req).(*proto.WorkflowManagerUpdateEventTriggerRequest)
-	}
-	value.InvocationToken = c.invocationToken
-	return c.client.UpdateEventTrigger(ctx, value)
+	return managerUnary(ctx, "workflow manager", c != nil && c.client != nil, req, &proto.WorkflowManagerUpdateEventTriggerRequest{}, c.invocationToken,
+		func(value *proto.WorkflowManagerUpdateEventTriggerRequest, token string) {
+			value.InvocationToken = token
+		},
+		func(ctx context.Context, value *proto.WorkflowManagerUpdateEventTriggerRequest) (*proto.ManagedWorkflowEventTrigger, error) {
+			return c.client.UpdateEventTrigger(ctx, value)
+		},
+	)
 }
 
 func (c *WorkflowManagerClient) DeleteTrigger(ctx context.Context, req *proto.WorkflowManagerDeleteEventTriggerRequest) error {
-	if c == nil || c.client == nil {
-		return fmt.Errorf("workflow manager: client is not initialized")
-	}
-	value := &proto.WorkflowManagerDeleteEventTriggerRequest{}
-	if req != nil {
-		value = gproto.Clone(req).(*proto.WorkflowManagerDeleteEventTriggerRequest)
-	}
-	value.InvocationToken = c.invocationToken
-	_, err := c.client.DeleteEventTrigger(ctx, value)
-	return err
+	return managerUnaryNoResponse(ctx, "workflow manager", c != nil && c.client != nil, req, &proto.WorkflowManagerDeleteEventTriggerRequest{}, c.invocationToken,
+		func(value *proto.WorkflowManagerDeleteEventTriggerRequest, token string) {
+			value.InvocationToken = token
+		},
+		func(ctx context.Context, value *proto.WorkflowManagerDeleteEventTriggerRequest) error {
+			_, err := c.client.DeleteEventTrigger(ctx, value)
+			return err
+		},
+	)
 }
 
 func (c *WorkflowManagerClient) PauseTrigger(ctx context.Context, req *proto.WorkflowManagerPauseEventTriggerRequest) (*proto.ManagedWorkflowEventTrigger, error) {
-	if c == nil || c.client == nil {
-		return nil, fmt.Errorf("workflow manager: client is not initialized")
-	}
-	value := &proto.WorkflowManagerPauseEventTriggerRequest{}
-	if req != nil {
-		value = gproto.Clone(req).(*proto.WorkflowManagerPauseEventTriggerRequest)
-	}
-	value.InvocationToken = c.invocationToken
-	return c.client.PauseEventTrigger(ctx, value)
+	return managerUnary(ctx, "workflow manager", c != nil && c.client != nil, req, &proto.WorkflowManagerPauseEventTriggerRequest{}, c.invocationToken,
+		func(value *proto.WorkflowManagerPauseEventTriggerRequest, token string) {
+			value.InvocationToken = token
+		},
+		func(ctx context.Context, value *proto.WorkflowManagerPauseEventTriggerRequest) (*proto.ManagedWorkflowEventTrigger, error) {
+			return c.client.PauseEventTrigger(ctx, value)
+		},
+	)
 }
 
 func (c *WorkflowManagerClient) ResumeTrigger(ctx context.Context, req *proto.WorkflowManagerResumeEventTriggerRequest) (*proto.ManagedWorkflowEventTrigger, error) {
-	if c == nil || c.client == nil {
-		return nil, fmt.Errorf("workflow manager: client is not initialized")
-	}
-	value := &proto.WorkflowManagerResumeEventTriggerRequest{}
-	if req != nil {
-		value = gproto.Clone(req).(*proto.WorkflowManagerResumeEventTriggerRequest)
-	}
-	value.InvocationToken = c.invocationToken
-	return c.client.ResumeEventTrigger(ctx, value)
+	return managerUnary(ctx, "workflow manager", c != nil && c.client != nil, req, &proto.WorkflowManagerResumeEventTriggerRequest{}, c.invocationToken,
+		func(value *proto.WorkflowManagerResumeEventTriggerRequest, token string) {
+			value.InvocationToken = token
+		},
+		func(ctx context.Context, value *proto.WorkflowManagerResumeEventTriggerRequest) (*proto.ManagedWorkflowEventTrigger, error) {
+			return c.client.ResumeEventTrigger(ctx, value)
+		},
+	)
 }
 
 func (c *WorkflowManagerClient) PublishEvent(ctx context.Context, req *proto.WorkflowManagerPublishEventRequest) (*proto.WorkflowEvent, error) {
-	if c == nil || c.client == nil {
-		return nil, fmt.Errorf("workflow manager: client is not initialized")
-	}
-	value := &proto.WorkflowManagerPublishEventRequest{}
-	if req != nil {
-		value = gproto.Clone(req).(*proto.WorkflowManagerPublishEventRequest)
-	}
-	value.InvocationToken = c.invocationToken
-	return c.client.PublishEvent(ctx, value)
+	return managerUnary(ctx, "workflow manager", c != nil && c.client != nil, req, &proto.WorkflowManagerPublishEventRequest{}, c.invocationToken,
+		func(value *proto.WorkflowManagerPublishEventRequest, token string) { value.InvocationToken = token },
+		func(ctx context.Context, value *proto.WorkflowManagerPublishEventRequest) (*proto.WorkflowEvent, error) {
+			return c.client.PublishEvent(ctx, value)
+		},
+	)
 }


### PR DESCRIPTION
## Summary
This is a narrow follow-up cleanup after #1295.

It deletes the remaining repeated request-wrapping logic in the Go SDK manager clients:
- add one shared `manager_request.go` helper for request cloning, invocation-token injection, and nil-client checks
- rewrite `AgentManagerClient` and `WorkflowManagerClient` methods to use that helper
- keep the public Go SDK surface unchanged

## Public interface
No public API changes.

Existing usage stays the same:

```go
agentClient, err := gestalt.AgentManager(invocationToken)
run, err := agentClient.Run(ctx, &proto.AgentManagerRunRequest{
    ProviderName: "managed",
})
```

```go
workflowClient, err := gestalt.WorkflowManager(invocationToken)
schedule, err := workflowClient.CreateSchedule(ctx, &proto.WorkflowManagerCreateScheduleRequest{
    ProviderName: "managed",
    Cron:         "*/5 * * * *",
})
```

The cleanup is internal: the wrappers no longer each carry their own copy of:
- nil-client checks
- request cloning
- `InvocationToken` injection
- unary request plumbing

## Verification
Reused the existing manager transport coverage rather than adding redundant tests.

- `go test ./... -run 'TestTransport_(Agent|Workflow)ManagerTCPTargetTokenEnv' -count=1` in `sdk/go`
- `git diff --check`
