### PR TITLE
Preserve HTTP subject resolution through provider composition

### DIFF
--- a/gestaltd/core/integration/restricted.go
+++ b/gestaltd/core/integration/restricted.go
@@ -233,6 +233,15 @@ func (r *Restricted) PostConnect(ctx context.Context, token *core.IntegrationTok
 	return nil, core.ErrPostConnectUnsupported
 }
 
+func (r *Restricted) SupportsHTTPSubject() bool {
+	return core.SupportsHTTPSubject(r.inner)
+}
+
+func (r *Restricted) ResolveHTTPSubject(ctx context.Context, req *core.HTTPSubjectResolveRequest) (*core.HTTPResolvedSubject, error) {
+	subject, _, err := core.ResolveHTTPSubject(ctx, r.inner, req)
+	return subject, err
+}
+
 func (r *Restricted) ConnectionForOperation(operation string) string {
 	if _, ok := r.allowed[operation]; !ok {
 		return ""

--- a/gestaltd/core/provider_capabilities.go
+++ b/gestaltd/core/provider_capabilities.go
@@ -105,3 +105,23 @@ func PostConnect(ctx context.Context, prov Provider, token *IntegrationToken) (m
 	}
 	return metadata, true, nil
 }
+
+func SupportsHTTPSubject(prov Provider) bool {
+	if aware, ok := prov.(interface{ SupportsHTTPSubject() bool }); ok {
+		return aware.SupportsHTTPSubject()
+	}
+	_, ok := prov.(HTTPSubjectResolver)
+	return ok
+}
+
+func ResolveHTTPSubject(ctx context.Context, prov Provider, req *HTTPSubjectResolveRequest) (*HTTPResolvedSubject, bool, error) {
+	if !SupportsHTTPSubject(prov) {
+		return nil, false, nil
+	}
+	resolver, ok := prov.(HTTPSubjectResolver)
+	if !ok {
+		return nil, false, nil
+	}
+	subject, err := resolver.ResolveHTTPSubject(ctx, req)
+	return subject, true, err
+}

--- a/gestaltd/internal/bootstrap/connected_provider.go
+++ b/gestaltd/internal/bootstrap/connected_provider.go
@@ -71,6 +71,11 @@ func (p *connectedProvider) PostConnect(ctx context.Context, token *core.Integra
 	}
 	return metadata, err
 }
