### PR TITLE
typescript runtime: remove legacy plugin hook compatibility

### DIFF
--- a/sdk/typescript/src/plugin.ts
+++ b/sdk/typescript/src/plugin.ts
@@ -438,7 +438,19 @@ export function isPluginProvider(
       "kind" in value &&
       (value as { kind?: unknown }).kind === "integration" &&
       "staticCatalog" in value &&
-      "execute" in value)
+      typeof (value as { staticCatalog?: unknown }).staticCatalog === "function" &&
+      "execute" in value &&
+      typeof (value as { execute?: unknown }).execute === "function" &&
+      "supportsSessionCatalog" in value &&
+      typeof (value as { supportsSessionCatalog?: unknown }).supportsSessionCatalog === "function" &&
+      "catalogForRequest" in value &&
+      typeof (value as { catalogForRequest?: unknown }).catalogForRequest === "function" &&
+      "supportsManifestMetadata" in value &&
+      typeof (value as { supportsManifestMetadata?: unknown }).supportsManifestMetadata === "function" &&
+      "writeManifestMetadata" in value &&
+      typeof (value as { writeManifestMetadata?: unknown }).writeManifestMetadata === "function" &&
+      "resolveHTTPSubject" in value &&
+      typeof (value as { resolveHTTPSubject?: unknown }).resolveHTTPSubject === "function")
   );
 }
 

--- a/sdk/typescript/src/runtime.ts
+++ b/sdk/typescript/src/runtime.ts
@@ -43,12 +43,10 @@ import {
   CatalogSchema as ProtoCatalogSchema,
   ConnectionMode as ProviderConnectionMode,
   GetSessionCatalogResponseSchema,
-  PostConnectResponseSchema,
   ResolveHTTPSubjectResponseSchema,
   OperationResultSchema,
   ProviderMetadataSchema,
   type HTTPSubjectRequest as ProtoHTTPSubjectRequest,
-  type IntegrationToken as ProtoIntegrationToken,
   type RequestContext as ProtoRequestContext,
   type ResolveHTTPSubjectRequest as ProtoResolveHTTPSubjectRequest,
   IntegrationProvider as IntegrationProviderService,
@@ -67,7 +65,7 @@ import {
 } from "../gen/v1/runtime_pb.ts";
 import { S3 as S3Service } from "../gen/v1/s3_pb.ts";
 import { WorkflowProvider as WorkflowProviderService } from "../gen/v1/workflow_pb.ts";
-import { errorMessage, type Request, type Subject } from "./api.ts";
+import { errorMessage, type Request } from "./api.ts";
 import {
   AgentProvider,
   createAgentProviderService,
@@ -87,7 +85,6 @@ import {
   type HTTPSubjectResolutionContext,
 } from "./http-subject.ts";
 import {
-  type ConnectedToken,
   PluginProvider,
   connectionModeToProtoValue,
   connectionParamToProto,
@@ -514,8 +511,8 @@ export function createProviderService(
             ]),
           ),
           staticCatalog: catalogToProto(provider.staticCatalog()),
-          supportsSessionCatalog: providerSupportsSessionCatalog(provider),
-          supportsPostConnect: providerSupportsPostConnect(provider),
+          supportsSessionCatalog: provider.supportsSessionCatalog(),
+          supportsPostConnect: false,
           minProtocolVersion: CURRENT_PROTOCOL_VERSION,
           maxProtocolVersion: CURRENT_PROTOCOL_VERSION,
         });
