### PR TITLE
Add remote provider dev attach sessions

### DIFF
--- a/docs/content/reference/cli.mdx
+++ b/docs/content/reference/cli.mdx
@@ -33,6 +33,8 @@ import { Callout } from 'nextra/components'
 | --- | --- |
 | `gestaltd provider dev --path PATH` | Run a local source plugin or UI bundle inside a synthesized Gestalt config. Serves `/admin` and any configured or inferred public UIs. |
 | `gestaltd provider dev --config PATH` | Layer supporting providers, plugins, and UI mounts on top of the synthesized local baseline. Repeat `--config` to merge left-to-right. |
+| `gestaltd provider dev --remote URL --path PATH` | Attach one local source plugin to an authenticated remote `gestaltd` session while the remote config keeps auth, authorization, connections, and host services. |
+| `gestaltd provider dev --remote URL --config PATH` | Attach every source-backed plugin in the layered config. Use repeated `--config` files the same way as local dev to choose which plugins are local and which remain remote. |
 | `gestaltd provider validate --path PATH` | Validate a local source plugin or UI bundle inside the same synthesized Gestalt config used by `provider dev`. |
 | `gestaltd provider validate --config PATH` | Validate the target provider together with selected supporting providers and `null` deletions from layered config overlays. |
 | `gestaltd provider release --version VERSION` | Build and package a provider release. Go, Python, Rust, and TypeScript source plugins default to the host platform. Pass `--platform ...` with `os/arch[/libc]` targets or `--platform all` for multi-platform builds. |
@@ -56,6 +58,8 @@ gestaltd provider validate --path ./plugins/support --config ./dev/support.yaml 
 gestaltd provider dev --path ./plugins/support
 gestaltd provider dev --path ./ui/dashboard
 gestaltd provider dev --path ./plugins/support --config ./dev/support.yaml --port 8080
+GESTALT_API_KEY=vat_... gestaltd provider dev --remote https://gestalt.example.com --path ./plugins/support
+GESTALT_API_KEY=vat_... gestaltd provider dev --remote https://gestalt.example.com --config ./remote.yaml --config ./local-overrides.yaml
 gestaltd provider release --version 0.0.1-alpha.1
 gestaltd provider release --version 0.0.1-alpha.1 --platform all
 gestaltd provider release --version 0.0.1-alpha.1 --platform linux/amd64,linux/arm64
@@ -66,5 +70,15 @@ scalar values win, lists replace inherited lists, and `null` deletes inherited
 keys. By default, lockfiles and artifact paths stay rooted at the leftmost
 config file. `--lockfile` overrides only the lockfile path. `--artifacts-dir`
 keeps its existing config-relative behavior for backward compatibility.
+
+`provider dev --remote` is environment-agnostic: the URL is just the remote
+`gestaltd` instance to attach to. The local command only replaces source-backed
+plugin implementations for the authenticated principal that created the session;
+all non-local plugins, credentials, policies, and host services continue to
+resolve through the remote instance. Remote servers expose attach targets only
+for source-backed plugin config entries or release-backed plugin entries that
+explicitly set `providerDev: true`. Remote mode tunnels plugin RPC, catalog,
+post-connect, and host-service calls; raw GraphQL surfaces are not tunneled in
+v1.
 
 See [Configuration](/configuration) for the relationship between `init`, `serve --locked`, and `validate`.

