### PR TITLE
Prepare gestalt CLI v0.0.1-alpha.6 release

### DIFF
--- a/gestalt/Cargo.toml
+++ b/gestalt/Cargo.toml
@@ -3,5 +3,5 @@ resolver = "2"
 members = ["cli"]
 
 [workspace.package]
-version = "0.0.1-alpha.5"
+version = "0.0.1-alpha.6"
 edition = "2024"


### PR DESCRIPTION
## Summary
- bump the gestalt CLI workspace version to `0.0.1-alpha.6` so the next CLI tag can publish
- keep `gestaltd` release prep tag-driven with no pre-edit to formulas or Helm
- document the exact coordinated tags to cut from the merged commit

## Release Tags
- `gestalt/v0.0.1-alpha.6`
- `gestaltd/v0.0.1-alpha.4`

## Examples
- `gestalt agent`
- `gestalt agent sessions create --provider simple --model fast`
- `git tag gestalt/v0.0.1-alpha.6 <sha> && git tag gestaltd/v0.0.1-alpha.4 <sha>`

## Verification
- `cargo test --manifest-path gestalt/cli/Cargo.toml --test auth_flow --test agents_cli`
- `cargo fmt --all -- --check`
- `cargo clippy --workspace --all-targets -- -D warnings`