### PR TITLE
Add OpenAI agent provider

### DIFF
--- a/docs/content/custom-providers/agent.mdx
+++ b/docs/content/custom-providers/agent.mdx
@@ -38,6 +38,9 @@ The agent service includes four run methods:
 
 Providers can also call back into Gestalt through `AgentHost.ExecuteTool` when
 they want the host to execute a bound plugin operation during a run.
+Providers should call `AgentHost.EmitEvent` for provider-owned run progress,
+tool calls, and model responses; the host persists and streams those events
+without owning the provider's internal state machine.
 
 ## Run shape
 
@@ -186,9 +189,33 @@ Gestalt returns an HTTP-like envelope:
 }
 ```
 
-In V1 there is no standardized IndexedDB or general storage binding for agent
-providers. If your provider needs durable state, define it in your own config
-schema and manage it behind the provider.
+## Run events
+
+Providers emit events through `AgentHost.EmitEvent`:
+
+```json
+{
+  "runId": "run-123",
+  "type": "agent.tool_call.completed",
+  "visibility": "public",
+  "data": {
+    "toolCallId": "call-1",
+    "toolId": "roadmap/sync",
+    "status": 200
+  }
+}
+```
+
+Event `type` and `data` are provider-owned. Use stable reverse-DNS-style or
+agent-prefixed names for public events, and keep provider-specific details in
+`data` rather than adding host-owned fields. Common event names are
+`agent.run.started`, `agent.model.response`, `agent.tool_call.started`,
+`agent.tool_call.completed`, `agent.tool_call.failed`, `agent.run.completed`,
+and `agent.run.failed`.
+
+If your provider needs durable state, configure an IndexedDB binding on the
+`providers.agent.<name>` entry or define your own storage config. The provider
+still owns its run schema and object-store names.
 
 ## What to read next
 

--- a/docs/content/providers/agent.mdx
+++ b/docs/content/providers/agent.mdx
@@ -92,15 +92,45 @@ The neutral agent run shape is intentionally small:
     },
     "required": ["summary"]
   },
+  "providerOptions": {
+    "temperature": 0.2,
+    "metadata": {
+      "source": "roadmap-review"
+    }
+  },
   "sessionRef": "session-123"
 }
 ```
 
 ## First-party agent providers
 
-There is not yet a first-party agent provider published from
-`valon-technologies/gestalt-providers`. If you need one today, implement a
-custom provider against the neutral protocol.
+`openai` is a first-party source package backed by the OpenAI Responses API:
+
+```yaml
+providers:
+  agent:
+    openai:
+      source: ./providers/agent/openai/manifest.yaml
+      default: true
+      config:
+        model: gpt-5.4
+        baseURL: https://api.openai.com/v1
+        apiKey:
+          secret:
+            provider: default
+            name: openai-api-key
+        timeoutMs: 120000
+        maxTurns: 8
+```
+
+The provider maps Gestalt tools to OpenAI function tools, calls
+`AgentHost.ExecuteTool` for each `function_call`, sends
+`function_call_output` items back to OpenAI, and emits run events such as
+`agent.run.started`, `agent.model.response`, `agent.tool_call.completed`, and
+`agent.run.completed`. Gestalt accepts the neutral run response and
+persists/streams emitted events; the provider owns the vendor loop, run state,
+session continuation via OpenAI response IDs, and any vendor-specific request
+options.
 
 ## What to read next
 

--- a/docs/content/reference/built-in-providers.mdx
+++ b/docs/content/reference/built-in-providers.mdx
@@ -152,12 +152,24 @@ workflows:
 
 ## Agent Providers
 
-Agent providers are configured under `providers.agent.<name>`, but there is
-not yet a first-party agent provider published from
-`valon-technologies/gestalt-providers`.
+Agent providers are configured under `providers.agent.<name>`, then referenced
+by global agent run requests, the agent CLI, or plugins using the host agent
+manager.
 
-If you need one today, implement it with
-[Custom Providers > Agent](/custom-providers/agent).
+```yaml
+providers:
+  agent:
+    openai:
+      source: ./providers/agent/openai/manifest.yaml
+      default: true
+      config:
+        model: gpt-5.4
+        apiKey: ${OPENAI_API_KEY}
+```
+
+| Name | Purpose |
+| --- | --- |
+| `openai` | Runs the neutral agent protocol on the OpenAI Responses API and maps Gestalt tools to function calls. |
 
 ## S3 Providers
 

