### PR TITLE
Support source-backed agent providers and Python provider packaging

### DIFF
--- a/gestaltd/internal/operator/lifecycle.go
+++ b/gestaltd/internal/operator/lifecycle.go
@@ -36,9 +36,10 @@ const (
 	PreparedAuditDir         = ".gestaltd/audit"
 	PreparedCacheDir         = ".gestaltd/cache"
 	PreparedWorkflowDir      = ".gestaltd/workflow"
+	PreparedAgentDir         = ".gestaltd/agent"
 	PreparedRuntimeDir       = ".gestaltd/runtime"
 	PreparedUIDir            = ".gestaltd/ui"
-	LockVersion              = 9
+	LockVersion              = 10
 
 	platformKeyGeneric = "generic"
 )
@@ -53,6 +54,7 @@ type Lockfile struct {
 	Caches         map[string]LockEntry         `json:"cache,omitempty"`
 	S3             map[string]LockEntry         `json:"s3,omitempty"`
 	Workflows      map[string]LockEntry         `json:"workflow,omitempty"`
+	Agents         map[string]LockEntry         `json:"agent,omitempty"`
 	Runtimes       map[string]LockEntry         `json:"runtime,omitempty"`
 	Secrets        map[string]LockEntry         `json:"secrets,omitempty"`
 	Telemetry      map[string]LockEntry         `json:"telemetry,omitempty"`
@@ -182,7 +184,7 @@ func (l *Lifecycle) initAtPaths(configPaths []string, state StatePaths) (*Lockfi
 		return nil, nil, initPaths{}, err
 	}
 
-	slog.Info("prepared locked artifacts", "providers", len(lock.Providers), "authentication", len(lock.Authentication), "authorization", len(lock.Authorization), "indexeddbs", len(lock.IndexedDBs), "cache", len(lock.Caches), "s3", len(lock.S3), "workflow", len(lock.Workflows), "runtime", len(lock.Runtimes), "secrets", len(lock.Secrets), "telemetry", len(lock.Telemetry), "audit", len(lock.Audit), "uis", len(lock.UIs))
+	slog.Info("prepared locked artifacts", "providers", len(lock.Providers), "authentication", len(lock.Authentication), "authorization", len(lock.Authorization), "indexeddbs", len(lock.IndexedDBs), "cache", len(lock.Caches), "s3", len(lock.S3), "workflow", len(lock.Workflows), "agent", len(lock.Agents), "runtime", len(lock.Runtimes), "secrets", len(lock.Secrets), "telemetry", len(lock.Telemetry), "audit", len(lock.Audit), "uis", len(lock.UIs))
 	slog.Info("wrote lockfile", "path", paths.lockfilePath)
 	return lock, cfg, paths, nil
 }
@@ -624,6 +626,7 @@ type initPaths struct {
 	auditDir         string
 	cacheDir         string
 	workflowDir      string
+	agentDir         string
 	runtimeDir       string
 	uiDir            string
 }
@@ -693,6 +696,7 @@ func hostProviderCollections(cfg *config.Config) []struct {
 		{config.HostProviderKindAudit, cfg.Providers.Audit},
 		{config.HostProviderKindCache, cfg.Providers.Cache},
 		{config.HostProviderKindWorkflow, cfg.Providers.Workflow},
+		{config.HostProviderKindAgent, cfg.Providers.Agent},
 	}
 }
 
