### PR TITLE
Add hosted agent runtime lifecycle policy

### DIFF
--- a/gestaltd/internal/bootstrap/agent_runtime.go
+++ b/gestaltd/internal/bootstrap/agent_runtime.go
@@ -24,17 +24,28 @@ import (
 type agentRuntime struct {
 	mu                  sync.RWMutex
 	defaultProviderName string
+	configuredProviders map[string]struct{}
 	providers           map[string]coreagent.Provider
 	invoker             invocation.Invoker
 	runMetadata         *coredata.AgentRunMetadataService
 }
 
 func newAgentRuntime(cfg *config.Config) (*agentRuntime, error) {
-	runtime := &agentRuntime{providers: map[string]coreagent.Provider{}}
+	runtime := &agentRuntime{
+		configuredProviders: map[string]struct{}{},
+		providers:           map[string]coreagent.Provider{},
+	}
 	if cfg != nil {
 		selectedProviderName, _, err := cfg.SelectedAgentProvider()
 		if err == nil {
 			runtime.defaultProviderName = strings.TrimSpace(selectedProviderName)
+		}
+		for name, entry := range cfg.Providers.Agent {
+			name = strings.TrimSpace(name)
+			if name == "" || entry == nil {
+				continue
+			}
+			runtime.configuredProviders[name] = struct{}{}
 		}
 	}
 	return runtime, nil
@@ -67,7 +78,7 @@ func (r *agentRuntime) HasConfiguredProviders() bool {
 	}
 	r.mu.RLock()
 	defer r.mu.RUnlock()
-	return len(r.providers) > 0
+	return len(r.configuredProviders) > 0 || len(r.providers) > 0
 }
 
 func (r *agentRuntime) SetInvoker(invoker invocation.Invoker) {
@@ -221,22 +232,60 @@ func (r *agentRuntime) Ping(ctx context.Context) error {
 		return fmt.Errorf("agent runtime is not configured")
 	}
 	r.mu.RLock()
-	hasProviders := len(r.providers) > 0
 	defaultProviderName := strings.TrimSpace(r.defaultProviderName)
+	providers := maps.Clone(r.providers)
+	configuredProviders := make(map[string]struct{}, len(r.configuredProviders))
+	for name := range r.configuredProviders {
+		name = strings.TrimSpace(name)
+		if name != "" {
+			configuredProviders[name] = struct{}{}
+		}
+	}
 	r.mu.RUnlock()
 
-	if !hasProviders && defaultProviderName == "" {
+	if len(configuredProviders) == 0 {
+		for name, provider := range providers {
+			name = strings.TrimSpace(name)
+			if name != "" && provider != nil {
+				configuredProviders[name] = struct{}{}
+			}
+		}
+	}
+	if defaultProviderName != "" {
+		configuredProviders[defaultProviderName] = struct{}{}
+	}
+	if len(configuredProviders) == 0 {
 		return nil
 	}
 
-	providerName, provider, err := r.ResolveProviderSelection("")
-	if err != nil {
-		return err
+	names := make([]string, 0, len(configuredProviders))
+	for name := range configuredProviders {
+		names = append(names, name)
 	}
-	if err := provider.Ping(ctx); err != nil {
-		return fmt.Errorf("agent provider %q unavailable: %w", providerName, err)
+	sort.Strings(names)
+	errs := make(chan error, len(names))
+	var wg sync.WaitGroup
+	for _, name := range names {
+		provider := providers[name]
+		if provider == nil {
+			errs <- fmt.Errorf("agent provider %q unavailable: %w", name, agentmanager.NewAgentProviderNotAvailableError(name))
+			continue
+		}
+		wg.Add(1)
+		go func(name string, provider coreagent.Provider) {
+			defer wg.Done()
+			if err := provider.Ping(ctx); err != nil {
+				errs <- fmt.Errorf("agent provider %q unavailable: %w", name, err)
+			}
+		}(name, provider)
 	}
-	return nil
+	wg.Wait()
+	close(errs)
+	var joined []error
+	for err := range errs {
+		joined = append(joined, err)
+	}
+	return errors.Join(joined...)
 }
 
 func (r *agentRuntime) ExecuteTool(ctx context.Context, req coreagent.ExecuteToolRequest) (*coreagent.ExecuteToolResponse, error) {

--- a/gestaltd/internal/bootstrap/agent_runtime_test.go
+++ b/gestaltd/internal/bootstrap/agent_runtime_test.go
@@ -9,9 +9,11 @@ import (
 	"strings"
 	"sync"
 	"testing"
+	"time"
 
 	"github.com/valon-technologies/gestalt/server/core"
 	coreagent "github.com/valon-technologies/gestalt/server/core/agent"
+	"github.com/valon-technologies/gestalt/server/core/indexeddb"
 	coretesting "github.com/valon-technologies/gestalt/server/core/testing"
 	"github.com/valon-technologies/gestalt/server/internal/config"
 	"github.com/valon-technologies/gestalt/server/internal/coredata"
@@ -19,6 +21,7 @@ import (
 	"github.com/valon-technologies/gestalt/server/internal/principal"
 	"github.com/valon-technologies/gestalt/server/internal/providerhost"
 	"github.com/valon-technologies/gestalt/server/internal/testutil"
+	"gopkg.in/yaml.v3"
 )
 
 func buildAgentProviderBinary(t *testing.T) string {
@@ -30,6 +33,17 @@ func buildAgentProviderBinary(t *testing.T) string {
 }
 
 type agentRuntimeFactoryContextKey struct{}
+
+func testHostedAgentRuntimeConfig() *config.HostedRuntimeConfig {
+	return &config.HostedRuntimeConfig{
+		MinReadyInstances:   1,
+		MaxReadyInstances:   1,
+		StartupTimeout:      "5s",
+		HealthCheckInterval: "1s",
+		RestartPolicy:       config.HostedRuntimeRestartPolicyNever,
+		DrainTimeout:        "1s",
+	}
+}
 
 type agentRuntimeInvokerCall struct {
 	providerName string
@@ -83,22 +97,34 @@ type pingAgentProvider struct {
 	coreagent.UnimplementedProvider
 	calls *int
 	err   error
+	delay time.Duration
 }
 
-func (p *pingAgentProvider) Ping(context.Context) error {
+func (p *pingAgentProvider) Ping(ctx context.Context) error {
 	if p.calls != nil {
 		(*p.calls)++
+	}
+	if p.delay > 0 {
+		select {
+		case <-ctx.Done():
+			return ctx.Err()
+		case <-time.After(p.delay):
+		}
 	}
 	return p.err
 }
 
-func TestAgentRuntimePingChecksSelectedProviderOnly(t *testing.T) {
+func TestAgentRuntimePingChecksConfiguredProviders(t *testing.T) {
 	t.Parallel()
 
 	defaultCalls := 0
 	canaryCalls := 0
 	runtime := &agentRuntime{
 		defaultProviderName: "simple",
+		configuredProviders: map[string]struct{}{
+			"canary": {},
+			"simple": {},
+		},
 		providers: map[string]coreagent.Provider{
 			"canary": &pingAgentProvider{
 				calls: &canaryCalls,
@@ -108,14 +134,48 @@ func TestAgentRuntimePingChecksSelectedProviderOnly(t *testing.T) {
 		},
 	}
 
-	if err := runtime.Ping(context.Background()); err != nil {
-		t.Fatalf("Ping: %v", err)
+	if err := runtime.Ping(context.Background()); err == nil || !strings.Contains(err.Error(), `agent provider "canary" unavailable`) {
+		t.Fatalf("Ping error = %v, want canary unavailable", err)
 	}
 	if defaultCalls != 1 {
 		t.Fatalf("default provider Ping calls = %d, want 1", defaultCalls)
 	}
+	if canaryCalls != 1 {
+		t.Fatalf("canary provider Ping calls = %d, want 1", canaryCalls)
+	}
+
+	defaultCalls = 0
+	canaryCalls = 0
+	runtime.FailProvider("canary")
+	if err := runtime.Ping(context.Background()); err == nil || !strings.Contains(err.Error(), `agent provider "canary" unavailable`) {
+		t.Fatalf("Ping after failed provider error = %v, want canary unavailable", err)
+	}
+	if defaultCalls != 1 {
+		t.Fatalf("default provider Ping calls after failed provider = %d, want 1", defaultCalls)
+	}
 	if canaryCalls != 0 {
-		t.Fatalf("canary provider Ping calls = %d, want 0", canaryCalls)
+		t.Fatalf("canary provider Ping calls after failed provider = %d, want 0", canaryCalls)
+	}
+}
+
+func TestAgentRuntimePingChecksConfiguredProvidersInParallel(t *testing.T) {
+	t.Parallel()
+
+	runtime := &agentRuntime{
+		defaultProviderName: "simple",
+		configuredProviders: map[string]struct{}{
+			"canary": {},
+			"simple": {},
+		},
+		providers: map[string]coreagent.Provider{
+			"canary": &pingAgentProvider{delay: 100 * time.Millisecond},
+			"simple": &pingAgentProvider{delay: 100 * time.Millisecond},
+		},
+	}
+	ctx, cancel := context.WithTimeout(context.Background(), 150*time.Millisecond)
+	defer cancel()
+	if err := runtime.Ping(ctx); err != nil {
+		t.Fatalf("Ping: %v", err)
 	}
 }
 
@@ -132,6 +192,10 @@ func TestAgentRuntimeConfigSelectedProviderStartsSessionWithRuntimeFields(t *tes
 		factoryContextValue = ctx.Value(agentRuntimeFactoryContextKey{})
 		return runtimeProvider, nil
 	}
+	runtimeConfig := testHostedAgentRuntimeConfig()
+	runtimeConfig.Template = "python-dev"
+	runtimeConfig.Image = "ghcr.io/valon/gestalt-python-runtime:latest"
+	runtimeConfig.Metadata = map[string]string{"tenant": "eng"}
 
 	cfg := &config.Config{
 		Server: config.ServerConfig{
@@ -146,11 +210,7 @@ func TestAgentRuntimeConfigSelectedProviderStartsSessionWithRuntimeFields(t *tes
 			Agent: map[string]*config.ProviderEntry{
 				"simple": {
 					Command: bin,
-					Runtime: &config.HostedRuntimeConfig{
-						Template: "python-dev",
-						Image:    "ghcr.io/valon/gestalt-python-runtime:latest",
-						Metadata: map[string]string{"tenant": "eng"},
-					},
+					Runtime: runtimeConfig,
 				},
 			},
 		},
@@ -199,6 +259,346 @@ func TestAgentRuntimeConfigSelectedProviderStartsSessionWithRuntimeFields(t *tes
 	}
 }
 
+func TestAgentRuntimeConfigStartsHostedAgentWarmPool(t *testing.T) {
+	t.Parallel()
+
+	bin := buildAgentProviderBinary(t)
+	runtimeProvider := newCapturingPluginRuntime()
+	factories := NewFactoryRegistry()
+	factories.Runtime = func(context.Context, string, *config.RuntimeProviderEntry, Deps) (pluginruntime.Provider, error) {
+		return runtimeProvider, nil
+	}
+	runtimeConfig := testHostedAgentRuntimeConfig()
+	runtimeConfig.MinReadyInstances = 2
+	runtimeConfig.MaxReadyInstances = 2
+	runtimeConfig.DrainTimeout = "2s"
+	cfg := &config.Config{
+		Server: config.ServerConfig{
+			Runtime: config.ServerRuntimeConfig{Provider: "hosted"},
+		},
+		Runtime: config.RuntimeConfig{
+			Providers: map[string]*config.RuntimeProviderEntry{
+				"hosted": {Driver: config.RuntimeProviderDriver("capture")},
+			},
+		},
+		Providers: config.ProvidersConfig{
+			Agent: map[string]*config.ProviderEntry{
+				"simple": {
+					Command: bin,
+					Runtime: runtimeConfig,
+				},
+			},
+		},
+	}
+	services := coretesting.NewStubServices(t)
+	agentRuntime := &agentRuntime{providers: map[string]coreagent.Provider{}}
+	agentRuntime.SetRunMetadata(services.AgentRunMetadata)
+	deps := Deps{
+		Services:              services,
+		AgentRuntime:          agentRuntime,
+		PluginRuntimeRegistry: newPluginRuntimeRegistry(cfg, factories.Runtime, Deps{}),
+	}
+	agents, err := buildAgents(context.Background(), cfg, factories, deps)
+	if err != nil {
+		t.Fatalf("buildAgents: %v", err)
+	}
+	defer func() {
+		if err := closeAgents(agents...); err != nil {
+			t.Fatalf("closeAgents: %v", err)
+		}
+	}()
+
+	requests := runtimeProvider.startSessionRequests()
+	if len(requests) != 2 {
+		t.Fatalf("start session requests = %d, want 2", len(requests))
+	}
+	for i, sessionID := range []string{"session-1", "session-2"} {
+		session, err := agents[0].CreateSession(context.Background(), coreagent.CreateSessionRequest{
+			SessionID: sessionID,
+			Model:     "gpt-test",
+		})
+		if err != nil {
+			t.Fatalf("CreateSession(%d): %v", i, err)
+		}
+		if session == nil || session.ID != sessionID {
+			t.Fatalf("CreateSession(%d) = %#v, want %q", i, session, sessionID)
+		}
+	}
+	pool := hostedAgentProviderPoolForTest(t, agents[0])
+	sessionBackend := pool.sessionBackend("session-1")
+	if sessionBackend == nil {
+		t.Fatal("session-1 backend was not recorded")
+	}
+	turn, err := agents[0].CreateTurn(context.Background(), coreagent.CreateTurnRequest{
+		TurnID:    "turn-1",
+		SessionID: "session-1",
+		Model:     "gpt-test",
+		Metadata: map[string]any{
+			"requireInteraction": true,
+		},
+	})
+	if err != nil {
+		t.Fatalf("CreateTurn: %v", err)
+	}
+	if turn == nil || turn.ID != "turn-1" || turn.SessionID != "session-1" {
+		t.Fatalf("CreateTurn = %#v, want turn-1 on session-1", turn)
+	}
+	if turn.Status != coreagent.ExecutionStatusWaitingForInput {
+		t.Fatalf("turn status = %q, want %q", turn.Status, coreagent.ExecutionStatusWaitingForInput)
+	}
+	drainDone := make(chan error, 1)
+	go func() {
+		drainDone <- pool.drainAndCloseBackend(sessionBackend)
+	}()
+	waitForAgentRuntimeCondition(t, 2*time.Second, func() bool {
+		pool.mu.Lock()
+		defer pool.mu.Unlock()
+		return sessionBackend.closing
+	})
+	sessions, err := agents[0].ListSessions(context.Background(), coreagent.ListSessionsRequest{})
+	if err != nil {
+		t.Fatalf("ListSessions(during drain): %v", err)
+	}
+	if len(sessions) != 2 {
+		t.Fatalf("ListSessions(during drain) = %d sessions, want 2", len(sessions))
+	}
+	fetched, err := agents[0].GetTurn(context.Background(), coreagent.GetTurnRequest{TurnID: "turn-1"})
+	if err != nil {
+		t.Fatalf("GetTurn(during drain): %v", err)
+	}
+	if fetched == nil || fetched.ID != "turn-1" || fetched.Status != coreagent.ExecutionStatusWaitingForInput {
+		t.Fatalf("GetTurn(during drain) = %#v, want waiting turn-1", fetched)
+	}
+	interactions, err := agents[0].ListInteractions(context.Background(), coreagent.ListInteractionsRequest{TurnID: "turn-1"})
+	if err != nil {
+		t.Fatalf("ListInteractions(during drain): %v", err)
+	}
+	if len(interactions) != 1 {
+		t.Fatalf("ListInteractions(during drain) = %d interactions, want 1", len(interactions))
+	}
+	if _, err := agents[0].ResolveInteraction(context.Background(), coreagent.ResolveInteractionRequest{
+		InteractionID: interactions[0].ID,
+		Resolution:    map[string]any{"approved": true},
+	}); err != nil {
+		t.Fatalf("ResolveInteraction(during drain): %v", err)
+	}
+	resolved, err := agents[0].GetTurn(context.Background(), coreagent.GetTurnRequest{TurnID: "turn-1"})
+	if err != nil {
+		t.Fatalf("GetTurn(after ResolveInteraction): %v", err)
+	}
+	if resolved == nil || resolved.Status != coreagent.ExecutionStatusSucceeded {
+		t.Fatalf("GetTurn(after ResolveInteraction) = %#v, want succeeded turn", resolved)
+	}
+	select {
+	case err := <-drainDone:
+		if err != nil {
+			t.Fatalf("drainAndCloseBackend: %v", err)
+		}
+	case <-time.After(2 * time.Second):
+		t.Fatal("drainAndCloseBackend did not finish after live turn completed")
+	}
+}
+
+func TestAgentRuntimeConfigScalesOutHostedAgentWarmPool(t *testing.T) {
+	t.Parallel()
+
+	bin := buildAgentProviderBinary(t)
+	runtimeProvider := newCapturingPluginRuntime()
+	factories := NewFactoryRegistry()
+	factories.Runtime = func(context.Context, string, *config.RuntimeProviderEntry, Deps) (pluginruntime.Provider, error) {
+		return runtimeProvider, nil
+	}
+	runtimeConfig := testHostedAgentRuntimeConfig()
+	runtimeConfig.MaxReadyInstances = 2
+	cfg := &config.Config{
+		Server: config.ServerConfig{
+			Runtime: config.ServerRuntimeConfig{Provider: "hosted"},
+		},
+		Runtime: config.RuntimeConfig{
+			Providers: map[string]*config.RuntimeProviderEntry{
+				"hosted": {Driver: config.RuntimeProviderDriver("capture")},
+			},
+		},
+		Providers: config.ProvidersConfig{
+			Agent: map[string]*config.ProviderEntry{
+				"simple": {
+					Command: bin,
+					Runtime: runtimeConfig,
+				},
+			},
+		},
+	}
+	services := coretesting.NewStubServices(t)
+	agentRuntime := &agentRuntime{providers: map[string]coreagent.Provider{}}
+	agentRuntime.SetRunMetadata(services.AgentRunMetadata)
+	deps := Deps{
+		Services:              services,
+		AgentRuntime:          agentRuntime,
+		PluginRuntimeRegistry: newPluginRuntimeRegistry(cfg, factories.Runtime, Deps{}),
+	}
+	agents, err := buildAgents(context.Background(), cfg, factories, deps)
+	if err != nil {
+		t.Fatalf("buildAgents: %v", err)
+	}
+	defer func() {
+		if err := closeAgents(agents...); err != nil {
+			t.Fatalf("closeAgents: %v", err)
+		}
+	}()
+
+	if got := len(runtimeProvider.startSessionRequests()); got != 1 {
+		t.Fatalf("initial start session requests = %d, want 1", got)
+	}
+	pool := hostedAgentProviderPoolForTest(t, agents[0])
+	initial := pool.readyBackends()
+	if len(initial) != 1 {
+		t.Fatalf("initial ready backends = %d, want 1", len(initial))
+	}
+	first, releaseFirst, err := pool.acquireBackend(context.Background(), initial[0], false)
+	if err != nil {
+		t.Fatalf("acquire first backend: %v", err)
+	}
+	defer releaseFirst()
+
+	session, err := agents[0].CreateSession(context.Background(), coreagent.CreateSessionRequest{
+		SessionID: "scale-out-session",
+		Model:     "gpt-test",
+	})
+	if err != nil {
+		t.Fatalf("CreateSession(scale out): %v", err)
+	}
+	if session == nil || session.ID != "scale-out-session" {
+		t.Fatalf("CreateSession(scale out) = %#v, want scale-out-session", session)
+	}
+	sessionBackend := pool.sessionBackend("scale-out-session")
+	if sessionBackend != first {
+		t.Fatalf("scale-out triggering request backend = %#v, want existing ready backend", sessionBackend)
+	}
+	waitForAgentRuntimeCondition(t, 2*time.Second, func() bool {
+		return len(runtimeProvider.startSessionRequests()) == 2 && len(pool.readyBackends()) == 2
+	})
+
+	var scaledBackend *hostedAgentPoolBackend
+	for _, backend := range pool.readyBackends() {
+		if backend != first {
+			scaledBackend = backend
+			break
+		}
+	}
+	if scaledBackend == nil {
+		t.Fatal("scaled backend was not started")
+	}
+	_, releaseSecond, err := pool.acquireBackend(context.Background(), scaledBackend, false)
+	if err != nil {
+		t.Fatalf("acquire scaled backend: %v", err)
+	}
+	defer releaseSecond()
+	if _, err := agents[0].CreateSession(context.Background(), coreagent.CreateSessionRequest{
+		SessionID: "max-capped-session",
+		Model:     "gpt-test",
+	}); err != nil {
+		t.Fatalf("CreateSession(max capped): %v", err)
+	}
+	if got := len(runtimeProvider.startSessionRequests()); got != 2 {
+		t.Fatalf("start session requests after max cap = %d, want 2", got)
+	}
+}
+
+func TestAgentRuntimeConfigRestartsUnhealthyHostedAgent(t *testing.T) {
+	t.Parallel()
+
+	bin := buildAgentProviderBinary(t)
+	runtimeProvider := newCapturingPluginRuntime()
+	factories := NewFactoryRegistry()
+	factories.Runtime = func(context.Context, string, *config.RuntimeProviderEntry, Deps) (pluginruntime.Provider, error) {
+		return runtimeProvider, nil
+	}
+	runtimeConfig := testHostedAgentRuntimeConfig()
+	runtimeConfig.HealthCheckInterval = "50ms"
+	runtimeConfig.RestartPolicy = config.HostedRuntimeRestartPolicyAlways
+	cfg := &config.Config{
+		Server: config.ServerConfig{
+			Runtime: config.ServerRuntimeConfig{Provider: "hosted"},
+		},
+		Runtime: config.RuntimeConfig{
+			Providers: map[string]*config.RuntimeProviderEntry{
+				"hosted": {Driver: config.RuntimeProviderDriver("capture")},
+			},
+		},
+		Providers: config.ProvidersConfig{
+			Agent: map[string]*config.ProviderEntry{
+				"simple": {
+					Command:   bin,
+					IndexedDB: &config.PluginIndexedDBConfig{Provider: "agent_state"},
+					Runtime:   runtimeConfig,
+				},
+			},
+		},
+	}
+	deps := Deps{
+		AgentRuntime:          &agentRuntime{providers: map[string]coreagent.Provider{}},
+		IndexedDBDefs:         map[string]*config.ProviderEntry{"agent_state": {}},
+		IndexedDBFactory:      func(yaml.Node) (indexeddb.IndexedDB, error) { return &coretesting.StubIndexedDB{}, nil },
+		PluginRuntimeRegistry: newPluginRuntimeRegistry(cfg, factories.Runtime, Deps{}),
+	}
+	agents, err := buildAgents(context.Background(), cfg, factories, deps)
+	if err != nil {
+		t.Fatalf("buildAgents: %v", err)
+	}
+	defer func() {
+		if err := closeAgents(agents...); err != nil {
+			t.Fatalf("closeAgents: %v", err)
+		}
+	}()
+
+	pool := hostedAgentProviderPoolForTest(t, agents[0])
+	backends := pool.readyBackends()
+	if len(backends) != 1 {
+		t.Fatalf("ready backends = %d, want 1", len(backends))
+	}
+	if err := backends[0].provider.Close(); err != nil {
+		t.Fatalf("Close backend provider: %v", err)
+	}
+	waitForAgentRuntimeCondition(t, 2*time.Second, func() bool {
+		return len(runtimeProvider.startSessionRequests()) >= 2 && len(pool.readyBackends()) == 1
+	})
+	session, err := agents[0].CreateSession(context.Background(), coreagent.CreateSessionRequest{
+		SessionID: "session-after-restart",
+		Model:     "gpt-test",
+	})
+	if err != nil {
+		t.Fatalf("CreateSession(after restart): %v", err)
+	}
+	if session == nil || session.ID != "session-after-restart" {
+		t.Fatalf("CreateSession(after restart) = %#v, want session-after-restart", session)
+	}
+}
+
+func TestHostedAgentProviderPoolPingChecksReadyBackendsInParallel(t *testing.T) {
+	t.Parallel()
+
+	pool := &hostedAgentProviderPool{
+		name: "simple",
+		backends: []*hostedAgentPoolBackend{
+			{
+				id:        1,
+				provider:  &pingAgentProvider{delay: 100 * time.Millisecond},
+				liveTurns: map[string]struct{}{},
+			},
+			{
+				id:        2,
+				provider:  &pingAgentProvider{delay: 100 * time.Millisecond},
+				liveTurns: map[string]struct{}{},
+			},
+		},
+	}
+	ctx, cancel := context.WithTimeout(context.Background(), 150*time.Millisecond)
+	defer cancel()
+	if err := pool.Ping(ctx); err != nil {
+		t.Fatalf("Ping: %v", err)
+	}
+}
+
 func TestAgentRuntimeConfigUsesDirectAgentHostBinding(t *testing.T) {
 	t.Parallel()
 
@@ -233,7 +633,7 @@ func TestAgentRuntimeConfigUsesDirectAgentHostBinding(t *testing.T) {
 			Agent: map[string]*config.ProviderEntry{
 				"simple": {
 					Command: bin,
-					Runtime: &config.HostedRuntimeConfig{},
+					Runtime: testHostedAgentRuntimeConfig(),
 				},
 			},
 		},
@@ -524,6 +924,36 @@ func TestAgentRuntimeConfigUsesDirectAgentHostBinding(t *testing.T) {
 	}
 }
 
+func waitForAgentRuntimeCondition(t *testing.T, timeout time.Duration, fn func() bool) {
+	t.Helper()
+	deadline := time.Now().Add(timeout)
+	for {
+		if fn() {
+			return
+		}
+		if time.Now().After(deadline) {
+			t.Fatal("condition was not satisfied before timeout")
+		}
+		time.Sleep(25 * time.Millisecond)
+	}
+}
+
+func hostedAgentProviderPoolForTest(t *testing.T, provider coreagent.Provider) *hostedAgentProviderPool {
+	t.Helper()
+	if withCleanup, ok := provider.(*agentProviderWithCleanup); ok {
+		provider = withCleanup.Provider
+	}
+	tracked, ok := provider.(*agentProviderWithTracking)
+	if !ok {
+		t.Fatalf("agent provider type = %T, want *agentProviderWithTracking", provider)
+	}
+	pool, ok := tracked.delegate.(*hostedAgentProviderPool)
+	if !ok {
+		t.Fatalf("tracked delegate type = %T, want *hostedAgentProviderPool", tracked.delegate)
+	}
+	return pool
+}
+
 //nolint:paralleltest // Hosted public-relay startup is serialized to avoid Linux CI contention.
 func TestAgentRuntimeConfigUsesPublicAgentHostRelayBinding(t *testing.T) {
 	// This exercises the hosted agent startup path over the public relay and is
@@ -559,7 +989,7 @@ func TestAgentRuntimeConfigUsesPublicAgentHostRelayBinding(t *testing.T) {
 			Agent: map[string]*config.ProviderEntry{
 				"simple": {
 					Command: bin,
-					Runtime: &config.HostedRuntimeConfig{},
+					Runtime: testHostedAgentRuntimeConfig(),
 				},
 			},
 		},
@@ -654,7 +1084,7 @@ func TestAgentRuntimeConfigRejectsMissingHostServiceAccess(t *testing.T) {
 			Agent: map[string]*config.ProviderEntry{
 				"simple": {
 					Command: bin,
-					Runtime: &config.HostedRuntimeConfig{},
+					Runtime: testHostedAgentRuntimeConfig(),
 				},
 			},
 		},

--- a/gestaltd/internal/bootstrap/hosted_agent_pool.go
+++ b/gestaltd/internal/bootstrap/hosted_agent_pool.go
@@ -1,0 +1,1060 @@
+package bootstrap
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"log/slog"
+	"strings"
+	"sync"
+	"time"
+
+	"github.com/valon-technologies/gestalt/server/core"
+	coreagent "github.com/valon-technologies/gestalt/server/core/agent"
+	"github.com/valon-technologies/gestalt/server/internal/config"
+	"github.com/valon-technologies/gestalt/server/internal/providerhost"
+)
+
+type hostedAgentProviderPool struct {
+	name         string
+	launch       *hostedAgentProviderLaunch
+	hostServices []providerhost.HostService
+	deps         Deps
+	policy       config.HostedRuntimeLifecyclePolicy
+
+	ctx         context.Context
+	cancel      context.CancelFunc
+	lifecycleWG sync.WaitGroup
+
+	mu                  sync.Mutex
+	nextID              int
+	nextPick            int
+	starting            int
+	closed              bool
+	backends            []*hostedAgentPoolBackend
+	sessionBackends     map[string]*hostedAgentPoolBackend
+	turnBackends        map[string]*hostedAgentPoolBackend
+	interactionBackends map[string]*hostedAgentPoolBackend
+}
+
+type hostedAgentPoolBackend struct {
+	id        int
+	provider  coreagent.Provider
+	active    int
+	liveTurns map[string]struct{}
+	draining  bool
+	closing   bool
+	closed    bool
+}
+
+func newHostedAgentProviderPool(ctx context.Context, launch *hostedAgentProviderLaunch, hostServices []providerhost.HostService, deps Deps, policy config.HostedRuntimeLifecyclePolicy) (coreagent.Provider, error) {
+	if launch == nil {
+		return nil, fmt.Errorf("hosted agent launch is required")
+	}
+	poolCtx, cancel := context.WithCancel(context.Background())
+	pool := &hostedAgentProviderPool{
+		name:                launch.name,
+		launch:              launch,
+		hostServices:        append([]providerhost.HostService(nil), hostServices...),
+		deps:                deps,
+		policy:              policy,
+		ctx:                 poolCtx,
+		cancel:              cancel,
+		sessionBackends:     map[string]*hostedAgentPoolBackend{},
+		turnBackends:        map[string]*hostedAgentPoolBackend{},
+		interactionBackends: map[string]*hostedAgentPoolBackend{},
+	}
+	for i := 0; i < policy.MinReadyInstances; i++ {
+		if _, err := pool.startBackend(ctx); err != nil {
+			_ = pool.Close()
+			return nil, err
+		}
+	}
+	if policy.RestartPolicy != config.HostedRuntimeRestartPolicyNever {
+		pool.lifecycleWG.Add(1)
+		go func() {
+			defer pool.lifecycleWG.Done()
+			pool.healthLoop()
+		}()
+	}
+	return pool, nil
+}
+
+func (p *hostedAgentProviderPool) CreateSession(ctx context.Context, req coreagent.CreateSessionRequest) (*coreagent.Session, error) {
+	preferred := p.sessionBackend(req.SessionID)
+	backend, release, err := p.acquireBackend(ctx, preferred, preferred != nil)
+	if err != nil {
+		return nil, err
+	}
+	session, err := backend.provider.CreateSession(ctx, req)
+	release()
+	p.maybeProbeAfterCallError(backend, err)
+	if err != nil {
+		return nil, err
+	}
+	if session != nil {
+		p.recordSession(session, backend)
+	} else {
+		p.recordSessionBackend(req.SessionID, backend)
+	}
+	return session, nil
+}
+
+func (p *hostedAgentProviderPool) GetSession(ctx context.Context, req coreagent.GetSessionRequest) (*coreagent.Session, error) {
+	if backend := p.sessionBackend(req.SessionID); backend != nil {
+		session, err := p.withBackendSession(ctx, backend, req)
+		if err == nil {
+			p.recordSession(session, backend)
+		} else if errors.Is(err, core.ErrNotFound) {
+			p.deleteSessionBackend(req.SessionID)
+		}
+		return session, err
+	}
+	var lastNotFound error
+	for _, backend := range p.availableBackends(true) {
+		session, err := p.withBackendSession(ctx, backend, req)
+		if err == nil {
+			p.recordSession(session, backend)
+			return session, nil
+		}
+		if errors.Is(err, core.ErrNotFound) {
+			lastNotFound = err
+			continue
+		}
+		return nil, err
+	}
+	if lastNotFound != nil {
+		return nil, lastNotFound
+	}
+	return nil, core.ErrNotFound
+}
+
+func (p *hostedAgentProviderPool) ListSessions(ctx context.Context, req coreagent.ListSessionsRequest) ([]*coreagent.Session, error) {
+	var out []*coreagent.Session
+	for _, backend := range p.availableBackends(true) {
+		acquired, release, err := p.acquireBackend(ctx, backend, true)
+		if err != nil {
+			return nil, err
+		}
+		sessions, err := acquired.provider.ListSessions(ctx, req)
+		release()
+		p.maybeProbeAfterCallError(acquired, err)
+		if err != nil {
+			return nil, err
+		}
+		for _, session := range sessions {
+			p.recordSession(session, acquired)
+		}
+		out = append(out, sessions...)
+	}
+	return out, nil
+}
+
+func (p *hostedAgentProviderPool) UpdateSession(ctx context.Context, req coreagent.UpdateSessionRequest) (*coreagent.Session, error) {
+	backend := p.sessionBackend(req.SessionID)
+	if backend == nil {
+		session, err := p.GetSession(ctx, coreagent.GetSessionRequest{SessionID: req.SessionID})
+		if err != nil {
+			return nil, err
+		}
+		backend = p.sessionBackend(sessionIDForSession(session))
+	}
+	if backend == nil {
+		return nil, core.ErrNotFound
+	}
+	acquired, release, err := p.acquireBackend(ctx, backend, true)
+	if err != nil {
+		return nil, err
+	}
+	session, err := acquired.provider.UpdateSession(ctx, req)
+	release()
+	p.maybeProbeAfterCallError(acquired, err)
+	if err == nil {
+		p.recordSession(session, acquired)
+	}
+	return session, err
+}
+
+func (p *hostedAgentProviderPool) CreateTurn(ctx context.Context, req coreagent.CreateTurnRequest) (*coreagent.Turn, error) {
+	preferred := p.turnBackend(req.TurnID)
+	if preferred == nil {
+		preferred = p.sessionBackend(req.SessionID)
+	}
+	backend, release, err := p.acquireBackend(ctx, preferred, preferred != nil)
+	if err != nil {
+		return nil, err
+	}
+	turn, err := backend.provider.CreateTurn(ctx, req)
+	release()
+	p.maybeProbeAfterCallError(backend, err)
+	if err != nil {
+		return nil, err
+	}
+	if turn != nil {
+		p.recordTurn(turn, backend)
+	} else {
+		p.recordTurnBackend(req.TurnID, backend)
+	}
+	return turn, nil
+}
+
+func (p *hostedAgentProviderPool) GetTurn(ctx context.Context, req coreagent.GetTurnRequest) (*coreagent.Turn, error) {
+	if backend := p.turnBackend(req.TurnID); backend != nil {
+		turn, err := p.withBackendTurn(ctx, backend, req)
+		if err == nil {
+			p.recordTurn(turn, backend)
+		} else if errors.Is(err, core.ErrNotFound) {
+			p.deleteTurnBackend(req.TurnID)
+		}
+		return turn, err
+	}
+	var lastNotFound error
+	for _, backend := range p.availableBackends(true) {
+		turn, err := p.withBackendTurn(ctx, backend, req)
+		if err == nil {
+			p.recordTurn(turn, backend)
+			return turn, nil
+		}
+		if errors.Is(err, core.ErrNotFound) {
+			lastNotFound = err
+			continue
+		}
+		return nil, err
+	}
+	if lastNotFound != nil {
+		return nil, lastNotFound
+	}
+	return nil, core.ErrNotFound
+}
+
+func (p *hostedAgentProviderPool) ListTurns(ctx context.Context, req coreagent.ListTurnsRequest) ([]*coreagent.Turn, error) {
+	if backend := p.sessionBackend(req.SessionID); backend != nil {
+		return p.listTurnsFromBackend(ctx, backend, req)
+	}
+	var out []*coreagent.Turn
+	for _, backend := range p.availableBackends(true) {
+		turns, err := p.listTurnsFromBackend(ctx, backend, req)
+		if err != nil {
+			return nil, err
+		}
+		out = append(out, turns...)
+	}
+	return out, nil
+}
+
+func (p *hostedAgentProviderPool) CancelTurn(ctx context.Context, req coreagent.CancelTurnRequest) (*coreagent.Turn, error) {
+	backend := p.turnBackend(req.TurnID)
+	if backend == nil {
+		turn, err := p.GetTurn(ctx, coreagent.GetTurnRequest{TurnID: req.TurnID})
+		if err != nil {
+			return nil, err
+		}
+		backend = p.turnBackend(turnIDForTurn(turn))
+	}
+	if backend == nil {
+		return nil, core.ErrNotFound
+	}
+	acquired, release, err := p.acquireBackend(ctx, backend, true)
+	if err != nil {
+		return nil, err
+	}
+	turn, err := acquired.provider.CancelTurn(ctx, req)
+	release()
+	p.maybeProbeAfterCallError(acquired, err)
+	if err == nil {
+		p.recordTurn(turn, acquired)
+	}
+	return turn, err
+}
+
+func (p *hostedAgentProviderPool) ListTurnEvents(ctx context.Context, req coreagent.ListTurnEventsRequest) ([]*coreagent.TurnEvent, error) {
+	if backend := p.turnBackend(req.TurnID); backend != nil {
+		return p.listTurnEventsFromBackend(ctx, backend, req)
+	}
+	var lastNotFound error
+	for _, backend := range p.availableBackends(true) {
+		events, err := p.listTurnEventsFromBackend(ctx, backend, req)
+		if err == nil {
+			return events, nil
+		}
+		if errors.Is(err, core.ErrNotFound) {
+			lastNotFound = err
+			continue
+		}
+		return nil, err
+	}
+	if lastNotFound != nil {
+		return nil, lastNotFound
+	}
+	return nil, core.ErrNotFound
+}
+
+func (p *hostedAgentProviderPool) GetInteraction(ctx context.Context, req coreagent.GetInteractionRequest) (*coreagent.Interaction, error) {
+	if backend := p.interactionBackend(req.InteractionID); backend != nil {
+		interaction, err := p.getInteractionFromBackend(ctx, backend, req)
+		if err == nil {
+			p.recordInteraction(interaction, backend)
+		} else if errors.Is(err, core.ErrNotFound) {
+			p.deleteInteractionBackend(req.InteractionID)
+		}
+		return interaction, err
+	}
+	var lastNotFound error
+	for _, backend := range p.availableBackends(true) {
+		interaction, err := p.getInteractionFromBackend(ctx, backend, req)
+		if err == nil {
+			p.recordInteraction(interaction, backend)
+			return interaction, nil
+		}
+		if errors.Is(err, core.ErrNotFound) {
+			lastNotFound = err
+			continue
+		}
+		return nil, err
+	}
+	if lastNotFound != nil {
+		return nil, lastNotFound
+	}
+	return nil, core.ErrNotFound
+}
+
+func (p *hostedAgentProviderPool) ListInteractions(ctx context.Context, req coreagent.ListInteractionsRequest) ([]*coreagent.Interaction, error) {
+	if backend := p.turnBackend(req.TurnID); backend != nil {
+		return p.listInteractionsFromBackend(ctx, backend, req)
+	}
+	var out []*coreagent.Interaction
+	for _, backend := range p.availableBackends(true) {
+		interactions, err := p.listInteractionsFromBackend(ctx, backend, req)
+		if err != nil {
+			return nil, err
+		}
+		out = append(out, interactions...)
+	}
+	return out, nil
+}
+
+func (p *hostedAgentProviderPool) ResolveInteraction(ctx context.Context, req coreagent.ResolveInteractionRequest) (*coreagent.Interaction, error) {
+	backend := p.interactionBackend(req.InteractionID)
+	if backend == nil {
+		interaction, err := p.GetInteraction(ctx, coreagent.GetInteractionRequest{InteractionID: req.InteractionID})
+		if err != nil {
+			return nil, err
+		}
+		backend = p.interactionBackend(interactionIDForInteraction(interaction))
+	}
+	if backend == nil {
+		return nil, core.ErrNotFound
+	}
+	acquired, release, err := p.acquireBackend(ctx, backend, true)
+	if err != nil {
+		return nil, err
+	}
+	interaction, err := acquired.provider.ResolveInteraction(ctx, req)
+	release()
+	p.maybeProbeAfterCallError(acquired, err)
+	if err == nil {
+		p.recordInteraction(interaction, acquired)
+	}
+	return interaction, err
+}
+
+func (p *hostedAgentProviderPool) GetCapabilities(ctx context.Context, req coreagent.GetCapabilitiesRequest) (*coreagent.ProviderCapabilities, error) {
+	backend, release, err := p.acquireBackend(ctx, nil, false)
+	if err != nil {
+		return nil, err
+	}
+	capabilities, err := backend.provider.GetCapabilities(ctx, req)
+	release()
+	p.maybeProbeAfterCallError(backend, err)
+	return capabilities, err
+}
+
+func (p *hostedAgentProviderPool) Ping(ctx context.Context) error {
+	backends := p.readyBackends()
+	if len(backends) == 0 {
+		return fmt.Errorf("hosted agent provider %q has no ready runtime instances", p.name)
+	}
+	errs := make(chan error, len(backends))
+	var wg sync.WaitGroup
+	for _, backend := range backends {
+		wg.Add(1)
+		go func(backend *hostedAgentPoolBackend) {
+			defer wg.Done()
+			acquired, release, err := p.acquireBackend(ctx, backend, true)
+			if err != nil {
+				errs <- err
+				return
+			}
+			defer release()
+			err = acquired.provider.Ping(ctx)
+			if err != nil {
+				errs <- fmt.Errorf("runtime instance %d: %w", acquired.id, err)
+			}
+		}(backend)
+	}
+	wg.Wait()
+	close(errs)
+	var joined []error
+	for err := range errs {
+		joined = append(joined, err)
+	}
+	return errors.Join(joined...)
+}
+
+func (p *hostedAgentProviderPool) Close() error {
+	if p == nil {
+		return nil
+	}
+	p.mu.Lock()
+	if p.closed {
+		p.mu.Unlock()
+		return nil
+	}
+	p.closed = true
+	backends := append([]*hostedAgentPoolBackend(nil), p.backends...)
+	for _, backend := range backends {
+		if backend != nil && !backend.closed {
+			backend.draining = true
+		}
+	}
+	p.mu.Unlock()
+	p.cancel()
+
+	errs := make(chan error, len(backends))
+	var wg sync.WaitGroup
+	for _, backend := range backends {
+		wg.Add(1)
+		go func(backend *hostedAgentPoolBackend) {
+			defer wg.Done()
+			errs <- p.drainAndCloseBackend(backend)
+		}(backend)
+	}
+	wg.Wait()
+	close(errs)
+	p.lifecycleWG.Wait()
+	var closeErrs []error
+	for err := range errs {
+		if err != nil {
+			closeErrs = append(closeErrs, err)
+		}
+	}
+	p.mu.Lock()
+	p.backends = nil
+	p.sessionBackends = map[string]*hostedAgentPoolBackend{}
+	p.turnBackends = map[string]*hostedAgentPoolBackend{}
+	p.interactionBackends = map[string]*hostedAgentPoolBackend{}
+	p.mu.Unlock()
+	if p.launch != nil {
+		p.launch.close()
+	}
+	return errors.Join(closeErrs...)
+}
+
+func (p *hostedAgentProviderPool) withBackendSession(ctx context.Context, backend *hostedAgentPoolBackend, req coreagent.GetSessionRequest) (*coreagent.Session, error) {
+	acquired, release, err := p.acquireBackend(ctx, backend, true)
+	if err != nil {
+		return nil, err
+	}
+	session, err := acquired.provider.GetSession(ctx, req)
+	release()
+	p.maybeProbeAfterCallError(acquired, err)
+	return session, err
+}
+
+func (p *hostedAgentProviderPool) withBackendTurn(ctx context.Context, backend *hostedAgentPoolBackend, req coreagent.GetTurnRequest) (*coreagent.Turn, error) {
+	acquired, release, err := p.acquireBackend(ctx, backend, true)
+	if err != nil {
+		return nil, err
+	}
+	turn, err := acquired.provider.GetTurn(ctx, req)
+	release()
+	p.maybeProbeAfterCallError(acquired, err)
+	return turn, err
+}
+
+func (p *hostedAgentProviderPool) listTurnsFromBackend(ctx context.Context, backend *hostedAgentPoolBackend, req coreagent.ListTurnsRequest) ([]*coreagent.Turn, error) {
+	acquired, release, err := p.acquireBackend(ctx, backend, true)
+	if err != nil {
+		return nil, err
+	}
+	turns, err := acquired.provider.ListTurns(ctx, req)
+	release()
+	p.maybeProbeAfterCallError(acquired, err)
+	if err == nil {
+		for _, turn := range turns {
+			p.recordTurn(turn, acquired)
+		}
+	}
+	return turns, err
+}
+
+func (p *hostedAgentProviderPool) listTurnEventsFromBackend(ctx context.Context, backend *hostedAgentPoolBackend, req coreagent.ListTurnEventsRequest) ([]*coreagent.TurnEvent, error) {
+	acquired, release, err := p.acquireBackend(ctx, backend, true)
+	if err != nil {
+		return nil, err
+	}
+	events, err := acquired.provider.ListTurnEvents(ctx, req)
+	release()
+	p.maybeProbeAfterCallError(acquired, err)
+	return events, err
+}
+
+func (p *hostedAgentProviderPool) getInteractionFromBackend(ctx context.Context, backend *hostedAgentPoolBackend, req coreagent.GetInteractionRequest) (*coreagent.Interaction, error) {
+	acquired, release, err := p.acquireBackend(ctx, backend, true)
+	if err != nil {
+		return nil, err
+	}
+	interaction, err := acquired.provider.GetInteraction(ctx, req)
+	release()
+	p.maybeProbeAfterCallError(acquired, err)
+	return interaction, err
+}
+
+func (p *hostedAgentProviderPool) listInteractionsFromBackend(ctx context.Context, backend *hostedAgentPoolBackend, req coreagent.ListInteractionsRequest) ([]*coreagent.Interaction, error) {
+	acquired, release, err := p.acquireBackend(ctx, backend, true)
+	if err != nil {
+		return nil, err
+	}
+	interactions, err := acquired.provider.ListInteractions(ctx, req)
+	release()
+	p.maybeProbeAfterCallError(acquired, err)
+	if err == nil {
+		for _, interaction := range interactions {
+			p.recordInteraction(interaction, acquired)
+		}
+	}
+	return interactions, err
+}
+
+func (p *hostedAgentProviderPool) acquireBackend(ctx context.Context, preferred *hostedAgentPoolBackend, allowDraining bool) (*hostedAgentPoolBackend, func(), error) {
+	for {
+		p.mu.Lock()
+		if p.closed {
+			p.mu.Unlock()
+			return nil, nil, fmt.Errorf("hosted agent provider %q is closed", p.name)
+		}
+		if preferred != nil {
+			if p.backendAvailableLocked(preferred, allowDraining) {
+				preferred.active++
+				p.mu.Unlock()
+				return preferred, p.releaseBackend(preferred), nil
+			}
+			p.mu.Unlock()
+			return nil, nil, fmt.Errorf("hosted agent provider %q runtime instance is not ready", p.name)
+		}
+		if backend := p.pickReadyBackendLocked(); backend != nil {
+			if backend.active > 0 && p.canScaleOutLocked() {
+				p.startScaleOutLocked()
+			}
+			backend.active++
+			p.mu.Unlock()
+			return backend, p.releaseBackend(backend), nil
+		}
+		if p.canScaleOutLocked() {
+			p.starting++
+			p.mu.Unlock()
+			started, startErr := p.startBackend(ctx)
+			p.mu.Lock()
+			p.starting--
+			if startErr == nil && p.backendAvailableLocked(started, false) {
+				started.active++
+				p.mu.Unlock()
+				return started, p.releaseBackend(started), nil
+			}
+			p.mu.Unlock()
+			if startErr != nil {
+				return nil, nil, startErr
+			}
+			continue
+		}
+		p.mu.Unlock()
+
+		select {
+		case <-ctx.Done():
+			return nil, nil, ctx.Err()
+		case <-time.After(25 * time.Millisecond):
+		}
+	}
+}
+
+func (p *hostedAgentProviderPool) releaseBackend(backend *hostedAgentPoolBackend) func() {
+	return func() {
+		p.mu.Lock()
+		if backend.active > 0 {
+			backend.active--
+		}
+		p.mu.Unlock()
+	}
+}
+
+func (p *hostedAgentProviderPool) pickReadyBackendLocked() *hostedAgentPoolBackend {
+	ready := make([]*hostedAgentPoolBackend, 0, len(p.backends))
+	for _, backend := range p.backends {
+		if p.backendAvailableLocked(backend, false) {
+			ready = append(ready, backend)
+		}
+	}
+	if len(ready) == 0 {
+		return nil
+	}
+	idle := ready[:0]
+	for _, backend := range ready {
+		if backend.active == 0 {
+			idle = append(idle, backend)
+		}
+	}
+	if len(idle) > 0 {
+		ready = idle
+	}
+	idx := p.nextPick % len(ready)
+	p.nextPick++
+	return ready[idx]
+}
+
+func (p *hostedAgentProviderPool) canScaleOutLocked() bool {
+	if p.policy.MaxReadyInstances <= 0 {
+		return false
+	}
+	ready := 0
+	for _, backend := range p.backends {
+		if p.backendAvailableLocked(backend, false) {
+			ready++
+		}
+	}
+	return ready+p.starting < p.policy.MaxReadyInstances
+}
+
+func (p *hostedAgentProviderPool) startScaleOutLocked() {
+	if p.closed || !p.canScaleOutLocked() {
+		return
+	}
+	p.starting++
+	p.lifecycleWG.Add(1)
+	go func() {
+		defer p.lifecycleWG.Done()
+		_, err := p.startBackend(p.ctx)
+		p.mu.Lock()
+		p.starting--
+		p.mu.Unlock()
+		if err != nil && !errors.Is(err, context.Canceled) {
+			slog.Warn("failed to scale out hosted agent runtime instance", "provider", p.name, "error", err)
+		}
+	}()
+}
+
+func (p *hostedAgentProviderPool) backendAvailableLocked(backend *hostedAgentPoolBackend, allowDraining bool) bool {
+	if backend == nil || backend.closed || backend.provider == nil {
+		return false
+	}
+	if (backend.draining || backend.closing) && !allowDraining {
+		return false
+	}
+	for _, candidate := range p.backends {
+		if candidate == backend {
+			return true
+		}
+	}
+	return false
+}
+
+func (p *hostedAgentProviderPool) readyBackends() []*hostedAgentPoolBackend {
+	return p.availableBackends(false)
+}
+
+func (p *hostedAgentProviderPool) availableBackends(allowDraining bool) []*hostedAgentPoolBackend {
+	p.mu.Lock()
+	defer p.mu.Unlock()
+	out := make([]*hostedAgentPoolBackend, 0, len(p.backends))
+	for _, backend := range p.backends {
+		if p.backendAvailableLocked(backend, allowDraining) {
+			out = append(out, backend)
+		}
+	}
+	return out
+}
+
+func (p *hostedAgentProviderPool) sessionBackend(sessionID string) *hostedAgentPoolBackend {
+	sessionID = strings.TrimSpace(sessionID)
+	if sessionID == "" {
+		return nil
+	}
+	p.mu.Lock()
+	defer p.mu.Unlock()
+	return p.sessionBackends[sessionID]
+}
+
+func (p *hostedAgentProviderPool) turnBackend(turnID string) *hostedAgentPoolBackend {
+	turnID = strings.TrimSpace(turnID)
+	if turnID == "" {
+		return nil
+	}
+	p.mu.Lock()
+	defer p.mu.Unlock()
+	return p.turnBackends[turnID]
+}
+
+func (p *hostedAgentProviderPool) interactionBackend(interactionID string) *hostedAgentPoolBackend {
+	interactionID = strings.TrimSpace(interactionID)
+	if interactionID == "" {
+		return nil
+	}
+	p.mu.Lock()
+	defer p.mu.Unlock()
+	return p.interactionBackends[interactionID]
+}
+
+func (p *hostedAgentProviderPool) recordSessionBackend(sessionID string, backend *hostedAgentPoolBackend) {
+	sessionID = strings.TrimSpace(sessionID)
+	if sessionID == "" || backend == nil {
+		return
+	}
+	p.mu.Lock()
+	defer p.mu.Unlock()
+	if p.backendAvailableLocked(backend, true) {
+		p.sessionBackends[sessionID] = backend
+	}
+}
+
+func (p *hostedAgentProviderPool) recordSession(session *coreagent.Session, backend *hostedAgentPoolBackend) {
+	if session == nil {
+		return
+	}
+	sessionID := strings.TrimSpace(session.ID)
+	if sessionID == "" {
+		return
+	}
+	if session.State == coreagent.SessionStateArchived && !p.backendDraining(backend) {
+		p.deleteSessionBackend(sessionID)
+		return
+	}
+	p.recordSessionBackend(sessionID, backend)
+}
+
+func (p *hostedAgentProviderPool) deleteSessionBackend(sessionID string) {
+	sessionID = strings.TrimSpace(sessionID)
+	if sessionID == "" {
+		return
+	}
+	p.mu.Lock()
+	defer p.mu.Unlock()
+	delete(p.sessionBackends, sessionID)
+}
+
+func (p *hostedAgentProviderPool) recordTurnBackend(turnID string, backend *hostedAgentPoolBackend) {
+	turnID = strings.TrimSpace(turnID)
+	if turnID == "" || backend == nil {
+		return
+	}
+	p.mu.Lock()
+	defer p.mu.Unlock()
+	if p.backendAvailableLocked(backend, true) {
+		p.turnBackends[turnID] = backend
+	}
+}
+
+func (p *hostedAgentProviderPool) recordTurn(turn *coreagent.Turn, backend *hostedAgentPoolBackend) {
+	if turn == nil {
+		return
+	}
+	turnID := strings.TrimSpace(turn.ID)
+	if turnID == "" {
+		return
+	}
+	p.recordSessionBackend(turn.SessionID, backend)
+	p.mu.Lock()
+	defer p.mu.Unlock()
+	if backend == nil || backend.liveTurns == nil || !p.backendAvailableLocked(backend, true) {
+		return
+	}
+	switch {
+	case turnStatusIsLive(turn.Status):
+		p.turnBackends[turnID] = backend
+		backend.liveTurns[turnID] = struct{}{}
+		return
+	case backend.draining:
+		p.turnBackends[turnID] = backend
+	default:
+		delete(p.turnBackends, turnID)
+	}
+	delete(backend.liveTurns, turnID)
+}
+
+func (p *hostedAgentProviderPool) deleteTurnBackend(turnID string) {
+	turnID = strings.TrimSpace(turnID)
+	if turnID == "" {
+		return
+	}
+	p.mu.Lock()
+	defer p.mu.Unlock()
+	delete(p.turnBackends, turnID)
+	for _, backend := range p.backends {
+		if backend.liveTurns != nil {
+			delete(backend.liveTurns, turnID)
+		}
+	}
+}
+
+func (p *hostedAgentProviderPool) recordInteraction(interaction *coreagent.Interaction, backend *hostedAgentPoolBackend) {
+	interactionID := interactionIDForInteraction(interaction)
+	if interactionID == "" || backend == nil {
+		return
+	}
+	p.mu.Lock()
+	defer p.mu.Unlock()
+	if p.backendAvailableLocked(backend, true) {
+		if (interaction.State == coreagent.InteractionStateResolved || interaction.State == coreagent.InteractionStateCanceled) && !backend.draining {
+			delete(p.interactionBackends, interactionID)
+		} else {
+			p.interactionBackends[interactionID] = backend
+		}
+		if turnID := strings.TrimSpace(interaction.TurnID); turnID != "" {
+			p.turnBackends[turnID] = backend
+		}
+		if sessionID := strings.TrimSpace(interaction.SessionID); sessionID != "" {
+			p.sessionBackends[sessionID] = backend
+		}
+	}
+}
+
+func (p *hostedAgentProviderPool) backendDraining(backend *hostedAgentPoolBackend) bool {
+	if backend == nil {
+		return false
+	}
+	p.mu.Lock()
+	defer p.mu.Unlock()
+	return backend.draining && !backend.closed
+}
+
+func (p *hostedAgentProviderPool) deleteInteractionBackend(interactionID string) {
+	interactionID = strings.TrimSpace(interactionID)
+	if interactionID == "" {
+		return
+	}
+	p.mu.Lock()
+	defer p.mu.Unlock()
+	delete(p.interactionBackends, interactionID)
+}
+
+func (p *hostedAgentProviderPool) healthLoop() {
+	ticker := time.NewTicker(p.policy.HealthCheckInterval)
+	defer ticker.Stop()
+	for {
+		select {
+		case <-p.ctx.Done():
+			return
+		case <-ticker.C:
+		}
+		p.ensureMinReady(p.ctx)
+		for _, backend := range p.readyBackends() {
+			if err := p.pingBackend(backend); err != nil {
+				slog.Warn("hosted agent runtime instance failed health check", "provider", p.name, "instance", backend.id, "error", err)
+				p.replaceBackend(backend)
+			}
+		}
+	}
+}
+
+func (p *hostedAgentProviderPool) maybeProbeAfterCallError(backend *hostedAgentPoolBackend, callErr error) {
+	if callErr == nil || backend == nil || errors.Is(callErr, core.ErrNotFound) || p.policy.RestartPolicy == config.HostedRuntimeRestartPolicyNever {
+		return
+	}
+	go func() {
+		if err := p.pingBackend(backend); err != nil {
+			slog.Warn("hosted agent runtime instance failed after provider call error", "provider", p.name, "instance", backend.id, "call_error", callErr, "ping_error", err)
+			p.replaceBackend(backend)
+		}
+	}()
+}
+
+func (p *hostedAgentProviderPool) pingBackend(backend *hostedAgentPoolBackend) error {
+	if backend == nil || backend.provider == nil {
+		return fmt.Errorf("runtime instance is unavailable")
+	}
+	timeout := p.policy.HealthCheckInterval
+	if timeout > 10*time.Second {
+		timeout = 10 * time.Second
+	}
+	ctx, cancel := context.WithTimeout(p.ctx, timeout)
+	defer cancel()
+	return backend.provider.Ping(ctx)
+}
+
+func (p *hostedAgentProviderPool) replaceBackend(backend *hostedAgentPoolBackend) {
+	if p.policy.RestartPolicy == config.HostedRuntimeRestartPolicyNever || !p.markBackendDraining(backend) {
+		return
+	}
+	if !p.addLifecycleWork() {
+		return
+	}
+	go func() {
+		defer p.lifecycleWG.Done()
+		// Replacement restores ready capacity. Session/turn recovery after the
+		// drained backend closes depends on the agent provider's durable store.
+		p.ensureMinReady(p.ctx)
+		if err := p.drainAndCloseBackend(backend); err != nil {
+			slog.Warn("failed to close unhealthy hosted agent runtime instance", "provider", p.name, "instance", backend.id, "error", err)
+		}
+	}()
+}
+
+func (p *hostedAgentProviderPool) addLifecycleWork() bool {
+	p.mu.Lock()
+	defer p.mu.Unlock()
+	if p.closed {
+		return false
+	}
+	p.lifecycleWG.Add(1)
+	return true
+}
+
+func (p *hostedAgentProviderPool) ensureMinReady(ctx context.Context) {
+	for {
+		p.mu.Lock()
+		if p.closed {
+			p.mu.Unlock()
+			return
+		}
+		ready := 0
+		for _, backend := range p.backends {
+			if p.backendAvailableLocked(backend, false) {
+				ready++
+			}
+		}
+		if ready+p.starting >= p.policy.MinReadyInstances {
+			p.mu.Unlock()
+			return
+		}
+		p.starting++
+		p.mu.Unlock()
+
+		_, err := p.startBackend(ctx)
+		p.mu.Lock()
+		p.starting--
+		p.mu.Unlock()
+		if err != nil {
+			slog.Warn("failed to start hosted agent runtime instance", "provider", p.name, "error", err)
+			return
+		}
+	}
+}
+
+func (p *hostedAgentProviderPool) startBackend(ctx context.Context) (*hostedAgentPoolBackend, error) {
+	startCtx, cancel := context.WithTimeout(ctx, p.policy.StartupTimeout)
+	defer cancel()
+	provider, err := startHostedAgentProviderInstance(startCtx, p.launch, p.hostServices, p.deps, false, nil)
+	if err != nil {
+		return nil, err
+	}
+	p.mu.Lock()
+	if p.closed {
+		p.mu.Unlock()
+		_ = provider.Close()
+		return nil, fmt.Errorf("hosted agent provider %q is closed", p.name)
+	}
+	p.nextID++
+	backend := &hostedAgentPoolBackend{
+		id:        p.nextID,
+		provider:  provider,
+		liveTurns: map[string]struct{}{},
+	}
+	p.backends = append(p.backends, backend)
+	p.mu.Unlock()
+	return backend, nil
+}
+
+func (p *hostedAgentProviderPool) markBackendDraining(backend *hostedAgentPoolBackend) bool {
+	if backend == nil {
+		return false
+	}
+	p.mu.Lock()
+	defer p.mu.Unlock()
+	if backend.draining || backend.closed {
+		return false
+	}
+	backend.draining = true
+	return true
+}
+
+func (p *hostedAgentProviderPool) drainAndCloseBackend(backend *hostedAgentPoolBackend) error {
+	if backend == nil {
+		return nil
+	}
+	p.mu.Lock()
+	if backend.closed || backend.closing {
+		p.mu.Unlock()
+		return nil
+	}
+	backend.closing = true
+	backend.draining = true
+	p.mu.Unlock()
+
+	deadline := time.Now().Add(p.policy.DrainTimeout)
+	for {
+		p.mu.Lock()
+		active := backend.active
+		liveTurns := len(backend.liveTurns)
+		if (active == 0 && liveTurns == 0) || time.Now().After(deadline) {
+			backend.closed = true
+			p.removeBackendLocked(backend)
+			p.mu.Unlock()
+			break
+		}
+		p.mu.Unlock()
+		time.Sleep(25 * time.Millisecond)
+	}
+	return backend.provider.Close()
+}
+
+func (p *hostedAgentProviderPool) removeBackendLocked(backend *hostedAgentPoolBackend) {
+	for i, candidate := range p.backends {
+		if candidate == backend {
+			p.backends = append(p.backends[:i], p.backends[i+1:]...)
+			break
+		}
+	}
+	for key, candidate := range p.sessionBackends {
+		if candidate == backend {
+			delete(p.sessionBackends, key)
+		}
+	}
+	for key, candidate := range p.turnBackends {
+		if candidate == backend {
+			delete(p.turnBackends, key)
+		}
+	}
+	for key, candidate := range p.interactionBackends {
+		if candidate == backend {
+			delete(p.interactionBackends, key)
+		}
+	}
+}
+
+func sessionIDForSession(session *coreagent.Session) string {
+	if session == nil {
+		return ""
+	}
+	return session.ID
+}
+
+func turnStatusIsLive(status coreagent.ExecutionStatus) bool {
+	switch status {
+	case coreagent.ExecutionStatusPending, coreagent.ExecutionStatusRunning, coreagent.ExecutionStatusWaitingForInput:
+		return true
+	default:
+		return false
+	}
+}
+
+func turnIDForTurn(turn *coreagent.Turn) string {
+	if turn == nil {
+		return ""
+	}
+	return turn.ID
+}
+
+func interactionIDForInteraction(interaction *coreagent.Interaction) string {
+	if interaction == nil {
+		return ""
+	}
+	return interaction.ID
+}

--- a/gestaltd/internal/bootstrap/provider_build.go
+++ b/gestaltd/internal/bootstrap/provider_build.go
@@ -941,6 +941,47 @@ func buildPluginProvider(ctx context.Context, name string, entry *config.Provide
 }
 
 func buildHostedAgentProvider(ctx context.Context, name string, entry *config.ProviderEntry, node yaml.Node, hostServices []providerhost.HostService, deps Deps) (coreagent.Provider, error) {
+	launch, err := prepareHostedAgentProviderLaunch(ctx, name, entry, node, deps)
+	if err != nil {
+		return nil, err
+	}
+	policy, err := entry.Runtime.LifecyclePolicy()
+	if err != nil {
+		launch.close()
+		return nil, fmt.Errorf("parse hosted agent runtime lifecycle policy: %w", err)
+	}
+	if policy.RestartPolicy == config.HostedRuntimeRestartPolicyAlways && entry.IndexedDB == nil {
+		launch.close()
+		return nil, fmt.Errorf("hosted agent runtime restart policy %q requires indexeddb persistence hook", config.HostedRuntimeRestartPolicyAlways)
+	}
+	return newHostedAgentProviderPool(ctx, launch, hostServices, deps, policy)
+}
+
+type hostedAgentProviderLaunch struct {
+	name            string
+	runtimeConfig   config.EffectiveHostedRuntime
+	runtimeProvider pluginruntime.Provider
+	runtimeOwned    bool
+	runtimePlan     HostedRuntimePlan
+	cfg             componentprovider.YAMLConfig
+	launch          pluginRuntimeLaunch
+	cleanup         func()
+}
+
+func (p *hostedAgentProviderLaunch) close() {
+	if p == nil {
+		return
+	}
+	if p.runtimeOwned && p.runtimeProvider != nil {
+		_ = p.runtimeProvider.Close()
+	}
+	if p.cleanup != nil {
+		p.cleanup()
+		p.cleanup = nil
+	}
+}
+
+func prepareHostedAgentProviderLaunch(ctx context.Context, name string, entry *config.ProviderEntry, node yaml.Node, deps Deps) (*hostedAgentProviderLaunch, error) {
 	runtimeConfig, runtimeProvider, runtimeOwned, err := effectiveConfiguredHostedRuntime(ctx, "providers.agent."+name, entry, deps)
 	if err != nil {
 		return nil, err
@@ -1006,22 +1047,54 @@ func buildHostedAgentProvider(ctx context.Context, name string, entry *config.Pr
 	}
 	cleanup = launch.cleanup
 
-	session, err := runtimeProvider.StartSession(ctx, buildHostedRuntimeStartSessionRequest(providermanifestv1.KindAgent, name, runtimeConfig))
+	preparedLaunch := &hostedAgentProviderLaunch{
+		name:            name,
+		runtimeConfig:   runtimeConfig,
+		runtimeProvider: runtimeProvider,
+		runtimeOwned:    runtimeOwned,
+		runtimePlan:     runtimePlan,
+		cfg:             cfg,
+		launch:          launch,
+		cleanup:         cleanup,
+	}
+	cleanup = nil
+	return preparedLaunch, nil
+}
+
+func startHostedAgentProviderInstance(ctx context.Context, launch *hostedAgentProviderLaunch, hostServices []providerhost.HostService, deps Deps, closeRuntime bool, cleanup func()) (coreagent.Provider, error) {
+	if launch == nil {
+		return nil, fmt.Errorf("hosted agent launch is required")
+	}
+	runtimeProvider := launch.runtimeProvider
+	if runtimeProvider == nil {
+		return nil, fmt.Errorf("agent provider: runtime is required")
+	}
+	cfg := launch.cfg
+	runtimePlan := launch.runtimePlan
+	name := launch.name
+	session, err := runtimeProvider.StartSession(ctx, buildHostedRuntimeStartSessionRequest(providermanifestv1.KindAgent, name, launch.runtimeConfig))
 	if err != nil {
-		if runtimeOwned {
+		if closeRuntime {
 			_ = runtimeProvider.Close()
+		}
+		if cleanup != nil {
+			cleanup()
 		}
 		return nil, fmt.Errorf("start agent runtime session: %w", err)
 	}
 	sessionID := session.ID
 	stopSession := true
+	closeOnFailure := closeRuntime
 	defer func() {
 		if !stopSession {
 			return
 		}
 		_ = stopPluginRuntimeSession(runtimeProvider, sessionID)
-		if runtimeOwned {
+		if closeOnFailure {
 			_ = runtimeProvider.Close()
+		}
+		if cleanup != nil {
+			cleanup()
 		}
 	}()
 	if err := waitForPluginRuntimeSessionReady(ctx, runtimeProvider, sessionID); err != nil {
@@ -1076,10 +1149,10 @@ func buildHostedAgentProvider(ctx context.Context, name string, entry *config.Pr
 	hostedPlugin, err := runtimeProvider.StartPlugin(ctx, pluginruntime.StartPluginRequest{
 		SessionID:     sessionID,
 		PluginName:    name,
-		Command:       launch.command,
-		Args:          launch.args,
+		Command:       launch.launch.command,
+		Args:          launch.launch.args,
 		Env:           startEnv,
-		BundleDir:     launch.bundleDir,
+		BundleDir:     launch.launch.bundleDir,
 		AllowedHosts:  allowedHosts,
 		DefaultAction: pluginruntime.PolicyAction(deps.Egress.DefaultAction),
 		HostBinary:    cfg.HostBinary,
@@ -1101,7 +1174,7 @@ func buildHostedAgentProvider(ctx context.Context, name string, entry *config.Pr
 			conn:         conn,
 			runtime:      runtimeProvider,
 			sessionID:    sessionID,
-			closeRuntime: runtimeOwned,
+			closeRuntime: closeRuntime,
 			cleanup:      cleanup,
 		},
 		Config: cfg.Config,
@@ -1113,6 +1186,7 @@ func buildHostedAgentProvider(ctx context.Context, name string, entry *config.Pr
 	}
 
 	stopSession = false
+	closeOnFailure = false
 	cleanup = nil
 	return provider, nil
 }

--- a/gestaltd/internal/config/config.go
+++ b/gestaltd/internal/config/config.go
@@ -451,10 +451,70 @@ type PluginIndexedDBConfig struct {
 }
 
 type HostedRuntimeConfig struct {
-	Provider string            `yaml:"provider,omitempty"`
-	Template string            `yaml:"template,omitempty"`
-	Image    string            `yaml:"image,omitempty"`
-	Metadata map[string]string `yaml:"metadata,omitempty"`
+	Provider            string                     `yaml:"provider,omitempty"`
+	Template            string                     `yaml:"template,omitempty"`
+	Image               string                     `yaml:"image,omitempty"`
+	Metadata            map[string]string          `yaml:"metadata,omitempty"`
+	MinReadyInstances   int                        `yaml:"minReadyInstances,omitempty"`
+	MaxReadyInstances   int                        `yaml:"maxReadyInstances,omitempty"`
+	StartupTimeout      string                     `yaml:"startupTimeout,omitempty"`
+	HealthCheckInterval string                     `yaml:"healthCheckInterval,omitempty"`
+	RestartPolicy       HostedRuntimeRestartPolicy `yaml:"restartPolicy,omitempty"`
+	DrainTimeout        string                     `yaml:"drainTimeout,omitempty"`
+}
+
+type HostedRuntimeRestartPolicy string
+
+const (
+	HostedRuntimeRestartPolicyAlways HostedRuntimeRestartPolicy = "always"
+	HostedRuntimeRestartPolicyNever  HostedRuntimeRestartPolicy = "never"
+)
+
+type HostedRuntimeLifecyclePolicy struct {
+	MinReadyInstances   int
+	MaxReadyInstances   int
+	StartupTimeout      time.Duration
+	HealthCheckInterval time.Duration
+	RestartPolicy       HostedRuntimeRestartPolicy
+	DrainTimeout        time.Duration
+}
+
+func (c *HostedRuntimeConfig) LifecyclePolicyFieldsSet() bool {
+	if c == nil {
+		return false
+	}
+	return c.MinReadyInstances != 0 ||
+		c.MaxReadyInstances != 0 ||
+		strings.TrimSpace(c.StartupTimeout) != "" ||
+		strings.TrimSpace(c.HealthCheckInterval) != "" ||
+		strings.TrimSpace(string(c.RestartPolicy)) != "" ||
+		strings.TrimSpace(c.DrainTimeout) != ""
+}
+
+func (c *HostedRuntimeConfig) LifecyclePolicy() (HostedRuntimeLifecyclePolicy, error) {
+	if c == nil {
+		return HostedRuntimeLifecyclePolicy{}, fmt.Errorf("runtime config is required")
+	}
+	startupTimeout, err := ParseDuration(strings.TrimSpace(c.StartupTimeout))
+	if err != nil {
+		return HostedRuntimeLifecyclePolicy{}, fmt.Errorf("startupTimeout: %w", err)
+	}
+	healthCheckInterval, err := ParseDuration(strings.TrimSpace(c.HealthCheckInterval))
+	if err != nil {
+		return HostedRuntimeLifecyclePolicy{}, fmt.Errorf("healthCheckInterval: %w", err)
+	}
+	drainTimeout, err := ParseDuration(strings.TrimSpace(c.DrainTimeout))
+	if err != nil {
+		return HostedRuntimeLifecyclePolicy{}, fmt.Errorf("drainTimeout: %w", err)
+	}
+	return HostedRuntimeLifecyclePolicy{
+		MinReadyInstances:   c.MinReadyInstances,
+		MaxReadyInstances:   c.MaxReadyInstances,
+		StartupTimeout:      startupTimeout,
+		HealthCheckInterval: healthCheckInterval,
+		RestartPolicy:       HostedRuntimeRestartPolicy(strings.TrimSpace(string(c.RestartPolicy))),
+		DrainTimeout:        drainTimeout,
+	}, nil
 }
 
 type WorkflowsConfig struct {

--- a/gestaltd/internal/config/config_test.go
+++ b/gestaltd/internal/config/config_test.go
@@ -3478,6 +3478,203 @@ server:
 	})
 }
 
+func TestLoadConfigAgentRuntimeLifecycleFields(t *testing.T) {
+	t.Parallel()
+
+	base := `
+providers:
+  agent:
+    simple:
+      source:
+        path: ./providers/agent/simple
+      indexeddb: agent_state
+      runtime:
+        provider: hosted
+        minReadyInstances: 1
+        maxReadyInstances: 2
+        startupTimeout: 5m
+        healthCheckInterval: 30s
+        restartPolicy: always
+        drainTimeout: 2m
+  indexeddb:
+    agent_state:
+      source:
+        path: ./providers/datastore/sqlite
+runtime:
+  providers:
+    hosted:
+      source:
+        path: ./providers/runtime/modal
+server:
+  encryptionKey: server-key
+`
+	t.Run("accepts required lifecycle fields directly under agent runtime", func(t *testing.T) {
+		t.Parallel()
+
+		path := mustWriteConfigFile(t, base)
+		cfg, err := Load(path)
+		if err != nil {
+			t.Fatalf("Load: %v", err)
+		}
+		runtimeCfg := cfg.Providers.Agent["simple"].Runtime
+		if runtimeCfg.MinReadyInstances != 1 || runtimeCfg.MaxReadyInstances != 2 {
+			t.Fatalf("runtime ready instances = %d/%d, want 1/2", runtimeCfg.MinReadyInstances, runtimeCfg.MaxReadyInstances)
+		}
+		if runtimeCfg.RestartPolicy != HostedRuntimeRestartPolicyAlways {
+			t.Fatalf("restartPolicy = %q, want %q", runtimeCfg.RestartPolicy, HostedRuntimeRestartPolicyAlways)
+		}
+	})
+
+	cases := []struct {
+		name string
+		yaml string
+		want string
+	}{
+		{
+			name: "rejects missing lifecycle fields",
+			yaml: `
+providers:
+  agent:
+    simple:
+      source:
+        path: ./providers/agent/simple
+      runtime:
+        provider: hosted
+        minReadyInstances: 1
+        startupTimeout: 5m
+        healthCheckInterval: 30s
+        restartPolicy: always
+        drainTimeout: 2m
+runtime:
+  providers:
+    hosted:
+      source:
+        path: ./providers/runtime/modal
+server:
+  encryptionKey: server-key
+`,
+			want: "providers.agent.simple.runtime.maxReadyInstances is required",
+		},
+		{
+			name: "rejects max below min",
+			yaml: `
+providers:
+  agent:
+    simple:
+      source:
+        path: ./providers/agent/simple
+      runtime:
+        provider: hosted
+        minReadyInstances: 2
+        maxReadyInstances: 1
+        startupTimeout: 5m
+        healthCheckInterval: 30s
+        restartPolicy: always
+        drainTimeout: 2m
+runtime:
+  providers:
+    hosted:
+      source:
+        path: ./providers/runtime/modal
+server:
+  encryptionKey: server-key
+`,
+			want: "providers.agent.simple.runtime.maxReadyInstances must be greater than or equal to minReadyInstances",
+		},
+		{
+			name: "rejects unknown restart policy",
+			yaml: `
+providers:
+  agent:
+    simple:
+      source:
+        path: ./providers/agent/simple
+      runtime:
+        provider: hosted
+        minReadyInstances: 1
+        maxReadyInstances: 2
+        startupTimeout: 5m
+        healthCheckInterval: 30s
+        restartPolicy: sometimes
+        drainTimeout: 2m
+runtime:
+  providers:
+    hosted:
+      source:
+        path: ./providers/runtime/modal
+server:
+  encryptionKey: server-key
+`,
+			want: "providers.agent.simple.runtime.restartPolicy must be one of",
+		},
+		{
+			name: "rejects restart without agent indexeddb",
+			yaml: `
+providers:
+  agent:
+    simple:
+      source:
+        path: ./providers/agent/simple
+      runtime:
+        provider: hosted
+        minReadyInstances: 1
+        maxReadyInstances: 2
+        startupTimeout: 5m
+        healthCheckInterval: 30s
+        restartPolicy: always
+        drainTimeout: 2m
+runtime:
+  providers:
+    hosted:
+      source:
+        path: ./providers/runtime/modal
+server:
+  encryptionKey: server-key
+`,
+			want: `providers.agent.simple.runtime.restartPolicy "always" requires providers.agent.simple.indexeddb as the provider persistence hook`,
+		},
+		{
+			name: "rejects lifecycle fields on plugin runtime",
+			yaml: `
+plugins:
+  service:
+    source:
+      path: ./plugins/service/manifest.yaml
+    runtime:
+      provider: hosted
+      minReadyInstances: 1
+      maxReadyInstances: 2
+      startupTimeout: 5m
+      healthCheckInterval: 30s
+      restartPolicy: always
+      drainTimeout: 2m
+runtime:
+  providers:
+    hosted:
+      source:
+        path: ./providers/runtime/modal
+server:
+  encryptionKey: server-key
+`,
+			want: "plugins.service.runtime lifecycle fields are only supported on providers.agent.*.runtime",
+		},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+
+			path := mustWriteConfigFile(t, tc.yaml)
+			_, err := Load(path)
+			if err == nil {
+				t.Fatal("Load: expected error, got nil")
+			}
+			if !strings.Contains(err.Error(), tc.want) {
+				t.Fatalf("unexpected error: %v", err)
+			}
+		})
+	}
+}
+
 func TestLoadRejectsUnknownProviderFields(t *testing.T) {
 	t.Parallel()
 

--- a/gestaltd/internal/config/config_validate.go
+++ b/gestaltd/internal/config/config_validate.go
@@ -475,19 +475,11 @@ func validatePlugin(cfg *Config, name string, entry *ProviderEntry, sourceSyntax
 		}
 	}
 	if entry.Runtime != nil {
-		entry.Runtime.Provider = strings.TrimSpace(entry.Runtime.Provider)
-		entry.Runtime.Template = strings.TrimSpace(entry.Runtime.Template)
-		entry.Runtime.Image = strings.TrimSpace(entry.Runtime.Image)
-		trimmed := make(map[string]string, len(entry.Runtime.Metadata))
-		for key, value := range entry.Runtime.Metadata {
-			trimmedKey := strings.TrimSpace(key)
-			if trimmedKey == "" {
-				return fmt.Errorf("config validation: plugins.%s.runtime.metadata keys must be non-empty", name)
-			}
-			trimmed[trimmedKey] = strings.TrimSpace(value)
+		if err := normalizeHostedRuntimeConfig("plugins."+name, entry.Runtime); err != nil {
+			return err
 		}
-		if entry.Runtime.Metadata != nil {
-			entry.Runtime.Metadata = trimmed
+		if entry.Runtime.LifecyclePolicyFieldsSet() {
+			return fmt.Errorf("config validation: plugins.%s.runtime lifecycle fields are only supported on providers.agent.*.runtime", name)
 		}
 	}
 	seenInvokes := make(map[string]int, len(entry.Invokes))
@@ -664,6 +656,11 @@ func validateAgentConfig(cfg *Config) error {
 				entry.IndexedDB.ObjectStores[i] = strings.TrimSpace(store)
 			}
 		}
+		if entry.Runtime != nil {
+			if err := normalizeHostedRuntimeConfig("providers.agent."+name, entry.Runtime); err != nil {
+				return err
+			}
+		}
 		if err := validateAgentProviderFields(cfg, name, entry); err != nil {
 			return err
 		}
@@ -710,6 +707,11 @@ func validateAgentProviderFields(cfg *Config, name string, entry *ProviderEntry)
 	if _, err := cfg.EffectiveHostedRuntime(subject, entry); err != nil {
 		return err
 	}
+	if entry.Runtime != nil {
+		if err := validateHostedAgentRuntimeLifecyclePolicy(subject, entry); err != nil {
+			return err
+		}
+	}
 	if entry.IndexedDB == nil {
 		return nil
 	}
@@ -726,6 +728,68 @@ func validateAgentProviderFields(cfg *Config, name string, entry *ProviderEntry)
 	}
 	if _, err := cfg.EffectiveAgentIndexedDB(name, entry); err != nil {
 		return err
+	}
+	return nil
+}
+
+func normalizeHostedRuntimeConfig(subject string, runtimeCfg *HostedRuntimeConfig) error {
+	if runtimeCfg == nil {
+		return nil
+	}
+	runtimeCfg.Provider = strings.TrimSpace(runtimeCfg.Provider)
+	runtimeCfg.Template = strings.TrimSpace(runtimeCfg.Template)
+	runtimeCfg.Image = strings.TrimSpace(runtimeCfg.Image)
+	runtimeCfg.StartupTimeout = strings.TrimSpace(runtimeCfg.StartupTimeout)
+	runtimeCfg.HealthCheckInterval = strings.TrimSpace(runtimeCfg.HealthCheckInterval)
+	runtimeCfg.RestartPolicy = HostedRuntimeRestartPolicy(strings.TrimSpace(string(runtimeCfg.RestartPolicy)))
+	runtimeCfg.DrainTimeout = strings.TrimSpace(runtimeCfg.DrainTimeout)
+	trimmed := make(map[string]string, len(runtimeCfg.Metadata))
+	for key, value := range runtimeCfg.Metadata {
+		trimmedKey := strings.TrimSpace(key)
+		if trimmedKey == "" {
+			return fmt.Errorf("config validation: %s.runtime.metadata keys must be non-empty", subject)
+		}
+		trimmed[trimmedKey] = strings.TrimSpace(value)
+	}
+	if runtimeCfg.Metadata != nil {
+		runtimeCfg.Metadata = trimmed
+	}
+	return nil
+}
+
+func validateHostedAgentRuntimeLifecyclePolicy(subject string, entry *ProviderEntry) error {
+	if entry == nil || entry.Runtime == nil {
+		return nil
+	}
+	runtimeCfg := entry.Runtime
+	if runtimeCfg.MinReadyInstances <= 0 {
+		return fmt.Errorf("config validation: %s.runtime.minReadyInstances is required and must be greater than 0", subject)
+	}
+	if runtimeCfg.MaxReadyInstances <= 0 {
+		return fmt.Errorf("config validation: %s.runtime.maxReadyInstances is required and must be greater than 0", subject)
+	}
+	if runtimeCfg.MaxReadyInstances < runtimeCfg.MinReadyInstances {
+		return fmt.Errorf("config validation: %s.runtime.maxReadyInstances must be greater than or equal to minReadyInstances", subject)
+	}
+	if strings.TrimSpace(runtimeCfg.StartupTimeout) == "" {
+		return fmt.Errorf("config validation: %s.runtime.startupTimeout is required", subject)
+	}
+	if strings.TrimSpace(runtimeCfg.HealthCheckInterval) == "" {
+		return fmt.Errorf("config validation: %s.runtime.healthCheckInterval is required", subject)
+	}
+	if strings.TrimSpace(runtimeCfg.DrainTimeout) == "" {
+		return fmt.Errorf("config validation: %s.runtime.drainTimeout is required", subject)
+	}
+	switch runtimeCfg.RestartPolicy {
+	case HostedRuntimeRestartPolicyAlways, HostedRuntimeRestartPolicyNever:
+	default:
+		return fmt.Errorf("config validation: %s.runtime.restartPolicy must be one of %q or %q", subject, HostedRuntimeRestartPolicyAlways, HostedRuntimeRestartPolicyNever)
+	}
+	if runtimeCfg.RestartPolicy == HostedRuntimeRestartPolicyAlways && entry.IndexedDB == nil {
+		return fmt.Errorf("config validation: %s.runtime.restartPolicy %q requires %s.indexeddb as the provider persistence hook; runtime replacement does not make backend-local state durable", subject, HostedRuntimeRestartPolicyAlways, subject)
+	}
+	if _, err := runtimeCfg.LifecyclePolicy(); err != nil {
+		return fmt.Errorf("config validation: %s.runtime.%w", subject, err)
 	}
 	return nil
 }


### PR DESCRIPTION
## Summary

Adds a host-managed lifecycle policy for runtime-backed agent providers. The policy is configured directly on `providers.agent.*.runtime` and is intentionally agent-only in this PR. There is no `runtime.hosting` wrapper.

New interface:

```yaml
providers:
  agent:
    assistant:
      source:
        path: ./providers/agent/simple
      indexeddb: agent_state
      runtime:
        provider: runtime/modal
        template: python-dev
        image: ghcr.io/valon/gestalt-python-runtime:latest
        metadata:
          tenant: eng
        minReadyInstances: 1
        maxReadyInstances: 2
        startupTimeout: 5m
        healthCheckInterval: 30s
        restartPolicy: always
        drainTimeout: 2m
  indexeddb:
    agent_state:
      source:
        path: ./providers/datastore/sqlite
```

Field behavior:

- `minReadyInstances`: required warm floor started at bootstrap and maintained by health checks.
- `maxReadyInstances`: required demand scale-out cap. When all ready backends are busy and ready capacity is below `maxReadyInstances`, the host starts another backend in the background for subsequent unpinned work while the triggering request still uses already-ready capacity.
- `startupTimeout`: bounds runtime session/provider startup for each hosted agent backend.
- `healthCheckInterval`: controls host-side `Ping` health checks.
- `restartPolicy`: one of `always` or `never`.
- `restartPolicy: always`: restarts failed runtime instances to restore ready capacity and requires `providers.agent.<name>.indexeddb` as the provider persistence hook. Runtime replacement does not make backend-local session/turn state durable by itself; providers must persist recoverable state through the hook.
- `drainTimeout`: bounds in-flight calls and live tracked turns before a backend is closed.

## Implementation

- Refactors hosted agent startup into a reusable launch plan plus backend instance starter.
- Adds a host-managed hosted agent provider pool that starts ready runtime instances through the existing runtime lifecycle: `StartSession -> BindHostService -> StartPlugin -> DialHostedAgent`.
- Preserves session, turn, and interaction affinity across a bounded pool.
- Scales out on demand up to `maxReadyInstances` without blocking the request that observed pressure on a cold start.
- Allows existing pinned resources to continue using draining/closing backends while new unpinned work routes only to ready instances.
- Tracks live turns so drain does not close a backend just because the initiating RPC returned.
- Waits for lifecycle goroutines before closing shared runtime launch resources.
- Health-checks backend providers with `Ping`, drains unhealthy instances, and restarts them when `restartPolicy: always`.
- Updates agent runtime readiness to ping every configured agent provider, not only the default selection, so explicit provider routes are covered by `/ready`.
- Fans out provider and backend readiness probes in parallel so warm pools do not consume the entire `/ready` timeout serially.
- Rejects lifecycle fields on plugin runtime config for now rather than silently ignoring them.

## Example

A Modal-backed agent provider that keeps one warm runtime session available, can scale to two ready sessions under concurrent demand, and gives the provider a durable store to use across replacement:

```yaml
providers:
  agent:
    slack_agent:
      source:
        path: ./providers/agent/slack
      indexeddb: agent_state
      runtime:
        provider: runtime/modal
        minReadyInstances: 1
        maxReadyInstances: 2
        startupTimeout: 5m
        healthCheckInterval: 30s
        restartPolicy: always
        drainTimeout: 2m
  indexeddb:
    agent_state:
      source:
        path: ./providers/datastore/sqlite
```

## Testing

- `go test ./internal/config -run TestLoadConfigAgentRuntimeLifecycleFields`
- `go test ./internal/bootstrap -run 'TestAgentRuntimePingChecksConfiguredProviders|TestAgentRuntimePingChecksConfiguredProvidersInParallel|TestHostedAgentProviderPoolPingChecksReadyBackendsInParallel|TestAgentRuntimeConfig(ScalesOutHostedAgentWarmPool|RestartsUnhealthyHostedAgent|StartsHostedAgentWarmPool)$'`
- `go test ./...`
- `golangci-lint run ./...`

## Review feedback applied

- Keep pinned session/turn/interaction traffic on draining and closing backends until close.
- Track live turns as part of draining instead of only tracking synchronous RPC occupancy.
- Drain all backends concurrently during provider shutdown.
- Wait for lifecycle goroutines before closing shared runtime launch resources.
- Remove the misleading `onFailure` policy value until there is a distinct implementation for it.
- Require agent IndexedDB when restart replacement is enabled, but document the actual contract: host replacement restores capacity; provider-managed persistence is what makes session/turn state durable.
- Ping all configured agent providers in readiness so non-default explicit providers cannot be down while `/ready` stays green.
- Parallelize readiness probes across providers and ready backends.
- Implement bounded non-blocking scale-out now so `maxReadyInstances` is an actual cap, not a placeholder field.