--- a/docs/content/reference/config-file.mdx
+++ b/docs/content/reference/config-file.mdx
@@ -1021,6 +1021,11 @@ For local development with a source provider package:
 source: ./manifest.yaml
 ```
 
+Set `providerDev: true` on a release-backed plugin only when that remote
+`gestaltd` instance should allow authenticated developers to attach a local
+implementation with `gestaltd provider dev --remote`. Source-backed plugin
+entries are already treated as explicit local-development targets.
+
 Gestalt synthesizes Go and Rust executable wrappers automatically when needed and runs Python source providers from the module declared in `[tool.gestalt].provider` or the legacy `[tool.gestalt].plugin`.
 
 <Tabs items={['Go', 'Python', 'Rust']}>

--- a/gestaltd/cmd/gestaltd/e2e_test.go
+++ b/gestaltd/cmd/gestaltd/e2e_test.go
@@ -1660,6 +1660,44 @@ func startCommandAndWaitReadyAndFile(t *testing.T, cmd *exec.Cmd, baseURL, requi
 	}
 }
 
+func waitForHTTPBody(t *testing.T, client *http.Client, url, wantBody string) string {
+	t.Helper()
+
+	tick := time.NewTicker(250 * time.Millisecond)
+	defer tick.Stop()
+	timeout := time.After(60 * time.Second)
+	var lastStatus int
+	var lastBody string
+	var lastErr error
+	for {
+		select {
+		case <-timeout:
+			if lastErr != nil {
+				t.Fatalf("GET %s did not become ready within 60 seconds; last error: %v", url, lastErr)
+			}
+			t.Fatalf("GET %s did not return expected body within 60 seconds; last status=%d body=%s", url, lastStatus, lastBody)
+		case <-tick.C:
+			resp, err := client.Get(url)
+			if err != nil {
+				lastErr = err
+				continue
+			}
+			body, readErr := io.ReadAll(resp.Body)
+			_ = resp.Body.Close()
+			if readErr != nil {
+				lastErr = readErr
+				continue
+			}
+			lastErr = nil
+			lastStatus = resp.StatusCode
+			lastBody = string(body)
+			if resp.StatusCode == http.StatusOK && strings.Contains(lastBody, wantBody) {
+				return lastBody
+			}
+		}
+	}
+}
+
 func startGestaltdWithConfig(t *testing.T, cfgPath string) string {
 	t.Helper()
 	return startGestaltdWithConfigs(t, []string{cfgPath}, false)
@@ -1767,18 +1805,7 @@ func TestE2EProviderDevAutoMountsOwnedUI(t *testing.T) {
 	startCommandAndWaitReady(t, cmd, baseURL)
 
 	client := &http.Client{Timeout: 2 * time.Second}
-	uiResp, err := client.Get(baseURL + "/provider/sync")
-	if err != nil {
-		t.Fatalf("GET /provider/sync: %v", err)
-	}
-	defer func() { _ = uiResp.Body.Close() }()
-	uiBody, _ := io.ReadAll(uiResp.Body)
-	if uiResp.StatusCode != http.StatusOK {
-		t.Fatalf("expected /provider/sync 200, got %d: %s", uiResp.StatusCode, uiBody)
-	}
-	if !strings.Contains(string(uiBody), "Roadmap Review UI") {
-		t.Fatalf("expected owned ui body marker, got: %s", uiBody)
-	}
+	_ = waitForHTTPBody(t, client, baseURL+"/provider/sync", "Roadmap Review UI")
 
 	integrationsResp, err := client.Get(baseURL + "/api/v1/integrations")
 	if err != nil {
@@ -1826,18 +1853,7 @@ func TestE2EProviderDevServesSourceUI(t *testing.T) {
 	startCommandAndWaitReady(t, cmd, baseURL)
 
 	client := &http.Client{Timeout: 2 * time.Second}
-	uiResp, err := client.Get(baseURL + "/roadmap_review/sync")
-	if err != nil {
-		t.Fatalf("GET /roadmap_review/sync: %v", err)
-	}
-	defer func() { _ = uiResp.Body.Close() }()
-	uiBody, _ := io.ReadAll(uiResp.Body)
-	if uiResp.StatusCode != http.StatusOK {
-		t.Fatalf("expected /roadmap_review/sync 200, got %d: %s", uiResp.StatusCode, uiBody)
-	}
-	if !strings.Contains(string(uiBody), "Roadmap Review UI") {
-		t.Fatalf("expected direct ui body marker, got: %s", uiBody)
-	}
+	_ = waitForHTTPBody(t, client, baseURL+"/roadmap_review/sync", "Roadmap Review UI")
 }
 
 func TestE2EProviderDevAutoMountsSiblingUIForPlugin(t *testing.T) {
@@ -1864,18 +1880,7 @@ func TestE2EProviderDevAutoMountsSiblingUIForPlugin(t *testing.T) {
 	startCommandAndWaitReady(t, cmd, baseURL)
 
 	client := &http.Client{Timeout: 2 * time.Second}
-	uiResp, err := client.Get(baseURL + "/provider/sync")
-	if err != nil {
-		t.Fatalf("GET /provider/sync: %v", err)
-	}
-	defer func() { _ = uiResp.Body.Close() }()
-	uiBody, _ := io.ReadAll(uiResp.Body)
-	if uiResp.StatusCode != http.StatusOK {
-		t.Fatalf("expected /provider/sync 200, got %d: %s", uiResp.StatusCode, uiBody)
-	}
-	if !strings.Contains(string(uiBody), "Roadmap Review UI") {
-		t.Fatalf("expected sibling ui body marker, got: %s", uiBody)
-	}
+	_ = waitForHTTPBody(t, client, baseURL+"/provider/sync", "Roadmap Review UI")
 }
 
 //nolint:paralleltest // Uses the default 8080 startup path intentionally.

--- a/gestaltd/cmd/gestaltd/provider_local.go
+++ b/gestaltd/cmd/gestaltd/provider_local.go
@@ -12,14 +12,21 @@ import (
 	"net"
 	"net/url"
 	"os"
+	"os/signal"
 	"path/filepath"
+	"runtime"
 	"slices"
 	"strings"
+	"syscall"
 
+	proto "github.com/valon-technologies/gestalt/sdk/go/gen/v1"
 	"github.com/valon-technologies/gestalt/server/internal/bootstrap"
 	"github.com/valon-technologies/gestalt/server/internal/config"
+	"github.com/valon-technologies/gestalt/server/internal/egress"
 	"github.com/valon-technologies/gestalt/server/internal/operator"
 	"github.com/valon-technologies/gestalt/server/internal/pluginsource"
+	"github.com/valon-technologies/gestalt/server/internal/providerdev"
+	"github.com/valon-technologies/gestalt/server/internal/providerhost"
 	"github.com/valon-technologies/gestalt/server/internal/providerpkg"
 	providermanifestv1 "github.com/valon-technologies/gestalt/server/sdk/providermanifest/v1"
 	"gopkg.in/yaml.v3"
@@ -37,6 +44,8 @@ type providerLocalCommandOptions struct {
 	ConfigPaths []string
 	Name        string
 	Port        int
+	Remote      string
+	RemoteToken string
 }
 
 type providerLocalSession struct {
@@ -99,11 +108,25 @@ func runProviderDev(args []string) error {
 	pathFlag := fs.String("path", "", "provider manifest path or directory (defaults to current working directory)")
 	nameFlag := fs.String("name", "", "provider key override")
 	portFlag := fs.Int("port", 0, "public port (defaults to a free localhost port)")
+	remoteFlag := fs.String("remote", "", "remote gestaltd base URL to attach local source plugins to")
+	remoteTokenFlag := fs.String("remote-token", "", "bearer token for --remote (defaults to GESTALT_API_KEY)")
 	if err := fs.Parse(args); err != nil {
 		return err
 	}
 	if fs.NArg() > 0 {
 		return fmt.Errorf("unexpected arguments: %s", strings.Join(fs.Args(), " "))
+	}
+	if strings.TrimSpace(*remoteFlag) != "" {
+		if *portFlag != 0 {
+			return errors.New("--port is only supported for local provider dev")
+		}
+		return runProviderRemoteDev(providerLocalCommandOptions{
+			Path:        *pathFlag,
+			ConfigPaths: []string(configPaths),
+			Name:        *nameFlag,
+			Remote:      *remoteFlag,
+			RemoteToken: *remoteTokenFlag,
+		})
 	}
 
 	port := *portFlag
@@ -132,6 +155,111 @@ func runProviderDev(args []string) error {
 	}
 	logProviderLocalSummary("provider dev ready", session)
 	return runServer(env)
+}
+
+type providerRemoteTarget struct {
+	Name  string
+	Entry *config.ProviderEntry
+}
+
+func runProviderRemoteDev(opts providerLocalCommandOptions) error {
+	configPaths, cleanup, err := prepareProviderRemoteConfigPaths(opts)
+	if err != nil {
+		return err
+	}
+	defer cleanup()
+
+	cfg, err := config.LoadPaths(configPaths)
+	if err != nil {
+		return fmt.Errorf("loading provider dev remote config: %w", err)
+	}
+	targets, err := collectProviderRemoteTargets(cfg, opts.Name)
+	if err != nil {
+		return err
+	}
+	if len(targets) == 0 {
+		return errors.New("provider dev --remote requires at least one source-backed plugin in --config or --path")
+	}
+
+	token := strings.TrimSpace(opts.RemoteToken)
+	if token == "" {
+		token = strings.TrimSpace(os.Getenv("GESTALT_API_KEY"))
+	}
+	if token == "" {
+		return errors.New("provider dev --remote requires --remote-token or GESTALT_API_KEY")
+	}
+
+	ctx, stop := signal.NotifyContext(context.Background(), syscall.SIGINT, syscall.SIGTERM)
+	defer stop()
+
+	client := providerdev.Client{
+		BaseURL: opts.Remote,
+		Token:   token,
+	}
+	requestedProviders := make([]providerdev.AttachProvider, 0, len(targets))
+	for _, target := range targets {
+		spec, _, err := bootstrap.BuildStartupProviderSpec(target.Name, target.Entry)
+		if err != nil {
+			return fmt.Errorf("build provider dev remote spec for plugins.%s: %w", target.Name, err)
+		}
+		pluginConfig, err := config.NodeToMap(target.Entry.Config)
+		if err != nil {
+			return fmt.Errorf("build provider dev remote config for plugins.%s: %w", target.Name, err)
+		}
+		requestedProviders = append(requestedProviders, providerdev.AttachProvider{
+			Name:   target.Name,
+			Spec:   spec,
+			Config: pluginConfig,
+		})
+	}
+	session, err := client.CreateSession(ctx, providerdev.CreateSessionRequest{Providers: requestedProviders})
+	if err != nil {
+		return err
+	}
+	defer func() { _ = client.CloseSession(context.Background(), session.ID) }()
+
+	sessionProviders := make(map[string]providerdev.CreateSessionProvider, len(session.Providers))
+	for _, provider := range session.Providers {
+		sessionProviders[provider.Name] = provider
+	}
+
+	processes := make([]*providerhost.PluginProcess, 0, len(targets))
+	providerClients := make(map[string]proto.IntegrationProviderClient, len(targets))
+	cleanupProcesses := func() {
+		for _, process := range processes {
+			_ = process.Close()
+		}
+	}
+	defer cleanupProcesses()
+
+	for _, target := range targets {
+		sessionProvider, ok := sessionProviders[target.Name]
+		if !ok {
+			return fmt.Errorf("remote provider dev did not return runtime env for provider %q", target.Name)
+		}
+		process, err := startProviderRemoteProcess(ctx, target, cfg, sessionProvider)
+		if err != nil {
+			return err
+		}
+		processes = append(processes, process)
+		providerClients[target.Name] = process.Integration()
+	}
+
+	slog.Info("provider dev attached",
+		"remote", strings.TrimRight(opts.Remote, "/"),
+		"session", session.ID,
+		"providers", providerRemoteTargetNames(targets),
+		"config_files", configPaths,
+	)
+	return client.RunDispatcher(ctx, session.ID, providerClients)
+}
+
+func providerRemoteTargetNames(targets []providerRemoteTarget) []string {
+	names := make([]string, 0, len(targets))
+	for _, target := range targets {
+		names = append(names, target.Name)
+	}
+	return names
 }
 
 type validatedConfigResult struct {
@@ -340,6 +468,186 @@ func prepareUILocalSession(sessionDir, baseConfigPath string, state operator.Sta
 	}, nil
 }
 
+func prepareProviderRemoteConfigPaths(opts providerLocalCommandOptions) ([]string, func(), error) {
+	cleanup := func() {}
+	if strings.TrimSpace(opts.Path) == "" {
+		if len(opts.ConfigPaths) == 0 {
+			return nil, cleanup, errors.New("provider dev --remote requires --config or --path")
+		}
+		return append([]string(nil), opts.ConfigPaths...), cleanup, nil
+	}
+
+	manifestPath, manifest, err := resolveProviderTargetManifest(opts.Path)
+	if err != nil {
+		return nil, cleanup, err
+	}
+	kind, err := providerpkg.ManifestKind(manifest)
+	if err != nil {
+		return nil, cleanup, err
+	}
+	if kind != providermanifestv1.KindPlugin {
+		return nil, cleanup, fmt.Errorf("provider dev --remote only supports kind: plugin in v1 (got %q)", kind)
+	}
+	targetManifestPath, err := canonicalPath(manifestPath)
+	if err != nil {
+		return nil, cleanup, err
+	}
+	resolvedKey, err := resolveProviderLocalPluginKey(opts.ConfigPaths, targetManifestPath, manifest, opts.Name)
+	if err != nil {
+		return nil, cleanup, err
+	}
+
+	sessionDir, err := os.MkdirTemp("", "gestaltd-provider-remote-*")
+	if err != nil {
+		return nil, cleanup, fmt.Errorf("create provider remote session dir: %w", err)
+	}
+	cleanup = func() { _ = os.RemoveAll(sessionDir) }
+	overlayPath := filepath.Join(sessionDir, "provider-remote-target.yaml")
+	if err := writeProviderRemotePluginOverlayConfig(overlayPath, resolvedKey, targetManifestPath); err != nil {
+		cleanup()
+		return nil, func() {}, err
+	}
+	configPaths := append([]string(nil), opts.ConfigPaths...)
+	configPaths = append(configPaths, overlayPath)
+	return configPaths, cleanup, nil
+}
+
+func collectProviderRemoteTargets(cfg *config.Config, explicitName string) ([]providerRemoteTarget, error) {
+	if cfg == nil {
+		return nil, nil
+	}
+	var targets []providerRemoteTarget
+	names := make([]string, 0, len(cfg.Plugins))
+	for name := range cfg.Plugins {
+		names = append(names, name)
+	}
+	slices.Sort(names)
+	for _, name := range names {
+		if explicitName != "" && name != explicitName {
+			continue
+		}
+		entry := cfg.Plugins[name]
+		if entry == nil || !entry.HasLocalSource() {
+			continue
+		}
+		manifestPath, manifest, err := ensureProviderRemoteManifestResolved(name, entry)
+		if err != nil {
+			return nil, err
+		}
+		if manifest == nil || manifestPath == "" {
+			return nil, fmt.Errorf("plugins.%s must resolve to a local source manifest", name)
+		}
+		kind, err := providerpkg.ManifestKind(manifest)
+		if err != nil {
+			return nil, err
+		}
+		if kind != providermanifestv1.KindPlugin {
+			return nil, fmt.Errorf("provider dev --remote only supports plugins in v1 (plugins.%s has kind %q)", name, kind)
+		}
+		targets = append(targets, providerRemoteTarget{Name: name, Entry: entry})
+	}
+	if explicitName != "" && len(targets) == 0 {
+		return nil, fmt.Errorf("no source-backed plugins.%s entry found in provider dev remote config", explicitName)
+	}
+	return targets, nil
+}
+
+func ensureProviderRemoteManifestResolved(name string, entry *config.ProviderEntry) (string, *providermanifestv1.Manifest, error) {
+	if entry == nil {
+		return "", nil, fmt.Errorf("plugins.%s is not configured", name)
+	}
+	if entry.ResolvedManifest != nil && entry.ResolvedManifestPath != "" {
+		return entry.ResolvedManifestPath, entry.ResolvedManifest, nil
+	}
+	sourcePath := strings.TrimSpace(entry.SourcePath())
+	if sourcePath == "" {
+		return "", nil, fmt.Errorf("plugins.%s must use a local source path", name)
+	}
+	info, err := os.Stat(sourcePath)
+	if err != nil {
+		return "", nil, fmt.Errorf("stat plugins.%s source %q: %w", name, sourcePath, err)
+	}
+	manifestPath := sourcePath
+	if info.IsDir() {
+		manifestPath, err = providerpkg.FindManifestFile(sourcePath)
+		if err != nil {
+			return "", nil, err
+		}
+	} else if !providerpkg.IsManifestFile(sourcePath) {
+		return "", nil, fmt.Errorf("plugins.%s source %q must point to a provider manifest file or directory", name, sourcePath)
+	}
+	manifestPath, err = canonicalPath(manifestPath)
+	if err != nil {
+		return "", nil, err
+	}
+	_, manifest, err := providerpkg.ReadSourceManifestFile(manifestPath)
+	if err != nil {
+		return "", nil, err
+	}
+	entry.ResolvedManifestPath = manifestPath
+	entry.ResolvedManifest = manifest
+	return manifestPath, manifest, nil
+}
+
+func startProviderRemoteProcess(ctx context.Context, target providerRemoteTarget, cfg *config.Config, remote providerdev.CreateSessionProvider) (*providerhost.PluginProcess, error) {
+	entry := target.Entry
+	command := entry.Command
+	args := slices.Clone(entry.Args)
+	env := cloneStringMap(entry.Env)
+	var cleanup func()
+	if command == "" {
+		if entry.ResolvedManifestPath == "" {
+			return nil, fmt.Errorf("plugins.%s resolved manifest path is required for source provider execution", target.Name)
+		}
+		rootDir := filepath.Dir(entry.ResolvedManifestPath)
+		var err error
+		command, args, cleanup, err = providerpkg.SourceProviderExecutionCommand(rootDir, runtime.GOOS, runtime.GOARCH)
+		if errors.Is(err, providerpkg.ErrNoSourceProviderPackage) {
+			return nil, fmt.Errorf("plugins.%s: prepare source provider execution: no Go, Python, Rust, or TypeScript provider source found", target.Name)
+		}
+		if err != nil {
+			return nil, fmt.Errorf("plugins.%s: prepare source provider execution: %w", target.Name, err)
+		}
+		execEnv, err := providerpkg.SourceProviderExecutionEnv(rootDir, runtime.GOOS, runtime.GOARCH)
+		if err != nil {
+			if cleanup != nil {
+				cleanup()
+			}
+			return nil, fmt.Errorf("plugins.%s: prepare source provider environment: %w", target.Name, err)
+		}
+		env = mergeStringMaps(env, execEnv)
+	}
+	env = mergeStringMaps(env, remote.Env)
+
+	allowedHosts := append([]string(nil), entry.AllowedHosts...)
+	for _, host := range remote.AllowedHosts {
+		allowedHosts = appendUniqueString(allowedHosts, host)
+	}
+	defaultAction := egress.PolicyAction("")
+	if cfg != nil {
+		defaultAction = egress.PolicyAction(cfg.Server.Egress.DefaultAction)
+	}
+	process, err := providerhost.StartPluginProcess(ctx, providerhost.ProcessConfig{
+		Command:       command,
+		Args:          args,
+		Env:           env,
+		AllowedHosts:  allowedHosts,
+		DefaultAction: defaultAction,
+		HostBinary:    entry.HostBinary,
+		Cleanup:       cleanup,
+		ProviderName:  target.Name,
+		Stdout:        os.Stdout,
+		Stderr:        os.Stderr,
+	})
+	if err != nil {
+		if cleanup != nil {
+			cleanup()
+		}
+		return nil, fmt.Errorf("start local provider plugins.%s: %w", target.Name, err)
+	}
+	return process, nil
+}
+
 func resolveProviderTargetManifest(pathFlag string) (string, *providermanifestv1.Manifest, error) {
 	targetPath := pathFlag
 	if strings.TrimSpace(targetPath) == "" {
@@ -475,6 +783,18 @@ func writeProviderLocalPluginOverlayConfig(path, pluginKey, manifestPath string,
 				},
 			},
 		}
+	}
+	return writeYAMLFile(path, cfg)
+}
+
+func writeProviderRemotePluginOverlayConfig(path, pluginKey, manifestPath string) error {
+	cfg := map[string]any{
+		"plugins": map[string]any{
+			pluginKey: map[string]any{
+				"source":  providerLocalSourceOverride(manifestPath),
+				"runtime": nil,
+			},
+		},
 	}
 	return writeYAMLFile(path, cfg)
 }
@@ -687,6 +1007,38 @@ func randomHex(numBytes int) (string, error) {
 		return "", fmt.Errorf("generate encryption key: %w", err)
 	}
 	return hex.EncodeToString(key), nil
+}
+
+func cloneStringMap(values map[string]string) map[string]string {
+	if len(values) == 0 {
+		return nil
+	}
+	out := make(map[string]string, len(values))
+	for key, value := range values {
+		out[key] = value
+	}
+	return out
+}
+
+func mergeStringMaps(base map[string]string, overlay map[string]string) map[string]string {
+	if len(overlay) == 0 {
+		return base
+	}
+	if base == nil {
+		base = make(map[string]string, len(overlay))
+	}
+	for key, value := range overlay {
+		base[key] = value
+	}
+	return base
+}
+
+func appendUniqueString(values []string, value string) []string {
+	value = strings.TrimSpace(value)
+	if value == "" || slices.Contains(values, value) {
+		return values
+	}
+	return append(values, value)
 }
 
 func canonicalPath(path string) (string, error) {
@@ -907,15 +1259,21 @@ func printProviderValidateUsage(w io.Writer) {
 func printProviderDevUsage(w io.Writer) {
 	writeUsageLine(w, "Usage:")
 	writeUsageLine(w, "  gestaltd provider dev [--path PATH] [--config PATH]... [--name NAME] [--port PORT]")
+	writeUsageLine(w, "  gestaltd provider dev --remote URL --config PATH [--config PATH]... [--name NAME]")
+	writeUsageLine(w, "  gestaltd provider dev --remote URL --path PATH [--config PATH]... [--name NAME]")
 	writeUsageLine(w, "")
 	writeUsageLine(w, "Run a local source plugin or ui inside a synthesized Gestalt config.")
 	writeUsageLine(w, "v1 supports kind: plugin and kind: ui manifests.")
 	writeUsageLine(w, "The built-in admin UI remains available at /admin; configured, owned, or sibling public UIs")
 	writeUsageLine(w, "are mounted when present.")
+	writeUsageLine(w, "With --remote, source-backed local plugins attach to an authenticated remote gestaltd session")
+	writeUsageLine(w, "while the remote config keeps its normal auth, authorization, connections, and host services.")
 	writeUsageLine(w, "")
 	writeUsageLine(w, "Flags:")
 	writeUsageLine(w, "  --path     Provider manifest path or directory (default: current working directory)")
 	writeUsageLine(w, "  --config   Additional config file to merge; repeat to add support providers or null deletions")
 	writeUsageLine(w, "  --name     Provider key override when the target key is ambiguous")
 	writeUsageLine(w, "  --port     Public port (default: auto-selected free localhost port)")
+	writeUsageLine(w, "  --remote   Remote gestaltd base URL to attach local source plugins to")
+	writeUsageLine(w, "  --remote-token  Bearer token for --remote (default: GESTALT_API_KEY)")
 }

--- a/gestaltd/cmd/gestaltd/provider_test.go
+++ b/gestaltd/cmd/gestaltd/provider_test.go
@@ -68,6 +68,33 @@ const (
 	authReleaseTypeScriptTarget    = "authentication:./auth.ts#auth"
 )
 
+func TestProviderRemoteConfigPathSynthesizesSourcePlugin(t *testing.T) {
+	t.Parallel()
+
+	dir := t.TempDir()
+	pluginDir := setupPluginDir(t, dir)
+	configPaths, cleanup, err := prepareProviderRemoteConfigPaths(providerLocalCommandOptions{Path: pluginDir})
+	if err != nil {
+		t.Fatalf("prepareProviderRemoteConfigPaths: %v", err)
+	}
+	defer cleanup()
+
+	cfg, err := config.LoadPaths(configPaths)
+	if err != nil {
+		t.Fatalf("config.LoadPaths: %v", err)
+	}
+	targets, err := collectProviderRemoteTargets(cfg, "")
+	if err != nil {
+		t.Fatalf("collectProviderRemoteTargets: %v", err)
+	}
+	if len(targets) != 1 {
+		t.Fatalf("targets = %#v, want one source-backed plugin", targets)
+	}
+	if targets[0].Entry.ResolvedManifestPath == "" {
+		t.Fatal("target resolved manifest path is empty")
+	}
+}
+
 func TestRun_ProviderCLIUsageAndErrors(t *testing.T) {
 	t.Parallel()
 

--- a/gestaltd/internal/bootstrap/bootstrap.go
+++ b/gestaltd/internal/bootstrap/bootstrap.go
@@ -29,6 +29,7 @@ import (
 	"github.com/valon-technologies/gestalt/server/internal/oauth"
 	"github.com/valon-technologies/gestalt/server/internal/pluginruntime"
 	"github.com/valon-technologies/gestalt/server/internal/provider"
+	"github.com/valon-technologies/gestalt/server/internal/providerdev"
 	"github.com/valon-technologies/gestalt/server/internal/providerhost"
 	"github.com/valon-technologies/gestalt/server/internal/registry"
 	"github.com/valon-technologies/gestalt/server/internal/workflowmanager"
@@ -219,6 +220,7 @@ type Result struct {
 	SecretManager         core.SecretManager
 	Telemetry             core.TelemetryProvider
 	PluginRuntimes        RuntimeInspector
+	ProviderDevSessions   *providerdev.Manager
 
 	pluginRuntimeRegistry *pluginRuntimeRegistry
 	auditClose            func(context.Context) error
@@ -313,6 +315,7 @@ func (r *Result) Close(ctx context.Context) error {
 		authCloseErr,
 		closeAuthorizationProvider(r.AuthorizationProvider),
 		externalCredentialsCloseErr,
+		closeProviderDevSessions(r.ProviderDevSessions),
 		CloseProviders(r.Providers),
 		r.Services.Close(),
 		closeIndexedDBs(r.ExtraIndexedDBs...),
@@ -1016,11 +1019,17 @@ func Bootstrap(ctx context.Context, cfg *config.Config, factories *FactoryRegist
 		}
 	}
 	prepared.Deps.AgentRuntime.SetRunMetadata(prepared.Services.AgentRunMetadata)
+	providerDevSessions, err := buildProviderDevManager(cfg, providers, prepared.Deps)
+	if err != nil {
+		prepared.Deps.WorkflowRuntime.FailPendingProviders(err)
+		return nil, err
+	}
 	sharedInvoker := invocation.NewBroker(providers, prepared.Services.Users, coredata.EffectiveExternalCredentialProvider(prepared.Services),
 		invocation.WithAuthorizer(authz),
 		invocation.WithConnectionMapper(invocation.ConnectionMap(connMaps.APIConnection)),
 		invocation.WithMCPConnectionMapper(invocation.ConnectionMap(connMaps.MCPConnection)),
 		invocation.WithConnectionAuth(lazyRefreshers(providersReady, connAuthResolver)),
+		invocation.WithProviderOverrides(providerDevSessions),
 	)
 	prepared.Deps.WorkflowRuntime.SetInvoker(sharedInvoker)
 	prepared.Deps.AgentRuntime.SetInvoker(sharedInvoker)
@@ -1113,6 +1122,7 @@ func Bootstrap(ctx context.Context, cfg *config.Config, factories *FactoryRegist
 		SecretManager:         prepared.SecretManager,
 		Telemetry:             prepared.Telemetry,
 		PluginRuntimes:        prepared.pluginRuntimeRegistry,
+		ProviderDevSessions:   providerDevSessions,
 		pluginRuntimeRegistry: prepared.pluginRuntimeRegistry,
 		auditClose:            auditClose,
 	}, nil

--- a/gestaltd/internal/bootstrap/cleanup.go
+++ b/gestaltd/internal/bootstrap/cleanup.go
@@ -6,6 +6,7 @@ import (
 	"io"
 
 	"github.com/valon-technologies/gestalt/server/core"
+	"github.com/valon-technologies/gestalt/server/internal/providerdev"
 	"github.com/valon-technologies/gestalt/server/internal/registry"
 )
 
@@ -32,4 +33,11 @@ func CloseProviders(providers *registry.ProviderMap[core.Provider]) error {
 	}
 
 	return errors.Join(errs...)
+}
+
+func closeProviderDevSessions(manager *providerdev.Manager) error {
+	if manager == nil {
+		return nil
+	}
+	return manager.Close()
 }

--- a/gestaltd/internal/bootstrap/executable_plugin_test.go
+++ b/gestaltd/internal/bootstrap/executable_plugin_test.go
@@ -5838,6 +5838,42 @@ func TestPluginRuntimeConfigUsesPublicS3RelayWithoutHostServiceTunnelCapability(
 	}
 }
 
+func TestProviderDevRuntimeEnvUsesPublicHostServiceRelay(t *testing.T) {
+	t.Parallel()
+
+	env, err := buildProviderDevRuntimeEnv("echoext", &config.ProviderEntry{
+		S3: []string{"main"},
+	}, Deps{
+		BaseURL:       "https://gestalt.example.test",
+		EncryptionKey: []byte("0123456789abcdef0123456789abcdef"),
+		S3: map[string]s3store.Client{
+			"main": &coretesting.StubS3{},
+		},
+	}, "provider-dev-session")
+	if err != nil {
+		t.Fatalf("buildProviderDevRuntimeEnv: %v", err)
+	}
+	t.Cleanup(func() {
+		if env.Cleanup != nil {
+			env.Cleanup()
+		}
+	})
+
+	for _, binding := range []string{"", "main"} {
+		socketEnv := providerhost.S3SocketEnv(binding)
+		if got := env.Env[socketEnv]; got != "tls://gestalt.example.test:443" {
+			t.Fatalf("runtime env %s = %q, want %q", socketEnv, got, "tls://gestalt.example.test:443")
+		}
+		tokenEnv := providerhost.S3SocketTokenEnv(binding)
+		if got := env.Env[tokenEnv]; got == "" {
+			t.Fatalf("runtime env %s is empty, want relay token", tokenEnv)
+		}
+	}
+	if !slices.Contains(env.AllowedHosts, "gestalt.example.test") {
+		t.Fatalf("allowed hosts = %#v, want gestalt.example.test", env.AllowedHosts)
+	}
+}
+
 func TestPluginRuntimeConfigUsesPublicAuthorizationRelayWithoutHostServiceTunnelCapability(t *testing.T) {
 	t.Parallel()
 

--- a/gestaltd/internal/bootstrap/provider_build.go
+++ b/gestaltd/internal/bootstrap/provider_build.go
@@ -200,6 +200,10 @@ func validateProviderConnectionMode(provider string, mode core.ConnectionMode) e
 	}
 }
 
+func BuildStartupProviderSpec(name string, entry *config.ProviderEntry) (providerhost.StaticProviderSpec, map[string]string, error) {
+	return buildStartupProviderSpec(name, entry)
+}
+
 func buildStartupProviderSpec(name string, entry *config.ProviderEntry) (providerhost.StaticProviderSpec, map[string]string, error) {
 	if entry == nil {
 		return providerhost.StaticProviderSpec{}, nil, fmt.Errorf("integration %q has no plugin defined", name)

--- a/gestaltd/internal/bootstrap/provider_dev.go
+++ b/gestaltd/internal/bootstrap/provider_dev.go
@@ -1,0 +1,112 @@
+package bootstrap
+
+import (
+	"fmt"
+	"maps"
+	"slices"
+
+	"github.com/valon-technologies/gestalt/server/core"
+	"github.com/valon-technologies/gestalt/server/internal/config"
+	"github.com/valon-technologies/gestalt/server/internal/egress"
+	"github.com/valon-technologies/gestalt/server/internal/providerdev"
+	"github.com/valon-technologies/gestalt/server/internal/providerhost"
+	"github.com/valon-technologies/gestalt/server/internal/registry"
+)
+
+func buildProviderDevManager(cfg *config.Config, providers *registry.ProviderMap[core.Provider], deps Deps) (*providerdev.Manager, error) {
+	if cfg == nil || len(cfg.Plugins) == 0 {
+		return nil, nil
+	}
+
+	targets := make([]providerdev.Target, 0, len(cfg.Plugins))
+	for name, entry := range cfg.Plugins {
+		if entry == nil || !entry.HasResolvedManifest() {
+			continue
+		}
+		if !entry.HasLocalSource() && !entry.ProviderDev {
+			continue
+		}
+		if _, err := providers.Get(name); err != nil {
+			continue
+		}
+		spec, _, err := buildStartupProviderSpec(name, entry)
+		if err != nil {
+			return nil, fmt.Errorf("provider dev target %q: %w", name, err)
+		}
+		pluginConfig, err := config.NodeToMap(entry.Config)
+		if err != nil {
+			return nil, fmt.Errorf("provider dev target %q config: %w", name, err)
+		}
+		targetName := name
+		targetEntry := entry
+		targets = append(targets, providerdev.Target{
+			Name:   targetName,
+			Spec:   spec,
+			Config: pluginConfig,
+			RuntimeEnv: func(sessionID string) (providerdev.RuntimeEnv, error) {
+				return buildProviderDevRuntimeEnv(targetName, targetEntry, deps, sessionID)
+			},
+		})
+	}
+	if len(targets) == 0 {
+		return nil, nil
+	}
+	return providerdev.NewManager(targets)
+}
+
+func buildProviderDevRuntimeEnv(name string, entry *config.ProviderEntry, deps Deps, sessionID string) (providerdev.RuntimeEnv, error) {
+	hostServices, _, cleanup, err := buildPluginRuntimeHostServices(name, entry, deps, false)
+	if err != nil {
+		return providerdev.RuntimeEnv{}, err
+	}
+	cleanupOnError := true
+	defer func() {
+		if cleanupOnError && cleanup != nil {
+			cleanup()
+		}
+	}()
+
+	env := map[string]string{}
+	var allowedHosts []string
+	startedHostServices, err := providerhost.StartHostServices(
+		hostServices,
+		providerhost.WithHostServicesProviderName(name),
+		providerhost.WithHostServicesTelemetry(deps.Telemetry),
+	)
+	if err != nil {
+		return providerdev.RuntimeEnv{}, fmt.Errorf("start host services: %w", err)
+	}
+	if startedHostServices != nil {
+		cleanup = chainCleanup(cleanup, func() {
+			_ = startedHostServices.Close()
+		})
+	}
+	for _, hostService := range startedHostServices.Bindings() {
+		bindingReq, bindingEnv, relayHost, err := buildHostedRuntimeHostServiceBinding(name, sessionID, hostService, deps, false)
+		if err != nil {
+			return providerdev.RuntimeEnv{}, err
+		}
+		if bindingReq.EnvVar != "" && bindingReq.Relay.DialTarget != "" {
+			env[bindingReq.EnvVar] = bindingReq.Relay.DialTarget
+		}
+		maps.Copy(env, bindingEnv)
+		allowedHosts = appendAllowedHost(allowedHosts, relayHost)
+	}
+	if deps.Egress.DefaultAction == egress.PolicyDeny {
+		proxyEnv, err := buildHostedRuntimePublicEgressProxy(name, sessionID, entry.AllowedHosts, deps.Egress.DefaultAction, deps)
+		if err != nil {
+			return providerdev.RuntimeEnv{}, err
+		}
+		maps.Copy(env, proxyEnv)
+		if _, proxyHost, err := pluginRuntimePublicProxyBaseURL(deps.BaseURL); err == nil {
+			allowedHosts = appendAllowedHost(allowedHosts, proxyHost)
+		}
+	}
+
+	cleanupOnError = false
+	return providerdev.RuntimeEnv{
+		Env:          env,
+		AllowedHosts: slices.Clone(allowedHosts),
+		Cleanup:      cleanup,
+	}, nil
+}

--- a/gestaltd/internal/config/config.go
+++ b/gestaltd/internal/config/config.go
@@ -373,6 +373,7 @@ type ProviderEntry struct {
 	Cache             []string                      `yaml:"cache,omitempty"`
 	S3                []string                      `yaml:"s3,omitempty"`
 	Runtime           *HostedRuntimeConfig          `yaml:"runtime,omitempty"`
+	ProviderDev       bool                          `yaml:"providerDev,omitempty"`
 	Surfaces          *ProviderSurfaceOverrides     `yaml:"surfaces,omitempty"`
 	MCP               bool                          `yaml:"mcp,omitempty"`
 

--- a/gestaltd/internal/invocation/broker.go
+++ b/gestaltd/internal/invocation/broker.go
@@ -71,6 +71,10 @@ type CapabilityLister interface {
 	ListCapabilities() []core.Capability
 }
 
+type ProviderOverrideResolver interface {
+	ResolveProviderOverride(ctx context.Context, p *principal.Principal, providerName string) (core.Provider, bool, error)
+}
+
 var (
 	_ Invoker          = (*Broker)(nil)
 	_ GraphQLInvoker   = (*Broker)(nil)
@@ -100,14 +104,15 @@ type OAuthRefresher interface {
 type RefresherResolver func() map[string]map[string]OAuthRefresher
 
 type Broker struct {
-	providers      *registry.ProviderMap[core.Provider]
-	users          *coredata.UserService
-	externalCreds  core.ExternalCredentialProvider
-	authorizer     authorization.RuntimeAuthorizer
-	connMapper     ConnectionMapper
-	mcpMapper      ConnectionMapper
-	connectionAuth RefresherResolver
-	refreshGroup   singleflight.Group
+	providers         *registry.ProviderMap[core.Provider]
+	users             *coredata.UserService
+	externalCreds     core.ExternalCredentialProvider
+	authorizer        authorization.RuntimeAuthorizer
+	connMapper        ConnectionMapper
+	mcpMapper         ConnectionMapper
+	connectionAuth    RefresherResolver
+	providerOverrides ProviderOverrideResolver
+	refreshGroup      singleflight.Group
 }
 
 type BrokerOption func(*Broker)
@@ -126,6 +131,10 @@ func WithConnectionAuth(r RefresherResolver) BrokerOption {
 
 func WithAuthorizer(a authorization.RuntimeAuthorizer) BrokerOption {
 	return func(b *Broker) { b.authorizer = a }
+}
+
+func WithProviderOverrides(r ProviderOverrideResolver) BrokerOption {
+	return func(b *Broker) { b.providerOverrides = r }
 }
 
 func NewBroker(providers *registry.ProviderMap[core.Provider], users *coredata.UserService, externalCreds core.ExternalCredentialProvider, opts ...BrokerOption) *Broker {
@@ -262,7 +271,18 @@ func (b *Broker) Invoke(ctx context.Context, p *principal.Principal, providerNam
 		return fail(fmt.Errorf("%w: %s.%s", ErrAuthorizationDenied, providerName, operation))
 	}
 
-	opMeta, transport, resolvedConnection, err := b.resolveOperation(ctx, p, prov, providerName, operation, conn, instance)
+	execProv := prov
+	if b.providerOverrides != nil {
+		override, ok, err := b.providerOverrides.ResolveProviderOverride(ctx, p, providerName)
+		if err != nil {
+			return fail(fmt.Errorf("%w: provider override: %v", ErrInternal, err))
+		}
+		if ok {
+			execProv = override
+		}
+	}
+
+	opMeta, transport, resolvedConnection, err := b.resolveOperation(ctx, p, execProv, providerName, operation, conn, instance)
 	if err != nil {
 		return fail(err)
 	}
@@ -295,7 +315,7 @@ func (b *Broker) Invoke(ctx context.Context, p *principal.Principal, providerNam
 	}
 
 	if transport == catalog.TransportMCPPassthrough {
-		toolResult, err := CallDirectTool(ctx, b, p, prov, providerName, operation, conn, instance, boundCredential, params, mcpupstream.CallToolMetaFromContext(ctx))
+		toolResult, err := CallDirectTool(ctx, b, p, execProv, providerName, operation, conn, instance, boundCredential, params, mcpupstream.CallToolMetaFromContext(ctx))
 		if err != nil {
 			return fail(err)
 		}
@@ -314,7 +334,7 @@ func (b *Broker) Invoke(ctx context.Context, p *principal.Principal, providerNam
 		return fail(err)
 	}
 
-	result, err = prov.Execute(ctx, operation, params, accessToken)
+	result, err = execProv.Execute(ctx, operation, params, accessToken)
 	if err != nil {
 		return fail(err)
 	}

--- a/gestaltd/internal/providerdev/session.go
+++ b/gestaltd/internal/providerdev/session.go
@@ -1,0 +1,1100 @@
+package providerdev
+
+import (
+	"bytes"
+	"context"
+	"crypto/rand"
+	"encoding/hex"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"io"
+	"net/http"
+	"net/url"
+	"slices"
+	"strings"
+	"sync"
+	"time"
+
+	proto "github.com/valon-technologies/gestalt/sdk/go/gen/v1"
+	"github.com/valon-technologies/gestalt/server/core"
+	"github.com/valon-technologies/gestalt/server/core/catalog"
+	"github.com/valon-technologies/gestalt/server/internal/principal"
+	"github.com/valon-technologies/gestalt/server/internal/providerhost"
+	"google.golang.org/grpc"
+	"google.golang.org/grpc/codes"
+	"google.golang.org/grpc/status"
+	gproto "google.golang.org/protobuf/proto"
+	"google.golang.org/protobuf/types/known/emptypb"
+)
+
+const (
+	DefaultPollTimeout        = 30 * time.Second
+	DefaultSessionIdleTimeout = 2 * time.Minute
+	DefaultCallIdleTimeout    = 30 * time.Minute
+
+	PathSessions = "/api/v1/provider-dev/sessions"
+)
+
+type RuntimeEnv struct {
+	Env          map[string]string
+	AllowedHosts []string
+	Cleanup      func()
+}
+
+type RuntimeEnvBuilder func(sessionID string) (RuntimeEnv, error)
+
+type Target struct {
+	Name       string
+	Spec       providerhost.StaticProviderSpec
+	Config     map[string]any
+	RuntimeEnv RuntimeEnvBuilder
+}
+
+type Manager struct {
+	mu         sync.RWMutex
+	targets    map[string]Target
+	sessions   map[string]*Session
+	ownerIndex map[string][]string
+}
+
+type CreateSessionRequest struct {
+	Providers []AttachProvider `json:"providers"`
+}
+
+type AttachProvider struct {
+	Name   string                          `json:"name"`
+	Spec   providerhost.StaticProviderSpec `json:"spec"`
+	Config map[string]any                  `json:"config,omitempty"`
+}
+
+type CreateSessionResponse struct {
+	ID        string                  `json:"id"`
+	Providers []CreateSessionProvider `json:"providers"`
+}
+
+type CreateSessionProvider struct {
+	Name         string            `json:"name"`
+	Env          map[string]string `json:"env,omitempty"`
+	AllowedHosts []string          `json:"allowedHosts,omitempty"`
+}
+
+type PollResponse struct {
+	CallID   string `json:"callId"`
+	Provider string `json:"provider"`
+	Method   string `json:"method"`
+	Request  string `json:"request"`
+}
+
+type CompleteCallRequest struct {
+	Response string    `json:"response,omitempty"`
+	Error    *RPCError `json:"error,omitempty"`
+}
+
+type RPCError struct {
+	Code    int32  `json:"code"`
+	Message string `json:"message"`
+}
+
+type Session struct {
+	id      string
+	owner   string
+	targets map[string]*attachedTarget
+
+	mu       sync.Mutex
+	calls    chan *rpcCall
+	pending  map[string]*rpcCall
+	done     chan struct{}
+	lastSeen time.Time
+	closeErr error
+	closed   bool
+}
+
+type attachedTarget struct {
+	target     Target
+	env        RuntimeEnv
+	providerMu sync.Mutex
+	provider   core.Provider
+	closed     bool
+}
+
+type rpcCall struct {
+	id          string
+	provider    string
+	method      string
+	request     []byte
+	deliveredAt time.Time
+	response    chan rpcResponse
+}
+
+type rpcResponse struct {
+	payload []byte
+	err     error
+}
+
+func NewManager(targets []Target) (*Manager, error) {
+	m := &Manager{
+		targets:    make(map[string]Target, len(targets)),
+		sessions:   map[string]*Session{},
+		ownerIndex: map[string][]string{},
+	}
+	for i := range targets {
+		target := targets[i]
+		name := strings.TrimSpace(target.Name)
+		if name == "" {
+			return nil, fmt.Errorf("provider dev target name is required")
+		}
+		target.Name = name
+		m.targets[name] = target
+	}
+	return m, nil
+}
+
+func (m *Manager) HasTargets() bool {
+	return m != nil && len(m.targets) != 0
+}
+
+func (m *Manager) CreateSession(ctx context.Context, p *principal.Principal, req CreateSessionRequest) (*CreateSessionResponse, error) {
+	select {
+	case <-ctx.Done():
+		return nil, ctx.Err()
+	default:
+	}
+
+	owner := principalSubjectID(p)
+	if owner == "" {
+		return nil, status.Error(codes.Unauthenticated, "provider dev requires an authenticated principal")
+	}
+	if m == nil {
+		return nil, status.Error(codes.FailedPrecondition, "provider dev is not configured")
+	}
+
+	requestedProviders, err := normalizeAttachProviders(req.Providers)
+	if err != nil {
+		return nil, err
+	}
+	if len(requestedProviders) == 0 {
+		return nil, status.Error(codes.InvalidArgument, "at least one provider is required")
+	}
+
+	m.mu.RLock()
+	targets := make([]Target, 0, len(requestedProviders))
+	for i := range requestedProviders {
+		requested := requestedProviders[i]
+		remoteTarget, ok := m.targets[requested.Name]
+		if !ok {
+			m.mu.RUnlock()
+			return nil, status.Errorf(codes.NotFound, "provider %q is not configured on this server", requested.Name)
+		}
+		target := remoteTarget
+		target.Spec = buildAttachSpec(remoteTarget.Spec, requested.Spec)
+		target.Config = requested.Config
+		targets = append(targets, target)
+	}
+	m.mu.RUnlock()
+
+	sessionID, err := randomID()
+	if err != nil {
+		return nil, status.Errorf(codes.Internal, "create provider dev session: %v", err)
+	}
+	session := &Session{
+		id:       sessionID,
+		owner:    owner,
+		targets:  make(map[string]*attachedTarget, len(targets)),
+		calls:    make(chan *rpcCall, 128),
+		pending:  map[string]*rpcCall{},
+		done:     make(chan struct{}),
+		lastSeen: time.Now(),
+	}
+	resp := &CreateSessionResponse{
+		ID:        sessionID,
+		Providers: make([]CreateSessionProvider, 0, len(targets)),
+	}
+	cleanupOnError := true
+	defer func() {
+		if cleanupOnError {
+			_ = session.Close()
+		}
+	}()
+
+	for i := range targets {
+		target := targets[i]
+		runtimeEnv := RuntimeEnv{}
+		if target.RuntimeEnv != nil {
+			runtimeEnv, err = target.RuntimeEnv(sessionID)
+			if err != nil {
+				return nil, status.Errorf(codes.FailedPrecondition, "prepare provider %q runtime env: %v", target.Name, err)
+			}
+		}
+		session.targets[target.Name] = &attachedTarget{
+			target: target,
+			env:    runtimeEnv,
+		}
+		resp.Providers = append(resp.Providers, CreateSessionProvider{
+			Name:         target.Name,
+			Env:          cloneStringMap(runtimeEnv.Env),
+			AllowedHosts: slices.Clone(runtimeEnv.AllowedHosts),
+		})
+	}
+
+	m.mu.Lock()
+	m.sessions[sessionID] = session
+	m.ownerIndex[owner] = append(m.ownerIndex[owner], sessionID)
+	m.mu.Unlock()
+	cleanupOnError = false
+
+	return resp, nil
+}
+
+func (m *Manager) PollSession(ctx context.Context, p *principal.Principal, sessionID string) (*PollResponse, bool, error) {
+	session, err := m.sessionForPrincipal(p, sessionID)
+	if err != nil {
+		return nil, false, err
+	}
+	session.touch()
+
+	select {
+	case call := <-session.calls:
+		session.mu.Lock()
+		if session.closed {
+			session.mu.Unlock()
+			return nil, false, status.Error(codes.NotFound, "provider dev session is closed")
+		}
+		call.deliveredAt = time.Now()
+		session.pending[call.id] = call
+		session.lastSeen = call.deliveredAt
+		session.mu.Unlock()
+		return &PollResponse{
+			CallID:   call.id,
+			Provider: call.provider,
+			Method:   call.method,
+			Request:  hex.EncodeToString(call.request),
+		}, true, nil
+	case <-session.done:
+		return nil, false, status.Error(codes.NotFound, "provider dev session is closed")
+	case <-ctx.Done():
+		if errors.Is(ctx.Err(), context.DeadlineExceeded) || errors.Is(ctx.Err(), context.Canceled) {
+			return nil, false, nil
+		}
+		return nil, false, ctx.Err()
+	}
+}
+
+func (m *Manager) CompleteCall(p *principal.Principal, sessionID, callID string, req CompleteCallRequest) error {
+	session, err := m.sessionForPrincipal(p, sessionID)
+	if err != nil {
+		return err
+	}
+	session.touch()
+	callID = strings.TrimSpace(callID)
+	if callID == "" {
+		return status.Error(codes.InvalidArgument, "call id is required")
+	}
+
+	session.mu.Lock()
+	call, ok := session.pending[callID]
+	if ok {
+		delete(session.pending, callID)
+	}
+	session.mu.Unlock()
+	if !ok {
+		return status.Errorf(codes.NotFound, "provider dev call %q not found", callID)
+	}
+
+	resp := rpcResponse{}
+	if req.Error != nil {
+		resp.err = status.Error(codes.Code(req.Error.Code), req.Error.Message)
+	} else if req.Response != "" {
+		payload, err := hex.DecodeString(req.Response)
+		if err != nil {
+			resp.err = status.Errorf(codes.InvalidArgument, "decode provider dev response: %v", err)
+		} else {
+			resp.payload = payload
+		}
+	}
+
+	select {
+	case call.response <- resp:
+		session.touch()
+		return nil
+	case <-session.done:
+		return status.Error(codes.NotFound, "provider dev session is closed")
+	default:
+		return status.Error(codes.DeadlineExceeded, "provider dev caller is no longer waiting")
+	}
+}
+
+func (m *Manager) CloseSession(p *principal.Principal, sessionID string) error {
+	session, err := m.sessionForPrincipal(p, sessionID)
+	if err != nil {
+		return err
+	}
+	if err := session.Close(); err != nil {
+		return status.Errorf(codes.Internal, "close provider dev session: %v", err)
+	}
+	m.removeSession(sessionID, session.owner)
+	return nil
+}
+
+func (m *Manager) ResolveProviderOverride(ctx context.Context, p *principal.Principal, providerName string) (core.Provider, bool, error) {
+	if m == nil {
+		return nil, false, nil
+	}
+	m.closeIdleSessions(time.Now())
+	owner := principalSubjectID(p)
+	if owner == "" {
+		return nil, false, nil
+	}
+	providerName = strings.TrimSpace(providerName)
+	if providerName == "" {
+		return nil, false, nil
+	}
+
+	m.mu.RLock()
+	sessionIDs := append([]string(nil), m.ownerIndex[owner]...)
+	sessions := make(map[string]*Session, len(sessionIDs))
+	for _, id := range sessionIDs {
+		sessions[id] = m.sessions[id]
+	}
+	m.mu.RUnlock()
+
+	for i := len(sessionIDs) - 1; i >= 0; i-- {
+		session := sessions[sessionIDs[i]]
+		if session == nil || session.isClosed() {
+			continue
+		}
+		target := session.targets[providerName]
+		if target == nil {
+			continue
+		}
+		prov, err := target.providerForSession(ctx, session, providerName)
+		if err != nil {
+			return nil, false, err
+		}
+		return prov, true, nil
+	}
+	return nil, false, nil
+}
+
+func (m *Manager) Close() error {
+	if m == nil {
+		return nil
+	}
+	m.mu.Lock()
+	sessions := make([]*Session, 0, len(m.sessions))
+	for _, session := range m.sessions {
+		sessions = append(sessions, session)
+	}
+	m.sessions = map[string]*Session{}
+	m.ownerIndex = map[string][]string{}
+	m.mu.Unlock()
+
+	var errs []error
+	for _, session := range sessions {
+		errs = append(errs, session.Close())
+	}
+	return errors.Join(errs...)
+}
+
+func (m *Manager) closeIdleSessions(now time.Time) {
+	if m == nil {
+		return
+	}
+	m.mu.RLock()
+	var expired []*Session
+	for _, session := range m.sessions {
+		if session.isIdleExpired(now) {
+			expired = append(expired, session)
+		}
+	}
+	m.mu.RUnlock()
+	for _, session := range expired {
+		_ = session.Close()
+		m.removeSession(session.id, session.owner)
+	}
+}
+
+func (m *Manager) sessionForPrincipal(p *principal.Principal, sessionID string) (*Session, error) {
+	owner := principalSubjectID(p)
+	if owner == "" {
+		return nil, status.Error(codes.Unauthenticated, "provider dev requires an authenticated principal")
+	}
+	sessionID = strings.TrimSpace(sessionID)
+	if sessionID == "" {
+		return nil, status.Error(codes.InvalidArgument, "session id is required")
+	}
+	if m == nil {
+		return nil, status.Error(codes.FailedPrecondition, "provider dev is not configured")
+	}
+
+	m.mu.RLock()
+	session := m.sessions[sessionID]
+	m.mu.RUnlock()
+	if session == nil || session.isClosed() {
+		return nil, status.Errorf(codes.NotFound, "provider dev session %q not found", sessionID)
+	}
+	if session.owner != owner {
+		return nil, status.Error(codes.PermissionDenied, "provider dev session belongs to another principal")
+	}
+	return session, nil
+}
+
+func (m *Manager) removeSession(sessionID, owner string) {
+	if m == nil {
+		return
+	}
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	delete(m.sessions, sessionID)
+	ids := m.ownerIndex[owner]
+	for i, id := range ids {
+		if id != sessionID {
+			continue
+		}
+		ids = append(ids[:i], ids[i+1:]...)
+		break
+	}
+	if len(ids) == 0 {
+		delete(m.ownerIndex, owner)
+		return
+	}
+	m.ownerIndex[owner] = ids
+}
+
+func (s *Session) Close() error {
+	if s == nil {
+		return nil
+	}
+	s.mu.Lock()
+	if s.closed {
+		err := s.closeErr
+		s.mu.Unlock()
+		return err
+	}
+	s.closed = true
+	close(s.done)
+	pending := make([]*rpcCall, 0, len(s.pending))
+	for id, call := range s.pending {
+		delete(s.pending, id)
+		pending = append(pending, call)
+	}
+	targets := make([]*attachedTarget, 0, len(s.targets))
+	for _, target := range s.targets {
+		targets = append(targets, target)
+	}
+	s.mu.Unlock()
+
+	for _, call := range pending {
+		select {
+		case call.response <- rpcResponse{err: status.Error(codes.Unavailable, "provider dev session closed")}:
+		default:
+		}
+	}
+
+	var errs []error
+	for _, target := range targets {
+		errs = append(errs, target.close())
+	}
+	s.mu.Lock()
+	s.closeErr = errors.Join(errs...)
+	err := s.closeErr
+	s.mu.Unlock()
+	return err
+}
+
+func (s *Session) isClosed() bool {
+	if s == nil {
+		return true
+	}
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	return s.closed
+}
+
+func (s *Session) touch() {
+	if s == nil {
+		return
+	}
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	if !s.closed {
+		s.lastSeen = time.Now()
+	}
+}
+
+func (s *Session) isIdleExpired(now time.Time) bool {
+	if s == nil {
+		return true
+	}
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	if s.closed {
+		return true
+	}
+	for _, call := range s.pending {
+		if call == nil {
+			continue
+		}
+		if call.deliveredAt.IsZero() || now.Sub(call.deliveredAt) <= DefaultCallIdleTimeout {
+			return false
+		}
+	}
+	return !s.lastSeen.IsZero() && now.Sub(s.lastSeen) > DefaultSessionIdleTimeout
+}
+
+func (s *Session) invoke(ctx context.Context, providerName, method string, req gproto.Message, resp gproto.Message) error {
+	if s == nil {
+		return status.Error(codes.Unavailable, "provider dev session is unavailable")
+	}
+	payload, err := gproto.Marshal(req)
+	if err != nil {
+		return status.Errorf(codes.Internal, "marshal provider dev request: %v", err)
+	}
+	callID, err := randomID()
+	if err != nil {
+		return status.Errorf(codes.Internal, "create provider dev call: %v", err)
+	}
+	call := &rpcCall{
+		id:       callID,
+		provider: providerName,
+		method:   method,
+		request:  payload,
+		response: make(chan rpcResponse, 1),
+	}
+	s.touch()
+
+	select {
+	case s.calls <- call:
+		s.touch()
+	case <-s.done:
+		return status.Error(codes.Unavailable, "provider dev session is closed")
+	case <-ctx.Done():
+		return ctx.Err()
+	}
+
+	select {
+	case result := <-call.response:
+		s.touch()
+		if result.err != nil {
+			return result.err
+		}
+		if resp == nil {
+			return nil
+		}
+		if err := gproto.Unmarshal(result.payload, resp); err != nil {
+			return status.Errorf(codes.Internal, "unmarshal provider dev response: %v", err)
+		}
+		return nil
+	case <-s.done:
+		return status.Error(codes.Unavailable, "provider dev session is closed")
+	case <-ctx.Done():
+		s.mu.Lock()
+		delete(s.pending, callID)
+		if !s.closed {
+			s.lastSeen = time.Now()
+		}
+		s.mu.Unlock()
+		return ctx.Err()
+	}
+}
+
+func (t *attachedTarget) providerForSession(ctx context.Context, session *Session, providerName string) (core.Provider, error) {
+	t.providerMu.Lock()
+	defer t.providerMu.Unlock()
+	if t.closed {
+		return nil, status.Error(codes.Unavailable, "provider dev target is closed")
+	}
+	if t.provider != nil {
+		return t.provider, nil
+	}
+
+	client := &sessionProviderClient{session: session, provider: providerName}
+	prov, err := providerhost.NewRemoteProvider(ctx, client, t.target.Spec, t.target.Config)
+	if err != nil {
+		return nil, err
+	}
+	t.provider = &attachProvider{Provider: prov, policyCatalog: t.target.Spec.Catalog}
+	return t.provider, nil
+}
+
+type attachProvider struct {
+	core.Provider
+	policyCatalog *catalog.Catalog
+}
+
+func (p *attachProvider) Catalog() *catalog.Catalog {
+	if p == nil || p.Provider == nil {
+		return nil
+	}
+	return buildAttachCatalog(p.policyCatalog, p.Provider.Catalog())
+}
+
+func (p *attachProvider) SupportsSessionCatalog() bool {
+	return p != nil && p.Provider != nil && core.SupportsSessionCatalog(p.Provider)
+}
+
+func (p *attachProvider) CatalogForRequest(ctx context.Context, token string) (*catalog.Catalog, error) {
+	if p == nil || p.Provider == nil {
+		return nil, core.ErrSessionCatalogUnsupported
+	}
+	scp, ok := p.Provider.(core.SessionCatalogProvider)
+	if !ok {
+		return nil, core.ErrSessionCatalogUnsupported
+	}
+	cat, err := scp.CatalogForRequest(ctx, token)
+	if err != nil {
+		return nil, err
+	}
+	if cat == nil {
+		return nil, nil
+	}
+	return buildAttachCatalog(p.policyCatalog, cat), nil
+}
+
+func (p *attachProvider) SupportsPostConnect() bool {
+	return p != nil && p.Provider != nil && core.SupportsPostConnect(p.Provider)
+}
+
+func (p *attachProvider) PostConnect(ctx context.Context, token *core.IntegrationToken) (map[string]string, error) {
+	if p == nil || p.Provider == nil {
+		return nil, core.ErrPostConnectUnsupported
+	}
+	pcp, ok := p.Provider.(core.PostConnectCapable)
+	if !ok {
+		return nil, core.ErrPostConnectUnsupported
+	}
+	return pcp.PostConnect(ctx, token)
+}
+
+func (p *attachProvider) Close() error {
+	if p == nil || p.Provider == nil {
+		return nil
+	}
+	if c, ok := p.Provider.(interface{ Close() error }); ok {
+		return c.Close()
+	}
+	return nil
+}
+
+func (t *attachedTarget) close() error {
+	if t == nil {
+		return nil
+	}
+	t.providerMu.Lock()
+	t.closed = true
+	prov := t.provider
+	t.provider = nil
+	t.providerMu.Unlock()
+
+	var errs []error
+	if c, ok := prov.(interface{ Close() error }); ok {
+		errs = append(errs, c.Close())
+	}
+	if t.env.Cleanup != nil {
+		t.env.Cleanup()
+	}
+	return errors.Join(errs...)
+}
+
+type sessionProviderClient struct {
+	session  *Session
+	provider string
+}
+
+func (c *sessionProviderClient) GetMetadata(ctx context.Context, req *emptypb.Empty, _ ...grpc.CallOption) (*proto.ProviderMetadata, error) {
+	resp := &proto.ProviderMetadata{}
+	err := c.session.invoke(ctx, c.provider, "GetMetadata", req, resp)
+	return resp, err
+}
+
+func (c *sessionProviderClient) StartProvider(ctx context.Context, req *proto.StartProviderRequest, _ ...grpc.CallOption) (*proto.StartProviderResponse, error) {
+	resp := &proto.StartProviderResponse{}
+	err := c.session.invoke(ctx, c.provider, "StartProvider", req, resp)
+	return resp, err
+}
+
+func (c *sessionProviderClient) Execute(ctx context.Context, req *proto.ExecuteRequest, _ ...grpc.CallOption) (*proto.OperationResult, error) {
+	resp := &proto.OperationResult{}
+	err := c.session.invoke(ctx, c.provider, "Execute", req, resp)
+	return resp, err
+}
+
+func (c *sessionProviderClient) ResolveHTTPSubject(ctx context.Context, req *proto.ResolveHTTPSubjectRequest, _ ...grpc.CallOption) (*proto.ResolveHTTPSubjectResponse, error) {
+	resp := &proto.ResolveHTTPSubjectResponse{}
+	err := c.session.invoke(ctx, c.provider, "ResolveHTTPSubject", req, resp)
+	return resp, err
+}
+
+func (c *sessionProviderClient) GetSessionCatalog(ctx context.Context, req *proto.GetSessionCatalogRequest, _ ...grpc.CallOption) (*proto.GetSessionCatalogResponse, error) {
+	resp := &proto.GetSessionCatalogResponse{}
+	err := c.session.invoke(ctx, c.provider, "GetSessionCatalog", req, resp)
+	return resp, err
+}
+
+func (c *sessionProviderClient) PostConnect(ctx context.Context, req *proto.PostConnectRequest, _ ...grpc.CallOption) (*proto.PostConnectResponse, error) {
+	resp := &proto.PostConnectResponse{}
+	err := c.session.invoke(ctx, c.provider, "PostConnect", req, resp)
+	return resp, err
+}
+
+type Client struct {
+	BaseURL    string
+	Token      string
+	HTTPClient *http.Client
+}
+
+func (c Client) CreateSession(ctx context.Context, req CreateSessionRequest) (*CreateSessionResponse, error) {
+	var out CreateSessionResponse
+	if err := c.doJSON(ctx, http.MethodPost, PathSessions, req, &out); err != nil {
+		return nil, err
+	}
+	return &out, nil
+}
+
+func (c Client) Poll(ctx context.Context, sessionID string) (*PollResponse, bool, error) {
+	path := PathSessions + "/" + url.PathEscape(sessionID) + "/poll"
+	var out PollResponse
+	statusCode, err := c.doJSONStatus(ctx, http.MethodGet, path, nil, &out)
+	if err != nil {
+		return nil, false, err
+	}
+	if statusCode == http.StatusNoContent {
+		return nil, false, nil
+	}
+	return &out, true, nil
+}
+
+func (c Client) Complete(ctx context.Context, sessionID, callID string, req CompleteCallRequest) error {
+	path := PathSessions + "/" + url.PathEscape(sessionID) + "/calls/" + url.PathEscape(callID)
+	return c.doJSON(ctx, http.MethodPost, path, req, nil)
+}
+
+func (c Client) CloseSession(ctx context.Context, sessionID string) error {
+	path := PathSessions + "/" + url.PathEscape(sessionID)
+	return c.doJSON(ctx, http.MethodDelete, path, nil, nil)
+}
+
+func (c Client) RunDispatcher(ctx context.Context, sessionID string, providers map[string]proto.IntegrationProviderClient) error {
+	for {
+		call, ok, err := c.Poll(ctx, sessionID)
+		if err != nil {
+			if dispatcherContextDone(ctx) {
+				return nil
+			}
+			return err
+		}
+		if !ok {
+			continue
+		}
+		req := c.dispatchCall(ctx, call, providers)
+		if err := c.Complete(ctx, sessionID, call.CallID, req); err != nil {
+			if dispatcherContextDone(ctx) {
+				return nil
+			}
+			return err
+		}
+	}
+}
+
+func dispatcherContextDone(ctx context.Context) bool {
+	return ctx.Err() != nil
+}
+
+func (c Client) dispatchCall(ctx context.Context, call *PollResponse, providers map[string]proto.IntegrationProviderClient) CompleteCallRequest {
+	client := providers[strings.TrimSpace(call.Provider)]
+	if client == nil {
+		return CompleteCallRequest{Error: encodeRPCError(status.Errorf(codes.NotFound, "local provider %q is not running", call.Provider))}
+	}
+	payload, err := hex.DecodeString(call.Request)
+	if err != nil {
+		return CompleteCallRequest{Error: encodeRPCError(status.Errorf(codes.InvalidArgument, "decode request: %v", err))}
+	}
+	resp, err := dispatchProviderRPC(ctx, client, call.Method, payload)
+	if err != nil {
+		return CompleteCallRequest{Error: encodeRPCError(err)}
+	}
+	return CompleteCallRequest{Response: hex.EncodeToString(resp)}
+}
+
+func dispatchProviderRPC(ctx context.Context, client proto.IntegrationProviderClient, method string, payload []byte) ([]byte, error) {
+	switch method {
+	case "GetMetadata":
+		req := &emptypb.Empty{}
+		if err := gproto.Unmarshal(payload, req); err != nil {
+			return nil, err
+		}
+		resp, err := client.GetMetadata(ctx, req)
+		if err != nil {
+			return nil, err
+		}
+		return gproto.Marshal(resp)
+	case "StartProvider":
+		req := &proto.StartProviderRequest{}
+		if err := gproto.Unmarshal(payload, req); err != nil {
+			return nil, err
+		}
+		resp, err := client.StartProvider(ctx, req)
+		if err != nil {
+			return nil, err
+		}
+		return gproto.Marshal(resp)
+	case "Execute":
+		req := &proto.ExecuteRequest{}
+		if err := gproto.Unmarshal(payload, req); err != nil {
+			return nil, err
+		}
+		resp, err := client.Execute(ctx, req)
+		if err != nil {
+			return nil, err
+		}
+		return gproto.Marshal(resp)
+	case "ResolveHTTPSubject":
+		req := &proto.ResolveHTTPSubjectRequest{}
+		if err := gproto.Unmarshal(payload, req); err != nil {
+			return nil, err
+		}
+		resp, err := client.ResolveHTTPSubject(ctx, req)
+		if err != nil {
+			return nil, err
+		}
+		return gproto.Marshal(resp)
+	case "GetSessionCatalog":
+		req := &proto.GetSessionCatalogRequest{}
+		if err := gproto.Unmarshal(payload, req); err != nil {
+			return nil, err
+		}
+		resp, err := client.GetSessionCatalog(ctx, req)
+		if err != nil {
+			return nil, err
+		}
+		return gproto.Marshal(resp)
+	case "PostConnect":
+		req := &proto.PostConnectRequest{}
+		if err := gproto.Unmarshal(payload, req); err != nil {
+			return nil, err
+		}
+		resp, err := client.PostConnect(ctx, req)
+		if err != nil {
+			return nil, err
+		}
+		return gproto.Marshal(resp)
+	default:
+		return nil, status.Errorf(codes.Unimplemented, "provider dev method %q is not supported", method)
+	}
+}
+
+func (c Client) doJSON(ctx context.Context, method, path string, in any, out any) error {
+	_, err := c.doJSONStatus(ctx, method, path, in, out)
+	return err
+}
+
+func (c Client) doJSONStatus(ctx context.Context, method, path string, in any, out any) (int, error) {
+	var body io.Reader
+	if in != nil {
+		payload, err := json.Marshal(in)
+		if err != nil {
+			return 0, err
+		}
+		body = bytes.NewReader(payload)
+	}
+	endpoint, err := c.endpoint(path)
+	if err != nil {
+		return 0, err
+	}
+	req, err := http.NewRequestWithContext(ctx, method, endpoint, body)
+	if err != nil {
+		return 0, err
+	}
+	req.Header.Set("Accept", "application/json")
+	if in != nil {
+		req.Header.Set("Content-Type", "application/json")
+	}
+	if token := strings.TrimSpace(c.Token); token != "" {
+		req.Header.Set("Authorization", "Bearer "+token)
+	}
+	httpClient := c.HTTPClient
+	if httpClient == nil {
+		httpClient = http.DefaultClient
+	}
+	resp, err := httpClient.Do(req)
+	if err != nil {
+		return 0, err
+	}
+	defer func() { _ = resp.Body.Close() }()
+	if resp.StatusCode == http.StatusNoContent {
+		return resp.StatusCode, nil
+	}
+	if resp.StatusCode < 200 || resp.StatusCode >= 300 {
+		payload, _ := io.ReadAll(io.LimitReader(resp.Body, 4096))
+		return resp.StatusCode, fmt.Errorf("provider dev remote %s %s: %s: %s", method, path, resp.Status, strings.TrimSpace(string(payload)))
+	}
+	if out != nil {
+		if err := json.NewDecoder(resp.Body).Decode(out); err != nil {
+			return resp.StatusCode, err
+		}
+	}
+	return resp.StatusCode, nil
+}
+
+func (c Client) endpoint(path string) (string, error) {
+	base, err := url.Parse(strings.TrimSpace(c.BaseURL))
+	if err != nil {
+		return "", err
+	}
+	if base.Scheme == "" || base.Host == "" {
+		return "", fmt.Errorf("remote URL must include scheme and host")
+	}
+	base.Path = strings.TrimRight(base.Path, "/") + path
+	base.RawQuery = ""
+	base.Fragment = ""
+	return base.String(), nil
+}
+
+func encodeRPCError(err error) *RPCError {
+	if err == nil {
+		return nil
+	}
+	st, ok := status.FromError(err)
+	if ok {
+		return &RPCError{Code: int32(st.Code()), Message: st.Message()}
+	}
+	return &RPCError{Code: int32(codes.Unknown), Message: err.Error()}
+}
+
+func normalizeAttachProviders(values []AttachProvider) ([]AttachProvider, error) {
+	out := make([]string, 0, len(values))
+	seen := map[string]struct{}{}
+	for i := range values {
+		value := values[i]
+		name := strings.TrimSpace(value.Name)
+		if name == "" {
+			continue
+		}
+		if _, ok := seen[name]; ok {
+			continue
+		}
+		if specName := strings.TrimSpace(value.Spec.Name); specName != "" && specName != name {
+			return nil, status.Errorf(codes.InvalidArgument, "provider spec name %q must match requested provider name %q", specName, name)
+		}
+		value.Name = name
+		value.Spec.Name = name
+		seen[name] = struct{}{}
+		out = append(out, name)
+	}
+	slices.Sort(out)
+	requests := make([]AttachProvider, 0, len(out))
+	for _, name := range out {
+		for i := range values {
+			value := values[i]
+			if strings.TrimSpace(value.Name) != name {
+				continue
+			}
+			value.Name = name
+			value.Spec.Name = name
+			requests = append(requests, value)
+			break
+		}
+	}
+	return requests, nil
+}
+
+func buildAttachSpec(remoteSpec providerhost.StaticProviderSpec, localSpec providerhost.StaticProviderSpec) providerhost.StaticProviderSpec {
+	spec := cloneStaticProviderSpec(remoteSpec)
+	if spec.Name == "" {
+		spec.Name = localSpec.Name
+	}
+	if localSpec.DisplayName != "" {
+		spec.DisplayName = localSpec.DisplayName
+	}
+	if localSpec.Description != "" {
+		spec.Description = localSpec.Description
+	}
+	if localSpec.IconSVG != "" {
+		spec.IconSVG = localSpec.IconSVG
+	}
+	spec.Catalog = buildAttachCatalog(remoteSpec.Catalog, localSpec.Catalog)
+	return spec
+}
+
+func buildAttachCatalog(remoteCat, localCat *catalog.Catalog) *catalog.Catalog {
+	if localCat == nil {
+		if remoteCat == nil {
+			return nil
+		}
+		return remoteCat.Clone()
+	}
+	out := localCat.Clone()
+	remoteOps := map[string]catalog.CatalogOperation{}
+	if remoteCat != nil {
+		out.BaseURL = remoteCat.BaseURL
+		out.AuthStyle = remoteCat.AuthStyle
+		out.Headers = cloneStringMap(remoteCat.Headers)
+		for i := range remoteCat.Operations {
+			op := remoteCat.Operations[i]
+			remoteOps[op.ID] = op
+		}
+	}
+	for i := range out.Operations {
+		remoteOp, ok := remoteOps[out.Operations[i].ID]
+		if !ok {
+			out.Operations[i].AllowedRoles = nil
+			out.Operations[i].RequiredScopes = nil
+			continue
+		}
+		out.Operations[i].AllowedRoles = slices.Clone(remoteOp.AllowedRoles)
+		out.Operations[i].RequiredScopes = slices.Clone(remoteOp.RequiredScopes)
+	}
+	return out
+}
+
+func cloneStaticProviderSpec(spec providerhost.StaticProviderSpec) providerhost.StaticProviderSpec {
+	out := spec
+	out.AuthTypes = slices.Clone(spec.AuthTypes)
+	if spec.ConnectionParams != nil {
+		out.ConnectionParams = make(map[string]core.ConnectionParamDef, len(spec.ConnectionParams))
+		for key, value := range spec.ConnectionParams {
+			out.ConnectionParams[key] = value
+		}
+	}
+	out.CredentialFields = slices.Clone(spec.CredentialFields)
+	if spec.Catalog != nil {
+		out.Catalog = spec.Catalog.Clone()
+	}
+	if spec.DiscoveryConfig != nil {
+		discovery := *spec.DiscoveryConfig
+		out.DiscoveryConfig = &discovery
+	}
+	return out
+}
+
+func principalSubjectID(p *principal.Principal) string {
+	if p == nil {
+		return ""
+	}
+	if subjectID := strings.TrimSpace(p.SubjectID); subjectID != "" {
+		return subjectID
+	}
+	if userID := strings.TrimSpace(p.UserID); userID != "" {
+		return principal.UserSubjectID(userID)
+	}
+	return ""
+}
+
+func cloneStringMap(values map[string]string) map[string]string {
+	if len(values) == 0 {
+		return nil
+	}
+	out := make(map[string]string, len(values))
+	for key, value := range values {
+		out[key] = value
+	}
+	return out
+}
+
+func randomID() (string, error) {
+	var b [16]byte
+	if _, err := rand.Read(b[:]); err != nil {
+		return "", err
+	}
+	return hex.EncodeToString(b[:]), nil
+}

--- a/gestaltd/internal/providerdev/session_test.go
+++ b/gestaltd/internal/providerdev/session_test.go
@@ -1,0 +1,308 @@
+package providerdev
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"sync"
+	"testing"
+	"time"
+
+	proto "github.com/valon-technologies/gestalt/sdk/go/gen/v1"
+	"github.com/valon-technologies/gestalt/server/core"
+	"github.com/valon-technologies/gestalt/server/core/catalog"
+	"github.com/valon-technologies/gestalt/server/internal/principal"
+	"github.com/valon-technologies/gestalt/server/internal/providerhost"
+	"google.golang.org/grpc"
+	"google.golang.org/grpc/codes"
+	"google.golang.org/grpc/status"
+	"google.golang.org/protobuf/types/known/emptypb"
+)
+
+func TestHTTPTransportDispatchesProviderRPCs(t *testing.T) {
+	t.Parallel()
+
+	local := &recordingIntegrationClient{
+		supportsSessionCatalog: true,
+		sessionCatalog: &proto.Catalog{
+			Name: "roadmap",
+			Operations: []*proto.CatalogOperation{{
+				Id:             "echo",
+				Transport:      catalog.TransportPlugin,
+				AllowedRoles:   []string{"viewer"},
+				RequiredScopes: []string{"local.session.scope"},
+			}},
+		},
+	}
+	spec := providerhost.StaticProviderSpec{
+		Name:           "roadmap",
+		DisplayName:    "Roadmap",
+		ConnectionMode: core.ConnectionModeNone,
+		Catalog: &catalog.Catalog{
+			Name: "roadmap",
+			Operations: []catalog.CatalogOperation{{
+				ID:             "echo",
+				Transport:      catalog.TransportPlugin,
+				AllowedRoles:   []string{"viewer"},
+				RequiredScopes: []string{"local.scope"},
+			}},
+		},
+	}
+	remoteSpec := providerhost.StaticProviderSpec{
+		Name:           "roadmap",
+		ConnectionMode: core.ConnectionModeUser,
+		AuthTypes:      []string{"oauth2"},
+		Catalog: &catalog.Catalog{
+			Name: "roadmap",
+			Operations: []catalog.CatalogOperation{{
+				ID:             "echo",
+				Transport:      catalog.TransportPlugin,
+				AllowedRoles:   []string{"admin"},
+				RequiredScopes: []string{"remote.scope"},
+			}},
+		},
+	}
+	manager, err := NewManager([]Target{{
+		Name: "roadmap",
+		Spec: remoteSpec,
+		RuntimeEnv: func(string) (RuntimeEnv, error) {
+			return RuntimeEnv{
+				Env:          map[string]string{"GESTALT_PLUGIN_INVOKER_SOCKET": "tls://gestalt.example.test:443"},
+				AllowedHosts: []string{"gestalt.example.test"},
+			}, nil
+		},
+	}})
+	if err != nil {
+		t.Fatalf("NewManager: %v", err)
+	}
+
+	p := &principal.Principal{SubjectID: "user:user-123", UserID: "user-123", Kind: principal.KindUser}
+	ts := httptest.NewServer(providerDevTestHandler(t, manager, p))
+	t.Cleanup(ts.Close)
+
+	client := Client{BaseURL: ts.URL, HTTPClient: ts.Client()}
+	session, err := client.CreateSession(context.Background(), CreateSessionRequest{Providers: []AttachProvider{{
+		Name:   "roadmap",
+		Spec:   spec,
+		Config: map[string]any{"remote": true},
+	}}})
+	if err != nil {
+		t.Fatalf("CreateSession: %v", err)
+	}
+	if len(session.Providers) != 1 {
+		t.Fatalf("session providers = %#v, want one", session.Providers)
+	}
+	if got := session.Providers[0].Env["GESTALT_PLUGIN_INVOKER_SOCKET"]; got != "tls://gestalt.example.test:443" {
+		t.Fatalf("runtime env = %q, want relay target", got)
+	}
+
+	dispatchCtx, dispatchCancel := context.WithCancel(context.Background())
+	defer dispatchCancel()
+	dispatchDone := make(chan error, 1)
+	go func() {
+		dispatchDone <- client.RunDispatcher(dispatchCtx, session.ID, map[string]proto.IntegrationProviderClient{
+			"roadmap": local,
+		})
+	}()
+
+	resolveCtx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	defer cancel()
+	prov, ok, err := manager.ResolveProviderOverride(resolveCtx, p, "roadmap")
+	if err != nil {
+		t.Fatalf("ResolveProviderOverride: %v", err)
+	}
+	if !ok {
+		t.Fatal("ResolveProviderOverride ok = false, want true")
+	}
+	if got := prov.ConnectionMode(); got != core.ConnectionModeUser {
+		t.Fatalf("ConnectionMode = %q, want remote %q", got, core.ConnectionModeUser)
+	}
+	cat := prov.Catalog()
+	if cat == nil || len(cat.Operations) != 1 {
+		t.Fatalf("Catalog operations = %#v, want one", cat)
+	}
+	if got := cat.Operations[0].AllowedRoles; len(got) != 1 || got[0] != "admin" {
+		t.Fatalf("Catalog AllowedRoles = %#v, want remote [admin]", got)
+	}
+	if got := cat.Operations[0].RequiredScopes; len(got) != 1 || got[0] != "remote.scope" {
+		t.Fatalf("Catalog RequiredScopes = %#v, want remote [remote.scope]", got)
+	}
+	sessionCat, attempted, err := core.CatalogForRequest(resolveCtx, prov, "remote-token")
+	if err != nil {
+		t.Fatalf("CatalogForRequest: %v", err)
+	}
+	if !attempted {
+		t.Fatal("CatalogForRequest attempted = false, want true")
+	}
+	if got := sessionCat.Operations[0].AllowedRoles; len(got) != 1 || got[0] != "admin" {
+		t.Fatalf("session Catalog AllowedRoles = %#v, want remote [admin]", got)
+	}
+	if got := sessionCat.Operations[0].RequiredScopes; len(got) != 1 || got[0] != "remote.scope" {
+		t.Fatalf("session Catalog RequiredScopes = %#v, want remote [remote.scope]", got)
+	}
+
+	result, err := prov.Execute(resolveCtx, "echo", map[string]any{"message": "hello"}, "remote-token")
+	if err != nil {
+		t.Fatalf("Execute: %v", err)
+	}
+	if result.Body != `{"message":"hello","operation":"echo","token":"remote-token"}` {
+		t.Fatalf("Execute body = %s", result.Body)
+	}
+
+	local.mu.Lock()
+	startName := local.startName
+	startConfig := fmt.Sprint(local.startConfig)
+	local.mu.Unlock()
+	if startName != "roadmap" {
+		t.Fatalf("StartProvider name = %q, want roadmap", startName)
+	}
+	if !strings.Contains(startConfig, "remote:true") {
+		t.Fatalf("StartProvider config = %s, want remote:true", startConfig)
+	}
+
+	dispatchCancel()
+	select {
+	case err := <-dispatchDone:
+		if err != nil {
+			t.Fatalf("dispatcher error = %v", err)
+		}
+	case <-time.After(5 * time.Second):
+		t.Fatal("dispatcher did not stop")
+	}
+}
+
+func providerDevTestHandler(t *testing.T, manager *Manager, p *principal.Principal) http.Handler {
+	t.Helper()
+	mux := http.NewServeMux()
+	mux.HandleFunc(PathSessions, func(w http.ResponseWriter, r *http.Request) {
+		if r.Method != http.MethodPost {
+			http.NotFound(w, r)
+			return
+		}
+		var req CreateSessionRequest
+		if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
+			http.Error(w, err.Error(), http.StatusBadRequest)
+			return
+		}
+		resp, err := manager.CreateSession(r.Context(), p, req)
+		if err != nil {
+			writeProviderDevTestError(w, err)
+			return
+		}
+		writeProviderDevTestJSON(w, http.StatusCreated, resp)
+	})
+	mux.HandleFunc(PathSessions+"/", func(w http.ResponseWriter, r *http.Request) {
+		rest := strings.TrimPrefix(r.URL.Path, PathSessions+"/")
+		parts := strings.Split(rest, "/")
+		if len(parts) == 2 && parts[1] == "poll" && r.Method == http.MethodGet {
+			ctx, cancel := context.WithTimeout(r.Context(), DefaultPollTimeout)
+			defer cancel()
+			resp, ok, err := manager.PollSession(ctx, p, parts[0])
+			if err != nil {
+				writeProviderDevTestError(w, err)
+				return
+			}
+			if !ok {
+				w.WriteHeader(http.StatusNoContent)
+				return
+			}
+			writeProviderDevTestJSON(w, http.StatusOK, resp)
+			return
+		}
+		if len(parts) == 3 && parts[1] == "calls" && r.Method == http.MethodPost {
+			var req CompleteCallRequest
+			if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
+				http.Error(w, err.Error(), http.StatusBadRequest)
+				return
+			}
+			if err := manager.CompleteCall(p, parts[0], parts[2], req); err != nil {
+				writeProviderDevTestError(w, err)
+				return
+			}
+			writeProviderDevTestJSON(w, http.StatusOK, map[string]string{"status": "ok"})
+			return
+		}
+		if len(parts) == 1 && r.Method == http.MethodDelete {
+			if err := manager.CloseSession(p, parts[0]); err != nil {
+				writeProviderDevTestError(w, err)
+				return
+			}
+			writeProviderDevTestJSON(w, http.StatusOK, map[string]string{"status": "closed"})
+			return
+		}
+		http.NotFound(w, r)
+	})
+	return mux
+}
+
+func writeProviderDevTestJSON(w http.ResponseWriter, code int, value any) {
+	w.Header().Set("Content-Type", "application/json")
+	w.WriteHeader(code)
+	_ = json.NewEncoder(w).Encode(value)
+}
+
+func writeProviderDevTestError(w http.ResponseWriter, err error) {
+	code := http.StatusInternalServerError
+	if st, ok := status.FromError(err); ok {
+		switch st.Code() {
+		case codes.InvalidArgument:
+			code = http.StatusBadRequest
+		case codes.Unauthenticated:
+			code = http.StatusUnauthorized
+		case codes.PermissionDenied:
+			code = http.StatusForbidden
+		case codes.NotFound:
+			code = http.StatusNotFound
+		case codes.FailedPrecondition:
+			code = http.StatusPreconditionFailed
+		}
+		err = fmt.Errorf("%s", st.Message())
+	}
+	http.Error(w, err.Error(), code)
+}
+
+type recordingIntegrationClient struct {
+	mu                     sync.Mutex
+	startName              string
+	startConfig            map[string]any
+	supportsSessionCatalog bool
+	sessionCatalog         *proto.Catalog
+}
+
+func (c *recordingIntegrationClient) GetMetadata(context.Context, *emptypb.Empty, ...grpc.CallOption) (*proto.ProviderMetadata, error) {
+	return &proto.ProviderMetadata{SupportsSessionCatalog: c.supportsSessionCatalog}, nil
+}
+
+func (c *recordingIntegrationClient) StartProvider(_ context.Context, req *proto.StartProviderRequest, _ ...grpc.CallOption) (*proto.StartProviderResponse, error) {
+	c.mu.Lock()
+	c.startName = req.GetName()
+	if req.GetConfig() != nil {
+		c.startConfig = req.GetConfig().AsMap()
+	}
+	c.mu.Unlock()
+	return &proto.StartProviderResponse{ProtocolVersion: proto.CurrentProtocolVersion}, nil
+}
+
+func (c *recordingIntegrationClient) Execute(_ context.Context, req *proto.ExecuteRequest, _ ...grpc.CallOption) (*proto.OperationResult, error) {
+	params := req.GetParams().AsMap()
+	body := fmt.Sprintf(`{"message":%q,"operation":%q,"token":%q}`, params["message"], req.GetOperation(), req.GetToken())
+	return &proto.OperationResult{Status: http.StatusOK, Body: body}, nil
+}
+
+func (c *recordingIntegrationClient) ResolveHTTPSubject(context.Context, *proto.ResolveHTTPSubjectRequest, ...grpc.CallOption) (*proto.ResolveHTTPSubjectResponse, error) {
+	return nil, status.Error(codes.Unimplemented, "resolve http subject is not implemented")
+}
+
+func (c *recordingIntegrationClient) GetSessionCatalog(context.Context, *proto.GetSessionCatalogRequest, ...grpc.CallOption) (*proto.GetSessionCatalogResponse, error) {
+	if !c.supportsSessionCatalog {
+		return nil, status.Error(codes.Unimplemented, "session catalog is not implemented")
+	}
+	return &proto.GetSessionCatalogResponse{Catalog: c.sessionCatalog}, nil
+}
+
+func (c *recordingIntegrationClient) PostConnect(context.Context, *proto.PostConnectRequest, ...grpc.CallOption) (*proto.PostConnectResponse, error) {
+	return nil, status.Error(codes.Unimplemented, "post connect is not implemented")
+}

--- a/gestaltd/internal/server/authorization.go
+++ b/gestaltd/internal/server/authorization.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"net/http"
 
+	"github.com/valon-technologies/gestalt/server/core"
 	"github.com/valon-technologies/gestalt/server/internal/invocation"
 	"github.com/valon-technologies/gestalt/server/internal/principal"
 )
@@ -21,6 +22,13 @@ func (s *Server) providerAccessContextWithContext(ctx context.Context, p *princi
 	}
 	access, _ := s.authorizer.ResolveAccess(ctx, p, provider)
 	return access
+}
+
+func (s *Server) providerOverrideForContext(ctx context.Context, p *principal.Principal, provider string) (core.Provider, bool, error) {
+	if s.providerDevSessions == nil {
+		return nil, false, nil
+	}
+	return s.providerDevSessions.ResolveProviderOverride(ctx, p, provider)
 }
 
 func rejectWorkloadCaller(w http.ResponseWriter, p *principal.Principal) error {

--- a/gestaltd/internal/server/handlers.go
+++ b/gestaltd/internal/server/handlers.go
@@ -146,10 +146,18 @@ func (s *Server) listIntegrations(w http.ResponseWriter, r *http.Request) {
 		if err != nil {
 			continue
 		}
+		surfaceProv := prov
+		if override, ok, err := s.providerOverrideForContext(r.Context(), p, name); err != nil {
+			slog.ErrorContext(r.Context(), "resolving provider dev override", "provider", name, "error", err)
+			writeError(w, http.StatusInternalServerError, "failed to resolve provider dev override")
+			return
+		} else if ok {
+			surfaceProv = override
+		}
 		info := integrationInfo{
 			Name:             name,
-			DisplayName:      prov.DisplayName(),
-			Description:      prov.Description(),
+			DisplayName:      surfaceProv.DisplayName(),
+			Description:      surfaceProv.Description(),
 			Connected:        false,
 			Instances:        []instanceInfo{},
 			AuthTypes:        []string{},
@@ -157,7 +165,7 @@ func (s *Server) listIntegrations(w http.ResponseWriter, r *http.Request) {
 			Connections:      []connectionDefInfo{},
 			CredentialFields: []credentialFieldInfo{},
 		}
-		if cat := prov.Catalog(); cat != nil {
+		if cat := surfaceProv.Catalog(); cat != nil {
 			info.IconSVG = cat.IconSVG
 		}
 		if entry, ok := s.pluginDefs[name]; ok && entry != nil {
@@ -184,7 +192,7 @@ func (s *Server) listIntegrations(w http.ResponseWriter, r *http.Request) {
 				}
 			}
 			info.MountedPath = s.integrationMountedPathForPrincipalContext(r.Context(), p, name, info.MountedPath)
-			if !s.integrationHasUsableSurfaceContext(r.Context(), p, name, prov, info) {
+			if !s.integrationHasUsableSurfaceContext(r.Context(), p, name, surfaceProv, info) {
 				continue
 			}
 			out = append(out, info)
@@ -196,7 +204,7 @@ func (s *Server) listIntegrations(w http.ResponseWriter, r *http.Request) {
 		info.Instances = append(make([]instanceInfo, 0, len(instances)), instances...)
 		s.populateIntegrationSettings(&info, prov)
 		info.MountedPath = s.integrationMountedPathForPrincipalContext(r.Context(), p, name, info.MountedPath)
-		if !s.integrationHasUsableSurfaceContext(r.Context(), p, name, prov, info) {
+		if !s.integrationHasUsableSurfaceContext(r.Context(), p, name, surfaceProv, info) {
 			continue
 		}
 		out = append(out, info)
@@ -448,6 +456,12 @@ func (s *Server) listOperations(w http.ResponseWriter, r *http.Request) {
 		metricutil.AttrInvocationSurface.String("http"),
 	)
 	p := PrincipalFromContext(r.Context())
+	if override, ok, err := s.providerOverrideForContext(r.Context(), p, name); err != nil {
+		writeError(w, http.StatusInternalServerError, err.Error())
+		return
+	} else if ok {
+		prov = override
+	}
 	if !s.allowProviderContext(r.Context(), p, name) {
 		s.auditHTTPEvent(r.Context(), p, name, operation, false, errOperationAccess)
 		writeError(w, http.StatusForbidden, errOperationAccess.Error())
@@ -529,6 +543,13 @@ func (s *Server) executeOperation(w http.ResponseWriter, r *http.Request) {
 	prov, ok := s.getProvider(w, providerName)
 	if !ok {
 		return
+	}
+	surfaceProv := prov
+	if override, ok, err := s.providerOverrideForContext(r.Context(), p, providerName); err != nil {
+		writeError(w, http.StatusInternalServerError, err.Error())
+		return
+	} else if ok {
+		surfaceProv = override
 	}
 	access := s.providerAccessContextWithContext(r.Context(), p, providerName)
 	providerAllowed := s.allowProviderContext(r.Context(), p, providerName)
@@ -638,7 +659,7 @@ func (s *Server) executeOperation(w http.ResponseWriter, r *http.Request) {
 		resolver = tr
 	}
 	boundSessionConnections, sessionInstance := s.catalogSelectorConfig().BoundSessionCatalogConnections(providerName, p, connection, instance)
-	opMeta, _, resolvedConnection, err := invocation.ResolveOperation(ctx, prov, providerName, resolver, p, operationName, boundSessionConnections, sessionInstance)
+	opMeta, _, resolvedConnection, err := invocation.ResolveOperation(ctx, surfaceProv, providerName, resolver, p, operationName, boundSessionConnections, sessionInstance)
 	if err != nil {
 		s.writeInvocationError(w, r, providerName, operationName, err)
 		return

--- a/gestaltd/internal/server/handlers_provider_dev.go
+++ b/gestaltd/internal/server/handlers_provider_dev.go
@@ -1,0 +1,144 @@
+package server
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"net/http"
+	"strings"
+
+	"github.com/go-chi/chi/v5"
+	"github.com/valon-technologies/gestalt/server/internal/principal"
+	"github.com/valon-technologies/gestalt/server/internal/providerdev"
+	"google.golang.org/grpc/codes"
+	"google.golang.org/grpc/status"
+)
+
+func (s *Server) createProviderDevSession(w http.ResponseWriter, r *http.Request) {
+	if s.providerDevSessions == nil {
+		writeError(w, http.StatusNotFound, "provider dev is not configured")
+		return
+	}
+	var req providerdev.CreateSessionRequest
+	if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
+		writeError(w, http.StatusBadRequest, "invalid provider dev session request")
+		return
+	}
+	p := PrincipalFromContext(r.Context())
+	if err := s.authorizeProviderDevSessionRequest(w, r, p, req); err != nil {
+		return
+	}
+	resp, err := s.providerDevSessions.CreateSession(r.Context(), p, req)
+	if err != nil {
+		writeProviderDevError(w, err)
+		return
+	}
+	writeJSON(w, http.StatusCreated, resp)
+}
+
+func (s *Server) authorizeProviderDevSessionRequest(w http.ResponseWriter, r *http.Request, p *principal.Principal, req providerdev.CreateSessionRequest) error {
+	if err := rejectWorkloadCaller(w, p); err != nil {
+		return err
+	}
+	for i := range req.Providers {
+		provider := req.Providers[i]
+		name := strings.TrimSpace(provider.Name)
+		if name == "" {
+			continue
+		}
+		if !principal.AllowsProviderPermission(p, name) || !s.allowProviderContext(r.Context(), p, name) {
+			writeError(w, http.StatusForbidden, errOperationAccess.Error())
+			return errOperationAccess
+		}
+	}
+	return nil
+}
+
+func (s *Server) pollProviderDevSession(w http.ResponseWriter, r *http.Request) {
+	if s.providerDevSessions == nil {
+		writeError(w, http.StatusNotFound, "provider dev is not configured")
+		return
+	}
+	sessionID := chi.URLParam(r, "sessionID")
+	ctx, cancel := context.WithTimeout(r.Context(), providerdev.DefaultPollTimeout)
+	defer cancel()
+	resp, ok, err := s.providerDevSessions.PollSession(ctx, PrincipalFromContext(r.Context()), sessionID)
+	if err != nil {
+		writeProviderDevError(w, err)
+		return
+	}
+	if !ok {
+		w.WriteHeader(http.StatusNoContent)
+		return
+	}
+	writeJSON(w, http.StatusOK, resp)
+}
+
+func (s *Server) completeProviderDevCall(w http.ResponseWriter, r *http.Request) {
+	if s.providerDevSessions == nil {
+		writeError(w, http.StatusNotFound, "provider dev is not configured")
+		return
+	}
+	var req providerdev.CompleteCallRequest
+	if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
+		writeError(w, http.StatusBadRequest, "invalid provider dev call response")
+		return
+	}
+	err := s.providerDevSessions.CompleteCall(
+		PrincipalFromContext(r.Context()),
+		chi.URLParam(r, "sessionID"),
+		chi.URLParam(r, "callID"),
+		req,
+	)
+	if err != nil {
+		writeProviderDevError(w, err)
+		return
+	}
+	writeJSON(w, http.StatusOK, map[string]string{"status": "ok"})
+}
+
+func (s *Server) closeProviderDevSession(w http.ResponseWriter, r *http.Request) {
+	if s.providerDevSessions == nil {
+		writeError(w, http.StatusNotFound, "provider dev is not configured")
+		return
+	}
+	err := s.providerDevSessions.CloseSession(PrincipalFromContext(r.Context()), chi.URLParam(r, "sessionID"))
+	if err != nil {
+		writeProviderDevError(w, err)
+		return
+	}
+	writeJSON(w, http.StatusOK, map[string]string{"status": "closed"})
+}
+
+func writeProviderDevError(w http.ResponseWriter, err error) {
+	if err == nil {
+		return
+	}
+	if errors.Is(err, context.Canceled) || errors.Is(err, context.DeadlineExceeded) {
+		writeError(w, http.StatusGatewayTimeout, err.Error())
+		return
+	}
+	st, ok := status.FromError(err)
+	if !ok {
+		writeError(w, http.StatusInternalServerError, err.Error())
+		return
+	}
+	switch st.Code() {
+	case codes.InvalidArgument:
+		writeError(w, http.StatusBadRequest, st.Message())
+	case codes.Unauthenticated:
+		writeError(w, http.StatusUnauthorized, st.Message())
+	case codes.PermissionDenied:
+		writeError(w, http.StatusForbidden, st.Message())
+	case codes.NotFound:
+		writeError(w, http.StatusNotFound, st.Message())
+	case codes.FailedPrecondition:
+		writeError(w, http.StatusPreconditionFailed, st.Message())
+	case codes.DeadlineExceeded:
+		writeError(w, http.StatusGatewayTimeout, st.Message())
+	case codes.Unavailable:
+		writeError(w, http.StatusServiceUnavailable, st.Message())
+	default:
+		writeError(w, http.StatusInternalServerError, st.Message())
+	}
+}

--- a/gestaltd/internal/server/routes_user.go
+++ b/gestaltd/internal/server/routes_user.go
@@ -60,6 +60,11 @@ func (s *Server) mountAuthenticatedRoutes(r chi.Router) {
 		r.Post("/auth/start-oauth", s.startIntegrationOAuth)
 		r.Post("/auth/connect-manual", s.connectManual)
 
+		r.Post("/provider-dev/sessions", s.createProviderDevSession)
+		r.Get("/provider-dev/sessions/{sessionID}/poll", s.pollProviderDevSession)
+		r.Post("/provider-dev/sessions/{sessionID}/calls/{callID}", s.completeProviderDevCall)
+		r.Delete("/provider-dev/sessions/{sessionID}", s.closeProviderDevSession)
+
 		r.Post("/tokens", s.createAPIToken)
 		r.Get("/tokens", s.listAPITokens)
 		r.Delete("/tokens", s.revokeAllAPITokens)

--- a/gestaltd/internal/server/runtime.go
+++ b/gestaltd/internal/server/runtime.go
@@ -114,7 +114,8 @@ func Run(ctx context.Context, cfg *config.Config, result *bootstrap.Result) erro
 			}
 			return ""
 		},
-		PrometheusMetrics: result.Telemetry.PrometheusHandler(),
+		PrometheusMetrics:   result.Telemetry.PrometheusHandler(),
+		ProviderDevSessions: result.ProviderDevSessions,
 		Admin: AdminRouteConfig{
 			AuthorizationPolicy: cfg.Server.Admin.AuthorizationPolicy,
 			AllowedRoles:        append([]string(nil), cfg.Server.Admin.AllowedRoles...),

--- a/gestaltd/internal/server/server.go
+++ b/gestaltd/internal/server/server.go
@@ -18,6 +18,7 @@ import (
 	"github.com/valon-technologies/gestalt/server/internal/invocation"
 	"github.com/valon-technologies/gestalt/server/internal/metricutil"
 	"github.com/valon-technologies/gestalt/server/internal/principal"
+	"github.com/valon-technologies/gestalt/server/internal/providerdev"
 	"github.com/valon-technologies/gestalt/server/internal/providerhost"
 	"github.com/valon-technologies/gestalt/server/internal/registry"
 	"github.com/valon-technologies/gestalt/server/internal/workflowmanager"
@@ -117,6 +118,7 @@ type Server struct {
 	mcpHandler             http.Handler
 	hostServiceRelayTokens *providerhost.HostServiceRelayTokenManager
 	egressProxyTokens      *providerhost.EgressProxyTokenManager
+	providerDevSessions    *providerdev.Manager
 	mountedHTTPBindings    []MountedHTTPBinding
 	mountedUIs             []MountedUI
 	adminRoute             AdminRouteConfig
@@ -162,6 +164,7 @@ type Config struct {
 	Readiness             ReadinessChecker
 	PrometheusMetrics     http.Handler
 	MCPHandler            http.Handler
+	ProviderDevSessions   *providerdev.Manager
 	MountedUIs            []MountedUI
 	Admin                 AdminRouteConfig
 	AdminUIProvider       string
@@ -333,6 +336,7 @@ func New(cfg Config) (*Server, error) {
 		mcpHandler:             cfg.MCPHandler,
 		hostServiceRelayTokens: hostServiceRelayTokens,
 		egressProxyTokens:      egressProxyTokens,
+		providerDevSessions:    cfg.ProviderDevSessions,
 		mountedHTTPBindings:    mountedHTTPBindings,
 		mountedUIs:             mountedUIs,
 		adminRoute:             adminRoute,


### PR DESCRIPTION
## Summary

Adds remote provider development sessions so `gestaltd provider dev` can run local source-backed plugin implementations while an authenticated remote `gestaltd` instance keeps the auth, authorization, connection, credential, and host-service envelope.

Release-backed remote plugins are not attachable by default; set `providerDev: true` on that plugin config entry to opt in. Source-backed entries remain attachable because they are already explicit local-development targets.

This PR covers provider RPCs and host-service relay env for plugin development. Remote UI tunneling is intentionally left as a follow-up.

## New interfaces

- `gestaltd provider dev --remote URL --path PATH [--remote-token TOKEN]`
- `gestaltd provider dev --remote URL --config PATH [--config PATH...]`
- Plugin config: `providerDev: true` enables release-backed remote attach targets.
- `POST /api/v1/provider-dev/sessions`
- `GET /api/v1/provider-dev/sessions/{id}/poll`
- `POST /api/v1/provider-dev/sessions/{id}/calls/{callID}`
- `DELETE /api/v1/provider-dev/sessions/{id}`

## Examples

```sh
GESTALT_API_KEY=vat_... gestaltd provider dev --remote https://gestalt.example.com --path ./plugins/support
GESTALT_API_KEY=vat_... gestaltd provider dev --remote https://gestalt.example.com --config ./remote.yaml --config ./local-overrides.yaml
```

```yaml
plugins:
  support:
    source:
      githubRelease:
        repo: valon-technologies/toolshed
        tag: plugins/support/v1.2.3
        asset: provider-release.yaml
    providerDev: true
```

## Verification

- `go test ./internal/providerdev ./internal/bootstrap ./internal/invocation ./internal/server ./cmd/gestaltd`
- `go test ./... -run TestDoesNotExist`
- `golangci-lint run ./...`
- Separate reviewer agent final pass: no blocker/high findings.
