### PR TITLE
Tunnel provider dev UI assets

### DIFF
--- a/docs/content/reference/cli.mdx
+++ b/docs/content/reference/cli.mdx
@@ -78,7 +78,8 @@ all non-local plugins, credentials, policies, and host services continue to
 resolve through the remote instance. Remote servers expose attach targets only
 for source-backed plugin config entries or release-backed plugin entries that
 explicitly set `providerDev: true`. Remote mode tunnels plugin RPC, catalog,
-post-connect, and host-service calls; raw GraphQL surfaces are not tunneled in
-v1.
+post-connect, host-service calls, and plugin-owned UI assets for mounted UIs
+that already exist on the remote server. Raw GraphQL surfaces are not tunneled
+in v1.
 
 See [Configuration](/configuration) for the relationship between `init`, `serve --locked`, and `validate`.

--- a/gestaltd/cmd/gestaltd/provider_local.go
+++ b/gestaltd/cmd/gestaltd/provider_local.go
@@ -10,6 +10,7 @@ import (
 	"io"
 	"log/slog"
 	"net"
+	"net/http"
 	"net/url"
 	"os"
 	"os/signal"
@@ -28,6 +29,7 @@ import (
 	"github.com/valon-technologies/gestalt/server/internal/providerdev"
 	"github.com/valon-technologies/gestalt/server/internal/providerhost"
 	"github.com/valon-technologies/gestalt/server/internal/providerpkg"
+	"github.com/valon-technologies/gestalt/server/internal/ui"
 	providermanifestv1 "github.com/valon-technologies/gestalt/server/sdk/providermanifest/v1"
 	"gopkg.in/yaml.v3"
 )
@@ -197,6 +199,7 @@ func runProviderRemoteDev(opts providerLocalCommandOptions) error {
 		Token:   token,
 	}
 	requestedProviders := make([]providerdev.AttachProvider, 0, len(targets))
+	localUIHandlers := make(map[string]http.Handler)
 	for _, target := range targets {
 		spec, _, err := bootstrap.BuildStartupProviderSpec(target.Name, target.Entry)
 		if err != nil {
@@ -206,11 +209,20 @@ func runProviderRemoteDev(opts providerLocalCommandOptions) error {
 		if err != nil {
 			return fmt.Errorf("build provider dev remote config for plugins.%s: %w", target.Name, err)
 		}
-		requestedProviders = append(requestedProviders, providerdev.AttachProvider{
+		requested := providerdev.AttachProvider{
 			Name:   target.Name,
 			Spec:   spec,
 			Config: pluginConfig,
-		})
+		}
+		uiHandler, hasUI, err := providerRemoteUIHandler(cfg, target)
+		if err != nil {
+			return fmt.Errorf("prepare provider dev remote ui for plugins.%s: %w", target.Name, err)
+		}
+		if hasUI {
+			requested.UI = &providerdev.AttachUI{}
+			localUIHandlers[target.Name] = uiHandler
+		}
+		requestedProviders = append(requestedProviders, requested)
 	}
 	session, err := client.CreateSession(ctx, providerdev.CreateSessionRequest{Providers: requestedProviders})
 	if err != nil {
@@ -249,9 +261,10 @@ func runProviderRemoteDev(opts providerLocalCommandOptions) error {
 		"remote", strings.TrimRight(opts.Remote, "/"),
 		"session", session.ID,
 		"providers", providerRemoteTargetNames(targets),
+		"ui_providers", providerRemoteUIProviderNames(localUIHandlers),
 		"config_files", configPaths,
 	)
-	return client.RunDispatcher(ctx, session.ID, providerClients)
+	return client.RunDispatcher(ctx, session.ID, providerClients, providerdev.WithUIHandlers(localUIHandlers))
 }
 
 func providerRemoteTargetNames(targets []providerRemoteTarget) []string {
@@ -259,6 +272,18 @@ func providerRemoteTargetNames(targets []providerRemoteTarget) []string {
 	for _, target := range targets {
 		names = append(names, target.Name)
 	}
+	return names
+}
+
+func providerRemoteUIProviderNames(handlers map[string]http.Handler) []string {
+	if len(handlers) == 0 {
+		return nil
+	}
+	names := make([]string, 0, len(handlers))
+	for name := range handlers {
+		names = append(names, name)
+	}
+	slices.Sort(names)
 	return names
 }
 
@@ -646,6 +671,112 @@ func startProviderRemoteProcess(ctx context.Context, target providerRemoteTarget
 		return nil, fmt.Errorf("start local provider plugins.%s: %w", target.Name, err)
 	}
 	return process, nil
+}
+
+func providerRemoteUIHandler(cfg *config.Config, target providerRemoteTarget) (http.Handler, bool, error) {
+	uiManifestPath, ok, err := providerRemoteUIManifestPath(cfg, target)
+	if err != nil || !ok {
+		return nil, ok, err
+	}
+	handler, err := sourceUIHandler(uiManifestPath)
+	if err != nil {
+		return nil, true, err
+	}
+	return handler, true, nil
+}
+
+func providerRemoteUIManifestPath(cfg *config.Config, target providerRemoteTarget) (string, bool, error) {
+	entry := target.Entry
+	if entry == nil {
+		return "", false, nil
+	}
+	if uiName := strings.TrimSpace(entry.UI); uiName != "" {
+		if cfg == nil || cfg.Providers.UI == nil || cfg.Providers.UI[uiName] == nil {
+			return "", false, fmt.Errorf("plugins.%s.ui references unknown ui %q", target.Name, uiName)
+		}
+		uiEntry := cfg.Providers.UI[uiName]
+		manifestPath, ok, err := sourceUIManifestPathFromEntry(uiEntry)
+		if err != nil || ok {
+			return manifestPath, ok, err
+		}
+		return "", false, nil
+	}
+	if entry.ResolvedManifest != nil && entry.ResolvedManifest.Spec != nil && entry.ResolvedManifest.Spec.UI != nil {
+		ownedUIPath := strings.TrimSpace(entry.ResolvedManifest.Spec.UI.Path)
+		if ownedUIPath == "" {
+			return "", false, nil
+		}
+		if strings.TrimSpace(entry.ResolvedManifestPath) == "" {
+			return "", false, fmt.Errorf("resolved manifest path is required for owned ui")
+		}
+		manifestPath, err := canonicalPath(filepath.Join(filepath.Dir(entry.ResolvedManifestPath), filepath.FromSlash(ownedUIPath)))
+		if err != nil {
+			return "", false, err
+		}
+		return manifestPath, true, nil
+	}
+	siblingPath, err := findSiblingUIManifestPath(entry.ResolvedManifestPath, entry.ResolvedManifest)
+	if err != nil {
+		return "", false, err
+	}
+	return siblingPath, siblingPath != "", nil
+}
+
+func sourceUIManifestPathFromEntry(entry *config.UIEntry) (string, bool, error) {
+	if entry == nil {
+		return "", false, nil
+	}
+	sourcePath := strings.TrimSpace(entry.SourcePath())
+	if sourcePath == "" {
+		return "", false, nil
+	}
+	info, err := os.Stat(sourcePath)
+	if err != nil {
+		return "", false, fmt.Errorf("stat ui source %q: %w", sourcePath, err)
+	}
+	manifestPath := sourcePath
+	if info.IsDir() {
+		manifestPath, err = providerpkg.FindManifestFile(sourcePath)
+		if err != nil {
+			return "", false, err
+		}
+	} else if !providerpkg.IsManifestFile(sourcePath) {
+		return "", false, fmt.Errorf("ui source %q must point to a provider manifest file or directory", sourcePath)
+	}
+	manifestPath, err = canonicalPath(manifestPath)
+	if err != nil {
+		return "", false, err
+	}
+	return manifestPath, true, nil
+}
+
+func sourceUIHandler(manifestPath string) (http.Handler, error) {
+	_, manifest, err := providerpkg.ReadSourceManifestFile(manifestPath)
+	if err != nil {
+		return nil, err
+	}
+	kind, err := providerpkg.ManifestKind(manifest)
+	if err != nil {
+		return nil, err
+	}
+	if kind != providermanifestv1.KindUI {
+		return nil, fmt.Errorf("ui manifest %q must have kind %q (got %q)", manifestPath, providermanifestv1.KindUI, kind)
+	}
+	if err := providerpkg.RunSourceReleaseBuild(manifestPath, manifest); err != nil {
+		return nil, err
+	}
+	_, manifest, err = providerpkg.ReadSourceManifestFile(manifestPath)
+	if err != nil {
+		return nil, fmt.Errorf("read ui manifest after release build: %w", err)
+	}
+	if manifest.Spec == nil || strings.TrimSpace(manifest.Spec.AssetRoot) == "" {
+		return nil, fmt.Errorf("ui manifest %q missing spec.assetRoot", manifestPath)
+	}
+	assetRoot := filepath.Join(filepath.Dir(manifestPath), filepath.FromSlash(manifest.Spec.AssetRoot))
+	if _, err := os.Stat(assetRoot); err != nil {
+		return nil, fmt.Errorf("ui asset root not found at %s: %w", assetRoot, err)
+	}
+	return ui.DirHandler(assetRoot)
 }
 
 func resolveProviderTargetManifest(pathFlag string) (string, *providermanifestv1.Manifest, error) {
@@ -1267,7 +1398,8 @@ func printProviderDevUsage(w io.Writer) {
 	writeUsageLine(w, "The built-in admin UI remains available at /admin; configured, owned, or sibling public UIs")
 	writeUsageLine(w, "are mounted when present.")
 	writeUsageLine(w, "With --remote, source-backed local plugins attach to an authenticated remote gestaltd session")
-	writeUsageLine(w, "while the remote config keeps its normal auth, authorization, connections, and host services.")
+	writeUsageLine(w, "while the remote config keeps its normal auth, authorization, connections, host services,")
+	writeUsageLine(w, "and mounted plugin UI routes.")
 	writeUsageLine(w, "")
 	writeUsageLine(w, "Flags:")
 	writeUsageLine(w, "  --path     Provider manifest path or directory (default: current working directory)")

--- a/gestaltd/internal/providerdev/session.go
+++ b/gestaltd/internal/providerdev/session.go
@@ -4,12 +4,14 @@ import (
 	"bytes"
 	"context"
 	"crypto/rand"
+	"encoding/base64"
 	"encoding/hex"
 	"encoding/json"
 	"errors"
 	"fmt"
 	"io"
 	"net/http"
+	"net/http/httptest"
 	"net/url"
 	"slices"
 	"strings"
@@ -48,6 +50,7 @@ type Target struct {
 	Name       string
 	Spec       providerhost.StaticProviderSpec
 	Config     map[string]any
+	UI         *AttachUI
 	RuntimeEnv RuntimeEnvBuilder
 }
 
@@ -66,6 +69,7 @@ type AttachProvider struct {
 	Name   string                          `json:"name"`
 	Spec   providerhost.StaticProviderSpec `json:"spec"`
 	Config map[string]any                  `json:"config,omitempty"`
+	UI     *AttachUI                       `json:"ui,omitempty"`
 }
 
 type CreateSessionResponse struct {
@@ -79,6 +83,21 @@ type CreateSessionProvider struct {
 	AllowedHosts []string          `json:"allowedHosts,omitempty"`
 }
 
+type AttachUI struct{}
+
+type UIAssetRequest struct {
+	Method   string      `json:"method,omitempty"`
+	Path     string      `json:"path"`
+	RawQuery string      `json:"rawQuery,omitempty"`
+	Header   http.Header `json:"header,omitempty"`
+}
+
+type UIAssetResponse struct {
+	Status int         `json:"status"`
+	Header http.Header `json:"header,omitempty"`
+	Body   string      `json:"body,omitempty"`
+}
+
 type PollResponse struct {
 	CallID   string `json:"callId"`
 	Provider string `json:"provider"`
@@ -87,8 +106,9 @@ type PollResponse struct {
 }
 
 type CompleteCallRequest struct {
-	Response string    `json:"response,omitempty"`
-	Error    *RPCError `json:"error,omitempty"`
+	Response       string    `json:"response,omitempty"`
+	ResponseBase64 string    `json:"responseBase64,omitempty"`
+	Error          *RPCError `json:"error,omitempty"`
 }
 
 type RPCError struct {
@@ -191,6 +211,7 @@ func (m *Manager) CreateSession(ctx context.Context, p *principal.Principal, req
 		target := remoteTarget
 		target.Spec = buildAttachSpec(remoteTarget.Spec, requested.Spec)
 		target.Config = requested.Config
+		target.UI = cloneAttachUI(requested.UI)
 		targets = append(targets, target)
 	}
 	m.mu.RUnlock()
@@ -311,12 +332,20 @@ func (m *Manager) CompleteCall(p *principal.Principal, sessionID, callID string,
 	}
 
 	resp := rpcResponse{}
-	if req.Error != nil {
+	switch {
+	case req.Error != nil:
 		resp.err = status.Error(codes.Code(req.Error.Code), req.Error.Message)
 		if resp.err == nil {
 			resp.err = status.Error(codes.InvalidArgument, "provider dev error code must be non-OK")
 		}
-	} else if req.Response != "" {
+	case req.ResponseBase64 != "":
+		payload, err := base64.StdEncoding.DecodeString(req.ResponseBase64)
+		if err != nil {
+			resp.err = status.Errorf(codes.InvalidArgument, "decode provider dev response: %v", err)
+		} else {
+			resp.payload = payload
+		}
+	case req.Response != "":
 		payload, err := hex.DecodeString(req.Response)
 		if err != nil {
 			resp.err = status.Errorf(codes.InvalidArgument, "decode provider dev response: %v", err)
@@ -384,6 +413,46 @@ func (m *Manager) ResolveProviderOverride(ctx context.Context, p *principal.Prin
 			return nil, false, err
 		}
 		return prov, true, nil
+	}
+	return nil, false, nil
+}
+
+func (m *Manager) ServeUIAsset(ctx context.Context, p *principal.Principal, providerName string, req UIAssetRequest) (*UIAssetResponse, bool, error) {
+	if m == nil {
+		return nil, false, nil
+	}
+	m.closeIdleSessions(time.Now())
+	owner := principalSubjectID(p)
+	if owner == "" {
+		return nil, false, nil
+	}
+	providerName = strings.TrimSpace(providerName)
+	if providerName == "" {
+		return nil, false, nil
+	}
+
+	m.mu.RLock()
+	sessionIDs := append([]string(nil), m.ownerIndex[owner]...)
+	sessions := make(map[string]*Session, len(sessionIDs))
+	for _, id := range sessionIDs {
+		sessions[id] = m.sessions[id]
+	}
+	m.mu.RUnlock()
+
+	for i := len(sessionIDs) - 1; i >= 0; i-- {
+		session := sessions[sessionIDs[i]]
+		if session == nil || session.isClosed() {
+			continue
+		}
+		target := session.targets[providerName]
+		if target == nil || target.target.UI == nil {
+			continue
+		}
+		resp, err := session.serveUIAsset(ctx, providerName, req)
+		if err != nil {
+			return nil, true, err
+		}
+		return resp, true, nil
 	}
 	return nil, false, nil
 }
@@ -571,9 +640,42 @@ func (s *Session) invoke(ctx context.Context, providerName, method string, req g
 	if err != nil {
 		return status.Errorf(codes.Internal, "marshal provider dev request: %v", err)
 	}
+	result, err := s.invokeRaw(ctx, providerName, method, payload)
+	if err != nil {
+		return err
+	}
+	if resp == nil {
+		return nil
+	}
+	if err := gproto.Unmarshal(result, resp); err != nil {
+		return status.Errorf(codes.Internal, "unmarshal provider dev response: %v", err)
+	}
+	return nil
+}
+
+func (s *Session) serveUIAsset(ctx context.Context, providerName string, req UIAssetRequest) (*UIAssetResponse, error) {
+	payload, err := json.Marshal(req)
+	if err != nil {
+		return nil, status.Errorf(codes.Internal, "marshal provider dev ui request: %v", err)
+	}
+	result, err := s.invokeRaw(ctx, providerName, "ServeUIAsset", payload)
+	if err != nil {
+		return nil, err
+	}
+	var resp UIAssetResponse
+	if err := json.Unmarshal(result, &resp); err != nil {
+		return nil, status.Errorf(codes.Internal, "unmarshal provider dev ui response: %v", err)
+	}
+	return &resp, nil
+}
+
+func (s *Session) invokeRaw(ctx context.Context, providerName, method string, payload []byte) ([]byte, error) {
+	if s == nil {
+		return nil, status.Error(codes.Unavailable, "provider dev session is unavailable")
+	}
 	callID, err := randomID()
 	if err != nil {
-		return status.Errorf(codes.Internal, "create provider dev call: %v", err)
+		return nil, status.Errorf(codes.Internal, "create provider dev call: %v", err)
 	}
 	call := &rpcCall{
 		id:       callID,
@@ -588,26 +690,20 @@ func (s *Session) invoke(ctx context.Context, providerName, method string, req g
 	case s.calls <- call:
 		s.touch()
 	case <-s.done:
-		return status.Error(codes.Unavailable, "provider dev session is closed")
+		return nil, status.Error(codes.Unavailable, "provider dev session is closed")
 	case <-ctx.Done():
-		return ctx.Err()
+		return nil, ctx.Err()
 	}
 
 	select {
 	case result := <-call.response:
 		s.touch()
 		if result.err != nil {
-			return result.err
+			return nil, result.err
 		}
-		if resp == nil {
-			return nil
-		}
-		if err := gproto.Unmarshal(result.payload, resp); err != nil {
-			return status.Errorf(codes.Internal, "unmarshal provider dev response: %v", err)
-		}
-		return nil
+		return result.payload, nil
 	case <-s.done:
-		return status.Error(codes.Unavailable, "provider dev session is closed")
+		return nil, status.Error(codes.Unavailable, "provider dev session is closed")
 	case <-ctx.Done():
 		s.mu.Lock()
 		call.canceled = true
@@ -616,7 +712,7 @@ func (s *Session) invoke(ctx context.Context, providerName, method string, req g
 			s.lastSeen = time.Now()
 		}
 		s.mu.Unlock()
-		return ctx.Err()
+		return nil, ctx.Err()
 	}
 }
 
@@ -777,6 +873,18 @@ type Client struct {
 	HTTPClient *http.Client
 }
 
+type DispatcherOption func(*dispatcherConfig)
+
+type dispatcherConfig struct {
+	UIHandlers map[string]http.Handler
+}
+
+func WithUIHandlers(handlers map[string]http.Handler) DispatcherOption {
+	return func(cfg *dispatcherConfig) {
+		cfg.UIHandlers = handlers
+	}
+}
+
 func (c Client) CreateSession(ctx context.Context, req CreateSessionRequest) (*CreateSessionResponse, error) {
 	var out CreateSessionResponse
 	if err := c.doJSON(ctx, http.MethodPost, PathSessions, req, &out); err != nil {
@@ -808,7 +916,13 @@ func (c Client) CloseSession(ctx context.Context, sessionID string) error {
 	return c.doJSON(ctx, http.MethodDelete, path, nil, nil)
 }
 
-func (c Client) RunDispatcher(ctx context.Context, sessionID string, providers map[string]proto.IntegrationProviderClient) error {
+func (c Client) RunDispatcher(ctx context.Context, sessionID string, providers map[string]proto.IntegrationProviderClient, options ...DispatcherOption) error {
+	cfg := dispatcherConfig{}
+	for _, option := range options {
+		if option != nil {
+			option(&cfg)
+		}
+	}
 	for {
 		call, ok, err := c.Poll(ctx, sessionID)
 		if err != nil {
@@ -820,7 +934,7 @@ func (c Client) RunDispatcher(ctx context.Context, sessionID string, providers m
 		if !ok {
 			continue
 		}
-		req := c.dispatchCall(ctx, call, providers)
+		req := c.dispatchCall(ctx, call, providers, cfg)
 		if err := c.Complete(ctx, sessionID, call.CallID, req); err != nil {
 			if dispatcherContextDone(ctx) {
 				return nil
@@ -834,7 +948,10 @@ func dispatcherContextDone(ctx context.Context) bool {
 	return ctx.Err() != nil
 }
 
-func (c Client) dispatchCall(ctx context.Context, call *PollResponse, providers map[string]proto.IntegrationProviderClient) CompleteCallRequest {
+func (c Client) dispatchCall(ctx context.Context, call *PollResponse, providers map[string]proto.IntegrationProviderClient, cfg dispatcherConfig) CompleteCallRequest {
+	if call.Method == "ServeUIAsset" {
+		return dispatchProviderDevUI(ctx, call, cfg.UIHandlers)
+	}
 	client := providers[strings.TrimSpace(call.Provider)]
 	if client == nil {
 		return CompleteCallRequest{Error: encodeRPCError(status.Errorf(codes.NotFound, "local provider %q is not running", call.Provider))}
@@ -847,7 +964,72 @@ func (c Client) dispatchCall(ctx context.Context, call *PollResponse, providers 
 	if err != nil {
 		return CompleteCallRequest{Error: encodeRPCError(err)}
 	}
-	return CompleteCallRequest{Response: hex.EncodeToString(resp)}
+	return CompleteCallRequest{ResponseBase64: base64.StdEncoding.EncodeToString(resp)}
+}
+
+func dispatchProviderDevUI(ctx context.Context, call *PollResponse, handlers map[string]http.Handler) CompleteCallRequest {
+	handler := handlers[strings.TrimSpace(call.Provider)]
+	if handler == nil {
+		return CompleteCallRequest{Error: encodeRPCError(status.Errorf(codes.NotFound, "local ui for provider %q is not running", call.Provider))}
+	}
+	payload, err := hex.DecodeString(call.Request)
+	if err != nil {
+		return CompleteCallRequest{Error: encodeRPCError(status.Errorf(codes.InvalidArgument, "decode ui request: %v", err))}
+	}
+	resp, err := dispatchProviderDevUIRequest(ctx, handler, payload)
+	if err != nil {
+		return CompleteCallRequest{Error: encodeRPCError(err)}
+	}
+	return CompleteCallRequest{ResponseBase64: base64.StdEncoding.EncodeToString(resp)}
+}
+
+func dispatchProviderDevUIRequest(ctx context.Context, handler http.Handler, payload []byte) ([]byte, error) {
+	var req UIAssetRequest
+	if err := json.Unmarshal(payload, &req); err != nil {
+		return nil, status.Errorf(codes.InvalidArgument, "decode ui request: %v", err)
+	}
+	method := strings.TrimSpace(req.Method)
+	if method == "" {
+		method = http.MethodGet
+	}
+	if method != http.MethodGet && method != http.MethodHead {
+		return nil, status.Errorf(codes.InvalidArgument, "provider dev ui only supports GET and HEAD requests")
+	}
+	path := normalizeUIAssetRequestPath(req.Path)
+	target := (&url.URL{
+		Scheme:   "http",
+		Host:     "provider-dev.local",
+		Path:     path,
+		RawQuery: req.RawQuery,
+	}).String()
+	httpReq, err := http.NewRequestWithContext(ctx, method, target, nil)
+	if err != nil {
+		return nil, status.Errorf(codes.InvalidArgument, "build ui request: %v", err)
+	}
+	if header := cloneHTTPHeader(req.Header); header != nil {
+		httpReq.Header = header
+	}
+	recorder := httptest.NewRecorder()
+	handler.ServeHTTP(recorder, httpReq)
+	httpResp := recorder.Result()
+	defer func() { _ = httpResp.Body.Close() }()
+	body, err := io.ReadAll(httpResp.Body)
+	if err != nil {
+		return nil, status.Errorf(codes.Internal, "read ui response: %v", err)
+	}
+	if method == http.MethodHead {
+		body = nil
+	}
+	resp := UIAssetResponse{
+		Status: httpResp.StatusCode,
+		Header: cloneHTTPHeader(httpResp.Header),
+		Body:   base64.StdEncoding.EncodeToString(body),
+	}
+	out, err := json.Marshal(resp)
+	if err != nil {
+		return nil, status.Errorf(codes.Internal, "encode ui response: %v", err)
+	}
+	return out, nil
 }
 
 func dispatchProviderRPC(ctx context.Context, client proto.IntegrationProviderClient, method string, payload []byte) ([]byte, error) {
@@ -1099,6 +1281,36 @@ func cloneStaticProviderSpec(spec providerhost.StaticProviderSpec) providerhost.
 		out.DiscoveryConfig = &discovery
 	}
 	return out
+}
+
+func cloneAttachUI(ui *AttachUI) *AttachUI {
+	if ui == nil {
+		return nil
+	}
+	out := *ui
+	return &out
+}
+
+func cloneHTTPHeader(header http.Header) http.Header {
+	if len(header) == 0 {
+		return nil
+	}
+	out := make(http.Header, len(header))
+	for key, values := range header {
+		out[key] = slices.Clone(values)
+	}
+	return out
+}
+
+func normalizeUIAssetRequestPath(value string) string {
+	value = strings.TrimSpace(value)
+	if value == "" {
+		return "/"
+	}
+	if !strings.HasPrefix(value, "/") {
+		value = "/" + value
+	}
+	return value
 }
 
 func principalSubjectID(p *principal.Principal) string {

--- a/gestaltd/internal/providerdev/session_test.go
+++ b/gestaltd/internal/providerdev/session_test.go
@@ -2,6 +2,7 @@ package providerdev
 
 import (
 	"context"
+	"encoding/base64"
 	"encoding/json"
 	"errors"
 	"fmt"
@@ -86,10 +87,16 @@ func TestHTTPTransportDispatchesProviderRPCs(t *testing.T) {
 	t.Cleanup(ts.Close)
 
 	client := Client{BaseURL: ts.URL, HTTPClient: ts.Client()}
+	localUI := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		r.Header.Set("X-Local-Handler", "observed")
+		w.Header().Set("Content-Type", "text/html; charset=utf-8")
+		_, _ = fmt.Fprintf(w, "local ui %s?%s range=%s", r.URL.Path, r.URL.RawQuery, r.Header.Get("Range"))
+	})
 	session, err := client.CreateSession(context.Background(), CreateSessionRequest{Providers: []AttachProvider{{
 		Name:   "roadmap",
 		Spec:   spec,
 		Config: map[string]any{"remote": true},
+		UI:     &AttachUI{},
 	}}})
 	if err != nil {
 		t.Fatalf("CreateSession: %v", err)
@@ -107,7 +114,7 @@ func TestHTTPTransportDispatchesProviderRPCs(t *testing.T) {
 	go func() {
 		dispatchDone <- client.RunDispatcher(dispatchCtx, session.ID, map[string]proto.IntegrationProviderClient{
 			"roadmap": local,
-		})
+		}, WithUIHandlers(map[string]http.Handler{"roadmap": localUI}))
 	}()
 
 	resolveCtx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
@@ -152,6 +159,67 @@ func TestHTTPTransportDispatchesProviderRPCs(t *testing.T) {
 	}
 	if result.Body != `{"message":"hello","operation":"echo","token":"remote-token"}` {
 		t.Fatalf("Execute body = %s", result.Body)
+	}
+
+	uiResp, ok, err := manager.ServeUIAsset(resolveCtx, p, "roadmap", UIAssetRequest{
+		Method:   http.MethodGet,
+		Path:     "/sync",
+		RawQuery: "tab=preview",
+		Header: http.Header{
+			"Range": []string{"bytes=0-3"},
+		},
+	})
+	if err != nil {
+		t.Fatalf("ServeUIAsset: %v", err)
+	}
+	if !ok {
+		t.Fatal("ServeUIAsset ok = false, want true")
+	}
+	if got := uiResp.Header.Get("Content-Type"); got != "text/html; charset=utf-8" {
+		t.Fatalf("ui content-type = %q, want text/html", got)
+	}
+	uiBody, err := base64.StdEncoding.DecodeString(uiResp.Body)
+	if err != nil {
+		t.Fatalf("decode ui body: %v", err)
+	}
+	if string(uiBody) != "local ui /sync?tab=preview range=bytes=0-3" {
+		t.Fatalf("ui body = %q", uiBody)
+	}
+
+	uiResp, ok, err = manager.ServeUIAsset(resolveCtx, p, "roadmap", UIAssetRequest{
+		Method: http.MethodGet,
+		Path:   "/empty-header",
+	})
+	if err != nil {
+		t.Fatalf("ServeUIAsset without headers: %v", err)
+	}
+	if !ok {
+		t.Fatal("ServeUIAsset without headers ok = false, want true")
+	}
+	uiBody, err = base64.StdEncoding.DecodeString(uiResp.Body)
+	if err != nil {
+		t.Fatalf("decode ui body without headers: %v", err)
+	}
+	if string(uiBody) != "local ui /empty-header? range=" {
+		t.Fatalf("ui body without headers = %q", uiBody)
+	}
+
+	uiResp, ok, err = manager.ServeUIAsset(resolveCtx, p, "roadmap", UIAssetRequest{
+		Method: http.MethodHead,
+		Path:   "/head",
+	})
+	if err != nil {
+		t.Fatalf("ServeUIAsset HEAD: %v", err)
+	}
+	if !ok {
+		t.Fatal("ServeUIAsset HEAD ok = false, want true")
+	}
+	uiBody, err = base64.StdEncoding.DecodeString(uiResp.Body)
+	if err != nil {
+		t.Fatalf("decode ui HEAD body: %v", err)
+	}
+	if len(uiBody) != 0 {
+		t.Fatalf("ui HEAD body = %q, want empty", uiBody)
 	}
 
 	local.mu.Lock()

--- a/gestaltd/internal/providerpkg/python_provider_test.go
+++ b/gestaltd/internal/providerpkg/python_provider_test.go
@@ -1,9 +1,7 @@
 package providerpkg
 
 import (
-	"fmt"
 	"os"
-	"os/exec"
 	"path/filepath"
 	"runtime"
 	"strings"
@@ -244,62 +242,11 @@ func pythonTestOtherPlatform() (string, string) {
 	return "linux", "amd64"
 }
 
-func pythonTestRuntimePath() (string, error) {
-	if value := os.Getenv("GESTALT_PYTHON"); value != "" {
-		if resolved, err := exec.LookPath(value); err == nil {
-			return resolved, nil
-		}
-		if info, err := os.Stat(value); err == nil && !info.IsDir() {
-			return value, nil
-		}
-	}
-	for _, candidate := range []string{"python3", "python"} {
-		if resolved, err := exec.LookPath(candidate); err == nil {
-			return resolved, nil
-		}
-	}
-	return "", exec.ErrNotFound
-}
-
 func pythonTestInterpreterPath(root, goos, suffix string) string {
 	if goos == "windows" {
 		return filepath.Join(root, suffix, "Scripts", "python.exe")
 	}
 	return filepath.Join(root, suffix, "bin", "python")
-}
-
-func mustWritePythonWithoutGRPCWrapper(t *testing.T, root, pythonPath string) string {
-	t.Helper()
-
-	path := filepath.Join(root, "python-no-grpc")
-	script := fmt.Sprintf(`#!%s
-import importlib.abc
-import runpy
-import sys
-
-class _BlockRuntimeDeps(importlib.abc.MetaPathFinder):
-    def find_spec(self, fullname, path=None, target=None):
-        if fullname == "grpc" or fullname.startswith("grpc."):
-            error = ModuleNotFoundError("No module named 'grpc'")
-            error.name = "grpc"
-            raise error
-        if fullname == "google" or fullname.startswith("google."):
-            error = ModuleNotFoundError("No module named 'google'")
-            error.name = "google"
-            raise error
-        return None
-
-sys.meta_path.insert(0, _BlockRuntimeDeps())
-
-if len(sys.argv) < 3 or sys.argv[1] != "-m":
-    raise SystemExit("unsupported invocation")
-
-module_name = sys.argv[2]
-sys.argv = [sys.argv[0], *sys.argv[3:]]
-runpy.run_module(module_name, run_name="__main__")
-`, pythonPath)
-	mustWriteFile(t, path, []byte(script), 0o755)
-	return path
 }
 
 func mustWritePythonInterpreter(t *testing.T, path string) {
@@ -311,30 +258,6 @@ func mustWritePythonInterpreter(t *testing.T, path string) {
 	if err := os.WriteFile(path, []byte("#!/bin/sh\nexit 0\n"), 0o755); err != nil {
 		t.Fatalf("WriteFile(%s): %v", path, err)
 	}
-}
-
-func mustWritePythonSourceManifest(t *testing.T, root, pluginName string) string {
-	t.Helper()
-
-	data, err := EncodeSourceManifestFormat(&providermanifestv1.Manifest{
-		Kind:    providermanifestv1.KindPlugin,
-		Source:  "github.com/testowner/plugins/" + pluginName,
-		Version: "0.0.1",
-		Spec: &providermanifestv1.Spec{
-			Connections: map[string]*providermanifestv1.ManifestConnectionDef{
-				"default": {
-					Auth: &providermanifestv1.ProviderAuth{Type: providermanifestv1.AuthTypeNone},
-				},
-			},
-		},
-	}, ManifestFormatYAML)
-	if err != nil {
-		t.Fatalf("EncodeSourceManifestFormat: %v", err)
-	}
-
-	path := filepath.Join(root, "manifest.yaml")
-	mustWriteFile(t, path, data, 0o644)
-	return path
 }
 
 func containsString(haystack, needle string) bool {

--- a/gestaltd/internal/server/middleware.go
+++ b/gestaltd/internal/server/middleware.go
@@ -11,6 +11,7 @@ import (
 	"github.com/valon-technologies/gestalt/server/core"
 	"github.com/valon-technologies/gestalt/server/internal/invocation"
 	"github.com/valon-technologies/gestalt/server/internal/principal"
+	"github.com/valon-technologies/gestalt/server/internal/providerdev"
 )
 
 type contextKey string
@@ -54,13 +55,37 @@ func requestMetaMiddleware(next http.Handler) http.Handler {
 	})
 }
 
+const (
+	defaultMaxBodyBytes         = 1 << 20
+	providerDevCallMaxBodyBytes = 128 << 20
+)
+
 func maxBodyMiddleware(limit int64) func(http.Handler) http.Handler {
 	return func(next http.Handler) http.Handler {
 		return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-			r.Body = http.MaxBytesReader(w, r.Body, limit)
+			r.Body = http.MaxBytesReader(w, r.Body, maxBodyLimitForRequest(r, limit))
 			next.ServeHTTP(w, r)
 		})
 	}
+}
+
+func maxBodyLimitForRequest(r *http.Request, defaultLimit int64) int64 {
+	if isProviderDevCompleteCallRequest(r) {
+		return providerDevCallMaxBodyBytes
+	}
+	return defaultLimit
+}
+
+func isProviderDevCompleteCallRequest(r *http.Request) bool {
+	if r == nil || r.Method != http.MethodPost || r.URL == nil {
+		return false
+	}
+	rest, ok := strings.CutPrefix(r.URL.Path, providerdev.PathSessions+"/")
+	if !ok {
+		return false
+	}
+	sessionID, callID, ok := strings.Cut(rest, "/calls/")
+	return ok && sessionID != "" && callID != "" && !strings.Contains(sessionID, "/") && !strings.Contains(callID, "/")
 }
 
 // contentSecurityPolicy is the CSP applied to all responses. script-src and

--- a/gestaltd/internal/server/mounted_ui.go
+++ b/gestaltd/internal/server/mounted_ui.go
@@ -2,6 +2,7 @@ package server
 
 import (
 	"context"
+	"encoding/base64"
 	"errors"
 	"fmt"
 	"net/http"
@@ -17,6 +18,7 @@ import (
 	"github.com/valon-technologies/gestalt/server/internal/invocation"
 	"github.com/valon-technologies/gestalt/server/internal/metricutil"
 	"github.com/valon-technologies/gestalt/server/internal/principal"
+	"github.com/valon-technologies/gestalt/server/internal/providerdev"
 	"github.com/valon-technologies/gestalt/server/internal/providerpkg"
 	"github.com/valon-technologies/gestalt/server/internal/ui"
 	"go.opentelemetry.io/otel/attribute"
@@ -326,7 +328,71 @@ func (s *Server) mountedUIHandler(mounted MountedUI) http.Handler {
 	if mounted.Path != "/" {
 		inner = http.StripPrefix(mounted.Path, inner)
 	}
+	inner = s.providerDevMountedUIHandler(mounted, inner)
 	return mountedUITelemetryHandler(mounted, s.protectedUIHandler(mounted, inner, s.redirectMountedUILogin))
+}
+
+func (s *Server) providerDevMountedUIHandler(mounted MountedUI, fallback http.Handler) http.Handler {
+	if s.providerDevSessions == nil || strings.TrimSpace(mounted.PluginName) == "" {
+		return fallback
+	}
+	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.Method != http.MethodGet && r.Method != http.MethodHead {
+			fallback.ServeHTTP(w, r)
+			return
+		}
+		resp, ok, err := s.providerDevSessions.ServeUIAsset(r.Context(), s.providerDevUIPrincipal(r, mounted), mounted.PluginName, providerdev.UIAssetRequest{
+			Method:   r.Method,
+			Path:     providerDevUIAssetPath(mounted, r.URL.Path),
+			RawQuery: r.URL.RawQuery,
+			Header:   providerDevUIRequestHeader(r.Header),
+		})
+		if err != nil {
+			writeProviderDevError(w, err)
+			return
+		}
+		if !ok {
+			fallback.ServeHTTP(w, r)
+			return
+		}
+		writeProviderDevUIAsset(w, resp)
+	})
+}
+
+func (s *Server) providerDevUIPrincipal(r *http.Request, mounted MountedUI) *principal.Principal {
+	if p := PrincipalFromContext(r.Context()); p != nil {
+		return p
+	}
+	if s == nil {
+		return nil
+	}
+	auth, err := s.mountedUIAuthRuntime(mounted)
+	if err != nil {
+		return nil
+	}
+	if auth.noAuth {
+		p := auth.anonymous
+		if p == nil {
+			return nil
+		}
+		enriched, err := s.resolvePrincipalUserID(r.Context(), p)
+		if err != nil {
+			return p
+		}
+		return enriched
+	}
+	if auth.resolver == nil {
+		return nil
+	}
+	p, err := s.resolveRequestPrincipalWithResolver(r, auth.resolver)
+	if err != nil || p == nil {
+		return nil
+	}
+	enriched, err := s.resolvePrincipalUserID(r.Context(), p)
+	if err != nil {
+		return p
+	}
+	return enriched
 }
 
 func (s *Server) adminUIHandler() http.Handler {
@@ -568,4 +634,77 @@ func mountedUIRoleAllowed(role string, allowedRoles []string) bool {
 		}
 	}
 	return false
+}
+
+func providerDevUIAssetPath(mounted MountedUI, requestPath string) string {
+	path := requestPath
+	if mounted.Path != "/" {
+		path = strings.TrimPrefix(path, mounted.Path)
+	}
+	if path == "" {
+		return "/"
+	}
+	if !strings.HasPrefix(path, "/") {
+		return "/" + path
+	}
+	return path
+}
+
+func providerDevUIRequestHeader(header http.Header) http.Header {
+	out := http.Header{}
+	copyHeaderValues(out, header, "If-Match")
+	copyHeaderValues(out, header, "If-None-Match")
+	copyHeaderValues(out, header, "If-Modified-Since")
+	copyHeaderValues(out, header, "If-Unmodified-Since")
+	copyHeaderValues(out, header, "If-Range")
+	copyHeaderValues(out, header, "Range")
+	if len(out) == 0 {
+		return nil
+	}
+	return out
+}
+
+func copyHeaderValues(dst, src http.Header, name string) {
+	values := src.Values(name)
+	for _, value := range values {
+		dst.Add(name, value)
+	}
+}
+
+func writeProviderDevUIAsset(w http.ResponseWriter, resp *providerdev.UIAssetResponse) {
+	if resp == nil {
+		writeError(w, http.StatusNotFound, "provider dev ui asset not found")
+		return
+	}
+	body, err := base64.StdEncoding.DecodeString(resp.Body)
+	if err != nil {
+		writeError(w, http.StatusBadGateway, "invalid provider dev ui response")
+		return
+	}
+	for key, values := range resp.Header {
+		if isHopByHopHeader(key) {
+			continue
+		}
+		w.Header().Del(key)
+		for _, value := range values {
+			w.Header().Add(key, value)
+		}
+	}
+	statusCode := resp.Status
+	if statusCode == 0 {
+		statusCode = http.StatusOK
+	}
+	w.WriteHeader(statusCode)
+	if len(body) != 0 {
+		_, _ = w.Write(body)
+	}
+}
+
+func isHopByHopHeader(name string) bool {
+	switch strings.ToLower(strings.TrimSpace(name)) {
+	case "connection", "keep-alive", "proxy-authenticate", "proxy-authorization", "te", "trailer", "transfer-encoding", "upgrade":
+		return true
+	default:
+		return false
+	}
 }

--- a/gestaltd/internal/server/provider_dev_ui_test.go
+++ b/gestaltd/internal/server/provider_dev_ui_test.go
@@ -1,0 +1,404 @@
+package server
+
+import (
+	"bytes"
+	"context"
+	"encoding/base64"
+	"encoding/hex"
+	"encoding/json"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+	"time"
+
+	"github.com/valon-technologies/gestalt/server/core"
+	coretesting "github.com/valon-technologies/gestalt/server/core/testing"
+	"github.com/valon-technologies/gestalt/server/internal/config"
+	"github.com/valon-technologies/gestalt/server/internal/coredata"
+	"github.com/valon-technologies/gestalt/server/internal/principal"
+	"github.com/valon-technologies/gestalt/server/internal/providerdev"
+)
+
+func TestProviderDevMountedUIHandlerOverridesFallback(t *testing.T) {
+	t.Parallel()
+
+	manager, err := providerdev.NewManager([]providerdev.Target{{Name: "roadmap"}})
+	if err != nil {
+		t.Fatalf("NewManager: %v", err)
+	}
+	p := &principal.Principal{SubjectID: "user:user-123", UserID: "user-123", Kind: principal.KindUser}
+	session, err := manager.CreateSession(context.Background(), p, providerdev.CreateSessionRequest{Providers: []providerdev.AttachProvider{{
+		Name: "roadmap",
+		UI:   &providerdev.AttachUI{},
+	}}})
+	if err != nil {
+		t.Fatalf("CreateSession: %v", err)
+	}
+
+	dispatchCtx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+	dispatchDone := make(chan error, 1)
+	go func() {
+		call, ok, err := manager.PollSession(dispatchCtx, p, session.ID)
+		if err != nil || !ok {
+			dispatchDone <- err
+			return
+		}
+		var assetReq providerdev.UIAssetRequest
+		payload, err := hex.DecodeString(call.Request)
+		if err == nil {
+			err = json.Unmarshal(payload, &assetReq)
+		}
+		if err != nil {
+			dispatchDone <- err
+			return
+		}
+		resp := providerdev.UIAssetResponse{
+			Status: http.StatusOK,
+			Header: http.Header{
+				"Content-Type": []string{"text/html; charset=utf-8"},
+			},
+			Body: base64.StdEncoding.EncodeToString([]byte("local ui " + assetReq.Path + "?" + assetReq.RawQuery + " range=" + assetReq.Header.Get("Range"))),
+		}
+		respPayload, err := json.Marshal(resp)
+		if err != nil {
+			dispatchDone <- err
+			return
+		}
+		dispatchDone <- manager.CompleteCall(p, session.ID, call.CallID, providerdev.CompleteCallRequest{
+			Response: hex.EncodeToString(respPayload),
+		})
+	}()
+
+	fallback := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		_, _ = w.Write([]byte("remote fallback"))
+	})
+	s := &Server{providerDevSessions: manager}
+	handler := s.mountedUIHandler(MountedUI{
+		Name:       "roadmap",
+		Path:       "/roadmap",
+		PluginName: "roadmap",
+		Handler:    fallback,
+	})
+	req := httptest.NewRequest(http.MethodGet, "/roadmap/sync?tab=preview", nil)
+	req.Header.Set("Range", "bytes=0-3")
+	req = req.WithContext(principal.WithPrincipal(req.Context(), p))
+	rec := httptest.NewRecorder()
+	handler.ServeHTTP(rec, req)
+
+	if rec.Code != http.StatusOK {
+		t.Fatalf("status = %d, body = %s", rec.Code, rec.Body.String())
+	}
+	if got := rec.Body.String(); got != "local ui /sync?tab=preview range=bytes=0-3" {
+		t.Fatalf("body = %q, want local ui body", got)
+	}
+	postCtx, postCancel := context.WithTimeout(context.Background(), 100*time.Millisecond)
+	defer postCancel()
+	postReq := httptest.NewRequest(http.MethodPost, "/roadmap/sync", nil)
+	postReq = postReq.WithContext(principal.WithPrincipal(postCtx, p))
+	postRec := httptest.NewRecorder()
+	handler.ServeHTTP(postRec, postReq)
+	if got := postRec.Body.String(); got != "remote fallback" {
+		t.Fatalf("POST body = %q, want fallback body", got)
+	}
+	select {
+	case err := <-dispatchDone:
+		if err != nil {
+			t.Fatalf("dispatch provider dev ui: %v", err)
+		}
+	case <-time.After(5 * time.Second):
+		t.Fatal("timed out waiting for provider dev ui dispatch")
+	}
+}
+
+func TestProviderDevMountedUIHandlerUsesMountedAuthRuntime(t *testing.T) {
+	t.Parallel()
+
+	services, err := coredata.New(&coretesting.StubIndexedDB{})
+	if err != nil {
+		t.Fatalf("coredata.New: %v", err)
+	}
+	serverAuth := &coretesting.StubAuthProvider{
+		N: "server",
+		ValidateTokenFn: func(context.Context, string) (*core.UserIdentity, error) {
+			return nil, principal.ErrInvalidToken
+		},
+	}
+	altAuth := &coretesting.StubAuthProvider{
+		N: "alt",
+		ValidateTokenFn: func(_ context.Context, token string) (*core.UserIdentity, error) {
+			if token != "alt-session" {
+				return nil, principal.ErrInvalidToken
+			}
+			return &core.UserIdentity{Email: "alt@example.com"}, nil
+		},
+	}
+	s := &Server{
+		users: services.Users,
+		auth:  serverAuth,
+		resolver: principal.NewResolver(
+			serverAuth,
+			services.Users,
+			services.APITokens,
+			nil,
+		),
+		authProviders: map[string]core.AuthenticationProvider{
+			"alt": altAuth,
+		},
+		authResolvers: map[string]*principal.Resolver{
+			"alt": principal.NewResolver(altAuth, services.Users, services.APITokens, nil),
+		},
+		pluginDefs: map[string]*config.ProviderEntry{
+			"roadmap": {RouteAuth: &config.RouteAuthDef{Provider: "alt"}},
+		},
+	}
+	mounted := MountedUI{
+		Name:       "roadmap",
+		Path:       "/roadmap",
+		PluginName: "roadmap",
+	}
+	req := httptest.NewRequest(http.MethodGet, "/roadmap/", nil)
+	req.Header.Set("Authorization", "Bearer alt-session")
+	p := s.providerDevUIPrincipal(req, mounted)
+	if p == nil || p.SubjectID == "" {
+		t.Fatalf("providerDevUIPrincipal = %#v, want principal from mounted auth runtime", p)
+	}
+
+	manager, err := providerdev.NewManager([]providerdev.Target{{Name: "roadmap"}})
+	if err != nil {
+		t.Fatalf("NewManager: %v", err)
+	}
+	session, err := manager.CreateSession(context.Background(), p, providerdev.CreateSessionRequest{Providers: []providerdev.AttachProvider{{
+		Name: "roadmap",
+		UI:   &providerdev.AttachUI{},
+	}}})
+	if err != nil {
+		t.Fatalf("CreateSession: %v", err)
+	}
+	s.providerDevSessions = manager
+
+	dispatchDone := make(chan error, 1)
+	go func() {
+		call, ok, err := manager.PollSession(context.Background(), p, session.ID)
+		if err != nil || !ok {
+			dispatchDone <- err
+			return
+		}
+		resp := providerdev.UIAssetResponse{
+			Status: http.StatusOK,
+			Body:   base64.StdEncoding.EncodeToString([]byte("local alt ui")),
+		}
+		respPayload, err := json.Marshal(resp)
+		if err != nil {
+			dispatchDone <- err
+			return
+		}
+		dispatchDone <- manager.CompleteCall(p, session.ID, call.CallID, providerdev.CompleteCallRequest{
+			Response: hex.EncodeToString(respPayload),
+		})
+	}()
+
+	handler := s.mountedUIHandler(MountedUI{
+		Name:       "roadmap",
+		Path:       "/roadmap",
+		PluginName: "roadmap",
+		Handler: http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			_, _ = w.Write([]byte("remote fallback"))
+		}),
+	})
+	rec := httptest.NewRecorder()
+	handler.ServeHTTP(rec, req)
+	if got := rec.Body.String(); got != "local alt ui" {
+		t.Fatalf("body = %q, want local alt ui", got)
+	}
+	select {
+	case err := <-dispatchDone:
+		if err != nil {
+			t.Fatalf("dispatch provider dev ui: %v", err)
+		}
+	case <-time.After(5 * time.Second):
+		t.Fatal("timed out waiting for provider dev ui dispatch")
+	}
+}
+
+func TestProviderDevMountedUIHandlerUsesAnonymousForNoAuthMountedUI(t *testing.T) {
+	t.Parallel()
+
+	services, err := coredata.New(&coretesting.StubIndexedDB{})
+	if err != nil {
+		t.Fatalf("coredata.New: %v", err)
+	}
+	noneAuth := &coretesting.StubAuthProvider{N: "none"}
+	resolver := principal.NewResolver(noneAuth, services.Users, services.APITokens, nil)
+	s := &Server{
+		users:              services.Users,
+		auth:               noneAuth,
+		resolver:           resolver,
+		noAuth:             true,
+		anonymousPrincipal: resolver.ResolveEmail(anonymousEmail),
+		authProviders: map[string]core.AuthenticationProvider{
+			"none": noneAuth,
+		},
+		authResolvers: map[string]*principal.Resolver{
+			"none": resolver,
+		},
+		pluginDefs: map[string]*config.ProviderEntry{
+			"roadmap": {RouteAuth: &config.RouteAuthDef{Provider: "none"}},
+		},
+	}
+	mounted := MountedUI{
+		Name:       "roadmap",
+		Path:       "/roadmap",
+		PluginName: "roadmap",
+	}
+	p := s.providerDevUIPrincipal(httptest.NewRequest(http.MethodGet, "/roadmap/", nil), mounted)
+	if p == nil || p.SubjectID == "" {
+		t.Fatalf("providerDevUIPrincipal = %#v, want enriched anonymous principal", p)
+	}
+
+	manager, err := providerdev.NewManager([]providerdev.Target{{Name: "roadmap"}})
+	if err != nil {
+		t.Fatalf("NewManager: %v", err)
+	}
+	session, err := manager.CreateSession(context.Background(), p, providerdev.CreateSessionRequest{Providers: []providerdev.AttachProvider{{
+		Name: "roadmap",
+		UI:   &providerdev.AttachUI{},
+	}}})
+	if err != nil {
+		t.Fatalf("CreateSession: %v", err)
+	}
+	s.providerDevSessions = manager
+
+	dispatchDone := make(chan error, 1)
+	go func() {
+		call, ok, err := manager.PollSession(context.Background(), p, session.ID)
+		if err != nil || !ok {
+			dispatchDone <- err
+			return
+		}
+		respPayload, err := json.Marshal(providerdev.UIAssetResponse{
+			Status: http.StatusOK,
+			Body:   base64.StdEncoding.EncodeToString([]byte("local anonymous ui")),
+		})
+		if err != nil {
+			dispatchDone <- err
+			return
+		}
+		dispatchDone <- manager.CompleteCall(p, session.ID, call.CallID, providerdev.CompleteCallRequest{
+			Response: hex.EncodeToString(respPayload),
+		})
+	}()
+
+	handler := s.mountedUIHandler(MountedUI{
+		Name:       "roadmap",
+		Path:       "/roadmap",
+		PluginName: "roadmap",
+		Handler: http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			_, _ = w.Write([]byte("remote fallback"))
+		}),
+	})
+	rec := httptest.NewRecorder()
+	handler.ServeHTTP(rec, httptest.NewRequest(http.MethodGet, "/roadmap/", nil))
+	if got := rec.Body.String(); got != "local anonymous ui" {
+		t.Fatalf("body = %q, want local anonymous ui", got)
+	}
+	select {
+	case err := <-dispatchDone:
+		if err != nil {
+			t.Fatalf("dispatch provider dev ui: %v", err)
+		}
+	case <-time.After(5 * time.Second):
+		t.Fatal("timed out waiting for provider dev ui dispatch")
+	}
+}
+
+func TestWriteProviderDevUIAssetInvalidBodyDoesNotForwardRemoteHeaders(t *testing.T) {
+	t.Parallel()
+
+	rec := httptest.NewRecorder()
+	writeProviderDevUIAsset(rec, &providerdev.UIAssetResponse{
+		Status: http.StatusOK,
+		Header: http.Header{
+			"Cache-Control":  []string{"max-age=3600"},
+			"Content-Length": []string{"999"},
+			"Content-Type":   []string{"text/html; charset=utf-8"},
+		},
+		Body: "not-base64",
+	})
+
+	if rec.Code != http.StatusBadGateway {
+		t.Fatalf("status = %d, body = %s", rec.Code, rec.Body.String())
+	}
+	if got := rec.Header().Get("Content-Type"); got != "application/json" {
+		t.Fatalf("content-type = %q, want application/json", got)
+	}
+	if got := rec.Header().Get("Content-Length"); got != "" {
+		t.Fatalf("content-length = %q, want no upstream content length", got)
+	}
+	if got := rec.Header().Get("Cache-Control"); got != "" {
+		t.Fatalf("cache-control = %q, want no upstream cache header", got)
+	}
+}
+
+func TestWriteProviderDevUIAssetReplacesExistingHeaders(t *testing.T) {
+	t.Parallel()
+
+	rec := httptest.NewRecorder()
+	rec.Header().Add("Content-Type", "application/json")
+	rec.Header().Add("Content-Type", "text/plain")
+	rec.Header().Set("X-Frame-Options", "DENY")
+	writeProviderDevUIAsset(rec, &providerdev.UIAssetResponse{
+		Status: http.StatusOK,
+		Header: http.Header{
+			"Content-Type":    []string{"text/html; charset=utf-8"},
+			"Set-Cookie":      []string{"a=1", "b=2"},
+			"X-Frame-Options": []string{"SAMEORIGIN"},
+		},
+		Body: base64.StdEncoding.EncodeToString([]byte("ok")),
+	})
+
+	if got := rec.Header().Values("Content-Type"); len(got) != 1 || got[0] != "text/html; charset=utf-8" {
+		t.Fatalf("content-type values = %#v, want only local ui value", got)
+	}
+	if got := rec.Header().Values("X-Frame-Options"); len(got) != 1 || got[0] != "SAMEORIGIN" {
+		t.Fatalf("x-frame-options values = %#v, want only local ui value", got)
+	}
+	if got := rec.Header().Values("Set-Cookie"); len(got) != 2 || got[0] != "a=1" || got[1] != "b=2" {
+		t.Fatalf("set-cookie values = %#v, want both local ui cookies", got)
+	}
+}
+
+func TestMaxBodyMiddlewareAllowsLargeProviderDevCallCompletions(t *testing.T) {
+	t.Parallel()
+
+	handler := maxBodyMiddleware(defaultMaxBodyBytes)(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if _, err := io.ReadAll(r.Body); err != nil {
+			writeError(w, http.StatusRequestEntityTooLarge, err.Error())
+			return
+		}
+		w.WriteHeader(http.StatusNoContent)
+	}))
+	largeBody := bytes.Repeat([]byte("x"), defaultMaxBodyBytes+1024)
+
+	providerDevReq := httptest.NewRequest(http.MethodPost, "/api/v1/provider-dev/sessions/session-1/calls/call-1", bytes.NewReader(largeBody))
+	providerDevRec := httptest.NewRecorder()
+	handler.ServeHTTP(providerDevRec, providerDevReq)
+	if providerDevRec.Code != http.StatusNoContent {
+		t.Fatalf("provider dev completion status = %d, want %d", providerDevRec.Code, http.StatusNoContent)
+	}
+
+	extraPathReq := httptest.NewRequest(http.MethodPost, "/api/v1/provider-dev/sessions/session-1/calls/call-1/extra", bytes.NewReader(largeBody))
+	extraPathRec := httptest.NewRecorder()
+	handler.ServeHTTP(extraPathRec, extraPathReq)
+	if extraPathRec.Code != http.StatusRequestEntityTooLarge {
+		t.Fatalf("provider dev extra path status = %d, want %d", extraPathRec.Code, http.StatusRequestEntityTooLarge)
+	}
+
+	normalReq := httptest.NewRequest(http.MethodPost, "/api/v1/tokens", bytes.NewReader(largeBody))
+	normalRec := httptest.NewRecorder()
+	handler.ServeHTTP(normalRec, normalReq)
+	if normalRec.Code != http.StatusRequestEntityTooLarge {
+		t.Fatalf("normal endpoint status = %d, want %d", normalRec.Code, http.StatusRequestEntityTooLarge)
+	}
+}

--- a/gestaltd/internal/server/routes.go
+++ b/gestaltd/internal/server/routes.go
@@ -16,7 +16,7 @@ func (s *Server) routes() {
 	r.Use(s.securityHeadersMiddleware)
 	r.Use(s.hostServiceRelayMiddleware)
 	r.Use(s.egressProxyMiddleware)
-	r.Use(maxBodyMiddleware(1 << 20)) // 1 MB
+	r.Use(maxBodyMiddleware(defaultMaxBodyBytes))
 
 	switch s.routeProfile {
 	case RouteProfilePublic:


### PR DESCRIPTION
## Summary

Extends remote provider development so a local plugin can also serve its local UI assets through the authenticated remote `gestaltd` instance. The remote server still owns the browser route, auth, authorization, telemetry labels, and mounted-UI fallback; only the static UI bytes are fetched from the local provider-dev session when the current principal has an attached UI-capable session.

Remote UI tunneling only applies to mounted plugin UIs that already exist on the remote server. If the remote config has no mounted UI route for the plugin, this PR does not dynamically add one.

## New Interfaces

- `providerdev.AttachProvider.UI` marks an attached provider-dev target as having local UI assets.
- `providerdev.Manager.ServeUIAsset(ctx, principal, provider, request)` resolves the latest attached provider-dev session for that principal and tunnels a UI asset request over the existing provider-dev long-poll transport.
- `providerdev.WithUIHandlers(map[string]http.Handler)` registers local UI handlers with the remote provider-dev dispatcher.
- `providerdev.CompleteCallRequest.responseBase64` lets new dispatchers return larger binary payloads without hex expansion. The legacy `response` hex field remains accepted.
- `gestaltd provider dev --remote ...` now auto-detects local plugin-owned, explicit local `providers.ui`, or sibling UI manifests and advertises those handlers to the remote session.

## Example

```sh
GESTALT_API_KEY=vat_... gestaltd provider dev \
  --remote https://gestalt.example.com \
  --path ./plugins/support
```

When `plugins.support` is mounted on the remote server, browser requests to that existing remote mount keep using remote auth/authorization while the UI bundle comes from the local source tree.

## Verification

- `go test ./internal/providerdev ./internal/server -count=1`
- `go test ./cmd/gestaltd -count=1`
- `golangci-lint run ./internal/providerdev ./internal/server ./cmd/gestaltd`
- `go test ./... -run TestDoesNotExist`
- `npm run build` in `docs/`

## Review Follow-Up

Applied reviewer feedback that was valid:
- Raised the body limit for provider-dev call completion requests and reduced new dispatcher response expansion via `responseBase64`.
- Resolved provider-dev mounted UI sessions using the mounted UI route auth runtime instead of always using the server-default resolver.
- Forwarded conditional and range headers to the local UI handler so static assets can preserve normal 304/206 behavior.

Merge-order note: #1381 also touches provider-dev session internals. This PR is independent, but if #1381 lands first this branch should be rebased so both sets of hardening remain present.

## Related

Review-comment cleanup from the merged remote provider-dev PR is being handled separately in #1381.