### PR TITLE
[codex] Add agent run events CLI

### DIFF
--- a/docs/content/client/cli/index.mdx
+++ b/docs/content/client/cli/index.mdx
@@ -31,7 +31,7 @@ asIndexPage: true
 | `gestalt workflow triggers ...` | Create, list, inspect, update, pause, resume, or delete workflow triggers. |
 | `gestalt workflow events publish ...` | Publish an event into the workflow system. |
 | `gestalt workflow runs ...` | List, inspect, and cancel workflow runs. |
-| `gestalt agent runs ...` | Create, list, inspect, and cancel global agent runs. |
+| `gestalt agent runs ...` | Create, list, inspect, cancel, and stream global agent runs. |
 | `gestalt tokens create\|list\|revoke` | Manage Gestalt API tokens. |
 
 ## URL resolution
@@ -214,6 +214,8 @@ gestalt agent runs create \
 gestalt agent runs list --provider managed --status running
 gestalt agent runs get <run-id>
 gestalt agent runs cancel <run-id> --reason "operator requested"
+gestalt agent runs events list <run-id> --after 0 --limit 100
+gestalt agent runs events stream <run-id> --after 100
 
 # advanced fields such as responseSchema, metadata, or providerOptions
 # go through --request-file, which also accepts "-" for stdin:
@@ -243,3 +245,9 @@ JSON
 repeated `--tool plugin:operation`, `--session-ref`, `--idempotency-key`, and
 `--request-file`. Use `--format json` when you want the raw HTTP response shape
 instead of the default table view.
+
+`gestalt agent runs events list` reads stored events from
+`GET /api/v1/agent/runs/{runID}/events`. `--after` is an event sequence cursor
+and `--limit` controls the page size. `gestalt agent runs events stream` reads
+`GET /api/v1/agent/runs/{runID}/events/stream` and writes the raw server-sent
+event stream to stdout.

