### PR TITLE
Improve gestalt agent interactive sessions

### DIFF
--- a/docs/content/client/cli/index.mdx
+++ b/docs/content/client/cli/index.mdx
@@ -248,8 +248,10 @@ JSON
 `--provider` or resumes an existing one with `--session`. The first turn in a
 CLI session can include repeated `--system` messages, repeated `--message`
 prompts, and repeated `--tool plugin:operation` additions. During execution,
-the CLI renders canonical turn events, polls for terminal state, and resolves
-pending interactions inline.
+the CLI parses the event stream, renders assistant/tool/interaction events,
+cancels the active turn on Ctrl-C, and resolves pending interactions inline.
+TTY sessions use line editing and per-directory history. End an input line with
+`\` to continue the same user message on the next prompt.
 
 `gestalt agent turns create` is the non-interactive equivalent. It supports
 repeated `--system`, repeated `--message`, repeated `--tool plugin:operation`,
@@ -258,6 +260,10 @@ stored events from `GET /api/v1/agent/turns/{turnID}/events`. `--after` is an
 event sequence cursor and `--limit` controls the page size. `gestalt agent
 turns events stream` reads `GET /api/v1/agent/turns/{turnID}/events/stream`
 and writes the raw server-sent event stream to stdout.
+
+Interactive sessions use `GET /api/v1/agent/turns/{turnID}/events/stream`
+with `until=blocked_or_terminal`, which lets the CLI switch immediately from
+streaming output to interaction prompts when a provider requests input.
 
 ### Local Quickstart
 

--- a/docs/content/reference/http-api.mdx
+++ b/docs/content/reference/http-api.mdx
@@ -76,7 +76,7 @@ Authenticated routes accept a `session_token` cookie or an `Authorization: Beare
 | `GET` | `/api/v1/agent/turns/{turnID}` | Inspect one agent turn. |
 | `POST` | `/api/v1/agent/turns/{turnID}/cancel` | Cancel one agent turn. The request body may include an optional `reason`. |
 | `GET` | `/api/v1/agent/turns/{turnID}/events` | List stored events for one turn. Supports optional `after` sequence cursor and `limit`. |
-| `GET` | `/api/v1/agent/turns/{turnID}/events/stream` | Stream turn events as server-sent events. Supports optional `after` sequence cursor and `limit`. |
+| `GET` | `/api/v1/agent/turns/{turnID}/events/stream` | Stream turn events as server-sent events. Supports optional `after` sequence cursor, `limit`, and `until=terminal\|blocked_or_terminal`. |
 | `GET` | `/api/v1/agent/turns/{turnID}/interactions` | List provider-owned interactions for one turn. |
 | `POST` | `/api/v1/agent/turns/{turnID}/interactions/{interactionID}/resolve` | Resolve one pending interaction by submitting a `resolution` payload. |
 
@@ -305,9 +305,13 @@ curl -H 'Authorization: Bearer gst_api_...' \
 curl -H 'Authorization: Bearer gst_api_...' \
   'http://localhost:8080/api/v1/agent/turns/turn-123/events?after=0&limit=100'
 
-# Stream turn events
+# Stream turn events until the turn reaches a terminal state
 curl -N -H 'Authorization: Bearer gst_api_...' \
   'http://localhost:8080/api/v1/agent/turns/turn-123/events/stream?after=0'
+
+# Stream turn events until the turn is terminal or waiting on an interaction
+curl -N -H 'Authorization: Bearer gst_api_...' \
+  'http://localhost:8080/api/v1/agent/turns/turn-123/events/stream?after=0&until=blocked_or_terminal'
 
 # List pending turn interactions
 curl -H 'Authorization: Bearer gst_api_...' \

--- a/gestalt/cli/Cargo.toml
+++ b/gestalt/cli/Cargo.toml
@@ -24,6 +24,8 @@ getrandom = "0.4"
 comfy-table = { version = "7.2.1", default-features = false }
 rpassword = "7"
 time = { version = "0.3", features = ["parsing"] }
+rustyline = "18"
+ctrlc = "3"
 
 [dev-dependencies]
 tempfile = "3"

--- a/gestalt/cli/src/api.rs
+++ b/gestalt/cli/src/api.rs
@@ -199,6 +199,7 @@ pub fn env_api_key_is_set() -> bool {
         .unwrap_or(false)
 }
 