--- a/providers/agent/openai/agent.ts
+++ b/providers/agent/openai/agent.ts
@@ -1,0 +1,675 @@
+import type {
+  AgentRunStatus as AgentRunStatusType,
+  ExecuteAgentToolResponse,
+  ResolvedAgentTool,
+  StartAgentProviderRunRequest,
+} from "../../../sdk/typescript/src/index.ts";
+
+type GestaltSDK = typeof import("../../../sdk/typescript/src/index.ts");
+
+const packageSDK = "@valon-technologies/gestalt";
+const localSDK = "../../../sdk/typescript/src/index.ts";
+const { AgentHost, AgentRunStatus, ENV_AGENT_HOST_SOCKET, defineAgentProvider } =
+  await loadGestaltSDK();
+
+async function loadGestaltSDK(): Promise<GestaltSDK> {
+  const candidate = await import(packageSDK).catch(() => undefined);
+  if (
+    candidate &&
+    "defineAgentProvider" in candidate &&
+    "AgentHost" in candidate &&
+    "AgentRunStatus" in candidate
+  ) {
+    return candidate as GestaltSDK;
+  }
+  return (await import(localSDK)) as GestaltSDK;
+}
+
+type JsonValue = null | boolean | number | string | JsonValue[] | { [key: string]: JsonValue };
+type JsonObject = { [key: string]: JsonValue };
+
+type OpenAIConfig = {
+  apiKey: string;
+  baseURL: string;
+  model: string;
+  timeoutMs: number;
+  maxTurns: number;
+  store?: boolean;
+};
+
+type OpenAITool = {
+  type: "function";
+  name: string;
+  description?: string;
+  parameters: JsonObject;
+  strict: boolean;
+};
+
+type ToolMapping = {
+  tool: ResolvedAgentTool;
+  openAIName: string;
+};
+
+type OpenAIFunctionCall = {
+  type: "function_call";
+  id?: string;
+  call_id: string;
+  name: string;
+  arguments: string;
+  status?: string;
+};
+
+type OpenAIResponse = {
+  id?: string;
+  status?: string;
+  output?: unknown[];
+  output_text?: string;
+  error?: {
+    message?: string;
+    code?: string;
+  } | null;
+};
+
+type RunResult = {
+  responseId: string;
+  outputText: string;
+  structuredOutput?: JsonObject;
+};
+
+type TimestampInit = {
+  seconds: bigint;
+  nanos: number;
+};
+
+type StoredRun = {
+  id: string;
+  providerName: string;
+  model: string;
+  status: AgentRunStatusType;
+  messages: StartAgentProviderRunRequest["messages"];
+  outputText: string;
+  structuredOutput?: JsonObject;
+  statusMessage: string;
+  sessionRef: string;
+  createdBy?: NonNullable<StartAgentProviderRunRequest["createdBy"]>;
+  createdAt?: TimestampInit;
+  startedAt?: TimestampInit;
+  completedAt?: TimestampInit;
+  executionRef: string;
+};
+
+const DEFAULT_CONFIG: OpenAIConfig = {
+  apiKey: "",
+  baseURL: "https://api.openai.com/v1",
+  model: "gpt-5.4",
+  timeoutMs: 120_000,
+  maxTurns: 8,
+};
+
+let config: OpenAIConfig = { ...DEFAULT_CONFIG };
+let host: AgentHost | undefined;
+
+const runs = new Map<string, StoredRun>();
+const controllers = new Map<string, AbortController>();
+const sessions = new Map<string, string>();
+
+export const provider = defineAgentProvider({
+  name: "openai",
+  displayName: "OpenAI Agent",
+  description: "OpenAI Responses API-backed agent provider",
+  version: "0.0.1-alpha.0",
+  configure(_name, rawConfig) {
+    config = parseConfig(rawConfig);
+    host = undefined;
+    runs.clear();
+    controllers.clear();
+    sessions.clear();
+  },
+  async startRun(request) {
+    const runID = request.runId || `run-${crypto.randomUUID()}`;
+    const startedAt = timestampNow();
+    const controller = new AbortController();
+    controllers.set(runID, controller);
+
+    const running = createRun(request, {
+      id: runID,
+      status: AgentRunStatus.RUNNING,
+      startedAt,
+      statusMessage: "running",
+    });
+    runs.set(runID, running);
+
+    await emitEvent(runID, "agent.run.started", {
+      model: modelForRequest(request),
+      messageCount: request.messages.length,
+      toolCount: request.tools.length,
+    });
+
+    void finishRun(request, runID, startedAt, controller);
+    return running;
+  },
+  async getRun(request) {
+    return requireRun(request.runId);
+  },
+  async listRuns() {
+    return [...runs.values()];
+  },
+  async cancelRun(request) {
+    const run = requireRun(request.runId);
+    const controller = controllers.get(request.runId);
+    if (controller) {
+      controller.abort();
+    }
+    if (isTerminal(run.status)) {
+      return run;
+    }
+    const canceled = cleanOptional({
+      id: run.id,
+      providerName: run.providerName,
+      model: run.model,
+      status: AgentRunStatus.CANCELED,
+      messages: run.messages,
+      outputText: run.outputText,
+      ...(run.structuredOutput ? { structuredOutput: run.structuredOutput } : {}),
+      statusMessage: request.reason || "canceled",
+      sessionRef: run.sessionRef,
+      ...(run.createdBy ? { createdBy: run.createdBy } : {}),
+      ...(run.createdAt ? { createdAt: run.createdAt } : {}),
+      ...(run.startedAt ? { startedAt: run.startedAt } : {}),
+      completedAt: timestampNow(),
+      executionRef: run.executionRef,
+    });
+    runs.set(request.runId, canceled);
+    await emitEvent(request.runId, "agent.run.canceled", {
+      status: "canceled",
+      reason: request.reason,
+    });
+    return canceled;
+  },
+});
+
+async function finishRun(
+  request: StartAgentProviderRunRequest,
+  runID: string,
+  startedAt: TimestampInit,
+  controller: AbortController,
+): Promise<void> {
+  try {
+    const result = await runResponsesLoop(request, runID, controller.signal);
+    const completed = createRun(request, {
+      id: runID,
+      status: AgentRunStatus.SUCCEEDED,
+      outputText: result.outputText,
+      ...(result.structuredOutput ? { structuredOutput: result.structuredOutput } : {}),
+      startedAt,
+      completedAt: timestampNow(),
+      statusMessage: "completed",
+    });
+    runs.set(runID, completed);
+    await emitEvent(runID, "agent.run.completed", {
+      responseId: result.responseId,
+      status: "succeeded",
+    });
+  } catch (error) {
+    const aborted = isAbortError(error);
+    const failed = createRun(request, {
+      id: runID,
+      status: aborted ? AgentRunStatus.CANCELED : AgentRunStatus.FAILED,
+      startedAt,
+      completedAt: timestampNow(),
+      statusMessage: aborted ? "canceled" : errorMessage(error),
+    });
+    runs.set(runID, failed);
+    await emitEvent(
+      runID,
+      aborted ? "agent.run.canceled" : "agent.run.failed",
+      aborted
+        ? { status: "canceled" }
+        : {
+            status: "failed",
+            error: errorMessage(error),
+          },
+    );
+  } finally {
+    controllers.delete(runID);
+  }
+}
+
+async function runResponsesLoop(
+  request: StartAgentProviderRunRequest,
+  runID: string,
+  signal: AbortSignal,
+): Promise<RunResult> {
+  const toolMappings = createToolMappings(request.tools);
+  const tools = toolMappings.map((mapping) => openAITool(mapping));
+  const toolByName = new Map(toolMappings.map((mapping) => [mapping.openAIName, mapping]));
+  const basePayload = createBasePayload(request, tools);
+  let payload: JsonObject = {
+    ...basePayload,
+    ...(request.sessionRef && sessions.has(request.sessionRef)
+      ? { previous_response_id: sessions.get(request.sessionRef)! }
+      : {}),
+    input: request.messages.map(openAIMessage),
+  };
+  let response: OpenAIResponse | undefined;
+
+  for (let turn = 0; turn < config.maxTurns; turn += 1) {
+    response = await createResponse(payload, signal);
+    await emitEvent(runID, "agent.model.response", {
+      ...(response.id ? { responseId: response.id } : {}),
+      ...(response.status ? { status: response.status } : {}),
+      outputCount: Array.isArray(response.output) ? response.output.length : 0,
+      turn: turn + 1,
+    });
+
+    const functionCalls = response.output?.filter(isFunctionCall) ?? [];
+    if (functionCalls.length === 0) {
+      const outputText = extractOutputText(response);
+      if (request.sessionRef && response.id) {
+        sessions.set(request.sessionRef, response.id);
+      }
+      const structuredOutput = parseStructuredOutput(request, outputText);
+      return cleanOptional({
+        responseId: response.id ?? "",
+        outputText,
+        structuredOutput,
+      }) as RunResult;
+    }
+
+    const toolOutputs = [];
+    for (const call of functionCalls) {
+      const mapping = toolByName.get(call.name);
+      if (!mapping) {
+        throw new Error(`OpenAI requested unknown tool ${call.name}`);
+      }
+      const args = parseToolArguments(call);
+      await emitEvent(runID, "agent.tool_call.started", {
+        toolCallId: call.call_id,
+        toolId: mapping.tool.id,
+        name: mapping.openAIName,
+      });
+
+      let toolResponse: ExecuteAgentToolResponse;
+      try {
+        toolResponse = await agentHost().executeTool({
+          runId: runID,
+          toolCallId: call.call_id,
+          toolId: mapping.tool.id,
+          arguments: args,
+        });
+      } catch (error) {
+        await emitEvent(runID, "agent.tool_call.failed", {
+          toolCallId: call.call_id,
+          toolId: mapping.tool.id,
+          error: errorMessage(error),
+        });
+        throw error;
+      }
+
+      await emitEvent(runID, "agent.tool_call.completed", {
+        toolCallId: call.call_id,
+        toolId: mapping.tool.id,
+        status: toolResponse.status,
+      });
+      toolOutputs.push({
+        type: "function_call_output",
+        call_id: call.call_id,
+        output: toolOutputText(toolResponse),
+      });
+    }
+
+    if (!response.id) {
+      throw new Error("OpenAI response omitted id before tool continuation");
+    }
+
+    payload = {
+      ...basePayload,
+      previous_response_id: response.id,
+      input: toolOutputs,
+    };
+  }
+
+  throw new Error(`OpenAI response exceeded maxTurns=${config.maxTurns}`);
+}
+
+function createBasePayload(
+  request: StartAgentProviderRunRequest,
+  tools: OpenAITool[],
+): JsonObject {
+  const payload: JsonObject = {
+    model: modelForRequest(request),
+  };
+  if (tools.length > 0) {
+    payload.tools = tools;
+    payload.tool_choice = "auto";
+  }
+  if (request.responseSchema && Object.keys(request.responseSchema).length > 0) {
+    payload.text = {
+      format: {
+        type: "json_schema",
+        name: "gestalt_agent_response",
+        schema: request.responseSchema,
+        strict: false,
+      },
+    };
+  }
+  if (config.store !== undefined) {
+    payload.store = config.store;
+  }
+  applyProviderOptions(payload, request.providerOptions ?? {});
+  return payload;
+}
+
+function applyProviderOptions(payload: JsonObject, options: JsonObject): void {
+  for (const key of [
+    "instructions",
+    "max_output_tokens",
+    "parallel_tool_calls",
+    "reasoning",
+    "temperature",
+    "tool_choice",
+    "top_p",
+    "truncation",
+    "user",
+  ]) {
+    const value = options[key];
+    if (value !== undefined) {
+      payload[key] = value;
+    }
+  }
+  if (isObject(options.metadata)) {
+    payload.metadata = options.metadata;
+  }
+  if (typeof options.store === "boolean") {
+    payload.store = options.store;
+  }
+}
+
+async function createResponse(payload: JsonObject, signal: AbortSignal): Promise<OpenAIResponse> {
+  const timeout = AbortSignal.timeout(config.timeoutMs);
+  const combinedSignal = AbortSignal.any([signal, timeout]);
+  const response = await fetch(`${trimTrailingSlash(config.baseURL)}/responses`, {
+    method: "POST",
+    headers: {
+      Authorization: `Bearer ${config.apiKey}`,
+      "Content-Type": "application/json",
+    },
+    body: JSON.stringify(payload),
+    signal: combinedSignal,
+  });
+
+  const text = await response.text();
+  const body = text ? tryParseJSON(text) : undefined;
+  if (!response.ok) {
+    const message =
+      isObject(body) && isObject(body.error) && typeof body.error.message === "string"
+        ? body.error.message
+        : text;
+    throw new Error(`OpenAI responses API returned ${response.status}: ${message}`);
+  }
+  if (!isObject(body)) {
+    throw new Error("OpenAI responses API returned a non-object response");
+  }
+  if (isObject(body.error) && typeof body.error.message === "string") {
+    throw new Error(`OpenAI responses API error: ${body.error.message}`);
+  }
+  return body as OpenAIResponse;
+}
+
+function createToolMappings(tools: ResolvedAgentTool[]): ToolMapping[] {
+  const seen = new Set<string>();
+  return tools.map((tool, index) => {
+    const base = normalizeFunctionName(tool.name || tool.id || `tool_${index + 1}`);
+    let openAIName = base;
+    let suffix = 2;
+    while (seen.has(openAIName)) {
+      const nextSuffix = `_${suffix}`;
+      openAIName = `${base.slice(0, 64 - nextSuffix.length)}${nextSuffix}`;
+      suffix += 1;
+    }
+    seen.add(openAIName);
+    return { tool, openAIName };
+  });
+}
+
+function openAITool(mapping: ToolMapping): OpenAITool {
+  const tool: OpenAITool = {
+    type: "function",
+    name: mapping.openAIName,
+    parameters:
+      mapping.tool.parametersSchema && Object.keys(mapping.tool.parametersSchema).length > 0
+        ? mapping.tool.parametersSchema
+        : { type: "object", properties: {}, additionalProperties: true },
+    strict: false,
+  };
+  if (mapping.tool.description) {
+    tool.description = mapping.tool.description;
+  }
+  return tool;
+}
+
+function openAIMessage(message: { role: string; text: string }): JsonObject {
+  return {
+    role: normalizeRole(message.role),
+    content: message.text,
+  };
+}
+
+function normalizeRole(role: string): string {
+  switch (role) {
+    case "system":
+    case "developer":
+    case "assistant":
+    case "user":
+      return role;
+    default:
+      return "user";
+  }
+}
+
+function parseToolArguments(call: OpenAIFunctionCall): JsonObject {
+  const parsed = parseJSON(call.arguments || "{}");
+  if (!isObject(parsed)) {
+    throw new Error(`OpenAI tool call ${call.call_id} arguments must be a JSON object`);
+  }
+  return parsed;
+}
+
+function isFunctionCall(item: unknown): item is OpenAIFunctionCall {
+  return (
+    isObject(item) &&
+    item.type === "function_call" &&
+    typeof item.call_id === "string" &&
+    typeof item.name === "string" &&
+    typeof item.arguments === "string"
+  );
+}
+
+function extractOutputText(response: OpenAIResponse): string {
+  if (typeof response.output_text === "string") {
+    return response.output_text;
+  }
+  const chunks: string[] = [];
+  for (const item of response.output ?? []) {
+    if (!isObject(item) || item.type !== "message" || !Array.isArray(item.content)) {
+      continue;
+    }
+    for (const content of item.content) {
+      if (isObject(content) && content.type === "output_text" && typeof content.text === "string") {
+        chunks.push(content.text);
+      }
+    }
+  }
+  return chunks.join("");
+}
+
+function parseStructuredOutput(
+  request: StartAgentProviderRunRequest,
+  outputText: string,
+): JsonObject | undefined {
+  if (!request.responseSchema || Object.keys(request.responseSchema).length === 0) {
+    return undefined;
+  }
+  const parsed = parseJSON(outputText);
+  if (!isObject(parsed)) {
+    throw new Error("OpenAI structured output was not a JSON object");
+  }
+  return parsed;
+}
+
+function toolOutputText(response: ExecuteAgentToolResponse): string {
+  if (response.status >= 200 && response.status < 300) {
+    return response.body;
+  }
+  return JSON.stringify({
+    status: response.status,
+    body: response.body,
+  });
+}
+
+function createRun(
+  request: StartAgentProviderRunRequest,
+  fields: Partial<StoredRun> & { id: string; status: AgentRunStatusType },
+): StoredRun {
+  return cleanOptional({
+    id: fields.id,
+    providerName: request.providerName || "openai",
+    model: modelForRequest(request),
+    status: fields.status,
+    messages: [...request.messages],
+    outputText: fields.outputText ?? "",
+    structuredOutput: fields.structuredOutput,
+    statusMessage: fields.statusMessage ?? "",
+    sessionRef: request.sessionRef,
+    createdBy: request.createdBy,
+    createdAt: fields.createdAt ?? timestampNow(),
+    startedAt: fields.startedAt,
+    completedAt: fields.completedAt,
+    executionRef: request.executionRef,
+  }) as StoredRun;
+}
+
+function modelForRequest(request: StartAgentProviderRunRequest): string {
+  return request.model || config.model;
+}
+
+function requireRun(runID: string): StoredRun {
+  const run = runs.get(runID);
+  if (!run) {
+    throw new Error(`unknown run ${runID}`);
+  }
+  return run;
+}
+
+async function emitEvent(runID: string, type: string, data: JsonObject): Promise<void> {
+  if (!process.env[ENV_AGENT_HOST_SOCKET]) {
+    return;
+  }
+  const cleanData = cleanOptional(data);
+  try {
+    await agentHost().emitEvent({
+      runId: runID,
+      type,
+      visibility: "public",
+      data: cleanData,
+    });
+  } catch {
+    // Event emission should never decide run success. Providers still return the
+    // current run and let the host surface callback failures through host logs.
+  }
+}
+
+function agentHost(): AgentHost {
+  host ??= new AgentHost();
+  return host;
+}
+
+function parseConfig(raw: Record<string, unknown>): OpenAIConfig {
+  const apiKey = stringConfig(raw, "apiKey", process.env.OPENAI_API_KEY ?? "");
+  if (!apiKey) {
+    throw new Error("OpenAI agent provider config.apiKey or OPENAI_API_KEY is required");
+  }
+  const parsed: OpenAIConfig = {
+    apiKey,
+    baseURL: stringConfig(raw, "baseURL", DEFAULT_CONFIG.baseURL),
+    model: stringConfig(raw, "model", DEFAULT_CONFIG.model),
+    timeoutMs: numberConfig(raw, "timeoutMs", DEFAULT_CONFIG.timeoutMs),
+    maxTurns: numberConfig(raw, "maxTurns", DEFAULT_CONFIG.maxTurns),
+  };
+  if (typeof raw.store === "boolean") {
+    parsed.store = raw.store;
+  }
+  return parsed;
+}
+
+function stringConfig(raw: Record<string, unknown>, key: string, fallback: string): string {
+  const value = raw[key];
+  return typeof value === "string" && value.trim() ? value.trim() : fallback;
+}
+
+function numberConfig(raw: Record<string, unknown>, key: string, fallback: number): number {
+  const value = raw[key];
+  if (typeof value !== "number" || !Number.isFinite(value) || value <= 0) {
+    return fallback;
+  }
+  return Math.trunc(value);
+}
+
+function normalizeFunctionName(value: string): string {
+  const normalized = value.replace(/[^A-Za-z0-9_-]/g, "_").replace(/^_+|_+$/g, "");
+  const prefixed = /^[A-Za-z0-9]/.test(normalized) ? normalized : `tool_${normalized}`;
+  return (prefixed || "tool").slice(0, 64);
+}
+
+function trimTrailingSlash(value: string): string {
+  return value.replace(/\/+$/, "");
+}
+
+function timestampNow() {
+  return {
+    seconds: BigInt(Math.trunc(Date.now() / 1000)),
+    nanos: 0,
+  };
+}
+
+function parseJSON(value: string): unknown {
+  try {
+    return JSON.parse(value);
+  } catch (error) {
+    throw new Error(`parse JSON: ${errorMessage(error)}`);
+  }
+}
+
+function tryParseJSON(value: string): unknown {
+  try {
+    return JSON.parse(value);
+  } catch {
+    return undefined;
+  }
+}
+
+function isObject(value: unknown): value is JsonObject {
+  return typeof value === "object" && value !== null && !Array.isArray(value);
+}
+
+function cleanOptional<T extends Record<string, unknown>>(value: T): T {
+  return Object.fromEntries(
+    Object.entries(value).filter((entry) => entry[1] !== undefined),
+  ) as T;
+}
+
+function isAbortError(error: unknown): boolean {
+  return error instanceof Error && error.name === "AbortError";
+}
+
+function isTerminal(status: AgentRunStatusType): boolean {
+  return (
+    status === AgentRunStatus.SUCCEEDED ||
+    status === AgentRunStatus.FAILED ||
+    status === AgentRunStatus.CANCELED
+  );
+}
+
+function errorMessage(error: unknown): string {
+  return error instanceof Error ? error.message : String(error);
+}