@@ -717,6 +721,8 @@ func lockEntriesForKind(lock *Lockfile, kind config.HostProviderKind) map[string
 		return lock.IndexedDBs
 	case config.HostProviderKindWorkflow:
 		return lock.Workflows
+	case config.HostProviderKindAgent:
+		return lock.Agents
 	case config.HostProviderKindRuntime:
 		return lock.Runtimes
 	default:
@@ -886,6 +892,7 @@ func resolveInitPaths(configPaths []string, cfg *config.Config, state StatePaths
 		auditDir:         filepath.Join(artifactsDir, filepath.FromSlash(PreparedAuditDir)),
 		cacheDir:         filepath.Join(artifactsDir, filepath.FromSlash(PreparedCacheDir)),
 		workflowDir:      filepath.Join(artifactsDir, filepath.FromSlash(PreparedWorkflowDir)),
+		agentDir:         filepath.Join(artifactsDir, filepath.FromSlash(PreparedAgentDir)),
 		runtimeDir:       filepath.Join(artifactsDir, filepath.FromSlash(PreparedRuntimeDir)),
 		uiDir:            filepath.Join(artifactsDir, filepath.FromSlash(PreparedUIDir)),
 	}
@@ -931,6 +938,10 @@ func workflowDestDir(paths initPaths, name string) string {
 	return filepath.Join(paths.workflowDir, name)
 }
 
+func agentDestDir(paths initPaths, name string) string {
+	return filepath.Join(paths.agentDir, name)
+}
+
 func runtimeDestDir(paths initPaths, name string) string {
 	return filepath.Join(paths.runtimeDir, name)
 }
@@ -961,6 +972,8 @@ func componentDestDir(paths initPaths, kind config.HostProviderKind, name string
 		return indexeddbDestDir(paths, name)
 	case config.HostProviderKindWorkflow:
 		return workflowDestDir(paths, name)
+	case config.HostProviderKindAgent:
+		return agentDestDir(paths, name)
 	case config.HostProviderKindRuntime:
 		return runtimeDestDir(paths, name)
 	default:
@@ -1017,6 +1030,8 @@ func providerManifestKind(kind config.HostProviderKind) string {
 		return providermanifestv1.KindIndexedDB
 	case config.HostProviderKindWorkflow:
 		return providermanifestv1.KindWorkflow
+	case config.HostProviderKindAgent:
+		return providermanifestv1.KindAgent
 	case config.HostProviderKindRuntime:
 		return providermanifestv1.KindRuntime
 	default:

--- a/gestaltd/internal/operator/lockschema.go
+++ b/gestaltd/internal/operator/lockschema.go
@@ -10,7 +10,8 @@ import (
 
 const (
 	providerLockSchemaName         = "gestaltd-provider-lock"
-	providerLockSchemaVersion      = 4
+	providerLockSchemaVersion      = 5
+	providerLockSchemaVersionV4    = 4
 	providerLockSchemaVersionV3    = 3
 	providerLockSchemaVersionV2    = 2
 	providerLockRevision           = 0
@@ -39,6 +40,7 @@ type providerLockBuckets struct {
 	Cache          map[string]portableLockEntry `json:"cache,omitempty"`
 	S3             map[string]portableLockEntry `json:"s3,omitempty"`
 	Workflow       map[string]portableLockEntry `json:"workflow,omitempty"`
+	Agent          map[string]portableLockEntry `json:"agent,omitempty"`
 	Runtime        map[string]portableLockEntry `json:"runtime,omitempty"`
 	Secrets        map[string]portableLockEntry `json:"secrets,omitempty"`
 	Telemetry      map[string]portableLockEntry `json:"telemetry,omitempty"`
@@ -66,6 +68,7 @@ func newLockfile() *Lockfile {
 		Caches:         make(map[string]LockEntry),
 		S3:             make(map[string]LockEntry),
 		Workflows:      make(map[string]LockEntry),
+		Agents:         make(map[string]LockEntry),
 		Runtimes:       make(map[string]LockEntry),
 		Secrets:        make(map[string]LockEntry),
 		Telemetry:      make(map[string]LockEntry),
@@ -103,6 +106,9 @@ func normalizeLockfile(lock *Lockfile) *Lockfile {
 	}
 	if lock.Workflows == nil {
 		lock.Workflows = make(map[string]LockEntry)
+	}
+	if lock.Agents == nil {
+		lock.Agents = make(map[string]LockEntry)
 	}
 	if lock.Runtimes == nil {
 		lock.Runtimes = make(map[string]LockEntry)
@@ -169,6 +175,7 @@ func providerLockKinds() []string {
 		providermanifestv1.KindCache,
 		providermanifestv1.KindS3,
 		providermanifestv1.KindWorkflow,
+		providermanifestv1.KindAgent,
 		providermanifestv1.KindRuntime,
 		providermanifestv1.KindSecrets,
 		providerLockKindTelemetry,
@@ -196,6 +203,8 @@ func lockEntriesForProviderKind(lock *Lockfile, kind string) map[string]LockEntr
 		return lock.S3
 	case providermanifestv1.KindWorkflow:
 		return lock.Workflows
+	case providermanifestv1.KindAgent:
+		return lock.Agents
 	case providermanifestv1.KindRuntime:
 		return lock.Runtimes
 	case providermanifestv1.KindSecrets:
@@ -225,6 +234,7 @@ func providerLockfileFromLockfile(lock *Lockfile) *providerLockfile {
 			Cache:          portableEntriesFromLockEntries(lock.Caches, providermanifestv1.KindCache),
 			S3:             portableEntriesFromLockEntries(lock.S3, providermanifestv1.KindS3),
 			Workflow:       portableEntriesFromLockEntries(lock.Workflows, providerLockKindWorkflow),
+			Agent:          portableEntriesFromLockEntries(lock.Agents, providermanifestv1.KindAgent),
 			Runtime:        portableEntriesFromLockEntries(lock.Runtimes, providermanifestv1.KindRuntime),
 			Secrets:        portableEntriesFromLockEntries(lock.Secrets, providermanifestv1.KindSecrets),
 			Telemetry:      portableEntriesFromLockEntries(lock.Telemetry, providerLockKindTelemetry),
@@ -246,6 +256,7 @@ func (lock *providerLockfile) toLockfile() *Lockfile {
 	runtimeLock.Caches = lockEntriesFromPortableEntries(lock.Providers.Cache)
 	runtimeLock.S3 = lockEntriesFromPortableEntries(lock.Providers.S3)
 	runtimeLock.Workflows = lockEntriesFromPortableEntries(lock.Providers.Workflow)
+	runtimeLock.Agents = lockEntriesFromPortableEntries(lock.Providers.Agent)
 	runtimeLock.Runtimes = lockEntriesFromPortableEntries(lock.Providers.Runtime)
 	runtimeLock.Secrets = lockEntriesFromPortableEntries(lock.Providers.Secrets)
 	runtimeLock.Telemetry = lockEntriesFromPortableEntries(lock.Providers.Telemetry)
@@ -261,7 +272,7 @@ func validateProviderLockfile(lock *providerLockfile) error {
 	if lock.Schema != providerLockSchemaName {
 		return fmt.Errorf("unsupported lockfile schema %q; run `gestaltd init` to upgrade", lock.Schema)
 	}
-	if lock.SchemaVersion != providerLockSchemaVersion && lock.SchemaVersion != providerLockSchemaVersionV3 && lock.SchemaVersion != providerLockSchemaVersionV2 {
+	if lock.SchemaVersion != providerLockSchemaVersion && lock.SchemaVersion != providerLockSchemaVersionV4 && lock.SchemaVersion != providerLockSchemaVersionV3 && lock.SchemaVersion != providerLockSchemaVersionV2 {
 		return fmt.Errorf("unsupported lockfile schema version %d; run `gestaltd init` to upgrade", lock.SchemaVersion)
 	}
 	return nil

--- a/gestaltd/internal/operator/release_metadata.go
+++ b/gestaltd/internal/operator/release_metadata.go
@@ -104,7 +104,7 @@ func validateProviderReleaseMetadata(metadata *providerReleaseMetadata) error {
 		return fmt.Errorf("provider release version: %w", err)
 	}
 	switch metadata.Kind {
-	case providermanifestv1.KindPlugin, providermanifestv1.KindAuthentication, providermanifestv1.KindAuthorization, providermanifestv1.KindIndexedDB, providermanifestv1.KindCache, providermanifestv1.KindS3, providermanifestv1.KindWorkflow, providermanifestv1.KindSecrets, providermanifestv1.KindRuntime, providermanifestv1.KindUI:
+	case providermanifestv1.KindPlugin, providermanifestv1.KindAuthentication, providermanifestv1.KindAuthorization, providermanifestv1.KindIndexedDB, providermanifestv1.KindCache, providermanifestv1.KindS3, providermanifestv1.KindWorkflow, providermanifestv1.KindAgent, providermanifestv1.KindSecrets, providermanifestv1.KindRuntime, providermanifestv1.KindUI:
 	default:
 		return fmt.Errorf("provider release kind %q is not supported", metadata.Kind)
 	}

--- a/sdk/python/README.md
+++ b/sdk/python/README.md
@@ -20,6 +20,25 @@ For non-host targets, configure a matching Python build interpreter with
 `GESTALT_PYTHON_<GOOS>_<GOARCH>` or a target-specific virtualenv such as
 `.venv-<goos>-<goarch>/`.
 
+## PyInstaller Packaging
+
+Executable providers can extend the SDK's PyInstaller command from
+`pyproject.toml` when a dependency uses package data, dynamic imports, or
+additional hooks:
+
+```toml
+[tool.gestalt.pyinstaller]
+collect-data = ["litellm"]
+hidden-imports = ["my_provider.dynamic_module"]
+additional-hooks-dir = ["pyinstaller-hooks"]
+```
+
+Supported keys mirror PyInstaller's collection options:
+`collect-data`, `collect-submodules`, `collect-binaries`, `collect-all`,
+`copy-metadata`, `recursive-copy-metadata`, `hidden-imports`,
+`exclude-modules`, and `additional-hooks-dir`. Hook directories are resolved
+relative to the provider root unless absolute.
+
 ## Regenerating Protobuf Stubs
 
 The checked-in Python protobuf stubs live in `gestalt/gen/v1`.

--- a/sdk/python/gestalt/__init__.py
+++ b/sdk/python/gestalt/__init__.py
@@ -34,6 +34,23 @@ from ._api import (
     Subject,
     field,
 )
+from ._indexeddb import (
+    CURSOR_NEXT,
+    CURSOR_NEXT_UNIQUE,
+    CURSOR_PREV,
+    CURSOR_PREV_UNIQUE,
+    AlreadyExistsError,
+    Cursor,
+    Index,
+    IndexedDB,
+    IndexSchema,
+    KeyRange,
+    NotFoundError,
+    ObjectStore,
+    ObjectStoreSchema,
+    indexeddb_socket_env,
+    indexeddb_socket_token_env,
+)
 from ._manifest_metadata import (
     HTTPAck,
     HTTPBinding,
@@ -48,7 +65,6 @@ _LAZY_EXPORTS = {
     "AgentHost": ("._agent", "AgentHost"),
     "AgentManager": ("._agent", "AgentManager"),
     "AgentProvider": ("._providers", "AgentProvider"),
-    "AlreadyExistsError": ("._indexeddb", "AlreadyExistsError"),
     "AuthenticatedUser": ("._providers", "AuthenticatedUser"),
     "AuthenticationProvider": ("._providers", "AuthenticationProvider"),
     "Authorization": ("._authorization", "Authorization"),
@@ -56,10 +72,6 @@ _LAZY_EXPORTS = {
     "BeginLoginRequest": ("._providers", "BeginLoginRequest"),
     "BeginLoginResponse": ("._providers", "BeginLoginResponse"),
     "ByteRange": ("._s3", "ByteRange"),
-    "CURSOR_NEXT": ("._indexeddb", "CURSOR_NEXT"),
-    "CURSOR_NEXT_UNIQUE": ("._indexeddb", "CURSOR_NEXT_UNIQUE"),
-    "CURSOR_PREV": ("._indexeddb", "CURSOR_PREV"),
-    "CURSOR_PREV_UNIQUE": ("._indexeddb", "CURSOR_PREV_UNIQUE"),
     "Cache": ("._cache", "Cache"),
     "CacheEntry": ("._cache", "CacheEntry"),
     "CacheProvider": ("._providers", "CacheProvider"),
@@ -79,7 +91,6 @@ _LAZY_EXPORTS = {
     "CompleteLoginRequest": ("._providers", "CompleteLoginRequest"),
     "CopyOptions": ("._s3", "CopyOptions"),
     "ConnectedToken": ("._plugin", "ConnectedToken"),
-    "Cursor": ("._indexeddb", "Cursor"),
     "ENV_PLUGIN_INVOKER_SOCKET": ("._invoker", "ENV_PLUGIN_INVOKER_SOCKET"),
     "ENV_PLUGIN_INVOKER_SOCKET_TOKEN": ("._invoker", "ENV_PLUGIN_INVOKER_SOCKET_TOKEN"),
     "ENV_S3_SOCKET": ("._s3", "ENV_S3_SOCKET"),
@@ -92,18 +103,11 @@ _LAZY_EXPORTS = {
         "._http_subject",
         "HTTPSubjectResolutionError",
     ),
-    "Index": ("._indexeddb", "Index"),
-    "IndexedDB": ("._indexeddb", "IndexedDB"),
-    "IndexSchema": ("._indexeddb", "IndexSchema"),
-    "KeyRange": ("._indexeddb", "KeyRange"),
     "ListOptions": ("._s3", "ListOptions"),
     "ListPage": ("._s3", "ListPage"),
     "MetadataProvider": ("._providers", "MetadataProvider"),
-    "NotFoundError": ("._indexeddb", "NotFoundError"),
     "ObjectMeta": ("._s3", "ObjectMeta"),
     "ObjectRef": ("._s3", "ObjectRef"),
-    "ObjectStore": ("._indexeddb", "ObjectStore"),
-    "ObjectStoreSchema": ("._indexeddb", "ObjectStoreSchema"),
     "OperationAnnotations": ("._catalog", "OperationAnnotations"),
     "Plugin": ("._plugin", "Plugin"),
     "PluginInvoker": ("._invoker", "PluginInvoker"),
@@ -133,8 +137,6 @@ _LAZY_EXPORTS = {
     "cache_socket_token_env": ("._cache", "cache_socket_token_env"),
     "http_subject": ("._plugin", "http_subject"),
     "http_subject_error": ("._http_subject", "http_subject_error"),
-    "indexeddb_socket_env": ("._indexeddb", "indexeddb_socket_env"),
-    "indexeddb_socket_token_env": ("._indexeddb", "indexeddb_socket_token_env"),
     "operation": ("._plugin", "operation"),
     "post_connect": ("._plugin", "post_connect"),
     "s3_socket_env": ("._s3", "s3_socket_env"),
@@ -151,6 +153,7 @@ def __getattr__(name: str):
     value = getattr(import_module(module_name, __name__), attr_name)
     globals()[name] = value
     return value
+
 
 __all__ = [
     "AgentHost",

--- a/sdk/python/gestalt/_build.py
+++ b/sdk/python/gestalt/_build.py
@@ -1,3 +1,4 @@
+import importlib
 import os
 import pathlib
 import subprocess
@@ -6,13 +7,22 @@ import tempfile
 from dataclasses import dataclass
 from typing import Final
 
+if sys.version_info >= (3, 11):
+    _toml_loads = importlib.import_module("tomllib").loads
+else:
+    import tomli
+
+    _toml_loads = tomli.loads
+
 from ._bootstrap import (
     BUNDLED_CONFIG_NAME,
     parse_plugin_target,
     write_bundled_plugin_config,
 )
 
-USAGE: Final[str] = "usage: python -m gestalt._build ROOT MODULE[:ATTRIBUTE] OUTPUT PLUGIN_NAME RUNTIME_KIND GOOS GOARCH"
+USAGE: Final[str] = (
+    "usage: python -m gestalt._build ROOT MODULE[:ATTRIBUTE] OUTPUT PLUGIN_NAME RUNTIME_KIND GOOS GOARCH"
+)
 
 
 @dataclass(frozen=True)
@@ -24,6 +34,19 @@ class BuildArgs:
     runtime_kind: str
     goos: str
     goarch: str
+
+
+@dataclass(frozen=True)
+class PyInstallerConfig:
+    collect_data: tuple[str, ...] = ()
+    collect_submodules: tuple[str, ...] = ()
+    collect_binaries: tuple[str, ...] = ()
+    collect_all: tuple[str, ...] = ()
+    copy_metadata: tuple[str, ...] = ()
+    recursive_copy_metadata: tuple[str, ...] = ()
+    hidden_imports: tuple[str, ...] = ()
+    exclude_modules: tuple[str, ...] = ()
+    additional_hooks_dir: tuple[pathlib.Path, ...] = ()
 
 
 def main(argv: list[str] | None = None) -> int:
@@ -80,6 +103,7 @@ def build_plugin_binary(args: BuildArgs) -> None:
                 bundle_config_path=bundle_config_path,
                 target_goos=args.goos,
                 target_goarch=args.goarch,
+                pyinstaller_config=_read_pyinstaller_config(root_path),
             ),
             cwd=root_path,
             env=env,
@@ -95,8 +119,14 @@ def _pyinstaller_command(
     bundle_config_path: pathlib.Path,
     target_goos: str,
     target_goarch: str,
+    pyinstaller_config: PyInstallerConfig | None = None,
 ) -> list[str]:
-    pyinstaller_name = output_path.name.removesuffix(".exe") if target_goos == "windows" else output_path.name
+    pyinstaller_name = (
+        output_path.name.removesuffix(".exe")
+        if target_goos == "windows"
+        else output_path.name
+    )
+    pyinstaller_config = pyinstaller_config or PyInstallerConfig()
 
     command = [
         sys.executable,
@@ -117,6 +147,7 @@ def _pyinstaller_command(
         module_name,
         "--paths",
         str(root_path),
+        *_pyinstaller_collection_args(pyinstaller_config),
         "--add-data",
         f"{bundle_config_path}{os.pathsep}.",
         str(pathlib.Path(__file__).with_name("_pyinstaller.py")),
@@ -126,6 +157,79 @@ def _pyinstaller_command(
         if target_arch:
             command.extend(["--target-arch", target_arch])
     return command
+
+
+def _read_pyinstaller_config(root_path: pathlib.Path) -> PyInstallerConfig:
+    project_path = root_path / "pyproject.toml"
+    if not project_path.exists():
+        return PyInstallerConfig()
+    data = _toml_loads(project_path.read_text(encoding="utf-8"))
+    raw = data.get("tool", {}).get("gestalt", {}).get("pyinstaller", {})
+    if not isinstance(raw, dict):
+        raise RuntimeError("tool.gestalt.pyinstaller must be a table")
+    return PyInstallerConfig(
+        collect_data=_string_tuple(raw, "collect-data"),
+        collect_submodules=_string_tuple(raw, "collect-submodules"),
+        collect_binaries=_string_tuple(raw, "collect-binaries"),
+        collect_all=_string_tuple(raw, "collect-all"),
+        copy_metadata=_string_tuple(raw, "copy-metadata"),
+        recursive_copy_metadata=_string_tuple(raw, "recursive-copy-metadata"),
+        hidden_imports=_string_tuple(raw, "hidden-imports"),
+        exclude_modules=_string_tuple(raw, "exclude-modules"),
+        additional_hooks_dir=tuple(
+            _config_path(root_path, value)
+            for value in _string_tuple(raw, "additional-hooks-dir")
+        ),
+    )
+
+
+def _string_tuple(raw: dict[str, object], key: str) -> tuple[str, ...]:
+    value = raw.get(key, ())
+    if value in (None, ()):
+        return ()
+    if not isinstance(value, list):
+        raise RuntimeError(
+            f"tool.gestalt.pyinstaller.{key} must be an array of non-empty strings"
+        )
+    out: list[str] = []
+    for item in value:
+        if not isinstance(item, str):
+            raise RuntimeError(
+                f"tool.gestalt.pyinstaller.{key} must be an array of non-empty strings"
+            )
+        stripped = item.strip()
+        if not stripped:
+            raise RuntimeError(
+                f"tool.gestalt.pyinstaller.{key} must be an array of non-empty strings"
+            )
+        out.append(stripped)
+    return tuple(out)
+
+
+def _config_path(root_path: pathlib.Path, value: str) -> pathlib.Path:
+    path = pathlib.Path(value)
+    if not path.is_absolute():
+        path = root_path / path
+    return path
+
+
+def _pyinstaller_collection_args(config: PyInstallerConfig) -> list[str]:
+    args: list[str] = []
+    for option, values in (
+        ("--collect-data", config.collect_data),
+        ("--collect-submodules", config.collect_submodules),
+        ("--collect-binaries", config.collect_binaries),
+        ("--collect-all", config.collect_all),
+        ("--copy-metadata", config.copy_metadata),
+        ("--recursive-copy-metadata", config.recursive_copy_metadata),
+        ("--hidden-import", config.hidden_imports),
+        ("--exclude-module", config.exclude_modules),
+    ):
+        for value in values:
+            args.extend([option, value])
+    for path in config.additional_hooks_dir:
+        args.extend(["--additional-hooks-dir", str(path)])
+    return args
 
 
 def _darwin_target_arch(goarch: str) -> str | None:

--- a/sdk/python/gestalt/_indexeddb.py
+++ b/sdk/python/gestalt/_indexeddb.py
@@ -9,17 +9,30 @@ from dataclasses import dataclass, field
 from typing import Any, Iterator, Protocol, cast
 from urllib import parse as _urlparse
 
-import grpc
-from google.protobuf import struct_pb2 as _struct_pb2
-from google.protobuf import timestamp_pb2 as _timestamp_pb2
+try:
+    import grpc as _grpc
+    from google.protobuf import struct_pb2 as _struct_pb2
+    from google.protobuf import timestamp_pb2 as _timestamp_pb2
 
-from .gen.v1 import datastore_pb2 as _pb
-from .gen.v1 import datastore_pb2_grpc as _pb_grpc
+    from .gen.v1 import datastore_pb2 as _pb
+    from .gen.v1 import datastore_pb2_grpc as _pb_grpc
+except ModuleNotFoundError as exc:
+    if exc.name not in {"google", "grpc"}:
+        raise
+    _IMPORT_ERROR: ModuleNotFoundError | None = exc
+    _grpc: Any = None
+    _pb: Any = None
+    _pb_grpc: Any = None
+    _struct_pb2: Any = None
+    _timestamp_pb2: Any = None
+else:
+    _IMPORT_ERROR = None
 
-pb: Any = _pb
-pb_grpc: Any = _pb_grpc
-struct_pb2: Any = _struct_pb2
-timestamp_pb2: Any = _timestamp_pb2
+grpc: Any = cast(Any, _grpc)
+pb: Any = cast(Any, _pb)
+pb_grpc: Any = cast(Any, _pb_grpc)
+struct_pb2: Any = cast(Any, _struct_pb2)
+timestamp_pb2: Any = cast(Any, _timestamp_pb2)
 
 ENV_INDEXEDDB_SOCKET = "GESTALT_INDEXEDDB_SOCKET"
 _INDEXEDDB_SOCKET_TOKEN_SUFFIX = "_TOKEN"
@@ -49,6 +62,13 @@ def indexeddb_socket_token_env(name: str | None = None) -> str:
     """Return the environment variable name for an IndexedDB relay token."""
 
     return f"{indexeddb_socket_env(name)}{_INDEXEDDB_SOCKET_TOKEN_SUFFIX}"
+
+
+def _ensure_indexeddb_runtime() -> None:
+    if _IMPORT_ERROR is not None:
+        raise RuntimeError(
+            "IndexedDB requires grpcio and protobuf runtime dependencies"
+        ) from _IMPORT_ERROR
 
 
 class NotFoundError(Exception):
@@ -93,6 +113,7 @@ class IndexedDB:
     """Client for a host-provided IndexedDB-compatible store."""
 
     def __init__(self, name: str | None = None) -> None:
+        _ensure_indexeddb_runtime()
         env_name = indexeddb_socket_env(name)
         target = os.environ.get(env_name, "")
         if not target:
@@ -106,16 +127,23 @@ class IndexedDB:
 
         self._channel.close()
 
-    def create_object_store(self, name: str, schema: ObjectStoreSchema | None = None) -> None:
+    def create_object_store(
+        self, name: str, schema: ObjectStoreSchema | None = None
+    ) -> None:
         """Create an object store with an optional schema."""
 
         pb_schema = pb.ObjectStoreSchema()
         if schema:
             for idx in schema.indexes:
                 pb_schema.indexes.append(
-                    pb.IndexSchema(name=idx.name, key_path=idx.key_path, unique=idx.unique)
+                    pb.IndexSchema(
+                        name=idx.name, key_path=idx.key_path, unique=idx.unique
+                    )
                 )
-        _grpc_call(self._stub.CreateObjectStore, pb.CreateObjectStoreRequest(name=name, schema=pb_schema))
+        _grpc_call(
+            self._stub.CreateObjectStore,
+            pb.CreateObjectStoreRequest(name=name, schema=pb_schema),
+        )
 
     def delete_object_store(self, name: str) -> None:
         """Delete an object store by name."""
@@ -148,24 +176,34 @@ class ObjectStore:
     def get(self, id: str) -> dict[str, Any]:
         """Fetch a record by primary key."""
 
-        resp = _grpc_call(self._stub.Get, pb.ObjectStoreRequest(store=self._store, id=id))
+        resp = _grpc_call(
+            self._stub.Get, pb.ObjectStoreRequest(store=self._store, id=id)
+        )
         return _record_to_dict(resp.record)
 
     def get_key(self, id: str) -> str:
         """Return the canonical key for a primary key lookup."""
 
-        resp = _grpc_call(self._stub.GetKey, pb.ObjectStoreRequest(store=self._store, id=id))
+        resp = _grpc_call(
+            self._stub.GetKey, pb.ObjectStoreRequest(store=self._store, id=id)
+        )
         return resp.key
 
     def add(self, record: dict[str, Any]) -> None:
         """Insert a new record."""
 
-        _grpc_call(self._stub.Add, pb.RecordRequest(store=self._store, record=_dict_to_record(record)))
+        _grpc_call(
+            self._stub.Add,
+            pb.RecordRequest(store=self._store, record=_dict_to_record(record)),
+        )
 
     def put(self, record: dict[str, Any]) -> None:
         """Insert or replace a record."""
 
-        _grpc_call(self._stub.Put, pb.RecordRequest(store=self._store, record=_dict_to_record(record)))
+        _grpc_call(
+            self._stub.Put,
+            pb.RecordRequest(store=self._store, record=_dict_to_record(record)),
+        )
 
     def delete(self, id: str) -> None:
         """Delete a record by primary key."""
@@ -182,7 +220,9 @@ class ObjectStore:
 
         resp = _grpc_call(
             self._stub.GetAll,
-            pb.ObjectStoreRangeRequest(store=self._store, range=_kr_to_proto(key_range)),
+            pb.ObjectStoreRangeRequest(
+                store=self._store, range=_kr_to_proto(key_range)
+            ),
         )
         return [_record_to_dict(r) for r in resp.records]
 
@@ -191,7 +231,9 @@ class ObjectStore:
 
         resp = _grpc_call(
             self._stub.GetAllKeys,
-            pb.ObjectStoreRangeRequest(store=self._store, range=_kr_to_proto(key_range)),
+            pb.ObjectStoreRangeRequest(
+                store=self._store, range=_kr_to_proto(key_range)
+            ),
         )
         return list(resp.keys)
 
@@ -200,7 +242,9 @@ class ObjectStore:
 
         resp = _grpc_call(
             self._stub.Count,
-            pb.ObjectStoreRangeRequest(store=self._store, range=_kr_to_proto(key_range)),
+            pb.ObjectStoreRangeRequest(
+                store=self._store, range=_kr_to_proto(key_range)
+            ),
         )
         return resp.count
 
@@ -209,7 +253,9 @@ class ObjectStore:
 
         resp = _grpc_call(
             self._stub.DeleteRange,
-            pb.ObjectStoreRangeRequest(store=self._store, range=_kr_to_proto(key_range)),
+            pb.ObjectStoreRangeRequest(
+                store=self._store, range=_kr_to_proto(key_range)
+            ),
         )
         return resp.deleted
 
@@ -230,7 +276,11 @@ class ObjectStore:
         """Open a key-only cursor over the store."""
 
         return Cursor(
-            self._stub, self._store, key_range=key_range, direction=direction, keys_only=True
+            self._stub,
+            self._store,
+            key_range=key_range,
+            direction=direction,
+            keys_only=True,
         )
 
     def index(self, name: str) -> Index:
@@ -259,13 +309,17 @@ class Index:
         resp = _grpc_call(self._stub.IndexGetKey, self._req(values))
         return resp.key
 
-    def get_all(self, *values: Any, key_range: KeyRange | None = None) -> list[dict[str, Any]]:
+    def get_all(
+        self, *values: Any, key_range: KeyRange | None = None
+    ) -> list[dict[str, Any]]:
         """Return all records matching the indexed values and key range."""
 
         resp = _grpc_call(self._stub.IndexGetAll, self._req(values, key_range))
         return [_record_to_dict(r) for r in resp.records]
 
-    def get_all_keys(self, *values: Any, key_range: KeyRange | None = None) -> list[str]:
+    def get_all_keys(
+        self, *values: Any, key_range: KeyRange | None = None
+    ) -> list[str]:
         """Return all primary keys matching the indexed values and key range."""
 
         resp = _grpc_call(self._stub.IndexGetAllKeys, self._req(values, key_range))
@@ -318,9 +372,7 @@ class Index:
             values=values,
         )
 
-    def _req(
-        self, values: tuple[Any, ...], key_range: KeyRange | None = None
-    ) -> Any:
+    def _req(self, values: tuple[Any, ...], key_range: KeyRange | None = None) -> Any:
         return pb.IndexQueryRequest(
             store=self._store,
             index=self._index,
@@ -336,20 +388,31 @@ def _indexeddb_channel(raw_target: str, *, token: str = "") -> grpc.Channel:
     if target.startswith("tcp://"):
         address = target[len("tcp://") :].strip()
         if not address:
-            raise RuntimeError(f"IndexedDB tcp target {raw_target!r} is missing host:port")
-        return _with_indexeddb_relay_token(grpc.insecure_channel(f"dns:///{address}"), token)
+            raise RuntimeError(
+                f"IndexedDB tcp target {raw_target!r} is missing host:port"
+            )
+        return _with_indexeddb_relay_token(
+            grpc.insecure_channel(f"dns:///{address}"), token
+        )
     if target.startswith("tls://"):
         address = target[len("tls://") :].strip()
         if not address:
-            raise RuntimeError(f"IndexedDB tls target {raw_target!r} is missing host:port")
+            raise RuntimeError(
+                f"IndexedDB tls target {raw_target!r} is missing host:port"
+            )
         return _with_indexeddb_relay_token(
-            grpc.secure_channel(f"dns:///{address}", grpc.ssl_channel_credentials()), token
+            grpc.secure_channel(f"dns:///{address}", grpc.ssl_channel_credentials()),
+            token,
         )
     if target.startswith("unix://"):
         socket_path = target[len("unix://") :].strip()
         if not socket_path:
-            raise RuntimeError(f"IndexedDB unix target {raw_target!r} is missing a socket path")
-        return _with_indexeddb_relay_token(grpc.insecure_channel(f"unix:{socket_path}"), token)
+            raise RuntimeError(
+                f"IndexedDB unix target {raw_target!r} is missing a socket path"
+            )
+        return _with_indexeddb_relay_token(
+            grpc.insecure_channel(f"unix:{socket_path}"), token
+        )
     if "://" in target:
         parsed = _urlparse.urlparse(target)
         raise RuntimeError(f"unsupported IndexedDB target scheme {parsed.scheme!r}")
@@ -360,26 +423,63 @@ def _with_indexeddb_relay_token(channel: grpc.Channel, token: str) -> grpc.Chann
     token = token.strip()
     if not token:
         return channel
-    interceptor = _RelayTokenInterceptor(token)
-    return grpc.intercept_channel(channel, interceptor)
 
+    class _ClientCallDetails(grpc.ClientCallDetails):
+        def __init__(
+            self,
+            method: str,
+            timeout: float | None,
+            metadata: Any,
+            credentials: Any,
+            wait_for_ready: bool | None,
+            compression: Any,
+        ) -> None:
+            self.method = method
+            self.timeout = timeout
+            self.metadata = metadata
+            self.credentials = credentials
+            self.wait_for_ready = wait_for_ready
+            self.compression = compression
 
-class _ClientCallDetails(grpc.ClientCallDetails):
-    def __init__(
-        self,
-        method: str,
-        timeout: float | None,
-        metadata: Any,
-        credentials: Any,
-        wait_for_ready: bool | None,
-        compression: Any,
-    ) -> None:
-        self.method = method
-        self.timeout = timeout
-        self.metadata = metadata
-        self.credentials = credentials
-        self.wait_for_ready = wait_for_ready
-        self.compression = compression
+    class _RelayTokenInterceptor(
+        grpc.UnaryUnaryClientInterceptor,
+        grpc.StreamStreamClientInterceptor,
+    ):
+        def __init__(self, token: str) -> None:
+            self._token = token
+
+        def _details(
+            self, client_call_details: grpc.ClientCallDetails
+        ) -> grpc.ClientCallDetails:
+            details = cast(_ClientCallDetailsFields, client_call_details)
+            metadata = list(details.metadata or [])
+            metadata.append((_INDEXEDDB_RELAY_TOKEN_HEADER, self._token))
+            return _ClientCallDetails(
+                details.method,
+                details.timeout,
+                metadata,
+                details.credentials,
+                details.wait_for_ready,
+                details.compression,
+            )
+
+        def intercept_unary_unary(
+            self,
+            continuation: Any,
+            client_call_details: grpc.ClientCallDetails,
+            request: Any,
+        ) -> Any:
+            return continuation(self._details(client_call_details), request)
+
+        def intercept_stream_stream(
+            self,
+            continuation: Any,
+            client_call_details: grpc.ClientCallDetails,
+            request_iterator: Any,
+        ) -> Any:
+            return continuation(self._details(client_call_details), request_iterator)
+
+    return grpc.intercept_channel(channel, _RelayTokenInterceptor(token))
 
 
 class _ClientCallDetailsFields(Protocol):
@@ -389,43 +489,6 @@ class _ClientCallDetailsFields(Protocol):
     credentials: Any
     wait_for_ready: bool | None
     compression: Any
-
-
-class _RelayTokenInterceptor(
-    grpc.UnaryUnaryClientInterceptor,
-    grpc.StreamStreamClientInterceptor,
-):
-    def __init__(self, token: str) -> None:
-        self._token = token
-
-    def _details(self, client_call_details: grpc.ClientCallDetails) -> grpc.ClientCallDetails:
-        details = cast(_ClientCallDetailsFields, client_call_details)
-        metadata = list(details.metadata or [])
-        metadata.append((_INDEXEDDB_RELAY_TOKEN_HEADER, self._token))
-        return _ClientCallDetails(
-            details.method,
-            details.timeout,
-            metadata,
-            details.credentials,
-            details.wait_for_ready,
-            details.compression,
-        )
-
-    def intercept_unary_unary(
-        self,
-        continuation: Any,
-        client_call_details: grpc.ClientCallDetails,
-        request: Any,
-    ) -> Any:
-        return continuation(self._details(client_call_details), request)
-
-    def intercept_stream_stream(
-        self,
-        continuation: Any,
-        client_call_details: grpc.ClientCallDetails,
-        request_iterator: Any,
-    ) -> Any:
-        return continuation(self._details(client_call_details), request_iterator)
 
 
 class _RequestIterator:
@@ -489,8 +552,8 @@ class Cursor:
         except grpc.RpcError as e:
             self._closed = True
             self._request_iter.close()
-            code = e.code()  # ty: ignore[unresolved-attribute]
-            details = e.details()  # ty: ignore[unresolved-attribute]
+            code = e.code()
+            details = e.details()
             if code == grpc.StatusCode.NOT_FOUND:
                 raise NotFoundError(details) from e
             if code == grpc.StatusCode.ALREADY_EXISTS:
@@ -511,8 +574,8 @@ class Cursor:
         except grpc.RpcError as e:
             self._closed = True
             self._request_iter.close()
-            code = e.code()  # ty: ignore[unresolved-attribute]
-            details = e.details()  # ty: ignore[unresolved-attribute]
+            code = e.code()
+            details = e.details()
             if code == grpc.StatusCode.NOT_FOUND:
                 raise NotFoundError(details) from e
             if code == grpc.StatusCode.ALREADY_EXISTS:
@@ -612,8 +675,8 @@ class Cursor:
         except grpc.RpcError as e:
             self._closed = True
             self._request_iter.close()
-            code = e.code()  # ty: ignore[unresolved-attribute]
-            details = e.details()  # ty: ignore[unresolved-attribute]
+            code = e.code()
+            details = e.details()
             if code == grpc.StatusCode.NOT_FOUND:
                 raise NotFoundError(details) from e
             if code == grpc.StatusCode.ALREADY_EXISTS:
@@ -673,8 +736,8 @@ def _grpc_call(method: Any, request: Any) -> Any:
     try:
         return method(request)
     except grpc.RpcError as e:
-        code = e.code()  # ty: ignore[unresolved-attribute]
-        details = e.details()  # ty: ignore[unresolved-attribute]
+        code = e.code()
+        details = e.details()
         if code == grpc.StatusCode.NOT_FOUND:
             raise NotFoundError(details) from e
         if code == grpc.StatusCode.ALREADY_EXISTS:
@@ -777,7 +840,10 @@ def _json_value_to_python(v: Any) -> Any:
     if kind == "bool_value":
         return v.bool_value
     if kind == "struct_value":
-        return {key: _json_value_to_python(value) for key, value in v.struct_value.fields.items()}
+        return {
+            key: _json_value_to_python(value)
+            for key, value in v.struct_value.fields.items()
+        }
     if kind == "list_value":
         return [_json_value_to_python(value) for value in v.list_value.values]
     raise TypeError(f"unsupported JSON value kind: {kind}")
@@ -794,7 +860,9 @@ def _key_value_to_python(kv: Any) -> Any:
 
 def _python_to_key_value(v: Any) -> Any:
     if isinstance(v, (list, tuple)):
-        return pb.KeyValue(array=pb.KeyValueArray(elements=[_python_to_key_value(elem) for elem in v]))
+        return pb.KeyValue(
+            array=pb.KeyValueArray(elements=[_python_to_key_value(elem) for elem in v])
+        )
     return pb.KeyValue(scalar=_to_typed_value(v))
 
 

--- a/sdk/python/gestalt/_indexeddb.py
+++ b/sdk/python/gestalt/_indexeddb.py
@@ -9,6 +9,8 @@ from dataclasses import dataclass, field
 from typing import Any, Iterator, Protocol, cast
 from urllib import parse as _urlparse
 
+from ._optional_imports import is_optional_provider_import_error
+
 try:
     import grpc as _grpc
     from google.protobuf import struct_pb2 as _struct_pb2
@@ -17,7 +19,7 @@ try:
     from .gen.v1 import datastore_pb2 as _pb
     from .gen.v1 import datastore_pb2_grpc as _pb_grpc
 except ModuleNotFoundError as exc:
-    if exc.name not in {"google", "grpc"}:
+    if not is_optional_provider_import_error(exc):
         raise
     _IMPORT_ERROR: ModuleNotFoundError | None = exc
     _grpc: Any = None

--- a/sdk/python/gestalt/_optional_imports.py
+++ b/sdk/python/gestalt/_optional_imports.py
@@ -1,0 +1,8 @@
+from __future__ import annotations
+
+
+def is_optional_provider_import_error(exc: ModuleNotFoundError) -> bool:
+    missing_module = exc.name or ""
+    return missing_module in {"google", "grpc"} or missing_module.startswith(
+        ("google.", "grpc.")
+    )

--- a/sdk/python/gestalt/_runtime.py
+++ b/sdk/python/gestalt/_runtime.py
@@ -20,16 +20,9 @@ from ._bootstrap import parse_plugin_target, read_bundled_plugin_config
 from ._catalog import catalog_to_proto
 from ._http_subject import HTTPSubjectRequest, HTTPSubjectResolutionError
 from ._operations import INTERNAL_ERROR_MESSAGE
+from ._optional_imports import is_optional_provider_import_error
 from ._plugin import ConnectedToken, Plugin, _module_plugin
 from ._serialization import json_body
-
-
-def _is_optional_provider_import_error(exc: ModuleNotFoundError) -> bool:
-    missing_module = exc.name or ""
-    return missing_module in {"google", "grpc"} or missing_module.startswith(
-        ("google.", "grpc.")
-    )
-
 
 if TYPE_CHECKING:
     from ._providers import (
@@ -71,7 +64,7 @@ else:
             WorkflowProvider,
         )
     except ModuleNotFoundError as exc:
-        if not _is_optional_provider_import_error(exc):
+        if not is_optional_provider_import_error(exc):
             raise
 
         class ProviderKind(str, Enum):

--- a/sdk/python/gestalt/_runtime.py
+++ b/sdk/python/gestalt/_runtime.py
@@ -21,6 +21,15 @@ from ._catalog import catalog_to_proto
 from ._http_subject import HTTPSubjectRequest, HTTPSubjectResolutionError
 from ._operations import INTERNAL_ERROR_MESSAGE
 from ._plugin import ConnectedToken, Plugin, _module_plugin
+from ._serialization import json_body
+
+
+def _is_optional_provider_import_error(exc: ModuleNotFoundError) -> bool:
+    missing_module = exc.name or ""
+    return missing_module in {"google", "grpc"} or missing_module.startswith(
+        ("google.", "grpc.")
+    )
+
 
 if TYPE_CHECKING:
     from ._providers import (
@@ -62,7 +71,7 @@ else:
             WorkflowProvider,
         )
     except ModuleNotFoundError as exc:
-        if exc.name not in {"google", "grpc"}:
+        if not _is_optional_provider_import_error(exc):
             raise
 
         class ProviderKind(str, Enum):
@@ -175,9 +184,6 @@ else:
         class WarningsProvider:
             def warnings(self) -> list[str]:
                 raise NotImplementedError
-
-
-from ._serialization import json_body
 
 json_format: Any = cast(Any, None)
 try:

--- a/sdk/python/gestalt/_runtime.py
+++ b/sdk/python/gestalt/_runtime.py
@@ -61,7 +61,10 @@ else:
             WarningsProvider,
             WorkflowProvider,
         )
-    except ModuleNotFoundError:
+    except ModuleNotFoundError as exc:
+        if exc.name not in {"google", "grpc"}:
+            raise
+
         class ProviderKind(str, Enum):
             INTEGRATION = "integration"
             AUTHENTICATION = "authentication"
@@ -172,6 +175,8 @@ else:
         class WarningsProvider:
             def warnings(self) -> list[str]:
                 raise NotImplementedError
+
+
 from ._serialization import json_body
 
 json_format: Any = cast(Any, None)
@@ -640,6 +645,7 @@ def _register_cache_services(server: Any, provider: PluginProvider) -> None:
 
 def _provider_servicer(*, plugin: Plugin) -> Any:
     _ensure_grpc_runtime()
+
     class ProviderServicer(plugin_pb2_grpc.IntegrationProviderServicer):
         def GetMetadata(self, _request: Any, _context: Any) -> Any:
             return plugin_pb2.ProviderMetadata(
@@ -762,6 +768,7 @@ def _provider_servicer(*, plugin: Plugin) -> Any:
 
 def _runtime_servicer(*, provider: PluginProvider, kind: ProviderKind) -> Any:
     _ensure_grpc_runtime()
+
     class RuntimeServicer(runtime_pb2_grpc.ProviderLifecycleServicer):
         def GetProviderIdentity(self, _request: Any, _context: Any) -> Any:
             metadata = _provider_metadata(provider=provider, kind=kind)
@@ -809,7 +816,9 @@ def _authentication_servicer(*, provider: PluginProvider) -> Any:
     _ensure_grpc_runtime()
     auth_provider = cast(AuthenticationProvider, provider)
 
-    class AuthenticationServicer(authentication_pb2_grpc.AuthenticationProviderServicer):
+    class AuthenticationServicer(
+        authentication_pb2_grpc.AuthenticationProviderServicer
+    ):
         @_grpc_handler("begin login")
         def BeginLogin(self, request: Any, context: Any) -> Any:
             response = auth_provider.begin_login(request)
@@ -900,7 +909,9 @@ def _cache_servicer(*, provider: PluginProvider) -> Any:
             for key in request.keys:
                 value = values.get(key)
                 if value is None:
-                    entries.append(cache_pb2.CacheResult(key=key, found=False, value=b""))
+                    entries.append(
+                        cache_pb2.CacheResult(key=key, found=False, value=b"")
+                    )
                 else:
                     entries.append(
                         cache_pb2.CacheResult(key=key, found=True, value=bytes(value))
@@ -919,7 +930,10 @@ def _cache_servicer(*, provider: PluginProvider) -> Any:
         @_grpc_handler("cache set_many")
         def SetMany(self, request: Any, _context: Any) -> Any:
             cache_provider.set_many(
-                [CacheEntry(key=entry.key, value=bytes(entry.value)) for entry in request.entries],
+                [
+                    CacheEntry(key=entry.key, value=bytes(entry.value))
+                    for entry in request.entries
+                ],
                 _duration_to_timedelta(request.ttl),
             )
             return empty_pb2.Empty()
@@ -1034,7 +1048,9 @@ def _access_from_proto(request_context: Any) -> Access:
 def _workflow_from_proto(request_context: Any) -> dict[str, Any]:
     if request_context is None:
         return {}
-    if hasattr(request_context, "HasField") and not request_context.HasField("workflow"):
+    if hasattr(request_context, "HasField") and not request_context.HasField(
+        "workflow"
+    ):
         return {}
     workflow = getattr(request_context, "workflow", None)
     if workflow is None:
@@ -1143,7 +1159,9 @@ def _connected_token(token: Any) -> ConnectedToken:
         refresh_token=getattr(token, "refresh_token", ""),
         scopes=getattr(token, "scopes", ""),
         expires_at=_timestamp_to_datetime(getattr(token, "expires_at", None)),
-        last_refreshed_at=_timestamp_to_datetime(getattr(token, "last_refreshed_at", None)),
+        last_refreshed_at=_timestamp_to_datetime(
+            getattr(token, "last_refreshed_at", None)
+        ),
         refresh_error_count=int(getattr(token, "refresh_error_count", 0) or 0),
         metadata_json=metadata_json,
         metadata=metadata,

--- a/sdk/python/pyproject.toml
+++ b/sdk/python/pyproject.toml
@@ -12,6 +12,7 @@ dependencies = [
   "pyyaml==6.0.3",
   "pyinstaller<7",
   "protobuf>=6.33.1,<8",
+  "tomli>=2.2.1,<3",
   "typing-extensions==4.12.2",
 ]
 

--- a/sdk/python/tests/test_build.py
+++ b/sdk/python/tests/test_build.py
@@ -23,15 +23,29 @@ class CapturedBuildRun:
 class BuildTests(unittest.TestCase):
     """Build entrypoint tests."""
 
-    def test_build_plugin_binary_writes_bundle_config_and_uses_target_platform_settings(self) -> None:
+    def test_build_plugin_binary_writes_bundle_config_and_uses_target_platform_settings(
+        self,
+    ) -> None:
         """Build mode should package runtime metadata alongside the frozen entrypoint."""
         cases = [
             ("linux", "linux", "amd64", "provider-bin", "provider-bin", None),
             ("linux", "windows", "amd64", "provider.exe", "provider", None),
             ("darwin", "darwin", "amd64", "provider-bin", "provider-bin", "x86_64"),
         ]
-        for platform, target_goos, target_goarch, output_name, expected_binary_name, expected_target_arch in cases:
-            with self.subTest(platform=platform, target_goos=target_goos, target_goarch=target_goarch, output_name=output_name):
+        for (
+            platform,
+            target_goos,
+            target_goarch,
+            output_name,
+            expected_binary_name,
+            expected_target_arch,
+        ) in cases:
+            with self.subTest(
+                platform=platform,
+                target_goos=target_goos,
+                target_goarch=target_goarch,
+                output_name=output_name,
+            ):
                 with tempfile.TemporaryDirectory() as tmpdir:
                     root = pathlib.Path(tmpdir) / "plugin"
                     output = root / "dist" / output_name
@@ -55,15 +69,22 @@ class BuildTests(unittest.TestCase):
                             check=check,
                             env=env,
                             binary_name=command[command.index("--name") + 1],
-                            target_arch=command[command.index("--target-arch") + 1] if "--target-arch" in command else None,
+                            target_arch=command[command.index("--target-arch") + 1]
+                            if "--target-arch" in command
+                            else None,
                             destination=destination,
-                            bundle_config=json.loads(pathlib.Path(source).read_text(encoding="utf-8")),
+                            bundle_config=json.loads(
+                                pathlib.Path(source).read_text(encoding="utf-8")
+                            ),
                         )
 
-                    with mock.patch.object(_build.sys, "platform", platform), mock.patch.object(
-                        _build.subprocess,
-                        "run",
-                        side_effect=fake_run,
+                    with (
+                        mock.patch.object(_build.sys, "platform", platform),
+                        mock.patch.object(
+                            _build.subprocess,
+                            "run",
+                            side_effect=fake_run,
+                        ),
                     ):
                         _build.build_plugin_binary(
                             _build.BuildArgs(
@@ -85,7 +106,10 @@ class BuildTests(unittest.TestCase):
                 self.assertEqual(captured.binary_name, expected_binary_name)
                 self.assertEqual(captured.target_arch, expected_target_arch)
                 self.assertEqual(captured.destination, ".")
-                self.assertEqual(pathlib.Path(captured.env["PYINSTALLER_CONFIG_DIR"]).name, "pyinstaller-config")
+                self.assertEqual(
+                    pathlib.Path(captured.env["PYINSTALLER_CONFIG_DIR"]).name,
+                    "pyinstaller-config",
+                )
                 self.assertEqual(captured.env["SOURCE_DATE_EPOCH"], "0")
                 self.assertEqual(
                     captured.bundle_config,
@@ -100,12 +124,110 @@ class BuildTests(unittest.TestCase):
                     captured.command,
                 )
 
+    def test_build_plugin_binary_applies_pyinstaller_config(self) -> None:
+        """Providers can request additional PyInstaller collection settings."""
+        with tempfile.TemporaryDirectory() as tmpdir:
+            root = pathlib.Path(tmpdir) / "plugin"
+            output = root / "dist" / "provider-bin"
+            root.mkdir()
+            (root / "pyproject.toml").write_text(
+                """
+[tool.gestalt.pyinstaller]
+collect-data = ["litellm"]
+collect-submodules = ["pkg.dynamic"]
+collect-binaries = ["nativepkg"]
+collect-all = ["heavy"]
+copy-metadata = ["distmeta"]
+recursive-copy-metadata = ["distmetadeps"]
+hidden-imports = ["provider.extra"]
+exclude-modules = ["unused"]
+additional-hooks-dir = ["hooks"]
+""".lstrip(),
+                encoding="utf-8",
+            )
+            captured: CapturedBuildRun | None = None
+
+            def fake_run(
+                command: list[str],
+                cwd: pathlib.Path,
+                env: dict[str, str],
+                check: bool,
+            ) -> None:
+                nonlocal captured
+
+                add_data = command[command.index("--add-data") + 1]
+                separator = _build.os.pathsep
+                source, destination = add_data.split(separator, 1)
+                captured = CapturedBuildRun(
+                    command=command,
+                    cwd=cwd,
+                    check=check,
+                    env=env,
+                    binary_name=command[command.index("--name") + 1],
+                    target_arch=None,
+                    destination=destination,
+                    bundle_config=json.loads(
+                        pathlib.Path(source).read_text(encoding="utf-8")
+                    ),
+                )
+
+            with mock.patch.object(_build.subprocess, "run", side_effect=fake_run):
+                _build.build_plugin_binary(
+                    _build.BuildArgs(
+                        root=root,
+                        target="provider",
+                        output_path=output,
+                        plugin_name="released-plugin",
+                        runtime_kind="integration",
+                        goos="linux",
+                        goarch="amd64",
+                    )
+                )
+
+        self.assertIsNotNone(captured)
+        assert captured is not None
+        self.assertEqual(
+            captured.command[captured.command.index("--collect-data") + 1], "litellm"
+        )
+        self.assertEqual(
+            captured.command[captured.command.index("--collect-submodules") + 1],
+            "pkg.dynamic",
+        )
+        self.assertEqual(
+            captured.command[captured.command.index("--collect-binaries") + 1],
+            "nativepkg",
+        )
+        self.assertEqual(
+            captured.command[captured.command.index("--collect-all") + 1], "heavy"
+        )
+        self.assertEqual(
+            captured.command[captured.command.index("--copy-metadata") + 1], "distmeta"
+        )
+        self.assertEqual(
+            captured.command[captured.command.index("--recursive-copy-metadata") + 1],
+            "distmetadeps",
+        )
+        self.assertIn(
+            ["--hidden-import", "provider.extra"], _argument_pairs(captured.command)
+        )
+        self.assertEqual(
+            captured.command[captured.command.index("--exclude-module") + 1], "unused"
+        )
+        self.assertEqual(
+            pathlib.Path(
+                captured.command[captured.command.index("--additional-hooks-dir") + 1]
+            ),
+            root.resolve() / "hooks",
+        )
+
     def test_parse_build_args_rejects_wrong_count(self) -> None:
         """Build arg parser should reject incorrect argument counts."""
         self.assertIsNone(_build._parse_build_args([]))
         self.assertIsNone(_build._parse_build_args(["one"]))
         self.assertIsNone(_build._parse_build_args(["one", "two", "three"]))
-        self.assertIsNone(_build._parse_build_args(["one", "two", "three", "four", "five"]))
+        self.assertIsNone(
+            _build._parse_build_args(["one", "two", "three", "four", "five"])
+        )
         self.assertIsNone(
             _build._parse_build_args(["one", "two", "three", "four", "five", "six"])
         )
@@ -133,6 +255,10 @@ class BuildTests(unittest.TestCase):
         self.assertEqual(result.runtime_kind, "integration")
         self.assertEqual(result.goos, "linux")
         self.assertEqual(result.goarch, "amd64")
+
+
+def _argument_pairs(command: list[str]) -> list[list[str]]:
+    return [command[index : index + 2] for index in range(len(command) - 1)]
 
 
 if __name__ == "__main__":

--- a/sdk/python/tests/test_runtime.py
+++ b/sdk/python/tests/test_runtime.py
@@ -34,6 +34,7 @@ from gestalt import (
     _bootstrap,
     _runtime,
 )
+from gestalt._optional_imports import is_optional_provider_import_error
 from gestalt.gen.v1 import authentication_pb2 as _authentication_pb2
 from gestalt.gen.v1 import cache_pb2 as _cache_pb2
 from gestalt.gen.v1 import plugin_pb2 as _plugin_pb2
@@ -171,19 +172,19 @@ class DurationConversionTests(unittest.TestCase):
 class OptionalProviderImportErrorTests(unittest.TestCase):
     def test_allows_optional_dependency_roots(self) -> None:
         self.assertTrue(
-            _runtime._is_optional_provider_import_error(
+            is_optional_provider_import_error(
                 ModuleNotFoundError("No module named 'grpc'", name="grpc")
             )
         )
         self.assertTrue(
-            _runtime._is_optional_provider_import_error(
+            is_optional_provider_import_error(
                 ModuleNotFoundError("No module named 'google'", name="google")
             )
         )
 
     def test_allows_optional_dependency_submodules(self) -> None:
         self.assertTrue(
-            _runtime._is_optional_provider_import_error(
+            is_optional_provider_import_error(
                 ModuleNotFoundError(
                     "No module named 'google.protobuf'",
                     name="google.protobuf",
@@ -191,7 +192,7 @@ class OptionalProviderImportErrorTests(unittest.TestCase):
             )
         )
         self.assertTrue(
-            _runtime._is_optional_provider_import_error(
+            is_optional_provider_import_error(
                 ModuleNotFoundError(
                     "No module named 'grpc.aio'",
                     name="grpc.aio",
@@ -201,7 +202,7 @@ class OptionalProviderImportErrorTests(unittest.TestCase):
 
     def test_rejects_unrelated_missing_dependencies(self) -> None:
         self.assertFalse(
-            _runtime._is_optional_provider_import_error(
+            is_optional_provider_import_error(
                 ModuleNotFoundError("No module named 'redis'", name="redis")
             )
         )

--- a/sdk/python/tests/test_runtime.py
+++ b/sdk/python/tests/test_runtime.py
@@ -168,6 +168,45 @@ class DurationConversionTests(unittest.TestCase):
         )
 
 
+class OptionalProviderImportErrorTests(unittest.TestCase):
+    def test_allows_optional_dependency_roots(self) -> None:
+        self.assertTrue(
+            _runtime._is_optional_provider_import_error(
+                ModuleNotFoundError("No module named 'grpc'", name="grpc")
+            )
+        )
+        self.assertTrue(
+            _runtime._is_optional_provider_import_error(
+                ModuleNotFoundError("No module named 'google'", name="google")
+            )
+        )
+
+    def test_allows_optional_dependency_submodules(self) -> None:
+        self.assertTrue(
+            _runtime._is_optional_provider_import_error(
+                ModuleNotFoundError(
+                    "No module named 'google.protobuf'",
+                    name="google.protobuf",
+                )
+            )
+        )
+        self.assertTrue(
+            _runtime._is_optional_provider_import_error(
+                ModuleNotFoundError(
+                    "No module named 'grpc.aio'",
+                    name="grpc.aio",
+                )
+            )
+        )
+
+    def test_rejects_unrelated_missing_dependencies(self) -> None:
+        self.assertFalse(
+            _runtime._is_optional_provider_import_error(
+                ModuleNotFoundError("No module named 'redis'", name="redis")
+            )
+        )
+
+
 class ManifestNameTests(unittest.TestCase):
     def test_display_name_variants(self) -> None:
         with tempfile.TemporaryDirectory() as tmpdir:

--- a/sdk/python/uv.lock
+++ b/sdk/python/uv.lock
@@ -182,6 +182,7 @@ dependencies = [
     { name = "protobuf" },
     { name = "pyinstaller" },
     { name = "pyyaml" },
+    { name = "tomli" },
     { name = "typing-extensions" },
 ]
 
@@ -200,6 +201,7 @@ requires-dist = [
     { name = "protobuf", specifier = ">=6.33.1,<8" },
     { name = "pyinstaller", specifier = "<7" },
     { name = "pyyaml", specifier = "==6.0.3" },
+    { name = "tomli", specifier = ">=2.2.1,<3" },
     { name = "typing-extensions", specifier = "==4.12.2" },
 ]
 


### PR DESCRIPTION
## Summary

This PR does two things that now need to ship together:

1. It lets host agent providers use the same source-backed release flow as other host provider kinds.
2. It grows the Python SDK so released Python providers package reliably without provider-local protobuf copies or hidden-import hacks.

## New Interfaces

Source-backed agent providers:

```yaml
providers:
  agent:
    simple:
      source: https://github.com/valon-technologies/gestalt-providers/releases/download/agent/simple/v0.0.1-alpha.3/provider-release.yaml
      default: true
      indexeddb:
        provider: main-db
        objectStores: [agent_runs, agent_run_idempotency]
      config:
        runStore: agent_runs
        idempotencyStore: agent_run_idempotency
```

Python provider module shape stays simple:

```python
provider = SimpleAgentRuntimeProvider()
```

Released Python providers can now declare packaging inputs in the SDK instead of vendoring release logic per provider:

```toml
[tool.gestalt]
agent = "provider"

[tool.gestalt.pyinstaller]
collect-data = ["litellm"]
collect-submodules = ["tiktoken_ext"]
```

The published Python SDK now also:

- eagerly imports `gestalt._indexeddb`, so provider authors do not need hidden-import workarounds for IndexedDB support
- tolerates optional provider import failures for `google.*` and `grpc.*` namespace/submodule imports in packaged runtime fallback paths
- keeps provider authors on the published SDK surface instead of copying generated protobuf code into downstream repos

## Validation

- `go test ./internal/providerpkg ./internal/operator ./internal/config ./internal/bootstrap`
- `uv run ruff check gestalt/_build.py gestalt/_runtime.py gestalt/_indexeddb.py gestalt/__init__.py tests/test_build.py tests/test_runtime.py`
- `uv run ty check --exclude 'gestalt/gen/**' gestalt scripts tests`
- `uv run python -m unittest tests.test_build tests.test_runtime tests.test_agent_transport tests.test_indexeddb_cursor_unit tests.test_indexeddb_transport`
- Published `gestalt-sdk==0.0.1a13` from tag `sdk/python/v0.0.1-alpha.13`

## Example Outcome

Downstream providers can now depend on the published SDK and release an agent provider without:

- generated protobuf copies in the provider repo
- provider-local `gestalt._indexeddb` hidden imports
- a separate `main()` wrapper just to start the runtime
