### PR TITLE
provider release: mark built source plugin artifacts executable

### DIFF
--- a/gestaltd/cmd/gestaltd/provider.go
+++ b/gestaltd/cmd/gestaltd/provider.go
@@ -475,7 +475,7 @@ func buildProviderReleaseMetadata(manifest *providermanifestv1.Manifest, version
 		return nil, fmt.Errorf("manifest is required")
 	}
 
-	runtime, err := releaseRuntimeMetadata(manifest)
+	runtime, err := releaseRuntimeMetadata(manifest, archives)
 	if err != nil {
 		return nil, err
 	}
@@ -511,7 +511,7 @@ func providerReleaseArtifactTarget(manifest *providermanifestv1.Manifest, archiv
 	return providerpkg.PlatformString(archive.Platform.GOOS, archive.Platform.GOARCH)
 }
 
-func releaseRuntimeMetadata(manifest *providermanifestv1.Manifest) (string, error) {
+func releaseRuntimeMetadata(manifest *providermanifestv1.Manifest, archives []releaseArchive) (string, error) {
 	kind, err := providerpkg.ManifestKind(manifest)
 	if err != nil {
 		return "", err
@@ -519,6 +519,9 @@ func releaseRuntimeMetadata(manifest *providermanifestv1.Manifest) (string, erro
 
 	switch kind {
 	case providermanifestv1.KindPlugin:
+		if releaseIncludesBuiltPluginArtifact(archives) {
+			return providerReleaseRuntimeKindExecutable, nil
+		}
 		if manifest.IsDeclarativeOnlyProvider() {
 			return providerReleaseRuntimeKindDeclarative, nil
 		}
@@ -528,6 +531,15 @@ func releaseRuntimeMetadata(manifest *providermanifestv1.Manifest) (string, erro
 	default:
 		return providerReleaseRuntimeKindExecutable, nil
 	}
+}
+
+func releaseIncludesBuiltPluginArtifact(archives []releaseArchive) bool {
+	for _, archive := range archives {
+		if archive.Platform != nil {
+			return true
+		}
+	}
+	return false
 }
 func validateReleaseOutputDir(manifest *providermanifestv1.Manifest, sourceDir, outputDir string) error {
 	if manifest == nil || manifest.Spec == nil || manifest.Spec.AssetRoot == "" {

--- a/gestaltd/cmd/gestaltd/provider_test.go
+++ b/gestaltd/cmd/gestaltd/provider_test.go
@@ -346,6 +346,40 @@ func TestRun_ProviderReleaseBuildsPythonSourcePluginForCurrentPlatform(t *testin
 	}
 }
 
+func TestRun_ProviderReleaseWritesExecutableMetadataForManifestBackedPythonSourcePlugin(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("fake Python build fixture is POSIX-only")
+	}
+
+	t.Setenv("GESTALT_TEST_PYINSTALLER_BINARY", pluginBin)
+	t.Setenv("PATH", pathWithoutGo(t))
+
+	pluginDir := newManifestBackedPythonSourceReleaseFixture(t, t.TempDir())
+	outputDir := t.TempDir()
+	const testVersion = "0.0.12-manifest.1"
+
+	runProviderReleaseCommand(t, pluginDir,
+		"--version", testVersion,
+		"--platform", runtime.GOOS+"/"+runtime.GOARCH,
+		"--output", outputDir,
+	)
+
+	archiveName := expectedPythonArchiveName(testVersion, runtime.GOOS, runtime.GOARCH)
+	manifest := readReleasedManifest(t, outputDir, archiveName)
+	assertReleasedManifestHasHostedHTTPMetadata(t, manifest, "greet")
+	if manifest.Entrypoint == nil {
+		t.Fatal("expected provider entrypoint")
+	}
+
+	metadata := readProviderReleaseMetadata(t, outputDir)
+	if metadata.Runtime != providerReleaseRuntimeKindExecutable {
+		t.Fatalf("release metadata runtime = %q, want %q", metadata.Runtime, providerReleaseRuntimeKindExecutable)
+	}
+	if _, ok := metadata.Artifacts[providerpkg.CurrentPlatformString()]; !ok {
+		t.Fatalf("release metadata artifacts missing current platform key %q: %+v", providerpkg.CurrentPlatformString(), metadata.Artifacts)
+	}
+}
+
 func TestRun_ProviderReleaseBuildsTypeScriptSourcePluginForCurrentPlatform(t *testing.T) {
 	if runtime.GOOS == "windows" {
 		t.Skip("fake Bun build fixture is POSIX-only")
@@ -2295,6 +2329,37 @@ def dynamic_catalog(request: gestalt.Request) -> gestalt.Catalog:
 	}
 	writeTestFile(t, pluginDir, "manifest.yaml", manifestData, 0o644)
 	writeFakePythonReleaseInterpreter(t, filepath.Join(pluginDir, ".venv", "bin", "python"), runtime.GOOS, runtime.GOARCH)
+	return pluginDir
+}
+
+func newManifestBackedPythonSourceReleaseFixture(t *testing.T, dir string) string {
+	t.Helper()
+
+	pluginDir := newPythonSourceReleaseFixture(t, dir)
+	writeReleaseTestManifest(t, pluginDir, &providermanifestv1.Manifest{
+		Kind:    providermanifestv1.KindPlugin,
+		Source:  "github.com/testowner/plugins/python-release",
+		Version: "0.0.1",
+		Spec: &providermanifestv1.Spec{
+			Surfaces: &providermanifestv1.ProviderSurfaces{
+				REST: &providermanifestv1.RESTSurface{
+					BaseURL: "https://api.example.test",
+					Operations: []providermanifestv1.ProviderOperation{
+						{
+							Name:   "list_widgets",
+							Method: "GET",
+							Path:   "/widgets",
+						},
+					},
+				},
+			},
+			Connections: map[string]*providermanifestv1.ManifestConnectionDef{
+				"default": {
+					Auth: &providermanifestv1.ProviderAuth{Type: providermanifestv1.AuthTypeNone},
+				},
+			},
+		},
+	})
 	return pluginDir
 }
 


### PR DESCRIPTION
## Summary
`gestaltd provider release` now marks manifest-backed source plugin releases as `runtime: executable` when the release actually includes built platform artifacts.

This fixes releases like the Slack plugin, where:
- the source manifest is declarative/manifest-backed
- release is invoked with an explicit platform such as `--platform linux/amd64`
- the packaged archive contains an `entrypoint` and executable artifact
- but `provider-release.yaml` was still being written as `runtime: declarative`

That mismatch caused `gestaltd init` to fail with:

```text
provider "slack" manifest runtime "executable" does not match metadata runtime "declarative"
```

## Interface
Provider release metadata now reflects the built archive shape, not just the source manifest shape.

Example for an explicit-platform source plugin release:

```yaml
schema: gestaltd-provider-release
schemaVersion: 1
package: github.com/valon-technologies/gestalt-providers/plugins/slack
kind: plugin
version: 0.0.1-alpha.11
runtime: executable
artifacts:
  linux/amd64:
    path: gestalt-plugin-slack_v0.0.1-alpha.11_linux_amd64.tar.gz
    sha256: <sha256>
```

The packaged manifest inside that archive continues to include the executable entrypoint:

```yaml
entrypoint:
  artifactPath: gestalt-plugin-slack
```

## Tests
Augments the existing provider-release coverage with a manifest-backed Python source plugin fixture that reproduces the Slack packaging path and verifies:
- explicit-platform release writes executable metadata
- packaged manifest still carries hosted HTTP metadata
- current platform artifact key is present in release metadata
