### PR TITLE
Stabilize local agent session/turn flows and refresh CLI/API docs

### DIFF
--- a/.github/workflows/build-gestaltd.yml
+++ b/.github/workflows/build-gestaltd.yml
@@ -39,6 +39,7 @@ jobs:
         with:
           version: v2.11.3
           working-directory: gestaltd
+          verify: false
 
   test:
     name: Go Tests

--- a/.github/workflows/release-gestalt-cli.yml
+++ b/.github/workflows/release-gestalt-cli.yml
@@ -52,11 +52,11 @@ jobs:
       path-filters: |
         gestalt
       component-summary: |
-        Command-line client for authenticating with Gestalt, connecting integrations, invoking operations, and managing API tokens from the terminal.
+        Command-line client for authenticating with Gestalt, working with integrations and workflows, and running interactive agent sessions from the terminal.
       install-markdown: |
         - Homebrew: `brew upgrade valon-technologies/gestalt/gestalt`
         - Docker: `docker pull valontechnologies/gestalt:${version}`
-        - Docs: [CLI reference](https://gestaltd.ai/reference/cli)
+        - Docs: [CLI guide](https://gestaltd.ai/client/cli)
       exclude-subject-patterns: |
         ^Update gestalt formula to v
       download-artifact-pattern: 'gestalt-*'
@@ -71,7 +71,7 @@ jobs:
       image-url: https://hub.docker.com/r/valontechnologies/gestalt
       dockerfile: gestalt/Dockerfile
       version-prefix: 'gestalt/v'
-      short-description: CLI client for managing Gestalt integrations, authentication, and operations.
+      short-description: CLI client for Gestalt authentication, integrations, workflows, and interactive agents.
       readme-filepath: docs/dockerhub/gestalt.md
       download-artifact-pattern: 'gestalt-linux-*'
       platforms: 'linux/amd64,linux/arm64,linux/arm/v7'

--- a/docs/content/client/cli/index.mdx
+++ b/docs/content/client/cli/index.mdx
@@ -4,7 +4,7 @@ asIndexPage: true
 
 # CLI
 
-`gestalt` is the client CLI for interacting with a running `gestaltd` server. It handles authentication, plugin connections, operation invocation, workflow management, agent runs, and API token management. A [Docker image](/client/cli/docker) is also available for CI and containerized environments.
+`gestalt` is the client CLI for interacting with a running `gestaltd` server. It handles authentication, plugin connections, operation invocation, workflow management, agent sessions and turns, and API token management. A [Docker image](/client/cli/docker) is also available for CI and containerized environments.
 
 ## Global flags
 
@@ -31,7 +31,9 @@ asIndexPage: true
 | `gestalt workflow triggers ...` | Create, list, inspect, update, pause, resume, or delete workflow triggers. |
 | `gestalt workflow events publish ...` | Publish an event into the workflow system. |
 | `gestalt workflow runs ...` | List, inspect, and cancel workflow runs. |
-| `gestalt agent runs ...` | Create, list, inspect, cancel, and stream global agent runs. |
+| `gestalt agent` | Start or resume an interactive agent session. |
+| `gestalt agent sessions ...` | Create, list, inspect, and update agent sessions. |
+| `gestalt agent turns ...` | Create, list, inspect, cancel, and stream agent turns. |
 | `gestalt tokens create\|list\|revoke` | Manage Gestalt API tokens. |
 
 ## URL resolution
@@ -43,7 +45,7 @@ The CLI resolves the server URL in this order:
 3. project-local `.gestalt/config.json`
 4. user-local config at `~/.config/gestalt/config.json`
 
-For authentication, the CLI checks `GESTALT_API_KEY` first, then stored credentials from `gestalt auth login`.
+For authentication, the CLI checks `GESTALT_API_KEY` first, then stored credentials from `gestalt auth login`. When the target server reports `loginSupported: false` from `/api/v1/auth/info`, the CLI can operate without stored credentials or an API key.
 
 ## Authentication Status
 
@@ -200,37 +202,31 @@ gestalt workflow runs get <run-id>
 gestalt workflow runs cancel <run-id> --reason "operator requested"
 ```
 
-### Agent Runs
+### Agent
 
 ```sh
-gestalt agent runs create \
-  --provider managed \
-  --model gpt-5.4 \
-  --system "Be concise." \
+gestalt agent --provider simple --model fast
+gestalt agent --session <session-id>
+
+gestalt agent sessions create --provider simple --model fast
+gestalt agent sessions list --provider simple --state active
+gestalt agent sessions get <session-id>
+gestalt agent sessions update <session-id> --state archived
+
+gestalt agent turns create <session-id> \
   --message "Summarize the roadmap risk." \
-  --idempotency-key agent-run-1
+  --tool roadmap:sync
+gestalt agent turns list <session-id> --status succeeded
+gestalt agent turns get <turn-id>
+gestalt agent turns cancel <turn-id> --reason "operator requested"
+gestalt agent turns events list <turn-id> --after 0 --limit 100
+gestalt agent turns events stream <turn-id> --after 100
 
-gestalt agent runs list --provider managed --status running
-gestalt agent runs get <run-id>
-gestalt agent runs cancel <run-id> --reason "operator requested"
-gestalt agent runs events list <run-id> --after 0 --limit 100
-gestalt agent runs events stream <run-id> --after 100
-
-# by default, global agent runs get the caller's authorized safe tool set.
-# use --tool to add a specific tool beyond that default:
-gestalt agent runs create \
-  --provider managed \
-  --message "Summarize the roadmap risk." \
-  --tool roadmap:push
-
-# advanced fields such as responseSchema, metadata, or explicit-only tool mode
+# advanced fields such as responseSchema, metadata, or providerOptions
 # go through --input, which also accepts "-" for stdin:
-cat <<'JSON' | gestalt --format json agent runs create --input -
+cat <<'JSON' | gestalt --format json agent turns create session-1 --input -
 {
-  "provider": "managed",
   "model": "gpt-5.4",
-  "toolSource": "explicit",
-  "sessionRef": "session-1",
   "messages": [
     {"role": "user", "text": "Summarize the roadmap risk."}
   ],
@@ -248,14 +244,38 @@ cat <<'JSON' | gestalt --format json agent runs create --input -
 JSON
 ```
 
-`gestalt agent runs create` supports repeated `--system`, repeated `--message`,
-repeated `--tool plugin:operation`, `--session-ref`, `--idempotency-key`, and
-`--input`. When you omit `--tool`, global runs attach the caller's authorized
-safe tool set by default. Use `--format json` when you want the raw HTTP
-response shape instead of the default table view.
+`gestalt agent` is the interactive path. It creates a session when you pass
+`--provider` or resumes an existing one with `--session`. The first turn in a
+CLI session can include repeated `--system` messages, repeated `--message`
+prompts, and repeated `--tool plugin:operation` additions. During execution,
+the CLI renders canonical turn events, polls for terminal state, and resolves
+pending interactions inline.
 
-`gestalt agent runs events list` reads stored events from
-`GET /api/v1/agent/runs/{runID}/events`. `--after` is an event sequence cursor
-and `--limit` controls the page size. `gestalt agent runs events stream` reads
-`GET /api/v1/agent/runs/{runID}/events/stream` and writes the raw server-sent
-event stream to stdout.
+`gestalt agent turns create` is the non-interactive equivalent. It supports
+repeated `--system`, repeated `--message`, repeated `--tool plugin:operation`,
+`--idempotency-key`, and `--input`. `gestalt agent turns events list` reads
+stored events from `GET /api/v1/agent/turns/{turnID}/events`. `--after` is an
+event sequence cursor and `--limit` controls the page size. `gestalt agent
+turns events stream` reads `GET /api/v1/agent/turns/{turnID}/events/stream`
+and writes the raw server-sent event stream to stdout.
+
+### Local Quickstart
+
+For a no-auth local setup with the first-party `agent/simple` provider:
+
+```sh
+cd /path/to/gestalt-providers/agent/simple
+uv sync --group dev
+
+cd /path/to/gestalt
+go run ./cmd/gestaltd init --config ./config.yaml
+go run ./cmd/gestaltd serve --locked --config ./config.yaml
+
+gestalt --url http://localhost:18080 agent --provider simple --model fast
+```
+
+Notes:
+
+- `uv sync --group dev` matters for source-backed Python providers. `gestaltd init` prefers the provider-local `.venv` when it builds locked artifacts.
+- If your local server has no platform auth configured, the CLI can connect without `GESTALT_API_KEY`.
+- Successful turns still need the upstream model credentials expected by your configured provider, such as `OPENAI_API_KEY` or `ANTHROPIC_API_KEY` for `agent/simple`.

--- a/docs/content/configuration.mdx
+++ b/docs/content/configuration.mdx
@@ -539,45 +539,34 @@ triggers are reconciled into the provider at startup. See
 ## Configuring agent providers
 
 The `providers.agent` block declares the global pool of agent backends. There
-is no `server.providers.agent`: a run request either names a provider
+is no `server.providers.agent`: a session request either names a provider
 explicitly or inherits the sole/default `providers.agent` entry when it omits
 `provider`.
 
 ```yaml
 providers:
   agent:
-    openai:
-      source: ./providers/agent/openai/manifest.yaml
+    simple:
+      source: ./providers/agent/simple/manifest.yaml
       default: true
       indexeddb:
         provider: default
-        db: agent_openai
-        objectStores:
-          - runs
-          - run_idempotency
+        db: simple_agent
       config:
-        model: gpt-5.4
-        apiKey:
-          secret:
-            provider: default
-            name: openai-api-key
-
-    claude:
-      source: ./providers/agent/claude/manifest.yaml
-      config:
-        model: claude-sonnet
-        apiKey:
-          secret:
-            provider: default
-            name: anthropic-api-key
+        runStore: runs
+        idempotencyStore: run_idempotency
+        defaultModel: fast
+        aliases:
+          fast: openai/gpt-4.1-mini
+          deep: anthropic/claude-sonnet-4-20250514
 ```
 
-Agent providers receive neutral run requests with `messages`, optional tools,
-optional structured-output schema, and optional `sessionRef`. The same
-provider pool is used by the global agent runs API/CLI and by plugins that use
-the host agent manager surface. Providers that need durable state can opt into
-a host IndexedDB binding with `indexeddb` and use the SDK IndexedDB helper
-against `GESTALT_INDEXEDDB_SOCKET`.
+Agent providers receive canonical session and turn requests with `messages`,
+optional tools, and optional structured-output schema. The same provider pool
+is used by the global agent API/CLI and by plugins that use the host agent
+manager surface. Providers that need durable state can opt into a host
+IndexedDB binding with `indexeddb` and use the SDK IndexedDB helper against
+`GESTALT_INDEXEDDB_SOCKET`.
 
 See [Agent](/providers/agent) for the provider model and
 [Custom Providers > Agent](/custom-providers/agent) if you need to implement

--- a/docs/content/custom-providers/agent.mdx
+++ b/docs/content/custom-providers/agent.mdx
@@ -2,19 +2,13 @@ import { Tabs } from 'nextra/components'
 
 # Agent
 
-This page covers building custom agent providers. If you only need to
+This page covers building custom `kind: agent` providers. If you only need to
 configure an agent backend for a deployment, use
 [Providers > Agent](/providers/agent).
 
-Agent providers implement a neutral run lifecycle over messages, tools, and
-optional session continuation state. They are a good fit when you want Gestalt
-to select between OpenAI-, Anthropic-, or custom-backed agent engines without
-hard-coding those SDKs into every caller.
-
-Whether the provider runs directly on the `gestaltd` host or inside a hosted
-runtime is an operator decision, not an authoring change. A provider that
-implements `kind: agent` can be launched locally or through
-`providers.agent.<name>.runtime` without changing its protocol surface.
+Agent providers are canonical backends for agent state. A provider owns its
+sessions, turns, interactions, capabilities, and turn events. Gestalt owns the
+public HTTP/CLI/SDK facade and the host tool-callback surface.
 
 ## Manifest
 
@@ -25,73 +19,63 @@ kind: agent
 source: github.com/your-org/agent/example
 version: 0.0.1
 displayName: Example Agent
-description: Neutral agent provider that queues runs onto a vendor backend.
+description: Minimal session-and-turn agent provider
 spec:
   configSchemaPath: ./agent_config.json
 ```
 
+Use `source: ./manifest.yaml` during development. For production, publish a
+provider release archive and reference the resulting metadata URL.
+
 ## Provider interface
 
-The agent service now includes six provider methods:
+The agent provider service now exposes the canonical lifecycle directly:
 
 | Method | Purpose |
 | --- | --- |
-| `StartRun` | Create or queue a run from messages, resolved tools, and optional session state |
-| `GetRun` | Inspect one run by `run_id` |
-| `ListRuns` | Return currently known runs for this provider |
-| `CancelRun` | Request cancellation for one run |
-| `GetCapabilities` | Advertise which optional agent features the provider actually supports |
-| `ResumeRun` | Continue a run after Gestalt resolves a pending interaction |
+| `CreateSession` | Create a new provider-owned session |
+| `GetSession` | Inspect one session by `session_id` |
+| `ListSessions` | Return sessions currently known to this provider |
+| `UpdateSession` | Update session state, metadata, or `client_ref` |
+| `CreateTurn` | Persist and start a new turn within a session |
+| `GetTurn` | Inspect one turn by `turn_id` |
+| `ListTurns` | List turns for a session |
+| `CancelTurn` | Request cancellation for one turn |
+| `ListTurnEvents` | Return stored events for a turn after a sequence cursor |
+| `GetInteraction` | Inspect one interaction |
+| `ListInteractions` | List interactions for a turn |
+| `ResolveInteraction` | Apply a caller-provided resolution to a pending interaction |
+| `GetCapabilities` | Advertise which optional agent features the provider supports |
 
-Providers can also call back into Gestalt through the host service:
+Providers can call back into Gestalt through the host service:
 
 | Host method | Purpose |
 | --- | --- |
-| `ExecuteTool` | Ask Gestalt to execute a bound plugin operation during a run |
-| `EmitEvent` | Append a run event to Gestalt-managed run storage |
-| `RequestInteraction` | Pause for human approval or clarification through a canonical host callback |
+| `ExecuteTool` | Ask Gestalt to execute a bound plugin operation during a turn |
 
-These callbacks work the same way when the provider is launched inside a hosted
-runtime.
+These callbacks work the same way when the provider runs directly on the
+`gestaltd` host or inside a hosted runtime.
 
-## Run shape
+## Canonical objects
 
-```json
-{
-  "runId": "run-123",
-  "providerName": "openai",
-  "model": "gpt-5.4",
-  "messages": [
-    {
-      "role": "system",
-      "text": "Be concise.",
-      "parts": [
-        { "type": "text", "text": "Be concise." }
-      ]
-    },
-    {
-      "role": "user",
-      "text": "Summarize the roadmap risk.",
-      "parts": [
-        { "type": "text", "text": "Summarize the roadmap risk." }
-      ],
-      "metadata": {
-        "ticket": "RD-42"
-      }
-    }
-  ],
-  "tools": [
-    {
-      "id": "roadmap/sync",
-      "name": "sync_roadmap",
-      "description": "Sync the roadmap plugin operation",
-      "target": { "pluginName": "roadmap", "operation": "sync" }
-    }
-  ],
-  "sessionRef": "session-123",
-  "executionRef": "run-123"
-}
-```
+Provider methods exchange canonical objects rather than vendor-native payloads:
+
+- `AgentSession`
+- `AgentTurn`
+- `AgentInteraction`
+- `AgentTurnEvent`
+
+Key fields:
+
+- sessions carry `id`, `provider_name`, `model`, `client_ref`, `state`, and timestamps
+- turns carry `id`, `session_id`, `status`, `messages`, `output_text`, optional `structured_output`, and timestamps
+- interactions carry `id`, `turn_id`, `session_id`, `type`, `state`, `request`, and `resolution`
+- turn events carry `turn_id`, monotonically increasing `seq`, canonical `type`, `source`, `visibility`, and structured `data`
+
+Providers should return canonical IDs exactly as persisted. Gestalt does not
+rewrite session or turn IDs on the provider's behalf.
+
+## Go example
 
 <Tabs items={['Go', 'TypeScript']}>
   <Tabs.Tab>
@@ -99,74 +83,137 @@ runtime.
     package main
 
     import (
-    	"context"
-    	"log"
+      "context"
+      "log"
 
-    	gestalt "github.com/valon-technologies/gestalt/sdk/go"
-    	proto "github.com/valon-technologies/gestalt/sdk/go/gen/v1"
+      gestalt "github.com/valon-technologies/gestalt/sdk/go"
+      proto "github.com/valon-technologies/gestalt/sdk/go/gen/v1"
+      "google.golang.org/protobuf/types/known/timestamppb"
     )
 
     type provider struct {
-    	proto.UnimplementedAgentProviderServer
+      proto.UnimplementedAgentProviderServer
     }
 
-    func (p *provider) StartRun(ctx context.Context, req *proto.StartAgentProviderRunRequest) (*proto.BoundAgentRun, error) {
-    	return &proto.BoundAgentRun{
-    		Id:           req.GetRunId(),
-    		ProviderName: req.GetProviderName(),
-    		Model:        req.GetModel(),
-    		Status:       proto.AgentRunStatus_AGENT_RUN_STATUS_PENDING,
-    		Messages:     req.GetMessages(),
-    		SessionRef:   req.GetSessionRef(),
-    		ExecutionRef: req.GetExecutionRef(),
-    	}, nil
+    func (p *provider) CreateSession(ctx context.Context, req *proto.CreateAgentProviderSessionRequest) (*proto.AgentSession, error) {
+      return &proto.AgentSession{
+        Id:           req.GetSessionId(),
+        ProviderName: "example",
+        Model:        req.GetModel(),
+        ClientRef:    req.GetClientRef(),
+        State:        proto.AgentSessionState_AGENT_SESSION_STATE_ACTIVE,
+        CreatedAt:    timestamppb.Now(),
+        UpdatedAt:    timestamppb.Now(),
+      }, nil
+    }
+
+    func (p *provider) GetSession(_ context.Context, req *proto.GetAgentProviderSessionRequest) (*proto.AgentSession, error) {
+      return &proto.AgentSession{
+        Id:           req.GetSessionId(),
+        ProviderName: "example",
+        State:        proto.AgentSessionState_AGENT_SESSION_STATE_ACTIVE,
+      }, nil
+    }
+
+    func (p *provider) ListSessions(context.Context, *proto.ListAgentProviderSessionsRequest) (*proto.ListAgentProviderSessionsResponse, error) {
+      return &proto.ListAgentProviderSessionsResponse{}, nil
+    }
+
+    func (p *provider) UpdateSession(_ context.Context, req *proto.UpdateAgentProviderSessionRequest) (*proto.AgentSession, error) {
+      return &proto.AgentSession{
+        Id:           req.GetSessionId(),
+        ProviderName: "example",
+        ClientRef:    req.GetClientRef(),
+        State:        req.GetState(),
+        UpdatedAt:    timestamppb.Now(),
+      }, nil
+    }
+
+    func (p *provider) CreateTurn(ctx context.Context, req *proto.CreateAgentProviderTurnRequest) (*proto.AgentTurn, error) {
+      return &proto.AgentTurn{
+        Id:           req.GetTurnId(),
+        SessionId:    req.GetSessionId(),
+        ProviderName: "example",
+        Model:        req.GetModel(),
+        Status:       proto.AgentExecutionStatus_AGENT_EXECUTION_STATUS_RUNNING,
+        Messages:     req.GetMessages(),
+        CreatedAt:    timestamppb.Now(),
+        StartedAt:    timestamppb.Now(),
+        ExecutionRef: req.GetExecutionRef(),
+      }, nil
+    }
+
+    func (p *provider) GetTurn(_ context.Context, req *proto.GetAgentProviderTurnRequest) (*proto.AgentTurn, error) {
+      return &proto.AgentTurn{
+        Id:           req.GetTurnId(),
+        SessionId:    "session-1",
+        ProviderName: "example",
+        Status:       proto.AgentExecutionStatus_AGENT_EXECUTION_STATUS_SUCCEEDED,
+        OutputText:   "done",
+        CompletedAt:  timestamppb.Now(),
+      }, nil
+    }
+
+    func (p *provider) ListTurns(context.Context, *proto.ListAgentProviderTurnsRequest) (*proto.ListAgentProviderTurnsResponse, error) {
+      return &proto.ListAgentProviderTurnsResponse{}, nil
+    }
+
+    func (p *provider) CancelTurn(_ context.Context, req *proto.CancelAgentProviderTurnRequest) (*proto.AgentTurn, error) {
+      return &proto.AgentTurn{
+        Id:            req.GetTurnId(),
+        SessionId:     "session-1",
+        ProviderName:  "example",
+        Status:        proto.AgentExecutionStatus_AGENT_EXECUTION_STATUS_CANCELED,
+        StatusMessage: "operator requested",
+        CompletedAt:   timestamppb.Now(),
+      }, nil
+    }
+
+    func (p *provider) ListTurnEvents(context.Context, *proto.ListAgentProviderTurnEventsRequest) (*proto.ListAgentProviderTurnEventsResponse, error) {
+      return &proto.ListAgentProviderTurnEventsResponse{}, nil
+    }
+
+    func (p *provider) GetInteraction(_ context.Context, req *proto.GetAgentProviderInteractionRequest) (*proto.AgentInteraction, error) {
+      return &proto.AgentInteraction{Id: req.GetInteractionId()}, nil
+    }
+
+    func (p *provider) ListInteractions(context.Context, *proto.ListAgentProviderInteractionsRequest) (*proto.ListAgentProviderInteractionsResponse, error) {
+      return &proto.ListAgentProviderInteractionsResponse{}, nil
+    }
+
+    func (p *provider) ResolveInteraction(_ context.Context, req *proto.ResolveAgentProviderInteractionRequest) (*proto.AgentInteraction, error) {
+      return &proto.AgentInteraction{
+        Id:         req.GetInteractionId(),
+        State:      proto.AgentInteractionState_AGENT_INTERACTION_STATE_RESOLVED,
+        Resolution: req.GetResolution(),
+        ResolvedAt: timestamppb.Now(),
+      }, nil
     }
 
     func (p *provider) GetCapabilities(context.Context, *proto.GetAgentProviderCapabilitiesRequest) (*proto.AgentProviderCapabilities, error) {
       return &proto.AgentProviderCapabilities{
-        StreamingText:       true,
-        ToolCalls:           true,
-        StructuredOutput:    true,
-        SessionContinuation: true,
-        Approvals:           true,
-        ResumableRuns:       true,
-      }, nil
-    }
-
-    func (p *provider) GetRun(_ context.Context, req *proto.GetAgentProviderRunRequest) (*proto.BoundAgentRun, error) {
-    	return &proto.BoundAgentRun{Id: req.GetRunId()}, nil
-    }
-
-    func (p *provider) ListRuns(context.Context, *proto.ListAgentProviderRunsRequest) (*proto.ListAgentProviderRunsResponse, error) {
-    	return &proto.ListAgentProviderRunsResponse{}, nil
-    }
-
-    func (p *provider) CancelRun(_ context.Context, req *proto.CancelAgentProviderRunRequest) (*proto.BoundAgentRun, error) {
-    	return &proto.BoundAgentRun{
-    		Id:     req.GetRunId(),
-    		Status: proto.AgentRunStatus_AGENT_RUN_STATUS_CANCELED,
-    	}, nil
-    }
-
-    func (p *provider) ResumeRun(_ context.Context, req *proto.ResumeAgentProviderRunRequest) (*proto.BoundAgentRun, error) {
-      return &proto.BoundAgentRun{
-        Id:     req.GetRunId(),
-        Status: proto.AgentRunStatus_AGENT_RUN_STATUS_RUNNING,
+        StreamingText:    true,
+        ToolCalls:        true,
+        StructuredOutput: true,
+        Interactions:     true,
+        ResumableTurns:   true,
       }, nil
     }
 
     func main() {
-    	if err := gestalt.ServeAgentProvider(context.Background(), &provider{}); err != nil {
-    		log.Fatal(err)
-    	}
+      if err := gestalt.ServeAgentProvider(context.Background(), &provider{}); err != nil {
+        log.Fatal(err)
+      }
     }
     ```
   </Tabs.Tab>
   <Tabs.Tab>
     ```ts
     import {
+      AgentExecutionStatus,
       AgentHost,
-      AgentRunStatus,
+      AgentInteractionState,
+      AgentSessionState,
       defineAgentProvider,
     } from "@valon-technologies/gestalt";
 
@@ -174,134 +221,135 @@ runtime.
 
     export const provider = defineAgentProvider({
       displayName: "Example Agent",
-      description: "Neutral run-based agent provider",
-      async startRun(request) {
+      description: "Minimal session-and-turn agent provider",
+
+      async createSession(request) {
+        return {
+          id: request.sessionId,
+          providerName: "example",
+          model: request.model,
+          clientRef: request.clientRef,
+          state: AgentSessionState.ACTIVE,
+        };
+      },
+
+      async getSession(request) {
+        return {
+          id: request.sessionId,
+          providerName: "example",
+          state: AgentSessionState.ACTIVE,
+        };
+      },
+
+      async listSessions() {
+        return [];
+      },
+
+      async updateSession(request) {
+        return {
+          id: request.sessionId,
+          providerName: "example",
+          clientRef: request.clientRef,
+          state: request.state,
+        };
+      },
+
+      async createTurn(request) {
         if (request.tools.length > 0) {
           await host.executeTool({
-            runId: request.runId,
+            sessionId: request.sessionId,
+            turnId: request.turnId,
             toolCallId: "call-1",
             toolId: request.tools[0].id,
             arguments: { taskId: "task-123" },
           });
         }
 
-        if (request.metadata?.requireApproval === true) {
-          await host.requestInteraction({
-            runId: request.runId,
-            type: "approval",
-            title: "Approve external call",
-            prompt: "Allow this provider to call the vendor backend?",
-            request: { host: "api.openai.com" },
-          });
-        }
-
         return {
-          id: request.runId,
-          providerName: request.providerName || "example",
+          id: request.turnId,
+          sessionId: request.sessionId,
+          providerName: "example",
           model: request.model,
-          status: AgentRunStatus.PENDING,
+          status: AgentExecutionStatus.RUNNING,
           messages: request.messages,
-          sessionRef: request.sessionRef,
           executionRef: request.executionRef,
         };
       },
-      async getRun(request) {
-        return { id: request.runId, providerName: "example", status: AgentRunStatus.RUNNING };
+
+      async getTurn(request) {
+        return {
+          id: request.turnId,
+          sessionId: "session-1",
+          providerName: "example",
+          status: AgentExecutionStatus.SUCCEEDED,
+          outputText: "done",
+        };
       },
-      async listRuns() {
+
+      async listTurns() {
         return [];
       },
-      async cancelRun(request) {
-        return { id: request.runId, providerName: "example", status: AgentRunStatus.CANCELED };
+
+      async cancelTurn(request) {
+        return {
+          id: request.turnId,
+          sessionId: "session-1",
+          providerName: "example",
+          status: AgentExecutionStatus.CANCELED,
+          statusMessage: "operator requested",
+        };
       },
+
+      async listTurnEvents() {
+        return [];
+      },
+
+      async getInteraction(request) {
+        return {
+          id: request.interactionId,
+          state: AgentInteractionState.PENDING,
+        };
+      },
+
+      async listInteractions() {
+        return [];
+      },
+
+      async resolveInteraction(request) {
+        return {
+          id: request.interactionId,
+          state: AgentInteractionState.RESOLVED,
+          resolution: request.resolution,
+        };
+      },
+
       async getCapabilities() {
         return {
           streamingText: true,
           toolCalls: true,
           structuredOutput: true,
-          sessionContinuation: true,
-          approvals: true,
-          resumableRuns: true,
+          interactions: true,
+          resumableTurns: true,
         };
-      },
-      async resumeRun(request) {
-        return { id: request.runId, providerName: "example", status: AgentRunStatus.RUNNING };
       },
     });
     ```
   </Tabs.Tab>
 </Tabs>
 
-## Tool callbacks
+## Execution model
 
-When the provider wants Gestalt to execute a bound plugin operation, it calls
-`AgentHost.ExecuteTool`:
+`CreateTurn` should persist the turn and return quickly, usually in
+`RUNNING` or `PENDING`. Long-running model/tool work should continue in the
+background. Callers then use `GetTurn`, `ListTurnEvents`, and
+`ListInteractions` to observe progress or resolve pending human input.
 
-```json
-{
-  "runId": "run-123",
-  "toolCallId": "call-1",
-  "toolId": "roadmap/sync",
-  "arguments": {
-    "taskId": "task-123"
-  }
-}
-```
-
-Gestalt returns an HTTP-like envelope:
-
-```json
-{
-  "status": 200,
-  "body": "{\"ok\":true,\"taskId\":\"task-123\",\"synced\":true}"
-}
-```
-
-## Interactions
-
-When the provider needs human input, it can request a persisted interaction:
-
-```json
-{
-  "runId": "run-123",
-  "type": "approval",
-  "title": "Approve external call",
-  "prompt": "Allow this provider to call the vendor backend?",
-  "request": {
-    "host": "api.openai.com"
-  }
-}
-```
-
-Gestalt returns an interaction record that the provider can later resume from:
-
-```json
-{
-  "id": "interaction-123",
-  "runId": "run-123",
-  "type": "approval",
-  "state": "pending",
-  "title": "Approve external call",
-  "prompt": "Allow this provider to call the vendor backend?",
-  "request": {
-    "host": "api.openai.com"
-  }
-}
-```
-
-The user-facing HTTP surface can then list those records at
-`GET /api/v1/agent/runs/{runID}/interactions` and resume the paused run through
-`POST /api/v1/agent/runs/{runID}/resume`.
-
-## IndexedDB binding
-
-Agent providers do have a standard IndexedDB binding. If you configure
-`providers.agent.<name>.indexeddb`, Gestalt exposes the selected store to the
-provider through the SDK `GESTALT_INDEXEDDB_SOCKET`, just like other hosted
-surfaces. The provider still owns its own object-store schema and durable-state
-model.
+If your provider needs durable state, configure `providers.agent.<name>.indexeddb`
+and store your canonical records there. Gestalt does not persist session or
+turn content for you.
 
 ## What to read next
 
-- [Providers > Agent](/providers/agent): operator-facing configuration model
-- [Custom Providers > Releasing](/custom-providers/releasing): packaging and publishing provider releases
+- [Providers > Agent](/providers/agent): deployment-side configuration
+- [HTTP API](/reference/http-api): caller-facing session and turn routes
+- [Reference > Config File](/reference/config-file#providersagent): `providers.agent` YAML

--- a/docs/content/custom-providers/index.mdx
+++ b/docs/content/custom-providers/index.mdx
@@ -12,7 +12,7 @@ deployment, start with [Providers](/providers).
 
 - Implementing executable or declarative plugin providers
 - Implementing custom runtime providers for hosted executable-plugin execution
-- Implementing custom agent providers for run-based reasoning backends
+- Implementing custom agent providers for session-and-turn reasoning backends
 - Building custom authentication, authorization, cache, IndexedDB, S3, secrets,
   workflow, and UI providers
 - Testing providers from local source with `source: ./manifest.yaml`
@@ -39,7 +39,7 @@ providers:
 
 - [Plugin](/custom-providers/plugins): custom tool providers, executable
   operations, declarative surfaces, and hybrid catalogs
-- [Agent](/custom-providers/agent): custom run-based agent providers and tool callbacks
+- [Agent](/custom-providers/agent): custom session-and-turn agent providers and tool callbacks
 - [Runtime](/custom-providers/runtime): hosted runtime backends for executable plugins
 - [Authentication](/custom-providers/authentication): platform login providers and optional bearer
   token validation

--- a/docs/content/providers/agent.mdx
+++ b/docs/content/providers/agent.mdx
@@ -2,126 +2,121 @@ import { Callout } from 'nextra/components'
 
 # Agent
 
-Gestalt agents are a standalone global provider primitive for run-based
-reasoning. An agent provider accepts messages, optional tools, optional
-structured-output contracts, and optional session continuation state, then
-returns a run object you can inspect or cancel later. Providers can also
-advertise optional capabilities and pause on canonical human interactions
-without changing the caller-facing run shape.
+Gestalt agent providers are global backends that own canonical agent state:
+sessions, turns, interactions, and turn events. Callers create a session,
+submit turns into that session, then inspect or stream the resulting turn
+state through the shared Gestalt HTTP API, CLI, or SDKs.
 
 <Callout type="info">
-  Agent providers are global, not plugin-scoped. A run either selects a named
-  `providers.agent` entry explicitly or inherits the sole/default provider when
-  it omits `provider`.
+  Agent providers are global, not plugin-scoped. A session either selects a
+  named `providers.agent` entry explicitly or inherits the sole/default
+  provider when it omits `provider`.
 </Callout>
 
 ## Mental model
 
-Use an agent provider when you want a neutral backend that can reason over
-messages and tools without baking a specific vendor SDK into every plugin or
-HTTP client.
+Use an agent provider when you want one portable interface for:
 
-- `providers.agent.<name>` defines the backend pool.
-- The provider owns the agent-side run lifecycle and any provider-specific
-  session continuation state.
-- The provider can advertise capabilities such as streaming text, structured
-  output, resumable runs, and approvals through the shared provider contract.
-- Gestalt can pass resolved tool definitions into the provider and receive tool
-  callbacks, run events, and interaction requests back through the host agent
-  socket.
-- The same provider pool is used by the global agent runs surfaces and by
-  plugins calling the host agent manager.
+- multi-turn sessions
+- asynchronous turns
+- tool execution through Gestalt plugin operations
+- provider-owned approvals, clarifications, and other interactions
+- stored event history for rendering or replay
 
 This is intentionally different from `runtime`, which decides where executable
-plugins run, and from `workflow`, which decides when a target runs.
+providers run, and from `workflow`, which decides when a target runs.
 
 ## Configuring `providers.agent`
 
 ```yaml
 providers:
+  indexeddb:
+    main:
+      source: ./providers/indexeddb/relationaldb/manifest.yaml
+      config:
+        dsn: sqlite:///tmp/gestalt.db
+
   agent:
-    openai:
-      source: ./providers/agent/openai/manifest.yaml
+    simple:
+      source: ./providers/agent/simple/manifest.yaml
       default: true
       indexeddb:
-        provider: default
-        db: agent_openai
-        objectStores:
-          - runs
-          - run_idempotency
+        provider: main
+        db: simple_agent
       config:
-        model: gpt-5.4
-        baseURL: https://api.openai.com/v1
-        apiKey:
-          secret:
-            provider: default
-            name: openai-api-key
-
-    claude:
-      source: ./providers/agent/claude/manifest.yaml
-      config:
-        model: claude-sonnet
-        apiKey:
-          secret:
-            provider: default
-            name: anthropic-api-key
+        runStore: runs
+        idempotencyStore: run_idempotency
+        defaultModel: fast
+        aliases:
+          fast: openai/gpt-4.1-mini
+          deep: anthropic/claude-sonnet-4-20250514
+        maxSteps: 8
+        timeoutSeconds: 120
 ```
 
 If exactly one agent provider is configured, or one is marked `default: true`,
-then run requests may omit `provider`.
+session creation may omit `provider`.
 
 If an agent provider needs durable state, configure `indexeddb` on that
 provider entry. Gestalt exposes the selected store to the provider process as
-the standard SDK `GESTALT_INDEXEDDB_SOCKET`; the provider still owns its run
-record schema and object-store names.
+the standard SDK `GESTALT_INDEXEDDB_SOCKET`, but the provider still owns the
+canonical session, turn, interaction, and event records stored there.
 
-If you want the agent provider to run in a hosted sandbox instead of directly
-on the `gestaltd` host, add a `runtime` block to that same
-`providers.agent.<name>` entry:
+If you want the provider to run in a hosted sandbox instead of directly on the
+`gestaltd` host, add a `runtime` block to that same `providers.agent.<name>`
+entry:
 
 ```yaml
 providers:
   agent:
-    openai:
-      source: ./providers/agent/openai/manifest.yaml
+    simple:
+      source: ./providers/agent/simple/manifest.yaml
       runtime:
         provider: modal
         image: ghcr.io/valon/gestalt-python-runtime:latest
       allowedHosts:
         - api.openai.com
+        - api.anthropic.com
       config:
-        model: gpt-5.4
+        defaultModel: fast
 ```
 
-This keeps the agent interface the same for callers. The run request still
-targets `provider: openai`. The only difference is where the provider process
-executes and how `gestaltd` enforces host-service access and egress.
+This keeps the caller interface the same. The request still targets
+`provider: simple`. The only difference is where the provider executes and how
+`gestaltd` enforces host-service access and egress.
 
-## Request shape
+## Session and turn shape
 
-The neutral agent run shape is intentionally small:
+The caller-facing contract is split into two steps:
+
+1. Create or look up a session.
+2. Create turns inside that session.
+
+Example session request:
 
 ```json
 {
-  "provider": "openai",
-  "model": "gpt-5.4",
+  "provider": "simple",
+  "model": "fast",
+  "clientRef": "roadmap-risk"
+}
+```
+
+Example turn request:
+
+```json
+{
+  "model": "fast",
   "messages": [
     {
-      "role": "system",
-      "text": "Be concise.",
-      "parts": [
-        { "type": "text", "text": "Be concise." }
-      ]
-    },
-    {
       "role": "user",
-      "text": "Summarize the roadmap risk.",
-      "parts": [
-        { "type": "text", "text": "Summarize the roadmap risk." }
-      ],
-      "metadata": {
-        "ticket": "RD-42"
-      }
+      "text": "Summarize the roadmap risk."
+    }
+  ],
+  "toolRefs": [
+    {
+      "pluginName": "roadmap",
+      "operation": "sync"
     }
   ],
   "responseSchema": {
@@ -130,41 +125,44 @@ The neutral agent run shape is intentionally small:
       "summary": { "type": "string" }
     },
     "required": ["summary"]
-  },
-  "sessionRef": "session-123"
+  }
 }
 ```
 
-For global runs, omitting `toolRefs` lets Gestalt attach the caller's
+For user-created turns, omitting `toolRefs` lets Gestalt attach the caller's
 authorized safe tools by default. Add `toolRefs` to extend that set, or set
 `toolSource: "explicit"` when you need explicit-only tools.
 
-`messages[].text` remains supported for simple callers. `messages[].parts` and
-`messages[].metadata` are optional extensions for richer transcript items and
-message-scoped annotations.
+Each `messages[]` entry accepts `role`, optional `text`, optional `parts`, and
+optional `metadata`. `parts[]` supports `type: text | json | tool_call |
+tool_result | image_ref`.
 
-Providers may also report capabilities such as:
+Providers may also advertise capabilities such as:
 
 ```json
 {
   "streamingText": true,
   "toolCalls": true,
+  "parallelToolCalls": false,
   "structuredOutput": true,
-  "sessionContinuation": true,
-  "approvals": true,
-  "resumableRuns": true
+  "interactions": true,
+  "resumableTurns": true
 }
 ```
 
-## First-party agent providers
+## First-party provider
 
-There is not yet a first-party agent provider published from
-`valon-technologies/gestalt-providers`. If you need one today, implement a
-custom provider against the neutral protocol or deploy a local source-backed
-provider under `providers.agent`.
+The current first-party provider is `agent/simple` from
+`valon-technologies/gestalt-providers`. It is intentionally small:
+
+- text-in, text-out agent loop
+- OpenAI and Anthropic model backends
+- Gestalt plugin operations as tools
+- provider-owned IndexedDB persistence
+- asynchronous turns plus turn event history
 
 ## What to read next
 
 - [Custom Providers > Agent](/custom-providers/agent): implementing your own agent backend
-- [HTTP API](/reference/http-api): global agent runs routes
-- [CLI](/client/cli): `gestalt agent runs ...`
+- [HTTP API](/reference/http-api): session, turn, interaction, and event routes
+- [CLI](/client/cli): `gestalt agent`, `gestalt agent sessions`, and `gestalt agent turns`

--- a/docs/content/reference/config-file.mdx
+++ b/docs/content/reference/config-file.mdx
@@ -471,48 +471,36 @@ allowlist logical stores exposed through that binding.
 
 ## `providers.agent`
 
-Agent providers back global agent runs. Configure one or more named entries
-under `providers.agent`. There is no `server.providers.agent`: each run request
-either selects a provider explicitly or inherits the sole/default
-`providers.agent` entry when `provider` is omitted. The same provider pool is
-used by the global agent runs API/CLI and by plugins that call the host agent
-manager.
+Agent providers back global agent sessions and turns. Configure one or more
+named entries under `providers.agent`. There is no `server.providers.agent`:
+each session request either selects a provider explicitly or inherits the
+sole/default `providers.agent` entry when `provider` is omitted. The same
+provider pool is used by the global agent API/CLI and by plugins that call the
+host agent manager.
 
 ```yaml
 providers:
   agent:
-    openai:
-      source: ./providers/agent/openai/manifest.yaml
+    simple:
+      source: ./providers/agent/simple/manifest.yaml
       default: true
       indexeddb:
         provider: default
-        db: agent_openai
-        objectStores:
-          - runs
-          - run_idempotency
+        db: simple_agent
       config:
-        model: gpt-5.4
-        baseURL: https://api.openai.com/v1
-        apiKey:
-          secret:
-            provider: default
-            name: openai-api-key
-
-    claude:
-      source: ./providers/agent/claude/manifest.yaml
-      config:
-        model: claude-sonnet
-        apiKey:
-          secret:
-            provider: default
-            name: anthropic-api-key
+        runStore: runs
+        idempotencyStore: run_idempotency
+        defaultModel: fast
+        aliases:
+          fast: openai/gpt-4.1-mini
+          deep: anthropic/claude-sonnet-4-20250514
 ```
 
-Agent providers receive neutral run requests with `messages`, optional
-resolved `tools`, optional `responseSchema`, optional `sessionRef`, and
-provider-specific `config`. Agent providers that need durable state can opt
-into a host IndexedDB binding with `indexeddb`; the provider process then uses
-the SDK IndexedDB helper against `GESTALT_INDEXEDDB_SOCKET`.
+Agent providers receive canonical session and turn requests with `messages`,
+optional resolved `tools`, optional `responseSchema`, and provider-specific
+`config`. Agent providers that need durable state can opt into a host
+IndexedDB binding with `indexeddb`; the provider process then uses the SDK
+IndexedDB helper against `GESTALT_INDEXEDDB_SOCKET`.
 
 Agent providers may also opt into a hosted runtime with `runtime`, using the
 same runtime-provider selection model as executable plugins. When
@@ -523,7 +511,7 @@ socket, and `allowedHosts` remains the operator-facing egress policy.
 
 | Field | Description |
 | --- | --- |
-| `default` | Marks this named agent entry as the default selection when a run request omits `provider`. |
+| `default` | Marks this named agent entry as the default selection when a session request omits `provider`. |
 | `source` | Either a local provider manifest path, a published `provider-release.yaml` metadata URL, or `source.githubRelease` for a GitHub-hosted release asset. |
 | `auth` | Optional inline source auth for remote release sources, including direct metadata URLs and `source.githubRelease`. |
 | `indexeddb` | Optional agent IndexedDB config. `indexeddb.provider` selects the named `providers.indexeddb` entry backing the agent's single IndexedDB SDK socket; unlike plugins, agents do not inherit the selected/default host IndexedDB automatically. `indexeddb.db` overrides the provider-visible database name and defaults to the agent provider key. `indexeddb.objectStores` optionally allowlists logical object stores the agent may use. |

--- a/docs/content/reference/go-sdk.mdx
+++ b/docs/content/reference/go-sdk.mdx
@@ -61,12 +61,33 @@ type Agent struct {
 	proto.UnimplementedAgentProviderServer
 }
 
-func (a *Agent) StartRun(_ context.Context, req *proto.StartAgentProviderRunRequest) (*proto.BoundAgentRun, error) {
-	return &proto.BoundAgentRun{
-		Id:           req.GetRunId(),
-		ProviderName: req.GetProviderName(),
+func (a *Agent) CreateSession(_ context.Context, req *proto.CreateAgentProviderSessionRequest) (*proto.AgentSession, error) {
+	return &proto.AgentSession{
+		Id:           req.GetSessionId(),
+		ProviderName: "example",
 		Model:        req.GetModel(),
-		Status:       proto.AgentRunStatus_AGENT_RUN_STATUS_PENDING,
+		State:        proto.AgentSessionState_AGENT_SESSION_STATE_ACTIVE,
+	}, nil
+}
+
+func (a *Agent) CreateTurn(_ context.Context, req *proto.CreateAgentProviderTurnRequest) (*proto.AgentTurn, error) {
+	return &proto.AgentTurn{
+		Id:           req.GetTurnId(),
+		SessionId:    req.GetSessionId(),
+		ProviderName: "example",
+		Model:        req.GetModel(),
+		Status:       proto.AgentExecutionStatus_AGENT_EXECUTION_STATUS_RUNNING,
+		Messages:     req.GetMessages(),
+		ExecutionRef: req.GetExecutionRef(),
+	}, nil
+}
+
+func (a *Agent) GetCapabilities(context.Context, *proto.GetAgentProviderCapabilitiesRequest) (*proto.AgentProviderCapabilities, error) {
+	return &proto.AgentProviderCapabilities{
+		StreamingText:  true,
+		ToolCalls:      true,
+		Interactions:   true,
+		ResumableTurns: true,
 	}, nil
 }
 

--- a/docs/content/reference/http-api.mdx
+++ b/docs/content/reference/http-api.mdx
@@ -67,25 +67,28 @@ Authenticated routes accept a `session_token` cookie or an `Authorization: Beare
 
 | Method | Path | Purpose |
 | --- | --- | --- |
-| `POST` | `/api/v1/agent/runs` | Create one agent run. Accepts an optional `idempotencyKey` field and optional `Idempotency-Key` header. |
-| `GET` | `/api/v1/agent/runs` | List agent runs. Supports optional `provider` and `status` query filters. |
-| `GET` | `/api/v1/agent/runs/{runID}` | Inspect one agent run. |
-| `POST` | `/api/v1/agent/runs/{runID}/cancel` | Cancel one agent run. The request body may include an optional `reason`. |
-| `GET` | `/api/v1/agent/runs/{runID}/events` | List stored events for one agent run. Supports optional `after` sequence cursor and `limit`. |
-| `GET` | `/api/v1/agent/runs/{runID}/events/stream` | Stream agent run events as server-sent events. Supports optional `after` sequence cursor and `limit`. |
-| `GET` | `/api/v1/agent/runs/{runID}/interactions` | List persisted interactions for one agent run. |
-| `POST` | `/api/v1/agent/runs/{runID}/resume` | Resume one paused agent run by submitting an `interactionId` and optional `resolution` payload. |
+| `POST` | `/api/v1/agent/sessions` | Create one agent session. Accepts an optional `idempotencyKey` field and optional `Idempotency-Key` header. |
+| `GET` | `/api/v1/agent/sessions` | List agent sessions. Supports optional `provider` and `state` query filters. |
+| `GET` | `/api/v1/agent/sessions/{sessionID}` | Inspect one agent session. |
+| `PATCH` | `/api/v1/agent/sessions/{sessionID}` | Update one agent session. |
+| `POST` | `/api/v1/agent/sessions/{sessionID}/turns` | Create one agent turn inside a session. Accepts an optional `idempotencyKey` field and optional `Idempotency-Key` header. |
+| `GET` | `/api/v1/agent/sessions/{sessionID}/turns` | List turns for one session. Supports optional `status`. |
+| `GET` | `/api/v1/agent/turns/{turnID}` | Inspect one agent turn. |
+| `POST` | `/api/v1/agent/turns/{turnID}/cancel` | Cancel one agent turn. The request body may include an optional `reason`. |
+| `GET` | `/api/v1/agent/turns/{turnID}/events` | List stored events for one turn. Supports optional `after` sequence cursor and `limit`. |
+| `GET` | `/api/v1/agent/turns/{turnID}/events/stream` | Stream turn events as server-sent events. Supports optional `after` sequence cursor and `limit`. |
+| `GET` | `/api/v1/agent/turns/{turnID}/interactions` | List provider-owned interactions for one turn. |
+| `POST` | `/api/v1/agent/turns/{turnID}/interactions/{interactionID}/resolve` | Resolve one pending interaction by submitting a `resolution` payload. |
 
-Agent run creation accepts `provider`, `model`, `messages`, optional
-`toolRefs`, optional `toolSource`, optional `responseSchema`, optional
-`sessionRef`, optional `metadata`, optional `providerOptions`, and optional
-`idempotencyKey`. When `toolSource` is omitted on a global run, Gestalt
-attaches the caller's authorized safe tools by default and treats `toolRefs` as
-additive. Set `toolSource` to `explicit` to opt into explicit-only tools.
-Missing `toolRefs[].pluginName` or `toolRefs[].operation` returns `400`.
-Conflicting header/body idempotency keys also return `400`, an in-progress
-idempotent create returns `409`, and an unconfigured agent surface returns
-`412`.
+Session creation accepts `provider`, `model`, optional `clientRef`, optional
+`metadata`, optional `providerOptions`, and optional `idempotencyKey`.
+
+Turn creation accepts `model`, `messages`, optional `toolRefs`, optional
+`toolSource`, optional `responseSchema`, optional `metadata`, optional
+`providerOptions`, and optional `idempotencyKey`. Missing
+`toolRefs[].pluginName` or `toolRefs[].operation` returns `400`. Conflicting
+header/body idempotency keys also return `400`, an in-progress idempotent
+create returns `409`, and an unconfigured agent surface returns `412`.
 
 Each `messages[]` entry accepts `role`, optional `text`, optional `parts`, and
 optional `metadata`. `parts[]` supports `type: text | json | tool_call |
@@ -221,13 +224,26 @@ curl -X POST http://localhost:8080/api/v1/workflow/events \
 curl 'http://localhost:8080/api/v1/workflow/runs?plugin=github&status=failed' \
   -H 'Authorization: Bearer gst_api_...'
 
-# Create an agent run
-curl -X POST http://localhost:8080/api/v1/agent/runs \
+# Create an agent session
+curl -X POST http://localhost:8080/api/v1/agent/sessions \
   -H 'Authorization: Bearer gst_api_...' \
   -H 'Content-Type: application/json' \
-  -H 'Idempotency-Key: agent-run-1' \
+  -H 'Idempotency-Key: agent-session-1' \
   -d '{
     "provider": "managed",
+    "model": "gpt-5.4",
+    "clientRef": "roadmap-risk",
+    "metadata": {
+      "ticket": "RD-42"
+    }
+  }'
+
+# Create a turn in that session
+curl -X POST http://localhost:8080/api/v1/agent/sessions/session-123/turns \
+  -H 'Authorization: Bearer gst_api_...' \
+  -H 'Content-Type: application/json' \
+  -H 'Idempotency-Key: agent-turn-1' \
+  -d '{
     "model": "gpt-5.4",
     "messages": [
       {
@@ -254,6 +270,9 @@ curl -X POST http://localhost:8080/api/v1/agent/runs \
         }
       }
     ],
+    "toolRefs": [
+      {"pluginName": "roadmap", "operation": "sync"}
+    ],
     "responseSchema": {
       "type": "object",
       "properties": {
@@ -261,88 +280,91 @@ curl -X POST http://localhost:8080/api/v1/agent/runs \
       },
       "required": ["summary"]
     },
-    "sessionRef": "session-1",
     "metadata": {
       "ticket": "RD-42"
     }
   }'
 
-# Create an explicit-only agent run
-curl -X POST http://localhost:8080/api/v1/agent/runs \
-  -H 'Authorization: Bearer gst_api_...' \
-  -H 'Content-Type: application/json' \
-  -d '{
-    "provider": "managed",
-    "messages": [
-      {"role": "user", "text": "Summarize the roadmap risk."}
-    ],
-    "toolSource": "explicit",
-    "toolRefs": [
-      {"pluginName": "roadmap", "operation": "sync"}
-    ]
-  }'
-
-# Inspect a run
+# List active sessions for one provider
 curl -H 'Authorization: Bearer gst_api_...' \
-  http://localhost:8080/api/v1/agent/runs/run-123
+  'http://localhost:8080/api/v1/agent/sessions?provider=managed&state=active'
 
-# List run events after sequence 0
+# Inspect a session
 curl -H 'Authorization: Bearer gst_api_...' \
-  'http://localhost:8080/api/v1/agent/runs/run-123/events?after=0&limit=100'
+  http://localhost:8080/api/v1/agent/sessions/session-123
 
-# Stream run events
+# Inspect a turn
+curl -H 'Authorization: Bearer gst_api_...' \
+  http://localhost:8080/api/v1/agent/turns/turn-123
+
+# List session turns
+curl -H 'Authorization: Bearer gst_api_...' \
+  'http://localhost:8080/api/v1/agent/sessions/session-123/turns?status=running'
+
+# List turn events after sequence 0
+curl -H 'Authorization: Bearer gst_api_...' \
+  'http://localhost:8080/api/v1/agent/turns/turn-123/events?after=0&limit=100'
+
+# Stream turn events
 curl -N -H 'Authorization: Bearer gst_api_...' \
-  'http://localhost:8080/api/v1/agent/runs/run-123/events/stream?after=0'
+  'http://localhost:8080/api/v1/agent/turns/turn-123/events/stream?after=0'
 
-# List pending run interactions
+# List pending turn interactions
 curl -H 'Authorization: Bearer gst_api_...' \
-  'http://localhost:8080/api/v1/agent/runs/run-123/interactions'
+  'http://localhost:8080/api/v1/agent/turns/turn-123/interactions'
 
-# Resume a paused run
-curl -X POST http://localhost:8080/api/v1/agent/runs/run-123/resume \
+# Resolve a pending interaction
+curl -X POST http://localhost:8080/api/v1/agent/turns/turn-123/interactions/interaction-123/resolve \
   -H 'Authorization: Bearer gst_api_...' \
   -H 'Content-Type: application/json' \
   -d '{
-    "interactionId": "interaction-123",
     "resolution": {
       "approved": true
     }
   }'
 
-# List filtered runs
-curl -H 'Authorization: Bearer gst_api_...' \
-  'http://localhost:8080/api/v1/agent/runs?provider=managed&status=running'
-
-# Cancel an agent run
-curl -X POST http://localhost:8080/api/v1/agent/runs/run-123/cancel \
+# Cancel an agent turn
+curl -X POST http://localhost:8080/api/v1/agent/turns/turn-123/cancel \
   -H 'Authorization: Bearer gst_api_...' \
   -H 'Content-Type: application/json' \
   -d '{"reason":"operator requested"}'
 
-# Typical create response
+# Typical session create response
 # {
-#   "id": "run-123",
+#   "id": "session-123",
 #   "provider": "managed",
 #   "model": "gpt-5.4",
-#   "status": "pending",
+#   "state": "active",
+#   "clientRef": "roadmap-risk",
+#   "createdAt": "2026-04-22T00:00:00Z",
+#   "updatedAt": "2026-04-22T00:00:00Z"
+# }
+
+# Typical turn create response
+# {
+#   "id": "turn-123",
+#   "sessionId": "session-123",
+#   "provider": "managed",
+#   "model": "gpt-5.4",
+#   "status": "running",
 #   "messages": [
 #     {"role":"system","text":"Be concise.","parts":[{"type":"text","text":"Be concise."}]},
 #     {"role":"user","text":"Summarize the roadmap risk.","parts":[{"type":"text","text":"Summarize the roadmap risk."}],"metadata":{"ticket":"RD-42"}}
 #   ],
-#   "sessionRef": "session-1",
 #   "createdAt": "2026-04-22T00:00:00Z",
-#   "executionRef": "run-123"
+#   "startedAt": "2026-04-22T00:00:00Z",
+#   "executionRef": "turn-123"
 # }
 
 # Typical interaction list response
 # [
 #   {
 #     "id": "interaction-123",
-#     "runId": "run-123",
+#     "turnId": "turn-123",
 #     "type": "approval",
 #     "state": "pending",
 #     "title": "Approve external call",
-#     "prompt": "Allow this run to continue?",
+#     "prompt": "Allow this turn to continue?",
 #     "request": {"host":"api.openai.com"}
 #   }
 # ]

--- a/docs/content/reference/plugin-manifests.mdx
+++ b/docs/content/reference/plugin-manifests.mdx
@@ -18,7 +18,7 @@ Every manifest defines exactly one provider kind, set by the `kind` field:
 | `plugin` | Plugin (REST, OpenAPI, GraphQL, MCP, or executable). |
 | `authentication` | Platform authentication provider. |
 | `authorization` | Human authorization decision and control-plane provider. |
-| `agent` | Global run-based agent provider. |
+| `agent` | Global session-and-turn agent provider. |
 | `cache` | Cache backend for plugin-bound cache bindings. |
 | `indexeddb` | Persistence backend. |
 | `runtime` | Hosted execution backend for executable plugins. |

--- a/docs/content/reference/python-sdk.mdx
+++ b/docs/content/reference/python-sdk.mdx
@@ -39,12 +39,30 @@ import gestalt
 
 
 class ExampleAgent(gestalt.AgentProvider):
-    def StartRun(self, request, context):
-        return gestalt.pb.BoundAgentRun(
-            id=request.run_id,
-            provider_name=request.provider_name,
+    def CreateSession(self, request, context):
+        return gestalt.pb.AgentSession(
+            id=request.session_id,
+            provider_name="example",
             model=request.model,
-            status=gestalt.pb.AGENT_RUN_STATUS_PENDING,
+            state=gestalt.pb.AGENT_SESSION_STATE_ACTIVE,
+        )
+
+    def CreateTurn(self, request, context):
+        return gestalt.pb.AgentTurn(
+            id=request.turn_id,
+            session_id=request.session_id,
+            provider_name="example",
+            model=request.model,
+            status=gestalt.pb.AGENT_EXECUTION_STATUS_RUNNING,
             messages=request.messages,
+            execution_ref=request.execution_ref,
+        )
+
+    def GetCapabilities(self, request, context):
+        return gestalt.pb.AgentProviderCapabilities(
+            streaming_text=True,
+            tool_calls=True,
+            interactions=True,
+            resumable_turns=True,
         )
 ```

--- a/docs/dockerhub/gestalt.md
+++ b/docs/dockerhub/gestalt.md
@@ -2,8 +2,8 @@
 
 `gestalt` is a CLI client for the Gestalt API. It connects to a running
 `gestaltd` server and provides commands for authenticating, listing plugins,
-invoking integration operations, managing workflow and agent runs, and managing
-credentials.
+invoking integration operations, managing workflows, running interactive agent
+sessions, and managing credentials.
 
 > **Alpha.** Gestalt is under active development. Images are tagged
 > with alpha versions and may introduce breaking changes. See the
@@ -77,7 +77,9 @@ jobs:
 | `plugin disconnect NAME` | Disconnect a plugin |
 | `plugin invoke NAME OP` | Execute a plugin operation |
 | `workflow ...` | Manage workflow schedules, triggers, events, and runs |
-| `agent runs ...` | Create, list, inspect, cancel, and stream agent runs |
+| `agent` | Start or resume an interactive agent session |
+| `agent sessions ...` | Create, list, inspect, and update agent sessions |
+| `agent turns ...` | Create, list, inspect, cancel, and stream agent turns |
 | `tokens create/list/revoke` | Manage API tokens |
 
 Use `--format json` or `--format table` to control output format. See the

--- a/gestalt/cli/Cargo.toml
+++ b/gestalt/cli/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "gestalt"
-description = "CLI for Gestalt API - authentication, integration management, and operation invocation"
+description = "CLI for the Gestalt API: authentication, integrations, workflows, and interactive agents"
 version.workspace = true
 edition.workspace = true
 

--- a/gestalt/cli/src/api.rs
+++ b/gestalt/cli/src/api.rs
@@ -246,25 +246,12 @@ impl std::error::Error for ApiError {}
 
 impl ApiClient {
     pub fn from_env(url_override: Option<&str>) -> Result<Self> {
-        let (token, source, stored_credentials) =
-            if let Some(key) = std::env::var(ENV_API_KEY).ok().filter(|v| !v.is_empty()) {
-                (key, TokenSource::EnvVar, None)
-            } else {
-                let store = CredentialStore::new()?;
-                match store.load()? {
-                    Some(creds) => (
-                        creds.api_token.clone(),
-                        TokenSource::StoredCredentials,
-                        Some(creds),
-                    ),
-                    None => {
-                        bail!(
-                            "not authenticated: set {} or run 'gestalt auth login'",
-                            ENV_API_KEY
-                        )
-                    }
-                }
-            };
+        let env_api_key = std::env::var(ENV_API_KEY).ok().filter(|v| !v.is_empty());
+        let stored_credentials = if env_api_key.is_none() {
+            CredentialStore::new()?.load()?
+        } else {
+            None
+        };
 
         let base_url = match resolve_url(url_override) {
             Ok(url) => url,
@@ -274,6 +261,27 @@ impl ApiClient {
             {
                 Some(url) => normalize_url(url),
                 None => return Err(err),
+            },
+        };
+        let (token, source) = match env_api_key {
+            Some(key) => (key, TokenSource::EnvVar),
+            None => match stored_credentials.as_ref() {
+                Some(creds) => (creds.api_token.clone(), TokenSource::StoredCredentials),
+                None => match server_auth_disabled(&base_url) {
+                    Ok(true) => (String::new(), TokenSource::Direct),
+                    Ok(false) => {
+                        bail!(
+                            "not authenticated: set {} or run 'gestalt auth login'",
+                            ENV_API_KEY
+                        )
+                    }
+                    Err(err) => {
+                        return Err(err.context(format!(
+                            "failed to determine authentication mode for {}",
+                            base_url
+                        )));
+                    }
+                },
             },
         };
         let mut client = Self::new(&base_url, &token)?;
@@ -316,16 +324,12 @@ impl ApiClient {
 
     pub fn get_stream(&self, path: &str) -> Result<reqwest::blocking::Response> {
         let url = format!("{}{}", self.base_url, path);
-        let resp = self
-            .stream_client
-            .request(Method::GET, &url)
-            .bearer_auth(&self.token)
-            .header(
-                header::ACCEPT,
-                HeaderValue::from_static("text/event-stream"),
-            )
-            .send()
-            .map_err(|e| self.wrap_send_error(e, &url))?;
+        let req = self.stream_client.request(Method::GET, &url);
+        let req = self.with_auth(req).header(
+            header::ACCEPT,
+            HeaderValue::from_static("text/event-stream"),
+        );
+        let resp = req.send().map_err(|e| self.wrap_send_error(e, &url))?;
         let status = resp.status();
         if !(status.is_client_error() || status.is_server_error()) {
             return Ok(resp);
@@ -392,17 +396,15 @@ impl ApiClient {
     {
         let url = format!("{}{}", self.base_url, path);
         let encoded = serde_urlencoded::to_string(body).context("failed to encode form body")?;
-        let resp = self
-            .client
-            .request(method, &url)
-            .bearer_auth(&self.token)
+        let req = self.client.request(method, &url);
+        let req = self
+            .with_auth(req)
             .header(
                 header::CONTENT_TYPE,
                 HeaderValue::from_static(http::APPLICATION_X_WWW_FORM_URLENCODED),
             )
-            .body(encoded)
-            .send()
-            .map_err(|e| self.wrap_send_error(e, &url))?;
+            .body(encoded);
+        let resp = req.send().map_err(|e| self.wrap_send_error(e, &url))?;
         self.handle_text_response(resp)
     }
 
@@ -416,13 +418,24 @@ impl ApiClient {
         T: Serialize + ?Sized,
     {
         let url = format!("{}{}", self.base_url, path);
-        let request = self.client.request(method, &url).bearer_auth(&self.token);
+        let request = self.with_auth(self.client.request(method, &url));
         let request = match body {
             Some(body) => request.json(body),
             None => request,
         };
         let resp = request.send().map_err(|e| self.wrap_send_error(e, &url))?;
         self.handle_response(resp)
+    }
+
+    fn with_auth(
+        &self,
+        request: reqwest::blocking::RequestBuilder,
+    ) -> reqwest::blocking::RequestBuilder {
+        if self.token.is_empty() {
+            request
+        } else {
+            request.bearer_auth(&self.token)
+        }
     }
 
     fn wrap_send_error(&self, err: reqwest::Error, url: &str) -> anyhow::Error {

--- a/gestalt/cli/tests/agents_cli.rs
+++ b/gestalt/cli/tests/agents_cli.rs
@@ -384,6 +384,147 @@ fn test_cli_runs_interactive_agent_session() {
 }
 
 #[test]
+fn test_cli_resumes_existing_agent_session_and_resolves_input_interaction() {
+    let server = ScriptedServer::spawn(vec![
+        ExpectedRequest::text(
+            Method::GET,
+            "/api/v1/agent/sessions/session-2",
+            StatusCode::OK,
+            http::APPLICATION_JSON,
+            r#"{
+                "id":"session-2",
+                "provider":"managed",
+                "model":"gpt-5.4",
+                "state":"active"
+            }"#,
+        ),
+        ExpectedRequest::json(
+            Method::POST,
+            "/api/v1/agent/sessions/session-2/turns",
+            r#"{"messages":[{"role":"user","text":"need incident context"}]}"#,
+            StatusCode::CREATED,
+            http::APPLICATION_JSON,
+            r#"{
+                "id":"turn-input",
+                "sessionId":"session-2",
+                "provider":"managed",
+                "model":"gpt-5.4",
+                "status":"running"
+            }"#,
+        ),
+        ExpectedRequest::text(
+            Method::GET,
+            "/api/v1/agent/turns/turn-input/events?after=0&limit=100",
+            StatusCode::OK,
+            http::APPLICATION_JSON,
+            r#"[
+                {"seq":1,"type":"turn.started","data":{"status":"running"}},
+                {"seq":2,"type":"interaction.requested","data":{"interaction_id":"interaction-2"}}
+            ]"#,
+        ),
+        ExpectedRequest::text(
+            Method::GET,
+            "/api/v1/agent/turns/turn-input",
+            StatusCode::OK,
+            http::APPLICATION_JSON,
+            r#"{
+                "id":"turn-input",
+                "sessionId":"session-2",
+                "provider":"managed",
+                "model":"gpt-5.4",
+                "status":"waiting_for_input",
+                "statusMessage":"waiting for input"
+            }"#,
+        ),
+        ExpectedRequest::text(
+            Method::GET,
+            "/api/v1/agent/turns/turn-input/interactions",
+            StatusCode::OK,
+            http::APPLICATION_JSON,
+            r#"[
+                {
+                    "id":"interaction-2",
+                    "turnId":"turn-input",
+                    "type":"input",
+                    "state":"pending",
+                    "title":"Incident ID",
+                    "prompt":"Provide the incident identifier to summarize.",
+                    "request":{"default":"INC-42","required":true}
+                }
+            ]"#,
+        ),
+        ExpectedRequest::json(
+            Method::POST,
+            "/api/v1/agent/turns/turn-input/interactions/interaction-2/resolve",
+            r#"{"resolution":{"response":"INC-42"}}"#,
+            StatusCode::OK,
+            http::APPLICATION_JSON,
+            r#"{
+                "id":"interaction-2",
+                "turnId":"turn-input",
+                "type":"input",
+                "state":"resolved",
+                "resolution":{"response":"INC-42"}
+            }"#,
+        ),
+        ExpectedRequest::text(
+            Method::GET,
+            "/api/v1/agent/turns/turn-input/events?after=2&limit=100",
+            StatusCode::OK,
+            http::APPLICATION_JSON,
+            r#"[
+                {"seq":3,"type":"interaction.resolved","data":{"interaction_id":"interaction-2"}},
+                {"seq":4,"type":"assistant.completed","data":{"text":"incident INC-42 summarized"}},
+                {"seq":5,"type":"turn.completed","data":{"status":"succeeded"}}
+            ]"#,
+        ),
+        ExpectedRequest::text(
+            Method::GET,
+            "/api/v1/agent/turns/turn-input",
+            StatusCode::OK,
+            http::APPLICATION_JSON,
+            r#"{
+                "id":"turn-input",
+                "sessionId":"session-2",
+                "provider":"managed",
+                "model":"gpt-5.4",
+                "status":"succeeded",
+                "outputText":"incident INC-42 summarized"
+            }"#,
+        ),
+    ]);
+
+    let home = tempfile::tempdir().unwrap();
+    cli_command(home.path())
+        .env("GESTALT_API_KEY", TEST_TOKEN)
+        .arg("--url")
+        .arg(server.url())
+        .args(["agent", "--session", "session-2"])
+        .write_stdin("need incident context\n\n/quit\n")
+        .assert()
+        .success()
+        .stdout(predicate::str::contains(
+            "interaction> requested (interaction-2)",
+        ))
+        .stdout(predicate::str::contains(
+            "interaction> resolved (interaction-2)",
+        ))
+        .stdout(predicate::str::contains(
+            "assistant> incident INC-42 summarized",
+        ))
+        .stderr(predicate::str::contains(
+            "Session session-2 [managed / gpt-5.4]",
+        ))
+        .stderr(predicate::str::contains("Incident ID"))
+        .stderr(predicate::str::contains(
+            "Provide the incident identifier to summarize.",
+        ))
+        .stderr(predicate::str::contains("Value [INC-42]:"));
+
+    server.assert_finished();
+}
+
+#[test]
 fn test_cli_resolves_agent_interaction_in_interactive_mode() {
     let server = ScriptedServer::spawn(vec![
         ExpectedRequest::json(

--- a/gestalt/cli/tests/auth_flow.rs
+++ b/gestalt/cli/tests/auth_flow.rs
@@ -250,3 +250,48 @@ fn test_auth_status_json_includes_server_fields() {
     assert_eq!(json["urlSource"], serde_json::json!("--url flag"));
     assert_eq!(json["authenticated"], serde_json::json!(false));
 }
+
+#[test]
+fn test_no_auth_server_allows_agent_session_commands_without_credentials() {
+    let mut server = Server::new();
+    let _auth_info = json_mock!(server, Method::GET, "/api/v1/auth/info", StatusCode::OK)
+        .with_body(r#"{"provider":"none","displayName":"none","loginSupported":false}"#)
+        .create();
+    let _create = json_mock!(
+        server,
+        Method::POST,
+        "/api/v1/agent/sessions",
+        StatusCode::CREATED
+    )
+    .match_header(header::AUTHORIZATION.as_str(), Matcher::Missing)
+    .match_body(Matcher::JsonString(
+        r#"{"provider":"managed","model":"gpt-5.4"}"#.to_string(),
+    ))
+    .with_body(
+        r#"{
+                "id":"session-1",
+                "provider":"managed",
+                "model":"gpt-5.4",
+                "state":"active"
+            }"#,
+    )
+    .create();
+
+    let home = tempfile::tempdir().unwrap();
+
+    cli_command(home.path())
+        .arg("--url")
+        .arg(server.url())
+        .args([
+            "agent",
+            "sessions",
+            "create",
+            "--provider",
+            "managed",
+            "--model",
+            "gpt-5.4",
+        ])
+        .assert()
+        .success()
+        .stdout(predicate::str::contains("session-1"));
+}

--- a/gestaltd/internal/server/agent_session_turn_test.go
+++ b/gestaltd/internal/server/agent_session_turn_test.go
@@ -413,6 +413,57 @@ func TestAgentSessionsAndTurnsRoundTrip(t *testing.T) {
 	}
 }
 
+func TestAgentSessionsAndTurnsRoundTripWithoutAuth(t *testing.T) {
+	t.Parallel()
+
+	provider := newMemoryAgentProvider()
+	ts := newTestServer(t, func(cfg *server.Config) {
+		services := coretesting.NewStubServices(t)
+		cfg.Auth = nil
+		cfg.Services = services
+		cfg.AgentManager = agentmanager.New(agentmanager.Config{
+			Agent:           &stubAgentControl{defaultProviderName: "managed", provider: provider},
+			SessionMetadata: services.AgentSessions,
+			RunMetadata:     services.AgentRunMetadata,
+		})
+	})
+	testutil.CloseOnCleanup(t, ts)
+
+	sessionReq, _ := http.NewRequest(http.MethodPost, ts.URL+"/api/v1/agent/sessions/", bytes.NewBufferString(`{"provider":"managed","model":"gpt-5.4","clientRef":"cli-1"}`))
+	sessionResp, err := http.DefaultClient.Do(sessionReq)
+	if err != nil {
+		t.Fatalf("create session: %v", err)
+	}
+	defer func() { _ = sessionResp.Body.Close() }()
+	if sessionResp.StatusCode != http.StatusCreated {
+		body, _ := io.ReadAll(sessionResp.Body)
+		t.Fatalf("create session status = %d body=%s", sessionResp.StatusCode, body)
+	}
+	var session map[string]any
+	if err := json.NewDecoder(sessionResp.Body).Decode(&session); err != nil {
+		t.Fatalf("decode session: %v", err)
+	}
+	sessionID := session["id"].(string)
+
+	turnReq, _ := http.NewRequest(http.MethodPost, ts.URL+"/api/v1/agent/sessions/"+sessionID+"/turns", bytes.NewBufferString(`{"messages":[{"role":"user","text":"hello"}]}`))
+	turnResp, err := http.DefaultClient.Do(turnReq)
+	if err != nil {
+		t.Fatalf("create turn: %v", err)
+	}
+	defer func() { _ = turnResp.Body.Close() }()
+	if turnResp.StatusCode != http.StatusCreated {
+		body, _ := io.ReadAll(turnResp.Body)
+		t.Fatalf("create turn status = %d body=%s", turnResp.StatusCode, body)
+	}
+	var turn map[string]any
+	if err := json.NewDecoder(turnResp.Body).Decode(&turn); err != nil {
+		t.Fatalf("decode turn: %v", err)
+	}
+	if turn["sessionId"] != sessionID {
+		t.Fatalf("turn sessionId = %#v, want %q", turn["sessionId"], sessionID)
+	}
+}
+
 func TestAgentInteractionResolutionAndEventStream(t *testing.T) {
 	t.Parallel()
 

--- a/gestaltd/internal/server/middleware.go
+++ b/gestaltd/internal/server/middleware.go
@@ -175,7 +175,17 @@ func (s *Server) resolveRequestPrincipalWithUserID(r *http.Request) (*principal.
 
 func (s *Server) serveAuthenticated(w http.ResponseWriter, r *http.Request, next http.Handler, resolver *principal.Resolver, noAuth bool, anonymous *principal.Principal, auditProvider string) {
 	if noAuth {
-		ctx := principal.WithPrincipal(r.Context(), anonymous)
+		p := anonymous
+		if p != nil {
+			enriched, err := s.resolvePrincipalUserID(r.Context(), p)
+			switch {
+			case err == nil && enriched != nil:
+				p = enriched
+			case err != nil:
+				slog.WarnContext(r.Context(), "auth: unable to resolve anonymous user ID", "error", err)
+			}
+		}
+		ctx := principal.WithPrincipal(r.Context(), p)
 		next.ServeHTTP(w, r.WithContext(ctx))
 		return
 	}


### PR DESCRIPTION
## Summary
This stabilization slice makes the merged agent session/turn surface usable for real local dogfooding and rewrites the stale run-era docs around the canonical model.

## Interfaces
- `POST /api/v1/agent/sessions`
- `GET /api/v1/agent/sessions?provider=<name>&state=<state>`
- `GET /api/v1/agent/sessions/{sessionID}`
- `PATCH /api/v1/agent/sessions/{sessionID}`
- `POST /api/v1/agent/sessions/{sessionID}/turns`
- `GET /api/v1/agent/sessions/{sessionID}/turns?status=<status>`
- `GET /api/v1/agent/turns/{turnID}`
- `POST /api/v1/agent/turns/{turnID}/cancel`
- `GET /api/v1/agent/turns/{turnID}/events`
- `GET /api/v1/agent/turns/{turnID}/events/stream`
- `GET /api/v1/agent/turns/{turnID}/interactions`
- `POST /api/v1/agent/turns/{turnID}/interactions/{interactionID}/resolve`
- `gestalt agent`
- `gestalt agent --session <session-id>`
- `gestalt agent sessions create --provider simple --model fast`
- `gestalt agent turns create <session-id> --message "hello"`

## Examples
```sh
gestalt --url http://localhost:18080 agent sessions create --provider simple --model fast
gestalt --url http://localhost:18080 agent --session session-123
gestalt --url http://localhost:18080 agent turns events list turn-123 --after 0 --limit 100
```

## What changed
- allow the CLI to operate without stored credentials or `GESTALT_API_KEY` when the server reports `loginSupported=false`
- enrich no-auth requests with a concrete anonymous subject so agent session/turn routes work end-to-end on local no-auth servers
- add functional coverage for the anonymous session path and for resuming an existing interactive session with an `input` interaction
- refresh the stale CLI, HTTP API, provider, SDK, release, and Docker docs around sessions, turns, interactions, and the verified local quickstart

## Verification
```sh
cd gestalt
cargo fmt --all -- --check
cargo clippy --workspace --all-targets -- -D warnings
cargo test --test auth_flow --test agents_cli

cd ../gestaltd
go test ./internal/server
```

## Notes
I also dogfooded the actual local path against `gestaltd` + `agent/simple` and verified that, once the provider-local Python environment exists, these now work on a no-auth server:

```sh
go run ./cmd/gestaltd init --config ./config.yaml
go run ./cmd/gestaltd serve --locked --config ./config.yaml
gestalt --url http://localhost:18081 --format json agent sessions create --provider simple --model fast
gestalt --url http://localhost:18081 --format json agent turns create <session-id> --message 'hello from local smoke'
```
