### PR TITLE
Fix agent collection route matching

### DIFF
--- a/gestaltd/internal/server/agent_session_turn_test.go
+++ b/gestaltd/internal/server/agent_session_turn_test.go
@@ -338,7 +338,7 @@ func TestAgentSessionsAndTurnsRoundTrip(t *testing.T) {
 	})
 	testutil.CloseOnCleanup(t, ts)
 
-	sessionReq, _ := http.NewRequest(http.MethodPost, ts.URL+"/api/v1/agent/sessions/", bytes.NewBufferString(`{"provider":"managed","model":"gpt-5.4","clientRef":"cli-1"}`))
+	sessionReq, _ := http.NewRequest(http.MethodPost, ts.URL+"/api/v1/agent/sessions", bytes.NewBufferString(`{"provider":"managed","model":"gpt-5.4","clientRef":"cli-1"}`))
 	sessionReq.AddCookie(&http.Cookie{Name: "session_token", Value: "ada-session"})
 	sessionResp, err := http.DefaultClient.Do(sessionReq)
 	if err != nil {
@@ -353,6 +353,25 @@ func TestAgentSessionsAndTurnsRoundTrip(t *testing.T) {
 		t.Fatalf("decode session: %v", err)
 	}
 	sessionID := session["id"].(string)
+
+	listSessionsReq, _ := http.NewRequest(http.MethodGet, ts.URL+"/api/v1/agent/sessions", nil)
+	listSessionsReq.AddCookie(&http.Cookie{Name: "session_token", Value: "ada-session"})
+	listSessionsResp, err := http.DefaultClient.Do(listSessionsReq)
+	if err != nil {
+		t.Fatalf("list sessions: %v", err)
+	}
+	defer func() { _ = listSessionsResp.Body.Close() }()
+	if listSessionsResp.StatusCode != http.StatusOK {
+		body, _ := io.ReadAll(listSessionsResp.Body)
+		t.Fatalf("list sessions status = %d body=%s", listSessionsResp.StatusCode, body)
+	}
+	var sessions []map[string]any
+	if err := json.NewDecoder(listSessionsResp.Body).Decode(&sessions); err != nil {
+		t.Fatalf("decode sessions: %v", err)
+	}
+	if len(sessions) != 1 || sessions[0]["id"] != sessionID {
+		t.Fatalf("sessions = %#v, want %q", sessions, sessionID)
+	}
 
 	turnReq, _ := http.NewRequest(http.MethodPost, ts.URL+"/api/v1/agent/sessions/"+sessionID+"/turns", bytes.NewBufferString(`{"messages":[{"role":"user","text":"hello"}]}`))
 	turnReq.AddCookie(&http.Cookie{Name: "session_token", Value: "ada-session"})

--- a/gestaltd/internal/server/routes_user.go
+++ b/gestaltd/internal/server/routes_user.go
@@ -9,6 +9,8 @@ func (s *Server) mountAuthenticatedRoutes(r chi.Router) {
 		r.Get("/integrations", s.listIntegrations)
 		r.Delete("/integrations/{name}", s.disconnectIntegration)
 
+		r.Get("/workflow/schedules", s.listGlobalWorkflowSchedules)
+		r.Post("/workflow/schedules", s.createWorkflowSchedule)
 		r.Route("/workflow/schedules", func(r chi.Router) {
 			r.Get("/", s.listGlobalWorkflowSchedules)
 			r.Post("/", s.createWorkflowSchedule)
@@ -18,6 +20,8 @@ func (s *Server) mountAuthenticatedRoutes(r chi.Router) {
 			r.Post("/{scheduleID}/pause", s.pauseGlobalWorkflowSchedule)
 			r.Post("/{scheduleID}/resume", s.resumeGlobalWorkflowSchedule)
 		})
+		r.Get("/workflow/event-triggers", s.listGlobalWorkflowEventTriggers)
+		r.Post("/workflow/event-triggers", s.createGlobalWorkflowEventTrigger)
 		r.Route("/workflow/event-triggers", func(r chi.Router) {
 			r.Get("/", s.listGlobalWorkflowEventTriggers)
 			r.Post("/", s.createGlobalWorkflowEventTrigger)
@@ -28,11 +32,14 @@ func (s *Server) mountAuthenticatedRoutes(r chi.Router) {
 			r.Post("/{triggerID}/resume", s.resumeGlobalWorkflowEventTrigger)
 		})
 		r.Post("/workflow/events", s.publishWorkflowEvent)
+		r.Get("/workflow/runs", s.listGlobalWorkflowRuns)
 		r.Route("/workflow/runs", func(r chi.Router) {
 			r.Get("/", s.listGlobalWorkflowRuns)
 			r.Get("/{runID}", s.getGlobalWorkflowRun)
 			r.Post("/{runID}/cancel", s.cancelGlobalWorkflowRun)
 		})
+		r.Post("/agent/sessions", s.createAgentSession)
+		r.Get("/agent/sessions", s.listAgentSessions)
 		r.Route("/agent/sessions", func(r chi.Router) {
 			r.Post("/", s.createAgentSession)
 			r.Get("/", s.listAgentSessions)


### PR DESCRIPTION
## Summary
- Accept no-trailing-slash collection routes before the generic integration fallback.
- Fixes `GET /api/v1/agent/sessions` and `POST /api/v1/agent/sessions`, which the CLI uses for `gestalt agent sessions list` and `gestalt agent` session creation.
- Applies the same canonical no-trailing-slash handling to workflow collection routes so `/api/v1/workflow/schedules`, `/api/v1/workflow/event-triggers`, and `/api/v1/workflow/runs` cannot fall through to `/{integration}/{operation}`.

## Endpoint Examples
```http
GET /api/v1/agent/sessions
Authorization: Bearer <token>
```

```http
POST /api/v1/agent/sessions
Authorization: Bearer <token>
Content-Type: application/json

{"provider":"simple","model":"deep"}
```

## Verification
- `go test ./internal/server -run TestAgentSessionsAndTurnsRoundTrip -count=1`
- `go test ./internal/server -count=1`