### PR TITLE
Add platform telemetry dimensions

### DIFF
--- a/docs/content/observability.mdx
+++ b/docs/content/observability.mdx
@@ -335,41 +335,43 @@ API traffic, health and readiness checks, the embedded admin UI, and scrapes of
 
 These metrics use standard OpenTelemetry HTTP server semantic attributes such as
 request method, response status, scheme, host, protocol, and route information
-when available.
+when available. Gestalt also attaches stable dimensions for request surfaces it
+can resolve, including `gestalt.provider`, `gestalt.operation`,
+`gestalt.transport`, `gestalt.connection_mode`, `gestalt.invocation_surface`,
+`gestalt.http_binding`, and `gestalt.ui`.
 
 If the process is started with
 `OTEL_SEMCONV_STABILITY_OPT_IN=http/dup`, the underlying HTTP instrumentation
 also emits the older legacy HTTP metric families alongside the current ones.
 
-### Provider gRPC Client Metrics
+### Provider gRPC Metrics
 
-These come from the OpenTelemetry gRPC client stats handler used for outbound
-gRPC traffic from `gestaltd` to provider processes. They only apply to
-provider-backed components.
+These come from OpenTelemetry gRPC stats handlers used for provider and host
+service traffic. They only apply to provider-backed components.
 
 <Tabs items={['OpenTelemetry', 'Prometheus']}>
   <Tabs.Tab>
     | Metric | Type | Meaning |
     | --- | --- | --- |
-    | `rpc.client.duration` | Histogram | Outbound provider RPC duration |
-    | `rpc.client.request.size` | Histogram | Outbound provider request message size |
-    | `rpc.client.response.size` | Histogram | Inbound plugin response message size |
-    | `rpc.client.requests_per_rpc` | Histogram | Request messages per RPC |
-    | `rpc.client.responses_per_rpc` | Histogram | Response messages per RPC |
+    | `rpc.client.call.duration` | Histogram | Outbound provider RPC duration |
+    | `rpc.server.call.duration` | Histogram | Inbound provider or host-service RPC duration |
   </Tabs.Tab>
   <Tabs.Tab>
     | Metric | Type | Meaning |
     | --- | --- | --- |
-    | `rpc_client_duration_milliseconds` | Histogram | Outbound plugin RPC duration |
-    | `rpc_client_request_size_bytes` | Histogram | Outbound plugin request message size |
-    | `rpc_client_response_size_bytes` | Histogram | Inbound plugin response message size |
-    | `rpc_client_requests_per_rpc` | Histogram | Request messages per RPC |
-    | `rpc_client_responses_per_rpc` | Histogram | Response messages per RPC |
+    | `rpc_client_call_duration_seconds` | Histogram | Outbound plugin RPC duration |
+    | `rpc_server_call_duration_seconds` | Histogram | Inbound provider or host-service RPC duration |
   </Tabs.Tab>
 </Tabs>
 
-These metrics use standard OpenTelemetry gRPC client semantic attributes such as
-`rpc.system=grpc`, `rpc.service`, and `rpc.method`.
+These metrics use standard OpenTelemetry gRPC semantic attributes such as
+`rpc.system.name=grpc`, `rpc.method`, and `rpc.response.status_code`. Gestalt
+also attaches `gestalt.rpc.role`, `gestalt.provider`, and
+`gestalt.host_service` when it can resolve them.
+
+If the process is started with `OTEL_SEMCONV_STABILITY_OPT_IN=rpc/dup`, the
+underlying gRPC instrumentation also emits legacy RPC metric families such as
+`rpc.client.duration` alongside the current ones.
 
 ## Prometheus Scrape Endpoint
 

--- a/gestaltd/.golangci.yml
+++ b/gestaltd/.golangci.yml
@@ -53,6 +53,11 @@ linters:
         linters:
           - gocritic
           - revive
+      # golangci-lint v2.11.3 reports false unused findings for helper types
+      # in this large integration test file on Linux CI.
+      - path: internal/server/server_test\.go
+        linters:
+          - unused
       # Test helper packages: relaxed style and errcheck for deferred Close
       - path: core/testing/
         linters:

--- a/gestaltd/internal/bootstrap/bootstrap.go
+++ b/gestaltd/internal/bootstrap/bootstrap.go
@@ -153,6 +153,7 @@ type Deps struct {
 	PluginInvoker         invocation.Invoker
 	PluginRuntime         pluginruntime.Provider
 	PluginRuntimeRegistry *pluginRuntimeRegistry
+	Telemetry             core.TelemetryProvider
 }
 
 type AuthFactory func(node yaml.Node, deps Deps) (core.AuthenticationProvider, error)
