### PR TITLE
Allow agent providers to bind IndexedDB

### DIFF
--- a/docs/content/configuration.mdx
+++ b/docs/content/configuration.mdx
@@ -554,6 +554,12 @@ providers:
     openai:
       source: ./providers/agent/openai/manifest.yaml
       default: true
+      indexeddb:
+        provider: default
+        db: agent_openai
+        objectStores:
+          - runs
+          - run_idempotency
       config:
         model: gpt-5.4
         apiKey:
@@ -574,9 +580,9 @@ providers:
 Agent providers receive neutral run requests with `messages`, optional tools,
 optional structured-output schema, and optional `sessionRef`. The same
 provider pool is used by the global agent runs API/CLI and by plugins that use
-the host agent manager surface. In V1 there is no standardized storage binding
-for agent providers, so provider-owned persistence should be declared in the
-provider's own `config`.
+the host agent manager surface. Providers that need durable state can opt into
+a host IndexedDB binding with `indexeddb` and use the SDK IndexedDB helper
+against `GESTALT_INDEXEDDB_SOCKET`.
 
 See [Agent](/providers/agent) for the provider model and
 [Custom Providers > Agent](/custom-providers/agent) if you need to implement

--- a/docs/content/providers/agent.mdx
+++ b/docs/content/providers/agent.mdx
@@ -38,6 +38,12 @@ providers:
     openai:
       source: ./providers/agent/openai/manifest.yaml
       default: true
+      indexeddb:
+        provider: default
+        db: agent_openai
+        objectStores:
+          - runs
+          - run_idempotency
       config:
         model: gpt-5.4
         baseURL: https://api.openai.com/v1
@@ -58,6 +64,11 @@ providers:
 
 If exactly one agent provider is configured, or one is marked `default: true`,
 then run requests may omit `provider`.
+
+If an agent provider needs durable state, configure `indexeddb` on that
+provider entry. Gestalt exposes the selected store to the provider process as
+the standard SDK `GESTALT_INDEXEDDB_SOCKET`; the provider still owns its run
+record schema and object-store names.
 
 ## Request shape
 
