### PR TITLE
Add provider-local dev and validate commands

### DIFF
--- a/docs/content/custom-providers/plugins.mdx
+++ b/docs/content/custom-providers/plugins.mdx
@@ -639,15 +639,34 @@ A Slack plugin could use this to check which Slack workspace the caller is conne
 
 ## Testing locally
 
-Point a local config at the source plugin. Gestalt synthesizes the executable wrapper, materializes the catalog, and merges any code-defined hosted HTTP metadata (`securitySchemes` / `http`) automatically:
+Use the provider-local commands when you are iterating on a source plugin.
+`gestaltd provider dev` and `gestaltd provider validate` synthesize a local
+Gestalt config around the target plugin instead of requiring a hand-written
+temp config.
 
-```yaml
-plugins:
-  slack:
-    source: ./slack/manifest.yaml
-    allowedHosts:
-      - slack.com
+Validate the plugin in isolation:
+
+```sh
+gestaltd provider validate --path ./slack
 ```
+
+Run the plugin locally with browser-facing UI available:
+
+```sh
+gestaltd provider dev --path ./slack
+```
+
+When the plugin needs supporting providers, extra plugins, or explicit mounted
+UIs, layer real config overlays on top of the synthesized baseline:
+
+```sh
+gestaltd provider validate --path ./slack --config ./dev/support.yaml
+gestaltd provider dev --path ./slack --config ./dev/support.yaml
+```
+
+Repeated `--config` flags merge left-to-right, and `null` deletes inherited
+entries. That makes it possible to boot some supporting providers while
+suppressing others for a local session.
 
 Hosted HTTP bindings stay layered on top of operations. A plugin can define an
 operation like `handle_command` in code, then attach `/command` with generated
@@ -657,11 +676,7 @@ Hand-authored manifest `spec.securitySchemes` / `spec.http` entries are still
 valid, but source-generated metadata is merged first and manifest values then
 override populated fields rather than replacing the generated binding wholesale.
 
-Start the server and invoke an operation:
-
-```sh
-gestaltd serve --config ./config.yaml
-```
+Once the local server is running, invoke an operation:
 
 ```sh
 gestalt plugin invoke slack conversations.getMessage -p channel=C01ABC23DEF -p ts=1712161829.000300

--- a/docs/content/reference/cli.mdx
+++ b/docs/content/reference/cli.mdx
@@ -31,6 +31,10 @@ import { Callout } from 'nextra/components'
 
 | Command | Purpose |
 | --- | --- |
+| `gestaltd provider dev --path PATH` | Run a local source plugin inside a synthesized Gestalt config. Serves `/admin` and any configured or inferred public UIs. |
+| `gestaltd provider dev --config PATH` | Layer supporting providers, plugins, and UI mounts on top of the synthesized local baseline. Repeat `--config` to merge left-to-right. |
+| `gestaltd provider validate --path PATH` | Validate a local source plugin inside the same synthesized Gestalt config used by `provider dev`. |
+| `gestaltd provider validate --config PATH` | Validate the target plugin together with selected supporting providers and `null` deletions from layered config overlays. |
 | `gestaltd provider release --version VERSION` | Build and package a provider release. Go, Python, Rust, and TypeScript source plugins default to the host platform. Pass `--platform ...` with `os/arch[/libc]` targets or `--platform all` for multi-platform builds. |
 | `gestaltd provider release --output DIR` | Output directory for the release archive. Defaults to `dist/`. |
 
@@ -46,6 +50,10 @@ gestaltd serve --config ./config.yaml --lockfile ./local/gestalt.lock.json
 gestaltd serve --locked --config ./config.yaml --lockfile ./local/gestalt.lock.json
 gestaltd init --config ./base.yaml --config ./overrides/local.yaml
 gestaltd serve --locked --config ./base.yaml --config ./overrides/prod.yaml
+gestaltd provider validate --path ./plugins/support
+gestaltd provider validate --path ./plugins/support --config ./dev/support.yaml --config ./dev/local.yaml
+gestaltd provider dev --path ./plugins/support
+gestaltd provider dev --path ./plugins/support --config ./dev/support.yaml --port 8080
 gestaltd provider release --version 0.0.1-alpha.1
 gestaltd provider release --version 0.0.1-alpha.1 --platform all
 gestaltd provider release --version 0.0.1-alpha.1 --platform linux/amd64,linux/arm64

--- a/gestaltd/cmd/gestaltd/e2e_test.go
+++ b/gestaltd/cmd/gestaltd/e2e_test.go
@@ -231,6 +231,150 @@ func TestE2EValidateRejectsInvalidConfigInput(t *testing.T) {
 	}
 }
 
