### PR TITLE
sdk/go: preserve indexeddb columns on CreateObjectStore

### DIFF
--- a/sdk/go/indexeddb.go
+++ b/sdk/go/indexeddb.go
@@ -96,9 +96,40 @@ type IndexSchema struct {
 	Unique  bool
 }
 
-// ObjectStoreSchema describes the indexes attached to an object store.
+// ColumnType describes a provider-preserved scalar column type.
+type ColumnType int32
+
+const (
+	// TypeString stores UTF-8 string values.
+	TypeString ColumnType = iota
+	// TypeInt stores 64-bit signed integer values.
+	TypeInt
+	// TypeFloat stores IEEE-754 double values.
+	TypeFloat
+	// TypeBool stores boolean values.
+	TypeBool
+	// TypeTime stores timestamp values.
+	TypeTime
+	// TypeBytes stores binary blob values.
+	TypeBytes
+	// TypeJSON stores JSON-like structured values.
+	TypeJSON
+)
+
+// ColumnDef describes one provider-preserved object-store column.
+type ColumnDef struct {
+	Name       string
+	Type       ColumnType
+	PrimaryKey bool
+	NotNull    bool
+	Unique     bool
+}
+
+// ObjectStoreSchema describes the indexes and columns attached to an object
+// store.
 type ObjectStoreSchema struct {
 	Indexes []IndexSchema
+	Columns []ColumnDef
 }
 
 // IndexedDBClient speaks to a running IndexedDB provider over a host-provided
@@ -249,8 +280,18 @@ func (db *IndexedDBClient) CreateObjectStore(ctx context.Context, name string, s
 	for i, idx := range schema.Indexes {
 		indexes[i] = &proto.IndexSchema{Name: idx.Name, KeyPath: idx.KeyPath, Unique: idx.Unique}
 	}
+	columns := make([]*proto.ColumnDef, len(schema.Columns))
+	for i, col := range schema.Columns {
+		columns[i] = &proto.ColumnDef{
+			Name:       col.Name,
+			Type:       int32(col.Type),
+			PrimaryKey: col.PrimaryKey,
+			NotNull:    col.NotNull,
+			Unique:     col.Unique,
+		}
+	}
 	_, err := db.client.CreateObjectStore(ctx, &proto.CreateObjectStoreRequest{
-		Name: name, Schema: &proto.ObjectStoreSchema{Indexes: indexes},
+		Name: name, Schema: &proto.ObjectStoreSchema{Indexes: indexes, Columns: columns},
 	})
 	return grpcErr(err)
 }

