### PR TITLE
gestaltd provider dev/validate: support local ui bundles and sibling plugin/ui layouts

### DIFF
--- a/docs/content/custom-providers/plugins.mdx
+++ b/docs/content/custom-providers/plugins.mdx
@@ -642,7 +642,10 @@ A Slack plugin could use this to check which Slack workspace the caller is conne
 Use the provider-local commands when you are iterating on a source plugin.
 `gestaltd provider dev` and `gestaltd provider validate` synthesize a local
 Gestalt config around the target plugin instead of requiring a hand-written
-temp config.
+temp config. If the plugin manifest declares `spec.ui.path`, Gestalt mounts
+that owned UI automatically. For the common `plugin/` + sibling `ui/` layout,
+the local commands also detect `../ui/manifest.yaml` and wire it in
+automatically during local development.
 
 Validate the plugin in isolation:
 
@@ -654,6 +657,14 @@ Run the plugin locally with browser-facing UI available:
 
 ```sh
 gestaltd provider dev --path ./slack
+```
+
+Validate or serve the UI bundle directly when you are working on the frontend
+itself:
+
+```sh
+gestaltd provider validate --path ./ui
+gestaltd provider dev --path ./ui
 ```
 
 When the plugin needs supporting providers, extra plugins, or explicit mounted

--- a/docs/content/custom-providers/ui.mdx
+++ b/docs/content/custom-providers/ui.mdx
@@ -10,6 +10,18 @@ prefixes configured in `providers.ui.<name>.path`. The built-in admin UI at
 `/admin` remains available regardless of whether a custom UI bundle is
 configured.
 
+For local iteration, you can run a source UI bundle directly with the same
+provider-local commands used for plugins:
+
+```sh
+gestaltd provider validate --path ./ui
+gestaltd provider dev --path ./ui
+```
+
+When the UI is part of a `plugin/` + sibling `ui/` package layout, running
+`gestaltd provider dev` from the plugin side also picks up that sibling UI
+automatically for the local session.
+
 A UI bundle is not a plugin in the executable sense. It contains no server-side
 code. Gestalt simply serves the static files from the asset root directory. The
 bundle talks to Gestalt through the same HTTP API and MCP endpoints that any

--- a/docs/content/reference/cli.mdx
+++ b/docs/content/reference/cli.mdx
@@ -31,10 +31,10 @@ import { Callout } from 'nextra/components'
 
 | Command | Purpose |
 | --- | --- |
-| `gestaltd provider dev --path PATH` | Run a local source plugin inside a synthesized Gestalt config. Serves `/admin` and any configured or inferred public UIs. |
+| `gestaltd provider dev --path PATH` | Run a local source plugin or UI bundle inside a synthesized Gestalt config. Serves `/admin` and any configured or inferred public UIs. |
 | `gestaltd provider dev --config PATH` | Layer supporting providers, plugins, and UI mounts on top of the synthesized local baseline. Repeat `--config` to merge left-to-right. |
-| `gestaltd provider validate --path PATH` | Validate a local source plugin inside the same synthesized Gestalt config used by `provider dev`. |
-| `gestaltd provider validate --config PATH` | Validate the target plugin together with selected supporting providers and `null` deletions from layered config overlays. |
+| `gestaltd provider validate --path PATH` | Validate a local source plugin or UI bundle inside the same synthesized Gestalt config used by `provider dev`. |
+| `gestaltd provider validate --config PATH` | Validate the target provider together with selected supporting providers and `null` deletions from layered config overlays. |
 | `gestaltd provider release --version VERSION` | Build and package a provider release. Go, Python, Rust, and TypeScript source plugins default to the host platform. Pass `--platform ...` with `os/arch[/libc]` targets or `--platform all` for multi-platform builds. |
 | `gestaltd provider release --output DIR` | Output directory for the release archive. Defaults to `dist/`. |
 
@@ -51,8 +51,10 @@ gestaltd serve --locked --config ./config.yaml --lockfile ./local/gestalt.lock.j
 gestaltd init --config ./base.yaml --config ./overrides/local.yaml
 gestaltd serve --locked --config ./base.yaml --config ./overrides/prod.yaml
 gestaltd provider validate --path ./plugins/support
+gestaltd provider validate --path ./ui/dashboard
 gestaltd provider validate --path ./plugins/support --config ./dev/support.yaml --config ./dev/local.yaml
 gestaltd provider dev --path ./plugins/support
+gestaltd provider dev --path ./ui/dashboard
 gestaltd provider dev --path ./plugins/support --config ./dev/support.yaml --port 8080
 gestaltd provider release --version 0.0.1-alpha.1
 gestaltd provider release --version 0.0.1-alpha.1 --platform all

