### PR TITLE
Refactor TypeScript fake bun tests around a helper binary

### DIFF
--- a/gestaltd/cmd/gestaltd/provider_test.go
+++ b/gestaltd/cmd/gestaltd/provider_test.go
@@ -28,6 +28,7 @@ import (
 	"github.com/valon-technologies/gestalt/server/internal/providerhost"
 	"github.com/valon-technologies/gestalt/server/internal/providerpkg"
 	"github.com/valon-technologies/gestalt/server/internal/testutil"
+	"github.com/valon-technologies/gestalt/server/internal/testutil/fakebun"
 	providermanifestv1 "github.com/valon-technologies/gestalt/server/sdk/providermanifest/v1"
 	"google.golang.org/grpc"
 	"gopkg.in/yaml.v3"
@@ -391,8 +392,6 @@ func TestRun_ProviderReleaseBuildsTypeScriptSourcePluginForCurrentPlatform(t *te
 		t.Skip("fake Bun build fixture is POSIX-only")
 	}
 
-	t.Setenv("PATH", pathWithoutGo(t))
-
 	pluginDir := newTypeScriptSourceReleaseFixture(t, t.TempDir())
 	bunPath := writeFakeTypeScriptProviderReleaseBun(
 		t,
@@ -402,6 +401,7 @@ func TestRun_ProviderReleaseBuildsTypeScriptSourcePluginForCurrentPlatform(t *te
 		runtime.GOOS,
 		runtime.GOARCH,
 	)
+	t.Setenv("PATH", pathWithoutGo(t))
 	t.Setenv("GESTALT_BUN", bunPath)
 
 	outputDir := t.TempDir()
@@ -575,8 +575,6 @@ func TestRun_ProviderReleaseBuildsRequestedPlatformSets(t *testing.T) {
 		}
 
 		builtBinary := buildGoSourceAuthBinary(t)
-		t.Setenv("PATH", pathWithoutGo(t))
-
 		pluginDir := newTypeScriptSourceAuthReleaseFixture(t, t.TempDir())
 		defaultPlatforms := defaultReleasePlatformsForTest(t)
 		bunPath := writeFakeTypeScriptComponentReleaseBunForPlatforms(
@@ -587,6 +585,7 @@ func TestRun_ProviderReleaseBuildsRequestedPlatformSets(t *testing.T) {
 			defaultPlatforms,
 			builtBinary,
 		)
+		t.Setenv("PATH", pathWithoutGo(t))
 		t.Setenv("GESTALT_BUN", bunPath)
 
 		outputDir := t.TempDir()
@@ -1450,9 +1449,9 @@ func TestRun_ProviderReleaseBuildsExecutableAuthProviders(t *testing.T) {
 				t.Helper()
 
 				builtBinary := buildGoSourceAuthBinary(t)
-				t.Setenv("PATH", pathWithoutGo(t))
 				pluginDir := newTypeScriptSourceAuthReleaseFixture(t, t.TempDir())
 				bunPath := writeFakeTypeScriptComponentReleaseBun(t, filepath.Join(pluginDir, "fake-bun"), authReleaseTypeScriptTarget, authReleasePluginName, runtime.GOOS, runtime.GOARCH, builtBinary)
+				t.Setenv("PATH", pathWithoutGo(t))
 				t.Setenv("GESTALT_BUN", bunPath)
 				return pluginDir
 			},
@@ -2584,142 +2583,54 @@ func writeFakeTypeScriptComponentReleaseBun(t *testing.T, path, expectedTarget, 
 func writeFakeTypeScriptComponentReleaseBunForPlatforms(t *testing.T, path, expectedTarget, expectedPluginName string, expectedPlatforms []releasePlatform, builtBinaryPath string) string {
 	t.Helper()
 
-	allowedCases := make([]string, 0, len(expectedPlatforms))
+	allowedPlatforms := make([]fakebun.Platform, 0, len(expectedPlatforms))
 	for _, platform := range expectedPlatforms {
-		allowedCases = append(allowedCases, fmt.Sprintf("%s/%s", platform.GOOS, platform.GOARCH))
+		allowedPlatforms = append(allowedPlatforms, fakebun.Platform{
+			GOOS:   platform.GOOS,
+			GOARCH: platform.GOARCH,
+		})
 	}
-	allowedPlatformCase := strings.Join(allowedCases, "|") + ")"
+	sdkPath := fakebun.LocalTypeScriptSDKPath()
+	if sdkPath == "" {
+		t.Fatal("local TypeScript SDK not found")
+	}
 
-	script := `#!/bin/sh
-set -eu
-
-if [ "$#" -lt 4 ] || [ "$1" != "--cwd" ]; then
-  echo "unexpected fake bun args: $*" >&2
-  exit 1
-fi
-
-cwd="$2"
-shift 2
-
-entry="$1"
-shift
-
-if [ "$#" -gt 0 ] && [ "$1" = "--" ]; then
-  shift
-fi
-
-entry_base="${entry##*/}"
-case "$entry_base" in
-  gestalt-ts-build|build.ts)
-    if [ "$#" -ne 6 ]; then
-      echo "unexpected build args: $*" >&2
-      exit 1
-    fi
-    source_dir="$1"
-    target="$2"
-    output="$3"
-    name="$4"
-    goos="$5"
-    goarch="$6"
-    if [ "$cwd" != "$source_dir" ]; then
-      echo "unexpected build cwd: $cwd != $source_dir" >&2
-      exit 1
-    fi
-    if [ "$target" != "` + authReleaseTypeScriptTarget + `" ]; then
-      echo "unexpected build target: $target" >&2
-      exit 1
-    fi
-    if [ "$target" != "` + expectedTarget + `" ]; then
-      echo "unexpected build target: $target" >&2
-      exit 1
-    fi
-    if [ "$name" != "` + expectedPluginName + `" ]; then
-      echo "unexpected plugin name: $name" >&2
-      exit 1
-    fi
-    case "$goos/$goarch" in
-      ` + allowedPlatformCase + `
-        ;;
-      *)
-        echo "unexpected target platform: $goos/$goarch" >&2
-        exit 1
-        ;;
-    esac
-    output_dir="${output%/*}"
-    if [ "$output_dir" = "$output" ]; then
-      output_dir="."
-    fi
-    mkdir -p "$output_dir"
-    cp "` + builtBinaryPath + `" "$output"
-    chmod +x "$output"
-    exit 0
-    ;;
-esac
-
-echo "unexpected fake bun entry: $entry ($*)" >&2
-exit 1
-`
-	writeTestFile(t, filepath.Dir(path), filepath.Base(path), []byte(script), 0o755)
-	return path
+	sourceDir := "."
+	return fakebun.NewExecutable(t, fakebun.Config{
+		Build: &fakebun.BuildConfig{
+			ExpectedCwd:        sourceDir,
+			ExpectedEntry:      filepath.Join(sdkPath, "src", "build.ts"),
+			ExpectedSourceDir:  sourceDir,
+			ExpectedTarget:     expectedTarget,
+			ExpectedPluginName: expectedPluginName,
+			AllowedPlatforms:   allowedPlatforms,
+			CopyBinaryFrom:     builtBinaryPath,
+		},
+	})
 }
 
 func writeFakeTypeScriptProviderReleaseBun(t *testing.T, path, expectedPluginName, expectedTarget, expectedGOOS, expectedGOARCH string) string {
 	t.Helper()
 
-	script := `#!/bin/sh
-set -eu
+	sdkPath := fakebun.LocalTypeScriptSDKPath()
+	if sdkPath == "" {
+		t.Fatal("local TypeScript SDK not found")
+	}
 
-if [ "$#" -lt 4 ] || [ "$1" != "--cwd" ]; then
-  echo "unexpected fake bun args: $*" >&2
-  exit 1
-fi
-
-cwd="$2"
-shift 2
-
-entry="$1"
-shift
-
-if [ "$#" -gt 0 ] && [ "$1" = "--" ]; then
-  shift
-fi
-
-entry_base="${entry##*/}"
-case "$entry_base" in
-  gestalt-ts-runtime|runtime.ts)
-    if [ "$#" -ne 2 ]; then
-      echo "unexpected runtime args: $*" >&2
-      exit 1
-    fi
-    root="$1"
-    target="$2"
-    if [ "$cwd" != "$root" ]; then
-      echo "unexpected runtime cwd: $cwd != $root" >&2
-      exit 1
-    fi
-    if [ "$target" != "` + typeScriptReleaseTarget + `" ]; then
-      echo "unexpected runtime target: $target" >&2
-      exit 1
-    fi
-    if [ "$target" != "` + expectedTarget + `" ]; then
-      echo "unexpected runtime target: $target" >&2
-      exit 1
-    fi
-    if [ -z "${GESTALT_PLUGIN_WRITE_CATALOG:-}" ] && [ -z "${GESTALT_PLUGIN_WRITE_MANIFEST_METADATA:-}" ]; then
-      echo "missing catalog or manifest metadata export path" >&2
-      exit 1
-    fi
-    if [ -n "${GESTALT_PLUGIN_WRITE_CATALOG:-}" ]; then
-      cat > "$GESTALT_PLUGIN_WRITE_CATALOG" <<'EOF'
-name: ` + typeScriptReleasePluginName + `
+	sourceDir := "."
+	return fakebun.NewExecutable(t, fakebun.Config{
+		Runtime: &fakebun.RuntimeConfig{
+			ExpectedCwd:      sourceDir,
+			ExpectedEntry:    filepath.Join(sdkPath, "src", "runtime.ts"),
+			ExpectedRoot:     sourceDir,
+			ExpectedTarget:   expectedTarget,
+			RequireAnyOutput: true,
+			Catalog: `name: ` + typeScriptReleasePluginName + `
 operations:
   - id: greet
     method: GET
-EOF
-    fi
-    if [ -n "${GESTALT_PLUGIN_WRITE_MANIFEST_METADATA:-}" ]; then
-      cat > "$GESTALT_PLUGIN_WRITE_MANIFEST_METADATA" <<'EOF'
-securitySchemes:
+`,
+			ManifestMetadata: `securitySchemes:
   signed:
     type: hmac
     secret:
@@ -2743,57 +2654,21 @@ http:
       status: 200
       body:
         status: accepted
-EOF
-    fi
-    exit 0
-    ;;
-  gestalt-ts-build|build.ts)
-    if [ "$#" -ne 6 ]; then
-      echo "unexpected build args: $*" >&2
-      exit 1
-    fi
-    source_dir="$1"
-    target="$2"
-    output="$3"
-    name="$4"
-    goos="$5"
-    goarch="$6"
-    if [ "$cwd" != "$source_dir" ]; then
-      echo "unexpected build cwd: $cwd != $source_dir" >&2
-      exit 1
-    fi
-    if [ "$target" != "` + typeScriptReleaseTarget + `" ]; then
-      echo "unexpected build target: $target" >&2
-      exit 1
-    fi
-    if [ "$target" != "` + expectedTarget + `" ]; then
-      echo "unexpected build target: $target" >&2
-      exit 1
-    fi
-    if [ "$name" != "` + expectedPluginName + `" ]; then
-      echo "unexpected plugin name: $name" >&2
-      exit 1
-    fi
-    if [ "$goos" != "` + expectedGOOS + `" ] || [ "$goarch" != "` + expectedGOARCH + `" ]; then
-      echo "unexpected target platform: $goos/$goarch" >&2
-      exit 1
-    fi
-    output_dir="${output%/*}"
-    if [ "$output_dir" = "$output" ]; then
-      output_dir="."
-    fi
-    mkdir -p "$output_dir"
-    printf '#!/bin/sh\n# fake ts release binary\nexit 0\n' > "$output"
-    chmod +x "$output"
-    exit 0
-    ;;
-esac
-
-echo "unexpected fake bun entry: $entry ($*)" >&2
-exit 1
-`
-	writeTestFile(t, filepath.Dir(path), filepath.Base(path), []byte(script), 0o755)
-	return path
+`,
+		},
+		Build: &fakebun.BuildConfig{
+			ExpectedCwd:        sourceDir,
+			ExpectedEntry:      filepath.Join(sdkPath, "src", "build.ts"),
+			ExpectedSourceDir:  sourceDir,
+			ExpectedTarget:     expectedTarget,
+			ExpectedPluginName: expectedPluginName,
+			AllowedPlatforms: []fakebun.Platform{{
+				GOOS:   expectedGOOS,
+				GOARCH: expectedGOARCH,
+			}},
+			BinaryContent: "#!/bin/sh\n# fake ts release binary\nexit 0\n",
+		},
+	})
 }
 
 func writeFakePythonReleaseInterpreter(t *testing.T, path, expectedGOOS, expectedGOARCH string) {

--- a/gestaltd/internal/providerpkg/typescript_provider_test.go
+++ b/gestaltd/internal/providerpkg/typescript_provider_test.go
@@ -8,6 +8,7 @@ import (
 	"strings"
 	"testing"
 
+	"github.com/valon-technologies/gestalt/server/internal/testutil/fakebun"
 	providermanifestv1 "github.com/valon-technologies/gestalt/server/sdk/providermanifest/v1"
 )
 
@@ -787,56 +788,24 @@ func mustWriteTypeScriptSourceComponentManifest(t *testing.T, root, pluginName, 
 func writeFakeTypeScriptBun(t *testing.T, root, pluginName, expectedTarget, expectedGOOS, expectedGOARCH string) string {
 	t.Helper()
 
-	path := filepath.Join(root, "bin", "bun")
-	script := `#!/bin/sh
-set -eu
+	sdkPath := fakebun.LocalTypeScriptSDKPath()
+	if sdkPath == "" {
+		t.Fatal("local TypeScript SDK not found")
+	}
 
-if [ "$#" -lt 4 ] || [ "$1" != "--cwd" ]; then
-  echo "unexpected fake bun args: $*" >&2
-  exit 1
-fi
-
-cwd="$2"
-shift 2
-
-entry="$1"
-shift
-
-if [ "$#" -gt 0 ] && [ "$1" = "--" ]; then
-  shift
-fi
-
-entry_base="${entry##*/}"
-
-case "$entry_base" in
-  gestalt-ts-runtime|runtime.ts)
-    if [ "$#" -ne 2 ]; then
-      echo "unexpected runtime args: $*" >&2
-      exit 1
-    fi
-    root="$1"
-    target="$2"
-    if [ "$cwd" != "$root" ]; then
-      echo "unexpected runtime cwd: $cwd != $root" >&2
-      exit 1
-    fi
-    if [ "$target" != "` + expectedTarget + `" ]; then
-      echo "unexpected runtime target: $target" >&2
-      exit 1
-    fi
-    if [ -z "${GESTALT_PLUGIN_WRITE_CATALOG:-}" ]; then
-      echo "missing GESTALT_PLUGIN_WRITE_CATALOG" >&2
-      exit 1
-    fi
-    cat > "$GESTALT_PLUGIN_WRITE_CATALOG" <<'EOF'
-name: ` + pluginName + `
+	return fakebun.NewExecutable(t, fakebun.Config{
+		Runtime: &fakebun.RuntimeConfig{
+			ExpectedCwd:    root,
+			ExpectedEntry:  filepath.Join(sdkPath, "src", "runtime.ts"),
+			ExpectedRoot:   root,
+			ExpectedTarget: expectedTarget,
+			RequireCatalog: true,
+			Catalog: fmt.Sprintf(`name: %s
 operations:
   - id: greet
     method: GET
-EOF
-    if [ -n "${GESTALT_PLUGIN_WRITE_MANIFEST_METADATA:-}" ]; then
-      cat > "$GESTALT_PLUGIN_WRITE_MANIFEST_METADATA" <<'EOF'
-securitySchemes:
+`, pluginName),
+			ManifestMetadata: `securitySchemes:
   signed:
     type: hmac
     secret:
@@ -856,51 +825,19 @@ http:
       required: true
       content:
         application/x-www-form-urlencoded: {}
-EOF
-    fi
-    exit 0
-    ;;
-  gestalt-ts-build|build.ts)
-    if [ "$#" -ne 6 ]; then
-      echo "unexpected build args: $*" >&2
-      exit 1
-    fi
-    source_dir="$1"
-    target="$2"
-    output="$3"
-    name="$4"
-    goos="$5"
-    goarch="$6"
-    if [ "$cwd" != "$source_dir" ]; then
-      echo "unexpected build cwd: $cwd != $source_dir" >&2
-      exit 1
-    fi
-    if [ "$target" != "` + expectedTarget + `" ]; then
-      echo "unexpected build target: $target" >&2
-      exit 1
-    fi
-    if [ "$name" != "` + pluginName + `" ]; then
-      echo "unexpected plugin name: $name" >&2
-      exit 1
-    fi
-    if [ "$goos" != "` + expectedGOOS + `" ] || [ "$goarch" != "` + expectedGOARCH + `" ]; then
-      echo "unexpected target platform: $goos/$goarch" >&2
-      exit 1
-    fi
-    output_dir="${output%/*}"
-    if [ "$output_dir" = "$output" ]; then
-      output_dir="."
-    fi
-    mkdir -p "$output_dir"
-    printf '#!/bin/sh\n# fake ts release binary\nexit 0\n' > "$output"
-    chmod +x "$output"
-    exit 0
-    ;;
-esac
-
-echo "unexpected fake bun entry: $entry ($*)" >&2
-exit 1
-`
-	mustWriteFile(t, path, []byte(script), 0o755)
-	return path
+`,
+		},
+		Build: &fakebun.BuildConfig{
+			ExpectedCwd:        root,
+			ExpectedEntry:      filepath.Join(sdkPath, "src", "build.ts"),
+			ExpectedSourceDir:  root,
+			ExpectedTarget:     expectedTarget,
+			ExpectedPluginName: pluginName,
+			AllowedPlatforms: []fakebun.Platform{{
+				GOOS:   expectedGOOS,
+				GOARCH: expectedGOARCH,
+			}},
+			BinaryContent: "#!/bin/sh\n# fake ts release binary\nexit 0\n",
+		},
+	})
 }

