### PR TITLE
hosted agents: align relay allowlists with proxy egress

### DIFF
--- a/gestaltd/internal/bootstrap/agent_runtime_test.go
+++ b/gestaltd/internal/bootstrap/agent_runtime_test.go
@@ -2,23 +2,38 @@ package bootstrap
 
 import (
 	"context"
+	"crypto/tls"
 	"encoding/json"
+	"fmt"
+	"net"
 	"net/http"
 	"net/http/httptest"
+	"net/url"
+	"os"
+	"path/filepath"
+	"slices"
 	"strings"
 	"sync"
 	"testing"
 
+	proto "github.com/valon-technologies/gestalt/sdk/go/gen/v1"
 	"github.com/valon-technologies/gestalt/server/core"
 	coreagent "github.com/valon-technologies/gestalt/server/core/agent"
 	corecrypto "github.com/valon-technologies/gestalt/server/core/crypto"
 	coretesting "github.com/valon-technologies/gestalt/server/core/testing"
 	"github.com/valon-technologies/gestalt/server/internal/config"
 	"github.com/valon-technologies/gestalt/server/internal/coredata"
+	"github.com/valon-technologies/gestalt/server/internal/egress"
 	"github.com/valon-technologies/gestalt/server/internal/pluginruntime"
 	"github.com/valon-technologies/gestalt/server/internal/principal"
 	"github.com/valon-technologies/gestalt/server/internal/providerhost"
 	"github.com/valon-technologies/gestalt/server/internal/testutil"
+	"google.golang.org/grpc"
+	"google.golang.org/grpc/credentials"
+	"google.golang.org/grpc/credentials/insecure"
+	"google.golang.org/protobuf/types/known/emptypb"
+	"google.golang.org/protobuf/types/known/structpb"
+	"google.golang.org/protobuf/types/known/timestamppb"
 )
 
 func buildAgentProviderBinary(t *testing.T) string {
@@ -78,6 +93,355 @@ func cloneAnyMap(src map[string]any) map[string]any {
 	}
 	return out
 }
