### PR TITLE
[codex] Add operation result status metrics

### DIFF
--- a/docs/content/observability.mdx
+++ b/docs/content/observability.mdx
@@ -148,10 +148,16 @@ plugin key), `gestalt.operation` (the catalog operation id),
 `none` or `user`). When the invocation came from a known surface, they also
 carry `gestalt.invocation_surface`.
 
-`gestaltd.operation.error_count` records failed operation invocations across
-surfaces, but it does not classify failures by HTTP status. For 4xx versus 5xx
-breakdowns on HTTP-invoked provider operations, use the HTTP server metrics with
-the resolved `gestalt.provider` and `gestalt.operation` labels described below.
+Operation metrics also carry `gestalt.result_status` and
+`gestalt.result_status_class`. `gestalt.result_status` is the normalized
+HTTP-like operation result status (`200`, `400`, `502`, and so on), and
+`gestalt.result_status_class` is the matching class (`1xx`, `2xx`, `3xx`,
+`4xx`, `5xx`, or `unknown`). Provider-returned statuses use the provider
+`OperationResult` status. Platform failures before provider execution use the
+same status mapping as the HTTP invocation handlers. `gestaltd.operation.error_count` records
+invocations with an invocation error or an operation result status of `400` or
+higher, so provider-returned 4xx and 5xx results are counted as operation
+failures.
 
 When a request references an unknown provider or operation, `gestaltd` records
 `unknown` for the missing metric attributes instead of using raw user input.
@@ -310,10 +316,12 @@ need actor, target, and outcome details.
 
 ### Current Non-Goals
 
-The built-in `gestaltd` metric surface does not yet emit per-operation upstream
-HTTP `status_code` or `status_class` metrics, nor deduplicated DAU, WAU, or MAU
-analytics for users or plugins. Those need separate semantic decisions or
-an analytics pipeline instead of more process-local counters.
+The built-in `gestaltd` metric surface emits broker operation result status via
+`gestalt.result_status` and `gestalt.result_status_class`, but it does not emit
+separate per-upstream-request HTTP `status_code` or `status_class` metrics for
+HTTP catalog transports. It also does not emit deduplicated DAU, WAU, or MAU
+analytics for users or plugins. Those need separate semantic decisions or an
+analytics pipeline instead of more process-local counters.
 
 ### HTTP Server Metrics
 
@@ -355,20 +363,22 @@ Unknown provider or operation paths keep the templated route label but do not ge
 resolved provider or operation labels.
 
 For Datadog dashboards, provider-operation status splits can be built from the
-HTTP server duration metric:
+broker operation metrics:
 
 ```text
-count:http.server.request.duration{service:<service>,gestalt.provider:*,http.response.status_code:4*}
-  by {gestalt.provider,gestalt.operation}.as_rate()
+sum:gestaltd.operation.error_count{service:<service>,gestalt.result_status_class:4xx}
+  by {gestalt.provider,gestalt.operation,gestalt.result_status}.as_count()
 ```
 
 ```text
-count:http.server.request.duration{service:<service>,gestalt.provider:*,http.response.status_code:5*}
-  by {gestalt.provider,gestalt.operation}.as_rate()
+sum:gestaltd.operation.error_count{service:<service>,gestalt.result_status_class:5xx}
+  by {gestalt.provider,gestalt.operation,gestalt.result_status}.as_count()
 ```
 
-Use the same metric with `http.response.status_code` in the grouping when a
-single graph should show both status class and provider-operation identity.
+For HTTP-only views, use `http.server.request.duration` with
+`http.response.status_code`. For cross-surface provider-operation views, prefer
+`gestaltd.operation.*` with `gestalt.result_status` and
+`gestalt.result_status_class`.
 
 If the process is started with
 `OTEL_SEMCONV_STABILITY_OPT_IN=http/dup`, the underlying HTTP instrumentation

--- a/gestaltd/internal/invocation/broker.go
+++ b/gestaltd/internal/invocation/broker.go
@@ -156,7 +156,7 @@ func (b *Broker) ListCapabilities() []core.Capability {
 	return caps
 }
 
