### PR TITLE
typescript runtime: preserve legacy plugin hook compatibility

### DIFF
--- a/sdk/typescript/src/runtime.ts
+++ b/sdk/typescript/src/runtime.ts
@@ -67,7 +67,7 @@ import {
 } from "../gen/v1/runtime_pb.ts";
 import { S3 as S3Service } from "../gen/v1/s3_pb.ts";
 import { WorkflowProvider as WorkflowProviderService } from "../gen/v1/workflow_pb.ts";
-import { errorMessage, type Request } from "./api.ts";
+import { errorMessage, type Request, type Subject } from "./api.ts";
 import {
   AgentProvider,
   createAgentProviderService,
@@ -514,8 +514,8 @@ export function createProviderService(
             ]),
           ),
           staticCatalog: catalogToProto(provider.staticCatalog()),
-          supportsSessionCatalog: provider.supportsSessionCatalog(),
-          supportsPostConnect: provider.supportsPostConnect(),
+          supportsSessionCatalog: providerSupportsSessionCatalog(provider),
+          supportsPostConnect: providerSupportsPostConnect(provider),
           minProtocolVersion: CURRENT_PROTOCOL_VERSION,
           maxProtocolVersion: CURRENT_PROTOCOL_VERSION,
         });
@@ -555,7 +555,8 @@ export function createProviderService(
     async resolveHTTPSubject(request: ProtoResolveHTTPSubjectRequest) {
       let subject;
       try {
-        subject = await provider.resolveHTTPSubject(
+        subject = await providerResolveHTTPSubject(
+          provider,
           providerHTTPSubjectRequest(request.request),
           providerHTTPSubjectResolutionContext(request.context),
         );
@@ -585,7 +586,8 @@ export function createProviderService(
     async getSessionCatalog(request: GetSessionCatalogRequest) {
       let catalog: Catalog | Record<string, unknown> | null | undefined;
       try {
-        catalog = await provider.catalogForRequest(
+        catalog = await providerCatalogForRequest(
+          provider,
           providerRequest(
             request.token,
             request.connectionParams,
@@ -609,7 +611,7 @@ export function createProviderService(
       });
     },
     async postConnect(request) {
-      if (!provider.supportsPostConnect()) {
+      if (!providerSupportsPostConnect(provider)) {
         throw new ConnectError(
           "provider does not support post connect",
           Code.Unimplemented,
@@ -617,7 +619,8 @@ export function createProviderService(
       }
       let metadata: Record<string, string> | null | undefined;
       try {
-        metadata = await provider.postConnectMetadata(
+        metadata = await providerPostConnectMetadata(
+          provider,
           providerConnectedToken(request.token),
         );
       } catch (error) {
@@ -912,6 +915,78 @@ function providerRuntimeEntry(
 
 function providerRuntimeError(label: string, error: unknown): ConnectError {
   return new ConnectError(`${label}: ${errorMessage(error)}`, Code.Unknown);
+}
+
+function providerSupportsSessionCatalog(provider: LoadedProvider): boolean {
+  const candidate = provider as LoadedProvider & {
+    supportsSessionCatalog?: () => boolean;
+    sessionCatalogHandler?: unknown;
+    catalogForRequest?: (
+      request: Request,
+    ) => Promise<Catalog | Record<string, unknown> | null | undefined>;
+  };
+  if (typeof candidate.supportsSessionCatalog === "function") {
+    return candidate.supportsSessionCatalog();
+  }
+  if (Object.prototype.hasOwnProperty.call(candidate, "sessionCatalogHandler")) {
+    return candidate.sessionCatalogHandler !== undefined;
+  }
+  return typeof candidate.catalogForRequest === "function";
+}
+
+function providerSupportsPostConnect(provider: LoadedProvider): boolean {
+  const candidate = provider as LoadedProvider & {
+    supportsPostConnect?: () => boolean;
+    postConnectHandler?: unknown;
+    postConnectMetadata?: (
+      token: ConnectedToken,
+    ) => Promise<Record<string, string> | null | undefined>;
+  };
+  if (typeof candidate.supportsPostConnect === "function") {
+    return candidate.supportsPostConnect();
+  }
+  if (Object.prototype.hasOwnProperty.call(candidate, "postConnectHandler")) {
+    return candidate.postConnectHandler !== undefined;
+  }
+  return typeof candidate.postConnectMetadata === "function";
+}
+
+async function providerCatalogForRequest(
+  provider: LoadedProvider,
+  request: Request,
+): Promise<Catalog | Record<string, unknown> | null | undefined> {
+  const candidate = provider as LoadedProvider & {
+    catalogForRequest?: (
+      request: Request,
+    ) => Promise<Catalog | Record<string, unknown> | null | undefined>;
+  };
+  return await candidate.catalogForRequest?.(request);
+}
+
+async function providerPostConnectMetadata(
+  provider: LoadedProvider,
+  token: ConnectedToken,
+): Promise<Record<string, string> | null | undefined> {
+  const candidate = provider as LoadedProvider & {
+    postConnectMetadata?: (
+      token: ConnectedToken,
+    ) => Promise<Record<string, string> | null | undefined>;
+  };
+  return await candidate.postConnectMetadata?.(token);
+}
+
+async function providerResolveHTTPSubject(
+  provider: LoadedProvider,
+  request: HTTPSubjectRequest,
+  context: HTTPSubjectResolutionContext,
+): Promise<Subject | null | undefined> {
+  const candidate = provider as LoadedProvider & {
+    resolveHTTPSubject?: (
+      request: HTTPSubjectRequest,
+      context: HTTPSubjectResolutionContext,
+    ) => Promise<Subject | null | undefined>;
+  };
+  return await candidate.resolveHTTPSubject?.(request, context);
 }
 
 function resolveLoadedProvider(

--- a/sdk/typescript/tests/runtime.test.ts
+++ b/sdk/typescript/tests/runtime.test.ts
@@ -679,6 +679,113 @@ test("integration provider service labels metadata failures", async () => {
   }
 });
 
+test("integration provider service tolerates legacy plugin objects without newer optional hooks", async () => {
+  const plugin = definePlugin({
+    operations: [
+      {
+        id: "noop",
+        handler() {
+          return { ok: true };
+        },
+      },
+    ],
+  });
+  (plugin as any).supportsSessionCatalog = undefined;
+  (plugin as any).supportsPostConnect = undefined;
+  (plugin as any).resolveHTTPSubject = undefined;
+
+  const service = createProviderService(plugin as any);
+  const metadata = await (service.getMetadata as any)();
+  expect(metadata.supportsSessionCatalog).toBe(false);
+  expect(metadata.supportsPostConnect).toBe(false);
+
+  await expectConnectCode(
+    (service.postConnect as any)(
+      create(PostConnectRequestSchema, {
+        token: {
+          id: "tok-123",
+          integration: "legacy-plugin",
+        },
+      }),
+    ),
+    Code.Unimplemented,
+  );
+
+  const unresolved = await (service.resolveHTTPSubject as any)(
+    create(ResolveHTTPSubjectRequestSchema, {
+      request: create(HTTPSubjectRequestSchema, {
+        binding: "command",
+      }),
+    }),
+  );
+  expect(unresolved.subject).toBeUndefined();
+});
+
+test("integration provider service infers optional hooks for prototype-backed structural plugin objects", async () => {
+  class StructuralPlugin {
+    kind = "integration" as const;
+    name = "structural-plugin";
+    displayName = "Structural Plugin";
+    description = "structural plugin";
+    version = "1.0.0";
+    connectionMode = "unspecified" as const;
+    authTypes: string[] = [];
+    connectionParams: Record<string, unknown> = {};
+
+    staticCatalog() {
+      return {
+        name: "structural-plugin",
+        operations: [],
+      };
+    }
+
+    async execute() {
+      return {
+        status: 200,
+        body: "{}",
+      };
+    }
+
+    async catalogForRequest() {
+      return {
+        name: "structural-session",
+        operations: [],
+      };
+    }
+
+    async postConnectMetadata() {
+      return {
+        structural: "true",
+      };
+    }
+  }
+
+  const service = createProviderService(new StructuralPlugin() as any);
+
+  const metadata = await (service.getMetadata as any)();
+  expect(metadata.supportsSessionCatalog).toBe(true);
+  expect(metadata.supportsPostConnect).toBe(true);
+
+  const sessionCatalog = await (service.getSessionCatalog as any)(
+    create(GetSessionCatalogRequestSchema, {
+      token: "token-123",
+    }),
+  );
+  expect(sessionCatalog.catalog?.name).toBe("structural-session");
+
+  const postConnect = await (service.postConnect as any)(
+    create(PostConnectRequestSchema, {
+      token: {
+        id: "tok-123",
+        integration: "structural-plugin",
+      },
+    }),
+  );
+  expect(postConnect.metadata).toEqual({
+    structural: "true",
+  });
+});
+
 test("integration provider service resolves hosted HTTP subjects through the plugin hook", async () => {
   let seenRequest:
     | import("../src/index.ts").HTTPSubjectRequest


### PR DESCRIPTION
## Summary
`gestaltd provider validate` was still failing on older TypeScript plugins whose exported plugin objects predated newer optional hook probes like `supportsPostConnect()`.

The concrete dogfood case was:
```text
get provider metadata: rpc error: code = Unknown desc = provider metadata: provider2.supportsPostConnect is not a function
```

This PR fixes the TypeScript runtime compatibility layer so it can safely adapt:
- legacy SDK class instances
- prototype-backed structural plugin objects
- current SDK plugin instances

without misreporting optional hook support.

## Interfaces
- `gestaltd provider validate --path ./plugin` now accepts legacy TypeScript plugin objects that omit newer optional hook probes like `supportsPostConnect()`.
- `createProviderService()` now infers optional hook support for legacy SDK class instances and structural plugin objects without treating current SDK class instances as if unsupported hooks were enabled.

## Examples
```sh
gestaltd provider validate --path /Users/hugh/src/toolshed/valon-tools/deploy/brain/plugin
```

Before:
```text
get provider metadata: rpc error: code = Unknown desc = provider metadata: provider2.supportsPostConnect is not a function
```

After:
```text
INFO loaded provider provider=brain operations=33
INFO provider validated kind=plugin manifest=/Users/hugh/src/toolshed/valon-tools/deploy/brain/plugin/manifest.yaml
INFO config ok
```

## Tests
- `cd sdk/typescript && bun test ./tests/runtime.test.ts`
- `cd gestaltd && go run ./cmd/gestaltd provider validate --path /Users/hugh/src/toolshed/valon-tools/deploy/brain/plugin`

## Notes
The compatibility rule is:
- prefer explicit `supportsSessionCatalog()` / `supportsPostConnect()` probes when present
- otherwise, use SDK-private handler fields when they exist to avoid false positives on current SDK class instances
- otherwise, fall back to hook-method presence for structural plugin objects