### PR TITLE
Bundle lazy Gestalt SDK modules in Python provider builds

### DIFF
--- a/sdk/python/gestalt/_build.py
+++ b/sdk/python/gestalt/_build.py
@@ -119,6 +119,10 @@ def _pyinstaller_command(
         str(bundle_config_path.parent / "spec"),
         "--name",
         pyinstaller_name,
+        # Bundle the entire SDK package so lazy `gestalt.__getattr__` exports
+        # (for example `gestalt._indexeddb`) remain available in frozen builds.
+        "--collect-submodules",
+        "gestalt",
         "--hidden-import",
         module_name,
         "--paths",

--- a/sdk/python/tests/test_build.py
+++ b/sdk/python/tests/test_build.py
@@ -111,6 +111,17 @@ class BuildTests(unittest.TestCase):
                     "pyinstaller-config",
                 )
                 self.assertEqual(captured.env["SOURCE_DATE_EPOCH"], "0")
+                self.assertIn("--collect-submodules", captured.command)
+                self.assertEqual(
+                    captured.command[
+                        captured.command.index("--collect-submodules") + 1
+                    ],
+                    "gestalt",
+                )
+                self.assertEqual(
+                    captured.command[captured.command.index("--hidden-import") + 1],
+                    "provider",
+                )
                 self.assertEqual(
                     captured.bundle_config,
                     {


### PR DESCRIPTION
## Summary
Fix Python provider release builds so frozen providers always bundle the lazy SDK submodules exposed through `gestalt.__getattr__`.

This unblocks Modal-hosted `agent/simple`, which currently fails at startup with:

```text
No module named 'gestalt._indexeddb'
```

## Interfaces
PyInstaller build command now includes:

```text
--collect-submodules gestalt
--hidden-import <provider module>
```

That means frozen Python providers keep working when they reach lazy SDK exports like:

```python
from gestalt import IndexedDB, S3, AuthorizationClient
```

which resolve at runtime to:

```text
gestalt._indexeddb
gestalt._s3
gestalt._authorization
```

## What changed
- add `--collect-submodules gestalt` to the Python provider build path in `sdk/python/gestalt/_build.py`
- extend the existing build test to assert the full SDK package is collected and the provider module hidden import is still preserved

## Validation
```bash
uv run python -m unittest tests.test_build
uv run ruff check gestalt/_build.py tests/test_build.py
uv run ty check gestalt/_build.py tests/test_build.py
```