### PR TITLE
Require provider attribution for agent event callbacks

### DIFF
--- a/gestaltd/internal/bootstrap/agent_runtime.go
+++ b/gestaltd/internal/bootstrap/agent_runtime.go
@@ -328,7 +328,10 @@ func (r *agentRuntime) EmitEvent(ctx context.Context, req coreagent.EmitEventReq
 		return nil, fmt.Errorf("%w: agent run %q is revoked", invocation.ErrAuthorizationDenied, runID)
 	}
 	providerName := strings.TrimSpace(req.ProviderName)
-	if providerName != "" && strings.TrimSpace(ref.ProviderName) != providerName {
+	if providerName == "" {
+		return nil, fmt.Errorf("%w: provider name is required", invocation.ErrAuthorizationDenied)
+	}
+	if strings.TrimSpace(ref.ProviderName) != providerName {
 		return nil, fmt.Errorf("%w: agent run %q is not valid for provider %q", invocation.ErrAuthorizationDenied, runID, providerName)
 	}
 	event, err := runEvents.Append(ctx, coreagent.RunEvent{


### PR DESCRIPTION
## Summary

Fixes the remaining Bugbot finding from #1301 by requiring provider attribution on agent event callbacks before appending a run event. This prevents a direct runtime caller with an empty provider name from skipping the owner check and writing an event with an empty `source`.

## Interfaces

No proto or REST shape changes.

`AgentHost.EmitEvent` still accepts:

```proto
rpc EmitEvent(EmitAgentEventRequest) returns (google.protobuf.Empty);

message EmitAgentEventRequest {
  string run_id = 1;
  string type = 2;
  string visibility = 3;
  google.protobuf.Struct data = 4;
}
```

The bound host service supplies provider identity out-of-band:

```go
proto.RegisterAgentHostServer(
  srv,
  providerhost.NewAgentHostServer("reviewer", executeTool, runtime.EmitEvent),
)
```

## Examples

Valid host callback path:

```go
providerhost.NewAgentHostServer("reviewer", nil, runtime.EmitEvent)
// Runtime receives ProviderName: "reviewer" and stores RunEvent.Source: "reviewer".
```

Invalid direct runtime call:

```go
runtime.EmitEvent(ctx, coreagent.EmitEventRequest{
  RunID: runID,
  Type:  "agent.message.delta",
})
// authorization denied: provider name is required
```

## Validation

- `go test ./internal/bootstrap -run TestBootstrapStartsAgentProvidersAfterInvokerIsReady -count=1`
- `golangci-lint run ./internal/bootstrap`
- `go test -coverprofile=/tmp/server-cover.out ./internal/server -run TestEgressProxySupportsHTTPSConnect -count=50`
- `go test -coverprofile=/tmp/server-cover-full.out ./internal/server -count=5`

## CI Note

The linked #1301 `Go Coverage` failure was a transient `TestEgressProxySupportsHTTPSConnect` EOF. The merged #1301 head commit has a green `Go Coverage` run, and the CONNECT test passed locally under repeated package coverage runs.