### PR TITLE
provider validate: label startup metadata failures across runtimes

### DIFF
--- a/gestaltd/internal/providerhost/provider_client.go
+++ b/gestaltd/internal/providerhost/provider_client.go
@@ -127,12 +127,12 @@ func getIntegrationProviderSupportWithRetry(ctx context.Context, client proto.In
 			return &integrationProviderSupport{}, nil
 		}
 		if status.Code(err) != codes.Unavailable {
-			return nil, err
+			return nil, fmt.Errorf("get provider metadata: %w", err)
 		}
 
 		select {
 		case <-ctx.Done():
-			return nil, err
+			return nil, fmt.Errorf("get provider metadata: %w", err)
 		case <-ticker.C:
 		}
 	}

--- a/gestaltd/internal/providerhost/provider_test.go
+++ b/gestaltd/internal/providerhost/provider_test.go
@@ -13,6 +13,10 @@ import (
 	"github.com/valon-technologies/gestalt/server/core/catalog"
 	"github.com/valon-technologies/gestalt/server/internal/invocation"
 	"github.com/valon-technologies/gestalt/server/internal/principal"
+	"google.golang.org/grpc"
+	"google.golang.org/grpc/codes"
+	"google.golang.org/grpc/status"
+	"google.golang.org/protobuf/types/known/emptypb"
 )
 
 type roundTripProvider struct{}
@@ -404,5 +408,70 @@ func TestRemoteProviderManualAuthOnly(t *testing.T) {
 	}
 	if cat.Operations[0].Transport != catalog.TransportPlugin {
 		t.Fatalf("Transport = %q, want %q", cat.Operations[0].Transport, catalog.TransportPlugin)
+	}
+}
+
+type metadataFailureProviderServer struct {
+	proto.UnimplementedIntegrationProviderServer
+}
+
+func (s *metadataFailureProviderServer) GetMetadata(context.Context, *emptypb.Empty) (*proto.ProviderMetadata, error) {
+	return nil, status.Error(codes.Unknown, "provider metadata: metadata exploded")
+}
+
+type unavailableMetadataProviderServer struct {
+	cancel context.CancelFunc
+}
+
+func (c *unavailableMetadataProviderServer) GetMetadata(context.Context, *emptypb.Empty, ...grpc.CallOption) (*proto.ProviderMetadata, error) {
+	if c.cancel != nil {
+		c.cancel()
+	}
+	return nil, status.Error(codes.Unavailable, "metadata warming up")
+}
+
+func (*unavailableMetadataProviderServer) StartProvider(context.Context, *proto.StartProviderRequest, ...grpc.CallOption) (*proto.StartProviderResponse, error) {
+	panic("unexpected StartProvider call")
+}
+
+func (*unavailableMetadataProviderServer) Execute(context.Context, *proto.ExecuteRequest, ...grpc.CallOption) (*proto.OperationResult, error) {
+	panic("unexpected Execute call")
+}
+
+func (*unavailableMetadataProviderServer) ResolveHTTPSubject(context.Context, *proto.ResolveHTTPSubjectRequest, ...grpc.CallOption) (*proto.ResolveHTTPSubjectResponse, error) {
+	panic("unexpected ResolveHTTPSubject call")
+}
+
+func (*unavailableMetadataProviderServer) GetSessionCatalog(context.Context, *proto.GetSessionCatalogRequest, ...grpc.CallOption) (*proto.GetSessionCatalogResponse, error) {
+	panic("unexpected GetSessionCatalog call")
+}
+
+func (*unavailableMetadataProviderServer) PostConnect(context.Context, *proto.PostConnectRequest, ...grpc.CallOption) (*proto.PostConnectResponse, error) {
+	panic("unexpected PostConnect call")
+}
+
+func TestNewRemoteProviderLabelsMetadataFailures(t *testing.T) {
+	t.Parallel()
+
+	client := newIntegrationProviderClient(t, &metadataFailureProviderServer{})
+	_, err := NewRemoteProvider(context.Background(), client, roundTripStaticSpec(), nil)
+	if err == nil {
+		t.Fatal("expected NewRemoteProvider to fail")
+	}
+	if got := err.Error(); got != `get provider metadata: rpc error: code = Unknown desc = provider metadata: metadata exploded` {
+		t.Fatalf("NewRemoteProvider error = %q", got)
+	}
+}
+
+func TestGetIntegrationProviderSupportWithRetryLabelsContextDoneFailures(t *testing.T) {
+	t.Parallel()
+
+	ctx, cancel := context.WithCancel(context.Background())
+	_, err := getIntegrationProviderSupportWithRetry(ctx, &unavailableMetadataProviderServer{cancel: cancel})
+	if err == nil {
+		t.Fatal("expected getIntegrationProviderSupportWithRetry to fail")
+	}
+	if got := err.Error(); got != `get provider metadata: rpc error: code = Unavailable desc = metadata warming up` {
+		t.Fatalf("getIntegrationProviderSupportWithRetry error = %q", got)
 	}
 }

