### PR TITLE
runtime relay: support server.runtime.baseUrl

### DIFF
--- a/gestaltd/internal/bootstrap/bootstrap.go
+++ b/gestaltd/internal/bootstrap/bootstrap.go
@@ -136,6 +136,7 @@ func (m providerMetadata) descriptionOr(v string) string {
 type Deps struct {
 	EncryptionKey         []byte
 	BaseURL               string
+	RuntimeBaseURL        string
 	SecretManager         core.SecretManager
 	Services              *coredata.Services
 	SelectedIndexedDBName string
@@ -743,6 +744,12 @@ func prepareCore(ctx context.Context, cfg *config.Config, factories *FactoryRegi
 	deps := Deps{
 		EncryptionKey: encKey,
 		BaseURL:       cfg.Server.BaseURL,
+		RuntimeBaseURL: func() string {
+			if baseURL := cfg.Server.RuntimeBaseURL(); baseURL != "" {
+				return baseURL
+			}
+			return cfg.Server.BaseURL
+		}(),
 		SecretManager: sm,
 		Telemetry:     tp,
 	}

--- a/gestaltd/internal/bootstrap/executable_plugin_test.go
+++ b/gestaltd/internal/bootstrap/executable_plugin_test.go
@@ -6111,6 +6111,125 @@ func TestPluginRuntimeConfigUsesPublicIndexedDBRelayWithoutHostServiceTunnelCapa
 	}
 }
 
+func TestPluginRuntimeConfigUsesRuntimeBaseURLForPublicIndexedDBRelay(t *testing.T) {
+	t.Parallel()
+
+	bin := buildEchoPluginBinary(t)
+	manifestRoot := writeStaticCatalog(t, &catalog.Catalog{
+		Name: "echoext",
+		Operations: []catalog.CatalogOperation{
+			{ID: "read_env", Method: http.MethodGet, Parameters: []catalog.CatalogParameter{{Name: "name", Type: "string", Required: true}}},
+		},
+	})
+	manifest := newExecutableManifest("Echo", "Echoes back the input parameters")
+	runtimeProvider := newCapturingBundlePluginRuntime()
+	runtimeProvider.support.EgressMode = pluginruntime.EgressModeHostname
+	runtimeProvider.support.LaunchMode = pluginruntime.LaunchModeHostPath
+	runtimeProvider.fakeHosted = true
+	factories := NewFactoryRegistry()
+	factories.Runtime = func(context.Context, string, *config.RuntimeProviderEntry, Deps) (pluginruntime.Provider, error) {
+		return runtimeProvider, nil
+	}
+	cfg := &config.Config{
+		Server: config.ServerConfig{
+			Runtime: config.ServerRuntimeConfig{Provider: "hosted"},
+			Egress:  config.EgressConfig{DefaultAction: string(egress.PolicyDeny)},
+		},
+		Runtime: config.RuntimeConfig{
+			Providers: map[string]*config.RuntimeProviderEntry{
+				"hosted": {
+					Driver: config.RuntimeProviderDriver("capture"),
+				},
+			},
+		},
+		Plugins: map[string]*config.ProviderEntry{
+			"echoext": {
+				Command:              bin,
+				Args:                 []string{"provider"},
+				ResolvedManifest:     manifest,
+				ResolvedManifestPath: filepath.Join(manifestRoot, "manifest.yaml"),
+				Runtime:              &config.HostedRuntimeConfig{},
+				IndexedDB:            &config.PluginIndexedDBConfig{ObjectStores: []string{"tasks"}},
+			},
+		},
+	}
+
+	deps := Deps{
+		BaseURL:               "",
+		RuntimeBaseURL:        "https://runtime.example.test",
+		EncryptionKey:         []byte("0123456789abcdef0123456789abcdef"),
+		SelectedIndexedDBName: "memory",
+		IndexedDBDefs: map[string]*config.ProviderEntry{
+			"memory": {
+				Source: config.ProviderSource{Path: "./providers/datastore/memory"},
+				Config: mustNode(t, map[string]any{"bucket": "plugin-state"}),
+			},
+		},
+		IndexedDBFactory: func(yaml.Node) (indexeddb.IndexedDB, error) {
+			return &coretesting.StubIndexedDB{}, nil
+		},
+	}
+	deps.PluginRuntimeRegistry = newPluginRuntimeRegistry(cfg, factories.Runtime, deps)
+
+	providers, _, err := buildProvidersStrict(context.Background(), cfg, factories, deps)
+	if err != nil {
+		t.Fatalf("buildProvidersStrict: %v", err)
+	}
+	t.Cleanup(func() { _ = CloseProviders(providers) })
+
+	prov, err := providers.Get("echoext")
+	if err != nil {
+		t.Fatalf("providers.Get: %v", err)
+	}
+	checkEnv := func(envName string) string {
+		t.Helper()
+		result, err := prov.Execute(context.Background(), "read_env", map[string]any{"name": envName}, "")
+		if err != nil {
+			t.Fatalf("Execute read_env(%s): %v", envName, err)
+		}
+		var env struct {
+			Value string `json:"value"`
+			Found bool   `json:"found"`
+		}
+		if err := json.Unmarshal([]byte(result.Body), &env); err != nil {
+			t.Fatalf("unmarshal env result for %s: %v", envName, err)
+		}
+		if !env.Found {
+			t.Fatalf("env %s not found", envName)
+		}
+		return env.Value
+	}
+
+	if got := checkEnv(providerhost.DefaultIndexedDBSocketEnv); got != "tls://runtime.example.test:443" {
+		t.Fatalf("plugin indexeddb socket env = %q, want %q", got, "tls://runtime.example.test:443")
+	}
+	if got := checkEnv(providerhost.IndexedDBSocketTokenEnv("")); got == "" {
+		t.Fatal("plugin indexeddb socket token env should be set for the public relay")
+	}
+
+	bindRequests := runtimeProvider.bindHostServiceRequests()
+	if len(bindRequests) != 1 {
+		t.Fatalf("BindHostService requests = %d, want 1", len(bindRequests))
+	}
+	if got := bindRequests[0].Relay.DialTarget; got != "tls://runtime.example.test:443" {
+		t.Fatalf("BindHostService relay target = %q, want %q", got, "tls://runtime.example.test:443")
+	}
+
+	startRequests := runtimeProvider.startPluginRequestsCopy()
+	if len(startRequests) != 1 {
+		t.Fatalf("StartPlugin requests = %d, want 1", len(startRequests))
+	}
+	if got := startRequests[0].Env[providerhost.IndexedDBSocketTokenEnv("")]; got == "" {
+		t.Fatal("StartPlugin env should include the IndexedDB relay token")
+	}
+	if !slices.Contains(startRequests[0].AllowedHosts, "runtime.example.test") {
+		t.Fatalf("StartPlugin allowed hosts = %#v, want relay host runtime.example.test", startRequests[0].AllowedHosts)
+	}
+	if slices.Contains(startRequests[0].AllowedHosts, "public.example.test") {
+		t.Fatalf("StartPlugin allowed hosts = %#v, want runtime relay host only", startRequests[0].AllowedHosts)
+	}
+}
+
 func TestPluginRuntimePublicIndexedDBRelayRoundTripsThroughHostedPlugin(t *testing.T) {
 	t.Parallel()
 
@@ -7617,6 +7736,95 @@ func TestPluginRuntimeConfigInjectsPublicEgressProxyWithoutHostServiceTunnelCapa
 	}
 	if parsed.Host != "gestalt.example.test" {
 		t.Fatalf("HTTP_PROXY host = %q, want gestalt.example.test", parsed.Host)
+	}
+	if parsed.User == nil {
+		t.Fatal("HTTP_PROXY should include relay credentials")
+	}
+	if got := startRequests[0].AllowedHosts; !slices.Equal(got, []string{"api.github.com"}) {
+		t.Fatalf("StartPlugin allowed hosts = %#v, want original allowedHosts only", got)
+	}
+}
+
+func TestPluginRuntimeConfigUsesRuntimeBaseURLForPublicEgressProxy(t *testing.T) {
+	t.Parallel()
+
+	bin := buildEchoPluginBinary(t)
+	manifestRoot := writeStaticCatalog(t, &catalog.Catalog{
+		Name: "echoext",
+		Operations: []catalog.CatalogOperation{
+			{ID: "read_env", Method: http.MethodGet, Parameters: []catalog.CatalogParameter{{Name: "name", Type: "string", Required: true}}},
+		},
+	})
+	manifest := newExecutableManifest("Echo", "Echoes back the input parameters")
+	runtimeProvider := newCapturingBundlePluginRuntime()
+	runtimeProvider.support.EgressMode = pluginruntime.EgressModeHostname
+	runtimeProvider.support.LaunchMode = pluginruntime.LaunchModeHostPath
+	runtimeProvider.fakeHosted = true
+	factories := NewFactoryRegistry()
+	factories.Runtime = func(context.Context, string, *config.RuntimeProviderEntry, Deps) (pluginruntime.Provider, error) {
+		return runtimeProvider, nil
+	}
+	cfg := &config.Config{
+		Server: config.ServerConfig{
+			Runtime: config.ServerRuntimeConfig{Provider: "hosted"},
+			Egress:  config.EgressConfig{DefaultAction: string(egress.PolicyDeny)},
+		},
+		Runtime: config.RuntimeConfig{
+			Providers: map[string]*config.RuntimeProviderEntry{
+				"hosted": {
+					Driver: config.RuntimeProviderDriver("capture"),
+				},
+			},
+		},
+		Plugins: map[string]*config.ProviderEntry{
+			"echoext": {
+				Command:              bin,
+				Args:                 []string{"provider"},
+				ResolvedManifest:     manifest,
+				ResolvedManifestPath: filepath.Join(manifestRoot, "manifest.yaml"),
+				Runtime:              &config.HostedRuntimeConfig{},
+				AllowedHosts:         []string{"api.github.com"},
+			},
+		},
+	}
+	deps := Deps{
+		BaseURL:        "",
+		RuntimeBaseURL: "https://runtime.example.test",
+		EncryptionKey:  []byte("0123456789abcdef0123456789abcdef"),
+		Egress:         EgressDeps{DefaultAction: egress.PolicyDeny},
+	}
+	deps.PluginRuntimeRegistry = newPluginRuntimeRegistry(cfg, factories.Runtime, deps)
+
+	providers, _, err := buildProvidersStrict(context.Background(), cfg, factories, deps)
+	if err != nil {
+		t.Fatalf("buildProvidersStrict: %v", err)
+	}
+	t.Cleanup(func() { _ = CloseProviders(providers) })
+
+	startRequests := runtimeProvider.startPluginRequestsCopy()
+	if len(startRequests) != 1 {
+		t.Fatalf("StartPlugin requests = %d, want 1", len(startRequests))
+	}
+	httpProxy := startRequests[0].Env["HTTP_PROXY"]
+	httpsProxy := startRequests[0].Env["HTTPS_PROXY"]
+	if httpProxy == "" {
+		t.Fatal("StartPlugin env should include HTTP_PROXY")
+	}
+	if httpsProxy == "" {
+		t.Fatal("StartPlugin env should include HTTPS_PROXY")
+	}
+	if httpProxy != httpsProxy {
+		t.Fatalf("HTTP_PROXY = %q, HTTPS_PROXY = %q, want matching values", httpProxy, httpsProxy)
+	}
+	parsed, err := url.Parse(httpProxy)
+	if err != nil {
+		t.Fatalf("parse HTTP_PROXY: %v", err)
+	}
+	if parsed.Scheme != "https" {
+		t.Fatalf("HTTP_PROXY scheme = %q, want https", parsed.Scheme)
+	}
+	if parsed.Host != "runtime.example.test" {
+		t.Fatalf("HTTP_PROXY host = %q, want runtime.example.test", parsed.Host)
 	}
 	if parsed.User == nil {
 		t.Fatal("HTTP_PROXY should include relay credentials")

--- a/gestaltd/internal/bootstrap/plugin_runtime_plan.go
+++ b/gestaltd/internal/bootstrap/plugin_runtime_plan.go
@@ -123,7 +123,7 @@ func hostCanRelayPluginRuntimeHostServices(deps Deps) bool {
 	if len(deps.EncryptionKey) == 0 {
 		return false
 	}
-	_, _, err := pluginRuntimePublicProxyBaseURL(deps.BaseURL)
+	_, _, err := pluginRuntimePublicProxyBaseURL(hostedRuntimeRelayBaseURL(deps))
 	return err == nil
 }
 

--- a/gestaltd/internal/bootstrap/provider_build.go
+++ b/gestaltd/internal/bootstrap/provider_build.go
@@ -1412,7 +1412,7 @@ func buildHostedRuntimeHostServiceBinding(providerName, sessionID string, hostSe
 			return pluginruntime.BindHostServiceRequest{}, nil, "", err
 		}
 		if !ok {
-			return pluginruntime.BindHostServiceRequest{}, nil, "", fmt.Errorf("provider %q requires server.baseURL and server.encryptionKey to relay %s without host service tunnels", providerName, serviceLabel)
+			return pluginruntime.BindHostServiceRequest{}, nil, "", fmt.Errorf("provider %q requires server.runtime.baseUrl (or server.baseURL) and server.encryptionKey to relay %s without host service tunnels", providerName, serviceLabel)
 		}
 		return pluginruntime.BindHostServiceRequest{
 			SessionID: sessionID,
@@ -1430,10 +1430,11 @@ func buildHostedRuntimeHostServiceBinding(providerName, sessionID string, hostSe
 }
 
 func buildHostedRuntimePublicEgressProxy(providerName, sessionID string, allowedHosts []string, defaultAction egress.PolicyAction, deps Deps) (map[string]string, error) {
-	if strings.TrimSpace(deps.BaseURL) == "" || len(deps.EncryptionKey) == 0 {
-		return nil, fmt.Errorf("provider %q requires server.baseURL and server.encryptionKey to enforce hostname-based egress on hosted runtimes without host service tunnels", providerName)
+	baseURL := hostedRuntimeRelayBaseURL(deps)
+	if baseURL == "" || len(deps.EncryptionKey) == 0 {
+		return nil, fmt.Errorf("provider %q requires server.runtime.baseUrl (or server.baseURL) and server.encryptionKey to enforce hostname-based egress on hosted runtimes without host service tunnels", providerName)
 	}
-	proxyBaseURL, _, err := pluginRuntimePublicProxyBaseURL(deps.BaseURL)
+	proxyBaseURL, _, err := pluginRuntimePublicProxyBaseURL(baseURL)
 	if err != nil {
 		return nil, err
 	}
@@ -1460,10 +1461,11 @@ func buildHostedRuntimePublicEgressProxy(providerName, sessionID string, allowed
 }
 
 func buildHostedRuntimePublicHostServiceRelay(providerName, sessionID string, hostService providerhost.StartedHostService, deps Deps, serviceKey, serviceLabel, methodPrefix string) (pluginruntime.HostServiceRelay, map[string]string, string, bool, error) {
-	if strings.TrimSpace(deps.BaseURL) == "" || len(deps.EncryptionKey) == 0 {
+	baseURL := hostedRuntimeRelayBaseURL(deps)
+	if baseURL == "" || len(deps.EncryptionKey) == 0 {
 		return pluginruntime.HostServiceRelay{}, nil, "", false, nil
 	}
-	dialTarget, relayHost, err := pluginRuntimePublicRelayTarget(deps.BaseURL)
+	dialTarget, relayHost, err := pluginRuntimePublicRelayTarget(baseURL)
 	if err != nil {
 		return pluginruntime.HostServiceRelay{}, nil, "", false, err
 	}
@@ -1489,6 +1491,13 @@ func buildHostedRuntimePublicHostServiceRelay(providerName, sessionID string, ho
 		}, relayHost, true, nil
 }
 
+func hostedRuntimeRelayBaseURL(deps Deps) string {
+	if baseURL := strings.TrimSpace(deps.RuntimeBaseURL); baseURL != "" {
+		return baseURL
+	}
+	return strings.TrimSpace(deps.BaseURL)
+}
+
 func pluginRuntimePublicRelayTarget(baseURL string) (string, string, error) {
 	parsed, host, err := pluginRuntimePublicProxyBaseURL(baseURL)
 	if err != nil {
@@ -1504,20 +1513,20 @@ func pluginRuntimePublicRelayTarget(baseURL string) (string, string, error) {
 func pluginRuntimePublicProxyBaseURL(baseURL string) (*url.URL, string, error) {
 	parsed, err := url.Parse(strings.TrimSpace(baseURL))
 	if err != nil {
-		return nil, "", fmt.Errorf("parse server.baseURL for public runtime relay: %w", err)
+		return nil, "", fmt.Errorf("parse hosted runtime public relay base URL: %w", err)
 	}
 	host := strings.TrimSpace(parsed.Hostname())
 	if host == "" {
-		return nil, "", fmt.Errorf("server.baseURL %q is missing a hostname", baseURL)
+		return nil, "", fmt.Errorf("hosted runtime public relay base URL %q is missing a hostname", baseURL)
 	}
 	if path := strings.TrimSpace(parsed.EscapedPath()); path != "" && path != "/" {
-		return nil, "", fmt.Errorf("server.baseURL %q must not include a path for public runtime relay", baseURL)
+		return nil, "", fmt.Errorf("hosted runtime public relay base URL %q must not include a path", baseURL)
 	}
 	if parsed.RawQuery != "" || parsed.Fragment != "" {
-		return nil, "", fmt.Errorf("server.baseURL %q must not include a query or fragment for public runtime relay", baseURL)
+		return nil, "", fmt.Errorf("hosted runtime public relay base URL %q must not include a query or fragment", baseURL)
 	}
 	if !strings.EqualFold(parsed.Scheme, "https") {
-		return nil, "", fmt.Errorf("server.baseURL %q must use https for public runtime relay", baseURL)
+		return nil, "", fmt.Errorf("hosted runtime public relay base URL %q must use https", baseURL)
 	}
 	parsed.Path = ""
 	parsed.RawPath = ""

--- a/gestaltd/internal/config/config.go
+++ b/gestaltd/internal/config/config.go
@@ -1028,6 +1028,7 @@ type ServerConfig struct {
 
 type ServerRuntimeConfig struct {
 	Provider string `yaml:"provider,omitempty"`
+	BaseURL  string `yaml:"baseUrl,omitempty"`
 }
 
 func (s ServerConfig) PublicListener() ListenerConfig {
@@ -1063,6 +1064,10 @@ func (s ServerConfig) ManagementAddr() string {
 
 func (s ServerConfig) ManagementBaseURL() string {
 	return strings.TrimRight(strings.TrimSpace(s.Management.BaseURL), "/")
+}
+
+func (s ServerConfig) RuntimeBaseURL() string {
+	return strings.TrimRight(strings.TrimSpace(s.Runtime.BaseURL), "/")
 }
 
 // ConnectionDef owns authentication and connection parameters for a named
@@ -2470,6 +2475,7 @@ func applyPluginMountBindings(cfg *Config) error {
 func resolveBaseURL(cfg *Config) {
 	cfg.Server.BaseURL = strings.TrimRight(strings.TrimSpace(cfg.Server.BaseURL), "/")
 	cfg.Server.Management.BaseURL = strings.TrimRight(strings.TrimSpace(cfg.Server.Management.BaseURL), "/")
+	cfg.Server.Runtime.BaseURL = strings.TrimRight(strings.TrimSpace(cfg.Server.Runtime.BaseURL), "/")
 }
 
 func resolveRelativePathsInValue(configPath string, root map[string]any, sourceSyntax providerSourceSyntaxMode) {

--- a/gestaltd/internal/config/config_test.go
+++ b/gestaltd/internal/config/config_test.go
@@ -1013,6 +1013,50 @@ providers:
 		}
 	})
 
+	t.Run("runtime.baseUrl must use https", func(t *testing.T) {
+		t.Parallel()
+
+		path := mustWriteConfigFile(t, `
+server:
+  encryptionKey: server-key
+  runtime:
+    baseUrl: http://gestalt.example.test
+providers:
+  indexeddb:
+    sqlite:
+      source:
+        path: ./providers/datastore/sqlite
+`)
+
+		if _, err := Load(path); err == nil {
+			t.Fatal("Load: expected error, got nil")
+		} else if !strings.Contains(err.Error(), "server.runtime.baseUrl must use https") {
+			t.Fatalf("Load error = %v, want server.runtime.baseUrl https validation", err)
+		}
+	})
+
+	t.Run("runtime.baseUrl may not include a path", func(t *testing.T) {
+		t.Parallel()
+
+		path := mustWriteConfigFile(t, `
+server:
+  encryptionKey: server-key
+  runtime:
+    baseUrl: https://gestalt.example.test/runtime
+providers:
+  indexeddb:
+    sqlite:
+      source:
+        path: ./providers/datastore/sqlite
+`)
+
+		if _, err := Load(path); err == nil {
+			t.Fatal("Load: expected error, got nil")
+		} else if !strings.Contains(err.Error(), "server.runtime.baseUrl may not include a path") {
+			t.Fatalf("Load error = %v, want server.runtime.baseUrl path validation", err)
+		}
+	})
+
 	t.Run("invalid baseUrl is rejected for split built-in admin auth", func(t *testing.T) {
 		t.Parallel()
 

--- a/gestaltd/internal/config/config_validate.go
+++ b/gestaltd/internal/config/config_validate.go
@@ -414,6 +414,9 @@ func validateRuntimeConfig(cfg *Config) error {
 	if cfg == nil {
 		return nil
 	}
+	if _, err := validateHostedRuntimeBaseURL("server.runtime.baseUrl", cfg.Server.RuntimeBaseURL()); err != nil {
+		return err
+	}
 	sourceSyntax := sourceSyntaxForConfig(cfg.APIVersion)
 	cfg.Server.Runtime.Provider = strings.TrimSpace(cfg.Server.Runtime.Provider)
 	for name, entry := range cfg.Runtime.Providers {
@@ -939,6 +942,20 @@ func validateAbsoluteBaseURL(label, raw string) (*url.URL, error) {
 	}
 	if parsed.RawQuery != "" || parsed.Fragment != "" {
 		return nil, fmt.Errorf("config validation: %s may not include query or fragment", label)
+	}
+	return parsed, nil
+}
+
+func validateHostedRuntimeBaseURL(label, raw string) (*url.URL, error) {
+	parsed, err := validateAbsoluteBaseURL(label, raw)
+	if err != nil || parsed == nil {
+		return parsed, err
+	}
+	if !strings.EqualFold(parsed.Scheme, "https") {
+		return nil, fmt.Errorf("config validation: %s must use https", label)
+	}
+	if path := strings.TrimSpace(parsed.EscapedPath()); path != "" && path != "/" {
+		return nil, fmt.Errorf("config validation: %s may not include a path", label)
 	}
 	return parsed, nil
 }

--- a/gestaltd/internal/testutil/cmd/indexeddbtransportd/main.go
+++ b/gestaltd/internal/testutil/cmd/indexeddbtransportd/main.go
@@ -4,33 +4,58 @@
 package main
 
 import (
+	"context"
+	"crypto/tls"
 	"flag"
 	"fmt"
+	"net"
+	"net/http"
+	"net/http/httputil"
 	"os"
 	"os/signal"
+	"path/filepath"
+	"strconv"
 	"strings"
 	"syscall"
+	"time"
 
+	"github.com/valon-technologies/gestalt/server/internal/providerhost"
 	"github.com/valon-technologies/gestalt/server/internal/testutil/indexeddbtransport"
+	"golang.org/x/net/http2"
+	"google.golang.org/grpc/codes"
 )
 
 func main() {
 	socket := flag.String("socket", "", "Unix socket path to listen on")
 	tcp := flag.String("tcp", "", "TCP host:port to listen on")
+	relayTLS := flag.String("relay-tls", "", "TLS relay host:port to listen on")
+	certFile := flag.String("cert-file", "", "PEM certificate for --relay-tls")
+	keyFile := flag.String("key-file", "", "PEM private key for --relay-tls")
 	expectToken := flag.String("expect-token", "", "Require the relay token header to match this value")
 	flag.Parse()
-	target := *socket
-	if strings.TrimSpace(*tcp) != "" {
-		target = "tcp://" + strings.TrimSpace(*tcp)
+	modeCount := 0
+	if strings.TrimSpace(*socket) != "" {
+		modeCount++
 	}
-	if strings.TrimSpace(target) == "" {
-		fmt.Fprintln(os.Stderr, "usage: indexeddbtransportd --socket <path> | --tcp <host:port>")
+	if strings.TrimSpace(*tcp) != "" {
+		modeCount++
+	}
+	if strings.TrimSpace(*relayTLS) != "" {
+		modeCount++
+	}
+	if modeCount != 1 {
+		fmt.Fprintln(os.Stderr, "usage: indexeddbtransportd --socket <path> | --tcp <host:port> | --relay-tls <host:port>")
 		os.Exit(1)
 	}
 
-	srv, err := indexeddbtransport.Start(target, indexeddbtransport.Options{
-		ExpectRelayToken: strings.TrimSpace(*expectToken),
-	})
+	srv, err := startHarness(
+		strings.TrimSpace(*socket),
+		strings.TrimSpace(*tcp),
+		strings.TrimSpace(*relayTLS),
+		strings.TrimSpace(*certFile),
+		strings.TrimSpace(*keyFile),
+		strings.TrimSpace(*expectToken),
+	)
 	if err != nil {
 		fmt.Fprintf(os.Stderr, "failed to start: %v\n", err)
 		os.Exit(1)
@@ -42,4 +67,128 @@ func main() {
 	sig := make(chan os.Signal, 1)
 	signal.Notify(sig, syscall.SIGINT, syscall.SIGTERM)
 	<-sig
+}
+
+type harness interface {
+	Stop()
+}
+
+func startHarness(
+	socket string,
+	tcp string,
+	relayTLS string,
+	certFile string,
+	keyFile string,
+	expectToken string,
+) (harness, error) {
+	switch {
+	case relayTLS != "":
+		if certFile == "" || keyFile == "" {
+			return nil, fmt.Errorf("--relay-tls requires --cert-file and --key-file")
+		}
+		return startTLSRelay(relayTLS, certFile, keyFile, expectToken)
+	case tcp != "":
+		return indexeddbtransport.Start("tcp://"+tcp, indexeddbtransport.Options{
+			ExpectRelayToken: expectToken,
+		})
+	default:
+		return indexeddbtransport.Start(socket, indexeddbtransport.Options{
+			ExpectRelayToken: expectToken,
+		})
+	}
+}
+
+type relayHarness struct {
+	backend    *indexeddbtransport.Server
+	relay      *http.Server
+	listener   net.Listener
+	socketPath string
+}
+
+func startTLSRelay(address string, certFile string, keyFile string, expectToken string) (*relayHarness, error) {
+	socketPath := filepath.Join(
+		os.TempDir(),
+		fmt.Sprintf("idb-relay-%d-%d.sock", os.Getpid(), time.Now().UnixNano()),
+	)
+	backend, err := indexeddbtransport.Start("unix://"+socketPath, indexeddbtransport.Options{})
+	if err != nil {
+		return nil, err
+	}
+
+	listener, err := net.Listen("tcp", address)
+	if err != nil {
+		backend.Stop()
+		return nil, err
+	}
+
+	proxy := newRuntimeRelayProxy(socketPath)
+	server := &http.Server{
+		Handler: http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			if expectToken != "" {
+				token := strings.TrimSpace(r.Header.Get(providerhost.HostServiceRelayTokenHeader))
+				if token != expectToken {
+					writeGRPCTrailersOnly(w, codes.Unauthenticated, "invalid-host-service-relay-token")
+					return
+				}
+			}
+			proxy.ServeHTTP(w, r)
+		}),
+		TLSConfig: &tls.Config{
+			MinVersion: tls.VersionTLS12,
+			NextProtos: []string{"h2"},
+		},
+	}
+	go func() {
+		_ = server.ServeTLS(listener, certFile, keyFile)
+	}()
+
+	return &relayHarness{
+		backend:    backend,
+		relay:      server,
+		listener:   listener,
+		socketPath: socketPath,
+	}, nil
+}
+
+func (h *relayHarness) Stop() {
+	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	defer cancel()
+	_ = h.relay.Shutdown(ctx)
+	_ = h.listener.Close()
+	h.backend.Stop()
+	_ = os.Remove(h.socketPath)
+}
+
+func newRuntimeRelayProxy(socketPath string) *httputil.ReverseProxy {
+	target := "gestalt-test-host-service-relay"
+	return &httputil.ReverseProxy{
+		Rewrite: func(pr *httputil.ProxyRequest) {
+			pr.Out.URL.Scheme = "http"
+			pr.Out.URL.Host = target
+			pr.Out.Host = target
+			pr.Out.Header.Del(providerhost.HostServiceRelayTokenHeader)
+		},
+		Transport: &http2.Transport{
+			AllowHTTP: true,
+			DialTLSContext: func(ctx context.Context, _, _ string, _ *tls.Config) (net.Conn, error) {
+				var dialer net.Dialer
+				return dialer.DialContext(ctx, "unix", socketPath)
+			},
+		},
+		FlushInterval: -1,
+		ErrorHandler: func(w http.ResponseWriter, _ *http.Request, _ error) {
+			writeGRPCTrailersOnly(w, codes.Unavailable, "host-service-relay-unavailable")
+		},
+	}
+}
+
+func writeGRPCTrailersOnly(w http.ResponseWriter, code codes.Code, message string) {
+	headers := w.Header()
+	headers.Set("Content-Type", "application/grpc")
+	headers.Set("Trailer", "Grpc-Status, Grpc-Message")
+	headers.Set("Grpc-Status", strconv.Itoa(int(code)))
+	if message != "" {
+		headers.Set("Grpc-Message", message)
+	}
+	w.WriteHeader(http.StatusOK)
 }

--- a/sdk/python/gestalt/_agent.py
+++ b/sdk/python/gestalt/_agent.py
@@ -6,7 +6,11 @@ from urllib import parse as _urlparse
 
 import grpc
 
-from ._grpc_transport import insecure_internal_channel, secure_internal_channel
+from ._grpc_transport import (
+    insecure_internal_channel,
+    internal_channel_target,
+    secure_internal_channel,
+)
 from .gen.v1 import agent_pb2 as _pb
 from .gen.v1 import agent_pb2_grpc as _pb_grpc
 
@@ -151,11 +155,11 @@ class _ClientCallDetails(grpc.ClientCallDetails):
 def _host_service_channel(service_name: str, target: str, *, token: str = "") -> Any:
     scheme, address = _parse_host_service_target(service_name, target)
     if scheme == "unix":
-        channel = insecure_internal_channel(f"unix:{address}")
+        channel = insecure_internal_channel(internal_channel_target("unix", address))
     elif scheme == "tcp":
-        channel = insecure_internal_channel(address)
+        channel = insecure_internal_channel(internal_channel_target("tcp", address))
     elif scheme == "tls":
-        channel = secure_internal_channel(address)
+        channel = secure_internal_channel(internal_channel_target("tls", address))
     else:
         raise RuntimeError(f"unsupported {service_name} transport scheme {scheme!r}")
     if token:

--- a/sdk/python/gestalt/_authorization.py
+++ b/sdk/python/gestalt/_authorization.py
@@ -11,7 +11,11 @@ import grpc
 from google.protobuf import empty_pb2 as _empty_pb2
 from google.protobuf import json_format
 
-from ._grpc_transport import insecure_internal_channel, secure_internal_channel
+from ._grpc_transport import (
+    insecure_internal_channel,
+    internal_channel_target,
+    secure_internal_channel,
+)
 from .gen.v1 import authorization_pb2 as _authorization_pb2
 from .gen.v1 import authorization_pb2_grpc as _authorization_pb2_grpc
 
@@ -191,7 +195,7 @@ def _authorization_channel(raw_target: str, *, token: str = "") -> grpc.Channel:
                 f"authorization: tcp target {raw_target!r} is missing host:port"
             )
         return _with_authorization_relay_token(
-            insecure_internal_channel(f"dns:///{address}"),
+            insecure_internal_channel(internal_channel_target("tcp", address)),
             token,
         )
     if target.startswith("tls://"):
@@ -201,7 +205,7 @@ def _authorization_channel(raw_target: str, *, token: str = "") -> grpc.Channel:
                 f"authorization: tls target {raw_target!r} is missing host:port"
             )
         return _with_authorization_relay_token(
-            secure_internal_channel(f"dns:///{address}"),
+            secure_internal_channel(internal_channel_target("tls", address)),
             token,
         )
     if target.startswith("unix://"):
@@ -211,7 +215,7 @@ def _authorization_channel(raw_target: str, *, token: str = "") -> grpc.Channel:
                 f"authorization: unix target {raw_target!r} is missing a socket path"
             )
         return _with_authorization_relay_token(
-            insecure_internal_channel(f"unix:{socket_path}"),
+            insecure_internal_channel(internal_channel_target("unix", socket_path)),
             token,
         )
     if "://" in target:
@@ -220,7 +224,7 @@ def _authorization_channel(raw_target: str, *, token: str = "") -> grpc.Channel:
             f"authorization: unsupported target scheme {parsed.scheme!r}"
         )
     return _with_authorization_relay_token(
-        insecure_internal_channel(f"unix:{target}"),
+        insecure_internal_channel(internal_channel_target("unix", target)),
         token,
     )
 

--- a/sdk/python/gestalt/_cache.py
+++ b/sdk/python/gestalt/_cache.py
@@ -11,7 +11,11 @@ from urllib import parse as _urlparse
 import grpc
 from google.protobuf import duration_pb2 as _duration_pb2
 
-from ._grpc_transport import insecure_internal_channel, secure_internal_channel
+from ._grpc_transport import (
+    insecure_internal_channel,
+    internal_channel_target,
+    secure_internal_channel,
+)
 from .gen.v1 import cache_pb2 as _pb
 from .gen.v1 import cache_pb2_grpc as _pb_grpc
 
@@ -199,11 +203,11 @@ class _ClientCallDetails(grpc.ClientCallDetails):
 def _cache_channel(target: str, *, token: str = "") -> Any:
     scheme, address = _parse_cache_target(target)
     if scheme == "unix":
-        channel = insecure_internal_channel(f"unix:{address}")
+        channel = insecure_internal_channel(internal_channel_target("unix", address))
     elif scheme == "tcp":
-        channel = insecure_internal_channel(address)
+        channel = insecure_internal_channel(internal_channel_target("tcp", address))
     elif scheme == "tls":
-        channel = secure_internal_channel(address)
+        channel = secure_internal_channel(internal_channel_target("tls", address))
     else:
         raise RuntimeError(f"unsupported cache transport scheme {scheme!r}")
     if token:

--- a/sdk/python/gestalt/_grpc_transport.py
+++ b/sdk/python/gestalt/_grpc_transport.py
@@ -11,6 +11,20 @@ grpc: Any = cast(Any, _grpc)
 _INTERNAL_CHANNEL_OPTIONS = (("grpc.enable_http_proxy", 0),)
 
 
+def internal_channel_target(scheme: str, address: str) -> str:
+    """Normalize an internal gRPC transport target for grpcio."""
+
+    normalized_scheme = scheme.strip().lower()
+    normalized_address = address.strip()
+    if not normalized_address:
+        raise RuntimeError("internal gRPC transport target is required")
+    if normalized_scheme == "unix":
+        return f"unix:{normalized_address}"
+    if normalized_scheme in {"tcp", "tls"}:
+        return normalized_address
+    raise RuntimeError(f"unsupported internal gRPC transport scheme {scheme!r}")
+
+
 def insecure_internal_channel(target: str) -> grpc.Channel:
     """Return an insecure internal gRPC channel with proxy use disabled."""
 

--- a/sdk/python/gestalt/_indexeddb.py
+++ b/sdk/python/gestalt/_indexeddb.py
@@ -13,7 +13,11 @@ import grpc as _grpc
 from google.protobuf import struct_pb2 as _struct_pb2
 from google.protobuf import timestamp_pb2 as _timestamp_pb2
 
-from ._grpc_transport import insecure_internal_channel, secure_internal_channel
+from ._grpc_transport import (
+    insecure_internal_channel,
+    internal_channel_target,
+    secure_internal_channel,
+)
 from .gen.v1 import datastore_pb2 as _pb
 from .gen.v1 import datastore_pb2_grpc as _pb_grpc
 
@@ -373,7 +377,7 @@ def _indexeddb_channel(raw_target: str, *, token: str = "") -> grpc.Channel:
                 f"IndexedDB tcp target {raw_target!r} is missing host:port"
             )
         return _with_indexeddb_relay_token(
-            insecure_internal_channel(f"dns:///{address}"),
+            insecure_internal_channel(internal_channel_target("tcp", address)),
             token,
         )
     if target.startswith("tls://"):
@@ -383,7 +387,7 @@ def _indexeddb_channel(raw_target: str, *, token: str = "") -> grpc.Channel:
                 f"IndexedDB tls target {raw_target!r} is missing host:port"
             )
         return _with_indexeddb_relay_token(
-            secure_internal_channel(f"dns:///{address}"),
+            secure_internal_channel(internal_channel_target("tls", address)),
             token,
         )
     if target.startswith("unix://"):
@@ -393,14 +397,14 @@ def _indexeddb_channel(raw_target: str, *, token: str = "") -> grpc.Channel:
                 f"IndexedDB unix target {raw_target!r} is missing a socket path"
             )
         return _with_indexeddb_relay_token(
-            insecure_internal_channel(f"unix:{socket_path}"),
+            insecure_internal_channel(internal_channel_target("unix", socket_path)),
             token,
         )
     if "://" in target:
         parsed = _urlparse.urlparse(target)
         raise RuntimeError(f"unsupported IndexedDB target scheme {parsed.scheme!r}")
     return _with_indexeddb_relay_token(
-        insecure_internal_channel(f"unix:{target}"),
+        insecure_internal_channel(internal_channel_target("unix", target)),
         token,
     )
 

--- a/sdk/python/gestalt/_invoker.py
+++ b/sdk/python/gestalt/_invoker.py
@@ -10,7 +10,11 @@ from google.protobuf import json_format
 from google.protobuf import struct_pb2 as _struct_pb2
 
 from ._api import Response
-from ._grpc_transport import insecure_internal_channel, secure_internal_channel
+from ._grpc_transport import (
+    insecure_internal_channel,
+    internal_channel_target,
+    secure_internal_channel,
+)
 from .gen.v1 import plugin_pb2 as _pb
 from .gen.v1 import plugin_pb2_grpc as _pb_grpc
 
@@ -199,7 +203,7 @@ def _plugin_invoker_channel(raw_target: str, *, token: str = "") -> grpc.Channel
                 f"plugin invoker: tcp target {raw_target!r} is missing host:port"
             )
         return _with_plugin_invoker_relay_token(
-            insecure_internal_channel(f"dns:///{address}"),
+            insecure_internal_channel(internal_channel_target("tcp", address)),
             token,
         )
     if target.startswith("tls://"):
@@ -209,7 +213,7 @@ def _plugin_invoker_channel(raw_target: str, *, token: str = "") -> grpc.Channel
                 f"plugin invoker: tls target {raw_target!r} is missing host:port"
             )
         return _with_plugin_invoker_relay_token(
-            secure_internal_channel(f"dns:///{address}"),
+            secure_internal_channel(internal_channel_target("tls", address)),
             token,
         )
     if target.startswith("unix://"):
@@ -219,7 +223,7 @@ def _plugin_invoker_channel(raw_target: str, *, token: str = "") -> grpc.Channel
                 f"plugin invoker: unix target {raw_target!r} is missing a socket path"
             )
         return _with_plugin_invoker_relay_token(
-            insecure_internal_channel(f"unix:{socket_path}"),
+            insecure_internal_channel(internal_channel_target("unix", socket_path)),
             token,
         )
     if "://" in target:
@@ -228,7 +232,7 @@ def _plugin_invoker_channel(raw_target: str, *, token: str = "") -> grpc.Channel
             f"plugin invoker: unsupported target scheme {parsed.scheme!r}"
         )
     return _with_plugin_invoker_relay_token(
-        insecure_internal_channel(f"unix:{target}"),
+        insecure_internal_channel(internal_channel_target("unix", target)),
         token,
     )
 

--- a/sdk/python/gestalt/_s3.py
+++ b/sdk/python/gestalt/_s3.py
@@ -14,7 +14,11 @@ from urllib import parse as _urlparse
 import grpc
 from google.protobuf import timestamp_pb2 as _timestamp_pb2
 
-from ._grpc_transport import insecure_internal_channel, secure_internal_channel
+from ._grpc_transport import (
+    insecure_internal_channel,
+    internal_channel_target,
+    secure_internal_channel,
+)
 from .gen.v1 import s3_pb2 as _pb
 from .gen.v1 import s3_pb2_grpc as _pb_grpc
 
@@ -353,11 +357,11 @@ class _RelayTokenInterceptor(
 def _s3_channel(target: str, *, token: str = "") -> Any:
     scheme, address = _parse_s3_target(target)
     if scheme == "unix":
-        channel = insecure_internal_channel(f"unix:{address}")
+        channel = insecure_internal_channel(internal_channel_target("unix", address))
     elif scheme == "tcp":
-        channel = insecure_internal_channel(address)
+        channel = insecure_internal_channel(internal_channel_target("tcp", address))
     elif scheme == "tls":
-        channel = secure_internal_channel(address)
+        channel = secure_internal_channel(internal_channel_target("tls", address))
     else:
         raise RuntimeError(f"unsupported s3 transport scheme {scheme!r}")
     token = token.strip()

--- a/sdk/python/tests/test_indexeddb_transport.py
+++ b/sdk/python/tests/test_indexeddb_transport.py
@@ -2,6 +2,7 @@
 from __future__ import annotations
 
 import os
+import shutil
 import socket
 import subprocess
 import tempfile
@@ -47,6 +48,57 @@ def _build_harness() -> str:
 _harness_bin: str | None = None
 _harness_proc: subprocess.Popen[bytes] | None = None
 _socket_path: str = ""
+
+_TLS_CERT_PEM = """-----BEGIN CERTIFICATE-----
+MIIDJTCCAg2gAwIBAgIUaQujB8wIeckTiFgjFgZbVaxm3EQwDQYJKoZIhvcNAQEL
+BQAwFDESMBAGA1UEAwwJMTI3LjAuMC4xMB4XDTI2MDQyNDE0NDA0MFoXDTM2MDQy
+MTE0NDA0MFowFDESMBAGA1UEAwwJMTI3LjAuMC4xMIIBIjANBgkqhkiG9w0BAQEF
+AAOCAQ8AMIIBCgKCAQEAsDkKPwQrtsaP9/AgIhbEy37Qo04MNGFu58T0HihDs3YF
+yGtJmiUv99dYYzsErAuPBIlITaDJqi3jtIpg8mgQZsokzkqeWtYG14Xy2fejwzIc
+Me4i4nE9Pj5WICJ2ydmERS2cOiDhUMojtaMgGv+kIZFOfF6/TpL6eyRPa2pRfgI0
+cbKltvafs0PGL66IchCGAOd1i+iDRCJcUC7Gle4vYwZyg0a3ojGt8+ufySmNxN1m
+gNHcAXU81xoqwfiuk62sDaz3Ev7kEsXp3nQf6Pv+3LTQjR8tcAh7DuD5QwEW+o66
+N3SmR+hX8KWKXGqa1j4G6hKkkCB5x1sUgRHagyVaRwIDAQABo28wbTAdBgNVHQ4E
+FgQU9PEc5NZcAXX9Hp46kuJT/8OpN0IwHwYDVR0jBBgwFoAU9PEc5NZcAXX9Hp46
+kuJT/8OpN0IwDwYDVR0TAQH/BAUwAwEB/zAaBgNVHREEEzARhwR/AAABgglsb2Nh
+bGhvc3QwDQYJKoZIhvcNAQELBQADggEBAJtCNvqECQmT7PrbErt9VzmwIok5JyFd
+RIkWdSTAYREET5PFK11BdKLcatrjNEedZ94X3M27dOpTDXhGhu2W2n/bg+6QKiEN
+UeZcDja28w50vrkJTSFTYgON96nX6zPd3mtVY8Z2gAE8DWtMnjfzDj26354dldht
+yHJtQIuj/67p6FDgu+nXVz84UtmH1PAoJ6/dSMTjpjMdDSLo0P44EHK80curNKdF
+u67O4clOBfuyR96gqeMXpx2qy6T4y1kOTcIecVjG/U/BD31xgRxqBhf7JXV40QDA
+zqha1yhGmVTSc6eS8FX/oD/QGmqbiQJmdprbop05KLItfi1FAE0yTvs=
+-----END CERTIFICATE-----
+"""
+
+_TLS_KEY_PEM = """-----BEGIN PRIVATE KEY-----
+MIIEvAIBADANBgkqhkiG9w0BAQEFAASCBKYwggSiAgEAAoIBAQCwOQo/BCu2xo/3
+8CAiFsTLftCjTgw0YW7nxPQeKEOzdgXIa0maJS/311hjOwSsC48EiUhNoMmqLeO0
+imDyaBBmyiTOSp5a1gbXhfLZ96PDMhwx7iLicT0+PlYgInbJ2YRFLZw6IOFQyiO1
+oyAa/6QhkU58Xr9Okvp7JE9ralF+AjRxsqW29p+zQ8YvrohyEIYA53WL6INEIlxQ
+LsaV7i9jBnKDRreiMa3z65/JKY3E3WaA0dwBdTzXGirB+K6TrawNrPcS/uQSxene
+dB/o+/7ctNCNHy1wCHsO4PlDARb6jro3dKZH6FfwpYpcaprWPgbqEqSQIHnHWxSB
+EdqDJVpHAgMBAAECggEACpDo+d1Mp7FhKXsW2iRmWVM5vEjuN2fOKAxpnLNKV+TQ
+NPOl3p2zMheR36VGwvAQe7Olh64H2XHV8NnJNU+jCB6/tTTJKOYjU+HerU4JXidP
+hHjkU5J5mxVOwa9/Utv9b85ryxp0mAz+tiHZR3UjiLW3MILX0qTCawbC0kx2JWlv
+8kDri5JK9Cbe1TpfiDPg+up//Mu9KltPuB8yaBAGgj3JmafdNfQWDNh/UnK0O0VG
+TzFyeQN998RqJc0zXvPds+x5k8BMG955HuX2EA/SjyD01IrT2BtLyrRaw3ovlSCS
+FhWzMf/85mUgOkKzXm3aTqjVnL+C/JHTlx21+ypw3QKBgQDb0V060PbUI1T6vL0d
+jqkN0AO6o/OWikglVUJ0v9nm4N7ueU6ODtx2NNjsyvHPvLodIGTAkplU55+VBhmf
+dz2JG3XLvTOxSyr75k/T4d28FkscrLphefutWx0UY2aTp6YXlMkQ+jzARiEESKmU
+KZgR03p+JxAkZmWb7cGJz45EBQKBgQDNOq203/Nyq8uM7s8ZnGX943ZR5oI716Bs
+X519C5IDwngMoDxySvdncHf2EROSxmciIH/C5i4oJ5yZCtdDOD2rSFR0DvQF2WKk
+ZIsJzZmLxt4wu7R6/HU+JeU4LSp0QRSpXj72fdXhUuRARznNbufnkbccPe12ww09
+XAQNiq6i2wKBgDMljuzNjHEl23MQEWzcMee92/BEj7waZtkQ8oqZzUjUT+rrHOUe
+/hsfBs5qFkPA5Qk77VWFhtnjnxUcuz+Iji/lzM3gMzPwiorcNvzVFDPceBOu+RsP
+OAlJJwYEbuyyWIoqG3Kw1wviBXKquZJ47yJOs7TAwBfIH6Jdeufm/HJFAoGAEQEJ
+n3DmxNuDE/w9YIvaz3xnM0X8CGVHP3N0owWwZWtZcwJbv8SCVym0ZsjnbEPQC73R
+mB5mOKF/khaZ21Hvmh92D9+lTE7Eo4ZJFtjYHgKuKi+DNqVwOWP+Z/cmC1fRFG9g
+nB+09uRdUQ4VtfW4dTFXkJl48Vwb3refBlg1O/0CgYBwKoyGmlcQfQAX0b29835W
+gWukLcKU+Kd99IAuVVbWNsAFwqEp0cm3gtrN6ZcPQ/U095WqsrGe7Bt2qw7xSt5D
+Jpp6kBddjP+CvphxEnoP0AQY71BBvW25NYxecd16Mhk5/g2/h/etwpnyE/XCXbOS
+2Xz7l2ukjglD2aCfiHN+EQ==
+-----END PRIVATE KEY-----
+"""
 
 
 def setUpModule() -> None:
@@ -99,6 +151,42 @@ def _start_tcp_harness(expect_token: str = "") -> tuple[subprocess.Popen[bytes],
         proc.kill()
         raise RuntimeError(f"tcp harness did not print READY, got: {line!r}")
     return proc, f"tcp://{address}"
+
+
+def _start_tls_relay_harness(
+    expect_token: str = "",
+) -> tuple[subprocess.Popen[bytes], str, str, str, str]:
+    harness_bin = _build_harness()
+    address = _reserve_tcp_address()
+    temp_dir = tempfile.mkdtemp(prefix="py-idb-tls-relay-")
+    cert_path = os.path.join(temp_dir, "cert.pem")
+    key_path = os.path.join(temp_dir, "key.pem")
+    with open(cert_path, "w", encoding="utf-8") as cert_file:
+        cert_file.write(_TLS_CERT_PEM)
+    with open(key_path, "w", encoding="utf-8") as key_file:
+        key_file.write(_TLS_KEY_PEM)
+    args = [
+        harness_bin,
+        "--relay-tls",
+        address,
+        "--cert-file",
+        cert_path,
+        "--key-file",
+        key_path,
+    ]
+    if expect_token:
+        args.extend(["--expect-token", expect_token])
+    proc = subprocess.Popen(
+        args,
+        stdout=subprocess.PIPE,
+    )
+    assert proc.stdout is not None
+    line = proc.stdout.readline().decode().strip()
+    proc.stdout.close()
+    if line != "READY":
+        proc.kill()
+        raise RuntimeError(f"tls relay harness did not print READY, got: {line!r}")
+    return proc, f"tls://{address}", cert_path, key_path, temp_dir
 
 
 def _client() -> IndexedDB:
@@ -222,6 +310,50 @@ class TestTCPTarget(unittest.TestCase):
         s.put({"id": "row-1", "value": "proxy-bypass"})
         got = s.get("row-1")
         self.assertEqual(got["value"], "proxy-bypass")
+        c.close()
+
+
+class TestTLSRelayTarget(unittest.TestCase):
+    def test_tls_relay_target_token_roundtrip_ignores_proxy_env(self) -> None:
+        token = "relay-token-python"
+        proc, target, cert_path, _, temp_dir = _start_tls_relay_harness(expect_token=token)
+        self.addCleanup(proc.wait)
+        self.addCleanup(proc.kill)
+        self.addCleanup(shutil.rmtree, temp_dir, True)
+
+        restore_names = [
+            "GESTALT_INDEXEDDB_SOCKET",
+            indexeddb_socket_token_env(),
+            "GRPC_DEFAULT_SSL_ROOTS_FILE_PATH",
+            "http_proxy",
+            "https_proxy",
+            "HTTP_PROXY",
+            "HTTPS_PROXY",
+        ]
+        previous_env = {name: os.environ.get(name) for name in restore_names}
+
+        def restore_env() -> None:
+            for name, value in previous_env.items():
+                if value is None:
+                    os.environ.pop(name, None)
+                else:
+                    os.environ[name] = value
+
+        os.environ["GESTALT_INDEXEDDB_SOCKET"] = target
+        os.environ[indexeddb_socket_token_env()] = token
+        os.environ["GRPC_DEFAULT_SSL_ROOTS_FILE_PATH"] = cert_path
+        os.environ["http_proxy"] = "http://127.0.0.1:1"
+        os.environ["https_proxy"] = "http://127.0.0.1:1"
+        os.environ["HTTP_PROXY"] = "http://127.0.0.1:1"
+        os.environ["HTTPS_PROXY"] = "http://127.0.0.1:1"
+        self.addCleanup(restore_env)
+
+        c = _client()
+        c.create_object_store("tls_relay_target_env")
+        s = c.object_store("tls_relay_target_env")
+        s.put({"id": "row-1", "value": "tls-relay"})
+        got = s.get("row-1")
+        self.assertEqual(got["value"], "tls-relay")
         c.close()
 
 


### PR DESCRIPTION
## Summary
Add a dedicated hosted-runtime relay/proxy base URL with fallback to `server.baseUrl`.

## New interface
```yaml
server:
  baseUrl: https://valon.tools/
  runtime:
    provider: modal
    baseUrl: https://toolshed-test-igvn5izafq-uk.a.run.app/
```

## Behavior
- hosted runtime host-service relays use `server.runtime.baseUrl` when set
- hosted runtime egress proxy URLs use `server.runtime.baseUrl` when set
- `server.baseUrl` remains the fallback when `server.runtime.baseUrl` is unset

## Examples
- keep public user traffic on `https://valon.tools/`
- route Modal sandbox callbacks through `https://toolshed-test-igvn5izafq-uk.a.run.app/`
- leave existing configs unchanged by omitting `server.runtime.baseUrl`

## Validation
- `go test ./internal/bootstrap -run 'TestPluginRuntimeConfigUsesPublicIndexedDBRelayWithoutHostServiceTunnelCapability|TestPluginRuntimeConfigUsesRuntimeBaseURLForPublicIndexedDBRelay|TestPluginRuntimeConfigInjectsPublicEgressProxyWithoutHostServiceTunnelCapability|TestPluginRuntimeConfigUsesRuntimeBaseURLForPublicEgressProxy|TestPluginRuntimePublicIndexedDBRelayRoundTripsThroughHostedPlugin|TestPluginRuntimePublicEgressProxyRoundTripsThroughHostedPlugin'`
- `go test ./internal/config -run 'TestLoadConfigAdminBaseURLValidation'`
- `golangci-lint run ./internal/bootstrap ./internal/config`
