### PR TITLE
Preserve workflow execution refs through cleanup wrapper

### DIFF
--- a/gestaltd/internal/bootstrap/bootstrap.go
+++ b/gestaltd/internal/bootstrap/bootstrap.go
@@ -400,7 +400,26 @@ type workflowProviderWithCleanup struct {
 	cleanup func()
 }
 
+type workflowProviderWithExecutionReferencesAndCleanup struct {
+	coreworkflow.Provider
+	coreworkflow.ExecutionReferenceStore
+	cleanup func()
+}
+
 func (p *workflowProviderWithCleanup) Close() error {
+	var errs []error
+	if p != nil && p.Provider != nil {
+		if err := p.Provider.Close(); err != nil {
+			errs = append(errs, err)
+		}
+	}
+	if p != nil && p.cleanup != nil {
+		p.cleanup()
+	}
+	return errors.Join(errs...)
+}
+
+func (p *workflowProviderWithExecutionReferencesAndCleanup) Close() error {
 	var errs []error
 	if p != nil && p.Provider != nil {
 		if err := p.Provider.Close(); err != nil {
@@ -1684,9 +1703,17 @@ func buildWorkflow(ctx context.Context, name string, entry *config.ProviderEntry
 		return nil, fmt.Errorf("workflow provider: %w", err)
 	}
 	if cleanup != nil {
-		provider = &workflowProviderWithCleanup{
-			Provider: provider,
-			cleanup:  cleanup,
+		if executionRefs, ok := provider.(coreworkflow.ExecutionReferenceStore); ok {
+			provider = &workflowProviderWithExecutionReferencesAndCleanup{
+				Provider:                provider,
+				ExecutionReferenceStore: executionRefs,
+				cleanup:                 cleanup,
+			}
+		} else {
+			provider = &workflowProviderWithCleanup{
+				Provider: provider,
+				cleanup:  cleanup,
+			}
 		}
 		cleanup = nil
 	}

--- a/gestaltd/internal/bootstrap/bootstrap_test.go
+++ b/gestaltd/internal/bootstrap/bootstrap_test.go
@@ -3323,9 +3323,10 @@ func TestBootstrapRoutesWorkflowIndexedDBHostServices(t *testing.T) {
 		}
 		return boundDB, nil
 	}
+	workflowProvider := &recordingWorkflowProvider{}
 	factories.Workflow = func(_ context.Context, _ string, _ yaml.Node, hostServices []providerhost.HostService, _ bootstrap.Deps) (coreworkflow.Provider, error) {
 		hostEnv = append([]providerhost.HostService(nil), hostServices...)
-		return &stubWorkflowProvider{}, nil
+		return workflowProvider, nil
 	}
 
 	result, err := bootstrap.Bootstrap(context.Background(), cfg, factories)
@@ -3348,6 +3349,29 @@ func TestBootstrapRoutesWorkflowIndexedDBHostServices(t *testing.T) {
 	}
 	if indexedDBHost.EnvVar == "" {
 		t.Fatal("missing workflow indexeddb host service")
+	}
+
+	provider, err := result.WorkflowControl.ResolveProvider("basic")
+	if err != nil {
+		t.Fatalf("ResolveProvider(basic): %v", err)
+	}
+	executionRefs, ok := provider.(coreworkflow.ExecutionReferenceStore)
+	if !ok {
+		t.Fatal("workflow provider with indexeddb cleanup does not preserve execution reference store")
+	}
+	if _, err := executionRefs.PutExecutionReference(context.Background(), &coreworkflow.ExecutionReference{
+		ID:           "workflow_schedule:sched-test:ref-test",
+		ProviderName: "basic",
+		Target: coreworkflow.Target{
+			PluginName: "roadmap",
+			Operation:  "sync",
+		},
+		SubjectID: "user:ada",
+	}); err != nil {
+		t.Fatalf("PutExecutionReference: %v", err)
+	}
+	if _, err := workflowProvider.GetExecutionReference(context.Background(), "workflow_schedule:sched-test:ref-test"); err != nil {
+		t.Fatalf("underlying workflow provider missing execution ref: %v", err)
 	}
 
 	withIndexedDBHostClient(t, indexedDBHost, func(client proto.IndexedDBClient) {


### PR DESCRIPTION
## Summary
- preserve the optional `coreworkflow.ExecutionReferenceStore` interface when workflow providers are wrapped with IndexedDB-host cleanup
- fixes the live `valon.tools` workflow API failure: `workflow execution refs are not configured: workflow provider "local" does not support execution references`
- augments the existing bootstrap IndexedDB host-service routing test to assert that execution refs still pass through the cleanup wrapper

## Interfaces / Usage
The user-facing workflow interfaces are unchanged:

```bash
gestalt workflow schedules list
gestalt workflow schedules create \
  --cron '*/1 * * * *' \
  --plugin slack \
  --operation chat.postMessage \
  -p channel=D123 \
  -p text='scheduled check'
```

Internally, providers that implement `coreworkflow.ExecutionReferenceStore` retain that interface after cleanup wrapping:

```go
if executionRefs, ok := provider.(coreworkflow.ExecutionReferenceStore); ok {
    provider = &workflowProviderWithExecutionReferencesAndCleanup{
        Provider:                provider,
        ExecutionReferenceStore: executionRefs,
        cleanup:                 cleanup,
    }
}
```

## Verification
- `go test ./internal/bootstrap -run TestBootstrapRoutesWorkflowIndexedDBHostServices -count=1`
- `go test ./internal/bootstrap ./internal/workflowmanager`
- `go build ./cmd/gestaltd`

## Follow-up after merge
Bump `valon-tools/deploy/Dockerfile` `GESTALT_REF` to this commit, redeploy `valon.tools`, then rerun:

```bash
GESTALT_URL=https://valon.tools gestalt workflow schedules list --format json
```