### PR TITLE
gestaltd provider dev: make sibling ui auto-wiring a true fallback

### DIFF
--- a/docs/content/custom-providers/plugins.mdx
+++ b/docs/content/custom-providers/plugins.mdx
@@ -644,8 +644,9 @@ Use the provider-local commands when you are iterating on a source plugin.
 Gestalt config around the target plugin instead of requiring a hand-written
 temp config. If the plugin manifest declares `spec.ui.path`, Gestalt mounts
 that owned UI automatically. For the common `plugin/` + sibling `ui/` layout,
-the local commands also detect `../ui/manifest.yaml` and wire it in
-automatically during local development.
+the local commands detect `../ui/manifest.yaml` and wire it in automatically
+during local development when the plugin is not already bound to an explicit UI
+entry.
 
 Validate the plugin in isolation:
 

--- a/docs/content/custom-providers/ui.mdx
+++ b/docs/content/custom-providers/ui.mdx
@@ -20,7 +20,8 @@ gestaltd provider dev --path ./ui
 
 When the UI is part of a `plugin/` + sibling `ui/` package layout, running
 `gestaltd provider dev` from the plugin side also picks up that sibling UI
-automatically for the local session.
+automatically for the local session when the plugin is not already bound to a
+configured UI.
 
 A UI bundle is not a plugin in the executable sense. It contains no server-side
 code. Gestalt simply serves the static files from the asset root directory. The

--- a/gestaltd/cmd/gestaltd/e2e_test.go
+++ b/gestaltd/cmd/gestaltd/e2e_test.go
@@ -279,6 +279,31 @@ func TestE2EProviderValidateSourceUI(t *testing.T) {
 	}
 }
 