--- a/providers/agent/openai/config.schema.json
+++ b/providers/agent/openai/config.schema.json
@@ -1,0 +1,37 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "type": "object",
+  "additionalProperties": false,
+  "properties": {
+    "apiKey": {
+      "type": "string",
+      "description": "OpenAI API key. If omitted, the provider reads OPENAI_API_KEY."
+    },
+    "baseURL": {
+      "type": "string",
+      "default": "https://api.openai.com/v1",
+      "description": "Base URL for the OpenAI-compatible v1 API."
+    },
+    "model": {
+      "type": "string",
+      "default": "gpt-5.4",
+      "description": "Default OpenAI model when the run request omits model."
+    },
+    "timeoutMs": {
+      "type": "integer",
+      "minimum": 1,
+      "default": 120000,
+      "description": "Per-request timeout for OpenAI Responses API calls."
+    },
+    "maxTurns": {
+      "type": "integer",
+      "minimum": 1,
+      "default": 8,
+      "description": "Maximum model/tool loop iterations before the provider fails the run."
+    },
+    "store": {
+      "type": "boolean",
+      "description": "Optional Responses API store flag."
+    }
+  }
+}

--- a/providers/agent/openai/manifest.yaml
+++ b/providers/agent/openai/manifest.yaml
@@ -1,0 +1,7 @@
+kind: agent
+source: github.com/valon-technologies/gestalt/providers/agent/openai
+version: 0.0.1-alpha.0
+displayName: OpenAI Agent
+description: OpenAI Responses API-backed agent provider.
+spec:
+  configSchemaPath: ./config.schema.json

