### PR TITLE
cli: add agent resume mode

### DIFF
--- a/gestalt/cli/Cargo.toml
+++ b/gestalt/cli/Cargo.toml
@@ -23,6 +23,7 @@ url = "2"
 getrandom = "0.4"
 comfy-table = { version = "7.2.1", default-features = false }
 rpassword = "7"
+time = { version = "0.3", features = ["parsing"] }
 
 [dev-dependencies]
 tempfile = "3"

--- a/gestalt/cli/src/cli.rs
+++ b/gestalt/cli/src/cli.rs
@@ -225,7 +225,11 @@ pub struct AgentArgs {
     #[arg(long)]
     pub session: Option<String>,
 
-    /// Agent provider name for a new session
+    /// Resume the most recently updated active agent session
+    #[arg(long, visible_alias = "continue", conflicts_with = "session")]
+    pub resume: bool,
+
+    /// Agent provider name for a new session, or provider filter when resuming
     #[arg(long)]
     pub provider: Option<String>,
 

--- a/gestalt/cli/src/commands/agents.rs
+++ b/gestalt/cli/src/commands/agents.rs
@@ -4,6 +4,7 @@ use serde_json::{Map, Value, json};
 use std::io::{self, Write};
 use std::thread;
 use std::time::Duration;
+use time::{OffsetDateTime, format_description::well_known::Rfc3339};
 
 use crate::api::ApiClient;
 use crate::cli::{
@@ -173,6 +174,14 @@ struct AgentSessionInfo {
     provider: String,
     #[serde(default)]
     model: String,
+    #[serde(default)]
+    state: String,
+    #[serde(default)]
+    last_turn_at: String,
+    #[serde(default)]
+    created_at: String,
+    #[serde(default)]
+    updated_at: String,
 }
 
 #[derive(Debug, Clone, Deserialize)]
@@ -225,6 +234,7 @@ impl AgentShell {
     fn connect(client: &ApiClient, args: &AgentArgs) -> Result<Self> {
         let session = match args.session.as_deref() {
             Some(session_id) => get_session_info(client, session_id)?,
+            None if args.resume => resume_latest_session_info(client, args.provider.as_deref())?,
             None => {
                 let session_args = AgentSessionCreateArgs {
                     provider: args.provider.clone(),
@@ -574,6 +584,49 @@ fn get_session_info(client: &ApiClient, id: &str) -> Result<AgentSessionInfo> {
             .get(&format!("{SESSIONS_PATH}/{id}"))
             .with_context(|| format!("failed to get agent session {id}"))?,
     )
+}
+
+fn resume_latest_session_info(
+    client: &ApiClient,
+    provider: Option<&str>,
+) -> Result<AgentSessionInfo> {
+    let sessions: Vec<AgentSessionInfo> = decode_json(
+        client
+            .get(&sessions_path(provider, Some("active")))
+            .context("failed to list active agent sessions")?,
+    )?;
+    sessions
+        .into_iter()
+        .filter(|session| session.state.is_empty() || session.state == "active")
+        .max_by(compare_sessions_for_resume)
+        .ok_or_else(|| match provider {
+            Some(provider) => anyhow::anyhow!(
+                "no active agent sessions found for provider {provider}; omit --resume to create one"
+            ),
+            None => anyhow::anyhow!(
+                "no active agent sessions found; omit --resume to create one"
+            ),
+        })
+}
+
+fn compare_sessions_for_resume(a: &AgentSessionInfo, b: &AgentSessionInfo) -> std::cmp::Ordering {
+    compare_session_time_field(&a.last_turn_at, &b.last_turn_at)
+        .then_with(|| compare_session_time_field(&a.updated_at, &b.updated_at))
+        .then_with(|| compare_session_time_field(&a.created_at, &b.created_at))
+        .then_with(|| a.id.cmp(&b.id))
+}
+
+fn compare_session_time_field(a: &str, b: &str) -> std::cmp::Ordering {
+    match (parse_session_time(a), parse_session_time(b)) {
+        (Some(a), Some(b)) => a.cmp(&b),
+        (Some(_), None) => std::cmp::Ordering::Greater,
+        (None, Some(_)) => std::cmp::Ordering::Less,
+        (None, None) => a.cmp(b),
+    }
+}
+
+fn parse_session_time(value: &str) -> Option<OffsetDateTime> {
+    OffsetDateTime::parse(value, &Rfc3339).ok()
 }
 
 fn create_turn_info(client: &ApiClient, args: &AgentTurnCreateArgs) -> Result<AgentTurnInfo> {

--- a/gestalt/cli/src/main.rs
+++ b/gestalt/cli/src/main.rs
@@ -1,10 +1,10 @@
 use clap::{CommandFactory, Parser};
 use gestalt::api::{self, ApiClient};
 use gestalt::cli::{
-    AgentCommands, AgentSessionCommands, AgentTurnCommands, AgentTurnEventCommands, AuthCommands,
-    Cli, Commands, ConfigCommands, DescribeArgs, InvokeArgs, PluginCommands, TokenCommands,
-    WorkflowCommands, WorkflowEventCommands, WorkflowRunCommands, WorkflowScheduleCommands,
-    WorkflowTriggerCommands,
+    AgentArgs, AgentCommands, AgentSessionCommands, AgentTurnCommands, AgentTurnEventCommands,
+    AuthCommands, Cli, Commands, ConfigCommands, DescribeArgs, InvokeArgs, PluginCommands,
+    TokenCommands, WorkflowCommands, WorkflowEventCommands, WorkflowRunCommands,
+    WorkflowScheduleCommands, WorkflowTriggerCommands,
 };
 use gestalt::commands;
 use gestalt::output;
@@ -125,6 +125,9 @@ fn run() -> anyhow::Result<()> {
             }
         }
         Commands::Agent(args) => {
+            if args.command.is_some() {
+                reject_agent_interactive_options(&args)?;
+            }
             let client = ApiClient::from_env(url)?;
             match args.command {
                 Some(command) => dispatch_agent_command(&client, command, format),
@@ -132,6 +135,33 @@ fn run() -> anyhow::Result<()> {
             }
         }
     }
+}
+
+fn reject_agent_interactive_options(args: &AgentArgs) -> anyhow::Result<()> {
+    if args.resume {
+        anyhow::bail!("--resume can only be used with interactive `gestalt agent`");
+    }
+    if args.session.is_some() {
+        anyhow::bail!("--session can only be used with interactive `gestalt agent`");
+    }
+    if args.model.is_some() {
+        anyhow::bail!("--model can only be used with interactive `gestalt agent`");
+    }
+    if !args.system.is_empty() {
+        anyhow::bail!("--system can only be used with interactive `gestalt agent`");
+    }
+    if !args.messages.is_empty() {
+        anyhow::bail!("--message can only be used with interactive `gestalt agent`");
+    }
+    if !args.tools.is_empty() {
+        anyhow::bail!("--tool can only be used with interactive `gestalt agent`");
+    }
+    if args.provider.is_some() {
+        anyhow::bail!(
+            "--provider before an agent subcommand is ignored; pass it after the subcommand if supported"
+        );
+    }
+    Ok(())
 }
 
 fn dispatch_agent_command(

--- a/gestalt/cli/tests/agents_cli.rs
+++ b/gestalt/cli/tests/agents_cli.rs
@@ -384,6 +384,148 @@ fn test_cli_runs_interactive_agent_session() {
 }
 
 #[test]
+fn test_cli_resumes_latest_active_agent_session() {
+    let server = ScriptedServer::spawn(vec![
+        ExpectedRequest::text(
+            Method::GET,
+            "/api/v1/agent/sessions?provider=managed&state=active",
+            StatusCode::OK,
+            http::APPLICATION_JSON,
+            r#"[
+                {
+                    "id":"session-old",
+                    "provider":"managed",
+                    "model":"gpt-5.3",
+                    "state":"active",
+                    "createdAt":"2026-04-21T00:00:00Z",
+                    "updatedAt":"2026-04-22T00:00:03Z",
+                    "lastTurnAt":"2026-04-22T00:00:10Z"
+                },
+                {
+                    "id":"session-new",
+                    "provider":"managed",
+                    "model":"gpt-5.4",
+                    "state":"active",
+                    "createdAt":"2026-04-22T00:00:00Z",
+                    "updatedAt":"2026-04-22T00:00:03.1Z",
+                    "lastTurnAt":"2026-04-22T00:00:10.1Z"
+                }
+            ]"#,
+        ),
+        ExpectedRequest::json(
+            Method::POST,
+            "/api/v1/agent/sessions/session-new/turns",
+            r#"{"messages":[{"role":"user","text":"continue plan"}]}"#,
+            StatusCode::CREATED,
+            http::APPLICATION_JSON,
+            r#"{
+                "id":"turn-resumed",
+                "sessionId":"session-new",
+                "provider":"managed",
+                "model":"gpt-5.4",
+                "status":"running"
+            }"#,
+        ),
+        ExpectedRequest::text(
+            Method::GET,
+            "/api/v1/agent/turns/turn-resumed/events?after=0&limit=100",
+            StatusCode::OK,
+            http::APPLICATION_JSON,
+            r#"[
+                {"seq":1,"type":"assistant.completed","data":{"text":"continued"}},
+                {"seq":2,"type":"turn.completed","data":{"status":"succeeded"}}
+            ]"#,
+        ),
+        ExpectedRequest::text(
+            Method::GET,
+            "/api/v1/agent/turns/turn-resumed",
+            StatusCode::OK,
+            http::APPLICATION_JSON,
+            r#"{
+                "id":"turn-resumed",
+                "sessionId":"session-new",
+                "provider":"managed",
+                "model":"gpt-5.4",
+                "status":"succeeded",
+                "outputText":"continued"
+            }"#,
+        ),
+    ]);
+
+    let home = tempfile::tempdir().unwrap();
+    cli_command(home.path())
+        .env("GESTALT_API_KEY", TEST_TOKEN)
+        .arg("--url")
+        .arg(server.url())
+        .args([
+            "agent",
+            "--continue",
+            "--provider",
+            "managed",
+            "--message",
+            "continue plan",
+        ])
+        .write_stdin("/quit\n")
+        .assert()
+        .success()
+        .stdout(predicate::str::contains("assistant> continued"))
+        .stderr(predicate::str::contains(
+            "Session session-new [managed / gpt-5.4]",
+        ));
+
+    server.assert_finished();
+}
+
+#[test]
+fn test_cli_resume_fails_without_active_agent_session() {
+    let server = ScriptedServer::spawn(vec![ExpectedRequest::text(
+        Method::GET,
+        "/api/v1/agent/sessions?state=active",
+        StatusCode::OK,
+        http::APPLICATION_JSON,
+        "[]",
+    )]);
+
+    let home = tempfile::tempdir().unwrap();
+    cli_command(home.path())
+        .env("GESTALT_API_KEY", TEST_TOKEN)
+        .arg("--url")
+        .arg(server.url())
+        .args(["agent", "--resume"])
+        .assert()
+        .failure()
+        .stderr(predicate::str::contains(
+            "no active agent sessions found; omit --resume to create one",
+        ));
+
+    server.assert_finished();
+}
+
+#[test]
+fn test_cli_rejects_interactive_agent_flags_with_subcommands() {
+    let home = tempfile::tempdir().unwrap();
+    cli_command(home.path())
+        .args(["agent", "--resume", "sessions", "list"])
+        .assert()
+        .failure()
+        .stderr(predicate::str::contains(
+            "--resume can only be used with interactive `gestalt agent`",
+        ));
+}
+
+#[test]
+fn test_cli_agent_help_describes_resume_provider_filter() {
+    let home = tempfile::tempdir().unwrap();
+    cli_command(home.path())
+        .args(["agent", "--help"])
+        .assert()
+        .success()
+        .stdout(predicate::str::contains("--resume"))
+        .stdout(predicate::str::contains("--continue"))
+        .stdout(predicate::str::contains("provider filter when resuming"));
+}
+
+#[test]
 fn test_cli_resumes_existing_agent_session_and_resolves_input_interaction() {
     let server = ScriptedServer::spawn(vec![
         ExpectedRequest::text(


### PR DESCRIPTION
## Summary
- Adds `gestalt agent --resume` with `--continue` as an alias for resuming the most recently active agent session.
- Allows `--provider` to filter the resume lookup while preserving explicit `--session` behavior.
- Rejects interactive-only root flags when an `agent` subcommand is used, so flags are not silently ignored.

## Interfaces
Existing explicit session resume stays unchanged:

```bash
gestalt agent --session <session-id>
```

New resume interface:

```bash
gestalt agent --resume
gestalt agent --continue
gestalt agent --resume --provider <provider>
gestalt agent --continue --provider <provider>
```

`--resume` selects the most recent active session using server-compatible ordering:

```text
lastTurnAt, updatedAt, createdAt, id
```

## Examples
Resume the latest active session:

```bash
GESTALT_URL=https://valon.tools gestalt agent --resume
```

Resume the latest active session for the simple provider:

```bash
GESTALT_URL=https://valon.tools gestalt agent --continue --provider simple
```

Resume an explicit session:

```bash
GESTALT_URL=https://valon.tools gestalt agent --session 01206bb1-781e-49ab-aae0-c84df41e42ec
```

Invalid root interactive flags with subcommands now fail instead of being ignored:

```bash
gestalt agent --resume sessions list
# error: --resume can only be used with interactive `gestalt agent`
```

## Wire Contract
No server endpoint changes.

`--resume` uses the existing session list endpoint:

```http
GET /api/v1/agent/sessions?state=active
GET /api/v1/agent/sessions?provider=<provider>&state=active
```

Once selected, turns are still created through the existing endpoint:

```http
POST /api/v1/agent/sessions/{session_id}/turns
```

## Tests
- `cargo test --test agents_cli -- --nocapture`
- `cargo test --workspace`
- `cargo clippy --workspace --all-targets -- -D warnings`

A separate review-agent pass found timestamp-ordering and ignored-flag issues; both were fixed before opening this PR.