### PR TITLE
cli: add full-screen agent terminal UI

### DIFF
--- a/docs/content/client/cli/index.mdx
+++ b/docs/content/client/cli/index.mdx
@@ -250,8 +250,13 @@ CLI session can include repeated `--system` messages, repeated `--message`
 prompts, and repeated `--tool plugin:operation` additions. During execution,
 the CLI parses the event stream, renders assistant/tool/interaction events,
 cancels the active turn on Ctrl-C, and resolves pending interactions inline.
-TTY sessions use line editing and per-directory history. End an input line with
-`\` to continue the same user message on the next prompt.
+TTY sessions use a full-screen terminal UI with a persistent transcript,
+streaming assistant output, a multiline composer, queued prompts while a turn
+is running, Ctrl-C cancellation, and inline interaction panels. Press Enter to
+send, Alt-Enter to insert a newline, PageUp/PageDown to scroll, `/session` to
+show the active session, and `/quit` to exit. Non-TTY sessions keep the
+prompt-and-print fallback used by scripts and tests; there, end an input line
+with `\` to continue the same user message on the next prompt.
 
 `gestalt agent turns create` is the non-interactive equivalent. It supports
 repeated `--system`, repeated `--message`, repeated `--tool plugin:operation`,

--- a/gestalt/cli/Cargo.toml
+++ b/gestalt/cli/Cargo.toml
@@ -26,9 +26,13 @@ rpassword = "7"
 time = { version = "0.3", features = ["parsing"] }
 rustyline = "18"
 ctrlc = "3"
+crossterm = "0.29"
+ratatui = { version = "0.30", features = ["crossterm_0_29"] }
+ratatui-textarea = "0.9"
 
 [dev-dependencies]
 tempfile = "3"
 mockito = "1"
 assert_cmd = "2"
 predicates = "3"
+portable-pty = "0.9"

--- a/gestalt/cli/src/commands/agents.rs
+++ b/gestalt/cli/src/commands/agents.rs
@@ -22,6 +22,8 @@ use crate::interactive::{
 use crate::output::{self, Format};
 use crate::params;
 
+mod tui;
+
 const SESSIONS_PATH: &str = "/api/v1/agent/sessions";
 const TURNS_PATH: &str = "/api/v1/agent/turns";
 const DEFAULT_EVENT_PAGE_SIZE: u32 = 100;
@@ -160,6 +162,10 @@ pub fn stream_turn_events(client: &ApiClient, args: &AgentTurnEventStreamArgs) -
 }
 
 pub fn run_interactive(client: &ApiClient, args: &AgentArgs) -> Result<()> {
+    if tui::can_run() {
+        return tui::run(client, args);
+    }
+
     let mut shell = AgentShell::connect(client, args)?;
     shell.print_banner()?;
     let interrupts = InterruptState::install();
@@ -793,18 +799,33 @@ fn stream_turn_events_until_blocked_or_terminal(
     turn_id: &str,
     renderer: &mut AgentTurnRenderer,
 ) -> Result<()> {
+    let after_seq = renderer.after_seq();
+    stream_turn_event_frames(client, turn_id, after_seq, |event| {
+        renderer.render_events(&[event])
+    })
+}
+
+fn stream_turn_event_frames<F>(
+    client: &ApiClient,
+    turn_id: &str,
+    after_seq: u64,
+    mut handle_event: F,
+) -> Result<()>
+where
+    F: FnMut(AgentTurnEventInfo) -> Result<()>,
+{
     let resp = client
         .get_stream(&turn_events_path(
             turn_id,
             true,
-            Some(renderer.after_seq()),
+            Some(after_seq),
             Some(DEFAULT_EVENT_PAGE_SIZE),
             Some(EVENT_STREAM_UNTIL_BLOCKED_OR_TERMINAL),
         ))
         .with_context(|| format!("failed to stream events for agent turn {turn_id}"))?;
     let mut reader = BufReader::new(resp);
     let mut line = String::new();
-    let mut data = String::new();
+    let mut decoder = SseEventDecoder::default();
 
     loop {
         line.clear();
@@ -812,33 +833,49 @@ fn stream_turn_events_until_blocked_or_terminal(
             .read_line(&mut line)
             .context("failed to read agent turn event stream")?;
         if read == 0 {
-            render_sse_event_data(&mut data, renderer)?;
+            if let Some(event) = decoder.finish()? {
+                handle_event(event)?;
+            }
             return Ok(());
         }
 
-        let trimmed = line.trim_end_matches(['\r', '\n']);
-        if trimmed.is_empty() {
-            render_sse_event_data(&mut data, renderer)?;
-            continue;
-        }
-
-        if let Some(value) = trimmed.strip_prefix("data:") {
-            if !data.is_empty() {
-                data.push('\n');
-            }
-            data.push_str(value.strip_prefix(' ').unwrap_or(value));
+        if let Some(event) = decoder.push_line(&line)? {
+            handle_event(event)?;
         }
     }
 }
 
-fn render_sse_event_data(data: &mut String, renderer: &mut AgentTurnRenderer) -> Result<()> {
-    if data.is_empty() {
-        return Ok(());
+#[derive(Default)]
+struct SseEventDecoder {
+    data: String,
+}
+
+impl SseEventDecoder {
+    fn push_line(&mut self, line: &str) -> Result<Option<AgentTurnEventInfo>> {
+        let trimmed = line.trim_end_matches(['\r', '\n']);
+        if trimmed.is_empty() {
+            return self.finish();
+        }
+
+        if let Some(value) = trimmed.strip_prefix("data:") {
+            if !self.data.is_empty() {
+                self.data.push('\n');
+            }
+            self.data.push_str(value.strip_prefix(' ').unwrap_or(value));
+        }
+
+        Ok(None)
     }
-    let raw = std::mem::take(data);
-    let event: AgentTurnEventInfo = serde_json::from_str(&raw)
-        .with_context(|| format!("failed to decode agent turn event stream frame: {raw}"))?;
-    renderer.render_events(&[event])
+
+    fn finish(&mut self) -> Result<Option<AgentTurnEventInfo>> {
+        if self.data.is_empty() {
+            return Ok(None);
+        }
+        let raw = std::mem::take(&mut self.data);
+        serde_json::from_str(&raw)
+            .with_context(|| format!("failed to decode agent turn event stream frame: {raw}"))
+            .map(Some)
+    }
 }
 
 fn create_session_info(

--- a/gestalt/cli/src/commands/agents/tui.rs
+++ b/gestalt/cli/src/commands/agents/tui.rs
@@ -1,0 +1,670 @@
+use std::collections::VecDeque;
+use std::io::{self, IsTerminal};
+use std::sync::mpsc::{self, Receiver, Sender, TryRecvError};
+use std::thread;
+use std::time::Duration;
+
+use anyhow::{Context, Result};
+use ratatui::crossterm::event::{self, Event, KeyCode, KeyEvent, KeyEventKind, KeyModifiers};
+use ratatui::prelude::*;
+use ratatui::widgets::{Block, Borders, Clear, Paragraph, Wrap};
+use ratatui_textarea::TextArea;
+use serde_json::{Map, Value};
+
+use crate::api::ApiClient;
+use crate::cli::{AgentArgs, AgentTurnCreateArgs};
+
+mod state;
+mod worker;
+
+use state::{AgentUiState, TranscriptKind, turn_status_label};
+use worker::{TurnWorker, WorkerCommand, WorkerEvent, spawn_turn_worker};
+
+use super::{
+    AgentInteractionInfo, AgentShell, INTERRUPT_CANCEL_REASON, cancel_turn_silent, compact_json,
+};
+
+const TICK_RATE: Duration = Duration::from_millis(50);
+
+pub(super) fn can_run() -> bool {
+    io::stdin().is_terminal() && io::stdout().is_terminal() && io::stderr().is_terminal()
+}
+
+pub(super) fn run(client: &ApiClient, args: &AgentArgs) -> Result<()> {
+    let shell = AgentShell::connect(client, args)?;
+    let mut app = TuiApp::new(client.clone(), shell);
+    let mut terminal = TerminalGuard::start()?;
+
+    if !args.messages.is_empty() {
+        app.enqueue_or_start(args.messages.clone());
+    }
+
+    let result = app.run(terminal.inner_mut());
+    terminal.restore()?;
+    result
+}
+
+struct TerminalGuard {
+    terminal: ratatui::DefaultTerminal,
+    restored: bool,
+}
+
+impl TerminalGuard {
+    fn start() -> Result<Self> {
+        Ok(Self {
+            terminal: ratatui::try_init().context("failed to initialize terminal UI")?,
+            restored: false,
+        })
+    }
+
+    fn inner_mut(&mut self) -> &mut ratatui::DefaultTerminal {
+        &mut self.terminal
+    }
+
+    fn restore(&mut self) -> Result<()> {
+        if !self.restored {
+            ratatui::try_restore().context("failed to restore terminal UI")?;
+            self.restored = true;
+        }
+        Ok(())
+    }
+}
+
+impl Drop for TerminalGuard {
+    fn drop(&mut self) {
+        if !self.restored {
+            ratatui::restore();
+            self.restored = true;
+        }
+    }
+}
+
+struct TuiApp {
+    client: ApiClient,
+    shell: AgentShell,
+    state: AgentUiState,
+    composer: TextArea<'static>,
+    interaction_input: InteractionInput,
+    worker: Option<TurnWorker>,
+    worker_rx: Receiver<WorkerEvent>,
+    worker_tx: Sender<WorkerEvent>,
+    queued_messages: VecDeque<Vec<String>>,
+    should_quit: bool,
+    quit_after_turn: bool,
+    transcript_visible_height: usize,
+}
+
+impl TuiApp {
+    fn new(client: ApiClient, shell: AgentShell) -> Self {
+        let (worker_tx, worker_rx) = mpsc::channel();
+        Self {
+            state: AgentUiState::new(&shell.session),
+            client,
+            shell,
+            composer: styled_textarea("Message"),
+            interaction_input: InteractionInput::default(),
+            worker: None,
+            worker_rx,
+            worker_tx,
+            queued_messages: VecDeque::new(),
+            should_quit: false,
+            quit_after_turn: false,
+            transcript_visible_height: 1,
+        }
+    }
+
+    fn run(&mut self, terminal: &mut ratatui::DefaultTerminal) -> Result<()> {
+        loop {
+            self.drain_worker_events();
+            self.start_next_queued_turn();
+            terminal.draw(|frame| self.draw(frame))?;
+
+            if self.should_quit {
+                return Ok(());
+            }
+
+            if event::poll(TICK_RATE).context("failed to poll terminal events")? {
+                match event::read().context("failed to read terminal event")? {
+                    Event::Key(key) if key.kind == KeyEventKind::Press => self.handle_key(key),
+                    Event::Resize(_, _) => {}
+                    _ => {}
+                }
+            }
+        }
+    }
+
+    fn draw(&mut self, frame: &mut Frame<'_>) {
+        let area = frame.area();
+        let interaction_height = if self.state.pending_interaction.is_some() {
+            7
+        } else {
+            0
+        };
+        let chunks = Layout::vertical([
+            Constraint::Min(3),
+            Constraint::Length(interaction_height),
+            Constraint::Length(self.composer_height()),
+            Constraint::Length(1),
+        ])
+        .split(area);
+
+        self.draw_transcript(frame, chunks[0]);
+        if self.state.pending_interaction.is_some() {
+            self.draw_interaction(frame, chunks[1]);
+        }
+        self.draw_composer(frame, chunks[2]);
+        self.draw_footer(frame, chunks[3]);
+    }
+
+    fn draw_transcript(&mut self, frame: &mut Frame<'_>, area: Rect) {
+        let title = format!(
+            "Session {} [{} / {}]",
+            self.state.session_id, self.state.provider, self.state.model
+        );
+        let mut lines = Vec::new();
+        self.transcript_visible_height = area.height.saturating_sub(2).max(1) as usize;
+        for item in self
+            .state
+            .visible_transcript(self.transcript_visible_height)
+        {
+            let style = match item.kind {
+                TranscriptKind::User => Style::default().fg(Color::Cyan),
+                TranscriptKind::Assistant => Style::default().fg(Color::White),
+                TranscriptKind::Tool => Style::default().fg(Color::Yellow),
+                TranscriptKind::Interaction => Style::default().fg(Color::Magenta),
+                TranscriptKind::System => Style::default().fg(Color::Green),
+                TranscriptKind::Error => Style::default().fg(Color::Red),
+            };
+            let label = Span::styled(
+                format!("{} ", item.kind.label()),
+                style.add_modifier(Modifier::BOLD),
+            );
+            lines.push(Line::from(vec![label, Span::raw(item.text.clone())]));
+        }
+        if lines.is_empty() {
+            lines.push(Line::from("Start typing below."));
+        }
+
+        let paragraph = Paragraph::new(lines)
+            .block(Block::default().borders(Borders::ALL).title(title))
+            .wrap(Wrap { trim: false });
+        frame.render_widget(paragraph, area);
+    }
+
+    fn draw_interaction(&mut self, frame: &mut Frame<'_>, area: Rect) {
+        let Some(interaction) = self.state.pending_interaction.as_ref() else {
+            return;
+        };
+        frame.render_widget(Clear, area);
+
+        let title = if interaction.title.is_empty() {
+            format!("Interaction {}", interaction.id)
+        } else {
+            interaction.title.clone()
+        };
+        let body = if interaction.interaction_type == "approval" {
+            interaction_summary(interaction, None, "Press y to approve, n to deny.")
+        } else {
+            let help = if interaction.request.get("secret").and_then(Value::as_bool) == Some(true) {
+                "Enter submits. Typed secret input is masked."
+            } else {
+                "Enter submits. Alt-Enter inserts a newline."
+            };
+            interaction_summary(interaction, self.interaction_input.validation(), help)
+        };
+        let block = Block::default()
+            .borders(Borders::ALL)
+            .border_style(Style::default().fg(Color::Magenta))
+            .title(title);
+        frame.render_widget(
+            Paragraph::new(body).block(block).wrap(Wrap { trim: false }),
+            area,
+        );
+
+        if interaction.interaction_type != "approval" && area.height > 4 {
+            let input_area = Rect {
+                x: area.x + 1,
+                y: area.y + area.height.saturating_sub(3),
+                width: area.width.saturating_sub(2),
+                height: 2,
+            };
+            self.interaction_input.render(frame, input_area);
+        }
+    }
+
+    fn draw_composer(&mut self, frame: &mut Frame<'_>, area: Rect) {
+        let title = if self.state.busy {
+            format!("Message - queued {}", self.queued_messages.len())
+        } else {
+            "Message".to_string()
+        };
+        self.composer.set_block(
+            Block::default()
+                .borders(Borders::ALL)
+                .border_style(Style::default().fg(Color::Cyan))
+                .title(title),
+        );
+        frame.render_widget(&self.composer, area);
+    }
+
+    fn draw_footer(&self, frame: &mut Frame<'_>, area: Rect) {
+        let status = if self.state.busy {
+            format!(
+                "{} | Enter queue/send | Alt-Enter newline | PgUp/PgDn scroll | Ctrl-C cancel",
+                self.state.status
+            )
+        } else {
+            format!(
+                "{} | Enter send | Alt-Enter newline | PgUp/PgDn scroll | Ctrl-C clear/exit",
+                self.state.status
+            )
+        };
+        frame.render_widget(
+            Paragraph::new(status).style(Style::default().fg(Color::DarkGray)),
+            area,
+        );
+    }
+
+    fn composer_height(&self) -> u16 {
+        let lines = self.composer.lines().len().max(1) as u16;
+        lines.saturating_add(2).clamp(3, 8)
+    }
+
+    fn handle_key(&mut self, key: KeyEvent) {
+        if self.state.pending_interaction.is_some() {
+            self.handle_interaction_key(key);
+            return;
+        }
+
+        match (key.code, key.modifiers) {
+            (KeyCode::Char('c'), modifiers) if modifiers.contains(KeyModifiers::CONTROL) => {
+                self.handle_interrupt();
+            }
+            (KeyCode::PageUp, _) => self.state.scroll_up(self.transcript_visible_height),
+            (KeyCode::PageDown, _) => self.state.scroll_down(),
+            (KeyCode::Home, modifiers) if modifiers.contains(KeyModifiers::CONTROL) => {
+                self.state.scroll_to_top(self.transcript_visible_height);
+            }
+            (KeyCode::End, modifiers) if modifiers.contains(KeyModifiers::CONTROL) => {
+                self.state.scroll_to_bottom();
+            }
+            (KeyCode::Enter, modifiers) if modifiers.contains(KeyModifiers::ALT) => {
+                self.composer.insert_newline();
+            }
+            (KeyCode::Enter, _) => self.submit_composer(),
+            _ => {
+                self.composer.input(key);
+            }
+        }
+    }
+
+    fn handle_interaction_key(&mut self, key: KeyEvent) {
+        let Some(interaction) = self.state.pending_interaction.clone() else {
+            return;
+        };
+        if interaction.interaction_type == "approval" {
+            match (key.code, key.modifiers) {
+                (KeyCode::Char('c'), modifiers) if modifiers.contains(KeyModifiers::CONTROL) => {
+                    self.handle_interrupt();
+                }
+                (KeyCode::Char('y') | KeyCode::Char('Y'), _) => {
+                    self.resolve_pending_interaction(Map::from_iter([(
+                        "approved".to_string(),
+                        Value::Bool(true),
+                    )]));
+                }
+                (KeyCode::Char('n') | KeyCode::Char('N'), _) => {
+                    self.resolve_pending_interaction(Map::from_iter([(
+                        "approved".to_string(),
+                        Value::Bool(false),
+                    )]));
+                }
+                _ => {}
+            }
+            return;
+        }
+
+        match (key.code, key.modifiers) {
+            (KeyCode::Char('c'), modifiers) if modifiers.contains(KeyModifiers::CONTROL) => {
+                self.handle_interrupt();
+            }
+            (KeyCode::Enter, modifiers) if modifiers.contains(KeyModifiers::ALT) => {
+                self.interaction_input.insert_newline();
+            }
+            (KeyCode::Enter, _) => {
+                let Some(response) = self.interaction_input.response(&interaction) else {
+                    self.state.status = "A value is required.".to_string();
+                    return;
+                };
+                self.resolve_pending_interaction(Map::from_iter([(
+                    "response".to_string(),
+                    Value::String(response),
+                )]));
+                self.interaction_input = InteractionInput::default();
+            }
+            _ => {
+                self.interaction_input.input(key);
+            }
+        }
+    }
+
+    fn submit_composer(&mut self) {
+        let message = textarea_text(&self.composer);
+        let trimmed = message.trim();
+        if trimmed.is_empty() {
+            return;
+        }
+
+        match trimmed {
+            "/quit" | "/exit" => {
+                if self.state.busy {
+                    self.quit_after_turn = true;
+                    self.state
+                        .push_system("Will exit after the current turn finishes.");
+                } else {
+                    self.should_quit = true;
+                }
+            }
+            "/help" => {
+                self.state.push_system(
+                    "Commands: /help, /session, /quit. Enter sends; Alt-Enter inserts a newline.",
+                );
+            }
+            "/session" => {
+                self.state
+                    .push_system(format!("session {}", self.shell.session.id));
+            }
+            _ => self.enqueue_or_start(vec![message]),
+        }
+
+        self.composer = styled_textarea("Message");
+    }
+
+    fn enqueue_or_start(&mut self, messages: Vec<String>) {
+        self.state.push_user(messages.join("\n"));
+        if self.state.busy {
+            self.queued_messages.push_back(messages);
+            self.state.status = "queued".to_string();
+            return;
+        }
+        self.start_turn(messages);
+    }
+
+    fn start_next_queued_turn(&mut self) {
+        if self.state.busy {
+            return;
+        }
+        if self.quit_after_turn {
+            self.should_quit = true;
+            return;
+        }
+        if let Some(messages) = self.queued_messages.pop_front() {
+            self.start_turn(messages);
+        }
+    }
+
+    fn start_turn(&mut self, messages: Vec<String>) {
+        let system_messages = if self.shell.applied_system_messages {
+            Vec::new()
+        } else {
+            self.shell.system_messages.clone()
+        };
+        self.shell.applied_system_messages = true;
+        let turn_args = AgentTurnCreateArgs {
+            session_id: self.shell.session.id.clone(),
+            model: self.shell.model_override.clone(),
+            system: system_messages,
+            messages,
+            tools: self.shell.tools.clone(),
+            idempotency_key: None,
+            input: None,
+        };
+        let (command_tx, command_rx) = mpsc::channel();
+        let worker = spawn_turn_worker(
+            self.client.clone(),
+            turn_args,
+            self.worker_tx.clone(),
+            command_rx,
+        );
+        self.worker = Some(TurnWorker {
+            command_tx,
+            handle: Some(worker),
+        });
+        self.state.start_turn();
+    }
+
+    fn drain_worker_events(&mut self) {
+        loop {
+            match self.worker_rx.try_recv() {
+                Ok(event) => self.handle_worker_event(event),
+                Err(TryRecvError::Empty) => break,
+                Err(TryRecvError::Disconnected) => break,
+            }
+        }
+    }
+
+    fn handle_worker_event(&mut self, event: WorkerEvent) {
+        match event {
+            WorkerEvent::TurnCreated(turn) => {
+                self.state.current_turn_id = Some(turn.id.clone());
+                self.state.status = turn_status_label(&turn);
+            }
+            WorkerEvent::TurnEvent(event) => self.state.apply_turn_event(event),
+            WorkerEvent::TurnSnapshot(turn) => self.state.finish_turn(&turn),
+            WorkerEvent::WaitingForInput(interaction) => {
+                self.interaction_input = InteractionInput::for_interaction(&interaction);
+                self.state.wait_for_interaction(interaction);
+            }
+            WorkerEvent::InteractionResolved(interaction) => {
+                let _ = interaction;
+                self.state.status = "interaction resolved".to_string();
+                self.state.pending_interaction = None;
+            }
+            WorkerEvent::Error(message) => {
+                self.state.push_error(message);
+                self.state.finish_worker();
+                self.worker = None;
+            }
+            WorkerEvent::Done => {
+                self.join_worker();
+                self.state.finish_worker();
+            }
+        }
+    }
+
+    fn resolve_pending_interaction(&mut self, resolution: Map<String, Value>) {
+        let Some(interaction) = self.state.pending_interaction.as_ref() else {
+            return;
+        };
+        if let Some(worker) = self.worker.as_ref() {
+            let sent = worker.command_tx.send(WorkerCommand::Resolve {
+                interaction_id: interaction.id.clone(),
+                resolution,
+            });
+            if sent.is_err() {
+                self.state
+                    .push_error("failed to send interaction resolution".to_string());
+            } else {
+                self.state.status = "resolving interaction".to_string();
+            }
+        }
+    }
+
+    fn handle_interrupt(&mut self) {
+        if self.state.busy {
+            if let Some(worker) = self.worker.as_ref() {
+                let _ = worker.command_tx.send(WorkerCommand::Cancel);
+            }
+            if let Some(turn_id) = self.state.current_turn_id.clone() {
+                let client = self.client.clone();
+                thread::spawn(move || {
+                    let _ = cancel_turn_silent(&client, &turn_id, INTERRUPT_CANCEL_REASON);
+                });
+            }
+            self.state.status = "cancel requested".to_string();
+            self.state.push_system("Cancel requested.");
+        } else if !textarea_text(&self.composer).is_empty() {
+            self.composer = styled_textarea("Message");
+        } else {
+            self.should_quit = true;
+        }
+    }
+
+    fn join_worker(&mut self) {
+        if let Some(mut worker) = self.worker.take()
+            && let Some(handle) = worker.handle.take()
+        {
+            let _ = handle.join();
+        }
+    }
+}
+
+fn styled_textarea(title: &'static str) -> TextArea<'static> {
+    let mut textarea = TextArea::default();
+    textarea.set_cursor_line_style(Style::default());
+    textarea.set_block(Block::default().borders(Borders::ALL).title(title));
+    textarea
+}
+
+struct InteractionInput {
+    textarea: TextArea<'static>,
+    secret: String,
+    is_secret: bool,
+    validation: Option<String>,
+}
+
+impl Default for InteractionInput {
+    fn default() -> Self {
+        Self {
+            textarea: styled_textarea("Response"),
+            secret: String::new(),
+            is_secret: false,
+            validation: None,
+        }
+    }
+}
+
+impl InteractionInput {
+    fn for_interaction(interaction: &AgentInteractionInfo) -> Self {
+        let is_secret = interaction
+            .request
+            .get("secret")
+            .and_then(Value::as_bool)
+            .unwrap_or(false);
+        let mut input = Self {
+            is_secret,
+            ..Self::default()
+        };
+        if !is_secret
+            && let Some(default) = interaction.request.get("default").and_then(Value::as_str)
+        {
+            input.textarea.insert_str(default);
+        }
+        input
+    }
+
+    fn render(&mut self, frame: &mut Frame<'_>, area: Rect) {
+        if self.is_secret {
+            let masked = if self.secret.is_empty() {
+                "Value hidden".to_string()
+            } else {
+                "*".repeat(self.secret.chars().count())
+            };
+            let paragraph = Paragraph::new(masked)
+                .block(Block::default().borders(Borders::TOP).title("Secret"));
+            frame.render_widget(paragraph, area);
+        } else {
+            self.textarea
+                .set_block(Block::default().borders(Borders::TOP).title("Response"));
+            frame.render_widget(&self.textarea, area);
+        }
+    }
+
+    fn input(&mut self, key: KeyEvent) {
+        self.validation = None;
+        if self.is_secret {
+            match key.code {
+                KeyCode::Char(ch)
+                    if !key.modifiers.contains(KeyModifiers::CONTROL)
+                        && !key.modifiers.contains(KeyModifiers::ALT) =>
+                {
+                    self.secret.push(ch);
+                }
+                KeyCode::Backspace => {
+                    self.secret.pop();
+                }
+                _ => {}
+            }
+        } else {
+            self.textarea.input(key);
+        }
+    }
+
+    fn insert_newline(&mut self) {
+        self.validation = None;
+        if !self.is_secret {
+            self.textarea.insert_newline();
+        }
+    }
+
+    fn response(&mut self, interaction: &AgentInteractionInfo) -> Option<String> {
+        let value = if self.is_secret {
+            self.secret.clone()
+        } else {
+            textarea_text(&self.textarea)
+        };
+        let trimmed = value.trim().to_string();
+        if trimmed.is_empty() {
+            if let Some(default) = interaction.request.get("default").and_then(Value::as_str) {
+                self.validation = None;
+                return Some(default.to_string());
+            }
+            let required = interaction
+                .request
+                .get("required")
+                .and_then(Value::as_bool)
+                .unwrap_or(true);
+            if required {
+                self.validation = Some("A value is required.".to_string());
+                return None;
+            }
+            self.validation = None;
+            return Some(String::new());
+        }
+        self.validation = None;
+        Some(trimmed)
+    }
+
+    fn validation(&self) -> Option<&str> {
+        self.validation.as_deref()
+    }
+}
+
+fn textarea_text(textarea: &TextArea<'_>) -> String {
+    textarea.lines().join("\n")
+}
+
+fn interaction_summary(
+    interaction: &AgentInteractionInfo,
+    validation: Option<&str>,
+    help: &str,
+) -> Vec<Line<'static>> {
+    let mut lines = Vec::new();
+    if !interaction.prompt.is_empty() {
+        lines.push(Line::from(interaction.prompt.clone()));
+    }
+    if !interaction.request.is_empty()
+        && let Ok(request) = compact_json(&Value::Object(interaction.request.clone()))
+    {
+        lines.push(Line::from(format!("Request: {request}")));
+    }
+    if let Some(validation) = validation {
+        lines.push(Line::from(Span::styled(
+            validation.to_string(),
+            Style::default().fg(Color::Red),
+        )));
+    }
+    lines.push(Line::from(""));
+    lines.push(Line::from(help.to_string()));
+    lines
+}

--- a/gestalt/cli/src/commands/agents/tui/state.rs
+++ b/gestalt/cli/src/commands/agents/tui/state.rs
@@ -1,0 +1,386 @@
+use serde_json::Value;
+
+use super::super::{
+    AgentInteractionInfo, AgentSessionInfo, AgentTurnEventInfo, AgentTurnInfo, compact_json,
+    pretty_json, string_any_field, string_field, value_any_field,
+};
+
+const MAX_TRANSCRIPT_ITEMS: usize = 500;
+
+pub(super) struct AgentUiState {
+    pub(super) session_id: String,
+    pub(super) provider: String,
+    pub(super) model: String,
+    pub(super) status: String,
+    pub(super) busy: bool,
+    pub(super) current_turn_id: Option<String>,
+    pub(super) pending_interaction: Option<AgentInteractionInfo>,
+    transcript: Vec<TranscriptItem>,
+    assistant_buffer: String,
+    saw_assistant_output: bool,
+    saw_structured_output: bool,
+    scroll_offset: usize,
+}
+
+impl AgentUiState {
+    pub(super) fn new(session: &AgentSessionInfo) -> Self {
+        let model = if session.model.is_empty() {
+            "<unspecified>".to_string()
+        } else {
+            session.model.clone()
+        };
+        Self {
+            session_id: session.id.clone(),
+            provider: session.provider.clone(),
+            model,
+            status: "ready".to_string(),
+            busy: false,
+            current_turn_id: None,
+            pending_interaction: None,
+            transcript: Vec::new(),
+            assistant_buffer: String::new(),
+            saw_assistant_output: false,
+            saw_structured_output: false,
+            scroll_offset: 0,
+        }
+    }
+
+    pub(super) fn start_turn(&mut self) {
+        self.finish_assistant_stream();
+        self.busy = true;
+        self.current_turn_id = None;
+        self.pending_interaction = None;
+        self.status = "starting turn".to_string();
+        self.saw_assistant_output = false;
+        self.saw_structured_output = false;
+    }
+
+    pub(super) fn finish_worker(&mut self) {
+        self.busy = false;
+        self.current_turn_id = None;
+        self.pending_interaction = None;
+        if self.status != "queued" {
+            self.status = "ready".to_string();
+        }
+    }
+
+    pub(super) fn apply_turn_event(&mut self, event: AgentTurnEventInfo) {
+        match event.event_type.as_str() {
+            "agent.message.delta" | "assistant.delta" => {
+                if let Some(text) = string_any_field(&event.data, &["text", "delta", "content"]) {
+                    self.push_assistant_delta(&text);
+                }
+            }
+            "assistant.completed" => {
+                if let Some(text) = string_field(&event.data, "text") {
+                    self.complete_assistant(&text);
+                } else {
+                    self.assistant_buffer.clear();
+                }
+            }
+            "turn.started" => {
+                self.status = string_any_field(&event.data, &["status", "state"])
+                    .map(|status| format!("turn {status}"))
+                    .unwrap_or_else(|| "turn started".to_string());
+            }
+            "tool.started" => {
+                let tool = event_tool_name(&event);
+                let suffix = value_any_field(&event.data, &["arguments", "input", "request"])
+                    .and_then(|value| compact_json(value).ok())
+                    .map(|value| format!(" {value}"))
+                    .unwrap_or_default();
+                self.push_tool(format!("{tool} started{suffix}"));
+                self.status = format!("{tool} running");
+            }
+            "tool.completed" => {
+                let tool = event_tool_name(&event);
+                let status = string_any_field(&event.data, &["status", "state"]).or_else(|| {
+                    event
+                        .data
+                        .get("statusCode")
+                        .and_then(Value::as_i64)
+                        .map(|v| v.to_string())
+                });
+                let mut text = match status {
+                    Some(status) => format!("{tool} completed ({status})"),
+                    None => format!("{tool} completed"),
+                };
+                if let Some(error) = string_field(&event.data, "error") {
+                    text.push_str(&format!(": {error}"));
+                } else if let Some(output) =
+                    value_any_field(&event.data, &["output", "result", "body"])
+                    && let Ok(encoded) = compact_json(output)
+                {
+                    text.push(' ');
+                    text.push_str(&encoded);
+                }
+                self.push_tool(text);
+                self.status = "tool completed".to_string();
+            }
+            "interaction.requested" => {
+                let id = string_any_field(&event.data, &["interaction_id", "interactionId"])
+                    .unwrap_or_else(|| "interaction".to_string());
+                self.push_interaction(format!("requested {id}"));
+                self.status = "waiting for input".to_string();
+            }
+            "interaction.resolved" => {
+                let id = string_any_field(&event.data, &["interaction_id", "interactionId"])
+                    .unwrap_or_else(|| "interaction".to_string());
+                self.push_interaction(format!("resolved {id}"));
+                self.status = "interaction resolved".to_string();
+            }
+            "turn.failed" => {
+                if let Some(message) = string_field(&event.data, "error") {
+                    self.push_error(format!("turn failed: {message}"));
+                }
+            }
+            "turn.canceled" => {
+                if let Some(reason) = string_field(&event.data, "reason") {
+                    self.push_system(format!("turn canceled: {reason}"));
+                } else {
+                    self.push_system("turn canceled");
+                }
+            }
+            "turn.completed" => {}
+            _ if event.visibility == "private" => {}
+            _ => self.push_system(generic_event_text(&event)),
+        }
+    }
+
+    pub(super) fn finish_turn(&mut self, turn: &AgentTurnInfo) {
+        let terminal = matches!(turn.status.as_str(), "succeeded" | "failed" | "canceled");
+        match turn.status.as_str() {
+            "succeeded" if !turn.output_text.is_empty() => {
+                if !self.assistant_buffer.is_empty() {
+                    let output_text = turn.output_text.clone();
+                    self.complete_assistant(&output_text);
+                } else if !self.saw_assistant_output {
+                    self.push_assistant(turn.output_text.clone());
+                }
+            }
+            "failed" if !turn.status_message.is_empty() => {
+                self.push_error(format!("turn failed: {}", turn.status_message));
+            }
+            "canceled" if !turn.status_message.is_empty() => {
+                self.push_system(format!("turn canceled: {}", turn.status_message));
+            }
+            _ => {}
+        }
+        if terminal {
+            self.finish_assistant_stream();
+        }
+        if !self.saw_structured_output
+            && let Some(structured_output) = turn.structured_output.as_ref()
+            && let Ok(text) = pretty_json(structured_output)
+            && terminal
+        {
+            self.push_system(format!("structured output\n{text}"));
+            self.saw_structured_output = true;
+        }
+        self.status = turn_status_label(turn);
+    }
+
+    pub(super) fn wait_for_interaction(&mut self, interaction: AgentInteractionInfo) {
+        self.status = "waiting for input".to_string();
+        self.pending_interaction = Some(interaction);
+    }
+
+    pub(super) fn push_user(&mut self, text: String) {
+        self.push(TranscriptKind::User, text);
+    }
+
+    fn push_assistant(&mut self, text: String) {
+        self.saw_assistant_output = true;
+        self.push(TranscriptKind::Assistant, text);
+    }
+
+    fn push_assistant_delta(&mut self, text: &str) {
+        self.saw_assistant_output = true;
+        self.assistant_buffer.push_str(text);
+        if let Some(last) = self.transcript.last_mut()
+            && last.kind == TranscriptKind::Assistant
+            && last.streaming
+        {
+            last.text.push_str(text);
+            return;
+        }
+        self.push_streaming(TranscriptKind::Assistant, text.to_string());
+    }
+
+    fn complete_assistant(&mut self, text: &str) {
+        self.saw_assistant_output = true;
+        if let Some(last) = self.transcript.last_mut()
+            && last.kind == TranscriptKind::Assistant
+            && last.streaming
+        {
+            if self.assistant_buffer.is_empty() {
+                last.text.push_str(text);
+            } else if let Some(suffix) = text.strip_prefix(&self.assistant_buffer) {
+                last.text.push_str(suffix);
+            }
+            last.streaming = false;
+            self.assistant_buffer.clear();
+            return;
+        }
+        self.push_assistant(text.to_string());
+        self.assistant_buffer.clear();
+    }
+
+    fn finish_assistant_stream(&mut self) {
+        for item in &mut self.transcript {
+            if item.kind == TranscriptKind::Assistant {
+                item.streaming = false;
+            }
+        }
+        self.assistant_buffer.clear();
+    }
+
+    fn push_tool(&mut self, text: String) {
+        self.push(TranscriptKind::Tool, text);
+    }
+
+    pub(super) fn push_interaction(&mut self, text: String) {
+        self.push(TranscriptKind::Interaction, text);
+    }
+
+    pub(super) fn push_system(&mut self, text: impl Into<String>) {
+        self.push(TranscriptKind::System, text.into());
+    }
+
+    pub(super) fn push_error(&mut self, text: String) {
+        self.push(TranscriptKind::Error, text);
+    }
+
+    fn push(&mut self, kind: TranscriptKind, text: String) {
+        self.transcript.push(TranscriptItem {
+            kind,
+            text,
+            streaming: false,
+        });
+        self.trim_transcript();
+    }
+
+    fn push_streaming(&mut self, kind: TranscriptKind, text: String) {
+        self.transcript.push(TranscriptItem {
+            kind,
+            text,
+            streaming: true,
+        });
+        self.trim_transcript();
+    }
+
+    fn trim_transcript(&mut self) {
+        if self.transcript.len() > MAX_TRANSCRIPT_ITEMS {
+            let remove = self.transcript.len() - MAX_TRANSCRIPT_ITEMS;
+            self.transcript.drain(0..remove);
+        }
+    }
+
+    pub(super) fn visible_transcript(&self, height: usize) -> &[TranscriptItem] {
+        let visible = height.max(1);
+        let offset = self.scroll_offset.min(self.max_scroll_offset(visible));
+        let end = self.transcript.len().saturating_sub(offset);
+        let start = end.saturating_sub(visible);
+        &self.transcript[start..end]
+    }
+
+    pub(super) fn scroll_up(&mut self, height: usize) {
+        self.scroll_offset = self
+            .scroll_offset
+            .saturating_add(5)
+            .min(self.max_scroll_offset(height));
+    }
+
+    pub(super) fn scroll_down(&mut self) {
+        self.scroll_offset = self.scroll_offset.saturating_sub(5);
+    }
+
+    pub(super) fn scroll_to_top(&mut self, height: usize) {
+        self.scroll_offset = self.max_scroll_offset(height);
+    }
+
+    pub(super) fn scroll_to_bottom(&mut self) {
+        self.scroll_offset = 0;
+    }
+
+    fn max_scroll_offset(&self, height: usize) -> usize {
+        self.transcript.len().saturating_sub(height.max(1))
+    }
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub(super) enum TranscriptKind {
+    User,
+    Assistant,
+    Tool,
+    Interaction,
+    System,
+    Error,
+}
+
+impl TranscriptKind {
+    pub(super) fn label(self) -> &'static str {
+        match self {
+            Self::User => "you>",
+            Self::Assistant => "assistant>",
+            Self::Tool => "tool>",
+            Self::Interaction => "interaction>",
+            Self::System => "system>",
+            Self::Error => "error>",
+        }
+    }
+}
+
+pub(super) struct TranscriptItem {
+    pub(super) kind: TranscriptKind,
+    pub(super) text: String,
+    streaming: bool,
+}
+
+fn event_tool_name(event: &AgentTurnEventInfo) -> String {
+    string_any_field(
+        &event.data,
+        &[
+            "tool_name",
+            "toolName",
+            "name",
+            "operation",
+            "tool_id",
+            "toolId",
+        ],
+    )
+    .unwrap_or_else(|| "tool".to_string())
+}
+
+fn generic_event_text(event: &AgentTurnEventInfo) -> String {
+    let mut fields = Vec::new();
+    if !event.id.is_empty() {
+        fields.push(format!("id={}", event.id));
+    }
+    if !event.source.is_empty() {
+        fields.push(format!("source={}", event.source));
+    }
+    if !event.turn_id.is_empty() {
+        fields.push(format!("turn={}", event.turn_id));
+    }
+    let suffix = if fields.is_empty() {
+        String::new()
+    } else {
+        format!(" ({})", fields.join(" "))
+    };
+    if event.data.is_empty() {
+        format!("{}{}", event.event_type, suffix)
+    } else {
+        compact_json(&Value::Object(event.data.clone()))
+            .map(|data| format!("{}{} {}", event.event_type, suffix, data))
+            .unwrap_or_else(|_| format!("{}{}", event.event_type, suffix))
+    }
+}
+
+pub(super) fn turn_status_label(turn: &AgentTurnInfo) -> String {
+    if turn.status.is_empty() {
+        "running".to_string()
+    } else {
+        turn.status.clone()
+    }
+}

--- a/gestalt/cli/src/commands/agents/tui/worker.rs
+++ b/gestalt/cli/src/commands/agents/tui/worker.rs
@@ -1,0 +1,170 @@
+use std::sync::mpsc::{Receiver, Sender, TryRecvError};
+use std::thread;
+use std::time::Duration;
+
+use anyhow::{Context, Result, anyhow};
+use serde_json::{Map, Value};
+
+use crate::api::ApiClient;
+use crate::cli::AgentTurnCreateArgs;
+
+use super::super::{
+    AgentInteractionInfo, AgentTurnEventInfo, AgentTurnInfo, INTERRUPT_CANCEL_REASON,
+    cancel_turn_silent, create_turn_info, get_turn_info, list_interactions_info,
+    resolve_interaction_info, stream_turn_event_frames,
+};
+
+pub(super) struct TurnWorker {
+    pub(super) command_tx: Sender<WorkerCommand>,
+    pub(super) handle: Option<thread::JoinHandle<()>>,
+}
+
+pub(super) enum WorkerCommand {
+    Resolve {
+        interaction_id: String,
+        resolution: Map<String, Value>,
+    },
+    Cancel,
+}
+
+pub(super) enum WorkerEvent {
+    TurnCreated(AgentTurnInfo),
+    TurnEvent(AgentTurnEventInfo),
+    TurnSnapshot(AgentTurnInfo),
+    WaitingForInput(AgentInteractionInfo),
+    InteractionResolved(AgentInteractionInfo),
+    Error(String),
+    Done,
+}
+
+pub(super) fn spawn_turn_worker(
+    client: ApiClient,
+    turn_args: AgentTurnCreateArgs,
+    event_tx: Sender<WorkerEvent>,
+    command_rx: Receiver<WorkerCommand>,
+) -> thread::JoinHandle<()> {
+    thread::spawn(move || {
+        let result = run_turn_worker(&client, turn_args, &event_tx, &command_rx);
+        if let Err(err) = result {
+            let _ = event_tx.send(WorkerEvent::Error(err.to_string()));
+        }
+        let _ = event_tx.send(WorkerEvent::Done);
+    })
+}
+
+fn run_turn_worker(
+    client: &ApiClient,
+    turn_args: AgentTurnCreateArgs,
+    event_tx: &Sender<WorkerEvent>,
+    command_rx: &Receiver<WorkerCommand>,
+) -> Result<()> {
+    let turn = create_turn_info(client, &turn_args)?;
+    let turn_id = turn.id.clone();
+    event_tx
+        .send(WorkerEvent::TurnCreated(turn))
+        .context("terminal UI closed before turn started")?;
+    if consume_cancel(client, &turn_id, command_rx) {
+        return Ok(());
+    }
+
+    let mut after_seq = 0;
+    loop {
+        stream_turn_event_frames(client, &turn_id, after_seq, |event| {
+            if event.seq > 0 {
+                after_seq = after_seq.max(event.seq as u64);
+            }
+            event_tx
+                .send(WorkerEvent::TurnEvent(event))
+                .context("terminal UI closed while streaming events")
+        })?;
+
+        if consume_cancel(client, &turn_id, command_rx) {
+            return Ok(());
+        }
+
+        let latest = get_turn_info(client, &turn_id)?;
+        event_tx
+            .send(WorkerEvent::TurnSnapshot(latest.clone()))
+            .context("terminal UI closed before turn snapshot")?;
+
+        match latest.status.as_str() {
+            "waiting_for_input" => {
+                let interactions = list_interactions_info(client, &turn_id)?;
+                let pending: Vec<_> = interactions
+                    .into_iter()
+                    .filter(|interaction| interaction.state == "pending")
+                    .collect();
+                if pending.is_empty() {
+                    return Err(anyhow!(
+                        "agent turn {} is waiting for input without a pending interaction",
+                        latest.id
+                    ));
+                }
+                for interaction in pending {
+                    event_tx
+                        .send(WorkerEvent::WaitingForInput(interaction.clone()))
+                        .context("terminal UI closed before interaction prompt")?;
+                    wait_for_interaction_resolution(
+                        client,
+                        &turn_id,
+                        interaction,
+                        command_rx,
+                        event_tx,
+                    )?;
+                }
+            }
+            "pending" | "running" => thread::sleep(Duration::from_millis(250)),
+            "succeeded" | "failed" | "canceled" => return Ok(()),
+            other => {
+                return Err(anyhow!(
+                    "agent turn {} has unsupported status {}",
+                    latest.id,
+                    other
+                ));
+            }
+        }
+    }
+}
+
+fn consume_cancel(client: &ApiClient, turn_id: &str, command_rx: &Receiver<WorkerCommand>) -> bool {
+    match command_rx.try_recv() {
+        Ok(WorkerCommand::Cancel) => {
+            let _ = cancel_turn_silent(client, turn_id, INTERRUPT_CANCEL_REASON);
+            true
+        }
+        Ok(WorkerCommand::Resolve { .. }) => false,
+        Err(TryRecvError::Empty | TryRecvError::Disconnected) => false,
+    }
+}
+
+fn wait_for_interaction_resolution(
+    client: &ApiClient,
+    turn_id: &str,
+    interaction: AgentInteractionInfo,
+    command_rx: &Receiver<WorkerCommand>,
+    event_tx: &Sender<WorkerEvent>,
+) -> Result<()> {
+    loop {
+        match command_rx
+            .recv()
+            .context("terminal UI closed before resolving interaction")?
+        {
+            WorkerCommand::Cancel => {
+                let _ = cancel_turn_silent(client, turn_id, INTERRUPT_CANCEL_REASON);
+                return Ok(());
+            }
+            WorkerCommand::Resolve {
+                interaction_id,
+                resolution,
+            } if interaction_id == interaction.id => {
+                let resolved =
+                    resolve_interaction_info(client, turn_id, &interaction.id, resolution)?;
+                event_tx
+                    .send(WorkerEvent::InteractionResolved(resolved))
+                    .context("terminal UI closed after resolving interaction")?;
+                return Ok(());
+            }
+            WorkerCommand::Resolve { .. } => {}
+        }
+    }
+}

--- a/gestalt/cli/tests/agents_cli.rs
+++ b/gestalt/cli/tests/agents_cli.rs
@@ -2,9 +2,10 @@ mod support;
 
 use serde_json::Value;
 use std::collections::VecDeque;
-use std::io::{BufRead, BufReader, Read};
+use std::io::{BufRead, BufReader, Read, Write};
 use std::net::{TcpListener, TcpStream};
-use std::sync::{Arc, Mutex};
+use std::sync::{Arc, Mutex, mpsc};
+use std::time::{Duration, Instant};
 use support::*;
 
 const SESSION_JSON: &str = r#"{
@@ -390,6 +391,310 @@ fn test_cli_runs_interactive_agent_session() {
         .stderr(predicate::str::contains("Type /quit to exit."));
 }
 
+#[cfg(unix)]
+#[test]
+fn test_cli_runs_tty_agent_session_with_full_screen_ui() {
+    let server = ScriptedServer::spawn(vec![
+        ExpectedRequest::json(
+            Method::POST,
+            "/api/v1/agent/sessions",
+            r#"{"provider":"managed","model":"gpt-5.4"}"#,
+            StatusCode::CREATED,
+            http::APPLICATION_JSON,
+            SESSION_JSON,
+        ),
+        ExpectedRequest::json(
+            Method::POST,
+            "/api/v1/agent/sessions/session-1/turns",
+            r#"{"model":"gpt-5.4","messages":[{"role":"user","text":"hello tui"}]}"#,
+            StatusCode::CREATED,
+            http::APPLICATION_JSON,
+            r#"{
+                "id":"turn-tty",
+                "sessionId":"session-1",
+                "provider":"managed",
+                "model":"gpt-5.4",
+                "status":"running"
+            }"#,
+        ),
+        ExpectedRequest::text(
+            Method::GET,
+            "/api/v1/agent/turns/turn-tty/events/stream?after=0&limit=100&until=blocked_or_terminal",
+            StatusCode::OK,
+            "text/event-stream",
+            "data: {\"seq\":1,\"type\":\"agent.message.delta\",\"data\":{\"text\":\"hello\"}}\n\n\
+             data: {\"seq\":2,\"type\":\"turn.completed\",\"data\":{\"status\":\"succeeded\"}}\n\n",
+        ),
+        ExpectedRequest::text(
+            Method::GET,
+            "/api/v1/agent/turns/turn-tty",
+            StatusCode::OK,
+            http::APPLICATION_JSON,
+            r#"{
+                "id":"turn-tty",
+                "sessionId":"session-1",
+                "provider":"managed",
+                "model":"gpt-5.4",
+                "status":"succeeded",
+                "outputText":"hello from tui"
+            }"#,
+        ),
+    ]);
+
+    let home = tempfile::tempdir().unwrap();
+    let mut session = spawn_tty_cli(
+        home.path(),
+        server.url(),
+        &["agent", "--provider", "managed", "--model", "gpt-5.4"],
+    );
+    let mut output = String::new();
+    session.wait_for(&mut output, "\x1b[?1049h");
+    session.wait_for(&mut output, "Session");
+    session.write("hello tui\r");
+    session.wait_for(&mut output, "assistant>");
+    session.wait_for(&mut output, "hello");
+    session.write("/quit\r");
+    session.wait_for_exit();
+
+    server.assert_finished();
+}
+
+#[cfg(unix)]
+#[test]
+fn test_cli_tty_turn_boundary_stops_stale_streaming_transcript_item() {
+    let server = ScriptedServer::spawn(vec![
+        ExpectedRequest::json(
+            Method::POST,
+            "/api/v1/agent/sessions",
+            r#"{"provider":"managed","model":"gpt-5.4"}"#,
+            StatusCode::CREATED,
+            http::APPLICATION_JSON,
+            SESSION_JSON,
+        ),
+        ExpectedRequest::json(
+            Method::POST,
+            "/api/v1/agent/sessions/session-1/turns",
+            r#"{"model":"gpt-5.4","messages":[{"role":"user","text":"first turn"}]}"#,
+            StatusCode::CREATED,
+            http::APPLICATION_JSON,
+            r#"{
+                "id":"turn-first",
+                "sessionId":"session-1",
+                "provider":"managed",
+                "model":"gpt-5.4",
+                "status":"running"
+            }"#,
+        ),
+        ExpectedRequest::text(
+            Method::GET,
+            "/api/v1/agent/turns/turn-first/events/stream?after=0&limit=100&until=blocked_or_terminal",
+            StatusCode::OK,
+            "text/event-stream",
+            "data: {\"seq\":1,\"type\":\"assistant.delta\",\"data\":{\"text\":\"alpha\"}}\n\n\
+             data: {\"seq\":2,\"type\":\"turn.failed\",\"data\":{}}\n\n",
+        ),
+        ExpectedRequest::text(
+            Method::GET,
+            "/api/v1/agent/turns/turn-first",
+            StatusCode::OK,
+            http::APPLICATION_JSON,
+            r#"{
+                "id":"turn-first",
+                "sessionId":"session-1",
+                "provider":"managed",
+                "model":"gpt-5.4",
+                "status":"failed"
+            }"#,
+        ),
+        ExpectedRequest::json(
+            Method::POST,
+            "/api/v1/agent/sessions/session-1/turns",
+            r#"{"model":"gpt-5.4","messages":[{"role":"user","text":"second turn"}]}"#,
+            StatusCode::CREATED,
+            http::APPLICATION_JSON,
+            r#"{
+                "id":"turn-second",
+                "sessionId":"session-1",
+                "provider":"managed",
+                "model":"gpt-5.4",
+                "status":"running"
+            }"#,
+        ),
+        ExpectedRequest::text(
+            Method::GET,
+            "/api/v1/agent/turns/turn-second/events/stream?after=0&limit=100&until=blocked_or_terminal",
+            StatusCode::OK,
+            "text/event-stream",
+            "data: {\"seq\":1,\"type\":\"assistant.delta\",\"data\":{\"text\":\"beta\"}}\n\n\
+             data: {\"seq\":2,\"type\":\"turn.completed\",\"data\":{\"status\":\"succeeded\"}}\n\n",
+        ),
+        ExpectedRequest::text(
+            Method::GET,
+            "/api/v1/agent/turns/turn-second",
+            StatusCode::OK,
+            http::APPLICATION_JSON,
+            r#"{
+                "id":"turn-second",
+                "sessionId":"session-1",
+                "provider":"managed",
+                "model":"gpt-5.4",
+                "status":"succeeded",
+                "outputText":"beta"
+            }"#,
+        ),
+    ]);
+
+    let home = tempfile::tempdir().unwrap();
+    let mut session = spawn_tty_cli(
+        home.path(),
+        server.url(),
+        &["agent", "--provider", "managed", "--model", "gpt-5.4"],
+    );
+    let mut output = String::new();
+    session.wait_for(&mut output, "Session");
+    session.write("first turn\r");
+    session.wait_for(&mut output, "alpha");
+    session.write("second turn\r");
+    session.wait_for(&mut output, "beta");
+    session.write("/quit\r");
+    session.wait_for_exit();
+
+    assert!(
+        !output.contains("alphabeta"),
+        "assistant output from separate turns was merged:\n{output}"
+    );
+    server.assert_finished();
+}
+
+#[cfg(unix)]
+#[test]
+fn test_cli_tty_secret_interaction_masks_and_requires_input() {
+    let server = ScriptedServer::spawn(vec![
+        ExpectedRequest::json(
+            Method::POST,
+            "/api/v1/agent/sessions",
+            r#"{"provider":"managed","model":"gpt-5.4"}"#,
+            StatusCode::CREATED,
+            http::APPLICATION_JSON,
+            SESSION_JSON,
+        ),
+        ExpectedRequest::json(
+            Method::POST,
+            "/api/v1/agent/sessions/session-1/turns",
+            r#"{"model":"gpt-5.4","messages":[{"role":"user","text":"needs secret"}]}"#,
+            StatusCode::CREATED,
+            http::APPLICATION_JSON,
+            r#"{
+                "id":"turn-secret",
+                "sessionId":"session-1",
+                "provider":"managed",
+                "model":"gpt-5.4",
+                "status":"running"
+            }"#,
+        ),
+        ExpectedRequest::text(
+            Method::GET,
+            "/api/v1/agent/turns/turn-secret/events/stream?after=0&limit=100&until=blocked_or_terminal",
+            StatusCode::OK,
+            "text/event-stream",
+            "data: {\"seq\":1,\"type\":\"turn.started\",\"data\":{\"status\":\"running\"}}\n\n\
+             data: {\"seq\":2,\"type\":\"interaction.requested\",\"data\":{\"interaction_id\":\"interaction-secret\"}}\n\n",
+        ),
+        ExpectedRequest::text(
+            Method::GET,
+            "/api/v1/agent/turns/turn-secret",
+            StatusCode::OK,
+            http::APPLICATION_JSON,
+            r#"{
+                "id":"turn-secret",
+                "sessionId":"session-1",
+                "provider":"managed",
+                "model":"gpt-5.4",
+                "status":"waiting_for_input",
+                "statusMessage":"waiting for input"
+            }"#,
+        ),
+        ExpectedRequest::text(
+            Method::GET,
+            "/api/v1/agent/turns/turn-secret/interactions",
+            StatusCode::OK,
+            http::APPLICATION_JSON,
+            r#"[
+                {
+                    "id":"interaction-secret",
+                    "turnId":"turn-secret",
+                    "type":"input",
+                    "state":"pending",
+                    "title":"API token",
+                    "prompt":"Enter the deployment token.",
+                    "request":{"required":true,"secret":true}
+                }
+            ]"#,
+        ),
+        ExpectedRequest::json(
+            Method::POST,
+            "/api/v1/agent/turns/turn-secret/interactions/interaction-secret/resolve",
+            r#"{"resolution":{"response":"supersecret"}}"#,
+            StatusCode::OK,
+            http::APPLICATION_JSON,
+            r#"{
+                "id":"interaction-secret",
+                "turnId":"turn-secret",
+                "type":"input",
+                "state":"resolved",
+                "resolution":{"response":"supersecret"}
+            }"#,
+        ),
+        ExpectedRequest::text(
+            Method::GET,
+            "/api/v1/agent/turns/turn-secret/events/stream?after=2&limit=100&until=blocked_or_terminal",
+            StatusCode::OK,
+            "text/event-stream",
+            "data: {\"seq\":3,\"type\":\"interaction.resolved\",\"data\":{\"interaction_id\":\"interaction-secret\"}}\n\n\
+             data: {\"seq\":4,\"type\":\"assistant.completed\",\"data\":{\"text\":\"token accepted\"}}\n\n\
+             data: {\"seq\":5,\"type\":\"turn.completed\",\"data\":{\"status\":\"succeeded\"}}\n\n",
+        ),
+        ExpectedRequest::text(
+            Method::GET,
+            "/api/v1/agent/turns/turn-secret",
+            StatusCode::OK,
+            http::APPLICATION_JSON,
+            r#"{
+                "id":"turn-secret",
+                "sessionId":"session-1",
+                "provider":"managed",
+                "model":"gpt-5.4",
+                "status":"succeeded",
+                "outputText":"token accepted"
+            }"#,
+        ),
+    ]);
+
+    let home = tempfile::tempdir().unwrap();
+    let mut session = spawn_tty_cli(
+        home.path(),
+        server.url(),
+        &["agent", "--provider", "managed", "--model", "gpt-5.4"],
+    );
+    let mut output = String::new();
+    session.wait_for(&mut output, "Session");
+    session.write("needs secret\r");
+    session.wait_for(&mut output, "API token");
+    session.write("\r");
+    session.wait_for(&mut output, "A value is required.");
+    session.write("supersecret\r");
+    session.wait_for(&mut output, "assistant>");
+    session.wait_for(&mut output, "accepted");
+    session.write("/quit\r");
+    session.wait_for_exit();
+
+    assert!(
+        !output.contains("supersecret"),
+        "secret input was rendered in TTY output:\n{output}"
+    );
+    server.assert_finished();
+}
+
 #[test]
 fn test_cli_resumes_latest_active_agent_session() {
     let server = ScriptedServer::spawn(vec![
@@ -527,7 +832,8 @@ fn test_cli_agent_help_describes_resume_provider_filter() {
         .success()
         .stdout(predicate::str::contains("--resume"))
         .stdout(predicate::str::contains("--continue"))
-        .stdout(predicate::str::contains("provider filter when resuming"));
+        .stdout(predicate::str::contains("provider filter when resuming"))
+        .stdout(predicate::str::contains("--ui").not());
 }
 
 #[test]
@@ -914,6 +1220,114 @@ struct ScriptedHttpRequest {
     target: String,
     authorization: Option<String>,
     body: Vec<u8>,
+}
+
+#[cfg(unix)]
+struct TtyCliSession {
+    writer: Box<dyn Write + Send>,
+    reader: Option<std::thread::JoinHandle<()>>,
+    rx: mpsc::Receiver<String>,
+    child: Box<dyn portable_pty::Child + Send + Sync>,
+}
+
+#[cfg(unix)]
+impl TtyCliSession {
+    fn write(&mut self, input: &str) {
+        self.writer.write_all(input.as_bytes()).unwrap();
+        self.writer.flush().unwrap();
+    }
+
+    fn wait_for(&mut self, output: &mut String, needle: &str) {
+        let deadline = Instant::now() + Duration::from_secs(10);
+        while !output.contains(needle) {
+            let now = Instant::now();
+            assert!(
+                now < deadline,
+                "timed out waiting for {needle:?}; output was:\n{output}"
+            );
+            let timeout = deadline
+                .saturating_duration_since(now)
+                .min(Duration::from_millis(100));
+            match self.rx.recv_timeout(timeout) {
+                Ok(chunk) => output.push_str(&chunk),
+                Err(mpsc::RecvTimeoutError::Timeout) => {}
+                Err(mpsc::RecvTimeoutError::Disconnected) => {
+                    panic!("PTY reader closed before seeing {needle:?}; output was:\n{output}")
+                }
+            }
+        }
+    }
+
+    fn wait_for_exit(&mut self) {
+        let deadline = Instant::now() + Duration::from_secs(10);
+        loop {
+            if let Some(status) = self.child.try_wait().unwrap() {
+                assert!(status.success(), "TTY CLI exited with {status:?}");
+                if let Some(reader) = self.reader.take() {
+                    let _ = reader.join();
+                }
+                return;
+            }
+            if Instant::now() >= deadline {
+                let _ = self.child.kill();
+                panic!("timed out waiting for TTY CLI to exit");
+            }
+            std::thread::sleep(Duration::from_millis(50));
+        }
+    }
+}
+
+#[cfg(unix)]
+fn spawn_tty_cli(home: &std::path::Path, url: &str, args: &[&str]) -> TtyCliSession {
+    use portable_pty::{CommandBuilder, PtySize, native_pty_system};
+
+    std::fs::create_dir_all(home).unwrap();
+    let pty_system = native_pty_system();
+    let pair = pty_system
+        .openpty(PtySize {
+            rows: 24,
+            cols: 100,
+            pixel_width: 0,
+            pixel_height: 0,
+        })
+        .unwrap();
+    let mut cmd = CommandBuilder::new(env!("CARGO_BIN_EXE_gestalt"));
+    cmd.cwd(home);
+    cmd.env("HOME", home);
+    cmd.env("XDG_CONFIG_HOME", home.join("xdg-config"));
+    cmd.env("GESTALT_API_KEY", TEST_TOKEN);
+    cmd.env_remove("GESTALT_URL");
+    cmd.arg("--url");
+    cmd.arg(url);
+    cmd.args(args);
+
+    let child = pair.slave.spawn_command(cmd).unwrap();
+    drop(pair.slave);
+    let mut reader = pair.master.try_clone_reader().unwrap();
+    let writer = pair.master.take_writer().unwrap();
+    let (tx, rx) = mpsc::channel();
+    let reader = std::thread::spawn(move || {
+        let mut buffer = [0; 4096];
+        loop {
+            match reader.read(&mut buffer) {
+                Ok(0) => return,
+                Ok(read) => {
+                    let chunk = String::from_utf8_lossy(&buffer[..read]).to_string();
+                    if tx.send(chunk).is_err() {
+                        return;
+                    }
+                }
+                Err(_) => return,
+            }
+        }
+    });
+
+    TtyCliSession {
+        writer,
+        reader: Some(reader),
+        rx,
+        child,
+    }
 }
 
 fn read_scripted_http_request(stream: &mut TcpStream) -> ScriptedHttpRequest {


### PR DESCRIPTION
## Summary

Adds the first full-screen terminal UI for interactive `gestalt agent` sessions. TTY sessions now open a Ratatui transcript/composer interface automatically; piped and non-TTY sessions keep the existing prompt-and-print fallback used by scripts and the existing integration tests.

## New Interfaces

- `gestalt agent` on a TTY starts the full-screen UI automatically. There is intentionally no `--ui` switch.
- TTY input interactions preserve existing `default`, `required`, and `secret` semantics; secret responses are masked in the terminal.
- `stream_turn_event_frames(client, turn_id, after_seq, handler)` is the shared internal SSE event-frame interface used by both the existing line renderer and the new TUI worker.
- `SseEventDecoder` owns SSE `data:` frame assembly and JSON decoding for agent turn events.
- `commands::agents::tui` is split into:
  - `tui.rs`: terminal lifecycle, Ratatui rendering, keyboard handling, composer/interactions.
  - `tui/state.rs`: transcript/status state reducer for agent turn events, including viewport-aware transcript scrolling.
  - `tui/worker.rs`: blocking HTTP/SSE turn worker and interaction/cancel command channel.

## Usage Examples

```sh
gestalt agent --provider managed --model gpt-5.4
```

Inside the TUI:

```text
Enter       send the composer, or queue while a turn is running
Alt-Enter   insert a newline
PageUp/Down scroll the transcript
Ctrl-C      cancel the active turn, or clear/exit while idle
/session    show the active session id
/quit       exit
```

The non-TTY path is unchanged for scripts, for example:

```sh
printf 'summarize risk\n/quit\n' | gestalt agent --provider managed --model gpt-5.4
```

## Verification

- `cargo test --manifest-path gestalt/cli/Cargo.toml --test agents_cli`
- `cargo test --manifest-path gestalt/cli/Cargo.toml`
- `cargo clippy --manifest-path gestalt/cli/Cargo.toml --all-targets -- -D warnings`
- PTY integration coverage for the full-screen UI and secret required interaction flow
