### PR TITLE
cli: add interactive gestalt agent

### DIFF
--- a/gestalt/cli/src/cli.rs
+++ b/gestalt/cli/src/cli.rs
@@ -65,11 +65,8 @@ pub enum Commands {
         command: WorkflowCommands,
     },
 
-    /// Manage global agent sessions and turns
-    Agent {
-        #[command(subcommand)]
-        command: AgentCommands,
-    },
+    /// Run an interactive agent session or inspect agent resources
+    Agent(AgentArgs),
 }
 
 #[derive(Subcommand)]
@@ -217,6 +214,36 @@ pub enum WorkflowCommands {
         #[command(subcommand)]
         command: WorkflowRunCommands,
     },
+}
+
+#[derive(Args)]
+pub struct AgentArgs {
+    #[command(subcommand)]
+    pub command: Option<AgentCommands>,
+
+    /// Resume an existing agent session
+    #[arg(long)]
+    pub session: Option<String>,
+
+    /// Agent provider name for a new session
+    #[arg(long)]
+    pub provider: Option<String>,
+
+    /// Model name override
+    #[arg(long)]
+    pub model: Option<String>,
+
+    /// Add a system message to the first turn created in this CLI session
+    #[arg(long = "system")]
+    pub system: Vec<String>,
+
+    /// Start with one or more user messages before entering the prompt loop
+    #[arg(long = "message")]
+    pub messages: Vec<String>,
+
+    /// Add a tool in plugin:operation form to each turn
+    #[arg(long = "tool", value_parser = AgentToolArg::parse)]
+    pub tools: Vec<AgentToolArg>,
 }
 
 #[derive(Subcommand)]

--- a/gestalt/cli/src/commands/agents.rs
+++ b/gestalt/cli/src/commands/agents.rs
@@ -1,17 +1,23 @@
 use anyhow::{Context, Result, bail};
+use serde::{Deserialize, de::DeserializeOwned};
 use serde_json::{Map, Value, json};
-use std::io;
+use std::io::{self, Write};
+use std::thread;
+use std::time::Duration;
 
 use crate::api::ApiClient;
 use crate::cli::{
-    AgentSessionCreateArgs, AgentSessionUpdateArgs, AgentToolArg, AgentTurnCreateArgs,
+    AgentArgs, AgentSessionCreateArgs, AgentSessionUpdateArgs, AgentToolArg, AgentTurnCreateArgs,
     AgentTurnEventListArgs, AgentTurnEventStreamArgs,
 };
+use crate::interactive::{InputPrompt, prompt_confirm, prompt_input};
 use crate::output::{self, Format};
 use crate::params;
 
 const SESSIONS_PATH: &str = "/api/v1/agent/sessions";
 const TURNS_PATH: &str = "/api/v1/agent/turns";
