### PR TITLE
Move agent run create validation server-side

### DIFF
--- a/gestalt/cli/src/commands/agents.rs
+++ b/gestalt/cli/src/commands/agents.rs
@@ -1,4 +1,4 @@
-use anyhow::{Context, Result, bail};
+use anyhow::{Context, Result};
 use serde_json::{Map, Value, json};
 use std::io;
 
@@ -114,22 +114,8 @@ fn build_create_body(args: &AgentRunCreateArgs) -> Result<Value> {
             Value::Array(args.tools.iter().map(agent_tool_ref_value).collect()),
         );
     }
-    validate_create_body(&body)?;
 
     Ok(Value::Object(body))
-}
-
-fn validate_create_body(body: &Map<String, Value>) -> Result<()> {
-    let has_messages = body
-        .get("messages")
-        .and_then(Value::as_array)
-        .is_some_and(|messages| !messages.is_empty());
-    if !has_messages {
-        bail!(
-            "agent runs create requires at least one message; pass --message, --system, or --request-file with a non-empty messages array"
-        );
-    }
-    Ok(())
 }
 
 fn build_messages(args: &AgentRunCreateArgs) -> Vec<Value> {

--- a/gestalt/cli/tests/agents_cli.rs
+++ b/gestalt/cli/tests/agents_cli.rs
@@ -150,15 +150,17 @@ fn test_cli_creates_agent_run_from_request_file() {
 }
 
 #[test]
-fn test_cli_rejects_agent_run_create_without_messages() {
+fn test_cli_surfaces_agent_run_create_validation_error_from_server() {
     let mut server = Server::new();
     let create = authed_json_mock!(
         server,
         Method::POST,
         "/api/v1/agent/runs",
-        StatusCode::CREATED
+        StatusCode::BAD_REQUEST
     )
-    .expect(0)
+    .match_header(header::CONTENT_TYPE.as_str(), http::APPLICATION_JSON)
+    .match_body(Matcher::JsonString("{}".to_string()))
+    .with_body(r#"{"error":"messages must contain at least one entry"}"#)
     .create();
 
     let home = tempfile::tempdir().unwrap();
@@ -167,7 +169,7 @@ fn test_cli_rejects_agent_run_create_without_messages() {
         .assert()
         .failure()
         .stderr(predicate::str::contains(
-            "agent runs create requires at least one message",
+            "failed to create agent run: messages must contain at least one entry",
         ));
 
     create.assert();

--- a/gestaltd/internal/agentmanager/manager.go
+++ b/gestaltd/internal/agentmanager/manager.go
@@ -30,6 +30,7 @@ var (
 	ErrAgentRunMetadataNotConfigured = errors.New("agent run metadata is not configured")
 	ErrAgentRunEventsNotConfigured   = errors.New("agent run events are not configured")
 	ErrAgentSubjectRequired          = errors.New("agent subject is required")
+	ErrAgentMessagesRequired         = errors.New("messages must contain at least one entry")
 	ErrAgentCallerPluginRequired     = errors.New("agent caller plugin is required for inherited tools")
 	ErrAgentInheritedSurfaceTool     = errors.New("agent inherited surface tools are not supported")
 	ErrAgentRunCreationInProgress    = errors.New("agent run creation is already in progress for this idempotency key")
@@ -135,6 +136,9 @@ func (m *Manager) Run(ctx context.Context, p *principal.Principal, req coreagent
 	subjectID := strings.TrimSpace(principalSubjectID(p))
 	if subjectID == "" {
 		return nil, ErrAgentSubjectRequired
+	}
+	if len(req.Messages) == 0 {
+		return nil, ErrAgentMessagesRequired
 	}
 	providerName, provider, err := m.resolveProviderSelection(req.ProviderName)
 	if err != nil {

--- a/gestaltd/internal/bootstrap/executable_plugin_test.go
+++ b/gestaltd/internal/bootstrap/executable_plugin_test.go
@@ -59,6 +59,7 @@ import (
 	"google.golang.org/grpc/codes"
 	"google.golang.org/grpc/credentials"
 	"google.golang.org/grpc/metadata"
+	grpcstatus "google.golang.org/grpc/status"
 	"google.golang.org/protobuf/types/known/emptypb"
 	"gopkg.in/yaml.v3"
 )
@@ -471,6 +472,10 @@ func (r *capturingBundlePluginRuntime) startFakeHostedPlugin(req pluginruntime.S
 					Method: http.MethodPost,
 				},
 				{
+					ID:     "agent_manager_validation_error",
+					Method: http.MethodPost,
+				},
+				{
 					ID:     "authorization_roundtrip",
 					Method: http.MethodPost,
 				},
@@ -566,6 +571,16 @@ func (r *capturingBundlePluginRuntime) startFakeHostedPlugin(req pluginruntime.S
 				return &core.OperationResult{Status: http.StatusOK, Body: string(body)}, nil
 			case "agent_manager_roundtrip":
 				record, err := fakeHostedAgentManagerRoundTrip(providerhost.InvocationTokenFromContext(ctx), env)
+				if err != nil {
+					return nil, err
+				}
+				body, err := json.Marshal(record)
+				if err != nil {
+					return nil, err
+				}
+				return &core.OperationResult{Status: http.StatusOK, Body: string(body)}, nil
+			case "agent_manager_validation_error":
+				record, err := fakeHostedAgentManagerValidationError(providerhost.InvocationTokenFromContext(ctx), env)
 				if err != nil {
 					return nil, err
 				}
@@ -1076,6 +1091,58 @@ func fakeHostedAgentManagerRoundTrip(invocationToken string, env map[string]stri
 		"provider_name": created.GetProviderName(),
 		"run_id":        runID,
 		"status":        fetched.GetRun().GetStatus().String(),
+	}, nil
+}
+
+func fakeHostedAgentManagerValidationError(invocationToken string, env map[string]string) (map[string]any, error) {
+	target := strings.TrimSpace(env[providerhost.DefaultAgentManagerSocketEnv])
+	if target == "" {
+		return nil, fmt.Errorf("missing agent manager relay target in %s", providerhost.DefaultAgentManagerSocketEnv)
+	}
+	token := strings.TrimSpace(env[providerhost.AgentManagerSocketTokenEnv()])
+	if token == "" {
+		return nil, fmt.Errorf("missing agent manager relay token in %s", providerhost.AgentManagerSocketTokenEnv())
+	}
+	address := strings.TrimSpace(strings.TrimPrefix(target, "tls://"))
+	if address == "" || address == target {
+		return nil, fmt.Errorf("unsupported agent manager relay target %q", target)
+	}
+
+	conn, err := grpc.NewClient(
+		address,
+		grpc.WithTransportCredentials(credentials.NewTLS(&tls.Config{
+			InsecureSkipVerify: true,
+			MinVersion:         tls.VersionTLS12,
+			NextProtos:         []string{"h2"},
+		})),
+	)
+	if err != nil {
+		return nil, fmt.Errorf("connect agent manager relay: %w", err)
+	}
+	defer func() { _ = conn.Close() }()
+
+	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	defer cancel()
+	ctx = metadata.NewOutgoingContext(ctx, metadata.Pairs(providerhost.HostServiceRelayTokenHeader, token))
+
+	client := proto.NewAgentManagerHostClient(conn)
+	_, err = client.Run(ctx, &proto.AgentManagerRunRequest{
+		InvocationToken: invocationToken,
+		ProviderName:    "managed",
+		IdempotencyKey:  "plugin-agent-run-empty",
+		ToolSource:      proto.AgentToolSourceMode_AGENT_TOOL_SOURCE_MODE_INHERIT_INVOKES,
+	})
+	if err == nil {
+		return nil, fmt.Errorf("expected agent manager validation error")
+	}
+	st, ok := grpcstatus.FromError(err)
+	if !ok {
+		return nil, fmt.Errorf("agent manager validation returned non-gRPC error: %w", err)
+	}
+
+	return map[string]any{
+		"code":    st.Code().String(),
+		"message": st.Message(),
 	}, nil
 }
 
@@ -3276,6 +3343,7 @@ func TestPluginAgentManagerRunUsesInheritedInvokesAndRequestContext(t *testing.T
 		Name: "echoext",
 		Operations: []catalog.CatalogOperation{
 			{ID: "agent_manager_roundtrip", Method: http.MethodPost},
+			{ID: "agent_manager_validation_error", Method: http.MethodPost},
 		},
 	})
 	manifest := newExecutableManifest("Echo", "Agent manager run roundtrip")
@@ -3431,6 +3499,29 @@ func TestPluginAgentManagerRunUsesInheritedInvokesAndRequestContext(t *testing.T
 	}
 	if startReq.Tools[0].Target.PluginName != "roadmap" || startReq.Tools[0].Target.Operation != "sync" {
 		t.Fatalf("StartRun tool target = %#v", startReq.Tools[0].Target)
+	}
+
+	result, err = prov.Execute(ctx, "agent_manager_validation_error", nil, "")
+	if err != nil {
+		t.Fatalf("Execute(agent_manager_validation_error): %v", err)
+	}
+
+	var validation struct {
+		Code    string `json:"code"`
+		Message string `json:"message"`
+	}
+	if err := json.Unmarshal([]byte(result.Body), &validation); err != nil {
+		t.Fatalf("json.Unmarshal validation: %v", err)
+	}
+	if validation.Code != codes.InvalidArgument.String() || validation.Message != agentmanager.ErrAgentMessagesRequired.Error() {
+		t.Fatalf("agent validation result = %+v", validation)
+	}
+
+	agentProvider.mu.Lock()
+	finalStartRunCount := len(agentProvider.startRunRequests)
+	agentProvider.mu.Unlock()
+	if finalStartRunCount != 1 {
+		t.Fatalf("StartRun count after validation error = %d, want 1", finalStartRunCount)
 	}
 }
 

--- a/gestaltd/internal/providerhost/agent_manager_server.go
+++ b/gestaltd/internal/providerhost/agent_manager_server.go
@@ -177,7 +177,7 @@ func agentManagerStatusError(err error) error {
 		return status.Error(codes.Aborted, err.Error())
 	case errors.Is(err, agentmanager.ErrAgentNotConfigured), errors.Is(err, agentmanager.ErrAgentProviderRequired), errors.Is(err, agentmanager.ErrAgentProviderNotAvailable), errors.Is(err, agentmanager.ErrAgentRunMetadataNotConfigured), errors.Is(err, invocation.ErrNoToken), errors.Is(err, invocation.ErrAmbiguousInstance), errors.Is(err, invocation.ErrUserResolution):
 		return status.Error(codes.FailedPrecondition, err.Error())
-	case errors.Is(err, agentmanager.ErrAgentCallerPluginRequired), errors.Is(err, agentmanager.ErrAgentInheritedSurfaceTool):
+	case errors.Is(err, agentmanager.ErrAgentCallerPluginRequired), errors.Is(err, agentmanager.ErrAgentInheritedSurfaceTool), errors.Is(err, agentmanager.ErrAgentMessagesRequired):
 		return status.Error(codes.InvalidArgument, err.Error())
 	case errors.Is(err, agentmanager.ErrAgentSubjectRequired), errors.Is(err, invocation.ErrNotAuthenticated):
 		return status.Error(codes.Unauthenticated, err.Error())

--- a/gestaltd/internal/server/agent_run_test.go
+++ b/gestaltd/internal/server/agent_run_test.go
@@ -709,6 +709,56 @@ func TestGlobalAgentRunCreateRejectsMismatchedIdempotencyKeySources(t *testing.T
 	}
 }
 
+func TestGlobalAgentRunCreateRejectsEmptyMessagesBeforeProviderStart(t *testing.T) {
+	t.Parallel()
+
+	services := coretesting.NewStubServices(t)
+	user := seedUser(t, services, "ada@example.test")
+	provider := newMemoryAgentProvider()
+	manager := agentmanager.New(agentmanager.Config{
+		Providers:   testutil.NewProviderRegistry(t),
+		Agent:       &stubAgentControl{defaultProviderName: "managed", provider: provider},
+		RunMetadata: services.AgentRunMetadata,
+	})
+
+	ts := newTestServer(t, func(cfg *server.Config) {
+		cfg.Auth = &coretesting.StubAuthProvider{
+			N: "stub",
+			ValidateTokenFn: func(_ context.Context, token string) (*core.UserIdentity, error) {
+				if token != "ada-session" {
+					return nil, core.ErrNotFound
+				}
+				return &core.UserIdentity{Email: user.Email, DisplayName: "Ada"}, nil
+			},
+		}
+		cfg.Services = services
+		cfg.AgentManager = manager
+	})
+	testutil.CloseOnCleanup(t, ts)
+
+	req, _ := http.NewRequest(http.MethodPost, ts.URL+"/api/v1/agent/runs/", bytes.NewBufferString(`{}`))
+	req.Header.Set("Content-Type", "application/json")
+	req.AddCookie(&http.Cookie{Name: "session_token", Value: "ada-session"})
+	resp, err := http.DefaultClient.Do(req)
+	if err != nil {
+		t.Fatalf("create request: %v", err)
+	}
+	defer func() { _ = resp.Body.Close() }()
+	if resp.StatusCode != http.StatusBadRequest {
+		t.Fatalf("expected 400, got %d", resp.StatusCode)
+	}
+	var payload map[string]string
+	if err := json.NewDecoder(resp.Body).Decode(&payload); err != nil {
+		t.Fatalf("decode error response: %v", err)
+	}
+	if payload["error"] != agentmanager.ErrAgentMessagesRequired.Error() {
+		t.Fatalf("error = %q, want %q", payload["error"], agentmanager.ErrAgentMessagesRequired.Error())
+	}
+	if len(provider.startRunRequests) != 0 {
+		t.Fatalf("unexpected StartRun requests = %#v", provider.startRunRequests)
+	}
+}
+
 func TestGlobalAgentRunCreateMapsProviderInvalidArgumentToBadRequest(t *testing.T) {
 	t.Parallel()
 
@@ -737,7 +787,7 @@ func TestGlobalAgentRunCreateMapsProviderInvalidArgumentToBadRequest(t *testing.
 	})
 	testutil.CloseOnCleanup(t, ts)
 
-	req, _ := http.NewRequest(http.MethodPost, ts.URL+"/api/v1/agent/runs/", bytes.NewBufferString(`{}`))
+	req, _ := http.NewRequest(http.MethodPost, ts.URL+"/api/v1/agent/runs/", bytes.NewBufferString(`{"messages":[{"role":"user","text":"Continue"}]}`))
 	req.Header.Set("Content-Type", "application/json")
 	req.AddCookie(&http.Cookie{Name: "session_token", Value: "ada-session"})
 	resp, err := http.DefaultClient.Do(req)

--- a/gestaltd/internal/server/handlers_agent_runs.go
+++ b/gestaltd/internal/server/handlers_agent_runs.go
@@ -558,7 +558,8 @@ func (s *Server) writeAgentRunManagerError(w http.ResponseWriter, r *http.Reques
 	case errors.Is(err, agentmanager.ErrAgentRunCreationInProgress):
 		writeError(w, http.StatusConflict, err.Error())
 	case errors.Is(err, agentmanager.ErrAgentCallerPluginRequired),
-		errors.Is(err, agentmanager.ErrAgentInheritedSurfaceTool):
+		errors.Is(err, agentmanager.ErrAgentInheritedSurfaceTool),
+		errors.Is(err, agentmanager.ErrAgentMessagesRequired):
 		writeError(w, http.StatusBadRequest, err.Error())
 	case errors.Is(err, invocation.ErrProviderNotFound),
 		errors.Is(err, invocation.ErrOperationNotFound),


### PR DESCRIPTION
## Summary
- move empty-message validation for `agent runs create` into `gestaltd`'s shared agent manager
- keep the REST and hosted-plugin gRPC surfaces aligned on `InvalidArgument`
- remove the CLI-side preflight check and verify the CLI relays the server error message

## Interface changes
```sh
gestalt agent runs create
# error: failed to create agent run: messages must contain at least one entry
```

```sh
gestalt agent runs create --message user='hello'
# creates the run as before
```

REST now validates the request before provider dispatch:
```http
POST /api/v1/agent/runs
Content-Type: application/json

{}
```

```http
400 Bad Request
{"error":"messages must contain at least one entry"}
```

The hosted plugin agent-manager relay returns the same validation through gRPC `InvalidArgument`.

## Testing
- `cargo test -p gestalt --test agents_cli`
- `go test ./internal/server -run 'TestGlobalAgentRun'`
- `go test ./internal/bootstrap -run 'TestPluginAgentManagerRunUsesInheritedInvokesAndRequestContext'`
- `git diff --check`