+#[derive(Clone)]
 pub struct ApiClient {
     client: Client,
     stream_client: Client,

--- a/gestalt/cli/src/commands/agents.rs
+++ b/gestalt/cli/src/commands/agents.rs
@@ -1,7 +1,12 @@
 use anyhow::{Context, Result, bail};
+use colored::Colorize;
 use serde::{Deserialize, de::DeserializeOwned};
 use serde_json::{Map, Value, json};
-use std::io::{self, Write};
+use std::io::{self, BufRead, BufReader, IsTerminal, Write};
+use std::sync::{
+    Arc,
+    atomic::{AtomicBool, AtomicU64, Ordering},
+};
 use std::thread;
 use std::time::Duration;
 use time::{OffsetDateTime, format_description::well_known::Rfc3339};
@@ -11,7 +16,9 @@ use crate::cli::{
     AgentArgs, AgentSessionCreateArgs, AgentSessionUpdateArgs, AgentToolArg, AgentTurnCreateArgs,
     AgentTurnEventListArgs, AgentTurnEventStreamArgs,
 };
-use crate::interactive::{InputPrompt, prompt_confirm, prompt_input};
+use crate::interactive::{
+    InputPrompt, InteractiveLineReader, PromptLine, prompt_confirm, prompt_input,
+};
 use crate::output::{self, Format};
 use crate::params;
 
@@ -19,6 +26,8 @@ const SESSIONS_PATH: &str = "/api/v1/agent/sessions";
 const TURNS_PATH: &str = "/api/v1/agent/turns";
 const DEFAULT_EVENT_PAGE_SIZE: u32 = 100;
 const EVENT_POLL_INTERVAL: Duration = Duration::from_millis(250);
+const EVENT_STREAM_UNTIL_BLOCKED_OR_TERMINAL: &str = "blocked_or_terminal";
+const INTERRUPT_CANCEL_REASON: &str = "operator interrupted";
 
 pub fn create_session(
     client: &ApiClient,
@@ -114,13 +123,26 @@ pub fn cancel_turn(
     Ok(())
 }
 
+fn cancel_turn_silent(client: &ApiClient, id: &str, reason: &str) -> Result<AgentTurnInfo> {
+    decode_json(
+        client
+            .post(
+                &format!("{TURNS_PATH}/{id}/cancel"),
+                &json!({ "reason": reason }),
+            )
+            .with_context(|| format!("failed to cancel agent turn {id}"))?,
+    )
+}
+
 pub fn list_turn_events(
     client: &ApiClient,
     args: &AgentTurnEventListArgs,
     format: Format,
 ) -> Result<()> {
     let resp = client
-        .get(&turn_events_path(&args.id, false, args.after, args.limit))
+        .get(&turn_events_path(
+            &args.id, false, args.after, args.limit, None,
+        ))
         .with_context(|| format!("failed to list events for agent turn {}", args.id))?;
     print_turn_events(&resp, format);
     Ok(())
@@ -128,7 +150,9 @@ pub fn list_turn_events(
 
 pub fn stream_turn_events(client: &ApiClient, args: &AgentTurnEventStreamArgs) -> Result<()> {
     let mut resp = client
-        .get_stream(&turn_events_path(&args.id, true, args.after, args.limit))
+        .get_stream(&turn_events_path(
+            &args.id, true, args.after, args.limit, None,
+        ))
         .with_context(|| format!("failed to stream events for agent turn {}", args.id))?;
     let mut stdout = io::stdout().lock();
     io::copy(&mut resp, &mut stdout).context("failed to read agent turn event stream")?;
@@ -138,13 +162,15 @@ pub fn stream_turn_events(client: &ApiClient, args: &AgentTurnEventStreamArgs) -
 pub fn run_interactive(client: &ApiClient, args: &AgentArgs) -> Result<()> {
     let mut shell = AgentShell::connect(client, args)?;
     shell.print_banner()?;
+    let interrupts = InterruptState::install();
+    let mut input = InteractiveLineReader::with_history_namespace("agent")?;
 
     if !args.messages.is_empty() {
-        shell.submit_turn(client, args.messages.clone())?;
+        shell.submit_turn(client, args.messages.clone(), &interrupts)?;
     }
 
     loop {
-        let Some(line) = prompt_agent_line()? else {
+        let Some(line) = prompt_agent_message(&mut input)? else {
             return Ok(());
         };
         let trimmed = line.trim();
@@ -163,7 +189,7 @@ pub fn run_interactive(client: &ApiClient, args: &AgentArgs) -> Result<()> {
             }
             _ => {}
         }
-        shell.submit_turn(client, vec![trimmed.to_string()])?;
+        shell.submit_turn(client, vec![line], &interrupts)?;
     }
 }
 
@@ -193,15 +219,26 @@ struct AgentTurnInfo {
     #[serde(default)]
     output_text: String,
     #[serde(default)]
+    structured_output: Option<Value>,
+    #[serde(default)]
     status_message: String,
 }
 
 #[derive(Debug, Clone, Deserialize)]
 #[serde(rename_all = "camelCase")]
 struct AgentTurnEventInfo {
+    #[serde(default)]
+    id: String,
+    #[serde(default)]
+    turn_id: String,
+    #[serde(default)]
     seq: i64,
     #[serde(rename = "type")]
     event_type: String,
+    #[serde(default)]
+    source: String,
+    #[serde(default)]
+    visibility: String,
     #[serde(default)]
     data: Map<String, Value>,
 }
@@ -272,7 +309,12 @@ impl AgentShell {
         Ok(())
     }
 
-    fn submit_turn(&mut self, client: &ApiClient, messages: Vec<String>) -> Result<()> {
+    fn submit_turn(
+        &mut self,
+        client: &ApiClient,
+        messages: Vec<String>,
+        interrupts: &InterruptState,
+    ) -> Result<()> {
         let system_messages = if self.applied_system_messages {
             Vec::new()
         } else {
@@ -289,15 +331,16 @@ impl AgentShell {
         };
         let turn = create_turn_info(client, &turn_args)?;
         self.applied_system_messages = true;
-        drive_turn(client, &turn)?;
+        drive_turn(client, &turn, interrupts)?;
         Ok(())
     }
 }
 
-fn drive_turn(client: &ApiClient, turn: &AgentTurnInfo) -> Result<()> {
-    let mut renderer = AgentTurnRenderer::default();
+fn drive_turn(client: &ApiClient, turn: &AgentTurnInfo, interrupts: &InterruptState) -> Result<()> {
+    let mut renderer = AgentTurnRenderer::new();
+    let _cancel_guard = TurnCancelGuard::spawn(client, &turn.id, interrupts);
     loop {
-        drain_turn_events(client, &turn.id, &mut renderer)?;
+        stream_turn_events_until_blocked_or_terminal(client, &turn.id, &mut renderer)?;
         let latest = get_turn_info(client, &turn.id)?;
         renderer.finish_turn(&latest)?;
 
@@ -315,7 +358,19 @@ fn drive_turn(client: &ApiClient, turn: &AgentTurnInfo) -> Result<()> {
                     );
                 }
                 for interaction in pending {
-                    let resolution = prompt_interaction_resolution(&interaction)?;
+                    let prompt_interrupt_count = interrupts.count();
+                    let resolution = match prompt_interaction_resolution(&interaction) {
+                        Ok(resolution) => resolution,
+                        Err(_) if interrupts.count() > prompt_interrupt_count => {
+                            let _ = cancel_turn_silent(client, &turn.id, INTERRUPT_CANCEL_REASON);
+                            return Ok(());
+                        }
+                        Err(err) => return Err(err),
+                    };
+                    if interrupts.count() > prompt_interrupt_count {
+                        let _ = cancel_turn_silent(client, &turn.id, INTERRUPT_CANCEL_REASON);
+                        return Ok(());
+                    }
                     resolve_interaction_info(client, &turn.id, &interaction.id, resolution)?;
                 }
             }
@@ -326,15 +381,87 @@ fn drive_turn(client: &ApiClient, turn: &AgentTurnInfo) -> Result<()> {
     }
 }
 
-#[derive(Default)]
+#[derive(Clone)]
+struct InterruptState {
+    count: Arc<AtomicU64>,
+}
+
+impl InterruptState {
+    fn install() -> Self {
+        let count = Arc::new(AtomicU64::new(0));
+        let handler_count = Arc::clone(&count);
+        if let Err(err) = ctrlc::set_handler(move || {
+            handler_count.fetch_add(1, Ordering::SeqCst);
+        }) {
+            eprintln!("warning: failed to install Ctrl-C handler: {err}");
+        }
+        Self { count }
+    }
+
+    fn count(&self) -> u64 {
+        self.count.load(Ordering::SeqCst)
+    }
+}
+
+struct TurnCancelGuard {
+    active: Arc<AtomicBool>,
+    handle: Option<thread::JoinHandle<()>>,
+}
+
+impl TurnCancelGuard {
+    fn spawn(client: &ApiClient, turn_id: &str, interrupts: &InterruptState) -> Self {
+        let active = Arc::new(AtomicBool::new(true));
+        let thread_active = Arc::clone(&active);
+        let client = client.clone();
+        let turn_id = turn_id.to_string();
+        let interrupts = interrupts.clone();
+        let baseline = interrupts.count();
+        let handle = thread::spawn(move || {
+            while thread_active.load(Ordering::SeqCst) {
+                if interrupts.count() > baseline {
+                    let _ = cancel_turn_silent(&client, &turn_id, INTERRUPT_CANCEL_REASON);
+                    return;
+                }
+                thread::sleep(Duration::from_millis(100));
+            }
+        });
+        Self {
+            active,
+            handle: Some(handle),
+        }
+    }
+}
+
+impl Drop for TurnCancelGuard {
+    fn drop(&mut self) {
+        self.active.store(false, Ordering::SeqCst);
+        if let Some(handle) = self.handle.take() {
+            let _ = handle.join();
+        }
+    }
+}
+
 struct AgentTurnRenderer {
     after_seq: u64,
     assistant_line_open: bool,
     saw_assistant_output: bool,
+    saw_structured_output: bool,
     delta_buffer: String,
+    use_color: bool,
 }
 
 impl AgentTurnRenderer {
+    fn new() -> Self {
+        Self {
+            after_seq: 0,
+            assistant_line_open: false,
+            saw_assistant_output: false,
+            saw_structured_output: false,
+            delta_buffer: String::new(),
+            use_color: io::stdout().is_terminal(),
+        }
+    }
+
     fn after_seq(&self) -> u64 {
         self.after_seq
     }
@@ -346,7 +473,8 @@ impl AgentTurnRenderer {
             }
             match event.event_type.as_str() {
                 "agent.message.delta" | "assistant.delta" => {
-                    if let Some(text) = string_field(&event.data, "text") {
+                    if let Some(text) = string_any_field(&event.data, &["text", "delta", "content"])
+                    {
                         self.start_assistant_line()?;
                         print!("{text}");
                         io::stdout().flush().context("failed to flush stdout")?;
@@ -367,51 +495,106 @@ impl AgentTurnRenderer {
                         println!();
                         self.assistant_line_open = false;
                     } else if let Some(text) = text {
-                        println!("assistant> {text}");
+                        println!("{} {text}", self.label("assistant>"));
                         self.saw_assistant_output = true;
                     }
                     self.delta_buffer.clear();
                 }
+                "turn.started" => {
+                    self.finish_assistant_line();
+                    match string_any_field(&event.data, &["status", "state"]) {
+                        Some(status) => println!("{} started ({status})", self.label("turn>")),
+                        None => println!("{} started", self.label("turn>")),
+                    }
+                }
                 "tool.started" => {
                     self.finish_assistant_line();
-                    let tool_id =
-                        string_field(&event.data, "tool_id").unwrap_or_else(|| "tool".to_string());
-                    println!("tool> {tool_id} started");
+                    let tool = string_any_field(
+                        &event.data,
+                        &[
+                            "tool_name",
+                            "toolName",
+                            "name",
+                            "operation",
+                            "tool_id",
+                            "toolId",
+                        ],
+                    )
+                    .unwrap_or_else(|| "tool".to_string());
+                    print!("{} {tool} started", self.label("tool>"));
+                    if let Some(input) =
+                        value_any_field(&event.data, &["arguments", "input", "request"])
+                    {
+                        print!(" {}", compact_json(input)?);
+                    }
+                    println!();
                 }
                 "tool.completed" => {
                     self.finish_assistant_line();
-                    let tool_id =
-                        string_field(&event.data, "tool_id").unwrap_or_else(|| "tool".to_string());
-                    match number_field(&event.data, "status") {
-                        Some(status) => println!("tool> {tool_id} completed ({status})"),
-                        None => println!("tool> {tool_id} completed"),
+                    let tool = string_any_field(
+                        &event.data,
+                        &[
+                            "tool_name",
+                            "toolName",
+                            "name",
+                            "operation",
+                            "tool_id",
+                            "toolId",
+                        ],
+                    )
+                    .unwrap_or_else(|| "tool".to_string());
+                    let status =
+                        string_any_field(&event.data, &["status", "state"]).or_else(|| {
+                            number_any_field(&event.data, &["status", "statusCode"])
+                                .map(|status| status.to_string())
+                        });
+                    match status {
+                        Some(status) => {
+                            print!("{} {tool} completed ({status})", self.label("tool>"))
+                        }
+                        None => print!("{} {tool} completed", self.label("tool>")),
                     }
+                    if let Some(error) = string_field(&event.data, "error") {
+                        print!(": {error}");
+                    } else if let Some(output) =
+                        value_any_field(&event.data, &["output", "result", "body"])
+                    {
+                        print!(" {}", compact_json(output)?);
+                    }
+                    println!();
                 }
                 "interaction.requested" => {
                     self.finish_assistant_line();
-                    let interaction_id = string_field(&event.data, "interaction_id")
-                        .unwrap_or_else(|| "interaction".to_string());
-                    println!("interaction> requested ({interaction_id})");
+                    let interaction_id =
+                        string_any_field(&event.data, &["interaction_id", "interactionId"])
+                            .unwrap_or_else(|| "interaction".to_string());
+                    println!(
+                        "{} requested ({interaction_id})",
+                        self.label("interaction>")
+                    );
                 }
                 "interaction.resolved" => {
                     self.finish_assistant_line();
-                    let interaction_id = string_field(&event.data, "interaction_id")
-                        .unwrap_or_else(|| "interaction".to_string());
-                    println!("interaction> resolved ({interaction_id})");
+                    let interaction_id =
+                        string_any_field(&event.data, &["interaction_id", "interactionId"])
+                            .unwrap_or_else(|| "interaction".to_string());
+                    println!("{} resolved ({interaction_id})", self.label("interaction>"));
                 }
                 "turn.failed" => {
                     self.finish_assistant_line();
                     if let Some(message) = string_field(&event.data, "error") {
-                        println!("turn> failed: {message}");
+                        println!("{} failed: {message}", self.label("turn>"));
                     }
                 }
                 "turn.canceled" => {
                     self.finish_assistant_line();
                     if let Some(reason) = string_field(&event.data, "reason") {
-                        println!("turn> canceled: {reason}");
+                        println!("{} canceled: {reason}", self.label("turn>"));
                     }
                 }
-                _ => {}
+                "turn.completed" => {}
+                _ if event.visibility == "private" => {}
+                _ => self.render_generic_event(event)?,
             }
         }
         Ok(())
@@ -421,16 +604,26 @@ impl AgentTurnRenderer {
         self.finish_assistant_line();
         match turn.status.as_str() {
             "succeeded" if !self.saw_assistant_output && !turn.output_text.is_empty() => {
-                println!("assistant> {}", turn.output_text);
+                println!("{} {}", self.label("assistant>"), turn.output_text);
                 self.saw_assistant_output = true;
             }
             "failed" if !turn.status_message.is_empty() => {
-                println!("turn> failed: {}", turn.status_message);
+                println!("{} failed: {}", self.label("turn>"), turn.status_message);
             }
             "canceled" if !turn.status_message.is_empty() => {
-                println!("turn> canceled: {}", turn.status_message);
+                println!("{} canceled: {}", self.label("turn>"), turn.status_message);
             }
             _ => {}
+        }
+        if !self.saw_structured_output
+            && let Some(structured_output) = turn.structured_output.as_ref()
+        {
+            println!(
+                "{} {}",
+                self.label("structured>"),
+                pretty_json(structured_output)?
+            );
+            self.saw_structured_output = true;
         }
         self.delta_buffer.clear();
         Ok(())
@@ -438,7 +631,7 @@ impl AgentTurnRenderer {
 
     fn start_assistant_line(&mut self) -> Result<()> {
         if !self.assistant_line_open {
-            print!("assistant> ");
+            print!("{} ", self.label("assistant>"));
             io::stdout().flush().context("failed to flush stdout")?;
             self.assistant_line_open = true;
         }
@@ -451,22 +644,74 @@ impl AgentTurnRenderer {
             self.assistant_line_open = false;
         }
     }
+
+    fn render_generic_event(&mut self, event: &AgentTurnEventInfo) -> Result<()> {
+        self.finish_assistant_line();
+        let mut fields = Vec::new();
+        if !event.id.is_empty() {
+            fields.push(format!("id={}", event.id));
+        }
+        if !event.source.is_empty() {
+            fields.push(format!("source={}", event.source));
+        }
+        if !event.turn_id.is_empty() {
+            fields.push(format!("turn={}", event.turn_id));
+        }
+        let suffix = if fields.is_empty() {
+            String::new()
+        } else {
+            format!(" ({})", fields.join(" "))
+        };
+        if event.data.is_empty() {
+            println!("{} {}{}", self.label("event>"), event.event_type, suffix);
+        } else {
+            println!(
+                "{} {}{} {}",
+                self.label("event>"),
+                event.event_type,
+                suffix,
+                compact_json(&Value::Object(event.data.clone()))?
+            );
+        }
+        Ok(())
+    }
+
+    fn label(&self, value: &str) -> String {
+        if self.use_color {
+            value.bold().cyan().to_string()
+        } else {
+            value.to_string()
+        }
+    }
 }
 
-fn prompt_agent_line() -> Result<Option<String>> {
-    let mut stderr = io::stderr().lock();
-    write!(stderr, "agent> ")?;
-    stderr.flush()?;
-
-    let mut line = String::new();
-    let read = io::stdin()
-        .read_line(&mut line)
-        .context("failed to read agent input")?;
-    if read == 0 {
-        writeln!(stderr)?;
-        return Ok(None);
+fn prompt_agent_message(input: &mut InteractiveLineReader) -> Result<Option<String>> {
+    let mut lines = Vec::new();
+    let mut prompt = "agent> ";
+    loop {
+        match input.read_line(prompt)? {
+            PromptLine::Line(mut line) => {
+                let continued = has_trailing_continuation(&line);
+                if continued {
+                    line.pop();
+                }
+                lines.push(line);
+                if !continued {
+                    return Ok(Some(lines.join("\n")));
+                }
+                prompt = "...> ";
+            }
+            PromptLine::Interrupted => {
+                eprintln!("^C");
+                return Ok(Some(String::new()));
+            }
+            PromptLine::Eof => return Ok(None),
+        }
     }
-    Ok(Some(line.trim().to_string()))
+}
+
+fn has_trailing_continuation(line: &str) -> bool {
+    line.chars().rev().take_while(|ch| *ch == '\\').count() % 2 == 1
 }
 
 fn prompt_interaction_resolution(interaction: &AgentInteractionInfo) -> Result<Map<String, Value>> {
@@ -543,27 +788,57 @@ fn prompt_interaction_resolution(interaction: &AgentInteractionInfo) -> Result<M
     }
 }
 
-fn drain_turn_events(
+fn stream_turn_events_until_blocked_or_terminal(
     client: &ApiClient,
     turn_id: &str,
     renderer: &mut AgentTurnRenderer,
 ) -> Result<()> {
-    loop {
-        let events = list_turn_events_info(
-            client,
+    let resp = client
+        .get_stream(&turn_events_path(
             turn_id,
-            renderer.after_seq(),
-            DEFAULT_EVENT_PAGE_SIZE,
-        )?;
-        if events.is_empty() {
+            true,
+            Some(renderer.after_seq()),
+            Some(DEFAULT_EVENT_PAGE_SIZE),
+            Some(EVENT_STREAM_UNTIL_BLOCKED_OR_TERMINAL),
+        ))
+        .with_context(|| format!("failed to stream events for agent turn {turn_id}"))?;
+    let mut reader = BufReader::new(resp);
+    let mut line = String::new();
+    let mut data = String::new();
+
+    loop {
+        line.clear();
+        let read = reader
+            .read_line(&mut line)
+            .context("failed to read agent turn event stream")?;
+        if read == 0 {
+            render_sse_event_data(&mut data, renderer)?;
             return Ok(());
         }
-        let event_count = events.len();
-        renderer.render_events(&events)?;
-        if event_count < DEFAULT_EVENT_PAGE_SIZE as usize {
-            return Ok(());
+
+        let trimmed = line.trim_end_matches(['\r', '\n']);
+        if trimmed.is_empty() {
+            render_sse_event_data(&mut data, renderer)?;
+            continue;
+        }
+
+        if let Some(value) = trimmed.strip_prefix("data:") {
+            if !data.is_empty() {
+                data.push('\n');
+            }
+            data.push_str(value.strip_prefix(' ').unwrap_or(value));
         }
     }
+}
+
+fn render_sse_event_data(data: &mut String, renderer: &mut AgentTurnRenderer) -> Result<()> {
+    if data.is_empty() {
+        return Ok(());
+    }
+    let raw = std::mem::take(data);
+    let event: AgentTurnEventInfo = serde_json::from_str(&raw)
+        .with_context(|| format!("failed to decode agent turn event stream frame: {raw}"))?;
+    renderer.render_events(&[event])
 }
 
 fn create_session_info(
@@ -648,19 +923,6 @@ fn get_turn_info(client: &ApiClient, id: &str) -> Result<AgentTurnInfo> {
     )
 }
 
-fn list_turn_events_info(
-    client: &ApiClient,
-    turn_id: &str,
-    after: u64,
-    limit: u32,
-) -> Result<Vec<AgentTurnEventInfo>> {
-    decode_json(
-        client
-            .get(&turn_events_path(turn_id, false, Some(after), Some(limit)))
-            .with_context(|| format!("failed to list events for agent turn {turn_id}"))?,
-    )
-}
-
 fn list_interactions_info(client: &ApiClient, turn_id: &str) -> Result<Vec<AgentInteractionInfo>> {
     decode_json(
         client
@@ -698,8 +960,24 @@ fn string_field(data: &Map<String, Value>, key: &str) -> Option<String> {
         .map(ToString::to_string)
 }
 
-fn number_field(data: &Map<String, Value>, key: &str) -> Option<i64> {
-    data.get(key).and_then(Value::as_i64)
+fn string_any_field(data: &Map<String, Value>, keys: &[&str]) -> Option<String> {
+    keys.iter().find_map(|key| string_field(data, key))
+}
+
+fn value_any_field<'a>(data: &'a Map<String, Value>, keys: &[&str]) -> Option<&'a Value> {
+    keys.iter().find_map(|key| data.get(*key))
+}
+
+fn number_any_field(data: &Map<String, Value>, keys: &[&str]) -> Option<i64> {
+    keys.iter().find_map(|key| data.get(*key)?.as_i64())
+}
+
+fn compact_json(value: &Value) -> Result<String> {
+    serde_json::to_string(value).context("failed to encode compact JSON")
+}
+
+fn pretty_json(value: &Value) -> Result<String> {
+    serde_json::to_string_pretty(value).context("failed to encode pretty JSON")
 }
 
 fn build_session_create_body(args: &AgentSessionCreateArgs) -> Result<Value> {
@@ -848,13 +1126,22 @@ fn session_turns_path(session_id: &str, status: Option<&str>) -> String {
     }
 }
 
-fn turn_events_path(id: &str, stream: bool, after: Option<u64>, limit: Option<u32>) -> String {
+fn turn_events_path(
+    id: &str,
+    stream: bool,
+    after: Option<u64>,
+    limit: Option<u32>,
+    until: Option<&str>,
+) -> String {
     let mut serializer = url::form_urlencoded::Serializer::new(String::new());
     if let Some(after) = after {
         serializer.append_pair("after", &after.to_string());
     }
     if let Some(limit) = limit {
         serializer.append_pair("limit", &limit.to_string());
+    }
+    if let Some(until) = until {
+        serializer.append_pair("until", until);
     }
     let suffix = if stream { "/events/stream" } else { "/events" };
     let query = serializer.finish();

--- a/gestalt/cli/src/interactive.rs
+++ b/gestalt/cli/src/interactive.rs
@@ -1,6 +1,11 @@
 use std::io::{self, BufRead, IsTerminal, Write};
+use std::path::PathBuf;
 
 use anyhow::{Context, Result, bail};
+use rustyline::error::ReadlineError;
+use rustyline::{Config, DefaultEditor};
+
+use crate::paths;
 
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct PromptOption {
@@ -15,6 +20,147 @@ pub struct InputPrompt {
     pub default: Option<String>,
     pub required: bool,
     pub secret: bool,
+}
+
+pub enum PromptLine {
+    Line(String),
+    Interrupted,
+    Eof,
+}
+
+enum LineReaderBackend {
+    Editor {
+        editor: Box<DefaultEditor>,
+        history_path: Option<PathBuf>,
+    },
+    Stdin,
+}
+
+pub struct InteractiveLineReader {
+    backend: LineReaderBackend,
+}
+
+impl InteractiveLineReader {
+    pub fn with_history_namespace(namespace: &str) -> Result<Self> {
+        if !io::stdin().is_terminal() || !io::stderr().is_terminal() {
+            return Ok(Self {
+                backend: LineReaderBackend::Stdin,
+            });
+        }
+
+        // Keep SIGINT owned by the CLI cancellation handler while line editing is active.
+        let editor_config = Config::builder().enable_signals(false).build();
+        let mut editor = match DefaultEditor::with_config(editor_config) {
+            Ok(editor) => editor,
+            Err(err) => {
+                eprintln!("warning: failed to initialize interactive line editor: {err}");
+                return Ok(Self {
+                    backend: LineReaderBackend::Stdin,
+                });
+            }
+        };
+        let history_path = match history_path(namespace) {
+            Ok(path) => Some(path),
+            Err(err) => {
+                eprintln!("warning: failed to resolve interactive history path: {err}");
+                None
+            }
+        };
+        if let Some(path) = history_path.as_ref()
+            && path.exists()
+            && let Err(err) = editor.load_history(path)
+        {
+            eprintln!("warning: failed to load history {}: {err}", path.display());
+        }
+
+        Ok(Self {
+            backend: LineReaderBackend::Editor {
+                editor: Box::new(editor),
+                history_path,
+            },
+        })
+    }
+
+    pub fn read_line(&mut self, prompt: &str) -> Result<PromptLine> {
+        match &mut self.backend {
+            LineReaderBackend::Editor { editor, .. } => match editor.readline(prompt) {
+                Ok(line) => {
+                    if !line.trim().is_empty() {
+                        let _ = editor.add_history_entry(line.as_str());
+                    }
+                    Ok(PromptLine::Line(line))
+                }
+                Err(ReadlineError::Interrupted) => Ok(PromptLine::Interrupted),
+                Err(ReadlineError::Eof) => Ok(PromptLine::Eof),
+                Err(err) => Err(err).context("failed to read interactive input"),
+            },
+            LineReaderBackend::Stdin => read_prompt_line(prompt),
+        }
+    }
+
+    pub fn save_history(&mut self) -> Result<()> {
+        match &mut self.backend {
+            LineReaderBackend::Editor {
+                editor,
+                history_path,
+            } => {
+                let Some(history_path) = history_path.as_ref() else {
+                    return Ok(());
+                };
+                if let Some(parent) = history_path.parent() {
+                    std::fs::create_dir_all(parent).with_context(|| {
+                        format!("failed to create history directory {}", parent.display())
+                    })?;
+                }
+                editor
+                    .save_history(history_path)
+                    .with_context(|| format!("failed to save history {}", history_path.display()))
+            }
+            LineReaderBackend::Stdin => Ok(()),
+        }
+    }
+}
+
+impl Drop for InteractiveLineReader {
+    fn drop(&mut self) {
+        let _ = self.save_history();
+    }
+}
+
+fn history_path(namespace: &str) -> Result<PathBuf> {
+    let cwd = std::env::current_dir().context("failed to determine current directory")?;
+    let encoded_cwd: String =
+        url::form_urlencoded::byte_serialize(cwd.to_string_lossy().as_bytes()).collect();
+    let namespace = namespace
+        .trim_matches(|ch: char| ch == '/' || ch.is_whitespace())
+        .replace('/', "_");
+    let namespace = if namespace.is_empty() {
+        "default".to_string()
+    } else {
+        namespace
+    };
+    Ok(paths::gestalt_config_dir()?
+        .join("history")
+        .join(namespace)
+        .join(format!("{encoded_cwd}.history")))
+}
+
+fn read_prompt_line(prompt: &str) -> Result<PromptLine> {
+    let mut stderr = io::stderr().lock();
+    write!(stderr, "{prompt}")?;
+    stderr.flush()?;
+
+    let mut line = String::new();
+    let read = io::stdin()
+        .read_line(&mut line)
+        .context("failed to read input")?;
+    if read == 0 {
+        writeln!(stderr)?;
+        return Ok(PromptLine::Eof);
+    }
+    Ok(PromptLine::Line(
+        line.trim_end_matches(['\r', '\n']).to_string(),
+    ))
 }
 
 fn read_line() -> Result<Option<String>> {

--- a/gestalt/cli/tests/agents_cli.rs
+++ b/gestalt/cli/tests/agents_cli.rs
@@ -335,23 +335,25 @@ fn test_cli_runs_interactive_agent_session() {
     )
     .match_header(header::CONTENT_TYPE.as_str(), http::APPLICATION_JSON)
     .match_body(Matcher::JsonString(
-        r#"{"model":"gpt-5.4","messages":[{"role":"user","text":"hello there"}]}"#.to_string(),
+        r#"{"model":"gpt-5.4","messages":[{"role":"user","text":"hello\nthere"}]}"#.to_string(),
     ))
     .with_body(TURN_JSON)
     .create();
-    let _events = authed_json_mock!(
-        server,
-        Method::GET,
-        "/api/v1/agent/turns/turn-1/events?after=0&limit=100",
-        StatusCode::OK
-    )
-    .with_body(
-        r#"[
-            {"seq":1,"type":"assistant.completed","data":{"text":"hello back"}},
-            {"seq":2,"type":"turn.completed","data":{"status":"succeeded"}}
-        ]"#,
-    )
-    .create();
+    let _events = server
+        .mock(
+            Method::GET.as_str(),
+            "/api/v1/agent/turns/turn-1/events/stream?after=0&limit=100&until=blocked_or_terminal",
+        )
+        .match_header(header::AUTHORIZATION.as_str(), Matcher::Exact(test_bearer()))
+        .with_status(usize::from(StatusCode::OK.as_u16()))
+        .with_header(header::CONTENT_TYPE.as_str(), "text/event-stream")
+        .with_body(
+            "data: {\"seq\":1,\"type\":\"tool.started\",\"data\":{\"toolName\":\"lookup\",\"arguments\":{\"ticket\":\"INC-42\"}}}\n\n\
+             data: {\"seq\":2,\"type\":\"tool.completed\",\"data\":{\"toolName\":\"lookup\",\"status\":200,\"output\":{\"ok\":true}}}\n\n\
+             data: {\"seq\":3,\"type\":\"assistant.completed\",\"data\":{\"text\":\"hello back\"}}\n\n\
+             data: {\"seq\":4,\"type\":\"turn.completed\",\"data\":{\"status\":\"succeeded\"}}\n\n",
+        )
+        .create();
     let _get_turn = authed_json_mock!(
         server,
         Method::GET,
@@ -365,7 +367,8 @@ fn test_cli_runs_interactive_agent_session() {
             "provider":"managed",
             "model":"gpt-5.4",
             "status":"succeeded",
-            "outputText":"hello back"
+            "outputText":"hello back",
+            "structuredOutput":{"summary":"ok"}
         }"#,
     )
     .create();
@@ -373,10 +376,14 @@ fn test_cli_runs_interactive_agent_session() {
     let home = tempfile::tempdir().unwrap();
     cli_command_for_server(home.path(), &server)
         .args(["agent", "--provider", "managed", "--model", "gpt-5.4"])
-        .write_stdin("hello there\n/quit\n")
+        .write_stdin("hello\\\nthere\n/quit\n")
         .assert()
         .success()
+        .stdout(predicate::str::contains("tool> lookup started"))
+        .stdout(predicate::str::contains("tool> lookup completed (200)"))
         .stdout(predicate::str::contains("assistant> hello back"))
+        .stdout(predicate::str::contains("structured>"))
+        .stdout(predicate::str::contains(r#""summary": "ok""#))
         .stderr(predicate::str::contains(
             "Session session-1 [managed / gpt-5.4]",
         ))
@@ -428,13 +435,11 @@ fn test_cli_resumes_latest_active_agent_session() {
         ),
         ExpectedRequest::text(
             Method::GET,
-            "/api/v1/agent/turns/turn-resumed/events?after=0&limit=100",
+            "/api/v1/agent/turns/turn-resumed/events/stream?after=0&limit=100&until=blocked_or_terminal",
             StatusCode::OK,
-            http::APPLICATION_JSON,
-            r#"[
-                {"seq":1,"type":"assistant.completed","data":{"text":"continued"}},
-                {"seq":2,"type":"turn.completed","data":{"status":"succeeded"}}
-            ]"#,
+            "text/event-stream",
+            "data: {\"seq\":1,\"type\":\"assistant.completed\",\"data\":{\"text\":\"continued\"}}\n\n\
+             data: {\"seq\":2,\"type\":\"turn.completed\",\"data\":{\"status\":\"succeeded\"}}\n\n",
         ),
         ExpectedRequest::text(
             Method::GET,
@@ -556,13 +561,11 @@ fn test_cli_resumes_existing_agent_session_and_resolves_input_interaction() {
         ),
         ExpectedRequest::text(
             Method::GET,
-            "/api/v1/agent/turns/turn-input/events?after=0&limit=100",
+            "/api/v1/agent/turns/turn-input/events/stream?after=0&limit=100&until=blocked_or_terminal",
             StatusCode::OK,
-            http::APPLICATION_JSON,
-            r#"[
-                {"seq":1,"type":"turn.started","data":{"status":"running"}},
-                {"seq":2,"type":"interaction.requested","data":{"interaction_id":"interaction-2"}}
-            ]"#,
+            "text/event-stream",
+            "data: {\"seq\":1,\"type\":\"turn.started\",\"data\":{\"status\":\"running\"}}\n\n\
+             data: {\"seq\":2,\"type\":\"interaction.requested\",\"data\":{\"interaction_id\":\"interaction-2\"}}\n\n",
         ),
         ExpectedRequest::text(
             Method::GET,
@@ -611,14 +614,12 @@ fn test_cli_resumes_existing_agent_session_and_resolves_input_interaction() {
         ),
         ExpectedRequest::text(
             Method::GET,
-            "/api/v1/agent/turns/turn-input/events?after=2&limit=100",
+            "/api/v1/agent/turns/turn-input/events/stream?after=2&limit=100&until=blocked_or_terminal",
             StatusCode::OK,
-            http::APPLICATION_JSON,
-            r#"[
-                {"seq":3,"type":"interaction.resolved","data":{"interaction_id":"interaction-2"}},
-                {"seq":4,"type":"assistant.completed","data":{"text":"incident INC-42 summarized"}},
-                {"seq":5,"type":"turn.completed","data":{"status":"succeeded"}}
-            ]"#,
+            "text/event-stream",
+            "data: {\"seq\":3,\"type\":\"interaction.resolved\",\"data\":{\"interaction_id\":\"interaction-2\"}}\n\n\
+             data: {\"seq\":4,\"type\":\"assistant.completed\",\"data\":{\"text\":\"incident INC-42 summarized\"}}\n\n\
+             data: {\"seq\":5,\"type\":\"turn.completed\",\"data\":{\"status\":\"succeeded\"}}\n\n",
         ),
         ExpectedRequest::text(
             Method::GET,
@@ -693,13 +694,11 @@ fn test_cli_resolves_agent_interaction_in_interactive_mode() {
         ),
         ExpectedRequest::text(
             Method::GET,
-            "/api/v1/agent/turns/turn-approval/events?after=0&limit=100",
+            "/api/v1/agent/turns/turn-approval/events/stream?after=0&limit=100&until=blocked_or_terminal",
             StatusCode::OK,
-            http::APPLICATION_JSON,
-            r#"[
-                {"seq":1,"type":"turn.started","data":{"status":"running"}},
-                {"seq":2,"type":"interaction.requested","data":{"interaction_id":"interaction-1"}}
-            ]"#,
+            "text/event-stream",
+            "data: {\"seq\":1,\"type\":\"turn.started\",\"data\":{\"status\":\"running\"}}\n\n\
+             data: {\"seq\":2,\"type\":\"interaction.requested\",\"data\":{\"interaction_id\":\"interaction-1\"}}\n\n",
         ),
         ExpectedRequest::text(
             Method::GET,
@@ -748,14 +747,12 @@ fn test_cli_resolves_agent_interaction_in_interactive_mode() {
         ),
         ExpectedRequest::text(
             Method::GET,
-            "/api/v1/agent/turns/turn-approval/events?after=2&limit=100",
+            "/api/v1/agent/turns/turn-approval/events/stream?after=2&limit=100&until=blocked_or_terminal",
             StatusCode::OK,
-            http::APPLICATION_JSON,
-            r#"[
-                {"seq":3,"type":"interaction.resolved","data":{"interaction_id":"interaction-1"}},
-                {"seq":4,"type":"assistant.completed","data":{"text":"deployment approved"}},
-                {"seq":5,"type":"turn.completed","data":{"status":"succeeded"}}
-            ]"#,
+            "text/event-stream",
+            "data: {\"seq\":3,\"type\":\"interaction.resolved\",\"data\":{\"interaction_id\":\"interaction-1\"}}\n\n\
+             data: {\"seq\":4,\"type\":\"assistant.completed\",\"data\":{\"text\":\"deployment approved\"}}\n\n\
+             data: {\"seq\":5,\"type\":\"turn.completed\",\"data\":{\"status\":\"succeeded\"}}\n\n",
         ),
         ExpectedRequest::text(
             Method::GET,

--- a/gestaltd/internal/server/agent_session_turn_test.go
+++ b/gestaltd/internal/server/agent_session_turn_test.go
@@ -561,6 +561,43 @@ func TestAgentInteractionResolutionAndEventStream(t *testing.T) {
 	_ = json.NewDecoder(turnResp.Body).Decode(&turn)
 	turnID := turn["id"].(string)
 
+	blockedCtx, blockedCancel := context.WithTimeout(context.Background(), 2*time.Second)
+	defer blockedCancel()
+	blockedReq, _ := http.NewRequestWithContext(blockedCtx, http.MethodGet, ts.URL+"/api/v1/agent/turns/"+turnID+"/events/stream?after=0&limit=1&until=blocked_or_terminal", nil)
+	blockedReq.AddCookie(&http.Cookie{Name: "session_token", Value: "ada-session"})
+	blockedResp, err := http.DefaultClient.Do(blockedReq)
+	if err != nil {
+		t.Fatalf("stream blocked events: %v", err)
+	}
+	defer func() { _ = blockedResp.Body.Close() }()
+	if blockedResp.StatusCode != http.StatusOK {
+		t.Fatalf("blocked stream status = %d", blockedResp.StatusCode)
+	}
+	blockedReader := bufio.NewReader(blockedResp.Body)
+	var blocked []string
+	for {
+		line, err := blockedReader.ReadString('\n')
+		if err != nil {
+			break
+		}
+		line = strings.TrimSpace(line)
+		if strings.HasPrefix(line, "data: ") {
+			blocked = append(blocked, strings.TrimPrefix(line, "data: "))
+		}
+	}
+	if blockedCtx.Err() != nil {
+		t.Fatalf("blocked stream did not close before context deadline")
+	}
+	if len(blocked) == 0 {
+		t.Fatal("expected blocked stream events")
+	}
+	if !strings.Contains(strings.Join(blocked, "\n"), "interaction.requested") {
+		t.Fatalf("blocked stream events = %#v, want interaction.requested", blocked)
+	}
+	if strings.Contains(strings.Join(blocked, "\n"), "turn.completed") {
+		t.Fatalf("blocked stream events = %#v, did not expect turn.completed", blocked)
+	}
+
 	streamCtx, cancel := context.WithCancel(context.Background())
 	defer cancel()
 	streamReq, _ := http.NewRequestWithContext(streamCtx, http.MethodGet, ts.URL+"/api/v1/agent/turns/"+turnID+"/events/stream?after=1&limit=10", nil)

--- a/gestaltd/internal/server/handlers_agent.go
+++ b/gestaltd/internal/server/handlers_agent.go
@@ -26,6 +26,8 @@ import (
 const agentIdempotencyKeyHeader = "Idempotency-Key"
 const defaultAgentTurnEventLimit = 100
 const maxAgentTurnEventLimit = 1000
+const agentTurnEventStreamUntilTerminal = "terminal"
+const agentTurnEventStreamUntilBlockedOrTerminal = "blocked_or_terminal"
 
 type agentMessageRequest struct {
 	Role     string                    `json:"role,omitempty"`
@@ -399,6 +401,10 @@ func (s *Server) streamAgentTurnEvents(w http.ResponseWriter, r *http.Request) {
 	if !ok {
 		return
 	}
+	until, ok := parseAgentTurnEventStreamUntil(w, r)
+	if !ok {
+		return
+	}
 	flusher, ok := w.(http.Flusher)
 	if !ok {
 		writeError(w, http.StatusInternalServerError, "streaming is not supported")
@@ -417,6 +423,7 @@ func (s *Server) streamAgentTurnEvents(w http.ResponseWriter, r *http.Request) {
 			s.writeAgentManagerError(w, r, "turn", turnID, nil, err)
 			return
 		}
+		pageFull := limit > 0 && len(events) == limit
 		for _, event := range events {
 			info := agentTurnEventInfoFromCore(event)
 			payload, err := json.Marshal(info)
@@ -432,12 +439,15 @@ func (s *Server) streamAgentTurnEvents(w http.ResponseWriter, r *http.Request) {
 				afterSeq = info.Seq
 			}
 		}
-		terminal, err := s.agentTurnTerminalStatus(ctx, p, turnID)
+		if pageFull {
+			continue
+		}
+		done, err := s.agentTurnStreamDone(ctx, p, turnID, until)
 		if err != nil {
 			s.writeAgentManagerError(w, r, "turn", turnID, nil, err)
 			return
 		}
-		if terminal {
+		if done {
 			return
 		}
 		select {
@@ -540,7 +550,20 @@ func parseAgentTurnEventQuery(w http.ResponseWriter, r *http.Request) (int64, in
 	return afterSeq, limit, true
 }
 
-func (s *Server) agentTurnTerminalStatus(ctx context.Context, p *principal.Principal, turnID string) (bool, error) {
+func parseAgentTurnEventStreamUntil(w http.ResponseWriter, r *http.Request) (string, bool) {
+	value := strings.TrimSpace(r.URL.Query().Get("until"))
+	switch value {
+	case "", agentTurnEventStreamUntilTerminal:
+		return agentTurnEventStreamUntilTerminal, true
+	case agentTurnEventStreamUntilBlockedOrTerminal:
+		return agentTurnEventStreamUntilBlockedOrTerminal, true
+	default:
+		writeError(w, http.StatusBadRequest, "until must be terminal or blocked_or_terminal")
+		return "", false
+	}
+}
+
+func (s *Server) agentTurnStreamDone(ctx context.Context, p *principal.Principal, turnID string, until string) (bool, error) {
 	turn, err := s.agentRuns.GetTurn(ctx, p, turnID)
 	if err != nil {
 		return false, err
@@ -548,6 +571,8 @@ func (s *Server) agentTurnTerminalStatus(ctx context.Context, p *principal.Princ
 	switch turn.Status {
 	case coreagent.ExecutionStatusSucceeded, coreagent.ExecutionStatusFailed, coreagent.ExecutionStatusCanceled:
 		return true, nil
+	case coreagent.ExecutionStatusWaitingForInput:
+		return until == agentTurnEventStreamUntilBlockedOrTerminal, nil
 	default:
 		return false, nil
 	}


### PR DESCRIPTION
## Summary
- add a reusable history-backed interactive line reader for `gestalt agent`
- drive interactive turns from parsed SSE frames using the new block-aware stream mode
- cancel the active turn on Ctrl-C and render assistant/tool/interaction/structured output events more fully

## New Interfaces
- CLI: `gestalt agent` supports TTY line editing, per-directory history, trailing-backslash multiline input, parsed event output, inline interaction prompts, and Ctrl-C active-turn cancellation.
- HTTP: `GET /api/v1/agent/turns/{turnID}/events/stream` accepts `until=terminal|blocked_or_terminal`; omitted `until` keeps the existing terminal-only behavior.

## Examples
```sh
# Continue one user message across prompts
agent> first line\
...> second line

# Stream until a turn is terminal or blocked on an interaction
curl -N -H 'Authorization: Bearer gst_api_...' \
  'http://localhost:8080/api/v1/agent/turns/turn-123/events/stream?after=0&until=blocked_or_terminal'

# Raw SSE pass-through remains unchanged
gestalt agent turns events stream turn-123 --after 0
```

## Verification
- `cargo check --manifest-path gestalt/cli/Cargo.toml`
- `cargo test --manifest-path gestalt/cli/Cargo.toml --test agents_cli`
- `go test ./internal/server -run Agent -count=1`