+const DEFAULT_EVENT_PAGE_SIZE: u32 = 100;
+const EVENT_POLL_INTERVAL: Duration = Duration::from_millis(250);
 
 pub fn create_session(
     client: &ApiClient,
@@ -126,6 +132,521 @@ pub fn stream_turn_events(client: &ApiClient, args: &AgentTurnEventStreamArgs) -
     let mut stdout = io::stdout().lock();
     io::copy(&mut resp, &mut stdout).context("failed to read agent turn event stream")?;
     Ok(())
+}
+
+pub fn run_interactive(client: &ApiClient, args: &AgentArgs) -> Result<()> {
+    let mut shell = AgentShell::connect(client, args)?;
+    shell.print_banner()?;
+
+    if !args.messages.is_empty() {
+        shell.submit_turn(client, args.messages.clone())?;
+    }
+
+    loop {
+        let Some(line) = prompt_agent_line()? else {
+            return Ok(());
+        };
+        let trimmed = line.trim();
+        if trimmed.is_empty() {
+            continue;
+        }
+        match trimmed {
+            "/quit" | "/exit" => return Ok(()),
+            "/help" => {
+                eprintln!("Commands: /help, /session, /quit");
+                continue;
+            }
+            "/session" => {
+                eprintln!("session {}", shell.session.id);
+                continue;
+            }
+            _ => {}
+        }
+        shell.submit_turn(client, vec![trimmed.to_string()])?;
+    }
+}
+
+#[derive(Debug, Clone, Deserialize)]
+#[serde(rename_all = "camelCase")]
+struct AgentSessionInfo {
+    id: String,
+    provider: String,
+    #[serde(default)]
+    model: String,
+}
+
+#[derive(Debug, Clone, Deserialize)]
+#[serde(rename_all = "camelCase")]
+struct AgentTurnInfo {
+    id: String,
+    #[serde(default)]
+    status: String,
+    #[serde(default)]
+    output_text: String,
+    #[serde(default)]
+    status_message: String,
+}
+
+#[derive(Debug, Clone, Deserialize)]
+#[serde(rename_all = "camelCase")]
+struct AgentTurnEventInfo {
+    seq: i64,
+    #[serde(rename = "type")]
+    event_type: String,
+    #[serde(default)]
+    data: Map<String, Value>,
+}
+
+#[derive(Debug, Clone, Deserialize)]
+#[serde(rename_all = "camelCase")]
+struct AgentInteractionInfo {
+    id: String,
+    #[serde(rename = "type")]
+    interaction_type: String,
+    #[serde(default)]
+    state: String,
+    #[serde(default)]
+    title: String,
+    #[serde(default)]
+    prompt: String,
+    #[serde(default)]
+    request: Map<String, Value>,
+}
+
+struct AgentShell {
+    session: AgentSessionInfo,
+    model_override: Option<String>,
+    system_messages: Vec<String>,
+    tools: Vec<AgentToolArg>,
+    applied_system_messages: bool,
+}
+
+impl AgentShell {
+    fn connect(client: &ApiClient, args: &AgentArgs) -> Result<Self> {
+        let session = match args.session.as_deref() {
+            Some(session_id) => get_session_info(client, session_id)?,
+            None => {
+                let session_args = AgentSessionCreateArgs {
+                    provider: args.provider.clone(),
+                    model: args.model.clone(),
+                    client_ref: None,
+                    idempotency_key: None,
+                    input: None,
+                };
+                create_session_info(client, &session_args)?
+            }
+        };
+
+        Ok(Self {
+            session,
+            model_override: args.model.clone(),
+            system_messages: args.system.clone(),
+            tools: args.tools.clone(),
+            applied_system_messages: false,
+        })
+    }
+
+    fn print_banner(&self) -> Result<()> {
+        let mut stderr = io::stderr().lock();
+        let model = if self.session.model.is_empty() {
+            "<unspecified>"
+        } else {
+            self.session.model.as_str()
+        };
+        writeln!(
+            stderr,
+            "Session {} [{} / {}]",
+            self.session.id, self.session.provider, model
+        )?;
+        writeln!(stderr, "Type /quit to exit.")?;
+        Ok(())
+    }
+
+    fn submit_turn(&mut self, client: &ApiClient, messages: Vec<String>) -> Result<()> {
+        let system_messages = if self.applied_system_messages {
+            Vec::new()
+        } else {
+            self.system_messages.clone()
+        };
+        let turn_args = AgentTurnCreateArgs {
+            session_id: self.session.id.clone(),
+            model: self.model_override.clone(),
+            system: system_messages,
+            messages,
+            tools: self.tools.clone(),
+            idempotency_key: None,
+            input: None,
+        };
+        let turn = create_turn_info(client, &turn_args)?;
+        self.applied_system_messages = true;
+        drive_turn(client, &turn)?;
+        Ok(())
+    }
+}
+
+fn drive_turn(client: &ApiClient, turn: &AgentTurnInfo) -> Result<()> {
+    let mut renderer = AgentTurnRenderer::default();
+    loop {
+        drain_turn_events(client, &turn.id, &mut renderer)?;
+        let latest = get_turn_info(client, &turn.id)?;
+        renderer.finish_turn(&latest)?;
+
+        match latest.status.as_str() {
+            "waiting_for_input" => {
+                let interactions = list_interactions_info(client, &turn.id)?;
+                let pending: Vec<_> = interactions
+                    .into_iter()
+                    .filter(|interaction| interaction.state == "pending")
+                    .collect();
+                if pending.is_empty() {
+                    bail!(
+                        "agent turn {} is waiting for input without a pending interaction",
+                        latest.id
+                    );
+                }
+                for interaction in pending {
+                    let resolution = prompt_interaction_resolution(&interaction)?;
+                    resolve_interaction_info(client, &turn.id, &interaction.id, resolution)?;
+                }
+            }
+            "pending" | "running" => thread::sleep(EVENT_POLL_INTERVAL),
+            "succeeded" | "failed" | "canceled" => return Ok(()),
+            other => bail!("agent turn {} has unsupported status {}", latest.id, other),
+        }
+    }
+}
+
+#[derive(Default)]
+struct AgentTurnRenderer {
+    after_seq: u64,
+    assistant_line_open: bool,
+    saw_assistant_output: bool,
+    delta_buffer: String,
+}
+
+impl AgentTurnRenderer {
+    fn after_seq(&self) -> u64 {
+        self.after_seq
+    }
+
+    fn render_events(&mut self, events: &[AgentTurnEventInfo]) -> Result<()> {
+        for event in events {
+            if event.seq > 0 {
+                self.after_seq = self.after_seq.max(event.seq as u64);
+            }
+            match event.event_type.as_str() {
+                "agent.message.delta" | "assistant.delta" => {
+                    if let Some(text) = string_field(&event.data, "text") {
+                        self.start_assistant_line()?;
+                        print!("{text}");
+                        io::stdout().flush().context("failed to flush stdout")?;
+                        self.saw_assistant_output = true;
+                        self.delta_buffer.push_str(&text);
+                    }
+                }
+                "assistant.completed" => {
+                    let text = string_field(&event.data, "text");
+                    if self.assistant_line_open {
+                        if let Some(text) = text.as_deref() {
+                            if self.delta_buffer.is_empty() {
+                                print!("{text}");
+                            } else if let Some(suffix) = text.strip_prefix(&self.delta_buffer) {
+                                print!("{suffix}");
+                            }
+                        }
+                        println!();
+                        self.assistant_line_open = false;
+                    } else if let Some(text) = text {
+                        println!("assistant> {text}");
+                        self.saw_assistant_output = true;
+                    }
+                    self.delta_buffer.clear();
+                }
+                "tool.started" => {
+                    self.finish_assistant_line();
+                    let tool_id =
+                        string_field(&event.data, "tool_id").unwrap_or_else(|| "tool".to_string());
+                    println!("tool> {tool_id} started");
+                }
+                "tool.completed" => {
+                    self.finish_assistant_line();
+                    let tool_id =
+                        string_field(&event.data, "tool_id").unwrap_or_else(|| "tool".to_string());
+                    match number_field(&event.data, "status") {
+                        Some(status) => println!("tool> {tool_id} completed ({status})"),
+                        None => println!("tool> {tool_id} completed"),
+                    }
+                }
+                "interaction.requested" => {
+                    self.finish_assistant_line();
+                    let interaction_id = string_field(&event.data, "interaction_id")
+                        .unwrap_or_else(|| "interaction".to_string());
+                    println!("interaction> requested ({interaction_id})");
+                }
+                "interaction.resolved" => {
+                    self.finish_assistant_line();
+                    let interaction_id = string_field(&event.data, "interaction_id")
+                        .unwrap_or_else(|| "interaction".to_string());
+                    println!("interaction> resolved ({interaction_id})");
+                }
+                "turn.failed" => {
+                    self.finish_assistant_line();
+                    if let Some(message) = string_field(&event.data, "error") {
+                        println!("turn> failed: {message}");
+                    }
+                }
+                "turn.canceled" => {
+                    self.finish_assistant_line();
+                    if let Some(reason) = string_field(&event.data, "reason") {
+                        println!("turn> canceled: {reason}");
+                    }
+                }
+                _ => {}
+            }
+        }
+        Ok(())
+    }
+
+    fn finish_turn(&mut self, turn: &AgentTurnInfo) -> Result<()> {
+        self.finish_assistant_line();
+        match turn.status.as_str() {
+            "succeeded" if !self.saw_assistant_output && !turn.output_text.is_empty() => {
+                println!("assistant> {}", turn.output_text);
+                self.saw_assistant_output = true;
+            }
+            "failed" if !turn.status_message.is_empty() => {
+                println!("turn> failed: {}", turn.status_message);
+            }
+            "canceled" if !turn.status_message.is_empty() => {
+                println!("turn> canceled: {}", turn.status_message);
+            }
+            _ => {}
+        }
+        self.delta_buffer.clear();
+        Ok(())
+    }
+
+    fn start_assistant_line(&mut self) -> Result<()> {
+        if !self.assistant_line_open {
+            print!("assistant> ");
+            io::stdout().flush().context("failed to flush stdout")?;
+            self.assistant_line_open = true;
+        }
+        Ok(())
+    }
+
+    fn finish_assistant_line(&mut self) {
+        if self.assistant_line_open {
+            println!();
+            self.assistant_line_open = false;
+        }
+    }
+}
+
+fn prompt_agent_line() -> Result<Option<String>> {
+    let mut stderr = io::stderr().lock();
+    write!(stderr, "agent> ")?;
+    stderr.flush()?;
+
+    let mut line = String::new();
+    let read = io::stdin()
+        .read_line(&mut line)
+        .context("failed to read agent input")?;
+    if read == 0 {
+        writeln!(stderr)?;
+        return Ok(None);
+    }
+    Ok(Some(line.trim().to_string()))
+}
+
+fn prompt_interaction_resolution(interaction: &AgentInteractionInfo) -> Result<Map<String, Value>> {
+    let mut stderr = io::stderr().lock();
+    writeln!(stderr)?;
+    writeln!(
+        stderr,
+        "Interaction {} [{}]",
+        interaction.id, interaction.interaction_type
+    )?;
+    if !interaction.title.is_empty() {
+        writeln!(stderr, "{}", interaction.title)?;
+    }
+    if !interaction.prompt.is_empty() {
+        writeln!(stderr, "{}", interaction.prompt)?;
+    }
+    if !interaction.request.is_empty() {
+        writeln!(
+            stderr,
+            "Request: {}",
+            serde_json::to_string(&interaction.request)
+                .context("failed to encode interaction request")?
+        )?;
+    }
+    drop(stderr);
+
+    match interaction.interaction_type.as_str() {
+        "approval" => {
+            let approved = prompt_confirm("Approve?", true)?;
+            Ok(Map::from_iter([(
+                "approved".to_string(),
+                Value::Bool(approved),
+            )]))
+        }
+        "clarification" | "input" => {
+            let default = interaction
+                .request
+                .get("default")
+                .and_then(Value::as_str)
+                .map(ToString::to_string);
+            let required = interaction
+                .request
+                .get("required")
+                .and_then(Value::as_bool)
+                .unwrap_or(true);
+            let secret = interaction
+                .request
+                .get("secret")
+                .and_then(Value::as_bool)
+                .unwrap_or(false);
+            let label = if interaction.title.is_empty() {
+                "Response".to_string()
+            } else {
+                interaction.title.clone()
+            };
+            let description = if interaction.prompt.is_empty() {
+                None
+            } else {
+                Some(interaction.prompt.clone())
+            };
+            let response = prompt_input(&InputPrompt {
+                label,
+                description,
+                default,
+                required,
+                secret,
+            })?;
+            Ok(Map::from_iter([(
+                "response".to_string(),
+                Value::String(response),
+            )]))
+        }
+        other => bail!("unsupported agent interaction type {other}"),
+    }
+}
+
+fn drain_turn_events(
+    client: &ApiClient,
+    turn_id: &str,
+    renderer: &mut AgentTurnRenderer,
+) -> Result<()> {
+    loop {
+        let events = list_turn_events_info(
+            client,
+            turn_id,
+            renderer.after_seq(),
+            DEFAULT_EVENT_PAGE_SIZE,
+        )?;
+        if events.is_empty() {
+            return Ok(());
+        }
+        let event_count = events.len();
+        renderer.render_events(&events)?;
+        if event_count < DEFAULT_EVENT_PAGE_SIZE as usize {
+            return Ok(());
+        }
+    }
+}
+
+fn create_session_info(
+    client: &ApiClient,
+    args: &AgentSessionCreateArgs,
+) -> Result<AgentSessionInfo> {
+    let body = build_session_create_body(args)?;
+    decode_json(
+        client
+            .post(SESSIONS_PATH, &body)
+            .context("failed to create agent session")?,
+    )
+}
+
+fn get_session_info(client: &ApiClient, id: &str) -> Result<AgentSessionInfo> {
+    decode_json(
+        client
+            .get(&format!("{SESSIONS_PATH}/{id}"))
+            .with_context(|| format!("failed to get agent session {id}"))?,
+    )
+}
+
+fn create_turn_info(client: &ApiClient, args: &AgentTurnCreateArgs) -> Result<AgentTurnInfo> {
+    let body = build_turn_create_body(args)?;
+    decode_json(
+        client
+            .post(&format!("{SESSIONS_PATH}/{}/turns", args.session_id), &body)
+            .with_context(|| {
+                format!("failed to create agent turn in session {}", args.session_id)
+            })?,
+    )
+}
+
+fn get_turn_info(client: &ApiClient, id: &str) -> Result<AgentTurnInfo> {
+    decode_json(
+        client
+            .get(&format!("{TURNS_PATH}/{id}"))
+            .with_context(|| format!("failed to get agent turn {id}"))?,
+    )
+}
+
+fn list_turn_events_info(
+    client: &ApiClient,
+    turn_id: &str,
+    after: u64,
+    limit: u32,
+) -> Result<Vec<AgentTurnEventInfo>> {
+    decode_json(
+        client
+            .get(&turn_events_path(turn_id, false, Some(after), Some(limit)))
+            .with_context(|| format!("failed to list events for agent turn {turn_id}"))?,
+    )
+}
+
+fn list_interactions_info(client: &ApiClient, turn_id: &str) -> Result<Vec<AgentInteractionInfo>> {
+    decode_json(
+        client
+            .get(&format!("{TURNS_PATH}/{turn_id}/interactions"))
+            .with_context(|| format!("failed to list interactions for agent turn {turn_id}"))?,
+    )
+}
+
+fn resolve_interaction_info(
+    client: &ApiClient,
+    turn_id: &str,
+    interaction_id: &str,
+    resolution: Map<String, Value>,
+) -> Result<AgentInteractionInfo> {
+    decode_json(
+        client
+            .post(
+                &format!("{TURNS_PATH}/{turn_id}/interactions/{interaction_id}/resolve"),
+                &json!({ "resolution": resolution }),
+            )
+            .with_context(|| format!("failed to resolve interaction {interaction_id}"))?,
+    )
+}
+
+fn decode_json<T>(value: Value) -> Result<T>
+where
+    T: DeserializeOwned,
+{
+    serde_json::from_value(value).context("failed to decode agent response")
+}
+
+fn string_field(data: &Map<String, Value>, key: &str) -> Option<String> {
+    data.get(key)
+        .and_then(Value::as_str)
+        .map(ToString::to_string)
+}
+
+fn number_field(data: &Map<String, Value>, key: &str) -> Option<i64> {
+    data.get(key).and_then(Value::as_i64)
 }
 
 fn build_session_create_body(args: &AgentSessionCreateArgs) -> Result<Value> {

--- a/gestalt/cli/src/main.rs
+++ b/gestalt/cli/src/main.rs
@@ -124,55 +124,55 @@ fn run() -> anyhow::Result<()> {
                 },
             }
         }