--- a/sdk/go/indexeddb_transport_test.go
+++ b/sdk/go/indexeddb_transport_test.go
@@ -9,11 +9,16 @@ import (
 	"os/exec"
 	"path/filepath"
 	"runtime"
+	"sync"
 	"testing"
 
 	gestalt "github.com/valon-technologies/gestalt/sdk/go"
+	proto "github.com/valon-technologies/gestalt/sdk/go/gen/v1"
+	"google.golang.org/grpc"
 	"google.golang.org/grpc/codes"
 	"google.golang.org/grpc/status"
+	gproto "google.golang.org/protobuf/proto"
+	"google.golang.org/protobuf/types/known/emptypb"
 )
 
 var (
@@ -242,6 +247,88 @@ func TestTransport_TCPTargetTokenEnv(t *testing.T) {
 	}
 	if got["value"] != "token" {
 		t.Fatalf("value = %v, want token", got["value"])
+	}
+}
+
+type indexedDBSchemaTransportHarness struct {
+	proto.UnimplementedIndexedDBServer
+
+	mu       sync.Mutex
+	requests []*proto.CreateObjectStoreRequest
+}
+
+func (h *indexedDBSchemaTransportHarness) CreateObjectStore(_ context.Context, req *proto.CreateObjectStoreRequest) (*emptypb.Empty, error) {
+	h.mu.Lock()
+	h.requests = append(h.requests, gproto.Clone(req).(*proto.CreateObjectStoreRequest))
+	h.mu.Unlock()
+	return &emptypb.Empty{}, nil
+}
+
+func TestTransport_CreateObjectStorePreservesColumns(t *testing.T) {
+	address := reserveTCPAddress()
+	lis, err := net.Listen("tcp", address)
+	if err != nil {
+		t.Fatalf("net.Listen: %v", err)
+	}
+	t.Cleanup(func() { _ = lis.Close() })
+
+	harness := &indexedDBSchemaTransportHarness{}
+	srv := grpc.NewServer()
+	proto.RegisterIndexedDBServer(srv, harness)
+	go func() {
+		_ = srv.Serve(lis)
+	}()
+	t.Cleanup(srv.Stop)
+
+	t.Setenv(gestalt.EnvIndexedDBSocket, "tcp://"+address)
+	client, err := gestalt.IndexedDB()
+	if err != nil {
+		t.Fatalf("IndexedDB: %v", err)
+	}
+	defer func() { _ = client.Close() }()
+
+	err = client.CreateObjectStore(context.Background(), "agent_session_metadata", gestalt.ObjectStoreSchema{
+		Indexes: []gestalt.IndexSchema{
+			{Name: "by_subject", KeyPath: []string{"subject_id"}},
+			{Name: "by_subject_session", KeyPath: []string{"subject_id", "session_id"}, Unique: true},
+		},
+		Columns: []gestalt.ColumnDef{
+			{Name: "id", Type: gestalt.TypeString, PrimaryKey: true},
+			{Name: "subject_id", Type: gestalt.TypeString, NotNull: true},
+			{Name: "session_id", Type: gestalt.TypeString, NotNull: true, Unique: true},
+			{Name: "metadata_json", Type: gestalt.TypeJSON},
+		},
+	})
+	if err != nil {
+		t.Fatalf("CreateObjectStore: %v", err)
+	}
+
+	harness.mu.Lock()
+	defer harness.mu.Unlock()
+	if len(harness.requests) != 1 {
+		t.Fatalf("create object store requests len = %d, want 1", len(harness.requests))
+	}
+	req := harness.requests[0]
+	if req.GetName() != "agent_session_metadata" {
+		t.Fatalf("request name = %q, want agent_session_metadata", req.GetName())
+	}
+	if len(req.GetSchema().GetIndexes()) != 2 {
+		t.Fatalf("index count = %d, want 2", len(req.GetSchema().GetIndexes()))
+	}
+	if len(req.GetSchema().GetColumns()) != 4 {
+		t.Fatalf("column count = %d, want 4", len(req.GetSchema().GetColumns()))
+	}
+	gotID := req.GetSchema().GetColumns()[0]
+	if gotID.GetName() != "id" || gotID.GetType() != int32(gestalt.TypeString) || !gotID.GetPrimaryKey() {
+		t.Fatalf("id column = %#v, want primary string id column", gotID)
+	}
+	gotSession := req.GetSchema().GetColumns()[2]
+	if gotSession.GetName() != "session_id" || !gotSession.GetNotNull() || !gotSession.GetUnique() {
+		t.Fatalf("session column = %#v, want non-null unique session_id column", gotSession)
+	}
+	gotMetadata := req.GetSchema().GetColumns()[3]
+	if gotMetadata.GetName() != "metadata_json" || gotMetadata.GetType() != int32(gestalt.TypeJSON) {
+		t.Fatalf("metadata column = %#v, want json metadata_json column", gotMetadata)
 	}
 }
 


### PR DESCRIPTION
## Summary
This fixes the Go SDK transport bug behind the latest `valon.tools` deploy failure. `sdk/go` was dropping `ObjectStoreSchema.Columns` on `CreateObjectStore`, so relational IndexedDB providers only saw indexes and then failed DDL for indexed columns like `session_id`.

## New Interfaces
```go
type ColumnType int32

const (
    TypeString ColumnType = iota
    TypeInt
    TypeFloat
    TypeBool
    TypeTime
    TypeBytes
    TypeJSON
)

type ColumnDef struct {
    Name       string
    Type       ColumnType
    PrimaryKey bool
    NotNull    bool
    Unique     bool
}

type ObjectStoreSchema struct {
    Indexes []IndexSchema
    Columns []ColumnDef
}
```

`IndexedDBClient.CreateObjectStore(...)` now serializes both `Indexes` and `Columns` into `provider.v1.ObjectStoreSchema`.

## Example
```go
err := client.CreateObjectStore(ctx, "agent_session_metadata", gestalt.ObjectStoreSchema{
    Indexes: []gestalt.IndexSchema{
        {Name: "by_subject_session", KeyPath: []string{"subject_id", "session_id"}, Unique: true},
    },
    Columns: []gestalt.ColumnDef{
        {Name: "id", Type: gestalt.TypeString, PrimaryKey: true},
        {Name: "subject_id", Type: gestalt.TypeString, NotNull: true},
        {Name: "session_id", Type: gestalt.TypeString, NotNull: true},
        {Name: "metadata_json", Type: gestalt.TypeJSON},
    },
})
```

## Validation
- `go test ./...` in `sdk/go`
- added a transport-level gRPC capture test asserting `CreateObjectStore` preserves columns on the wire
