### PR TITLE
Follow up provider dev session edge cases from #1378

### DIFF
--- a/gestaltd/internal/providerdev/session.go
+++ b/gestaltd/internal/providerdev/session.go
@@ -101,13 +101,14 @@ type Session struct {
 	owner   string
 	targets map[string]*attachedTarget
 
-	mu       sync.Mutex
-	calls    chan *rpcCall
-	pending  map[string]*rpcCall
-	done     chan struct{}
-	lastSeen time.Time
-	closeErr error
-	closed   bool
+	mu        sync.Mutex
+	calls     chan *rpcCall
+	pending   map[string]*rpcCall
+	done      chan struct{}
+	closeDone chan struct{}
+	lastSeen  time.Time
+	closeErr  error
+	closed    bool
 }
 
 type attachedTarget struct {
@@ -124,6 +125,7 @@ type rpcCall struct {
 	method      string
 	request     []byte
 	deliveredAt time.Time
+	canceled    bool
 	response    chan rpcResponse
 }
 
@@ -198,13 +200,14 @@ func (m *Manager) CreateSession(ctx context.Context, p *principal.Principal, req
 		return nil, status.Errorf(codes.Internal, "create provider dev session: %v", err)
 	}
 	session := &Session{
-		id:       sessionID,
-		owner:    owner,
-		targets:  make(map[string]*attachedTarget, len(targets)),
-		calls:    make(chan *rpcCall, 128),
-		pending:  map[string]*rpcCall{},
-		done:     make(chan struct{}),
-		lastSeen: time.Now(),
+		id:        sessionID,
+		owner:     owner,
+		targets:   make(map[string]*attachedTarget, len(targets)),
+		calls:     make(chan *rpcCall, 128),
+		pending:   map[string]*rpcCall{},
+		done:      make(chan struct{}),
+		closeDone: make(chan struct{}),
+		lastSeen:  time.Now(),
 	}
 	resp := &CreateSessionResponse{
 		ID:        sessionID,
@@ -253,30 +256,36 @@ func (m *Manager) PollSession(ctx context.Context, p *principal.Principal, sessi
 	}
 	session.touch()
 
-	select {
-	case call := <-session.calls:
-		session.mu.Lock()
-		if session.closed {
+	for {
+		select {
+		case call := <-session.calls:
+			session.mu.Lock()
+			if session.closed {
+				session.mu.Unlock()
+				return nil, false, status.Error(codes.NotFound, "provider dev session is closed")
+			}
+			if call.canceled {
+				session.mu.Unlock()
+				continue
+			}
+			call.deliveredAt = time.Now()
+			session.pending[call.id] = call
+			session.lastSeen = call.deliveredAt
 			session.mu.Unlock()
+			return &PollResponse{
+				CallID:   call.id,
+				Provider: call.provider,
+				Method:   call.method,
+				Request:  hex.EncodeToString(call.request),
+			}, true, nil
+		case <-session.done:
 			return nil, false, status.Error(codes.NotFound, "provider dev session is closed")
+		case <-ctx.Done():
+			if errors.Is(ctx.Err(), context.DeadlineExceeded) || errors.Is(ctx.Err(), context.Canceled) {
+				return nil, false, nil
+			}
+			return nil, false, ctx.Err()
 		}
-		call.deliveredAt = time.Now()
-		session.pending[call.id] = call
-		session.lastSeen = call.deliveredAt
-		session.mu.Unlock()
-		return &PollResponse{
-			CallID:   call.id,
-			Provider: call.provider,
-			Method:   call.method,
-			Request:  hex.EncodeToString(call.request),
-		}, true, nil
-	case <-session.done:
-		return nil, false, status.Error(codes.NotFound, "provider dev session is closed")
-	case <-ctx.Done():
-		if errors.Is(ctx.Err(), context.DeadlineExceeded) || errors.Is(ctx.Err(), context.Canceled) {
-			return nil, false, nil
-		}
-		return nil, false, ctx.Err()
 	}
 }
 
@@ -304,6 +313,9 @@ func (m *Manager) CompleteCall(p *principal.Principal, sessionID, callID string,
 	resp := rpcResponse{}
 	if req.Error != nil {
 		resp.err = status.Error(codes.Code(req.Error.Code), req.Error.Message)
+		if resp.err == nil {
+			resp.err = status.Error(codes.InvalidArgument, "provider dev error code must be non-OK")
+		}
 	} else if req.Response != "" {
 		payload, err := hex.DecodeString(req.Response)
 		if err != nil {
@@ -466,13 +478,21 @@ func (s *Session) Close() error {
 		return nil
 	}
 	s.mu.Lock()
+	if s.closeDone == nil {
+		s.closeDone = make(chan struct{})
+	}
 	if s.closed {
+		closeDone := s.closeDone
+		s.mu.Unlock()
+		<-closeDone
+		s.mu.Lock()
 		err := s.closeErr
 		s.mu.Unlock()
 		return err
 	}
 	s.closed = true
 	close(s.done)
+	closeDone := s.closeDone
 	pending := make([]*rpcCall, 0, len(s.pending))
 	for id, call := range s.pending {
 		delete(s.pending, id)
@@ -498,6 +518,7 @@ func (s *Session) Close() error {
 	s.mu.Lock()
 	s.closeErr = errors.Join(errs...)
 	err := s.closeErr
+	close(closeDone)
 	s.mu.Unlock()
 	return err
 }
@@ -589,6 +610,7 @@ func (s *Session) invoke(ctx context.Context, providerName, method string, req g
 		return status.Error(codes.Unavailable, "provider dev session is closed")
 	case <-ctx.Done():
 		s.mu.Lock()
+		call.canceled = true
 		delete(s.pending, callID)
 		if !s.closed {
 			s.lastSeen = time.Now()

--- a/gestaltd/internal/providerdev/session_test.go
+++ b/gestaltd/internal/providerdev/session_test.go
@@ -3,6 +3,7 @@ package providerdev
 import (
 	"context"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"net/http"
 	"net/http/httptest"
@@ -14,6 +15,7 @@ import (
 	proto "github.com/valon-technologies/gestalt/sdk/go/gen/v1"
 	"github.com/valon-technologies/gestalt/server/core"
 	"github.com/valon-technologies/gestalt/server/core/catalog"
+	coretesting "github.com/valon-technologies/gestalt/server/core/testing"
 	"github.com/valon-technologies/gestalt/server/internal/principal"
 	"github.com/valon-technologies/gestalt/server/internal/providerhost"
 	"google.golang.org/grpc"
@@ -174,6 +176,143 @@ func TestHTTPTransportDispatchesProviderRPCs(t *testing.T) {
 	}
 }
 
+func TestCompleteCallTreatsOKErrorCodeAsProtocolError(t *testing.T) {
+	t.Parallel()
+
+	p := &principal.Principal{SubjectID: "user:user-123", UserID: "user-123", Kind: principal.KindUser}
+	call := &rpcCall{id: "call-1", response: make(chan rpcResponse, 1)}
+	session := &Session{
+		id:        "session-1",
+		owner:     p.SubjectID,
+		pending:   map[string]*rpcCall{"call-1": call},
+		done:      make(chan struct{}),
+		closeDone: make(chan struct{}),
+		lastSeen:  time.Now(),
+	}
+	manager := &Manager{
+		sessions:   map[string]*Session{"session-1": session},
+		ownerIndex: map[string][]string{p.SubjectID: {"session-1"}},
+	}
+
+	if err := manager.CompleteCall(p, "session-1", "call-1", CompleteCallRequest{
+		Error: &RPCError{Code: int32(codes.OK), Message: "unexpected ok"},
+	}); err != nil {
+		t.Fatalf("CompleteCall: %v", err)
+	}
+
+	select {
+	case resp := <-call.response:
+		if got := status.Code(resp.err); got != codes.InvalidArgument {
+			t.Fatalf("response error code = %s, want %s", got, codes.InvalidArgument)
+		}
+		if got := resp.payload; got != nil {
+			t.Fatalf("response payload = %x, want nil", got)
+		}
+	case <-time.After(time.Second):
+		t.Fatal("call response was not delivered")
+	}
+}
+
+func TestPollSessionDropsCanceledQueuedCall(t *testing.T) {
+	t.Parallel()
+
+	p := &principal.Principal{SubjectID: "user:user-123", UserID: "user-123", Kind: principal.KindUser}
+	session := &Session{
+		id:        "session-1",
+		owner:     p.SubjectID,
+		calls:     make(chan *rpcCall, 1),
+		pending:   map[string]*rpcCall{},
+		done:      make(chan struct{}),
+		closeDone: make(chan struct{}),
+		lastSeen:  time.Now(),
+	}
+	manager := &Manager{
+		sessions:   map[string]*Session{"session-1": session},
+		ownerIndex: map[string][]string{p.SubjectID: {"session-1"}},
+	}
+
+	invokeCtx, cancel := context.WithCancel(context.Background())
+	invokeDone := make(chan error, 1)
+	go func() {
+		invokeDone <- session.invoke(invokeCtx, "roadmap", "Execute", &emptypb.Empty{}, &emptypb.Empty{})
+	}()
+
+	deadline := time.Now().Add(time.Second)
+	for len(session.calls) == 0 && time.Now().Before(deadline) {
+		time.Sleep(10 * time.Millisecond)
+	}
+	if len(session.calls) == 0 {
+		t.Fatal("invoke did not enqueue a call")
+	}
+
+	cancel()
+	if err := <-invokeDone; !errors.Is(err, context.Canceled) {
+		t.Fatalf("invoke error = %v, want %v", err, context.Canceled)
+	}
+
+	pollCtx, pollCancel := context.WithTimeout(context.Background(), 25*time.Millisecond)
+	defer pollCancel()
+	resp, ok, err := manager.PollSession(pollCtx, p, "session-1")
+	if err != nil {
+		t.Fatalf("PollSession: %v", err)
+	}
+	if ok || resp != nil {
+		t.Fatalf("PollSession = (%#v, %t), want no call", resp, ok)
+	}
+	if got := len(session.pending); got != 0 {
+		t.Fatalf("pending calls = %d, want 0", got)
+	}
+	if got := len(session.calls); got != 0 {
+		t.Fatalf("queued calls = %d, want 0", got)
+	}
+}
+
+func TestSessionCloseReturnsSameErrorToConcurrentCallers(t *testing.T) {
+	t.Parallel()
+
+	expected := errors.New("close failed")
+	prov := &blockingCloseProvider{
+		StubIntegration: coretesting.StubIntegration{N: "roadmap"},
+		started:         make(chan struct{}),
+		release:         make(chan struct{}),
+		err:             expected,
+	}
+	session := &Session{
+		targets: map[string]*attachedTarget{
+			"roadmap": {provider: prov},
+		},
+		pending:   map[string]*rpcCall{},
+		done:      make(chan struct{}),
+		closeDone: make(chan struct{}),
+	}
+
+	firstDone := make(chan error, 1)
+	go func() {
+		firstDone <- session.Close()
+	}()
+	<-prov.started
+
+	secondDone := make(chan error, 1)
+	go func() {
+		secondDone <- session.Close()
+	}()
+
+	select {
+	case err := <-secondDone:
+		t.Fatalf("second Close returned before cleanup finished: %v", err)
+	case <-time.After(50 * time.Millisecond):
+	}
+
+	close(prov.release)
+
+	if err := <-firstDone; !errors.Is(err, expected) {
+		t.Fatalf("first Close error = %v, want %v", err, expected)
+	}
+	if err := <-secondDone; !errors.Is(err, expected) {
+		t.Fatalf("second Close error = %v, want %v", err, expected)
+	}
+}
+
 func providerDevTestHandler(t *testing.T, manager *Manager, p *principal.Principal) http.Handler {
 	t.Helper()
 	mux := http.NewServeMux()
@@ -305,4 +444,17 @@ func (c *recordingIntegrationClient) GetSessionCatalog(context.Context, *proto.G
 
 func (c *recordingIntegrationClient) PostConnect(context.Context, *proto.PostConnectRequest, ...grpc.CallOption) (*proto.PostConnectResponse, error) {
 	return nil, status.Error(codes.Unimplemented, "post connect is not implemented")
+}
+
+type blockingCloseProvider struct {
+	coretesting.StubIntegration
+	started chan struct{}
+	release chan struct{}
+	err     error
+}
+
+func (p *blockingCloseProvider) Close() error {
+	close(p.started)
+	<-p.release
+	return p.err
 }


### PR DESCRIPTION
## Summary
- harden provider dev session cancellation, completion, and close edge cases surfaced during review of `#1378`
- add focused `internal/providerdev` coverage for the affected lifecycle paths

## Interfaces
No user-facing interface changes.

## Review Comments Applied
- `Race leaks pending call after invoker cancellation`
- `Status code zero treated as success`
- `Concurrent Session Close can lose error`

## Review Comments Intentionally Not Applied
- `GraphQL invocations bypass provider dev override`: raw GraphQL surfaces were explicitly out of scope for v1 remote provider-dev attach and still require a protocol expansion.
- `No per-principal cap on dev sessions`: valid hardening idea, but it needs a product/security policy limit decision and is broader than this follow-up.
- `Idle scan runs on every provider invocation`: performance tuning here needs a lifecycle/sweeper design rather than a narrow bugfix.

## Verification
- `go test ./internal/providerdev`
- `golangci-lint run ./internal/providerdev`