+
+type capturingHostedAgentRuntime struct {
+	provider *pluginruntime.LocalProvider
+	support  pluginruntime.Support
+
+	mu                  sync.Mutex
+	bindRequests        []pluginruntime.BindHostServiceRequest
+	startPluginRequests []pluginruntime.StartPluginRequest
+	extraEnv            map[string]string
+	fakeAgents          map[string]*fakeHostedAgentServer
+}
+
+type fakeHostedAgentServer struct {
+	dir      string
+	env      map[string]string
+	listener net.Listener
+	server   *grpc.Server
+}
+
+func newCapturingHostedAgentRuntime() *capturingHostedAgentRuntime {
+	return &capturingHostedAgentRuntime{
+		provider: pluginruntime.NewLocalProvider(),
+		support: pluginruntime.Support{
+			CanHostPlugins: true,
+			LaunchMode:     pluginruntime.LaunchModeHostPath,
+		},
+		fakeAgents: make(map[string]*fakeHostedAgentServer),
+	}
+}
+
+func (r *capturingHostedAgentRuntime) Support(context.Context) (pluginruntime.Support, error) {
+	return r.support, nil
+}
+
+func (r *capturingHostedAgentRuntime) StartSession(ctx context.Context, req pluginruntime.StartSessionRequest) (*pluginruntime.Session, error) {
+	return r.provider.StartSession(ctx, req)
+}
+
+func (r *capturingHostedAgentRuntime) ListSessions(ctx context.Context) ([]pluginruntime.Session, error) {
+	return r.provider.ListSessions(ctx)
+}
+
+func (r *capturingHostedAgentRuntime) GetSession(ctx context.Context, req pluginruntime.GetSessionRequest) (*pluginruntime.Session, error) {
+	return r.provider.GetSession(ctx, req)
+}
+
+func (r *capturingHostedAgentRuntime) StopSession(ctx context.Context, req pluginruntime.StopSessionRequest) error {
+	r.cleanupFakeHostedAgent(req.SessionID)
+	return r.provider.StopSession(ctx, req)
+}
+
+func (r *capturingHostedAgentRuntime) BindHostService(ctx context.Context, req pluginruntime.BindHostServiceRequest) (*pluginruntime.HostServiceBinding, error) {
+	r.mu.Lock()
+	r.bindRequests = append(r.bindRequests, cloneBindHostServiceRequest(req))
+	r.mu.Unlock()
+	return r.provider.BindHostService(ctx, req)
+}
+
+func (r *capturingHostedAgentRuntime) StartPlugin(ctx context.Context, req pluginruntime.StartPluginRequest) (*pluginruntime.HostedPlugin, error) {
+	r.mu.Lock()
+	r.startPluginRequests = append(r.startPluginRequests, pluginruntime.StartPluginRequest{
+		SessionID:     req.SessionID,
+		PluginName:    req.PluginName,
+		Command:       req.Command,
+		Args:          slices.Clone(req.Args),
+		Env:           cloneRuntimeMetadata(req.Env),
+		BundleDir:     req.BundleDir,
+		AllowedHosts:  slices.Clone(req.AllowedHosts),
+		DefaultAction: req.DefaultAction,
+		HostBinary:    req.HostBinary,
+	})
+	r.mu.Unlock()
+	return r.startFakeHostedAgent(req)
+}
+
+func (r *capturingHostedAgentRuntime) Close() error {
+	r.mu.Lock()
+	sessionIDs := make([]string, 0, len(r.fakeAgents))
+	for sessionID := range r.fakeAgents {
+		sessionIDs = append(sessionIDs, sessionID)
+	}
+	r.mu.Unlock()
+	for _, sessionID := range sessionIDs {
+		r.cleanupFakeHostedAgent(sessionID)
+	}
+	return r.provider.Close()
+}
+
+func (r *capturingHostedAgentRuntime) startPluginRequestsCopy() []pluginruntime.StartPluginRequest {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	out := make([]pluginruntime.StartPluginRequest, len(r.startPluginRequests))
+	for i, req := range r.startPluginRequests {
+		out[i] = pluginruntime.StartPluginRequest{
+			SessionID:     req.SessionID,
+			PluginName:    req.PluginName,
+			Command:       req.Command,
+			Args:          slices.Clone(req.Args),
+			Env:           cloneRuntimeMetadata(req.Env),
+			BundleDir:     req.BundleDir,
+			AllowedHosts:  slices.Clone(req.AllowedHosts),
+			DefaultAction: req.DefaultAction,
+			HostBinary:    req.HostBinary,
+		}
+	}
+	return out
+}
+
+func (r *capturingHostedAgentRuntime) startFakeHostedAgent(req pluginruntime.StartPluginRequest) (*pluginruntime.HostedPlugin, error) {
+	env := cloneRuntimeMetadata(req.Env)
+	r.mu.Lock()
+	for _, binding := range r.bindRequests {
+		if binding.SessionID != req.SessionID {
+			continue
+		}
+		if env == nil {
+			env = map[string]string{}
+		}
+		env[binding.EnvVar] = binding.Relay.DialTarget
+	}
+	for key, value := range r.extraEnv {
+		if env == nil {
+			env = map[string]string{}
+		}
+		env[key] = value
+	}
+	r.mu.Unlock()
+
+	dir, err := providerhost.NewPluginTempDir("gstp-fake-agent-")
+	if err != nil {
+		return nil, fmt.Errorf("create fake hosted agent dir: %w", err)
+	}
+	socketPath := filepath.Join(dir, "agent.sock")
+	lis, err := net.Listen("unix", socketPath)
+	if err != nil {
+		_ = os.RemoveAll(dir)
+		return nil, fmt.Errorf("listen for fake hosted agent: %w", err)
+	}
+
+	srv := grpc.NewServer()
+	proto.RegisterAgentProviderServer(srv, &fakeHostedAgentProviderServer{env: env})
+	proto.RegisterProviderLifecycleServer(srv, &fakeHostedAgentLifecycleServer{name: req.PluginName})
+	go func() {
+		_ = srv.Serve(lis)
+	}()
+
+	r.mu.Lock()
+	r.fakeAgents[req.SessionID] = &fakeHostedAgentServer{
+		dir:      dir,
+		env:      env,
+		listener: lis,
+		server:   srv,
+	}
+	r.mu.Unlock()
+
+	return &pluginruntime.HostedPlugin{
+		ID:         req.SessionID,
+		SessionID:  req.SessionID,
+		PluginName: req.PluginName,
+		DialTarget: "unix://" + socketPath,
+	}, nil
+}
+
+func (r *capturingHostedAgentRuntime) cleanupFakeHostedAgent(sessionID string) {
+	r.mu.Lock()
+	server := r.fakeAgents[sessionID]
+	delete(r.fakeAgents, sessionID)
+	r.mu.Unlock()
+	if server == nil {
+		return
+	}
+	server.server.Stop()
+	_ = server.listener.Close()
+	_ = os.RemoveAll(server.dir)
+}
+
+type fakeHostedAgentLifecycleServer struct {
+	proto.UnimplementedProviderLifecycleServer
+	name string
+}
+
+func (s *fakeHostedAgentLifecycleServer) GetProviderIdentity(context.Context, *emptypb.Empty) (*proto.ProviderIdentity, error) {
+	return &proto.ProviderIdentity{
+		Kind:               proto.ProviderKind_PROVIDER_KIND_AGENT,
+		Name:               s.name,
+		DisplayName:        "Fake Hosted Agent",
+		Description:        "test-only fake hosted agent",
+		Version:            "test",
+		MinProtocolVersion: proto.CurrentProtocolVersion,
+		MaxProtocolVersion: proto.CurrentProtocolVersion,
+	}, nil
+}
+
+func (s *fakeHostedAgentLifecycleServer) ConfigureProvider(context.Context, *proto.ConfigureProviderRequest) (*proto.ConfigureProviderResponse, error) {
+	return &proto.ConfigureProviderResponse{ProtocolVersion: proto.CurrentProtocolVersion}, nil
+}
+
+func (s *fakeHostedAgentLifecycleServer) HealthCheck(context.Context, *emptypb.Empty) (*proto.HealthCheckResponse, error) {
+	return &proto.HealthCheckResponse{Ready: true}, nil
+}
+
+type fakeHostedAgentProviderServer struct {
+	proto.UnimplementedAgentProviderServer
+	env map[string]string
+}
+
+func (s *fakeHostedAgentProviderServer) StartRun(ctx context.Context, req *proto.StartAgentProviderRunRequest) (*proto.BoundAgentRun, error) {
+	runID := strings.TrimSpace(req.GetRunId())
+	if runID == "" {
+		runID = "agent-run-1"
+	}
+	output := map[string]any{
+		"provider_name": req.GetProviderName(),
+	}
+	if proxyTargetURL := strings.TrimSpace(s.env["GESTALT_FAKE_PROXY_TARGET_URL"]); proxyTargetURL != "" {
+		resp, err := fakeHostedMakeHTTPRequest(proxyTargetURL, s.env)
+		if err != nil {
+			output["proxy_error"] = err.Error()
+		} else {
+			output["proxy_status"] = resp["status"]
+			output["proxy_body"] = resp["body"]
+		}
+	}
+	if len(req.GetTools()) > 0 {
+		client, conn, err := dialFakeAgentHost(ctx, s.env[providerhost.DefaultAgentHostSocketEnv], s.env[providerhost.DefaultAgentHostSocketEnv+"_TOKEN"])
+		if err != nil {
+			output["host_error"] = err.Error()
+		} else {
+			defer func() { _ = conn.Close() }()
+			arguments, err := structpb.NewStruct(map[string]any{"taskId": "task-123"})
+			if err != nil {
+				return nil, fmt.Errorf("build tool arguments: %w", err)
+			}
+			resp, err := client.ExecuteTool(ctx, &proto.ExecuteAgentToolRequest{
+				RunId:      runID,
+				ToolCallId: "call-1",
+				ToolId:     req.GetTools()[0].GetId(),
+				Arguments:  arguments,
+			})
+			if err != nil {
+				output["tool_error"] = err.Error()
+			} else {
+				output["tool_status"] = resp.GetStatus()
+				output["tool_body"] = resp.GetBody()
+			}
+		}
+	}
+
+	body, err := json.Marshal(output)
+	if err != nil {
+		return nil, fmt.Errorf("marshal output: %w", err)
+	}
+	now := timestamppb.Now()
+	return &proto.BoundAgentRun{
+		Id:           runID,
+		ProviderName: req.GetProviderName(),
+		Model:        req.GetModel(),
+		Status:       proto.AgentRunStatus_AGENT_RUN_STATUS_SUCCEEDED,
+		OutputText:   string(body),
+		SessionRef:   req.GetSessionRef(),
+		CreatedBy:    req.GetCreatedBy(),
+		CreatedAt:    now,
+		StartedAt:    now,
+		CompletedAt:  now,
+		ExecutionRef: req.GetExecutionRef(),
+	}, nil
+}
+
+func dialFakeAgentHost(ctx context.Context, target, token string) (proto.AgentHostClient, *grpc.ClientConn, error) {
+	network, address, err := parseFakeManagerTarget("agent host", target)
+	if err != nil {
+		return nil, nil, err
+	}
+	opts := make([]grpc.DialOption, 0, 4)
+	switch network {
+	case "unix":
+		opts = append(opts,
+			grpc.WithTransportCredentials(insecure.NewCredentials()),
+			grpc.WithContextDialer(func(ctx context.Context, _ string) (net.Conn, error) {
+				var d net.Dialer
+				return d.DialContext(ctx, "unix", address)
+			}),
+			grpc.WithAuthority("localhost"),
+		)
+		conn, err := grpc.NewClient("passthrough:///localhost", opts...)
+		if err != nil {
+			return nil, nil, err
+		}
+		conn.Connect()
+		return proto.NewAgentHostClient(conn), conn, nil
+	case "tls":
+		host, _, err := net.SplitHostPort(address)
+		if err != nil {
+			return nil, nil, fmt.Errorf("agent host: parse tls target %q: %w", address, err)
+		}
+		opts = append(opts, grpc.WithTransportCredentials(credentials.NewTLS(&tls.Config{
+			MinVersion:         tls.VersionTLS12,
+			ServerName:         host,
+			InsecureSkipVerify: true, // Test-only relay harness certificate.
+			NextProtos:         []string{"h2"},
+		})))
+		if strings.TrimSpace(token) != "" {
+			opts = append(opts, grpc.WithPerRPCCredentials(fakeRelayPerRPCCredentials{token: token}))
+		}
+		conn, err := grpc.NewClient(address, opts...)
+		if err != nil {
+			return nil, nil, err
+		}
+		conn.Connect()
+		return proto.NewAgentHostClient(conn), conn, nil
+	default:
+		return nil, nil, fmt.Errorf("agent host: unsupported transport network %q", network)
+	}
+}
+
+func parseFakeManagerTarget(serviceName, raw string) (network string, address string, err error) {
+	target := strings.TrimSpace(raw)
+	if target == "" {
+		return "", "", fmt.Errorf("%s: transport target is required", serviceName)
+	}
+	switch {
+	case strings.HasPrefix(target, "tls://"):
+		address = strings.TrimSpace(strings.TrimPrefix(target, "tls://"))
+		if address == "" {
+			return "", "", fmt.Errorf("%s: tls target %q is missing host:port", serviceName, raw)
+		}
+		return "tls", address, nil
+	case strings.HasPrefix(target, "unix://"):
+		address = strings.TrimSpace(strings.TrimPrefix(target, "unix://"))
+		if address == "" {
+			return "", "", fmt.Errorf("%s: unix target %q is missing a socket path", serviceName, raw)
+		}
+		return "unix", address, nil
+	default:
+		return "", "", fmt.Errorf("%s: unsupported target %q", serviceName, raw)
+	}
+}
+
+type fakeRelayPerRPCCredentials struct {
+	token string
+}
+
+func (c fakeRelayPerRPCCredentials) GetRequestMetadata(context.Context, ...string) (map[string]string, error) {
+	return map[string]string{
+		"x-gestalt-host-service-relay-token": c.token,
+	}, nil
+}
+
+func (fakeRelayPerRPCCredentials) RequireTransportSecurity() bool { return false }
 
 func TestAgentRuntimeConfigSelectedProviderStartsSessionWithRuntimeFields(t *testing.T) {
 	t.Parallel()
@@ -326,6 +690,7 @@ func TestAgentRuntimeConfigUsesPublicAgentHostRelayBinding(t *testing.T) {
 
 	runtimeProvider := newCapturingBundlePluginRuntime()
 	runtimeProvider.support.HostServiceAccess = pluginruntime.HostServiceAccessNone
+	runtimeProvider.support.EgressMode = pluginruntime.EgressModeHostname
 	runtimeProvider.support.LaunchMode = pluginruntime.LaunchModeHostPath
 
 	factories := NewFactoryRegistry()
@@ -397,6 +762,192 @@ func TestAgentRuntimeConfigUsesPublicAgentHostRelayBinding(t *testing.T) {
 	}
 	if got := startRequests[0].Env[providerhost.DefaultAgentHostSocketEnv+"_TOKEN"]; strings.TrimSpace(got) == "" {
 		t.Fatalf("StartPlugin env missing %s_TOKEN: %#v", providerhost.DefaultAgentHostSocketEnv, startRequests[0].Env)
+	}
+	if got := startRequests[0].Env["HTTP_PROXY"]; got != "" {
+		t.Fatalf("StartPlugin HTTP_PROXY = %q, want empty when relay access does not require hostname egress", got)
+	}
+	if got := startRequests[0].Env["HTTPS_PROXY"]; got != "" {
+		t.Fatalf("StartPlugin HTTPS_PROXY = %q, want empty when relay access does not require hostname egress", got)
+	}
+	if got := startRequests[0].AllowedHosts; len(got) != 0 {
+		t.Fatalf("StartPlugin allowed hosts = %#v, want empty when relay access is not enforcing hostname egress", got)
+	}
+}
+
+//nolint:paralleltest // Hosted public-relay startup is serialized to avoid Linux CI contention.
+func TestAgentRuntimeConfigUsesPublicEgressProxyWhenHostnameEgressIsRequired(t *testing.T) {
+	bin := buildAgentProviderBinary(t)
+	secret := []byte("0123456789abcdef0123456789abcdef")
+	relayHandler := newRuntimeRelayTestHandler(t, secret)
+	proxyHandler := newRuntimeEgressProxyTestHandler(t, secret)
+	relaySrv := httptest.NewUnstartedServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if strings.TrimSpace(r.Header.Get(providerhost.HostServiceRelayTokenHeader)) != "" {
+			relayHandler.ServeHTTP(w, r)
+			return
+		}
+		proxyHandler.ServeHTTP(w, r)
+	}))
+	relaySrv.EnableHTTP2 = true
+	relaySrv.StartTLS()
+	testutil.CloseOnCleanup(t, relaySrv)
+
+	targetSrv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if got := r.URL.Path; got != "/proxy-test" {
+			t.Fatalf("target path = %q, want /proxy-test", got)
+		}
+		_, _ = w.Write([]byte("agent-egress-proxy-ok"))
+	}))
+	testutil.CloseOnCleanup(t, targetSrv)
+
+	runtimeProvider := newCapturingHostedAgentRuntime()
+	runtimeProvider.support.HostServiceAccess = pluginruntime.HostServiceAccessNone
+	runtimeProvider.support.EgressMode = pluginruntime.EgressModeHostname
+	runtimeProvider.extraEnv = map[string]string{
+		"GESTALT_FAKE_PROXY_TARGET_URL": targetSrv.URL + "/proxy-test",
+	}
+
+	factories := NewFactoryRegistry()
+	factories.Runtime = func(context.Context, string, *config.RuntimeProviderEntry, Deps) (pluginruntime.Provider, error) {
+		return runtimeProvider, nil
+	}
+
+	cfg := &config.Config{
+		Server: config.ServerConfig{
+			Runtime: config.ServerRuntimeConfig{Provider: "hosted"},
+			Egress:  config.EgressConfig{DefaultAction: string(egress.PolicyDeny)},
+		},
+		Runtime: config.RuntimeConfig{
+			Providers: map[string]*config.RuntimeProviderEntry{
+				"hosted": {Driver: config.RuntimeProviderDriver("capture")},
+			},
+		},
+		Providers: config.ProvidersConfig{
+			Agent: map[string]*config.ProviderEntry{
+				"simple": {
+					Command: bin,
+					Runtime: &config.HostedRuntimeConfig{},
+					AllowedHosts: []string{
+						"127.0.0.1",
+						"localhost",
+					},
+				},
+			},
+		},
+	}
+
+	services := coretesting.NewStubServices(t)
+	invoker := &recordingAgentRuntimeInvoker{}
+	runtimeState := &agentRuntime{providers: map[string]coreagent.Provider{}}
+	runtimeState.SetInvoker(invoker)
+	runtimeState.SetRunMetadata(services.AgentRunMetadata)
+	runtimeState.SetRunEvents(services.AgentRunEvents)
+	deps := Deps{
+		BaseURL:       relaySrv.URL,
+		EncryptionKey: secret,
+		Egress:        EgressDeps{DefaultAction: egress.PolicyDeny},
+		AgentRuntime:  runtimeState,
+	}
+	deps.PluginRuntimeRegistry = newPluginRuntimeRegistry(cfg, factories.Runtime, deps)
+
+	agents, err := buildAgents(context.Background(), cfg, factories, deps)
+	if err != nil {
+		t.Fatalf("buildAgents: %v", err)
+	}
+	defer func() {
+		if err := closeAgents(agents...); err != nil {
+			t.Fatalf("closeAgents: %v", err)
+		}
+	}()
+
+	run, err := agents[0].StartRun(context.Background(), coreagent.StartRunRequest{
+		RunID:        "run-1",
+		ProviderName: "simple",
+		CreatedBy:    coreagent.Actor{SubjectID: "user:user-123"},
+		Tools: []coreagent.Tool{{
+			ID:   "lookup",
+			Name: "Lookup roadmap task",
+			Target: coreagent.ToolTarget{
+				PluginName: "roadmap",
+				Operation:  "sync",
+			},
+		}},
+	})
+	if err != nil {
+		t.Fatalf("StartRun: %v", err)
+	}
+
+	var output struct {
+		ProviderName string `json:"provider_name"`
+		ProxyStatus  int    `json:"proxy_status"`
+		ProxyBody    string `json:"proxy_body"`
+		ToolStatus   int    `json:"tool_status"`
+		ToolBody     string `json:"tool_body"`
+		ProxyError   string `json:"proxy_error"`
+		HostError    string `json:"host_error"`
+		ToolError    string `json:"tool_error"`
+	}
+	if err := json.Unmarshal([]byte(run.OutputText), &output); err != nil {
+		t.Fatalf("json.Unmarshal(run.OutputText): %v", err)
+	}
+	if output.ProviderName != "simple" {
+		t.Fatalf("provider_name = %q, want simple", output.ProviderName)
+	}
+	if output.ProxyStatus != http.StatusOK {
+		t.Fatalf("proxy_status = %d, want %d (output=%s)", output.ProxyStatus, http.StatusOK, run.OutputText)
+	}
+	if output.ProxyBody != "agent-egress-proxy-ok" {
+		t.Fatalf("proxy_body = %q, want %q", output.ProxyBody, "agent-egress-proxy-ok")
+	}
+	if output.ToolStatus != http.StatusAccepted {
+		t.Fatalf("tool_status = %d, want %d (output=%s)", output.ToolStatus, http.StatusAccepted, run.OutputText)
+	}
+	if output.ToolBody != `{"taskId":"task-123"}` {
+		t.Fatalf("tool_body = %q, want %q", output.ToolBody, `{"taskId":"task-123"}`)
+	}
+	if output.ProxyError != "" || output.HostError != "" || output.ToolError != "" {
+		t.Fatalf("runtime callback errors = %+v", output)
+	}
+	calls := invoker.Calls()
+	if len(calls) != 1 {
+		t.Fatalf("invoker calls = %d, want 1", len(calls))
+	}
+	if calls[0].providerName != "roadmap" || calls[0].operation != "sync" {
+		t.Fatalf("invoker call = %#v, want roadmap sync", calls[0])
+	}
+
+	startRequests := runtimeProvider.startPluginRequestsCopy()
+	if len(startRequests) != 1 {
+		t.Fatalf("start plugin requests = %d, want 1", len(startRequests))
+	}
+	if got := startRequests[0].Env[providerhost.DefaultAgentHostSocketEnv+"_TOKEN"]; strings.TrimSpace(got) == "" {
+		t.Fatalf("StartPlugin env missing %s_TOKEN: %#v", providerhost.DefaultAgentHostSocketEnv, startRequests[0].Env)
+	}
+	httpProxy := startRequests[0].Env["HTTP_PROXY"]
+	httpsProxy := startRequests[0].Env["HTTPS_PROXY"]
+	if httpProxy == "" {
+		t.Fatal("StartPlugin env should include HTTP_PROXY when hostname egress is required")
+	}
+	if httpsProxy == "" {
+		t.Fatal("StartPlugin env should include HTTPS_PROXY when hostname egress is required")
+	}
+	if httpProxy != httpsProxy {
+		t.Fatalf("HTTP_PROXY = %q, HTTPS_PROXY = %q, want matching values", httpProxy, httpsProxy)
+	}
+	parsed, err := url.Parse(httpProxy)
+	if err != nil {
+		t.Fatalf("parse HTTP_PROXY: %v", err)
+	}
+	if parsed.Host != relaySrv.Listener.Addr().String() {
+		t.Fatalf("HTTP_PROXY host = %q, want %q", parsed.Host, relaySrv.Listener.Addr().String())
+	}
+	if parsed.User == nil {
+		t.Fatal("HTTP_PROXY should include relay credentials")
+	}
+	if got := startRequests[0].AllowedHosts; !slices.Contains(got, parsed.Hostname()) {
+		t.Fatalf("StartPlugin allowed hosts = %#v, want relay host %q", got, parsed.Hostname())
+	}
+	if got := startRequests[0].AllowedHosts; !slices.Contains(got, "127.0.0.1") {
+		t.Fatalf("StartPlugin allowed hosts = %#v, want explicit proxy target host 127.0.0.1", got)
 	}
 }
 