--- a/sdk/python/gestalt/_runtime.py
+++ b/sdk/python/gestalt/_runtime.py
@@ -624,6 +624,7 @@ def _provider_servicer(*, plugin: Plugin) -> Any:
     _ensure_grpc_runtime()
 
     class ProviderServicer(plugin_pb2_grpc.IntegrationProviderServicer):
+        @_grpc_handler("provider metadata")
         def GetMetadata(self, _request: Any, _context: Any) -> Any:
             return plugin_pb2.ProviderMetadata(
                 supports_session_catalog=plugin.supports_session_catalog(),
@@ -747,6 +748,7 @@ def _runtime_servicer(*, provider: PluginProvider, kind: ProviderKind) -> Any:
     _ensure_grpc_runtime()
 
     class RuntimeServicer(runtime_pb2_grpc.ProviderLifecycleServicer):
+        @_grpc_handler("provider identity")
         def GetProviderIdentity(self, _request: Any, _context: Any) -> Any:
             metadata = _provider_metadata(provider=provider, kind=kind)
             return runtime_pb2.ProviderIdentity(

--- a/sdk/python/tests/test_runtime.py
+++ b/sdk/python/tests/test_runtime.py
@@ -723,6 +723,21 @@ class MainEntrypointTests(unittest.TestCase):
             "provider does not support post connect",
         )
 
+    def test_provider_servicer_labels_metadata_failures(self) -> None:
+        class BrokenMetadataPlugin(Plugin):
+            def supports_post_connect(self) -> bool:
+                raise RuntimeError("metadata exploded")
+
+        plugin = BrokenMetadataPlugin("source-name")
+        servicer = _runtime._provider_servicer(plugin=plugin)
+        context = AbortContext()
+
+        with self.assertRaisesRegex(AbortCalled, "provider metadata: metadata exploded"):
+            servicer.GetMetadata(mock.Mock(), context)
+
+        self.assertEqual(context.code(), grpc.StatusCode.UNKNOWN)
+        self.assertEqual(context.details, "provider metadata: metadata exploded")
+
 
 class AuthenticationRuntimeTests(unittest.TestCase):
     class StubAuthenticationProvider(
@@ -1094,6 +1109,40 @@ class CacheRuntimeTests(unittest.TestCase):
                 "b": b"two",
             },
         )
+
+    def test_runtime_servicer_labels_provider_identity_failures(self) -> None:
+        class BrokenWarningsProvider(CacheProvider, WarningsProvider):
+            def warnings(self) -> list[str]:
+                raise RuntimeError("identity exploded")
+
+            def get(self, key: str) -> bytes | None:
+                return None
+
+            def set(
+                self,
+                key: str,
+                value: bytes,
+                ttl: dt.timedelta | None = None,
+            ) -> None:
+                return None
+
+            def delete(self, key: str) -> bool:
+                return False
+
+            def touch(self, key: str, ttl: dt.timedelta) -> bool:
+                return False
+
+        runtime_servicer = _runtime._runtime_servicer(
+            provider=BrokenWarningsProvider(),
+            kind=ProviderKind.CACHE,
+        )
+        context = AbortContext()
+
+        with self.assertRaisesRegex(AbortCalled, "provider identity: identity exploded"):
+            runtime_servicer.GetProviderIdentity(mock.Mock(), context)
+
+        self.assertEqual(context.code(), grpc.StatusCode.UNKNOWN)
+        self.assertEqual(context.details, "provider identity: identity exploded")
 
 
 class S3RuntimeTests(unittest.TestCase):

