### PR TITLE
gestaltd: wait for provider grpc readiness

### DIFF
--- a/gestaltd/internal/providerhost/process.go
+++ b/gestaltd/internal/providerhost/process.go
@@ -22,6 +22,7 @@ import (
 	"github.com/valon-technologies/gestalt/server/internal/sandbox"
 	"go.opentelemetry.io/contrib/instrumentation/google.golang.org/grpc/otelgrpc"
 	"google.golang.org/grpc"
+	"google.golang.org/grpc/connectivity"
 	"google.golang.org/grpc/credentials/insecure"
 )
 
@@ -613,7 +614,7 @@ func safeBaseEnv() []string {
 func waitForPluginConn(ctx context.Context, socket string, waitCh <-chan error, cfg ProcessConfig) (*grpc.ClientConn, error) {
 	for {
 		if _, err := os.Stat(socket); err == nil {
-			conn, dialErr := dialUnixSocket(ctx, socket, cfg)
+			conn, dialErr := dialReadyUnixSocket(ctx, socket, waitCh, cfg)
 			if dialErr == nil {
 				return conn, nil
 			}
@@ -636,6 +637,18 @@ func waitForPluginConn(ctx context.Context, socket string, waitCh <-chan error, 
 	}
 }
 
+func dialReadyUnixSocket(ctx context.Context, socket string, waitCh <-chan error, cfg ProcessConfig) (*grpc.ClientConn, error) {
+	conn, err := dialUnixSocket(ctx, socket, cfg)
+	if err != nil {
+		return nil, err
+	}
+	if err := waitForGRPCReady(ctx, conn, waitCh); err != nil {
+		_ = conn.Close()
+		return nil, err
+	}
+	return conn, nil
+}
+
 func dialUnixSocket(ctx context.Context, socket string, cfg ProcessConfig) (*grpc.ClientConn, error) {
 	conn, err := grpc.NewClient(
 		"passthrough:///localhost",
@@ -656,4 +669,32 @@ func dialUnixSocket(ctx context.Context, socket string, cfg ProcessConfig) (*grp
 	}
 	conn.Connect()
 	return conn, nil
+}
+
+func waitForGRPCReady(ctx context.Context, conn *grpc.ClientConn, waitCh <-chan error) error {
+	for {
+		state := conn.GetState()
+		if state == connectivity.Ready {
+			return nil
+		}
+		if state == connectivity.Shutdown {
+			return fmt.Errorf("plugin gRPC connection shut down before ready")
+		}
+
+		select {
+		case err, ok := <-waitCh:
+			if !ok || err == nil {
+				return fmt.Errorf("plugin process exited before serving gRPC")
+			}
+			return fmt.Errorf("plugin process exited before serving gRPC: %w", err)
+		default:
+		}
+
+		waitCtx, cancel := context.WithTimeout(ctx, 25*time.Millisecond)
+		changed := conn.WaitForStateChange(waitCtx, state)
+		cancel()
+		if !changed && ctx.Err() != nil {
+			return fmt.Errorf("waiting for plugin gRPC ready: %w", ctx.Err())
+		}
+	}
 }

--- a/gestaltd/internal/providerhost/process_test.go
+++ b/gestaltd/internal/providerhost/process_test.go
@@ -1,9 +1,19 @@
 package providerhost
 
 import (
+	"context"
+	"errors"
+	"net"
 	"os"
 	"path/filepath"
+	"strings"
 	"testing"
+	"time"
+
+	"google.golang.org/grpc"
+	"google.golang.org/grpc/credentials/insecure"
+	"google.golang.org/grpc/health"
+	healthpb "google.golang.org/grpc/health/grpc_health_v1"
 )
 
 func TestResolvePluginTempBaseDirCreatesMissingCandidate(t *testing.T) {
@@ -51,5 +61,168 @@ func TestResolvePluginTempBaseDirSkipsFileCandidate(t *testing.T) {
 	}
 	if !info.IsDir() {
 		t.Fatalf("created fallback candidate is not a directory")
+	}
+}
+
+func TestWaitForPluginConnWaitsForGRPCReady(t *testing.T) {
+	t.Parallel()
+
+	root, err := os.MkdirTemp("/tmp", "gstp-process-test-")
+	if err != nil {
+		t.Fatalf("create short temp dir: %v", err)
+	}
+	t.Cleanup(func() { _ = os.RemoveAll(root) })
+	socket := filepath.Join(root, "plugin.sock")
+	rawLis, err := net.Listen("unix", socket)
+	if err != nil {
+		t.Fatalf("listen raw unix socket: %v", err)
+	}
+
+	rawDone := make(chan struct{})
+	go func() {
+		defer close(rawDone)
+		deadline := time.Now().Add(150 * time.Millisecond)
+		for time.Now().Before(deadline) {
+			_ = rawLis.(*net.UnixListener).SetDeadline(time.Now().Add(25 * time.Millisecond))
+			conn, err := rawLis.Accept()
+			if err != nil {
+				if netErr, ok := err.(net.Error); ok && netErr.Timeout() {
+					continue
+				}
+				return
+			}
+			_ = conn.Close()
+		}
+	}()
+
+	grpcReady := make(chan struct{})
+	grpcStop := make(chan struct{})
+	go func() {
+		<-rawDone
+		_ = rawLis.Close()
+		_ = os.Remove(socket)
+
+		grpcLis, err := net.Listen("unix", socket)
+		if err != nil {
+			t.Errorf("listen grpc unix socket: %v", err)
+			close(grpcReady)
+			return
+		}
+		srv := grpc.NewServer()
+		healthServer := health.NewServer()
+		healthServer.SetServingStatus("", healthpb.HealthCheckResponse_SERVING)
+		healthpb.RegisterHealthServer(srv, healthServer)
+		defer srv.Stop()
+		go func() {
+			_ = srv.Serve(grpcLis)
+		}()
+		waitForTestGRPCHealth(t, socket)
+		close(grpcReady)
+		<-grpcStop
+	}()
+
+	result := make(chan error, 1)
+	go func() {
+		ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+		defer cancel()
+		conn, err := waitForPluginConn(ctx, socket, make(chan error), ProcessConfig{})
+		if conn != nil {
+			_ = conn.Close()
+		}
+		result <- err
+	}()
+
+	select {
+	case err := <-result:
+		t.Fatalf("waitForPluginConn returned before grpc server was ready: %v", err)
+	case <-grpcReady:
+	}
+	defer close(grpcStop)
+
+	select {
+	case err := <-result:
+		if err != nil {
+			t.Fatalf("waitForPluginConn() error: %v", err)
+		}
+	case <-time.After(5 * time.Second):
+		t.Fatal("waitForPluginConn() did not return after grpc server became ready")
+	}
+}
+
+func TestWaitForPluginConnReturnsProcessExitBeforeReady(t *testing.T) {
+	t.Parallel()
+
+	root, err := os.MkdirTemp("/tmp", "gstp-process-exit-test-")
+	if err != nil {
+		t.Fatalf("create short temp dir: %v", err)
+	}
+	t.Cleanup(func() { _ = os.RemoveAll(root) })
+	socket := filepath.Join(root, "plugin.sock")
+	rawLis, err := net.Listen("unix", socket)
+	if err != nil {
+		t.Fatalf("listen raw unix socket: %v", err)
+	}
+	t.Cleanup(func() { _ = rawLis.Close() })
+	go func() {
+		for {
+			conn, err := rawLis.Accept()
+			if err != nil {
+				return
+			}
+			_ = conn.Close()
+		}
+	}()
+
+	exitErr := errors.New("provider crashed")
+	waitCh := make(chan error, 1)
+	go func() {
+		time.Sleep(75 * time.Millisecond)
+		waitCh <- exitErr
+		close(waitCh)
+	}()
+
+	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	defer cancel()
+	conn, err := waitForPluginConn(ctx, socket, waitCh, ProcessConfig{})
+	if conn != nil {
+		_ = conn.Close()
+	}
+	if err == nil {
+		t.Fatal("waitForPluginConn() error = nil, want provider exit error")
+	}
+	if !strings.Contains(err.Error(), "plugin process exited before serving gRPC") ||
+		!strings.Contains(err.Error(), "provider crashed") {
+		t.Fatalf("waitForPluginConn() error = %v, want provider exit context", err)
+	}
+}
+
+func waitForTestGRPCHealth(t *testing.T, socket string) {
+	t.Helper()
+
+	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	defer cancel()
+	conn, err := grpc.NewClient(
+		"passthrough:///localhost",
+		grpc.WithTransportCredentials(insecure.NewCredentials()),
+		grpc.WithAuthority("localhost"),
+		grpc.WithContextDialer(func(ctx context.Context, _ string) (net.Conn, error) {
+			var d net.Dialer
+			return d.DialContext(ctx, "unix", socket)
+		}),
+	)
+	if err != nil {
+		t.Fatalf("create grpc health client: %v", err)
+	}
+	defer func() { _ = conn.Close() }()
+	client := healthpb.NewHealthClient(conn)
+	for {
+		_, err := client.Check(ctx, &healthpb.HealthCheckRequest{})
+		if err == nil {
+			return
+		}
+		if ctx.Err() != nil {
+			t.Fatalf("grpc health never became ready: %v", err)
+		}
+		time.Sleep(10 * time.Millisecond)
 	}
 }


### PR DESCRIPTION
## Summary
- Makes executable provider startup wait until the gRPC channel reaches `READY`, not merely until the Unix socket path exists.
- Preserves real provider-exit behavior by continuing to watch the provider process `waitCh` while waiting for readiness.
- Adds process-level regression coverage for transient pre-ready socket EOFs and provider exit before readiness.

## Interfaces
No public REST, CLI, provider proto, or YAML configuration interfaces change.

Executable providers continue to receive the same provider socket environment:

```text
GESTALT_PLUGIN_SOCKET=/tmp/.../plugin.sock
```

Host-service socket envs are unchanged, for example:

```text
GESTALT_AGENT_HOST_SOCKET=/tmp/.../host-0.sock
GESTALT_AGENT_MANAGER_SOCKET=/tmp/.../host-1.sock
```

## Behavior Example
Before this change, an executable provider could bind `plugin.sock` before its gRPC server was fully accepting handshakes. `gestaltd` returned the connection immediately, and the first provider RPC could fail:

```text
rpc error: code = Unavailable desc = connection error: desc = "transport: authentication handshake failed: EOF"
```

After this change, startup keeps waiting until the gRPC channel is `READY`. If the provider process exits first, the startup error still reports the provider exit instead of timing out generically.

## Production Symptom
Observed against `https://valon.tools` after deploy:

```bash
GESTALT_URL=https://valon.tools gestalt agent sessions list --state active --format json
# error: failed to list agent sessions: agent request failed
```

Cloud Run backend log:

```text
agent provider error: rpc error: code = Unavailable desc = connection error: desc = "transport: authentication handshake failed: EOF"
```

## Tests
- `go test ./internal/providerhost -count=1`
- `go test ./internal/bootstrap -run 'TestBootstrap.*Agent|TestExecutable.*Agent|Test.*AgentProvider' -count=1`
- `go test -race ./internal/providerhost -run 'TestWaitForPluginConn' -count=1`

A separate review-agent pass found two test coverage gaps; both were fixed before opening this PR.