--- a/gestaltd/internal/bootstrap/provider_build.go
+++ b/gestaltd/internal/bootstrap/provider_build.go
@@ -1041,7 +1041,7 @@ func buildHostedAgentProvider(ctx context.Context, name string, entry *config.Pr
 	})
 
 	startEnv := maps.Clone(cfg.Env)
-	allowedHosts := slices.Clone(cfg.AllowedHosts)
+	allowedHosts := hostedAgentAllowedHosts(cfg.AllowedHosts, runtimePlan)
 	for _, hostService := range startedHostServices.Bindings() {
 		bindingReq, bindingEnv, relayHost, err := buildHostedRuntimeHostServiceBinding(name, sessionID, hostService, deps, runtimePlan.Resolved.HostServiceAccess == RuntimeHostServiceAccessDirect)
 		if err != nil {
@@ -1056,7 +1056,9 @@ func buildHostedAgentProvider(ctx context.Context, name string, entry *config.Pr
 			}
 			maps.Copy(startEnv, bindingEnv)
 		}
-		allowedHosts = appendAllowedHost(allowedHosts, relayHost)
+		if runtimePlan.RequiresHostnameEgress {
+			allowedHosts = appendAllowedHost(allowedHosts, relayHost)
+		}
 	}
 	if runtimePlan.HostnameEgressDelivery == RuntimeHostnameEgressDeliveryPublicProxy {
 		proxyEnv, err := buildHostedRuntimePublicEgressProxy(name, sessionID, cfg.AllowedHosts, deps.Egress.DefaultAction, deps)
@@ -1538,6 +1540,37 @@ func appendAllowedHost(allowedHosts []string, host string) []string {
 		}
 	}
 	return append(allowedHosts, host)