-func (b *Broker) Invoke(ctx context.Context, p *principal.Principal, providerName, instance, operation string, params map[string]any) (_ *core.OperationResult, err error) {
+func (b *Broker) Invoke(ctx context.Context, p *principal.Principal, providerName, instance, operation string, params map[string]any) (result *core.OperationResult, err error) {
 	startedAt := time.Now()
 	metricProvider := metricutil.UnknownAttrValue
 	metricOperation := metricutil.UnknownAttrValue
@@ -168,6 +168,7 @@ func (b *Broker) Invoke(ctx context.Context, p *principal.Principal, providerNam
 	)
 	defer span.End()
 	defer func() {
+		resultStatus := operationResultStatus(result, err)
 		recordOperationMetrics(
 			ctx,
 			startedAt,
@@ -175,7 +176,8 @@ func (b *Broker) Invoke(ctx context.Context, p *principal.Principal, providerNam
 			metricOperation,
 			metricTransport,
 			metricConnectionMode,
-			err != nil,
+			resultStatus,
+			operationResultFailed(resultStatus, err),
 		)
 	}()
 
@@ -293,16 +295,16 @@ func (b *Broker) Invoke(ctx context.Context, p *principal.Principal, providerNam
 	}
 
 	if transport == catalog.TransportMCPPassthrough {
-		result, err := CallDirectTool(ctx, b, p, prov, providerName, operation, conn, instance, boundCredential, params, mcpupstream.CallToolMetaFromContext(ctx))
+		toolResult, err := CallDirectTool(ctx, b, p, prov, providerName, operation, conn, instance, boundCredential, params, mcpupstream.CallToolMetaFromContext(ctx))
 		if err != nil {
 			return fail(err)
 		}
-		opResult, err := toolResultToOperationResult(result)
+		opResult, err := toolResultToOperationResult(toolResult)
 		if err != nil {
 			return fail(fmt.Errorf("%w: converting tool result: %v", ErrInternal, err))
 		}
-		if result != nil {
-			opResult.MCPResult = result
+		if toolResult != nil {
+			opResult.MCPResult = toolResult
 		}
 		return opResult, nil
 	}
@@ -312,7 +314,7 @@ func (b *Broker) Invoke(ctx context.Context, p *principal.Principal, providerNam
 		return fail(err)
 	}
 
-	result, err := prov.Execute(ctx, operation, params, accessToken)
+	result, err = prov.Execute(ctx, operation, params, accessToken)
 	if err != nil {
 		return fail(err)
 	}
@@ -320,7 +322,7 @@ func (b *Broker) Invoke(ctx context.Context, p *principal.Principal, providerNam
 	return result, nil
 }
 
-func (b *Broker) InvokeGraphQL(ctx context.Context, p *principal.Principal, providerName, instance string, request GraphQLRequest) (_ *core.OperationResult, err error) {
+func (b *Broker) InvokeGraphQL(ctx context.Context, p *principal.Principal, providerName, instance string, request GraphQLRequest) (result *core.OperationResult, err error) {
 	startedAt := time.Now()
 	metricProvider := metricutil.UnknownAttrValue
 	metricOperation := metricutil.AttrValue("graphql")
@@ -332,6 +334,7 @@ func (b *Broker) InvokeGraphQL(ctx context.Context, p *principal.Principal, prov
 	)
 	defer span.End()
 	defer func() {
+		resultStatus := operationResultStatus(result, err)
 		recordOperationMetrics(
 			ctx,
 			startedAt,
@@ -339,7 +342,8 @@ func (b *Broker) InvokeGraphQL(ctx context.Context, p *principal.Principal, prov
 			metricOperation,
 			metricTransport,
 			metricConnectionMode,
-			err != nil,
+			resultStatus,
+			operationResultFailed(resultStatus, err),
 		)
 	}()
 
@@ -441,7 +445,7 @@ func (b *Broker) InvokeGraphQL(ctx context.Context, p *principal.Principal, prov
 		return fail(err)
 	}
 
-	result, err := graphQLProv.InvokeGraphQL(ctx, request, accessToken)
+	result, err = graphQLProv.InvokeGraphQL(ctx, request, accessToken)
 	if err != nil {
 		return fail(err)
 	}

--- a/gestaltd/internal/invocation/metrics.go
+++ b/gestaltd/internal/invocation/metrics.go
@@ -2,8 +2,13 @@ package invocation
 
 import (
 	"context"
+	"errors"
+	"net/http"
+	"strconv"
 	"time"
 
+	"github.com/valon-technologies/gestalt/server/core"
+	"github.com/valon-technologies/gestalt/server/internal/apiexec"
 	"github.com/valon-technologies/gestalt/server/internal/metricutil"
 	"go.opentelemetry.io/otel/attribute"
 	"go.opentelemetry.io/otel/metric"
@@ -45,14 +50,18 @@ func recordOperationMetrics(
 	operation string,
 	transport string,
 	connectionMode string,
+	resultStatus int,
 	failed bool,
 ) {
 	metrics := operationMetricsCache.Load(ctx, tracerName, newOperationMetrics)
+	resultStatusValue, resultStatusClass := resultStatusAttributes(resultStatus)
 	attrs := []attribute.KeyValue{
 		attrProvider.String(metricutil.AttrValue(provider)),
 		attrOperation.String(metricutil.AttrValue(operation)),
 		attrTransport.String(metricutil.AttrValue(transport)),
 		attrConnectionMode.String(metricutil.AttrValue(connectionMode)),
+		metricutil.AttrResultStatus.String(resultStatusValue),
+		metricutil.AttrResultStatusClass.String(resultStatusClass),
 	}
 	if surface := InvocationSurfaceFromContext(ctx); surface != "" {
 		attrs = append(attrs, metricutil.AttrInvocationSurface.String(metricutil.AttrValue(string(surface))))
@@ -65,4 +74,50 @@ func recordOperationMetrics(
 	if failed {
 		metrics.errorCount.Add(ctx, 1, metric.WithAttributes(attrs...))
 	}
+}
+
+func operationResultStatus(result *core.OperationResult, err error) int {
+	if result != nil && validHTTPStatus(result.Status) {
+		return result.Status
+	}
+	if err == nil {
+		return 0
+	}
+
+	var upstreamErr *apiexec.UpstreamHTTPError
+	switch {
+	case errors.Is(err, ErrProviderNotFound), errors.Is(err, ErrOperationNotFound):
+		return http.StatusNotFound
+	case errors.Is(err, ErrNotAuthenticated):
+		return http.StatusUnauthorized
+	case errors.Is(err, ErrAuthorizationDenied), errors.Is(err, ErrScopeDenied):
+		return http.StatusForbidden
+	case errors.Is(err, ErrNoToken), errors.Is(err, ErrReconnectRequired):
+		return http.StatusPreconditionFailed
+	case errors.Is(err, ErrAmbiguousInstance):
+		return http.StatusConflict
+	case errors.Is(err, ErrUserResolution), errors.Is(err, ErrInternal):
+		return http.StatusInternalServerError
+	case errors.Is(err, core.ErrMCPOnly), errors.Is(err, apiexec.ErrMissingPathParam):
+		return http.StatusBadRequest
+	case errors.As(err, &upstreamErr) && validHTTPStatus(upstreamErr.Status):
+		return upstreamErr.Status
+	default:
+		return http.StatusBadGateway
+	}
+}
+
+func operationResultFailed(status int, err error) bool {
+	return err != nil || status >= http.StatusBadRequest && status <= 599
+}
+
+func resultStatusAttributes(status int) (string, string) {
+	if !validHTTPStatus(status) {
+		return metricutil.UnknownAttrValue, metricutil.UnknownAttrValue
+	}
+	return strconv.Itoa(status), strconv.Itoa(status/100) + "xx"
+}
+
+func validHTTPStatus(status int) bool {
+	return status >= 100 && status <= 599
 }

--- a/gestaltd/internal/metricutil/attrs.go
+++ b/gestaltd/internal/metricutil/attrs.go
@@ -20,6 +20,8 @@ const (
 	AttrUI                = attribute.Key("gestalt.ui")
 	AttrRPCRole           = attribute.Key("gestalt.rpc.role")
 	AttrHostService       = attribute.Key("gestalt.host_service")
+	AttrResultStatus      = attribute.Key("gestalt.result_status")
+	AttrResultStatusClass = attribute.Key("gestalt.result_status_class")
 	AttrHTTPRoute         = attribute.Key("http.route")
 )
 

--- a/gestaltd/internal/server/metrics_test.go
+++ b/gestaltd/internal/server/metrics_test.go
@@ -290,17 +290,29 @@ func TestRefreshAndOperationResultMetrics(t *testing.T) {
 		"gestalt.type":     "oauth",
 		"gestalt.action":   "refresh",
 	})
-	metrictest.RequireInt64Sum(t, rm, "gestaltd.operation.count", 2, map[string]string{
-		"gestalt.provider":        providerName,
-		"gestalt.operation":       "list",
-		"gestalt.transport":       "rest",
-		"gestalt.connection_mode": "user",
+	metrictest.RequireInt64Sum(t, rm, "gestaltd.operation.count", 1, map[string]string{
+		"gestalt.provider":            providerName,
+		"gestalt.operation":           "list",
+		"gestalt.transport":           "rest",
+		"gestalt.connection_mode":     "user",
+		"gestalt.result_status":       "200",
+		"gestalt.result_status_class": "2xx",
+	})
+	metrictest.RequireInt64Sum(t, rm, "gestaltd.operation.count", 1, map[string]string{
+		"gestalt.provider":            providerName,
+		"gestalt.operation":           "list",
+		"gestalt.transport":           "rest",
+		"gestalt.connection_mode":     "user",
+		"gestalt.result_status":       "412",
+		"gestalt.result_status_class": "4xx",
 	})
 	metrictest.RequireInt64Sum(t, rm, "gestaltd.operation.error_count", 1, map[string]string{
-		"gestalt.provider":        providerName,
-		"gestalt.operation":       "list",
-		"gestalt.transport":       "rest",
-		"gestalt.connection_mode": "user",
+		"gestalt.provider":            providerName,
+		"gestalt.operation":           "list",
+		"gestalt.transport":           "rest",
+		"gestalt.connection_mode":     "user",
+		"gestalt.result_status":       "412",
+		"gestalt.result_status_class": "4xx",
 	})
 }
 
@@ -318,6 +330,9 @@ func TestOperationMetricsDefaultRESTTransportFromCatalogContext(t *testing.T) {
 				N:        providerName,
 				ConnMode: core.ConnectionModeNone,
 				ExecuteFn: func(_ context.Context, operation string, _ map[string]any, _ string) (*core.OperationResult, error) {
+					if operation == "lookup" {
+						return &core.OperationResult{Status: http.StatusNotFound, Body: `{"error":"missing"}`}, nil
+					}
 					return &core.OperationResult{Status: http.StatusOK, Body: `{"operation":"` + operation + `"}`}, nil
 				},
 			},
@@ -325,6 +340,7 @@ func TestOperationMetricsDefaultRESTTransportFromCatalogContext(t *testing.T) {
 				Name: providerName,
 				Operations: []catalog.CatalogOperation{
 					{ID: "list", Method: http.MethodGet, Path: "/list"},
+					{ID: "lookup", Method: http.MethodGet, Path: "/lookup"},
 				},
 			},
 		})
@@ -341,21 +357,71 @@ func TestOperationMetricsDefaultRESTTransportFromCatalogContext(t *testing.T) {
 		t.Fatalf("operation status = %d, want %d", resp.StatusCode, http.StatusOK)
 	}
 
+	errorReq, _ := http.NewRequest(http.MethodGet, srv.URL+"/api/v1/"+providerName+"/lookup", nil)
+	errorResp, err := http.DefaultClient.Do(errorReq)
+	if err != nil {
+		t.Fatalf("operation error request: %v", err)
+	}
+	defer func() { _ = errorResp.Body.Close() }()
+	if errorResp.StatusCode != http.StatusNotFound {
+		t.Fatalf("operation error status = %d, want %d", errorResp.StatusCode, http.StatusNotFound)
+	}
+
 	rm := metrictest.CollectMetrics(t, metrics.Reader)
 	metrictest.RequireInt64Sum(t, rm, "gestaltd.operation.count", 1, map[string]string{
-		"gestalt.provider":           providerName,
-		"gestalt.operation":          "list",
-		"gestalt.transport":          "rest",
-		"gestalt.connection_mode":    "none",
-		"gestalt.invocation_surface": "http",
+		"gestalt.provider":            providerName,
+		"gestalt.operation":           "list",
+		"gestalt.transport":           "rest",
+		"gestalt.connection_mode":     "none",
+		"gestalt.invocation_surface":  "http",
+		"gestalt.result_status":       "200",
+		"gestalt.result_status_class": "2xx",
+	})
+	metrictest.RequireFloat64Histogram(t, rm, "gestaltd.operation.duration", map[string]string{
+		"gestalt.provider":            providerName,
+		"gestalt.operation":           "list",
+		"gestalt.transport":           "rest",
+		"gestalt.connection_mode":     "none",
+		"gestalt.invocation_surface":  "http",
+		"gestalt.result_status":       "200",
+		"gestalt.result_status_class": "2xx",
+	})
+	metrictest.RequireInt64Sum(t, rm, "gestaltd.operation.count", 1, map[string]string{
+		"gestalt.provider":            providerName,
+		"gestalt.operation":           "lookup",
+		"gestalt.transport":           "rest",
+		"gestalt.connection_mode":     "none",
+		"gestalt.invocation_surface":  "http",
+		"gestalt.result_status":       "404",
+		"gestalt.result_status_class": "4xx",
+	})
+	metrictest.RequireInt64Sum(t, rm, "gestaltd.operation.error_count", 1, map[string]string{
+		"gestalt.provider":            providerName,
+		"gestalt.operation":           "lookup",
+		"gestalt.transport":           "rest",
+		"gestalt.connection_mode":     "none",
+		"gestalt.invocation_surface":  "http",
+		"gestalt.result_status":       "404",
+		"gestalt.result_status_class": "4xx",
+	})
+	metrictest.RequireFloat64Histogram(t, rm, "gestaltd.operation.duration", map[string]string{
+		"gestalt.provider":            providerName,
+		"gestalt.operation":           "lookup",
+		"gestalt.transport":           "rest",
+		"gestalt.connection_mode":     "none",
+		"gestalt.invocation_surface":  "http",
+		"gestalt.result_status":       "404",
+		"gestalt.result_status_class": "4xx",
 	})
 	metrictest.RequireFloat64Histogram(t, rm, "http.server.request.duration", map[string]string{
-		"http.route":                 "/api/v1/{integration}/{operation}",
-		"gestalt.provider":           providerName,
-		"gestalt.operation":          "list",
-		"gestalt.transport":          "rest",
-		"gestalt.connection_mode":    "none",
-		"gestalt.invocation_surface": "http",
+		"http.route":                  "/api/v1/{integration}/{operation}",
+		"gestalt.provider":            providerName,
+		"gestalt.operation":           "list",
+		"gestalt.transport":           "rest",
+		"gestalt.connection_mode":     "none",
+		"gestalt.invocation_surface":  "http",
+		"gestalt.result_status":       "200",
+		"gestalt.result_status_class": "2xx",
 	})
 }
 


### PR DESCRIPTION
## Summary

Adds operation result status dimensions to broker operation telemetry so provider operations can be split by exact result status and status class across invocation surfaces.

## New interfaces

- `gestalt.result_status` on `gestaltd.operation.count`, `gestaltd.operation.duration`, and `gestaltd.operation.error_count`. Examples: `200`, `404`, `502`, `unknown`.
- `gestalt.result_status_class` on the same operation metrics. Examples: `2xx`, `4xx`, `5xx`, `unknown`.
- `gestaltd.operation.error_count` now records invocation errors and provider-returned operation results with status `>= 400`, so plugin/provider 4xx and 5xx outcomes are visible without relying only on HTTP transport metrics.

## Examples

```text
sum:gestaltd.operation.error_count{service:<service>,gestalt.result_status_class:4xx}
  by {gestalt.provider,gestalt.operation,gestalt.result_status}.as_count()
```

```text
sum:gestaltd.operation.error_count{service:<service>,gestalt.result_status_class:5xx}
  by {gestalt.provider,gestalt.operation,gestalt.result_status}.as_count()
```

## Testing

- `go test ./internal/server -run 'TestRefreshAndOperationResultMetrics|TestOperationMetricsDefaultRESTTransportFromCatalogContext' -count=1`
- `go test ./...`
- `npm run typecheck && npm run build` in `docs/`

The docs build still emits the existing Nextra git timestamp warnings in this fresh worktree.