### PR TITLE
[codex] Remove legacy runtime compatibility fields

### DIFF
--- a/gestaltd/internal/bootstrap/provider_build.go
+++ b/gestaltd/internal/bootstrap/provider_build.go
@@ -1182,9 +1182,8 @@ func buildPluginRuntimeHostServiceBinding(pluginName, sessionID string, hostServ
 		}, relayEnv, relayHost, nil
 	}
 	return pluginruntime.BindHostServiceRequest{
-		SessionID:      sessionID,
-		EnvVar:         hostService.EnvVar,
-		HostSocketPath: hostService.SocketPath,
+		SessionID: sessionID,
+		EnvVar:    hostService.EnvVar,
 		Relay: pluginruntime.HostServiceRelay{
 			DialTarget: "unix://" + hostService.SocketPath,
 		},

--- a/gestaltd/internal/pluginruntime/executable.go
+++ b/gestaltd/internal/pluginruntime/executable.go
@@ -156,25 +156,19 @@ func (p *executableProvider) StopSession(ctx context.Context, req StopSessionReq
 
 func (p *executableProvider) BindHostService(ctx context.Context, req BindHostServiceRequest) (*HostServiceBinding, error) {
 	resp, err := p.runtime.BindHostService(ctx, &proto.BindPluginRuntimeHostServiceRequest{
-		SessionId:      req.SessionID,
-		EnvVar:         req.EnvVar,
-		HostSocketPath: req.HostSocketPath,
-		Relay:          hostServiceRelayToProto(req.Relay),
+		SessionId: req.SessionID,
+		EnvVar:    req.EnvVar,
+		Relay:     hostServiceRelayToProto(req.Relay),
 	})
 	if err != nil {
 		return nil, fmt.Errorf("bind runtime host service: %w", err)
 	}
 	relay := hostServiceRelayFromProto(resp.GetRelay())
-	socketPath := ""
-	if strings.HasPrefix(relay.DialTarget, "unix://") {
-		socketPath = strings.TrimPrefix(relay.DialTarget, "unix://")
-	}
 	return &HostServiceBinding{
-		ID:         resp.GetId(),
-		SessionID:  resp.GetSessionId(),
-		EnvVar:     resp.GetEnvVar(),
-		SocketPath: socketPath,
-		Relay:      relay,
+		ID:        resp.GetId(),
+		SessionID: resp.GetSessionId(),
+		EnvVar:    resp.GetEnvVar(),
+		Relay:     relay,
 	}, nil
 }
 
@@ -220,11 +214,7 @@ func supportFromProtoResponse(src *proto.GetPluginRuntimeCapabilitiesResponse) S
 	if src == nil {
 		return Support{}
 	}
-	if support := supportFromProto(src.GetSupport()); support != (Support{}) {
-		return support
-	}
-	//nolint:staticcheck // older runtime providers still populate the legacy field during the compatibility window
-	return supportFromLegacyCapabilities(src.Capabilities)
+	return supportFromProto(src.GetSupport())
 }
 
 func supportFromProto(src *proto.PluginRuntimeSupport) Support {
@@ -237,37 +227,6 @@ func supportFromProto(src *proto.PluginRuntimeSupport) Support {
 		EgressMode:        egressModeFromProto(src.GetEgressMode()),
 		LaunchMode:        launchModeFromProto(src.GetLaunchMode()),
 		ExecutionTarget:   executionTargetFromProto(src.GetExecutionTarget()),
-	}
-}
-
-func supportFromLegacyCapabilities(src *proto.PluginRuntimeCapabilities) Support {
-	if src == nil {
-		return Support{}
-	}
-	hostServiceAccess := HostServiceAccessNone
-	if src.GetHostServiceTunnels() {
-		hostServiceAccess = HostServiceAccessDirect
-	}
-	egressMode := EgressModeNone
-	switch {
-	case src.GetHostnameProxyEgress():
-		egressMode = EgressModeHostname
-	case src.GetCidrEgress():
-		egressMode = EgressModeCIDR
-	}
-	launchMode := LaunchModeBundle
-	if src.GetHostPathExecution() {
-		launchMode = LaunchModeHostPath
-	}
-	return Support{
-		CanHostPlugins:    src.GetHostedPluginRuntime() && src.GetProviderGrpcTunnel(),
-		HostServiceAccess: hostServiceAccess,
-		EgressMode:        egressMode,
-		LaunchMode:        launchMode,
-		ExecutionTarget: ExecutionTarget{
-			GOOS:   strings.TrimSpace(src.GetExecutionGoos()),
-			GOARCH: strings.TrimSpace(src.GetExecutionGoarch()),
-		},
 	}
 }
 

--- a/gestaltd/internal/pluginruntime/local.go
+++ b/gestaltd/internal/pluginruntime/local.go
@@ -33,11 +33,10 @@ type localSession struct {
 }
 
 type localBinding struct {
-	id         string
-	envVar     string
-	envTarget  string
-	socketPath string
-	relay      HostServiceRelay
+	id        string
+	envVar    string
+	envTarget string
+	relay     HostServiceRelay
 }
 
 type localPlugin struct {
@@ -178,7 +177,7 @@ func (p *LocalProvider) BindHostService(_ context.Context, req BindHostServiceRe
 		return nil, fmt.Errorf("host service env var is required")
 	}
 
-	relay, envTarget, socketPath, err := normalizeHostServiceBinding(req)
+	relay, envTarget, err := normalizeHostServiceBinding(req)
 	if err != nil {
 		return nil, err
 	}
@@ -190,19 +189,17 @@ func (p *LocalProvider) BindHostService(_ context.Context, req BindHostServiceRe
 		return nil, err
 	}
 	binding := localBinding{
-		id:         p.newID("binding"),
-		envVar:     req.EnvVar,
-		envTarget:  envTarget,
-		socketPath: socketPath,
-		relay:      relay,
+		id:        p.newID("binding"),
+		envVar:    req.EnvVar,
+		envTarget: envTarget,
+		relay:     relay,
 	}
 	session.bindings = append(session.bindings, binding)
 	return &HostServiceBinding{
-		ID:         binding.id,
-		SessionID:  session.id,
-		EnvVar:     binding.envVar,
-		SocketPath: binding.socketPath,
-		Relay:      binding.relay,
+		ID:        binding.id,
+		SessionID: session.id,
+		EnvVar:    binding.envVar,
+		Relay:     binding.relay,
 	}, nil
 }
 
@@ -345,23 +342,20 @@ func cloneStringMap(values map[string]string) map[string]string {
 	return out
 }
 
-func normalizeHostServiceBinding(req BindHostServiceRequest) (HostServiceRelay, string, string, error) {
+func normalizeHostServiceBinding(req BindHostServiceRequest) (HostServiceRelay, string, error) {
 	if relay := req.Relay; relay.DialTarget != "" {
 		network, address, err := dialTarget(relay.DialTarget)
 		if err != nil {
-			return HostServiceRelay{}, "", "", fmt.Errorf("host service relay: %w", err)
+			return HostServiceRelay{}, "", fmt.Errorf("host service relay: %w", err)
 		}
 		switch network {
 		case "unix":
-			return relay, address, address, nil
+			return relay, address, nil
 		case "tcp", "tls":
-			return relay, relay.DialTarget, "", nil
+			return relay, relay.DialTarget, nil
 		default:
-			return HostServiceRelay{}, "", "", fmt.Errorf("host service relay network %q is not supported", network)
+			return HostServiceRelay{}, "", fmt.Errorf("host service relay network %q is not supported", network)
 		}
 	}
-	if req.HostSocketPath == "" {
-		return HostServiceRelay{}, "", "", fmt.Errorf("host service relay is required")
-	}
-	return HostServiceRelay{DialTarget: "unix://" + req.HostSocketPath}, req.HostSocketPath, req.HostSocketPath, nil
+	return HostServiceRelay{}, "", fmt.Errorf("host service relay is required")
 }

--- a/gestaltd/internal/pluginruntime/runtime.go
+++ b/gestaltd/internal/pluginruntime/runtime.go
@@ -91,18 +91,14 @@ type HostServiceRelay struct {
 type BindHostServiceRequest struct {
 	SessionID string
 	EnvVar    string
-	// Deprecated: use Relay instead.
-	HostSocketPath string
-	Relay          HostServiceRelay
+	Relay     HostServiceRelay
 }
 
 type HostServiceBinding struct {
 	ID        string
 	SessionID string
 	EnvVar    string
-	// Deprecated: use Relay instead.
-	SocketPath string
-	Relay      HostServiceRelay
+	Relay     HostServiceRelay
 }
 
 // StartPluginRequest describes the plugin process to launch inside a runtime

--- a/sdk/go/gen/v1/pluginruntime.pb.go
+++ b/sdk/go/gen/v1/pluginruntime.pb.go
@@ -172,106 +172,6 @@ func (PluginRuntimeLaunchMode) EnumDescriptor() ([]byte, []int) {
 	return file_v1_pluginruntime_proto_rawDescGZIP(), []int{2}
 }
 
-type PluginRuntimeCapabilities struct {
-	state               protoimpl.MessageState `protogen:"open.v1"`
-	HostedPluginRuntime bool                   `protobuf:"varint,1,opt,name=hosted_plugin_runtime,json=hostedPluginRuntime,proto3" json:"hosted_plugin_runtime,omitempty"`
-	HostServiceTunnels  bool                   `protobuf:"varint,2,opt,name=host_service_tunnels,json=hostServiceTunnels,proto3" json:"host_service_tunnels,omitempty"`
-	ProviderGrpcTunnel  bool                   `protobuf:"varint,3,opt,name=provider_grpc_tunnel,json=providerGrpcTunnel,proto3" json:"provider_grpc_tunnel,omitempty"`
-	HostnameProxyEgress bool                   `protobuf:"varint,4,opt,name=hostname_proxy_egress,json=hostnameProxyEgress,proto3" json:"hostname_proxy_egress,omitempty"`
-	CidrEgress          bool                   `protobuf:"varint,5,opt,name=cidr_egress,json=cidrEgress,proto3" json:"cidr_egress,omitempty"`
-	HostPathExecution   bool                   `protobuf:"varint,6,opt,name=host_path_execution,json=hostPathExecution,proto3" json:"host_path_execution,omitempty"`
-	ExecutionGoos       string                 `protobuf:"bytes,7,opt,name=execution_goos,json=executionGoos,proto3" json:"execution_goos,omitempty"`
-	ExecutionGoarch     string                 `protobuf:"bytes,8,opt,name=execution_goarch,json=executionGoarch,proto3" json:"execution_goarch,omitempty"`
-	unknownFields       protoimpl.UnknownFields
-	sizeCache           protoimpl.SizeCache
-}
-
-func (x *PluginRuntimeCapabilities) Reset() {
-	*x = PluginRuntimeCapabilities{}
-	mi := &file_v1_pluginruntime_proto_msgTypes[0]
-	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
-	ms.StoreMessageInfo(mi)
-}
-
-func (x *PluginRuntimeCapabilities) String() string {
-	return protoimpl.X.MessageStringOf(x)
-}
-
-func (*PluginRuntimeCapabilities) ProtoMessage() {}
-
-func (x *PluginRuntimeCapabilities) ProtoReflect() protoreflect.Message {
-	mi := &file_v1_pluginruntime_proto_msgTypes[0]
-	if x != nil {
-		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
-		if ms.LoadMessageInfo() == nil {
-			ms.StoreMessageInfo(mi)
-		}
-		return ms
-	}
-	return mi.MessageOf(x)
-}
-
-// Deprecated: Use PluginRuntimeCapabilities.ProtoReflect.Descriptor instead.
-func (*PluginRuntimeCapabilities) Descriptor() ([]byte, []int) {
-	return file_v1_pluginruntime_proto_rawDescGZIP(), []int{0}
-}
-
-func (x *PluginRuntimeCapabilities) GetHostedPluginRuntime() bool {
-	if x != nil {
-		return x.HostedPluginRuntime
-	}
-	return false
-}
-
-func (x *PluginRuntimeCapabilities) GetHostServiceTunnels() bool {
-	if x != nil {
-		return x.HostServiceTunnels
-	}
-	return false
-}
-
-func (x *PluginRuntimeCapabilities) GetProviderGrpcTunnel() bool {
-	if x != nil {
-		return x.ProviderGrpcTunnel
-	}
-	return false
-}
-
-func (x *PluginRuntimeCapabilities) GetHostnameProxyEgress() bool {
-	if x != nil {
-		return x.HostnameProxyEgress
-	}
-	return false
-}
-
-func (x *PluginRuntimeCapabilities) GetCidrEgress() bool {
-	if x != nil {
-		return x.CidrEgress
-	}
-	return false
-}
-
-func (x *PluginRuntimeCapabilities) GetHostPathExecution() bool {
-	if x != nil {
-		return x.HostPathExecution
-	}
-	return false
-}
-
-func (x *PluginRuntimeCapabilities) GetExecutionGoos() string {
-	if x != nil {
-		return x.ExecutionGoos
-	}
-	return ""
-}
-
-func (x *PluginRuntimeCapabilities) GetExecutionGoarch() string {
-	if x != nil {
-		return x.ExecutionGoarch
-	}
-	return ""
-}
-
 type PluginRuntimeExecutionTarget struct {
 	state         protoimpl.MessageState `protogen:"open.v1"`
 	Goos          string                 `protobuf:"bytes,1,opt,name=goos,proto3" json:"goos,omitempty"`
@@ -282,7 +182,7 @@ type PluginRuntimeExecutionTarget struct {
 
 func (x *PluginRuntimeExecutionTarget) Reset() {
 	*x = PluginRuntimeExecutionTarget{}
-	mi := &file_v1_pluginruntime_proto_msgTypes[1]
+	mi := &file_v1_pluginruntime_proto_msgTypes[0]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -294,7 +194,7 @@ func (x *PluginRuntimeExecutionTarget) String() string {
 func (*PluginRuntimeExecutionTarget) ProtoMessage() {}
 
 func (x *PluginRuntimeExecutionTarget) ProtoReflect() protoreflect.Message {
-	mi := &file_v1_pluginruntime_proto_msgTypes[1]
+	mi := &file_v1_pluginruntime_proto_msgTypes[0]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -307,7 +207,7 @@ func (x *PluginRuntimeExecutionTarget) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use PluginRuntimeExecutionTarget.ProtoReflect.Descriptor instead.
 func (*PluginRuntimeExecutionTarget) Descriptor() ([]byte, []int) {
-	return file_v1_pluginruntime_proto_rawDescGZIP(), []int{1}
+	return file_v1_pluginruntime_proto_rawDescGZIP(), []int{0}
 }
 
 func (x *PluginRuntimeExecutionTarget) GetGoos() string {
@@ -337,7 +237,7 @@ type PluginRuntimeSupport struct {
 
 func (x *PluginRuntimeSupport) Reset() {
 	*x = PluginRuntimeSupport{}
-	mi := &file_v1_pluginruntime_proto_msgTypes[2]
+	mi := &file_v1_pluginruntime_proto_msgTypes[1]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -349,7 +249,7 @@ func (x *PluginRuntimeSupport) String() string {
 func (*PluginRuntimeSupport) ProtoMessage() {}
 
 func (x *PluginRuntimeSupport) ProtoReflect() protoreflect.Message {
-	mi := &file_v1_pluginruntime_proto_msgTypes[2]
+	mi := &file_v1_pluginruntime_proto_msgTypes[1]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -362,7 +262,7 @@ func (x *PluginRuntimeSupport) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use PluginRuntimeSupport.ProtoReflect.Descriptor instead.
 func (*PluginRuntimeSupport) Descriptor() ([]byte, []int) {
-	return file_v1_pluginruntime_proto_rawDescGZIP(), []int{2}
+	return file_v1_pluginruntime_proto_rawDescGZIP(), []int{1}
 }
 
 func (x *PluginRuntimeSupport) GetCanHostPlugins() bool {
@@ -401,17 +301,15 @@ func (x *PluginRuntimeSupport) GetExecutionTarget() *PluginRuntimeExecutionTarge
 }
 
 type GetPluginRuntimeCapabilitiesResponse struct {
-	state protoimpl.MessageState `protogen:"open.v1"`
-	// Deprecated: Marked as deprecated in v1/pluginruntime.proto.
-	Capabilities  *PluginRuntimeCapabilities `protobuf:"bytes,1,opt,name=capabilities,proto3" json:"capabilities,omitempty"`
-	Support       *PluginRuntimeSupport      `protobuf:"bytes,2,opt,name=support,proto3" json:"support,omitempty"`
+	state         protoimpl.MessageState `protogen:"open.v1"`
+	Support       *PluginRuntimeSupport  `protobuf:"bytes,2,opt,name=support,proto3" json:"support,omitempty"`
 	unknownFields protoimpl.UnknownFields
 	sizeCache     protoimpl.SizeCache
 }
 
 func (x *GetPluginRuntimeCapabilitiesResponse) Reset() {
 	*x = GetPluginRuntimeCapabilitiesResponse{}
-	mi := &file_v1_pluginruntime_proto_msgTypes[3]
+	mi := &file_v1_pluginruntime_proto_msgTypes[2]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -423,7 +321,7 @@ func (x *GetPluginRuntimeCapabilitiesResponse) String() string {
 func (*GetPluginRuntimeCapabilitiesResponse) ProtoMessage() {}
 
 func (x *GetPluginRuntimeCapabilitiesResponse) ProtoReflect() protoreflect.Message {
-	mi := &file_v1_pluginruntime_proto_msgTypes[3]
+	mi := &file_v1_pluginruntime_proto_msgTypes[2]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -436,15 +334,7 @@ func (x *GetPluginRuntimeCapabilitiesResponse) ProtoReflect() protoreflect.Messa
 
 // Deprecated: Use GetPluginRuntimeCapabilitiesResponse.ProtoReflect.Descriptor instead.
 func (*GetPluginRuntimeCapabilitiesResponse) Descriptor() ([]byte, []int) {
-	return file_v1_pluginruntime_proto_rawDescGZIP(), []int{3}
-}
-
-// Deprecated: Marked as deprecated in v1/pluginruntime.proto.
-func (x *GetPluginRuntimeCapabilitiesResponse) GetCapabilities() *PluginRuntimeCapabilities {
-	if x != nil {
-		return x.Capabilities
-	}
-	return nil
+	return file_v1_pluginruntime_proto_rawDescGZIP(), []int{2}
 }
 
 func (x *GetPluginRuntimeCapabilitiesResponse) GetSupport() *PluginRuntimeSupport {
@@ -465,7 +355,7 @@ type PluginRuntimeSession struct {
 
 func (x *PluginRuntimeSession) Reset() {
 	*x = PluginRuntimeSession{}
-	mi := &file_v1_pluginruntime_proto_msgTypes[4]
+	mi := &file_v1_pluginruntime_proto_msgTypes[3]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -477,7 +367,7 @@ func (x *PluginRuntimeSession) String() string {
 func (*PluginRuntimeSession) ProtoMessage() {}
 
 func (x *PluginRuntimeSession) ProtoReflect() protoreflect.Message {
-	mi := &file_v1_pluginruntime_proto_msgTypes[4]
+	mi := &file_v1_pluginruntime_proto_msgTypes[3]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -490,7 +380,7 @@ func (x *PluginRuntimeSession) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use PluginRuntimeSession.ProtoReflect.Descriptor instead.
 func (*PluginRuntimeSession) Descriptor() ([]byte, []int) {
-	return file_v1_pluginruntime_proto_rawDescGZIP(), []int{4}
+	return file_v1_pluginruntime_proto_rawDescGZIP(), []int{3}
 }
 
 func (x *PluginRuntimeSession) GetId() string {
@@ -526,7 +416,7 @@ type StartPluginRuntimeSessionRequest struct {
 
 func (x *StartPluginRuntimeSessionRequest) Reset() {
 	*x = StartPluginRuntimeSessionRequest{}
-	mi := &file_v1_pluginruntime_proto_msgTypes[5]
+	mi := &file_v1_pluginruntime_proto_msgTypes[4]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -538,7 +428,7 @@ func (x *StartPluginRuntimeSessionRequest) String() string {
 func (*StartPluginRuntimeSessionRequest) ProtoMessage() {}
 
 func (x *StartPluginRuntimeSessionRequest) ProtoReflect() protoreflect.Message {
-	mi := &file_v1_pluginruntime_proto_msgTypes[5]
+	mi := &file_v1_pluginruntime_proto_msgTypes[4]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -551,7 +441,7 @@ func (x *StartPluginRuntimeSessionRequest) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use StartPluginRuntimeSessionRequest.ProtoReflect.Descriptor instead.
 func (*StartPluginRuntimeSessionRequest) Descriptor() ([]byte, []int) {
-	return file_v1_pluginruntime_proto_rawDescGZIP(), []int{5}
+	return file_v1_pluginruntime_proto_rawDescGZIP(), []int{4}
 }
 
 func (x *StartPluginRuntimeSessionRequest) GetPluginName() string {
@@ -591,7 +481,7 @@ type GetPluginRuntimeSessionRequest struct {
 
 func (x *GetPluginRuntimeSessionRequest) Reset() {
 	*x = GetPluginRuntimeSessionRequest{}
-	mi := &file_v1_pluginruntime_proto_msgTypes[6]
+	mi := &file_v1_pluginruntime_proto_msgTypes[5]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -603,7 +493,7 @@ func (x *GetPluginRuntimeSessionRequest) String() string {
 func (*GetPluginRuntimeSessionRequest) ProtoMessage() {}
 
 func (x *GetPluginRuntimeSessionRequest) ProtoReflect() protoreflect.Message {
-	mi := &file_v1_pluginruntime_proto_msgTypes[6]
+	mi := &file_v1_pluginruntime_proto_msgTypes[5]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -616,7 +506,7 @@ func (x *GetPluginRuntimeSessionRequest) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use GetPluginRuntimeSessionRequest.ProtoReflect.Descriptor instead.
 func (*GetPluginRuntimeSessionRequest) Descriptor() ([]byte, []int) {
-	return file_v1_pluginruntime_proto_rawDescGZIP(), []int{6}
+	return file_v1_pluginruntime_proto_rawDescGZIP(), []int{5}
 }
 
 func (x *GetPluginRuntimeSessionRequest) GetSessionId() string {
@@ -635,7 +525,7 @@ type StopPluginRuntimeSessionRequest struct {
 
 func (x *StopPluginRuntimeSessionRequest) Reset() {
 	*x = StopPluginRuntimeSessionRequest{}
-	mi := &file_v1_pluginruntime_proto_msgTypes[7]
+	mi := &file_v1_pluginruntime_proto_msgTypes[6]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -647,7 +537,7 @@ func (x *StopPluginRuntimeSessionRequest) String() string {
 func (*StopPluginRuntimeSessionRequest) ProtoMessage() {}
 
 func (x *StopPluginRuntimeSessionRequest) ProtoReflect() protoreflect.Message {
-	mi := &file_v1_pluginruntime_proto_msgTypes[7]
+	mi := &file_v1_pluginruntime_proto_msgTypes[6]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -660,7 +550,7 @@ func (x *StopPluginRuntimeSessionRequest) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use StopPluginRuntimeSessionRequest.ProtoReflect.Descriptor instead.
 func (*StopPluginRuntimeSessionRequest) Descriptor() ([]byte, []int) {
-	return file_v1_pluginruntime_proto_rawDescGZIP(), []int{7}
+	return file_v1_pluginruntime_proto_rawDescGZIP(), []int{6}
 }
 
 func (x *StopPluginRuntimeSessionRequest) GetSessionId() string {
@@ -679,7 +569,7 @@ type PluginRuntimeHostServiceRelay struct {
 
 func (x *PluginRuntimeHostServiceRelay) Reset() {
 	*x = PluginRuntimeHostServiceRelay{}
-	mi := &file_v1_pluginruntime_proto_msgTypes[8]
+	mi := &file_v1_pluginruntime_proto_msgTypes[7]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -691,7 +581,7 @@ func (x *PluginRuntimeHostServiceRelay) String() string {
 func (*PluginRuntimeHostServiceRelay) ProtoMessage() {}
 
 func (x *PluginRuntimeHostServiceRelay) ProtoReflect() protoreflect.Message {
-	mi := &file_v1_pluginruntime_proto_msgTypes[8]
+	mi := &file_v1_pluginruntime_proto_msgTypes[7]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -704,7 +594,7 @@ func (x *PluginRuntimeHostServiceRelay) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use PluginRuntimeHostServiceRelay.ProtoReflect.Descriptor instead.
 func (*PluginRuntimeHostServiceRelay) Descriptor() ([]byte, []int) {
-	return file_v1_pluginruntime_proto_rawDescGZIP(), []int{8}
+	return file_v1_pluginruntime_proto_rawDescGZIP(), []int{7}
 }
 
 func (x *PluginRuntimeHostServiceRelay) GetDialTarget() string {
@@ -715,19 +605,17 @@ func (x *PluginRuntimeHostServiceRelay) GetDialTarget() string {
 }
 
 type BindPluginRuntimeHostServiceRequest struct {
-	state     protoimpl.MessageState `protogen:"open.v1"`
-	SessionId string                 `protobuf:"bytes,1,opt,name=session_id,json=sessionId,proto3" json:"session_id,omitempty"`
-	EnvVar    string                 `protobuf:"bytes,2,opt,name=env_var,json=envVar,proto3" json:"env_var,omitempty"`
-	// Deprecated: Marked as deprecated in v1/pluginruntime.proto.
-	HostSocketPath string                         `protobuf:"bytes,3,opt,name=host_socket_path,json=hostSocketPath,proto3" json:"host_socket_path,omitempty"`
-	Relay          *PluginRuntimeHostServiceRelay `protobuf:"bytes,4,opt,name=relay,proto3" json:"relay,omitempty"`
-	unknownFields  protoimpl.UnknownFields
-	sizeCache      protoimpl.SizeCache
+	state         protoimpl.MessageState         `protogen:"open.v1"`
+	SessionId     string                         `protobuf:"bytes,1,opt,name=session_id,json=sessionId,proto3" json:"session_id,omitempty"`
+	EnvVar        string                         `protobuf:"bytes,2,opt,name=env_var,json=envVar,proto3" json:"env_var,omitempty"`
+	Relay         *PluginRuntimeHostServiceRelay `protobuf:"bytes,4,opt,name=relay,proto3" json:"relay,omitempty"`
+	unknownFields protoimpl.UnknownFields
+	sizeCache     protoimpl.SizeCache
 }
 
 func (x *BindPluginRuntimeHostServiceRequest) Reset() {
 	*x = BindPluginRuntimeHostServiceRequest{}
-	mi := &file_v1_pluginruntime_proto_msgTypes[9]
+	mi := &file_v1_pluginruntime_proto_msgTypes[8]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -739,7 +627,7 @@ func (x *BindPluginRuntimeHostServiceRequest) String() string {
 func (*BindPluginRuntimeHostServiceRequest) ProtoMessage() {}
 
 func (x *BindPluginRuntimeHostServiceRequest) ProtoReflect() protoreflect.Message {
-	mi := &file_v1_pluginruntime_proto_msgTypes[9]
+	mi := &file_v1_pluginruntime_proto_msgTypes[8]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -752,7 +640,7 @@ func (x *BindPluginRuntimeHostServiceRequest) ProtoReflect() protoreflect.Messag
 
 // Deprecated: Use BindPluginRuntimeHostServiceRequest.ProtoReflect.Descriptor instead.
 func (*BindPluginRuntimeHostServiceRequest) Descriptor() ([]byte, []int) {
-	return file_v1_pluginruntime_proto_rawDescGZIP(), []int{9}
+	return file_v1_pluginruntime_proto_rawDescGZIP(), []int{8}
 }
 
 func (x *BindPluginRuntimeHostServiceRequest) GetSessionId() string {
@@ -769,14 +657,6 @@ func (x *BindPluginRuntimeHostServiceRequest) GetEnvVar() string {
 	return ""
 }
 
-// Deprecated: Marked as deprecated in v1/pluginruntime.proto.
-func (x *BindPluginRuntimeHostServiceRequest) GetHostSocketPath() string {
-	if x != nil {
-		return x.HostSocketPath
-	}
-	return ""
-}
-
 func (x *BindPluginRuntimeHostServiceRequest) GetRelay() *PluginRuntimeHostServiceRelay {
 	if x != nil {
 		return x.Relay
@@ -785,12 +665,10 @@ func (x *BindPluginRuntimeHostServiceRequest) GetRelay() *PluginRuntimeHostServi
 }
 
 type PluginRuntimeHostServiceBinding struct {
-	state     protoimpl.MessageState `protogen:"open.v1"`
-	Id        string                 `protobuf:"bytes,1,opt,name=id,proto3" json:"id,omitempty"`
-	SessionId string                 `protobuf:"bytes,2,opt,name=session_id,json=sessionId,proto3" json:"session_id,omitempty"`
-	EnvVar    string                 `protobuf:"bytes,3,opt,name=env_var,json=envVar,proto3" json:"env_var,omitempty"`
-	// Deprecated: Marked as deprecated in v1/pluginruntime.proto.
-	SocketPath    string                         `protobuf:"bytes,4,opt,name=socket_path,json=socketPath,proto3" json:"socket_path,omitempty"`
+	state         protoimpl.MessageState         `protogen:"open.v1"`
+	Id            string                         `protobuf:"bytes,1,opt,name=id,proto3" json:"id,omitempty"`
+	SessionId     string                         `protobuf:"bytes,2,opt,name=session_id,json=sessionId,proto3" json:"session_id,omitempty"`
+	EnvVar        string                         `protobuf:"bytes,3,opt,name=env_var,json=envVar,proto3" json:"env_var,omitempty"`
 	Relay         *PluginRuntimeHostServiceRelay `protobuf:"bytes,5,opt,name=relay,proto3" json:"relay,omitempty"`
 	unknownFields protoimpl.UnknownFields
 	sizeCache     protoimpl.SizeCache
@@ -798,7 +676,7 @@ type PluginRuntimeHostServiceBinding struct {
 
 func (x *PluginRuntimeHostServiceBinding) Reset() {
 	*x = PluginRuntimeHostServiceBinding{}
-	mi := &file_v1_pluginruntime_proto_msgTypes[10]
+	mi := &file_v1_pluginruntime_proto_msgTypes[9]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -810,7 +688,7 @@ func (x *PluginRuntimeHostServiceBinding) String() string {
 func (*PluginRuntimeHostServiceBinding) ProtoMessage() {}
 
 func (x *PluginRuntimeHostServiceBinding) ProtoReflect() protoreflect.Message {
-	mi := &file_v1_pluginruntime_proto_msgTypes[10]
+	mi := &file_v1_pluginruntime_proto_msgTypes[9]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -823,7 +701,7 @@ func (x *PluginRuntimeHostServiceBinding) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use PluginRuntimeHostServiceBinding.ProtoReflect.Descriptor instead.
 func (*PluginRuntimeHostServiceBinding) Descriptor() ([]byte, []int) {
-	return file_v1_pluginruntime_proto_rawDescGZIP(), []int{10}
+	return file_v1_pluginruntime_proto_rawDescGZIP(), []int{9}
 }
 
 func (x *PluginRuntimeHostServiceBinding) GetId() string {
@@ -843,14 +721,6 @@ func (x *PluginRuntimeHostServiceBinding) GetSessionId() string {
 func (x *PluginRuntimeHostServiceBinding) GetEnvVar() string {
 	if x != nil {
 		return x.EnvVar
-	}
-	return ""
-}
-
-// Deprecated: Marked as deprecated in v1/pluginruntime.proto.
-func (x *PluginRuntimeHostServiceBinding) GetSocketPath() string {
-	if x != nil {
-		return x.SocketPath
 	}
 	return ""
 }
@@ -883,7 +753,7 @@ type StartHostedPluginRequest struct {
 
 func (x *StartHostedPluginRequest) Reset() {
 	*x = StartHostedPluginRequest{}
-	mi := &file_v1_pluginruntime_proto_msgTypes[11]
+	mi := &file_v1_pluginruntime_proto_msgTypes[10]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -895,7 +765,7 @@ func (x *StartHostedPluginRequest) String() string {
 func (*StartHostedPluginRequest) ProtoMessage() {}
 
 func (x *StartHostedPluginRequest) ProtoReflect() protoreflect.Message {
-	mi := &file_v1_pluginruntime_proto_msgTypes[11]
+	mi := &file_v1_pluginruntime_proto_msgTypes[10]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -908,7 +778,7 @@ func (x *StartHostedPluginRequest) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use StartHostedPluginRequest.ProtoReflect.Descriptor instead.
 func (*StartHostedPluginRequest) Descriptor() ([]byte, []int) {
-	return file_v1_pluginruntime_proto_rawDescGZIP(), []int{11}
+	return file_v1_pluginruntime_proto_rawDescGZIP(), []int{10}
 }
 
 func (x *StartHostedPluginRequest) GetSessionId() string {
@@ -986,7 +856,7 @@ type HostedPlugin struct {
 
 func (x *HostedPlugin) Reset() {
 	*x = HostedPlugin{}
-	mi := &file_v1_pluginruntime_proto_msgTypes[12]
+	mi := &file_v1_pluginruntime_proto_msgTypes[11]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -998,7 +868,7 @@ func (x *HostedPlugin) String() string {
 func (*HostedPlugin) ProtoMessage() {}
 
 func (x *HostedPlugin) ProtoReflect() protoreflect.Message {
-	mi := &file_v1_pluginruntime_proto_msgTypes[12]
+	mi := &file_v1_pluginruntime_proto_msgTypes[11]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -1011,7 +881,7 @@ func (x *HostedPlugin) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use HostedPlugin.ProtoReflect.Descriptor instead.
 func (*HostedPlugin) Descriptor() ([]byte, []int) {
-	return file_v1_pluginruntime_proto_rawDescGZIP(), []int{12}
+	return file_v1_pluginruntime_proto_rawDescGZIP(), []int{11}
 }
 
 func (x *HostedPlugin) GetId() string {
@@ -1046,17 +916,7 @@ var File_v1_pluginruntime_proto protoreflect.FileDescriptor
 
 const file_v1_pluginruntime_proto_rawDesc = "" +
 	"\n" +
-	"\x16v1/pluginruntime.proto\x12\x13gestalt.provider.v1\x1a\x1bgoogle/protobuf/empty.proto\"\x8a\x03\n" +
-	"\x19PluginRuntimeCapabilities\x122\n" +
-	"\x15hosted_plugin_runtime\x18\x01 \x01(\bR\x13hostedPluginRuntime\x120\n" +
-	"\x14host_service_tunnels\x18\x02 \x01(\bR\x12hostServiceTunnels\x120\n" +
-	"\x14provider_grpc_tunnel\x18\x03 \x01(\bR\x12providerGrpcTunnel\x122\n" +
-	"\x15hostname_proxy_egress\x18\x04 \x01(\bR\x13hostnameProxyEgress\x12\x1f\n" +
-	"\vcidr_egress\x18\x05 \x01(\bR\n" +
-	"cidrEgress\x12.\n" +
-	"\x13host_path_execution\x18\x06 \x01(\bR\x11hostPathExecution\x12%\n" +
-	"\x0eexecution_goos\x18\a \x01(\tR\rexecutionGoos\x12)\n" +
-	"\x10execution_goarch\x18\b \x01(\tR\x0fexecutionGoarch\"J\n" +
+	"\x16v1/pluginruntime.proto\x12\x13gestalt.provider.v1\x1a\x1bgoogle/protobuf/empty.proto\"J\n" +
 	"\x1cPluginRuntimeExecutionTarget\x12\x12\n" +
 	"\x04goos\x18\x01 \x01(\tR\x04goos\x12\x16\n" +
 	"\x06goarch\x18\x02 \x01(\tR\x06goarch\"\xa1\x03\n" +
@@ -1067,10 +927,9 @@ const file_v1_pluginruntime_proto_rawDesc = "" +
 	"egressMode\x12M\n" +
 	"\vlaunch_mode\x18\x04 \x01(\x0e2,.gestalt.provider.v1.PluginRuntimeLaunchModeR\n" +
 	"launchMode\x12\\\n" +
-	"\x10execution_target\x18\x05 \x01(\v21.gestalt.provider.v1.PluginRuntimeExecutionTargetR\x0fexecutionTarget\"\xc3\x01\n" +
-	"$GetPluginRuntimeCapabilitiesResponse\x12V\n" +
-	"\fcapabilities\x18\x01 \x01(\v2..gestalt.provider.v1.PluginRuntimeCapabilitiesB\x02\x18\x01R\fcapabilities\x12C\n" +
-	"\asupport\x18\x02 \x01(\v2).gestalt.provider.v1.PluginRuntimeSupportR\asupport\"\xce\x01\n" +
+	"\x10execution_target\x18\x05 \x01(\v21.gestalt.provider.v1.PluginRuntimeExecutionTargetR\x0fexecutionTarget\"q\n" +
+	"$GetPluginRuntimeCapabilitiesResponse\x12C\n" +
+	"\asupport\x18\x02 \x01(\v2).gestalt.provider.v1.PluginRuntimeSupportR\asupportJ\x04\b\x01\x10\x02\"\xce\x01\n" +
 	"\x14PluginRuntimeSession\x12\x0e\n" +
 	"\x02id\x18\x01 \x01(\tR\x02id\x12\x14\n" +
 	"\x05state\x18\x02 \x01(\tR\x05state\x12S\n" +
@@ -1095,21 +954,18 @@ const file_v1_pluginruntime_proto_rawDesc = "" +
 	"session_id\x18\x01 \x01(\tR\tsessionId\"@\n" +
 	"\x1dPluginRuntimeHostServiceRelay\x12\x1f\n" +
 	"\vdial_target\x18\x01 \x01(\tR\n" +
-	"dialTarget\"\xd5\x01\n" +
+	"dialTarget\"\xad\x01\n" +
 	"#BindPluginRuntimeHostServiceRequest\x12\x1d\n" +
 	"\n" +
 	"session_id\x18\x01 \x01(\tR\tsessionId\x12\x17\n" +
-	"\aenv_var\x18\x02 \x01(\tR\x06envVar\x12,\n" +
-	"\x10host_socket_path\x18\x03 \x01(\tB\x02\x18\x01R\x0ehostSocketPath\x12H\n" +
-	"\x05relay\x18\x04 \x01(\v22.gestalt.provider.v1.PluginRuntimeHostServiceRelayR\x05relay\"\xd8\x01\n" +
+	"\aenv_var\x18\x02 \x01(\tR\x06envVar\x12H\n" +
+	"\x05relay\x18\x04 \x01(\v22.gestalt.provider.v1.PluginRuntimeHostServiceRelayR\x05relayJ\x04\b\x03\x10\x04\"\xb9\x01\n" +
 	"\x1fPluginRuntimeHostServiceBinding\x12\x0e\n" +
 	"\x02id\x18\x01 \x01(\tR\x02id\x12\x1d\n" +
 	"\n" +
 	"session_id\x18\x02 \x01(\tR\tsessionId\x12\x17\n" +
-	"\aenv_var\x18\x03 \x01(\tR\x06envVar\x12#\n" +
-	"\vsocket_path\x18\x04 \x01(\tB\x02\x18\x01R\n" +
-	"socketPath\x12H\n" +
-	"\x05relay\x18\x05 \x01(\v22.gestalt.provider.v1.PluginRuntimeHostServiceRelayR\x05relay\"\x96\x03\n" +
+	"\aenv_var\x18\x03 \x01(\tR\x06envVar\x12H\n" +
+	"\x05relay\x18\x05 \x01(\v22.gestalt.provider.v1.PluginRuntimeHostServiceRelayR\x05relayJ\x04\b\x04\x10\x05\"\x96\x03\n" +
 	"\x18StartHostedPluginRequest\x12\x1d\n" +
 	"\n" +
 	"session_id\x18\x01 \x01(\tR\tsessionId\x12\x1f\n" +
@@ -1171,58 +1027,56 @@ func file_v1_pluginruntime_proto_rawDescGZIP() []byte {
 }
 
 var file_v1_pluginruntime_proto_enumTypes = make([]protoimpl.EnumInfo, 3)
-var file_v1_pluginruntime_proto_msgTypes = make([]protoimpl.MessageInfo, 16)
+var file_v1_pluginruntime_proto_msgTypes = make([]protoimpl.MessageInfo, 15)
 var file_v1_pluginruntime_proto_goTypes = []any{
 	(PluginRuntimeHostServiceAccess)(0),          // 0: gestalt.provider.v1.PluginRuntimeHostServiceAccess
 	(PluginRuntimeEgressMode)(0),                 // 1: gestalt.provider.v1.PluginRuntimeEgressMode
 	(PluginRuntimeLaunchMode)(0),                 // 2: gestalt.provider.v1.PluginRuntimeLaunchMode
-	(*PluginRuntimeCapabilities)(nil),            // 3: gestalt.provider.v1.PluginRuntimeCapabilities
-	(*PluginRuntimeExecutionTarget)(nil),         // 4: gestalt.provider.v1.PluginRuntimeExecutionTarget
-	(*PluginRuntimeSupport)(nil),                 // 5: gestalt.provider.v1.PluginRuntimeSupport
-	(*GetPluginRuntimeCapabilitiesResponse)(nil), // 6: gestalt.provider.v1.GetPluginRuntimeCapabilitiesResponse
-	(*PluginRuntimeSession)(nil),                 // 7: gestalt.provider.v1.PluginRuntimeSession
-	(*StartPluginRuntimeSessionRequest)(nil),     // 8: gestalt.provider.v1.StartPluginRuntimeSessionRequest
-	(*GetPluginRuntimeSessionRequest)(nil),       // 9: gestalt.provider.v1.GetPluginRuntimeSessionRequest
-	(*StopPluginRuntimeSessionRequest)(nil),      // 10: gestalt.provider.v1.StopPluginRuntimeSessionRequest
-	(*PluginRuntimeHostServiceRelay)(nil),        // 11: gestalt.provider.v1.PluginRuntimeHostServiceRelay
-	(*BindPluginRuntimeHostServiceRequest)(nil),  // 12: gestalt.provider.v1.BindPluginRuntimeHostServiceRequest
-	(*PluginRuntimeHostServiceBinding)(nil),      // 13: gestalt.provider.v1.PluginRuntimeHostServiceBinding
-	(*StartHostedPluginRequest)(nil),             // 14: gestalt.provider.v1.StartHostedPluginRequest
-	(*HostedPlugin)(nil),                         // 15: gestalt.provider.v1.HostedPlugin
-	nil,                                          // 16: gestalt.provider.v1.PluginRuntimeSession.MetadataEntry
-	nil,                                          // 17: gestalt.provider.v1.StartPluginRuntimeSessionRequest.MetadataEntry
-	nil,                                          // 18: gestalt.provider.v1.StartHostedPluginRequest.EnvEntry
-	(*emptypb.Empty)(nil),                        // 19: google.protobuf.Empty
+	(*PluginRuntimeExecutionTarget)(nil),         // 3: gestalt.provider.v1.PluginRuntimeExecutionTarget
+	(*PluginRuntimeSupport)(nil),                 // 4: gestalt.provider.v1.PluginRuntimeSupport
+	(*GetPluginRuntimeCapabilitiesResponse)(nil), // 5: gestalt.provider.v1.GetPluginRuntimeCapabilitiesResponse
+	(*PluginRuntimeSession)(nil),                 // 6: gestalt.provider.v1.PluginRuntimeSession
+	(*StartPluginRuntimeSessionRequest)(nil),     // 7: gestalt.provider.v1.StartPluginRuntimeSessionRequest
+	(*GetPluginRuntimeSessionRequest)(nil),       // 8: gestalt.provider.v1.GetPluginRuntimeSessionRequest
+	(*StopPluginRuntimeSessionRequest)(nil),      // 9: gestalt.provider.v1.StopPluginRuntimeSessionRequest
+	(*PluginRuntimeHostServiceRelay)(nil),        // 10: gestalt.provider.v1.PluginRuntimeHostServiceRelay
+	(*BindPluginRuntimeHostServiceRequest)(nil),  // 11: gestalt.provider.v1.BindPluginRuntimeHostServiceRequest
+	(*PluginRuntimeHostServiceBinding)(nil),      // 12: gestalt.provider.v1.PluginRuntimeHostServiceBinding
+	(*StartHostedPluginRequest)(nil),             // 13: gestalt.provider.v1.StartHostedPluginRequest
+	(*HostedPlugin)(nil),                         // 14: gestalt.provider.v1.HostedPlugin
+	nil,                                          // 15: gestalt.provider.v1.PluginRuntimeSession.MetadataEntry
+	nil,                                          // 16: gestalt.provider.v1.StartPluginRuntimeSessionRequest.MetadataEntry
+	nil,                                          // 17: gestalt.provider.v1.StartHostedPluginRequest.EnvEntry
+	(*emptypb.Empty)(nil),                        // 18: google.protobuf.Empty
 }
 var file_v1_pluginruntime_proto_depIdxs = []int32{
 	0,  // 0: gestalt.provider.v1.PluginRuntimeSupport.host_service_access:type_name -> gestalt.provider.v1.PluginRuntimeHostServiceAccess
 	1,  // 1: gestalt.provider.v1.PluginRuntimeSupport.egress_mode:type_name -> gestalt.provider.v1.PluginRuntimeEgressMode
 	2,  // 2: gestalt.provider.v1.PluginRuntimeSupport.launch_mode:type_name -> gestalt.provider.v1.PluginRuntimeLaunchMode
-	4,  // 3: gestalt.provider.v1.PluginRuntimeSupport.execution_target:type_name -> gestalt.provider.v1.PluginRuntimeExecutionTarget
-	3,  // 4: gestalt.provider.v1.GetPluginRuntimeCapabilitiesResponse.capabilities:type_name -> gestalt.provider.v1.PluginRuntimeCapabilities
-	5,  // 5: gestalt.provider.v1.GetPluginRuntimeCapabilitiesResponse.support:type_name -> gestalt.provider.v1.PluginRuntimeSupport
-	16, // 6: gestalt.provider.v1.PluginRuntimeSession.metadata:type_name -> gestalt.provider.v1.PluginRuntimeSession.MetadataEntry
-	17, // 7: gestalt.provider.v1.StartPluginRuntimeSessionRequest.metadata:type_name -> gestalt.provider.v1.StartPluginRuntimeSessionRequest.MetadataEntry
-	11, // 8: gestalt.provider.v1.BindPluginRuntimeHostServiceRequest.relay:type_name -> gestalt.provider.v1.PluginRuntimeHostServiceRelay
-	11, // 9: gestalt.provider.v1.PluginRuntimeHostServiceBinding.relay:type_name -> gestalt.provider.v1.PluginRuntimeHostServiceRelay
-	18, // 10: gestalt.provider.v1.StartHostedPluginRequest.env:type_name -> gestalt.provider.v1.StartHostedPluginRequest.EnvEntry
-	19, // 11: gestalt.provider.v1.PluginRuntimeProvider.GetCapabilities:input_type -> google.protobuf.Empty
-	8,  // 12: gestalt.provider.v1.PluginRuntimeProvider.StartSession:input_type -> gestalt.provider.v1.StartPluginRuntimeSessionRequest
-	9,  // 13: gestalt.provider.v1.PluginRuntimeProvider.GetSession:input_type -> gestalt.provider.v1.GetPluginRuntimeSessionRequest
-	10, // 14: gestalt.provider.v1.PluginRuntimeProvider.StopSession:input_type -> gestalt.provider.v1.StopPluginRuntimeSessionRequest
-	12, // 15: gestalt.provider.v1.PluginRuntimeProvider.BindHostService:input_type -> gestalt.provider.v1.BindPluginRuntimeHostServiceRequest
-	14, // 16: gestalt.provider.v1.PluginRuntimeProvider.StartPlugin:input_type -> gestalt.provider.v1.StartHostedPluginRequest
-	6,  // 17: gestalt.provider.v1.PluginRuntimeProvider.GetCapabilities:output_type -> gestalt.provider.v1.GetPluginRuntimeCapabilitiesResponse
-	7,  // 18: gestalt.provider.v1.PluginRuntimeProvider.StartSession:output_type -> gestalt.provider.v1.PluginRuntimeSession
-	7,  // 19: gestalt.provider.v1.PluginRuntimeProvider.GetSession:output_type -> gestalt.provider.v1.PluginRuntimeSession
-	19, // 20: gestalt.provider.v1.PluginRuntimeProvider.StopSession:output_type -> google.protobuf.Empty
-	13, // 21: gestalt.provider.v1.PluginRuntimeProvider.BindHostService:output_type -> gestalt.provider.v1.PluginRuntimeHostServiceBinding
-	15, // 22: gestalt.provider.v1.PluginRuntimeProvider.StartPlugin:output_type -> gestalt.provider.v1.HostedPlugin
-	17, // [17:23] is the sub-list for method output_type
-	11, // [11:17] is the sub-list for method input_type
-	11, // [11:11] is the sub-list for extension type_name
-	11, // [11:11] is the sub-list for extension extendee
-	0,  // [0:11] is the sub-list for field type_name
+	3,  // 3: gestalt.provider.v1.PluginRuntimeSupport.execution_target:type_name -> gestalt.provider.v1.PluginRuntimeExecutionTarget
+	4,  // 4: gestalt.provider.v1.GetPluginRuntimeCapabilitiesResponse.support:type_name -> gestalt.provider.v1.PluginRuntimeSupport
+	15, // 5: gestalt.provider.v1.PluginRuntimeSession.metadata:type_name -> gestalt.provider.v1.PluginRuntimeSession.MetadataEntry
+	16, // 6: gestalt.provider.v1.StartPluginRuntimeSessionRequest.metadata:type_name -> gestalt.provider.v1.StartPluginRuntimeSessionRequest.MetadataEntry
+	10, // 7: gestalt.provider.v1.BindPluginRuntimeHostServiceRequest.relay:type_name -> gestalt.provider.v1.PluginRuntimeHostServiceRelay
+	10, // 8: gestalt.provider.v1.PluginRuntimeHostServiceBinding.relay:type_name -> gestalt.provider.v1.PluginRuntimeHostServiceRelay
+	17, // 9: gestalt.provider.v1.StartHostedPluginRequest.env:type_name -> gestalt.provider.v1.StartHostedPluginRequest.EnvEntry
+	18, // 10: gestalt.provider.v1.PluginRuntimeProvider.GetCapabilities:input_type -> google.protobuf.Empty
+	7,  // 11: gestalt.provider.v1.PluginRuntimeProvider.StartSession:input_type -> gestalt.provider.v1.StartPluginRuntimeSessionRequest
+	8,  // 12: gestalt.provider.v1.PluginRuntimeProvider.GetSession:input_type -> gestalt.provider.v1.GetPluginRuntimeSessionRequest
+	9,  // 13: gestalt.provider.v1.PluginRuntimeProvider.StopSession:input_type -> gestalt.provider.v1.StopPluginRuntimeSessionRequest
+	11, // 14: gestalt.provider.v1.PluginRuntimeProvider.BindHostService:input_type -> gestalt.provider.v1.BindPluginRuntimeHostServiceRequest
+	13, // 15: gestalt.provider.v1.PluginRuntimeProvider.StartPlugin:input_type -> gestalt.provider.v1.StartHostedPluginRequest
+	5,  // 16: gestalt.provider.v1.PluginRuntimeProvider.GetCapabilities:output_type -> gestalt.provider.v1.GetPluginRuntimeCapabilitiesResponse
+	6,  // 17: gestalt.provider.v1.PluginRuntimeProvider.StartSession:output_type -> gestalt.provider.v1.PluginRuntimeSession
+	6,  // 18: gestalt.provider.v1.PluginRuntimeProvider.GetSession:output_type -> gestalt.provider.v1.PluginRuntimeSession
+	18, // 19: gestalt.provider.v1.PluginRuntimeProvider.StopSession:output_type -> google.protobuf.Empty
+	12, // 20: gestalt.provider.v1.PluginRuntimeProvider.BindHostService:output_type -> gestalt.provider.v1.PluginRuntimeHostServiceBinding
+	14, // 21: gestalt.provider.v1.PluginRuntimeProvider.StartPlugin:output_type -> gestalt.provider.v1.HostedPlugin
+	16, // [16:22] is the sub-list for method output_type
+	10, // [10:16] is the sub-list for method input_type
+	10, // [10:10] is the sub-list for extension type_name
+	10, // [10:10] is the sub-list for extension extendee
+	0,  // [0:10] is the sub-list for field type_name
 }
 
 func init() { file_v1_pluginruntime_proto_init() }
@@ -1236,7 +1090,7 @@ func file_v1_pluginruntime_proto_init() {
 			GoPackagePath: reflect.TypeOf(x{}).PkgPath(),
 			RawDescriptor: unsafe.Slice(unsafe.StringData(file_v1_pluginruntime_proto_rawDesc), len(file_v1_pluginruntime_proto_rawDesc)),
 			NumEnums:      3,
-			NumMessages:   16,
+			NumMessages:   15,
 			NumExtensions: 0,
 			NumServices:   1,
 		},

--- a/sdk/proto/v1/pluginruntime.proto
+++ b/sdk/proto/v1/pluginruntime.proto
@@ -6,17 +6,6 @@ import "google/protobuf/empty.proto";
 
 option go_package = "github.com/valon-technologies/gestalt/sdk/go/gen/v1;proto";
 
-message PluginRuntimeCapabilities {
-  bool hosted_plugin_runtime = 1;
-  bool host_service_tunnels = 2;
-  bool provider_grpc_tunnel = 3;
-  bool hostname_proxy_egress = 4;
-  bool cidr_egress = 5;
-  bool host_path_execution = 6;
-  string execution_goos = 7;
-  string execution_goarch = 8;
-}
-
 enum PluginRuntimeHostServiceAccess {
   PLUGIN_RUNTIME_HOST_SERVICE_ACCESS_UNSPECIFIED = 0;
   PLUGIN_RUNTIME_HOST_SERVICE_ACCESS_NONE = 1;
@@ -50,7 +39,7 @@ message PluginRuntimeSupport {
 }
 
 message GetPluginRuntimeCapabilitiesResponse {
-  PluginRuntimeCapabilities capabilities = 1 [deprecated = true];
+  reserved 1;
   PluginRuntimeSupport support = 2;
 }
 
@@ -80,17 +69,17 @@ message PluginRuntimeHostServiceRelay {
 }
 
 message BindPluginRuntimeHostServiceRequest {
+  reserved 3;
   string session_id = 1;
   string env_var = 2;
-  string host_socket_path = 3 [deprecated = true];
   PluginRuntimeHostServiceRelay relay = 4;
 }
 
 message PluginRuntimeHostServiceBinding {
+  reserved 4;
   string id = 1;
   string session_id = 2;
   string env_var = 3;
-  string socket_path = 4 [deprecated = true];
   PluginRuntimeHostServiceRelay relay = 5;
 }
 


### PR DESCRIPTION
## Summary

This removes the runtime-provider compatibility surface that still exposed the old raw capability and socket-path fields.

The runtime proto now only exposes the grouped `support` contract on `GetPluginRuntimeCapabilitiesResponse`. The old `PluginRuntimeCapabilities` message and `capabilities` response field are gone. `BindPluginRuntimeHostServiceRequest` and `PluginRuntimeHostServiceBinding` now only use `relay`; the deprecated `host_socket_path` and `socket_path` fields are gone as well.

The host-side runtime adapter now requires the grouped support field directly instead of deriving support from the legacy capability booleans. Direct local bindings still use the same `unix://<socket>` relay target, but that target is carried only through `relay.dial_target`.

## Interface shape

Before, runtime providers could return either the old capability bag or the grouped support field:

```proto
message GetPluginRuntimeCapabilitiesResponse {
  PluginRuntimeCapabilities capabilities = 1 [deprecated = true];
  PluginRuntimeSupport support = 2;
}
```

Now the provider contract is a single support profile:

```proto
message GetPluginRuntimeCapabilitiesResponse {
  reserved 1;
  PluginRuntimeSupport support = 2;
}
```

Before, host services had both socket-path and relay fields:

```proto
message BindPluginRuntimeHostServiceRequest {
  string session_id = 1;
  string env_var = 2;
  string host_socket_path = 3 [deprecated = true];
  PluginRuntimeHostServiceRelay relay = 4;
}
```

Now all host-service bindings use the relay target:

```proto
message BindPluginRuntimeHostServiceRequest {
  reserved 3;
  string session_id = 1;
  string env_var = 2;
  PluginRuntimeHostServiceRelay relay = 4;
}
```

## Validation

Validated from a clean detached worktree at this commit.

Ran `buf generate` and verified no generated Go binding diff.

Ran `go test ./...` in `sdk/go`.

Ran `go test ./internal/pluginruntime ./internal/bootstrap ./internal/server` in `gestaltd`.

Ran full `go test ./...` in `gestaltd`.

Ran `git diff --check`.

`buf lint` still fails on pre-existing repository-wide proto lint issues unrelated to this PR, so I used the same generated-binding check pattern as CI instead.