### PR TITLE
Hosted HTTP bindings: add credentialMode override for webhook routes

### DIFF
--- a/docs/content/reference/plugin-manifests.mdx
+++ b/docs/content/reference/plugin-manifests.mdx
@@ -271,6 +271,7 @@ mounts at `/api/v1/example/command`.
 | --- | --- | --- |
 | `path` | string | Plugin-relative route path. |
 | `method` | string | HTTP method for the hosted route. |
+| `credentialMode` | string | Optional credential override for the bound operation. `none` skips provider OAuth token resolution for the route; omit it to inherit the provider default. |
 | `security` | string | Name of a scheme from `spec.securitySchemes`. |
 | `target` | string | Canonical operation ID to invoke. |
 | `requestBody` | HTTPRequestBody | Allowed request content types. |
@@ -294,6 +295,7 @@ spec:
     command:
       path: /command
       method: POST
+      credentialMode: none
       security: signed
       target: handle_command
       requestBody:

--- a/gestaltd/internal/config/config.go
+++ b/gestaltd/internal/config/config.go
@@ -752,6 +752,9 @@ func mergeHTTPBinding(base, override *HTTPBinding) *HTTPBinding {
 	if override.Method != "" {
 		merged.Method = override.Method
 	}
+	if override.CredentialMode != "" {
+		merged.CredentialMode = override.CredentialMode
+	}
 	if override.Security != "" {
 		merged.Security = override.Security
 	}

--- a/gestaltd/internal/invocation/broker.go
+++ b/gestaltd/internal/invocation/broker.go
@@ -215,7 +215,7 @@ func (b *Broker) Invoke(ctx context.Context, p *principal.Principal, providerNam
 	}
 
 	metricProvider = providerName
-	metricConnectionMode = metricutil.NormalizeConnectionMode(prov.ConnectionMode())
+	metricConnectionMode = metricutil.NormalizeConnectionMode(effectiveConnectionMode(ctx, prov))
 	span.SetAttributes(attrConnectionMode.String(metricConnectionMode))
 
 	if p == nil {
@@ -386,7 +386,7 @@ func (b *Broker) InvokeGraphQL(ctx context.Context, p *principal.Principal, prov
 	}
 
 	metricProvider = providerName
-	metricConnectionMode = metricutil.NormalizeConnectionMode(prov.ConnectionMode())
+	metricConnectionMode = metricutil.NormalizeConnectionMode(effectiveConnectionMode(ctx, prov))
 	span.SetAttributes(attrConnectionMode.String(metricConnectionMode))
 
 	if p == nil {
@@ -610,7 +610,7 @@ func (b *Broker) resolveToken(ctx context.Context, prov core.Provider, p *princi
 		ctx = withResolvedPrincipal(ctx, p)
 	}
 
-	mode := core.NormalizeConnectionMode(prov.ConnectionMode())
+	mode := effectiveConnectionMode(ctx, prov)
 	switch mode {
 	case core.ConnectionModeNone:
 		SetCredentialAudit(ctx, core.ConnectionModeNone, "", "", "")
@@ -754,7 +754,7 @@ func (b *Broker) resolveSubjectToken(ctx context.Context, prov core.Provider, su
 		}
 	}
 
-	accessToken, err := b.refreshTokenIfNeeded(ctx, storedToken, providerName, connection, metricutil.NormalizeConnectionMode(prov.ConnectionMode()))
+	accessToken, err := b.refreshTokenIfNeeded(ctx, storedToken, providerName, connection, metricutil.NormalizeConnectionMode(effectiveConnectionMode(ctx, prov)))
 	return ctx, accessToken, err
 }
 

--- a/gestaltd/internal/invocation/catalog.go
+++ b/gestaltd/internal/invocation/catalog.go
@@ -156,7 +156,7 @@ func resolveSessionCatalog(ctx context.Context, prov core.Provider, provName str
 			instance = boundCredential.Instance
 		}
 	}
-	if prov.ConnectionMode() == core.ConnectionModeNone {
+	if effectiveConnectionMode(ctx, prov) == core.ConnectionModeNone {
 		if resolver != nil && p != nil {
 			enrichedCtx, token, err := ResolveTokenForBinding(ctx, resolver, p, provName, connection, instance, boundCredential)
 			if err != nil {

--- a/gestaltd/internal/invocation/credential_mode.go
+++ b/gestaltd/internal/invocation/credential_mode.go
@@ -1,0 +1,46 @@
+package invocation
+
+import (
+	"context"
+
+	"github.com/valon-technologies/gestalt/server/core"
+)
+
+type credentialModeOverrideCtxKey struct{}
+
+func WithCredentialModeOverride(ctx context.Context, mode core.ConnectionMode) context.Context {
+	mode = normalizeCredentialModeOverride(mode)
+	if mode == "" {
+		return ctx
+	}
+	return context.WithValue(ctx, credentialModeOverrideCtxKey{}, mode)
+}
+
+func CredentialModeOverrideFromContext(ctx context.Context) core.ConnectionMode {
+	if ctx == nil {
+		return ""
+	}
+	mode, _ := ctx.Value(credentialModeOverrideCtxKey{}).(core.ConnectionMode)
+	return normalizeCredentialModeOverride(mode)
+}
+
+func effectiveConnectionMode(ctx context.Context, prov core.Provider) core.ConnectionMode {
+	if override := CredentialModeOverrideFromContext(ctx); override != "" {
+		return override
+	}
+	if prov == nil {
+		return ""
+	}
+	return core.NormalizeConnectionMode(prov.ConnectionMode())
+}
+
+func normalizeCredentialModeOverride(mode core.ConnectionMode) core.ConnectionMode {
+	switch mode {
+	case "":
+		return ""
+	case core.ConnectionModeNone, core.ConnectionModeUser:
+		return mode
+	default:
+		return core.NormalizeConnectionMode(mode)
+	}
+}

--- a/gestaltd/internal/invocation/direct_tool.go
+++ b/gestaltd/internal/invocation/direct_tool.go
@@ -22,7 +22,8 @@ func CallDirectTool(ctx context.Context, resolver TokenResolver, p *principal.Pr
 	if p == nil {
 		return nil, ErrNotAuthenticated
 	}
-	if resolver != nil && prov.ConnectionMode() != core.ConnectionModeNone {
+	mode := effectiveConnectionMode(ctx, prov)
+	if resolver != nil && mode != core.ConnectionModeNone {
 		var token string
 		var err error
 		ctx, token, err = ResolveTokenForBinding(ctx, resolver, p, provName, connection, instance, boundCredential)
@@ -30,7 +31,7 @@ func CallDirectTool(ctx context.Context, resolver TokenResolver, p *principal.Pr
 			return nil, err
 		}
 		ctx = mcpupstream.WithUpstreamToken(ctx, token)
-	} else if prov.ConnectionMode() == core.ConnectionModeNone {
+	} else if mode == core.ConnectionModeNone {
 		ctx = WithCredentialContext(ctx, CredentialContext{Mode: core.ConnectionModeNone})
 	}
 	ctx = mcpupstream.WithCallToolMeta(ctx, meta)

--- a/gestaltd/internal/providerpkg/manifest.go
+++ b/gestaltd/internal/providerpkg/manifest.go
@@ -465,6 +465,12 @@ func validateHTTPBinding(path string, binding *providermanifestv1.HTTPBinding, s
 		return fmt.Errorf("%s.method %q is not a valid HTTP method", path, binding.Method)
 	}
 	binding.Method = method
+	binding.CredentialMode = providermanifestv1.ConnectionMode(strings.TrimSpace(string(binding.CredentialMode)))
+	switch binding.CredentialMode {
+	case "", providermanifestv1.ConnectionModeNone, providermanifestv1.ConnectionModeUser:
+	default:
+		return fmt.Errorf("%s.credentialMode %q is not supported", path, binding.CredentialMode)
+	}
 	if strings.TrimSpace(binding.Target) == "" {
 		return fmt.Errorf("%s.target is required", path)
 	}

--- a/gestaltd/internal/providerpkg/source_manifest_metadata.go
+++ b/gestaltd/internal/providerpkg/source_manifest_metadata.go
@@ -243,6 +243,9 @@ func mergeGeneratedHTTPBinding(base, override *providermanifestv1.HTTPBinding) *
 	if override.Method != "" {
 		merged.Method = override.Method
 	}
+	if override.CredentialMode != "" {
+		merged.CredentialMode = override.CredentialMode
+	}
 	if override.Security != "" {
 		merged.Security = override.Security
 	}

--- a/gestaltd/internal/server/http_binding_dispatch.go
+++ b/gestaltd/internal/server/http_binding_dispatch.go
@@ -68,6 +68,9 @@ func (s *Server) httpBindingOperationInvocation(ctx context.Context, binding Mou
 	ctx = invocation.WithAccessContext(ctx, s.providerAccessContextWithContext(ctx, p, binding.PluginName))
 	ctx = invocation.WithWorkflowContext(ctx, httpBindingContextValue(binding, verified, parsed))
 	ctx = invocation.WithInvocationSurface(ctx, invocation.InvocationSurfaceHTTP)
+	if binding.CredentialMode != "" {
+		ctx = invocation.WithCredentialModeOverride(ctx, binding.CredentialMode)
+	}
 	return s.invoker.Invoke(ctx, p, binding.PluginName, "", binding.Target, params)
 }
 

--- a/gestaltd/internal/server/http_bindings.go
+++ b/gestaltd/internal/server/http_bindings.go
@@ -231,7 +231,8 @@ func validateMountedHTTPBinding(pluginName, bindingName string, binding *config.
 
 func validateMountedHTTPBindingRoutes(bindings []MountedHTTPBinding, mountedUIs []MountedUI) error {
 	seen := make(map[string]string, len(bindings))
-	for _, binding := range bindings {
+	for i := range bindings {
+		binding := &bindings[i]
 		if binding.Path == "" {
 			return fmt.Errorf("http binding %s.%s path is required", binding.PluginName, binding.Name)
 		}
@@ -258,8 +259,8 @@ func validateMountedHTTPBindingRoutes(bindings []MountedHTTPBinding, mountedUIs 
 }
 
 func (s *Server) mountHTTPBindingRoutes(r chi.Router) {
-	for _, binding := range s.mountedHTTPBindings {
-		binding := binding
+	for i := range s.mountedHTTPBindings {
+		binding := &s.mountedHTTPBindings[i]
 		r.MethodFunc(binding.Method, binding.Path, func(w http.ResponseWriter, r *http.Request) {
 			metricutil.AddHTTPAttributes(r.Context(),
 				metricutil.AttrProvider.String(metricutil.AttrValue(binding.PluginName)),
@@ -267,7 +268,7 @@ func (s *Server) mountHTTPBindingRoutes(r chi.Router) {
 				metricutil.AttrHTTPBinding.String(metricutil.AttrValue(binding.Name)),
 				metricutil.AttrInvocationSurface.String("http"),
 			)
-			s.handleHTTPBinding(binding, w, r)
+			s.handleHTTPBinding(*binding, w, r)
 		})
 	}
 }

--- a/gestaltd/internal/server/http_bindings.go
+++ b/gestaltd/internal/server/http_bindings.go
@@ -92,15 +92,16 @@ func mountedHTTPBindingsFromEntries(entries map[string]*config.ProviderEntry, pr
 				return nil, fmt.Errorf("http binding %s.%s references undefined security scheme %q", pluginName, bindingName, securityName)
 			}
 			mounted = append(mounted, MountedHTTPBinding{
-				Name:         bindingName,
-				PluginName:   pluginName,
-				Path:         mountedHTTPBindingPath(pluginName, relativePath),
-				Method:       method,
-				Target:       target,
-				RequestBody:  binding.RequestBody,
-				Ack:          binding.Ack,
-				SecurityName: securityName,
-				Security:     scheme,
+				Name:           bindingName,
+				PluginName:     pluginName,
+				Path:           mountedHTTPBindingPath(pluginName, relativePath),
+				Method:         method,
+				Target:         target,
+				CredentialMode: core.ConnectionMode(binding.CredentialMode),
+				RequestBody:    binding.RequestBody,
+				Ack:            binding.Ack,
+				SecurityName:   securityName,
+				Security:       scheme,
 			})
 		}
 	}
@@ -186,6 +187,12 @@ func validateMountedHTTPBinding(pluginName, bindingName string, binding *config.
 		return fmt.Errorf("%s.method %q is not a valid HTTP method", path, binding.Method)
 	}
 	binding.Method = method
+	binding.CredentialMode = providermanifestv1.ConnectionMode(strings.TrimSpace(string(binding.CredentialMode)))
+	switch binding.CredentialMode {
+	case "", providermanifestv1.ConnectionModeNone, providermanifestv1.ConnectionModeUser:
+	default:
+		return fmt.Errorf("%s.credentialMode %q is not supported", path, binding.CredentialMode)
+	}
 	binding.Target = strings.TrimSpace(binding.Target)
 	if binding.Target == "" {
 		return fmt.Errorf("%s.target is required", path)

--- a/gestaltd/internal/server/server.go
+++ b/gestaltd/internal/server/server.go
@@ -52,15 +52,16 @@ type MountedUI struct {
 }
 
 type MountedHTTPBinding struct {
-	Name         string
-	PluginName   string
-	Path         string
-	Method       string
-	Target       string
-	RequestBody  *providermanifestv1.HTTPRequestBody
-	Ack          *providermanifestv1.HTTPAck
-	SecurityName string
-	Security     *providermanifestv1.HTTPSecurityScheme
+	Name           string
+	PluginName     string
+	Path           string
+	Method         string
+	Target         string
+	CredentialMode core.ConnectionMode
+	RequestBody    *providermanifestv1.HTTPRequestBody
+	Ack            *providermanifestv1.HTTPAck
+	SecurityName   string
+	Security       *providermanifestv1.HTTPSecurityScheme
 }
 
 type AdminRouteConfig struct {

--- a/gestaltd/internal/server/server_test.go
+++ b/gestaltd/internal/server/server_test.go
@@ -13363,6 +13363,83 @@ func TestHostedHTTPBinding_RejectsReservedSystemResolvedSubject(t *testing.T) {
 	}
 }
 
+func TestHostedHTTPBinding_CredentialModeNoneBypassesProviderTokenLookup(t *testing.T) {
+	t.Parallel()
+
+	type bindingInvocation struct {
+		Token      string
+		Credential invocation.CredentialContext
+	}
+
+	invocations := make(chan bindingInvocation, 1)
+	provider := &stubIntegrationWithOps{
+		StubIntegration: coretesting.StubIntegration{
+			N:        "events",
+			ConnMode: core.ConnectionModeUser,
+			ExecuteFn: func(ctx context.Context, op string, _ map[string]any, token string) (*core.OperationResult, error) {
+				if op != "handle_event" {
+					t.Fatalf("operation = %q, want %q", op, "handle_event")
+				}
+				invocations <- bindingInvocation{
+					Token:      token,
+					Credential: invocation.CredentialContextFromContext(ctx),
+				}
+				return &core.OperationResult{Status: http.StatusOK, Body: `{"accepted":true}`}, nil
+			},
+		},
+		ops: []core.Operation{{Name: "handle_event", Method: http.MethodPost}},
+	}
+
+	ts := newTestServer(t, func(cfg *server.Config) {
+		cfg.Providers = testutil.NewProviderRegistry(t, provider)
+		cfg.PluginDefs = map[string]*config.ProviderEntry{
+			"events": {
+				SecuritySchemes: map[string]*config.HTTPSecurityScheme{
+					"public": {Type: providermanifestv1.HTTPSecuritySchemeTypeNone},
+				},
+				HTTP: map[string]*config.HTTPBinding{
+					"event": {
+						Path:           "/event",
+						Method:         http.MethodPost,
+						CredentialMode: providermanifestv1.ConnectionModeNone,
+						Security:       "public",
+						Target:         "handle_event",
+					},
+				},
+			},
+		}
+		cfg.Authorizer = mustAuthorizer(t, config.AuthorizationConfig{}, cfg.Providers, cfg.PluginDefs, nil)
+	})
+	testutil.CloseOnCleanup(t, ts)
+
+	req, err := http.NewRequest(http.MethodPost, ts.URL+"/api/v1/events/event", strings.NewReader(`{"event":"opened"}`))
+	if err != nil {
+		t.Fatalf("NewRequest: %v", err)
+	}
+	req.Header.Set("Content-Type", "application/json")
+
+	resp, err := http.DefaultClient.Do(req)
+	if err != nil {
+		t.Fatalf("http binding request: %v", err)
+	}
+	defer func() { _ = resp.Body.Close() }()
+	if resp.StatusCode != http.StatusOK {
+		t.Fatalf("status = %d, want %d", resp.StatusCode, http.StatusOK)
+	}
+
+	select {
+	case invocation := <-invocations:
+		if invocation.Token != "" {
+			t.Fatalf("token = %q, want empty", invocation.Token)
+		}
+		if got, want := invocation.Credential.Mode, core.ConnectionModeNone; got != want {
+			t.Fatalf("credential mode = %q, want %q", got, want)
+		}
+	case <-time.After(2 * time.Second):
+		t.Fatal("timed out waiting for http binding invocation")
+	}
+}
+
 func TestHostedHTTPBinding_RejectsGenericOperationRouteConflicts(t *testing.T) {
 	t.Parallel()
 

--- a/gestaltd/sdk/providermanifest/v1/manifest.jsonschema.json
+++ b/gestaltd/sdk/providermanifest/v1/manifest.jsonschema.json
@@ -321,6 +321,13 @@
             "DELETE"
           ]
         },
+        "credentialMode": {
+          "type": "string",
+          "enum": [
+            "none",
+            "user"
+          ]
+        },
         "requestBody": {
           "$ref": "#/$defs/httpRequestBody"
         },

--- a/gestaltd/sdk/providermanifest/v1/types.go
+++ b/gestaltd/sdk/providermanifest/v1/types.go
@@ -134,12 +134,13 @@ const (
 )
 
 type HTTPBinding struct {
-	Path        string           `json:"path" yaml:"path"`
-	Method      string           `json:"method" yaml:"method"`
-	RequestBody *HTTPRequestBody `json:"requestBody,omitempty" yaml:"requestBody,omitempty"`
-	Security    string           `json:"security,omitempty" yaml:"security,omitempty"`
-	Target      string           `json:"target" yaml:"target"`
-	Ack         *HTTPAck         `json:"ack,omitempty" yaml:"ack,omitempty"`
+	Path           string           `json:"path" yaml:"path"`
+	Method         string           `json:"method" yaml:"method"`
+	CredentialMode ConnectionMode   `json:"credentialMode,omitempty" yaml:"credentialMode,omitempty"`
+	RequestBody    *HTTPRequestBody `json:"requestBody,omitempty" yaml:"requestBody,omitempty"`
+	Security       string           `json:"security,omitempty" yaml:"security,omitempty"`
+	Target         string           `json:"target" yaml:"target"`
+	Ack            *HTTPAck         `json:"ack,omitempty" yaml:"ack,omitempty"`
 }
 
 type HTTPRequestBody struct {

--- a/sdk/go/manifest_metadata.go
+++ b/sdk/go/manifest_metadata.go
@@ -66,12 +66,13 @@ type HTTPSecurityScheme struct {
 // HTTPBinding describes one hosted HTTP endpoint bound to a registered
 // operation target.
 type HTTPBinding struct {
-	Path        string           `json:"path" yaml:"path"`
-	Method      string           `json:"method" yaml:"method"`
-	RequestBody *HTTPRequestBody `json:"requestBody,omitempty" yaml:"requestBody,omitempty"`
-	Security    string           `json:"security,omitempty" yaml:"security,omitempty"`
-	Target      string           `json:"target" yaml:"target"`
-	Ack         *HTTPAck         `json:"ack,omitempty" yaml:"ack,omitempty"`
+	Path           string           `json:"path" yaml:"path"`
+	Method         string           `json:"method" yaml:"method"`
+	CredentialMode string           `json:"credentialMode,omitempty" yaml:"credentialMode,omitempty"`
+	RequestBody    *HTTPRequestBody `json:"requestBody,omitempty" yaml:"requestBody,omitempty"`
+	Security       string           `json:"security,omitempty" yaml:"security,omitempty"`
+	Target         string           `json:"target" yaml:"target"`
+	Ack            *HTTPAck         `json:"ack,omitempty" yaml:"ack,omitempty"`
 }
 
 // HTTPRequestBody describes the accepted content types for a hosted HTTP

--- a/sdk/python/gestalt/_manifest_metadata.py
+++ b/sdk/python/gestalt/_manifest_metadata.py
@@ -55,6 +55,7 @@ class HTTPBindingRequired(TypedDict):
 
 
 class HTTPBinding(HTTPBindingRequired, total=False):
+    credentialMode: str
     requestBody: HTTPRequestBody
     ack: HTTPAck
 

--- a/sdk/rust/src/manifest_metadata.rs
+++ b/sdk/rust/src/manifest_metadata.rs
@@ -78,6 +78,14 @@ pub enum HTTPAuthScheme {
     Bearer,
 }
 
+/// Credential modes supported by hosted HTTP bindings.
+#[derive(Clone, Copy, Debug, Eq, PartialEq, Serialize, Deserialize)]
+#[serde(rename_all = "lowercase")]
+pub enum HTTPBindingCredentialMode {
+    None,
+    User,
+}
+
 /// Secret reference used by generated hosted HTTP bindings.
 #[derive(Clone, Debug, Default, Eq, PartialEq, Serialize, Deserialize)]
 pub struct HTTPSecretRef {
@@ -358,6 +366,8 @@ impl HTTPAck {
 pub struct HTTPBinding {
     pub path: String,
     pub method: String,
+    #[serde(rename = "credentialMode", skip_serializing_if = "Option::is_none")]
+    pub credential_mode: Option<HTTPBindingCredentialMode>,
     #[serde(rename = "requestBody", skip_serializing_if = "Option::is_none")]
     pub request_body: Option<HTTPRequestBody>,
     pub security: String,
@@ -377,11 +387,18 @@ impl HTTPBinding {
         Self {
             path: path.into().trim().to_owned(),
             method: normalize_method(method.as_ref()),
+            credential_mode: None,
             request_body: None,
             security: security.into().trim().to_owned(),
             target: target.into().trim().to_owned(),
             ack: None,
         }
+    }
+
+    /// Overrides provider credential resolution for this binding.
+    pub fn credential_mode(mut self, credential_mode: HTTPBindingCredentialMode) -> Self {
+        self.credential_mode = Some(credential_mode);
+        self
     }
 
     /// Attaches request-body metadata.

--- a/sdk/typescript/src/manifest-metadata.ts
+++ b/sdk/typescript/src/manifest-metadata.ts
@@ -47,6 +47,7 @@ export interface HTTPAck {
 export interface HTTPBinding {
   path: string;
   method: string;
+  credentialMode?: "none" | "user";
   requestBody?: HTTPRequestBody;
   security: string;
   target: string;


### PR DESCRIPTION
## Summary
Hosted HTTP bindings can now override provider credential resolution with `credentialMode`.

This fixes webhook-style routes, such as Slack Events API callbacks, that are authenticated by request signing and need to invoke their bound operation before any provider OAuth token exists.

## New Interface
```yaml
spec:
  http:
    event:
      path: /event
      method: POST
      credentialMode: none
      security: slack
      target: events.handle
```

Supported values:
- `none`: skip provider OAuth token resolution for this hosted HTTP route
- `user`: force normal user credential resolution for this hosted HTTP route
- omitted: inherit the provider default connection mode

The generated manifest metadata surface now exposes the same field in:
- Go
- Python
- Rust
- TypeScript

## Behavior
Before:
- hosted HTTP bindings always inherited the provider connection mode
- a user-mode provider behind a signed webhook route would fail with `not_connected` before the target operation ran

After:
- a binding can explicitly opt out of provider token lookup with `credentialMode: none`
- the target operation still runs with normal request context, authz, and HTTP subject resolution

## Example
Slack-style webhook route:
```yaml
spec:
  securitySchemes:
    slack:
      type: hmac
      secret:
        env: SLACK_SIGNING_SECRET
      signatureHeader: X-Slack-Signature
      signaturePrefix: v0=
      payloadTemplate: "v0:{header:X-Slack-Request-Timestamp}:{raw_body}"
      timestampHeader: X-Slack-Request-Timestamp
      maxAgeSeconds: 300
  http:
    event:
      path: /event
      method: POST
      credentialMode: none
      security: slack
      target: events.handle
```

## Validation
- `go test ./internal/server -run 'TestHostedHTTPBinding_CredentialModeNoneBypassesProviderTokenLookup|TestHostedHTTPBinding_APIKeySyncInvokesOperation|TestHostedHTTPBinding_RejectsReservedSystemResolvedSubject'`
- `go test ./internal/providerpkg ./internal/config ./internal/invocation`
