### PR TITLE
Validate empty agent run create requests

### DIFF
--- a/gestalt/cli/src/commands/agents.rs
+++ b/gestalt/cli/src/commands/agents.rs
@@ -1,4 +1,4 @@
-use anyhow::{Context, Result};
+use anyhow::{Context, Result, bail};
 use serde_json::{Map, Value, json};
 use std::io;
 
@@ -114,8 +114,22 @@ fn build_create_body(args: &AgentRunCreateArgs) -> Result<Value> {
             Value::Array(args.tools.iter().map(agent_tool_ref_value).collect()),
         );
     }
+    validate_create_body(&body)?;
 
     Ok(Value::Object(body))
+}
+
+fn validate_create_body(body: &Map<String, Value>) -> Result<()> {
+    let has_messages = body
+        .get("messages")
+        .and_then(Value::as_array)
+        .is_some_and(|messages| !messages.is_empty());
+    if !has_messages {
+        bail!(
+            "agent runs create requires at least one message; pass --message, --system, or --request-file with a non-empty messages array"
+        );
+    }
+    Ok(())
 }
 
 fn build_messages(args: &AgentRunCreateArgs) -> Vec<Value> {

--- a/gestalt/cli/tests/agents_cli.rs
+++ b/gestalt/cli/tests/agents_cli.rs
@@ -150,6 +150,30 @@ fn test_cli_creates_agent_run_from_request_file() {
 }
 
 #[test]
+fn test_cli_rejects_agent_run_create_without_messages() {
+    let mut server = Server::new();
+    let create = authed_json_mock!(
+        server,
+        Method::POST,
+        "/api/v1/agent/runs",
+        StatusCode::CREATED
+    )
+    .expect(0)
+    .create();
+
+    let home = tempfile::tempdir().unwrap();
+    cli_command_for_server(home.path(), &server)
+        .args(["agent", "runs", "create"])
+        .assert()
+        .failure()
+        .stderr(predicate::str::contains(
+            "agent runs create requires at least one message",
+        ));
+
+    create.assert();
+}
+
+#[test]
 fn test_cli_lists_agent_runs_with_server_side_filters() {
     let mut server = Server::new();
     let _mock = authed_json_mock!(

--- a/gestaltd/internal/server/agent_run_test.go
+++ b/gestaltd/internal/server/agent_run_test.go
@@ -23,6 +23,8 @@ import (
 	"github.com/valon-technologies/gestalt/server/internal/providerhost"
 	"github.com/valon-technologies/gestalt/server/internal/server"
 	"github.com/valon-technologies/gestalt/server/internal/testutil"
+	"google.golang.org/grpc/codes"
+	"google.golang.org/grpc/status"
 	"google.golang.org/protobuf/types/known/structpb"
 )
 
@@ -91,6 +93,7 @@ type memoryAgentProvider struct {
 	startRunRequests []coreagent.StartRunRequest
 	cancelRequests   []coreagent.CancelRunRequest
 	runs             map[string]*coreagent.Run
+	startRunErr      error
 	getRunErr        error
 	listRunsErr      error
 	cancelRunErr     error
@@ -102,6 +105,9 @@ func newMemoryAgentProvider() *memoryAgentProvider {
 
 func (p *memoryAgentProvider) StartRun(_ context.Context, req coreagent.StartRunRequest) (*coreagent.Run, error) {
 	p.startRunRequests = append(p.startRunRequests, req)
+	if p.startRunErr != nil {
+		return nil, p.startRunErr
+	}
 	now := time.Now().UTC().Truncate(time.Second)
 	run := &coreagent.Run{
 		ID:           req.RunID,
@@ -700,6 +706,57 @@ func TestGlobalAgentRunCreateRejectsMismatchedIdempotencyKeySources(t *testing.T
 	}
 	if len(provider.startRunRequests) != 0 {
 		t.Fatalf("unexpected StartRun requests = %#v", provider.startRunRequests)
+	}
+}
+
+func TestGlobalAgentRunCreateMapsProviderInvalidArgumentToBadRequest(t *testing.T) {
+	t.Parallel()
+
+	services := coretesting.NewStubServices(t)
+	user := seedUser(t, services, "ada@example.test")
+	provider := newMemoryAgentProvider()
+	provider.startRunErr = status.Error(codes.InvalidArgument, "messages must contain at least one entry")
+	manager := agentmanager.New(agentmanager.Config{
+		Providers:   testutil.NewProviderRegistry(t),
+		Agent:       &stubAgentControl{defaultProviderName: "managed", provider: provider},
+		RunMetadata: services.AgentRunMetadata,
+	})
+
+	ts := newTestServer(t, func(cfg *server.Config) {
+		cfg.Auth = &coretesting.StubAuthProvider{
+			N: "stub",
+			ValidateTokenFn: func(_ context.Context, token string) (*core.UserIdentity, error) {
+				if token != "ada-session" {
+					return nil, core.ErrNotFound
+				}
+				return &core.UserIdentity{Email: user.Email, DisplayName: "Ada"}, nil
+			},
+		}
+		cfg.Services = services
+		cfg.AgentManager = manager
+	})
+	testutil.CloseOnCleanup(t, ts)
+
+	req, _ := http.NewRequest(http.MethodPost, ts.URL+"/api/v1/agent/runs/", bytes.NewBufferString(`{}`))
+	req.Header.Set("Content-Type", "application/json")
+	req.AddCookie(&http.Cookie{Name: "session_token", Value: "ada-session"})
+	resp, err := http.DefaultClient.Do(req)
+	if err != nil {
+		t.Fatalf("create request: %v", err)
+	}
+	defer func() { _ = resp.Body.Close() }()
+	if resp.StatusCode != http.StatusBadRequest {
+		t.Fatalf("expected 400, got %d", resp.StatusCode)
+	}
+	var payload map[string]string
+	if err := json.NewDecoder(resp.Body).Decode(&payload); err != nil {
+		t.Fatalf("decode error response: %v", err)
+	}
+	if payload["error"] != "messages must contain at least one entry" {
+		t.Fatalf("error = %q, want %q", payload["error"], "messages must contain at least one entry")
+	}
+	if len(provider.startRunRequests) != 1 {
+		t.Fatalf("StartRun count = %d, want 1", len(provider.startRunRequests))
 	}
 }
 

--- a/gestaltd/internal/server/handlers_agent_runs.go
+++ b/gestaltd/internal/server/handlers_agent_runs.go
@@ -19,6 +19,8 @@ import (
 	"github.com/valon-technologies/gestalt/server/internal/agentmanager"
 	"github.com/valon-technologies/gestalt/server/internal/invocation"
 	"github.com/valon-technologies/gestalt/server/internal/principal"
+	"google.golang.org/grpc/codes"
+	grpcstatus "google.golang.org/grpc/status"
 )
 
 const agentIdempotencyKeyHeader = "Idempotency-Key"
@@ -600,6 +602,8 @@ func (s *Server) writeAgentRunProviderError(ctx context.Context, w http.Response
 	switch {
 	case errors.Is(err, core.ErrNotFound):
 		writeError(w, http.StatusNotFound, fmt.Sprintf("agent run %q not found", runID))
+	case grpcstatus.Code(err) == codes.InvalidArgument:
+		writeError(w, http.StatusBadRequest, grpcstatus.Convert(err).Message())
 	default:
 		slog.ErrorContext(ctx, "agent run provider error", "run_id", runID, "error", err)
 		writeError(w, http.StatusInternalServerError, "agent run request failed")


### PR DESCRIPTION
## Summary
- fail fast in the CLI when `gestalt agent runs create` would send an empty request
- return `400 Bad Request` when an agent provider returns `InvalidArgument` instead of collapsing it to a generic `500`
- extend the existing CLI and server agent run integration suites for the new behavior

## New behavior
```sh
gestalt agent runs create
# error: agent runs create requires at least one message; pass --message, --system, or --request-file with a non-empty messages array
```

```sh
gestalt agent runs create --message user='hello'
# creates the run as before
```

If a provider rejects a create request with gRPC `InvalidArgument`, the REST API now responds with `400` and preserves the provider message, for example:

```json
{"error":"messages must contain at least one entry"}
```

## Testing
- `cargo test -p gestalt --test agents_cli`
- `go test ./internal/server -run 'TestGlobalAgentRun'`
- `git diff --check`
