### PR TITLE
server: support hosted runtime relay over HTTP/2

### DIFF
--- a/gestaltd/internal/server/runtime.go
+++ b/gestaltd/internal/server/runtime.go
@@ -17,6 +17,8 @@ import (
 	"github.com/valon-technologies/gestalt/server/internal/invocation"
 	gestaltmcp "github.com/valon-technologies/gestalt/server/internal/mcp"
 	"github.com/valon-technologies/gestalt/server/internal/pluginsource"
+	"golang.org/x/net/http2"
+	"golang.org/x/net/http2/h2c"
 )
 
 const runtimeShutdownTimeout = 15 * time.Second
@@ -272,7 +274,7 @@ func newMCPHandler(cfg *config.Config, connMaps bootstrap.ConnectionMaps, result
 func newHTTPServer(addr string, handler http.Handler) *http.Server {
 	return &http.Server{
 		Addr:              addr,
-		Handler:           handler,
+		Handler:           h2c.NewHandler(handler, &http2.Server{}),
 		ReadHeaderTimeout: 10 * time.Second,
 		IdleTimeout:       120 * time.Second,
 		MaxHeaderBytes:    1 << 20,

--- a/gestaltd/internal/server/runtime_test.go
+++ b/gestaltd/internal/server/runtime_test.go
@@ -1,9 +1,22 @@
 package server
 
 import (
+	"context"
+	"net"
+	"net/http"
+	"sync"
 	"testing"
+	"time"
 
+	proto "github.com/valon-technologies/gestalt/sdk/go/gen/v1"
+	coretesting "github.com/valon-technologies/gestalt/server/core/testing"
 	"github.com/valon-technologies/gestalt/server/internal/bootstrap"
+	"github.com/valon-technologies/gestalt/server/internal/invocation"
+	"github.com/valon-technologies/gestalt/server/internal/providerhost"
+	"github.com/valon-technologies/gestalt/server/internal/registry"
+	"google.golang.org/grpc"
+	"google.golang.org/grpc/credentials/insecure"
+	"google.golang.org/grpc/metadata"
 )
 
 func TestHTTPCatalogConnectionMapUsesAPIConnection(t *testing.T) {
@@ -18,5 +31,118 @@ func TestHTTPCatalogConnectionMapUsesAPIConnection(t *testing.T) {
 	got := httpCatalogConnectionMap(connMaps)
 	if got["notion"] != "OAuth" {
 		t.Fatalf("catalog connection = %q, want %q", got["notion"], "OAuth")
+	}
+}
+
+type runtimeTestCacheServer struct {
+	proto.UnimplementedCacheServer
+
+	mu   sync.Mutex
+	keys []string
+}
+
+func (s *runtimeTestCacheServer) Get(_ context.Context, req *proto.CacheGetRequest) (*proto.CacheGetResponse, error) {
+	s.mu.Lock()
+	s.keys = append(s.keys, req.GetKey())
+	s.mu.Unlock()
+	return &proto.CacheGetResponse{
+		Found: true,
+		Value: []byte("relay:" + req.GetKey()),
+	}, nil
+}
+
+func TestNewHTTPServerSupportsH2CHostServiceRelay(t *testing.T) {
+	t.Parallel()
+
+	secret := []byte("relay-test-secret-0123456789abcd")
+	cacheSrv := &runtimeTestCacheServer{}
+	hostServices, err := providerhost.StartHostServices([]providerhost.HostService{{
+		EnvVar: "GESTALT_TEST_CACHE_SOCKET",
+		Register: func(srv *grpc.Server) {
+			proto.RegisterCacheServer(srv, cacheSrv)
+		},
+	}})
+	if err != nil {
+		t.Fatalf("StartHostServices: %v", err)
+	}
+	t.Cleanup(func() {
+		_ = hostServices.Close()
+	})
+
+	bindings := hostServices.Bindings()
+	if len(bindings) != 1 {
+		t.Fatalf("host service bindings len = %d, want 1", len(bindings))
+	}
+
+	reg := registry.New()
+	services := coretesting.NewStubServices(t)
+	handler, err := New(Config{
+		Auth:         &coretesting.StubAuthProvider{N: "none"},
+		Services:     services,
+		Providers:    &reg.Providers,
+		StateSecret:  secret,
+		RouteProfile: RouteProfilePublic,
+		Invoker:      invocation.NewBroker(&reg.Providers, services.Users, services.Tokens),
+	})
+	if err != nil {
+		t.Fatalf("New: %v", err)
+	}
+
+	listener, err := net.Listen("tcp", "127.0.0.1:0")
+	if err != nil {
+		t.Fatalf("Listen: %v", err)
+	}
+	t.Cleanup(func() {
+		_ = listener.Close()
+	})
+
+	httpServer := newHTTPServer(listener.Addr().String(), handler)
+	serverDone := make(chan error, 1)
+	go func() {
+		serverDone <- httpServer.Serve(listener)
+	}()
+	t.Cleanup(func() {
+		shutdownCtx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+		defer cancel()
+		_ = httpServer.Shutdown(shutdownCtx)
+		if err := <-serverDone; err != nil && err != http.ErrServerClosed {
+			t.Fatalf("Serve: %v", err)
+		}
+	})
+
+	tokenManager, err := providerhost.NewHostServiceRelayTokenManager(secret)
+	if err != nil {
+		t.Fatalf("NewHostServiceRelayTokenManager: %v", err)
+	}
+	token, err := tokenManager.MintToken(providerhost.HostServiceRelayTokenRequest{
+		PluginName:   "relay-plugin",
+		SessionID:    "session-1",
+		Service:      "cache",
+		SocketPath:   bindings[0].SocketPath,
+		MethodPrefix: "/" + proto.Cache_ServiceDesc.ServiceName + "/",
+		TTL:          time.Minute,
+	})
+	if err != nil {
+		t.Fatalf("MintToken: %v", err)
+	}
+
+	conn, err := grpc.NewClient(listener.Addr().String(), grpc.WithTransportCredentials(insecure.NewCredentials()))
+	if err != nil {
+		t.Fatalf("grpc.NewClient: %v", err)
+	}
+	t.Cleanup(func() {
+		_ = conn.Close()
+	})
+
+	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	defer cancel()
+	ctx = metadata.NewOutgoingContext(ctx, metadata.Pairs(providerhost.HostServiceRelayTokenHeader, token))
+
+	resp, err := proto.NewCacheClient(conn).Get(ctx, &proto.CacheGetRequest{Key: "hello"})
+	if err != nil {
+		t.Fatalf("Cache.Get via h2c relay: %v", err)
+	}
+	if got := string(resp.GetValue()); got != "relay:hello" {
+		t.Fatalf("Cache.Get value = %q, want %q", got, "relay:hello")
 	}
 }


### PR DESCRIPTION
## Summary
Enable hosted runtime host-service relay traffic over HTTP/2 without introducing a second base URL.

## Interface
There is no new config surface.

Hosted runtimes continue to use the existing single origin:
```yaml
server:
  baseUrl: https://valon.tools/
```

The server side now accepts cleartext HTTP/2 (h2c) on its HTTP listeners so public relay gRPC can traverse Cloud Run's end-to-end HTTP/2 path.

## Behavior
- `gestaltd` HTTP listeners now serve both normal HTTP/1.1 traffic and h2c
- hosted runtime public relay gRPC traffic can terminate at the existing public origin
- no `server.runtime.baseUrl` split is required

## Examples
- keep Slack/OAuth/web traffic on `https://valon.tools/`
- keep hosted runtime relay traffic on that same origin
- deploy behind Cloud Run with end-to-end HTTP/2 enabled instead of introducing a runtime-only base URL

## Validation
- `go test ./internal/server -run 'TestHTTPCatalogConnectionMapUsesAPIConnection|TestNewHTTPServerSupportsH2CHostServiceRelay'`
- `go test ./internal/server`
- `golangci-lint run ./internal/server`
