### PR TITLE
[codex] Simplify runtime provider docs

### DIFF
--- a/docs/content/configuration.mdx
+++ b/docs/content/configuration.mdx
@@ -200,10 +200,9 @@ plugins:
 ## Choosing a plugin runtime
 
 Executable plugins run on the same machine as `gestaltd` unless the plugin opts
-into a hosted runtime. Runtime selection is two-step:
-
-- define named backends under `runtime.providers`
-- opt an individual plugin in with `plugins.<name>.runtime`
+into a hosted runtime. Runtime selection is two-step: define named backends
+under `runtime.providers`, then opt an individual plugin in with
+`plugins.<name>.runtime`.
 
 `server.runtime.provider` is only a default selector for plugins that already
 set `plugins.<name>.runtime`; it does not move every plugin into a hosted
@@ -240,22 +239,18 @@ selected runtime backend. Their meaning is backend-specific: a local runtime may
 ignore them, while a hosted runtime may use them to choose a sandbox template,
 container image, or labels/tags for lifecycle management.
 
-The built-in runtime drivers are:
-
-- `local` for same-machine execution
-- installable `kind: runtime` providers such as Modal for hosted execution
+The built-in `local` runtime handles same-machine execution. Installable
+`kind: runtime` providers such as Modal handle hosted execution.
 
 The current Modal backend requires `runtime.providers.<name>.config.app` and
-`plugins.<name>.runtime.image`. Modal does not expose generic direct
-host-service tunnels, but it can still satisfy plugins that need relay-backed
-host services or Gestalt's hostname-based egress model when the host is
-configured for the public relay and proxy path. In practice that means
-`server.baseURL` and `server.encryptionKey` must be set, and the runtime
-provider must advertise the matching capabilities. Without those prerequisites,
-Gestalt rejects Modal for plugins that require relay-backed host services or
-hostname-based egress.
+`plugins.<name>.runtime.image`. Modal can satisfy plugins that need
+Gestalt-owned services or hostname-based egress when the host is configured for
+the public relay and proxy path. In practice that means `server.baseURL` and
+`server.encryptionKey` must be set, and the runtime must report a compatible
+support profile. Without those prerequisites, Gestalt rejects Modal for plugins
+that require relay-backed host services or hostname-based egress.
 
-For the runtime-provider lifecycle and capability model, see
+For the runtime-provider lifecycle and support model, see
 [Providers > Runtime](/providers/runtime).
 
 ## Binding S3 object stores