-        Commands::Agent { command } => {
+        Commands::Agent(args) => {
             let client = ApiClient::from_env(url)?;
-            match command {
-                AgentCommands::Sessions { command } => match command {
-                    AgentSessionCommands::Create(args) => {
-                        commands::agents::create_session(&client, &args, format)
-                    }
-                    AgentSessionCommands::List { provider, state } => {
-                        commands::agents::list_sessions(
-                            &client,
-                            provider.as_deref(),
-                            state.as_deref(),
-                            format,
-                        )
-                    }
-                    AgentSessionCommands::Get { id } => {
-                        commands::agents::get_session(&client, &id, format)
-                    }
-                    AgentSessionCommands::Update(args) => {
-                        commands::agents::update_session(&client, &args, format)
-                    }
-                },
-                AgentCommands::Turns { command } => match command {
-                    AgentTurnCommands::Create(args) => {
-                        commands::agents::create_turn(&client, &args, format)
-                    }
-                    AgentTurnCommands::List { session_id, status } => commands::agents::list_turns(
-                        &client,
-                        &session_id,
-                        status.as_deref(),
-                        format,
-                    ),
-                    AgentTurnCommands::Get { id } => {
-                        commands::agents::get_turn(&client, &id, format)
-                    }
-                    AgentTurnCommands::Cancel { id, reason } => {
-                        commands::agents::cancel_turn(&client, &id, reason.as_deref(), format)
-                    }
-                    AgentTurnCommands::Events { command } => match command {
-                        AgentTurnEventCommands::List(args) => {
-                            commands::agents::list_turn_events(&client, &args, format)
-                        }
-                        AgentTurnEventCommands::Stream(args) => {
-                            commands::agents::stream_turn_events(&client, &args)
-                        }
-                    },
-                },
+            match args.command {
+                Some(command) => dispatch_agent_command(&client, command, format),
+                None => commands::agents::run_interactive(&client, &args),
             }
         }
+    }
+}
+
+fn dispatch_agent_command(
+    client: &ApiClient,
+    command: AgentCommands,
+    format: gestalt::output::Format,
+) -> anyhow::Result<()> {
+    match command {
+        AgentCommands::Sessions { command } => match command {
+            AgentSessionCommands::Create(args) => {
+                commands::agents::create_session(client, &args, format)
+            }
+            AgentSessionCommands::List { provider, state } => commands::agents::list_sessions(
+                client,
+                provider.as_deref(),
+                state.as_deref(),
+                format,
+            ),
+            AgentSessionCommands::Get { id } => commands::agents::get_session(client, &id, format),
+            AgentSessionCommands::Update(args) => {
+                commands::agents::update_session(client, &args, format)
+            }
+        },
+        AgentCommands::Turns { command } => match command {
+            AgentTurnCommands::Create(args) => commands::agents::create_turn(client, &args, format),
+            AgentTurnCommands::List { session_id, status } => {
+                commands::agents::list_turns(client, &session_id, status.as_deref(), format)
+            }
+            AgentTurnCommands::Get { id } => commands::agents::get_turn(client, &id, format),
+            AgentTurnCommands::Cancel { id, reason } => {
+                commands::agents::cancel_turn(client, &id, reason.as_deref(), format)
+            }
+            AgentTurnCommands::Events { command } => match command {
+                AgentTurnEventCommands::List(args) => {
+                    commands::agents::list_turn_events(client, &args, format)
+                }
+                AgentTurnEventCommands::Stream(args) => {
+                    commands::agents::stream_turn_events(client, &args)
+                }
+            },
+        },
     }
 }
 

