### PR TITLE
Introduce ExternalCredentialProvider runtime boundary

### DIFF
--- a/gestaltd/core/external_credentials.go
+++ b/gestaltd/core/external_credentials.go
@@ -1,0 +1,16 @@
+package core
+
+import "context"
+
+// ExternalCredentialProvider manages subject-scoped third-party credentials
+// used to invoke integrations on behalf of users, workloads, or system
+// subjects.
+type ExternalCredentialProvider interface {
+	PutCredential(ctx context.Context, credential *ExternalCredential) error
+	RestoreCredential(ctx context.Context, credential *ExternalCredential) error
+	GetCredential(ctx context.Context, subjectID, integration, connection, instance string) (*ExternalCredential, error)
+	ListCredentials(ctx context.Context, subjectID string) ([]*ExternalCredential, error)
+	ListCredentialsForProvider(ctx context.Context, subjectID, integration string) ([]*ExternalCredential, error)
+	ListCredentialsForConnection(ctx context.Context, subjectID, integration, connection string) ([]*ExternalCredential, error)
+	DeleteCredential(ctx context.Context, id string) error
+}

--- a/gestaltd/core/types.go
+++ b/gestaltd/core/types.go
@@ -13,7 +13,7 @@ type User struct {
 	UpdatedAt   time.Time
 }
 
