### PR TITLE
gestaltd: give indexeddb schema changes migration budget

### DIFF
--- a/gestaltd/internal/providerhost/indexeddb_client.go
+++ b/gestaltd/internal/providerhost/indexeddb_client.go
@@ -63,7 +63,7 @@ func (r *remoteIndexedDB) ObjectStore(name string) indexeddb.ObjectStore {
 }
 
 func (r *remoteIndexedDB) CreateObjectStore(ctx context.Context, name string, schema indexeddb.ObjectStoreSchema) error {
-	ctx, cancel := providerCallContext(ctx)
+	ctx, cancel := providerMigrationContext(ctx)
 	defer cancel()
 	indexes := make([]*proto.IndexSchema, len(schema.Indexes))
 	for i, idx := range schema.Indexes {
@@ -83,7 +83,7 @@ func (r *remoteIndexedDB) CreateObjectStore(ctx context.Context, name string, sc
 }
 
 func (r *remoteIndexedDB) DeleteObjectStore(ctx context.Context, name string) error {
-	ctx, cancel := providerCallContext(ctx)
+	ctx, cancel := providerMigrationContext(ctx)
 	defer cancel()
 	_, err := r.client.DeleteObjectStore(ctx, &proto.DeleteObjectStoreRequest{Name: name})
 	return grpcToDatastoreErr(err)

--- a/gestaltd/internal/providerhost/indexeddb_client_test.go
+++ b/gestaltd/internal/providerhost/indexeddb_client_test.go
@@ -1,0 +1,60 @@
+package providerhost
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	proto "github.com/valon-technologies/gestalt/sdk/go/gen/v1"
+	"github.com/valon-technologies/gestalt/server/core/indexeddb"
+	"google.golang.org/grpc"
+	"google.golang.org/protobuf/types/known/emptypb"
+)
+
+type deadlineIndexedDBClient struct {
+	proto.IndexedDBClient
+	createObjectStore func(context.Context, *proto.CreateObjectStoreRequest, ...grpc.CallOption) (*emptypb.Empty, error)
+	deleteObjectStore func(context.Context, *proto.DeleteObjectStoreRequest, ...grpc.CallOption) (*emptypb.Empty, error)
+}
+
+func (c *deadlineIndexedDBClient) CreateObjectStore(ctx context.Context, req *proto.CreateObjectStoreRequest, opts ...grpc.CallOption) (*emptypb.Empty, error) {
+	return c.createObjectStore(ctx, req, opts...)
+}
+
+func (c *deadlineIndexedDBClient) DeleteObjectStore(ctx context.Context, req *proto.DeleteObjectStoreRequest, opts ...grpc.CallOption) (*emptypb.Empty, error) {
+	return c.deleteObjectStore(ctx, req, opts...)
+}
+
+func TestRemoteIndexedDBSchemaChangesUseMigrationTimeout(t *testing.T) {
+	t.Parallel()
+
+	assertMigrationDeadline := func(t *testing.T, ctx context.Context) {
+		t.Helper()
+		deadline, ok := ctx.Deadline()
+		if !ok {
+			t.Fatal("schema change context has no deadline")
+		}
+		if remaining := time.Until(deadline); remaining <= providerRPCTimeout {
+			t.Fatalf("schema change deadline remaining = %s, want greater than provider RPC timeout %s", remaining, providerRPCTimeout)
+		}
+	}
+
+	client := &deadlineIndexedDBClient{
+		createObjectStore: func(ctx context.Context, _ *proto.CreateObjectStoreRequest, _ ...grpc.CallOption) (*emptypb.Empty, error) {
+			assertMigrationDeadline(t, ctx)
+			return &emptypb.Empty{}, nil
+		},
+		deleteObjectStore: func(ctx context.Context, _ *proto.DeleteObjectStoreRequest, _ ...grpc.CallOption) (*emptypb.Empty, error) {
+			assertMigrationDeadline(t, ctx)
+			return &emptypb.Empty{}, nil
+		},
+	}
+	db := &remoteIndexedDB{client: client}
+
+	if err := db.CreateObjectStore(context.Background(), "api_tokens", indexeddb.ObjectStoreSchema{}); err != nil {
+		t.Fatalf("CreateObjectStore: %v", err)
+	}
+	if err := db.DeleteObjectStore(context.Background(), "api_tokens"); err != nil {
+		t.Fatalf("DeleteObjectStore: %v", err)
+	}
+}

--- a/gestaltd/internal/providerhost/runtime_client.go
+++ b/gestaltd/internal/providerhost/runtime_client.go
@@ -125,6 +125,13 @@ func providerCallContext(parent context.Context) (context.Context, context.Cance
 	return context.WithTimeout(parent, providerRPCTimeout)
 }
 
+func providerMigrationContext(parent context.Context) (context.Context, context.CancelFunc) {
+	if parent == nil {
+		parent = context.Background()
+	}
+	return context.WithTimeout(parent, providerMigrateTimeout)
+}
+
 func providerStreamContext(parent context.Context) (context.Context, context.CancelFunc) {
 	if parent == nil {
 		parent = context.Background()


### PR DESCRIPTION
## Summary
- fixes the failed `valon.tools` rollout seen after toolshed #838
- makes remote IndexedDB `CreateObjectStore` and `DeleteObjectStore` use the existing provider migration timeout instead of the generic 10s provider RPC timeout
- keeps normal IndexedDB CRUD/read calls on the shorter provider RPC timeout

## Interfaces
No REST, YAML, CLI, or proto changes.

The remote IndexedDB provider interface remains:

```go
CreateObjectStore(ctx context.Context, name string, schema indexeddb.ObjectStoreSchema) error
DeleteObjectStore(ctx context.Context, name string) error
```

The host-side implementation now wraps those schema-changing calls with the migration budget:

```go
ctx, cancel := providerMigrationContext(ctx)
```

## Production Failure
The #838 deploy image built successfully, but the new Cloud Run revision failed startup before readiness:

```text
bootstrap: system indexeddb from resource "main-db": create api_tokens store: rpc error: code = DeadlineExceeded desc = context deadline exceeded
```

A later retry similarly failed on `runtime_session_logs`. These are schema setup / DDL-style calls, not normal low-latency provider reads.

## Examples
```text
bootstrap: system indexeddb from resource "main-db": create api_tokens store
bootstrap: system indexeddb from resource "main-db": create runtime_session_logs store
```

Those operations now get the provider migration timeout rather than the generic provider RPC timeout.

## Validation
- `cd gestaltd && go test ./internal/providerhost`
- `cd gestaltd && go test ./internal/bootstrap`
- `cd gestaltd && go test ./...`
