### PR TITLE
bootstrap: pass raw config to runtime providers

### DIFF
--- a/gestaltd/internal/bootstrap/plugin_runtime_executable.go
+++ b/gestaltd/internal/bootstrap/plugin_runtime_executable.go
@@ -7,6 +7,7 @@ import (
 
 	"github.com/valon-technologies/gestalt/server/internal/config"
 	"github.com/valon-technologies/gestalt/server/internal/pluginruntime"
+	"gopkg.in/yaml.v3"
 )
 
 func buildExecutablePluginRuntime(ctx context.Context, name string, entry *config.RuntimeProviderEntry, deps Deps) (pluginruntime.Provider, error) {
@@ -14,20 +15,9 @@ func buildExecutablePluginRuntime(ctx context.Context, name string, entry *confi
 		return nil, fmt.Errorf("runtime provider entry is required")
 	}
 
-	configNode := entry.Config
-	if !config.IsComponentRuntimeConfigNode(configNode) {
-		var err error
-		configNode, err = config.BuildComponentRuntimeConfigNode(name, "runtime", &entry.ProviderEntry, entry.Config)
-		if err != nil {
-			return nil, fmt.Errorf("runtime provider %q: %w", name, err)
-		}
-	}
-
-	runtimeConfig := map[string]any{}
-	if configNode.Kind != 0 {
-		if err := configNode.Decode(&runtimeConfig); err != nil {
-			return nil, fmt.Errorf("decode runtime provider %q config: %w", name, err)
-		}
+	runtimeConfig, err := runtimeProviderConfigMap(name, entry)
+	if err != nil {
+		return nil, err
 	}
 
 	return pluginruntime.NewExecutableProvider(ctx, pluginruntime.ExecutableConfig{
@@ -40,4 +30,30 @@ func buildExecutablePluginRuntime(ctx context.Context, name string, entry *confi
 		HostBinary:   entry.HostBinary,
 		Telemetry:    deps.Telemetry,
 	})
+}
+
+func runtimeProviderConfigMap(name string, entry *config.RuntimeProviderEntry) (map[string]any, error) {
+	if entry == nil {
+		return nil, fmt.Errorf("runtime provider entry is required")
+	}
+
+	configNode := entry.Config
+	if config.IsComponentRuntimeConfigNode(configNode) {
+		var wrapped struct {
+			Config yaml.Node `yaml:"config,omitempty"`
+		}
+		if err := configNode.Decode(&wrapped); err != nil {
+			return nil, fmt.Errorf("decode wrapped runtime provider %q config: %w", name, err)
+		}
+		configNode = wrapped.Config
+	}
+
+	runtimeConfig := map[string]any{}
+	if configNode.Kind == 0 {
+		return runtimeConfig, nil
+	}
+	if err := configNode.Decode(&runtimeConfig); err != nil {
+		return nil, fmt.Errorf("decode runtime provider %q config: %w", name, err)
+	}
+	return runtimeConfig, nil
 }

--- a/gestaltd/internal/bootstrap/plugin_runtime_executable_test.go
+++ b/gestaltd/internal/bootstrap/plugin_runtime_executable_test.go
@@ -1,0 +1,93 @@
+package bootstrap
+
+import (
+	"testing"
+
+	"github.com/valon-technologies/gestalt/server/internal/config"
+	"gopkg.in/yaml.v3"
+)
+
+func TestRuntimeProviderConfigMapUsesRawConfig(t *testing.T) {
+	t.Parallel()
+
+	entry := &config.RuntimeProviderEntry{
+		ProviderEntry: config.ProviderEntry{
+			Env: map[string]string{
+				"MODAL_TOKEN_ID":     "${MODAL_TOKEN_ID}",
+				"MODAL_TOKEN_SECRET": "${MODAL_TOKEN_SECRET}",
+			},
+			Config: mustRuntimeNode(t, map[string]any{
+				"app":         "gestalt-runtime",
+				"environment": "main",
+			}),
+		},
+	}
+
+	got, err := runtimeProviderConfigMap("modal", entry)
+	if err != nil {
+		t.Fatalf("runtimeProviderConfigMap: %v", err)
+	}
+
+	if got["app"] != "gestalt-runtime" {
+		t.Fatalf("config app = %#v, want gestalt-runtime", got["app"])
+	}
+	if got["environment"] != "main" {
+		t.Fatalf("config environment = %#v, want main", got["environment"])
+	}
+	for _, key := range []string{"env", "config", "source", "name", "MODAL_TOKEN_ID", "MODAL_TOKEN_SECRET"} {
+		if _, exists := got[key]; exists {
+			t.Fatalf("config unexpectedly contains %q: %#v", key, got)
+		}
+	}
+}
+
+func TestRuntimeProviderConfigMapUnwrapsComponentRuntimeConfig(t *testing.T) {
+	t.Parallel()
+
+	rawConfig := mustRuntimeNode(t, map[string]any{
+		"app":         "gestalt-runtime",
+		"environment": "main",
+	})
+	entry := &config.RuntimeProviderEntry{
+		ProviderEntry: config.ProviderEntry{
+			Source: config.ProviderSource{Path: "./runtime/modal/provider-release.yaml"},
+			Env: map[string]string{
+				"MODAL_TOKEN_ID":     "${MODAL_TOKEN_ID}",
+				"MODAL_TOKEN_SECRET": "${MODAL_TOKEN_SECRET}",
+			},
+			Config: rawConfig,
+		},
+	}
+	wrapped, err := config.BuildComponentRuntimeConfigNode("modal", "runtime", &entry.ProviderEntry, rawConfig)
+	if err != nil {
+		t.Fatalf("BuildComponentRuntimeConfigNode: %v", err)
+	}
+	entry.Config = wrapped
+
+	got, err := runtimeProviderConfigMap("modal", entry)
+	if err != nil {
+		t.Fatalf("runtimeProviderConfigMap: %v", err)
+	}
+
+	if got["app"] != "gestalt-runtime" {
+		t.Fatalf("config app = %#v, want gestalt-runtime", got["app"])
+	}
+	if got["environment"] != "main" {
+		t.Fatalf("config environment = %#v, want main", got["environment"])
+	}
+	for _, key := range []string{"env", "config", "source", "name", "MODAL_TOKEN_ID", "MODAL_TOKEN_SECRET"} {
+		if _, exists := got[key]; exists {
+			t.Fatalf("config unexpectedly contains %q: %#v", key, got)
+		}
+	}
+}
+
+func mustRuntimeNode(t *testing.T, value any) yaml.Node {
+	t.Helper()
+
+	var node yaml.Node
+	if err := node.Encode(value); err != nil {
+		t.Fatalf("node.Encode: %v", err)
+	}
+	return node
+}


### PR DESCRIPTION
## Summary
Runtime providers should receive only their inner `config` payload during `ConfigureProvider`. Their `env` entries should stay process environment for the runtime provider binary.

This fixes the regression that broke `valon-tools` Cloud Run startup when `runtime.providers.modal.env` was added for Modal credentials.

## Interface
```yaml
runtime:
  providers:
    modal:
      source: <provider-release.yaml>
      env:
        MODAL_TOKEN_ID: ${MODAL_TOKEN_ID}
        MODAL_TOKEN_SECRET: ${MODAL_TOKEN_SECRET}
      config:
        app: gestalt-runtime
        environment: main
```

## Behavior
Before this change, executable runtime bootstrap wrapped runtime provider config in a component envelope and passed fields like `name`, `source`, and `env` through `ConfigureProvider(...)`.

After this change:
- runtime provider binaries still receive `ProviderEntry.Env` as process env
- `ConfigureProvider(...)` receives only the raw inner `config` map
- prepared/wrapped runtime config nodes are unwrapped back to the same inner `config`

## Example
With the config above, the Modal runtime now sees:
```yaml
app: gestalt-runtime
environment: main
```

and the process environment still contains:
```text
MODAL_TOKEN_ID=...
MODAL_TOKEN_SECRET=...
```

## Validation
```bash
go test ./internal/bootstrap -run 'TestRuntimeProviderConfigMapUsesRawConfig|TestRuntimeProviderConfigMapUnwrapsComponentRuntimeConfig|TestPluginRuntimeConfigSelectedProviderStartsSessionWithRuntimeFields'
go test ./internal/providerhost -run 'TestConfigureRuntimeProvider'
```