### PR TITLE
Fix isolated provider local defaults for IndexedDB and TypeScript

### DIFF
--- a/docs/dockerhub/gestaltd.md
+++ b/docs/dockerhub/gestaltd.md
@@ -69,7 +69,7 @@ server:
 providers:
   indexeddb:
     main:
-      source: https://github.com/valon-technologies/gestalt-providers/releases/download/indexeddb/relationaldb/v0.0.1-alpha.1/provider-release.yaml
+      source: https://github.com/valon-technologies/gestalt-providers/releases/download/indexeddb/relationaldb/v0.0.1-alpha.4/provider-release.yaml
       config:
         dsn: sqlite:///data/gestalt.db
 

--- a/gestaltd/cmd/gestaltd/provider_test.go
+++ b/gestaltd/cmd/gestaltd/provider_test.go
@@ -394,6 +394,8 @@ func TestRun_ProviderReleaseBuildsTypeScriptSourcePluginForCurrentPlatform(t *te
 	t.Setenv("PATH", pathWithoutGo(t))
 
 	pluginDir := newTypeScriptSourceReleaseFixture(t, t.TempDir())
+	sdkDir := writeFakeTypeScriptReleaseSDKDir(t, t.TempDir())
+	t.Setenv("GESTALT_TYPESCRIPT_SDK_DIR", sdkDir)
 	bunPath := writeFakeTypeScriptProviderReleaseBun(
 		t,
 		filepath.Join(pluginDir, "fake-bun"),
@@ -578,6 +580,8 @@ func TestRun_ProviderReleaseBuildsRequestedPlatformSets(t *testing.T) {
 		t.Setenv("PATH", pathWithoutGo(t))
 
 		pluginDir := newTypeScriptSourceAuthReleaseFixture(t, t.TempDir())
+		sdkDir := writeFakeTypeScriptReleaseSDKDir(t, t.TempDir())
+		t.Setenv("GESTALT_TYPESCRIPT_SDK_DIR", sdkDir)
 		defaultPlatforms := defaultReleasePlatformsForTest(t)
 		bunPath := writeFakeTypeScriptComponentReleaseBunForPlatforms(
 			t,
@@ -1452,6 +1456,8 @@ func TestRun_ProviderReleaseBuildsExecutableAuthProviders(t *testing.T) {
 				builtBinary := buildGoSourceAuthBinary(t)
 				t.Setenv("PATH", pathWithoutGo(t))
 				pluginDir := newTypeScriptSourceAuthReleaseFixture(t, t.TempDir())
+				sdkDir := writeFakeTypeScriptReleaseSDKDir(t, t.TempDir())
+				t.Setenv("GESTALT_TYPESCRIPT_SDK_DIR", sdkDir)
 				bunPath := writeFakeTypeScriptComponentReleaseBun(t, filepath.Join(pluginDir, "fake-bun"), authReleaseTypeScriptTarget, authReleasePluginName, runtime.GOOS, runtime.GOARCH, builtBinary)
 				t.Setenv("GESTALT_BUN", bunPath)
 				return pluginDir
@@ -2593,6 +2599,36 @@ func writeFakeTypeScriptComponentReleaseBunForPlatforms(t *testing.T, path, expe
 	script := `#!/bin/sh
 set -eu
 
+state_file="` + path + `.install-cwd"
+
+if [ "$#" -gt 0 ] && [ "$1" = "install" ]; then
+  shift
+  cwd=""
+  while [ "$#" -gt 0 ]; do
+    case "$1" in
+      --cwd)
+        cwd="$2"
+        shift 2
+        ;;
+      --frozen-lockfile)
+        shift
+        ;;
+      *)
+        echo "unexpected bun install args: $*" >&2
+        exit 1
+        ;;
+    esac
+  done
+  if [ -z "$cwd" ]; then
+    echo "missing bun install --cwd" >&2
+    exit 1
+  fi
+  mkdir -p "$cwd/node_modules"
+  : > "$cwd/node_modules/.installed"
+  printf '%s' "$cwd" > "$state_file"
+  exit 0
+fi
+
 if [ "$#" -lt 4 ] || [ "$1" != "--cwd" ]; then
   echo "unexpected fake bun args: $*" >&2
   exit 1
@@ -2608,9 +2644,12 @@ if [ "$#" -gt 0 ] && [ "$1" = "--" ]; then
   shift
 fi
 
-entry_base="${entry##*/}"
-case "$entry_base" in
-  gestalt-ts-build|build.ts)
+case "$entry" in
+  "$cwd"/src/build.ts)
+    if [ -f "$state_file" ] && [ "$(cat "$state_file")" != "$cwd" ]; then
+      echo "unexpected build cwd after install: $cwd != $(cat "$state_file")" >&2
+      exit 1
+    fi
     if [ "$#" -ne 6 ]; then
       echo "unexpected build args: $*" >&2
       exit 1
@@ -2621,10 +2660,6 @@ case "$entry_base" in
     name="$4"
     goos="$5"
     goarch="$6"
-    if [ "$cwd" != "$source_dir" ]; then
-      echo "unexpected build cwd: $cwd != $source_dir" >&2
-      exit 1
-    fi
     if [ "$target" != "` + authReleaseTypeScriptTarget + `" ]; then
       echo "unexpected build target: $target" >&2
       exit 1
@@ -2663,11 +2698,54 @@ exit 1
 	return path
 }
 
+func writeFakeTypeScriptReleaseSDKDir(t *testing.T, root string) string {
+	t.Helper()
+	writeTestFile(t, root, "package.json", []byte(`{
+  "name": "@valon-technologies/gestalt",
+  "version": "0.0.1-alpha.test"
+}
+`), 0o644)
+	writeTestFile(t, root, "bun.lock", []byte("{}\n"), 0o644)
+	writeTestFile(t, filepath.Join(root, "src"), "runtime.ts", []byte("export {};\n"), 0o644)
+	writeTestFile(t, filepath.Join(root, "src"), "build.ts", []byte("export {};\n"), 0o644)
+	return root
+}
+
 func writeFakeTypeScriptProviderReleaseBun(t *testing.T, path, expectedPluginName, expectedTarget, expectedGOOS, expectedGOARCH string) string {
 	t.Helper()
 
 	script := `#!/bin/sh
 set -eu
+
+state_file="` + path + `.install-cwd"
+
+if [ "$#" -gt 0 ] && [ "$1" = "install" ]; then
+  shift
+  cwd=""
+  while [ "$#" -gt 0 ]; do
+    case "$1" in
+      --cwd)
+        cwd="$2"
+        shift 2
+        ;;
+      --frozen-lockfile)
+        shift
+        ;;
+      *)
+        echo "unexpected bun install args: $*" >&2
+        exit 1
+        ;;
+    esac
+  done
+  if [ -z "$cwd" ]; then
+    echo "missing bun install --cwd" >&2
+    exit 1
+  fi
+  mkdir -p "$cwd/node_modules"
+  : > "$cwd/node_modules/.installed"
+  printf '%s' "$cwd" > "$state_file"
+  exit 0
+fi
 
 if [ "$#" -lt 4 ] || [ "$1" != "--cwd" ]; then
   echo "unexpected fake bun args: $*" >&2
@@ -2684,19 +2762,18 @@ if [ "$#" -gt 0 ] && [ "$1" = "--" ]; then
   shift
 fi
 
-entry_base="${entry##*/}"
-case "$entry_base" in
-  gestalt-ts-runtime|runtime.ts)
+case "$entry" in
+  "$cwd"/src/runtime.ts)
+    if [ -f "$state_file" ] && [ "$(cat "$state_file")" != "$cwd" ]; then
+      echo "unexpected runtime cwd after install: $cwd != $(cat "$state_file")" >&2
+      exit 1
+    fi
     if [ "$#" -ne 2 ]; then
       echo "unexpected runtime args: $*" >&2
       exit 1
     fi
     root="$1"
     target="$2"
-    if [ "$cwd" != "$root" ]; then
-      echo "unexpected runtime cwd: $cwd != $root" >&2
-      exit 1
-    fi
     if [ "$target" != "` + typeScriptReleaseTarget + `" ]; then
       echo "unexpected runtime target: $target" >&2
       exit 1
@@ -2747,7 +2824,11 @@ EOF
     fi
     exit 0
     ;;
-  gestalt-ts-build|build.ts)
+  "$cwd"/src/build.ts)
+    if [ -f "$state_file" ] && [ "$(cat "$state_file")" != "$cwd" ]; then
+      echo "unexpected build cwd after install: $cwd != $(cat "$state_file")" >&2
+      exit 1
+    fi
     if [ "$#" -ne 6 ]; then
       echo "unexpected build args: $*" >&2
       exit 1
