### PR TITLE
[codex] agent runs: default safe tools and standardize input

### DIFF
--- a/docs/content/client/cli/index.mdx
+++ b/docs/content/client/cli/index.mdx
@@ -208,7 +208,6 @@ gestalt agent runs create \
   --model gpt-5.4 \
   --system "Be concise." \
   --message "Summarize the roadmap risk." \
-  --tool roadmap:sync \
   --idempotency-key agent-run-1
 
 gestalt agent runs list --provider managed --status running
@@ -217,12 +216,20 @@ gestalt agent runs cancel <run-id> --reason "operator requested"
 gestalt agent runs events list <run-id> --after 0 --limit 100
 gestalt agent runs events stream <run-id> --after 100
 
-# advanced fields such as responseSchema, metadata, or providerOptions
-# go through --request-file, which also accepts "-" for stdin:
-cat <<'JSON' | gestalt --format json agent runs create --request-file -
+# by default, global agent runs get the caller's authorized safe tool set.
+# use --tool to add a specific tool beyond that default:
+gestalt agent runs create \
+  --provider managed \
+  --message "Summarize the roadmap risk." \
+  --tool roadmap:push
+
+# advanced fields such as responseSchema, metadata, or explicit-only tool mode
+# go through --input, which also accepts "-" for stdin:
+cat <<'JSON' | gestalt --format json agent runs create --input -
 {
   "provider": "managed",
   "model": "gpt-5.4",
+  "toolSource": "explicit",
   "sessionRef": "session-1",
   "messages": [
     {"role": "user", "text": "Summarize the roadmap risk."}
@@ -243,8 +250,9 @@ JSON
 
 `gestalt agent runs create` supports repeated `--system`, repeated `--message`,
 repeated `--tool plugin:operation`, `--session-ref`, `--idempotency-key`, and
-`--request-file`. Use `--format json` when you want the raw HTTP response shape
-instead of the default table view.
+`--input`. When you omit `--tool`, global runs attach the caller's authorized
+safe tool set by default. Use `--format json` when you want the raw HTTP
+response shape instead of the default table view.
 
 `gestalt agent runs events list` reads stored events from
 `GET /api/v1/agent/runs/{runID}/events`. `--after` is an event sequence cursor

--- a/docs/content/providers/agent.mdx
+++ b/docs/content/providers/agent.mdx
@@ -104,9 +104,6 @@ The neutral agent run shape is intentionally small:
     { "role": "system", "text": "Be concise." },
     { "role": "user", "text": "Summarize the roadmap risk." }
   ],
-  "toolRefs": [
-    { "pluginName": "roadmap", "operation": "sync" }
-  ],
   "responseSchema": {
     "type": "object",
     "properties": {
@@ -117,6 +114,10 @@ The neutral agent run shape is intentionally small:
   "sessionRef": "session-123"
 }
 ```
+
+For global runs, omitting `toolRefs` lets Gestalt attach the caller's
+authorized safe tools by default. Add `toolRefs` to extend that set, or set
+`toolSource: "explicit"` when you need explicit-only tools.
 
 ## First-party agent providers
 

--- a/docs/content/reference/http-api.mdx
+++ b/docs/content/reference/http-api.mdx
@@ -74,13 +74,16 @@ Authenticated routes accept a `session_token` cookie or an `Authorization: Beare
 | `GET` | `/api/v1/agent/runs/{runID}/events` | List stored events for one agent run. Supports optional `after` sequence cursor and `limit`. |
 | `GET` | `/api/v1/agent/runs/{runID}/events/stream` | Stream agent run events as server-sent events. Supports optional `after` sequence cursor and `limit`. |
 
-Agent run creation accepts `provider`, `model`, `messages`, `toolRefs`,
-optional `toolSource`, optional `responseSchema`, optional `sessionRef`,
-optional `metadata`, optional `providerOptions`, and optional
-`idempotencyKey`. Missing `toolRefs[].pluginName` or `toolRefs[].operation`
-returns `400`. Conflicting header/body idempotency keys also return `400`, an
-in-progress idempotent create returns `409`, and an unconfigured agent surface
-returns `412`.
+Agent run creation accepts `provider`, `model`, `messages`, optional
+`toolRefs`, optional `toolSource`, optional `responseSchema`, optional
+`sessionRef`, optional `metadata`, optional `providerOptions`, and optional
+`idempotencyKey`. When `toolSource` is omitted on a global run, Gestalt
+attaches the caller's authorized safe tools by default and treats `toolRefs` as
+additive. Set `toolSource` to `explicit` to opt into explicit-only tools.
+Missing `toolRefs[].pluginName` or `toolRefs[].operation` returns `400`.
+Conflicting header/body idempotency keys also return `400`, an in-progress
+idempotent create returns `409`, and an unconfigured agent surface returns
+`412`.
 
 ### API Tokens
 
@@ -223,10 +226,6 @@ curl -X POST http://localhost:8080/api/v1/agent/runs \
       {"role": "system", "text": "Be concise."},
       {"role": "user", "text": "Summarize the roadmap risk."}
     ],
-    "toolRefs": [
-      {"pluginName": "roadmap", "operation": "sync"}
-    ],
-    "toolSource": "explicit",
     "responseSchema": {
       "type": "object",
       "properties": {
@@ -238,6 +237,21 @@ curl -X POST http://localhost:8080/api/v1/agent/runs \
     "metadata": {
       "ticket": "RD-42"
     }
+  }'
+
+# Create an explicit-only agent run
+curl -X POST http://localhost:8080/api/v1/agent/runs \
+  -H 'Authorization: Bearer gst_api_...' \
+  -H 'Content-Type: application/json' \
+  -d '{
+    "provider": "managed",
+    "messages": [
+      {"role": "user", "text": "Summarize the roadmap risk."}
+    ],
+    "toolSource": "explicit",
+    "toolRefs": [
+      {"pluginName": "roadmap", "operation": "sync"}
+    ]
   }'
 
 # Inspect a run

--- a/gestalt/cli/src/cli.rs
+++ b/gestalt/cli/src/cli.rs
@@ -458,7 +458,7 @@ pub struct AgentRunCreateArgs {
     #[arg(long = "message")]
     pub messages: Vec<String>,
 
-    /// Attach a tool reference in plugin:operation form
+    /// Add a tool beyond the default safe tool set in plugin:operation form
     #[arg(long = "tool", value_parser = AgentToolArg::parse)]
     pub tools: Vec<AgentToolArg>,
 
@@ -471,8 +471,8 @@ pub struct AgentRunCreateArgs {
     pub idempotency_key: Option<String>,
 
     /// Load the JSON request body from a file (use "-" for stdin)
-    #[arg(long = "request-file")]
-    pub request_file: Option<String>,
+    #[arg(long = "input", alias = "request-file")]
+    pub input: Option<String>,
 }
 
 #[derive(Args)]

--- a/gestalt/cli/src/commands/agents.rs
+++ b/gestalt/cli/src/commands/agents.rs
@@ -80,7 +80,7 @@ pub fn stream_run_events(client: &ApiClient, args: &AgentRunEventStreamArgs) -> 
 }
 
 fn build_create_body(args: &AgentRunCreateArgs) -> Result<Value> {
-    let mut body = match args.request_file.as_deref() {
+    let mut body = match args.input.as_deref() {
         Some(path) => params::load_input_file(path)?,
         None => Map::new(),
     };
@@ -126,7 +126,7 @@ fn validate_create_body(body: &Map<String, Value>) -> Result<()> {
         .is_some_and(|messages| !messages.is_empty());
     if !has_messages {
         bail!(
-            "agent runs create requires at least one message; pass --message, --system, or --request-file with a non-empty messages array"
+            "agent runs create requires at least one message; pass --message, --system, or --input with a non-empty messages array"
         );
     }
     Ok(())

--- a/gestalt/cli/tests/agents_cli.rs
+++ b/gestalt/cli/tests/agents_cli.rs
@@ -57,9 +57,6 @@ fn test_cli_creates_agent_run() {
                 "messages":[
                     {"role":"system","text":"Be concise."},
                     {"role":"user","text":"Summarize the roadmap risk."}
-                ],
-                "toolRefs":[
-                    {"pluginName":"roadmap","operation":"sync"}
                 ]
             }"#
         .to_string(),
@@ -81,8 +78,6 @@ fn test_cli_creates_agent_run() {
             "Be concise.",
             "--message",
             "Summarize the roadmap risk.",
-            "--tool",
-            "roadmap:sync",
             "--idempotency-key",
             "agent-create-1",
         ])
@@ -93,7 +88,7 @@ fn test_cli_creates_agent_run() {
 }
 
 #[test]
-fn test_cli_creates_agent_run_from_request_file() {
+fn test_cli_creates_agent_run_from_input() {
     let request_json = r#"{
         "provider":"managed",
         "model":"gpt-5.4",
@@ -141,7 +136,7 @@ fn test_cli_creates_agent_run_from_request_file() {
             "agent",
             "runs",
             "create",
-            "--request-file",
+            "--input",
             request_path.to_str().unwrap(),
         ])
         .assert()

--- a/gestaltd/internal/agentmanager/manager.go
+++ b/gestaltd/internal/agentmanager/manager.go
@@ -449,23 +449,18 @@ func (m *Manager) resolveTools(ctx context.Context, p *principal.Principal, call
 			})
 		}
 	}
-	if len(refs) == 0 {
-		return nil, nil
+	explicitTools, err := m.resolveExplicitTools(ctx, p, refs)
+	if err != nil {
+		return nil, err
 	}
-	out := make([]coreagent.Tool, 0, len(refs))
-	seen := make(map[string]struct{}, len(refs))
-	for _, ref := range refs {
-		tool, err := m.resolveTool(ctx, p, ref)
-		if err != nil {
-			return nil, err
-		}
-		if _, ok := seen[tool.ID]; ok {
-			continue
-		}
-		seen[tool.ID] = struct{}{}
-		out = append(out, tool)
+	if source != coreagent.ToolSourceModeUnspecified || strings.TrimSpace(callerPluginName) != "" {
+		return explicitTools, nil
 	}
-	return out, nil
+	defaultTools := m.resolveDefaultTools(ctx, p)
+	if len(defaultTools) == 0 {
+		return explicitTools, nil
+	}
+	return mergeTools(explicitTools, defaultTools), nil
 }
 
 func (m *Manager) resolveTool(ctx context.Context, p *principal.Principal, ref coreagent.ToolRef) (coreagent.Tool, error) {
@@ -571,6 +566,174 @@ func (m *Manager) resolveTool(ctx context.Context, p *principal.Principal, ref c
 			Instance:   sessionInstance,
 		},
 	}, nil
+}
+
+func (m *Manager) resolveExplicitTools(ctx context.Context, p *principal.Principal, refs []coreagent.ToolRef) ([]coreagent.Tool, error) {
+	if len(refs) == 0 {
+		return nil, nil
+	}
+	out := make([]coreagent.Tool, 0, len(refs))
+	seen := make(map[string]struct{}, len(refs))
+	for _, ref := range refs {
+		tool, err := m.resolveTool(ctx, p, ref)
+		if err != nil {
+			return nil, err
+		}
+		if _, ok := seen[tool.ID]; ok {
+			continue
+		}
+		seen[tool.ID] = struct{}{}
+		out = append(out, tool)
+	}
+	return out, nil
+}
+
+func (m *Manager) resolveDefaultTools(ctx context.Context, p *principal.Principal) []coreagent.Tool {
+	if m == nil || m.providers == nil {
+		return nil
+	}
+	out := make([]coreagent.Tool, 0, 8)
+	for _, providerName := range m.providers.List() {
+		if !m.allowProvider(ctx, p, providerName) {
+			continue
+		}
+		providerTools, err := m.resolveDefaultToolsForProvider(ctx, p, providerName)
+		if err != nil {
+			continue
+		}
+		out = append(out, providerTools...)
+	}
+	return out
+}
+
+func (m *Manager) resolveDefaultToolsForProvider(ctx context.Context, p *principal.Principal, providerName string) ([]coreagent.Tool, error) {
+	prov, err := m.providers.Get(providerName)
+	if err != nil {
+		return nil, err
+	}
+	connection, instance, cat, ok := m.resolveDefaultToolCatalog(ctx, p, providerName, prov)
+	if !ok || cat == nil {
+		return nil, nil
+	}
+
+	out := make([]coreagent.Tool, 0, len(cat.Operations))
+	for i := range cat.Operations {
+		op := &cat.Operations[i]
+		if !defaultToolAllowed(*op) {
+			continue
+		}
+		if !m.allowOperation(ctx, p, providerName, op.ID) {
+			continue
+		}
+		if !principal.AllowsOperationPermission(p, providerName, op.ID) {
+			continue
+		}
+		if m.authorizer != nil && !m.authorizer.AllowCatalogOperation(ctx, p, providerName, *op) {
+			continue
+		}
+
+		tool, err := m.resolveTool(ctx, p, coreagent.ToolRef{
+			PluginName: providerName,
+			Operation:  op.ID,
+			Connection: connection,
+			Instance:   instance,
+		})
+		if err != nil {
+			continue
+		}
+		out = append(out, tool)
+	}
+	return out, nil
+}
+
+func (m *Manager) resolveDefaultToolCatalog(ctx context.Context, p *principal.Principal, providerName string, prov core.Provider) (string, string, *catalog.Catalog, bool) {
+	ctx = invocation.WithAccessContext(ctx, m.providerAccessContext(ctx, p, providerName))
+	resolver, _ := m.invoker.(invocation.TokenResolver)
+	bindingResolver, _ := m.invoker.(invocation.EffectiveCredentialBindingResolver)
+	requiresCredential := core.NormalizeConnectionMode(prov.ConnectionMode()) != core.ConnectionModeNone
+	targets := m.catalogSelectorConfig().BoundSessionCatalogTargets(providerName, p, "", "")
+	if len(targets) == 0 {
+		targets = []invocation.CatalogResolutionTarget{{}}
+	}
+	for _, target := range targets {
+		connection := strings.TrimSpace(target.Connection)
+		instance := strings.TrimSpace(target.Instance)
+		boundCredential := invocation.CredentialBindingResolution{}
+		if bindingResolver != nil {
+			resolvedBinding, err := bindingResolver.ResolveEffectiveCredentialBinding(p, providerName, connection, instance)
+			if err != nil {
+				continue
+			}
+			boundCredential = resolvedBinding
+		}
+
+		catalogCtx := ctx
+		if requiresCredential {
+			if resolver == nil {
+				continue
+			}
+			resolvedCtx, _, err := invocation.ResolveTokenForBinding(ctx, resolver, p, providerName, connection, instance, boundCredential)
+			if err != nil {
+				continue
+			}
+			cred := invocation.CredentialContextFromContext(resolvedCtx)
+			if cred.Connection != "" {
+				connection = cred.Connection
+			}
+			if cred.Instance != "" {
+				instance = cred.Instance
+			}
+			catalogCtx = resolvedCtx
+		}
+
+		var cat *catalog.Catalog
+		var err error
+		if requiresCredential {
+			cat, _, err = invocation.ResolveCatalogStrictWithMetadata(catalogCtx, prov, providerName, resolver, p, connection, instance)
+		} else {
+			cat, _, err = invocation.ResolveCatalogWithMetadata(catalogCtx, prov, providerName, resolver, p, connection, instance)
+		}
+		if err != nil || cat == nil {
+			continue
+		}
+		return connection, instance, cat, true
+	}
+	return "", "", nil, false
+}
+
+func defaultToolAllowed(op catalog.CatalogOperation) bool {
+	if op.Visible != nil && !*op.Visible {
+		return false
+	}
+	if op.Annotations.DestructiveHint != nil && *op.Annotations.DestructiveHint {
+		return false
+	}
+	if op.ReadOnly {
+		return true
+	}
+	return op.Annotations.ReadOnlyHint != nil && *op.Annotations.ReadOnlyHint
+}
+
+func mergeTools(groups ...[]coreagent.Tool) []coreagent.Tool {
+	total := 0
+	for _, group := range groups {
+		total += len(group)
+	}
+	if total == 0 {
+		return nil
+	}
+	out := make([]coreagent.Tool, 0, total)
+	seen := make(map[string]struct{}, total)
+	for _, group := range groups {
+		for _, tool := range group {
+			if _, ok := seen[tool.ID]; ok {
+				continue
+			}
+			seen[tool.ID] = struct{}{}
+			out = append(out, tool)
+		}
+	}
+	return out
 }
 
 func (m *Manager) allowProvider(ctx context.Context, p *principal.Principal, provider string) bool {

--- a/gestaltd/internal/providerhost/process.go
+++ b/gestaltd/internal/providerhost/process.go
@@ -25,7 +25,7 @@ import (
 )
 
 const (
-	processStartupTimeout  = 20 * time.Second
+	processStartupTimeout  = 45 * time.Second
 	processShutdownTimeout = 2 * time.Second
 	processStartRetryCount = 5
 	processStartRetryDelay = 100 * time.Millisecond

--- a/gestaltd/internal/server/agent_run_test.go
+++ b/gestaltd/internal/server/agent_run_test.go
@@ -17,8 +17,11 @@ import (
 	proto "github.com/valon-technologies/gestalt/sdk/go/gen/v1"
 	"github.com/valon-technologies/gestalt/server/core"
 	coreagent "github.com/valon-technologies/gestalt/server/core/agent"
+	"github.com/valon-technologies/gestalt/server/core/catalog"
 	coretesting "github.com/valon-technologies/gestalt/server/core/testing"
 	"github.com/valon-technologies/gestalt/server/internal/agentmanager"
+	"github.com/valon-technologies/gestalt/server/internal/config"
+	"github.com/valon-technologies/gestalt/server/internal/invocation"
 	"github.com/valon-technologies/gestalt/server/internal/principal"
 	"github.com/valon-technologies/gestalt/server/internal/providerhost"
 	"github.com/valon-technologies/gestalt/server/internal/server"
@@ -168,6 +171,23 @@ func (p *memoryAgentProvider) CancelRun(_ context.Context, req coreagent.CancelR
 func (p *memoryAgentProvider) Ping(context.Context) error { return nil }
 func (p *memoryAgentProvider) Close() error               { return nil }
 
+type stubAgentToolInvoker struct {
+	tokens map[string]string
+}
+
+func (s *stubAgentToolInvoker) Invoke(context.Context, *principal.Principal, string, string, string, map[string]any) (*core.OperationResult, error) {
+	return nil, nil
+}
+
+func (s *stubAgentToolInvoker) ResolveToken(ctx context.Context, _ *principal.Principal, providerName, _, _ string) (context.Context, string, error) {
+	if s != nil && s.tokens != nil {
+		if token, ok := s.tokens[providerName]; ok {
+			return ctx, token, nil
+		}
+	}
+	return ctx, "", core.ErrNotFound
+}
+
 func cloneAgentRun(run *coreagent.Run) *coreagent.Run {
 	if run == nil {
 		return nil
@@ -208,9 +228,33 @@ func TestGlobalAgentRunLifecycleSupportsCreateListGetAndCancel(t *testing.T) {
 	services := coretesting.NewStubServices(t)
 	user := seedUser(t, services, "ada@example.test")
 	provider := newMemoryAgentProvider()
+	roadmapProvider := &coretesting.StubIntegration{
+		N:        "roadmap",
+		DN:       "Roadmap",
+		ConnMode: core.ConnectionModeUser,
+		CatalogVal: &catalog.Catalog{
+			Name: "roadmap",
+			Operations: []catalog.CatalogOperation{
+				{ID: "sync", Method: http.MethodGet, Path: "/sync"},
+				{ID: "push", Method: http.MethodPost, Path: "/push"},
+			},
+		},
+	}
+	slackProvider := &coretesting.StubIntegration{
+		N:        "slack",
+		DN:       "Slack",
+		ConnMode: core.ConnectionModeUser,
+		CatalogVal: &catalog.Catalog{
+			Name: "slack",
+			Operations: []catalog.CatalogOperation{
+				{ID: "users.profile.get", Method: http.MethodGet, Path: "/users.profile.get"},
+			},
+		},
+	}
 	manager := agentmanager.New(agentmanager.Config{
-		Providers:   testutil.NewProviderRegistry(t),
+		Providers:   testutil.NewProviderRegistry(t, roadmapProvider, slackProvider),
 		Agent:       &stubAgentControl{defaultProviderName: "managed", provider: provider},
+		Invoker:     &stubAgentToolInvoker{tokens: map[string]string{"roadmap": "roadmap-token"}},
 		RunMetadata: services.AgentRunMetadata,
 		RunEvents:   services.AgentRunEvents,
 	})
@@ -277,6 +321,11 @@ func TestGlobalAgentRunLifecycleSupportsCreateListGetAndCancel(t *testing.T) {
 	}
 	if got := provider.startRunRequests[0].IdempotencyKey; got != "agent-http-create-1" {
 		t.Fatalf("StartRun idempotency key = %q, want %q", got, "agent-http-create-1")
+	}
+	if got := provider.startRunRequests[0].Tools; len(got) != 1 {
+		t.Fatalf("StartRun tools = %#v, want one default safe tool", got)
+	} else if got[0].Target.PluginName != "roadmap" || got[0].Target.Operation != "sync" {
+		t.Fatalf("StartRun default tool = %#v, want roadmap.sync", got[0])
 	}
 	startedData, err := structpb.NewStruct(map[string]any{"status": "running"})
 	if err != nil {
@@ -571,6 +620,180 @@ func TestGlobalAgentRunProviderAvailabilityFailuresArePreconditionFailures(t *te
 	}
 	if len(events) != 1 || events[0].RunID != "run-managed" || events[0].Source != "managed" {
 		t.Fatalf("events = %#v, want stored managed event", events)
+	}
+}
+
+func TestGlobalAgentRunDefaultToolsUseAccessScopedSessionCatalog(t *testing.T) {
+	t.Parallel()
+
+	services := coretesting.NewStubServices(t)
+	user := seedUser(t, services, "viewer-user@test.local")
+	seedToken(t, services, &core.IntegrationToken{
+		ID:          "tok-cat-human",
+		SubjectID:   principal.UserSubjectID(user.ID),
+		Integration: "test-int",
+		Connection:  testCatalogConnection,
+		Instance:    "default",
+		AccessToken: testCatalogToken,
+	})
+
+	var seenAccess invocation.AccessContext
+	provider := newMemoryAgentProvider()
+	sessionProvider := &stubIntegrationWithSessionCatalog{
+		stubIntegrationWithOps: stubIntegrationWithOps{
+			StubIntegration: coretesting.StubIntegration{N: "test-int", ConnMode: core.ConnectionModeUser},
+		},
+		catalog: &catalog.Catalog{Name: "test-int"},
+		catalogForRequestFn: func(ctx context.Context, token string) (*catalog.Catalog, error) {
+			if token != testCatalogToken {
+				return nil, errors.New("unexpected token")
+			}
+			seenAccess = invocation.AccessContextFromContext(ctx)
+			switch seenAccess.Role {
+			case "viewer":
+				return &catalog.Catalog{
+					Name: "test-int",
+					Operations: []catalog.CatalogOperation{
+						{ID: "viewer_session", Method: http.MethodGet, Path: "/viewer", AllowedRoles: []string{"viewer"}},
+					},
+				}, nil
+			default:
+				return &catalog.Catalog{
+					Name: "test-int",
+					Operations: []catalog.CatalogOperation{
+						{ID: "public_session", Method: http.MethodGet, Path: "/public"},
+					},
+				}, nil
+			}
+		},
+	}
+
+	providers := testutil.NewProviderRegistry(t, sessionProvider)
+	pluginDefs := map[string]*config.ProviderEntry{
+		"test-int": {AuthorizationPolicy: "sample_policy"},
+	}
+	authz := mustAuthorizer(t, config.AuthorizationConfig{
+		Policies: map[string]config.HumanPolicyDef{
+			"sample_policy": {
+				Default: "deny",
+				Members: []config.HumanPolicyMemberDef{
+					{SubjectID: principal.UserSubjectID(user.ID), Role: "viewer"},
+				},
+			},
+		},
+	}, providers, pluginDefs, map[string]string{"test-int": testCatalogConnection})
+	broker := invocation.NewBroker(providers, services.Users, services.Tokens, invocation.WithAuthorizer(authz))
+	manager := agentmanager.New(agentmanager.Config{
+		Providers:         providers,
+		Agent:             &stubAgentControl{defaultProviderName: "managed", provider: provider},
+		Invoker:           broker,
+		Authorizer:        authz,
+		CatalogConnection: map[string]string{"test-int": testCatalogConnection},
+		RunMetadata:       services.AgentRunMetadata,
+	})
+
+	ts := newTestServer(t, func(cfg *server.Config) {
+		cfg.Auth = &coretesting.StubAuthProvider{
+			N: "stub",
+			ValidateTokenFn: func(_ context.Context, token string) (*core.UserIdentity, error) {
+				if token != "viewer-session" {
+					return nil, core.ErrNotFound
+				}
+				return &core.UserIdentity{Email: user.Email, DisplayName: "Viewer"}, nil
+			},
+		}
+		cfg.Services = services
+		cfg.AgentManager = manager
+		cfg.Authorizer = authz
+		cfg.PluginDefs = pluginDefs
+		cfg.CatalogConnection = map[string]string{"test-int": testCatalogConnection}
+	})
+	testutil.CloseOnCleanup(t, ts)
+
+	req, _ := http.NewRequest(http.MethodPost, ts.URL+"/api/v1/agent/runs/", bytes.NewBufferString(`{
+		"messages":[{"role":"user","text":"Summarize the roadmap risk."}]
+	}`))
+	req.Header.Set("Content-Type", "application/json")
+	req.AddCookie(&http.Cookie{Name: "session_token", Value: "viewer-session"})
+	resp, err := http.DefaultClient.Do(req)
+	if err != nil {
+		t.Fatalf("create request: %v", err)
+	}
+	defer func() { _ = resp.Body.Close() }()
+	if resp.StatusCode != http.StatusCreated {
+		t.Fatalf("expected 201, got %d", resp.StatusCode)
+	}
+	if len(provider.startRunRequests) != 1 {
+		t.Fatalf("StartRun count = %d, want 1", len(provider.startRunRequests))
+	}
+	if got := provider.startRunRequests[0].Tools; len(got) != 1 {
+		t.Fatalf("StartRun tools = %#v, want one access-scoped default tool", got)
+	} else if got[0].Target.PluginName != "test-int" || got[0].Target.Operation != "viewer_session" {
+		t.Fatalf("StartRun default tool = %#v, want test-int.viewer_session", got[0])
+	}
+	if seenAccess.Policy != "sample_policy" || seenAccess.Role != "viewer" {
+		t.Fatalf("session catalog access context = %+v, want sample_policy/viewer", seenAccess)
+	}
+}
+
+func TestGlobalAgentRunCreateExplicitToolSourceSkipsDefaultTools(t *testing.T) {
+	t.Parallel()
+
+	services := coretesting.NewStubServices(t)
+	user := seedUser(t, services, "ada@example.test")
+	provider := newMemoryAgentProvider()
+	roadmapProvider := &coretesting.StubIntegration{
+		N:        "roadmap",
+		DN:       "Roadmap",
+		ConnMode: core.ConnectionModeUser,
+		CatalogVal: &catalog.Catalog{
+			Name: "roadmap",
+			Operations: []catalog.CatalogOperation{
+				{ID: "sync", Method: http.MethodGet, Path: "/sync"},
+			},
+		},
+	}
+	manager := agentmanager.New(agentmanager.Config{
+		Providers:   testutil.NewProviderRegistry(t, roadmapProvider),
+		Agent:       &stubAgentControl{defaultProviderName: "managed", provider: provider},
+		Invoker:     &stubAgentToolInvoker{tokens: map[string]string{"roadmap": "roadmap-token"}},
+		RunMetadata: services.AgentRunMetadata,
+	})
+
+	ts := newTestServer(t, func(cfg *server.Config) {
+		cfg.Auth = &coretesting.StubAuthProvider{
+			N: "stub",
+			ValidateTokenFn: func(_ context.Context, token string) (*core.UserIdentity, error) {
+				if token != "ada-session" {
+					return nil, core.ErrNotFound
+				}
+				return &core.UserIdentity{Email: user.Email, DisplayName: "Ada"}, nil
+			},
+		}
+		cfg.Services = services
+		cfg.AgentManager = manager
+	})
+	testutil.CloseOnCleanup(t, ts)
+
+	req, _ := http.NewRequest(http.MethodPost, ts.URL+"/api/v1/agent/runs/", bytes.NewBufferString(`{
+		"messages":[{"role":"user","text":"Summarize the roadmap risk."}],
+		"toolSource":"explicit"
+	}`))
+	req.Header.Set("Content-Type", "application/json")
+	req.AddCookie(&http.Cookie{Name: "session_token", Value: "ada-session"})
+	resp, err := http.DefaultClient.Do(req)
+	if err != nil {
+		t.Fatalf("create request: %v", err)
+	}
+	defer func() { _ = resp.Body.Close() }()
+	if resp.StatusCode != http.StatusCreated {
+		t.Fatalf("expected 201, got %d", resp.StatusCode)
+	}
+	if len(provider.startRunRequests) != 1 {
+		t.Fatalf("StartRun count = %d, want 1", len(provider.startRunRequests))
+	}
+	if got := provider.startRunRequests[0].Tools; len(got) != 0 {
+		t.Fatalf("StartRun tools = %#v, want none in explicit mode", got)
 	}
 }
 


### PR DESCRIPTION
## What changed

This PR removes the need to explicitly list platform tools for normal global agent runs.

- global `POST /api/v1/agent/runs` now defaults to the caller's authorized safe tools when `toolSource` is omitted
- `toolRefs` stay additive in that default mode
- `toolSource: "explicit"` still forces explicit-only tools
- the CLI now prefers the OSS-standard `--input` escape hatch for raw JSON bodies
- default tool resolution now carries provider access context into session catalog resolution so role-scoped catalogs stay correct
- CLI and HTTP docs now show the defaulted flow first, with the explicit-only override as the advanced path

## Why it changed

The previous UX required `--tool` or a bespoke `--request-file` flow even when the platform already knew the caller's identity, authorization, and connected integrations. That made common cases worse than the underlying architecture required.

The backend already stores a concrete per-run tool allowlist. This change keeps that runtime contract, but changes the default policy for global runs to populate that allowlist automatically from authorized safe tools.

## New interfaces

CLI:

```sh
gestalt agent runs create --provider managed --message "Summarize the roadmap risk."

gestalt agent runs create \
  --provider managed \
  --message "Summarize the roadmap risk." \
  --tool roadmap:push

cat request.json | gestalt --format json agent runs create --input -
```

HTTP API:

```sh
curl -X POST http://localhost:8080/api/v1/agent/runs \
  -H 'Content-Type: application/json' \
  -d '{
    "provider": "managed",
    "messages": [{"role": "user", "text": "Summarize the roadmap risk."}]
  }'

curl -X POST http://localhost:8080/api/v1/agent/runs \
  -H 'Content-Type: application/json' \
  -d '{
    "provider": "managed",
    "toolSource": "explicit",
    "toolRefs": [{"pluginName": "roadmap", "operation": "sync"}],
    "messages": [{"role": "user", "text": "Summarize the roadmap risk."}]
  }'
```

## Validation

- `go test ./internal/server -run 'TestGlobalAgentRunLifecycleSupportsCreateListGetAndCancel|TestGlobalAgentRunDefaultToolsUseAccessScopedSessionCatalog|TestGlobalAgentRunCreateExplicitToolSourceSkipsDefaultTools'`
- `cargo test -p gestalt --test agents_cli`

## Notes

The default tool set is intentionally the caller's authorized safe tools, not every available tool. The stored run contract still uses a fully resolved per-run tool list, so provider/runtime behavior stays explicit and reproducible.
