### PR TITLE
Resolve runtime provider config secret refs before configure

### DIFF
--- a/gestaltd/internal/bootstrap/bootstrap_test.go
+++ b/gestaltd/internal/bootstrap/bootstrap_test.go
@@ -5763,6 +5763,51 @@ func TestBootstrapSecretResolution(t *testing.T) {
 		}
 	})
 
+	t.Run("resolves config secret ref in runtime provider config", func(t *testing.T) {
+		t.Parallel()
+
+		factories := validFactories()
+		factories.Secrets["test-secrets"] = func(yaml.Node) (core.SecretManager, error) {
+			return &coretesting.StubSecretManager{
+				Secrets: map[string]string{"modal-token-id": "ak-test", "modal-token-secret": "as-test"},
+			}, nil
+		}
+
+		cfg := validConfig()
+		cfg.Runtime.Providers = map[string]*config.RuntimeProviderEntry{
+			"modal": {
+				ProviderEntry: config.ProviderEntry{
+					Config: yaml.Node{
+						Kind: yaml.MappingNode,
+						Content: []*yaml.Node{
+							{Kind: yaml.ScalarNode, Value: "app", Tag: "!!str"},
+							{Kind: yaml.ScalarNode, Value: "gestalt-runtime", Tag: "!!str"},
+							{Kind: yaml.ScalarNode, Value: "tokenId", Tag: "!!str"},
+							{Kind: yaml.ScalarNode, Value: transportSecretRef("modal-token-id"), Tag: "!!str"},
+							{Kind: yaml.ScalarNode, Value: "tokenSecret", Tag: "!!str"},
+							{Kind: yaml.ScalarNode, Value: transportSecretRef("modal-token-secret"), Tag: "!!str"},
+						},
+					},
+				},
+			},
+		}
+
+		if err := bootstrap.ResolveConfigSecrets(ctx, cfg, factories); err != nil {
+			t.Fatalf("ResolveConfigSecrets: %v", err)
+		}
+
+		var decoded map[string]string
+		if err := cfg.Runtime.Providers["modal"].Config.Decode(&decoded); err != nil {
+			t.Fatalf("decode: %v", err)
+		}
+		if decoded["tokenId"] != "ak-test" {
+			t.Errorf("tokenId: got %q, want %q", decoded["tokenId"], "ak-test")
+		}
+		if decoded["tokenSecret"] != "as-test" {
+			t.Errorf("tokenSecret: got %q, want %q", decoded["tokenSecret"], "as-test")
+		}
+	})
+
 	t.Run("resolves config secret ref in workload tokens", func(t *testing.T) {
 		t.Parallel()
 

--- a/gestaltd/internal/config/secret_refs.go
+++ b/gestaltd/internal/config/secret_refs.go
@@ -248,6 +248,14 @@ func TransformConfigStringFields(cfg *Config, transform ConfigStringTransformer)
 			}
 		}
 	}
+	for _, entry := range cfg.Runtime.Providers {
+		if entry == nil {
+			continue
+		}
+		if err := transformConfigStringFieldsInStruct(entry, transform); err != nil {
+			return err
+		}
+	}
 	for _, entry := range cfg.Providers.UI {
 		if entry == nil {
 			continue


### PR DESCRIPTION
## Summary
Runtime provider config secret refs were not participating in `ResolveConfigSecrets`, so entries like `runtime.providers.modal.config.tokenId.secret` and `runtime.providers.modal.config.tokenSecret.secret` reached executable runtime providers as unresolved transport refs instead of concrete strings.

That broke the Modal-backed agent path in `valon-tools`: `runtime/modal` fell back away from the intended config credentials and Cloud Run startup failed before the Slack webhook agent could come up.

## Interface
Runtime provider config now supports the same resolved-string behavior as other provider config surfaces during bootstrap.

Before bootstrap resolution:
```yaml
runtime:
  providers:
    modal:
      source: https://github.com/valon-technologies/gestalt-providers/releases/download/runtime/modal/v0.0.1-alpha.6/provider-release.yaml
      config:
        app: gestalt-runtime
        tokenId:
          secret:
            provider: secrets
            name: modal-token-id
        tokenSecret:
          secret:
            provider: secrets
            name: modal-token-secret
        environment: main
```

After `ResolveConfigSecrets`, the runtime provider now receives concrete config values just like auth / indexeddb / s3 providers do:
```yaml
config:
  app: gestalt-runtime
  tokenId: ak-...
  tokenSecret: as-...
  environment: main
```

## Example
This is the `valon-tools` production shape that now resolves correctly before `runtime/modal` is configured:
```yaml
runtime:
  providers:
    modal:
      config:
        app: gestalt-runtime
        tokenId:
          secret:
            provider: secrets
            name: modal-token-id
        tokenSecret:
          secret:
            provider: secrets
            name: modal-token-secret
        environment: main
```

## Validation
- `go test ./internal/bootstrap -run 'TestBootstrapSecretResolution'`
- `go test ./internal/config -run 'Test'`
