### PR TITLE
gestaltd: include agent provider in readiness

### DIFF
--- a/gestaltd/internal/bootstrap/agent_control.go
+++ b/gestaltd/internal/bootstrap/agent_control.go
@@ -1,6 +1,10 @@
 package bootstrap
 
-import coreagent "github.com/valon-technologies/gestalt/server/core/agent"
+import (
+	"context"
+
+	coreagent "github.com/valon-technologies/gestalt/server/core/agent"
+)
 
 // AgentControl exposes the configured agent-provider selection surface that
 // higher-level manager and HTTP layers build on.
@@ -8,6 +12,7 @@ type AgentControl interface {
 	ResolveProvider(name string) (coreagent.Provider, error)
 	ResolveProviderSelection(name string) (providerName string, provider coreagent.Provider, err error)
 	ProviderNames() []string
+	Ping(context.Context) error
 }
 
 var _ AgentControl = (*agentRuntime)(nil)

--- a/gestaltd/internal/bootstrap/agent_runtime.go
+++ b/gestaltd/internal/bootstrap/agent_runtime.go
@@ -216,6 +216,29 @@ func (r *agentRuntime) ProviderNames() []string {
 	return names
 }
 
+func (r *agentRuntime) Ping(ctx context.Context) error {
+	if r == nil {
+		return fmt.Errorf("agent runtime is not configured")
+	}
+	r.mu.RLock()
+	hasProviders := len(r.providers) > 0
+	defaultProviderName := strings.TrimSpace(r.defaultProviderName)
+	r.mu.RUnlock()
+
+	if !hasProviders && defaultProviderName == "" {
+		return nil
+	}
+
+	providerName, provider, err := r.ResolveProviderSelection("")
+	if err != nil {
+		return err
+	}
+	if err := provider.Ping(ctx); err != nil {
+		return fmt.Errorf("agent provider %q unavailable: %w", providerName, err)
+	}
+	return nil
+}
+
 func (r *agentRuntime) ExecuteTool(ctx context.Context, req coreagent.ExecuteToolRequest) (*coreagent.ExecuteToolResponse, error) {
 	if r == nil {
 		return nil, fmt.Errorf("agent runtime is not configured")

--- a/gestaltd/internal/bootstrap/agent_runtime_test.go
+++ b/gestaltd/internal/bootstrap/agent_runtime_test.go
@@ -3,6 +3,7 @@ package bootstrap
 import (
 	"context"
 	"encoding/json"
+	"errors"
 	"net/http"
 	"net/http/httptest"
 	"strings"
@@ -76,6 +77,46 @@ func cloneAnyMap(src map[string]any) map[string]any {
 		out[key] = value
 	}
 	return out
+}
+
+type pingAgentProvider struct {
+	coreagent.UnimplementedProvider
+	calls *int
+	err   error
+}
+
+func (p *pingAgentProvider) Ping(context.Context) error {
+	if p.calls != nil {
+		(*p.calls)++
+	}
+	return p.err
+}
+
+func TestAgentRuntimePingChecksSelectedProviderOnly(t *testing.T) {
+	t.Parallel()
+
+	defaultCalls := 0
+	canaryCalls := 0
+	runtime := &agentRuntime{
+		defaultProviderName: "simple",
+		providers: map[string]coreagent.Provider{
+			"canary": &pingAgentProvider{
+				calls: &canaryCalls,
+				err:   errors.New("canary down"),
+			},
+			"simple": &pingAgentProvider{calls: &defaultCalls},
+		},
+	}
+
+	if err := runtime.Ping(context.Background()); err != nil {
+		t.Fatalf("Ping: %v", err)
+	}
+	if defaultCalls != 1 {
+		t.Fatalf("default provider Ping calls = %d, want 1", defaultCalls)
+	}
+	if canaryCalls != 0 {
+		t.Fatalf("canary provider Ping calls = %d, want 0", canaryCalls)
+	}
 }
 
 func TestAgentRuntimeConfigSelectedProviderStartsSessionWithRuntimeFields(t *testing.T) {

--- a/gestaltd/internal/pluginruntime/dial.go
+++ b/gestaltd/internal/pluginruntime/dial.go
@@ -8,6 +8,7 @@ import (
 	"net/url"
 	"path/filepath"
 	"strings"
+	"time"
 
 	proto "github.com/valon-technologies/gestalt/sdk/go/gen/v1"
 	"github.com/valon-technologies/gestalt/server/internal/metricutil"
@@ -16,6 +17,7 @@ import (
 	"go.opentelemetry.io/otel/metric"
 	"go.opentelemetry.io/otel/trace"
 	"google.golang.org/grpc"
+	"google.golang.org/grpc/connectivity"
 	"google.golang.org/grpc/credentials"
 	"google.golang.org/grpc/credentials/insecure"
 )
@@ -45,6 +47,8 @@ type dialTelemetryProviders struct {
 	meterProvider  metric.MeterProvider
 	tracerProvider trace.TracerProvider
 }
+
+const hostedGRPCReadyTimeout = 30 * time.Second
 
 func (p dialTelemetryProviders) MeterProvider() metric.MeterProvider {
 	return p.meterProvider
@@ -128,7 +132,35 @@ func dialHostedConn(ctx context.Context, target string, opts ...DialOption) (*gr
 	if err != nil {
 		return nil, err
 	}
+	if err := waitForHostedGRPCReady(ctx, conn); err != nil {
+		_ = conn.Close()
+		return nil, err
+	}
 	return conn, nil
+}
+
+func waitForHostedGRPCReady(ctx context.Context, conn *grpc.ClientConn) error {
+	if ctx == nil {
+		ctx = context.Background()
+	}
+	readyCtx, cancel := context.WithTimeout(ctx, hostedGRPCReadyTimeout)
+	defer cancel()
+	for {
+		state := conn.GetState()
+		if state == connectivity.Ready {
+			return nil
+		}
+		if state == connectivity.Shutdown {
+			return fmt.Errorf("hosted plugin gRPC connection shut down before ready")
+		}
+
+		waitCtx, cancel := context.WithTimeout(readyCtx, 25*time.Millisecond)
+		changed := conn.WaitForStateChange(waitCtx, state)
+		cancel()
+		if !changed && readyCtx.Err() != nil {
+			return fmt.Errorf("waiting for hosted plugin gRPC ready: %w", readyCtx.Err())
+		}
+	}
 }
 
 func (c *dialedHostedPluginConn) Lifecycle() proto.ProviderLifecycleClient {

--- a/gestaltd/internal/providerhost/agent_client.go
+++ b/gestaltd/internal/providerhost/agent_client.go
@@ -10,7 +10,6 @@ import (
 	"github.com/valon-technologies/gestalt/server/internal/egress"
 	"google.golang.org/grpc/codes"
 	"google.golang.org/grpc/status"
-	"google.golang.org/protobuf/types/known/emptypb"
 )
 
 type AgentExecConfig struct {
@@ -310,10 +309,19 @@ func (r *remoteAgent) GetCapabilities(ctx context.Context, req coreagent.GetCapa
 }
 
 func (r *remoteAgent) Ping(ctx context.Context) error {
-	ctx, cancel := providerCallContext(ctx)
+	if err := CheckRuntimeProviderHealth(ctx, r.runtime); err != nil {
+		return err
+	}
+	capabilitiesCtx, cancel := providerCallContext(ctx)
 	defer cancel()
-	_, err := r.runtime.HealthCheck(ctx, &emptypb.Empty{})
-	return err
+	resp, err := r.client.GetCapabilities(capabilitiesCtx, &proto.GetAgentProviderCapabilitiesRequest{})
+	if err != nil {
+		return fmt.Errorf("agent provider capabilities check failed: %w", err)
+	}
+	if resp == nil {
+		return fmt.Errorf("agent provider capabilities check returned nil response")
+	}
+	return nil
 }
 
 func (r *remoteAgent) Close() error {

--- a/gestaltd/internal/providerhost/agent_client_test.go
+++ b/gestaltd/internal/providerhost/agent_client_test.go
@@ -1,0 +1,89 @@
+package providerhost
+
+import (
+	"context"
+	"errors"
+	"testing"
+
+	proto "github.com/valon-technologies/gestalt/sdk/go/gen/v1"
+	"google.golang.org/grpc"
+	"google.golang.org/grpc/codes"
+	"google.golang.org/grpc/status"
+)
+
+type fakeAgentProviderClient struct {
+	getCapabilities func(context.Context, *proto.GetAgentProviderCapabilitiesRequest, ...grpc.CallOption) (*proto.AgentProviderCapabilities, error)
+}
+
+func (c *fakeAgentProviderClient) CreateSession(context.Context, *proto.CreateAgentProviderSessionRequest, ...grpc.CallOption) (*proto.AgentSession, error) {
+	return nil, errors.New("unexpected CreateSession call")
+}
+
+func (c *fakeAgentProviderClient) GetSession(context.Context, *proto.GetAgentProviderSessionRequest, ...grpc.CallOption) (*proto.AgentSession, error) {
+	return nil, errors.New("unexpected GetSession call")
+}
+
+func (c *fakeAgentProviderClient) ListSessions(context.Context, *proto.ListAgentProviderSessionsRequest, ...grpc.CallOption) (*proto.ListAgentProviderSessionsResponse, error) {
+	return nil, errors.New("unexpected ListSessions call")
+}
+
+func (c *fakeAgentProviderClient) UpdateSession(context.Context, *proto.UpdateAgentProviderSessionRequest, ...grpc.CallOption) (*proto.AgentSession, error) {
+	return nil, errors.New("unexpected UpdateSession call")
+}
+
+func (c *fakeAgentProviderClient) CreateTurn(context.Context, *proto.CreateAgentProviderTurnRequest, ...grpc.CallOption) (*proto.AgentTurn, error) {
+	return nil, errors.New("unexpected CreateTurn call")
+}
+
+func (c *fakeAgentProviderClient) GetTurn(context.Context, *proto.GetAgentProviderTurnRequest, ...grpc.CallOption) (*proto.AgentTurn, error) {
+	return nil, errors.New("unexpected GetTurn call")
+}
+
+func (c *fakeAgentProviderClient) ListTurns(context.Context, *proto.ListAgentProviderTurnsRequest, ...grpc.CallOption) (*proto.ListAgentProviderTurnsResponse, error) {
+	return nil, errors.New("unexpected ListTurns call")
+}
+
+func (c *fakeAgentProviderClient) CancelTurn(context.Context, *proto.CancelAgentProviderTurnRequest, ...grpc.CallOption) (*proto.AgentTurn, error) {
+	return nil, errors.New("unexpected CancelTurn call")
+}
+
+func (c *fakeAgentProviderClient) ListTurnEvents(context.Context, *proto.ListAgentProviderTurnEventsRequest, ...grpc.CallOption) (*proto.ListAgentProviderTurnEventsResponse, error) {
+	return nil, errors.New("unexpected ListTurnEvents call")
+}
+
+func (c *fakeAgentProviderClient) GetInteraction(context.Context, *proto.GetAgentProviderInteractionRequest, ...grpc.CallOption) (*proto.AgentInteraction, error) {
+	return nil, errors.New("unexpected GetInteraction call")
+}
+
+func (c *fakeAgentProviderClient) ListInteractions(context.Context, *proto.ListAgentProviderInteractionsRequest, ...grpc.CallOption) (*proto.ListAgentProviderInteractionsResponse, error) {
+	return nil, errors.New("unexpected ListInteractions call")
+}
+
+func (c *fakeAgentProviderClient) ResolveInteraction(context.Context, *proto.ResolveAgentProviderInteractionRequest, ...grpc.CallOption) (*proto.AgentInteraction, error) {
+	return nil, errors.New("unexpected ResolveInteraction call")
+}
+
+func (c *fakeAgentProviderClient) GetCapabilities(ctx context.Context, req *proto.GetAgentProviderCapabilitiesRequest, opts ...grpc.CallOption) (*proto.AgentProviderCapabilities, error) {
+	if c.getCapabilities != nil {
+		return c.getCapabilities(ctx, req, opts...)
+	}
+	return &proto.AgentProviderCapabilities{}, nil
+}
+
+func TestRemoteAgentPingRequiresAgentProviderSurface(t *testing.T) {
+	t.Parallel()
+
+	agent := &remoteAgent{
+		client: &fakeAgentProviderClient{
+			getCapabilities: func(context.Context, *proto.GetAgentProviderCapabilitiesRequest, ...grpc.CallOption) (*proto.AgentProviderCapabilities, error) {
+				return nil, status.Error(codes.Unimplemented, "unknown service")
+			},
+		},
+		runtime: &fakeProviderLifecycleClient{},
+	}
+
+	err := agent.Ping(context.Background())
+	if status.Code(err) != codes.Unimplemented {
+		t.Fatalf("Ping error code = %s, want %s (err=%v)", status.Code(err), codes.Unimplemented, err)
+	}
+}

--- a/gestaltd/internal/providerhost/runtime_client.go
+++ b/gestaltd/internal/providerhost/runtime_client.go
@@ -3,6 +3,7 @@ package providerhost
 import (
 	"context"
 	"fmt"
+	"strings"
 	"time"
 
 	proto "github.com/valon-technologies/gestalt/sdk/go/gen/v1"
@@ -77,6 +78,29 @@ func ConfigureRuntimeProvider(ctx context.Context, client proto.ProviderLifecycl
 		Version:     configuredMeta.GetVersion(),
 		Warnings:    append([]string(nil), configuredMeta.GetWarnings()...),
 	}, nil
+}
+
+func CheckRuntimeProviderHealth(ctx context.Context, client proto.ProviderLifecycleClient) error {
+	if client == nil {
+		return fmt.Errorf("runtime client is required")
+	}
+	healthCtx, cancel := providerCallContext(ctx)
+	defer cancel()
+	resp, err := client.HealthCheck(healthCtx, &emptypb.Empty{})
+	if err != nil {
+		return err
+	}
+	if resp == nil {
+		return fmt.Errorf("provider health check returned nil response")
+	}
+	if !resp.GetReady() {
+		message := strings.TrimSpace(resp.GetMessage())
+		if message == "" {
+			message = "not ready"
+		}
+		return fmt.Errorf("provider health check failed: %s", message)
+	}
+	return nil
 }
 
 func validateRuntimeProtocol(meta *proto.ProviderIdentity) error {

--- a/gestaltd/internal/server/runtime.go
+++ b/gestaltd/internal/server/runtime.go
@@ -21,7 +21,11 @@ import (
 	"golang.org/x/net/http2/h2c"
 )
 
-const runtimeShutdownTimeout = 15 * time.Second
+const (
+	runtimeShutdownTimeout        = 15 * time.Second
+	readinessDatastorePingTimeout = 2 * time.Second
+	readinessAgentPingTimeout     = 5 * time.Second
+)
 
 func httpCatalogConnectionMap(connMaps bootstrap.ConnectionMaps) map[string]string {
 	return connMaps.APIConnection
@@ -94,10 +98,18 @@ func Run(ctx context.Context, cfg *config.Config, result *bootstrap.Result) erro
 				return "providers loading"
 			}
 
-			pingCtx, cancel := context.WithTimeout(context.Background(), 2*time.Second)
+			pingCtx, cancel := context.WithTimeout(context.Background(), readinessDatastorePingTimeout)
 			defer cancel()
 			if err := result.Services.Ping(pingCtx); err != nil {
 				return "datastore unavailable"
+			}
+			if result.AgentControl != nil {
+				agentPingCtx, agentPingCancel := context.WithTimeout(context.Background(), readinessAgentPingTimeout)
+				defer agentPingCancel()
+				if err := result.AgentControl.Ping(agentPingCtx); err != nil {
+					slog.Warn("agent provider readiness check failed", "error", err)
+					return "agent providers unavailable"
+				}
 			}
 			return ""
 		},


### PR DESCRIPTION
## Summary
- waits for hosted provider gRPC channels to reach READY before gestaltd publishes remote providers
- includes the default selected agent provider in `/ready`, so Cloud Run does not route traffic to revisions whose default agent provider cannot serve requests
- uses separate datastore and agent readiness timeout budgets so one probe cannot starve the other
- tightens remote AgentProvider `Ping` to require lifecycle `HealthCheck` plus a real `AgentProvider.GetCapabilities` RPC; `Unimplemented` is now a readiness failure

## Interfaces
No REST or YAML configuration changes.

`AgentControl` exposes readiness through:

```go
Ping(ctx context.Context) error
```

`AgentProvider` implementations still implement:

```go
Ping(ctx context.Context) error
GetCapabilities(ctx context.Context, req agent.GetCapabilitiesRequest) (*agent.ProviderCapabilities, error)
```

For remote providers, gestaltd validates provider reachability by calling provider lifecycle `HealthCheck` and `AgentProvider.GetCapabilities`.

## Examples
```http
GET /ready
503 {"status":"agent providers unavailable"}
```

```bash
GESTALT_URL=https://valon.tools gestalt agent sessions list --state active --format json
```

That CLI request should not be routed to a new revision until the default selected agent provider is callable.

## Validation
- `cd gestaltd && go test ./internal/pluginruntime ./internal/providerhost ./internal/bootstrap ./internal/server`
- `cd gestaltd && go test ./...`