--- a/providers/agent/openai/package.json
+++ b/providers/agent/openai/package.json
@@ -1,0 +1,15 @@
+{
+  "name": "@valon-technologies/gestalt-agent-provider-openai",
+  "version": "0.0.1-alpha.0",
+  "private": true,
+  "type": "module",
+  "gestalt": {
+    "provider": {
+      "kind": "agent",
+      "target": "./agent.ts#provider"
+    }
+  },
+  "dependencies": {
+    "@valon-technologies/gestalt": "0.0.1-alpha.10"
+  }
+}

--- a/sdk/typescript/src/agent.ts
+++ b/sdk/typescript/src/agent.ts
@@ -17,6 +17,8 @@ import {
   AgentRunStatus,
   AgentToolSourceMode,
   BoundAgentRunSchema,
+  EmitAgentEventRequestSchema,
+  ExecuteAgentToolRequestSchema,
   ListAgentProviderRunsResponseSchema,
   type AgentActor,
   type AgentMessage,
@@ -146,13 +148,15 @@ export class AgentHost {
   }
 
   async executeTool(
-    request: ExecuteAgentToolRequest,
+    request: MessageInitShape<typeof ExecuteAgentToolRequestSchema>,
   ): Promise<ExecuteAgentToolResponse> {
-    return await this.client.executeTool(request);
+    return await this.client.executeTool(create(ExecuteAgentToolRequestSchema, request));
   }
 
-  async emitEvent(request: EmitAgentEventRequest): Promise<void> {
-    await this.client.emitEvent(request);
+  async emitEvent(
+    request: MessageInitShape<typeof EmitAgentEventRequestSchema>,
+  ): Promise<void> {
+    await this.client.emitEvent(create(EmitAgentEventRequestSchema, request));
   }
 }
 

--- a/sdk/typescript/tests/openai-agent-provider.transport.test.ts
+++ b/sdk/typescript/tests/openai-agent-provider.transport.test.ts
@@ -1,0 +1,494 @@
+import { mkdtempSync } from "node:fs";
+import { createServer as createHTTPServer, type IncomingMessage } from "node:http";
+import { createServer } from "node:http2";
+import { tmpdir } from "node:os";
+import { join, resolve } from "node:path";
+
+import { create } from "@bufbuild/protobuf";
+import { type ServiceImpl } from "@connectrpc/connect";
+import { connectNodeAdapter } from "@connectrpc/connect-node";
+import { expect, test } from "bun:test";
+
+import {
+  AgentHost as AgentHostService,
+  AgentProvider as AgentProviderService,
+  AgentRunStatus,
+  ExecuteAgentToolResponseSchema,
+  GetAgentProviderRunRequestSchema,
+  StartAgentProviderRunRequestSchema,
+} from "../gen/v1/agent_pb.ts";
+import {
+  ENV_AGENT_HOST_SOCKET,
+  createAgentProviderService,
+  isAgentProvider,
+  loadProviderFromTarget,
+} from "../src/index.ts";
+import { createUnixGrpcClient, removeTempDir } from "./helpers.ts";
+
+test("OpenAI agent provider runs the Responses tool loop through host callbacks", async () => {
+  const tempDir = mkdtempSync(join(tmpdir(), "gts-openai-agent-"));
+  const hostSocketPath = join(tempDir, "agent-host.sock");
+  const providerSocketPath = join(tempDir, "agent-provider.sock");
+  const previousHostSocket = process.env[ENV_AGENT_HOST_SOCKET];
+  const openAIRequests: Array<{
+    path: string;
+    authorization: string | undefined;
+    body: Record<string, unknown>;
+  }> = [];
+  const toolCalls: Array<{
+    runId: string;
+    toolCallId: string;
+    toolId: string;
+    arguments: unknown;
+  }> = [];
+  const events: Array<{
+    runId: string;
+    type: string;
+    data: unknown;
+  }> = [];
+  const provider = await loadProviderFromTarget(
+    resolve(import.meta.dir, "../../../providers/agent/openai"),
+  );
+  if (!isAgentProvider(provider)) {
+    throw new Error("OpenAI package did not load an agent provider");
+  }
+
+  const openAIServer = createHTTPServer(async (request, response) => {
+    const body = JSON.parse(await readRequestBody(request)) as Record<string, unknown>;
+    openAIRequests.push({
+      path: request.url ?? "",
+      authorization: request.headers.authorization,
+      body,
+    });
+
+    response.writeHead(200, { "Content-Type": "application/json" });
+    switch (openAIRequests.length) {
+    case 1:
+      response.end(
+        JSON.stringify({
+          id: "resp-tool",
+          object: "response",
+          status: "completed",
+          output: [
+            {
+              id: "fc_1",
+              type: "function_call",
+              call_id: "call_lookup",
+              name: "lookup_status",
+              arguments: JSON.stringify({ ticket: "INC-1" }),
+              status: "completed",
+            },
+          ],
+        }),
+      );
+      return;
+    case 2:
+      response.end(
+        JSON.stringify({
+          id: "resp-final",
+          object: "response",
+          status: "completed",
+          output_text: "Deployment is healthy.",
+          output: [
+            {
+              id: "msg_1",
+              type: "message",
+              status: "completed",
+              role: "assistant",
+              content: [
+                {
+                  type: "output_text",
+                  text: "Deployment is healthy.",
+                  annotations: [],
+                },
+              ],
+            },
+          ],
+        }),
+      );
+      return;
+    default:
+      response.end(
+        JSON.stringify({
+          id: "resp-followup",
+          object: "response",
+          status: "completed",
+          output_text: "Still healthy.",
+          output: [
+            {
+              id: "msg_2",
+              type: "message",
+              status: "completed",
+              role: "assistant",
+              content: [
+                {
+                  type: "output_text",
+                  text: "Still healthy.",
+                  annotations: [],
+                },
+              ],
+            },
+          ],
+        }),
+      );
+      return;
+    }
+  });
+
+  const hostHandler = connectNodeAdapter({
+    grpc: true,
+    grpcWeb: false,
+    connect: false,
+    routes(router) {
+      router.service(AgentHostService, {
+        async executeTool(input) {
+          toolCalls.push({
+            runId: input.runId,
+            toolCallId: input.toolCallId,
+            toolId: input.toolId,
+            arguments: input.arguments,
+          });
+          return create(ExecuteAgentToolResponseSchema, {
+            status: 200,
+            body: "",
+          });
+        },
+        async emitEvent(input) {
+          events.push({
+            runId: input.runId,
+            type: input.type,
+            data: input.data,
+          });
+          return {};
+        },
+      } satisfies Partial<ServiceImpl<typeof AgentHostService>>);
+    },
+  });
+  const hostServer = createServer(hostHandler);
+
+  const providerHandler = connectNodeAdapter({
+    grpc: true,
+    grpcWeb: false,
+    connect: false,
+    routes(router) {
+      router.service(AgentProviderService, createAgentProviderService(provider));
+    },
+  });
+  const providerServer = createServer(providerHandler);
+
+  try {
+    await listenHTTP(openAIServer);
+    await listenUnix(hostServer, hostSocketPath);
+    process.env[ENV_AGENT_HOST_SOCKET] = hostSocketPath;
+
+    const address = openAIServer.address();
+    if (!address || typeof address === "string") {
+      throw new Error("OpenAI test server did not bind to TCP");
+    }
+    await provider.configureProvider("openai", {
+      apiKey: "test-api-key",
+      baseURL: `http://127.0.0.1:${address.port}/v1`,
+      model: "gpt-config",
+      timeoutMs: 5_000,
+    });
+    await listenUnix(providerServer, providerSocketPath);
+
+    const client = createUnixGrpcClient(AgentProviderService, providerSocketPath);
+    const started = await client.startRun(
+      create(StartAgentProviderRunRequestSchema, {
+        runId: "run-123",
+        providerName: "openai",
+        model: "gpt-test",
+        messages: [
+          {
+            role: "system",
+            text: "Be concise.",
+          },
+          {
+            role: "user",
+            text: "Check deployment status for INC-1.",
+          },
+        ],
+        tools: [
+          {
+            id: "roadmap/lookup-status",
+            name: "lookup_status",
+            description: "Look up deployment status.",
+            parametersSchema: {
+              type: "object",
+              properties: {
+                ticket: { type: "string" },
+              },
+              required: ["ticket"],
+            },
+          },
+        ],
+        providerOptions: {
+          temperature: 0.2,
+          metadata: {
+            source: "transport-test",
+          },
+        },
+        sessionRef: "session-123",
+        executionRef: "exec-123",
+      }),
+    );
+    expect(started.status).toBe(AgentRunStatus.RUNNING);
+
+    const run = await waitForRunStatus(client, "run-123", AgentRunStatus.SUCCEEDED);
+    expect(run.id).toBe("run-123");
+    expect(run.status).toBe(AgentRunStatus.SUCCEEDED);
+    expect(run.providerName).toBe("openai");
+    expect(run.model).toBe("gpt-test");
+    expect(run.outputText).toBe("Deployment is healthy.");
+
+    expect(toolCalls).toEqual([
+      {
+        runId: "run-123",
+        toolCallId: "call_lookup",
+        toolId: "roadmap/lookup-status",
+        arguments: { ticket: "INC-1" },
+      },
+    ]);
+
+    expect(openAIRequests).toHaveLength(2);
+    expect(openAIRequests[0]?.path).toBe("/v1/responses");
+    expect(openAIRequests[0]?.authorization).toBe("Bearer test-api-key");
+    expect(openAIRequests[0]?.body).toMatchObject({
+      model: "gpt-test",
+      input: [
+        { role: "system", content: "Be concise." },
+        { role: "user", content: "Check deployment status for INC-1." },
+      ],
+      tool_choice: "auto",
+      temperature: 0.2,
+      metadata: {
+        source: "transport-test",
+      },
+    });
+    expect(openAIRequests[0]?.body.tools).toEqual([
+      {
+        type: "function",
+        name: "lookup_status",
+        description: "Look up deployment status.",
+        parameters: {
+          type: "object",
+          properties: {
+            ticket: { type: "string" },
+          },
+          required: ["ticket"],
+        },
+        strict: false,
+      },
+    ]);
+    expect(openAIRequests[1]?.body).toMatchObject({
+      model: "gpt-test",
+      previous_response_id: "resp-tool",
+      input: [
+        {
+          type: "function_call_output",
+          call_id: "call_lookup",
+          output: "",
+        },
+      ],
+    });
+
+    expect(events.map((event) => event.type)).toEqual([
+      "agent.run.started",
+      "agent.model.response",
+      "agent.tool_call.started",
+      "agent.tool_call.completed",
+      "agent.model.response",
+      "agent.run.completed",
+    ]);
+    expect(events.every((event) => event.runId === "run-123")).toBe(true);
+
+    await client.startRun(
+      create(StartAgentProviderRunRequestSchema, {
+        runId: "run-456",
+        providerName: "openai",
+        model: "gpt-test",
+        messages: [
+          {
+            role: "user",
+            text: "Check it again.",
+          },
+        ],
+        sessionRef: "session-123",
+        executionRef: "exec-456",
+      }),
+    );
+    const followup = await waitForRunStatus(client, "run-456", AgentRunStatus.SUCCEEDED);
+    expect(followup.outputText).toBe("Still healthy.");
+    expect(openAIRequests[2]?.body).toMatchObject({
+      model: "gpt-test",
+      previous_response_id: "resp-final",
+      input: [{ role: "user", content: "Check it again." }],
+    });
+  } finally {
+    if (previousHostSocket === undefined) {
+      delete process.env[ENV_AGENT_HOST_SOCKET];
+    } else {
+      process.env[ENV_AGENT_HOST_SOCKET] = previousHostSocket;
+    }
+    await closeServer(providerServer);
+    await closeServer(hostServer);
+    await closeServer(openAIServer);
+    removeTempDir(tempDir);
+  }
+});
+
+test("OpenAI agent provider fails structured runs when output is not a JSON object", async () => {
+  const tempDir = mkdtempSync(join(tmpdir(), "gts-openai-structured-"));
+  const hostSocketPath = join(tempDir, "agent-host.sock");
+  const providerSocketPath = join(tempDir, "agent-provider.sock");
+  const previousHostSocket = process.env[ENV_AGENT_HOST_SOCKET];
+  const events: string[] = [];
+  const provider = await loadProviderFromTarget(
+    resolve(import.meta.dir, "../../../providers/agent/openai"),
+  );
+  if (!isAgentProvider(provider)) {
+    throw new Error("OpenAI package did not load an agent provider");
+  }
+
+  const openAIServer = createHTTPServer(async (_request, response) => {
+    response.writeHead(200, { "Content-Type": "application/json" });
+    response.end(
+      JSON.stringify({
+        id: "resp-invalid-json",
+        object: "response",
+        status: "completed",
+        output_text: "not json",
+      }),
+    );
+  });
+  const hostServer = createServer(
+    connectNodeAdapter({
+      grpc: true,
+      grpcWeb: false,
+      connect: false,
+      routes(router) {
+        router.service(AgentHostService, {
+          async emitEvent(input) {
+            events.push(input.type);
+            return {};
+          },
+        } satisfies Partial<ServiceImpl<typeof AgentHostService>>);
+      },
+    }),
+  );
+  const providerServer = createServer(
+    connectNodeAdapter({
+      grpc: true,
+      grpcWeb: false,
+      connect: false,
+      routes(router) {
+        router.service(AgentProviderService, createAgentProviderService(provider));
+      },
+    }),
+  );
+
+  try {
+    await listenHTTP(openAIServer);
+    await listenUnix(hostServer, hostSocketPath);
+    process.env[ENV_AGENT_HOST_SOCKET] = hostSocketPath;
+
+    const address = openAIServer.address();
+    if (!address || typeof address === "string") {
+      throw new Error("OpenAI test server did not bind to TCP");
+    }
+    await provider.configureProvider("openai", {
+      apiKey: "test-api-key",
+      baseURL: `http://127.0.0.1:${address.port}/v1`,
+      timeoutMs: 5_000,
+    });
+    await listenUnix(providerServer, providerSocketPath);
+
+    const client = createUnixGrpcClient(AgentProviderService, providerSocketPath);
+    const started = await client.startRun(
+      create(StartAgentProviderRunRequestSchema, {
+        runId: "run-structured",
+        providerName: "openai",
+        messages: [{ role: "user", text: "Return a summary." }],
+        responseSchema: {
+          type: "object",
+          properties: { summary: { type: "string" } },
+          required: ["summary"],
+        },
+      }),
+    );
+    expect(started.status).toBe(AgentRunStatus.RUNNING);
+
+    const failed = await waitForRunStatus(
+      client,
+      "run-structured",
+      AgentRunStatus.FAILED,
+    );
+    expect(failed.statusMessage).toContain("parse JSON");
+    expect(events).toContain("agent.run.failed");
+  } finally {
+    if (previousHostSocket === undefined) {
+      delete process.env[ENV_AGENT_HOST_SOCKET];
+    } else {
+      process.env[ENV_AGENT_HOST_SOCKET] = previousHostSocket;
+    }
+    await closeServer(providerServer);
+    await closeServer(hostServer);
+    await closeServer(openAIServer);
+    removeTempDir(tempDir);
+  }
+});
+
+async function readRequestBody(request: IncomingMessage): Promise<string> {
+  const chunks: Buffer[] = [];
+  for await (const chunk of request) {
+    chunks.push(Buffer.from(chunk));
+  }
+  return Buffer.concat(chunks).toString("utf8");
+}
+
+async function listenHTTP(server: ReturnType<typeof createHTTPServer>): Promise<void> {
+  await new Promise<void>((resolve, reject) => {
+    server.once("error", reject);
+    server.listen(0, "127.0.0.1", () => {
+      server.off("error", reject);
+      resolve();
+    });
+  });
+}
+
+async function listenUnix(server: ReturnType<typeof createServer>, socketPath: string): Promise<void> {
+  await new Promise<void>((resolve, reject) => {
+    server.once("error", reject);
+    server.listen(socketPath, () => {
+      server.off("error", reject);
+      resolve();
+    });
+  });
+}
+
+async function closeServer(server: { listening: boolean; close: (cb: () => void) => void }): Promise<void> {
+  if (!server.listening) {
+    return;
+  }
+  await new Promise<void>((resolve) => {
+    server.close(() => resolve());
+  });
+}
+
+async function waitForRunStatus(
+  client: ReturnType<typeof createUnixGrpcClient<typeof AgentProviderService>>,
+  runId: string,
+  status: AgentRunStatus,
+) {
+  const deadline = Date.now() + 2_000;
+  let lastRun;
+  while (Date.now() < deadline) {
+    lastRun = await client.getRun(create(GetAgentProviderRunRequestSchema, { runId }));
+    if (lastRun.status === status) {
+      return lastRun;
+    }
+    await Bun.sleep(10);
+  }
+  throw new Error(`timed out waiting for ${runId} status ${status}; last=${lastRun?.status}`);
+}


### PR DESCRIPTION
## Summary

Adds a first-party `openai` agent source package backed by the OpenAI Responses API. The host remains thin: Gestalt passes neutral messages/tools into the provider, the provider owns the Responses loop and run state, and the provider emits progress events back through `AgentHost.EmitEvent`.

## New Interfaces

Provider source package:

```yaml
kind: agent
source: github.com/valon-technologies/gestalt/providers/agent/openai
version: 0.0.1-alpha.0
spec:
  configSchemaPath: ./config.schema.json
```

Provider config:

```json
{
  "apiKey": "sk-...",
  "baseURL": "https://api.openai.com/v1",
  "model": "gpt-5.4",
  "timeoutMs": 120000,
  "maxTurns": 8,
  "store": false
}
```

Provider-owned event examples:

```json
{ "type": "agent.run.started", "data": { "model": "gpt-5.4", "messageCount": 2, "toolCount": 1 } }
{ "type": "agent.model.response", "data": { "responseId": "resp_...", "status": "completed", "turn": 1 } }
{ "type": "agent.tool_call.completed", "data": { "toolCallId": "call_...", "toolId": "roadmap/sync", "status": 200 } }
{ "type": "agent.run.completed", "data": { "responseId": "resp_...", "status": "succeeded" } }
```

The TypeScript `AgentHost` helper now accepts plain protobuf init objects for `executeTool` and `emitEvent`, matching the documented provider examples.

## Usage Example

```yaml
providers:
  agent:
    openai:
      source: ./providers/agent/openai/manifest.yaml
      default: true
      config:
        model: gpt-5.4
        baseURL: https://api.openai.com/v1
        apiKey:
          secret:
            provider: default
            name: openai-api-key
        timeoutMs: 120000
        maxTurns: 8
```

Run request provider options are passed through to the OpenAI Responses request for supported fields:

```json
{
  "provider": "openai",
  "messages": [{ "role": "user", "text": "Check deployment status for INC-1." }],
  "toolRefs": [{ "pluginName": "roadmap", "operation": "lookupStatus" }],
  "providerOptions": {
    "temperature": 0.2,
    "metadata": { "source": "roadmap-review" }
  }
}
```

## Tests

- `bun test tests/openai-agent-provider.transport.test.ts tests/agent.transport.test.ts`
- `bun run typecheck`
- `bun test`
- `bun src/build.ts ../../providers/agent/openai agent:./agent.ts#provider "$tmp/openai-agent-provider" openai darwin arm64`