### PR TITLE
Python SDK: support tcp plugin sockets for hosted runtimes

### DIFF
--- a/sdk/python/gestalt/_runtime.py
+++ b/sdk/python/gestalt/_runtime.py
@@ -9,6 +9,7 @@ import pathlib
 import signal
 import sys
 import traceback
+import urllib.parse as _urlparse
 from concurrent import futures
 from dataclasses import dataclass
 from http import HTTPStatus
@@ -180,15 +181,18 @@ def serve(
     runtime_kind: ProviderKind | str | None = None,
 ) -> None:
     _ensure_grpc_runtime()
-    socket_path = _socket_path_from_env()
-    _remove_stale_socket(socket_path)
+    scheme, address = _provider_socket_target_from_env()
+    bind_target = address
+    if scheme == "unix":
+        _remove_stale_socket(pathlib.Path(address))
+        bind_target = f"unix:{address}"
 
     server = grpc.server(
         futures.ThreadPoolExecutor(max_workers=GRPC_SERVER_MAX_WORKERS)
     )
     servable = _servable_target(target, runtime_kind=runtime_kind)
     _register_services(server=server, servable=servable)
-    server.add_insecure_port(f"unix:{socket_path}")
+    server.add_insecure_port(bind_target)
     close_provider = _close_once_callable(servable)
     server.start()
     _register_shutdown_handlers(server, close_provider)