--- a/gestaltd/internal/testutil/cmd/fakebun/main.go
+++ b/gestaltd/internal/testutil/cmd/fakebun/main.go
@@ -1,0 +1,239 @@
+package main
+
+import (
+	"errors"
+	"fmt"
+	"os"
+	"path/filepath"
+	"strings"
+
+	"github.com/valon-technologies/gestalt/server/internal/testutil/fakebun"
+)
+
+func main() {
+	if err := run(os.Args[1:]); err != nil {
+		fmt.Fprintln(os.Stderr, err)
+		os.Exit(1)
+	}
+}
+
+func run(args []string) error {
+	exePath, err := os.Executable()
+	if err != nil {
+		return fmt.Errorf("resolve executable path: %w", err)
+	}
+	cfg, err := fakebun.LoadExecutableConfig(exePath)
+	if err != nil {
+		return err
+	}
+	if len(args) == 0 {
+		return fmt.Errorf("unexpected fake bun args: %s", strings.Join(args, " "))
+	}
+	if args[0] == "install" {
+		return runInstall(cfg.Install, args[1:])
+	}
+
+	var errs []error
+	if cfg.Runtime != nil {
+		if err := runRuntime(*cfg.Runtime, args); err == nil {
+			return nil
+		} else {
+			errs = append(errs, fmt.Errorf("runtime: %w", err))
+		}
+	}
+	if cfg.Build != nil {
+		if err := runBuild(*cfg.Build, args); err == nil {
+			return nil
+		} else {
+			errs = append(errs, fmt.Errorf("build: %w", err))
+		}
+	}
+	if len(errs) == 0 {
+		return fmt.Errorf("unexpected fake bun args: %s", strings.Join(args, " "))
+	}
+	return errors.Join(errs...)
+}
+
+func runInstall(cfg *fakebun.InstallConfig, args []string) error {
+	if cfg == nil {
+		return fmt.Errorf("unexpected bun install args: %s", strings.Join(args, " "))
+	}
+
+	cwd := ""
+	frozen := false
+	for i := 0; i < len(args); i++ {
+		switch args[i] {
+		case "--cwd":
+			if i+1 >= len(args) {
+				return fmt.Errorf("missing bun install cwd")
+			}
+			cwd = args[i+1]
+			i++
+		case "--frozen-lockfile":
+			frozen = true
+		default:
+			return fmt.Errorf("unexpected bun install args: %s", strings.Join(args, " "))
+		}
+	}
+
+	if cwd == "" {
+		return fmt.Errorf("missing bun install --cwd")
+	}
+	if cfg.ExpectedCwd != "" && cwd != cfg.ExpectedCwd {
+		return fmt.Errorf("unexpected bun install cwd: %s != %s", cwd, cfg.ExpectedCwd)
+	}
+	if cfg.RequireFrozenLockfile && !frozen {
+		return fmt.Errorf("missing bun install --frozen-lockfile")
+	}
+
+	nodeModulesDir := filepath.Join(cwd, "node_modules")
+	if err := os.MkdirAll(nodeModulesDir, 0o755); err != nil {
+		return err
+	}
+	return os.WriteFile(filepath.Join(nodeModulesDir, ".installed"), nil, 0o644)
+}
+
+func runRuntime(cfg fakebun.RuntimeConfig, args []string) error {
+	inv, err := parseInvocation(cfg.Mode, args)
+	if err != nil {
+		return err
+	}
+	if cfg.ExpectedCwd != "" && inv.cwd != cfg.ExpectedCwd {
+		return fmt.Errorf("unexpected runtime cwd: %s != %s", inv.cwd, cfg.ExpectedCwd)
+	}
+	if cfg.ExpectedEntry != "" && inv.entry != cfg.ExpectedEntry {
+		return fmt.Errorf("unexpected runtime entry: %s != %s", inv.entry, cfg.ExpectedEntry)
+	}
+	if len(inv.tail) != 2 {
+		return fmt.Errorf("unexpected runtime args: %s", strings.Join(inv.tail, " "))
+	}
+	if cfg.ExpectedRoot != "" && inv.tail[0] != cfg.ExpectedRoot {
+		return fmt.Errorf("unexpected runtime root: %s != %s", inv.tail[0], cfg.ExpectedRoot)
+	}
+	if cfg.ExpectedTarget != "" && inv.tail[1] != cfg.ExpectedTarget {
+		return fmt.Errorf("unexpected runtime target: %s != %s", inv.tail[1], cfg.ExpectedTarget)
+	}
+
+	catalogPath := os.Getenv("GESTALT_PLUGIN_WRITE_CATALOG")
+	manifestMetadataPath := os.Getenv("GESTALT_PLUGIN_WRITE_MANIFEST_METADATA")
+	if cfg.RequireAnyOutput && catalogPath == "" && manifestMetadataPath == "" {
+		return fmt.Errorf("missing catalog or manifest metadata export path")
+	}
+	if cfg.RequireCatalog && catalogPath == "" {
+		return fmt.Errorf("missing GESTALT_PLUGIN_WRITE_CATALOG")
+	}
+	if catalogPath != "" && cfg.Catalog != "" {
+		if err := os.WriteFile(catalogPath, []byte(cfg.Catalog), 0o644); err != nil {
+			return err
+		}
+	}
+
+	if cfg.RequireManifestMetadata && manifestMetadataPath == "" {
+		return fmt.Errorf("missing GESTALT_PLUGIN_WRITE_MANIFEST_METADATA")
+	}
+	if manifestMetadataPath != "" && cfg.ManifestMetadata != "" {
+		if err := os.WriteFile(manifestMetadataPath, []byte(cfg.ManifestMetadata), 0o644); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+func runBuild(cfg fakebun.BuildConfig, args []string) error {
+	inv, err := parseInvocation(cfg.Mode, args)
+	if err != nil {
+		return err
+	}
+	if cfg.ExpectedCwd != "" && inv.cwd != cfg.ExpectedCwd {
+		return fmt.Errorf("unexpected build cwd: %s != %s", inv.cwd, cfg.ExpectedCwd)
+	}
+	if cfg.ExpectedEntry != "" && inv.entry != cfg.ExpectedEntry {
+		return fmt.Errorf("unexpected build entry: %s != %s", inv.entry, cfg.ExpectedEntry)
+	}
+	if len(inv.tail) != 6 {
+		return fmt.Errorf("unexpected build args: %s", strings.Join(inv.tail, " "))
+	}
+
+	sourceDir := inv.tail[0]
+	target := inv.tail[1]
+	output := inv.tail[2]
+	name := inv.tail[3]
+	goos := inv.tail[4]
+	goarch := inv.tail[5]
+
+	if cfg.ExpectedSourceDir != "" && sourceDir != cfg.ExpectedSourceDir {
+		return fmt.Errorf("unexpected build source dir: %s != %s", sourceDir, cfg.ExpectedSourceDir)
+	}
+	if cfg.ExpectedTarget != "" && target != cfg.ExpectedTarget {
+		return fmt.Errorf("unexpected build target: %s != %s", target, cfg.ExpectedTarget)
+	}
+	if cfg.ExpectedPluginName != "" && name != cfg.ExpectedPluginName {
+		return fmt.Errorf("unexpected build plugin name: %s != %s", name, cfg.ExpectedPluginName)
+	}
+	if len(cfg.AllowedPlatforms) > 0 {
+		allowed := false
+		for _, platform := range cfg.AllowedPlatforms {
+			if goos == platform.GOOS && goarch == platform.GOARCH {
+				allowed = true
+				break
+			}
+		}
+		if !allowed {
+			return fmt.Errorf("unexpected target platform: %s/%s", goos, goarch)
+		}
+	}
+
+	if err := os.MkdirAll(filepath.Dir(output), 0o755); err != nil {
+		return err
+	}
+	if cfg.CopyBinaryFrom != "" {
+		return copyFile(cfg.CopyBinaryFrom, output)
+	}
+	return os.WriteFile(output, []byte(cfg.BinaryContent), 0o755)
+}
+
+type invocation struct {
+	cwd   string
+	entry string
+	tail  []string
+}
+
+func parseInvocation(mode fakebun.InvocationMode, args []string) (invocation, error) {
+	if mode == "" {
+		mode = fakebun.InvocationDirect
+	}
+	if len(args) < 3 || args[0] != "--cwd" {
+		return invocation{}, fmt.Errorf("unexpected fake bun args: %s", strings.Join(args, " "))
+	}
+
+	cwd := args[1]
+	switch mode {
+	case fakebun.InvocationDirect:
+		entry := args[2]
+		tail := args[3:]
+		if len(tail) > 0 && tail[0] == "--" {
+			tail = tail[1:]
+		}
+		return invocation{cwd: cwd, entry: entry, tail: tail}, nil
+	case fakebun.InvocationRun:
+		if len(args) < 4 || args[2] != "run" {
+			return invocation{}, fmt.Errorf("unexpected fake bun args: %s", strings.Join(args, " "))
+		}
+		entry := args[3]
+		tail := args[4:]
+		if len(tail) > 0 && tail[0] == "--" {
+			tail = tail[1:]
+		}
+		return invocation{cwd: cwd, entry: entry, tail: tail}, nil
+	default:
+		return invocation{}, fmt.Errorf("unsupported fake bun invocation mode %q", mode)
+	}
+}
+
+func copyFile(src, dst string) error {
+	data, err := os.ReadFile(src)
+	if err != nil {
+		return err
+	}
+	return os.WriteFile(dst, data, 0o755)
+}

--- a/gestaltd/internal/testutil/fakebun/fakebun.go
+++ b/gestaltd/internal/testutil/fakebun/fakebun.go
@@ -1,0 +1,191 @@
+package fakebun
+
+import (
+	"encoding/json"
+	"fmt"
+	"io"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"runtime"
+	"sync"
+	"testing"
+)
+
+type InvocationMode string
+
+const (
+	InvocationDirect InvocationMode = "direct"
+	InvocationRun    InvocationMode = "run"
+)
+
+type Config struct {
+	Install *InstallConfig `json:"install,omitempty"`
+	Runtime *RuntimeConfig `json:"runtime,omitempty"`
+	Build   *BuildConfig   `json:"build,omitempty"`
+}
+
+type InstallConfig struct {
+	ExpectedCwd           string `json:"expected_cwd,omitempty"`
+	RequireFrozenLockfile bool   `json:"require_frozen_lockfile,omitempty"`
+}
+
+type RuntimeConfig struct {
+	Mode                    InvocationMode `json:"mode,omitempty"`
+	ExpectedCwd             string         `json:"expected_cwd,omitempty"`
+	ExpectedEntry           string         `json:"expected_entry,omitempty"`
+	ExpectedRoot            string         `json:"expected_root,omitempty"`
+	ExpectedTarget          string         `json:"expected_target,omitempty"`
+	RequireAnyOutput        bool           `json:"require_any_output,omitempty"`
+	RequireCatalog          bool           `json:"require_catalog,omitempty"`
+	Catalog                 string         `json:"catalog,omitempty"`
+	RequireManifestMetadata bool           `json:"require_manifest_metadata,omitempty"`
+	ManifestMetadata        string         `json:"manifest_metadata,omitempty"`
+}
+
+type BuildConfig struct {
+	Mode               InvocationMode `json:"mode,omitempty"`
+	ExpectedCwd        string         `json:"expected_cwd,omitempty"`
+	ExpectedEntry      string         `json:"expected_entry,omitempty"`
+	ExpectedSourceDir  string         `json:"expected_source_dir,omitempty"`
+	ExpectedTarget     string         `json:"expected_target,omitempty"`
+	ExpectedPluginName string         `json:"expected_plugin_name,omitempty"`
+	AllowedPlatforms   []Platform     `json:"allowed_platforms,omitempty"`
+	BinaryContent      string         `json:"binary_content,omitempty"`
+	CopyBinaryFrom     string         `json:"copy_binary_from,omitempty"`
+}
+
+type Platform struct {
+	GOOS   string `json:"goos"`
+	GOARCH string `json:"goarch"`
+}
+
+var (
+	buildHelperOnce sync.Once
+	helperBinary    string
+	helperBinaryErr error
+)
+
+func NewExecutable(t testing.TB, cfg Config) string {
+	t.Helper()
+
+	sharedBinary, err := builtHelperBinary()
+	if err != nil {
+		t.Fatalf("build fake bun helper: %v", err)
+	}
+
+	dstPath := filepath.Join(t.TempDir(), "bun"+executableSuffix())
+	if err := copyFile(sharedBinary, dstPath); err != nil {
+		t.Fatalf("copy fake bun helper: %v", err)
+	}
+
+	data, err := json.Marshal(cfg)
+	if err != nil {
+		t.Fatalf("marshal fake bun config: %v", err)
+	}
+	if err := os.WriteFile(ConfigPath(dstPath), data, 0o644); err != nil {
+		t.Fatalf("write fake bun config: %v", err)
+	}
+	return dstPath
+}
+
+func LoadExecutableConfig(exePath string) (Config, error) {
+	data, err := os.ReadFile(ConfigPath(exePath))
+	if err != nil {
+		return Config{}, fmt.Errorf("read fake bun config: %w", err)
+	}
+	var cfg Config
+	if err := json.Unmarshal(data, &cfg); err != nil {
+		return Config{}, fmt.Errorf("parse fake bun config: %w", err)
+	}
+	return cfg, nil
+}
+
+func ConfigPath(exePath string) string {
+	return exePath + ".json"
+}
+
+func LocalTypeScriptSDKPath() string {
+	root, err := repoRoot()
+	if err != nil {
+		return ""
+	}
+	path := filepath.Join(root, "sdk", "typescript")
+	if _, err := os.Stat(filepath.Join(path, "package.json")); err != nil {
+		return ""
+	}
+	return path
+}
+
+func builtHelperBinary() (string, error) {
+	buildHelperOnce.Do(func() {
+		tmpDir, err := os.MkdirTemp("", "gestalt-fake-bun-*")
+		if err != nil {
+			helperBinaryErr = fmt.Errorf("create temp dir: %w", err)
+			return
+		}
+
+		helperBinary = filepath.Join(tmpDir, "bun"+executableSuffix())
+		root, err := repoRoot()
+		if err != nil {
+			helperBinaryErr = err
+			return
+		}
+
+		cmd := exec.Command(goBinaryPath(), "build", "-o", helperBinary, "./internal/testutil/cmd/fakebun")
+		cmd.Dir = filepath.Join(root, "gestaltd")
+		cmd.Stdout = os.Stderr
+		cmd.Stderr = os.Stderr
+		if err := cmd.Run(); err != nil {
+			helperBinaryErr = fmt.Errorf("go build fake bun helper: %w", err)
+			return
+		}
+	})
+	return helperBinary, helperBinaryErr
+}
+
+func repoRoot() (string, error) {
+	_, file, _, ok := runtime.Caller(0)
+	if !ok {
+		return "", fmt.Errorf("runtime.Caller failed")
+	}
+	return filepath.Clean(filepath.Join(filepath.Dir(file), "..", "..", "..", "..")), nil
+}
+
+func goBinaryPath() string {
+	if resolved, err := exec.LookPath("go"); err == nil {
+		return resolved
+	}
+	return "go"
+}
+
+func executableSuffix() string {
+	if runtime.GOOS == "windows" {
+		return ".exe"
+	}
+	return ""
+}
+
+func copyFile(src, dst string) error {
+	in, err := os.Open(src)
+	if err != nil {
+		return err
+	}
+	defer func() { _ = in.Close() }()
+
+	info, err := in.Stat()
+	if err != nil {
+		return err
+	}
+
+	out, err := os.OpenFile(dst, os.O_CREATE|os.O_WRONLY|os.O_TRUNC, info.Mode())
+	if err != nil {
+		return err
+	}
+	defer func() { _ = out.Close() }()
+
+	if _, err := io.Copy(out, in); err != nil {
+		return err
+	}
+	return out.Close()
+}


### PR DESCRIPTION
## Summary
This follow-up replaces the inline fake-`bun` shell scripts in the TypeScript subprocess tests with a small Go helper binary plus per-test JSON config.

The goal is to keep the current integration-style coverage while making the subprocess boundary easier to evolve and less brittle when the Bun invocation contract changes.

## New Test Interface
- `fakebun.NewExecutable(t, fakebun.Config{...})`
- `fakebun.LocalTypeScriptSDKPath()`

These are internal test helpers under `gestaltd/internal/testutil/fakebun`.

## Examples
```go
bunPath := fakebun.NewExecutable(t, fakebun.Config{
    Runtime: &fakebun.RuntimeConfig{
        ExpectedCwd:    root,
        ExpectedEntry:  filepath.Join(fakebun.LocalTypeScriptSDKPath(), "src", "runtime.ts"),
        ExpectedRoot:   root,
        ExpectedTarget: typeScriptTestPluginTarget,
        RequireCatalog: true,
        Catalog:        "name: ts-release\noperations:\n  - id: greet\n    method: GET\n",
    },
    Build: &fakebun.BuildConfig{
        ExpectedCwd:        root,
        ExpectedEntry:      filepath.Join(fakebun.LocalTypeScriptSDKPath(), "src", "build.ts"),
        ExpectedSourceDir:  root,
        ExpectedTarget:     typeScriptTestPluginTarget,
        ExpectedPluginName: "ts-release",
        AllowedPlatforms:   []fakebun.Platform{{GOOS: runtime.GOOS, GOARCH: runtime.GOARCH}},
        BinaryContent:      "#!/bin/sh\n# fake ts release binary\nexit 0\n",
    },
})
```

```go
bunPath := fakebun.NewExecutable(t, fakebun.Config{
    Build: &fakebun.BuildConfig{
        ExpectedCwd:        ".",
        ExpectedEntry:      filepath.Join(fakebun.LocalTypeScriptSDKPath(), "src", "build.ts"),
        ExpectedSourceDir:  ".",
        ExpectedTarget:     authReleaseTypeScriptTarget,
        ExpectedPluginName: authReleasePluginName,
        AllowedPlatforms:   []fakebun.Platform{{GOOS: runtime.GOOS, GOARCH: runtime.GOARCH}},
        CopyBinaryFrom:     builtBinaryPath,
    },
})
```

## Scope
- Refactors `gestaltd/internal/providerpkg/typescript_provider_test.go`
- Refactors `gestaltd/cmd/gestaltd/provider_test.go`
- Adds shared helper code under `gestaltd/internal/testutil/fakebun`
- Does not change product/runtime behavior
- Does not introduce `testscript`; this stays focused on subprocess-boundary tests

## Why This Shape
The follow-up is based on two OSS patterns:
- Go stdlib uses helper executables / helper-process patterns for `os/exec` testing instead of large inline shell mocks.
- HashiCorp uses `testscript` for higher-level CLI workflows, but that is a larger shift than this follow-up needs.

This PR adopts the first pattern for Gestalt’s TypeScript test fakes without widening the test surface.

## Tests
```sh
go test ./internal/providerpkg -count=1
go test ./cmd/gestaltd -count=1
golangci-lint run ./internal/providerpkg ./internal/testutil/fakebun ./internal/testutil/cmd/fakebun ./cmd/gestaltd
```