+func TestE2EProviderValidateIsolatedSourcePlugin(t *testing.T) {
+	t.Parallel()
+
+	dir := t.TempDir()
+	providersDir := setupDefaultLocalProvidersDir(t, dir)
+	pluginDir := setupPluginDir(t, dir)
+
+	cmd := exec.Command(gestaltdBin, "provider", "validate", "--path", pluginDir)
+	cmd.Env = append(os.Environ(),
+		"GESTALT_PROVIDERS_DIR="+providersDir,
+		"GOTELEMETRY=off",
+	)
+	out, err := cmd.CombinedOutput()
+	if err != nil {
+		t.Fatalf("gestaltd provider validate failed: %v\noutput: %s", err, out)
+	}
+	if !strings.Contains(string(out), "config ok") {
+		t.Fatalf("expected validate success, got: %s", out)
+	}
+	if !strings.Contains(string(out), "provider validated") {
+		t.Fatalf("expected provider validation summary, got: %s", out)
+	}
+}
+
+func TestE2EProviderValidateReusesConfiguredPluginKey(t *testing.T) {
+	t.Parallel()
+
+	dir := t.TempDir()
+	providersDir := setupDefaultLocalProvidersDir(t, dir)
+	pluginDir := setupPluginDir(t, dir)
+	cfgPath := filepath.Join(dir, "config.yaml")
+	cfg := `plugins:
+  provider_go:
+    source: https://example.test/provider-release.yaml
+`
+	if err := os.WriteFile(cfgPath, []byte(cfg), 0o644); err != nil {
+		t.Fatalf("write config: %v", err)
+	}
+
+	cmd := exec.Command(gestaltdBin, "provider", "validate", "--path", pluginDir, "--config", cfgPath, "--name", "provider_go")
+	cmd.Env = append(os.Environ(),
+		"GESTALT_PROVIDERS_DIR="+providersDir,
+		"GOTELEMETRY=off",
+	)
+	out, err := cmd.CombinedOutput()
+	if err != nil {
+		t.Fatalf("gestaltd provider validate failed: %v\noutput: %s", err, out)
+	}
+	if !strings.Contains(string(out), "plugin=provider_go") {
+		t.Fatalf("expected configured plugin key in output, got: %s", out)
+	}
+}
+
+func TestE2EProviderValidateRejectsNonPluginManifest(t *testing.T) {
+	t.Parallel()
+
+	dir := t.TempDir()
+	manifestPath := componentProviderManifestPath(t, setupIndexedDBProviderDir(t, dir))
+
+	out, err := exec.Command(gestaltdBin, "provider", "validate", "--path", manifestPath).CombinedOutput()
+	if err == nil {
+		t.Fatalf("expected gestaltd provider validate to fail for non-plugin manifest\n%s", out)
+	}
+	if !strings.Contains(string(out), "only support kind: plugin in v1") {
+		t.Fatalf("expected plugin-only error, got: %s", out)
+	}
+}
+
+func TestE2EProviderValidateLayeredConfigSupportsNullDeletion(t *testing.T) {
+	t.Parallel()
+
+	dir := t.TempDir()
+	providersDir := setupDefaultLocalProvidersDir(t, dir)
+	targetDir := setupPluginDir(t, filepath.Join(dir, "target"))
+	supportDir := setupPrebuiltPluginDir(t, filepath.Join(dir, "support"))
+	mountedUI := setupMountedUIDir(t, dir)
+	attachOwnedUIToPluginSource(t, targetDir, mountedUI.ManifestPath)
+
+	supportManifest := componentProviderManifestPath(t, supportDir)
+	supportRel, err := filepath.Rel(dir, supportManifest)
+	if err != nil {
+		t.Fatalf("filepath.Rel(support): %v", err)
+	}
+	uiRel, err := filepath.Rel(dir, mountedUI.ManifestPath)
+	if err != nil {
+		t.Fatalf("filepath.Rel(ui): %v", err)
+	}
+
+	baseCfgPath := filepath.Join(dir, "support.yaml")
+	baseCfg := fmt.Sprintf(`providers:
+  ui:
+    roadmap:
+      source:
+        path: %s
+      path: /provider
+plugins:
+  support:
+    source:
+      path: %s
+    ui: roadmap
+    mountPath: /provider
+`, filepath.ToSlash(uiRel), filepath.ToSlash(supportRel))
+	if err := os.WriteFile(baseCfgPath, []byte(baseCfg), 0o644); err != nil {
+		t.Fatalf("write support config: %v", err)
+	}
+
+	overrideCfgPath := filepath.Join(dir, "support-override.yaml")
+	overrideCfg := `providers:
+  ui:
+    roadmap: null
+plugins:
+  support: null
+`
+	if err := os.WriteFile(overrideCfgPath, []byte(overrideCfg), 0o644); err != nil {
+		t.Fatalf("write support override: %v", err)
+	}
+
+	failingCmd := exec.Command(gestaltdBin, "provider", "validate", "--path", targetDir, "--config", baseCfgPath)
+	failingCmd.Env = append(os.Environ(),
+		"GESTALT_PROVIDERS_DIR="+providersDir,
+		"GOTELEMETRY=off",
+	)
+	failingOut, err := failingCmd.CombinedOutput()
+	if err == nil {
+		t.Fatalf("expected provider validate without null deletion to fail\n%s", failingOut)
+	}
+	if !strings.Contains(string(failingOut), `collides with providers.ui.roadmap`) {
+		t.Fatalf("expected mount collision error, got: %s", failingOut)
+	}
+
+	successCmd := exec.Command(gestaltdBin, "provider", "validate", "--path", targetDir, "--config", baseCfgPath, "--config", overrideCfgPath)
+	successCmd.Env = append(os.Environ(),
+		"GESTALT_PROVIDERS_DIR="+providersDir,
+		"GOTELEMETRY=off",
+	)
+	successOut, err := successCmd.CombinedOutput()
+	if err != nil {
+		t.Fatalf("gestaltd provider validate with null deletion failed: %v\noutput: %s", err, successOut)
+	}
+	if !strings.Contains(string(successOut), "config ok") {
+		t.Fatalf("expected validate success with null deletion, got: %s", successOut)
+	}
+}
+
 func TestE2EValidateConfigPathPrecedence(t *testing.T) {
 	t.Parallel()
 
@@ -1074,6 +1218,25 @@ func setupMountedUIDir(t *testing.T, baseDir string) *mountedUITestConfig {
 	return setupMountedUIDirWithRoutes(t, baseDir, nil)
 }
 
+func attachOwnedUIToPluginSource(t *testing.T, pluginDir, uiManifestPath string) {
+	t.Helper()
+
+	manifestPath := componentProviderManifestPath(t, pluginDir)
+	_, manifest, err := providerpkg.ReadSourceManifestFile(manifestPath)
+	if err != nil {
+		t.Fatalf("ReadSourceManifestFile(%s): %v", manifestPath, err)
+	}
+	if manifest.Spec == nil {
+		manifest.Spec = &providermanifestv1.Spec{}
+	}
+	relativeUIPath, err := filepath.Rel(pluginDir, uiManifestPath)
+	if err != nil {
+		t.Fatalf("filepath.Rel(%s, %s): %v", pluginDir, uiManifestPath, err)
+	}
+	manifest.Spec.UI = &providermanifestv1.OwnedUI{Path: filepath.ToSlash(relativeUIPath)}
+	writeManifestFile(t, pluginDir, manifest)
+}
+
 func setupMountedUIDirWithRoutes(t *testing.T, baseDir string, routes []providermanifestv1.UIRoute) *mountedUITestConfig {
 	t.Helper()
 
@@ -1443,6 +1606,110 @@ func TestE2EServeAndHealthCheck(t *testing.T) {
 	if len(integrations) == 0 {
 		t.Fatal("expected at least one integration from the example plugin")
 	}
+}
+
+func TestE2EProviderDevServesAdminWithoutInjectingRootUI(t *testing.T) {
+	t.Parallel()
+
+	if testing.Short() {
+		t.Skip("skipping provider dev serve test in short mode")
+	}
+
+	dir := t.TempDir()
+	providersDir := setupDefaultLocalProvidersDir(t, dir)
+	pluginDir := setupPluginDir(t, dir)
+	port, holder := reservePort(t)
+	baseURL := fmt.Sprintf("http://127.0.0.1:%d", port)
+	_ = holder.Close()
+
+	cmd := exec.Command(gestaltdBin, "provider", "dev", "--path", pluginDir, "--port", fmt.Sprintf("%d", port))
+	cmd.Env = append(os.Environ(),
+		"GESTALT_PROVIDERS_DIR="+providersDir,
+		"GOTELEMETRY=off",
+	)
+	startCommandAndWaitReady(t, cmd, baseURL)
+
+	client := &http.Client{Timeout: 2 * time.Second}
+	adminResp, err := client.Get(baseURL + "/admin/")
+	if err != nil {
+		t.Fatalf("GET /admin/: %v", err)
+	}
+	defer func() { _ = adminResp.Body.Close() }()
+	adminBody, _ := io.ReadAll(adminResp.Body)
+	if adminResp.StatusCode != http.StatusOK {
+		t.Fatalf("expected /admin/ 200, got %d: %s", adminResp.StatusCode, adminBody)
+	}
+
+	rootResp, err := client.Get(baseURL + "/")
+	if err != nil {
+		t.Fatalf("GET /: %v", err)
+	}
+	defer func() { _ = rootResp.Body.Close() }()
+	if rootResp.StatusCode == http.StatusOK {
+		body, _ := io.ReadAll(rootResp.Body)
+		t.Fatalf("expected root path to stay unmounted without a public UI, got 200: %s", body)
+	}
+}
+
+func TestE2EProviderDevAutoMountsOwnedUI(t *testing.T) {
+	t.Parallel()
+
+	if testing.Short() {
+		t.Skip("skipping provider dev owned-ui test in short mode")
+	}
+
+	dir := t.TempDir()
+	providersDir := setupDefaultLocalProvidersDir(t, dir)
+	pluginDir := setupPluginDir(t, dir)
+	mountedUI := setupMountedUIDir(t, dir)
+	attachOwnedUIToPluginSource(t, pluginDir, mountedUI.ManifestPath)
+	port, holder := reservePort(t)
+	baseURL := fmt.Sprintf("http://127.0.0.1:%d", port)
+	_ = holder.Close()
+
+	cmd := exec.Command(gestaltdBin, "provider", "dev", "--path", componentProviderManifestPath(t, pluginDir), "--port", fmt.Sprintf("%d", port))
+	cmd.Env = append(os.Environ(),
+		"GESTALT_PROVIDERS_DIR="+providersDir,
+		"GOTELEMETRY=off",
+	)
+	startCommandAndWaitReady(t, cmd, baseURL)
+
+	client := &http.Client{Timeout: 2 * time.Second}
+	uiResp, err := client.Get(baseURL + "/provider/sync")
+	if err != nil {
+		t.Fatalf("GET /provider/sync: %v", err)
+	}
+	defer func() { _ = uiResp.Body.Close() }()
+	uiBody, _ := io.ReadAll(uiResp.Body)
+	if uiResp.StatusCode != http.StatusOK {
+		t.Fatalf("expected /provider/sync 200, got %d: %s", uiResp.StatusCode, uiBody)
+	}
+	if !strings.Contains(string(uiBody), "Roadmap Review UI") {
+		t.Fatalf("expected owned ui body marker, got: %s", uiBody)
+	}
+
+	integrationsResp, err := client.Get(baseURL + "/api/v1/integrations")
+	if err != nil {
+		t.Fatalf("GET /api/v1/integrations: %v", err)
+	}
+	defer func() { _ = integrationsResp.Body.Close() }()
+	integrationsBody, _ := io.ReadAll(integrationsResp.Body)
+	if integrationsResp.StatusCode != http.StatusOK {
+		t.Fatalf("expected /api/v1/integrations 200, got %d: %s", integrationsResp.StatusCode, integrationsBody)
+	}
+	var integrations []struct {
+		Name        string `json:"name"`
+		MountedPath string `json:"mountedPath"`
+	}
+	if err := json.Unmarshal(integrationsBody, &integrations); err != nil {
+		t.Fatalf("json.Unmarshal integrations: %v (body: %s)", err, integrationsBody)
+	}
+	for _, integration := range integrations {
+		if integration.Name == "provider" && integration.MountedPath == "/provider" {
+			return
+		}
+	}
+	t.Fatalf(`integration "provider" mountedPath missing from response: %s`, integrationsBody)
 }
 
 //nolint:paralleltest // Uses the default 8080 startup path intentionally.

--- a/gestaltd/cmd/gestaltd/main_test.go
+++ b/gestaltd/cmd/gestaltd/main_test.go
@@ -34,7 +34,17 @@ func TestE2ECLIHelp(t *testing.T) {
 		{
 			name:      "provider",
 			args:      []string{"provider", "--help"},
-			wantParts: []string{"gestaltd provider <command> [flags]"},
+			wantParts: []string{"gestaltd provider <command> [flags]", "dev", "validate", "release"},
+		},
+		{
+			name:      "provider validate",
+			args:      []string{"provider", "validate", "--help"},
+			wantParts: []string{"gestaltd provider validate", "v1 supports kind: plugin manifests only", "--config PATH"},
+		},
+		{
+			name:      "provider dev",
+			args:      []string{"provider", "dev", "--help"},
+			wantParts: []string{"gestaltd provider dev", "The built-in admin UI remains available at /admin", "--port PORT"},
 		},
 	}
 
@@ -93,6 +103,16 @@ func TestE2ECLIRejectsBadArgs(t *testing.T) {
 			name:     "missing validate config",
 			args:     []string{"validate", "--config", "nonexistent.yaml"},
 			wantPart: "nonexistent.yaml",
+		},
+		{
+			name:     "provider validate trailing args",
+			args:     []string{"provider", "validate", "--path", ".", "extra"},
+			wantPart: "unexpected arguments: extra",
+		},
+		{
+			name:     "provider dev trailing args",
+			args:     []string{"provider", "dev", "--path", ".", "extra"},
+			wantPart: "unexpected arguments: extra",
 		},
 	}
 

--- a/gestaltd/cmd/gestaltd/provider.go
+++ b/gestaltd/cmd/gestaltd/provider.go
@@ -31,6 +31,10 @@ func runProvider(args []string) error {
 	case "-h", "--help", "help":
 		printProviderUsage(os.Stderr)
 		return flag.ErrHelp
+	case "dev":
+		return runProviderDev(args[1:])
+	case "validate":
+		return runProviderValidate(args[1:])
 	case "release":
 		return runProviderRelease(args[1:])
 	default:
@@ -599,7 +603,9 @@ func printProviderUsage(w io.Writer) {
 	writeUsageLine(w, "  gestaltd provider <command> [flags]")
 	writeUsageLine(w, "")
 	writeUsageLine(w, "Commands:")
+	writeUsageLine(w, "  dev         Run a local source plugin inside a synthesized Gestalt config")
 	writeUsageLine(w, "  release     Build provider release archives")
+	writeUsageLine(w, "  validate    Validate a local source plugin inside a synthesized Gestalt config")
 }
 
 func printProviderReleaseUsage(w io.Writer) {

--- a/gestaltd/cmd/gestaltd/provider_local.go
+++ b/gestaltd/cmd/gestaltd/provider_local.go
@@ -1,0 +1,636 @@
+package main
+
+import (
+	"context"
+	"crypto/rand"
+	"encoding/hex"
+	"errors"
+	"flag"
+	"fmt"
+	"io"
+	"log/slog"
+	"net"
+	"net/url"
+	"os"
+	"path/filepath"
+	"slices"
+	"strings"
+
+	"github.com/valon-technologies/gestalt/server/internal/bootstrap"
+	"github.com/valon-technologies/gestalt/server/internal/config"
+	"github.com/valon-technologies/gestalt/server/internal/operator"
+	"github.com/valon-technologies/gestalt/server/internal/pluginsource"
+	"github.com/valon-technologies/gestalt/server/internal/providerpkg"
+	providermanifestv1 "github.com/valon-technologies/gestalt/server/sdk/providermanifest/v1"
+	"gopkg.in/yaml.v3"
+)
+
+const (
+	providerDevHost          = "127.0.0.1"
+	providerDevIndexedDBName = "main"
+)
+
+type providerLocalCommandOptions struct {
+	Path        string
+	ConfigPaths []string
+	Name        string
+	Port        int
+}
+
+type providerLocalSession struct {
+	Dir               string
+	ManifestPath      string
+	PluginKey         string
+	ConfigPaths       []string
+	State             operator.StatePaths
+	PublicURL         string
+	AdminURL          string
+	PublicUIPaths     []string
+	AutoMountedUIPath string
+}
+
+func runProviderValidate(args []string) error {
+	fs := flag.NewFlagSet("gestaltd provider validate", flag.ContinueOnError)
+	fs.Usage = func() { printProviderValidateUsage(fs.Output()) }
+	var configPaths repeatedStringFlag
+	fs.Var(&configPaths, "config", "path to config file (repeat to layer overrides)")
+	pathFlag := fs.String("path", "", "provider manifest path or directory (defaults to current working directory)")
+	nameFlag := fs.String("name", "", "plugin key override")
+	if err := fs.Parse(args); err != nil {
+		return err
+	}
+	if fs.NArg() > 0 {
+		return fmt.Errorf("unexpected arguments: %s", strings.Join(fs.Args(), " "))
+	}
+
+	session, err := prepareProviderLocalSession(providerLocalCommandOptions{
+		Path:        *pathFlag,
+		ConfigPaths: []string(configPaths),
+		Name:        *nameFlag,
+		Port:        8080,
+	})
+	if err != nil {
+		return err
+	}
+	defer func() { _ = os.RemoveAll(session.Dir) }()
+
+	result, err := validateConfigWithStatePaths(session.ConfigPaths, session.State)
+	if err != nil {
+		return err
+	}
+
+	logProviderLocalSummary("provider validated", session)
+	logConfigSummary(result.Paths, result.Config)
+	for _, warning := range result.Warnings {
+		slog.Warn(warning)
+	}
+	slog.Info("config ok")
+	return nil
+}
+
+func runProviderDev(args []string) error {
+	fs := flag.NewFlagSet("gestaltd provider dev", flag.ContinueOnError)
+	fs.Usage = func() { printProviderDevUsage(fs.Output()) }
+	var configPaths repeatedStringFlag
+	fs.Var(&configPaths, "config", "path to config file (repeat to layer overrides)")
+	pathFlag := fs.String("path", "", "provider manifest path or directory (defaults to current working directory)")
+	nameFlag := fs.String("name", "", "plugin key override")
+	portFlag := fs.Int("port", 0, "public port (defaults to a free localhost port)")
+	if err := fs.Parse(args); err != nil {
+		return err
+	}
+	if fs.NArg() > 0 {
+		return fmt.Errorf("unexpected arguments: %s", strings.Join(fs.Args(), " "))
+	}
+
+	port := *portFlag
+	if port == 0 {
+		selectedPort, err := reserveLocalPort()
+		if err != nil {
+			return err
+		}
+		port = selectedPort
+	}
+
+	session, err := prepareProviderLocalSession(providerLocalCommandOptions{
+		Path:        *pathFlag,
+		ConfigPaths: []string(configPaths),
+		Name:        *nameFlag,
+		Port:        port,
+	})
+	if err != nil {
+		return err
+	}
+	defer func() { _ = os.RemoveAll(session.Dir) }()
+
+	env, err := setupBootstrapWithConfigPaths(session.ConfigPaths, session.State, false)
+	if err != nil {
+		return err
+	}
+	logProviderLocalSummary("provider dev ready", session)
+	return runServer(env)
+}
+
+type validatedConfigResult struct {
+	Paths    []string
+	Config   *config.Config
+	Warnings []string
+}
+
+func validateConfigWithStatePaths(configFlags []string, state operator.StatePaths) (*validatedConfigResult, error) {
+	paths, cfg, err := loadConfigForValidationWithStatePaths(configFlags, state)
+	if err != nil {
+		return nil, err
+	}
+
+	warnings, err := bootstrap.Validate(context.Background(), cfg, buildFactories())
+	if err != nil {
+		return nil, err
+	}
+
+	return &validatedConfigResult{
+		Paths:    paths,
+		Config:   cfg,
+		Warnings: warnings,
+	}, nil
+}
+
+func prepareProviderLocalSession(opts providerLocalCommandOptions) (*providerLocalSession, error) {
+	manifestPath, manifest, err := resolveProviderTargetManifest(opts.Path)
+	if err != nil {
+		return nil, err
+	}
+
+	kind, err := providerpkg.ManifestKind(manifest)
+	if err != nil {
+		return nil, err
+	}
+	if kind != providermanifestv1.KindPlugin {
+		return nil, fmt.Errorf("gestaltd provider dev and validate only support kind: plugin in v1 (got %q)", kind)
+	}
+
+	targetManifestPath, err := canonicalPath(manifestPath)
+	if err != nil {
+		return nil, err
+	}
+
+	sessionDir, err := os.MkdirTemp("", "gestaltd-provider-*")
+	if err != nil {
+		return nil, fmt.Errorf("create provider session dir: %w", err)
+	}
+	cleanupSessionDir := true
+	defer func() {
+		if cleanupSessionDir {
+			_ = os.RemoveAll(sessionDir)
+		}
+	}()
+
+	baseConfigPath := filepath.Join(sessionDir, "provider-base.yaml")
+	dbPath := filepath.Join(sessionDir, "provider.db")
+	if err := writeProviderLocalBaseConfig(baseConfigPath, dbPath); err != nil {
+		return nil, err
+	}
+
+	resolvedKey, err := resolveProviderLocalPluginKey(opts.ConfigPaths, targetManifestPath, manifest, opts.Name)
+	if err != nil {
+		return nil, err
+	}
+
+	overlayConfigPath := filepath.Join(sessionDir, "provider-target.yaml")
+	autoMountPath := ""
+	if err := writeProviderLocalOverlayConfig(overlayConfigPath, resolvedKey, targetManifestPath, opts.Port, ""); err != nil {
+		return nil, err
+	}
+
+	configPaths := append([]string{baseConfigPath}, opts.ConfigPaths...)
+	configPaths = append(configPaths, overlayConfigPath)
+
+	loadedCfg, err := config.LoadPaths(configPaths)
+	if err != nil {
+		return nil, fmt.Errorf("loading provider dev config: %w", err)
+	}
+
+	if shouldAutoMountOwnedUI(loadedCfg, resolvedKey, manifest) {
+		autoMountPath = "/" + resolvedKey
+		if err := ensureNoPublicUIPathCollision(loadedCfg, resolvedKey, autoMountPath); err != nil {
+			return nil, err
+		}
+		if err := writeProviderLocalOverlayConfig(overlayConfigPath, resolvedKey, targetManifestPath, opts.Port, autoMountPath); err != nil {
+			return nil, err
+		}
+		configPaths[len(configPaths)-1] = overlayConfigPath
+		loadedCfg, err = config.LoadPaths(configPaths)
+		if err != nil {
+			return nil, fmt.Errorf("loading provider dev config with auto-mounted ui: %w", err)
+		}
+	}
+
+	publicURL := providerLocalPublicURL(loadedCfg)
+	publicUIPaths := mountedPublicUIPaths(loadedCfg)
+	if autoMountPath != "" && !slices.Contains(publicUIPaths, autoMountPath) {
+		publicUIPaths = append(publicUIPaths, autoMountPath)
+		slices.Sort(publicUIPaths)
+	}
+	cleanupSessionDir = false
+	return &providerLocalSession{
+		Dir:               sessionDir,
+		ManifestPath:      targetManifestPath,
+		PluginKey:         resolvedKey,
+		ConfigPaths:       configPaths,
+		State:             operator.StatePaths{ArtifactsDir: filepath.Join(sessionDir, "artifacts"), LockfilePath: filepath.Join(sessionDir, "gestalt.lock.json")},
+		PublicURL:         publicURL,
+		AdminURL:          strings.TrimRight(publicURL, "/") + "/admin/",
+		PublicUIPaths:     publicUIPaths,
+		AutoMountedUIPath: autoMountPath,
+	}, nil
+}
+
+func resolveProviderTargetManifest(pathFlag string) (string, *providermanifestv1.Manifest, error) {
+	targetPath := pathFlag
+	if strings.TrimSpace(targetPath) == "" {
+		targetPath = "."
+	}
+	info, err := os.Stat(targetPath)
+	if err != nil {
+		return "", nil, err
+	}
+
+	manifestPath := targetPath
+	if info.IsDir() {
+		manifestPath, err = providerpkg.FindManifestFile(targetPath)
+		if err != nil {
+			return "", nil, err
+		}
+	} else if !providerpkg.IsManifestFile(targetPath) {
+		return "", nil, fmt.Errorf("path %q must point to a provider manifest file or directory", targetPath)
+	}
+
+	_, manifest, err := providerpkg.ReadSourceManifestFile(manifestPath)
+	if err != nil {
+		return "", nil, err
+	}
+	return manifestPath, manifest, nil
+}
+
+func resolveProviderLocalPluginKey(configPaths []string, targetManifestPath string, manifest *providermanifestv1.Manifest, explicitName string) (string, error) {
+	plugins, err := loadConfiguredPlugins(configPaths)
+	if err != nil {
+		return "", err
+	}
+	matchingKeys, err := matchingPluginKeys(plugins, targetManifestPath)
+	if err != nil {
+		return "", err
+	}
+
+	if explicitName != "" {
+		if !isValidExplicitPluginKey(explicitName) {
+			return "", fmt.Errorf("invalid --name %q: use only letters, numbers, and underscores", explicitName)
+		}
+		if len(matchingKeys) == 1 && matchingKeys[0] != explicitName {
+			return "", fmt.Errorf("target manifest is already configured as plugins.%s; pass --name %q or remove the conflicting config entry", matchingKeys[0], matchingKeys[0])
+		}
+		if len(matchingKeys) > 1 && !slices.Contains(matchingKeys, explicitName) {
+			return "", fmt.Errorf("target manifest is configured by multiple plugin keys (%s); remove the ambiguity before using --name", strings.Join(matchingKeys, ", "))
+		}
+		return explicitName, nil
+	}
+
+	if len(matchingKeys) == 1 {
+		return matchingKeys[0], nil
+	}
+	if len(matchingKeys) > 1 {
+		return "", fmt.Errorf("target manifest is configured by multiple plugin keys (%s); pass --name to choose the target key", strings.Join(matchingKeys, ", "))
+	}
+
+	if name := derivedPluginKey(manifest, targetManifestPath); name != "" {
+		if _, ok := plugins[name]; ok {
+			return name, nil
+		}
+		return name, nil
+	}
+	return "", fmt.Errorf("unable to derive a plugin key for %s; pass --name", targetManifestPath)
+}
+
+func writeProviderLocalBaseConfig(path, dbPath string) error {
+	encryptionKey, err := randomHex(32)
+	if err != nil {
+		return err
+	}
+
+	cfg := map[string]any{
+		"server": map[string]any{
+			"encryptionKey": encryptionKey,
+			"providers": map[string]any{
+				"indexeddb": providerDevIndexedDBName,
+			},
+		},
+		"providers": map[string]any{
+			"indexeddb": map[string]any{
+				providerDevIndexedDBName: map[string]any{
+					"source": providerLocalIndexedDBSourceConfig(),
+					"config": map[string]any{
+						"dsn": "sqlite://" + dbPath,
+					},
+				},
+			},
+			"secrets": map[string]any{
+				"env": map[string]any{
+					"source": "env",
+				},
+			},
+		},
+	}
+	return writeYAMLFile(path, cfg)
+}
+
+func writeProviderLocalOverlayConfig(path, pluginKey, manifestPath string, port int, mountPath string) error {
+	pluginEntry := map[string]any{
+		"source": map[string]any{
+			"path": manifestPath,
+		},
+		"runtime": nil,
+	}
+	if mountPath != "" {
+		pluginEntry["mountPath"] = mountPath
+	}
+
+	cfg := map[string]any{
+		"server": map[string]any{
+			"public": map[string]any{
+				"host": providerDevHost,
+				"port": port,
+			},
+		},
+		"plugins": map[string]any{
+			pluginKey: pluginEntry,
+		},
+	}
+	return writeYAMLFile(path, cfg)
+}
+
+func shouldAutoMountOwnedUI(cfg *config.Config, pluginKey string, manifest *providermanifestv1.Manifest) bool {
+	if cfg == nil || manifest == nil || manifest.Spec == nil || manifest.Spec.UI == nil {
+		return false
+	}
+	entry := cfg.Plugins[pluginKey]
+	if entry == nil {
+		return true
+	}
+	return strings.TrimSpace(entry.MountPath) == "" && strings.TrimSpace(entry.UI) == ""
+}
+
+func ensureNoPublicUIPathCollision(cfg *config.Config, pluginKey, mountPath string) error {
+	if cfg == nil {
+		return nil
+	}
+	for name, entry := range cfg.Providers.UI {
+		if entry == nil || strings.TrimSpace(entry.Path) == "" {
+			continue
+		}
+		if strings.TrimSpace(entry.Path) != mountPath {
+			continue
+		}
+		if entry.OwnerPlugin == pluginKey || name == pluginKey {
+			continue
+		}
+		return fmt.Errorf("auto-mounted ui path %q for plugins.%s collides with providers.ui.%s", mountPath, pluginKey, name)
+	}
+	for name, entry := range cfg.Plugins {
+		if entry == nil || name == pluginKey {
+			continue
+		}
+		if strings.TrimSpace(entry.MountPath) == mountPath {
+			return fmt.Errorf("auto-mounted ui path %q for plugins.%s collides with plugins.%s.mountPath", mountPath, pluginKey, name)
+		}
+	}
+	return nil
+}
+
+func providerLocalIndexedDBSourceConfig() any {
+	if providersDir := strings.TrimSpace(os.Getenv("GESTALT_PROVIDERS_DIR")); providersDir != "" {
+		return map[string]any{
+			"path": filepath.Join(providersDir, "indexeddb", "relationaldb", "manifest.yaml"),
+		}
+	}
+	return defaultProviderMetadataURL(config.DefaultIndexedDBProvider, config.DefaultIndexedDBVersion)
+}
+
+func defaultProviderMetadataURL(source, version string) string {
+	rel := strings.TrimPrefix(strings.TrimSpace(source), config.DefaultProviderRepo+"/")
+	return fmt.Sprintf("https://github.com/valon-technologies/gestalt-providers/releases/download/%s/v%s/provider-release.yaml", rel, strings.TrimSpace(version))
+}
+
+func providerLocalPublicURL(cfg *config.Config) string {
+	if cfg == nil {
+		return ""
+	}
+	addr := cfg.Server.PublicAddr()
+	if addr == "" {
+		return ""
+	}
+	return (&url.URL{Scheme: "http", Host: addr}).String()
+}
+
+func mountedPublicUIPaths(cfg *config.Config) []string {
+	if cfg == nil || len(cfg.Providers.UI) == 0 {
+		return nil
+	}
+	paths := make([]string, 0, len(cfg.Providers.UI))
+	for _, entry := range cfg.Providers.UI {
+		if entry == nil || strings.TrimSpace(entry.Path) == "" {
+			continue
+		}
+		paths = append(paths, strings.TrimSpace(entry.Path))
+	}
+	slices.Sort(paths)
+	return slices.Compact(paths)
+}
+
+func logProviderLocalSummary(message string, session *providerLocalSession) {
+	if session == nil {
+		return
+	}
+	publicUIPaths := session.PublicUIPaths
+	if len(publicUIPaths) == 0 {
+		publicUIPaths = nil
+	}
+	slog.Info(message,
+		"plugin", session.PluginKey,
+		"manifest", session.ManifestPath,
+		"public_url", session.PublicURL,
+		"admin_url", session.AdminURL,
+		"mounted_ui_paths", publicUIPaths,
+		"auto_mounted_ui_path", session.AutoMountedUIPath,
+		"config_files", session.ConfigPaths,
+	)
+}
+
+func reserveLocalPort() (int, error) {
+	listener, err := net.Listen("tcp", net.JoinHostPort(providerDevHost, "0"))
+	if err != nil {
+		return 0, fmt.Errorf("reserve provider dev port: %w", err)
+	}
+	defer func() { _ = listener.Close() }()
+	addr, ok := listener.Addr().(*net.TCPAddr)
+	if !ok {
+		return 0, errors.New("reserve provider dev port: unexpected listener address type")
+	}
+	return addr.Port, nil
+}
+
+func randomHex(numBytes int) (string, error) {
+	key := make([]byte, numBytes)
+	if _, err := rand.Read(key); err != nil {
+		return "", fmt.Errorf("generate encryption key: %w", err)
+	}
+	return hex.EncodeToString(key), nil
+}
+
+func canonicalPath(path string) (string, error) {
+	absPath, err := filepath.Abs(path)
+	if err != nil {
+		return "", err
+	}
+	resolved, err := filepath.EvalSymlinks(absPath)
+	if err == nil {
+		return resolved, nil
+	}
+	if errors.Is(err, os.ErrNotExist) {
+		return filepath.Clean(absPath), nil
+	}
+	return "", err
+}
+
+func derivedPluginKey(manifest *providermanifestv1.Manifest, manifestPath string) string {
+	if manifest != nil {
+		if src, err := pluginsource.Parse(manifest.Source); err == nil {
+			if name := sanitizeDerivedPluginKey(src.PluginName()); name != "" {
+				return name
+			}
+		}
+	}
+	return sanitizeDerivedPluginKey(filepath.Base(filepath.Dir(manifestPath)))
+}
+
+func sanitizeDerivedPluginKey(value string) string {
+	value = strings.TrimSpace(strings.ToLower(value))
+	var b strings.Builder
+	previousUnderscore := false
+	for _, r := range value {
+		switch {
+		case r >= 'a' && r <= 'z':
+			b.WriteRune(r)
+			previousUnderscore = false
+		case r >= '0' && r <= '9':
+			b.WriteRune(r)
+			previousUnderscore = false
+		default:
+			if previousUnderscore || b.Len() == 0 {
+				continue
+			}
+			b.WriteByte('_')
+			previousUnderscore = true
+		}
+	}
+	return strings.Trim(b.String(), "_")
+}
+
+func isValidExplicitPluginKey(value string) bool {
+	if value == "" {
+		return false
+	}
+	for _, r := range value {
+		if (r >= 'a' && r <= 'z') || (r >= 'A' && r <= 'Z') || (r >= '0' && r <= '9') || r == '_' {
+			continue
+		}
+		return false
+	}
+	return true
+}
+
+func loadConfiguredPlugins(configPaths []string) (map[string]*config.ProviderEntry, error) {
+	if len(configPaths) == 0 {
+		return map[string]*config.ProviderEntry{}, nil
+	}
+	cfg, err := config.LoadPaths(configPaths)
+	if err != nil {
+		return nil, fmt.Errorf("load provider overlay config: %w", err)
+	}
+	if cfg.Plugins == nil {
+		return map[string]*config.ProviderEntry{}, nil
+	}
+	return cfg.Plugins, nil
+}
+
+func matchingPluginKeys(plugins map[string]*config.ProviderEntry, targetManifestPath string) ([]string, error) {
+	targetCanonical, err := canonicalPath(targetManifestPath)
+	if err != nil {
+		return nil, err
+	}
+
+	var matches []string
+	for name, entry := range plugins {
+		if !providerEntryMatchesTarget(entry, targetCanonical) {
+			continue
+		}
+		matches = append(matches, name)
+	}
+	slices.Sort(matches)
+	return matches, nil
+}
+
+func providerEntryMatchesTarget(entry *config.ProviderEntry, targetManifestPath string) bool {
+	if entry == nil || !entry.HasLocalSource() {
+		return false
+	}
+	canonicalSource, err := canonicalPath(entry.SourcePath())
+	if err != nil {
+		return false
+	}
+	targetCanonical, err := canonicalPath(targetManifestPath)
+	if err != nil {
+		return false
+	}
+	return canonicalSource == targetCanonical
+}
+
+func writeYAMLFile(path string, value any) error {
+	data, err := yaml.Marshal(value)
+	if err != nil {
+		return fmt.Errorf("encode %s: %w", path, err)
+	}
+	if err := os.WriteFile(path, data, 0o600); err != nil {
+		return fmt.Errorf("write %s: %w", path, err)
+	}
+	return nil
+}
+
+func printProviderValidateUsage(w io.Writer) {
+	writeUsageLine(w, "Usage:")
+	writeUsageLine(w, "  gestaltd provider validate [--path PATH] [--config PATH]... [--name NAME]")
+	writeUsageLine(w, "")
+	writeUsageLine(w, "Validate a local source plugin inside a synthesized Gestalt config.")
+	writeUsageLine(w, "v1 supports kind: plugin manifests only.")
+	writeUsageLine(w, "Repeated --config flags merge left-to-right using the normal Gestalt rules.")
+	writeUsageLine(w, "")
+	writeUsageLine(w, "Flags:")
+	writeUsageLine(w, "  --path     Provider manifest path or directory (default: current working directory)")
+	writeUsageLine(w, "  --config   Additional config file to merge; repeat to add support providers or null deletions")
+	writeUsageLine(w, "  --name     Plugin key override when the target key is ambiguous")
+}
+
+func printProviderDevUsage(w io.Writer) {
+	writeUsageLine(w, "Usage:")
+	writeUsageLine(w, "  gestaltd provider dev [--path PATH] [--config PATH]... [--name NAME] [--port PORT]")
+	writeUsageLine(w, "")
+	writeUsageLine(w, "Run a local source plugin inside a synthesized Gestalt config.")
+	writeUsageLine(w, "v1 supports kind: plugin manifests only.")
+	writeUsageLine(w, "The built-in admin UI remains available at /admin; configured or owned public UIs")
+	writeUsageLine(w, "are mounted when present.")
+	writeUsageLine(w, "")
+	writeUsageLine(w, "Flags:")
+	writeUsageLine(w, "  --path     Provider manifest path or directory (default: current working directory)")
+	writeUsageLine(w, "  --config   Additional config file to merge; repeat to add support providers or null deletions")
+	writeUsageLine(w, "  --name     Plugin key override when the target key is ambiguous")
+	writeUsageLine(w, "  --port     Public port (default: auto-selected free localhost port)")
+}

--- a/gestaltd/cmd/gestaltd/run.go
+++ b/gestaltd/cmd/gestaltd/run.go
@@ -1,7 +1,6 @@
 package main
 
 import (
-	"context"
 	"flag"
 	"fmt"
 	"io"
@@ -9,7 +8,6 @@ import (
 	"os"
 	"strings"
 
-	"github.com/valon-technologies/gestalt/server/internal/bootstrap"
 	"github.com/valon-technologies/gestalt/server/internal/config"
 	"github.com/valon-technologies/gestalt/server/internal/operator"
 	"github.com/valon-technologies/gestalt/server/internal/sandbox"
@@ -162,7 +160,7 @@ func validateConfig(configFlags []string, lockfilePath string) error {
 	}
 	defer func() { _ = os.RemoveAll(scratchDir) }()
 
-	paths, cfg, err := loadConfigForValidationWithStatePaths(configFlags, operator.StatePaths{
+	result, err := validateConfigWithStatePaths(configFlags, operator.StatePaths{
 		ArtifactsDir: scratchDir,
 		LockfilePath: lockfilePath,
 	})
@@ -170,13 +168,8 @@ func validateConfig(configFlags []string, lockfilePath string) error {
 		return err
 	}
 
-	warnings, err := bootstrap.Validate(context.Background(), cfg, buildFactories())
-	if err != nil {
-		return err
-	}
-
-	logConfigSummary(paths, cfg)
-	for _, w := range warnings {
+	logConfigSummary(result.Paths, result.Config)
+	for _, w := range result.Warnings {
 		slog.Warn(w)
 	}
 	slog.Info("config ok")
@@ -250,7 +243,7 @@ func printMainUsage(w io.Writer) {
 	writeUsageLine(w, "")
 	writeUsageLine(w, "Commands:")
 	writeUsageLine(w, "  init        Resolve providers and plugins and write lock state")
-	writeUsageLine(w, "  provider    Build provider release archives")
+	writeUsageLine(w, "  provider    Develop, validate, or build provider release archives")
 	writeUsageLine(w, "  serve       Start the server (use --locked for production)")
 	writeUsageLine(w, "  validate    Load and validate configuration without starting the server")
 	writeUsageLine(w, "  version     Print the version and exit")


### PR DESCRIPTION
## Summary

Adds provider-local authoring commands for source plugins:

- `gestaltd provider validate --path ./plugins/support`
- `gestaltd provider validate --path ./plugins/support --config ./dev/support.yaml --config ./dev/local.yaml`
- `gestaltd provider dev --path ./plugins/support`
- `gestaltd provider dev --path ./plugins/support --config ./dev/support.yaml --port 8080`

This keeps `gestaltd validate` and `gestaltd provider release` intact, while giving plugin authors a provider-centric way to validate and run a source plugin without hand-writing a temp config.

## Interfaces

### `gestaltd provider validate`

- accepts `--path` as either a manifest file or a directory
- supports repeated `--config` overlays for booting supporting providers/plugins or deleting them with `null`
- rejects non-`kind: plugin` manifests in v1
- reuses the existing validation path and runtime requirements

Examples:

```sh
gestaltd provider validate --path ./plugins/support
gestaltd provider validate --path ./plugins/support --config ./dev/support.yaml --config ./dev/local.yaml
```

### `gestaltd provider dev`

- synthesizes a runtime-complete local baseline for the target plugin
- serves `/admin` on the public listener
- serves configured public UIs as-is
- auto-mounts owned plugin UI at `/<plugin-key>` when the plugin has `spec.ui` and no explicit UI binding
- keeps the target plugin on local execution by clearing `plugins.<target>.runtime`

Examples:

```sh
gestaltd provider dev --path ./plugins/support
gestaltd provider dev --path ./plugins/support --config ./dev/support.yaml --port 8080
```

## Tests

Integration-style coverage added to `go test ./cmd/gestaltd`:

- provider validate succeeds for an isolated source plugin
- provider validate rejects non-plugin manifests
- provider validate honors layered config `null` deletion for support config
- provider dev serves `/admin` without injecting a root public UI
- provider dev auto-mounts owned UI and exposes it through integrations metadata
- CLI help and bad-arg handling for the new provider commands

Regression slice run:

```sh
go test ./cmd/gestaltd -run 'TestE2EValidateRejectsInvalidConfigInput|TestE2EValidateConfigPathPrecedence|TestE2EServeAndHealthCheck|TestE2EDefaultServeAutoGeneratesLocalConfig|TestE2EServePluginOwnedUIWiring|TestE2ECLIHelp|TestE2ECLIRejectsBadArgs|TestE2EProviderValidateIsolatedSourcePlugin|TestE2EProviderValidateRejectsNonPluginManifest|TestE2EProviderValidateLayeredConfigSupportsNullDeletion|TestE2EProviderDevServesAdminWithoutInjectingRootUI|TestE2EProviderDevAutoMountsOwnedUI' -count=1
```