@@ -84,10 +95,6 @@ The neutral agent run shape is intentionally small:
   "sessionRef": "session-123"
 }
 ```
-
-In V1 there is no standardized host IndexedDB or general storage binding for
-agent providers. If a backend needs durable state, define that in the
-provider's own `config` schema.
 
 ## First-party agent providers
 

--- a/docs/content/reference/config-file.mdx
+++ b/docs/content/reference/config-file.mdx
@@ -482,6 +482,12 @@ providers:
     openai:
       source: ./providers/agent/openai/manifest.yaml
       default: true
+      indexeddb:
+        provider: default
+        db: agent_openai
+        objectStores:
+          - runs
+          - run_idempotency
       config:
         model: gpt-5.4
         baseURL: https://api.openai.com/v1
@@ -502,15 +508,16 @@ providers:
 
 Agent providers receive neutral run requests with `messages`, optional
 resolved `tools`, optional `responseSchema`, optional `sessionRef`, and
-provider-specific `config`. In V1 there is no standardized host IndexedDB or
-other storage binding for agent providers. If an agent backend needs durable
-state, define that in the provider's own `config` schema.
+provider-specific `config`. Agent providers that need durable state can opt
+into a host IndexedDB binding with `indexeddb`; the provider process then uses
+the SDK IndexedDB helper against `GESTALT_INDEXEDDB_SOCKET`.
 
 | Field | Description |
 | --- | --- |
 | `default` | Marks this named agent entry as the default selection when a run request omits `provider`. |
 | `source` | Either a local provider manifest path, a published `provider-release.yaml` metadata URL, or `source.githubRelease` for a GitHub-hosted release asset. |
 | `auth` | Optional inline source auth for remote release sources, including direct metadata URLs and `source.githubRelease`. |
+| `indexeddb` | Optional agent IndexedDB config. `indexeddb.provider` selects the named `providers.indexeddb` entry backing the agent's single IndexedDB SDK socket; unlike plugins, agents do not inherit the selected/default host IndexedDB automatically. `indexeddb.db` overrides the provider-visible database name and defaults to the agent provider key. `indexeddb.objectStores` optionally allowlists logical object stores the agent may use. |
 | `config` | Provider-specific config passed into the agent provider. |
 | `env` | Extra environment variables passed to the provider process. |
 | `allowedHosts` | Outbound host allowlist. For executable providers, this is only a complete boundary when a supported sandboxed runtime is active. |

--- a/gestaltd/internal/bootstrap/bootstrap.go
+++ b/gestaltd/internal/bootstrap/bootstrap.go
@@ -361,6 +361,24 @@ func (p *workflowProviderWithCleanup) Close() error {
 	return errors.Join(errs...)
 }
 
+type agentProviderWithCleanup struct {
+	coreagent.Provider
+	cleanup func()
+}
+
+func (p *agentProviderWithCleanup) Close() error {
+	var errs []error
+	if p != nil && p.Provider != nil {
+		if err := p.Provider.Close(); err != nil {
+			errs = append(errs, err)
+		}
+	}
+	if p != nil && p.cleanup != nil {
+		p.cleanup()
+	}
+	return errors.Join(errs...)
+}
+
 type agentProviderWithTracking struct {
 	delegate     coreagent.Provider
 	providerName string
@@ -1424,13 +1442,40 @@ func buildAgent(ctx context.Context, name string, entry *config.ProviderEntry, f
 			proto.RegisterAgentHostServer(srv, providerhost.NewAgentHostServer(name, deps.AgentRuntime.ExecuteTool))
 		},
 	}}
+	var cleanup func()
+	defer func() {
+		if cleanup != nil {
+			cleanup()
+		}
+	}()
+	effectiveIndexedDB, err := config.ResolveEffectiveAgentIndexedDB(name, entry, deps.IndexedDBDefs)
+	if err != nil {
+		return nil, fmt.Errorf("agent provider: %w", err)
+	}
+	if effectiveIndexedDB.Enabled {
+		indexedDBHostServices, indexedDBCleanup, err := buildAgentIndexedDBHostServices(name, effectiveIndexedDB, deps)
+		if err != nil {
+			return nil, fmt.Errorf("agent provider: %w", err)
+		}
+		hostServices = append(hostServices, indexedDBHostServices...)
+		cleanup = chainCleanup(cleanup, indexedDBCleanup)
+	}
 	provider, err := factories.Agent(ctx, name, node, hostServices, deps)
 	if err != nil {
 		return nil, fmt.Errorf("agent provider: %w", err)
 	}
-	return &agentProviderWithTracking{
+	tracked := &agentProviderWithTracking{
 		delegate:     provider,
 		providerName: name,
 		runtime:      deps.AgentRuntime,
-	}, nil
+	}
+	if cleanup != nil {
+		provider := &agentProviderWithCleanup{
+			Provider: tracked,
+			cleanup:  cleanup,
+		}
+		cleanup = nil
+		return provider, nil
+	}
+	return tracked, nil
 }

--- a/gestaltd/internal/bootstrap/bootstrap_test.go
+++ b/gestaltd/internal/bootstrap/bootstrap_test.go
@@ -2030,6 +2030,101 @@ func TestBootstrapPassesIndexedDBHostSocketToWorkflowProviders(t *testing.T) {
 	}
 }
 
+func TestBootstrapPassesIndexedDBHostSocketToAgentProviders(t *testing.T) {
+	t.Parallel()
+
+	cfg := validConfig()
+	cfg.Providers.IndexedDB["agent_state"] = &config.ProviderEntry{Source: config.ProviderSource{Path: "stub"}}
+	cfg.Providers.Agent = map[string]*config.ProviderEntry{
+		"simple": {
+			Source: config.ProviderSource{Path: "stub"},
+			IndexedDB: &config.PluginIndexedDBConfig{
+				Provider:     "agent_state",
+				DB:           "agent_simple",
+				ObjectStores: []string{"runs"},
+			},
+		},
+	}
+
+	factories := validFactories()
+	var (
+		boundDB      *trackedIndexedDB
+		hostServices []providerhost.HostService
+	)
+	factories.IndexedDB = func(yaml.Node) (indexeddb.IndexedDB, error) {
+		boundDB = &trackedIndexedDB{StubIndexedDB: &coretesting.StubIndexedDB{}}
+		return boundDB, nil
+	}
+	factories.Agent = func(_ context.Context, _ string, _ yaml.Node, services []providerhost.HostService, _ bootstrap.Deps) (coreagent.Provider, error) {
+		hostServices = append([]providerhost.HostService(nil), services...)
+		return &stubAgentProvider{}, nil
+	}
+
+	result, err := bootstrap.Bootstrap(context.Background(), cfg, factories)
+	if err != nil {
+		t.Fatalf("Bootstrap: %v", err)
+	}
+	defer func() { _ = result.Close(context.Background()) }()
+	<-result.ProvidersReady
+
+	if len(hostServices) != 2 {
+		t.Fatalf("agent host services = %d, want 2", len(hostServices))
+	}
+	if hostServices[0].EnvVar != providerhost.DefaultAgentHostSocketEnv {
+		t.Fatalf("agent host env = %q, want %q", hostServices[0].EnvVar, providerhost.DefaultAgentHostSocketEnv)
+	}
+	if hostServices[1].EnvVar != providerhost.DefaultIndexedDBSocketEnv {
+		t.Fatalf("agent indexeddb env = %q, want %q", hostServices[1].EnvVar, providerhost.DefaultIndexedDBSocketEnv)
+	}
+
+	withIndexedDBHostClient(t, hostServices[1], func(client proto.IndexedDBClient) {
+		if _, err := client.CreateObjectStore(context.Background(), &proto.CreateObjectStoreRequest{
+			Name:   "runs",
+			Schema: &proto.ObjectStoreSchema{},
+		}); err != nil {
+			t.Fatalf("CreateObjectStore(runs): %v", err)
+		}
+		record, err := gestalt.RecordToProto(gestalt.Record{"id": "run-1", "status": "running"})
+		if err != nil {
+			t.Fatalf("RecordToProto: %v", err)
+		}
+		if _, err := client.Put(context.Background(), &proto.RecordRequest{
+			Store:  "runs",
+			Record: record,
+		}); err != nil {
+			t.Fatalf("Put(runs): %v", err)
+		}
+		resp, err := client.Get(context.Background(), &proto.ObjectStoreRequest{
+			Store: "runs",
+			Id:    "run-1",
+		})
+		if err != nil {
+			t.Fatalf("Get(runs): %v", err)
+		}
+		got, err := gestalt.RecordFromProto(resp.GetRecord())
+		if err != nil {
+			t.Fatalf("RecordFromProto: %v", err)
+		}
+		if got["status"] != "running" {
+			t.Fatalf("status = %#v, want %q", got["status"], "running")
+		}
+
+		if _, err := client.CreateObjectStore(context.Background(), &proto.CreateObjectStoreRequest{
+			Name:   "sessions",
+			Schema: &proto.ObjectStoreSchema{},
+		}); err == nil {
+			t.Fatal("CreateObjectStore(sessions) succeeded, want allowlist failure")
+		}
+	})
+
+	if _, err := boundDB.ObjectStore("agent_simple_runs").Get(context.Background(), "run-1"); err != nil {
+		t.Fatalf("prefixed backing store should contain run: %v", err)
+	}
+	if _, err := boundDB.ObjectStore("runs").Get(context.Background(), "run-1"); err == nil {
+		t.Fatal("unprefixed backing store should remain empty")
+	}
+}
+
 func TestBootstrapPassesIndexedDBHostSocketsToAuthorizationProviders(t *testing.T) {
 	t.Parallel()
 

--- a/gestaltd/internal/bootstrap/provider_build.go
+++ b/gestaltd/internal/bootstrap/provider_build.go
@@ -1436,6 +1436,29 @@ func buildWorkflowIndexedDBHostServices(name string, effective config.EffectiveW
 	}, nil
 }
 
+func buildAgentIndexedDBHostServices(name string, effective config.EffectiveAgentIndexedDB, deps Deps) ([]providerhost.HostService, func(), error) {
+	if deps.IndexedDBFactory == nil || len(deps.IndexedDBDefs) == 0 {
+		return nil, nil, fmt.Errorf("indexeddb host services are not available")
+	}
+
+	ds, err := buildAgentScopedIndexedDB(name, effective, deps)
+	if err != nil {
+		return nil, nil, err
+	}
+
+	hostServices := []providerhost.HostService{{
+		EnvVar: providerhost.DefaultIndexedDBSocketEnv,
+		Register: func(srv *grpc.Server) {
+			proto.RegisterIndexedDBServer(srv, providerhost.NewIndexedDBServer(ds, name, providerhost.IndexedDBServerOptions{
+				AllowedStores: effective.ObjectStores,
+			}))
+		},
+	}}
+	return hostServices, func() {
+		_ = closeIndexedDBs(ds)
+	}, nil
+}
+
 func buildPluginWorkflowManagerHostService(pluginName string, deps Deps, tokens *providerhost.InvocationTokenManager) providerhost.HostService {
 	manager := deps.WorkflowManager
 	if manager == nil {
@@ -1602,6 +1625,15 @@ func buildPluginScopedIndexedDB(pluginName string, effective config.EffectivePlu
 }
 
 func buildWorkflowScopedIndexedDB(name string, effective config.EffectiveWorkflowIndexedDB, deps Deps) (indexeddb.IndexedDB, error) {
+	return buildScopedIndexedDB(scopedIndexedDBBuildOptions{
+		MetricsName:   name,
+		ProviderName:  effective.ProviderName,
+		DB:            effective.DB,
+		AllowedStores: effective.ObjectStores,
+	}, deps)
+}
+
+func buildAgentScopedIndexedDB(name string, effective config.EffectiveAgentIndexedDB, deps Deps) (indexeddb.IndexedDB, error) {
 	return buildScopedIndexedDB(scopedIndexedDBBuildOptions{
 		MetricsName:   name,
 		ProviderName:  effective.ProviderName,

--- a/gestaltd/internal/config/config_test.go
+++ b/gestaltd/internal/config/config_test.go
@@ -3311,6 +3311,52 @@ server:
 		}
 	})
 
+	t.Run("agent provider accepts indexeddb bindings", func(t *testing.T) {
+		t.Parallel()
+
+		path := mustWriteConfigFile(t, `
+providers:
+  agent:
+    simple:
+      source:
+        path: ./providers/agent/simple
+      indexeddb:
+        provider: agent_state
+        db: agent_simple
+        objectStores:
+          - runs
+          - run_idempotency
+  indexeddb:
+    agent_state:
+      source:
+        path: ./providers/datastore/sqlite
+server:
+  providers:
+    indexeddb: agent_state
+  encryptionKey: server-key
+`)
+
+		cfg, err := Load(path)
+		if err != nil {
+			t.Fatalf("Load: %v", err)
+		}
+		want := &PluginIndexedDBConfig{
+			Provider:     "agent_state",
+			DB:           "agent_simple",
+			ObjectStores: []string{"runs", "run_idempotency"},
+		}
+		if got := cfg.Providers.Agent["simple"].IndexedDB; !reflect.DeepEqual(got, want) {
+			t.Fatalf("Providers.Agent[simple].IndexedDB = %#v, want %#v", got, want)
+		}
+		effective, err := cfg.EffectiveAgentIndexedDB("simple", cfg.Providers.Agent["simple"])
+		if err != nil {
+			t.Fatalf("EffectiveAgentIndexedDB: %v", err)
+		}
+		if effective.ProviderName != "agent_state" || effective.DB != "agent_simple" {
+			t.Fatalf("effective = %#v", effective)
+		}
+	})
+
 	t.Run("rejects unknown indexeddb bindings on workflow providers", func(t *testing.T) {
 		t.Parallel()
 
@@ -3337,6 +3383,36 @@ server:
 			t.Fatal("Load: expected error, got nil")
 		}
 		if !strings.Contains(err.Error(), `providers.workflow.basic.indexeddb.provider references unknown indexeddb "missing"`) {
+			t.Fatalf("unexpected error: %v", err)
+		}
+	})
+
+	t.Run("rejects unknown indexeddb bindings on agent providers", func(t *testing.T) {
+		t.Parallel()
+
+		path := mustWriteConfigFile(t, `
+providers:
+  agent:
+    simple:
+      source:
+        path: ./providers/agent/simple
+      indexeddb:
+        provider: missing
+  indexeddb:
+    agent_state:
+      source:
+        path: ./providers/datastore/sqlite
+server:
+  providers:
+    indexeddb: agent_state
+  encryptionKey: server-key
+`)
+
+		_, err := Load(path)
+		if err == nil {
+			t.Fatal("Load: expected error, got nil")
+		}
+		if !strings.Contains(err.Error(), `providers.agent.simple.indexeddb.provider references unknown indexeddb "missing"`) {
 			t.Fatalf("unexpected error: %v", err)
 		}
 	})

--- a/gestaltd/internal/config/config_validate.go
+++ b/gestaltd/internal/config/config_validate.go
@@ -649,7 +649,14 @@ func validateAgentConfig(cfg *Config) error {
 		if entry.Default {
 			defaults = append(defaults, name)
 		}
-		if err := validateAgentProviderFields(name, entry); err != nil {
+		if entry.IndexedDB != nil {
+			entry.IndexedDB.Provider = strings.TrimSpace(entry.IndexedDB.Provider)
+			entry.IndexedDB.DB = strings.TrimSpace(entry.IndexedDB.DB)
+			for i, store := range entry.IndexedDB.ObjectStores {
+				entry.IndexedDB.ObjectStores[i] = strings.TrimSpace(store)
+			}
+		}
+		if err := validateAgentProviderFields(cfg, name, entry); err != nil {
 			return err
 		}
 		if err := validateProviderEntrySource("agent", name, entry, sourceSyntax); err != nil {
@@ -663,7 +670,7 @@ func validateAgentConfig(cfg *Config) error {
 	return nil
 }
 
-func validateAgentProviderFields(name string, entry *ProviderEntry) error {
+func validateAgentProviderFields(cfg *Config, name string, entry *ProviderEntry) error {
 	if entry == nil {
 		return nil
 	}
@@ -676,9 +683,6 @@ func validateAgentProviderFields(name string, entry *ProviderEntry) error {
 	}
 	if strings.TrimSpace(entry.UI) != "" {
 		return fmt.Errorf("config validation: %s.ui is only supported on plugins.*", subject)
-	}
-	if entry.IndexedDB != nil {
-		return fmt.Errorf("config validation: %s.indexeddb is not supported", subject)
 	}
 	if len(entry.Cache) > 0 {
 		return fmt.Errorf("config validation: %s.cache is only supported on plugins.*", subject)
@@ -697,6 +701,23 @@ func validateAgentProviderFields(name string, entry *ProviderEntry) error {
 	}
 	if entry.AuthorizationPolicy != "" {
 		return fmt.Errorf("config validation: %s.authorizationPolicy is only supported on plugins.* and ui.*", subject)
+	}
+	if entry.IndexedDB == nil {
+		return nil
+	}
+
+	seenStores := make(map[string]struct{}, len(entry.IndexedDB.ObjectStores))
+	for i, store := range entry.IndexedDB.ObjectStores {
+		if store == "" {
+			return fmt.Errorf("config validation: %s.indexeddb.objectStores[%d] is required", subject, i)
+		}
+		if _, exists := seenStores[store]; exists {
+			return fmt.Errorf("config validation: %s.indexeddb.objectStores[%d] duplicates %q", subject, i, store)
+		}
+		seenStores[store] = struct{}{}
+	}
+	if _, err := cfg.EffectiveAgentIndexedDB(name, entry); err != nil {
+		return err
 	}
 	return nil
 }

--- a/gestaltd/internal/config/provider_selection.go
+++ b/gestaltd/internal/config/provider_selection.go
@@ -120,6 +120,14 @@ type EffectiveWorkflowIndexedDB struct {
 	ObjectStores []string
 }
 
+type EffectiveAgentIndexedDB struct {
+	Enabled      bool
+	ProviderName string
+	Provider     *ProviderEntry
+	DB           string
+	ObjectStores []string
+}
+
 type EffectivePluginRuntime struct {
 	Enabled      bool
 	ProviderName string
@@ -169,6 +177,10 @@ func (c *Config) EffectiveAgentProvider(providerName string) (string, *ProviderE
 
 func (c *Config) EffectiveWorkflowIndexedDB(name string, entry *ProviderEntry) (EffectiveWorkflowIndexedDB, error) {
 	return ResolveEffectiveWorkflowIndexedDB(name, entry, c.Providers.IndexedDB)
+}
+
+func (c *Config) EffectiveAgentIndexedDB(name string, entry *ProviderEntry) (EffectiveAgentIndexedDB, error) {
+	return ResolveEffectiveAgentIndexedDB(name, entry, c.Providers.IndexedDB)
 }
 
 func (c *Config) EffectivePluginRuntime(pluginName string, entry *ProviderEntry) (EffectivePluginRuntime, error) {
@@ -243,6 +255,35 @@ func ResolveEffectiveWorkflowIndexedDB(name string, entry *ProviderEntry, entrie
 	}
 
 	return EffectiveWorkflowIndexedDB{
+		Enabled:      true,
+		ProviderName: providerName,
+		Provider:     provider,
+		DB:           dbName,
+		ObjectStores: slices.Clone(entry.IndexedDB.ObjectStores),
+	}, nil
+}
+
+func ResolveEffectiveAgentIndexedDB(name string, entry *ProviderEntry, entries map[string]*ProviderEntry) (EffectiveAgentIndexedDB, error) {
+	if entry == nil || entry.IndexedDB == nil {
+		return EffectiveAgentIndexedDB{}, nil
+	}
+
+	providerName := strings.TrimSpace(entry.IndexedDB.Provider)
+	if providerName == "" {
+		return EffectiveAgentIndexedDB{}, fmt.Errorf("config validation: providers.agent.%s.indexeddb.provider is required", name)
+	}
+
+	provider, ok := entries[providerName]
+	if !ok || provider == nil {
+		return EffectiveAgentIndexedDB{}, fmt.Errorf("config validation: providers.agent.%s.indexeddb.provider references unknown indexeddb %q", name, providerName)
+	}
+
+	dbName := strings.TrimSpace(entry.IndexedDB.DB)
+	if dbName == "" {
+		dbName = name
+	}
+
+	return EffectiveAgentIndexedDB{
 		Enabled:      true,
 		ProviderName: providerName,
 		Provider:     provider,


### PR DESCRIPTION
Agent providers can now opt into the same host-owned IndexedDB socket pattern
used by workflow providers. This is needed by durable agent providers such as
`agent/simple`: the provider owns its object-store schema, while `gestaltd`
selects the backing IndexedDB provider, scopes the DB name, enforces the
optional object-store allowlist, and exposes `GESTALT_INDEXEDDB_SOCKET` to the
agent process.

## New interfaces

YAML
```yaml
providers:
  indexeddb:
    default:
      source: ./providers/indexeddb/relationaldb/manifest.yaml
      config:
        dsn: sqlite:///var/lib/gestalt/state.db

  agent:
    simple:
      source: ./providers/agent/simple/manifest.yaml
      default: true
      indexeddb:
        provider: default
        db: agent_simple
        objectStores:
          - runs
          - run_idempotency
      config:
        defaultModel: fast
```

Provider environment
```text
GESTALT_AGENT_HOST_SOCKET=/tmp/gestalt-agent-host.sock
GESTALT_INDEXEDDB_SOCKET=/tmp/gestalt-indexeddb.sock
```

Golang config resolution
```go
effective, err := cfg.EffectiveAgentIndexedDB("simple", cfg.Providers.Agent["simple"])
if err != nil {
    return err
}
fmt.Println(effective.ProviderName, effective.DB, effective.ObjectStores)
```

Provider SDK usage
```python
import gestalt

store = gestalt.IndexedDB().object_store("runs")
store.add({"id": "run_01", "status": "running"})
```

## Validation
- `go test ./internal/config`
- `go test ./internal/bootstrap`
- `go test ./internal/providerhost`
- `go test ./internal/coredata`
- `go test ./cmd/gestaltd`
