### PR TITLE
agent runs: narrow default tool provider resolution

### DIFF
--- a/gestaltd/internal/agentmanager/manager.go
+++ b/gestaltd/internal/agentmanager/manager.go
@@ -76,6 +76,7 @@ type Config struct {
 	Agent             AgentControl
 	RunMetadata       *coredata.AgentRunMetadataService
 	RunEvents         *coredata.AgentRunEventService
+	Tokens            *coredata.TokenService
 	Invoker           invocation.Invoker
 	Authorizer        authorization.RuntimeAuthorizer
 	DefaultConnection map[string]string
@@ -89,6 +90,7 @@ type Manager struct {
 	agent             AgentControl
 	runMetadata       *coredata.AgentRunMetadataService
 	runEvents         *coredata.AgentRunEventService
+	tokens            *coredata.TokenService
 	invoker           invocation.Invoker
 	authorizer        authorization.RuntimeAuthorizer
 	defaultConnection map[string]string
@@ -111,6 +113,7 @@ func New(cfg Config) *Manager {
 		agent:             cfg.Agent,
 		runMetadata:       cfg.RunMetadata,
 		runEvents:         cfg.RunEvents,
+		tokens:            cfg.Tokens,
 		invoker:           cfg.Invoker,
 		authorizer:        cfg.Authorizer,
 		defaultConnection: maps.Clone(cfg.DefaultConnection),
@@ -593,10 +596,7 @@ func (m *Manager) resolveDefaultTools(ctx context.Context, p *principal.Principa
 		return nil
 	}
 	out := make([]coreagent.Tool, 0, 8)
-	for _, providerName := range m.providers.List() {
-		if !m.allowProvider(ctx, p, providerName) {
-			continue
-		}
+	for _, providerName := range m.defaultToolProviders(ctx, p) {
 		providerTools, err := m.resolveDefaultToolsForProvider(ctx, p, providerName)
 		if err != nil {
 			continue
@@ -604,6 +604,118 @@ func (m *Manager) resolveDefaultTools(ctx context.Context, p *principal.Principa
 		out = append(out, providerTools...)
 	}
 	return out
+}
+
+func (m *Manager) defaultToolProviders(ctx context.Context, p *principal.Principal) []string {
+	if m == nil || m.providers == nil {
+		return nil
+	}
+	providerNames := m.providers.List()
+	if len(providerNames) == 0 {
+		return nil
+	}
+
+	out := make([]string, 0, len(providerNames))
+	credentialAvailability := make(map[string]bool, len(providerNames))
+	for _, providerName := range providerNames {
+		if !m.allowProvider(ctx, p, providerName) {
+			continue
+		}
+		prov, err := m.providers.Get(providerName)
+		if err != nil {
+			continue
+		}
+		if core.NormalizeConnectionMode(prov.ConnectionMode()) == core.ConnectionModeNone {
+			out = append(out, providerName)
+			continue
+		}
+		if !m.hasDefaultToolCredential(ctx, p, providerName, credentialAvailability) {
+			continue
+		}
+		out = append(out, providerName)
+	}
+	return out
+}
+
+func (m *Manager) hasDefaultToolCredential(ctx context.Context, p *principal.Principal, providerName string, credentialAvailability map[string]bool) bool {
+	if m == nil || m.tokens == nil {
+		return true
+	}
+
+	bindingResolver, _ := m.invoker.(invocation.EffectiveCredentialBindingResolver)
+	targets := m.catalogSelectorConfig().BoundSessionCatalogTargets(providerName, p, "", "")
+	if len(targets) == 0 {
+		targets = []invocation.CatalogResolutionTarget{{}}
+	}
+	for _, target := range targets {
+		subjectID := m.defaultToolCredentialSubjectID(p, providerName)
+		connection := strings.TrimSpace(target.Connection)
+		instance := strings.TrimSpace(target.Instance)
+		if bindingResolver != nil {
+			boundCredential, err := bindingResolver.ResolveEffectiveCredentialBinding(p, providerName, connection, instance)
+			if err != nil {
+				continue
+			}
+			if subject := strings.TrimSpace(boundCredential.CredentialSubjectID); subject != "" {
+				subjectID = subject
+			}
+			if conn := strings.TrimSpace(boundCredential.Connection); conn != "" {
+				connection = conn
+			}
+			if inst := strings.TrimSpace(boundCredential.Instance); inst != "" {
+				instance = inst
+			}
+		}
+		if subjectID == "" {
+			continue
+		}
+
+		cacheKey := subjectID + "\x00" + providerName + "\x00" + connection + "\x00" + instance
+		if ok, found := credentialAvailability[cacheKey]; found {
+			if ok {
+				return true
+			}
+			continue
+		}
+
+		ok := m.hasStoredDefaultToolCredential(ctx, subjectID, providerName, connection, instance)
+		credentialAvailability[cacheKey] = ok
+		if ok {
+			return true
+		}
+	}
+	return false
+}
+
+func (m *Manager) defaultToolCredentialSubjectID(p *principal.Principal, providerName string) string {
+	if m != nil && m.authorizer != nil {
+		boundCredential, err := invocation.ResolveEffectiveCredentialBinding(m.authorizer, p, providerName, "", "")
+		if err == nil && boundCredential.HasBinding {
+			if subjectID := strings.TrimSpace(boundCredential.CredentialSubjectID); subjectID != "" {
+				return subjectID
+			}
+		}
+	}
+	return principal.EffectiveCredentialSubjectID(p)
+}
+
+func (m *Manager) hasStoredDefaultToolCredential(ctx context.Context, subjectID, providerName, connection, instance string) bool {
+	if m == nil || m.tokens == nil {
+		return false
+	}
+	subjectID = strings.TrimSpace(subjectID)
+	providerName = strings.TrimSpace(providerName)
+	connection = strings.TrimSpace(connection)
+	instance = strings.TrimSpace(instance)
+	if subjectID == "" || providerName == "" {
+		return false
+	}
+	if instance != "" {
+		_, err := m.tokens.Token(ctx, subjectID, providerName, connection, instance)
+		return err == nil
+	}
+	tokens, err := m.tokens.ListTokensForConnection(ctx, subjectID, providerName, connection)
+	return err == nil && len(tokens) > 0
 }
 
 func (m *Manager) resolveDefaultToolsForProvider(ctx context.Context, p *principal.Principal, providerName string) ([]coreagent.Tool, error) {

--- a/gestaltd/internal/bootstrap/bootstrap.go
+++ b/gestaltd/internal/bootstrap/bootstrap.go
@@ -903,6 +903,7 @@ func Bootstrap(ctx context.Context, cfg *config.Config, factories *FactoryRegist
 		Agent:             prepared.Deps.AgentRuntime,
 		RunMetadata:       prepared.Services.AgentRunMetadata,
 		RunEvents:         prepared.Services.AgentRunEvents,
+		Tokens:            prepared.Services.Tokens,
 		Invoker:           sharedInvoker,
 		Authorizer:        authz,
 		DefaultConnection: connMaps.DefaultConnection,

--- a/gestaltd/internal/server/agent_run_test.go
+++ b/gestaltd/internal/server/agent_run_test.go
@@ -18,9 +18,11 @@ import (
 	"github.com/valon-technologies/gestalt/server/core"
 	coreagent "github.com/valon-technologies/gestalt/server/core/agent"
 	"github.com/valon-technologies/gestalt/server/core/catalog"
+	"github.com/valon-technologies/gestalt/server/core/indexeddb"
 	coretesting "github.com/valon-technologies/gestalt/server/core/testing"
 	"github.com/valon-technologies/gestalt/server/internal/agentmanager"
 	"github.com/valon-technologies/gestalt/server/internal/config"
+	"github.com/valon-technologies/gestalt/server/internal/coredata"
 	"github.com/valon-technologies/gestalt/server/internal/invocation"
 	"github.com/valon-technologies/gestalt/server/internal/principal"
 	"github.com/valon-technologies/gestalt/server/internal/providerhost"
@@ -733,6 +735,241 @@ func TestGlobalAgentRunDefaultToolsUseAccessScopedSessionCatalog(t *testing.T) {
 	}
 	if seenAccess.Policy != "sample_policy" || seenAccess.Role != "viewer" {
 		t.Fatalf("session catalog access context = %+v, want sample_policy/viewer", seenAccess)
+	}
+}
+
+func TestGlobalAgentRunDefaultToolsSkipCredentialedProvidersWithoutStoredTokens(t *testing.T) {
+	t.Parallel()
+
+	services := coretesting.NewStubServices(t)
+	user := seedUser(t, services, "viewer-user@test.local")
+	seedToken(t, services, &core.IntegrationToken{
+		ID:          "tok-cat-connected",
+		SubjectID:   principal.UserSubjectID(user.ID),
+		Integration: "connected",
+		Connection:  testCatalogConnection,
+		Instance:    "default",
+		AccessToken: testCatalogToken,
+	})
+	now := time.Now().UTC()
+	if err := services.DB.ObjectStore(coredata.StoreIntegrationTokens).Put(context.Background(), indexeddb.Record{
+		"id":                      "tok-corrupt-other-connection",
+		"subject_id":              principal.UserSubjectID(user.ID),
+		"integration":             "connected",
+		"connection":              "other",
+		"instance":                "default",
+		"access_token_encrypted":  "not-valid-ciphertext",
+		"refresh_token_encrypted": "not-valid-ciphertext",
+		"created_at":              now,
+		"updated_at":              now,
+	}); err != nil {
+		t.Fatalf("seed corrupt token: %v", err)
+	}
+
+	provider := newMemoryAgentProvider()
+	connectedCatalogCalls := 0
+	missingCatalogCalls := 0
+	connectedProvider := &stubIntegrationWithSessionCatalog{
+		stubIntegrationWithOps: stubIntegrationWithOps{
+			StubIntegration: coretesting.StubIntegration{N: "connected", ConnMode: core.ConnectionModeUser},
+		},
+		catalog: &catalog.Catalog{Name: "connected"},
+		catalogForRequestFn: func(_ context.Context, token string) (*catalog.Catalog, error) {
+			connectedCatalogCalls++
+			if token != testCatalogToken {
+				return nil, errors.New("unexpected connected token")
+			}
+			return &catalog.Catalog{
+				Name: "connected",
+				Operations: []catalog.CatalogOperation{
+					{ID: "read", Method: http.MethodGet, Path: "/read", ReadOnly: true},
+				},
+			}, nil
+		},
+	}
+	missingProvider := &stubIntegrationWithSessionCatalog{
+		stubIntegrationWithOps: stubIntegrationWithOps{
+			StubIntegration: coretesting.StubIntegration{N: "missing", ConnMode: core.ConnectionModeUser},
+		},
+		catalog: &catalog.Catalog{Name: "missing"},
+		catalogForRequestFn: func(_ context.Context, _ string) (*catalog.Catalog, error) {
+			missingCatalogCalls++
+			return &catalog.Catalog{
+				Name: "missing",
+				Operations: []catalog.CatalogOperation{
+					{ID: "should_not_appear", Method: http.MethodGet, Path: "/missing", ReadOnly: true},
+				},
+			}, nil
+		},
+	}
+	weatherProvider := &coretesting.StubIntegration{
+		N:        "weather",
+		ConnMode: core.ConnectionModeNone,
+		CatalogVal: &catalog.Catalog{
+			Name: "weather",
+			Operations: []catalog.CatalogOperation{
+				{ID: "forecast", Method: http.MethodGet, Path: "/forecast", ReadOnly: true},
+			},
+		},
+	}
+
+	providers := testutil.NewProviderRegistry(t, connectedProvider, missingProvider, weatherProvider)
+	broker := invocation.NewBroker(providers, services.Users, services.Tokens)
+	manager := agentmanager.New(agentmanager.Config{
+		Providers:         providers,
+		Agent:             &stubAgentControl{defaultProviderName: "managed", provider: provider},
+		Invoker:           broker,
+		Tokens:            services.Tokens,
+		CatalogConnection: map[string]string{"connected": testCatalogConnection, "missing": testCatalogConnection},
+		RunMetadata:       services.AgentRunMetadata,
+	})
+
+	ts := newTestServer(t, func(cfg *server.Config) {
+		cfg.Auth = &coretesting.StubAuthProvider{
+			N: "stub",
+			ValidateTokenFn: func(_ context.Context, token string) (*core.UserIdentity, error) {
+				if token != "viewer-session" {
+					return nil, core.ErrNotFound
+				}
+				return &core.UserIdentity{Email: user.Email, DisplayName: "Viewer"}, nil
+			},
+		}
+		cfg.Services = services
+		cfg.AgentManager = manager
+		cfg.CatalogConnection = map[string]string{"connected": testCatalogConnection, "missing": testCatalogConnection}
+	})
+	testutil.CloseOnCleanup(t, ts)
+
+	req, _ := http.NewRequest(http.MethodPost, ts.URL+"/api/v1/agent/runs/", bytes.NewBufferString(`{
+		"messages":[{"role":"user","text":"Summarize the roadmap risk."}]
+	}`))
+	req.Header.Set("Content-Type", "application/json")
+	req.AddCookie(&http.Cookie{Name: "session_token", Value: "viewer-session"})
+	resp, err := http.DefaultClient.Do(req)
+	if err != nil {
+		t.Fatalf("create request: %v", err)
+	}
+	defer func() { _ = resp.Body.Close() }()
+	if resp.StatusCode != http.StatusCreated {
+		t.Fatalf("expected 201, got %d", resp.StatusCode)
+	}
+	if len(provider.startRunRequests) != 1 {
+		t.Fatalf("StartRun count = %d, want 1", len(provider.startRunRequests))
+	}
+
+	gotTools := provider.startRunRequests[0].Tools
+	gotTargets := make([]string, 0, len(gotTools))
+	for _, tool := range gotTools {
+		gotTargets = append(gotTargets, tool.Target.PluginName+"."+tool.Target.Operation)
+	}
+	slices.Sort(gotTargets)
+	if !slices.Equal(gotTargets, []string{"connected.read", "weather.forecast"}) {
+		t.Fatalf("StartRun tools = %#v, want connected.read and weather.forecast", gotTargets)
+	}
+	if connectedCatalogCalls == 0 {
+		t.Fatal("connected catalog calls = 0, want at least one session catalog resolution")
+	}
+	if missingCatalogCalls != 0 {
+		t.Fatalf("missing catalog calls = %d, want 0", missingCatalogCalls)
+	}
+}
+
+func TestGlobalAgentRunDefaultToolsUseAPITokenCredentialSubject(t *testing.T) {
+	t.Parallel()
+
+	plaintext, hashed, err := principal.GenerateToken(principal.TokenTypeAPI)
+	if err != nil {
+		t.Fatalf("GenerateToken: %v", err)
+	}
+
+	services := coretesting.NewStubServices(t)
+	owner := seedUser(t, services, "api-owner@test.local")
+	credentialUser := seedUser(t, services, "credential-user@test.local")
+	expiresAt := time.Now().UTC().Add(time.Hour)
+	if err := services.APITokens.StoreAPIToken(context.Background(), &core.APIToken{
+		ID:                  "api-token-bound-credential-subject",
+		OwnerKind:           core.APITokenOwnerKindUser,
+		OwnerID:             owner.ID,
+		CredentialSubjectID: principal.UserSubjectID(credentialUser.ID),
+		Name:                "bound-credential-subject",
+		HashedToken:         hashed,
+		ExpiresAt:           &expiresAt,
+	}); err != nil {
+		t.Fatalf("StoreAPIToken: %v", err)
+	}
+
+	seedToken(t, services, &core.IntegrationToken{
+		ID:          "tok-cat-credential-subject",
+		SubjectID:   principal.UserSubjectID(credentialUser.ID),
+		Integration: "connected",
+		Connection:  testCatalogConnection,
+		Instance:    "default",
+		AccessToken: testCatalogToken,
+	})
+
+	provider := newMemoryAgentProvider()
+	connectedProvider := &stubIntegrationWithSessionCatalog{
+		stubIntegrationWithOps: stubIntegrationWithOps{
+			StubIntegration: coretesting.StubIntegration{N: "connected", ConnMode: core.ConnectionModeUser},
+		},
+		catalog: &catalog.Catalog{Name: "connected"},
+		catalogForRequestFn: func(_ context.Context, token string) (*catalog.Catalog, error) {
+			if token != testCatalogToken {
+				return nil, errors.New("unexpected connected token")
+			}
+			return &catalog.Catalog{
+				Name: "connected",
+				Operations: []catalog.CatalogOperation{
+					{ID: "read", Method: http.MethodGet, Path: "/read", ReadOnly: true},
+				},
+			}, nil
+		},
+	}
+
+	providers := testutil.NewProviderRegistry(t, connectedProvider)
+	broker := invocation.NewBroker(providers, services.Users, services.Tokens)
+	manager := agentmanager.New(agentmanager.Config{
+		Providers:         providers,
+		Agent:             &stubAgentControl{defaultProviderName: "managed", provider: provider},
+		Invoker:           broker,
+		Tokens:            services.Tokens,
+		CatalogConnection: map[string]string{"connected": testCatalogConnection},
+		RunMetadata:       services.AgentRunMetadata,
+	})
+
+	ts := newTestServer(t, func(cfg *server.Config) {
+		cfg.Auth = &coretesting.StubAuthProvider{
+			N: "stub",
+			ValidateTokenFn: func(_ context.Context, _ string) (*core.UserIdentity, error) {
+				return nil, core.ErrNotFound
+			},
+		}
+		cfg.Services = services
+		cfg.AgentManager = manager
+		cfg.CatalogConnection = map[string]string{"connected": testCatalogConnection}
+	})
+	testutil.CloseOnCleanup(t, ts)
+
+	req, _ := http.NewRequest(http.MethodPost, ts.URL+"/api/v1/agent/runs/", bytes.NewBufferString(`{
+		"messages":[{"role":"user","text":"Summarize the roadmap risk."}]
+	}`))
+	req.Header.Set("Content-Type", "application/json")
+	req.Header.Set("Authorization", "Bearer "+plaintext)
+	resp, err := http.DefaultClient.Do(req)
+	if err != nil {
+		t.Fatalf("create request: %v", err)
+	}
+	defer func() { _ = resp.Body.Close() }()
+	if resp.StatusCode != http.StatusCreated {
+		t.Fatalf("expected 201, got %d", resp.StatusCode)
+	}
+	if len(provider.startRunRequests) != 1 {
+		t.Fatalf("StartRun count = %d, want 1", len(provider.startRunRequests))
+	}
+	if got := provider.startRunRequests[0].Tools; len(got) != 1 {
+		t.Fatalf("StartRun tools = %#v, want one default tool from credential subject", got)
+	} else if got[0].Target.PluginName != "connected" || got[0].Target.Operation != "read" {
+		t.Fatalf("StartRun default tool = %#v, want connected.read", got[0])
 	}
 }
 


### PR DESCRIPTION
## Summary
This follow-up keeps the new global agent-run interface unchanged, but makes the default safe-tool path avoid probing credentialed providers unless the effective credential subject has a usable stored credential on one of that provider's default or bound catalog targets.

That means `gestalt agent runs create` still auto-attaches safe authorized tools by default, while the server does less unnecessary provider work on the way to building that tool set.

## Interface
No new flags or request fields.

Current interface remains:

```bash
gestalt agent runs create --message "Summarize the roadmap risk."
```

```bash
gestalt agent runs create --message "Draft a reply for me" --tool slack:chat.postMessage
```

HTTP shape remains:

```http
POST /api/v1/agent/runs
Authorization: Bearer <api-token>
Content-Type: application/json
```

```json
{
  "messages": [{"role": "user", "text": "Summarize the roadmap risk."}]
}
```

## What Changed
- prefilter default-tool providers to connection-mode-none providers plus integrations that have a stored credential on one of the provider's default or bound catalog targets for the effective credential subject
- keep the existing per-provider resolution flow once a provider makes it through that prefilter
- wire token storage into the bootstrap-created agent manager
- add an HTTP-path regression test showing that a credentialed provider with no stored token is skipped before session-catalog resolution
- add HTTP-path coverage showing that an API token's credential subject drives default-tool attachment
- add regression coverage showing that a corrupt token on another connection of the same integration does not hide default tools for the active catalog target

## Verification
- `go test ./internal/server -run 'TestGlobalAgentRunLifecycleSupportsCreateListGetAndCancel|TestGlobalAgentRunDefaultToolsUseAccessScopedSessionCatalog|TestGlobalAgentRunDefaultToolsSkipCredentialedProvidersWithoutStoredTokens|TestGlobalAgentRunDefaultToolsUseAPITokenCredentialSubject|TestGlobalAgentRunCreateExplicitToolSourceSkipsDefaultTools'`
- `go test ./internal/bootstrap -run TestThisPatternShouldNotMatchAnything`
- `go test ./internal/agentmanager -run TestThisPatternShouldNotMatchAnything`
- `golangci-lint run ./internal/agentmanager/... ./internal/bootstrap/... ./internal/server/...`
