### PR TITLE
agent: require explicit tools for turns

### DIFF
--- a/gestalt/cli/src/cli.rs
+++ b/gestalt/cli/src/cli.rs
@@ -555,7 +555,7 @@ pub struct AgentTurnCreateArgs {
     #[arg(long = "message")]
     pub messages: Vec<String>,
 
-    /// Add a tool beyond the default safe tool set in plugin:operation form
+    /// Add a tool in plugin:operation form
     #[arg(long = "tool", value_parser = AgentToolArg::parse)]
     pub tools: Vec<AgentToolArg>,
 

--- a/gestaltd/internal/agentmanager/manager.go
+++ b/gestaltd/internal/agentmanager/manager.go
@@ -80,31 +80,29 @@ type Service interface {
 }
 
 type Config struct {
-	Providers           *registry.ProviderMap[core.Provider]
-	Agent               AgentControl
-	SessionMetadata     *coredata.AgentSessionMetadataService
-	RunMetadata         *coredata.AgentRunMetadataService
-	ExternalCredentials core.ExternalCredentialProvider
-	Invoker             invocation.Invoker
-	Authorizer          authorization.RuntimeAuthorizer
-	DefaultConnection   map[string]string
-	CatalogConnection   map[string]string
-	PluginInvokes       map[string][]config.PluginInvocationDependency
-	Now                 func() time.Time
+	Providers         *registry.ProviderMap[core.Provider]
+	Agent             AgentControl
+	SessionMetadata   *coredata.AgentSessionMetadataService
+	RunMetadata       *coredata.AgentRunMetadataService
+	Invoker           invocation.Invoker
+	Authorizer        authorization.RuntimeAuthorizer
+	DefaultConnection map[string]string
+	CatalogConnection map[string]string
+	PluginInvokes     map[string][]config.PluginInvocationDependency
+	Now               func() time.Time
 }
 
 type Manager struct {
-	providers           *registry.ProviderMap[core.Provider]
-	agent               AgentControl
-	sessionMetadata     *coredata.AgentSessionMetadataService
-	runMetadata         *coredata.AgentRunMetadataService
-	externalCredentials core.ExternalCredentialProvider
-	invoker             invocation.Invoker
-	authorizer          authorization.RuntimeAuthorizer
-	defaultConnection   map[string]string
-	catalogConnection   map[string]string
-	pluginInvokes       map[string][]config.PluginInvocationDependency
-	now                 func() time.Time
+	providers         *registry.ProviderMap[core.Provider]
+	agent             AgentControl
+	sessionMetadata   *coredata.AgentSessionMetadataService
+	runMetadata       *coredata.AgentRunMetadataService
+	invoker           invocation.Invoker
+	authorizer        authorization.RuntimeAuthorizer
+	defaultConnection map[string]string
+	catalogConnection map[string]string
+	pluginInvokes     map[string][]config.PluginInvocationDependency
+	now               func() time.Time
 }
 
 func New(cfg Config) *Manager {
@@ -117,17 +115,16 @@ func New(cfg Config) *Manager {
 		pluginInvokes[pluginName] = append([]config.PluginInvocationDependency(nil), deps...)
 	}
 	return &Manager{
-		providers:           cfg.Providers,
-		agent:               cfg.Agent,
-		sessionMetadata:     cfg.SessionMetadata,
-		runMetadata:         cfg.RunMetadata,
-		externalCredentials: cfg.ExternalCredentials,
-		invoker:             cfg.Invoker,
-		authorizer:          cfg.Authorizer,
-		defaultConnection:   maps.Clone(cfg.DefaultConnection),
-		catalogConnection:   maps.Clone(cfg.CatalogConnection),
-		pluginInvokes:       pluginInvokes,
-		now:                 now,
+		providers:         cfg.Providers,
+		agent:             cfg.Agent,
+		sessionMetadata:   cfg.SessionMetadata,
+		runMetadata:       cfg.RunMetadata,
+		invoker:           cfg.Invoker,
+		authorizer:        cfg.Authorizer,
+		defaultConnection: maps.Clone(cfg.DefaultConnection),
+		catalogConnection: maps.Clone(cfg.CatalogConnection),
+		pluginInvokes:     pluginInvokes,
+		now:               now,
 	}
 }
 
@@ -743,14 +740,7 @@ func (m *Manager) resolveTools(ctx context.Context, p *principal.Principal, call
 	if err != nil {
 		return nil, err
 	}
-	if source != coreagent.ToolSourceModeUnspecified || strings.TrimSpace(callerPluginName) != "" {
-		return explicitTools, nil
-	}
-	defaultTools := m.resolveDefaultTools(ctx, p)
-	if len(defaultTools) == 0 {
-		return explicitTools, nil
-	}
-	return mergeTools(explicitTools, defaultTools), nil
+	return explicitTools, nil
 }
 
 func (m *Manager) resolveTool(ctx context.Context, p *principal.Principal, ref coreagent.ToolRef) (coreagent.Tool, error) {
@@ -876,263 +866,6 @@ func (m *Manager) resolveExplicitTools(ctx context.Context, p *principal.Princip
 		out = append(out, tool)
 	}
 	return out, nil
-}
-
-func (m *Manager) resolveDefaultTools(ctx context.Context, p *principal.Principal) []coreagent.Tool {
-	if m == nil || m.providers == nil {
-		return nil
-	}
-	out := make([]coreagent.Tool, 0, 8)
-	for _, providerName := range m.defaultToolProviders(ctx, p) {
-		providerTools, err := m.resolveDefaultToolsForProvider(ctx, p, providerName)
-		if err != nil {
-			continue
-		}
-		out = append(out, providerTools...)
-	}
-	return out
-}
-
-func (m *Manager) defaultToolProviders(ctx context.Context, p *principal.Principal) []string {
-	if m == nil || m.providers == nil {
-		return nil
-	}
-	providerNames := m.providers.List()
-	if len(providerNames) == 0 {
-		return nil
-	}
-
-	out := make([]string, 0, len(providerNames))
-	credentialAvailability := make(map[string]bool, len(providerNames))
-	for _, providerName := range providerNames {
-		if !m.allowProvider(ctx, p, providerName) {
-			continue
-		}
-		prov, err := m.providers.Get(providerName)
-		if err != nil {
-			continue
-		}
-		if core.NormalizeConnectionMode(prov.ConnectionMode()) == core.ConnectionModeNone {
-			out = append(out, providerName)
-			continue
-		}
-		if !m.hasDefaultToolCredential(ctx, p, providerName, credentialAvailability) {
-			continue
-		}
-		out = append(out, providerName)
-	}
-	return out
-}
-
-func (m *Manager) hasDefaultToolCredential(ctx context.Context, p *principal.Principal, providerName string, credentialAvailability map[string]bool) bool {
-	if m == nil || coredata.ExternalCredentialProviderMissing(m.externalCredentials) {
-		return false
-	}
-
-	bindingResolver, _ := m.invoker.(invocation.EffectiveCredentialBindingResolver)
-	targets := m.catalogSelectorConfig().BoundSessionCatalogTargets(providerName, p, "", "")
-	if len(targets) == 0 {
-		targets = []invocation.CatalogResolutionTarget{{}}
-	}
-	for _, target := range targets {
-		subjectID := m.defaultToolCredentialSubjectID(p, providerName)
-		connection := strings.TrimSpace(target.Connection)
-		instance := strings.TrimSpace(target.Instance)
-		if bindingResolver != nil {
-			boundCredential, err := bindingResolver.ResolveEffectiveCredentialBinding(p, providerName, connection, instance)
-			if err != nil {
-				continue
-			}
-			if subject := strings.TrimSpace(boundCredential.CredentialSubjectID); subject != "" {
-				subjectID = subject
-			}
-			if conn := strings.TrimSpace(boundCredential.Connection); conn != "" {
-				connection = conn
-			}
-			if inst := strings.TrimSpace(boundCredential.Instance); inst != "" {
-				instance = inst
-			}
-		}
-		if subjectID == "" {
-			continue
-		}
-
-		cacheKey := subjectID + "\x00" + providerName + "\x00" + connection + "\x00" + instance
-		if ok, found := credentialAvailability[cacheKey]; found {
-			if ok {
-				return true
-			}
-			continue
-		}
-
-		ok := m.hasStoredDefaultToolCredential(ctx, subjectID, providerName, connection, instance)
-		credentialAvailability[cacheKey] = ok
-		if ok {
-			return true
-		}
-	}
-	return false
-}
-
-func (m *Manager) defaultToolCredentialSubjectID(p *principal.Principal, providerName string) string {
-	if m != nil && m.authorizer != nil {
-		boundCredential, err := invocation.ResolveEffectiveCredentialBinding(m.authorizer, p, providerName, "", "")
-		if err == nil && boundCredential.HasBinding {
-			if subjectID := strings.TrimSpace(boundCredential.CredentialSubjectID); subjectID != "" {
-				return subjectID
-			}
-		}
-	}
-	return principal.EffectiveCredentialSubjectID(p)
-}
-
-func (m *Manager) hasStoredDefaultToolCredential(ctx context.Context, subjectID, providerName, connection, instance string) bool {
-	if m == nil || coredata.ExternalCredentialProviderMissing(m.externalCredentials) {
-		return false
-	}
-	subjectID = strings.TrimSpace(subjectID)
-	providerName = strings.TrimSpace(providerName)
-	connection = strings.TrimSpace(connection)
-	instance = strings.TrimSpace(instance)
-	if subjectID == "" || providerName == "" {
-		return false
-	}
-	if instance != "" {
-		_, err := m.externalCredentials.GetCredential(ctx, subjectID, providerName, connection, instance)
-		return err == nil
-	}
-	credentials, err := m.externalCredentials.ListCredentialsForConnection(ctx, subjectID, providerName, connection)
-	return err == nil && len(credentials) > 0
-}
-
-func (m *Manager) resolveDefaultToolsForProvider(ctx context.Context, p *principal.Principal, providerName string) ([]coreagent.Tool, error) {
-	prov, err := m.providers.Get(providerName)
-	if err != nil {
-		return nil, err
-	}
-	connection, instance, cat, ok := m.resolveDefaultToolCatalog(ctx, p, providerName, prov)
-	if !ok || cat == nil {
-		return nil, nil
-	}
-
-	out := make([]coreagent.Tool, 0, len(cat.Operations))
-	for i := range cat.Operations {
-		op := &cat.Operations[i]
-		if !defaultToolAllowed(*op) {
-			continue
-		}
-		if !m.allowOperation(ctx, p, providerName, op.ID) {
-			continue
-		}
-		if !principal.AllowsOperationPermission(p, providerName, op.ID) {
-			continue
-		}
-		if m.authorizer != nil && !m.authorizer.AllowCatalogOperation(ctx, p, providerName, *op) {
-			continue
-		}
-
-		tool, err := m.resolveTool(ctx, p, coreagent.ToolRef{
-			PluginName: providerName,
-			Operation:  op.ID,
-			Connection: connection,
-			Instance:   instance,
-		})
-		if err != nil {
-			continue
-		}
-		out = append(out, tool)
-	}
-	return out, nil
-}
-
-func (m *Manager) resolveDefaultToolCatalog(ctx context.Context, p *principal.Principal, providerName string, prov core.Provider) (string, string, *catalog.Catalog, bool) {
-	ctx = invocation.WithAccessContext(ctx, m.providerAccessContext(ctx, p, providerName))
-	resolver, _ := m.invoker.(invocation.TokenResolver)
-	bindingResolver, _ := m.invoker.(invocation.EffectiveCredentialBindingResolver)
-	requiresCredential := core.NormalizeConnectionMode(prov.ConnectionMode()) != core.ConnectionModeNone
-	targets := m.catalogSelectorConfig().BoundSessionCatalogTargets(providerName, p, "", "")
-	if len(targets) == 0 {
-		targets = []invocation.CatalogResolutionTarget{{}}
-	}
-	for _, target := range targets {
-		connection := strings.TrimSpace(target.Connection)
-		instance := strings.TrimSpace(target.Instance)
-		boundCredential := invocation.CredentialBindingResolution{}
-		if bindingResolver != nil {
-			resolvedBinding, err := bindingResolver.ResolveEffectiveCredentialBinding(p, providerName, connection, instance)
-			if err != nil {
-				continue
-			}
-			boundCredential = resolvedBinding
-		}
-
-		catalogCtx := ctx
-		if requiresCredential {
-			if resolver == nil {
-				continue
-			}
-			resolvedCtx, _, err := invocation.ResolveTokenForBinding(ctx, resolver, p, providerName, connection, instance, boundCredential)
-			if err != nil {
-				continue
-			}
-			cred := invocation.CredentialContextFromContext(resolvedCtx)
-			if cred.Connection != "" {
-				connection = cred.Connection
-			}
-			if cred.Instance != "" {
-				instance = cred.Instance
-			}
-			catalogCtx = resolvedCtx
-		}
-
-		var cat *catalog.Catalog
-		var err error
-		if requiresCredential {
-			cat, _, err = invocation.ResolveCatalogStrictWithMetadata(catalogCtx, prov, providerName, resolver, p, connection, instance)
-		} else {
-			cat, _, err = invocation.ResolveCatalogWithMetadata(catalogCtx, prov, providerName, resolver, p, connection, instance)
-		}
-		if err != nil || cat == nil {
-			continue
-		}
-		return connection, instance, cat, true
-	}
-	return "", "", nil, false
-}
-
-func defaultToolAllowed(op catalog.CatalogOperation) bool {
-	if op.Visible != nil && !*op.Visible {
-		return false
-	}
-	if op.Annotations.DestructiveHint != nil && *op.Annotations.DestructiveHint {
-		return false
-	}
-	if op.ReadOnly {
-		return true
-	}
-	return op.Annotations.ReadOnlyHint != nil && *op.Annotations.ReadOnlyHint
-}
-
-func mergeTools(groups ...[]coreagent.Tool) []coreagent.Tool {
-	total := 0
-	for _, group := range groups {
-		total += len(group)
-	}
-	if total == 0 {
-		return nil
-	}
-	out := make([]coreagent.Tool, 0, total)
-	seen := make(map[string]struct{}, total)
-	for _, group := range groups {
-		for _, tool := range group {
-			if _, ok := seen[tool.ID]; ok {
-				continue
-			}
-			seen[tool.ID] = struct{}{}
-			out = append(out, tool)
-		}
-	}
-	return out
 }
 
 func (m *Manager) allowProvider(ctx context.Context, p *principal.Principal, provider string) bool {

--- a/gestaltd/internal/agentmanager/manager_test.go
+++ b/gestaltd/internal/agentmanager/manager_test.go
@@ -1,0 +1,84 @@
+package agentmanager
+
+import (
+	"context"
+	"testing"
+
+	"github.com/valon-technologies/gestalt/server/core"
+	coreagent "github.com/valon-technologies/gestalt/server/core/agent"
+	"github.com/valon-technologies/gestalt/server/core/catalog"
+	coretesting "github.com/valon-technologies/gestalt/server/core/testing"
+	"github.com/valon-technologies/gestalt/server/internal/principal"
+	"github.com/valon-technologies/gestalt/server/internal/testutil"
+)
+
+type catalogCountingProvider struct {
+	coretesting.StubIntegration
+	catalogCalls int
+}
+
+func (p *catalogCountingProvider) Catalog() *catalog.Catalog {
+	p.catalogCalls++
+	return p.CatalogVal
+}
+
+func TestResolveToolsDoesNotImplicitlyHydrateDefaultTools(t *testing.T) {
+	t.Parallel()
+
+	provider := &catalogCountingProvider{
+		StubIntegration: coretesting.StubIntegration{
+			N:        "docs",
+			ConnMode: core.ConnectionModeNone,
+			CatalogVal: &catalog.Catalog{Operations: []catalog.CatalogOperation{{
+				ID:       "search",
+				Title:    "Search",
+				ReadOnly: true,
+			}}},
+		},
+	}
+	manager := New(Config{Providers: testutil.NewProviderRegistry(t, provider)})
+	tools, err := manager.resolveTools(context.Background(), &principal.Principal{
+		SubjectID: principal.UserSubjectID("user-1"),
+	}, "", nil, coreagent.ToolSourceModeUnspecified)
+	if err != nil {
+		t.Fatalf("resolveTools: %v", err)
+	}
+	if len(tools) != 0 {
+		t.Fatalf("resolveTools returned %d tools, want none", len(tools))
+	}
+	if provider.catalogCalls != 0 {
+		t.Fatalf("provider catalog calls = %d, want 0", provider.catalogCalls)
+	}
+}
+
+func TestResolveToolsStillResolvesExplicitTools(t *testing.T) {
+	t.Parallel()
+
+	provider := &catalogCountingProvider{
+		StubIntegration: coretesting.StubIntegration{
+			N:        "docs",
+			ConnMode: core.ConnectionModeNone,
+			CatalogVal: &catalog.Catalog{Operations: []catalog.CatalogOperation{{
+				ID:       "search",
+				Title:    "Search",
+				ReadOnly: true,
+			}}},
+		},
+	}
+	manager := New(Config{Providers: testutil.NewProviderRegistry(t, provider)})
+	tools, err := manager.resolveTools(context.Background(), &principal.Principal{
+		SubjectID: principal.UserSubjectID("user-1"),
+	}, "", []coreagent.ToolRef{{
+		PluginName: "docs",
+		Operation:  "search",
+	}}, coreagent.ToolSourceModeUnspecified)
+	if err != nil {
+		t.Fatalf("resolveTools: %v", err)
+	}
+	if len(tools) != 1 {
+		t.Fatalf("resolveTools returned %d tools, want 1", len(tools))
+	}
+	if tools[0].Target.PluginName != "docs" || tools[0].Target.Operation != "search" {
+		t.Fatalf("tool target = %#v, want docs.search", tools[0].Target)
+	}
+}

--- a/gestaltd/internal/bootstrap/bootstrap.go
+++ b/gestaltd/internal/bootstrap/bootstrap.go
@@ -1032,16 +1032,15 @@ func Bootstrap(ctx context.Context, cfg *config.Config, factories *FactoryRegist
 		CatalogConnection: connMaps.APIConnection,
 	}))
 	agentManager.SetTarget(agentmanager.New(agentmanager.Config{
-		Providers:           providers,
-		Agent:               prepared.Deps.AgentRuntime,
-		SessionMetadata:     prepared.Services.AgentSessions,
-		RunMetadata:         prepared.Services.AgentRunMetadata,
-		ExternalCredentials: coredata.EffectiveExternalCredentialProvider(prepared.Services),
-		Invoker:             sharedInvoker,
-		Authorizer:          authz,
-		DefaultConnection:   connMaps.DefaultConnection,
-		CatalogConnection:   connMaps.APIConnection,
-		PluginInvokes:       agentPluginInvokes(cfg),
+		Providers:         providers,
+		Agent:             prepared.Deps.AgentRuntime,
+		SessionMetadata:   prepared.Services.AgentSessions,
+		RunMetadata:       prepared.Services.AgentRunMetadata,
+		Invoker:           sharedInvoker,
+		Authorizer:        authz,
+		DefaultConnection: connMaps.DefaultConnection,
+		CatalogConnection: connMaps.APIConnection,
+		PluginInvokes:     agentPluginInvokes(cfg),
 	}))
 	extraWorkflows, err := buildWorkflows(ctx, cfg, factories, prepared.Deps)
 	if err != nil {

--- a/gestaltd/internal/server/agent_session_turn_test.go
+++ b/gestaltd/internal/server/agent_session_turn_test.go
@@ -15,6 +15,7 @@ import (
 	"github.com/google/uuid"
 	"github.com/valon-technologies/gestalt/server/core"
 	coreagent "github.com/valon-technologies/gestalt/server/core/agent"
+	"github.com/valon-technologies/gestalt/server/core/catalog"
 	coretesting "github.com/valon-technologies/gestalt/server/core/testing"
 	"github.com/valon-technologies/gestalt/server/internal/agentmanager"
 	"github.com/valon-technologies/gestalt/server/internal/server"
@@ -58,6 +59,7 @@ type memoryAgentProvider struct {
 	turns        map[string]*coreagent.Turn
 	turnEvents   map[string][]*coreagent.TurnEvent
 	interactions map[string]*coreagent.Interaction
+	turnRequests []coreagent.CreateTurnRequest
 }
 
 func newMemoryAgentProvider() *memoryAgentProvider {
@@ -137,6 +139,7 @@ func (p *memoryAgentProvider) CreateTurn(_ context.Context, req coreagent.Create
 	p.mu.Lock()
 	defer p.mu.Unlock()
 
+	p.turnRequests = append(p.turnRequests, cloneCreateTurnRequest(req))
 	now := time.Now().UTC().Truncate(time.Second)
 	turn := &coreagent.Turn{
 		ID:           req.TurnID,
@@ -180,6 +183,17 @@ func (p *memoryAgentProvider) CreateTurn(_ context.Context, req coreagent.Create
 		session.UpdatedAt = &now
 	}
 	return cloneTurn(turn), nil
+}
+
+func (p *memoryAgentProvider) capturedTurnRequests() []coreagent.CreateTurnRequest {
+	p.mu.Lock()
+	defer p.mu.Unlock()
+
+	out := make([]coreagent.CreateTurnRequest, 0, len(p.turnRequests))
+	for _, req := range p.turnRequests {
+		out = append(out, cloneCreateTurnRequest(req))
+	}
+	return out
 }
 
 func (p *memoryAgentProvider) GetTurn(_ context.Context, req coreagent.GetTurnRequest) (*coreagent.Turn, error) {
@@ -333,6 +347,16 @@ func cloneTurn(src *coreagent.Turn) *coreagent.Turn {
 	return &dst
 }
 
+func cloneCreateTurnRequest(src coreagent.CreateTurnRequest) coreagent.CreateTurnRequest {
+	dst := src
+	dst.Messages = append([]coreagent.Message(nil), src.Messages...)
+	dst.Tools = append([]coreagent.Tool(nil), src.Tools...)
+	dst.ResponseSchema = cloneMap(src.ResponseSchema)
+	dst.Metadata = cloneMap(src.Metadata)
+	dst.ProviderOptions = cloneMap(src.ProviderOptions)
+	return dst
+}
+
 func cloneTurnEvent(src *coreagent.TurnEvent) *coreagent.TurnEvent {
 	if src == nil {
 		return nil
@@ -369,7 +393,16 @@ func TestAgentSessionsAndTurnsRoundTrip(t *testing.T) {
 		}
 		cfg.Services = services
 		cfg.AgentManager = agentmanager.New(agentmanager.Config{
-			Agent:           &stubAgentControl{defaultProviderName: "managed", provider: provider},
+			Agent: &stubAgentControl{defaultProviderName: "managed", provider: provider},
+			Providers: testutil.NewProviderRegistry(t, &coretesting.StubIntegration{
+				N:        "docs",
+				ConnMode: core.ConnectionModeNone,
+				CatalogVal: &catalog.Catalog{Operations: []catalog.CatalogOperation{{
+					ID:       "search",
+					Title:    "Search",
+					ReadOnly: true,
+				}}},
+			}),
 			SessionMetadata: services.AgentSessions,
 			RunMetadata:     services.AgentRunMetadata,
 		})
@@ -426,6 +459,13 @@ func TestAgentSessionsAndTurnsRoundTrip(t *testing.T) {
 		t.Fatalf("decode turn: %v", err)
 	}
 	turnID := turn["id"].(string)
+	turnRequests := provider.capturedTurnRequests()
+	if len(turnRequests) != 1 {
+		t.Fatalf("provider turn requests len = %d, want 1", len(turnRequests))
+	}
+	if len(turnRequests[0].Tools) != 0 {
+		t.Fatalf("provider turn tools len = %d, want 0", len(turnRequests[0].Tools))
+	}
 
 	eventsReq, _ := http.NewRequest(http.MethodGet, ts.URL+"/api/v1/agent/turns/"+turnID+"/events?after=0&limit=10", nil)
 	eventsReq.AddCookie(&http.Cookie{Name: "session_token", Value: "ada-session"})

--- a/sdk/go/agent_manager_transport_test.go
+++ b/sdk/go/agent_manager_transport_test.go
@@ -133,4 +133,10 @@ func TestTransport_AgentManagerTCPTargetTokenEnv(t *testing.T) {
 	if harness.turnRequests[0].GetSessionId() != "session-1" || harness.turnRequests[0].GetModel() != "gpt-test" {
 		t.Fatalf("turn request = %+v, want session_id=session-1 model=gpt-test", harness.turnRequests[0])
 	}
+	if len(harness.turnRequests[0].GetToolRefs()) != 0 {
+		t.Fatalf("turn tool refs len = %d, want 0", len(harness.turnRequests[0].GetToolRefs()))
+	}
+	if harness.turnRequests[0].GetToolSource() != proto.AgentToolSourceMode_AGENT_TOOL_SOURCE_MODE_UNSPECIFIED {
+		t.Fatalf("turn tool source = %s, want unspecified", harness.turnRequests[0].GetToolSource())
+	}
 }


### PR DESCRIPTION
## Summary

The production smoke test after deploying #1373 exposed that creating a turn with no explicit tools triggers the server's implicit default safe-tool hydration. In valon.tools that path enumerates/authorizes a large catalog surface, times out, and can leave the agent provider unhealthy.

This removes that implicit default-tool resolver. Plain turns are model-only. Tool-enabled turns must pass `toolRefs`, and plugin-owned calls can still use `toolSource: "inherit_invokes"`.

## Interfaces

No REST shape changes. Existing fields remain supported:

```json
{
  "messages": [{"role": "user", "text": "hello"}],
  "toolRefs": [{"pluginName": "docs", "operation": "search"}],
  "toolSource": "inherit_invokes"
}
```

Behavior change:

```go
// Before: omitted toolSource + no caller plugin hydrated default safe tools.
// Now: omitted toolSource only resolves explicit toolRefs.
func (m *Manager) resolveTools(ctx context.Context, p *principal.Principal, callerPluginName string, explicit []agent.ToolRef, source agent.ToolSourceMode) ([]agent.Tool, error)
```

## Examples

Plain/model-only turn:

```json
{"messages":[{"role":"user","text":"Reply with exactly: PONG"}]}
```

Tool-enabled turn:

```json
{
  "messages": [{"role": "user", "text": "Search docs"}],
  "toolRefs": [{"pluginName": "docs", "operation": "search"}]
}
```

CLI help now describes `--tool` as explicit opt-in only:

```sh
gestalt agent turns create <session-id> --message "hello" --tool docs:search
```

## Validation

```sh
cd gestaltd
go test ./internal/agentmanager ./internal/server
go test ./...

cd ../sdk/go
go test ./...

cd ../gestalt/cli
cargo fmt --all -- --check
cargo clippy --workspace --all-targets -- -D warnings
```

Reviewer feedback addressed: added HTTP server boundary coverage that omitted `toolRefs` reaches the provider with zero tools, and SDK transport coverage that omitted tools remain omitted on the wire.
