### PR TITLE
external credentials: remove integration_tokens compatibility paths

### DIFF
--- a/docs/content/architecture/data-model.mdx
+++ b/docs/content/architecture/data-model.mdx
@@ -22,7 +22,7 @@ Created automatically on first login.
 
 Emails and display names are plaintext. If you need encrypted PII at rest, handle it at the storage layer.
 
-### `integration_tokens`
+### `external_credentials`
 
 Stores upstream credentials (OAuth tokens, API keys, manual credentials) for each subject's connected integrations.
 
@@ -91,17 +91,17 @@ Credentials are encrypted. Everything else is plaintext.
 
 | Data | Where | How |
 | --- | --- | --- |
-| Access tokens | `integration_tokens.access_token_encrypted` | AES-256-GCM |
-| Refresh tokens | `integration_tokens.refresh_token_encrypted` | AES-256-GCM |
+| Access tokens | `external_credentials.access_token_encrypted` | AES-256-GCM |
+| Refresh tokens | `external_credentials.refresh_token_encrypted` | AES-256-GCM |
 | MCP OAuth client secrets | `oauth_registrations.client_secret_encrypted` | AES-256-GCM |
 | API tokens | `api_tokens.hashed_token` | One-way SHA-256 |
 | Emails, names, metadata, scopes, timestamps | Various | Plaintext |
 
 All encrypted fields use the same key derived from `server.encryptionKey`. There is no per-user or per-provider key separation.
 
-## Token storage granularity
+## Credential storage granularity
 
-Integration tokens are keyed by four dimensions: `subject_id`, `integration`, `connection`, and `instance`.
+External credentials are keyed by four dimensions: `subject_id`, `integration`, `connection`, and `instance`.
 
 The *integration* is the provider name from your config. The *connection* is the named connection within that provider (most have just `default`). The *instance* distinguishes multiple accounts within the same connection, which matters for providers with post-connect discovery (e.g., a user connected to three Slack workspaces).
 