--- a/sdk/typescript/src/runtime.ts
+++ b/sdk/typescript/src/runtime.ts
@@ -435,16 +435,20 @@ export function createRuntimeService(
 ): Partial<ServiceImpl<typeof ProviderLifecycle>> {
   return {
     async getProviderIdentity() {
-      return create(ProviderIdentitySchema, {
-        kind: providerRuntimeEntry(provider.kind).protoKind,
-        name: provider.name,
-        displayName: provider.displayName,
-        description: provider.description,
-        version: provider.version,
-        warnings: await provider.warnings(),
-        minProtocolVersion: CURRENT_PROTOCOL_VERSION,
-        maxProtocolVersion: CURRENT_PROTOCOL_VERSION,
-      });
+      try {
+        return create(ProviderIdentitySchema, {
+          kind: providerRuntimeEntry(provider.kind).protoKind,
+          name: provider.name,
+          displayName: provider.displayName,
+          description: provider.description,
+          version: provider.version,
+          warnings: await provider.warnings(),
+          minProtocolVersion: CURRENT_PROTOCOL_VERSION,
+          maxProtocolVersion: CURRENT_PROTOCOL_VERSION,
+        });
+      } catch (error) {
+        throw providerRuntimeError("provider identity", error);
+      }
     },
     async configureProvider(request: ConfigureProviderRequest) {
       assertProtocolVersion(request.protocolVersion);
@@ -454,10 +458,7 @@ export function createRuntimeService(
           objectFromUnknown(request.config),
         );
       } catch (error) {
-        throw new ConnectError(
-          `configure provider: ${errorMessage(error)}`,
-          Code.Unknown,
-        );
+        throw providerRuntimeError("configure provider", error);
       }
       return create(ConfigureProviderResponseSchema, {
         protocolVersion: CURRENT_PROTOCOL_VERSION,
@@ -496,27 +497,31 @@ export function createProviderService(
     throw new Error("provider is not a plugin provider");
   }
   return {
-    getMetadata() {
-      return create(ProviderMetadataSchema, {
-        name: provider.name,
-        displayName: provider.displayName,
-        description: provider.description,
-        connectionMode: connectionModeToProtoValue(
-          provider.connectionMode,
-        ) as ProviderConnectionMode,
-        authTypes: [...provider.authTypes],
-        connectionParams: Object.fromEntries(
-          Object.entries(provider.connectionParams).map(([key, value]) => [
-            key,
-            connectionParamToProto(value),
-          ]),
-        ),
-        staticCatalog: catalogToProto(provider.staticCatalog()),
-        supportsSessionCatalog: provider.supportsSessionCatalog(),
-        supportsPostConnect: provider.supportsPostConnect(),
-        minProtocolVersion: CURRENT_PROTOCOL_VERSION,
-        maxProtocolVersion: CURRENT_PROTOCOL_VERSION,
-      });
+    async getMetadata() {
+      try {
+        return create(ProviderMetadataSchema, {
+          name: provider.name,
+          displayName: provider.displayName,
+          description: provider.description,
+          connectionMode: connectionModeToProtoValue(
+            provider.connectionMode,
+          ) as ProviderConnectionMode,
+          authTypes: [...provider.authTypes],
+          connectionParams: Object.fromEntries(
+            Object.entries(provider.connectionParams).map(([key, value]) => [
+              key,
+              connectionParamToProto(value),
+            ]),
+          ),
+          staticCatalog: catalogToProto(provider.staticCatalog()),
+          supportsSessionCatalog: provider.supportsSessionCatalog(),
+          supportsPostConnect: provider.supportsPostConnect(),
+          minProtocolVersion: CURRENT_PROTOCOL_VERSION,
+          maxProtocolVersion: CURRENT_PROTOCOL_VERSION,
+        });
+      } catch (error) {
+        throw providerRuntimeError("provider metadata", error);
+      }
     },
     async startProvider(request: StartProviderRequest) {
       assertProtocolVersion(request.protocolVersion);
@@ -526,10 +531,7 @@ export function createProviderService(
           objectFromUnknown(request.config),
         );
       } catch (error) {
-        throw new ConnectError(
-          `configure provider: ${errorMessage(error)}`,
-          Code.Unknown,
-        );
+        throw providerRuntimeError("configure provider", error);
       }
       return create(StartProviderResponseSchema, {
         protocolVersion: CURRENT_PROTOCOL_VERSION,
@@ -906,6 +908,10 @@ function providerRuntimeEntry(
     );
   }
   return entry;
+}
+
+function providerRuntimeError(label: string, error: unknown): ConnectError {
+  return new ConnectError(`${label}: ${errorMessage(error)}`, Code.Unknown);
 }
 
 function resolveLoadedProvider(

--- a/sdk/typescript/tests/runtime.test.ts
+++ b/sdk/typescript/tests/runtime.test.ts
@@ -652,6 +652,33 @@ test("integration provider service exposes metadata, configure, execute, and ses
   });
 });
 
+test("integration provider service labels metadata failures", async () => {
+  const plugin = definePlugin({
+    operations: [
+      {
+        id: "noop",
+        handler() {
+          return { ok: true };
+        },
+      },
+    ],
+  });
+  (plugin as any).supportsPostConnect = () => {
+    throw new Error("metadata exploded");
+  };
+
+  try {
+    await (createProviderService(plugin).getMetadata as any)();
+    throw new Error("expected getMetadata to fail");
+  } catch (error) {
+    expect(error).toBeInstanceOf(ConnectError);
+    expect((error as ConnectError).code).toBe(Code.Unknown);
+    expect((error as ConnectError).message).toContain(
+      "provider metadata: metadata exploded",
+    );
+  }
+});
+
 test("integration provider service resolves hosted HTTP subjects through the plugin hook", async () => {
   let seenRequest:
     | import("../src/index.ts").HTTPSubjectRequest
@@ -1051,6 +1078,35 @@ test("authentication provider supports runtime metadata, login flows, and token 
     }),
   );
   expect(validated.email).toBe("api-token@example.com");
+});
+
+test("runtime lifecycle labels provider identity failures", async () => {
+  const plugin = definePlugin({
+    operations: [
+      {
+        id: "noop",
+        handler() {
+          return { ok: true };
+        },
+      },
+    ],
+  });
+  (plugin as any).warnings = async () => {
+    throw new Error("identity exploded");
+  };
+
+  try {
+    await (createRuntimeService(plugin).getProviderIdentity as any)(
+      create(EmptySchema, {}),
+    );
+    throw new Error("expected getProviderIdentity to fail");
+  } catch (error) {
+    expect(error).toBeInstanceOf(ConnectError);
+    expect((error as ConnectError).code).toBe(Code.Unknown);
+    expect((error as ConnectError).message).toContain(
+      "provider identity: identity exploded",
+    );
+  }
 });
 
 test("cache provider supports runtime metadata and cache operations", async () => {


### PR DESCRIPTION
## Summary
Startup validation failures during remote provider setup were still uneven across SDKs. `gestaltd provider validate --path ./plugin` could collapse some startup metadata/identity failures into generic internal errors, especially for TypeScript and Python providers.

This PR keeps the behavior language-agnostic where the host still has context, and fixes the missing SDK/runtime wrappers where errors were being sanitized before they crossed the boundary.

## Interfaces
- `gestaltd provider validate --path ./plugin` now preserves startup phase context for provider metadata and provider identity failures.
- Host-side remote provider setup now prefixes metadata fetch failures with `get provider metadata`.
- TypeScript and Python runtimes now return labeled `provider metadata: ...` / `provider identity: ...` errors instead of generic internal failures.

## Examples
```sh
gestaltd provider validate --path ./plugin
```

Before:
```text
rpc error: code = Internal desc = internal error
```

After:
```text
get provider metadata: rpc error: code = Unknown desc = provider metadata: metadata exploded
```

And for the real TypeScript dogfood case:
```text
get provider metadata: rpc error: code = Unknown desc = provider metadata: provider2.supportsPostConnect is not a function
```

## Tests
- `go test ./internal/providerhost -run 'Test(RemoteProviderRoundTrip|RemoteProviderManualAuthOnly|NewRemoteProviderLabelsMetadataFailures)$' -count=1`
- `cd sdk/typescript && bun test ./tests/runtime.test.ts`
- `cd sdk/python && python3 -m unittest tests.test_runtime`
- `golangci-lint run ./internal/providerhost`

## Notes
- This does not broaden `provider validate` semantics.
- Go and Rust already had better startup error propagation; this PR brings the host contract and the TypeScript/Python runtimes into line.