### PR TITLE
config: bump generated default ui provider to 0.0.1-alpha.17

### DIFF
--- a/gestaltd/internal/config/config.go
+++ b/gestaltd/internal/config/config.go
@@ -34,7 +34,7 @@ const (
 	DefaultIndexedDBProvider = DefaultProviderRepo + "/indexeddb/relationaldb"
 	DefaultIndexedDBVersion  = "0.0.1-alpha.1"
 	DefaultUIProvider        = DefaultProviderRepo + "/ui/default"
-	DefaultUIVersion         = "0.0.1-alpha.15"
+	DefaultUIVersion         = "0.0.1-alpha.17"
 	DefaultProviderInstance  = "default"
 )
 


### PR DESCRIPTION
## Summary
- bump the generated default UI provider version from `0.0.1-alpha.15` to `0.0.1-alpha.17`
- pick up the released provider-owned `/admin` shell from `github.com/valon-technologies/gestalt-providers/ui/default`
- keep the config surface unchanged: existing explicit pins continue to work as-is

## Scope
- affects newly generated default configs that rely on `DefaultUIVersion`
- existing `providers.ui.default.version` values in already-written configs remain unchanged until they are updated or regenerated

## Interface
- implicit default root UI in generated configs now resolves to `github.com/valon-technologies/gestalt-providers/ui/default@0.0.1-alpha.17`
- explicit pin:
```yaml
providers:
  ui:
    default:
      source: github.com/valon-technologies/gestalt-providers/ui/default
      version: 0.0.1-alpha.17
      path: /
```
- generated default provider set with no override:
```yaml
server:
  listeners:
    public:
      address: :8080
```

## Release
- provider release: https://github.com/valon-technologies/gestalt-providers/releases/tag/ui/default/v0.0.1-alpha.17

## Testing
- `go test ./internal/operator -run 'TestDefaultManagedConfigIncludesRootUI|TestDefaultLocalSourceConfigIncludesRootUI'`
- `go test ./internal/config -run 'Test.*UI'`
