### PR TITLE
[codex] Return precondition errors for missing agent providers

### DIFF
--- a/gestaltd/internal/agentmanager/manager.go
+++ b/gestaltd/internal/agentmanager/manager.go
@@ -25,6 +25,8 @@ import (
 
 var (
 	ErrAgentNotConfigured            = errors.New("agent is not configured")
+	ErrAgentProviderRequired         = errors.New("agent provider is required")
+	ErrAgentProviderNotAvailable     = errors.New("agent provider is not available")
 	ErrAgentRunMetadataNotConfigured = errors.New("agent run metadata is not configured")
 	ErrAgentRunEventsNotConfigured   = errors.New("agent run events are not configured")
 	ErrAgentSubjectRequired          = errors.New("agent subject is required")
@@ -32,6 +34,26 @@ var (
 	ErrAgentInheritedSurfaceTool     = errors.New("agent inherited surface tools are not supported")
 	ErrAgentRunCreationInProgress    = errors.New("agent run creation is already in progress for this idempotency key")
 )
+
+type AgentProviderNotAvailableError struct {
+	Name string
+}
+
+func (e AgentProviderNotAvailableError) Error() string {
+	name := strings.TrimSpace(e.Name)
+	if name == "" {
+		return ErrAgentProviderNotAvailable.Error()
+	}
+	return fmt.Sprintf("agent provider %q is not available", name)
+}
+
+func (e AgentProviderNotAvailableError) Unwrap() error {
+	return ErrAgentProviderNotAvailable
+}
+
+func NewAgentProviderNotAvailableError(name string) error {
+	return AgentProviderNotAvailableError{Name: name}
+}
 
 type AgentControl interface {
 	ResolveProvider(name string) (coreagent.Provider, error)

--- a/gestaltd/internal/bootstrap/agent_runtime.go
+++ b/gestaltd/internal/bootstrap/agent_runtime.go
@@ -14,6 +14,7 @@ import (
 	"github.com/valon-technologies/gestalt/server/core"
 	coreagent "github.com/valon-technologies/gestalt/server/core/agent"
 	"github.com/valon-technologies/gestalt/server/core/indexeddb"
+	"github.com/valon-technologies/gestalt/server/internal/agentmanager"
 	"github.com/valon-technologies/gestalt/server/internal/config"
 	"github.com/valon-technologies/gestalt/server/internal/coredata"
 	"github.com/valon-technologies/gestalt/server/internal/invocation"
@@ -191,7 +192,7 @@ func (r *agentRuntime) ResolveProvider(name string) (coreagent.Provider, error) 
 	defer r.mu.RUnlock()
 	provider, ok := r.providers[strings.TrimSpace(name)]
 	if !ok || provider == nil {
-		return nil, fmt.Errorf("agent provider %q is not available", name)
+		return nil, agentmanager.NewAgentProviderNotAvailableError(name)
 	}
 	return provider, nil
 }
@@ -207,11 +208,11 @@ func (r *agentRuntime) ResolveProviderSelection(name string) (string, coreagent.
 		selectedName = strings.TrimSpace(r.defaultProviderName)
 	}
 	if selectedName == "" {
-		return "", nil, fmt.Errorf("agent provider is required")
+		return "", nil, agentmanager.ErrAgentProviderRequired
 	}
 	provider, ok := r.providers[selectedName]
 	if !ok || provider == nil {
-		return "", nil, fmt.Errorf("agent provider %q is not available", selectedName)
+		return "", nil, agentmanager.NewAgentProviderNotAvailableError(selectedName)
 	}
 	return selectedName, provider, nil
 }

--- a/gestaltd/internal/providerhost/agent_manager_server.go
+++ b/gestaltd/internal/providerhost/agent_manager_server.go
@@ -175,7 +175,7 @@ func agentManagerStatusError(err error) error {
 	switch {
 	case errors.Is(err, agentmanager.ErrAgentRunCreationInProgress):
 		return status.Error(codes.Aborted, err.Error())
-	case errors.Is(err, agentmanager.ErrAgentNotConfigured), errors.Is(err, agentmanager.ErrAgentRunMetadataNotConfigured), errors.Is(err, invocation.ErrNoToken), errors.Is(err, invocation.ErrAmbiguousInstance), errors.Is(err, invocation.ErrUserResolution):
+	case errors.Is(err, agentmanager.ErrAgentNotConfigured), errors.Is(err, agentmanager.ErrAgentProviderRequired), errors.Is(err, agentmanager.ErrAgentProviderNotAvailable), errors.Is(err, agentmanager.ErrAgentRunMetadataNotConfigured), errors.Is(err, invocation.ErrNoToken), errors.Is(err, invocation.ErrAmbiguousInstance), errors.Is(err, invocation.ErrUserResolution):
 		return status.Error(codes.FailedPrecondition, err.Error())
 	case errors.Is(err, agentmanager.ErrAgentCallerPluginRequired), errors.Is(err, agentmanager.ErrAgentInheritedSurfaceTool):
 		return status.Error(codes.InvalidArgument, err.Error())

--- a/gestaltd/internal/server/agent_run_test.go
+++ b/gestaltd/internal/server/agent_run_test.go
@@ -43,7 +43,7 @@ func (s *stubAgentControl) ResolveProviderSelection(name string) (string, coreag
 		name = s.defaultProviderName
 	}
 	if name == "" {
-		return "", nil, errors.New("provider not found")
+		return "", nil, agentmanager.ErrAgentProviderRequired
 	}
 	provider, err := s.ResolveProvider(name)
 	if err != nil {
@@ -59,9 +59,12 @@ func (s *stubAgentControl) ResolveProvider(name string) (coreagent.Provider, err
 	if s.providers != nil {
 		provider, ok := s.providers[name]
 		if !ok {
-			return nil, errors.New("provider not found")
+			return nil, agentmanager.NewAgentProviderNotAvailableError(name)
 		}
 		return provider, nil
+	}
+	if s.provider == nil {
+		return nil, agentmanager.NewAgentProviderNotAvailableError(name)
 	}
 	return s.provider, nil
 }
@@ -444,6 +447,124 @@ func readSSEFrame(t *testing.T, body io.Reader) string {
 		if strings.TrimSpace(line) == "" {
 			return frame.String()
 		}
+	}
+}
+
+func TestGlobalAgentRunProviderAvailabilityFailuresArePreconditionFailures(t *testing.T) {
+	t.Parallel()
+
+	services := coretesting.NewStubServices(t)
+	user := seedUser(t, services, "ada@example.test")
+	subjectID := principal.UserSubjectID(user.ID)
+	if _, err := services.AgentRunMetadata.Put(context.Background(), &coreagent.ExecutionReference{
+		ID:           "run-managed",
+		ProviderName: "managed",
+		SubjectID:    subjectID,
+	}); err != nil {
+		t.Fatalf("Put agent run metadata: %v", err)
+	}
+	if _, err := services.AgentRunEvents.Append(context.Background(), coreagent.RunEvent{
+		RunID:      "run-managed",
+		Type:       "agent.run.started",
+		Source:     "managed",
+		Visibility: "public",
+		Data:       map[string]any{"status": "running"},
+	}); err != nil {
+		t.Fatalf("Append agent run event: %v", err)
+	}
+	manager := agentmanager.New(agentmanager.Config{
+		Providers:   testutil.NewProviderRegistry(t),
+		Agent:       &stubAgentControl{providers: map[string]coreagent.Provider{}},
+		RunMetadata: services.AgentRunMetadata,
+		RunEvents:   services.AgentRunEvents,
+	})
+
+	ts := newTestServer(t, func(cfg *server.Config) {
+		cfg.Auth = &coretesting.StubAuthProvider{
+			N: "stub",
+			ValidateTokenFn: func(_ context.Context, token string) (*core.UserIdentity, error) {
+				if token != "ada-session" {
+					return nil, core.ErrNotFound
+				}
+				return &core.UserIdentity{Email: user.Email, DisplayName: "Ada"}, nil
+			},
+		}
+		cfg.Services = services
+		cfg.AgentManager = manager
+	})
+	testutil.CloseOnCleanup(t, ts)
+
+	errorCases := []struct {
+		name      string
+		method    string
+		path      string
+		body      string
+		wantError string
+	}{
+		{
+			name:      "create without selected provider",
+			method:    http.MethodPost,
+			path:      "/api/v1/agent/runs/",
+			body:      `{"messages":[{"role":"user","text":"Summarize the rollout."}]}`,
+			wantError: "agent provider is required",
+		},
+		{
+			name:      "create with unavailable provider",
+			method:    http.MethodPost,
+			path:      "/api/v1/agent/runs/",
+			body:      `{"provider":"managed","messages":[{"role":"user","text":"Summarize the rollout."}]}`,
+			wantError: `agent provider "managed" is not available`,
+		},
+		{
+			name:      "get stale run with unavailable provider",
+			method:    http.MethodGet,
+			path:      "/api/v1/agent/runs/run-managed",
+			wantError: `agent provider "managed" is not available`,
+		},
+	}
+	for _, tc := range errorCases {
+		var body io.Reader
+		if tc.body != "" {
+			body = strings.NewReader(tc.body)
+		}
+		req, _ := http.NewRequest(tc.method, ts.URL+tc.path, body)
+		if tc.body != "" {
+			req.Header.Set("Content-Type", "application/json")
+		}
+		req.AddCookie(&http.Cookie{Name: "session_token", Value: "ada-session"})
+		resp, err := http.DefaultClient.Do(req)
+		if err != nil {
+			t.Fatalf("%s request: %v", tc.name, err)
+		}
+		defer func() { _ = resp.Body.Close() }()
+		if resp.StatusCode != http.StatusPreconditionFailed {
+			t.Fatalf("%s status = %d, want %d", tc.name, resp.StatusCode, http.StatusPreconditionFailed)
+		}
+		var payload map[string]string
+		if err := json.NewDecoder(resp.Body).Decode(&payload); err != nil {
+			t.Fatalf("%s decode error response: %v", tc.name, err)
+		}
+		if payload["error"] != tc.wantError {
+			t.Fatalf("%s error = %q, want %q", tc.name, payload["error"], tc.wantError)
+		}
+	}
+
+	eventsReq, _ := http.NewRequest(http.MethodGet, ts.URL+"/api/v1/agent/runs/run-managed/events?after=0&limit=10", nil)
+	eventsReq.AddCookie(&http.Cookie{Name: "session_token", Value: "ada-session"})
+	eventsResp, err := http.DefaultClient.Do(eventsReq)
+	if err != nil {
+		t.Fatalf("events request: %v", err)
+	}
+	defer func() { _ = eventsResp.Body.Close() }()
+	if eventsResp.StatusCode != http.StatusOK {
+		t.Fatalf("events status = %d, want %d", eventsResp.StatusCode, http.StatusOK)
+	}
+	var events []agentRunEventResponse
+	if err := json.NewDecoder(eventsResp.Body).Decode(&events); err != nil {
+		t.Fatalf("decode events response: %v", err)
+	}
+	if len(events) != 1 || events[0].RunID != "run-managed" || events[0].Source != "managed" {
+		t.Fatalf("events = %#v, want stored managed event", events)
 	}
 }
 

--- a/gestaltd/internal/server/handlers_agent_runs.go
+++ b/gestaltd/internal/server/handlers_agent_runs.go
@@ -546,6 +546,8 @@ func (s *Server) writeAgentRunManagerError(w http.ResponseWriter, r *http.Reques
 	pluginName, operation := firstAgentToolTarget(req.ToolRefs)
 	switch {
 	case errors.Is(err, agentmanager.ErrAgentNotConfigured),
+		errors.Is(err, agentmanager.ErrAgentProviderRequired),
+		errors.Is(err, agentmanager.ErrAgentProviderNotAvailable),
 		errors.Is(err, agentmanager.ErrAgentRunMetadataNotConfigured),
 		errors.Is(err, agentmanager.ErrAgentRunEventsNotConfigured):
 		writeError(w, http.StatusPreconditionFailed, err.Error())


### PR DESCRIPTION
## What changed

- Adds typed agent manager errors for missing provider selection and unavailable named providers.
- Maps those errors to `412 Precondition Failed` for the agent run REST API instead of falling through to a generic `500`.
- Maps the same errors to gRPC `FailedPrecondition` for provider-host agent manager calls.
- Keeps stored run events readable when run metadata and event storage exist, even if the backing provider is no longer available.

## Interface behavior

```sh
# No default agent provider is configured or requested.
POST /api/v1/agent/runs
-> 412 {"error":"agent provider is required"}

# A provider is requested but is unavailable.
POST /api/v1/agent/runs
{"provider":"managed"}
-> 412 {"error":"agent provider \"managed\" is not available"}

# A stale run points at a provider that is unavailable.
GET /api/v1/agent/runs/RUN_ID
-> 412 {"error":"agent provider \"managed\" is not available"}

# Stored events remain readable for that run.
GET /api/v1/agent/runs/RUN_ID/events?after=0&limit=10
-> 200 [...]
```

From the local CLI build, that means:

```sh
cargo run -p gestalt -- --url http://localhost:8080 agent runs create --message user=hello
cargo run -p gestalt -- --url http://localhost:8080 agent runs create --provider managed --message user=hello
cargo run -p gestalt -- --url http://localhost:8080 agent runs events list RUN_ID --after 0 --limit 10
```

## Tests

- `go test ./internal/server -run 'TestGlobalAgentRun'`
- `go test ./internal/server ./internal/bootstrap ./internal/providerhost ./internal/agentmanager`
- `golangci-lint run`
- `git diff --check`

No unit tests were added. The new coverage is functional HTTP transport coverage through `httptest` against the authenticated agent run REST endpoints.