### PR TITLE
Fix workflow agent review findings

### DIFF
--- a/gestaltd/core/workflow/workflow.go
+++ b/gestaltd/core/workflow/workflow.go
@@ -6,6 +6,7 @@ import (
 	"encoding/hex"
 	"encoding/json"
 	"fmt"
+	"strings"
 	"time"
 
 	"github.com/valon-technologies/gestalt/server/core"
@@ -293,7 +294,7 @@ func (t Target) AgentTarget() AgentTarget {
 }
 
 func TargetFingerprint(target Target) (string, error) {
-	if target.Agent != nil && !emptyPluginTarget(target.PluginTarget()) {
+	if target.Agent != nil && PluginTargetSet(target.PluginTarget()) {
 		return "", fmt.Errorf("target cannot include both agent and plugin fields")
 	}
 	payload, err := json.Marshal(normalizedTargetFingerprintPayload(target))
@@ -327,7 +328,7 @@ func normalizedTargetFingerprintPayload(target Target) Target {
 		return out
 	}
 	pluginTarget := target.PluginTarget()
-	if !emptyPluginTarget(pluginTarget) {
+	if PluginTargetSet(pluginTarget) {
 		if len(pluginTarget.Input) == 0 {
 			pluginTarget.Input = nil
 		}
@@ -336,10 +337,16 @@ func normalizedTargetFingerprintPayload(target Target) Target {
 	return out
 }
 
-func emptyPluginTarget(target PluginTarget) bool {
-	return target.PluginName == "" &&
-		target.Operation == "" &&
-		target.Connection == "" &&
-		target.Instance == "" &&
+// PluginTargetSet reports whether a workflow target contains any plugin target field.
+func PluginTargetSet(target PluginTarget) bool {
+	return !PluginTargetEmpty(target)
+}
+
+// PluginTargetEmpty reports whether a workflow target has no plugin target fields.
+func PluginTargetEmpty(target PluginTarget) bool {
+	return strings.TrimSpace(target.PluginName) == "" &&
+		strings.TrimSpace(target.Operation) == "" &&
+		strings.TrimSpace(target.Connection) == "" &&
+		strings.TrimSpace(target.Instance) == "" &&
 		len(target.Input) == 0
 }

--- a/gestaltd/internal/bootstrap/workflow_runtime.go
+++ b/gestaltd/internal/bootstrap/workflow_runtime.go
@@ -304,15 +304,7 @@ func (r *workflowRuntime) resolveWorkflowExecutionRef(ctx context.Context, req c
 }
 
 func workflowTargetHasMixedKinds(target coreworkflow.Target) bool {
-	return target.Agent != nil && workflowPluginTargetSet(target.PluginTarget())
-}
-
-func workflowPluginTargetSet(target coreworkflow.PluginTarget) bool {
-	return strings.TrimSpace(target.PluginName) != "" ||
-		strings.TrimSpace(target.Operation) != "" ||
-		strings.TrimSpace(target.Connection) != "" ||
-		strings.TrimSpace(target.Instance) != "" ||
-		len(target.Input) > 0
+	return target.Agent != nil && coreworkflow.PluginTargetSet(target.PluginTarget())
 }
 
 func (r *workflowRuntime) invokeAgent(ctx context.Context, req coreworkflow.InvokeOperationRequest, agentManager agentmanager.Service) (*coreworkflow.InvokeOperationResponse, error) {
@@ -374,7 +366,9 @@ func (r *workflowRuntime) invokeAgent(ctx context.Context, req coreworkflow.Invo
 	}
 	turn, err = waitForWorkflowAgentTurn(runCtx, agentManager, principalValue, turn)
 	if err != nil {
-		_, _ = agentManager.CancelTurn(context.WithoutCancel(ctx), principalValue, turn.ID, err.Error())
+		if turn != nil && strings.TrimSpace(turn.ID) != "" {
+			_, _ = agentManager.CancelTurn(context.WithoutCancel(ctx), principalValue, turn.ID, err.Error())
+		}
 		return nil, err
 	}
 	switch turn.Status {
@@ -425,6 +419,9 @@ func waitForWorkflowAgentTurn(ctx context.Context, agentManager agentmanager.Ser
 			next, err := agentManager.GetTurn(ctx, p, current.ID)
 			if err != nil {
 				return current, err
+			}
+			if next == nil || strings.TrimSpace(next.ID) == "" {
+				return current, fmt.Errorf("workflow agent turn is missing")
 			}
 			current = next
 		}

--- a/gestaltd/internal/bootstrap/workflow_runtime_test.go
+++ b/gestaltd/internal/bootstrap/workflow_runtime_test.go
@@ -5,6 +5,7 @@ import (
 	"errors"
 	"net"
 	"net/http"
+	"strings"
 	"testing"
 	"time"
 
@@ -111,6 +112,44 @@ func cloneMapAny(value map[string]any) map[string]any {
 		out[key] = item
 	}
 	return out
+}
+
+type workflowRuntimeAgentManagerStub struct {
+	agentmanager.Service
+	createSessionRequests []coreagent.ManagerCreateSessionRequest
+	createTurnRequests    []coreagent.ManagerCreateTurnRequest
+	cancelTurnIDs         []string
+	returnNilTurn         bool
+}
+
+func (m *workflowRuntimeAgentManagerStub) CreateSession(_ context.Context, _ *principal.Principal, req coreagent.ManagerCreateSessionRequest) (*coreagent.Session, error) {
+	m.createSessionRequests = append(m.createSessionRequests, req)
+	return &coreagent.Session{
+		ID:           "session-1",
+		ProviderName: req.ProviderName,
+		Model:        req.Model,
+		State:        coreagent.SessionStateActive,
+	}, nil
+}
+
+func (m *workflowRuntimeAgentManagerStub) CreateTurn(_ context.Context, _ *principal.Principal, req coreagent.ManagerCreateTurnRequest) (*coreagent.Turn, error) {
+	m.createTurnRequests = append(m.createTurnRequests, req)
+	if m.returnNilTurn {
+		return nil, nil
+	}
+	return &coreagent.Turn{
+		ID:           "turn-1",
+		SessionID:    req.SessionID,
+		ProviderName: "managed",
+		Model:        req.Model,
+		Status:       coreagent.ExecutionStatusSucceeded,
+		OutputText:   "turn completed",
+	}, nil
+}
+
+func (m *workflowRuntimeAgentManagerStub) CancelTurn(_ context.Context, _ *principal.Principal, turnID, _ string) (*coreagent.Turn, error) {
+	m.cancelTurnIDs = append(m.cancelTurnIDs, turnID)
+	return &coreagent.Turn{ID: turnID, Status: coreagent.ExecutionStatusCanceled}, nil
 }
 
 type workflowRoundTripProvider struct {
@@ -420,6 +459,89 @@ func TestWorkflowRuntimeInvokeAgentTargetCreatesAndSupervisesTurn(t *testing.T) 
 	}
 	if len(turnReq.Tools) != 1 || turnReq.Tools[0].Target.PluginName != "roadmap" || turnReq.Tools[0].Target.Operation != "sync" {
 		t.Fatalf("turn tools = %#v", turnReq.Tools)
+	}
+}
+
+func TestWorkflowRuntimeInvokeAgentTargetWithExecutionRefIgnoresWhitespaceLegacyPluginFields(t *testing.T) {
+	t.Parallel()
+
+	target := coreworkflow.Target{
+		PluginName: " \t",
+		Operation:  "\n",
+		Connection: " ",
+		Instance:   "\t",
+		Agent: &coreworkflow.AgentTarget{
+			ProviderName:   "managed",
+			Model:          "deep",
+			Prompt:         "Send the status summary",
+			ToolSource:     coreagent.ToolSourceModeExplicit,
+			TimeoutSeconds: 5,
+		},
+	}
+	fingerprint, err := coreworkflow.TargetFingerprint(target)
+	if err != nil {
+		t.Fatalf("TargetFingerprint: %v", err)
+	}
+	refProvider := newWorkflowRuntimeExecutionRefProvider()
+	if _, err := refProvider.PutExecutionReference(context.Background(), &coreworkflow.ExecutionReference{
+		ID:                "agent-ref",
+		ProviderName:      "temporal",
+		Target:            target,
+		TargetFingerprint: fingerprint,
+		SubjectID:         principal.WorkloadSubjectID("scheduler"),
+	}); err != nil {
+		t.Fatalf("Put execution ref: %v", err)
+	}
+	agentManager := &workflowRuntimeAgentManagerStub{}
+	runtime := &workflowRuntime{
+		providers: map[string]coreworkflow.Provider{"temporal": refProvider},
+	}
+	runtime.SetAgentManager(agentManager)
+
+	resp, err := runtime.Invoke(context.Background(), coreworkflow.InvokeOperationRequest{
+		ProviderName: "temporal",
+		ExecutionRef: "agent-ref",
+		RunID:        "run-agent-123",
+		Target:       target,
+	})
+	if err != nil {
+		t.Fatalf("Invoke: %v", err)
+	}
+	if resp.Status != http.StatusOK || resp.Body != "turn completed" {
+		t.Fatalf("response = %#v", resp)
+	}
+	if len(agentManager.createTurnRequests) != 1 {
+		t.Fatalf("turn requests = %d, want 1", len(agentManager.createTurnRequests))
+	}
+}
+
+func TestWorkflowRuntimeInvokeAgentTargetHandlesMissingTurn(t *testing.T) {
+	t.Parallel()
+
+	agentManager := &workflowRuntimeAgentManagerStub{returnNilTurn: true}
+	runtime := &workflowRuntime{}
+	runtime.SetAgentManager(agentManager)
+	p := principal.Canonicalize(&principal.Principal{
+		SubjectID:           principal.UserSubjectID("ada"),
+		CredentialSubjectID: principal.UserSubjectID("ada"),
+	})
+
+	_, err := runtime.Invoke(principal.WithPrincipal(context.Background(), p), coreworkflow.InvokeOperationRequest{
+		ProviderName: "temporal",
+		RunID:        "run-agent-123",
+		Target: coreworkflow.Target{Agent: &coreworkflow.AgentTarget{
+			ProviderName:   "managed",
+			Model:          "deep",
+			Prompt:         "Send the status summary",
+			ToolSource:     coreagent.ToolSourceModeExplicit,
+			TimeoutSeconds: 5,
+		}},
+	})
+	if err == nil || !strings.Contains(err.Error(), "workflow agent turn is missing") {
+		t.Fatalf("Invoke error = %v, want missing turn error", err)
+	}
+	if len(agentManager.cancelTurnIDs) != 0 {
+		t.Fatalf("cancel turn IDs = %#v, want none for missing turn", agentManager.cancelTurnIDs)
 	}
 }
 

--- a/gestaltd/internal/providerhost/workflow_convert.go
+++ b/gestaltd/internal/providerhost/workflow_convert.go
@@ -63,7 +63,7 @@ func workflowTargetFromProto(target *proto.BoundWorkflowTarget) coreworkflow.Tar
 		return coreworkflow.Target{}
 	}
 	plugin := workflowPluginTargetFromProto(target.GetPlugin())
-	if workflowPluginTargetEmpty(plugin) {
+	if coreworkflow.PluginTargetEmpty(plugin) {
 		plugin = coreworkflow.PluginTarget{
 			PluginName: strings.TrimSpace(target.GetPluginName()),
 			Operation:  strings.TrimSpace(target.GetOperation()),
@@ -80,7 +80,7 @@ func workflowTargetFromProto(target *proto.BoundWorkflowTarget) coreworkflow.Tar
 		Input:      plugin.Input,
 		Agent:      workflowAgentTargetFromProto(target.GetAgent()),
 	}
-	if !workflowPluginTargetEmpty(plugin) {
+	if coreworkflow.PluginTargetSet(plugin) {
 		out.Plugin = &plugin
 	}
 	return out
@@ -112,16 +112,8 @@ func workflowTargetProtoHasPluginFields(target *proto.BoundWorkflowTarget) bool 
 		target.GetInput() != nil
 }
 
-func workflowPluginTargetEmpty(target coreworkflow.PluginTarget) bool {
-	return strings.TrimSpace(target.PluginName) == "" &&
-		strings.TrimSpace(target.Operation) == "" &&
-		strings.TrimSpace(target.Connection) == "" &&
-		strings.TrimSpace(target.Instance) == "" &&
-		len(target.Input) == 0
-}
-
 func workflowPluginTargetToProto(target coreworkflow.PluginTarget) (*proto.BoundWorkflowPluginTarget, error) {
-	if workflowPluginTargetEmpty(target) {
+	if coreworkflow.PluginTargetEmpty(target) {
 		return nil, nil
 	}
 	input, err := structFromMap(target.Input)

--- a/gestaltd/internal/workflowmanager/manager.go
+++ b/gestaltd/internal/workflowmanager/manager.go
@@ -713,7 +713,7 @@ func (m *Manager) resolveProviderByName(providerName string) (coreworkflow.Provi
 
 func (m *Manager) resolveTarget(ctx context.Context, p *principal.Principal, target coreworkflow.Target) (coreworkflow.Target, error) {
 	pluginTarget := target.PluginTarget()
-	hasPlugin := workflowPluginTargetSet(pluginTarget)
+	hasPlugin := coreworkflow.PluginTargetSet(pluginTarget)
 	hasAgent := target.Agent != nil
 	if hasAgent && hasPlugin {
 		return coreworkflow.Target{}, fmt.Errorf("workflow target must set exactly one of plugin or agent")
@@ -722,14 +722,6 @@ func (m *Manager) resolveTarget(ctx context.Context, p *principal.Principal, tar
 		return m.resolveAgentTarget(ctx, p, target.AgentTarget())
 	}
 	return m.resolvePluginTarget(ctx, p, pluginTarget)
-}
-
-func workflowPluginTargetSet(target coreworkflow.PluginTarget) bool {
-	return strings.TrimSpace(target.PluginName) != "" ||
-		strings.TrimSpace(target.Operation) != "" ||
-		strings.TrimSpace(target.Connection) != "" ||
-		strings.TrimSpace(target.Instance) != "" ||
-		len(target.Input) > 0
 }
 
 func (m *Manager) resolvePluginTarget(ctx context.Context, p *principal.Principal, target coreworkflow.PluginTarget) (coreworkflow.Target, error) {


### PR DESCRIPTION
## Summary
- Centralize workflow plugin-target emptiness detection in `core/workflow` via `PluginTargetSet` and `PluginTargetEmpty`.
- Make plugin-target whitespace handling consistent across fingerprinting, runtime mixed-target validation, workflow manager resolution, and providerhost proto conversion.
- Guard workflow agent turn cleanup when turn creation/supervision returns a nil turn, avoiding nil dereference during cancellation.

## Review Comments Addressed
- https://github.com/valon-technologies/gestalt/pull/1374#discussion_r3144647159
- https://github.com/valon-technologies/gestalt/pull/1374#discussion_r3144647163
- https://github.com/valon-technologies/gestalt/pull/1374#discussion_r3144647167

## Interface Notes
```go
// PluginTargetSet reports whether a workflow target contains any plugin target field.
func PluginTargetSet(target workflow.PluginTarget) bool

// PluginTargetEmpty reports whether a workflow target has no plugin target fields.
func PluginTargetEmpty(target workflow.PluginTarget) bool
```

Example usage:
```go
if target.Agent != nil && workflow.PluginTargetSet(target.PluginTarget()) {
    return fmt.Errorf("target cannot include both agent and plugin fields")
}
```

## Verification
- `go test ./core/workflow ./internal/bootstrap ./internal/workflowmanager ./internal/providerhost`
- `go test ./...` from `gestaltd`