@@ -309,11 +313,37 @@ def _module_target(
     return None
 
 
-def _socket_path_from_env() -> pathlib.Path:
-    socket_path = os.environ.get(ENV_PROVIDER_SOCKET)
-    if not socket_path:
+def _provider_socket_target_from_env() -> tuple[str, str]:
+    raw_target = os.environ.get(ENV_PROVIDER_SOCKET)
+    if not raw_target:
         raise RuntimeError(f"{ENV_PROVIDER_SOCKET} is required")
-    return pathlib.Path(socket_path)
+    return _parse_provider_socket_target(raw_target)
+
+
+def _parse_provider_socket_target(raw: str) -> tuple[str, str]:
+    target = raw.strip()
+    if not target:
+        raise RuntimeError("provider socket target is required")
+    if target.startswith("tcp://"):
+        address = target.removeprefix("tcp://").strip()
+        if not address:
+            raise RuntimeError(
+                f"provider tcp target {raw!r} is missing host:port"
+            )
+        return "tcp", address
+    if target.startswith("unix://"):
+        address = target.removeprefix("unix://").strip()
+        if not address:
+            raise RuntimeError(
+                f"provider unix target {raw!r} is missing a socket path"
+            )
+        return "unix", address
+    if "://" in target:
+        parsed = _urlparse.urlparse(target)
+        raise RuntimeError(
+            f"unsupported provider socket target scheme {parsed.scheme!r}"
+        )
+    return "unix", target
 
 
 def _remove_stale_socket(socket_path: pathlib.Path) -> None:

--- a/sdk/python/tests/test_runtime.py
+++ b/sdk/python/tests/test_runtime.py
@@ -2,14 +2,17 @@ import datetime as dt
 import importlib
 import json
 import pathlib
+import socket
 import sys
 import tempfile
+import threading
 import unittest
 from typing import Any, cast
 from unittest import mock
 
 import grpc
 from google.protobuf import duration_pb2 as _duration_pb2
+from google.protobuf import empty_pb2 as _empty_pb2
 from google.protobuf import json_format
 from google.protobuf import struct_pb2 as _struct_pb2
 from google.protobuf import timestamp_pb2 as _timestamp_pb2
@@ -39,6 +42,7 @@ from gestalt import (
 from gestalt.gen.v1 import authentication_pb2 as _authentication_pb2
 from gestalt.gen.v1 import cache_pb2 as _cache_pb2
 from gestalt.gen.v1 import plugin_pb2 as _plugin_pb2
+from gestalt.gen.v1 import plugin_pb2_grpc as _plugin_pb2_grpc
 from gestalt.gen.v1 import runtime_pb2 as _runtime_pb2
 from gestalt.gen.v1 import s3_pb2_grpc as _s3_pb2_grpc
 from gestalt.gen.v1 import workflow_pb2_grpc as _workflow_pb2_grpc
@@ -46,7 +50,9 @@ from gestalt.gen.v1 import workflow_pb2_grpc as _workflow_pb2_grpc
 authentication_pb2: Any = _authentication_pb2
 cache_pb2: Any = _cache_pb2
 duration_pb2: Any = _duration_pb2
+empty_pb2: Any = _empty_pb2
 plugin_pb2: Any = _plugin_pb2
+plugin_pb2_grpc: Any = _plugin_pb2_grpc
 runtime_pb2: Any = _runtime_pb2
 s3_pb2_grpc: Any = _s3_pb2_grpc
 struct_pb2: Any = _struct_pb2
@@ -168,6 +174,112 @@ class DurationConversionTests(unittest.TestCase):
             _runtime._duration_to_timedelta(duration_pb2.Duration(nanos=5_999)),
             dt.timedelta(microseconds=5),
         )
+
+
+class ProviderSocketTargetTests(unittest.TestCase):
+    def test_parse_provider_socket_target_defaults_plain_paths_to_unix(self) -> None:
+        self.assertEqual(
+            _runtime._parse_provider_socket_target("/tmp/provider.sock"),
+            ("unix", "/tmp/provider.sock"),
+        )
+
+    def test_parse_provider_socket_target_accepts_unix_and_tcp_targets(self) -> None:
+        self.assertEqual(
+            _runtime._parse_provider_socket_target("unix:///tmp/provider.sock"),
+            ("unix", "/tmp/provider.sock"),
+        )
+        self.assertEqual(
+            _runtime._parse_provider_socket_target("tcp://127.0.0.1:50051"),
+            ("tcp", "127.0.0.1:50051"),
+        )
+
+    def test_parse_provider_socket_target_rejects_unsupported_schemes(self) -> None:
+        with self.assertRaisesRegex(
+            RuntimeError,
+            "unsupported provider socket target scheme 'tls'",
+        ):
+            _runtime._parse_provider_socket_target("tls://127.0.0.1:50051")
+
+
+class RuntimeServeTransportTests(unittest.TestCase):
+    def test_runtime_serve_supports_tcp_provider_sockets(self) -> None:
+        plugin = Plugin("tcp-runtime")
+
+        @plugin.operation
+        def ping() -> str:
+            return "pong"
+
+        with socket.socket(socket.AF_INET, socket.SOCK_STREAM) as sock:
+            sock.bind(("127.0.0.1", 0))
+            host, port = sock.getsockname()
+        address = f"{host}:{port}"
+        server_holder: dict[str, grpc.Server] = {}
+        ready = threading.Event()
+        failures: list[BaseException] = []
+
+        def capture_shutdown(server: grpc.Server, _close_provider: Any) -> None:
+            server_holder["server"] = server
+            ready.set()
+
+        def run_server() -> None:
+            try:
+                with mock.patch.object(
+                    _runtime,
+                    "_register_shutdown_handlers",
+                    side_effect=capture_shutdown,
+                ):
+                    _runtime.serve(plugin)
+            except BaseException as exc:  # pragma: no cover - surfaced via assertions
+                failures.append(exc)
+                ready.set()
+
+        with mock.patch.dict(
+            _runtime.os.environ,
+            {_runtime.ENV_PROVIDER_SOCKET: f"tcp://{address}"},
+            clear=False,
+        ):
+            thread = threading.Thread(target=run_server, daemon=True)
+            thread.start()
+            self.assertTrue(ready.wait(timeout=5))
+            self.assertEqual(failures, [])
+            self.assertIn("server", server_holder)
+
+            channel = grpc.insecure_channel(address)
+            self.addCleanup(channel.close)
+            grpc.channel_ready_future(channel).result(timeout=5)
+            stub = plugin_pb2_grpc.IntegrationProviderStub(channel)
+
+            metadata = stub.GetMetadata(empty_pb2.Empty(), timeout=5)
+            started = stub.StartProvider(
+                plugin_pb2.StartProviderRequest(
+                    name="tcp-runtime",
+                    protocol_version=_runtime.CURRENT_PROTOCOL_VERSION,
+                ),
+                timeout=5,
+            )
+            result = stub.Execute(
+                plugin_pb2.ExecuteRequest(operation="ping"),
+                timeout=5,
+            )
+
+            self.assertEqual(
+                metadata.min_protocol_version,
+                _runtime.CURRENT_PROTOCOL_VERSION,
+            )
+            self.assertEqual(
+                metadata.max_protocol_version,
+                _runtime.CURRENT_PROTOCOL_VERSION,
+            )
+            self.assertEqual(
+                started.protocol_version,
+                _runtime.CURRENT_PROTOCOL_VERSION,
+            )
+            self.assertEqual(json.loads(result.body), "pong")
+
+            server_holder["server"].stop(grace=0).wait()
+            thread.join(timeout=5)
+            self.assertFalse(thread.is_alive())
+            self.assertEqual(failures, [])
 
 
 class PublicImportTests(unittest.TestCase):


### PR DESCRIPTION
## Summary
Hosted Python providers currently treat every `GESTALT_PLUGIN_SOCKET` value like a Unix socket path. When a hosted runtime passes `tcp://0.0.0.0:50051`, the SDK binds `unix:tcp:/0.0.0.0:50051` and the provider never comes up.

This PR makes the Python runtime honor the same transport contract the rest of the SDK already uses.

## Interfaces
```bash
export GESTALT_PLUGIN_SOCKET=unix:///tmp/provider.sock
export GESTALT_PLUGIN_SOCKET=tcp://0.0.0.0:50051
export GESTALT_PLUGIN_SOCKET=/tmp/provider.sock
```

```python
from gestalt import _runtime

_runtime.serve(provider, runtime_kind="agent")
```

Behavior:
- `unix:///path/to/plugin.sock` -> bind `unix:/path/to/plugin.sock`
- `tcp://host:port` -> bind `host:port`
- plain paths still mean Unix sockets
- unsupported schemes fail fast with a clear error

## Example
```bash
export GESTALT_PLUGIN_SOCKET=tcp://0.0.0.0:50051
python -m gestalt._runtime /workspace plugin:provider agent
```

## Testing
- `uv run python -m unittest tests.test_runtime`
- `uv run ruff check gestalt/_runtime.py tests/test_runtime.py`
- `uv run ty check gestalt/_runtime.py tests/test_runtime.py`

The new coverage adds a real TCP gRPC roundtrip through `gestalt._runtime.serve()` plus parser coverage for the provider socket target contract.