### PR TITLE
gestaltd: scope indexeddb schema migration timeouts

### DIFF
--- a/gestaltd/internal/bootstrap/bootstrap.go
+++ b/gestaltd/internal/bootstrap/bootstrap.go
@@ -826,7 +826,7 @@ func prepareCore(ctx context.Context, cfg *config.Config, factories *FactoryRegi
 		return nil, fmt.Errorf("bootstrap: system indexeddb from resource %q: %w", selectedIndexedDBName, storeErr)
 	}
 	store = metricutil.InstrumentIndexedDB(store, selectedIndexedDBName)
-	svc, svcErr := coredata.New(store)
+	svc, svcErr := coredata.NewWithContext(providerhost.WithProviderMigrationTimeout(ctx), store)
 	if svcErr != nil {
 		_ = store.Close()
 		return nil, fmt.Errorf("bootstrap: system indexeddb from resource %q: %w", selectedIndexedDBName, svcErr)

--- a/gestaltd/internal/coredata/services.go
+++ b/gestaltd/internal/coredata/services.go
@@ -26,7 +26,13 @@ type Services struct {
 }
 
 func New(ds indexeddb.IndexedDB) (*Services, error) {
-	ctx := context.Background()
+	return NewWithContext(context.Background(), ds)
+}
+
+func NewWithContext(ctx context.Context, ds indexeddb.IndexedDB) (*Services, error) {
+	if ctx == nil {
+		ctx = context.Background()
+	}
 	if err := ds.CreateObjectStore(ctx, StoreUsers, UsersSchema); err != nil {
 		return nil, fmt.Errorf("create users store: %w", err)
 	}

--- a/gestaltd/internal/coredata/services_test.go
+++ b/gestaltd/internal/coredata/services_test.go
@@ -105,6 +105,47 @@ func (d *countingIndexedDB) getAllCount(name string) int {
 	return d.getAllCounts[name]
 }
 
+type createContextRecordingIndexedDB struct {
+	inner          indexeddb.IndexedDB
+	mu             sync.Mutex
+	createContexts map[string]context.Context
+}
+
+func newCreateContextRecordingIndexedDB(inner indexeddb.IndexedDB) *createContextRecordingIndexedDB {
+	return &createContextRecordingIndexedDB{
+		inner:          inner,
+		createContexts: make(map[string]context.Context),
+	}
+}
+
+func (d *createContextRecordingIndexedDB) ObjectStore(name string) indexeddb.ObjectStore {
+	return d.inner.ObjectStore(name)
+}
+
+func (d *createContextRecordingIndexedDB) CreateObjectStore(ctx context.Context, name string, schema indexeddb.ObjectStoreSchema) error {
+	d.mu.Lock()
+	d.createContexts[name] = ctx
+	d.mu.Unlock()
+	return d.inner.CreateObjectStore(ctx, name, schema)
+}
+
+func (d *createContextRecordingIndexedDB) DeleteObjectStore(ctx context.Context, name string) error {
+	return d.inner.DeleteObjectStore(ctx, name)
+}
+
+func (d *createContextRecordingIndexedDB) Ping(ctx context.Context) error { return d.inner.Ping(ctx) }
+func (d *createContextRecordingIndexedDB) Close() error                   { return d.inner.Close() }
+
+func (d *createContextRecordingIndexedDB) createdStoreContexts() map[string]context.Context {
+	d.mu.Lock()
+	defer d.mu.Unlock()
+	contexts := make(map[string]context.Context, len(d.createContexts))
+	for name, ctx := range d.createContexts {
+		contexts[name] = ctx
+	}
+	return contexts
+}
+
 type countingObjectStore struct {
 	name  string
 	db    *countingIndexedDB
@@ -175,6 +216,33 @@ func TestNew(t *testing.T) {
 		}
 		if _, err := coredata.New(db); err != nil {
 			t.Fatalf("second New: %v", err)
+		}
+	})
+
+	t.Run("new_with_context_uses_caller_context_for_schema_creation", func(t *testing.T) {
+		t.Parallel()
+
+		type schemaContextKey struct{}
+		const marker = "schema-migration"
+		ctx := context.WithValue(context.Background(), schemaContextKey{}, marker)
+		db := newCreateContextRecordingIndexedDB(&coretesting.StubIndexedDB{})
+		if _, err := coredata.NewWithContext(ctx, db); err != nil {
+			t.Fatalf("coredata.NewWithContext: %v", err)
+		}
+
+		contexts := db.createdStoreContexts()
+		if len(contexts) == 0 {
+			t.Fatal("NewWithContext did not create any object stores")
+		}
+		for _, store := range []string{coredata.StoreUsers, coredata.StoreRuntimeSessionLogs} {
+			if _, ok := contexts[store]; !ok {
+				t.Fatalf("NewWithContext did not create store %q", store)
+			}
+		}
+		for store, createCtx := range contexts {
+			if got := createCtx.Value(schemaContextKey{}); got != marker {
+				t.Fatalf("CreateObjectStore(%q) context marker = %v, want %q", store, got, marker)
+			}
 		}
 	})
 

--- a/gestaltd/internal/providerhost/indexeddb_client.go
+++ b/gestaltd/internal/providerhost/indexeddb_client.go
@@ -63,7 +63,7 @@ func (r *remoteIndexedDB) ObjectStore(name string) indexeddb.ObjectStore {
 }
 
 func (r *remoteIndexedDB) CreateObjectStore(ctx context.Context, name string, schema indexeddb.ObjectStoreSchema) error {
-	ctx, cancel := providerMigrationContext(ctx)
+	ctx, cancel := providerSchemaChangeContext(ctx)
 	defer cancel()
 	indexes := make([]*proto.IndexSchema, len(schema.Indexes))
 	for i, idx := range schema.Indexes {
@@ -83,7 +83,7 @@ func (r *remoteIndexedDB) CreateObjectStore(ctx context.Context, name string, sc
 }
 
 func (r *remoteIndexedDB) DeleteObjectStore(ctx context.Context, name string) error {
-	ctx, cancel := providerMigrationContext(ctx)
+	ctx, cancel := providerSchemaChangeContext(ctx)
 	defer cancel()
 	_, err := r.client.DeleteObjectStore(ctx, &proto.DeleteObjectStoreRequest{Name: name})
 	return grpcToDatastoreErr(err)

--- a/gestaltd/internal/providerhost/indexeddb_client_test.go
+++ b/gestaltd/internal/providerhost/indexeddb_client_test.go
@@ -25,36 +25,48 @@ func (c *deadlineIndexedDBClient) DeleteObjectStore(ctx context.Context, req *pr
 	return c.deleteObjectStore(ctx, req, opts...)
 }
 
-func TestRemoteIndexedDBSchemaChangesUseMigrationTimeout(t *testing.T) {
+func TestRemoteIndexedDBSchemaChangesUseMigrationTimeoutWhenRequested(t *testing.T) {
 	t.Parallel()
 
-	assertMigrationDeadline := func(t *testing.T, ctx context.Context) {
+	assertDeadline := func(t *testing.T, ctx context.Context, want time.Duration) {
 		t.Helper()
 		deadline, ok := ctx.Deadline()
 		if !ok {
 			t.Fatal("schema change context has no deadline")
 		}
-		if remaining := time.Until(deadline); remaining <= providerRPCTimeout {
-			t.Fatalf("schema change deadline remaining = %s, want greater than provider RPC timeout %s", remaining, providerRPCTimeout)
+		remaining := time.Until(deadline)
+		if remaining <= want-2*time.Second || remaining > want {
+			t.Fatalf("schema change deadline remaining = %s, want within 2s of %s", remaining, want)
 		}
 	}
 
+	var wantDeadline time.Duration
 	client := &deadlineIndexedDBClient{
 		createObjectStore: func(ctx context.Context, _ *proto.CreateObjectStoreRequest, _ ...grpc.CallOption) (*emptypb.Empty, error) {
-			assertMigrationDeadline(t, ctx)
+			assertDeadline(t, ctx, wantDeadline)
 			return &emptypb.Empty{}, nil
 		},
 		deleteObjectStore: func(ctx context.Context, _ *proto.DeleteObjectStoreRequest, _ ...grpc.CallOption) (*emptypb.Empty, error) {
-			assertMigrationDeadline(t, ctx)
+			assertDeadline(t, ctx, wantDeadline)
 			return &emptypb.Empty{}, nil
 		},
 	}
 	db := &remoteIndexedDB{client: client}
 
+	wantDeadline = providerRPCTimeout
 	if err := db.CreateObjectStore(context.Background(), "api_tokens", indexeddb.ObjectStoreSchema{}); err != nil {
 		t.Fatalf("CreateObjectStore: %v", err)
 	}
 	if err := db.DeleteObjectStore(context.Background(), "api_tokens"); err != nil {
 		t.Fatalf("DeleteObjectStore: %v", err)
+	}
+
+	migrationCtx := WithProviderMigrationTimeout(context.Background())
+	wantDeadline = providerMigrateTimeout
+	if err := db.CreateObjectStore(migrationCtx, "api_tokens", indexeddb.ObjectStoreSchema{}); err != nil {
+		t.Fatalf("CreateObjectStore with migration context: %v", err)
+	}
+	if err := db.DeleteObjectStore(migrationCtx, "api_tokens"); err != nil {
+		t.Fatalf("DeleteObjectStore with migration context: %v", err)
 	}
 }

--- a/gestaltd/internal/providerhost/runtime_client.go
+++ b/gestaltd/internal/providerhost/runtime_client.go
@@ -125,6 +125,24 @@ func providerCallContext(parent context.Context) (context.Context, context.Cance
 	return context.WithTimeout(parent, providerRPCTimeout)
 }
 
+type providerMigrationTimeoutContextKey struct{}
+
+func WithProviderMigrationTimeout(ctx context.Context) context.Context {
+	if ctx == nil {
+		ctx = context.Background()
+	}
+	return context.WithValue(ctx, providerMigrationTimeoutContextKey{}, true)
+}
+
+func providerSchemaChangeContext(parent context.Context) (context.Context, context.CancelFunc) {
+	if parent != nil {
+		if useMigrationTimeout, _ := parent.Value(providerMigrationTimeoutContextKey{}).(bool); useMigrationTimeout {
+			return providerMigrationContext(parent)
+		}
+	}
+	return providerCallContext(parent)
+}
+
 func providerMigrationContext(parent context.Context) (context.Context, context.CancelFunc) {
 	if parent == nil {
 		parent = context.Background()


### PR DESCRIPTION
## Summary

Follow-up to #1372. Keep the longer provider migration timeout for bootstrap-owned IndexedDB schema creation, but do not make every remote IndexedDB schema-change call use the migration budget by default.

## Interfaces

```go
// Marks startup/bootstrap migration work as eligible for the provider migration timeout.
func providerhost.WithProviderMigrationTimeout(ctx context.Context) context.Context

// Lets coredata callers pass the context used for core object-store creation.
func coredata.NewWithContext(ctx context.Context, ds indexeddb.IndexedDB) (*Services, error)
```

No REST, YAML, CLI, proto, or AgentProvider interface changes.

## Examples

Bootstrap startup schema creation opts into the migration budget:

```go
svc, err := coredata.NewWithContext(providerhost.WithProviderMigrationTimeout(ctx), store)
```

Normal request-path schema changes continue to use the standard provider RPC timeout:

```go
err := db.CreateObjectStore(ctx, "api_tokens", schema)
```

## Validation

```sh
cd gestaltd
go test ./internal/coredata ./internal/providerhost ./internal/bootstrap
go test ./...
```

Reviewer feedback addressed: added coredata contract coverage proving `NewWithContext` forwards caller context into object-store creation.