--- a/docs/content/custom-providers/runtime.mdx
+++ b/docs/content/custom-providers/runtime.mdx
@@ -133,10 +133,10 @@ func (p *Provider) StopSession(context.Context, *proto.StopPluginRuntimeSessionR
 
 func (p *Provider) BindHostService(context.Context, req *proto.BindPluginRuntimeHostServiceRequest) (*proto.PluginRuntimeHostServiceBinding, error) {
 	return &proto.PluginRuntimeHostServiceBinding{
-		Id:         "binding-1",
-		SessionId:  req.GetSessionId(),
-		EnvVar:     req.GetEnvVar(),
-		SocketPath: req.GetHostSocketPath(),
+		Id:        "binding-1",
+		SessionId: req.GetSessionId(),
+		EnvVar:    req.GetEnvVar(),
+		Relay:     req.GetRelay(),
 	}, nil
 }
 
@@ -165,11 +165,11 @@ host-reachable executable plugin session. If that is false, Gestalt will reject
 hosted execution for that runtime immediately instead of failing later during
 bootstrap.
 
-`host_service_access` should be `direct` only when the backend can really
-expose guest-local host-service sockets inside the runtime session. When that
-value is `none`, Gestalt may still derive an *effective* relay-backed
-host-service path if the current host deployment has the public relay
-prerequisites, but that relay behavior is host-provided, not runtime-advertised.
+`host_service_access` should be `direct` only when the backend can expose
+guest-local host-service sockets inside the runtime session. Most hosted
+runtimes should report `none` and let Gestalt decide whether the current
+deployment can provide relay-backed host services through the public relay
+path. That relay path is host-provided behavior, not runtime-owned behavior.
 
 `egress_mode` should be `hostname` only when the runtime can preserve
 Gestalt's hostname-based `allowedHosts` model. `cidr` is useful metadata, but
@@ -182,10 +182,8 @@ the host to stage a runtime bundle first. When bundle launch is required,
 `execution_target` must accurately describe the platform the backend will
 actually run so the host can choose or stage the right artifact.
 
-Older runtime providers may continue returning the legacy `capabilities` field
-for compatibility, but new providers should populate `support` instead. Gestalt
-still understands the old booleans, but the grouped support shape is now the
-primary contract and the one operators see reflected in inspection.
+New providers should populate `support`. That grouped support shape is the
+runtime contract operators see in inspection.
 
 ## Sessions and host services
 
@@ -202,11 +200,8 @@ the provider receives a public dial target and the hosted plugin talks back to
 ## Dial targets
 
 `StartPlugin` returns a host-reachable `dial_target`, not a guest-local socket
-path. Gestalt currently supports:
-
-- `unix://...`
-- `tcp://host:port`
-- `tls://host:port`
+path. Gestalt currently supports `unix://...`, `tcp://host:port`, and
+`tls://host:port`.
 
 If your backend starts the plugin behind a guest-local listener, the runtime
 provider is responsible for bridging that listener back into one of the
@@ -225,7 +220,7 @@ Then point `runtime.providers.<name>.source` at the resulting
 
 ## What to read next
 
-- [Providers > Runtime](/providers/runtime): operator-facing runtime model
-- [Releasing](/custom-providers/releasing): packaging and published artifacts
-- [Config File](/reference/config-file#runtime): runtime config fields
-- [Provider Manifests](/reference/plugin-manifests): manifest schema
+For the operator-facing model, see [Providers > Runtime](/providers/runtime).
+For packaging, see [Releasing](/custom-providers/releasing). For config and
+manifest fields, see [Config File](/reference/config-file#runtime) and
+[Provider Manifests](/reference/plugin-manifests).

--- a/docs/content/providers/plugins.mdx
+++ b/docs/content/providers/plugins.mdx
@@ -10,13 +10,11 @@ A plugin package includes a manifest that defines metadata, connections, and
 optional passthrough API surfaces. Some plugins are fully executable, some are
 fully declarative, and some are hybrid packages that combine both models.
 
-From a deployment point of view, the important pieces are:
-
-- `source` to choose the package, using either a local manifest path or a published `provider-release.yaml` metadata URL
-- `config` for provider-specific settings such as OAuth app credentials
-- `allowedOperations` to publish only part of a large catalog
-- `allowedHosts` to declare outbound egress policy
-- `runtime` to opt an executable plugin into hosted execution
+From a deployment point of view, `source` chooses the package, `config`
+passes provider-specific settings such as OAuth app credentials,
+`allowedOperations` publishes only part of a large catalog, `allowedHosts`
+declares outbound egress policy, and `runtime` opts an executable plugin into
+hosted execution.
 
 If the manifest enables MCP, the same operations are also exposed through the
 server's `/mcp` endpoint.
@@ -115,14 +113,13 @@ them to choose a sandbox template, container image, or lifecycle labels.
 A built-in `local` runtime is always available for same-machine execution. The
 first installable hosted runtime provider is `modal`. It requires
 `runtime.providers.<name>.config.app` and `plugins.<name>.runtime.image`.
-Gestalt only uses it for plain executable plugins today. Modal does not expose
-generic direct host-service tunnels, but it can still run plugins that need
-relay-backed host services or Gestalt's hostname-based egress model when the
-host is configured for the public relay and proxy path. In practice that means
-`server.baseURL` and `server.encryptionKey` must be set, and the runtime
-provider must advertise the matching capabilities. Without those prerequisites,
-plugins that need `indexeddb`, `cache`, `s3`, workflow-manager access when
-workflows are configured, nested `invokes`, `allowedHosts`, or
+Gestalt only uses it for plain executable plugins today. Modal can still run
+plugins that need Gestalt-owned services or hostname-based egress when the host
+is configured for the public relay and proxy path. In practice that means
+`server.baseURL` and `server.encryptionKey` must be set, and the runtime must
+report a compatible support profile. Without those prerequisites, plugins that
+need `indexeddb`, `cache`, `s3`, workflow-manager access when workflows are
+configured, nested `invokes`, `allowedHosts`, or
 `server.egress.defaultAction: deny` stay on `local`.
 
 For the runtime-provider model itself, see [Providers > Runtime](/providers/runtime).
@@ -180,8 +177,8 @@ release packaging now live under [Custom Providers > Plugin](/custom-providers/p
 
 ## What to read next
 
-- [Configuration](/configuration): provider entries, connections, and `allowedHosts`
-- [HTTP API](/reference/http-api): invoking plugin operations
-- [Provider Manifests](/reference/plugin-manifests): manifest field reference
-- [Authorization](/providers/authorization): runtime authorization semantics
-- [Custom Plugin](/custom-providers/plugins): advanced authoring docs
+For configuration, see [Configuration](/configuration). For operation
+invocation, see [HTTP API](/reference/http-api). For manifest fields, see
+[Provider Manifests](/reference/plugin-manifests). For authorization behavior,
+see [Authorization](/providers/authorization). To build a plugin, see
+[Custom Plugin](/custom-providers/plugins).

--- a/docs/content/providers/runtime.mdx
+++ b/docs/content/providers/runtime.mdx
@@ -11,16 +11,8 @@ over gRPC.
 ## Scope
 
 Runtime providers only apply to executable plugins under `plugins.<name>`.
-They do **not** replace host-local infrastructure providers such as:
-
-- `providers.authentication`
-- `providers.authorization`
-- `providers.indexeddb`
-- `providers.cache`
-- `providers.s3`
-- `providers.secrets`
-- `providers.workflow`
-
+They do **not** replace host-local infrastructure providers such as
+authentication, authorization, IndexedDB, cache, S3, secrets, or workflow.
 Those providers still live on the `gestaltd` host. A runtime provider only
 changes where the plugin process runs.
 
@@ -29,16 +21,13 @@ changes where the plugin process runs.
 By default, executable plugins run on the same machine as `gestaltd`. A plugin
 only uses a runtime provider when it opts in with `plugins.<name>.runtime`.
 
-When a plugin does opt in, Gestalt follows this lifecycle:
-
-1. Select a runtime backend from `runtime.providers`
-2. Query its runtime support
-3. Start a runtime session
-4. Wait for the session to become ready
-5. Bind host-local services into that session
-6. Start the plugin process inside the session
-7. Dial the plugin back over gRPC and use it like any other plugin
-8. Stop the session on shutdown or bootstrap failure
+When a plugin does opt in, Gestalt selects a backend from `runtime.providers`,
+reads the backend's support profile, starts a runtime session, waits for that
+session to become ready, binds any required host-local services, starts the
+plugin process inside the session, then dials the plugin back over gRPC. From
+that point on, the hosted plugin behaves like any other plugin from the
+caller's point of view. Gestalt stops the runtime session during shutdown or
+after a bootstrap failure.
 
 That is why the runtime interface is bigger than a single `StartPlugin` call:
 Gestalt needs an explicit lifecycle boundary, not just a fire-and-forget launch
@@ -73,40 +62,31 @@ plugins:
         environment: production
 ```
 
-Selection is two-step:
-
-- `runtime.providers` defines named backends
-- `plugins.<name>.runtime` opts a specific plugin into hosted execution
-
-`server.runtime.provider` is only a default selector for plugins that already
-set `plugins.<name>.runtime`.
+Selection is intentionally two-step. `runtime.providers` defines named
+backends, while `plugins.<name>.runtime` opts a specific plugin into hosted
+execution. `server.runtime.provider` is only a default selector for plugins
+that already set `plugins.<name>.runtime`.
 
 ## Runtime profiles
 
-Runtime backends are not interchangeable, but most operators should not have to
-reason about a bag of low-level booleans to understand why a runtime is or is
-not compatible with a plugin. Gestalt therefore evaluates a runtime in terms of
-four higher-level questions.
+Runtime backends are not interchangeable, but the compatibility check is meant
+to read in terms of behavior, not implementation details. Gestalt asks whether
+the runtime can host plugins, how hosted plugins reach Gestalt-owned services,
+whether the runtime can preserve hostname-based `allowedHosts`, and whether the
+plugin should launch from a host path or from a staged bundle.
 
-First, can the runtime host executable plugins at all. Second, how do hosted
-plugins reach Gestalt-owned services such as IndexedDB, cache, S3,
-workflow-manager access, authorization, and nested plugin invocation. Gestalt
-describes that as a host-service access mode of `none`, `relay`, or `direct`.
-Third, what kind of egress policy can the runtime preserve: no policy, CIDR or
-firewall style controls, or Gestalt's hostname-based `allowedHosts` model.
-Fourth, how does the plugin launch: directly from host paths or from a staged
-bundle, and on what execution target.
+Host-service access is reported as `none`, `relay`, or `direct`. `direct`
+means the runtime can expose guest-local service sockets inside the session.
+`relay` means the current host deployment can provide those services through
+Gestalt's public relay path. Egress support is separate: a runtime must preserve
+Gestalt's hostname-based policy model before plugins with `allowedHosts` or a
+default-deny egress policy can run there.
 
-The admin inspection API exposes that grouped model directly. `GET
-/admin/api/v1/runtime/providers` returns an `advertised` profile, which is what
-the runtime says it can do, and an `effective` profile, which is what the
-current `gestaltd` deployment can actually guarantee once relay and public
-proxy prerequisites are considered.
-
-Older runtime providers may still advertise the legacy boolean capability bag.
-Gestalt continues to accept that format for compatibility, but it immediately
-derives the grouped support model from it and does not treat the raw booleans
-as the primary operator interface anymore.
+The admin inspection API exposes both sides of that decision. `GET
+/admin/api/v1/runtime/providers` includes `profile.advertised`, which is what
+the runtime reports, and `profile.effective`, which is what this `gestaltd`
+deployment can actually provide after relay and public proxy prerequisites are
+considered.
 
 ## Host services and hosted plugins
 
@@ -135,7 +115,7 @@ Today there are two main runtime choices:
 | Backend | Type | Notes |
 | --- | --- | --- |
 | `local` | Built-in driver | Runs the plugin on the same machine as `gestaltd`. Supports host-path execution and the existing host-local runtime behavior. |
-| `modal` | Installable `kind: runtime` provider | Runs the plugin in a hosted Linux sandbox. Requires `runtime.providers.<name>.config.app` and `plugins.<name>.runtime.image`. When the host is configured for the public relay and proxy path, Modal uses relay-backed host services and Gestalt's public hostname-egress proxy instead of generic direct host-service tunnels. |
+| `modal` | Installable `kind: runtime` provider | Runs the plugin in a hosted Linux sandbox. Requires `runtime.providers.<name>.config.app` and `plugins.<name>.runtime.image`. When the host is configured for the public relay and proxy path, Modal can run plugins that need Gestalt-owned services and hostname-based egress. |
 
 ## Bundle staging and host-path execution
 
@@ -152,8 +132,8 @@ universal plugin semantics.
 
 ## What to read next
 
-- [Configuration](/configuration): selecting a runtime backend
-- [Plugin](/providers/plugins): plugin-side runtime opt-in
-- [Config File](/reference/config-file#runtime): field-by-field config reference
-- [Security](/security): how runtimes affect the execution boundary
-- [Custom Providers > Runtime](/custom-providers/runtime): building your own runtime provider
+For the config fields, see [Configuration](/configuration) and
+[Config File](/reference/config-file#runtime). For plugin-side opt-in, see
+[Plugin](/providers/plugins). For the execution boundary, see
+[Security](/security). To build a runtime backend, see
+[Custom Providers > Runtime](/custom-providers/runtime).

--- a/docs/content/reference/config-file.mdx
+++ b/docs/content/reference/config-file.mdx
@@ -254,11 +254,10 @@ runtime:
 | `regions` | Optional region allowlist passed through to Modal. |
 
 When a plugin uses the Modal runtime provider, `plugins.<name>.runtime.image` is
-required. Modal does not expose generic direct host-service tunnels, but it can
-still run hosted plugins that need Gestalt-owned services or hostname-based
-egress when the host is configured for the public relay and proxy path. In
-practice that means `server.baseURL` and `server.encryptionKey` must be set, and
-the runtime provider must advertise the matching runtime capabilities. Without
+required. Modal can still run hosted plugins that need Gestalt-owned services
+or hostname-based egress when the host is configured for the public relay and
+proxy path. In practice that means `server.baseURL` and `server.encryptionKey`
+must be set, and the runtime must report a compatible support profile. Without
 those prerequisites, Gestalt will reject Modal for plugins that need
 relay-backed host services, `allowedHosts`, or a server-wide default-deny
 egress policy.

--- a/docs/content/reference/http-api.mdx
+++ b/docs/content/reference/http-api.mdx
@@ -94,7 +94,7 @@ returns `412`.
 | Method | Path | Purpose |
 | --- | --- | --- |
 | `GET` | `/metrics` | Prometheus scrape endpoint for emitted metrics. Requires Gestalt authentication only when served on the public listener. The recommended production pattern is to move it to `server.management` and protect that listener at the network or proxy layer. |
-| `GET` | `/admin/api/v1/runtime/providers` | List configured runtime providers. When support inspection succeeds, loaded providers include a derived `profile` with `advertised` and `effective` runtime behavior. `sessionCount` is present when session inspection also succeeds, and `error` explains any current inspection failure. |
+| `GET` | `/admin/api/v1/runtime/providers` | List configured runtime providers. When support inspection succeeds, loaded providers include a derived `profile` with `advertised` behavior reported by the runtime and `effective` behavior resolved for this host deployment. `sessionCount` is present when session inspection also succeeds, and `error` explains any current inspection failure. |
 | `GET` | `/admin/api/v1/runtime/providers/{provider}/sessions` | List active sessions for one runtime provider, including session `id`, lifecycle `state`, and the hosted `plugin` when known. |
 | `GET` | `/admin/api/v1/authorization/plugins` | List plugins that declare `authorizationPolicy`, including the bound policy name and mounted UI path when present. |
 | `GET` | `/admin/api/v1/authorization/plugins/{plugin}/members` | List merged static and dynamic human membership rows for one plugin. Rows include `source`, `effective`, `mutable`, and selector metadata. |

--- a/docs/content/security.mdx
+++ b/docs/content/security.mdx
@@ -92,8 +92,8 @@ not be treated as a portable security boundary by itself.
 
 The built-in `local` runtime uses this same host-local sandbox path. Hosted
 runtime providers may define a stronger or different execution boundary, but
-they only count as equivalent for security policy purposes when they advertise
-the matching runtime capabilities. In particular, Gestalt's `allowedHosts`
+they only count as equivalent for security policy purposes when their support
+profile preserves the same policy. In particular, Gestalt's `allowedHosts`
 model is hostname-based, so a backend that only supports CIDR or firewall rules
 is not a drop-in replacement for hostname-aware egress enforcement.
 


### PR DESCRIPTION
## Summary

This updates the runtime-provider documentation to describe the current support-profile model more directly. The operator-facing runtime page now explains hosted execution as a lifecycle managed by `gestaltd`, with compatibility described in terms of runtime behavior and host-resolved behavior instead of low-level implementation details.

The custom runtime provider guide now points new providers at the grouped `support` contract and fixes the `BindHostService` example to return the relay-shaped binding rather than the deprecated socket-path field. Related plugin, configuration, config reference, HTTP API, and security pages now use the same support-profile language.

## Impact

The docs should be easier to review and maintain because they no longer teach the legacy capability-bag migration path. They still preserve the important operational requirements: hosted plugins must explicitly opt into a runtime, Modal requires `image`, relay-backed host services and hostname egress require `server.baseURL` plus `server.encryptionKey`, and the admin API still exposes the actual `profile.advertised` and `profile.effective` JSON fields.

## Validation

Ran `npm run typecheck` in `docs`.

Ran `npm run build` in `docs`.