+func (p *connectedProvider) SupportsHTTPSubject() bool { return core.SupportsHTTPSubject(p.inner) }
+func (p *connectedProvider) ResolveHTTPSubject(ctx context.Context, req *core.HTTPSubjectResolveRequest) (*core.HTTPResolvedSubject, error) {
+	subject, _, err := core.ResolveHTTPSubject(ctx, p.inner, req)
+	return subject, err
+}
 func (p *connectedProvider) Close() error {
 	if closer, ok := p.inner.(io.Closer); ok {
 		return closer.Close()
@@ -93,6 +98,15 @@ func (p *connectedSessionCatalogProvider) PostConnect(ctx context.Context, token
 		return nil, core.ErrPostConnectUnsupported
 	}
 	return metadata, err
+}
+
+func (p *connectedSessionCatalogProvider) SupportsHTTPSubject() bool {
+	return core.SupportsHTTPSubject(p.Provider)
+}
+
+func (p *connectedSessionCatalogProvider) ResolveHTTPSubject(ctx context.Context, req *core.HTTPSubjectResolveRequest) (*core.HTTPResolvedSubject, error) {
+	subject, _, err := core.ResolveHTTPSubject(ctx, p.Provider, req)
+	return subject, err
 }
 
 func (p *connectedSessionCatalogProvider) CatalogForRequest(ctx context.Context, token string) (*catalog.Catalog, error) {
@@ -121,6 +135,15 @@ func (p *connectedGraphQLProvider) PostConnect(ctx context.Context, token *core.
 		return nil, core.ErrPostConnectUnsupported
 	}
 	return metadata, err
+}
+
+func (p *connectedGraphQLProvider) SupportsHTTPSubject() bool {
+	return core.SupportsHTTPSubject(p.Provider)
+}
+
+func (p *connectedGraphQLProvider) ResolveHTTPSubject(ctx context.Context, req *core.HTTPSubjectResolveRequest) (*core.HTTPResolvedSubject, error) {
+	subject, _, err := core.ResolveHTTPSubject(ctx, p.Provider, req)
+	return subject, err
 }
 
 func (p *connectedGraphQLProvider) InvokeGraphQL(ctx context.Context, request core.GraphQLRequest, token string) (*core.OperationResult, error) {
@@ -157,6 +180,15 @@ func (p *connectedOAuthProvider) PostConnect(ctx context.Context, token *core.In
 		return nil, core.ErrPostConnectUnsupported
 	}
 	return metadata, err
+}
+
+func (p *connectedOAuthProvider) SupportsHTTPSubject() bool {
+	return core.SupportsHTTPSubject(p.Provider)
+}
+
+func (p *connectedOAuthProvider) ResolveHTTPSubject(ctx context.Context, req *core.HTTPSubjectResolveRequest) (*core.HTTPResolvedSubject, error) {
+	subject, _, err := core.ResolveHTTPSubject(ctx, p.Provider, req)
+	return subject, err
 }
 
 func (p *connectedOAuthProvider) AuthorizationURL(state string, scopes []string) string {

--- a/gestaltd/internal/bootstrap/graphql_session_provider.go
+++ b/gestaltd/internal/bootstrap/graphql_session_provider.go
@@ -72,6 +72,15 @@ func (p *graphQLSessionCatalogProvider) PostConnect(ctx context.Context, token *
 	return metadata, err
 }
 
+func (p *graphQLSessionCatalogProvider) SupportsHTTPSubject() bool {
+	return core.SupportsHTTPSubject(p.Provider)
+}
+
+func (p *graphQLSessionCatalogProvider) ResolveHTTPSubject(ctx context.Context, req *core.HTTPSubjectResolveRequest) (*core.HTTPResolvedSubject, error) {
+	subject, _, err := core.ResolveHTTPSubject(ctx, p.Provider, req)
+	return subject, err
+}
+
 func (p *graphQLSessionCatalogProvider) Execute(ctx context.Context, operation string, params map[string]any, token string) (*core.OperationResult, error) {
 	if _, ok := graphQLCatalogOperation(p.Catalog(), operation); ok {
 		return p.Provider.Execute(ctx, operation, params, token)

--- a/gestaltd/internal/bootstrap/startup_proxy.go
+++ b/gestaltd/internal/bootstrap/startup_proxy.go
@@ -161,6 +161,13 @@ func (p *startupProviderProxy) SupportsSessionCatalog() bool {
 	}
 	return core.SupportsSessionCatalog(provider)
 }
+func (p *startupProviderProxy) SupportsHTTPSubject() bool {
+	provider := p.resolved()
+	if provider == nil {
+		return true
+	}
+	return core.SupportsHTTPSubject(provider)
+}
 func (p *startupProviderProxy) Catalog() *catalog.Catalog {
 	if p.spec.Catalog == nil {
 		return nil
@@ -180,6 +187,21 @@ func (p *startupProviderProxy) Execute(ctx context.Context, operation string, pa
 		return nil, err
 	}
 	return provider.Execute(ctx, operation, params, token)
+}
+
+func (p *startupProviderProxy) ResolveHTTPSubject(ctx context.Context, req *core.HTTPSubjectResolveRequest) (*core.HTTPResolvedSubject, error) {
+	done, err := p.beginWorkflowWait(ctx)
+	if err != nil {
+		return nil, err
+	}
+	defer done()
+
+	provider, err := p.await(ctx)
+	if err != nil {
+		return nil, err
+	}
+	subject, _, err := core.ResolveHTTPSubject(ctx, provider, req)
+	return subject, err
 }
 
 func (p *startupProviderProxy) CallTool(ctx context.Context, name string, args map[string]any) (*mcpgo.CallToolResult, error) {

--- a/gestaltd/internal/composite/merged.go
+++ b/gestaltd/internal/composite/merged.go
@@ -188,6 +188,29 @@ func (m *MergedProvider) PostConnect(ctx context.Context, token *core.Integratio
 	return nil, core.ErrPostConnectUnsupported
 }
 
+func (m *MergedProvider) SupportsHTTPSubject() bool {
+	for _, provider := range m.owned {
+		if core.SupportsHTTPSubject(provider) {
+			return true
+		}
+	}
+	return false
+}
+
+func (m *MergedProvider) ResolveHTTPSubject(ctx context.Context, req *core.HTTPSubjectResolveRequest) (*core.HTTPResolvedSubject, error) {
+	for _, provider := range m.owned {
+		if !core.SupportsHTTPSubject(provider) {
+			continue
+		}
+		subject, supported, err := core.ResolveHTTPSubject(ctx, provider, req)
+		if !supported {
+			continue
+		}
+		return subject, err
+	}
+	return nil, nil
+}
+
 func (m *MergedProvider) CatalogForRequest(ctx context.Context, token string) (*catalog.Catalog, error) {
 	if !m.SupportsSessionCatalog() {
 		return nil, core.WrapSessionCatalogUnsupported(fmt.Errorf("provider %q does not support session catalogs", m.Name()))

--- a/gestaltd/internal/composite/provider.go
+++ b/gestaltd/internal/composite/provider.go
@@ -139,6 +139,15 @@ func (p *Provider) PostConnect(ctx context.Context, token *core.IntegrationToken
 	return nil, core.ErrPostConnectUnsupported
 }
 
+func (p *Provider) SupportsHTTPSubject() bool {
+	return core.SupportsHTTPSubject(p.api)
+}
+
+func (p *Provider) ResolveHTTPSubject(ctx context.Context, req *core.HTTPSubjectResolveRequest) (*core.HTTPResolvedSubject, error) {
+	subject, _, err := core.ResolveHTTPSubject(ctx, p.api, req)
+	return subject, err
+}
+
 func (p *Provider) Close() error {
 	var firstErr error
 	if err := p.mcp.Close(); err != nil {

--- a/gestaltd/internal/providerdev/session.go
+++ b/gestaltd/internal/providerdev/session.go
@@ -666,6 +666,18 @@ func (p *attachProvider) PostConnect(ctx context.Context, token *core.Integratio
 	return pcp.PostConnect(ctx, token)
 }
 
+func (p *attachProvider) SupportsHTTPSubject() bool {
+	return p != nil && p.Provider != nil && core.SupportsHTTPSubject(p.Provider)
+}
+
+func (p *attachProvider) ResolveHTTPSubject(ctx context.Context, req *core.HTTPSubjectResolveRequest) (*core.HTTPResolvedSubject, error) {
+	if p == nil || p.Provider == nil {
+		return nil, nil
+	}
+	subject, _, err := core.ResolveHTTPSubject(ctx, p.Provider, req)
+	return subject, err
+}
+
 func (p *attachProvider) Close() error {
 	if p == nil || p.Provider == nil {
 		return nil

--- a/gestaltd/internal/server/http_binding_subject.go
+++ b/gestaltd/internal/server/http_binding_subject.go
@@ -19,17 +19,12 @@ func (s *Server) resolveHTTPBindingPrincipal(ctx context.Context, binding Mounte
 	if err != nil {
 		return nil, err
 	}
-	resolver, ok := prov.(core.HTTPSubjectResolver)
-	if !ok {
-		return bindingPrincipal, nil
-	}
-
 	resolveCtx := principal.WithPrincipal(ctx, bindingPrincipal)
 	resolveCtx = invocation.WithAccessContext(resolveCtx, s.providerAccessContextWithContext(resolveCtx, bindingPrincipal, binding.PluginName))
 	resolveCtx = invocation.WithWorkflowContext(resolveCtx, httpBindingContextValue(binding, verified, parsed))
 	resolveCtx = invocation.WithInvocationSurface(resolveCtx, invocation.InvocationSurfaceHTTP)
 
-	resolved, err := resolver.ResolveHTTPSubject(resolveCtx, &core.HTTPSubjectResolveRequest{
+	resolved, supported, err := core.ResolveHTTPSubject(resolveCtx, prov, &core.HTTPSubjectResolveRequest{
 		Binding:         binding.Name,
 		Method:          requestMethod(r, binding),
 		Path:            requestPath(r, binding),
@@ -42,6 +37,9 @@ func (s *Server) resolveHTTPBindingPrincipal(ctx context.Context, binding Mounte
 		VerifiedSubject: verifiedSubject(verified),
 		VerifiedClaims:  verifiedClaims(verified),
 	})
+	if !supported {
+		return bindingPrincipal, nil
+	}
 	if err != nil {
 		var resolveErr *core.HTTPSubjectResolveError
 		if errors.As(err, &resolveErr) {

--- a/gestaltd/internal/server/server_test.go
+++ b/gestaltd/internal/server/server_test.go
@@ -13973,6 +13973,112 @@ func TestHostedHTTPBinding_RejectsReservedSystemResolvedSubject(t *testing.T) {
 	}
 }
 
+func TestHostedHTTPBinding_ComposedProviderPreservesSubjectResolver(t *testing.T) {
+	t.Parallel()
+
+	subjects := make(chan string, 1)
+	resolved := atomic.Bool{}
+	baseProvider := &stubIntegrationWithResolvedSubject{
+		stubIntegrationWithOps: stubIntegrationWithOps{
+			StubIntegration: coretesting.StubIntegration{
+				N:        "events",
+				ConnMode: core.ConnectionModeNone,
+				ExecuteFn: func(ctx context.Context, op string, params map[string]any, _ string) (*core.OperationResult, error) {
+					if op != "handle_event" {
+						t.Fatalf("operation = %q, want %q", op, "handle_event")
+					}
+					if got, want := params["event"], "opened"; got != want {
+						t.Fatalf("params[event] = %#v, want %q", got, want)
+					}
+					subjects <- principal.FromContext(ctx).SubjectID
+					return &core.OperationResult{Status: http.StatusOK, Body: `{"accepted":true}`}, nil
+				},
+			},
+			ops: []core.Operation{{Name: "handle_event", Method: http.MethodPost}},
+		},
+		resolveFn: func(_ context.Context, req *core.HTTPSubjectResolveRequest) (*core.HTTPResolvedSubject, error) {
+			resolved.Store(true)
+			if got, want := req.Params["event"], "opened"; got != want {
+				t.Fatalf("resolver params[event] = %#v, want %q", got, want)
+			}
+			return &core.HTTPResolvedSubject{
+				ID:          "user:slack-linked",
+				Kind:        string(principal.KindUser),
+				DisplayName: "Slack User",
+				AuthSource:  "authorization",
+			}, nil
+		},
+	}
+	restricted := coreintegration.NewRestricted(baseProvider, map[string]string{"handle_event": ""})
+	otherProvider := &stubIntegrationWithOps{
+		StubIntegration: coretesting.StubIntegration{
+			N:        "events-mcp",
+			ConnMode: core.ConnectionModeNone,
+		},
+		ops: []core.Operation{{Name: "other_event", Method: http.MethodPost}},
+	}
+	provider, err := composite.NewMergedWithConnections(
+		"events",
+		"Events",
+		"Event receiver",
+		"",
+		composite.BoundProvider{Provider: restricted},
+		composite.BoundProvider{Provider: otherProvider},
+	)
+	if err != nil {
+		t.Fatalf("NewMergedWithConnections: %v", err)
+	}
+
+	ts := newTestServer(t, func(cfg *server.Config) {
+		cfg.Providers = testutil.NewProviderRegistry(t, provider)
+		cfg.PluginDefs = map[string]*config.ProviderEntry{
+			"events": {
+				SecuritySchemes: map[string]*config.HTTPSecurityScheme{
+					"public": {Type: providermanifestv1.HTTPSecuritySchemeTypeNone},
+				},
+				HTTP: map[string]*config.HTTPBinding{
+					"event": {
+						Path:     "/event",
+						Method:   http.MethodPost,
+						Security: "public",
+						Target:   "handle_event",
+					},
+				},
+			},
+		}
+		cfg.Authorizer = mustAuthorizer(t, config.AuthorizationConfig{}, cfg.Providers, cfg.PluginDefs, nil)
+	})
+	testutil.CloseOnCleanup(t, ts)
+
+	req, err := http.NewRequest(http.MethodPost, ts.URL+"/api/v1/events/event", strings.NewReader(`{"event":"opened"}`))
+	if err != nil {
+		t.Fatalf("NewRequest: %v", err)
+	}
+	req.Header.Set("Content-Type", "application/json")
+
+	resp, err := http.DefaultClient.Do(req)
+	if err != nil {
+		t.Fatalf("http binding request: %v", err)
+	}
+	defer func() { _ = resp.Body.Close() }()
+	if resp.StatusCode != http.StatusOK {
+		body, _ := io.ReadAll(resp.Body)
+		t.Fatalf("status = %d, want %d: %s", resp.StatusCode, http.StatusOK, strings.TrimSpace(string(body)))
+	}
+	if !resolved.Load() {
+		t.Fatal("expected composed provider to call HTTP subject resolver")
+	}
+
+	select {
+	case subjectID := <-subjects:
+		if subjectID != "user:slack-linked" {
+			t.Fatalf("operation subject = %q, want %q", subjectID, "user:slack-linked")
+		}
+	case <-time.After(2 * time.Second):
+		t.Fatal("timed out waiting for http binding invocation")
+	}
+}
+
 func TestHostedHTTPBinding_CredentialModeNoneBypassesProviderTokenLookup(t *testing.T) {
 	t.Parallel()
 


### PR DESCRIPTION
## Summary

Preserve hosted HTTP subject resolution when a provider is wrapped or composed.

The Slack webhook agent path is currently built as a composed provider: the executable Slack plugin is merged with its MCP surface, and in some configurations may also be restricted, connection-bound, or startup-proxied. `resolveHTTPBindingPrincipal` previously checked the concrete registry provider with a direct `core.HTTPSubjectResolver` type assertion. If a wrapper did not expose that optional interface, the host skipped subject resolution and executed the webhook as `system:http_binding:<plugin>:<binding>`.

## New interfaces/helpers

```go
func core.SupportsHTTPSubject(prov core.Provider) bool

func core.ResolveHTTPSubject(
    ctx context.Context,
    prov core.Provider,
    req *core.HTTPSubjectResolveRequest,
) (*core.HTTPResolvedSubject, bool, error)
```

Provider wrappers now forward HTTP subject resolution in the same style as session catalogs and post-connect:

```go
func (m *MergedProvider) SupportsHTTPSubject() bool
func (m *MergedProvider) ResolveHTTPSubject(ctx context.Context, req *core.HTTPSubjectResolveRequest) (*core.HTTPResolvedSubject, error)
```

Forwarding was added for merged providers, restricted providers, connection-bound providers, GraphQL session wrappers, composite API/MCP providers, startup proxies, and provider-dev attach wrappers.

## Example

```go
restricted := coreintegration.NewRestricted(slackProvider, map[string]string{
    "events.handle": "",
})

merged, _ := composite.NewMergedWithConnections(
    "slack",
    "Slack",
    "Slack provider",
    "",
    composite.BoundProvider{Provider: restricted},
    composite.BoundProvider{Provider: mcpProvider},
)

subject, supported, err := core.ResolveHTTPSubject(ctx, merged, &core.HTTPSubjectResolveRequest{
    Binding: "event",
    Method:  http.MethodPost,
    Path:    "/api/v1/slack/event",
    Params:  slackEventPayload,
})
```

With this change, `supported == true` and the request executes as the plugin-resolved user subject instead of silently falling back to `system:http_binding:slack:event`.

## Verification

```sh
go test ./internal/server -run 'TestHostedHTTPBinding_(ComposedProviderPreservesSubjectResolver|RejectsReservedSystemResolvedSubject|CredentialModeNoneBypassesProviderTokenLookup)'
go test ./core ./core/integration ./internal/composite ./internal/bootstrap ./internal/providerdev
go test ./internal/server
```