--- a/gestaltd/cmd/gestaltd/e2e_test.go
+++ b/gestaltd/cmd/gestaltd/e2e_test.go
@@ -255,6 +255,30 @@ func TestE2EProviderValidateIsolatedSourcePlugin(t *testing.T) {
 	}
 }
 
+func TestE2EProviderValidateSourceUI(t *testing.T) {
+	t.Parallel()
+
+	dir := t.TempDir()
+	providersDir := setupDefaultLocalProvidersDir(t, dir)
+	mountedUI := setupMountedUIDir(t, dir)
+
+	cmd := exec.Command(gestaltdBin, "provider", "validate", "--path", mountedUI.ManifestPath)
+	cmd.Env = append(os.Environ(),
+		"GESTALT_PROVIDERS_DIR="+providersDir,
+		"GOTELEMETRY=off",
+	)
+	out, err := cmd.CombinedOutput()
+	if err != nil {
+		t.Fatalf("gestaltd provider validate failed: %v\noutput: %s", err, out)
+	}
+	if !strings.Contains(string(out), "config ok") {
+		t.Fatalf("expected validate success, got: %s", out)
+	}
+	if !strings.Contains(string(out), "ui=roadmap_review") {
+		t.Fatalf("expected ui validation summary, got: %s", out)
+	}
+}
+
 func TestE2EProviderValidateReusesConfiguredPluginKey(t *testing.T) {
 	t.Parallel()
 
@@ -294,7 +318,7 @@ func TestE2EProviderValidateRejectsNonPluginManifest(t *testing.T) {
 	if err == nil {
 		t.Fatalf("expected gestaltd provider validate to fail for non-plugin manifest\n%s", out)
 	}
-	if !strings.Contains(string(out), "only support kind: plugin in v1") {
+	if !strings.Contains(string(out), "only support kind: plugin or ui in v1") {
 		t.Fatalf("expected plugin-only error, got: %s", out)
 	}
 }
@@ -1240,7 +1264,12 @@ func attachOwnedUIToPluginSource(t *testing.T, pluginDir, uiManifestPath string)
 func setupMountedUIDirWithRoutes(t *testing.T, baseDir string, routes []providermanifestv1.UIRoute) *mountedUITestConfig {
 	t.Helper()
 
-	uiDir := filepath.Join(baseDir, "mounted-ui")
+	return setupMountedUIDirAt(t, filepath.Join(baseDir, "mounted-ui"), routes)
+}
+
+func setupMountedUIDirAt(t *testing.T, uiDir string, routes []providermanifestv1.UIRoute) *mountedUITestConfig {
+	t.Helper()
+
 	distDir := filepath.Join(uiDir, "dist")
 	assetsDir := filepath.Join(distDir, "assets")
 	if err := os.MkdirAll(assetsDir, 0o755); err != nil {
@@ -1710,6 +1739,80 @@ func TestE2EProviderDevAutoMountsOwnedUI(t *testing.T) {
 		}
 	}
 	t.Fatalf(`integration "provider" mountedPath missing from response: %s`, integrationsBody)
+}
+
+func TestE2EProviderDevServesSourceUI(t *testing.T) {
+	t.Parallel()
+
+	if testing.Short() {
+		t.Skip("skipping provider dev ui test in short mode")
+	}
+
+	dir := t.TempDir()
+	providersDir := setupDefaultLocalProvidersDir(t, dir)
+	mountedUI := setupMountedUIDir(t, dir)
+	port, holder := reservePort(t)
+	baseURL := fmt.Sprintf("http://127.0.0.1:%d", port)
+	_ = holder.Close()
+
+	cmd := exec.Command(gestaltdBin, "provider", "dev", "--path", mountedUI.ManifestPath, "--port", fmt.Sprintf("%d", port))
+	cmd.Env = append(os.Environ(),
+		"GESTALT_PROVIDERS_DIR="+providersDir,
+		"GOTELEMETRY=off",
+	)
+	startCommandAndWaitReady(t, cmd, baseURL)
+
+	client := &http.Client{Timeout: 2 * time.Second}
+	uiResp, err := client.Get(baseURL + "/roadmap_review/sync")
+	if err != nil {
+		t.Fatalf("GET /roadmap_review/sync: %v", err)
+	}
+	defer func() { _ = uiResp.Body.Close() }()
+	uiBody, _ := io.ReadAll(uiResp.Body)
+	if uiResp.StatusCode != http.StatusOK {
+		t.Fatalf("expected /roadmap_review/sync 200, got %d: %s", uiResp.StatusCode, uiBody)
+	}
+	if !strings.Contains(string(uiBody), "Roadmap Review UI") {
+		t.Fatalf("expected direct ui body marker, got: %s", uiBody)
+	}
+}
+
+func TestE2EProviderDevAutoMountsSiblingUIForPlugin(t *testing.T) {
+	t.Parallel()
+
+	if testing.Short() {
+		t.Skip("skipping provider dev sibling-ui test in short mode")
+	}
+
+	dir := t.TempDir()
+	providersDir := setupDefaultLocalProvidersDir(t, dir)
+	rootDir := filepath.Join(dir, "package")
+	pluginDir := setupPluginDir(t, filepath.Join(rootDir, "plugin"))
+	_ = setupMountedUIDirAt(t, filepath.Join(rootDir, "ui"), nil)
+	port, holder := reservePort(t)
+	baseURL := fmt.Sprintf("http://127.0.0.1:%d", port)
+	_ = holder.Close()
+
+	cmd := exec.Command(gestaltdBin, "provider", "dev", "--path", componentProviderManifestPath(t, pluginDir), "--port", fmt.Sprintf("%d", port))
+	cmd.Env = append(os.Environ(),
+		"GESTALT_PROVIDERS_DIR="+providersDir,
+		"GOTELEMETRY=off",
+	)
+	startCommandAndWaitReady(t, cmd, baseURL)
+
+	client := &http.Client{Timeout: 2 * time.Second}
+	uiResp, err := client.Get(baseURL + "/provider/sync")
+	if err != nil {
+		t.Fatalf("GET /provider/sync: %v", err)
+	}
+	defer func() { _ = uiResp.Body.Close() }()
+	uiBody, _ := io.ReadAll(uiResp.Body)
+	if uiResp.StatusCode != http.StatusOK {
+		t.Fatalf("expected /provider/sync 200, got %d: %s", uiResp.StatusCode, uiBody)
+	}
+	if !strings.Contains(string(uiBody), "Roadmap Review UI") {
+		t.Fatalf("expected sibling ui body marker, got: %s", uiBody)
+	}
 }
 
 //nolint:paralleltest // Uses the default 8080 startup path intentionally.

--- a/gestaltd/cmd/gestaltd/main_test.go
+++ b/gestaltd/cmd/gestaltd/main_test.go
@@ -39,12 +39,12 @@ func TestE2ECLIHelp(t *testing.T) {
 		{
 			name:      "provider validate",
 			args:      []string{"provider", "validate", "--help"},
-			wantParts: []string{"gestaltd provider validate", "v1 supports kind: plugin manifests only", "--config PATH"},
+			wantParts: []string{"gestaltd provider validate", "v1 supports kind: plugin and kind: ui manifests", "--config PATH"},
 		},
 		{
 			name:      "provider dev",
 			args:      []string{"provider", "dev", "--help"},
-			wantParts: []string{"gestaltd provider dev", "The built-in admin UI remains available at /admin", "--port PORT"},
+			wantParts: []string{"gestaltd provider dev", "The built-in admin UI remains available at /admin", "sibling public UIs", "--port PORT"},
 		},
 	}
 

--- a/gestaltd/cmd/gestaltd/provider_local.go
+++ b/gestaltd/cmd/gestaltd/provider_local.go
@@ -28,6 +28,8 @@ import (
 const (
 	providerDevHost          = "127.0.0.1"
 	providerDevIndexedDBName = "main"
+	providerLocalPluginDir   = "plugin"
+	providerLocalSiblingUI   = "ui"
 )
 
 type providerLocalCommandOptions struct {
@@ -39,8 +41,9 @@ type providerLocalCommandOptions struct {
 
 type providerLocalSession struct {
 	Dir               string
+	Kind              string
 	ManifestPath      string
-	PluginKey         string
+	TargetKey         string
 	ConfigPaths       []string
 	State             operator.StatePaths
 	PublicURL         string
@@ -55,7 +58,7 @@ func runProviderValidate(args []string) error {
 	var configPaths repeatedStringFlag
 	fs.Var(&configPaths, "config", "path to config file (repeat to layer overrides)")
 	pathFlag := fs.String("path", "", "provider manifest path or directory (defaults to current working directory)")
-	nameFlag := fs.String("name", "", "plugin key override")
+	nameFlag := fs.String("name", "", "provider key override")
 	if err := fs.Parse(args); err != nil {
 		return err
 	}
@@ -94,7 +97,7 @@ func runProviderDev(args []string) error {
 	var configPaths repeatedStringFlag
 	fs.Var(&configPaths, "config", "path to config file (repeat to layer overrides)")
 	pathFlag := fs.String("path", "", "provider manifest path or directory (defaults to current working directory)")
-	nameFlag := fs.String("name", "", "plugin key override")
+	nameFlag := fs.String("name", "", "provider key override")
 	portFlag := fs.Int("port", 0, "public port (defaults to a free localhost port)")
 	if err := fs.Parse(args); err != nil {
 		return err
@@ -165,8 +168,8 @@ func prepareProviderLocalSession(opts providerLocalCommandOptions) (*providerLoc
 	if err != nil {
 		return nil, err
 	}
-	if kind != providermanifestv1.KindPlugin {
-		return nil, fmt.Errorf("gestaltd provider dev and validate only support kind: plugin in v1 (got %q)", kind)
+	if kind != providermanifestv1.KindPlugin && kind != providermanifestv1.KindUI {
+		return nil, fmt.Errorf("gestaltd provider dev and validate only support kind: plugin or ui in v1 (got %q)", kind)
 	}
 
 	targetManifestPath, err := canonicalPath(manifestPath)
@@ -190,15 +193,35 @@ func prepareProviderLocalSession(opts providerLocalCommandOptions) (*providerLoc
 	if err := writeProviderLocalBaseConfig(baseConfigPath, dbPath); err != nil {
 		return nil, err
 	}
+	state := operator.StatePaths{
+		ArtifactsDir: filepath.Join(sessionDir, "artifacts"),
+		LockfilePath: filepath.Join(sessionDir, "gestalt.lock.json"),
+	}
 
+	var session *providerLocalSession
+	switch kind {
+	case providermanifestv1.KindPlugin:
+		session, err = preparePluginLocalSession(sessionDir, baseConfigPath, state, opts, targetManifestPath, manifest)
+	case providermanifestv1.KindUI:
+		session, err = prepareUILocalSession(sessionDir, baseConfigPath, state, opts, targetManifestPath, manifest)
+	default:
+		err = fmt.Errorf("unsupported provider local target kind %q", kind)
+	}
+	if err != nil {
+		return nil, err
+	}
+	cleanupSessionDir = false
+	return session, nil
+}
+
+func preparePluginLocalSession(sessionDir, baseConfigPath string, state operator.StatePaths, opts providerLocalCommandOptions, targetManifestPath string, manifest *providermanifestv1.Manifest) (*providerLocalSession, error) {
 	resolvedKey, err := resolveProviderLocalPluginKey(opts.ConfigPaths, targetManifestPath, manifest, opts.Name)
 	if err != nil {
 		return nil, err
 	}
 
 	overlayConfigPath := filepath.Join(sessionDir, "provider-target.yaml")
-	autoMountPath := ""
-	if err := writeProviderLocalOverlayConfig(overlayConfigPath, resolvedKey, targetManifestPath, opts.Port, ""); err != nil {
+	if err := writeProviderLocalPluginOverlayConfig(overlayConfigPath, resolvedKey, targetManifestPath, opts.Port, "", "", ""); err != nil {
 		return nil, err
 	}
 
@@ -210,19 +233,43 @@ func prepareProviderLocalSession(opts providerLocalCommandOptions) (*providerLoc
 		return nil, fmt.Errorf("loading provider dev config: %w", err)
 	}
 
-	if shouldAutoMountOwnedUI(loadedCfg, resolvedKey, manifest) {
+	autoMountPath := ""
+	siblingUIManifestPath, err := findSiblingUIManifestPath(targetManifestPath, manifest)
+	if err != nil {
+		return nil, err
+	}
+	switch {
+	case shouldAutoMountOwnedUI(loadedCfg, resolvedKey, manifest):
 		autoMountPath = "/" + resolvedKey
 		if err := ensureNoPublicUIPathCollision(loadedCfg, resolvedKey, autoMountPath); err != nil {
 			return nil, err
 		}
-		if err := writeProviderLocalOverlayConfig(overlayConfigPath, resolvedKey, targetManifestPath, opts.Port, autoMountPath); err != nil {
+		if err := writeProviderLocalPluginOverlayConfig(overlayConfigPath, resolvedKey, targetManifestPath, opts.Port, autoMountPath, "", ""); err != nil {
 			return nil, err
 		}
-		configPaths[len(configPaths)-1] = overlayConfigPath
-		loadedCfg, err = config.LoadPaths(configPaths)
-		if err != nil {
-			return nil, fmt.Errorf("loading provider dev config with auto-mounted ui: %w", err)
+	case siblingUIManifestPath != "":
+		var uiName string
+		if entry := loadedCfg.Plugins[resolvedKey]; entry != nil {
+			uiName = strings.TrimSpace(entry.UI)
+			autoMountPath = strings.TrimSpace(entry.MountPath)
 		}
+		if uiName == "" {
+			uiName = resolvedKey
+		}
+		if autoMountPath == "" {
+			autoMountPath = "/" + resolvedKey
+			if err := ensureNoPublicUIPathCollision(loadedCfg, resolvedKey, autoMountPath); err != nil {
+				return nil, err
+			}
+		}
+		if err := writeProviderLocalPluginOverlayConfig(overlayConfigPath, resolvedKey, targetManifestPath, opts.Port, autoMountPath, uiName, siblingUIManifestPath); err != nil {
+			return nil, err
+		}
+	}
+
+	loadedCfg, err = config.LoadPaths(configPaths)
+	if err != nil {
+		return nil, fmt.Errorf("loading provider dev config with mounted ui: %w", err)
 	}
 
 	publicURL := providerLocalPublicURL(loadedCfg)
@@ -231,13 +278,61 @@ func prepareProviderLocalSession(opts providerLocalCommandOptions) (*providerLoc
 		publicUIPaths = append(publicUIPaths, autoMountPath)
 		slices.Sort(publicUIPaths)
 	}
-	cleanupSessionDir = false
+
 	return &providerLocalSession{
 		Dir:               sessionDir,
+		Kind:              providermanifestv1.KindPlugin,
 		ManifestPath:      targetManifestPath,
-		PluginKey:         resolvedKey,
+		TargetKey:         resolvedKey,
 		ConfigPaths:       configPaths,
-		State:             operator.StatePaths{ArtifactsDir: filepath.Join(sessionDir, "artifacts"), LockfilePath: filepath.Join(sessionDir, "gestalt.lock.json")},
+		State:             state,
+		PublicURL:         publicURL,
+		AdminURL:          strings.TrimRight(publicURL, "/") + "/admin/",
+		PublicUIPaths:     publicUIPaths,
+		AutoMountedUIPath: autoMountPath,
+	}, nil
+}
+
+func prepareUILocalSession(sessionDir, baseConfigPath string, state operator.StatePaths, opts providerLocalCommandOptions, targetManifestPath string, manifest *providermanifestv1.Manifest) (*providerLocalSession, error) {
+	resolvedKey, err := resolveProviderLocalUIKey(opts.ConfigPaths, targetManifestPath, manifest, opts.Name)
+	if err != nil {
+		return nil, err
+	}
+
+	autoMountPath := "/" + resolvedKey
+	if configuredUIs, err := loadConfiguredUIs(opts.ConfigPaths); err == nil {
+		if entry := configuredUIs[resolvedKey]; entry != nil && strings.TrimSpace(entry.Path) != "" {
+			autoMountPath = strings.TrimSpace(entry.Path)
+		}
+	}
+
+	overlayConfigPath := filepath.Join(sessionDir, "provider-target.yaml")
+	if err := writeProviderLocalUIOverlayConfig(overlayConfigPath, resolvedKey, targetManifestPath, opts.Port, autoMountPath); err != nil {
+		return nil, err
+	}
+
+	configPaths := append([]string{baseConfigPath}, opts.ConfigPaths...)
+	configPaths = append(configPaths, overlayConfigPath)
+
+	loadedCfg, err := config.LoadPaths(configPaths)
+	if err != nil {
+		return nil, fmt.Errorf("loading provider dev config: %w", err)
+	}
+
+	publicURL := providerLocalPublicURL(loadedCfg)
+	publicUIPaths := mountedPublicUIPaths(loadedCfg)
+	if autoMountPath != "" && !slices.Contains(publicUIPaths, autoMountPath) {
+		publicUIPaths = append(publicUIPaths, autoMountPath)
+		slices.Sort(publicUIPaths)
+	}
+
+	return &providerLocalSession{
+		Dir:               sessionDir,
+		Kind:              providermanifestv1.KindUI,
+		ManifestPath:      targetManifestPath,
+		TargetKey:         resolvedKey,
+		ConfigPaths:       configPaths,
+		State:             state,
 		PublicURL:         publicURL,
 		AdminURL:          strings.TrimRight(publicURL, "/") + "/admin/",
 		PublicUIPaths:     publicUIPaths,
@@ -343,15 +438,16 @@ func writeProviderLocalBaseConfig(path, dbPath string) error {
 	return writeYAMLFile(path, cfg)
 }
 
-func writeProviderLocalOverlayConfig(path, pluginKey, manifestPath string, port int, mountPath string) error {
+func writeProviderLocalPluginOverlayConfig(path, pluginKey, manifestPath string, port int, mountPath, uiName, uiManifestPath string) error {
 	pluginEntry := map[string]any{
-		"source": map[string]any{
-			"path": manifestPath,
-		},
+		"source":  providerLocalSourceOverride(manifestPath),
 		"runtime": nil,
 	}
 	if mountPath != "" {
 		pluginEntry["mountPath"] = mountPath
+	}
+	if uiName != "" {
+		pluginEntry["ui"] = uiName
 	}
 
 	cfg := map[string]any{
@@ -365,7 +461,49 @@ func writeProviderLocalOverlayConfig(path, pluginKey, manifestPath string, port 
 			pluginKey: pluginEntry,
 		},
 	}
+	if uiName != "" && uiManifestPath != "" {
+		cfg["providers"] = map[string]any{
+			"ui": map[string]any{
+				uiName: map[string]any{
+					"source": providerLocalSourceOverride(uiManifestPath),
+				},
+			},
+		}
+	}
 	return writeYAMLFile(path, cfg)
+}
+
+func writeProviderLocalUIOverlayConfig(path, uiKey, manifestPath string, port int, mountPath string) error {
+	uiEntry := map[string]any{
+		"source": providerLocalSourceOverride(manifestPath),
+	}
+	if mountPath != "" {
+		uiEntry["path"] = mountPath
+	}
+
+	cfg := map[string]any{
+		"server": map[string]any{
+			"public": map[string]any{
+				"host": providerDevHost,
+				"port": port,
+			},
+		},
+		"providers": map[string]any{
+			"ui": map[string]any{
+				uiKey: uiEntry,
+			},
+		},
+	}
+	return writeYAMLFile(path, cfg)
+}
+
+func providerLocalSourceOverride(manifestPath string) map[string]any {
+	return map[string]any{
+		"path":          manifestPath,
+		"url":           nil,
+		"githubRelease": nil,
+		"auth":          nil,
+	}
 }
 
 func shouldAutoMountOwnedUI(cfg *config.Config, pluginKey string, manifest *providermanifestv1.Manifest) bool {
@@ -404,6 +542,54 @@ func ensureNoPublicUIPathCollision(cfg *config.Config, pluginKey, mountPath stri
 		}
 	}
 	return nil
+}
+
+func findSiblingUIManifestPath(pluginManifestPath string, manifest *providermanifestv1.Manifest) (string, error) {
+	if manifest == nil || manifest.Spec == nil || manifest.Spec.UI != nil {
+		return "", nil
+	}
+	pluginDir := filepath.Dir(pluginManifestPath)
+	for filepath.Base(pluginDir) != providerLocalPluginDir {
+		parentDir := filepath.Dir(pluginDir)
+		if parentDir == pluginDir {
+			return "", nil
+		}
+		pluginDir = parentDir
+	}
+
+	uiDir := filepath.Join(filepath.Dir(pluginDir), providerLocalSiblingUI)
+	info, err := os.Stat(uiDir)
+	if err != nil {
+		if errors.Is(err, os.ErrNotExist) {
+			return "", nil
+		}
+		return "", fmt.Errorf("stat sibling ui dir %s: %w", uiDir, err)
+	}
+	if !info.IsDir() {
+		return "", nil
+	}
+
+	uiManifestPath, err := providerpkg.FindManifestFile(uiDir)
+	if err != nil {
+		return "", fmt.Errorf("find sibling ui manifest: %w", err)
+	}
+	uiManifestPath, err = canonicalPath(uiManifestPath)
+	if err != nil {
+		return "", err
+	}
+
+	_, uiManifest, err := providerpkg.ReadSourceManifestFile(uiManifestPath)
+	if err != nil {
+		return "", err
+	}
+	kind, err := providerpkg.ManifestKind(uiManifest)
+	if err != nil {
+		return "", err
+	}
+	if kind != providermanifestv1.KindUI {
+		return "", fmt.Errorf("sibling ui manifest %q must have kind %q (got %q)", uiManifestPath, providermanifestv1.KindUI, kind)
+	}
+	return uiManifestPath, nil
 }
 
 func providerLocalIndexedDBSourceConfig() any {
@@ -454,15 +640,22 @@ func logProviderLocalSummary(message string, session *providerLocalSession) {
 	if len(publicUIPaths) == 0 {
 		publicUIPaths = nil
 	}
-	slog.Info(message,
-		"plugin", session.PluginKey,
+	args := []any{
+		"kind", session.Kind,
 		"manifest", session.ManifestPath,
 		"public_url", session.PublicURL,
 		"admin_url", session.AdminURL,
 		"mounted_ui_paths", publicUIPaths,
 		"auto_mounted_ui_path", session.AutoMountedUIPath,
 		"config_files", session.ConfigPaths,
-	)
+	}
+	switch session.Kind {
+	case providermanifestv1.KindUI:
+		args = append(args, "ui", session.TargetKey)
+	default:
+		args = append(args, "plugin", session.TargetKey)
+	}
+	slog.Info(message, args...)
 }
 
 func reserveLocalPort() (int, error) {
@@ -562,6 +755,20 @@ func loadConfiguredPlugins(configPaths []string) (map[string]*config.ProviderEnt
 	return cfg.Plugins, nil
 }
 
+func loadConfiguredUIs(configPaths []string) (map[string]*config.UIEntry, error) {
+	if len(configPaths) == 0 {
+		return map[string]*config.UIEntry{}, nil
+	}
+	cfg, err := config.LoadPaths(configPaths)
+	if err != nil {
+		return nil, fmt.Errorf("load provider overlay config: %w", err)
+	}
+	if cfg.Providers.UI == nil {
+		return map[string]*config.UIEntry{}, nil
+	}
+	return cfg.Providers.UI, nil
+}
+
 func matchingPluginKeys(plugins map[string]*config.ProviderEntry, targetManifestPath string) ([]string, error) {
 	targetCanonical, err := canonicalPath(targetManifestPath)
 	if err != nil {
@@ -579,7 +786,75 @@ func matchingPluginKeys(plugins map[string]*config.ProviderEntry, targetManifest
 	return matches, nil
 }
 
+func resolveProviderLocalUIKey(configPaths []string, targetManifestPath string, manifest *providermanifestv1.Manifest, explicitName string) (string, error) {
+	uis, err := loadConfiguredUIs(configPaths)
+	if err != nil {
+		return "", err
+	}
+	matchingKeys, err := matchingUIKeys(uis, targetManifestPath)
+	if err != nil {
+		return "", err
+	}
+
+	if explicitName != "" {
+		if !isValidExplicitPluginKey(explicitName) {
+			return "", fmt.Errorf("invalid --name %q: use only letters, numbers, and underscores", explicitName)
+		}
+		if len(matchingKeys) == 1 && matchingKeys[0] != explicitName {
+			return "", fmt.Errorf("target manifest is already configured as providers.ui.%s; pass --name %q or remove the conflicting config entry", matchingKeys[0], matchingKeys[0])
+		}
+		if len(matchingKeys) > 1 && !slices.Contains(matchingKeys, explicitName) {
+			return "", fmt.Errorf("target manifest is configured by multiple ui keys (%s); remove the ambiguity before using --name", strings.Join(matchingKeys, ", "))
+		}
+		return explicitName, nil
+	}
+
+	if len(matchingKeys) == 1 {
+		return matchingKeys[0], nil
+	}
+	if len(matchingKeys) > 1 {
+		return "", fmt.Errorf("target manifest is configured by multiple ui keys (%s); pass --name to choose the target key", strings.Join(matchingKeys, ", "))
+	}
+
+	if name := derivedPluginKey(manifest, targetManifestPath); name != "" {
+		return name, nil
+	}
+	return "", fmt.Errorf("unable to derive a ui key for %s; pass --name", targetManifestPath)
+}
+
+func matchingUIKeys(entries map[string]*config.UIEntry, targetManifestPath string) ([]string, error) {
+	targetCanonical, err := canonicalPath(targetManifestPath)
+	if err != nil {
+		return nil, err
+	}
+
+	var matches []string
+	for name, entry := range entries {
+		if !uiEntryMatchesTarget(entry, targetCanonical) {
+			continue
+		}
+		matches = append(matches, name)
+	}
+	slices.Sort(matches)
+	return matches, nil
+}
+
 func providerEntryMatchesTarget(entry *config.ProviderEntry, targetManifestPath string) bool {
+	if entry == nil || !entry.HasLocalSource() {
+		return false
+	}
+	canonicalSource, err := canonicalPath(entry.SourcePath())
+	if err != nil {
+		return false
+	}
+	targetCanonical, err := canonicalPath(targetManifestPath)
+	if err != nil {
+		return false
+	}
+	return canonicalSource == targetCanonical
+}
+
+func uiEntryMatchesTarget(entry *config.UIEntry, targetManifestPath string) bool {
 	if entry == nil || !entry.HasLocalSource() {
 		return false
 	}
@@ -609,28 +884,28 @@ func printProviderValidateUsage(w io.Writer) {
 	writeUsageLine(w, "Usage:")
 	writeUsageLine(w, "  gestaltd provider validate [--path PATH] [--config PATH]... [--name NAME]")
 	writeUsageLine(w, "")
-	writeUsageLine(w, "Validate a local source plugin inside a synthesized Gestalt config.")
-	writeUsageLine(w, "v1 supports kind: plugin manifests only.")
+	writeUsageLine(w, "Validate a local source plugin or ui inside a synthesized Gestalt config.")
+	writeUsageLine(w, "v1 supports kind: plugin and kind: ui manifests.")
 	writeUsageLine(w, "Repeated --config flags merge left-to-right using the normal Gestalt rules.")
 	writeUsageLine(w, "")
 	writeUsageLine(w, "Flags:")
 	writeUsageLine(w, "  --path     Provider manifest path or directory (default: current working directory)")
 	writeUsageLine(w, "  --config   Additional config file to merge; repeat to add support providers or null deletions")
-	writeUsageLine(w, "  --name     Plugin key override when the target key is ambiguous")
+	writeUsageLine(w, "  --name     Provider key override when the target key is ambiguous")
 }
 
 func printProviderDevUsage(w io.Writer) {
 	writeUsageLine(w, "Usage:")
 	writeUsageLine(w, "  gestaltd provider dev [--path PATH] [--config PATH]... [--name NAME] [--port PORT]")
 	writeUsageLine(w, "")
-	writeUsageLine(w, "Run a local source plugin inside a synthesized Gestalt config.")
-	writeUsageLine(w, "v1 supports kind: plugin manifests only.")
-	writeUsageLine(w, "The built-in admin UI remains available at /admin; configured or owned public UIs")
+	writeUsageLine(w, "Run a local source plugin or ui inside a synthesized Gestalt config.")
+	writeUsageLine(w, "v1 supports kind: plugin and kind: ui manifests.")
+	writeUsageLine(w, "The built-in admin UI remains available at /admin; configured, owned, or sibling public UIs")
 	writeUsageLine(w, "are mounted when present.")
 	writeUsageLine(w, "")
 	writeUsageLine(w, "Flags:")
 	writeUsageLine(w, "  --path     Provider manifest path or directory (default: current working directory)")
 	writeUsageLine(w, "  --config   Additional config file to merge; repeat to add support providers or null deletions")
-	writeUsageLine(w, "  --name     Plugin key override when the target key is ambiguous")
+	writeUsageLine(w, "  --name     Provider key override when the target key is ambiguous")
 	writeUsageLine(w, "  --port     Public port (default: auto-selected free localhost port)")
 }


### PR DESCRIPTION
## Summary

Adds local provider DX support for UI bundles and for plugin repos that keep frontend assets in a sibling `ui/` package.

New interfaces:
- `gestaltd provider validate --path ./ui`
- `gestaltd provider dev --path ./ui`
- `gestaltd provider dev --path ./plugin`
  Detects a sibling `../ui/manifest.yaml` automatically for the common `plugin/` + `ui/` layout.

Examples:
```sh
gestaltd provider validate --path ./ui
gestaltd provider dev --path ./ui
gestaltd provider validate --path ./plugin --config ./dev/support.yaml
gestaltd provider dev --path ./plugin --config ./dev/support.yaml --name workplaceHub
```

## What changed

- `provider dev` / `provider validate` now accept `kind: ui` manifests in addition to `kind: plugin`
- direct local-source overlays now clear remote source fields when replacing a published provider with a local manifest path
- plugin local dev/validate auto-wire a sibling `ui` manifest when the plugin does not already declare `spec.ui.path`
- CLI help and custom-provider docs now describe direct UI usage and sibling UI auto-detection
- integration coverage now exercises:
  - direct UI validation
  - direct UI serving
  - sibling `plugin/` + `ui/` local development

## Verification

```sh
cd gestaltd
go test ./cmd/gestaltd -run 'TestE2ECLIHelp|TestE2ECLIRejectsBadArgs|TestE2EProviderValidateIsolatedSourcePlugin|TestE2EProviderValidateSourceUI|TestE2EProviderValidateReusesConfiguredPluginKey|TestE2EProviderValidateRejectsNonPluginManifest|TestE2EProviderValidateLayeredConfigSupportsNullDeletion|TestE2EProviderDevServesAdminWithoutInjectingRootUI|TestE2EProviderDevAutoMountsOwnedUI|TestE2EProviderDevServesSourceUI|TestE2EProviderDevAutoMountsSiblingUIForPlugin' -count=1

go test ./cmd/gestaltd -run 'TestE2EServePluginOwnedUIWiring|TestE2EServeAndHealthCheck|TestE2EDefaultServeAutoGeneratesLocalConfig' -count=1

golangci-lint run ./cmd/gestaltd
```