--- a/docs/content/reference/http-api.mdx
+++ b/docs/content/reference/http-api.mdx
@@ -71,6 +71,8 @@ Authenticated routes accept a `session_token` cookie or an `Authorization: Beare
 | `GET` | `/api/v1/agent/runs` | List agent runs. Supports optional `provider` and `status` query filters. |
 | `GET` | `/api/v1/agent/runs/{runID}` | Inspect one agent run. |
 | `POST` | `/api/v1/agent/runs/{runID}/cancel` | Cancel one agent run. The request body may include an optional `reason`. |
+| `GET` | `/api/v1/agent/runs/{runID}/events` | List stored events for one agent run. Supports optional `after` sequence cursor and `limit`. |
+| `GET` | `/api/v1/agent/runs/{runID}/events/stream` | Stream agent run events as server-sent events. Supports optional `after` sequence cursor and `limit`. |
 
 Agent run creation accepts `provider`, `model`, `messages`, `toolRefs`,
 optional `toolSource`, optional `responseSchema`, optional `sessionRef`,
@@ -241,6 +243,14 @@ curl -X POST http://localhost:8080/api/v1/agent/runs \
 # Inspect a run
 curl -H 'Authorization: Bearer gst_api_...' \
   http://localhost:8080/api/v1/agent/runs/run-123
+
+# List run events after sequence 0
+curl -H 'Authorization: Bearer gst_api_...' \
+  'http://localhost:8080/api/v1/agent/runs/run-123/events?after=0&limit=100'
+
+# Stream run events
+curl -N -H 'Authorization: Bearer gst_api_...' \
+  'http://localhost:8080/api/v1/agent/runs/run-123/events/stream?after=0'
 
 # List filtered runs
 curl -H 'Authorization: Bearer gst_api_...' \

--- a/docs/dockerhub/gestalt.md
+++ b/docs/dockerhub/gestalt.md
@@ -77,7 +77,7 @@ jobs:
 | `plugin disconnect NAME` | Disconnect a plugin |
 | `plugin invoke NAME OP` | Execute a plugin operation |
 | `workflow ...` | Manage workflow schedules, triggers, events, and runs |
-| `agent runs ...` | Create, list, inspect, and cancel agent runs |
+| `agent runs ...` | Create, list, inspect, cancel, and stream agent runs |
 | `tokens create/list/revoke` | Manage API tokens |
 
 Use `--format json` or `--format table` to control output format. See the

--- a/gestalt/cli/src/api.rs
+++ b/gestalt/cli/src/api.rs
@@ -201,6 +201,7 @@ pub fn env_api_key_is_set() -> bool {
 
 pub struct ApiClient {
     client: Client,
+    stream_client: Client,
     base_url: String,
     token: String,
     token_source: TokenSource,
@@ -287,14 +288,22 @@ impl ApiClient {
             HeaderValue::from_static(http::APPLICATION_JSON),
         );
 
+        let request_timeout = std::time::Duration::from_secs(30);
         let client = Client::builder()
-            .timeout(std::time::Duration::from_secs(30))
-            .default_headers(default_headers)
+            .timeout(request_timeout)
+            .default_headers(default_headers.clone())
             .build()
             .context("failed to build HTTP client")?;
+        let stream_client = Client::builder()
+            .timeout(None::<std::time::Duration>)
+            .connect_timeout(request_timeout)
+            .default_headers(default_headers)
+            .build()
+            .context("failed to build streaming HTTP client")?;
 
         Ok(Self {
             client,
+            stream_client,
             base_url: base_url.trim_end_matches('/').to_string(),
             token: token.to_string(),
             token_source: TokenSource::Direct,
@@ -303,6 +312,27 @@ impl ApiClient {
 
     pub fn get(&self, path: &str) -> Result<serde_json::Value> {
         self.send(Method::GET, path)
+    }
+
+    pub fn get_stream(&self, path: &str) -> Result<reqwest::blocking::Response> {
+        let url = format!("{}{}", self.base_url, path);
+        let resp = self
+            .stream_client
+            .request(Method::GET, &url)
+            .bearer_auth(&self.token)
+            .header(
+                header::ACCEPT,
+                HeaderValue::from_static("text/event-stream"),
+            )
+            .send()
+            .map_err(|e| self.wrap_send_error(e, &url))?;
+        let status = resp.status();
+        if !(status.is_client_error() || status.is_server_error()) {
+            return Ok(resp);
+        }
+        let body = resp.text().context("failed to read response body")?;
+        self.bail_on_error_response(status, &body)?;
+        bail!("HTTP {}: {}", status.as_u16(), body)
     }
 
     pub fn post<T>(&self, path: &str, body: &T) -> Result<serde_json::Value>

--- a/gestalt/cli/src/cli.rs
+++ b/gestalt/cli/src/cli.rs
@@ -351,6 +351,19 @@ pub enum AgentRunCommands {
         #[arg(long)]
         reason: Option<String>,
     },
+    /// Inspect or stream agent run events
+    Events {
+        #[command(subcommand)]
+        command: AgentRunEventCommands,
+    },
+}
+
+#[derive(Subcommand)]
+pub enum AgentRunEventCommands {
+    /// List stored events for an agent run
+    List(AgentRunEventListArgs),
+    /// Stream events for an agent run as server-sent events
+    Stream(AgentRunEventStreamArgs),
 }
 
 #[derive(Subcommand)]
@@ -460,6 +473,34 @@ pub struct AgentRunCreateArgs {
     /// Load the JSON request body from a file (use "-" for stdin)
     #[arg(long = "request-file")]
     pub request_file: Option<String>,
+}
+
+#[derive(Args)]
+pub struct AgentRunEventListArgs {
+    /// Run ID
+    pub id: String,
+
+    /// Return events after this event sequence number
+    #[arg(long)]
+    pub after: Option<u64>,
+
+    /// Maximum number of events to return
+    #[arg(long)]
+    pub limit: Option<u32>,
+}
+
+#[derive(Args)]
+pub struct AgentRunEventStreamArgs {
+    /// Run ID
+    pub id: String,
+
+    /// Stream events after this event sequence number
+    #[arg(long)]
+    pub after: Option<u64>,
+
+    /// Maximum number of events to fetch per server poll
+    #[arg(long)]
+    pub limit: Option<u32>,
 }
 
 #[derive(Args)]

--- a/gestalt/cli/src/commands/agents.rs
+++ b/gestalt/cli/src/commands/agents.rs
@@ -1,8 +1,11 @@
 use anyhow::{Context, Result};
 use serde_json::{Map, Value, json};
+use std::io;
 
 use crate::api::ApiClient;
-use crate::cli::{AgentRunCreateArgs, AgentToolArg};
+use crate::cli::{
+    AgentRunCreateArgs, AgentRunEventListArgs, AgentRunEventStreamArgs, AgentToolArg,
+};
 use crate::output::{self, Format};
 use crate::params;
 
@@ -52,6 +55,27 @@ pub fn cancel_run(
         .post(&format!("{RUNS_PATH}/{id}/cancel"), &body)
         .with_context(|| format!("failed to cancel agent run {id}"))?;
     print_run(&resp, format);
+    Ok(())
+}
+
+pub fn list_run_events(
+    client: &ApiClient,
+    args: &AgentRunEventListArgs,
+    format: Format,
+) -> Result<()> {
+    let resp = client
+        .get(&run_events_path(&args.id, false, args.after, args.limit))
+        .with_context(|| format!("failed to list events for agent run {}", args.id))?;
+    print_run_events(&resp, format);
+    Ok(())
+}
+
+pub fn stream_run_events(client: &ApiClient, args: &AgentRunEventStreamArgs) -> Result<()> {
+    let mut resp = client
+        .get_stream(&run_events_path(&args.id, true, args.after, args.limit))
+        .with_context(|| format!("failed to stream events for agent run {}", args.id))?;
+    let mut stdout = io::stdout().lock();
+    io::copy(&mut resp, &mut stdout).context("failed to read agent run event stream")?;
     Ok(())
 }
 
@@ -128,6 +152,24 @@ fn runs_path(provider: Option<&str>, status: Option<&str>) -> String {
     }
 }
 
+fn run_events_path(id: &str, stream: bool, after: Option<u64>, limit: Option<u32>) -> String {
+    let mut serializer = url::form_urlencoded::Serializer::new(String::new());
+    if let Some(after) = after {
+        serializer.append_pair("after", &after.to_string());
+    }
+    if let Some(limit) = limit {
+        serializer.append_pair("limit", &limit.to_string());
+    }
+    let suffix = if stream { "/events/stream" } else { "/events" };
+    let query = serializer.finish();
+    let path = format!("{RUNS_PATH}/{id}{suffix}");
+    if query.is_empty() {
+        path
+    } else {
+        format!("{path}?{query}")
+    }
+}
+
 fn print_run(value: &Value, format: Format) {
     match format {
         Format::Json => output::print_json(value),
@@ -149,8 +191,31 @@ fn print_runs(value: &Value, format: Format) {
     }
 }
 
+fn print_run_events(value: &Value, format: Format) {
+    match format {
+        Format::Json => output::print_json(value),
+        Format::Table => {
+            let items = value.as_array().cloned().unwrap_or_default();
+            let rows: Vec<Vec<String>> = items.iter().map(run_event_row).collect();
+            output::print_table(&event_headers(), &rows);
+        }
+    }
+}
+
 fn run_headers() -> [&'static str; 6] {
     ["ID", "Provider", "Model", "Status", "Session", "Created"]
+}
+
+fn event_headers() -> [&'static str; 7] {
+    [
+        "Seq",
+        "Type",
+        "Source",
+        "Visibility",
+        "Run",
+        "Created",
+        "Data",
+    ]
 }
 
 fn run_row(value: &Value) -> Vec<String> {
@@ -161,5 +226,20 @@ fn run_row(value: &Value) -> Vec<String> {
         value["status"].as_str().unwrap_or("-").to_string(),
         value["sessionRef"].as_str().unwrap_or("-").to_string(),
         value["createdAt"].as_str().unwrap_or("-").to_string(),
+    ]
+}
+
+fn run_event_row(value: &Value) -> Vec<String> {
+    vec![
+        value["seq"]
+            .as_i64()
+            .map(|seq| seq.to_string())
+            .unwrap_or_else(|| "-".to_string()),
+        value["type"].as_str().unwrap_or("-").to_string(),
+        value["source"].as_str().unwrap_or("-").to_string(),
+        value["visibility"].as_str().unwrap_or("-").to_string(),
+        value["runId"].as_str().unwrap_or("-").to_string(),
+        value["createdAt"].as_str().unwrap_or("-").to_string(),
+        serde_json::to_string(&value["data"]).unwrap_or_else(|_| "-".to_string()),
     ]
 }

--- a/gestalt/cli/src/main.rs
+++ b/gestalt/cli/src/main.rs
@@ -1,9 +1,9 @@
 use clap::{CommandFactory, Parser};
 use gestalt::api::{self, ApiClient};
 use gestalt::cli::{
-    AgentCommands, AgentRunCommands, AuthCommands, Cli, Commands, ConfigCommands, DescribeArgs,
-    InvokeArgs, PluginCommands, TokenCommands, WorkflowCommands, WorkflowEventCommands,
-    WorkflowRunCommands, WorkflowScheduleCommands, WorkflowTriggerCommands,
+    AgentCommands, AgentRunCommands, AgentRunEventCommands, AuthCommands, Cli, Commands,
+    ConfigCommands, DescribeArgs, InvokeArgs, PluginCommands, TokenCommands, WorkflowCommands,
+    WorkflowEventCommands, WorkflowRunCommands, WorkflowScheduleCommands, WorkflowTriggerCommands,
 };
 use gestalt::commands;
 use gestalt::output;
@@ -140,6 +140,14 @@ fn run() -> anyhow::Result<()> {
                     AgentRunCommands::Cancel { id, reason } => {
                         commands::agents::cancel_run(&client, &id, reason.as_deref(), format)
                     }
+                    AgentRunCommands::Events { command } => match command {
+                        AgentRunEventCommands::List(args) => {
+                            commands::agents::list_run_events(&client, &args, format)
+                        }
+                        AgentRunEventCommands::Stream(args) => {
+                            commands::agents::stream_run_events(&client, &args)
+                        }
+                    },
                 },
             }
         }

--- a/gestalt/cli/tests/agents_cli.rs
+++ b/gestalt/cli/tests/agents_cli.rs
@@ -16,6 +16,29 @@ const RUN_JSON: &str = r#"{
     "executionRef":"run-1"
 }"#;
 
+const RUN_EVENTS_JSON: &str = r#"[
+    {
+        "id":"evt-1",
+        "runId":"run-1",
+        "seq":1,
+        "type":"agent.run.started",
+        "source":"managed",
+        "visibility":"public",
+        "data":{"status":"running"},
+        "createdAt":"2026-04-22T00:00:01Z"
+    },
+    {
+        "id":"evt-2",
+        "runId":"run-1",
+        "seq":2,
+        "type":"agent.message.delta",
+        "source":"managed",
+        "visibility":"public",
+        "data":{"text":"risk is dependency churn"},
+        "createdAt":"2026-04-22T00:00:02Z"
+    }
+]"#;
+
 #[test]
 fn test_cli_creates_agent_run() {
     let mut server = Server::new();
@@ -207,4 +230,55 @@ fn test_cli_cancels_agent_run() {
         .assert()
         .success()
         .stdout(predicate::str::contains("canceled"));
+}
+
+#[test]
+fn test_cli_lists_agent_run_events() {
+    let mut server = Server::new();
+    let _mock = authed_json_mock!(
+        server,
+        Method::GET,
+        "/api/v1/agent/runs/run-1/events?after=0&limit=10",
+        StatusCode::OK
+    )
+    .with_body(RUN_EVENTS_JSON)
+    .create();
+
+    let home = tempfile::tempdir().unwrap();
+    cli_command_for_server(home.path(), &server)
+        .args([
+            "--format", "json", "agent", "runs", "events", "list", "run-1", "--after", "0",
+            "--limit", "10",
+        ])
+        .assert()
+        .success()
+        .stdout(predicate::str::contains("agent.message.delta"))
+        .stdout(predicate::str::contains("risk is dependency churn"));
+}
+
+#[test]
+fn test_cli_streams_agent_run_events() {
+    let mut server = Server::new();
+    let _mock = server
+        .mock(
+            Method::GET.as_str(),
+            "/api/v1/agent/runs/run-1/events/stream?after=2&limit=1",
+        )
+        .match_header(header::AUTHORIZATION.as_str(), Matcher::Exact(test_bearer()))
+        .with_status(usize::from(StatusCode::OK.as_u16()))
+        .with_header(header::CONTENT_TYPE.as_str(), "text/event-stream")
+        .with_body(
+            "id: 3\nevent: agent.run.completed\ndata: {\"seq\":3,\"type\":\"agent.run.completed\",\"data\":{\"status\":\"succeeded\"}}\n\n",
+        )
+        .create();
+
+    let home = tempfile::tempdir().unwrap();
+    cli_command_for_server(home.path(), &server)
+        .args([
+            "agent", "runs", "events", "stream", "run-1", "--after", "2", "--limit", "1",
+        ])
+        .assert()
+        .success()
+        .stdout(predicate::str::contains("event: agent.run.completed"))
+        .stdout(predicate::str::contains(r#""status":"succeeded""#));
 }


### PR DESCRIPTION
## What changed

- Adds `gestalt agent runs events list` for stored agent run events from `GET /api/v1/agent/runs/{runID}/events`.
- Adds `gestalt agent runs events stream` for raw server-sent events from `GET /api/v1/agent/runs/{runID}/events/stream`.
- Uses a dedicated streaming HTTP client without a total response timeout, while keeping the normal 30 second timeout for non-streaming JSON requests.
- Documents the event commands in the CLI guide, DockerHub CLI summary, and HTTP API reference.

## New CLI interfaces

```sh
# List stored events after an event sequence cursor.
gestalt agent runs events list RUN_ID --after 0 --limit 100

# Stream new events as server-sent events.
gestalt agent runs events stream RUN_ID --after 100
```

The list command supports the normal CLI output modes:

```sh
gestalt --format table agent runs events list RUN_ID
gestalt --format json agent runs events list RUN_ID --after 0 --limit 100
```

The stream command writes raw SSE frames to stdout, for example:

```text
id: 101
event: agent.message.delta
data: {"seq":101,"type":"agent.message.delta","data":{"text":"..."}}
```

## Tests

- `cargo test -p gestalt --test agents_cli`
- `cargo test -p gestalt`
- `git diff --check`

No unit tests were added. The new coverage is functional CLI-to-mock-server HTTP transport coverage for the event list and SSE stream contracts.