@@ -2758,10 +2839,6 @@ EOF
     name="$4"
     goos="$5"
     goarch="$6"
-    if [ "$cwd" != "$source_dir" ]; then
-      echo "unexpected build cwd: $cwd != $source_dir" >&2
-      exit 1
-    fi
     if [ "$target" != "` + typeScriptReleaseTarget + `" ]; then
       echo "unexpected build target: $target" >&2
       exit 1

--- a/gestaltd/deploy/helm/gestalt/values.yaml
+++ b/gestaltd/deploy/helm/gestalt/values.yaml
@@ -97,7 +97,7 @@ config:
       main:
         # SQLite is appropriate for local development or single-instance
         # deployments with mounted persistent storage at /data.
-        source: https://github.com/valon-technologies/gestalt-providers/releases/download/indexeddb/relationaldb/v0.0.1-alpha.1/provider-release.yaml
+        source: https://github.com/valon-technologies/gestalt-providers/releases/download/indexeddb/relationaldb/v0.0.1-alpha.4/provider-release.yaml
         config:
           dsn: "sqlite:///data/gestalt.db"
     # Add providers.ui.<name> entries when you want to mount public static UI bundles.

--- a/gestaltd/internal/config/config.go
+++ b/gestaltd/internal/config/config.go
@@ -32,7 +32,7 @@ const (
 	DefaultProviderRepo = "github.com/valon-technologies/gestalt-providers"
 
 	DefaultIndexedDBProvider = DefaultProviderRepo + "/indexeddb/relationaldb"
-	DefaultIndexedDBVersion  = "0.0.1-alpha.1"
+	DefaultIndexedDBVersion  = "0.0.1-alpha.4"
 	DefaultUIProvider        = DefaultProviderRepo + "/ui/default"
 	DefaultUIVersion         = "0.0.1-alpha.15"
 	DefaultProviderInstance  = "default"

--- a/gestaltd/internal/operator/localconfig_test.go
+++ b/gestaltd/internal/operator/localconfig_test.go
@@ -35,6 +35,15 @@ func TestDefaultManagedConfigIncludesRootUI(t *testing.T) {
 	if got := rootUI.Path; got != "/" {
 		t.Fatalf(`Providers.UI["root"].Path = %q, want %q`, got, "/")
 	}
+
+	indexedDB := cfg.Providers.IndexedDB["main"]
+	if indexedDB == nil {
+		t.Fatal(`Providers.IndexedDB["main"] = nil`)
+	}
+	wantIndexedDBURL := defaultProviderMetadataURL(config.DefaultIndexedDBProvider, config.DefaultIndexedDBVersion)
+	if got := indexedDB.SourceMetadataURL(); got != wantIndexedDBURL {
+		t.Fatalf(`Providers.IndexedDB["main"].SourceMetadataURL() = %q, want %q`, got, wantIndexedDBURL)
+	}
 }
 
 func TestDefaultLocalSourceConfigIncludesRootUI(t *testing.T) {

--- a/gestaltd/internal/providerpkg/typescript_provider.go
+++ b/gestaltd/internal/providerpkg/typescript_provider.go
@@ -20,6 +20,7 @@ const (
 	typeScriptRuntimeBin   = "gestalt-ts-runtime"
 	typeScriptBuildBin     = "gestalt-ts-build"
 	typeScriptBunEnvVar    = "GESTALT_BUN"
+	typeScriptSDKDirEnvVar = "GESTALT_TYPESCRIPT_SDK_DIR"
 	typeScriptProviderKey  = "provider"
 	typeScriptPluginKey    = "plugin"
 	typeScriptAuthKey      = "auth"
@@ -82,9 +83,13 @@ func typeScriptExecutionCommand(root, target string) (string, []string, func(), 
 	if err != nil {
 		return "", nil, nil, err
 	}
-	if sdkPath := localTypeScriptSDKPath(); sdkPath != "" {
+	sdkPath, err := prepareLocalTypeScriptSDK(bunPath)
+	if err != nil {
+		return "", nil, nil, err
+	}
+	if sdkPath != "" {
 		return bunPath, []string{
-			"--cwd", root,
+			"--cwd", sdkPath,
 			filepath.Join(sdkPath, "src", "runtime.ts"),
 			"--",
 			root,
@@ -119,9 +124,13 @@ func buildTypeScriptBinary(sourceDir, binaryPath, pluginName, target, goos, goar
 	}
 
 	var args []string
-	if sdkPath := localTypeScriptSDKPath(); sdkPath != "" {
+	sdkPath, err := prepareLocalTypeScriptSDK(bunPath)
+	if err != nil {
+		return "", fmt.Errorf("prepare local TypeScript SDK: %w", err)
+	}
+	if sdkPath != "" {
 		args = []string{
-			"--cwd", sourceDir,
+			"--cwd", sdkPath,
 			filepath.Join(sdkPath, "src", "build.ts"),
 			"--",
 			sourceDir,
@@ -207,7 +216,54 @@ func bunExecutableCandidates() []string {
 	return candidates
 }
 
+func prepareLocalTypeScriptSDK(bunPath string) (string, error) {
+	sdkPath := localTypeScriptSDKPath()
+	if sdkPath == "" {
+		return "", nil
+	}
+	if err := ensureLocalTypeScriptSDKDependencies(bunPath, sdkPath); err != nil {
+		return "", err
+	}
+	return sdkPath, nil
+}
+
+func ensureLocalTypeScriptSDKDependencies(bunPath, sdkPath string) error {
+	nodeModulesPath := filepath.Join(sdkPath, "node_modules")
+	if info, err := os.Stat(nodeModulesPath); err == nil {
+		if info.IsDir() {
+			return nil
+		}
+		return fmt.Errorf("local TypeScript SDK node_modules path %q is not a directory", nodeModulesPath)
+	} else if !os.IsNotExist(err) {
+		return fmt.Errorf("stat local TypeScript SDK node_modules: %w", err)
+	}
+
+	args := []string{"install", "--cwd", sdkPath}
+	lockfilePath := filepath.Join(sdkPath, "bun.lock")
+	if _, err := os.Stat(lockfilePath); err == nil {
+		args = append(args, "--frozen-lockfile")
+	} else if !os.IsNotExist(err) {
+		return fmt.Errorf("stat local TypeScript SDK bun.lock: %w", err)
+	}
+
+	cmd := exec.Command(bunPath, args...)
+	cmd.Dir = sdkPath
+	cmd.Stdout = os.Stdout
+	cmd.Stderr = os.Stderr
+	if err := cmd.Run(); err != nil {
+		return fmt.Errorf("bun install for local TypeScript SDK: %w", err)
+	}
+	return nil
+}
+
 func localTypeScriptSDKPath() string {
+	if override := strings.TrimSpace(os.Getenv(typeScriptSDKDirEnvVar)); override != "" {
+		path := filepath.Clean(override)
+		if _, err := os.Stat(filepath.Join(path, "package.json")); err == nil {
+			return path
+		}
+		return ""
+	}
 	_, file, _, ok := runtime.Caller(0)
 	if !ok {
 		return ""

--- a/gestaltd/internal/providerpkg/typescript_provider_test.go
+++ b/gestaltd/internal/providerpkg/typescript_provider_test.go
@@ -309,7 +309,7 @@ func TestHasSourceComponentPackage_TypeScript(t *testing.T) {
 
 func TestDetectBunExecutable_UsesEnvironmentOverride(t *testing.T) {
 	root := t.TempDir()
-	bunPath := writeFakeTypeScriptBun(t, root, "ts-release", typeScriptTestPluginTarget, runtime.GOOS, runtime.GOARCH)
+	bunPath := writeFakeTypeScriptBun(t, root, "ts-release", typeScriptTestPluginTarget, runtime.GOOS, runtime.GOARCH, root)
 	t.Setenv(typeScriptBunEnvVar, bunPath)
 	t.Setenv("PATH", "")
 	t.Setenv("HOME", filepath.Join(root, "home"))
@@ -326,8 +326,10 @@ func TestDetectBunExecutable_UsesEnvironmentOverride(t *testing.T) {
 func TestSourceProviderExecutionCommand_TypeScript(t *testing.T) {
 	root := t.TempDir()
 	mustWriteTypeScriptProviderPackage(t, root, typeScriptTestPluginTarget)
-	bunPath := writeFakeTypeScriptBun(t, root, "ts-release", typeScriptTestPluginTarget, runtime.GOOS, runtime.GOARCH)
+	sdkDir := writeFakeTypeScriptSDKDir(t, t.TempDir())
+	bunPath := writeFakeTypeScriptBun(t, root, "ts-release", typeScriptTestPluginTarget, runtime.GOOS, runtime.GOARCH, sdkDir)
 	t.Setenv(typeScriptBunEnvVar, bunPath)
+	t.Setenv(typeScriptSDKDirEnvVar, sdkDir)
 
 	command, args, cleanup, err := SourceProviderExecutionCommand(root, runtime.GOOS, runtime.GOARCH)
 	if err != nil {
@@ -342,8 +344,8 @@ func TestSourceProviderExecutionCommand_TypeScript(t *testing.T) {
 	if len(args) != 6 {
 		t.Fatalf("args len = %d, want 6 (%v)", len(args), args)
 	}
-	if args[0] != "--cwd" || args[1] != root {
-		t.Fatalf("args prefix = %v, want [--cwd %s ...]", args[:2], root)
+	if args[0] != "--cwd" || args[1] != sdkDir {
+		t.Fatalf("args prefix = %v, want [--cwd %s ...]", args[:2], sdkDir)
 	}
 	if args[3] != "--" {
 		t.Fatalf("args[3] = %q, want --", args[3])
@@ -354,6 +356,32 @@ func TestSourceProviderExecutionCommand_TypeScript(t *testing.T) {
 
 	if got := filepath.Base(args[2]); got != "runtime.ts" {
 		t.Fatalf("runtime entry = %q, want local runtime.ts path", args[2])
+	}
+}
+
+func TestSourceProviderExecutionCommand_TypeScriptInstallsLocalSDKDeps(t *testing.T) {
+	root := t.TempDir()
+	mustWriteTypeScriptProviderPackage(t, root, typeScriptTestPluginTarget)
+	sdkDir := writeFakeTypeScriptSDKDir(t, t.TempDir())
+	bunPath := writeFakeTypeScriptBun(t, root, "ts-release", typeScriptTestPluginTarget, runtime.GOOS, runtime.GOARCH, sdkDir)
+	t.Setenv(typeScriptBunEnvVar, bunPath)
+	t.Setenv(typeScriptSDKDirEnvVar, sdkDir)
+
+	command, args, cleanup, err := SourceProviderExecutionCommand(root, runtime.GOOS, runtime.GOARCH)
+	if err != nil {
+		t.Fatalf("SourceProviderExecutionCommand: %v", err)
+	}
+	if cleanup != nil {
+		t.Fatal("cleanup should be nil for TypeScript source providers")
+	}
+	if command != bunPath {
+		t.Fatalf("command = %q, want %q", command, bunPath)
+	}
+	if _, err := os.Stat(filepath.Join(sdkDir, "node_modules", ".installed")); err != nil {
+		t.Fatalf("expected bun install marker in fake SDK node_modules: %v", err)
+	}
+	if got := filepath.Dir(args[2]); got != filepath.Join(sdkDir, "src") {
+		t.Fatalf("runtime entry dir = %q, want %q", got, filepath.Join(sdkDir, "src"))
 	}
 }
 
@@ -384,8 +412,10 @@ func TestSourceComponentExecutionCommand_TypeScript(t *testing.T) {
 		t.Run(tt.name, func(t *testing.T) {
 			root := t.TempDir()
 			mustWriteTypeScriptComponentPackage(t, root, tt.kind, tt.target)
-			bunPath := writeFakeTypeScriptBun(t, root, "ts-release", tt.target, runtime.GOOS, runtime.GOARCH)
+			sdkDir := writeFakeTypeScriptSDKDir(t, t.TempDir())
+			bunPath := writeFakeTypeScriptBun(t, root, "ts-release", tt.target, runtime.GOOS, runtime.GOARCH, sdkDir)
 			t.Setenv(typeScriptBunEnvVar, bunPath)
+			t.Setenv(typeScriptSDKDirEnvVar, sdkDir)
 
 			command, args, cleanup, err := SourceComponentExecutionCommand(root, tt.kind, runtime.GOOS, runtime.GOARCH)
 			if err != nil {
@@ -414,8 +444,10 @@ func TestPrepareSourceManifest_GeneratesTypeScriptStaticCatalog(t *testing.T) {
 	root := t.TempDir()
 	manifestPath := mustWriteTypeScriptSourceManifest(t, root, "ts-release")
 	mustWriteTypeScriptProviderPackage(t, root, typeScriptTestPluginTarget)
-	bunPath := writeFakeTypeScriptBun(t, root, "ts-release", typeScriptTestPluginTarget, runtime.GOOS, runtime.GOARCH)
+	sdkDir := writeFakeTypeScriptSDKDir(t, t.TempDir())
+	bunPath := writeFakeTypeScriptBun(t, root, "ts-release", typeScriptTestPluginTarget, runtime.GOOS, runtime.GOARCH, sdkDir)
 	t.Setenv(typeScriptBunEnvVar, bunPath)
+	t.Setenv(typeScriptSDKDirEnvVar, sdkDir)
 
 	_, manifest, err := PrepareSourceManifest(manifestPath)
 	if err != nil {
@@ -469,8 +501,10 @@ func TestPrepareSourceManifest_MergesGeneratedTypeScriptManifestMetadata(t *test
 	manifestPath := filepath.Join(root, "manifest.yaml")
 	mustWriteFile(t, manifestPath, data, 0o644)
 	mustWriteTypeScriptProviderPackage(t, root, typeScriptTestPluginTarget)
-	bunPath := writeFakeTypeScriptBun(t, root, "ts-release", typeScriptTestPluginTarget, runtime.GOOS, runtime.GOARCH)
+	sdkDir := writeFakeTypeScriptSDKDir(t, t.TempDir())
+	bunPath := writeFakeTypeScriptBun(t, root, "ts-release", typeScriptTestPluginTarget, runtime.GOOS, runtime.GOARCH, sdkDir)
 	t.Setenv(typeScriptBunEnvVar, bunPath)
+	t.Setenv(typeScriptSDKDirEnvVar, sdkDir)
 
 	preparedData, preparedManifest, err := PrepareSourceManifest(manifestPath)
 	if err != nil {
@@ -539,7 +573,11 @@ func TestPrepareSourceManifest_MergesGeneratedTypeScriptManifestMetadata(t *test
 func TestValidateSourceProviderRelease_TypeScript(t *testing.T) {
 	root := t.TempDir()
 	mustWriteTypeScriptProviderPackage(t, root, typeScriptTestPluginTarget)
-	bunPath := writeFakeTypeScriptBun(t, root, "ts-release", typeScriptTestPluginTarget, runtime.GOOS, runtime.GOARCH)
+	expectedCWD := localTypeScriptSDKPath()
+	if expectedCWD == "" {
+		expectedCWD = root
+	}
+	bunPath := writeFakeTypeScriptBun(t, root, "ts-release", typeScriptTestPluginTarget, runtime.GOOS, runtime.GOARCH, expectedCWD)
 	t.Setenv(typeScriptBunEnvVar, bunPath)
 
 	if err := ValidateSourceProviderRelease(root, runtime.GOOS, runtime.GOARCH); err != nil {
@@ -574,7 +612,11 @@ func TestValidateSourceComponentRelease_TypeScript(t *testing.T) {
 		t.Run(tt.name, func(t *testing.T) {
 			root := t.TempDir()
 			mustWriteTypeScriptComponentPackage(t, root, tt.kind, tt.target)
-			bunPath := writeFakeTypeScriptBun(t, root, "ts-release", tt.target, runtime.GOOS, runtime.GOARCH)
+			expectedCWD := localTypeScriptSDKPath()
+			if expectedCWD == "" {
+				expectedCWD = root
+			}
+			bunPath := writeFakeTypeScriptBun(t, root, "ts-release", tt.target, runtime.GOOS, runtime.GOARCH, expectedCWD)
 			t.Setenv(typeScriptBunEnvVar, bunPath)
 
 			if err := ValidateSourceComponentRelease(root, tt.kind, runtime.GOOS, runtime.GOARCH); err != nil {
@@ -587,8 +629,10 @@ func TestValidateSourceComponentRelease_TypeScript(t *testing.T) {
 func TestBuildSourceProviderReleaseBinary_TypeScript(t *testing.T) {
 	root := t.TempDir()
 	mustWriteTypeScriptProviderPackage(t, root, typeScriptTestPluginTarget)
-	bunPath := writeFakeTypeScriptBun(t, root, "ts-release", typeScriptTestPluginTarget, runtime.GOOS, runtime.GOARCH)
+	sdkDir := writeFakeTypeScriptSDKDir(t, t.TempDir())
+	bunPath := writeFakeTypeScriptBun(t, root, "ts-release", typeScriptTestPluginTarget, runtime.GOOS, runtime.GOARCH, sdkDir)
 	t.Setenv(typeScriptBunEnvVar, bunPath)
+	t.Setenv(typeScriptSDKDirEnvVar, sdkDir)
 
 	outputPath := filepath.Join(t.TempDir(), "gestalt-plugin-ts-release")
 	libc, err := BuildSourceProviderReleaseBinary(root, outputPath, "ts-release", runtime.GOOS, runtime.GOARCH)
@@ -610,6 +654,23 @@ func TestBuildSourceProviderReleaseBinary_TypeScript(t *testing.T) {
 	}
 	if libc != wantLibC {
 		t.Fatalf("libc = %q, want %q", libc, wantLibC)
+	}
+}
+
+func TestBuildSourceProviderReleaseBinary_TypeScriptInstallsLocalSDKDeps(t *testing.T) {
+	root := t.TempDir()
+	mustWriteTypeScriptProviderPackage(t, root, typeScriptTestPluginTarget)
+	sdkDir := writeFakeTypeScriptSDKDir(t, t.TempDir())
+	bunPath := writeFakeTypeScriptBun(t, root, "ts-release", typeScriptTestPluginTarget, runtime.GOOS, runtime.GOARCH, sdkDir)
+	t.Setenv(typeScriptBunEnvVar, bunPath)
+	t.Setenv(typeScriptSDKDirEnvVar, sdkDir)
+
+	outputPath := filepath.Join(t.TempDir(), "gestalt-plugin-ts-release")
+	if _, err := BuildSourceProviderReleaseBinary(root, outputPath, "ts-release", runtime.GOOS, runtime.GOARCH); err != nil {
+		t.Fatalf("BuildSourceProviderReleaseBinary: %v", err)
+	}
+	if _, err := os.Stat(filepath.Join(sdkDir, "node_modules", ".installed")); err != nil {
+		t.Fatalf("expected bun install marker in fake SDK node_modules: %v", err)
 	}
 }
 
@@ -645,8 +706,10 @@ func TestBuildSourceComponentReleaseBinary_TypeScript(t *testing.T) {
 			root := t.TempDir()
 			mustWriteTypeScriptComponentPackage(t, root, tt.kind, tt.target)
 			mustWriteTypeScriptSourceComponentManifest(t, root, tt.pluginName, tt.kind)
-			bunPath := writeFakeTypeScriptBun(t, root, tt.pluginName, tt.target, runtime.GOOS, runtime.GOARCH)
+			sdkDir := writeFakeTypeScriptSDKDir(t, t.TempDir())
+			bunPath := writeFakeTypeScriptBun(t, root, tt.pluginName, tt.target, runtime.GOOS, runtime.GOARCH, sdkDir)
 			t.Setenv(typeScriptBunEnvVar, bunPath)
+			t.Setenv(typeScriptSDKDirEnvVar, sdkDir)
 
 			outputPath := filepath.Join(t.TempDir(), "gestalt-plugin-"+tt.pluginName)
 			libc, err := BuildSourceComponentReleaseBinary(root, outputPath, tt.kind, runtime.GOOS, runtime.GOARCH)
@@ -784,12 +847,39 @@ func mustWriteTypeScriptSourceComponentManifest(t *testing.T, root, pluginName, 
 	return path
 }
 
-func writeFakeTypeScriptBun(t *testing.T, root, pluginName, expectedTarget, expectedGOOS, expectedGOARCH string) string {
+func writeFakeTypeScriptBun(t *testing.T, root, pluginName, expectedTarget, expectedGOOS, expectedGOARCH, expectedCWD string) string {
 	t.Helper()
 
 	path := filepath.Join(root, "bin", "bun")
 	script := `#!/bin/sh
 set -eu
+
+if [ "$#" -gt 0 ] && [ "$1" = "install" ]; then
+  shift
+  cwd=""
+  while [ "$#" -gt 0 ]; do
+    case "$1" in
+      --cwd)
+        cwd="$2"
+        shift 2
+        ;;
+      --frozen-lockfile)
+        shift
+        ;;
+      *)
+        echo "unexpected bun install args: $*" >&2
+        exit 1
+        ;;
+    esac
+  done
+  if [ -z "$cwd" ]; then
+    echo "missing bun install --cwd" >&2
+    exit 1
+  fi
+  mkdir -p "$cwd/node_modules"
+  : > "$cwd/node_modules/.installed"
+  exit 0
+fi
 
 if [ "$#" -lt 4 ] || [ "$1" != "--cwd" ]; then
   echo "unexpected fake bun args: $*" >&2
@@ -816,8 +906,8 @@ case "$entry_base" in
     fi
     root="$1"
     target="$2"
-    if [ "$cwd" != "$root" ]; then
-      echo "unexpected runtime cwd: $cwd != $root" >&2
+    if [ "$cwd" != "` + expectedCWD + `" ]; then
+      echo "unexpected runtime cwd: $cwd != ` + expectedCWD + `" >&2
       exit 1
     fi
     if [ "$target" != "` + expectedTarget + `" ]; then
@@ -871,8 +961,8 @@ EOF
     name="$4"
     goos="$5"
     goarch="$6"
-    if [ "$cwd" != "$source_dir" ]; then
-      echo "unexpected build cwd: $cwd != $source_dir" >&2
+    if [ "$cwd" != "` + expectedCWD + `" ]; then
+      echo "unexpected build cwd: $cwd != ` + expectedCWD + `" >&2
       exit 1
     fi
     if [ "$target" != "` + expectedTarget + `" ]; then
@@ -903,4 +993,18 @@ exit 1
 `
 	mustWriteFile(t, path, []byte(script), 0o755)
 	return path
+}
+
+func writeFakeTypeScriptSDKDir(t *testing.T, root string) string {
+	t.Helper()
+
+	mustWriteFile(t, filepath.Join(root, "package.json"), []byte(`{
+  "name": "@valon-technologies/gestalt",
+  "version": "0.0.1-alpha.test"
+}
+`), 0o644)
+	mustWriteFile(t, filepath.Join(root, "bun.lock"), []byte("{}\n"), 0o644)
+	mustWriteFile(t, filepath.Join(root, "src", "runtime.ts"), []byte("export {};\n"), 0o644)
+	mustWriteFile(t, filepath.Join(root, "src", "build.ts"), []byte("export {};\n"), 0o644)
+	return root
 }


### PR DESCRIPTION
## Summary
This fixes the two Gestalt-side DX failures that showed up while dogfooding `gestaltd provider validate` against `~/src/toolshed/valon-tools/deploy`.

## Interface
- Isolated `gestaltd provider validate` and `gestaltd provider dev` now synthesize a compatible default IndexedDB release instead of the stale `indexeddb/relationaldb v0.0.1-alpha.1` pin.
- When local TypeScript providers use the repo checkout SDK, Gestalt now bootstraps `sdk/typescript` dependencies automatically on first use.
- Helm/default Docker config examples now point at the same compatible IndexedDB release.

## Examples
```sh
# Isolated UI validation now works with the synthesized local baseline.
gestaltd provider validate --path ~/src/toolshed/valon-tools/deploy/brain/ui

# Clean-checkout TypeScript validation now auto-installs sdk/typescript deps once,
# then continues with normal provider validation.
gestaltd provider validate --path ~/src/toolshed/valon-tools/deploy/create-customer-roadmap-review/plugin
```

## Dogfood Result
Post-fix isolated validation over `valon-tools/deploy` is:
- PASS: `ci-workqueue`, `create-customer-roadmap-review`, `data-schema-explorer`, `deployment-viewer`, `vm-style-guide`, `workplace-hub` plugins
- PASS: all `ui/` packages
- Remaining FAIL: `brain/plugin` with a provider-specific internal runtime error, after Gestalt-side setup succeeds

## Tests
```sh
go test ./cmd/gestaltd -run 'TestE2EDefaultServeAutoGeneratesLocalConfig|TestE2EProviderValidateIsolatedSourcePlugin|TestE2EProviderValidateSourceUI|TestE2EProviderDevServesAdminWithoutInjectingRootUI|TestE2EProviderDevAutoMountsOwnedUI|TestE2EProviderDevServesSourceUI|TestE2EProviderDevAutoMountsSiblingUIForPlugin' -count=1
go test ./internal/operator -run 'TestDefaultManagedConfigIncludesRootUI|TestDefaultLocalSourceConfigIncludesRootUI' -count=1
go test ./internal/providerpkg -run 'Test(SourceProviderExecutionCommand_TypeScript|SourceProviderExecutionCommand_TypeScriptInstallsLocalSDKDeps|SourceComponentExecutionCommand_TypeScript|PrepareSourceManifest_GeneratesTypeScriptStaticCatalog|PrepareSourceManifest_MergesGeneratedTypeScriptManifestMetadata|ValidateSourceProviderRelease_TypeScript|ValidateSourceComponentRelease_TypeScript|BuildSourceProviderReleaseBinary_TypeScript|BuildSourceProviderReleaseBinary_TypeScriptInstallsLocalSDKDeps|BuildSourceComponentReleaseBinary_TypeScript)' -count=1
golangci-lint run ./cmd/gestaltd ./internal/providerpkg ./internal/operator ./internal/config

# Real dogfood spot-checks
gestaltd provider validate --path ~/src/toolshed/valon-tools/deploy/brain/ui
gestaltd provider validate --path ~/src/toolshed/valon-tools/deploy/ci-workqueue/plugin
gestaltd provider validate --path ~/src/toolshed/valon-tools/deploy/create-customer-roadmap-review/plugin
```