### PR TITLE
typescript sdk: restore plugin post-connect for alpha.13

### DIFF
--- a/sdk/typescript/README.md
+++ b/sdk/typescript/README.md
@@ -16,7 +16,7 @@ property in `package.json`:
   "name": "my-provider",
   "version": "0.0.1-alpha.1",
   "dependencies": {
-    "@valon-technologies/gestalt": "0.0.1-alpha.1"
+    "@valon-technologies/gestalt": "0.0.1-alpha.13"
   },
   "gestalt": {
     "provider": {

--- a/sdk/typescript/src/plugin.ts
+++ b/sdk/typescript/src/plugin.ts
@@ -32,7 +32,11 @@ import {
   type HTTPSubjectResolutionContext,
   type HTTPSubjectResolver,
 } from "./http-subject.ts";
-import { RuntimeProvider, type RuntimeProviderOptions } from "./provider.ts";
+import {
+  isRuntimeProvider,
+  RuntimeProvider,
+  type RuntimeProviderOptions,
+} from "./provider.ts";
 import type { Schema } from "./schema.ts";
 
 /**
@@ -433,8 +437,7 @@ export function isPluginProvider(
 ): value is PluginProvider {
   return (
     value instanceof PluginProvider ||
-    (typeof value === "object" &&
-      value !== null &&
+    (isRuntimeProvider(value) &&
       "kind" in value &&
       (value as { kind?: unknown }).kind === "integration" &&
       "staticCatalog" in value &&
@@ -449,6 +452,10 @@ export function isPluginProvider(
       typeof (value as { supportsManifestMetadata?: unknown }).supportsManifestMetadata === "function" &&
       "writeManifestMetadata" in value &&
       typeof (value as { writeManifestMetadata?: unknown }).writeManifestMetadata === "function" &&
+      "supportsPostConnect" in value &&
+      typeof (value as { supportsPostConnect?: unknown }).supportsPostConnect === "function" &&
+      "postConnectMetadata" in value &&
+      typeof (value as { postConnectMetadata?: unknown }).postConnectMetadata === "function" &&
       "resolveHTTPSubject" in value &&
       typeof (value as { resolveHTTPSubject?: unknown }).resolveHTTPSubject === "function")
   );

--- a/sdk/typescript/src/provider.ts
+++ b/sdk/typescript/src/provider.ts
@@ -152,7 +152,17 @@ export function isRuntimeProvider(value: unknown): value is RuntimeProvider {
       value !== null &&
       "kind" in value &&
       "resolveName" in value &&
-      "configureProvider" in value)
+      typeof (value as { resolveName?: unknown }).resolveName === "function" &&
+      "configureProvider" in value &&
+      typeof (value as { configureProvider?: unknown }).configureProvider === "function" &&
+      "supportsHealthCheck" in value &&
+      typeof (value as { supportsHealthCheck?: unknown }).supportsHealthCheck === "function" &&
+      "healthCheck" in value &&
+      typeof (value as { healthCheck?: unknown }).healthCheck === "function" &&
+      "warnings" in value &&
+      typeof (value as { warnings?: unknown }).warnings === "function" &&
+      "closeProvider" in value &&
+      typeof (value as { closeProvider?: unknown }).closeProvider === "function")
   );
 }
 

--- a/sdk/typescript/src/runtime.ts
+++ b/sdk/typescript/src/runtime.ts
@@ -43,10 +43,12 @@ import {
   CatalogSchema as ProtoCatalogSchema,
   ConnectionMode as ProviderConnectionMode,
   GetSessionCatalogResponseSchema,
+  PostConnectResponseSchema,
   ResolveHTTPSubjectResponseSchema,
   OperationResultSchema,
   ProviderMetadataSchema,
   type HTTPSubjectRequest as ProtoHTTPSubjectRequest,
+  type IntegrationToken as ProtoIntegrationToken,
   type RequestContext as ProtoRequestContext,
   type ResolveHTTPSubjectRequest as ProtoResolveHTTPSubjectRequest,
   IntegrationProvider as IntegrationProviderService,
@@ -85,6 +87,7 @@ import {
   type HTTPSubjectResolutionContext,
 } from "./http-subject.ts";
 import {
+  type ConnectedToken,
   PluginProvider,
   connectionModeToProtoValue,
   connectionParamToProto,
@@ -512,7 +515,7 @@ export function createProviderService(
           ),
           staticCatalog: catalogToProto(provider.staticCatalog()),
           supportsSessionCatalog: provider.supportsSessionCatalog(),
-          supportsPostConnect: false,
+          supportsPostConnect: provider.supportsPostConnect(),
           minProtocolVersion: CURRENT_PROTOCOL_VERSION,
           maxProtocolVersion: CURRENT_PROTOCOL_VERSION,
         });
@@ -605,11 +608,29 @@ export function createProviderService(
         catalog: catalogToProto(catalog),
       });
     },
-    async postConnect() {
-      throw new ConnectError(
-        "provider does not support post connect",
-        Code.Unimplemented,
-      );
+    async postConnect(request) {
+      if (!provider.supportsPostConnect()) {
+        throw new ConnectError(
+          "provider does not support post connect",
+          Code.Unimplemented,
+        );
+      }
+      let metadata: Record<string, string> | null | undefined;
+      try {
+        metadata = await provider.postConnectMetadata(
+          providerConnectedToken(request.token),
+        );
+      } catch (error) {
+        throw new ConnectError(
+          `post connect: ${errorMessage(error)}`,
+          Code.Unknown,
+        );
+      }
+      return create(PostConnectResponseSchema, {
+        metadata: {
+          ...(metadata ?? {}),
+        },
+      });
     },
   };
 }
@@ -841,6 +862,29 @@ function providerHTTPSubjectResolutionContext(
     credential: request.credential,
     access: request.access,
     workflow: request.workflow,
+  };
+}
+
+function providerConnectedToken(
+  token?: ProtoIntegrationToken,
+): ConnectedToken {
+  const metadataJson = token?.metadataJson ?? "";
+  return {
+    id: token?.id ?? "",
+    subjectId: token?.userId ?? "",
+    integration: token?.integration ?? "",
+    connection: token?.connection ?? "",
+    instance: token?.instance ?? "",
+    accessToken: token?.accessToken ?? "",
+    refreshToken: token?.refreshToken ?? "",
+    scopes: token?.scopes ?? "",
+    expiresAt: timestampToDate(token?.expiresAt),
+    lastRefreshedAt: timestampToDate(token?.lastRefreshedAt),
+    refreshErrorCount: token?.refreshErrorCount ?? 0,
+    metadataJson,
+    metadata: stringRecordFromJSON(metadataJson),
+    createdAt: timestampToDate(token?.createdAt),
+    updatedAt: timestampToDate(token?.updatedAt),
   };
 }
 

--- a/sdk/typescript/tests/runtime.test.ts
+++ b/sdk/typescript/tests/runtime.test.ts
@@ -411,7 +411,7 @@ export const plugin = definePlugin({
   }
 });
 
-test("loadProviderFromTarget rejects legacy structural plugin objects without alpha.12 hook methods", async () => {
+test("loadProviderFromTarget rejects legacy structural plugin objects without alpha.13 hook methods", async () => {
   const root = makeTempDir("gestalt-typescript-runtime-legacy-structural-");
 
   try {
@@ -451,6 +451,79 @@ test("loadProviderFromTarget rejects legacy structural plugin objects without al
     return false;
   },
   writeManifestMetadata() {},
+  supportsPostConnect() {
+    return false;
+  },
+  async postConnectMetadata() {
+    return undefined;
+  },
+  async execute() {
+    return { status: 200, body: "{}" };
+  },
+};`,
+      "utf8",
+    );
+
+    await expect(loadProviderFromTarget(root)).rejects.toThrow(
+      "plugin:./provider.ts#plugin did not resolve to a Gestalt plugin provider",
+    );
+  } finally {
+    removeTempDir(root);
+  }
+});
+
+test("loadProviderFromTarget rejects structural plugin objects without the full runtime lifecycle contract", async () => {
+  const root = makeTempDir("gestalt-typescript-runtime-structural-runtime-base-");
+
+  try {
+    writeFileSync(
+      join(root, "package.json"),
+      JSON.stringify({
+        name: "structural-runtime-base-provider",
+        gestalt: {
+          provider: {
+            kind: "plugin",
+            target: "./provider.ts#plugin",
+          },
+        },
+      }),
+      "utf8",
+    );
+    writeFileSync(
+      join(root, "provider.ts"),
+      `export const plugin = {
+  kind: "integration",
+  name: "structural-runtime-base",
+  displayName: "Structural Runtime Base",
+  description: "structural plugin missing runtime base methods",
+  version: "1.0.0",
+  connectionMode: "unspecified",
+  authTypes: [],
+  connectionParams: {},
+  resolveName() {},
+  async configureProvider() {},
+  staticCatalog() {
+    return { name: "structural-runtime-base", operations: [] };
+  },
+  supportsSessionCatalog() {
+    return false;
+  },
+  async catalogForRequest() {
+    return undefined;
+  },
+  supportsManifestMetadata() {
+    return false;
+  },
+  writeManifestMetadata() {},
+  supportsPostConnect() {
+    return false;
+  },
+  async postConnectMetadata() {
+    return undefined;
+  },
+  async resolveHTTPSubject() {
+    return undefined;
+  },
   async execute() {
     return { status: 200, body: "{}" };
   },
@@ -559,7 +632,7 @@ test("integration provider service exposes metadata, configure, execute, and ses
   const metadata = await (service.getMetadata as any)();
   expect(metadata.name).toBe("basic-provider");
   expect(metadata.supportsSessionCatalog).toBe(true);
-  expect(metadata.supportsPostConnect).toBe(false);
+  expect(metadata.supportsPostConnect).toBe(true);
   expect(metadata.minProtocolVersion).toBe(CURRENT_PROTOCOL_VERSION);
   expect(metadata.maxProtocolVersion).toBe(CURRENT_PROTOCOL_VERSION);
   expect(
@@ -684,25 +757,27 @@ test("integration provider service exposes metadata, configure, execute, and ses
     "Session Hello ops user:user-123 identity viewer",
   );
 
-  await expectConnectCode(
-    (service.postConnect as any)(
-      create(PostConnectRequestSchema, {
-        token: {
-          id: "tok-123",
-          userId: "user:user-123",
-          integration: "basic-provider",
-          connection: "workspace",
-          instance: "__default__",
-          accessToken: "access-token",
-          metadataJson: JSON.stringify({
-            team_id: "T123",
-            user_id: "U456",
-          }),
-        },
-      }),
-    ),
-    Code.Unimplemented,
+  const postConnect = await (service.postConnect as any)(
+    create(PostConnectRequestSchema, {
+      token: {
+        id: "tok-123",
+        userId: "user:user-123",
+        integration: "basic-provider",
+        connection: "workspace",
+        instance: "__default__",
+        accessToken: "access-token",
+        metadataJson: JSON.stringify({
+          team_id: "T123",
+          user_id: "U456",
+        }),
+      },
+    }),
   );
+  expect(postConnect.metadata).toEqual({
+    "gestalt.external_identity.type": "fixture_identity",
+    "gestalt.external_identity.id": "workspace:__default__:user:user-123",
+    configured_connection: "workspace",
+  });
 });
 
 test("integration provider service labels metadata failures", async () => {
@@ -716,7 +791,7 @@ test("integration provider service labels metadata failures", async () => {
       },
     ],
   });
-  (plugin as any).supportsSessionCatalog = () => {
+  (plugin as any).supportsPostConnect = () => {
     throw new Error("metadata exploded");
   };
 


### PR DESCRIPTION
## Summary
- restore TypeScript plugin `postConnect` support in the runtime metadata and RPC surface
- require structural plugin exports to satisfy the full alpha.13 runtime lifecycle + hook surface, including `supportsPostConnect()` and `postConnectMetadata()`
- update the TypeScript SDK README dependency example to `@valon-technologies/gestalt@0.0.1-alpha.13`

## Interfaces
```ts
export const plugin = definePlugin({
  postConnect(token) {
    return {
      "gestalt.external_identity.type": "example",
      "gestalt.external_identity.id": `${token.connection}:${token.instance}:${token.subjectId}`,
    };
  },
  operations: [/* ... */],
});
```

Structural plugin exports must now implement the full runtime lifecycle contract as well as the alpha.13 plugin hooks.

## Examples
```sh
cd sdk/typescript && bun run check
gestaltd provider validate --path /path/to/plugin/manifest.yaml
```

## Testing
```sh
cd sdk/typescript
bun run check
```