--- a/gestalt/cli/tests/agents_cli.rs
+++ b/gestalt/cli/tests/agents_cli.rs
@@ -1,5 +1,10 @@
 mod support;
 
+use serde_json::Value;
+use std::collections::VecDeque;
+use std::io::{BufRead, BufReader, Read};
+use std::net::{TcpListener, TcpStream};
+use std::sync::{Arc, Mutex};
 use support::*;
 
 const SESSION_JSON: &str = r#"{
@@ -305,4 +310,363 @@ fn test_cli_streams_agent_turn_events() {
         .success()
         .stdout(predicate::str::contains("event: turn.completed"))
         .stdout(predicate::str::contains(r#""status":"succeeded""#));
+}
+
+#[test]
+fn test_cli_runs_interactive_agent_session() {
+    let mut server = Server::new();
+    let _session = authed_json_mock!(
+        server,
+        Method::POST,
+        "/api/v1/agent/sessions",
+        StatusCode::CREATED
+    )
+    .match_header(header::CONTENT_TYPE.as_str(), http::APPLICATION_JSON)
+    .match_body(Matcher::JsonString(
+        r#"{"provider":"managed","model":"gpt-5.4"}"#.to_string(),
+    ))
+    .with_body(SESSION_JSON)
+    .create();
+    let _turn = authed_json_mock!(
+        server,
+        Method::POST,
+        "/api/v1/agent/sessions/session-1/turns",
+        StatusCode::CREATED
+    )
+    .match_header(header::CONTENT_TYPE.as_str(), http::APPLICATION_JSON)
+    .match_body(Matcher::JsonString(
+        r#"{"model":"gpt-5.4","messages":[{"role":"user","text":"hello there"}]}"#.to_string(),
+    ))
+    .with_body(TURN_JSON)
+    .create();
+    let _events = authed_json_mock!(
+        server,
+        Method::GET,
+        "/api/v1/agent/turns/turn-1/events?after=0&limit=100",
+        StatusCode::OK
+    )
+    .with_body(
+        r#"[
+            {"seq":1,"type":"assistant.completed","data":{"text":"hello back"}},
+            {"seq":2,"type":"turn.completed","data":{"status":"succeeded"}}
+        ]"#,
+    )
+    .create();
+    let _get_turn = authed_json_mock!(
+        server,
+        Method::GET,
+        "/api/v1/agent/turns/turn-1",
+        StatusCode::OK
+    )
+    .with_body(
+        r#"{
+            "id":"turn-1",
+            "sessionId":"session-1",
+            "provider":"managed",
+            "model":"gpt-5.4",
+            "status":"succeeded",
+            "outputText":"hello back"
+        }"#,
+    )
+    .create();
+
+    let home = tempfile::tempdir().unwrap();
+    cli_command_for_server(home.path(), &server)
+        .args(["agent", "--provider", "managed", "--model", "gpt-5.4"])
+        .write_stdin("hello there\n/quit\n")
+        .assert()
+        .success()
+        .stdout(predicate::str::contains("assistant> hello back"))
+        .stderr(predicate::str::contains(
+            "Session session-1 [managed / gpt-5.4]",
+        ))
+        .stderr(predicate::str::contains("Type /quit to exit."));
+}
+
+#[test]
+fn test_cli_resolves_agent_interaction_in_interactive_mode() {
+    let server = ScriptedServer::spawn(vec![
+        ExpectedRequest::json(
+            Method::POST,
+            "/api/v1/agent/sessions",
+            r#"{"provider":"managed","model":"gpt-5.4"}"#,
+            StatusCode::CREATED,
+            http::APPLICATION_JSON,
+            SESSION_JSON,
+        ),
+        ExpectedRequest::json(
+            Method::POST,
+            "/api/v1/agent/sessions/session-1/turns",
+            r#"{"model":"gpt-5.4","messages":[{"role":"user","text":"approve deployment"}]}"#,
+            StatusCode::CREATED,
+            http::APPLICATION_JSON,
+            r#"{
+                "id":"turn-approval",
+                "sessionId":"session-1",
+                "provider":"managed",
+                "model":"gpt-5.4",
+                "status":"running"
+            }"#,
+        ),
+        ExpectedRequest::text(
+            Method::GET,
+            "/api/v1/agent/turns/turn-approval/events?after=0&limit=100",
+            StatusCode::OK,
+            http::APPLICATION_JSON,
+            r#"[
+                {"seq":1,"type":"turn.started","data":{"status":"running"}},
+                {"seq":2,"type":"interaction.requested","data":{"interaction_id":"interaction-1"}}
+            ]"#,
+        ),
+        ExpectedRequest::text(
+            Method::GET,
+            "/api/v1/agent/turns/turn-approval",
+            StatusCode::OK,
+            http::APPLICATION_JSON,
+            r#"{
+                "id":"turn-approval",
+                "sessionId":"session-1",
+                "provider":"managed",
+                "model":"gpt-5.4",
+                "status":"waiting_for_input",
+                "statusMessage":"waiting for input"
+            }"#,
+        ),
+        ExpectedRequest::text(
+            Method::GET,
+            "/api/v1/agent/turns/turn-approval/interactions",
+            StatusCode::OK,
+            http::APPLICATION_JSON,
+            r#"[
+                {
+                    "id":"interaction-1",
+                    "turnId":"turn-approval",
+                    "type":"approval",
+                    "state":"pending",
+                    "title":"Approve deployment",
+                    "prompt":"Allow the deployment to continue?",
+                    "request":{"environment":"prod"}
+                }
+            ]"#,
+        ),
+        ExpectedRequest::json(
+            Method::POST,
+            "/api/v1/agent/turns/turn-approval/interactions/interaction-1/resolve",
+            r#"{"resolution":{"approved":true}}"#,
+            StatusCode::OK,
+            http::APPLICATION_JSON,
+            r#"{
+                "id":"interaction-1",
+                "turnId":"turn-approval",
+                "type":"approval",
+                "state":"resolved",
+                "resolution":{"approved":true}
+            }"#,
+        ),
+        ExpectedRequest::text(
+            Method::GET,
+            "/api/v1/agent/turns/turn-approval/events?after=2&limit=100",
+            StatusCode::OK,
+            http::APPLICATION_JSON,
+            r#"[
+                {"seq":3,"type":"interaction.resolved","data":{"interaction_id":"interaction-1"}},
+                {"seq":4,"type":"assistant.completed","data":{"text":"deployment approved"}},
+                {"seq":5,"type":"turn.completed","data":{"status":"succeeded"}}
+            ]"#,
+        ),
+        ExpectedRequest::text(
+            Method::GET,
+            "/api/v1/agent/turns/turn-approval",
+            StatusCode::OK,
+            http::APPLICATION_JSON,
+            r#"{
+                "id":"turn-approval",
+                "sessionId":"session-1",
+                "provider":"managed",
+                "model":"gpt-5.4",
+                "status":"succeeded",
+                "outputText":"deployment approved"
+            }"#,
+        ),
+    ]);
+
+    let home = tempfile::tempdir().unwrap();
+    cli_command(home.path())
+        .env("GESTALT_API_KEY", TEST_TOKEN)
+        .arg("--url")
+        .arg(server.url())
+        .args(["agent", "--provider", "managed", "--model", "gpt-5.4"])
+        .write_stdin("approve deployment\nY\n/quit\n")
+        .assert()
+        .success()
+        .stdout(predicate::str::contains(
+            "interaction> requested (interaction-1)",
+        ))
+        .stdout(predicate::str::contains(
+            "interaction> resolved (interaction-1)",
+        ))
+        .stdout(predicate::str::contains("assistant> deployment approved"))
+        .stderr(predicate::str::contains("Approve deployment"))
+        .stderr(predicate::str::contains("Approve? [Y/n]:"));
+
+    server.assert_finished();
+}
+
+#[derive(Clone)]
+struct ExpectedRequest {
+    method: Method,
+    path: String,
+    body: Option<Value>,
+    status: StatusCode,
+    content_type: String,
+    response_body: String,
+}
+
+impl ExpectedRequest {
+    fn json(
+        method: Method,
+        path: &str,
+        body: &str,
+        status: StatusCode,
+        content_type: &str,
+        response_body: &str,
+    ) -> Self {
+        Self {
+            method,
+            path: path.to_string(),
+            body: Some(serde_json::from_str(body).unwrap()),
+            status,
+            content_type: content_type.to_string(),
+            response_body: response_body.to_string(),
+        }
+    }
+
+    fn text(
+        method: Method,
+        path: &str,
+        status: StatusCode,
+        content_type: &str,
+        response_body: &str,
+    ) -> Self {
+        Self {
+            method,
+            path: path.to_string(),
+            body: None,
+            status,
+            content_type: content_type.to_string(),
+            response_body: response_body.to_string(),
+        }
+    }
+}
+
+struct ScriptedServer {
+    base_url: String,
+    expected: Arc<Mutex<VecDeque<ExpectedRequest>>>,
+    handle: std::thread::JoinHandle<()>,
+}
+
+impl ScriptedServer {
+    fn spawn(expected: Vec<ExpectedRequest>) -> Self {
+        let listener = TcpListener::bind("127.0.0.1:0").unwrap();
+        let base_url = format!("http://{}", listener.local_addr().unwrap());
+        let expected = Arc::new(Mutex::new(VecDeque::from(expected)));
+        let expected_for_thread = Arc::clone(&expected);
+        let handle = std::thread::spawn(move || {
+            loop {
+                if expected_for_thread.lock().unwrap().is_empty() {
+                    break;
+                }
+                let (stream, _) = listener.accept().unwrap();
+                handle_scripted_request(stream, &expected_for_thread);
+            }
+        });
+        Self {
+            base_url,
+            expected,
+            handle,
+        }
+    }
+
+    fn url(&self) -> &str {
+        &self.base_url
+    }
+
+    fn assert_finished(self) {
+        self.handle.join().unwrap();
+        let remaining = self.expected.lock().unwrap();
+        assert!(
+            remaining.is_empty(),
+            "scripted server still had pending requests: {}",
+            remaining.len()
+        );
+    }
+}
+
+fn handle_scripted_request(stream: TcpStream, expected: &Arc<Mutex<VecDeque<ExpectedRequest>>>) {
+    let mut stream = stream;
+    let request = read_scripted_http_request(&mut stream);
+    let next = expected.lock().unwrap().pop_front().unwrap();
+    assert_eq!(request.method, next.method);
+    assert_eq!(request.target, next.path);
+    assert_eq!(
+        request.authorization.as_deref().unwrap_or_default(),
+        test_bearer()
+    );
+    match next.body {
+        Some(expected_body) => {
+            let actual: Value = serde_json::from_slice(&request.body).unwrap();
+            assert_eq!(actual, expected_body);
+        }
+        None => assert!(request.body.is_empty(), "unexpected request body"),
+    }
+    http::write_response(
+        &mut stream,
+        next.status,
+        &next.content_type,
+        &next.response_body,
+        &[],
+    )
+    .unwrap();
+}
+
+struct ScriptedHttpRequest {
+    method: Method,
+    target: String,
+    authorization: Option<String>,
+    body: Vec<u8>,
+}
+
+fn read_scripted_http_request(stream: &mut TcpStream) -> ScriptedHttpRequest {
+    let mut reader = BufReader::new(stream.try_clone().unwrap());
+    let mut request_line = String::new();
+    reader.read_line(&mut request_line).unwrap();
+
+    let mut content_length = 0usize;
+    let mut authorization = None;
+    loop {
+        let mut line = String::new();
+        reader.read_line(&mut line).unwrap();
+        if line == "\r\n" {
+            break;
+        }
+        if let Some((name, value)) = line.split_once(':') {
+            if name.eq_ignore_ascii_case(header::CONTENT_LENGTH.as_str()) {
+                content_length = value.trim().parse().unwrap();
+            }
+            if name.eq_ignore_ascii_case(header::AUTHORIZATION.as_str()) {
+                authorization = Some(value.trim().to_string());
+            }
+        }
+    }
+
+    let mut body = vec![0; content_length];
+    reader.read_exact(&mut body).unwrap();
+
+    let mut parts = request_line.split_whitespace();
+    ScriptedHttpRequest {
+        method: Method::from_bytes(parts.next().unwrap().as_bytes()).unwrap(),
+        target: parts.next().unwrap().to_string(),
+        authorization,
+        body,
+    }
 }