+}
+
+func hostedAgentAllowedHosts(allowedHosts []string, runtimePlan HostedRuntimePlan) []string {
+	cloned := slices.Clone(allowedHosts)
+	if runtimePlan.Resolved.HostServiceAccess != RuntimeHostServiceAccessRelay || runtimePlan.RequiresHostnameEgress {
+		return cloned
+	}
+	// Hosted agent bundles include loopback host allowances for local SDK
+	// transports. Once the agent host is exposed over the public relay, those
+	// loopback hosts are no longer relevant and can spuriously force hosted
+	// runtimes into proxy-enforced egress mode.
+	out := cloned[:0]
+	for _, host := range cloned {
+		if isLoopbackAllowedHost(host) {
+			continue
+		}
+		out = append(out, host)
+	}
+	if len(out) == 0 {
+		return nil
+	}
+	return out
+}
+
+func isLoopbackAllowedHost(host string) bool {
+	host = strings.TrimSpace(strings.Trim(host, "[]"))
+	if strings.EqualFold(host, "localhost") {
+		return true
+	}
+	ip := net.ParseIP(host)
+	return ip != nil && ip.IsLoopback()
 }
 
 func buildPluginIndexedDBHostServices(pluginName string, effective config.EffectivePluginIndexedDB, deps Deps) ([]providerhost.HostService, func(), error) {


### PR DESCRIPTION
## Summary
Hosted agent startup over the public relay now keeps relay-only access from forcing proxy-mode hostname egress when the runtime is not enforcing hostname controls.

## New Behavior
- Default-allow hosted agent relay: `StartPlugin` omits `HTTP_PROXY` / `HTTPS_PROXY` and sends no relay-only `AllowedHosts`.
- Default-deny hosted agent relay: `StartPlugin` includes `HTTP_PROXY` / `HTTPS_PROXY` and still includes the relay host in `AllowedHosts`.

## Examples
- Default allow:
  - hosted agent runtime uses the public relay for `GESTALT_AGENT_HOST`
  - `StartPlugin.Env` includes `GESTALT_AGENT_HOST_TOKEN`
  - `StartPlugin.Env` omits `HTTP_PROXY` / `HTTPS_PROXY`
  - `StartPlugin.AllowedHosts` stays empty unless the agent explicitly requires hostname egress
- Default deny:
  - hosted agent runtime uses the public relay for `GESTALT_AGENT_HOST`
  - `StartPlugin.Env` includes `GESTALT_AGENT_HOST_TOKEN`
  - `StartPlugin.Env` includes `HTTP_PROXY` / `HTTPS_PROXY`
  - `StartPlugin.AllowedHosts` still contains the relay host so the relay dial target stays reachable

## Tests
- `go test ./internal/bootstrap -run 'TestAgentRuntimeConfigUsesPublicAgentHostRelayBinding|TestAgentRuntimeConfigUsesPublicEgressProxyWhenHostnameEgressIsRequired|TestAgentRuntimeConfigRejectsMissingHostServiceAccess|TestPluginRuntimeConfigUsesPublicWorkflowManagerRelayWithoutHostServiceTunnelCapability|TestPluginRuntimePublicEgressProxyRoundTripsThroughHostedPlugin'`
- `golangci-lint run ./internal/bootstrap/...`