### PR TITLE
[codex] surface default UI agent availability

### DIFF
--- a/gestaltd/cmd/gestaltd/e2e_test.go
+++ b/gestaltd/cmd/gestaltd/e2e_test.go
@@ -1145,7 +1145,7 @@ func setupDefaultLocalProvidersDir(t *testing.T, baseDir string) string {
 		Entrypoint: &providermanifestv1.Entrypoint{ArtifactPath: filepath.Base(indexedDBBinDest)},
 	})
 
-	rootUIDir := filepath.Join(providersDir, "web", "default")
+	rootUIDir := filepath.Join(providersDir, "ui", "default")
 	rootDistDir := filepath.Join(rootUIDir, "dist")
 	if err := os.MkdirAll(rootDistDir, 0o755); err != nil {
 		t.Fatalf("MkdirAll(%s): %v", rootDistDir, err)

--- a/gestaltd/internal/agentmanager/manager.go
+++ b/gestaltd/internal/agentmanager/manager.go
@@ -40,6 +40,7 @@ type AgentControl interface {
 }
 
 type Service interface {
+	Available() bool
 	Run(ctx context.Context, p *principal.Principal, req coreagent.ManagerRunRequest) (*coreagent.ManagedRun, error)
 	GetRun(ctx context.Context, p *principal.Principal, runID string) (*coreagent.ManagedRun, error)
 	ListRuns(ctx context.Context, p *principal.Principal) ([]*coreagent.ManagedRun, error)
@@ -95,6 +96,13 @@ func New(cfg Config) *Manager {
 		pluginInvokes:     pluginInvokes,
 		now:               now,
 	}
+}
+
+func (m *Manager) Available() bool {
+	if m == nil || m.agent == nil {
+		return false
+	}
+	return len(m.agent.ProviderNames()) > 0
 }
 
 func (m *Manager) Run(ctx context.Context, p *principal.Principal, req coreagent.ManagerRunRequest) (*coreagent.ManagedRun, error) {

--- a/gestaltd/internal/bootstrap/lazy_agent_manager.go
+++ b/gestaltd/internal/bootstrap/lazy_agent_manager.go
@@ -25,6 +25,14 @@ func (l *lazyAgentManager) SetTarget(target agentmanager.Service) {
 	l.target = target
 }
 
+func (l *lazyAgentManager) Available() bool {
+	target, err := l.current()
+	if err != nil {
+		return false
+	}
+	return target.Available()
+}
+
 func (l *lazyAgentManager) Run(ctx context.Context, p *principal.Principal, req coreagent.ManagerRunRequest) (*coreagent.ManagedRun, error) {
 	target, err := l.current()
 	if err != nil {

--- a/gestaltd/internal/bootstrap/provider_build.go
+++ b/gestaltd/internal/bootstrap/provider_build.go
@@ -1609,6 +1609,10 @@ func (unavailableWorkflowManager) PublishEvent(context.Context, *principal.Princ
 
 type unavailableAgentManager struct{}
 
+func (unavailableAgentManager) Available() bool {
+	return false
+}
+
 func (unavailableAgentManager) Run(context.Context, *principal.Principal, coreagent.ManagerRunRequest) (*coreagent.ManagedRun, error) {
 	return nil, fmt.Errorf("agent manager is not available")
 }

--- a/gestaltd/internal/operator/localconfig.go
+++ b/gestaltd/internal/operator/localconfig.go
@@ -172,5 +172,5 @@ providers:
   secrets:
     env:
       source: env
-`, encryptionKey, filepath.Join(providersDir, "indexeddb", "relationaldb", "manifest.yaml"), "sqlite://"+dbPath, filepath.Join(providersDir, "web", "default", "manifest.yaml"))
+`, encryptionKey, filepath.Join(providersDir, "indexeddb", "relationaldb", "manifest.yaml"), "sqlite://"+dbPath, filepath.Join(providersDir, "ui", "default", "manifest.yaml"))
 }

--- a/gestaltd/internal/operator/localconfig_test.go
+++ b/gestaltd/internal/operator/localconfig_test.go
@@ -58,7 +58,7 @@ func TestDefaultLocalSourceConfigIncludesRootUI(t *testing.T) {
 	if rootUI == nil {
 		t.Fatal(`Providers.UI["root"] = nil`)
 	}
-	wantPath := filepath.Join(providersDir, "web", "default", "manifest.yaml")
+	wantPath := filepath.Join(providersDir, "ui", "default", "manifest.yaml")
 	if got := rootUI.SourcePath(); got != wantPath {
 		t.Fatalf(`Providers.UI["root"].Source.Path = %q, want %q`, got, wantPath)
 	}

--- a/gestaltd/internal/server/handlers_auth.go
+++ b/gestaltd/internal/server/handlers_auth.go
@@ -24,9 +24,14 @@ type loginRequest struct {
 }
 
 type authInfoResponse struct {
-	Provider       string `json:"provider"`
-	DisplayName    string `json:"displayName"`
-	LoginSupported bool   `json:"loginSupported"`
+	Provider       string                   `json:"provider"`
+	DisplayName    string                   `json:"displayName"`
+	LoginSupported bool                     `json:"loginSupported"`
+	Features       authInfoFeaturesResponse `json:"features"`
+}
+
+type authInfoFeaturesResponse struct {
+	Agent bool `json:"agent"`
 }
 
 func (s *Server) authProviderName() string {
@@ -43,6 +48,10 @@ func (s *Server) authEnabled() bool {
 	return s.auth != nil && !s.noAuth
 }
 
+func (s *Server) agentFeatureAvailable() bool {
+	return s != nil && s.agentRuns != nil && s.agentRuns.Available()
+}
+
 func (s *Server) authInfo(w http.ResponseWriter, _ *http.Request) {
 	provider := s.authProviderName()
 	displayName := provider
@@ -55,6 +64,9 @@ func (s *Server) authInfo(w http.ResponseWriter, _ *http.Request) {
 		Provider:       provider,
 		DisplayName:    displayName,
 		LoginSupported: s.authEnabled(),
+		Features: authInfoFeaturesResponse{
+			Agent: s.agentFeatureAvailable(),
+		},
 	})
 }
 

--- a/gestaltd/internal/server/server_test.go
+++ b/gestaltd/internal/server/server_test.go
@@ -41,6 +41,7 @@ import (
 	"github.com/valon-technologies/gestalt/server/core/session"
 	coretesting "github.com/valon-technologies/gestalt/server/core/testing"
 	"github.com/valon-technologies/gestalt/server/internal/adminui"
+	"github.com/valon-technologies/gestalt/server/internal/agentmanager"
 	"github.com/valon-technologies/gestalt/server/internal/apiexec"
 	"github.com/valon-technologies/gestalt/server/internal/authorization"
 	"github.com/valon-technologies/gestalt/server/internal/bootstrap"
@@ -13657,6 +13658,7 @@ func TestAuthInfo(t *testing.T) {
 	if body["loginSupported"] != true {
 		t.Fatalf("expected loginSupported true, got %#v", body["loginSupported"])
 	}
+	requireAuthInfoAgentFeature(t, body, false)
 }
 
 func TestAuthInfoFallback(t *testing.T) {
@@ -13690,6 +13692,7 @@ func TestAuthInfoFallback(t *testing.T) {
 	if body["loginSupported"] != true {
 		t.Fatalf("expected loginSupported true, got %#v", body["loginSupported"])
 	}
+	requireAuthInfoAgentFeature(t, body, false)
 }
 
 func TestAuthInfoNoAuth(t *testing.T) {
@@ -13722,6 +13725,49 @@ func TestAuthInfoNoAuth(t *testing.T) {
 	}
 	if body["loginSupported"] != false {
 		t.Fatalf("expected loginSupported false, got %#v", body["loginSupported"])
+	}
+	requireAuthInfoAgentFeature(t, body, false)
+}
+
+func TestAuthInfoAgentFeature(t *testing.T) {
+	t.Parallel()
+
+	ts := newTestServer(t, func(cfg *server.Config) {
+		cfg.AgentManager = agentmanager.New(agentmanager.Config{
+			Agent: &stubAgentControl{
+				defaultProviderName: "managed",
+				provider:            newMemoryAgentProvider(),
+			},
+		})
+	})
+	testutil.CloseOnCleanup(t, ts)
+
+	resp, err := http.Get(ts.URL + "/api/v1/auth/info")
+	if err != nil {
+		t.Fatalf("GET /api/v1/auth/info: %v", err)
+	}
+	defer func() { _ = resp.Body.Close() }()
+
+	if resp.StatusCode != http.StatusOK {
+		t.Fatalf("expected 200, got %d", resp.StatusCode)
+	}
+
+	var body map[string]any
+	if err := json.NewDecoder(resp.Body).Decode(&body); err != nil {
+		t.Fatalf("decoding: %v", err)
+	}
+	requireAuthInfoAgentFeature(t, body, true)
+}
+
+func requireAuthInfoAgentFeature(t *testing.T, body map[string]any, want bool) {
+	t.Helper()
+
+	features, ok := body["features"].(map[string]any)
+	if !ok {
+		t.Fatalf("expected features object, got %#v", body["features"])
+	}
+	if features["agent"] != want {
+		t.Fatalf("expected features.agent %v, got %#v", want, features["agent"])
 	}
 }
 


### PR DESCRIPTION
## What changed

- fix the default local UI provider path to point at `ui/default/manifest.yaml`
- expose `features.agent` from `/api/v1/auth/info` based on whether an agent provider is configured

## Why

The local-source default config was still pointing at the old `web/default` location, so the default UI would not resolve correctly from a local providers checkout.

The default UI also needs a first-class way to know whether the Agents surface should be shown. When no agent provider is configured, the server currently returns HTTP 412 from `/api/v1/agent/runs`; surfacing that capability bit from `auth/info` lets the UI hide Agents up front.

## Impact

- local default config now selects the shipped default UI provider correctly
- default UI consumers can hide the Agents navigation and dashboard affordances when the backend has no configured agent provider

## Validation

- `go test ./internal/operator -run 'TestDefault.*ConfigIncludesRootUI'`
- `go test ./internal/server -run 'TestAuthInfo|TestAuthInfoAgentFeature'`
- `go test ./internal/agentmanager ./internal/bootstrap -run 'TestDoesNotExist'`
