### PR TITLE
sdk: bypass proxies for internal host-service channels

### DIFF
--- a/sdk/go/authorization_client.go
+++ b/sdk/go/authorization_client.go
@@ -69,7 +69,7 @@ func sharedAuthorizationClient(ctx context.Context, target, token string) (proto
 	switch network {
 	case "unix":
 		conn, err = grpc.DialContext(ctx, "passthrough:///localhost",
-			append([]grpc.DialOption{
+			append(internalHostServiceBaseDialOptions(
 				grpc.WithTransportCredentials(insecure.NewCredentials()),
 				grpc.WithContextDialer(func(ctx context.Context, _ string) (net.Conn, error) {
 					var d net.Dialer
@@ -77,14 +77,14 @@ func sharedAuthorizationClient(ctx context.Context, target, token string) (proto
 				}),
 				grpc.WithAuthority("localhost"),
 				grpc.WithBlock(),
-			}, opts...)...,
+			), opts...)...,
 		)
 	case "tcp":
 		conn, err = grpc.DialContext(ctx, address,
-			append([]grpc.DialOption{
+			append(internalHostServiceBaseDialOptions(
 				grpc.WithTransportCredentials(insecure.NewCredentials()),
 				grpc.WithBlock(),
-			}, opts...)...,
+			), opts...)...,
 		)
 	case "tls":
 		host, _, splitErr := net.SplitHostPort(address)
@@ -92,14 +92,14 @@ func sharedAuthorizationClient(ctx context.Context, target, token string) (proto
 			return nil, fmt.Errorf("authorization: parse tls target %q: %w", address, splitErr)
 		}
 		conn, err = grpc.DialContext(ctx, address,
-			append([]grpc.DialOption{
+			append(internalHostServiceBaseDialOptions(
 				grpc.WithTransportCredentials(credentials.NewTLS(&tls.Config{
 					MinVersion: tls.VersionTLS12,
 					ServerName: host,
 					NextProtos: []string{"h2"},
 				})),
 				grpc.WithBlock(),
-			}, opts...)...,
+			), opts...)...,
 		)
 	default:
 		return nil, fmt.Errorf("authorization: unsupported transport network %q", network)

--- a/sdk/go/cache.go
+++ b/sdk/go/cache.go
@@ -93,7 +93,7 @@ func Cache(name ...string) (*CacheClient, error) {
 	switch network {
 	case "unix":
 		conn, err = grpc.DialContext(ctx, "passthrough:///localhost",
-			append([]grpc.DialOption{
+			append(internalHostServiceBaseDialOptions(
 				grpc.WithTransportCredentials(insecure.NewCredentials()),
 				grpc.WithContextDialer(func(ctx context.Context, _ string) (net.Conn, error) {
 					var d net.Dialer
@@ -101,14 +101,14 @@ func Cache(name ...string) (*CacheClient, error) {
 				}),
 				grpc.WithAuthority("localhost"),
 				grpc.WithBlock(),
-			}, opts...)...,
+			), opts...)...,
 		)
 	case "tcp":
 		conn, err = grpc.DialContext(ctx, address,
-			append([]grpc.DialOption{
+			append(internalHostServiceBaseDialOptions(
 				grpc.WithTransportCredentials(insecure.NewCredentials()),
 				grpc.WithBlock(),
-			}, opts...)...,
+			), opts...)...,
 		)
 	case "tls":
 		host, _, splitErr := net.SplitHostPort(address)
@@ -116,14 +116,14 @@ func Cache(name ...string) (*CacheClient, error) {
 			return nil, fmt.Errorf("cache: parse tls target %q: %w", address, splitErr)
 		}
 		conn, err = grpc.DialContext(ctx, address,
-			append([]grpc.DialOption{
+			append(internalHostServiceBaseDialOptions(
 				grpc.WithTransportCredentials(credentials.NewTLS(&tls.Config{
 					MinVersion: tls.VersionTLS12,
 					ServerName: host,
 					NextProtos: []string{"h2"},
 				})),
 				grpc.WithBlock(),
-			}, opts...)...,
+			), opts...)...,
 		)
 	default:
 		return nil, fmt.Errorf("cache: unsupported transport network %q", network)

--- a/sdk/go/host_service_transport.go
+++ b/sdk/go/host_service_transport.go
@@ -1,0 +1,10 @@
+package gestalt
+
+import "google.golang.org/grpc"
+
+func internalHostServiceBaseDialOptions(base ...grpc.DialOption) []grpc.DialOption {
+	opts := make([]grpc.DialOption, 0, len(base)+1)
+	opts = append(opts, grpc.WithNoProxy())
+	opts = append(opts, base...)
+	return opts
+}

--- a/sdk/go/indexeddb.go
+++ b/sdk/go/indexeddb.go
@@ -163,7 +163,7 @@ func IndexedDB(name ...string) (*IndexedDBClient, error) {
 	switch network {
 	case "unix":
 		conn, err = grpc.DialContext(ctx, "passthrough:///localhost",
-			append([]grpc.DialOption{
+			append(internalHostServiceBaseDialOptions(
 				grpc.WithTransportCredentials(insecure.NewCredentials()),
 				grpc.WithContextDialer(func(ctx context.Context, _ string) (net.Conn, error) {
 					var d net.Dialer
@@ -171,14 +171,14 @@ func IndexedDB(name ...string) (*IndexedDBClient, error) {
 				}),
 				grpc.WithAuthority("localhost"),
 				grpc.WithBlock(),
-			}, opts...)...,
+			), opts...)...,
 		)
 	case "tcp":
 		conn, err = grpc.DialContext(ctx, address,
-			append([]grpc.DialOption{
+			append(internalHostServiceBaseDialOptions(
 				grpc.WithTransportCredentials(insecure.NewCredentials()),
 				grpc.WithBlock(),
-			}, opts...)...,
+			), opts...)...,
 		)
 	case "tls":
 		host, _, splitErr := net.SplitHostPort(address)
@@ -186,14 +186,14 @@ func IndexedDB(name ...string) (*IndexedDBClient, error) {
 			return nil, fmt.Errorf("indexeddb: parse tls target %q: %w", address, splitErr)
 		}
 		conn, err = grpc.DialContext(ctx, address,
-			append([]grpc.DialOption{
+			append(internalHostServiceBaseDialOptions(
 				grpc.WithTransportCredentials(credentials.NewTLS(&tls.Config{
 					MinVersion: tls.VersionTLS12,
 					ServerName: host,
 					NextProtos: []string{"h2"},
 				})),
 				grpc.WithBlock(),
-			}, opts...)...,
+			), opts...)...,
 		)
 	default:
 		return nil, fmt.Errorf("indexeddb: unsupported transport network %q", network)

--- a/sdk/go/indexeddb_transport_test.go
+++ b/sdk/go/indexeddb_transport_test.go
@@ -227,6 +227,10 @@ func TestTransport_TCPTargetTokenEnv(t *testing.T) {
 
 	t.Setenv(gestalt.EnvIndexedDBSocket, target)
 	t.Setenv(gestalt.IndexedDBSocketTokenEnv(""), token)
+	t.Setenv("http_proxy", "http://127.0.0.1:1")
+	t.Setenv("https_proxy", "http://127.0.0.1:1")
+	t.Setenv("HTTP_PROXY", "http://127.0.0.1:1")
+	t.Setenv("HTTPS_PROXY", "http://127.0.0.1:1")
 	client, err := gestalt.IndexedDB()
 	if err != nil {
 		t.Fatalf("connect tcp indexeddb with token: %v", err)

--- a/sdk/go/invoker.go
+++ b/sdk/go/invoker.go
@@ -89,7 +89,7 @@ func sharedPluginInvokerClient(ctx context.Context, target, token string) (proto
 	switch network {
 	case "unix":
 		conn, err = grpc.DialContext(ctx, "passthrough:///localhost",
-			append([]grpc.DialOption{
+			append(internalHostServiceBaseDialOptions(
 				grpc.WithTransportCredentials(insecure.NewCredentials()),
 				grpc.WithContextDialer(func(ctx context.Context, _ string) (net.Conn, error) {
 					var d net.Dialer
@@ -97,14 +97,14 @@ func sharedPluginInvokerClient(ctx context.Context, target, token string) (proto
 				}),
 				grpc.WithAuthority("localhost"),
 				grpc.WithBlock(),
-			}, opts...)...,
+			), opts...)...,
 		)
 	case "tcp":
 		conn, err = grpc.DialContext(ctx, address,
-			append([]grpc.DialOption{
+			append(internalHostServiceBaseDialOptions(
 				grpc.WithTransportCredentials(insecure.NewCredentials()),
 				grpc.WithBlock(),
-			}, opts...)...,
+			), opts...)...,
 		)
 	case "tls":
 		host, _, splitErr := net.SplitHostPort(address)
@@ -112,14 +112,14 @@ func sharedPluginInvokerClient(ctx context.Context, target, token string) (proto
 			return nil, fmt.Errorf("plugin invoker: parse tls target %q: %w", address, splitErr)
 		}
 		conn, err = grpc.DialContext(ctx, address,
-			append([]grpc.DialOption{
+			append(internalHostServiceBaseDialOptions(
 				grpc.WithTransportCredentials(credentials.NewTLS(&tls.Config{
 					MinVersion: tls.VersionTLS12,
 					ServerName: host,
 					NextProtos: []string{"h2"},
 				})),
 				grpc.WithBlock(),
-			}, opts...)...,
+			), opts...)...,
 		)
 	default:
 		return nil, fmt.Errorf("plugin invoker: unsupported transport network %q", network)

--- a/sdk/go/invoker_transport_test.go
+++ b/sdk/go/invoker_transport_test.go
@@ -67,6 +67,10 @@ func TestTransport_PluginInvokerTCPTargetTokenEnv(t *testing.T) {
 
 	t.Setenv(gestalt.EnvPluginInvokerSocket, "tcp://"+address)
 	t.Setenv(gestalt.EnvPluginInvokerSocketToken, "relay-token-go")
+	t.Setenv("http_proxy", "http://127.0.0.1:1")
+	t.Setenv("https_proxy", "http://127.0.0.1:1")
+	t.Setenv("HTTP_PROXY", "http://127.0.0.1:1")
+	t.Setenv("HTTPS_PROXY", "http://127.0.0.1:1")
 
 	client, err := gestalt.Invoker("parent-token")
 	if err != nil {

--- a/sdk/go/manager_transport.go
+++ b/sdk/go/manager_transport.go
@@ -70,7 +70,7 @@ func dialManagerTransport(ctx context.Context, serviceName, target, token string
 	switch network {
 	case "unix":
 		return grpc.DialContext(ctx, "passthrough:///localhost",
-			append([]grpc.DialOption{
+			append(internalHostServiceBaseDialOptions(
 				grpc.WithTransportCredentials(insecure.NewCredentials()),
 				grpc.WithContextDialer(func(ctx context.Context, _ string) (net.Conn, error) {
 					var d net.Dialer
@@ -78,14 +78,14 @@ func dialManagerTransport(ctx context.Context, serviceName, target, token string
 				}),
 				grpc.WithAuthority("localhost"),
 				grpc.WithBlock(),
-			}, opts...)...,
+			), opts...)...,
 		)
 	case "tcp":
 		return grpc.DialContext(ctx, address,
-			append([]grpc.DialOption{
+			append(internalHostServiceBaseDialOptions(
 				grpc.WithTransportCredentials(insecure.NewCredentials()),
 				grpc.WithBlock(),
-			}, opts...)...,
+			), opts...)...,
 		)
 	case "tls":
 		host, _, err := net.SplitHostPort(address)
@@ -93,14 +93,14 @@ func dialManagerTransport(ctx context.Context, serviceName, target, token string
 			return nil, fmt.Errorf("%s: parse tls target %q: %w", serviceName, address, err)
 		}
 		return grpc.DialContext(ctx, address,
-			append([]grpc.DialOption{
+			append(internalHostServiceBaseDialOptions(
 				grpc.WithTransportCredentials(credentials.NewTLS(&tls.Config{
 					MinVersion: tls.VersionTLS12,
 					ServerName: host,
 					NextProtos: []string{"h2"},
 				})),
 				grpc.WithBlock(),
-			}, opts...)...,
+			), opts...)...,
 		)
 	default:
 		return nil, fmt.Errorf("%s: unsupported transport network %q", serviceName, network)

--- a/sdk/go/s3.go
+++ b/sdk/go/s3.go
@@ -196,7 +196,7 @@ func S3(name ...string) (*S3Client, error) {
 	switch network {
 	case "unix":
 		conn, err = grpc.DialContext(ctx, "passthrough:///localhost",
-			append([]grpc.DialOption{
+			append(internalHostServiceBaseDialOptions(
 				grpc.WithTransportCredentials(insecure.NewCredentials()),
 				grpc.WithContextDialer(func(ctx context.Context, _ string) (net.Conn, error) {
 					var d net.Dialer
@@ -204,14 +204,14 @@ func S3(name ...string) (*S3Client, error) {
 				}),
 				grpc.WithAuthority("localhost"),
 				grpc.WithBlock(),
-			}, opts...)...,
+			), opts...)...,
 		)
 	case "tcp":
 		conn, err = grpc.DialContext(ctx, address,
-			append([]grpc.DialOption{
+			append(internalHostServiceBaseDialOptions(
 				grpc.WithTransportCredentials(insecure.NewCredentials()),
 				grpc.WithBlock(),
-			}, opts...)...,
+			), opts...)...,
 		)
 	case "tls":
 		host, _, splitErr := net.SplitHostPort(address)
@@ -219,14 +219,14 @@ func S3(name ...string) (*S3Client, error) {
 			return nil, fmt.Errorf("s3: parse tls target %q: %w", address, splitErr)
 		}
 		conn, err = grpc.DialContext(ctx, address,
-			append([]grpc.DialOption{
+			append(internalHostServiceBaseDialOptions(
 				grpc.WithTransportCredentials(credentials.NewTLS(&tls.Config{
 					MinVersion: tls.VersionTLS12,
 					ServerName: host,
 					NextProtos: []string{"h2"},
 				})),
 				grpc.WithBlock(),
-			}, opts...)...,
+			), opts...)...,
 		)
 	default:
 		return nil, fmt.Errorf("s3: unsupported transport network %q", network)

--- a/sdk/python/gestalt/_agent.py
+++ b/sdk/python/gestalt/_agent.py
@@ -6,6 +6,7 @@ from urllib import parse as _urlparse
 
 import grpc
 
+from ._grpc_transport import insecure_internal_channel, secure_internal_channel
 from .gen.v1 import agent_pb2 as _pb
 from .gen.v1 import agent_pb2_grpc as _pb_grpc
 
@@ -150,11 +151,11 @@ class _ClientCallDetails(grpc.ClientCallDetails):
 def _host_service_channel(service_name: str, target: str, *, token: str = "") -> Any:
     scheme, address = _parse_host_service_target(service_name, target)
     if scheme == "unix":
-        channel = grpc.insecure_channel(f"unix:{address}")
+        channel = insecure_internal_channel(f"unix:{address}")
     elif scheme == "tcp":
-        channel = grpc.insecure_channel(address)
+        channel = insecure_internal_channel(address)
     elif scheme == "tls":
-        channel = grpc.secure_channel(address, grpc.ssl_channel_credentials())
+        channel = secure_internal_channel(address)
     else:
         raise RuntimeError(f"unsupported {service_name} transport scheme {scheme!r}")
     if token:

--- a/sdk/python/gestalt/_authorization.py
+++ b/sdk/python/gestalt/_authorization.py
@@ -11,6 +11,7 @@ import grpc
 from google.protobuf import empty_pb2 as _empty_pb2
 from google.protobuf import json_format
 
+from ._grpc_transport import insecure_internal_channel, secure_internal_channel
 from .gen.v1 import authorization_pb2 as _authorization_pb2
 from .gen.v1 import authorization_pb2_grpc as _authorization_pb2_grpc
 
@@ -190,7 +191,7 @@ def _authorization_channel(raw_target: str, *, token: str = "") -> grpc.Channel:
                 f"authorization: tcp target {raw_target!r} is missing host:port"
             )
         return _with_authorization_relay_token(
-            grpc.insecure_channel(f"dns:///{address}"),
+            insecure_internal_channel(f"dns:///{address}"),
             token,
         )
     if target.startswith("tls://"):
@@ -200,10 +201,7 @@ def _authorization_channel(raw_target: str, *, token: str = "") -> grpc.Channel:
                 f"authorization: tls target {raw_target!r} is missing host:port"
             )
         return _with_authorization_relay_token(
-            grpc.secure_channel(
-                f"dns:///{address}",
-                grpc.ssl_channel_credentials(),
-            ),
+            secure_internal_channel(f"dns:///{address}"),
             token,
         )
     if target.startswith("unix://"):
@@ -213,7 +211,7 @@ def _authorization_channel(raw_target: str, *, token: str = "") -> grpc.Channel:
                 f"authorization: unix target {raw_target!r} is missing a socket path"
             )
         return _with_authorization_relay_token(
-            grpc.insecure_channel(f"unix:{socket_path}"),
+            insecure_internal_channel(f"unix:{socket_path}"),
             token,
         )
     if "://" in target:
@@ -222,7 +220,7 @@ def _authorization_channel(raw_target: str, *, token: str = "") -> grpc.Channel:
             f"authorization: unsupported target scheme {parsed.scheme!r}"
         )
     return _with_authorization_relay_token(
-        grpc.insecure_channel(f"unix:{target}"),
+        insecure_internal_channel(f"unix:{target}"),
         token,
     )
 

--- a/sdk/python/gestalt/_cache.py
+++ b/sdk/python/gestalt/_cache.py
@@ -11,6 +11,7 @@ from urllib import parse as _urlparse
 import grpc
 from google.protobuf import duration_pb2 as _duration_pb2
 
+from ._grpc_transport import insecure_internal_channel, secure_internal_channel
 from .gen.v1 import cache_pb2 as _pb
 from .gen.v1 import cache_pb2_grpc as _pb_grpc
 
@@ -198,11 +199,11 @@ class _ClientCallDetails(grpc.ClientCallDetails):
 def _cache_channel(target: str, *, token: str = "") -> Any:
     scheme, address = _parse_cache_target(target)
     if scheme == "unix":
-        channel = grpc.insecure_channel(f"unix:{address}")
+        channel = insecure_internal_channel(f"unix:{address}")
     elif scheme == "tcp":
-        channel = grpc.insecure_channel(address)
+        channel = insecure_internal_channel(address)
     elif scheme == "tls":
-        channel = grpc.secure_channel(address, grpc.ssl_channel_credentials())
+        channel = secure_internal_channel(address)
     else:
         raise RuntimeError(f"unsupported cache transport scheme {scheme!r}")
     if token:

--- a/sdk/python/gestalt/_grpc_transport.py
+++ b/sdk/python/gestalt/_grpc_transport.py
@@ -1,0 +1,31 @@
+"""Shared gRPC transport helpers for Gestalt-internal host-service channels."""
+
+from __future__ import annotations
+
+from typing import Any, cast
+
+import grpc as _grpc
+
+grpc: Any = cast(Any, _grpc)
+
+_INTERNAL_CHANNEL_OPTIONS = (("grpc.enable_http_proxy", 0),)
+
+
+def insecure_internal_channel(target: str) -> grpc.Channel:
+    """Return an insecure internal gRPC channel with proxy use disabled."""
+
+    return grpc.insecure_channel(target, options=_INTERNAL_CHANNEL_OPTIONS)
+
+
+def secure_internal_channel(
+    target: str, credentials: grpc.ChannelCredentials | None = None
+) -> grpc.Channel:
+    """Return a TLS internal gRPC channel with proxy use disabled."""
+
+    if credentials is None:
+        credentials = grpc.ssl_channel_credentials()
+    return grpc.secure_channel(
+        target,
+        credentials,
+        options=_INTERNAL_CHANNEL_OPTIONS,
+    )

--- a/sdk/python/gestalt/_indexeddb.py
+++ b/sdk/python/gestalt/_indexeddb.py
@@ -13,6 +13,7 @@ import grpc as _grpc
 from google.protobuf import struct_pb2 as _struct_pb2
 from google.protobuf import timestamp_pb2 as _timestamp_pb2
 
+from ._grpc_transport import insecure_internal_channel, secure_internal_channel
 from .gen.v1 import datastore_pb2 as _pb
 from .gen.v1 import datastore_pb2_grpc as _pb_grpc
 
@@ -372,7 +373,8 @@ def _indexeddb_channel(raw_target: str, *, token: str = "") -> grpc.Channel:
                 f"IndexedDB tcp target {raw_target!r} is missing host:port"
             )
         return _with_indexeddb_relay_token(
-            grpc.insecure_channel(f"dns:///{address}"), token
+            insecure_internal_channel(f"dns:///{address}"),
+            token,
         )
     if target.startswith("tls://"):
         address = target[len("tls://") :].strip()
@@ -381,7 +383,7 @@ def _indexeddb_channel(raw_target: str, *, token: str = "") -> grpc.Channel:
                 f"IndexedDB tls target {raw_target!r} is missing host:port"
             )
         return _with_indexeddb_relay_token(
-            grpc.secure_channel(f"dns:///{address}", grpc.ssl_channel_credentials()),
+            secure_internal_channel(f"dns:///{address}"),
             token,
         )
     if target.startswith("unix://"):
@@ -391,12 +393,16 @@ def _indexeddb_channel(raw_target: str, *, token: str = "") -> grpc.Channel:
                 f"IndexedDB unix target {raw_target!r} is missing a socket path"
             )
         return _with_indexeddb_relay_token(
-            grpc.insecure_channel(f"unix:{socket_path}"), token
+            insecure_internal_channel(f"unix:{socket_path}"),
+            token,
         )
     if "://" in target:
         parsed = _urlparse.urlparse(target)
         raise RuntimeError(f"unsupported IndexedDB target scheme {parsed.scheme!r}")
-    return _with_indexeddb_relay_token(grpc.insecure_channel(f"unix:{target}"), token)
+    return _with_indexeddb_relay_token(
+        insecure_internal_channel(f"unix:{target}"),
+        token,
+    )
 
 
 def _with_indexeddb_relay_token(channel: grpc.Channel, token: str) -> grpc.Channel:

--- a/sdk/python/gestalt/_invoker.py
+++ b/sdk/python/gestalt/_invoker.py
@@ -10,6 +10,7 @@ from google.protobuf import json_format
 from google.protobuf import struct_pb2 as _struct_pb2
 
 from ._api import Response
+from ._grpc_transport import insecure_internal_channel, secure_internal_channel
 from .gen.v1 import plugin_pb2 as _pb
 from .gen.v1 import plugin_pb2_grpc as _pb_grpc
 
@@ -198,7 +199,8 @@ def _plugin_invoker_channel(raw_target: str, *, token: str = "") -> grpc.Channel
                 f"plugin invoker: tcp target {raw_target!r} is missing host:port"
             )
         return _with_plugin_invoker_relay_token(
-            grpc.insecure_channel(f"dns:///{address}"), token
+            insecure_internal_channel(f"dns:///{address}"),
+            token,
         )
     if target.startswith("tls://"):
         address = target[len("tls://") :].strip()
@@ -207,7 +209,7 @@ def _plugin_invoker_channel(raw_target: str, *, token: str = "") -> grpc.Channel
                 f"plugin invoker: tls target {raw_target!r} is missing host:port"
             )
         return _with_plugin_invoker_relay_token(
-            grpc.secure_channel(f"dns:///{address}", grpc.ssl_channel_credentials()),
+            secure_internal_channel(f"dns:///{address}"),
             token,
         )
     if target.startswith("unix://"):
@@ -217,14 +219,18 @@ def _plugin_invoker_channel(raw_target: str, *, token: str = "") -> grpc.Channel
                 f"plugin invoker: unix target {raw_target!r} is missing a socket path"
             )
         return _with_plugin_invoker_relay_token(
-            grpc.insecure_channel(f"unix:{socket_path}"), token
+            insecure_internal_channel(f"unix:{socket_path}"),
+            token,
         )
     if "://" in target:
         parsed = _urlparse.urlparse(target)
         raise RuntimeError(
             f"plugin invoker: unsupported target scheme {parsed.scheme!r}"
         )
-    return _with_plugin_invoker_relay_token(grpc.insecure_channel(f"unix:{target}"), token)
+    return _with_plugin_invoker_relay_token(
+        insecure_internal_channel(f"unix:{target}"),
+        token,
+    )
 
 
 def _with_plugin_invoker_relay_token(

--- a/sdk/python/gestalt/_s3.py
+++ b/sdk/python/gestalt/_s3.py
@@ -14,6 +14,7 @@ from urllib import parse as _urlparse
 import grpc
 from google.protobuf import timestamp_pb2 as _timestamp_pb2
 
+from ._grpc_transport import insecure_internal_channel, secure_internal_channel
 from .gen.v1 import s3_pb2 as _pb
 from .gen.v1 import s3_pb2_grpc as _pb_grpc
 
@@ -352,11 +353,11 @@ class _RelayTokenInterceptor(
 def _s3_channel(target: str, *, token: str = "") -> Any:
     scheme, address = _parse_s3_target(target)
     if scheme == "unix":
-        channel = grpc.insecure_channel(f"unix:{address}")
+        channel = insecure_internal_channel(f"unix:{address}")
     elif scheme == "tcp":
-        channel = grpc.insecure_channel(address)
+        channel = insecure_internal_channel(address)
     elif scheme == "tls":
-        channel = grpc.secure_channel(address, grpc.ssl_channel_credentials())
+        channel = secure_internal_channel(address)
     else:
         raise RuntimeError(f"unsupported s3 transport scheme {scheme!r}")
     token = token.strip()

--- a/sdk/python/tests/test_indexeddb_transport.py
+++ b/sdk/python/tests/test_indexeddb_transport.py
@@ -179,6 +179,51 @@ class TestTCPTarget(unittest.TestCase):
         self.assertEqual(got["value"], "token")
         c.close()
 
+    def test_tcp_target_ignores_proxy_env(self) -> None:
+        token = "relay-token-python"
+        proc, target = _start_tcp_harness(expect_token=token)
+        self.addCleanup(proc.wait)
+        self.addCleanup(proc.kill)
+
+        target_env = "GESTALT_INDEXEDDB_SOCKET"
+        token_env = indexeddb_socket_token_env()
+        previous_target = os.environ.get(target_env)
+        previous_token = os.environ.get(token_env)
+        previous_http_proxy = os.environ.get("http_proxy")
+        previous_https_proxy = os.environ.get("https_proxy")
+
+        def restore_env() -> None:
+            if previous_target is None:
+                os.environ.pop(target_env, None)
+            else:
+                os.environ[target_env] = previous_target
+            if previous_token is None:
+                os.environ.pop(token_env, None)
+            else:
+                os.environ[token_env] = previous_token
+            if previous_http_proxy is None:
+                os.environ.pop("http_proxy", None)
+            else:
+                os.environ["http_proxy"] = previous_http_proxy
+            if previous_https_proxy is None:
+                os.environ.pop("https_proxy", None)
+            else:
+                os.environ["https_proxy"] = previous_https_proxy
+
+        os.environ[target_env] = target
+        os.environ[token_env] = token
+        os.environ["http_proxy"] = "http://127.0.0.1:1"
+        os.environ["https_proxy"] = "http://127.0.0.1:1"
+        self.addCleanup(restore_env)
+
+        c = _client()
+        c.create_object_store("tcp_target_proxy_env")
+        s = c.object_store("tcp_target_proxy_env")
+        s.put({"id": "row-1", "value": "proxy-bypass"})
+        got = s.get("row-1")
+        self.assertEqual(got["value"], "proxy-bypass")
+        c.close()
+
 
 class TestCursorHappyPath(unittest.TestCase):
     def test_cursor_iterates_all_records(self) -> None:

--- a/sdk/python/tests/test_plugin_invoker_transport.py
+++ b/sdk/python/tests/test_plugin_invoker_transport.py
@@ -335,3 +335,45 @@ class PluginInvokerTransportTests(unittest.TestCase):
             else:
                 os.environ[ENV_PLUGIN_INVOKER_SOCKET_TOKEN] = previous_token
             tcp_server.stop(grace=0).wait()
+
+    def test_tcp_target_ignores_proxy_env(self) -> None:
+        tcp_server = grpc.server(futures.ThreadPoolExecutor(max_workers=1))
+        plugin_pb2_grpc.add_PluginInvokerServicer_to_server(
+            _PluginInvokerServicer(),
+            tcp_server,
+        )
+        port = tcp_server.add_insecure_port("127.0.0.1:0")
+        tcp_server.start()
+        previous_socket = os.environ.get(ENV_PLUGIN_INVOKER_SOCKET)
+        previous_token = os.environ.get(ENV_PLUGIN_INVOKER_SOCKET_TOKEN)
+        previous_http_proxy = os.environ.get("http_proxy")
+        previous_https_proxy = os.environ.get("https_proxy")
+        os.environ[ENV_PLUGIN_INVOKER_SOCKET] = f"tcp://127.0.0.1:{port}"
+        os.environ[ENV_PLUGIN_INVOKER_SOCKET_TOKEN] = "relay-token-python"
+        os.environ["http_proxy"] = "http://127.0.0.1:1"
+        os.environ["https_proxy"] = "http://127.0.0.1:1"
+        try:
+            with PluginInvoker("invoke-proxy") as client:
+                response = client.invoke("github", "plain_text")
+
+            self.assertEqual(response.status, 200)
+            self.assertEqual(response.body, "plain response")
+            self.assertEqual(_relay_tokens, ["relay-token-python"])
+        finally:
+            if previous_socket is None:
+                os.environ.pop(ENV_PLUGIN_INVOKER_SOCKET, None)
+            else:
+                os.environ[ENV_PLUGIN_INVOKER_SOCKET] = previous_socket
+            if previous_token is None:
+                os.environ.pop(ENV_PLUGIN_INVOKER_SOCKET_TOKEN, None)
+            else:
+                os.environ[ENV_PLUGIN_INVOKER_SOCKET_TOKEN] = previous_token
+            if previous_http_proxy is None:
+                os.environ.pop("http_proxy", None)
+            else:
+                os.environ["http_proxy"] = previous_http_proxy
+            if previous_https_proxy is None:
+                os.environ.pop("https_proxy", None)
+            else:
+                os.environ["https_proxy"] = previous_https_proxy
+            tcp_server.stop(grace=0).wait()


### PR DESCRIPTION
## Summary
Internal host-service SDK channels should never inherit process-level HTTP proxy settings. This change makes the official Go and Python SDK transports bypass proxies for `GESTALT_*_SOCKET` channels, which prevents hosted providers from accidentally proxying relay traffic back into Gestalt.

## Interfaces
- Go internal host-service transports now add `grpc.WithNoProxy()`
- Python internal host-service transports now add channel option `("grpc.enable_http_proxy", 0)`
- No public config schema changes

## Examples
```go
os.Setenv(gestalt.EnvIndexedDBSocket, "tls://valon.tools:443")
os.Setenv("http_proxy", "http://127.0.0.1:1")
client, err := gestalt.IndexedDB()
// client still connects through the Gestalt relay instead of the dead proxy
```

```python
os.environ["GESTALT_PLUGIN_INVOKER_SOCKET"] = "tls://valon.tools:443"
os.environ["http_proxy"] = "http://127.0.0.1:1"
with gestalt.PluginInvoker("invoke-token") as client:
    response = client.invoke("github", "plain_text")
# the internal host-service channel bypasses the proxy
```

## Validation
- `cd sdk/go && go test ./...`
- `cd sdk/python && uv run python -m unittest tests.test_indexeddb_transport tests.test_plugin_invoker_transport tests.test_cache_transport tests.test_agent_transport tests.test_s3_transport`
- `cd sdk/python && uv run ruff check gestalt/_grpc_transport.py gestalt/_indexeddb.py gestalt/_cache.py gestalt/_authorization.py gestalt/_invoker.py gestalt/_s3.py gestalt/_agent.py tests/test_indexeddb_transport.py tests/test_plugin_invoker_transport.py tests/test_cache_transport.py tests/test_agent_transport.py tests/test_s3_transport.py`
- `cd sdk/python && uv run ty check gestalt/_grpc_transport.py gestalt/_indexeddb.py gestalt/_cache.py gestalt/_authorization.py gestalt/_invoker.py gestalt/_s3.py gestalt/_agent.py tests/test_indexeddb_transport.py tests/test_plugin_invoker_transport.py tests/test_cache_transport.py tests/test_agent_transport.py tests/test_s3_transport.py`
