### PR TITLE
gestaltd: async authorization canonical sync

### DIFF
--- a/gestaltd/internal/bootstrap/bootstrap.go
+++ b/gestaltd/internal/bootstrap/bootstrap.go
@@ -10,6 +10,7 @@ import (
 	"slices"
 	"strings"
 	"sync"
+	"time"
 
 	proto "github.com/valon-technologies/gestalt/sdk/go/gen/v1"
 	"github.com/valon-technologies/gestalt/server/core"
@@ -221,8 +222,34 @@ type Result struct {
 
 	pluginRuntimeRegistry *pluginRuntimeRegistry
 	auditClose            func(context.Context) error
+	canonicalSyncCancel   context.CancelFunc
+	canonicalSyncDone     chan struct{}
 	mu                    sync.Mutex
 	closed                bool
+}
+
+const canonicalAuthorizationSyncRetryInterval = 30 * time.Second
+
+func runCanonicalAuthorizationSync(ctx context.Context, services *coredata.Services, authorizer authorization.RuntimeAuthorizer, provider core.AuthorizationProvider) {
+	attempt := 0
+	for {
+		attempt++
+		started := time.Now()
+		if err := syncProviderBackedHumanCanonicalState(ctx, services, authorizer, provider); err != nil {
+			if errors.Is(err, context.Canceled) {
+				return
+			}
+			slog.WarnContext(ctx, "authorization canonical sync failed", "error", err, "attempt", attempt, "duration", time.Since(started).String())
+			select {
+			case <-time.After(canonicalAuthorizationSyncRetryInterval):
+				continue
+			case <-ctx.Done():
+				return
+			}
+		}
+		slog.InfoContext(ctx, "authorization canonical sync finished", "attempt", attempt, "duration", time.Since(started).String())
+		return
+	}
 }
 
 func (r *Result) Start(ctx context.Context) error {
@@ -236,12 +263,21 @@ func (r *Result) Start(ctx context.Context) error {
 		return fmt.Errorf("bootstrap result already closed")
 	}
 	if r.Authorizer != nil {
+		started := time.Now()
 		if err := r.Authorizer.Start(ctx); err != nil {
 			return err
 		}
+		slog.InfoContext(ctx, "authorization provider state loaded", "duration", time.Since(started).String())
 	}
-	if err := syncProviderBackedHumanCanonicalState(ctx, r.Services, r.Authorizer, r.AuthorizationProvider); err != nil {
-		return err
+	if r.canonicalSyncDone == nil {
+		syncCtx, cancel := context.WithCancel(ctx)
+		done := make(chan struct{})
+		r.canonicalSyncCancel = cancel
+		r.canonicalSyncDone = done
+		go func() {
+			defer close(done)
+			runCanonicalAuthorizationSync(syncCtx, r.Services, r.Authorizer, r.AuthorizationProvider)
+		}()
 	}
 	return nil
 }
@@ -258,6 +294,12 @@ func (r *Result) Close(ctx context.Context) error {
 	}
 	if r.ProvidersReady != nil {
 		<-r.ProvidersReady
+	}
+	if r.canonicalSyncCancel != nil {
+		r.canonicalSyncCancel()
+	}
+	if r.canonicalSyncDone != nil {
+		<-r.canonicalSyncDone
 	}
 
 	var errs []error

--- a/gestaltd/internal/bootstrap/bootstrap_test.go
+++ b/gestaltd/internal/bootstrap/bootstrap_test.go
@@ -7106,6 +7106,7 @@ func TestBootstrapSecretResolution(t *testing.T) {
 		if err != nil {
 			t.Fatalf("CanonicalIdentityIDForUser(first): %v", err)
 		}
+		waitForCanonicalAuthorizationState(t, ctx, result, canonicalIdentityID, "calendar", "admin")
 		if err := result.Services.IdentityPluginAccess.DeleteAccess(ctx, canonicalIdentityID, "calendar"); err != nil {
 			t.Fatalf("DeleteAccess(calendar): %v", err)
 		}
@@ -7152,6 +7153,7 @@ func TestBootstrapSecretResolution(t *testing.T) {
 		if err != nil {
 			t.Fatalf("CanonicalIdentityIDForUser: %v", err)
 		}
+		waitForCanonicalAuthorizationState(t, ctx, result, canonicalIdentityID, "calendar", "admin")
 		pluginAccess, err := result.Services.IdentityPluginAccess.GetAccess(ctx, canonicalIdentityID, "calendar")
 		if err != nil {
 			t.Fatalf("GetAccess(calendar): %v", err)
@@ -7605,6 +7607,42 @@ func TestBootstrapWorkloadAuthorizationRejectsEitherProvider(t *testing.T) {
 	_, err := bootstrap.Bootstrap(context.Background(), cfg, factories)
 	if err == nil || !strings.Contains(err.Error(), `unsupported connection mode "either"`) {
 		t.Fatalf("Bootstrap error = %v, want unsupported connection mode either", err)
+	}
+}
+
+func waitForCanonicalAuthorizationState(t *testing.T, ctx context.Context, result *bootstrap.Result, identityID, plugin, role string) {
+	t.Helper()
+
+	deadline := time.Now().Add(3 * time.Second)
+	var lastPluginAccessErr, lastWorkspaceRoleErr error
+	for {
+		pluginReady := false
+		if access, err := result.Services.IdentityPluginAccess.GetAccess(ctx, identityID, plugin); err == nil && access.InvokeAllOperations {
+			pluginReady = true
+		} else {
+			lastPluginAccessErr = err
+		}
+
+		roleReady := false
+		roles, err := result.Services.WorkspaceRoles.ListByPrincipal(ctx, identityID)
+		if err == nil {
+			for _, existing := range roles {
+				if existing != nil && existing.Role == role {
+					roleReady = true
+					break
+				}
+			}
+		} else {
+			lastWorkspaceRoleErr = err
+		}
+
+		if pluginReady && roleReady {
+			return
+		}
+		if time.Now().After(deadline) {
+			t.Fatalf("canonical authorization state for identity %q was not synced; pluginErr=%v roleErr=%v", identityID, lastPluginAccessErr, lastWorkspaceRoleErr)
+		}
+		time.Sleep(25 * time.Millisecond)
 	}
 }
 


### PR DESCRIPTION
## Summary
- Runs provider-backed canonical authorization reconciliation in a cancellable background startup task with retry instead of blocking `gestaltd serve` from reaching readiness.
- Keeps the external credentials provider host contract simple: only the canonical `external_credentials` store is exposed.
- Leaves the default external credentials provider version unchanged at `external_credentials/default/v0.0.1-alpha.1`.

## Manual Backfill Precondition
Legacy `integration_tokens` rows must be copied manually into the canonical `external_credentials` store before deploying this runtime change.

The runtime intentionally does not scan, read-through, backfill, or mutate `integration_tokens`.

## Interfaces
No public REST, `AgentProvider`, `ExternalCredentialsProvider`, or IndexedDB provider-host interfaces change.

The default external credentials provider still receives only the canonical store:

```go
IndexedDBServerOptions{
    AllowedStores: []string{"external_credentials"},
}
```

## Configuration Example
Implicit default:

```yaml
server:
  providers:
    externalCredentials: default
```

Equivalent explicit provider source:

```yaml
providers:
  externalCredentials:
    default:
      source: https://github.com/valon-technologies/gestalt-providers/releases/download/external_credentials/default/v0.0.1-alpha.1/provider-release.yaml
      indexeddb:
        provider: main-db
      config:
        encryptionKey:
          secret:
            provider: secrets
            name: gestalt-encryption-key
```

## REST Endpoints
Unchanged. Existing integration/agent endpoints continue to resolve credentials through the configured external credentials provider after the manual migration:

```bash
GET /api/v1/integrations/{integration}/operations
POST /api/v1/integrations/{integration}/{operation}
POST /api/v1/agent/sessions
POST /api/v1/agent/sessions/{session_id}/turns
```

## Tests
- `go test ./internal/bootstrap ./internal/providerhost -count=1` from `gestaltd`.
