### PR TITLE
[codex] Add agent CLI and singular command names

### DIFF
--- a/README.md
+++ b/README.md
@@ -52,20 +52,9 @@ In a second terminal, connect the CLI to the server:
 
 ```sh
 gestalt init
-gestalt plugins list
-gestalt plugins invoke httpbin get_ip
+gestalt plugin list
+gestalt plugin invoke httpbin get_ip
 ```
-
-Managed identities are available from the same client CLI via the top-level
-`gestalt identities` command:
-
-```sh
-gestalt identities list
-gestalt identities create --name "Release Bot"
-```
-
-See [CLI docs](https://gestaltd.ai/client/cli) for identity members, grants,
-and identity-owned token commands.
 
 For the full walkthrough, see [Getting Started](https://gestaltd.ai/getting-started).
 
@@ -74,6 +63,6 @@ For the full walkthrough, see [Getting Started](https://gestaltd.ai/getting-star
 | Path | Description |
 | --- | --- |
 | [`gestaltd`](./gestaltd) | Go server daemon, config loading, provider bootstrap, HTTP API, MCP surface, deployment assets, and admin UI serving code. |
-| [`gestalt`](./gestalt) | Rust CLI client for setup, auth, managed identity operations, invocation, and token management. |
+| [`gestalt`](./gestalt) | Rust CLI client for setup, auth, plugin invocation, workflow and agent runs, and token management. |
 | [`sdk`](./sdk) | Go, Python, Rust, and TypeScript SDKs plus shared protocol definitions. |
 | [`docs`](./docs) | Source for the public documentation site at [gestaltd.ai](https://gestaltd.ai). |

--- a/docs/content/client/cli/docker.mdx
+++ b/docs/content/client/cli/docker.mdx
@@ -24,7 +24,7 @@ docker run --rm \
   -e GESTALT_URL=https://gestalt.example.com \
   -e GESTALT_API_KEY=gst_api_... \
   valontechnologies/gestalt:latest \
-  plugins list
+  plugin list
 ```
 
 ## CI example
@@ -39,5 +39,5 @@ jobs:
             -e GESTALT_URL="${{ vars.GESTALT_URL }}" \
             -e GESTALT_API_KEY="${{ secrets.GESTALT_API_KEY }}" \
             valontechnologies/gestalt:latest \
-            plugins list --format json
+            plugin list --format json
 ```

--- a/docs/content/client/cli/index.mdx
+++ b/docs/content/client/cli/index.mdx
@@ -22,15 +22,15 @@ asIndexPage: true
 | `gestalt auth status` | Show current authentication state and server connectivity. |
 | `gestalt init` | Run the interactive setup wizard. |
 | `gestalt config get\|set\|unset\|list` | Manage the local client config. |
-| `gestalt plugins list` | List plugins from the server. |
-| `gestalt plugins connect NAME` | Connect a plugin through OAuth or interactive manual authentication. |
-| `gestalt plugins disconnect NAME` | Disconnect a plugin, removing stored credentials. |
-| `gestalt plugins invoke NAME [OPERATION]` | Invoke an operation or list operations when omitted. |
-| `gestalt plugins describe NAME OPERATION` | Show one operation's parameter contract. |
-| `gestalt workflows schedules ...` | Create, list, inspect, update, pause, resume, or delete workflow schedules. |
-| `gestalt workflows triggers ...` | Create, list, inspect, update, pause, resume, or delete workflow triggers. |
-| `gestalt workflows events publish ...` | Publish an event into the workflow system. |
-| `gestalt workflows runs ...` | List, inspect, and cancel workflow runs. |
+| `gestalt plugin list` | List plugins from the server. |
+| `gestalt plugin connect NAME` | Connect a plugin through OAuth or interactive manual authentication. |
+| `gestalt plugin disconnect NAME` | Disconnect a plugin, removing stored credentials. |
+| `gestalt plugin invoke NAME [OPERATION]` | Invoke an operation or list operations when omitted. |
+| `gestalt plugin describe NAME OPERATION` | Show one operation's parameter contract. |
+| `gestalt workflow schedules ...` | Create, list, inspect, update, pause, resume, or delete workflow schedules. |
+| `gestalt workflow triggers ...` | Create, list, inspect, update, pause, resume, or delete workflow triggers. |
+| `gestalt workflow events publish ...` | Publish an event into the workflow system. |
+| `gestalt workflow runs ...` | List, inspect, and cancel workflow runs. |
 | `gestalt agent runs ...` | Create, list, inspect, and cancel global agent runs. |
 | `gestalt tokens create\|list\|revoke` | Manage Gestalt API tokens. |
 
@@ -63,43 +63,43 @@ The CLI searches the current directory and then parent directories until it find
 
 ## Plugin connect flags
 
-`gestalt plugins connect NAME` accepts `--connection` and `--instance`. When the selected connection uses manual authentication instead of OAuth, the CLI prompts for the required credential fields and connection parameters.
+`gestalt plugin connect NAME` accepts `--connection` and `--instance`. When the selected connection uses manual authentication instead of OAuth, the CLI prompts for the required credential fields and connection parameters.
 
 ## Plugin disconnect flags
 
-`gestalt plugins disconnect NAME` accepts `--connection` and `--instance` to target a specific named connection or stored instance. When both are omitted, the default connection is disconnected.
+`gestalt plugin disconnect NAME` accepts `--connection` and `--instance` to target a specific named connection or stored instance. When both are omitted, the default connection is disconnected.
 
 ## Invoke flags
 
-`gestalt plugins invoke` accepts `-p`/`--param key=value`, `--input-file file.json` (use `-` for stdin), `--connection`, `--instance`, and `--select`. Use `:=` instead of `=` to pass JSON values: `-p items:='["a","b"]'`.
+`gestalt plugin invoke` accepts `-p`/`--param key=value`, `--input-file file.json` (use `-` for stdin), `--connection`, `--instance`, and `--select`. Use `:=` instead of `=` to pass JSON values: `-p items:='["a","b"]'`.
 
 ## Operation name matching
 
 Operation names with dots (like `chat.postMessage`) can be typed as space-separated segments:
 
 ```sh
-gestalt plugins invoke slack chat postMessage
+gestalt plugin invoke slack chat postMessage
 ```
 
-This resolves to `chat.postMessage`. If the segments match a prefix shared by multiple operations, the CLI displays the matching subset instead of an error. For example, `gestalt plugins invoke slack chat` lists all operations starting with `chat.`.
+This resolves to `chat.postMessage`. If the segments match a prefix shared by multiple operations, the CLI displays the matching subset instead of an error. For example, `gestalt plugin invoke slack chat` lists all operations starting with `chat.`.
 
 ## Examples
 
 ```sh
-gestalt plugins list
-gestalt plugins connect notion --connection MCP
-gestalt plugins describe slack chat.postMessage
-gestalt plugins invoke slack chat postMessage \
+gestalt plugin list
+gestalt plugin connect notion --connection MCP
+gestalt plugin describe slack chat.postMessage
+gestalt plugin invoke slack chat postMessage \
   --connection plugin \
   -p channel=C123 \
   -p text='hello'
-gestalt workflows schedules create \
+gestalt workflow schedules create \
   --cron "0 */6 * * *" \
   --plugin github \
   --operation issues.list \
   -p owner=valon-technologies \
   -p repo=gestalt
-gestalt workflows triggers create \
+gestalt workflow triggers create \
   --type roadmap.item.updated \
   --source roadmap \
   --subject item \
@@ -107,13 +107,13 @@ gestalt workflows triggers create \
   --operation chat.postMessage \
   -p channel=C123 \
   -p text='Roadmap item updated'
-gestalt workflows events publish \
+gestalt workflow events publish \
   --type roadmap.item.updated \
   --source roadmap \
   --subject item \
   -p id=item-1 \
   -e traceId=trace-1
-gestalt workflows runs list --plugin github --status failed
+gestalt workflow runs list --plugin github --status failed
 gestalt tokens create --name automation
 ```
 
@@ -125,10 +125,10 @@ workflow runs.
 ### Schedules
 
 ```sh
-gestalt workflows schedules list
-gestalt workflows schedules list --plugin github
-gestalt workflows schedules get <schedule-id>
-gestalt workflows schedules create \
+gestalt workflow schedules list
+gestalt workflow schedules list --plugin github
+gestalt workflow schedules get <schedule-id>
+gestalt workflow schedules create \
   --cron "0 */6 * * *" \
   --timezone America/New_York \
   --plugin github \
@@ -138,10 +138,10 @@ gestalt workflows schedules create \
   -p owner=valon-technologies \
   -p repo=gestalt \
   -p state=open
-gestalt workflows schedules update <schedule-id> --cron "0 9 * * 1-5"
-gestalt workflows schedules pause <schedule-id>
-gestalt workflows schedules resume <schedule-id>
-gestalt workflows schedules delete <schedule-id>
+gestalt workflow schedules update <schedule-id> --cron "0 9 * * 1-5"
+gestalt workflow schedules pause <schedule-id>
+gestalt workflow schedules resume <schedule-id>
+gestalt workflow schedules delete <schedule-id>
 ```
 
 Use `-p key=value` for strings and `-p key:=json` for structured values. Use
@@ -150,10 +150,10 @@ Use `-p key=value` for strings and `-p key:=json` for structured values. Use
 ### Triggers
 
 ```sh
-gestalt workflows triggers list
-gestalt workflows triggers list --plugin slack --type roadmap.item.updated
-gestalt workflows triggers get <trigger-id>
-gestalt workflows triggers create \
+gestalt workflow triggers list
+gestalt workflow triggers list --plugin slack --type roadmap.item.updated
+gestalt workflow triggers get <trigger-id>
+gestalt workflow triggers create \
   --type roadmap.item.updated \
   --source roadmap \
   --subject item \
@@ -162,10 +162,10 @@ gestalt workflows triggers create \
   --connection default \
   -p channel=C123 \
   -p text='Roadmap item updated'
-gestalt workflows triggers update <trigger-id> --type roadmap.item.synced
-gestalt workflows triggers pause <trigger-id>
-gestalt workflows triggers resume <trigger-id>
-gestalt workflows triggers delete <trigger-id>
+gestalt workflow triggers update <trigger-id> --type roadmap.item.synced
+gestalt workflow triggers pause <trigger-id>
+gestalt workflow triggers resume <trigger-id>
+gestalt workflow triggers delete <trigger-id>
 ```
 
 The create and update commands use the same target input conventions as
@@ -175,7 +175,7 @@ match fields.
 ### Event publishing
 
 ```sh
-gestalt workflows events publish \
+gestalt workflow events publish \
   --type roadmap.item.updated \
   --source roadmap \
   --subject item \
@@ -194,10 +194,10 @@ start the next operations.
 ### Runs
 
 ```sh
-gestalt workflows runs list
-gestalt workflows runs list --plugin github --status failed
-gestalt workflows runs get <run-id>
-gestalt workflows runs cancel <run-id> --reason "operator requested"
+gestalt workflow runs list
+gestalt workflow runs list --plugin github --status failed
+gestalt workflow runs get <run-id>
+gestalt workflow runs cancel <run-id> --reason "operator requested"
 ```
 
 ### Agent Runs

--- a/docs/content/configuration.mdx
+++ b/docs/content/configuration.mdx
@@ -495,7 +495,7 @@ entries under top-level `workflows.schedules` and `workflows.eventTriggers`
 select a provider with `provider`, or inherit the sole/default
 `providers.workflow` entry when that field is omitted. User-owned schedules use
 the same provider pool through the global workflow API and CLI surface:
-`/api/v1/workflow/schedules` and `gestalt workflows ...`.
+`/api/v1/workflow/schedules` and `gestalt workflow ...`.
 
 ```yaml
 providers:

--- a/docs/content/custom-providers/plugins.mdx
+++ b/docs/content/custom-providers/plugins.mdx
@@ -521,7 +521,7 @@ plugins:
 ```
 
 ```sh
-gestalt plugins invoke slack-readonly conversations.list -p limit=5
+gestalt plugin invoke slack-readonly conversations.list -p limit=5
 ```
 
 Gestalt handles OAuth token injection, request formatting, and response passthrough. The `spec.surfaces.rest.baseUrl` is the root for all declared paths, and each operation's `parameters` define how input fields map to query parameters or request body fields.
@@ -532,7 +532,7 @@ You can also declare OpenAPI, GraphQL, and MCP surfaces using `spec.surfaces.ope
 
 Operation IDs should use period-separated hierarchical names. The Slack plugin uses `conversations.list`, `conversations.history`, `chat.postMessage`, and `users.info`.
 
-This convention enables prefix matching in the CLI. When you run `gestalt plugins invoke slack conversations`, the CLI joins the space-separated segments with periods and shows all operations whose ID starts with `conversations.`. This makes large catalogs navigable without memorizing every operation name.
+This convention enables prefix matching in the CLI. When you run `gestalt plugin invoke slack conversations`, the CLI joins the space-separated segments with periods and shows all operations whose ID starts with `conversations.`. This makes large catalogs navigable without memorizing every operation name.
 
 ## Dynamic catalogs
 
@@ -664,7 +664,7 @@ gestaltd serve --config ./config.yaml
 ```
 
 ```sh
-gestalt plugins invoke slack conversations.getMessage -p channel=C01ABC23DEF -p ts=1712161829.000300
+gestalt plugin invoke slack conversations.getMessage -p channel=C01ABC23DEF -p ts=1712161829.000300
 ```
 
 If your plugin makes outbound HTTP requests and you see 403 errors, check

--- a/docs/content/getting-started.mdx
+++ b/docs/content/getting-started.mdx
@@ -36,7 +36,7 @@ The wizard prompts for the server URL. Enter `http://localhost:8080` and it save
 Verify the connection:
 
 ```sh
-gestalt plugins list
+gestalt plugin list
 ```
 
 ```
@@ -52,7 +52,7 @@ gestalt plugins list
 See what the httpbin plugin can do:
 
 ```sh
-gestalt plugins invoke httpbin
+gestalt plugin invoke httpbin
 ```
 
 ```
@@ -72,7 +72,7 @@ gestalt plugins invoke httpbin
 <Tabs items={['CLI', 'HTTP']}>
   <Tabs.Tab>
     ```sh
-    gestalt plugins invoke httpbin get_ip
+    gestalt plugin invoke httpbin get_ip
     ```
 
     ```
@@ -100,7 +100,7 @@ gestalt plugins invoke httpbin
   </Tabs.Tab>
 </Tabs>
 
-Both access the same underlying operation. Anything you can do with `gestalt plugins invoke` you can also do with `curl` or any HTTP client.
+Both access the same underlying operation. Anything you can do with `gestalt plugin invoke` you can also do with `curl` or any HTTP client.
 
 ## Connecting over MCP
 

--- a/docs/content/providers/workflow.mdx
+++ b/docs/content/providers/workflow.mdx
@@ -155,14 +155,14 @@ omitted, that field is ignored during matching.
 ## Creating user-owned schedules
 
 User-owned schedules are global resources exposed through
-`POST /api/v1/workflow/schedules` and `gestalt workflows schedules ...`.
+`POST /api/v1/workflow/schedules` and `gestalt workflow schedules ...`.
 These schedules execute as the creating subject, not as a plugin-local or
 synthetic workflow workload.
 
 <Tabs items={['CLI', 'HTTP']}>
   <Tabs.Tab>
     ```sh
-    gestalt workflows schedules create \
+    gestalt workflow schedules create \
       --cron "0 */6 * * *" \
       --timezone America/New_York \
       --plugin github \
@@ -177,18 +177,18 @@ synthetic workflow workload.
     List schedules:
 
     ```sh
-    gestalt workflows schedules list
-    gestalt workflows schedules list --plugin github
+    gestalt workflow schedules list
+    gestalt workflow schedules list --plugin github
     ```
 
     Inspect, update, pause, resume, or delete a schedule:
 
     ```sh
-    gestalt workflows schedules get <schedule-id>
-    gestalt workflows schedules update <schedule-id> --cron "0 9 * * 1-5"
-    gestalt workflows schedules pause <schedule-id>
-    gestalt workflows schedules resume <schedule-id>
-    gestalt workflows schedules delete <schedule-id>
+    gestalt workflow schedules get <schedule-id>
+    gestalt workflow schedules update <schedule-id> --cron "0 9 * * 1-5"
+    gestalt workflow schedules pause <schedule-id>
+    gestalt workflow schedules resume <schedule-id>
+    gestalt workflow schedules delete <schedule-id>
     ```
   </Tabs.Tab>
   <Tabs.Tab>
@@ -246,13 +246,13 @@ workflow backend.
 
 User-owned triggers are global resources exposed through
 `POST /api/v1/workflow/event-triggers` and
-`gestalt workflows triggers ...`. These triggers execute as the creating
+`gestalt workflow triggers ...`. These triggers execute as the creating
 subject, not as a plugin-local or synthetic workflow workload.
 
 <Tabs items={['CLI', 'HTTP']}>
   <Tabs.Tab>
     ```sh
-    gestalt workflows triggers create \
+    gestalt workflow triggers create \
       --type roadmap.item.updated \
       --source roadmap \
       --subject item \
@@ -266,18 +266,18 @@ subject, not as a plugin-local or synthetic workflow workload.
     List triggers:
 
     ```sh
-    gestalt workflows triggers list
-    gestalt workflows triggers list --plugin slack --type roadmap.item.updated
+    gestalt workflow triggers list
+    gestalt workflow triggers list --plugin slack --type roadmap.item.updated
     ```
 
     Inspect, update, pause, resume, or delete a trigger:
 
     ```sh
-    gestalt workflows triggers get <trigger-id>
-    gestalt workflows triggers update <trigger-id> --type roadmap.item.synced
-    gestalt workflows triggers pause <trigger-id>
-    gestalt workflows triggers resume <trigger-id>
-    gestalt workflows triggers delete <trigger-id>
+    gestalt workflow triggers get <trigger-id>
+    gestalt workflow triggers update <trigger-id> --type roadmap.item.synced
+    gestalt workflow triggers pause <trigger-id>
+    gestalt workflow triggers resume <trigger-id>
+    gestalt workflow triggers delete <trigger-id>
     ```
   </Tabs.Tab>
   <Tabs.Tab>
@@ -337,7 +337,7 @@ specific workflow backend.
 Triggers become useful once something can publish matching events into
 the workflow system. Gestalt now exposes a public event-ingress route at
 `POST /api/v1/workflow/events` and the matching CLI command
-`gestalt workflows events publish`.
+`gestalt workflow events publish`.
 
 When you publish an event, Gestalt normalizes the event ID, spec version, and
 timestamp if you omit them, then fans that event out across the configured
@@ -349,7 +349,7 @@ workflows.
 <Tabs items={['CLI', 'HTTP']}>
   <Tabs.Tab>
     ```sh
-    gestalt workflows events publish \
+    gestalt workflow events publish \
       --type roadmap.item.updated \
       --source roadmap \
       --subject item \
@@ -445,15 +445,15 @@ Runs are the execution records produced by schedules, triggers, or other
 workflow-provider actions. The global run surface is
 `GET /api/v1/workflow/runs`, `GET /api/v1/workflow/runs/{runID}`,
 `POST /api/v1/workflow/runs/{runID}/cancel`, and
-`gestalt workflows runs ...`.
+`gestalt workflow runs ...`.
 
 <Tabs items={['CLI', 'HTTP', 'UI']}>
   <Tabs.Tab>
     ```sh
-    gestalt workflows runs list
-    gestalt workflows runs list --plugin github --status failed
-    gestalt workflows runs get <run-id>
-    gestalt workflows runs cancel <run-id> --reason "operator requested"
+    gestalt workflow runs list
+    gestalt workflow runs list --plugin github --status failed
+    gestalt workflow runs get <run-id>
+    gestalt workflow runs cancel <run-id> --reason "operator requested"
     ```
   </Tabs.Tab>
   <Tabs.Tab>

--- a/docs/content/reference/config-file.mdx
+++ b/docs/content/reference/config-file.mdx
@@ -411,7 +411,7 @@ top-level `workflows.schedules.*.provider` or
 explicitly, or inherit the sole/default workflow provider when `provider` is
 omitted. User-owned schedules and triggers use the same provider pool
 through `/api/v1/workflow/schedules`,
-`/api/v1/workflow/event-triggers`, and `gestalt workflows ...`.
+`/api/v1/workflow/event-triggers`, and `gestalt workflow ...`.
 
 ```yaml
 providers:
@@ -913,7 +913,7 @@ Disables audit output explicitly. `providers.audit.<name>.config` is not allowed
 
 ## `plugins`
 
-Each entry in the `plugins` map is a named plugin backed by an executable provider package. The provider package is the source of truth for operations and transport details. Server config selects the provider, passes provider-specific config, and declares connection policy. The HTTP API route paths still use "integrations" (e.g. `/api/v1/integrations`) as stable code surface, but the CLI and config both use `plugins` as the canonical term.
+Each entry in the `plugins` map is a named plugin backed by an executable provider package. The provider package is the source of truth for operations and transport details. Server config selects the provider, passes provider-specific config, and declares connection policy. The HTTP API route paths still use "integrations" (e.g. `/api/v1/integrations`) as stable code surface, while the CLI uses the singular `plugin` command.
 
 ```yaml
 plugins:

--- a/docs/content/reference/http-api.mdx
+++ b/docs/content/reference/http-api.mdx
@@ -2,7 +2,7 @@
 
 `gestaltd` exposes a REST API and an optional MCP endpoint. When `server.management` is not configured, every route below is served from the public listener. When `server.management` is configured, `/admin`, `/admin/api/v1/*`, `/metrics`, `/health`, and `/ready` move to the management listener and return `404` on the public listener. Prefer the split-listener setup for production so the operator surface does not share the public listener.
 
-The HTTP API uses "integrations" in route paths (e.g. `/api/v1/integrations`) as a stable code surface. The CLI and config both use "plugins" as the canonical term. See [Config File](/reference/config-file#providersplugins) for context.
+The HTTP API uses "integrations" in route paths (e.g. `/api/v1/integrations`) as a stable code surface. The CLI uses the `plugin` command, while config still uses the `plugins` map. See [Config File](/reference/config-file#providersplugins) for context.
 
 ## Authentication model
 

--- a/docs/dockerhub/gestalt.md
+++ b/docs/dockerhub/gestalt.md
@@ -1,8 +1,8 @@
 # gestalt Docker image
 
 `gestalt` is a CLI client for the Gestalt API. It connects to a running
-`gestaltd` server and provides commands for authenticating, managing workspace
-identities, listing plugins, invoking integration operations, and managing
+`gestaltd` server and provides commands for authenticating, listing plugins,
+invoking integration operations, managing workflow and agent runs, and managing
 credentials.
 
 > **Alpha.** Gestalt is under active development. Images are tagged
@@ -37,7 +37,7 @@ docker run --rm \
   -e GESTALT_URL=https://gestalt.example.com \
   -e GESTALT_API_KEY=gst_api_... \
   valontechnologies/gestalt:latest \
-  plugins list
+  plugin list
 ```
 
 ### Invoke an operation
@@ -47,46 +47,8 @@ docker run --rm \
   -e GESTALT_URL=https://gestalt.example.com \
   -e GESTALT_API_KEY=gst_api_... \
   valontechnologies/gestalt:latest \
-  plugins invoke github search_code -p "query=gestalt org:my-org"
+  plugin invoke github search_code -p "query=gestalt org:my-org"
 ```
-
-### Manage managed identities
-
-The same image exposes the top-level `identities` command surface:
-
-```sh
-docker run --rm \
-  -e GESTALT_URL=https://gestalt.example.com \
-  -e GESTALT_API_KEY=gst_api_... \
-  valontechnologies/gestalt:latest \
-  identities list
-
-docker run --rm \
-  -e GESTALT_URL=https://gestalt.example.com \
-  -e GESTALT_API_KEY=gst_api_... \
-  valontechnologies/gestalt:latest \
-  identities create --name "Release Bot"
-
-docker run --rm \
-  -e GESTALT_URL=https://gestalt.example.com \
-  -e GESTALT_API_KEY=gst_api_... \
-  valontechnologies/gestalt:latest \
-  identities members add <identity-id> deployer@example.com --role editor
-
-docker run --rm \
-  -e GESTALT_URL=https://gestalt.example.com \
-  -e GESTALT_API_KEY=gst_api_... \
-  valontechnologies/gestalt:latest \
-  identities grants set <identity-id> github --operation issues.list
-
-docker run --rm \
-  -e GESTALT_URL=https://gestalt.example.com \
-  -e GESTALT_API_KEY=gst_api_... \
-  valontechnologies/gestalt:latest \
-  identities tokens create <identity-id> --name ci --permission github:issues.list
-```
-
-Members with the `viewer` role can list and create identity-owned API tokens. Revoking identity-owned tokens requires `editor` or `admin` membership.
 
 ### Use in CI pipelines
 
@@ -103,18 +65,19 @@ jobs:
             -e GESTALT_URL="${{ vars.GESTALT_URL }}" \
             -e GESTALT_API_KEY="${{ secrets.GESTALT_API_KEY }}" \
             valontechnologies/gestalt:latest \
-            plugins list --format json
+            plugin list --format json
 ```
 
 ## Key commands
 
 | Command | Description |
 |---|---|
-| `plugins list` | List available plugins |
-| `plugins connect NAME` | Connect a plugin via OAuth or manual authentication |
-| `plugins disconnect NAME` | Disconnect a plugin |
-| `plugins invoke NAME OP` | Execute a plugin operation |
-| `identities ...` | Manage managed identities, members, grants, and identity-owned tokens |
+| `plugin list` | List available plugins |
+| `plugin connect NAME` | Connect a plugin via OAuth or manual authentication |
+| `plugin disconnect NAME` | Disconnect a plugin |
+| `plugin invoke NAME OP` | Execute a plugin operation |
+| `workflow ...` | Manage workflow schedules, triggers, events, and runs |
+| `agent runs ...` | Create, list, inspect, and cancel agent runs |
 | `tokens create/list/revoke` | Manage API tokens |
 
 Use `--format json` or `--format table` to control output format. See the
@@ -134,7 +97,7 @@ to inspect available commands:
 
 ```sh
 docker run --rm valontechnologies/gestalt:latest --help
-docker run --rm valontechnologies/gestalt:latest plugins invoke --help
+docker run --rm valontechnologies/gestalt:latest plugin invoke --help
 ```
 
 For an interactive shell, use the native binary or Homebrew install instead

--- a/gestalt/cli/src/cli.rs
+++ b/gestalt/cli/src/cli.rs
@@ -5,7 +5,7 @@ use crate::params;
 
 #[derive(Parser)]
 #[command(name = "gestalt")]
-#[command(about = "CLI for Gestalt API - authentication, plugins, and operations")]
+#[command(about = "CLI for Gestalt API - authentication, plugin, workflow, agent, and operations")]
 #[command(version)]
 pub struct Cli {
     #[command(subcommand)]
@@ -38,8 +38,8 @@ pub enum Commands {
     },
 
     /// Manage plugins
-    #[command(alias = "integrations")]
-    Plugins {
+    #[command(aliases = ["plugins", "integrations"])]
+    Plugin {
         #[command(subcommand)]
         command: PluginCommands,
     },
@@ -59,7 +59,8 @@ pub enum Commands {
     },
 
     /// Manage workflow resources
-    Workflows {
+    #[command(alias = "workflows")]
+    Workflow {
         #[command(subcommand)]
         command: WorkflowCommands,
     },

--- a/gestalt/cli/src/commands/invoke.rs
+++ b/gestalt/cli/src/commands/invoke.rs
@@ -222,7 +222,7 @@ fn rewrite_connect_error(
 }
 
 fn connect_command(plugin: &str, connection: Option<&str>, instance: Option<&str>) -> String {
-    let mut connect_command = format!("gestalt plugins connect {}", plugin);
+    let mut connect_command = format!("gestalt plugin connect {}", plugin);
     if let Some(connection) = connection {
         connect_command.push_str(" --connection ");
         connect_command.push_str(connection);

--- a/gestalt/cli/src/main.rs
+++ b/gestalt/cli/src/main.rs
@@ -31,7 +31,7 @@ fn run() -> anyhow::Result<()> {
             ConfigCommands::Unset { key } => commands::config::unset(&key),
             ConfigCommands::List => commands::config::list(format),
         },
-        Commands::Plugins { command } => dispatch_plugin_command(command, url, format),
+        Commands::Plugin { command } => dispatch_plugin_command(command, url, format),
         Commands::Invoke(args) => {
             dispatch_plugin_command(PluginCommands::Invoke(args), url, format)
         }
@@ -48,7 +48,7 @@ fn run() -> anyhow::Result<()> {
                 TokenCommands::Revoke { id } => commands::tokens::revoke(&client, &id, format),
             }
         }
-        Commands::Workflows { command } => {
+        Commands::Workflow { command } => {
             let client = ApiClient::from_env(url)?;
             match command {
                 WorkflowCommands::Schedules { command } => match command {

--- a/gestalt/cli/tests/agents_cli.rs
+++ b/gestalt/cli/tests/agents_cli.rs
@@ -70,6 +70,63 @@ fn test_cli_creates_agent_run() {
 }
 
 #[test]
+fn test_cli_creates_agent_run_from_request_file() {
+    let request_json = r#"{
+        "provider":"managed",
+        "model":"gpt-5.4",
+        "toolSource":"explicit",
+        "sessionRef":"session-1",
+        "metadata":{"ticket":"AIT-123"},
+        "providerOptions":{"temperature":0.2},
+        "responseSchema":{
+            "type":"object",
+            "properties":{"summary":{"type":"string"}},
+            "required":["summary"]
+        },
+        "messages":[
+            {"role":"user","text":"Summarize the roadmap risk."}
+        ],
+        "toolRefs":[
+            {
+                "pluginName":"roadmap",
+                "operation":"sync",
+                "connection":"workspace",
+                "instance":"prod",
+                "title":"Roadmap sync",
+                "description":"Read roadmap state"
+            }
+        ]
+    }"#;
+    let mut server = Server::new();
+    let _mock = authed_json_mock!(
+        server,
+        Method::POST,
+        "/api/v1/agent/runs",
+        StatusCode::CREATED
+    )
+    .match_header(header::CONTENT_TYPE.as_str(), http::APPLICATION_JSON)
+    .match_body(Matcher::JsonString(request_json.to_string()))
+    .with_body(RUN_JSON)
+    .create();
+
+    let home = tempfile::tempdir().unwrap();
+    let request_path = home.path().join("agent-request.json");
+    std::fs::write(&request_path, request_json).unwrap();
+
+    cli_command_for_server(home.path(), &server)
+        .args([
+            "agent",
+            "runs",
+            "create",
+            "--request-file",
+            request_path.to_str().unwrap(),
+        ])
+        .assert()
+        .success()
+        .stdout(predicate::str::contains("run-1"));
+}
+
+#[test]
 fn test_cli_lists_agent_runs_with_server_side_filters() {
     let mut server = Server::new();
     let _mock = authed_json_mock!(

--- a/gestalt/cli/tests/invoke_contract.rs
+++ b/gestalt/cli/tests/invoke_contract.rs
@@ -47,11 +47,11 @@ fn test_invoke_precondition_error_suggests_connect_command() {
     .create();
 
     cli_command_for_server(home.path(), &server)
-        .args(["plugins", "invoke", "auth_svc", "list_items"])
+        .args(["plugin", "invoke", "auth_svc", "list_items"])
         .assert()
         .failure()
         .stderr(predicate::str::contains(
-            "failed to invoke auth_svc.list_items: plugin \"auth_svc\" is not connected. Connect it first with `gestalt plugins connect auth_svc`",
+            "failed to invoke auth_svc.list_items: plugin \"auth_svc\" is not connected. Connect it first with `gestalt plugin connect auth_svc`",
         ))
         .stderr(predicate::str::contains("OAuth first").not());
 }
@@ -80,11 +80,11 @@ fn test_invoke_reconnect_error_suggests_reconnect_command() {
     .create();
 
     cli_command_for_server(home.path(), &server)
-        .args(["plugins", "invoke", "clickhouse", "run_query"])
+        .args(["plugin", "invoke", "clickhouse", "run_query"])
         .assert()
         .failure()
         .stderr(predicate::str::contains(
-            "failed to invoke clickhouse.run_query: token for plugin \"clickhouse\" expired or was revoked. Reconnect it with `gestalt plugins connect clickhouse`",
+            "failed to invoke clickhouse.run_query: token for plugin \"clickhouse\" expired or was revoked. Reconnect it with `gestalt plugin connect clickhouse`",
         ))
         .stderr(predicate::str::contains("OAuth token for integration").not());
 }
@@ -104,11 +104,11 @@ fn test_catalog_reconnect_error_suggests_reconnect_command() {
     .create();
 
     cli_command_for_server(home.path(), &server)
-        .args(["plugins", "invoke", "clickhouse"])
+        .args(["plugin", "invoke", "clickhouse"])
         .assert()
         .failure()
         .stderr(predicate::str::contains(
-            "failed to invoke clickhouse: token for plugin \"clickhouse\" expired or was revoked. Reconnect it with `gestalt plugins connect clickhouse`",
+            "failed to invoke clickhouse: token for plugin \"clickhouse\" expired or was revoked. Reconnect it with `gestalt plugin connect clickhouse`",
         ))
         .stderr(predicate::str::contains("OAuth token for integration").not());
 }
@@ -150,7 +150,7 @@ fn test_list_operations_formats_parameters() {
     )
     .create();
 
-    let output = run_cli(&server, &["plugins", "invoke", "test_svc"]);
+    let output = run_cli(&server, &["plugin", "invoke", "test_svc"]);
     mock.assert();
     assert!(
         output.status.success(),
@@ -309,7 +309,7 @@ fn test_invoke_with_connection_and_instance() {
 
     secondary_invoke_mock.assert();
     assert!(err.contains(
-        "Connect it first with `gestalt plugins connect other_svc --connection workspace --instance team-a`"
+        "Connect it first with `gestalt plugin connect other_svc --connection workspace --instance team-a`"
     ));
 }
 
@@ -344,7 +344,7 @@ fn test_invoke_retries_without_catalog_when_preflight_masks_surface_error() {
 
     cli_command_for_server(home.path(), &server)
         .args([
-            "plugins",
+            "plugin",
             "invoke",
             "--connection",
             "session-conn",
@@ -379,7 +379,7 @@ fn test_cli_lists_operations_with_connection_and_instance() {
     cmd.env("GESTALT_API_KEY", TEST_TOKEN).args([
         "--url",
         &server.url(),
-        "plugins",
+        "plugin",
         "invoke",
         "--connection",
         "workspace",
@@ -423,7 +423,7 @@ fn test_describe_operation() {
     .with_body(catalog_body())
     .create();
 
-    let output = run_cli(&server, &["plugins", "describe", "test_svc", "do_thing"]);
+    let output = run_cli(&server, &["plugin", "describe", "test_svc", "do_thing"]);
     assert!(
         output.status.success(),
         "stderr: {}",
@@ -484,7 +484,7 @@ fn test_cli_invoke_merges_file_params_and_selects_output() {
         &server.url(),
         "--format",
         "json",
-        "plugins",
+        "plugin",
         "invoke",
         "test_svc",
         "do_thing",
@@ -540,7 +540,7 @@ fn test_cli_invoke_table_keeps_nested_json_inline() {
     cmd.env("GESTALT_API_KEY", TEST_TOKEN).args([
         "--url",
         &server.url(),
-        "plugins",
+        "plugin",
         "invoke",
         "test_svc",
         "do_thing",
@@ -578,7 +578,7 @@ fn test_cli_invoke_rejects_duplicate_scalar_params() {
     cmd.env("GESTALT_API_KEY", TEST_TOKEN).args([
         "--url",
         &server.url(),
-        "plugins",
+        "plugin",
         "invoke",
         "test_svc",
         "do_thing",
@@ -604,7 +604,7 @@ fn test_prefix_match_shows_filtered_table() {
     .with_body(multi_operation_catalog())
     .create();
 
-    let output = run_cli(&server, &["plugins", "invoke", "test_svc", "widgets"]);
+    let output = run_cli(&server, &["plugin", "invoke", "test_svc", "widgets"]);
     assert!(
         output.status.success(),
         "stderr: {}",
@@ -625,7 +625,7 @@ fn test_prefix_match_shows_filtered_table() {
 
     let output = run_cli(
         &server,
-        &["plugins", "invoke", "test_svc", "widgets", "bulk"],
+        &["plugin", "invoke", "test_svc", "widgets", "bulk"],
     );
     assert!(
         output.status.success(),
@@ -697,7 +697,7 @@ fn test_space_separated_segments_invoke() {
 
     let output = run_cli(
         &server,
-        &["plugins", "invoke", "test_svc", "widgets", "bulk", "create"],
+        &["plugin", "invoke", "test_svc", "widgets", "bulk", "create"],
     );
     assert!(
         output.status.success(),
@@ -717,7 +717,7 @@ fn test_space_separated_segments_invoke() {
 
     let output = run_cli(
         &server,
-        &["plugins", "invoke", "test_svc", "widgets", "delete"],
+        &["plugin", "invoke", "test_svc", "widgets", "delete"],
     );
     assert!(
         output.status.success(),
@@ -739,7 +739,7 @@ fn test_no_match_returns_error() {
     .with_body(multi_operation_catalog())
     .create();
 
-    let output = run_cli(&server, &["plugins", "invoke", "test_svc", "nonexistent"]);
+    let output = run_cli(&server, &["plugin", "invoke", "test_svc", "nonexistent"]);
     assert!(!output.status.success());
     let stderr = String::from_utf8_lossy(&output.stderr);
     assert!(stderr.contains("no operation matching"), "stderr: {stderr}");
@@ -759,7 +759,7 @@ fn test_prefix_match_with_params_warns() {
 
     let output = run_cli(
         &server,
-        &["plugins", "invoke", "test_svc", "widgets", "-p", "name=foo"],
+        &["plugin", "invoke", "test_svc", "widgets", "-p", "name=foo"],
     );
     assert!(
         output.status.success(),

--- a/gestalt/cli/tests/plugins_connect.rs
+++ b/gestalt/cli/tests/plugins_connect.rs
@@ -261,7 +261,7 @@ fn test_manual_connect_uses_prompted_credentials_and_connection_params() {
 
     let home = tempfile::tempdir().unwrap();
     cli_command_for_server(home.path(), &server)
-        .args(["plugins", "connect", "widget_metrics"])
+        .args(["plugin", "connect", "widget_metrics"])
         .write_stdin("eu-west\nwm-key\n")
         .assert()
         .success()
@@ -331,7 +331,7 @@ fn test_manual_connect_prompts_for_connection_and_finishes_candidate_selection()
 
     let home = tempfile::tempdir().unwrap();
     cli_command_for_server(home.path(), &server)
-        .args(["plugins", "connect", "manual-svc"])
+        .args(["plugin", "connect", "manual-svc"])
         .write_stdin("1\nabc123\n2\n")
         .assert()
         .success()
@@ -379,7 +379,7 @@ fn test_connection_selection_uses_selected_connection_auth_type() {
 
     let home = tempfile::tempdir().unwrap();
     cli_command_for_server(home.path(), &server)
-        .args(["plugins", "connect", "manual-svc"])
+        .args(["plugin", "connect", "manual-svc"])
         .write_stdin("1\n")
         .assert()
         .success()
@@ -423,7 +423,7 @@ fn test_connect_auto_selects_single_connection_and_uses_its_auth_type() {
 
     let home = tempfile::tempdir().unwrap();
     cli_command_for_server(home.path(), &server)
-        .args(["plugins", "connect", "single-svc"])
+        .args(["plugin", "connect", "single-svc"])
         .assert()
         .success()
         .stderr(predicate::str::contains("Select a Single Service connection:").not())
@@ -450,7 +450,7 @@ fn test_connect_unknown_connection_lists_normalized_available_names() {
 
     let home = tempfile::tempdir().unwrap();
     cli_command_for_server(home.path(), &server)
-        .args(["plugins", "connect", "manual-svc", "--connection", "bogus"])
+        .args(["plugin", "connect", "manual-svc", "--connection", "bogus"])
         .assert()
         .failure()
         .stderr(predicate::str::contains("unknown connection 'bogus'"))
@@ -491,7 +491,7 @@ fn test_manual_connect_uses_credentials_object_for_multi_field_auth() {
 
     let home = tempfile::tempdir().unwrap();
     cli_command_for_server(home.path(), &server)
-        .args(["plugins", "connect", "widget_metrics"])
+        .args(["plugin", "connect", "widget_metrics"])
         .write_stdin("wm-key\nworkspace-42\n")
         .assert()
         .success()
@@ -522,7 +522,7 @@ fn test_manual_connect_falls_back_to_generic_credential_prompt() {
 
     let home = tempfile::tempdir().unwrap();
     cli_command_for_server(home.path(), &server)
-        .args(["plugins", "connect", "manual-svc"])
+        .args(["plugin", "connect", "manual-svc"])
         .write_stdin("secret\n")
         .assert()
         .success()
@@ -540,7 +540,7 @@ fn test_manual_connect_fails_when_stdin_closes_during_prompt() {
 
     let home = tempfile::tempdir().unwrap();
     cli_command_for_server(home.path(), &server)
-        .args(["plugins", "connect", "manual-svc"])
+        .args(["plugin", "connect", "manual-svc"])
         .write_stdin("")
         .assert()
         .failure()
@@ -568,7 +568,7 @@ fn test_cli_plugins_list_table_output() {
         .create();
 
     let mut cmd = cli_command(home.path());
-    cmd.args(["plugins", "list"]);
+    cmd.args(["plugin", "list"]);
     cmd.assert()
         .success()
         .stdout(predicate::str::contains("ACME_CRM").or(predicate::str::contains("acme_crm")))
@@ -589,6 +589,20 @@ fn test_cli_plugins_list_table_output() {
 
     let mut cmd = cli_command(home.path());
     cmd.args(["integrations", "list"]);
+    cmd.assert()
+        .success()
+        .stdout(predicate::str::contains("acme_crm"));
+
+    mock.assert();
+
+    let mock = authed_json_mock!(server, Method::GET, "/api/v1/integrations", StatusCode::OK)
+        .with_body(
+            r#"[{"name":"acme_crm","description":"Acme CRM plugin with a longer description","connected":true}]"#,
+        )
+        .create();
+
+    let mut cmd = cli_command(home.path());
+    cmd.args(["plugins", "list"]);
     cmd.assert()
         .success()
         .stdout(predicate::str::contains("acme_crm"));
@@ -618,7 +632,7 @@ fn test_cli_plugins_list_accepts_legacy_credentials_without_api_url() {
     config_cmd.assert().success();
 
     let mut cmd = cli_command(home.path());
-    cmd.args(["plugins", "list"]);
+    cmd.args(["plugin", "list"]);
     cmd.assert()
         .success()
         .stdout(predicate::str::contains("Acme CRM plugin"));

--- a/gestalt/cli/tests/workflows_cli.rs
+++ b/gestalt/cli/tests/workflows_cli.rs
@@ -77,12 +77,27 @@ fn test_cli_lists_schedules() {
 
     let home = tempfile::tempdir().unwrap();
     cli_command_for_server(home.path(), &server)
-        .args(["workflows", "schedules", "list"])
+        .args(["workflow", "schedules", "list"])
         .assert()
         .success()
         .stdout(predicate::str::contains("sched-1"))
         .stdout(predicate::str::contains("dummy"))
         .stdout(predicate::str::contains("doit"));
+
+    let _mock = authed_json_mock!(
+        server,
+        Method::GET,
+        "/api/v1/workflow/schedules",
+        StatusCode::OK
+    )
+    .with_body(format!("[{SCHEDULE_JSON}]"))
+    .create();
+
+    cli_command_for_server(home.path(), &server)
+        .args(["workflows", "schedules", "list"])
+        .assert()
+        .success()
+        .stdout(predicate::str::contains("sched-1"));
 }
 
 #[test]
@@ -103,7 +118,7 @@ fn test_cli_list_schedules_filters_by_plugin() {
 
     let home = tempfile::tempdir().unwrap();
     cli_command_for_server(home.path(), &server)
-        .args(["workflows", "schedules", "list", "--plugin", "beta"])
+        .args(["workflow", "schedules", "list", "--plugin", "beta"])
         .assert()
         .success()
         .stdout(predicate::str::contains("sched-b"))
@@ -124,7 +139,7 @@ fn test_cli_gets_schedule() {
 
     let home = tempfile::tempdir().unwrap();
     cli_command_for_server(home.path(), &server)
-        .args(["workflows", "schedules", "get", "sched-1"])
+        .args(["workflow", "schedules", "get", "sched-1"])
         .assert()
         .success()
         .stdout(predicate::str::contains("sched-1"))
@@ -156,7 +171,7 @@ fn test_cli_creates_schedule() {
     let home = tempfile::tempdir().unwrap();
     cli_command_for_server(home.path(), &server)
         .args([
-            "workflows",
+            "workflow",
             "schedules",
             "create",
             "--cron",
@@ -211,7 +226,7 @@ fn test_cli_updates_schedule_merges_existing_fields() {
     let home = tempfile::tempdir().unwrap();
     cli_command_for_server(home.path(), &server)
         .args([
-            "workflows",
+            "workflow",
             "schedules",
             "update",
             "sched-1",
@@ -237,7 +252,7 @@ fn test_cli_deletes_schedule() {
 
     let home = tempfile::tempdir().unwrap();
     cli_command_for_server(home.path(), &server)
-        .args(["workflows", "schedules", "delete", "sched-1"])
+        .args(["workflow", "schedules", "delete", "sched-1"])
         .assert()
         .success()
         .stderr(predicate::str::contains(
@@ -259,7 +274,7 @@ fn test_cli_pauses_schedule() {
 
     let home = tempfile::tempdir().unwrap();
     cli_command_for_server(home.path(), &server)
-        .args(["workflows", "schedules", "pause", "sched-1"])
+        .args(["workflow", "schedules", "pause", "sched-1"])
         .assert()
         .success()
         .stdout(predicate::str::contains("sched-1"));
@@ -279,7 +294,7 @@ fn test_cli_resumes_schedule() {
 
     let home = tempfile::tempdir().unwrap();
     cli_command_for_server(home.path(), &server)
-        .args(["workflows", "schedules", "resume", "sched-1"])
+        .args(["workflow", "schedules", "resume", "sched-1"])
         .assert()
         .success()
         .stdout(predicate::str::contains("sched-1"));
@@ -299,7 +314,7 @@ fn test_cli_list_schedules_json_format() {
 
     let home = tempfile::tempdir().unwrap();
     cli_command_for_server(home.path(), &server)
-        .args(["--format", "json", "workflows", "schedules", "list"])
+        .args(["--format", "json", "workflow", "schedules", "list"])
         .assert()
         .success()
         .stdout(predicate::str::contains(r#""id": "sched-1""#))
@@ -320,7 +335,7 @@ fn test_cli_lists_event_triggers() {
 
     let home = tempfile::tempdir().unwrap();
     cli_command_for_server(home.path(), &server)
-        .args(["workflows", "triggers", "list"])
+        .args(["workflow", "triggers", "list"])
         .assert()
         .success()
         .stdout(predicate::str::contains("trg-1"))
@@ -347,7 +362,7 @@ fn test_cli_list_event_triggers_filters() {
     let home = tempfile::tempdir().unwrap();
     cli_command_for_server(home.path(), &server)
         .args([
-            "workflows",
+            "workflow",
             "triggers",
             "list",
             "--plugin",
@@ -375,7 +390,7 @@ fn test_cli_gets_event_trigger() {
 
     let home = tempfile::tempdir().unwrap();
     cli_command_for_server(home.path(), &server)
-        .args(["workflows", "triggers", "get", "trg-1"])
+        .args(["workflow", "triggers", "get", "trg-1"])
         .assert()
         .success()
         .stdout(predicate::str::contains("trg-1"))
@@ -406,7 +421,7 @@ fn test_cli_creates_event_trigger() {
     let home = tempfile::tempdir().unwrap();
     cli_command_for_server(home.path(), &server)
         .args([
-            "workflows",
+            "workflow",
             "triggers",
             "create",
             "--type",
@@ -463,7 +478,7 @@ fn test_cli_updates_event_trigger_merges_existing_fields() {
     let home = tempfile::tempdir().unwrap();
     cli_command_for_server(home.path(), &server)
         .args([
-            "workflows",
+            "workflow",
             "triggers",
             "update",
             "trg-1",
@@ -489,7 +504,7 @@ fn test_cli_deletes_event_trigger() {
 
     let home = tempfile::tempdir().unwrap();
     cli_command_for_server(home.path(), &server)
-        .args(["workflows", "triggers", "delete", "trg-1"])
+        .args(["workflow", "triggers", "delete", "trg-1"])
         .assert()
         .success()
         .stderr(predicate::str::contains("Workflow trigger trg-1 deleted."));
@@ -509,7 +524,7 @@ fn test_cli_pauses_event_trigger() {
 
     let home = tempfile::tempdir().unwrap();
     cli_command_for_server(home.path(), &server)
-        .args(["workflows", "triggers", "pause", "trg-1"])
+        .args(["workflow", "triggers", "pause", "trg-1"])
         .assert()
         .success()
         .stdout(predicate::str::contains("trg-1"));
@@ -529,7 +544,7 @@ fn test_cli_resumes_event_trigger() {
 
     let home = tempfile::tempdir().unwrap();
     cli_command_for_server(home.path(), &server)
-        .args(["workflows", "triggers", "resume", "trg-1"])
+        .args(["workflow", "triggers", "resume", "trg-1"])
         .assert()
         .success()
         .stdout(predicate::str::contains("trg-1"));
@@ -544,7 +559,7 @@ fn test_cli_lists_runs() {
 
     let home = tempfile::tempdir().unwrap();
     cli_command_for_server(home.path(), &server)
-        .args(["workflows", "runs", "list"])
+        .args(["workflow", "runs", "list"])
         .assert()
         .success()
         .stdout(predicate::str::contains("run-1"))
@@ -566,13 +581,7 @@ fn test_cli_list_runs_filters() {
     let home = tempfile::tempdir().unwrap();
     cli_command_for_server(home.path(), &server)
         .args([
-            "workflows",
-            "runs",
-            "list",
-            "--plugin",
-            "beta",
-            "--status",
-            "failed",
+            "workflow", "runs", "list", "--plugin", "beta", "--status", "failed",
         ])
         .assert()
         .success()
@@ -594,7 +603,7 @@ fn test_cli_gets_run() {
 
     let home = tempfile::tempdir().unwrap();
     cli_command_for_server(home.path(), &server)
-        .args(["workflows", "runs", "get", "run-1"])
+        .args(["workflow", "runs", "get", "run-1"])
         .assert()
         .success()
         .stdout(predicate::str::contains("run-1"))
@@ -628,7 +637,7 @@ fn test_cli_cancels_run() {
     let home = tempfile::tempdir().unwrap();
     cli_command_for_server(home.path(), &server)
         .args([
-            "workflows",
+            "workflow",
             "runs",
             "cancel",
             "run-1",
@@ -668,7 +677,7 @@ fn test_cli_publishes_event() {
     let home = tempfile::tempdir().unwrap();
     cli_command_for_server(home.path(), &server)
         .args([
-            "workflows",
+            "workflow",
             "events",
             "publish",
             "--type",


### PR DESCRIPTION
## What changed

- Makes `plugin` the canonical CLI command for plugin management and operation invocation.
- Makes `workflow` the canonical CLI command for workflow schedules, triggers, events, and runs.
- Keeps `plugins`, `integrations`, and `workflows` as compatibility aliases.
- Confirms the existing `agent runs` CLI surface covers the global agent REST endpoints and adds functional coverage for the richer `--request-file` create contract.
- Updates CLI docs, Docker examples, and command suggestions to show the singular commands.

## New CLI interfaces

```sh
gestalt plugin list
gestalt plugin connect NAME --connection workspace --instance prod
gestalt plugin disconnect NAME --connection workspace --instance prod
gestalt plugin invoke slack chat.postMessage -p channel=C123 -p text=hello
gestalt plugin describe slack chat.postMessage
```

```sh
gestalt workflow schedules create \
  --cron "0 */6 * * *" \
  --plugin github \
  --operation issues.list

gestalt workflow triggers create \
  --type roadmap.item.updated \
  --plugin slack \
  --operation chat.postMessage

gestalt workflow events publish --type roadmap.item.updated -p id=item-1
gestalt workflow runs list --plugin github --status failed
```

```sh
gestalt agent runs create \
  --provider managed \
  --model gpt-5.4 \
  --message "Summarize the roadmap risk." \
  --tool roadmap:sync

gestalt agent runs create --request-file agent-request.json
gestalt agent runs list --provider managed --status running
gestalt agent runs get RUN_ID
gestalt agent runs cancel RUN_ID --reason "operator requested"
```

Compatibility aliases remain accepted:

```sh
gestalt plugins ...
gestalt integrations ...
gestalt workflows ...
```

## Tests

- `cargo test -p gestalt --test agents_cli --test workflows_cli --test plugins_connect --test invoke_contract`
- `cargo test -p gestalt`

No new unit tests were added; new/changed coverage is functional CLI-to-mock-server HTTP contract coverage.