+func TestE2EProviderValidateIgnoresSiblingUIDirWithoutManifest(t *testing.T) {
+	t.Parallel()
+
+	dir := t.TempDir()
+	providersDir := setupDefaultLocalProvidersDir(t, dir)
+	rootDir := filepath.Join(dir, "package")
+	pluginDir := setupPluginDir(t, filepath.Join(rootDir, "plugin"))
+	if err := os.MkdirAll(filepath.Join(rootDir, "ui"), 0o755); err != nil {
+		t.Fatalf("MkdirAll(sibling ui): %v", err)
+	}
+
+	cmd := exec.Command(gestaltdBin, "provider", "validate", "--path", componentProviderManifestPath(t, pluginDir))
+	cmd.Env = append(os.Environ(),
+		"GESTALT_PROVIDERS_DIR="+providersDir,
+		"GOTELEMETRY=off",
+	)
+	out, err := cmd.CombinedOutput()
+	if err != nil {
+		t.Fatalf("gestaltd provider validate failed: %v\noutput: %s", err, out)
+	}
+	if !strings.Contains(string(out), "config ok") {
+		t.Fatalf("expected validate success, got: %s", out)
+	}
+}
+
 func TestE2EProviderValidateReusesConfiguredPluginKey(t *testing.T) {
 	t.Parallel()
 
@@ -1264,10 +1289,16 @@ func attachOwnedUIToPluginSource(t *testing.T, pluginDir, uiManifestPath string)
 func setupMountedUIDirWithRoutes(t *testing.T, baseDir string, routes []providermanifestv1.UIRoute) *mountedUITestConfig {
 	t.Helper()
 
-	return setupMountedUIDirAt(t, filepath.Join(baseDir, "mounted-ui"), routes)
+	return setupMountedUIDirNamedAt(t, filepath.Join(baseDir, "mounted-ui"), "roadmap_review", "/create-customer-roadmap-review", "github.com/test/ui/roadmap-review", "Roadmap Review UI", "Roadmap Review UI", routes)
 }
 
 func setupMountedUIDirAt(t *testing.T, uiDir string, routes []providermanifestv1.UIRoute) *mountedUITestConfig {
+	t.Helper()
+
+	return setupMountedUIDirNamedAt(t, uiDir, "roadmap_review", "/create-customer-roadmap-review", "github.com/test/ui/roadmap-review", "Roadmap Review UI", "Roadmap Review UI", routes)
+}
+
+func setupMountedUIDirNamedAt(t *testing.T, uiDir, name, pathPrefix, source, displayName, bodyMarker string, routes []providermanifestv1.UIRoute) *mountedUITestConfig {
 	t.Helper()
 
 	distDir := filepath.Join(uiDir, "dist")
@@ -1276,25 +1307,25 @@ func setupMountedUIDirAt(t *testing.T, uiDir string, routes []providermanifestv1
 		t.Fatalf("MkdirAll(%s): %v", assetsDir, err)
 	}
 
-	writeTestFile(t, uiDir, filepath.Join("dist", "index.html"), []byte(`<!doctype html>
+	writeTestFile(t, uiDir, filepath.Join("dist", "index.html"), []byte(fmt.Sprintf(`<!doctype html>
 <html>
   <head>
     <meta charset="utf-8" />
-    <title>Roadmap Review UI</title>
+    <title>%s</title>
   </head>
   <body>
-    <div id="app">Roadmap Review UI</div>
+    <div id="app">%s</div>
     <script type="module" src="assets/app.js"></script>
   </body>
 </html>
-`), 0o644)
+`, displayName, bodyMarker)), 0o644)
 	writeTestFile(t, uiDir, filepath.Join("dist", "assets", "app.js"), []byte(`window.__ROADMAP_REVIEW_UI__ = "ready";
 `), 0o644)
 	writeManifestFile(t, uiDir, &providermanifestv1.Manifest{
 		Kind:        providermanifestv1.KindUI,
-		Source:      "github.com/test/ui/roadmap-review",
+		Source:      source,
 		Version:     "0.0.1-alpha.1",
-		DisplayName: "Roadmap Review UI",
+		DisplayName: displayName,
 		Spec: &providermanifestv1.Spec{
 			AssetRoot: "dist",
 			Routes:    routes,
@@ -1302,8 +1333,8 @@ func setupMountedUIDirAt(t *testing.T, uiDir string, routes []providermanifestv1
 	})
 
 	return &mountedUITestConfig{
-		Name:         "roadmap_review",
-		Path:         "/create-customer-roadmap-review",
+		Name:         name,
+		Path:         pathPrefix,
 		ManifestPath: filepath.Join(uiDir, "manifest.yaml"),
 	}
 }
@@ -1812,6 +1843,73 @@ func TestE2EProviderDevAutoMountsSiblingUIForPlugin(t *testing.T) {
 	}
 	if !strings.Contains(string(uiBody), "Roadmap Review UI") {
 		t.Fatalf("expected sibling ui body marker, got: %s", uiBody)
+	}
+}
+
+func TestE2EProviderDevPrefersExplicitUIBindingOverSiblingAutoDetection(t *testing.T) {
+	t.Parallel()
+
+	if testing.Short() {
+		t.Skip("skipping provider dev explicit-ui precedence test in short mode")
+	}
+
+	dir := t.TempDir()
+	providersDir := setupDefaultLocalProvidersDir(t, dir)
+	rootDir := filepath.Join(dir, "package")
+	pluginDir := setupPluginDir(t, filepath.Join(rootDir, "plugin"))
+	_ = setupMountedUIDirAt(t, filepath.Join(rootDir, "ui"), nil)
+	explicitUI := setupMountedUIDirNamedAt(t, filepath.Join(dir, "explicit-ui"), "explicit", "/configured", "github.com/test/ui/explicit", "Explicit Config UI", "Explicit Config UI", nil)
+
+	cfgPath := filepath.Join(dir, "config.yaml")
+	cfg := fmt.Sprintf(`providers:
+  ui:
+    explicit:
+      source:
+        path: %q
+      path: /configured
+plugins:
+  provider:
+    source: https://example.test/provider-release.yaml
+    ui: explicit
+    mountPath: /configured
+`, explicitUI.ManifestPath)
+	if err := os.WriteFile(cfgPath, []byte(cfg), 0o644); err != nil {
+		t.Fatalf("write config: %v", err)
+	}
+
+	port, holder := reservePort(t)
+	baseURL := fmt.Sprintf("http://127.0.0.1:%d", port)
+	_ = holder.Close()
+
+	cmd := exec.Command(gestaltdBin, "provider", "dev", "--path", componentProviderManifestPath(t, pluginDir), "--config", cfgPath, "--port", fmt.Sprintf("%d", port))
+	cmd.Env = append(os.Environ(),
+		"GESTALT_PROVIDERS_DIR="+providersDir,
+		"GOTELEMETRY=off",
+	)
+	startCommandAndWaitReady(t, cmd, baseURL)
+
+	client := &http.Client{Timeout: 2 * time.Second}
+	uiResp, err := client.Get(baseURL + "/configured/sync")
+	if err != nil {
+		t.Fatalf("GET /configured/sync: %v", err)
+	}
+	defer func() { _ = uiResp.Body.Close() }()
+	uiBody, _ := io.ReadAll(uiResp.Body)
+	if uiResp.StatusCode != http.StatusOK {
+		t.Fatalf("expected /configured/sync 200, got %d: %s", uiResp.StatusCode, uiBody)
+	}
+	if !strings.Contains(string(uiBody), "Explicit Config UI") {
+		t.Fatalf("expected explicit ui body marker, got: %s", uiBody)
+	}
+
+	siblingResp, err := client.Get(baseURL + "/provider/sync")
+	if err != nil {
+		t.Fatalf("GET /provider/sync: %v", err)
+	}
+	defer func() { _ = siblingResp.Body.Close() }()
+	if siblingResp.StatusCode == http.StatusOK {
+		body, _ := io.ReadAll(siblingResp.Body)
+		t.Fatalf("expected sibling ui auto-mount to stay disabled, got 200: %s", body)
 	}
 }
 

--- a/gestaltd/cmd/gestaltd/provider_local.go
+++ b/gestaltd/cmd/gestaltd/provider_local.go
@@ -247,7 +247,7 @@ func preparePluginLocalSession(sessionDir, baseConfigPath string, state operator
 		if err := writeProviderLocalPluginOverlayConfig(overlayConfigPath, resolvedKey, targetManifestPath, opts.Port, autoMountPath, "", ""); err != nil {
 			return nil, err
 		}
-	case siblingUIManifestPath != "":
+	case siblingUIManifestPath != "" && shouldAutoWireSiblingUI(loadedCfg, resolvedKey):
 		var uiName string
 		if entry := loadedCfg.Plugins[resolvedKey]; entry != nil {
 			uiName = strings.TrimSpace(entry.UI)
@@ -544,6 +544,26 @@ func ensureNoPublicUIPathCollision(cfg *config.Config, pluginKey, mountPath stri
 	return nil
 }
 
+func shouldAutoWireSiblingUI(cfg *config.Config, pluginKey string) bool {
+	if cfg == nil {
+		return true
+	}
+	if entry := cfg.Plugins[pluginKey]; entry != nil && strings.TrimSpace(entry.UI) != "" {
+		return false
+	}
+	if entry := cfg.Providers.UI[pluginKey]; entry != nil && providerEntryHasConfiguredSource(&entry.ProviderEntry) {
+		return false
+	}
+	return true
+}
+
+func providerEntryHasConfiguredSource(entry *config.ProviderEntry) bool {
+	if entry == nil {
+		return false
+	}
+	return entry.SourcePath() != "" || entry.SourceReleaseLocation() != "" || entry.Source.IsBuiltin()
+}
+
 func findSiblingUIManifestPath(pluginManifestPath string, manifest *providermanifestv1.Manifest) (string, error) {
 	if manifest == nil || manifest.Spec == nil || manifest.Spec.UI != nil {
 		return "", nil
@@ -571,6 +591,9 @@ func findSiblingUIManifestPath(pluginManifestPath string, manifest *providermani
 
 	uiManifestPath, err := providerpkg.FindManifestFile(uiDir)
 	if err != nil {
+		if isNoManifestFileErr(err) {
+			return "", nil
+		}
 		return "", fmt.Errorf("find sibling ui manifest: %w", err)
 	}
 	uiManifestPath, err = canonicalPath(uiManifestPath)
@@ -590,6 +613,10 @@ func findSiblingUIManifestPath(pluginManifestPath string, manifest *providermani
 		return "", fmt.Errorf("sibling ui manifest %q must have kind %q (got %q)", uiManifestPath, providermanifestv1.KindUI, kind)
 	}
 	return uiManifestPath, nil
+}
+
+func isNoManifestFileErr(err error) bool {
+	return err != nil && strings.Contains(err.Error(), "no manifest file found in ")
 }
 
 func providerLocalIndexedDBSourceConfig() any {


### PR DESCRIPTION
## Summary

Makes sibling `ui/` auto-wiring in `gestaltd provider dev` / `gestaltd provider validate` a true fallback instead of an override.

Updated interfaces:
- `gestaltd provider dev --path ./plugin`
- `gestaltd provider validate --path ./plugin`

Behavior examples:
- If `./plugin` has a sibling `../ui/manifest.yaml` and no explicit UI binding, `provider dev` / `provider validate` auto-wire that sibling UI.
- If `plugins.<name>.ui` is explicitly configured, sibling auto-wiring stays disabled and the configured UI source wins.
- If `../ui` exists but has no manifest yet, `provider dev` / `provider validate` ignore it and continue.

Examples:
```sh
gestaltd provider dev --path ./plugin
gestaltd provider validate --path ./plugin
gestaltd provider dev --path ./plugin --config ./dev/support.yaml
```

## What changed

- sibling UI detection no longer overrides explicit `plugins.<name>.ui` bindings
- sibling UI detection ignores unfinished `ui/` directories until a manifest exists
- docs now describe sibling auto-wiring as fallback behavior
- integration coverage now exercises:
  - bare sibling `ui/` directory is ignored
  - explicit UI binding wins over sibling auto-detection

## Verification

```sh
cd gestaltd
go test ./cmd/gestaltd -run 'TestE2EProviderValidate(IgnoresSiblingUIDirWithoutManifest|SourceUI|IsolatedSourcePlugin)|TestE2EProviderDev(ServesSourceUI|AutoMountsSiblingUIForPlugin|PrefersExplicitUIBindingOverSiblingAutoDetection)' -count=1

go test ./cmd/gestaltd -run 'TestE2ECLIHelp|TestE2ECLIRejectsBadArgs|TestE2EProviderValidateIsolatedSourcePlugin|TestE2EProviderValidateSourceUI|TestE2EProviderValidateIgnoresSiblingUIDirWithoutManifest|TestE2EProviderValidateReusesConfiguredPluginKey|TestE2EProviderValidateRejectsNonPluginManifest|TestE2EProviderValidateLayeredConfigSupportsNullDeletion|TestE2EProviderDevServesAdminWithoutInjectingRootUI|TestE2EProviderDevAutoMountsOwnedUI|TestE2EProviderDevServesSourceUI|TestE2EProviderDevAutoMountsSiblingUIForPlugin|TestE2EProviderDevPrefersExplicitUIBindingOverSiblingAutoDetection' -count=1

golangci-lint run ./cmd/gestaltd
```
