### PR TITLE
external credentials: move local storage to provider-owned store

### DIFF
--- a/gestaltd/cmd/gestaltd/provider_test.go
+++ b/gestaltd/cmd/gestaltd/provider_test.go
@@ -1302,7 +1302,7 @@ func TestRun_ProviderReleaseBuildsGoSourceExternalCredentialsPlugin(t *testing.T
 	if credential.CreatedAt.IsZero() || credential.UpdatedAt.IsZero() {
 		t.Fatalf("credential timestamps = created_at:%v updated_at:%v", credential.CreatedAt, credential.UpdatedAt)
 	}
-	raw, err := services.DB.ObjectStore(coredata.StoreIntegrationTokens).Get(context.Background(), credential.ID)
+	raw, err := services.DB.ObjectStore(coredata.StoreExternalCredentials).Get(context.Background(), credential.ID)
 	if err != nil {
 		t.Fatalf("stored credential raw Get: %v", err)
 	}

--- a/gestaltd/internal/bootstrap/bootstrap.go
+++ b/gestaltd/internal/bootstrap/bootstrap.go
@@ -1240,14 +1240,15 @@ func buildNamedExternalCredentialsProvider(ctx context.Context, name string, ent
 }
 
 func buildExternalCredentialsHostServices(name string, deps Deps) ([]providerhost.HostService, error) {
-	if deps.Services == nil || deps.Services.Tokens == nil {
+	provider := coredata.LocalExternalCredentialProvider(deps.Services)
+	if coredata.ExternalCredentialProviderMissing(provider) {
 		return nil, fmt.Errorf("local external credentials provider is not available")
 	}
 	return []providerhost.HostService{{
 		Name:   "external-credentials",
 		EnvVar: providerhost.DefaultExternalCredentialSocketEnv,
 		Register: func(srv *grpc.Server) {
-			proto.RegisterExternalCredentialProviderServer(srv, providerhost.NewExternalCredentialProviderServer(deps.Services.Tokens))
+			proto.RegisterExternalCredentialProviderServer(srv, providerhost.NewExternalCredentialProviderServer(provider))
 		},
 	}}, nil
 }
@@ -1293,7 +1294,7 @@ func closeExternalCredentialProviderCandidate(services *coredata.Services) error
 	if services == nil || coredata.ExternalCredentialProviderMissing(services.ExternalCredentials) {
 		return nil
 	}
-	if services.Tokens != nil && services.ExternalCredentials == services.Tokens {
+	if coredata.SameExternalCredentialProvider(services.ExternalCredentials, coredata.LocalExternalCredentialProvider(services)) {
 		return nil
 	}
 	return closeExternalCredentialProvider(services.ExternalCredentials)

--- a/gestaltd/internal/coredata/convert.go
+++ b/gestaltd/internal/coredata/convert.go
@@ -21,23 +21,6 @@ func recString(rec indexeddb.Record, key string) string {
 	}
 }
 
-func recInt(rec indexeddb.Record, key string) int {
-	v, ok := rec[key]
-	if !ok || v == nil {
-		return 0
-	}
-	switch n := v.(type) {
-	case int:
-		return n
-	case int64:
-		return int(n)
-	case float64:
-		return int(n)
-	default:
-		return 0
-	}
-}
-
 func recInt64(rec indexeddb.Record, key string) int64 {
 	v, ok := rec[key]
 	if !ok || v == nil {

--- a/gestaltd/internal/coredata/external_credentials.go
+++ b/gestaltd/internal/coredata/external_credentials.go
@@ -13,10 +13,26 @@ func EffectiveExternalCredentialProvider(services *Services) core.ExternalCreden
 	if !ExternalCredentialProviderMissing(services.ExternalCredentials) {
 		return services.ExternalCredentials
 	}
+	if provider := LocalExternalCredentialProvider(services); !ExternalCredentialProviderMissing(provider) {
+		return provider
+	}
 	if services.Tokens != nil {
 		return services.Tokens
 	}
 	return nil
+}
+
+func LocalExternalCredentialProvider(services *Services) core.ExternalCredentialProvider {
+	if services == nil {
+		return nil
+	}
+	if !ExternalCredentialProviderMissing(services.LocalExternalCredentials) {
+		return services.LocalExternalCredentials
+	}
+	if services.Tokens == nil {
+		return nil
+	}
+	return services.Tokens.Provider()
 }
 
 func ExternalCredentialProviderMissing(provider core.ExternalCredentialProvider) bool {
@@ -30,4 +46,16 @@ func ExternalCredentialProviderMissing(provider core.ExternalCredentialProvider)
 	default:
 		return false
 	}
+}
+
+func SameExternalCredentialProvider(a, b core.ExternalCredentialProvider) bool {
+	if ExternalCredentialProviderMissing(a) || ExternalCredentialProviderMissing(b) {
+		return false
+	}
+	va := reflect.ValueOf(a)
+	vb := reflect.ValueOf(b)
+	if va.Type() != vb.Type() || !va.Type().Comparable() {
+		return false
+	}
+	return va.Interface() == vb.Interface()
 }

--- a/gestaltd/internal/coredata/external_credentials_test.go
+++ b/gestaltd/internal/coredata/external_credentials_test.go
@@ -5,6 +5,20 @@ import "testing"
 func TestEffectiveExternalCredentialProviderHandlesTypedNilFallbacks(t *testing.T) {
 	t.Parallel()
 
+	t.Run("falls back from typed nil external credentials to local provider", func(t *testing.T) {
+		t.Parallel()
+
+		var missing *TokenService
+		local := &TokenService{}
+		got := EffectiveExternalCredentialProvider(&Services{
+			ExternalCredentials:      missing,
+			LocalExternalCredentials: local,
+		})
+		if got != local {
+			t.Fatalf("EffectiveExternalCredentialProvider returned %#v, want %#v", got, local)
+		}
+	})
+
 	t.Run("falls back from typed nil external credentials to tokens", func(t *testing.T) {
 		t.Parallel()
 

--- a/gestaltd/internal/coredata/schemas.go
+++ b/gestaltd/internal/coredata/schemas.go
@@ -1,10 +1,16 @@
 package coredata
 
-import "github.com/valon-technologies/gestalt/server/core/indexeddb"
+import (
+	"github.com/valon-technologies/gestalt/server/core/indexeddb"
+	"github.com/valon-technologies/gestalt/server/internal/externalcredentials"
+)
 
 const (
-	StoreUsers                    = "users"
+	StoreUsers = "users"
+	// StoreIntegrationTokens is kept only as a legacy table name for
+	// deployment-managed migrations. New runtime writes use StoreExternalCredentials.
 	StoreIntegrationTokens        = "integration_tokens"
+	StoreExternalCredentials      = externalcredentials.StoreName
 	StoreAPITokens                = "api_tokens"
 	StoreIdentities               = "identities"
 	StoreIdentityAuthBindings     = "identity_auth_bindings"
@@ -33,30 +39,11 @@ var UsersSchema = indexeddb.ObjectStoreSchema{
 	},
 }
 
-var IntegrationTokensSchema = indexeddb.ObjectStoreSchema{
-	Indexes: []indexeddb.IndexSchema{
-		{Name: "by_subject", KeyPath: []string{"subject_id"}},
-		{Name: "by_subject_integration", KeyPath: []string{"subject_id", "integration"}},
-		{Name: "by_subject_connection", KeyPath: []string{"subject_id", "integration", "connection"}},
-		{Name: "by_lookup", KeyPath: []string{"subject_id", "integration", "connection", "instance"}, Unique: true},
-	},
-	Columns: []indexeddb.ColumnDef{
-		{Name: "id", Type: indexeddb.TypeString, PrimaryKey: true},
-		{Name: "subject_id", Type: indexeddb.TypeString, NotNull: true},
-		{Name: "integration", Type: indexeddb.TypeString, NotNull: true},
-		{Name: "connection", Type: indexeddb.TypeString, NotNull: true},
-		{Name: "instance", Type: indexeddb.TypeString},
-		{Name: "access_token_encrypted", Type: indexeddb.TypeString},
-		{Name: "refresh_token_encrypted", Type: indexeddb.TypeString},
-		{Name: "scopes", Type: indexeddb.TypeString},
-		{Name: "expires_at", Type: indexeddb.TypeTime},
-		{Name: "last_refreshed_at", Type: indexeddb.TypeTime},
-		{Name: "refresh_error_count", Type: indexeddb.TypeInt},
-		{Name: "metadata_json", Type: indexeddb.TypeString},
-		{Name: "created_at", Type: indexeddb.TypeTime},
-		{Name: "updated_at", Type: indexeddb.TypeTime},
-	},
-}
+var ExternalCredentialsSchema = externalcredentials.Schema
+
+// IntegrationTokensSchema is kept only as a legacy schema alias for
+// deployment-managed migrations. New runtime writes use ExternalCredentialsSchema.
+var IntegrationTokensSchema = externalcredentials.Schema
 
 var APITokensSchema = indexeddb.ObjectStoreSchema{
 	Indexes: []indexeddb.IndexSchema{

--- a/gestaltd/internal/coredata/services.go
+++ b/gestaltd/internal/coredata/services.go
@@ -11,6 +11,7 @@ import (
 
 type Services struct {
 	Users                    *UserService
+	LocalExternalCredentials core.ExternalCredentialProvider
 	ExternalCredentials      core.ExternalCredentialProvider
 	Tokens                   *TokenService
 	APITokens                *APITokenService
@@ -30,9 +31,6 @@ func New(ds indexeddb.IndexedDB, enc *corecrypto.AESGCMEncryptor) (*Services, er
 	ctx := context.Background()
 	if err := ds.CreateObjectStore(ctx, StoreUsers, UsersSchema); err != nil {
 		return nil, fmt.Errorf("create users store: %w", err)
-	}
-	if err := ds.CreateObjectStore(ctx, StoreIntegrationTokens, IntegrationTokensSchema); err != nil {
-		return nil, fmt.Errorf("create integration_tokens store: %w", err)
 	}
 	if err := ds.CreateObjectStore(ctx, StoreAPITokens, APITokensSchema); err != nil {
 		return nil, fmt.Errorf("create api_tokens store: %w", err)
@@ -83,7 +81,11 @@ func New(ds indexeddb.IndexedDB, enc *corecrypto.AESGCMEncryptor) (*Services, er
 		return nil, fmt.Errorf("backfill users store: %w", err)
 	}
 	apiTokens := NewAPITokenService(ds, apiTokenAccess, users)
-	tokens := NewTokenService(ds, enc)
+	localExternalCredentials, err := NewLocalExternalCredentialProvider(ds, enc)
+	if err != nil {
+		return nil, fmt.Errorf("create local external credentials provider: %w", err)
+	}
+	tokens := NewTokenService(localExternalCredentials)
 
 	if err := rebuildCanonicalIdentityGraph(ctx, identities, authBindings, identityManagementGrants, workspaceRoles, identityPluginAccess, apiTokenAccess); err != nil {
 		return nil, err
@@ -95,7 +97,8 @@ func New(ds indexeddb.IndexedDB, enc *corecrypto.AESGCMEncryptor) (*Services, er
 		return nil, fmt.Errorf("backfill canonical api token access: %w", err)
 	}
 	return &Services{
-		ExternalCredentials:      tokens,
+		LocalExternalCredentials: localExternalCredentials,
+		ExternalCredentials:      localExternalCredentials,
 		Users:                    users,
 		Tokens:                   tokens,
 		APITokens:                apiTokens,

--- a/gestaltd/internal/coredata/services_test.go
+++ b/gestaltd/internal/coredata/services_test.go
@@ -757,7 +757,7 @@ func TestTokenService(t *testing.T) {
 			t.Fatalf("StoreToken legacy source: %v", err)
 		}
 
-		store := db.ObjectStore(coredata.StoreIntegrationTokens)
+		store := db.ObjectStore(coredata.StoreExternalCredentials)
 		primaryRaw, err := store.Get(ctx, newest.ID)
 		if err != nil {
 			t.Fatalf("Get primary raw: %v", err)
@@ -802,18 +802,8 @@ func TestTokenService(t *testing.T) {
 		if err := svc.Tokens.DeleteToken(ctx, newest.ID); err != nil {
 			t.Fatalf("DeleteToken newest: %v", err)
 		}
-		fallback, err := svc.Tokens.Token(ctx, principal.UserSubjectID(user.ID), "svc", "default", "i1")
-		if err != nil {
-			t.Fatalf("Token after deleting newest duplicate: %v", err)
-		}
-		if fallback.ID != "tok-legacy-duplicate" {
-			t.Fatalf("fallback ID = %q, want %q", fallback.ID, "tok-legacy-duplicate")
-		}
-		if fallback.AccessToken != "legacy" {
-			t.Fatalf("fallback AccessToken = %q, want %q", fallback.AccessToken, "legacy")
-		}
-		if fallback.RefreshToken != "refresh-legacy" {
-			t.Fatalf("fallback RefreshToken = %q, want %q", fallback.RefreshToken, "refresh-legacy")
+		if _, err := svc.Tokens.Token(ctx, principal.UserSubjectID(user.ID), "svc", "default", "i1"); err != core.ErrNotFound {
+			t.Fatalf("Token after deleting duplicate lookup = %v, want ErrNotFound", err)
 		}
 	})
 
@@ -878,7 +868,7 @@ func TestTokenService(t *testing.T) {
 			t.Fatalf("StoreToken: %v", err)
 		}
 
-		raw, err := db.ObjectStore(coredata.StoreIntegrationTokens).Get(ctx, "enc-tok")
+		raw, err := db.ObjectStore(coredata.StoreExternalCredentials).Get(ctx, "enc-tok")
 		if err != nil {
 			t.Fatalf("raw Get: %v", err)
 		}
@@ -907,6 +897,191 @@ func TestTokenService(t *testing.T) {
 		}
 		if got.RefreshToken != "plaintext-refresh" {
 			t.Errorf("decrypted RefreshToken = %q, want %q", got.RefreshToken, "plaintext-refresh")
+		}
+	})
+
+	t.Run("New_reads_legacy_integration_tokens_until_manual_migration", func(t *testing.T) {
+		t.Parallel()
+
+		db := &coretesting.StubIndexedDB{}
+		enc, err := corecrypto.NewAESGCM([]byte(testEncryptionKey))
+		if err != nil {
+			t.Fatalf("NewAESGCM: %v", err)
+		}
+		ctx := context.Background()
+		if err := db.CreateObjectStore(ctx, coredata.StoreIntegrationTokens, coredata.IntegrationTokensSchema); err != nil {
+			t.Fatalf("CreateObjectStore(%s): %v", coredata.StoreIntegrationTokens, err)
+		}
+		accessEncrypted, refreshEncrypted, err := enc.EncryptTokenPair("legacy-access", "legacy-refresh")
+		if err != nil {
+			t.Fatalf("EncryptTokenPair: %v", err)
+		}
+		if err := db.ObjectStore(coredata.StoreIntegrationTokens).Put(ctx, indexeddb.Record{
+			"id":                      "legacy-token",
+			"subject_id":              "user:user-legacy",
+			"integration":             "slack",
+			"connection":              "default",
+			"instance":                "workspace-1",
+			"access_token_encrypted":  accessEncrypted,
+			"refresh_token_encrypted": refreshEncrypted,
+			"created_at":              time.Now().UTC(),
+			"updated_at":              time.Now().UTC(),
+		}); err != nil {
+			t.Fatalf("seed legacy integration token: %v", err)
+		}
+
+		svc, err := coredata.New(db, enc)
+		if err != nil {
+			t.Fatalf("coredata.New: %v", err)
+		}
+
+		got, err := svc.Tokens.Token(ctx, "user:user-legacy", "slack", "default", "workspace-1")
+		if err != nil {
+			t.Fatalf("Token: %v", err)
+		}
+		if got.ID != "legacy-token" || got.AccessToken != "legacy-access" || got.RefreshToken != "legacy-refresh" {
+			t.Fatalf("Token = %+v, want legacy-token / legacy-access / legacy-refresh", got)
+		}
+		if _, err := db.ObjectStore(coredata.StoreExternalCredentials).Get(ctx, "legacy-token"); err == nil {
+			t.Fatalf("legacy-only token should not be copied into %s during startup", coredata.StoreExternalCredentials)
+		}
+	})
+
+	t.Run("New_prefers_external_credentials_over_legacy_store", func(t *testing.T) {
+		t.Parallel()
+
+		db := &coretesting.StubIndexedDB{}
+		enc, err := corecrypto.NewAESGCM([]byte(testEncryptionKey))
+		if err != nil {
+			t.Fatalf("NewAESGCM: %v", err)
+		}
+		ctx := context.Background()
+		if err := db.CreateObjectStore(ctx, coredata.StoreIntegrationTokens, coredata.IntegrationTokensSchema); err != nil {
+			t.Fatalf("CreateObjectStore(%s): %v", coredata.StoreIntegrationTokens, err)
+		}
+		if err := db.CreateObjectStore(ctx, coredata.StoreExternalCredentials, coredata.ExternalCredentialsSchema); err != nil {
+			t.Fatalf("CreateObjectStore(%s): %v", coredata.StoreExternalCredentials, err)
+		}
+		accessEncrypted, refreshEncrypted, err := enc.EncryptTokenPair("legacy-access", "legacy-refresh")
+		if err != nil {
+			t.Fatalf("EncryptTokenPair: %v", err)
+		}
+		legacyRaw := indexeddb.Record{
+			"id":                      "legacy-token",
+			"subject_id":              "user:user-legacy",
+			"integration":             "slack",
+			"connection":              "default",
+			"instance":                "workspace-1",
+			"access_token_encrypted":  accessEncrypted,
+			"refresh_token_encrypted": refreshEncrypted,
+			"created_at":              time.Now().UTC().Add(-time.Minute),
+			"updated_at":              time.Now().UTC().Add(-time.Minute),
+		}
+		if err := db.ObjectStore(coredata.StoreIntegrationTokens).Put(ctx, legacyRaw); err != nil {
+			t.Fatalf("seed legacy integration token: %v", err)
+		}
+		currentAccessEncrypted, currentRefreshEncrypted, err := enc.EncryptTokenPair("current-access", "current-refresh")
+		if err != nil {
+			t.Fatalf("EncryptTokenPair current: %v", err)
+		}
+		currentRaw := indexeddb.Record{
+			"id":                      "current-token",
+			"subject_id":              "user:user-legacy",
+			"integration":             "slack",
+			"connection":              "default",
+			"instance":                "workspace-1",
+			"access_token_encrypted":  currentAccessEncrypted,
+			"refresh_token_encrypted": currentRefreshEncrypted,
+			"created_at":              time.Now().UTC(),
+			"updated_at":              time.Now().UTC(),
+		}
+		if err := db.ObjectStore(coredata.StoreExternalCredentials).Put(ctx, currentRaw); err != nil {
+			t.Fatalf("seed external credential: %v", err)
+		}
+
+		svc, err := coredata.New(db, enc)
+		if err != nil {
+			t.Fatalf("coredata.New: %v", err)
+		}
+
+		got, err := svc.Tokens.Token(ctx, "user:user-legacy", "slack", "default", "workspace-1")
+		if err != nil {
+			t.Fatalf("Token: %v", err)
+		}
+		if got.ID != "current-token" || got.AccessToken != "current-access" || got.RefreshToken != "current-refresh" {
+			t.Fatalf("Token = %+v, want current-token / current-access / current-refresh", got)
+		}
+	})
+
+	t.Run("DeleteToken_removes_matching_legacy_lookup_rows", func(t *testing.T) {
+		t.Parallel()
+
+		db := &coretesting.StubIndexedDB{}
+		enc, err := corecrypto.NewAESGCM([]byte(testEncryptionKey))
+		if err != nil {
+			t.Fatalf("NewAESGCM: %v", err)
+		}
+		ctx := context.Background()
+		if err := db.CreateObjectStore(ctx, coredata.StoreIntegrationTokens, coredata.IntegrationTokensSchema); err != nil {
+			t.Fatalf("CreateObjectStore(%s): %v", coredata.StoreIntegrationTokens, err)
+		}
+		if err := db.CreateObjectStore(ctx, coredata.StoreExternalCredentials, coredata.ExternalCredentialsSchema); err != nil {
+			t.Fatalf("CreateObjectStore(%s): %v", coredata.StoreExternalCredentials, err)
+		}
+
+		legacyAccessEncrypted, legacyRefreshEncrypted, err := enc.EncryptTokenPair("legacy-access", "legacy-refresh")
+		if err != nil {
+			t.Fatalf("EncryptTokenPair legacy: %v", err)
+		}
+		legacyRaw := indexeddb.Record{
+			"id":                      "legacy-token",
+			"subject_id":              "user:user-legacy",
+			"integration":             "slack",
+			"connection":              "default",
+			"instance":                "workspace-1",
+			"access_token_encrypted":  legacyAccessEncrypted,
+			"refresh_token_encrypted": legacyRefreshEncrypted,
+			"created_at":              time.Now().UTC().Add(-time.Minute),
+			"updated_at":              time.Now().UTC().Add(-time.Minute),
+		}
+		if err := db.ObjectStore(coredata.StoreIntegrationTokens).Put(ctx, legacyRaw); err != nil {
+			t.Fatalf("seed legacy integration token: %v", err)
+		}
+
+		currentAccessEncrypted, currentRefreshEncrypted, err := enc.EncryptTokenPair("current-access", "current-refresh")
+		if err != nil {
+			t.Fatalf("EncryptTokenPair current: %v", err)
+		}
+		currentRaw := indexeddb.Record{
+			"id":                      "current-token",
+			"subject_id":              "user:user-legacy",
+			"integration":             "slack",
+			"connection":              "default",
+			"instance":                "workspace-1",
+			"access_token_encrypted":  currentAccessEncrypted,
+			"refresh_token_encrypted": currentRefreshEncrypted,
+			"created_at":              time.Now().UTC(),
+			"updated_at":              time.Now().UTC(),
+		}
+		if err := db.ObjectStore(coredata.StoreExternalCredentials).Put(ctx, currentRaw); err != nil {
+			t.Fatalf("seed external credential: %v", err)
+		}
+
+		svc, err := coredata.New(db, enc)
+		if err != nil {
+			t.Fatalf("coredata.New: %v", err)
+		}
+		if err := svc.Tokens.DeleteToken(ctx, "current-token"); err != nil {
+			t.Fatalf("DeleteToken: %v", err)
+		}
+		if _, err := svc.Tokens.Token(ctx, "user:user-legacy", "slack", "default", "workspace-1"); err != core.ErrNotFound {
+			t.Fatalf("Token after delete = %v, want ErrNotFound", err)
+		}
+		if _, err := db.ObjectStore(coredata.StoreIntegrationTokens).Get(ctx, "legacy-token"); err != indexeddb.ErrNotFound {
+			t.Fatalf("legacy token raw Get = %v, want ErrNotFound", err)
+		}
+		if _, err := db.ObjectStore(coredata.StoreExternalCredentials).Get(ctx, "current-token"); err != indexeddb.ErrNotFound {
+			t.Fatalf("external credential raw Get = %v, want ErrNotFound", err)
 		}
 	})
 }

--- a/gestaltd/internal/coredata/tokens.go
+++ b/gestaltd/internal/coredata/tokens.go
@@ -2,314 +2,125 @@ package coredata
 
 import (
 	"context"
-	"errors"
 	"fmt"
-	"sort"
-	"strings"
-	"time"
 
-	"github.com/google/uuid"
 	"github.com/valon-technologies/gestalt/server/core"
 	corecrypto "github.com/valon-technologies/gestalt/server/core/crypto"
 	"github.com/valon-technologies/gestalt/server/core/indexeddb"
+	"github.com/valon-technologies/gestalt/server/internal/externalcredentials"
 )
 
-type LocalExternalCredentialProvider struct {
-	store indexeddb.ObjectStore
-	enc   *corecrypto.AESGCMEncryptor
+type TokenService struct {
+	provider core.ExternalCredentialProvider
 }
 
-type TokenService = LocalExternalCredentialProvider
+var _ core.ExternalCredentialProvider = (*TokenService)(nil)
 
-var errUnreadableStoredIntegrationToken = errors.New("unreadable stored integration token")
-
-var _ core.ExternalCredentialProvider = (*LocalExternalCredentialProvider)(nil)
-
-func NewLocalExternalCredentialProvider(ds indexeddb.IndexedDB, enc *corecrypto.AESGCMEncryptor) *LocalExternalCredentialProvider {
-	return &LocalExternalCredentialProvider{
-		store: ds.ObjectStore(StoreIntegrationTokens),
-		enc:   enc,
+func NewLocalExternalCredentialProvider(ds indexeddb.IndexedDB, enc *corecrypto.AESGCMEncryptor) (core.ExternalCredentialProvider, error) {
+	if enc == nil {
+		return nil, nil
 	}
+	return externalcredentials.NewLocalProvider(ds, enc)
 }
 
-func NewTokenService(ds indexeddb.IndexedDB, enc *corecrypto.AESGCMEncryptor) *LocalExternalCredentialProvider {
-	return NewLocalExternalCredentialProvider(ds, enc)
+func NewTokenService(provider core.ExternalCredentialProvider) *TokenService {
+	return &TokenService{provider: provider}
 }
 
-func (s *LocalExternalCredentialProvider) PutCredential(ctx context.Context, credential *core.ExternalCredential) error {
-	return s.storeToken(ctx, credential, false)
+func (s *TokenService) PutCredential(ctx context.Context, credential *core.ExternalCredential) error {
+	provider, err := s.requireProvider()
+	if err != nil {
+		return err
+	}
+	return provider.PutCredential(ctx, credential)
 }
 
-func (s *LocalExternalCredentialProvider) RestoreCredential(ctx context.Context, credential *core.ExternalCredential) error {
-	return s.storeToken(ctx, credential, true)
+func (s *TokenService) RestoreCredential(ctx context.Context, credential *core.ExternalCredential) error {
+	provider, err := s.requireProvider()
+	if err != nil {
+		return err
+	}
+	return provider.RestoreCredential(ctx, credential)
 }
 
-func (s *LocalExternalCredentialProvider) GetCredential(ctx context.Context, subjectID, integration, connection, instance string) (*core.ExternalCredential, error) {
-	rec, err := s.tokenRecord(ctx, subjectID, integration, connection, instance)
+func (s *TokenService) GetCredential(ctx context.Context, subjectID, integration, connection, instance string) (*core.ExternalCredential, error) {
+	provider, err := s.requireProvider()
 	if err != nil {
 		return nil, err
 	}
-	return s.recordToToken(rec)
+	return provider.GetCredential(ctx, subjectID, integration, connection, instance)
 }
 
-func (s *LocalExternalCredentialProvider) ListCredentials(ctx context.Context, subjectID string) ([]*core.ExternalCredential, error) {
-	recs, err := s.store.Index("by_subject").GetAll(ctx, nil, subjectID)
+func (s *TokenService) ListCredentials(ctx context.Context, subjectID string) ([]*core.ExternalCredential, error) {
+	provider, err := s.requireProvider()
 	if err != nil {
-		return nil, fmt.Errorf("list tokens: %w", err)
+		return nil, err
 	}
-	return s.recordsToTokens(recs)
+	return provider.ListCredentials(ctx, subjectID)
 }
 
-func (s *LocalExternalCredentialProvider) ListCredentialsForProvider(ctx context.Context, subjectID, integration string) ([]*core.ExternalCredential, error) {
-	recs, err := s.store.Index("by_subject_integration").GetAll(ctx, nil, subjectID, integration)
+func (s *TokenService) ListCredentialsForProvider(ctx context.Context, subjectID, integration string) ([]*core.ExternalCredential, error) {
+	provider, err := s.requireProvider()
 	if err != nil {
-		return nil, fmt.Errorf("list tokens for integration: %w", err)
+		return nil, err
 	}
-	return s.recordsToTokens(recs)
+	return provider.ListCredentialsForProvider(ctx, subjectID, integration)
 }
 
-func (s *LocalExternalCredentialProvider) ListCredentialsForConnection(ctx context.Context, subjectID, integration, connection string) ([]*core.ExternalCredential, error) {
-	recs, err := s.store.Index("by_subject_connection").GetAll(ctx, nil, subjectID, integration, connection)
+func (s *TokenService) ListCredentialsForConnection(ctx context.Context, subjectID, integration, connection string) ([]*core.ExternalCredential, error) {
+	provider, err := s.requireProvider()
 	if err != nil {
-		return nil, fmt.Errorf("list tokens for connection: %w", err)
+		return nil, err
 	}
-	return s.recordsToTokens(recs)
+	return provider.ListCredentialsForConnection(ctx, subjectID, integration, connection)
 }
 
-func (s *LocalExternalCredentialProvider) DeleteCredential(ctx context.Context, id string) error {
-	if id == "" {
-		return s.store.Delete(ctx, id)
-	}
-	_, err := s.store.Get(ctx, id)
+func (s *TokenService) DeleteCredential(ctx context.Context, id string) error {
+	provider, err := s.requireProvider()
 	if err != nil {
-		if err == indexeddb.ErrNotFound {
-			return nil
-		}
 		return err
 	}
-	if err := s.store.Delete(ctx, id); err != nil {
-		return err
-	}
-	return nil
+	return provider.DeleteCredential(ctx, id)
 }
 
-func (s *LocalExternalCredentialProvider) StoreToken(ctx context.Context, token *core.IntegrationToken) error {
-	return s.storeToken(ctx, token, false)
+func (s *TokenService) StoreToken(ctx context.Context, token *core.IntegrationToken) error {
+	return s.PutCredential(ctx, token)
 }
 
-func (s *LocalExternalCredentialProvider) RestoreToken(ctx context.Context, token *core.IntegrationToken) error {
-	return s.storeToken(ctx, token, true)
+func (s *TokenService) RestoreToken(ctx context.Context, token *core.IntegrationToken) error {
+	return s.RestoreCredential(ctx, token)
 }
 
-func (s *LocalExternalCredentialProvider) storeToken(ctx context.Context, token *core.IntegrationToken, preserveTimestamps bool) error {
-	token.SubjectID = strings.TrimSpace(token.SubjectID)
-
-	accessEnc, refreshEnc, err := s.enc.EncryptTokenPair(token.AccessToken, token.RefreshToken)
-	if err != nil {
-		return fmt.Errorf("encrypt token pair: %w", err)
-	}
-	if token.ID == "" {
-		token.ID = uuid.New().String()
-	}
-	now := time.Now()
-	createdAt := tokenCreatedAt(token, now)
-	updatedAt := tokenUpdatedAt(token, now, preserveTimestamps)
-	fields := indexeddb.Record{
-		"subject_id":              token.SubjectID,
-		"integration":             token.Integration,
-		"connection":              token.Connection,
-		"instance":                token.Instance,
-		"access_token_encrypted":  accessEnc,
-		"refresh_token_encrypted": refreshEnc,
-		"scopes":                  token.Scopes,
-		"expires_at":              token.ExpiresAt,
-		"last_refreshed_at":       token.LastRefreshedAt,
-		"refresh_error_count":     token.RefreshErrorCount,
-		"metadata_json":           token.MetadataJSON,
-		"updated_at":              updatedAt,
-	}
-
-	existing, err := s.tokenRecord(ctx, token.SubjectID, token.Integration, token.Connection, token.Instance)
-	switch err {
-	case nil:
-		token.ID = recString(existing, "id")
-		fields["id"] = token.ID
-		existingCreatedAt := recTime(existing, "created_at")
-		if preserveTimestamps && !token.CreatedAt.IsZero() {
-			existingCreatedAt = token.CreatedAt
-		}
-		if existingCreatedAt.IsZero() {
-			existingCreatedAt = createdAt
-		}
-		fields["created_at"] = existingCreatedAt
-		if err := s.store.Put(ctx, fields); err != nil {
-			return fmt.Errorf("update token: %w", err)
-		}
-	case core.ErrNotFound:
-		fields["id"] = token.ID
-		fields["created_at"] = createdAt
-		if err := s.store.Add(ctx, fields); err != nil {
-			return fmt.Errorf("create token: %w", err)
-		}
-	default:
-		return fmt.Errorf("check existing token: %w", err)
-	}
-
-	if err := s.deleteDuplicateLookupRecords(ctx, token.ID, token.SubjectID, token.Integration, token.Connection, token.Instance); err != nil {
-		return err
-	}
-	return nil
-}
-
-func tokenCreatedAt(token *core.IntegrationToken, fallback time.Time) time.Time {
-	if !token.CreatedAt.IsZero() {
-		return token.CreatedAt
-	}
-	return fallback
-}
-
-func tokenUpdatedAt(token *core.IntegrationToken, fallback time.Time, preserve bool) time.Time {
-	if preserve && !token.UpdatedAt.IsZero() {
-		return token.UpdatedAt
-	}
-	return fallback
-}
-
-func (s *LocalExternalCredentialProvider) Token(ctx context.Context, subjectID, integration, connection, instance string) (*core.IntegrationToken, error) {
+func (s *TokenService) Token(ctx context.Context, subjectID, integration, connection, instance string) (*core.IntegrationToken, error) {
 	return s.GetCredential(ctx, subjectID, integration, connection, instance)
 }
 
-func (s *LocalExternalCredentialProvider) ListTokens(ctx context.Context, subjectID string) ([]*core.IntegrationToken, error) {
+func (s *TokenService) ListTokens(ctx context.Context, subjectID string) ([]*core.IntegrationToken, error) {
 	return s.ListCredentials(ctx, subjectID)
 }
 
-func (s *LocalExternalCredentialProvider) ListTokensForIntegration(ctx context.Context, subjectID, integration string) ([]*core.IntegrationToken, error) {
+func (s *TokenService) ListTokensForIntegration(ctx context.Context, subjectID, integration string) ([]*core.IntegrationToken, error) {
 	return s.ListCredentialsForProvider(ctx, subjectID, integration)
 }
 
-func (s *LocalExternalCredentialProvider) ListTokensForConnection(ctx context.Context, subjectID, integration, connection string) ([]*core.IntegrationToken, error) {
+func (s *TokenService) ListTokensForConnection(ctx context.Context, subjectID, integration, connection string) ([]*core.IntegrationToken, error) {
 	return s.ListCredentialsForConnection(ctx, subjectID, integration, connection)
 }
 
-func (s *LocalExternalCredentialProvider) DeleteToken(ctx context.Context, id string) error {
+func (s *TokenService) DeleteToken(ctx context.Context, id string) error {
 	return s.DeleteCredential(ctx, id)
 }
 
-func (s *LocalExternalCredentialProvider) recordToToken(rec indexeddb.Record) (*core.IntegrationToken, error) {
-	access, refresh, err := s.enc.DecryptTokenPair(
-		recString(rec, "access_token_encrypted"),
-		recString(rec, "refresh_token_encrypted"),
-	)
-	if err != nil {
-		return nil, fmt.Errorf("%w: decrypt token pair: %v", errUnreadableStoredIntegrationToken, err)
+func (s *TokenService) Provider() core.ExternalCredentialProvider {
+	if s == nil {
+		return nil
 	}
-	return &core.IntegrationToken{
-		ID:                recString(rec, "id"),
-		SubjectID:         tokenRecordSubjectID(rec),
-		Integration:       recString(rec, "integration"),
-		Connection:        recString(rec, "connection"),
-		Instance:          recString(rec, "instance"),
-		AccessToken:       access,
-		RefreshToken:      refresh,
-		Scopes:            recString(rec, "scopes"),
-		ExpiresAt:         recTimePtr(rec, "expires_at"),
-		LastRefreshedAt:   recTimePtr(rec, "last_refreshed_at"),
-		RefreshErrorCount: recInt(rec, "refresh_error_count"),
-		MetadataJSON:      recString(rec, "metadata_json"),
-		CreatedAt:         recTime(rec, "created_at"),
-		UpdatedAt:         recTime(rec, "updated_at"),
-	}, nil
+	return s.provider
 }
 
-func (s *LocalExternalCredentialProvider) recordsToTokens(recs []indexeddb.Record) ([]*core.IntegrationToken, error) {
-	recs = dedupeTokenRecords(recs)
-	out := make([]*core.IntegrationToken, 0, len(recs))
-	for _, rec := range recs {
-		t, err := s.recordToToken(rec)
-		if err != nil {
-			return nil, err
-		}
-		out = append(out, t)
+func (s *TokenService) requireProvider() (core.ExternalCredentialProvider, error) {
+	if s == nil || ExternalCredentialProviderMissing(s.provider) {
+		return nil, fmt.Errorf("external credential provider is not available")
 	}
-	return out, nil
-}
-
-func (s *LocalExternalCredentialProvider) tokenRecord(ctx context.Context, subjectID, integration, connection, instance string) (indexeddb.Record, error) {
-	recs, err := s.store.Index("by_lookup").GetAll(ctx, nil, subjectID, integration, connection, instance)
-	if err != nil {
-		return nil, fmt.Errorf("get token: %w", err)
-	}
-	recs = dedupeTokenRecords(recs)
-	if len(recs) == 0 {
-		return nil, core.ErrNotFound
-	}
-	return recs[0], nil
-}
-
-func (s *LocalExternalCredentialProvider) deleteDuplicateLookupRecords(ctx context.Context, keepID, subjectID, integration, connection, instance string) error {
-	recs, err := s.store.Index("by_lookup").GetAll(ctx, nil, subjectID, integration, connection, instance)
-	if err != nil {
-		return fmt.Errorf("list duplicate tokens: %w", err)
-	}
-	for _, rec := range recs {
-		id := recString(rec, "id")
-		if id == "" || id == keepID {
-			continue
-		}
-		if err := s.store.Delete(ctx, id); err != nil && err != indexeddb.ErrNotFound {
-			return fmt.Errorf("delete duplicate token %q: %w", id, err)
-		}
-	}
-	return nil
-}
-
-func dedupeTokenRecords(recs []indexeddb.Record) []indexeddb.Record {
-	if len(recs) <= 1 {
-		return recs
-	}
-
-	bestByLookup := make(map[string]indexeddb.Record, len(recs))
-	for _, rec := range recs {
-		key := tokenLookupKey(rec)
-		best, ok := bestByLookup[key]
-		if !ok || tokenRecordLess(rec, best) {
-			bestByLookup[key] = rec
-		}
-	}
-
-	out := make([]indexeddb.Record, 0, len(bestByLookup))
-	for _, rec := range bestByLookup {
-		out = append(out, rec)
-	}
-	sort.Slice(out, func(i, j int) bool {
-		return tokenRecordLess(out[i], out[j])
-	})
-	return out
-}
-
-func tokenLookupKey(rec indexeddb.Record) string {
-	return tokenRecordSubjectID(rec) + "\x00" +
-		recString(rec, "integration") + "\x00" +
-		recString(rec, "connection") + "\x00" +
-		recString(rec, "instance")
-}
-
-func tokenRecordSubjectID(rec indexeddb.Record) string {
-	return strings.TrimSpace(recString(rec, "subject_id"))
-}
-
-func tokenRecordLess(a, b indexeddb.Record) bool {
-	aUpdated := recTime(a, "updated_at")
-	bUpdated := recTime(b, "updated_at")
-	if !aUpdated.Equal(bUpdated) {
-		return aUpdated.After(bUpdated)
-	}
-
-	aCreated := recTime(a, "created_at")
-	bCreated := recTime(b, "created_at")
-	if !aCreated.Equal(bCreated) {
-		return aCreated.After(bCreated)
-	}
-
-	return recString(a, "id") < recString(b, "id")
+	return s.provider, nil
 }

--- a/gestaltd/internal/externalcredentials/local.go
+++ b/gestaltd/internal/externalcredentials/local.go
@@ -1,0 +1,492 @@
+package externalcredentials
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"sort"
+	"strings"
+	"time"
+
+	"github.com/google/uuid"
+	"github.com/valon-technologies/gestalt/server/core"
+	corecrypto "github.com/valon-technologies/gestalt/server/core/crypto"
+	"github.com/valon-technologies/gestalt/server/core/indexeddb"
+)
+
+const (
+	StoreName       = "external_credentials"
+	legacyStoreName = "integration_tokens"
+)
+
+var Schema = indexeddb.ObjectStoreSchema{
+	Indexes: []indexeddb.IndexSchema{
+		{Name: "by_subject", KeyPath: []string{"subject_id"}},
+		{Name: "by_subject_integration", KeyPath: []string{"subject_id", "integration"}},
+		{Name: "by_subject_connection", KeyPath: []string{"subject_id", "integration", "connection"}},
+		{Name: "by_lookup", KeyPath: []string{"subject_id", "integration", "connection", "instance"}, Unique: true},
+	},
+	Columns: []indexeddb.ColumnDef{
+		{Name: "id", Type: indexeddb.TypeString, PrimaryKey: true},
+		{Name: "subject_id", Type: indexeddb.TypeString, NotNull: true},
+		{Name: "integration", Type: indexeddb.TypeString, NotNull: true},
+		{Name: "connection", Type: indexeddb.TypeString, NotNull: true},
+		{Name: "instance", Type: indexeddb.TypeString},
+		{Name: "access_token_encrypted", Type: indexeddb.TypeString},
+		{Name: "refresh_token_encrypted", Type: indexeddb.TypeString},
+		{Name: "scopes", Type: indexeddb.TypeString},
+		{Name: "expires_at", Type: indexeddb.TypeTime},
+		{Name: "last_refreshed_at", Type: indexeddb.TypeTime},
+		{Name: "refresh_error_count", Type: indexeddb.TypeInt},
+		{Name: "metadata_json", Type: indexeddb.TypeString},
+		{Name: "created_at", Type: indexeddb.TypeTime},
+		{Name: "updated_at", Type: indexeddb.TypeTime},
+	},
+}
+
+var errUnreadableStoredExternalCredential = errors.New("unreadable stored external credential")
+
+type LocalProvider struct {
+	store       indexeddb.ObjectStore
+	legacyStore indexeddb.ObjectStore
+	enc         *corecrypto.AESGCMEncryptor
+}
+
+var _ core.ExternalCredentialProvider = (*LocalProvider)(nil)
+
+func NewLocalProvider(ds indexeddb.IndexedDB, enc *corecrypto.AESGCMEncryptor) (*LocalProvider, error) {
+	if ds == nil {
+		return nil, fmt.Errorf("external credentials store: indexeddb is required")
+	}
+	if enc == nil {
+		return nil, fmt.Errorf("external credentials store: encryptor is required")
+	}
+	ctx := context.Background()
+	if err := ds.CreateObjectStore(ctx, StoreName, Schema); err != nil {
+		return nil, fmt.Errorf("create %s store: %w", StoreName, err)
+	}
+	provider := &LocalProvider{
+		store:       ds.ObjectStore(StoreName),
+		legacyStore: ds.ObjectStore(legacyStoreName),
+		enc:         enc,
+	}
+	return provider, nil
+}
+
+func (p *LocalProvider) PutCredential(ctx context.Context, credential *core.ExternalCredential) error {
+	return p.storeCredential(ctx, credential, false)
+}
+
+func (p *LocalProvider) RestoreCredential(ctx context.Context, credential *core.ExternalCredential) error {
+	return p.storeCredential(ctx, credential, true)
+}
+
+func (p *LocalProvider) GetCredential(ctx context.Context, subjectID, integration, connection, instance string) (*core.ExternalCredential, error) {
+	rec, err := p.credentialRecord(ctx, subjectID, integration, connection, instance)
+	if err != nil {
+		return nil, err
+	}
+	return p.recordToCredential(rec)
+}
+
+func (p *LocalProvider) ListCredentials(ctx context.Context, subjectID string) ([]*core.ExternalCredential, error) {
+	recs, err := p.listCredentialRecords(ctx, "by_subject", subjectID)
+	if err != nil {
+		return nil, fmt.Errorf("list external credentials: %w", err)
+	}
+	return p.recordsToCredentials(recs)
+}
+
+func (p *LocalProvider) ListCredentialsForProvider(ctx context.Context, subjectID, integration string) ([]*core.ExternalCredential, error) {
+	recs, err := p.listCredentialRecords(ctx, "by_subject_integration", subjectID, integration)
+	if err != nil {
+		return nil, fmt.Errorf("list external credentials for integration: %w", err)
+	}
+	return p.recordsToCredentials(recs)
+}
+
+func (p *LocalProvider) ListCredentialsForConnection(ctx context.Context, subjectID, integration, connection string) ([]*core.ExternalCredential, error) {
+	recs, err := p.listCredentialRecords(ctx, "by_subject_connection", subjectID, integration, connection)
+	if err != nil {
+		return nil, fmt.Errorf("list external credentials for connection: %w", err)
+	}
+	return p.recordsToCredentials(recs)
+}
+
+func (p *LocalProvider) DeleteCredential(ctx context.Context, id string) error {
+	if id == "" {
+		return p.store.Delete(ctx, id)
+	}
+	currentRec, currentErr := getCredentialRecordByID(ctx, p.store, id)
+	if currentErr != nil {
+		return currentErr
+	}
+	legacyRec, legacyErr := getCredentialRecordByID(ctx, p.legacyStore, id)
+	if legacyErr != nil {
+		return legacyErr
+	}
+	rec := currentRec
+	if rec == nil {
+		rec = legacyRec
+	}
+	if rec == nil {
+		return nil
+	}
+	subjectID := credentialRecordSubjectID(rec)
+	integration := recordString(rec, "integration")
+	connection := recordString(rec, "connection")
+	instance := recordString(rec, "instance")
+
+	errs := []error{
+		deleteCredentialLookupRecords(ctx, p.store, subjectID, integration, connection, instance),
+		deleteCredentialLookupRecords(ctx, p.legacyStore, subjectID, integration, connection, instance),
+	}
+	return errors.Join(errs...)
+}
+
+func (p *LocalProvider) storeCredential(ctx context.Context, credential *core.ExternalCredential, preserveTimestamps bool) error {
+	if credential == nil {
+		return fmt.Errorf("external credential is required")
+	}
+	credential.SubjectID = strings.TrimSpace(credential.SubjectID)
+
+	accessEnc, refreshEnc, err := p.enc.EncryptTokenPair(credential.AccessToken, credential.RefreshToken)
+	if err != nil {
+		return fmt.Errorf("encrypt credential pair: %w", err)
+	}
+	if credential.ID == "" {
+		credential.ID = uuid.New().String()
+	}
+	now := time.Now()
+	createdAt := credentialCreatedAt(credential, now)
+	updatedAt := credentialUpdatedAt(credential, now, preserveTimestamps)
+	fields := indexeddb.Record{
+		"subject_id":              credential.SubjectID,
+		"integration":             credential.Integration,
+		"connection":              credential.Connection,
+		"instance":                credential.Instance,
+		"access_token_encrypted":  accessEnc,
+		"refresh_token_encrypted": refreshEnc,
+		"scopes":                  credential.Scopes,
+		"expires_at":              credential.ExpiresAt,
+		"last_refreshed_at":       credential.LastRefreshedAt,
+		"refresh_error_count":     credential.RefreshErrorCount,
+		"metadata_json":           credential.MetadataJSON,
+		"updated_at":              updatedAt,
+	}
+
+	existing, err := p.credentialRecord(ctx, credential.SubjectID, credential.Integration, credential.Connection, credential.Instance)
+	switch {
+	case err == nil:
+		credential.ID = recordString(existing, "id")
+		fields["id"] = credential.ID
+		existingCreatedAt := recordTime(existing, "created_at")
+		if preserveTimestamps && !credential.CreatedAt.IsZero() {
+			existingCreatedAt = credential.CreatedAt
+		}
+		if existingCreatedAt.IsZero() {
+			existingCreatedAt = createdAt
+		}
+		fields["created_at"] = existingCreatedAt
+		if err := p.store.Put(ctx, fields); err != nil {
+			return fmt.Errorf("update external credential: %w", err)
+		}
+	case errors.Is(err, core.ErrNotFound):
+		fields["id"] = credential.ID
+		fields["created_at"] = createdAt
+		if err := p.store.Add(ctx, fields); err != nil {
+			return fmt.Errorf("create external credential: %w", err)
+		}
+	default:
+		return fmt.Errorf("check existing external credential: %w", err)
+	}
+
+	if err := p.deleteDuplicateLookupRecords(ctx, credential.ID, credential.SubjectID, credential.Integration, credential.Connection, credential.Instance); err != nil {
+		return err
+	}
+	return nil
+}
+
+func credentialCreatedAt(credential *core.ExternalCredential, fallback time.Time) time.Time {
+	if !credential.CreatedAt.IsZero() {
+		return credential.CreatedAt
+	}
+	return fallback
+}
+
+func credentialUpdatedAt(credential *core.ExternalCredential, fallback time.Time, preserve bool) time.Time {
+	if preserve && !credential.UpdatedAt.IsZero() {
+		return credential.UpdatedAt
+	}
+	return fallback
+}
+
+func (p *LocalProvider) recordToCredential(rec indexeddb.Record) (*core.ExternalCredential, error) {
+	access, refresh, err := p.enc.DecryptTokenPair(
+		recordString(rec, "access_token_encrypted"),
+		recordString(rec, "refresh_token_encrypted"),
+	)
+	if err != nil {
+		return nil, fmt.Errorf("%w: decrypt credential pair: %v", errUnreadableStoredExternalCredential, err)
+	}
+	return &core.ExternalCredential{
+		ID:                recordString(rec, "id"),
+		SubjectID:         credentialRecordSubjectID(rec),
+		Integration:       recordString(rec, "integration"),
+		Connection:        recordString(rec, "connection"),
+		Instance:          recordString(rec, "instance"),
+		AccessToken:       access,
+		RefreshToken:      refresh,
+		Scopes:            recordString(rec, "scopes"),
+		ExpiresAt:         recordTimePtr(rec, "expires_at"),
+		LastRefreshedAt:   recordTimePtr(rec, "last_refreshed_at"),
+		RefreshErrorCount: recordInt(rec, "refresh_error_count"),
+		MetadataJSON:      recordString(rec, "metadata_json"),
+		CreatedAt:         recordTime(rec, "created_at"),
+		UpdatedAt:         recordTime(rec, "updated_at"),
+	}, nil
+}
+
+func (p *LocalProvider) recordsToCredentials(recs []indexeddb.Record) ([]*core.ExternalCredential, error) {
+	recs = dedupeCredentialRecords(recs)
+	out := make([]*core.ExternalCredential, 0, len(recs))
+	for _, rec := range recs {
+		credential, err := p.recordToCredential(rec)
+		if err != nil {
+			return nil, err
+		}
+		out = append(out, credential)
+	}
+	return out, nil
+}
+
+func (p *LocalProvider) credentialRecord(ctx context.Context, subjectID, integration, connection, instance string) (indexeddb.Record, error) {
+	recs, err := p.listCredentialRecords(ctx, "by_lookup", subjectID, integration, connection, instance)
+	if err != nil {
+		return nil, fmt.Errorf("get external credential: %w", err)
+	}
+	if len(recs) == 0 {
+		return nil, core.ErrNotFound
+	}
+	return recs[0], nil
+}
+
+func (p *LocalProvider) listCredentialRecords(ctx context.Context, indexName string, keys ...any) ([]indexeddb.Record, error) {
+	current, err := p.store.Index(indexName).GetAll(ctx, nil, keys...)
+	if err != nil {
+		return nil, err
+	}
+	legacy, err := getAllLegacyCredentialRecords(ctx, p.legacyStore, indexName, keys...)
+	if err != nil {
+		return nil, err
+	}
+	return mergeCredentialRecords(current, legacy), nil
+}
+
+func (p *LocalProvider) deleteDuplicateLookupRecords(ctx context.Context, keepID, subjectID, integration, connection, instance string) error {
+	recs, err := p.store.Index("by_lookup").GetAll(ctx, nil, subjectID, integration, connection, instance)
+	if err != nil {
+		return fmt.Errorf("list duplicate external credentials: %w", err)
+	}
+	for _, rec := range recs {
+		id := recordString(rec, "id")
+		if id == "" || id == keepID {
+			continue
+		}
+		if err := p.store.Delete(ctx, id); err != nil && !errors.Is(err, indexeddb.ErrNotFound) {
+			return fmt.Errorf("delete duplicate external credential %q: %w", id, err)
+		}
+	}
+	return nil
+}
+
+func dedupeCredentialRecords(recs []indexeddb.Record) []indexeddb.Record {
+	if len(recs) <= 1 {
+		return recs
+	}
+
+	bestByLookup := make(map[string]indexeddb.Record, len(recs))
+	for _, rec := range recs {
+		key := credentialLookupKey(rec)
+		best, ok := bestByLookup[key]
+		if !ok || credentialRecordLess(rec, best) {
+			bestByLookup[key] = rec
+		}
+	}
+
+	out := make([]indexeddb.Record, 0, len(bestByLookup))
+	for _, rec := range bestByLookup {
+		out = append(out, rec)
+	}
+	sort.Slice(out, func(i, j int) bool {
+		return credentialRecordLess(out[i], out[j])
+	})
+	return out
+}
+
+func mergeCredentialRecords(current, legacy []indexeddb.Record) []indexeddb.Record {
+	current = dedupeCredentialRecords(current)
+	legacy = dedupeCredentialRecords(legacy)
+	if len(current) == 0 {
+		return legacy
+	}
+	if len(legacy) == 0 {
+		return current
+	}
+
+	bestByLookup := make(map[string]indexeddb.Record, len(current)+len(legacy))
+	for _, rec := range current {
+		bestByLookup[credentialLookupKey(rec)] = rec
+	}
+	for _, rec := range legacy {
+		key := credentialLookupKey(rec)
+		if _, ok := bestByLookup[key]; ok {
+			continue
+		}
+		bestByLookup[key] = rec
+	}
+
+	out := make([]indexeddb.Record, 0, len(bestByLookup))
+	for _, rec := range bestByLookup {
+		out = append(out, rec)
+	}
+	sort.Slice(out, func(i, j int) bool {
+		return credentialRecordLess(out[i], out[j])
+	})
+	return out
+}
+
+func credentialLookupKey(rec indexeddb.Record) string {
+	return credentialRecordSubjectID(rec) + "\x00" +
+		recordString(rec, "integration") + "\x00" +
+		recordString(rec, "connection") + "\x00" +
+		recordString(rec, "instance")
+}
+
+func credentialRecordSubjectID(rec indexeddb.Record) string {
+	return strings.TrimSpace(recordString(rec, "subject_id"))
+}
+
+func credentialRecordLess(a, b indexeddb.Record) bool {
+	aUpdated := recordTime(a, "updated_at")
+	bUpdated := recordTime(b, "updated_at")
+	if !aUpdated.Equal(bUpdated) {
+		return aUpdated.After(bUpdated)
+	}
+
+	aCreated := recordTime(a, "created_at")
+	bCreated := recordTime(b, "created_at")
+	if !aCreated.Equal(bCreated) {
+		return aCreated.After(bCreated)
+	}
+
+	return recordString(a, "id") < recordString(b, "id")
+}
+
+func getAllLegacyCredentialRecords(ctx context.Context, store indexeddb.ObjectStore, indexName string, keys ...any) ([]indexeddb.Record, error) {
+	if store == nil {
+		return nil, nil
+	}
+	recs, err := store.Index(indexName).GetAll(ctx, nil, keys...)
+	if errors.Is(err, indexeddb.ErrNotFound) {
+		return nil, nil
+	}
+	return recs, err
+}
+
+func deleteCredentialRecord(ctx context.Context, store indexeddb.ObjectStore, id string) error {
+	if store == nil {
+		return nil
+	}
+	_, err := store.Get(ctx, id)
+	if err != nil {
+		if errors.Is(err, indexeddb.ErrNotFound) {
+			return nil
+		}
+		return err
+	}
+	return store.Delete(ctx, id)
+}
+
+func getCredentialRecordByID(ctx context.Context, store indexeddb.ObjectStore, id string) (indexeddb.Record, error) {
+	if store == nil {
+		return nil, nil
+	}
+	rec, err := store.Get(ctx, id)
+	if errors.Is(err, indexeddb.ErrNotFound) {
+		return nil, nil
+	}
+	return rec, err
+}
+
+func deleteCredentialLookupRecords(ctx context.Context, store indexeddb.ObjectStore, subjectID, integration, connection, instance string) error {
+	if store == nil {
+		return nil
+	}
+	recs, err := store.Index("by_lookup").GetAll(ctx, nil, subjectID, integration, connection, instance)
+	if errors.Is(err, indexeddb.ErrNotFound) {
+		return nil
+	}
+	if err != nil {
+		return err
+	}
+	var errs []error
+	for _, rec := range recs {
+		id := recordString(rec, "id")
+		if id == "" {
+			continue
+		}
+		errs = append(errs, deleteCredentialRecord(ctx, store, id))
+	}
+	return errors.Join(errs...)
+}
+
+func recordString(rec indexeddb.Record, key string) string {
+	value, _ := rec[key].(string)
+	return value
+}
+
+func recordInt(rec indexeddb.Record, key string) int {
+	switch value := rec[key].(type) {
+	case int:
+		return value
+	case int8:
+		return int(value)
+	case int16:
+		return int(value)
+	case int32:
+		return int(value)
+	case int64:
+		return int(value)
+	case float64:
+		return int(value)
+	default:
+		return 0
+	}
+}
+
+func recordTime(rec indexeddb.Record, key string) time.Time {
+	value, ok := rec[key]
+	if !ok || value == nil {
+		return time.Time{}
+	}
+	switch raw := value.(type) {
+	case time.Time:
+		return raw
+	case *time.Time:
+		if raw == nil {
+			return time.Time{}
+		}
+		return *raw
+	default:
+		return time.Time{}
+	}
+}
+
+func recordTimePtr(rec indexeddb.Record, key string) *time.Time {
+	value := recordTime(rec, key)
+	if value.IsZero() {
+		return nil
+	}
+	return &value
+}

--- a/gestaltd/internal/server/agent_run_test.go
+++ b/gestaltd/internal/server/agent_run_test.go
@@ -752,7 +752,7 @@ func TestGlobalAgentRunDefaultToolsSkipCredentialedProvidersWithoutStoredTokens(
 		AccessToken: testCatalogToken,
 	})
 	now := time.Now().UTC()
-	if err := services.DB.ObjectStore(coredata.StoreIntegrationTokens).Put(context.Background(), indexeddb.Record{
+	if err := services.DB.ObjectStore(coredata.StoreExternalCredentials).Put(context.Background(), indexeddb.Record{
 		"id":                      "tok-corrupt-other-connection",
 		"subject_id":              principal.UserSubjectID(user.ID),
 		"integration":             "connected",


### PR DESCRIPTION
## Summary

This moves local external credential ownership out of `coredata`'s live `integration_tokens` store and into a provider-owned `external_credentials` store.

New writes now go to `external_credentials`.
Legacy `integration_tokens` remains read/delete compatible during rollout, but there is **no startup migration** in `gestaltd`; deployment-managed SQL backfill stays out-of-band.

## New Interfaces

- `coredata.Services.LocalExternalCredentials core.ExternalCredentialProvider`
- `coredata.LocalExternalCredentialProvider(services) core.ExternalCredentialProvider`
- `coredata.TokenService` now acts as a compatibility adapter over `core.ExternalCredentialProvider`

## Examples

```go
svc, err := coredata.New(db, encryptor)
if err != nil {
    return err
}

provider := coredata.LocalExternalCredentialProvider(svc)
cred, err := provider.GetCredential(ctx, subjectID, "github", "default", "workspace-1")
```

```go
err := svc.Tokens.StoreToken(ctx, &core.IntegrationToken{
    SubjectID:   subjectID,
    Integration: "github",
    Connection:  "default",
    Instance:    "workspace-1",
    AccessToken: accessToken,
})
```

## Behavior

- `coredata.New` initializes a local provider-owned `external_credentials` store
- bootstrap host services expose the local provider rather than assuming `TokenService` is the storage owner
- reads merge `external_credentials` with legacy `integration_tokens` for rollout compatibility
- if both stores contain the same logical credential, `external_credentials` wins
- deletes remove matching rows from both stores

## Verification

- `go test ./internal/coredata`
- `go test ./internal/bootstrap ./internal/providerhost ./internal/operator`
- `go test ./internal/server ./cmd/gestaltd`