@@ -555,8 +552,7 @@ export function createProviderService(
     async resolveHTTPSubject(request: ProtoResolveHTTPSubjectRequest) {
       let subject;
       try {
-        subject = await providerResolveHTTPSubject(
-          provider,
+        subject = await provider.resolveHTTPSubject(
           providerHTTPSubjectRequest(request.request),
           providerHTTPSubjectResolutionContext(request.context),
         );
@@ -586,8 +582,7 @@ export function createProviderService(
     async getSessionCatalog(request: GetSessionCatalogRequest) {
       let catalog: Catalog | Record<string, unknown> | null | undefined;
       try {
-        catalog = await providerCatalogForRequest(
-          provider,
+        catalog = await provider.catalogForRequest(
           providerRequest(
             request.token,
             request.connectionParams,
@@ -610,30 +605,11 @@ export function createProviderService(
         catalog: catalogToProto(catalog),
       });
     },
-    async postConnect(request) {
-      if (!providerSupportsPostConnect(provider)) {
-        throw new ConnectError(
-          "provider does not support post connect",
-          Code.Unimplemented,
-        );
-      }
-      let metadata: Record<string, string> | null | undefined;
-      try {
-        metadata = await providerPostConnectMetadata(
-          provider,
-          providerConnectedToken(request.token),
-        );
-      } catch (error) {
-        throw new ConnectError(
-          `post connect: ${errorMessage(error)}`,
-          Code.Unknown,
-        );
-      }
-      return create(PostConnectResponseSchema, {
-        metadata: {
-          ...(metadata ?? {}),
-        },
-      });
+    async postConnect() {
+      throw new ConnectError(
+        "provider does not support post connect",
+        Code.Unimplemented,
+      );
     },
   };
 }
@@ -868,29 +844,6 @@ function providerHTTPSubjectResolutionContext(
   };
 }
 
-function providerConnectedToken(
-  token?: ProtoIntegrationToken,
-): ConnectedToken {
-  const metadataJson = token?.metadataJson ?? "";
-  return {
-    id: token?.id ?? "",
-    subjectId: token?.userId ?? "",
-    integration: token?.integration ?? "",
-    connection: token?.connection ?? "",
-    instance: token?.instance ?? "",
-    accessToken: token?.accessToken ?? "",
-    refreshToken: token?.refreshToken ?? "",
-    scopes: token?.scopes ?? "",
-    expiresAt: timestampToDate(token?.expiresAt),
-    lastRefreshedAt: timestampToDate(token?.lastRefreshedAt),
-    refreshErrorCount: token?.refreshErrorCount ?? 0,
-    metadataJson,
-    metadata: stringRecordFromJSON(metadataJson),
-    createdAt: timestampToDate(token?.createdAt),
-    updatedAt: timestampToDate(token?.updatedAt),
-  };
-}
-
 function providerStringLists(
   input: Record<string, { values?: string[] }> | undefined,
 ): Record<string, string[]> {
@@ -915,78 +868,6 @@ function providerRuntimeEntry(
 
 function providerRuntimeError(label: string, error: unknown): ConnectError {
   return new ConnectError(`${label}: ${errorMessage(error)}`, Code.Unknown);
-}
-
-function providerSupportsSessionCatalog(provider: LoadedProvider): boolean {
-  const candidate = provider as LoadedProvider & {
-    supportsSessionCatalog?: () => boolean;
-    sessionCatalogHandler?: unknown;
-    catalogForRequest?: (
-      request: Request,
-    ) => Promise<Catalog | Record<string, unknown> | null | undefined>;
-  };
-  if (typeof candidate.supportsSessionCatalog === "function") {
-    return candidate.supportsSessionCatalog();
-  }
-  if (Object.prototype.hasOwnProperty.call(candidate, "sessionCatalogHandler")) {
-    return candidate.sessionCatalogHandler !== undefined;
-  }
-  return typeof candidate.catalogForRequest === "function";
-}
-
-function providerSupportsPostConnect(provider: LoadedProvider): boolean {
-  const candidate = provider as LoadedProvider & {
-    supportsPostConnect?: () => boolean;
-    postConnectHandler?: unknown;
-    postConnectMetadata?: (
-      token: ConnectedToken,
-    ) => Promise<Record<string, string> | null | undefined>;
-  };
-  if (typeof candidate.supportsPostConnect === "function") {
-    return candidate.supportsPostConnect();
-  }
-  if (Object.prototype.hasOwnProperty.call(candidate, "postConnectHandler")) {
-    return candidate.postConnectHandler !== undefined;
-  }
-  return typeof candidate.postConnectMetadata === "function";
-}
-
-async function providerCatalogForRequest(
-  provider: LoadedProvider,
-  request: Request,
-): Promise<Catalog | Record<string, unknown> | null | undefined> {
-  const candidate = provider as LoadedProvider & {
-    catalogForRequest?: (
-      request: Request,
-    ) => Promise<Catalog | Record<string, unknown> | null | undefined>;
-  };
-  return await candidate.catalogForRequest?.(request);
-}
-
-async function providerPostConnectMetadata(
-  provider: LoadedProvider,
-  token: ConnectedToken,
-): Promise<Record<string, string> | null | undefined> {
-  const candidate = provider as LoadedProvider & {
-    postConnectMetadata?: (
-      token: ConnectedToken,
-    ) => Promise<Record<string, string> | null | undefined>;
-  };
-  return await candidate.postConnectMetadata?.(token);
-}
-
-async function providerResolveHTTPSubject(
-  provider: LoadedProvider,
-  request: HTTPSubjectRequest,
-  context: HTTPSubjectResolutionContext,
-): Promise<Subject | null | undefined> {
-  const candidate = provider as LoadedProvider & {
-    resolveHTTPSubject?: (
-      request: HTTPSubjectRequest,
-      context: HTTPSubjectResolutionContext,
-    ) => Promise<Subject | null | undefined>;
-  };
-  return await candidate.resolveHTTPSubject?.(request, context);
 }
 
 function resolveLoadedProvider(

--- a/sdk/typescript/tests/runtime.test.ts
+++ b/sdk/typescript/tests/runtime.test.ts
@@ -411,6 +411,61 @@ export const plugin = definePlugin({
   }
 });
 
+test("loadProviderFromTarget rejects legacy structural plugin objects without alpha.12 hook methods", async () => {
+  const root = makeTempDir("gestalt-typescript-runtime-legacy-structural-");
+
+  try {
+    writeFileSync(
+      join(root, "package.json"),
+      JSON.stringify({
+        name: "legacy-structural-provider",
+        gestalt: {
+          provider: {
+            kind: "plugin",
+            target: "./provider.ts#plugin",
+          },
+        },
+      }),
+      "utf8",
+    );
+    writeFileSync(
+      join(root, "provider.ts"),
+      `export const plugin = {
+  kind: "integration",
+  name: "legacy-structural",
+  displayName: "Legacy Structural",
+  description: "legacy structural plugin",
+  connectionMode: "unspecified",
+  authTypes: [],
+  connectionParams: {},
+  staticCatalog() {
+    return { name: "legacy-structural", operations: [] };
+  },
+  supportsSessionCatalog() {
+    return false;
+  },
+  async catalogForRequest() {
+    return undefined;
+  },
+  supportsManifestMetadata() {
+    return false;
+  },
+  writeManifestMetadata() {},
+  async execute() {
+    return { status: 200, body: "{}" };
+  },
+};`,
+      "utf8",
+    );
+
+    await expect(loadProviderFromTarget(root)).rejects.toThrow(
+      "plugin:./provider.ts#plugin did not resolve to a Gestalt plugin provider",
+    );
+  } finally {
+    removeTempDir(root);
+  }
+});
+
 test("runtime serves a secrets provider over unix gRPC", async () => {
   const runtimeEntry = join(import.meta.dir, "..", "src", "runtime.ts");
   const root = fixturePath("secrets-provider");
@@ -504,7 +559,7 @@ test("integration provider service exposes metadata, configure, execute, and ses
   const metadata = await (service.getMetadata as any)();
   expect(metadata.name).toBe("basic-provider");
   expect(metadata.supportsSessionCatalog).toBe(true);
-  expect(metadata.supportsPostConnect).toBe(true);
+  expect(metadata.supportsPostConnect).toBe(false);
   expect(metadata.minProtocolVersion).toBe(CURRENT_PROTOCOL_VERSION);
   expect(metadata.maxProtocolVersion).toBe(CURRENT_PROTOCOL_VERSION);
   expect(
@@ -629,27 +684,25 @@ test("integration provider service exposes metadata, configure, execute, and ses
     "Session Hello ops user:user-123 identity viewer",
   );
 
-  const postConnect = await (service.postConnect as any)(
-    create(PostConnectRequestSchema, {
-      token: {
-        id: "tok-123",
-        userId: "user:user-123",
-        integration: "basic-provider",
-        connection: "workspace",
-        instance: "__default__",
-        accessToken: "access-token",
-        metadataJson: JSON.stringify({
-          team_id: "T123",
-          user_id: "U456",
-        }),
-      },
-    }),
+  await expectConnectCode(
+    (service.postConnect as any)(
+      create(PostConnectRequestSchema, {
+        token: {
+          id: "tok-123",
+          userId: "user:user-123",
+          integration: "basic-provider",
+          connection: "workspace",
+          instance: "__default__",
+          accessToken: "access-token",
+          metadataJson: JSON.stringify({
+            team_id: "T123",
+            user_id: "U456",
+          }),
+        },
+      }),
+    ),
+    Code.Unimplemented,
   );
-  expect(postConnect.metadata).toEqual({
-    "gestalt.external_identity.type": "fixture_identity",
-    "gestalt.external_identity.id": "workspace:__default__:user:user-123",
-    configured_connection: "workspace",
-  });
 });
 
 test("integration provider service labels metadata failures", async () => {
@@ -663,7 +716,7 @@ test("integration provider service labels metadata failures", async () => {
       },
     ],
   });
-  (plugin as any).supportsPostConnect = () => {
+  (plugin as any).supportsSessionCatalog = () => {
     throw new Error("metadata exploded");
   };
 
@@ -677,113 +730,6 @@ test("integration provider service labels metadata failures", async () => {
       "provider metadata: metadata exploded",
     );
   }
-});
-
-test("integration provider service tolerates legacy plugin objects without newer optional hooks", async () => {
-  const plugin = definePlugin({
-    operations: [
-      {
-        id: "noop",
-        handler() {
-          return { ok: true };
-        },
-      },
-    ],
-  });
-  (plugin as any).supportsSessionCatalog = undefined;
-  (plugin as any).supportsPostConnect = undefined;
-  (plugin as any).resolveHTTPSubject = undefined;
-
-  const service = createProviderService(plugin as any);
-  const metadata = await (service.getMetadata as any)();
-  expect(metadata.supportsSessionCatalog).toBe(false);
-  expect(metadata.supportsPostConnect).toBe(false);
-
-  await expectConnectCode(
-    (service.postConnect as any)(
-      create(PostConnectRequestSchema, {
-        token: {
-          id: "tok-123",
-          integration: "legacy-plugin",
-        },
-      }),
-    ),
-    Code.Unimplemented,
-  );
-
-  const unresolved = await (service.resolveHTTPSubject as any)(
-    create(ResolveHTTPSubjectRequestSchema, {
-      request: create(HTTPSubjectRequestSchema, {
-        binding: "command",
-      }),
-    }),
-  );
-  expect(unresolved.subject).toBeUndefined();
-});
-
-test("integration provider service infers optional hooks for prototype-backed structural plugin objects", async () => {
-  class StructuralPlugin {
-    kind = "integration" as const;
-    name = "structural-plugin";
-    displayName = "Structural Plugin";
-    description = "structural plugin";
-    version = "1.0.0";
-    connectionMode = "unspecified" as const;
-    authTypes: string[] = [];
-    connectionParams: Record<string, unknown> = {};
-
-    staticCatalog() {
-      return {
-        name: "structural-plugin",
-        operations: [],
-      };
-    }
-
-    async execute() {
-      return {
-        status: 200,
-        body: "{}",
-      };
-    }
-
-    async catalogForRequest() {
-      return {
-        name: "structural-session",
-        operations: [],
-      };
-    }
-
-    async postConnectMetadata() {
-      return {
-        structural: "true",
-      };
-    }
-  }
-
-  const service = createProviderService(new StructuralPlugin() as any);
-
-  const metadata = await (service.getMetadata as any)();
-  expect(metadata.supportsSessionCatalog).toBe(true);
-  expect(metadata.supportsPostConnect).toBe(true);
-
-  const sessionCatalog = await (service.getSessionCatalog as any)(
-    create(GetSessionCatalogRequestSchema, {
-      token: "token-123",
-    }),
-  );
-  expect(sessionCatalog.catalog?.name).toBe("structural-session");
-
-  const postConnect = await (service.postConnect as any)(
-    create(PostConnectRequestSchema, {
-      token: {
-        id: "tok-123",
-        integration: "structural-plugin",
-      },
-    }),
-  );
-  expect(postConnect.metadata).toEqual({
-    structural: "true",
-  });
 });
 
 test("integration provider service resolves hosted HTTP subjects through the plugin hook", async () => {


### PR DESCRIPTION
## Summary
- remove the TypeScript runtime's legacy plugin-hook compatibility shims
- require loaded structural plugin exports to implement the modern hook surface up front
- fail legacy structural exports during provider load instead of later during RPC startup

## Interfaces
```ts
// Structural plugin exports now need the full modern hook surface.
export const plugin = {
  kind: "integration",
  staticCatalog() { /* ... */ },
  execute() { /* ... */ },
  supportsSessionCatalog() { return false; },
  async catalogForRequest() { return undefined; },
  supportsManifestMetadata() { return false; },
  writeManifestMetadata() {},
  supportsPostConnect() { return false; },
  async postConnectMetadata() { return undefined; },
  async resolveHTTPSubject() { return undefined; },
};
```

## Examples
```sh
gestaltd provider validate --path /Users/hugh/src/toolshed/.worktrees/modern-plugin-hooks-branch/valon-tools/deploy/brain/plugin/manifest.yaml
cd sdk/typescript && bun test ./tests/runtime.test.ts
```

## Testing
```sh
cd sdk/typescript
bun test ./tests/runtime.test.ts

cd /Users/hugh/src/gestalt/.worktrees/delete-ts-plugin-compat/gestaltd
for manifest in /Users/hugh/src/toolshed/.worktrees/modern-plugin-hooks-branch/valon-tools/deploy/{brain,create-customer-roadmap-review,data-schema-explorer,deployment-viewer,vm-style-guide,workplace-hub}/plugin/manifest.yaml; do
  go run ./cmd/gestaltd provider validate --path "$manifest" || exit 1
done
```

## Merge Order
Merge after toolshed PR #823, which upgrades the internal TypeScript plugins to export the modern hook surface.
