### PR TITLE
gestaltd: watch and restart provider dev sessions

### DIFF
--- a/docs/content/custom-providers/plugins.mdx
+++ b/docs/content/custom-providers/plugins.mdx
@@ -656,6 +656,14 @@ Run the plugin locally with browser-facing UI available:
 gestaltd provider dev --path ./slack
 ```
 
+`gestaltd provider dev` watches the plugin package and any layered `--config`
+files by default, then restarts the local server when they change. Pass
+`--no-watch` if you want a single serve session instead:
+
+```sh
+gestaltd provider dev --path ./slack --no-watch
+```
+
 When the plugin needs supporting providers, extra plugins, or explicit mounted
 UIs, layer real config overlays on top of the synthesized baseline:
 

--- a/docs/content/reference/cli.mdx
+++ b/docs/content/reference/cli.mdx
@@ -31,8 +31,9 @@ import { Callout } from 'nextra/components'
 
 | Command | Purpose |
 | --- | --- |
-| `gestaltd provider dev --path PATH` | Run a local source plugin inside a synthesized Gestalt config. Serves `/admin` and any configured or inferred public UIs. |
+| `gestaltd provider dev --path PATH` | Run a local source plugin inside a synthesized Gestalt config. Serves `/admin` and any configured or inferred public UIs, then watches the plugin package and layered config files for restart-on-change by default. |
 | `gestaltd provider dev --config PATH` | Layer supporting providers, plugins, and UI mounts on top of the synthesized local baseline. Repeat `--config` to merge left-to-right. |
+| `gestaltd provider dev --no-watch` | Disable restart-on-change and run a single local serve session. |
 | `gestaltd provider validate --path PATH` | Validate a local source plugin inside the same synthesized Gestalt config used by `provider dev`. |
 | `gestaltd provider validate --config PATH` | Validate the target plugin together with selected supporting providers and `null` deletions from layered config overlays. |
 | `gestaltd provider release --version VERSION` | Build and package a provider release. Go, Python, Rust, and TypeScript source plugins default to the host platform. Pass `--platform ...` with `os/arch[/libc]` targets or `--platform all` for multi-platform builds. |
@@ -53,6 +54,7 @@ gestaltd serve --locked --config ./base.yaml --config ./overrides/prod.yaml
 gestaltd provider validate --path ./plugins/support
 gestaltd provider validate --path ./plugins/support --config ./dev/support.yaml --config ./dev/local.yaml
 gestaltd provider dev --path ./plugins/support
+gestaltd provider dev --path ./plugins/support --no-watch
 gestaltd provider dev --path ./plugins/support --config ./dev/support.yaml --port 8080
 gestaltd provider release --version 0.0.1-alpha.1
 gestaltd provider release --version 0.0.1-alpha.1 --platform all

--- a/gestaltd/cmd/gestaltd/e2e_test.go
+++ b/gestaltd/cmd/gestaltd/e2e_test.go
@@ -1568,6 +1568,68 @@ func startCommandAndWaitReadyAndFile(t *testing.T, cmd *exec.Cmd, baseURL, requi
 	}
 }
 
+func waitForInvokeOutputContains(t *testing.T, baseURL, integration, operation, param, want string) {
+	t.Helper()
+
+	timeout := time.After(90 * time.Second)
+	tick := time.NewTicker(500 * time.Millisecond)
+	defer tick.Stop()
+
+	cliEnv := append(os.Environ(), "GESTALT_URL="+baseURL, "GESTALT_API_KEY=e2e-test-key")
+	args := []string{"invoke", integration, operation, "--format", "json", "--url", baseURL}
+	if param != "" {
+		args = append(args, "-p", param)
+	}
+
+	lastOutput := ""
+	for {
+		select {
+		case <-timeout:
+			t.Fatalf("timed out waiting for %q in invoke output, last output: %s", want, lastOutput)
+		case <-tick.C:
+			cmd := exec.Command(gestaltCLIBin, args...)
+			cmd.Env = cliEnv
+			out, err := cmd.CombinedOutput()
+			lastOutput = string(out)
+			if err == nil && strings.Contains(lastOutput, want) {
+				return
+			}
+		}
+	}
+}
+
+func waitForHTTPResponse(t *testing.T, url string, wantStatus int, wantSubstring string) {
+	t.Helper()
+
+	client := &http.Client{Timeout: 2 * time.Second}
+	timeout := time.After(90 * time.Second)
+	tick := time.NewTicker(500 * time.Millisecond)
+	defer tick.Stop()
+
+	lastStatus := 0
+	lastBody := ""
+	for {
+		select {
+		case <-timeout:
+			t.Fatalf("timed out waiting for %s to return %d with %q, last status=%d body=%s", url, wantStatus, wantSubstring, lastStatus, lastBody)
+		case <-tick.C:
+			resp, err := client.Get(url)
+			if err != nil {
+				lastStatus = 0
+				lastBody = err.Error()
+				continue
+			}
+			body, _ := io.ReadAll(resp.Body)
+			_ = resp.Body.Close()
+			lastStatus = resp.StatusCode
+			lastBody = string(body)
+			if resp.StatusCode == wantStatus && (wantSubstring == "" || strings.Contains(lastBody, wantSubstring)) {
+				return
+			}
+		}
+	}
+}
+
 func startGestaltdWithConfig(t *testing.T, cfgPath string) string {
 	t.Helper()
 	return startGestaltdWithConfigs(t, []string{cfgPath}, false)
@@ -1710,6 +1772,145 @@ func TestE2EProviderDevAutoMountsOwnedUI(t *testing.T) {
 		}
 	}
 	t.Fatalf(`integration "provider" mountedPath missing from response: %s`, integrationsBody)
+}
+
+func TestE2EProviderDevRestartsOnOwnedUIChange(t *testing.T) {
+	t.Parallel()
+
+	if testing.Short() {
+		t.Skip("skipping provider dev owned-ui watch test in short mode")
+	}
+
+	dir := t.TempDir()
+	providersDir := setupDefaultLocalProvidersDir(t, dir)
+	pluginDir := setupPluginDir(t, dir)
+	mountedUI := setupMountedUIDir(t, dir)
+	attachOwnedUIToPluginSource(t, pluginDir, mountedUI.ManifestPath)
+	port, holder := reservePort(t)
+	baseURL := fmt.Sprintf("http://127.0.0.1:%d", port)
+	_ = holder.Close()
+
+	cmd := exec.Command(gestaltdBin, "provider", "dev", "--path", componentProviderManifestPath(t, pluginDir), "--port", fmt.Sprintf("%d", port))
+	cmd.Env = append(os.Environ(),
+		"GESTALT_PROVIDERS_DIR="+providersDir,
+		"GOTELEMETRY=off",
+	)
+	startCommandAndWaitReady(t, cmd, baseURL)
+
+	waitForHTTPResponse(t, baseURL+"/provider/sync", http.StatusOK, "Roadmap Review UI")
+
+	indexPath := filepath.Join(filepath.Dir(mountedUI.ManifestPath), "dist", "index.html")
+	indexHTML, err := os.ReadFile(indexPath)
+	if err != nil {
+		t.Fatalf("read owned ui index.html: %v", err)
+	}
+	updatedHTML := strings.Replace(string(indexHTML), "Roadmap Review UI", "Updated Roadmap Review UI", 1)
+	if updatedHTML == string(indexHTML) {
+		t.Fatal(`expected owned ui fixture to contain "Roadmap Review UI"`)
+	}
+	if err := os.WriteFile(indexPath, []byte(updatedHTML), 0o644); err != nil {
+		t.Fatalf("write owned ui index.html: %v", err)
+	}
+
+	waitForHTTPResponse(t, baseURL+"/provider/sync", http.StatusOK, "Updated Roadmap Review UI")
+}
+
+func TestE2EProviderDevRestartsOnSourceChange(t *testing.T) {
+	t.Parallel()
+
+	if testing.Short() {
+		t.Skip("skipping provider dev watch test in short mode")
+	}
+
+	dir := t.TempDir()
+	providersDir := setupDefaultLocalProvidersDir(t, dir)
+	pluginDir := setupPluginDir(t, dir)
+	port, holder := reservePort(t)
+	baseURL := fmt.Sprintf("http://127.0.0.1:%d", port)
+	_ = holder.Close()
+
+	cmd := exec.Command(gestaltdBin, "provider", "dev", "--path", pluginDir, "--port", fmt.Sprintf("%d", port))
+	cmd.Env = append(os.Environ(),
+		"GESTALT_PROVIDERS_DIR="+providersDir,
+		"GOTELEMETRY=off",
+	)
+	startCommandAndWaitReady(t, cmd, baseURL)
+
+	waitForInvokeOutputContains(t, baseURL, "provider", "greet", "name=Watch", "Hello, Watch!")
+
+	providerPath := filepath.Join(pluginDir, "provider.go")
+	providerSource, err := os.ReadFile(providerPath)
+	if err != nil {
+		t.Fatalf("read provider source: %v", err)
+	}
+	updatedSource := strings.Replace(string(providerSource), `greeting = "Hello"`, `greeting = "Howdy"`, 1)
+	if updatedSource == string(providerSource) {
+		t.Fatal(`expected provider fixture source to contain greeting = "Hello"`)
+	}
+	if err := os.WriteFile(providerPath, []byte(updatedSource), 0o644); err != nil {
+		t.Fatalf("write provider source: %v", err)
+	}
+
+	waitForInvokeOutputContains(t, baseURL, "provider", "greet", "name=Watch", "Howdy, Watch!")
+}
+
+func TestE2EProviderDevAppliesWatchedConfigChanges(t *testing.T) {
+	t.Parallel()
+
+	if testing.Short() {
+		t.Skip("skipping provider dev config watch test in short mode")
+	}
+
+	dir := t.TempDir()
+	providersDir := setupDefaultLocalProvidersDir(t, dir)
+	pluginDir := setupPluginDir(t, dir)
+	mountedUI := setupMountedUIDir(t, dir)
+	attachOwnedUIToPluginSource(t, pluginDir, mountedUI.ManifestPath)
+	configPath := filepath.Join(dir, "watch-config.yaml")
+	if err := os.WriteFile(configPath, []byte("plugins: {}\n"), 0o644); err != nil {
+		t.Fatalf("write watch config: %v", err)
+	}
+	port, holder := reservePort(t)
+	baseURL := fmt.Sprintf("http://127.0.0.1:%d", port)
+	_ = holder.Close()
+
+	cmd := exec.Command(gestaltdBin, "provider", "dev", "--path", pluginDir, "--config", configPath, "--port", fmt.Sprintf("%d", port))
+	cmd.Env = append(os.Environ(),
+		"GESTALT_PROVIDERS_DIR="+providersDir,
+		"GOTELEMETRY=off",
+	)
+	startCommandAndWaitReady(t, cmd, baseURL)
+
+	waitForHTTPResponse(t, baseURL+"/provider/sync", http.StatusOK, "Roadmap Review UI")
+
+	updatedConfig := fmt.Sprintf(`providers:
+  ui:
+    provider:
+      source:
+        path: %q
+plugins:
+  provider:
+    source:
+      path: %q
+    ui: provider
+    mountPath: /review
+`, mountedUI.ManifestPath, componentProviderManifestPath(t, pluginDir))
+	if err := os.WriteFile(configPath, []byte(updatedConfig), 0o644); err != nil {
+		t.Fatalf("rewrite watch config: %v", err)
+	}
+
+	waitForHTTPResponse(t, baseURL+"/review/sync", http.StatusOK, "Roadmap Review UI")
+
+	client := &http.Client{Timeout: 2 * time.Second}
+	resp, err := client.Get(baseURL + "/provider/sync")
+	if err != nil {
+		t.Fatalf("GET /provider/sync after config change: %v", err)
+	}
+	defer func() { _ = resp.Body.Close() }()
+	if resp.StatusCode == http.StatusOK {
+		body, _ := io.ReadAll(resp.Body)
+		t.Fatalf("expected old auto-mounted path to be removed after config change, got 200: %s", body)
+	}
 }
 
 //nolint:paralleltest // Uses the default 8080 startup path intentionally.

--- a/gestaltd/cmd/gestaltd/main_test.go
+++ b/gestaltd/cmd/gestaltd/main_test.go
@@ -44,7 +44,7 @@ func TestE2ECLIHelp(t *testing.T) {
 		{
 			name:      "provider dev",
 			args:      []string{"provider", "dev", "--help"},
-			wantParts: []string{"gestaltd provider dev", "The built-in admin UI remains available at /admin", "--port PORT"},
+			wantParts: []string{"gestaltd provider dev", "The built-in admin UI remains available at /admin", "--port PORT", "--no-watch"},
 		},
 	}
 

--- a/gestaltd/cmd/gestaltd/provider_local.go
+++ b/gestaltd/cmd/gestaltd/provider_local.go
@@ -40,7 +40,14 @@ type providerLocalCommandOptions struct {
 type providerLocalSession struct {
 	Dir               string
 	ManifestPath      string
+	PackageDir        string
+	Manifest          *providermanifestv1.Manifest
+	BaseConfigPath    string
+	OverlayConfigPath string
+	NameOverride      string
+	Port              int
 	PluginKey         string
+	UserConfigPaths   []string
 	ConfigPaths       []string
 	State             operator.StatePaths
 	PublicURL         string
@@ -95,6 +102,7 @@ func runProviderDev(args []string) error {
 	fs.Var(&configPaths, "config", "path to config file (repeat to layer overrides)")
 	pathFlag := fs.String("path", "", "provider manifest path or directory (defaults to current working directory)")
 	nameFlag := fs.String("name", "", "plugin key override")
+	noWatchFlag := fs.Bool("no-watch", false, "disable file watching and run a single local serve session")
 	portFlag := fs.Int("port", 0, "public port (defaults to a free localhost port)")
 	if err := fs.Parse(args); err != nil {
 		return err
@@ -122,6 +130,10 @@ func runProviderDev(args []string) error {
 		return err
 	}
 	defer func() { _ = os.RemoveAll(session.Dir) }()
+
+	if !*noWatchFlag {
+		return runProviderDevWatch(session)
+	}
 
 	env, err := setupBootstrapWithConfigPaths(session.ConfigPaths, session.State, false)
 	if err != nil {
@@ -191,37 +203,72 @@ func prepareProviderLocalSession(opts providerLocalCommandOptions) (*providerLoc
 		return nil, err
 	}
 
-	resolvedKey, err := resolveProviderLocalPluginKey(opts.ConfigPaths, targetManifestPath, manifest, opts.Name)
-	if err != nil {
-		return nil, err
-	}
-
 	overlayConfigPath := filepath.Join(sessionDir, "provider-target.yaml")
-	autoMountPath := ""
-	if err := writeProviderLocalOverlayConfig(overlayConfigPath, resolvedKey, targetManifestPath, opts.Port, ""); err != nil {
+	session := &providerLocalSession{
+		Dir:               sessionDir,
+		ManifestPath:      targetManifestPath,
+		PackageDir:        filepath.Dir(targetManifestPath),
+		Manifest:          manifest,
+		BaseConfigPath:    baseConfigPath,
+		OverlayConfigPath: overlayConfigPath,
+		NameOverride:      opts.Name,
+		Port:              opts.Port,
+		UserConfigPaths:   append([]string(nil), opts.ConfigPaths...),
+		State:             operator.StatePaths{ArtifactsDir: filepath.Join(sessionDir, "artifacts"), LockfilePath: filepath.Join(sessionDir, "gestalt.lock.json")},
+	}
+	if err := refreshProviderLocalSession(session); err != nil {
 		return nil, err
 	}
+	cleanupSessionDir = false
+	return session, nil
+}
 
-	configPaths := append([]string{baseConfigPath}, opts.ConfigPaths...)
-	configPaths = append(configPaths, overlayConfigPath)
+func refreshProviderLocalSession(session *providerLocalSession) error {
+	if session == nil {
+		return errors.New("provider local session is required")
+	}
+
+	_, manifest, err := providerpkg.ReadSourceManifestFile(session.ManifestPath)
+	if err != nil {
+		return err
+	}
+	kind, err := providerpkg.ManifestKind(manifest)
+	if err != nil {
+		return err
+	}
+	if kind != providermanifestv1.KindPlugin {
+		return fmt.Errorf("gestaltd provider dev and validate only support kind: plugin in v1 (got %q)", kind)
+	}
+
+	resolvedKey, err := resolveProviderLocalPluginKey(session.UserConfigPaths, session.ManifestPath, manifest, session.NameOverride)
+	if err != nil {
+		return err
+	}
+
+	if err := writeProviderLocalOverlayConfig(session.OverlayConfigPath, resolvedKey, session.ManifestPath, session.Port, ""); err != nil {
+		return err
+	}
+
+	configPaths := append([]string{session.BaseConfigPath}, session.UserConfigPaths...)
+	configPaths = append(configPaths, session.OverlayConfigPath)
 
 	loadedCfg, err := config.LoadPaths(configPaths)
 	if err != nil {
-		return nil, fmt.Errorf("loading provider dev config: %w", err)
+		return fmt.Errorf("loading provider dev config: %w", err)
 	}
 
+	autoMountPath := ""
 	if shouldAutoMountOwnedUI(loadedCfg, resolvedKey, manifest) {
 		autoMountPath = "/" + resolvedKey
 		if err := ensureNoPublicUIPathCollision(loadedCfg, resolvedKey, autoMountPath); err != nil {
-			return nil, err
+			return err
 		}
-		if err := writeProviderLocalOverlayConfig(overlayConfigPath, resolvedKey, targetManifestPath, opts.Port, autoMountPath); err != nil {
-			return nil, err
+		if err := writeProviderLocalOverlayConfig(session.OverlayConfigPath, resolvedKey, session.ManifestPath, session.Port, autoMountPath); err != nil {
+			return err
 		}
-		configPaths[len(configPaths)-1] = overlayConfigPath
 		loadedCfg, err = config.LoadPaths(configPaths)
 		if err != nil {
-			return nil, fmt.Errorf("loading provider dev config with auto-mounted ui: %w", err)
+			return fmt.Errorf("loading provider dev config with auto-mounted ui: %w", err)
 		}
 	}
 
@@ -231,18 +278,15 @@ func prepareProviderLocalSession(opts providerLocalCommandOptions) (*providerLoc
 		publicUIPaths = append(publicUIPaths, autoMountPath)
 		slices.Sort(publicUIPaths)
 	}
-	cleanupSessionDir = false
-	return &providerLocalSession{
-		Dir:               sessionDir,
-		ManifestPath:      targetManifestPath,
-		PluginKey:         resolvedKey,
-		ConfigPaths:       configPaths,
-		State:             operator.StatePaths{ArtifactsDir: filepath.Join(sessionDir, "artifacts"), LockfilePath: filepath.Join(sessionDir, "gestalt.lock.json")},
-		PublicURL:         publicURL,
-		AdminURL:          strings.TrimRight(publicURL, "/") + "/admin/",
-		PublicUIPaths:     publicUIPaths,
-		AutoMountedUIPath: autoMountPath,
-	}, nil
+
+	session.Manifest = manifest
+	session.PluginKey = resolvedKey
+	session.ConfigPaths = configPaths
+	session.PublicURL = publicURL
+	session.AdminURL = strings.TrimRight(publicURL, "/") + "/admin/"
+	session.PublicUIPaths = publicUIPaths
+	session.AutoMountedUIPath = autoMountPath
+	return nil
 }
 
 func resolveProviderTargetManifest(pathFlag string) (string, *providermanifestv1.Manifest, error) {
@@ -621,16 +665,18 @@ func printProviderValidateUsage(w io.Writer) {
 
 func printProviderDevUsage(w io.Writer) {
 	writeUsageLine(w, "Usage:")
-	writeUsageLine(w, "  gestaltd provider dev [--path PATH] [--config PATH]... [--name NAME] [--port PORT]")
+	writeUsageLine(w, "  gestaltd provider dev [--path PATH] [--config PATH]... [--name NAME] [--port PORT] [--no-watch]")
 	writeUsageLine(w, "")
 	writeUsageLine(w, "Run a local source plugin inside a synthesized Gestalt config.")
 	writeUsageLine(w, "v1 supports kind: plugin manifests only.")
 	writeUsageLine(w, "The built-in admin UI remains available at /admin; configured or owned public UIs")
-	writeUsageLine(w, "are mounted when present.")
+	writeUsageLine(w, "are mounted when present. By default, provider dev watches the plugin package and")
+	writeUsageLine(w, "layered config files and restarts the local server when they change.")
 	writeUsageLine(w, "")
 	writeUsageLine(w, "Flags:")
 	writeUsageLine(w, "  --path     Provider manifest path or directory (default: current working directory)")
 	writeUsageLine(w, "  --config   Additional config file to merge; repeat to add support providers or null deletions")
 	writeUsageLine(w, "  --name     Plugin key override when the target key is ambiguous")
 	writeUsageLine(w, "  --port     Public port (default: auto-selected free localhost port)")
+	writeUsageLine(w, "  --no-watch Disable file watching and run a single local serve session")
 }

--- a/gestaltd/cmd/gestaltd/provider_local_watch.go
+++ b/gestaltd/cmd/gestaltd/provider_local_watch.go
@@ -1,0 +1,525 @@
+package main
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"io/fs"
+	"log/slog"
+	"net/http"
+	"os"
+	"os/exec"
+	"os/signal"
+	"path/filepath"
+	"slices"
+	"strings"
+	"sync"
+	"syscall"
+	"time"
+
+	"github.com/fsnotify/fsnotify"
+	"github.com/valon-technologies/gestalt/server/internal/providerpkg"
+)
+
+const (
+	providerDevReadyTimeout    = 60 * time.Second
+	providerDevShutdownTimeout = 15 * time.Second
+	providerDevRestartDebounce = 300 * time.Millisecond
+)
+
+func runProviderDevWatch(session *providerLocalSession) error {
+	ctx, stop := signal.NotifyContext(context.Background(), os.Interrupt, syscall.SIGTERM)
+	defer stop()
+
+	watcher, err := newProviderDevWatcher(session)
+	if err != nil {
+		return err
+	}
+	defer func() { _ = watcher.Close() }()
+
+	slog.Info("provider dev watch enabled",
+		"watch_roots", watcher.watchRoots(),
+		"config_files", watcher.configFilesList(),
+	)
+
+	proc, err := startProviderDevServeProcess(session)
+	if err != nil {
+		return err
+	}
+	if err := waitForProviderDevReady(ctx, session.PublicURL, proc); err != nil {
+		_ = proc.Stop(providerDevShutdownTimeout)
+		return err
+	}
+	logProviderLocalSummary("provider dev ready", session)
+
+	var (
+		restartTimer *time.Timer
+		restartCh    <-chan time.Time
+		restartPath  string
+	)
+
+	for {
+		var procDone <-chan struct{}
+		if proc != nil {
+			procDone = proc.Done()
+		}
+
+		select {
+		case <-ctx.Done():
+			if restartTimer != nil {
+				stopAndDrainTimer(restartTimer)
+			}
+			if proc != nil {
+				_ = proc.Stop(providerDevShutdownTimeout)
+			}
+			return nil
+		case err, ok := <-watcher.Errors():
+			if !ok {
+				if proc != nil {
+					_ = proc.Stop(providerDevShutdownTimeout)
+				}
+				return errors.New("provider dev watcher error channel closed unexpectedly")
+			}
+			if proc != nil {
+				_ = proc.Stop(providerDevShutdownTimeout)
+			}
+			return fmt.Errorf("provider dev watch error: %w", err)
+		case event, ok := <-watcher.Events():
+			if !ok {
+				if proc != nil {
+					_ = proc.Stop(providerDevShutdownTimeout)
+				}
+				return errors.New("provider dev watcher stopped unexpectedly")
+			}
+			relevant, changedPath, err := watcher.HandleEvent(event)
+			if err != nil {
+				slog.Warn("provider dev watch event error", "path", event.Name, "err", err)
+				continue
+			}
+			if !relevant {
+				continue
+			}
+			restartPath = changedPath
+			if restartTimer == nil {
+				restartTimer = time.NewTimer(providerDevRestartDebounce)
+			} else {
+				stopAndDrainTimer(restartTimer)
+				restartTimer.Reset(providerDevRestartDebounce)
+			}
+			restartCh = restartTimer.C
+		case <-restartCh:
+			restartCh = nil
+			changedPath := restartPath
+			restartPath = ""
+			slog.Info("provider dev change detected; restarting", "path", changedPath)
+
+			if err := refreshProviderLocalSession(session); err != nil {
+				slog.Error("provider dev refresh failed", "path", changedPath, "err", err)
+				continue
+			}
+			if err := watcher.SyncSession(session); err != nil {
+				slog.Error("provider dev watch refresh failed", "path", changedPath, "err", err)
+				continue
+			}
+
+			if proc != nil {
+				_ = proc.Stop(providerDevShutdownTimeout)
+				proc = nil
+			}
+
+			nextProc, err := startProviderDevServeProcess(session)
+			if err != nil {
+				slog.Error("provider dev restart failed", "path", changedPath, "err", err)
+				continue
+			}
+			if err := waitForProviderDevReady(ctx, session.PublicURL, nextProc); err != nil {
+				_ = nextProc.Stop(providerDevShutdownTimeout)
+				slog.Error("provider dev restart failed", "path", changedPath, "err", err)
+				continue
+			}
+
+			proc = nextProc
+			logProviderLocalSummary("provider dev restarted", session)
+			slog.Info("provider dev restart source", "path", changedPath)
+		case <-procDone:
+			if proc == nil {
+				continue
+			}
+			slog.Warn("provider dev server exited; waiting for the next change to restart", "err", proc.WaitErr())
+			proc = nil
+		}
+	}
+}
+
+type providerDevServeProcess struct {
+	cmd     *exec.Cmd
+	done    chan struct{}
+	mu      sync.RWMutex
+	waitErr error
+}
+
+func startProviderDevServeProcess(session *providerLocalSession) (*providerDevServeProcess, error) {
+	executable, err := os.Executable()
+	if err != nil {
+		return nil, fmt.Errorf("resolve current executable: %w", err)
+	}
+
+	args := []string{"serve", "--artifacts-dir", session.State.ArtifactsDir, "--lockfile", session.State.LockfilePath}
+	for _, configPath := range session.ConfigPaths {
+		args = append(args, "--config", configPath)
+	}
+
+	cmd := exec.Command(executable, args...)
+	cmd.Stdout = os.Stdout
+	cmd.Stderr = os.Stderr
+	cmd.Env = os.Environ()
+
+	proc := &providerDevServeProcess{
+		cmd:  cmd,
+		done: make(chan struct{}),
+	}
+	if err := cmd.Start(); err != nil {
+		return nil, fmt.Errorf("start provider dev server: %w", err)
+	}
+	go func() {
+		err := cmd.Wait()
+		proc.mu.Lock()
+		proc.waitErr = err
+		proc.mu.Unlock()
+		close(proc.done)
+	}()
+	return proc, nil
+}
+
+func (p *providerDevServeProcess) Done() <-chan struct{} {
+	if p == nil {
+		return nil
+	}
+	return p.done
+}
+
+func (p *providerDevServeProcess) WaitErr() error {
+	if p == nil {
+		return nil
+	}
+	p.mu.RLock()
+	defer p.mu.RUnlock()
+	return p.waitErr
+}
+
+func (p *providerDevServeProcess) Stop(timeout time.Duration) error {
+	if p == nil || p.cmd == nil || p.cmd.Process == nil {
+		return nil
+	}
+	select {
+	case <-p.done:
+		return nil
+	default:
+	}
+
+	if err := p.cmd.Process.Signal(syscall.SIGTERM); err != nil && !errors.Is(err, os.ErrProcessDone) {
+		return fmt.Errorf("signal provider dev server: %w", err)
+	}
+
+	select {
+	case <-p.done:
+		return nil
+	case <-time.After(timeout):
+		if err := p.cmd.Process.Kill(); err != nil && !errors.Is(err, os.ErrProcessDone) {
+			return fmt.Errorf("kill provider dev server: %w", err)
+		}
+		<-p.done
+		return nil
+	}
+}
+
+func waitForProviderDevReady(ctx context.Context, baseURL string, proc *providerDevServeProcess) error {
+	client := &http.Client{Timeout: 2 * time.Second}
+	ticker := time.NewTicker(250 * time.Millisecond)
+	defer ticker.Stop()
+	timeout := time.NewTimer(providerDevReadyTimeout)
+	defer timeout.Stop()
+
+	for {
+		select {
+		case <-ctx.Done():
+			return ctx.Err()
+		case <-timeout.C:
+			return fmt.Errorf("provider dev server did not become ready within %s", providerDevReadyTimeout)
+		case <-proc.Done():
+			if err := proc.WaitErr(); err != nil {
+				return fmt.Errorf("provider dev server exited before becoming ready: %w", err)
+			}
+			return errors.New("provider dev server exited before becoming ready")
+		case <-ticker.C:
+			resp, err := client.Get(strings.TrimRight(baseURL, "/") + "/ready")
+			if err != nil {
+				continue
+			}
+			_ = resp.Body.Close()
+			if resp.StatusCode == http.StatusOK {
+				return nil
+			}
+		}
+	}
+}
+
+type providerDevWatcher struct {
+	watcher           *fsnotify.Watcher
+	packageDir        string
+	staticCatalogPath string
+	watchDirs         []string
+	configFiles       map[string]struct{}
+	watchedDirs       map[string]struct{}
+}
+
+func newProviderDevWatcher(session *providerLocalSession) (*providerDevWatcher, error) {
+	fsWatcher, err := fsnotify.NewWatcher()
+	if err != nil {
+		return nil, fmt.Errorf("create file watcher: %w", err)
+	}
+
+	watcher := &providerDevWatcher{
+		watcher:     fsWatcher,
+		configFiles: map[string]struct{}{},
+		watchedDirs: map[string]struct{}{},
+	}
+	if err := watcher.SyncSession(session); err != nil {
+		_ = fsWatcher.Close()
+		return nil, err
+	}
+	return watcher, nil
+}
+
+func (w *providerDevWatcher) Close() error {
+	if w == nil || w.watcher == nil {
+		return nil
+	}
+	return w.watcher.Close()
+}
+
+func (w *providerDevWatcher) Events() <-chan fsnotify.Event {
+	return w.watcher.Events
+}
+
+func (w *providerDevWatcher) Errors() <-chan error {
+	return w.watcher.Errors
+}
+
+func (w *providerDevWatcher) SyncSession(session *providerLocalSession) error {
+	if w == nil || session == nil {
+		return nil
+	}
+
+	packageDir, err := canonicalPath(session.PackageDir)
+	if err != nil {
+		return err
+	}
+	w.packageDir = packageDir
+	staticCatalogPath, err := canonicalPath(providerpkg.StaticCatalogPath(packageDir))
+	if err != nil {
+		return err
+	}
+	w.staticCatalogPath = staticCatalogPath
+
+	if err := w.syncWatchDirs(providerDevWatchRoots(session)); err != nil {
+		return err
+	}
+
+	configFiles := make(map[string]struct{}, len(session.UserConfigPaths))
+	for _, path := range session.UserConfigPaths {
+		if strings.TrimSpace(path) == "" {
+			continue
+		}
+		canonicalFile, err := canonicalPath(path)
+		if err != nil {
+			return err
+		}
+		configFiles[canonicalFile] = struct{}{}
+		if err := w.addDir(filepath.Dir(canonicalFile)); err != nil {
+			return err
+		}
+	}
+	w.configFiles = configFiles
+	return nil
+}
+
+func (w *providerDevWatcher) HandleEvent(event fsnotify.Event) (bool, string, error) {
+	if event.Op&^fsnotify.Chmod == 0 {
+		return false, "", nil
+	}
+
+	eventPath, err := canonicalPath(event.Name)
+	if err != nil {
+		return false, "", err
+	}
+	if event.Op&(fsnotify.Remove|fsnotify.Rename) != 0 {
+		w.dropWatchedDir(eventPath)
+	}
+	if eventPath == w.staticCatalogPath {
+		return false, "", nil
+	}
+	if err := w.addCreatedDirs(eventPath); err != nil {
+		return false, "", err
+	}
+
+	if pathWithinAnyRoot(eventPath, w.watchDirs) {
+		return true, eventPath, nil
+	}
+	if _, ok := w.configFiles[eventPath]; ok {
+		return true, eventPath, nil
+	}
+	return false, "", nil
+}
+
+func (w *providerDevWatcher) watchRoots() []string {
+	if len(w.watchDirs) == 0 {
+		return nil
+	}
+	return append([]string(nil), w.watchDirs...)
+}
+
+func (w *providerDevWatcher) configFilesList() []string {
+	if len(w.configFiles) == 0 {
+		return nil
+	}
+	paths := make([]string, 0, len(w.configFiles))
+	for path := range w.configFiles {
+		paths = append(paths, path)
+	}
+	slices.Sort(paths)
+	return paths
+}
+
+func (w *providerDevWatcher) syncWatchDirs(roots []string) error {
+	canonicalRoots := make([]string, 0, len(roots))
+	for _, root := range roots {
+		if strings.TrimSpace(root) == "" {
+			continue
+		}
+		canonicalRoot, err := canonicalPath(root)
+		if err != nil {
+			return err
+		}
+		if slices.Contains(canonicalRoots, canonicalRoot) {
+			continue
+		}
+		if err := w.addRecursiveDir(canonicalRoot); err != nil {
+			return err
+		}
+		canonicalRoots = append(canonicalRoots, canonicalRoot)
+	}
+	slices.Sort(canonicalRoots)
+	w.watchDirs = canonicalRoots
+	return nil
+}
+
+func (w *providerDevWatcher) addCreatedDirs(path string) error {
+	info, err := os.Stat(path)
+	if err != nil {
+		if errors.Is(err, os.ErrNotExist) {
+			return nil
+		}
+		return err
+	}
+	if !info.IsDir() {
+		return nil
+	}
+	if pathWithinRoot(path, w.packageDir) {
+		return w.addRecursiveDir(path)
+	}
+	return w.addDir(path)
+}
+
+func (w *providerDevWatcher) dropWatchedDir(path string) {
+	if len(w.watchedDirs) == 0 {
+		return
+	}
+	for watchedDir := range w.watchedDirs {
+		if watchedDir == path || pathWithinRoot(watchedDir, path) {
+			delete(w.watchedDirs, watchedDir)
+		}
+	}
+}
+
+func (w *providerDevWatcher) addRecursiveDir(root string) error {
+	return filepath.WalkDir(root, func(path string, d fs.DirEntry, err error) error {
+		if err != nil {
+			return err
+		}
+		if !d.IsDir() {
+			return nil
+		}
+		return w.addDir(path)
+	})
+}
+
+func (w *providerDevWatcher) addDir(dir string) error {
+	canonicalDir, err := canonicalPath(dir)
+	if err != nil {
+		return err
+	}
+	if _, ok := w.watchedDirs[canonicalDir]; ok {
+		return nil
+	}
+	if err := w.watcher.Add(canonicalDir); err != nil {
+		return fmt.Errorf("watch %s: %w", canonicalDir, err)
+	}
+	w.watchedDirs[canonicalDir] = struct{}{}
+	return nil
+}
+
+func providerDevWatchRoots(session *providerLocalSession) []string {
+	if session == nil {
+		return nil
+	}
+
+	roots := []string{session.PackageDir}
+	if session.Manifest == nil || session.Manifest.Spec == nil || session.Manifest.Spec.UI == nil {
+		return roots
+	}
+
+	ownedUIPath := strings.TrimSpace(session.Manifest.Spec.UI.Path)
+	if ownedUIPath == "" {
+		return roots
+	}
+
+	resolvedPath := filepath.Clean(filepath.Join(session.PackageDir, filepath.FromSlash(ownedUIPath)))
+	if info, err := os.Stat(resolvedPath); err == nil && !info.IsDir() {
+		resolvedPath = filepath.Dir(resolvedPath)
+	}
+	roots = append(roots, resolvedPath)
+	return roots
+}
+
+func pathWithinRoot(path, root string) bool {
+	if path == root {
+		return true
+	}
+	rel, err := filepath.Rel(root, path)
+	if err != nil {
+		return false
+	}
+	return rel != "." && rel != ".." && !strings.HasPrefix(rel, ".."+string(filepath.Separator))
+}
+
+func pathWithinAnyRoot(path string, roots []string) bool {
+	for _, root := range roots {
+		if pathWithinRoot(path, root) {
+			return true
+		}
+	}
+	return false
+}
+
+func stopAndDrainTimer(timer *time.Timer) {
+	if timer == nil {
+		return
+	}
+	if !timer.Stop() {
+		select {
+		case <-timer.C:
+		default:
+		}
+	}
+}

--- a/gestaltd/go.mod
+++ b/gestaltd/go.mod
@@ -3,6 +3,7 @@ module github.com/valon-technologies/gestalt/server
 go 1.26
 
 require (
+	github.com/fsnotify/fsnotify v1.8.0
 	github.com/go-chi/chi/v5 v5.2.5
 	github.com/golang-jwt/jwt/v5 v5.3.1
 	github.com/google/uuid v1.6.0

--- a/gestaltd/go.sum
+++ b/gestaltd/go.sum
@@ -16,6 +16,8 @@ github.com/felixge/httpsnoop v1.0.4 h1:NFTV2Zj1bL4mc9sqWACXbQFVBBg2W3GPvqp8/ESS2
 github.com/felixge/httpsnoop v1.0.4/go.mod h1:m8KPJKqk1gH5J9DgRY2ASl2lWCfGKXixSwevea8zH2U=
 github.com/frankban/quicktest v1.14.6 h1:7Xjx+VpznH+oBnejlPUj8oUpdxnVs4f8XU8WnHkI4W8=
 github.com/frankban/quicktest v1.14.6/go.mod h1:4ptaffx2x8+WTWXmUCuVU6aPUX1/Mz7zb5vbUoiM6w0=
+github.com/fsnotify/fsnotify v1.8.0 h1:dAwr6QBTBZIkG8roQaJjGof0pp0EeF+tNV7YBP3F/8M=
+github.com/fsnotify/fsnotify v1.8.0/go.mod h1:8jBTzvmWwFyi3Pb8djgCCO5IBqzKJ/Jwo8TRcHyHii0=
 github.com/go-chi/chi/v5 v5.2.5 h1:Eg4myHZBjyvJmAFjFvWgrqDTXFyOzjj7YIm3L3mu6Ug=
 github.com/go-chi/chi/v5 v5.2.5/go.mod h1:X7Gx4mteadT3eDOMTsXzmI4/rwUpOwBHLpAfupzFJP0=
 github.com/go-logr/logr v1.2.2/go.mod h1:jdQByPbusPIv2/zmleS9BjJVeZ6kBagPoEUsqbVz/1A=


### PR DESCRIPTION
## Summary
- make `gestaltd provider dev` watch the target plugin package and layered `--config` files by default
- restart by supervising a real child `gestaltd serve` process so serve semantics stay identical and the temp session state is preserved across restarts
- keep one-shot behavior available via `--no-watch`
- document the new behavior in `docs/` and add end-to-end coverage for a live source edit that changes invoke output without relaunching `provider dev`

## New interface
```sh
gestaltd provider dev [--path PATH] [--config PATH]... [--name NAME] [--port PORT] [--no-watch]
```

## Examples
```sh
gestaltd provider dev --path ./plugins/support
gestaltd provider dev --path ./plugins/support --config ./dev/support.yaml --port 8080
gestaltd provider dev --path ./plugins/support --no-watch
```

## Verification
```sh
golangci-lint run ./cmd/gestaltd
go test ./cmd/gestaltd -run 'TestE2ECLIHelp|TestE2ECLIRejectsBadArgs|TestE2EProviderValidateIsolatedSourcePlugin|TestE2EProviderValidateReusesConfiguredPluginKey|TestE2EProviderValidateRejectsNonPluginManifest|TestE2EProviderValidateLayeredConfigSupportsNullDeletion|TestE2EProviderDevServesAdminWithoutInjectingRootUI|TestE2EProviderDevAutoMountsOwnedUI|TestE2EProviderDevRestartsOnSourceChange' -count=1
```