### PR DESCRIPTION
## Summary
This makes bare `gestalt agent` the interactive agent entrypoint while keeping `gestalt agent sessions ...` and `gestalt agent turns ...` as the low-level resource controls. The CLI now creates or resumes a session, submits turns, renders canonical event progress live, and resolves pending provider-owned interactions inline.

## Interfaces
New CLI interface:
- `gestalt agent [--session <id>] [--provider <name>] [--model <model>] [--system <text>] [--message <text>] [--tool <plugin:operation>]`
- `gestalt agent sessions ...`
- `gestalt agent turns ...`

Canonical HTTP surface the interactive loop uses:
- `POST /api/v1/agent/sessions`
- `POST /api/v1/agent/sessions/{sessionID}/turns`
- `GET /api/v1/agent/turns/{turnID}/events`
- `GET /api/v1/agent/turns/{turnID}`
- `GET /api/v1/agent/turns/{turnID}/interactions`
- `POST /api/v1/agent/turns/{turnID}/interactions/{interactionID}/resolve`

## Examples
- `gestalt agent --provider simple --model gpt-5.4`
- `gestalt agent --session session_123`
- `gestalt agent --provider simple --tool github:_search --message "summarize PR 42"`

Interactive approval flow example:
1. `gestalt agent --provider managed --model gpt-5.4`
2. Type `approve deployment`
3. CLI renders `interaction> requested (...)`
4. CLI prompts `Approve? [Y/n]:`
5. CLI resolves the interaction and continues rendering the same turn to completion

## Implementation
- reclaim bare `gestalt agent` as the interactive entrypoint while preserving the existing session/turn management subcommands
- poll canonical turn events in pages so long turns do not truncate after a fixed batch size
- render assistant output, tool lifecycle updates, and interaction lifecycle updates in the REPL
- resolve pending interactions inline and continue the same turn until terminal status
- extend the existing CLI contract tests with interactive session and interaction flows

## Verification
- `cargo test --manifest-path gestalt/cli/Cargo.toml --test agents_cli`
- `cargo clippy --manifest-path gestalt/cli/Cargo.toml --tests -- -D warnings`
- `go test ./internal/server`