@@ -112,7 +112,7 @@ The `_connection` and `_instance` selectors in the [HTTP API](/reference/http-ap
 - **`none`**: No credentials stored. Operations run without upstream authentication.
 - **`user`**: Each calling subject connects individually. Tokens are keyed by `subject_id`.
 
-Renaming a `plugins` key in config is a breaking change. Stored tokens reference the old name.
+Renaming a `plugins` key in config is a breaking change. Stored credentials reference the old name.
 
 ## Sessions
 

--- a/docs/content/architecture/security-internals.mdx
+++ b/docs/content/architecture/security-internals.mdx
@@ -22,7 +22,7 @@ Each encryption generates a fresh 12-byte nonce via `crypto/rand`, encrypts the 
 
 ### Creation
 
-For OAuth connections, Gestalt generates an encrypted state parameter (10-minute TTL) and optional PKCE verifier, redirects the caller to the provider, then exchanges the authorization code for tokens on callback. Both the access token and refresh token are encrypted and stored in `integration_tokens`, keyed by `(subject_id, integration, connection, instance)`.
+For OAuth connections, Gestalt generates an encrypted state parameter (10-minute TTL) and optional PKCE verifier, redirects the caller to the provider, then exchanges the authorization code for tokens on callback. Both the access token and refresh token are encrypted and stored in `external_credentials`, keyed by `(subject_id, integration, connection, instance)`.
 
 If the provider supports post-connect discovery (multiple workspaces or accounts), Gestalt fetches the resource list after the token exchange. One resource is auto-selected; multiple resources prompt the user.
 

--- a/docs/content/observability.mdx
+++ b/docs/content/observability.mdx
@@ -279,7 +279,7 @@ These metrics carry low-cardinality attributes:
 - `gestalt.db` identifies the logical IndexedDB resource configured in
   `gestaltd`, such as the server's primary IndexedDB binding.
 - `gestalt.object_store` identifies the IndexedDB object store being accessed,
-  such as `users`, `integration_tokens`, or `api_tokens`.
+  such as `users`, `external_credentials`, or `api_tokens`.
 - `gestalt.plugin` identifies the plugin namespace for plugin-hosted IndexedDB
   traffic. Core services omit this attribute.
 - `gestalt.method` identifies the operation. Values correspond to the

--- a/docs/internal/remove-identity-singleton-rollout.md
+++ b/docs/internal/remove-identity-singleton-rollout.md
@@ -68,8 +68,8 @@ After that rewrite, rerun the precheck and make sure it returns `0`.
 1. Take a snapshot / backup of the `external_credentials` table.
 2. Drain old app revisions so old code is no longer serving against the store.
    No rolling old/new overlap after the schema flip.
-3. Deploy the new revision.
-4. Let startup rebuild canonical `external_credentials` from `integration_tokens`.
+3. Run the manual backfill from `integration_tokens` into `external_credentials`.
+4. Deploy the new revision.
 
 ## Exact cutover SQL
 
@@ -103,8 +103,9 @@ CREATE TABLE external_credentials (
 ```
 
 The backup table is expected to keep the pre-cutover rows and indexes exactly as
-they were. The new `external_credentials` table must start empty; startup will
-clear and repopulate it canonically from `integration_tokens`.
+they were. The new `external_credentials` table must be populated manually
+before the new revision serves traffic; this rollout no longer relies on
+startup rebuilding canonical rows from `integration_tokens`.
 
 ## Required verification
 

--- a/gestaltd/internal/coredata/schemas.go
+++ b/gestaltd/internal/coredata/schemas.go
@@ -6,10 +6,7 @@ import (
 )
 
 const (
-	StoreUsers = "users"
-	// StoreIntegrationTokens is kept only as a legacy table name for
-	// deployment-managed migrations. New runtime writes use StoreExternalCredentials.
-	StoreIntegrationTokens        = "integration_tokens"
+	StoreUsers                    = "users"
 	StoreExternalCredentials      = externalcredentials.StoreName
 	StoreAPITokens                = "api_tokens"
 	StoreIdentities               = "identities"
@@ -43,10 +40,6 @@ var UsersSchema = indexeddb.ObjectStoreSchema{
 }
 
 var ExternalCredentialsSchema = externalcredentials.Schema
-
-// IntegrationTokensSchema is kept only as a legacy schema alias for
-// deployment-managed migrations. New runtime writes use ExternalCredentialsSchema.
-var IntegrationTokensSchema = externalcredentials.Schema
 
 var APITokensSchema = indexeddb.ObjectStoreSchema{
 	Indexes: []indexeddb.IndexSchema{

--- a/gestaltd/internal/coredata/services_test.go
+++ b/gestaltd/internal/coredata/services_test.go
@@ -5,6 +5,7 @@ import (
 	"errors"
 	"fmt"
 	"reflect"
+	"strings"
 	"sync"
 	"testing"
 	"time"
@@ -900,7 +901,7 @@ func TestTokenService(t *testing.T) {
 		}
 	})
 
-	t.Run("New_reads_legacy_integration_tokens_until_manual_migration", func(t *testing.T) {
+	t.Run("New_reads_existing_external_credentials", func(t *testing.T) {
 		t.Parallel()
 
 		db := &coretesting.StubIndexedDB{}
@@ -909,14 +910,58 @@ func TestTokenService(t *testing.T) {
 			t.Fatalf("NewAESGCM: %v", err)
 		}
 		ctx := context.Background()
-		if err := db.CreateObjectStore(ctx, coredata.StoreIntegrationTokens, coredata.IntegrationTokensSchema); err != nil {
-			t.Fatalf("CreateObjectStore(%s): %v", coredata.StoreIntegrationTokens, err)
+		if err := db.CreateObjectStore(ctx, coredata.StoreExternalCredentials, coredata.ExternalCredentialsSchema); err != nil {
+			t.Fatalf("CreateObjectStore(%s): %v", coredata.StoreExternalCredentials, err)
+		}
+		accessEncrypted, refreshEncrypted, err := enc.EncryptTokenPair("current-access", "current-refresh")
+		if err != nil {
+			t.Fatalf("EncryptTokenPair: %v", err)
+		}
+		if err := db.ObjectStore(coredata.StoreExternalCredentials).Put(ctx, indexeddb.Record{
+			"id":                      "current-token",
+			"subject_id":              "user:user-current",
+			"integration":             "slack",
+			"connection":              "default",
+			"instance":                "workspace-1",
+			"access_token_encrypted":  accessEncrypted,
+			"refresh_token_encrypted": refreshEncrypted,
+			"created_at":              time.Now().UTC(),
+			"updated_at":              time.Now().UTC(),
+		}); err != nil {
+			t.Fatalf("seed external credential: %v", err)
+		}
+
+		svc, err := coredata.New(db, enc)
+		if err != nil {
+			t.Fatalf("coredata.New: %v", err)
+		}
+
+		got, err := svc.Tokens.Token(ctx, "user:user-current", "slack", "default", "workspace-1")
+		if err != nil {
+			t.Fatalf("Token: %v", err)
+		}
+		if got.ID != "current-token" || got.AccessToken != "current-access" || got.RefreshToken != "current-refresh" {
+			t.Fatalf("Token = %+v, want current-token / current-access / current-refresh", got)
+		}
+	})
+
+	t.Run("New_rejects_legacy_integration_tokens_rows", func(t *testing.T) {
+		t.Parallel()
+
+		db := &coretesting.StubIndexedDB{}
+		enc, err := corecrypto.NewAESGCM([]byte(testEncryptionKey))
+		if err != nil {
+			t.Fatalf("NewAESGCM: %v", err)
+		}
+		ctx := context.Background()
+		if err := db.CreateObjectStore(ctx, "integration_tokens", coredata.ExternalCredentialsSchema); err != nil {
+			t.Fatalf("CreateObjectStore(integration_tokens): %v", err)
 		}
 		accessEncrypted, refreshEncrypted, err := enc.EncryptTokenPair("legacy-access", "legacy-refresh")
 		if err != nil {
 			t.Fatalf("EncryptTokenPair: %v", err)
 		}
-		if err := db.ObjectStore(coredata.StoreIntegrationTokens).Put(ctx, indexeddb.Record{
+		if err := db.ObjectStore("integration_tokens").Put(ctx, indexeddb.Record{
 			"id":                      "legacy-token",
 			"subject_id":              "user:user-legacy",
 			"integration":             "slack",
@@ -930,24 +975,16 @@ func TestTokenService(t *testing.T) {
 			t.Fatalf("seed legacy integration token: %v", err)
 		}
 
-		svc, err := coredata.New(db, enc)
-		if err != nil {
-			t.Fatalf("coredata.New: %v", err)
+		_, err = coredata.New(db, enc)
+		if err == nil {
+			t.Fatal("coredata.New succeeded, want legacy migration error")
 		}
-
-		got, err := svc.Tokens.Token(ctx, "user:user-legacy", "slack", "default", "workspace-1")
-		if err != nil {
-			t.Fatalf("Token: %v", err)
-		}
-		if got.ID != "legacy-token" || got.AccessToken != "legacy-access" || got.RefreshToken != "legacy-refresh" {
-			t.Fatalf("Token = %+v, want legacy-token / legacy-access / legacy-refresh", got)
-		}
-		if _, err := db.ObjectStore(coredata.StoreExternalCredentials).Get(ctx, "legacy-token"); err == nil {
-			t.Fatalf("legacy-only token should not be copied into %s during startup", coredata.StoreExternalCredentials)
+		if !strings.Contains(err.Error(), "manual external_credentials migration") {
+			t.Fatalf("coredata.New error = %v, want manual migration guidance", err)
 		}
 	})
 
-	t.Run("New_prefers_external_credentials_over_legacy_store", func(t *testing.T) {
+	t.Run("DeleteToken_removes_matching_external_credential_rows", func(t *testing.T) {
 		t.Parallel()
 
 		db := &coretesting.StubIndexedDB{}
@@ -956,29 +993,8 @@ func TestTokenService(t *testing.T) {
 			t.Fatalf("NewAESGCM: %v", err)
 		}
 		ctx := context.Background()
-		if err := db.CreateObjectStore(ctx, coredata.StoreIntegrationTokens, coredata.IntegrationTokensSchema); err != nil {
-			t.Fatalf("CreateObjectStore(%s): %v", coredata.StoreIntegrationTokens, err)
-		}
 		if err := db.CreateObjectStore(ctx, coredata.StoreExternalCredentials, coredata.ExternalCredentialsSchema); err != nil {
 			t.Fatalf("CreateObjectStore(%s): %v", coredata.StoreExternalCredentials, err)
-		}
-		accessEncrypted, refreshEncrypted, err := enc.EncryptTokenPair("legacy-access", "legacy-refresh")
-		if err != nil {
-			t.Fatalf("EncryptTokenPair: %v", err)
-		}
-		legacyRaw := indexeddb.Record{
-			"id":                      "legacy-token",
-			"subject_id":              "user:user-legacy",
-			"integration":             "slack",
-			"connection":              "default",
-			"instance":                "workspace-1",
-			"access_token_encrypted":  accessEncrypted,
-			"refresh_token_encrypted": refreshEncrypted,
-			"created_at":              time.Now().UTC().Add(-time.Minute),
-			"updated_at":              time.Now().UTC().Add(-time.Minute),
-		}
-		if err := db.ObjectStore(coredata.StoreIntegrationTokens).Put(ctx, legacyRaw); err != nil {
-			t.Fatalf("seed legacy integration token: %v", err)
 		}
 		currentAccessEncrypted, currentRefreshEncrypted, err := enc.EncryptTokenPair("current-access", "current-refresh")
 		if err != nil {
@@ -1006,79 +1022,16 @@ func TestTokenService(t *testing.T) {
 
 		got, err := svc.Tokens.Token(ctx, "user:user-legacy", "slack", "default", "workspace-1")
 		if err != nil {
-			t.Fatalf("Token: %v", err)
+			t.Fatalf("Token before delete: %v", err)
 		}
 		if got.ID != "current-token" || got.AccessToken != "current-access" || got.RefreshToken != "current-refresh" {
-			t.Fatalf("Token = %+v, want current-token / current-access / current-refresh", got)
-		}
-	})
-
-	t.Run("DeleteToken_removes_matching_legacy_lookup_rows", func(t *testing.T) {
-		t.Parallel()
-
-		db := &coretesting.StubIndexedDB{}
-		enc, err := corecrypto.NewAESGCM([]byte(testEncryptionKey))
-		if err != nil {
-			t.Fatalf("NewAESGCM: %v", err)
-		}
-		ctx := context.Background()
-		if err := db.CreateObjectStore(ctx, coredata.StoreIntegrationTokens, coredata.IntegrationTokensSchema); err != nil {
-			t.Fatalf("CreateObjectStore(%s): %v", coredata.StoreIntegrationTokens, err)
-		}
-		if err := db.CreateObjectStore(ctx, coredata.StoreExternalCredentials, coredata.ExternalCredentialsSchema); err != nil {
-			t.Fatalf("CreateObjectStore(%s): %v", coredata.StoreExternalCredentials, err)
-		}
-
-		legacyAccessEncrypted, legacyRefreshEncrypted, err := enc.EncryptTokenPair("legacy-access", "legacy-refresh")
-		if err != nil {
-			t.Fatalf("EncryptTokenPair legacy: %v", err)
-		}
-		legacyRaw := indexeddb.Record{
-			"id":                      "legacy-token",
-			"subject_id":              "user:user-legacy",
-			"integration":             "slack",
-			"connection":              "default",
-			"instance":                "workspace-1",
-			"access_token_encrypted":  legacyAccessEncrypted,
-			"refresh_token_encrypted": legacyRefreshEncrypted,
-			"created_at":              time.Now().UTC().Add(-time.Minute),
-			"updated_at":              time.Now().UTC().Add(-time.Minute),
-		}
-		if err := db.ObjectStore(coredata.StoreIntegrationTokens).Put(ctx, legacyRaw); err != nil {
-			t.Fatalf("seed legacy integration token: %v", err)
-		}
-
-		currentAccessEncrypted, currentRefreshEncrypted, err := enc.EncryptTokenPair("current-access", "current-refresh")
-		if err != nil {
-			t.Fatalf("EncryptTokenPair current: %v", err)
-		}
-		currentRaw := indexeddb.Record{
-			"id":                      "current-token",
-			"subject_id":              "user:user-legacy",
-			"integration":             "slack",
-			"connection":              "default",
-			"instance":                "workspace-1",
-			"access_token_encrypted":  currentAccessEncrypted,
-			"refresh_token_encrypted": currentRefreshEncrypted,
-			"created_at":              time.Now().UTC(),
-			"updated_at":              time.Now().UTC(),
-		}
-		if err := db.ObjectStore(coredata.StoreExternalCredentials).Put(ctx, currentRaw); err != nil {
-			t.Fatalf("seed external credential: %v", err)
-		}
-
-		svc, err := coredata.New(db, enc)
-		if err != nil {
-			t.Fatalf("coredata.New: %v", err)
+			t.Fatalf("Token before delete = %+v, want current-token / current-access / current-refresh", got)
 		}
 		if err := svc.Tokens.DeleteToken(ctx, "current-token"); err != nil {
 			t.Fatalf("DeleteToken: %v", err)
 		}
 		if _, err := svc.Tokens.Token(ctx, "user:user-legacy", "slack", "default", "workspace-1"); err != core.ErrNotFound {
 			t.Fatalf("Token after delete = %v, want ErrNotFound", err)
-		}
-		if _, err := db.ObjectStore(coredata.StoreIntegrationTokens).Get(ctx, "legacy-token"); err != indexeddb.ErrNotFound {
-			t.Fatalf("legacy token raw Get = %v, want ErrNotFound", err)
 		}
 		if _, err := db.ObjectStore(coredata.StoreExternalCredentials).Get(ctx, "current-token"); err != indexeddb.ErrNotFound {
 			t.Fatalf("external credential raw Get = %v, want ErrNotFound", err)

--- a/gestaltd/internal/externalcredentials/local.go
+++ b/gestaltd/internal/externalcredentials/local.go
@@ -15,8 +15,8 @@ import (
 )
 
 const (
-	StoreName       = "external_credentials"
-	legacyStoreName = "integration_tokens"
+	StoreName              = "external_credentials"
+	removedLegacyStoreName = "integration_tokens"
 )
 
 var Schema = indexeddb.ObjectStoreSchema{
@@ -47,9 +47,8 @@ var Schema = indexeddb.ObjectStoreSchema{
 var errUnreadableStoredExternalCredential = errors.New("unreadable stored external credential")
 
 type LocalProvider struct {
-	store       indexeddb.ObjectStore
-	legacyStore indexeddb.ObjectStore
-	enc         *corecrypto.AESGCMEncryptor
+	store indexeddb.ObjectStore
+	enc   *corecrypto.AESGCMEncryptor
 }
 
 var _ core.ExternalCredentialProvider = (*LocalProvider)(nil)
@@ -65,10 +64,12 @@ func NewLocalProvider(ds indexeddb.IndexedDB, enc *corecrypto.AESGCMEncryptor) (
 	if err := ds.CreateObjectStore(ctx, StoreName, Schema); err != nil {
 		return nil, fmt.Errorf("create %s store: %w", StoreName, err)
 	}
+	if err := failOnLegacyCredentialRows(ctx, ds); err != nil {
+		return nil, err
+	}
 	provider := &LocalProvider{
-		store:       ds.ObjectStore(StoreName),
-		legacyStore: ds.ObjectStore(legacyStoreName),
-		enc:         enc,
+		store: ds.ObjectStore(StoreName),
+		enc:   enc,
 	}
 	return provider, nil
 }
@@ -117,17 +118,9 @@ func (p *LocalProvider) DeleteCredential(ctx context.Context, id string) error {
 	if id == "" {
 		return p.store.Delete(ctx, id)
 	}
-	currentRec, currentErr := getCredentialRecordByID(ctx, p.store, id)
-	if currentErr != nil {
-		return currentErr
-	}
-	legacyRec, legacyErr := getCredentialRecordByID(ctx, p.legacyStore, id)
-	if legacyErr != nil {
-		return legacyErr
-	}
-	rec := currentRec
-	if rec == nil {
-		rec = legacyRec
+	rec, err := getCredentialRecordByID(ctx, p.store, id)
+	if err != nil {
+		return err
 	}
 	if rec == nil {
 		return nil
@@ -136,12 +129,7 @@ func (p *LocalProvider) DeleteCredential(ctx context.Context, id string) error {
 	integration := recordString(rec, "integration")
 	connection := recordString(rec, "connection")
 	instance := recordString(rec, "instance")
-
-	errs := []error{
-		deleteCredentialLookupRecords(ctx, p.store, subjectID, integration, connection, instance),
-		deleteCredentialLookupRecords(ctx, p.legacyStore, subjectID, integration, connection, instance),
-	}
-	return errors.Join(errs...)
+	return deleteCredentialLookupRecords(ctx, p.store, subjectID, integration, connection, instance)
 }
 
 func (p *LocalProvider) storeCredential(ctx context.Context, credential *core.ExternalCredential, preserveTimestamps bool) error {
@@ -272,15 +260,11 @@ func (p *LocalProvider) credentialRecord(ctx context.Context, subjectID, integra
 }
 
 func (p *LocalProvider) listCredentialRecords(ctx context.Context, indexName string, keys ...any) ([]indexeddb.Record, error) {
-	current, err := p.store.Index(indexName).GetAll(ctx, nil, keys...)
+	recs, err := p.store.Index(indexName).GetAll(ctx, nil, keys...)
 	if err != nil {
 		return nil, err
 	}
-	legacy, err := getAllLegacyCredentialRecords(ctx, p.legacyStore, indexName, keys...)
-	if err != nil {
-		return nil, err
-	}
-	return mergeCredentialRecords(current, legacy), nil
+	return dedupeCredentialRecords(recs), nil
 }
 
 func (p *LocalProvider) deleteDuplicateLookupRecords(ctx context.Context, keepID, subjectID, integration, connection, instance string) error {
@@ -324,38 +308,6 @@ func dedupeCredentialRecords(recs []indexeddb.Record) []indexeddb.Record {
 	return out
 }
 
-func mergeCredentialRecords(current, legacy []indexeddb.Record) []indexeddb.Record {
-	current = dedupeCredentialRecords(current)
-	legacy = dedupeCredentialRecords(legacy)
-	if len(current) == 0 {
-		return legacy
-	}
-	if len(legacy) == 0 {
-		return current
-	}
-
-	bestByLookup := make(map[string]indexeddb.Record, len(current)+len(legacy))
-	for _, rec := range current {
-		bestByLookup[credentialLookupKey(rec)] = rec
-	}
-	for _, rec := range legacy {
-		key := credentialLookupKey(rec)
-		if _, ok := bestByLookup[key]; ok {
-			continue
-		}
-		bestByLookup[key] = rec
-	}
-
-	out := make([]indexeddb.Record, 0, len(bestByLookup))
-	for _, rec := range bestByLookup {
-		out = append(out, rec)
-	}
-	sort.Slice(out, func(i, j int) bool {
-		return credentialRecordLess(out[i], out[j])
-	})
-	return out
-}
-
 func credentialLookupKey(rec indexeddb.Record) string {
 	return credentialRecordSubjectID(rec) + "\x00" +
 		recordString(rec, "integration") + "\x00" +
@@ -381,17 +333,6 @@ func credentialRecordLess(a, b indexeddb.Record) bool {
 	}
 
 	return recordString(a, "id") < recordString(b, "id")
-}
-
-func getAllLegacyCredentialRecords(ctx context.Context, store indexeddb.ObjectStore, indexName string, keys ...any) ([]indexeddb.Record, error) {
-	if store == nil {
-		return nil, nil
-	}
-	recs, err := store.Index(indexName).GetAll(ctx, nil, keys...)
-	if errors.Is(err, indexeddb.ErrNotFound) {
-		return nil, nil
-	}
-	return recs, err
 }
 
 func deleteCredentialRecord(ctx context.Context, store indexeddb.ObjectStore, id string) error {
@@ -439,6 +380,49 @@ func deleteCredentialLookupRecords(ctx context.Context, store indexeddb.ObjectSt
 		errs = append(errs, deleteCredentialRecord(ctx, store, id))
 	}
 	return errors.Join(errs...)
+}
+
+func failOnLegacyCredentialRows(ctx context.Context, ds indexeddb.IndexedDB) error {
+	exists, err := objectStoreExists(ctx, ds, removedLegacyStoreName)
+	if err != nil {
+		return fmt.Errorf("check legacy %s store: %w", removedLegacyStoreName, err)
+	}
+	if !exists {
+		return nil
+	}
+	count, err := ds.ObjectStore(removedLegacyStoreName).Count(ctx, nil)
+	switch {
+	case err == nil:
+	case errors.Is(err, indexeddb.ErrNotFound):
+		return nil
+	default:
+		return fmt.Errorf("count legacy %s rows: %w", removedLegacyStoreName, err)
+	}
+	if count == 0 {
+		return nil
+	}
+	return fmt.Errorf("legacy %s store still contains %d rows; run the manual external_credentials migration before starting gestaltd", removedLegacyStoreName, count)
+}
+
+func objectStoreExists(ctx context.Context, db indexeddb.IndexedDB, storeName string) (bool, error) {
+	if storeName == "" {
+		return false, nil
+	}
+	type objectStoreExistenceChecker interface {
+		HasObjectStore(name string) bool
+	}
+	if checker, ok := db.(objectStoreExistenceChecker); ok {
+		return checker.HasObjectStore(storeName), nil
+	}
+	_, err := db.ObjectStore(storeName).Count(ctx, nil)
+	switch {
+	case err == nil:
+		return true, nil
+	case errors.Is(err, indexeddb.ErrNotFound):
+		return false, nil
+	default:
+		return false, err
+	}
 }
 
 func recordString(rec indexeddb.Record, key string) string {


### PR DESCRIPTION
## Summary

Remove the runtime `integration_tokens` compatibility path now that `external_credentials` has been manually backfilled in CloudSQL.

This change does four things:
- deletes the dual-read / dual-delete fallback from `gestaltd/internal/externalcredentials/local.go`
- adds a fail-closed startup guard if legacy `integration_tokens` rows still exist
- removes the `StoreIntegrationTokens` / `IntegrationTokensSchema` aliases from `gestaltd/internal/coredata/schemas.go`
- updates the remaining docs and contract tests to treat `external_credentials` as the canonical store

## Interfaces

- `core.ExternalCredentialProvider`
  - runtime credential lookup/delete now resolves only against `external_credentials`
  - startup now errors if legacy `integration_tokens` rows are still present
- `coredata.TokenService`
  - remains the compatibility adapter for token-shaped callers
  - no longer falls back to legacy `integration_tokens` rows

## Examples

```go
credential, err := services.ExternalCredentials.GetCredential(
    ctx,
    "user:123",
    "slack",
    "default",
    "workspace-1",
)
```

```go
err := services.Tokens.StoreToken(ctx, &core.IntegrationToken{
    SubjectID:   "user:123",
    Integration: "slack",
    Connection:  "default",
    Instance:    "workspace-1",
})
```

```go
err := services.Tokens.DeleteToken(ctx, tokenID) // deletes from external_credentials only
```

```text
legacy integration_tokens store still contains N rows; run the manual external_credentials migration before starting gestaltd
```

## Verification

```bash
go test ./internal/coredata -run 'TestTokenService|TestEffectiveExternalCredentialProviderHandlesTypedNilFallbacks'
go test ./internal/server -run 'TestDisconnectIntegration/default token|TestConnectManual/connected|TestIntegrationOAuthCallback/connected|TestExecuteOperation_RefreshesExpiredToken'
go test ./internal/coredata ./internal/server ./internal/invocation ./cmd/gestaltd
```
