### PR TITLE
Runtime providers: make grouped support the only contract

### DIFF
--- a/docs/content/custom-providers/runtime.mdx
+++ b/docs/content/custom-providers/runtime.mdx
@@ -67,7 +67,7 @@ The runtime surface is intentionally small but lifecycle-oriented:
 
 | Method | Purpose |
 | --- | --- |
-| `GetCapabilities` | Advertise what this backend can actually do. |
+| `GetCapabilities` | Advertise grouped runtime support for this backend. |
 | `StartSession` | Create a hosted runtime session for a plugin. |
 | `GetSession` | Report session status so Gestalt can wait for readiness. |
 | `StopSession` | Tear a session down on shutdown or bootstrap failure. |
@@ -100,10 +100,15 @@ func (p *Provider) Configure(context.Context, string, map[string]any) error {
 
 func (p *Provider) GetCapabilities(context.Context, *emptypb.Empty) (*proto.GetPluginRuntimeCapabilitiesResponse, error) {
 	return &proto.GetPluginRuntimeCapabilitiesResponse{
-		Capabilities: &proto.PluginRuntimeCapabilities{
-			HostedPluginRuntime: true,
-			HostServiceTunnels:  true,
-			ProviderGrpcTunnel:  true,
+		Support: &proto.PluginRuntimeSupport{
+			CanHostPlugins:   true,
+			HostServiceAccess: proto.PluginRuntimeHostServiceAccess_PLUGIN_RUNTIME_HOST_SERVICE_ACCESS_DIRECT,
+			EgressMode:        proto.PluginRuntimeEgressMode_PLUGIN_RUNTIME_EGRESS_MODE_HOSTNAME,
+			LaunchMode:        proto.PluginRuntimeLaunchMode_PLUGIN_RUNTIME_LAUNCH_MODE_BUNDLE,
+			ExecutionTarget: &proto.PluginRuntimeExecutionTarget{
+				Goos:   "linux",
+				Goarch: "amd64",
+			},
 		},
 	}, nil
 }
@@ -151,33 +156,36 @@ func main() {
 }
 ```
 
-## Capability guidelines
+## Support guidelines
 
-Advertise capabilities conservatively. The host still receives the raw runtime
-capability flags, but it derives a higher-level runtime profile from them. That
-profile is what operators see in admin inspection, and it is what bootstrap
-uses to decide whether a hosted plugin can start safely on a given backend.
+Advertise the smallest truthful grouped support surface you can.
 
-In practice that means `host_service_tunnels` should only be true when your
-backend can really expose direct guest-local host-service sockets. If that flag
-is false, Gestalt may still derive an effective relay-backed host-service mode
-when `server.baseURL` and `server.encryptionKey` allow the public relay path.
+`can_host_plugins` should only be true when the backend can actually launch a
+host-reachable executable plugin session. If that is false, Gestalt will reject
+hosted execution for that runtime immediately instead of failing later during
+bootstrap.
 
-Likewise, `hostname_proxy_egress` is not just a firewall hint. It means the
-runtime can preserve Gestalt's hostname-based `allowedHosts` semantics. That
-preservation may happen inside the backend itself, or it may happen by routing
-hosted HTTP(S) traffic through Gestalt's public egress proxy. `cidr_egress`
-remains useful metadata, but it is not equivalent to hostname-based policy.
+`host_service_access` should be `direct` only when the backend can really
+expose guest-local host-service sockets inside the runtime session. When that
+value is `none`, Gestalt may still derive an *effective* relay-backed
+host-service path if the current host deployment has the public relay
+prerequisites, but that relay behavior is host-provided, not runtime-advertised.
 
-`host_path_execution` should only be true when the backend can execute directly
-from the host paths Gestalt provides. Otherwise Gestalt will derive a bundle
-launch mode and stage a runtime bundle first. When bundle launch is required,
-`execution_goos` and `execution_goarch` must accurately describe the target
-platform so the host can choose or stage the right artifact.
+`egress_mode` should be `hostname` only when the runtime can preserve
+Gestalt's hostname-based `allowedHosts` model. `cidr` is useful metadata, but
+it is not equivalent to hostname-based policy. If your backend can only express
+network controls at firewall or CIDR granularity, advertise `cidr`.
 
-If these capabilities are wrong, operators will see either false compatibility
-rejections or late runtime failures. The safest rule is to advertise the
-smallest truthful surface and let Gestalt derive the rest.
+`launch_mode` should be `host_path` only when the backend can execute directly
+from the host paths Gestalt provides. Otherwise advertise `bundle`, which tells
+the host to stage a runtime bundle first. When bundle launch is required,
+`execution_target` must accurately describe the platform the backend will
+actually run so the host can choose or stage the right artifact.
+
+Older runtime providers may continue returning the legacy `capabilities` field
+for compatibility, but new providers should populate `support` instead. Gestalt
+still understands the old booleans, but the grouped support shape is now the
+primary contract and the one operators see reflected in inspection.
 
 ## Sessions and host services
 

--- a/docs/content/providers/runtime.mdx
+++ b/docs/content/providers/runtime.mdx
@@ -32,7 +32,7 @@ only uses a runtime provider when it opts in with `plugins.<name>.runtime`.
 When a plugin does opt in, Gestalt follows this lifecycle:
 
 1. Select a runtime backend from `runtime.providers`
-2. Query its capabilities
+2. Query its runtime support
 3. Start a runtime session
 4. Wait for the session to become ready
 5. Bind host-local services into that session
@@ -97,28 +97,16 @@ firewall style controls, or Gestalt's hostname-based `allowedHosts` model.
 Fourth, how does the plugin launch: directly from host paths or from a staged
 bundle, and on what execution target.
 
-The admin inspection API exposes both the runtime's raw capability flags and
-this derived profile. `GET /admin/api/v1/runtime/providers` returns an
-`advertised` profile, which is what the runtime says it can do, and an
-`effective` profile, which is what the current `gestaltd` deployment can
-actually guarantee once public relay and proxy prerequisites are considered.
+The admin inspection API exposes that grouped model directly. `GET
+/admin/api/v1/runtime/providers` returns an `advertised` profile, which is what
+the runtime says it can do, and an `effective` profile, which is what the
+current `gestaltd` deployment can actually guarantee once relay and public
+proxy prerequisites are considered.
 
-The raw capability flags still exist because runtime authors need precise
-contract boundaries. The most important ones are:
-
-| Capability | Meaning |
-| --- | --- |
-| `hosted_plugin_runtime` | The backend can host executable plugins at all. |
-| `host_service_tunnels` | The backend can inject guest-local host-service sockets directly. When this is false, Gestalt may still provide relay-backed host services through its public relay path. |
-| `provider_grpc_tunnel` | The backend can return a host-reachable gRPC dial target for the hosted plugin. |
-| `hostname_proxy_egress` | The backend can preserve Gestalt's hostname-based `allowedHosts` model. |
-| `cidr_egress` | The backend supports CIDR or firewall style controls. This is useful, but it is not equivalent to hostname-based policy. |
-| `host_path_execution` | The backend can execute directly from host paths instead of requiring bundle staging. |
-| `execution_goos` / `execution_goarch` | The execution platform the runtime reports to the host when bundle staging is required. |
-
-Gestalt uses those raw flags to derive the higher-level profile, validate a
-plugin's actual needs, and reject incompatible runtime or plugin combinations
-before startup instead of silently weakening the security model.
+Older runtime providers may still advertise the legacy boolean capability bag.
+Gestalt continues to accept that format for compatibility, but it immediately
+derives the grouped support model from it and does not treat the raw booleans
+as the primary operator interface anymore.
 
 ## Host services and hosted plugins
 
@@ -153,10 +141,10 @@ Today there are two main runtime choices:
 
 Some runtimes can execute directly from host paths. Others cannot.
 
-When a backend reports `host_path_execution`, Gestalt may launch the plugin
-directly from local paths, including synthesized source-provider execution.
-When it does not, Gestalt stages a runtime bundle first and asks the backend to
-start the plugin from that staged bundle instead.
+When a backend advertises a `host_path` launch mode, Gestalt may launch the
+plugin directly from local paths, including synthesized source-provider
+execution. When it advertises `bundle`, Gestalt stages a runtime bundle first
+and asks the backend to start the plugin from that staged bundle instead.
 
 This is why `plugins.<name>.runtime.image`, `template`, and `metadata` are
 forwarded to the runtime backend: they are runtime-specific launch hints, not

--- a/docs/content/reference/http-api.mdx
+++ b/docs/content/reference/http-api.mdx
@@ -113,7 +113,7 @@ returns `412`.
 | Method | Path | Purpose |
 | --- | --- | --- |
 | `GET` | `/metrics` | Prometheus scrape endpoint for emitted metrics. Requires Gestalt authentication only when served on the public listener. The recommended production pattern is to move it to `server.management` and protect that listener at the network or proxy layer. |
-| `GET` | `/admin/api/v1/runtime/providers` | List configured runtime providers. When capability inspection succeeds, loaded providers include raw `capabilities` and a derived `profile` with `advertised` and `effective` runtime behavior. `sessionCount` is present when session inspection also succeeds, and `error` explains any current inspection failure. |
+| `GET` | `/admin/api/v1/runtime/providers` | List configured runtime providers. When support inspection succeeds, loaded providers include a derived `profile` with `advertised` and `effective` runtime behavior. `sessionCount` is present when session inspection also succeeds, and `error` explains any current inspection failure. |
 | `GET` | `/admin/api/v1/runtime/providers/{provider}/sessions` | List active sessions for one runtime provider, including session `id`, lifecycle `state`, and the hosted `plugin` when known. |
 | `GET` | `/admin/api/v1/authorization/plugins` | List plugins that declare `authorizationPolicy`, including the bound policy name and mounted UI path when present. |
 | `GET` | `/admin/api/v1/authorization/plugins/{plugin}/members` | List merged static and dynamic human membership rows for one plugin. Rows include `source`, `effective`, `mutable`, and selector metadata. |

--- a/gestaltd/internal/bootstrap/executable_plugin_test.go
+++ b/gestaltd/internal/bootstrap/executable_plugin_test.go
@@ -206,8 +206,8 @@ func newCapturingPluginRuntime() *capturingPluginRuntime {
 	return &capturingPluginRuntime{provider: pluginruntime.NewLocalProvider()}
 }
 
-func (r *capturingPluginRuntime) Capabilities(ctx context.Context) (pluginruntime.Capabilities, error) {
-	return r.provider.Capabilities(ctx)
+func (r *capturingPluginRuntime) Support(ctx context.Context) (pluginruntime.Support, error) {
+	return r.provider.Support(ctx)
 }
 
 func (r *capturingPluginRuntime) StartSession(ctx context.Context, req pluginruntime.StartSessionRequest) (*pluginruntime.Session, error) {
@@ -277,7 +277,7 @@ func (r *capturingPluginRuntime) bindHostServiceRequests() []pluginruntime.BindH
 
 type capturingBundlePluginRuntime struct {
 	provider      *pluginruntime.LocalProvider
-	capabilities  pluginruntime.Capabilities
+	support       pluginruntime.Support
 	bindHostCalls atomic.Int32
 	fakeHosted    bool
 
@@ -296,18 +296,20 @@ type fakeHostedPluginServer struct {
 func newCapturingBundlePluginRuntime() *capturingBundlePluginRuntime {
 	return &capturingBundlePluginRuntime{
 		provider: pluginruntime.NewLocalProvider(),
-		capabilities: pluginruntime.Capabilities{
-			HostedPluginRuntime: true,
-			ProviderGRPCTunnel:  true,
-			ExecutionGOOS:       runtime.GOOS,
-			ExecutionGOARCH:     runtime.GOARCH,
+		support: pluginruntime.Support{
+			CanHostPlugins: true,
+			LaunchMode:     pluginruntime.LaunchModeBundle,
+			ExecutionTarget: pluginruntime.ExecutionTarget{
+				GOOS:   runtime.GOOS,
+				GOARCH: runtime.GOARCH,
+			},
 		},
 		fakePlugins: make(map[string]*fakeHostedPluginServer),
 	}
 }
 
-func (r *capturingBundlePluginRuntime) Capabilities(context.Context) (pluginruntime.Capabilities, error) {
-	return r.capabilities, nil
+func (r *capturingBundlePluginRuntime) Support(context.Context) (pluginruntime.Support, error) {
+	return r.support, nil
 }
 
 func (r *capturingBundlePluginRuntime) StartSession(ctx context.Context, req pluginruntime.StartSessionRequest) (*pluginruntime.Session, error) {
@@ -1205,8 +1207,8 @@ type slowStopPluginRuntime struct {
 	stopCount atomic.Int32
 }
 
-func (r *slowStopPluginRuntime) Capabilities(ctx context.Context) (pluginruntime.Capabilities, error) {
-	return r.inner.Capabilities(ctx)
+func (r *slowStopPluginRuntime) Support(ctx context.Context) (pluginruntime.Support, error) {
+	return r.inner.Support(ctx)
 }
 
 func (r *slowStopPluginRuntime) StartSession(ctx context.Context, req pluginruntime.StartSessionRequest) (*pluginruntime.Session, error) {
@@ -1249,12 +1251,12 @@ func (r *failingBindSlowStopPluginRuntime) BindHostService(context.Context, plug
 }
 
 type staticCapabilityPluginRuntime struct {
-	inner        pluginruntime.Provider
-	capabilities pluginruntime.Capabilities
+	inner   pluginruntime.Provider
+	support pluginruntime.Support
 }
 
-func (r *staticCapabilityPluginRuntime) Capabilities(context.Context) (pluginruntime.Capabilities, error) {
-	return r.capabilities, nil
+func (r *staticCapabilityPluginRuntime) Support(context.Context) (pluginruntime.Support, error) {
+	return r.support, nil
 }
 
 func (r *staticCapabilityPluginRuntime) StartSession(ctx context.Context, req pluginruntime.StartSessionRequest) (*pluginruntime.Session, error) {
@@ -3326,8 +3328,8 @@ func TestPluginAgentManagerRunUsesInheritedInvokesAndRequestContext(t *testing.T
 	})
 
 	runtimeProvider := newCapturingBundlePluginRuntime()
-	runtimeProvider.capabilities.HostnameProxyEgress = true
-	runtimeProvider.capabilities.HostPathExecution = true
+	runtimeProvider.support.EgressMode = pluginruntime.EgressModeHostname
+	runtimeProvider.support.LaunchMode = pluginruntime.LaunchModeHostPath
 	runtimeProvider.fakeHosted = true
 	factories := NewFactoryRegistry()
 	factories.Runtime = func(context.Context, string, *config.RuntimeProviderEntry, Deps) (pluginruntime.Provider, error) {
@@ -5387,12 +5389,12 @@ func TestPluginRuntimeConfigUsesPublicS3RelayWithoutHostServiceTunnelCapability(
 	})
 	manifest := newExecutableManifest("Echo", "Echoes back the input parameters")
 	runtimeProvider := newCapturingBundlePluginRuntime()
-	runtimeProvider.capabilities.HostnameProxyEgress = true
-	runtimeProvider.capabilities.HostPathExecution = true
+	runtimeProvider.support.EgressMode = pluginruntime.EgressModeHostname
+	runtimeProvider.support.LaunchMode = pluginruntime.LaunchModeHostPath
 	runtimeProvider.fakeHosted = true
-	runtimeProvider.capabilities.HostPathExecution = true
+	runtimeProvider.support.LaunchMode = pluginruntime.LaunchModeHostPath
 	runtimeProvider.fakeHosted = true
-	runtimeProvider.capabilities.HostPathExecution = true
+	runtimeProvider.support.LaunchMode = pluginruntime.LaunchModeHostPath
 	runtimeProvider.fakeHosted = true
 	factories := NewFactoryRegistry()
 	factories.Runtime = func(context.Context, string, *config.RuntimeProviderEntry, Deps) (pluginruntime.Provider, error) {
@@ -5557,8 +5559,8 @@ func TestPluginRuntimeConfigUsesPublicAuthorizationRelayWithoutHostServiceTunnel
 	}
 
 	runtimeProvider := newCapturingBundlePluginRuntime()
-	runtimeProvider.capabilities.HostnameProxyEgress = true
-	runtimeProvider.capabilities.HostPathExecution = true
+	runtimeProvider.support.EgressMode = pluginruntime.EgressModeHostname
+	runtimeProvider.support.LaunchMode = pluginruntime.LaunchModeHostPath
 	runtimeProvider.fakeHosted = true
 	factories := NewFactoryRegistry()
 	factories.Runtime = func(context.Context, string, *config.RuntimeProviderEntry, Deps) (pluginruntime.Provider, error) {
@@ -5662,8 +5664,8 @@ func TestPluginRuntimeConfigUsesPublicIndexedDBRelayWithoutHostServiceTunnelCapa
 	})
 	manifest := newExecutableManifest("Echo", "Echoes back the input parameters")
 	runtimeProvider := newCapturingBundlePluginRuntime()
-	runtimeProvider.capabilities.HostnameProxyEgress = true
-	runtimeProvider.capabilities.HostPathExecution = true
+	runtimeProvider.support.EgressMode = pluginruntime.EgressModeHostname
+	runtimeProvider.support.LaunchMode = pluginruntime.LaunchModeHostPath
 	runtimeProvider.fakeHosted = true
 	factories := NewFactoryRegistry()
 	factories.Runtime = func(context.Context, string, *config.RuntimeProviderEntry, Deps) (pluginruntime.Provider, error) {
@@ -5791,8 +5793,8 @@ func TestPluginRuntimePublicIndexedDBRelayRoundTripsThroughHostedPlugin(t *testi
 	})
 	manifest := newExecutableManifest("Echo", "Echoes back the input parameters")
 	runtimeProvider := newCapturingBundlePluginRuntime()
-	runtimeProvider.capabilities.HostnameProxyEgress = true
-	runtimeProvider.capabilities.HostPathExecution = true
+	runtimeProvider.support.EgressMode = pluginruntime.EgressModeHostname
+	runtimeProvider.support.LaunchMode = pluginruntime.LaunchModeHostPath
 	runtimeProvider.fakeHosted = true
 
 	factories := NewFactoryRegistry()
@@ -5902,8 +5904,8 @@ func TestPluginRuntimeConfigUsesPublicCacheRelayWithoutHostServiceTunnelCapabili
 	})
 	manifest := newExecutableManifest("Echo", "Echoes back the input parameters")
 	runtimeProvider := newCapturingBundlePluginRuntime()
-	runtimeProvider.capabilities.HostnameProxyEgress = true
-	runtimeProvider.capabilities.HostPathExecution = true
+	runtimeProvider.support.EgressMode = pluginruntime.EgressModeHostname
+	runtimeProvider.support.LaunchMode = pluginruntime.LaunchModeHostPath
 	runtimeProvider.fakeHosted = true
 	factories := NewFactoryRegistry()
 	factories.Runtime = func(context.Context, string, *config.RuntimeProviderEntry, Deps) (pluginruntime.Provider, error) {
@@ -6035,8 +6037,8 @@ func TestPluginRuntimePublicCacheRelayRoundTripsThroughHostedPlugin(t *testing.T
 	})
 	manifest := newExecutableManifest("Echo", "Echoes back the input parameters")
 	runtimeProvider := newCapturingBundlePluginRuntime()
-	runtimeProvider.capabilities.HostnameProxyEgress = true
-	runtimeProvider.capabilities.HostPathExecution = true
+	runtimeProvider.support.EgressMode = pluginruntime.EgressModeHostname
+	runtimeProvider.support.LaunchMode = pluginruntime.LaunchModeHostPath
 	runtimeProvider.fakeHosted = true
 
 	factories := NewFactoryRegistry()
@@ -6163,8 +6165,8 @@ func TestPluginRuntimePublicS3RelayRoundTripsThroughHostedPlugin(t *testing.T) {
 	})
 	manifest := newExecutableManifest("Echo", "Echoes back the input parameters")
 	runtimeProvider := newCapturingBundlePluginRuntime()
-	runtimeProvider.capabilities.HostnameProxyEgress = true
-	runtimeProvider.capabilities.HostPathExecution = true
+	runtimeProvider.support.EgressMode = pluginruntime.EgressModeHostname
+	runtimeProvider.support.LaunchMode = pluginruntime.LaunchModeHostPath
 	runtimeProvider.fakeHosted = true
 
 	factories := NewFactoryRegistry()
@@ -6314,8 +6316,8 @@ func TestPluginRuntimePublicPluginInvokerRelayRoundTripsThroughHostedPlugin(t *t
 	}
 
 	runtimeProvider := newCapturingBundlePluginRuntime()
-	runtimeProvider.capabilities.HostnameProxyEgress = true
-	runtimeProvider.capabilities.HostPathExecution = true
+	runtimeProvider.support.EgressMode = pluginruntime.EgressModeHostname
+	runtimeProvider.support.LaunchMode = pluginruntime.LaunchModeHostPath
 	runtimeProvider.fakeHosted = true
 
 	factories := NewFactoryRegistry()
@@ -6476,8 +6478,8 @@ func TestPluginRuntimeConfigUsesPublicWorkflowManagerRelayWithoutHostServiceTunn
 	})
 	manifest := newExecutableManifest("Echo", "Echoes back the input parameters")
 	runtimeProvider := newCapturingBundlePluginRuntime()
-	runtimeProvider.capabilities.HostnameProxyEgress = true
-	runtimeProvider.capabilities.HostPathExecution = true
+	runtimeProvider.support.EgressMode = pluginruntime.EgressModeHostname
+	runtimeProvider.support.LaunchMode = pluginruntime.LaunchModeHostPath
 	runtimeProvider.fakeHosted = true
 	factories := NewFactoryRegistry()
 	factories.Runtime = func(context.Context, string, *config.RuntimeProviderEntry, Deps) (pluginruntime.Provider, error) {
@@ -6582,10 +6584,9 @@ func TestPluginRuntimeConfigRejectsMissingHostnameEgressCapability(t *testing.T)
 	manifest := newExecutableManifest("Echo", "Echoes back the input parameters")
 	runtimeProvider := &staticCapabilityPluginRuntime{
 		inner: pluginruntime.NewLocalProvider(),
-		capabilities: pluginruntime.Capabilities{
-			HostedPluginRuntime: true,
-			ProviderGRPCTunnel:  true,
-			HostServiceTunnels:  true,
+		support: pluginruntime.Support{
+			CanHostPlugins:    true,
+			HostServiceAccess: pluginruntime.HostServiceAccessDirect,
 		},
 	}
 	factories := NewFactoryRegistry()
@@ -6636,10 +6637,9 @@ func TestPluginRuntimeConfigRejectsMissingHostServiceAccess(t *testing.T) {
 	manifest := newExecutableManifest("Echo", "Echoes back the input parameters")
 	runtimeProvider := &staticCapabilityPluginRuntime{
 		inner: pluginruntime.NewLocalProvider(),
-		capabilities: pluginruntime.Capabilities{
-			HostedPluginRuntime: true,
-			ProviderGRPCTunnel:  true,
-			HostPathExecution:   true,
+		support: pluginruntime.Support{
+			CanHostPlugins: true,
+			LaunchMode:     pluginruntime.LaunchModeHostPath,
 		},
 	}
 	factories := NewFactoryRegistry()
@@ -6937,8 +6937,8 @@ func TestPluginRuntimePublicWorkflowManagerRelayRoundTripsThroughHostedPlugin(t 
 	})
 	manifest := newExecutableManifest("Echo", "Echoes back the input parameters")
 	runtimeProvider := newCapturingBundlePluginRuntime()
-	runtimeProvider.capabilities.HostnameProxyEgress = true
-	runtimeProvider.capabilities.HostPathExecution = true
+	runtimeProvider.support.EgressMode = pluginruntime.EgressModeHostname
+	runtimeProvider.support.LaunchMode = pluginruntime.LaunchModeHostPath
 	runtimeProvider.fakeHosted = true
 	factories := NewFactoryRegistry()
 	factories.Runtime = func(context.Context, string, *config.RuntimeProviderEntry, Deps) (pluginruntime.Provider, error) {
@@ -7086,8 +7086,8 @@ func TestPluginRuntimePublicAuthorizationRelayRoundTripsThroughHostedPlugin(t *t
 		},
 	}
 	runtimeProvider := newCapturingBundlePluginRuntime()
-	runtimeProvider.capabilities.HostnameProxyEgress = true
-	runtimeProvider.capabilities.HostPathExecution = true
+	runtimeProvider.support.EgressMode = pluginruntime.EgressModeHostname
+	runtimeProvider.support.LaunchMode = pluginruntime.LaunchModeHostPath
 	runtimeProvider.fakeHosted = true
 	factories := NewFactoryRegistry()
 	factories.Runtime = func(context.Context, string, *config.RuntimeProviderEntry, Deps) (pluginruntime.Provider, error) {
@@ -7206,8 +7206,8 @@ func TestPluginRuntimeConfigInjectsPublicEgressProxyWithoutHostServiceTunnelCapa
 	})
 	manifest := newExecutableManifest("Echo", "Echoes back the input parameters")
 	runtimeProvider := newCapturingBundlePluginRuntime()
-	runtimeProvider.capabilities.HostnameProxyEgress = true
-	runtimeProvider.capabilities.HostPathExecution = true
+	runtimeProvider.support.EgressMode = pluginruntime.EgressModeHostname
+	runtimeProvider.support.LaunchMode = pluginruntime.LaunchModeHostPath
 	runtimeProvider.fakeHosted = true
 	factories := NewFactoryRegistry()
 	factories.Runtime = func(context.Context, string, *config.RuntimeProviderEntry, Deps) (pluginruntime.Provider, error) {
@@ -7294,8 +7294,8 @@ func TestPluginRuntimeConfigSkipsPublicEgressProxyWhenHostnameEgressIsNotRequire
 	})
 	manifest := newExecutableManifest("Echo", "Echoes back the input parameters")
 	runtimeProvider := newCapturingBundlePluginRuntime()
-	runtimeProvider.capabilities.HostnameProxyEgress = true
-	runtimeProvider.capabilities.HostPathExecution = true
+	runtimeProvider.support.EgressMode = pluginruntime.EgressModeHostname
+	runtimeProvider.support.LaunchMode = pluginruntime.LaunchModeHostPath
 	runtimeProvider.fakeHosted = true
 	factories := NewFactoryRegistry()
 	factories.Runtime = func(context.Context, string, *config.RuntimeProviderEntry, Deps) (pluginruntime.Provider, error) {
@@ -7360,9 +7360,9 @@ func TestPluginRuntimeConfigUsesDirectHostServiceBindingsAndSkipsPublicEgressPro
 	})
 	manifest := newExecutableManifest("Echo", "Echoes back the input parameters")
 	runtimeProvider := newCapturingBundlePluginRuntime()
-	runtimeProvider.capabilities.HostServiceTunnels = true
-	runtimeProvider.capabilities.HostnameProxyEgress = true
-	runtimeProvider.capabilities.HostPathExecution = true
+	runtimeProvider.support.HostServiceAccess = pluginruntime.HostServiceAccessDirect
+	runtimeProvider.support.EgressMode = pluginruntime.EgressModeHostname
+	runtimeProvider.support.LaunchMode = pluginruntime.LaunchModeHostPath
 	runtimeProvider.fakeHosted = true
 	factories := NewFactoryRegistry()
 	factories.Runtime = func(context.Context, string, *config.RuntimeProviderEntry, Deps) (pluginruntime.Provider, error) {
@@ -7465,8 +7465,8 @@ func TestPluginRuntimePublicEgressProxyRoundTripsThroughHostedPlugin(t *testing.
 	})
 	manifest := newExecutableManifest("Echo", "Hosted egress proxy roundtrip")
 	runtimeProvider := newCapturingBundlePluginRuntime()
-	runtimeProvider.capabilities.HostnameProxyEgress = true
-	runtimeProvider.capabilities.HostPathExecution = true
+	runtimeProvider.support.EgressMode = pluginruntime.EgressModeHostname
+	runtimeProvider.support.LaunchMode = pluginruntime.LaunchModeHostPath
 	runtimeProvider.fakeHosted = true
 	factories := NewFactoryRegistry()
 	factories.Runtime = func(context.Context, string, *config.RuntimeProviderEntry, Deps) (pluginruntime.Provider, error) {
@@ -7554,10 +7554,9 @@ func TestPluginRuntimeConfigRejectsDefaultDenyWithoutHostnameEgressCapability(t 
 	manifest := newExecutableManifest("Echo", "Echoes back the input parameters")
 	runtimeProvider := &staticCapabilityPluginRuntime{
 		inner: pluginruntime.NewLocalProvider(),
-		capabilities: pluginruntime.Capabilities{
-			HostedPluginRuntime: true,
-			ProviderGRPCTunnel:  true,
-			HostServiceTunnels:  true,
+		support: pluginruntime.Support{
+			CanHostPlugins:    true,
+			HostServiceAccess: pluginruntime.HostServiceAccessDirect,
 		},
 	}
 	factories := NewFactoryRegistry()

--- a/gestaltd/internal/bootstrap/plugin_runtime_inspect.go
+++ b/gestaltd/internal/bootstrap/plugin_runtime_inspect.go
@@ -14,16 +14,15 @@ type RuntimeInspector interface {
 }
 
 type RuntimeProviderSnapshot struct {
-	Name               string
-	Driver             config.RuntimeProviderDriver
-	Default            bool
-	Loaded             bool
-	CapabilitiesLoaded bool
-	Capabilities       pluginruntime.Capabilities
-	AdvertisedProfile  RuntimeProfile
-	EffectiveProfile   RuntimeProfile
-	Sessions           []pluginruntime.Session
-	Error              string
+	Name          string
+	Driver        config.RuntimeProviderDriver
+	Default       bool
+	Loaded        bool
+	SupportLoaded bool
+	Advertised    RuntimeBehavior
+	Effective     RuntimeBehavior
+	Sessions      []pluginruntime.Session
+	Error         string
 }
 
 func (r *pluginRuntimeRegistry) SnapshotPluginRuntimes(ctx context.Context) ([]RuntimeProviderSnapshot, error) {
@@ -74,16 +73,15 @@ func (r *pluginRuntimeRegistry) SnapshotPluginRuntimes(ctx context.Context) ([]R
 		}
 		if item.provider != nil {
 			snapshot.Loaded = true
-			caps, err := item.provider.Capabilities(ctx)
+			support, err := item.provider.Support(ctx)
 			if err != nil {
-				snapshot.Error = fmt.Sprintf("capabilities: %v", err)
+				snapshot.Error = fmt.Sprintf("support: %v", err)
 				out = append(out, snapshot)
 				continue
 			}
-			snapshot.Capabilities = caps
-			snapshot.CapabilitiesLoaded = true
-			snapshot.AdvertisedProfile = runtimeAdvertisedProfile(caps)
-			snapshot.EffectiveProfile = runtimeEffectiveProfile(snapshot.AdvertisedProfile, caps, r.deps)
+			snapshot.SupportLoaded = true
+			snapshot.Advertised = runtimeAdvertisedBehavior(support)
+			snapshot.Effective = runtimeResolvedBehavior(snapshot.Advertised, r.deps)
 			sessions, err := item.provider.ListSessions(ctx)
 			if err != nil {
 				snapshot.Error = fmt.Sprintf("list sessions: %v", err)

--- a/gestaltd/internal/bootstrap/plugin_runtime_launch.go
+++ b/gestaltd/internal/bootstrap/plugin_runtime_launch.go
@@ -22,13 +22,13 @@ type pluginRuntimeLaunch struct {
 	cleanup   func()
 }
 
-func preparePluginRuntimeLaunch(name string, entry *config.ProviderEntry, command string, args []string, cleanup func(), profile RuntimeProfile) (pluginRuntimeLaunch, error) {
+func preparePluginRuntimeLaunch(name string, entry *config.ProviderEntry, command string, args []string, cleanup func(), behavior RuntimeBehavior) (pluginRuntimeLaunch, error) {
 	launch := pluginRuntimeLaunch{
 		command: command,
 		args:    slices.Clone(args),
 		cleanup: cleanup,
 	}
-	if profile.LaunchMode == RuntimeLaunchModeHostPath {
+	if behavior.LaunchMode == RuntimeLaunchModeHostPath {
 		return launch, nil
 	}
 	if entry == nil {
@@ -39,7 +39,7 @@ func preparePluginRuntimeLaunch(name string, entry *config.ProviderEntry, comman
 		return pluginRuntimeLaunch{}, fmt.Errorf("resolved manifest path is required for non-local plugin runtime")
 	}
 	rootDir := filepath.Dir(manifestPath)
-	if !profile.ExecutionTarget.IsSet() {
+	if !behavior.ExecutionTarget.IsSet() {
 		return pluginRuntimeLaunch{}, fmt.Errorf("non-local plugin runtime must declare execution goos/goarch")
 	}
 
@@ -51,7 +51,7 @@ func preparePluginRuntimeLaunch(name string, entry *config.ProviderEntry, comman
 		_ = os.RemoveAll(bundleDir)
 	}
 
-	localCommand, err := stagePluginRuntimeBundle(name, manifestPath, bundleDir, profile.ExecutionTarget.GOOS, profile.ExecutionTarget.GOARCH)
+	localCommand, err := stagePluginRuntimeBundle(name, manifestPath, bundleDir, behavior.ExecutionTarget.GOOS, behavior.ExecutionTarget.GOARCH)
 	if err != nil {
 		bundleCleanup()
 		return pluginRuntimeLaunch{}, err

--- a/gestaltd/internal/bootstrap/plugin_runtime_plan.go
+++ b/gestaltd/internal/bootstrap/plugin_runtime_plan.go
@@ -9,12 +9,12 @@ import (
 	"github.com/valon-technologies/gestalt/server/internal/pluginruntime"
 )
 
-type RuntimeHostServiceMode string
+type RuntimeHostServiceAccess string
 
 const (
-	RuntimeHostServiceModeNone   RuntimeHostServiceMode = "none"
-	RuntimeHostServiceModeRelay  RuntimeHostServiceMode = "relay"
-	RuntimeHostServiceModeDirect RuntimeHostServiceMode = "direct"
+	RuntimeHostServiceAccessNone   RuntimeHostServiceAccess = "none"
+	RuntimeHostServiceAccessRelay  RuntimeHostServiceAccess = "relay"
+	RuntimeHostServiceAccessDirect RuntimeHostServiceAccess = "direct"
 )
 
 type RuntimeEgressMode string
@@ -25,12 +25,12 @@ const (
 	RuntimeEgressModeHostname RuntimeEgressMode = "hostname"
 )
 
-type RuntimeHostnameEgressTransport string
+type RuntimeHostnameEgressDelivery string
 
 const (
-	RuntimeHostnameEgressTransportNone        RuntimeHostnameEgressTransport = "none"
-	RuntimeHostnameEgressTransportRuntime     RuntimeHostnameEgressTransport = "runtime"
-	RuntimeHostnameEgressTransportPublicProxy RuntimeHostnameEgressTransport = "public_proxy"
+	RuntimeHostnameEgressDeliveryNone        RuntimeHostnameEgressDelivery = "none"
+	RuntimeHostnameEgressDeliveryRuntime     RuntimeHostnameEgressDelivery = "runtime"
+	RuntimeHostnameEgressDeliveryPublicProxy RuntimeHostnameEgressDelivery = "public_proxy"
 )
 
 type RuntimeLaunchMode string
@@ -49,86 +49,71 @@ func (t RuntimeExecutionTarget) IsSet() bool {
 	return strings.TrimSpace(t.GOOS) != "" && strings.TrimSpace(t.GOARCH) != ""
 }
 
-type RuntimeProfile struct {
-	HostedExecution bool
-	HostServiceMode RuntimeHostServiceMode
-	EgressMode      RuntimeEgressMode
-	LaunchMode      RuntimeLaunchMode
-	ExecutionTarget RuntimeExecutionTarget
+type RuntimeBehavior struct {
+	CanHostPlugins    bool
+	HostServiceAccess RuntimeHostServiceAccess
+	EgressMode        RuntimeEgressMode
+	LaunchMode        RuntimeLaunchMode
+	ExecutionTarget   RuntimeExecutionTarget
 }
 
 type PluginRuntimePlan struct {
-	Effective                 RuntimeProfile
+	Resolved                  RuntimeBehavior
 	RequiresHostServiceAccess bool
 	RequiresHostnameEgress    bool
-	HostnameEgressTransport   RuntimeHostnameEgressTransport
+	HostnameEgressDelivery    RuntimeHostnameEgressDelivery
 }
 
-func buildPluginRuntimePlan(pluginName string, entry *config.ProviderEntry, deps Deps, caps pluginruntime.Capabilities) (PluginRuntimePlan, error) {
-	advertised := runtimeAdvertisedProfile(caps)
-	effective := runtimeEffectiveProfile(advertised, caps, deps)
+func buildPluginRuntimePlan(pluginName string, entry *config.ProviderEntry, deps Deps, support pluginruntime.Support) (PluginRuntimePlan, error) {
+	advertised := runtimeAdvertisedBehavior(support)
+	resolved := runtimeResolvedBehavior(advertised, deps)
 	requiresHostServiceAccess, requiresHostnameEgress, err := pluginRuntimeRequirementsForPlugin(pluginName, entry, deps)
 	if err != nil {
 		return PluginRuntimePlan{}, err
 	}
 	return PluginRuntimePlan{
-		Effective:                 effective,
+		Resolved:                  resolved,
 		RequiresHostServiceAccess: requiresHostServiceAccess,
 		RequiresHostnameEgress:    requiresHostnameEgress,
-		HostnameEgressTransport:   runtimeHostnameEgressTransport(requiresHostnameEgress, caps, effective, deps),
+		HostnameEgressDelivery:    runtimeHostnameEgressDelivery(requiresHostnameEgress, resolved),
 	}, nil
 }
 
-func runtimeAdvertisedProfile(caps pluginruntime.Capabilities) RuntimeProfile {
-	hostServiceMode := RuntimeHostServiceModeNone
-	if caps.HostServiceTunnels {
-		hostServiceMode = RuntimeHostServiceModeDirect
-	}
-	egressMode := RuntimeEgressModeNone
-	switch {
-	case caps.HostnameProxyEgress:
-		egressMode = RuntimeEgressModeHostname
-	case caps.CIDREgress:
-		egressMode = RuntimeEgressModeCIDR
-	}
-	launchMode := RuntimeLaunchModeBundle
-	if caps.HostPathExecution {
-		launchMode = RuntimeLaunchModeHostPath
-	}
-	return RuntimeProfile{
-		HostedExecution: caps.HostedPluginRuntime && caps.ProviderGRPCTunnel,
-		HostServiceMode: hostServiceMode,
-		EgressMode:      egressMode,
-		LaunchMode:      launchMode,
+func runtimeAdvertisedBehavior(support pluginruntime.Support) RuntimeBehavior {
+	return RuntimeBehavior{
+		CanHostPlugins:    support.CanHostPlugins,
+		HostServiceAccess: runtimeHostServiceAccessFromSupport(support.HostServiceAccess),
+		EgressMode:        runtimeEgressModeFromSupport(support.EgressMode),
+		LaunchMode:        runtimeLaunchModeFromSupport(support.LaunchMode),
 		ExecutionTarget: RuntimeExecutionTarget{
-			GOOS:   strings.TrimSpace(caps.ExecutionGOOS),
-			GOARCH: strings.TrimSpace(caps.ExecutionGOARCH),
+			GOOS:   strings.TrimSpace(support.ExecutionTarget.GOOS),
+			GOARCH: strings.TrimSpace(support.ExecutionTarget.GOARCH),
 		},
 	}
 }
 
-func runtimeEffectiveProfile(advertised RuntimeProfile, caps pluginruntime.Capabilities, deps Deps) RuntimeProfile {
-	effective := advertised
-	if effective.HostServiceMode == RuntimeHostServiceModeNone && hostCanRelayPluginRuntimeHostServices(deps) {
-		effective.HostServiceMode = RuntimeHostServiceModeRelay
+func runtimeResolvedBehavior(advertised RuntimeBehavior, deps Deps) RuntimeBehavior {
+	resolved := advertised
+	if resolved.HostServiceAccess == RuntimeHostServiceAccessNone && hostCanRelayPluginRuntimeHostServices(deps) {
+		resolved.HostServiceAccess = RuntimeHostServiceAccessRelay
 	}
-	if effective.EgressMode == RuntimeEgressModeHostname && !caps.HostServiceTunnels && !hostCanProvideHostedHostnameEgress(deps) {
-		effective.EgressMode = RuntimeEgressModeNone
+	if resolved.EgressMode == RuntimeEgressModeHostname && resolved.HostServiceAccess != RuntimeHostServiceAccessDirect && !hostCanProvideHostedHostnameEgress(deps) {
+		resolved.EgressMode = RuntimeEgressModeNone
 	}
-	return effective
+	return resolved
 }
 
-func runtimeHostnameEgressTransport(required bool, caps pluginruntime.Capabilities, effective RuntimeProfile, deps Deps) RuntimeHostnameEgressTransport {
-	if !required || effective.EgressMode != RuntimeEgressModeHostname {
-		return RuntimeHostnameEgressTransportNone
+func runtimeHostnameEgressDelivery(required bool, resolved RuntimeBehavior) RuntimeHostnameEgressDelivery {
+	if !required || resolved.EgressMode != RuntimeEgressModeHostname {
+		return RuntimeHostnameEgressDeliveryNone
 	}
-	if caps.HostServiceTunnels {
-		return RuntimeHostnameEgressTransportRuntime
+	if resolved.HostServiceAccess == RuntimeHostServiceAccessDirect {
+		return RuntimeHostnameEgressDeliveryRuntime
 	}
-	if hostCanProvideHostedHostnameEgress(deps) {
-		return RuntimeHostnameEgressTransportPublicProxy
+	if resolved.HostServiceAccess == RuntimeHostServiceAccessRelay {
+		return RuntimeHostnameEgressDeliveryPublicProxy
 	}
-	return RuntimeHostnameEgressTransportNone
+	return RuntimeHostnameEgressDeliveryNone
 }
 
 func hostCanRelayPluginRuntimeHostServices(deps Deps) bool {
@@ -177,17 +162,46 @@ func (p PluginRuntimePlan) Validate(label string) error {
 	if label == "" {
 		label = "plugin runtime"
 	}
-	if !p.Effective.HostedExecution {
+	if !p.Resolved.CanHostPlugins {
 		return fmt.Errorf("%s cannot host executable plugins in a host-reachable session", label)
 	}
-	if p.RequiresHostServiceAccess && p.Effective.HostServiceMode == RuntimeHostServiceModeNone {
+	if p.RequiresHostServiceAccess && p.Resolved.HostServiceAccess == RuntimeHostServiceAccessNone {
 		return fmt.Errorf("%s cannot provide host service access required by this plugin", label)
 	}
-	if p.RequiresHostnameEgress && p.Effective.EgressMode != RuntimeEgressModeHostname {
+	if p.RequiresHostnameEgress && p.Resolved.EgressMode != RuntimeEgressModeHostname {
 		return fmt.Errorf("%s cannot preserve hostname-based egress required by this plugin", label)
 	}
-	if p.Effective.LaunchMode == RuntimeLaunchModeBundle && !p.Effective.ExecutionTarget.IsSet() {
+	if p.Resolved.LaunchMode == RuntimeLaunchModeBundle && !p.Resolved.ExecutionTarget.IsSet() {
 		return fmt.Errorf("%s cannot stage hosted plugin bundles because it does not declare an execution target", label)
 	}
 	return nil
+}
+
+func runtimeHostServiceAccessFromSupport(src pluginruntime.HostServiceAccess) RuntimeHostServiceAccess {
+	switch src {
+	case pluginruntime.HostServiceAccessDirect:
+		return RuntimeHostServiceAccessDirect
+	default:
+		return RuntimeHostServiceAccessNone
+	}
+}
+
+func runtimeEgressModeFromSupport(src pluginruntime.EgressMode) RuntimeEgressMode {
+	switch src {
+	case pluginruntime.EgressModeHostname:
+		return RuntimeEgressModeHostname
+	case pluginruntime.EgressModeCIDR:
+		return RuntimeEgressModeCIDR
+	default:
+		return RuntimeEgressModeNone
+	}
+}
+
+func runtimeLaunchModeFromSupport(src pluginruntime.LaunchMode) RuntimeLaunchMode {
+	switch src {
+	case pluginruntime.LaunchModeHostPath:
+		return RuntimeLaunchModeHostPath
+	default:
+		return RuntimeLaunchModeBundle
+	}
 }

--- a/gestaltd/internal/bootstrap/provider_build.go
+++ b/gestaltd/internal/bootstrap/provider_build.go
@@ -755,14 +755,14 @@ func buildPluginProvider(ctx context.Context, name string, entry *config.Provide
 	if err != nil {
 		return nil, err
 	}
-	runtimeCapabilities, err := runtimeProvider.Capabilities(ctx)
+	runtimeSupport, err := runtimeProvider.Support(ctx)
 	if err != nil {
 		if runtimeOwned {
 			_ = runtimeProvider.Close()
 		}
-		return nil, fmt.Errorf("query %s capabilities: %w", pluginRuntimeLabel(runtimeConfig), err)
+		return nil, fmt.Errorf("query %s support: %w", pluginRuntimeLabel(runtimeConfig), err)
 	}
-	runtimePlan, err := buildPluginRuntimePlan(name, entry, deps, runtimeCapabilities)
+	runtimePlan, err := buildPluginRuntimePlan(name, entry, deps, runtimeSupport)
 	if err != nil {
 		if runtimeOwned {
 			_ = runtimeProvider.Close()
@@ -775,7 +775,7 @@ func buildPluginProvider(ctx context.Context, name string, entry *config.Provide
 		}
 		return nil, err
 	}
-	if command == "" && runtimePlan.Effective.LaunchMode == RuntimeLaunchModeHostPath {
+	if command == "" && runtimePlan.Resolved.LaunchMode == RuntimeLaunchModeHostPath {
 		if entry.ResolvedManifestPath == "" {
 			if runtimeOwned {
 				_ = runtimeProvider.Close()
@@ -810,10 +810,10 @@ func buildPluginProvider(ctx context.Context, name string, entry *config.Provide
 			maps.Copy(env, execEnv)
 		}
 	}
-	if command == "" && runtimePlan.Effective.LaunchMode != RuntimeLaunchModeHostPath {
+	if command == "" && runtimePlan.Resolved.LaunchMode != RuntimeLaunchModeHostPath {
 		args = nil
 	}
-	launch, err := preparePluginRuntimeLaunch(name, entry, command, args, cleanup, runtimePlan.Effective)
+	launch, err := preparePluginRuntimeLaunch(name, entry, command, args, cleanup, runtimePlan.Resolved)
 	if err != nil {
 		if runtimeOwned {
 			_ = runtimeProvider.Close()
@@ -845,7 +845,7 @@ func buildPluginProvider(ctx context.Context, name string, entry *config.Provide
 		return nil, fmt.Errorf("wait for plugin runtime session %q ready: %w", sessionID, err)
 	}
 
-	hostServices, invTokens, runtimeCleanup, err := buildPluginRuntimeHostServices(name, entry, deps, runtimePlan.Effective.HostServiceMode == RuntimeHostServiceModeDirect)
+	hostServices, invTokens, runtimeCleanup, err := buildPluginRuntimeHostServices(name, entry, deps, runtimePlan.Resolved.HostServiceAccess == RuntimeHostServiceAccessDirect)
 	if err != nil {
 		return nil, err
 	}
@@ -862,7 +862,7 @@ func buildPluginProvider(ctx context.Context, name string, entry *config.Provide
 	startEnv := maps.Clone(env)
 	allowedHosts := slices.Clone(entry.AllowedHosts)
 	for _, hostService := range startedHostServices.Bindings() {
-		bindingReq, bindingEnv, relayHost, err := buildPluginRuntimeHostServiceBinding(name, sessionID, hostService, deps, runtimePlan.Effective.HostServiceMode == RuntimeHostServiceModeDirect)
+		bindingReq, bindingEnv, relayHost, err := buildPluginRuntimeHostServiceBinding(name, sessionID, hostService, deps, runtimePlan.Resolved.HostServiceAccess == RuntimeHostServiceAccessDirect)
 		if err != nil {
 			return nil, err
 		}
@@ -877,7 +877,7 @@ func buildPluginProvider(ctx context.Context, name string, entry *config.Provide
 		}
 		allowedHosts = appendAllowedHost(allowedHosts, relayHost)
 	}
-	if runtimePlan.HostnameEgressTransport == RuntimeHostnameEgressTransportPublicProxy {
+	if runtimePlan.HostnameEgressDelivery == RuntimeHostnameEgressDeliveryPublicProxy {
 		proxyEnv, err := buildPluginRuntimePublicEgressProxy(name, sessionID, entry.AllowedHosts, deps.Egress.DefaultAction, deps)
 		if err != nil {
 			return nil, err

--- a/gestaltd/internal/pluginruntime/executable.go
+++ b/gestaltd/internal/pluginruntime/executable.go
@@ -59,12 +59,12 @@ func NewExecutableProvider(ctx context.Context, cfg ExecutableConfig) (Provider,
 	}, nil
 }
 
-func (p *executableProvider) Capabilities(ctx context.Context) (Capabilities, error) {
+func (p *executableProvider) Support(ctx context.Context) (Support, error) {
 	resp, err := p.runtime.GetCapabilities(ctx, &emptypb.Empty{})
 	if err != nil {
-		return Capabilities{}, fmt.Errorf("get runtime capabilities: %w", err)
+		return Support{}, fmt.Errorf("get runtime support: %w", err)
 	}
-	return capabilitiesFromProto(resp.GetCapabilities()), nil
+	return supportFromProtoResponse(resp), nil
 }
 
 func (p *executableProvider) StartSession(ctx context.Context, req StartSessionRequest) (*Session, error) {
@@ -216,19 +216,97 @@ func (p *executableProvider) Close() error {
 	return p.proc.Close()
 }
 
-func capabilitiesFromProto(src *proto.PluginRuntimeCapabilities) Capabilities {
+func supportFromProtoResponse(src *proto.GetPluginRuntimeCapabilitiesResponse) Support {
 	if src == nil {
-		return Capabilities{}
+		return Support{}
 	}
-	return Capabilities{
-		HostedPluginRuntime: src.GetHostedPluginRuntime(),
-		HostServiceTunnels:  src.GetHostServiceTunnels(),
-		ProviderGRPCTunnel:  src.GetProviderGrpcTunnel(),
-		HostnameProxyEgress: src.GetHostnameProxyEgress(),
-		CIDREgress:          src.GetCidrEgress(),
-		HostPathExecution:   src.GetHostPathExecution(),
-		ExecutionGOOS:       src.GetExecutionGoos(),
-		ExecutionGOARCH:     src.GetExecutionGoarch(),
+	if support := supportFromProto(src.GetSupport()); support != (Support{}) {
+		return support
+	}
+	//nolint:staticcheck // older runtime providers still populate the legacy field during the compatibility window
+	return supportFromLegacyCapabilities(src.Capabilities)
+}
+
+func supportFromProto(src *proto.PluginRuntimeSupport) Support {
+	if src == nil {
+		return Support{}
+	}
+	return Support{
+		CanHostPlugins:    src.GetCanHostPlugins(),
+		HostServiceAccess: hostServiceAccessFromProto(src.GetHostServiceAccess()),
+		EgressMode:        egressModeFromProto(src.GetEgressMode()),
+		LaunchMode:        launchModeFromProto(src.GetLaunchMode()),
+		ExecutionTarget:   executionTargetFromProto(src.GetExecutionTarget()),
+	}
+}
+
+func supportFromLegacyCapabilities(src *proto.PluginRuntimeCapabilities) Support {
+	if src == nil {
+		return Support{}
+	}
+	hostServiceAccess := HostServiceAccessNone
+	if src.GetHostServiceTunnels() {
+		hostServiceAccess = HostServiceAccessDirect
+	}
+	egressMode := EgressModeNone
+	switch {
+	case src.GetHostnameProxyEgress():
+		egressMode = EgressModeHostname
+	case src.GetCidrEgress():
+		egressMode = EgressModeCIDR
+	}
+	launchMode := LaunchModeBundle
+	if src.GetHostPathExecution() {
+		launchMode = LaunchModeHostPath
+	}
+	return Support{
+		CanHostPlugins:    src.GetHostedPluginRuntime() && src.GetProviderGrpcTunnel(),
+		HostServiceAccess: hostServiceAccess,
+		EgressMode:        egressMode,
+		LaunchMode:        launchMode,
+		ExecutionTarget: ExecutionTarget{
+			GOOS:   strings.TrimSpace(src.GetExecutionGoos()),
+			GOARCH: strings.TrimSpace(src.GetExecutionGoarch()),
+		},
+	}
+}
+
+func hostServiceAccessFromProto(src proto.PluginRuntimeHostServiceAccess) HostServiceAccess {
+	switch src {
+	case proto.PluginRuntimeHostServiceAccess_PLUGIN_RUNTIME_HOST_SERVICE_ACCESS_DIRECT:
+		return HostServiceAccessDirect
+	default:
+		return HostServiceAccessNone
+	}
+}
+
+func egressModeFromProto(src proto.PluginRuntimeEgressMode) EgressMode {
+	switch src {
+	case proto.PluginRuntimeEgressMode_PLUGIN_RUNTIME_EGRESS_MODE_HOSTNAME:
+		return EgressModeHostname
+	case proto.PluginRuntimeEgressMode_PLUGIN_RUNTIME_EGRESS_MODE_CIDR:
+		return EgressModeCIDR
+	default:
+		return EgressModeNone
+	}
+}
+
+func launchModeFromProto(src proto.PluginRuntimeLaunchMode) LaunchMode {
+	switch src {
+	case proto.PluginRuntimeLaunchMode_PLUGIN_RUNTIME_LAUNCH_MODE_HOST_PATH:
+		return LaunchModeHostPath
+	default:
+		return LaunchModeBundle
+	}
+}
+
+func executionTargetFromProto(src *proto.PluginRuntimeExecutionTarget) ExecutionTarget {
+	if src == nil {
+		return ExecutionTarget{}
+	}
+	return ExecutionTarget{
+		GOOS:   strings.TrimSpace(src.GetGoos()),
+		GOARCH: strings.TrimSpace(src.GetGoarch()),
 	}
 }
 

--- a/gestaltd/internal/pluginruntime/local.go
+++ b/gestaltd/internal/pluginruntime/local.go
@@ -52,15 +52,16 @@ func NewLocalProvider() *LocalProvider {
 	}
 }
 
-func (p *LocalProvider) Capabilities(context.Context) (Capabilities, error) {
-	return Capabilities{
-		HostedPluginRuntime: true,
-		HostServiceTunnels:  true,
-		ProviderGRPCTunnel:  true,
-		HostnameProxyEgress: true,
-		HostPathExecution:   true,
-		ExecutionGOOS:       runtime.GOOS,
-		ExecutionGOARCH:     runtime.GOARCH,
+func (p *LocalProvider) Support(context.Context) (Support, error) {
+	return Support{
+		CanHostPlugins:    true,
+		HostServiceAccess: HostServiceAccessDirect,
+		EgressMode:        EgressModeHostname,
+		LaunchMode:        LaunchModeHostPath,
+		ExecutionTarget: ExecutionTarget{
+			GOOS:   runtime.GOOS,
+			GOARCH: runtime.GOARCH,
+		},
 	}, nil
 }
 

--- a/gestaltd/internal/pluginruntime/runtime.go
+++ b/gestaltd/internal/pluginruntime/runtime.go
@@ -28,15 +28,39 @@ const (
 	PolicyDeny  PolicyAction = "deny"
 )
 
-type Capabilities struct {
-	HostedPluginRuntime bool
-	HostServiceTunnels  bool
-	ProviderGRPCTunnel  bool
-	HostnameProxyEgress bool
-	CIDREgress          bool
-	HostPathExecution   bool
-	ExecutionGOOS       string
-	ExecutionGOARCH     string
+type HostServiceAccess string
+
+const (
+	HostServiceAccessNone   HostServiceAccess = "none"
+	HostServiceAccessDirect HostServiceAccess = "direct"
+)
+
+type EgressMode string
+
+const (
+	EgressModeNone     EgressMode = "none"
+	EgressModeCIDR     EgressMode = "cidr"
+	EgressModeHostname EgressMode = "hostname"
+)
+
+type LaunchMode string
+
+const (
+	LaunchModeHostPath LaunchMode = "host_path"
+	LaunchModeBundle   LaunchMode = "bundle"
+)
+
+type ExecutionTarget struct {
+	GOOS   string
+	GOARCH string
+}
+
+type Support struct {
+	CanHostPlugins    bool
+	HostServiceAccess HostServiceAccess
+	EgressMode        EgressMode
+	LaunchMode        LaunchMode
+	ExecutionTarget   ExecutionTarget
 }
 
 type Session struct {
@@ -111,7 +135,7 @@ type HostedPluginConn interface {
 }
 
 type Provider interface {
-	Capabilities(ctx context.Context) (Capabilities, error)
+	Support(ctx context.Context) (Support, error)
 	ListSessions(ctx context.Context) ([]Session, error)
 	StartSession(ctx context.Context, req StartSessionRequest) (*Session, error)
 	GetSession(ctx context.Context, req GetSessionRequest) (*Session, error)

--- a/gestaltd/internal/server/handlers_admin_runtime.go
+++ b/gestaltd/internal/server/handlers_admin_runtime.go
@@ -9,22 +9,13 @@ import (
 )
 
 type adminRuntimeProviderInfo struct {
-	Name         string                    `json:"name"`
-	Driver       string                    `json:"driver"`
-	Default      bool                      `json:"default"`
-	Loaded       bool                      `json:"loaded"`
-	SessionCount *int                      `json:"sessionCount,omitempty"`
-	Capabilities *adminRuntimeCapabilities `json:"capabilities,omitempty"`
-	Profile      *adminRuntimeProfilePair  `json:"profile,omitempty"`
-	Error        string                    `json:"error,omitempty"`
-}
-
-type adminRuntimeCapabilities struct {
-	HostedPluginRuntime bool `json:"hostedPluginRuntime"`
-	HostServiceTunnels  bool `json:"hostServiceTunnels"`
-	ProviderGRPCTunnel  bool `json:"providerGRPCTunnel"`
-	HostnameProxyEgress bool `json:"hostnameProxyEgress"`
-	CIDREgress          bool `json:"cidrEgress"`
+	Name         string                   `json:"name"`
+	Driver       string                   `json:"driver"`
+	Default      bool                     `json:"default"`
+	Loaded       bool                     `json:"loaded"`
+	SessionCount *int                     `json:"sessionCount,omitempty"`
+	Profile      *adminRuntimeProfilePair `json:"profile,omitempty"`
+	Error        string                   `json:"error,omitempty"`
 }
 
 type adminRuntimeProfilePair struct {
@@ -33,7 +24,7 @@ type adminRuntimeProfilePair struct {
 }
 
 type adminRuntimeProfile struct {
-	HostedExecution   bool                         `json:"hostedExecution"`
+	CanHostPlugins    bool                         `json:"canHostPlugins"`
 	HostServiceAccess string                       `json:"hostServiceAccess"`
 	EgressMode        string                       `json:"egressMode"`
 	LaunchMode        string                       `json:"launchMode"`
@@ -73,8 +64,7 @@ func (s *Server) listAdminRuntimeProviders(w http.ResponseWriter, r *http.Reques
 			Loaded:  snapshot.Loaded,
 			Error:   strings.TrimSpace(snapshot.Error),
 		}
-		if snapshot.Loaded && snapshot.CapabilitiesLoaded {
-			row.Capabilities = adminRuntimeCapabilitiesFromSnapshot(snapshot)
+		if snapshot.Loaded && snapshot.SupportLoaded {
 			row.Profile = adminRuntimeProfilePairFromSnapshot(snapshot)
 		}
 		if snapshot.Loaded && row.Error == "" {
@@ -129,34 +119,24 @@ func (s *Server) adminRuntimeSnapshots(r *http.Request) ([]bootstrap.RuntimeProv
 	return s.pluginRuntimes.SnapshotPluginRuntimes(r.Context())
 }
 
-func adminRuntimeCapabilitiesFromSnapshot(snapshot *bootstrap.RuntimeProviderSnapshot) *adminRuntimeCapabilities {
-	return &adminRuntimeCapabilities{
-		HostedPluginRuntime: snapshot.Capabilities.HostedPluginRuntime,
-		HostServiceTunnels:  snapshot.Capabilities.HostServiceTunnels,
-		ProviderGRPCTunnel:  snapshot.Capabilities.ProviderGRPCTunnel,
-		HostnameProxyEgress: snapshot.Capabilities.HostnameProxyEgress,
-		CIDREgress:          snapshot.Capabilities.CIDREgress,
-	}
-}
-
 func adminRuntimeProfilePairFromSnapshot(snapshot *bootstrap.RuntimeProviderSnapshot) *adminRuntimeProfilePair {
 	return &adminRuntimeProfilePair{
-		Advertised: adminRuntimeProfileFromBootstrap(snapshot.AdvertisedProfile),
-		Effective:  adminRuntimeProfileFromBootstrap(snapshot.EffectiveProfile),
+		Advertised: adminRuntimeProfileFromBootstrap(snapshot.Advertised),
+		Effective:  adminRuntimeProfileFromBootstrap(snapshot.Effective),
 	}
 }
 
-func adminRuntimeProfileFromBootstrap(profile bootstrap.RuntimeProfile) adminRuntimeProfile {
+func adminRuntimeProfileFromBootstrap(behavior bootstrap.RuntimeBehavior) adminRuntimeProfile {
 	out := adminRuntimeProfile{
-		HostedExecution:   profile.HostedExecution,
-		HostServiceAccess: strings.TrimSpace(string(profile.HostServiceMode)),
-		EgressMode:        strings.TrimSpace(string(profile.EgressMode)),
-		LaunchMode:        strings.TrimSpace(string(profile.LaunchMode)),
+		CanHostPlugins:    behavior.CanHostPlugins,
+		HostServiceAccess: strings.TrimSpace(string(behavior.HostServiceAccess)),
+		EgressMode:        strings.TrimSpace(string(behavior.EgressMode)),
+		LaunchMode:        strings.TrimSpace(string(behavior.LaunchMode)),
 	}
-	if profile.ExecutionTarget.IsSet() {
+	if behavior.ExecutionTarget.IsSet() {
 		out.ExecutionTarget = &adminRuntimeExecutionTarget{
-			GOOS:   strings.TrimSpace(profile.ExecutionTarget.GOOS),
-			GOARCH: strings.TrimSpace(profile.ExecutionTarget.GOARCH),
+			GOOS:   strings.TrimSpace(behavior.ExecutionTarget.GOOS),
+			GOARCH: strings.TrimSpace(behavior.ExecutionTarget.GOARCH),
 		}
 	}
 	return out

--- a/gestaltd/internal/server/server_test.go
+++ b/gestaltd/internal/server/server_test.go
@@ -2887,32 +2887,25 @@ func TestAdminAPI_RuntimeProviders(t *testing.T) {
 					Default: true,
 				},
 				{
-					Name:               "modal",
-					Driver:             config.RuntimeProviderDriver("modal"),
-					Loaded:             true,
-					CapabilitiesLoaded: true,
-					Capabilities: pluginruntime.Capabilities{
-						HostedPluginRuntime: true,
-						ProviderGRPCTunnel:  true,
-						CIDREgress:          true,
-						ExecutionGOOS:       "linux",
-						ExecutionGOARCH:     "amd64",
-					},
-					AdvertisedProfile: bootstrap.RuntimeProfile{
-						HostedExecution: true,
-						HostServiceMode: bootstrap.RuntimeHostServiceModeNone,
-						EgressMode:      bootstrap.RuntimeEgressModeCIDR,
-						LaunchMode:      bootstrap.RuntimeLaunchModeBundle,
+					Name:          "modal",
+					Driver:        config.RuntimeProviderDriver("modal"),
+					Loaded:        true,
+					SupportLoaded: true,
+					Advertised: bootstrap.RuntimeBehavior{
+						CanHostPlugins:    true,
+						HostServiceAccess: bootstrap.RuntimeHostServiceAccessNone,
+						EgressMode:        bootstrap.RuntimeEgressModeCIDR,
+						LaunchMode:        bootstrap.RuntimeLaunchModeBundle,
 						ExecutionTarget: bootstrap.RuntimeExecutionTarget{
 							GOOS:   "linux",
 							GOARCH: "amd64",
 						},
 					},
-					EffectiveProfile: bootstrap.RuntimeProfile{
-						HostedExecution: true,
-						HostServiceMode: bootstrap.RuntimeHostServiceModeRelay,
-						EgressMode:      bootstrap.RuntimeEgressModeCIDR,
-						LaunchMode:      bootstrap.RuntimeLaunchModeBundle,
+					Effective: bootstrap.RuntimeBehavior{
+						CanHostPlugins:    true,
+						HostServiceAccess: bootstrap.RuntimeHostServiceAccessRelay,
+						EgressMode:        bootstrap.RuntimeEgressModeCIDR,
+						LaunchMode:        bootstrap.RuntimeLaunchModeBundle,
 						ExecutionTarget: bootstrap.RuntimeExecutionTarget{
 							GOOS:   "linux",
 							GOARCH: "amd64",
@@ -2970,13 +2963,6 @@ func TestAdminAPI_RuntimeProviders(t *testing.T) {
 	if got := providers[1]["sessionCount"]; got != float64(1) {
 		t.Fatalf("runtime providers[1].sessionCount = %v, want 1", got)
 	}
-	caps, ok := providers[1]["capabilities"].(map[string]any)
-	if !ok {
-		t.Fatalf("runtime providers[1].capabilities = %#v, want object", providers[1]["capabilities"])
-	}
-	if caps["hostedPluginRuntime"] != true || caps["providerGRPCTunnel"] != true || caps["cidrEgress"] != true {
-		t.Fatalf("runtime providers[1].capabilities = %#v", caps)
-	}
 	profile, ok := providers[1]["profile"].(map[string]any)
 	if !ok {
 		t.Fatalf("runtime providers[1].profile = %#v, want object", providers[1]["profile"])
@@ -2989,10 +2975,10 @@ func TestAdminAPI_RuntimeProviders(t *testing.T) {
 	if !ok {
 		t.Fatalf("runtime providers[1].profile.effective = %#v, want object", profile["effective"])
 	}
-	if advertised["hostedExecution"] != true || advertised["hostServiceAccess"] != "none" || advertised["egressMode"] != "cidr" || advertised["launchMode"] != "bundle" {
+	if advertised["canHostPlugins"] != true || advertised["hostServiceAccess"] != "none" || advertised["egressMode"] != "cidr" || advertised["launchMode"] != "bundle" {
 		t.Fatalf("runtime providers[1].profile.advertised = %#v", advertised)
 	}
-	if effective["hostedExecution"] != true || effective["hostServiceAccess"] != "relay" || effective["egressMode"] != "cidr" || effective["launchMode"] != "bundle" {
+	if effective["canHostPlugins"] != true || effective["hostServiceAccess"] != "relay" || effective["egressMode"] != "cidr" || effective["launchMode"] != "bundle" {
 		t.Fatalf("runtime providers[1].profile.effective = %#v", effective)
 	}
 	executionTarget, ok := effective["executionTarget"].(map[string]any)
@@ -3063,7 +3049,7 @@ func TestAdminAPI_RuntimeProviderInspectionError(t *testing.T) {
 				Name:   "modal",
 				Driver: config.RuntimeProviderDriver("modal"),
 				Loaded: true,
-				Error:  "capabilities: boom",
+				Error:  "support: boom",
 			}},
 		}
 	})
@@ -3086,8 +3072,8 @@ func TestAdminAPI_RuntimeProviderInspectionError(t *testing.T) {
 	if len(providers) != 1 {
 		t.Fatalf("runtime providers len = %d, want 1", len(providers))
 	}
-	if got := providers[0]["error"]; got != "capabilities: boom" {
-		t.Fatalf("runtime providers[0].error = %v, want capabilities: boom", got)
+	if got := providers[0]["error"]; got != "support: boom" {
+		t.Fatalf("runtime providers[0].error = %v, want support: boom", got)
 	}
 	if _, ok := providers[0]["profile"]; ok {
 		t.Fatalf("runtime providers[0].profile unexpectedly present: %#v", providers[0]["profile"])
@@ -3116,26 +3102,21 @@ func TestAdminAPI_RuntimeProviderSessionInspectionErrorKeepsProfile(t *testing.T
 	ts := newTestServer(t, func(cfg *server.Config) {
 		cfg.PluginRuntimes = &staticRuntimeInspector{
 			snapshots: []bootstrap.RuntimeProviderSnapshot{{
-				Name:               "modal",
-				Driver:             config.RuntimeProviderDriver("modal"),
-				Loaded:             true,
-				CapabilitiesLoaded: true,
-				Capabilities: pluginruntime.Capabilities{
-					HostedPluginRuntime: true,
-					ProviderGRPCTunnel:  true,
-					CIDREgress:          true,
+				Name:          "modal",
+				Driver:        config.RuntimeProviderDriver("modal"),
+				Loaded:        true,
+				SupportLoaded: true,
+				Advertised: bootstrap.RuntimeBehavior{
+					CanHostPlugins:    true,
+					HostServiceAccess: bootstrap.RuntimeHostServiceAccessNone,
+					EgressMode:        bootstrap.RuntimeEgressModeCIDR,
+					LaunchMode:        bootstrap.RuntimeLaunchModeBundle,
 				},
-				AdvertisedProfile: bootstrap.RuntimeProfile{
-					HostedExecution: true,
-					HostServiceMode: bootstrap.RuntimeHostServiceModeNone,
-					EgressMode:      bootstrap.RuntimeEgressModeCIDR,
-					LaunchMode:      bootstrap.RuntimeLaunchModeBundle,
-				},
-				EffectiveProfile: bootstrap.RuntimeProfile{
-					HostedExecution: true,
-					HostServiceMode: bootstrap.RuntimeHostServiceModeRelay,
-					EgressMode:      bootstrap.RuntimeEgressModeCIDR,
-					LaunchMode:      bootstrap.RuntimeLaunchModeBundle,
+				Effective: bootstrap.RuntimeBehavior{
+					CanHostPlugins:    true,
+					HostServiceAccess: bootstrap.RuntimeHostServiceAccessRelay,
+					EgressMode:        bootstrap.RuntimeEgressModeCIDR,
+					LaunchMode:        bootstrap.RuntimeLaunchModeBundle,
 				},
 				Error: "list sessions: boom",
 			}},
@@ -3165,9 +3146,6 @@ func TestAdminAPI_RuntimeProviderSessionInspectionErrorKeepsProfile(t *testing.T
 	}
 	if _, ok := providers[0]["sessionCount"]; ok {
 		t.Fatalf("runtime providers[0].sessionCount unexpectedly present: %#v", providers[0]["sessionCount"])
-	}
-	if _, ok := providers[0]["capabilities"].(map[string]any); !ok {
-		t.Fatalf("runtime providers[0].capabilities = %#v, want object", providers[0]["capabilities"])
 	}
 	profile, ok := providers[0]["profile"].(map[string]any)
 	if !ok {

--- a/sdk/go/gen/v1/pluginruntime.pb.go
+++ b/sdk/go/gen/v1/pluginruntime.pb.go
@@ -22,6 +22,156 @@ const (
 	_ = protoimpl.EnforceVersion(protoimpl.MaxVersion - 20)
 )
 
+type PluginRuntimeHostServiceAccess int32
+
+const (
+	PluginRuntimeHostServiceAccess_PLUGIN_RUNTIME_HOST_SERVICE_ACCESS_UNSPECIFIED PluginRuntimeHostServiceAccess = 0
+	PluginRuntimeHostServiceAccess_PLUGIN_RUNTIME_HOST_SERVICE_ACCESS_NONE        PluginRuntimeHostServiceAccess = 1
+	PluginRuntimeHostServiceAccess_PLUGIN_RUNTIME_HOST_SERVICE_ACCESS_DIRECT      PluginRuntimeHostServiceAccess = 2
+)
+
+// Enum value maps for PluginRuntimeHostServiceAccess.
+var (
+	PluginRuntimeHostServiceAccess_name = map[int32]string{
+		0: "PLUGIN_RUNTIME_HOST_SERVICE_ACCESS_UNSPECIFIED",
+		1: "PLUGIN_RUNTIME_HOST_SERVICE_ACCESS_NONE",
+		2: "PLUGIN_RUNTIME_HOST_SERVICE_ACCESS_DIRECT",
+	}
+	PluginRuntimeHostServiceAccess_value = map[string]int32{
+		"PLUGIN_RUNTIME_HOST_SERVICE_ACCESS_UNSPECIFIED": 0,
+		"PLUGIN_RUNTIME_HOST_SERVICE_ACCESS_NONE":        1,
+		"PLUGIN_RUNTIME_HOST_SERVICE_ACCESS_DIRECT":      2,
+	}
+)
+
+func (x PluginRuntimeHostServiceAccess) Enum() *PluginRuntimeHostServiceAccess {
+	p := new(PluginRuntimeHostServiceAccess)
+	*p = x
+	return p
+}
+
+func (x PluginRuntimeHostServiceAccess) String() string {
+	return protoimpl.X.EnumStringOf(x.Descriptor(), protoreflect.EnumNumber(x))
+}
+
+func (PluginRuntimeHostServiceAccess) Descriptor() protoreflect.EnumDescriptor {
+	return file_v1_pluginruntime_proto_enumTypes[0].Descriptor()
+}
+
+func (PluginRuntimeHostServiceAccess) Type() protoreflect.EnumType {
+	return &file_v1_pluginruntime_proto_enumTypes[0]
+}
+
+func (x PluginRuntimeHostServiceAccess) Number() protoreflect.EnumNumber {
+	return protoreflect.EnumNumber(x)
+}
+
+// Deprecated: Use PluginRuntimeHostServiceAccess.Descriptor instead.
+func (PluginRuntimeHostServiceAccess) EnumDescriptor() ([]byte, []int) {
+	return file_v1_pluginruntime_proto_rawDescGZIP(), []int{0}
+}
+
+type PluginRuntimeEgressMode int32
+
+const (
+	PluginRuntimeEgressMode_PLUGIN_RUNTIME_EGRESS_MODE_UNSPECIFIED PluginRuntimeEgressMode = 0
+	PluginRuntimeEgressMode_PLUGIN_RUNTIME_EGRESS_MODE_NONE        PluginRuntimeEgressMode = 1
+	PluginRuntimeEgressMode_PLUGIN_RUNTIME_EGRESS_MODE_CIDR        PluginRuntimeEgressMode = 2
+	PluginRuntimeEgressMode_PLUGIN_RUNTIME_EGRESS_MODE_HOSTNAME    PluginRuntimeEgressMode = 3
+)
+
+// Enum value maps for PluginRuntimeEgressMode.
+var (
+	PluginRuntimeEgressMode_name = map[int32]string{
+		0: "PLUGIN_RUNTIME_EGRESS_MODE_UNSPECIFIED",
+		1: "PLUGIN_RUNTIME_EGRESS_MODE_NONE",
+		2: "PLUGIN_RUNTIME_EGRESS_MODE_CIDR",
+		3: "PLUGIN_RUNTIME_EGRESS_MODE_HOSTNAME",
+	}
+	PluginRuntimeEgressMode_value = map[string]int32{
+		"PLUGIN_RUNTIME_EGRESS_MODE_UNSPECIFIED": 0,
+		"PLUGIN_RUNTIME_EGRESS_MODE_NONE":        1,
+		"PLUGIN_RUNTIME_EGRESS_MODE_CIDR":        2,
+		"PLUGIN_RUNTIME_EGRESS_MODE_HOSTNAME":    3,
+	}
+)
+
+func (x PluginRuntimeEgressMode) Enum() *PluginRuntimeEgressMode {
+	p := new(PluginRuntimeEgressMode)
+	*p = x
+	return p
+}
+
+func (x PluginRuntimeEgressMode) String() string {
+	return protoimpl.X.EnumStringOf(x.Descriptor(), protoreflect.EnumNumber(x))
+}
+
+func (PluginRuntimeEgressMode) Descriptor() protoreflect.EnumDescriptor {
+	return file_v1_pluginruntime_proto_enumTypes[1].Descriptor()
+}
+
+func (PluginRuntimeEgressMode) Type() protoreflect.EnumType {
+	return &file_v1_pluginruntime_proto_enumTypes[1]
+}
+
+func (x PluginRuntimeEgressMode) Number() protoreflect.EnumNumber {
+	return protoreflect.EnumNumber(x)
+}
+
+// Deprecated: Use PluginRuntimeEgressMode.Descriptor instead.
+func (PluginRuntimeEgressMode) EnumDescriptor() ([]byte, []int) {
+	return file_v1_pluginruntime_proto_rawDescGZIP(), []int{1}
+}
+
+type PluginRuntimeLaunchMode int32
+
+const (
+	PluginRuntimeLaunchMode_PLUGIN_RUNTIME_LAUNCH_MODE_UNSPECIFIED PluginRuntimeLaunchMode = 0
+	PluginRuntimeLaunchMode_PLUGIN_RUNTIME_LAUNCH_MODE_BUNDLE      PluginRuntimeLaunchMode = 1
+	PluginRuntimeLaunchMode_PLUGIN_RUNTIME_LAUNCH_MODE_HOST_PATH   PluginRuntimeLaunchMode = 2
+)
+
+// Enum value maps for PluginRuntimeLaunchMode.
+var (
+	PluginRuntimeLaunchMode_name = map[int32]string{
+		0: "PLUGIN_RUNTIME_LAUNCH_MODE_UNSPECIFIED",
+		1: "PLUGIN_RUNTIME_LAUNCH_MODE_BUNDLE",
+		2: "PLUGIN_RUNTIME_LAUNCH_MODE_HOST_PATH",
+	}
+	PluginRuntimeLaunchMode_value = map[string]int32{
+		"PLUGIN_RUNTIME_LAUNCH_MODE_UNSPECIFIED": 0,
+		"PLUGIN_RUNTIME_LAUNCH_MODE_BUNDLE":      1,
+		"PLUGIN_RUNTIME_LAUNCH_MODE_HOST_PATH":   2,
+	}
+)
+
+func (x PluginRuntimeLaunchMode) Enum() *PluginRuntimeLaunchMode {
+	p := new(PluginRuntimeLaunchMode)
+	*p = x
+	return p
+}
+
+func (x PluginRuntimeLaunchMode) String() string {
+	return protoimpl.X.EnumStringOf(x.Descriptor(), protoreflect.EnumNumber(x))
+}
+
+func (PluginRuntimeLaunchMode) Descriptor() protoreflect.EnumDescriptor {
+	return file_v1_pluginruntime_proto_enumTypes[2].Descriptor()
+}
+
+func (PluginRuntimeLaunchMode) Type() protoreflect.EnumType {
+	return &file_v1_pluginruntime_proto_enumTypes[2]
+}
+
+func (x PluginRuntimeLaunchMode) Number() protoreflect.EnumNumber {
+	return protoreflect.EnumNumber(x)
+}
+
+// Deprecated: Use PluginRuntimeLaunchMode.Descriptor instead.
+func (PluginRuntimeLaunchMode) EnumDescriptor() ([]byte, []int) {
+	return file_v1_pluginruntime_proto_rawDescGZIP(), []int{2}
+}
+
 type PluginRuntimeCapabilities struct {
 	state               protoimpl.MessageState `protogen:"open.v1"`
 	HostedPluginRuntime bool                   `protobuf:"varint,1,opt,name=hosted_plugin_runtime,json=hostedPluginRuntime,proto3" json:"hosted_plugin_runtime,omitempty"`
@@ -122,16 +272,146 @@ func (x *PluginRuntimeCapabilities) GetExecutionGoarch() string {
 	return ""
 }
 
+type PluginRuntimeExecutionTarget struct {
+	state         protoimpl.MessageState `protogen:"open.v1"`
+	Goos          string                 `protobuf:"bytes,1,opt,name=goos,proto3" json:"goos,omitempty"`
+	Goarch        string                 `protobuf:"bytes,2,opt,name=goarch,proto3" json:"goarch,omitempty"`
+	unknownFields protoimpl.UnknownFields
+	sizeCache     protoimpl.SizeCache
+}
+
+func (x *PluginRuntimeExecutionTarget) Reset() {
+	*x = PluginRuntimeExecutionTarget{}
+	mi := &file_v1_pluginruntime_proto_msgTypes[1]
+	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+	ms.StoreMessageInfo(mi)
+}
+
+func (x *PluginRuntimeExecutionTarget) String() string {
+	return protoimpl.X.MessageStringOf(x)
+}
+
+func (*PluginRuntimeExecutionTarget) ProtoMessage() {}
+
+func (x *PluginRuntimeExecutionTarget) ProtoReflect() protoreflect.Message {
+	mi := &file_v1_pluginruntime_proto_msgTypes[1]
+	if x != nil {
+		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+		if ms.LoadMessageInfo() == nil {
+			ms.StoreMessageInfo(mi)
+		}
+		return ms
+	}
+	return mi.MessageOf(x)
+}
+
+// Deprecated: Use PluginRuntimeExecutionTarget.ProtoReflect.Descriptor instead.
+func (*PluginRuntimeExecutionTarget) Descriptor() ([]byte, []int) {
+	return file_v1_pluginruntime_proto_rawDescGZIP(), []int{1}
+}
+
+func (x *PluginRuntimeExecutionTarget) GetGoos() string {
+	if x != nil {
+		return x.Goos
+	}
+	return ""
+}
+
+func (x *PluginRuntimeExecutionTarget) GetGoarch() string {
+	if x != nil {
+		return x.Goarch
+	}
+	return ""
+}
+
+type PluginRuntimeSupport struct {
+	state             protoimpl.MessageState         `protogen:"open.v1"`
+	CanHostPlugins    bool                           `protobuf:"varint,1,opt,name=can_host_plugins,json=canHostPlugins,proto3" json:"can_host_plugins,omitempty"`
+	HostServiceAccess PluginRuntimeHostServiceAccess `protobuf:"varint,2,opt,name=host_service_access,json=hostServiceAccess,proto3,enum=gestalt.provider.v1.PluginRuntimeHostServiceAccess" json:"host_service_access,omitempty"`
+	EgressMode        PluginRuntimeEgressMode        `protobuf:"varint,3,opt,name=egress_mode,json=egressMode,proto3,enum=gestalt.provider.v1.PluginRuntimeEgressMode" json:"egress_mode,omitempty"`
+	LaunchMode        PluginRuntimeLaunchMode        `protobuf:"varint,4,opt,name=launch_mode,json=launchMode,proto3,enum=gestalt.provider.v1.PluginRuntimeLaunchMode" json:"launch_mode,omitempty"`
+	ExecutionTarget   *PluginRuntimeExecutionTarget  `protobuf:"bytes,5,opt,name=execution_target,json=executionTarget,proto3" json:"execution_target,omitempty"`
+	unknownFields     protoimpl.UnknownFields
+	sizeCache         protoimpl.SizeCache
+}
+
+func (x *PluginRuntimeSupport) Reset() {
+	*x = PluginRuntimeSupport{}
+	mi := &file_v1_pluginruntime_proto_msgTypes[2]
+	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+	ms.StoreMessageInfo(mi)
+}
+
+func (x *PluginRuntimeSupport) String() string {
+	return protoimpl.X.MessageStringOf(x)
+}
+
+func (*PluginRuntimeSupport) ProtoMessage() {}
+
+func (x *PluginRuntimeSupport) ProtoReflect() protoreflect.Message {
+	mi := &file_v1_pluginruntime_proto_msgTypes[2]
+	if x != nil {
+		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+		if ms.LoadMessageInfo() == nil {
+			ms.StoreMessageInfo(mi)
+		}
+		return ms
+	}
+	return mi.MessageOf(x)
+}
+
+// Deprecated: Use PluginRuntimeSupport.ProtoReflect.Descriptor instead.
+func (*PluginRuntimeSupport) Descriptor() ([]byte, []int) {
+	return file_v1_pluginruntime_proto_rawDescGZIP(), []int{2}
+}
+
+func (x *PluginRuntimeSupport) GetCanHostPlugins() bool {
+	if x != nil {
+		return x.CanHostPlugins
+	}
+	return false
+}
+
+func (x *PluginRuntimeSupport) GetHostServiceAccess() PluginRuntimeHostServiceAccess {
+	if x != nil {
+		return x.HostServiceAccess
+	}
+	return PluginRuntimeHostServiceAccess_PLUGIN_RUNTIME_HOST_SERVICE_ACCESS_UNSPECIFIED
+}
+
+func (x *PluginRuntimeSupport) GetEgressMode() PluginRuntimeEgressMode {
+	if x != nil {
+		return x.EgressMode
+	}
+	return PluginRuntimeEgressMode_PLUGIN_RUNTIME_EGRESS_MODE_UNSPECIFIED
+}
+
+func (x *PluginRuntimeSupport) GetLaunchMode() PluginRuntimeLaunchMode {
+	if x != nil {
+		return x.LaunchMode
+	}
+	return PluginRuntimeLaunchMode_PLUGIN_RUNTIME_LAUNCH_MODE_UNSPECIFIED
+}
+
+func (x *PluginRuntimeSupport) GetExecutionTarget() *PluginRuntimeExecutionTarget {
+	if x != nil {
+		return x.ExecutionTarget
+	}
+	return nil
+}
+
 type GetPluginRuntimeCapabilitiesResponse struct {
-	state         protoimpl.MessageState     `protogen:"open.v1"`
+	state protoimpl.MessageState `protogen:"open.v1"`
+	// Deprecated: Marked as deprecated in v1/pluginruntime.proto.
 	Capabilities  *PluginRuntimeCapabilities `protobuf:"bytes,1,opt,name=capabilities,proto3" json:"capabilities,omitempty"`
+	Support       *PluginRuntimeSupport      `protobuf:"bytes,2,opt,name=support,proto3" json:"support,omitempty"`
 	unknownFields protoimpl.UnknownFields
 	sizeCache     protoimpl.SizeCache
 }
 
 func (x *GetPluginRuntimeCapabilitiesResponse) Reset() {
 	*x = GetPluginRuntimeCapabilitiesResponse{}
-	mi := &file_v1_pluginruntime_proto_msgTypes[1]
+	mi := &file_v1_pluginruntime_proto_msgTypes[3]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -143,7 +423,7 @@ func (x *GetPluginRuntimeCapabilitiesResponse) String() string {
 func (*GetPluginRuntimeCapabilitiesResponse) ProtoMessage() {}
 
 func (x *GetPluginRuntimeCapabilitiesResponse) ProtoReflect() protoreflect.Message {
-	mi := &file_v1_pluginruntime_proto_msgTypes[1]
+	mi := &file_v1_pluginruntime_proto_msgTypes[3]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -156,12 +436,20 @@ func (x *GetPluginRuntimeCapabilitiesResponse) ProtoReflect() protoreflect.Messa
 
 // Deprecated: Use GetPluginRuntimeCapabilitiesResponse.ProtoReflect.Descriptor instead.
 func (*GetPluginRuntimeCapabilitiesResponse) Descriptor() ([]byte, []int) {
-	return file_v1_pluginruntime_proto_rawDescGZIP(), []int{1}
+	return file_v1_pluginruntime_proto_rawDescGZIP(), []int{3}
 }
 
+// Deprecated: Marked as deprecated in v1/pluginruntime.proto.
 func (x *GetPluginRuntimeCapabilitiesResponse) GetCapabilities() *PluginRuntimeCapabilities {
 	if x != nil {
 		return x.Capabilities
+	}
+	return nil
+}
+
+func (x *GetPluginRuntimeCapabilitiesResponse) GetSupport() *PluginRuntimeSupport {
+	if x != nil {
+		return x.Support
 	}
 	return nil
 }
@@ -177,7 +465,7 @@ type PluginRuntimeSession struct {
 
 func (x *PluginRuntimeSession) Reset() {
 	*x = PluginRuntimeSession{}
-	mi := &file_v1_pluginruntime_proto_msgTypes[2]
+	mi := &file_v1_pluginruntime_proto_msgTypes[4]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -189,7 +477,7 @@ func (x *PluginRuntimeSession) String() string {
 func (*PluginRuntimeSession) ProtoMessage() {}
 
 func (x *PluginRuntimeSession) ProtoReflect() protoreflect.Message {
-	mi := &file_v1_pluginruntime_proto_msgTypes[2]
+	mi := &file_v1_pluginruntime_proto_msgTypes[4]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -202,7 +490,7 @@ func (x *PluginRuntimeSession) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use PluginRuntimeSession.ProtoReflect.Descriptor instead.
 func (*PluginRuntimeSession) Descriptor() ([]byte, []int) {
-	return file_v1_pluginruntime_proto_rawDescGZIP(), []int{2}
+	return file_v1_pluginruntime_proto_rawDescGZIP(), []int{4}
 }
 
 func (x *PluginRuntimeSession) GetId() string {
@@ -238,7 +526,7 @@ type StartPluginRuntimeSessionRequest struct {
 
 func (x *StartPluginRuntimeSessionRequest) Reset() {
 	*x = StartPluginRuntimeSessionRequest{}
-	mi := &file_v1_pluginruntime_proto_msgTypes[3]
+	mi := &file_v1_pluginruntime_proto_msgTypes[5]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -250,7 +538,7 @@ func (x *StartPluginRuntimeSessionRequest) String() string {
 func (*StartPluginRuntimeSessionRequest) ProtoMessage() {}
 
 func (x *StartPluginRuntimeSessionRequest) ProtoReflect() protoreflect.Message {
-	mi := &file_v1_pluginruntime_proto_msgTypes[3]
+	mi := &file_v1_pluginruntime_proto_msgTypes[5]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -263,7 +551,7 @@ func (x *StartPluginRuntimeSessionRequest) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use StartPluginRuntimeSessionRequest.ProtoReflect.Descriptor instead.
 func (*StartPluginRuntimeSessionRequest) Descriptor() ([]byte, []int) {
-	return file_v1_pluginruntime_proto_rawDescGZIP(), []int{3}
+	return file_v1_pluginruntime_proto_rawDescGZIP(), []int{5}
 }
 
 func (x *StartPluginRuntimeSessionRequest) GetPluginName() string {
@@ -303,7 +591,7 @@ type GetPluginRuntimeSessionRequest struct {
 
 func (x *GetPluginRuntimeSessionRequest) Reset() {
 	*x = GetPluginRuntimeSessionRequest{}
-	mi := &file_v1_pluginruntime_proto_msgTypes[4]
+	mi := &file_v1_pluginruntime_proto_msgTypes[6]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -315,7 +603,7 @@ func (x *GetPluginRuntimeSessionRequest) String() string {
 func (*GetPluginRuntimeSessionRequest) ProtoMessage() {}
 
 func (x *GetPluginRuntimeSessionRequest) ProtoReflect() protoreflect.Message {
-	mi := &file_v1_pluginruntime_proto_msgTypes[4]
+	mi := &file_v1_pluginruntime_proto_msgTypes[6]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -328,7 +616,7 @@ func (x *GetPluginRuntimeSessionRequest) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use GetPluginRuntimeSessionRequest.ProtoReflect.Descriptor instead.
 func (*GetPluginRuntimeSessionRequest) Descriptor() ([]byte, []int) {
-	return file_v1_pluginruntime_proto_rawDescGZIP(), []int{4}
+	return file_v1_pluginruntime_proto_rawDescGZIP(), []int{6}
 }
 
 func (x *GetPluginRuntimeSessionRequest) GetSessionId() string {
@@ -347,7 +635,7 @@ type StopPluginRuntimeSessionRequest struct {
 
 func (x *StopPluginRuntimeSessionRequest) Reset() {
 	*x = StopPluginRuntimeSessionRequest{}
-	mi := &file_v1_pluginruntime_proto_msgTypes[5]
+	mi := &file_v1_pluginruntime_proto_msgTypes[7]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -359,7 +647,7 @@ func (x *StopPluginRuntimeSessionRequest) String() string {
 func (*StopPluginRuntimeSessionRequest) ProtoMessage() {}
 
 func (x *StopPluginRuntimeSessionRequest) ProtoReflect() protoreflect.Message {
-	mi := &file_v1_pluginruntime_proto_msgTypes[5]
+	mi := &file_v1_pluginruntime_proto_msgTypes[7]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -372,7 +660,7 @@ func (x *StopPluginRuntimeSessionRequest) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use StopPluginRuntimeSessionRequest.ProtoReflect.Descriptor instead.
 func (*StopPluginRuntimeSessionRequest) Descriptor() ([]byte, []int) {
-	return file_v1_pluginruntime_proto_rawDescGZIP(), []int{5}
+	return file_v1_pluginruntime_proto_rawDescGZIP(), []int{7}
 }
 
 func (x *StopPluginRuntimeSessionRequest) GetSessionId() string {
@@ -391,7 +679,7 @@ type PluginRuntimeHostServiceRelay struct {
 
 func (x *PluginRuntimeHostServiceRelay) Reset() {
 	*x = PluginRuntimeHostServiceRelay{}
-	mi := &file_v1_pluginruntime_proto_msgTypes[6]
+	mi := &file_v1_pluginruntime_proto_msgTypes[8]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -403,7 +691,7 @@ func (x *PluginRuntimeHostServiceRelay) String() string {
 func (*PluginRuntimeHostServiceRelay) ProtoMessage() {}
 
 func (x *PluginRuntimeHostServiceRelay) ProtoReflect() protoreflect.Message {
-	mi := &file_v1_pluginruntime_proto_msgTypes[6]
+	mi := &file_v1_pluginruntime_proto_msgTypes[8]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -416,7 +704,7 @@ func (x *PluginRuntimeHostServiceRelay) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use PluginRuntimeHostServiceRelay.ProtoReflect.Descriptor instead.
 func (*PluginRuntimeHostServiceRelay) Descriptor() ([]byte, []int) {
-	return file_v1_pluginruntime_proto_rawDescGZIP(), []int{6}
+	return file_v1_pluginruntime_proto_rawDescGZIP(), []int{8}
 }
 
 func (x *PluginRuntimeHostServiceRelay) GetDialTarget() string {
@@ -439,7 +727,7 @@ type BindPluginRuntimeHostServiceRequest struct {
 
 func (x *BindPluginRuntimeHostServiceRequest) Reset() {
 	*x = BindPluginRuntimeHostServiceRequest{}
-	mi := &file_v1_pluginruntime_proto_msgTypes[7]
+	mi := &file_v1_pluginruntime_proto_msgTypes[9]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -451,7 +739,7 @@ func (x *BindPluginRuntimeHostServiceRequest) String() string {
 func (*BindPluginRuntimeHostServiceRequest) ProtoMessage() {}
 
 func (x *BindPluginRuntimeHostServiceRequest) ProtoReflect() protoreflect.Message {
-	mi := &file_v1_pluginruntime_proto_msgTypes[7]
+	mi := &file_v1_pluginruntime_proto_msgTypes[9]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -464,7 +752,7 @@ func (x *BindPluginRuntimeHostServiceRequest) ProtoReflect() protoreflect.Messag
 
 // Deprecated: Use BindPluginRuntimeHostServiceRequest.ProtoReflect.Descriptor instead.
 func (*BindPluginRuntimeHostServiceRequest) Descriptor() ([]byte, []int) {
-	return file_v1_pluginruntime_proto_rawDescGZIP(), []int{7}
+	return file_v1_pluginruntime_proto_rawDescGZIP(), []int{9}
 }
 
 func (x *BindPluginRuntimeHostServiceRequest) GetSessionId() string {
@@ -510,7 +798,7 @@ type PluginRuntimeHostServiceBinding struct {
 
 func (x *PluginRuntimeHostServiceBinding) Reset() {
 	*x = PluginRuntimeHostServiceBinding{}
-	mi := &file_v1_pluginruntime_proto_msgTypes[8]
+	mi := &file_v1_pluginruntime_proto_msgTypes[10]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -522,7 +810,7 @@ func (x *PluginRuntimeHostServiceBinding) String() string {
 func (*PluginRuntimeHostServiceBinding) ProtoMessage() {}
 
 func (x *PluginRuntimeHostServiceBinding) ProtoReflect() protoreflect.Message {
-	mi := &file_v1_pluginruntime_proto_msgTypes[8]
+	mi := &file_v1_pluginruntime_proto_msgTypes[10]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -535,7 +823,7 @@ func (x *PluginRuntimeHostServiceBinding) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use PluginRuntimeHostServiceBinding.ProtoReflect.Descriptor instead.
 func (*PluginRuntimeHostServiceBinding) Descriptor() ([]byte, []int) {
-	return file_v1_pluginruntime_proto_rawDescGZIP(), []int{8}
+	return file_v1_pluginruntime_proto_rawDescGZIP(), []int{10}
 }
 
 func (x *PluginRuntimeHostServiceBinding) GetId() string {
@@ -595,7 +883,7 @@ type StartHostedPluginRequest struct {
 
 func (x *StartHostedPluginRequest) Reset() {
 	*x = StartHostedPluginRequest{}
-	mi := &file_v1_pluginruntime_proto_msgTypes[9]
+	mi := &file_v1_pluginruntime_proto_msgTypes[11]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -607,7 +895,7 @@ func (x *StartHostedPluginRequest) String() string {
 func (*StartHostedPluginRequest) ProtoMessage() {}
 
 func (x *StartHostedPluginRequest) ProtoReflect() protoreflect.Message {
-	mi := &file_v1_pluginruntime_proto_msgTypes[9]
+	mi := &file_v1_pluginruntime_proto_msgTypes[11]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -620,7 +908,7 @@ func (x *StartHostedPluginRequest) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use StartHostedPluginRequest.ProtoReflect.Descriptor instead.
 func (*StartHostedPluginRequest) Descriptor() ([]byte, []int) {
-	return file_v1_pluginruntime_proto_rawDescGZIP(), []int{9}
+	return file_v1_pluginruntime_proto_rawDescGZIP(), []int{11}
 }
 
 func (x *StartHostedPluginRequest) GetSessionId() string {
@@ -698,7 +986,7 @@ type HostedPlugin struct {
 
 func (x *HostedPlugin) Reset() {
 	*x = HostedPlugin{}
-	mi := &file_v1_pluginruntime_proto_msgTypes[10]
+	mi := &file_v1_pluginruntime_proto_msgTypes[12]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -710,7 +998,7 @@ func (x *HostedPlugin) String() string {
 func (*HostedPlugin) ProtoMessage() {}
 
 func (x *HostedPlugin) ProtoReflect() protoreflect.Message {
-	mi := &file_v1_pluginruntime_proto_msgTypes[10]
+	mi := &file_v1_pluginruntime_proto_msgTypes[12]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -723,7 +1011,7 @@ func (x *HostedPlugin) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use HostedPlugin.ProtoReflect.Descriptor instead.
 func (*HostedPlugin) Descriptor() ([]byte, []int) {
-	return file_v1_pluginruntime_proto_rawDescGZIP(), []int{10}
+	return file_v1_pluginruntime_proto_rawDescGZIP(), []int{12}
 }
 
 func (x *HostedPlugin) GetId() string {
@@ -768,9 +1056,21 @@ const file_v1_pluginruntime_proto_rawDesc = "" +
 	"cidrEgress\x12.\n" +
 	"\x13host_path_execution\x18\x06 \x01(\bR\x11hostPathExecution\x12%\n" +
 	"\x0eexecution_goos\x18\a \x01(\tR\rexecutionGoos\x12)\n" +
-	"\x10execution_goarch\x18\b \x01(\tR\x0fexecutionGoarch\"z\n" +
-	"$GetPluginRuntimeCapabilitiesResponse\x12R\n" +
-	"\fcapabilities\x18\x01 \x01(\v2..gestalt.provider.v1.PluginRuntimeCapabilitiesR\fcapabilities\"\xce\x01\n" +
+	"\x10execution_goarch\x18\b \x01(\tR\x0fexecutionGoarch\"J\n" +
+	"\x1cPluginRuntimeExecutionTarget\x12\x12\n" +
+	"\x04goos\x18\x01 \x01(\tR\x04goos\x12\x16\n" +
+	"\x06goarch\x18\x02 \x01(\tR\x06goarch\"\xa1\x03\n" +
+	"\x14PluginRuntimeSupport\x12(\n" +
+	"\x10can_host_plugins\x18\x01 \x01(\bR\x0ecanHostPlugins\x12c\n" +
+	"\x13host_service_access\x18\x02 \x01(\x0e23.gestalt.provider.v1.PluginRuntimeHostServiceAccessR\x11hostServiceAccess\x12M\n" +
+	"\vegress_mode\x18\x03 \x01(\x0e2,.gestalt.provider.v1.PluginRuntimeEgressModeR\n" +
+	"egressMode\x12M\n" +
+	"\vlaunch_mode\x18\x04 \x01(\x0e2,.gestalt.provider.v1.PluginRuntimeLaunchModeR\n" +
+	"launchMode\x12\\\n" +
+	"\x10execution_target\x18\x05 \x01(\v21.gestalt.provider.v1.PluginRuntimeExecutionTargetR\x0fexecutionTarget\"\xc3\x01\n" +
+	"$GetPluginRuntimeCapabilitiesResponse\x12V\n" +
+	"\fcapabilities\x18\x01 \x01(\v2..gestalt.provider.v1.PluginRuntimeCapabilitiesB\x02\x18\x01R\fcapabilities\x12C\n" +
+	"\asupport\x18\x02 \x01(\v2).gestalt.provider.v1.PluginRuntimeSupportR\asupport\"\xce\x01\n" +
 	"\x14PluginRuntimeSession\x12\x0e\n" +
 	"\x02id\x18\x01 \x01(\tR\x02id\x12\x14\n" +
 	"\x05state\x18\x02 \x01(\tR\x05state\x12S\n" +
@@ -834,7 +1134,20 @@ const file_v1_pluginruntime_proto_rawDesc = "" +
 	"\vplugin_name\x18\x03 \x01(\tR\n" +
 	"pluginName\x12\x1f\n" +
 	"\vdial_target\x18\x04 \x01(\tR\n" +
-	"dialTarget2\x9f\x05\n" +
+	"dialTarget*\xb0\x01\n" +
+	"\x1ePluginRuntimeHostServiceAccess\x122\n" +
+	".PLUGIN_RUNTIME_HOST_SERVICE_ACCESS_UNSPECIFIED\x10\x00\x12+\n" +
+	"'PLUGIN_RUNTIME_HOST_SERVICE_ACCESS_NONE\x10\x01\x12-\n" +
+	")PLUGIN_RUNTIME_HOST_SERVICE_ACCESS_DIRECT\x10\x02*\xb8\x01\n" +
+	"\x17PluginRuntimeEgressMode\x12*\n" +
+	"&PLUGIN_RUNTIME_EGRESS_MODE_UNSPECIFIED\x10\x00\x12#\n" +
+	"\x1fPLUGIN_RUNTIME_EGRESS_MODE_NONE\x10\x01\x12#\n" +
+	"\x1fPLUGIN_RUNTIME_EGRESS_MODE_CIDR\x10\x02\x12'\n" +
+	"#PLUGIN_RUNTIME_EGRESS_MODE_HOSTNAME\x10\x03*\x96\x01\n" +
+	"\x17PluginRuntimeLaunchMode\x12*\n" +
+	"&PLUGIN_RUNTIME_LAUNCH_MODE_UNSPECIFIED\x10\x00\x12%\n" +
+	"!PLUGIN_RUNTIME_LAUNCH_MODE_BUNDLE\x10\x01\x12(\n" +
+	"$PLUGIN_RUNTIME_LAUNCH_MODE_HOST_PATH\x10\x022\x9f\x05\n" +
 	"\x15PluginRuntimeProvider\x12d\n" +
 	"\x0fGetCapabilities\x12\x16.google.protobuf.Empty\x1a9.gestalt.provider.v1.GetPluginRuntimeCapabilitiesResponse\x12p\n" +
 	"\fStartSession\x125.gestalt.provider.v1.StartPluginRuntimeSessionRequest\x1a).gestalt.provider.v1.PluginRuntimeSession\x12l\n" +
@@ -857,48 +1170,59 @@ func file_v1_pluginruntime_proto_rawDescGZIP() []byte {
 	return file_v1_pluginruntime_proto_rawDescData
 }
 
-var file_v1_pluginruntime_proto_msgTypes = make([]protoimpl.MessageInfo, 14)
+var file_v1_pluginruntime_proto_enumTypes = make([]protoimpl.EnumInfo, 3)
+var file_v1_pluginruntime_proto_msgTypes = make([]protoimpl.MessageInfo, 16)
 var file_v1_pluginruntime_proto_goTypes = []any{
-	(*PluginRuntimeCapabilities)(nil),            // 0: gestalt.provider.v1.PluginRuntimeCapabilities
-	(*GetPluginRuntimeCapabilitiesResponse)(nil), // 1: gestalt.provider.v1.GetPluginRuntimeCapabilitiesResponse
-	(*PluginRuntimeSession)(nil),                 // 2: gestalt.provider.v1.PluginRuntimeSession
-	(*StartPluginRuntimeSessionRequest)(nil),     // 3: gestalt.provider.v1.StartPluginRuntimeSessionRequest
-	(*GetPluginRuntimeSessionRequest)(nil),       // 4: gestalt.provider.v1.GetPluginRuntimeSessionRequest
-	(*StopPluginRuntimeSessionRequest)(nil),      // 5: gestalt.provider.v1.StopPluginRuntimeSessionRequest
-	(*PluginRuntimeHostServiceRelay)(nil),        // 6: gestalt.provider.v1.PluginRuntimeHostServiceRelay
-	(*BindPluginRuntimeHostServiceRequest)(nil),  // 7: gestalt.provider.v1.BindPluginRuntimeHostServiceRequest
-	(*PluginRuntimeHostServiceBinding)(nil),      // 8: gestalt.provider.v1.PluginRuntimeHostServiceBinding
-	(*StartHostedPluginRequest)(nil),             // 9: gestalt.provider.v1.StartHostedPluginRequest
-	(*HostedPlugin)(nil),                         // 10: gestalt.provider.v1.HostedPlugin
-	nil,                                          // 11: gestalt.provider.v1.PluginRuntimeSession.MetadataEntry
-	nil,                                          // 12: gestalt.provider.v1.StartPluginRuntimeSessionRequest.MetadataEntry
-	nil,                                          // 13: gestalt.provider.v1.StartHostedPluginRequest.EnvEntry
-	(*emptypb.Empty)(nil),                        // 14: google.protobuf.Empty
+	(PluginRuntimeHostServiceAccess)(0),          // 0: gestalt.provider.v1.PluginRuntimeHostServiceAccess
+	(PluginRuntimeEgressMode)(0),                 // 1: gestalt.provider.v1.PluginRuntimeEgressMode
+	(PluginRuntimeLaunchMode)(0),                 // 2: gestalt.provider.v1.PluginRuntimeLaunchMode
+	(*PluginRuntimeCapabilities)(nil),            // 3: gestalt.provider.v1.PluginRuntimeCapabilities
+	(*PluginRuntimeExecutionTarget)(nil),         // 4: gestalt.provider.v1.PluginRuntimeExecutionTarget
+	(*PluginRuntimeSupport)(nil),                 // 5: gestalt.provider.v1.PluginRuntimeSupport
+	(*GetPluginRuntimeCapabilitiesResponse)(nil), // 6: gestalt.provider.v1.GetPluginRuntimeCapabilitiesResponse
+	(*PluginRuntimeSession)(nil),                 // 7: gestalt.provider.v1.PluginRuntimeSession
+	(*StartPluginRuntimeSessionRequest)(nil),     // 8: gestalt.provider.v1.StartPluginRuntimeSessionRequest
+	(*GetPluginRuntimeSessionRequest)(nil),       // 9: gestalt.provider.v1.GetPluginRuntimeSessionRequest
+	(*StopPluginRuntimeSessionRequest)(nil),      // 10: gestalt.provider.v1.StopPluginRuntimeSessionRequest
+	(*PluginRuntimeHostServiceRelay)(nil),        // 11: gestalt.provider.v1.PluginRuntimeHostServiceRelay
+	(*BindPluginRuntimeHostServiceRequest)(nil),  // 12: gestalt.provider.v1.BindPluginRuntimeHostServiceRequest
+	(*PluginRuntimeHostServiceBinding)(nil),      // 13: gestalt.provider.v1.PluginRuntimeHostServiceBinding
+	(*StartHostedPluginRequest)(nil),             // 14: gestalt.provider.v1.StartHostedPluginRequest
+	(*HostedPlugin)(nil),                         // 15: gestalt.provider.v1.HostedPlugin
+	nil,                                          // 16: gestalt.provider.v1.PluginRuntimeSession.MetadataEntry
+	nil,                                          // 17: gestalt.provider.v1.StartPluginRuntimeSessionRequest.MetadataEntry
+	nil,                                          // 18: gestalt.provider.v1.StartHostedPluginRequest.EnvEntry
+	(*emptypb.Empty)(nil),                        // 19: google.protobuf.Empty
 }
 var file_v1_pluginruntime_proto_depIdxs = []int32{
-	0,  // 0: gestalt.provider.v1.GetPluginRuntimeCapabilitiesResponse.capabilities:type_name -> gestalt.provider.v1.PluginRuntimeCapabilities
-	11, // 1: gestalt.provider.v1.PluginRuntimeSession.metadata:type_name -> gestalt.provider.v1.PluginRuntimeSession.MetadataEntry
-	12, // 2: gestalt.provider.v1.StartPluginRuntimeSessionRequest.metadata:type_name -> gestalt.provider.v1.StartPluginRuntimeSessionRequest.MetadataEntry
-	6,  // 3: gestalt.provider.v1.BindPluginRuntimeHostServiceRequest.relay:type_name -> gestalt.provider.v1.PluginRuntimeHostServiceRelay
-	6,  // 4: gestalt.provider.v1.PluginRuntimeHostServiceBinding.relay:type_name -> gestalt.provider.v1.PluginRuntimeHostServiceRelay
-	13, // 5: gestalt.provider.v1.StartHostedPluginRequest.env:type_name -> gestalt.provider.v1.StartHostedPluginRequest.EnvEntry
-	14, // 6: gestalt.provider.v1.PluginRuntimeProvider.GetCapabilities:input_type -> google.protobuf.Empty
-	3,  // 7: gestalt.provider.v1.PluginRuntimeProvider.StartSession:input_type -> gestalt.provider.v1.StartPluginRuntimeSessionRequest
-	4,  // 8: gestalt.provider.v1.PluginRuntimeProvider.GetSession:input_type -> gestalt.provider.v1.GetPluginRuntimeSessionRequest
-	5,  // 9: gestalt.provider.v1.PluginRuntimeProvider.StopSession:input_type -> gestalt.provider.v1.StopPluginRuntimeSessionRequest
-	7,  // 10: gestalt.provider.v1.PluginRuntimeProvider.BindHostService:input_type -> gestalt.provider.v1.BindPluginRuntimeHostServiceRequest
-	9,  // 11: gestalt.provider.v1.PluginRuntimeProvider.StartPlugin:input_type -> gestalt.provider.v1.StartHostedPluginRequest
-	1,  // 12: gestalt.provider.v1.PluginRuntimeProvider.GetCapabilities:output_type -> gestalt.provider.v1.GetPluginRuntimeCapabilitiesResponse
-	2,  // 13: gestalt.provider.v1.PluginRuntimeProvider.StartSession:output_type -> gestalt.provider.v1.PluginRuntimeSession
-	2,  // 14: gestalt.provider.v1.PluginRuntimeProvider.GetSession:output_type -> gestalt.provider.v1.PluginRuntimeSession
-	14, // 15: gestalt.provider.v1.PluginRuntimeProvider.StopSession:output_type -> google.protobuf.Empty
-	8,  // 16: gestalt.provider.v1.PluginRuntimeProvider.BindHostService:output_type -> gestalt.provider.v1.PluginRuntimeHostServiceBinding
-	10, // 17: gestalt.provider.v1.PluginRuntimeProvider.StartPlugin:output_type -> gestalt.provider.v1.HostedPlugin
-	12, // [12:18] is the sub-list for method output_type
-	6,  // [6:12] is the sub-list for method input_type
-	6,  // [6:6] is the sub-list for extension type_name
-	6,  // [6:6] is the sub-list for extension extendee
-	0,  // [0:6] is the sub-list for field type_name
+	0,  // 0: gestalt.provider.v1.PluginRuntimeSupport.host_service_access:type_name -> gestalt.provider.v1.PluginRuntimeHostServiceAccess
+	1,  // 1: gestalt.provider.v1.PluginRuntimeSupport.egress_mode:type_name -> gestalt.provider.v1.PluginRuntimeEgressMode
+	2,  // 2: gestalt.provider.v1.PluginRuntimeSupport.launch_mode:type_name -> gestalt.provider.v1.PluginRuntimeLaunchMode
+	4,  // 3: gestalt.provider.v1.PluginRuntimeSupport.execution_target:type_name -> gestalt.provider.v1.PluginRuntimeExecutionTarget
+	3,  // 4: gestalt.provider.v1.GetPluginRuntimeCapabilitiesResponse.capabilities:type_name -> gestalt.provider.v1.PluginRuntimeCapabilities
+	5,  // 5: gestalt.provider.v1.GetPluginRuntimeCapabilitiesResponse.support:type_name -> gestalt.provider.v1.PluginRuntimeSupport
+	16, // 6: gestalt.provider.v1.PluginRuntimeSession.metadata:type_name -> gestalt.provider.v1.PluginRuntimeSession.MetadataEntry
+	17, // 7: gestalt.provider.v1.StartPluginRuntimeSessionRequest.metadata:type_name -> gestalt.provider.v1.StartPluginRuntimeSessionRequest.MetadataEntry
+	11, // 8: gestalt.provider.v1.BindPluginRuntimeHostServiceRequest.relay:type_name -> gestalt.provider.v1.PluginRuntimeHostServiceRelay
+	11, // 9: gestalt.provider.v1.PluginRuntimeHostServiceBinding.relay:type_name -> gestalt.provider.v1.PluginRuntimeHostServiceRelay
+	18, // 10: gestalt.provider.v1.StartHostedPluginRequest.env:type_name -> gestalt.provider.v1.StartHostedPluginRequest.EnvEntry
+	19, // 11: gestalt.provider.v1.PluginRuntimeProvider.GetCapabilities:input_type -> google.protobuf.Empty
+	8,  // 12: gestalt.provider.v1.PluginRuntimeProvider.StartSession:input_type -> gestalt.provider.v1.StartPluginRuntimeSessionRequest
+	9,  // 13: gestalt.provider.v1.PluginRuntimeProvider.GetSession:input_type -> gestalt.provider.v1.GetPluginRuntimeSessionRequest
+	10, // 14: gestalt.provider.v1.PluginRuntimeProvider.StopSession:input_type -> gestalt.provider.v1.StopPluginRuntimeSessionRequest
+	12, // 15: gestalt.provider.v1.PluginRuntimeProvider.BindHostService:input_type -> gestalt.provider.v1.BindPluginRuntimeHostServiceRequest
+	14, // 16: gestalt.provider.v1.PluginRuntimeProvider.StartPlugin:input_type -> gestalt.provider.v1.StartHostedPluginRequest
+	6,  // 17: gestalt.provider.v1.PluginRuntimeProvider.GetCapabilities:output_type -> gestalt.provider.v1.GetPluginRuntimeCapabilitiesResponse
+	7,  // 18: gestalt.provider.v1.PluginRuntimeProvider.StartSession:output_type -> gestalt.provider.v1.PluginRuntimeSession
+	7,  // 19: gestalt.provider.v1.PluginRuntimeProvider.GetSession:output_type -> gestalt.provider.v1.PluginRuntimeSession
+	19, // 20: gestalt.provider.v1.PluginRuntimeProvider.StopSession:output_type -> google.protobuf.Empty
+	13, // 21: gestalt.provider.v1.PluginRuntimeProvider.BindHostService:output_type -> gestalt.provider.v1.PluginRuntimeHostServiceBinding
+	15, // 22: gestalt.provider.v1.PluginRuntimeProvider.StartPlugin:output_type -> gestalt.provider.v1.HostedPlugin
+	17, // [17:23] is the sub-list for method output_type
+	11, // [11:17] is the sub-list for method input_type
+	11, // [11:11] is the sub-list for extension type_name
+	11, // [11:11] is the sub-list for extension extendee
+	0,  // [0:11] is the sub-list for field type_name
 }
 
 func init() { file_v1_pluginruntime_proto_init() }
@@ -911,13 +1235,14 @@ func file_v1_pluginruntime_proto_init() {
 		File: protoimpl.DescBuilder{
 			GoPackagePath: reflect.TypeOf(x{}).PkgPath(),
 			RawDescriptor: unsafe.Slice(unsafe.StringData(file_v1_pluginruntime_proto_rawDesc), len(file_v1_pluginruntime_proto_rawDesc)),
-			NumEnums:      0,
-			NumMessages:   14,
+			NumEnums:      3,
+			NumMessages:   16,
 			NumExtensions: 0,
 			NumServices:   1,
 		},
 		GoTypes:           file_v1_pluginruntime_proto_goTypes,
 		DependencyIndexes: file_v1_pluginruntime_proto_depIdxs,
+		EnumInfos:         file_v1_pluginruntime_proto_enumTypes,
 		MessageInfos:      file_v1_pluginruntime_proto_msgTypes,
 	}.Build()
 	File_v1_pluginruntime_proto = out.File

--- a/sdk/proto/v1/pluginruntime.proto
+++ b/sdk/proto/v1/pluginruntime.proto
@@ -17,8 +17,41 @@ message PluginRuntimeCapabilities {
   string execution_goarch = 8;
 }
 
+enum PluginRuntimeHostServiceAccess {
+  PLUGIN_RUNTIME_HOST_SERVICE_ACCESS_UNSPECIFIED = 0;
+  PLUGIN_RUNTIME_HOST_SERVICE_ACCESS_NONE = 1;
+  PLUGIN_RUNTIME_HOST_SERVICE_ACCESS_DIRECT = 2;
+}
+
+enum PluginRuntimeEgressMode {
+  PLUGIN_RUNTIME_EGRESS_MODE_UNSPECIFIED = 0;
+  PLUGIN_RUNTIME_EGRESS_MODE_NONE = 1;
+  PLUGIN_RUNTIME_EGRESS_MODE_CIDR = 2;
+  PLUGIN_RUNTIME_EGRESS_MODE_HOSTNAME = 3;
+}
+
+enum PluginRuntimeLaunchMode {
+  PLUGIN_RUNTIME_LAUNCH_MODE_UNSPECIFIED = 0;
+  PLUGIN_RUNTIME_LAUNCH_MODE_BUNDLE = 1;
+  PLUGIN_RUNTIME_LAUNCH_MODE_HOST_PATH = 2;
+}
+
+message PluginRuntimeExecutionTarget {
+  string goos = 1;
+  string goarch = 2;
+}
+
+message PluginRuntimeSupport {
+  bool can_host_plugins = 1;
+  PluginRuntimeHostServiceAccess host_service_access = 2;
+  PluginRuntimeEgressMode egress_mode = 3;
+  PluginRuntimeLaunchMode launch_mode = 4;
+  PluginRuntimeExecutionTarget execution_target = 5;
+}
+
 message GetPluginRuntimeCapabilitiesResponse {
-  PluginRuntimeCapabilities capabilities = 1;
+  PluginRuntimeCapabilities capabilities = 1 [deprecated = true];
+  PluginRuntimeSupport support = 2;
 }
 
 message PluginRuntimeSession {


### PR DESCRIPTION
This PR is a cleanup-first follow-up to the runtime planner/profile work.

It removes the legacy runtime capability bag from the provider contract and makes grouped runtime support the only supported runtime-provider surface in `gestaltd`. Bootstrap now consumes grouped support directly, admin runtime inspection exposes only the higher-level profile view, and the old boolean contract is gone instead of lingering as a compatibility shim.

Old provider interface:

```go
func (p *Provider) GetCapabilities(context.Context, *emptypb.Empty) (*proto.GetPluginRuntimeCapabilitiesResponse, error) {
	return &proto.GetPluginRuntimeCapabilitiesResponse{
		Capabilities: &proto.PluginRuntimeCapabilities{
			HostedPluginRuntime: true,
			HostServiceTunnels:  true,
			ProviderGrpcTunnel:  true,
			HostnameProxyEgress: true,
			HostPathExecution:   false,
			ExecutionGoos:       "linux",
			ExecutionGoarch:     "amd64",
		},
	}, nil
}
```

New provider interface:

```go
func (p *Provider) GetCapabilities(context.Context, *emptypb.Empty) (*proto.GetPluginRuntimeCapabilitiesResponse, error) {
	return &proto.GetPluginRuntimeCapabilitiesResponse{
		Support: &proto.PluginRuntimeSupport{
			CanHostPlugins:    true,
			HostServiceAccess: proto.PluginRuntimeHostServiceAccess_PLUGIN_RUNTIME_HOST_SERVICE_ACCESS_DIRECT,
			EgressMode:        proto.PluginRuntimeEgressMode_PLUGIN_RUNTIME_EGRESS_MODE_HOSTNAME,
			LaunchMode:        proto.PluginRuntimeLaunchMode_PLUGIN_RUNTIME_LAUNCH_MODE_BUNDLE,
			ExecutionTarget: &proto.PluginRuntimeExecutionTarget{
				Goos:   "linux",
				Goarch: "amd64",
			},
		},
	}, nil
}
```

Old admin runtime inspection shape:

```json
{
  "name": "modal",
  "capabilities": {
    "hostedPluginRuntime": true,
    "providerGRPCTunnel": true,
    "cidrEgress": true
  },
  "profile": {
    "advertised": {
      "hostedExecution": true,
      "hostServiceAccess": "none",
      "egressMode": "cidr",
      "launchMode": "bundle"
    },
    "effective": {
      "hostedExecution": true,
      "hostServiceAccess": "relay",
      "egressMode": "cidr",
      "launchMode": "bundle"
    }
  }
}
```

New admin runtime inspection shape:

```json
{
  "name": "modal",
  "profile": {
    "advertised": {
      "canHostPlugins": true,
      "hostServiceAccess": "none",
      "egressMode": "cidr",
      "launchMode": "bundle"
    },
    "effective": {
      "canHostPlugins": true,
      "hostServiceAccess": "relay",
      "egressMode": "cidr",
      "launchMode": "bundle"
    }
  }
}
```

Why this is simpler:

- bootstrap consumes one grouped runtime support model instead of re-deriving meaning from unrelated raw booleans
- the remaining awkward planner/profile names are cleaned up (`Resolved`, `RuntimeBehavior`, `canHostPlugins`, `HostnameEgressDelivery`)
- admin runtime inspection shows only the operator-meaningful view instead of both the raw transport bag and the derived profile
- runtime providers now have one supported contract instead of a primary model plus compatibility path

Validation:

- `cd gestaltd && go test ./internal/pluginruntime ./internal/bootstrap ./internal/server -count=1`
- `cd gestaltd && golangci-lint run ./internal/pluginruntime ./internal/bootstrap ./internal/server`
- `cd sdk/go && go test ./...`
- `cd docs && npm run build`