-type IntegrationToken struct {
+type ExternalCredential struct {
 	ID                string
 	SubjectID         string
 	Integration       string
@@ -29,6 +29,8 @@ type IntegrationToken struct {
 	CreatedAt         time.Time
 	UpdatedAt         time.Time
 }
+
+type IntegrationToken = ExternalCredential
 
 type AccessPermission struct {
 	Plugin     string   `json:"plugin"`

--- a/gestaltd/internal/bootstrap/agent_runtime_test.go
+++ b/gestaltd/internal/bootstrap/agent_runtime_test.go
@@ -311,8 +311,11 @@ func TestAgentRuntimeConfigUsesDirectAgentHostBinding(t *testing.T) {
 	}
 }
 
+//nolint:paralleltest // Hosted public-relay startup is serialized to avoid Linux CI contention.
 func TestAgentRuntimeConfigUsesPublicAgentHostRelayBinding(t *testing.T) {
-	t.Parallel()
+	// This exercises the hosted agent startup path over the public relay and is
+	// sensitive to Linux CI contention when it runs alongside the other hosted
+	// runtime bootstrap tests.
 
 	bin := buildAgentProviderBinary(t)
 	secret := []byte("0123456789abcdef0123456789abcdef")

--- a/gestaltd/internal/bootstrap/bootstrap.go
+++ b/gestaltd/internal/bootstrap/bootstrap.go
@@ -882,7 +882,7 @@ func Bootstrap(ctx context.Context, cfg *config.Config, factories *FactoryRegist
 	}
 	prepared.Deps.AgentRuntime.SetRunMetadata(prepared.Services.AgentRunMetadata)
 	prepared.Deps.AgentRuntime.SetRunEvents(prepared.Services.AgentRunEvents)
-	sharedInvoker := invocation.NewBroker(providers, prepared.Services.Users, prepared.Services.Tokens,
+	sharedInvoker := invocation.NewBroker(providers, prepared.Services.Users, coredata.EffectiveExternalCredentialProvider(prepared.Services),
 		invocation.WithAuthorizer(authz),
 		invocation.WithConnectionMapper(invocation.ConnectionMap(connMaps.APIConnection)),
 		invocation.WithMCPConnectionMapper(invocation.ConnectionMap(connMaps.MCPConnection)),

--- a/gestaltd/internal/bootstrap/validate.go
+++ b/gestaltd/internal/bootstrap/validate.go
@@ -12,6 +12,7 @@ import (
 	"github.com/valon-technologies/gestalt/server/core/catalog"
 	"github.com/valon-technologies/gestalt/server/internal/authorization"
 	"github.com/valon-technologies/gestalt/server/internal/config"
+	"github.com/valon-technologies/gestalt/server/internal/coredata"
 	"github.com/valon-technologies/gestalt/server/internal/invocation"
 	"github.com/valon-technologies/gestalt/server/internal/metricutil"
 	"github.com/valon-technologies/gestalt/server/internal/plugininvocation"
@@ -68,7 +69,7 @@ func Validate(ctx context.Context, cfg *config.Config, factories *FactoryRegistr
 	defer func() { _ = authz.Close() }()
 	prepared.Deps.AgentRuntime.SetRunMetadata(prepared.Services.AgentRunMetadata)
 	prepared.Deps.AgentRuntime.SetRunEvents(prepared.Services.AgentRunEvents)
-	sharedInvoker := invocation.NewBroker(providers, prepared.Services.Users, prepared.Services.Tokens,
+	sharedInvoker := invocation.NewBroker(providers, prepared.Services.Users, coredata.EffectiveExternalCredentialProvider(prepared.Services),
 		invocation.WithAuthorizer(authz),
 		invocation.WithConnectionMapper(invocation.ConnectionMap(connMaps.APIConnection)),
 		invocation.WithMCPConnectionMapper(invocation.ConnectionMap(connMaps.MCPConnection)),

--- a/gestaltd/internal/coredata/external_credentials.go
+++ b/gestaltd/internal/coredata/external_credentials.go
@@ -1,0 +1,33 @@
+package coredata
+
+import (
+	"reflect"
+
+	"github.com/valon-technologies/gestalt/server/core"
+)
+
+func EffectiveExternalCredentialProvider(services *Services) core.ExternalCredentialProvider {
+	if services == nil {
+		return nil
+	}
+	if !ExternalCredentialProviderMissing(services.ExternalCredentials) {
+		return services.ExternalCredentials
+	}
+	if services.Tokens != nil {
+		return services.Tokens
+	}
+	return nil
+}
+
+func ExternalCredentialProviderMissing(provider core.ExternalCredentialProvider) bool {
+	if provider == nil {
+		return true
+	}
+	value := reflect.ValueOf(provider)
+	switch value.Kind() {
+	case reflect.Chan, reflect.Func, reflect.Interface, reflect.Map, reflect.Pointer, reflect.Slice:
+		return value.IsNil()
+	default:
+		return false
+	}
+}

--- a/gestaltd/internal/coredata/external_credentials_test.go
+++ b/gestaltd/internal/coredata/external_credentials_test.go
@@ -1,0 +1,31 @@
+package coredata
+
+import "testing"
+
+func TestEffectiveExternalCredentialProviderHandlesTypedNilFallbacks(t *testing.T) {
+	t.Parallel()
+
+	t.Run("falls back from typed nil external credentials to tokens", func(t *testing.T) {
+		t.Parallel()
+
+		var missing *TokenService
+		tokens := &TokenService{}
+		got := EffectiveExternalCredentialProvider(&Services{
+			ExternalCredentials: missing,
+			Tokens:              tokens,
+		})
+		if got != tokens {
+			t.Fatalf("EffectiveExternalCredentialProvider returned %#v, want %#v", got, tokens)
+		}
+	})
+
+	t.Run("does not wrap typed nil tokens", func(t *testing.T) {
+		t.Parallel()
+
+		var tokens *TokenService
+		got := EffectiveExternalCredentialProvider(&Services{Tokens: tokens})
+		if got != nil {
+			t.Fatalf("EffectiveExternalCredentialProvider returned %#v, want nil", got)
+		}
+	})
+}

--- a/gestaltd/internal/coredata/services.go
+++ b/gestaltd/internal/coredata/services.go
@@ -4,12 +4,14 @@ import (
 	"context"
 	"fmt"
 
+	"github.com/valon-technologies/gestalt/server/core"
 	corecrypto "github.com/valon-technologies/gestalt/server/core/crypto"
 	"github.com/valon-technologies/gestalt/server/core/indexeddb"
 )
 
 type Services struct {
 	Users                    *UserService
+	ExternalCredentials      core.ExternalCredentialProvider
 	Tokens                   *TokenService
 	APITokens                *APITokenService
 	Identities               *IdentityService
@@ -93,6 +95,7 @@ func New(ds indexeddb.IndexedDB, enc *corecrypto.AESGCMEncryptor) (*Services, er
 		return nil, fmt.Errorf("backfill canonical api token access: %w", err)
 	}
 	return &Services{
+		ExternalCredentials:      tokens,
 		Users:                    users,
 		Tokens:                   tokens,
 		APITokens:                apiTokens,

--- a/gestaltd/internal/coredata/tokens.go
+++ b/gestaltd/internal/coredata/tokens.go
@@ -14,29 +14,94 @@ import (
 	"github.com/valon-technologies/gestalt/server/core/indexeddb"
 )
 
-type TokenService struct {
+type LocalExternalCredentialProvider struct {
 	store indexeddb.ObjectStore
 	enc   *corecrypto.AESGCMEncryptor
 }
 
+type TokenService = LocalExternalCredentialProvider
+
 var errUnreadableStoredIntegrationToken = errors.New("unreadable stored integration token")
 
-func NewTokenService(ds indexeddb.IndexedDB, enc *corecrypto.AESGCMEncryptor) *TokenService {
-	return &TokenService{
+var _ core.ExternalCredentialProvider = (*LocalExternalCredentialProvider)(nil)
+
+func NewLocalExternalCredentialProvider(ds indexeddb.IndexedDB, enc *corecrypto.AESGCMEncryptor) *LocalExternalCredentialProvider {
+	return &LocalExternalCredentialProvider{
 		store: ds.ObjectStore(StoreIntegrationTokens),
 		enc:   enc,
 	}
 }
 
-func (s *TokenService) StoreToken(ctx context.Context, token *core.IntegrationToken) error {
+func NewTokenService(ds indexeddb.IndexedDB, enc *corecrypto.AESGCMEncryptor) *LocalExternalCredentialProvider {
+	return NewLocalExternalCredentialProvider(ds, enc)
+}
+
+func (s *LocalExternalCredentialProvider) PutCredential(ctx context.Context, credential *core.ExternalCredential) error {
+	return s.storeToken(ctx, credential, false)
+}
+
+func (s *LocalExternalCredentialProvider) RestoreCredential(ctx context.Context, credential *core.ExternalCredential) error {
+	return s.storeToken(ctx, credential, true)
+}
+
+func (s *LocalExternalCredentialProvider) GetCredential(ctx context.Context, subjectID, integration, connection, instance string) (*core.ExternalCredential, error) {
+	rec, err := s.tokenRecord(ctx, subjectID, integration, connection, instance)
+	if err != nil {
+		return nil, err
+	}
+	return s.recordToToken(rec)
+}
+
+func (s *LocalExternalCredentialProvider) ListCredentials(ctx context.Context, subjectID string) ([]*core.ExternalCredential, error) {
+	recs, err := s.store.Index("by_subject").GetAll(ctx, nil, subjectID)
+	if err != nil {
+		return nil, fmt.Errorf("list tokens: %w", err)
+	}
+	return s.recordsToTokens(recs)
+}
+
+func (s *LocalExternalCredentialProvider) ListCredentialsForProvider(ctx context.Context, subjectID, integration string) ([]*core.ExternalCredential, error) {
+	recs, err := s.store.Index("by_subject_integration").GetAll(ctx, nil, subjectID, integration)
+	if err != nil {
+		return nil, fmt.Errorf("list tokens for integration: %w", err)
+	}
+	return s.recordsToTokens(recs)
+}
+
+func (s *LocalExternalCredentialProvider) ListCredentialsForConnection(ctx context.Context, subjectID, integration, connection string) ([]*core.ExternalCredential, error) {
+	recs, err := s.store.Index("by_subject_connection").GetAll(ctx, nil, subjectID, integration, connection)
+	if err != nil {
+		return nil, fmt.Errorf("list tokens for connection: %w", err)
+	}
+	return s.recordsToTokens(recs)
+}
+
+func (s *LocalExternalCredentialProvider) DeleteCredential(ctx context.Context, id string) error {
+	if id == "" {
+		return s.store.Delete(ctx, id)
+	}
+	_, err := s.store.Get(ctx, id)
+	if err != nil {
+		if err == indexeddb.ErrNotFound {
+			return nil
+		}
+		return err
+	}
+	if err := s.store.Delete(ctx, id); err != nil {
+		return err
+	}
+	return nil
+}
+
+func (s *LocalExternalCredentialProvider) StoreToken(ctx context.Context, token *core.IntegrationToken) error {
 	return s.storeToken(ctx, token, false)
 }
 
-func (s *TokenService) RestoreToken(ctx context.Context, token *core.IntegrationToken) error {
+func (s *LocalExternalCredentialProvider) RestoreToken(ctx context.Context, token *core.IntegrationToken) error {
 	return s.storeToken(ctx, token, true)
 }
 
-func (s *TokenService) storeToken(ctx context.Context, token *core.IntegrationToken, preserveTimestamps bool) error {
+func (s *LocalExternalCredentialProvider) storeToken(ctx context.Context, token *core.IntegrationToken, preserveTimestamps bool) error {
 	token.SubjectID = strings.TrimSpace(token.SubjectID)
 
 	accessEnc, refreshEnc, err := s.enc.EncryptTokenPair(token.AccessToken, token.RefreshToken)
@@ -110,56 +175,27 @@ func tokenUpdatedAt(token *core.IntegrationToken, fallback time.Time, preserve b
 	return fallback
 }
 
-func (s *TokenService) Token(ctx context.Context, subjectID, integration, connection, instance string) (*core.IntegrationToken, error) {
-	rec, err := s.tokenRecord(ctx, subjectID, integration, connection, instance)
-	if err != nil {
-		return nil, err
-	}
-	return s.recordToToken(rec)
+func (s *LocalExternalCredentialProvider) Token(ctx context.Context, subjectID, integration, connection, instance string) (*core.IntegrationToken, error) {
+	return s.GetCredential(ctx, subjectID, integration, connection, instance)
 }
 
-func (s *TokenService) ListTokens(ctx context.Context, subjectID string) ([]*core.IntegrationToken, error) {
-	recs, err := s.store.Index("by_subject").GetAll(ctx, nil, subjectID)
-	if err != nil {
-		return nil, fmt.Errorf("list tokens: %w", err)
-	}
-	return s.recordsToTokens(recs)
+func (s *LocalExternalCredentialProvider) ListTokens(ctx context.Context, subjectID string) ([]*core.IntegrationToken, error) {
+	return s.ListCredentials(ctx, subjectID)
 }
 
-func (s *TokenService) ListTokensForIntegration(ctx context.Context, subjectID, integration string) ([]*core.IntegrationToken, error) {
-	recs, err := s.store.Index("by_subject_integration").GetAll(ctx, nil, subjectID, integration)
-	if err != nil {
-		return nil, fmt.Errorf("list tokens for integration: %w", err)
-	}
-	return s.recordsToTokens(recs)
+func (s *LocalExternalCredentialProvider) ListTokensForIntegration(ctx context.Context, subjectID, integration string) ([]*core.IntegrationToken, error) {
+	return s.ListCredentialsForProvider(ctx, subjectID, integration)
 }
 
-func (s *TokenService) ListTokensForConnection(ctx context.Context, subjectID, integration, connection string) ([]*core.IntegrationToken, error) {
-	recs, err := s.store.Index("by_subject_connection").GetAll(ctx, nil, subjectID, integration, connection)
-	if err != nil {
-		return nil, fmt.Errorf("list tokens for connection: %w", err)
-	}
-	return s.recordsToTokens(recs)
+func (s *LocalExternalCredentialProvider) ListTokensForConnection(ctx context.Context, subjectID, integration, connection string) ([]*core.IntegrationToken, error) {
+	return s.ListCredentialsForConnection(ctx, subjectID, integration, connection)
 }
 
-func (s *TokenService) DeleteToken(ctx context.Context, id string) error {
-	if id == "" {
-		return s.store.Delete(ctx, id)
-	}
-	_, err := s.store.Get(ctx, id)
-	if err != nil {
-		if err == indexeddb.ErrNotFound {
-			return nil
-		}
-		return err
-	}
-	if err := s.store.Delete(ctx, id); err != nil {
-		return err
-	}
-	return nil
+func (s *LocalExternalCredentialProvider) DeleteToken(ctx context.Context, id string) error {
+	return s.DeleteCredential(ctx, id)
 }
 
-func (s *TokenService) recordToToken(rec indexeddb.Record) (*core.IntegrationToken, error) {
+func (s *LocalExternalCredentialProvider) recordToToken(rec indexeddb.Record) (*core.IntegrationToken, error) {
 	access, refresh, err := s.enc.DecryptTokenPair(
 		recString(rec, "access_token_encrypted"),
 		recString(rec, "refresh_token_encrypted"),
@@ -185,7 +221,7 @@ func (s *TokenService) recordToToken(rec indexeddb.Record) (*core.IntegrationTok
 	}, nil
 }
 
-func (s *TokenService) recordsToTokens(recs []indexeddb.Record) ([]*core.IntegrationToken, error) {
+func (s *LocalExternalCredentialProvider) recordsToTokens(recs []indexeddb.Record) ([]*core.IntegrationToken, error) {
 	recs = dedupeTokenRecords(recs)
 	out := make([]*core.IntegrationToken, 0, len(recs))
 	for _, rec := range recs {
@@ -198,7 +234,7 @@ func (s *TokenService) recordsToTokens(recs []indexeddb.Record) ([]*core.Integra
 	return out, nil
 }
 
-func (s *TokenService) tokenRecord(ctx context.Context, subjectID, integration, connection, instance string) (indexeddb.Record, error) {
+func (s *LocalExternalCredentialProvider) tokenRecord(ctx context.Context, subjectID, integration, connection, instance string) (indexeddb.Record, error) {
 	recs, err := s.store.Index("by_lookup").GetAll(ctx, nil, subjectID, integration, connection, instance)
 	if err != nil {
 		return nil, fmt.Errorf("get token: %w", err)
@@ -210,7 +246,7 @@ func (s *TokenService) tokenRecord(ctx context.Context, subjectID, integration, 
 	return recs[0], nil
 }
 
-func (s *TokenService) deleteDuplicateLookupRecords(ctx context.Context, keepID, subjectID, integration, connection, instance string) error {
+func (s *LocalExternalCredentialProvider) deleteDuplicateLookupRecords(ctx context.Context, keepID, subjectID, integration, connection, instance string) error {
 	recs, err := s.store.Index("by_lookup").GetAll(ctx, nil, subjectID, integration, connection, instance)
 	if err != nil {
 		return fmt.Errorf("list duplicate tokens: %w", err)

--- a/gestaltd/internal/invocation/broker.go
+++ b/gestaltd/internal/invocation/broker.go
@@ -102,7 +102,7 @@ type RefresherResolver func() map[string]map[string]OAuthRefresher
 type Broker struct {
 	providers      *registry.ProviderMap[core.Provider]
 	users          *coredata.UserService
-	tokens         *coredata.TokenService
+	externalCreds  core.ExternalCredentialProvider
 	authorizer     authorization.RuntimeAuthorizer
 	connMapper     ConnectionMapper
 	mcpMapper      ConnectionMapper
@@ -128,8 +128,8 @@ func WithAuthorizer(a authorization.RuntimeAuthorizer) BrokerOption {
 	return func(b *Broker) { b.authorizer = a }
 }
 
-func NewBroker(providers *registry.ProviderMap[core.Provider], users *coredata.UserService, tokens *coredata.TokenService, opts ...BrokerOption) *Broker {
-	b := &Broker{providers: providers, users: users, tokens: tokens}
+func NewBroker(providers *registry.ProviderMap[core.Provider], users *coredata.UserService, externalCreds core.ExternalCredentialProvider, opts ...BrokerOption) *Broker {
+	b := &Broker{providers: providers, users: users, externalCreds: externalCreds}
 	for _, o := range opts {
 		o(b)
 	}
@@ -707,7 +707,7 @@ func (b *Broker) resolveSubjectToken(ctx context.Context, prov core.Provider, su
 	var err error
 
 	if instance != "" {
-		storedToken, err = b.tokens.Token(ctx, subjectID, providerName, connection, instance)
+		storedToken, err = b.externalCreds.GetCredential(ctx, subjectID, providerName, connection, instance)
 		if err != nil {
 			if errors.Is(err, core.ErrNotFound) {
 				return ctx, "", fmt.Errorf("%w: no token stored for integration %q instance %q", ErrNoToken, providerName, instance)
@@ -715,7 +715,7 @@ func (b *Broker) resolveSubjectToken(ctx context.Context, prov core.Provider, su
 			return ctx, "", fmt.Errorf("%w: retrieving integration token: %v", ErrInternal, err)
 		}
 	} else {
-		tokens, listErr := b.tokens.ListTokensForConnection(ctx, subjectID, providerName, connection)
+		tokens, listErr := b.externalCreds.ListCredentialsForConnection(ctx, subjectID, providerName, connection)
 		if listErr != nil {
 			return ctx, "", fmt.Errorf("%w: listing tokens: %v", ErrInternal, listErr)
 		}
@@ -791,13 +791,13 @@ func (b *Broker) refreshTokenIfNeeded(ctx context.Context, token *core.Integrati
 		return resp, err
 	})
 	if err != nil {
-		fresh, fetchErr := b.tokens.Token(ctx, token.SubjectID, token.Integration, token.Connection, token.Instance)
+		fresh, fetchErr := b.externalCreds.GetCredential(ctx, token.SubjectID, token.Integration, token.Connection, token.Instance)
 		if fetchErr == nil && fresh != nil && fresh.AccessToken != token.AccessToken {
 			return fresh.AccessToken, nil
 		}
 		token.RefreshErrorCount++
 		token.UpdatedAt = time.Now()
-		if storeErr := b.tokens.StoreToken(ctx, token); storeErr != nil {
+		if storeErr := b.externalCreds.PutCredential(ctx, token); storeErr != nil {
 			slog.WarnContext(ctx, "failed to persist refresh error count", "provider", providerName, "error", storeErr)
 		}
 		if time.Now().Before(*token.ExpiresAt) {
@@ -822,7 +822,7 @@ func (b *Broker) refreshTokenIfNeeded(ctx context.Context, token *core.Integrati
 	token.RefreshErrorCount = 0
 	token.UpdatedAt = now
 
-	if err := b.tokens.StoreToken(ctx, token); err != nil {
+	if err := b.externalCreds.PutCredential(ctx, token); err != nil {
 		return "", fmt.Errorf("persisting refreshed token: %w", err)
 	}
 	return token.AccessToken, nil

--- a/gestaltd/internal/server/external_credentials_test.go
+++ b/gestaltd/internal/server/external_credentials_test.go
@@ -1,0 +1,23 @@
+package server
+
+import (
+	"context"
+	"testing"
+
+	"github.com/valon-technologies/gestalt/server/internal/coredata"
+)
+
+func TestSubjectHasOtherExternalIdentityLinkTreatsTypedNilProviderAsMissing(t *testing.T) {
+	t.Parallel()
+
+	var tokens *coredata.TokenService
+	srv := &Server{externalCredentials: tokens}
+
+	got, err := srv.subjectHasOtherExternalIdentityLink(context.Background(), "user:test", externalIdentityRef{}, "")
+	if err != nil {
+		t.Fatalf("subjectHasOtherExternalIdentityLink error = %v, want nil", err)
+	}
+	if got {
+		t.Fatal("subjectHasOtherExternalIdentityLink = true, want false")
+	}
+}

--- a/gestaltd/internal/server/external_identity_sync.go
+++ b/gestaltd/internal/server/external_identity_sync.go
@@ -7,6 +7,7 @@ import (
 
 	"github.com/valon-technologies/gestalt/server/core"
 	"github.com/valon-technologies/gestalt/server/internal/authorization"
+	"github.com/valon-technologies/gestalt/server/internal/coredata"
 )
 
 var errExternalIdentityAlreadyLinked = errors.New("external identity already linked")
@@ -38,11 +39,11 @@ func (s *Server) unlinkStoredTokenAuthorization(ctx context.Context, tok *core.I
 }
 
 func (s *Server) subjectHasOtherExternalIdentityLink(ctx context.Context, subjectID string, ref externalIdentityRef, skipTokenID string) (bool, error) {
-	if s.tokens == nil || subjectID == "" {
+	if coredata.ExternalCredentialProviderMissing(s.externalCredentials) || subjectID == "" {
 		return false, nil
 	}
 	ref = normalizeExternalIdentityRef(ref)
-	tokens, err := s.tokens.ListTokens(ctx, subjectID)
+	tokens, err := s.externalCredentials.ListCredentials(ctx, subjectID)
 	if err != nil {
 		return false, err
 	}

--- a/gestaltd/internal/server/handlers.go
+++ b/gestaltd/internal/server/handlers.go
@@ -170,7 +170,7 @@ func (s *Server) listIntegrations(w http.ResponseWriter, r *http.Request) {
 					case core.ConnectionModeNone:
 						info.Connected = true
 					case core.ConnectionModeUser:
-						_, err := s.tokens.Token(r.Context(), binding.CredentialSubjectID, name, binding.Connection, binding.Instance)
+						_, err := s.externalCredentials.GetCredential(r.Context(), binding.CredentialSubjectID, name, binding.Connection, binding.Instance)
 						switch {
 						case err == nil:
 							info.Connected = true
@@ -220,7 +220,7 @@ func (s *Server) userConnectedIntegrations(r *http.Request) (map[string][]instan
 		}
 		userID = dbUser.ID
 	}
-	tokens, err := s.tokens.ListTokens(r.Context(), principal.UserSubjectID(userID))
+	tokens, err := s.externalCredentials.ListCredentials(r.Context(), principal.UserSubjectID(userID))
 	if err != nil {
 		return nil, fmt.Errorf("listing tokens: %w", err)
 	}
@@ -277,7 +277,7 @@ func (s *Server) disconnectIntegration(w http.ResponseWriter, r *http.Request) {
 		auditTarget = connectionAuditTarget(name, requestedConnection, requestedInstance)
 	}
 
-	tokens, err := s.tokens.ListTokensForIntegration(r.Context(), subjectID, name)
+	tokens, err := s.externalCredentials.ListCredentialsForProvider(r.Context(), subjectID, name)
 	if err != nil {
 		auditErr = errors.New("failed to list tokens")
 		writeError(w, http.StatusInternalServerError, "failed to list tokens")
@@ -335,14 +335,14 @@ func (s *Server) disconnectIntegration(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	if err := s.tokens.DeleteToken(r.Context(), tokenID); err != nil {
+	if err := s.externalCredentials.DeleteCredential(r.Context(), tokenID); err != nil {
 		auditErr = errors.New("failed to disconnect integration")
 		writeError(w, http.StatusInternalServerError, "failed to disconnect integration")
 		return
 	}
 
 	if err := s.unlinkStoredTokenAuthorization(r.Context(), matched[0]); err != nil {
-		if restoreErr := s.tokens.RestoreToken(r.Context(), matched[0]); restoreErr != nil {
+		if restoreErr := s.externalCredentials.RestoreCredential(r.Context(), matched[0]); restoreErr != nil {
 			slog.Error("restore disconnected integration after authz unlink failure", "integration", name, "connection", matched[0].Connection, "instance", matched[0].Instance, "token_id", matched[0].ID, "error", restoreErr)
 		}
 		auditErr = errors.New("failed to disconnect integration")

--- a/gestaltd/internal/server/handlers_connect.go
+++ b/gestaltd/internal/server/handlers_connect.go
@@ -264,7 +264,7 @@ type discoveryCandidateInfo struct {
 
 func (s *Server) storeTokenFromMaterial(ctx context.Context, tm tokenMaterial) (*core.IntegrationToken, error) {
 	now := s.now().UTC().Truncate(time.Second)
-	previous, err := s.tokens.Token(ctx, tm.SubjectID, tm.Integration, tm.Connection, tm.Instance)
+	previous, err := s.externalCredentials.GetCredential(ctx, tm.SubjectID, tm.Integration, tm.Connection, tm.Instance)
 	if err != nil && !errors.Is(err, core.ErrNotFound) {
 		return nil, err
 	}
@@ -285,7 +285,7 @@ func (s *Server) storeTokenFromMaterial(ctx context.Context, tm tokenMaterial) (
 		CreatedAt:       now,
 		UpdatedAt:       now,
 	}
-	if err := s.tokens.StoreToken(ctx, tok); err != nil {
+	if err := s.externalCredentials.PutCredential(ctx, tok); err != nil {
 		return nil, err
 	}
 	if err := s.syncStoredTokenAuthorization(ctx, tok); err != nil {
@@ -308,9 +308,9 @@ func (s *Server) storeTokenFromMaterial(ctx context.Context, tm tokenMaterial) (
 
 func (s *Server) rollbackStoredToken(ctx context.Context, previous *core.IntegrationToken, tokenID string) error {
 	if previous != nil {
-		return s.tokens.RestoreToken(ctx, previous)
+		return s.externalCredentials.RestoreCredential(ctx, previous)
 	}
-	return s.tokens.DeleteToken(ctx, tokenID)
+	return s.externalCredentials.DeleteCredential(ctx, tokenID)
 }
 
 func (s *Server) unlinkReplacedTokenAuthorization(ctx context.Context, previous, current *core.IntegrationToken) error {

--- a/gestaltd/internal/server/server.go
+++ b/gestaltd/internal/server/server.go
@@ -82,7 +82,7 @@ type Server struct {
 	serverAuthProvider     string
 	auditSink              core.AuditSink
 	users                  *coredata.UserService
-	tokens                 *coredata.TokenService
+	externalCredentials    core.ExternalCredentialProvider
 	apiTokens              *coredata.APITokenService
 	identities             *coredata.IdentityService
 	identityGrants         *coredata.IdentityManagementGrantService
@@ -233,7 +233,7 @@ func New(cfg Config) (*Server, error) {
 	}
 
 	users := cfg.Services.Users
-	tokens := cfg.Services.Tokens
+	externalCredentials := coredata.EffectiveExternalCredentialProvider(cfg.Services)
 	apiTokens := cfg.Services.APITokens
 	identities := cfg.Services.Identities
 	identityGrants := cfg.Services.IdentityManagementGrants
@@ -282,7 +282,7 @@ func New(cfg Config) (*Server, error) {
 		serverAuthProvider:     serverAuthProvider,
 		auditSink:              cfg.AuditSink,
 		users:                  users,
-		tokens:                 tokens,
+		externalCredentials:    externalCredentials,
 		apiTokens:              apiTokens,
 		identities:             identities,
 		identityGrants:         identityGrants,

--- a/gestaltd/internal/server/server_test.go
+++ b/gestaltd/internal/server/server_test.go
@@ -121,13 +121,68 @@ func newTestHandler(t *testing.T, opts ...func(*server.Config)) http.Handler {
 		brokerOpts = append(brokerOpts, invocation.WithAuthorizer(cfg.Authorizer))
 	}
 	if cfg.Invoker == nil {
-		cfg.Invoker = invocation.NewBroker(cfg.Providers, cfg.Services.Users, cfg.Services.Tokens, brokerOpts...)
+		externalCredentials := coredata.EffectiveExternalCredentialProvider(cfg.Services)
+		cfg.Invoker = invocation.NewBroker(cfg.Providers, cfg.Services.Users, externalCredentials, brokerOpts...)
 	}
 	srv, err := server.New(cfg)
 	if err != nil {
 		t.Fatalf("creating server: %v", err)
 	}
 	return srv
+}
+
+type recordingExternalCredentialProvider struct {
+	inner                  core.ExternalCredentialProvider
+	getCredentialCalls     atomic.Int64
+	listCredentialsCalls   atomic.Int64
+	listForProviderCalls   atomic.Int64
+	listForConnectionCalls atomic.Int64
+	putCredentialCalls     atomic.Int64
+	restoreCredentialCalls atomic.Int64
+	deleteCredentialCalls  atomic.Int64
+}
+
+func newRecordingExternalCredentialProvider(inner core.ExternalCredentialProvider) *recordingExternalCredentialProvider {
+	return &recordingExternalCredentialProvider{inner: inner}
+}
+
+func (r *recordingExternalCredentialProvider) PutCredential(ctx context.Context, credential *core.ExternalCredential) error {
+	r.putCredentialCalls.Add(1)
+	return r.inner.PutCredential(ctx, credential)
+}
+
+func (r *recordingExternalCredentialProvider) RestoreCredential(ctx context.Context, credential *core.ExternalCredential) error {
+	r.restoreCredentialCalls.Add(1)
+	return r.inner.RestoreCredential(ctx, credential)
+}
+
+func (r *recordingExternalCredentialProvider) GetCredential(ctx context.Context, subjectID, integration, connection, instance string) (*core.ExternalCredential, error) {
+	r.getCredentialCalls.Add(1)
+	return r.inner.GetCredential(ctx, subjectID, integration, connection, instance)
+}
+
+func (r *recordingExternalCredentialProvider) ListCredentials(ctx context.Context, subjectID string) ([]*core.ExternalCredential, error) {
+	r.listCredentialsCalls.Add(1)
+	return r.inner.ListCredentials(ctx, subjectID)
+}
+
+func (r *recordingExternalCredentialProvider) ListCredentialsForProvider(ctx context.Context, subjectID, integration string) ([]*core.ExternalCredential, error) {
+	r.listForProviderCalls.Add(1)
+	return r.inner.ListCredentialsForProvider(ctx, subjectID, integration)
+}
+
+func (r *recordingExternalCredentialProvider) ListCredentialsForConnection(ctx context.Context, subjectID, integration, connection string) ([]*core.ExternalCredential, error) {
+	r.listForConnectionCalls.Add(1)
+	return r.inner.ListCredentialsForConnection(ctx, subjectID, integration, connection)
+}
+
+func (r *recordingExternalCredentialProvider) DeleteCredential(ctx context.Context, id string) error {
+	r.deleteCredentialCalls.Add(1)
+	return r.inner.DeleteCredential(ctx, id)
+}
+
+func (r *recordingExternalCredentialProvider) lookupCalls() int64 {
+	return r.getCredentialCalls.Load() + r.listCredentialsCalls.Load() + r.listForProviderCalls.Load() + r.listForConnectionCalls.Load()
 }
 
 type staticRuntimeInspector struct {
@@ -7669,6 +7724,8 @@ func TestDisconnectIntegration(t *testing.T) {
 		t.Parallel()
 
 		svc := coretesting.NewStubServices(t)
+		recordingCreds := newRecordingExternalCredentialProvider(svc.Tokens)
+		svc.ExternalCredentials = recordingCreds
 		u := seedUser(t, svc, "anonymous@gestalt")
 		externalIdentityID := testExternalIdentityResourceID("slack_identity", "team:T123:user:U456")
 		authzProvider := newMemoryAuthorizationProvider("memory-authorization")
@@ -7726,6 +7783,12 @@ func TestDisconnectIntegration(t *testing.T) {
 		}
 		if len(tokens) != 0 {
 			t.Fatalf("expected 0 tokens after disconnect, got %d", len(tokens))
+		}
+		if recordingCreds.listForProviderCalls.Load() == 0 {
+			t.Fatal("expected disconnect to list credentials through ExternalCredentialProvider")
+		}
+		if recordingCreds.deleteCredentialCalls.Load() == 0 {
+			t.Fatal("expected disconnect to delete credentials through ExternalCredentialProvider")
 		}
 		respAuthz, err := authzProvider.ReadRelationships(context.Background(), &core.ReadRelationshipsRequest{
 			Relation: authorization.ProviderExternalIdentityRelationAssume,
@@ -11649,6 +11712,8 @@ func TestIntegrationOAuthCallback(t *testing.T) {
 
 		var auditBuf bytes.Buffer
 		svc := coretesting.NewStubServices(t)
+		recordingCreds := newRecordingExternalCredentialProvider(svc.Tokens)
+		svc.ExternalCredentials = recordingCreds
 		externalIdentityID := testExternalIdentityResourceID("slack_identity", "team:T123:user:U456")
 		authzProvider := newMemoryAuthorizationProvider("memory-authorization")
 		legacy, err := authorization.New(config.AuthorizationConfig{}, map[string]*config.ProviderEntry{}, nil, nil)
@@ -11760,6 +11825,12 @@ func TestIntegrationOAuthCallback(t *testing.T) {
 		}
 		if stored.AccessToken != "slack-token" {
 			t.Fatalf("stored access token = %q, want %q", stored.AccessToken, "slack-token")
+		}
+		if recordingCreds.getCredentialCalls.Load() == 0 {
+			t.Fatal("expected oauth callback to load credentials through ExternalCredentialProvider")
+		}
+		if recordingCreds.putCredentialCalls.Load() == 0 {
+			t.Fatal("expected oauth callback to store credentials through ExternalCredentialProvider")
 		}
 		var metadata map[string]string
 		if err := json.Unmarshal([]byte(stored.MetadataJSON), &metadata); err != nil {
@@ -14189,6 +14260,8 @@ func TestExecuteOperation_RefreshesExpiredToken(t *testing.T) {
 	t.Parallel()
 
 	svc := coretesting.NewStubServices(t)
+	recordingCreds := newRecordingExternalCredentialProvider(svc.Tokens)
+	svc.ExternalCredentials = recordingCreds
 	u := seedUser(t, svc, "anonymous@gestalt")
 	expired := time.Now().Add(-1 * time.Hour)
 	seedToken(t, svc, &core.IntegrationToken{
@@ -14237,6 +14310,12 @@ func TestExecuteOperation_RefreshesExpiredToken(t *testing.T) {
 	}
 	if refreshedToken != "fresh-access-token" {
 		t.Fatalf("expected operation to use refreshed token, got %q", refreshedToken)
+	}
+	if recordingCreds.lookupCalls() == 0 {
+		t.Fatal("expected broker to resolve credentials through ExternalCredentialProvider")
+	}
+	if recordingCreds.putCredentialCalls.Load() == 0 {
+		t.Fatal("expected broker to persist refreshed credentials through ExternalCredentialProvider")
 	}
 }
 
@@ -14989,6 +15068,8 @@ func TestConnectManual(t *testing.T) {
 
 		var auditBuf bytes.Buffer
 		svc := coretesting.NewStubServices(t)
+		recordingCreds := newRecordingExternalCredentialProvider(svc.Tokens)
+		svc.ExternalCredentials = recordingCreds
 		ts := newTestServer(t, func(cfg *server.Config) {
 			cfg.Providers = testutil.NewProviderRegistry(t, &stubManualProvider{
 				StubIntegration: coretesting.StubIntegration{N: "manual-svc"},
@@ -15031,6 +15112,12 @@ func TestConnectManual(t *testing.T) {
 		}
 		if stored.AccessToken != "my-api-key" {
 			t.Fatalf("expected credential my-api-key, got %q", stored.AccessToken)
+		}
+		if recordingCreds.getCredentialCalls.Load() == 0 {
+			t.Fatal("expected manual connect to load credentials through ExternalCredentialProvider")
+		}
+		if recordingCreds.putCredentialCalls.Load() == 0 {
+			t.Fatal("expected manual connect to store credentials through ExternalCredentialProvider")
 		}
 
 		var auditRecord map[string]any


### PR DESCRIPTION
## Summary

This PR introduces an `ExternalCredentialProvider` runtime boundary for subject-scoped third-party credentials, and moves the server and broker to depend on that interface instead of the concrete `TokenService`.

Storage behavior is intentionally unchanged in this PR:
- `integration_tokens` remains the backing store
- token encryption remains unchanged
- the current local implementation is now an adapter behind the new interface

## New interface

```go
type ExternalCredentialProvider interface {
    PutCredential(ctx context.Context, credential *ExternalCredential) error
    RestoreCredential(ctx context.Context, credential *ExternalCredential) error
    GetCredential(ctx context.Context, subjectID, integration, connection, instance string) (*ExternalCredential, error)
    ListCredentials(ctx context.Context, subjectID string) ([]*ExternalCredential, error)
    ListCredentialsForProvider(ctx context.Context, subjectID, integration string) ([]*ExternalCredential, error)
    ListCredentialsForConnection(ctx context.Context, subjectID, integration, connection string) ([]*ExternalCredential, error)
    DeleteCredential(ctx context.Context, id string) error
}
```

## Runtime examples

Local adapter over the existing store:

```go
services.ExternalCredentials = coredata.NewLocalExternalCredentialProvider(db, encryptor)
```

Broker wiring:

```go
invoker := invocation.NewBroker(providers, services.Users, services.ExternalCredentials, opts...)
```

Server wiring:

```go
srv, err := server.New(server.Config{
    Services: services,
})
```

`server.New` now reads `cfg.Services.ExternalCredentials` and falls back to `cfg.Services.Tokens` for compatibility.

## What changed

- added `core.ExternalCredentialProvider`
- introduced `core.ExternalCredential` as the canonical runtime type, with `IntegrationToken` kept as an alias for compatibility
- renamed the current local storage implementation to `LocalExternalCredentialProvider`
- kept `TokenService` as a compatibility alias for the same implementation
- moved server and broker call sites from direct `TokenService` methods to `ExternalCredentialProvider`
- augmented existing transport/integration-style server tests to prove the server and broker go through the new interface

## Test coverage

Reused existing end-to-end server flows instead of adding new narrow unit-only tests:
- OAuth callback connect
- manual connect
- disconnect
- token refresh during operation execution

Commands run:

```bash
go test ./internal/server -run 'TestIntegrationOAuthCallback/connected|TestConnectManual/connected|TestDisconnectIntegration/default_token|TestExecuteOperation_RefreshesExpiredToken'
go test ./internal/server ./internal/invocation ./internal/bootstrap ./internal/coredata
```

## Follow-up

This PR only establishes the runtime boundary. The next PR will make external credentials a first-class host/provider primitive and add the optional `SecretManager`-backed implementation path without changing the core-facing interface.