@@ -663,6 +664,7 @@ func prepareCore(ctx context.Context, cfg *config.Config, factories *FactoryRegi
 		EncryptionKey: encKey,
 		BaseURL:       cfg.Server.BaseURL,
 		SecretManager: sm,
+		Telemetry:     tp,
 	}
 	workflowRuntime, err := newWorkflowRuntime(cfg)
 	if err != nil {
@@ -1317,6 +1319,7 @@ func buildHostIndexedDBHostServices(selectedName string, indexeddbs map[string]i
 
 func indexedDBHostService(envVar, name string, ds indexeddb.IndexedDB) providerhost.HostService {
 	return providerhost.HostService{
+		Name:   "indexeddb",
 		EnvVar: envVar,
 		Register: func(srv *grpc.Server) {
 			proto.RegisterIndexedDBServer(srv, providerhost.NewIndexedDBServer(ds, name, providerhost.IndexedDBServerOptions{}))
@@ -1384,6 +1387,7 @@ func buildWorkflow(ctx context.Context, name string, entry *config.ProviderEntry
 		}
 	}
 	hostServices := []providerhost.HostService{{
+		Name:   "workflow_host",
 		EnvVar: providerhost.DefaultWorkflowHostSocketEnv,
 		Register: func(srv *grpc.Server) {
 			proto.RegisterWorkflowHostServer(srv, providerhost.NewWorkflowHostServer(name, deps.WorkflowRuntime.Invoke))
@@ -1437,6 +1441,7 @@ func buildAgent(ctx context.Context, name string, entry *config.ProviderEntry, f
 		}
 	}
 	hostServices := []providerhost.HostService{{
+		Name:   "agent_host",
 		EnvVar: providerhost.DefaultAgentHostSocketEnv,
 		Register: func(srv *grpc.Server) {
 			proto.RegisterAgentHostServer(srv, providerhost.NewAgentHostServer(name, deps.AgentRuntime.ExecuteTool))

--- a/gestaltd/internal/bootstrap/plugin_runtime.go
+++ b/gestaltd/internal/bootstrap/plugin_runtime.go
@@ -59,7 +59,7 @@ func (r *pluginRuntimeRegistry) Resolve(ctx context.Context, pluginName string, 
 	var provider pluginruntime.Provider
 	switch effective.Provider.Driver {
 	case config.RuntimeProviderDriverLocal:
-		provider = pluginruntime.NewLocalProvider()
+		provider = pluginruntime.NewLocalProvider(pluginruntime.WithLocalTelemetry(r.deps.Telemetry))
 	default:
 		if factory == nil {
 			return config.EffectivePluginRuntime{}, nil, fmt.Errorf("runtime provider %q is not registered", providerName)

--- a/gestaltd/internal/bootstrap/plugin_runtime_executable.go
+++ b/gestaltd/internal/bootstrap/plugin_runtime_executable.go
@@ -9,7 +9,7 @@ import (
 	"github.com/valon-technologies/gestalt/server/internal/pluginruntime"
 )
 
-func buildExecutablePluginRuntime(ctx context.Context, name string, entry *config.RuntimeProviderEntry, _ Deps) (pluginruntime.Provider, error) {
+func buildExecutablePluginRuntime(ctx context.Context, name string, entry *config.RuntimeProviderEntry, deps Deps) (pluginruntime.Provider, error) {
 	if entry == nil {
 		return nil, fmt.Errorf("runtime provider entry is required")
 	}
@@ -38,5 +38,6 @@ func buildExecutablePluginRuntime(ctx context.Context, name string, entry *confi
 		Config:       runtimeConfig,
 		AllowedHosts: append([]string(nil), entry.AllowedHosts...),
 		HostBinary:   entry.HostBinary,
+		Telemetry:    deps.Telemetry,
 	})
 }

--- a/gestaltd/internal/bootstrap/provider_build.go
+++ b/gestaltd/internal/bootstrap/provider_build.go
@@ -850,7 +850,11 @@ func buildPluginProvider(ctx context.Context, name string, entry *config.Provide
 		return nil, err
 	}
 	cleanup = chainCleanup(cleanup, runtimeCleanup)
-	startedHostServices, err := providerhost.StartHostServices(hostServices)
+	startedHostServices, err := providerhost.StartHostServices(
+		hostServices,
+		providerhost.WithHostServicesProviderName(name),
+		providerhost.WithHostServicesTelemetry(deps.Telemetry),
+	)
 	if err != nil {
 		return nil, fmt.Errorf("start runtime host services: %w", err)
 	}
@@ -904,7 +908,10 @@ func buildPluginProvider(ctx context.Context, name string, entry *config.Provide
 	if err != nil {
 		return nil, fmt.Errorf("start hosted plugin: %w", err)
 	}
-	conn, err := pluginruntime.DialHostedPlugin(ctx, hostedPlugin.DialTarget)
+	conn, err := pluginruntime.DialHostedPlugin(ctx, hostedPlugin.DialTarget,
+		pluginruntime.WithProviderName(name),
+		pluginruntime.WithTelemetry(deps.Telemetry),
+	)
 	if err != nil {
 		return nil, fmt.Errorf("dial hosted plugin: %w", err)
 	}
@@ -950,10 +957,10 @@ func effectivePluginRuntime(ctx context.Context, name string, entry *config.Prov
 			return runtimeConfig, runtimeProvider, false, nil
 		}
 		if runtimeConfig.Enabled {
-			return runtimeConfig, pluginruntime.NewLocalProvider(), true, nil
+			return runtimeConfig, pluginruntime.NewLocalProvider(pluginruntime.WithLocalTelemetry(deps.Telemetry)), true, nil
 		}
 	}
-	return config.EffectivePluginRuntime{}, pluginruntime.NewLocalProvider(), true, nil
+	return config.EffectivePluginRuntime{}, pluginruntime.NewLocalProvider(pluginruntime.WithLocalTelemetry(deps.Telemetry)), true, nil
 }
 
 const (
@@ -1327,6 +1334,7 @@ func buildPluginIndexedDBHostServices(pluginName string, effective config.Effect
 	}
 
 	hostServices := []providerhost.HostService{{
+		Name:   "indexeddb",
 		EnvVar: providerhost.DefaultIndexedDBSocketEnv,
 		Register: func(srv *grpc.Server) {
 			proto.RegisterIndexedDBServer(srv, providerhost.NewIndexedDBServer(ds, pluginName, providerhost.IndexedDBServerOptions{
@@ -1359,6 +1367,7 @@ func buildPluginCacheHostServices(pluginName string, entry *config.ProviderEntry
 		}
 		boundCaches = append(boundCaches, value)
 		hostServices = append(hostServices, providerhost.HostService{
+			Name:   "cache",
 			EnvVar: providerhost.CacheSocketEnv(bindingName),
 			Register: func(cacheValue corecache.Cache) func(*grpc.Server) {
 				return func(srv *grpc.Server) {
@@ -1370,6 +1379,7 @@ func buildPluginCacheHostServices(pluginName string, entry *config.ProviderEntry
 	if len(boundCaches) == 1 {
 		value := boundCaches[0]
 		hostServices = append(hostServices, providerhost.HostService{
+			Name:   "cache",
 			EnvVar: providerhost.DefaultCacheSocketEnv,
 			Register: func(srv *grpc.Server) {
 				proto.RegisterCacheServer(srv, providerhost.NewCacheServer(value, pluginName))
@@ -1393,6 +1403,7 @@ func buildPluginS3HostServices(pluginName string, entry *config.ProviderEntry, d
 			return nil, fmt.Errorf("s3 %q is not available", binding)
 		}
 		hostServices = append(hostServices, providerhost.HostService{
+			Name:   "s3",
 			EnvVar: providerhost.S3SocketEnv(binding),
 			Register: func(client s3store.Client) func(*grpc.Server) {
 				return func(srv *grpc.Server) {
@@ -1404,6 +1415,7 @@ func buildPluginS3HostServices(pluginName string, entry *config.ProviderEntry, d
 	if len(entry.S3) == 1 {
 		client := deps.S3[entry.S3[0]]
 		hostServices = append(hostServices, providerhost.HostService{
+			Name:   "s3",
 			EnvVar: providerhost.DefaultS3SocketEnv,
 			Register: func(srv *grpc.Server) {
 				proto.RegisterS3Server(srv, providerhost.NewS3Server(client, pluginName))
@@ -1424,6 +1436,7 @@ func buildWorkflowIndexedDBHostServices(name string, effective config.EffectiveW
 	}
 
 	hostServices := []providerhost.HostService{{
+		Name:   "indexeddb",
 		EnvVar: providerhost.DefaultIndexedDBSocketEnv,
 		Register: func(srv *grpc.Server) {
 			proto.RegisterIndexedDBServer(srv, providerhost.NewIndexedDBServer(ds, name, providerhost.IndexedDBServerOptions{
@@ -1465,6 +1478,7 @@ func buildPluginWorkflowManagerHostService(pluginName string, deps Deps, tokens 
 		manager = unavailableWorkflowManager{}
 	}
 	return providerhost.HostService{
+		Name:   "workflow_manager",
 		EnvVar: providerhost.DefaultWorkflowManagerSocketEnv,
 		Register: func(srv *grpc.Server) {
 			proto.RegisterWorkflowManagerHostServer(srv, providerhost.NewWorkflowManagerServer(pluginName, manager, tokens))
@@ -1478,6 +1492,7 @@ func buildPluginAgentManagerHostService(pluginName string, deps Deps, tokens *pr
 		manager = unavailableAgentManager{}
 	}
 	return providerhost.HostService{
+		Name:   "agent_manager",
 		EnvVar: providerhost.DefaultAgentManagerSocketEnv,
 		Register: func(srv *grpc.Server) {
 			proto.RegisterAgentManagerHostServer(srv, providerhost.NewAgentManagerServer(pluginName, manager, tokens))
@@ -1487,6 +1502,7 @@ func buildPluginAgentManagerHostService(pluginName string, deps Deps, tokens *pr
 
 func buildPluginAuthorizationHostService(provider core.AuthorizationProvider) providerhost.HostService {
 	return providerhost.HostService{
+		Name:   "authorization",
 		EnvVar: providerhost.DefaultAuthorizationSocketEnv,
 		Register: func(srv *grpc.Server) {
 			proto.RegisterAuthorizationProviderServer(srv, providerhost.NewAuthorizationProviderServer(provider))
@@ -1500,6 +1516,7 @@ func buildPluginInvokerHostService(pluginName string, entry *config.ProviderEntr
 		invoker = unavailablePluginInvoker{}
 	}
 	return providerhost.HostService{
+		Name:   "plugin_invoker",
 		EnvVar: providerhost.DefaultPluginInvokerSocketEnv,
 		Register: func(srv *grpc.Server) {
 			proto.RegisterPluginInvokerServer(srv, providerhost.NewPluginInvokerServer(pluginName, entry.Invokes, invoker, tokens))

--- a/gestaltd/internal/drivers/telemetry/stdout/stdout_test.go
+++ b/gestaltd/internal/drivers/telemetry/stdout/stdout_test.go
@@ -1,0 +1,81 @@
+package stdout
+
+import (
+	"context"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+)
+
+func TestPrometheusResourceMetricsIncludeEnvDefaultsAndPreserveExplicitAttrs(t *testing.T) {
+	t.Setenv("OTEL_SERVICE_VERSION", "env-version")
+	t.Setenv("GIT_COMMIT_SHA", "env-sha")
+	t.Setenv("K_SERVICE", "toolshed-test")
+	t.Setenv("K_REVISION", "toolshed-rev-1")
+	t.Setenv("K_CONFIGURATION", "toolshed-config")
+
+	envBody := scrapeProviderMetrics(t, yamlConfig{ServiceName: "env-tools"})
+	for _, want := range []string{
+		`service_name="env-tools"`,
+		`service_version="env-version"`,
+		`git_commit_sha="env-sha"`,
+		`cloud_provider="gcp"`,
+		`cloud_platform="gcp_cloud_run"`,
+		`faas_name="toolshed-test"`,
+		`faas_version="toolshed-rev-1"`,
+		`gcp_cloud_run_configuration_name="toolshed-config"`,
+	} {
+		if !strings.Contains(envBody, want) {
+			t.Fatalf("Prometheus metrics missing %s:\n%s", want, envBody)
+		}
+	}
+
+	explicitBody := scrapeProviderMetrics(t, yamlConfig{
+		ServiceName: "valon-tools",
+		ResourceAttributes: map[string]string{
+			"service.version": "configured-version",
+			"git.commit.sha":  "configured-sha",
+		},
+	})
+	for _, want := range []string{
+		`target_info`,
+		`service_name="valon-tools"`,
+		`service_version="configured-version"`,
+		`git_commit_sha="configured-sha"`,
+		`cloud_provider="gcp"`,
+		`cloud_platform="gcp_cloud_run"`,
+	} {
+		if !strings.Contains(explicitBody, want) {
+			t.Fatalf("Prometheus metrics missing %s:\n%s", want, explicitBody)
+		}
+	}
+	for _, unexpected := range []string{
+		`service_version="env-version"`,
+		`git_commit_sha="env-sha"`,
+	} {
+		if strings.Contains(explicitBody, unexpected) {
+			t.Fatalf("Prometheus metrics unexpectedly include %s:\n%s", unexpected, explicitBody)
+		}
+	}
+}
+
+func scrapeProviderMetrics(t *testing.T, cfg yamlConfig) string {
+	t.Helper()
+
+	p, err := New(cfg)
+	if err != nil {
+		t.Fatalf("New telemetry provider: %v", err)
+	}
+	t.Cleanup(func() { _ = p.Shutdown(context.Background()) })
+
+	counter, err := p.MeterProvider().Meter("resource-test").Int64Counter("resource_test_counter")
+	if err != nil {
+		t.Fatalf("create counter: %v", err)
+	}
+	counter.Add(context.Background(), 1)
+
+	rec := httptest.NewRecorder()
+	p.PrometheusHandler().ServeHTTP(rec, httptest.NewRequest(http.MethodGet, "/metrics", nil))
+	return rec.Body.String()
+}

--- a/gestaltd/internal/drivers/telemetry/telemetryutil/resource.go
+++ b/gestaltd/internal/drivers/telemetry/telemetryutil/resource.go
@@ -1,6 +1,9 @@
 package telemetryutil
 
 import (
+	"os"
+	"strings"
+
 	"go.opentelemetry.io/otel/attribute"
 	"go.opentelemetry.io/otel/sdk/resource"
 	semconv "go.opentelemetry.io/otel/semconv/v1.26.0"
@@ -12,6 +15,7 @@ func BuildResource(serviceName string, attrs map[string]string) *resource.Resour
 	if serviceName == "" {
 		serviceName = DefaultServiceName
 	}
+	attrs = resourceAttrsWithDefaults(attrs)
 
 	resourceAttrs := []attribute.KeyValue{
 		semconv.ServiceName(serviceName),
@@ -20,4 +24,50 @@ func BuildResource(serviceName string, attrs map[string]string) *resource.Resour
 		resourceAttrs = append(resourceAttrs, attribute.String(k, v))
 	}
 	return resource.NewWithAttributes(semconv.SchemaURL, resourceAttrs...)
+}
+
+func resourceAttrsWithDefaults(attrs map[string]string) map[string]string {
+	merged := make(map[string]string, len(attrs)+6)
+	for k, v := range attrs {
+		merged[k] = v
+	}
+	setDefault := func(key, value string) {
+		if strings.TrimSpace(value) == "" {
+			return
+		}
+		if _, ok := merged[key]; ok {
+			return
+		}
+		merged[key] = value
+	}
+
+	setDefault("service.version", firstEnv(
+		"OTEL_SERVICE_VERSION",
+		"GESTALT_SERVICE_VERSION",
+		"SERVICE_VERSION",
+	))
+	setDefault("git.commit.sha", firstEnv(
+		"GIT_COMMIT_SHA",
+		"GITHUB_SHA",
+		"COMMIT_SHA",
+		"SOURCE_VERSION",
+	))
+
+	if service := strings.TrimSpace(os.Getenv("K_SERVICE")); service != "" {
+		setDefault("cloud.provider", semconv.CloudProviderGCP.Value.AsString())
+		setDefault("cloud.platform", semconv.CloudPlatformGCPCloudRun.Value.AsString())
+		setDefault("faas.name", service)
+		setDefault("faas.version", os.Getenv("K_REVISION"))
+		setDefault("gcp.cloud_run.configuration.name", os.Getenv("K_CONFIGURATION"))
+	}
+	return merged
+}
+
+func firstEnv(keys ...string) string {
+	for _, key := range keys {
+		if value := strings.TrimSpace(os.Getenv(key)); value != "" {
+			return value
+		}
+	}
+	return ""
 }

--- a/gestaltd/internal/invocation/broker.go
+++ b/gestaltd/internal/invocation/broker.go
@@ -32,11 +32,11 @@ const (
 	tracerName            = "gestaltd"
 	graphQLOperationID    = "graphql"
 
-	attrProvider       = attribute.Key("gestalt.provider")
-	attrOperation      = attribute.Key("gestalt.operation")
-	attrTransport      = attribute.Key("gestalt.transport")
+	attrProvider       = metricutil.AttrProvider
+	attrOperation      = metricutil.AttrOperation
+	attrTransport      = metricutil.AttrTransport
 	attrSubjectID      = attribute.Key("gestalt.subject_id")
-	attrConnectionMode = attribute.Key("gestalt.connection_mode")
+	attrConnectionMode = metricutil.AttrConnectionMode
 )
 
 type connectionCtxKey struct{}

--- a/gestaltd/internal/invocation/metrics.go
+++ b/gestaltd/internal/invocation/metrics.go
@@ -54,6 +54,10 @@ func recordOperationMetrics(
 		attrTransport.String(metricutil.AttrValue(transport)),
 		attrConnectionMode.String(metricutil.AttrValue(connectionMode)),
 	}
+	if surface := InvocationSurfaceFromContext(ctx); surface != "" {
+		attrs = append(attrs, metricutil.AttrInvocationSurface.String(metricutil.AttrValue(string(surface))))
+	}
+	metricutil.AddHTTPAttributes(ctx, attrs...)
 
 	metrics.count.Add(ctx, 1, metric.WithAttributes(attrs...))
 	duration := time.Since(startedAt)

--- a/gestaltd/internal/metricutil/attrs.go
+++ b/gestaltd/internal/metricutil/attrs.go
@@ -1,0 +1,74 @@
+package metricutil
+
+import (
+	"context"
+
+	"go.opentelemetry.io/contrib/instrumentation/google.golang.org/grpc/otelgrpc"
+	"go.opentelemetry.io/contrib/instrumentation/net/http/otelhttp"
+	"go.opentelemetry.io/otel/attribute"
+	"go.opentelemetry.io/otel/metric"
+	"go.opentelemetry.io/otel/trace"
+)
+
+const (
+	AttrProvider          = attribute.Key("gestalt.provider")
+	AttrOperation         = attribute.Key("gestalt.operation")
+	AttrTransport         = attribute.Key("gestalt.transport")
+	AttrConnectionMode    = attribute.Key("gestalt.connection_mode")
+	AttrInvocationSurface = attribute.Key("gestalt.invocation_surface")
+	AttrHTTPBinding       = attribute.Key("gestalt.http_binding")
+	AttrUI                = attribute.Key("gestalt.ui")
+	AttrRPCRole           = attribute.Key("gestalt.rpc.role")
+	AttrHostService       = attribute.Key("gestalt.host_service")
+	AttrHTTPRoute         = attribute.Key("http.route")
+)
+
+type TelemetryProviders interface {
+	MeterProvider() metric.MeterProvider
+	TracerProvider() trace.TracerProvider
+}
+
+func AddHTTPAttributes(ctx context.Context, attrs ...attribute.KeyValue) {
+	if len(attrs) == 0 {
+		return
+	}
+	if labeler, ok := otelhttp.LabelerFromContext(ctx); ok {
+		missing := make([]attribute.KeyValue, 0, len(attrs))
+		existing := make(map[attribute.Key]struct{}, len(labeler.Get()))
+		for _, attr := range labeler.Get() {
+			existing[attr.Key] = struct{}{}
+		}
+		for _, attr := range attrs {
+			if _, ok := existing[attr.Key]; ok {
+				continue
+			}
+			missing = append(missing, attr)
+		}
+		if len(missing) > 0 {
+			labeler.Add(missing...)
+		}
+	}
+	span := trace.SpanFromContext(ctx)
+	if span.IsRecording() {
+		span.SetAttributes(attrs...)
+	}
+}
+
+func GRPCOptions(telemetry TelemetryProviders, attrs ...attribute.KeyValue) []otelgrpc.Option {
+	opts := make([]otelgrpc.Option, 0, 4)
+	if telemetry != nil {
+		if mp := telemetry.MeterProvider(); mp != nil {
+			opts = append(opts, otelgrpc.WithMeterProvider(mp))
+		}
+		if tp := telemetry.TracerProvider(); tp != nil {
+			opts = append(opts, otelgrpc.WithTracerProvider(tp))
+		}
+	}
+	if len(attrs) > 0 {
+		opts = append(opts,
+			otelgrpc.WithMetricAttributes(attrs...),
+			otelgrpc.WithSpanAttributes(attrs...),
+		)
+	}
+	return opts
+}

--- a/gestaltd/internal/metricutil/semantic_metrics.go
+++ b/gestaltd/internal/metricutil/semantic_metrics.go
@@ -11,14 +11,14 @@ import (
 const meterName = "gestaltd"
 
 var (
-	attrProvider       = attribute.Key("gestalt.provider")
+	attrProvider       = AttrProvider
 	attrAction         = attribute.Key("gestalt.action")
 	attrDB             = attribute.Key("gestalt.db")
 	attrType           = attribute.Key("gestalt.type")
 	attrMethod         = attribute.Key("gestalt.method")
 	attrObjectStore    = attribute.Key("gestalt.object_store")
 	attrPlugin         = attribute.Key("gestalt.plugin")
-	attrConnectionMode = attribute.Key("gestalt.connection_mode")
+	attrConnectionMode = AttrConnectionMode
 )
 
 type counterMetrics struct {

--- a/gestaltd/internal/pluginruntime/dial.go
+++ b/gestaltd/internal/pluginruntime/dial.go
@@ -10,7 +10,11 @@ import (
 	"strings"
 
 	proto "github.com/valon-technologies/gestalt/sdk/go/gen/v1"
+	"github.com/valon-technologies/gestalt/server/internal/metricutil"
 	"go.opentelemetry.io/contrib/instrumentation/google.golang.org/grpc/otelgrpc"
+	"go.opentelemetry.io/otel/attribute"
+	"go.opentelemetry.io/otel/metric"
+	"go.opentelemetry.io/otel/trace"
 	"google.golang.org/grpc"
 	"google.golang.org/grpc/credentials"
 	"google.golang.org/grpc/credentials/insecure"
@@ -22,7 +26,60 @@ type dialedHostedPluginConn struct {
 	plugin    proto.IntegrationProviderClient
 }
 
-func DialHostedPlugin(ctx context.Context, target string) (HostedPluginConn, error) {
+type DialOption func(*dialConfig)
+
+type dialConfig struct {
+	providerName   string
+	telemetry      metricutil.TelemetryProviders
+	meterProvider  metric.MeterProvider
+	tracerProvider trace.TracerProvider
+}
+
+type dialTelemetryProviders struct {
+	meterProvider  metric.MeterProvider
+	tracerProvider trace.TracerProvider
+}
+
+func (p dialTelemetryProviders) MeterProvider() metric.MeterProvider {
+	return p.meterProvider
+}
+
+func (p dialTelemetryProviders) TracerProvider() trace.TracerProvider {
+	return p.tracerProvider
+}
+
+func WithProviderName(name string) DialOption {
+	return func(cfg *dialConfig) {
+		cfg.providerName = strings.TrimSpace(name)
+	}
+}
+
+func WithTelemetry(telemetry metricutil.TelemetryProviders) DialOption {
+	return func(cfg *dialConfig) {
+		cfg.telemetry = telemetry
+	}
+}
+
+func WithMeterProvider(provider metric.MeterProvider) DialOption {
+	return func(cfg *dialConfig) {
+		cfg.meterProvider = provider
+	}
+}
+
+func WithTracerProvider(provider trace.TracerProvider) DialOption {
+	return func(cfg *dialConfig) {
+		cfg.tracerProvider = provider
+	}
+}
+
+func DialHostedPlugin(ctx context.Context, target string, opts ...DialOption) (HostedPluginConn, error) {
+	var cfg dialConfig
+	for _, opt := range opts {
+		if opt != nil {
+			opt(&cfg)
+		}
+	}
+
 	network, address, err := dialTarget(target)
 	if err != nil {
 		return nil, err
@@ -30,11 +87,11 @@ func DialHostedPlugin(ctx context.Context, target string) (HostedPluginConn, err
 	var conn *grpc.ClientConn
 	switch network {
 	case "unix":
-		conn, err = dialUnixTarget(ctx, address)
+		conn, err = dialUnixTarget(ctx, address, cfg)
 	case "tcp":
-		conn, err = dialTCPTarget(address)
+		conn, err = dialTCPTarget(address, cfg)
 	case "tls":
-		conn, err = dialTLSTarget(address)
+		conn, err = dialTLSTarget(address, cfg)
 	default:
 		err = fmt.Errorf("unsupported hosted plugin dial network %q", network)
 	}
@@ -105,7 +162,7 @@ func dialTarget(raw string) (network string, address string, err error) {
 	return "unix", filepath.Clean(raw), nil
 }
 
-func dialUnixTarget(ctx context.Context, socket string) (*grpc.ClientConn, error) {
+func dialUnixTarget(ctx context.Context, socket string, cfg dialConfig) (*grpc.ClientConn, error) {
 	conn, err := grpc.NewClient(
 		"passthrough:///localhost",
 		grpc.WithTransportCredentials(insecure.NewCredentials()),
@@ -114,7 +171,7 @@ func dialUnixTarget(ctx context.Context, socket string) (*grpc.ClientConn, error
 			var d net.Dialer
 			return d.DialContext(ctx, "unix", socket)
 		}),
-		grpc.WithStatsHandler(otelgrpc.NewClientHandler()),
+		grpc.WithStatsHandler(otelgrpc.NewClientHandler(hostedPluginGRPCOptions(cfg)...)),
 	)
 	if err != nil {
 		return nil, err
@@ -123,11 +180,11 @@ func dialUnixTarget(ctx context.Context, socket string) (*grpc.ClientConn, error
 	return conn, nil
 }
 
-func dialTCPTarget(address string) (*grpc.ClientConn, error) {
+func dialTCPTarget(address string, cfg dialConfig) (*grpc.ClientConn, error) {
 	conn, err := grpc.NewClient(
 		address,
 		grpc.WithTransportCredentials(insecure.NewCredentials()),
-		grpc.WithStatsHandler(otelgrpc.NewClientHandler()),
+		grpc.WithStatsHandler(otelgrpc.NewClientHandler(hostedPluginGRPCOptions(cfg)...)),
 	)
 	if err != nil {
 		return nil, err
@@ -136,7 +193,7 @@ func dialTCPTarget(address string) (*grpc.ClientConn, error) {
 	return conn, nil
 }
 
-func dialTLSTarget(address string) (*grpc.ClientConn, error) {
+func dialTLSTarget(address string, cfg dialConfig) (*grpc.ClientConn, error) {
 	host, _, err := net.SplitHostPort(address)
 	if err != nil {
 		return nil, fmt.Errorf("parse hosted plugin tls dial target %q: %w", address, err)
@@ -148,11 +205,34 @@ func dialTLSTarget(address string) (*grpc.ClientConn, error) {
 			ServerName: host,
 			NextProtos: []string{"h2"},
 		})),
-		grpc.WithStatsHandler(otelgrpc.NewClientHandler()),
+		grpc.WithStatsHandler(otelgrpc.NewClientHandler(hostedPluginGRPCOptions(cfg)...)),
 	)
 	if err != nil {
 		return nil, err
 	}
 	conn.Connect()
 	return conn, nil
+}
+
+func hostedPluginGRPCOptions(cfg dialConfig) []otelgrpc.Option {
+	attrs := []attribute.KeyValue{
+		metricutil.AttrRPCRole.String("hosted_plugin_client"),
+	}
+	if cfg.providerName != "" {
+		attrs = append(attrs, metricutil.AttrProvider.String(metricutil.AttrValue(cfg.providerName)))
+	}
+	return metricutil.GRPCOptions(cfg.telemetryProviders(), attrs...)
+}
+
+func (cfg dialConfig) telemetryProviders() metricutil.TelemetryProviders {
+	if cfg.telemetry != nil {
+		return cfg.telemetry
+	}
+	if cfg.meterProvider == nil && cfg.tracerProvider == nil {
+		return nil
+	}
+	return dialTelemetryProviders{
+		meterProvider:  cfg.meterProvider,
+		tracerProvider: cfg.tracerProvider,
+	}
 }

--- a/gestaltd/internal/pluginruntime/dial_test.go
+++ b/gestaltd/internal/pluginruntime/dial_test.go
@@ -1,0 +1,64 @@
+package pluginruntime
+
+import (
+	"context"
+	"net"
+	"os"
+	"path/filepath"
+	"testing"
+
+	proto "github.com/valon-technologies/gestalt/sdk/go/gen/v1"
+	coretesting "github.com/valon-technologies/gestalt/server/core/testing"
+	"github.com/valon-technologies/gestalt/server/internal/providerhost"
+	"github.com/valon-technologies/gestalt/server/internal/testutil/metrictest"
+	"google.golang.org/grpc"
+	"google.golang.org/protobuf/types/known/emptypb"
+)
+
+func TestDialHostedPluginRecordsRPCClientDurationWithTelemetryAttrs(t *testing.T) {
+	t.Parallel()
+
+	metrics := metrictest.NewManualMeterProvider(t)
+	const providerName = "hosted-metrics"
+
+	dir, err := providerhost.NewPluginTempDir("grpc-metrics-")
+	if err != nil {
+		t.Fatalf("NewPluginTempDir: %v", err)
+	}
+	t.Cleanup(func() { _ = os.RemoveAll(dir) })
+	socket := filepath.Join(dir, "plugin.sock")
+	lis, err := net.Listen("unix", socket)
+	if err != nil {
+		t.Fatalf("listen unix: %v", err)
+	}
+	srv := grpc.NewServer()
+	proto.RegisterIntegrationProviderServer(srv, providerhost.NewProviderServer(&coretesting.StubIntegration{N: providerName}))
+	errCh := make(chan error, 1)
+	go func() {
+		errCh <- srv.Serve(lis)
+	}()
+	t.Cleanup(func() {
+		srv.Stop()
+		_ = lis.Close()
+		<-errCh
+	})
+
+	conn, err := DialHostedPlugin(context.Background(), "unix://"+socket,
+		WithProviderName(providerName),
+		WithMeterProvider(metrics.Provider),
+	)
+	if err != nil {
+		t.Fatalf("DialHostedPlugin: %v", err)
+	}
+	t.Cleanup(func() { _ = conn.Close() })
+
+	if _, err := conn.Integration().GetMetadata(context.Background(), &emptypb.Empty{}); err != nil {
+		t.Fatalf("GetMetadata: %v", err)
+	}
+
+	rm := metrictest.CollectMetrics(t, metrics.Reader)
+	metrictest.RequireFloat64Histogram(t, rm, "rpc.client.call.duration", map[string]string{
+		"gestalt.rpc.role": "hosted_plugin_client",
+		"gestalt.provider": providerName,
+	})
+}

--- a/gestaltd/internal/pluginruntime/executable.go
+++ b/gestaltd/internal/pluginruntime/executable.go
@@ -8,6 +8,7 @@ import (
 	"sync"
 
 	proto "github.com/valon-technologies/gestalt/sdk/go/gen/v1"
+	"github.com/valon-technologies/gestalt/server/internal/metricutil"
 	"github.com/valon-technologies/gestalt/server/internal/providerhost"
 	"google.golang.org/grpc/codes"
 	"google.golang.org/grpc/status"
@@ -22,6 +23,7 @@ type ExecutableConfig struct {
 	Config       map[string]any
 	AllowedHosts []string
 	HostBinary   string
+	Telemetry    metricutil.TelemetryProviders
 }
 
 type executableProvider struct {
@@ -29,8 +31,9 @@ type executableProvider struct {
 	runtime   proto.PluginRuntimeProviderClient
 	lifecycle proto.ProviderLifecycleClient
 
-	mu       sync.Mutex
-	sessions map[string]*Session
+	telemetry metricutil.TelemetryProviders
+	mu        sync.Mutex
+	sessions  map[string]*Session
 }
 
 func NewExecutableProvider(ctx context.Context, cfg ExecutableConfig) (Provider, error) {
@@ -40,6 +43,8 @@ func NewExecutableProvider(ctx context.Context, cfg ExecutableConfig) (Provider,
 		Env:          cfg.Env,
 		AllowedHosts: cfg.AllowedHosts,
 		HostBinary:   cfg.HostBinary,
+		ProviderName: cfg.Name,
+		Telemetry:    cfg.Telemetry,
 	})
 	if err != nil {
 		return nil, err
@@ -55,6 +60,7 @@ func NewExecutableProvider(ctx context.Context, cfg ExecutableConfig) (Provider,
 		proc:      proc,
 		runtime:   proto.NewPluginRuntimeProviderClient(proc.Conn()),
 		lifecycle: lifecycle,
+		telemetry: cfg.Telemetry,
 		sessions:  make(map[string]*Session),
 	}, nil
 }

--- a/gestaltd/internal/pluginruntime/local.go
+++ b/gestaltd/internal/pluginruntime/local.go
@@ -12,15 +12,17 @@ import (
 	"sync/atomic"
 
 	"github.com/valon-technologies/gestalt/server/internal/egress"
+	"github.com/valon-technologies/gestalt/server/internal/metricutil"
 	"github.com/valon-technologies/gestalt/server/internal/providerhost"
 )
 
 type LocalProvider struct {
 	nextID uint64
 
-	mu       sync.Mutex
-	sessions map[string]*localSession
-	closed   bool
+	telemetry metricutil.TelemetryProviders
+	mu        sync.Mutex
+	sessions  map[string]*localSession
+	closed    bool
 }
 
 type localSession struct {
@@ -46,10 +48,24 @@ type localPlugin struct {
 	process *providerhost.PluginProcess
 }
 
-func NewLocalProvider() *LocalProvider {
-	return &LocalProvider{
+type LocalOption func(*LocalProvider)
+
+func WithLocalTelemetry(telemetry metricutil.TelemetryProviders) LocalOption {
+	return func(p *LocalProvider) {
+		p.telemetry = telemetry
+	}
+}
+
+func NewLocalProvider(opts ...LocalOption) *LocalProvider {
+	p := &LocalProvider{
 		sessions: make(map[string]*localSession),
 	}
+	for _, opt := range opts {
+		if opt != nil {
+			opt(p)
+		}
+	}
+	return p
 }
 
 func (p *LocalProvider) Support(context.Context) (Support, error) {
@@ -248,6 +264,8 @@ func (p *LocalProvider) StartPlugin(ctx context.Context, req StartPluginRequest)
 		DefaultAction: egress.PolicyAction(req.DefaultAction),
 		HostBinary:    req.HostBinary,
 		SocketDir:     rootDir,
+		ProviderName:  req.PluginName,
+		Telemetry:     p.telemetry,
 	})
 	if err != nil {
 		p.mu.Lock()

--- a/gestaltd/internal/providerhost/agent_client.go
+++ b/gestaltd/internal/providerhost/agent_client.go
@@ -42,6 +42,7 @@ func NewExecutableAgent(ctx context.Context, cfg AgentExecConfig) (coreagent.Pro
 		HostBinary:    cfg.HostBinary,
 		Cleanup:       cfg.Cleanup,
 		HostServices:  cfg.HostServices,
+		ProviderName:  cfg.Name,
 	}
 	proc, err := startAgentProviderProcess(ctx, execCfg.processConfig())
 	if err != nil {

--- a/gestaltd/internal/providerhost/auth_client.go
+++ b/gestaltd/internal/providerhost/auth_client.go
@@ -61,6 +61,7 @@ func NewExecutableAuthenticationProvider(ctx context.Context, cfg Authentication
 		AllowedHosts: cfg.AllowedHosts,
 		HostBinary:   cfg.HostBinary,
 		Cleanup:      cfg.Cleanup,
+		ProviderName: cfg.Name,
 	}
 	proc, err := startProviderProcess(ctx, execCfg.processConfig())
 	if err != nil {

--- a/gestaltd/internal/providerhost/authorization_client.go
+++ b/gestaltd/internal/providerhost/authorization_client.go
@@ -38,6 +38,7 @@ func NewExecutableAuthorizationProvider(ctx context.Context, cfg AuthorizationEx
 		HostBinary:   cfg.HostBinary,
 		Cleanup:      cfg.Cleanup,
 		HostServices: cfg.HostServices,
+		ProviderName: cfg.Name,
 	}
 	proc, err := startProviderProcess(ctx, execCfg.processConfig())
 	if err != nil {

--- a/gestaltd/internal/providerhost/cache_client.go
+++ b/gestaltd/internal/providerhost/cache_client.go
@@ -38,6 +38,7 @@ func NewExecutableCache(ctx context.Context, cfg CacheExecConfig) (corecache.Cac
 		AllowedHosts: cfg.AllowedHosts,
 		HostBinary:   cfg.HostBinary,
 		Cleanup:      cfg.Cleanup,
+		ProviderName: cfg.Name,
 	}
 	proc, err := startProviderProcess(ctx, execCfg.processConfig())
 	if err != nil {

--- a/gestaltd/internal/providerhost/grpc_telemetry.go
+++ b/gestaltd/internal/providerhost/grpc_telemetry.go
@@ -1,0 +1,47 @@
+package providerhost
+
+import (
+	"strings"
+
+	"github.com/valon-technologies/gestalt/server/internal/metricutil"
+	"go.opentelemetry.io/contrib/instrumentation/google.golang.org/grpc/otelgrpc"
+	"go.opentelemetry.io/otel/attribute"
+)
+
+func providerClientGRPCOptions(providerName string, telemetry metricutil.TelemetryProviders) []otelgrpc.Option {
+	return grpcTelemetryOptions("provider_client", providerName, "", telemetry)
+}
+
+func providerServerGRPCOptions(providerName string, telemetry metricutil.TelemetryProviders) []otelgrpc.Option {
+	return grpcTelemetryOptions("provider_server", providerName, "", telemetry)
+}
+
+func hostServiceServerGRPCOptions(providerName string, service HostService, telemetry metricutil.TelemetryProviders) []otelgrpc.Option {
+	return grpcTelemetryOptions("host_service_server", providerName, hostServiceMetricName(service), telemetry)
+}
+
+func grpcTelemetryOptions(role, providerName, hostService string, telemetry metricutil.TelemetryProviders) []otelgrpc.Option {
+	attrs := []attribute.KeyValue{
+		metricutil.AttrRPCRole.String(role),
+	}
+	if providerName != "" {
+		attrs = append(attrs, metricutil.AttrProvider.String(metricutil.AttrValue(providerName)))
+	}
+	if hostService != "" {
+		attrs = append(attrs, metricutil.AttrHostService.String(metricutil.AttrValue(hostService)))
+	}
+	return metricutil.GRPCOptions(telemetry, attrs...)
+}
+
+func hostServiceMetricName(service HostService) string {
+	if service.Name != "" {
+		return strings.TrimSpace(service.Name)
+	}
+	envVar := strings.TrimSpace(service.EnvVar)
+	if envVar == "" {
+		return ""
+	}
+	envVar = strings.TrimPrefix(envVar, "GESTALT_")
+	envVar = strings.TrimSuffix(envVar, "_SOCKET")
+	return strings.ToLower(envVar)
+}

--- a/gestaltd/internal/providerhost/host_services.go
+++ b/gestaltd/internal/providerhost/host_services.go
@@ -8,10 +8,13 @@ import (
 	"path/filepath"
 	"sync"
 
+	"github.com/valon-technologies/gestalt/server/internal/metricutil"
+	"go.opentelemetry.io/contrib/instrumentation/google.golang.org/grpc/otelgrpc"
 	"google.golang.org/grpc"
 )
 
 type StartedHostService struct {
+	Name       string
 	EnvVar     string
 	SocketPath string
 }
@@ -25,7 +28,33 @@ type StartedHostServices struct {
 	closeErr  error
 }
 
-func StartHostServices(services []HostService) (*StartedHostServices, error) {
+type HostServicesOption func(*hostServicesConfig)
+
+type hostServicesConfig struct {
+	providerName string
+	telemetry    metricutil.TelemetryProviders
+}
+
+func WithHostServicesProviderName(name string) HostServicesOption {
+	return func(cfg *hostServicesConfig) {
+		cfg.providerName = name
+	}
+}
+
+func WithHostServicesTelemetry(telemetry metricutil.TelemetryProviders) HostServicesOption {
+	return func(cfg *hostServicesConfig) {
+		cfg.telemetry = telemetry
+	}
+}
+
+func StartHostServices(services []HostService, opts ...HostServicesOption) (*StartedHostServices, error) {
+	var cfg hostServicesConfig
+	for _, opt := range opts {
+		if opt != nil {
+			opt(&cfg)
+		}
+	}
+
 	active := make([]HostService, 0, len(services))
 	for _, service := range services {
 		if service.Register == nil || service.EnvVar == "" {
@@ -55,11 +84,12 @@ func StartHostServices(services []HostService) (*StartedHostServices, error) {
 			}
 			return nil, fmt.Errorf("listen on host socket: %w", err)
 		}
-		srv := grpc.NewServer()
+		srv := grpc.NewServer(grpc.StatsHandler(otelgrpc.NewServerHandler(hostServiceServerGRPCOptions(cfg.providerName, service, cfg.telemetry)...)))
 		service.Register(srv)
 		started.hostLiss = append(started.hostLiss, lis)
 		started.hostSrvs = append(started.hostSrvs, srv)
 		started.services = append(started.services, StartedHostService{
+			Name:       hostServiceMetricName(service),
 			EnvVar:     service.EnvVar,
 			SocketPath: hostSocket,
 		})

--- a/gestaltd/internal/providerhost/host_services_test.go
+++ b/gestaltd/internal/providerhost/host_services_test.go
@@ -1,0 +1,90 @@
+package providerhost
+
+import (
+	"context"
+	"net"
+	"testing"
+
+	proto "github.com/valon-technologies/gestalt/sdk/go/gen/v1"
+	"github.com/valon-technologies/gestalt/server/internal/testutil/metrictest"
+	"go.opentelemetry.io/otel/metric"
+	"go.opentelemetry.io/otel/trace"
+	nooptrace "go.opentelemetry.io/otel/trace/noop"
+	"google.golang.org/grpc"
+	"google.golang.org/grpc/credentials/insecure"
+)
+
+type hostServiceMetricsTelemetry struct {
+	meterProvider metric.MeterProvider
+}
+
+func (t hostServiceMetricsTelemetry) MeterProvider() metric.MeterProvider {
+	return t.meterProvider
+}
+
+func (hostServiceMetricsTelemetry) TracerProvider() trace.TracerProvider {
+	return nooptrace.NewTracerProvider()
+}
+
+type metricsCacheServer struct {
+	proto.UnimplementedCacheServer
+}
+
+func (metricsCacheServer) Get(context.Context, *proto.CacheGetRequest) (*proto.CacheGetResponse, error) {
+	return &proto.CacheGetResponse{Found: true, Value: []byte("ok")}, nil
+}
+
+func TestStartHostServicesRecordsRPCServerDurationWithTelemetryAttrs(t *testing.T) {
+	t.Parallel()
+
+	metrics := metrictest.NewManualMeterProvider(t)
+	const providerName = "metrics-plugin"
+
+	hostServices, err := StartHostServices([]HostService{{
+		Name:   "cache",
+		EnvVar: "GESTALT_TEST_CACHE_SOCKET",
+		Register: func(srv *grpc.Server) {
+			proto.RegisterCacheServer(srv, metricsCacheServer{})
+		},
+	}},
+		WithHostServicesProviderName(providerName),
+		WithHostServicesTelemetry(hostServiceMetricsTelemetry{meterProvider: metrics.Provider}),
+	)
+	if err != nil {
+		t.Fatalf("StartHostServices: %v", err)
+	}
+	t.Cleanup(func() { _ = hostServices.Close() })
+
+	bindings := hostServices.Bindings()
+	if len(bindings) != 1 {
+		t.Fatalf("host service bindings len = %d, want 1", len(bindings))
+	}
+
+	conn, err := grpc.NewClient("passthrough:///host-service",
+		grpc.WithTransportCredentials(insecure.NewCredentials()),
+		grpc.WithAuthority("localhost"),
+		grpc.WithContextDialer(func(ctx context.Context, _ string) (net.Conn, error) {
+			var d net.Dialer
+			return d.DialContext(ctx, "unix", bindings[0].SocketPath)
+		}),
+	)
+	if err != nil {
+		t.Fatalf("grpc.NewClient: %v", err)
+	}
+	t.Cleanup(func() { _ = conn.Close() })
+
+	resp, err := proto.NewCacheClient(conn).Get(context.Background(), &proto.CacheGetRequest{Key: "hello"})
+	if err != nil {
+		t.Fatalf("Cache.Get: %v", err)
+	}
+	if !resp.GetFound() {
+		t.Fatal("Cache.Get found = false, want true")
+	}
+
+	rm := metrictest.CollectMetrics(t, metrics.Reader)
+	metrictest.RequireFloat64Histogram(t, rm, "rpc.server.call.duration", map[string]string{
+		"gestalt.rpc.role":     "host_service_server",
+		"gestalt.provider":     providerName,
+		"gestalt.host_service": "cache",
+	})
+}

--- a/gestaltd/internal/providerhost/indexeddb_client.go
+++ b/gestaltd/internal/providerhost/indexeddb_client.go
@@ -39,6 +39,7 @@ func NewExecutableIndexedDB(ctx context.Context, cfg IndexedDBExecConfig) (index
 		AllowedHosts: cfg.AllowedHosts,
 		HostBinary:   cfg.HostBinary,
 		Cleanup:      cfg.Cleanup,
+		ProviderName: cfg.Name,
 	}
 	proc, err := startProviderProcess(ctx, execCfg.processConfig())
 	if err != nil {

--- a/gestaltd/internal/providerhost/process.go
+++ b/gestaltd/internal/providerhost/process.go
@@ -17,6 +17,7 @@ import (
 	proto "github.com/valon-technologies/gestalt/sdk/go/gen/v1"
 	"github.com/valon-technologies/gestalt/server/core"
 	"github.com/valon-technologies/gestalt/server/internal/egress"
+	"github.com/valon-technologies/gestalt/server/internal/metricutil"
 	"github.com/valon-technologies/gestalt/server/internal/sandbox"
 	"go.opentelemetry.io/contrib/instrumentation/google.golang.org/grpc/otelgrpc"
 	"google.golang.org/grpc"
@@ -40,6 +41,8 @@ type ProcessConfig struct {
 	Cleanup       func()
 	HostServices  []HostService
 	SocketDir     string
+	ProviderName  string
+	Telemetry     metricutil.TelemetryProviders
 }
 
 type ExecConfig struct {
@@ -55,11 +58,14 @@ type ExecConfig struct {
 	HostServices     []HostService
 	InvocationTokens *InvocationTokenManager
 	InvocationGrants invocationGrants
+	ProviderName     string
+	Telemetry        metricutil.TelemetryProviders
 }
 
 type HostService struct {
 	Register func(*grpc.Server)
 	EnvVar   string
+	Name     string
 }
 
 type providerProcess struct {
@@ -119,6 +125,8 @@ func (c ExecConfig) processConfig() ProcessConfig {
 		HostBinary:    c.HostBinary,
 		Cleanup:       c.Cleanup,
 		HostServices:  c.HostServices,
+		ProviderName:  firstNonBlank(c.ProviderName, c.StaticSpec.Name),
+		Telemetry:     c.Telemetry,
 	}
 }
 
@@ -182,7 +190,8 @@ func serveProvider(ctx context.Context, register func(*grpc.Server)) error {
 		_ = os.Remove(socket)
 	}()
 
-	srv := grpc.NewServer()
+	providerName := strings.TrimSpace(os.Getenv(proto.EnvProviderName))
+	srv := grpc.NewServer(grpc.StatsHandler(otelgrpc.NewServerHandler(providerServerGRPCOptions(providerName, nil)...)))
 	register(srv)
 
 	stopped := make(chan struct{})
@@ -218,10 +227,14 @@ func startProviderProcess(ctx context.Context, cfg ProcessConfig) (*providerProc
 		return nil, fmt.Errorf("create socket dir: %w", err)
 	}
 	pluginSocket := filepath.Join(dir, "plugin.sock")
-	env := mergeExecEnv(cfg.Env, map[string]string{
+	execEnv := map[string]string{
 		proto.EnvProviderSocket:    pluginSocket,
 		proto.EnvProviderParentPID: strconv.Itoa(os.Getpid()),
-	})
+	}
+	if providerName := strings.TrimSpace(cfg.ProviderName); providerName != "" {
+		execEnv[proto.EnvProviderName] = providerName
+	}
+	env := mergeExecEnv(cfg.Env, execEnv)
 
 	proc := &providerProcess{dir: dir}
 	proc.cleanup = cfg.Cleanup
@@ -244,7 +257,7 @@ func startProviderProcess(ctx context.Context, cfg ProcessConfig) (*providerProc
 			}
 			return nil, fmt.Errorf("listen on host socket: %w", err)
 		}
-		srv := grpc.NewServer()
+		srv := grpc.NewServer(grpc.StatsHandler(otelgrpc.NewServerHandler(hostServiceServerGRPCOptions(cfg.ProviderName, hostService, cfg.Telemetry)...)))
 		hostService.Register(srv)
 		proc.hostLiss = append(proc.hostLiss, lis)
 		proc.hostSrvs = append(proc.hostSrvs, srv)
@@ -329,7 +342,7 @@ func startProviderProcess(ctx context.Context, cfg ProcessConfig) (*providerProc
 	startCtx, cancel := context.WithTimeout(ctx, processStartupTimeout)
 	defer cancel()
 
-	conn, err := waitForPluginConn(startCtx, pluginSocket, proc.waitCh)
+	conn, err := waitForPluginConn(startCtx, pluginSocket, proc.waitCh, cfg)
 	if err != nil {
 		_ = proc.Close()
 		return nil, err
@@ -562,6 +575,15 @@ func envSlice(values map[string]string) []string {
 	return out
 }
 
+func firstNonBlank(values ...string) string {
+	for _, value := range values {
+		if trimmed := strings.TrimSpace(value); trimmed != "" {
+			return trimmed
+		}
+	}
+	return ""
+}
+
 var safeEnvKeys = []string{
 	"PATH", "HOME", "TMPDIR", "LANG", "TZ",
 	"SSL_CERT_FILE", "SSL_CERT_DIR",
@@ -577,10 +599,10 @@ func safeBaseEnv() []string {
 	return out
 }
 
-func waitForPluginConn(ctx context.Context, socket string, waitCh <-chan error) (*grpc.ClientConn, error) {
+func waitForPluginConn(ctx context.Context, socket string, waitCh <-chan error, cfg ProcessConfig) (*grpc.ClientConn, error) {
 	for {
 		if _, err := os.Stat(socket); err == nil {
-			conn, dialErr := dialUnixSocket(ctx, socket)
+			conn, dialErr := dialUnixSocket(ctx, socket, cfg)
 			if dialErr == nil {
 				return conn, nil
 			}
@@ -603,7 +625,7 @@ func waitForPluginConn(ctx context.Context, socket string, waitCh <-chan error) 
 	}
 }
 
-func dialUnixSocket(ctx context.Context, socket string) (*grpc.ClientConn, error) {
+func dialUnixSocket(ctx context.Context, socket string, cfg ProcessConfig) (*grpc.ClientConn, error) {
 	conn, err := grpc.NewClient(
 		"passthrough:///localhost",
 		grpc.WithTransportCredentials(insecure.NewCredentials()),
@@ -616,7 +638,7 @@ func dialUnixSocket(ctx context.Context, socket string) (*grpc.ClientConn, error
 			var d net.Dialer
 			return d.DialContext(ctx, "unix", socket)
 		}),
-		grpc.WithStatsHandler(otelgrpc.NewClientHandler()),
+		grpc.WithStatsHandler(otelgrpc.NewClientHandler(providerClientGRPCOptions(cfg.ProviderName, cfg.Telemetry)...)),
 	)
 	if err != nil {
 		return nil, err

--- a/gestaltd/internal/providerhost/s3_client.go
+++ b/gestaltd/internal/providerhost/s3_client.go
@@ -40,6 +40,7 @@ func NewExecutableS3(ctx context.Context, cfg S3ExecConfig) (s3store.Client, err
 		AllowedHosts: cfg.AllowedHosts,
 		HostBinary:   cfg.HostBinary,
 		Cleanup:      cfg.Cleanup,
+		ProviderName: cfg.Name,
 	}
 	proc, err := startProviderProcess(ctx, execCfg.processConfig())
 	if err != nil {

--- a/gestaltd/internal/providerhost/secrets_client.go
+++ b/gestaltd/internal/providerhost/secrets_client.go
@@ -34,6 +34,7 @@ func NewExecutableSecretManager(ctx context.Context, cfg SecretsExecConfig) (cor
 		AllowedHosts: cfg.AllowedHosts,
 		HostBinary:   cfg.HostBinary,
 		Cleanup:      cfg.Cleanup,
+		ProviderName: cfg.Name,
 	}
 	proc, err := startProviderProcess(ctx, execCfg.processConfig())
 	if err != nil {

--- a/gestaltd/internal/providerhost/workflow_client.go
+++ b/gestaltd/internal/providerhost/workflow_client.go
@@ -42,6 +42,7 @@ func NewExecutableWorkflow(ctx context.Context, cfg WorkflowExecConfig) (corewor
 		HostBinary:    cfg.HostBinary,
 		Cleanup:       cfg.Cleanup,
 		HostServices:  cfg.HostServices,
+		ProviderName:  cfg.Name,
 	}
 	proc, err := startWorkflowProviderProcess(ctx, execCfg.processConfig())
 	if err != nil {

--- a/gestaltd/internal/server/handlers.go
+++ b/gestaltd/internal/server/handlers.go
@@ -441,6 +441,12 @@ func (s *Server) listOperations(w http.ResponseWriter, r *http.Request) {
 	if !ok {
 		return
 	}
+	metricutil.AddHTTPAttributes(r.Context(),
+		metricutil.AttrProvider.String(metricutil.AttrValue(name)),
+		metricutil.AttrOperation.String(operation),
+		metricutil.AttrConnectionMode.String(metricutil.NormalizeConnectionMode(prov.ConnectionMode())),
+		metricutil.AttrInvocationSurface.String("http"),
+	)
 	p := PrincipalFromContext(r.Context())
 	if !s.allowProviderContext(r.Context(), p, name) {
 		s.auditHTTPEvent(r.Context(), p, name, operation, false, errOperationAccess)
@@ -637,6 +643,12 @@ func (s *Server) executeOperation(w http.ResponseWriter, r *http.Request) {
 		s.writeInvocationError(w, r, providerName, operationName, err)
 		return
 	}
+	metricutil.AddHTTPAttributes(r.Context(),
+		metricutil.AttrProvider.String(metricutil.AttrValue(providerName)),
+		metricutil.AttrOperation.String(metricutil.AttrValue(opMeta.ID)),
+		metricutil.AttrConnectionMode.String(metricutil.NormalizeConnectionMode(prov.ConnectionMode())),
+		metricutil.AttrInvocationSurface.String("http"),
+	)
 	if s.authorizer != nil && !s.authorizer.AllowCatalogOperation(ctx, p, providerName, opMeta) {
 		s.auditHTTPAuthorizationEvent(ctx, p, providerName, operationName, false, errOperationAccess, auditAuthorization{
 			Policy:   access.Policy,

--- a/gestaltd/internal/server/http_bindings.go
+++ b/gestaltd/internal/server/http_bindings.go
@@ -12,6 +12,7 @@ import (
 	"github.com/valon-technologies/gestalt/server/core/catalog"
 	"github.com/valon-technologies/gestalt/server/internal/config"
 	"github.com/valon-technologies/gestalt/server/internal/httpbinding"
+	"github.com/valon-technologies/gestalt/server/internal/metricutil"
 	"github.com/valon-technologies/gestalt/server/internal/registry"
 	providermanifestv1 "github.com/valon-technologies/gestalt/server/sdk/providermanifest/v1"
 )
@@ -253,6 +254,12 @@ func (s *Server) mountHTTPBindingRoutes(r chi.Router) {
 	for _, binding := range s.mountedHTTPBindings {
 		binding := binding
 		r.MethodFunc(binding.Method, binding.Path, func(w http.ResponseWriter, r *http.Request) {
+			metricutil.AddHTTPAttributes(r.Context(),
+				metricutil.AttrProvider.String(metricutil.AttrValue(binding.PluginName)),
+				metricutil.AttrOperation.String(metricutil.AttrValue(binding.Target)),
+				metricutil.AttrHTTPBinding.String(metricutil.AttrValue(binding.Name)),
+				metricutil.AttrInvocationSurface.String("http"),
+			)
 			s.handleHTTPBinding(binding, w, r)
 		})
 	}

--- a/gestaltd/internal/server/metrics_test.go
+++ b/gestaltd/internal/server/metrics_test.go
@@ -343,10 +343,19 @@ func TestOperationMetricsDefaultRESTTransportFromCatalogContext(t *testing.T) {
 
 	rm := metrictest.CollectMetrics(t, metrics.Reader)
 	metrictest.RequireInt64Sum(t, rm, "gestaltd.operation.count", 1, map[string]string{
-		"gestalt.provider":        providerName,
-		"gestalt.operation":       "list",
-		"gestalt.transport":       "rest",
-		"gestalt.connection_mode": "none",
+		"gestalt.provider":           providerName,
+		"gestalt.operation":          "list",
+		"gestalt.transport":          "rest",
+		"gestalt.connection_mode":    "none",
+		"gestalt.invocation_surface": "http",
+	})
+	metrictest.RequireFloat64Histogram(t, rm, "http.server.request.duration", map[string]string{
+		"http.route":                 "/api/v1/{integration}/{operation}",
+		"gestalt.provider":           providerName,
+		"gestalt.operation":          "list",
+		"gestalt.transport":          "rest",
+		"gestalt.connection_mode":    "none",
+		"gestalt.invocation_surface": "http",
 	})
 }
 
@@ -569,6 +578,34 @@ func TestHTTPMiddlewareMetricsUseConfiguredMeterProvider(t *testing.T) {
 	if !hasMetricWithPrefix(rm, "http.server.") {
 		t.Fatalf("expected otelhttp metrics in configured meter provider, got %+v", rm.ScopeMetrics)
 	}
+	metrictest.RequireFloat64Histogram(t, rm, "http.server.request.duration", map[string]string{
+		"http.route": "/ready",
+	})
+}
+
+func TestHTTPMetricsDoNotLabelUnknownPluginRouteParams(t *testing.T) {
+	t.Parallel()
+
+	metrics := metrictest.NewManualMeterProvider(t)
+	srv := newTestServer(t, func(cfg *server.Config) {
+		cfg.MeterProvider = metrics.Provider
+	})
+	testutil.CloseOnCleanup(t, srv)
+
+	req, _ := http.NewRequest(http.MethodGet, srv.URL+"/api/v1/not-a-provider/not-an-operation", nil)
+	resp, err := http.DefaultClient.Do(req)
+	if err != nil {
+		t.Fatalf("request: %v", err)
+	}
+	defer func() { _ = resp.Body.Close() }()
+	if resp.StatusCode == http.StatusOK {
+		t.Fatalf("expected non-200 for unknown provider route")
+	}
+
+	rm := metrictest.CollectMetrics(t, metrics.Reader)
+	routeAttrs := map[string]string{"http.route": "/api/v1/{integration}/{operation}"}
+	metrictest.RequireFloat64HistogramOmitsAttr(t, rm, "http.server.request.duration", routeAttrs, "gestalt.provider")
+	metrictest.RequireFloat64HistogramOmitsAttr(t, rm, "http.server.request.duration", routeAttrs, "gestalt.operation")
 }
 
 func TestHTTPDiscoveryMetrics(t *testing.T) {

--- a/gestaltd/internal/server/mounted_ui.go
+++ b/gestaltd/internal/server/mounted_ui.go
@@ -14,9 +14,11 @@ import (
 	"github.com/valon-technologies/gestalt/server/internal/adminui"
 	"github.com/valon-technologies/gestalt/server/internal/config"
 	"github.com/valon-technologies/gestalt/server/internal/invocation"
+	"github.com/valon-technologies/gestalt/server/internal/metricutil"
 	"github.com/valon-technologies/gestalt/server/internal/principal"
 	"github.com/valon-technologies/gestalt/server/internal/providerpkg"
 	"github.com/valon-technologies/gestalt/server/internal/ui"
+	"go.opentelemetry.io/otel/attribute"
 )
 
 const browserLoginPath = "/api/v1/auth/login"
@@ -256,7 +258,7 @@ func (s *Server) mountedUIHandler(mounted MountedUI) http.Handler {
 	if mounted.Path != "/" {
 		inner = http.StripPrefix(mounted.Path, inner)
 	}
-	return s.protectedUIHandler(mounted, inner, s.redirectMountedUILogin)
+	return mountedUITelemetryHandler(mounted, s.protectedUIHandler(mounted, inner, s.redirectMountedUILogin))
 }
 
 func (s *Server) adminUIHandler() http.Handler {
@@ -265,7 +267,7 @@ func (s *Server) adminUIHandler() http.Handler {
 	}
 	mounted := s.adminMountedUI()
 	inner := http.StripPrefix(mounted.Path, mounted.Handler)
-	return s.protectedUIHandler(mounted, inner, s.redirectAdminUILogin)
+	return mountedUITelemetryHandler(mounted, s.protectedUIHandler(mounted, inner, s.redirectAdminUILogin))
 }
 
 func (s *Server) adminMountedUI() MountedUI {
@@ -293,6 +295,20 @@ func (s *Server) protectedUIHandler(mounted MountedUI, inner http.Handler, redir
 			return
 		}
 		inner.ServeHTTP(w, r.WithContext(ctx))
+	})
+}
+
+func mountedUITelemetryHandler(mounted MountedUI, next http.Handler) http.Handler {
+	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		attrs := []attribute.KeyValue{
+			metricutil.AttrUI.String(metricutil.AttrValue(mounted.Name)),
+			metricutil.AttrInvocationSurface.String("ui"),
+		}
+		if mounted.PluginName != "" {
+			attrs = append(attrs, metricutil.AttrProvider.String(metricutil.AttrValue(mounted.PluginName)))
+		}
+		metricutil.AddHTTPAttributes(r.Context(), attrs...)
+		next.ServeHTTP(w, r)
 	})
 }
 

--- a/gestaltd/internal/server/routes.go
+++ b/gestaltd/internal/server/routes.go
@@ -6,11 +6,13 @@ import (
 
 	"github.com/go-chi/chi/v5"
 	"github.com/go-chi/chi/v5/middleware"
+	"github.com/valon-technologies/gestalt/server/internal/metricutil"
 )
 
 func (s *Server) routes() {
 	r := s.router
 	r.Use(requestMetaMiddleware)
+	r.Use(routePatternTelemetryMiddleware)
 	r.Use(s.securityHeadersMiddleware)
 	r.Use(s.hostServiceRelayMiddleware)
 	r.Use(s.egressProxyMiddleware)
@@ -121,6 +123,19 @@ func redirectPreservingQuery(w http.ResponseWriter, r *http.Request, target stri
 		target += "?" + rawQuery
 	}
 	http.Redirect(w, r, target, code)
+}
+
+func routePatternTelemetryMiddleware(next http.Handler) http.Handler {
+	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		next.ServeHTTP(w, r)
+		routeCtx := chi.RouteContext(r.Context())
+		if routeCtx == nil {
+			return
+		}
+		if route := routeCtx.RoutePattern(); route != "" {
+			metricutil.AddHTTPAttributes(r.Context(), metricutil.AttrHTTPRoute.String(route))
+		}
+	})
 }
 
 func (s *Server) mountManagementHiddenRoutes(r chi.Router) {

--- a/gestaltd/internal/testutil/metrictest/metrictest.go
+++ b/gestaltd/internal/testutil/metrictest/metrictest.go
@@ -138,6 +138,36 @@ func RequireFloat64Histogram(t *testing.T, rm metricdata.ResourceMetrics, name s
 	t.Fatalf("metric %q with attrs %v not found", name, attrs)
 }
 
+func RequireFloat64HistogramOmitsAttr(t *testing.T, rm metricdata.ResourceMetrics, name string, attrs map[string]string, forbiddenKey string) {
+	t.Helper()
+
+	found := false
+	for _, scope := range rm.ScopeMetrics {
+		for _, metric := range scope.Metrics {
+			if metric.Name != name {
+				continue
+			}
+			histogram, ok := metric.Data.(metricdata.Histogram[float64])
+			if !ok {
+				t.Fatalf("metric %q is %T, want Histogram[float64]", name, metric.Data)
+			}
+			for _, point := range histogram.DataPoints {
+				if !AttrsMatch(point.Attributes, attrs) {
+					continue
+				}
+				found = true
+				if _, ok := point.Attributes.Value(attribute.Key(forbiddenKey)); ok {
+					t.Fatalf("metric %q attrs %v unexpectedly include %q", name, attrs, forbiddenKey)
+				}
+			}
+		}
+	}
+
+	if !found {
+		t.Fatalf("metric %q with attrs %v not found", name, attrs)
+	}
+}
+
 func AttrsMatch(set attribute.Set, want map[string]string) bool {
 	for key, expected := range want {
 		value, ok := set.Value(attribute.Key(key))

--- a/sdk/go/gen/v1/env.go
+++ b/sdk/go/gen/v1/env.go
@@ -24,6 +24,10 @@ const (
 	// want to terminate themselves when the parent goes away unexpectedly.
 	EnvProviderParentPID = "GESTALT_PLUGIN_PARENT_PID"
 
+	// EnvProviderName is the provider name assigned by the host for executable
+	// providers.
+	EnvProviderName = "GESTALT_PLUGIN_NAME"
+
 	// CurrentProtocolVersion is the provider protocol version spoken by this
 	// build of the host and SDK. Providers must echo this version in their
 	// StartProviderResponse.


### PR DESCRIPTION
## Summary

Adds platform-level telemetry dimensions so production metrics can be grouped by route, provider/plugin, operation, transport, invocation surface, gRPC role, and host service without per-feature one-offs.

## New Interfaces

- `pluginruntime.DialHostedPlugin(ctx, target, ...DialOption)`
  - `pluginruntime.WithProviderName("github")`
  - `pluginruntime.WithTelemetry(tp)`
  - `pluginruntime.WithMeterProvider(mp)` / `pluginruntime.WithTracerProvider(tp)`
- `pluginruntime.NewLocalProvider(...LocalOption)`
  - `pluginruntime.WithLocalTelemetry(tp)`
- `providerhost.StartHostServices(services, ...HostServicesOption)`
  - `providerhost.WithHostServicesProviderName("github")`
  - `providerhost.WithHostServicesTelemetry(tp)`
- `providerhost.ProcessConfig{ProviderName: "github", Telemetry: tp}`
- `providerhost.HostService{Name: "cache", EnvVar: "GESTALT_CACHE_SOCKET", Register: register}`
- `proto.EnvProviderName` exposes `GESTALT_PLUGIN_NAME` to executable providers.

## Examples

```go
conn, err := pluginruntime.DialHostedPlugin(ctx, target,
    pluginruntime.WithProviderName("github"),
    pluginruntime.WithTelemetry(telemetryProvider),
)
```

```go
started, err := providerhost.StartHostServices(hostServices,
    providerhost.WithHostServicesProviderName("github"),
    providerhost.WithHostServicesTelemetry(telemetryProvider),
)
```

```go
proc, err := providerhost.StartPluginProcess(ctx, providerhost.ProcessConfig{
    Command:      command,
    ProviderName: "github",
    Telemetry:    telemetryProvider,
})
```

## Notes

- HTTP server metrics now get `http.route` and Gestalt dimensions including `gestalt.provider`, `gestalt.operation`, `gestalt.transport`, `gestalt.connection_mode`, `gestalt.invocation_surface`, `gestalt.http_binding`, and `gestalt.ui` when the platform can resolve them.
- gRPC stats handlers now use the configured telemetry provider and attach `gestalt.rpc.role`, `gestalt.provider`, and `gestalt.host_service`.
- Resource attributes now fill missing `service.version`, `git.commit.sha`, Cloud Run `cloud.provider` / `cloud.platform`, and related FaaS attributes from environment defaults while preserving explicit config.
- The repo’s current OpenTelemetry gRPC version emits `rpc.client.call.duration` / `rpc.server.call.duration`; `OTEL_SEMCONV_STABILITY_OPT_IN=rpc/dup` also emits legacy names like `rpc.client.duration`.

## Validation

- `go test ./...` in `gestaltd`
- `go test ./...` in `sdk/go`
- `git diff --check origin/main...HEAD`

Functional coverage uses real HTTP requests, a real hosted-plugin gRPC call, and a real Unix-socket host-service gRPC call. No unit tests were added.