### PR TITLE
preserve post-connect through provider wrappers

### DIFF
--- a/gestaltd/core/integration/restricted.go
+++ b/gestaltd/core/integration/restricted.go
@@ -222,6 +222,17 @@ func (r *Restricted) DiscoveryConfig() *core.DiscoveryConfig {
 	return r.inner.DiscoveryConfig()
 }
 
+func (r *Restricted) SupportsPostConnect() bool {
+	return core.SupportsPostConnect(r.inner)
+}
+
+func (r *Restricted) PostConnect(ctx context.Context, token *core.IntegrationToken) (map[string]string, error) {
+	if pcp, ok := r.inner.(core.PostConnectCapable); ok {
+		return pcp.PostConnect(ctx, token)
+	}
+	return nil, core.ErrPostConnectUnsupported
+}
+
 func (r *Restricted) ConnectionForOperation(operation string) string {
 	if _, ok := r.allowed[operation]; !ok {
 		return ""

--- a/gestaltd/core/integration/restricted_test.go
+++ b/gestaltd/core/integration/restricted_test.go
@@ -2,6 +2,7 @@ package integration_test
 
 import (
 	"context"
+	"reflect"
 	"testing"
 
 	"github.com/valon-technologies/gestalt/server/core"
@@ -312,6 +313,13 @@ func (s *stubOAuth) RefreshToken(ctx context.Context, refreshToken string) (*cor
 	return nil, nil
 }
 
+func (s *stubOAuth) PostConnect(_ context.Context, _ *core.IntegrationToken) (map[string]string, error) {
+	return map[string]string{
+		"gestalt.external_identity.type": "slack_identity",
+		"gestalt.external_identity.id":   "team:T123:user:U456",
+	}, nil
+}
+
 func TestCatalogRenamesAliasedOperations(t *testing.T) {
 	t.Parallel()
 
@@ -346,5 +354,40 @@ func TestCatalogRenamesAliasedOperations(t *testing.T) {
 	}
 	if cat.Operations[0].ID != "renamed_alpha" {
 		t.Errorf("expected aliased ID %q, got %q", "renamed_alpha", cat.Operations[0].ID)
+	}
+}
+
+func TestRestrictedPreservesPostConnectCapability(t *testing.T) {
+	t.Parallel()
+
+	inner := &stubOAuth{
+		stubWithOps: stubWithOps{
+			StubIntegration: coretesting.StubIntegration{N: "slack"},
+			ops:             sampleOps(),
+		},
+	}
+
+	prov := coreintegration.NewRestricted(inner, map[string]string{"list_channels": ""})
+	if !core.SupportsPostConnect(prov) {
+		t.Fatal("expected restricted wrapper to expose post-connect support")
+	}
+
+	got, supported, err := core.PostConnect(context.Background(), prov, &core.IntegrationToken{
+		Integration: "slack",
+		Connection:  "default",
+		AccessToken: "tok",
+	})
+	if err != nil {
+		t.Fatalf("PostConnect: %v", err)
+	}
+	if !supported {
+		t.Fatal("expected core.PostConnect to report support")
+	}
+	want := map[string]string{
+		"gestalt.external_identity.type": "slack_identity",
+		"gestalt.external_identity.id":   "team:T123:user:U456",
+	}
+	if !reflect.DeepEqual(got, want) {
+		t.Fatalf("PostConnect metadata = %#v, want %#v", got, want)
 	}
 }

--- a/gestaltd/core/provider_capabilities.go
+++ b/gestaltd/core/provider_capabilities.go
@@ -89,6 +89,9 @@ func SupportsPostConnect(prov Provider) bool {
 }
 
 func PostConnect(ctx context.Context, prov Provider, token *IntegrationToken) (map[string]string, bool, error) {
+	if !SupportsPostConnect(prov) {
+		return nil, false, nil
+	}
 	pcp, ok := prov.(PostConnectCapable)
 	if !ok {
 		return nil, false, nil

--- a/gestaltd/internal/bootstrap/connected_provider.go
+++ b/gestaltd/internal/bootstrap/connected_provider.go
@@ -60,8 +60,16 @@ func (p *connectedProvider) DiscoveryConfig() *core.DiscoveryConfig {
 }
 func (p *connectedProvider) ConnectionForOperation(string) string { return p.connection }
 func (p *connectedProvider) Catalog() *catalog.Catalog            { return p.inner.Catalog() }
+func (p *connectedProvider) SupportsPostConnect() bool            { return core.SupportsPostConnect(p.inner) }
 func (p *connectedProvider) Execute(ctx context.Context, operation string, params map[string]any, token string) (*core.OperationResult, error) {
 	return p.inner.Execute(ctx, operation, params, token)
+}
+func (p *connectedProvider) PostConnect(ctx context.Context, token *core.IntegrationToken) (map[string]string, error) {
+	metadata, supported, err := core.PostConnect(ctx, p.inner, token)
+	if !supported {
+		return nil, core.ErrPostConnectUnsupported
+	}
+	return metadata, err
 }
 func (p *connectedProvider) Close() error {
 	if closer, ok := p.inner.(io.Closer); ok {
@@ -73,6 +81,18 @@ func (p *connectedProvider) Close() error {
 type connectedSessionCatalogProvider struct {
 	core.Provider
 	session core.SessionCatalogProvider
+}
+
+func (p *connectedSessionCatalogProvider) SupportsPostConnect() bool {
+	return core.SupportsPostConnect(p.Provider)
+}
+
+func (p *connectedSessionCatalogProvider) PostConnect(ctx context.Context, token *core.IntegrationToken) (map[string]string, error) {
+	metadata, supported, err := core.PostConnect(ctx, p.Provider, token)
+	if !supported {
+		return nil, core.ErrPostConnectUnsupported
+	}
+	return metadata, err
 }
 
 func (p *connectedSessionCatalogProvider) CatalogForRequest(ctx context.Context, token string) (*catalog.Catalog, error) {
@@ -89,6 +109,18 @@ func (p *connectedSessionCatalogProvider) Close() error {
 type connectedGraphQLProvider struct {
 	core.Provider
 	graphQL core.GraphQLSurfaceInvoker
+}
+
+func (p *connectedGraphQLProvider) SupportsPostConnect() bool {
+	return core.SupportsPostConnect(p.Provider)
+}
+
+func (p *connectedGraphQLProvider) PostConnect(ctx context.Context, token *core.IntegrationToken) (map[string]string, error) {
+	metadata, supported, err := core.PostConnect(ctx, p.Provider, token)
+	if !supported {
+		return nil, core.ErrPostConnectUnsupported
+	}
+	return metadata, err
 }
 
 func (p *connectedGraphQLProvider) InvokeGraphQL(ctx context.Context, request core.GraphQLRequest, token string) (*core.OperationResult, error) {
@@ -113,6 +145,18 @@ func (p *connectedGraphQLProvider) Close() error {
 type connectedOAuthProvider struct {
 	core.Provider
 	auth core.OAuthProvider
+}
+
+func (p *connectedOAuthProvider) SupportsPostConnect() bool {
+	return core.SupportsPostConnect(p.Provider)
+}
+
+func (p *connectedOAuthProvider) PostConnect(ctx context.Context, token *core.IntegrationToken) (map[string]string, error) {
+	metadata, supported, err := core.PostConnect(ctx, p.Provider, token)
+	if !supported {
+		return nil, core.ErrPostConnectUnsupported
+	}
+	return metadata, err
 }
 
 func (p *connectedOAuthProvider) AuthorizationURL(state string, scopes []string) string {

--- a/gestaltd/internal/bootstrap/connected_provider_test.go
+++ b/gestaltd/internal/bootstrap/connected_provider_test.go
@@ -1,0 +1,167 @@
+package bootstrap
+
+import (
+	"context"
+	"net/http"
+	"reflect"
+	"testing"
+
+	"github.com/valon-technologies/gestalt/server/core"
+	"github.com/valon-technologies/gestalt/server/core/catalog"
+)
+
+type connectedCapabilityProvider struct {
+	postConnectMetadata map[string]string
+}
+
+func (p *connectedCapabilityProvider) Name() string        { return "slack" }
+func (p *connectedCapabilityProvider) DisplayName() string { return "Slack" }
+func (p *connectedCapabilityProvider) Description() string { return "Slack provider" }
+func (p *connectedCapabilityProvider) ConnectionMode() core.ConnectionMode {
+	return core.ConnectionModeUser
+}
+func (p *connectedCapabilityProvider) AuthTypes() []string { return []string{"oauth"} }
+func (p *connectedCapabilityProvider) ConnectionParamDefs() map[string]core.ConnectionParamDef {
+	return nil
+}
+func (p *connectedCapabilityProvider) CredentialFields() []core.CredentialFieldDef { return nil }
+func (p *connectedCapabilityProvider) DiscoveryConfig() *core.DiscoveryConfig      { return nil }
+func (p *connectedCapabilityProvider) ConnectionForOperation(string) string        { return "" }
+func (p *connectedCapabilityProvider) Catalog() *catalog.Catalog {
+	return &catalog.Catalog{
+		Name: "slack",
+		Operations: []catalog.CatalogOperation{{
+			ID:     "viewer",
+			Method: http.MethodGet,
+		}},
+	}
+}
+func (p *connectedCapabilityProvider) Execute(_ context.Context, _ string, _ map[string]any, _ string) (*core.OperationResult, error) {
+	return &core.OperationResult{Status: http.StatusOK, Body: `{"ok":true}`}, nil
+}
+func (p *connectedCapabilityProvider) CatalogForRequest(_ context.Context, _ string) (*catalog.Catalog, error) {
+	return p.Catalog(), nil
+}
+func (p *connectedCapabilityProvider) InvokeGraphQL(_ context.Context, _ core.GraphQLRequest, _ string) (*core.OperationResult, error) {
+	return &core.OperationResult{Status: http.StatusOK, Body: `{"data":{"viewer":{"id":"U456"}}}`}, nil
+}
+func (p *connectedCapabilityProvider) AuthorizationURL(state string, _ []string) string {
+	return "https://example.com/start?state=" + state
+}
+func (p *connectedCapabilityProvider) ExchangeCode(_ context.Context, _ string) (*core.TokenResponse, error) {
+	return &core.TokenResponse{AccessToken: "access-token"}, nil
+}
+func (p *connectedCapabilityProvider) RefreshToken(_ context.Context, _ string) (*core.TokenResponse, error) {
+	return &core.TokenResponse{AccessToken: "refreshed-token"}, nil
+}
+func (p *connectedCapabilityProvider) PostConnect(_ context.Context, _ *core.IntegrationToken) (map[string]string, error) {
+	return p.postConnectMetadata, nil
+}
+
+func TestBindProviderConnectionPreservesPostConnectCapability(t *testing.T) {
+	t.Parallel()
+
+	want := map[string]string{
+		"gestalt.external_identity.type": "slack_identity",
+		"gestalt.external_identity.id":   "team:T123:user:U456",
+	}
+	prov := bindProviderConnection(&connectedCapabilityProvider{postConnectMetadata: want}, "default")
+
+	if _, ok := prov.(core.OAuthProvider); !ok {
+		t.Fatal("expected bound provider to preserve oauth support")
+	}
+	if _, ok := prov.(core.SessionCatalogProvider); !ok {
+		t.Fatal("expected bound provider to preserve session catalog support")
+	}
+	if _, ok := prov.(core.GraphQLSurfaceInvoker); !ok {
+		t.Fatal("expected bound provider to preserve graphql support")
+	}
+	if got := prov.ConnectionForOperation("viewer"); got != "default" {
+		t.Fatalf("ConnectionForOperation(viewer) = %q, want %q", got, "default")
+	}
+	if !core.SupportsPostConnect(prov) {
+		t.Fatal("expected bound provider to preserve post-connect support")
+	}
+
+	got, supported, err := core.PostConnect(context.Background(), prov, &core.IntegrationToken{
+		Integration: "slack",
+		Connection:  "default",
+		AccessToken: "tok",
+	})
+	if err != nil {
+		t.Fatalf("PostConnect: %v", err)
+	}
+	if !supported {
+		t.Fatal("expected core.PostConnect to report support")
+	}
+	if !reflect.DeepEqual(got, want) {
+		t.Fatalf("PostConnect metadata = %#v, want %#v", got, want)
+	}
+}
+
+type connectedNoPostConnectProvider struct{}
+
+func (p *connectedNoPostConnectProvider) Name() string        { return "slack" }
+func (p *connectedNoPostConnectProvider) DisplayName() string { return "Slack" }
+func (p *connectedNoPostConnectProvider) Description() string { return "Slack provider" }
+func (p *connectedNoPostConnectProvider) ConnectionMode() core.ConnectionMode {
+	return core.ConnectionModeUser
+}
+func (p *connectedNoPostConnectProvider) AuthTypes() []string { return []string{"oauth"} }
+func (p *connectedNoPostConnectProvider) ConnectionParamDefs() map[string]core.ConnectionParamDef {
+	return nil
+}
+func (p *connectedNoPostConnectProvider) CredentialFields() []core.CredentialFieldDef { return nil }
+func (p *connectedNoPostConnectProvider) DiscoveryConfig() *core.DiscoveryConfig      { return nil }
+func (p *connectedNoPostConnectProvider) ConnectionForOperation(string) string        { return "" }
+func (p *connectedNoPostConnectProvider) Catalog() *catalog.Catalog {
+	return &catalog.Catalog{
+		Name: "slack",
+		Operations: []catalog.CatalogOperation{{
+			ID:     "viewer",
+			Method: http.MethodGet,
+		}},
+	}
+}
+func (p *connectedNoPostConnectProvider) Execute(_ context.Context, _ string, _ map[string]any, _ string) (*core.OperationResult, error) {
+	return &core.OperationResult{Status: http.StatusOK, Body: `{"ok":true}`}, nil
+}
+func (p *connectedNoPostConnectProvider) CatalogForRequest(_ context.Context, _ string) (*catalog.Catalog, error) {
+	return p.Catalog(), nil
+}
+func (p *connectedNoPostConnectProvider) InvokeGraphQL(_ context.Context, _ core.GraphQLRequest, _ string) (*core.OperationResult, error) {
+	return &core.OperationResult{Status: http.StatusOK, Body: `{"data":{"viewer":{"id":"U456"}}}`}, nil
+}
+func (p *connectedNoPostConnectProvider) AuthorizationURL(state string, _ []string) string {
+	return "https://example.com/start?state=" + state
+}
+func (p *connectedNoPostConnectProvider) ExchangeCode(_ context.Context, _ string) (*core.TokenResponse, error) {
+	return &core.TokenResponse{AccessToken: "access-token"}, nil
+}
+func (p *connectedNoPostConnectProvider) RefreshToken(_ context.Context, _ string) (*core.TokenResponse, error) {
+	return &core.TokenResponse{AccessToken: "refreshed-token"}, nil
+}
+
+func TestBindProviderConnectionDoesNotFalsePositivePostConnectSupport(t *testing.T) {
+	t.Parallel()
+
+	prov := bindProviderConnection(&connectedNoPostConnectProvider{}, "default")
+	if core.SupportsPostConnect(prov) {
+		t.Fatal("expected bound provider to report no post-connect support")
+	}
+
+	got, supported, err := core.PostConnect(context.Background(), prov, &core.IntegrationToken{
+		Integration: "slack",
+		Connection:  "default",
+		AccessToken: "tok",
+	})
+	if err != nil {
+		t.Fatalf("PostConnect: %v", err)
+	}
+	if supported {
+		t.Fatal("expected core.PostConnect to report unsupported")
+	}
+	if got != nil {
+		t.Fatalf("PostConnect metadata = %#v, want nil", got)
+	}
+}

--- a/gestaltd/internal/bootstrap/graphql_session_provider.go
+++ b/gestaltd/internal/bootstrap/graphql_session_provider.go
@@ -60,6 +60,18 @@ func (p *graphQLSessionCatalogProvider) SupportsSessionCatalog() bool {
 	return true
 }
 
+func (p *graphQLSessionCatalogProvider) SupportsPostConnect() bool {
+	return core.SupportsPostConnect(p.Provider)
+}
+
+func (p *graphQLSessionCatalogProvider) PostConnect(ctx context.Context, token *core.IntegrationToken) (map[string]string, error) {
+	metadata, supported, err := core.PostConnect(ctx, p.Provider, token)
+	if !supported {
+		return nil, core.ErrPostConnectUnsupported
+	}
+	return metadata, err
+}
+
 func (p *graphQLSessionCatalogProvider) Execute(ctx context.Context, operation string, params map[string]any, token string) (*core.OperationResult, error) {
 	if _, ok := graphQLCatalogOperation(p.Catalog(), operation); ok {
 		return p.Provider.Execute(ctx, operation, params, token)

--- a/gestaltd/internal/bootstrap/graphql_session_provider_test.go
+++ b/gestaltd/internal/bootstrap/graphql_session_provider_test.go
@@ -5,11 +5,13 @@ import (
 	"encoding/json"
 	"net/http"
 	"net/http/httptest"
+	"reflect"
 	"strings"
 	"sync/atomic"
 	"testing"
 
 	"github.com/valon-technologies/gestalt/server/core"
+	"github.com/valon-technologies/gestalt/server/core/catalog"
 	"github.com/valon-technologies/gestalt/server/internal/config"
 	"github.com/valon-technologies/gestalt/server/internal/graphql"
 	"github.com/valon-technologies/gestalt/server/internal/provider"
@@ -121,6 +123,77 @@ func TestGraphQLSessionCatalogProviderLoadsCatalogOnDemand(t *testing.T) {
 	}
 	if got := executionCalls.Load(); got != 1 {
 		t.Fatalf("execution calls after Execute = %d, want 1", got)
+	}
+}
+
+type graphQLPostConnectProvider struct {
+	metadata map[string]string
+}
+
+func (p *graphQLPostConnectProvider) Name() string        { return "linear" }
+func (p *graphQLPostConnectProvider) DisplayName() string { return "Linear" }
+func (p *graphQLPostConnectProvider) Description() string { return "Linear provider" }
+func (p *graphQLPostConnectProvider) ConnectionMode() core.ConnectionMode {
+	return core.ConnectionModeUser
+}
+func (p *graphQLPostConnectProvider) AuthTypes() []string { return []string{"oauth"} }
+func (p *graphQLPostConnectProvider) ConnectionParamDefs() map[string]core.ConnectionParamDef {
+	return nil
+}
+func (p *graphQLPostConnectProvider) CredentialFields() []core.CredentialFieldDef { return nil }
+func (p *graphQLPostConnectProvider) DiscoveryConfig() *core.DiscoveryConfig      { return nil }
+func (p *graphQLPostConnectProvider) ConnectionForOperation(string) string        { return "" }
+func (p *graphQLPostConnectProvider) Catalog() *catalog.Catalog {
+	return &catalog.Catalog{Name: "linear"}
+}
+func (p *graphQLPostConnectProvider) Execute(_ context.Context, _ string, _ map[string]any, _ string) (*core.OperationResult, error) {
+	return &core.OperationResult{Status: http.StatusOK, Body: `{"ok":true}`}, nil
+}
+func (p *graphQLPostConnectProvider) InvokeGraphQL(_ context.Context, _ core.GraphQLRequest, _ string) (*core.OperationResult, error) {
+	return &core.OperationResult{Status: http.StatusOK, Body: `{"data":{}}`}, nil
+}
+func (p *graphQLPostConnectProvider) AuthorizationURL(state string, _ []string) string {
+	return "https://example.com/start?state=" + state
+}
+func (p *graphQLPostConnectProvider) ExchangeCode(_ context.Context, _ string) (*core.TokenResponse, error) {
+	return &core.TokenResponse{AccessToken: "access-token"}, nil
+}
+func (p *graphQLPostConnectProvider) RefreshToken(_ context.Context, _ string) (*core.TokenResponse, error) {
+	return &core.TokenResponse{AccessToken: "refreshed-token"}, nil
+}
+func (p *graphQLPostConnectProvider) PostConnect(_ context.Context, _ *core.IntegrationToken) (map[string]string, error) {
+	return p.metadata, nil
+}
+
+func TestGraphQLSessionCatalogProviderPreservesPostConnectCapability(t *testing.T) {
+	t.Parallel()
+
+	want := map[string]string{
+		"gestalt.external_identity.type": "slack_identity",
+		"gestalt.external_identity.id":   "team:T123:user:U456",
+	}
+	wrapped := wrapGraphQLSessionCatalogProvider(&graphQLPostConnectProvider{metadata: want}, "linear", "https://example.com/graphql", nil, nil)
+
+	if _, ok := wrapped.(core.OAuthProvider); !ok {
+		t.Fatal("expected wrapped provider to preserve oauth support")
+	}
+	if !core.SupportsPostConnect(wrapped) {
+		t.Fatal("expected wrapped provider to preserve post-connect support")
+	}
+
+	got, supported, err := core.PostConnect(context.Background(), wrapped, &core.IntegrationToken{
+		Integration: "slack",
+		Connection:  "default",
+		AccessToken: "tok",
+	})
+	if err != nil {
+		t.Fatalf("PostConnect: %v", err)
+	}
+	if !supported {
+		t.Fatal("expected core.PostConnect to report support")
+	}
+	if !reflect.DeepEqual(got, want) {
+		t.Fatalf("PostConnect metadata = %#v, want %#v", got, want)
 	}
 }
 

--- a/gestaltd/internal/composite/merged.go
+++ b/gestaltd/internal/composite/merged.go
@@ -165,6 +165,29 @@ func (m *MergedProvider) SupportsSessionCatalog() bool {
 	return false
 }
 
+func (m *MergedProvider) SupportsPostConnect() bool {
+	for _, provider := range m.owned {
+		if core.SupportsPostConnect(provider) {
+			return true
+		}
+	}
+	return false
+}
+
+func (m *MergedProvider) PostConnect(ctx context.Context, token *core.IntegrationToken) (map[string]string, error) {
+	for _, provider := range m.owned {
+		if !core.SupportsPostConnect(provider) {
+			continue
+		}
+		metadata, supported, err := core.PostConnect(ctx, provider, token)
+		if !supported {
+			continue
+		}
+		return metadata, err
+	}
+	return nil, core.ErrPostConnectUnsupported
+}
+
 func (m *MergedProvider) CatalogForRequest(ctx context.Context, token string) (*catalog.Catalog, error) {
 	if !m.SupportsSessionCatalog() {
 		return nil, core.WrapSessionCatalogUnsupported(fmt.Errorf("provider %q does not support session catalogs", m.Name()))

--- a/gestaltd/internal/composite/merged_test.go
+++ b/gestaltd/internal/composite/merged_test.go
@@ -3,6 +3,7 @@ package composite_test
 import (
 	"context"
 	"net/http"
+	"reflect"
 	"testing"
 
 	"github.com/valon-technologies/gestalt/server/core"
@@ -220,6 +221,93 @@ func TestMergedSessionCatalogRoutesDynamicOperation(t *testing.T) {
 	}
 	if !dynamicHit {
 		t.Fatal("expected dynamic session-backed provider to execute viewer")
+	}
+}
+
+func TestMergedPreservesPostConnectCapability(t *testing.T) {
+	t.Parallel()
+
+	want := map[string]string{
+		"gestalt.external_identity.type": "slack_identity",
+		"gestalt.external_identity.id":   "team:T123:user:U456",
+	}
+
+	merged, err := composite.NewMergedWithConnections("test", "Test", "desc", "",
+		composite.BoundProvider{Provider: &fakeProvider{name: "rest", ops: []core.Operation{{Name: "status"}}}},
+		composite.BoundProvider{Provider: &fakePostConnectProvider{
+			fakeProvider: &fakeProvider{name: "slack"},
+			metadata:     want,
+		}},
+	)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !core.SupportsPostConnect(merged) {
+		t.Fatal("expected merged provider to expose post-connect support")
+	}
+
+	got, supported, err := core.PostConnect(context.Background(), merged, &core.IntegrationToken{
+		Integration: "slack",
+		Connection:  "default",
+		AccessToken: "tok",
+	})
+	if err != nil {
+		t.Fatalf("PostConnect: %v", err)
+	}
+	if !supported {
+		t.Fatal("expected core.PostConnect to report support")
+	}
+	if !reflect.DeepEqual(got, want) {
+		t.Fatalf("PostConnect metadata = %#v, want %#v", got, want)
+	}
+}
+
+type falsePositivePostConnectProvider struct {
+	*fakeProvider
+}
+
+func (p *falsePositivePostConnectProvider) SupportsPostConnect() bool {
+	return false
+}
+
+func (p *falsePositivePostConnectProvider) PostConnect(_ context.Context, _ *core.IntegrationToken) (map[string]string, error) {
+	return nil, core.ErrPostConnectUnsupported
+}
+
+func TestMergedPostConnectSkipsProvidersThatAdvertiseNoSupport(t *testing.T) {
+	t.Parallel()
+
+	want := map[string]string{
+		"gestalt.external_identity.type": "slack_identity",
+		"gestalt.external_identity.id":   "team:T123:user:U456",
+	}
+
+	merged, err := composite.NewMergedWithConnections("test", "Test", "desc", "",
+		composite.BoundProvider{Provider: &falsePositivePostConnectProvider{
+			fakeProvider: &fakeProvider{name: "wrapper"},
+		}},
+		composite.BoundProvider{Provider: &fakePostConnectProvider{
+			fakeProvider: &fakeProvider{name: "slack"},
+			metadata:     want,
+		}},
+	)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	got, supported, err := core.PostConnect(context.Background(), merged, &core.IntegrationToken{
+		Integration: "slack",
+		Connection:  "default",
+		AccessToken: "tok",
+	})
+	if err != nil {
+		t.Fatalf("PostConnect: %v", err)
+	}
+	if !supported {
+		t.Fatal("expected core.PostConnect to report support")
+	}
+	if !reflect.DeepEqual(got, want) {
+		t.Fatalf("PostConnect metadata = %#v, want %#v", got, want)
 	}
 }
 

--- a/gestaltd/internal/composite/provider.go
+++ b/gestaltd/internal/composite/provider.go
@@ -128,6 +128,17 @@ func (p *Provider) DiscoveryConfig() *core.DiscoveryConfig {
 	return p.api.DiscoveryConfig()
 }
 
+func (p *Provider) SupportsPostConnect() bool {
+	return core.SupportsPostConnect(p.api)
+}
+
+func (p *Provider) PostConnect(ctx context.Context, token *core.IntegrationToken) (map[string]string, error) {
+	if pcp, ok := p.api.(core.PostConnectCapable); ok {
+		return pcp.PostConnect(ctx, token)
+	}
+	return nil, core.ErrPostConnectUnsupported
+}
+
 func (p *Provider) Close() error {
 	var firstErr error
 	if err := p.mcp.Close(); err != nil {

--- a/gestaltd/internal/composite/provider_session_test.go
+++ b/gestaltd/internal/composite/provider_session_test.go
@@ -3,6 +3,7 @@ package composite_test
 import (
 	"context"
 	"net/http"
+	"reflect"
 	"testing"
 
 	mcpgo "github.com/mark3labs/mcp-go/mcp"
@@ -107,5 +108,52 @@ func TestCompositeExecuteDelegatesDynamicAPISessionOperation(t *testing.T) {
 	}
 	if !dynamicHit {
 		t.Fatal("expected API provider to execute dynamic session-backed viewer operation")
+	}
+}
+
+type fakePostConnectProvider struct {
+	*fakeProvider
+	metadata map[string]string
+}
+
+func (p *fakePostConnectProvider) PostConnect(_ context.Context, _ *core.IntegrationToken) (map[string]string, error) {
+	return p.metadata, nil
+}
+
+func TestCompositePreservesPostConnectCapability(t *testing.T) {
+	t.Parallel()
+
+	api := &fakePostConnectProvider{
+		fakeProvider: &fakeProvider{name: "api"},
+		metadata: map[string]string{
+			"gestalt.external_identity.type": "slack_identity",
+			"gestalt.external_identity.id":   "team:T123:user:U456",
+		},
+	}
+	mcp := &fakeMCPUpstream{
+		fakeSessionProvider: &fakeSessionProvider{
+			fakeProvider: &fakeProvider{name: "mcp", connMode: core.ConnectionModeUser},
+			sessionCat:   &catalog.Catalog{Name: "test"},
+		},
+	}
+
+	prov := composite.New("test", api, mcp)
+	if !core.SupportsPostConnect(prov) {
+		t.Fatal("expected composite provider to expose post-connect support")
+	}
+
+	got, supported, err := core.PostConnect(context.Background(), prov, &core.IntegrationToken{
+		Integration: "slack",
+		Connection:  "default",
+		AccessToken: "tok",
+	})
+	if err != nil {
+		t.Fatalf("PostConnect: %v", err)
+	}
+	if !supported {
+		t.Fatal("expected core.PostConnect to report support")
+	}
+	if !reflect.DeepEqual(got, api.metadata) {
+		t.Fatalf("PostConnect metadata = %#v, want %#v", got, api.metadata)
 	}
 }


### PR DESCRIPTION
## Summary
This preserves `PostConnectCapable` across the host’s provider wrapper stack instead of only on the base provider.

That fixes Slack webhook subject resolution for connected Slack providers: when the host stores the OAuth token, it still runs the provider’s `post_connect` hook, persists the returned metadata, and AuthorizationProvider can resolve the incoming Slack user back to the invoking Gestalt `subject_id`.

## Wrappers Fixed
The following wrappers now preserve `SupportsPostConnect` / `PostConnect(...)`:
- `internal/composite.Provider`
- `internal/composite.MergedProvider`
- `core/integration.Restricted`
- `internal/bootstrap.connectedProvider`
- `internal/bootstrap.connectedSessionCatalogProvider`
- `internal/bootstrap.connectedGraphQLProvider`
- `internal/bootstrap.connectedOAuthProvider`
- `internal/bootstrap.graphQLSessionCatalogProvider`

## Behavior
Before:
- wrapper composition preserved OAuth and session-catalog behavior
- but some wrappers dropped `PostConnectCapable`
- `core.SupportsPostConnect(prov)` returned `false`
- `runPostConnect(...)` skipped provider post-connect
- stored `integration_tokens.metadata_json` stayed empty
- Slack webhook subject resolution returned `403`

After:
- wrapper composition preserves `PostConnectCapable`
- `runPostConnect(...)` still executes after OAuth/manual connect
- stored tokens keep provider-derived metadata
- Slack webhook routes can resolve the correct `subject_id`

## Interface
Wrappers now preserve this optional provider capability end to end:

```go
type PostConnectCapable interface {
    PostConnect(ctx context.Context, token *IntegrationToken) (map[string]string, error)
}
```

And the host can safely continue using:

```go
if core.SupportsPostConnect(prov) {
    metadata, _, err := core.PostConnect(ctx, prov, token)
    if err != nil {
        return err
    }
    // persist metadata into integration_tokens.metadata_json
}
```

## Slack Example
This is what the Slack provider returns from `post_connect`:

```json
{
  "gestalt.external_identity.type": "slack_identity",
  "gestalt.external_identity.id": "team:T123:user:U456"
}
```

That metadata is what lets an incoming Slack webhook event resolve the Slack user back to the connected Gestalt subject.

## Validation
```bash
go test ./internal/composite ./core/integration
go test ./internal/bootstrap -run 'TestBindProviderConnectionPreservesPostConnectCapability|TestGraphQLSessionCatalogProviderLoadsCatalogOnDemand|TestGraphQLSessionCatalogProviderPreservesPostConnectCapability'
go test ./internal/server -run 'TestConnectManual|TestOAuthCallback_UsesStateConnection'
```
